### PR TITLE
MFT: implement reconstruction with sampler + processor + merger + sink

### DIFF
--- a/Detectors/ITSMFT/MFT/base/CMakeLists.txt
+++ b/Detectors/ITSMFT/MFT/base/CMakeLists.txt
@@ -4,10 +4,12 @@ O2_SETUP(NAME ${MODULE_NAME})
 
 set(SRCS
   src/Constants.cxx
+  src/EventHeader.cxx
 )
 
 set(HEADERS
   include/${MODULE_NAME}/Constants.h
+  include/${MODULE_NAME}/EventHeader.h
 )
 
 Set(LINKDEF src/MFTBaseLinkDef.h)

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/EventHeader.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/EventHeader.h
@@ -1,0 +1,46 @@
+#ifndef ALICEO2_MFT_EVENTHEADER_H_
+#define ALICEO2_MFT_EVENTHEADER_H_
+
+#include "FairEventHeader.h"
+
+#ifndef __CINT__
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#endif
+
+namespace AliceO2 {
+namespace MFT {
+
+class EventHeader : public FairEventHeader
+{
+
+ public:
+  
+  EventHeader();
+  virtual ~EventHeader();
+
+  void  SetPartNo(Int_t ipart) { fPartNo = ipart;}
+  Int_t GetPartNo()            { return fPartNo; }
+  
+  template <class Archive>
+    void serialize(Archive& ar, const unsigned int /*version*/)
+    {
+      ar& boost::serialization::base_object<FairEventHeader>(*this);
+    }
+  
+ private:
+
+  Int_t fPartNo;
+  
+#ifndef __CINT__ // for BOOST serialization
+  friend class boost::serialization::access;
+#endif // for BOOST serialization
+  
+  ClassDef(EventHeader, 1);
+
+};
+
+}
+}
+
+#endif

--- a/Detectors/ITSMFT/MFT/base/src/EventHeader.cxx
+++ b/Detectors/ITSMFT/MFT/base/src/EventHeader.cxx
@@ -1,0 +1,19 @@
+#include "MFTBase/EventHeader.h"
+
+using namespace AliceO2::MFT;
+
+ClassImp(AliceO2::MFT::EventHeader)
+
+//_____________________________________________________________________________
+EventHeader::EventHeader()
+: FairEventHeader()
+  , fPartNo(0)
+{
+
+}
+
+//_____________________________________________________________________________
+EventHeader::~EventHeader()
+{
+
+}

--- a/Detectors/ITSMFT/MFT/base/src/MFTBaseLinkDef.h
+++ b/Detectors/ITSMFT/MFT/base/src/MFTBaseLinkDef.h
@@ -5,5 +5,6 @@
 #pragma link off all functions;
 
 #pragma link C++ class AliceO2::MFT::Constants+;
+#pragma link C++ class AliceO2::MFT::EventHeader+;
 
 #endif

