### PR TITLE
Redeclaration of private constexpr class member to avoid linker error

### DIFF
--- a/Utilities/DataFlow/src/SubframeBuilderDevice.cxx
+++ b/Utilities/DataFlow/src/SubframeBuilderDevice.cxx
@@ -13,8 +13,12 @@
 #include "Headers/DataHeader.h"
 #include "FairMQProgOptions.h"
 
-// temporary hack to solve issue 279; linking problem for this constexpr
-// variable
+// From C++11 on, constexpr static data members are implicitly inlined. Redeclaration
+// is still permitted, but deprecated. Some compilers do not implement this standard
+// correctly. It also has to be noticed that this error does not occur for all the
+// other public constexpr members
+constexpr uint32_t AliceO2::DataFlow::SubframeBuilderDevice::mOrbitsPerTimeframe;
+constexpr uint32_t AliceO2::DataFlow::SubframeBuilderDevice::mOrbitDuration;
 constexpr uint32_t AliceO2::DataFlow::SubframeBuilderDevice::mDuration;
 
 using HeartbeatHeader = AliceO2::Header::HeartbeatHeader;


### PR DESCRIPTION
This is a follow up for the previously committed fix for issue #279,
linker problem with private constexpr class member.

Added redeclaration of all private constexpr data members and enhancing
the comment in the code.

From C++11 on, constexpr static data members are implicitly inlined.
Redeclaration is still permitted, but deprecated. Some compilers do
not implement this standard correctly. It also has to be noticed that
this error does not occur for all the other public constexpr members.

Closing #282. Whether the variables have to be constexpr (and fixed) or
configurable will be handled when the work on the devices is resumed.