### PR TITLE
Fix remaining ROOT IO problem for basic hit classes

### DIFF
--- a/Detectors/Base/src/BaseLinkDef.h
+++ b/Detectors/Base/src/BaseLinkDef.h
@@ -10,7 +10,9 @@
 #pragma link C++ class AliceO2::Base::Track::TrackPar+;
 #pragma link C++ class AliceO2::Base::Track::TrackParCov+;
 #pragma link C++ class AliceO2::Base::TrackReference+;
+#pragma link C++ class ROOT::Math::Cartesian3D<float>+;
 #pragma link C++ class ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<float>,ROOT::Math::DefaultCoordinateSystemTag>+;
 #pragma link C++ class AliceO2::Base::BasicXYZEHit<float,float>+;
+#pragma link C++ class AliceO2::Base::BasicXYZEHit<double,double>+;
 
 #endif

--- a/Detectors/Base/test/testBasicHits.cxx
+++ b/Detectors/Base/test/testBasicHits.cxx
@@ -53,6 +53,25 @@ BOOST_AUTO_TEST_CASE(BasicXYZHit_ROOTIO)
     BOOST_CHECK(obj != nullptr);
     fin.Close();
   }
+
+  // same for double valued hits
+  using HitTypeD = BasicXYZEHit<double, double>;
+  HitTypeD hitD(1., 2., 3., 0.01, -1.1, -1, 1);
+
+  // try writing hit to a TBuffer
+  {
+    TFile fout("HitsIO.root", "RECREATE");
+    fout.WriteTObject(&hitD, "TestObject");
+    fout.Close();
+  }
+
+  {
+    TFile fin("HitsIO.root");
+    TObject* obj = (TObject*)fin.Get("TestObject");
+
+    BOOST_CHECK(obj != nullptr);
+    fin.Close();
+  }
 }
 
 } // end namespace Base


### PR DESCRIPTION
 * ROOT only provides dictionaries for <double> specializations
   of their Point3D, etc. classes
 * we need to create a dictionary for the <float> case
 * extend unit test to check correct working for <double> case, too