### PR TITLE
Let ConditionsMQServer derive from FairRoot/parmq/ParameterMQServer

### DIFF
--- a/o2cdb/CMakeLists.txt
+++ b/o2cdb/CMakeLists.txt
@@ -46,7 +46,7 @@ Set(NO_DICT_SRCS
 )
 
 set(DEPENDENCIES
-  Base ParBase FairMQ boost_thread boost_program_options boost_system boost_log fairmq_logger pthread Core Tree XMLParser Hist
+  Base ParBase FairMQ ParMQ boost_program_options boost_system boost_log fairmq_logger pthread Core Tree XMLParser Hist
 )
 
 set(LIBRARY_NAME AliceO2Cdb)

--- a/o2cdb/ConditionsMQServer.h
+++ b/o2cdb/ConditionsMQServer.h
@@ -17,51 +17,23 @@
 
 #include <string>
 
-#include "FairMQDevice.h"
+#include "ParameterMQServer.h"
 #include "Manager.h"
-
-class FairRuntimeDb;
 
 namespace AliceO2 {
 namespace CDB {
 
-class ConditionsMQServer : public FairMQDevice
+class ConditionsMQServer : public ParameterMQServer
 {
   public:
-    enum
-    {
-        FirstInputName = FairMQDevice::Last,
-        FirstInputType,
-        SecondInputName,
-        SecondInputType,
-        OutputName,
-        OutputType,
-        Last
-    };
-
     ConditionsMQServer();
     virtual ~ConditionsMQServer();
 
     virtual void Run();
     virtual void InitTask();
 
-    static void CustomCleanup(void *data, void* hint);
-
-    virtual void SetProperty(const int key, const std::string& value);
-    virtual std::string GetProperty(const int key, const std::string& default_ = "");
-    virtual void SetProperty(const int key, const int value);
-    virtual int GetProperty(const int key, const int default_ = 0);
-
   private:
-    FairRuntimeDb* fRtdb;
     Manager* fCdbManager;
-
-    std::string fFirstInputName;
-    std::string fFirstInputType;
-    std::string fSecondInputName;
-    std::string fSecondInputType;
-    std::string fOutputName;
-    std::string fOutputType;
 };
 }
 }

--- a/o2cdb/README
+++ b/o2cdb/README
@@ -3,8 +3,8 @@ To run the MQ server-client example with the MQ server replying with CDB objects
 0) In each shell configure the AliceO2 environment: source <your ${CMAKE_BINARY_DIR}>/config.sh
 
 1) To create a local O2CDB instance run the macro
-   root -l bin/config/fill_local_ocdb.C
-   under your build directory. This will create "DET/Calib/Histo" calibration objects in bin/config/O2CDB for a hundred of runs
+   root -l fill_local_ocdb.C
+   in ${CMAKE_BINARY_DIR}/bin/config/. This will create "DET/Calib/Histo" calibration objects for a hundred runs in the same directory/O2CDB/.
 
 2a) In one shell run the server example:
 <your ${CMAKE_BINARY_DIR}>/bin/conditions-server --id parmq-server --config-json-file <your ${CMAKE_BINARY_DIR}>/bin/config/conditions-server.json

--- a/o2cdb/fill_local_ocdb.C
+++ b/o2cdb/fill_local_ocdb.C
@@ -7,7 +7,7 @@ void fill_local_ocdb()
   TH1F* h = 0;
   for (int run = 2000; run < 2100; run++) {
     cdb->setRun(run);
-    h = new TH1F("aHisto", "gauss", 100, -5, 5);
+    h = new TH1F(Form("histo for %d run", run), "gauss", 100, -5, 5);
     h->FillRandom("gaus", 1000);
     AliceO2::CDB::ConditionId* id = new AliceO2::CDB::ConditionId("DET/Calib/Histo", run, run, 1, 0);
     AliceO2::CDB::ConditionMetaData* md = new AliceO2::CDB::ConditionMetaData();


### PR DESCRIPTION
This commit also requires the following change (one added line, string data members made protected) in parmq/ParameterMQServer.h in FairRoot:

diff --git a/parmq/ParameterMQServer.h b/parmq/ParameterMQServer.h
index 2253b37..661d9c7 100644
--- a/parmq/ParameterMQServer.h
+++ b/parmq/ParameterMQServer.h
@@ -53,6 +53,7 @@ class ParameterMQServer : public FairMQDevice
   private:
     FairRuntimeDb* fRtdb;

+  protected:
     std::string fFirstInputName;
     std::string fFirstInputType;
     std::string fSecondInputName; 



Cheers,
   Raffaele