### PR TITLE
Enable a simulation unit test for TPC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,18 @@ include(CTest)
 include(CheckCompiler)
 #include(CheckFortran)
 
+# check if we have a simulation environment
+# (unfortunately neither GEANT4_FOUND nor GEANT3_FOUND work reliably)
+find_library(G4RUNLIB libG4run.dylib libG4run.so HINTS ENV LD_LIBRARY_PATH)
+find_library(G3RUNLIB libgeant321.dylib libgeant321.so HINTS ENV LD_LIBRARY_PATH)
+find_library(VMCLIB libgeant4vmc.dylib libgeant4vmc.so HINTS ENV LD_LIBRARY_PATH)
+if (G4RUNLIB AND G3RUNLIB AND VMCLIB)
+  SET (HAVESIMULATION 1)
+  message(STATUS "Simulation environment found")
+endif()
+
+
+
 #Check the compiler and set the compile and link flags
 IF (NOT CMAKE_BUILD_TYPE)
   Message(STATUS "Set BuildType DEBUG")

--- a/Detectors/TPC/simulation/CMakeLists.txt
+++ b/Detectors/TPC/simulation/CMakeLists.txt
@@ -114,3 +114,13 @@ O2_GENERATE_TESTS(
   MODULE_LIBRARY_NAME ${MODULE_NAME}
   TEST_SRCS ${TEST_SRCS}
 )
+
+# add the TPC run sim as a unit test (if simulation was enabled)
+if (HAVESIMULATION)
+  add_test(NAME tpcsim_G4 COMMAND ${CMAKE_BINARY_DIR}/bin/tpc-run-sim -n 2 -e  TGeant4)
+  set_tests_properties(tpcsim_G4 PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished succesfully")
+  add_test(NAME tpcsim_G3 COMMAND ${CMAKE_BINARY_DIR}/bin/tpc-run-sim -n 2 -e  TGeant3)
+  set_tests_properties(tpcsim_G3 PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished succesfully")
+  # sets the necessary environment
+  set_tests_properties(tpcsim_G3 tpcsim_G4  PROPERTIES ENVIRONMENT VMCWORKDIR=${CMAKE_SOURCE_DIR})
+endif()


### PR DESCRIPTION
Just until now, no simulation tests were being run.

Defining a cmake variable HAVESIMULATION that determines if we are compiling
in a sim enviroment (not DAQ) and use this to add one Geant4 and one Geant3
sim test for the TPC

This is just a first step in extending our testing, but one which should detect
simple configuration errors etc. A more thourough/engineered solution will follow.