### PR TITLE
Renaming applications to avoid problems on Mac OS (#362)

### DIFF
--- a/Utilities/aliceHLTwrapper/CMakeLists.txt
+++ b/Utilities/aliceHLTwrapper/CMakeLists.txt
@@ -21,8 +21,8 @@ set(BUCKET_NAME O2DeviceApplication_bucket)
 O2_GENERATE_LIBRARY()
 
 Set(Exe_Names
-    aliceHLTWrapper
-    aliceHLTEventSampler
+    AliceHLTWrapperDevice
+    AliceHLTEventSamplerDevice
     runComponent
     )
 

--- a/Utilities/aliceHLTwrapper/src/aliceHLTWrapper.cxx
+++ b/Utilities/aliceHLTwrapper/src/aliceHLTWrapper.cxx
@@ -1,8 +1,8 @@
 //****************************************************************************
 //* This file is free software: you can redistribute it and/or modify        *
 //* it under the terms of the GNU General Public License as published by     *
-//* the Free Software Foundation, either version 3 of the License, or	     *
-//* (at your option) any later version.					     *
+//* the Free Software Foundation, either version 3 of the License, or        *
+//* (at your option) any later version.                                      *
 //*                                                                          *
 //* Primary Authors: Matthias Richter <richterm@scieq.net>                   *
 //*                                                                          *
@@ -10,7 +10,7 @@
 //* any purpose. It is provided "as is" without express or implied warranty. *
 //****************************************************************************
 
-//  @file   aliHLTWrapper.cxx
+//  @file   aliceHLTWrapper.cxx
 //  @author Matthias Richter
 //  @since  2014-05-07
 //  @brief  FairRoot/ALFA device running ALICE HLT code


### PR DESCRIPTION
Renaming
`aliceHLTWrapper` -> `AliceHLTWrapperDevice`
`aliceHLTEventSampler` -> `AliceHLTEventSamplerDevice`

This also follows the naming scheme recently been used for
device applications.

I'm going to update also the scripts/macrp now, but this needs a bit more time to test as those have not been running for a while.