### PR TITLE
Install FLP2EPN Example scripts and configs

### DIFF
--- a/Examples/flp2epn-distributed/CMakeLists.txt
+++ b/Examples/flp2epn-distributed/CMakeLists.txt
@@ -67,3 +67,13 @@ EndForEach (_file RANGE 0 ${_length})
 add_test(NAME run_flp2epn_distributed COMMAND ${CMAKE_BINARY_DIR}/Examples/flp2epn-distributed/test/testFLP2EPN-distributed.sh)
 set_tests_properties(run_flp2epn_distributed PROPERTIES TIMEOUT "30")
 set_tests_properties(run_flp2epn_distributed PROPERTIES PASS_REGULAR_EXPRESSION "acknowledged after")
+
+install(FILES ${CMAKE_BINARY_DIR}/bin/startFLP2EPN-distributed.sh
+              ${CMAKE_BINARY_DIR}/Examples/flp2epn-distributed/test/testFLP2EPN-distributed.sh
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+
+install(FILES ${CMAKE_BINARY_DIR}/bin/config/flp2epn-prototype.json
+              ${CMAKE_BINARY_DIR}/bin/config/flp2epn-prototype-dds.json
+              ${CMAKE_BINARY_DIR}/bin/config/flp2epn-dds-topology.xml
+              ${CMAKE_BINARY_DIR}/bin/config/flp2epn-dds-hosts.cfg
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/bin/config)


### PR DESCRIPTION
As is those get installed in the BUILD directory, but not in the
installation area.