### PR TITLE
Update deprecated configuration calls

### DIFF
--- a/CCDB/src/ConditionsMQServer.cxx
+++ b/CCDB/src/ConditionsMQServer.cxx
@@ -48,19 +48,19 @@ void ConditionsMQServer::InitTask()
 {
   ParameterMQServer::InitTask();
   // Set first input
-  if (GetProperty(FirstInputType, "") == "OCDB") {
-    mCdbManager->setDefaultStorage(GetProperty(FirstInputName, "").c_str());
+  if (GetFirstInputType() == "OCDB") {
+    mCdbManager->setDefaultStorage(GetFirstInputName().c_str());
   }
 
   // Set second input
-  if (GetProperty(SecondInputType, "") == "OCDB") {
-    mCdbManager->setDefaultStorage(GetProperty(SecondInputName, "").c_str());
+  if (GetSecondInputType() == "OCDB") {
+    mCdbManager->setDefaultStorage(GetSecondInputName().c_str());
   }
 
   // Set output
-  if (GetProperty(OutputName, "") != "") {
-    if (GetProperty(OutputType, "") == "OCDB") {
-      mCdbManager->setDefaultStorage(GetProperty(OutputName, "").c_str());
+  if (GetOutputName() != "") {
+    if (GetOutputType() == "OCDB") {
+      mCdbManager->setDefaultStorage(GetOutputName().c_str());
     }
   }
 }

--- a/Utilities/QC/QCMerger/include/QCMerger/MergerDevice.h
+++ b/Utilities/QC/QCMerger/include/QCMerger/MergerDevice.h
@@ -32,7 +32,7 @@ namespace qc
 class MergerDevice : public FairMQDevice
 {
  public:
-  MergerDevice(std::unique_ptr<Merger> merger, std::string producerId, int numIoThreads);
+  MergerDevice(std::unique_ptr<Merger> merger, std::string producerId);
   ~MergerDevice() override;
 
   static void deleteTMessage(void* data, void* hint);

--- a/Utilities/QC/QCMerger/src/MergerDevice.cxx
+++ b/Utilities/QC/QCMerger/src/MergerDevice.cxx
@@ -36,8 +36,8 @@ MergerDevice::MergerDevice(unique_ptr<Merger> merger, string mergerId, int numIo
   : mMerger(move(merger)), ddsCustomCmd(new CCustomCmd(mService))
 {
   this->SetTransport("zeromq");
-  this->SetProperty(Id, mergerId);
-  this->SetProperty(NumIoThreads, numIoThreads);
+  this->SetId(mergerId);
+  this->SetNumIoThreads(numIoThreads);
 
   procSelfStatus.open("/proc/self/status");
 
@@ -119,7 +119,7 @@ boost::property_tree::ptree MergerDevice::createCheckStateResponse(const ptree& 
 
   ptree response;
   response.put("command", "state");
-  response.put("node_id", GetProperty(Id, "error"));
+  response.put("node_id", GetId());
   response.put("node_state", GetCurrentStateName());
   response.put("internal_message_id", to_string(mInternalStateMessageId));
   response.put("request_timestamp", request.get<string>("requestTimestamp"));
@@ -140,7 +140,7 @@ boost::property_tree::ptree MergerDevice::createGetMetricsResponse(const ptree& 
 
   ptree response;
   response.put("command", "metrics");
-  response.put("node_id", GetProperty(Id, "error"));
+  response.put("node_id", GetId());
   response.put("PID", getpid());
   response.put("internal_message_id", to_string(mInternalMetricMessageId));
   response.put("request_timestamp", request.get<string>("requestTimestamp"));

--- a/Utilities/QC/QCMerger/src/MergerDevice.cxx
+++ b/Utilities/QC/QCMerger/src/MergerDevice.cxx
@@ -32,12 +32,11 @@ namespace o2
 {
 namespace qc
 {
-MergerDevice::MergerDevice(unique_ptr<Merger> merger, string mergerId, int numIoThreads)
+MergerDevice::MergerDevice(unique_ptr<Merger> merger, string mergerId)
   : mMerger(move(merger)), ddsCustomCmd(new CCustomCmd(mService))
 {
   this->SetTransport("zeromq");
   this->SetId(mergerId);
-  this->SetNumIoThreads(numIoThreads);
 
   procSelfStatus.open("/proc/self/status");
 

--- a/Utilities/QC/QCMerger/src/runMerger.cxx
+++ b/Utilities/QC/QCMerger/src/runMerger.cxx
@@ -38,7 +38,6 @@ namespace bpo = boost::program_options;
 
 namespace
 {
-const int NUMBER_OF_IO_THREADS = 1;
 const int NUMBER_OF_REQUIRED_PROGRAM_PARAMETERS = 6;
 ostringstream localAddress;
 
@@ -97,8 +96,7 @@ int main(int argc, char** argv)
   bpo::store(bpo::command_line_parser(argc, argv).options(options).run(), vm);
   bpo::notify(vm);
 
-  MergerDevice mergerDevice(unique_ptr<Merger>(new Merger(NUMBER_OF_QC_OBJECTS_FOR_COMPLETE_DATA)), MERGER_DEVICE_ID,
-                            NUMBER_OF_IO_THREADS);
+  MergerDevice mergerDevice(unique_ptr<Merger>(new Merger(NUMBER_OF_QC_OBJECTS_FOR_COMPLETE_DATA)), MERGER_DEVICE_ID);
   mergerDevice.CatchSignals();
 
   LOG(INFO) << "PID: " << getpid();

--- a/Utilities/QC/QCMerger/src/runMerger.cxx
+++ b/Utilities/QC/QCMerger/src/runMerger.cxx
@@ -102,7 +102,7 @@ int main(int argc, char** argv)
   mergerDevice.CatchSignals();
 
   LOG(INFO) << "PID: " << getpid();
-  LOG(INFO) << "Merger id: " << mergerDevice.GetProperty(MergerDevice::Id, "default_id");
+  LOG(INFO) << "Merger id: " << mergerDevice.GetId();
 
   mergerDevice.establishChannel("pull", "bind", stringLocalAddress.c_str(), "data-in", INPUT_BUFFER_SIZE,
                                 INPUT_BUFFER_SIZE);

--- a/Utilities/QC/QCMerger/test/MergerDeviceTestSuite.cxx
+++ b/Utilities/QC/QCMerger/test/MergerDeviceTestSuite.cxx
@@ -38,8 +38,8 @@ BOOST_AUTO_TEST_CASE(createMergerDevice)
   unique_ptr<MergerDevice> mrgerDevice(new MergerDevice(
     unique_ptr<Merger>(new Merger(NUMBER_OF_QC_OBJECTS_FOR_COMPLETE_DATA)), MERGER_DEVICE_ID, NUMBER_OF_IO_THREADS));
 
-  BOOST_CHECK(mrgerDevice->GetProperty(MergerDevice::Id, "default_id") == MERGER_DEVICE_ID);
-  BOOST_CHECK(mrgerDevice->GetProperty(MergerDevice::NumIoThreads, 0) == NUMBER_OF_IO_THREADS);
+  BOOST_CHECK(mrgerDevice->GetId() == MERGER_DEVICE_ID);
+  BOOST_CHECK(mrgerDevice->GetNumIoThreads() == NUMBER_OF_IO_THREADS);
 }
 
 BOOST_AUTO_TEST_CASE(establishChannelByMergerDevice)

--- a/Utilities/QC/QCMerger/test/MergerDeviceTestSuite.cxx
+++ b/Utilities/QC/QCMerger/test/MergerDeviceTestSuite.cxx
@@ -24,7 +24,6 @@ namespace
 const char* INPUT_ADDRESS = "tcp://*:5005";
 const char* OUTPUT_ADDREDD = "tcp://login01.pro.cyfronet.pl:5004";
 const char* MERGER_DEVICE_ID = "TEST_MERGER";
-const int NUMBER_OF_IO_THREADS = 1;
 const int NUMBER_OF_QC_OBJECTS_FOR_COMPLETE_DATA = 2;
 int bufferSize = 10;
 
@@ -36,16 +35,15 @@ BOOST_AUTO_TEST_SUITE(MergerDeviceTestSuite)
 BOOST_AUTO_TEST_CASE(createMergerDevice)
 {
   unique_ptr<MergerDevice> mrgerDevice(new MergerDevice(
-    unique_ptr<Merger>(new Merger(NUMBER_OF_QC_OBJECTS_FOR_COMPLETE_DATA)), MERGER_DEVICE_ID, NUMBER_OF_IO_THREADS));
+    unique_ptr<Merger>(new Merger(NUMBER_OF_QC_OBJECTS_FOR_COMPLETE_DATA)), MERGER_DEVICE_ID));
 
   BOOST_CHECK(mrgerDevice->GetId() == MERGER_DEVICE_ID);
-  BOOST_CHECK(mrgerDevice->GetNumIoThreads() == NUMBER_OF_IO_THREADS);
 }
 
 BOOST_AUTO_TEST_CASE(establishChannelByMergerDevice)
 {
   unique_ptr<MergerDevice> mrgerDevice(new MergerDevice(
-    unique_ptr<Merger>(new Merger(NUMBER_OF_QC_OBJECTS_FOR_COMPLETE_DATA)), MERGER_DEVICE_ID, NUMBER_OF_IO_THREADS));
+    unique_ptr<Merger>(new Merger(NUMBER_OF_QC_OBJECTS_FOR_COMPLETE_DATA)), MERGER_DEVICE_ID));
 
   BOOST_TEST(mrgerDevice->fChannels.size() == 0, "Producer device has a channel connected at startup");
 

--- a/Utilities/QC/QCProducer/include/QCProducer/ProducerDevice.h
+++ b/Utilities/QC/QCProducer/include/QCProducer/ProducerDevice.h
@@ -26,7 +26,7 @@ namespace qc
 class ProducerDevice : public FairMQDevice
 {
  public:
-  ProducerDevice(const char* producerId, const int numIoThreads, std::shared_ptr<Producer>& producer);
+  ProducerDevice(const char* producerId, std::shared_ptr<Producer>& producer);
   ~ProducerDevice() override = default;
 
   static void deleteTMessage(void* data, void* hint);

--- a/Utilities/QC/QCProducer/src/ProducerDevice.cxx
+++ b/Utilities/QC/QCProducer/src/ProducerDevice.cxx
@@ -33,8 +33,8 @@ ProducerDevice::ProducerDevice(const char* producerId, const int numIoThreads, s
   : ddsCustomCmd(new CCustomCmd(mService))
 {
   this->SetTransport("zeromq");
-  this->SetProperty(Id, producerId);
-  this->SetProperty(NumIoThreads, numIoThreads);
+  this->SetId(producerId);
+  this->SetNumIoThreads(numIoThreads);
   mProducer = producer;
   lastCheckedSecond = getCurrentSecond();
 }
@@ -135,7 +135,7 @@ void ProducerDevice::subscribeDdsCommands()
     if (request.get<string>("command") == "check-state") {
       ptree response;
       response.put("command", "check-state");
-      response.put("node_id", GetProperty(Id, "error"));
+      response.put("node_id", GetId());
       response.put("node_state", GetCurrentStateName());
       response.put("internal_message_id", to_string(mInternalStateMessageId));
       response.put("request_timestamp", request.get<string>("requestTimestamp"));

--- a/Utilities/QC/QCProducer/src/ProducerDevice.cxx
+++ b/Utilities/QC/QCProducer/src/ProducerDevice.cxx
@@ -29,12 +29,11 @@ namespace o2
 {
 namespace qc
 {
-ProducerDevice::ProducerDevice(const char* producerId, const int numIoThreads, shared_ptr<Producer>& producer)
+ProducerDevice::ProducerDevice(const char* producerId, shared_ptr<Producer>& producer)
   : ddsCustomCmd(new CCustomCmd(mService))
 {
   this->SetTransport("zeromq");
   this->SetId(producerId);
-  this->SetNumIoThreads(numIoThreads);
   mProducer = producer;
   lastCheckedSecond = getCurrentSecond();
 }

--- a/Utilities/QC/QCProducer/src/runProducer.cxx
+++ b/Utilities/QC/QCProducer/src/runProducer.cxx
@@ -31,7 +31,6 @@ using namespace o2::qc;
 namespace
 {
 shared_ptr<Producer> producer;
-const int NUMBER_OF_IO_THREADS = 1;
 const char* outputAddress;
 mutex keyMutex;
 }
@@ -77,7 +76,7 @@ int main(int argc, char** argv)
     return -1;
   }
 
-  ProducerDevice producerDevice(producerId, NUMBER_OF_IO_THREADS, producer);
+  ProducerDevice producerDevice(producerId, producer);
   producerDevice.CatchSignals();
 
   LOG(INFO) << "PID: " << getpid();

--- a/Utilities/QC/QCProducer/src/runProducer.cxx
+++ b/Utilities/QC/QCProducer/src/runProducer.cxx
@@ -81,7 +81,7 @@ int main(int argc, char** argv)
   producerDevice.CatchSignals();
 
   LOG(INFO) << "PID: " << getpid();
-  LOG(INFO) << "Producer id: " << producerDevice.GetProperty(ProducerDevice::Id, "default_id");
+  LOG(INFO) << "Producer id: " << producerDevice.GetId();
   LOG(INFO) << "Hostname: " << getenv("HOSTNAME");
 
   condition_variable keyCondition;

--- a/Utilities/QC/QCProducer/test/ProducerDeviceTestSuite.cxx
+++ b/Utilities/QC/QCProducer/test/ProducerDeviceTestSuite.cxx
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_SUITE(ProducerTestSuite)
 BOOST_AUTO_TEST_CASE(establishChannelByProducerDevice)
 {
   shared_ptr<Producer> producer(new TH1Producer(NAME, TITLE, NUMBER_OF_BINS));
-  unique_ptr<ProducerDevice> producerDevice(new ProducerDevice("Producer", 1, producer));
+  unique_ptr<ProducerDevice> producerDevice(new ProducerDevice("Producer", producer));
 
   BOOST_TEST(producerDevice->fChannels.size() == 0, "Producer device has a channel connected at startup");
 

--- a/Utilities/QC/QCViewer/include/QCViewer/ViewerDevice.h
+++ b/Utilities/QC/QCViewer/include/QCViewer/ViewerDevice.h
@@ -26,7 +26,7 @@ namespace qc
 class ViewerDevice : public FairMQDevice
 {
  public:
-  ViewerDevice(std::string viewerId, int numIoThreads, std::string drawingOptions = "");
+  ViewerDevice(std::string viewerId, std::string drawingOptions = "");
   ~ViewerDevice() override = default;
 
   void executeRunLoop();

--- a/Utilities/QC/QCViewer/src/ViewerDevice.cxx
+++ b/Utilities/QC/QCViewer/src/ViewerDevice.cxx
@@ -24,11 +24,10 @@ namespace o2
 {
 namespace qc
 {
-ViewerDevice::ViewerDevice(std::string viewerId, int numIoThreads, string drawingOptions)
+ViewerDevice::ViewerDevice(std::string viewerId, string drawingOptions)
 {
   this->SetTransport("zeromq");
   this->SetId(viewerId);
-  this->SetNumIoThreads(numIoThreads);
   mDrawingOptions = drawingOptions;
 }
 

--- a/Utilities/QC/QCViewer/src/ViewerDevice.cxx
+++ b/Utilities/QC/QCViewer/src/ViewerDevice.cxx
@@ -27,8 +27,8 @@ namespace qc
 ViewerDevice::ViewerDevice(std::string viewerId, int numIoThreads, string drawingOptions)
 {
   this->SetTransport("zeromq");
-  this->SetProperty(ViewerDevice::Id, viewerId);
-  this->SetProperty(ViewerDevice::NumIoThreads, numIoThreads);
+  this->SetId(viewerId);
+  this->SetNumIoThreads(numIoThreads);
   mDrawingOptions = drawingOptions;
 }
 

--- a/Utilities/QC/QCViewer/src/runViewerDevice.cxx
+++ b/Utilities/QC/QCViewer/src/runViewerDevice.cxx
@@ -24,7 +24,7 @@ int main(int argc, char** argv)
   if (argc == 2) {
     drawingOptions = argv[1];
   }
-  ViewerDevice viewerDevice("Viewer_1", 1, drawingOptions);
+  ViewerDevice viewerDevice("Viewer_1", drawingOptions);
   viewerDevice.CatchSignals();
   auto* app = new TApplication("app1", &argc, argv);
 

--- a/Utilities/QC/QCViewer/src/runViewerDevice.cxx
+++ b/Utilities/QC/QCViewer/src/runViewerDevice.cxx
@@ -29,7 +29,7 @@ int main(int argc, char** argv)
   auto* app = new TApplication("app1", &argc, argv);
 
   LOG(INFO) << "PID: " << getpid();
-  LOG(INFO) << "Viewer id: " << viewerDevice.GetProperty(ViewerDevice::Id, "default_id");
+  LOG(INFO) << "Viewer id: " << viewerDevice.GetId();
 
   viewerDevice.establishChannel("pull", "bind", "tcp://*:5004", "data-in");
   viewerDevice.executeRunLoop();

--- a/Utilities/QC/QCViewer/test/ViewerTestSuite.cxx
+++ b/Utilities/QC/QCViewer/test/ViewerTestSuite.cxx
@@ -25,7 +25,7 @@ BOOST_AUTO_TEST_CASE(createViewerDevice)
 
   ViewerDevice viewer(viewerId, numberOfThreads);
 
-  BOOST_TEST(viewer.GetProperty(ViewerDevice::Id, "default_id") == viewerId);
+  BOOST_TEST(viewer.GetId() == viewerId);
 }
 
 BOOST_AUTO_TEST_CASE(establishChannelByViewerDevice)

--- a/Utilities/QC/QCViewer/test/ViewerTestSuite.cxx
+++ b/Utilities/QC/QCViewer/test/ViewerTestSuite.cxx
@@ -23,7 +23,7 @@ BOOST_AUTO_TEST_CASE(createViewerDevice)
   const std::string viewerId = "Viewer_1";
   const int numberOfThreads = 1;
 
-  ViewerDevice viewer(viewerId, numberOfThreads);
+  ViewerDevice viewer(viewerId);
 
   BOOST_TEST(viewer.GetId() == viewerId);
 }
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_CASE(establishChannelByViewerDevice)
 {
   const std::string viewerId = "Viewer_1";
   const int numberOfThreads = 1;
-  ViewerDevice viewer(viewerId, numberOfThreads);
+  ViewerDevice viewer(viewerId);
 
   BOOST_TEST(viewer.fChannels.size() == 0, "Viewer device has a channel connected at startup");
 

--- a/Utilities/aliceHLTwrapper/src/WrapperDevice.cxx
+++ b/Utilities/aliceHLTwrapper/src/WrapperDevice.cxx
@@ -135,7 +135,7 @@ void WrapperDevice::InitTask()
   // id is now specified with the --id option of FairMQProgOptions
   string idkey="--instance-id";
   string id="";
-  id=GetProperty(FairMQDevice::Id, id);
+  id=GetId();
   vector<char*> argv;
   argv.emplace_back(&idkey[0]);
   argv.emplace_back(&id[0]);


### PR DESCRIPTION
These changes depend on a recent FairRootGroup/FairRoot@f48bd27 commit in FairRoot.
`SetProperty`/`GetProperty` interface of FairMQDevice will be deprecated/removed in the near future, replaced either by access to config container or directly setters/getters.