### PR TITLE
Eliminate warnings

### DIFF
--- a/Generators/Pythia8Generator.h
+++ b/Generators/Pythia8Generator.h
@@ -13,6 +13,12 @@
 #ifndef PNDP8GENERATOR_H
 #define PNDP8GENERATOR_H 1
 
+// Avoid the inclusion of dlfcn.h by Pyhtia.h that CINT is not able to process (avoid compile error on GCC > 5)
+#ifdef __CINT__
+#define _DLFCN_H_
+#define _DLFCN_H
+#endif
+
 #include "Basics.h"          // for RndmEngine
 #include "FairGenerator.h"   // for FairGenerator
 #include "Pythia8/Pythia.h"  // for Pythia

--- a/devices/flp2epn-distributed/FLPSender.cxx
+++ b/devices/flp2epn-distributed/FLPSender.cxx
@@ -28,18 +28,18 @@ struct f2eHeader {
 };
 
 FLPSender::FLPSender()
-  : fIndex(0)
-  , fSendOffset(0)
-  , fSendDelay(8)
-  , fHeaderBuffer()
+  : fHeaderBuffer()
   , fDataBuffer()
   , fArrivalTime()
   , fNumEPNs(0)
+  , fIndex(0)
+  , fSendOffset(0)
+  , fSendDelay(8)
+  , fEventSize(10000)
+  , fTestMode(0)
   , fHeartbeatTimeoutInMs(20000)
   , fHeartbeats()
   , fHeartbeatMutex()
-  , fEventSize(10000)
-  , fTestMode(0)
 {
 }
 

--- a/devices/flp2epn-distributed/FLPSyncSampler.cxx
+++ b/devices/flp2epn-distributed/FLPSyncSampler.cxx
@@ -20,11 +20,11 @@ using boost::posix_time::ptime;
 using namespace AliceO2::Devices;
 
 FLPSyncSampler::FLPSyncSampler()
-  : fEventRate(1)
+  : fTimeframeRTT()
+  , fEventRate(1)
   , fMaxEvents(0)
   , fStoreRTTinFile(0)
   , fEventCounter(0)
-  , fTimeframeRTT()
 {
 }
 

--- a/devices/flp2epn-distributed/run/runEPNReceiver.cxx
+++ b/devices/flp2epn-distributed/run/runEPNReceiver.cxx
@@ -17,8 +17,15 @@
 using namespace std;
 using namespace AliceO2::Devices;
 
