### PR TITLE
Disable DDS support in aliceHLTWrapper, Fixes #183

### DIFF
--- a/Utilities/aliceHLTwrapper/src/aliceHLTEventSampler.cxx
+++ b/Utilities/aliceHLTwrapper/src/aliceHLTEventSampler.cxx
@@ -30,6 +30,14 @@
 #define HAVE_FAIRMQ_INTERFACE_CHANGESTATE_STRING
 #endif
 
+// DDS intercom API has been changed in release 1.4
+// as it is not a matter of a few lines, DDS support is disabled for
+// the moment. We need a major rewrite and testing
+#ifdef ENABLE_DDS
+#define ENFORCED_DDS_DISABLE
+#undef ENABLE_DDS
+#endif
+
 #ifdef ENABLE_DDS
 #include <mutex>
 #include <condition_variable>
@@ -271,7 +279,11 @@ int main(int argc, char** argv)
 
   if (bUseDDS) {
 #ifndef ENABLE_DDS
+#ifdef ENFORCED_DDS_DISABLE
+    cerr << "Fatal: device is not compatible with DDS Intercom API any more" << endl;
+#else
     cerr << "Fatal: device has not been compiled with DDS support" << endl;
+#endif
     exit(ENOSYS);
 #endif
     int result=preprocessSocketsDDS(inputSockets, networkPrefix);

--- a/Utilities/aliceHLTwrapper/src/aliceHLTWrapper.cxx
+++ b/Utilities/aliceHLTwrapper/src/aliceHLTWrapper.cxx
@@ -35,6 +35,14 @@
 #define HAVE_FAIRMQ_INTERFACE_CHANGESTATE_STRING
 #endif
 
+// DDS intercom API has been changed in release 1.4
+// as it is not a matter of a few lines, DDS support is disabled for
+// the moment. We need a major rewrite and testing 
+#ifdef ENABLE_DDS
+#define ENFORCED_DDS_DISABLE
+#undef ENABLE_DDS
+#endif
+
 #ifdef ENABLE_DDS
 #include <mutex>
 #include <condition_variable>
@@ -293,7 +301,11 @@ int main(int argc, char** argv)
 
   if (bUseDDS) {
 #ifndef ENABLE_DDS
+#ifdef ENFORCED_DDS_DISABLE
+    cerr << "Fatal: device is not compatible with DDS Intercom API any more" << endl;
+#else
     cerr << "Fatal: device has not been compiled with DDS support" << endl;
+#endif
     exit(ENOSYS);
 #endif
     int result=preprocessSocketsDDS(inputSockets, networkPrefix);


### PR DESCRIPTION
DDS Intercom API has been changed in version v1.4 without maintaining
backward compatibility. As it is not a matter of changing a few lines
of code, DDS support is disabled now in the aliceHLTWrapper. The device
needs a major rewrite to adopt to the latest changes in FairRoot and
the new DDS Intercom API