### PR TITLE
Improve Graphviz support

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -29,6 +29,7 @@ set(SRCS
     src/DataRelayer.cxx
     src/DataSourceDevice.cxx
     src/DeviceMetricsInfo.cxx
+    src/DeviceSpec.cxx
     src/DDSConfigHelpers.cxx
     src/FairOptionsRetriever.cxx
     src/FairOptionsRetriever.cxx
@@ -70,6 +71,7 @@ set(TEST_SRCS
       test/test_BoostOptionsRetriever.cxx
       test/test_SuppressionGenerator.cxx
       test/test_SingleDataSource.cxx
+      test/test_Graphviz.cxx
    )
 
 O2_GENERATE_TESTS(

--- a/Framework/Core/include/Framework/DeviceSpec.h
+++ b/Framework/Core/include/Framework/DeviceSpec.h
@@ -10,6 +10,7 @@
 #ifndef FRAMEWORK_DEVICESPEC_H
 #define FRAMEWORK_DEVICESPEC_H
 
+#include "Framework/WorkflowSpec.h"
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/ChannelSpec.h"
 #include "Framework/AlgorithmSpec.h"
@@ -34,6 +35,10 @@ struct DeviceSpec {
   std::map<std::string, InputSpec> forwards;
   std::vector<char *> args; // Calculated list of args for the device.
 };
+
+void
+dataProcessorSpecs2DeviceSpecs(const o2::framework::WorkflowSpec &workflow,
+                               std::vector<o2::framework::DeviceSpec> &devices);
 
 }
 }

