### PR TITLE
C++11 modernization: use override keyword

### DIFF
--- a/CCDB/include/CCDB/BackendOCDB.h
+++ b/CCDB/include/CCDB/BackendOCDB.h
@@ -18,13 +18,13 @@ class BackendOCDB : public Backend {
 private:
 public:
   BackendOCDB();
-  virtual ~BackendOCDB()= default;
+  ~BackendOCDB() override = default;
 
   /// Prepares an object before transmission to CCDB server
-  void Pack(const std::string& path, const std::string& key, std::string*& messageString);
+  void Pack(const std::string& path, const std::string& key, std::string*& messageString) override;
 
   /// Parses an incoming message from the CCDB server and prints the metadata of the included object
-  void UnPack(std::unique_ptr<FairMQMessage> msg);
+  void UnPack(std::unique_ptr<FairMQMessage> msg) override;
 };
 }
 }

--- a/CCDB/include/CCDB/BackendRiak.h
+++ b/CCDB/include/CCDB/BackendRiak.h
@@ -24,13 +24,13 @@ private:
 
 public:
   BackendRiak();
-  virtual ~BackendRiak()= default;
+  ~BackendRiak() override = default;
 
   /// Compresses and serializes an object prior to transmission to server
-  void Pack(const std::string& path, const std::string& key, std::string*& messageString);
+  void Pack(const std::string& path, const std::string& key, std::string*& messageString) override;
 
   /// Deserializes and uncompresses an incoming message from the CCDB server
-  void UnPack(std::unique_ptr<FairMQMessage> msg);
+  void UnPack(std::unique_ptr<FairMQMessage> msg) override;
 };
 }
 }

--- a/CCDB/include/CCDB/Condition.h
+++ b/CCDB/include/CCDB/Condition.h
@@ -58,7 +58,7 @@ class Condition : public TObject
               ConditionMetaData *metaData, Bool_t owner = kFALSE);
 
     /// Default destructor
-    virtual ~Condition();
+    ~Condition() override;
 
     /// Set the object identity from an ConditionId
     void setId(const ConditionId &id)
@@ -156,10 +156,10 @@ class Condition : public TObject
     };
 
     /// Method to compare two CDB objects, used for sorting in ROOT ordered containers
-    virtual Int_t Compare(const TObject *obj) const;
+    Int_t Compare(const TObject *obj) const override;
 
     /// Define this class sortable (via the Compare method) for ROOT ordered containers
-    virtual Bool_t IsSortable() const;
+    Bool_t IsSortable() const override;
 
   private:
     Condition(const Condition &other);          // no copy ctor
@@ -170,7 +170,7 @@ class Condition : public TObject
     ConditionMetaData *mConditionMetaData; ///< metaData
     Bool_t mOwner;     ///< Ownership flag
 
-  ClassDef(Condition, 1)
+  ClassDefOverride(Condition, 1)
 };
 }
 }

--- a/CCDB/include/CCDB/ConditionId.h
+++ b/CCDB/include/CCDB/ConditionId.h
@@ -26,7 +26,7 @@ class ConditionId : public TObject
 
     static ConditionId *makeFromString(const TString &idString);
 
-    virtual ~ConditionId();
+    ~ConditionId() override;
 
     const IdPath &getPath() const
     {
@@ -151,11 +151,11 @@ class ConditionId : public TObject
 
     void print(Option_t *option = "") const;
 
-    virtual Int_t Compare(const TObject *obj) const;
+    Int_t Compare(const TObject *obj) const override;
 
-    virtual Bool_t IsSortable() const;
+    Bool_t IsSortable() const override;
 
-    virtual const char *GetName() const
+    const char *GetName() const override
     {
       return mPath.getPathString().Data();
     }
@@ -167,7 +167,7 @@ class ConditionId : public TObject
     Int_t mSubVersion;    // subversion
     TString mLastStorage; // previous storage place (new, grid, local, dump)
 
-  ClassDef(ConditionId, 1)
+  ClassDefOverride(ConditionId, 1)
 };
 }
 }

--- a/CCDB/include/CCDB/ConditionMetaData.h
+++ b/CCDB/include/CCDB/ConditionMetaData.h
@@ -20,7 +20,7 @@ class ConditionMetaData : public TObject
     ConditionMetaData(const char *responsible, UInt_t beamPeriod = 0, const char *alirootVersion = "",
                       const char *comment = "");
 
-    virtual ~ConditionMetaData();
+    ~ConditionMetaData() override;
 
     void setObjectClassName(const char *name)
     {
@@ -92,7 +92,7 @@ class ConditionMetaData : public TObject
 
     TMap mProperties; // list of object specific properties
 
-  ClassDef(ConditionMetaData, 1)
+  ClassDefOverride(ConditionMetaData, 1)
 };
 }
 }

--- a/CCDB/include/CCDB/ConditionsMQClient.h
+++ b/CCDB/include/CCDB/ConditionsMQClient.h
@@ -18,11 +18,11 @@ namespace CDB {
 class ConditionsMQClient : public FairMQDevice {
 public:
   ConditionsMQClient();
-  virtual ~ConditionsMQClient();
+  ~ConditionsMQClient() override;
 
 protected:
-  virtual void InitTask();
-  virtual void Run();
+  void InitTask() override;
+  void Run() override;
 
 private:
   int mRunId;

--- a/CCDB/include/CCDB/ConditionsMQServer.h
+++ b/CCDB/include/CCDB/ConditionsMQServer.h
@@ -20,11 +20,11 @@ class ConditionsMQServer : public ParameterMQServer {
 public:
   ConditionsMQServer();
 
-  virtual ~ConditionsMQServer();
+  ~ConditionsMQServer() override;
 
-  virtual void Run();
+  void Run() override;
 
-  virtual void InitTask();
+  void InitTask() override;
 
 private:
   Manager* fCdbManager;

--- a/CCDB/include/CCDB/FileStorage.h
+++ b/CCDB/include/CCDB/FileStorage.h
@@ -22,32 +22,32 @@ class FileStorage : public Storage
     friend class FileStorageFactory;
 
   public:
-    virtual Bool_t isReadOnly() const
+    Bool_t isReadOnly() const override
     {
       return mReadOnly;
     };
 
-    virtual Bool_t hasSubVersion() const
+    Bool_t hasSubVersion() const override
     {
       return kFALSE;
     };
 
-    virtual Bool_t hasConditionType(const char *path) const;
+    Bool_t hasConditionType(const char *path) const override;
 
-    virtual Bool_t idToFilename(const ConditionId &id, TString &filename) const;
+    Bool_t idToFilename(const ConditionId &id, TString &filename) const override;
 
-    virtual void setRetry(Int_t /* nretry */, Int_t /* initsec */);
+    void setRetry(Int_t /* nretry */, Int_t /* initsec */) override;
 
   protected:
-    virtual Condition *getCondition(const ConditionId &query);
+    Condition *getCondition(const ConditionId &query) override;
 
-    virtual ConditionId *getConditionId(const ConditionId &query);
+    ConditionId *getConditionId(const ConditionId &query) override;
 
-    virtual TList *getAllEntries(const ConditionId &query);
+    TList *getAllEntries(const ConditionId &query) override;
 
-    virtual Bool_t putCondition(Condition *entry, const char *mirrors = "");
+    Bool_t putCondition(Condition *entry, const char *mirrors = "") override;
 
-    virtual TList *getIdListFromFile(const char *fileName);
+    TList *getIdListFromFile(const char *fileName) override;
 
   private:
     FileStorage(const FileStorage &source);
@@ -56,7 +56,7 @@ class FileStorage : public Storage
 
     FileStorage(const char *dbFile, Bool_t readOnly);
 
-    virtual ~FileStorage();
+    ~FileStorage() override;
 
     Bool_t keyNameToId(const char *keyname, IdRunRange &runRange, Int_t &version, Int_t &subVersion);
 
@@ -69,7 +69,7 @@ class FileStorage : public Storage
     //	Bool_t getId(const  ConditionId& query,  ConditionId& result);
     ConditionId *getId(const ConditionId &query);
 
-    virtual void queryValidFiles();
+    void queryValidFiles() override;
 
     void getEntriesForLevel0(const ConditionId &query, TList *result);
 
@@ -78,7 +78,7 @@ class FileStorage : public Storage
     TFile *mFile;     // FileStorage file
     Bool_t mReadOnly; // ReadOnly flag
 
-  ClassDef(FileStorage, 0)
+  ClassDefOverride(FileStorage, 0)
 };
 
 /////////////////////////////////////////////////////////////////////
@@ -91,14 +91,14 @@ class FileStorageFactory : public StorageFactory
 {
 
   public:
-    virtual Bool_t validateStorageUri(const char *dbString);
+    Bool_t validateStorageUri(const char *dbString) override;
 
-    virtual StorageParameters *createStorageParameter(const char *dbString);
+    StorageParameters *createStorageParameter(const char *dbString) override;
 
   protected:
-    virtual Storage *createStorage(const StorageParameters *param);
+    Storage *createStorage(const StorageParameters *param) override;
 
-  ClassDef(FileStorageFactory, 0)
+  ClassDefOverride(FileStorageFactory, 0)
 };
 
 /////////////////////////////////////////////////////////////////////
@@ -115,7 +115,7 @@ class FileStorageParameters : public StorageParameters
 
     FileStorageParameters(const char *dbPath, Bool_t readOnly = kFALSE);
 
-    virtual ~FileStorageParameters();
+    ~FileStorageParameters() override;
 
     const TString &getPathString() const
     {
@@ -127,7 +127,7 @@ class FileStorageParameters : public StorageParameters
       return mReadOnly;
     };
 
-    virtual StorageParameters *cloneParam() const;
+    StorageParameters *cloneParam() const override;
 
     virtual ULong_t getHash() const;
 
@@ -137,7 +137,7 @@ class FileStorageParameters : public StorageParameters
     TString mDBPath;  // FileStorage file path name
     Bool_t mReadOnly; // ReadOnly flag
 
-  ClassDef(FileStorageParameters, 0)
+  ClassDefOverride(FileStorageParameters, 0)
 };
 }
 }

--- a/CCDB/include/CCDB/GridStorage.h
+++ b/CCDB/include/CCDB/GridStorage.h
@@ -25,48 +25,48 @@ class GridStorage : public Storage
     friend class GridStorageFactory;
 
   public:
-    virtual Bool_t isReadOnly() const
+    Bool_t isReadOnly() const override
     {
       return kFALSE;
     }
 
-    virtual Bool_t hasSubVersion() const
+    Bool_t hasSubVersion() const override
     {
       return kFALSE;
     }
 
-    virtual Bool_t hasConditionType(const char *path) const;
+    Bool_t hasConditionType(const char *path) const override;
 
-    virtual Bool_t idToFilename(const ConditionId &id, TString &filename) const;
+    Bool_t idToFilename(const ConditionId &id, TString &filename) const override;
 
-    virtual void setRetry(Int_t nretry, Int_t initsec);
+    void setRetry(Int_t nretry, Int_t initsec) override;
 
-    virtual void setMirrorSEs(const char *mirrors)
+    void setMirrorSEs(const char *mirrors) override
     {
       mMirrorSEs = mirrors;
     }
 
-    virtual const char *getMirrorSEs() const
+    const char *getMirrorSEs() const override
     {
       return mMirrorSEs;
     }
 
   protected:
-    virtual Condition *getCondition(const ConditionId &queryId);
+    Condition *getCondition(const ConditionId &queryId) override;
 
-    virtual ConditionId *getConditionId(const ConditionId &queryId);
+    ConditionId *getConditionId(const ConditionId &queryId) override;
 
-    virtual TList *getAllEntries(const ConditionId &queryId);
+    TList *getAllEntries(const ConditionId &queryId) override;
 
-    virtual Bool_t putCondition(Condition *entry, const char *mirrors = "");
+    Bool_t putCondition(Condition *entry, const char *mirrors = "") override;
 
-    virtual TList *getIdListFromFile(const char *fileName);
+    TList *getIdListFromFile(const char *fileName) override;
 
   private:
     GridStorage(const char *gridUrl, const char *user, const char *dbFolder, const char *se, const char *cacheFolder,
                 Bool_t operateDisconnected, Long64_t cacheSize, Long_t cleanupInterval);
 
-    virtual ~GridStorage();
+    ~GridStorage() override;
 
     GridStorage(const GridStorage &db);
 
@@ -91,7 +91,7 @@ class GridStorage : public Storage
 
     void makeQueryFilter(Int_t firstRun, Int_t lastRun, const ConditionMetaData *md, TString &result) const;
 
-    virtual void queryValidFiles();
+    void queryValidFiles() override;
 
     TString mGridUrl;            // GridStorage Url ("alien://aliendb4.cern.ch:9000")
     TString mUser;               // User
@@ -103,7 +103,7 @@ class GridStorage : public Storage
     Long64_t mCacheSize;         // local cache size (in bytes)
     Long_t mCleanupInterval;     // local cache cleanup interval
 
-  ClassDef(GridStorage, 0) // access class to a DataBase in an AliEn storage
+  ClassDefOverride(GridStorage, 0) // access class to a DataBase in an AliEn storage
 };
 
 /////////////////////////////////////////////////////////////////////
@@ -116,17 +116,17 @@ class GridStorageFactory : public StorageFactory
 {
 
   public:
-    virtual Bool_t validateStorageUri(const char *gridString);
+    Bool_t validateStorageUri(const char *gridString) override;
 
-    virtual StorageParameters *createStorageParameter(const char *gridString);
+    StorageParameters *createStorageParameter(const char *gridString) override;
 
-    virtual ~GridStorageFactory()
-    = default;
+    ~GridStorageFactory()
+    override = default;
 
   protected:
-    virtual Storage *createStorage(const StorageParameters *param);
+    Storage *createStorage(const StorageParameters *param) override;
 
-  ClassDef(GridStorageFactory, 0)
+  ClassDefOverride(GridStorageFactory, 0)
 };
 
 /////////////////////////////////////////////////////////////////////
@@ -145,7 +145,7 @@ class GridStorageParameters : public StorageParameters
                           const char *cacheFolder,
                           Bool_t operateDisconnected, Long64_t cacheSize, Long_t cleanupInterval);
 
-    virtual ~GridStorageParameters();
+    ~GridStorageParameters() override;
 
     const TString &GridUrl() const
     {
@@ -187,7 +187,7 @@ class GridStorageParameters : public StorageParameters
       return mCleanupInterval;
     }
 
-    virtual StorageParameters *cloneParam() const;
+    StorageParameters *cloneParam() const override;
 
     virtual ULong_t getHash() const;
 
@@ -203,7 +203,7 @@ class GridStorageParameters : public StorageParameters
     Long64_t mCacheSize;         // local cache size (in bytes)
     Long_t mCleanupInterval;     // local cache cleanup interval
 
-  ClassDef(GridStorageParameters, 0)
+  ClassDefOverride(GridStorageParameters, 0)
 };
 }
 }

--- a/CCDB/include/CCDB/IdPath.h
+++ b/CCDB/include/CCDB/IdPath.h
@@ -25,7 +25,7 @@ class IdPath : public TObject
 
     IdPath(const TString &path);
 
-    virtual ~IdPath();
+    ~IdPath() override;
 
     const TString &getPathString() const
     {
@@ -73,7 +73,7 @@ class IdPath : public TObject
     Bool_t mValid;    // validity flag
     Bool_t mWildcard; // wildcard flag
 
-  ClassDef(IdPath, 1)
+  ClassDefOverride(IdPath, 1)
 };
 }
 }

--- a/CCDB/include/CCDB/IdRunRange.h
+++ b/CCDB/include/CCDB/IdRunRange.h
@@ -16,7 +16,7 @@ class IdRunRange : public TObject
 
     IdRunRange(Int_t firstRun, Int_t lastRun);
 
-    virtual ~IdRunRange();
+    ~IdRunRange() override;
 
     Int_t getFirstRun() const
     {
@@ -68,7 +68,7 @@ class IdRunRange : public TObject
 
     static const Int_t sInfinity = 999999999; //! Flag for "infinity"
 
-  ClassDef(IdRunRange, 1)
+  ClassDefOverride(IdRunRange, 1)
 };
 }
 }

--- a/CCDB/include/CCDB/LocalStorage.h
+++ b/CCDB/include/CCDB/LocalStorage.h
@@ -23,32 +23,32 @@ class LocalStorage : public Storage
     friend class LocalStorageFactory;
 
   public:
-    virtual Bool_t isReadOnly() const
+    Bool_t isReadOnly() const override
     {
       return kFALSE;
     };
 
-    virtual Bool_t hasSubVersion() const
+    Bool_t hasSubVersion() const override
     {
       return kTRUE;
     };
 
-    virtual Bool_t hasConditionType(const char *path) const;
+    Bool_t hasConditionType(const char *path) const override;
 
-    virtual Bool_t idToFilename(const ConditionId &id, TString &filename) const;
+    Bool_t idToFilename(const ConditionId &id, TString &filename) const override;
 
-    virtual void setRetry(Int_t /* nretry */, Int_t /* initsec */);
+    void setRetry(Int_t /* nretry */, Int_t /* initsec */) override;
 
   protected:
-    virtual Condition *getCondition(const ConditionId &queryId);
+    Condition *getCondition(const ConditionId &queryId) override;
 
-    virtual ConditionId *getConditionId(const ConditionId &queryId);
+    ConditionId *getConditionId(const ConditionId &queryId) override;
 
-    virtual TList *getAllEntries(const ConditionId &queryId);
+    TList *getAllEntries(const ConditionId &queryId) override;
 
-    virtual Bool_t putCondition(Condition *entry, const char *mirrors = "");
+    Bool_t putCondition(Condition *entry, const char *mirrors = "") override;
 
-    virtual TList *getIdListFromFile(const char *fileName);
+    TList *getIdListFromFile(const char *fileName) override;
 
   private:
     LocalStorage(const LocalStorage &source);
@@ -57,7 +57,7 @@ class LocalStorage : public Storage
 
     LocalStorage(const char *baseDir);
 
-    virtual ~LocalStorage();
+    ~LocalStorage() override;
 
     Bool_t filenameToId(const char *filename, IdRunRange &runRange, Int_t &version, Int_t &subVersion);
 
@@ -66,7 +66,7 @@ class LocalStorage : public Storage
     //	Bool_t getId(const  ConditionId& query,  ConditionId& result);
     ConditionId *getId(const ConditionId &query);
 
-    virtual void queryValidFiles();
+    void queryValidFiles() override;
 
     void queryValidCVMFSFiles(TString &cvmfsOcdbTag);
 
@@ -76,21 +76,21 @@ class LocalStorage : public Storage
 
     TString mBaseDirectory; // path of the DB folder
 
