### PR TITLE
Add Valgrind suppression file for ROOT and Boost

### DIFF
--- a/Utilities/Tools/README.md
+++ b/Utilities/Tools/README.md
@@ -39,6 +39,6 @@ boost, reporting false positives which can limit its usefulness. For
 this reason it offers the possibility to specify a suppression file
 (via the `--suppressions=<filename>` option) to avoid reporting known
 false positives. In case your false positives come from ROOT and
-boost, you can use the `Utilities/Tools/root-boost.supp` file (notice
+boost, you can use the `Utilities/Tools/boost-root.supp` file (notice
 that different platforms and version of the software might require
 adjustments in order to eliminate all the false positives).

--- a/Utilities/Tools/README.md
+++ b/Utilities/Tools/README.md
@@ -29,3 +29,16 @@ Examples are `commit_id=HEAD` when we want to compare to the last git commit,
 or `commit_id=HEAD^^^` when we compare to the state 3 commits ago.
 
 The pull request checker uses this mechanism to provide faster checks on github.
+
+# Remove false positives from valgrind
+
+[valgrind](http://valgrind.org) is a popular multiplatform memory
+debugger and profiler. While it helps catching many subtle memory
+error and leaks, it can be fooled by complex codebases like ROOT and
+boost, reporting false positives which can limit its usefulness. For
+this reason it offers the possibility to specify a suppression file
+(via the `--suppressions=<filename>` option) to avoid reporting known
+false positives. In case your false positives come from ROOT and
+boost, you can use the `Utilities/Tools/root-boost.supp` file (notice
+that different platforms and version of the software might require
+adjustments in order to eliminate all the false positives).


### PR DESCRIPTION
Valgrind has various false positives when boost / ROOT are linked. This
pollutes the reports and makes more difficult to spot real errors. The
following suppression file can be used via the `--suppressions` option
to remove all the messages which come from an empty:

    int main(int argc, char **) {return 0;}

linked against ROOT and Boost.