### PR TITLE
fix cmake issue with O2_GENERATE_LIBRARY

### DIFF
--- a/CCDB/CMakeLists.txt
+++ b/CCDB/CMakeLists.txt
@@ -64,10 +64,6 @@ Set(Exe_Source
   src/runConditionsClient.cxx
 )
 
-# todo we repeat ourselves because the macro O2_GENERATE_LIBRARY dares deleting the variables we pass to it.
-set(LIBRARY_NAME ${MODULE_NAME})
-set(BUCKET_NAME CCDB_bucket)
-
 list(LENGTH Exe_Names _length)
 math(EXPR _length ${_length}-1)
 

--- a/DataFormats/Headers/CMakeLists.txt
+++ b/DataFormats/Headers/CMakeLists.txt
@@ -18,9 +18,6 @@ set(BUCKET_NAME fairroot_base_bucket)
 
 O2_GENERATE_LIBRARY()
 
-set(LIBRARY_NAME ${MODULE_NAME})
-set(BUCKET_NAME fairroot_base_bucket)
-
 set(TEST_SRCS
   test/dataHeaderTest.cxx
 )

--- a/Detectors/ITSMFT/MFT/reconstruction/CMakeLists.txt
+++ b/Detectors/ITSMFT/MFT/reconstruction/CMakeLists.txt
@@ -49,10 +49,6 @@ Set(Exe_Source
   src/runMFTrecoMerger.cxx
 )
 
-# todo we repeat ourselves because the macro O2_GENERATE_LIBRARY dares deleting the variables we pass to it.
-set(BUCKET_NAME mft_reconstruction_bucket)
-set(LIBRARY_NAME ${MODULE_NAME})
-
 list(LENGTH Exe_Names _length)
 math(EXPR _length ${_length}-1)
 

--- a/Examples/ExampleModule1/CMakeLists.txt
+++ b/Examples/ExampleModule1/CMakeLists.txt
@@ -21,10 +21,6 @@ set(BUCKET_NAME ExampleModule1_bucket)
 
 O2_GENERATE_LIBRARY()
 