-  ClassDef(LocalStorage, 0) // access class to a DataBase in a local storage
+  ClassDefOverride(LocalStorage, 0) // access class to a DataBase in a local storage
 };
 
 //  class  LocalStorageFactory
 class LocalStorageFactory : public StorageFactory
 {
   public:
-    virtual Bool_t validateStorageUri(const char *dbString);
+    Bool_t validateStorageUri(const char *dbString) override;
 
-    virtual StorageParameters *createStorageParameter(const char *dbString);
+    StorageParameters *createStorageParameter(const char *dbString) override;
 
   protected:
-    virtual Storage *createStorage(const StorageParameters *param);
+    Storage *createStorage(const StorageParameters *param) override;
 
-  ClassDef(LocalStorageFactory, 0)
+  ClassDefOverride(LocalStorageFactory, 0)
 };
 
 //  class  LocalStorageParameters
@@ -103,14 +103,14 @@ class LocalStorageParameters : public StorageParameters
 
     LocalStorageParameters(const char *dbPath, const char *uri);
 
-    virtual ~LocalStorageParameters();
+    ~LocalStorageParameters() override;
 
     const TString &getPathString() const
     {
       return mDBPath;
     };
 
-    virtual StorageParameters *cloneParam() const;
+    StorageParameters *cloneParam() const override;
 
     virtual ULong_t getHash() const;
 
@@ -118,7 +118,7 @@ class LocalStorageParameters : public StorageParameters
 
   private:
     TString mDBPath; // path of the DB folder
-  ClassDef(LocalStorageParameters, 0)
+  ClassDefOverride(LocalStorageParameters, 0)
 };
 }
 }

--- a/CCDB/include/CCDB/Manager.h
+++ b/CCDB/include/CCDB/Manager.h
@@ -191,7 +191,7 @@ class Manager : public TObject
 
     static void destroy();
 
-    ~Manager();
+    ~Manager() override;
 
     void clearCache();
 
@@ -306,7 +306,7 @@ class Manager : public TObject
   private:
     ULong64_t mKey; //! Key for locking/unlocking
 
-  ClassDef(Manager, 0)
+  ClassDefOverride(Manager, 0)
 };
 
 /////////////////////////////////////////////////////////////////////
@@ -322,8 +322,8 @@ class StorageFactory : public TObject
     friend class Manager;
 
   public:
-    virtual ~StorageFactory()
-    = default;
+    ~StorageFactory()
+    override = default;
 
     virtual Bool_t validateStorageUri(const char *dbString) = 0;
 
@@ -332,7 +332,7 @@ class StorageFactory : public TObject
   protected:
     virtual Storage *createStorage(const StorageParameters *param) = 0;
 
-  ClassDef(StorageFactory, 0)
+  ClassDefOverride(StorageFactory, 0)
 };
 
 /////////////////////////////////////////////////////////////////////
@@ -347,7 +347,7 @@ class StorageParameters : public TObject
   public:
     StorageParameters();
 
-    virtual ~StorageParameters();
+    ~StorageParameters() override;
 
     const TString &getStorageType() const
     {
@@ -376,7 +376,7 @@ class StorageParameters : public TObject
     TString mType; //! CDB type
     TString mURI;  //! CDB URI
 
-  ClassDef(StorageParameters, 0)
+  ClassDefOverride(StorageParameters, 0)
 };
 
 }

--- a/CCDB/include/CCDB/Storage.h
+++ b/CCDB/include/CCDB/Storage.h
@@ -118,7 +118,7 @@ class Storage : public TObject
     virtual void setRetry(Int_t nretry, Int_t initsec) = 0;
 
   protected:
-    virtual ~Storage();
+    ~Storage() override;
 
     void getSelection(/*const*/ ConditionId *id);
 
@@ -155,7 +155,7 @@ class Storage : public TObject
 
     Storage &operator=(const Storage &source);
 
-  ClassDef(Storage, 0)
+  ClassDefOverride(Storage, 0)
 };
 }
 }

--- a/CCDB/include/CCDB/XmlHandler.h
+++ b/CCDB/include/CCDB/XmlHandler.h
@@ -25,7 +25,7 @@ class XmlHandler : public TObject
 
     XmlHandler(const XmlHandler &sh);
 
-    virtual ~XmlHandler();
+    ~XmlHandler() override;
 
     XmlHandler &operator=(const XmlHandler &sh);
 
@@ -76,7 +76,7 @@ class XmlHandler : public TObject
     Int_t mEndIdRunRange;   // end run corresponding to the request
     TString mOCDBFolder;  // OCDB folder corresponding to the request
 
-  ClassDef(XmlHandler, 0) // The XML file handler for the OCDB
+  ClassDefOverride(XmlHandler, 0) // The XML file handler for the OCDB
 };
 }
 }

--- a/Common/Field/include/Field/MagFieldContFact.h
+++ b/Common/Field/include/Field/MagFieldContFact.h
@@ -23,10 +23,10 @@ class  MagFieldContFact : public FairContFact
 
   public:
     MagFieldContFact();
-    ~MagFieldContFact() = default;
-    FairParSet* createContainer(FairContainer*);
+    ~MagFieldContFact() override = default;
+    FairParSet* createContainer(FairContainer*) override;
     
-    ClassDef(MagFieldContFact, 0) // Factory for Magnetic field parameters containers
+    ClassDefOverride(MagFieldContFact, 0) // Factory for Magnetic field parameters containers
 };
 
 }

--- a/Common/Field/include/Field/MagFieldFact.h
+++ b/Common/Field/include/Field/MagFieldFact.h
@@ -19,9 +19,9 @@ class MagFieldFact : public FairFieldFactory
 
  public:
   MagFieldFact();
-  virtual ~MagFieldFact();
-  virtual FairField* createFairField();
-  virtual void SetParm();
+  ~MagFieldFact() override;
+  FairField* createFairField() override;
+  void SetParm() override;
   
  protected:
   MagFieldParam* mFieldPar;
@@ -30,7 +30,7 @@ class MagFieldFact : public FairFieldFactory
   MagFieldFact(const MagFieldFact&);
   MagFieldFact& operator=(const MagFieldFact&);
 
-  ClassDef(MagFieldFact,1)
+  ClassDefOverride(MagFieldFact,1)
 };
 
 }

--- a/Common/Field/include/Field/MagFieldParam.h
+++ b/Common/Field/include/Field/MagFieldParam.h
@@ -41,8 +41,8 @@ class MagFieldParam : public FairParGenericSet
     Double_t                  GetMaxField()   const {return mMaxField;}
     const char*               GetMapPath()    const {return mMapPath.Data();}
 
-    virtual void   putParams(FairParamList* list);
-    virtual Bool_t getParams(FairParamList* list);
+    void   putParams(FairParamList* list) override;
+    Bool_t getParams(FairParamList* list) override;
     
   protected:
     BMap_t     mMapType;  ///< map type ID
@@ -54,7 +54,7 @@ class MagFieldParam : public FairParGenericSet
     Double_t mMaxField;                  ///< max field for geant
     TString  mMapPath;                   ///< path to map file
     
-    ClassDef(MagFieldParam,1)
+    ClassDefOverride(MagFieldParam,1)
 };
 }
 }

--- a/Common/Field/include/Field/MagneticField.h
+++ b/Common/Field/include/Field/MagneticField.h
@@ -58,7 +58,7 @@ class MagneticField : public FairField
     MagneticField &operator=(const MagneticField &src);
 
     /// Default destructor
-    virtual ~MagneticField() = default;
+    ~MagneticField() override = default;
 
     /// real field creation is here
     void CreateField();
@@ -66,33 +66,33 @@ class MagneticField : public FairField
     /// Virtual methods from FairField
 
     /// X component, avoid using since slow
-    virtual Double_t GetBx(Double_t x, Double_t y, Double_t z) {
+    Double_t GetBx(Double_t x, Double_t y, Double_t z) override {
       double xyz[3]={x,y,z},b[3];
       GetFieldValue(xyz,b);
       return b[0];
     } 
 
     /// Y component, avoid using since slow
-    virtual Double_t GetBy(Double_t x, Double_t y, Double_t z) {
+    Double_t GetBy(Double_t x, Double_t y, Double_t z) override {
       double xyz[3]={x,y,z},b[3];
       GetFieldValue(xyz,b);
       return b[1];
     }
 
     /// Z component
-    virtual Double_t GetBz(Double_t x, Double_t y, Double_t z) {
+    Double_t GetBz(Double_t x, Double_t y, Double_t z) override {
       double xyz[3]={x,y,z};
       return getBz(xyz); 
     } 
 
     /// Method to calculate the field at point xyz
-    virtual void GetFieldValue(const Double_t point[3], Double_t* bField);
+    void GetFieldValue(const Double_t point[3], Double_t* bField) override;
 
     /// 3d field query alias for Alias Method to calculate the field at point xyz
-    virtual void GetBxyz(const Double_t p[3], Double_t* b) {Field(p,b);}
+    void GetBxyz(const Double_t p[3], Double_t* b) override {Field(p,b);}
 
     /// Fill Paramater
-    virtual void FillParContainer();
+    void FillParContainer() override;
     
     /// Method to calculate the integral_0^z of br,bt,bz
     void getTPCIntegral(const Double_t *xyz, Double_t *b) const;
@@ -207,7 +207,7 @@ class MagneticField : public FairField
     }
 
     /// Prints short or long info
-    virtual void Print(Option_t *opt) const;
+    void Print(Option_t *opt) const override;
 
     Bool_t loadParameterization();
 
@@ -274,7 +274,7 @@ class MagneticField : public FairField
 
 
     
-    ClassDef(o2::Field::MagneticField,
+    ClassDefOverride(o2::Field::MagneticField,
     3) // Class for all Alice MagField wrapper for measured data + Tosca parameterization
 };
 }

--- a/Common/Field/include/Field/MagneticWrapperChebyshev.h
+++ b/Common/Field/include/Field/MagneticWrapperChebyshev.h
@@ -48,7 +48,7 @@ class MagneticWrapperChebyshev : public TNamed
     /// Copy constructor
     MagneticWrapperChebyshev(const MagneticWrapperChebyshev &src);
 
-    ~MagneticWrapperChebyshev()
+    ~MagneticWrapperChebyshev() override
     {
       Clear();
     }
@@ -60,7 +60,7 @@ class MagneticWrapperChebyshev : public TNamed
     MagneticWrapperChebyshev &operator=(const MagneticWrapperChebyshev &rhs);
 
     /// Clears all dynamic parts
-    virtual void Clear(const Option_t * = "");
+    void Clear(const Option_t * = "") override;
 
     Int_t getNumberOfParametersSol() const
     {
@@ -193,7 +193,7 @@ class MagneticWrapperChebyshev : public TNamed
     }
 
     /// Prints info
-    virtual void Print(Option_t * = "") const;
+    void Print(Option_t * = "") const override;
 
     /// Computes field in cartesian coordinates. If point is outside of the parameterized region
     /// it gets it at closest valid point
@@ -404,7 +404,7 @@ class MagneticWrapperChebyshev : public TNamed
     TObjArray *mParameterizationDipole; ///< Parameterization pieces for Dipole field
 
     FairLogger *mLogger; //!
-    ClassDef(o2::Field::MagneticWrapperChebyshev,
+    ClassDefOverride(o2::Field::MagneticWrapperChebyshev,
     2) // Wrapper class for the set of Chebishev parameterizations of Alice mag.field
 };
 

--- a/Common/MathUtils/include/MathUtils/Chebyshev3D.h
+++ b/Common/MathUtils/include/MathUtils/Chebyshev3D.h
@@ -111,7 +111,7 @@ class Chebyshev3D : public TNamed
                 Bool_t run = kTRUE, const Float_t* precD=nullptr);
 #endif
 
-    ~Chebyshev3D()
+    ~Chebyshev3D() override
     {
       Clear();
     }
@@ -138,7 +138,7 @@ class Chebyshev3D : public TNamed
 
     void evaluateDerivative3D2(const Float_t *par, Float_t dbdrdr[3][3][3]);
 
-    void Print(const Option_t *opt = "") const;
+    void Print(const Option_t *opt = "") const override;
 
     Bool_t isInside(const Float_t *par) const;
 
@@ -195,7 +195,7 @@ class Chebyshev3D : public TNamed
 #endif
 
   protected:
-    void Clear(const Option_t *option = "");
+    void Clear(const Option_t *option = "") override;
 
     void setDimOut(const int d, const float *prec = nullptr);
 
@@ -244,7 +244,7 @@ class Chebyshev3D : public TNamed
 
     static const Float_t sMinimumPrecision; ///< minimum precision allowed
 
-    ClassDef(o2::MathUtils::Chebyshev3D,
+    ClassDefOverride(o2::MathUtils::Chebyshev3D,
     2) // Chebyshev parametrization for 3D->N function
 };
 

--- a/Common/MathUtils/include/MathUtils/Chebyshev3DCalc.h
+++ b/Common/MathUtils/include/MathUtils/Chebyshev3DCalc.h
@@ -36,7 +36,7 @@ class Chebyshev3DCalc : public TNamed
     Chebyshev3DCalc(FILE *stream);
 
     /// Default destructor
-    ~Chebyshev3DCalc()
+    ~Chebyshev3DCalc() override
     {
       Clear();
     }
@@ -45,7 +45,7 @@ class Chebyshev3DCalc : public TNamed
     Chebyshev3DCalc &operator=(const Chebyshev3DCalc &rhs);
 
     /// Prints info
-    void Print(const Option_t *opt = "") const;
+    void Print(const Option_t *opt = "") const override;
 
     /// Loads coefficients from the stream
     void loadData(FILE *stream);
@@ -133,7 +133,7 @@ class Chebyshev3DCalc : public TNamed
     }
 
     /// Deletes all dynamically allocated structures
-    void Clear(const Option_t *option = "");
+    void Clear(const Option_t *option = "") override;
 
     static Float_t chebyshevEvaluation1D(Float_t x, const Float_t *array, int ncf);
 
@@ -179,7 +179,7 @@ class Chebyshev3DCalc : public TNamed
     Float_t *mTemporaryCoefficients2D; //[mNumberOfColumns] temp. coeffs for 2d summation
     Float_t *mTemporaryCoefficients1D; //[mNumberOfRows] temp. coeffs for 1d summation
 
-    ClassDef(o2::MathUtils::Chebyshev3DCalc,
+    ClassDefOverride(o2::MathUtils::Chebyshev3DCalc,
     2) // Class for interpolation of 3D->1 function by Chebyshev parametrization
 };
 

--- a/DataFormats/simulation/include/SimulationDataFormat/MCTrack.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCTrack.h
@@ -38,7 +38,7 @@ class MCTrack : public TObject
     MCTrack(TParticle *particle);
 
     ///  Destructor
-    virtual ~MCTrack();
+    ~MCTrack() override;
 
     ///  Output to screen
     void Print(Int_t iTrack = 0) const;
@@ -153,7 +153,7 @@ class MCTrack : public TObject
 
     Int_t mNumberOfPoints;
 
-  ClassDef(MCTrack, 1);
+  ClassDefOverride(MCTrack, 1);
 };
 
 inline Double_t MCTrack::GetEnergy() const

--- a/DataFormats/simulation/include/SimulationDataFormat/Stack.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/Stack.h
@@ -50,7 +50,7 @@ class Stack : public FairGenericStack
     Stack(Int_t size = 100);
 
     /// Default destructor
-    virtual ~Stack();
+    ~Stack() override;
 
     /// Add a TParticle to the stack.
     /// Declared in TVirtualMCStack
@@ -66,79 +66,79 @@ class Stack : public FairGenericStack
     /// \param ntr Track number (filled by the stack)
     /// \param weight Particle weight
     /// \param is Generation status code (whatever that means)
-    virtual void PushTrack(Int_t toBeDone, Int_t parentID, Int_t pdgCode, Double_t px, Double_t py, Double_t pz,
+    void PushTrack(Int_t toBeDone, Int_t parentID, Int_t pdgCode, Double_t px, Double_t py, Double_t pz,
                            Double_t e, Double_t vx, Double_t vy, Double_t vz, Double_t time, Double_t polx,
                            Double_t poly,
-                           Double_t polz, TMCProcess proc, Int_t &ntr, Double_t weight, Int_t is);
+                           Double_t polz, TMCProcess proc, Int_t &ntr, Double_t weight, Int_t is) override;
 
-    virtual void PushTrack(Int_t toBeDone, Int_t parentID, Int_t pdgCode, Double_t px, Double_t py, Double_t pz,
+    void PushTrack(Int_t toBeDone, Int_t parentID, Int_t pdgCode, Double_t px, Double_t py, Double_t pz,
                            Double_t e, Double_t vx, Double_t vy, Double_t vz, Double_t time, Double_t polx,
                            Double_t poly,
-                           Double_t polz, TMCProcess proc, Int_t &ntr, Double_t weight, Int_t is, Int_t secondParentId);
+                           Double_t polz, TMCProcess proc, Int_t &ntr, Double_t weight, Int_t is, Int_t secondParentId) override;
 
     /// Get next particle for tracking from the stack.
     /// Declared in TVirtualMCStack
     /// Returns a pointer to the TParticle of the track
     /// \param iTrack index of popped track (return)
-    virtual TParticle *PopNextTrack(Int_t &iTrack);
+    TParticle *PopNextTrack(Int_t &iTrack) override;
 
     /// Get primary particle by index for tracking from stack
     /// Declared in TVirtualMCStack
     /// Returns a pointer to the TParticle of the track
     /// \param iPrim index of primary particle
-    virtual TParticle *PopPrimaryForTracking(Int_t iPrim);
+    TParticle *PopPrimaryForTracking(Int_t iPrim) override;
 
     /// Set the current track number
     /// Declared in TVirtualMCStack
     /// \param iTrack track number
-    virtual void SetCurrentTrack(Int_t iTrack)
+    void SetCurrentTrack(Int_t iTrack) override
     {
       mIndexOfCurrentTrack = iTrack;
     }
 
     /// Get total number of tracks
     /// Declared in TVirtualMCStack
-    virtual Int_t GetNtrack() const
+    Int_t GetNtrack() const override
     {
       return mNumberOfEntriesInParticles;
     }
 
     /// Get number of primary tracks
     /// Declared in TVirtualMCStack
-    virtual Int_t GetNprimary() const
+    Int_t GetNprimary() const override
     {
       return mNumberOfPrimaryParticles;
     }
 
     /// Get the current track's particle
     /// Declared in TVirtualMCStack
-    virtual TParticle *GetCurrentTrack() const;
+    TParticle *GetCurrentTrack() const override;
 
     /// Get the number of the current track
     /// Declared in TVirtualMCStack
