### PR TITLE
Fix of ITS hit generation (instead of #312)

### DIFF
--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
@@ -142,8 +142,9 @@ class Detector : public AliceO2::Base::Detector
                                     UInt_t &dettype) const;
 
     /// This method is an example of how to add your own point of type Point to the clones array
-    AliceO2::ITSMFT::Point *addHit(Int_t trackID, Int_t detID, TVector3 startPos, TVector3 pos, TVector3 mom, Double_t startTime,
-                  Double_t time, Double_t length, Double_t eLoss, Int_t shunt, Int_t status, Int_t statusStart);
+    AliceO2::ITSMFT::Point *addHit(int trackID, int detID, TVector3 startPos, TVector3 endPos, TVector3 startMom,
+				   double startE, double endTime, double eLoss,
+				   unsigned char startStatus, unsigned char endStatus);
 
     /// Book arrays for wrapper volumes
     virtual void setNumberOfWrapperVolumes(Int_t n);
@@ -201,18 +202,6 @@ class Detector : public AliceO2::Base::Detector
     /// particle can be found. See the TParticle class.
     virtual TParticle *GetParticle() const;
 
-    // SetTrack and GetTrack methods from AliHit.h
-
-    virtual void SetTrack(Int_t track)
-    {
-      mTrackNumber = track;
-    }
-
-    virtual Int_t GetTrack() const
-    {
-      return mTrackNumber;
-    }
-
     /// Prints out the content of this class in ASCII format
     /// \param ostream *os The output stream
     void Print(std::ostream *os) const;
@@ -255,39 +244,18 @@ class Detector : public AliceO2::Base::Detector
   protected:
     Int_t *mLayerID;               //! [mNumberLayers] layer identifier
     Int_t mNumberLayers;           //! Number of layers
-    Int_t mStatus;                 //! Track Status
-    Int_t mModule;                 //! Module number
-    Float_t mParticlePx;           //! PX of particle at the point of the hit
-    Float_t mParticlePy;           //! PY of particle at the point of the hit
-    Float_t mParticlePz;           //! PZ of particle at the point of the hit
-    Float_t mEnergyDepositionStep; //! Energy deposited in the current step
-    Float_t mTof;                  //! Time of flight at the point of the hit
-    Int_t mStatus0;                //! Track Status of Starting point
-    Float_t mStartingStepX;        //! Starting point of this step
-    Float_t mStartingStepY;        //! Starting point of this step
-    Float_t mStartingStepZ;        //! Starting point of this step
-    Float_t mStartingStepT;        //! Starting point of this step
-    Int_t mTrackNumber;            //! Track number
-    Float_t mPositionX;            //! X position of the hit
-    Float_t mPositionY;            //! Y position of the hit
-    Float_t mPositionZ;            //! Z position of the hit
-    TString *mLayerName;           //![mNumberLayers] layer identifier
+    TString *mLayerName;           //! [mNumberLayers] layer identifier
 
   private:
-    /// Track information to be stored until the track leaves the
-    /// active volume.
-    Int_t mTrackNumberID;             //! track index
-    Int_t mVolumeID;                  //! volume id
-    Int_t mShunt;                     //! shunt
-    Int_t mTrkStatusFlag;             //! track status flag
-    TLorentzVector mPosition;         //! position
-    TLorentzVector mEntrancePosition; //! position at entrance
-    TLorentzVector mMomentum;         //! momentum
-    Double32_t mEntranceTime;         //! time at entrance
-    Double32_t mTime;                 //! time
-    Double32_t mLength;               //! length
-    Double32_t mEnergyLoss;           //! energy loss
-
+    /// this is transient data about track passing the sensor
+    struct TrackData {                  // this is transient 
+      bool  mHitStarted;                //! hit creation started
+      unsigned char mTrkStatusStart;    //! track status flag
+      TLorentzVector mPositionStart;    //! position at entrance
+      TLorentzVector mMomentumStart;    //! momentum
+      double mEnergyLoss;               //! energy loss
+    } mTrackData; //! 
+    
     Int_t mNumberOfDetectors;
     TArrayD mShiftX;
     TArrayD mShiftY;

--- a/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
@@ -45,19 +45,15 @@ using namespace AliceO2::ITS;
 Detector::Detector()
   : AliceO2::Base::Detector("ITS", kTRUE, kAliIts),
     mLayerID(nullptr),
