### PR TITLE
o2cdb: namespaces, naming, format, first doxygen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,12 @@
 
 # build directory
 build/
+
+# common editor backups
+*.swp
+*~
+
+# doxygen stuff
+html-doc/
+
+header/AliceO2Config.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,8 +61,7 @@ set(LIBRARY_OUTPUT_PATH "${CMAKE_BINARY_DIR}/lib")
 set(EXECUTABLE_OUTPUT_PATH "${CMAKE_BINARY_DIR}/bin")
 set(INCLUDE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/include")
 Set(VMCWORKDIR ${CMAKE_SOURCE_DIR})
-Option(USE_PATH_INFO "Information from PATH and LD_LIBRARY_PATH are
-used." OFF)
+Option(USE_PATH_INFO "Information from PATH and LD_LIBRARY_PATH are used." OFF)
 If(USE_PATH_INFO)
   Set(PATH "$PATH")
   If (APPLE)
@@ -194,8 +193,8 @@ add_subdirectory (passive)
 add_subdirectory (MathUtils)
 add_subdirectory (field)
 add_subdirectory (devices)
-Add_Subdirectory(macro)
-
+add_subdirectory (macro)
+add_subdirectory (o2cdb)
 
 WRITE_CONFIG_FILE(config.sh)
 

--- a/macro/putCondition.C
+++ b/macro/putCondition.C
@@ -1,0 +1,12 @@
+using namespace AliceO2::CDB;
+void putCondition()
+{
+  Manager *cdb = Manager::Instance();
+  cdb->setDefaultStorage("local://");
+  ConditionId id("DET/Align/Data", 190000, 191000);
+  TH1F *h1 = new TH1F("aHisto", "yeah", 100, 0, 10);
+  ConditionMetaData *md = new ConditionMetaData("any comment");
+  md->addDateToComment();
+  Condition *e = new Condition(h1, id, md);
+  cdb->putObject(e);
+}

--- a/o2cdb/CMakeLists.txt
+++ b/o2cdb/CMakeLists.txt
@@ -1,0 +1,37 @@
+set(INCLUDE_DIRECTORIES
+  ${BASE_INCLUDE_DIRECTORIES} 
+  ${Boost_INCLUDE_DIR}
+  ${CMAKE_SOURCE_DIR}/o2cdb
+  ${ROOT_INCLUDE_DIR}
+)
+include_directories(${INCLUDE_DIRECTORIES})
+
+set(LINK_DIRECTORIES
+  ${Boost_LIBRARY_DIRS}
+  ${FAIRROOT_LIBRARY_DIR}
+)
+link_directories(${LINK_DIRECTORIES})
+
+set(SRCS
+  Manager.cxx
+  Condition.cxx
+  GridStorage.cxx
+  LocalStorage.cxx
+  FileStorage.cxx
+  ConditionMetaData.cxx
+  ConditionId.cxx
+  IdPath.cxx
+  IdRunRange.cxx
+  Storage.cxx
+  XmlHandler.cxx
+)
+
+set(DEPENDENCIES
+  ${DEPENDENCIES}
+  ${CMAKE_THREAD_LIBS_INIT}
+  boost_thread boost_system FairMQ
+)
+
+set(LIBRARY_NAME AliceO2Cdb)
+Set(LINKDEF O2CdbLinkDef.h)
+GENERATE_LIBRARY()

--- a/o2cdb/Condition.cxx
+++ b/o2cdb/Condition.cxx
@@ -1,0 +1,90 @@
+/// \file Condition.h
+/// \brief Implementation of the Condition class (CDB object) containing the condition and its metadata
+
+#include <FairLogger.h>
+#include "Condition.h"
+
+using namespace AliceO2::CDB;
+
+ClassImp(Condition)
+
+Condition::Condition() : mObject(NULL), mId(), mConditionMetaData(NULL), mOwner(kFALSE)
+{
+}
+
+Condition::Condition(TObject* object, const ConditionId& id, ConditionMetaData* metaData, Bool_t owner)
+  : mObject(object), mId(id), mConditionMetaData(metaData), mOwner(owner)
+{
+  mConditionMetaData->setObjectClassName(mObject->ClassName());
+}
+
+Condition::Condition(TObject* object, const IdPath& path, const IdRunRange& runRange, ConditionMetaData* metaData, Bool_t owner)
+  : mObject(object), mId(path, runRange, -1, -1), mConditionMetaData(metaData), mOwner(owner)
+{
+  mConditionMetaData->setObjectClassName(mObject->ClassName());
+}
+
+Condition::Condition(TObject* object, const IdPath& path, const IdRunRange& runRange, Int_t version, ConditionMetaData* metaData,
+             Bool_t owner)
+  : mObject(object), mId(path, runRange, version, -1), mConditionMetaData(metaData), mOwner(owner)
+{
+  mConditionMetaData->setObjectClassName(mObject->ClassName());
+}
+
+Condition::Condition(TObject* object, const IdPath& path, const IdRunRange& runRange, Int_t version, Int_t subVersion,
+             ConditionMetaData* metaData, Bool_t owner)
+  : mObject(object), mId(path, runRange, version, subVersion), mConditionMetaData(metaData), mOwner(owner)
+{
+  mConditionMetaData->setObjectClassName(mObject->ClassName());
+}
+
+Condition::Condition(TObject* object, const IdPath& path, Int_t firstRun, Int_t lastRun, ConditionMetaData* metaData, Bool_t owner)
+  : mObject(object), mId(path, firstRun, lastRun, -1, -1), mConditionMetaData(metaData), mOwner(owner)
+{
+  mConditionMetaData->setObjectClassName(mObject->ClassName());
+}
+
+Condition::Condition(TObject* object, const IdPath& path, Int_t firstRun, Int_t lastRun, Int_t version, ConditionMetaData* metaData,
+             Bool_t owner)
+  : mObject(object), mId(path, firstRun, lastRun, version, -1), mConditionMetaData(metaData), mOwner(owner)
+{
+  mConditionMetaData->setObjectClassName(mObject->ClassName());
+}
+
+Condition::Condition(TObject* object, const IdPath& path, Int_t firstRun, Int_t lastRun, Int_t version, Int_t subVersion,
+             ConditionMetaData* metaData, Bool_t owner)
+  : mObject(object), mId(path, firstRun, lastRun, version, subVersion), mConditionMetaData(metaData), mOwner(owner)
+{
+  mConditionMetaData->setObjectClassName(mObject->ClassName());
+}
+
+Condition::~Condition()
+{
+
+  if (mOwner) {
+    if (mObject) {
+      delete mObject;
+    }
+
+    if (mConditionMetaData) {
+      delete mConditionMetaData;
+    }
+  }
+}
+
+void Condition::printId() const
+{
+
+  LOG(INFO) << mId.ToString().Data() << FairLogger::endl;
+}
+
+Int_t Condition::Compare(const TObject* obj) const
+{
+  Condition* o2 = (Condition*)obj;
+  return TString(this->getId().getPathString()).CompareTo((o2->getId().getPathString()));
+}
+
+Bool_t Condition::IsSortable() const
+{
+  return kTRUE;
+}

--- a/o2cdb/Condition.h
+++ b/o2cdb/Condition.h
@@ -1,0 +1,157 @@
+/// \file Condition.h
+/// \brief Definition of the Condition class (CDB object) containing the condition and its metadata
+
+#ifndef ALICEO2_CDB_ENTRY_H_
+#define ALICEO2_CDB_ENTRY_H_
+
+#include "ConditionId.h"
+#include "ConditionMetaData.h"
+
+namespace AliceO2 {
+namespace CDB {
+
+/// Class containing the condition (a ROOT TObject) and the metadata identifying it (ConditionId)
+/// An instance of this class is a CDB object and has a specified run-range validity, version
+/// and subversion. These metadata are both building the file name of the CDB object and are
+/// contained in the metadata.
+class Condition : public TObject {
+
+public:
+  /// Default constructor
+  Condition();
+
+  /// Constructor
+  Condition(TObject* object, const ConditionId& id, ConditionMetaData* metaData, Bool_t owner = kFALSE);
+
+  /// Constructor
+  Condition(TObject* object, const IdPath& path, const IdRunRange& runRange, ConditionMetaData* metaData, Bool_t owner = kFALSE);
+
+  /// Constructor
+  Condition(TObject* object, const IdPath& path, const IdRunRange& runRange, Int_t version, ConditionMetaData* metaData,
+        Bool_t owner = kFALSE);
+
+  /// Constructor
+  Condition(TObject* object, const IdPath& path, const IdRunRange& runRange, Int_t version, Int_t subVersion,
+        ConditionMetaData* metaData, Bool_t owner = kFALSE);
+
+  /// Constructor
+  Condition(TObject* object, const IdPath& path, Int_t firstRun, Int_t lastRun, ConditionMetaData* metaData, Bool_t owner = kFALSE);
+
+  /// Constructor
+  Condition(TObject* object, const IdPath& path, Int_t firstRun, Int_t lastRun, Int_t version, ConditionMetaData* metaData,
+        Bool_t owner = kFALSE);
+
+  /// Constructor
+  Condition(TObject* object, const IdPath& path, Int_t firstRun, Int_t lastRun, Int_t version, Int_t subVersion,
+        ConditionMetaData* metaData, Bool_t owner = kFALSE);
+
+  /// Default destructor
+  virtual ~Condition();
+
+  /// Set the object identity from an ConditionId
+  void setId(const ConditionId& id)
+  {
+    mId = id;
+  };
+
+  /// ConditionId accessor
+  ConditionId& getId()
+  {
+    return mId;
+  };
+
+  /// ConditionId accessor
+  const ConditionId& getId() const
+  {
+    return mId;
+  };
+
+  /// Print the identifier fields
+  void printId() const;
+
+  /// Setter of the TObject data member
+  void setObject(TObject* object)
+  {
+    mObject = object;
+  };
+
+  /// Getter of the TObject data member
+  TObject* getObject()
+  {
+    return mObject;
+  };
+ 
+  /// Getter of the TObject data member
+  const TObject* getObject() const
+  {
+    return mObject;
+  };
+
+  void setConditionMetaData(ConditionMetaData* metaData)
+  {
+    mConditionMetaData = metaData;
+  };
+  ConditionMetaData* getConditionMetaData()
+  {
+    return mConditionMetaData;
+  };
+  const ConditionMetaData* getConditionMetaData() const
+  {
+    return mConditionMetaData;
+  };
+  void printConditionMetaData() const
+  {
+    mConditionMetaData->printConditionMetaData();
+  }
+
+  /// Getter of the TObject data member
+  void setOwner(Bool_t owner)
+  {
+    mOwner = owner;
+  };
+  /// Getter of the TObject data member
+  Bool_t isOwner() const
+  {
+    return mOwner;
+  };
+
+  /// Setter of the version
+  void setVersion(Int_t version)
+  {
+    mId.setVersion(version);
+  }
+  /// Setter of the subversion
+  void setSubVersion(Int_t subVersion)
+  {
+    mId.setSubVersion(subVersion);
+  }
+
+  /// Getter of the last storage where the CDB object was before the current one
+  const TString getLastStorage() const
+  {
+    return mId.getLastStorage();
+  };
+  /// Getter of the last storage where the CDB object was before the current one
+  void setLastStorage(TString lastStorage)
+  {
+    mId.setLastStorage(lastStorage);
+  };
+  /// Method to compare two CDB objects, used for sorting in ROOT ordered containers
+  virtual Int_t Compare(const TObject* obj) const;
+  /// Define this class sortable (via the Compare method) for ROOT ordered containers
+  virtual Bool_t IsSortable() const;
+
+private:
+  Condition(const Condition& other);          // no copy ctor
+  void operator=(const Condition& other); // no assignment op
+
+  TObject* mObject;    ///< The actual condition, a ROOT TObject
+  ConditionId mId;        ///< The condition identifier 
+  ConditionMetaData* mConditionMetaData; ///< metaData
+  Bool_t mOwner;     ///< Ownership flag
+
+  ClassDef(Condition, 1)
+};
+}
+}
+#endif

--- a/o2cdb/ConditionId.cxx
+++ b/o2cdb/ConditionId.cxx
@@ -1,0 +1,145 @@
+#include "ConditionId.h"
+#include <Riostream.h>
+#include <TObjArray.h>
+#include <TObjString.h>
+
+// using std::endl;
+// using std::cout;
+using namespace AliceO2::CDB;
+
+ClassImp(ConditionId)
+
+ConditionId::ConditionId() : mPath(), mIdRunRange(-1, -1), mVersion(-1), mSubVersion(-1), mLastStorage("new")
+{
+  // constructor
+}
+
+ConditionId::ConditionId(const ConditionId& other)
+  : TObject(),
+    mPath(other.mPath),
+    mIdRunRange(other.mIdRunRange),
+    mVersion(other.mVersion),
+    mSubVersion(other.mSubVersion),
+    mLastStorage(other.mLastStorage)
+{
+  // constructor
+}
+
+ConditionId::ConditionId(const IdPath& path, Int_t firstRun, Int_t lastRun, Int_t version, Int_t subVersion)
+  : mPath(path), mIdRunRange(firstRun, lastRun), mVersion(version), mSubVersion(subVersion), mLastStorage("new")
+{
+  // constructor
+}
+
+ConditionId::ConditionId(const IdPath& path, const IdRunRange& runRange, Int_t version, Int_t subVersion)
+  : mPath(path), mIdRunRange(runRange), mVersion(version), mSubVersion(subVersion), mLastStorage("new")
+{
+  // constructor
+}
+
+ConditionId* ConditionId::makeFromString(const TString& idString)
+{
+  // constructor from string
+  // string has the format as the output of ConditionId::ToString:
+  // path: "TRD/Calib/PIDLQ"; run range: [0,999999999]; version: v0_s0
+
+  ConditionId* id = new ConditionId("a/b/c", -1, -1, -1, -1);
+
+  TObjArray* arr1 = idString.Tokenize(';');
+  TIter iter1(arr1);
+  TObjString* objStr1 = 0;
+  while ((objStr1 = dynamic_cast<TObjString*>(iter1.Next()))) {
+    TString buff(objStr1->GetName());
+
+    if (buff.Contains("path:")) {
+      TString path(buff(buff.First('\"') + 1, buff.Length() - buff.First('\"') - 2));
+      id->setPath(path.Data());
+
+    } else if (buff.Contains("run range:")) {
+      TString firstRunStr(buff(buff.Index('[') + 1, buff.Index(',') - buff.Index('[') - 1));
+      TString lastRunStr(buff(buff.Index(',') + 1, buff.Index(']') - buff.Index(',') - 1));
+      id->setIdRunRange(firstRunStr.Atoi(), lastRunStr.Atoi());
+
+    } else if (buff.Contains("version:")) {
+      if (buff.Contains("_s")) {
+        TString versStr(buff(buff.Last('v') + 1, buff.Index('_') - buff.Last('v') - 1));
+        TString subVersStr(buff(buff.Last('s') + 1, buff.Length() - buff.Last('s') - 1));
+        id->setVersion(versStr.Atoi());
+        id->setSubVersion(subVersStr.Atoi());
+      } else {
+        TString versStr(buff(buff.Last('v') + 1, buff.Length() - buff.Last('v') - 1));
+        id->setVersion(versStr.Atoi());
+      }
+    }
+  }
+
+  delete arr1;
+
+  return id;
+}
+
+ConditionId::~ConditionId()
+{
+  // destructor
+}
+
+Bool_t ConditionId::isValid() const
+{
+  // validity check
+
+  if (!(mPath.isValid() && mIdRunRange.isValid())) {
+    return kFALSE;
+  }
+
+  // FALSE if doesn't have version but has subVersion
+  return !(!hasVersion() && hasSubVersion());
+}
+
+Bool_t ConditionId::isEqual(const TObject* obj) const
+{
+  // check if this id is equal to other id (compares path, run range, versions)
+
+  if (this == obj) {
+    return kTRUE;
+  }
+
+  if (ConditionId::Class() != obj->IsA()) {
+    return kFALSE;
+  }
+  ConditionId* other = (ConditionId*)obj;
+  return mPath.getPathString() == other->getPathString() && mIdRunRange.isEqual(&other->getIdRunRange()) &&
+         mVersion == other->getVersion() && mSubVersion == other->getSubVersion();
+}
+
+TString ConditionId::ToString() const
+{
+  // returns a string of ConditionId data
+
+  TString result = Form("path: \"%s\"; run range: [%d,%d]", getPathString().Data(), getFirstRun(), getLastRun());
+
+  if (getVersion() >= 0)
+    result += Form("; version: v%d", getVersion());
+  if (getSubVersion() >= 0)
+    result += Form("_s%d", getSubVersion());
+  return result;
+}
+
+void ConditionId::print(Option_t* /*option*/) const
+{
+  // Prints ToString()
+
+  cout << ToString().Data() << endl;
+}
+
+Int_t ConditionId::Compare(const TObject* obj) const
+{
+  //
+  // compare according y
+  ConditionId* o2 = (ConditionId*)obj;
+  return TString(this->getPathString()).CompareTo((o2->getPathString()));
+}
+
+Bool_t ConditionId::IsSortable() const
+{
+  return kTRUE;
+}

--- a/o2cdb/ConditionId.h
+++ b/o2cdb/ConditionId.h
@@ -1,0 +1,146 @@
+#ifndef ALICEO2_CDB_OBJECTID_H_
+#define ALICEO2_CDB_OBJECTID_H_
+
+//  Identity of an object stored into a database:  		   //
+//  path, run validity range, version, subVersion 		   //
+#include "IdPath.h"
+#include "IdRunRange.h"
+
+#include <TObject.h>
+
+namespace AliceO2 {
+namespace CDB {
+
+class ConditionId : public TObject {
+
+public:
+  ConditionId();
+  ConditionId(const ConditionId& other);
+  ConditionId(const IdPath& path, const IdRunRange& runRange, Int_t version = -1, Int_t subVersion = -1);
+  ConditionId(const IdPath& path, Int_t firstRun, Int_t lastRun, Int_t verison = -1, Int_t subVersion = -1);
+
+  static ConditionId* makeFromString(const TString& idString);
+  virtual ~ConditionId();
+  const IdPath& getPath() const
+  {
+    return mPath;
+  }
+  const TString& getPathString() const
+  {
+    return mPath.getPathString();
+  }
+  const TString getPathLevel(Int_t i) const
+  {
+    return mPath.getLevel(i);
+  }
+  Bool_t isWildcard() const
+  {
+    return mPath.isWildcard();
+  }
+  void setPath(const char* path)
+  {
+    mPath.setPath(path);
+  }
+  const IdRunRange& getIdRunRange() const
+  {
+    return mIdRunRange;
+  }
+  IdRunRange& getIdRunRange()
+  {
+    return mIdRunRange;
+  }
+  Int_t getFirstRun() const
+  {
+    return mIdRunRange.getFirstRun();
+  }
+  Int_t getLastRun() const
+  {
+    return mIdRunRange.getLastRun();
+  }
+  void setFirstRun(Int_t firstRun)
+  {
+    mIdRunRange.setFirstRun(firstRun);
+  }
+  void setLastRun(Int_t lastRun)
+  {
+    mIdRunRange.setLastRun(lastRun);
+  }
+  void setIdRunRange(Int_t firstRun, Int_t lastRun)
+  {
+    mIdRunRange.setIdRunRange(firstRun, lastRun);
+  }
+
+  Bool_t isAnyRange() const
+  {
+    return mIdRunRange.isAnyRange();
+  }
+
+  Int_t getVersion() const
+  {
+    return mVersion;
+  }
+  Int_t getSubVersion() const
+  {
+    return mSubVersion;
+  }
+  void setVersion(Int_t version)
+  {
+    mVersion = version;
+  }
+  void setSubVersion(Int_t subVersion)
+  {
+    mSubVersion = subVersion;
+  }
+
+  const TString& getLastStorage() const
+  {
+    return mLastStorage;
+  }
+  void setLastStorage(TString& lastStorage)
+  {
+    mLastStorage = lastStorage;
+  }
+
+  Bool_t isValid() const;
+  Bool_t isSpecified() const
+  {
+    return !(isWildcard() || isAnyRange());
+  }
+
+  Bool_t hasVersion() const
+  {
+    return mVersion >= 0;
+  }
+  Bool_t hasSubVersion() const
+  {
+    return mSubVersion >= 0;
+  }
+
+  Bool_t isSupersetOf(const ConditionId& other) const
+  {
+    return mPath.isSupersetOf(other.mPath) && mIdRunRange.isSupersetOf(other.mIdRunRange);
+  }
+
+  virtual Bool_t isEqual(const TObject* obj) const;
+
+  TString ToString() const;
+  void print(Option_t* option = "") const;
+  virtual Int_t Compare(const TObject* obj) const;
+  virtual Bool_t IsSortable() const;
+  virtual const char* GetName() const
+  {
+    return mPath.getPathString().Data();
+  }
+
+private:
+  IdPath mPath;           // path
+  IdRunRange mIdRunRange;   // run range
+  Int_t mVersion;       // version
+  Int_t mSubVersion;    // subversion
+  TString mLastStorage; // previous storage place (new, grid, local, dump)
+
+  ClassDef(ConditionId, 1)
+};
+}
+}
+#endif

--- a/o2cdb/ConditionMetaData.cxx
+++ b/o2cdb/ConditionMetaData.cxx
@@ -1,0 +1,111 @@
+//  Set of data describing the object  				   //
+//  but not used to identify the object 			   //
+#include <TObjString.h>
+#include <TTimeStamp.h>
+
+#include <FairLogger.h>
+
+#include "ConditionMetaData.h"
+
+using namespace AliceO2::CDB;
+
+ClassImp(ConditionMetaData)
+
+ConditionMetaData::ConditionMetaData()
+  : TObject(), mObjectClassName(""), mResponsible(""), mBeamPeriod(0), mAliRootVersion(""), mComment(""), mProperties()
+{
+  // default constructor
+
+  mProperties.SetOwner(1);
+}
+
+ConditionMetaData::ConditionMetaData(const char* responsible, UInt_t beamPeriod, const char* alirootVersion, const char* comment)
+  : TObject(),
+    mObjectClassName(""),
+    mResponsible(responsible),
+    mBeamPeriod(beamPeriod),
+    mAliRootVersion(alirootVersion),
+    mComment(comment),
+    mProperties()
+{
+  // constructor
+
+  mProperties.SetOwner(1);
+}
+
+ConditionMetaData::~ConditionMetaData()
+{
+  // destructor
+}
+
+void ConditionMetaData::setProperty(const char* property, TObject* object)
+{
+  // add something to the list of properties
+
+  mProperties.Add(new TObjString(property), object);
+}
+
+TObject* ConditionMetaData::getProperty(const char* property) const
+{
+  // get a property specified by its name (property)
+
+  return mProperties.GetValue(property);
+}
+
+Bool_t ConditionMetaData::removeProperty(const char* property)
+{
+  // removes a property
+
+  TObjString objStrProperty(property);
+  TObjString* aKey = (TObjString*)mProperties.Remove(&objStrProperty);
+
+  if (aKey) {
+    delete aKey;
+    return kTRUE;
+  } else {
+    return kFALSE;
+  }
+}
+
+void ConditionMetaData::addDateToComment()
+{
+  // add the date to the comment.
+  // This method is supposed to be useful if called at the time when the object
+  // is created, so that later it can more easily be tracked, in particular
+  // when the date of the file can be lost or when one is interested in the
+  // date of creation, irrespective of a later copy of it
+
+  TTimeStamp ts(time(0));
+  TString comment(getComment());
+  comment += Form("\tDate of production: %s\n", ts.AsString());
+  comment.Remove(comment.Last('+'));
+  setComment(comment);
+}
+
+void ConditionMetaData::printConditionMetaData()
+{
+  // print the object's metaData
+
+  TString message;
+  if (mObjectClassName != "")
+    message += TString::Format("\tObject's class name:	%s\n", mObjectClassName.Data());
+  if (mResponsible != "")
+    message += TString::Format("\tResponsible:		%s\n", mResponsible.Data());
+  if (mBeamPeriod != 0)
+    message += TString::Format("\tBeam period:		%d\n", mBeamPeriod);
+  if (mAliRootVersion != "")
+    message += TString::Format("\tAliRoot version:	%s\n", mAliRootVersion.Data());
+  if (mComment != "")
+    message += TString::Format("\tComment:		%s\n", mComment.Data());
+  if (mProperties.GetEntries() > 0) {
+    message += "\tProperties key names:";
+
+    TIter iter(mProperties.GetTable());
+    TPair* aPair;
+    while ((aPair = (TPair*)iter.Next())) {
+      message += TString::Format("\t\t%s\n", ((TObjString*)aPair->Key())->String().Data());
+    }
+  }
+  message += '\n';
+  Printf("**** Object's ConditionMetaData parameters **** \n%s", message.Data());
+}

--- a/o2cdb/ConditionMetaData.h
+++ b/o2cdb/ConditionMetaData.h
@@ -1,0 +1,85 @@
+#ifndef ALI_META_DATA_H
+#define ALI_META_DATA_H
+
+#include <TObject.h>
+#include <TMap.h>
+
+namespace AliceO2 {
+namespace CDB {
+//  Set of data describing the object  				   //
+//  but not used to identify the object 			   //
+
+class ConditionMetaData : public TObject {
+
+public:
+  ConditionMetaData();
+  ConditionMetaData(const char* responsible, UInt_t beamPeriod = 0, const char* alirootVersion = "", const char* comment = "");
+  virtual ~ConditionMetaData();
+
+  void setObjectClassName(const char* name)
+  {
+    mObjectClassName = name;
+  };
+  const char* getObjectClassName() const
+  {
+    return mObjectClassName.Data();
+  };
+
+  void setResponsible(const char* yourName)
+  {
+    mResponsible = yourName;
+  };
+  const char* getResponsible() const
+  {
+    return mResponsible.Data();
+  };
+
+  void setBeamPeriod(UInt_t period)
+  {
+    mBeamPeriod = period;
+  };
+  UInt_t getBeamPeriod() const
+  {
+    return mBeamPeriod;
+  };
+
+  void setAliRootVersion(const char* version)
+  {
+    mAliRootVersion = version;
+  };
+  const char* getAliRootVersion() const
+  {
+    return mAliRootVersion.Data();
+  };
+
+  void setComment(const char* comment)
+  {
+    mComment = comment;
+  };
+  const char* getComment() const
+  {
+    return mComment.Data();
+  };
+  void addDateToComment();
+
+  void setProperty(const char* property, TObject* object);
+  TObject* getProperty(const char* property) const;
+  Bool_t removeProperty(const char* property);
+
+  void printConditionMetaData();
+
+private:
+  TString mObjectClassName; // object's class name
+  TString mResponsible;     // object's responsible person
+  UInt_t mBeamPeriod;       // beam period
+  TString mAliRootVersion;  // AliRoot version
+  TString mComment;         // extra comments
+  // TList mCalibRuns;
+
+  TMap mProperties; // list of object specific properties
+
+  ClassDef(ConditionMetaData, 1)
+};
+}
+}
+#endif

--- a/o2cdb/FileStorage.cxx
+++ b/o2cdb/FileStorage.cxx
@@ -1,0 +1,742 @@
+//  access class to a DataBase in a dump storage (single file)     //
+#include <cstdlib>
+#include <TSystem.h>
+#include <TKey.h>
+#include <TFile.h>
+#include <TRegexp.h>
+#include <TObjString.h>
+#include <TList.h>
+
+#include <FairLogger.h>
+
+#include "FileStorage.h"
+#include "Condition.h"
+
+using namespace AliceO2::CDB;
+
+ClassImp(FileStorage)
+
+FileStorage::FileStorage(const char* dbFile, Bool_t readOnly) : mFile(NULL), mReadOnly(readOnly)
+{
+  // constructor
+
+  // opening file
+  mFile = TFile::Open(dbFile, mReadOnly ? "READ" : "UPDATE");
+  if (!mFile) {
+    LOG(ERROR) << "Can't open file \"" << dbFile << "\"" << FairLogger::endl;
+  } else {
+    LOG(ERROR) << "File \"" << dbFile << "\" opened" << FairLogger::endl;
+    if (mReadOnly)
+      LOG(DEBUG) << "in read-only mode" << FairLogger::endl;
+  }
+
+  mType = "dump";
+  mBaseFolder = dbFile;
+}
+
+FileStorage::~FileStorage()
+{
+  // destructor
+
+  if (mFile) {
+    mFile->Close();
+    delete mFile;
+  }
+}
+
+Bool_t FileStorage::keyNameToId(const char* keyname, IdRunRange& runRange, Int_t& version, Int_t& subVersion)
+{
+  // build  ConditionId from keyname numbers
+
+  Ssiz_t mSize;
+
+  // valid keyname: Run#firstRun_#lastRun_v#version_s#subVersion.root
+  TRegexp keyPattern("^Run[0-9]+_[0-9]+_v[0-9]+_s[0-9]+$");
+  keyPattern.Index(keyname, &mSize);
+  if (!mSize) {
+    LOG(DEBUG) << "Bad keyname \"" << keyname << "\"." << FairLogger::endl;
+    return kFALSE;
+  }
+
+  TObjArray* strArray = (TObjArray*)TString(keyname).Tokenize("_");
+
+  TString firstRunString(((TObjString*)strArray->At(0))->GetString());
+  runRange.setFirstRun(atoi(firstRunString.Data() + 3));
+  runRange.setLastRun(atoi(((TObjString*)strArray->At(1))->GetString()));
+
+  TString verString(((TObjString*)strArray->At(2))->GetString());
+  version = atoi(verString.Data() + 1);
+
+  TString subVerString(((TObjString*)strArray->At(3))->GetString());
+  subVersion = atoi(subVerString.Data() + 1);
+
+  delete strArray;
+
+  return kTRUE;
+}
+
+Bool_t FileStorage::idToKeyName(const IdRunRange& runRange, Int_t version, Int_t subVersion, TString& keyname)
+{
+  // build key name from  ConditionId data (run range, version, subVersion)
+
+  if (!runRange.isValid()) {
+    LOG(DEBUG) << "Invalid run range [" << runRange.getFirstRun() << "," << runRange.getLastRun() << "]."
+               << FairLogger::endl;
+    return kFALSE;
+  }
+
+  if (version < 0) {
+    LOG(DEBUG) << "Invalid version \'" << version << "\'." << FairLogger::endl;
+    return kFALSE;
+  }
+
+  if (subVersion < 0) {
+    LOG(DEBUG) << "Invalid subversion \'" << subVersion << "\'." << FairLogger::endl;
+    return kFALSE;
+  }
+
+  keyname += "Run";
+  keyname += runRange.getFirstRun();
+  keyname += "_";
+  keyname += runRange.getLastRun();
+  keyname += "_v";
+  keyname += version;
+  keyname += "_s";
+  keyname += subVersion;
+
+  return kTRUE;
+}
+
+Bool_t FileStorage::makeDir(const TString& path)
+{
+  // descend into TDirectory, making TDirectories if they don't exist
+  TObjArray* strArray = (TObjArray*)path.Tokenize("/");
+
+  TIter iter(strArray);
+  TObjString* str;
+
+  while ((str = (TObjString*)iter.Next())) {
+
+    TString dirName(str->GetString());
+    if (!dirName.Length()) {
+      continue;
+    }
+
+    if (gDirectory->cd(dirName)) {
+      continue;
+    }
+
+    TDirectory* aDir = gDirectory->mkdir(dirName, "");
+    if (!aDir) {
+      LOG(ERROR) << "Can't create directory \"" << dirName.Data() << "\"!" << FairLogger::endl;
+      delete strArray;
+
+      return kFALSE;
+    }
+
+    aDir->cd();
+  }
+
+  delete strArray;
+
+  return kTRUE;
+}
+
+Bool_t FileStorage::prepareId(ConditionId& id)
+{
+  // prepare id (version, subVersion) of the object that will be stored (called by putCondition)
+
+  IdRunRange aIdRunRange;                         // the runRange got from filename
+  IdRunRange lastIdRunRange(-1, -1);              // highest runRange found
+  Int_t aVersion, aSubVersion;                // the version subVersion got from filename
+  Int_t lastVersion = 0, lastSubVersion = -1; // highest version and subVersion found
+
+  TIter iter(gDirectory->GetListOfKeys());
+  TKey* key;
+
+  if (!id.hasVersion()) { // version not specified: look for highest version & subVersion
+
+    while ((key = (TKey*)iter.Next())) { // loop on keys
+
+      const char* keyName = key->GetName();
+
+      if (!keyNameToId(keyName, aIdRunRange, aVersion, aSubVersion)) {
+        LOG(DEBUG) << "Bad keyname <" << keyName << ">!I'll skip it." << FairLogger::endl;
+        continue;
+      }
+
+      if (!aIdRunRange.isOverlappingWith(id.getIdRunRange()))
+        continue;
+      if (aVersion < lastVersion)
+        continue;
+      if (aVersion > lastVersion)
+        lastSubVersion = -1;
+      if (aSubVersion < lastSubVersion)
+        continue;
+      lastVersion = aVersion;
+      lastSubVersion = aSubVersion;
+      lastIdRunRange = aIdRunRange;
+    }
+
+    id.setVersion(lastVersion);
+    id.setSubVersion(lastSubVersion + 1);
+
+  } else { // version specified, look for highest subVersion only
+
+    while ((key = (TKey*)iter.Next())) { // loop on the keys
+
+      const char* keyName = key->GetName();
+
+      if (!keyNameToId(keyName, aIdRunRange, aVersion, aSubVersion)) {
+        LOG(DEBUG) << "Bad keyname <" << keyName << ">!I'll skip it." << FairLogger::endl;
+        continue;
+      }
+
+      if (aIdRunRange.isOverlappingWith(id.getIdRunRange()) && aVersion == id.getVersion() &&
+          aSubVersion > lastSubVersion) {
+        lastSubVersion = aSubVersion;
+        lastIdRunRange = aIdRunRange;
+      }
+    }
+
+    id.setSubVersion(lastSubVersion + 1);
+  }
+
+  TString lastStorage = id.getLastStorage();
+  if (lastStorage.Contains(TString("grid"), TString::kIgnoreCase) && id.getSubVersion() > 0) {
+    LOG(ERROR) << "GridStorage to FileStorage Storage error! local object with version v" << id.getVersion() << "_s"
+               << id.getSubVersion() - 1 << " found:" << FairLogger::endl;
+    LOG(ERROR) << "this object has been already transferred from GridStorage (check v" << id.getVersion() << "_s0)!"
+               << FairLogger::endl;
+    return kFALSE;
+  }
+
+  if (lastStorage.Contains(TString("new"), TString::kIgnoreCase) && id.getSubVersion() > 0) {
+    LOG(DEBUG) << "A NEW object is being stored with version v" << id.getVersion() << "_s" << id.getSubVersion()
+               << FairLogger::endl;
+    LOG(DEBUG) << "and it will hide previously stored object with v" << id.getVersion() << "_s"
+               << id.getSubVersion() - 1 << "!" << FairLogger::endl;
+  }
+
+  if (!lastIdRunRange.isAnyRange() && !(lastIdRunRange.isEqual(&id.getIdRunRange())))
+    LOG(WARNING) << "Run range modified w.r.t. previous version (Run" << lastIdRunRange.getFirstRun() << "_"
+                 << lastIdRunRange.getLastRun() << "_v" << id.getVersion() << "_s" << id.getSubVersion() - 1 << ")"
+                 << FairLogger::endl;
+
+  return kTRUE;
+}
+
+ConditionId* FileStorage::getId(const ConditionId& query)
+{
+  // look for filename matching query (called by getCondition)
+
+  IdRunRange aIdRunRange;          // the runRange got from filename
+  Int_t aVersion, aSubVersion; // the version and subVersion got from filename
+
+  TIter iter(gDirectory->GetListOfKeys());
+  TKey* key;
+
+  ConditionId* result = new ConditionId();
+  result->setPath(query.getPathString());
+
+  if (!query.hasVersion()) { // neither version and subversion specified -> look for highest version
+                             // and subVersion
+
+    while ((key = (TKey*)iter.Next())) { // loop on the keys
+
+      if (!keyNameToId(key->GetName(), aIdRunRange, aVersion, aSubVersion))
+        continue;
+      // aIdRunRange, aVersion, aSubVersion filled from filename
+
+      if (!aIdRunRange.isSupersetOf(query.getIdRunRange()))
+        continue;
+      // aIdRunRange contains requested run!
+
+      if (result->getVersion() < aVersion) {
+        result->setVersion(aVersion);
+        result->setSubVersion(aSubVersion);
+
+        result->setFirstRun(aIdRunRange.getFirstRun());
+        result->setLastRun(aIdRunRange.getLastRun());
+
+      } else if (result->getVersion() == aVersion && result->getSubVersion() < aSubVersion) {
+
+        result->setSubVersion(aSubVersion);
+
+        result->setFirstRun(aIdRunRange.getFirstRun());
+        result->setLastRun(aIdRunRange.getLastRun());
+      } else if (result->getVersion() == aVersion && result->getSubVersion() == aSubVersion) {
+        LOG(ERROR) << "More than one object valid for run " << query.getFirstRun() << ", version " << aVersion << "_"
+                   << aSubVersion << "!" << FairLogger::endl;
+
+        delete result;
+        return NULL;
+      }
+    }
+
+  } else if (!query.hasSubVersion()) { // version specified but not subversion -> look for highest
+                                       // subVersion
+
+    result->setVersion(query.getVersion());
+
+    while ((key = (TKey*)iter.Next())) { // loop on the keys
+
+      if (!keyNameToId(key->GetName(), aIdRunRange, aVersion, aSubVersion))
+        continue;
+      // aIdRunRange, aVersion, aSubVersion filled from filename
+
+      if (!aIdRunRange.isSupersetOf(query.getIdRunRange()))
+        continue;
+      // aIdRunRange contains requested run!
+
+      if (query.getVersion() != aVersion)
+        continue;
+      // aVersion is requested version!
+
+      if (result->getSubVersion() == aSubVersion) {
+        LOG(ERROR) << "More than one object valid for run " << query.getFirstRun() << " version " << aVersion << "_"
+                   << aSubVersion << "!" << FairLogger::endl;
+        delete result;
+        return NULL;
+      }
+      if (result->getSubVersion() < aSubVersion) {
+
+        result->setSubVersion(aSubVersion);
+
+        result->setFirstRun(aIdRunRange.getFirstRun());
+        result->setLastRun(aIdRunRange.getLastRun());
+      }
+    }
+
+  } else { // both version and subversion specified
+
+    while ((key = (TKey*)iter.Next())) { // loop on the keys
+
+      if (!keyNameToId(key->GetName(), aIdRunRange, aVersion, aSubVersion))
+        continue;
+      // aIdRunRange, aVersion, aSubVersion filled from filename
+
+      if (!aIdRunRange.isSupersetOf(query.getIdRunRange()))
+        continue;
+      // aIdRunRange contains requested run!
+
+      if (query.getVersion() != aVersion || query.getSubVersion() != aSubVersion)
+        continue;
+      // aVersion and aSubVersion are requested version and subVersion!
+
+      if (result->getVersion() == aVersion && result->getSubVersion() == aSubVersion) {
+        LOG(ERROR) << "More than one object valid for run " << query.getFirstRun() << " version " << aVersion << "_"
+                   << aSubVersion << "!" << FairLogger::endl;
+        delete result;
+        return NULL;
+      }
+      result->setVersion(aVersion);
+      result->setSubVersion(aSubVersion);
+      result->setFirstRun(aIdRunRange.getFirstRun());
+      result->setLastRun(aIdRunRange.getLastRun());
+    }
+  }
+
+  return result;
+}
+
+Condition* FileStorage::getCondition(const ConditionId& queryId)
+{
+  // get  Condition from the database
+
+  TDirectory::TContext context(gDirectory, mFile);
+
+  if (!(mFile && mFile->IsOpen())) {
+    LOG(ERROR) << "FileStorage is not initialized properly" << FairLogger::endl;
+    return NULL;
+  }
+
+  if (!gDirectory->cd(queryId.getPathString())) {
+    return NULL;
+  }
+
+  ConditionId* dataId = getConditionId(queryId);
+
+  if (!dataId || !dataId->isSpecified()) {
+    if (dataId)
+      delete dataId;
+    return NULL;
+  }
+
+  TString keyname;
+  if (!idToKeyName(dataId->getIdRunRange(), dataId->getVersion(), dataId->getSubVersion(), keyname)) {
+    LOG(DEBUG) << "Bad ID encountered! Subnormal error!" << FairLogger::endl;
+    delete dataId;
+    return NULL;
+  }
+
+  // get the only  Condition object from the file
+  // the object in the file is an  Condition entry named keyname
+  // keyName = Run#firstRun_#lastRun_v#version_s#subVersion
+
+  TObject* anObject = gDirectory->Get(keyname);
+  if (!anObject) {
+    LOG(DEBUG) << "Bad storage data: NULL entry object!" << FairLogger::endl;
+    delete dataId;
+    return NULL;
+  }
+
+  if (Condition::Class() != anObject->IsA()) {
+    LOG(DEBUG) << "Bad storage data: Invalid entry object!" << FairLogger::endl;
+    delete dataId;
+    return NULL;
+  }
+
+  ((Condition*)anObject)->setLastStorage("dump");
+
+  delete dataId;
+  return (Condition*)anObject;
+}
+
+ConditionId* FileStorage::getConditionId(const ConditionId& queryId)
+{
+  // get  Condition from the database
+
+  TDirectory::TContext context(gDirectory, mFile);
+
+  if (!(mFile && mFile->IsOpen())) {
+    LOG(ERROR) << "FileStorage is not initialized properly" << FairLogger::endl;
+    return NULL;
+  }
+
+  if (!gDirectory->cd(queryId.getPathString())) {
+    return NULL;
+  }
+
+  ConditionId* dataId = 0;
+
+  // look for a filename matching query requests (path, runRange, version, subVersion)
+  if (!queryId.hasVersion()) {
+    // if version is not specified, first check the selection criteria list
+    ConditionId selectedId(queryId);
+    getSelection(&selectedId);
+    dataId = getId(queryId);
+  } else {
+    dataId = getId(queryId);
+  }
+
+  if (dataId && !dataId->isSpecified()) {
+    delete dataId;
+    return NULL;
+  }
+
+  return dataId;
+}
+
+void FileStorage::getEntriesForLevel0(const ConditionId& queryId, TList* result)
+{
+  // multiple request ( Storage::GetAllObjects)
+
+  TDirectory* saveDir = gDirectory;
+
+  TIter iter(gDirectory->GetListOfKeys());
+  TKey* key;
+
+  while ((key = (TKey*)iter.Next())) {
+
+    TString keyNameStr(key->GetName());
+    if (queryId.getPath().doesLevel1Contain(keyNameStr)) {
+      gDirectory->cd(keyNameStr);
+      getEntriesForLevel1(queryId, result);
+
+      saveDir->cd();
+    }
+  }
+}
+
+void FileStorage::getEntriesForLevel1(const ConditionId& queryId, TList* result)
+{
+  // multiple request ( Storage::GetAllObjects)
+
+  TIter iter(gDirectory->GetListOfKeys());
+  TKey* key;
+
+  TDirectory* level0Dir = (TDirectory*)gDirectory->GetMother();
+
+  while ((key = (TKey*)iter.Next())) {
+
+    TString keyNameStr(key->GetName());
+    if (queryId.getPath().doesLevel2Contain(keyNameStr)) {
+
+      IdPath aPath(level0Dir->GetName(), gDirectory->GetName(), keyNameStr);
+      ConditionId anId(aPath, queryId.getIdRunRange(), queryId.getVersion(), -1);
+
+      Condition* anCondition = getCondition(anId);
+      if (anCondition) {
+        result->Add(anCondition);
+      }
+    }
+  }
+}
+
+TList* FileStorage::getAllEntries(const ConditionId& queryId)
+{
+  // return list of CDB entries matching a generic request (Storage::GetAllObjects)
+
+  TDirectory::TContext context(gDirectory, mFile);
+
+  if (!(mFile && mFile->IsOpen())) {
+    LOG(ERROR) << "FileStorage is not initialized properly" << FairLogger::endl;
+    return NULL;
+  }
+
+  TList* result = new TList();
+  result->SetOwner();
+
+  TIter iter(gDirectory->GetListOfKeys());
+  TKey* key;
+
+  while ((key = (TKey*)iter.Next())) {
+
+    TString keyNameStr(key->GetName());
+    if (queryId.getPath().doesLevel0Contain(keyNameStr)) {
+      gDirectory->cd(keyNameStr);
+      getEntriesForLevel0(queryId, result);
+
+      mFile->cd();
+    }
+  }
+
+  return result;
+}
+
+Bool_t FileStorage::putCondition(Condition* entry, const char* mirrors)
+{
+  // put an  Condition object into the database
+
+  TDirectory::TContext context(gDirectory, mFile);
+
+  if (!(mFile && mFile->IsOpen())) {
+    LOG(ERROR) << "FileStorage is not initialized properly" << FairLogger::endl;
+    return kFALSE;
+  }
+
+  if (mReadOnly) {
+    LOG(ERROR) << "FileStorage is read only!" << FairLogger::endl;
+    return kFALSE;
+  }
+
+  TString mirrorsString(mirrors);
+  if (!mirrorsString.IsNull())
+    LOG(WARNING) << "LocalStorage storage cannot take mirror SEs into account. They will be ignored." << FairLogger::endl;
+
+  ConditionId& id = entry->getId();
+
+  if (!gDirectory->cd(id.getPathString())) {
+    if (!makeDir(id.getPathString())) {
+      LOG(ERROR) << "Can't open directory \"" << id.getPathString().Data() << "\"!" << FairLogger::endl;
+      return kFALSE;
+    }
+  }
+
+  // set version and subVersion for the entry to be stored
+  if (!prepareId(id)) {
+    return kFALSE;
+  }
+
+  // build keyname from entry's id
+  TString keyname;
+  if (!idToKeyName(id.getIdRunRange(), id.getVersion(), id.getSubVersion(), keyname)) {
+    LOG(ERROR) << "Invalid ID encountered! Subnormal error!" << FairLogger::endl;
+    return kFALSE;
+  }
+
+  // write object (key name: Run#firstRun_#lastRun_v#version_s#subVersion)
+  Bool_t result = gDirectory->WriteTObject(entry, keyname);
+  if (!result) {
+    LOG(ERROR) << "Can't write entry to file \"" << mFile->GetName() << "\"" << FairLogger::endl;
+  }
+
+  if (result) {
+    LOG(INFO) << "CDB object stored into file " << mFile->GetName() << FairLogger::endl;
+    LOG(INFO) << "TDirectory/key name: " << id.getPathString().Data() << "/" << keyname.Data() << FairLogger::endl;
+  }
+
+  return result;
+}
+
+TList* FileStorage::getIdListFromFile(const char* fileName)
+{
+
+  TString turl(fileName);
+  if (turl[0] != '/') {
+    turl.Prepend(TString(gSystem->WorkingDirectory()) + '/');
+  }
+  TFile* file = TFile::Open(turl);
+  if (!file) {
+    LOG(ERROR) << "Can't open selection file <" << turl.Data() << ">!" << FairLogger::endl;
+    return NULL;
+  }
+  file->cd();
+
+  TList* list = new TList();
+  list->SetOwner();
+  int i = 0;
+  TString keycycle;
+
+  ConditionId* id;
+  while (1) {
+    i++;
+    keycycle = " ConditionId;";
+    keycycle += i;
+
+    id = (ConditionId*)file->Get(keycycle);
+    if (!id)
+      break;
+    list->AddFirst(id);
+  }
+  file->Close();
+  delete file;
+  file = 0;
+  return list;
+}
+
+Bool_t FileStorage::hasConditionType(const char* path) const
+{
+  // check for path in storage
+
+  TDirectory::TContext context(gDirectory, mFile);
+  if (!(mFile && mFile->IsOpen())) {
+    LOG(ERROR) << "FileStorage is not initialized properly" << FairLogger::endl;
+    return kFALSE;
+  }
+
+  return gDirectory->cd(path);
+}
+
+void FileStorage::queryValidFiles()
+{
+  // Query the CDB for files valid for  Storage::mRun
+  // fills list mValidFileIds with  ConditionId objects created from file name
+
+  LOG(ERROR) << "Not yet (and maybe never) implemented" << FairLogger::endl;
+}
+
+Bool_t FileStorage::idToFilename(const ConditionId& /*id*/, TString& /*filename*/) const
+{
+  // build file name from  ConditionId (path, run range, version) and mDBFolder
+
+  LOG(ERROR) << "Not implemented" << FairLogger::endl;
+  return kFALSE;
+}
+
+void FileStorage::setRetry(Int_t /* nretry */, Int_t /* initsec */)
+{
+  // Function to set the exponential retry for putting entries in the OCDB
+  LOG(INFO) << "This function sets the exponential retry for putting entries in the OCDB - to be "
+               "used ONLY for  GridStorage --> returning without doing anything" << FairLogger::endl;
+  return;
+}
+
+// FileStorage factory
+ClassImp(FileStorageFactory)
+
+Bool_t FileStorageFactory::validateStorageUri(const char* dbString)
+{
+  // check if the string is valid dump URI
+  TRegexp dbPattern("^dump://.+$");
+  return TString(dbString).Contains(dbPattern);
+}
+
+StorageParameters* FileStorageFactory::createStorageParameter(const char* dbString)
+{
+  // create  FileStorageParameters class from the URI string
+
+  if (!validateStorageUri(dbString)) {
+    return NULL;
+  }
+
+  TString pathname(dbString + sizeof("dump://") - 1);
+
+  Bool_t readOnly;
+
+  if (pathname.Contains(TRegexp(";ReadOnly$"))) {
+    pathname.Resize(pathname.Length() - sizeof(";ReadOnly") + 1);
+    readOnly = kTRUE;
+  } else {
+    readOnly = kFALSE;
+  }
+
+  gSystem->ExpandPathName(pathname);
+
+  if (pathname[0] != '/') {
+    pathname.Prepend(TString(gSystem->WorkingDirectory()) + '/');
+  }
+
+  return new FileStorageParameters(pathname, readOnly);
+}
+
+Storage* FileStorageFactory::createStorage(const StorageParameters* param)
+{
+  // create FileStorage instance from parameters
+  if (FileStorageParameters::Class() == param->IsA()) {
+    const FileStorageParameters* dumpParam = (const FileStorageParameters*)param;
+    FileStorage* dumpStorage = new FileStorage(dumpParam->getPathString(), dumpParam->isReadOnly());
+    return dumpStorage;
+  }
+  return NULL;
+}
+
+// FileStorage parameter class
+ClassImp(FileStorageParameters)
+
+FileStorageParameters::FileStorageParameters() : StorageParameters(), mDBPath(), mReadOnly(kFALSE)
+{
+  // default constructor
+}
+
+FileStorageParameters::FileStorageParameters(const char* dbPath, Bool_t readOnly) : mDBPath(dbPath), mReadOnly(readOnly)
+{
+  // constructor
+  TString uri;
+  uri += "dump://";
+  uri += dbPath;
+
+  if (mReadOnly) {
+    uri += ";ReadOnly";
+  }
+
+  setUri(uri);
+  setType("dump");
+}
+
+FileStorageParameters::~FileStorageParameters()
+{
+  // destructor
+}
+
+StorageParameters* FileStorageParameters::cloneParam() const
+{
+  // clone parameter
+
+  return new FileStorageParameters(mDBPath, mReadOnly);
+}
+
+ULong_t FileStorageParameters::getHash() const
+{
+  // return getHash function
+
+  return mDBPath.Hash();
+}
+
+Bool_t FileStorageParameters::isEqual(const TObject* obj) const
+{
+  // check if this object is equal to  StorageParameters obj
+
+  if (this == obj) {
+    return kTRUE;
+  }
+
+  if (FileStorageParameters::Class() != obj->IsA()) {
+    return kFALSE;
+  }
+
+  FileStorageParameters* other = (FileStorageParameters*)obj;
+
+  return mDBPath == other->mDBPath;
+}

--- a/o2cdb/FileStorage.h
+++ b/o2cdb/FileStorage.h
@@ -1,0 +1,116 @@
+#ifndef ALICEO2_CDB_FILEDUMP_H_
+#define ALICEO2_CDB_FILEDUMP_H_
+
+#include "Storage.h"
+#include "Manager.h"
+
+class TDirectory;
+class TFile;
+
+namespace AliceO2 {
+namespace CDB {
+
+class FileStorage : public Storage {
+  friend class FileStorageFactory;
+
+public:
+  virtual Bool_t isReadOnly() const
+  {
+    return mReadOnly;
+  };
+  virtual Bool_t hasSubVersion() const
+  {
+    return kFALSE;
+  };
+  virtual Bool_t hasConditionType(const char* path) const;
+  virtual Bool_t idToFilename(const ConditionId& id, TString& filename) const;
+  virtual void setRetry(Int_t /* nretry */, Int_t /* initsec */);
+
+protected:
+  virtual Condition* getCondition(const ConditionId& query);
+  virtual ConditionId* getConditionId(const ConditionId& query);
+  virtual TList* getAllEntries(const ConditionId& query);
+  virtual Bool_t putCondition(Condition* entry, const char* mirrors = "");
+  virtual TList* getIdListFromFile(const char* fileName);
+
+private:
+  FileStorage(const FileStorage& source);
+  FileStorage& operator=(const FileStorage& source);
+  FileStorage(const char* dbFile, Bool_t readOnly);
+  virtual ~FileStorage();
+
+  Bool_t keyNameToId(const char* keyname, IdRunRange& runRange, Int_t& version, Int_t& subVersion);
+  Bool_t idToKeyName(const IdRunRange& runRange, Int_t version, Int_t subVersion, TString& keyname);
+
+  Bool_t makeDir(const TString& dir);
+
+  Bool_t prepareId(ConditionId& id);
+  //	Bool_t getId(const  ConditionId& query,  ConditionId& result);
+  ConditionId* getId(const ConditionId& query);
+
+  virtual void queryValidFiles();
+
+  void getEntriesForLevel0(const ConditionId& query, TList* result);
+  void getEntriesForLevel1(const ConditionId& query, TList* result);
+
+  TFile* mFile;     // FileStorage file
+  Bool_t mReadOnly; // ReadOnly flag
+
+  ClassDef(FileStorage, 0)
+};
+
+/////////////////////////////////////////////////////////////////////
+//                                                                 //
+//  class  FileStorageFactory					   //
+//                                                                 //
+/////////////////////////////////////////////////////////////////////
+
+class FileStorageFactory : public StorageFactory {
+
+public:
+  virtual Bool_t validateStorageUri(const char* dbString);
+  virtual StorageParameters* createStorageParameter(const char* dbString);
+
+protected:
+  virtual Storage* createStorage(const StorageParameters* param);
+
+  ClassDef(FileStorageFactory, 0)
+};
+
+/////////////////////////////////////////////////////////////////////
+//                                                                 //
+//  class  FileStorageParameters					   //
+//                                                                 //
+/////////////////////////////////////////////////////////////////////
+
+class FileStorageParameters : public StorageParameters {
+
+public:
+  FileStorageParameters();
+  FileStorageParameters(const char* dbPath, Bool_t readOnly = kFALSE);
+
+  virtual ~FileStorageParameters();
+
+  const TString& getPathString() const
+  {
+    return mDBPath;
+  };
+  Bool_t isReadOnly() const
+  {
+    return mReadOnly;
+  };
+
+  virtual StorageParameters* cloneParam() const;
+
+  virtual ULong_t getHash() const;
+  virtual Bool_t isEqual(const TObject* obj) const;
+
+private:
+  TString mDBPath;  // FileStorage file path name
+  Bool_t mReadOnly; // ReadOnly flag
+
+  ClassDef(FileStorageParameters, 0)
+};
+}
+}
+#endif

--- a/o2cdb/GridStorage.cxx
+++ b/o2cdb/GridStorage.cxx
@@ -1,0 +1,1419 @@
+// access class to a DataBase in an AliEn storage  			                       //
+#include <cstdlib>
+#include <TGrid.h>
+#include <TGridResult.h>
+#include <TFile.h>
+#include <TKey.h>
+#include <TROOT.h>
+#include <TList.h>
+#include <TObjArray.h>
+#include <TObjString.h>
+#include <TMath.h>
+#include <TRegexp.h>
+
+#include <FairLogger.h>
+
+#include "Condition.h"
+#include "GridStorage.h"
+#include "Manager.h"
+
+using namespace AliceO2::CDB;
+
+ClassImp(GridStorage)
+
+GridStorage::GridStorage(const char* gridUrl, const char* user, const char* dbFolder, const char* se, const char* cacheFolder,
+           Bool_t operateDisconnected, Long64_t cacheSize, Long_t cleanupInterval)
+  : Storage(),
+    mGridUrl(gridUrl),
+    mUser(user),
+    mDBFolder(dbFolder),
+    mSE(se),
+    mMirrorSEs(""),
+    mCacheFolder(cacheFolder),
+    mOperateDisconnected(operateDisconnected),
+    mCacheSize(cacheSize),
+    mCleanupInterval(cleanupInterval)
+{
+  // constructor //
+  // alalal
+
+  // if the same GridStorage is alreay active, skip connection
+  if (!gGrid || mGridUrl != gGrid->GridUrl() || ((mUser != "") && (mUser != gGrid->GetUser()))) {
+    // connection to the GridStorage
+    LOG(INFO) << "Connection to the GridStorage..." << FairLogger::endl;
+    if (gGrid) {
+      LOG(INFO) << "gGrid = " << gGrid << ";  mGridUrl = " << mGridUrl.Data()
+                << ";  gGrid->GridUrl() = " << gGrid->GridUrl() << FairLogger::endl;
+      LOG(INFO) << "mUser = " << mUser.Data() << ";  gGrid->getUser() = " << gGrid->GetUser() << FairLogger::endl;
+    }
+    TGrid::Connect(mGridUrl.Data(), mUser.Data());
+  }
+
+  if (!gGrid) {
+    LOG(ERROR) << "Connection failed!" << FairLogger::endl;
+    return;
+  }
+
+  TString initDir(gGrid->Pwd(0));
+  if (mDBFolder[0] != '/') {
+    mDBFolder.Prepend(initDir);
+  }
+
+  // check DBFolder: trying to cd to DBFolder; if it does not exist, create it
+  if (!gGrid->Cd(mDBFolder.Data(), 0)) {
+    LOG(DEBUG) << "Creating new folder <" << mDBFolder.Data() << "> ..." << FairLogger::endl;
+    TGridResult* res = gGrid->Command(Form("mkdir -p %s", mDBFolder.Data()));
+    TString result = res->GetKey(0, "__result__");
+    if (result == "0") {
+      LOG(FATAL) << "Cannot create folder \"" << mDBFolder.Data() << "\"!" << FairLogger::endl;
+      return;
+    }
+  } else {
+    LOG(DEBUG) << "Folder <" << mDBFolder.Data() << "> found" << FairLogger::endl;
+  }
+
+  // removes any '/' at the end of path, then append one '/'
+  while (mDBFolder.EndsWith("/"))
+    mDBFolder.Remove(mDBFolder.Last('/'));
+  mDBFolder += "/";
+
+  mType = "alien";
+  mBaseFolder = mDBFolder;
+
+  // Setting the cache
+
+  // Check if local cache folder is already defined
+  TString origCache(TFile::GetCacheFileDir());
+  if (mCacheFolder.Length() > 0) {
+    if (origCache.Length() == 0) {
+      LOG(INFO) << "Setting local cache to: " << mCacheFolder.Data() << FairLogger::endl;
+    } else if (mCacheFolder != origCache) {
+      LOG(WARNING) << "LocalStorage cache folder was already defined, changing it to: " << mCacheFolder.Data()
+                   << FairLogger::endl;
+    }
+
+    // default settings are: operateDisconnected=kTRUE, forceCacheread = kFALSE
+    if (!TFile::SetCacheFileDir(mCacheFolder.Data(), mOperateDisconnected)) {
+      LOG(ERROR) << "Could not set cache folder " << mCacheFolder.Data() << " !" << FairLogger::endl;
+      mCacheFolder = "";
+    } else {
+      // reset mCacheFolder because the function may have
+      // slightly changed the folder name (e.g. '/' added)
+      mCacheFolder = TFile::GetCacheFileDir();
+    }
+
+    // default settings are: cacheSize=1GB, cleanupInterval = 0
+    if (!TFile::ShrinkCacheFileDir(mCacheSize, mCleanupInterval)) {
+      LOG(ERROR) << "Could not set following values to ShrinkCacheFileDir: cacheSize = " << mCacheSize
+                 << " cleanupInterval = " << mCleanupInterval << " !" << FairLogger::endl;
+    }
+  }
+
+  // return to the initial directory
+  gGrid->Cd(initDir.Data(), 0);
+
+  mNretry = 3;           // default
+  mInitRetrySeconds = 5; // default
+}
+
+GridStorage::~GridStorage()
+{
+  // destructor
+  delete gGrid;
+  gGrid = 0;
+}
+
+Bool_t GridStorage::filenameToId(TString& filename, ConditionId& id)
+{
+  // build  ConditionId from full path filename (mDBFolder/path/Run#x_#y_v#z_s0.root)
+
+  if (filename.Contains(mDBFolder)) {
+    filename = filename(mDBFolder.Length(), filename.Length() - mDBFolder.Length());
+  }
+
+  TString idPath = filename(0, filename.Last('/'));
+  id.setPath(idPath);
+  if (!id.isValid())
+    return kFALSE;
+
+  filename = filename(idPath.Length() + 1, filename.Length() - idPath.Length());
+
+  Ssiz_t mSize;
+  // valid filename: Run#firstRun_#lastRun_v#version_s0.root
+  TRegexp keyPattern("^Run[0-9]+_[0-9]+_v[0-9]+_s0.root$");
+  keyPattern.Index(filename, &mSize);
+  if (!mSize) {
+
+    // TODO backward compatibility ... maybe remove later!
+    Ssiz_t oldmSize;
+    TRegexp oldKeyPattern("^Run[0-9]+_[0-9]+_v[0-9]+.root$");
+    oldKeyPattern.Index(filename, &oldmSize);
+    if (!oldmSize) {
+      LOG(DEBUG) << "Bad filename <" << filename.Data() << ">." << FairLogger::endl;
+      return kFALSE;
+    } else {
+      LOG(DEBUG) << "Old filename format <" << filename.Data() << ">." << FairLogger::endl;
+      id.setSubVersion(-11); // TODO trick to ensure backward compatibility
+    }
+
+  } else {
+    id.setSubVersion(-1); // TODO trick to ensure backward compatibility
+  }
+
+  filename.Resize(filename.Length() - sizeof(".root") + 1);
+
+  TObjArray* strArray = (TObjArray*)filename.Tokenize("_");
+
+  TString firstRunString(((TObjString*)strArray->At(0))->GetString());
+  id.setFirstRun(atoi(firstRunString.Data() + 3));
+  id.setLastRun(atoi(((TObjString*)strArray->At(1))->GetString()));
+
+  TString verString(((TObjString*)strArray->At(2))->GetString());
+  id.setVersion(atoi(verString.Data() + 1));
+
+  delete strArray;
+
+  return kTRUE;
+}
+
+Bool_t GridStorage::idToFilename(const ConditionId& id, TString& filename) const
+{
+  // build file name from  ConditionId (path, run range, version) and mDBFolder
+
+  if (!id.getIdRunRange().isValid()) {
+    LOG(DEBUG) << "Invalid run range [" << id.getFirstRun() << "," << id.getLastRun() << "]." << FairLogger::endl;
+    return kFALSE;
+  }
+
+  if (id.getVersion() < 0) {
+    LOG(DEBUG) << "Invalid version <" << id.getVersion() << ">." << FairLogger::endl;
+    return kFALSE;
+  }
+
+  filename = Form("Run%d_%d_v%d", id.getFirstRun(), id.getLastRun(), id.getVersion());
+
+  if (id.getSubVersion() != -11)
+    filename += "_s0"; // TODO to ensure backward compatibility
+  filename += ".root";
+
+  filename.Prepend(mDBFolder + id.getPathString() + '/');
+
+  return kTRUE;
+}
+
+void GridStorage::setRetry(Int_t nretry, Int_t initsec)
+{
+
+  // Function to set the exponential retry for putting entries in the OCDB
+
+  LOG(WARNING) << "WARNING!!! You are changing the exponential retry times and delay: this "
+                  "function should be used by experts!" << FairLogger::endl;
+  mNretry = nretry;
+  mInitRetrySeconds = initsec;
+  LOG(DEBUG) << "mNretry = " << mNretry << ", mInitRetrySeconds = " << mInitRetrySeconds << FairLogger::endl;
+}
+
+Bool_t GridStorage::prepareId(ConditionId& id)
+{
+  // prepare id (version) of the object that will be stored (called by putCondition)
+
+  TString initDir(gGrid->Pwd(0));
+
+  TString dirName(mDBFolder);
+
+  Bool_t dirExist = kFALSE;
+
+  // go to the path; if directory does not exist, create it
+  for (int i = 0; i < 3; i++) {
+    // TString cmd("find -d ");
+    // cmd += Form("%s ",dirName);
+    // cmd +=
+    // gGrid->Command(cmd.Data());
+    dirName += Form("%s/", id.getPathLevel(i).Data());
+    dirExist = gGrid->Cd(dirName, 0);
+    if (!dirExist) {
+      LOG(DEBUG) << "Creating new folder <" << dirName.Data() << "> ..." << FairLogger::endl;
+      if (!gGrid->Mkdir(dirName, "", 0)) {
+        LOG(ERROR) << "Cannot create directory <" << dirName.Data() << "> !" << FairLogger::endl;
+        gGrid->Cd(initDir.Data());
+        return kFALSE;
+      }
+
+      // if folders are new add tags to them
+      if (i == 1) {
+
+      } else if (i == 2) {
+        LOG(DEBUG) << "Tagging level 2 folder with \"CDB\" and \"CDB_MD\" tag" << FairLogger::endl;
+        if (!addTag(dirName, "CDB")) {
+          LOG(ERROR) << "Could not tag folder " << dirName.Data() << " !" << FairLogger::endl;
+          if (!gGrid->Rmdir(dirName.Data())) {
+            LOG(ERROR) << "Unexpected: could not remove " << dirName.Data() << " directory!" << FairLogger::endl;
+          }
+          return 0;
+        }
+        if (!addTag(dirName, "CDB_MD")) {
+          LOG(ERROR) << "Could not tag folder " << dirName.Data() << " !" << FairLogger::endl;
+          if (!gGrid->Rmdir(dirName.Data())) {
+            LOG(ERROR) << "Unexpected: could not remove " << dirName.Data() << " directory!" << FairLogger::endl;
+          }
+          return 0;
+        }
+      }
+    }
+  }
+  gGrid->Cd(initDir, 0);
+
+  TString filename;
+  ConditionId anId;                 // the id got from filename
+  IdRunRange lastIdRunRange(-1, -1); // highest runRange found
+  Int_t lastVersion = 0;         // highest version found
+
+  TGridResult* res = gGrid->Ls(dirName);
+
+  // loop on the files in the directory, look for highest version
+  for (int i = 0; i < res->GetEntries(); i++) {
+    filename = res->GetFileNamePath(i);
+    if (!filenameToId(filename, anId))
+      continue;
+    if (anId.getIdRunRange().isOverlappingWith(id.getIdRunRange()) && anId.getVersion() > lastVersion) {
+      lastVersion = anId.getVersion();
+      lastIdRunRange = anId.getIdRunRange();
+    }
+  }
+  delete res;
+
+  // GRP entries with explicitly set version escape default incremental versioning
+  if (id.getPathString().Contains("GRP") && id.hasVersion() && lastVersion != 0) {
+    LOG(DEBUG) << "Condition " << id.ToString().Data() << " won't be put in the destination OCDB" << FairLogger::endl;
+    return kFALSE;
+  }
+
+  id.setVersion(lastVersion + 1);
+  id.setSubVersion(0);
+
+  TString lastStorage = id.getLastStorage();
+  if (lastStorage.Contains(TString("new"), TString::kIgnoreCase) && id.getVersion() > 1) {
+    LOG(DEBUG) << "A NEW object is being stored with version " << id.getVersion() << FairLogger::endl;
+    LOG(DEBUG) << "and it will hide previously stored object with version " << id.getVersion() - 1 << "!"
+               << FairLogger::endl;
+  }
+
+  if (!lastIdRunRange.isAnyRange() && !(lastIdRunRange.isEqual(&id.getIdRunRange())))
+    LOG(WARNING) << "Run range modified w.r.t. previous version (Run" << lastIdRunRange.getFirstRun() << "_"
+                 << lastIdRunRange.getLastRun() << "_v" << id.getVersion() << ")" << FairLogger::endl;
+
+  return kTRUE;
+}
+
+ConditionId* GridStorage::getId(const TObjArray& validFileIds, const ConditionId& query)
+{
+  // look for the ConditionId that matches query's requests (highest or exact version)
+
+  if (validFileIds.GetEntriesFast() < 1)
+    return NULL;
+
+  TIter iter(&validFileIds);
+
+  ConditionId* anIdPtr = 0;
+  ConditionId* result = 0;
+
+  while ((anIdPtr = dynamic_cast<ConditionId*>(iter.Next()))) {
+    if (anIdPtr->getPathString() != query.getPathString())
+      continue;
+
+    // if(!CheckVersion(query, anIdPtr, result)) return NULL;
+
+    if (!query.hasVersion()) { // look for highest version
+      if (result && result->getVersion() > anIdPtr->getVersion())
+        continue;
+      if (result && result->getVersion() == anIdPtr->getVersion()) {
+        LOG(ERROR) << "More than one object valid for run " << query.getFirstRun() << " version "
+                   << anIdPtr->getVersion() << "!" << FairLogger::endl;
+        return NULL;
+      }
+      result = new ConditionId(*anIdPtr);
+    } else { // look for specified version
+      if (query.getVersion() != anIdPtr->getVersion())
+        continue;
+      if (result && result->getVersion() == anIdPtr->getVersion()) {
+        LOG(ERROR) << "More than one object valid for run " << query.getFirstRun() << " version "
+                   << anIdPtr->getVersion() << "!" << FairLogger::endl;
+        return NULL;
+      }
+      result = new ConditionId(*anIdPtr);
+    }
+  }
+
+  return result;
+}
+
+ConditionId* GridStorage::getConditionId(const ConditionId& queryId)
+{
+  // get  ConditionId from the database
+  // User must delete returned object
+
+  ConditionId* dataId = 0;
+
+  ConditionId selectedId(queryId);
+  if (!selectedId.hasVersion()) {
+    // if version is not specified, first check the selection criteria list
+    getSelection(&selectedId);
+  }
+
+  TObjArray validFileIds;
+  validFileIds.SetOwner(1);
+
+  // look for file matching query requests (path, runRange, version)
+  if (selectedId.getFirstRun() == mRun && mPathFilter.isSupersetOf(selectedId.getPathString()) &&
+      mVersion == selectedId.getVersion() && !mConditionMetaDataFilter) {
+    // look into list of valid files previously loaded with  Storage::FillValidFileIds()
+    LOG(DEBUG) << "List of files valid for run " << selectedId.getFirstRun()
+               << " was loaded. Looking there for fileids valid for path " << selectedId.getPathString().Data() << "!"
+               << FairLogger::endl;
+    dataId = getId(mValidFileIds, selectedId);
+
+  } else {
+    // List of files valid for reqested run was not loaded. Looking directly into CDB
+    LOG(DEBUG) << "List of files valid for run " << selectedId.getFirstRun() << " and version "
+               << selectedId.getVersion() << " was not loaded. Looking directly into CDB for fileids valid for path "
+               << selectedId.getPathString().Data() << "!" << FairLogger::endl;
+
+    TString filter;
+    makeQueryFilter(selectedId.getFirstRun(), selectedId.getLastRun(), 0, filter);
+
+    TString pattern = ".root";
+    TString optionQuery = "-y -m";
+    if (selectedId.getVersion() >= 0) {
+      pattern.Prepend(Form("_v%d_s0", selectedId.getVersion()));
+      optionQuery = "";
+    }
+
+    TString folderCopy(Form("%s%s/Run", mDBFolder.Data(), selectedId.getPathString().Data()));
+
+    if (optionQuery.Contains("-y")) {
+      LOG(INFO) << "Only latest version will be returned" << FairLogger::endl;
+    }
+
+    LOG(DEBUG) << "** mDBFolder = " << folderCopy.Data() << ", pattern = " << pattern.Data()
+               << ", filter = " << filter.Data() << FairLogger::endl;
+    TGridResult* res = gGrid->Query(folderCopy, pattern, filter, optionQuery.Data());
+    if (res) {
+      for (int i = 0; i < res->GetEntries(); i++) {
+        ConditionId* validFileId = new ConditionId();
+        TString filename = res->GetKey(i, "lfn");
+        if (filename == "")
+          continue;
+        if (filenameToId(filename, *validFileId))
+          validFileIds.AddLast(validFileId);
+      }
+      delete res;
+    } else {
+      return 0; // this should be only in case of file catalogue glitch
+    }
+
+    dataId = getId(validFileIds, selectedId);
+  }
+
+  return dataId;
+}
+
+Condition* GridStorage::getCondition(const ConditionId& queryId)
+{
+  // get  Condition from the database
+
+  ConditionId* dataId = getConditionId(queryId);
+
+  if (!dataId) {
+    LOG(FATAL) << "No valid CDB object found! request was: " << queryId.ToString().Data() << FairLogger::endl;
+    return NULL;
+  }
+
+  TString filename;
+  if (!idToFilename(*dataId, filename)) {
+    LOG(DEBUG) << "Bad data ID encountered! Subnormal error!" << FairLogger::endl;
+    delete dataId;
+    LOG(FATAL) << "No valid CDB object found! request was: " << queryId.ToString().Data() << FairLogger::endl;
+  }
+
+  Condition* anCondition = getConditionFromFile(filename, dataId);
+
+  delete dataId;
+  if (!anCondition)
+    LOG(FATAL) << "No valid CDB object found! request was: " << queryId.ToString().Data() << FairLogger::endl;
+
+  return anCondition;
+}
+
+Condition* GridStorage::getConditionFromFile(TString& filename, ConditionId* dataId)
+{
+  // Get AliCBCondition object from file "filename"
+
+  LOG(DEBUG) << "Opening file: " << filename.Data() << FairLogger::endl;
+
+  filename.Prepend("/alien");
+
+  // if option="CACHEREAD" TFile will use the local caching facility!
+  TString option = "READ";
+  if (mCacheFolder != "") {
+
+    // Check if local cache folder was changed in the meanwhile
+    TString origCache(TFile::GetCacheFileDir());
+    if (mCacheFolder != origCache) {
+      LOG(WARNING) << "LocalStorage cache folder has been overwritten!! mCacheFolder = " << mCacheFolder.Data()
+                   << " origCache = " << origCache.Data() << FairLogger::endl;
+      TFile::SetCacheFileDir(mCacheFolder.Data(), mOperateDisconnected);
+      TFile::ShrinkCacheFileDir(mCacheSize, mCleanupInterval);
+    }
+
+    option.Prepend("CACHE");
+  }
+
+  LOG(DEBUG) << "Option: " << option.Data() << FairLogger::endl;
+
+  TFile* file = TFile::Open(filename, option);
+  if (!file) {
+    LOG(DEBUG) << "Can't open file <" << filename.Data() << ">!" << FairLogger::endl;
+    return NULL;
+  }
+
+  // get the only  Condition object from the file
+  // the object in the file is an  Condition entry named " Condition"
+
+  Condition* anCondition = dynamic_cast<Condition*>(file->Get(" Condition"));
+
+  if (!anCondition) {
+    LOG(DEBUG) << "Bad storage data: file does not contain an  Condition object!" << FairLogger::endl;
+    file->Close();
+    return NULL;
+  }
+
+  // The object's ConditionId is not reset during storage
+  // If object's ConditionId runRange or version do not match with filename,
+  // it means that someone renamed file by hand. In this case a warning msg is issued.
+
+  if (anCondition) {
+    ConditionId entryId = anCondition->getId();
+    Int_t tmpSubVersion = dataId->getSubVersion();
+    dataId->setSubVersion(entryId.getSubVersion()); // otherwise filename and id may mismatch
+    if (!entryId.isEqual(dataId)) {
+      LOG(WARNING) << "Mismatch between file name and object's ConditionId!" << FairLogger::endl;
+      LOG(WARNING) << "File name: " << dataId->ToString().Data() << FairLogger::endl;
+      LOG(WARNING) << "Object's ConditionId: " << entryId.ToString().Data() << FairLogger::endl;
+    }
+    dataId->setSubVersion(tmpSubVersion);
+  }
+
+  anCondition->setLastStorage("grid");
+
+  // Check whether entry contains a TTree. In case load the tree in memory!
+  loadTreeFromFile(anCondition);
+
+  // close file, return retieved entry
+  file->Close();
+  delete file;
+  file = 0;
+
+  return anCondition;
+}
+
+TList* GridStorage::getAllEntries(const ConditionId& queryId)
+{
+  // return list of CDB entries matching a generic request (Storage::GetAllObjects)
+
+  TList* result = new TList();
+  result->SetOwner();
+
+  TObjArray validFileIds;
+  validFileIds.SetOwner(1);
+
+  Bool_t alreadyLoaded = kFALSE;
+
+  // look for file matching query requests (path, runRange)
+  if (queryId.getFirstRun() == mRun && mPathFilter.isSupersetOf(queryId.getPathString()) && mVersion < 0 &&
+      !mConditionMetaDataFilter) {
+    // look into list of valid files previously loaded with  Storage::FillValidFileIds()
+    LOG(DEBUG) << "List of files valid for run " << queryId.getFirstRun() << " and for path \""
+               << queryId.getPathString().Data() << "\" was loaded. Looking there!" << FairLogger::endl;
+
+    alreadyLoaded = kTRUE;
+
+  } else {
+    // List of files valid for reqested run was not loaded. Looking directly into CDB
+    LOG(DEBUG) << "List of files valid for run " << queryId.getFirstRun() << " and for path \""
+               << queryId.getPathString().Data() << " was not loaded. Looking directly into CDB!" << FairLogger::endl;
+
+    TString filter;
+    makeQueryFilter(queryId.getFirstRun(), queryId.getLastRun(), 0, filter);
+
+    TString path = queryId.getPathString();
+
+    TString pattern = "Run*.root";
+    TString optionQuery = "-y";
+
+    TString addFolder = "";
+    if (!path.Contains("*")) {
+      if (!path.BeginsWith("/"))
+        addFolder += "/";
+      addFolder += path;
+    } else {
+      if (path.BeginsWith("/"))
+        path.Remove(0, 1);
+      if (path.EndsWith("/"))
+        path.Remove(path.Length() - 1, 1);
+      TObjArray* tokenArr = path.Tokenize("/");
+      if (tokenArr->GetEntries() != 3) {
+        LOG(ERROR) << "Not a 3 level path! Keeping old query..." << FairLogger::endl;
+        pattern.Prepend(path + "/");
+      } else {
+        TString str0 = ((TObjString*)tokenArr->At(0))->String();
+        TString str1 = ((TObjString*)tokenArr->At(1))->String();
+        TString str2 = ((TObjString*)tokenArr->At(2))->String();
+        if (str0 != "*" && str1 != "*" && str2 == "*") {
+          // e.g. "ITS/Calib/*"
+          addFolder = "/" + str0 + "/" + str1;
+        } else if (str0 != "*" && str1 == "*" && str2 == "*") {
+          // e.g. "ITS/*/*"
+          addFolder = "/" + str0;
+        } else if (str0 == "*" && str1 == "*" && str2 == "*") {
+          // e.g. "*/*/*"
+          // do nothing: addFolder is already an empty string;
+        } else {
+          // e.g. "ITS/*/RecoParam"
+          pattern.Prepend(path + "/");
+        }
+      }
+      delete tokenArr;
+      tokenArr = 0;
+    }
+
+    TString folderCopy(Form("%s%s", mDBFolder.Data(), addFolder.Data()));
+
+    LOG(DEBUG) << "mDBFolder = " << folderCopy.Data() << ", pattern = " << pattern.Data()
+               << ", filter = " << filter.Data() << FairLogger::endl;
+
+    TGridResult* res = gGrid->Query(folderCopy, pattern, filter, optionQuery.Data());
+
+    if (!res) {
+      LOG(ERROR) << "GridStorage query failed" << FairLogger::endl;
+      return 0;
+    }
+
+    for (int i = 0; i < res->GetEntries(); i++) {
+      ConditionId* validFileId = new ConditionId();
+      TString filename = res->GetKey(i, "lfn");
+      if (filename == "")
+        continue;
+      if (filenameToId(filename, *validFileId))
+        validFileIds.AddLast(validFileId);
+    }
+    delete res;
+  }
+
+  TIter* iter = 0;
+  if (alreadyLoaded) {
+    iter = new TIter(&mValidFileIds);
+  } else {
+    iter = new TIter(&validFileIds);
+  }
+
+  TObjArray selectedIds;
+  selectedIds.SetOwner(1);
+
+  // loop on list of valid Ids to select the right version to get.
+  // According to query and to the selection criteria list, version can be the highest or exact
+  IdPath pathCopy;
+  ConditionId* anIdPtr = 0;
+  ConditionId* dataId = 0;
+  IdPath queryPath = queryId.getPath();
+  while ((anIdPtr = dynamic_cast<ConditionId*>(iter->Next()))) {
+    IdPath thisCDBPath = anIdPtr->getPath();
+    if (!(queryPath.isSupersetOf(thisCDBPath)) || pathCopy.getPathString() == thisCDBPath.getPathString())
+      continue;
+    pathCopy = thisCDBPath;
+
+    // check the selection criteria list for this query
+    ConditionId thisId(*anIdPtr);
+    thisId.setVersion(queryId.getVersion());
+    if (!thisId.hasVersion())
+      getSelection(&thisId);
+
+    if (alreadyLoaded) {
+      dataId = getId(mValidFileIds, thisId);
+    } else {
+      dataId = getId(validFileIds, thisId);
+    }
+    if (dataId)
+      selectedIds.Add(dataId);
+  }
+
+  delete iter;
+  iter = 0;
+
+  // selectedIds contains the Ids of the files matching all requests of query!
+  // All the objects are now ready to be retrieved
+  iter = new TIter(&selectedIds);
+  while ((anIdPtr = dynamic_cast<ConditionId*>(iter->Next()))) {
+    TString filename;
+    if (!idToFilename(*anIdPtr, filename)) {
+      LOG(DEBUG) << "Bad data ID encountered! Subnormal error!" << FairLogger::endl;
+      continue;
+    }
+
+    Condition* anCondition = getConditionFromFile(filename, anIdPtr);
+
+    if (anCondition)
+      result->Add(anCondition);
+  }
+  delete iter;
+  iter = 0;
+
+  return result;
+}
+
+Bool_t GridStorage::putCondition(Condition* entry, const char* mirrors)
+{
+  // put an  Condition object into the database
+
+  ConditionId& id = entry->getId();
+
+  // set version for the entry to be stored
+  if (!prepareId(id))
+    return kFALSE;
+
+  // build filename from entry's id
+  TString filename;
+  if (!idToFilename(id, filename)) {
+    LOG(ERROR) << "Bad ID encountered, cannot make a file name out of it!" << FairLogger::endl;
+    return kFALSE;
+  }
+
+  TString folderToTag = Form("%s%s", mDBFolder.Data(), id.getPathString().Data());
+
+  TDirectory* saveDir = gDirectory;
+
+  TString fullFilename = Form("/alien%s", filename.Data());
+  TString seMirrors(mirrors);
+  if (seMirrors.IsNull() || seMirrors.IsWhitespace())
+    seMirrors = getMirrorSEs();
+  // specify SE to filename
+  // if a list of SEs was passed to this method or set via setMirrorSEs, set the first as SE for
+  // opening the file.
+  // The other SEs will be used in cascade in case of failure in opening the file.
+  // The remaining SEs will be used to create replicas.
+  TObjArray* arraySEs = seMirrors.Tokenize(',');
+  Int_t nSEs = arraySEs->GetEntries();
+  Int_t remainingSEs = 1;
+  if (nSEs == 0) {
+    if (mSE != "default")
+      fullFilename += Form("?se=%s", mSE.Data());
+  } else {
+    remainingSEs = nSEs;
+  }
+
+  // open file
+  TFile* file = 0;
+  TFile* reopenedFile = 0;
+  LOG(DEBUG) << "mNretry = " << mNretry << ", mInitRetrySeconds = " << mInitRetrySeconds << FairLogger::endl;
+  TString targetSE("");
+
+  Bool_t result = kFALSE;
+  Bool_t reOpenResult = kFALSE;
+  Int_t reOpenAttempts = 0;
+  while (!reOpenResult && reOpenAttempts < 2) { // loop to check the file after closing it, to catch
+                                                // the unlikely but possible case when the file
+    // is cleaned up by alien just before closing as a consequence of a network disconnection while
+    // writing
+
+    while (!file && remainingSEs > 0) {
+      if (nSEs != 0) {
+        TObjString* target = (TObjString*)arraySEs->At(nSEs - remainingSEs);
+        targetSE = target->String();
+        if (!(targetSE.BeginsWith("ALICE::") && targetSE.CountChar(':') == 4)) {
+          LOG(ERROR) << "\"" << targetSE.Data() << "\" is an invalid storage element identifier." << FairLogger::endl;
+          continue;
+        }
+        if (fullFilename.Contains('?'))
+          fullFilename.Remove(fullFilename.Last('?'));
+        fullFilename += Form("?se=%s", targetSE.Data());
+      }
+      Int_t remainingAttempts = mNretry;
+      Int_t nsleep = mInitRetrySeconds; // number of seconds between attempts. We let it increase exponentially
+      LOG(DEBUG) << "Uploading file into SE #" << nSEs - remainingSEs + 1 << ": " << targetSE.Data()
+                 << FairLogger::endl;
+      while (remainingAttempts > 0) {
+        LOG(DEBUG) << "Uploading file into OCDB at " << targetSE.Data() << " - Attempt #"
+                   << mNretry - remainingAttempts + 1 << FairLogger::endl;
+        remainingAttempts--;
+        file = TFile::Open(fullFilename, "CREATE");
+        if (!file || !file->IsWritable()) {
+          if (file) { // file is not writable
+            file->Close();
+            delete file;
+            file = 0;
+          }
+          TString message(TString::Format("Attempt %d failed.", mNretry - remainingAttempts));
+          if (remainingAttempts > 0) {
+            message += " Sleeping for ";
+            message += nsleep;
+            message += " seconds";
+          } else {
+            if (remainingSEs > 0)
+              message += " Trying to upload at next SE";
+          }
+          LOG(DEBUG) << message.Data() << FairLogger::endl;
+          if (remainingAttempts > 0)
+            sleep(nsleep);
+        } else {
+          remainingAttempts = 0;
+        }
+        nsleep *= mInitRetrySeconds;
+      }
+      remainingSEs--;
+    }
+    if (!file) {
+      LOG(ERROR) << "All " << mNretry << " attempts have failed on all " << nSEs << " SEs. Returning..."
+                 << FairLogger::endl;
+      return kFALSE;
+    }
+
+    file->cd();
+
+    // setTreeToFile(entry, file);
+    entry->setVersion(id.getVersion());
+
+    // write object (key name: " Condition")
+    result = (file->WriteTObject(entry, " Condition") != 0);
+    file->Close();
+    if (!result) {
+      LOG(ERROR) << "Can't write entry to file <" << filename.Data() << ">!" << FairLogger::endl;
+    } else {
+      LOG(DEBUG) << "Reopening file " << fullFilename.Data() << " for checking its correctness" << FairLogger::endl;
+      reopenedFile = TFile::Open(fullFilename.Data(), "READ");
+      if (!reopenedFile) {
+        reOpenResult = kFALSE;
+        LOG(INFO) << "The file \"" << fullFilename.Data()
+                  << "\" was closed successfully but cannot be reopened. Trying now to regenerate "
+                     "it (regeneration attempt number " << ++reOpenAttempts << FairLogger::endl;
+        delete file;
+        file = 0;
+        LOG(DEBUG) << "Removing file " << filename.Data() << FairLogger::endl;
+        if (!gGrid->Rm(filename.Data()))
+          LOG(ERROR) << "Can't delete file!" << FairLogger::endl;
+        remainingSEs++;
+      } else {
+        reOpenResult = kTRUE;
+        if (!Manager::Instance()->isOcdbUploadMode()) {
+          reopenedFile->Close();
+          delete reopenedFile;
+          reopenedFile = 0;
+        }
+      }
+    }
+  }
+
+  if (saveDir)
+    saveDir->cd();
+  else
+    gROOT->cd();
+  delete file;
+  file = 0;
+
+  if (result && reOpenResult) {
+
+    if (!tagFileId(filename, &id)) {
+      LOG(INFO) << "CDB tagging failed. Deleting file \"" << filename.Data() << "\"!" << FairLogger::endl;
+      if (!gGrid->Rm(filename.Data()))
+        LOG(ERROR) << "Can't delete file!" << FairLogger::endl;
+      return kFALSE;
+    }
+
+    tagFileConditionMetaData(filename, entry->getConditionMetaData());
+  } else {
+    LOG(ERROR) << "The file could not be opened or the object could not be written." << FairLogger::endl;
+    if (!gGrid->Rm(filename.Data()))
+      LOG(ERROR) << "Can't delete file!" << FairLogger::endl;
+    return kFALSE;
+  }
+
+  LOG(INFO) << "CDB object stored into file \"" << filename.Data() << "\" " << FairLogger::endl;
+  if (nSEs == 0)
+    LOG(INFO) << "Storage Element: " << mSE.Data() << FairLogger::endl;
+  else
+    LOG(INFO) << "Storage Element: " << targetSE.Data() << FairLogger::endl;
+
+  // In case of other SEs specified by the user, mirror the file to the remaining SEs
+  for (Int_t i = 0; i < nSEs; i++) {
+    if (i == nSEs - remainingSEs - 1)
+      continue; // skip mirroring to the SE where the file was saved
+    TString mirrorCmd("mirror ");
+    mirrorCmd += filename;
+    mirrorCmd += " ";
+    TObjString* target = (TObjString*)arraySEs->At(i);
+    TString mirrorSE(target->String());
+    mirrorCmd += mirrorSE;
+    LOG(DEBUG) << "mirror command: \"" << mirrorCmd.Data() << "\"" << FairLogger::endl;
+    LOG(INFO) << "Mirroring to storage element: " << mirrorSE.Data() << FairLogger::endl;
+    gGrid->Command(mirrorCmd.Data());
+  }
+  arraySEs->Delete();
+  arraySEs = 0;
+
+  if (Manager::Instance()->isOcdbUploadMode()) { // if uploading to OCDBs, add to cvmfs too
+    if (!filename.BeginsWith("/alice/data") && !filename.BeginsWith("/alice/simulation/2008/v4-15-Release")) {
+      LOG(ERROR) << "Cannot upload to CVMFS OCDBs a non official CDB object: \"" << filename.Data() << "\"!"
+                 << FairLogger::endl;
+    } else {
+      if (!putInCvmfs(filename, reopenedFile))
+        LOG(ERROR) << "Could not upload AliEn file \"" << filename.Data() << "\" to CVMFS OCDB!" << FairLogger::endl;
+    }
+    reopenedFile->Close();
+    delete reopenedFile;
+    reopenedFile = 0;
+  }
+
+  return kTRUE;
+}
+
+Bool_t GridStorage::putInCvmfs(TString& filename, TFile* cdbFile) const
+{
+  // Add the CDB object to cvmfs OCDB
+
+  TString cvmfsFilename(filename);
+  // cvmfsFilename.Remove(TString::kTrailing, '/');
+  TString basename = (cvmfsFilename(cvmfsFilename.Last('/') + 1, cvmfsFilename.Length()));
+  TString cvmfsDirname = cvmfsFilename.Remove(cvmfsFilename.Last('/'), cvmfsFilename.Length());
+  TRegexp threeLevelsRE("[^/]+/[^/]+/[^/]+$");
+  TString threeLevels = cvmfsDirname(threeLevelsRE);
+
+  TRegexp re_RawFolder("^/alice/data/20[0-9]+/OCDB");
+  TRegexp re_MCFolder("^/alice/simulation/2008/v4-15-Release");
+  TString rawFolder = cvmfsDirname(re_RawFolder);
+  TString mcFolder = cvmfsDirname(re_MCFolder);
+  if (!rawFolder.IsNull()) {
+    cvmfsDirname.Replace(0, 6, "/cvmfs/alice-ocdb.cern.ch/calibration");
+  } else if (!mcFolder.IsNull()) {
+    cvmfsDirname.Replace(0, 36, "/cvmfs/alice-ocdb.cern.ch/calibration/MC");
+  } else {
+    LOG(ERROR) << "OCDB folder set for an invalid OCDB storage:\n   " << cvmfsDirname.Data() << FairLogger::endl;
+    return kFALSE;
+  }
+  // now cvmfsDirname is the full dirname in cvmfs
+  LOG(DEBUG) << "Publishing \"" << basename.Data() << "\" in \"" << cvmfsDirname.Data() << "\"" << FairLogger::endl;
+
+  // Tar the file with the right prefix path. Include the directory structure in the tarball
+  // to cover the case of a containing directory being new in cvmfs, plus a container directory
+  // to avoid clashing with stuff present in the local directory
+  TString firstLevel(threeLevels(0, threeLevels.First('/')));
+  TString tempDir("tmpToCvmfsOcdbs");
+  gSystem->Exec(Form("rm -r %s > /dev/null 2>&1", tempDir.Data())); // to be sure not to publish other stuff in cvmfs
+  Int_t result = gSystem->Exec(Form("mkdir -p %s/%s", tempDir.Data(), threeLevels.Data()));
+  if (result != 0) {
+    LOG(ERROR) << "Could not create the directory \"" << tempDir.Data() << "/" << threeLevels.Data() << "\""
+               << FairLogger::endl;
+    return kFALSE;
+  }
+  cdbFile->Cp(Form("%s/%s/%s", tempDir.Data(), threeLevels.Data(), basename.Data()));
+  TString tarFileName("cdbObjectToAdd.tar.gz");
+  TString cvmfsBaseFolder(cvmfsDirname(0, cvmfsDirname.Last('/')));
+  cvmfsBaseFolder = cvmfsBaseFolder(0, cvmfsBaseFolder.Last('/'));
+  cvmfsBaseFolder = cvmfsBaseFolder(0, cvmfsBaseFolder.Last('/'));
+  // tarCommand should be e.g.: tar --transform
+  // 's,^,/cvmfs/alice-ocdb.cern.ch/calibration/data/2010/OCDB/,S' -cvzf objecttoadd.tar.gz basename
+  result = gSystem->Exec(Form("tar --transform 's,^%s,%s,S' -cvzf %s %s", tempDir.Data(), cvmfsBaseFolder.Data(),
+                              tarFileName.Data(), tempDir.Data()));
+  if (result != 0) {
+    LOG(ERROR) << "Could not create the tarball for the object \"" << filename.Data() << "\"" << FairLogger::endl;
+    return kFALSE;
+  }
+
+  // Copy the file to cvmfs (requires to have the executable in the path and access to the server)
+  result = gSystem->Exec(Form("ocdb-cvmfs %s", tarFileName.Data()));
+  if (result != 0) {
+    LOG(ERROR) << "Could not execute \"ocdb-cvmfs " << filename.Data() << "\"" << FairLogger::endl;
+    return kFALSE;
+  }
+
+  // Remove the local file and the tar-file
+  gSystem->Exec(Form("rm -r %s", tempDir.Data()));
+  gSystem->Exec(Form("rm %s", tarFileName.Data()));
+
+  return kTRUE;
+}
+
+Bool_t GridStorage::addTag(TString& folderToTag, const char* tagname)
+{
+  // add "tagname" tag (CDB or CDB_MD) to folder where object will be stored
+
+  Bool_t result = kTRUE;
+  LOG(DEBUG) << "adding " << tagname << " tag to folder \"" << folderToTag.Data() << "\"" << FairLogger::endl;
+  TString addTagCommand = Form("addTag %s %s", folderToTag.Data(), tagname);
+  TGridResult* gridres = gGrid->Command(addTagCommand.Data());
+  const char* resCode = gridres->GetKey(0, "__result__"); // '1' if success
+  if (resCode[0] != '1') {
+    LOG(ERROR) << "Couldn't add \"" << tagname << "\" tags to folder " << folderToTag.Data() << "!" << FairLogger::endl;
+    result = kFALSE;
+  }
+  delete gridres;
+  return result;
+}
+
+Bool_t GridStorage::tagFileId(TString& filename, const ConditionId* id)
+{
+  // tag stored object in CDB table using object ConditionId's parameters
+
+  TString dirname(filename);
+  Int_t dirNumber = gGrid->Mkdir(dirname.Remove(dirname.Last('/')), "-d");
+
+  TString addTagValue1 = Form("addTagValue %s CDB ", filename.Data());
+  TString addTagValue2 =
+    Form("first_run=%d last_run=%d version=%d ", id->getFirstRun(), id->getLastRun(), id->getVersion());
+  TString addTagValue3 = Form("path_level_0=\"%s\" path_level_1=\"%s\" path_level_2=\"%s\" ",
+                              id->getPathLevel(0).Data(), id->getPathLevel(1).Data(), id->getPathLevel(2).Data());
+  // TString addTagValue4 = Form("version_path=\"%s\"
+  // dir_number=%d",Form("%d_%s",id->getVersion(),filename.Data()),dirNumber);
+  TString addTagValue4 = Form("version_path=\"%09d%s\" dir_number=%d", id->getVersion(), filename.Data(), dirNumber);
+  TString addTagValue =
+    Form("%s%s%s%s", addTagValue1.Data(), addTagValue2.Data(), addTagValue3.Data(), addTagValue4.Data());
+
+  Bool_t result = kFALSE;
+  LOG(DEBUG) << "Tagging file. Tag command: " << addTagValue.Data() << FairLogger::endl;
+  TGridResult* res = gGrid->Command(addTagValue.Data());
+  const char* resCode = res->GetKey(0, "__result__"); // '1' if success
+  if (resCode[0] != '1') {
+    LOG(ERROR) << "Couldn't add CDB tag value to file " << filename.Data() << " !" << FairLogger::endl;
+    result = kFALSE;
+  } else {
+    LOG(DEBUG) << "Object successfully tagged." << FairLogger::endl;
+    result = kTRUE;
+  }
+  delete res;
+  return result;
+}
+
+Bool_t GridStorage::tagFileConditionMetaData(TString& filename, const ConditionMetaData* md)
+{
+  // tag stored object in CDB table using object ConditionId's parameters
+
+  TString addTagValue1 = Form("addTagValue %s CDB_MD ", filename.Data());
+  TString addTagValue2 = Form("object_classname=\"%s\" responsible=\"%s\" beam_period=%d ", md->getObjectClassName(),
+                              md->getResponsible(), md->getBeamPeriod());
+  TString addTagValue3 = Form("aliroot_version=\"%s\" comment=\"%s\"", md->getAliRootVersion(), md->getComment());
+  TString addTagValue = Form("%s%s%s", addTagValue1.Data(), addTagValue2.Data(), addTagValue3.Data());
+
+  Bool_t result = kFALSE;
+  LOG(DEBUG) << "Tagging file. Tag command: " << addTagValue.Data() << FairLogger::endl;
+  TGridResult* res = gGrid->Command(addTagValue.Data());
+  const char* resCode = res->GetKey(0, "__result__"); // '1' if success
+  if (resCode[0] != '1') {
+    LOG(WARNING) << "Couldn't add CDB_MD tag value to file " << filename.Data() << " !" << FairLogger::endl;
+    result = kFALSE;
+  } else {
+    LOG(DEBUG) << "Object successfully tagged." << FairLogger::endl;
+    result = kTRUE;
+  }
+  return result;
+}
+
+TList* GridStorage::getIdListFromFile(const char* fileName)
+{
+
+  TString turl(fileName);
+  turl.Prepend("/alien" + mDBFolder);
+  turl += "?se=";
+  turl += mSE.Data();
+  TFile* file = TFile::Open(turl);
+  if (!file) {
+    LOG(ERROR) << "Can't open selection file <" << turl.Data() << ">!" << FairLogger::endl;
+    return NULL;
+  }
+
+  TList* list = new TList();
+  list->SetOwner();
+  int i = 0;
+  TString keycycle;
+
+  ConditionId* id;
+  while (1) {
+    i++;
+    keycycle = " ConditionId;";
+    keycycle += i;
+
+    id = (ConditionId*)file->Get(keycycle);
+    if (!id)
+      break;
+    list->AddFirst(id);
+  }
+  file->Close();
+  delete file;
+  file = 0;
+
+  return list;
+}
+
+Bool_t GridStorage::hasConditionType(const char* path) const
+{
+  // check for path in storage's DBFolder
+
+  TString initDir(gGrid->Pwd(0));
+  TString dirName(mDBFolder);
+  dirName += path; // dirName = mDBFolder/path
+  Bool_t result = kFALSE;
+  if (gGrid->Cd(dirName, 0))
+    result = kTRUE;
+  gGrid->Cd(initDir.Data(), 0);
+  return result;
+}
+
+void GridStorage::queryValidFiles()
+{
+  // Query the CDB for files valid for  Storage::mRun
+  // Fills list mValidFileIds with  ConditionId objects extracted from CDB files
+  // selected from AliEn metadata.
+  // If mVersion was not set, mValidFileIds is filled with highest versions.
+
+  TString filter;
+  makeQueryFilter(mRun, mRun, mConditionMetaDataFilter, filter);
+
+  TString path = mPathFilter.getPathString();
+
+  TString pattern = "Run*";
+  TString optionQuery = "-y";
+  if (mVersion >= 0) {
+    pattern += Form("_v%d_s0", mVersion);
+    optionQuery = "";
+  }
+  pattern += ".root";
+  LOG(DEBUG) << "pattern: " << pattern.Data() << FairLogger::endl;
+
+  TString addFolder = "";
+  if (!path.Contains("*")) {
+    if (!path.BeginsWith("/"))
+      addFolder += "/";
+    addFolder += path;
+  } else {
+    if (path.BeginsWith("/"))
+      path.Remove(0, 1);
+    if (path.EndsWith("/"))
+      path.Remove(path.Length() - 1, 1);
+    TObjArray* tokenArr = path.Tokenize("/");
+    if (tokenArr->GetEntries() != 3) {
+      LOG(ERROR) << "Not a 3 level path! Keeping old query..." << FairLogger::endl;
+      pattern.Prepend(path + "/");
+    } else {
+      TString str0 = ((TObjString*)tokenArr->At(0))->String();
+      TString str1 = ((TObjString*)tokenArr->At(1))->String();
+      TString str2 = ((TObjString*)tokenArr->At(2))->String();
+      if (str0 != "*" && str1 != "*" && str2 == "*") {
+        // e.g. "ITS/Calib/*"
+        addFolder = "/" + str0 + "/" + str1;
+      } else if (str0 != "*" && str1 == "*" && str2 == "*") {
+        // e.g. "ITS/*/*"
+        addFolder = "/" + str0;
+      } else if (str0 == "*" && str1 == "*" && str2 == "*") {
+        // e.g. "*/*/*"
+        // do nothing: addFolder is already an empty string;
+      } else {
+        // e.g. "ITS/*/RecoParam"
+        pattern.Prepend(path + "/");
+      }
+    }
+    delete tokenArr;
+    tokenArr = 0;
+  }
+
+  TString folderCopy(Form("%s%s", mDBFolder.Data(), addFolder.Data()));
+
+  LOG(DEBUG) << "mDBFolder = " << folderCopy.Data() << ", pattern = " << pattern.Data()
+             << ", filter = " << filter.Data() << FairLogger::endl;
+
+  if (optionQuery == "-y") {
+    LOG(INFO) << "Only latest version will be returned" << FairLogger::endl;
+  }
+
+  TGridResult* res = gGrid->Query(folderCopy, pattern, filter, optionQuery.Data());
+
+  if (!res) {
+    LOG(ERROR) << "GridStorage query failed" << FairLogger::endl;
+    return;
+  }
+
+  TIter next(res);
+  TMap* map;
+  while ((map = (TMap*)next())) {
+    TObjString* entry;
+    if ((entry = (TObjString*)((TMap*)map)->GetValue("lfn"))) {
+      TString& filename = entry->String();
+      if (filename.IsNull())
+        continue;
+      LOG(DEBUG) << "Found valid file: " << filename.Data() << FairLogger::endl;
+      ConditionId* validFileId = new ConditionId();
+      Bool_t result = filenameToId(filename, *validFileId);
+      if (result) {
+        mValidFileIds.AddLast(validFileId);
+      } else {
+        delete validFileId;
+      }
+    }
+  }
+  delete res;
+}
+
+void GridStorage::makeQueryFilter(Int_t firstRun, Int_t lastRun, const ConditionMetaData* md, TString& result) const
+{
+  // create filter for file query
+
+  result = Form("CDB:first_run<=%d and CDB:last_run>=%d", firstRun, lastRun);
+
+  //	if(version >= 0) {
+  //		result += Form(" and CDB:version=%d", version);
+  //	}
+  //	if(pathFilter.getLevel0() != "*") {
+  //		result += Form(" and CDB:path_level_0=\"%s\"", pathFilter.getLevel0().Data());
+  //	}
+  //	if(pathFilter.getLevel1() != "*") {
+  //		result += Form(" and CDB:path_level_1=\"%s\"", pathFilter.getLevel1().Data());
+  //	}
+  //	if(pathFilter.getLevel2() != "*") {
+  //		result += Form(" and CDB:path_level_2=\"%s\"", pathFilter.getLevel2().Data());
+  //	}
+
+  if (md) {
+    if (md->getObjectClassName()[0] != '\0') {
+      result += Form(" and CDB_MD:object_classname=\"%s\"", md->getObjectClassName());
+    }
+    if (md->getResponsible()[0] != '\0') {
+      result += Form(" and CDB_MD:responsible=\"%s\"", md->getResponsible());
+    }
+    if (md->getBeamPeriod() != 0) {
+      result += Form(" and CDB_MD:beam_period=%d", md->getBeamPeriod());
+    }
+    if (md->getAliRootVersion()[0] != '\0') {
+      result += Form(" and CDB_MD:aliroot_version=\"%s\"", md->getAliRootVersion());
+    }
+    if (md->getComment()[0] != '\0') {
+      result += Form(" and CDB_MD:comment=\"%s\"", md->getComment());
+    }
+  }
+  LOG(DEBUG) << "filter: " << result.Data() << FairLogger::endl;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//                                                                                             //
+//  GridStorage factory  			                                                       //
+//                                                                                             //
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+ClassImp(GridStorageFactory)
+
+Bool_t GridStorageFactory::validateStorageUri(const char* gridString)
+{
+  // check if the string is valid GridStorage URI
+
+  TRegexp gridPattern("^alien://.+$");
+
+  return TString(gridString).Contains(gridPattern);
+}
+
+StorageParameters* GridStorageFactory::createStorageParameter(const char* gridString)
+{
+  // create  GridStorageParameters class from the URI string
+
+  if (!validateStorageUri(gridString)) {
+    return NULL;
+  }
+
+  TString buffer(gridString);
+
+  TString gridUrl = "alien://";
+  TString user = "";
+  TString dbFolder = "";
+  TString se = "default";
+  TString cacheFolder = "";
+  Bool_t operateDisconnected = kTRUE;
+  Long64_t cacheSize = (UInt_t)1024 * 1024 * 1024; // 1GB
+  Long_t cleanupInterval = 0;
+
+  TObjArray* arr = buffer.Tokenize('?');
+  TIter iter(arr);
+  TObjString* str = 0;
+
+  while ((str = (TObjString*)iter.Next())) {
+    TString entry(str->String());
+    Int_t indeq = entry.Index('=');
+    if (indeq == -1) {
+      if (entry.BeginsWith("alien://")) { // maybe it's a gridUrl!
+        gridUrl = entry;
+        continue;
+      } else {
+        LOG(ERROR) << "Invalid entry! " << entry.Data() << FairLogger::endl;
+        continue;
+      }
+    }
+
+    TString key = entry(0, indeq);
+    TString value = entry(indeq + 1, entry.Length() - indeq);
+
+    if (key.Contains("grid", TString::kIgnoreCase)) {
+      gridUrl += value;
+    } else if (key.Contains("user", TString::kIgnoreCase)) {
+      user = value;
+    } else if (key.Contains("se", TString::kIgnoreCase)) {
+      se = value;
+    } else if (key.Contains("cacheF", TString::kIgnoreCase)) {
+      cacheFolder = value;
+      if (!cacheFolder.IsNull() && !cacheFolder.EndsWith("/"))
+        cacheFolder += "/";
+    } else if (key.Contains("folder", TString::kIgnoreCase)) {
+      dbFolder = value;
+    } else if (key.Contains("operateDisc", TString::kIgnoreCase)) {
+      if (value == "kTRUE") {
+        operateDisconnected = kTRUE;
+      } else if (value == "kFALSE") {
+        operateDisconnected = kFALSE;
+      } else if (value == "0" || value == "1") {
+        operateDisconnected = (Bool_t)value.Atoi();
+      } else {
+        LOG(ERROR) << "Invalid entry! " << entry.Data() << FairLogger::endl;
+        return NULL;
+      }
+    } else if (key.Contains("cacheS", TString::kIgnoreCase)) {
+      if (value.IsDigit()) {
+        cacheSize = value.Atoi();
+      } else {
+        LOG(ERROR) << "Invalid entry! " << entry.Data() << FairLogger::endl;
+        return NULL;
+      }
+    } else if (key.Contains("cleanupInt", TString::kIgnoreCase)) {
+      if (value.IsDigit()) {
+        cleanupInterval = value.Atoi();
+      } else {
+        LOG(ERROR) << "Invalid entry! " << entry.Data() << FairLogger::endl;
+        return NULL;
+      }
+    } else {
+      LOG(ERROR) << "Invalid entry! " << entry.Data() << FairLogger::endl;
+      return NULL;
+    }
+  }
+  delete arr;
+  arr = 0;
+
+  LOG(DEBUG) << "gridUrl:	" << gridUrl.Data() << FairLogger::endl;
+  LOG(DEBUG) << "user:	" << user.Data() << FairLogger::endl;
+  LOG(DEBUG) << "dbFolder:	" << dbFolder.Data() << FairLogger::endl;
+  LOG(DEBUG) << "s.e.:	" << se.Data() << FairLogger::endl;
+  LOG(DEBUG) << "local cache folder: " << cacheFolder.Data() << FairLogger::endl;
+  LOG(DEBUG) << "local cache operate disconnected: " << operateDisconnected << FairLogger::endl;
+  LOG(DEBUG) << "local cache size: " << cacheSize << "" << FairLogger::endl;
+  LOG(DEBUG) << "local cache cleanup interval: " << cleanupInterval << "" << FairLogger::endl;
+
+  if (dbFolder == "") {
+    LOG(ERROR) << "Base folder must be specified!" << FairLogger::endl;
+    return NULL;
+  }
+
+  return new GridStorageParameters(gridUrl.Data(), user.Data(), dbFolder.Data(), se.Data(), cacheFolder.Data(), operateDisconnected,
+                       cacheSize, cleanupInterval);
+}
+
+Storage* GridStorageFactory::createStorage(const StorageParameters* param)
+{
+  // create  GridStorage storage instance from parameters
+  GridStorage* grid = 0;
+  if (GridStorageParameters::Class() == param->IsA()) {
+    const GridStorageParameters* gridParam = (const GridStorageParameters*)param;
+    grid = new GridStorage(gridParam->GridUrl().Data(), gridParam->getUser().Data(), gridParam->getDBFolder().Data(),
+                    gridParam->getSE().Data(), gridParam->getCacheFolder().Data(), gridParam->getOperateDisconnected(),
+                    gridParam->getCacheSize(), gridParam->getCleanupInterval());
+  }
+  if (!gGrid && grid) {
+    delete grid;
+    grid = 0;
+  }
+  return grid;
+}
+
+//  GridStorage Parameter class
+ClassImp(GridStorageParameters)
+GridStorageParameters::GridStorageParameters()
+  : StorageParameters(),
+    mGridUrl(),
+    mUser(),
+    mDBFolder(),
+    mSE(),
+    mCacheFolder(),
+    mOperateDisconnected(),
+    mCacheSize(),
+    mCleanupInterval()
+
+{
+  // default constructor
+}
+
+GridStorageParameters::GridStorageParameters(const char* gridUrl, const char* user, const char* dbFolder, const char* se,
+                     const char* cacheFolder, Bool_t operateDisconnected, Long64_t cacheSize, Long_t cleanupInterval)
+  : StorageParameters(),
+    mGridUrl(gridUrl),
+    mUser(user),
+    mDBFolder(dbFolder),
+    mSE(se),
+    mCacheFolder(cacheFolder),
+    mOperateDisconnected(operateDisconnected),
+    mCacheSize(cacheSize),
+    mCleanupInterval(cleanupInterval)
+{
+  // constructor
+  setType("alien");
+  TString uri = Form("%s?User=%s?DBFolder=%s?SE=%s?CacheFolder=%s"
+                     "?OperateDisconnected=%d?CacheSize=%lld?CleanupInterval=%ld",
+                     mGridUrl.Data(), mUser.Data(), mDBFolder.Data(), mSE.Data(), mCacheFolder.Data(),
+                     mOperateDisconnected, mCacheSize, mCleanupInterval);
+  setUri(uri.Data());
+}
+
+GridStorageParameters::~GridStorageParameters()
+{
+  // destructor
+}
+
+StorageParameters* GridStorageParameters::cloneParam() const
+{
+  // clone parameter
+  return new GridStorageParameters(mGridUrl.Data(), mUser.Data(), mDBFolder.Data(), mSE.Data(), mCacheFolder.Data(),
+                       mOperateDisconnected, mCacheSize, mCleanupInterval);
+}
+
+ULong_t GridStorageParameters::getHash() const
+{
+  // return getHash function
+  return mGridUrl.Hash() + mUser.Hash() + mDBFolder.Hash() + mSE.Hash() + mCacheFolder.Hash();
+}
+
+Bool_t GridStorageParameters::isEqual(const TObject* obj) const
+{
+  // check if this object is equal to  StorageParameters obj
+  if (this == obj) {
+    return kTRUE;
+  }
+  if (GridStorageParameters::Class() != obj->IsA()) {
+    return kFALSE;
+  }
+  GridStorageParameters* other = (GridStorageParameters*)obj;
+  if (mGridUrl != other->mGridUrl)
+    return kFALSE;
+  if (mUser != other->mUser)
+    return kFALSE;
+  if (mDBFolder != other->mDBFolder)
+    return kFALSE;
+  if (mSE != other->mSE)
+    return kFALSE;
+  if (mCacheFolder != other->mCacheFolder)
+    return kFALSE;
+  if (mOperateDisconnected != other->mOperateDisconnected)
+    return kFALSE;
+  if (mCacheSize != other->mCacheSize)
+    return kFALSE;
+  if (mCleanupInterval != other->mCleanupInterval)
+    return kFALSE;
+  return kTRUE;
+}

--- a/o2cdb/GridStorage.h
+++ b/o2cdb/GridStorage.h
@@ -1,0 +1,168 @@
+#ifndef ALICEO2_CDB_GRID_H_
+#define ALICEO2_CDB_GRID_H_
+
+#include "Storage.h"
+#include "Manager.h"
+#include "ConditionMetaData.h"
+
+namespace AliceO2 {
+namespace CDB {
+
+class GridStorage : public Storage {
+  friend class GridStorageFactory;
+
+public:
+  virtual Bool_t isReadOnly() const
+  {
+    return kFALSE;
+  }
+  virtual Bool_t hasSubVersion() const
+  {
+    return kFALSE;
+  }
+  virtual Bool_t hasConditionType(const char* path) const;
+  virtual Bool_t idToFilename(const ConditionId& id, TString& filename) const;
+  virtual void setRetry(Int_t nretry, Int_t initsec);
+  virtual void setMirrorSEs(const char* mirrors)
+  {
+    mMirrorSEs = mirrors;
+  }
+  virtual const char* getMirrorSEs() const
+  {
+    return mMirrorSEs;
+  }
+
+protected:
+  virtual Condition* getCondition(const ConditionId& queryId);
+  virtual ConditionId* getConditionId(const ConditionId& queryId);
+  virtual TList* getAllEntries(const ConditionId& queryId);
+  virtual Bool_t putCondition(Condition* entry, const char* mirrors = "");
+  virtual TList* getIdListFromFile(const char* fileName);
+
+private:
+  GridStorage(const char* gridUrl, const char* user, const char* dbFolder, const char* se, const char* cacheFolder,
+       Bool_t operateDisconnected, Long64_t cacheSize, Long_t cleanupInterval);
+
+  virtual ~GridStorage();
+
+  GridStorage(const GridStorage& db);
+  GridStorage& operator=(const GridStorage& db);
+
+  Bool_t filenameToId(TString& filename, ConditionId& id);
+
+  Bool_t prepareId(ConditionId& id);
+  ConditionId* getId(const TObjArray& validFileIds, const ConditionId& query);
+  Condition* getConditionFromFile(TString& filename, ConditionId* dataId);
+  Bool_t putInCvmfs(TString& fullFilename, TFile* cdbFile) const;
+
+  // TODO  use AliEnTag classes!
+  Bool_t addTag(TString& foldername, const char* tagname);
+  Bool_t tagFileId(TString& filename, const ConditionId* id);
+  Bool_t tagFileConditionMetaData(TString& filename, const ConditionMetaData* md);
+
+  void makeQueryFilter(Int_t firstRun, Int_t lastRun, const ConditionMetaData* md, TString& result) const;
+
+  virtual void queryValidFiles();
+
+  TString mGridUrl;            // GridStorage Url ("alien://aliendb4.cern.ch:9000")
+  TString mUser;               // User
+  TString mDBFolder;           // path of the DB folder
+  TString mSE;                 // Storage Element
+  TString mMirrorSEs;          // Mirror Storage Elements
+  TString mCacheFolder;        // local cache folder
+  Bool_t mOperateDisconnected; // Operate disconnected flag
+  Long64_t mCacheSize;         // local cache size (in bytes)
+  Long_t mCleanupInterval;     // local cache cleanup interval
+
+  ClassDef(GridStorage, 0) // access class to a DataBase in an AliEn storage
+};
+
+/////////////////////////////////////////////////////////////////////
+//                                                                 //
+//  class  GridStorageFactory					   //
+//                                                                 //
+/////////////////////////////////////////////////////////////////////
+
+class GridStorageFactory : public StorageFactory {
+
+public:
+  virtual Bool_t validateStorageUri(const char* gridString);
+  virtual StorageParameters* createStorageParameter(const char* gridString);
+  virtual ~GridStorageFactory()
+  {
+  }
+
+protected:
+  virtual Storage* createStorage(const StorageParameters* param);
+
+  ClassDef(GridStorageFactory, 0)
+};
+
+/////////////////////////////////////////////////////////////////////
+//                                                                 //
+//  class  GridStorageParameters					   //
+//                                                                 //
+/////////////////////////////////////////////////////////////////////
+
+class GridStorageParameters : public StorageParameters {
+
+public:
+  GridStorageParameters();
+  GridStorageParameters(const char* gridUrl, const char* user, const char* dbFolder, const char* se, const char* cacheFolder,
+            Bool_t operateDisconnected, Long64_t cacheSize, Long_t cleanupInterval);
+
+  virtual ~GridStorageParameters();
+
+  const TString& GridUrl() const
+  {
+    return mGridUrl;
+  }
+  const TString& getUser() const
+  {
+    return mUser;
+  }
+  const TString& getDBFolder() const
+  {
+    return mDBFolder;
+  }
+  const TString& getSE() const
+  {
+    return mSE;
+  }
+  const TString& getCacheFolder() const
+  {
+    return mCacheFolder;
+  }
+  Bool_t getOperateDisconnected() const
+  {
+    return mOperateDisconnected;
+  }
+  Long64_t getCacheSize() const
+  {
+    return mCacheSize;
+  }
+  Long_t getCleanupInterval() const
+  {
+    return mCleanupInterval;
+  }
+
+  virtual StorageParameters* cloneParam() const;
+
+  virtual ULong_t getHash() const;
+  virtual Bool_t isEqual(const TObject* obj) const;
+
+private:
+  TString mGridUrl;            // GridStorage url "Host:port"
+  TString mUser;               // User
+  TString mDBFolder;           // path of the DB folder
+  TString mSE;                 // Storage Element
+  TString mCacheFolder;        // Cache folder
+  Bool_t mOperateDisconnected; // Operate disconnected flag
+  Long64_t mCacheSize;         // local cache size (in bytes)
+  Long_t mCleanupInterval;     // local cache cleanup interval
+
+  ClassDef(GridStorageParameters, 0)
+};
+}
+}
+#endif

--- a/o2cdb/IdPath.cxx
+++ b/o2cdb/IdPath.cxx
@@ -1,0 +1,215 @@
+//  Path string identifying the object:  			   //
+//  (example: "ZDC/Calib/Pedestals") 		         	   //
+#include <TObjArray.h>
+#include <TObjString.h>
+#include <TRegexp.h>
+
+#include <FairLogger.h>
+
+#include "IdPath.h"
+
+using namespace AliceO2::CDB;
+
+ClassImp(IdPath)
+
+IdPath::IdPath() : TObject(), mPath(""), mLevel0(""), mLevel1(""), mLevel2(""), mValid(kTRUE), mWildcard(kFALSE)
+{
+  // default constructor
+}
+
+IdPath::IdPath(const IdPath& other)
+  : TObject(other),
+    mPath(other.mPath),
+    mLevel0(""),
+    mLevel1(""),
+    mLevel2(""),
+    mValid(other.mValid),
+    mWildcard(other.mWildcard)
+{
+  // constructor
+  init();
+  InitPath();
+}
+
+IdPath::IdPath(const char* level0, const char* level1, const char* level2)
+  : TObject(), mPath(""), mLevel0(level0), mLevel1(level1), mLevel2(level2), mValid(kTRUE), mWildcard(kFALSE)
+{
+  // constructor
+
+  mPath += level0;
+  mPath += '/';
+  mPath += level1;
+  mPath += '/';
+  mPath += level2;
+
+  if ((isWord(mLevel0) || mLevel0 == "*") && (isWord(mLevel1) || mLevel1 == "*") &&
+      (isWord(mLevel2) || mLevel2 == "*")) {
+
+    mValid = kTRUE;
+  } else {
+    mValid = kFALSE;
+    LOG(ERROR) << "Invalid  Path \"" << level0 << "/" << level1 << "/" << level2 << "\"!" << FairLogger::endl;
+  }
+
+  init();
+}
+
+IdPath::IdPath(const char* path)
+  : TObject(), mPath(path), mLevel0(""), mLevel1(""), mLevel2(""), mValid(kTRUE), mWildcard(kFALSE)
+{
+  // constructor
+
+  init();
+  InitPath();
+}
+
+IdPath::IdPath(const TString& path)
+  : TObject(), mPath(path), mLevel0(""), mLevel1(""), mLevel2(""), mValid(kTRUE), mWildcard(kFALSE)
+{
+  init();
+  InitPath();
+}
+
+void IdPath::InitPath()
+{
+  // sets mLevel0, mLevel1, mLevel2, validity flagss from mPath
+
+  TSubString strippedString = mPath.Strip(TString::kBoth);
+  TString aString(strippedString);
+  strippedString = aString.Strip(TString::kBoth, '/');
+
+  TObjArray* anArray = TString(strippedString).Tokenize("/");
+  Int_t paramCount = anArray->GetEntriesFast();
+
+  if (paramCount == 1) {
+    if (mPath == "*") {
+      mLevel0 = "*";
+      mLevel1 = "*";
+      mLevel2 = "*";
+
+      mValid = kTRUE;
+    } else {
+      mValid = kFALSE;
+    }
+
+  } else if (paramCount == 2) {
+    mLevel0 = ((TObjString*)anArray->At(0))->GetString();
+    TString bString = ((TObjString*)anArray->At(1))->GetString();
+
+    if (isWord(mLevel0) && bString == "*") {
+      mLevel1 = "*";
+      mLevel2 = "*";
+
+      mValid = kTRUE;
+
+    } else {
+      mValid = kFALSE;
+    }
+
+  } else if (paramCount == 3) {
+    mLevel0 = ((TObjString*)anArray->At(0))->GetString();
+    mLevel1 = ((TObjString*)anArray->At(1))->GetString();
+    mLevel2 = ((TObjString*)anArray->At(2))->GetString();
+
+    if ((isWord(mLevel0) || mLevel0 == "*") && (isWord(mLevel1) || mLevel1 == "*") &&
+        (isWord(mLevel2) || mLevel2 == "*")) {
+
+      mValid = kTRUE;
+    } else {
+      mValid = kFALSE;
+    }
+
+  } else {
+    mValid = kFALSE;
+  }
+
+  if (!mValid) {
+    LOG(INFO) << "Invalid  Path \"" << mPath.Data() << "\"!" << FairLogger::endl;
+  } else {
+    mPath = Form("%s/%s/%s", mLevel0.Data(), mLevel1.Data(), mLevel2.Data());
+  }
+
+  delete anArray;
+
+  init();
+}
+
+IdPath::~IdPath()
+{
+  // destructor
+}
+
+Bool_t IdPath::isWord(const TString& str)
+{
+  // check if string is a word
+
+  TRegexp pattern("^[a-zA-Z0-9_.-]+$");
+
+  return str.Contains(pattern);
+}
+
+void IdPath::init()
+{
+  // set mWildcard flag
+
+  mWildcard = mPath.MaybeWildcard();
+}
+
+Bool_t IdPath::doesLevel0Contain(const TString& str) const
+{
+  // check if Level0 is wildcard or is equal to str
+
+  if (mLevel0 == "*") {
+    return kTRUE;
+  }
+
+  return mLevel0 == str;
+}
+
+Bool_t IdPath::doesLevel1Contain(const TString& str) const
+{
+  // check if Level1 is wildcard or is equal to str
+
+  if (mLevel1 == "*") {
+    return kTRUE;
+  }
+
+  return mLevel1 == str;
+}
+
+Bool_t IdPath::doesLevel2Contain(const TString& str) const
+{
+  // check if Level2 is wildcard or is equal to str
+
+  if (mLevel2 == "*") {
+    return kTRUE;
+  }
+
+  return mLevel2 == str;
+}
+
+Bool_t IdPath::isSupersetOf(const IdPath& other) const
+{
+  // check if path is wildcard and comprises other
+
+  return doesLevel0Contain(other.mLevel0) && doesLevel1Contain(other.mLevel1) && doesLevel2Contain(other.mLevel2);
+}
+
+const char* IdPath::getLevel(Int_t i) const
+{
+  // return level i of the path
+
+  switch (i) {
+    case 0:
+      return mLevel0.Data();
+      break;
+    case 1:
+      return mLevel1.Data();
+      break;
+    case 2:
+      return mLevel2.Data();
+      break;
+    default:
+      return 0;
+  }
+}

--- a/o2cdb/IdPath.h
+++ b/o2cdb/IdPath.h
@@ -1,0 +1,75 @@
+#ifndef ALICEO2_CDB_PATH_H_
+#define ALICEO2_CDB_PATH_H_
+
+//  Path string identifying the object:  			   //
+//  "level0/level1/level2" 					   //
+//  (example: "ZDC/Calib/Pedestals") 		         	   //
+#include <TObject.h>
+#include <TString.h>
+
+namespace AliceO2 {
+namespace CDB {
+
+class IdPath : public TObject {
+
+public:
+  IdPath();
+
+  IdPath(const IdPath& other);
+
+  IdPath(const char* level0, const char* level1, const char* level2);
+
+  IdPath(const char* path);
+
+  IdPath(const TString& path);
+
+  virtual ~IdPath();
+
+  const TString& getPathString() const
+  {
+    return mPath;
+  }
+  void setPath(const char* path)
+  {
+    mPath = path;
+    InitPath();
+  }
+
+  const char* getLevel(Int_t i) const;
+
+  Bool_t isValid() const
+  {
+    return mValid;
+  }
+
+  Bool_t isWildcard() const
+  {
+    return mWildcard;
+  }
+
+  Bool_t doesLevel0Contain(const TString& str) const;
+  Bool_t doesLevel1Contain(const TString& str) const;
+  Bool_t doesLevel2Contain(const TString& str) const;
+
+  Bool_t isSupersetOf(const IdPath& other) const;
+
+private:
+  Bool_t isWord(const TString& str);
+
+  void InitPath();
+
+  void init();
+
+  TString mPath;   // detector pathname (Detector/DBType/SpecType)
+  TString mLevel0; // level0 name (ex. detector: ZDC, TPC...)
+  TString mLevel1; // level1 name (ex. DB type, Calib, Align)
+  TString mLevel2; // level2 name (ex. DetSpecType, pedestals, gain...)
+
+  Bool_t mValid;    // validity flag
+  Bool_t mWildcard; // wildcard flag
+
+  ClassDef(IdPath, 1)
+};
+}
+}
+#endif

--- a/o2cdb/IdRunRange.cxx
+++ b/o2cdb/IdRunRange.cxx
@@ -1,0 +1,89 @@
+//  defines the run validity range of the object:		   //
+//  [mFirstRun, mLastRun] 					   //
+
+#include <FairLogger.h>
+#include "IdRunRange.h"
+
+using namespace AliceO2::CDB;
+
+ClassImp(IdRunRange)
+
+IdRunRange::IdRunRange() : mFirstRun(-1), mLastRun(-1)
+{
+  // constructor
+}
+
+IdRunRange::IdRunRange(Int_t firstRun, Int_t lastRun) : mFirstRun(firstRun), mLastRun(lastRun)
+{
+  // constructor
+}
+
+IdRunRange::~IdRunRange()
+{
+  // destructor
+}
+
+Bool_t IdRunRange::isOverlappingWith(const IdRunRange& other) const
+{
+  // check if this runRange overlaps other runRange
+
+  if (!(isValid() && other.isValid())) {
+    LOG(ERROR) << "Comparing invalid run ranges!" << FairLogger::endl;
+    return kFALSE;
+  }
+
+  if (isAnyRange() || other.isAnyRange()) {
+    LOG(ERROR) << "Comparing unspecified ranges!" << FairLogger::endl;
+    return kFALSE;
+  }
+
+  return ((mFirstRun < other.mFirstRun && other.mFirstRun <= mLastRun) ||
+          (other.mFirstRun <= mFirstRun && mFirstRun <= other.mLastRun));
+}
+
+Bool_t IdRunRange::isSupersetOf(const IdRunRange& other) const
+{
+  // check if this runRange contains other runRange
+
+  if (!(isValid() && other.isValid())) {
+    LOG(ERROR) << "Comparing invalid run ranges!" << FairLogger::endl;
+    return kFALSE;
+  }
+
+  if (isAnyRange()) {
+    return kTRUE;
+  }
+
+  return mFirstRun <= other.mFirstRun && other.mFirstRun <= mLastRun && mFirstRun <= other.mLastRun &&
+         other.mLastRun <= mLastRun;
+}
+
+Bool_t IdRunRange::isEqual(const TObject* obj) const
+{
+  // check if this runRange is equal to other runRange
+
+  if (this == obj) {
+    return kTRUE;
+  }
+
+  if (IdRunRange::Class() != obj->IsA()) {
+    return kFALSE;
+  }
+  IdRunRange* other = (IdRunRange*)obj;
+  return mFirstRun == other->mFirstRun && mLastRun == other->mLastRun;
+}
+
+Bool_t IdRunRange::isValid() const
+{
+  // validity check
+
+  if (mFirstRun < 0 && mLastRun < 0) {
+    return kTRUE;
+  }
+
+  if (mFirstRun >= 0 && mLastRun >= mFirstRun) {
+    return kTRUE;
+  }
+
+  return kFALSE;
+}

--- a/o2cdb/IdRunRange.h
+++ b/o2cdb/IdRunRange.h
@@ -1,0 +1,70 @@
+#ifndef ALICEO2_CDB_RUNRANGE_H_
+#define ALICEO2_CDB_RUNRANGE_H_
+
+//  defines the run validity range of the object:		   //
+//  [mFirstRun, mLastRun] 					   //
+#include <TObject.h>
+
+namespace AliceO2 {
+namespace CDB {
+class IdRunRange : public TObject {
+
+public:
+  IdRunRange();
+  IdRunRange(Int_t firstRun, Int_t lastRun);
+
+  virtual ~IdRunRange();
+
+  Int_t getFirstRun() const
+  {
+    return mFirstRun;
+  };
+  Int_t getLastRun() const
+  {
+    return mLastRun;
+  };
+
+  void setFirstRun(Int_t firstRun)
+  {
+    mFirstRun = firstRun;
+  };
+  void setLastRun(Int_t lastRun)
+  {
+    mLastRun = lastRun;
+  };
+
+  void setIdRunRange(Int_t firstRun, Int_t lastRun)
+  {
+    mFirstRun = firstRun;
+    mLastRun = lastRun;
+  };
+
+  Bool_t isValid() const;
+
+  Bool_t isAnyRange() const
+  {
+    return mFirstRun < 0 && mLastRun < 0;
+  };
+
+  Bool_t isOverlappingWith(const IdRunRange& other) const;
+
+  Bool_t isSupersetOf(const IdRunRange& other) const;
+
+  virtual Bool_t isEqual(const TObject* obj) const;
+
+  static Int_t Infinity()
+  {
+    return sInfinity;
+  }
+
+private:
+  Int_t mFirstRun; // first valid run
+  Int_t mLastRun;  // last valid run
+
+  static const Int_t sInfinity = 999999999; //! Flag for "infinity"
+
+  ClassDef(IdRunRange, 1)
+};
+}
+}
+#endif

--- a/o2cdb/LocalStorage.cxx
+++ b/o2cdb/LocalStorage.cxx
@@ -1,0 +1,1159 @@
+// access class to a DataBase in a local storage  			                       //
+#include <cstdlib>
+#include <stdexcept>
+#include <fstream>
+
+#include <TSystem.h>
+#include <TObjString.h>
+#include <TRegexp.h>
+#include <TFile.h>
+#include <TKey.h>
+
+#include <FairLogger.h>
+
+#include "LocalStorage.h"
+#include "Condition.h"
+// using namespace std;
+// using std::endl;
+// using std::cout;
+
+using namespace AliceO2::CDB;
+
+ClassImp(LocalStorage)
+
+LocalStorage::LocalStorage(const char* baseDir) : mBaseDirectory(baseDir)
+{
+  // constructor
+
+  LOG(DEBUG) << "mBaseDirectory = " << mBaseDirectory.Data() << FairLogger::endl;
+
+  // check baseDire: trying to cd to baseDir; if it does not exist, create it
+  void* dir = gSystem->OpenDirectory(baseDir);
+  if (dir == NULL) {
+    if (gSystem->mkdir(baseDir, kTRUE)) {
+      LOG(ERROR) << "Can't open directory \"" << baseDir << "\"!"
+                 << FairLogger::endl; //!!!!!!!! to be commented out for testing
+    }
+
+  } else {
+    LOG(DEBUG) << "Folder \"" << mBaseDirectory.Data() << "\" found" << FairLogger::endl;
+    gSystem->FreeDirectory(dir);
+  }
+  mType = "local";
+  mBaseFolder = mBaseDirectory;
+}
+
+LocalStorage::~LocalStorage()
+{
+  // destructor
+}
+
+Bool_t LocalStorage::filenameToId(const char* filename, IdRunRange& runRange, Int_t& version, Int_t& subVersion)
+{
+  // build  ConditionId from filename numbers
+
+  Ssiz_t mSize;
+
+  // valid filename: Run#firstRun_#lastRun_v#version_s#subVersion.root
+  TRegexp keyPattern("^Run[0-9]+_[0-9]+_v[0-9]+_s[0-9]+.root$");
+  keyPattern.Index(filename, &mSize);
+  if (!mSize) {
+    LOG(DEBUG) << "Bad filename <" << filename << ">." << FairLogger::endl;
+    return kFALSE;
+  }
+
+  TString idString(filename);
+  idString.Resize(idString.Length() - sizeof(".root") + 1);
+
+  TObjArray* strArray = (TObjArray*)idString.Tokenize("_");
+
+  TString firstRunString(((TObjString*)strArray->At(0))->GetString());
+  runRange.setFirstRun(atoi(firstRunString.Data() + 3));
+  runRange.setLastRun(atoi(((TObjString*)strArray->At(1))->GetString()));
+
+  TString verString(((TObjString*)strArray->At(2))->GetString());
+  version = atoi(verString.Data() + 1);
+
+  TString subVerString(((TObjString*)strArray->At(3))->GetString());
+  subVersion = atoi(subVerString.Data() + 1);
+
+  delete strArray;
+
+  return kTRUE;
+}
+
+Bool_t LocalStorage::idToFilename(const ConditionId& id, TString& filename) const
+{
+  // build file name from  ConditionId data (run range, version, subVersion)
+
+  LOG(DEBUG) << "mBaseDirectory = " << mBaseDirectory.Data() << FairLogger::endl;
+
+  if (!id.getIdRunRange().isValid()) {
+    LOG(DEBUG) << "Invalid run range \"" << id.getFirstRun() << "," << id.getLastRun() << "\"." << FairLogger::endl;
+    return kFALSE;
+  }
+
+  if (id.getVersion() < 0) {
+    LOG(DEBUG) << "Invalid version <" << id.getVersion() << ">." << FairLogger::endl;
+    return kFALSE;
+  }
+
+  if (id.getSubVersion() < 0) {
+    LOG(DEBUG) << "Invalid subversion <" << id.getSubVersion() << ">." << FairLogger::endl;
+    return kFALSE;
+  }
+
+  filename = Form("Run%d_%d_v%d_s%d.root", id.getFirstRun(), id.getLastRun(), id.getVersion(), id.getSubVersion());
+
+  filename.Prepend(mBaseDirectory + '/' + id.getPathString() + '/');
+
+  return kTRUE;
+}
+
+Bool_t LocalStorage::prepareId(ConditionId& id)
+{
+  // prepare id (version, subVersion) of the object that will be stored (called by putCondition)
+
+  TString dirName = Form("%s/%s", mBaseDirectory.Data(), id.getPathString().Data());
+
+  // go to the path; if directory does not exist, create it
+  void* dirPtr = gSystem->OpenDirectory(dirName);
+  if (!dirPtr) {
+    gSystem->mkdir(dirName, kTRUE);
+    dirPtr = gSystem->OpenDirectory(dirName);
+
+    if (!dirPtr) {
+      LOG(ERROR) << "Can't create directory \"" << dirName.Data() << "\"!" << FairLogger::endl;
+      return kFALSE;
+    }
+  }
+
+  const char* filename;
+  IdRunRange aIdRunRange;                         // the runRange got from filename
+  IdRunRange lastIdRunRange(-1, -1);              // highest runRange found
+  Int_t aVersion, aSubVersion;                // the version subVersion got from filename
+  Int_t lastVersion = 0, lastSubVersion = -1; // highest version and subVersion found
+
+  if (!id.hasVersion()) { // version not specified: look for highest version & subVersion
+
+    while ((filename = gSystem->GetDirEntry(dirPtr))) { // loop on the files
+
+      TString aString(filename);
+      if (aString == "." || aString == "..")
+        continue;
+
+      if (!filenameToId(filename, aIdRunRange, aVersion, aSubVersion)) {
+        LOG(DEBUG) << "Bad filename <" << filename << ">! I'll skip it." << FairLogger::endl;
+        continue;
+      }
+
+      if (!aIdRunRange.isOverlappingWith(id.getIdRunRange()))
+        continue;
+      if (aVersion < lastVersion)
+        continue;
+      if (aVersion > lastVersion)
+        lastSubVersion = -1;
+      if (aSubVersion < lastSubVersion)
+        continue;
+      lastVersion = aVersion;
+      lastSubVersion = aSubVersion;
+      lastIdRunRange = aIdRunRange;
+    }
+
+    id.setVersion(lastVersion);
+    id.setSubVersion(lastSubVersion + 1);
+
+  } else { // version specified, look for highest subVersion only
+
+    while ((filename = gSystem->GetDirEntry(dirPtr))) { // loop on the files
+
+      TString aString(filename);
+      if (aString == "." || aString == "..") {
+        continue;
+      }
+
+      if (!filenameToId(filename, aIdRunRange, aVersion, aSubVersion)) {
+        LOG(DEBUG) << "Bad filename <" << filename << ">!I'll skip it." << FairLogger::endl;
+        continue;
+      }
+
+      if (aIdRunRange.isOverlappingWith(id.getIdRunRange()) && aVersion == id.getVersion() &&
+          aSubVersion > lastSubVersion) {
+        lastSubVersion = aSubVersion;
+        lastIdRunRange = aIdRunRange;
+      }
+    }
+
+    id.setSubVersion(lastSubVersion + 1);
+  }
+
+  gSystem->FreeDirectory(dirPtr);
+
+  TString lastStorage = id.getLastStorage();
+  if (lastStorage.Contains(TString("grid"), TString::kIgnoreCase) && id.getSubVersion() > 0) {
+    LOG(ERROR) << "GridStorage to LocalStorage Storage error! local object with version v" << id.getVersion() << "_s"
+               << id.getSubVersion() - 1 << " found:" << FairLogger::endl;
+    LOG(ERROR) << "This object has been already transferred from GridStorage (check v" << id.getVersion() << "_s0)!"
+               << FairLogger::endl;
+    return kFALSE;
+  }
+
+  if (lastStorage.Contains(TString("new"), TString::kIgnoreCase) && id.getSubVersion() > 0) {
+    LOG(DEBUG) << "A NEW object is being stored with version v" << id.getVersion() << "_s" << id.getSubVersion()
+               << FairLogger::endl;
+    LOG(DEBUG) << "and it will hide previously stored object with v" << id.getVersion() << "_s"
+               << id.getSubVersion() - 1 << "!" << FairLogger::endl;
+  }
+
+  if (!lastIdRunRange.isAnyRange() && !(lastIdRunRange.isEqual(&id.getIdRunRange())))
+    LOG(WARNING) << "Run range modified w.r.t. previous version (Run" << lastIdRunRange.getFirstRun() << "_"
+                 << lastIdRunRange.getLastRun() << "_v" << id.getVersion() << "_s" << id.getSubVersion() - 1
+                 << FairLogger::endl;
+
+  return kTRUE;
+}
+
+ConditionId* LocalStorage::getId(const ConditionId& query)
+{
+  // look for filename matching query (called by getConditionId)
+
+  // if querying for mRun and not specifying a version, look in the mValidFileIds list
+  if (!Manager::Instance()->getCvmfsOcdbTag().IsNull() && query.getFirstRun() == mRun && !query.hasVersion()) {
+    // if(query.getFirstRun() == mRun && !query.hasVersion()) {
+    // get id from mValidFileIds
+    TIter iter(&mValidFileIds);
+
+    ConditionId* anIdPtr = 0;
+    ConditionId* result = 0;
+
+    while ((anIdPtr = dynamic_cast<ConditionId*>(iter.Next()))) {
+      if (anIdPtr->getPathString() == query.getPathString()) {
+        result = new ConditionId(*anIdPtr);
+        break;
+      }
+    }
+    return result;
+  }
+
+  // otherwise browse in the local filesystem CDB storage
+  TString dirName = Form("%s/%s", mBaseDirectory.Data(), query.getPathString().Data());
+
+  void* dirPtr = gSystem->OpenDirectory(dirName);
+  if (!dirPtr) {
+    LOG(DEBUG) << "Directory <" << (query.getPathString()).Data() << "> not found" << FairLogger::endl;
+    LOG(DEBUG) << "in DB folder " << mBaseDirectory.Data() << FairLogger::endl;
+    return NULL;
+  }
+
+  const char* filename;
+  ConditionId* result = new ConditionId();
+  result->setPath(query.getPathString());
+
+  IdRunRange aIdRunRange;          // the runRange got from filename
+  Int_t aVersion, aSubVersion; // the version and subVersion got from filename
+
+  if (!query.hasVersion()) { // neither version and subversion specified -> look for highest version
+                             // and subVersion
+
+    while ((filename = gSystem->GetDirEntry(dirPtr))) { // loop on files
+
+      TString aString(filename);
+      if (aString.BeginsWith('.'))
+        continue;
+
+      if (!filenameToId(filename, aIdRunRange, aVersion, aSubVersion))
+        continue;
+      // aIdRunRange, aVersion, aSubVersion filled from filename
+
+      if (!aIdRunRange.isSupersetOf(query.getIdRunRange()))
+        continue;
+      // aIdRunRange contains requested run!
+
+      LOG(DEBUG) << "Filename " << filename << " matches\n" << FairLogger::endl;
+
+      if (result->getVersion() < aVersion) {
+        result->setVersion(aVersion);
+        result->setSubVersion(aSubVersion);
+
+        result->setFirstRun(aIdRunRange.getFirstRun());
+        result->setLastRun(aIdRunRange.getLastRun());
+
+      } else if (result->getVersion() == aVersion && result->getSubVersion() < aSubVersion) {
+
+        result->setSubVersion(aSubVersion);
+
+        result->setFirstRun(aIdRunRange.getFirstRun());
+        result->setLastRun(aIdRunRange.getLastRun());
+      } else if (result->getVersion() == aVersion && result->getSubVersion() == aSubVersion) {
+        LOG(ERROR) << "More than one object valid for run " << query.getFirstRun() << " version " << aVersion << "_"
+                   << aSubVersion << "!" << FairLogger::endl;
+        gSystem->FreeDirectory(dirPtr);
+        delete result;
+        return NULL;
+      }
+    }
+
+  } else if (!query.hasSubVersion()) { // version specified but not subversion -> look for highest
+                                       // subVersion
+    result->setVersion(query.getVersion());
+
+    while ((filename = gSystem->GetDirEntry(dirPtr))) { // loop on files
+
+      TString aString(filename);
+      if (aString.BeginsWith('.'))
+        continue;
+
+      if (!filenameToId(filename, aIdRunRange, aVersion, aSubVersion))
+        continue;
+      // aIdRunRange, aVersion, aSubVersion filled from filename
+
+      if (!aIdRunRange.isSupersetOf(query.getIdRunRange()))
+        continue;
+      // aIdRunRange contains requested run!
+
+      if (query.getVersion() != aVersion)
+        continue;
+      // aVersion is requested version!
+
+      if (result->getSubVersion() == aSubVersion) {
+        LOG(ERROR) << "More than one object valid for run " << query.getFirstRun() << " version " << aVersion << "_"
+                   << aSubVersion << "!" << FairLogger::endl;
+        gSystem->FreeDirectory(dirPtr);
+        delete result;
+        return NULL;
+      }
+      if (result->getSubVersion() < aSubVersion) {
+
+        result->setSubVersion(aSubVersion);
+
+        result->setFirstRun(aIdRunRange.getFirstRun());
+        result->setLastRun(aIdRunRange.getLastRun());
+      }
+    }
+
+  } else { // both version and subversion specified
+
+    // ConditionId dataId(queryId.getPathString(), -1, -1, -1, -1);
+    // Bool_t result;
+    while ((filename = gSystem->GetDirEntry(dirPtr))) { // loop on files
+
+      TString aString(filename);
+      if (aString.BeginsWith('.'))
+        continue;
+
+      if (!filenameToId(filename, aIdRunRange, aVersion, aSubVersion)) {
+        LOG(DEBUG) << "Could not make id from file: " << filename << FairLogger::endl;
+        continue;
+      }
+      // aIdRunRange, aVersion, aSubVersion filled from filename
+
+      if (!aIdRunRange.isSupersetOf(query.getIdRunRange()))
+        continue;
+      // aIdRunRange contains requested run!
+
+      if (query.getVersion() != aVersion || query.getSubVersion() != aSubVersion) {
+        continue;
+      }
+      // aVersion and aSubVersion are requested version and subVersion!
+
+      result->setVersion(aVersion);
+      result->setSubVersion(aSubVersion);
+      result->setFirstRun(aIdRunRange.getFirstRun());
+      result->setLastRun(aIdRunRange.getLastRun());
+      break;
+    }
+  }
+
+  gSystem->FreeDirectory(dirPtr);
+
+  return result;
+}
+
+Condition* LocalStorage::getCondition(const ConditionId& queryId)
+{
+  // get  Condition from the storage (the CDB file matching the query is
+  // selected by getConditionId and the contained  id is passed here)
+
+  ConditionId* dataId = getConditionId(queryId);
+
+  TString errMessage(TString::Format("No valid CDB object found! request was: %s", queryId.ToString().Data()));
+  if (!dataId || !dataId->isSpecified()) {
+    LOG(ERROR) << "No file found matching this id!" << FairLogger::endl;
+    throw std::runtime_error(errMessage.Data());
+    return NULL;
+  }
+
+  TString filename;
+  if (!idToFilename(*dataId, filename)) {
+    LOG(ERROR) << "Bad data ID encountered!" << FairLogger::endl;
+    delete dataId;
+    throw std::runtime_error(errMessage.Data());
+    return NULL;
+  }
+
+  TFile file(filename, "READ"); // open file
+  if (!file.IsOpen()) {
+    LOG(ERROR) << "Can't open file <" << filename.Data() << ">!" << FairLogger::endl;
+    delete dataId;
+    throw std::runtime_error(errMessage.Data());
+    return NULL;
+  }
+
+  // get the only  Condition object from the file
+  // the object in the file is an  Condition entry named " Condition"
+
+  Condition* anCondition = dynamic_cast<Condition*>(file.Get(" Condition"));
+  if (!anCondition) {
+    LOG(ERROR) << "Bad storage data: No  Condition in file!" << FairLogger::endl;
+    file.Close();
+    delete dataId;
+    throw std::runtime_error(errMessage.Data());
+    return NULL;
+  }
+
+  ConditionId& entryId = anCondition->getId();
+
+  // The object's ConditionId are not reset during storage
+  // If object's ConditionId runRange or version do not match with filename,
+  // it means that someone renamed file by hand. In this case a warning msg is issued.
+
+  anCondition->setLastStorage("local");
+
+  if (!entryId.isEqual(dataId)) {
+    LOG(WARNING) << "Mismatch between file name and object's ConditionId!" << FairLogger::endl;
+    LOG(WARNING) << "File name: " << dataId->ToString().Data() << FairLogger::endl;
+    LOG(WARNING) << "Object's ConditionId: " << entryId.ToString().Data() << FairLogger::endl;
+  }
+
+  // Check whether entry contains a TTree. In case load the tree in memory!
+  loadTreeFromFile(anCondition);
+
+  // close file, return retrieved entry
+  file.Close();
+  delete dataId;
+
+  return anCondition;
+}
+
+ConditionId* LocalStorage::getConditionId(const ConditionId& queryId)
+{
+  // get  ConditionId from the storage
+  // Via getId, select the CDB file matching the query and return
+  // the contained  ConditionId
+
+  ConditionId* dataId = 0;
+
+  // look for a filename matching query requests (path, runRange, version, subVersion)
+  if (!queryId.hasVersion()) {
+    // if version is not specified, first check the selection criteria list
+    ConditionId selectedId(queryId);
+    getSelection(&selectedId);
+    dataId = getId(selectedId);
+  } else {
+    dataId = getId(queryId);
+  }
+
+  if (dataId && !dataId->isSpecified()) {
+    delete dataId;
+    return NULL;
+  }
+
+  return dataId;
+}
+
+void LocalStorage::getEntriesForLevel0(const char* level0, const ConditionId& queryId, TList* result)
+{
+  // multiple request ( Storage::GetAllObjects)
+
+  TString level0Dir = Form("%s/%s", mBaseDirectory.Data(), level0);
+
+  void* level0DirPtr = gSystem->OpenDirectory(level0Dir);
+  if (!level0DirPtr) {
+    LOG(DEBUG) << "Can't open level0 directory <" << level0Dir.Data() << ">!" << FairLogger::endl;
+    return;
+  }
+
+  const char* level1;
+  Long_t flag = 0;
+  while ((level1 = gSystem->GetDirEntry(level0DirPtr))) {
+
+    TString level1Str(level1);
+    // skip directories starting with a dot (".svn" and similar in old svn working copies)
+    if (level1Str.BeginsWith('.')) {
+      continue;
+    }
+
+    TString fullPath = Form("%s/%s", level0Dir.Data(), level1);
+
+    Int_t res = gSystem->GetPathInfo(fullPath.Data(), 0, (Long64_t*)0, &flag, 0);
+
+    if (res) {
+      LOG(DEBUG) << "Error reading entry " << level1Str.Data() << " !" << FairLogger::endl;
+      continue;
+    }
+    if (!(flag & 2))
+      continue; // bit 1 of flag = directory!
+
+    if (queryId.getPath().doesLevel1Contain(level1)) {
+      getEntriesForLevel1(level0, level1, queryId, result);
+    }
+  }
+
+  gSystem->FreeDirectory(level0DirPtr);
+}
+
+void LocalStorage::getEntriesForLevel1(const char* level0, const char* level1, const ConditionId& queryId, TList* result)
+{
+  // multiple request ( Storage::GetAllObjects)
+
+  TString level1Dir = Form("%s/%s/%s", mBaseDirectory.Data(), level0, level1);
+
+  void* level1DirPtr = gSystem->OpenDirectory(level1Dir);
+  if (!level1DirPtr) {
+    LOG(DEBUG) << "Can't open level1 directory <" << level1Dir.Data() << ">!" << FairLogger::endl;
+    return;
+  }
+
+  const char* level2;
+  Long_t flag = 0;
+  while ((level2 = gSystem->GetDirEntry(level1DirPtr))) {
+
+    TString level2Str(level2);
+    // skip directories starting with a dot (".svn" and similar in old svn working copies)
+    if (level2Str.BeginsWith('.')) {
+      continue;
+    }
+
+    TString fullPath = Form("%s/%s", level1Dir.Data(), level2);
+
+    Int_t res = gSystem->GetPathInfo(fullPath.Data(), 0, (Long64_t*)0, &flag, 0);
+
+    if (res) {
+      LOG(DEBUG) << "Error reading entry " << level2Str.Data() << " !" << FairLogger::endl;
+      continue;
+    }
+    if (!(flag & 2))
+      continue; // skip if not a directory
+
+    if (queryId.getPath().doesLevel2Contain(level2)) {
+
+      IdPath entryPath(level0, level1, level2);
+
+      ConditionId entryId(entryPath, queryId.getIdRunRange(), queryId.getVersion(), queryId.getSubVersion());
+
+      // check filenames to see if any includes queryId.getIdRunRange()
+      void* level2DirPtr = gSystem->OpenDirectory(fullPath);
+      if (!level2DirPtr) {
+        LOG(DEBUG) << "Can't open level2 directory <" << fullPath.Data() << ">!" << FairLogger::endl;
+        return;
+      }
+      const char* level3;
+      Long_t file_flag = 0;
+      while ((level3 = gSystem->GetDirEntry(level2DirPtr))) {
+        TString fileName(level3);
+        TString fullFileName = Form("%s/%s", fullPath.Data(), level3);
+
+        Int_t file_res = gSystem->GetPathInfo(fullFileName.Data(), 0, (Long64_t*)0, &file_flag, 0);
+
+        if (file_res) {
+          LOG(DEBUG) << "Error reading entry " << level2Str.Data() << " !" << FairLogger::endl;
+          continue;
+        }
+        if (file_flag)
+          continue; // it is not a regular file!
+
+        // skip if result already contains an entry for this path
+        Bool_t alreadyLoaded = kFALSE;
+        Int_t nEntries = result->GetEntries();
+        for (int i = 0; i < nEntries; i++) {
+          Condition* lCondition = (Condition*)result->At(i);
+          ConditionId lId = lCondition->getId();
+          TString lIdPath = lId.getPathString();
+          if (lIdPath.EqualTo(entryPath.getPathString())) {
+            alreadyLoaded = kTRUE;
+            break;
+          }
+        }
+        if (alreadyLoaded)
+          continue;
+
+        // skip filenames not matching the regex below
+        TRegexp re("^Run[0-9]+_[0-9]+_");
+        if (!fileName.Contains(re))
+          continue;
+        // Extract first- and last-run and version and subversion.
+        // This allows to avoid quering for a calibration path if we did not find a filename with
+        // run-range including the one specified in the query and
+        // with version, subversion matching the query
+        TString fn = fileName(3, fileName.Length() - 3);
+        TString firstRunStr = fn(0, fn.First('_'));
+        fn.Remove(0, firstRunStr.Length() + 1);
+        TString lastRunStr = fn(0, fn.First('_'));
+        fn.Remove(0, lastRunStr.Length() + 1);
+        TString versionStr = fn(1, fn.First('_') - 1);
+        fn.Remove(0, versionStr.Length() + 2);
+        TString subvStr = fn(1, fn.First('.') - 1);
+        Int_t firstRun = firstRunStr.Atoi();
+        Int_t lastRun = lastRunStr.Atoi();
+        IdRunRange rr(firstRun, lastRun);
+        Int_t version = versionStr.Atoi();
+        Int_t subVersion = subvStr.Atoi();
+
+        Condition* anCondition = 0;
+        Bool_t versionOK = kTRUE, subVersionOK = kTRUE;
+        if (queryId.hasVersion() && version != queryId.getVersion())
+          versionOK = kFALSE;
+        if (queryId.hasSubVersion() && subVersion != queryId.getSubVersion())
+          subVersionOK = kFALSE;
+        if (rr.isSupersetOf(queryId.getIdRunRange()) && versionOK && subVersionOK) {
+          anCondition = getCondition(entryId);
+          result->Add(anCondition);
+        }
+      }
+    }
+  }
+
+  gSystem->FreeDirectory(level1DirPtr);
+}
+
+TList* LocalStorage::getAllEntries(const ConditionId& queryId)
+{
+  // return list of CDB entries matching a generic request (Storage::GetAllObjects)
+
+  TList* result = new TList();
+  result->SetOwner();
+
+  // if querying for mRun and not specifying a version, look in the mValidFileIds list
+  if (queryId.getFirstRun() == mRun && !queryId.hasVersion()) {
+    // get id from mValidFileIds
+    TIter* iter = new TIter(&mValidFileIds);
+    TObjArray selectedIds;
+    selectedIds.SetOwner(1);
+
+    // loop on list of valid Ids to select the right version to get.
+    // According to query and to the selection criteria list, version can be the highest or exact
+    ConditionId* anIdPtr = 0;
+    ConditionId* dataId = 0;
+    IdPath queryPath = queryId.getPathString();
+    while ((anIdPtr = dynamic_cast<ConditionId*>(iter->Next()))) {
+      IdPath thisCDBPath = anIdPtr->getPathString();
+      if (!(queryPath.isSupersetOf(thisCDBPath))) {
+        continue;
+      }
+
+      ConditionId thisId(*anIdPtr);
+      dataId = getId(thisId);
+      if (dataId)
+        selectedIds.Add(dataId);
+    }
+
+    delete iter;
+    iter = 0;
+
+    // selectedIds contains the Ids of the files matching all requests of query!
+    // All the objects are now ready to be retrieved
+    iter = new TIter(&selectedIds);
+    while ((anIdPtr = dynamic_cast<ConditionId*>(iter->Next()))) {
+      Condition* anCondition = getCondition(*anIdPtr);
+      if (anCondition)
+        result->Add(anCondition);
+    }
+    delete iter;
+    iter = 0;
+    return result;
+  }
+
+  void* storageDirPtr = gSystem->OpenDirectory(mBaseDirectory);
+  if (!storageDirPtr) {
+    LOG(DEBUG) << "Can't open storage directory <" << mBaseDirectory.Data() << ">" << FairLogger::endl;
+    return NULL;
+  }
+
+  const char* level0;
+  Long_t flag = 0;
+  while ((level0 = gSystem->GetDirEntry(storageDirPtr))) {
+
+    TString level0Str(level0);
+    // skip directories starting with a dot (".svn" and similar in old svn working copies)
+    if (level0Str.BeginsWith('.')) {
+      continue;
+    }
+
+    TString fullPath = Form("%s/%s", mBaseDirectory.Data(), level0);
+
+    Int_t res = gSystem->GetPathInfo(fullPath.Data(), 0, (Long64_t*)0, &flag, 0);
+
+    if (res) {
+      LOG(DEBUG) << "Error reading entry " << level0Str.Data() << " !" << FairLogger::endl;
+      continue;
+    }
+
+    if (!(flag & 2))
+      continue; // bit 1 of flag = directory!
+
+    if (queryId.getPath().doesLevel0Contain(level0)) {
+      getEntriesForLevel0(level0, queryId, result);
+    }
+  }
+
+  gSystem->FreeDirectory(storageDirPtr);
+
+  return result;
+}
+
+Bool_t LocalStorage::putCondition(Condition* entry, const char* mirrors)
+{
+  // put an  Condition object into the database
+
+  ConditionId& id = entry->getId();
+
+  // set version and subVersion for the entry to be stored
+  if (!prepareId(id))
+    return kFALSE;
+
+  // build filename from entry's id
+  TString filename = "";
+  if (!idToFilename(id, filename)) {
+
+    LOG(DEBUG) << "Bad ID encountered! Subnormal error!" << FairLogger::endl;
+    return kFALSE;
+  }
+
+  TString mirrorsString(mirrors);
+  if (!mirrorsString.IsNull())
+    LOG(WARNING) << " LocalStorage storage cannot take mirror SEs into account. They will be ignored." << FairLogger::endl;
+
+  // open file
+  TFile file(filename, "CREATE");
+  if (!file.IsOpen()) {
+    LOG(ERROR) << "Can't open file <" << filename.Data() << ">!" << FairLogger::endl;
+    return kFALSE;
+  }
+
+  // setTreeToFile(entry, &file);
+
+  entry->setVersion(id.getVersion());
+  entry->setSubVersion(id.getSubVersion());
+
+  // write object (key name: " Condition")
+  Bool_t result = file.WriteTObject(entry, " Condition");
+  if (!result)
+    LOG(DEBUG) << "Can't write entry to file: " << filename.Data() << FairLogger::endl;
+
+  file.Close();
+  if (result) {
+    if (!(id.getPathString().Contains("SHUTTLE/STATUS")))
+      LOG(INFO) << "CDB object stored into file \"" << filename.Data() << "\"" << FairLogger::endl;
+  }
+
+  return result;
+}
+
+TList* LocalStorage::getIdListFromFile(const char* fileName)
+{
+
+  TString fullFileName(fileName);
+  fullFileName.Prepend(mBaseDirectory + '/');
+  TFile* file = TFile::Open(fullFileName);
+  if (!file) {
+    LOG(ERROR) << "Can't open selection file <" << fullFileName.Data() << ">!" << FairLogger::endl;
+    return NULL;
+  }
+  file->cd();
+
+  TList* list = new TList();
+  list->SetOwner();
+  int i = 0;
+  TString keycycle;
+
+  ConditionId* id;
+  while (1) {
+    i++;
+    keycycle = " ConditionId;";
+    keycycle += i;
+
+    id = (ConditionId*)file->Get(keycycle);
+    if (!id)
+      break;
+    list->AddFirst(id);
+  }
+  file->Close();
+  delete file;
+  file = 0;
+  return list;
+}
+
+Bool_t LocalStorage::hasConditionType(const char* path) const
+{
+  // check for path in storage's mBaseDirectory
+
+  TString dirName = Form("%s/%s", mBaseDirectory.Data(), path);
+  Bool_t result = kFALSE;
+
+  void* dirPtr = gSystem->OpenDirectory(dirName);
+  if (dirPtr)
+    result = kTRUE;
+  gSystem->FreeDirectory(dirPtr);
+
+  return result;
+}
+
+void LocalStorage::queryValidFiles()
+{
+  // Query the CDB for files valid for  Storage::mRun.
+  // Fills list mValidFileIds with  ConditionId objects extracted from CDB files
+  // present in the local storage.
+  // If mVersion was not set, mValidFileIds is filled with highest versions.
+  // In the CVMFS case, the mValidFileIds is filled from the file containing
+  // the filepaths corresponding to the highest versions for the give OCDB tag
+  // by launching the script which extracts the last versions for the given run.
+  //
+
+  if (mVersion != -1)
+    LOG(WARNING) << "Version parameter is not used by local storage query!" << FairLogger::endl;
+  if (mConditionMetaDataFilter) {
+    LOG(WARNING) << "CDB meta data parameters are not used by local storage query!" << FairLogger::endl;
+    delete mConditionMetaDataFilter;
+    mConditionMetaDataFilter = 0;
+  }
+
+  // Check if in CVMFS case
+  TString cvmfsOcdbTag(gSystem->Getenv("OCDB_PATH"));
+  if (!cvmfsOcdbTag.IsNull()) {
+    queryValidCVMFSFiles(cvmfsOcdbTag);
+    return;
+  }
+
+  void* storageDirPtr = gSystem->OpenDirectory(mBaseDirectory);
+
+  const char* level0;
+  while ((level0 = gSystem->GetDirEntry(storageDirPtr))) {
+
+    TString level0Str(level0);
+    if (level0Str.BeginsWith(".")) {
+      continue;
+    }
+
+    if (mPathFilter.doesLevel0Contain(level0)) {
+      TString level0Dir = Form("%s/%s", mBaseDirectory.Data(), level0);
+      void* level0DirPtr = gSystem->OpenDirectory(level0Dir);
+      const char* level1;
+      while ((level1 = gSystem->GetDirEntry(level0DirPtr))) {
+
+        TString level1Str(level1);
+        if (level1Str.BeginsWith(".")) {
+          continue;
+        }
+
+        if (mPathFilter.doesLevel1Contain(level1)) {
+          TString level1Dir = Form("%s/%s/%s", mBaseDirectory.Data(), level0, level1);
+
+          void* level1DirPtr = gSystem->OpenDirectory(level1Dir);
+          const char* level2;
+          while ((level2 = gSystem->GetDirEntry(level1DirPtr))) {
+
+            TString level2Str(level2);
+            if (level2Str.BeginsWith(".")) {
+              continue;
+            }
+
+            if (mPathFilter.doesLevel2Contain(level2)) {
+              TString dirName = Form("%s/%s/%s/%s", mBaseDirectory.Data(), level0, level1, level2);
+
+              void* dirPtr = gSystem->OpenDirectory(dirName);
+
+              const char* filename;
+
+              IdRunRange aIdRunRange;                    // the runRange got from filename
+              IdRunRange hvIdRunRange;                   // the runRange of the highest version valid file
+              Int_t aVersion, aSubVersion;           // the version and subVersion got from filename
+              Int_t highestV = -1, highestSubV = -1; // the highest version and subVersion for this calibration type
+
+              while ((filename = gSystem->GetDirEntry(dirPtr))) { // loop on files
+
+                TString aString(filename);
+                if (aString.BeginsWith("."))
+                  continue;
+
+                if (!filenameToId(filename, aIdRunRange, aVersion, aSubVersion)) {
+                  continue;
+                }
+
+                IdRunRange runrg(mRun, mRun);
+                if (!aIdRunRange.isSupersetOf(runrg))
+                  continue;
+
+                // check to keep the highest version/subversion (in case of more than one)
+                if (aVersion > highestV) {
+                  highestV = aVersion;
+                  highestSubV = aSubVersion;
+                  hvIdRunRange = aIdRunRange;
+                } else if (aVersion == highestV) {
+                  if (aSubVersion > highestSubV) {
+                    highestSubV = aSubVersion;
+                    hvIdRunRange = aIdRunRange;
+                  }
+                }
+              }
+              if (highestV >= 0) {
+                IdPath validPath(level0, level1, level2);
+                ConditionId* validId = new ConditionId(validPath, hvIdRunRange, highestV, highestSubV);
+                mValidFileIds.AddLast(validId);
+              }
+
+              gSystem->FreeDirectory(dirPtr);
+            }
+          }
+          gSystem->FreeDirectory(level1DirPtr);
+        }
+      }
+      gSystem->FreeDirectory(level0DirPtr);
+    }
+  }
+  gSystem->FreeDirectory(storageDirPtr);
+}
+
+void LocalStorage::queryValidCVMFSFiles(TString& cvmfsOcdbTag)
+{
+  // Called in the CVMFS case to fill the mValidFileIds from the file containing
+  // the filepaths corresponding to the highest versions for the given OCDB tag
+  // by launching the script which extracts the last versions for the given run.
+  //
+
+  TString command = cvmfsOcdbTag;
+  LOG(DEBUG) << "Getting valid files from CVMFS-OCDB tag \"" << cvmfsOcdbTag.Data() << "\"" << FairLogger::endl;
+  // CVMFS-OCDB tag. This is the file $OCDB_PATH/catalogue/20??.list.gz
+  // containing all CDB file paths (for the given AR tag)
+  cvmfsOcdbTag.Strip(TString::kTrailing, '/');
+  cvmfsOcdbTag.Append("/");
+  gSystem->ExpandPathName(cvmfsOcdbTag);
+  if (gSystem->AccessPathName(cvmfsOcdbTag))
+    LOG(FATAL) << "cvmfs OCDB set to an invalid path: " << cvmfsOcdbTag.Data() << FairLogger::endl;
+
+  // The file containing the list of valid files for the current run has to be generated
+  // by running the (shell+awk) script on the CVMFS OCDB tag file.
+
+  // the script in cvmfs to extract CDB filepaths for the given run has the following fullpath
+  // w.r.t. $OCDB_PATH: bin/OCDBperRun.sh
+  command = command.Strip(TString::kTrailing, '/');
+  command.Append("/bin/getOCDBFilesPerRun.sh ");
+  command += cvmfsOcdbTag;
+  // from URI define the last two levels of the path of the cvmfs ocdb tag (e.g. data/2012.list.gz)
+  TString uri(getUri());
+  uri.Remove(TString::kTrailing, '/');
+  TObjArray* osArr = uri.Tokenize('/');
+  TObjString* mcdata_os = dynamic_cast<TObjString*>(osArr->At(osArr->GetEntries() - 3));
+  TObjString* yeartype_os = 0;
+  TString mcdata = mcdata_os->GetString();
+  if (mcdata == TString("data")) {
+    yeartype_os = dynamic_cast<TObjString*>(osArr->At(osArr->GetEntries() - 2));
+  } else {
+    mcdata_os = dynamic_cast<TObjString*>(osArr->At(osArr->GetEntries() - 2));
+    yeartype_os = dynamic_cast<TObjString*>(osArr->At(osArr->GetEntries() - 1));
+  }
+  mcdata = mcdata_os->GetString();
+  TString yeartype = yeartype_os->GetString();
+  command += mcdata;
+  command += '/';
+  command += yeartype;
+  command += ".list.gz cvmfs ";
+  command += TString::Itoa(mRun, 10);
+  command += ' ';
+  command += TString::Itoa(mRun, 10);
+  command += " -y > ";
+  TString runValidFile(gSystem->WorkingDirectory());
+  runValidFile += '/';
+  runValidFile += mcdata;
+  runValidFile += '_';
+  runValidFile += yeartype;
+  runValidFile += '_';
+  runValidFile += TString::Itoa(mRun, 10);
+  command += runValidFile;
+  LOG(DEBUG) << "Running command: \"" << command.Data() << "\"" << FairLogger::endl;
+  Int_t result = gSystem->Exec(command.Data());
+  if (result != 0) {
+    LOG(ERROR) << "Was not able to execute \"" << command.Data() << "\"" << FairLogger::endl;
+  }
+
+  // We expect the file with valid paths for this run to be generated in the current directory
+  // and to be named as the CVMFS OCDB tag, without .gz, with '_runnumber' appended
+  // Fill mValidFileIds from file
+  std::ifstream file(runValidFile.Data());
+  if (!file.is_open()) {
+    LOG(FATAL) << "Error opening file \"" << runValidFile.Data() << "\"!" << FairLogger::endl;
+  }
+  TString filepath;
+  while (filepath.ReadLine(file)) {
+    // skip line in case it is not a root file path
+    if (!filepath.EndsWith(".root")) {
+      continue;
+    }
+    // extract three-level path and basename
+    TObjArray* tokens = filepath.Tokenize('/');
+    if (tokens->GetEntries() < 5) {
+      LOG(ERROR) << "\"" << filepath.Data() << "\" is not a valid cvmfs path for an OCDB object" << FairLogger::endl;
+      continue;
+    }
+    TObjString* baseNameOstr = (TObjString*)tokens->At(tokens->GetEntries() - 1);
+    TString baseName(baseNameOstr->String());
+    TObjString* l0oStr = (TObjString*)tokens->At(tokens->GetEntries() - 4);
+    TObjString* l1oStr = (TObjString*)tokens->At(tokens->GetEntries() - 3);
+    TObjString* l2oStr = (TObjString*)tokens->At(tokens->GetEntries() - 2);
+    TString l0(l0oStr->String());
+    TString l1(l1oStr->String());
+    TString l2(l2oStr->String());
+    TString threeLevels = l0 + '/' + l1 + '/' + l2;
+
+    IdPath validPath(threeLevels);
+    // use basename and three-level path to create ConditionId
+    IdRunRange aIdRunRange;          // the runRange got from filename
+    Int_t aVersion, aSubVersion; // the version and subVersion got from filename
+    if (!filenameToId(baseName, aIdRunRange, aVersion, aSubVersion))
+      LOG(ERROR) << "Could not create a valid CDB id from path: \"" << filepath.Data() << "\"" << FairLogger::endl;
+
+    IdRunRange runrg(mRun, mRun);
+    if (!aIdRunRange.isSupersetOf(runrg))
+      continue; // should never happen (would mean awk script wrong output)
+                // aIdRunRange contains requested run!
+    ConditionId* validId = new ConditionId(validPath, aIdRunRange, aVersion, aSubVersion);
+    mValidFileIds.AddLast(validId);
+  }
+
+  file.close();
+  return;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//                                                                                             //
+//  LocalStorage factory  			                                               //
+//                                                                                             //
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+ClassImp(LocalStorageFactory)
+
+Bool_t LocalStorageFactory::validateStorageUri(const char* dbString)
+{
+  // check if the string is valid local URI
+
+  TRegexp dbPatternLocalStorage("^local://.+$");
+
+  return (TString(dbString).Contains(dbPatternLocalStorage) || TString(dbString).BeginsWith("snapshot://folder="));
+}
+
+StorageParameters* LocalStorageFactory::createStorageParameter(const char* dbString)
+{
+  // create  LocalStorageParameters class from the URI string
+
+  if (!validateStorageUri(dbString)) {
+    return NULL;
+  }
+
+  TString checkSS(dbString);
+  if (checkSS.BeginsWith("snapshot://")) {
+    TString snapshotPath("OCDB");
+    snapshotPath.Prepend(TString(gSystem->WorkingDirectory()) + '/');
+    checkSS.Remove(0, checkSS.First(':') + 3);
+    return new LocalStorageParameters(snapshotPath, checkSS);
+  }
+
+  // if the string argument is not a snapshot URI, than it is a plain local URI
+  TString pathname(dbString + sizeof("local://") - 1);
+
+  if (gSystem->ExpandPathName(pathname))
+    return NULL;
+
+  if (pathname[0] != '/') {
+    pathname.Prepend(TString(gSystem->WorkingDirectory()) + '/');
+  }
+  // pathname.Prepend("local://");
+
+  return new LocalStorageParameters(pathname);
+}
+
+Storage* LocalStorageFactory::createStorage(const StorageParameters* param)
+{
+  // create LocalStorage storage instance from parameters
+
+  if (LocalStorageParameters::Class() == param->IsA()) {
+
+    const LocalStorageParameters* localParam = (const LocalStorageParameters*)param;
+
+    return new LocalStorage(localParam->getPathString());
+  }
+
+  return NULL;
+}
+void LocalStorage::setRetry(Int_t /* nretry */, Int_t /* initsec */)
+{
+
+  // Function to set the exponential retry for putting entries in the OCDB
+
+  LOG(INFO) << "This function sets the exponential retry for putting entries in the OCDB - to be "
+               "used ONLY for  GridStorage --> returning without doing anything" << FairLogger::endl;
+  return;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//                                                                                             //
+//  LocalStorage Parameter class  			                                       // //
+//                                                                                             //
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+ClassImp(LocalStorageParameters)
+
+LocalStorageParameters::LocalStorageParameters() : StorageParameters(), mDBPath()
+{
+  // default constructor
+}
+
+LocalStorageParameters::LocalStorageParameters(const char* dbPath) : StorageParameters(), mDBPath(dbPath)
+{
+  // constructor
+
+  setType("local");
+  setUri(TString("local://") + dbPath);
+}
+
+LocalStorageParameters::LocalStorageParameters(const char* dbPath, const char* uri) : StorageParameters(), mDBPath(dbPath)
+{
+  // constructor
+
+  setType("local");
+  setUri(TString("alien://") + uri);
+}
+
+LocalStorageParameters::~LocalStorageParameters()
+{
+  // destructor
+}
+
+StorageParameters* LocalStorageParameters::cloneParam() const
+{
+  // clone parameter
+
+  return new LocalStorageParameters(mDBPath);
+}
+
+ULong_t LocalStorageParameters::getHash() const
+{
+  // return getHash function
+
+  return mDBPath.Hash();
+}
+
+Bool_t LocalStorageParameters::isEqual(const TObject* obj) const
+{
+  // check if this object is equal to  StorageParameters obj
+
+  if (this == obj) {
+    return kTRUE;
+  }
+
+  if (LocalStorageParameters::Class() != obj->IsA()) {
+    return kFALSE;
+  }
+
+  LocalStorageParameters* other = (LocalStorageParameters*)obj;
+
+  return mDBPath == other->mDBPath;
+}

--- a/o2cdb/LocalStorage.h
+++ b/o2cdb/LocalStorage.h
@@ -1,0 +1,88 @@
+#ifndef ALICEO2_CDB_LOCAL_H_
+#define ALICEO2_CDB_LOCAL_H_
+
+//  class  LocalStorage						   //
+//  access class to a DataBase in a local storage                  //
+#include "Storage.h"
+#include "Manager.h"
+
+namespace AliceO2 {
+namespace CDB {
+
+class LocalStorage : public Storage {
+  friend class LocalStorageFactory;
+
+public:
+  virtual Bool_t isReadOnly() const
+  {
+    return kFALSE;
+  };
+  virtual Bool_t hasSubVersion() const
+  {
+    return kTRUE;
+  };
+  virtual Bool_t hasConditionType(const char* path) const;
+  virtual Bool_t idToFilename(const ConditionId& id, TString& filename) const;
+  virtual void setRetry(Int_t /* nretry */, Int_t /* initsec */);
+
+protected:
+  virtual Condition* getCondition(const ConditionId& queryId);
+  virtual ConditionId* getConditionId(const ConditionId& queryId);
+  virtual TList* getAllEntries(const ConditionId& queryId);
+  virtual Bool_t putCondition(Condition* entry, const char* mirrors = "");
+  virtual TList* getIdListFromFile(const char* fileName);
+
+private:
+  LocalStorage(const LocalStorage& source);
+  LocalStorage& operator=(const LocalStorage& source);
+  LocalStorage(const char* baseDir);
+  virtual ~LocalStorage();
+
+  Bool_t filenameToId(const char* filename, IdRunRange& runRange, Int_t& version, Int_t& subVersion);
+
+  Bool_t prepareId(ConditionId& id);
+  //	Bool_t getId(const  ConditionId& query,  ConditionId& result);
+  ConditionId* getId(const ConditionId& query);
+
+  virtual void queryValidFiles();
+  void queryValidCVMFSFiles(TString& cvmfsOcdbTag);
+
+  void getEntriesForLevel0(const char* level0, const ConditionId& query, TList* result);
+  void getEntriesForLevel1(const char* level0, const char* Level1, const ConditionId& query, TList* result);
+
+  TString mBaseDirectory; // path of the DB folder
+
+  ClassDef(LocalStorage, 0) // access class to a DataBase in a local storage
+};
+
+//  class  LocalStorageFactory
+class LocalStorageFactory : public StorageFactory {
+public:
+  virtual Bool_t validateStorageUri(const char* dbString);
+  virtual StorageParameters* createStorageParameter(const char* dbString);
+protected:
+  virtual Storage* createStorage(const StorageParameters* param);
+  ClassDef(LocalStorageFactory, 0)
+};
+
+//  class  LocalStorageParameters
+class LocalStorageParameters : public StorageParameters {
+public:
+  LocalStorageParameters();
+  LocalStorageParameters(const char* dbPath);
+  LocalStorageParameters(const char* dbPath, const char* uri);
+  virtual ~LocalStorageParameters();
+  const TString& getPathString() const
+  {
+    return mDBPath;
+  };
+  virtual StorageParameters* cloneParam() const;
+  virtual ULong_t getHash() const;
+  virtual Bool_t isEqual(const TObject* obj) const;
+private:
+  TString mDBPath; // path of the DB folder
+  ClassDef(LocalStorageParameters, 0)
+};
+}
+}
+#endif

--- a/o2cdb/Manager.cxx
+++ b/o2cdb/Manager.cxx
@@ -1,0 +1,1814 @@
+#include <fstream>
+
+#include <TObjString.h>
+#include <TSAXParser.h>
+#include <TKey.h>
+#include <TUUID.h>
+#include <TGrid.h>
+#include <TMessage.h>
+#include <TObject.h>
+#include <TRegexp.h>
+#include <TString.h>
+
+#include <FairLogger.h>
+
+#include "Manager.h"
+#include "Storage.h"
+#include "FileStorage.h"
+#include "LocalStorage.h"
+#include "GridStorage.h"
+#include "Condition.h"
+#include "XmlHandler.h"
+
+using namespace AliceO2::CDB;
+
+ClassImp(StorageParameters)
+
+ClassImp(Manager)
+
+TString Manager::sOcdbFolderXmlFile("alien:///alice/data/OCDBFoldervsIdRunRange.xml");
+Manager* Manager::sInstance = 0x0;
+
+Manager* Manager::Instance(TMap* entryCache, Int_t run)
+{
+  // returns Manager instance (singleton)
+
+  if (!sInstance) {
+    sInstance = new Manager();
+    if (!entryCache)
+      sInstance->init();
+    else
+      sInstance->initFromCache(entryCache, run);
+  }
+
+  return sInstance;
+}
+
+void Manager::init()
+{
+  // factory registering
+
+  registerFactory(new FileStorageFactory());
+  registerFactory(new LocalStorageFactory());
+  // GridStorageFactory is registered only if AliEn libraries are enabled in Root
+  if (!gSystem->Exec("root-config --has-alien 2>/dev/null |grep yes 2>&1 > /dev/null")) { // returns 0 if yes
+    LOG(INFO) << "AliEn classes enabled in Root. GridStorage factory registered." << FairLogger::endl;
+    registerFactory(new GridStorageFactory());
+  }
+}
+
+void Manager::initFromCache(TMap* entryCache, Int_t run)
+{
+  // initialize manager from existing cache
+  // used on the slaves in case of parallel reconstruction
+  setRun(run);
+
+  TIter iter(entryCache->GetTable());
+  TPair* pair = 0;
+
+  while ((pair = dynamic_cast<TPair*>(iter.Next()))) {
+    mConditionCache.Add(pair->Key(), pair->Value());
+  }
+  // mCondition is the new owner of the cache
+  mConditionCache.SetOwnerKeyValue(kTRUE, kTRUE);
+  entryCache->SetOwnerKeyValue(kFALSE, kFALSE);
+  LOG(INFO) << mConditionCache.GetEntries() << " cache entries have been loaded" << FairLogger::endl;
+}
+
+void Manager::dumpToSnapshotFile(const char* snapshotFileName, Bool_t singleKeys) const
+{
+  //
+  // If singleKeys is true, dump the entries map and the ids list to the snapshot file
+  // (provided mostly for historical reasons, the file is then read with initFromSnapshot),
+  // otherwise write to file each Condition separately (the is the preferred way, the file
+  // is then read with setSnapshotMode).
+
+  // open the file
+  TFile* f = TFile::Open(snapshotFileName, "RECREATE");
+  if (!f || f->IsZombie()) {
+    LOG(ERROR) << "Cannot open file " << snapshotFileName << FairLogger::endl;
+    return;
+  }
+
+  LOG(INFO) << "Dumping entriesMap (entries'cache) with " << mConditionCache.GetEntries() << " entries!"
+            << FairLogger::endl;
+  LOG(INFO) << "Dumping entriesList with " << mIds->GetEntries() << "entries!" << FairLogger::endl;
+
+  f->cd();
+  if (singleKeys) {
+    f->WriteObject(&mConditionCache, "CDBentriesMap");
+    f->WriteObject(mIds, "CDBidsList");
+  } else {
+    // We write the entries one by one named by their calibration path
+    TIter iter(mConditionCache.GetTable());
+    TPair* pair = 0;
+    while ((pair = dynamic_cast<TPair*>(iter.Next()))) {
+      TObjString* os = dynamic_cast<TObjString*>(pair->Key());
+      if (!os)
+        continue;
+      TString path = os->GetString();
+      Condition* entry = dynamic_cast<Condition*>(pair->Value());
+      if (!entry)
+        continue;
+      path.ReplaceAll("/", "*");
+      entry->Write(path.Data());
+    }
+  }
+  f->Close();
+  delete f;
+}
+
+void Manager::dumpToLightSnapshotFile(const char* lightSnapshotFileName) const
+{
+  // The light snapshot does not contain the CDB objects (Entries) but
+  // only the information identifying them, that is the map of storages and
+  // the list of Ids, as in the UserInfo of AliESDs.root
+
+  // open the file
+  TFile* f = TFile::Open(lightSnapshotFileName, "RECREATE");
+  if (!f || f->IsZombie()) {
+    LOG(ERROR) << "Cannot open file " << lightSnapshotFileName << FairLogger::endl;
+    return;
+  }
+
+  LOG(INFO) << "Dumping map of storages with " << mStorageMap->GetEntries() << " entries!" << FairLogger::endl;
+  LOG(INFO) << "Dumping entriesList with " << mIds->GetEntries() << " entries!" << FairLogger::endl;
+  f->WriteObject(mStorageMap, "cdbStoragesMap");
+  f->WriteObject(mIds, "CDBidsList");
+
+  f->Close();
+  delete f;
+}
+
+Bool_t Manager::initFromSnapshot(const char* snapshotFileName, Bool_t overwrite)
+{
+  // initialize manager from a CDB snapshot, that is add the entries
+  // to the entries map and the ids to the ids list taking them from
+  // the map and the list found in the input file
+
+  // if the manager is locked it cannot initialize from a snapshot
+  if (mLock) {
+    LOG(ERROR) << "Being locked I cannot initialize from the snapshot!" << FairLogger::endl;
+    return kFALSE;
+  }
+
+  // open the file
+  TString snapshotFile(snapshotFileName);
+  if (snapshotFile.BeginsWith("alien://")) {
+    if (!gGrid) {
+      TGrid::Connect("alien://", "");
+      if (!gGrid) {
+        LOG(ERROR) << "Connection to alien failed!" << FairLogger::endl;
+        return kFALSE;
+      }
+    }
+  }
+
+  TFile* f = TFile::Open(snapshotFileName);
+  if (!f || f->IsZombie()) {
+    LOG(ERROR) << "Cannot open file " << snapshotFileName << FairLogger::endl;
+    return kFALSE;
+  }
+
+  // retrieve entries' map from snapshot file
+  TMap* entriesMap = 0;
+  TIter next(f->GetListOfKeys());
+  TKey* key;
+  while ((key = (TKey*)next())) {
+    if (strcmp(key->GetClassName(), "TMap") != 0)
+      continue;
+    entriesMap = (TMap*)key->ReadObj();
+    break;
+  }
+  if (!entriesMap || entriesMap->GetEntries() == 0) {
+    LOG(ERROR) << "Cannot get valid map of CDB entries from snapshot file" << FairLogger::endl;
+    return kFALSE;
+  }
+
+  // retrieve ids' list from snapshot file
+  TList* idsList = 0;
+  TIter nextKey(f->GetListOfKeys());
+  TKey* keyN;
+  while ((keyN = (TKey*)nextKey())) {
+    if (strcmp(keyN->GetClassName(), "TList") != 0)
+      continue;
+    idsList = (TList*)keyN->ReadObj();
+    break;
+  }
+  if (!idsList || idsList->GetEntries() == 0) {
+    LOG(ERROR) << "Cannot get valid list of CDB entries from snapshot file" << FairLogger::endl;
+    return kFALSE;
+  }
+
+  // Add each (entry,id) from the snapshot to the memory: entry to the cache, id to the list of ids.
+  // If "overwrite" is false: add the entry to the cache and its id to the list of ids
+  // only if neither of them is already there.
+  // If "overwrite" is true: write the snapshot entry,id in any case. If something
+  // was already there for that calibration type, remove it and issue a warning
+  TIter iterObj(entriesMap->GetTable());
+  TPair* pair = 0;
+  Int_t nAdded = 0;
+  while ((pair = dynamic_cast<TPair*>(iterObj.Next()))) {
+    TObjString* os = (TObjString*)pair->Key();
+    TString path = os->GetString();
+    TIter iterId(idsList);
+    ConditionId* id = 0;
+    ConditionId* correspondingId = 0;
+    while ((id = dynamic_cast<ConditionId*>(iterId.Next()))) {
+      TString idpath(id->getPathString());
+      if (idpath == path) {
+        correspondingId = id;
+        break;
+      }
+    }
+    if (!correspondingId) {
+      LOG(ERROR) << "id for \"" << path.Data()
+                 << "\" not found in the snapshot (while entry was). This entry is skipped!" << FairLogger::endl;
+      break;
+    }
+    Bool_t cached = mConditionCache.Contains(path.Data());
+    Bool_t registeredId = kFALSE;
+    TIter iter(mIds);
+    ConditionId* idT = 0;
+    while ((idT = dynamic_cast<ConditionId*>(iter.Next()))) {
+      if (idT->getPathString() == path) {
+        registeredId = kTRUE;
+        break;
+      }
+    }
+
+    if (overwrite) {
+      if (cached || registeredId) {
+        LOG(WARNING) << "An entry was already cached for \"" << path.Data()
+                     << "\". Removing it before caching from snapshot" << FairLogger::endl;
+        unloadFromCache(path.Data());
+      }
+      mConditionCache.Add(pair->Key(), pair->Value());
+      mIds->Add(id);
+      nAdded++;
+    } else {
+      if (cached || registeredId) {
+        LOG(WARNING) << "An entry was already cached for \"" << path.Data()
+                     << "\". Not adding this object from snapshot" << FairLogger::endl;
+      } else {
+        mConditionCache.Add(pair->Key(), pair->Value());
+        mIds->Add(id);
+        nAdded++;
+      }
+    }
+  }
+
+  // mCondition is the new owner of the cache
+  mConditionCache.SetOwnerKeyValue(kTRUE, kTRUE);
+  entriesMap->SetOwnerKeyValue(kFALSE, kFALSE);
+  mIds->SetOwner(kTRUE);
+  idsList->SetOwner(kFALSE);
+  LOG(INFO) << nAdded << " new (entry,id) cached. Total number " << mConditionCache.GetEntries() << FairLogger::endl;
+
+  f->Close();
+  delete f;
+
+  return kTRUE;
+}
+
+void Manager::destroy()
+{
+  // delete ALCDBManager instance and active storages
+
+  if (sInstance) {
+    delete sInstance;
+    sInstance = 0x0;
+  }
+}
+
+Manager::Manager()
+  : TObject(),
+    mFactories(),
+    mActiveStorages(),
+    mSpecificStorages(),
+    mConditionCache(),
+    mIds(0),
+    mStorageMap(0),
+    mDefaultStorage(NULL),
+    mdrainStorage(NULL),
+    mOfficialStorageParameters(0),
+    mReferenceStorageParameters(0),
+    mRun(-1),
+    mCache(kTRUE),
+    mLock(kFALSE),
+    mSnapshotMode(kFALSE),
+    mSnapshotFile(0),
+    mOcdbUploadMode(kFALSE),
+    mRaw(kFALSE),
+    mCvmfsOcdb(""),
+    mStartRunLhcPeriod(-1),
+    mEndRunLhcPeriod(-1),
+    mLhcPeriod(""),
+    mKey(0)
+{
+  // default constuctor
+  mFactories.SetOwner(1);
+  mActiveStorages.SetOwner(1);
+  mSpecificStorages.SetOwner(1);
+  mConditionCache.SetName("CDBConditionCache");
+  mConditionCache.SetOwnerKeyValue(kTRUE, kTRUE);
+
+  mStorageMap = new TMap();
+  mStorageMap->SetOwner(1);
+  mIds = new TList();
+  mIds->SetOwner(1);
+}
+
+Manager::~Manager()
+{
+  // destructor
+  clearCache();
+  destroyActiveStorages();
+  mFactories.Delete();
+  mdrainStorage = 0x0;
+  mDefaultStorage = 0x0;
+  delete mStorageMap;
+  mStorageMap = 0;
+  delete mIds;
+  mIds = 0;
+  delete mOfficialStorageParameters;
+  delete mReferenceStorageParameters;
+  if (mSnapshotMode) {
+    mSnapshotFile->Close();
+    mSnapshotFile = 0;
+  }
+}
+
+void Manager::putActiveStorage(StorageParameters* param, Storage* storage)
+{
+  // put a storage object into the list of active storages
+
+  mActiveStorages.Add(param, storage);
+  LOG(DEBUG) << "Active storages: " << mActiveStorages.GetEntries() << FairLogger::endl;
+}
+
+void Manager::registerFactory(StorageFactory* factory)
+{
+  // add a storage factory to the list of registerd factories
+
+  if (!mFactories.Contains(factory)) {
+    mFactories.Add(factory);
+  }
+}
+
+Bool_t Manager::hasStorage(const char* dbString) const
+{
+  // check if dbString is a URI valid for one of the registered factories
+
+  TIter iter(&mFactories);
+
+  StorageFactory* factory = 0;
+  while ((factory = (StorageFactory*)iter.Next())) {
+
+    if (factory->validateStorageUri(dbString)) {
+      return kTRUE;
+    }
+  }
+
+  return kFALSE;
+}
+
+StorageParameters* Manager::createStorageParameter(const char* dbString) const
+{
+  // create  StorageParameters object from URI string
+
+  TString uriString(dbString);
+
+  if (!mCvmfsOcdb.IsNull() && uriString.BeginsWith("alien://")) {
+    alienToCvmfsUri(uriString);
+  }
+
+  TIter iter(&mFactories);
+
+  StorageFactory* factory = 0;
+  while ((factory = (StorageFactory*)iter.Next())) {
+    StorageParameters* param = factory->createStorageParameter(uriString);
+    if (param)
+      return param;
+  }
+
+  return NULL;
+}
+
+void Manager::alienToCvmfsUri(TString& uriString) const
+{
+  // convert alien storage uri to local:///cvmfs storage uri (called when OCDB_PATH is set)
+
+  TObjArray* arr = uriString.Tokenize('?');
+  TIter iter(arr);
+  TObjString* str = 0;
+  TString entryKey = "";
+  TString entryValue = "";
+  TString newUriString = "";
+  while ((str = (TObjString*)iter.Next())) {
+    TString entry(str->String());
+    Int_t indeq = entry.Index('=');
+    entryKey = entry(0, indeq + 1);
+    entryValue = entry(indeq + 1, entry.Length() - indeq);
+
+    if (entryKey.Contains("folder", TString::kIgnoreCase)) {
+
+      TRegexp re_RawFolder("^/alice/data/20[0-9]+/OCDB");
+      TRegexp re_MCFolder("^/alice/simulation/2008/v4-15-Release");
+      TString rawFolder = entryValue(re_RawFolder);
+      TString mcFolder = entryValue(re_MCFolder);
+      if (!rawFolder.IsNull()) {
+        entryValue.Replace(0, 6, "/cvmfs/alice-ocdb.cern.ch/calibration");
+        // entryValue.Replace(entryValue.Length()-4, entryValue.Length(), "");
+      } else if (!mcFolder.IsNull()) {
+        entryValue.Replace(0, 36, "/cvmfs/alice-ocdb.cern.ch/calibration/MC");
+      } else {
+        LOG(FATAL) << "Environment variable for cvmfs OCDB folder set for an invalid OCDB storage:\n   "
+                   << entryValue.Data() << FairLogger::endl;
+      }
+    } else {
+      newUriString += entryKey;
+    }
+    newUriString += entryValue;
+    newUriString += '?';
+  }
+  newUriString.Prepend("local://");
+  newUriString.Remove(TString::kTrailing, '?');
+  uriString = newUriString;
+}
+
+Storage* Manager::getStorage(const char* dbString)
+{
+  // Get the CDB storage corresponding to the URI string passed as argument
+  // If "raw://" is passed, get the storage for the raw OCDB for the current run (mRun)
+
+  TString uriString(dbString);
+  if (uriString.EqualTo("raw://")) {
+    if (!mLhcPeriod.IsNull() && !mLhcPeriod.IsWhitespace()) {
+      return getDefaultStorage();
+    } else {
+      TString lhcPeriod("");
+      Int_t startRun = -1, endRun = -1;
+      getLHCPeriodAgainstAlienFile(mRun, lhcPeriod, startRun, endRun);
+      return getStorage(lhcPeriod.Data());
+    }
+  }
+
+  StorageParameters* param = createStorageParameter(dbString);
+  if (!param) {
+    LOG(ERROR) << "Failed to activate requested storage! Check URI: " << dbString << FairLogger::endl;
+    return NULL;
+  }
+
+  Storage* aStorage = getStorage(param);
+
+  delete param;
+  return aStorage;
+}
+
+Storage* Manager::getStorage(const StorageParameters* param)
+{
+  // get storage object from  StorageParameters object
+
+  // if the list of active storages already contains
+  // the requested storage, return it
+  Storage* aStorage = getActiveStorage(param);
+  if (aStorage) {
+    return aStorage;
+  }
+
+  // if lock is ON, cannot activate more storages!
+  if (mLock) {
+    if (mDefaultStorage) {
+      LOG(FATAL) << "Lock is ON, and default storage is already set: cannot reset it or activate "
+                    "more storages!" << FairLogger::endl;
+    }
+  }
+
+  // loop on the list of registered factories
+  TIter iter(&mFactories);
+  StorageFactory* factory = 0;
+  while ((factory = (StorageFactory*)iter.Next())) {
+
+    // each factory tries to create its storage from the parameter
+    aStorage = factory->createStorage(param);
+    if (aStorage) {
+      putActiveStorage(param->cloneParam(), aStorage);
+      aStorage->setUri(param->getUri());
+      if (mRun >= 0) {
+        if (aStorage->getStorageType() == "alien" || aStorage->getStorageType() == "local")
+          aStorage->queryStorages(mRun);
+      }
+      return aStorage;
+    }
+  }
+
+  LOG(ERROR) << "Failed to activate requested storage! Check URI: " << param->getUri().Data() << FairLogger::endl;
+
+  return NULL;
+}
+
+Storage* Manager::getActiveStorage(const StorageParameters* param)
+{
+  // get a storage object from the list of active storages
+
+  return dynamic_cast<Storage*>(mActiveStorages.GetValue(param));
+}
+
+TList* Manager::getActiveStorages()
+{
+  // return list of active storages
+  // user has responsibility to delete returned object
+
+  TList* result = new TList();
+
+  TIter iter(mActiveStorages.GetTable());
+  TPair* aPair = 0;
+  while ((aPair = (TPair*)iter.Next())) {
+    result->Add(aPair->Value());
+  }
+
+  return result;
+}
+
+void Manager::setdrainMode(const char* dbString)
+{
+  // set drain storage from URI string
+
+  mdrainStorage = getStorage(dbString);
+}
+
+void Manager::setdrainMode(const StorageParameters* param)
+{
+  // set drain storage from  StorageParameters
+
+  mdrainStorage = getStorage(param);
+}
+
+void Manager::setdrainMode(Storage* storage)
+{
+  // set drain storage from another active storage
+
+  mdrainStorage = storage;
+}
+
+Bool_t Manager::drain(Condition* entry)
+{
+  // drain retrieved object to drain storage
+
+  LOG(DEBUG) << "draining into drain storage..." << FairLogger::endl;
+  return mdrainStorage->putObject(entry);
+}
+
+Bool_t Manager::setOcdbUploadMode()
+{
+  // Set the framework in official upload mode. This tells the framework to upload
+  // objects to cvmfs after they have been uploaded to AliEn OCDBs.
+  // It return false if the executable to upload to cvmfs is not found.
+
+  TString cvmfsUploadExecutable("$HOME/bin/ocdb-cvmfs");
+  gSystem->ExpandPathName(cvmfsUploadExecutable);
+  if (gSystem->AccessPathName(cvmfsUploadExecutable))
+    return kFALSE;
+  mOcdbUploadMode = kTRUE;
+  return kTRUE;
+}
+
+void Manager::setDefaultStorage(const char* storageUri)
+{
+  // sets default storage from URI string
+
+  // if in the cvmfs case (triggered by environment variable) check for path validity
+  // and modify Uri if it is "raw://"
+  TString cvmfsOcdb(gSystem->Getenv("OCDB_PATH"));
+  if (!cvmfsOcdb.IsNull()) {
+    mCvmfsOcdb = cvmfsOcdb;
+    validateCvmfsCase();
+  }
+
+  // checking whether we are in the raw case
+  TString uriTemp(storageUri);
+  if (uriTemp == "raw://") {
+    mRaw = kTRUE; // read then by setRun to check if the method has to be called again with expanded uri
+    LOG(INFO) << "Setting the run-number will set the corresponding OCDB for raw data reconstruction."
+              << FairLogger::endl;
+    return;
+  }
+
+  Storage* bckStorage = mDefaultStorage;
+
+  mDefaultStorage = getStorage(storageUri);
+
+  if (!mDefaultStorage)
+    return;
+
+  if (bckStorage && (mDefaultStorage != bckStorage)) {
+    LOG(WARNING) << "Existing default storage replaced: clearing cache!" << FairLogger::endl;
+    clearCache();
+  }
+
+  if (mStorageMap->Contains("default")) {
+    delete mStorageMap->Remove(((TPair*)mStorageMap->FindObject("default"))->Key());
+  }
+  mStorageMap->Add(new TObjString("default"), new TObjString(mDefaultStorage->getUri()));
+}
+
+void Manager::setDefaultStorage(const StorageParameters* param)
+{
+  // set default storage from  StorageParameters object
+
+  Storage* bckStorage = mDefaultStorage;
+
+  mDefaultStorage = getStorage(param);
+
+  if (!mDefaultStorage)
+    return;
+
+  if (bckStorage && (mDefaultStorage != bckStorage)) {
+    LOG(WARNING) << "Existing default storage replaced: clearing cache!" << FairLogger::endl;
+    clearCache();
+  }
+
+  if (mStorageMap->Contains("default")) {
+    delete mStorageMap->Remove(((TPair*)mStorageMap->FindObject("default"))->Key());
+  }
+  mStorageMap->Add(new TObjString("default"), new TObjString(mDefaultStorage->getUri()));
+}
+
+void Manager::setDefaultStorage(Storage* storage)
+{
+  // set default storage from another active storage
+
+  // if lock is ON, cannot activate more storages!
+  if (mLock) {
+    if (mDefaultStorage) {
+      LOG(FATAL) << "Lock is ON, and default storage is already set: cannot reset it or activate "
+                    "more storages!" << FairLogger::endl;
+    }
+  }
+
+  if (!storage) {
+    unsetDefaultStorage();
+    return;
+  }
+
+  Storage* bckStorage = mDefaultStorage;
+
+  mDefaultStorage = storage;
+
+  if (bckStorage && (mDefaultStorage != bckStorage)) {
+    LOG(WARNING) << "Existing default storage replaced: clearing cache!" << FairLogger::endl;
+    clearCache();
+  }
+
+  if (mStorageMap->Contains("default")) {
+    delete mStorageMap->Remove(((TPair*)mStorageMap->FindObject("default"))->Key());
+  }
+  mStorageMap->Add(new TObjString("default"), new TObjString(mDefaultStorage->getUri()));
+}
+
+void Manager::validateCvmfsCase() const
+{
+  // The OCDB_PATH variable contains the path to the directory in /cvmfs/ which is
+  // an AliRoot tag based snapshot of the AliEn file catalogue (e.g.
+  // /cvmfs/alice.cern.ch/x86_64-2.6-gnu-4.1.2/Packages/OCDB/v5-05-76-AN).
+  // The directory has to contain:
+  // 1) <data|MC>/20??.list.gz gzipped text files listing the OCDB files (seen by that AliRoot tag)
+  // 2) bin/getOCDBFilesPerRun.sh   (shell+awk) script extracting from 1) the list
+  //    of valid files for the given run.
+
+  if (!mCvmfsOcdb.BeginsWith("/cvmfs")) //!!!! to be commented out for testing
+    LOG(FATAL) << "OCDB_PATH set to an invalid path: " << mCvmfsOcdb.Data() << FairLogger::endl;
+
+  TString cvmfsUri(mCvmfsOcdb);
+  gSystem->ExpandPathName(cvmfsUri);
+  if (gSystem->AccessPathName(cvmfsUri))
+    LOG(FATAL) << "OCDB_PATH set to an invalid path: " << cvmfsUri.Data() << FairLogger::endl;
+
+  // check that we find the two scripts we need
+
+  LOG(DEBUG) << "OCDB_PATH envvar is set. Changing OCDB storage from alien:// to local:///cvmfs type."
+             << FairLogger::endl;
+  cvmfsUri = cvmfsUri.Strip(TString::kTrailing, '/');
+  cvmfsUri.Append("/bin/getOCDBFilesPerRun.sh");
+  if (gSystem->AccessPathName(cvmfsUri))
+    LOG(FATAL) << "Cannot find valid script: " << cvmfsUri.Data() << FairLogger::endl;
+}
+
+void Manager::setDefaultStorageFromRun(Int_t run)
+{
+  // set default storage from the run number - to be used only with raw data
+
+  // if lock is ON, cannot activate more storages!
+  if (mLock) {
+    if (mDefaultStorage) {
+      LOG(FATAL) << "Lock is ON, and default storage is already set: cannot activate default "
+                    "storage from run number" << FairLogger::endl;
+    }
+  }
+
+  TString lhcPeriod("");
+  Int_t startRun = 0, endRun = 0;
+  if (!mCvmfsOcdb.IsNull()) { // mRaw and cvmfs case: set LHC period from cvmfs file
+    getLHCPeriodAgainstCvmfsFile(run, lhcPeriod, startRun, endRun);
+  } else { // mRaw: set LHC period from AliEn XML file
+    getLHCPeriodAgainstAlienFile(run, lhcPeriod, startRun, endRun);
+  }
+
+  mLhcPeriod = lhcPeriod;
+  mStartRunLhcPeriod = startRun;
+  mEndRunLhcPeriod = endRun;
+
+  setDefaultStorage(mLhcPeriod.Data());
+  if (!mDefaultStorage)
+    LOG(FATAL) << mLhcPeriod.Data() << " storage not there! Please check!" << FairLogger::endl;
+}
+
+void Manager::getLHCPeriodAgainstAlienFile(Int_t run, TString& lhcPeriod, Int_t& startRun, Int_t& endRun)
+{
+  // set LHC period (year + first, last run) comparing run number and AliEn XML file
+
+  // retrieve XML file from alien
+  if (!gGrid) {
+    TGrid::Connect("alien://", "");
+    if (!gGrid) {
+      LOG(ERROR) << "Connection to alien failed!" << FairLogger::endl;
+      return;
+    }
+  }
+  TUUID uuid;
+  TString rndname = "/tmp/";
+  rndname += "OCDBFolderXML.";
+  rndname += uuid.AsString();
+  rndname += ".xml";
+  LOG(DEBUG) << "file to be copied = " << sOcdbFolderXmlFile.Data() << FairLogger::endl;
+  if (!TFile::Cp(sOcdbFolderXmlFile.Data(), rndname.Data())) {
+    LOG(FATAL) << "Cannot make a local copy of OCDBFolder xml file in " << rndname.Data() << FairLogger::endl;
+  }
+  XmlHandler* saxcdb = new XmlHandler();
+  saxcdb->setRun(run);
+  TSAXParser* saxParser = new TSAXParser();
+  saxParser->ConnectToHandler(" Handler", saxcdb);
+  saxParser->ParseFile(rndname.Data());
+  LOG(INFO) << " LHC folder = " << saxcdb->getOcdbFolder().Data() << FairLogger::endl;
+  LOG(INFO) << " LHC period start run = " << saxcdb->getStartIdRunRange() << FairLogger::endl;
+  LOG(INFO) << " LHC period end run = " << saxcdb->getEndIdRunRange() << FairLogger::endl;
+  lhcPeriod = saxcdb->getOcdbFolder();
+  startRun = saxcdb->getStartIdRunRange();
+  endRun = saxcdb->getEndIdRunRange();
+}
+
+void Manager::getLHCPeriodAgainstCvmfsFile(Int_t run, TString& lhcPeriod, Int_t& startRun, Int_t& endRun)
+{
+  // set LHC period (year + first, last run) comparing run number and CVMFS file
+  // We don't want to connect to AliEn just to set the uri from the runnumber
+  // for that we use the script getUriFromYear.sh in the cvmfs AliRoot package
+
+  TString getYearScript(mCvmfsOcdb);
+  getYearScript = getYearScript.Strip(TString::kTrailing, '/');
+  getYearScript.Append("/bin/getUriFromYear.sh");
+  if (gSystem->AccessPathName(getYearScript))
+    LOG(FATAL) << "Cannot find valid script: " << getYearScript.Data() << FairLogger::endl;
+  TString inoutFile(gSystem->WorkingDirectory());
+  inoutFile += "/uri_range_";
+  inoutFile += TString::Itoa(run, 10);
+  TString command(getYearScript);
+  command += ' ';
+  command += TString::Itoa(run, 10);
+  command += Form(" > %s", inoutFile.Data());
+  LOG(DEBUG) << "Running command: \"" << command.Data() << "\"" << FairLogger::endl;
+  Int_t result = gSystem->Exec(command.Data());
+  if (result != 0) {
+    LOG(FATAL) << "Was not able to execute \"" << command.Data() << "\"" << FairLogger::endl;
+  }
+
+  // now read the file with the uri and first and last run
+  std::ifstream file(inoutFile.Data());
+  if (!file.is_open()) {
+    LOG(FATAL) << "Error opening file \"" << inoutFile.Data() << "\"!" << FairLogger::endl;
+  }
+  TString line;
+  TObjArray* oStringsArray = 0;
+  while (line.ReadLine(file)) {
+    oStringsArray = line.Tokenize(' ');
+  }
+  TObjString* oStrUri = dynamic_cast<TObjString*>(oStringsArray->At(0));
+  TObjString* oStrFirst = dynamic_cast<TObjString*>(oStringsArray->At(1));
+  TString firstRun = oStrFirst->GetString();
+  TObjString* oStrLast = dynamic_cast<TObjString*>(oStringsArray->At(2));
+  TString lastRun = oStrLast->GetString();
+
+  lhcPeriod = oStrUri->GetString();
+  startRun = firstRun.Atoi();
+  endRun = lastRun.Atoi();
+
+  file.close();
+}
+
+void Manager::unsetDefaultStorage()
+{
+  // Unset default storage
+
+  // if lock is ON, action is forbidden!
+  if (mLock) {
+    if (mDefaultStorage) {
+      LOG(FATAL) << "Lock is ON: cannot unset default storage!" << FairLogger::endl;
+    }
+  }
+
+  if (mDefaultStorage) {
+    LOG(WARNING) << "Clearing cache!" << FairLogger::endl;
+    clearCache();
+  }
+
+  mRun = mStartRunLhcPeriod = mEndRunLhcPeriod = -1;
+  mRaw = kFALSE;
+
+  mDefaultStorage = 0x0;
+}
+
+void Manager::setSpecificStorage(const char* calibType, const char* dbString, Int_t version, Int_t subVersion)
+{
+  // sets storage specific for detector or calibration type (works with  Manager::getObject(...))
+
+  StorageParameters* aPar = createStorageParameter(dbString);
+  if (!aPar)
+    return;
+  setSpecificStorage(calibType, aPar, version, subVersion);
+  delete aPar;
+}
+
+void Manager::setSpecificStorage(const char* calibType, const StorageParameters* param, Int_t version, Int_t subVersion)
+{
+  // sets storage specific for detector or calibration type (works with  Manager::getObject(...))
+  // Default storage should be defined prior to any specific storages, e.g.:
+  //  Manager::instance()->setDefaultStorage("alien://");
+  //  Manager::instance()->setSpecificStorage("TPC/*","local://DB_TPC");
+  //  Manager::instance()->setSpecificStorage("*/Align/*","local://DB_TPCAlign");
+  // calibType must be a valid CDB path! (3 level folder structure)
+  // Specific version/subversion is set in the uniqueid of the Param value stored in the
+  // specific storages map
+
+  if (!mDefaultStorage && !mRaw) {
+    LOG(ERROR) << "Please activate a default storage first!" << FairLogger::endl;
+    return;
+  }
+
+  IdPath aPath(calibType);
+  if (!aPath.isValid()) {
+    LOG(ERROR) << "Not a valid path: " << calibType << FairLogger::endl;
+    return;
+  }
+
+  TObjString* objCalibType = new TObjString(aPath.getPathString());
+  if (mSpecificStorages.Contains(objCalibType)) {
+    LOG(WARNING) << "Storage \"" << calibType << "\" already activated! It will be replaced by the new one"
+                 << FairLogger::endl;
+    StorageParameters* checkPar = dynamic_cast<StorageParameters*>(mSpecificStorages.GetValue(calibType));
+    if (checkPar)
+      delete checkPar;
+    delete mSpecificStorages.Remove(objCalibType);
+  }
+  Storage* aStorage = getStorage(param);
+  if (!aStorage)
+    return;
+
+  // Set the unique id of the AliCDBParam stored in the map to store specific version/subversion
+  UInt_t uId = ((subVersion+1)<<16) + (version+1);
+  StorageParameters *specificParam = param->cloneParam();
+  specificParam->SetUniqueID(uId);
+  mSpecificStorages.Add(objCalibType, specificParam);
+
+  if (mStorageMap->Contains(objCalibType)) {
+    delete mStorageMap->Remove(objCalibType);
+  }
+  mStorageMap->Add(objCalibType->Clone(), new TObjString(param->getUri()));
+}
+
+Storage* Manager::getSpecificStorage(const char* calibType)
+{
+  // get storage specific for detector or calibration type
+
+  IdPath calibPath(calibType);
+  if (!calibPath.isValid())
+    return NULL;
+
+  StorageParameters* checkPar = (StorageParameters*)mSpecificStorages.GetValue(calibPath.getPathString());
+  if (!checkPar) {
+    LOG(ERROR) << calibType << " storage not found!" << FairLogger::endl;
+    return NULL;
+  } else {
+    return getStorage(checkPar);
+  }
+}
+
+StorageParameters* Manager::selectSpecificStorage(const TString& path)
+{
+  // select storage valid for path from the list of specific storages
+
+  IdPath aPath(path);
+  if (!aPath.isValid())
+    return NULL;
+
+  TIter iter(&mSpecificStorages);
+  TObjString* aCalibType = 0;
+  IdPath tmpPath("null/null/null");
+  StorageParameters* aPar = 0;
+  while ((aCalibType = (TObjString*)iter.Next())) {
+    IdPath calibTypePath(aCalibType->GetName());
+    if (calibTypePath.isSupersetOf(aPath)) {
+      if (calibTypePath.isSupersetOf(tmpPath))
+        continue;
+      aPar = (StorageParameters*)mSpecificStorages.GetValue(aCalibType);
+      tmpPath.setPath(calibTypePath.getPathString());
+    }
+  }
+  return aPar;
+}
+
+Condition* Manager::getObject(const IdPath& path, Int_t runNumber, Int_t version, Int_t subVersion)
+{
+  // get an  Condition object from the database
+
+  if (runNumber < 0) {
+    // RunNumber is not specified. Try with mRun
+    if (mRun < 0) {
+      LOG(ERROR) << "Run number neither specified in query nor set in  Manager! Use  Manager::setRun."
+                 << FairLogger::endl;
+      return NULL;
+    }
+    runNumber = mRun;
+  }
+
+  return getObject(ConditionId(path, runNumber, runNumber, version, subVersion));
+}
+
+Condition* Manager::getObject(const IdPath& path, const IdRunRange& runRange, Int_t version, Int_t subVersion)
+{
+  // get an  Condition object from the database!
+
+  return getObject(ConditionId(path, runRange, version, subVersion));
+}
+
+Condition* Manager::getObject(const ConditionId& queryId, Bool_t forceCaching)
+{
+  // get an  Condition object from the database
+
+  // check if queryId's path and runRange are valid
+  // queryId is invalid also if version is not specified and subversion is!
+  if (!queryId.isValid()) {
+    LOG(ERROR) << "Invalid query: " << queryId.ToString().Data() << FairLogger::endl;
+    return NULL;
+  }
+
+  // query is not specified if path contains wildcard or run range= [-1,-1]
+  if (!queryId.isSpecified()) {
+    LOG(ERROR) << "Unspecified query: " << queryId.ToString().Data() << FairLogger::endl;
+    return NULL;
+  }
+
+  if (mLock && !(mRun >= queryId.getFirstRun() && mRun <= queryId.getLastRun()))
+    LOG(FATAL) << "Lock is ON: cannot use different run number than the internal one!" << FairLogger::endl;
+
+  if (mCache && !(mRun >= queryId.getFirstRun() && mRun <= queryId.getLastRun()))
+    LOG(WARNING) << "Run number explicitly set in query: CDB cache temporarily disabled!" << FairLogger::endl;
+
+  Condition* entry = 0;
+
+  // first look into map of cached objects
+  if (mCache && queryId.getFirstRun() == mRun)
+    entry = (Condition*)mConditionCache.GetValue(queryId.getPathString());
+  if (entry) {
+    LOG(DEBUG) << "Object " << queryId.getPathString().Data() << " retrieved from cache !!" << FairLogger::endl;
+    return entry;
+  }
+
+  // if snapshot flag is set, try getting from the snapshot
+  // but in the case a specific storage is specified for this path
+  StorageParameters* aPar = selectSpecificStorage(queryId.getPathString());
+  if (!aPar) {
+    if (mSnapshotMode && queryId.getFirstRun() == mRun) {
+      entry = getConditionFromSnapshot(queryId.getPathString());
+      if (entry) {
+        LOG(INFO) << "Object \"" << queryId.getPathString().Data() << "\" retrieved from the snapshot."
+                  << FairLogger::endl;
+        if (queryId.getFirstRun() == mRun) // no need to check mCache, mSnapshotMode not possible otherwise
+          cacheCondition(queryId.getPathString(), entry);
+
+        if (!mIds->Contains(&entry->getId()))
+          mIds->Add(entry->getId().Clone());
+
+        return entry;
+      }
+    }
+  }
+
+  // Condition is not in cache (and, in case we are in snapshot mode, not in the snapshot either)
+  // => retrieve it from the storage and cache it!!
+  if (!mDefaultStorage) {
+    LOG(ERROR) << "No storage set!" << FairLogger::endl;
+    return NULL;
+  }
+
+  Int_t version = -1, subVersion = -1;
+  Storage* aStorage = 0;
+  if (aPar) {
+    aStorage = getStorage(aPar);
+    TString str = aPar->getUri();
+    UInt_t uId = aPar->GetUniqueID();
+    version = Int_t(uId&0xffff) - 1;
+    subVersion = Int_t(uId>>16) - 1;
+    LOG(DEBUG) << "Looking into storage: " << str.Data() << FairLogger::endl;
+  } else {
+    aStorage = getDefaultStorage();
+    LOG(DEBUG) << "Looking into default storage" << FairLogger::endl;
+  }
+
+  ConditionId finalQueryId(queryId);
+  if(version >= 0) {
+      LOG(DEBUG) << "Specific version set to: " << version << FairLogger::endl;
+      finalQueryId.setVersion(version);
+    }
+  if(subVersion >= 0) {
+      LOG(DEBUG) << "Specific subversion set to: " << subVersion << FairLogger::endl;
+      finalQueryId.setSubVersion(subVersion);
+    }
+  entry = aStorage->getObject(finalQueryId);
+
+  if (entry && mCache && (queryId.getFirstRun() == mRun || forceCaching)) {
+    cacheCondition(queryId.getPathString(), entry);
+  }
+
+  if (entry && !mIds->Contains(&entry->getId())) {
+    mIds->Add(entry->getId().Clone());
+  }
+
+  return entry;
+}
+
+Condition* Manager::getConditionFromSnapshot(const char* path)
+{
+  // get the entry from the open snapshot file
+
+  TString sPath(path);
+  sPath.ReplaceAll("/", "*");
+  if (!mSnapshotFile) {
+    LOG(ERROR) << "No snapshot file is open!" << FairLogger::endl;
+    return 0;
+  }
+  Condition* entry = dynamic_cast<Condition*>(mSnapshotFile->Get(sPath.Data()));
+  if (!entry) {
+    LOG(DEBUG) << "Cannot get a CDB entry for \"" << path << "\" from snapshot file" << FairLogger::endl;
+    return 0;
+  }
+
+  return entry;
+}
+
+Bool_t Manager::setSnapshotMode(const char* snapshotFileName)
+{
+  // set the manager in snapshot mode
+
+  if (!mCache) {
+    LOG(ERROR) << "Cannot set the CDB manage in snapshot mode if the cache is not active!" << FairLogger::endl;
+    return kFALSE;
+  }
+
+  // open snapshot file
+  TString snapshotFile(snapshotFileName);
+  if (snapshotFile.BeginsWith("alien://")) {
+    if (!gGrid) {
+      TGrid::Connect("alien://", "");
+      if (!gGrid) {
+        LOG(ERROR) << "Connection to alien failed!" << FairLogger::endl;
+        return kFALSE;
+      }
+    }
+  }
+
+  mSnapshotFile = TFile::Open(snapshotFileName);
+  if (!mSnapshotFile || mSnapshotFile->IsZombie()) {
+    LOG(ERROR) << "Cannot open file " << snapshotFileName << FairLogger::endl;
+    return kFALSE;
+  }
+
+  LOG(INFO) << "The CDB manager is set in snapshot mode!" << FairLogger::endl;
+  mSnapshotMode = kTRUE;
+  return kTRUE;
+}
+
+const char* Manager::getUri(const char* path)
+{
+  // return the URI of the storage where to look for path
+
+  if (!isDefaultStorageSet())
+    return 0;
+
+  StorageParameters* aPar = selectSpecificStorage(path);
+
+  if (aPar) {
+    return aPar->getUri().Data();
+
+  } else {
+    return getDefaultStorage()->getUri().Data();
+  }
+
+  return 0;
+}
+
+Int_t Manager::getStartRunLHCPeriod()
+{
+  // get the first run of validity
+  // for the current period
+  // if set
+  if (mStartRunLhcPeriod == -1)
+    LOG(WARNING) << "Run-range not yet set for the current LHC period." << FairLogger::endl;
+  return mStartRunLhcPeriod;
+}
+
+Int_t Manager::getEndRunLHCPeriod()
+{
+  // get the last run of validity
+  // for the current period
+  // if set
+  if (mEndRunLhcPeriod == -1)
+    LOG(WARNING) << "Run-range not yet set for the current LHC period." << FairLogger::endl;
+  return mEndRunLhcPeriod;
+}
+
+TString Manager::getLHCPeriod()
+{
+  // get the current LHC period string
+  //
+  if (mLhcPeriod.IsWhitespace() || mLhcPeriod.IsNull())
+    LOG(WARNING) << "LHC period (OCDB folder) not yet set" << FairLogger::endl;
+  return mLhcPeriod;
+}
+
+ConditionId* Manager::getId(const IdPath& path, Int_t runNumber, Int_t version, Int_t subVersion)
+{
+  // get the ConditionId of the valid object from the database (does not retrieve the object)
+  // User must delete returned object!
+
+  if (runNumber < 0) {
+    // RunNumber is not specified. Try with mRun
+    if (mRun < 0) {
+      LOG(ERROR) << "Run number neither specified in query nor set in  Manager! Use  Manager::setRun."
+                 << FairLogger::endl;
+      return NULL;
+    }
+    runNumber = mRun;
+  }
+
+  return getId(ConditionId(path, runNumber, runNumber, version, subVersion));
+}
+
+ConditionId* Manager::getId(const IdPath& path, const IdRunRange& runRange, Int_t version, Int_t subVersion)
+{
+  // get the ConditionId of the valid object from the database (does not retrieve the object)
+  // User must delete returned object!
+
+  return getId(ConditionId(path, runRange, version, subVersion));
+}
+
+ConditionId* Manager::getId(const ConditionId& query)
+{
+  // get the ConditionId of the valid object from the database (does not retrieve the object)
+  // User must delete returned object!
+
+  if (!mDefaultStorage) {
+    LOG(ERROR) << "No storage set!" << FairLogger::endl;
+    return NULL;
+  }
+
+  // check if query's path and runRange are valid
+  // query is invalid also if version is not specified and subversion is!
+  if (!query.isValid()) {
+    LOG(ERROR) << "Invalid query: " << query.ToString().Data() << FairLogger::endl;
+    return NULL;
+  }
+
+  // query is not specified if path contains wildcard or run range= [-1,-1]
+  if (!query.isSpecified()) {
+    LOG(ERROR) << "Unspecified query: " << query.ToString().Data() << FairLogger::endl;
+    return NULL;
+  }
+
+  if (mCache && query.getFirstRun() != mRun)
+    LOG(WARNING) << "Run number explicitly set in query: CDB cache temporarily disabled!" << FairLogger::endl;
+
+  Condition* entry = 0;
+
+  // first look into map of cached objects
+  if (mCache && query.getFirstRun() == mRun)
+    entry = (Condition*)mConditionCache.GetValue(query.getPathString());
+
+  if (entry) {
+    LOG(DEBUG) << "Object " << query.getPathString().Data() << " retrieved from cache !!" << FairLogger::endl;
+    return dynamic_cast<ConditionId*>(entry->getId().Clone());
+  }
+
+  // Condition is not in cache -> retrieve it from CDB and cache it!!
+  Storage* aStorage = 0;
+  StorageParameters* aPar = selectSpecificStorage(query.getPathString());
+
+  if (aPar) {
+    aStorage = getStorage(aPar);
+    TString str = aPar->getUri();
+    LOG(DEBUG) << "Looking into storage: " << str.Data() << FairLogger::endl;
+
+  } else {
+    aStorage = getDefaultStorage();
+    LOG(DEBUG) << "Looking into default storage" << FairLogger::endl;
+  }
+
+  return aStorage->getId(query);
+}
+
+TList* Manager::getAllObjects(const IdPath& path, Int_t runNumber, Int_t version, Int_t subVersion)
+{
+  // get multiple  Condition objects from the database
+
+  if (runNumber < 0) {
+    // RunNumber is not specified. Try with mRun
+    if (mRun < 0) {
+      LOG(ERROR) << "Run number neither specified in query nor set in  Manager! Use  Manager::setRun."
+                 << FairLogger::endl;
+      return NULL;
+    }
+    runNumber = mRun;
+  }
+
+  return getAllObjects(ConditionId(path, runNumber, runNumber, version, subVersion));
+}
+
+TList* Manager::getAllObjects(const IdPath& path, const IdRunRange& runRange, Int_t version, Int_t subVersion)
+{
+  // get multiple  Condition objects from the database
+
+  return getAllObjects(ConditionId(path, runRange, version, subVersion));
+}
+
+TList* Manager::getAllObjects(const ConditionId& query)
+{
+  // get multiple  Condition objects from the database
+  // Warning: this method works correctly only for queries of the type "Detector/*"
+  // 		and not for more specific queries e.g. "Detector/Calib/*" !
+  // Warning #2: Entries are cached, but getAllObjects will keep on retrieving objects from OCDB!
+  // 		To get an object from cache use getObject() function
+
+  if (!mDefaultStorage) {
+    LOG(ERROR) << "No storage set!" << FairLogger::endl;
+    return NULL;
+  }
+
+  if (!query.isValid()) {
+    LOG(ERROR) << "Invalid query: " << query.ToString().Data() << FairLogger::endl;
+    return NULL;
+  }
+
+  if ((mSpecificStorages.GetEntries() > 0) && query.getPathString().BeginsWith('*')) {
+    // if specific storages are active a query with "*" is ambiguous
+    LOG(ERROR) << "Query too generic in this context!" << FairLogger::endl;
+    return NULL;
+  }
+
+  if (query.isAnyRange()) {
+    LOG(ERROR) << "Unspecified run or runrange: " << query.ToString().Data() << FairLogger::endl;
+    return NULL;
+  }
+
+  if (mLock && query.getFirstRun() != mRun)
+    LOG(FATAL) << "Lock is ON: cannot use different run number than the internal one!" << FairLogger::endl;
+
+  StorageParameters* aPar = selectSpecificStorage(query.getPathString());
+
+  Storage* aStorage;
+  if (aPar) {
+    aStorage = getStorage(aPar);
+    LOG(DEBUG) << "Looking into storage: " << aPar->getUri().Data() << FairLogger::endl;
+
+  } else {
+    aStorage = getDefaultStorage();
+    LOG(DEBUG) << "Looking into default storage: " << aStorage->getUri().Data() << FairLogger::endl;
+  }
+
+  TList* result = 0;
+  if (aStorage)
+    result = aStorage->getAllObjects(query);
+  if (!result)
+    return 0;
+
+  // loop on result to check whether entries should be re-queried with specific storages
+  if (mSpecificStorages.GetEntries() > 0 && !(mSpecificStorages.GetEntries() == 1 && aPar)) {
+    LOG(INFO) << "Now look into all other specific storages..." << FairLogger::endl;
+
+    TIter iter(result);
+    Condition* chkCondition = 0;
+
+    while ((chkCondition = dynamic_cast<Condition*>(iter.Next()))) {
+      ConditionId& chkId = chkCondition->getId();
+      LOG(DEBUG) << "Checking id " << chkId.getPathString().Data() << " " << FairLogger::endl;
+      StorageParameters* chkPar = selectSpecificStorage(chkId.getPathString());
+      if (!chkPar || aPar == chkPar)
+        continue;
+      Storage* chkStorage = getStorage(chkPar);
+      LOG(DEBUG) << "Found specific storage! " << chkPar->getUri().Data() << FairLogger::endl;
+
+      Condition* newCondition = 0;
+      chkId.setIdRunRange(query.getFirstRun(), query.getLastRun());
+      chkId.setVersion(query.getVersion());
+      chkId.setSubVersion(query.getSubVersion());
+
+      if (chkStorage)
+        newCondition = chkStorage->getObject(chkId);
+      if (!newCondition)
+        continue;
+
+      // object is found in specific storage: replace entry in the result list!
+      chkCondition->setOwner(1);
+      delete result->Remove(chkCondition);
+      result->AddFirst(newCondition);
+    }
+
+    Int_t nEntries = result->GetEntries();
+    LOG(INFO) << "After look into other specific storages, result list is:" << FairLogger::endl;
+    for (int i = 0; i < nEntries; i++) {
+      Condition* entry = (Condition*)result->At(i);
+      LOG(INFO) << entry->getId().ToString().Data() << FairLogger::endl;
+    }
+  }
+
+  // caching entries
+  TIter iter(result);
+  Condition* entry = 0;
+  while ((entry = dynamic_cast<Condition*>(iter.Next()))) {
+
+    if (!mIds->Contains(&entry->getId())) {
+      mIds->Add(entry->getId().Clone());
+    }
+    if (mCache && (query.getFirstRun() == mRun)) {
+      cacheCondition(entry->getId().getPathString(), entry);
+    }
+  }
+
+  return result;
+}
+
+Bool_t Manager::putObject(TObject* object, const ConditionId& id, ConditionMetaData* metaData, const char* mirrors)
+{
+  // store an  Condition object into the database
+
+  if (object == 0x0) {
+    LOG(ERROR) << "Null Condition! No storage will be done!" << FairLogger::endl;
+    return kFALSE;
+  }
+
+  Condition anCondition(object, id, metaData);
+  return putObject(&anCondition, mirrors);
+}
+
+Bool_t Manager::putObject(Condition* entry, const char* mirrors)
+{
+  // store an  Condition object into the database
+
+  if (!mDefaultStorage) {
+    LOG(ERROR) << "No storage set!" << FairLogger::endl;
+    return kFALSE;
+  }
+
+  if (!entry) {
+    LOG(ERROR) << "No entry!" << FairLogger::endl;
+    return kFALSE;
+  }
+
+  if (entry->getObject() == 0x0) {
+    LOG(ERROR) << "No valid object in CDB entry!" << FairLogger::endl;
+    return kFALSE;
+  }
+
+  if (!entry->getId().isValid()) {
+    LOG(ERROR) << "Invalid entry ID: " << entry->getId().ToString().Data() << FairLogger::endl;
+    return kFALSE;
+  }
+
+  if (!entry->getId().isSpecified()) {
+    LOG(ERROR) << "Unspecified entry ID: " << entry->getId().ToString().Data() << FairLogger::endl;
+    return kFALSE;
+  }
+
+  ConditionId id = entry->getId();
+  StorageParameters* aPar = selectSpecificStorage(id.getPathString());
+
+  Storage* aStorage = 0;
+
+  if (aPar) {
+    aStorage = getStorage(aPar);
+  } else {
+    aStorage = getDefaultStorage();
+  }
+
+  LOG(DEBUG) << "Storing object into storage: " << aStorage->getUri().Data() << FairLogger::endl;
+
+  TString strMirrors(mirrors);
+  Bool_t result = kFALSE;
+  if (!strMirrors.IsNull() && !strMirrors.IsWhitespace())
+    result = aStorage->putObject(entry, mirrors);
+  else
+    result = aStorage->putObject(entry, "");
+
+  if (mRun >= 0)
+    queryStorages();
+
+  return result;
+}
+
+void Manager::setMirrorSEs(const char* mirrors)
+{
+  // set mirror Storage Elements for the default storage, if it is of type "alien"
+  if (mDefaultStorage->getStorageType() != "alien") {
+    LOG(INFO) << "The default storage is not of type \"alien\". Settings for Storage Elements are "
+                 "not taken into account!" << FairLogger::endl;
+    return;
+  }
+  mDefaultStorage->setMirrorSEs(mirrors);
+}
+
+const char* Manager::getMirrorSEs() const
+{
+  // get mirror Storage Elements for the default storage, if it is of type "alien"
+  if (mDefaultStorage->getStorageType() != "alien") {
+    LOG(INFO) << "The default storage is not of type \"alien\". Settings for Storage Elements are "
+                 "not taken into account!" << FairLogger::endl;
+    return "";
+  }
+  return mDefaultStorage->getMirrorSEs();
+}
+
+void Manager::cacheCondition(const char* path, Condition* entry)
+{
+  // cache  Condition. Cache is valid until run number is changed.
+
+  Condition* chkCondition = dynamic_cast<Condition*>(mConditionCache.GetValue(path));
+
+  if (chkCondition) {
+    LOG(DEBUG) << "Object " << path << " already in cache !!" << FairLogger::endl;
+    return;
+  } else {
+    LOG(DEBUG) << "Caching entry " << path << FairLogger::endl;
+  }
+
+  mConditionCache.Add(new TObjString(path), entry);
+  LOG(DEBUG) << "Cache entries: " << mConditionCache.GetEntries() << FairLogger::endl;
+}
+
+void Manager::print(Option_t* /*option*/) const
+{
+  // Print list of active storages and their URIs
+
+  TString output = Form("Run number = %d; ", mRun);
+  output += "Cache is ";
+  if (!mCache)
+    output += "NOT ";
+  output += Form("ACTIVE; Number of active storages: %d\n", mActiveStorages.GetEntries());
+
+  if (mDefaultStorage) {
+    output += Form("\t*** Default Storage URI: \"%s\"\n", mDefaultStorage->getUri().Data());
+  }
+  if (mSpecificStorages.GetEntries() > 0) {
+    TIter iter(mSpecificStorages.GetTable());
+    TPair* aPair = 0;
+    Int_t i = 1;
+    while ((aPair = (TPair*)iter.Next())) {
+      output += Form("\t*** Specific storage %d: Path \"%s\" -> URI \"%s\"\n", i++,
+                     ((TObjString*)aPair->Key())->GetName(), ((StorageParameters*)aPair->Value())->getUri().Data());
+    }
+  }
+  if (mdrainStorage) {
+    output += Form("*** drain Storage URI: %s\n", mdrainStorage->getUri().Data());
+  }
+  LOG(INFO) << output.Data() << FairLogger::endl;
+}
+
+void Manager::setRun(Int_t run)
+{
+  // Sets current run number.
+  // When the run number changes the caching is cleared.
+
+  if (mRun == run)
+    return;
+
+  if (mLock && mRun >= 0) {
+    LOG(FATAL) << "Lock is ON, cannot reset run number!" << FairLogger::endl;
+  }
+
+  mRun = run;
+
+  if (mRaw) {
+    // here the LHCPeriod xml file is parsed; the string containing the correct period is returned;
+    // the default storage is set
+    if (mStartRunLhcPeriod <= run && mEndRunLhcPeriod >= run) {
+      LOG(INFO) << "LHCPeriod alien folder for current run already in memory" << FairLogger::endl;
+    } else {
+      setDefaultStorageFromRun(mRun);
+      if (mConditionCache.GetEntries() != 0)
+        clearCache();
+      return;
+    }
+  }
+  clearCache();
+  queryStorages();
+}
+
+void Manager::clearCache()
+{
+  // clear  Condition cache
+
+  LOG(DEBUG) << "Cache entries to be deleted: " << mConditionCache.GetEntries() << FairLogger::endl;
+
+  /*
+  // To clean entries one by one
+  TIter iter(mConditionCache.GetTable());
+  TPair* pair=0;
+  while((pair= dynamic_cast<TPair*> (iter.Next()))){
+
+  TObjString* key = dynamic_cast<TObjString*> (pair->Key());
+   Condition* entry = dynamic_cast< Condition*> (pair->Value());
+  LOG(DEBUG) << "Deleting entry: " << key->GetName() << FairLogger::endl;
+  if (entry) delete entry;
+  delete mConditionCache.Remove(key);
+  }
+  */
+  mConditionCache.DeleteAll();
+  LOG(DEBUG) << "After deleting - Cache entries: " << mConditionCache.GetEntries() << FairLogger::endl;
+}
+
+void Manager::unloadFromCache(const char* path)
+{
+  // unload cached object
+  // that is remove the entry from the cache and the id from the list of ids
+  //
+  if (!mActiveStorages.GetEntries()) {
+    LOG(DEBUG) << "No active storages. Object \"" << path << "\" is not unloaded from cache" << FairLogger::endl;
+    return;
+  }
+
+  IdPath queryPath(path);
+  if (!queryPath.isValid())
+    return;
+
+  if (!queryPath.isWildcard()) { // path is not wildcard, get it directly from the cache and unload it!
+    if (mConditionCache.Contains(path)) {
+      LOG(DEBUG) << "Unloading object \"" << path << "\" from cache and from list of ids" << FairLogger::endl;
+      TObjString pathStr(path);
+      delete mConditionCache.Remove(&pathStr);
+      // we do not remove from the list of ConditionId's (it's not very coherent but we leave the
+      // id for the benefit of the userinfo)
+      /*
+         TIter iter(mIds);
+         ConditionId *id = 0;
+         while((id = dynamic_cast<ConditionId*> (iter.Next()))){
+         if(queryPath.isSupersetOf(id->getPath()))
+         delete mIds->Remove(id);
+         }*/
+    } else {
+      LOG(WARNING) << "Cache does not contain object \"" << path << "\"!" << FairLogger::endl;
+    }
+    LOG(DEBUG) << "Cache entries: " << mConditionCache.GetEntries() << FairLogger::endl;
+    return;
+  }
+
+  // path is wildcard: loop on the cache and unload all comprised objects!
+  TIter iter(mConditionCache.GetTable());
+  TPair* pair = 0;
+  Int_t removed = 0;
+
+  while ((pair = dynamic_cast<TPair*>(iter.Next()))) {
+    IdPath entryPath = pair->Key()->GetName();
+    if (queryPath.isSupersetOf(entryPath)) {
+      LOG(DEBUG) << "Unloading object \"" << entryPath.getPathString().Data() << "\" from cache and from list of ids"
+                 << FairLogger::endl;
+      TObjString pathStr(entryPath.getPathString());
+      delete mConditionCache.Remove(&pathStr);
+      removed++;
+
+      // we do not remove from the list of ConditionId's (it's not very coherent but we leave the
+      // id for the benefit of the userinfo)
+      /*
+         TIter iterids(mIds);
+         ConditionId *anId = 0;
+         while((anId = dynamic_cast<ConditionId*> (iterids.Next()))){
+          IdPath aPath = anId->getPath();
+         TString aPathStr = aPath.getPath();
+         if(queryPath.isSupersetOf(aPath)) {
+         delete mIds->Remove(anId);
+         }
+         }*/
+    }
+  }
+  LOG(DEBUG) << "Cache entries and ids removed: " << removed << " Remaining: " << mConditionCache.GetEntries()
+             << FairLogger::endl;
+}
+
+void Manager::destroyActiveStorages()
+{
+  // delete list of active storages
+
+  mActiveStorages.DeleteAll();
+  mSpecificStorages.DeleteAll();
+}
+
+void Manager::destroyActiveStorage(Storage* /*storage*/)
+{
+  // destroys active storage
+
+  /*
+     TIter iter(mActiveStorages.GetTable());
+     TPair* aPair;
+     while ((aPair = (TPair*) iter.Next())) {
+     if(storage == ( Storage*) aPair->Value())
+     delete mActiveStorages.Remove(aPair->Key());
+     storage->Delete(); storage=0x0;
+     }
+     */
+}
+
+void Manager::queryStorages()
+{
+  // query default and specific storages for files valid for mRun. Every storage loads the Ids into
+  // its list.
+
+  if (mRun < 0) {
+    LOG(ERROR) << "Run number not yet set! Use  Manager::setRun." << FairLogger::endl;
+    return;
+  }
+  if (!mDefaultStorage) {
+    LOG(ERROR) << "Default storage is not set! Use  Manager::setDefaultStorage" << FairLogger::endl;
+    return;
+  }
+  if (mDefaultStorage->getStorageType() == "alien" || mDefaultStorage->getStorageType() == "local") {
+    mDefaultStorage->queryStorages(mRun);
+    //} else {
+    //	LOG(DEBUG) << "Skipping query for valid files, it used only in grid..." << FairLogger::endl;
+  }
+
+  TIter iter(&mSpecificStorages);
+  TObjString* aCalibType = 0;
+  StorageParameters* aPar = 0;
+  while ((aCalibType = dynamic_cast<TObjString*>(iter.Next()))) {
+    aPar = (StorageParameters*)mSpecificStorages.GetValue(aCalibType);
+    if (aPar) {
+      LOG(DEBUG) << "Querying specific storage " << aCalibType->GetName() << FairLogger::endl;
+      Storage* aStorage = getStorage(aPar);
+      if (aStorage->getStorageType() == "alien" || aStorage->getStorageType() == "local") {
+        aStorage->queryStorages(mRun, aCalibType->GetName());
+      } else {
+        LOG(DEBUG) << "Skipping query for valid files, it is used only in grid..." << FairLogger::endl;
+      }
+    }
+  }
+}
+
+Bool_t Manager::diffObjects(const char* cdbFile1, const char* cdbFile2) const
+{
+  // Compare byte-by-byte the objects contained in the CDB entry in two different files,
+  // whose name is passed as input
+  // Return value:
+  //   kTRUE - in case the content of the OCDB object (persistent part) is exactly the same
+  //   kFALSE - otherwise
+
+  TString f1Str(cdbFile1);
+  TString f2Str(cdbFile2);
+  if (!gGrid && (f1Str.BeginsWith("alien://") || f2Str.BeginsWith("alien://")))
+    TGrid::Connect("alien://");
+
+  TFile* f1 = TFile::Open(cdbFile1);
+  if (!f1) {
+    Printf("Cannot open file \"%s\"", cdbFile1);
+    return kFALSE;
+  }
+  TFile* f2 = TFile::Open(cdbFile2);
+  if (!f2) {
+    Printf("Cannot open file \"%s\"", cdbFile2);
+    return kFALSE;
+  }
+
+  Condition* entry1 = (Condition*)f1->Get(" Condition");
+  if (!entry1) {
+    Printf("Cannot get CDB entry from file \"%s\"", cdbFile1);
+    return kFALSE;
+  }
+  Condition* entry2 = (Condition*)f2->Get(" Condition");
+  if (!entry2) {
+    Printf("Cannot get CDB entry from file \"%s\"", cdbFile2);
+    return kFALSE;
+  }
+
+  // stream the two objects in the buffer of two TMessages
+  TObject* object1 = entry1->getObject();
+  TObject* object2 = entry2->getObject();
+  TMessage* file1 = new TMessage(TBuffer::kWrite);
+  file1->WriteObject(object1);
+  Int_t size1 = file1->Length();
+  TMessage* file2 = new TMessage(TBuffer::kWrite);
+  file2->WriteObject(object2);
+  Int_t size2 = file2->Length();
+  if (size1 != size2) {
+    Printf("Problem 2:  OCDB entry of different size (%d,%d)", size1, size2);
+    return kFALSE;
+  }
+
+  // if the two buffers have the same size, check that they are the same byte-by-byte
+  Int_t countDiff = 0;
+  char* buf1 = file1->Buffer();
+  char* buf2 = file2->Buffer();
+  // for (Int_t i=0; i<size1; i++)    if (file1->Buffer()[i]!=file2->Buffer()[i]) countDiff++;
+  for (Int_t i = 0; i < size1; i++)
+    if (buf1[i] != buf2[i])
+      countDiff++;
+
+  if (countDiff > 0) {
+    Printf("The CDB objects differ by %d bytes.", countDiff);
+    return kFALSE;
+  }
+
+  Printf("The CDB objects are the same in the two files.");
+  return kTRUE;
+}
+
+ULong64_t Manager::setLock(Bool_t lock, ULong64_t key)
+{
+  // To lock/unlock user must provide the key. A new key is provided after
+  // each successful lock. User should always backup the returned key and
+  // use it on next access.
+  if (mLock == lock)
+    return 0; // nothing to be done
+  if (lock) {
+    // User wants to lock - check his identity
+    if (mKey) {
+      // Lock has a user - check his key
+      if (mKey != key) {
+        LOG(FATAL) << "Wrong key provided to lock CDB. Please remove CDB lock access from your code !"
+                   << FairLogger::endl;
+        return 0;
+      }
+    }
+    // Provide new key
+    mKey = gSystem->Now();
+    mLock = kTRUE;
+    return mKey;
+  }
+  // User wants to unlock - check the provided key
+  if (key != mKey) {
+    LOG(FATAL) << "Lock is ON: wrong key provided" << FairLogger::endl;
+    return 0;
+  }
+  mLock = kFALSE;
+  return key;
+}
+
+void Manager::extractBaseFolder(TString& url)
+{
+  // TBD RS
+  // remove everything but the url -
+  // Exact copy of the AliReconstuction::Rectify.... (to be removed)
+  //
+  //
+  TString sbs;
+  if (!(sbs = url("\\?User=[^?]*")).IsNull())
+    url.ReplaceAll(sbs, "");
+  if (!(sbs = url("\\?DBFolder=[^?]*")).IsNull())
+    url.ReplaceAll("?DB", "");
+  if (!(sbs = url("\\?SE=[^?]*")).IsNull())
+    url.ReplaceAll(sbs, "");
+  if (!(sbs = url("\\?CacheFolder=[^?]*")).IsNull())
+    url.ReplaceAll(sbs, "");
+  if (!(sbs = url("\\?OperateDisconnected=[^?]*")).IsNull())
+    url.ReplaceAll(sbs, "");
+  if (!(sbs = url("\\?CacheSize=[^?]*")).IsNull())
+    url.ReplaceAll(sbs, "");
+  if (!(sbs = url("\\?CleanupInterval=[^?]*")).IsNull())
+    url.ReplaceAll(sbs, "");
+  Bool_t slash = kFALSE, space = kFALSE;
+  while ((slash = url.EndsWith("/")) || (space = url.EndsWith(" "))) {
+    if (slash)
+      url = url.Strip(TString::kTrailing, '/');
+    if (space)
+      url = url.Strip(TString::kTrailing, ' ');
+  }
+  // url.ToLower();
+  //
+}
+
+// interface to specific  Parameter class           //
+// (GridStorageParam,  LocalStorageParam,  DumpParam)  //
+
+StorageParameters::StorageParameters() : mType(), mURI()
+{
+  // constructor
+}
+
+StorageParameters::~StorageParameters()
+{
+  // destructor
+}

--- a/o2cdb/Manager.h
+++ b/o2cdb/Manager.h
@@ -1,0 +1,277 @@
+#ifndef ALICEO2_CDB_MANAGER_H_
+#define ALICEO2_CDB_MANAGER_H_
+
+#include <TObject.h>
+#include <TList.h>
+#include <TMap.h>
+#include <TSystem.h>
+#include <TFile.h>
+
+//  @file   Manager.h
+//  @author Raffaele Grosso
+//  @since  2014-12-02 
+//  @brief  Adapted to AliceO2 from the original AliCDBManager.h in AliRoot
+namespace AliceO2 {
+namespace CDB {
+
+/// @class Manager
+/// Steer retrieval and upload of condition objects from/to
+/// different storages (local, alien, file)
+class Condition;
+class ConditionId;
+class IdPath;
+class IdRunRange;
+class ConditionMetaData;
+class Storage;
+class StorageFactory;
+class StorageParameters;
+
+class Manager : public TObject {
+
+public:
+  void registerFactory(StorageFactory* factory);
+  Bool_t hasStorage(const char* dbString) const;
+  StorageParameters* createStorageParameter(const char* dbString) const;
+  Storage* getStorage(const char* dbString);
+  TList* getActiveStorages();
+  const TMap* getStorageMap() const
+  {
+    return mStorageMap;
+  }
+  const TList* getRetrievedIds() const
+  {
+    return mIds;
+  }
+  void setDefaultStorage(const char* dbString);
+  void setDefaultStorage(const StorageParameters* param);
+  void setDefaultStorage(Storage* storage);
+  void setDefaultStorageFromRun(Int_t run);
+  Bool_t isDefaultStorageSet() const
+  {
+    return mDefaultStorage != 0;
+  }
+  Storage* getDefaultStorage() const
+  {
+    return mDefaultStorage;
+  }
+  void unsetDefaultStorage();
+  void setSpecificStorage(const char* calibType, const char* dbString, Int_t version = -1, Int_t subVersion = -1);
+  Storage* getSpecificStorage(const char* calibType);
+  void setdrainMode(const char* dbString);
+  void setdrainMode(const StorageParameters* param);
+  void setdrainMode(Storage* storage);
+  void unsetdrainMode()
+  {
+    mdrainStorage = 0x0;
+  }
+  Bool_t isdrainSet() const
+  {
+    return mdrainStorage != 0;
+  }
+  Bool_t drain(Condition* entry);
+
+  Bool_t setOcdbUploadMode();
+  void unsetOcdbUploadMode()
+  {
+    mOcdbUploadMode = kFALSE;
+  }
+  Bool_t isOcdbUploadMode() const
+  {
+    return mOcdbUploadMode;
+  }
+  Condition* getObject(const ConditionId& query, Bool_t forceCaching = kFALSE);
+  Condition* getObject(const IdPath& path, Int_t runNumber = -1, Int_t version = -1, Int_t subVersion = -1);
+  Condition* getObject(const IdPath& path, const IdRunRange& runRange, Int_t version = -1, Int_t subVersion = -1);
+  Condition* getConditionFromSnapshot(const char* path);
+  const char* getUri(const char* path);
+  TList* getAllObjects(const ConditionId& query);
+  TList* getAllObjects(const IdPath& path, Int_t runNumber = -1, Int_t version = -1, Int_t subVersion = -1);
+  TList* getAllObjects(const IdPath& path, const IdRunRange& runRange, Int_t version = -1, Int_t subVersion = -1);
+  Bool_t putObject(TObject* object, const ConditionId& id, ConditionMetaData* metaData, const char* mirrors = "");
+  Bool_t putObject(Condition* entry, const char* mirrors = "");
+  void setCacheFlag(Bool_t cacheFlag)
+  {
+    mCache = cacheFlag;
+  }
+  Bool_t getCacheFlag() const
+  {
+    return mCache;
+  }
+  ULong64_t setLock(Bool_t lockFlag = kTRUE, ULong64_t key = 0);
+  Bool_t getLock() const
+  {
+    return mLock;
+  }
+  void setRawFlag(Bool_t rawFlag)
+  {
+    mRaw = rawFlag;
+  }
+  Bool_t getRawFlag() const
+  {
+    return mRaw;
+  }
+  void setRun(Int_t run);
+  Int_t getRun() const
+  {
+    return mRun;
+  }
+  void setMirrorSEs(const char* mirrors);
+  const char* getMirrorSEs() const;
+  void destroyActiveStorages();
+  void destroyActiveStorage(Storage* storage);
+  void queryStorages();
+  void print(Option_t* option = "") const;
+  static void destroy();
+  ~Manager();
+  void clearCache();
+  void unloadFromCache(const char* path);
+  const TMap* getConditionCache() const
+  {
+    return &mConditionCache;
+  }
+  static Manager* Instance(TMap* entryCache = NULL, Int_t run = -1);
+  void init();
+  void initFromCache(TMap* entryCache, Int_t run);
+  Bool_t initFromSnapshot(const char* snapshotFileName, Bool_t overwrite = kTRUE);
+  Bool_t setSnapshotMode(const char* snapshotFileName = "OCDB.root");
+  void unsetSnapshotMode()
+  {
+    mSnapshotMode = kFALSE;
+  }
+  void dumpToSnapshotFile(const char* snapshotFileName, Bool_t singleKeys) const;
+  void dumpToLightSnapshotFile(const char* lightSnapshotFileName) const;
+  Int_t getStartRunLHCPeriod();
+  Int_t getEndRunLHCPeriod();
+  TString getLHCPeriod();
+  TString getCvmfsOcdbTag() const
+  {
+    return mCvmfsOcdb;
+  }
+  Bool_t diffObjects(const char* cdbFile1, const char* cdbFile2) const;
+  void extractBaseFolder(TString& url); // remove everything but the url from OCDB path
+
+protected:
+  static TString sOcdbFolderXmlFile; // alien path of the XML file for OCDB folder <--> Run range correspondance
+
+  Manager();
+  Manager(const Manager& source);
+  Manager& operator=(const Manager& source);
+
+  static Manager* sInstance; // Manager instance
+
+  Storage* getStorage(const StorageParameters* param);
+  Storage* getActiveStorage(const StorageParameters* param);
+  void putActiveStorage(StorageParameters* param, Storage* storage);
+  void setSpecificStorage(const char* calibType, const StorageParameters* param, Int_t version = -1, Int_t subVersion = -1);
+  void alienToCvmfsUri(TString& uriString) const;
+  void validateCvmfsCase() const;
+  void getLHCPeriodAgainstAlienFile(Int_t run, TString& lhcPeriod, Int_t& startRun, Int_t& endRun);
+  void getLHCPeriodAgainstCvmfsFile(Int_t run, TString& lhcPeriod, Int_t& startRun, Int_t& endRun);
+
+  void cacheCondition(const char* path, Condition* entry);
+
+  StorageParameters* selectSpecificStorage(const TString& path);
+
+  ConditionId* getId(const ConditionId& query);
+  ConditionId* getId(const IdPath& path, Int_t runNumber = -1, Int_t version = -1, Int_t subVersion = -1);
+  ConditionId* getId(const IdPath& path, const IdRunRange& runRange, Int_t version = -1, Int_t subVersion = -1);
+
+  TList mFactories;       //! list of registered storage factories
+  TMap mActiveStorages;   //! list of active storages
+  TMap mSpecificStorages; //! list of detector-specific storages
+  TMap mConditionCache;       //! cache of the retrieved objects
+
+  TList* mIds;       //! List of the retrieved object ConditionId's (to be streamed to file)
+  TMap* mStorageMap; //! list of storages (to be streamed to file)
+
+  Storage* mDefaultStorage; //! pointer to default storage
+  Storage* mdrainStorage;   //! pointer to drain storage
+
+  StorageParameters* mOfficialStorageParameters;  // Conditions data storage parameters
+  StorageParameters* mReferenceStorageParameters; // Reference data storage parameters
+
+  Int_t mRun;    //! The run number
+  Bool_t mCache; //! The cache flag
+  Bool_t mLock;  //! Lock flag, if ON default storage and run number cannot be reset
+
+  Bool_t mSnapshotMode; //! flag saying if we are in snapshot mode
+  TFile* mSnapshotFile;
+  Bool_t mOcdbUploadMode; //! flag for uploads to Official CDBs (upload to cvmfs must follow upload
+  // to AliEn)
+
+  Bool_t mRaw;              // flag to say whether we are in the raw case
+  TString mCvmfsOcdb;       // set from $OCDB_PATH, points to a cvmfs AliRoot package
+  Int_t mStartRunLhcPeriod; // 1st run of the LHC period set
+  Int_t mEndRunLhcPeriod;   // last run of the LHC period set
+  TString mLhcPeriod;       // LHC period alien folder
+
+private:
+  ULong64_t mKey; //! Key for locking/unlocking
+
+  ClassDef(Manager, 0)
+};
+
+/////////////////////////////////////////////////////////////////////
+//                                                                 //
+//  class StorageFactory                                     //
+//                                                                 //
+/////////////////////////////////////////////////////////////////////
+
+class StorageParameters;
+class StorageFactory : public TObject {
+  friend class Manager;
+
+public:
+  virtual ~StorageFactory()
+  {
+  }
+  virtual Bool_t validateStorageUri(const char* dbString) = 0;
+  virtual StorageParameters* createStorageParameter(const char* dbString) = 0;
+
+protected:
+  virtual Storage* createStorage(const StorageParameters* param) = 0;
+
+  ClassDef(StorageFactory, 0)
+};
+
+/////////////////////////////////////////////////////////////////////
+//                                                                 //
+// class StorageParameters //
+//                                                                 //
+/////////////////////////////////////////////////////////////////////
+
+class StorageParameters : public TObject {
+
+public:
+  StorageParameters();
+  virtual ~StorageParameters();
+  const TString& getStorageType() const
+  {
+    return mType;
+  };
+  const TString& getUri() const
+  {
+    return mURI;
+  };
+  virtual StorageParameters* cloneParam() const = 0;
+
+protected:
+  void setType(const char* type)
+  {
+    mType = type;
+  };
+  void setUri(const char* uri)
+  {
+    mURI = uri;
+  };
+
+private:
+  TString mType; //! CDB type
+  TString mURI;  //! CDB URI
+
+  ClassDef(StorageParameters, 0)
+};
+
+}
+}
+#endif

--- a/o2cdb/O2CdbLinkDef.h
+++ b/o2cdb/O2CdbLinkDef.h
@@ -1,0 +1,27 @@
+#ifdef __CINT__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class AliceO2::CDB::IdPath+;
+#pragma link C++ class AliceO2::CDB::IdRunRange+;
+#pragma link C++ class AliceO2::CDB::ConditionId+;
+#pragma link C++ class AliceO2::CDB::ConditionMetaData+;
+#pragma link C++ class AliceO2::CDB::Condition+;
+#pragma link C++ class AliceO2::CDB::Storage+;
+#pragma link C++ class AliceO2::CDB::StorageFactory+;
+#pragma link C++ class AliceO2::CDB::Manager+;
+#pragma link C++ class AliceO2::CDB::StorageParameters+;
+#pragma link C++ class AliceO2::CDB::LocalStorage+;
+#pragma link C++ class AliceO2::CDB::LocalStorageFactory+;
+#pragma link C++ class AliceO2::CDB::LocalStorageParameters+;
+#pragma link C++ class AliceO2::CDB::FileStorage+;
+#pragma link C++ class AliceO2::CDB::FileStorageFactory+;
+#pragma link C++ class AliceO2::CDB::FileStorageParameters+;
+#pragma link C++ class AliceO2::CDB::GridStorage+;
+#pragma link C++ class AliceO2::CDB::GridStorageFactory+;
+#pragma link C++ class AliceO2::CDB::GridStorageParameters+;
+#pragma link C++ class AliceO2::CDB::XmlHandler+;
+
+#endif

--- a/o2cdb/Storage.cxx
+++ b/o2cdb/Storage.cxx
@@ -1,0 +1,506 @@
+#include <TKey.h>
+#include <TH1.h>
+#include <TTree.h>
+#include <TNtuple.h>
+#include <TFile.h>
+
+#include <FairLogger.h>
+
+#include "Storage.h"
+#include "GridStorage.h"
+#include "Condition.h"
+
+using namespace AliceO2::CDB;
+
+ClassImp(Storage)
+
+Storage::Storage()
+  : mValidFileIds(),
+    mRun(-1),
+    mPathFilter(),
+    mVersion(-1),
+    mConditionMetaDataFilter(0),
+    mSelections(),
+    mURI(),
+    mType(),
+    mBaseFolder(),
+    mNretry(0),
+    mInitRetrySeconds(0)
+{
+  // constructor
+
+  mValidFileIds.SetOwner(1);
+  mSelections.SetOwner(1);
+}
+
+Storage::~Storage()
+{
+  // destructor
+
+  removeAllSelections();
+  mValidFileIds.Clear();
+  delete mConditionMetaDataFilter;
+}
+
+void Storage::getSelection(/*const*/ ConditionId* id)
+{
+  // return required version and subversion from the list of selection criteria
+
+  TIter iter(&mSelections);
+  ConditionId* aSelection;
+
+  // loop on the list of selection criteria
+  while ((aSelection = (ConditionId*)iter.Next())) {
+    // check if selection element contains id's path and run (range)
+    if (aSelection->isSupersetOf(*id)) {
+      LOG(DEBUG) << "Using selection criterion: " << aSelection->ToString().Data() << " " << FairLogger::endl;
+      // return required version and subversion
+
+      id->setVersion(aSelection->getVersion());
+      id->setSubVersion(aSelection->getSubVersion());
+      return;
+    }
+  }
+
+  // no valid element is found in the list of selection criteria -> return
+  LOG(DEBUG) << "Looking for objects with most recent version" << FairLogger::endl;
+  return;
+}
+
+void Storage::readSelectionFromFile(const char* fileName)
+{
+  // read selection criteria list from file
+
+  removeAllSelections();
+
+  TList* list = getIdListFromFile(fileName);
+  if (!list)
+    return;
+
+  list->SetOwner();
+  Int_t nId = list->GetEntries();
+  ConditionId* id;
+  TKey* key;
+
+  for (int i = nId - 1; i >= 0; i--) {
+    key = (TKey*)list->At(i);
+    id = (ConditionId*)key->ReadObj();
+    if (id)
+      addSelection(*id);
+  }
+  delete list;
+  LOG(INFO) << "Selection criteria list filled with " << mSelections.GetEntries() << " entries" << FairLogger::endl;
+  printSelectionList();
+}
+
+void Storage::addSelection(const ConditionId& selection)
+{
+  // add a selection criterion
+
+  IdPath path = selection.getPath();
+  if (!path.isValid())
+    return;
+
+  TIter iter(&mSelections);
+  const ConditionId* anId;
+  while ((anId = (ConditionId*)iter.Next())) {
+    if (selection.isSupersetOf(*anId)) {
+      LOG(WARNING) << "This selection is more general than a previous one and will hide it!" << FairLogger::endl;
+      LOG(WARNING) << (anId->ToString()).Data() << FairLogger::endl;
+      mSelections.AddBefore(anId, new ConditionId(selection));
+      return;
+    }
+  }
+  mSelections.AddFirst(new ConditionId(selection));
+}
+
+void Storage::addSelection(const IdPath& path, const IdRunRange& runRange, Int_t version, Int_t subVersion)
+{
+  // add a selection criterion
+
+  addSelection(ConditionId(path, runRange, version, subVersion));
+}
+
+void Storage::addSelection(const IdPath& path, Int_t firstRun, Int_t lastRun, Int_t version, Int_t subVersion)
+{
+  // add a selection criterion
+
+  addSelection(ConditionId(path, firstRun, lastRun, version, subVersion));
+}
+
+void Storage::removeSelection(const ConditionId& selection)
+{
+  // remove a selection criterion
+
+  TIter iter(&mSelections);
+  ConditionId* aSelection;
+
+  while ((aSelection = (ConditionId*)iter.Next())) {
+    if (selection.isSupersetOf(*aSelection)) {
+      mSelections.Remove(aSelection);
+    }
+  }
+}
+
+void Storage::removeSelection(const IdPath& path, const IdRunRange& runRange)
+{
+  // remove a selection criterion
+
+  removeSelection(ConditionId(path, runRange, -1, -1));
+}
+
+void Storage::removeSelection(const IdPath& path, Int_t firstRun, Int_t lastRun)
+{
+  // remove a selection criterion
+
+  removeSelection(ConditionId(path, firstRun, lastRun, -1, -1));
+}
+
+void Storage::removeSelection(int position)
+{
+  // remove a selection criterion from its position in the list
+
+  delete mSelections.RemoveAt(position);
+}
+
+void Storage::removeAllSelections()
+{
+  // remove all selection criteria
+
+  mSelections.Clear();
+}
+
+void Storage::printSelectionList()
+{
+  // prints the list of selection criteria
+
+  TIter iter(&mSelections);
+  ConditionId* aSelection;
+
+  // loop on the list of selection criteria
+  int index = 0;
+  while ((aSelection = (ConditionId*)iter.Next())) {
+    LOG(INFO) << "index " << index++ << " -> selection: " << aSelection->ToString().Data() << FairLogger::endl;
+  }
+}
+
+Condition* Storage::getObject(const ConditionId& query)
+{
+  // get an  Condition object from the database
+
+  // check if query's path and runRange are valid
+  // query is invalid also if version is not specified and subversion is!
+  if (!query.isValid()) {
+    LOG(ERROR) << "Invalid query: " << query.ToString().Data() << FairLogger::endl;
+    return NULL;
+  }
+
+  // query is not specified if path contains wildcard or runrange = [-1,-1]
+  if (!query.isSpecified()) {
+    LOG(ERROR) << "Unspecified query: " << query.ToString().Data() << FairLogger::endl;
+    return NULL;
+  }
+
+  // This is needed otherwise TH1  objects (histos, TTree's) are lost when file is closed!
+  Bool_t oldStatus = TH1::AddDirectoryStatus();
+  TH1::AddDirectory(kFALSE);
+
+  Condition* entry = getCondition(query);
+
+  if (oldStatus != kFALSE)
+    TH1::AddDirectory(kTRUE);
+
+  // if drain storage is set, drain entry into drain storage
+  if (entry && (Manager::Instance())->isdrainSet())
+    Manager::Instance()->drain(entry);
+
+  return entry;
+}
+
+Condition* Storage::getObject(const IdPath& path, Int_t runNumber, Int_t version, Int_t subVersion)
+{
+  // get an  Condition object from the database
+
+  return getObject(ConditionId(path, runNumber, runNumber, version, subVersion));
+}
+
+Condition* Storage::getObject(const IdPath& path, const IdRunRange& runRange, Int_t version, Int_t subVersion)
+{
+  // get an  Condition object from the database
+
+  return getObject(ConditionId(path, runRange, version, subVersion));
+}
+
+TList* Storage::getAllObjects(const ConditionId& query)
+{
+  // get multiple  Condition objects from the database
+
+  if (!query.isValid()) {
+    LOG(ERROR) << "Invalid query: " << query.ToString().Data() << FairLogger::endl;
+    return NULL;
+  }
+
+  if (query.isAnyRange()) {
+    LOG(ERROR) << "Unspecified run or runrange: " << query.ToString().Data() << FairLogger::endl;
+    return NULL;
+  }
+
+  // This is needed otherwise TH1  objects (histos, TTree's) are lost when file is closed!
+  Bool_t oldStatus = TH1::AddDirectoryStatus();
+  TH1::AddDirectory(kFALSE);
+
+  TList* result = getAllEntries(query);
+
+  if (oldStatus != kFALSE)
+    TH1::AddDirectory(kTRUE);
+
+  Int_t nEntries = result->GetEntries();
+
+  LOG(INFO) << nEntries << " objects retrieved. Request was: " << query.ToString().Data() << FairLogger::endl;
+  for (int i = 0; i < nEntries; i++) {
+    Condition* entry = (Condition*)result->At(i);
+    LOG(INFO) << entry->getId().ToString().Data() << FairLogger::endl;
+  }
+
+  // if drain storage is set, drain entries into drain storage
+  if ((Manager::Instance())->isdrainSet()) {
+    for (int i = 0; i < result->GetEntries(); i++) {
+      Condition* entry = (Condition*)result->At(i);
+      Manager::Instance()->drain(entry);
+    }
+  }
+
+  return result;
+}
+
+TList* Storage::getAllObjects(const IdPath& path, Int_t runNumber, Int_t version, Int_t subVersion)
+{
+  // get multiple  Condition objects from the database
+
+  return getAllObjects(ConditionId(path, runNumber, runNumber, version, subVersion));
+}
+
+TList* Storage::getAllObjects(const IdPath& path, const IdRunRange& runRange, Int_t version, Int_t subVersion)
+{
+  // get multiple  Condition objects from the database
+
+  return getAllObjects(ConditionId(path, runRange, version, subVersion));
+}
+
+ConditionId* Storage::getId(const ConditionId& query)
+{
+  // get the ConditionId of the valid object from the database (does not open the file)
+
+  // check if query's path and runRange are valid
+  // query is invalid also if version is not specified and subversion is!
+  if (!query.isValid()) {
+    LOG(ERROR) << "Invalid query: " << query.ToString().Data() << FairLogger::endl;
+    return NULL;
+  }
+
+  // query is not specified if path contains wildcard or runrange = [-1,-1]
+  if (!query.isSpecified()) {
+    LOG(ERROR) << "Unspecified query: " << query.ToString().Data() << FairLogger::endl;
+    return NULL;
+  }
+
+  ConditionId* id = getConditionId(query);
+
+  return id;
+}
+
+ConditionId* Storage::getId(const IdPath& path, Int_t runNumber, Int_t version, Int_t subVersion)
+{
+  // get the ConditionId of the valid object from the database (does not open the file)
+
+  return getId(ConditionId(path, runNumber, runNumber, version, subVersion));
+}
+
+ConditionId* Storage::getId(const IdPath& path, const IdRunRange& runRange, Int_t version, Int_t subVersion)
+{
+  // get the ConditionId of the valid object from the database (does not open the file)
+
+  return getId(ConditionId(path, runRange, version, subVersion));
+}
+
+Bool_t Storage::putObject(TObject* object, ConditionId& id, ConditionMetaData* metaData, const char* mirrors)
+{
+  // store an  Condition object into the database
+
+  if (object == 0x0) {
+    LOG(ERROR) << "Null Condition! No storage will be done!" << FairLogger::endl;
+    return kFALSE;
+  }
+
+  Condition anCondition(object, id, metaData);
+
+  return putObject(&anCondition, mirrors);
+}
+
+Bool_t Storage::putObject(Condition* entry, const char* mirrors)
+{
+  // store an  Condition object into the database
+
+  if (!entry) {
+    LOG(ERROR) << "No entry!" << FairLogger::endl;
+    return kFALSE;
+  }
+
+  if (entry->getObject() == 0x0) {
+    LOG(ERROR) << "No valid object in CDB entry!" << FairLogger::endl;
+    return kFALSE;
+  }
+
+  if (!entry->getId().isValid()) {
+    LOG(ERROR) << "Invalid entry ID: " << entry->getId().ToString().Data() << FairLogger::endl;
+    return kFALSE;
+  }
+
+  if (!entry->getId().isSpecified()) {
+    LOG(ERROR) << "Unspecified entry ID: " << entry->getId().ToString().Data() << FairLogger::endl;
+    return kFALSE;
+  }
+
+  TString strMirrors(mirrors);
+  if (!strMirrors.IsNull() && !strMirrors.IsWhitespace())
+    return putCondition(entry, mirrors);
+  else
+    return putCondition(entry);
+}
+
+void Storage::queryStorages(Int_t run, const char* pathFilter, Int_t version, ConditionMetaData* md)
+{
+  // query CDB for files valid for given run, and fill list mValidFileIds
+  // Actual query is done in virtual function queryValidFiles()
+  // If version is not specified, the query will fill mValidFileIds
+  // with highest versions
+
+  mRun = run;
+
+  mPathFilter = pathFilter;
+  if (!mPathFilter.isValid()) {
+    LOG(ERROR) << "Filter not valid: " << pathFilter << FairLogger::endl;
+    mPathFilter = "*";
+    return;
+  }
+
+  mVersion = version;
+
+  LOG(INFO) << "Querying files valid for run " << mRun << " and path \"" << pathFilter << "\" into CDB storage \""
+            << mType.Data() << "://" << mBaseFolder.Data() << "\"" << FairLogger::endl;
+
+  // In mValidFileIds, clear id for the same 3level path, if any
+  LOG(DEBUG) << "Clearing list of CDB ConditionId's previously loaded for path \"" << pathFilter << "\""
+             << FairLogger::endl;
+  IdPath filter(pathFilter);
+  for (Int_t i = mValidFileIds.GetEntries() - 1; i >= 0; --i) {
+    ConditionId* rmMe = dynamic_cast<ConditionId*>(mValidFileIds.At(i));
+    IdPath rmPath = rmMe->getPathString();
+    if (filter.isSupersetOf(rmPath)) {
+      LOG(DEBUG) << "Removing id \"" << rmPath.getPathString().Data() << "\" matching: \"" << pathFilter << "\""
+                 << FairLogger::endl;
+      delete mValidFileIds.RemoveAt(i);
+    }
+  }
+
+  if (mConditionMetaDataFilter) {
+    delete mConditionMetaDataFilter;
+    mConditionMetaDataFilter = 0;
+  }
+  if (md)
+    mConditionMetaDataFilter = dynamic_cast<ConditionMetaData*>(md->Clone());
+
+  queryValidFiles();
+
+  LOG(INFO) << mValidFileIds.GetEntries() << " valid files found!" << FairLogger::endl;
+}
+
+void Storage::printrQueryStorages()
+{
+  // print parameters used to load list of CDB ConditionId's (mRun, mPathFilter, mVersion)
+
+  ConditionId paramId(mPathFilter, mRun, mRun, mVersion);
+  LOG(INFO) << "**** queryStorages Parameters **** \n\t\"" << paramId.ToString().Data() << "\"" << FairLogger::endl;
+
+  if (mConditionMetaDataFilter)
+    mConditionMetaDataFilter->printConditionMetaData();
+
+  TString message = "**** ConditionId's of valid objects found *****\n";
+  TIter iter(&mValidFileIds);
+  ConditionId* anId = 0;
+
+  // loop on the list of selection criteria
+  while ((anId = dynamic_cast<ConditionId*>(iter.Next()))) {
+    message += Form("\t%s\n", anId->ToString().Data());
+  }
+  message += Form("\n\tTotal: %d objects found\n", mValidFileIds.GetEntriesFast());
+  LOG(INFO) << message.Data() << FairLogger::endl;
+}
+
+void Storage::setMirrorSEs(const char* mirrors)
+{
+  // if the current storage is not of "alien" type, just issue a warning
+  //  GridStorage implements its own setMirrorSEs method, classes for other storage types do not
+
+  TString storageType = getStorageType();
+  if (storageType != "alien") {
+    LOG(WARNING) << "The current storage is of type \"" << storageType.Data() << "\". Setting of SEs to \"" << mirrors
+                 << "\" skipped!" << FairLogger::endl;
+    return;
+  }
+  LOG(ERROR) << "We should never get here!!  GridStorage must have masked this virtual method!" << FairLogger::endl;
+  return;
+}
+
+const char* Storage::getMirrorSEs() const
+{
+  // if the current storage is not of "alien" type, just issue a warning
+  //  GridStorage implements its own getMirrorSEs method, classes for other storage types do not
+
+  TString storageType = getStorageType();
+  if (storageType != "alien") {
+    LOG(WARNING) << "The current storage is of type \"" << storageType.Data()
+                 << "\" and cannot handle SEs. Returning empty string!" << FairLogger::endl;
+    return "";
+  }
+  LOG(ERROR) << "We should never get here!!  GridStorage must have masked this virtual method!" << FairLogger::endl;
+  return "";
+}
+
+void Storage::loadTreeFromFile(Condition* entry) const
+{
+  // Checks whether entry contains a TTree and in case loads it into memory
+
+  TObject* obj = (TObject*)entry->getObject();
+  if (!obj) {
+    LOG(ERROR) << "Cannot retrieve the object:" << FairLogger::endl;
+    entry->printConditionMetaData();
+    return;
+  }
+
+  if (!strcmp(obj->ClassName(), TTree::Class_Name())) {
+
+    LOG(WARNING) << "Condition contains a TTree! Loading baskets..." << FairLogger::endl;
+
+    TTree* tree = dynamic_cast<TTree*>(obj);
+
+    if (!tree)
+      return;
+
+    tree->LoadBaskets();
+    tree->SetDirectory(0);
+  } else if (!strcmp(obj->ClassName(), TNtuple::Class_Name())) {
+
+    LOG(WARNING) << "Condition contains a TNtuple! Loading baskets..." << FairLogger::endl;
+
+    TNtuple* ntu = dynamic_cast<TNtuple*>(obj);
+
+    if (!ntu)
+      return;
+
+    ntu->LoadBaskets();
+    ntu->SetDirectory(0);
+  }
+
+  return;
+}

--- a/o2cdb/Storage.h
+++ b/o2cdb/Storage.h
@@ -1,0 +1,112 @@
+#ifndef ALICEO2_CDB_STORAGE_H_
+#define ALICEO2_CDB_STORAGE_H_
+
+//  interface to specific storage classes                          //
+//  ( GridStorage,  LocalStorage, FileStorage)			   //
+#include "ConditionId.h"
+#include "ConditionMetaData.h"
+#include "Manager.h"
+
+#include <TList.h>
+#include <TObjArray.h>
+
+class TFile;
+
+namespace AliceO2 {
+namespace CDB {
+
+class Condition;
+class IdPath;
+class Param;
+
+class Storage : public TObject {
+
+public:
+  Storage();
+
+  void setUri(const TString& uri)
+  {
+    mURI = uri;
+  }
+  const TString& getUri() const
+  {
+    return mURI;
+  }
+  const TString& getStorageType() const
+  {
+    return mType;
+  }
+  const TString& getBaseFolder() const
+  {
+    return mBaseFolder;
+  }
+
+  void readSelectionFromFile(const char* fileName);
+  void addSelection(const ConditionId& selection);
+  void addSelection(const IdPath& path, const IdRunRange& runRange, Int_t version, Int_t subVersion = -1);
+  void addSelection(const IdPath& path, Int_t firstRun, Int_t lastRun, Int_t version, Int_t subVersion = -1);
+  void removeSelection(const ConditionId& selection);
+  void removeSelection(const IdPath& path, const IdRunRange& runRange);
+  void removeSelection(const IdPath& path, Int_t firstRun = -1, Int_t lastRun = -1);
+  void removeSelection(int position);
+  void removeAllSelections();
+  void printSelectionList();
+  Condition* getObject(const ConditionId& query);
+  Condition* getObject(const IdPath& path, Int_t runNumber, Int_t version = -1, Int_t subVersion = -1);
+  Condition* getObject(const IdPath& path, const IdRunRange& runRange, Int_t version = -1, Int_t subVersion = -1);
+  TList* getAllObjects(const ConditionId& query);
+  TList* getAllObjects(const IdPath& path, Int_t runNumber, Int_t version = -1, Int_t subVersion = -1);
+  TList* getAllObjects(const IdPath& path, const IdRunRange& runRange, Int_t version = -1, Int_t subVersion = -1);
+  ConditionId* getId(const ConditionId& query);
+  ConditionId* getId(const IdPath& path, Int_t runNumber, Int_t version = -1, Int_t subVersion = -1);
+  ConditionId* getId(const IdPath& path, const IdRunRange& runRange, Int_t version = -1, Int_t subVersion = -1);
+  Bool_t putObject(TObject* object, ConditionId& id, ConditionMetaData* metaData, const char* mirrors = "");
+  Bool_t putObject(Condition* entry, const char* mirrors = "");
+  virtual void setMirrorSEs(const char* mirrors);
+  virtual const char* getMirrorSEs() const;
+  virtual Bool_t isReadOnly() const = 0;
+  virtual Bool_t hasSubVersion() const = 0;
+  virtual Bool_t hasConditionType(const char* path) const = 0;
+  virtual Bool_t idToFilename(const ConditionId& id, TString& filename) const = 0;
+  void queryStorages(Int_t run, const char* pathFilter = "*", Int_t version = -1, ConditionMetaData* mdFilter = 0);
+  void printrQueryStorages();
+  TObjArray* getQueryStoragesList()
+  {
+    return &mValidFileIds;
+  }
+  virtual void setRetry(Int_t nretry, Int_t initsec) = 0;
+
+protected:
+  virtual ~Storage();
+  void getSelection(/*const*/ ConditionId* id);
+  virtual Condition* getCondition(const ConditionId& query) = 0;
+  virtual ConditionId* getConditionId(const ConditionId& query) = 0;
+  virtual TList* getAllEntries(const ConditionId& query) = 0;
+  virtual Bool_t putCondition(Condition* entry, const char* mirrors = "") = 0;
+  virtual TList* getIdListFromFile(const char* fileName) = 0;
+  virtual void queryValidFiles() = 0;
+  void loadTreeFromFile(Condition* entry) const;
+  // void 	setTreeToFile( Condition* entry, TFile* file) const;
+
+  TObjArray mValidFileIds;   // list of ConditionId's of the files valid for a given run (cached as mRun)
+  Int_t mRun;                // run number, used to manage list of valid files
+  IdPath mPathFilter;          // path filter, used to manage list of valid files
+  Int_t mVersion;            // version, used to manage list of valid files
+  ConditionMetaData* mConditionMetaDataFilter; // metadata, used to manage list of valid files
+
+  TList mSelections;         // list of selection criteria
+  TString mURI;              // storage URI;
+  TString mType;             //! LocalStorage, GridStorage: base folder name - Dump: file name
+  TString mBaseFolder;       //! LocalStorage, GridStorage: base folder name - Dump: file name
+  Short_t mNretry;           // Number of retries in opening the file
+  Short_t mInitRetrySeconds; // Seconds for first retry
+
+private:
+  Storage(const Storage& source);
+  Storage& operator=(const Storage& source);
+
+  ClassDef(Storage, 0)
+};
+}
+}
+#endif

--- a/o2cdb/XmlHandler.cxx
+++ b/o2cdb/XmlHandler.cxx
@@ -1,0 +1,149 @@
+//  The SAX XML file handler used in the CDBManager                       //
+#include <cstdlib>
+#include <Riostream.h>
+
+#include <TList.h>
+#include <TObject.h>
+#include <TXMLAttr.h>
+#include <TSAXParser.h>
+
+#include <FairLogger.h>
+#include "XmlHandler.h"
+
+using namespace AliceO2::CDB;
+ClassImp(XmlHandler)
+
+XmlHandler::XmlHandler() : TObject(), mRun(-1), mStartIdRunRange(-1), mEndIdRunRange(-1), mOCDBFolder("")
+{
+  //
+  // XmlHandler default constructor
+  //
+}
+
+XmlHandler::XmlHandler(Int_t run) : TObject(), mRun(run), mStartIdRunRange(-1), mEndIdRunRange(-1), mOCDBFolder("")
+{
+  //
+  // XmlHandler constructor with requested run
+  //
+}
+
+XmlHandler::XmlHandler(const XmlHandler& sh)
+  : TObject(sh),
+    mRun(sh.mRun),
+    mStartIdRunRange(sh.mStartIdRunRange),
+    mEndIdRunRange(sh.mEndIdRunRange),
+    mOCDBFolder(sh.mOCDBFolder)
+{
+  //
+  // XmlHandler copy constructor
+  //
+}
+
+XmlHandler& XmlHandler::operator=(const XmlHandler& sh)
+{
+  //
+  // Assignment operator
+  //
+  if (&sh == this)
+    return *this;
+
+  new (this) XmlHandler(sh);
+  return *this;
+}
+
+XmlHandler::~XmlHandler()
+{
+  //
+  // XmlHandler destructor
+  //
+}
+
+void XmlHandler::OnStartDocument()
+{
+  // if something should happen right at the beginning of the
+  // XML document, this must happen here
+  LOG(INFO) << "Reading XML file for LHCPeriod <-> Run Range correspondence" << FairLogger::endl;
+}
+
+void XmlHandler::OnEndDocument()
+{
+  // if something should happen at the end of the XML document
+  // this must be done here
+}
+
+void XmlHandler::OnStartElement(const char* name, const TList* attributes)
+{
+  // when a new XML element is found, it is processed here
+
+  // set the current system if necessary
+  TString strName(name);
+  LOG(DEBUG) << "name = " << strName.Data() << FairLogger::endl;
+  Int_t startRun = -1;
+  Int_t endRun = -1;
+  TXMLAttr* attr;
+  TIter next(attributes);
+  while ((attr = (TXMLAttr*)next())) {
+    TString attrName = attr->GetName();
+    LOG(DEBUG) << "Name = " << attrName.Data() << FairLogger::endl;
+    if (attrName == "StartIdRunRange") {
+      startRun = (Int_t)(((TString)(attr->GetValue())).Atoi());
+      LOG(DEBUG) << "startRun = " << startRun << FairLogger::endl;
+    }
+    if (attrName == "EndIdRunRange") {
+      endRun = (Int_t)(((TString)(attr->GetValue())).Atoi());
+      LOG(DEBUG) << "endRun = " << endRun << FairLogger::endl;
+    }
+    if (attrName == "OCDBFolder") {
+      if (mRun >= startRun && mRun <= endRun && startRun != -1 && endRun != -1) {
+        mOCDBFolder = (TString)(attr->GetValue());
+        LOG(DEBUG) << "OCDBFolder = " << mOCDBFolder.Data() << FairLogger::endl;
+        mStartIdRunRange = startRun;
+        mEndIdRunRange = endRun;
+      }
+    }
+  }
+  return;
+}
+void XmlHandler::OnEndElement(const char* name)
+{
+  // do everything that needs to be done when an end tag of an element is found
+  TString strName(name);
+  LOG(DEBUG) << "name = " << strName.Data() << FairLogger::endl;
+}
+
+void XmlHandler::OnCharacters(const char* characters)
+{
+  // copy the text content of an XML element
+  // mContent = characters;
+  TString strCharacters(characters);
+  LOG(DEBUG) << "characters = " << strCharacters.Data() << FairLogger::endl;
+}
+
+void XmlHandler::OnComment(const char* /*text*/)
+{
+  // comments within the XML file are ignored
+}
+
+void XmlHandler::OnWarning(const char* text)
+{
+  // process warnings here
+  LOG(INFO) << "Warning: " << text << FairLogger::endl;
+}
+
+void XmlHandler::OnError(const char* text)
+{
+  // process errors here
+  LOG(ERROR) << "Error: " << text << FairLogger::endl;
+}
+
+void XmlHandler::OnFatalError(const char* text)
+{
+  // process fatal errors here
+  LOG(FATAL) << "Fatal error: " << text << FairLogger::endl;
+}
+
+void XmlHandler::OnCdataBlock(const char* /*text*/, Int_t /*len*/)
+{
+  // process character data blocks here
+  // not implemented and should not be used here
+}

--- a/o2cdb/XmlHandler.h
+++ b/o2cdb/XmlHandler.h
@@ -1,0 +1,58 @@
+#ifndef ALICE_O2_XML_HANDLER_H_
+#define ALICE_O2_XML_HANDLER_H_
+//  The SAX XML file handler used by the OCDB Manager                     //
+//  get the OCDB Folder <-> Run Range correspondance                      //
+#include <TObject.h>
+class TString;
+
+namespace AliceO2 {
+namespace CDB {
+class XmlHandler : public TObject {
+
+public:
+  XmlHandler();
+  XmlHandler(Int_t run);
+  XmlHandler(const XmlHandler& sh);
+  virtual ~XmlHandler();
+  XmlHandler& operator=(const XmlHandler& sh);
+
+  // functions to interface to TSAXHandler
+  void OnStartDocument();
+  void OnEndDocument();
+  void OnStartElement(const char* name, const TList* attributes);
+  void OnEndElement(const char* name);
+  void OnCharacters(const char* name);
+  void OnComment(const char* name);
+  void OnWarning(const char* name);
+  void OnError(const char* name);
+  void OnFatalError(const char* name);
+  void OnCdataBlock(const char* name, Int_t len);
+
+  Int_t getStartIdRunRange() const
+  {
+    return mStartIdRunRange;
+  }
+  Int_t getEndIdRunRange() const
+  {
+    return mEndIdRunRange;
+  }
+  TString getOcdbFolder() const
+  {
+    return mOCDBFolder;
+  }
+  void setRun(Int_t run)
+  {
+    mRun = run;
+  }
+
+private:
+  Int_t mRun;           // run for which the LHC Period Folder has to be found
+  Int_t mStartIdRunRange; // start run corresponding to the request
+  Int_t mEndIdRunRange;   // end run corresponding to the request
+  TString mOCDBFolder;  // OCDB folder corresponding to the request
+
+  ClassDef(XmlHandler, 0) // The XML file handler for the OCDB
+};
+}
+}
+#endif


### PR DESCRIPTION
Importing STEER/CDB/ from AliRoot as starting point of the o2cdb,
applying naming conventions to it.
Get rid of cmake warning due to missing space in CMakeLists.txt

Apply clang format on o2cdb

Format function names.
The camelcase convention with lowercase starting letter has been
abandoned for compatibility with ROOT in the following cases:
GetName (for TObject derived)
Compare and IsSortable, for allowing TList,TClonesArray::Sort
XmlHandler::On\* methods, for compatibility with TXMLParser

Remove hardcoded storage uris for DataType

First doxygen (Entry) and removing //______

Rename Entry as Condition
Entry,ObjectId,MetaData->Condition
<Local|Grid|File>Storage
Path -> IdPath
RunRange -> IdRunRange

Introduce a FairMQ server and client
Exclude Client/Server from dictionaries generation
