### PR TITLE
Reduction of the dependence of the Geometry classes on ROOT

### DIFF
--- a/Detectors/EMCAL/base/include/EMCALBase/EMCGeometry.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/EMCGeometry.h
@@ -11,13 +11,15 @@
 #ifndef ALICEO2_EMCAL_EMCGEOMETRY_H_
 #define ALICEO2_EMCAL_EMCGEOMETRY_H_
 
+#include <array>
 #include <iosfwd>
+#include <string>
+#include <vector>
 
 #include <TArrayD.h>
 #include <TList.h>
 #include <TMath.h>
-#include <TNamed.h>
-#include <TString.h>
+#include <RStringView.h>
 
 #include <FairLogger.h>
 
@@ -27,7 +29,7 @@ namespace o2
 {
 namespace EMCAL
 {
-class EMCGeometry : public TNamed
+class EMCGeometry
 {
   /// possible SM Type
  public:
@@ -59,13 +61,13 @@ class EMCGeometry : public TNamed
   /// EMCAL_COMPLETE12SMV1_DCAL_8SM, EMCAL_COMPLETE12SMV1_DCAL_DEV (see main class description for definition) \param
   /// title \param mcname: Geant3/4, Flukla, ... \param mctitle: Geant4 physics list tag name
   ///
-  EMCGeometry(const Text_t* name, const Text_t* title, const Text_t* mcname = "", const Text_t* mctitle = "");
+  EMCGeometry(const std::string_view name, const std::string_view mcname = "", const std::string_view mctitle = "");
 
   ///
   /// Destructor
   ///
-  ~EMCGeometry() override;
-
+  ~EMCGeometry();
+    
   /// Assignement operator requested by coding convention but not needed
   EMCGeometry& operator=(const EMCGeometry& /*rvalue*/)
   {
@@ -77,8 +79,9 @@ class EMCGeometry : public TNamed
   // General
   //
 
+  const std::string &GetName() const { return mGeoName; }
   Bool_t IsInitialized() const { return sInit; }
-  static const Char_t* GetDefaultGeometryName() { return sDefaultGeometryName; }
+  static const std::string &GetDefaultGeometryName() { return sDefaultGeometryName; }
 
   ///
   /// Print EMCal parameters
@@ -94,7 +97,7 @@ class EMCGeometry : public TNamed
   /// \param mcname: Geant3/4, Fluka, needed for settings of transport (not needed since 15/03/16)
   /// \param mctitle: Geant4 physics list ((not needed since 15/03/16))
   ///
-  void Init(const Text_t* mcname = "", const Text_t* mctitle = "");
+  void Init(const std::string_view mcname = "", const std::string_view mctitle = "");
 
   ///
   /// Additional options that can be used to select
@@ -109,13 +112,13 @@ class EMCGeometry : public TNamed
   /// \param mcname: Geant3/4, Flukla, ...
   /// \param mctitle: Geant4 physics list tag name
   ///
-  void DefineSamplingFraction(const Text_t* mcname = "", const Text_t* mctitle = "");
+    void DefineSamplingFraction(const std::string_view mcname = "", const std::string_view mctitle = "");
 
   //////////////////////////////////////
   // Return EMCAL geometrical parameters
   //
 
-  TString GetGeoName() const { return mGeoName; }
+  const std::string &GetGeoName() const { return mGeoName; }
 
   const Int_t* GetEMCSystem() const { return mEMCSMSystem; }
   Int_t* GetEMCSystem() { return mEMCSMSystem; } // Why? GCB
@@ -270,16 +273,16 @@ class EMCGeometry : public TNamed
   Float_t GetSteelFrontThickness() const { return mSteelFrontThick; }
   //////////////////////////////////////////////////
 
-  static const Char_t* sDefaultGeometryName; ///< Default name of geometry
+  static std::string sDefaultGeometryName; ///< Default name of geometry
   static Bool_t sInit;                       ///< Tells if geometry has been succesfully set up.
 
  private:
   // Member data
 
-  TString mGeoName; ///< geometry name
+  std::string mGeoName; ///< geometry name
 
   TObjArray* mArrayOpts;          //!<! array of geometry options
-  const char* mAdditionalOpts[6]; //!<! some additional options for the geometry type and name
+  std::array<std::string, 6> mAdditionalOpts; //!<! some additional options for the geometry type and name
   Int_t mNAdditionalOpts;         //!<! size of additional options parameter
 
   Float_t mECPbRadThickness; ///< cm, Thickness of the Pb radiators
@@ -356,9 +359,6 @@ class EMCGeometry : public TNamed
     mEtaCentersOfCells; ///< [fNEta*fNETAdiv*fNPhi*fNPHIdiv], positive direction (eta>0); eta depend from phi position;
   TArrayD mPhiCentersOfCells; ///< [fNPhi*fNPHIdiv] from center of SM (-10. < phi < +10.)
 
-  // Move from AliEMCALv0 - Feb 19, 2006
-  TList* mShishKebabTrd1Modules; //!<! list of modules
-
   // Local coordinates of SM for TRD1
   Float_t mParSM[3]; ///< SM sizes as in GEANT (TRD1)
 
@@ -366,13 +366,10 @@ class EMCGeometry : public TNamed
   Int_t mIHADR; ///< Options for Geant (MIP business) - will call in AliEMCAL
 
   Float_t mSteelFrontThick; ///< Thickness of the front stell face of the support box - 9-sep-04; obsolete?
-
-  /// \cond CLASSIMP
-  ClassDef(EMCGeometry, 1);
-  /// \endcond
 };
+
+std::ostream& operator<<(std::ostream& stream, const EMCGeometry& geo);
 }
 }
 
-std::ostream& operator<<(std::ostream& stream, const o2::EMCAL::EMCGeometry& geo);
 #endif

--- a/Detectors/EMCAL/base/include/EMCALBase/ShishKebabTrd1Module.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/ShishKebabTrd1Module.h
@@ -12,6 +12,7 @@
 #define ALICEO2_EMCAL_SHISHKEBABTRD1MODULE_H
 
 #include <iomanip>
+#include <memory>
 
 #include <TMath.h>
 #include <TNamed.h>
@@ -37,13 +38,13 @@ class EMCGeometry;
 ///
 /// \author: Alexei Pavlinov (WSU).
 ///
-class ShishKebabTrd1Module : public TNamed
+class ShishKebabTrd1Module
 {
  public:
   ///
   /// Constructor.
   ///
-  ShishKebabTrd1Module(Double_t theta = 0.0, EMCGeometry* g = nullptr);
+  ShishKebabTrd1Module(Double_t theta = 0.0, EMCGeometry * g = nullptr);
 
   ///
   /// Constructor.
@@ -71,15 +72,12 @@ class ShishKebabTrd1Module : public TNamed
     return *this;
   }
 
-  ~ShishKebabTrd1Module() override = default;
+  ~ShishKebabTrd1Module() = default;
 
   ///
   /// Recover module parameters stored in geometry
   ///
-  Bool_t GetParameters();
-
-  /// Define name of object (add more comment)
-  void DefineName(Double_t theta);
+  Bool_t SetParameters();
 
   ///
   /// This is what we have in produced SM. (add explanation)
@@ -90,7 +88,7 @@ class ShishKebabTrd1Module : public TNamed
   void DefineFirstModule(const Int_t key = 0); // key=0-zero tilt of first module
 
   Double_t GetTheta() const { return mTheta; }
-  TVector2& GetCenterOfModule() { return mOK; }
+  const TVector2& GetCenterOfModule() const { return mOK; }
   Double_t GetPosX() const { return mOK.Y(); }
   Double_t GetPosZ() const { return mOK.X(); }
   Double_t GetPosXfromR() const { return mOK.Y() - mgr; }
@@ -102,7 +100,7 @@ class ShishKebabTrd1Module : public TNamed
 
   //  Additional offline stuff
   //  ieta=0 or 1 - Jun 02, 2006
-  TVector2& GetCenterOfCellInLocalCoordinateofSM(Int_t ieta)
+  const TVector2& GetCenterOfCellInLocalCoordinateofSM(Int_t ieta) const
   {
     if (ieta <= 0)
       return mOK2;
@@ -119,7 +117,7 @@ class ShishKebabTrd1Module : public TNamed
       xr = mOK1.Y();
       zr = mOK1.X();
     }
-    LOG(DEBUG2) << GetName() << " ieta " << std::setw(2) << std::setprecision(2) << ieta << " xr " << std::setw(8)
+    LOG(DEBUG2) <<  " ieta " << std::setw(2) << std::setprecision(2) << ieta << " xr " << std::setw(8)
                 << std::setprecision(4) << xr << " zr " << std::setw(8) << std::setprecision(4) << zr
                 << FairLogger::endl;
   }
