### PR TITLE
Reviving start scripts for the 2014 prototype setup

### DIFF
--- a/Utilities/aliceHLTwrapper/launch-flp-epn.sh
+++ b/Utilities/aliceHLTwrapper/launch-flp-epn.sh
@@ -20,13 +20,13 @@
 
 ###################################################################
 # global settings
-number_of_flps=36
+number_of_flps=2
 flp_command_socket=48490
 flp_heartbeat_socket=48491
 baseport_on_flpgroup=48420
 baseport_on_epngroup=48480
-number_of_epns=28
-number_of_epns_per_node=1
+number_of_epns=2
+number_of_epns_per_node=2
 rundir=`pwd`
 
 ###################################################################
@@ -46,86 +46,15 @@ done
 
 ###################################################################
 # fill the list of nodes
-# 
+#
+# for every FLP group there needs to be an entry in the node list
+# nodes can be specified multiple times
 flpnodelist=
-flpnodelist=(${flpnodelist[@]} cn48$ibkey)
-flpnodelist=(${flpnodelist[@]} cn49$ibkey)
-flpnodelist=(${flpnodelist[@]} cn50$ibkey)
-flpnodelist=(${flpnodelist[@]} cn51$ibkey)
-flpnodelist=(${flpnodelist[@]} cn52$ibkey)
-flpnodelist=(${flpnodelist[@]} cn53$ibkey)
-flpnodelist=(${flpnodelist[@]} cn54$ibkey)
-flpnodelist=(${flpnodelist[@]} cn55$ibkey)
-flpnodelist=(${flpnodelist[@]} cn56$ibkey)
-flpnodelist=(${flpnodelist[@]} cn57$ibkey)
-flpnodelist=(${flpnodelist[@]} cn58$ibkey)
+flpnodelist=(${flpnodelist[@]} localhost)
+flpnodelist=(${flpnodelist[@]} localhost)
 
-#flpnodelist=(${flpnodelist[@]} cn00$ibkey)
-flpnodelist=(${flpnodelist[@]} cn01$ibkey)
-flpnodelist=(${flpnodelist[@]} cn02$ibkey)
-flpnodelist=(${flpnodelist[@]} cn03$ibkey)
-flpnodelist=(${flpnodelist[@]} cn04$ibkey)
-flpnodelist=(${flpnodelist[@]} cn05$ibkey)
-flpnodelist=(${flpnodelist[@]} cn06$ibkey)
-flpnodelist=(${flpnodelist[@]} cn07$ibkey)
-flpnodelist=(${flpnodelist[@]} cn08$ibkey)
-flpnodelist=(${flpnodelist[@]} cn09$ibkey)
-flpnodelist=(${flpnodelist[@]} cn10$ibkey)
-flpnodelist=(${flpnodelist[@]} cn11$ibkey)
-flpnodelist=(${flpnodelist[@]} cn12$ibkey)
-flpnodelist=(${flpnodelist[@]} cn13$ibkey)
-flpnodelist=(${flpnodelist[@]} cn14$ibkey)
-flpnodelist=(${flpnodelist[@]} cn15$ibkey)
-flpnodelist=(${flpnodelist[@]} cn16$ibkey)
-flpnodelist=(${flpnodelist[@]} cn17$ibkey)
-flpnodelist=(${flpnodelist[@]} cn18$ibkey)
-flpnodelist=(${flpnodelist[@]} cn19$ibkey)
-flpnodelist=(${flpnodelist[@]} cn26$ibkey)
-flpnodelist=(${flpnodelist[@]} cn27$ibkey)
-flpnodelist=(${flpnodelist[@]} cn28$ibkey)
-#flpnodelist=(${flpnodelist[@]} cn29$ibkey)
-flpnodelist=(${flpnodelist[@]} cn30$ibkey)
-flpnodelist=(${flpnodelist[@]} cn31$ibkey)
-flpnodelist=(${flpnodelist[@]} cn32$ibkey)
-flpnodelist=(${flpnodelist[@]} cn33$ibkey)
-flpnodelist=(${flpnodelist[@]} cn34$ibkey)
-flpnodelist=(${flpnodelist[@]} cn35$ibkey)
-
-# nodes with GPU
 epnnodelist=
