### PR TITLE
Further work on Descriptor struct: unit test, runtime init

### DIFF
--- a/DataFormats/Headers/test/dataHeaderTest.cxx
+++ b/DataFormats/Headers/test/dataHeaderTest.cxx
@@ -7,6 +7,51 @@
 namespace AliceO2 {
   namespace Header {
 
+    BOOST_AUTO_TEST_CASE(Description_test)
+    {
+      // test for the templated Descriptor struct
+      constexpr int descriptorSize = 8;
+      typedef Descriptor<descriptorSize> TestDescriptorT;
+      BOOST_CHECK(TestDescriptorT::size == descriptorSize);
+      BOOST_CHECK(TestDescriptorT::bitcount == descriptorSize * 8);
+      BOOST_CHECK(sizeof(TestDescriptorT::ItgType) == descriptorSize);
+
+      // the Descriptor allows to define an integral value from
+      // a char sequence so that the in-memory representation shows
+      // a readable pattern
+      constexpr char readable[] = "DESCRPTR";
+      // the inverse sequence as integer value:       R T P R C S E D
+      constexpr TestDescriptorT::ItgType itgvalue = 0x5254505243534544;
+
+      TestDescriptorT testDescriptor(readable);
+      TestDescriptorT anotherDescriptor("ANOTHER");
+
+      // copy constructor and comparison operator
+      BOOST_CHECK(testDescriptor == TestDescriptorT(testDescriptor));
+
+      // comparison operator
+      BOOST_CHECK(testDescriptor != anotherDescriptor);
+
+      // type cast operator
+      BOOST_CHECK(itgvalue == testDescriptor);
+
+      // assignment operator
+      anotherDescriptor = testDescriptor;
+      BOOST_CHECK(testDescriptor == anotherDescriptor);
+      anotherDescriptor = TestDescriptorT("SOMEMORE");
+      BOOST_CHECK(itgvalue != anotherDescriptor);
+
+      // assignment using implicit conversion with constructor
+      anotherDescriptor = itgvalue;
+      BOOST_CHECK(testDescriptor == anotherDescriptor);
+
+      // check with runtime string
+      std::string runtimeString = "RUNTIMES";
+      TestDescriptorT runtimeDescriptor;
+      runtimeDescriptor.runtimeInit(runtimeString.c_str());
+      BOOST_CHECK(runtimeDescriptor == TestDescriptorT("RUNTIMES"));
+    }
+
     BOOST_AUTO_TEST_CASE(DataDescription_test)
     {
       char test[16]="ITSRAW*********";
@@ -21,6 +66,11 @@ namespace AliceO2 {
       BOOST_CHECK(strcmp(desc2.str, "ITSRAW")==0);
 
       BOOST_CHECK(desc2 == "ITSRAW");
+
+      std::string runtimeString = "DATA_DESCRIPTION";
+      DataDescription runtimeDesc;
+      runtimeDesc.runtimeInit(runtimeString.c_str());
+      BOOST_CHECK(runtimeDesc == DataDescription("DATA_DESCRIPTION"));
     }
   } 
 }


### PR DESCRIPTION
Added default initialization for the default constructor and a constructor
from the integer type. Declaring all constructors constexpr.

Adding type cast operator to simplify the usage of Descriptor struct which
returns its integer member.

Adding a runtime init function in both DataDescription and generic
Descriptor to allow for use cases where the initializer string comes only
at runtime. The naming of the functions indicates that this is not a
compile-time feature and must be used with care.

Defining a type alias DataHeader::SubSpecificationType for the type of
member subSpecification of the DataHeader to allow generic use outside
the struct.