-    mTrackNumberID(-1),
-    mVolumeID(-1),
-    mEntrancePosition(),
-    mPosition(),
-    mMomentum(),
-    mEntranceTime(-1.),
-    mTime(-1.),
-    mLength(-1.),
-    mEnergyLoss(-1),
-    mShunt(),
-    mPointCollection(new TClonesArray("AliceO2::ITSMFT::Point")),
-    mGeometryHandler(new GeometryHandler()),
-    mMisalignmentParameter(nullptr),
+    mNumberLayers(),
+    mTrackData(),
+    /*
+    mHitStarted(false),
+    mTrkStatusStart(),
+    mPositionStart(),
+    mMomentumStart(),
+    mEnergyLoss(),
+    */
     mNumberOfDetectors(-1),
     mShiftX(),
     mShiftY(),
@@ -83,6 +79,10 @@ Detector::Detector()
     mDetectorThickness(nullptr),
     mChipTypeID(nullptr),
     mBuildLevel(nullptr),
+    mPointCollection(new TClonesArray("AliceO2::ITSMFT::Point")),
+    
+    mGeometryHandler(new GeometryHandler()),
+    mMisalignmentParameter(nullptr),
     mGeometry(nullptr),
     mStaveModelInnerBarrel(kIBModel0),
     mStaveModelOuterBarrel(kOBModel0)
@@ -92,19 +92,16 @@ Detector::Detector()
 Detector::Detector(const char *name, Bool_t active, const Int_t nlay)
   : AliceO2::Base::Detector(name, active, kAliIts),
     mLayerID(nullptr),
-    mTrackNumberID(-1),
-    mVolumeID(-1),
-    mEntrancePosition(),
-    mPosition(),
-    mMomentum(),
-    mEntranceTime(-1.),
-    mTime(-1.),
-    mLength(-1.),
-    mEnergyLoss(-1),
-    mShunt(),
-    mPointCollection(new TClonesArray("AliceO2::ITSMFT::Point")),
-    mGeometryHandler(new GeometryHandler()),
-    mMisalignmentParameter(nullptr),
+    mNumberLayers(nlay),
+    mLayerName(new TString[nlay]),
+    mTrackData(),
+    /*
+    mHitStarted(false),
+    mTrkStatusStart(),
+    mPositionStart(),
+    mMomentumStart(),
+    mEnergyLoss(),
+    */
     mNumberOfDetectors(-1),
     mShiftX(),
     mShiftY(),
@@ -130,12 +127,15 @@ Detector::Detector(const char *name, Bool_t active, const Int_t nlay)
     mDetectorThickness(nullptr),
     mChipTypeID(nullptr),
     mBuildLevel(nullptr),
+
+    mPointCollection(new TClonesArray("AliceO2::ITSMFT::Point")),
+    mGeometryHandler(new GeometryHandler()),
+    mMisalignmentParameter(nullptr),
+    
     mGeometry(nullptr),