@@ -141,8 +139,8 @@ class ShishKebabTrd1Module : public TNamed
   }
 
   // 15-may-06
-  TVector2& GetCenterOfModuleFace() { return mOB; }
-  TVector2& GetCenterOfModuleFace(Int_t ieta)
+  const TVector2& GetCenterOfModuleFace() const { return mOB; }
+  const TVector2& GetCenterOfModuleFace(Int_t ieta) const
   {
     if (ieta <= 0)
       return mOB2;
@@ -151,7 +149,7 @@ class ShishKebabTrd1Module : public TNamed
   }
 
   // Jul 30, 2007
-  void GetPositionAtCenterCellLine(Int_t ieta, Double_t dist, TVector2& v);
+  void GetPositionAtCenterCellLine(Int_t ieta, Double_t dist, TVector2& v) const;
 
   //
   Double_t GetTanBetta() const { return mgtanBetta; }
@@ -166,7 +164,7 @@ class ShishKebabTrd1Module : public TNamed
 
  protected:
   // geometry info
-  EMCGeometry* mGeometry; //!<! pointer to geometry info
+  EMCGeometry *mGeometry; //!<! pointer to geometry info
   Double_t mga;           ///<  2*dx1=2*dy1
   Double_t mga2;          ///<  2*dx2
   Double_t mgb;           ///<  2*dz1
