### PR TITLE
An o2Device executable to rule them all

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,14 +2,17 @@
 
 node {
   stage "Verify author"
-  def power_users = ["ktf",
-                     "dberzano",
-                     "MohammadAlTurany",
-                     "matthiasrichter",
-                     "Barthelemy",
-                     "wiechula",
-                     "bovulpes",
-                     "rbx"]
+  def power_users = [
+    "Barthelemy",
+    "MohammadAlTurany",
+    "PatrykLesiak",
+    "bovulpes",
+    "dberzano",
+    "ktf",
+    "matthiasrichter",
+    "rbx",
+    "wiechula",
+  ]
   echo "Changeset from " + env.CHANGE_AUTHOR
   if (power_users.contains(env.CHANGE_AUTHOR)) {
     currentBuild.displayName = "Testing ${env.BRANCH_NAME} from ${env.CHANGE_AUTHOR}"


### PR DESCRIPTION
This is propaedeutic to tomorrow / next week discussion. Do not merge.

The idea is to have an application, o2Device, which is passed as argument the name of a library actually containing the device. The application then changes the process name to the name of the device, loads the library actually containing the device and setups the state machine. This allows us to avoid having to write a main for every single device out there.

```
o2Device libAliceExampleSink.so --id sink --config-file-json config.json
o2Device libAliceExampleSampler.so --id sampler --config-file-json config.json
```
