### PR TITLE
Fixes ROOT IO warnings emitted from FairRunSim

### DIFF
--- a/Detectors/EMCAL/base/include/EMCALBase/EMCGeometry.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/EMCGeometry.h
@@ -358,6 +358,8 @@ class EMCGeometry
   Int_t mIHADR; ///< Options for Geant (MIP business) - will call in AliEMCAL
 
   Float_t mSteelFrontThick; ///< Thickness of the front stell face of the support box - 9-sep-04; obsolete?
+
+  ClassDefNV(EMCGeometry, 1);
 };
 
 std::ostream& operator<<(std::ostream& stream, const EMCGeometry& geo);

--- a/Detectors/EMCAL/base/src/EMCALBaseLinkDef.h
+++ b/Detectors/EMCAL/base/src/EMCALBaseLinkDef.h
@@ -14,8 +14,9 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
-#pragma link C++ class o2::EMCAL::Digit;
-#pragma link C++ class o2::EMCAL::Hit;
-
+#pragma link C++ class o2::EMCAL::Digit+;
+#pragma link C++ class o2::EMCAL::Hit+;
+#pragma link C++ class o2::EMCAL::EMCGeometry+;
+#pragma link C++ class o2::EMCAL::Geometry+;
 
 #endif

--- a/Detectors/EMCAL/base/src/EMCGeometry.cxx
+++ b/Detectors/EMCAL/base/src/EMCGeometry.cxx
@@ -724,3 +724,5 @@ std::ostream& o2::EMCAL::operator<<(std::ostream& stream, const o2::EMCAL::EMCGe
   geo.PrintStream(stream);
   return stream;
 }
+
+ClassImp(EMCGeometry);

--- a/Detectors/Passive/include/DetectorsPassive/FrameStructureRun3.h
+++ b/Detectors/Passive/include/DetectorsPassive/FrameStructureRun3.h
@@ -29,7 +29,7 @@ namespace passive
 class FrameStructure : public FairModule
 {
  public:
-  FrameStructure(const char* Name = "FrameStruct", const char* title = "FrameStruct");
+  FrameStructure(const char* name, const char* title = "FrameStruct");
 
   /**  default constructor    */
   FrameStructure() = default;
@@ -57,10 +57,10 @@ class FrameStructure : public FairModule
     true; //!< if holes are enabled (just a central place for other to query; no influence on frame structure)
 
   // medium IDs for the Frame
-  int mAirMedID = -1;
-  int mSteelMedID = -1;
-  int mAluMedID = -1;
-  int mG10MedID = -1;
+  int mAirMedID = -1; //!
+  int mSteelMedID = -1; //!
+  int mAluMedID = -1; //!
+  int mG10MedID = -1; //!
 
   ClassDefOverride(FrameStructure, 1);
 };

--- a/Detectors/Passive/src/FrameStructureRun3.cxx
+++ b/Detectors/Passive/src/FrameStructureRun3.cxx
@@ -38,6 +38,7 @@ const char* TOPNAME = "cave";
 #define kDegrad TMath::DegToRad()
 
 FrameStructure::FrameStructure(const char* name, const char* Title) : FairModule(name, Title) {}
+
 void FrameStructure::makeHeatScreen(const char* name, float dyP, int rot1, int rot2)
 {
   // Heat screen panel


### PR DESCRIPTION
provide missing dictionary entries
fix a constructor for FrameStructure which was not taken by ROOT properly