### PR TITLE
MagneticField: Proper VMC interface + Aliasing optimization

### DIFF
--- a/Common/Field/include/Field/MagneticField.h
+++ b/Common/Field/include/Field/MagneticField.h
@@ -82,14 +82,14 @@ class MagneticField : public FairField
     /// X component, avoid using since slow
     Double_t GetBx(Double_t x, Double_t y, Double_t z) override {
       double xyz[3]={x,y,z},b[3];
-      GetFieldValue(xyz,b);
+      MagneticField::Field(xyz,b);
       return b[0];
     } 
 
     /// Y component, avoid using since slow
     Double_t GetBy(Double_t x, Double_t y, Double_t z) override {
       double xyz[3]={x,y,z},b[3];
-      GetFieldValue(xyz,b);
+      MagneticField::Field(xyz,b);
       return b[1];
     }
 
@@ -100,10 +100,11 @@ class MagneticField : public FairField
     } 
 
     /// Method to calculate the field at point xyz
-    void GetFieldValue(const Double_t point[3], Double_t* bField) override;
+    /// Main interface from TVirtualMagField used in simulation
+    void Field(const Double_t* __restrict__ point, Double_t* __restrict__ bField) override;
 
     /// 3d field query alias for Alias Method to calculate the field at point xyz
-    void GetBxyz(const Double_t p[3], Double_t* b) override {Field(p,b);}
+    void GetBxyz(const Double_t p[3], Double_t* b) override { MagneticField::Field(p,b); }
 
     /// Fill Paramater
     void FillParContainer() override;
@@ -163,7 +164,7 @@ class MagneticField : public FairField
       return mMapType == MagFieldParam::k5kGUniform;
     }
 
-    void MachineField(const Double_t *x, Double_t *b) const;
+    void MachineField(const Double_t * __restrict__ x, Double_t * __restrict__ b) const;
 
     MagFieldParam::BMap_t getMapType() const
     {

--- a/Common/Field/src/MagneticField.cxx
+++ b/Common/Field/src/MagneticField.cxx
@@ -228,7 +228,7 @@ Bool_t MagneticField::loadParameterization()
   return kTRUE;
 }
 
-void MagneticField::GetFieldValue(const Double_t *xyz, Double_t *b)
+void MagneticField::Field(const Double_t * __restrict__ xyz, Double_t * __restrict__ b)
 {
   /*
    * query field value at point
@@ -323,7 +323,7 @@ void MagneticField::initializeMachineField(MagFieldParam::BeamType_t btype, Doub
   mCompensatorField2A = 11.7905;
 }
 
-void MagneticField::MachineField(const Double_t *x, Double_t *b) const
+void MagneticField::MachineField(const Double_t * __restrict__ x, Double_t * __restrict__ b) const
 {
   // ---- This is the ZDC part
   // Compansators for Alice Muon Arm Dipole


### PR DESCRIPTION
The VMC simulation code calls the field via the "Field" API and not
via "GetFieldValue" from FairRoot; It is better to directly override this
function to avoid a double virtual dispatch.

Allowing the compiler to perform more optimization by declaring
the position and field pointers to be strictly separate
(avoids pointer aliasing problem).

Avoiding some virtual function dispatches by prepending with the class name.