@@ -201,7 +199,6 @@ class ShishKebabTrd1Module : public TNamed
   TVector2 mORB; ///< position of right/bottom point of module
   TVector2 mORT; ///< position of right/top    point of module
 
-  ClassDef(ShishKebabTrd1Module, 1);
 };
 }
 }

--- a/Detectors/EMCAL/base/src/EMCALBaseLinkDef.h
+++ b/Detectors/EMCAL/base/src/EMCALBaseLinkDef.h
@@ -15,9 +15,7 @@
 #pragma link off all functions;
 
 #pragma link C++ class o2::EMCAL::Digit;
-#pragma link C++ class o2::EMCAL::EMCGeometry;
-#pragma link C++ class o2::EMCAL::Geometry;
 #pragma link C++ class o2::EMCAL::Hit;
-#pragma link C++ class o2::EMCAL::ShishKebabTrd1Module;
+
 
 #endif

--- a/Detectors/EMCAL/base/src/EMCGeometry.cxx
+++ b/Detectors/EMCAL/base/src/EMCGeometry.cxx
@@ -18,6 +18,8 @@
 #include <TObjString.h>
 #include <TRegexp.h>
 
+#include <boost/algorithm/string/predicate.hpp>
+
 #include "EMCALBase/EMCGeometry.h"
 
 using namespace o2::EMCAL;