-    virtual Int_t GetCurrentTrackNumber() const
+    Int_t GetCurrentTrackNumber() const override
     {
       return mIndexOfCurrentTrack;
     }
 
     /// Get the track number of the parent of the current track
     /// Declared in TVirtualMCStack
-    virtual Int_t GetCurrentParentTrackNumber() const;
+    Int_t GetCurrentParentTrackNumber() const override;
 
     /// Add a TParticle to the mParticles array
     virtual void AddParticle(TParticle *part);
 
     /// Fill the MCTrack output array, applying filter criteria
-    virtual void FillTrackArray();
+    void FillTrackArray() override;
 
     /// Update the track index in the MCTracks and MCPoints
-    virtual void UpdateTrackIndex(TRefArray *detArray = nullptr);
+    void UpdateTrackIndex(TRefArray *detArray = nullptr) override;
 
     /// Resets arrays and stack and deletes particles and tracks
-    virtual void Reset();
+    void Reset() override;
 
     /// Register the MCTrack array to the Root Manager
-    virtual void Register();
+    void Register() override;
 
     /// Output to screen
     /// \param iVerbose: 0=events summary, 1=track info
@@ -147,7 +147,7 @@ class Stack : public FairGenericStack
 
     /// Output to screen (derived from base class)
     /// \param option: 0=events summary, non0=track info
-    virtual void Print(Option_t* option = nullptr) const;
+    void Print(Option_t* option = nullptr) const override;
 
     /// Modifiers
     void StoreSecondaries(Bool_t choice = kTRUE)
@@ -183,13 +183,13 @@ class Stack : public FairGenericStack
     /// Accessors
     TParticle *GetParticle(Int_t trackId) const;
 
-    TClonesArray *GetListOfParticles()
+    TClonesArray *GetListOfParticles() override
     {
       return mParticles;
     }
 
     /// Clone for worker (used in MT mode only)
-    virtual FairGenericStack *CloneStack() const;
+    FairGenericStack *CloneStack() const override;
 
   private:
     FairLogger *mLogger;
@@ -235,7 +235,7 @@ class Stack : public FairGenericStack
 
     Stack &operator=(const Stack &);
 
-  ClassDef(Stack, 1)
+  ClassDefOverride(Stack, 1)
 };
 }
 }

--- a/Detectors/Base/include/DetectorsBase/Detector.h
+++ b/Detectors/Base/include/DetectorsBase/Detector.h
@@ -25,7 +25,7 @@ class Detector : public FairDetector
     Detector();
 
     /// Default Destructor
-    virtual ~Detector();
+    ~Detector() override;
 
     // Module composition
     virtual void Material(Int_t imat, const char *name, Float_t a, Float_t z, Float_t dens, Float_t radl, Float_t absl,
@@ -96,7 +96,7 @@ class Detector : public FairDetector
     static Float_t mDensityFactor; //! factor that is multiplied to all material densities (ONLY for
     // systematic studies)
 
-  ClassDef(Detector, 0) // Base class for ALICE Modules
+  ClassDefOverride(Detector, 0) // Base class for ALICE Modules
 };
 }
 }

--- a/Detectors/Base/include/DetectorsBase/TrackReference.h
+++ b/Detectors/Base/include/DetectorsBase/TrackReference.h
@@ -51,8 +51,8 @@ class TrackReference : public TObject
     TrackReference(const TrackReference &tr);
 
     /// Default Destructor
-    virtual ~TrackReference()
-    = default;
+    ~TrackReference()
+    override = default;
 
     // static AliExternalTrackParam * MakeTrack(const TrackReference *ref, Double_t mass);
     virtual Int_t GetTrack() const
@@ -212,7 +212,7 @@ class TrackReference : public TObject
       return kTRUE;
     }
 
-    Int_t Compare(const TObject *obj) const
+    Int_t Compare(const TObject *obj) const override
     {
       Int_t ll = ((TrackReference *) obj)->GetTrack();
       if (ll < mTrackNumber) {
@@ -224,7 +224,7 @@ class TrackReference : public TObject
       return 0;
     }
 
-    virtual void Print(Option_t *opt = "") const;
+    void Print(Option_t *opt = "") const override;
 
   protected:
     Int_t mTrackNumber;          ///< Track number
@@ -238,7 +238,7 @@ class TrackReference : public TObject
     Float_t mTof;                ///< time of flight in cm
     Int_t mUserId;               ///< optional Id defined by user
     Int_t mDetectorId;           ///< Detector Id
-  ClassDef(TrackReference, 1)  // Base class for all Alice track references
+  ClassDefOverride(TrackReference, 1)  // Base class for all Alice track references
 };
 }
 }

--- a/Detectors/EMCAL/base/include/EMCALBase/Digit.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/Digit.h
@@ -20,7 +20,7 @@ namespace o2 {
       Digit() = default;
       
       Digit(Int_t module, Int_t tower, Double_t amplitude, Double_t time);
-      virtual ~Digit() = default;
+      ~Digit() override = default;
       
       bool operator<(const Digit &ref) const;
       
@@ -47,7 +47,7 @@ namespace o2 {
       Int_t             mTower;                 ///< Tower index inside supermodule
       Double_t          mAmplitude;             ///< Amplitude
       
-      ClassDef(Digit, 1);
+      ClassDefOverride(Digit, 1);
     };
     
     std::ostream &operator<<(std::ostream &stream, const Digit &dig);

--- a/Detectors/EMCAL/base/include/EMCALBase/Point.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/Point.h
@@ -59,7 +59,7 @@ namespace o2 {
       Point operator+(const Point &rhs) const;
       
       /// \brief Destructor
-      virtual ~Point() = default;
+      ~Point() override = default;
       
       /// \brief Get the initial energy of the primary particle entering EMCAL
       /// \return Energy of the primary particle entering EMCAL
@@ -96,7 +96,7 @@ namespace o2 {
       Int_t             mParent;            ///< Parent particle that entered the EMCAL
       Double32_t        mInitialEnergy;     ///< Energy of the parent particle that entered the EMCAL
       
-      ClassDef(Point, 1);
+      ClassDefOverride(Point, 1);
     };
     
     std::ostream &operator<<(std::ostream &stream, const Point &point);

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/Detector.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/Detector.h
@@ -25,20 +25,20 @@ namespace o2 {
       
       Detector(const char* Name, Bool_t Active);
       
-      virtual ~Detector() = default;
+      ~Detector() override = default;
       
-      virtual void   Initialize() final;
+      void   Initialize() final;
       
-      virtual Bool_t ProcessHits( FairVolume* v=nullptr) final;
+      Bool_t ProcessHits( FairVolume* v=nullptr) final;
       
       Point *AddHit(Int_t shunt, Int_t trackID, Int_t parentID, Int_t primary, Double_t initialEnergy,
                     Int_t detID, const Point3D<float> &pos, const Vector3D<float> &mom, Double_t time, Double_t length);
       
-      virtual void   Register();
+      void   Register() override;
       
-      virtual TClonesArray* GetCollection(Int_t iColl) const final;
+      TClonesArray* GetCollection(Int_t iColl) const final;
       
-      virtual void   Reset() final;
+      void   Reset() final;
       
     protected:
       
@@ -48,7 +48,7 @@ namespace o2 {
     
       TClonesArray        *mPointCollection;            ///< Collection of EMCAL points
       
-      ClassDef(Detector, 1)
+      ClassDefOverride(Detector, 1)
     };
   }
 }

--- a/Detectors/ITSMFT/ITS/base/include/ITSBase/ContainerFactory.h
+++ b/Detectors/ITSMFT/ITS/base/include/ITSBase/ContainerFactory.h
@@ -28,14 +28,14 @@ class ContainerFactory : public FairContFact
   ContainerFactory();
 
   /// Default destructor
-  ~ContainerFactory() = default;
+  ~ContainerFactory() override = default;
   /// Calls the constructor of the corresponding parameter container.
   /// For an actual context, which is not an empty string and not
   /// the default context
   /// of this container, the name is concatinated with the context.
-  FairParSet* createContainer(FairContainer*);
+  FairParSet* createContainer(FairContainer*) override;
 
-  ClassDef(ContainerFactory, 0) // Factory for all AliceO2 ITS parameter containers
+  ClassDefOverride(ContainerFactory, 0) // Factory for all AliceO2 ITS parameter containers
 };
 }
 }

--- a/Detectors/ITSMFT/ITS/base/include/ITSBase/GeometryManager.h
+++ b/Detectors/ITSMFT/ITS/base/include/ITSBase/GeometryManager.h
@@ -56,7 +56,7 @@ class GeometryManager : public TObject
   static Bool_t getOriginalGlobalMatrix(const char* symname, TGeoHMatrix& m);
 
   /// Default destructor
-  ~GeometryManager();
+  ~GeometryManager() override;
 
  private:
   /// Default constructor
@@ -69,7 +69,7 @@ class GeometryManager : public TObject
 
   static TGeoManager* mGeometry;
 
-  ClassDef(GeometryManager, 0); // Manager of geometry information for alignment
+  ClassDefOverride(GeometryManager, 0); // Manager of geometry information for alignment
 };
 }
 }

--- a/Detectors/ITSMFT/ITS/base/include/ITSBase/GeometryTGeo.h
+++ b/Detectors/ITSMFT/ITS/base/include/ITSBase/GeometryTGeo.h
@@ -57,7 +57,7 @@ class GeometryTGeo : public TObject
   GeometryTGeo(Bool_t build = kFALSE, Bool_t loadSegmentationsentations = kTRUE);
 
   /// Default destructor
-  virtual ~GeometryTGeo();
+  ~GeometryTGeo() override;
 
   GeometryTGeo(const GeometryTGeo& src);
 
@@ -220,7 +220,7 @@ class GeometryTGeo : public TObject
   const o2::ITSMFT::Segmentation* getSegmentation(Int_t lr) const;
 
   TObjArray* getSegmentations() const { return (TObjArray*)mSegmentations; }
-  virtual void Print(Option_t* opt = "") const;
+  void Print(Option_t* opt = "") const override;
 
   static UInt_t getUIDShift() { return mUIDShift; }
   static void setUIDShift(UInt_t s = 16) { mUIDShift = s < 16 ? s : 16; }
@@ -356,7 +356,7 @@ class GeometryTGeo : public TObject
 
   static TString mSegmentationFileName; ///< file name for segmentations
 
-  ClassDef(GeometryTGeo, 1) // ITS geometry based on TGeo
+  ClassDefOverride(GeometryTGeo, 1) // ITS geometry based on TGeo
 };
 
 /// Returns ymbolic name

--- a/Detectors/ITSMFT/ITS/base/include/ITSBase/MisalignmentParameter.h
+++ b/Detectors/ITSMFT/ITS/base/include/ITSBase/MisalignmentParameter.h
@@ -23,13 +23,13 @@ class MisalignmentParameter : public FairParGenericSet
                         const char* title = "Misalignment parameter for AliceO2ITSHitProducerIdealMisallign Parameters",
                         const char* context = "TestDefaultContext");
 
-  ~MisalignmentParameter();
+  ~MisalignmentParameter() override;
 
   void Clear();
 
-  void putParams(FairParamList*);
+  void putParams(FairParamList*) override;
 
-  Bool_t getParams(FairParamList*);
+  Bool_t getParams(FairParamList*) override;
 
   TArrayD getShiftX() { return mShiftX; }
   TArrayD getShiftY() { return mShiftY; }
@@ -51,7 +51,7 @@ class MisalignmentParameter : public FairParGenericSet
 
   MisalignmentParameter& operator=(const MisalignmentParameter&);
 
-  ClassDef(MisalignmentParameter, 1)
+  ClassDefOverride(MisalignmentParameter, 1)
 };
 }
 }

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/Cluster.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/Cluster.h
@@ -21,7 +21,7 @@ class Cluster : public o2::ITSMFT::Cluster
  public:
   Cluster();
   Cluster(const Cluster& cluster);
-  virtual ~Cluster();
+  ~Cluster() override;
 
   Cluster& operator=(const Cluster& cluster) = delete;
 
@@ -54,14 +54,14 @@ class Cluster : public o2::ITSMFT::Cluster
   //
   virtual Bool_t isSortable() const { return kTRUE; }
   virtual Bool_t isEqual(const TObject* obj) const;
-  virtual Int_t Compare(const TObject* obj) const;
+  Int_t Compare(const TObject* obj) const override;
   //
  protected:
   //
   static UInt_t sMode;        //!< general mode (sorting mode etc)
   static GeometryTGeo* sGeom; //!< pointer on the geometry data
 
-  ClassDef(Cluster, 1)
+  ClassDefOverride(Cluster, 1)
 };
 }
 }

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTrack.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTrack.h
@@ -24,7 +24,7 @@ class CookedTrack : public TObject
   CookedTrack(float x, float alpha, const std::array<float,o2::Base::Track::kNParams> &par, const std::array<float,o2::Base::Track::kCovMatSize> &cov);
   CookedTrack(const CookedTrack& t);
   CookedTrack& operator=(const CookedTrack& tr);
-  virtual ~CookedTrack();
+  ~CookedTrack() override;
 
   // These functions must be provided
   Double_t getPredictedChi2(const Cluster* c) const;
@@ -66,7 +66,7 @@ class CookedTrack : public TObject
   Double_t mChi2;            ///< Chi2 for this track
   std::vector<Int_t> mIndex; ///< Indices of associated clusters
 
-  ClassDef(CookedTrack, 1)
+  ClassDefOverride(CookedTrack, 1)
 };
 }
 }

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTrackerTask.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTrackerTask.h
@@ -20,10 +20,10 @@ class CookedTrackerTask : public FairTask
 {
  public:
   CookedTrackerTask(Int_t nThreads=1);
-  virtual ~CookedTrackerTask();
+  ~CookedTrackerTask() override;
 
-  virtual InitStatus Init();
-  virtual void Exec(Option_t* option);
+  InitStatus Init() override;
+  void Exec(Option_t* option) override;
   void setBz(Double_t bz) { mTracker.setBz(bz); }
 
  private:
@@ -34,7 +34,7 @@ class CookedTrackerTask : public FairTask
   const TClonesArray* mClustersArray;   ///< Array of clusters
   TClonesArray* mTracksArray; ///< Array of tracks
 
-  ClassDef(CookedTrackerTask, 1)
+  ClassDefOverride(CookedTrackerTask, 1)
 };
 }
 }

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/TrivialClustererTask.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/TrivialClustererTask.h
@@ -19,10 +19,10 @@ class TrivialClustererTask : public FairTask
 {
  public:
   TrivialClustererTask();
-  virtual ~TrivialClustererTask();
+  ~TrivialClustererTask() override;
 
-  virtual InitStatus Init();
-  virtual void Exec(Option_t* option);
+  InitStatus Init() override;
+  void Exec(Option_t* option) override;
 
  private:
   GeometryTGeo mGeometry; ///< ITS geometry
@@ -31,7 +31,7 @@ class TrivialClustererTask : public FairTask
   TClonesArray* mDigitsArray;   ///< Array of digits
   TClonesArray* mClustersArray; ///< Array of clusters
 
-  ClassDef(TrivialClustererTask, 2)
+  ClassDefOverride(TrivialClustererTask, 2)
 };
 }
 }

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
@@ -59,25 +59,25 @@ class Detector : public o2::Base::Detector
     Detector();
 
     /// Default destructor
-    virtual ~Detector();
+    ~Detector() override;
 
     /// Initialization of the detector is done here
-    virtual void Initialize();
+    void Initialize() override;
 
     /// This method is called for each step during simulation (see FairMCApplication::Stepping())
-    virtual Bool_t ProcessHits(FairVolume *v = nullptr);
+    Bool_t ProcessHits(FairVolume *v = nullptr) override;
 
     /// Registers the produced collections in FAIRRootManager
-    virtual void Register();
+    void Register() override;
 
     /// Gets the produced collections
-    virtual TClonesArray *GetCollection(Int_t iColl) const;
+    TClonesArray *GetCollection(Int_t iColl) const override;
 
     /// Has to be called after each event to reset the containers
-    virtual void Reset();
+    void Reset() override;
 
     /// Base class to create the detector geometry
-    void ConstructGeometry();
+    void ConstructGeometry() override;
 
     /// Creates the Service Barrel (as a simple cylinder) for IB and OB
     /// \param innerBarrel if true, build IB service barrel, otherwise for OB
@@ -102,8 +102,8 @@ class Detector : public o2::Base::Detector
     /// \param dthick detector thickness (if omitted, defaults to 0)
     /// \param dettypeID ??
     /// \param buildLevel (if 0, all geometry is build, used for material budget studies)
-    virtual void defineLayer(Int_t nlay, Double_t phi0, Double_t r, Double_t zlen, Int_t nladd, Int_t nmod,
-                             Double_t lthick = 0., Double_t dthick = 0., UInt_t detType = 0, Int_t buildFlag = 0);
+    void defineLayer(Int_t nlay, Double_t phi0, Double_t r, Double_t zlen, Int_t nladd, Int_t nmod,
+                             Double_t lthick = 0., Double_t dthick = 0., UInt_t detType = 0, Int_t buildFlag = 0) override;
 
     /// Sets the layer parameters for a "turbo" layer
     /// (i.e. a layer whose staves overlap in phi)
@@ -120,9 +120,9 @@ class Detector : public o2::Base::Detector
     /// \param dthick detector thickness (if omitted, defaults to 0)
     /// \param dettypeID ??
     /// \param buildLevel (if 0, all geometry is build, used for material budget studies)
-    virtual void defineLayerTurbo(Int_t nlay, Double_t phi0, Double_t r, Double_t zlen, Int_t nladd, Int_t nmod,
+    void defineLayerTurbo(Int_t nlay, Double_t phi0, Double_t r, Double_t zlen, Int_t nladd, Int_t nmod,
                                   Double_t width, Double_t tilt, Double_t lthick = 0., Double_t dthick = 0.,
-                                  UInt_t detType = 0, Int_t buildFlag = 0);
+                                  UInt_t detType = 0, Int_t buildFlag = 0) override;
 
     /// Gets the layer parameters
     /// \param nlay layer number
@@ -147,27 +147,27 @@ class Detector : public o2::Base::Detector
 				   unsigned char startStatus, unsigned char endStatus);
 
     /// Book arrays for wrapper volumes
-    virtual void setNumberOfWrapperVolumes(Int_t n);
+    void setNumberOfWrapperVolumes(Int_t n) override;
 
     /// Set per wrapper volume parameters
-    virtual void defineWrapperVolume(Int_t id, Double_t rmin, Double_t rmax, Double_t zspan);
+    void defineWrapperVolume(Int_t id, Double_t rmin, Double_t rmax, Double_t zspan) override;
 
     // The following methods can be implemented if you need to make
     // any optional action in your detector during the transport
 
