### PR TITLE
Ignore .ruby-version files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ compile_commands.json
 # Datafiles
 *.root
 *.o2tf
+
+# rbenv files
+.ruby-version


### PR DESCRIPTION
These are files generated by rbenv which should not be committed.