### PR TITLE
CMake setup: Fixing a circular dependency and adding check for header files

### DIFF
--- a/cmake/O2Utils.cmake
+++ b/cmake/O2Utils.cmake
@@ -509,18 +509,21 @@ function(O2_GENERATE_MAN)
       COMMAND nroff -Tascii -man ${CMAKE_CURRENT_SOURCE_DIR}/doc/${PARSED_ARGS_NAME}.${PARSED_ARGS_SECTION}.in > ${CMAKE_CURRENT_BINARY_DIR}/${PARSED_ARGS_NAME}.${PARSED_ARGS_SECTION}
       VERBATIM
     )
-    ADD_CUSTOM_TARGET(${PARSED_ARGS_NAME}.${PARSED_ARGS_SECTION} DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${PARSED_ARGS_NAME}.${PARSED_ARGS_SECTION})
+    # the prefix man. for the target name avoids circular dependencies for the
+    # man pages added at top level. Simply droping the dependency for those
+    # does not invoke the custom command on all systems.
+    set(CUSTOM_TARGET_NAME man.${PARSED_ARGS_NAME}.${PARSED_ARGS_SECTION})
+    ADD_CUSTOM_TARGET(${CUSTOM_TARGET_NAME} DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${PARSED_ARGS_NAME}.${PARSED_ARGS_SECTION})
     if (PARSED_ARGS_MODULE)
       # add to the man target of specified module
-      add_dependencies(${PARSED_ARGS_MODULE}.man ${PARSED_ARGS_NAME}.${PARSED_ARGS_SECTION})
+      add_dependencies(${PARSED_ARGS_MODULE}.man ${CUSTOM_TARGET_NAME})
     elseif(MODULE_NAME)
       # add to the man target of current module
-      add_dependencies(${MODULE_NAME}.man ${PARSED_ARGS_NAME}.${PARSED_ARGS_SECTION})
+      add_dependencies(${MODULE_NAME}.man ${CUSTOM_TARGET_NAME})
     else()
       # add to top level target otherwise
-      add_dependencies(man ${PARSED_ARGS_NAME}.${PARSED_ARGS_SECTION})
+      add_dependencies(man ${CUSTOM_TARGET_NAME})
     endif()
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PARSED_ARGS_NAME}.${PARSED_ARGS_SECTION} DESTINATION share/man/man${PARSED_ARGS_SECTION})
   endif(NROFF_FOUND)
 endfunction(O2_GENERATE_MAN)
-

--- a/cmake/O2Utils.cmake
+++ b/cmake/O2Utils.cmake
@@ -281,6 +281,15 @@ macro(O2_GENERATE_LIBRARY)
   ############### install the library ###################
   install(TARGETS ${Int_LIB} DESTINATION lib)
 
+  # public header files must be in include/${MODULE_NAME}, make sure there
+  # are no header files directly in include
+  # TODO: this should probably be combined with what has been defined as
+  # HEADERS.
+  file(GLOB PUBLIC_HEADERS_IN_WRONG_PLACE ${CMAKE_CURRENT_SOURCE_DIR}/include/*.h)
+  if(PUBLIC_HEADERS_IN_WRONG_PLACE)
+    Message("found header files: ${PUBLIC_HEADERS_IN_WRONG_PLACE}")
+    Message(FATAL_ERROR "public header files required to be in 'include/<modulename>'")
+  endif()
   # Install all the public headers
   if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/include/${MODULE_NAME})
     install(DIRECTORY include/${MODULE_NAME} DESTINATION include)


### PR DESCRIPTION
The circular dependencies had been created for man pages in the top directory where the target file and the configured dependency are the same. They are dropped by `make` automatically
```
    make[2]: Circular CMakeFiles/o2.1 <- o2.1 dependency dropped.
    make[2]: Circular o2.1 <- o2.1 dependency dropped.
    make[2]: Circular CMakeFiles/FairMQDevice.1 <- FairMQDevice.1 dependency dropped.
    make[2]: Circular FairMQDevice.1 <- FairMQDevice.1 dependency dropped.
```
This PR solves these warnings. 

Also adding a check to make sure that there are no header files directly in the `include` directory.