### PR TITLE
MCStepLogger: TTree output and other improvements

### DIFF
--- a/Utilities/MCStepLogger/CMakeLists.txt
+++ b/Utilities/MCStepLogger/CMakeLists.txt
@@ -8,10 +8,16 @@ O2_SETUP(NAME ${MODULE_NAME})
 set(SRCS
     src/MCStepInterceptor.cxx
     src/MCStepLoggerImpl.cxx
+    src/StepInfo.cxx
    )
+
+set(HEADERS
+   src/StepInfo.h
+  )
 
 set(LIBRARY_NAME ${MODULE_NAME})
 set(BUCKET_NAME ${MODULE_BUCKET_NAME})
+set(LINKDEF src/MCStepLoggerLinkDef.h)
 
 O2_GENERATE_LIBRARY()
 

--- a/Utilities/MCStepLogger/src/MCStepLoggerLinkDef.h
+++ b/Utilities/MCStepLogger/src/MCStepLoggerLinkDef.h
@@ -1,0 +1,28 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See https://alice-o2.web.cern.ch/ for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+
+#ifdef __CLING__
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class o2::StepInfo+;
+#pragma link C++ class o2::MagCallInfo+;
+#pragma link C++ class std::vector<o2::StepInfo>+;
+#pragma link C++ class std::vector<o2::MagCallInfo>+;
+#pragma link C++ class std::vector<o2::StepInfo*>+;
+#pragma link C++ class std::vector<o2::MagCallInfo*>+;
+#pragma link C++ class std::vector<TGeoVolume const *>+;
+#pragma link C++ class std::vector<std::vector<TGeoVolume const *> *>+;
+#pragma link C++ class o2::VolInfoContainer+;
+
+
+#endif

