### PR TITLE
Explicitely forbid comparison of data descriptors with pointers, e.g. const char* strings

### DIFF
--- a/DataFormats/Headers/include/Headers/DataHeader.h
+++ b/DataFormats/Headers/include/Headers/DataHeader.h
@@ -264,6 +264,14 @@ struct Descriptor {
 
   bool operator==(const Descriptor& other) const {return itg == other.itg;}
   bool operator!=(const Descriptor& other) const {return not this->operator==(other);}
+
+  // explicitly forbid comparison with e.g. const char* strings
+  // use: value == Descriptor<N>("DESC") for the appropriate
+  // template instantiation instead
+  template<typename T>
+  bool operator==(const T*) const = delete;
+  template<typename T>
+  bool operator!=(const T*) const = delete;
   // print function needs to be implemented for every derivation
   void print() const {
     // eventually terminate string before printing
@@ -588,6 +596,13 @@ struct DataDescription {
 
   bool operator==(const DataDescription&) const;
   bool operator!=(const DataDescription& other) const {return not this->operator==(other);}
+
+  // explicitly forbid comparison with e.g. const char* strings
+  // use: value == DataDescription("SOMEDESCRIPTION") instead
+  template<typename T>
+  bool operator==(const T*) const = delete;
+  template<typename T>
+  bool operator!=(const T*) const = delete;
   void print() const;
 };
 

--- a/DataFormats/Headers/test/testDataHeader.cxx
+++ b/DataFormats/Headers/test/testDataHeader.cxx
@@ -72,14 +72,14 @@ namespace o2 {
       BOOST_CHECK(desc.itg[0] == itgDesc);
       BOOST_CHECK(desc.itg[1] == 0);
 
-      BOOST_CHECK(desc == "ITSRAW");
+      BOOST_CHECK(desc == DataDescription("ITSRAW"));
 
       DataDescription desc2(test);
       BOOST_CHECK(strcmp(desc2.str, "ITSRAW")==0);
       // the upper part must be 0 since the string has only up tp 8 chars
       BOOST_CHECK(desc2.itg[1] == 0);
 
-      BOOST_CHECK(desc2 == "ITSRAW");
+      BOOST_CHECK(desc2 == DataDescription("ITSRAW"));
 
       std::string runtimeString = "DATA_DESCRIPTION";
       DataDescription runtimeDesc;


### PR DESCRIPTION
The DataDescription and Descriptor structs are not supposed to be
compared by string. The compiler probably creates an operator for
raw pointers automatically.