### PR TITLE
Fix all the modernize-deprecated-headers errors reported by clang-tidy

### DIFF
--- a/Common/Field/src/MagFieldContFact.cxx
+++ b/Common/Field/src/MagFieldContFact.cxx
@@ -2,7 +2,7 @@
 /// \brief Implementation of the MagFieldContFact: factory for ALICE mag. field
 /// \author ruben.shahoyan@cern.ch
 
-#include <string.h> // for strcmp, NULL
+#include <cstring> // for strcmp, NULL
 #include "FairLogger.h"                // for FairLogger, MESSAGE_ORIGIN
 #include "FairRuntimeDb.h"          // for FairRuntimeD
 #include "FairParSet.h"

--- a/Common/Field/src/MagneticWrapperChebyshev.cxx
+++ b/Common/Field/src/MagneticWrapperChebyshev.cxx
@@ -6,8 +6,8 @@
 #include <TArrayF.h>     // for TArrayF
 #include <TArrayI.h>     // for TArrayI
 #include <TSystem.h>     // for TSystem, gSystem
-#include <stdio.h>       // for printf, fprintf, fclose, fopen, FILE
-#include <string.h>      // for memcpy
+#include <cstdio>       // for printf, fprintf, fclose, fopen, FILE
+#include <cstring>      // for memcpy
 #include "FairLogger.h"  // for FairLogger, MESSAGE_ORIGIN
 #include "TMath.h"       // for BinarySearch, Sort
 #include "TMathBase.h"   // for Abs

--- a/Common/MathUtils/src/Chebyshev3D.cxx
+++ b/Common/MathUtils/src/Chebyshev3D.cxx
@@ -10,7 +10,7 @@
 #include <TRandom.h>          // for TRandom, gRandom
 #include <TString.h>          // for TString
 #include <TSystem.h>          // for TSystem, gSystem
-#include <stdio.h>            // for printf, fprintf, FILE, fclose, fflush, etc
+#include <cstdio>            // for printf, fprintf, FILE, fclose, fflush, etc
 #include "MathUtils/Chebyshev3DCalc.h"  // for Chebyshev3DCalc, etc
 #include "FairLogger.h"       // for FairLogger, MESSAGE_ORIGIN
 #include "TMathBase.h"        // for Max, Abs

--- a/DataFormats/simulation/src/Stack.cxx
+++ b/DataFormats/simulation/src/Stack.cxx
@@ -16,7 +16,7 @@
 #include "TParticle.h"        // for TParticle
 #include "TRefArray.h"        // for TRefArray
 
-#include <stddef.h>           // for NULL
+#include <cstddef>           // for NULL
 
 using std::cout;
 using std::endl;

--- a/Detectors/ITSMFT/ITS/base/src/GeometryManager.cxx
+++ b/Detectors/ITSMFT/ITS/base/src/GeometryManager.cxx
@@ -13,7 +13,7 @@
 #include "TObjArray.h"        // for TObjArray
 #include "TObject.h"          // for TObject
 
-#include "stddef.h" // for NULL
+#include <cstddef> // for NULL
 
 using namespace AliceO2::ITS;
 

--- a/Detectors/ITSMFT/ITS/base/src/GeometryTGeo.cxx
+++ b/Detectors/ITSMFT/ITS/base/src/GeometryTGeo.cxx
@@ -25,9 +25,9 @@
 #include "TObjArray.h"        // for TObjArray
 #include "TObject.h"          // for TObject
 
-#include <ctype.h>  // for isdigit
-#include <stdio.h>  // for snprintf, NULL, printf
-#include <string.h> // for strstr, strlen
+#include <cctype>  // for isdigit
+#include <cstdio>  // for snprintf, NULL, printf
+#include <cstring> // for strstr, strlen
 
 using AliceO2::ITSMFT::Segmentation;
 using AliceO2::ITSMFT::SegmentationPixel;

--- a/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
@@ -28,7 +28,7 @@
 #include "TVirtualMC.h"             // for gMC, TVirtualMC
 #include "TVirtualMCStack.h"        // for TVirtualMCStack
 
-#include <stdio.h>                  // for NULL, snprintf
+#include <cstdio>                  // for NULL, snprintf
 
 class FairModule;
 

--- a/Detectors/ITSMFT/ITS/simulation/src/GeometryHandler.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/GeometryHandler.cxx
@@ -12,8 +12,8 @@
 #include "TGeoVolume.h"  // for TGeoVolume
 #include "TVirtualMC.h"  // for TVirtualMC, gMC
 
-#include <stdio.h>  // for printf
-#include <string.h> // for NULL, strlen, strncpy
+#include <cstdio>  // for printf
+#include <cstring> // for NULL, strlen, strncpy
 #include <iostream> // for cout, endl
 #include <map>      // for map
 #include <utility>  // for pair

--- a/Detectors/ITSMFT/ITS/simulation/src/V11Geometry.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/V11Geometry.cxx
@@ -22,7 +22,7 @@
 #include "TMathBase.h"     // for Max, Min, Abs
 #include <TGeoTube.h>      // for TGeoTubeSeg
 
