### PR TITLE
Allow void* based API to AliceO2::Headers::get<>

### DIFF
--- a/DataFormats/Headers/include/Headers/DataHeader.h
+++ b/DataFormats/Headers/include/Headers/DataHeader.h
@@ -411,6 +411,11 @@ const HeaderType* get(const byte* buffer, size_t /*len*/=0) {
   return nullptr;
 }
 
+template<typename HeaderType>
+const HeaderType* get(const void* buffer, size_t len=0) {
+  return get<HeaderType>(reinterpret_cast<const byte *>(buffer), len);
+}
+
 //__________________________________________________________________________________________________
 /// @struct Stack
 /// @brief a move-only header stack with serialized headers


### PR DESCRIPTION
This is because `void *` is what is actually returned by ZeroMQ /
FairMQ. This way we avoid one cast in user code.