### PR TITLE
fix Pythia6 dependency typo

### DIFF
--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -562,7 +562,7 @@ o2_define_bucket(
     generators_bucket
 
     DEPENDENCIES
-    Base SimulationDataFormat pythia6 pythia8 MathCore
+    Base SimulationDataFormat Pythia6 pythia8 MathCore
 
     INCLUDE_DIRECTORIES
     ${ROOT_INCLUDE_DIR}


### PR DESCRIPTION
```make
(...)
[  2%] Linking CXX shared library ../lib/libGenerators.so
/usr/bin/ld: cannot find -lpythia6
collect2: error: ld returned 1 exit status
Generators/CMakeFiles/Generators.dir/build.make:172: recipe for target 'lib/libGenerators.so' failed
make[2]: *** [lib/libGenerators.so] Error 1
CMakeFiles/Makefile2:1018: recipe for target 'Generators/CMakeFiles/Generators.dir/all' failed
make[1]: *** [Generators/CMakeFiles/Generators.dir/all] Error 2
Makefile:138: recipe for target 'all' failed
make: *** [all] Error 2
```

During compilation I got the linker error above on Linux. Turns out version 6 is with a capital P and only version 8 with a small p. As far as I can see this is the case for the Pythia6 installation from FairSoft and from aliBuild.