### PR TITLE
Add missing std members

### DIFF
--- a/Utilities/aliceHLTwrapper/src/aliceHLTEventSampler.cxx
+++ b/Utilities/aliceHLTwrapper/src/aliceHLTEventSampler.cxx
@@ -42,8 +42,11 @@
 #endif
 
 using std::cout;
+using std::endl;
 using std::cerr;
+using std::string;
 using std::stringstream;
+using std::vector;
 
 struct SocketProperties_t {
   std::string type;

--- a/Utilities/aliceHLTwrapper/src/aliceHLTWrapper.cxx
+++ b/Utilities/aliceHLTwrapper/src/aliceHLTWrapper.cxx
@@ -50,8 +50,12 @@
 #include <boost/chrono.hpp>
 
 using std::cout;
+using std::endl;
 using std::cerr;
+using std::string;
 using std::stringstream;
+using std::ostream;
+using std::vector;
 
 struct SocketProperties_t {
   std::string type;


### PR DESCRIPTION
This worked so far, because one of FairMQ header files had 'using namespace std', that will be cleaned soon.