--- a/Utilities/MCStepLogger/src/StepInfo.cxx
+++ b/Utilities/MCStepLogger/src/StepInfo.cxx
@@ -1,0 +1,152 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See https://alice-o2.web.cern.ch/ for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+//****************************************************************************
+//* This file is free software: you can redistribute it and/or modify        *
+//* it under the terms of the GNU General Public License as published by     *
+//* the Free Software Foundation, either version 3 of the License, or        *
+//* (at your option) any later version.                                      *
+//*                                                                          *
+//* Primary Authors: Sandro Wenzel <sandro.wenzel@cern.ch>                   *
+//*                                                                          *
+//* The authors make no claims about the suitability of this software for    *
+//* any purpose. It is provided "as is" without express or implied warranty. *
+//****************************************************************************
+
+//  @file   StepInfo.cxx
+//  @author Sandro Wenzel
+//  @since  2017-06-29
+//  @brief  structures encapsulating information about MC stepping
+
+
+#include <StepInfo.h>
+#include <TArrayI.h>
+#include <TParticle.h>
+#include <TVirtualMC.h>
+#include <chrono>
+
+#include <TDatabasePDG.h>
+#include <TGeoManager.h>
+#include <TGeoMedium.h>
+#include <TGeoVolume.h>
+#include <cassert>
+#include <iostream>
+
+ClassImp(o2::StepInfo);
+ClassImp(o2::MagCallInfo);
+
+namespace o2
+{
+// construct directly using virtual mc
+StepInfo::StepInfo(TVirtualMC* mc)
+{
+  assert(mc);
+
+  // init base time point
+  if (stepcounter == -1) {
+    starttime = std::chrono::high_resolution_clock::now();
+  }
+  stepcounter++;
+  stepid = stepcounter;
+  currentinstance = this;
+
+  eventid = mc->CurrentEvent();
+  auto stack = mc->GetStack();
+
+  trackID = stack->GetCurrentTrackNumber();
+  pdg = mc->TrackPid();
+  auto particle = TDatabasePDG::Instance()->GetParticle(pdg);
+  pname = particle ? particle->GetName() : "NULL";
+  auto id = mc->CurrentVolID(copyNo);
+  volId = id;
+
+  auto curtrack = stack->GetCurrentTrack();
+  primary = curtrack ? curtrack->IsPrimary() : false;
+
+  auto geovolume = gGeoManager->GetCurrentVolume();
+  volname = geovolume ? geovolume->GetName() : "NULL";
+  auto medium = geovolume ? geovolume->GetMedium() : nullptr;
+  mediumname = medium ? medium->GetName() : "NULL";
+
+  // try to resolve the module via external map
+  // keep information in faster vector once looked up
+  modulename = "UNKNOWN";
+  if (volnametomodulemap && volnametomodulemap->size() > 0 && volId >= 0) {
+    // lookup in vector first
+    if (volId >= volidtomodulevector.size()) {
+      volidtomodulevector.resize(volId + 1, nullptr);
+    }
+    if (volidtomodulevector[volId] == nullptr) {
+      // lookup in map
+      auto iter = volnametomodulemap->find(volname);
+      if (iter != volnametomodulemap->end()) {
+        volidtomodulevector[volId] = &iter->second;
+      }
+    }
+    if (volidtomodulevector[volId]) {
+      modulename = *volidtomodulevector[volId];
+    }
+  }
+
+  // auto v2 = gGeoManager->GetCurrentNavigator()->GetCurrentVolume();
+  // if (strcmp(mc->CurrentVolName(), v2->GetName())!=0){
+  //  std::cerr << "inconsistent state\n";
+  //}
+
+  double xd, yd, zd;
+  mc->TrackPosition(xd, yd, zd);
+  x = xd;
+  y = yd;
+  z = zd;
+  E = curtrack->Energy();
+  auto now = std::chrono::high_resolution_clock::now();
+  cputimestamp = std::chrono::duration_cast<std::chrono::nanoseconds>(now - starttime).count();
+  nsecondaries = mc->NSecondaries();
+
+  if (nsecondaries > 0) {
+    secondaryprocesses = new int[nsecondaries];
+    // for the processes
+    for (int i = 0; i < nsecondaries; ++i) {
+      secondaryprocesses[i] = mc->ProdProcess(i);
+    }
+  }
+
+  TArrayI procs;
+  mc->StepProcesses(procs);
+  nprocessesactive = procs.GetSize();
+
+  // is track entering volume
+
+  // is track exiting volume
+
+  // was track stoped due to energy limit ??
+  stopped = mc->IsTrackStop();
+}
+
+std::chrono::time_point<std::chrono::high_resolution_clock> StepInfo::starttime;
+int StepInfo::stepcounter = -1;
+StepInfo* StepInfo::currentinstance = nullptr;
+std::map<std::string, std::string>* StepInfo::volnametomodulemap = nullptr;
+std::vector<std::string*> StepInfo::volidtomodulevector;
+
+MagCallInfo::MagCallInfo(TVirtualMC* mc, float ax, float ay, float az, float aBx, float aBy, float aBz)
+  : x{ ax }, y{ ay }, z{ az }, Bx{ aBx }, By{ aBy }, Bz{ aBz }
+{
+  stepcounter++;
+  id = stepcounter;
+  stepid = StepInfo::stepcounter;
+  // copy the stepinfo
+  if (StepInfo::currentinstance) {
+    // stepinfo = *StepInfo::currentinstance;
+  }
+}
+
+int MagCallInfo::stepcounter = -1;
+}

