### PR TITLE
Make linking Generators optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,7 @@ ENDIF (NOT ALICEO2_MODULAR_BUILD)
 
 IF (PYTHIA8_FOUND AND Pythia6_FOUND)
   add_subdirectory(Generators)
+  set(GENERATORS_LIBRARY Generators)
 ENDIF ()
 
 add_subdirectory(CCDB)

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -405,7 +405,7 @@ o2_define_bucket(
     TPCBase
     DetectorsBase
     SimulationDataFormat
-    Generators
+    ${GENERATORS_LIBRARY}
 
     INCLUDE_DIRECTORIES
     ${FAIRROOT_INCLUDE_DIR}


### PR DESCRIPTION
Since Generators depends on Pythia8, we need to handle the case O2 was
built without.