### PR TITLE
Fairlinks and event display visualisation

### DIFF
--- a/Detectors/TPC/CMakeLists.txt
+++ b/Detectors/TPC/CMakeLists.txt
@@ -17,3 +17,4 @@
 add_subdirectory(base)
 add_subdirectory(reconstruction)
 add_subdirectory(simulation)
+add_subdirectory(eventdisplay)

--- a/Detectors/TPC/eventdisplay/CMakeLists.txt
+++ b/Detectors/TPC/eventdisplay/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(MODULE_NAME "TPCEventdisplay")
+
+O2_SETUP(NAME ${MODULE_NAME})
+
+link_directories( ${LINK_DIRECTORIES})
+
+set(SRCS
+   src/HitDrawTask.cxx
+)
+
+set(HEADERS
+   include/${MODULE_NAME}/HitDrawTask.h
+)
+Set(LINKDEF src/TPCEventdisplayLinkDef.h)
+Set(LIBRARY_NAME ${MODULE_NAME})
+set(BUCKET_NAME tpc_eventdisplay_bucket)
+
+O2_GENERATE_LIBRARY()

--- a/Detectors/TPC/eventdisplay/include/TPCEventdisplay/HitDrawTask.h
+++ b/Detectors/TPC/eventdisplay/include/TPCEventdisplay/HitDrawTask.h
@@ -1,0 +1,37 @@
+/// \file HitDrawTask.h
+/// \brief Task to draw MC hits in event display
+/// \author Jens Wiechula, Jens.Wiechula@ikf.uni-frankfurt.de
+
+#ifndef FAIRMCPOINTDRAW_H_
+#define FAIRMCPOINTDRAW_H_
+
+#include "FairPointSetDraw.h"           // for FairPointSetDraw
+
+#include "Rtypes.h"                     // for HitDrawTask::Class, etc
+
+class TObject;
+class TVector3;
+
+namespace o2 {
+namespace TPC {
+
+/// \class HitDrawTask
+/// This class is required to draw MC hits in the event display
+/// The generic class can not be used, since the hits don't inherit from
+/// FairPoint
+class HitDrawTask: public FairPointSetDraw
+{
+  public:
+    HitDrawTask();
+    HitDrawTask(const char* name, Color_t color ,Style_t mstyle, Int_t iVerbose = 1):FairPointSetDraw(name, color, mstyle, iVerbose) {};
+    virtual ~HitDrawTask();
+
+  protected:
+    TVector3 GetVector(TObject* obj);
+
+    ClassDef(HitDrawTask,0);
+};
+
+};
+};
+#endif /* FAIRMCPOINTDRAW_H_ */

--- a/Detectors/TPC/eventdisplay/src/HitDrawTask.cxx
+++ b/Detectors/TPC/eventdisplay/src/HitDrawTask.cxx
@@ -1,0 +1,33 @@
+/// \file HitDrawTask.cxx
+/// \brief Task to draw MC hits in event display
+/// \author Jens Wiechula, Jens.Wiechula@ikf.uni-frankfurt.de
+//
+#include "TPCEventdisplay/HitDrawTask.h"
+
+#include "TPCSimulation/Point.h"                // for FairMCPoint
+
+#include "TVector3.h"                   // for TVector3
+
+class TObject;
+
+using namespace o2::TPC;
+
+HitDrawTask::HitDrawTask()
+{
+  // TODO Auto-generated constructor stub
+
+}
+
+HitDrawTask::~HitDrawTask()
+{
+  // TODO Auto-generated destructor stub
+}
+
+TVector3 HitDrawTask::GetVector(TObject* obj)
+{
+  Point* p = static_cast<Point*>(obj);
+  return TVector3(p->GetX(), p->GetY(), p->GetZ());
+}
+
+
+ClassImp(HitDrawTask)

--- a/Detectors/TPC/eventdisplay/src/TPCEventdisplayLinkDef.h
+++ b/Detectors/TPC/eventdisplay/src/TPCEventdisplayLinkDef.h
@@ -1,0 +1,9 @@
+#ifdef __CLING__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class o2::TPC::HitDrawTask+;
+
+#endif

--- a/Detectors/TPC/simulation/include/TPCSimulation/Detector.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/Detector.h
@@ -7,6 +7,7 @@
 #include "TLorentzVector.h"  // for TLorentzVector
 #include "TClonesArray.h"
 #include "TString.h"
+#include "FairLink.h"
 
 #include "TPCSimulation/Point.h"
 