-    mNumberLayers(nlay),
     mStaveModelInnerBarrel(kIBModel0),
     mStaveModelOuterBarrel(kOBModel0)
 {
-  mLayerName = new TString[mNumberLayers];
 
   for (Int_t j = 0; j < mNumberLayers; j++) {
     mLayerName[j].Form("%s%d", GeometryTGeo::getITSSensorPattern(), j); // See V1Layer
@@ -176,34 +176,15 @@ Detector::Detector(const Detector &rhs)
   : AliceO2::Base::Detector(rhs),
     mLayerID(nullptr),
     mNumberLayers(rhs.mNumberLayers),
-    mStatus(rhs.mStatus),
-    mModule(rhs.mModule),
-    mParticlePx(rhs.mParticlePx),
-    mParticlePy(rhs.mParticlePy),
-    mParticlePz(rhs.mParticlePz),
-    mEnergyDepositionStep(rhs.mEnergyDepositionStep),
-    mTof(rhs.mTof),
-    mStatus0(rhs.mStatus0),
-    mStartingStepX(rhs.mStartingStepX),
-    mStartingStepY(rhs.mStartingStepY),
-    mStartingStepZ(rhs.mStartingStepZ),
-    mStartingStepT(rhs.mStartingStepT),
-    mTrackNumber(rhs.mTrackNumber),
-    mPositionX(rhs.mPositionX),
-    mPositionY(rhs.mPositionY),
-    mPositionZ(rhs.mPositionZ),
     mLayerName(nullptr),
-    mTrackNumberID(rhs.mTrackNumberID),
-    mVolumeID(rhs.mVolumeID),
-    mShunt(rhs.mShunt),
-    mPosition(rhs.mPosition),
-    mEntrancePosition(rhs.mEntrancePosition),
-    mMomentum(rhs.mMomentum),
-    mEntranceTime(rhs.mEntranceTime),
-    mTime(rhs.mTime),
-    mLength(rhs.mLength),
-    mEnergyLoss(rhs.mEnergyLoss),
-
+    mTrackData(),
+    /*    
+    mHitStarted(false),
+    mTrkStatusStart(),
+    mPositionStart(),
+    mMomentumStart(),
+    mEnergyLoss(),
+    */
     mNumberOfDetectors(rhs.mNumberOfDetectors),
     mShiftX(),
     mShiftY(),
@@ -297,33 +278,7 @@ Detector &Detector::operator=(const Detector &rhs)
 
   mLayerID = nullptr;
   mNumberLayers = rhs.mNumberLayers;
-  mStatus = rhs.mStatus;
-  mModule = rhs.mModule;
-  mParticlePx = rhs.mParticlePx;
-  mParticlePy = rhs.mParticlePy;
-  mParticlePz = rhs.mParticlePz;
-  mEnergyDepositionStep = rhs.mEnergyDepositionStep;
-  mTof = rhs.mTof;
-  mStatus0 = rhs.mStatus0;
-  mStartingStepX = rhs.mStartingStepX;
-  mStartingStepY = rhs.mStartingStepY;
-  mStartingStepZ = rhs.mStartingStepZ;
-  mStartingStepT = rhs.mStartingStepT;
-  mTrackNumber = rhs.mTrackNumber;
-  mPositionX = rhs.mPositionX;
-  mPositionY = rhs.mPositionY;
-  mPositionZ = rhs.mPositionZ;
   mLayerName = nullptr;
-  mTrackNumberID = rhs.mTrackNumberID;
-  mVolumeID = rhs.mVolumeID;
-  mShunt = rhs.mShunt;
-  mPosition = rhs.mPosition;
-  mEntrancePosition = rhs.mEntrancePosition;
-  mMomentum = rhs.mMomentum;
-  mEntranceTime = rhs.mEntranceTime;
-  mTime = rhs.mTime;
-  mLength = rhs.mLength;
-  mEnergyLoss = rhs.mEnergyLoss;
 
   mNumberOfDetectors = rhs.mNumberOfDetectors;
 
@@ -416,74 +371,70 @@ Bool_t Detector::ProcessHits(FairVolume *vol)
     return kFALSE;
   }
 
-  // FIXME: Is copy actually needed?
-  Int_t copy = vol->getCopyNo();
-  Int_t id = vol->getMCid();
-  Int_t lay = 0;
+  Int_t lay=0, volID = vol->getMCid();
 
   // FIXME: Determine the layer number. Is this information available directly from the FairVolume?
-  while ((lay < mNumberLayers) && id != mLayerID[lay]) {
+  bool notSens = false;
+  while ((lay < mNumberLayers) && (notSens=(volID != mLayerID[lay]))) {
     ++lay;
   }
-
+  if (notSens) return kFALSE; //RS: can this happen? This method must be called for sensors only?
+  
   // FIXME: Is it needed to keep a track reference when the outer ITS volume is encountered?
   // if(TVirtualMC::GetMC()->IsTrackExiting()) {
   //  AddTrackReference(gAlice->GetMCApp()->GetCurrentTrackNumber(), AliTrackReference::kITS);
   // } // if Outer ITS mother Volume
+  bool startHit=false, stopHit=false;
+  unsigned char status = 0;
+  if (TVirtualMC::GetMC()->IsTrackEntering()) { status |= Point::kTrackEntering; }
+  if (TVirtualMC::GetMC()->IsTrackInside())   { status |= Point::kTrackInside; }
+  if (TVirtualMC::GetMC()->IsTrackExiting())  { status |= Point::kTrackExiting; }
+  if (TVirtualMC::GetMC()->IsTrackOut())      { status |= Point::kTrackOut; }
+  if (TVirtualMC::GetMC()->IsTrackStop())     { status |= Point::kTrackStopped; }
+  if (TVirtualMC::GetMC()->IsTrackAlive())    { status |= Point::kTrackAlive; }
 
-  // Retrieve the indices with the volume path
-  int stave(0), halfstave(0), chipinmodule(0), module;
-  TVirtualMC::GetMC()->CurrentVolOffID(1, chipinmodule);
-  TVirtualMC::GetMC()->CurrentVolOffID(2, module);
-  TVirtualMC::GetMC()->CurrentVolOffID(3, halfstave);
-  TVirtualMC::GetMC()->CurrentVolOffID(4, stave);
-  int chipindex = mGeometryTGeo->getChipIndex(lay, stave, halfstave, module, chipinmodule);
-
-  // Record information on the points
-  mEnergyLoss = TVirtualMC::GetMC()->Edep();
-  mTime = TVirtualMC::GetMC()->TrackTime();
-  mTrackNumberID = TVirtualMC::GetMC()->GetStack()->GetCurrentTrackNumber();
-  mVolumeID = vol->getMCid();
-
-  // FIXME: Set a temporary value to mShunt for now, determine its use at a later stage
-  Int_t trackStatus = 0;
-  if (TVirtualMC::GetMC()->IsTrackEntering()) { trackStatus |= 1 << Point::kTrackEntering; }
-  if (TVirtualMC::GetMC()->IsTrackInside()) { trackStatus |= 1 << Point::kTrackInside; }
-  if (TVirtualMC::GetMC()->IsTrackExiting()) { trackStatus |= 1 << Point::kTrackExiting; }
-  if (TVirtualMC::GetMC()->IsTrackOut()) { trackStatus |= 1 << Point::kTrackOut; }
-  if (TVirtualMC::GetMC()->IsTrackStop()) { trackStatus |= 1 << Point::kTrackStopped; }
-  if (TVirtualMC::GetMC()->IsTrackAlive()) { trackStatus |= 1 << Point::kTrackAlive; }
-  mStatus = trackStatus;
-
-  TVirtualMC::GetMC()->TrackPosition(mPosition);
-  TVirtualMC::GetMC()->TrackMomentum(mMomentum);
-
-  // mLength = TVirtualMC::GetMC()->TrackLength();
-
-  if (TVirtualMC::GetMC()->IsTrackEntering()) {
-    mEntrancePosition = mPosition;
-    mEntranceTime = mTime;
-    mStatus0 = mStatus;
-    return kFALSE; // don't save entering hit.
+  // track is entering or created in the volume
+  if ( (status & Point::kTrackEntering) || (status & Point::kTrackInside && !mTrackData.mHitStarted) ) {
+    startHit = true;
+  }
+  else if ( (status & (Point::kTrackExiting|Point::kTrackOut|Point::kTrackStopped)) ) {
+    stopHit = true;
   }
 
-  // Create Point on every step of the active volume
-  Point *p=addHit(mTrackNumberID, chipindex, //mVolumeID,
-         TVector3(mEntrancePosition.X(), mEntrancePosition.Y(), mEntrancePosition.Z()),
-         TVector3(mPosition.X(), mPosition.Y(), mPosition.Z()),
-         TVector3(mMomentum.Px(), mMomentum.Py(), mMomentum.Pz()), mEntranceTime, mTime, mLength,
-         mEnergyLoss, mShunt, mStatus, mStatus0);
-  p->SetTotalEnergy(TVirtualMC::GetMC()->Etot());
+  // increment energy loss at all steps except entrance
+  if (!startHit) mTrackData.mEnergyLoss += TVirtualMC::GetMC()->Edep();
+  if (!(startHit|stopHit)) return kFALSE; // do noting
+
+  if (startHit) {
+    mTrackData.mEnergyLoss = 0.;
+    TVirtualMC::GetMC()->TrackMomentum(mTrackData.mMomentumStart);
+    TVirtualMC::GetMC()->TrackPosition(mTrackData.mPositionStart);
+    mTrackData.mTrkStatusStart = status;
+    mTrackData.mHitStarted = true;
+  }
+  if (stopHit) {
+    TLorentzVector positionStop;
+    TVirtualMC::GetMC()->TrackPosition(positionStop);
+    // Retrieve the indices with the volume path
+    int stave(0), halfstave(0), chipinmodule(0), module;
+    TVirtualMC::GetMC()->CurrentVolOffID(1, chipinmodule);
+    TVirtualMC::GetMC()->CurrentVolOffID(2, module);
+    TVirtualMC::GetMC()->CurrentVolOffID(3, halfstave);
+    TVirtualMC::GetMC()->CurrentVolOffID(4, stave);
+    int chipindex = mGeometryTGeo->getChipIndex(lay, stave, halfstave, module, chipinmodule);
+    
+    Point *p = addHit(TVirtualMC::GetMC()->GetStack()->GetCurrentTrackNumber(), chipindex,
+		      mTrackData.mPositionStart.Vect(),positionStop.Vect(),mTrackData.mMomentumStart.Vect(),
+		      mTrackData.mMomentumStart.E(),positionStop.T(),mTrackData.mEnergyLoss,
+		      mTrackData.mTrkStatusStart,status);
+    //p->SetTotalEnergy(TVirtualMC::GetMC()->Etot());
+
+    // RS: not sure this is needed
+    // Increment number of Detector det points in TParticle
+    AliceO2::Data::Stack *stack = (AliceO2::Data::Stack *) TVirtualMC::GetMC()->GetStack();
+    stack->AddPoint(kAliIts);
+  }
   
-  // Increment number of Detector det points in TParticle
-  AliceO2::Data::Stack *stack = (AliceO2::Data::Stack *) TVirtualMC::GetMC()->GetStack();
-  stack->AddPoint(kAliIts);
-
-  // Save old position for the next hit.
-  mEntrancePosition = mPosition;
-  mEntranceTime = mTime;
-  mStatus0 = mStatus;
-
   return kTRUE;
 }
 
@@ -1048,15 +999,12 @@ void Detector::defineSensitiveVolumes()
   }
 }
 
