### PR TITLE
Alice detector ID class allowing iteration over detectors

### DIFF
--- a/Detectors/Base/CMakeLists.txt
+++ b/Detectors/Base/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SRCS
   src/Detector.cxx
   src/Track.cxx
   src/TrackReference.cxx
+  src/DetID.cxx
 )
 
 Set(HEADERS
@@ -14,6 +15,7 @@ Set(HEADERS
   include/${MODULE_NAME}/Track.h
   include/${MODULE_NAME}/TrackReference.h
   include/${MODULE_NAME}/Utils.h
+  include/${MODULE_NAME}/DetID.h
 )
 
 Set(LINKDEF src/BaseLinkDef.h)
@@ -21,4 +23,15 @@ Set(LIBRARY_NAME ${MODULE_NAME})
 set(BUCKET_NAME detectors_base)
 
 O2_GENERATE_LIBRARY()
+
+set(TEST_SRCS
+  test/testDetID.cxx
+)
+
+O2_GENERATE_TESTS(
+  MODULE_LIBRARY_NAME ${LIBRARY_NAME}
+  BUCKET_NAME ${BUCKET_NAME}
+  TEST_SRCS ${TEST_SRCS}
+)
+
 

--- a/Detectors/Base/include/DetectorsBase/DetID.h
+++ b/Detectors/Base/include/DetectorsBase/DetID.h
@@ -1,0 +1,132 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See https://alice-o2.web.cern.ch/ for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @copyright
+/// © Copyright 2014 Copyright Holders of the ALICE O2 collaboration.
+/// See https://aliceinfo.cern.ch/AliceO2 for details on the Copyright holders.
+/// This software is distributed under the terms of the
+/// GNU General Public License version 3 (GPL Version 3).
+///
+/// License text in a separate file.
+///
+/// In applying this license, CERN does not waive the privileges and immunities
+/// granted to it by virtue of its status as an Intergovernmental Organization
+/// or submit itself to any jurisdiction.
+
+/// @brief ALICE detectors ID's, names, masks
+///
+/// @author Ruben Shahoyan, ruben.shahoyan@cern.ch
+
+/*!
+  Example of class usage:
+  using namespace o2::base;
+  DetID det[3] = {DetID(DetID::ITS), DetID(DetID::TPC), DetID(DetID::TRD)};
+  int mskTot = 0;
+  for (int i=0;i<3;i++) {
+    printf("detID: %2d %10s 0x%x\n",det[i].getID(),det[i].getName(),det[i].getMask());
+    mskTot |= det[i].getMask();
+  }
+  printf("joint mask: 0x%x\n",mskTot);
+ */
+
+#ifndef O2_BASE_DETID_
+#define O2_BASE_DETID_
+
+#include <cstdint>
+#include <array>
+#include <type_traits>
+#include <Rtypes.h>
+
+namespace o2
+{
+namespace Base
+{
+/// generic template to convert enum to underlying int type
+template <typename E>
+constexpr typename std::underlying_type<E>::type toInt(const E e)
+{
+  return static_cast<typename std::underlying_type<E>::type>(e);
+}
+
+constexpr std::int32_t IDtoMask(int id) { return 0x1 << id; }
+ 
+/// Static class with identifiers, bitmasks and names for ALICE detectors
+class DetID
+{
+ public:
+  /// Detector identifiers: continuous, starting from 0
+  enum ID : std::int32_t {
+    ITS = 0,
+    TPC,
+    TRD,
+    TOF,
+    PHS,
+    CPV,
+    EMC,
+    HMP,
+    MFT,
+    MCH,
+    MID,
+    ZDC,
+    FIT,
+    First = ITS,
+    Last = FIT
+  };
+
+  DetID(ID id);
+
+  /// get derector id
+  ID getID() const { return mID; }
+
+  /// get detector mask
+  std::int32_t getMask() const { return getMask(mID); }
+
+  /// get detector name
+  const char* getName() const { return getName(mID); }
+
+  /// conversion operator to int
+  operator int() const { return static_cast<int>(mID); }
+
+  //  ---------------- general static methods -----------------
+  /// get number of defined detectors
+  static constexpr int getNDetectors() { return nDetectors; }
+
+  /// names of defined detectors
+  static const char* getName(ID id) { return sDetNames[toInt(id)]; }
+
+  // detector ID to mask conversion
+  static std::int32_t getMask(ID id) { return sMasks[toInt(id)]; }
+
+  // we need default c-tor only for root persistency, code must use c-tor with argument
+  DetID() : mID(ID::First) {}
+
+ private:
+  ID mID; ///< detector ID
+
+  /// number of defined detectors
+  static constexpr int nDetectors = toInt(ID::Last) + 1;
+
+  static constexpr std::array<const char[4], nDetectors> sDetNames =      ///< defined detector names
+    {"ITS", "TPC", "TRD", "TOF", "PHS", "CPV", "EMC", "HMP", "MFT", "MCH", "MID", "ZDC", "FIT"};
+
+  // detector names, will be defined in DataSources
+  static constexpr std::array<std::int32_t,nDetectors> sMasks =  ///< detectot masks for bitvectors
+    { IDtoMask(toInt(ITS)), IDtoMask(toInt(TPC)), IDtoMask(toInt(TRD)),
+      IDtoMask(toInt(TOF)), IDtoMask(toInt(PHS)), IDtoMask(toInt(CPV)),
+      IDtoMask(toInt(EMC)), IDtoMask(toInt(HMP)), IDtoMask(toInt(MFT)),
+      IDtoMask(toInt(MCH)), IDtoMask(toInt(MID)), IDtoMask(toInt(ZDC)),
+      IDtoMask(toInt(FIT)) };
+
+  ClassDefNV(DetID, 1);
+};
+}
+}
+
+#endif

--- a/Detectors/Base/src/BaseLinkDef.h
+++ b/Detectors/Base/src/BaseLinkDef.h
@@ -20,5 +20,6 @@
 #pragma link C++ class o2::Base::Track::TrackPar+;
 #pragma link C++ class o2::Base::Track::TrackParCov+;
 #pragma link C++ class o2::Base::TrackReference+;
+#pragma link C++ class o2::Base::DetID+;
 
 #endif

--- a/Detectors/Base/src/DetID.cxx
+++ b/Detectors/Base/src/DetID.cxx
@@ -1,0 +1,43 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See https://alice-o2.web.cern.ch/ for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @copyright
+/// © Copyright 2014 Copyright Holders of the ALICE O2 collaboration.
+/// See https://aliceinfo.cern.ch/AliceO2 for details on the Copyright holders.
+/// This software is distributed under the terms of the
+/// GNU General Public License version 3 (GPL Version 3).
+///
+/// License text in a separate file.
+///
+/// In applying this license, CERN does not waive the privileges and immunities
+/// granted to it by virtue of its status as an Intergovernmental Organization
+/// or submit itself to any jurisdiction.
+
+/// @file   DetID.cxx
+/// @author Ruben Shahoyan
+/// @brief  detector ids, masks, names class implementation
+
+#include "DetectorsBase/DetID.h"
+#include "FairLogger.h"
+
+using namespace o2::Base;
+
+ClassImp(DetID);
+
+
+DetID::DetID(ID id) : mID(id)
+{
+  if (id < First || id > Last) {
+    LOG(FATAL) << "Unknown detector ID: " << toInt(id) << FairLogger::endl;
+  }
+}
+
+constexpr std::array<const char[4], DetID::nDetectors> DetID::sDetNames;
+constexpr std::array<std::int32_t, DetID::nDetectors> DetID::sMasks;

--- a/Detectors/Base/test/testDetID.cxx
+++ b/Detectors/Base/test/testDetID.cxx
@@ -1,0 +1,38 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See https://alice-o2.web.cern.ch/ for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test DetID
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include <iostream>
+#include "DetectorsBase/DetID.h"
+
+using namespace o2::Base;
+
+BOOST_AUTO_TEST_CASE(DetID_test)
+{
+  // test for the templated Descriptor struct
+  for (DetID::ID id=DetID::First; id<=DetID::Last;id=DetID::ID(toInt(id)+1)) {
+    DetID det(id);
+    std::cout << "#" << toInt(id) << " Detector " << det.getName()
+	      << " ID=" << det << " mask: " << det.getMask() <<std::endl;
+    BOOST_CHECK(toInt(id) == det);
+
+    // test that all names are initialized
+    BOOST_CHECK(std::strlen(det.getName()) == 3);
+  }
+
+  {
+    // test specific name access
+    DetID det(DetID::ITS);
+    BOOST_CHECK(std::strcmp(det.getName(),"ITS") == 0);
+  }
+}


### PR DESCRIPTION
The names of detectors are currently defined in the class itself and overlap with DataOrigin
names. Once DataOrigin will be complete, detector names will be taken from there