### PR TITLE
Use int for Sector::MAXSECTOR instead of char

### DIFF
--- a/Detectors/TPC/base/include/TPCBase/Sector.h
+++ b/Detectors/TPC/base/include/TPCBase/Sector.h
@@ -27,7 +27,7 @@ class Sector
 {
   public:
     // the number of sectors
-    static constexpr char MAXSECTOR=36;
+    static constexpr int MAXSECTOR=36;
 
     /// constructor
     Sector() {}


### PR DESCRIPTION
char might be confusing and int is semantically more correct

This PR is due to suggestions by @ktf and @matthiasrichter.