### PR TITLE
Make O2 compile under Xcode

### DIFF
--- a/CCDB/include/CCDB/Backend.h
+++ b/CCDB/include/CCDB/Backend.h
@@ -22,7 +22,7 @@
 
 // Google protocol buffers headers
 #include <google/protobuf/stubs/common.h>
-#include "request.pb.h"
+
 
 namespace o2 {
 namespace CDB {

--- a/CCDB/src/Backend.cxx
+++ b/CCDB/src/Backend.cxx
@@ -13,6 +13,7 @@
 /// \author Charis Kouzinopoulos <charalampos.kouzinopoulos@cern.ch>
 
 #include "CCDB/Backend.h"
+#include "request.pb.h"
 
 using namespace o2::CDB;
 using namespace std;

--- a/CCDB/src/BackendRiak.cxx
+++ b/CCDB/src/BackendRiak.cxx
@@ -14,6 +14,7 @@
 
 #include "CCDB/BackendRiak.h"
 #include "CCDB/ObjectHandler.h"
+#include "request.pb.h"
 
 #include <zlib.h>
 


### PR DESCRIPTION
Compilation breaks under Xcode when request.pb.h is included
in the header file with the message that the file is not found.
Working when the header created by protobuf is included in
source files.