### PR TITLE
Adapt conditions to new scheme

### DIFF
--- a/CCDB/src/runConditionsClient.cxx
+++ b/CCDB/src/runConditionsClient.cxx
@@ -18,13 +18,6 @@
 #include "FairMQParser.h"
 #include "FairMQProgOptions.h"
 #include "ConditionsMQClient.h"
-
-#ifdef NANOMSG
-#include "FairMQTransportFactoryNN.h"
-#else
-#include "FairMQTransportFactoryZMQ.h"
-#endif
-
 using namespace std;
 using namespace boost::program_options;
 using namespace AliceO2::CDB;
@@ -56,14 +49,6 @@ int main(int argc, char** argv)
         client.fChannels = config.GetFairMQMap();
 
         LOG(INFO) << "PID: " << getpid();
-
-#ifdef NANOMSG
-        FairMQTransportFactory* transportFactory = new FairMQTransportFactoryNN();
-#else
-        FairMQTransportFactory* transportFactory = new FairMQTransportFactoryZMQ();
-#endif
-
-        client.SetTransport(transportFactory);
 
         client.SetProperty(ConditionsMQClient::Id, "client");
         client.SetProperty(ConditionsMQClient::ParameterName, parameterName);

--- a/CCDB/src/runConditionsClient.cxx
+++ b/CCDB/src/runConditionsClient.cxx
@@ -46,10 +46,7 @@ int main(int argc, char** argv)
 
         config.AddToCmdLineOptions(clientOptions);
 
-        if (config.ParseAll(argc, argv))
-        {
-            return 0;
-        }
+        config.ParseAll(argc, argv);
 
         string file = config.GetValue<string>("config-json-file");
         string id = config.GetValue<string>("id");

--- a/CCDB/src/runConditionsServer.cxx
+++ b/CCDB/src/runConditionsServer.cxx
@@ -19,13 +19,6 @@
 #include "FairMQProgOptions.h"
 #include "ConditionsMQServer.h"
 #include "TApplication.h"
-
-#ifdef NANOMSG
-#include "FairMQTransportFactoryNN.h"
-#else
-#include "FairMQTransportFactoryZMQ.h"
-#endif
-
 using namespace std;
 using namespace boost::program_options;
 using namespace AliceO2::CDB;
@@ -69,13 +62,6 @@ int main(int argc, char** argv)
         LOG(INFO) << "PID: " << getpid();
 
         TApplication app("ConditionsMQServer", 0, 0);
-
-#ifdef NANOMSG
-        FairMQTransportFactory* transportFactory = new FairMQTransportFactoryNN();
-#else
-        FairMQTransportFactory* transportFactory = new FairMQTransportFactoryZMQ();
-#endif
-        server.SetTransport(transportFactory);
 
         server.SetProperty(ConditionsMQServer::Id, id);
         server.SetProperty(ConditionsMQServer::NumIoThreads, config.GetValue<int>("io-threads"));

--- a/CCDB/src/runConditionsServer.cxx
+++ b/CCDB/src/runConditionsServer.cxx
@@ -57,11 +57,8 @@ int main(int argc, char** argv)
 
         config.AddToCmdLineOptions(serverOptions);
 
-        if (config.ParseAll(argc, argv))
-        {
-            return 0;
-        }
-
+       config.ParseAll(argc, argv);
+       
         string file = config.GetValue<string>("config-json-file");
         string id = config.GetValue<string>("id");
 


### PR DESCRIPTION
Call the ParseAll without if statement as it does not return anything
Remove outdated way of choosing the transport engine