-    virtual void CopyClones(TClonesArray *cl1, TClonesArray *cl2, Int_t offset)
+    void CopyClones(TClonesArray *cl1, TClonesArray *cl2, Int_t offset) override
     {
       ;
     }
 
-    virtual void SetSpecialPhysicsCuts()
+    void SetSpecialPhysicsCuts() override
     {
       ;
     }
 
-    virtual void EndOfEvent();
+    void EndOfEvent() override;
 
-    virtual void FinishPrimary()
+    void FinishPrimary() override
     {
       ;
     }
@@ -177,22 +177,22 @@ class Detector : public o2::Base::Detector
       ;
     }
 
-    virtual void BeginPrimary()
+    void BeginPrimary() override
     {
       ;
     }
 
-    virtual void PostTrack()
+    void PostTrack() override
     {
       ;
     }
 
-    virtual void PreTrack()
+    void PreTrack() override
     {
       ;
     }
 
-    virtual void BeginEvent()
+    void BeginEvent() override
     {
       ;
     }
@@ -237,7 +237,7 @@ class Detector : public o2::Base::Detector
     }
 
     /// Clone this object (used in MT mode only)
-    virtual FairModule *CloneModule() const;
+    FairModule *CloneModule() const override;
 
     GeometryTGeo *mGeometryTGeo; //! access to geometry details
 
@@ -310,7 +310,7 @@ class Detector : public o2::Base::Detector
     Model mStaveModelInnerBarrel; //! The stave model for the Inner Barrel
     Model mStaveModelOuterBarrel; //! The stave model for the Outer Barrel
 
-  ClassDef(Detector, 1)
+  ClassDefOverride(Detector, 1)
 };
 
 // Input and output function for standard C++ input/output.

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/DigitWriteoutBuffer.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/DigitWriteoutBuffer.h
@@ -24,21 +24,21 @@ class DigitWriteoutBuffer : public FairWriteoutBuffer
 
     DigitWriteoutBuffer(TString branchname, TString foldername, Bool_t persistance);
 
-    virtual ~DigitWriteoutBuffer();
+    ~DigitWriteoutBuffer() override;
 
     // Implementation of virtual function required by the interface
-    void AddNewDataToTClonesArray(FairTimeStamp *);
+    void AddNewDataToTClonesArray(FairTimeStamp *) override;
 
-    virtual double FindTimeForData(FairTimeStamp *);
+    double FindTimeForData(FairTimeStamp *) override;
 
-    virtual void FillDataMap(FairTimeStamp *data, double activeTime);
+    void FillDataMap(FairTimeStamp *data, double activeTime) override;
 
-    virtual void EraseDataFromDataMap(FairTimeStamp *data);
+    void EraseDataFromDataMap(FairTimeStamp *data) override;
 
   protected:
     std::map<o2::ITSMFT::Digit, double> mData_map;
 
-  ClassDef(DigitWriteoutBuffer, 1);
+  ClassDefOverride(DigitWriteoutBuffer, 1);
 };
 }
 }

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Digitizer.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Digitizer.h
@@ -23,7 +23,7 @@ namespace o2
     {
     public:
       Digitizer();
-      ~Digitizer();
+      ~Digitizer() override;
 
       void init(Bool_t build = kTRUE);
 
@@ -43,7 +43,7 @@ namespace o2
       std::vector<o2::ITSMFT::SimulationAlpide> mSimulations; ///< Array of chips response simulations
       DigitContainer mDigitContainer;             ///< Internal digit storage
 
-      ClassDef(Digitizer, 2);
+      ClassDefOverride(Digitizer, 2);
     };
   }
 }

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/DigitizerTask.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/DigitizerTask.h
@@ -35,11 +35,11 @@ namespace o2
     public:
       DigitizerTask(Bool_t useAlpide = kFALSE);
 
-      virtual ~DigitizerTask();
+      ~DigitizerTask() override;
 
-      virtual InitStatus Init();
+      InitStatus Init() override;
 
-      virtual void Exec(Option_t* option);
+      void Exec(Option_t* option) override;
 
       Digitizer& getDigitizer() { return mDigitizer; }
     private:
@@ -49,7 +49,7 @@ namespace o2
       TClonesArray* mPointsArray; ///< Array of MC hits
       TClonesArray* mDigitsArray; ///< Array of digits
 
-      ClassDef(DigitizerTask, 1)
+      ClassDefOverride(DigitizerTask, 1)
     };
   }
 }

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/GeometryHandler.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/GeometryHandler.h
@@ -29,7 +29,7 @@ class GeometryHandler : public TObject
 
     /// Default destructor
     ~GeometryHandler()
-    = default;
+    override = default;
 
     Int_t getUniqueDetectorId();
 
@@ -86,7 +86,7 @@ class GeometryHandler : public TObject
 
     GeometryHandler operator=(const GeometryHandler &);
 
-  ClassDef(GeometryHandler, 1)
+  ClassDefOverride(GeometryHandler, 1)
 };
 }
 }

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/V11Geometry.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/V11Geometry.h
@@ -34,8 +34,8 @@ class V11Geometry : public TObject
     V11Geometry(Int_t debug) : mDebug(debug)
     { };
 
-    virtual ~V11Geometry()
-    = default;
+    ~V11Geometry()
+    override = default;
 
     /// Sets the debug flag for debugging output
     void setDebug(Int_t level = 5)
@@ -441,7 +441,7 @@ class V11Geometry : public TObject
     Double_t angleForRoundedCorners1(Double_t dx, Double_t dy, Double_t sdr) const;
 
     Int_t mDebug;            //! Debug flag/level
-  ClassDef(V11Geometry, 1) // Base class for ITS v11 geometry
+  ClassDefOverride(V11Geometry, 1) // Base class for ITS v11 geometry
 };
 }
 }

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/V1Layer.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/V1Layer.h
@@ -51,7 +51,7 @@ class V1Layer : public V11Geometry
     V1Layer &operator=(const V1Layer &source);
 
     /// Default destructor
-    virtual ~V1Layer();
+    ~V1Layer() override;
 
     Bool_t isTurbo() const
     {
@@ -397,7 +397,7 @@ class V1Layer : public V11Geometry
     static const Double_t sOBSFBotBeamAngle;    ///< OB SF bottom beam angle
     static const Double_t sOBSFrameBeamSidePhi; ///< OB SF side beam angle
 
-  ClassDef(V1Layer, 0) // ITS v1 geometry
+  ClassDefOverride(V1Layer, 0) // ITS v1 geometry
 };
 }
 }

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/Chip.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/Chip.h
@@ -25,14 +25,14 @@ public:
   Chip();
   Chip(ChipSegmentation *segmentation, const char * ladderName);
   
-  virtual ~Chip();
+  ~Chip() override;
   
   TGeoVolume * CreateVolume();
   void GetPosition(LadderSegmentation * ladderSeg, Int_t iChip, Double_t *pos);
 
 private:
   
-  ClassDef(Chip, 1);
+  ClassDefOverride(Chip, 1);
 
 };
 

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/ChipSegmentation.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/ChipSegmentation.h
@@ -18,8 +18,8 @@ public:
   ChipSegmentation();
   ChipSegmentation(UInt_t uniqueID);
   
-  virtual ~ChipSegmentation() = default;
-  virtual void Clear(const Option_t* /*opt*/) {;}
+  ~ChipSegmentation() override = default;
+  void Clear(const Option_t* /*opt*/) override {;}
   virtual void Print(Option_t* /*option*/);
 
   /// \brief Transform (x,y) Hit coordinate into Pixel ID on the matrix
@@ -27,7 +27,7 @@ public:
   
 private:
   
-  ClassDef(ChipSegmentation, 1);
+  ClassDefOverride(ChipSegmentation, 1);
 
 };
 

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/Constants.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/Constants.h
@@ -78,12 +78,12 @@ public:
 protected:
 
   Constants() : TObject() {}
-  virtual ~Constants() = default;
+  ~Constants() override = default;
 
   static Double_t  sDiskThicknessInX0[sNDisks]; ///< default disk thickness in X0 for reconstruction
   static Double_t  sPlaneZPos[2*sNDisks]; ///< default Plane Z position for reconstruction
 
-  ClassDef(Constants, 1);
+  ClassDefOverride(Constants, 1);
 
 };
 

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/Flex.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/Flex.h
@@ -19,7 +19,7 @@ public:
 
   Flex();
   Flex(LadderSegmentation *ladder);
-  virtual ~Flex();
+  ~Flex() override;
   TGeoVolumeAssembly*  MakeFlex(Int_t nbsensors, Double_t length);
   void Make_ElectricComponents(TGeoVolumeAssembly*  flex, Int_t nbsensors, Double_t length, Double_t zvarnish);
 
@@ -34,7 +34,7 @@ private:
   Double_t *mFlexOrigin;
   LadderSegmentation * mLadderSeg;
 
-  ClassDef(Flex,1)
+  ClassDefOverride(Flex,1)
 
 };
 

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/Geometry.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/Geometry.h
@@ -66,7 +66,7 @@ class Geometry : public TNamed {
 
   static Geometry* Instance();
 
-  virtual ~Geometry();
+  ~Geometry() override;
 
   void Build();
   
@@ -111,7 +111,7 @@ private:
   Segmentation*    mSegmentation; ///< \brief Segmentation of the detector
   Int_t mSensorVolumeID; ///< \brief ID of the volume describing the CMOS Sensor
 
-  ClassDef(Geometry, 1)
+  ClassDefOverride(Geometry, 1)
 
 };
 

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/GeometryBuilder.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/GeometryBuilder.h
@@ -16,13 +16,13 @@ class GeometryBuilder : public TNamed {
  public:
 
   GeometryBuilder();
-  virtual ~GeometryBuilder();
+  ~GeometryBuilder() override;
 
   void BuildGeometry();
 
  private:
 
-  ClassDef(GeometryBuilder, 1)
+  ClassDefOverride(GeometryBuilder, 1)
 
 };
 

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/GeometryTGeo.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/GeometryTGeo.h
@@ -17,7 +17,7 @@ class GeometryTGeo : public TObject {
 public:
 
   GeometryTGeo();
-  ~GeometryTGeo();
+  ~GeometryTGeo() override;
 
   /// The number of disks
   Int_t GetNofDisks() const { return mNDisks; }
@@ -47,7 +47,7 @@ private:
   static TString sLadderName;      ///< \brief MFT-ladder prefix
   static TString sSensorName;      ///< \brief MFT-sensor (chip) prefix
 
-  ClassDef(GeometryTGeo, 1) // MFT geometry based on TGeo
+  ClassDefOverride(GeometryTGeo, 1) // MFT geometry based on TGeo
 
 };
 

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/HalfCone.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/HalfCone.h
@@ -19,7 +19,7 @@ public:
   
   HalfCone();
   
-  virtual ~HalfCone();
+  ~HalfCone() override;
   
   TGeoVolumeAssembly* CreateHalfCone(Int_t half);
 
@@ -29,7 +29,7 @@ protected:
 
 private:
   
-  ClassDef(HalfCone,1)
+  ClassDefOverride(HalfCone,1)
   
 };
 

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/HalfDetector.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/HalfDetector.h
@@ -21,7 +21,7 @@ public:
   HalfDetector();
   HalfDetector(HalfSegmentation *segmentation);
   
-  virtual ~HalfDetector();
+  ~HalfDetector() override;
   
   /// \brief Returns the Volume holding the Half-MFT
   TGeoVolumeAssembly * GetVolume() {return mHalfVolume;};
@@ -35,7 +35,7 @@ private:
   HalfSegmentation * mSegmentation; ///< \brief Pointer to the half-MFT segmentation
   void CreateHalfDisks();
   
-  ClassDef(HalfDetector, 1);
+  ClassDefOverride(HalfDetector, 1);
 
 };
 

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/HalfDisk.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/HalfDisk.h
@@ -26,7 +26,7 @@ public:
   TGeoVolumeAssembly * CreateHeatExchanger();
   void CreateLadders();
 
-  virtual ~HalfDisk();
+  ~HalfDisk() override;
   
   /// \brief Returns a pointer to the Volume Assembly describing the entire half-disk
   TGeoVolumeAssembly * GetVolume() {return mHalfDiskVolume;};
@@ -38,7 +38,7 @@ private:
   TGeoVolumeAssembly * mHalfDiskVolume;       ///< \brief Half-Disk Volume
   HalfDiskSegmentation * mSegmentation; ///< \brief Virtual Segmentation of the half-disk
 
-  ClassDef(HalfDisk, 1);
+  ClassDefOverride(HalfDisk, 1);
  
 };
 

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/HalfDiskSegmentation.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/HalfDiskSegmentation.h
@@ -24,9 +24,9 @@ public:
   HalfDiskSegmentation(UInt_t uniqueID);
   HalfDiskSegmentation(const HalfDiskSegmentation& pt);
   
-  virtual ~HalfDiskSegmentation();
+  ~HalfDiskSegmentation() override;
 
-  virtual void Clear(const Option_t* /*opt*/);
+  void Clear(const Option_t* /*opt*/) override;
   
   virtual void Print(Option_t* opt="");
   
@@ -57,7 +57,7 @@ private:
 
   TClonesArray *mLadders; ///< \brief Array of pointer to LadderSegmentation
   
-  ClassDef(HalfDiskSegmentation, 1);
+  ClassDefOverride(HalfDiskSegmentation, 1);
 
 };
 

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/HalfSegmentation.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/HalfSegmentation.h
@@ -25,8 +25,8 @@ public:
   HalfSegmentation(const Char_t *initFile, const Short_t id);
   HalfSegmentation(const HalfSegmentation &source);
 
-  virtual ~HalfSegmentation();
-  virtual void Clear(const Option_t* /*opt*/);
+  ~HalfSegmentation() override;
+  void Clear(const Option_t* /*opt*/) override;
   
   Bool_t GetID() const {return (GetUniqueID()>>12);};
   
@@ -41,7 +41,7 @@ private:
 
   TClonesArray *mHalfDisks; ///< \brief Array of pointer to HalfDiskSegmentation
 
-  ClassDef(HalfSegmentation, 1);
+  ClassDefOverride(HalfSegmentation, 1);
   
 };
 

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/HeatExchanger.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/HeatExchanger.h
@@ -20,7 +20,7 @@ class HeatExchanger : public TNamed {
   HeatExchanger();
   HeatExchanger(Double_t Rwater, Double_t DRPipe, Double_t HeatExchangerThickness, Double_t CarbonThickness);
   
-  virtual ~HeatExchanger() = default;
+  ~HeatExchanger() override = default;
   
   TGeoVolumeAssembly* Create(Int_t kHalf, Int_t disk);
 
@@ -108,7 +108,7 @@ class HeatExchanger : public TNamed {
   Double_t mAngle4fifth[4]; // angle of torus for fifth pipe of disk 4
   Double_t mRadius4fifth[4]; // radius of torus for fifth pipe of disk 4
 
-  ClassDef(HeatExchanger, 2);
+  ClassDefOverride(HeatExchanger, 2);
 
 };
 

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/Ladder.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/Ladder.h
@@ -22,7 +22,7 @@ public:
   Ladder();
   Ladder(LadderSegmentation *segmentation);
   
-  virtual ~Ladder();
+  ~Ladder() override;
   
   TGeoVolume * CreateVolume();
   void CreateSensors();
@@ -35,7 +35,7 @@ private:
   Flex      * mFlex;               ///< \brief Flex object (\todo to be removed ?)
   TGeoVolumeAssembly * mLadderVolume;               ///< \brief Pointer to the Volume holding the ladder geometry
   
-  ClassDef(Ladder, 1);
+  ClassDefOverride(Ladder, 1);
 
 };
 

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/LadderSegmentation.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/LadderSegmentation.h
@@ -22,9 +22,9 @@ public:
   LadderSegmentation(UInt_t uniqueID);
   LadderSegmentation(const LadderSegmentation& ladder);
 
-  virtual ~LadderSegmentation() { if(mChips){mChips->Delete(); delete mChips; mChips=nullptr;} }
+  ~LadderSegmentation() override { if(mChips){mChips->Delete(); delete mChips; mChips=nullptr;} }
   virtual void Print(Option_t* opt="");
-  virtual void Clear(const Option_t* /*opt*/) { if(mChips){mChips->Clear();} }
+  void Clear(const Option_t* /*opt*/) override { if(mChips){mChips->Clear();} }
   
   ChipSegmentation* GetSensor(Int_t sensor) const ;
 
@@ -42,7 +42,7 @@ private:
   Int_t mNSensors;      ///< \brief Number of Sensors holded by the ladder
   TClonesArray *mChips; ///< \brief Array of pointer to ChipSegmentation
 
-  ClassDef(LadderSegmentation, 1);
+  ClassDefOverride(LadderSegmentation, 1);
 
 };
 

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/Plane.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/Plane.h
@@ -25,8 +25,8 @@ public:
   Plane(const Plane& pt);
   Plane& operator=(const Plane &source);
   
-  virtual ~Plane();  // destructor
-  virtual void Clear(const Option_t* /*opt*/);
+  ~Plane() override;  // destructor
+  void Clear(const Option_t* /*opt*/) override;
   
   Bool_t Init(Int_t    planeNumber,
 	      Double_t zCenter, 
@@ -86,7 +86,7 @@ private:
 
   Bool_t mHasPixelRectangularPatternAlongY, mPlaneIsOdd;
 
-  ClassDef(Plane, 1)
+  ClassDefOverride(Plane, 1)
 
 };
 

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/Segmentation.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/Segmentation.h
@@ -23,8 +23,8 @@ public:
   Segmentation();
   Segmentation(const Char_t *nameGeomFile);
   
-  virtual ~Segmentation();
-  virtual void Clear(const Option_t* /*opt*/);
+  ~Segmentation() override;
+  void Clear(const Option_t* /*opt*/) override;
 
   /// \brief Returns pointer to the segmentation of the half-MFT
   /// \param iHalf Integer : 0 = Bottom; 1 = Top
@@ -40,7 +40,7 @@ private:
 
   TClonesArray *mHalves; ///< \brief Array of pointer to HalfSegmentation
 
-  ClassDef(Segmentation, 1);
+  ClassDefOverride(Segmentation, 1);
   
 };
 

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/Support.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/Support.h
@@ -21,7 +21,7 @@ public:
   
   Support();
   
-  virtual ~Support();
+  ~Support() override;
   
   TGeoVolumeAssembly* CreateVolume(Int_t half, Int_t disk);
   TGeoVolumeAssembly* CreatePCBs(Int_t half, Int_t disk);
@@ -55,7 +55,7 @@ protected:
 
 private:
   