-typedef struct DeviceOptions
+struct DeviceOptions
 {
+  DeviceOptions() :
+    id(), ioThreads(0), heartbeatIntervalInMs(0), bufferTimeoutInMs(0), numFLPs(0), testMode(0), interactive(0),
+    dataInSocketType(), dataInBufSize(1000), dataInMethod(), dataInAddress(), dataInRateLogging(0),
+    dataOutSocketType(), dataOutBufSize(1000), dataOutMethod(), dataOutAddress(), dataOutRateLogging(0),
+    hbOutSocketType(), hbOutBufSize(1000), hbOutMethod(), hbOutAddress(), hbOutRateLogging(0),
+    ackOutSocketType(), ackOutBufSize(1000), ackOutMethod(), ackOutAddress(), ackOutRateLogging(0) {}
+
   string id;
   int ioThreads;
   int heartbeatIntervalInMs;
@@ -50,7 +57,7 @@ typedef struct DeviceOptions
   string ackOutMethod;
   string ackOutAddress;
   int ackOutRateLogging;
-} DeviceOptions_t;
+};
 
 inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
 {
@@ -147,7 +154,7 @@ int main(int argc, char** argv)
   epn.CatchSignals();
 
   // container for the command line options
-  DeviceOptions_t options;
+  DeviceOptions options;
   // parse the command line options and fill the container
   try {
     if (!parse_cmd_line(argc, argv, &options))

--- a/devices/flp2epn-distributed/run/runFLPSender.cxx
+++ b/devices/flp2epn-distributed/run/runFLPSender.cxx
@@ -17,8 +17,14 @@
 using namespace std;
 using namespace AliceO2::Devices;
 
-typedef struct DeviceOptions
+struct DeviceOptions
 {
+  DeviceOptions() :
+    id(), flpIndex(0), eventSize(0), ioThreads(0), numEPNs(0), heartbeatTimeoutInMs(0), testMode(0), interactive(0), sendOffset(0), sendDelay(0),
+    dataInSocketType(), dataInBufSize(0), dataInMethod(), dataInAddress(), dataInRateLogging(0),
+    dataOutSocketType(), dataOutBufSize(0), dataOutMethod(), dataOutAddress(), dataOutRateLogging(0),
+    hbInSocketType(), hbInBufSize(0), hbInMethod(), hbInAddress(), hbInRateLogging(0) {}
+
   string id;
   int flpIndex;
   int eventSize;
@@ -47,7 +53,7 @@ typedef struct DeviceOptions
   string hbInMethod;
   string hbInAddress;
   int hbInRateLogging;
-} DeviceOptions_t;
+};
 
 inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
 {
@@ -141,7 +147,7 @@ int main(int argc, char** argv)
   flp.CatchSignals();
 
   // container for the command line options
-  DeviceOptions_t options;
+  DeviceOptions options;
   // parse the command line options and fill the container
   try {
     if (!parse_cmd_line(argc, argv, &options)) {

--- a/devices/flp2epn-distributed/run/runFLPSyncSampler.cxx
+++ b/devices/flp2epn-distributed/run/runFLPSyncSampler.cxx
@@ -17,8 +17,13 @@
 using namespace std;
 using namespace AliceO2::Devices;
 
-typedef struct DeviceOptions
+struct DeviceOptions
 {
+  DeviceOptions() :
+    id(), eventRate(0), maxEvents(0), ioThreads(0), interactive(0), storeRTTinFile(0),
+    dataOutSocketType(), dataOutBufSize(0), dataOutMethod(), dataOutAddress(), dataOutRateLogging(0),
+    ackInSocketType(), ackInBufSize(0), ackInMethod(), ackInAddress(), ackInRateLogging(0) {}
+
   string id;
   int eventRate;
   int maxEvents;
@@ -37,7 +42,7 @@ typedef struct DeviceOptions
   string ackInMethod;
   string ackInAddress;
   int ackInRateLogging;
-} DeviceOptions_t;
+};
 
 inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
 {
@@ -108,7 +113,7 @@ int main(int argc, char** argv)
   sampler.CatchSignals();
 
   // container for the command line options
-  DeviceOptions_t options;
+  DeviceOptions options;
   // parse the command line options and fill the container
   try {
     if (!parse_cmd_line(argc, argv, &options))

--- a/devices/flp2epn-distributed/runO2Prototype/runEPNReceiver.cxx
+++ b/devices/flp2epn-distributed/runO2Prototype/runEPNReceiver.cxx
@@ -25,8 +25,15 @@
 using namespace std;
 using namespace AliceO2::Devices;
 
-typedef struct DeviceOptions
+struct DeviceOptions
 {
+  DeviceOptions() :
+    id(), ioThreads(0), heartbeatIntervalInMs(0), bufferTimeoutInMs(0), numFLPs(0), testMode(0),
+    dataInSocketType(), dataInBufSize(1000), dataInMethod(), dataInRateLogging(0),
+    dataOutSocketType(), dataOutBufSize(1000), dataOutMethod(), dataOutRateLogging(0),
+    hbOutSocketType(), hbOutBufSize(1000), hbOutMethod(), hbOutRateLogging(0),
+    ackOutSocketType(), ackOutBufSize(1000), ackOutMethod(), ackOutRateLogging(0) {}
+
   string id;
   int ioThreads;
   int heartbeatIntervalInMs;
@@ -57,7 +64,7 @@ typedef struct DeviceOptions
   string ackOutMethod;
   // string ackOutAddress;
   int ackOutRateLogging;
-} DeviceOptions_t;
+};
 
 inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
 {
@@ -152,7 +159,7 @@ int main(int argc, char** argv)
   epn.CatchSignals();
 
   // create container for command line options and fill it
-  DeviceOptions_t options;
+  DeviceOptions options;
   try {
     if (!parse_cmd_line(argc, argv, &options))
       return 0;

--- a/devices/flp2epn-distributed/runO2Prototype/runFLPSender.cxx
+++ b/devices/flp2epn-distributed/runO2Prototype/runFLPSender.cxx
@@ -25,8 +25,14 @@
 using namespace std;
 using namespace AliceO2::Devices;
 
-typedef struct DeviceOptions
+struct DeviceOptions
 {
+  DeviceOptions() :
+    id(), flpIndex(0), eventSize(0), ioThreads(0), numEPNs(0), heartbeatTimeoutInMs(0), testMode(0), sendOffset(0), sendDelay(0),
+    dataInSocketType(), dataInBufSize(0), dataInMethod(), dataInRateLogging(0),
+    dataOutSocketType(), dataOutBufSize(0), dataOutMethod(), dataOutRateLogging(0),
+    hbInSocketType(), hbInBufSize(0), hbInMethod(), hbInRateLogging(0) {}
+
   string id;
   int flpIndex;
   int eventSize;
@@ -54,7 +60,7 @@ typedef struct DeviceOptions
   string hbInMethod;
   // string hbInAddress;
   int hbInRateLogging;
-} DeviceOptions_t;
+};
 
 inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
 {
@@ -143,7 +149,7 @@ int main(int argc, char** argv)
   flp.CatchSignals();
 
   // container for the command line options
-  DeviceOptions_t options;
+  DeviceOptions options;
   // parse the command line options and fill the container
   try {
     if (!parse_cmd_line(argc, argv, &options))

--- a/devices/flp2epn-distributed/runO2Prototype/runFLPSyncSampler.cxx
+++ b/devices/flp2epn-distributed/runO2Prototype/runFLPSyncSampler.cxx
@@ -25,8 +25,13 @@
 using namespace std;
 using namespace AliceO2::Devices;
 
-typedef struct DeviceOptions
+struct DeviceOptions
 {
+  DeviceOptions() :
+    id(), eventRate(0), maxEvents(0), ioThreads(0), storeRTTinFile(0),
+    dataOutSocketType(), dataOutBufSize(0), dataOutMethod(), dataOutRateLogging(0),
+    ackInSocketType(), ackInBufSize(0), ackInMethod(), ackInRateLogging(0) {}
+
   string id;
   int eventRate;
   int maxEvents;
@@ -44,7 +49,7 @@ typedef struct DeviceOptions
   string ackInMethod;
   // string ackInAddress;
   int ackInRateLogging;
-} DeviceOptions_t;
+};
 
 inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
 {
@@ -113,7 +118,7 @@ int main(int argc, char** argv)
   sampler.CatchSignals();
 
   // create container for command line options and fill it
-  DeviceOptions_t options;
+  DeviceOptions options;
   try {
     if (!parse_cmd_line(argc, argv, &options))
       return 0;

--- a/devices/flp2epn/O2EPNex.cxx
+++ b/devices/flp2epn/O2EPNex.cxx
@@ -30,8 +30,8 @@ void O2EPNex::Run()
 
     fChannels.at("data-in").at(0).Receive(msg);
 
-    int numInput = msg->GetSize() / sizeof(Content);
-    Content* input = static_cast<Content*>(msg->GetData());
+    // int numInput = msg->GetSize() / sizeof(Content);
+    // Content* input = static_cast<Content*>(msg->GetData());
 
     // for (int i = 0; i < numInput; ++i) {
     //     LOG(INFO) << (&input[i])->x << " " << (&input[i])->y << " " << (&input[i])->z << " " << (&input[i])->a << " " << (&input[i])->b;

--- a/devices/flp2epn/O2EpnMerger.cxx
+++ b/devices/flp2epn/O2EpnMerger.cxx
@@ -26,7 +26,7 @@ void O2EpnMerger::Run()
 
     poller->Poll(100);
 
-    for (int i = 0; i < fChannels.at("data-in").size(); i++) {
+    for (unsigned int i = 0; i < fChannels.at("data-in").size(); i++) {
       if (poller->CheckInput(i)) {
         if (fChannels.at("data-in").at(i).Receive(msg)) {
           // LOG(INFO) << "------ recieve Msg from " << i ;

--- a/devices/flp2epn/O2Merger.cxx
+++ b/devices/flp2epn/O2Merger.cxx
@@ -31,7 +31,7 @@ void O2Merger::Run()
 
     poller->Poll(100);
 
-    for (int i = 0; i < fChannels.at("data-in").size(); i++) {
+    for (unsigned int i = 0; i < fChannels.at("data-in").size(); i++) {
       if (poller->CheckInput(i)) {
         if (fChannels.at("data-in").at(i).Receive(msg) >= 0) {
           // LOG(INFO) << "------ recieve Msg from " << i ;

--- a/devices/flp2epn/run/runEPN.cxx
+++ b/devices/flp2epn/run/runEPN.cxx
@@ -20,15 +20,19 @@
 
 using namespace std;
 
-typedef struct DeviceOptions
+struct DeviceOptions
 {
+    DeviceOptions() :
+        id(), ioThreads(1),
+        inputSocketType(), inputBufSize(1000), inputMethod(), inputAddress() {}
+
     string id;
     int ioThreads;
     string inputSocketType;
     int inputBufSize;
     string inputMethod;
     string inputAddress;
-} DeviceOptions_t;
+};
 
 inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
 {
@@ -49,7 +53,7 @@ inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
     bpo::variables_map vm;
     bpo::store(bpo::parse_command_line(_argc, _argv, desc), vm);
 
-    if ( vm.count("help") )
+    if (vm.count("help"))
     {
         LOG(INFO) << "EPN" << endl << desc;
         return false;
@@ -57,23 +61,12 @@ inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
 
     bpo::notify(vm);
 
-    if ( vm.count("id") )
-        _options->id = vm["id"].as<string>();
-
-    if ( vm.count("io-threads") )
-        _options->ioThreads = vm["io-threads"].as<int>();
-
-    if ( vm.count("input-socket-type") )
-        _options->inputSocketType = vm["input-socket-type"].as<string>();
-
-    if ( vm.count("input-buff-size") )
-        _options->inputBufSize = vm["input-buff-size"].as<int>();
-
-    if ( vm.count("input-method") )
-        _options->inputMethod = vm["input-method"].as<string>();
-
-    if ( vm.count("input-address") )
-        _options->inputAddress = vm["input-address"].as<string>();
+    if (vm.count("id"))                { _options->id              = vm["id"].as<string>(); }
+    if (vm.count("io-threads"))        { _options->ioThreads       = vm["io-threads"].as<int>(); }
+    if (vm.count("input-socket-type")) { _options->inputSocketType = vm["input-socket-type"].as<string>(); }
+    if (vm.count("input-buff-size"))   { _options->inputBufSize    = vm["input-buff-size"].as<int>(); }
+    if (vm.count("input-method"))      { _options->inputMethod     = vm["input-method"].as<string>(); }
+    if (vm.count("input-address"))     { _options->inputAddress    = vm["input-address"].as<string>(); }
 
     return true;
 }
@@ -83,7 +76,7 @@ int main(int argc, char** argv)
     O2EPNex epn;
     epn.CatchSignals();
 
-    DeviceOptions_t options;
+    DeviceOptions options;
     try
     {
         if (!parse_cmd_line(argc, argv, &options))

--- a/devices/flp2epn/run/runEPN_M.cxx
+++ b/devices/flp2epn/run/runEPN_M.cxx
@@ -20,15 +20,19 @@
 
 using namespace std;
 
-typedef struct DeviceOptions
+struct DeviceOptions
 {
+    DeviceOptions() :
+        id(), ioThreads(1),
+        inputSocketType(), inputBufSize(1000), inputMethod(), inputAddress() {}
+
     string id;
     int ioThreads;
     string inputSocketType;
     int inputBufSize;
     string inputMethod;
     string inputAddress;
-} DeviceOptions_t;
+};
 
 inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
 {
@@ -49,7 +53,7 @@ inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
     bpo::variables_map vm;
     bpo::store(bpo::parse_command_line(_argc, _argv, desc), vm);
 
-    if ( vm.count("help") )
+    if (vm.count("help"))
     {
         LOG(INFO) << "EPN Merger" << endl << desc;
         return false;
@@ -57,23 +61,12 @@ inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
 
     bpo::notify(vm);
 
-    if ( vm.count("id") )
-        _options->id = vm["id"].as<string>();
-
-    if ( vm.count("io-threads") )
-        _options->ioThreads = vm["io-threads"].as<int>();
-
-    if ( vm.count("input-socket-type") )
-        _options->inputSocketType = vm["input-socket-type"].as<string>();
-
-    if ( vm.count("input-buff-size") )
-        _options->inputBufSize = vm["input-buff-size"].as<int>();
-
-    if ( vm.count("input-method") )
-        _options->inputMethod = vm["input-method"].as<string>();
-
-    if ( vm.count("input-address") )
-        _options->inputAddress = vm["input-address"].as<string>();
+    if (vm.count("id"))                { _options->id              = vm["id"].as<string>(); }
+    if (vm.count("io-threads"))        { _options->ioThreads       = vm["io-threads"].as<int>(); }
+    if (vm.count("input-socket-type")) { _options->inputSocketType = vm["input-socket-type"].as<string>(); }
+    if (vm.count("input-buff-size"))   { _options->inputBufSize    = vm["input-buff-size"].as<int>(); }
+    if (vm.count("input-method"))      { _options->inputMethod     = vm["input-method"].as<string>(); }
+    if (vm.count("input-address"))     { _options->inputAddress    = vm["input-address"].as<string>(); }
 
     return true;
 }
@@ -83,7 +76,7 @@ int main(int argc, char** argv)
     O2EpnMerger epn;
     epn.CatchSignals();
 
-    DeviceOptions_t options;
+    DeviceOptions options;
     try
     {
         if (!parse_cmd_line(argc, argv, &options))

--- a/devices/flp2epn/run/runFLP.cxx
+++ b/devices/flp2epn/run/runFLP.cxx
@@ -20,8 +20,12 @@
 
 using namespace std;
 
-typedef struct DeviceOptions
+struct DeviceOptions
 {
+    DeviceOptions() :
+        id(), ioThreads(1),
+        outputSocketType(), outputBufSize(1000), outputMethod(), outputAddress() {}
+
     string id;
     int eventSize;
     int ioThreads;
@@ -29,7 +33,7 @@ typedef struct DeviceOptions
     int outputBufSize;
     string outputMethod;
     string outputAddress;
-} DeviceOptions_t;
+};
 
 inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
 {
@@ -51,7 +55,7 @@ inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
     bpo::variables_map vm;
     bpo::store(bpo::parse_command_line(_argc, _argv, desc), vm);
 
-    if ( vm.count("help") )
+    if (vm.count("help"))
     {
         LOG(INFO) << "FLP" << endl << desc;
         return false;
@@ -59,26 +63,13 @@ inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
 
     bpo::notify(vm);
 
-    if ( vm.count("id") )
-        _options->id = vm["id"].as<string>();
-
-    if ( vm.count("event-size") )
-        _options->eventSize = vm["event-size"].as<int>();
-
-    if ( vm.count("io-threads") )
-        _options->ioThreads = vm["io-threads"].as<int>();
-
-    if ( vm.count("output-socket-type") )
-        _options->outputSocketType = vm["output-socket-type"].as<string>();
-
-    if ( vm.count("output-buff-size") )
-        _options->outputBufSize = vm["output-buff-size"].as<int>();
-
-    if ( vm.count("output-method") )
-        _options->outputMethod = vm["output-method"].as<string>();
-
-    if ( vm.count("output-address") )
-        _options->outputAddress = vm["output-address"].as<string>();
+    if (vm.count("id"))                 { _options->id               = vm["id"].as<string>(); }
+    if (vm.count("event-size"))         { _options->eventSize        = vm["event-size"].as<int>(); }
+    if (vm.count("io-threads"))         { _options->ioThreads        = vm["io-threads"].as<int>(); }
+    if (vm.count("output-socket-type")) { _options->outputSocketType = vm["output-socket-type"].as<string>(); }
+    if (vm.count("output-buff-size"))   { _options->outputBufSize    = vm["output-buff-size"].as<int>(); }
+    if (vm.count("output-method"))      { _options->outputMethod     = vm["output-method"].as<string>(); }
+    if (vm.count("output-address"))     { _options->outputAddress    = vm["output-address"].as<string>(); }
 
     return true;
 }
@@ -88,7 +79,7 @@ int main(int argc, char** argv)
     O2FLPex flp;
     flp.CatchSignals();
 
-    DeviceOptions_t options;
+    DeviceOptions options;
     try
     {
         if (!parse_cmd_line(argc, argv, &options))

--- a/devices/flp2epn/run/runMerger.cxx
+++ b/devices/flp2epn/run/runMerger.cxx
@@ -20,8 +20,13 @@
 
 using namespace std;
 
-typedef struct DeviceOptions
+struct DeviceOptions
 {
+    DeviceOptions() :
+        id(), ioThreads(1), numInputs(0),
+        inputSocketType(), inputBufSize(), inputMethod(), inputAddress(),
+        outputSocketType(), outputBufSize(1000), outputMethod(), outputAddress() {}
+
     string id;
     int ioThreads;
     int numInputs;
@@ -33,7 +38,7 @@ typedef struct DeviceOptions
     int outputBufSize;
     string outputMethod;
     string outputAddress;
-} DeviceOptions_t;
+};
 
 inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
 {
@@ -59,7 +64,7 @@ inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
     bpo::variables_map vm;
     bpo::store(bpo::parse_command_line(_argc, _argv, desc), vm);
 
-    if ( vm.count("help") )
+    if (vm.count("help"))
     {
         LOG(INFO) << "MERGER" << endl << desc;
         return false;
@@ -67,38 +72,17 @@ inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
 
     bpo::notify(vm);
 
-    if ( vm.count("id") )
-        _options->id = vm["id"].as<string>();
-
-    if ( vm.count("io-threads") )
-        _options->ioThreads = vm["io-threads"].as<int>();
-
-    if ( vm.count("num-inputs") )
-        _options->numInputs = vm["num-inputs"].as<int>();
-
-    if ( vm.count("input-socket-type") )
-        _options->inputSocketType = vm["input-socket-type"].as< vector<string> >();
-
-    if ( vm.count("input-buff-size") )
-        _options->inputBufSize = vm["input-buff-size"].as< vector<int> >();
-
-    if ( vm.count("input-method") )
-        _options->inputMethod = vm["input-method"].as< vector<string> >();
-
-    if ( vm.count("input-address") )
-        _options->inputAddress = vm["input-address"].as< vector<string> >();
-
-    if ( vm.count("output-socket-type") )
-        _options->outputSocketType = vm["output-socket-type"].as<string>();
-
-    if ( vm.count("output-buff-size") )
-        _options->outputBufSize = vm["output-buff-size"].as<int>();
-
-    if ( vm.count("output-method") )
-        _options->outputMethod = vm["output-method"].as<string>();
-
-    if ( vm.count("output-address") )
-        _options->outputAddress = vm["output-address"].as<string>();
+    if (vm.count("id"))                 { _options->id               = vm["id"].as<string>(); }
+    if (vm.count("io-threads"))         { _options->ioThreads        = vm["io-threads"].as<int>(); }
+    if (vm.count("num-inputs"))         { _options->numInputs        = vm["num-inputs"].as<int>(); }
+    if (vm.count("input-socket-type"))  { _options->inputSocketType  = vm["input-socket-type"].as< vector<string> >(); }
+    if (vm.count("input-buff-size"))    { _options->inputBufSize     = vm["input-buff-size"].as< vector<int> >(); }
+    if (vm.count("input-method"))       { _options->inputMethod      = vm["input-method"].as< vector<string> >(); }
+    if (vm.count("input-address"))      { _options->inputAddress     = vm["input-address"].as< vector<string> >(); }
+    if (vm.count("output-socket-type")) { _options->outputSocketType = vm["output-socket-type"].as<string>(); }
+    if (vm.count("output-buff-size"))   { _options->outputBufSize    = vm["output-buff-size"].as<int>(); }
+    if (vm.count("output-method"))      { _options->outputMethod     = vm["output-method"].as<string>(); }
+    if (vm.count("output-address"))     { _options->outputAddress    = vm["output-address"].as<string>(); }
 
     return true;
 }
@@ -108,7 +92,7 @@ int main(int argc, char** argv)
     O2Merger merger;
     merger.CatchSignals();
 
-    DeviceOptions_t options;
+    DeviceOptions options;
     try
     {
         if (!parse_cmd_line(argc, argv, &options))

--- a/devices/flp2epn/run/runProxy.cxx
+++ b/devices/flp2epn/run/runProxy.cxx
@@ -20,8 +20,13 @@
 
 using namespace std;
 
-typedef struct DeviceOptions
+struct DeviceOptions
 {
+    DeviceOptions() :
+        id(), ioThreads(1),
+        inputSocketType(), inputBufSize(1000), inputMethod(), inputAddress(),
+        outputSocketType(), outputBufSize(1000), outputMethod(), outputAddress() {}
+
     string id;
     int ioThreads;
     string inputSocketType;
@@ -32,7 +37,7 @@ typedef struct DeviceOptions
     int outputBufSize;
     string outputMethod;
     string outputAddress;
-} DeviceOptions_t;
+};
 
 inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
 {
@@ -57,7 +62,7 @@ inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
     bpo::variables_map vm;
     bpo::store(bpo::parse_command_line(_argc, _argv, desc), vm);
 
-    if ( vm.count("help") )
+    if (vm.count("help"))
     {
         LOG(INFO) << "Proxy" << endl << desc;
         return false;
@@ -65,35 +70,16 @@ inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
 
     bpo::notify(vm);
 
-    if ( vm.count("id") )
-        _options->id = vm["id"].as<string>();
-
-    if ( vm.count("io-threads") )
-        _options->ioThreads = vm["io-threads"].as<int>();
-
-    if ( vm.count("input-socket-type") )
-        _options->inputSocketType = vm["input-socket-type"].as<string>();
-
-    if ( vm.count("input-buff-size") )
-        _options->inputBufSize = vm["input-buff-size"].as<int>();
-
-    if ( vm.count("input-method") )
-        _options->inputMethod = vm["input-method"].as<string>();
-
-    if ( vm.count("input-address") )
-        _options->inputAddress = vm["input-address"].as<string>();
-
-    if ( vm.count("output-socket-type") )
-        _options->outputSocketType = vm["output-socket-type"].as<string>();
-
-    if ( vm.count("output-buff-size") )
-        _options->outputBufSize = vm["output-buff-size"].as<int>();
-
-    if ( vm.count("output-method") )
-        _options->outputMethod = vm["output-method"].as<string>();
-
-    if ( vm.count("output-address") )
-        _options->outputAddress = vm["output-address"].as<string>();
+    if (vm.count("id"))                 { _options->id               = vm["id"].as<string>(); }
+    if (vm.count("io-threads"))         { _options->ioThreads        = vm["io-threads"].as<int>(); }
+    if (vm.count("input-socket-type"))  { _options->inputSocketType  = vm["input-socket-type"].as<string>(); }
+    if (vm.count("input-buff-size"))    { _options->inputBufSize     = vm["input-buff-size"].as<int>(); }
+    if (vm.count("input-method"))       { _options->inputMethod      = vm["input-method"].as<string>(); }
+    if (vm.count("input-address"))      { _options->inputAddress     = vm["input-address"].as<string>(); }
+    if (vm.count("output-socket-type")) { _options->outputSocketType = vm["output-socket-type"].as<string>(); }
+    if (vm.count("output-buff-size"))   { _options->outputBufSize    = vm["output-buff-size"].as<int>(); }
+    if (vm.count("output-method"))      { _options->outputMethod     = vm["output-method"].as<string>(); }
+    if (vm.count("output-address"))     { _options->outputAddress    = vm["output-address"].as<string>(); }
 
     return true;
 }
@@ -103,7 +89,7 @@ int main(int argc, char** argv)
     O2Proxy proxy;
     proxy.CatchSignals();
 
-    DeviceOptions_t options;
+    DeviceOptions options;
     try
     {
         if (!parse_cmd_line(argc, argv, &options))


### PR DESCRIPTION
Eliminate several warnings:
- member initialization order for some device classes `[-Wreorder]`.
- comparison between signed and unsigned integer `[-Wsign-compare]`.
- member initialization lists `[-Weffc++]`.
