### PR TITLE
Correcting namespace names, mv header file to more appropriate place

### DIFF
--- a/DataFormats/Legacy/HLT/include/AliceHLT/TPCRawCluster.h
+++ b/DataFormats/Legacy/HLT/include/AliceHLT/TPCRawCluster.h
@@ -33,9 +33,8 @@
 #include <fstream>  // ifstream
 #include <cstring>  // memcpy
 
-namespace ALICE {
-namespace HLT {
-namespace TPC {
+namespace o2 {
+namespace AliceHLT {
 
 /**
  * @struct RawCluster
@@ -214,7 +213,6 @@ private:
   RawCluster* mClustersEnd;
 };
 
-}; // namespace TPC
 }; // namespace HLT
 }; // namespace ALICE
 #endif

--- a/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/Component.h
+++ b/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/Component.h
@@ -37,8 +37,8 @@ typedef boost::signals2::signal<unsigned char* (unsigned int)> cballoc_signal_t;
 
 namespace bpo = boost::program_options;
 
-namespace ALICE {
-namespace HLT {
+namespace o2 {
+namespace alice_hlt {
 class SystemInterface;
 
 /// @class Component
@@ -122,7 +122,7 @@ public:
   /// the AliHLTComponentBlockData header immediately followed by the block
   /// payload. After processing, handles to output blocks are provided in this
   /// list.
-  int process(std::vector<o2::AliceHLT::MessageFormat::BufferDesc_t>& dataArray,
+  int process(std::vector<o2::alice_hlt::MessageFormat::BufferDesc_t>& dataArray,
               cballoc_signal_t* cbAllocate=nullptr);
 
   int getEventCount() const {return mEventCount;}
@@ -143,10 +143,10 @@ private:
   /// handle of the processing component
   AliHLTComponentHandle mProcessor;
   /// container for handling the i/o buffers
-  o2::AliceHLT::MessageFormat mFormatHandler;
+  o2::alice_hlt::MessageFormat mFormatHandler;
   int mEventCount;
 };
 
-} // namespace hlt
-} // namespace alice
+} // namespace alice_hlt
+} // namespace o2
 #endif // COMPONENT_H

--- a/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/EventSampler.h
+++ b/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/EventSampler.h
@@ -33,8 +33,8 @@
 
 namespace bpo = boost::program_options;
 
-namespace ALICE {
-namespace HLT {
+namespace o2 {
+namespace alice_hlt {
 class Component;
 
 /// @class EventSampler
@@ -104,6 +104,6 @@ private:
   std::string mLatencyLogFileName;   // output file for logging of latency
 };
 
-} // namespace hlt
-} // namespace alice
+} // namespace alice_hlt
+} // namespace o2
 #endif // EVENTSAMPLER_H

--- a/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/HOMERFactory.h
+++ b/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/HOMERFactory.h
@@ -13,14 +13,14 @@
 //****************************************************************************
 //* This file is free software: you can redistribute it and/or modify        *
 //* it under the terms of the GNU General Public License as published by     *
-//* the Free Software Foundation, either version 3 of the License, or	     *
-//* (at your option) any later version.					     *
+//* the Free Software Foundation, either version 3 of the License, or        *
+//* (at your option) any later version.                                      *
 //*                                                                          *
 //* Primary Authors: Matthias Richter <richterm@scieq.net>                   *
 //*                                                                          *
 //* The authors make no claims about the suitability of this software for    *
 //* any purpose. It is provided "as is" without express or implied warranty. *
-//*									     *
+//*                                                                          *
 //* See original copyright notice below                                      *
 //****************************************************************************
 
@@ -89,26 +89,26 @@ class HOMERFactory {
    * Open a homer reader working on a TCP port.
    */
   AliHLTHOMERReader* OpenReader(const char* hostname, unsigned short port );
-  
+
   /**
    * Open a homer reader working on multiple TCP ports.
    */
   AliHLTHOMERReader* OpenReader(unsigned int tcpCnt, const char** hostnames, unsigned short* ports);
-	
+
   /**
    * Open a HOMER reader for reading from a System V shared memory segment.
   AliHLTHOMERReader* OpenReader(key_t shmKey, int shmSize );
    */
-	
+
   /**
    * Open a HOMER reader for reading from multiple System V shared memory segments
   AliHLTHOMERReader* OpenReader(unsigned int shmCnt, key_t* shmKey, int* shmSize );
    */
-	
+
   /**
    * Open a HOMER reader for reading from multiple TCP ports and multiple System V shared memory segments
   AliHLTHOMERReader* OpenReader(unsigned int tcpCnt, const char** hostnames, unsigned short* ports, 
-				    unsigned int shmCnt, key_t* shmKey, int* shmSize );
+                                    unsigned int shmCnt, key_t* shmKey, int* shmSize );
    */
 
   /**
@@ -156,34 +156,34 @@ class HOMERFactory {
   int UnloadHOMERLibrary();
 
   /** status of the loading of the HOMER library */
-static  int fgLibraryStatus; //!transient
+  static  int sLibraryStatus; //!transient
 
   /** entry in the HOMER library */
-  void (*fFctCreateReaderFromTCPPort)(); //!transient
+  void (*mFctCreateReaderFromTCPPort)(); //!transient
 
   /** entry in the HOMER library */
-  void (*fFctCreateReaderFromTCPPorts)(); //!transient
+  void (*mFctCreateReaderFromTCPPorts)(); //!transient
 
   /** entry in the HOMER library */
-  void (*fFctCreateReaderFromBuffer)(); //!transient
+  void (*mFctCreateReaderFromBuffer)(); //!transient
 
   /** entry in the HOMER library */
-  void (*fFctDeleteReader)(); //!transient
+  void (*mFctDeleteReader)(); //!transient
 
   /** entry in the HOMER library */
-  void (*fFctCreateWriter)(); //!transient
+  void (*mFctCreateWriter)(); //!transient
 
   /** entry in the HOMER library */
-  void (*fFctDeleteWriter)(); //!transient
+  void (*mFctDeleteWriter)(); //!transient
 
   /** Indicates the library that was actually (and if) loaded in LoadHOMERLibrary(). */
-  const char* fLoadedLib;  //!transient
+  const char* mLoadedLib;  //!transient
 
   /** library handle returned by dlopen */
-  void* fHandle;
+  void* mHandle;
 
-  static const char* fgkLibraries[]; /// List of libraries to try and load.
-  static int fgkLibRefCount[]; /// The library reference count to control when to unload the library.
+  static const char* sLibraries[]; /// List of libraries to try and load.
+  static int sLibRefCount[]; /// The library reference count to control when to unload the library.
 };
 }    // namespace alice_hlt
 }    // namespace o2

--- a/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/HOMERFactory.h
+++ b/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/HOMERFactory.h
@@ -38,8 +38,8 @@
 class AliHLTHOMERReader;
 class AliHLTHOMERWriter;
 
-namespace ALICE {
-  namespace HLT {
+namespace o2 {
+  namespace alice_hlt {
 
 /**
  * @class HOMERFactory
@@ -185,6 +185,6 @@ static  int fgLibraryStatus; //!transient
   static const char* fgkLibraries[]; /// List of libraries to try and load.
   static int fgkLibRefCount[]; /// The library reference count to control when to unload the library.
 };
-}    // namespace hlt
-}    // namespace alice
+}    // namespace alice_hlt
+}    // namespace o2
 #endif

--- a/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/MessageFormat.h
+++ b/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/MessageFormat.h
@@ -39,7 +39,7 @@ class AliHLTHOMERReader;
 class AliHLTHOMERWriter;
 
 namespace o2 {
-namespace AliceHLT {
+namespace alice_hlt {
 /// @struct BlockDescriptor
 /// Helper struct to provide constructors to AliHLTComponentBlockData
 ///
@@ -203,7 +203,7 @@ private:
   /// list of message payload descriptors
   std::vector<BufferDesc_t>             mMessages;
   /// HOMER factory for creation and deletion of HOMER readers and writers
-  ALICE::HLT::HOMERFactory*        mpFactory;
+  o2::alice_hlt::HOMERFactory*        mpFactory;
   /// output mode: HOMER, multi-message, sequential
   int mOutputMode;
   /// list of event descriptors
@@ -215,6 +215,6 @@ private:
   HeartbeatTrailer mHeartbeatTrailer;
 };
 
-} // namespace AliceHLT
-} // namespace AliceO2
+} // namespace alice_hlt
+} // namespace o2
 #endif // MESSAGEFORMAT_H

--- a/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/SystemInterface.h
+++ b/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/SystemInterface.h
@@ -28,8 +28,8 @@
 //  @brief  FairRoot/ALFA interface to ALICE HLT code
 
 #include "AliHLTDataTypes.h"
-namespace ALICE {
-namespace HLT {
+namespace o2 {
+namespace alice_hlt {
 
 /// @class SystemInterface
 /// Tool class for the ALICE HLT external interface defined in
@@ -133,6 +133,6 @@ private:
   AliHLTAnalysisEnvironment     mEnvironment;
 };
 
-} // namespace hlt
-} // namespace alice
+} // namespace alice_hlt
+} // namespace o2
 #endif // SYSTEMINTERFACE_H

--- a/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/WrapperDevice.h
+++ b/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/WrapperDevice.h
@@ -35,8 +35,8 @@ namespace bpo = boost::program_options;
 
 class FairMQMessage;
 
-namespace ALICE {
-namespace HLT {
+namespace o2 {
+namespace alice_hlt {
 class Component;
 
 /// @class WrapperDevice
@@ -106,6 +106,6 @@ private:
   int mVerbosity;            // verbosity level
 };
 
-} // namespace hlt
-} // namespace alice
+} // namespace alice_hlt
+} // namespace o2
 #endif // WRAPPERDEVICE_H

--- a/Utilities/aliceHLTwrapper/src/Component.cxx
+++ b/Utilities/aliceHLTwrapper/src/Component.cxx
@@ -38,8 +38,8 @@
 #include <sstream>
 #include <getopt.h>
 #include <memory>
-using namespace ALICE::HLT;
-using namespace o2::AliceHLT;
+
+using namespace o2::alice_hlt;
 
 using std::endl;
 using std::string;
@@ -175,7 +175,7 @@ int Component::init(int argc, char** argv)
 
   int iResult = 0;
   // TODO: make the SystemInterface a singleton
-  unique_ptr<ALICE::HLT::SystemInterface> iface(new SystemInterface);
+  unique_ptr<o2::alice_hlt::SystemInterface> iface(new SystemInterface);
   if (iface.get() == nullptr || ((iResult = iface->initSystem(runNumber))) < 0) {
     // LOG(ERROR) << "failed to set up SystemInterface " << iface.get() << " (" << iResult << ")";
     return -ENOSYS;

--- a/Utilities/aliceHLTwrapper/src/EventSampler.cxx
+++ b/Utilities/aliceHLTwrapper/src/EventSampler.cxx
@@ -52,7 +52,7 @@ using std::chrono::system_clock;
 typedef std::chrono::duration<int,std::ratio<60*60*24> > PeriodDay;
 const std::chrono::time_point<system_clock, PeriodDay> dayref=std::chrono::time_point_cast<PeriodDay>(system_clock::now());
 
-using namespace ALICE::HLT;
+using namespace o2::alice_hlt;
 
 EventSampler::EventSampler(int verbosity)
   : mEventPeriod(-1)

--- a/Utilities/aliceHLTwrapper/src/HOMERFactory.cxx
+++ b/Utilities/aliceHLTwrapper/src/HOMERFactory.cxx
@@ -54,7 +54,7 @@
 #include "aliceHLTwrapper/AliHLTHOMERReader.h"
 #include "aliceHLTwrapper/AliHLTHOMERWriter.h"
 
-using namespace ALICE::HLT;
+using namespace o2::alice_hlt;
 
 using std::cerr;
 using std::cout;

--- a/Utilities/aliceHLTwrapper/src/MessageFormat.cxx
+++ b/Utilities/aliceHLTwrapper/src/MessageFormat.cxx
@@ -39,8 +39,7 @@
 #include <cassert>
 #include <sstream>
 
-using namespace o2::AliceHLT;
-using namespace ALICE::HLT;
+using namespace o2::alice_hlt;
 using std::cerr;
 using std::endl;
 using std::unique_ptr;
@@ -202,7 +201,7 @@ int MessageFormat::readHOMERFormat(uint8_t* buffer, unsigned size,
                                    vector<BlockDescriptor>& descriptorList) const
 {
   // read message payload in HOMER format
-  if (mpFactory == nullptr) const_cast<MessageFormat*>(this)->mpFactory = new ALICE::HLT::HOMERFactory;
+  if (mpFactory == nullptr) const_cast<MessageFormat*>(this)->mpFactory = new o2::alice_hlt::HOMERFactory;
   if (buffer == nullptr || mpFactory == nullptr) return -EINVAL;
   unique_ptr<AliHLTHOMERReader> reader(mpFactory->OpenReaderBuffer(buffer, size));
   if (reader.get() == nullptr) return -ENOMEM;
@@ -516,7 +515,7 @@ AliHLTHOMERWriter* MessageFormat::createHOMERFormat(const AliHLTComponentBlockDa
 {
   // send data blocks in HOMER format in one message
   int iResult = 0;
-  if (mpFactory == nullptr) const_cast<MessageFormat*>(this)->mpFactory = new ALICE::HLT::HOMERFactory;
+  if (mpFactory == nullptr) const_cast<MessageFormat*>(this)->mpFactory = new o2::alice_hlt::HOMERFactory;
   if (!mpFactory) return nullptr;
   unique_ptr<AliHLTHOMERWriter> writer(mpFactory->OpenWriter());
   if (writer.get() == nullptr) return nullptr;

--- a/Utilities/aliceHLTwrapper/src/SystemInterface.cxx
+++ b/Utilities/aliceHLTwrapper/src/SystemInterface.cxx
@@ -32,7 +32,7 @@
 #include <cstring>
 #include <iostream>
 #include <dlfcn.h>
-using namespace ALICE::HLT;
+using namespace o2::alice_hlt;
 
 using std::cerr;
 using std::cout;

--- a/Utilities/aliceHLTwrapper/src/WrapperDevice.cxx
+++ b/Utilities/aliceHLTwrapper/src/WrapperDevice.cxx
@@ -46,7 +46,7 @@
 using std::string;
 using std::vector;
 using std::unique_ptr;
-using namespace ALICE::HLT;
+using namespace o2::alice_hlt;
 
 using std::chrono::system_clock;
 using TimeScale = std::chrono::milliseconds;
@@ -93,7 +93,7 @@ void WrapperDevice::InitTask()
 
   int iResult=0;
 
-  std::unique_ptr<Component> component(new ALICE::HLT::Component);
+  std::unique_ptr<Component> component(new o2::alice_hlt::Component);
   if (!component.get()) return /*-ENOMEM*/;
 
   // loop over program options, check if the option was used and
@@ -247,7 +247,7 @@ void WrapperDevice::Run()
 
     if (!mSkipProcessing) {
       // prepare input from messages
-      vector<o2::AliceHLT::MessageFormat::BufferDesc_t> dataArray;
+      vector<o2::alice_hlt::MessageFormat::BufferDesc_t> dataArray;
       for (auto& socketInput : socketInputs) {
         for (auto& msg : socketInput.fParts) {
           void* buffer=msg->GetData();

--- a/Utilities/aliceHLTwrapper/src/aliceHLTEventSampler.cxx
+++ b/Utilities/aliceHLTwrapper/src/aliceHLTEventSampler.cxx
@@ -27,7 +27,7 @@
 
 #include "aliceHLTwrapper/EventSampler.h"
 #include "runFairMQDevice.h" // FairMQDevice launcher boiler plate code
-using namespace ALICE::HLT;
+using namespace o2::alice_hlt;
 
 namespace bpo = boost::program_options;
 
@@ -38,5 +38,5 @@ void addCustomOptions(bpo::options_description& options)
 
 FairMQDevicePtr getDevice(const FairMQProgOptions& /*config*/)
 {
-  return new ALICE::HLT::EventSampler;
+  return new o2::alice_hlt::EventSampler;
 }

--- a/Utilities/aliceHLTwrapper/src/aliceHLTWrapper.cxx
+++ b/Utilities/aliceHLTwrapper/src/aliceHLTWrapper.cxx
@@ -28,16 +28,15 @@
 
 #include "runFairMQDevice.h" // FairMQDevice launcher boiler plate code
 #include "aliceHLTwrapper/WrapperDevice.h"
-using namespace ALICE::HLT;
 
 namespace bpo = boost::program_options;
 
 void addCustomOptions(bpo::options_description& options)
 {
-  options.add(WrapperDevice::GetOptionsDescription());
+  options.add(o2::alice_hlt::WrapperDevice::GetOptionsDescription());
 }
 
 FairMQDevicePtr getDevice(const FairMQProgOptions& /*config*/)
 {
-  return new ALICE::HLT::WrapperDevice;
+  return new o2::alice_hlt::WrapperDevice;
 }

--- a/Utilities/aliceHLTwrapper/src/runComponent.cxx
+++ b/Utilities/aliceHLTwrapper/src/runComponent.cxx
@@ -72,7 +72,7 @@ int main(int argc, char** argv)
     }
   }
 
-  ALICE::HLT::Component component;
+  o2::alice_hlt::Component component;
   if ((iResult = component.init(componentOptions.size(), &componentOptions[0])) < 0) {
     cerr << "error: init failed with " << iResult << endl;
     // the ALICE HLT external interface uses the following error definition
@@ -81,7 +81,7 @@ int main(int argc, char** argv)
     return -iResult;
   }
 
-  vector<o2::AliceHLT::MessageFormat::BufferDesc_t> blockData;
+  vector<o2::alice_hlt::MessageFormat::BufferDesc_t> blockData;
   char* inputBuffer = nullptr;
   if (inputFileName) {
     std::ifstream input(inputFileName, std::ifstream::binary);

--- a/Utilities/aliceHLTwrapper/test/testMessageFormat.cxx
+++ b/Utilities/aliceHLTwrapper/test/testMessageFormat.cxx
@@ -18,7 +18,7 @@
 #include "Headers/HeartbeatFrame.h"
 
 namespace o2 { 
-namespace AliceHLT {
+namespace alice_hlt {
   template<typename... Targs>
   void hexDump(Targs... Fargs) {
     //o2::Header::hexDump(Fargs...);
@@ -266,5 +266,5 @@ namespace AliceHLT {
       ++datafieldidx;
     }
   }
-} // namespace AliceHLT
+} // namespace alice_hlt
 } // namespace o2


### PR DESCRIPTION
All code of the aliceHLTWrapper module is now in the o2::AliceHLT
namespace. A header file has still been directly under the include
directory without the additional level.