-  ClassDef(Support,1)
+  ClassDefOverride(Support,1)
   
 };
 

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/VSegmentation.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/VSegmentation.h
@@ -22,7 +22,7 @@ public:
   VSegmentation();
   VSegmentation(const VSegmentation& input);
 
-  virtual ~VSegmentation()= default;
+  ~VSegmentation() override = default;
   
   /// Set Position of the Element. Unit is [cm]
   void SetPosition(const Double_t *pos){
@@ -54,7 +54,7 @@ private:
                                     /// angle phi, then a rotation with theta about the rotated X axis, and
                                     /// finally a rotation with psi about the new Z axis.
   
-  ClassDef(VSegmentation, 1);
+  ClassDefOverride(VSegmentation, 1);
 
 };
 

--- a/Detectors/ITSMFT/MFT/reconstruction/include/MFTReconstruction/FindHits.h
+++ b/Detectors/ITSMFT/MFT/reconstruction/include/MFTReconstruction/FindHits.h
@@ -23,13 +23,13 @@ class FindHits : public FairTask
  public:
 
   FindHits();
-  virtual ~FindHits();
+  ~FindHits() override;
 
   void Reset();
 
-  virtual InitStatus Init();
-  virtual InitStatus ReInit();
-  virtual void Exec(Option_t* opt);
+  InitStatus Init() override;
+  InitStatus ReInit() override;
+  void Exec(Option_t* opt) override;
 
   virtual void InitMQ(TList* tempList);
   virtual void ExecMQ(TList* inputList,TList* outputList);
@@ -50,7 +50,7 @@ class FindHits : public FairTask
   FairMCEventHeader *mMCEventHeader;
   EventHeader *mEventHeader;
 
-  ClassDef(FindHits,1);
+  ClassDefOverride(FindHits,1);
 
 };
 

--- a/Detectors/ITSMFT/MFT/reconstruction/include/MFTReconstruction/FindTracks.h
+++ b/Detectors/ITSMFT/MFT/reconstruction/include/MFTReconstruction/FindTracks.h
@@ -22,13 +22,13 @@ class FindTracks : public FairTask
 
   FindTracks();
   FindTracks(Int_t iVerbose);
-  virtual ~FindTracks();
+  ~FindTracks() override;
 
   void Reset();
 
-  virtual InitStatus Init();
-  virtual InitStatus ReInit();
-  virtual void Exec(Option_t* opt);
+  InitStatus Init() override;
+  InitStatus ReInit() override;
+  void Exec(Option_t* opt) override;
 
   virtual void InitMQ(TList* tempList);
   virtual void ExecMQ(TList* inputList,TList* outputList);
@@ -47,7 +47,7 @@ class FindTracks : public FairTask
 
   EventHeader *mEventHeader;
 
-  ClassDef(FindTracks,1);
+  ClassDefOverride(FindTracks,1);
 
 };
 

--- a/Detectors/ITSMFT/MFT/reconstruction/include/MFTReconstruction/Hit.h
+++ b/Detectors/ITSMFT/MFT/reconstruction/include/MFTReconstruction/Hit.h
@@ -21,14 +21,14 @@ class Hit : public FairHit
   Hit();
   Hit(Int_t detID, TVector3& pos, TVector3& dpos, Int_t mcindex);
   
-  virtual ~Hit();
+  ~Hit() override;
   
  private:
   
   Hit(const Hit&);
   Hit operator=(const Hit&);
 
-  ClassDef(Hit,1);
+  ClassDefOverride(Hit,1);
 
 };
 

--- a/Detectors/ITSMFT/MFT/reconstruction/include/MFTReconstruction/Track.h
+++ b/Detectors/ITSMFT/MFT/reconstruction/include/MFTReconstruction/Track.h
@@ -17,7 +17,7 @@ class Track : public FairTrackParam
  public:
 
   Track();
-  virtual ~Track();
+  ~Track() override;
 
   Track(const Track& track);
 
@@ -25,7 +25,7 @@ class Track : public FairTrackParam
 
   Track& operator=(const Track& track);
 
-  ClassDef(Track,1);
+  ClassDefOverride(Track,1);
 
 };
 

--- a/Detectors/ITSMFT/MFT/reconstruction/include/MFTReconstruction/devices/FileSink.h
+++ b/Detectors/ITSMFT/MFT/reconstruction/include/MFTReconstruction/devices/FileSink.h
@@ -18,7 +18,7 @@ class FileSink : public FairMQDevice
  public:
 
   FileSink();
-  virtual ~FileSink();
+  ~FileSink() override;
   
   void SetOutputFileName(std::string tempString) { mFileName = tempString; }
   void AddOutputBranch  (std::string classString, std::string branchString) 
@@ -35,7 +35,7 @@ class FileSink : public FairMQDevice
  protected:
 
   bool StoreData(FairMQParts&, int);
-  virtual void Init();
+  void Init() override;
 
  private:
 

--- a/Detectors/ITSMFT/MFT/reconstruction/include/MFTReconstruction/devices/Merger.h
+++ b/Detectors/ITSMFT/MFT/reconstruction/include/MFTReconstruction/devices/Merger.h
@@ -23,13 +23,13 @@ class Merger : public FairMQDevice
  public:
 
   Merger();
-  virtual ~Merger();
+  ~Merger() override;
   
   void SetNofParts(int iparts) { mNofParts = iparts; }
   
  protected:
 
-  virtual void Init();
+  void Init() override;
   bool MergeData(FairMQParts&, int);
   
  private:

--- a/Detectors/ITSMFT/MFT/reconstruction/include/MFTReconstruction/devices/Sampler.h
+++ b/Detectors/ITSMFT/MFT/reconstruction/include/MFTReconstruction/devices/Sampler.h
@@ -19,7 +19,7 @@ class Sampler : public FairMQDevice
  public:
 
   Sampler();
-  virtual ~Sampler();
+  ~Sampler() override;
   
   void AddInputFileName(std::string s) { mFileNames.push_back(s); }
   void AddInputBranchName(std::string s) { mBranchNames.push_back(s); }
@@ -35,10 +35,10 @@ class Sampler : public FairMQDevice
 
  protected:
 
-  virtual bool ConditionalRun();
-  virtual void PreRun();
-  virtual void PostRun();
-  virtual void InitTask();
+  bool ConditionalRun() override;
+  void PreRun() override;
+  void PostRun() override;
+  void InitTask() override;
  
  private:
 

--- a/Detectors/ITSMFT/MFT/reconstruction/include/MFTReconstruction/devices/TaskProcessor.h
+++ b/Detectors/ITSMFT/MFT/reconstruction/include/MFTReconstruction/devices/TaskProcessor.h
@@ -21,7 +21,7 @@ class TaskProcessor : public FairMQDevice
  public:
 
   TaskProcessor();
-  virtual ~TaskProcessor();
+  ~TaskProcessor() override;
 
   void SetDataToKeep(std::string tStr) { mDataToKeep = tStr;}
 
@@ -32,8 +32,8 @@ class TaskProcessor : public FairMQDevice
  protected:
 
   bool ProcessData(FairMQParts&, int);
-  virtual void Init();
-  virtual void PostRun();
+  void Init() override;
+  void PostRun() override;
 
  private:
   

--- a/Detectors/ITSMFT/MFT/simulation/include/MFTSimulation/Detector.h
+++ b/Detectors/ITSMFT/MFT/simulation/include/MFTSimulation/Detector.h
@@ -25,35 +25,35 @@ public:
   Detector();
 
   /// Default destructor
-  virtual ~Detector();
+  ~Detector() override;
 
   Int_t IsVersion() const { return mVersion; }
 
   /// Initialization of the detector is done here
-  virtual void Initialize();
+  void Initialize() override;
 
   /// This method is called for each step during simulation (see FairMCApplication::Stepping())
-  virtual Bool_t ProcessHits(FairVolume* v = nullptr);
+  Bool_t ProcessHits(FairVolume* v = nullptr) override;
 
   /// Has to be called after each event to reset the containers
-  virtual void Reset();
+  void Reset() override;
 
   /// Registers the produced collections in FAIRRootManager
-  virtual void Register(); 
+  void Register() override; 
 
   /// Gets the produced collections
-  virtual TClonesArray* GetCollection(Int_t iColl) const;
+  TClonesArray* GetCollection(Int_t iColl) const override;
 
-  virtual void EndOfEvent();
+  void EndOfEvent() override;
 
-  virtual void CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset) {;}
-  virtual void FinishPrimary() {;}
-  virtual void FinishRun() {;}
-  virtual void BeginPrimary() {;}
-  virtual void PostTrack() {;}
-  virtual void PreTrack() {;}
-  virtual void BeginEvent() {;}
-  virtual void SetSpecialPhysicsCuts() {;}
+  void CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset) override {;}
+  void FinishPrimary() override {;}
+  void FinishRun() override {;}
+  void BeginPrimary() override {;}
+  void PostTrack() override {;}
+  void PreTrack() override {;}
+  void BeginEvent() override {;}
+  void SetSpecialPhysicsCuts() override {;}
 
   GeometryTGeo* GetGeometryTGeo() const { return mGeometryTGeo; }
   
@@ -70,7 +70,7 @@ public:
 
   /// Constructing the geometry
 
-  void ConstructGeometry();  // inherited from FairModule
+  void ConstructGeometry() override;  // inherited from FairModule
   void CreateGeometry();
   void DefineSensitiveVolumes();
 
@@ -88,7 +88,7 @@ private:
 
   Point* AddHit(Int_t trackID, Int_t detID, TVector3 pos, TVector3 mom, Double_t time, Double_t length, Double_t eLoss);
 
-  ClassDef(Detector,1)
+  ClassDefOverride(Detector,1)
 
 };
 

--- a/Detectors/ITSMFT/MFT/simulation/include/MFTSimulation/EventHeader.h
+++ b/Detectors/ITSMFT/MFT/simulation/include/MFTSimulation/EventHeader.h
@@ -17,7 +17,7 @@ class EventHeader : public FairEventHeader
  public:
   
   EventHeader();
-  virtual ~EventHeader();
+  ~EventHeader() override;
 
   void  SetPartNo(Int_t ipart) { mPartNo = ipart;}
   Int_t GetPartNo()            { return mPartNo; }
@@ -36,7 +36,7 @@ class EventHeader : public FairEventHeader
   friend class boost::serialization::access;
 #endif // for BOOST serialization
   
-  ClassDef(EventHeader, 1);
+  ClassDefOverride(EventHeader, 1);
 
 };
 

--- a/Detectors/ITSMFT/MFT/simulation/include/MFTSimulation/Point.h
+++ b/Detectors/ITSMFT/MFT/simulation/include/MFTSimulation/Point.h
@@ -18,11 +18,11 @@ class Point : public FairMCPoint
 
   Point();
   Point(Int_t trackID, Int_t detID, TVector3 pos, TVector3 mom, Double_t time, Double_t length, Double_t eLoss);
-  virtual ~Point();
+  ~Point() override;
 
  private:
 
-  ClassDef(Point, 1)
+  ClassDefOverride(Point, 1)
 
 };
 

--- a/Detectors/ITSMFT/common/base/include/ITSMFTBase/Digit.h
+++ b/Detectors/ITSMFT/common/base/include/ITSMFTBase/Digit.h
@@ -41,7 +41,7 @@ class Digit : public FairTimeStamp
   Digit(UShort_t chipindex, UShort_t row, UShort_t col, Double_t charge, Double_t timestamp);
 
   /// Destructor
-  virtual ~Digit();
+  ~Digit() override;
 
   /// Addition operator
   /// Adds the charge of 2 digits
@@ -90,7 +90,7 @@ class Digit : public FairTimeStamp
   /// Comparison is done based on the chip index and pixel index
   /// @param other The digit to compare with
   /// @return True if digits are equal, false otherwise
-  virtual bool equal(FairTimeStamp* other)
+  bool equal(FairTimeStamp* other) override
   {
     Digit* mydigi = dynamic_cast<Digit*>(other);
     if (mydigi) {
@@ -159,7 +159,7 @@ class Digit : public FairTimeStamp
   Double_t mCharge;    ///< Accumulated charge
   Int_t mLabels[3];    ///< Particle labels associated to this digit
 
-  ClassDef(Digit, 2);
+  ClassDefOverride(Digit, 2);
 };
 }
 }

--- a/Detectors/ITSMFT/common/base/include/ITSMFTBase/SDigit.h
+++ b/Detectors/ITSMFT/common/base/include/ITSMFTBase/SDigit.h
@@ -20,7 +20,7 @@ class SDigit : public TObject
   SDigit(UInt_t chip, UInt_t index, Double_t noise, Int_t roCycle = 0);
   SDigit(const SDigit& source);
   SDigit& operator=(const SDigit& source);
-  virtual ~SDigit() = default;
+  ~SDigit() override = default;
   Double_t getSignal(Int_t i) const { return ((i >= 0 && i < kBuffSize) ? mSignal[i] : 0.0); }
   Double_t getSignal() const { return mTotalSignal; }
   Double_t getSignalAfterElect() const { return mSignalAfterElect; }
@@ -45,9 +45,9 @@ class SDigit : public TObject
   void print(Option_t* option = "") const;
   Int_t read(const char* name) { return TObject::Read(name); }
   //
-  virtual Bool_t IsSortable() const { return kTRUE; }
-  virtual Bool_t IsEqual(const TObject* obj) const { return GetUniqueID() == obj->GetUniqueID(); }
-  virtual Int_t Compare(const TObject* obj) const;
+  Bool_t IsSortable() const override { return kTRUE; }
+  Bool_t IsEqual(const TObject* obj) const override { return GetUniqueID() == obj->GetUniqueID(); }
+  Int_t Compare(const TObject* obj) const override;
   //
   static Int_t getBuffSize() { return kBuffSize; };
   //
@@ -62,7 +62,7 @@ class SDigit : public TObject
   Float_t mNoise;             ///< Total noise, coupling, ...
   Float_t mSignalAfterElect;  ///< Signal after electronics
   //
-  ClassDef(SDigit, 1) // Item list of signals and track numbers
+  ClassDefOverride(SDigit, 1) // Item list of signals and track numbers
 };
 }
 }

--- a/Detectors/ITSMFT/common/base/include/ITSMFTBase/Segmentation.h
+++ b/Detectors/ITSMFT/common/base/include/ITSMFTBase/Segmentation.h
@@ -51,7 +51,7 @@ class Segmentation : public TObject
     }
 
     /// Destructor
-    virtual ~OutOfActiveAreaException() throw() = default;
+    ~OutOfActiveAreaException() throw() override = default;
     /// Get the value for which the exception was raised
     /// @return Value (point in one direction)
     Double_t GetValue() const { return mValue; }
@@ -72,7 +72,7 @@ class Segmentation : public TObject
     /// Provide error message string containing direction,
     /// value of the point, and limits
     /// @return Error message
-    const char* what() const noexcept { return mErrorMessage.c_str(); }
+    const char* what() const noexcept override { return mErrorMessage.c_str(); }
    private:
     std::string mErrorMessage; ///< Error message connected to the exception
     Direction mDirection;      ///< Direction in which the exception was raised
@@ -107,7 +107,7 @@ class Segmentation : public TObject
     }
 
     /// Destructor
-    virtual ~InvalidPixelException() = default;
+    ~InvalidPixelException() override = default;
     /// Get the ID of the pixel which raised the exception
     /// @return ID of the pixel
     Int_t GetPixelID() const { return mValue; }
@@ -122,7 +122,7 @@ class Segmentation : public TObject
     Bool_t IsZ() const { return mDirection == kZ; }
     /// Provide error message string containing direction,
     /// index of the pixel out of range, and the maximum pixel ID
-    const char* what() const noexcept { return mErrorMessage.c_str(); }
+    const char* what() const noexcept override { return mErrorMessage.c_str(); }
    private:
     std::string mErrorMessage; ///< Error message connected to this exception
     Direction mDirection;      ///< Direction in which the pixel index is out of range
@@ -136,7 +136,7 @@ class Segmentation : public TObject
   Segmentation(const Segmentation& source);
 
   /// Default destructor
-  virtual ~Segmentation();
+  ~Segmentation() override;
 
   Segmentation& operator=(const Segmentation& source);
 
@@ -259,7 +259,7 @@ class Segmentation : public TObject
   virtual void printDefaultParameters() const = 0;
 
  protected:
-  virtual void Copy(TObject& obj) const;
+  void Copy(TObject& obj) const override;
 
   Float_t mDx; // SPD: Full width of the detector (x axis)- microns
   // SDD: Drift distance of the 1/2detector (x axis)-microns
@@ -272,7 +272,7 @@ class Segmentation : public TObject
   // SSD: Full thickness of the detector (y axis) -um
   TF1* mCorrection; // correction function
 
-  ClassDef(Segmentation, 1) // Segmentation virtual base class
+  ClassDefOverride(Segmentation, 1) // Segmentation virtual base class
 };
 }
 }

--- a/Detectors/ITSMFT/common/base/include/ITSMFTBase/SegmentationPixel.h
+++ b/Detectors/ITSMFT/common/base/include/ITSMFTBase/SegmentationPixel.h
@@ -30,25 +30,25 @@ class SegmentationPixel : public Segmentation
   //  SegmentationPixel(Option_t *opt="" );
   SegmentationPixel(const SegmentationPixel& source);
 
-  virtual ~SegmentationPixel();
+  ~SegmentationPixel() override;
 
   SegmentationPixel& operator=(const SegmentationPixel& source);
 
-  virtual void Init();
+  void Init() override;
 
-  virtual void setNumberOfPads(Int_t, Int_t) { MayNotUse("SetPadSize"); }
-  virtual Int_t getNumberOfPads() const { return mNumberOfColumns * mNumberOfRows; }
+  void setNumberOfPads(Int_t, Int_t) override { MayNotUse("SetPadSize"); }
+  Int_t getNumberOfPads() const override { return mNumberOfColumns * mNumberOfRows; }
   /// Returns pixel coordinates (ix,iz) for given coordinates (x,z counted from corner of col/row
   /// 0:0). Expects x, z in cm
-  virtual void getPadIxz(Float_t x, Float_t z, Int_t& ix, Int_t& iz) const;
+  void getPadIxz(Float_t x, Float_t z, Int_t& ix, Int_t& iz) const override;
 
   /// Transform from pixel to real local coordinates
   /// Eeturns x, z in cm. wrt corner of col/row 0:0
-  virtual void getPadCxz(Int_t ix, Int_t iz, Float_t& x, Float_t& z) const;
+  void getPadCxz(Int_t ix, Int_t iz, Float_t& x, Float_t& z) const override;
 
   /// Local transformation of real local coordinates (x,z)
   /// Expects x, z in cm (wrt corner of col/row 0:0
