### PR TITLE
Handling a compiler warning for printf formatting

### DIFF
--- a/DataFormats/Headers/src/DataHeader.cxx
+++ b/DataFormats/Headers/src/DataHeader.cxx
@@ -102,9 +102,9 @@ void AliceO2::Header::DataHeader::print() const
   printf("  origin       : %s\n", dataOrigin.str);
   printf("  serialization: %s\n", payloadSerializationMethod.str);
   printf("  description  : %s\n", dataDescription.str);
-  printf("  sub spec.    : %llu\n", subSpecification);
+  printf("  sub spec.    : %llu\n", (long long unsigned int)subSpecification);
   printf("  header size  : %i\n", headerSize);
-  printf("  payloadSize  : %llu\n", payloadSize);
+  printf("  payloadSize  : %llu\n", (long long unsigned int)payloadSize);
 }
 
 //__________________________________________________________________________________________________


### PR DESCRIPTION
This is a minor issue, printf needs the correct format specifier but 'llu'
for long long unsinged int has a different underlying type for different
architectures. On some 64bit systems it does not match the type for uint64_t,
on 32 bit systems, long long is the 64bit integer.

Solved by casting the variable to long long unsinged.
We can probably avoid this by switching to stream output.