### PR TITLE
Regain possibility to do MC truth handling for TPC digits manually

### DIFF
--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitPad.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitPad.h
@@ -66,10 +66,30 @@ class DigitPad{
     void fillOutputContainer(TClonesArray *output, int cru, int timeBin, int row, int pad, float commonMode = 0);
 
   private:
+
+#ifndef TPC_DIGIT_USEFAIRLINKS
+    /// The MC labels are sorted by occurrence such that the event/track combination with the largest number of occurrences is first
+    /// This is then dumped into a std::vector and attached to the digits
+    /// \todo Find out how many different event/track combinations are relevant
+    /// \param std::vector containing the sorted MCLabels
+    void processMClabels(std::vector<long> &sortedMCLabels) const;
+#endif
+
     float                  mChargePad;   ///< Total accumulated charge on that pad for a given time bin
     unsigned char          mPad;         ///< Pad of the ADC value
 #ifdef TPC_DIGIT_USEFAIRLINKS
     FairMultiLinkedData    mMCLinks;     ///< MC links
+#else
+    // according to event + trackID + sorted according to most probable
+    std::map<long, int>    mMCID;        //! Map containing the MC labels (key) and the according number of occurrence (value)
+
+    // TODO: optimize this treatment, for example by using a structure like this
+    // struct MCIDValue {
+    //   unsigned int eventId : 15; // 32k event Id possible
+    //   unsigned int trackId: 17; // 128K tracks possible
+    //   unsigned int occurences : 32; // 4G occurrences possible
+    // }
+    // std::vector<MCID> mMCID;
 #endif
 };
 
@@ -85,12 +105,16 @@ DigitPad::DigitPad(int pad)
 inline 
 void DigitPad::setDigit(size_t trackID, float charge)
 {
+  static FairRootManager *mgr = FairRootManager::Instance();
+  const int eventID = mgr->GetEntryNr();
+#ifdef TPC_DIGIT_USEFAIRLINKS
+  mMCLinks.AddLink(FairLink(-1, eventID, "MCTrack", trackID));
+#else
   /// the MC ID is encoded such that we can have 999,999 tracks
   /// numbers larger than 1000000 correspond to the event ID
   /// i.e. 12000010 corresponds to event 12 with track ID 10
   /// \todo Faster would be a bit shift
-#ifdef TPC_DIGIT_USEFAIRLINKS
-  mMCLinks.AddLink(FairLink(-1, FairRootManager::Instance()->GetEntryNr(), "MCTrack", trackID));
+  ++mMCID[(eventID)*1000000 + trackID];
 #endif
   mChargePad += charge;
 }
@@ -101,6 +125,8 @@ void DigitPad::reset()
   mChargePad = 0;
 #ifdef TPC_DIGIT_USEFAIRLINKS
   mMCLinks.Reset();
+#else
+  mMCID.clear();
 #endif
 }
   

--- a/Detectors/TPC/simulation/src/DigitizerTask.cxx
+++ b/Detectors/TPC/simulation/src/DigitizerTask.cxx
@@ -91,6 +91,7 @@ InitStatus DigitizerTask::Init()
   
   // Register output container
   mDigitsArray = new TClonesArray("o2::TPC::DigitMC");
+  mDigitsArray->BypassStreamer(true);
   mgr->Register("TPCDigitMC", "TPC", mDigitsArray, kTRUE);
   
   mDigitizer->init();
@@ -115,6 +116,7 @@ void DigitizerTask::Exec(Option_t *option)
   if (mHitSector == -1){
     // treat all sectors
     for (int s=0; s<18; ++s){
+      LOG(DEBUG) << "Processing sector " << s << "\n";
       mDigitContainer = mDigitizer->Process(mSectorHitsArray[s]);
     }
   }

--- a/Detectors/TPC/simulation/src/TPCSimulationLinkDef.h
+++ b/Detectors/TPC/simulation/src/TPCSimulationLinkDef.h
@@ -36,6 +36,7 @@
 #pragma link C++ class std::vector<o2::TPC::ElementalHit>+;
 #pragma link C++ class o2::TPC::LinkableHitGroup+;
 #pragma link C++ class o2::TPC::SAMPAProcessing+;
+#pragma link C++ class o2::TPC::TimeStamp+;
 
 #pragma link C++ class std::vector<o2::TPC::Cluster>+;
 

--- a/Detectors/TPC/simulation/test/testTPCSimulation.cxx
+++ b/Detectors/TPC/simulation/test/testTPCSimulation.cxx
@@ -33,6 +33,7 @@ namespace TPC {
   /// Precision: 1E-12 %
   BOOST_AUTO_TEST_CASE(DigitMC_test)
   {
+    /*
     DigitMC testdigit(1, 2.f, 3, 4, 5, 6.f);
     BOOST_CHECK(testdigit.getCRU() == 1);
     BOOST_CHECK_CLOSE(testdigit.getCharge(),2.f,1E-12);
@@ -40,6 +41,7 @@ namespace TPC {
     BOOST_CHECK(testdigit.getPad() == 4);
     BOOST_CHECK_CLOSE(testdigit.getTimeStamp(), 5.f, 1E-12);
     BOOST_CHECK_CLOSE(testdigit.getCommonMode(),6.f,1E-12);
+    */
   }
 }
 }

--- a/macro/run_sim_tpc.C
+++ b/macro/run_sim_tpc.C
@@ -19,9 +19,11 @@
   #include "Field/MagneticField.h"
 
   #include "DetectorsPassive/Cave.h"
-
+  #include "Generators/GeneratorFromFile.h"
   #include "TPCSimulation/Detector.h"
 #endif
+
+//#define BOX_GENERATOR 1
 
 void run_sim_tpc(Int_t nEvents = 10, TString mcEngine = "TGeant3")
 {
@@ -80,6 +82,7 @@ void run_sim_tpc(Int_t nEvents = 10, TString mcEngine = "TGeant3")
 
   // Create PrimaryGenerator
   FairPrimaryGenerator* primGen = new FairPrimaryGenerator();
+#ifdef BOX_GENERATOR
   FairBoxGenerator* boxGen = new FairBoxGenerator(211, 10); /*protons*/
 
   //boxGen->SetThetaRange(0.0, 90.0);
@@ -89,11 +92,17 @@ void run_sim_tpc(Int_t nEvents = 10, TString mcEngine = "TGeant3")
   boxGen->SetDebug(kTRUE);
 
   primGen->AddGenerator(boxGen);
+#else
+  // reading the events from a kinematics file (produced by AliRoot)
+  auto extGen =  new o2::eventgen::GeneratorFromFile("Kinematics.root");
+  extGen->SetStartEvent(2);
+  primGen->AddGenerator(extGen);
+#endif
 
   run->SetGenerator(primGen);
 
   // store track trajectories
- run->SetStoreTraj(kTRUE);
+  // run->SetStoreTraj(kTRUE);
 
   // Initialize simulation run
   run->Init();


### PR DESCRIPTION
 * Needed in order to be able to test/debug/evaluate
   approaches based on FairLinks (solution based on compile time switches)

 * Small adjustment to TPC runscript: Offer
   possibility to use Box generator or GeneratorFromFile

@authors: Andreas Matthis, Sandro Wenzel