### PR TITLE
Fix compiler warnings

### DIFF
--- a/DataFormats/TimeFrame/test/TimeFrameTest.cxx
+++ b/DataFormats/TimeFrame/test/TimeFrameTest.cxx
@@ -15,7 +15,7 @@
 #include "TimeFrame/TimeFrame.h"
 #include <FairMQMessage.h>
 #include <FairMQParts.h>
-#include <FairMQDevice.h>
+#include <FairMQTransportFactory.h>
 #include "Headers/DataHeader.h"
 #include "TFile.h"
 
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(TimeFrame_test)
   FairMQParts messages;
 
   // we use the ZMQ Factory to create some messages
-  std::unique_ptr<FairMQTransportFactory> zmq(FairMQDevice::MakeTransport("zeromq"));
+  std::shared_ptr<FairMQTransportFactory> zmq(FairMQTransportFactory::CreateTransportFactory("zeromq"));
   BOOST_CHECK(zmq);
   messages.AddPart(zmq->CreateMessage(1000));
 

--- a/Detectors/TPC/base/include/TPCBase/CalArray.h
+++ b/Detectors/TPC/base/include/TPCBase/CalArray.h
@@ -78,10 +78,10 @@ public:
   int getPadSubsetNumber() const { return mPadSubsetNumber; }
 
   void setValue(const size_t channel, const T& value) { mData[channel] = value; }
-  const T& getValue(const size_t channel) const { return mData[channel]; }
+  const T getValue(const size_t channel) const { return mData[channel]; }
 
   void setValue(const size_t row, const size_t pad, const T& value);
-  const T& getValue(const size_t row, const size_t pad) const;
+  const T getValue(const size_t row, const size_t pad) const;
 
   void setName(const std::string& name) { mName = name; }
   const std::string& getName() const { return mName; }
@@ -158,7 +158,7 @@ inline void CalArray<T>::setValue(const size_t row, const size_t pad, const T& v
 
 //______________________________________________________________________________
 template <class T>
-inline const T& CalArray<T>::getValue(const size_t row, const size_t pad) const
+inline const T CalArray<T>::getValue(const size_t row, const size_t pad) const
 {
   // TODO: might need speedup and beautification
   Mapper& mapper = Mapper::instance();

--- a/Utilities/DataCompression/include/DataCompression/HuffmanCodec.h
+++ b/Utilities/DataCompression/include/DataCompression/HuffmanCodec.h
@@ -451,10 +451,10 @@ public:
     }
     std::map<int, std::shared_ptr<_NodeType>> treeNodes;
     for (auto conf : treeNodeConfigurations) {
-      std::shared_ptr<_NodeType> left;
+      std::shared_ptr<_NodeType> left_local;
       auto ln = leaveNodeMap.find(conf.left);
       if ( ln != leaveNodeMap.end()) {
-        left = mLeaveNodes[ln->second];
+        left_local = mLeaveNodes[ln->second];
         leaveNodeMap.erase(ln);
       } else {
         auto tn = treeNodes.find(conf.left);
@@ -462,13 +462,13 @@ public:
           std::cerr << "Internal error: can not find left child node with index " << conf.left << std::endl;
           return -1;
         }
-        left = tn->second;
+        left_local = tn->second;
         treeNodes.erase(tn);
       }
-      std::shared_ptr<_NodeType> right;
+      std::shared_ptr<_NodeType> right_local;
       auto rn = leaveNodeMap.find(conf.right);
       if (rn != leaveNodeMap.end()) {
-        right = mLeaveNodes[rn->second];
+        right_local = mLeaveNodes[rn->second];
         leaveNodeMap.erase(rn);
       } else {
         auto tn = treeNodes.find(conf.right);
@@ -476,11 +476,11 @@ public:
           std::cerr << "Internal error: can not find right child node with index " << conf.right << std::endl;
           return -1;
         }
-        right = tn->second;
+        right_local = tn->second;
         treeNodes.erase(tn);
       }
       // make combined node shared ptr and add to map
-      treeNodes[conf.index] = std::make_shared<_NodeType>(left, right);
+      treeNodes[conf.index] = std::make_shared<_NodeType>(left_local, right_local);
     }
     if (leaveNodeMap.size() != 0 || treeNodes.size() != 1) {
       std::cerr << "error: " << leaveNodeMap.size() << " unhandled leave node(s)"

--- a/Utilities/DataCompression/test/test_HuffmanCodec.cxx
+++ b/Utilities/DataCompression/test/test_HuffmanCodec.cxx
@@ -140,8 +140,9 @@ BOOST_AUTO_TEST_CASE(test_HuffmanCodec)
               << "   code length: " << std::setw(3) << codeLen
               << "   code: ";
     if (not HuffmanModel_t::orderMSB) std::cout << std::setw(code.size() - codeLen);
-    for (int i = 0; i<codeLen; i++)
-      std::cout << code[codeLen-1-i];
+    for (int k = 0; k<codeLen; k++) {
+      std::cout << code[codeLen-1-k];
+    }
     std::cout << std::endl;
     if (HuffmanModel_t::orderMSB) code <<= (code.size()-codeLen);
     uint16_t decodedLen = 0;

--- a/Utilities/DataFlow/test/test_PayloadMerger01.cxx
+++ b/Utilities/DataFlow/test/test_PayloadMerger01.cxx
@@ -21,14 +21,13 @@
 #include "DataFlow/SubframeUtils.h"
 #include "fairmq/FairMQTransportFactory.h"
 #include "fairmq/FairMQParts.h"
-#include "fairmq/FairMQDevice.h"
 
 using SubframeId = o2::dataflow::SubframeId;
 using HeartbeatHeader = o2::Header::HeartbeatHeader;
 using HeartbeatTrailer = o2::Header::HeartbeatTrailer;
 
 SubframeId fakeAddition(o2::dataflow::PayloadMerger<SubframeId> &merger,
-                  std::unique_ptr<FairMQTransportFactory> &transport,
+                  std::shared_ptr<FairMQTransportFactory> &transport,
                   int64_t orbit) {
   // Create a message
   //
@@ -46,7 +45,7 @@ SubframeId fakeAddition(o2::dataflow::PayloadMerger<SubframeId> &merger,
 }
 
 BOOST_AUTO_TEST_CASE(PayloadMergerTest) {
-  std::unique_ptr<FairMQTransportFactory> zmq(FairMQDevice::MakeTransport("zeromq"));
+  auto zmq = FairMQTransportFactory::CreateTransportFactory("zeromq");
 
   // Needs three subtimeframes to merge them
   auto checkIfComplete = [](SubframeId id, o2::dataflow::PayloadMerger<SubframeId>::MessageMap &m) -> bool {


### PR DESCRIPTION
These commits fix some compiler warnings and make the build completely warning free (at least using gcc on linux).