### PR TITLE
Swenzel/tpcimpr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,10 +154,8 @@ ENDIF (NOT ALICEO2_MODULAR_BUILD)
 # cause another cmake executable to run.  The same process will walk through
 # the project's entire directory structure.
 
-IF (PYTHIA8_FOUND AND Pythia6_FOUND)
-  add_subdirectory(Generators)
-  set(GENERATORS_LIBRARY Generators)
-ENDIF ()
+add_subdirectory(Generators)
+set(GENERATORS_LIBRARY Generators)
 
 add_subdirectory(CCDB)
 add_subdirectory(Common)

--- a/Detectors/TPC/simulation/include/TPCSimulation/Detector.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/Detector.h
@@ -13,8 +13,6 @@
 
 class FairVolume;  // lines 10-10
 
-class AliTPCParam;
-
 namespace o2 {
 namespace TPC {
 
@@ -103,6 +101,9 @@ class Detector: public o2::Base::Detector {
     const TString& GetGeoFileName() const   { return mGeoFileName; }
 
   private:
+    int mHitCounter = 0;
+    int mElectronCounter = 0;
+    int mStepCounter = 0;
     
     SimulationType mSimulationType;       ///< Type of simulation
 
@@ -122,6 +123,7 @@ class Detector: public o2::Base::Detector {
     /** container for data points */
     TClonesArray*  mPointCollection;
     TClonesArray*  mHitGroupCollection;    //! container that keeps track-grouped hits
+    TClonesArray*  mHitsPerSectorCollection[18];
 
     TString mGeoFileName;                  ///< Name of the file containing the TPC geometry
     size_t mEventNr;                       //!< current event number

--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitPad.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitPad.h
@@ -8,9 +8,13 @@
 
 #include <map>
 
+#define TPC_DIGIT_USEFAIRLINKS 1
+
 #include "FairRootManager.h"
+#ifdef TPC_DIGIT_USEFAIRLINKS
 #include "FairMultiLinkedData.h"
 #include "FairLink.h"
+#endif
 #include "TPCSimulation/CommonMode.h"
 #include <TClonesArray.h>
 
@@ -43,10 +47,11 @@ class DigitPad{
     /// \return Accumulated charge
     float getChargePad() const {return mChargePad;}
 
+#ifdef TPC_DIGIT_USEFAIRLINKS
     /// Get the MC Links
     /// \return MC Links
     const FairMultiLinkedData& getMCLinks() const { return mMCLinks; }
-
+#endif
     /// Add digit to the time bin container
     /// \param hitID MC Hit ID
     /// \param charge Charge of the digit
@@ -63,24 +68,30 @@ class DigitPad{
   private:
     float                  mChargePad;   ///< Total accumulated charge on that pad for a given time bin
     unsigned char          mPad;         ///< Pad of the ADC value
+#ifdef TPC_DIGIT_USEFAIRLINKS
     FairMultiLinkedData    mMCLinks;     ///< MC links
+#endif
 };
 
 inline
 DigitPad::DigitPad(int pad)
   : mChargePad(0.)
   , mPad(pad)
+#ifdef TPC_DIGIT_USEFAIRLINKS
   , mMCLinks()
+#endif
 {}
 
 inline 
-void DigitPad::setDigit(size_t hitID, float charge)
+void DigitPad::setDigit(size_t trackID, float charge)
 {
   /// the MC ID is encoded such that we can have 999,999 tracks
   /// numbers larger than 1000000 correspond to the event ID
   /// i.e. 12000010 corresponds to event 12 with track ID 10
   /// \todo Faster would be a bit shift
-  mMCLinks.AddLink(FairLink(-1, FairRootManager::Instance()->GetEntryNr(), "TPCPoint", hitID));
+#ifdef TPC_DIGIT_USEFAIRLINKS
+  mMCLinks.AddLink(FairLink(-1, FairRootManager::Instance()->GetEntryNr(), "MCTrack", trackID));
+#endif
   mChargePad += charge;
 }
 
@@ -88,7 +99,9 @@ inline
 void DigitPad::reset()
 {
   mChargePad = 0;
+#ifdef TPC_DIGIT_USEFAIRLINKS
   mMCLinks.Reset();
+#endif
 }
   
 }

--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitizerTask.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitizerTask.h
@@ -25,7 +25,7 @@ class DigitizerTask : public FairTask{
   public:
       
     /// Default constructor
-    DigitizerTask();
+    DigitizerTask(int sectorid=-1);
       
     /// Destructor
     ~DigitizerTask() override;
@@ -67,8 +67,11 @@ class DigitizerTask : public FairTask{
 
     int                 mTimeBinMax;   ///< Maximum time bin to be written out
     bool                mIsContinuousReadout; ///< Switch for continuous readout
+    int                 mHitSector=-1; ///< which sector to treat
 
-  ClassDefOverride(DigitizerTask, 1);
+    TClonesArray        *mSectorHitsArray[18];
+
+    ClassDefOverride(DigitizerTask, 1);
 };
 
 inline

--- a/Detectors/TPC/simulation/include/TPCSimulation/Point.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/Point.h
@@ -6,15 +6,26 @@
 #include "SimulationDataFormat/BaseHits.h"
 #include <vector>
 
+// this decides if TPC hits are grouped into
+// a LinkableHitGroup container
+#define TPC_GROUPED_HITS 1
+
 namespace o2 {
 namespace TPC {
 
 // a minimal and plain TPC hit class
 class ElementalHit {
  public:
-  Point3D<float> mPos; // cartesian position of Hit
+  //:: so as to get the right Point3D
+  ::Point3D<float> mPos; // cartesian position of Hit
   float mTime = -1;    // time of flight
   float mELoss = -2;   // energy loss
+
+  float GetX() const { return mPos.X(); }
+  float GetY() const { return mPos.Y(); }
+  float GetZ() const { return mPos.Z(); }
+  float GetEnergyLoss() const { return mELoss; }
+  float GetTime() const { return mTime; }
 
  public:
   ElementalHit() = default; // for ROOT IO
@@ -34,24 +45,139 @@ class ElementalHit {
 // and can be stored as element of a TClonesArray into a branch
 class LinkableHitGroup : public o2::BaseHit {
 public:
-  LinkableHitGroup() : mHits() {}
+  LinkableHitGroup() :
+#ifdef HIT_AOS
+  mHits()
+#else
+  mHitsXVctr(),
+  mHitsYVctr(),
+  mHitsZVctr(),
+  mHitsTVctr(),
+  mHitsEVctr(),
+  mHitsX(nullptr),
+  mHitsY(nullptr),
+  mHitsZ(nullptr),
+  mHitsT(nullptr),
+  mHitsE(nullptr),
+  mSize(0)
+#endif
+    {
+    }
 
-  LinkableHitGroup(int trackID) : mHits() {
+  LinkableHitGroup(int trackID) :
+#ifdef HIT_AOS
+  mHits()
+#else
+  mHitsXVctr(),
+  mHitsYVctr(),
+  mHitsZVctr(),
+  mHitsTVctr(),
+  mHitsEVctr(),
+  mHitsX(nullptr),
+  mHitsY(nullptr),
+  mHitsZ(nullptr),
+  mHitsT(nullptr),
+  mHitsE(nullptr),
+  mSize(0)
+#endif
+  {
     SetTrackID(trackID);
   }
 
   ~LinkableHitGroup() override = default;
 
-  void addHit(float x, float y, float z, float time, float e) {
+  void addHit(float x, float y, float z, float time, short e) {
+#ifdef HIT_AOS
     mHits.emplace_back(x,y,z,time,e);
+#else
+    mHitsXVctr.emplace_back(x);
+    mHitsYVctr.emplace_back(y);
+    mHitsZVctr.emplace_back(z);
+    mHitsTVctr.emplace_back(time);
+    mHitsEVctr.emplace_back(e);
+    mSize=mHitsXVctr.size();
+    mHitsX=&mHitsXVctr[0];
+    mHitsY=&mHitsYVctr[0];
+    mHitsZ=&mHitsZVctr[0];
+    mHitsT=&mHitsTVctr[0];
+    mHitsE=&mHitsEVctr[0];
+#endif
   }
 
-  size_t getSize() const {return mHits.size();}
-  std::vector<o2::TPC::ElementalHit> const & getHitGroup() const { return mHits; }
+  size_t getSize() const {
+#ifdef HIT_AOS
+    return mHits.size();
+#else
+    return mSize;
+#endif
+  }
 
+  ElementalHit getHit(size_t index) const {
+#ifdef HIT_AOS
+    // std::vector storage
+    return mHits[index];
+#else
+    return ElementalHit(mHitsX[index],mHitsY[index],mHitsZ[index],mHitsT[index],mHitsE[index]);
+#endif
+  }
+
+  // the Clear method of TObject
+  // called for instance from TClonesArray->Clear("C")
+  void Clear(Option_t */*option*/) override {
+#ifdef HIT_AOS
+    mHits.clear();
+#else
+    mHitsXVctr.clear();
+    mHitsYVctr.clear();
+    mHitsZVctr.clear();
+    mHitsTVctr.clear();
+    mHitsEVctr.clear();
+#endif
+    shrinkToFit();
+  }
+
+  void shrinkToFit() {
+    // shrink all the containers to have exactly the required size
+    // might improve overall memory consumption
+#ifdef HIT_AOS
+    // std::vector storage
+    mHits.shrink_to_fit();
+#else
+    mHitsXVctr.shrink_to_fit();
+    mHitsYVctr.shrink_to_fit();
+    mHitsZVctr.shrink_to_fit();
+    mHitsTVctr.shrink_to_fit();
+    mHitsEVctr.shrink_to_fit();
+    mHitsX=&mHitsXVctr[0];
+    mHitsY=&mHitsYVctr[0];
+    mHitsZ=&mHitsZVctr[0];
+    mHitsT=&mHitsTVctr[0];
+    mHitsE=&mHitsEVctr[0];
+    mSize=mHitsXVctr.size();
+#endif
+  }
+
+  // in future we might want to have a method
+  // FitAndCompress()
+  // which does a track fit and produces a parametrized hit
+  // (such as done in a similar form in AliRoot)
 public:
+#ifdef HIT_AOS
   std::vector<o2::TPC::ElementalHit> mHits; // the hits for this group
-  // could think about AOS/SOA storage
+#else
+  std::vector<float> mHitsXVctr; //! do not stream this (just for memory handling convenience)
+  std::vector<float> mHitsYVctr; //! do not stream this
+  std::vector<float> mHitsZVctr; //! do not stream this
+  std::vector<float> mHitsTVctr; //! do not stream this
+  std::vector<short> mHitsEVctr; //! do not stream this
+  // let us stream ordinary buffers for compression AND ROOT IO/speed!!
+  Int_t mSize;
+  float* mHitsX = nullptr; //[mSize]
+  float* mHitsY = nullptr; //[mSize]
+  float* mHitsZ = nullptr; //[mSize]
+  float* mHitsT = nullptr; //[mSize]
+  short* mHitsE = nullptr; //[mSize]
+#endif
   ClassDefOverride(LinkableHitGroup, 1);
 };
 

--- a/Detectors/TPC/simulation/src/DigitPad.cxx
+++ b/Detectors/TPC/simulation/src/DigitPad.cxx
@@ -24,7 +24,9 @@ void DigitPad::fillOutputContainer(TClonesArray *output, int cru, int timeBin, i
     TClonesArray &clref = *output;
     const size_t digiPos = clref.GetEntriesFast();
     DigitMC *digit = new(clref[digiPos]) DigitMC(cru, mADC, row, pad, timeBin, commonMode);
+#ifdef TPC_DIGIT_USEFAIRLINKS
     digit->SetLinks(getMCLinks());
+#endif
   }
 }
 

--- a/Generators/CMakeLists.txt
+++ b/Generators/CMakeLists.txt
@@ -4,27 +4,30 @@
 set(MODULE_NAME "Generators")
 
 O2_SETUP(NAME ${MODULE_NAME})
+
+set(SRCS
+    src/GeneratorFromFile.cxx
+    src/Pythia6Generator.cxx
+   )
+set(HEADERS
+    include/${MODULE_NAME}/GeneratorFromFile.h
+    include/${MODULE_NAME}/Pythia6Generator.h
+   )
+
 if (PYTHIA8_INCLUDE_DIR)
-
-  set(SRCS
-      src/Pythia6Generator.cxx
+  set(SRCS ${SRCS}
       src/Pythia8Generator.cxx
-      )
-
-  set(HEADERS
-      include/${MODULE_NAME}/Pythia6Generator.h
+     )
+  set(HEADERS ${HEADERS}
       include/${MODULE_NAME}/Pythia8Generator.h
       )
-
-  set(LINKDEF src/GeneratorsLinkDef.h)
-  set(LIBRARY_NAME ${MODULE_NAME})
-    set(BUCKET_NAME generators_bucket)
-
-#  set(DEPENDENCIES Base O2SimulationDataFormat pythia8 Pythia6)
-
-  O2_GENERATE_LIBRARY()
-
-
+  set(BUCKET_NAME generators_bucket)
 else (PYTHIA8_INCLUDE_DIR)
   message(STATUS "module 'Generators' requires Pythia8 ... deactivated")
+  set(BUCKET_NAME generators_base_bucket)
 endif (PYTHIA8_INCLUDE_DIR)
+
+set(LINKDEF src/GeneratorsLinkDef.h)
+set(LIBRARY_NAME ${MODULE_NAME})
+
+O2_GENERATE_LIBRARY()

--- a/Generators/include/Generators/GeneratorFromFile.h
+++ b/Generators/include/Generators/GeneratorFromFile.h
@@ -1,0 +1,48 @@
+/// \author S. Wenzel - Mai 2017
+
+#ifndef ALICEO2_GENERATORFROMFILE_H_
+#define ALICEO2_GENERATORFROMFILE_H_
+
+#include "FairGenerator.h"
+
+class TBranch;
+class TFile;
+
+namespace o2
+{
+namespace eventgen
+{
+/// This class implements a generic FairGenerator which
+/// reads the particles from an external file
+/// at the moment, this only supports reading from an AliRoot kinematics file
+/// TODO: generalize this to be able to read from files of various formats
+/// (idea: use Reader policies or classes)
+class GeneratorFromFile : public FairGenerator
+{
+ public:
+  GeneratorFromFile() = default;
+  GeneratorFromFile(const char* name);
+
+  // the FairGenerator interface methods
+
+  /** Generates (or reads) one event and adds the tracks to the
+   ** injected primary generator instance.
+   ** @param primGen  pointer to the primary FairPrimaryGenerator
+   **/
+  bool ReadEvent(FairPrimaryGenerator* primGen) override;
+
+  // Set from which event to start
+  void SetStartEvent(int start);
+
+ private:
+  TFile* mEventFile = nullptr; //! the file containing the persistent events
+  int mEventCounter = 0;
+  int mEventsAvailable = 0;
+
+  ClassDefOverride(GeneratorFromFile, 1);
+};
+
+} // end namespace eventgen
+} // end namespace o2
+
+#endif

--- a/Generators/src/GeneratorFromFile.cxx
+++ b/Generators/src/GeneratorFromFile.cxx
@@ -1,0 +1,89 @@
+#include "Generators/GeneratorFromFile.h"
+#include <FairLogger.h>
+#include <FairPrimaryGenerator.h>
+#include <TBranch.h>
+#include <TClonesArray.h>
+#include <TFile.h>
+#include <TParticle.h>
+#include <TTree.h>
+#include <sstream>
+
+namespace o2
+{
+namespace eventgen
+{
+GeneratorFromFile::GeneratorFromFile(const char* name)
+{
+  mEventFile = TFile::Open(name);
+  if (mEventFile == nullptr) {
+    LOG(ERROR) << "EventFile " << name << " not found \n";
+    return;
+  }
+  // the kinematics will be stored inside a Tree "TreeK" with branch "Particles"
+  // different events are stored inside TDirectories
+
+  // we need to probe for the number of events
+  TObject* object = nullptr;
+  do {
+    std::stringstream eventstringstr;
+    eventstringstr << "Event" << mEventsAvailable;
+    // std::cout << "probing for " << eventstring << "\n";
+    object = mEventFile->Get(eventstringstr.str().c_str());
+    // std::cout << "got " << object << "\n";
+    if (object != nullptr)
+      mEventsAvailable++;
+  } while (object != nullptr);
+  std::cout << "Found " << mEventsAvailable << " events in this file \n";
+}
+
+void GeneratorFromFile::SetStartEvent(int start)
+{
+  if (start < mEventsAvailable) {
+    mEventCounter = start;
+  } else {
+    std::cerr << "start event bigger than available events\n";
+  }
+}
+
+Bool_t GeneratorFromFile::ReadEvent(FairPrimaryGenerator* primGen)
+{
+  if (mEventCounter < mEventsAvailable) {
+    // get the tree and the branch
+    std::stringstream treestringstr;
+    treestringstr << "Event" << mEventCounter << "/TreeK";
+    TTree* tree = (TTree*)mEventFile->Get(treestringstr.str().c_str());
+    if (tree == nullptr)
+      return kFALSE;
+
+    auto branch = tree->GetBranch("Particles");
+    TParticle* primary = new TParticle();
+    branch->SetAddress(&primary);
+    for (int i = 0; i < branch->GetEntries(); ++i) {
+      branch->GetEntry(i); // fill primary
+      auto pdgid = primary->GetPdgCode();
+      auto px = primary->Px();
+      auto py = primary->Py();
+      auto pz = primary->Pz();
+      auto vx = primary->Vx();
+      auto vy = primary->Vy();
+      auto vz = primary->Vz();
+
+      auto parent = -1;
+      bool wanttracking = true;
+      auto e = primary->Energy();
+      auto tof = primary->T();
+      auto weight = primary->GetWeight();
+      primGen->AddTrack(pdgid, px, py, pz, vx, vy, vz, parent, wanttracking, e, tof, weight);
+    }
+    mEventCounter++;
+    return kTRUE;
+  } else {
+    LOG(ERROR) << "GeneratorFromFile: Ran out of events\n";
+  }
+  return kFALSE;
+}
+
+} // end namespace
+} // end namespace o2
+
+ClassImp(o2::eventgen::GeneratorFromFile)

--- a/Generators/src/GeneratorsLinkDef.h
+++ b/Generators/src/GeneratorsLinkDef.h
@@ -18,5 +18,6 @@
 
 #pragma link C++ class  Pythia6Generator+;
 #pragma link C++ class  Pythia8Generator+;
+#pragma link C++ class  o2::eventgen::GeneratorFromFile+;
 
 #endif

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -543,6 +543,7 @@ o2_define_bucket(
     tpc_base_bucket
     Field
     DetectorsBase
+    Generators
     TPCBase
     SimulationDataFormat
     Geom
@@ -634,18 +635,30 @@ o2_define_bucket(
     ${CMAKE_SOURCE_DIR}/Detectors/TPC/reconstruction/include
 )
 
+# base bucket for generators not needing any external stuff
+o2_define_bucket(
+    NAME
+    generators_base_bucket
+
+    DEPENDENCIES
+    Base SimulationDataFormat MathCore RIO Tree
+    fairroot_base_bucket
+
+    INCLUDE_DIRECTORIES
+    ${ROOT_INCLUDE_DIR}
+    ${FAIRROOT_INCLUDE_DIR}
+)
+
 o2_define_bucket(
     NAME
     generators_bucket
 
     DEPENDENCIES
-    Base SimulationDataFormat pythia6 pythia8 MathCore
+    generators_base_bucket
+    pythia8
 
     INCLUDE_DIRECTORIES
-    ${ROOT_INCLUDE_DIR}
-    ${FAIRROOT_INCLUDE_DIR}
     ${PYTHIA8_INCLUDE_DIR}
-    ${PYTHIA6_INCLUDE_DIR}
 )
 
 o2_define_bucket(


### PR DESCRIPTION
Improvements for TPC:

  * sectorwise hit storage (with a runtime gain in memory usage)
  * sectorwise hit processing in digitization
  * be able to switch on/off FairLinks during compilation for TPC digits
  

General improvements:

  * An event generator being able to read from an (AliRoot) kinematics file 