### PR TITLE
Implementing the handling of heartbeat information in the AliceHLTWrapperDevice

### DIFF
--- a/DataFormats/Headers/include/Headers/HeartbeatFrame.h
+++ b/DataFormats/Headers/include/Headers/HeartbeatFrame.h
@@ -46,7 +46,7 @@ struct HeartbeatHeader
 {
   union {
     // the complete 64 bit header word, initialize with blockType 1 and size 1
-    uint64_t headerWord = 0x11000000;
+    uint64_t headerWord = 0x1100000000000000;
     struct {
 	// bit 0 to 31: orbit number
 	uint32_t orbit;
@@ -64,13 +64,15 @@ struct HeartbeatHeader
 	uint8_t blockType:4;
     };
   };
+
+  operator bool() const {return headerWord != 0 && blockType == 0x1;}
 };
 
 struct HeartbeatTrailer
 {
   union {
-    // the complete 64 bit trailer word, initialize with blockType 1 and size 1
-    uint64_t trailerWord = 0x51000000;
+    // the complete 64 bit trailer word, initialize with blockType 5 and size 1
+    uint64_t trailerWord = 0x5100000000000000;
     struct {
 	// bit 0 to 31: data length in words
 	uint32_t dataLength;
@@ -88,6 +90,8 @@ struct HeartbeatTrailer
 	uint8_t blockType:4;
     };
   };
+
+  operator bool() const {return trailerWord != 0 && blockType == 0x5;}
 };
 
 // composite struct for the HBH and HBT which are the envelope for the payload

--- a/Utilities/aliceHLTwrapper/src/Component.cxx
+++ b/Utilities/aliceHLTwrapper/src/Component.cxx
@@ -81,7 +81,7 @@ bpo::options_description Component::GetOptionsDescription()
      bpo::value<string>()->default_value("0"),
      "maximum size of output buffer/msg")
     ((std::string(OptionKeys[OptionKeyOutputMode]) + ",m").c_str(),
-     bpo::value<string>()->default_value("2"),
+     bpo::value<string>()->default_value("3"),
      "output mode");
 
   return od;


### PR DESCRIPTION
The device forwards now incoming heartbeat information and wraps the HLT data blocks in heartbeat frames if the HBF is available at the input.