### PR TITLE
Squashed development of test programs for Utility/DataCompression

### DIFF
--- a/Utilities/DataCompression/test/test_dc_primitives.cxx
+++ b/Utilities/DataCompression/test/test_dc_primitives.cxx
@@ -1,0 +1,86 @@
+/**
+g++ --std=c++11 -g -ggdb -I$BOOST_ROOT/include -I../include/ -o test_dc_primitives test_dc_primitives.cxx
+ */
+
+#include "DataCompression/dc_primitives.h"
+#include <boost/mpl/size.hpp>
+#include <boost/type.hpp>
+#include <boost/mpl/range_c.hpp>
+#include <boost/mpl/vector.hpp>
+#include <boost/mpl/for_each.hpp>
+#include <boost/mpl/vector_c.hpp>
+#include <iostream>
+#include <iomanip>
+#include <vector>
+
+/**
+ * TODO: would like to have a general Tester for different kinds
+ * of meta programs, but did not succeed so far to define a templated
+ * Tester which can take the iterator argument at a placeholder
+ * location. Some reading
+ * http://stackoverflow.com/questions/24954220/boostmplfor-each-without-instantiating
+ * http://stackoverflow.com/questions/2840640/how-to-loop-through-a-boostmpllist
+ * http://stackoverflow.com/questions/16087806/boost-mpl-nested-lambdas
+ */
+struct getmaxTester
+{
+  template<typename T> void operator()(boost::type<T>) {
+    std::cout << "Max number in " << std::setw(2) << T::value << "-bit range: "<< getmax<uint64_t,  T::value>::value << std::endl;
+  }
+};
+
+struct upperbinaryboundTester
+{
+  template<typename T> void operator()(boost::type<T>) {
+    std::cout << "number of bits required for value " << std::setw(4) << T::value << ": " << std::setw(3) << upperbinarybound<T::value>::value << std::endl;
+  }
+};
+
+template<typename ValueList>
+struct AlphabetTester
+{
+  ValueList mList;
+  AlphabetTester();
+  AlphabetTester(const ValueList& list) : mList(list) {}
+  template<typename Alphabet> void operator()(Alphabet& alphabet) {
+    for (const auto v : mList) {
+      std::cout << "Alphabet '" << alphabet.getName() << "': value " << std::setw(2) << v << " is " << (alphabet.isValid(v)?"valid":"not valid") << std::endl;
+    }
+  }
+};
+
+int main()
+{
+  // test the getmax meta program
+  std::cout << std::endl << "Testing getmax meta program ..." << std::endl;
+  typedef boost::mpl::vector_c<uint16_t, 0, 1, 2, 3, 4, 31, 32, 64> bitranges;
+  boost::mpl::for_each<bitranges, boost::type<boost::mpl::_> >(getmaxTester());
+
+  // test the getnofelements meta program
+  std::cout << std::endl << "Testing getnofelements meta program ..." << std::endl;
+  constexpr uint16_t lowerelement = 0;
+  constexpr uint16_t upperelement = 10;
+  std::cout << "Number of elements in range [" 
+	    << lowerelement << "," << upperelement << "]: "
+	    << getnofelements<uint16_t, lowerelement, upperelement >::value
+	    << std::endl;
+
+  // test the upperbinarybound compile time evaluation
+  std::cout << std::endl << "Testing upperbinarybound meta program ..." << std::endl;
+  boost::mpl::for_each<boost::mpl::vector_c<int, 6, 1000, 86, 200>, boost::type<boost::mpl::_> >(upperbinaryboundTester());
+
+  std::cout << std::endl << "Testing alphabet template ..." << std::endl;
+  // declare two types of alphabets: a contiguous range alphabet with symbols
+  // between -1 and 10 and a bit-range alphabet for a 10-bit word
+  typedef boost::mpl::string<'T','e','s','t'>::type TestAlphabetName;
+  typedef boost::mpl::string<'1','0','-','b','i','t'>::type TenBitAlphabetName;
+  typedef ContiguousAlphabet<int16_t, -1, 10, TestAlphabetName> TestAlphabet;
+  typedef BitRangeContiguousAlphabet<int16_t, 10, TenBitAlphabetName> TenBitAlphabet;
+
+  // now check a set of values if they are valid in each of the alphabets
+  // the check is done at runtime on types of alphabets rather than on
+  // actual objects
+  std::vector<int16_t> values = {0 , 5, 15, -2, -1};
+  typedef boost::mpl::vector<TestAlphabet, TenBitAlphabet> ParameterSet;
+  boost::mpl::for_each<ParameterSet>( AlphabetTester<std::vector<int16_t>>(values) );
+}