--- a/Utilities/MCStepLogger/src/StepInfo.h
+++ b/Utilities/MCStepLogger/src/StepInfo.h
@@ -1,0 +1,120 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See https://alice-o2.web.cern.ch/ for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+//****************************************************************************
+//* This file is free software: you can redistribute it and/or modify        *
+//* it under the terms of the GNU General Public License as published by     *
+//* the Free Software Foundation, either version 3 of the License, or        *
+//* (at your option) any later version.                                      *
+//*                                                                          *
+//* Primary Authors: Sandro Wenzel <sandro.wenzel@cern.ch>                   *
+//*                                                                          *
+//* The authors make no claims about the suitability of this software for    *
+//* any purpose. It is provided "as is" without express or implied warranty. *
+//****************************************************************************
+
+#ifndef O2_STEPINFO
+#define O2_STEPINFO
+
+#include <Rtypes.h>
+#include <chrono>
+#include <map>
+
+class TVirtualMC;
+class TGeoVolume;
+class TGeoMedium;
+
+namespace o2
+{
+// class collecting info about one MC step done
+
+struct VolInfoContainer {
+  VolInfoContainer() = default;
+
+  // keeps info about volumes (might exist somewhere else already)
+  // essentially a mapping from volumeID x copyNo to TGeoVolumes
+  std::vector<std::vector<TGeoVolume const*>*> volumes; // sparse container
+
+  void insert(int id, int copyNo, TGeoVolume const* vol)
+  {
+    if (volumes.size() <= id) {
+      volumes.resize(id + 1, nullptr);
+    }
+    if (volumes[id] == nullptr) {
+      volumes[id] = new std::vector<TGeoVolume const*>;
+    }
+    if (volumes[id]->size() <= copyNo) {
+      volumes[id]->resize(copyNo + 1, nullptr);
+    }
+    (*volumes[id])[copyNo] = vol;
+  }
+
+  TGeoVolume const* get(int id, int copy) const { return (*volumes[id])[copy]; }
+  ClassDefNV(VolInfoContainer, 1);
+};
+
+struct StepInfo {
+  StepInfo() = default;
+  // construct directly using virtual mc
+  StepInfo(TVirtualMC* mc);
+
+  long cputimestamp;
+  int stepid = -1; // serves as primary key
+  int eventid = -1;
+  int volId = -1; // keep another branch somewhere mapping this to name, medium, etc.
+  int copyNo = -1;
+  int trackID = -1;
+  int pdg = 0;
+  std::string pname; // particle name
+  std::string modulename;
+  float x = 0.;
+  float y = 0.;
+  float z = 0.;
+  float E = 0.;
+  float step = 0.;
+  float maxstep = 0.;
+  int nsecondaries = 0;
+  int* secondaryprocesses = nullptr; //[nsecondaries]
+  int nprocessesactive = 0;          // number of active processes
+  bool stopped = false;              //
+  bool primary = false;
+
+  std::string volname;
+  std::string mediumname;
+
+  static int stepcounter;           //!
+  static StepInfo* currentinstance; //!
+  static std::chrono::time_point<std::chrono::high_resolution_clock> starttime;
+  static void resetCounter() { stepcounter = -1; }
+  static std::map<std::string, std::string>* volnametomodulemap;
+  static std::vector<std::string*> volidtomodulevector;
+
+  ClassDefNV(StepInfo, 2);
+};
+
+struct MagCallInfo {
+  MagCallInfo() = default;
+  MagCallInfo(TVirtualMC* mc, float x, float y, float z, float Bx, float By, float Bz);
+
+  long id = -1;
+  long stepid = -1; // cross-reference to current MC stepid (if any??)
+  //  StepInfo stepinfo; // cross-reference to step info via pointer
+  float x = 0.;
+  float y = 0.;
+  float z = 0.;
+  float Bx = 0.;
+  float By = 0.;
+  float Bz = 0.;
+
+  static int stepcounter;
+  ClassDefNV(MagCallInfo, 1);
+};
+}
+#endif

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -371,6 +371,9 @@ o2_define_bucket(
     dl
     root_base_bucket
     VMC
+    EG
+    Tree
+    Geom
 
     INCLUDE_DIRECTORIES
 )


### PR DESCRIPTION
The logger can now stream to a ROOT TTree when environment
variable MCSTEPLOG_TTREE is activated; In this case, it will
not report a summary on the screen; The output file is controlled
via MCSTEPLOG_OUTFILE; This mode will give the most flexibility to
analyse the data.

Improved logging for magnetic field calls, now recording the position
and magnetic field answer

Possibility to provide an ascii file with a mapping of geometry volume
names to detector names; This is activated via the MCSTEPLOG_VOLMAPFILE
environment variable; This information is useful to get quick statistics of
how many steps where done in each detector etc.;
The format of the file is as follows
VOLNAME1 DETECTOR
VOLNAME2 DETECTOR