### PR TITLE
Copy rootconfig.dat in share/config/

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,6 +183,7 @@ add_subdirectory(macro)
 add_subdirectory(Utilities)
 add_subdirectory(doc)
 add_subdirectory(run)
+add_subdirectory(config)
 
 IF (IWYU_FOUND)
   ADD_CUSTOM_TARGET(checkHEADERS

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -1,0 +1,16 @@
+# **************************************************************************
+# * Copyright(c) 1998-2014, ALICE Experiment at CERN, All rights reserved. *
+# *                                                                        *
+# * Author: The ALICE Off-line Project.                                    *
+# * Contributors are mentioned in the code where appropriate.              *
+# *                                                                        *
+# * Permission to use, copy, modify and distribute this software and its   *
+# * documentation strictly for non-commercial purposes is hereby granted   *
+# * without fee, provided that the above copyright notice appears in all   *
+# * copies and that both the copyright notice and this permission notice   *
+# * appear in the supporting documentation. The authors make no claims     *
+# * about the suitability of this software for any purpose. It is          *
+# * provided "as is" without express or implied warranty.                  *
+# **************************************************************************
+
+Install(FILES rootmanager.dat DESTINATION share/config/)


### PR DESCRIPTION
This will be read by FairRootManager and set the name of the sim branch according to the content of the `rootmanager.dat` file.