### PR TITLE
Correct field tracking parameters for media

### DIFF
--- a/Detectors/Base/include/DetectorsBase/Detector.h
+++ b/Detectors/Base/include/DetectorsBase/Detector.h
@@ -117,6 +117,11 @@ class Detector : public FairDetector
       }
     }
 
+    // static and reusable service function to set tracking parameters in relation to field
+    // returns global integration mode (inhomogenety) for the field and the max field value
+    // which is required for media creation
+    static void initFieldTrackingParams(int &mode, float &maxfield);
+
   protected:
     Detector(const Detector &origin);
 

--- a/Detectors/Base/src/Detector.cxx
+++ b/Detectors/Base/src/Detector.cxx
@@ -12,6 +12,7 @@
 /// \brief Implementation of the Detector class
 
 #include "DetectorsBase/Detector.h"
+#include "Field/MagneticField.h"
 #include <TVirtualMC.h>  // for TVirtualMC, gMC
 #include "TString.h"     // for TString
 
@@ -126,6 +127,23 @@ void Detector::defineLayerTurbo(Int_t nlay, Double_t phi0, Double_t r, Double_t 
                                 Int_t nmod, Double_t width, Double_t tilt, Double_t lthick,
                                 Double_t dthick, UInt_t dettypeID, Int_t buildLevel)
 {
+}
+
+void Detector::initFieldTrackingParams(int& integration, float& maxfield)
+{
+  auto vmc = TVirtualMC::GetMC();
+  auto field = vmc->GetMagField();
+  // set reasonable default values
+  integration = 2;
+  maxfield = 10;
+  // see if we can query the o2 field
+  if (auto o2field = dynamic_cast<o2::field::MagneticField*>(field)) {
+    integration = o2field->Integral(); // default integration method?
+    maxfield = o2field->Max();
+  }
+  else {
+    LOG(INFO) << "No magnetic field found; using default tracking values " << integration << " " << maxfield << " to initialize media\n";
+  }
 }
 
 ClassImp(o2::Base::Detector)

--- a/Detectors/EMCAL/simulation/src/Detector.cxx
+++ b/Detectors/EMCAL/simulation/src/Detector.cxx
@@ -372,11 +372,10 @@ void Detector::CreateMaterials()
   // Don't forget to add a new tracking medium with non-default cuts
 
   // for EMCAL: idtmed[1599->1698] equivalent to fIdtmed[0->100]
-  // From TPCsimulation/src/Detector.cxx:
-  // until we solve the problem of reading the field from files with changed class names we
-  //  need to hard code some values here to be able to run the macros  M.Al-Turany (Nov.14)
+
   Int_t isxfld = 2;
   Float_t sxmgmx = 10.0;
+  o2::Base::Detector::initFieldTrackingParams(isxfld, sxmgmx);
 
   // Air                                                                         -> idtmed[1599]
   Medium(ID_AIR, "Air$", 0, 0, isxfld, sxmgmx, 10.0, 1.0, 0.1, 0.1, 10.0, nullptr, 0);