-Point *Detector::addHit(Int_t trackID, Int_t detID, TVector3 startPos, TVector3 pos,
-                        TVector3 mom, Double_t startTime, Double_t time,
-                        Double_t length, Double_t eLoss, Int_t shunt,
-                        Int_t status, Int_t statusStart)
+Point *Detector::addHit(int trackID, int detID, TVector3 startPos, TVector3 endPos, TVector3 startMom, double startE,
+			double endTime, double eLoss, unsigned char startStatus, unsigned char endStatus)
 {
   TClonesArray &clref = *mPointCollection;
   Int_t size = clref.GetEntriesFast();
-  return new(clref[size])
-    Point(trackID, detID, startPos, pos, mom, startTime, time, length, eLoss, shunt, status, statusStart);
+  return new(clref[size]) Point(trackID, detID, startPos, endPos, startMom, startE, endTime, eLoss, startStatus, endStatus);
 }
 
 TParticle *Detector::GetParticle() const
@@ -1070,8 +1018,8 @@ TParticle *Detector::GetParticle() const
   //   none.
   // Return:
   //   The TParticle of the track that created this hit.
-
-  return ((AliceO2::Data::Stack *) TVirtualMC::GetMC()->GetStack())->GetParticle(GetTrack());
+  int trc = TVirtualMC::GetMC()->GetStack()->GetCurrentTrackNumber();
+  return ((AliceO2::Data::Stack *) TVirtualMC::GetMC()->GetStack())->GetParticle(trc);
 }
 
 void Detector::Print(std::ostream *os) const
