### PR TITLE
Skeleton for a TimeFrame class

### DIFF
--- a/DataFormats/CMakeLists.txt
+++ b/DataFormats/CMakeLists.txt
@@ -3,3 +3,4 @@
 add_subdirectory (Generic)
 add_subdirectory (Headers)
 add_subdirectory (simulation)
+add_subdirectory (TimeFrame)

--- a/DataFormats/Headers/include/Headers/TimeStamp.h
+++ b/DataFormats/Headers/include/Headers/TimeStamp.h
@@ -102,7 +102,7 @@ class TimeStamp
   typedef AliceO2::Header::Descriptor<2> TimeUnitID;
   // TODO: typedefs for the types of ticks and subticks
 
-  TimeStamp();
+  TimeStamp() = default;
   TimeStamp(uint64_t ts) : mTimeStamp64(ts) {}
   TimeStamp(const TimeUnitID& unit, uint32_t tick, uint16_t subtick = 0)
     : mUnit(unit), mTicks(tick), mSubTicks(subtick) {}

--- a/DataFormats/TimeFrame/CMakeLists.txt
+++ b/DataFormats/TimeFrame/CMakeLists.txt
@@ -1,0 +1,29 @@
+# @author Sandro Wenzel
+# @brief  cmake setup for module DataFormats/TimeFrame
+
+set(MODULE_NAME "TimeFrame")
+set(MODULE_BUCKET_NAME TimeFrame_bucket)
+
+O2_SETUP(NAME ${MODULE_NAME})
+
+set(SRCS
+    src/TimeFrame.cxx
+)
+
+# define headers
+set(HEADERS include/TimeFrame/TimeFrame.h)
+
+set(LINKDEF src/TimeFrameLinkDef.h)
+set(LIBRARY_NAME ${MODULE_NAME})
+set(BUCKET_NAME ${MODULE_BUCKET_NAME})
+
+O2_GENERATE_LIBRARY()
+
+set(TEST_SRCS
+  test/TimeFrameTest.cxx
+)
+
+O2_GENERATE_TESTS(
+  MODULE_LIBRARY_NAME ${LIBRARY_NAME}
+  BUCKET_NAME ${BUCKET_NAME}
+  TEST_SRCS ${TEST_SRCS})

--- a/DataFormats/TimeFrame/include/TimeFrame/TimeFrame.h
+++ b/DataFormats/TimeFrame/include/TimeFrame/TimeFrame.h
@@ -1,0 +1,76 @@
+#ifndef ALICEO2_TIMEFRAME_H
+#define ALICEO2_TIMEFRAME_H
+
+#include "FairMQParts.h"
+#include "TObject.h" // for ClassDef
+#include "Headers/TimeStamp.h"
+
+namespace AliceO2
+{
+namespace DataFormat
+{
+// helper struct so that we can
+// stream messages using ROOT
+struct MessageSizePair {
+  MessageSizePair() : size(0), buffer(nullptr) {}
+  MessageSizePair(size_t s, char* b) : size(s), buffer(b) {}
+  Int_t size;   // size of buffer in bytes (must be Int_t due to ROOT requirement)
+  char* buffer; //[size]
+};
+
+// a class encapsulating a TimeFrame as sent out by EPN
+class TimeFrame
+{
+ public:
+  TimeFrame() : mParts() {} // in principle just for ROOT IO
+  // constructor taking FairMQParts
+  // might offer another constructor not depending on FairMQ ... directly taking buffers?
+  // FIXME: take care of ownership later
+  TimeFrame(FairMQParts& parts) : mParts()
+  {
+    for (int i = 0; i < parts.Size(); ++i) {
+      mParts.push_back(MessageSizePair(parts[i].GetSize(), (char*)parts[i].GetData()));
+    }
+  }
+
+  // return TimeStamp (starttime) of this TimeFrame
+  Header::TimeStamp const& GetTimeStamp() const { return mTimeStamp; }
+
+  // return duration of this TimeFrame
+  // allow user to ask for specific unit (needs to be std::chrono unit)
+  template <typename TimeUnit>
+  std::chrono::duration<typename TimeUnit::duration> GetDuration() const
+  {
+    // FIXME: implement
+    return 0.;
+  }
+
+  // from how many flps we received data
+  int GetNumFlps() const { /* FIXME: implement */ return 0; }
+  // is this TimeFrame complete
+  bool IsComplete() const { /* FIXME: implement */ return false; }
+  // return the number of message parts in this TimeFrame
+  size_t GetNumParts() const { return mParts.size(); }
+  // access to the raw data
+  MessageSizePair& GetPart(size_t i) { return mParts[i]; }
+  // Get total payload size in bytes
+  size_t GetPayloadSize() const { /* FIXME: implement */ return 0; }
+  // Get payload size of part i
+  size_t GetPayloadSize(size_t i) const { /* FIXME: implement */ return 0; }
+
+private:
+  // FIXME: enable this when we have a dictionary for TimeStamp etc
+  Header::TimeStamp mTimeStamp; //! the TimeStamp for this TimeFrame
+
+  size_t mEpnId; // EPN origin of TimeFrame
+  std::vector<MessageSizePair> mParts; // the message parts as accumulated by the EPN
+
+  // FIXME: add Index data structure
+  // Index mIndex; // index structure into parts
+
+  ClassDefNV(TimeFrame, 1);
+};
+}
+}
+
+#endif // ALICEO2_TIMEFRAME_H

