### PR TITLE
Added dl as a dependency to the flp2epn bucket

### DIFF
--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -95,6 +95,7 @@ o2_define_bucket(
     flp2epn_bucket
 
     DEPENDENCIES
+    dl
     common_boost_bucket
     ${Boost_CHRONO_LIBRARY}
     ${Boost_DATE_TIME_LIBRARY}
@@ -544,15 +545,15 @@ o2_define_bucket(
     Base
     FairTools
     ParBase
-    FairMQ 
+    FairMQ
     ParMQ
-    fairmq_logger 
-    pthread 
-    Core 
-    Tree 
-    XMLParser 
-    Hist 
-    Net 
+    fairmq_logger
+    pthread
+    Core
+    Tree
+    XMLParser
+    Hist
+    Net
     RIO
     dl
 


### PR DESCRIPTION
Fixes the following linking error on slc7:

DEBUG:O2:0: /usr/bin/ld: CMakeFiles/testProxy.dir/src/runProxy.cxx.o: undefined reference to symbol 'dlclose@@GLIBC_2.2.5'
DEBUG:O2:0: /usr/bin/ld: note: 'dlclose@@GLIBC_2.2.5' is defined in DSO /lib64/libdl.so.2 so try adding it to the linker command line
DEBUG:O2:0: /lib64/libdl.so.2: could not read symbols: Invalid operation