-# todo we repeat ourselves because the above macro dares deleting the variables we pass to it.
-set(LIBRARY_NAME ${MODULE_NAME})
-set(BUCKET_NAME ExampleModule1_bucket)
-
 # Define application
 O2_GENERATE_EXECUTABLE(
     EXE_NAME runExampleModule1

--- a/Examples/ExampleModule2/CMakeLists.txt
+++ b/Examples/ExampleModule2/CMakeLists.txt
@@ -24,10 +24,6 @@ set(LINKDEF src/ExampleLinkDef.h) # needed for the dictionary generation
 
 O2_GENERATE_LIBRARY()
 
-# todo we repeat ourselves because the above macro dares deleting the variables we pass to it.
-set(LIBRARY_NAME ${MODULE_NAME})
-set(BUCKET_NAME ExampleModule2_bucket)
-
 # Define application
 O2_GENERATE_EXECUTABLE(
     EXE_NAME runExampleModule2

--- a/Examples/flp2epn-distributed/CMakeLists.txt
+++ b/Examples/flp2epn-distributed/CMakeLists.txt
@@ -42,14 +42,6 @@ set(Exe_Source
     run/runEPNReceiver.cxx
     )
 
-# todo we repeat ourselves because the macro O2_GENERATE_LIBRARY dares deleting the variables we pass to it.
-if (DDS_FOUND)
-  set(BUCKET_NAME flp2epndistrib_bucket)
-else ()
-  set(BUCKET_NAME flp2epn_bucket)
-endif ()
-set(LIBRARY_NAME ${MODULE_NAME})
-
 list(LENGTH Exe_Names _length)
 math(EXPR _length ${_length}-1)
 

--- a/Examples/flp2epn/CMakeLists.txt
+++ b/Examples/flp2epn/CMakeLists.txt
@@ -34,10 +34,6 @@ set(Exe_Source
     src/runProxy.cxx
     )
 
-# todo we repeat ourselves because the macro O2_GENERATE_LIBRARY dares deleting the variables we pass to it.
-set(LIBRARY_NAME ${MODULE_NAME})
-set(BUCKET_NAME flp2epn_bucket)
-
 list(LENGTH Exe_Names _length)
 math(EXPR _length ${_length}-1)
 

--- a/Utilities/O2MessageMonitor/CMakeLists.txt
+++ b/Utilities/O2MessageMonitor/CMakeLists.txt
@@ -18,10 +18,6 @@ set(BUCKET_NAME O2MessageMonitor_bucket)
 
 O2_GENERATE_LIBRARY()
 
-# todo we repeat ourselves because the above macro dares deleting the variables we pass to it.
-set(LIBRARY_NAME ${MODULE_NAME})
-set(BUCKET_NAME O2MessageMonitor_bucket)
-
 # Define application
 O2_GENERATE_EXECUTABLE(
   EXE_NAME runO2MessageMonitor

--- a/Utilities/QC/QCMerger/CMakeLists.txt
+++ b/Utilities/QC/QCMerger/CMakeLists.txt
@@ -20,10 +20,6 @@ set(BUCKET_NAME QC_base_bucket)
 
 O2_GENERATE_LIBRARY()
 
-# todo we repeat ourselves because the above macro dares deleting the variables we pass to it.
-set(LIBRARY_NAME ${MODULE_NAME})
-set(BUCKET_NAME QC_merger_bucket)
-
 # Define application
 O2_GENERATE_EXECUTABLE(
     EXE_NAME runQCMergerDevice

--- a/Utilities/QC/QCMetricsExtractor/CMakeLists.txt
+++ b/Utilities/QC/QCMetricsExtractor/CMakeLists.txt
@@ -18,10 +18,6 @@ set(BUCKET_NAME QC_base_bucket)
 
 O2_GENERATE_LIBRARY()
 
-# todo we repeat ourselves because the above macro dares deleting the variables we pass to it.
-set(LIBRARY_NAME ${MODULE_NAME})
-set(BUCKET_NAME QC_merger_bucket)
-
 # Define application
 O2_GENERATE_EXECUTABLE(
     EXE_NAME runQCMetricsExtractor

--- a/Utilities/QC/QCProducer/CMakeLists.txt
+++ b/Utilities/QC/QCProducer/CMakeLists.txt
@@ -29,10 +29,6 @@ set(BUCKET_NAME QC_base_bucket)
 
 O2_GENERATE_LIBRARY()
 
-# todo we repeat ourselves because the above macro dares deleting the variables we pass to it.
-set(LIBRARY_NAME ${MODULE_NAME})
-set(BUCKET_NAME QC_base_bucket)
-
 # Define application
 O2_GENERATE_EXECUTABLE(
     EXE_NAME runQCProducerDevice

--- a/Utilities/QC/QCViewer/CMakeLists.txt
+++ b/Utilities/QC/QCViewer/CMakeLists.txt
@@ -18,10 +18,6 @@ set(BUCKET_NAME QC_viewer_bucket)
 
 O2_GENERATE_LIBRARY()
 
-# todo we repeat ourselves because the above macro dares deleting the variables we pass to it.
-set(LIBRARY_NAME ${MODULE_NAME})
-set(BUCKET_NAME QC_viewer_bucket)
-
 # Define application
 O2_GENERATE_EXECUTABLE(
     EXE_NAME runQCViewerDevice

--- a/Utilities/aliceHLTwrapper/CMakeLists.txt
+++ b/Utilities/aliceHLTwrapper/CMakeLists.txt
@@ -21,10 +21,6 @@ set(BUCKET_NAME alicehlt_bucket)
 
 O2_GENERATE_LIBRARY()
 
-# todo we repeat ourselves because the above macro dares deleting the variables we pass to it.
-set(LIBRARY_NAME ${MODULE_NAME})
-set(BUCKET_NAME alicehlt_bucket)
-
 Set(Exe_Names
     aliceHLTWrapperApp
     aliceHLTEventSampler

--- a/cmake/O2Utils.cmake
+++ b/cmake/O2Utils.cmake
@@ -280,14 +280,6 @@ macro(O2_GENERATE_LIBRARY)
   # Install all the public headers
   install(DIRECTORY include/${MODULE_NAME} DESTINATION include)
 
-  Set(LIBRARY_NAME)
-  Set(DICTIONARY)
-  Set(LINKDEF)
-  Set(SRCS)
-  Set(HEADERS)
-  Set(NO_DICT_SRCS)
-  Set(DEPENDENCIES)
-
 endmacro(O2_GENERATE_LIBRARY)
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
 * do no longer reset variables gives to O2_GENERATE_LIBRARY
 * resulting simplification of CMakeLists.txt files

see issue #149