--- a/DataFormats/TimeFrame/src/TimeFrame.cxx
+++ b/DataFormats/TimeFrame/src/TimeFrame.cxx
@@ -1,0 +1,1 @@
+#include "TimeFrame/TimeFrame.h"

--- a/DataFormats/TimeFrame/src/TimeFrameLinkDef.h
+++ b/DataFormats/TimeFrame/src/TimeFrameLinkDef.h
@@ -1,0 +1,11 @@
+
+#ifdef __CLING__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class AliceO2::DataFormat::TimeFrame+;
+#pragma link C++ class AliceO2::DataFormat::MessageSizePair+;
+
+#endif

--- a/DataFormats/TimeFrame/test/TimeFrameTest.cxx
+++ b/DataFormats/TimeFrame/test/TimeFrameTest.cxx
@@ -1,0 +1,103 @@
+#define BOOST_TEST_MODULE Test TimeFrame TimeFrametest
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include "TimeFrame/TimeFrame.h"
+#include "FairMQMessage.h"
+#include "FairMQParts.h"
+#include "FairMQTransportFactoryZMQ.h"
+#include "Headers/DataHeader.h"
+#include "TFile.h"
+
+namespace AliceO2
+{
+namespace DataFormat
+{
+BOOST_AUTO_TEST_CASE(MessageSizePair_test)
+{
+  size_t S = 100;
+  char* buffer = new char[S];
+
+  // fill the buffer with something
+  buffer[0] = 'a';
+  buffer[S - 1] = 'z';
+
+  MessageSizePair mes(S, buffer);
+
+  // assert some properties on MessageSizePair
+  BOOST_CHECK(mes.size == S);
+  BOOST_CHECK(mes.buffer = buffer);
+
+  // check ROOT IO of MessageSizePair
+  TFile* file = TFile::Open("mspair.root", "RECREATE");
+  if (file) {
+    file->WriteObject(&mes, "MessageSizePair");
+    file->Close();
+  }
+
+  MessageSizePair* ptr = nullptr;
+  TFile* infile = TFile::Open("mspair.root", "READ");
+  if (infile) {
+    infile->GetObject("MessageSizePair", ptr);
+    infile->Close();
+    BOOST_CHECK(ptr != nullptr);
+  }
+  BOOST_CHECK(ptr->size == S);
+  // test first and last characters in buffer to see if correctly streamed
+  BOOST_CHECK(ptr->buffer[0] == buffer[0]);
+  BOOST_CHECK(ptr->buffer[S - 1] == buffer[S - 1]);
+}
+
+// some (modified) convenience functions to be able to create messages
+// copied from FairRoot
+template<typename T>
+inline static void SimpleMsgCleanup(void* /*data*/, void* obj)
+{
+  delete static_cast<T*>(obj);
+}
+
+template<typename Factory, typename T>
+inline static FairMQMessagePtr NewSimpleMessage(Factory const &f, const T& data)
+{
+  T* dataCopy = new T(data);
+  return f.CreateMessage(dataCopy, sizeof(T), SimpleMsgCleanup<T>, dataCopy);
+}
+
+BOOST_AUTO_TEST_CASE(TimeFrame_test)
+{
+  FairMQParts messages;
+
+  // we use the ZMQ Factory to create some messages
+  FairMQTransportFactoryZMQ zmq;
+  messages.AddPart(zmq.CreateMessage(1000));
+
+  AliceO2::Header::DataHeader dh;
+  messages.AddPart(NewSimpleMessage(zmq, dh));
+
+  TimeFrame frame(messages);
+  BOOST_CHECK(frame.GetNumParts() == 2);
+
+  // test ROOT IO
+  TFile* file = TFile::Open("timeframe.root", "RECREATE");
+  if (file) {
+    file->WriteObject(&frame, "Timeframe");
+    file->Close();
+  }
+
+  TimeFrame* ptr = nullptr;
+  TFile* infile = TFile::Open("timeframe.root", "READ");
+  if (infile) {
+    infile->GetObject("Timeframe", ptr);
+    infile->Close();
+    BOOST_CHECK(ptr != nullptr);
+  }
+
+  // test access to data
+  BOOST_CHECK(ptr->GetNumParts() == 2);
+  for (int i = 0; i < ptr->GetNumParts(); ++i) {
+    BOOST_CHECK(ptr->GetPart(i).size == messages[i].GetSize());
+  }
+}
+
+} // end namespace DataFlow
+} // end namespace AliceO2

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -22,7 +22,9 @@ find_package(IWYU)
 find_package(DDS)
 
 find_package(Boost 1.59 COMPONENTS thread system timer program_options random filesystem chrono exception regex serialization log log_setup unit_test_framework date_time REQUIRED)
