### PR TITLE
Add integration test for flp2epn-distributed devices

### DIFF
--- a/devices/flp2epn-distributed/CMakeLists.txt
+++ b/devices/flp2epn-distributed/CMakeLists.txt
@@ -1,3 +1,6 @@
+configure_file(${CMAKE_SOURCE_DIR}/devices/flp2epn-distributed/run/startFLP2EPN-distributed.sh.in ${CMAKE_BINARY_DIR}/bin/startFLP2EPN-distributed.sh)
+configure_file(${CMAKE_SOURCE_DIR}/devices/flp2epn-distributed/test/testFLP2EPN-distributed.sh.in ${CMAKE_BINARY_DIR}/devices/flp2epn-distributed/test/testFLP2EPN-distributed.sh)
+
 set(INCLUDE_DIRECTORIES
   ${CMAKE_SOURCE_DIR}/devices/flp2epn-distributed
 )
@@ -21,10 +24,6 @@ endif()
 
 include_directories(${INCLUDE_DIRECTORIES})
 include_directories(SYSTEM ${SYSTEM_INCLUDE_DIRECTORIES})
-
-configure_file(
-  ${CMAKE_SOURCE_DIR}/devices/flp2epn-distributed/run/startFLP2EPN-distributed.sh.in ${CMAKE_BINARY_DIR}/bin/startFLP2EPN-distributed.sh
-)
 
 set(LINK_DIRECTORIES
   ${Boost_LIBRARY_DIRS}
@@ -115,3 +114,7 @@ ForEach(_file RANGE 0 ${_length})
   set(DEPENDENCIES FLP2EPNex_distributed)
   GENERATE_EXECUTABLE()
 EndForEach(_file RANGE 0 ${_length})
+
+add_test(NAME run_flp2epn_distributed COMMAND ${CMAKE_BINARY_DIR}/devices/flp2epn-distributed/test/testFLP2EPN-distributed.sh)
+set_tests_properties(run_flp2epn_distributed PROPERTIES TIMEOUT "30")
+set_tests_properties(run_flp2epn_distributed PROPERTIES PASS_REGULAR_EXPRESSION "acknowledged after")

--- a/devices/flp2epn-distributed/EPNReceiver.h
+++ b/devices/flp2epn-distributed/EPNReceiver.h
@@ -23,7 +23,7 @@ namespace Devices {
 
 struct TFBuffer
 {
-  std::vector<FairMQMessage*> parts;
+  std::vector<std::unique_ptr<FairMQMessage>> parts;
   boost::posix_time::ptime startTime;
   boost::posix_time::ptime endTime;
 };

--- a/devices/flp2epn-distributed/FLPSender.cxx
+++ b/devices/flp2epn-distributed/FLPSender.cxx
@@ -197,7 +197,8 @@ inline void FLPSender::sendFrontData()
   //   fArrivalTime.pop();
   //   fDataBuffer.pop();
   // } else { // if the heartbeat from the corresponding EPN is within timeout period, send the data.
-    if (fChannels.at("data-out").at(direction).SendPartAsync(fHeaderBuffer.front()) < 0) {
+    if (fChannels.at("data-out").at(direction).SendPart(fHeaderBuffer.front()) < 0) {
+      // TODO: replace SendPart() with SendPartAsync() after nov15 fairroot release
       LOG(ERROR) << "Failed to queue ID part of event #" << currentTimeframeId;
     } else {
       if (fChannels.at("data-out").at(direction).SendAsync(fDataBuffer.front()) < 0) {

--- a/devices/flp2epn-distributed/FLPSender.h
+++ b/devices/flp2epn-distributed/FLPSender.h
@@ -75,17 +75,14 @@ class FLPSender : public FairMQDevice
     /// Sends the "oldest" element from the sub-timeframe container
     void sendFrontData();
 
-    std::queue<FairMQMessage*> fHeaderBuffer; ///< Stores sub-timeframe headers
-    std::queue<FairMQMessage*> fDataBuffer; ///< Stores sub-timeframe bodies
+    std::queue<std::unique_ptr<FairMQMessage>> fHeaderBuffer; ///< Stores sub-timeframe headers
+    std::queue<std::unique_ptr<FairMQMessage>> fDataBuffer; ///< Stores sub-timeframe bodies
     std::queue<boost::posix_time::ptime> fArrivalTime; ///< Stores arrival times of sub-timeframes
 
     int fNumEPNs; ///< Number of epnReceivers
     unsigned int fIndex; ///< Index of the flpSender among other flpSenders
     unsigned int fSendOffset; ///< Offset for staggering output
     unsigned int fSendDelay; ///< Delay for staggering output
-
-    int fSndMoreFlag; ///< Flag for faster access to multipart sending
-    int fNoBlockFlag; ///< Flag for faster access to sending without blocking
 
     int fEventSize; ///< Size of the sub-timeframe body (only for test mode)
     int fTestMode; ///< Run the device in test mode (only syncSampler+flpSender+epnReceiver)

--- a/devices/flp2epn-distributed/FLPSyncSampler.cxx
+++ b/devices/flp2epn-distributed/FLPSyncSampler.cxx
@@ -21,6 +21,8 @@ using namespace AliceO2::Devices;
 
 FLPSyncSampler::FLPSyncSampler()
   : fEventRate(1)
+  , fMaxEvents(0)
+  , fStoreRTTinFile(0)
   , fEventCounter(0)
   , fTimeframeRTT()
 {
@@ -42,7 +44,7 @@ void FLPSyncSampler::Run()
   boost::thread resetEventCounter(boost::bind(&FLPSyncSampler::ResetEventCounter, this));
   boost::thread ackListener(boost::bind(&FLPSyncSampler::ListenForAcks, this));
 
-  uint16_t timeFrameId = 1;
+  uint16_t timeFrameId = 0;
 
   FairMQChannel& dataOutputChannel = fChannels.at("data-out").at(0);
 
@@ -50,11 +52,11 @@ void FLPSyncSampler::Run()
     unique_ptr<FairMQMessage> msg(fTransportFactory->CreateMessage(sizeof(uint16_t)));
     memcpy(msg->GetData(), &timeFrameId, sizeof(uint16_t));
 
-    if (dataOutputChannel.SendAsync(msg) > 0) {
+    if (dataOutputChannel.Send(msg) >= 0) {
       fTimeframeRTT[timeFrameId].start = boost::posix_time::microsec_clock::local_time();
 
       if (++timeFrameId == UINT16_MAX - 1) {
-        timeFrameId = 1;
+        timeFrameId = 0;
       }
     }
 
@@ -62,6 +64,11 @@ void FLPSyncSampler::Run()
 
     while (fEventCounter == 0) {
       boost::this_thread::sleep(boost::posix_time::milliseconds(1));
+    }
+
+    if (fMaxEvents > 0 && timeFrameId >= fMaxEvents) {
+      LOG(INFO) << "Reached configured maximum number of events (" << fMaxEvents << "). Exiting Run().";
+      break;
     }
   }
 
@@ -79,32 +86,51 @@ void FLPSyncSampler::ListenForAcks()
 {
   uint16_t id = 0;
 
-  string name = to_iso_string(boost::posix_time::microsec_clock::local_time()).substr(0, 20);
-  ofstream ofsFrames(name + "-frames.log");
-  ofstream ofsTimes(name + "-times.log");
+  unique_ptr<FairMQPoller> poller(fTransportFactory->CreatePoller(fChannels.at("ack-in")));
+
+  ofstream ofsFrames;
+  ofstream ofsTimes;
+
+  // store round trip time measurements in a file
+  if (fStoreRTTinFile > 0) {
+    string name = to_iso_string(boost::posix_time::microsec_clock::local_time()).substr(0, 20);
+    ofsFrames.open(name + "-frames.log");
+    ofsTimes.open(name + "-times.log");
+  }
 
   while (CheckCurrentState(RUNNING)) {
     try {
+      poller->Poll(100);
+
       unique_ptr<FairMQMessage> idMsg(fTransportFactory->CreateMessage());
 
-      if (fChannels.at("ack-in").at(0).Receive(idMsg) > 0) {
-        id = *(static_cast<uint16_t*>(idMsg->GetData()));
-        fTimeframeRTT.at(id).end = boost::posix_time::microsec_clock::local_time();
-        // store values in a file
-        ofsFrames << id << "\n";
-        ofsTimes  << (fTimeframeRTT.at(id).end - fTimeframeRTT.at(id).start).total_microseconds() << "\n";
+      if (poller->CheckInput(0)) {
+        if (fChannels.at("ack-in").at(0).Receive(idMsg) >= 0) {
+          id = *(static_cast<uint16_t*>(idMsg->GetData()));
+          fTimeframeRTT.at(id).end = boost::posix_time::microsec_clock::local_time();
+          // store values in a file
+          if (fStoreRTTinFile > 0) {
+            ofsFrames << id << "\n";
+            ofsTimes  << (fTimeframeRTT.at(id).end - fTimeframeRTT.at(id).start).total_microseconds() << "\n";
+          }
 
-        LOG(INFO) << "Timeframe #" << id << " acknowledged after "
-                  << (fTimeframeRTT.at(id).end - fTimeframeRTT.at(id).start).total_microseconds() << " μs.";
+          LOG(INFO) << "Timeframe #" << id << " acknowledged after "
+                    << (fTimeframeRTT.at(id).end - fTimeframeRTT.at(id).start).total_microseconds() << " μs.";
+        }
       }
+
+      boost::this_thread::interruption_point();
     } catch (boost::thread_interrupted&) {
       LOG(DEBUG) << "Acknowledgement listener thread interrupted";
       break;
     }
   }
 
-  ofsFrames.close();
-  ofsTimes.close();
+  // store round trip time measurements in a file
+  if (fStoreRTTinFile > 0) {
+    ofsFrames.close();
+    ofsTimes.close();
+  }
 }
 
 void FLPSyncSampler::ResetEventCounter()
@@ -143,6 +169,12 @@ void FLPSyncSampler::SetProperty(const int key, const int value)
     case EventRate:
       fEventRate = value;
       break;
+    case MaxEvents:
+      fMaxEvents = value;
+      break;
+    case StoreRTTinFile:
+      fStoreRTTinFile = value;
+      break;
     default:
       FairMQDevice::SetProperty(key, value);
       break;
@@ -154,6 +186,10 @@ int FLPSyncSampler::GetProperty(const int key, const int default_ /*= 0*/)
   switch (key) {
     case EventRate:
       return fEventRate;
+    case MaxEvents:
+      return fMaxEvents;
+    case StoreRTTinFile:
+      return fStoreRTTinFile;
     default:
       return FairMQDevice::GetProperty(key, default_);
   }

--- a/devices/flp2epn-distributed/FLPSyncSampler.h
+++ b/devices/flp2epn-distributed/FLPSyncSampler.h
@@ -33,6 +33,8 @@ class FLPSyncSampler : public FairMQDevice
   public:
     enum {
       EventRate = FairMQDevice::Last, ///< Publishing rate of the timeframe IDs
+      MaxEvents, ///< Maximum number of events to send (0 - unlimited)
+      StoreRTTinFile, ///< Store round trip time measurements in a file
       Last
     };
 
@@ -74,6 +76,8 @@ class FLPSyncSampler : public FairMQDevice
 
     std::array<timeframeDuration, UINT16_MAX> fTimeframeRTT; ///< Container for the roundtrip values per timeframe ID
     int fEventRate; ///< Publishing rate of the timeframe IDs
+    int fMaxEvents; ///< Maximum number of events to send (0 - unlimited)
+    int fStoreRTTinFile; ///< Store round trip time measurements in a file.
     int fEventCounter; ///< Controls the send rate of the timeframe IDs
 };
 

--- a/devices/flp2epn-distributed/run/runFLPSender.cxx
+++ b/devices/flp2epn-distributed/run/runFLPSender.cxx
@@ -26,6 +26,7 @@ typedef struct DeviceOptions
   int numEPNs;
   int heartbeatTimeoutInMs;
   int testMode;
+  int interactive;
   int sendOffset;
   int sendDelay;
 
@@ -64,6 +65,7 @@ inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
     ("num-epns", bpo::value<int>()->required(), "Number of EPNs")
     ("heartbeat-timeout", bpo::value<int>()->default_value(20000), "Heartbeat timeout in milliseconds")
     ("test-mode", bpo::value<int>()->default_value(0), "Run in test mode")
+    ("interactive", bpo::value<int>()->default_value(1), "Run in interactive mode (1/0)")
     ("send-offset", bpo::value<int>()->default_value(0), "Offset for staggered sending")
     ("send-delay", bpo::value<int>()->default_value(8), "Delay for staggered sending")
 
@@ -97,35 +99,36 @@ inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
 
   bpo::notify(vm);
 
-  if (vm.count("id"))                      { _options->id                        = vm["id"].as<string>(); }
-  if (vm.count("flp-index"))               { _options->flpIndex                  = vm["flp-index"].as<int>(); }
-  if (vm.count("event-size"))              { _options->eventSize                 = vm["event-size"].as<int>(); }
-  if (vm.count("io-threads"))              { _options->ioThreads                 = vm["io-threads"].as<int>(); }
+  if (vm.count("id"))                    { _options->id                   = vm["id"].as<string>(); }
+  if (vm.count("flp-index"))             { _options->flpIndex             = vm["flp-index"].as<int>(); }
+  if (vm.count("event-size"))            { _options->eventSize            = vm["event-size"].as<int>(); }
+  if (vm.count("io-threads"))            { _options->ioThreads            = vm["io-threads"].as<int>(); }
 
-  if (vm.count("num-epns"))                { _options->numEPNs                   = vm["num-epns"].as<int>(); }
+  if (vm.count("num-epns"))              { _options->numEPNs              = vm["num-epns"].as<int>(); }
 
-  if (vm.count("heartbeat-timeout"))       { _options->heartbeatTimeoutInMs      = vm["heartbeat-timeout"].as<int>(); }
-  if (vm.count("test-mode"))               { _options->testMode                  = vm["test-mode"].as<int>(); }
-  if (vm.count("send-offset"))             { _options->sendOffset                = vm["send-offset"].as<int>(); }
-  if (vm.count("send-delay"))              { _options->sendDelay                 = vm["send-delay"].as<int>(); }
+  if (vm.count("heartbeat-timeout"))     { _options->heartbeatTimeoutInMs = vm["heartbeat-timeout"].as<int>(); }
+  if (vm.count("test-mode"))             { _options->testMode             = vm["test-mode"].as<int>(); }
+  if (vm.count("interactive"))           { _options->interactive          = vm["interactive"].as<int>(); }
+  if (vm.count("send-offset"))           { _options->sendOffset           = vm["send-offset"].as<int>(); }
+  if (vm.count("send-delay"))            { _options->sendDelay            = vm["send-delay"].as<int>(); }
 
-  if (vm.count("data-in-socket-type"))  { _options->dataInSocketType       = vm["data-in-socket-type"].as<string>(); }
-  if (vm.count("data-in-buff-size"))    { _options->dataInBufSize          = vm["data-in-buff-size"].as<int>(); }
-  if (vm.count("data-in-method"))       { _options->dataInMethod           = vm["data-in-method"].as<string>(); }
-  if (vm.count("data-in-address"))      { _options->dataInAddress          = vm["data-in-address"].as<string>(); }
-  if (vm.count("data-in-rate-logging")) { _options->dataInRateLogging      = vm["data-in-rate-logging"].as<int>(); }
+  if (vm.count("data-in-socket-type"))   { _options->dataInSocketType     = vm["data-in-socket-type"].as<string>(); }
+  if (vm.count("data-in-buff-size"))     { _options->dataInBufSize        = vm["data-in-buff-size"].as<int>(); }
+  if (vm.count("data-in-method"))        { _options->dataInMethod         = vm["data-in-method"].as<string>(); }
+  if (vm.count("data-in-address"))       { _options->dataInAddress        = vm["data-in-address"].as<string>(); }
+  if (vm.count("data-in-rate-logging"))  { _options->dataInRateLogging    = vm["data-in-rate-logging"].as<int>(); }
 
-  if (vm.count("data-out-socket-type"))      { _options->dataOutSocketType          = vm["data-out-socket-type"].as<string>(); }
-  if (vm.count("data-out-buff-size"))        { _options->dataOutBufSize             = vm["data-out-buff-size"].as<int>(); }
-  if (vm.count("data-out-method"))           { _options->dataOutMethod              = vm["data-out-method"].as<string>(); }
-  if (vm.count("data-out-address"))          { _options->dataOutAddress             = vm["data-out-address"].as<vector<string>>(); }
-  if (vm.count("data-out-rate-logging"))     { _options->dataOutRateLogging         = vm["data-out-rate-logging"].as<int>(); }
+  if (vm.count("data-out-socket-type"))  { _options->dataOutSocketType    = vm["data-out-socket-type"].as<string>(); }
+  if (vm.count("data-out-buff-size"))    { _options->dataOutBufSize       = vm["data-out-buff-size"].as<int>(); }
+  if (vm.count("data-out-method"))       { _options->dataOutMethod        = vm["data-out-method"].as<string>(); }
+  if (vm.count("data-out-address"))      { _options->dataOutAddress       = vm["data-out-address"].as<vector<string>>(); }
+  if (vm.count("data-out-rate-logging")) { _options->dataOutRateLogging   = vm["data-out-rate-logging"].as<int>(); }
 
-  if (vm.count("hb-in-socket-type"))    { _options->hbInSocketType         = vm["hb-in-socket-type"].as<string>(); }
-  if (vm.count("hb-in-buff-size"))      { _options->hbInBufSize            = vm["hb-in-buff-size"].as<int>(); }
-  if (vm.count("hb-in-method"))         { _options->hbInMethod             = vm["hb-in-method"].as<string>(); }
-  if (vm.count("hb-in-address"))        { _options->hbInAddress            = vm["hb-in-address"].as<string>(); }
-  if (vm.count("hb-in-rate-logging"))   { _options->hbInRateLogging        = vm["hb-in-rate-logging"].as<int>(); }
+  if (vm.count("hb-in-socket-type"))     { _options->hbInSocketType       = vm["hb-in-socket-type"].as<string>(); }
+  if (vm.count("hb-in-buff-size"))       { _options->hbInBufSize          = vm["hb-in-buff-size"].as<int>(); }
+  if (vm.count("hb-in-method"))          { _options->hbInMethod           = vm["hb-in-method"].as<string>(); }
+  if (vm.count("hb-in-address"))         { _options->hbInAddress          = vm["hb-in-address"].as<string>(); }
+  if (vm.count("hb-in-rate-logging"))    { _options->hbInRateLogging      = vm["hb-in-rate-logging"].as<int>(); }
 
   return true;
 }
@@ -204,7 +207,19 @@ int main(int argc, char** argv)
 
   // run the device
   flp.ChangeState("RUN");
-  flp.InteractiveStateLoop();
+  if (options.interactive > 0) {
+    flp.InteractiveStateLoop();
+  } else {
+    flp.WaitForEndOfState("RUN");
+
+    flp.ChangeState("RESET_TASK");
+    flp.WaitForEndOfState("RESET_TASK");
+
+    flp.ChangeState("RESET_DEVICE");
+    flp.WaitForEndOfState("RESET_DEVICE");
+
+    flp.ChangeState("END");
+  }
 
   return 0;
 }

--- a/devices/flp2epn-distributed/run/runFLPSyncSampler.cxx
+++ b/devices/flp2epn-distributed/run/runFLPSyncSampler.cxx
@@ -21,7 +21,10 @@ typedef struct DeviceOptions
 {
   string id;
   int eventRate;
+  int maxEvents;
   int ioThreads;
+  int interactive;
+  int storeRTTinFile;
 
   string dataOutSocketType;
   int dataOutBufSize;
@@ -46,7 +49,10 @@ inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
   desc.add_options()
     ("id", bpo::value<string>()->required(), "Device ID")
     ("event-rate", bpo::value<int>()->default_value(0), "Event rate limit in maximum number of events per second")
+    ("max-events", bpo::value<int>()->default_value(0), "Maximum number of events to send (0 - unlimited)")
     ("io-threads", bpo::value<int>()->default_value(1), "Number of I/O threads")
+    ("interactive", bpo::value<int>()->default_value(1), "Run in interactive mode (1/0)")
+    ("store-rtt-in-file", bpo::value<int>()->default_value(0), "Store round trip time measurements in a file (1/0)")
 
     ("data-out-socket-type", bpo::value<string>()->default_value("pub"), "Data output socket type: pub/push")
     ("data-out-buff-size", bpo::value<int>()->default_value(100), "Data output buffer size in number of messages (ZeroMQ)/bytes(nanomsg)")
@@ -72,9 +78,12 @@ inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
 
   bpo::notify(vm);
 
-  if (vm.count("id"))                       { _options->id                = vm["id"].as<string>(); }
-  if (vm.count("event-rate"))               { _options->eventRate         = vm["event-rate"].as<int>(); }
-  if (vm.count("io-threads"))               { _options->ioThreads         = vm["io-threads"].as<int>(); }
+  if (vm.count("id"))                    { _options->id                 = vm["id"].as<string>(); }
+  if (vm.count("event-rate"))            { _options->eventRate          = vm["event-rate"].as<int>(); }
+  if (vm.count("max-events"))            { _options->maxEvents          = vm["max-events"].as<int>(); }
+  if (vm.count("io-threads"))            { _options->ioThreads          = vm["io-threads"].as<int>(); }
+  if (vm.count("interactive"))           { _options->interactive        = vm["interactive"].as<int>(); }
+  if (vm.count("store-rtt-in-file"))     { _options->storeRTTinFile     = vm["store-rtt-in-file"].as<int>(); }
 
   if (vm.count("data-out-socket-type"))  { _options->dataOutSocketType  = vm["data-out-socket-type"].as<string>(); }
   if (vm.count("data-out-buff-size"))    { _options->dataOutBufSize     = vm["data-out-buff-size"].as<int>(); }
@@ -82,11 +91,11 @@ inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
   if (vm.count("data-out-address"))      { _options->dataOutAddress     = vm["data-out-address"].as<string>(); }
   if (vm.count("data-out-rate-logging")) { _options->dataOutRateLogging = vm["data-out-rate-logging"].as<int>(); }
 
-  if (vm.count("ack-in-socket-type"))    { _options->ackInSocketType   = vm["ack-in-socket-type"].as<string>(); }
-  if (vm.count("ack-in-buff-size"))      { _options->ackInBufSize      = vm["ack-in-buff-size"].as<int>(); }
-  if (vm.count("ack-in-method"))         { _options->ackInMethod       = vm["ack-in-method"].as<string>(); }
-  if (vm.count("ack-in-address"))        { _options->ackInAddress      = vm["ack-in-address"].as<string>(); }
-  if (vm.count("ack-in-rate-logging"))   { _options->ackInRateLogging  = vm["ack-in-rate-logging"].as<int>(); }
+  if (vm.count("ack-in-socket-type"))    { _options->ackInSocketType    = vm["ack-in-socket-type"].as<string>(); }
+  if (vm.count("ack-in-buff-size"))      { _options->ackInBufSize       = vm["ack-in-buff-size"].as<int>(); }
+  if (vm.count("ack-in-method"))         { _options->ackInMethod        = vm["ack-in-method"].as<string>(); }
+  if (vm.count("ack-in-address"))        { _options->ackInAddress       = vm["ack-in-address"].as<string>(); }
+  if (vm.count("ack-in-rate-logging"))   { _options->ackInRateLogging   = vm["ack-in-rate-logging"].as<int>(); }
 
   return true;
 }
@@ -119,6 +128,8 @@ int main(int argc, char** argv)
   sampler.SetProperty(FLPSyncSampler::Id, options.id);
   sampler.SetProperty(FLPSyncSampler::NumIoThreads, options.ioThreads);
   sampler.SetProperty(FLPSyncSampler::EventRate, options.eventRate);
+  sampler.SetProperty(FLPSyncSampler::MaxEvents, options.maxEvents);
+  sampler.SetProperty(FLPSyncSampler::StoreRTTinFile, options.storeRTTinFile);
 
   // configure data output channel
   FairMQChannel dataOutChannel(options.dataOutSocketType, options.dataOutMethod, options.dataOutAddress);
@@ -144,7 +155,19 @@ int main(int argc, char** argv)
 
   // run the device
   sampler.ChangeState("RUN");
-  sampler.InteractiveStateLoop();
+  if (options.interactive > 0) {
+    sampler.InteractiveStateLoop();
+  } else {
+    sampler.WaitForEndOfState("RUN");
+
+    sampler.ChangeState("RESET_TASK");
+    sampler.WaitForEndOfState("RESET_TASK");
+
+    sampler.ChangeState("RESET_DEVICE");
+    sampler.WaitForEndOfState("RESET_DEVICE");
+
+    sampler.ChangeState("END");
+  }
 
   return 0;
 }

--- a/devices/flp2epn-distributed/runO2Prototype/runFLPSyncSampler.cxx
+++ b/devices/flp2epn-distributed/runO2Prototype/runFLPSyncSampler.cxx
@@ -29,6 +29,8 @@ typedef struct DeviceOptions
 {
   string id;
   int eventRate;
+  int maxEvents;
+  int storeRTTinFile;
   int ioThreads;
 
   string dataOutSocketType;
@@ -54,6 +56,8 @@ inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
   desc.add_options()
     ("id", bpo::value<string>()->required(), "Device ID")
     ("event-rate", bpo::value<int>()->default_value(100), "Event rate limit in maximum number of events per second")
+    ("max-events", bpo::value<int>()->default_value(0), "Maximum number of events to send (0 - unlimited)")
+    ("store-rtt-in-file", bpo::value<int>()->default_value(0), "Store round trip time measurements in a file (1/0)")
     ("io-threads", bpo::value<int>()->default_value(1), "Number of I/O threads")
 
     ("data-out-socket-type", bpo::value<string>()->default_value("pub"), "Data output socket type: pub/push")
@@ -80,9 +84,11 @@ inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
 
   bpo::notify(vm);
 
-  if (vm.count("id"))                       { _options->id                = vm["id"].as<string>(); }
-  if (vm.count("event-rate"))               { _options->eventRate         = vm["event-rate"].as<int>(); }
-  if (vm.count("io-threads"))               { _options->ioThreads         = vm["io-threads"].as<int>(); }
+  if (vm.count("id"))                    { _options->id                 = vm["id"].as<string>(); }
+  if (vm.count("event-rate"))            { _options->eventRate          = vm["event-rate"].as<int>(); }
+  if (vm.count("max-events"))            { _options->maxEvents          = vm["max-events"].as<int>(); }
+  if (vm.count("store-rtt-in-file"))     { _options->storeRTTinFile     = vm["store-rtt-in-file"].as<int>(); }
+  if (vm.count("io-threads"))            { _options->ioThreads          = vm["io-threads"].as<int>(); }
 
   if (vm.count("data-out-socket-type"))  { _options->dataOutSocketType  = vm["data-out-socket-type"].as<string>(); }
   if (vm.count("data-out-buff-size"))    { _options->dataOutBufSize     = vm["data-out-buff-size"].as<int>(); }
@@ -90,11 +96,11 @@ inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
   // if (vm.count("data-out-address"))      { _options->dataOutAddress     = vm["data-out-address"].as<string>(); }
   if (vm.count("data-out-rate-logging")) { _options->dataOutRateLogging = vm["data-out-rate-logging"].as<int>(); }
 
-  if (vm.count("ack-in-socket-type"))    { _options->ackInSocketType   = vm["ack-in-socket-type"].as<string>(); }
-  if (vm.count("ack-in-buff-size"))      { _options->ackInBufSize      = vm["ack-in-buff-size"].as<int>(); }
-  if (vm.count("ack-in-method"))         { _options->ackInMethod       = vm["ack-in-method"].as<string>(); }
+  if (vm.count("ack-in-socket-type"))    { _options->ackInSocketType    = vm["ack-in-socket-type"].as<string>(); }
+  if (vm.count("ack-in-buff-size"))      { _options->ackInBufSize       = vm["ack-in-buff-size"].as<int>(); }
+  if (vm.count("ack-in-method"))         { _options->ackInMethod        = vm["ack-in-method"].as<string>(); }
   // if (vm.count("ack-in-address"))        { _options->ackInAddress      = vm["ack-in-address"].as<string>(); }
-  if (vm.count("ack-in-rate-logging"))   { _options->ackInRateLogging  = vm["ack-in-rate-logging"].as<int>(); }
+  if (vm.count("ack-in-rate-logging"))   { _options->ackInRateLogging   = vm["ack-in-rate-logging"].as<int>(); }
 
   return true;
 }
@@ -148,6 +154,8 @@ int main(int argc, char** argv)
   sampler.SetProperty(FLPSyncSampler::Id, options.id);
   sampler.SetProperty(FLPSyncSampler::NumIoThreads, options.ioThreads);
   sampler.SetProperty(FLPSyncSampler::EventRate, options.eventRate);
+  sampler.SetProperty(FLPSyncSampler::MaxEvents, options.maxEvents);
+  sampler.SetProperty(FLPSyncSampler::StoreRTTinFile, options.storeRTTinFile);
 
   FairMQChannel dataOutChannel(options.dataOutSocketType, options.dataOutMethod, ownAddress);
   dataOutChannel.UpdateSndBufSize(options.dataOutBufSize);

--- a/devices/flp2epn-distributed/test/testFLP2EPN-distributed.sh.in
+++ b/devices/flp2epn-distributed/test/testFLP2EPN-distributed.sh.in
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+# setup a trap to kill everything if the test fails/timeouts
+
+trap 'kill -TERM $FLP0_PID; kill -TERM $FLP1_PID; kill -TERM $EPN0_PID; kill -TERM $EPN1_PID; kill -TERM $SAMPLER_PID; wait $FLP0_PID; wait $FLP1_PID; wait $EPN0_PID; wait $EPN1_PID; wait $SAMPLER_PID;' TERM
+
+# start 2 flpSenders in non-interactive mode
+
+FLP0="flpSender"
+FLP0+=" --id FLP1"
+FLP0+=" --interactive 0"
+FLP0+=" --flp-index 0"
+FLP0+=" --event-size 1000000"
+FLP0+=" --num-epns 2"
+FLP0+=" --heartbeat-timeout 20000"
+FLP0+=" --test-mode 1"
+FLP0+=" --send-offset 0"
+FLP0+=" --hb-in-address tcp://127.0.0.1:7580"
+FLP0+=" --data-in-socket-type sub --data-in-method connect --data-in-address tcp://127.0.0.1:7550" # non-default socket type and method for test mode, default is pull/bind
+FLP0+=" --data-out-address tcp://127.0.0.1:7560"
+FLP0+=" --data-out-address tcp://127.0.0.1:7561"
+@CMAKE_BINARY_DIR@/bin/$FLP0 &
+FLP0_PID=$!
+
+FLP1="flpSender"
+FLP1+=" --id FLP2"
+FLP1+=" --interactive 0"
+FLP1+=" --flp-index 1"
+FLP1+=" --event-size 1000000"
+FLP1+=" --num-epns 2"
+FLP1+=" --heartbeat-timeout 20000"
+FLP1+=" --test-mode 1"
+FLP1+=" --send-offset 0"
+FLP1+=" --hb-in-address tcp://127.0.0.1:7581"
+FLP1+=" --data-in-socket-type sub --data-in-method connect --data-in-address tcp://127.0.0.1:7550" # non-default socket type and method for test mode, default is pull/bind
+FLP1+=" --data-out-address tcp://127.0.0.1:7560"
+FLP1+=" --data-out-address tcp://127.0.0.1:7561"
+@CMAKE_BINARY_DIR@/bin/$FLP1 &
+FLP1_PID=$!
+
+# start 2 epnReceivers in non-interactive mode
+
+EPN0="epnReceiver"
+EPN0+=" --id EPN1"
+EPN0+=" --interactive 0"
+EPN0+=" --heartbeat-interval 5000"
+EPN0+=" --num-flps 2"
+EPN0+=" --test-mode 1"
+EPN0+=" --data-in-address tcp://127.0.0.1:7560"
+EPN0+=" --data-out-address tcp://*:7590 --data-out-socket-type pub" # non-default socket type  for test mode (because no receiver - do pub), default is push.
+EPN0+=" --hb-out-address tcp://127.0.0.1:7580"
+EPN0+=" --hb-out-address tcp://127.0.0.1:7581"
+EPN0+=" --ack-out-address tcp://127.0.0.1:7990"
+@CMAKE_BINARY_DIR@/bin/$EPN0 &
+EPN0_PID=$!
+
+EPN1="epnReceiver"
+EPN1+=" --id EPN2"
+EPN1+=" --interactive 0"
+EPN1+=" --heartbeat-interval 5000"
+EPN1+=" --num-flps 2"
+EPN1+=" --test-mode 1"
+EPN1+=" --data-in-address tcp://127.0.0.1:7561"
+EPN1+=" --data-out-address tcp://*:7591 --data-out-socket-type pub" # non-default socket type  for test mode (because no receiver - do pub), default is push.
+EPN1+=" --hb-out-address tcp://127.0.0.1:7580"
+EPN1+=" --hb-out-address tcp://127.0.0.1:7581"
+EPN1+=" --ack-out-address tcp://127.0.0.1:7990"
+@CMAKE_BINARY_DIR@/bin/$EPN1 &
+EPN1_PID=$!
+
+# give them some time to initialize before starting flpSyncSampler
+
+sleep 2
+
+# start flpSyncSampler in non-interactive mode
+
+SAMPLER="flpSyncSampler"
+SAMPLER+=" --id 101"
+SAMPLER+=" --event-rate 100"
+SAMPLER+=" --max-events 100"
+SAMPLER+=" --interactive 0"
+SAMPLER+=" --ack-in-address tcp://*:7990"
+SAMPLER+=" --data-out-address tcp://*:7550"
+@CMAKE_BINARY_DIR@/bin/$SAMPLER &
+SAMPLER_PID=$!
+
+# wait for the flpSyncSampler process to finish
+
+wait $SAMPLER_PID
+
+# stop the flpSenders and epnReceivers
+
+kill -SIGINT $FLP0_PID
+kill -SIGINT $FLP1_PID
+kill -SIGINT $EPN0_PID
+kill -SIGINT $EPN1_PID
+
+# wait for everything to finish
+
+wait $FLP0_PID
+wait $FLP1_PID
+wait $EPN0_PID
+wait $EPN1_PID

--- a/devices/flp2epn/O2EPNex.cxx
+++ b/devices/flp2epn/O2EPNex.cxx
@@ -7,8 +7,17 @@
 
 #include <boost/thread.hpp>
 #include <boost/bind.hpp>
-#include "O2EPNex.h"
+
 #include "FairMQLogger.h"
+#include "O2EPNex.h"
+
+struct Content {
+  double a;
+  double b;
+  int x;
+  int y;
+  int z;
+};
 
 O2EPNex::O2EPNex()
 {
@@ -17,19 +26,16 @@ O2EPNex::O2EPNex()
 void O2EPNex::Run()
 {
   while (CheckCurrentState(RUNNING)) {
-    FairMQMessage* msg = fTransportFactory->CreateMessage();
+    std::unique_ptr<FairMQMessage> msg(fTransportFactory->CreateMessage());
 
-    fChannels["data-in"].at(0).Receive(msg);
+    fChannels.at("data-in").at(0).Receive(msg);
 
-    int inputSize = msg->GetSize();
-    int numInput = inputSize / sizeof(Content);
-    Content* input = reinterpret_cast<Content*>(msg->GetData());
+    int numInput = msg->GetSize() / sizeof(Content);
+    Content* input = static_cast<Content*>(msg->GetData());
 
     // for (int i = 0; i < numInput; ++i) {
     //     LOG(INFO) << (&input[i])->x << " " << (&input[i])->y << " " << (&input[i])->z << " " << (&input[i])->a << " " << (&input[i])->b;
     // }
-
-    delete msg;
   }
 }
 

--- a/devices/flp2epn/O2EPNex.h
+++ b/devices/flp2epn/O2EPNex.h
@@ -10,19 +10,12 @@
 
 #include "FairMQDevice.h"
 
-struct Content {
-  double a;
-  double b;
-  int x;
-  int y;
-  int z;
-};
-
 class O2EPNex : public FairMQDevice
 {
   public:
     O2EPNex();
     virtual ~O2EPNex();
+
   protected:
     virtual void Run();
 };

--- a/devices/flp2epn/O2EpnMerger.h
+++ b/devices/flp2epn/O2EpnMerger.h
@@ -10,19 +10,12 @@
 
 #include "FairMQDevice.h"
 
-struct Content {
-  double a;
-  double b;
-  int x;
-  int y;
-  int z;
-};
-
 class O2EpnMerger: public FairMQDevice
 {
   public:
     O2EpnMerger();
     virtual ~O2EpnMerger();
+
   protected:
     virtual void Run();
 };

--- a/devices/flp2epn/O2FLPex.cxx
+++ b/devices/flp2epn/O2FLPex.cxx
@@ -17,6 +17,15 @@
 
 using namespace std;
 
+struct Content {
+  int id;
+  double a;
+  double b;
+  int x;
+  int y;
+  int z;
+};
+
 O2FLPex::O2FLPex() :
   fEventSize(10000)
 {
@@ -26,74 +35,68 @@ O2FLPex::~O2FLPex()
 {
 }
 
-void O2FLPex::Init()
-{
-  FairMQDevice::Init();
-}
-
 void O2FLPex::Run()
 {
   srand(time(NULL));
 
+  FairMQChannel& outChannel = fChannels.at("data-out").at(0);
+
   LOG(DEBUG) << "Message size: " << fEventSize * sizeof(Content) << " bytes.";
 
   while (CheckCurrentState(RUNNING)) {
-    Content* payload = new Content[fEventSize];
+    vector<Content> payload(fEventSize);
 
     for (int i = 0; i < fEventSize; ++i) {
-      (&payload[i])->x = rand() % 100 + 1;
-      (&payload[i])->y = rand() % 100 + 1;
-      (&payload[i])->z = rand() % 100 + 1;
-      (&payload[i])->a = (rand() % 100 + 1) / (rand() % 100 + 1);
-      (&payload[i])->b = (rand() % 100 + 1) / (rand() % 100 + 1);
+      payload.at(i).x = rand() % 100 + 1;
+      payload.at(i).y = rand() % 100 + 1;
+      payload.at(i).z = rand() % 100 + 1;
+      payload.at(i).a = (rand() % 100 + 1) / (rand() % 100 + 1);
+      payload.at(i).b = (rand() % 100 + 1) / (rand() % 100 + 1);
       // LOG(INFO) << (&payload[i])->x << " " << (&payload[i])->y << " " << (&payload[i])->z << " " << (&payload[i])->a << " " << (&payload[i])->b;
     }
 
-    FairMQMessage* msg = fTransportFactory->CreateMessage(fEventSize * sizeof(Content));
-    memcpy(msg->GetData(), payload, fEventSize * sizeof(Content));
+    unique_ptr<FairMQMessage> msg(fTransportFactory->CreateMessage(fEventSize * sizeof(Content)));
+    memcpy(msg->GetData(), payload.data(), fEventSize * sizeof(Content));
 
-    fChannels["data-out"].at(0).Send(msg);
-
-    delete[] payload;
-    delete msg;
+    outChannel.Send(msg);
   }
 }
 
 void O2FLPex::SetProperty(const int key, const string& value)
 {
   switch (key) {
-  default:
-    FairMQDevice::SetProperty(key, value);
-    break;
+    default:
+      FairMQDevice::SetProperty(key, value);
+      break;
   }
 }
 
 string O2FLPex::GetProperty(const int key, const string& default_/*= ""*/)
 {
   switch (key) {
-  default:
-    return FairMQDevice::GetProperty(key, default_);
+    default:
+      return FairMQDevice::GetProperty(key, default_);
   }
 }
 
 void O2FLPex::SetProperty(const int key, const int value)
 {
   switch (key) {
-  case EventSize:
-    fEventSize = value;
-    break;
-  default:
-    FairMQDevice::SetProperty(key, value);
-    break;
+    case EventSize:
+      fEventSize = value;
+      break;
+    default:
+      FairMQDevice::SetProperty(key, value);
+      break;
   }
 }
 
 int O2FLPex::GetProperty(const int key, const int default_/*= 0*/)
 {
   switch (key) {
-  case EventSize:
-    return fEventSize;
-  default:
-    return FairMQDevice::GetProperty(key, default_);
+    case EventSize:
+      return fEventSize;
+    default:
+      return FairMQDevice::GetProperty(key, default_);
   }
 }

--- a/devices/flp2epn/O2FLPex.h
+++ b/devices/flp2epn/O2FLPex.h
@@ -12,15 +12,6 @@
 
 #include "FairMQDevice.h"
 
-struct Content {
-  int id;
-  double a;
-  double b;
-  int x;
-  int y;
-  int z;
-};
-
 class O2FLPex : public FairMQDevice
 {
   public:
@@ -41,7 +32,6 @@ class O2FLPex : public FairMQDevice
   protected:
     int fEventSize;
 
-    virtual void Init();
     virtual void Run();
 };
 

--- a/devices/flp2epn/O2Merger.h
+++ b/devices/flp2epn/O2Merger.h
@@ -16,6 +16,7 @@ class O2Merger: public FairMQDevice
   public:
     O2Merger();
     virtual ~O2Merger();
+
   protected:
     virtual void Run();
 };

--- a/devices/flp2epn/O2Proxy.h
+++ b/devices/flp2epn/O2Proxy.h
@@ -16,6 +16,7 @@ class O2Proxy: public FairMQDevice
   public:
     O2Proxy();
     virtual ~O2Proxy();
+
   protected:
     virtual void Run();
 };


### PR DESCRIPTION
 - Add integration test for flp2epn-distributed.
   Test starts a chain of flpSyncSampler, 2 flpSenders and 2 epnReceivers.
   100 time frames are generated.
   Test succeeds if the timeframes are correctly distributed, merged and acknowledged.
 - Use smart pointer methods in flp2epn and flp2epn-distributed devices.