@@ -1097,18 +1045,16 @@ void Detector::Print(std::ostream *os) const
   Int_t fmt;
 #endif
 #endif
-
-  fmt = os->setf(std::ios::scientific); // set scientific floating point output
-  *os << mTrackNumber << " " << mPositionX << " " << mPositionY << " " << mPositionZ << " ";
-  fmt = os->setf(std::ios::hex); // set hex for mStatus only.
-  *os << mStatus << " ";
-  fmt = os->setf(std::ios::dec); // every thing else decimel.
-  *os << mModule << " ";
-  *os << mParticlePx << " " << mParticlePy << " " << mParticlePz << " ";
-  *os << mEnergyDepositionStep << " " << mTof;
-  *os << " " << mStartingStepX << " " << mStartingStepY << " " << mStartingStepZ;
+  // RS: why do we need to pring this garbage?
+  
+  //fmt = os->setf(std::ios::scientific); // set scientific floating point output
+  //fmt = os->setf(std::ios::hex); // set hex for mStatus only.
+  //fmt = os->setf(std::ios::dec); // every thing else decimel.
+  //  *os << mModule << " ";
+  //  *os << mEnergyDepositionStep << " " << mTof;
+  //  *os << " " << mStartingStepX << " " << mStartingStepY << " " << mStartingStepZ;
   //    *os << " " << endl;
-  os->flags(fmt); // reset back to old formating.
+  //os->flags(fmt); // reset back to old formating.
   return;
 }
 
@@ -1121,11 +1067,7 @@ void Detector::Read(std::istream *is)
   //   none.
   // Return:
   //   none.
-
-  *is >> mTrackNumber >> mPositionX >> mPositionY >> mPositionZ;
-  *is >> mStatus >> mModule >> mParticlePx >> mParticlePy >> mParticlePz >> mEnergyDepositionStep >>
-  mTof;
-  *is >> mStartingStepX >> mStartingStepY >> mStartingStepZ;
+  // RS no need to read garbage
   return;
 }
 

--- a/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Point.h
+++ b/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Point.h
@@ -4,7 +4,7 @@
 #ifndef ALICEO2_ITSMFT_POINT_H_
 #define ALICEO2_ITSMFT_POINT_H_
 
