### PR TITLE
Adding hit mother class; move to DataFormats/simulation

### DIFF
--- a/DataFormats/simulation/CMakeLists.txt
+++ b/DataFormats/simulation/CMakeLists.txt
@@ -10,9 +10,21 @@ set(SRCS
 Set(HEADERS
     include/${MODULE_NAME}/Stack.h
     include/${MODULE_NAME}/MCTrack.h
+    include/${MODULE_NAME}/BaseHits.h
 )
+
 Set(LINKDEF src/SimulationDataLinkDef.h)
 Set(LIBRARY_NAME ${MODULE_NAME})
 set(BUCKET_NAME data_format_simulation_bucket)
 
 O2_GENERATE_LIBRARY()
+
+set(TEST_SRCS
+  test/testBasicHits.cxx
+)
+
+O2_GENERATE_TESTS(
+  MODULE_LIBRARY_NAME ${LIBRARY_NAME}
+  BUCKET_NAME ${BUCKET_NAME}
+  TEST_SRCS ${TEST_SRCS}
+)

--- a/DataFormats/simulation/include/SimulationDataFormat/BaseHits.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/BaseHits.h
@@ -3,7 +3,6 @@
 #include "FairMultiLinkedData_Interface.h"
 #include "Math/GenVector/DisplacementVector3D.h"
 #include "Math/GenVector/PositionVector3D.h"
-#include "Math/SVector.h"
 
 template <typename T>
 using Point3D = ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<T>, ROOT::Math::DefaultCoordinateSystemTag>;
@@ -12,37 +11,47 @@ using Vector3D = ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<T>, RO
 
 namespace AliceO2
 {
-namespace Base
+
+// Mother class of all hit classes for AliceO2
+// just defines what is absolutely necessary to have
+// as common interface
+// at the moment ony GetTrackID() used by Stack.h
+// eventually we could add some interfaces to retrieve
+// the coordinates as floats or something
+class BaseHit : public FairMultiLinkedData_Interface
 {
+ public:
+  BaseHit() = default;
+  BaseHit(int id) : mTrackID{id} {}
+  int GetTrackID() const { return mTrackID; }
+  void SetTrackID(int id) { mTrackID = id; }
+
+ private:
+  int mTrackID; // track_id
+  ClassDefOverride(BaseHit, 1);
+};
+
 // a set of configurable classes to define basic hit types
 // these are meant to be an alternative to FairMCPoint
 // which always includes the momentum and is purely based on double values
 
-// A basic hit class template, encoding cartesian coordinates, energy loss
-// time_of_flight, detectorID and trackID
-
-// we need to derive from FairMultiLinkedData_Interface for the
-// MC truth handling
-
 // T is basic type for position, E is basic type for time and energy loss
 template <typename T, typename E=float>
-class BasicXYZEHit : public FairMultiLinkedData_Interface
+class BasicXYZEHit : public BaseHit
 {
   Point3D<T> mPos; // cartesian position of Hit
   E mTime;         // time of flight
   E mELoss;        // energy loss
-  int mTrackID;    // track_id; this might be part of link?
   short mDetectorID; // the detector/sensor id
 
  public:
   BasicXYZEHit() = default; // for ROOT IO
 
   // constructor
- BasicXYZEHit(T x, T y, T z, E time, E e, int trackid, short did)
-    :  mPos(x, y, z), mTime(time), mELoss(e), mTrackID(trackid), mDetectorID(did)
+  BasicXYZEHit(T x, T y, T z, E time, E e, int trackid, short did)
+    :  mPos(x, y, z), mTime(time), mELoss(e), BaseHit(trackid), mDetectorID(did)
   {
   }
-
 
   // getting the cartesian coordinates
   T GetX() const { return mPos.X(); }
@@ -55,10 +64,8 @@ class BasicXYZEHit : public FairMultiLinkedData_Interface
   E GetTime() const { return mTime; }
   // get detector + track information
   short GetDetectorID() const { return mDetectorID; }
-  int GetTrackID() const { return mTrackID; }
 
   // modifiers
-  void SetTrackID(int id) { mTrackID = id; }
   void SetTime(E time) { mTime = time; }
   void SetEnergyLoss(E eLoss) { mELoss = eLoss; }
   void SetDetectorID(short detID) { mDetectorID = detID; }
@@ -73,10 +80,8 @@ class BasicXYZEHit : public FairMultiLinkedData_Interface
   }
   void SetPos(Point3D<T> const &p) { mPos = p; }
 
-
-  ClassDef(BasicXYZEHit, 1);
+  ClassDefOverride(BasicXYZEHit, 1);
 };
 
-} // end namespace Base
 } // end namespace AliceO2
 #endif