--- a/Utilities/DataCompression/test/test_huffmancodec.cxx
+++ b/Utilities/DataCompression/test/test_huffmancodec.cxx
@@ -1,0 +1,140 @@
+//****************************************************************************
+//* This file is free software: you can redistribute it and/or modify        *
+//* it under the terms of the GNU General Public License as published by     *
+//* the Free Software Foundation, either version 3 of the License, or        *
+//* (at your option) any later version.                                      *
+//*                                                                          *
+//* Primary Authors: Matthias Richter <richterm@scieq.net>                   *
+//*                                                                          *
+//* The authors make no claims about the suitability of this software for    *
+//* any purpose. It is provided "as is" without express or implied warranty. *
+//****************************************************************************
+
+//  @file   test_huffmancodec.cxx
+//  @author Matthias Richter
+//  @since  2015-08-11
+//  @brief  Test program for Huffman codec template class
+
+// Compilation: make sure variable BOOST_ROOT points to your boost installation
+/*
+   g++ --std=c++11 -g -ggdb -I$BOOST_ROOT/include -I../include -o test_huffmancodec test_huffmancodec.cxx
+*/
+
+#include <iostream>
+#include <iomanip>
+#include <cstring>
+#include <vector>
+#include <bitset>
+#include <random> // std::exponential_distribution
+#include <cmath>  // std::exp
+#include <boost/mpl/string.hpp>
+#include "DataCompression/dc_primitives.h"
+#include "DataCompression/HuffmanCodec.h"
+
+int main()
+{
+  // defining a contiguous alphabet of integral 16 bit unsigned numbers
+  // in the range [-1, 10] including the upper bound
+  // the first definition is a data type, then an object of this type is
+  // defined
+  typedef ContiguousAlphabet<int16_t, -1, 15> SimpleRangeAlphabet_t;
+  SimpleRangeAlphabet_t alphabet;
+  std::cout << "alphabet '" << alphabet.getName()
+	    << "' has " <<  SimpleRangeAlphabet_t::size::value
+	    << " element(s)"
+	    << std::endl;
+  for (auto a : alphabet) {
+    // trying also the postfix ++ operator; a is not the iterator itself
+    // so it has no consequence on the iteration
+    std::cout << a++ << " ";
+    // simple testing of the type defines in the alphabet iterator
+    SimpleRangeAlphabet_t::iterator::value_type v = a;
+    SimpleRangeAlphabet_t::iterator::reference r = a;
+  }
+  std::cout << std::endl;
+
+  std::cout << std::endl << "checking some numbers to be valid symbols in the alphabet" << std::endl;
+  std::vector<int16_t> values = {0 , 5, 15, -2, -1};
+  for (auto v : values) {
+    std::cout << v << " is " << (alphabet.isValid(v)?"valid":"not valid") << std::endl;
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  // Using the Huffman propability model for the alphabet
+  //
+  // HuffmanModel_t is a data type, huffmanmodel an object of this type
+  // the node type is defined to be HuffmanNode specialized to bitset<16>
+  // third template parameter determines whether code has to be decoded
+  // MSB to LSB (true) or LSB to MSB (false)
+  typedef AliceO2::HuffmanModel<
+    ProbabilityModel<SimpleRangeAlphabet_t>
+    , AliceO2::HuffmanNode<std::bitset<16> >
+    , true
+    > HuffmanModel_t;
+  HuffmanModel_t huffmanmodel;
+
+  std::cout << std::endl << "Huffman probability model after initialization: " << std::endl;
+  huffmanmodel.init(0.);
+  for (auto s : alphabet) {
+    std::cout << "val = " << std::setw(2) << s << " --> weight = " << huffmanmodel[s] << std::endl;
+  }
+
+  // an exponential distribution random generator to be used to create a
+  // sequence of random numbers to be encoded
+  double lambda=1.;
+  std::default_random_engine generator;
+  std::exponential_distribution<double> distribution(lambda);
+
+  // add weights directly for every symbol, using the expenential distribution
+  // and an epsilon value to make the Huffman table more 'interesting'
+  // set epsilon to 0 to get a completely 'linear' tree
+  int x = 0;
+  for (auto s : alphabet) {
+    double epsilon = (SimpleRangeAlphabet_t::size::value - x)*0.1;
+    double p = lambda * std::exp(-lambda*x++) + epsilon;
+    //p = p - 1.; // compensate for the 1 we have previously initialized
+    huffmanmodel.addWeight(s, p);
+  }
+
+  // normalizing the weight to the total weight thus having the probability
+  // for every symbol
+  std::cout << std::endl << "Probabilities:" << std::endl;
+  huffmanmodel.normalize();
+  for (auto i : huffmanmodel) {
+    std::cout << "val = " << std::setw(2) << i.first << " --> weight = " << i.second << std::endl;
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  // generate the Huffman tree in the Huffman model and create a Huffman
+  // codec operating on the probability table
+  std::cout << std::endl << "Generating binary tree and Huffman codes" << std::endl;
+  huffmanmodel.GenerateHuffmanTree();
+  huffmanmodel.print();
+  typedef AliceO2::HuffmanCodec<HuffmanModel_t > Codec_t;
+  Codec_t codec(huffmanmodel);
+
+  ////////////////////////////////////////////////////////////////////////////
+  // print Huffman code summary
+  std::cout << std::endl << "Huffman code summary: "
+	    << (HuffmanModel_t::orderMSB?"MSB to LSB":"LSB to MSB")
+	    << std::endl;
+  for ( auto i : huffmanmodel) {
+    uint16_t codeLen = 0;
+    HuffmanModel_t::code_type code;
+    codec.Encode(i.first, code, codeLen);
+    std::cout << "value: " << std::setw(4) << i.first 
+              << "   code length: " << std::setw(3) << codeLen
+              << "   code: ";
+    if (not HuffmanModel_t::orderMSB) std::cout << std::setw(code.size() - codeLen);
+    for (int i = 0; i<codeLen; i++)
+      std::cout << code[codeLen-1-i];
+    std::cout << std::endl;
+    if (HuffmanModel_t::orderMSB) code <<= (code.size()-codeLen);
+    uint16_t decodedLen = 0;
+    HuffmanModel_t::value_type value;
+    codec.Decode(value, code, decodedLen);
+    if (codeLen != decodedLen || value != i.first) {
+      std::cout << "mismatch in decoded value: " << value << "(" << decodedLen << ")" << std::endl;
+    }
+  }
+}

--- a/Utilities/DataCompression/tpccluster_parameter_model.h
+++ b/Utilities/DataCompression/tpccluster_parameter_model.h
@@ -1,5 +1,5 @@
-#include "dc_primitives.h"
-#include "HuffmanCodec.h"
+#include "DataCompression/dc_primitives.h"
+#include "DataCompression/HuffmanCodec.h"
 #include <bitset>
 #include <boost/mpl/vector.hpp>
 #include <boost/mpl/string.hpp>


### PR DESCRIPTION
Test program development squashed into single commit per executable, both moved to `Utilities/DataCompression/test`. Integration to cmake will follow soon.

Follow-up-change in tpccluster_parameter_model.h according to moved header files.