-#include "FairMCPoint.h"  // for FairMCPoint
+#include "SimulationDataFormat/BaseHits.h"     // for BasicXYZEHit
 #include "Rtypes.h"       // for Bool_t, Double_t, Int_t, Double32_t, etc
 #include "TVector3.h"     // for TVector3
 #include <iostream>
@@ -12,22 +12,22 @@
 namespace AliceO2 {
 namespace ITSMFT {
 
-class Point : public FairMCPoint
+class Point : public AliceO2::BasicXYZEHit<Float_t,Float_t>
 {
 
   public:
     enum PointStatus_t
     {
-        kTrackEntering = 0,
-        kTrackInside,
-        kTrackExiting,
-        kTrackOut,
-        kTrackStopped,
-        kTrackAlive
+        kTrackEntering = 0x1,
+        kTrackInside   = 0x1<<1,
+        kTrackExiting  = 0x1<<2,
+        kTrackOut      = 0x1<<3,
+        kTrackStopped  = 0x1<<4,
+        kTrackAlive    = 0x1<<5
     };
 
     /// Default constructor
-    Point();
+    Point() = default;
 
     /// Class Constructor
     /// \param trackID Index of MCTrack
@@ -35,114 +35,89 @@ class Point : public FairMCPoint
     /// \param startPos Coordinates at entrance to active volume [cm]
     /// \param pos Coordinates to active volume [cm]
     /// \param mom Momentum of track at entrance [GeV]
-    /// \param startTime Time at entrance [ns]
+    /// \param endTime Time at entrance [ns]
     /// \param time Time since event start [ns]
-    /// \param length Track length since creation [cm]
     /// \param eLoss Energy deposit [GeV]
-    /// \param shunt Shunt value
-    Point(Int_t trackID, Int_t detID, TVector3 startPos, TVector3 pos, TVector3 mom, Double_t startTime, Double_t time,
-          Double_t length, Double_t eLoss, Int_t shunt, Int_t status, Int_t statusStart);
+    /// \param startStatus: status at entrance
+    /// \param endStatus: status at exit
+    inline Point(int trackID, unsigned short detID, TVector3 startPos, TVector3 pos, TVector3 mom, double startE,
+		 double endTime, double eLoss,unsigned char statusStart, unsigned char status);
 
-    // Default Destructor
-    virtual ~Point();
 
-    void SetTotalEnergy(Double_t e) { mTotalEnergy=e; }
-    Double_t GetTotalEnergy() const { return mTotalEnergy; }
-
-    Double_t GetStartX() const
-    { return mStartX; }
-
-    Double_t GetStartY() const
-    { return mStartY; }
-
-    Double_t GetStartZ() const
-    { return mStartZ; }
-
-    /// Get Position at the start of the hit
+    // Entrance position getters
+    Point3D<Float_t> GetPosStart() const { return mPosStart; }
+    Float_t GetStartX() const { return mPosStart.X(); }
+    Float_t GetStartY() const { return mPosStart.Y(); }
+    Float_t GetStartZ() const { return mPosStart.Z(); }  
     template<typename F> void GetStartPosition(F &x, F &y, F &z) const
     {
-      x = mStartX;
-      y = mStartY;
-      z = mStartZ;
+      x = GetStartX();
+      y = GetStartY();
+      z = GetStartZ();
     }
+    // momentum getters
+    Vector3D<Float_t> GetMomentum() const { return mMomentum; }
+    Vector3D<Float_t>& GetMomentum()      { return mMomentum; }
+    Float_t GetPx() const { return mMomentum.X(); }
+    Float_t GetPy() const { return mMomentum.Y(); }
+    Float_t GetPz() const { return mMomentum.Z(); }
+    Float_t GetE()  const { return mE; }
+    Float_t GetTotalEnergy() const { return GetE(); }
+    
+    UChar_t GetStatusEnd()   const  { return mTrackStatusEnd; }
+    UChar_t GetStatusStart() const  { return mTrackStatusStart; }
 
-    Double_t GetStartTime() const
-    { return mStartTime; }
+    Bool_t IsEntering()      const  { return mTrackStatusEnd & kTrackEntering; }
+    Bool_t IsInside()        const  { return mTrackStatusEnd & kTrackInside; }
+    Bool_t IsExiting()       const  { return mTrackStatusEnd & kTrackExiting; }
+    Bool_t IsOut()           const  { return mTrackStatusEnd & kTrackOut; }
+    Bool_t IsStopped()       const  { return mTrackStatusEnd & kTrackStopped; }
+    Bool_t IsAlive()         const  { return mTrackStatusEnd & kTrackAlive; }
 
-    Int_t GetShunt() const
-    { return mShunt; }
-
-    Int_t GetStatus() const
-    { return mTrackStatus; }
-
-    Int_t GetStatusStart() const
-    { return mTrackStatusStart; }
-
-    Bool_t IsEntering() const
-    { return mTrackStatus & (1 << kTrackEntering); }
-
-    Bool_t IsInsideDetector() const
-    { return mTrackStatus & (1 << kTrackInside); }
-
-    Bool_t IsExiting() const
-    { return mTrackStatus & (1 << kTrackExiting); }
-
-    Bool_t IsOut() const
-    { return mTrackStatus & (1 << kTrackOut); }
-
-    Bool_t IsStopped() const
-    { return mTrackStatus & (1 << kTrackStopped); }
-
-    Bool_t IsAlive() const
-    { return mTrackStatus & (1 << kTrackAlive); }
-
-    Bool_t IsEnteringStart() const
-    { return mTrackStatusStart & (1 << kTrackEntering); }
-
-    Bool_t IsInsideDetectorStart() const
-    { return mTrackStatusStart & (1 << kTrackInside); }
-
-    Bool_t IsExitingStart() const
-    { return mTrackStatusStart & (1 << kTrackExiting); }
-
-    Bool_t IsOutStart() const
-    { return mTrackStatusStart & (1 << kTrackOut); }
-
-    Bool_t IsStoppedStart() const
-    { return mTrackStatusStart & (1 << kTrackStopped); }
-
-    Bool_t IsAliveStart() const
-    { return mTrackStatusStart & (1 << kTrackAlive); }
-
+    Bool_t IsEnteringStart() const  { return mTrackStatusStart & kTrackEntering; }
+    Bool_t IsInsideStart()   const  { return mTrackStatusStart & kTrackInside; }
+    Bool_t IsExitingStart()  const  { return mTrackStatusStart & kTrackExiting; }
+    Bool_t IsOutStart()      const  { return mTrackStatusStart & kTrackOut; }
+    Bool_t IsStoppedStart()  const  { return mTrackStatusStart & kTrackStopped; }
+    Bool_t IsAliveStart()    const  { return mTrackStatusStart & kTrackAlive; }
 
     /// Output to screen
     virtual void Print(const Option_t *opt) const;
-
     friend std::ostream &operator<<(std::ostream &of, const Point &point)
     {
-      of << "-I- Point: O2its point for track " << point.fTrackID << " in detector " << point.fDetectorID << std::endl;
+      of << "-I- Point: O2its point for track " << point.GetTrackID() << " in detector " << point.GetDetectorID() << std::endl;
+      /*
       of << "    Position (" << point.fX << ", " << point.fY << ", " << point.fZ << ") cm" << std::endl;
       of << "    Momentum (" << point.fPx << ", " << point.fPy << ", " << point.fPz << ") GeV" << std::endl;
       of << "    Time " << point.fTime << " ns,  Length " << point.fLength << " cm,  Energy loss "
       << point.fELoss * 1.0e06 << " keV" << std::endl;
+      */
       return of;
     }
 
   private:
     /// Copy constructor
     Point(const Point &point);
-
     Point operator=(const Point &point);
+    Vector3D<Float_t> mMomentum;              ///< momentum at entrance
+    Point3D<Float_t> mPosStart;               ///< position at entrance (base mPos give position on exit)
+    Float_t mE;                               ///< total energy at entrance
+    UChar_t mTrackStatusEnd;                  ///< MC status flag at exit
+    UChar_t mTrackStatusStart;                ///< MC status at starting point
 
-    Int_t mTrackStatus;                     ///< MC status flag at hit
-    Int_t mTrackStatusStart;                ///< MC status at starting point
-    Int_t mShunt;                           ///< Shunt
-    Double32_t mStartX, mStartY, mStartZ;   ///< Position at the entrance of the active volume
-    Double32_t mStartTime;     ///< Time at the entrance of the active volume
-    Double32_t mTotalEnergy;   ///< Total energy
-
-  ClassDef(Point, 2)
+  ClassDef(Point, 3)
 };
+
+Point::Point(int trackID, unsigned short detID, TVector3 startPos, TVector3 endPos, TVector3 startMom,
+             double startE,double endTime, double eLoss, unsigned char startStatus, unsigned char endStatus)
+  : BasicXYZEHit(endPos.X(),endPos.Y(),endPos.Z(),endTime,eLoss,trackID,detID),
+    mMomentum(startMom.Px(),startMom.Py(),startMom.Pz()),
+    mPosStart(startPos.X(),startPos.Y(),startPos.Z()),
+    mE(startE),
+    mTrackStatusEnd(endStatus),
+    mTrackStatusStart(startStatus)
+{}
+
 
 }
 }