--- a/Framework/Core/src/DeviceSpec.cxx
+++ b/Framework/Core/src/DeviceSpec.cxx
@@ -1,0 +1,168 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/DeviceSpec.h"
+#include "Framework/WorkflowSpec.h"
+#include "Framework/ChannelMatching.h"
+#include <vector>
+
+using namespace o2::framework;
+
+namespace o2 {
+namespace framework {
+
+// Construct the list of actual devices we want, given a workflow.
+void
+dataProcessorSpecs2DeviceSpecs(const o2::framework::WorkflowSpec &workflow,
+                               std::vector<o2::framework::DeviceSpec> &devices) {
+  // FIXME: for the moment we assume one channel per kind of product. Later on we
+  //        should optimize and make sure that multiple products can be multiplexed
+  //        on a single channel in case of a single receiver.
+  // FIXME: make start port configurable?
+  std::map<LogicalChannel, int> maxOutputCounts; // How many outputs of a given kind do we need?
+  // First we calculate the available outputs
+  for (auto &spec : workflow) {
+    for (auto &out : spec.outputs) {
+      maxOutputCounts.insert(std::make_pair(outputSpec2LogicalChannel(out), 0));
+    }
+  }
+
+  // Then we calculate how many inputs match a given output.
+  for (auto &output: maxOutputCounts) {
+    for (auto &spec : workflow) {
+      for (auto &in : spec.inputs) {
+        if (matchDataSpec2Channel(in, output.first)) {
+          maxOutputCounts[output.first] += 1;
+        }
+      }
+    }
+  }
+
+  // We then create the actual devices.
+  // - If an input is used only once, we simply connect to the output.
+  // - If an input is used by multiple entries, we keep track of how
+  //   how many have used it so far and make sure that all but the last
+  //   device using such an output forward it as `out_<origin>_<description>_<N>`.
+  // - If there is no output matching a given input, we should complain
+  // - If there is no input using a given output, we should warn?
+  std::map<PhysicalChannel, short> portMappings;
+  unsigned short nextPort = 22000;
+  std::map<LogicalChannel, size_t> outputUsages;
+
+  for (auto &processor : workflow) {
+    DeviceSpec device;
+    device.id = processor.name;
+    device.algorithm = processor.algorithm;
+    device.options = processor.options;
+
+    // Channels which need to be forwarded (because they are used by
+    // a downstream provider).
+    std::vector<ChannelSpec> forwardedChannels;
+
+    for (auto &outData : processor.outputs) {
+      ChannelSpec channel;
+      channel.method = Bind;
+      channel.type = Pub;
+      channel.port = nextPort;
+
+      auto logicalChannel = outputSpec2LogicalChannel(outData);
+      auto physicalChannel = outputSpec2PhysicalChannel(outData, 0);
+      auto channelUsage = outputUsages.find(logicalChannel);
+      // Decide the name of the channel. If this is
+      // the first time this channel is used, it means it
+      // is really an output.
+      if (channelUsage != outputUsages.end()) {
+        throw std::runtime_error("Too many outputs with the same name");
+      }
+
+      outputUsages.insert(std::make_pair(logicalChannel, 0));
+      auto portAlloc = std::make_pair(physicalChannel, nextPort);
+      channel.name = physicalChannel.id;
+
+      device.channels.push_back(channel);
+      device.outputs.insert(std::make_pair(channel.name, outData));
+
+      // This should actually be implied by the previous assert.
+      assert(portMappings.find(portAlloc.first) == portMappings.end());
+      portMappings.insert(portAlloc);
+      nextPort++;
+    }
+
+    // We now process the inputs. They are all of connect kind and we
+    // should look up in the previously created channel map where to
+    // connect to. If we have more than one device which reads
+    // from the same output, we should actually treat them as
+    // serialised output.
+    // FIXME: Alexey was referring to a device which can duplicate output
+    //        without overhead (not sure how that would work). Maybe we should use
+    //        that instead.
+    for (auto &input : processor.inputs) {
+      ChannelSpec channel;
+      channel.method = Connect;
+      channel.type = Sub;
+
+      // Create the channel name and find how many times we have used it.
+      auto logicalChannel = inputSpec2LogicalChannelMatcher(input);
+      auto usagesIt = outputUsages.find(logicalChannel);
+      if (usagesIt == outputUsages.end()) {
+        throw std::runtime_error("Could not find output matching " + logicalChannel.name);
+      }
+
+      // Find the maximum number of usages for the channel.
+      auto maxUsagesIt = maxOutputCounts.find(logicalChannel);
+      if (maxUsagesIt == maxOutputCounts.end()) {
+        // The previous throw should already catch this condition.
+        assert(false && "The previous check should have already caught this");
+      }
+      auto maxUsages = maxUsagesIt->second;
+
+      // Create the input channels:
+      // - Name of the channel to lookup always channel_name_<usages>
+      // - If usages is different from maxUsages, we should create a forwarding
+      // channel.
+      auto logicalInput = inputSpec2LogicalChannelMatcher(input);
+      auto currentChannelId = outputUsages.find(logicalInput);
+      if (currentChannelId == outputUsages.end()) {
+        std::runtime_error("Missing output for " + logicalInput.name);
+      }
+
+      auto physicalChannel = inputSpec2PhysicalChannelMatcher(input, currentChannelId->second);
+      auto currentPort = portMappings.find(physicalChannel);
+      if (currentPort == portMappings.end()) {
+        std::runtime_error("Missing physical channel " + physicalChannel.id);
+      }
+
+      channel.name = "in_" + physicalChannel.id;
+      channel.port = currentPort->second;
+      device.channels.push_back(channel);
+      device.inputs.insert(std::make_pair(channel.name, input));
+      // Increase the number of usages we did for a given logical channel
+      currentChannelId->second += 1;
+
+      // Here is where we create the forwarding port which can be later reused.
+      if (currentChannelId->second != maxUsages) {
+        ChannelSpec forwardedChannel;
+        forwardedChannel.method = Bind;
+        forwardedChannel.type = Pub;
+        auto physicalForward = inputSpec2PhysicalChannelMatcher(input, currentChannelId->second);
+        forwardedChannel.port = nextPort;
+        portMappings.insert(std::make_pair(physicalForward, nextPort));
+        forwardedChannel.name = physicalForward.id;
+
+        device.channels.push_back(forwardedChannel);
+        device.forwards.insert(std::make_pair(forwardedChannel.name, input));
+        nextPort++;
+      }
+    }
+    devices.push_back(device);
+  }
+}
+
+} // namespace framework
+} // namespace o2