@@ -120,7 +121,8 @@ class Detector: public o2::Base::Detector {
     /** container for data points */
     TClonesArray*  mPointCollection;
 
-    TString mGeoFileName;                  /// Name of the file containing the TPC geometry
+    TString mGeoFileName;                  ///< Name of the file containing the TPC geometry
+    size_t mEventNr;                       //!< current event number
 
     Detector(const Detector&);
     Detector& operator=(const Detector&);
@@ -133,7 +135,9 @@ Point* Detector::addHit(float x, float y, float z, float time, float nElectrons,
 {
   TClonesArray& clref = *mPointCollection;
   Int_t size = clref.GetEntriesFast();
-  return new(clref[size]) Point(x, y, z, time, nElectrons, trackID, detID);
+  Point *point = new(clref[size]) Point(x, y, z, time, nElectrons, trackID, detID);
+  point->SetLink(FairLink(-1, mEventNr, FairRootManager::Instance()->GetBranchId("MCTrack"), trackID)); 
+  return point;
 }
 }
 }

--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitCRU.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitCRU.h
@@ -41,18 +41,21 @@ class DigitCRU{
     /// \return Size of the time bin container
     size_t getSize() const {return mTimeBins.size();}
 
+    /// Get the container
+    /// \return container
+    const std::deque<std::unique_ptr<DigitTime>>& getTimeBinContainer() const { return mTimeBins; }
+
     /// Get the CRU ID
     /// \return CRU ID
     int getCRUID() const {return mCRU;}
 
     /// Add digit to the row container
-    /// \param eventID MC ID of the event
-    /// \param trackID MC ID of the track
+    /// \param hitID MC Hit ID
     /// \param timeBin Time bin of the digit
     /// \param row Pad row of digit
     /// \param pad Pad of digit
     /// \param charge Charge of the digit
-    void setDigit(int eventID, int trackID, int timeBin, int row, int pad, float charge);
+    void setDigit(size_t hitID, int timeBin, int row, int pad, float charge);
 
     /// Fill output TClonesArray
     /// \param output Output container

--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitContainer.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitContainer.h
@@ -41,14 +41,13 @@ class DigitContainer{
     int getNentries() const;
 
     /// Add digit to the container
-    /// \param eventID MC ID of the event
-    /// \param trackID MC ID of the track
+    /// \param hitID MC Hit ID
     /// \param cru CRU of the digit
     /// \param row Pad row of digit
     /// \param pad Pad of digit
     /// \param timeBin Time bin of the digit
     /// \param charge Charge of the digit
-    void addDigit(int eventID, int trackID, int cru, int timeBin, int row, int pad, float charge);
+    void addDigit(size_t hitID, int cru, int timeBin, int row, int pad, float charge);
 
     /// Fill output TClonesArray
     /// \param output Output container

--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitMC.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitMC.h
@@ -43,7 +43,7 @@ class DigitMC : public FairTimeStamp, public Digit {
     /// \param pad Pad in which the DigitMC was created
     /// \param time Time at which the DigitMC was created
     /// \param commonMode Common mode signal on that ROC in the time bin of the DigitMC. If not assigned, it is set to zero.
-    DigitMC(std::vector<long> &MClabel, int cru, float charge, int row, int pad, int time, float commonMode = 0.f);
+    DigitMC(int cru, float charge, int row, int pad, int time, float commonMode = 0.f);
 
     /// Destructor
     ~DigitMC() override = default;
@@ -55,27 +55,12 @@ class DigitMC : public FairTimeStamp, public Digit {
     /// Get the common mode signal of the DigitMC
     /// \return common mode signal of the DigitMC
     float getCommonMode() const { return mCommonMode; }
-    
-    /// Get the number of MC labels associated to the DigitMC
-    /// \return Number of MC labels associated to the DigitMC
-    size_t getNumberOfMClabels() const { return mMClabel.size(); }
-
-    /// Get a specific MC Event ID
-    /// \param iOccurrence Sorted by occurrence, i.e. for iOccurrence=0 the MC event ID of the most dominant track
-    /// \return MC Event ID
-    int getMCEvent(int iOccurrence) const { return static_cast<int>(mMClabel[iOccurrence]*1E-6); }
-    
-    /// Get a specific MC Track ID
-    /// \param iOccurrence Sorted by occurrence, i.e. for iOccurrence=0 the MC ID of the most dominant track
-    /// \return MC Track ID
-    int getMCTrack(int iOccurrence) const { return static_cast<int>((mMClabel[iOccurrence])%int(1E6)); }
 
   private:
     #ifndef __CINT__
     friend class boost::serialization::access;
     #endif
     
-    std::vector<long>       mMClabel;         ///< MC Event ID and track ID encoded in a long
     float                   mCommonMode;      ///< Common mode value of the DigitMC
       
   ClassDefOverride(DigitMC, 3);
@@ -85,15 +70,13 @@ inline
 DigitMC::DigitMC()
   : FairTimeStamp()
   , Digit(-1, -1.f, -1, -1)
-  , mMClabel(0)
   , mCommonMode(0.f)
 {}
 
 inline
-DigitMC::DigitMC(std::vector<long> &MClabel, int cru, float charge, int row, int pad, int time, float commonMode)
+DigitMC::DigitMC(int cru, float charge, int row, int pad, int time, float commonMode)
   : FairTimeStamp(time)
   , Digit(cru, charge, row, pad)
-  , mMClabel(MClabel)
   , mCommonMode(commonMode)
 {}
 

--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitPad.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitPad.h
@@ -1,12 +1,16 @@
 /// \file DigitPad.h
 /// \brief Definition of the Pad container
 /// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
+/// \author Jens Wiechula, Jens.Wiechula@ikf.uni-frankfurt.de
 
 #ifndef ALICEO2_TPC_DigitPad_H_
 #define ALICEO2_TPC_DigitPad_H_
 
 #include <map>
 
+#include "FairRootManager.h"
+#include "FairMultiLinkedData.h"
+#include "FairLink.h"
 #include "TPCSimulation/CommonMode.h"
 #include <TClonesArray.h>
 
@@ -39,11 +43,14 @@ class DigitPad{
     /// \return Accumulated charge
     float getChargePad() const {return mChargePad;}
 
+    /// Get the MC Links
+    /// \return MC Links
+    const FairMultiLinkedData& getMCLinks() const { return mMCLinks; }
+
     /// Add digit to the time bin container
-    /// \param eventID MC ID of the event
-    /// \param trackID MC ID of the track
+    /// \param hitID MC Hit ID
     /// \param charge Charge of the digit
-    void setDigit(int eventID, int trackID, float charge);
+    void setDigit(size_t hitID, float charge);
 
     /// Fill output TClonesArray
     /// \param output Output container
@@ -53,33 +60,27 @@ class DigitPad{
     /// \param pad pad ID
     void fillOutputContainer(TClonesArray *output, int cru, int timeBin, int row, int pad, float commonMode = 0);
 
-    /// The MC labels are sorted by occurrence such that the event/track combination with the largest number of occurrences is first
-    /// This is then dumped into a std::vector and attached to the digits
-    /// \todo Find out how many different event/track combinations are relevant
-    /// \param std::vector containing the sorted MCLabels
-    void processMClabels(std::vector<long> &sortedMCLabels);
-    
   private:
     float                  mChargePad;   ///< Total accumulated charge on that pad for a given time bin
     unsigned char          mPad;         ///< Pad of the ADC value
-    std::map<long, int>    mMCID;        ///< Map containing the MC labels (key) and the according number of occurrence (value)
+    FairMultiLinkedData    mMCLinks;     ///< MC links
 };
 
 inline
 DigitPad::DigitPad(int pad)
   : mChargePad(0.)
   , mPad(pad)
-  , mMCID()
+  , mMCLinks()
 {}
 
 inline 
-void DigitPad::setDigit(int eventID, int trackID, float charge)
+void DigitPad::setDigit(size_t hitID, float charge)
 {
   /// the MC ID is encoded such that we can have 999,999 tracks
   /// numbers larger than 1000000 correspond to the event ID
   /// i.e. 12000010 corresponds to event 12 with track ID 10
   /// \todo Faster would be a bit shift
-  ++mMCID[(eventID)*1000000 + trackID];
+  mMCLinks.AddLink(FairLink(-1, FairRootManager::Instance()->GetEntryNr(), "TPCPoint", hitID));
   mChargePad += charge;
 }
 
@@ -87,7 +88,7 @@ inline
 void DigitPad::reset()
 {
   mChargePad = 0;
-  mMCID.clear();
+  mMCLinks.Reset();
 }
   
 }

--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitRow.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitRow.h
@@ -36,6 +36,10 @@ class DigitRow{
     /// \return Size of the pad container
     size_t getSize() const {return mPads.size();}
 
+    /// Get the container
+    /// \return container
+    const std::vector<std::unique_ptr<DigitPad>>& getPadContainer() const { return mPads; }
+
     /// Get the number of entries in the container
     /// \return Number of entries in the pad container
     int getNentries() const;
@@ -45,9 +49,10 @@ class DigitRow{
     int getRow() const {return mRow;}
 
     /// Add digit to the pad container
+    /// \param hitID MC Hit ID
     /// \param pad Pad of the digit
     /// \param charge Charge of the digit
-    void setDigit(int eventID, int trackID, int pad, float charge);
+    void setDigit(size_t hitID, int pad, float charge);
 
     /// Fill output TClonesArray
     /// \param output Output container

--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitTime.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitTime.h
@@ -36,6 +36,10 @@ class DigitTime{
     /// \return Size of the Row container
     size_t getSize() const {return mRows.size();}
 
+    /// Get the container
+    /// \return container
+    const std::vector<std::unique_ptr<DigitRow>>& getRowContainer() const { return mRows; }
+
     /// Get the number of entries in the container
     /// \return Number of entries in the Row container
     int getNentries() const;
@@ -49,13 +53,12 @@ class DigitTime{
     float getTotalChargeTimeBin() const {return mTotalChargeTimeBin;}
 
     /// Add digit to the row container
-    /// \param eventID MC ID of the event
-    /// \param trackID MC ID of the track
+    /// \param hitID MC Hit ID
     /// \param cru CRU of the digit
     /// \param row Pad row of digit
     /// \param pad Pad of digit
     /// \param charge Charge of the digit
-    void setDigit(int eventID, int trackID, int cru, int row, int pad, float charge);
+    void setDigit(size_t hitID, int cru, int row, int pad, float charge);
 
     /// Fill output TClonesArray
     /// \param output Output container

--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitizerTask.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitizerTask.h
@@ -39,6 +39,10 @@ class DigitizerTask : public FairTask{
     /// \param debugsString String containing the debug flags
     ///        o PRFdebug - Debug output after application of the PRF
     void setDebugOutput(TString debugString);
+
+    /// Set the maximal number of written out time bins
+    /// \param nTimeBinsMax Maximal number of time bins to be written out
+    void setMaximalTimeBinWriteOut(int i) { mTimeBinMax = i; }
       
     /// Digitization
     /// \param option Option
@@ -56,6 +60,8 @@ class DigitizerTask : public FairTask{
     TClonesArray        *mDigitsArray;  ///< Array of the Digits, passed from the digitization
     
     std::string         mHitFileName;  ///< External hit file exported from AliRoot
+
+    int                 mTimeBinMax;   ///< Maximum time bin to be written out
 
   ClassDefOverride(DigitizerTask, 1);
 };

--- a/Detectors/TPC/simulation/src/Detector.cxx
+++ b/Detectors/TPC/simulation/src/Detector.cxx
@@ -55,14 +55,18 @@ using namespace o2::TPC;
 Detector::Detector()
   : o2::Base::Detector("TPC", kTRUE, kAliTpc),
     mSimulationType(SimulationType::Other),
-    mPointCollection(new TClonesArray("o2::TPC::Point"))
+    mPointCollection(new TClonesArray("o2::TPC::Point")),
+    mGeoFileName(),
+    mEventNr(0)
 {
 }
 
 Detector::Detector(const char* name, Bool_t active)
   : o2::Base::Detector(name, active, kAliTpc),
     mSimulationType(SimulationType::Other),
-    mPointCollection(new TClonesArray("o2::TPC::Point"))
+    mPointCollection(new TClonesArray("o2::TPC::Point")),
+    mGeoFileName(),
+    mEventNr(0)
 {
 
 }
@@ -273,7 +277,7 @@ void Detector::EndOfEvent()
 {
 
   mPointCollection->Clear();
-
+  ++mEventNr;
 }
 
 

--- a/Detectors/TPC/simulation/src/DigitCRU.cxx
+++ b/Detectors/TPC/simulation/src/DigitCRU.cxx
@@ -10,12 +10,12 @@
 
 using namespace o2::TPC;
 
-void DigitCRU::setDigit(int eventID, int trackID, int timeBin, int row, int pad, float charge)
+void DigitCRU::setDigit(size_t hitID, int timeBin, int row, int pad, float charge)
 {
   mEffectiveTimeBin = timeBin - mFirstTimeBin;
   if(mEffectiveTimeBin < 0.) {
     LOG(FATAL) << "TPC DigitCRU buffer misaligned ";
-    LOG(DEBUG) << "for Event " << eventID << " CRU " <<mCRU << " TimeBin " << timeBin << " First TimeBin " << mFirstTimeBin << " Row " << row << " Pad " << pad;
+    LOG(DEBUG) << "for hit " << hitID << " CRU " <<mCRU << " TimeBin " << timeBin << " First TimeBin " << mFirstTimeBin << " Row " << row << " Pad " << pad;
     LOG(FATAL) << FairLogger::endl;
     return;
   }
@@ -26,12 +26,12 @@ void DigitCRU::setDigit(int eventID, int trackID, int timeBin, int row, int pad,
   /// Check whether the container at this spot already contains an entry
   DigitTime *result = mTimeBins[mEffectiveTimeBin].get();
   if(result != nullptr) {
-    mTimeBins[mEffectiveTimeBin]->setDigit(eventID, trackID, mCRU, row, pad, charge);
+    mTimeBins[mEffectiveTimeBin]->setDigit(hitID, mCRU, row, pad, charge);
   }
   else {
     const Mapper& mapper = Mapper::instance();
     mTimeBins[mEffectiveTimeBin] = std::unique_ptr<DigitTime> (new DigitTime(timeBin, mapper.getPadRegionInfo(CRU(mCRU).region()).getNumberOfPadRows()));
-    mTimeBins[mEffectiveTimeBin]->setDigit(eventID, trackID, mCRU, row, pad, charge);
+    mTimeBins[mEffectiveTimeBin]->setDigit(hitID, mCRU, row, pad, charge);
   }
 }
 

--- a/Detectors/TPC/simulation/src/DigitContainer.cxx
+++ b/Detectors/TPC/simulation/src/DigitContainer.cxx
@@ -11,17 +11,17 @@
 
 using namespace o2::TPC;
 
-void DigitContainer::addDigit(int eventID, int trackID, int cru, int timeBin, int row, int pad, float charge)
+void DigitContainer::addDigit(size_t hitID, int cru, int timeBin, int row, int pad, float charge)
 {
   /// Check whether the container at this spot already contains an entry
   DigitCRU *result = mCRU[cru].get();
   if(result != nullptr){
-    mCRU[cru]->setDigit(eventID, trackID, timeBin, row, pad, charge);
+    mCRU[cru]->setDigit(hitID, timeBin, row, pad, charge);
   }
   else{
     const Mapper& mapper = Mapper::instance();
     mCRU[cru] = std::unique_ptr<DigitCRU> (new DigitCRU(cru));
-    mCRU[cru]->setDigit(eventID, trackID, timeBin, row, pad, charge);
+    mCRU[cru]->setDigit(hitID, timeBin, row, pad, charge);
   }
 }
 

--- a/Detectors/TPC/simulation/src/DigitRow.cxx
+++ b/Detectors/TPC/simulation/src/DigitRow.cxx
@@ -7,16 +7,16 @@
 
 using namespace o2::TPC;
 
-void DigitRow::setDigit(int eventID, int trackID, int pad, float charge)
+void DigitRow::setDigit(size_t hitID, int pad, float charge)
 {
   /// Check whether the container at this spot already contains an entry
   DigitPad *result =  mPads[pad].get();
   if(result != nullptr) {
-    mPads[pad]->setDigit(eventID, trackID, charge);
+    mPads[pad]->setDigit(hitID, charge);
   }
   else{
     mPads[pad] = std::unique_ptr<DigitPad> (new DigitPad(pad));
-    mPads[pad]->setDigit(eventID, trackID, charge);
+    mPads[pad]->setDigit(hitID, charge);
   }
 }
 

--- a/Detectors/TPC/simulation/src/DigitTime.cxx
+++ b/Detectors/TPC/simulation/src/DigitTime.cxx
@@ -8,17 +8,17 @@
 
 using namespace o2::TPC;
 
-void DigitTime::setDigit(int eventID, int trackID, int cru, int row, int pad, float charge)
+void DigitTime::setDigit(size_t hitID, int cru, int row, int pad, float charge)
 {
   /// Check whether the container at this spot already contains an entry
   DigitRow *result = mRows[row].get();
   if(result != nullptr) {
-    mRows[row]->setDigit(eventID, trackID, pad, charge);
+    mRows[row]->setDigit(hitID, pad, charge);
   }
   else{
     const Mapper& mapper = Mapper::instance();
     mRows[row] = std::unique_ptr<DigitRow> (new DigitRow(row, mapper.getPadRegionInfo(CRU(cru).region()).getPadsInRowRegion(row)));
-    mRows[row]->setDigit(eventID, trackID, pad, charge);
+    mRows[row]->setDigit(hitID, pad, charge);
   }
   mTotalChargeTimeBin+=charge;
 }

--- a/Detectors/TPC/simulation/src/Digitizer.cxx
+++ b/Detectors/TPC/simulation/src/Digitizer.cxx
@@ -57,6 +57,7 @@ DigitContainer *Digitizer::Process(TClonesArray *points)
 
   static std::array<float, mNShapedPoints> signalArray;
 
+  size_t hitCounter=0;
   for(auto pointObject : *points) {
     Point *inputpoint = static_cast<Point *>(pointObject);
 
@@ -125,7 +126,7 @@ DigitContainer *Digitizer::Process(TClonesArray *points)
       SAMPAProcessing::getShapedSignal(ADCsignal, absoluteTime, signalArray);
       for(float i=0; i<mNShapedPoints; ++i) {
         const float time = absoluteTime + i * ZBINWIDTH;
-        mDigitContainer->addDigit(MCEventID, MCTrackID, digiPos.getCRU().number(), getTimeBinFromTime(time), row, pad, signalArray[i]);
+        mDigitContainer->addDigit(hitCounter, digiPos.getCRU().number(), getTimeBinFromTime(time), row, pad, signalArray[i]);
       }
 
       // }
@@ -133,6 +134,7 @@ DigitContainer *Digitizer::Process(TClonesArray *points)
       /// end of loop over prf
     }
     /// end of loop over electrons
+    ++hitCounter;
   }
   /// end of loop over points
 

--- a/Detectors/TPC/simulation/src/DigitizerTask.cxx
+++ b/Detectors/TPC/simulation/src/DigitizerTask.cxx
@@ -28,6 +28,7 @@ DigitizerTask::DigitizerTask()
   , mPointsArray(nullptr)
   , mDigitsArray(nullptr)
   , mHitFileName()
+  , mTimeBinMax(1000000)
 {
   /// \todo get rid of new
   mDigitizer = new Digitizer;
@@ -88,18 +89,14 @@ void DigitizerTask::Exec(Option_t *option)
   mDigitsArray->Delete();
   mDigitContainer = mDigitizer->Process(mPointsArray);
   mDigitContainer->fillOutputContainer(mDigitsArray, eventTime);
-  mgr->Fill();
-//  std::vector<CommonMode> commonModeContainer(0);
-//  digits->processCommonMode(commonModeContainer);
-//  digits->fillOutputContainer(mDigitsArray, commonModeContainer);
 }
 
 void DigitizerTask::FinishTask()
 {
   FairRootManager *mgr = FairRootManager::Instance();
+  mgr->SetLastFill(kTRUE); /// necessary, otherwise the data is not written out
   mDigitsArray->Delete();
-  mDigitContainer->fillOutputContainer(mDigitsArray, 1000000);
-  mgr->Fill();
+  mDigitContainer->fillOutputContainer(mDigitsArray, mTimeBinMax);
 }
 
 void DigitizerTask::fillHitArrayFromFile()

--- a/Detectors/TPC/simulation/test/testTPCDigitContainer.cxx
+++ b/Detectors/TPC/simulation/test/testTPCDigitContainer.cxx
@@ -21,8 +21,10 @@ namespace TPC {
     const SAMPAProcessing& sampa = SAMPAProcessing::instance();
     auto *mDigitContainer = new DigitContainer();
 
-    std::vector<int> MCevent = {1, 250, 3, 62, 1000};
-    std::vector<int> MCtrack = {22, 3, 4, 23, 523};
+    /// \todo add test with FairLink stuff if possible
+    std::vector<int> hitID = {1, 250, 3, 62, 1000};
+    //std::vector<int> MCevent = {1, 250, 3, 62, 1000};
+    //std::vector<int> MCtrack = {22, 3, 4, 23, 523};
     std::vector<int> CRU     = {1, 23, 36, 53, 214};
     std::vector<int> Time    = {231, 2, 500, 230, 1};
     std::vector<int> Row     = {12, 5, 6, 2, 6};
@@ -30,7 +32,8 @@ namespace TPC {
     std::vector<int> nEle    = {60, 100, 250, 1023, 2};
 
     for(int i=0; i<CRU.size(); ++i) {
-      mDigitContainer->addDigit(MCevent[i], MCtrack[i], CRU[i], Time[i], Row[i], Pad[i], nEle[i]);
+      //mDigitContainer->addDigit(MCevent[i], MCtrack[i], CRU[i], Time[i], Row[i], Pad[i], nEle[i]);
+      mDigitContainer->addDigit(hitID[i], CRU[i], Time[i], Row[i], Pad[i], nEle[i]);
     }
 
     auto *mDigitsArray = new TClonesArray("o2::TPC::DigitMC");
@@ -41,8 +44,9 @@ namespace TPC {
     int digits = 0;
     for(auto digitsObject : *mDigitsArray) {
       DigitMC *digit = static_cast<DigitMC *>(digitsObject);
-      BOOST_CHECK(digit->getMCEvent(0) == MCevent[digits]);
-      BOOST_CHECK(digit->getMCTrack(0) == MCtrack[digits]);
+      /// \todo fix this
+      //BOOST_CHECK(digit->getMCEvent(0) == MCevent[digits]);
+      //BOOST_CHECK(digit->getMCTrack(0) == MCtrack[digits]);
       BOOST_CHECK(digit->getCRU() == CRU[digits]);
       BOOST_CHECK(digit->getTimeStamp() == Time[digits]);
       BOOST_CHECK(digit->getRow() == Row[digits]);
@@ -62,8 +66,10 @@ namespace TPC {
     const SAMPAProcessing& sampa = SAMPAProcessing::instance();
     auto *mDigitContainer = new DigitContainer();
 
-    std::vector<int> MCevent = { 1, 62,  1, 62, 62, 50, 62, 1, 1, 1};
-    std::vector<int> MCtrack = {22,  3, 22,  3,  3, 70,  3, 7, 7, 7};
+    /// \todo add test with FairLink stuff if possible
+    std::vector<int> hitID = { 1, 62,  1, 62, 62, 50, 62, 1, 1, 1};
+    //std::vector<int> MCevent = { 1, 62,  1, 62, 62, 50, 62, 1, 1, 1};
+    //std::vector<int> MCtrack = {22,  3, 22,  3,  3, 70,  3, 7, 7, 7};
     std::vector<int> CRU     = {23, 23, 23, 23, 23, 23, 23, 23, 23, 23};
     std::vector<int> Time    = {231, 231, 231, 231, 231, 231, 231, 231, 231, 231};
     std::vector<int> Row     = {12, 12, 12, 12, 12, 12, 12, 12, 12, 12};
@@ -75,7 +81,8 @@ namespace TPC {
 
     int nEleSum = 0;
     for(int i=0; i<CRU.size(); ++i) {
-      mDigitContainer->addDigit(MCevent[i], MCtrack[i], CRU[i], Time[i], Row[i], Pad[i], nEle[i]);
+      //mDigitContainer->addDigit(MCevent[i], MCtrack[i], CRU[i], Time[i], Row[i], Pad[i], nEle[i]);
+      mDigitContainer->addDigit(hitID[i], CRU[i], Time[i], Row[i], Pad[i], nEle[i]);
       nEleSum += nEle[i];
     }
 
@@ -87,10 +94,12 @@ namespace TPC {
     int digits = 0;
     for(auto digitsObject : *mDigitsArray) {
       DigitMC *digit = static_cast<DigitMC *>(digitsObject);
-      for(int j=0; j<digit->getNumberOfMClabels(); ++j) {
-        BOOST_CHECK(digit->getMCEvent(j) == MCeventSorted[j]);
-        BOOST_CHECK(digit->getMCTrack(j) == MCtrackSorted[j]);
-      }
+      /// \todo fix this
+      //BOOST_CHECK(digit->getMCEvent(0) == MCevent[digits]);
+      //for(int j=0; j<digit->getNumberOfMClabels(); ++j) {
+        //BOOST_CHECK(digit->getMCEvent(j) == MCeventSorted[j]);
+        //BOOST_CHECK(digit->getMCTrack(j) == MCtrackSorted[j]);
+      //}
       BOOST_CHECK(digit->getCRU() == CRU[digits]);
       BOOST_CHECK(digit->getTimeStamp() == Time[digits]);
       BOOST_CHECK(digit->getRow() == Row[digits]);

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -609,6 +609,24 @@ o2_define_bucket(
     ${CMAKE_SOURCE_DIR}/Detectors/TPC/base/include
 )
 
+o2_define_bucket(
+    NAME
+    tpc_eventdisplay_bucket
+
+    DEPENDENCIES
+    tpc_base_bucket
+    tpc_simulation_bucket
+    EventDisplay
+    #   Core
+    #    root_base_bucket
+    #    fairroot_geom
+    #    ${GENERATORS_LIBRARY}
+
+    INCLUDE_DIRECTORIES
+    ${FAIRROOT_INCLUDE_DIR}
+    ${CMAKE_SOURCE_DIR}/Detectors/TPC/simulation/include
+)
+
 
 o2_define_bucket(
     NAME

--- a/macro/run_digi_tpc.C
+++ b/macro/run_digi_tpc.C
@@ -12,6 +12,7 @@
   #include "FairSystemInfo.h"
   #include "FairRuntimeDb.h"
   #include "FairParRootFileIo.h"
+  #include "FairLinkManager.h"
 
   #include "TGeoGlobalMagField.h"
   #include "Field/MagneticField.h"
@@ -36,6 +37,13 @@ void run_digi_tpc(Int_t nEvents = 10, TString mcEngine = "TGeant3"){
 
         // Setup FairRoot analysis manager
         FairRunAna * run = new FairRunAna();
+
+        // ===| Activation of fair links for MC ID |============================
+        run->SetUseFairLinks(kTRUE);
+        // -- only store the link to the MC track
+        //    if commented, also the links to all previous steps will be stored
+        FairLinkManager::Instance()->AddIncludeType(0);
+
         FairFileSource *fFileSource = new FairFileSource(inputfile.str().c_str());
         run->SetSource(fFileSource);
         run->SetOutputFile(outputfile.str().c_str());

--- a/macro/run_digi_tpc.C
+++ b/macro/run_digi_tpc.C
@@ -60,7 +60,6 @@ void run_digi_tpc(Int_t nEvents = 10, TString mcEngine = "TGeant3"){
 
         timer.Start();
         run->Run();
-        run->TerminateRun();
 
         std::cout << std::endl << std::endl;
 

--- a/macro/run_sim_tpc.C
+++ b/macro/run_sim_tpc.C
@@ -54,6 +54,9 @@ void run_sim_tpc(Int_t nEvents = 10, TString mcEngine = "TGeant3")
 
   // Create simulation run
   FairRunSim* run = new FairRunSim();
+  // enable usage of the fair link mechanism
+  run->SetUseFairLinks(kTRUE);
+
   run->SetName(mcEngine);      // Transport engine
   run->SetOutputFile(outFile); // Output file
   FairRuntimeDb* rtdb = run->GetRuntimeDb();
@@ -89,7 +92,7 @@ void run_sim_tpc(Int_t nEvents = 10, TString mcEngine = "TGeant3")
   run->SetGenerator(primGen);
 
   // store track trajectories
-//  run->SetStoreTraj(kTRUE);
+ run->SetStoreTraj(kTRUE);
 
   // Initialize simulation run
   run->Init();

--- a/macro/tpcEventDisplay.C
+++ b/macro/tpcEventDisplay.C
@@ -1,0 +1,45 @@
+//#if (!defined(__CINT__) && !defined(__CLING__)) || defined(__MAKECINT__)
+#include "TString.h"
+#include "FairRunAna.h"
+#include "FairFileSource.h"
+#include "FairRuntimeDb.h"
+#include "FairParRootFileIo.h"
+#include "FairEventManager.h"
+#include "FairMCTracks.h"
+#include "TPCEventdisplay/HitDrawTask.h"
+//#endif
+
+using namespace o2::TPC;
+
+void tpcEventDisplay(TString InputFile, TString ParFile)
+{
+  //-----User Settings:-----------------------------------------------
+  //TString  InputFile     ="test.root";
+  //TString  ParFile       ="params.root";
+  TString  OutFile	 ="tst.root";
+
+
+  // -----   Reconstruction run   -------------------------------------------
+  FairRunAna *fRun= new FairRunAna();
+  FairFileSource *fFileSource = new FairFileSource(InputFile.Data());
+  fRun->SetSource(fFileSource);
+  fRun->SetOutputFile(OutFile.Data());
+
+  FairRuntimeDb* rtdb = fRun->GetRuntimeDb();
+  FairParRootFileIo* parInput1 = new FairParRootFileIo();
+  parInput1->open(ParFile.Data());
+  rtdb->setFirstInput(parInput1);
+
+  FairEventManager *fMan= new FairEventManager();
+
+  //----------------------Traks and points -------------------------------------
+  FairMCTracks    *Track     = new FairMCTracks("Monte-Carlo Tracks");
+  FairPointSetDraw *pointSet = new HitDrawTask("TPCPoint", kRed, kFullSquare);
+
+  fMan->AddTask(Track);
+  fMan->AddTask(pointSet);
+
+
+  fMan->Init();
+
+}


### PR DESCRIPTION
Enable the usage of FairLinks for MC matching for hits and digits
Add director and first class for hit visualisation using the event display.

It can be used in the following way:
run simple simulation
`tpc-run-sim -m all`

start display in root
`
gSystem->AddIncludePath("-I$O2_ROOT/include -I$FAIRROOT_ROOT/include");
.x $PATH_TO_O2_SOURCE/tpcEventDisplay.C+("AliceO2_TGeant3.tpc.mc_2_event.root","AliceO2_TGeant3.tpc.params_2.root")
`

Click 'FairEventManager' -> 'Info' -> 'Current Event' arrow up