### PR TITLE
Reverting accidentally merged commit

### DIFF
--- a/DataFormats/Generic/test/testMessageList.cxx
+++ b/DataFormats/Generic/test/testMessageList.cxx
@@ -78,8 +78,7 @@ void print_list(ListType& list, typename ListType::HdrComparison hdrsel = typena
        it != list.end();
        ++it) {
     // the iterator defines a conversion operator to the header type
-    typename ListType::header_type hdr = it;
-    std::cout << hdr << std::endl;
+    std::cout << static_cast<typename ListType::header_type>(it) << std::endl;
     // dereferencing of the iterator gives the payload
     std::cout << *it << std::endl;
   }


### PR DESCRIPTION
This commit was not part of the pull request but got merged accidentally.

Revert "Bugfix: replace static_cast by local variable for type conversion"

This reverts commit d525a090af6eb016c7d92783b9dc3cc1478d2d72.
The type cast has not been the problem.