--- a/Framework/Core/src/GraphvizHelpers.cxx
+++ b/Framework/Core/src/GraphvizHelpers.cxx
@@ -18,45 +18,44 @@ namespace framework {
 
 /// Helper to dump a workflow as a graphviz file
 void
-dumpDataProcessorSpec2Graphviz(const std::vector<DataProcessorSpec> &specs)
+dumpDataProcessorSpec2Graphviz(std::ostream &out, const std::vector<DataProcessorSpec> &specs)
 {
-  std::cout << "digraph structs {\n";
-  std::cout << "   node[shape=record]\n";
+  out << "digraph structs {\n";
+  out << "  node[shape=record]\n";
   for (auto &spec : specs) {
-    std::cout << R"(  struct [label=")" << spec.name << R"("];\n)";
+    out << R"(  struct [label=")" << spec.name << R"("];)" << "\n";
   }
-  std::cout << "}\n";
+  out << "}\n";
 }
 
 /// Helper to dump a set of devices as a graphviz file
 void
-dumpDeviceSpec2Graphviz(const std::vector<DeviceSpec> &specs)
+dumpDeviceSpec2Graphviz(std::ostream &out, const std::vector<DeviceSpec> &specs)
 {
-  std::cout << R"GRAPHVIZ(
-    digraph structs {
-    node[shape=record]
-  )GRAPHVIZ";
+  out << R"GRAPHVIZ(digraph structs {
+  node[shape=record]
+)GRAPHVIZ";
   std::map<std::string, std::string> outputChannel2Device;
   std::map<std::string, unsigned int> outputChannel2Port;
 
   for (auto &spec : specs) {
     auto id = spec.id;
     std::replace(id.begin(), id.end(), '-', '_'); // replace all 'x' to 'y'
-    std::cout << "   " << id << R"( [label="{{)";
+    out << "  " << id << R"( [label="{{)";
     bool firstInput = true;
     for (auto && input : spec.channels) {
       if (input.type != Sub) {
         continue;
       }
       if (firstInput == false) {
-        std::cout << "|";
+        out << "|";
       }
       firstInput = false;
-      std::cout << "<" << input.name << ">" << input.name;
+      out << "<" << input.name << ">" << input.name;
     }
-    std::cout << "}|";
-    std::cout << id << "(" << spec.channels.size() << ")";
-    std::cout << "|{";
+    out << "}|";
+    out << id << "(" << spec.channels.size() << ")";
+    out << "|{";
     bool firstOutput = true;
     for (auto && output : spec.channels) {
       outputChannel2Device.insert(std::make_pair(output.name, id));
@@ -65,12 +64,12 @@ dumpDeviceSpec2Graphviz(const std::vector<DeviceSpec> &specs)
         continue;
       }
       if (firstOutput == false) {
-        std::cout << "|";
+        out << "|";
       }
       firstOutput = false;
-      std::cout <<  "<" << output.name << ">" << output.name;
+      out <<  "<" << output.name << ">" << output.name;
     }
-    std::cout << R"(}}"];\n)";
+    out << R"(}}"];)" << "\n";
   }
   for (auto &spec : specs) {
     for (auto &channel: spec.channels) {
@@ -83,14 +82,14 @@ dumpDeviceSpec2Graphviz(const std::vector<DeviceSpec> &specs)
       }
       auto outputName = channel.name;
       outputName.erase(0, 3);
-      std::cout << outputChannel2Device[outputName] << ":" << outputName
-                << "-> "
-                << id << ":" << channel.name
-                << R"( [label=")" << channel.port << R"(")"
-                << "]\n";
+      out << "  " << outputChannel2Device[outputName] << ":" << outputName
+                  << "-> "
+                  << id << ":" << channel.name
+                  << R"( [label=")" << channel.port << R"(")"
+                  << "]\n";
     }
   }
-  std::cout << "}\n";
+  out << "}\n";
 }
 
 } // namespace framework

--- a/Framework/Core/src/GraphvizHelpers.h
+++ b/Framework/Core/src/GraphvizHelpers.h
@@ -13,12 +13,13 @@
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/DeviceSpec.h"
 #include <vector>
