### PR TITLE
update of the aliceHLTWrapper 2nd try

### DIFF
--- a/devices/aliceHLTwrapper/CMakeLists.txt
+++ b/devices/aliceHLTwrapper/CMakeLists.txt
@@ -63,7 +63,7 @@ set(DEPENDENCIES
 set(DEPENDENCIES
   ${DEPENDENCIES}
 #  ${CMAKE_THREAD_LIBS_INIT}
-   boost_thread boost_system FairMQ
+   boost_thread boost_system boost_chrono FairMQ
 )
 
 set(LIBRARY_NAME ALICEHLT)

--- a/devices/aliceHLTwrapper/Component.cxx
+++ b/devices/aliceHLTwrapper/Component.cxx
@@ -227,6 +227,7 @@ int Component::process(vector<MessageFormat::BufferDesc_t>& dataArray,
     double inputBlockMultiplier = 0.;
     mpSystem->getOutputSize(mProcessor, &constEventBase, &constBlockBase, &inputBlockMultiplier);
     outputBufferSize = constEventBase + nofInputBlocks * constBlockBase + totalInputSize * inputBlockMultiplier;
+    outputBufferSize+=sizeof(AliHLTComponentStatistics) + sizeof(AliHLTComponentTableEntry);
     // take the full available buffer and increase if that
     // is too little
     mOutputBuffer.resize(mOutputBuffer.capacity());
@@ -313,7 +314,7 @@ int Component::process(vector<MessageFormat::BufferDesc_t>& dataArray,
       if (bValid) {
         totalPayloadSize += pOutputBlock->fSize;
         validBlocks++;
-        pFiltered = pOutputBlock;
+        memcpy(pFiltered, pOutputBlock, sizeof(AliHLTComponentBlockData));
         pFiltered++;
       } else {
         cerr << "Inconsistent data reference in output block " << blockIndex << endl;

--- a/devices/aliceHLTwrapper/Component.cxx
+++ b/devices/aliceHLTwrapper/Component.cxx
@@ -319,6 +319,7 @@ int Component::process(vector<MessageFormat::BufferDesc_t>& dataArray,
         cerr << "Inconsistent data reference in output block " << blockIndex << endl;
       }
     }
+    evtData.fBlockCnt=validBlocks;
 
     // create the messages
     // TODO: for now there is an extra copy of the data, but it should be

--- a/devices/aliceHLTwrapper/Component.cxx
+++ b/devices/aliceHLTwrapper/Component.cxx
@@ -163,7 +163,8 @@ int Component::init(int argc, char** argv)
   return iResult;
 }
 
-int Component::process(vector<MessageFormat::BufferDesc_t>& dataArray)
+int Component::process(vector<MessageFormat::BufferDesc_t>& dataArray,
+                       cballoc_signal_t* cbAllocate)
 {
   if (!mpSystem) return -ENOSYS;
   int iResult = 0;
@@ -323,7 +324,7 @@ int Component::process(vector<MessageFormat::BufferDesc_t>& dataArray)
     // TODO: for now there is an extra copy of the data, but it should be
     // handled in place
     vector<MessageFormat::BufferDesc_t> outputMessages =
-      mFormatHandler.createMessages(pOutputBlocks, validBlocks, totalPayloadSize, evtData);
+      mFormatHandler.createMessages(pOutputBlocks, validBlocks, totalPayloadSize, evtData, cbAllocate);
     dataArray.insert(dataArray.end(), outputMessages.begin(), outputMessages.end());
   }
 

--- a/devices/aliceHLTwrapper/Component.h
+++ b/devices/aliceHLTwrapper/Component.h
@@ -22,6 +22,9 @@
 #include "AliHLTDataTypes.h"
 #include "MessageFormat.h"
 #include <vector>
+#include <boost/signals2.hpp>
+//using boost::signals2::signal;
+typedef boost::signals2::signal<unsigned char* (unsigned int)> cballoc_signal_t;
 
 namespace ALICE {
 namespace HLT {
@@ -71,7 +74,8 @@ public:
   /// the AliHLTComponentBlockData header immediately followed by the block
   /// payload. After processing, handles to output blocks are provided in this
   /// list.
-  int process(vector<AliceO2::AliceHLT::MessageFormat::BufferDesc_t>& dataArray);
+  int process(vector<AliceO2::AliceHLT::MessageFormat::BufferDesc_t>& dataArray,
+              cballoc_signal_t* cbAllocate=nullptr);
 
   int getEventCount() const {return mEventCount;}
 

--- a/devices/aliceHLTwrapper/EventSampler.cxx
+++ b/devices/aliceHLTwrapper/EventSampler.cxx
@@ -30,7 +30,8 @@
 #include <chrono>
 #include <fstream>
 
-using namespace std;
+using std::string;
+using std::vector;
 
 // time reference for the timestamp of events is the beginning of the day
 using std::chrono::system_clock;

--- a/devices/aliceHLTwrapper/MessageFormat.cxx
+++ b/devices/aliceHLTwrapper/MessageFormat.cxx
@@ -386,7 +386,8 @@ int MessageFormat::insertEvtData(const AliHLTComponentEventData& evtData)
     // TODO: simple logic at the moment, header is not inserted
     // if there is a mismatch, as the headers are inserted one by one, all
     // headers in the list have the same ID
-    if (evtData.fEventID!=it->fEventID) {
+    if (it != mListEvtData.end() &&
+        evtData.fEventID!=it->fEventID) {
       cerr << "Error: mismatching event ID " << evtData.fEventID
 	   << ", expected " << it->fEventID
 	   << " for event with timestamp "
@@ -397,6 +398,7 @@ int MessageFormat::insertEvtData(const AliHLTComponentEventData& evtData)
     // insert before the younger element
     mListEvtData.insert(it, evtData);
   }
+  return 0;
 }
 
 AliHLTUInt64_t MessageFormat::byteSwap64(AliHLTUInt64_t src) const

--- a/devices/aliceHLTwrapper/MessageFormat.h
+++ b/devices/aliceHLTwrapper/MessageFormat.h
@@ -22,6 +22,7 @@
 #include "AliHLTDataTypes.h"
 #include "HOMERFactory.h"
 #include <vector>
+#include <boost/signals2.hpp>
 
 class AliHLTHOMERReader;
 class AliHLTHOMERWriter;
@@ -98,7 +99,8 @@ public:
   // create message payloads in the internal buffer and return list
   // of decriptors
   vector<BufferDesc_t> createMessages(const AliHLTComponentBlockData* blocks, unsigned count,
-                                      unsigned totalPayloadSize, const AliHLTComponentEventData& evtData);
+                                      unsigned totalPayloadSize, const AliHLTComponentEventData& evtData,
+                                      boost::signals2::signal<unsigned char* (unsigned int)> *cbAllocate=nullptr);
 
   // read a sequence of blocks consisting of AliHLTComponentBlockData followed by payload
   // from a buffer

--- a/devices/aliceHLTwrapper/WrapperDevice.cxx
+++ b/devices/aliceHLTwrapper/WrapperDevice.cxx
@@ -28,7 +28,8 @@
 #include <iostream>
 #include <memory>
 
-using namespace std;
+using std::string;
+using std::vector;
 using namespace ALICE::HLT;
 
 // the chrono lib needs C++11

--- a/devices/aliceHLTwrapper/WrapperDevice.h
+++ b/devices/aliceHLTwrapper/WrapperDevice.h
@@ -22,6 +22,8 @@
 #include "FairMQDevice.h"
 #include <vector>
 
+class FairMQMessage;
+
 namespace ALICE {
 namespace HLT {
 class Component;
@@ -80,8 +82,12 @@ private:
   // assignment operator prohibited
   WrapperDevice& operator=(const WrapperDevice&);
 
+  /// create a new message with data buffer of specified size
+  unsigned char* createMessageBuffer(unsigned size);
+
   Component* mComponent;     // component instance
   std::vector<char*> mArgv;       // array of arguments for the component
+  std::vector<FairMQMessage*> mMessages; // array of output messages
 
   int mPollingPeriod;        // period of polling on input sockets in ms
   int mSkipProcessing;       // skip component processing


### PR DESCRIPTION
avoiding copy of the output data when creating messages and some bugfixes

There was a mistake when rebasing commit 0e9bdbbfe41d5caa7474119d43be26e367866888 which dropped the std:: attributes for string and vector in the header file

Corrected as a new commit a1bf73ad7a4c4057063bcac32593708006d050e3 now