--- a/DataFormats/simulation/src/SimulationDataLinkDef.h
+++ b/DataFormats/simulation/src/SimulationDataLinkDef.h
@@ -15,4 +15,10 @@
 #pragma link C++ class AliceO2::Data::Stack+;
 #pragma link C++ class MCTrack+;
 
+#pragma link C++ class ROOT::Math::Cartesian3D<float>+;
+#pragma link C++ class ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<float>,ROOT::Math::DefaultCoordinateSystemTag>+;
+#pragma link C++ class AliceO2::BaseHit+;
+#pragma link C++ class AliceO2::BasicXYZEHit<float,float>+;
+#pragma link C++ class AliceO2::BasicXYZEHit<double,double>+;
+
 #endif

--- a/DataFormats/simulation/src/Stack.cxx
+++ b/DataFormats/simulation/src/Stack.cxx
@@ -2,12 +2,12 @@
 /// \brief Implementation of the Stack class
 /// \author M. Al-Turany - June 2014
 
-#include "include/SimulationDataFormat/Stack.h"
-#include "include/SimulationDataFormat/MCTrack.h"
+#include "SimulationDataFormat/Stack.h"
+#include "SimulationDataFormat/MCTrack.h"
 
 #include "FairDetector.h"     // for FairDetector
 #include "FairLogger.h"       // for MESSAGE_ORIGIN, FairLogger
-#include "FairMCPoint.h"      // for FairMCPoint
+#include "SimulationDataFormat/BaseHits.h"
 #include "FairGenericRootManager.h"  // for FairGenericRootManager
 
 #include "TClonesArray.h"     // for TClonesArray
@@ -315,7 +315,7 @@ void Stack::UpdateTrackIndex(TRefArray *detList)
 
       // Update track index for all MCPoints in the collection
       for (Int_t iPoint = 0; iPoint < nPoints; iPoint++) {
-        FairMCPoint *point = (FairMCPoint *) hitArray->At(iPoint);
+        auto *point = (AliceO2::BaseHit *) hitArray->UncheckedAt(iPoint);
         Int_t iTrack = point->GetTrackID();
 
         mIndexIterator = mIndexMap.find(iTrack);

--- a/DataFormats/simulation/test/testBasicHits.cxx
+++ b/DataFormats/simulation/test/testBasicHits.cxx
@@ -2,14 +2,13 @@
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
-#include "DetectorsBase/BaseHits.h"
+#include "SimulationDataFormat/BaseHits.h"
 #include "Math/GenVector/Transform3D.h"
 #include "TFile.h"
 
 namespace AliceO2
 {
-namespace Base
-{
+
 BOOST_AUTO_TEST_CASE(BasicXYZHit)
 {
   using HitType = BasicXYZEHit<float>;
@@ -74,5 +73,4 @@ BOOST_AUTO_TEST_CASE(BasicXYZHit_ROOTIO)
   }
 }
 
-} // end namespace Base
 } // end namespace AliceO2

--- a/Detectors/Base/CMakeLists.txt
+++ b/Detectors/Base/CMakeLists.txt
@@ -14,7 +14,6 @@ Set(HEADERS
   include/${MODULE_NAME}/Track.h
   include/${MODULE_NAME}/TrackReference.h
   include/${MODULE_NAME}/Utils.h
-  include/${MODULE_NAME}/BaseHits.h
 )
 
 Set(LINKDEF src/BaseLinkDef.h)
@@ -23,12 +22,3 @@ set(BUCKET_NAME detectors_base)
 
 O2_GENERATE_LIBRARY()
 
-set(TEST_SRCS
-  test/testBasicHits.cxx
-)
-
-O2_GENERATE_TESTS(
-  MODULE_LIBRARY_NAME ${LIBRARY_NAME}
-  BUCKET_NAME ${BUCKET_NAME}
-  TEST_SRCS ${TEST_SRCS}
-)

--- a/Detectors/Base/src/BaseLinkDef.h
+++ b/Detectors/Base/src/BaseLinkDef.h
@@ -10,9 +10,5 @@
 #pragma link C++ class AliceO2::Base::Track::TrackPar+;
 #pragma link C++ class AliceO2::Base::Track::TrackParCov+;
 #pragma link C++ class AliceO2::Base::TrackReference+;
-#pragma link C++ class ROOT::Math::Cartesian3D<float>+;
-#pragma link C++ class ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<float>,ROOT::Math::DefaultCoordinateSystemTag>+;
-#pragma link C++ class AliceO2::Base::BasicXYZEHit<float,float>+;
-#pragma link C++ class AliceO2::Base::BasicXYZEHit<double,double>+;
 
 #endif


### PR DESCRIPTION
 * restructuring O2 hit class; we need to have
   a common base class with an interface as needed by the particle stack
 * move class to DataFormats/simulation to avoid cyclic dependency
 * commit achieves a complete decoupling from FairMC point; now
   all of our detectors have to use the AliceO2::BaseHit and derived classes