### PR TITLE
Fix the Copyright header

### DIFF
--- a/Utilities/DataCompression/include/DataCompression/DataDeflater.h
+++ b/Utilities/DataCompression/include/DataCompression/DataDeflater.h
@@ -1,4 +1,3 @@
-//-*- Mode: C++ -*-
 // Copyright CERN and copyright holders of ALICE O2. This software is
 // distributed under the terms of the GNU General Public License v3 (GPL
 // Version 3), copied verbatim in the file "COPYING".

--- a/Utilities/DataCompression/include/DataCompression/TruncatedPrecisionConverter.h
+++ b/Utilities/DataCompression/include/DataCompression/TruncatedPrecisionConverter.h
@@ -1,4 +1,3 @@
-//-*- Mode: C++ -*-
 // Copyright CERN and copyright holders of ALICE O2. This software is
 // distributed under the terms of the GNU General Public License v3 (GPL
 // Version 3), copied verbatim in the file "COPYING".

--- a/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/Component.h
+++ b/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/Component.h
@@ -1,4 +1,3 @@
-//-*- Mode: C++ -*-
 // Copyright CERN and copyright holders of ALICE O2. This software is
 // distributed under the terms of the GNU General Public License v3 (GPL
 // Version 3), copied verbatim in the file "COPYING".

--- a/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/EventSampler.h
+++ b/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/EventSampler.h
@@ -1,4 +1,3 @@
-//-*- Mode: C++ -*-
 // Copyright CERN and copyright holders of ALICE O2. This software is
 // distributed under the terms of the GNU General Public License v3 (GPL
 // Version 3), copied verbatim in the file "COPYING".

--- a/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/HOMERFactory.h
+++ b/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/HOMERFactory.h
@@ -1,4 +1,3 @@
-//-*- Mode: C++ -*-
 // Copyright CERN and copyright holders of ALICE O2. This software is
 // distributed under the terms of the GNU General Public License v3 (GPL
 // Version 3), copied verbatim in the file "COPYING".

--- a/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/MessageFormat.h
+++ b/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/MessageFormat.h
@@ -1,4 +1,3 @@
-//-*- Mode: C++ -*-
 // Copyright CERN and copyright holders of ALICE O2. This software is
 // distributed under the terms of the GNU General Public License v3 (GPL
 // Version 3), copied verbatim in the file "COPYING".

--- a/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/SystemInterface.h
+++ b/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/SystemInterface.h
@@ -1,4 +1,3 @@
-//-*- Mode: C++ -*-
 // Copyright CERN and copyright holders of ALICE O2. This software is
 // distributed under the terms of the GNU General Public License v3 (GPL
 // Version 3), copied verbatim in the file "COPYING".

--- a/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/WrapperDevice.h
+++ b/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/WrapperDevice.h
@@ -1,4 +1,3 @@
-//-*- Mode: C++ -*-
 // Copyright CERN and copyright holders of ALICE O2. This software is
 // distributed under the terms of the GNU General Public License v3 (GPL
 // Version 3), copied verbatim in the file "COPYING".


### PR DESCRIPTION
Remove the unnecessary option "-*- Mode: C++ -*-" from the first line, since it does not match the guidelines for Copyright.