### PR TITLE
Fix member name convention + nullptr + default

### DIFF
--- a/CCDB/include/CCDB/ConditionsMQServer.h
+++ b/CCDB/include/CCDB/ConditionsMQServer.h
@@ -27,7 +27,7 @@ public:
   void InitTask() override;
 
 private:
-  Manager* fCdbManager;
+  Manager* mCdbManager;
 
   void getFromOCDB(std::string key);
 

--- a/CCDB/src/ConditionsMQServer.cxx
+++ b/CCDB/src/ConditionsMQServer.cxx
@@ -32,25 +32,25 @@ using std::endl;
 using std::cout;
 using std::string;
 
-ConditionsMQServer::ConditionsMQServer() : ParameterMQServer(), fCdbManager(o2::CDB::Manager::Instance()) {}
+ConditionsMQServer::ConditionsMQServer() : ParameterMQServer(), mCdbManager(o2::CDB::Manager::Instance()) {}
 
 void ConditionsMQServer::InitTask()
 {
   ParameterMQServer::InitTask();
   // Set first input
   if (GetProperty(FirstInputType, "") == "OCDB") {
-    fCdbManager->setDefaultStorage(GetProperty(FirstInputName, "").c_str());
+    mCdbManager->setDefaultStorage(GetProperty(FirstInputName, "").c_str());
   }
 
   // Set second input
   if (GetProperty(SecondInputType, "") == "OCDB") {
-    fCdbManager->setDefaultStorage(GetProperty(SecondInputName, "").c_str());
+    mCdbManager->setDefaultStorage(GetProperty(SecondInputName, "").c_str());
   }
 
   // Set output
   if (GetProperty(OutputName, "") != "") {
     if (GetProperty(OutputType, "") == "OCDB") {
-      fCdbManager->setDefaultStorage(GetProperty(OutputName, "").c_str());
+      mCdbManager->setDefaultStorage(GetProperty(OutputName, "").c_str());
     }
   }
 }
@@ -157,8 +157,8 @@ void ConditionsMQServer::getFromOCDB(std::string key)
 
   Condition* aCondition = nullptr;
 
-  fCdbManager->setRun(runId);
-  aCondition = fCdbManager->getObject(IdPath(identifier), runId);
+  mCdbManager->setRun(runId);
+  aCondition = mCdbManager->getObject(IdPath(identifier), runId);
 
   if (aCondition) {
     LOG(DEBUG) << "Sending following parameter to the client:";
@@ -171,8 +171,8 @@ void ConditionsMQServer::getFromOCDB(std::string key)
 
     fChannels.at("data-get").at(0).Send(message);
   } else {
-    LOG(ERROR) << "Could not get a condition for \"" << key << "\" and run " << runId << "!";
+    LOG(ERROR) << R"(Could not get a condition for ")" << key << R"(" and run )" << runId << "!";
   }
 }
 
-ConditionsMQServer::~ConditionsMQServer() { delete fCdbManager; }
+ConditionsMQServer::~ConditionsMQServer() { delete mCdbManager; }

--- a/CCDB/src/IdPath.cxx
+++ b/CCDB/src/IdPath.cxx
@@ -46,7 +46,7 @@ IdPath::IdPath(const char *level0, const char *level1, const char *level2)
     mValid = kTRUE;
   } else {
     mValid = kFALSE;
-    LOG(ERROR) << "Invalid  Path \"" << level0 << "/" << level1 << "/" << level2 << "\"!" << FairLogger::endl;
+    LOG(ERROR) << R"(Invalid  Path ")" << level0 << "/" << level1 << "/" << level2 << R"("!)" << FairLogger::endl;
   }
 
   init();
@@ -122,7 +122,7 @@ void IdPath::InitPath()
   }
 
   if (!mValid) {
-    LOG(INFO) << "Invalid  Path \"" << mPath.Data() << "\"!" << FairLogger::endl;
+    LOG(INFO) << R"(Invalid  Path ")" << mPath.Data() << R"("!)" << FairLogger::endl;
   } else {
     mPath = Form("%s/%s/%s", mLevel0.Data(), mLevel1.Data(), mLevel2.Data());
   }
@@ -208,6 +208,6 @@ const char *IdPath::getLevel(Int_t i) const
       return mLevel2.Data();
       break;
     default:
-      return 0;
+      return nullptr;
   }
 }

--- a/Detectors/ITSMFT/ITS/base/include/ITSBase/GeometryTGeo.h
+++ b/Detectors/ITSMFT/ITS/base/include/ITSBase/GeometryTGeo.h
@@ -484,13 +484,13 @@ inline void GeometryTGeo::setChipTypeName(Int_t i, const char* nm)
 /// Get segmentation by ID
  inline const o2::ITSMFT::Segmentation* GeometryTGeo::getSegmentationById(Int_t id) const
 {
-  return mSegmentations ? (o2::ITSMFT::Segmentation*)mSegmentations->At(id) : 0;
+  return mSegmentations ? (o2::ITSMFT::Segmentation*)mSegmentations->At(id) : nullptr;
 }
 
 /// Get segmentation of layer
  inline const o2::ITSMFT::Segmentation* GeometryTGeo::getSegmentation(Int_t lr) const
 {
-  return mSegmentations ? (o2::ITSMFT::Segmentation*)mSegmentations->At(getLayerChipTypeId(lr)) : 0;
+  return mSegmentations ? (o2::ITSMFT::Segmentation*)mSegmentations->At(getLayerChipTypeId(lr)) : nullptr;
 }
 }
 }


### PR DESCRIPTION
last set of fixes to achieve clean state for

* member names
* C++11 features: nullptr