### PR TITLE
Added simple check for availability of FairMQ in the cmake config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,8 @@ else(NOT ALICEO2_MODULAR_BUILD)
 endif(NOT ALICEO2_MODULAR_BUILD)
 
 find_package(AliRoot)
-find_package(FairRoot)
+find_package(FairRoot REQUIRED)
+find_package(FairMQ REQUIRED)
 
 # Load some basic macros which are needed later on
 include(FairMacros)
@@ -108,7 +109,6 @@ CHECK_EXTERNAL_PACKAGE_INSTALL_DIR()
 # mandatory
 
 find_package(ROOT 5.32.00 REQUIRED)
-find_package(FairMQ REQUIRED)
 find_package(Pythia8)
 find_package(Pythia6)
 if(ALICEO2_MODULAR_BUILD)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,7 @@ CHECK_EXTERNAL_PACKAGE_INSTALL_DIR()
 # mandatory
 
 find_package(ROOT 5.32.00 REQUIRED)
+find_package(FairMQ REQUIRED)
 find_package(Pythia8)
 find_package(Pythia6)
 if(ALICEO2_MODULAR_BUILD)

--- a/cmake/modules/FindFairMQ.cmake
+++ b/cmake/modules/FindFairMQ.cmake
@@ -6,13 +6,29 @@
 # also have to be available in the required (minimal) version.
 #
 
+if(FairRoot_DIR)
+  set(FAIRROOTPATH ${FairRoot_DIR})
+else()
+  set(FAIRROOTPATH $ENV{FAIRROOTPATH})
+endif(FairRoot_DIR)
+
+if(FAIRROOTPATH)
+  if(NOT FairMQ_FIND_QUIETLY)
+  MESSAGE(STATUS "FairRoot ... - found ${FAIRROOTPATH}")
+  endif(NOT FairMQ_FIND_QUIETLY)
+else()
+  if(NOT FairMQ_FIND_QUIETLY)
+  MESSAGE(FATAL_ERROR "FairRoot installation not found")
+  endif(NOT FairMQ_FIND_QUIETLY)
+endif(FAIRROOTPATH)
+
 set(FAIRMQ_REQUIRED_HEADERS FairMQDevice.h)
 if(NOT FairMQ_FIND_QUIETLY)
   message(STATUS "Looking for FairMQ functionality in FairRoot ...")
 endif(NOT FairMQ_FIND_QUIETLY)
 
 find_path(FAIRMQ_INCLUDE_DIR NAMES ${FAIRMQ_REQUIRED_HEADERS}
-  PATHS ${FairRoot_DIR}/include
+  PATHS ${FAIRROOTPATH}/include
   NO_DEFAULT_PATH
 )
 
@@ -27,7 +43,7 @@ if(FAIRMQ_INCLUDE_DIR)
   set(FAIRMQ_FOUND TRUE)
 else(FAIRMQ_INCLUDE_DIR)
   if(FairMQ_FIND_REQUIRED)
-    message(FATAL_ERROR "FairRoot is not built with FairMQ support")
+    message(STATUS "FairRoot is not built with FairMQ support")
   else(FairMQ_FIND_REQUIRED)
     if(NOT FairMQ_FIND_QUIETLY)
       message(STATUS "Looking for FairMQ functionality in FairRoot: no")

--- a/cmake/modules/FindFairMQ.cmake
+++ b/cmake/modules/FindFairMQ.cmake
@@ -1,0 +1,36 @@
+#
+# Simple check for availability of FairMQ
+#
+# The FairMQ module of FairRoot might be disabled in the built of FairRoot
+# due to missing dependencies, e.g ZeroMQ and boost. Those dependencies
+# also have to be available in the required (minimal) version.
+#
+
+set(FAIRMQ_REQUIRED_HEADERS FairMQDevice.h)
+if(NOT FairMQ_FIND_QUIETLY)
+  message(STATUS "Looking for FairMQ functionality in FairRoot ...")
+endif(NOT FairMQ_FIND_QUIETLY)
+
+find_path(FAIRMQ_INCLUDE_DIR NAMES ${FAIRMQ_REQUIRED_HEADERS}
+  PATHS ${FairRoot_DIR}/include
+  NO_DEFAULT_PATH
+)
+
+# search once more in the system if not yet found
+find_path(FAIRMQ_INCLUDE_DIR NAMES ${FAIRMQ_REQUIRED_HEADERS}
+)
+
+if(FAIRMQ_INCLUDE_DIR)
+  if(NOT FairMQ_FIND_QUIETLY)
+    message(STATUS "Looking for FairMQ functionality in FairRoot: yes")
+  endif(NOT FairMQ_FIND_QUIETLY)
+  set(FAIRMQ_FOUND TRUE)
+else(FAIRMQ_INCLUDE_DIR)
+  if(FairMQ_FIND_REQUIRED)
+    message(FATAL_ERROR "FairRoot is not built with FairMQ support")
+  else(FairMQ_FIND_REQUIRED)
+    if(NOT FairMQ_FIND_QUIETLY)
+      message(STATUS "Looking for FairMQ functionality in FairRoot: no")
+    endif(NOT FairMQ_FIND_QUIETLY)
+  endif(FairMQ_FIND_REQUIRED)
+endif(FAIRMQ_INCLUDE_DIR)


### PR DESCRIPTION
The FairMQ module of FairRoot might be disabled in the built of FairRoot
due to missing dependencies, e.g ZeroMQ and boost. Those dependencies
also have to be available in the required (minimal) version.