### PR TITLE
add the namespaces to the classdef 

### DIFF
--- a/Detectors/TPC/simulation/include/Digitizer.h
+++ b/Detectors/TPC/simulation/include/Digitizer.h
@@ -34,9 +34,9 @@ namespace AliceO2{
       void getElectronDrift(Float_t *xyz);
       Float_t getGEMAmplification();
       const Int_t getTimeBin(Float_t zPos);
-      
-      
-      
+
+
+
       Double_t Gamma4(Double_t x, Double_t p0, Double_t p1);
 
       void setGainFactor(Double_t gain) { mGain = gain; }
@@ -49,7 +49,7 @@ namespace AliceO2{
       DigitContainer          *mDigitContainer;           ///< Internal digit storage
       Double_t                mGain;                      ///< pad gain factor (global for the moment)
 
-      ClassDef(Digitizer, 1);
+      ClassDef(ALICEO2::TPC::Digitizer, 1);
     };
 }
 }

--- a/Detectors/TPC/simulation/include/DigitizerTask.h
+++ b/Detectors/TPC/simulation/include/DigitizerTask.h
@@ -1,7 +1,7 @@
 /// \file DigitizerTask.h
 /// \brief Task for ALICE TPC digitization
-#ifndef __ALICEO2__DigitizerTask__
-#define __ALICEO2__DigitizerTask__
+#ifndef __ALICEO2__TPC__DigitizerTask__
+#define __ALICEO2__TPC__DigitizerTask__
 
 #include <stdio.h>
 #include "FairTask.h"
@@ -11,24 +11,24 @@ namespace AliceO2 { namespace TPC { class Digitizer; } }
 
 namespace AliceO2 {
     namespace TPC{
-        
+
         class Digitizer;
-        
+
         class DigitizerTask : public FairTask{
         public:
             DigitizerTask();
             virtual ~DigitizerTask();
-            
+
             virtual InitStatus Init();
             virtual void Exec(Option_t *option);
-            
+
         private:
             Digitizer           *mDigitizer;
-            
+
             TClonesArray        *mPointsArray;
             TClonesArray        *mDigitsArray;
             
-            ClassDef(DigitizerTask, 1)
+            ClassDef(AliceO2::TPC::DigitizerTask, 1)
         };
     }
 }


### PR DESCRIPTION
Add the namespaces to the classdef  otherwise the classes cannot be used in the macro on MAC OS with ROOT6