### PR TITLE
Generic tools for the data header

### DIFF
--- a/DataFormats/Headers/src/DataHeader.cxx
+++ b/DataFormats/Headers/src/DataHeader.cxx
@@ -176,16 +176,7 @@ bool AliceO2::Header::DataHeader::operator==(const DataHeader& that) const
 }
 
 //__________________________________________________________________________________________________
-AliceO2::Header::DataOrigin::DataOrigin() : itg(gInvalidToken32) {}
-
-//__________________________________________________________________________________________________
-bool AliceO2::Header::DataOrigin::operator==(const DataOrigin& other) const
-{
-  return itg == other.itg;
-}
-
-//__________________________________________________________________________________________________
-void AliceO2::Header::DataOrigin::print() const
+void AliceO2::Header::printDataOrigin::operator()(const char* str) const
 {
   printf("Data origin  : %s\n", str);
 }

--- a/DataFormats/Headers/src/DataHeader.cxx
+++ b/DataFormats/Headers/src/DataHeader.cxx
@@ -15,7 +15,7 @@
 #include <cstring> // strncpy
 
 //the answer to life and everything
-const uint32_t AliceO2::Header::BaseHeader::sMagicString = CharArr2uint32("O2O2");
+const uint32_t AliceO2::Header::BaseHeader::sMagicString = String2<uint32_t>("O2O2");
 
 //possible serialization types
 const AliceO2::Header::SerializationMethod AliceO2::Header::gSerializationMethodAny    ("*******");


### PR DESCRIPTION
* Generic methods to convert a string to a uint of variable size, basically it allows to change
```
String2uint64("DESCRIPTION") -> String2<uint64_t>("DESCRIPTION")
```
It goes through the same template code for all types.

* Generic implementation for N-byte descriptors, using it for the DataOrigin
* Adding also a type conversion operator for `AliceO2::Header::Block` to extract the first `BaseHeader`