+set (ZeroMQ_NO_DEPRECATED 1) # no deprecation warning since we have converted to new variables
 find_package(ZeroMQ)
+
 
 find_package(AliRoot)
 find_package(FairRoot REQUIRED)

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -151,6 +151,21 @@ o2_define_bucket(
 
 o2_define_bucket(
     NAME
+    TimeFrame_bucket
+
+    DEPENDENCIES
+    Base
+    Headers
+    fairroot_base_bucket
+
+    INCLUDE_DIRECTORIES
+    ${FAIRROOT_INCLUDE_DIR}
+    ${ZeroMQ_INCLUDE_DIR}
+    ${CMAKE_SOURCE_DIR}/DataFormats/Headers/include
+)
+
+o2_define_bucket(
+    NAME
     flp2epn_bucket
 
     DEPENDENCIES
@@ -240,7 +255,7 @@ o2_define_bucket(
     root_base_bucket
 
     DEPENDENCIES
-    Core # ROOT
+    Core RIO # ROOT
 
     INCLUDE_DIRECTORIES
     ${ROOT_INCLUDE_DIR}
@@ -265,6 +280,7 @@ o2_define_bucket(
 
     DEPENDENCIES
     root_base_bucket
+    ${ZeroMQ_LIBRARY_SHARED}
     Base FairMQ FairTools fairmq_logger Base
     common_boost_bucket
     ${Boost_THREAD_LIBRARY} pthread


### PR DESCRIPTION
This is a working piece of deployable unit that brings in a skeleton TimeFrame class (including working ROOT IO + unit test).

This can now be used by the DataFlow effort and expanded thereafter.