### PR TITLE
Added command line option to specify the OCDB configuration

### DIFF
--- a/Utilities/aliceHLTwrapper/doc/AliceHLTWrapperDevice.1.in
+++ b/Utilities/aliceHLTwrapper/doc/AliceHLTWrapperDevice.1.in
@@ -60,13 +60,52 @@ of multiple strings
 .TP 2
 .B --run  \fIn\fR
 Run number
+.TP 2
+.B --ocdb  \fIuri\fR
+Set the OCDB URI and override the value of environment variable ALIHLT_HCDBDIR
 
 .SS Other Options
 .B --poll-period \fIperiod\fR
 Polling period on the input channel
+.B --output-mode \fImode\fR
+The output mode of the device, default is O2 format (3)
+.RS 2
+.B 0
+- HOMER format
+.br
+.B 1
+- blocks in multiple messages
+.br
+.B 2
+- blocks concatenated in one message (default)
+.br
+.B 3
+- O2 format
+.RE
 
-.SH CONFIGURATION DATABASE
-HLT components need the Alice OCDB to load the configuration. The path to the OCDB must be set in environment variable \fBALIHLT_HCDBDIR\fR.
+.SH FEATURES
+.SS Message channels
+The device supports input and output channels with the names
+.IR --data-in /
+.I --data-out
+respectively. All input channels are treated equally and the device expects messages
+from all channels before data is processed.
+
+If no input channel is specified the device will run in a self-triggered mode
+and call the component processing repeatedly with the period specified by
+.IR --poll-period .
+
+.SS Configuration database
+HLT components need the Alice OCDB to load the configuration. The path to the OCDB
+must be set in environment variable
+.B ALIHLT_HCDBDIR
+or via option
+.BR --ocdb .
+
+.SS Heartbeat information
+The device interprets Heartbeat frame data blocks at the input channel. If this
+information is available at the input, all output blocks will be wrapped into
+Haertbeat frames.
 
 .SH EXAMPLES
 .B AliceHLTWrapperDevice

--- a/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/Component.h
+++ b/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/Component.h
@@ -1,3 +1,4 @@
+//-*- Mode: C++ -*-
 // Copyright CERN and copyright holders of ALICE O2. This software is
 // distributed under the terms of the GNU General Public License v3 (GPL
 // Version 3), copied verbatim in the file "COPYING".
@@ -7,8 +8,6 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-
-//-*- Mode: C++ -*-
 
 #ifndef COMPONENT_H
 #define COMPONENT_H
@@ -63,6 +62,7 @@ class SystemInterface;
 ///                 Currently, all HLT components need configuration and
 ///                 calibration data from OCDB; OCDB interface needs to
 ///                 be initialized with run number
+/// --ocdb          uri of the OCDB, e.g. 'local://./OCDB'
 /// --msgsize       size of the output buffer in byte
 ///                 This overrides the default behavior where output buffer
 ///                 size is determined from the input size and properties
@@ -71,6 +71,7 @@ class SystemInterface;
 ///                 0  HOMER format
 ///                 1  blocks in multiple messages
 ///                 2  blocks concatenated in one message (default)
+///                 3  O2 data format (default)
 ///
 class Component {
 public:
@@ -95,6 +96,7 @@ public:
     OptionKeyComponent,
     OptionKeyParameter,
     OptionKeyRun,
+    OptionKeyOCDB,
     OptionKeyMsgsize,
     OptionKeyOutputMode,
     OptionKeyInstanceId,
@@ -106,6 +108,7 @@ public:
     "component",
     "parameter",
     "run",
+    "ocdb",
     "msgsize",
     "output-mode",
     "instance-id",

--- a/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/EventSampler.h
+++ b/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/EventSampler.h
@@ -1,3 +1,4 @@
+//-*- Mode: C++ -*-
 // Copyright CERN and copyright holders of ALICE O2. This software is
 // distributed under the terms of the GNU General Public License v3 (GPL
 // Version 3), copied verbatim in the file "COPYING".
@@ -7,8 +8,6 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-
-//-*- Mode: C++ -*-
 
 #ifndef EVENTSAMPLER_H
 #define EVENTSAMPLER_H

--- a/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/HOMERFactory.h
+++ b/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/HOMERFactory.h
@@ -1,3 +1,4 @@
+//-*- Mode: C++ -*-
 // Copyright CERN and copyright holders of ALICE O2. This software is
 // distributed under the terms of the GNU General Public License v3 (GPL
 // Version 3), copied verbatim in the file "COPYING".
@@ -7,8 +8,6 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-
-//-*- Mode: C++ -*-
 
 #ifndef HOMERFACTORY_H
 #define HOMERFACTORY_H

--- a/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/MessageFormat.h
+++ b/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/MessageFormat.h
@@ -1,3 +1,4 @@
+//-*- Mode: C++ -*-
 // Copyright CERN and copyright holders of ALICE O2. This software is
 // distributed under the terms of the GNU General Public License v3 (GPL
 // Version 3), copied verbatim in the file "COPYING".
@@ -7,8 +8,6 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-
-//-*- Mode: C++ -*-
 
 #ifndef MESSAGEFORMAT_H
 #define MESSAGEFORMAT_H

--- a/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/SystemInterface.h
+++ b/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/SystemInterface.h
@@ -1,3 +1,4 @@
+//-*- Mode: C++ -*-
 // Copyright CERN and copyright holders of ALICE O2. This software is
 // distributed under the terms of the GNU General Public License v3 (GPL
 // Version 3), copied verbatim in the file "COPYING".
@@ -7,8 +8,6 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-
-//-*- Mode: C++ -*-
 
 #ifndef SYSTEMINTERFACE_H
 #define SYSTEMINTERFACE_H

--- a/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/WrapperDevice.h
+++ b/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/WrapperDevice.h
@@ -1,3 +1,4 @@
+//-*- Mode: C++ -*-
 // Copyright CERN and copyright holders of ALICE O2. This software is
 // distributed under the terms of the GNU General Public License v3 (GPL
 // Version 3), copied verbatim in the file "COPYING".
@@ -7,8 +8,6 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-
-//-*- Mode: C++ -*-
 
 #ifndef WRAPPERDEVICE_H
 #define WRAPPERDEVICE_H


### PR DESCRIPTION
- the OCDB URI can now be specified as command line option --ocdb,
  the existence of ALIHLT_HCDBDIR is checked otherwise
- logging through the FairMQ logging channel
- minor code cleanup