-  virtual void getPadTxz(Float_t& x, Float_t& z) const;
+  void getPadTxz(Float_t& x, Float_t& z) const override;
 
   /// Transformation from Geant detector centered local coordinates (cm) to
   /// Pixel cell numbers ix and iz.
@@ -61,7 +61,7 @@ class SegmentationPixel : public Segmentation
   /// the center of the sensitive volulme.
   /// \param Int_t ix Detector x cell coordinate. Has the range 0 <= ix < mNumberOfRows
   /// \param Int_t iz Detector z cell coordinate. Has the range 0 <= iz < mNumberOfColumns
-  virtual Bool_t localToDetector(Float_t x, Float_t z, Int_t& ix, Int_t& iz) const;
+  Bool_t localToDetector(Float_t x, Float_t z, Int_t& ix, Int_t& iz) const override;
 
   /// Transformation from Detector cell coordiantes to Geant detector centered
   /// local coordinates (cm)
@@ -73,7 +73,7 @@ class SegmentationPixel : public Segmentation
   /// center of the sensitive volulme.
   /// If ix and or iz is outside of the segmentation range a value of -0.5*Dx()
   /// or -0.5*Dz() is returned.
-  virtual Bool_t detectorToLocal(Int_t ix, Int_t iz, Float_t& x, Float_t& z) const;
+  Bool_t detectorToLocal(Int_t ix, Int_t iz, Float_t& x, Float_t& z) const override;
 
   /// Transformation from Detector cell coordiantes to Geant detector centered
   /// local coordinates (cm)
@@ -91,22 +91,22 @@ class SegmentationPixel : public Segmentation
   /// and -0.5*dxActive() or -0.5*dzActive() and -0.5*dzActive() are returned.
   virtual void cellBoundries(Int_t ix, Int_t iz, Double_t& xl, Double_t& xu, Double_t& zl, Double_t& zu) const;
 
-  virtual Int_t getNumberOfChips() const { return mNumberOfChips; }
-  virtual Int_t getMaximumChipIndex() const { return mNumberOfChips - 1; }
+  Int_t getNumberOfChips() const override { return mNumberOfChips; }
+  Int_t getMaximumChipIndex() const override { return mNumberOfChips - 1; }
   /// Returns chip number (in range 0-4) starting from local Geant coordinates
-  virtual Int_t getChipFromLocal(Float_t, Float_t zloc) const;
+  Int_t getChipFromLocal(Float_t, Float_t zloc) const override;
 
   /// Returns the number of chips containing a road defined by given local Geant coordinate limits
-  virtual Int_t getChipsInLocalWindow(Int_t* array, Float_t zmin, Float_t zmax, Float_t, Float_t) const;
+  Int_t getChipsInLocalWindow(Int_t* array, Float_t zmin, Float_t zmax, Float_t, Float_t) const override;
 
   /// Returns chip number (in range 0-4) starting from channel number
-  virtual Int_t getChipFromChannel(Int_t, Int_t iz) const;
+  Int_t getChipFromChannel(Int_t, Int_t iz) const override;
 
   /// Returs x pixel pitch for a give pixel
-  virtual Float_t cellSizeX(Int_t ix = 0) const;
+  Float_t cellSizeX(Int_t ix = 0) const override;
 
   /// Returns z pixel pitch for a given pixel (cols starts from 0)
-  virtual Float_t cellSizeZ(Int_t iz) const;
+  Float_t cellSizeZ(Int_t iz) const override;
 
   Float_t dxActive() const { return mDxActive; }
   Float_t dzActive() const { return mDzActive; }
@@ -118,17 +118,17 @@ class SegmentationPixel : public Segmentation
   Float_t getGuardBot() const { return mGuardBottom; }
   Int_t getNumberOfRows() const { return mNumberOfRows; }
   Int_t getNumberOfColumns() const { return mNumberOfColumns; }
-  virtual Int_t numberOfCellsInX() const { return getNumberOfRows(); }
-  virtual Int_t numberOfCellsInZ() const { return getNumberOfColumns(); }
+  Int_t numberOfCellsInX() const override { return getNumberOfRows(); }
+  Int_t numberOfCellsInZ() const override { return getNumberOfColumns(); }
   /// Returns the neighbouring pixels for use in Cluster Finders and the like.
-  virtual void neighbours(Int_t iX, Int_t iZ, Int_t* Nlist, Int_t Xlist[10], Int_t Zlist[10]) const;
+  void neighbours(Int_t iX, Int_t iZ, Int_t* Nlist, Int_t Xlist[10], Int_t Zlist[10]) const override;
 
-  virtual void printDefaultParameters() const
+  void printDefaultParameters() const override
   {
     LOG(WARNING) << "No def. parameters defined as const static data members" << FairLogger::endl;
   }
 
-  virtual void Print(Option_t* option = "") const;
+  void Print(Option_t* option = "") const override;
 
   virtual Int_t getChipTypeID() const { return GetUniqueID(); }
   /// Set matrix of periodic shifts of diod center. Provided arrays must be in the format
@@ -192,7 +192,7 @@ class SegmentationPixel : public Segmentation
 
   static const char* sSegmentationsListName; ///< pattern for segmentations list name
 
-  ClassDef(SegmentationPixel, 1) // Segmentation class upgrade pixels
+  ClassDefOverride(SegmentationPixel, 1) // Segmentation class upgrade pixels
 };
 }
 }

--- a/Detectors/ITSMFT/common/base/include/ITSMFTBase/SensMap.h
+++ b/Detectors/ITSMFT/common/base/include/ITSMFTBase/SensMap.h
@@ -34,7 +34,7 @@ class SensMap : public TObject
   SensMap(const SensMap& source);
   SensMap& operator=(const SensMap& source);
 
-  virtual ~SensMap();
+  ~SensMap() override;
 
   void clear(Option_t* option = "");
   void deleteItem(UInt_t col, UInt_t row, Int_t cycle);
@@ -85,7 +85,7 @@ class SensMap : public TObject
   //
   Bool_t isSortable() const { return kTRUE; }
   Bool_t isEqual(const TObject* obj) const { return GetUniqueID() == obj->GetUniqueID(); }
-  Int_t Compare(const TObject* obj) const
+  Int_t Compare(const TObject* obj) const override
   {
     return (GetUniqueID() < obj->GetUniqueID()) ? -1 : ((GetUniqueID() > obj->GetUniqueID()) ? 1 : 0);
   }
@@ -111,7 +111,7 @@ class SensMap : public TObject
   TClonesArray* mItems; ///< pListItems array
   TBtree* mBTree;       ///< tree for ordered access
   //
-  ClassDef(SensMap, 1) ///< list of sensor signals (should be sortable objects)
+  ClassDefOverride(SensMap, 1) ///< list of sensor signals (should be sortable objects)
 };
 
 //______________________________________________________________________

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Cluster.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Cluster.h
@@ -57,7 +57,7 @@ class Cluster : public FairTimeStamp
  public:
   Cluster();
   Cluster(const Cluster& cluster);
-  virtual ~Cluster();
+  ~Cluster() override;
 
   Cluster& operator=(const Cluster& cluster) = delete;
 
@@ -189,9 +189,9 @@ class Cluster : public FairTimeStamp
   UShort_t mPatternMinCol;            ///< pattern start column
   UChar_t mPattern[kMaxPatternBytes]; ///< cluster topology
   //
-  ClassDef(Cluster, CLUSTER_VERSION + 1)
+  ClassDefOverride(Cluster, CLUSTER_VERSION + 1)
 #else
-  ClassDef(Cluster, CLUSTER_VERSION)
+  ClassDefOverride(Cluster, CLUSTER_VERSION)
 #endif
 };
 //______________________________________________________

--- a/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Chip.h
+++ b/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Chip.h
@@ -55,12 +55,12 @@ class Chip : public TObject
         { }
 
         /// Destructor
-	virtual ~IndexException() throw() {}
+	~IndexException() throw() override {}
 
         /// Build error message
         /// The error message contains the indices stored in the chip and in the hit
         /// @return Error message connected to this exception
-        const char *what() const throw()
+        const char *what() const throw() override
         {
           std::stringstream message;
           message << "Chip ID " << mDetIdHit << " from hit different compared to this ID " << mDetIdChip;
@@ -118,11 +118,11 @@ class Chip : public TObject
     Bool_t operator<(const Chip &other) const;
 
     /// Destructor
-    virtual ~Chip();
+    ~Chip() override;
 
     /// Empties the point container
     /// @param option unused
-    virtual void Clear(Option_t *opt = "");
+    void Clear(Option_t *opt = "") override;
 
     /// Change the chip index
     /// @param index New chip index
@@ -214,7 +214,7 @@ class Chip : public TObject
     std::vector<const Point *>mPoints;        ///< Hits connnected to the given chip
     const TGeoHMatrix *mMat;     ///< Transformation matrix
 
-  ClassDef(Chip, 2);
+  ClassDefOverride(Chip, 2);
 };
 }
 }

--- a/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/ClusterShape.h
+++ b/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/ClusterShape.h
@@ -24,7 +24,7 @@ namespace o2 {
       ClusterShape();
       ClusterShape(UInt_t, UInt_t);
       ClusterShape(UInt_t, UInt_t, const std::vector<UInt_t>&);
-      virtual ~ClusterShape();
+      ~ClusterShape() override;
 
       // Set the number of rows
       inline void SetNRows(UInt_t Nrows) {mNrows = Nrows;}
@@ -101,7 +101,7 @@ namespace o2 {
       UInt_t  mNcols;
       std::vector<UInt_t> mShape;
 
-      ClassDef(ClusterShape,1)
+      ClassDefOverride(ClusterShape,1)
     };
   }
 }

--- a/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Point.h
+++ b/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Point.h
@@ -82,7 +82,7 @@ class Point : public o2::BasicXYZEHit<Float_t,Float_t>
     Bool_t IsAliveStart()    const  { return mTrackStatusStart & kTrackAlive; }
 
     /// Output to screen
-    virtual void Print(const Option_t *opt) const;
+    void Print(const Option_t *opt) const override;
     friend std::ostream &operator<<(std::ostream &of, const Point &point)
     {
       of << "-I- Point: O2its point for track " << point.GetTrackID() << " in detector " << point.GetDetectorID() << std::endl;
@@ -105,7 +105,7 @@ class Point : public o2::BasicXYZEHit<Float_t,Float_t>
     UChar_t mTrackStatusEnd;                  ///< MC status flag at exit
     UChar_t mTrackStatusStart;                ///< MC status at starting point
 
-  ClassDef(Point, 3)
+  ClassDefOverride(Point, 3)
 };
 
 Point::Point(int trackID, unsigned short detID, TVector3 startPos, TVector3 endPos, TVector3 startMom,

--- a/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/SimuClusterShaper.h
+++ b/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/SimuClusterShaper.h
@@ -23,7 +23,7 @@ namespace o2 {
     public:
       SimuClusterShaper();
       SimuClusterShaper(const UInt_t &cs);
-      virtual ~SimuClusterShaper();
+      ~SimuClusterShaper() override;
       void FillClusterRandomly();
       void AddNoisePixel();
 
@@ -44,7 +44,7 @@ namespace o2 {
       UInt_t mNpixOn;
       ClusterShape *mCShape;
 
-      ClassDef(SimuClusterShaper,1)
+      ClassDefOverride(SimuClusterShaper,1)
     };
   }
 }

--- a/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/SimulationAlpide.h
+++ b/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/SimulationAlpide.h
@@ -40,7 +40,7 @@ namespace o2 {
       SimulationAlpide
       (Double_t param[NumberOfParameters], SegmentationPixel *, Chip *);
       SimulationAlpide(const SimulationAlpide&);
-      virtual   ~SimulationAlpide();
+        ~SimulationAlpide() override;
 
       void Init(Double_t param[NumberOfParameters], SegmentationPixel *, Chip *);
 
@@ -66,7 +66,7 @@ namespace o2 {
       SensMap           *mSensMap;  //! Sensor map for hits manipulations
       Chip              *mChip;     //! Chip being processed
 
-      ClassDef(SimulationAlpide,1)   // Simulation of pixel clusters
+      ClassDefOverride(SimulationAlpide,1)   // Simulation of pixel clusters
     };
   }
 }

--- a/Detectors/ITSMFT/test/HitAnalysis/include/HitAnalysis/HitAnalysis.h
+++ b/Detectors/ITSMFT/test/HitAnalysis/include/HitAnalysis/HitAnalysis.h
@@ -36,13 +36,13 @@ class HitAnalysis : public FairTask
   public:
     HitAnalysis();
 
-    virtual ~HitAnalysis();
+    ~HitAnalysis() override;
 
-    virtual InitStatus Init();
+    InitStatus Init() override;
 
-    virtual void Exec(Option_t *option);
+    void Exec(Option_t *option) override;
 
-    virtual void FinishTask();
+    void FinishTask() override;
 
     void SetProcessHits()
     { mProcessChips = kFALSE; }
@@ -70,7 +70,7 @@ class HitAnalysis : public FairTask
     TH1 *mLocalZ1;            ///< Histogram for Hit Z position in local coordinates
     TH1 *mHitCounter;         ///< simple hit counter histogram
 
-  ClassDef(HitAnalysis, 1);
+  ClassDefOverride(HitAnalysis, 1);
 };
 }
 }

--- a/Detectors/Passive/include/DetectorsPassive/Cave.h
+++ b/Detectors/Passive/include/DetectorsPassive/Cave.h
@@ -25,18 +25,18 @@ class Cave : public FairModule
   public:
     Cave(const char* name, const char* Title="Exp Cave");
     Cave();
-    virtual ~Cave();
-    virtual void ConstructGeometry();
+    ~Cave() override;
+    void ConstructGeometry() override;
 
     /// Clone this object (used in MT mode only)
-    virtual FairModule* CloneModule() const;
+    FairModule* CloneModule() const override;
 
   private:
     Cave(const Cave& orig);
     Cave& operator=(const Cave&);
 
     Double_t mWorld[3];
-    ClassDef(o2::Passive::Cave,1) //
+    ClassDefOverride(o2::Passive::Cave,1) //
 };
 }
 }

--- a/Detectors/Passive/include/DetectorsPassive/GeoCave.h
+++ b/Detectors/Passive/include/DetectorsPassive/GeoCave.h
@@ -31,13 +31,13 @@ class  GeoCave : public FairGeoSet
     TString name;
   public:
     GeoCave();
-    ~GeoCave() = default;
-    const char* getModuleName(Int_t) {return name.Data();}
-    Bool_t read(std::fstream&,FairGeoMedia*);
-    void addRefNodes();
-    void write(std::fstream&);
-    void print();
-    ClassDef(o2::Passive::GeoCave,0) // Class for the geometry of CAVE
+    ~GeoCave() override = default;
+    const char* getModuleName(Int_t) override {return name.Data();}
+    Bool_t read(std::fstream&,FairGeoMedia*) override;
+    void addRefNodes() override;
+    void write(std::fstream&) override;
+    void print() override;
+    ClassDefOverride(o2::Passive::GeoCave,0) // Class for the geometry of CAVE
 };
 }
 }

--- a/Detectors/Passive/include/DetectorsPassive/Magnet.h
+++ b/Detectors/Passive/include/DetectorsPassive/Magnet.h
@@ -26,17 +26,17 @@ class Magnet : public FairModule
   public:
     Magnet(const char* name, const char* Title="MY Magnet");
     Magnet();
-    virtual ~Magnet();
-    void ConstructGeometry();
+    ~Magnet() override;
+    void ConstructGeometry() override;
 
     /// Clone this object (used in MT mode only)
-    virtual FairModule* CloneModule() const;
+    FairModule* CloneModule() const override;
 
   private:
     Magnet(const Magnet& orig);
     Magnet& operator=(const Magnet&);
 
-    ClassDef(o2::Passive::Magnet,1)
+    ClassDefOverride(o2::Passive::Magnet,1)
 
 };
 

--- a/Detectors/Passive/include/DetectorsPassive/PassiveContFact.h
+++ b/Detectors/Passive/include/DetectorsPassive/PassiveContFact.h
@@ -29,9 +29,9 @@ class PassiveContFact : public FairContFact
     void setAllContainers();
   public:
     PassiveContFact();
-    virtual ~PassiveContFact() {;}
-    FairParSet* createContainer(FairContainer*);
-    ClassDef(o2::Passive::PassiveContFact,0) // Factory for all Passive parameter containers
+    ~PassiveContFact() override {;}
+    FairParSet* createContainer(FairContainer*) override;
+    ClassDefOverride(o2::Passive::PassiveContFact,0) // Factory for all Passive parameter containers
 };
 }
 }

--- a/Detectors/Passive/include/DetectorsPassive/Pipe.h
+++ b/Detectors/Passive/include/DetectorsPassive/Pipe.h
@@ -26,17 +26,17 @@ class Pipe : public FairModule {
     Pipe(const char * name, const char *Title="Alice Pipe");
     Pipe();
 
-    virtual ~Pipe();
-    virtual void ConstructGeometry();
+    ~Pipe() override;
+    void ConstructGeometry() override;
 
     /// Clone this object (used in MT mode only)
-    virtual FairModule* CloneModule() const;
+    FairModule* CloneModule() const override;
 
   private:
     Pipe(const Pipe& orig);
     Pipe& operator=(const Pipe&);
    
-  ClassDef(Pipe,1) //PIPE
+  ClassDefOverride(Pipe,1) //PIPE
 
 };
 }

--- a/Detectors/TPC/base/include/TPCBase/CalArray.h
+++ b/Detectors/TPC/base/include/TPCBase/CalArray.h
@@ -67,7 +67,7 @@ private:
   PadSubset mPadSubset;       ///< Subset type
   int       mPadSubsetNumber; ///< Number of the pad subset, e.g. ROC 0 is IROC A00
 
-  //ClassDef(CalArray, 1);
+  //ClassDefOverride(CalArray, 1);
 };
 
 // ===| pad region etc. initialisation |========================================

--- a/Detectors/TPC/base/include/TPCBase/ContainerFactory.h
+++ b/Detectors/TPC/base/include/TPCBase/ContainerFactory.h
@@ -18,9 +18,9 @@ class ContainerFactory : public FairContFact
     void setAllContainers();
   public:
     ContainerFactory();
