### PR TITLE
Fix #296: Installation of public header files

### DIFF
--- a/cmake/O2Utils.cmake
+++ b/cmake/O2Utils.cmake
@@ -279,8 +279,7 @@ macro(O2_GENERATE_LIBRARY)
   install(TARGETS ${Int_LIB} DESTINATION lib)
 
   # Install all the public headers
-  install(DIRECTORY include/${MODULE_NAME} DESTINATION include)
-  if(EXISTS include/${MODULE_NAME})
+  if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/include/${MODULE_NAME})
     install(DIRECTORY include/${MODULE_NAME} DESTINATION include)
   endif()
 


### PR DESCRIPTION
This is related to #256, the previous fix in #257 introduced
a bug skipping header file installation completely. The
check for existence of public header directory needs the
CMAKE_CURRENT_SOURCE_DIR in the directory path.