### PR TITLE
Implement first version of EMCAL hit creation

### DIFF
--- a/Detectors/EMCAL/base/include/EMCALBase/Geometry.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/Geometry.h
@@ -32,8 +32,8 @@ namespace EMCAL
 {
 class ShishKebabTrd1Module;
 
-using doublevect = std::vector<double>;
-using intvect = std::vector<int>;
+using DoubleVect = std::vector<double>;
+using IntVect = std::vector<int>;
 
 class Geometry
 {
@@ -483,24 +483,24 @@ class Geometry
 
   std::vector<EMCALSMType> GetEMCSystem() const { return mEMCSMSystem; } // EMC System, SM type list
   // Local Coordinates of SM
-  doublevect GetCentersOfCellsEtaDir() const
+  DoubleVect GetCentersOfCellsEtaDir() const
   {
     return mCentersOfCellsEtaDir;
   } // size fNEta*fNETAdiv (for TRD1 only) (eta or z in SM, in cm)
-  doublevect GetCentersOfCellsXDir() const
+  DoubleVect GetCentersOfCellsXDir() const
   {
     return mCentersOfCellsXDir;
   } // size fNEta*fNETAdiv (for TRD1 only) (       x in SM, in cm)
-  doublevect GetCentersOfCellsPhiDir() const
+  DoubleVect GetCentersOfCellsPhiDir() const
   {
     return mCentersOfCellsPhiDir;
   } // size fNPhi*fNPHIdiv (for TRD1 only) (phi or y in SM, in cm)
   //
-  doublevect GetEtaCentersOfCells() const
+  DoubleVect GetEtaCentersOfCells() const
   {
     return mEtaCentersOfCells;
   } // [fNEta*fNETAdiv*fNPhi*fNPHIdiv], positive direction (eta>0); eta depend from phi position;
-  doublevect GetPhiCentersOfCells() const
+  DoubleVect GetPhiCentersOfCells() const
   {
     return mPhiCentersOfCells;
   } // [fNPhi*fNPHIdiv] from center of SM (-10. < phi < +10.)
@@ -576,19 +576,19 @@ class Geometry
   Int_t mNETAdiv;             ///< Number eta division of module
   Int_t mNPHIdiv;             ///< Number phi division of module
   Int_t mNCellsInModule;      ///< Number cell in module
-  doublevect mPhiBoundariesOfSM; ///< Phi boundaries of SM in rad; size is fNumberOfSuperModules;
-  doublevect mPhiCentersOfSM;    ///< Phi of centers of SM; size is fNumberOfSuperModules/2
-  doublevect mPhiCentersOfSMSec; ///< Phi of centers of section where SM lies; size is fNumberOfSuperModules/2
+  DoubleVect mPhiBoundariesOfSM; ///< Phi boundaries of SM in rad; size is fNumberOfSuperModules;
+  DoubleVect mPhiCentersOfSM;    ///< Phi of centers of SM; size is fNumberOfSuperModules/2
+  DoubleVect mPhiCentersOfSMSec; ///< Phi of centers of section where SM lies; size is fNumberOfSuperModules/2
 
   // Local Coordinates of SM
-  doublevect mPhiCentersOfCells;    ///< [fNPhi*fNPHIdiv] from center of SM (-10. < phi < +10.)
-  doublevect mCentersOfCellsEtaDir; ///< Size fNEta*fNETAdiv (for TRD1 only) (eta or z in SM, in cm)
-  doublevect mCentersOfCellsPhiDir; ///< Size fNPhi*fNPHIdiv (for TRD1 only) (phi or y in SM, in cm)
-  doublevect
+  DoubleVect mPhiCentersOfCells;    ///< [fNPhi*fNPHIdiv] from center of SM (-10. < phi < +10.)
+  DoubleVect mCentersOfCellsEtaDir; ///< Size fNEta*fNETAdiv (for TRD1 only) (eta or z in SM, in cm)
+  DoubleVect mCentersOfCellsPhiDir; ///< Size fNPhi*fNPHIdiv (for TRD1 only) (phi or y in SM, in cm)
+  DoubleVect
     mEtaCentersOfCells; ///< [fNEta*fNETAdiv*fNPhi*fNPHIdiv], positive direction (eta>0); eta depend from phi position;
   Int_t mNCells;        ///< Number of cells in calo
   Int_t mNPhi;          ///< Number of Towers in the PHI direction
-  doublevect mCentersOfCellsXDir;   ///< Size fNEta*fNETAdiv (for TRD1 only) (       x in SM, in cm)
+  DoubleVect mCentersOfCellsXDir;   ///< Size fNEta*fNETAdiv (for TRD1 only) (       x in SM, in cm)
   Float_t mEnvelop[3];           ///< The GEANT TUB for the detector
   Float_t mArm1EtaMin;           ///< Minimum pseudorapidity position of EMCAL in Eta
   Float_t mArm1EtaMax;           ///< Maximum pseudorapidity position of EMCAL in Eta

--- a/Detectors/EMCAL/base/include/EMCALBase/Geometry.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/Geometry.h
@@ -32,9 +32,6 @@ namespace EMCAL
 {
 class ShishKebabTrd1Module;
 
-using DoubleVect = std::vector<double>;
-using IntVect = std::vector<int>;
-
 class Geometry
 {
  public:
@@ -483,24 +480,24 @@ class Geometry
 
   std::vector<EMCALSMType> GetEMCSystem() const { return mEMCSMSystem; } // EMC System, SM type list
   // Local Coordinates of SM
-  DoubleVect GetCentersOfCellsEtaDir() const
+  std::vector<Double_t> GetCentersOfCellsEtaDir() const
   {
     return mCentersOfCellsEtaDir;
   } // size fNEta*fNETAdiv (for TRD1 only) (eta or z in SM, in cm)
-  DoubleVect GetCentersOfCellsXDir() const
+  std::vector<Double_t> GetCentersOfCellsXDir() const
   {
     return mCentersOfCellsXDir;
   } // size fNEta*fNETAdiv (for TRD1 only) (       x in SM, in cm)
-  DoubleVect GetCentersOfCellsPhiDir() const
+  std::vector<Double_t> GetCentersOfCellsPhiDir() const
   {
     return mCentersOfCellsPhiDir;
   } // size fNPhi*fNPHIdiv (for TRD1 only) (phi or y in SM, in cm)
   //
-  DoubleVect GetEtaCentersOfCells() const
+  std::vector<Double_t> GetEtaCentersOfCells() const
   {
     return mEtaCentersOfCells;
   } // [fNEta*fNETAdiv*fNPhi*fNPHIdiv], positive direction (eta>0); eta depend from phi position;
-  DoubleVect GetPhiCentersOfCells() const
+  std::vector<Double_t> GetPhiCentersOfCells() const
   {
     return mPhiCentersOfCells;
   } // [fNPhi*fNPHIdiv] from center of SM (-10. < phi < +10.)
@@ -576,19 +573,19 @@ class Geometry
   Int_t mNETAdiv;             ///< Number eta division of module
   Int_t mNPHIdiv;             ///< Number phi division of module
   Int_t mNCellsInModule;      ///< Number cell in module
-  DoubleVect mPhiBoundariesOfSM; ///< Phi boundaries of SM in rad; size is fNumberOfSuperModules;
-  DoubleVect mPhiCentersOfSM;    ///< Phi of centers of SM; size is fNumberOfSuperModules/2
-  DoubleVect mPhiCentersOfSMSec; ///< Phi of centers of section where SM lies; size is fNumberOfSuperModules/2
+  std::vector<Double_t> mPhiBoundariesOfSM; ///< Phi boundaries of SM in rad; size is fNumberOfSuperModules;
+  std::vector<Double_t> mPhiCentersOfSM;    ///< Phi of centers of SM; size is fNumberOfSuperModules/2
+  std::vector<Double_t> mPhiCentersOfSMSec; ///< Phi of centers of section where SM lies; size is fNumberOfSuperModules/2
 
   // Local Coordinates of SM
-  DoubleVect mPhiCentersOfCells;    ///< [fNPhi*fNPHIdiv] from center of SM (-10. < phi < +10.)
-  DoubleVect mCentersOfCellsEtaDir; ///< Size fNEta*fNETAdiv (for TRD1 only) (eta or z in SM, in cm)
-  DoubleVect mCentersOfCellsPhiDir; ///< Size fNPhi*fNPHIdiv (for TRD1 only) (phi or y in SM, in cm)
-  DoubleVect
+  std::vector<Double_t> mPhiCentersOfCells;    ///< [fNPhi*fNPHIdiv] from center of SM (-10. < phi < +10.)
+  std::vector<Double_t> mCentersOfCellsEtaDir; ///< Size fNEta*fNETAdiv (for TRD1 only) (eta or z in SM, in cm)
+  std::vector<Double_t> mCentersOfCellsPhiDir; ///< Size fNPhi*fNPHIdiv (for TRD1 only) (phi or y in SM, in cm)
+  std::vector<Double_t>
     mEtaCentersOfCells; ///< [fNEta*fNETAdiv*fNPhi*fNPHIdiv], positive direction (eta>0); eta depend from phi position;
   Int_t mNCells;        ///< Number of cells in calo
   Int_t mNPhi;          ///< Number of Towers in the PHI direction
-  DoubleVect mCentersOfCellsXDir;   ///< Size fNEta*fNETAdiv (for TRD1 only) (       x in SM, in cm)
+  std::vector<Double_t> mCentersOfCellsXDir;   ///< Size fNEta*fNETAdiv (for TRD1 only) (       x in SM, in cm)
   Float_t mEnvelop[3];           ///< The GEANT TUB for the detector
   Float_t mArm1EtaMin;           ///< Minimum pseudorapidity position of EMCAL in Eta
   Float_t mArm1EtaMax;           ///< Maximum pseudorapidity position of EMCAL in Eta

--- a/Detectors/EMCAL/base/include/EMCALBase/Hit.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/Hit.h
@@ -13,104 +13,102 @@
 
 #include "SimulationDataFormat/BaseHits.h"
 
-namespace o2 {
-  namespace EMCAL {
-    
-    /// \class Hit
-    /// \brief EMCAL simulation hit information
-    class Hit : public o2::BasicXYZEHit<float> {
-    public:
-      
-      /// \brief Default constructor
-      Hit() = default;
-      
-      /// \brief Hit constructor
-      ///
-      /// Fully defining information of the EMCAL point (position,
-      /// momentum, energy, track, ...)
-      ///
-      /// \param shunt
-      /// \param primary Number of primary particle
-      /// \param trackID Index of the track
-      /// \param parentID ID of the parent primary entering the EMCAL
-      /// \param detID ID of the detector segment
-      /// \param initialEnergy Energy of the primary particle enering the EMCAL
-      /// \param pos Position vector of the point
-      /// \param mom Momentum vector for the particle at the point
-      /// \param tof Time of the hit
-      /// \param length Length of the segment
-      Hit(Int_t shunt, Int_t primary, Int_t trackID, Int_t parentID, Int_t detID, Int_t initialEnergy,
-            const Point3D<float> &pos, const Vector3D<float> &mom, Double_t tof, Double_t eLoss):
-      o2::BasicXYZEHit<float>(pos.X(), pos.Y(), pos.X(), tof, eLoss, trackID, detID),
+namespace o2
+{
+namespace EMCAL
+{
+/// \class Hit
+/// \brief EMCAL simulation hit information
+class Hit : public o2::BasicXYZEHit<float>
+{
+ public:
+  /// \brief Default constructor
+  Hit() = default;
+
+  /// \brief Hit constructor
+  ///
+  /// Fully defining information of the EMCAL point (position,
+  /// momentum, energy, track, ...)
+  ///
+  /// \param primary Number of primary particle
+  /// \param trackID Index of the track
+  /// \param parentID ID of the parent primary entering the EMCAL
+  /// \param detID ID of the detector segment
+  /// \param initialEnergy Energy of the primary particle enering the EMCAL
+  /// \param pos Position vector of the point
+  /// \param mom Momentum vector for the particle at the point
+  /// \param tof Time of the hit
+  /// \param length Length of the segment
+  Hit(Int_t primary, Int_t trackID, Int_t parentID, Int_t detID, Int_t initialEnergy, const Point3D<float>& pos,
+      const Vector3D<float>& mom, Double_t tof, Double_t eLoss)
+    : o2::BasicXYZEHit<float>(pos.X(), pos.Y(), pos.Z(), tof, eLoss, trackID, detID),
       mPvector(mom),
-      mShunt(shunt),
       mPrimary(primary),
       mParent(parentID),
       mInitialEnergy(initialEnergy)
-      {
-      }
-      
-      /// \brief Check whether the points are from the same parent and in the same detector volume
-      /// \return True if points are the same (origin and detector), false otherwise
-      Bool_t operator==(const Hit &rhs) const;
-      
-      /// \brief Sorting points according to parent particle and detector volume
-      /// \return True if this point is smaller, false otherwise
-      Bool_t operator<(const Hit &rhs) const;
-      
-      /// \brief Adds energy loss from the other point to this point
-      /// \param rhs EMCAL point to add to this point
-      /// \return This point with the summed energy loss
-      Hit &operator+=(const Hit &rhs);
-      
-      /// \brief Creates a new point base on this point but adding the energy loss of the right hand side
-      /// \param
-      /// \return New EMAL point base on this point
-      Hit operator+(const Hit &rhs) const;
-      
-      /// \brief Destructor
-      ~Hit() override = default;
-      
-      /// \brief Get the initial energy of the primary particle entering EMCAL
-      /// \return Energy of the primary particle entering EMCAL
-      Double_t GetInitialEnergy() const { return mInitialEnergy; }
-      
-      /// \brief Get parent track of the particle producing the hit
-      /// \return ID of the parent particle
-      Int_t GetParentTrack() const { return mParent; }
-      
-      /// \brief Get Primary particles at the origin of the hit
-      /// \return Primary particles at the origin of the hit
-      Int_t GetPrimary() const { return mPrimary; }
-      
-      /// \brief Set initial energy of the primary particle entering EMCAL
-      /// \param energy Energy of the primary particle entering EMCAL
-      void SetInitialEnergy(Double_t energy) { mInitialEnergy = energy; }
-      
-      /// \brief Set the ID of the parent track of the track producing the hit
-      /// \param parentID ID of the parent track
-      void SetParentTrack(Int_t parentID) { mParent = parentID; }
-      
-      /// \brief Set primary particles at the origin of the hit
-      /// \param primary Primary particles at the origin of the hit
-      void SetPrimary(Int_t primary) { mPrimary = primary; }
-      
-      /// \brief Writing point information to an output stream;
-      /// \param stream target output stream
-      void PrintStream(std::ostream &stream) const;
-      
-    private:
-      Vector3D<float>   mPvector;           ///< Momentum Vector
-      Int_t             mShunt;             ///< Shunt (check if needed)
-      Int_t             mPrimary;           ///< Primary particles at the origin of the hit
-      Int_t             mParent;            ///< Parent particle that entered the EMCAL
-      Double32_t        mInitialEnergy;     ///< Energy of the parent particle that entered the EMCAL
-      
-      ClassDefOverride(Hit, 1);
-    };
-    
-    std::ostream &operator<<(std::ostream &stream, const Hit &point);
+  {
   }
+
+  /// \brief Check whether the points are from the same parent and in the same detector volume
+  /// \return True if points are the same (origin and detector), false otherwise
+  Bool_t operator==(const Hit& rhs) const;
+
+  /// \brief Sorting points according to parent particle and detector volume
+  /// \return True if this point is smaller, false otherwise
+  Bool_t operator<(const Hit& rhs) const;
+
+  /// \brief Adds energy loss from the other point to this point
+  /// \param rhs EMCAL point to add to this point
+  /// \return This point with the summed energy loss
+  Hit& operator+=(const Hit& rhs);
+
+  /// \brief Creates a new point base on this point but adding the energy loss of the right hand side
+  /// \param
+  /// \return New EMAL point base on this point
+  Hit operator+(const Hit& rhs) const;
+
+  /// \brief Destructor
+  ~Hit() override = default;
+
+  /// \brief Get the initial energy of the primary particle entering EMCAL
+  /// \return Energy of the primary particle entering EMCAL
+  Double_t GetInitialEnergy() const { return mInitialEnergy; }
+
+  /// \brief Get parent track of the particle producing the hit
+  /// \return ID of the parent particle
+  Int_t GetParentTrack() const { return mParent; }
+
+  /// \brief Get Primary particles at the origin of the hit
+  /// \return Primary particles at the origin of the hit
+  Int_t GetPrimary() const { return mPrimary; }
+
+  /// \brief Set initial energy of the primary particle entering EMCAL
+  /// \param energy Energy of the primary particle entering EMCAL
+  void SetInitialEnergy(Double_t energy) { mInitialEnergy = energy; }
+
+  /// \brief Set the ID of the parent track of the track producing the hit
+  /// \param parentID ID of the parent track
+  void SetParentTrack(Int_t parentID) { mParent = parentID; }
+
+  /// \brief Set primary particles at the origin of the hit
+  /// \param primary Primary particles at the origin of the hit
+  void SetPrimary(Int_t primary) { mPrimary = primary; }
+
+  /// \brief Writing point information to an output stream;
+  /// \param stream target output stream
+  void PrintStream(std::ostream& stream) const;
+
+ private:
+  Vector3D<float> mPvector;  ///< Momentum Vector
+  Int_t mPrimary;            ///< Primary particles at the origin of the hit
+  Int_t mParent;             ///< Parent particle that entered the EMCAL
+  Double32_t mInitialEnergy; ///< Energy of the parent particle that entered the EMCAL
+
+  ClassDefOverride(Hit, 1);
+};
+
+std::ostream& operator<<(std::ostream& stream, const Hit& point);
+}
 }
 
 #endif /* Point_h */

--- a/Detectors/EMCAL/base/include/EMCALBase/ShishKebabTrd1Module.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/ShishKebabTrd1Module.h
@@ -44,7 +44,7 @@ class ShishKebabTrd1Module
   ///
   /// Constructor.
   ///
-  ShishKebabTrd1Module(Double_t theta = 0.0, Geometry * g = nullptr);
+  ShishKebabTrd1Module(Double_t theta = 0.0, Geometry* g = nullptr);
 
   ///
   /// Constructor.
@@ -91,10 +91,10 @@ class ShishKebabTrd1Module
   const TVector2& GetCenterOfModule() const { return mOK; }
   Double_t GetPosX() const { return mOK.Y(); }
   Double_t GetPosZ() const { return mOK.X(); }
-  Double_t GetPosXfromR() const { return mOK.Y() - mgr; }
+  Double_t GetPosXfromR() const { return mOK.Y() - sr; }
   Double_t GetA() const { return mA; }
   Double_t GetB() const { return mB; }
-  Double_t GetRadius() const { return mgr; }
+  Double_t GetRadius() const { return sr; }
   TVector2 GetORB() const { return mORB; }
   TVector2 GetORT() const { return mORT; }
 
@@ -117,7 +117,7 @@ class ShishKebabTrd1Module
       xr = mOK1.Y();
       zr = mOK1.X();
     }
-    LOG(DEBUG2) <<  " ieta " << std::setw(2) << std::setprecision(2) << ieta << " xr " << std::setw(8)
+    LOG(DEBUG2) << " ieta " << std::setw(2) << std::setprecision(2) << ieta << " xr " << std::setw(8)
                 << std::setprecision(4) << xr << " zr " << std::setw(8) << std::setprecision(4) << zr
                 << FairLogger::endl;
   }
@@ -134,7 +134,7 @@ class ShishKebabTrd1Module
 
   void GetCenterOfCellInLocalCoordinateofSM1X1(Double_t& xr, Double_t& zr) const
   { // 1X1 case - Nov 27,2006 // Center of cell is center of module
-    xr = mOK.Y() - mgr;
+    xr = mOK.Y() - sr;
     zr = mOK.X();
   }
 
@@ -152,8 +152,8 @@ class ShishKebabTrd1Module
   void GetPositionAtCenterCellLine(Int_t ieta, Double_t dist, TVector2& v) const;
 
   //
-  Double_t GetTanBetta() const { return mgtanBetta; }
-  Double_t Getb() const { return mgb; }
+  Double_t GetTanBetta() const { return stanBetta; }
+  Double_t Getb() const { return sb; }
 
   // service methods
   void PrintShish(Int_t pri = 1) const; // *MENU*
@@ -164,13 +164,13 @@ class ShishKebabTrd1Module
 
  protected:
   // geometry info
-  Geometry *mGeometry; //!<! pointer to geometry info
-  Double_t mga;           ///<  2*dx1=2*dy1
-  Double_t mga2;          ///<  2*dx2
-  Double_t mgb;           ///<  2*dz1
-  Double_t mgangle;       ///<  in rad (1.5 degree)
-  Double_t mgtanBetta;    ///<  tan(fgangle/2.)
-  Double_t mgr;           ///<  radius to IP
+  Geometry* mGeometry;       //!<! pointer to geometry info
+  static Double_t sa;        ///<  2*dx1=2*dy1
+  static Double_t sa2;       ///<  2*dx2
+  static Double_t sb;        ///<  2*dz1
+  static Double_t sangle;    ///<  in rad (1.5 degree)
+  static Double_t stanBetta; ///<  tan(fgangle/2.)
+  static Double_t sr;        ///<  radius to IP
 
   TVector2 mOK;     ///< position the module center in ALICE system; x->y; z->x;
   Double_t mA;      ///< parameters of right line : y = A*z + B
@@ -198,7 +198,6 @@ class ShishKebabTrd1Module
   // Apr 14, 2010 - checking of geometry
   TVector2 mORB; ///< position of right/bottom point of module
   TVector2 mORT; ///< position of right/top    point of module
-
 };
 }
 }

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/Detector.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/Detector.h
@@ -15,8 +15,8 @@
 #include "MathUtils/Cartesian3D.h"
 #include "RStringView.h"
 #include "Rtypes.h"
-#include "TArrayF.h"
 
+#include <set>
 #include <vector>
 
 class FairVolume;
@@ -29,30 +29,105 @@ namespace EMCAL
 class Hit;
 class Geometry;
 
+/// \struct Track hit
+/// \brief Helper structure storing hits assigned to the same track within the event
+///
+/// Hits are handled additive in the EMCAL simulation, meaning all hits belonging to
+/// the same track are added. This struct is used internally in the EMCAL detector class
+/// setting up a search structure for hits belonging to a certain track
+struct TrackHit {
+  Int_t mTrackID; ///< track ID
+  Hit* mHit;      ///< Associated EMCAL hit
+
+  bool operator==(const TrackHit& other) const { return mTrackID == other.mTrackID; }
+  bool operator<(const TrackHit& other) const { return mTrackID < other.mTrackID; }
+};
+
+///
+/// \class Detector
+/// \bief Detector class for the EMCAL detector
+///
+/// The detector class handles the implementation of the EMCAL detector
+/// within the virtual Monte-Carlo framework and the simulation of the
+/// EMCAL detector up to hit generation
 class Detector : public o2::Base::Detector
 {
  public:
   enum { ID_AIR = 0, ID_PB = 1, ID_SC = 2, ID_AL = 3, ID_STEEL = 4, ID_PAPER = 5 };
 
+  ///
+  /// Default constructor
+  ///
   Detector() = default;
 
+  ///
+  /// Main constructor
+  ///
+  /// \param[in] name Name of the detector (EMCAL)
+  /// \param[in] isActive Switch whether detector is active in simulation
   Detector(const char* name, Bool_t isActive);
 
+  ///
+  /// Destructor
+  ///
   ~Detector() override = default;
 
+  ///
+  /// Initializing detector
+  ///
   void Initialize() final;
 
+  ///
+  /// Processing hit creation in the EMCAL scintillator volume
+  ///
+  /// \param[in] v Current sensitive volume
   Bool_t ProcessHits(FairVolume* v = nullptr) final;
 
-  Hit* AddHit(Int_t shunt, Int_t trackID, Int_t parentID, Int_t primary, Double_t initialEnergy, Int_t detID,
-              const Point3D<float>& pos, const Vector3D<float>& mom, Double_t time, Double_t length);
+  ///
+  /// Add EMCAL hit
+  /// Internally adding hits coming from the same track
+  ///
+  /// \param[in] trackID Index of the track in the MC stack
+  /// \param[in] parentID Index of the parent particle (entering the EMCAL) in the MC stack
+  /// \param[in] primary Index of the primary particle in the MC stack
+  /// \param[in] initialEnergy Energy of the particle entering the EMCAL
+  /// \param[in] detID Index of the detector (cell) for which the hit is created
+  /// \param[in] pos Position vector of the particle at the hit
+  /// \param[in] mom Momentum vector of the particle at the hit
+  /// \param[in] time Time of the hit
+  /// \param[in] energyloss Energy deposit in EMCAL
+  ///
+  Hit* AddHit(Int_t trackID, Int_t parentID, Int_t primary, Double_t initialEnergy, Int_t detID,
+              const Point3D<float>& pos, const Vector3D<float>& mom, Double_t time, Double_t energyloss);
 
+  ///
+  /// Register TClonesArray with hits
+  ///
   void Register() override;
 
+  ///
+  /// Get access to the point collection
+  /// \return TClonesArray with points
+  ///
   TClonesArray* GetCollection(Int_t iColl) const final;
 
+  ///
+  /// Reset
+  /// Clean point collection
+  ///
   void Reset() final;
 
+  ///
+  /// Steps to be carried out at the end of the event
+  /// For EMCAL cleaning the hit collection and the lookup table
+  ///
+  void EndOfEvent() final;
+
+  ///
+  /// Get the EMCAL geometry desciption
+  /// Will be created the first time the function is called
+  /// \return Access to the EMCAL Geometry description
+  ///
   Geometry* GetGeometry();
 
  protected:
@@ -64,6 +139,11 @@ class Detector : public o2::Base::Detector
   void ConstructGeometry() override;
 
   ///
+  /// Generate EMCAL envelop (mother volume of all supermodules)
+  ///
+  void CreateEmcalEnvelope();
+
+  ///
   /// Generate tower geometry
   ///
   void CreateShiskebabGeometry();
@@ -71,12 +151,12 @@ class Detector : public o2::Base::Detector
   ///
   /// Generate super module geometry
   ///
-  void CreateSmod(const std::string_view mother = "XEN1");
+  void CreateSupermoduleGeometry(const std::string_view mother = "XEN1");
 
   ///
   /// Generate module geometry (2x2 towers)
   ///
-  void CreateEmod(const std::string_view mother = "SMOD", const std::string_view child = "EMOD");
+  void CreateEmcalModuleGeometry(const std::string_view mother = "SMOD", const std::string_view child = "EMOD");
 
   ///
   /// Generate aluminium plates geometry
@@ -84,39 +164,24 @@ class Detector : public o2::Base::Detector
   void CreateAlFrontPlate(const std::string_view mother = "EMOD", const std::string_view child = "ALFP");
 
   ///
-  /// Generate towers in module of 1x1
-  /// Prototype studies, remove?
+  /// Calculate the amount of light seen by the APD for a given track segment (charged particles only)
+  /// Calculation done according to Bricks law
   ///
-  void Trd1Tower1X1(Double_t* parSCM0);
-
+  /// \param[in] energydeposit Energy deposited by a charged particle in the track segment
+  /// \param[in] tracklength Length of the track segment
+  /// \param[in] charge Track charge (in units of elementary charge)
   ///
-  /// Generate towers in module of 3x3
-  /// Prototype studies, remove?
-  ///
-  void Trd1Tower3X3(const Double_t* parSCM0);
-
-  ///
-  /// Used by AliEMCALv0::Trd1Tower3X3
-  /// Prototype studies, remove?
-  ///
-  void PbInTrap(const Double_t parTRAP[11], const std::string_view n);
-
-  ///
-  /// Used by AliEMCALv0::Trd1Tower1X1
-  /// Prototype studies, remove?
-  ///
-  void PbInTrd1(const Double_t* parTrd1, const std::string_view n);
+  Double_t CalculateLightYield(Double_t energydeposit, Double_t tracklength, Int_t charge) const;
 
  private:
   Int_t mBirkC0;
   Double_t mBirkC1;
   Double_t mBirkC2;
 
+  std::set<TrackHit>
+    mEventHits; ///< Set of hits within the event, used for fast lookup of hits connected to a primary particle
   TClonesArray* mPointCollection; ///< Collection of EMCAL points
   Geometry* mGeometry;            ///< Geometry pointer
-
-  TArrayF mEnvelop1; //!<! parameters of EMCAL envelop for TRD1(2) case
-  Int_t mIdRotm;     //!<! number of rotation matrix (working variable)
 
   Double_t mSampleWidth; //!<! sample width = double(g->GetECPbRadThick()+g->GetECScintThick());
   Double_t mSmodPar0;    //!<! x size of super module

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/Detector.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/Detector.h
@@ -17,7 +17,6 @@
 #include "Rtypes.h"
 
 #include <vector>
-#include <unordered_map>
 
 class FairVolume;
 class TClonesArray;
@@ -164,10 +163,13 @@ class Detector : public o2::Base::Detector
   Double_t mBirkC1;
   Double_t mBirkC2;
 
-  std::unordered_map<int, Hit *>
-    mEventHits; ///< Set of hits within the event, used for fast lookup of hits connected to a primary particle
   TClonesArray* mPointCollection; ///< Collection of EMCAL points
   Geometry* mGeometry;            ///< Geometry pointer
+  
+  // Worker variables during hit creation
+  Int_t mCurrentTrackID; //!<! ID of the current track
+  Int_t mCurrentCellID;  //!<! ID of the current cell
+  Hit * mCurrentHit; //!<! current summed energy
 
   Double_t mSampleWidth; //!<! sample width = double(g->GetECPbRadThick()+g->GetECScintThick());
   Double_t mSmodPar0;    //!<! x size of super module

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/Detector.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/Detector.h
@@ -16,8 +16,8 @@
 #include "RStringView.h"
 #include "Rtypes.h"
 
-#include <set>
 #include <vector>
+#include <unordered_map>
 
 class FairVolume;
 class TClonesArray;
@@ -28,20 +28,6 @@ namespace EMCAL
 {
 class Hit;
 class Geometry;
-
-/// \struct Track hit
-/// \brief Helper structure storing hits assigned to the same track within the event
-///
-/// Hits are handled additive in the EMCAL simulation, meaning all hits belonging to
-/// the same track are added. This struct is used internally in the EMCAL detector class
-/// setting up a search structure for hits belonging to a certain track
-struct TrackHit {
-  Int_t mTrackID; ///< track ID
-  Hit* mHit;      ///< Associated EMCAL hit
-
-  bool operator==(const TrackHit& other) const { return mTrackID == other.mTrackID; }
-  bool operator<(const TrackHit& other) const { return mTrackID < other.mTrackID; }
-};
 
 ///
 /// \class Detector
@@ -178,7 +164,7 @@ class Detector : public o2::Base::Detector
   Double_t mBirkC1;
   Double_t mBirkC2;
 
-  std::set<TrackHit>
+  std::unordered_map<int, Hit *>
     mEventHits; ///< Set of hits within the event, used for fast lookup of hits connected to a primary particle
   TClonesArray* mPointCollection; ///< Collection of EMCAL points
   Geometry* mGeometry;            ///< Geometry pointer

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/Detector.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/Detector.h
@@ -15,6 +15,7 @@
 #include "MathUtils/Cartesian3D.h"
 #include "RStringView.h"
 #include "Rtypes.h"
+#include "TLorentzVector.h"
 
 #include <vector>
 
@@ -165,11 +166,13 @@ class Detector : public o2::Base::Detector
 
   TClonesArray* mPointCollection; ///< Collection of EMCAL points
   Geometry* mGeometry;            ///< Geometry pointer
-  
+
   // Worker variables during hit creation
-  Int_t mCurrentTrackID; //!<! ID of the current track
-  Int_t mCurrentCellID;  //!<! ID of the current cell
-  Hit * mCurrentHit; //!<! current summed energy
+  Int_t mCurrentTrackID;      //!<! ID of the current track
+  Int_t mCurrentCellID;       //!<! ID of the current cell
+  Hit* mCurrentHit;           //!<! current summed energy
+  TLorentzVector mCurrentPos; //!<! Current hit position (needed for VMC interface)
+  TLorentzVector mCurrentMom; //!<! Current momentum vector (needed for VMC interface)
 
   Double_t mSampleWidth; //!<! sample width = double(g->GetECPbRadThick()+g->GetECScintThick());
   Double_t mSmodPar0;    //!<! x size of super module

--- a/Detectors/EMCAL/simulation/src/Detector.cxx
+++ b/Detectors/EMCAL/simulation/src/Detector.cxx
@@ -8,6 +8,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#include <algorithm>
 #include <iomanip>
 
 #include "TClonesArray.h"
@@ -161,9 +162,9 @@ Hit* Detector::AddHit(Int_t trackID, Int_t parentID, Int_t primary, Double_t ini
               << ")  with energy " << initialEnergy << " loosing " << eLoss << std::endl;
 
   Hit* myhit(nullptr);
-  auto hitentry = mEventHits.find({ trackID, nullptr });
+  auto hitentry = mEventHits.find(trackID);
   if (hitentry != mEventHits.end()) {
-    myhit = hitentry->mHit;
+    myhit = hitentry->second;
     myhit->SetEnergyLoss(myhit->GetEnergyLoss() + eLoss);
   } else {
     TClonesArray& refCollection = *mPointCollection;

--- a/Detectors/EMCAL/testsimulation/drawEMCALgeometry.C
+++ b/Detectors/EMCAL/testsimulation/drawEMCALgeometry.C
@@ -1,0 +1,81 @@
+#if (!defined(__CINT__) && !defined(__CLING__)) || defined(__MAKECINT__)
+#include "DetectorsPassive/Cave.h"
+#include "DetectorsPassive/FrameStructure.h"
+#include "FairRunSim.h"
+#include "TGeoManager.h"
+#include "TOFSimulation/Detector.h"
+#include "TROOT.h"
+#include "TString.h"
+#include "TString.h"
+#include "TSystem.h"
+
+#include <boost/program_options.hpp>
+#include <iomanip>
+#include <iostream>
+#endif
+
+void drawEMCALgeometry()
+{
+  // minimal macro to test setup of the geometry
+
+  TString dir = getenv("VMCWORKDIR");
+  TString geom_dir = dir + "/Detectors/Geometry/";
+  gSystem->Setenv("GEOMPATH", geom_dir.Data());
+
+  TString tut_configdir = dir + "/Detectors/gconfig";
+  gSystem->Setenv("CONFIG_DIR", tut_configdir.Data());
+
+  // Create simulation run
+  FairRunSim* run = new FairRunSim();
+  run->SetOutputFile("foo.root"); // Output file
+  run->SetName("TGeant3");        // Transport engine
+  // Create media
+  run->SetMaterials("media.geo"); // Materials
+
+  // Create geometry
+
+  o2::Passive::Cave* cave = new o2::Passive::Cave("CAVE");
+  cave->SetGeometryFileName("cave.geo");
+  run->AddModule(cave);
+
+  o2::Passive::FrameStructure* frame = new o2::Passive::FrameStructure("Frame", "Frame");
+  run->AddModule(frame);
+
+  o2::EMCAL::Detector* tof = new o2::EMCAL::Detector("EMCAL", kTRUE);
+  run->AddModule(tof);
+
+  run->Init();
+  {
+    const TString ToHide =
+      "cave";
+
+    TObjArray* lToHide = ToHide.Tokenize(" ");
+    TIter* iToHide = new TIter(lToHide);
+    TObjString* name;
+    while ((name = (TObjString*)iToHide->Next()))
+      gGeoManager->GetVolume(name->GetName())->SetVisibility(kFALSE);
+
+    TString ToShow =
+      "SMOD SM3rd DCSM DCEXT";
+    // ToShow.ReplaceAll("FCOV", "");//Remove external cover but PHOS hole
+    // ToShow.ReplaceAll("FLTA", "");//Remove internal cover but PHOS hole
+
+    TObjArray* lToShow = ToShow.Tokenize(" ");
+    TIter* iToShow = new TIter(lToShow);
+    while ((name = (TObjString*)iToShow->Next()))
+      gGeoManager->GetVolume(name->GetName())->SetVisibility(kTRUE);
+
+    const TString ToTrans = "SCM0 SCMCX SCMY";
+
+    TObjArray* lToTrans = ToTrans.Tokenize(" ");
+    TIter* iToTrans = new TIter(lToTrans);
+    while ((name = (TObjString*)iToTrans->Next()))
+      gGeoManager->GetVolume(name->GetName())->SetTransparency(50);
+  }
+
+  gGeoManager->GetListOfVolumes()->ls();
+  gGeoManager->CloseGeometry();
+
+  gGeoManager->GetTopVolume()->Draw("ogl");
+  gGeoManager->Export("EMCALgeometry.root");
+}

--- a/macro/run_sim_emcal.C
+++ b/macro/run_sim_emcal.C
@@ -1,0 +1,134 @@
+#if (!defined(__CLING__) && !defined(__CINT__)) || defined(__MAKECINT__)
+  #include <TSystem.h>
+  #include <TMath.h>
+  #include <TString.h>
+  #include <TStopwatch.h>
+
+  #include "FairRunSim.h"
+  #include "FairRuntimeDb.h"
+  #include "FairPrimaryGenerator.h"
+  #include "FairBoxGenerator.h"
+  #include "FairParRootFileIo.h"
+
+  #include "DetectorsPassive/Cave.h"
+  #include "Field/MagneticField.h"
+  #include "EMCALSimulation/Detector.h"
+#endif
+
+extern TSystem *gSystem;
+
+double radii2Turbo(double rMin, double rMid, double rMax, double sensW)
+{
+  // compute turbo angle from radii and sensor width
+  return TMath::ASin((rMax * rMax - rMin * rMin) / (2 * rMid * sensW)) * TMath::RadToDeg();
+}
+
+void run_sim_emcal(Int_t nEvents = 1, TString mcEngine = "TGeant3")
+{
+  FairLogger::GetLogger()->SetLogScreenLevel("DEBUG2");
+  TString dir = getenv("VMCWORKDIR");
+  TString geom_dir = dir + "/Detectors/Geometry/";
+  gSystem->Setenv("GEOMPATH",geom_dir.Data());
+
+
+  TString tut_configdir = dir + "/Detectors/gconfig";
+  gSystem->Setenv("CONFIG_DIR",tut_configdir.Data());
+
+  // Output file name
+  char fileout[100];
+  sprintf(fileout, "AliceO2_%s.mc_%i_event.root", mcEngine.Data(), nEvents);
+  TString outFile = fileout;
+
+  // Parameter file name
+  char filepar[100];
+  sprintf(filepar, "AliceO2_%s.params_%i.root", mcEngine.Data(), nEvents);
+  TString parFile = filepar;
+
+  // In general, the following parts need not be touched
+
+  // Debug option
+  gDebug = 0;
+
+  // Timer
+  TStopwatch timer;
+  timer.Start();
+
+  // CDB manager
+  //   o2::CDB::Manager *cdbManager = o2::CDB::Manager::Instance();
+  //   cdbManager->setDefaultStorage("local://$ALICEO2/tpc/dirty/o2cdb");
+  //   cdbManager->setRun(0);
+
+
+  // Create simulation run
+  FairRunSim* run = new FairRunSim();
+  run->SetName(mcEngine);      // Transport engine
+  run->SetOutputFile(outFile); // Output file
+  FairRuntimeDb* rtdb = run->GetRuntimeDb();
+
+  // Create media
+   run->SetMaterials("media.geo"); // Materials
+
+  // Create geometry
+  o2::Passive::Cave* cave = new o2::Passive::Cave("CAVE");
+  cave->SetGeometryFileName("cave.geo");
+  run->AddModule(cave);
+
+  /*FairConstField field;
+   field.SetField(0., 0., 5.); //in kG
+   field.SetFieldRegion(-5000.,5000.,-5000.,5000.,-5000.,5000.); //in c
+  */
+  o2::field::MagneticField field("field","field +5kG");
+  run->SetField(&field);
+
+  o2::EMCAL::Detector* emcal = new o2::EMCAL::Detector("EMCAL", kTRUE);
+  run->AddModule(emcal);
+
+  // Create PrimaryGenerator
+  FairPrimaryGenerator* primGen = new FairPrimaryGenerator();
+  FairBoxGenerator* boxGen = new FairBoxGenerator(11, 100); // electrons
+
+  //boxGen->SetThetaRange(0.0, 90.0);
+  boxGen->SetEtaRange(-0.9,0.9);
+  boxGen->SetPtRange(1, 1.01);
+  boxGen->SetPhiRange(0., 360.);
+  boxGen->SetDebug(kFALSE);
+
+  primGen->AddGenerator(boxGen);
+
+  run->SetGenerator(primGen);
+  run->SetStoreTraj(kTRUE);
+
+  // store track trajectories
+  //run->SetStoreTraj(kTRUE);
+
+  // Initialize simulation run
+  run->Init();
+
+  // Runtime database
+  Bool_t kParameterMerged = kTRUE;
+  FairParRootFileIo* parOut = new FairParRootFileIo(kParameterMerged);
+  parOut->open(parFile.Data());
+  rtdb->setOutput(parOut);
+  rtdb->saveOutput();
+  rtdb->print();
+
+  // Start run
+  run->Run(nEvents);
+
+  delete run;
+
+  // Finish
+  timer.Stop();
+  Double_t rtime = timer.RealTime();
+  Double_t ctime = timer.CpuTime();
+
+  // Write geometry
+  gGeoManager->Export("geometry.root", "geometry");
+
+  cout << "Output file is " << outFile << endl;
+  cout << "Parameter file is " << parFile << endl;
+  cout << "Real time " << rtime << " s, CPU time " << ctime << "s" << endl << endl;
+  cout << endl << endl;
+  cout << "Macro finished succesfully." << endl;
+  cout << endl << endl;
+}

--- a/macro/run_sim_emcal.sh
+++ b/macro/run_sim_emcal.sh
@@ -1,0 +1,1 @@
+root.exe -b  -q SetIncludePath.C run_sim_emcal.C++\($1,\""$2"\"\)


### PR DESCRIPTION
- Bug fix (temporary) in Shishkebab geometry
- Small fix in EMCAL geometry
- Remove unused variable (shut) in Hit
- Fix z-coordinate of Hit
- Fix add function for hit: All hits from the same track are
  added to 1 hit. For this a lookup table is used to map the hits
- Handle calculation of the module ID: Module ID needs to be
  obtained from the copy number of the volume and the volume ID
  over various levels in the geometry tree
- Process Hits add currently hits once a volume is passed