### PR TITLE
Fix #392: make sure that man pages are created when building submodule

### DIFF
--- a/cmake/O2Utils.cmake
+++ b/cmake/O2Utils.cmake
@@ -15,6 +15,13 @@ macro(O2_SETUP)
   )
   CHECK_VARIABLE(PARSED_ARGS_NAME "You must provide a name")
 
+  # set the variable to be used within parsing of this module
+  set(MODULE_NAME ${PARSED_ARGS_NAME})
+
+  # add a local target for the man page generation and make the
+  # global man target dpending on it
+  add_custom_target(${PARSED_ARGS_NAME}.man ALL)
+  add_dependencies(man ${PARSED_ARGS_NAME}.man)
 endmacro()
 
 #------------------------------------------------------------------------------
@@ -483,7 +490,7 @@ function(O2_GENERATE_MAN)
   cmake_parse_arguments(
       PARSED_ARGS
       "" # bool args
-      "NAME;SECTION" # mono-valued arguments
+      "NAME;SECTION;MODULE" # mono-valued arguments
       "" # multi-valued arguments
       ${ARGN} # arguments
   )
@@ -499,7 +506,16 @@ function(O2_GENERATE_MAN)
       VERBATIM
     )
     ADD_CUSTOM_TARGET(${PARSED_ARGS_NAME}.${PARSED_ARGS_SECTION} DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${PARSED_ARGS_NAME}.${PARSED_ARGS_SECTION})
-    add_dependencies(man ${PARSED_ARGS_NAME}.${PARSED_ARGS_SECTION})
+    if (PARSED_ARGS_MODULE)
+      # add to the man target of specified module
+      add_dependencies(${PARSED_ARGS_MODULE}.man ${PARSED_ARGS_NAME}.${PARSED_ARGS_SECTION})
+    elseif(MODULE_NAME)
+      # add to the man target of current module
+      add_dependencies(${MODULE_NAME}.man ${PARSED_ARGS_NAME}.${PARSED_ARGS_SECTION})
+    else()
+      # add to top level target otherwise
+      add_dependencies(man ${PARSED_ARGS_NAME}.${PARSED_ARGS_SECTION})
+    endif()
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PARSED_ARGS_NAME}.${PARSED_ARGS_SECTION} DESTINATION share/man/man${PARSED_ARGS_SECTION})
   endif(NROFF_FOUND)
 endfunction(O2_GENERATE_MAN)


### PR DESCRIPTION
All man pages had been added to the global man target. This makes
a build in only a submodule fail at installation, and the man pages
were not updated when running make in the subdirectory.

Adding additional custom target per submodule for man pages and
make this target depending on the configured man pages of the
module.