--- a/Detectors/ITSMFT/common/simulation/src/Chip.cxx
+++ b/Detectors/ITSMFT/common/simulation/src/Chip.cxx
@@ -117,7 +117,7 @@ Double_t &zstart, Double_t &zpoint, Double_t &timestart, Double_t &eloss) const
   ypoint = posloc[1] - poslocStart[1];
   zpoint = posloc[2] - poslocStart[2];
 
-  timestart = tmp->GetStartTime();
+  timestart = tmp->GetTime();
   eloss = tmp->GetEnergyLoss();
 
   return kTRUE;
@@ -141,7 +141,7 @@ Bool_t Chip::LineSegmentGlobal(Int_t hitindex, Double_t &xstart, Double_t &xpoin
   xpoint = tmp->GetX() - xstart;
   ypoint = tmp->GetY() - ystart;
   zpoint = tmp->GetY() - zstart;
-  timestart = tmp->GetStartTime();
+  timestart = tmp->GetTime();
   eloss = tmp->GetEnergyLoss();
 
   return kTRUE;

--- a/Detectors/ITSMFT/common/simulation/src/ITSMFTSimulationLinkDef.h
+++ b/Detectors/ITSMFT/common/simulation/src/ITSMFTSimulationLinkDef.h
@@ -9,5 +9,6 @@
 #pragma link C++ class AliceO2::ITSMFT::ClusterShape+;
 #pragma link C++ class AliceO2::ITSMFT::SimuClusterShaper+;
 #pragma link C++ class AliceO2::ITSMFT::SimulationAlpide+;
+#pragma link C++ class ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<float>,ROOT::Math::DefaultCoordinateSystemTag>+;
 
 #endif

--- a/Detectors/ITSMFT/common/simulation/src/Point.cxx
+++ b/Detectors/ITSMFT/common/simulation/src/Point.cxx
@@ -10,40 +10,15 @@ ClassImp(AliceO2::ITSMFT::Point)
 using std::cout;
 using std::endl;
 using namespace AliceO2::ITSMFT;
+using namespace AliceO2; //::Base;
 
-Point::Point() : FairMCPoint(),
-                 mTrackStatus(0),
-                 mTrackStatusStart(0),
-                 mShunt(0),
-                 mStartX(0.),
-                 mStartY(0.),
-                 mStartZ(0.),
-                 mStartTime(0.),
-                 mTotalEnergy(0.)
-{
-}
-
-Point::Point(Int_t trackID, Int_t detID, TVector3 startPos, TVector3 pos, TVector3 mom,
-             Double_t startTime, Double_t time, Double_t length, Double_t eLoss, Int_t shunt, Int_t status,
-             Int_t statusStart)
-  : FairMCPoint(trackID, detID, pos, mom, time, length, eLoss),
-    mTrackStatus(status),
-    mTrackStatusStart(statusStart),
-    mShunt(shunt),
-    mStartX(startPos.X()),
-    mStartY(startPos.Y()),
-    mStartZ(startPos.Z()),
-    mStartTime(startTime),
-    mTotalEnergy(0.)
-{
-}
-
-Point::~Point()
-= default;
 
 void Point::Print(const Option_t *opt) const
 {
-  cout << *this;
+  printf("Det: %5d Track: %6d E.loss: %.3e P: %+.3e %+.3e %+.3e\n"
+	 "PosIn: %+.3e %+.3e %+.3e PosOut: %+.3e %+.3e %+.3e\n",
+	 GetDetectorID(),GetTrackID(),GetEnergyLoss(),GetPx(),GetPy(),GetPz(),
+	 GetStartX(),GetStartY(),GetStartZ(),GetX(),GetY(),GetZ() );
 }
 
 

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -356,6 +356,7 @@ o2_define_bucket(
     ITSMFTBase
 
     INCLUDE_DIRECTORIES
+    ${CMAKE_SOURCE_DIR}/DataFormats/simulation/include
     ${CMAKE_SOURCE_DIR}/Detectors/Base/include
     ${CMAKE_SOURCE_DIR}/Detectors/ITSMFT/common/base/include
 )


### PR DESCRIPTION
1) Adopt new BaseHit::BaseXYZE_f_f as a base class for ITS hit
2) Make sure just 1 hit is generated at each traversal of sensor by track
3) Lot of cleaning in ITS/Detector
4) Squashed separate commit to make ITSMFT Point c-tor inline

The previous PR #312 became polluted due, reopening here after squashing 2 relevant commits