### PR TITLE
Fix issue #246

### DIFF
--- a/Generators/include/Generators/Pythia8Generator.h
+++ b/Generators/include/Generators/Pythia8Generator.h
@@ -21,7 +21,7 @@
 
 //#include "Pythia8/Basics.h"          // for RndmEngine
 #include "FairGenerator.h"   // for FairGenerator
-#include "Pythia.h"  // for Pythia
+#include "Pythia8/Pythia.h"  // for Pythia
 #include "Rtypes.h"          // for Double_t, Bool_t, Int_t, etc
 #include "TRandom.h"         // for TRandom
 #include "TRandom1.h"        // for TRandom1

--- a/Generators/src/Pythia8Generator.cxx
+++ b/Generators/src/Pythia8Generator.cxx
@@ -12,7 +12,7 @@
 
 #include <math.h>
 #include "TROOT.h"
-#include "Pythia.h"
+#include "Pythia8/Pythia.h"
 #include "FairPrimaryGenerator.h"
 //#include "FairGenerator.h"
 

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -47,6 +47,11 @@ if(Pythia6_FOUND)
       ${Pythia6_LIBRARY_DIR}
   )
 endif()
+if(PYTHIA8_FOUND)
+  link_directories(
+      ${PYTHIA8_LIB_DIR}
+  )
+endif()
 
 ########## General definitions and flags ##########
 
@@ -524,7 +529,7 @@ o2_define_bucket(
     generators_bucket
 
     DEPENDENCIES
-    Base SimulationDataFormat Pythia6 pythia8 MathCore
+    Base SimulationDataFormat pythia6 pythia8 MathCore
 
     INCLUDE_DIRECTORIES
     ${ROOT_INCLUDE_DIR}


### PR DESCRIPTION
This PR should fix issue 246 and lead back to a fully compiling dev branch on jenkins.
It turns out that there is an inconsistent use of upper and lower case spelling for pythia6.
The O2 recipes build a libpythia6 but sometimes (FairRoot + Generators) ask for libPythia6

I changed this code to comply with the O2 build system for the moment.