-    ~ContainerFactory() = default;
-    FairParSet* createContainer(FairContainer*);
-    ClassDef( o2::TPC::ContainerFactory,0) // Factory for all tpc parameter containers
+    ~ContainerFactory() override = default;
+    FairParSet* createContainer(FairContainer*) override;
+    ClassDefOverride( o2::TPC::ContainerFactory,0) // Factory for all tpc parameter containers
 };
 }
 }

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/DigitData.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/DigitData.h
@@ -33,7 +33,7 @@ class DigitData : public Digit {
     DigitData(int cru, float charge, int row, int pad, int time);
 
     /// Destructor
-    virtual ~DigitData()= default;
+    ~DigitData() override = default;
 
     /// Get the timeBin of the DigitData
     /// \return timeBin of the DigitData

--- a/Detectors/TPC/simulation/include/TPCSimulation/BoxCluster.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/BoxCluster.h
@@ -43,7 +43,7 @@ namespace o2{
 		 Short_t size);
 
       /// Destructor
-      virtual ~BoxCluster();
+      ~BoxCluster() override;
 
       /// Setter for special Box cluster parameters
       /// @param pad Pad with the maximum charge
@@ -75,7 +75,7 @@ namespace o2{
       Short_t                   mTime;
       Short_t                   mSize;
 
-      ClassDef(BoxCluster, 1);
+      ClassDefOverride(BoxCluster, 1);
     };
   }
 }

--- a/Detectors/TPC/simulation/include/TPCSimulation/BoxClusterer.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/BoxClusterer.h
@@ -23,12 +23,12 @@ namespace o2{
       
       // Should this really be a public member?
       // Maybe better to just call by process
-      void Init();
+      void Init() override;
       
       /// Steer conversion of points to digits
       /// @param digits Container with TPC digits
       /// @return Container with clusters
-      ClusterContainer* Process(TClonesArray *digits);
+      ClusterContainer* Process(TClonesArray *digits) override;
       
     private:
       // To be done
@@ -56,7 +56,7 @@ namespace o2{
       Int_t**   mAllSigBins;   //!<! Array of pointers to the indexes over threshold
       Int_t*    mAllNSigBins;  //!<! Array with number of signals in each row
       
-      ClassDef(BoxClusterer, 1);
+      ClassDefNV(BoxClusterer, 1);
     };
   }
 }

--- a/Detectors/TPC/simulation/include/TPCSimulation/Cluster.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/Cluster.h
@@ -35,7 +35,7 @@ namespace o2{
 	      float padmean, float padsigma, float timemean, float timesigma);
       
       /// Destructor
-      ~Cluster() = default;
+      ~Cluster() override = default;
 
       /// Copy Constructor
       Cluster(const Cluster& other);
@@ -84,7 +84,7 @@ namespace o2{
       float   mTimeMean;
       float   mTimeSigma;
             
-      ClassDef(Cluster, 1);
+      ClassDefOverride(Cluster, 1);
     };
   }
 }

--- a/Detectors/TPC/simulation/include/TPCSimulation/ClustererTask.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/ClustererTask.h
@@ -23,10 +23,10 @@ namespace o2 {
     class ClustererTask : public FairTask{
     public:
       ClustererTask();
-      virtual ~ClustererTask();
+      ~ClustererTask() override;
       
-      virtual InitStatus Init();
-      virtual void Exec(Option_t *option);
+      InitStatus Init() override;
+      void Exec(Option_t *option) override;
 
       enum class ClustererType : int { HW, Box};
       void setClustererEnable(ClustererType type, bool val) {
@@ -65,7 +65,7 @@ namespace o2 {
       TClonesArray        *mClustersArray;
       TClonesArray        *mHwClustersArray;
       
-      ClassDef(ClustererTask, 1)
+      ClassDefOverride(ClustererTask, 1)
     };
   }
 }

--- a/Detectors/TPC/simulation/include/TPCSimulation/Detector.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/Detector.h
@@ -36,28 +36,28 @@ class Detector: public o2::Base::Detector {
     Detector();
 
     /**       destructor     */
-    virtual ~Detector();
+    ~Detector() override;
 
     /**      Initialization of the detector is done here    */
-    virtual void   Initialize();
+    void   Initialize() override;
 
     /**       this method is called for each step during simulation
      *       (see FairMCApplication::Stepping())
     */
 //     virtual Bool_t ProcessHitsOrig( FairVolume* v=0);
-    virtual Bool_t ProcessHits( FairVolume* v=nullptr);
+    Bool_t ProcessHits( FairVolume* v=nullptr) override;
 
     /**       Registers the produced collections in FAIRRootManager.     */
-    virtual void   Register();
+    void   Register() override;
 
     /** Gets the produced collections */
-    virtual TClonesArray* GetCollection(Int_t iColl) const ;
+    TClonesArray* GetCollection(Int_t iColl) const override ;
 
     /**      has to be called after each event to reset the containers      */
-    virtual void   Reset();
+    void   Reset() override;
 
     /**      Create the detector geometry        */
-    void ConstructGeometry();
+    void ConstructGeometry() override;
 
     /**      This method is an example of how to add your own point
      *       of type DetectorPoint to the clones array
@@ -86,16 +86,16 @@ class Detector: public o2::Base::Detector {
      *  any optional action in your detector during the transport.
     */
 
-    virtual void   CopyClones( TClonesArray* cl1,  TClonesArray* cl2 ,
-                               Int_t offset) {;}
-    virtual void   SetSpecialPhysicsCuts();// {;}
-    virtual void   EndOfEvent();
-    virtual void   FinishPrimary() {;}
-    virtual void   FinishRun() {;}
-    virtual void   BeginPrimary() {;}
-    virtual void   PostTrack() {;}
-    virtual void   PreTrack() {;}
-    virtual void   BeginEvent() {;}
+    void   CopyClones( TClonesArray* cl1,  TClonesArray* cl2 ,
+                               Int_t offset) override {;}
+    void   SetSpecialPhysicsCuts() override;// {;}
+    void   EndOfEvent() override;
+    void   FinishPrimary() override {;}
+    void   FinishRun() override {;}
+    void   BeginPrimary() override {;}
+    void   PostTrack() override {;}
+    void   PreTrack() override {;}
+    void   BeginEvent() override {;}
 
     void SetGeoFileName(const TString file) { mGeoFileName=file;   }
     const TString& GetGeoFileName() const   { return mGeoFileName; }
@@ -125,7 +125,7 @@ class Detector: public o2::Base::Detector {
     Detector(const Detector&);
     Detector& operator=(const Detector&);
 
-    ClassDef(Detector,1)
+    ClassDefOverride(Detector,1)
 };
 
 inline

--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitMC.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitMC.h
@@ -46,7 +46,7 @@ class DigitMC : public FairTimeStamp, public Digit {
     DigitMC(std::vector<long> &MClabel, int cru, float charge, int row, int pad, int time, float commonMode = 0.f);
 
     /// Destructor
-    virtual ~DigitMC()= default;
+    ~DigitMC() override = default;
 
     /// Get the timeBin of the DigitMC
     /// \return timeBin of the DigitMC
@@ -78,7 +78,7 @@ class DigitMC : public FairTimeStamp, public Digit {
     std::vector<long>       mMClabel;         ///< MC Event ID and track ID encoded in a long
     float                   mCommonMode;      ///< Common mode value of the DigitMC
       
-  ClassDef(DigitMC, 3);
+  ClassDefOverride(DigitMC, 3);
 };
 
 inline

--- a/Detectors/TPC/simulation/include/TPCSimulation/Digitizer.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/Digitizer.h
@@ -111,7 +111,7 @@ class Digitizer {
     std::unique_ptr<TTree>  mDebugTreePRF;      ///< Output tree for the output after the PRF
     static bool             mDebugFlagPRF;      ///< Flag for debug output after the PRF
 
-  ClassDef(Digitizer, 1);
+  ClassDefNV(Digitizer, 1);
 };
 
 // inline implementations

--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitizerTask.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitizerTask.h
@@ -28,10 +28,10 @@ class DigitizerTask : public FairTask{
     DigitizerTask();
       
     /// Destructor
-    virtual ~DigitizerTask();
+    ~DigitizerTask() override;
       
     /// Inititializes the digitizer and connects input and output container
-    virtual InitStatus Init() override;
+    InitStatus Init() override;
 
     void setHitFileName(std::string name) { mHitFileName = name; }
 
@@ -42,9 +42,9 @@ class DigitizerTask : public FairTask{
       
     /// Digitization
     /// \param option Option
-    virtual void Exec(Option_t *option) override;
+    void Exec(Option_t *option) override;
       
-    virtual void FinishTask() override;
+    void FinishTask() override;
 
   private:
     void fillHitArrayFromFile();

--- a/Detectors/TPC/simulation/include/TPCSimulation/HwCluster.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/HwCluster.h
@@ -37,7 +37,7 @@ class HwCluster : public Cluster {
         float** clusterData, short maxPad, short maxTime);
 
     /// Destructor
-    ~HwCluster() = default;
+    ~HwCluster() override = default;
 
     /// Copy Constructor
     /// \param other HwCluster to be copied
@@ -78,7 +78,7 @@ class HwCluster : public Cluster {
 
     std::vector<std::vector<float>> mClusterData;  ///< CLuster data
 
-    ClassDef(HwCluster, 1);
+    ClassDefOverride(HwCluster, 1);
   };
 }
 }

--- a/Detectors/TPC/simulation/include/TPCSimulation/Point.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/Point.h
@@ -27,10 +27,10 @@ class Point : public o2::BasicXYZEHit<float>
     Point(float x, float y, float z, float time, float nElectrons, float trackID, float detID);
 
     /// Destructor
-    virtual ~Point() = default;
+    ~Point() override = default;
 
     /// Output to screen
-    virtual void Print(const Option_t* opt) const override;
+    void Print(const Option_t* opt) const override;
 
   private:
     /// Copy constructor

--- a/Examples/ExampleModule2/include/ExampleModule2/Foo.h
+++ b/Examples/ExampleModule2/include/ExampleModule2/Foo.h
@@ -34,7 +34,7 @@ class Foo
     /// @return Returns the input number given.
     int returnsN(int n);
 
-  ClassDef(Foo, 1)
+  ClassDefNV(Foo, 1)
 };
 
 } // namespace ExampleModule2

--- a/Examples/flp2epn-distributed/include/FLP2EPNex_distributed/EPNReceiver.h
+++ b/Examples/flp2epn-distributed/include/FLP2EPNex_distributed/EPNReceiver.h
@@ -36,9 +36,9 @@ class EPNReceiver : public FairMQDevice
     EPNReceiver();
 
     /// Default destructor
-    virtual ~EPNReceiver();
+    ~EPNReceiver() override;
 
-    virtual void InitTask();
+    void InitTask() override;
 
     /// Prints the contents of the timeframe container
     void PrintBuffer(const std::unordered_map<uint16_t, TFBuffer> &buffer) const;
@@ -48,7 +48,7 @@ class EPNReceiver : public FairMQDevice
 
   protected:
     /// Overloads the Run() method of FairMQDevice
-    virtual void Run();
+    void Run() override;
 
     std::unordered_map<uint16_t, TFBuffer> mTimeframeBuffer; ///< Stores (sub-)timeframes
     std::unordered_set<uint16_t> mDiscardedSet; ///< Set containing IDs of dropped timeframes

--- a/Examples/flp2epn-distributed/include/FLP2EPNex_distributed/FLPSender.h
+++ b/Examples/flp2epn-distributed/include/FLP2EPNex_distributed/FLPSender.h
@@ -31,14 +31,14 @@ class FLPSender : public FairMQDevice
     FLPSender();
 
     /// Default destructor
-    virtual ~FLPSender();
+    ~FLPSender() override;
 
   protected:
     /// Overloads the InitTask() method of FairMQDevice
-    virtual void InitTask();
+    void InitTask() override;
 
     /// Overloads the Run() method of FairMQDevice
-    virtual void Run();
+    void Run() override;
 
   private:
     /// Sends the "oldest" element from the sub-timeframe container

--- a/Examples/flp2epn-distributed/include/FLP2EPNex_distributed/FLPSyncSampler.h
+++ b/Examples/flp2epn-distributed/include/FLP2EPNex_distributed/FLPSyncSampler.h
@@ -37,7 +37,7 @@ class FLPSyncSampler : public FairMQDevice
     FLPSyncSampler();
 
     /// Default destructor
-    virtual ~FLPSyncSampler();
+    ~FLPSyncSampler() override;
 
     /// Controls the send rate of the timeframe IDs
     void ResetEventCounter();
@@ -47,12 +47,12 @@ class FLPSyncSampler : public FairMQDevice
 
   protected:
     /// Overloads the InitTask() method of FairMQDevice
-    virtual void InitTask();
+    void InitTask() override;
 
     /// Overloads the Run() method of FairMQDevice
-    virtual bool ConditionalRun();
-    virtual void PreRun();
-    virtual void PostRun();
+    bool ConditionalRun() override;
+    void PreRun() override;
+    void PostRun() override;
 
     std::array<timeframeDuration, UINT16_MAX> mTimeframeRTT; ///< Container for the roundtrip values per timeframe ID
     int mEventRate; ///< Publishing rate of the timeframe IDs

--- a/Examples/flp2epn/include/flp2epn/O2EPNex.h
+++ b/Examples/flp2epn/include/flp2epn/O2EPNex.h
@@ -15,7 +15,7 @@ class O2EPNex : public FairMQDevice
   public:
     O2EPNex();
 
-    virtual ~O2EPNex();
+    ~O2EPNex() override;
 
     bool Process(std::unique_ptr<FairMQMessage>&, int);
 };

--- a/Examples/flp2epn/include/flp2epn/O2FLPex.h
+++ b/Examples/flp2epn/include/flp2epn/O2FLPex.h
@@ -15,13 +15,13 @@ class O2FLPex : public FairMQDevice
   public:
     O2FLPex();
 
-    virtual ~O2FLPex();
+    ~O2FLPex() override;
 
   protected:
     int fNumContent;
 
-    virtual void InitTask();
-    virtual bool ConditionalRun();
+    void InitTask() override;
+    bool ConditionalRun() override;
 };
 
 #endif

--- a/Generators/include/Generators/Pythia6Generator.h
+++ b/Generators/include/Generators/Pythia6Generator.h
@@ -88,14 +88,14 @@ class Pythia6Generator : public FairGenerator
 
 
   /** Destructor. **/
-  virtual ~Pythia6Generator();
+  ~Pythia6Generator() override;
 
 	
   /** Reads on event from the input file and pushes the tracks onto
    ** the stack. Abstract method in base class.
    ** @param primGen  pointer to the CbmrimaryGenerator
    **/
-  virtual Bool_t ReadEvent(FairPrimaryGenerator* primGen);
+  Bool_t ReadEvent(FairPrimaryGenerator* primGen) override;
 
   void SetVerbose (Int_t verb) { fVerbose = verb; };
 
@@ -115,7 +115,7 @@ class Pythia6Generator : public FairGenerator
   
 //  TDatabasePDG *fPDG; //!
 
-  ClassDef(Pythia6Generator,1);
+  ClassDefOverride(Pythia6Generator,1);
 
 };
 

