### PR TITLE
Porting the real cluster finder

### DIFF
--- a/Detectors/ITSMFT/ITS/macros/test/run_test.sh
+++ b/Detectors/ITSMFT/ITS/macros/test/run_test.sh
@@ -1,8 +1,8 @@
 #
 nEvents=10
 mcEngine=\"TGeant3\"
-#To activate the ALPIDE response, set alp=kTRUE
-alp=kFALSE
+#To de-activate the ALPIDE response, set alp=kFALSE
+alp=kTRUE
 #
 root.exe -b -q $O2_ROOT/share/macro/run_sim_its_ALP3.C+\($nEvents,$mcEngine\) >& sim.log
 #root.exe -b -q $O2_ROOT/share/macro/run_sim_its.C+\($nEvents,$mcEngine\) >& sim.log

--- a/Detectors/ITSMFT/ITS/reconstruction/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/reconstruction/CMakeLists.txt
@@ -5,17 +5,20 @@ O2_SETUP(NAME ${MODULE_NAME})
 set(SRCS
     src/Cluster.cxx
     src/TrivialClustererTask.cxx
+    src/ClustererTask.cxx
     src/CookedTrack.cxx
     src/CookedTrackerTask.cxx
     )
 set(HEADERS
     include/${MODULE_NAME}/Cluster.h
     include/${MODULE_NAME}/TrivialClustererTask.h
+    include/${MODULE_NAME}/ClustererTask.h
     include/${MODULE_NAME}/CookedTrack.h
     include/${MODULE_NAME}/CookedTrackerTask.h
     )
 set(NO_DICT_SRCS # sources not for the dictionary
     src/TrivialClusterer.cxx
+    src/Clusterer.cxx
     src/CAaux.cxx
     src/CATracker.cxx
     src/CATrackingStation.cxx
@@ -23,6 +26,7 @@ set(NO_DICT_SRCS # sources not for the dictionary
     )
 set(NO_DICT_HEADERS # sources not for the dictionary
     include/${MODULE_NAME}/TrivialClusterer.h
+    include/${MODULE_NAME}/Clusterer.h
     include/${MODULE_NAME}/CAaux.h
     include/${MODULE_NAME}/CATracker.h
     include/${MODULE_NAME}/CATrackingStation.h

--- a/Detectors/ITSMFT/ITS/reconstruction/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/reconstruction/CMakeLists.txt
@@ -18,6 +18,7 @@ set(HEADERS
     )
 set(NO_DICT_SRCS # sources not for the dictionary
     src/TrivialClusterer.cxx
+    src/PixelReader.cxx
     src/Clusterer.cxx
     src/CAaux.cxx
     src/CATracker.cxx
@@ -26,6 +27,7 @@ set(NO_DICT_SRCS # sources not for the dictionary
     )
 set(NO_DICT_HEADERS # sources not for the dictionary
     include/${MODULE_NAME}/TrivialClusterer.h
+    include/${MODULE_NAME}/PixelReader.h
     include/${MODULE_NAME}/Clusterer.h
     include/${MODULE_NAME}/CAaux.h
     include/${MODULE_NAME}/CATracker.h

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/Clusterer.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/Clusterer.h
@@ -3,36 +3,51 @@
 #ifndef ALICEO2_ITS_CLUSTERER_H
 #define ALICEO2_ITS_CLUSTERER_H
 
-#include "Rtypes.h"  // for Clusterer::Class, Double_t, ClassDef, etc
+#include <utility>
+#include <vector>
+
+#include "Rtypes.h"
 
 class TClonesArray;
-
-namespace o2 {
-  namespace ITSMFT {
-    class SegmentationPixel;
-  }
-}
 
 namespace o2
 {
 namespace ITS
 {
+  class PixelReader;
   class Clusterer
 {
  public:
   Clusterer();
-  ~Clusterer();
+  ~Clusterer() = default;
 
   Clusterer(const Clusterer&) = delete;
   Clusterer& operator=(const Clusterer&) = delete;
 
-  /// Steer conversion of points to digits
-  /// @param points Container with ITS points
-  /// @return digits container
-  void process(const o2::ITSMFT::SegmentationPixel *seg, const TClonesArray* digits, TClonesArray* clusters);
+  static void setPixelGeometry(Float_t px, Float_t pz, Float_t x0, Float_t z0) {
+    mPitchX=px; mPitchZ=pz; mX0=x0; mZ0=z0;
+  }
+  void process(PixelReader &r, TClonesArray &clusters);
 
+ private:
+  enum {kMaxRow=650}; //Anything larger than the real number of rows (512 for ALPIDE)
+  void initChip(UShort_t chipID, UShort_t row, UShort_t col, Int_t label);
+  void updateChip(UShort_t chipID, UShort_t row, UShort_t col, Int_t label);
+  void finishChip(TClonesArray &clusters);
+
+  Int_t mColumn1[kMaxRow+2];
+  Int_t mColumn2[kMaxRow+2];
+  Int_t *mCurr, *mPrev;
+  std::vector<std::vector<std::pair<UShort_t,UShort_t>>> mPreClusters;
+  std::vector<Int_t> mLabels;
+  
+  UShort_t mChipID; ///< ID of the chip being processed
+  UShort_t mCol;    ///< Column being processed
+
+  static Float_t mPitchX, mPitchZ; ///< Pixel pitch in X and Z (cm)
+  static Float_t mX0, mZ0;         ///< Local X and Y coordinates (cm) of the very 1st pixel
 };
-}
-}
 
+}
+}
 #endif /* ALICEO2_ITS_CLUSTERER_H */

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/Clusterer.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/Clusterer.h
@@ -38,9 +38,16 @@ namespace ITS
   Int_t mColumn1[kMaxRow+2];
   Int_t mColumn2[kMaxRow+2];
   Int_t *mCurr, *mPrev;
-  std::vector<std::vector<std::pair<UShort_t,UShort_t>>> mPreClusters;
-  std::vector<Int_t> mIndices;
-  std::vector<Int_t> mLabels;
+  
+  using Pixel = std::pair<UShort_t,UShort_t>;
+  using NextIndex = Int_t;
+  std::vector< std::pair<NextIndex, Pixel> > mPixels;
+
+  using MCLabel = Int_t;
+  using FirstIndex = Int_t;
+  std::vector< std::pair<FirstIndex,MCLabel> > mPreClusterHeads;
+  
+  std::vector<Int_t> mPreClusterIndices;
   
   UShort_t mChipID; ///< ID of the chip being processed
   UShort_t mCol;    ///< Column being processed

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/Clusterer.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/Clusterer.h
@@ -39,6 +39,7 @@ namespace ITS
   Int_t mColumn2[kMaxRow+2];
   Int_t *mCurr, *mPrev;
   std::vector<std::vector<std::pair<UShort_t,UShort_t>>> mPreClusters;
+  std::vector<Int_t> mIndices;
   std::vector<Int_t> mLabels;
   
   UShort_t mChipID; ///< ID of the chip being processed

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/Clusterer.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/Clusterer.h
@@ -1,0 +1,38 @@
+/// \file Clusterer.h
+/// \brief Definition of the ITS cluster finder
+#ifndef ALICEO2_ITS_CLUSTERER_H
+#define ALICEO2_ITS_CLUSTERER_H
+
+#include "Rtypes.h"  // for Clusterer::Class, Double_t, ClassDef, etc
+
+class TClonesArray;
+
+namespace o2 {
+  namespace ITSMFT {
+    class SegmentationPixel;
+  }
+}
+
+namespace o2
+{
+namespace ITS
+{
+  class Clusterer
+{
+ public:
+  Clusterer();
+  ~Clusterer();
+
+  Clusterer(const Clusterer&) = delete;
+  Clusterer& operator=(const Clusterer&) = delete;
+
+  /// Steer conversion of points to digits
+  /// @param points Container with ITS points
+  /// @return digits container
+  void process(const o2::ITSMFT::SegmentationPixel *seg, const TClonesArray* digits, TClonesArray* clusters);
+
+};
+}
+}
+
+#endif /* ALICEO2_ITS_CLUSTERER_H */

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/ClustererTask.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/ClustererTask.h
@@ -7,6 +7,7 @@
 #include "FairTask.h" 
 
 #include "ITSBase/GeometryTGeo.h"
+#include "ITSReconstruction/PixelReader.h"
 #include "ITSReconstruction/Clusterer.h"
 
 class TClonesArray;
@@ -25,10 +26,10 @@ class ClustererTask : public FairTask
   void Exec(Option_t* option) override;
 
  private:
-  GeometryTGeo mGeometry; ///< ITS geometry
-  Clusterer mClusterer;   ///< Cluster finder
+  GeometryTGeo mGeometry;    ///< ITS geometry
+  DigitPixelReader mReader;  ///< Pixel reader
+  Clusterer mClusterer;      ///< Cluster finder
 
-  TClonesArray* mDigitsArray;   ///< Array of digits
   TClonesArray* mClustersArray; ///< Array of clusters
 
   ClassDefOverride(ClustererTask, 1)

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/ClustererTask.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/ClustererTask.h
@@ -1,0 +1,39 @@
+/// \file ClustererTask.h
+/// \brief Definition of the ITS cluster finder task
+
+#ifndef ALICEO2_ITS_CLUSTERERTASK
+#define ALICEO2_ITS_CLUSTERERTASK
+
+#include "FairTask.h" 
+
+#include "ITSBase/GeometryTGeo.h"
+#include "ITSReconstruction/Clusterer.h"
+
+class TClonesArray;
+
+namespace o2
+{
+namespace ITS
+{
+class ClustererTask : public FairTask
+{
+ public:
+  ClustererTask();
+  ~ClustererTask() override;
+
+  InitStatus Init() override;
+  void Exec(Option_t* option) override;
+
+ private:
+  GeometryTGeo mGeometry; ///< ITS geometry
+  Clusterer mClusterer;   ///< Cluster finder
+
+  TClonesArray* mDigitsArray;   ///< Array of digits
+  TClonesArray* mClustersArray; ///< Array of clusters
+
+  ClassDefOverride(ClustererTask, 1)
+};
+}
+}
+
+#endif /* ALICEO2_ITS_CLUSTERERTASK */

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/PixelReader.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/PixelReader.h
@@ -5,6 +5,8 @@
 
 #include <Rtypes.h>
 
+class TClonesArray;
+
 namespace o2
 {
 namespace ITS
@@ -14,13 +16,14 @@ namespace ITS
 ///
 class PixelReader {
  public:
-  PixelReader();
+  PixelReader() {}
   PixelReader(const PixelReader& cluster) = delete;
   ~PixelReader() {};
 
   PixelReader& operator=(const PixelReader& cluster) = delete;
 
-  virtual Bool_t getNextFiredPixel(UShort_t &id, UShort_t &row, UShort_t &col) = 0; 
+  virtual void init() = 0;
+  virtual Bool_t getNextFiredPixel(UShort_t &id, UShort_t &row, UShort_t &col, Int_t &label) = 0; 
   //
  protected:
   //
@@ -32,7 +35,13 @@ class PixelReader {
 ///
 class DigitPixelReader : public PixelReader {
  public:
-  virtual Bool_t getNextFiredPixel(UShort_t &id, UShort_t &row, UShort_t &col); 
+  DigitPixelReader() : mDigitArray(nullptr), mIdx(0) {}
+  void setDigitArray(const TClonesArray *a) { mDigitArray=a; mIdx=0; }
+  void init() {mIdx=0;}
+  virtual Bool_t getNextFiredPixel(UShort_t &id, UShort_t &row, UShort_t &col, Int_t &label);
+ private:
+  const TClonesArray *mDigitArray;
+  Int_t mIdx;
 };
  
 /// \class RawPixelReader
@@ -40,7 +49,7 @@ class DigitPixelReader : public PixelReader {
 ///
 class RawPixelReader : public PixelReader {
  public:
-  virtual Bool_t getNextFiredPixel(UShort_t &id, UShort_t &row, UShort_t &col); 
+  virtual Bool_t getNextFiredPixel(UShort_t &id, UShort_t &row, UShort_t &col, Int_t &label); 
 };
 
  

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/PixelReader.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/PixelReader.h
@@ -1,0 +1,50 @@
+/// \file PixelReader.h
+/// \brief Definition of the ITS pixel reader
+#ifndef ALICEO2_ITS_PIXELREADER_H
+#define ALICEO2_ITS_PIXELREADER_H
+
+#include <Rtypes.h>
+
+namespace o2
+{
+namespace ITS
+{
+/// \class PixelReader
+/// \brief PixelReader class for the ITS
+///
+class PixelReader {
+ public:
+  PixelReader();
+  PixelReader(const PixelReader& cluster) = delete;
+  ~PixelReader() {};
+
+  PixelReader& operator=(const PixelReader& cluster) = delete;
+
+  virtual Bool_t getNextFiredPixel(UShort_t &id, UShort_t &row, UShort_t &col) = 0; 
+  //
+ protected:
+  //
+
+};
+
+/// \class DigitPixelReader
+/// \brief DigitPixelReader class for the ITS. Feeds the MC digits to the Cluster Finder
+///
+class DigitPixelReader : public PixelReader {
+ public:
+  virtual Bool_t getNextFiredPixel(UShort_t &id, UShort_t &row, UShort_t &col); 
+};
+ 
+/// \class RawPixelReader
+/// \brief RawPixelReader class for the ITS. Feeds raw data to the Cluster Finder
+///
+class RawPixelReader : public PixelReader {
+ public:
+  virtual Bool_t getNextFiredPixel(UShort_t &id, UShort_t &row, UShort_t &col); 
+};
+
+ 
+}
+}
+
+#endif /* ALICEO2_ITS_PIXELREADER_H */

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/PixelReader.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/PixelReader.h
@@ -37,8 +37,8 @@ class DigitPixelReader : public PixelReader {
  public:
   DigitPixelReader() : mDigitArray(nullptr), mIdx(0) {}
   void setDigitArray(const TClonesArray *a) { mDigitArray=a; mIdx=0; }
-  void init() {mIdx=0;}
-  virtual Bool_t getNextFiredPixel(UShort_t &id, UShort_t &row, UShort_t &col, Int_t &label);
+  void init() override {mIdx=0;}
+  Bool_t getNextFiredPixel(UShort_t &id, UShort_t &row, UShort_t &col, Int_t &label) override;
  private:
   const TClonesArray *mDigitArray;
   Int_t mIdx;
@@ -49,7 +49,7 @@ class DigitPixelReader : public PixelReader {
 ///
 class RawPixelReader : public PixelReader {
  public:
-  virtual Bool_t getNextFiredPixel(UShort_t &id, UShort_t &row, UShort_t &col, Int_t &label); 
+  Bool_t getNextFiredPixel(UShort_t &id, UShort_t &row, UShort_t &col, Int_t &label) override; 
 };
 
  

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/PixelReader.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/PixelReader.h
@@ -16,9 +16,9 @@ namespace ITS
 ///
 class PixelReader {
  public:
-  PixelReader() {}
+  PixelReader() = default;
   PixelReader(const PixelReader& cluster) = delete;
-  ~PixelReader() {};
+  virtual ~PixelReader() = default;
 
   PixelReader& operator=(const PixelReader& cluster) = delete;
 

--- a/Detectors/ITSMFT/ITS/reconstruction/src/Clusterer.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/Clusterer.cxx
@@ -1,45 +1,130 @@
 /// \file Clusterer.cxx
 /// \brief Implementation of the ITS cluster finder
-#include "ITSMFTBase/Digit.h"
-#include "ITSMFTBase/SegmentationPixel.h"
+#include <algorithm>
+
+#include "TClonesArray.h"
+
+#include "ITSReconstruction/PixelReader.h"
 #include "ITSReconstruction/Clusterer.h"
 #include "ITSReconstruction/Cluster.h"
 
-#include "FairLogger.h"   // for LOG
-#include "TClonesArray.h" // for TClonesArray
-
-using o2::ITSMFT::SegmentationPixel;
-using o2::ITSMFT::Digit;
 using namespace o2::ITS;
 
-Clusterer::Clusterer() = default;
+Float_t Clusterer::mPitchX=0.002;
+Float_t Clusterer::mPitchZ=0.002;
+Float_t Clusterer::mX0=0.;
+Float_t Clusterer::mZ0=0.;
 
-Clusterer::~Clusterer() = default;
-
-void
-Clusterer::process(const SegmentationPixel *seg, const TClonesArray* digits, TClonesArray* clusters)
+Clusterer::Clusterer()
+  :mCurr(mColumn2)
+  ,mPrev(mColumn1)
+  ,mChipID(65535)
+  ,mCol(65535)
 {
-  Float_t sigma2 = seg->cellSizeX() * seg->cellSizeX() / 12.;
+  std::fill(std::begin(mColumn1), std::end(mColumn1), -1);
+  std::fill(std::begin(mColumn2), std::end(mColumn2), -1);
+}
 
-  TClonesArray& clref = *clusters;
-  for (TIter digP = TIter(digits).Begin(); digP != TIter::End(); ++digP) {
-    Digit* dig = static_cast<Digit*>(*digP);
-    Int_t ix = dig->getRow(), iz = dig->getColumn();
-    Double_t charge = dig->getCharge();
-    Int_t lab = dig->getLabel(0);
+void Clusterer::process(PixelReader &reader, TClonesArray &clusters)
+{
+  reader.init();
 
-    Float_t x = 0., y = 0., z = 0.;
-    seg->detectorToLocal(ix, iz, x, z);
+  UShort_t chipID,row,col;
+  Int_t label;
+  if ( !reader.getNextFiredPixel(chipID,row,col,label) ) return;
+  initChip(chipID,row,col,label);   // mChipID=chipID and mCol=col
+
+  while (reader.getNextFiredPixel(chipID,row,col,label)) {
+
+    while (chipID == mChipID) {
+        updateChip(chipID,row,col,label);
+        if ( !reader.getNextFiredPixel(chipID,row,col,label) ) goto exit;
+    }
+
+    finishChip(clusters);
+    initChip(chipID,row,col,label); // mChipID=chipID and mCol=col
+  }
+
+ exit:
+  finishChip(clusters);
+}
+
+void Clusterer::initChip(UShort_t chipID, UShort_t row, UShort_t col, Int_t label)
+{
+  mPrev=mColumn1;
+  mCurr=mColumn2;
+  std::fill(std::begin(mColumn1), std::end(mColumn1), -1);
+  std::fill(std::begin(mColumn2), std::end(mColumn2), -1);
+
+  mPreClusters.clear();
+  mLabels.clear();
+
+  mChipID=chipID;
+  mCol=col;
+  mCurr[row+1]=0;
+  mPreClusters.emplace_back(1,std::pair<UShort_t,UShort_t>(row,col)); //start the first precluster
+  mLabels.push_back(label);
+}
+
+void Clusterer::updateChip(UShort_t chipID, UShort_t row, UShort_t col, Int_t label)
+{
+  if (mCol != col) { // switch the buffers
+     Int_t *tmp=mCurr;
+     mCurr=mPrev;
+     mPrev=tmp;
+     if (col > mCol+1) std::fill(mPrev, mPrev+kMaxRow+2, -1);
+     std::fill(mCurr, mCurr+kMaxRow+2, -1);
+     mCol=col;
+  }
+
+  Int_t idx=row+1;
+  auto clusterIdx = mCurr[idx-1];     //upper
+  if (clusterIdx < 0) {
+     clusterIdx = mPrev[idx];         //left
+     if (clusterIdx < 0) {
+        clusterIdx = mPrev[idx-1];    //upper left
+        if (clusterIdx < 0) {
+	   clusterIdx = mPrev[idx+1]; //lower left
+	   if (clusterIdx < 0) {
+	      mCurr[idx]=mPreClusters.size();
+	      mPreClusters.emplace_back(1,std::pair<UShort_t,UShort_t>(row,col)); //new precluster
+              mLabels.push_back(label);
+              return;
+	   }
+        }
+     }
+  }
+  mCurr[idx] = clusterIdx;
+  mPreClusters[clusterIdx].emplace_back(row,col); //update an existing precluster
+}
+
+void Clusterer::finishChip(TClonesArray &clusters)
+{
+  static Float_t sigmaX2 = mPitchX * mPitchX / 12.; //FIXME
+  static Float_t sigmaY2 = mPitchZ * mPitchZ / 12.;
+
+  Int_t i=0;
+  for (auto pre : mPreClusters) {
+    Int_t npix = pre.size();
+    Float_t x=0., z=0.;
+    for (auto dig : pre) {
+      x += dig.first;
+      z += dig.second;
+    }
+    x /= npix;
+    x = mX0 + x*mPitchX;
+    z /= npix;
+    z = mZ0 + z*mPitchZ;
     Cluster c;
-    c.setVolumeId(dig->getChipIndex());
+    c.setVolumeId(mChipID);
     c.setX(x);
-    c.setY(y);
+    c.setY(0);
     c.setZ(z);
-    c.setSigmaY2(sigma2);
-    c.setSigmaZ2(sigma2);
+    c.setSigmaY2(sigmaX2);
+    c.setSigmaZ2(sigmaY2);
+    c.setNxNzN(3,3,npix); //FIXME
     c.setFrameLoc();
-    c.setLabel(lab, 0);
-
-    new (clref[clref.GetEntriesFast()]) Cluster(c);
+    c.setLabel(mLabels[i++], 0);
+    new (clusters[clusters.GetEntriesFast()]) Cluster(c);
   }
 }

--- a/Detectors/ITSMFT/ITS/reconstruction/src/Clusterer.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/Clusterer.cxx
@@ -156,7 +156,7 @@ void Clusterer::finishChip(TClonesArray &clusters)
     x = mX0 + x*mPitchX;
     z /= npix;
     z = mZ0 + z*mPitchZ;
-    Cluster *c = (Cluster *)clusters.ConstructedAt(noc++);
+    Cluster *c = static_cast<Cluster *>(clusters.ConstructedAt(noc++));
     c->setVolumeId(mChipID);
     c->setX(x);
     c->setY(0);

--- a/Detectors/ITSMFT/ITS/reconstruction/src/Clusterer.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/Clusterer.cxx
@@ -114,6 +114,8 @@ void Clusterer::finishChip(TClonesArray &clusters)
   static Float_t sigmaX2 = mPitchX * mPitchX / 12.; //FIXME
   static Float_t sigmaY2 = mPitchZ * mPitchZ / 12.;
 
+  Int_t noc = clusters.GetEntriesFast();
+  
   for (Int_t i1=0; i1<mPreClusterHeads.size(); ++i1) {
     const auto ci = mPreClusterIndices[i1];
     if (ci<0) continue;
@@ -154,15 +156,15 @@ void Clusterer::finishChip(TClonesArray &clusters)
     x = mX0 + x*mPitchX;
     z /= npix;
     z = mZ0 + z*mPitchZ;
-    Cluster &c = *(new (clusters[clusters.GetEntriesFast()]) Cluster());
-    c.setVolumeId(mChipID);
-    c.setX(x);
-    c.setY(0);
-    c.setZ(z);
-    c.setSigmaY2(sigmaX2);
-    c.setSigmaZ2(sigmaY2);
-    c.setNxNzN(xmax-xmin+1,zmax-zmin+1,npix);
-    c.setFrameLoc();
-    c.setLabel(mPreClusterHeads[i1].second, 0);
+    Cluster *c = (Cluster *)clusters.ConstructedAt(noc++);
+    c->setVolumeId(mChipID);
+    c->setX(x);
+    c->setY(0);
+    c->setZ(z);
+    c->setSigmaY2(sigmaX2);
+    c->setSigmaZ2(sigmaY2);
+    c->setNxNzN(xmax-xmin+1,zmax-zmin+1,npix);
+    c->setFrameLoc();
+    c->setLabel(mPreClusterHeads[i1].second, 0);
   }
 }

--- a/Detectors/ITSMFT/ITS/reconstruction/src/Clusterer.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/Clusterer.cxx
@@ -106,10 +106,16 @@ void Clusterer::finishChip(TClonesArray &clusters)
   Int_t i=0;
   for (auto pre : mPreClusters) {
     Int_t npix = pre.size();
+    UShort_t xmax=0, xmin=65535;
+    UShort_t zmax=0, zmin=65535;
     Float_t x=0., z=0.;
     for (auto dig : pre) {
       x += dig.first;
       z += dig.second;
+      if (dig.first < xmin) xmin=dig.first;
+      if (dig.first > xmax) xmax=dig.first;
+      if (dig.second < zmin) zmin=dig.second;
+      if (dig.second > zmax) zmax=dig.second;
     }
     x /= npix;
     x = mX0 + x*mPitchX;
@@ -122,7 +128,7 @@ void Clusterer::finishChip(TClonesArray &clusters)
     c.setZ(z);
     c.setSigmaY2(sigmaX2);
     c.setSigmaZ2(sigmaY2);
-    c.setNxNzN(3,3,npix); //FIXME
+    c.setNxNzN(xmax-xmin+1,zmax-zmin+1,npix);
     c.setFrameLoc();
     c.setLabel(mLabels[i++], 0);
     new (clusters[clusters.GetEntriesFast()]) Cluster(c);

--- a/Detectors/ITSMFT/ITS/reconstruction/src/Clusterer.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/Clusterer.cxx
@@ -1,0 +1,45 @@
+/// \file Clusterer.cxx
+/// \brief Implementation of the ITS cluster finder
+#include "ITSMFTBase/Digit.h"
+#include "ITSMFTBase/SegmentationPixel.h"
+#include "ITSReconstruction/Clusterer.h"
+#include "ITSReconstruction/Cluster.h"
+
+#include "FairLogger.h"   // for LOG
+#include "TClonesArray.h" // for TClonesArray
+
+using o2::ITSMFT::SegmentationPixel;
+using o2::ITSMFT::Digit;
+using namespace o2::ITS;
+
+Clusterer::Clusterer() = default;
+
+Clusterer::~Clusterer() = default;
+
+void
+Clusterer::process(const SegmentationPixel *seg, const TClonesArray* digits, TClonesArray* clusters)
+{
+  Float_t sigma2 = seg->cellSizeX() * seg->cellSizeX() / 12.;
+
+  TClonesArray& clref = *clusters;
+  for (TIter digP = TIter(digits).Begin(); digP != TIter::End(); ++digP) {
+    Digit* dig = static_cast<Digit*>(*digP);
+    Int_t ix = dig->getRow(), iz = dig->getColumn();
+    Double_t charge = dig->getCharge();
+    Int_t lab = dig->getLabel(0);
+
+    Float_t x = 0., y = 0., z = 0.;
+    seg->detectorToLocal(ix, iz, x, z);
+    Cluster c;
+    c.setVolumeId(dig->getChipIndex());
+    c.setX(x);
+    c.setY(y);
+    c.setZ(z);
+    c.setSigmaY2(sigma2);
+    c.setSigmaZ2(sigma2);
+    c.setFrameLoc();
+    c.setLabel(lab, 0);
+
+    new (clref[clref.GetEntriesFast()]) Cluster(c);
+  }
+}

--- a/Detectors/ITSMFT/ITS/reconstruction/src/ClustererTask.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/ClustererTask.cxx
@@ -1,0 +1,62 @@
+/// \file  ClustererTask.cxx
+/// \brief Implementation of the ITS cluster finder task
+
+#include "ITSReconstruction/ClustererTask.h"
+
+#include "FairLogger.h"      // for LOG
+#include "FairRootManager.h" // for FairRootManager
+#include "TClonesArray.h"    // for TClonesArray
+
+ClassImp(o2::ITS::ClustererTask)
+
+using o2::ITSMFT::SegmentationPixel;
+using namespace o2::ITS;
+
+//_____________________________________________________________________
+ClustererTask::ClustererTask() : FairTask("ITSClustererTask"), mDigitsArray(nullptr), mClustersArray(nullptr) {}
+
+//_____________________________________________________________________
+ClustererTask::~ClustererTask()
+{
+  if (mClustersArray) {
+    mClustersArray->Delete();
+    delete mClustersArray;
+  }
+}
+
+//_____________________________________________________________________
+/// \brief Init function
+/// Inititializes the clusterer and connects input and output container
+InitStatus ClustererTask::Init()
+{
+  FairRootManager* mgr = FairRootManager::Instance();
+  if (!mgr) {
+    LOG(ERROR) << "Could not instantiate FairRootManager. Exiting ..." << FairLogger::endl;
+    return kERROR;
+  }
+
+  mDigitsArray = dynamic_cast<TClonesArray*>(mgr->GetObject("ITSDigit"));
+  if (!mDigitsArray) {
+    LOG(ERROR) << "ITS points not registered in the FairRootManager. Exiting ..." << FairLogger::endl;
+    return kERROR;
+  }
+
+  // Register output container
+  mClustersArray = new TClonesArray("o2::ITS::Cluster");
+  mgr->Register("ITSCluster", "ITS", mClustersArray, kTRUE);
+
+  mGeometry.Build(kTRUE);
+
+  return kSUCCESS;
+}
+
+//_____________________________________________________________________
+void ClustererTask::Exec(Option_t* option)
+{
+  mClustersArray->Clear();
+  LOG(DEBUG) << "Running digitization on new event" << FairLogger::endl;
+
+  const SegmentationPixel* seg = (SegmentationPixel*)mGeometry.getSegmentationById(0);
+
+  mClusterer.process(seg, mDigitsArray, mClustersArray);
+}

--- a/Detectors/ITSMFT/ITS/reconstruction/src/ITSReconstructionLinkDef.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/ITSReconstructionLinkDef.h
@@ -6,6 +6,7 @@
 
 #pragma link C++ class o2::ITS::Cluster+;
 #pragma link C++ class o2::ITS::TrivialClustererTask+;
+#pragma link C++ class o2::ITS::ClustererTask+;
 #pragma link C++ class o2::ITS::CookedTrack+;
 #pragma link C++ class o2::ITS::CookedTrackerTask+;
 

--- a/Detectors/ITSMFT/ITS/reconstruction/src/PixelReader.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/PixelReader.cxx
@@ -1,24 +1,30 @@
 /// \file PixelReader.cxx
 /// \brief Implementation of the ITS pixel reader class
 
+#include <TClonesArray.h>
+
+#include "ITSMFTBase/Digit.h"
 #include "ITSReconstruction/PixelReader.h"
 
 using namespace o2::ITS;
-
-//_____________________________________________________
-PixelReader::PixelReader()
-{
-// default constructor
-}
+using o2::ITSMFT::Digit;
 
 //______________________________________________________________________________
-Bool_t DigitPixelReader::getNextFiredPixel(UShort_t &id, UShort_t &row, UShort_t &col)
+Bool_t DigitPixelReader::getNextFiredPixel(UShort_t &id, UShort_t &row, UShort_t &col, Int_t &label)
 {
+  if (mIdx >= mDigitArray->GetEntriesFast()) return kFALSE;
+
+  const Digit *d=static_cast<Digit *>(mDigitArray->UncheckedAt(mIdx++));
+  id = d->getChipIndex();
+  row = d->getRow();
+  col = d->getColumn();
+  label = d->getLabel(0);
+  
   return kTRUE;
 }
 
 //______________________________________________________________________________
-Bool_t RawPixelReader::getNextFiredPixel(UShort_t &id, UShort_t &row, UShort_t &col)
+Bool_t RawPixelReader::getNextFiredPixel(UShort_t &id, UShort_t &row, UShort_t &col, Int_t &label)
 {
   return kTRUE;
 }

--- a/Detectors/ITSMFT/ITS/reconstruction/src/PixelReader.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/PixelReader.cxx
@@ -1,0 +1,24 @@
+/// \file PixelReader.cxx
+/// \brief Implementation of the ITS pixel reader class
+
+#include "ITSReconstruction/PixelReader.h"
+
+using namespace o2::ITS;
+
+//_____________________________________________________
+PixelReader::PixelReader()
+{
+// default constructor
+}
+
+//______________________________________________________________________________
+Bool_t DigitPixelReader::getNextFiredPixel(UShort_t &id, UShort_t &row, UShort_t &col)
+{
+  return kTRUE;
+}
+
+//______________________________________________________________________________
+Bool_t RawPixelReader::getNextFiredPixel(UShort_t &id, UShort_t &row, UShort_t &col)
+{
+  return kTRUE;
+}

--- a/Detectors/ITSMFT/common/simulation/CMakeLists.txt
+++ b/Detectors/ITSMFT/common/simulation/CMakeLists.txt
@@ -4,25 +4,25 @@ O2_SETUP(NAME ${MODULE_NAME})
 
 set(SRCS
     src/Point.cxx
-    src/Chip.cxx
     src/ClusterShape.cxx
-    src/SimuClusterShaper.cxx
-    src/SimulationAlpide.cxx
     )
 set(HEADERS
     include/${MODULE_NAME}/Point.h
-    include/${MODULE_NAME}/Chip.h
     include/${MODULE_NAME}/ClusterShape.h
-    include/${MODULE_NAME}/SimuClusterShaper.h
-    include/${MODULE_NAME}/SimulationAlpide.h
     )
 set(NO_DICT_SRCS # sources not for the dictionary
+    src/Chip.cxx
     src/DigitChip.cxx
     src/DigitContainer.cxx
+    src/SimuClusterShaper.cxx
+    src/SimulationAlpide.cxx
    )
 set(NO_DICT_HEADERS # sources not for the dictionary
+    include/${MODULE_NAME}/Chip.h
     include/${MODULE_NAME}/DigitChip.h
-    include/${MODULE_NAME}/DigitCcontainer.h
+    include/${MODULE_NAME}/DigitContainer.h
+    include/${MODULE_NAME}/SimuClusterShaper.h
+    include/${MODULE_NAME}/SimulationAlpide.h
    )
 Set(LINKDEF src/ITSMFTSimulationLinkDef.h)
 Set(LIBRARY_NAME ${MODULE_NAME})

--- a/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Chip.h
+++ b/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Chip.h
@@ -213,8 +213,6 @@ class Chip : public TObject
     Int_t mChipIndex;     ///< Chip ID
     std::vector<const Point *>mPoints;        ///< Hits connnected to the given chip
     const TGeoHMatrix *mMat;     ///< Transformation matrix
-
-  ClassDefOverride(Chip, 2);
 };
 }
 }

--- a/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/SimuClusterShaper.h
+++ b/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/SimuClusterShaper.h
@@ -65,8 +65,6 @@ namespace o2 {
       UInt_t  mNpixOn;
       const SegmentationPixel* mSeg;
       ClusterShape *mCShape;
-
-      ClassDefOverride(SimuClusterShaper,1)
     };
   }
 }

--- a/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/SimulationAlpide.h
+++ b/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/SimulationAlpide.h
@@ -54,8 +54,6 @@ namespace o2 {
 
     protected:
       Double_t           mParam[NumberOfParameters]; // Chip response parameters
-
-      ClassDefOverride(SimulationAlpide,1)   // Simulation of pixel clusters
     };
   }
 }

--- a/Detectors/ITSMFT/common/simulation/src/Chip.cxx
+++ b/Detectors/ITSMFT/common/simulation/src/Chip.cxx
@@ -14,8 +14,6 @@
 #include "ITSMFTSimulation/Chip.h"
 #include "ITSMFTSimulation/Point.h"
 
-ClassImp(o2::ITSMFT::Chip)
-
 using namespace o2::ITSMFT;
 
 Chip::Chip() :

--- a/Detectors/ITSMFT/common/simulation/src/DigitChip.cxx
+++ b/Detectors/ITSMFT/common/simulation/src/DigitChip.cxx
@@ -48,7 +48,8 @@ Digit* DigitChip::addDigit(UShort_t chipid, UShort_t row, UShort_t col, Double_t
   if (digit) {
     LOG(DEBUG) << "Adding charge to pixel..." << FairLogger::endl;
     charge += digit->getCharge();
-    delete digit;
+    digit->setCharge(charge);
+    return digit;
   }
 
   digit = new Digit(chipid, row, col, charge, timestamp);

--- a/Detectors/ITSMFT/common/simulation/src/ITSMFTSimulationLinkDef.h
+++ b/Detectors/ITSMFT/common/simulation/src/ITSMFTSimulationLinkDef.h
@@ -5,10 +5,6 @@
 #pragma link off all functions;
 
 #pragma link C++ class o2::ITSMFT::Point+;
-#pragma link C++ class o2::ITSMFT::Chip+;
 #pragma link C++ class o2::ITSMFT::ClusterShape+;
-#pragma link C++ class o2::ITSMFT::SimuClusterShaper+;
-#pragma link C++ class o2::ITSMFT::SimulationAlpide+;
-#pragma link C++ class ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<float>,ROOT::Math::DefaultCoordinateSystemTag>+;
 
 #endif

--- a/Detectors/ITSMFT/common/simulation/src/SimuClusterShaper.cxx
+++ b/Detectors/ITSMFT/common/simulation/src/SimuClusterShaper.cxx
@@ -8,8 +8,6 @@
 
 #include "ITSMFTSimulation/SimuClusterShaper.h"
 
-ClassImp(o2::ITSMFT::SimuClusterShaper)
-
 using namespace o2::ITSMFT;
 
 //______________________________________________________________________

--- a/Detectors/ITSMFT/common/simulation/src/SimulationAlpide.cxx
+++ b/Detectors/ITSMFT/common/simulation/src/SimulationAlpide.cxx
@@ -17,8 +17,6 @@
 #include "ITSMFTSimulation/Point.h"
 #include "ITSMFTSimulation/DigitContainer.h"
 
-ClassImp(o2::ITSMFT::SimulationAlpide)
-
 using namespace o2::ITSMFT;
 
 //______________________________________________________________________

--- a/macro/run_clus_its.C
+++ b/macro/run_clus_its.C
@@ -10,7 +10,7 @@
   #include "FairParRootFileIo.h"
   #include "FairSystemInfo.h"
 
-  #include "ITSReconstruction/TrivialClustererTask.h"
+  #include "ITSReconstruction/ClustererTask.h"
 #endif
 
 void run_clus_its(Int_t nEvents = 10, TString mcEngine = "TGeant3"){
@@ -41,7 +41,7 @@ void run_clus_its(Int_t nEvents = 10, TString mcEngine = "TGeant3"){
         rtdb->setFirstInput(parInput1);
 
         // Setup clusterizer
-        o2::ITS::TrivialClustererTask *clus = new o2::ITS::TrivialClustererTask;
+        o2::ITS::ClustererTask *clus = new o2::ITS::ClustererTask;
         fRun->AddTask(clus);
 
         fRun->Init();


### PR DESCRIPTION
This is a minimalistic port of the ITS cluster finder. From now on, both this cluster finder and the ALPIDE response are activated inside the default ITS test. 