### PR TITLE
Fix #428: adding missing include for std::array

### DIFF
--- a/Utilities/DataCompression/include/DataCompression/DataDeflater.h
+++ b/Utilities/DataCompression/include/DataCompression/DataDeflater.h
@@ -44,7 +44,7 @@ template<typename CodeType, std::size_t Length = 8 * sizeof(CodeType)>
 class CodecIdentity {
 public:
   using code_type = CodeType;
-  static_assert(Length <= 8 * sizeof(code_type));
+  static_assert(Length <= 8 * sizeof(code_type), "CodeType must allow specified bit length");
   static const std::size_t sMaxLength = Length;
 
   CodecIdentity() = default;

--- a/Utilities/DataCompression/test/test_DataDeflater.cxx
+++ b/Utilities/DataCompression/test/test_DataDeflater.cxx
@@ -32,6 +32,7 @@
 #include <iostream>
 #include <iomanip>
 #include <vector>
+#include <array>
 #include <bitset>
 #include <thread>
 #include <stdexcept>  // exeptions, runtime_error


### PR DESCRIPTION
std::array is used in test_DataDeflater.cxx, but the include was
missing, some compilers seem to be more strict on that and fail.

Also suppressing a warning by using the static_assert with two
arguments (condition and error string)