### PR TITLE
Use BOX_GENERATOR by default in TPC sim macro

### DIFF
--- a/macro/run_sim_tpc.C
+++ b/macro/run_sim_tpc.C
@@ -23,7 +23,7 @@
   #include "TPCSimulation/Detector.h"
 #endif
 
-//#define BOX_GENERATOR 1
+#define BOX_GENERATOR 1
 
 void run_sim_tpc(Int_t nEvents = 10, TString mcEngine = "TGeant3")
 {


### PR DESCRIPTION
 * this used to be the default behaviour and got unfortunately overwritten
   in some commit
 * fixing this here