### PR TITLE
Add missing file from FairRoot

### DIFF
--- a/cmake/scripts/generate_dictionary_root.sh.in
+++ b/cmake/scripts/generate_dictionary_root.sh.in
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# This macro is used to generate the ROOT dictionaries
+# To use the ctest launchers one needs some environment variables which
+# are only present when running CMake. To have the same environment at
+# the time the dictionary is build this script is used which is build
+# at the time cmake runs.
+
+# Setup the needed environment
+export LD_LIBRARY_PATH=@MY_LD_LIBRARY_PATH@
+export DYLD_LIBRARY_PATH=@MY_LD_LIBRARY_PATH@
+export ROOTSYS=@ROOTSYS@
+
+@ROOT_CINT_EXECUTABLE@ -f @Int_DICTIONARY@ @EXTRA_DICT_PARAMETERS_STR@ -c  @Int_DEF_STR@ @Int_INC_STR@ @Int_HDRS_STR@ @Int_LINKDEF@


### PR DESCRIPTION
Looks like cmake/scripts/generate_dictionary_root.sh.in is needed when
compiling O2. I copied it from FairRoot. Not sure if this is what we
want or what is needed is making sure that the macro refers to fairroot
directory, rather than "CMAKE_PROJECT_DIR" which of course is different
for O2.