### PR TITLE
Fix #268 DataDescription c'tor: String2<uint64_t> offset adjusted

### DIFF
--- a/DataFormats/Headers/include/Headers/DataHeader.h
+++ b/DataFormats/Headers/include/Headers/DataHeader.h
@@ -573,7 +573,7 @@ struct DataDescription {
   // note: no operator=(const char*) as this potentially runs into trouble with this
   // general pointer type, use: somedesc = DataDescription("SOMEDESCRIPTION")
   template<std::size_t NN>
-  constexpr DataDescription(const char (&desc)[NN]) : itg{String2<uint64_t, NN, 0, true>(desc), (Internal::strLength(desc) > 8 ? String2<uint64_t, NN, std::conditional< (NN > 8), Internal::intWrapper<8>, Internal::intWrapper<NN-1>>::type::value >(desc) : 0)} {
+  constexpr DataDescription(const char (&desc)[NN]) : itg{String2<uint64_t, NN, 0, true>(desc), (Internal::strLength(desc) > 8 ? String2<uint64_t, NN, std::conditional< (NN > 8), Internal::intWrapper<8>, Internal::intWrapper<0>>::type::value >(desc) : 0)} {
     // the initializer implements a number of compile time checks
     // - for the conversion of the first part of the string to the first 64bit field
     //   the check for the string length needs to be disabled as it is naturally longer

--- a/DataFormats/Headers/test/dataHeaderTest.cxx
+++ b/DataFormats/Headers/test/dataHeaderTest.cxx
@@ -60,10 +60,20 @@ namespace AliceO2 {
       DataDescription desc("ITSRAW");
       BOOST_CHECK(strcmp(desc.str, "ITSRAW")==0);
 
+      // checking the corresponding integer value
+      // the upper part must be 0 since the string has only up tp 8 chars
+      // lower part corresponds to reverse ITSRAW
+      //                       W A R S T I
+      uint64_t itgDesc = 0x0000574152535449;
+      BOOST_CHECK(desc.itg[0] == itgDesc);
+      BOOST_CHECK(desc.itg[1] == 0);
+
       BOOST_CHECK(desc == "ITSRAW");
 
       DataDescription desc2(test);
       BOOST_CHECK(strcmp(desc2.str, "ITSRAW")==0);
+      // the upper part must be 0 since the string has only up tp 8 chars
+      BOOST_CHECK(desc2.itg[1] == 0);
 
       BOOST_CHECK(desc2 == "ITSRAW");
 


### PR DESCRIPTION
The DataDescription structure has a 16 Byte field, which is
initialized by two calls to String2<uint64_t>.

This warning occurs if the actual string is shorter than 9 characters,
when only the first integer field can be filled. The condition is
correctly handled, but in clang the code branch is still compiled,
though not called. It turns out that the previously chosen offset
parameter was not a good choice. Using 0 as offset masks the warning.

Also extending the unit test in order to check the underlying
integer member.