### PR TITLE
Change back aliceHLTWrapper executable name

### DIFF
--- a/Utilities/aliceHLTwrapper/CMakeLists.txt
+++ b/Utilities/aliceHLTwrapper/CMakeLists.txt
@@ -21,7 +21,7 @@ set(BUCKET_NAME O2DeviceApplication_bucket)
 O2_GENERATE_LIBRARY()
 
 Set(Exe_Names
-    aliceHLTWrapper
+    aliceHLTWrapperApp
     aliceHLTEventSampler
     runComponent
     )


### PR DESCRIPTION
In commit 3dc9c2e37eecf043cbba8a609720a212f4733af6 the aliceHLTWrapperApp executable was changed into aliceHLTWrapper.
However, this causes issues in non-case sensitive systems such as Mac OS X. Indeed, an aliceHLTWrapper.dir is created by cmake...and the system does not distinguish it from the aliceHLTwrapper.dir (notice the lower case for w) which comes from the Utilities/aliceHLTwrapper directory.
Switching back to the old name for the executable solves the issue