### PR TITLE
Removed AliceO2Config.h.in and updated run_sim.C 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,6 @@ cmake_policy(SET ${p} NEW)
 endif()
 endforeach()
 
-
-
 # Set name of our project to "ALICEO2". Has to be done
 # after check of cmake version since this is a new feature
 project(ALICEO2)
@@ -221,13 +219,11 @@ add_subdirectory (Utilities)
 add_subdirectory (Detectors)
 add_subdirectory (DataFormats)
 
-
 Option(BUILD_DOXYGEN "Build Doxygen" OFF)
 if(BUILD_DOXYGEN)
   MESSAGE(STATUS "*** Building the Doxygen documentaion ***")
   ADD_SUBDIRECTORY(doxygen)
 endif(BUILD_DOXYGEN)
-
 
 If(IWYU_FOUND)
   ADD_CUSTOM_TARGET(checkHEADERS
@@ -235,13 +231,8 @@ If(IWYU_FOUND)
   )
 EndIf()
 
-
 WRITE_CONFIG_FILE(config.sh)
 
 configure_file(${CMAKE_SOURCE_DIR}/CTestCustom.cmake
                ${CMAKE_BINARY_DIR}/CTestCustom.cmake
               )
-
-# Create an automatically generated config header file to pass file paths to the application
-configure_file(${PROJECT_SOURCE_DIR}/Common/Header/AliceO2Config.h.in
-               ${CMAKE_CURRENT_SOURCE_DIR}/Common/Header/AliceO2Config.h)

--- a/Common/CMakeLists.txt
+++ b/Common/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory (Field)
-add_subdirectory(MathUtils)
+add_subdirectory (Resources)
+add_subdirectory (MathUtils)

--- a/Common/Field/include/MagneticField.h
+++ b/Common/Field/include/MagneticField.h
@@ -6,7 +6,6 @@
 #define ALICEO2_FIELD_MAGNETICFIELD_H_
 
 #include <TVirtualMagField.h>  // for TVirtualMagField
-#include "AliceO2Config.h"     // for O2PROTO1_MAGF_CREATEFIELDMAP_DIR, etc
 #include "Rtypes.h"            // for Double_t, Char_t, Int_t, Float_t, etc
 #include "TNamed.h"            // for TNamed
 class FairLogger;  // lines 14-14
@@ -35,7 +34,7 @@ public:
   /// The "be" is the energy of the beam in GeV/nucleon
   MagneticField(const char* name, const char* title, Double_t factorSol = 1., Double_t factorDip = 1.,
                 BMap_t maptype = k5kG, BeamType_t btype = kBeamTypepp, Double_t benergy = -1, Int_t integ = 2,
-                Double_t fmax = 15, const char* path = O2PROTO1_MAGF_DIR);
+                Double_t fmax = 15, const char* path = "share/field/mfchebKGI_sym.root");
   MagneticField(const MagneticField& src);
   MagneticField& operator=(const MagneticField& src);
 
@@ -178,7 +177,7 @@ public:
   /// unless the special uniform map was used for MC
   static MagneticField* createFieldMap(Float_t l3Current = -30000., Float_t diCurrent = -6000., Int_t convention = 0,
                                        Bool_t uniform = kFALSE, Float_t beamenergy = 7000, const Char_t* btype = "pp",
-                                       const Char_t* path = O2PROTO1_MAGF_CREATEFIELDMAP_DIR);
+                                       const Char_t* path = "share/field/mfchebKGI_sym.root");
 
 protected:
   // not supposed to be changed during the run, set only at the initialization via constructor

--- a/Common/Header/AliceO2Config.h.in
+++ b/Common/Header/AliceO2Config.h.in
@@ -1,2 +1,0 @@
-#define O2PROTO1_MAGF_DIR "@CMAKE_SOURCE_DIR@/Common/Resources/maps/mfchebKGI_sym.root"
-#define O2PROTO1_MAGF_CREATEFIELDMAP_DIR "@CMAKE_SOURCE_DIR@/Common/Resources/maps/mfchebKGI_sym.root"

--- a/Common/Resources/CMakeLists.txt
+++ b/Common/Resources/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory (maps)

--- a/Common/Resources/maps/CMakeLists.txt
+++ b/Common/Resources/maps/CMakeLists.txt
@@ -1,0 +1,3 @@
+Install(FILES mfchebKGI_sym.root
+        DESTINATION share/field
+       )

--- a/Detectors/CMakeLists.txt
+++ b/Detectors/CMakeLists.txt
@@ -14,7 +14,10 @@
 # **************************************************************************
 
 # Libraries
-add_subdirectory(Passive)
-add_subdirectory(ITSMFT)
-add_subdirectory(TPC)
-add_subdirectory(Base)
+add_subdirectory (Base)
+add_subdirectory (gconfig)
+add_subdirectory (Geometry)
+add_subdirectory (ITSMFT)
+add_subdirectory (Passive)
+add_subdirectory (TPC)
+

--- a/Detectors/Geometry/CMakeLists.txt
+++ b/Detectors/Geometry/CMakeLists.txt
@@ -1,0 +1,4 @@
+Install(FILES cave.geo media.geo
+        DESTINATION share/geometry
+       )
+

--- a/Detectors/gconfig/CMakeLists.txt
+++ b/Detectors/gconfig/CMakeLists.txt
@@ -1,0 +1,4 @@
+Install(FILES g3libs.C g3Config.C SetCuts.C
+        DESTINATION share/gconfig/
+       )
+

--- a/macro/run_sim.C
+++ b/macro/run_sim.C
@@ -7,11 +7,11 @@ double radii2Turbo(double rMin, double rMid, double rMax, double sensW)
 void run_sim(Int_t nEvents = 10, TString mcEngine = "TGeant3")
 {
   TString dir = getenv("VMCWORKDIR");
-  TString geom_dir = dir + "/Detectors/Geometry/";
+  TString geom_dir = dir + "share/geometry/";
   gSystem->Setenv("GEOMPATH",geom_dir.Data());
 
 
-  TString tut_configdir = dir + "/Detectors/gconfig";
+  TString tut_configdir = dir + "share/gconfig/";
   gSystem->Setenv("CONFIG_DIR",tut_configdir.Data());
 
   // Output file name


### PR DESCRIPTION
Removed AliceO2Config.h.in

Hardcoded geometry, config and magnet field map paths based on the new Alice

Updated run_sim.C to work again with the new AliceO2 installation directorie