--- a/Detectors/ITSMFT/MFT/reconstruction/CMakeLists.txt
+++ b/Detectors/ITSMFT/MFT/reconstruction/CMakeLists.txt
@@ -18,6 +18,7 @@ set(HEADERS
 set(NO_DICT_SRCS
   src/devices/Sampler.cxx
   src/devices/FileSink.cxx
+  src/devices/Merger.cxx
 )
 
 set(NO_DICT_HEADERS
@@ -25,6 +26,7 @@ set(NO_DICT_HEADERS
   include/${MODULE_NAME}/devices/TaskProcessor.h
   include/${MODULE_NAME}/devices/TaskProcessor.tpl
   include/${MODULE_NAME}/devices/FileSink.h
+  include/${MODULE_NAME}/devices/Merger.h
 )
 
 Set(LINKDEF src/MFTReconstructionLinkDef.h)
@@ -37,12 +39,14 @@ Set(Exe_Names
   mft-reco-sampler
   mft-reco-processor
   mft-reco-sink
+  mft-reco-merger
 )
 
 Set(Exe_Source
   src/runMFTrecoSampler.cxx
   src/runMFTrecoTaskProcessor.cxx
   src/runMFTrecoFileSink.cxx
+  src/runMFTrecoMerger.cxx
 )
 
 # todo we repeat ourselves because the macro O2_GENERATE_LIBRARY dares deleting the variables we pass to it.

--- a/Detectors/ITSMFT/MFT/reconstruction/config/reco_merger.json
+++ b/Detectors/ITSMFT/MFT/reconstruction/config/reco_merger.json
@@ -1,0 +1,176 @@
+{
+  "fairMQOptions":
+  {
+    "device":
+    {
+      "id": "sampler1",
+      "channel":
+      {
+        "name": "data-out",
+        "socket":
+        {
+          "type": "push",
+          "method": "bind",
+          "address": "tcp://*:5565",
+          "sndBufSize": "1000",
+          "rcvBufSize": "1000",
+          "rateLogging": "1"
+        }
+      }
+    },
+    "device":
+    {
+      "id": "sampler2",
+      "channel":
+      {
+        "name": "data-out",
+        "socket":
+        {
+          "type": "push",
+          "method": "bind",
+          "address": "tcp://*:5566",
+          "sndBufSize": "1000",
+          "rcvBufSize": "1000",
+          "rateLogging": "1"
+        }
+      }
+    },
+    "device":
+    {
+      "id": "processor1",
+      "channel":
+      {
+        "name": "data-in",
+        "socket":
+        {
+          "type": "pull",
+          "method": "connect",
+          "address": "tcp://localhost:5565",
+          "sndBufSize": "1000",
+          "rcvBufSize": "1000",
+          "rateLogging": "1"
+        }
+      },
+      "channel":
+      {
+        "name": "data-out",
+        "socket":
+        {
+          "type": "push",
+          "method": "connect",
+          "address": "tcp://localhost:5572",
+          "sndBufSize": "1000",
+          "rcvBufSize": "1000",
+          "rateLogging": "1"
+        }
+      }
+    },
+     "device":
+    {
+      "id": "processor2",
+      "channel":
+      {
+        "name": "data-in",
+        "socket":
+        {
+          "type": "pull",
+          "method": "connect",
+          "address": "tcp://localhost:5566",
+          "sndBufSize": "1000",
+          "rcvBufSize": "1000",
+          "rateLogging": "1"
+        }
+      },
+      "channel":
+      {
+        "name": "data-out",
+        "socket":
+        {
+          "type": "push",
+          "method": "connect",
+          "address": "tcp://localhost:5572",
+          "sndBufSize": "1000",
+          "rcvBufSize": "1000",
+          "rateLogging": "1"
+        }
+      }
+    },
+    "device":
+    {
+      "id": "merger",
+      "channel":
+      {
+        "name": "data-in",
+        "socket":
+        {
+          "type": "pull",
+           "method": "bind",
+           "address": "tcp://*:5572",
+           "sndBufSize": "1000",
+           "rcvBufSize": "1000",
+           "rateLogging": "1"
+        }
+      },
+      "channel":
+      {
+        "name": "data-out",
+        "socket":
+        {
+          "type": "push",
+          "method": "connect",
+          "address": "tcp://localhost:5570",
+          "sndBufSize": "1000",
+          "rcvBufSize": "1000",
+          "rateLogging": "1"
+        }
+      }
+    },
+    "device":
+    {
+      "id": "sink",
+      "channel":
+      {
+        "name": "data-in",
+        "socket":
+        {
+          "type": "pull",
+          "method": "bind",
+          "address": "tcp://*:5570",
+          "sndBufSize": "1000",
+          "rcvBufSize": "1000",
+          "rateLogging": "1"
+        }
+      },
+      "channel":
+      {
+        "name": "ack",
+        "socket":
+        {
+          "type": "push",
+          "method": "connect",
+          "address": "tcp://localhost:5556",
+          "sndBufSize": "1000",
+          "rcvBufSize": "1000",
+          "rateLogging": "1"
+        }
+      }
+    },
+    "device":
+    {
+      "id": "sink1",
+      "channel":
+      {
+        "name": "data-in",
+        "socket":
+        {
+          "type": "pull",
+          "method": "bind",
+          "address": "tcp://*:5572",
+          "sndBufSize": "1000",
+          "rcvBufSize": "1000",
+          "rateLogging": "1"
+        }
+      }
+    }
+  }
+}

--- a/Detectors/ITSMFT/MFT/reconstruction/include/MFTReconstruction/FindHits.h
+++ b/Detectors/ITSMFT/MFT/reconstruction/include/MFTReconstruction/FindHits.h
@@ -8,10 +8,14 @@
 
 #include "FairTask.h"
 
+class FairMCEventHeader;
+
 class TClonesArray;
 
 namespace AliceO2 {
 namespace MFT {
+
+class EventHeader;
 
 class FindHits : public FairTask
 {
@@ -42,6 +46,9 @@ class FindHits : public FairTask
 
   Int_t fTNofEvents;
   Int_t fTNofHits;
+
+  FairMCEventHeader *fMCEventHeader;
+  EventHeader *fEventHeader;
 
   ClassDef(FindHits,1);
 

--- a/Detectors/ITSMFT/MFT/reconstruction/include/MFTReconstruction/FindTracks.h
+++ b/Detectors/ITSMFT/MFT/reconstruction/include/MFTReconstruction/FindTracks.h
@@ -13,6 +13,8 @@ class TClonesArray;
 namespace AliceO2 {
 namespace MFT {
 
+class EventHeader;
+
 class FindTracks : public FairTask
 {
 
@@ -42,6 +44,8 @@ class FindTracks : public FairTask
   Int_t fTNofEvents;
   Int_t fTNofHits;
   Int_t fTNofTracks;
+
+  EventHeader *fEventHeader;
 
   ClassDef(FindTracks,1);
 

--- a/Detectors/ITSMFT/MFT/reconstruction/include/MFTReconstruction/devices/Merger.h
+++ b/Detectors/ITSMFT/MFT/reconstruction/include/MFTReconstruction/devices/Merger.h
@@ -1,0 +1,49 @@
+#ifndef MERGER_H_
+#define MERGER_H_
+
+#include "TClonesArray.h"
+#include "TFile.h"
+#include "TFolder.h"
+#include "TTree.h"
+#include "FairEventHeader.h"
+
+#include "FairMQDevice.h"
+
+#include "MFTBase/EventHeader.h"
+
+namespace AliceO2 {
+
+namespace MFT {
+
+class Merger : public FairMQDevice
+{
+
+ public:
+
+  Merger();
+  virtual ~Merger();
+  
+  void SetNofParts(int iparts) { fNofParts = iparts; }
+  
+ protected:
+
+  virtual void Init();
+  virtual void Run();
+  
+ private:
+  
+  EventHeader* fEventHeader;
+  int fNofParts;
+  
+  std::map     <std::pair<int,int>,int>                     fNofPartsPerEventMap;  // number of parts for pair<event number,run id>
+  std::multimap<std::pair<std::pair<int,int>,int>,TObject*> fObjectMap;            // TObjects for given pair<pair<event number, run,id>part>
+  
+  Merger(const Merger&);
+  Merger& operator=(const Merger&);
+  
+};
+ 
+}
+}
+
+#endif

--- a/Detectors/ITSMFT/MFT/reconstruction/include/MFTReconstruction/devices/TaskProcessor.h
+++ b/Detectors/ITSMFT/MFT/reconstruction/include/MFTReconstruction/devices/TaskProcessor.h
@@ -4,11 +4,10 @@
 #include <string>
 
 #include "FairMQDevice.h"
-#include "FairEventHeader.h"
+
+#include "MFTBase/EventHeader.h"
 
 #include "TMessage.h"
-
-class FairEventHeader;
 
 class TList;
 
@@ -40,7 +39,7 @@ class TaskProcessor : public FairMQDevice
   std::string     fInputChannelName;
   std::string     fOutputChannelName;
   
-  FairEventHeader* fEventHeader;
+  EventHeader*     fEventHeader;
   TList*           fInput;
   TList*           fOutput;
   

--- a/Detectors/ITSMFT/MFT/reconstruction/src/devices/FileSink.cxx
+++ b/Detectors/ITSMFT/MFT/reconstruction/src/devices/FileSink.cxx
@@ -8,6 +8,7 @@
 
 #include "FairEventHeader.h"
 
+#include "MFTBase/EventHeader.h"
 #include "MFTReconstruction/devices/FileSink.h"
 #include "MFTReconstruction/Hit.h"
 
@@ -97,19 +98,23 @@ void FileSink::Init()
     if (fClassNames[fNObjects].find("TClonesArray(") == 0) {
 
       fClassNames[fNObjects] = fClassNames[fNObjects].substr(13,fClassNames[fNObjects].length()-12-2);
+
       LOG(INFO) << "FileSink::Init >>>>> Create a TClonesArray of this class: " << fClassNames[fNObjects].c_str() << "";
+
       fOutputObjects[fNObjects] = new TClonesArray(fClassNames[fNObjects].c_str());
-      fOutputObjects[fNObjects]->Print();
+
       LOG(INFO) << "FileSink::Init >>>>> Create a branch " << fBranchNames[fNObjects].c_str() << "";
+
       fTree->Branch(fBranchNames[fNObjects].c_str(),"TClonesArray", &fOutputObjects[fNObjects]);
       foldMFT->Add(fOutputObjects[fNObjects]);
       BranchNameList->AddLast(new TObjString(fBranchNames[fNObjects].c_str()));
 
-    } else if ( fClassNames[fNObjects].find("FairEventHeader") == 0 ) {
+    } else if ( fClassNames[fNObjects].find("AliceO2::MFT::EventHeader") == 0 ) {
 
-      LOG(INFO) << "FileSink::Init >>>>> Create the branch FairEventHeader" << "";
-      fOutputObjects            [fNObjects] = new    FairEventHeader();
-      fTree->Branch(fBranchNames[fNObjects].c_str(),"FairEventHeader", &fOutputObjects[fNObjects]);
+      LOG(INFO) << "FileSink::Init >>>>> Create the branch EventHeader" << "";
+
+      fOutputObjects            [fNObjects] = new EventHeader();
+      fTree->Branch(fBranchNames[fNObjects].c_str(),"AliceO2::MFT::EventHeader", &fOutputObjects[fNObjects]);
       foldEventHeader->Add(fOutputObjects[fNObjects]);
       BranchNameList->AddLast(new TObjString(fBranchNames[fNObjects].c_str()));
 
@@ -148,16 +153,24 @@ void FileSink::Run()
 	
 	TMessage2 tm(parts.At(ipart)->GetData(), parts.At(ipart)->GetSize());
 	tempObjects[ipart] = (TObject*)tm.ReadObject(tm.GetClass());
+
 	for (unsigned int ibr = 0; ibr < fBranchNames.size(); ibr++) { 
 	  
-          LOG(INFO) << "FileSink::Run >>>>> branch " << ibr << "   " << fBranchNames[ibr].c_str() << "";
-          LOG(INFO) << "FileSink::Run >>>>> branch " << fBranchNames[ibr].c_str() << " " << tempObjects[ipart]->GetName() << "";
-	  // !!! force !!!
-	  if (kTRUE || (strcmp(tempObjects[ipart]->GetName(),fBranchNames[ibr].c_str()) == 0)) { 
+          //LOG(INFO) << "FileSink::Run >>>>> branch " << ibr << "   " << fBranchNames[ibr].c_str() << " " << tempObjects[ipart]->GetName() << "";
+
+	  // !!! force ???
+	  //if (kFALSE || (strcmp(tempObjects[ipart]->GetName(),fBranchNames[ibr].c_str()) == 0)) { 
+
+	  if ((strcmp(tempObjects[ipart]->GetName(),fBranchNames[ibr].c_str()) == 0) || (strncmp(fBranchNames[ibr].c_str(),"MFT",3) == 0 && strncmp(tempObjects[ipart]->GetName(),"AliceO2",7) == 0)) {
+
 	    fOutputObjects[ibr] = tempObjects[ipart];
-	    LOG(INFO) << "FileSink""Run >>>>> out object branch " << ibr << " part " << ipart << "";	    
+
+	    LOG(INFO) << "FileSink::Run >>>>> branch " << ibr << "   " << fBranchNames[ibr].c_str() << " " << tempObjects[ipart]->GetName() << "";
+	    //LOG(INFO) << "FileSink::Run >>>>> out object branch " << ibr << " part " << ipart << "";	    
+
 	    //fOutputObjects[ibr]->Dump();
 	    fTree->SetBranchAddress(fBranchNames[ibr].c_str(),&fOutputObjects[ibr]);
+
 	  }
 	}
       }

--- a/Detectors/ITSMFT/MFT/reconstruction/src/devices/Merger.cxx
+++ b/Detectors/ITSMFT/MFT/reconstruction/src/devices/Merger.cxx
@@ -1,0 +1,233 @@
+#include <boost/thread.hpp>
+#include <boost/bind.hpp>
+
+#include "FairMQLogger.h"
+
+#include "TMessage.h"
+
+#include "MFTBase/EventHeader.h"
+#include "MFTReconstruction/devices/Merger.h"
+
+using namespace AliceO2::MFT;
+
+using namespace std;
+
+// special class to expose protected TMessage constructor
+//_____________________________________________________________________________
+class TMessage2 : public TMessage
+{
+  public:
+  TMessage2(void* buf, Int_t len)
+    : TMessage(buf, len)
+  {
+    LOG(INFO) << "Merger::TMessage2 >>>>> create message of length " << len << "";
+    ResetBit(kIsOwner);
+  }
+};
+
+//_____________________________________________________________________________
+Merger::Merger()
+  : FairMQDevice()
+  , fEventHeader(NULL)
+  , fNofParts(2)
+  , fNofPartsPerEventMap()
+  , fObjectMap()
+{
+
+}
+
+//_____________________________________________________________________________
+Merger::~Merger()
+{ 
+
+}
+
+//_____________________________________________________________________________
+void Merger::Init()
+{
+
+}
+
+//_____________________________________________________________________________
+void Merger::Run()
+{
+
+  typedef std::multimap<std::pair<std::pair<int,int>,int>,TObject*> MultiMapDef;
+
+  int fNofReceivedMessages = 0;
+  int fNofSentMessages = 0;
+  bool printInfo = true;
+
+  std::pair<int, int> evRIPair;
+  std::pair<std::pair<int,int>,int> evRIPartTrio;
+  std::pair<MultiMapDef::iterator, MultiMapDef::iterator> ret;
+  //  bool dataDuplicationFlag = false;
+  int nofReceivedParts = 0; // if set to -1, the data seems to be duplicated
+
+  while (CheckCurrentState(RUNNING)) {
+
+    FairMQParts parts;
+    
+    if (Receive(parts, "data-in") >= 0) {
+
+      fNofReceivedMessages++;
+      //dataDuplicationFlag = false;
+      nofReceivedParts = 0;
+      TObject*      tempObject;
+      TClonesArray* tempArrays[10];
+      int nofArrays = 0;
+
+      LOG(INFO) << "Merger::Run >>>>> receive " << parts.Size() << " parts" << "";
+
+      for (int ipart = 0 ; ipart < parts.Size() ; ipart++) {
+
+	TMessage2 tm(parts.At(ipart)->GetData(), parts.At(ipart)->GetSize());
+	tempObject = (TObject*)tm.ReadObject(tm.GetClass());
+
+	if (strcmp(tempObject->GetName(),"EventHeader.") == 0) {
+
+	  fEventHeader = (EventHeader*)tempObject;
+
+	  LOG(INFO) << "Merger::Run >>>>> got EventHeader part [" << fEventHeader->GetRunId() << "][" << fEventHeader->GetMCEntryNumber() << "][" << fEventHeader->GetPartNo() << "]";
+                  
+	  // setting how many parts were received...
+	  evRIPair    .first  = fEventHeader->GetMCEntryNumber();
+	  evRIPair    .second = fEventHeader->GetRunId();
+	  evRIPartTrio.first  = evRIPair;
+	  evRIPartTrio.second = fEventHeader->GetPartNo();
+          
+	  MultiMapDef::iterator it3;
+	  it3 = fObjectMap.find(evRIPartTrio);
+	  if (it3 != fObjectMap.end()) {
+
+	    LOG(INFO) << "Merger::Run >>>>> shouldn't happen, already got objects for part " << evRIPartTrio.second 
+		      << ", event " << evRIPair.first << ", run " << evRIPair.second << ". Skipping this message!!!";
+
+	    nofReceivedParts = -1;
+	    break; // break the for(ipart) loop, as nothing else is left to do
+
+	  }
+                  
+	  std::map<std::pair<int,int>,int>::iterator it2;
+	  it2 = fNofPartsPerEventMap.find(evRIPair);
+	  if (it2 == fNofPartsPerEventMap.end()) {
+
+	    LOG(INFO) << "Merger::Run >>>>> First part of event " << evRIPair.first;
+
+	    fNofPartsPerEventMap[evRIPair] = 1;
+	    nofReceivedParts = 1;
+
+	  } else {
+
+	    it2->second+=1;
+	    nofReceivedParts = it2->second;
+
+	  }
+
+	  LOG(INFO) << "Merger::Run >>>>> got " << nofReceivedParts << " parts of event " << evRIPair.first;
+
+	} else { 
+
+	  tempArrays[nofArrays] = (TClonesArray*)tempObject;
+	  nofArrays++;
+
+	}
+
+      } // end the for(ipart) loop, should have received TCAs in tempArrays and EventHeader
+
+      if (nofReceivedParts == -1) continue;
+      
+      if (nofReceivedParts != fNofParts) { // got all the parts of the event, have to combine and send message, consisting of objects from tempArrays  
+
+	LOG(INFO) << "Merger::Run >>>>> not all parts are yet here (" << nofReceivedParts << " of " << fNofParts << ") adding to (size = " << fObjectMap.size() << ")";
+
+	LOG(INFO) << "Merger::Run >>>>> + " << fEventHeader->GetName() << "[" << evRIPartTrio.first.second << "][" << evRIPartTrio.first.first << "][" << evRIPartTrio.second << "]";
+
+	fObjectMap.insert(std::pair<std::pair<std::pair<int,int>,int>,TObject*>(evRIPartTrio,(TObject*)fEventHeader));
+
+	for (int iarray = 0 ; iarray < nofArrays ; iarray++) {
+	  
+	  LOG(INFO) << "Merger::Run >>>>> + " << tempArrays[iarray]->GetName() << "[" << evRIPartTrio.first.second << "][" << evRIPartTrio.first.first << "][" << evRIPartTrio.second << "]";
+
+	  fObjectMap.insert(std::pair<std::pair<std::pair<int,int>,int>,TObject*>(evRIPartTrio,(TObject*)tempArrays[iarray]));
+
+	}
+
+	LOG(INFO) << "Merger::Run >>>>> now we have fObjectMap (size = " << fObjectMap.size() << ")";
+
+	if (printInfo) 
+	  LOG(INFO) << "Merger::Run::printInfo >>>>> [" << fEventHeader->GetRunId() << "][" << fEventHeader->GetMCEntryNumber() << "][" << fEventHeader->GetPartNo() << "] Received: " << fNofReceivedMessages << " // Buffered: " << fObjectMap.size() << " // Sent: " << fNofSentMessages << " <<";
+
+      } else { 
+	
+	int currentEventPart = fEventHeader->GetPartNo();
+	for (int iarray = 0 ; iarray < nofArrays; iarray++) {
+
+	  LOG(TRACE) << "BEFORE ADDING, TCA \"" << tempArrays[iarray]->GetName() << "\" has " << tempArrays[iarray]->GetEntries() << " entries.";
+	  TClonesArray* arrayToAdd;
+          
+	  for (int ieventpart = 0; ieventpart < fNofParts; ieventpart++) {
+
+	    if ( ieventpart == currentEventPart ) continue;
+
+	    evRIPartTrio.second = ieventpart;
+	    ret = fObjectMap.equal_range(evRIPartTrio);
+
+	    for (MultiMapDef::iterator it = ret.first; it != ret.second; ++it) {
+
+	      if (strcmp(tempArrays[iarray]->GetName(),it->second->GetName()) == 0) {
+
+		arrayToAdd = (TClonesArray*)it->second;
+		tempArrays[iarray]->AbsorbObjects(arrayToAdd);
+		LOG(TRACE) << "FOUND ONE!, TCA has now " << tempArrays[iarray]->GetEntries() << " entries.";
+
+	      }
+
+	    }
+
+	  }
+
+	}
+	
+	for (int ieventpart = 0; ieventpart < fNofParts; ieventpart++) {
+
+	  if ( ieventpart == currentEventPart ) continue;
+	  evRIPartTrio.second = ieventpart;
+	  ret = fObjectMap.equal_range(evRIPartTrio);
+	  fObjectMap.erase(ret.first,ret.second);
+
+	}
+	
+	TMessage* messageFEH;
+	TMessage* messageTCA[10];
+	FairMQParts partsOut;
+        
+	messageFEH = new TMessage(kMESS_OBJECT);
+	messageFEH->WriteObject(fEventHeader);
+	partsOut.AddPart(NewMessage(messageFEH->Buffer(), 
+				    messageFEH->BufferSize(), 
+				    [](void* /*data*/, void* hint) { delete (TMessage*)hint;},
+				    messageFEH));
+	for (int iarray = 0; iarray < nofArrays; iarray++) {
+
+	  messageTCA[iarray] = new TMessage(kMESS_OBJECT);
+	  messageTCA[iarray]->WriteObject(tempArrays[iarray]);
+	  partsOut.AddPart(NewMessage(messageTCA[iarray]->Buffer(), 
+				      messageTCA[iarray]->BufferSize(), 
+				      [](void* /*data*/, void* hint) { delete (TMessage*)hint;},
+				      messageTCA[iarray]));
+
+	}
+
+	Send(partsOut, "data-out");
+	fNofSentMessages++;
+	
+	if (printInfo)
+	  LOG(INFO) << "Merger::Run::printInfo >>>>> after Send() [" << fEventHeader->GetRunId() << "][" << fEventHeader->GetMCEntryNumber() << "][" << fEventHeader->GetPartNo() << "] Received: " << fNofReceivedMessages << " // Buffered: " << fObjectMap.size() << " // Sent: " << fNofSentMessages << " <<";
+	
+      }
+    }
+  }
+  
+}
+

--- a/Detectors/ITSMFT/MFT/reconstruction/src/devices/Sampler.cxx
+++ b/Detectors/ITSMFT/MFT/reconstruction/src/devices/Sampler.cxx
@@ -36,7 +36,7 @@ Sampler::~Sampler()
 void Sampler::Run()
 {
 
-  LOG(INFO) << ">>>>>>>>>> Sampler::Run" << "";
+  LOG(INFO) << "SamplerRun::Run >>>>> run" << "";
   
   TMessage* message[1000];
   FairMQParts parts;
@@ -45,18 +45,20 @@ void Sampler::Run()
 
   while (CheckCurrentState(RUNNING)) {
 
-    if ( eventCounter == 10 ) break;
+    if (eventCounter == 100) break;
 
     Int_t readEventReturn = fSource->ReadEvent(eventCounter);
 
-    if ( readEventReturn != 0 ) break;
+    if (readEventReturn != 0) break;
 
-    for ( int iobj = 0 ; iobj < fNObjects ; iobj++ ) {
+    for (int iobj = 0; iobj < fNObjects; iobj++) {
+
       LOG(INFO) << "Sampler::Run >>>>> object " << iobj << " event " << eventCounter << "";
       //fInputObjects[iobj]->Dump();
       message[iobj] = new TMessage(kMESS_OBJECT);
       message[iobj]->WriteObject(fInputObjects[iobj]);
       parts.AddPart(NewMessage(message[iobj]->Buffer(),message[iobj]->BufferSize(),[](void* /*data*/, void* hint) { delete (TMessage*)hint;},message[iobj]));
+
     }
     
     Send(parts, fOutputChannelName);
@@ -77,34 +79,41 @@ void Sampler::InitTask()
   
   fRunAna = new FairRunAna();
   
-  if ( fFileNames.size() > 0 ) {
+  if (fFileNames.size() > 0) {
+
     fSource = new FairFileSource(fFileNames.at(0).c_str());
-    for ( unsigned int ifile = 1 ; ifile < fFileNames.size() ; ifile++ ) 
+    for (unsigned int ifile = 1; ifile < fFileNames.size(); ifile++ ) 
       ((FairFileSource*)fSource)->AddFile(fFileNames.at(ifile));
+
   }
+
   fSource->Init();
 
   LOG(INFO) << "Sampler::InitTask >>>>> going to request " << fBranchNames.size() << "  branches:";
-  for ( unsigned int ibrn = 0 ; ibrn < fBranchNames.size() ; ibrn++ ) {
+
+  for (unsigned int ibrn = 0; ibrn < fBranchNames.size(); ibrn++ ) {
 
     LOG(INFO) << "Sampler::InitTask >>>>> requesting branch \"" << fBranchNames[ibrn] << "\"";
 
     int branchStat = fSource->ActivateObject((TObject**)&fInputObjects[fNObjects],fBranchNames[ibrn].c_str()); // should check the status...
 
-    if ( fInputObjects[fNObjects] ) {
+    if (fInputObjects[fNObjects]) {
 
-      LOG(INFO) << "Sampler::InitTask >>>>> activated object \"" << fInputObjects[fNObjects] << "\" with name \"" << fBranchNames[ibrn] << "\" (" << branchStat << "), it got name: \"" << fInputObjects[fNObjects]->GetName() << "\"";
+      LOG(INFO) << "Sampler::InitTask >>>>> activated object " << fInputObjects[fNObjects] << " with name " << fBranchNames[ibrn] << " (" << branchStat << "), it got name: " << fInputObjects[fNObjects]->GetName() << "";
 
-      if ( strcmp(fInputObjects[fNObjects]->GetName(),fBranchNames[ibrn].c_str()) )
-        if ( strcmp(fInputObjects[fNObjects]->ClassName(),"TClonesArray") == 0 ) 
+      if (strcmp(fInputObjects[fNObjects]->GetName(),fBranchNames[ibrn].c_str()))
+        if (strcmp(fInputObjects[fNObjects]->ClassName(),"TClonesArray") == 0) 
           ((TClonesArray*)fInputObjects[fNObjects])->SetName(fBranchNames[ibrn].c_str());
       fNObjects++;
+
     }
+
   }
 
   LOG(INFO) << "Sampler::InitTask >>>>> nof objects = " << fNObjects << "";
   
   fMaxIndex = fSource->CheckMaxEventNo();
+
   LOG(INFO) << "Sampler::InitTask >>>>> input source has " << fMaxIndex << " events.";
 
 }

--- a/Detectors/ITSMFT/MFT/reconstruction/src/runMFTrecoFileSink.cxx
+++ b/Detectors/ITSMFT/MFT/reconstruction/src/runMFTrecoFileSink.cxx
@@ -13,65 +13,66 @@ int main(int argc, char** argv)
   FairMQProgOptions config;
   FileSink fileSink;
 
-  try 
-    {
-
-      std::string filename;
-      std::vector<std::string> classname;
-      std::vector<std::string> branchname;
-      std::string inChannel;
-      
-      options_description fileSink_options("FileSink options");
-      fileSink_options.add_options()
-	("file-name", value<std::string>(&filename), "Path to the output file")
-	("class-name", value<std::vector<std::string>>(&classname), "class name")
-	("branch-name", value<std::vector<std::string>>(&branchname), "branch name")
-	("in-channel", value<std::string>(&inChannel)->default_value("data-in") , "input channel name");
-
-      config.AddToCmdLineOptions(fileSink_options);
-      
-      config.ParseAll(argc, argv);
-
-      fileSink.SetProperty(FileSink::OutputFileName,filename);
-
-      if ( classname.size() != branchname.size() ) {
-	LOG(ERROR) << "Run::FileSink >>>>> The classname size (" << classname.size() << ") and branchname size (" << branchname.size() << ") MISMATCH!!!";
-      }
-      
-      //fileSink.AddOutputBranch("FairEventHeader","EventHeader.");
-      for ( unsigned int ielem = 0 ; ielem < classname.size() ; ielem++ ) {
-	fileSink.AddOutputBranch(classname.at(ielem),branchname.at(ielem));
-      }
-      
-      fileSink.SetInputChannelName(inChannel);
-      
-      string control = config.GetValue<std::string>("control");
-      LOG(INFO) << "Run::FileSink >>>>> device control is " << control.c_str() << "";
-
-      runStateMachine(fileSink, config);     
-      
-      // equivalent to this (interactive mode)
-      /*
-      fileSink.CatchSignals();
-
-      fileSink.SetConfig(config);
-
-      fileSink.ChangeState("INIT_DEVICE");
-      fileSink.WaitForEndOfState("INIT_DEVICE");
-      
-      fileSink.ChangeState("INIT_TASK");
-      fileSink.WaitForEndOfState("INIT_TASK");
-      
-      fileSink.ChangeState("RUN");
-      fileSink.InteractiveStateLoop();
-      */
+  try {
+    
+    std::string filename;
+    std::vector<std::string> classname;
+    std::vector<std::string> branchname;
+    std::string inChannel;
+    
+    options_description fileSink_options("FileSink options");
+    fileSink_options.add_options()
+      ("file-name", value<std::string>(&filename), "Path to the output file")
+      ("class-name", value<std::vector<std::string>>(&classname), "class name")
+      ("branch-name", value<std::vector<std::string>>(&branchname), "branch name")
+      ("in-channel", value<std::string>(&inChannel)->default_value("data-in") , "input channel name");
+    
+    config.AddToCmdLineOptions(fileSink_options);
+    
+    config.ParseAll(argc, argv);
+    
+    fileSink.SetProperty(FileSink::OutputFileName,filename);
+    
+    if ( classname.size() != branchname.size() ) {
+      LOG(ERROR) << "Run::FileSink >>>>> The classname size (" << classname.size() << ") and branchname size (" << branchname.size() << ") MISMATCH!!!";
     }
-  catch (std::exception& e)
-    {
-      LOG(ERROR)  << "Unhandled Exception reached the top of main: " 
-		  << e.what() << ", application will now exit";
-      return 1;
+    
+    fileSink.AddOutputBranch("AliceO2::MFT::EventHeader","EventHeader.");
+    for ( unsigned int ielem = 0 ; ielem < classname.size() ; ielem++ ) {
+      fileSink.AddOutputBranch(classname.at(ielem),branchname.at(ielem));
     }
+    
+    fileSink.SetInputChannelName(inChannel);
+    
+    string control = config.GetValue<std::string>("control");
+    LOG(INFO) << "Run::FileSink >>>>> device control is " << control.c_str() << "";
+    
+    runStateMachine(fileSink, config);     
+    
+    // equivalent to this (interactive mode)
+    /*
+    fileSink.CatchSignals();
+
+    fileSink.SetConfig(config);
+
+    fileSink.ChangeState("INIT_DEVICE");
+    fileSink.WaitForEndOfState("INIT_DEVICE");
+      
+    fileSink.ChangeState("INIT_TASK");
+    fileSink.WaitForEndOfState("INIT_TASK");
+      
+    fileSink.ChangeState("RUN");
+    fileSink.InteractiveStateLoop();
+    */
+  }
+
+  catch (std::exception& e) {
+
+    LOG(ERROR)  << "Unhandled Exception reached the top of main: " 
+		<< e.what() << ", application will now exit";
+    return 1;
+
+  }
   
   return 0;
   

--- a/Detectors/ITSMFT/MFT/reconstruction/src/runMFTrecoMerger.cxx
+++ b/Detectors/ITSMFT/MFT/reconstruction/src/runMFTrecoMerger.cxx
@@ -1,0 +1,54 @@
+#include <iostream>
+
+#include "FairMQLogger.h"
+#include "FairMQParser.h"
+#include "FairMQProgOptions.h"
+#include "runSimpleMQStateMachine.h"
+
+#include "MFTReconstruction/devices/Merger.h"
+
+using namespace std;
+using namespace boost::program_options;
+using namespace AliceO2::MFT;
+
+int main(int argc, char **argv)
+{
+
+  printf("Run MFT reconstruction merger!\n");
+
+  try {
+
+    std::string filename;
+    std::vector<std::string> classname;
+    std::vector<std::string> branchname;
+    
+    options_description merger_options("Merger options");
+    merger_options.add_options()
+      ("file-name",   po::value<std::string>             (&filename)  , "Path to the output file")
+      ("class-name",  po::value<std::vector<std::string>>(&classname) , "class name")
+      ("branch-name", po::value<std::vector<std::string>>(&branchname), "branch name");
+    
+    
+    FairMQProgOptions config;
+    config.AddToCmdLineOptions(merger_options);
+    
+    config.ParseAll(argc, argv);
+    
+    Merger merger;
+    
+    runStateMachine(merger, config);
+    
+  }
+
+  catch (std::exception& e) {
+
+    LOG(ERROR) << "Catch exception! " << e.what() << "";
+    
+    return 1;
+
+  }
+  
+  return 0;
+  
+}
+   

--- a/Detectors/ITSMFT/MFT/reconstruction/src/runMFTrecoSampler.cxx
+++ b/Detectors/ITSMFT/MFT/reconstruction/src/runMFTrecoSampler.cxx
@@ -7,6 +7,7 @@
 #include "FairMQProgOptions.h"
 #include "runSimpleMQStateMachine.h"
 
+#include "MFTBase/EventHeader.h"
 #include "MFTReconstruction/FindHits.h"
 #include "MFTReconstruction/devices/Sampler.h"
 
@@ -19,45 +20,55 @@ int main(int argc, char **argv)
 
   printf("Run MFT reconstruction sampler!\n");
 
-  Sampler sampler;
+  try {
 
-  FairMQProgOptions config;
-
-  try
-  {
     std::vector<std::string> filename;
     std::vector<std::string> branchname;
-
+    
     options_description sampler_options("MFT sampler options");
     sampler_options.add_options()
       ("file-name", value<std::vector<std::string>>(&filename),
-                    "Path to the input file")
+       "Path to the input file")
       ("branch-name", value<std::vector<std::string>>(&branchname)->required(), "branch name");
-
+    
+    FairMQProgOptions config;
     config.AddToCmdLineOptions(sampler_options);
     config.ParseAll(argc, argv);
-
+    
     string control = config.GetValue<std::string>("control");
     LOG(INFO) << "Run::Sampler >>>>> device control is " << control.c_str() << "";
-
+    
     LOG(INFO) << "Run::Sampler >>>>> Using file " << filename.at(0).c_str() << " and branch " << branchname.at(0).c_str() << "";
-
+    
+    Sampler sampler;
+    
     for (UInt_t ielem = 0; ielem < filename.size(); ielem++) {
       sampler.AddInputFileName(filename.at(ielem));
     }
-
+      
     for (UInt_t ielem = 0; ielem < branchname.size(); ielem++) {
       sampler.AddInputBranchName(branchname.at(ielem));
+      LOG(INFO) << "Run::Sampler >>>>> add input branch " << branchname.at(ielem).c_str() << "";
+   }
+      
+    if (strcmp(branchname.at(0).c_str(),"MFTPoints") == 0) {
+      LOG(INFO) << "Run::Sampler >>>>> add input branch MCEventHeader." << "";
+      sampler.AddInputBranchName("MCEventHeader.");
     }
-    
-    TApplication app("Sampler", 0, 0);
 
+    if (strcmp(branchname.at(0).c_str(),"MFTHits") == 0) {
+      LOG(INFO) << "Run::Sampler >>>>> add input branch EventHeader." << "";
+      sampler.AddInputBranchName("EventHeader.");
+    }
+
+    TApplication app("Sampler", 0, 0);
+      
     runStateMachine(sampler, config);
     /*
     sampler.CatchSignals();
-
+	
     sampler.SetConfig(config);
-
+	
     sampler.ChangeState("INIT_DEVICE");
     sampler.WaitForEndOfState("INIT_DEVICE");
     
@@ -70,15 +81,17 @@ int main(int argc, char **argv)
     gApplication->Terminate();
 
   } 
-  catch (std::exception& e)
-  {
 
-    LOG(INFO) << "Catch exception! " << e.what() << "";
-
+  catch (std::exception& e) {
+    
+    LOG(ERROR)  << "Unhandled Exception reached the top of main: " 
+		<< e.what() << ", application will now exit";
+    
     return 1;
+
   }
-
+  
   return 0;
-
+  
 }
 

--- a/Detectors/ITSMFT/MFT/reconstruction/src/runMFTrecoTaskProcessor.cxx
+++ b/Detectors/ITSMFT/MFT/reconstruction/src/runMFTrecoTaskProcessor.cxx
@@ -17,83 +17,82 @@ int main(int argc, char** argv)
 
   printf("Run MFT reconstruction task processor!\n");
 
-  FairMQProgOptions config;
+  try {
 
-  try
-    {
-      std::string taskname;
-      std::string keepdata;
-      std::string inChannel;
-      std::string outChannel;
-
-      options_description processor_options("Processor options");
-      processor_options.add_options()
-	("task-name",   po::value<std::string>(&taskname)->required()                  ,  "Name of task to run")
-	("keep-data",   po::value<std::string>(&keepdata)                              ,  "Name of data to keep in stream")
-	("in-channel",  po::value<std::string>(&inChannel)->default_value("data-in")   , "input channel name")
-	("out-channel", po::value<std::string>(&outChannel)->default_value("data-out") , "output channel name");
-        
-      config.AddToCmdLineOptions(processor_options);
+    std::string taskname;
+    std::string keepdata;
+    std::string inChannel;
+    std::string outChannel;
+    
+    options_description processor_options("Processor options");
+    processor_options.add_options()
+      ("task-name",   po::value<std::string>(&taskname)->required()                  ,  "Name of task to run")
+      ("keep-data",   po::value<std::string>(&keepdata)                              ,  "Name of data to keep in stream")
+      ("in-channel",  po::value<std::string>(&inChannel)->default_value("data-in")   , "input channel name")
+      ("out-channel", po::value<std::string>(&outChannel)->default_value("data-out") , "output channel name");
+    
+    FairMQProgOptions config;
+    config.AddToCmdLineOptions(processor_options);
+    config.ParseAll(argc, argv);
+    
+    string control = config.GetValue<std::string>("control");
+    LOG(INFO) << "Run::TaskProcessor >>>>> device control is " << control.c_str() << "";
+    
+    if (strcmp(taskname.c_str(),"FindHits") == 0) {
+      HitFinder processor;
+      processor.SetDataToKeep(keepdata);
+      processor.SetInputChannelName (inChannel);
+      processor.SetOutputChannelName(outChannel);
       
-      config.ParseAll(argc, argv);
+      runStateMachine(processor, config);
+      /*
+      processor.CatchSignals();
 
-      string control = config.GetValue<std::string>("control");
-      LOG(INFO) << "Run::TaskProcessor >>>>> device control is " << control.c_str() << "";
+      processor.SetConfig(config);
 
-      if (strcmp(taskname.c_str(),"FindHits") == 0) {
-	HitFinder processor;
-	processor.SetDataToKeep(keepdata);
-	processor.SetInputChannelName (inChannel);
-	processor.SetOutputChannelName(outChannel);
-
-	runStateMachine(processor, config);
-	/*
-	processor.CatchSignals();
-
-	processor.SetConfig(config);
-
-	processor.ChangeState("INIT_DEVICE");
-	processor.WaitForEndOfState("INIT_DEVICE");
+      processor.ChangeState("INIT_DEVICE");
+      processor.WaitForEndOfState("INIT_DEVICE");
 	
-	processor.ChangeState("INIT_TASK");
-	processor.WaitForEndOfState("INIT_TASK");
+      processor.ChangeState("INIT_TASK");
+      processor.WaitForEndOfState("INIT_TASK");
 	
-	processor.ChangeState("RUN");
-	processor.InteractiveStateLoop();
-	*/
-       }
-      else if (strcmp(taskname.c_str(),"FindTracks") == 0) {
-	TrackFinder processor;
-	processor.SetDataToKeep(keepdata);
-	processor.SetInputChannelName (inChannel);
-	processor.SetOutputChannelName(outChannel);
+      processor.ChangeState("RUN");
+      processor.InteractiveStateLoop();
+      */
+    } else if (strcmp(taskname.c_str(),"FindTracks") == 0) {
+      TrackFinder processor;
+      processor.SetDataToKeep(keepdata);
+      processor.SetInputChannelName (inChannel);
+      processor.SetOutputChannelName(outChannel);
+      
+      runStateMachine(processor, config);
+      /*
+      processor.CatchSignals();
 
-	runStateMachine(processor, config);
-	/*
-	processor.CatchSignals();
+      processor.SetConfig(config);
 
-	processor.SetConfig(config);
-
-	processor.ChangeState("INIT_DEVICE");
-	processor.WaitForEndOfState("INIT_DEVICE");
+      processor.ChangeState("INIT_DEVICE");
+      processor.WaitForEndOfState("INIT_DEVICE");
 	
-	processor.ChangeState("INIT_TASK");
-	processor.WaitForEndOfState("INIT_TASK");
+      processor.ChangeState("INIT_TASK");
+      processor.WaitForEndOfState("INIT_TASK");
 	
-	processor.ChangeState("RUN");
-	processor.InteractiveStateLoop();
-	*/
-       }
-      else {
-	LOG(INFO) << "TASK \"" << taskname << "\" UNKNOWN!!!";
-      }
+      processor.ChangeState("RUN");
+      processor.InteractiveStateLoop();
+      */
+    } else {
+      LOG(INFO) << "TASK \"" << taskname << "\" UNKNOWN!!!";
     }
-  catch (std::exception& e)
-    {
-      LOG(ERROR)  << "Unhandled Exception reached the top of main: "
-		  << e.what() << ", application will now exit";
-      return 1;
-    }
+
+  }
+
+  catch (std::exception& e) {
+
+    LOG(ERROR)  << "Unhandled Exception reached the top of main: "
+		<< e.what() << ", application will now exit";
+    return 1;
+    
+  }
   
   return 0;
   


### PR DESCRIPTION
Implement the reconstruction (MC points to hits and hits to tracks - one after the other) from two simulation files, using two samplers, two processor, one merger and one sink.
