### PR TITLE
Initialization error

### DIFF
--- a/Detectors/ITSMFT/ITS/simulation/src/DigitizerTask.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/DigitizerTask.cxx
@@ -25,7 +25,6 @@ DigitizerTask::DigitizerTask() :
   fPointsArray(nullptr),
   fDigitsArray(nullptr)
 {
-  fDigitizer = new Digitizer;
 }
 
 DigitizerTask::~DigitizerTask()
@@ -54,7 +53,8 @@ InitStatus DigitizerTask::Init()
   // Register output container
   fDigitsArray = new TClonesArray("AliceO2::ITS::Digit");
   mgr->Register("ITSDigit", "ITS", fDigitsArray, kTRUE);
-
+  
+  fDigitizer = new Digitizer;
   fDigitizer->Init();
   return kSUCCESS;
 }

--- a/macro/run_clusterer.C
+++ b/macro/run_clusterer.C
@@ -2,8 +2,8 @@ void run_clusterer(Int_t nEvents = 10, TString mcEngine = "TGeant3")
 {
   // Initialize logger
   FairLogger *logger = FairLogger::GetLogger();
-  logger->SetLogVerbosityLevel("HIGH");
-  logger->SetLogScreenLevel("DEBUG");
+  logger->SetLogVerbosityLevel("LOW");
+  logger->SetLogScreenLevel("INFO");
 
   // Input and output file name
   std::stringstream inputfile, outputfile, paramfile;

--- a/macro/run_digi.C
+++ b/macro/run_digi.C
@@ -25,7 +25,7 @@ void run_digi(Int_t nEvents = 10, TString mcEngine = "TGeant3"){
         parInput1->open(paramfile.str().c_str());
         rtdb->setFirstInput(parInput1);
 
-        TGeoManager::Import("geofile_full.root");
+      //  TGeoManager::Import("geofile_full.root");
 
         // Setup digitizer
         AliceO2::ITS::DigitizerTask *digi = new AliceO2::ITS::DigitizerTask;

--- a/macro/run_sim.C
+++ b/macro/run_sim.C
@@ -160,7 +160,7 @@ void run_sim(Int_t nEvents = 10, TString mcEngine = "TGeant3")
 
   // ===| Add TPC |============================================================
   AliceO2::TPC::Detector* tpc = new AliceO2::TPC::Detector("TPC", kTRUE);
-  tpc->SetGeoFileName("/data/Work/software/o2/AliceO2/wiechula/Detectors/TPC/simulation/geometry/TPCGeometry.root");
+  tpc->SetGeoFileName("TPCGeometry.root");
   run->AddModule(tpc);
 
   // Create PrimaryGenerator
@@ -178,7 +178,7 @@ void run_sim(Int_t nEvents = 10, TString mcEngine = "TGeant3")
   run->SetGenerator(primGen);
 
   // store track trajectories
-  run->SetStoreTraj(kTRUE);
+//  run->SetStoreTraj(kTRUE);
 
   // Initialize simulation run
   run->Init();
@@ -193,7 +193,7 @@ void run_sim(Int_t nEvents = 10, TString mcEngine = "TGeant3")
 
   // Start run
   run->Run(nEvents);
-  run->CreateGeometryFile("geofile_full.root");
+//  run->CreateGeometryFile("geofile_full.root");
 
   // Finish
   timer.Stop();


### PR DESCRIPTION
Problem: Digitizer was created in the constructor of the task and in the ctor of the digitiser it tries to access the geometry which is still not available at this stage.   

Solution: The Digitizer is created and initialised in the init of the Task.

No need to load the geometry separately (This was the work around!) it is taken now from the parameters 
Remove hardcoded paths.
Switch off  track visualisation
Set the verbosity to low in the macro
  