+#include <iosfwd>
 
 namespace o2 {
 namespace framework {
 
-void dumpDataProcessorSpec2Graphviz(const std::vector<o2::framework::DataProcessorSpec> &specs);
-void dumpDeviceSpec2Graphviz(const std::vector<o2::framework::DeviceSpec> &specs);
+void dumpDataProcessorSpec2Graphviz(std::ostream &, const std::vector<o2::framework::DataProcessorSpec> &specs);
+void dumpDeviceSpec2Graphviz(std::ostream &, const std::vector<o2::framework::DeviceSpec> &specs);
 
 } // namespace framework
 } // namespace o2

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -154,6 +154,9 @@ int doParent(fd_set *in_fdset,
     // TODO: have multiple display modes
     // TODO: graphical view of the processing?
     assert(infos.size() == controls.size());
+    std::smatch match;
+    std::string token;
+    const std::string delimiter("\n");
     for (size_t di = 0, de = infos.size(); di < de; ++di) {
       DeviceInfo &info = infos[di];
       DeviceControl &control = controls[di];
@@ -164,11 +167,8 @@ int doParent(fd_set *in_fdset,
       }
 
       auto s = info.unprinted;
-      std::string delimiter("\n");
       size_t pos = 0;
-      std::string token;
       info.history.resize(info.historySize);
-      std::smatch match;
 
       while ((pos = s.find(delimiter)) != std::string::npos) {
           token = s.substr(0, pos);
@@ -211,152 +211,6 @@ int doParent(fd_set *in_fdset,
   return 0;
 }
 
-// Construct the list of actual devices we want, given a workflow.
-void
-dataProcessorSpecs2DeviceSpecs(const o2::framework::WorkflowSpec &workflow,
-                               std::vector<o2::framework::DeviceSpec> &devices) {
-  // FIXME: for the moment we assume one channel per kind of product. Later on we
-  //        should optimize and make sure that multiple products can be multiplexed
-  //        on a single channel in case of a single receiver.
-  // FIXME: make start port configurable?
-  std::map<LogicalChannel, int> maxOutputCounts; // How many outputs of a given kind do we need?
-  // First we calculate the available outputs
-  for (auto &spec : workflow) {
-    for (auto &out : spec.outputs) {
-      maxOutputCounts.insert(std::make_pair(outputSpec2LogicalChannel(out), 0));
-    }
-  }
-
-  // Then we calculate how many inputs match a given output.
-  for (auto &output: maxOutputCounts) {
-    for (auto &spec : workflow) {
-      for (auto &in : spec.inputs) {
-        if (matchDataSpec2Channel(in, output.first)) {
-          maxOutputCounts[output.first] += 1;
-        }
-      }
-    }
-  }
-
-  // We then create the actual devices.
-  // - If an input is used only once, we simply connect to the output.
-  // - If an input is used by multiple entries, we keep track of how
-  //   how many have used it so far and make sure that all but the last
-  //   device using such an output forward it as `out_<origin>_<description>_<N>`.
-  // - If there is no output matching a given input, we should complain
-  // - If there is no input using a given output, we should warn?
-  std::map<PhysicalChannel, short> portMappings;
-  unsigned short nextPort = 22000;
-  std::map<LogicalChannel, size_t> outputUsages;
-
-  for (auto &processor : workflow) {
-    DeviceSpec device;
-    device.id = processor.name;
-    device.algorithm = processor.algorithm;
-    device.options = processor.options;
-
-    // Channels which need to be forwarded (because they are used by
-    // a downstream provider).
-    std::vector<ChannelSpec> forwardedChannels;
-
-    for (auto &outData : processor.outputs) {
-      ChannelSpec channel;
-      channel.method = Bind;
-      channel.type = Pub;
-      channel.port = nextPort;
-
-      auto logicalChannel = outputSpec2LogicalChannel(outData);
-      auto physicalChannel = outputSpec2PhysicalChannel(outData, 0);
-      auto channelUsage = outputUsages.find(logicalChannel);
-      // Decide the name of the channel. If this is
-      // the first time this channel is used, it means it
-      // is really an output.
-      if (channelUsage != outputUsages.end()) {
-        throw std::runtime_error("Too many outputs with the same name");
-      }
-
-      outputUsages.insert(std::make_pair(logicalChannel, 0));
-      auto portAlloc = std::make_pair(physicalChannel, nextPort);
-      channel.name = physicalChannel.id;
-
-      device.channels.push_back(channel);
-      device.outputs.insert(std::make_pair(channel.name, outData));
-
-      // This should actually be implied by the previous assert.
-      assert(portMappings.find(portAlloc.first) == portMappings.end());
-      portMappings.insert(portAlloc);
-      nextPort++;
-    }
-
-    // We now process the inputs. They are all of connect kind and we
-    // should look up in the previously created channel map where to
-    // connect to. If we have more than one device which reads
-    // from the same output, we should actually treat them as
-    // serialised output.
-    // FIXME: Alexey was referring to a device which can duplicate output
-    //        without overhead (not sure how that would work). Maybe we should use
-    //        that instead.
-    for (auto &input : processor.inputs) {
-      ChannelSpec channel;
-      channel.method = Connect;
-      channel.type = Sub;
-
-      // Create the channel name and find how many times we have used it.
-      auto logicalChannel = inputSpec2LogicalChannelMatcher(input);
-      auto usagesIt = outputUsages.find(logicalChannel);
-      if (usagesIt == outputUsages.end()) {
-        throw std::runtime_error("Could not find output matching" + logicalChannel.name);
-      }
-
-      // Find the maximum number of usages for the channel.
-      auto maxUsagesIt = maxOutputCounts.find(logicalChannel);
-      if (maxUsagesIt == maxOutputCounts.end()) {
-        // The previous throw should already catch this condition.
-        assert(false && "The previous check should have already caught this");
-      }
-      auto maxUsages = maxUsagesIt->second;
-
-      // Create the input channels:
-      // - Name of the channel to lookup always channel_name_<usages>
-      // - If usages is different from maxUsages, we should create a forwarding
-      // channel.
-      auto logicalInput = inputSpec2LogicalChannelMatcher(input);
-      auto currentChannelId = outputUsages.find(logicalInput);
-      if (currentChannelId == outputUsages.end()) {
-        std::runtime_error("Missing output for " + logicalInput.name);
-      }
-
-      auto physicalChannel = inputSpec2PhysicalChannelMatcher(input, currentChannelId->second);
-      auto currentPort = portMappings.find(physicalChannel);
-      if (currentPort == portMappings.end()) {
-        std::runtime_error("Missing physical channel " + physicalChannel.id);
-      }
-
-      channel.name = "in_" + physicalChannel.id;
-      channel.port = currentPort->second;
-      device.channels.push_back(channel);
-      device.inputs.insert(std::make_pair(channel.name, input));
-      // Increase the number of usages we did for a given logical channel
-      currentChannelId->second += 1;
-
-      // Here is where we create the forwarding port which can be later reused.
-      if (currentChannelId->second != maxUsages) {
-        ChannelSpec forwardedChannel;
-        forwardedChannel.method = Bind;
-        forwardedChannel.type = Pub;
-        auto physicalForward = inputSpec2PhysicalChannelMatcher(input, currentChannelId->second);
-        forwardedChannel.port = nextPort;
-        portMappings.insert(std::make_pair(physicalForward, nextPort));
-        forwardedChannel.name = physicalForward.id;
-
-        device.channels.push_back(forwardedChannel);
-        device.forwards.insert(std::make_pair(forwardedChannel.name, input));
-        nextPort++;
-      }
-    }
-    devices.push_back(device);
-  }
-}
 
 /// This creates a string to configure channels of a FairMQDevice
 /// FIXME: support shared memory
@@ -370,7 +224,6 @@ std::string channel2String(const ChannelSpec &channel) {
   result += std::string("method=") + (channel.method == Bind ? "bind" : "connect") + ",";
   result += std::string("address=") + (snprintf(buffer,32,addressFormat, channel.port), buffer);
 
-  std::cout << result << std::endl;
   return result;
 }
 
@@ -689,7 +542,7 @@ int doMain(int argc, char **argv, const o2::framework::WorkflowSpec & specs) {
 
   if (graphViz) {
     // Dump a graphviz representation of what I will do.
-    dumpDeviceSpec2Graphviz(deviceSpecs);
+    dumpDeviceSpec2Graphviz(std::cout, deviceSpecs);
     exit(0);
   }
 

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -507,8 +507,8 @@ int doMain(int argc, char **argv, const o2::framework::WorkflowSpec & specs) {
         char *currentOptValue = argv[ai+1];
         const std::string &validOption = "--" + spec.options[oi].name;
         if (strncmp(currentOpt, validOption.c_str(), validOption.size()) == 0) {
-          tmpArgs.push_back(strdup(validOption.c_str()));
-          tmpArgs.push_back(strdup(currentOptValue));
+          tmpArgs.emplace_back(strdup(validOption.c_str()));
+          tmpArgs.emplace_back(strdup(currentOptValue));
           control.options.insert(std::make_pair(spec.options[oi].name,
                                                 currentOptValue));
           break;

--- a/Framework/Core/test/test_Graphviz.cxx
+++ b/Framework/Core/test/test_Graphviz.cxx
@@ -1,0 +1,111 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#define BOOST_TEST_MODULE Test Framework GraphvizHelpers
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include "Framework/WorkflowSpec.h"
+#include "Framework/DeviceSpec.h"
+#include "../src/GraphvizHelpers.h"
+#include <boost/test/unit_test.hpp>
+
+
+using namespace o2::framework;
+
+AlgorithmSpec simplePipe(o2::Header::DataDescription what) {
+  return AlgorithmSpec{
+    [what](const std::vector<DataRef> inputs,
+       ServiceRegistry& services,
+       DataAllocator& allocator)
+      {
+        auto bData = allocator.newCollectionChunk<int>(OutputSpec{"TST", what, 0}, 1);
+      }
+    };
+}
+
+// This is how you can define your processing in a declarative way
+WorkflowSpec defineDataProcessing() {
+  return {
+  {
+    "A",
+    Inputs{},
+    Outputs{
+      {"TST", "A1", OutputSpec::Timeframe},
+      {"TST", "A2", OutputSpec::Timeframe}
+    },
+    AlgorithmSpec{
+      [](const std::vector<DataRef> inputs,
+         ServiceRegistry& services,
+         DataAllocator& allocator) {
+       sleep(1);
+       auto aData = allocator.newCollectionChunk<int>(OutputSpec{"TST", "A1", 0}, 1);
+       auto bData = allocator.newCollectionChunk<int>(OutputSpec{"TST", "A2", 0}, 1);
+      }
+    }
+  },
+  {
+    "B",
+    Inputs{{"TST", "A1", InputSpec::Timeframe}},
+    Outputs{{"TST", "B1", OutputSpec::Timeframe}},
+    simplePipe(o2::Header::DataDescription{"B1"})
+  },
+  {
+    "C",
+    Inputs{{"TST", "A2", InputSpec::Timeframe}},
+    Outputs{{"TST", "C1", OutputSpec::Timeframe}},
+    simplePipe(o2::Header::DataDescription{"C1"})
+  },
+  {
+    "D",
+    Inputs{
+      {"TST", "B1", InputSpec::Timeframe},
+      {"TST", "C1", InputSpec::Timeframe},
+    },
+    Outputs{},
+    AlgorithmSpec{
+      [](const std::vector<DataRef> inputs,
+         ServiceRegistry& services,
+         DataAllocator& allocator) {
+      },
+    }
+  }
+  };
+}
+
+BOOST_AUTO_TEST_CASE(TestGraphviz) {
+  auto workflow = defineDataProcessing();
+  std::ostringstream str;
+  auto expectedResult = R"EXPECTED(digraph structs {
+  node[shape=record]
+  struct [label="A"];
+  struct [label="B"];
+  struct [label="C"];
+  struct [label="D"];
+}
+)EXPECTED";
+  dumpDataProcessorSpec2Graphviz(str, workflow);
+  BOOST_CHECK(str.str() == expectedResult);
+  std::vector<DeviceSpec> devices;
+  dataProcessorSpecs2DeviceSpecs(workflow, devices);
+  str.str("");
+  dumpDeviceSpec2Graphviz(str, devices);
+  BOOST_CHECK(str.str() == R"EXPECTED(digraph structs {
+  node[shape=record]
+  A [label="{{}|A(2)|{<out_TST_A1_0_0>out_TST_A1_0_0|<out_TST_A2_0_0>out_TST_A2_0_0}}"];
+  B [label="{{<in_out_TST_A1_0_0>in_out_TST_A1_0_0}|B(2)|{<out_TST_B1_0_0>out_TST_B1_0_0}}"];
+  C [label="{{<in_out_TST_A2_0_0>in_out_TST_A2_0_0}|C(2)|{<out_TST_C1_0_0>out_TST_C1_0_0}}"];
+  D [label="{{<in_out_TST_B1_0_0>in_out_TST_B1_0_0|<in_out_TST_C1_0_0>in_out_TST_C1_0_0}|D(2)|{}}"];
+  A:out_TST_A1_0_0-> B:in_out_TST_A1_0_0 [label="22000"]
+  A:out_TST_A2_0_0-> C:in_out_TST_A2_0_0 [label="22001"]
+  B:out_TST_B1_0_0-> D:in_out_TST_B1_0_0 [label="22002"]
+  C:out_TST_C1_0_0-> D:in_out_TST_C1_0_0 [label="22003"]
+}
+)EXPECTED");
+}

--- a/Framework/Core/test/test_Graphviz.cxx
+++ b/Framework/Core/test/test_Graphviz.cxx
@@ -98,14 +98,14 @@ BOOST_AUTO_TEST_CASE(TestGraphviz) {
   dumpDeviceSpec2Graphviz(str, devices);
   BOOST_CHECK(str.str() == R"EXPECTED(digraph structs {
   node[shape=record]
-  A [label="{{}|A(2)|{<out_TST_A1_0_0>out_TST_A1_0_0|<out_TST_A2_0_0>out_TST_A2_0_0}}"];
-  B [label="{{<in_out_TST_A1_0_0>in_out_TST_A1_0_0}|B(2)|{<out_TST_B1_0_0>out_TST_B1_0_0}}"];
-  C [label="{{<in_out_TST_A2_0_0>in_out_TST_A2_0_0}|C(2)|{<out_TST_C1_0_0>out_TST_C1_0_0}}"];
-  D [label="{{<in_out_TST_B1_0_0>in_out_TST_B1_0_0|<in_out_TST_C1_0_0>in_out_TST_C1_0_0}|D(2)|{}}"];
-  A:out_TST_A1_0_0-> B:in_out_TST_A1_0_0 [label="22000"]
-  A:out_TST_A2_0_0-> C:in_out_TST_A2_0_0 [label="22001"]
-  B:out_TST_B1_0_0-> D:in_out_TST_B1_0_0 [label="22002"]
-  C:out_TST_C1_0_0-> D:in_out_TST_C1_0_0 [label="22003"]
+  A [label="{{}|A(2)|{<out_TST_A1_0>out_TST_A1_0|<out_TST_A2_0>out_TST_A2_0}}"];
+  B [label="{{<in_out_TST_A1_0>in_out_TST_A1_0}|B(2)|{<out_TST_B1_0>out_TST_B1_0}}"];
+  C [label="{{<in_out_TST_A2_0>in_out_TST_A2_0}|C(2)|{<out_TST_C1_0>out_TST_C1_0}}"];
+  D [label="{{<in_out_TST_B1_0>in_out_TST_B1_0|<in_out_TST_C1_0>in_out_TST_C1_0}|D(2)|{}}"];
+  A:out_TST_A1_0-> B:in_out_TST_A1_0 [label="22000"]
+  A:out_TST_A2_0-> C:in_out_TST_A2_0 [label="22001"]
+  B:out_TST_B1_0-> D:in_out_TST_B1_0 [label="22002"]
+  C:out_TST_C1_0-> D:in_out_TST_C1_0 [label="22003"]
 }
 )EXPECTED");
 }


### PR DESCRIPTION
This refactor code so that an actual test for the Graphviz output is
possible (and provided). This is nice because it basically as well
allows to test the DataProcessorSpec to DeviceSpec conversion in a
sandboxed manner.