-#epnnodelist=(${epnnodelist[@]} 10.162.130.20) # cn00 infiniband
-epnnodelist=(${epnnodelist[@]} 10.162.130.21) # cn01 infiniband
-epnnodelist=(${epnnodelist[@]} 10.162.130.22) # cn02 infiniband
-epnnodelist=(${epnnodelist[@]} 10.162.130.23) # cn03 infiniband
-epnnodelist=(${epnnodelist[@]} 10.162.130.24) # cn04 infiniband
-epnnodelist=(${epnnodelist[@]} 10.162.130.25) # cn05 infiniband
-epnnodelist=(${epnnodelist[@]} 10.162.130.26) # cn06 infiniband
-epnnodelist=(${epnnodelist[@]} 10.162.130.27) # cn07 infiniband
-epnnodelist=(${epnnodelist[@]} 10.162.130.28) # cn08 infiniband
-epnnodelist=(${epnnodelist[@]} 10.162.130.29) # cn09 infiniband
-
-epnnodelist=(${epnnodelist[@]} 10.162.130.30) # cn10 infiniband
-epnnodelist=(${epnnodelist[@]} 10.162.130.31) # cn11 infiniband
-epnnodelist=(${epnnodelist[@]} 10.162.130.32) # cn12 infiniband
-epnnodelist=(${epnnodelist[@]} 10.162.130.33) # cn13 infiniband
-epnnodelist=(${epnnodelist[@]} 10.162.130.34) # cn14 infiniband
-epnnodelist=(${epnnodelist[@]} 10.162.130.35) # cn15 infiniband
-epnnodelist=(${epnnodelist[@]} 10.162.130.36) # cn16 infiniband
-epnnodelist=(${epnnodelist[@]} 10.162.130.37) # cn17 infiniband
-epnnodelist=(${epnnodelist[@]} 10.162.130.38) # cn18 infiniband
-epnnodelist=(${epnnodelist[@]} 10.162.130.39) # cn19 infiniband
-
-epnnodelist=(${epnnodelist[@]} 10.162.130.46) # cn26 infiniband
-epnnodelist=(${epnnodelist[@]} 10.162.130.47) # cn27 infiniband
-epnnodelist=(${epnnodelist[@]} 10.162.130.48) # cn28 infiniband
-#epnnodelist=(${epnnodelist[@]} 10.162.130.49) # cn29 infiniband
-epnnodelist=(${epnnodelist[@]} 10.162.130.50) # cn30 infiniband
-epnnodelist=(${epnnodelist[@]} 10.162.130.51) # cn31 infiniband
-epnnodelist=(${epnnodelist[@]} 10.162.130.52) # cn32 infiniband
-epnnodelist=(${epnnodelist[@]} 10.162.130.53) # cn33 infiniband
-epnnodelist=(${epnnodelist[@]} 10.162.130.54) # cn34 infiniband
-epnnodelist=(${epnnodelist[@]} 10.162.130.55) # cn35 infiniband
-
+epnnodelist=(${epnnodelist[@]} 127.0.0.1)
 
 nflpnodes=${#flpnodelist[@]}
 nepnnodes=${#epnnodelist[@]}
@@ -146,6 +75,10 @@ epnsessioncmd=
 epnsessiondataout=
 nepnsessions=0
 
+# the same node name can be specified for multiple FLP groups
+# this map holds a count of groups per node while adding the groups
+declare -A flpgroupsPerNode
+
 ###################################################################
 
 ###################################################################
@@ -155,7 +88,7 @@ create_flpgroup() {
     basesocket=$2
 
     # for now only one flp per node
-    deviceid="FLP_$node"
+    deviceid="FLP_$node${3:+_${3}}"
     command="flpSender"
     command+=" --id $deviceid"
     command+=" --control static"
@@ -244,7 +177,9 @@ while [ "$nflpsessions" -lt "$number_of_flps" ]; do
         error=1
         break
     fi
-    create_flpgroup ${flpnodelist[$inode]} $baseport_on_flpgroup
+    key=${flpnodelist[$inode]}
+    create_flpgroup ${flpnodelist[$inode]} $(( baseport_on_flpgroup + ${flpgroupsPerNode[$key]:=0} )) ${flpgroupsPerNode[$key]:=0}
+    flpgroupsPerNode[$key]=$(( flpgroupsPerNode[$key] + 1 ))
 
     let inode++
 done


### PR DESCRIPTION
Bringing the 2014 prototype setup back to live. Some adjustments in the start scripts.
* Renaming aliceHLTWrapper to AliceHLTWrapperDevice following https://github.com/AliceO2Group/AliceO2/issues/362/https://github.com/AliceO2Group/AliceO2/pull/363
* Removing node setup tailored to the HLT dev cluster and replacing it with a local setup
* Some enhancements to run multiple FLP groups on one node