-#include <stdio.h>         // for printf, snprintf
+#include <cstdio>         // for printf, snprintf
 #include <Riostream.h>
 
 using std::endl;

--- a/Detectors/ITSMFT/ITS/simulation/src/V1Layer.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/V1Layer.cxx
@@ -21,7 +21,7 @@
 #include "TMathBase.h"            // for Abs
 #include <TMath.h>                // for Sin, RadToDeg, DegToRad, Cos, Tan, etc
 
-#include <stdio.h>                // for snprintf
+#include <cstdio>                // for snprintf
 
 class TGeoMedium;
 

--- a/Detectors/ITSMFT/common/base/src/SegmentationPixel.cxx
+++ b/Detectors/ITSMFT/common/base/src/SegmentationPixel.cxx
@@ -8,7 +8,7 @@
 #include <TObjArray.h> // for TObjArray
 #include <TString.h>   // for TString
 #include <TSystem.h>   // for TSystem, gSystem
-#include <stdio.h>     // for printf
+#include <cstdio>     // for printf
 #include "TMathBase.h" // for Abs, Max, Min
 #include "TObject.h"   // for TObject
 

--- a/Detectors/ITSMFT/common/simulation/src/Chip.cxx
+++ b/Detectors/ITSMFT/common/simulation/src/Chip.cxx
@@ -6,7 +6,7 @@
 //  Adapted from AliITSUChip by Massimo Masera
 //
 
-#include <string.h>                   // for memset
+#include <cstring>                   // for memset
 
 #include <TMath.h>                    // for Sqrt
 #include "TObjArray.h"                // for TObjArray

--- a/Detectors/Passive/src/Cave.cxx
+++ b/Detectors/Passive/src/Cave.cxx
@@ -16,7 +16,7 @@
 #include "FairGeoLoader.h"     // for FairGeoLoader
 #include "include/DetectorsPassive/GeoCave.h"
 #include "TString.h"           // for TString
-#include <stddef.h>            // for NULL
+#include <cstddef>            // for NULL
 
 using namespace AliceO2::Passive;
 

--- a/Detectors/Passive/src/GeoCave.cxx
+++ b/Detectors/Passive/src/GeoCave.cxx
@@ -26,7 +26,7 @@
 #include "FairGeoNode.h"                // for FairGeoNode, etc
 #include "FairGeoShapes.h"              // for FairGeoShapes
 #include "TList.h"                      // for TList
-#include <string.h>                     // for strcmp
+#include <cstring>                     // for strcmp
 #include <iostream>                     // for cout
 
 using namespace std;

--- a/Detectors/Passive/src/Magnet.cxx
+++ b/Detectors/Passive/src/Magnet.cxx
@@ -20,7 +20,7 @@
 #include "TGeoMedium.h"          // for TGeoMedium
 #include "TGeoTube.h"            // for TGeoTubeSeg
 #include "TGeoVolume.h"          // for TGeoVolume
-#include <stddef.h>                     // for NULL
+#include <cstddef>                     // for NULL
 #include <iostream>                     // for operator<<, basic_ostream, etc
 
 using namespace AliceO2::Passive;

--- a/Detectors/Passive/src/PassiveContFact.cxx
+++ b/Detectors/Passive/src/PassiveContFact.cxx
@@ -26,7 +26,7 @@
 #include "FairRuntimeDb.h"              // for FairRuntimeDb
 #include "TList.h"                      // for TList
 #include "TString.h"                    // for TString
-#include <string.h>                     // for strcmp, NULL
+#include <cstring>                     // for strcmp, NULL
 
 
 using namespace std;

--- a/Detectors/TPC/simulation/src/Detector.cxx
+++ b/Detectors/TPC/simulation/src/Detector.cxx
@@ -9,7 +9,7 @@
 #include "TClonesArray.h"       // for TClonesArray
 #include "TVirtualMC.h"         // for TVirtualMC, gMC
 
-#include <stddef.h>             // for NULL
+#include <cstddef>             // for NULL
 
 #include "FairGeoVolume.h"
 #include "FairGeoNode.h"

--- a/Examples/ExampleModule1/test/testExampleModule1.cxx
+++ b/Examples/ExampleModule1/test/testExampleModule1.cxx
@@ -8,7 +8,7 @@
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
-#include <assert.h>
+#include <cassert>
 #include "ExampleModule1/Foo.h"
 
 

--- a/Examples/flp2epn/src/O2FLPex.cxx
+++ b/Examples/flp2epn/src/O2FLPex.cxx
@@ -6,8 +6,8 @@
  */
 
 #include <vector>
-#include <stdlib.h>     /* srand, rand */
-#include <time.h>       /* time */
+#include <cstdlib>     /* srand, rand */
+#include <ctime>       /* time */
 
 #include "FairMQLogger.h"
 #include "FairMQProgOptions.h"


### PR DESCRIPTION
Description of the check can be found at:

https://clang.llvm.org/extra/clang-tidy/checks/modernize-deprecated-headers.html