@@ -169,6 +171,7 @@ EMCGeometry::~EMCGeometry()
 
 void EMCGeometry::Init(std::string_view mcname, std::string_view mctitle)
 {
+  using boost::algorithm::contains;
   mAdditionalOpts[0] = "nl=";       // number of sampling layers (fNECLayers)
   mAdditionalOpts[1] = "pbTh=";     // cm, Thickness of the Pb   (fECPbRadThick)
   mAdditionalOpts[2] = "scTh=";     // cm, Thickness of the Sc    (fECScintThick)
@@ -177,45 +180,43 @@ void EMCGeometry::Init(std::string_view mcname, std::string_view mctitle)
   mAdditionalOpts[5] = "allIHADR="; // = 0,1,2 (0 - no hadronic interaction)
 
   mNAdditionalOpts = sizeof(mAdditionalOpts) / sizeof(char*);
-    
-  std::function<bool(const std::string_view, const char *)> findSubstring = [](const std::string_view tocheck, const char *teststring) { return tocheck.find(teststring) != std::string::npos; };
 
   // geometry
   sInit = kFALSE; // Assume failed until proven otherwise.
   std::transform(mGeoName.begin(), mGeoName.end(), mGeoName.begin(), ::toupper);
  
   // Convert old geometry names to new ones
-  if (findSubstring(mGeoName, "SHISH_77_TRD1_2X2_FINAL_110DEG")) {
-    if (findSubstring(mGeoName, "PBTH=0.144") && findSubstring(mGeoName, "SCTH=0.176")) {
+  if (contains(mGeoName, "SHISH_77_TRD1_2X2_FINAL_110DEG")) {
+    if (contains(mGeoName, "PBTH=0.144") && contains(mGeoName, "SCTH=0.176")) {
       mGeoName = "EMCAL_COMPLETE";
     } else {
       mGeoName = "EMCAL_PDC06";
     }
   }
 
-  if (findSubstring(mGeoName, "WSUC"))
+  if (contains(mGeoName, "WSUC"))
     mGeoName = "EMCAL_WSUC";
 
   // check that we have a valid geometry name
-  if(!(findSubstring(mGeoName, "EMCAL_PDC06") || findSubstring(mGeoName, "EMCAL_WSUC") || findSubstring(mGeoName, "EMCAL_COMPLETE") ||
-       findSubstring(mGeoName, "EMCAL_COMPLETEV1") || findSubstring(mGeoName, "EMCAL_COMPLETE12SMV1") ||
-       findSubstring(mGeoName, "EMCAL_FIRSTYEAR") || findSubstring(mGeoName, "EMCAL_FIRSTYEARV1"))) {
+  if(!(contains(mGeoName, "EMCAL_PDC06") || contains(mGeoName, "EMCAL_WSUC") || contains(mGeoName, "EMCAL_COMPLETE") ||
+       contains(mGeoName, "EMCAL_COMPLETEV1") || contains(mGeoName, "EMCAL_COMPLETE12SMV1") ||
+       contains(mGeoName, "EMCAL_FIRSTYEAR") || contains(mGeoName, "EMCAL_FIRSTYEARV1"))) {
     LOG(FATAL) << "Init, " << mGeoName << " is an undefined geometry!\n";
   }
 
   // Option to know whether we have the "half" supermodule(s) or not
   mKey110DEG = 0;
-  if(findSubstring(mGeoName,"COMPLETE") || findSubstring(mGeoName,"PDC06") || findSubstring(mGeoName,"12SM"))
+  if(contains(mGeoName,"COMPLETE") || contains(mGeoName,"PDC06") || contains(mGeoName,"12SM"))
     mKey110DEG = 1; // for GetAbsCellId
-  if(findSubstring(mGeoName,"COMPLETEV1"))
+  if(contains(mGeoName,"COMPLETEV1"))
     mKey110DEG = 0;
 
   mnSupModInDCAL = 0;
-  if(findSubstring(mGeoName, "DCAL_DEV")) {
+  if(contains(mGeoName, "DCAL_DEV")) {
     mnSupModInDCAL = 10;
-  } else if(findSubstring(mGeoName, "DCAL_8SM")) {
+  } else if(contains(mGeoName, "DCAL_8SM")) {
     mnSupModInDCAL = 8;
-  } else if(findSubstring(mGeoName, "DCAL")) {
+  } else if(contains(mGeoName, "DCAL")) {
     mnSupModInDCAL = 6;
   }
 
@@ -256,13 +257,13 @@ void EMCGeometry::Init(std::string_view mcname, std::string_view mctitle)
   CheckAdditionalOptions();
 
   // modifications to the above for PDC06 geometry
-  if(findSubstring(mGeoName, "PDC06")) {           // 18-may-05 - about common structure
+  if(contains(mGeoName, "PDC06")) {           // 18-may-05 - about common structure
     mECScintThick = mECPbRadThickness = 0.16; // (13-may-05 from V.Petrov)
     CheckAdditionalOptions();
   }
 
   // modifications to the above for WSUC geometry
-  if(findSubstring(mGeoName, "WSUC")) { // 18-may-05 - about common structure
+  if(contains(mGeoName, "WSUC")) { // 18-may-05 - about common structure
     mNumberOfSuperModules = 2;     // 27-may-05; Nov 24,2010 for TB
     mNPhi = mNZ = 4;
     mTrd1AlFrontThick = 1.0; // one cm
@@ -277,13 +278,13 @@ void EMCGeometry::Init(std::string_view mcname, std::string_view mctitle)
   }
 
   // In 2009-2010 data taking runs only 4 SM, in the upper position.
-  if(findSubstring(mGeoName, "FIRSTYEAR")) {
+  if(contains(mGeoName, "FIRSTYEAR")) {
     mNumberOfSuperModules = 4;
     mArm1PhiMax = 120.0;
     CheckAdditionalOptions();
   }
 
-  if(findSubstring(mGeoName, "FIRSTYEARV1") || findSubstring(mGeoName, "COMPLETEV1") || findSubstring(mGeoName, "COMPLETE12SMV1")) {
+  if(contains(mGeoName, "FIRSTYEARV1") || contains(mGeoName, "COMPLETEV1") || contains(mGeoName, "COMPLETE12SMV1")) {
     // Oct 26,2010 : First module has tilt = 0.75 degree :
     // look to AliEMCALShishKebabTrd1Module::DefineFirstModule(key)
     // New sizes from production drawing, added Al front plate.
@@ -298,19 +299,19 @@ void EMCGeometry::Init(std::string_view mcname, std::string_view mctitle)
     mEtaModuleSize = mPhiModuleSize;
     mLateralSteelStrip = 0.015; // 0.015cm  = 0.15mm
 
-    if(findSubstring(mGeoName, "COMPLETEV1")) {
+    if(contains(mGeoName, "COMPLETEV1")) {
       mNumberOfSuperModules = 10;
       mArm1PhiMax = 180.0;
-    } else if(findSubstring(mGeoName, "COMPLETE12SMV1")) {
+    } else if(contains(mGeoName, "COMPLETE12SMV1")) {
       mNumberOfSuperModules = 12;
       mArm1PhiMax = 200.0;
     }
-    if(findSubstring(mGeoName, "DCAL")) {
+    if(contains(mGeoName, "DCAL")) {
       mNumberOfSuperModules = 12 + mnSupModInDCAL;
       mArm1PhiMax = 320.0;
-      if(findSubstring(mGeoName, "DCAL_8SM"))
+      if(contains(mGeoName, "DCAL_8SM"))
         mArm1PhiMax = 340.0; // degrees, End of DCAL Phi position
-      else if(findSubstring(mGeoName, "DCAL_DEV"))
+      else if(contains(mGeoName, "DCAL_DEV"))
         mArm1PhiMin = 40.0; // degrees, Starting EMCAL(shifted) Phi position
       mDCALPhiMin = mArm1PhiMax - 10. * mnSupModInDCAL;
     }
@@ -331,17 +332,17 @@ void EMCGeometry::Init(std::string_view mcname, std::string_view mctitle)
 
   //
   // BASIC EMCAL SM
-  if(findSubstring(mGeoName, "WSUC")) {
+  if(contains(mGeoName, "WSUC")) {
     for(int i = 0; i < 2; i++) {
       mEMCSMSystem[iSM] = EMCAL_STANDARD;
       iSM++;
     }
-  } else if(findSubstring(mGeoName, "FIRSTYEAR")) {
+  } else if(contains(mGeoName, "FIRSTYEAR")) {
     for(int i = 0; i < 4; i++) {
       mEMCSMSystem[iSM] = EMCAL_STANDARD;
       iSM++;
     }
-  } else if(findSubstring(mGeoName, "PDC06") || findSubstring(mGeoName, "COMPLETE")) {
+  } else if(contains(mGeoName, "PDC06") || contains(mGeoName, "COMPLETE")) {
     for(int i = 0; i < 10; i++) {
       mEMCSMSystem[iSM] = EMCAL_STANDARD;
       iSM++;
@@ -350,10 +351,10 @@ void EMCGeometry::Init(std::string_view mcname, std::string_view mctitle)
 
   //
   // EMCAL 110SM
-  if (mKey110DEG && findSubstring(mGeoName, "12SM")) {
+  if (mKey110DEG && contains(mGeoName, "12SM")) {
     for(int i = 0; i < 2; i++) {
       mEMCSMSystem[iSM] = EMCAL_HALF;
-      if(findSubstring(mGeoName, "12SMV1")) {
+      if(contains(mGeoName, "12SMV1")) {
         mEMCSMSystem[iSM] = EMCAL_THIRD;
       }
       iSM++;
@@ -362,8 +363,8 @@ void EMCGeometry::Init(std::string_view mcname, std::string_view mctitle)
 
   //
   // DCAL SM
-  if(mnSupModInDCAL && findSubstring(mGeoName, "DCAL")) {
-    if(findSubstring(mGeoName, "8SM")) {
+  if(mnSupModInDCAL && contains(mGeoName, "DCAL")) {
+    if(contains(mGeoName, "8SM")) {
       for(int i = 0; i < mnSupModInDCAL - 2; i++) {
         mEMCSMSystem[iSM] = DCAL_STANDARD;
         iSM++;
@@ -407,14 +408,14 @@ void EMCGeometry::Init(std::string_view mcname, std::string_view mctitle)
   mEtaTileSize = mEtaModuleSize / double(mNETAdiv) - mLateralSteelStrip; // 13-may-05
 
   mLongModuleSize = mNECLayers * (mECScintThick + mECPbRadThickness);
-  if(findSubstring(mGeoName, "V1")) {
+  if(contains(mGeoName, "V1")) {
     Double_t ws = mECScintThick + mECPbRadThickness + 2. * mTrd1BondPaperThick; // sampling width
     // Number of Pb tiles = Number of Sc tiles - 1
     mLongModuleSize = mTrd1AlFrontThick + (ws * mNECLayers - mECPbRadThickness);
   }
   m2Trd1Dx2 = mEtaModuleSize + 2. * mLongModuleSize * TMath::Tan(mTrd1Angle * TMath::DegToRad() / 2.);
 
-  if(!findSubstring(mGeoName, "WSUC"))
+  if(!contains(mGeoName, "WSUC"))
     mShellThickness = TMath::Sqrt(mLongModuleSize * mLongModuleSize + m2Trd1Dx2 * m2Trd1Dx2);
 
   // These parameters are used to create the mother volume to hold the supermodules
@@ -506,7 +507,7 @@ void EMCGeometry::Init(std::string_view mcname, std::string_view mctitle)
 
 void EMCGeometry::PrintStream(std::ostream& stream) const
 {
-  std::function<bool(const std::string_view, const char *)> findSubstring = [](const std::string_view tocheck, const char *teststring) { return tocheck.find(teststring) != std::string::npos; };
+  using boost::algorithm::contains;
 
   // Separate routine is callable from broswer; Nov 7,2006
   stream << "\nInit: geometry of EMCAL named " << mGeoName << " :\n";
@@ -516,11 +517,11 @@ void EMCGeometry::PrintStream(std::ostream& stream) const
       stream << i << ": " << o->String() << std::endl;
     }
   }
-  if (findSubstring(mGeoName, "DCAL")) {
+  if (contains(mGeoName, "DCAL")) {
     stream << "Phi min of DCAL SuperModule: " << std::setw(7) << std::setprecision(1) << mDCALPhiMin << ", DCAL has "
            << mnSupModInDCAL << "  SuperModule\n";
     stream << "The DCAL inner edge is +- " << std::setw(7) << std::setprecision(1) << mDCALInnerEdge << std::endl;
-    if (findSubstring(mGeoName, "DCAL_8SM"))
+    if (contains(mGeoName, "DCAL_8SM"))
       stream << "DCAL has its 2 EXTENTION SM\n";
   }
   stream << "Granularity: " << GetNZ() << " in eta and " << GetNPhi() << " in phi\n";
@@ -552,9 +553,9 @@ void EMCGeometry::PrintStream(std::ostream& stream) const
          << " dz " << mParSM[2] << "(SMOD, BOX)\n";
   stream << " fPhiGapForSM  " << std::setw(7) << std::setprecision(4) << mPhiGapForSM << " cm ("
          << TMath::ATan2(mPhiGapForSM, mIPDistance) * TMath::RadToDeg() << " <- phi size in degree)\n";
-  if (mKey110DEG && !findSubstring(mGeoName, "12SMV1"))
+  if (mKey110DEG && !contains(mGeoName, "12SMV1"))
     stream << " Last two modules have size 10 degree in  phi (180<phi<190)\n";
-  if (mKey110DEG && findSubstring(mGeoName, "12SMV1"))
+  if (mKey110DEG && contains(mGeoName, "12SMV1"))
     stream << " Last two modules have size 6.6 degree in  phi (180<phi<186.6)\n";
   stream << " phi SM boundaries \n";
   for (int i = 0; i < mPhiBoundariesOfSM.GetSize() / 2.; i++) {
@@ -631,8 +632,7 @@ void EMCGeometry::DefineSamplingFraction(const std::string_view mcname, const st
   // Look http://rhic.physics.wayne.edu/~pavlinov/ALICE/SHISHKEBAB/RES/linearityAndResolutionForTRD1.html
   // Keep for compatibility
   //
-
-  std::function<bool(const std::string_view, const char *)> findSubstring = [](const std::string_view tocheck, const char *teststring) { return tocheck.find(teststring) != std::string::npos; };
+  using boost::algorithm::contains;
 
   // Sampling factor for G3
   mSampling = 10.87;      // Default value - Nov 25,2010
@@ -641,7 +641,7 @@ void EMCGeometry::DefineSamplingFraction(const std::string_view mcname, const st
   } else if (mNECLayers == 61) { // 20% layer reduction
     mSampling = 12.80;
   } else if (mNECLayers == 77) {
-    if(findSubstring(mGeoName, "V1")) {
+    if(contains(mGeoName, "V1")) {
       mSampling = 10.87;                                         // Adding paper sheets and cover plate; Nov 25,2010
     } else if (mECScintThick > 0.159 && mECScintThick < 0.161) { // original sampling fraction, equal layers
       mSampling = 12.327;                                        // fECScintThick = fECPbRadThickness = 0.160;
@@ -653,14 +653,14 @@ void EMCGeometry::DefineSamplingFraction(const std::string_view mcname, const st
   }
 
   Float_t samplingFactorTranportModel = 1.;
-  if(findSubstring(mcname, "Geant3"))
+  if(contains(mcname, "Geant3"))
     samplingFactorTranportModel = 1.; // 0.988 // Do nothing
-  else if(findSubstring(mcname, "Fluka"))
+  else if(contains(mcname, "Fluka"))
     samplingFactorTranportModel = 1.; // To be set
-  else if(findSubstring(mcname, "Geant4")) {
-    if(findSubstring(mctitle, "EMV-EMCAL"))
+  else if(contains(mcname, "Geant4")) {
+    if(contains(mctitle, "EMV-EMCAL"))
       samplingFactorTranportModel = 0.821; // EMC list but for EMCal, before 0.86
-    else if(findSubstring(mctitle, "EMV"))
+    else if(contains(mctitle, "EMV"))
       samplingFactorTranportModel = 1.096; // 0.906, 0.896 (OPT)
     else
       samplingFactorTranportModel = 0.821; // 1.15 (CHIPS), 1.149 (BERT), 1.147 (BERT_CHIPS)

--- a/Detectors/EMCAL/base/src/Geometry.cxx
+++ b/Detectors/EMCAL/base/src/Geometry.cxx
@@ -19,6 +19,8 @@
 #include "EMCALBase/Geometry.h"
 #include "EMCALBase/ShishKebabTrd1Module.h"
 
+#include <boost/algorithm/string/predicate.hpp>
+
 using namespace o2::EMCAL;
 
 // these initialisations are needed for a singleton
@@ -235,6 +237,8 @@ Geometry* Geometry::GetInstance(const std::string_view name, const std::string_v
 Geometry* Geometry::GetInstanceFromRunNumber(Int_t runNumber, const std::string_view geoName, const std::string_view mcname,
                                              const std::string_view mctitle)
 {
+  using boost::algorithm::contains;
+
   // printf("AliEMCALGeometry::GetInstanceFromRunNumber() - run %d, geoName <<%s>> \n",runNumber,geoName.Data());
 
   bool showInfo = !(getenv("HLT_ONLINE_MODE") && strcmp(getenv("HLT_ONLINE_MODE"), "on") == 0);
@@ -244,7 +248,7 @@ Geometry* Geometry::GetInstanceFromRunNumber(Int_t runNumber, const std::string_
     // First year geometry, 4 SM.
 
     if (showInfo) {
-      if (geoName.find("FIRSTYEARV1") != std::string::npos && geoName != std::string("")) {
+      if (contains(geoName, "FIRSTYEARV1") && geoName != std::string("")) {
         LOG(INFO) << "o2::EMCAL::Geometry::GetInstanceFromRunNumber() *** ATTENTION *** \n"
                   << "\t Specified geometry name <<" << geoName << ">> for run " << runNumber
                   << " is not considered! \n"
@@ -260,7 +264,7 @@ Geometry* Geometry::GetInstanceFromRunNumber(Int_t runNumber, const std::string_
     // Almost complete EMCAL geometry, 10 SM. Year 2011 configuration
 
     if (showInfo) {
-      if (geoName.find("COMPLETEV1") != std::string::npos && geoName != std::string("")) {
+      if (contains(geoName, "COMPLETEV1") && geoName != std::string("")) {
         LOG(INFO) << "o2::EMCAL::Geometry::GetInstanceFromRunNumber() *** ATTENTION *** \n"
                   << "\t Specified geometry name <<" << geoName << ">> for run " << runNumber
                   << " is not considered! \n"
@@ -276,7 +280,7 @@ Geometry* Geometry::GetInstanceFromRunNumber(Int_t runNumber, const std::string_
     // The last 2 SM were not active, anyway they were there.
 
     if (showInfo) {
-      if (geoName.find("COMPLETE12SMV1") != std::string::npos && geoName != std::string("")) {
+      if (contains(geoName, "COMPLETE12SMV1") && geoName != std::string("")) {
         LOG(INFO) << "o2::EMCAL::Geometry::GetInstanceFromRunNumber() *** ATTENTION *** \n"
                   << "\t Specified geometry name <<" << geoName << " >> for run " << runNumber
                   << " is not considered! \n"
@@ -292,7 +296,7 @@ Geometry* Geometry::GetInstanceFromRunNumber(Int_t runNumber, const std::string_
     // EMCAL + DCAL geometry, 20 SM. Year 2015 and on
 
     if (showInfo) {
-      if (geoName.find("DCAL_8SM") != std::string::npos && geoName != std::string("")) {
+      if (contains(geoName, "DCAL_8SM") && geoName != std::string("")) {
         LOG(INFO) << "o2::EMCAL::Geometry::GetInstanceFromRunNumber() *** ATTENTION *** \n"
                   << "\t Specified geometry name <<" << geoName << ">> for run " << runNumber
                   << " is not considered! \n"

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/Detector.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/Detector.h
@@ -16,6 +16,8 @@
 #include "TArrayF.h"
 #include "TString.h"
 
+#include <vector>
+
 #include "Math/GenVector/DisplacementVector3D.h"
 #include "Math/GenVector/PositionVector3D.h"
 
@@ -26,27 +28,15 @@ using Vector3D = ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<T>, RO
 
 class FairVolume;
 class TClonesArray;
-class TList;
 
 namespace o2
 {
 namespace EMCAL
 {
+
 class Hit;
-}
-}
-namespace o2
-{
-namespace EMCAL
-{
 class Geometry;
-}
-}
-
-namespace o2
-{
-namespace EMCAL
-{
+    
 class Detector : public o2::Base::Detector
 {
  public:
@@ -133,7 +123,6 @@ class Detector : public o2::Base::Detector
   TClonesArray* mPointCollection; ///< Collection of EMCAL points
   Geometry* mGeometry;            ///< Geometry pointer
 
-  TList* mShishKebabModules; //!<! list of modules
   TArrayF mEnvelop1;         //!<! parameters of EMCAL envelop for TRD1(2) case
   Int_t mIdRotm;             //!<! number of rotation matrix (working variable)
 


### PR DESCRIPTION
As argued in #445 the dependence on ROOT is reduced:
- Classes Geometry, EMCGeometry and ShishKebabTrdModule do not
  inherit from TNamed any more
- The containers for the ShishKebabTrd1Modules are moved from
  TList to std::vector, and not any more a pointer but class members
  directly. Furthermore they do not own pointers but the objects
  directly. Boundary errors are not handled any more with returning
  a nullptr but by throwing an exception
- The EMCGeometry is now a member of Geometry and not a pointer
  member
- ROOT TString is replace wherever possible with std::string, const char*
  in function arguements with std::string_view (still taken from ROOT)