--- a/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
@@ -450,13 +450,9 @@ Bool_t Detector::ProcessHits(FairVolume *vol)
 
 void Detector::createMaterials()
 {
-  // Int_t   ifield = ((AliceO2::Field::MagneticField*)TGeoGlobalMagField::Instance()->GetField())->Integral();
-  // Float_t fieldm = ((AliceO2::Field::MagneticField*)TGeoGlobalMagField::Instance()->GetField())->Max();
-
-  // until we solve the problem of reading the field from files with changed class names we
-  //  need to hard code some values here to be able to run the macros  M.Al-Turany (Nov.14)
   Int_t ifield = 2;
   Float_t fieldm = 10.0;
+  o2::Base::Detector::initFieldTrackingParams(ifield, fieldm);
   ////////////
 
   Float_t tmaxfd = 0.1;   // 1.0; // Degree

--- a/Detectors/ITSMFT/MFT/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/MFT/simulation/src/Detector.cxx
@@ -28,7 +28,6 @@
 #include "Field/MagneticField.h"
 
 #include "TVirtualMC.h"
-#include "TGeoGlobalMagField.h"
 #include "TLorentzVector.h"
 #include "TVector3.h"
 #include "TClonesArray.h"
@@ -331,11 +330,10 @@ void Detector::createMaterials()
   Float_t epsilSi  =  0.5e-4;                // tracking precision [cm]
   Float_t stminSi  = -0.001;                 // minimum step due to continuous processes [cm] (negative value: choose it automatically)
   
-  o2::field::MagneticField *fld = (o2::field::MagneticField*)(TVirtualMC::GetMC()->GetMagField());
-
-  Int_t fieldType = fld->GetType();
-  Float_t maxField = fld->Max();
-
+  Int_t fieldType;
+  Float_t maxField;
+  o2::Base::Detector::initFieldTrackingParams(fieldType, maxField);
+  
   LOG(INFO) << "Detector::CreateMaterials >>>>> fieldType " << fieldType << " maxField " << maxField << "\n"; 
 
   o2::Base::Detector::Mixture(++matId, "Air$", aAir, zAir, dAir, nAir, wAir);

--- a/Detectors/Passive/src/FrameStructure.cxx
+++ b/Detectors/Passive/src/FrameStructure.cxx
@@ -9,9 +9,9 @@
 // or submit itself to any jurisdiction.
 
 #include "DetectorsPassive/FrameStructure.h"
+#include "DetectorsBase/Detector.h"
 #include <TGeoBBox.h>
 #include <TGeoCompositeShape.h>
-#include <TGeoGlobalMagField.h>
 #include <TGeoManager.h>
 #include <TGeoMatrix.h>
 #include <TGeoPgon.h>
@@ -1376,8 +1376,9 @@ void FrameStructure::CreateMaterials()
   tmaxfd = -20.;  // Maximum angle due to field deflection
   deemax = -.3;   // Maximum fractional energy loss, DLS
   stmin = -.8;
-  Int_t isxfld = 2.;    //((AliMagF*)TGeoGlobalMagField::Instance()->GetField())->Integ();
-  Float_t sxmgmx = 10.; //((AliMagF*)TGeoGlobalMagField::Instance()->GetField())->Max();
+  Int_t isxfld = 2.;
+  Float_t sxmgmx = 10.;
+  o2::Base::Detector::initFieldTrackingParams(isxfld, sxmgmx);
 
   Float_t asteel[4] = { 55.847, 51.9961, 58.6934, 28.0855 };
   Float_t zsteel[4] = { 26., 24., 28., 14. };

--- a/Detectors/Passive/src/FrameStructureRun3.cxx
+++ b/Detectors/Passive/src/FrameStructureRun3.cxx
@@ -10,6 +10,7 @@
 
 #include "Field/MagneticField.h"
 #include "DetectorsPassive/FrameStructureRun3.h"
+#include "DetectorsBase/Detector.h"
 #include <TGeoArb8.h>
 #include <TGeoBBox.h>
 #include <TGeoBoolNode.h>
@@ -253,17 +254,7 @@ void FrameStructure::createMaterials()
   stmin = -.8;
   int isxfld = 2; // field uniformity value as defined by Geant3
   float sxmgmx = 10.; // max field
-  auto vmc = TVirtualMC::GetMC();
-  auto field = vmc->GetMagField();
-  if (dynamic_cast<o2::field::MagneticField*>(field) != nullptr) {
-    auto o2field = (o2::field::MagneticField*)field;
-    isxfld = o2field->Integral(); // default integration method?
-    sxmgmx = o2field->Max();
-    LOG(INFO) << "magnetic field found; using isxfld " << isxfld << " " << sxmgmx << " " << "\n";
-  }
-  else {
-    LOG(INFO) << "No magnetic field found; using default values " << isxfld << " " << sxmgmx << " to initialize media \n";
-  }
+  o2::Base::Detector::initFieldTrackingParams(isxfld, sxmgmx);
 
   float asteel[4] = { 55.847, 51.9961, 58.6934, 28.0855 };
   float zsteel[4] = { 26., 24., 28., 14. };

--- a/Detectors/TOF/simulation/src/Detector.cxx
+++ b/Detectors/TOF/simulation/src/Detector.cxx
@@ -104,10 +104,9 @@ TClonesArray* Detector::GetCollection(Int_t iColl) const
 void Detector::Reset() { mHitCollection->Clear(); }
 void Detector::CreateMaterials()
 {
-  //  AliMagF *magneticField = (AliMagF*)((AliMagF*)TGeoGlobalMagField::Instance()->GetField());
-
-  Int_t isxfld = 2;     // magneticField->Integ();
-  Float_t sxmgmx = 10.; // magneticField->Max();
+  Int_t isxfld = 2;
+  Float_t sxmgmx = 10.;
+  o2::Base::Detector::initFieldTrackingParams(isxfld, sxmgmx);
 
   //--- Quartz (SiO2) ---
   Float_t aq[2] = { 28.0855, 15.9994 };

--- a/Detectors/TPC/simulation/src/Detector.cxx
+++ b/Detectors/TPC/simulation/src/Detector.cxx
@@ -39,7 +39,6 @@
 
 // geo stuff
 #include "TGeoManager.h"
-#include "TGeoGlobalMagField.h"
 #include "TGeoVolume.h"
 #include "TGeoPcon.h"
 #include "TGeoTube.h"
@@ -423,15 +422,10 @@ void Detector::CreateMaterials()
   // Origin: Marek Kowalski  IFJ, Krakow, Marek.Kowalski@ifj.edu.pl
   //-----------------------------------------------------------------
 
-  //   Int_t iSXFLD=((AliMagF*)TGeoGlobalMagField::Instance()->GetField())->Integ();
-  //   Float_t sXMGMX=((AliMagF*)TGeoGlobalMagField::Instance()->GetField())->Max();
-  // Int_t   iSXFLD = ((AliceO2::Field::MagneticField*)TGeoGlobalMagField::Instance()->GetField())->Integral();
-  // Float_t sXMGMX = ((AliceO2::Field::MagneticField*)TGeoGlobalMagField::Instance()->GetField())->Max();
-
-  // until we solve the problem of reading the field from files with changed class names we
-  //  need to hard code some values here to be able to run the macros  M.Al-Turany (Nov.14)
   Int_t   iSXFLD = 2;
   Float_t sXMGMX = 10.0;
+  // init the field tracking params
+  o2::Base::Detector::initFieldTrackingParams(iSXFLD, sXMGMX);
 
   Float_t amat[7]; // atomic numbers
   Float_t zmat[7]; // z

--- a/Detectors/TRD/simulation/src/Detector.cxx
+++ b/Detectors/TRD/simulation/src/Detector.cxx
@@ -69,9 +69,9 @@ void Detector::createMaterials()
   //
   // Create the materials for the TRD
   //
-
-  int isxfld = 2;     //((AliMagF *) TGeoGlobalMagField::Instance()->GetField())->Integ();
-  float sxmgmx = 10.; //((AliMagF *) TGeoGlobalMagField::Instance()->GetField())->Max();
+  int isxfld = 2;
+  float sxmgmx = 10.;
+  o2::Base::Detector::initFieldTrackingParams(isxfld, sxmgmx);
 
   //////////////////////////////////////////////////////////////////////////
   //     Define Materials

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -323,13 +323,15 @@ o2_define_bucket(
     DEPENDENCIES
     fairroot_base_bucket
     root_physics_bucket
-    
+    Field
+
     VMC # ROOT
     Geom
 
     INCLUDE_DIRECTORIES
     ${FAIRROOT_INCLUDE_DIR}
     ${CMAKE_SOURCE_DIR}/Common/MathUtils/include
+    ${CMAKE_SOURCE_DIR}/Common/Field/include
 )
 
 o2_define_bucket(
@@ -785,6 +787,7 @@ o2_define_bucket(
     DEPENDENCIES
     fairroot_geom
     Field
+    DetectorsBase
 
     INCLUDE_DIRECTORIES
     ${CMAKE_SOURCE_DIR}/Common/Field/include

--- a/macro/run_digi_tpc.C
+++ b/macro/run_digi_tpc.C
@@ -14,7 +14,6 @@
   #include "FairParRootFileIo.h"
   #include "FairLinkManager.h"
 
-  #include "TGeoGlobalMagField.h"
   #include "Field/MagneticField.h"
 
   #include "TPCSimulation/DigitizerTask.h"

--- a/macro/run_sim_tpc.C
+++ b/macro/run_sim_tpc.C
@@ -15,7 +15,6 @@
   #include "FairParRootFileIo.h"
   #include "FairSystemInfo.h"
 
-  #include "TGeoGlobalMagField.h"
   #include "Field/MagneticField.h"
 
   #include "DetectorsPassive/Cave.h"


### PR DESCRIPTION
This commit is providing a global function to query
the magnetic field for the tracking parameters needed to define media.

Applying this function to the detector code, where just until now hard-coded
values were used.