### PR TITLE
Add new test which simply load all libraries.

### DIFF
--- a/macro/CMakeLists.txt
+++ b/macro/CMakeLists.txt
@@ -26,6 +26,12 @@ GENERATE_ROOT_TEST_SCRIPT(${CMAKE_SOURCE_DIR}/macro/run_digi.C)
   Set_Tests_Properties(run_digi_TGeant4 PROPERTIES TIMEOUT "30")
   Set_Tests_Properties(run_digi_TGeant4 PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished succesfully")
 
+GENERATE_ROOT_TEST_SCRIPT(${CMAKE_SOURCE_DIR}/macro/load_all_libs.C)
+
+  Add_Test(load_all_libs
+          ${CMAKE_BINARY_DIR}/macro/load_all_libs.sh)
+  Set_Tests_Properties(load_all_libs PROPERTIES TIMEOUT "30")
+  Set_Tests_Properties(load_all_libs PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished succesfully")
 
 
 Install(FILES run_sim.C run_digi.C

--- a/macro/load_all_libs.C
+++ b/macro/load_all_libs.C
@@ -1,0 +1,20 @@
+void load_all_libs()
+{
+  gSystem->Load("libALICEHLT");
+  gSystem->Load("libAliceO2Base");
+  gSystem->Load("libAliceO2Cdb");
+  gSystem->Load("libFLP2EPNex");
+  gSystem->Load("libFLP2EPNex_distributed");
+  gSystem->Load("libFLP2EPNex_dynamic");
+  gSystem->Load("libField");
+  gSystem->Load("libMathUtils");
+  gSystem->Load("libO2Data");
+  gSystem->Load("libO2Gen");
+  gSystem->Load("libPassive");
+  gSystem->Load("libRoundtripTest");
+  gSystem->Load("libits");
+  gSystem->Load("libtpc");
+
+  cout << endl << endl;
+  cout << "Macro finished succesfully." << endl;
+}


### PR DESCRIPTION
This test is needed that gcov knows about all libraries which
belong to the project. gcov still doesn't know about the binaries.