--- a/Generators/include/Generators/Pythia8Generator.h
+++ b/Generators/include/Generators/Pythia8Generator.h
@@ -35,9 +35,9 @@ class PyTr1Rng : public RndmEngine
 {
  public:
   PyTr1Rng() {  rng = new TRandom1(gRandom->GetSeed()); };
-  virtual ~PyTr1Rng() = default;
+  ~PyTr1Rng() override = default;
 
-  Double_t flat() { return rng->Rndm(); };
+  Double_t flat() override { return rng->Rndm(); };
 
  private:
   TRandom1 *rng; //!
@@ -47,9 +47,9 @@ class PyTr3Rng : public RndmEngine
 {
  public:
   PyTr3Rng() {  rng = new TRandom3(gRandom->GetSeed()); };
-  virtual ~PyTr3Rng() = default;
+  ~PyTr3Rng() override = default;
 
-  Double_t flat() { return rng->Rndm(); };
+  Double_t flat() override { return rng->Rndm(); };
 
  private:
   TRandom3 *rng; //!
@@ -66,14 +66,14 @@ class Pythia8Generator : public FairGenerator
   Pythia8Generator();
 
   /** destructor **/
-  virtual ~Pythia8Generator();
+  ~Pythia8Generator() override;
 
   /** public method ReadEvent **/
-  Bool_t ReadEvent(FairPrimaryGenerator*);
+  Bool_t ReadEvent(FairPrimaryGenerator*) override;
   void SetParameters(char*);
   void Print(); //!
 
-  virtual Bool_t Init(); //!
+  Bool_t Init() override; //!
 
   void SetMom(Double_t mom) { fMom = mom; };
   void SetId(Double_t id) { fId  = id; };
@@ -95,7 +95,7 @@ class Pythia8Generator : public FairGenerator
   Bool_t fUseRandom1;  // flag to use TRandom1
   Bool_t fUseRandom3;  // flag to use TRandom3 (default)
 
-  ClassDef(Pythia8Generator,1);
+  ClassDefOverride(Pythia8Generator,1);
 };
 
 #endif /* !PNDP8GENERATOR_H */

--- a/Utilities/DataFlow/include/DataFlow/EPNReceiverDevice.h
+++ b/Utilities/DataFlow/include/DataFlow/EPNReceiverDevice.h
@@ -26,8 +26,8 @@ class EPNReceiverDevice : public FairMQDevice
 {
   public:
     EPNReceiverDevice() = default;
-    virtual ~EPNReceiverDevice() final = default;
-    virtual void InitTask() final;
+    ~EPNReceiverDevice() final = default;
+    void InitTask() final;
 
     /// Prints the contents of the timeframe container
     void PrintBuffer(const std::unordered_map<uint16_t, TFBuffer> &buffer) const;
@@ -37,7 +37,7 @@ class EPNReceiverDevice : public FairMQDevice
 
   protected:
     /// Overloads the Run() method of FairMQDevice
-    virtual void Run();
+    void Run() override;
 
     std::unordered_map<uint16_t, TFBuffer> mTimeframeBuffer; ///< Stores (sub-)timeframes
     std::unordered_set<uint16_t> mDiscardedSet; ///< Set containing IDs of dropped timeframes

--- a/Utilities/DataFlow/include/DataFlow/FLPSenderDevice.h
+++ b/Utilities/DataFlow/include/DataFlow/FLPSenderDevice.h
@@ -24,14 +24,14 @@ class FLPSenderDevice : public FairMQDevice
     FLPSenderDevice() = default;
 
     /// Default destructor
-    virtual ~FLPSenderDevice() final = default;
+    ~FLPSenderDevice() final = default;
 
   protected:
     /// Overloads the InitTask() method of FairMQDevice
-    virtual void InitTask() final;
+    void InitTask() final;
 
     /// Overloads the Run() method of FairMQDevice
-    virtual void Run() final;
+    void Run() final;
 
   private:
     /// Sends the "oldest" element from the sub-timeframe container

--- a/Utilities/DataFlow/include/DataFlow/HeartbeatSampler.h
+++ b/Utilities/DataFlow/include/DataFlow/HeartbeatSampler.h
@@ -35,14 +35,14 @@ public:
   static constexpr const char* OptionKeyPeriod = "period";
 
   HeartbeatSampler() = default;
-  virtual ~HeartbeatSampler() final = default;
+  ~HeartbeatSampler() final = default;
 
 protected:
   /// overloading the InitTask() method of FairMQDevice
-  virtual void InitTask() final;
+  void InitTask() final;
 
   /// overloading ConditionalRun method of FairMQDevice
-  virtual bool ConditionalRun() final;
+  bool ConditionalRun() final;
 
 private:
   /// publishing period (configurable)

--- a/Utilities/DataFlow/include/DataFlow/SubframeBuilderDevice.h
+++ b/Utilities/DataFlow/include/DataFlow/SubframeBuilderDevice.h
@@ -63,7 +63,7 @@ public:
   SubframeBuilderDevice();
 
   /// Default destructor
-  virtual ~SubframeBuilderDevice() final;
+  ~SubframeBuilderDevice() final;
 
 protected:
   /// overloading the InitTask() method of FairMQDevice

--- a/Utilities/DataFlow/include/DataFlow/TimeframeValidatorDevice.h
+++ b/Utilities/DataFlow/include/DataFlow/TimeframeValidatorDevice.h
@@ -16,13 +16,13 @@ public:
     TimeframeValidatorDevice();
 
     /// Default destructor
-    virtual ~TimeframeValidatorDevice() = default;
+    ~TimeframeValidatorDevice() override = default;
 
-    virtual void InitTask() final;
+    void InitTask() final;
 
   protected:
     /// Overloads the Run() method of FairMQDevice
-    virtual void Run() final;
+    void Run() final;
 
     std::string mInChannelName;
 };

--- a/Utilities/O2Device/include/O2Device/O2Device.h
+++ b/Utilities/O2Device/include/O2Device/O2Device.h
@@ -33,7 +33,7 @@ class O2Device : public FairMQDevice
 {
 public:
   using FairMQDevice::FairMQDevice;
-  virtual ~O2Device() = default;
+  ~O2Device() override = default;
 
   /// Here is how to add an annotated data part (with header);
   /// @param[in,out] parts is a reference to the message;

--- a/Utilities/O2MessageMonitor/include/O2MessageMonitor/O2MessageMonitor.h
+++ b/Utilities/O2MessageMonitor/include/O2MessageMonitor/O2MessageMonitor.h
@@ -32,11 +32,11 @@ class O2MessageMonitor : public o2::Base::O2Device
 {
 public:
   O2MessageMonitor();
-  virtual ~O2MessageMonitor() = default;
+  ~O2MessageMonitor() override = default;
 
 protected:
-  virtual void Run();
-  void InitTask();
+  void Run() override;
+  void InitTask() override;
   bool HandleData(o2::Base::O2Message& parts, int index);
   bool HandleO2frame(const byte* headerBuffer, size_t headerBufferSize,
       const byte* dataBuffer,   size_t dataBufferSize);

--- a/Utilities/Publishers/include/Publishers/DataPublisherDevice.h
+++ b/Utilities/Publishers/include/Publishers/DataPublisherDevice.h
@@ -41,7 +41,7 @@ public:
   DataPublisherDevice();
 
   /// Default destructor
-  virtual ~DataPublisherDevice() final;
+  ~DataPublisherDevice() final;
 
 protected:
   /// overloading the InitTask() method of FairMQDevice

--- a/Utilities/QC/QCCommon/include/QCCommon/TMessageWrapper.h
+++ b/Utilities/QC/QCCommon/include/QCCommon/TMessageWrapper.h
@@ -11,5 +11,5 @@ public:
         ResetBit(kIsOwner);
     }
 
-    virtual ~TMessageWrapper() = default;
+    ~TMessageWrapper() override = default;
 };

--- a/Utilities/QC/QCMerger/include/QCMerger/MergerDevice.h
+++ b/Utilities/QC/QCMerger/include/QCMerger/MergerDevice.h
@@ -19,7 +19,7 @@ class MergerDevice : public FairMQDevice
 {
 public:
   MergerDevice(std::unique_ptr<Merger> merger, std::string producerId, int numIoThreads);
-  virtual ~MergerDevice();
+  ~MergerDevice() override;
 
   static void deleteTMessage(void* data, void* hint);
   void establishChannel(std::string type,
@@ -31,7 +31,7 @@ public:
   void executeRunLoop();
 
 protected:
-  virtual void Run() override;
+  void Run() override;
 
 private:
   void subscribeCustomCommands();

--- a/Utilities/QC/QCProducer/include/QCProducer/ProducerDevice.h
+++ b/Utilities/QC/QCProducer/include/QCProducer/ProducerDevice.h
@@ -13,7 +13,7 @@ class ProducerDevice : public FairMQDevice
 {
 public:
   ProducerDevice(const char * producerId, const int numIoThreads, std::shared_ptr<Producer> & producer);
-  virtual ~ProducerDevice() = default;
+  ~ProducerDevice() override = default;
 
   static void deleteTMessage(void* data, void* hint);
   void executeRunLoop();
@@ -21,7 +21,7 @@ public:
 
 protected:
   ProducerDevice() = default;
-  virtual void Run() override;
+  void Run() override;
 
 private:
   std::shared_ptr<Producer> mProducer;

--- a/Utilities/QC/QCViewer/include/QCViewer/ViewerDevice.h
+++ b/Utilities/QC/QCViewer/include/QCViewer/ViewerDevice.h
@@ -13,13 +13,13 @@ class ViewerDevice : public FairMQDevice
 {
 public:
   ViewerDevice(std::string viewerId, int numIoThreads, std::string drawingOptions = "");
-  virtual ~ViewerDevice() = default;
+  ~ViewerDevice() override = default;
 
   void executeRunLoop();
   void establishChannel(std::string type, std::string method, std::string address, std::string channelName);
 protected:
   ViewerDevice() = default;
-  virtual void Run() override;
+  void Run() override;
 
 private:
   std::unordered_map<std::string, std::shared_ptr<TCanvas>> objectsToDraw;

--- a/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/AliHLTHOMERReader.h
+++ b/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/AliHLTHOMERReader.h
@@ -112,7 +112,7 @@ class AliHLTMonitoringReader
 	virtual unsigned long FindBlockNdx( char type[8], char origin[4], 
 				    homer_uint32 spec, unsigned long startNdx=0 ) const = 0;
 #ifdef USE_ROOT
-        ClassDef(AliHLTMonitoringReader,1);
+        ClassDefOverride(AliHLTMonitoringReader,1);
 #endif
     };
 
@@ -139,18 +139,18 @@ class AliHLTHOMERReader: public AliHLTMonitoringReader
 		     unsigned int shmCnt, const key_t* shmKey, const int* shmSize );
 	/* For reading from a buffer */
 	AliHLTHOMERReader( const void* pBuffer, int size );
-	virtual ~AliHLTHOMERReader();
+	~AliHLTHOMERReader() override;
 
 	/* Return the status of the connection as established by one of the constructors.
 	   0 means connection is ok, non-zero specifies the type of error that occured. */
-	int GetConnectionStatus() const
+	int GetConnectionStatus() const override
 		{
 		return fConnectionStatus;
 		}
 
 	/* Return the index of the connection for which an error given by the above
 	   function occured. */
-	unsigned int GetErrorConnectionNdx() const
+	unsigned int GetErrorConnectionNdx() const override
 		{
 		return fErrorConnection;
 		}
@@ -163,47 +163,47 @@ class AliHLTHOMERReader: public AliHLTMonitoringReader
 
 	/* Defined in AliHLTMonitoringReader */
 	/** Read in the next available event */
-	virtual int  ReadNextEvent();
+	int  ReadNextEvent() override;
 	/** Read in the next available event */
-	virtual int ReadNextEvent( unsigned long timeout );
+	int ReadNextEvent( unsigned long timeout ) override;
 
 	/** Return the type of the current event */
-	virtual homer_uint64 GetEventType() const
+	homer_uint64 GetEventType() const override
 		{
 		return fCurrentEventType;
 		}
 
 	/** Return the ID of the current event */
-	virtual homer_uint64 GetEventID() const
+	homer_uint64 GetEventID() const override
 		{
 		return fCurrentEventID;
 		}
 
 	/** Return the number of data blocks in the current event */
-	virtual unsigned long GetBlockCnt() const
+	unsigned long GetBlockCnt() const override
 		{
 		return fBlockCnt;
 		}
 
 	/** Return a pointer to the start of the current event's data
 	   block with the given block index (starting at 0). */
-	virtual const void* GetBlockData( unsigned long ndx ) const;
+	const void* GetBlockData( unsigned long ndx ) const override;
 	/** Return the size (in bytes) of the current event's data
 	   block with the given block index (starting at 0). */
-	virtual unsigned long GetBlockDataLength( unsigned long ndx ) const;
+	unsigned long GetBlockDataLength( unsigned long ndx ) const override;
 	/** Return IP address or hostname of node which sent the 
 	   current event's data block with the given block index 
 	   (starting at 0).
 	   For HOMER this is the ID of the node on which the subscriber 
 	   that provided this data runs/ran. */
-	virtual const char* GetBlockSendNodeID( unsigned long ndx ) const;
+	const char* GetBlockSendNodeID( unsigned long ndx ) const override;
 	/** Return byte order of the data stored in the 
 	   current event's data block with the given block 
 	   index (starting at 0). 
 	   0 is unknown alignment, 
 	   1 ist little endian, 
 	   2 is big endian. */
-	virtual homer_uint8 GetBlockByteOrder( unsigned long ndx ) const;
+	homer_uint8 GetBlockByteOrder( unsigned long ndx ) const override;
 	/** Return the alignment (in bytes) of the given datatype 
 	   in the data stored in the current event's data block
 	   with the given block index (starting at 0). 
@@ -215,20 +215,20 @@ class AliHLTHOMERReader: public AliHLTMonitoringReader
 	   4: double
 	   5: float
 	*/
-	virtual homer_uint8 GetBlockTypeAlignment( unsigned long ndx, homer_uint8 dataType ) const;
+	homer_uint8 GetBlockTypeAlignment( unsigned long ndx, homer_uint8 dataType ) const override;
 
-	virtual homer_uint64 GetBlockStatusFlags( unsigned long ndx ) const;
+	homer_uint64 GetBlockStatusFlags( unsigned long ndx ) const override;
 
 	/* HOMER specific */
 	/** Return the type of the data in the current event's data
 	   block with the given block index (starting at 0). */
-	homer_uint64 GetBlockDataType( unsigned long ndx ) const;
+	homer_uint64 GetBlockDataType( unsigned long ndx ) const override;
 	/** Return the origin of the data in the current event's data
 	   block with the given block index (starting at 0). */
-	homer_uint32 GetBlockDataOrigin( unsigned long ndx ) const;
+	homer_uint32 GetBlockDataOrigin( unsigned long ndx ) const override;
 	/** Return a specification of the data in the current event's data
 	   block with the given block index (starting at 0). */
-	homer_uint32 GetBlockDataSpec( unsigned long ndx ) const;
+	homer_uint32 GetBlockDataSpec( unsigned long ndx ) const override;
 
 	/** Return the time stamp of when the data block was created.
 	   This is a UNIX time stamp in seconds.
@@ -244,13 +244,13 @@ class AliHLTHOMERReader: public AliHLTMonitoringReader
 	   data type, origin, and specification. Returns the block's 
 	   index. */
 	unsigned long FindBlockNdx( homer_uint64 type, homer_uint32 origin, 
-				    homer_uint32 spec, unsigned long startNdx=0 ) const;
+				    homer_uint32 spec, unsigned long startNdx=0 ) const override;
 
 	/** Find the next data block in the current event with the given
 	   data type, origin, and specification. Returns the block's 
 	   index. */
 	unsigned long FindBlockNdx( char type[8], char origin[4], 
-				    homer_uint32 spec, unsigned long startNdx=0 ) const;
+				    homer_uint32 spec, unsigned long startNdx=0 ) const override;
 	
 	/** Return the ID of the node that actually produced this data block.
 	   This may be different from the node which sent the data to this
@@ -345,7 +345,7 @@ class AliHLTHOMERReader: public AliHLTMonitoringReader
       	AliHLTHOMERReader& operator=(const AliHLTHOMERReader&);
       	
 #ifdef USE_ROOT
-        ClassDef(AliHLTHOMERReader,2);
+        ClassDefOverride(AliHLTHOMERReader,2);
 #endif
     };
 

--- a/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/AliHLTHOMERWriter.h
+++ b/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/AliHLTHOMERWriter.h
@@ -82,12 +82,12 @@ class AliHLTHOMERWriter : public AliHLTMonitoringWriter
     public:
 
 	AliHLTHOMERWriter();
-	virtual ~AliHLTHOMERWriter();
+	~AliHLTHOMERWriter() override;
 
         /**
 	 * Resets the writer and clears the block list.
          */
-	void Clear();
+	void Clear() override;
 
         /**
          * Add a data block to the writer.
@@ -96,7 +96,7 @@ class AliHLTHOMERWriter : public AliHLTMonitoringWriter
          * @param homerHeader    pointer to the header describing the block
 	 * @param data           pointer to data
          */
-	void AddBlock( const void* homerHeader, const void* data );
+	void AddBlock( const void* homerHeader, const void* data ) override;
 
         /**
          * Add a data block to the writer.
@@ -123,14 +123,14 @@ class AliHLTHOMERWriter : public AliHLTMonitoringWriter
         /**
          * Get the total buffer size required to write all data into one buffer
          */
-	homer_uint32 GetTotalMemorySize( bool includeData = true );
+	homer_uint32 GetTotalMemorySize( bool includeData = true ) override;
 
         /**
          * Copy the data into a buffer.
          * The buffer is supposed to be big enough, the capacity should be queried
          * by calling @ref GetTotalMemorySize.
          */
-	void Copy( void* destination, homer_uint64 eventType, homer_uint64 eventNr, homer_uint64 statusFlags, homer_uint64 nodeID, bool includeData = true );
+	void Copy( void* destination, homer_uint64 eventType, homer_uint64 eventNr, homer_uint64 statusFlags, homer_uint64 nodeID, bool includeData = true ) override;
 
         /** determine alignment of 64 bit variables */
 	static homer_uint8 DetermineUInt64Alignment();
@@ -236,7 +236,7 @@ class AliHLTHOMERWriter : public AliHLTMonitoringWriter
         /** list of data blocks */
         std::vector<TBlockData> fBlocks; //!transient
 #ifdef USE_ROOT
-      ClassDef(AliHLTHOMERWriter,0);
+      ClassDefOverride(AliHLTHOMERWriter,0);
 #endif
     };
 

--- a/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/EventSampler.h
+++ b/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/EventSampler.h
@@ -36,29 +36,29 @@ public:
   /// default constructor
   EventSampler(int verbosity=0);
   /// destructor
-  ~EventSampler();
+  ~EventSampler() override;
 
   /////////////////////////////////////////////////////////////////
   // the FairMQDevice interface
 
   /// inherited from FairMQDevice
-  virtual void Init();
+  void Init() override;
   /// inherited from FairMQDevice
-  virtual void Run();
+  void Run() override;
   /// inherited from FairMQDevice
-  virtual void Pause();
-  /// inherited from FairMQDevice
-  /// handle device specific properties and forward to FairMQDevice::SetProperty
-  virtual void SetProperty(const int key, const std::string& value);
-  /// inherited from FairMQDevice
-  /// handle device specific properties and forward to FairMQDevice::GetProperty
-  virtual std::string GetProperty(const int key, const std::string& default_ = "");
+  void Pause() override;
   /// inherited from FairMQDevice
   /// handle device specific properties and forward to FairMQDevice::SetProperty
-  virtual void SetProperty(const int key, const int value);
+  void SetProperty(const int key, const std::string& value) override;
   /// inherited from FairMQDevice
   /// handle device specific properties and forward to FairMQDevice::GetProperty
-  virtual int GetProperty(const int key, const int default_ = 0);
+  std::string GetProperty(const int key, const std::string& default_ = "") override;
+  /// inherited from FairMQDevice
+  /// handle device specific properties and forward to FairMQDevice::SetProperty
+  void SetProperty(const int key, const int value) override;
+  /// inherited from FairMQDevice
+  /// handle device specific properties and forward to FairMQDevice::GetProperty
+  int GetProperty(const int key, const int default_ = 0) override;
 
   /// sampler loop started in a separate thread
   void samplerLoop();

--- a/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/WrapperDevice.h
+++ b/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/WrapperDevice.h
@@ -40,31 +40,31 @@ public:
   /// default constructor
   WrapperDevice(int argc, char** argv, int verbosity = 0);
   /// destructor
-  ~WrapperDevice();
+  ~WrapperDevice() override;
 
   /////////////////////////////////////////////////////////////////
   // the FairMQDevice interface
 
   /// inherited from FairMQDevice
-  virtual void Init();
+  void Init() override;
   /// inherited from FairMQDevice
-  virtual void InitTask();
+  void InitTask() override;
   /// inherited from FairMQDevice
-  virtual void Run();
+  void Run() override;
   /// inherited from FairMQDevice
-  virtual void Pause();
-  /// inherited from FairMQDevice
-  /// handle device specific properties and forward to FairMQDevice::SetProperty
-  virtual void SetProperty(const int key, const std::string& value);
-  /// inherited from FairMQDevice
-  /// handle device specific properties and forward to FairMQDevice::GetProperty
-  virtual std::string GetProperty(const int key, const std::string& default_ = "");
+  void Pause() override;
   /// inherited from FairMQDevice
   /// handle device specific properties and forward to FairMQDevice::SetProperty
-  virtual void SetProperty(const int key, const int value);
+  void SetProperty(const int key, const std::string& value) override;
   /// inherited from FairMQDevice
   /// handle device specific properties and forward to FairMQDevice::GetProperty
-  virtual int GetProperty(const int key, const int default_ = 0);
+  std::string GetProperty(const int key, const std::string& default_ = "") override;
+  /// inherited from FairMQDevice
+  /// handle device specific properties and forward to FairMQDevice::SetProperty
+  void SetProperty(const int key, const int value) override;
+  /// inherited from FairMQDevice
+  /// handle device specific properties and forward to FairMQDevice::GetProperty
+  int GetProperty(const int key, const int default_ = 0) override;
 
   /////////////////////////////////////////////////////////////////
   // device property identifier


### PR DESCRIPTION
 * systematically apply C++11 override keyword
 * replacement of ClassDef -> ClassDefOverride or ClassDefNV
 * code is now clean with respect to this coding rule

fixes issue #304