### PR TITLE
Fix #402 index out of bound error in the vector of dummy test data

### DIFF
--- a/Utilities/aliceHLTwrapper/test/testMessageFormat.cxx
+++ b/Utilities/aliceHLTwrapper/test/testMessageFormat.cxx
@@ -133,7 +133,7 @@ namespace o2::AliceHLT {
         BOOST_CHECK(output.mSize == sizeof(o2::Header::DataHeader));
       } else {
         o2::Header::hexDump("Payload block", output.mP, output.mSize);
-        o2::Header::hexDump("  Data string", dataFields[dataidx].c_str(), dataFields[dataidx].size());
+        o2::Header::hexDump("  Data string", dataFields[dataidx/2].c_str(), dataFields[dataidx/2].size() + 1);
         const char* data = (char*)output.mP;
         BOOST_CHECK(dataFields[dataidx/2] == data);
       }


### PR DESCRIPTION
The index has to be divided by 2 to get the correct index in the array
of test data. Comes from the fact that every payload message is preceded
by a header message.