### PR TITLE
Add parallel / merge constructs to workflow

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -37,6 +37,7 @@ set(SRCS
     src/LocalRootFileService.cxx
     src/SimpleMetricsService.cxx
     src/TextControlService.cxx
+    src/WorkflowSpec.cxx
     src/runDataProcessing.cxx
     ${GUI_SOURCES}
    )
@@ -72,6 +73,7 @@ set(TEST_SRCS
       test/test_SuppressionGenerator.cxx
       test/test_SingleDataSource.cxx
       test/test_Graphviz.cxx
+      test/test_ParallelProducer.cxx
    )
 
 O2_GENERATE_TESTS(

--- a/Framework/Core/README.md
+++ b/Framework/Core/README.md
@@ -184,20 +184,20 @@ Data flow parallelism is simply expressed by tuning the data flow, adding explic
     DataProcessorSpec{
       "tpc_processor_1",
       Inputs{},
-      Outputs{{"TPC", "CLUSTERS", SubSpec(1)}},
+      Outputs{{"TPC", "CLUSTERS", SubSpec(0)}},
       ...
     },
     DataProcessorSpec{
       "tpc_processor_2",
       Inputs{},
-      Outputs{{"TPC", "CLUSTERS", SubSpec(2)}},
+      Outputs{{"TPC", "CLUSTERS", SubSpec(1)}},
       ...
     }
     ...
     DataProcessorSpec{
       "tpc_processor_18",
       Inputs{},
-      Outputs{{"TPC", "CLUSTERS", SubSpec(18)}},
+      Outputs{{"TPC", "CLUSTERS", SubSpec(17)}},
       ...
     }
 

--- a/Framework/Core/README.md
+++ b/Framework/Core/README.md
@@ -73,6 +73,7 @@ Similarly the `requiredServices` vector would define which services are required
 The `algorithm` property, of `AlgorithmSpec` is instead used to specify the actual computation. Notice that the same `DataProcessorSpec` can used different `AlgorithmSpec`. The rationale for this is that while inputs and outputs might be the same, you might want to compare different versions of your algorithm. The `AlgorithmSpec` resembles the following:
 
 
+
     struct AlgorithmSpec {
       using ProcessCallback = std::function<void(const std::vector<DataRef>, ServiceRegistry&, DataAllocator&)>;
       using InitCallback = std::function<ProcessCallback(const ConfigParamRegistry &, ServiceRegistry &)>;
@@ -95,8 +96,8 @@ The `onProcess` function is to be used for stateless computations. It’s a free
 
     AlgorithmSpec{
       InitiCallBack{[](const ConfigParamRegistry &, ServiceRegistry &){
-          auto statefulGeo = std::make_unique<TGeo>();
-          return [geo = std::move(statefulGeo)](const std::vector<DataRef>, ServiceRegistry&, DataAllocator&) {
+          auto statefulGeo = std::make_shared<TGeo>();
+          return [geo = statefulGeo](const std::vector<DataRef>, ServiceRegistry&, DataAllocator&) {
             // do something with geo
           };
         }
@@ -182,12 +183,21 @@ Data flow parallelism is simply expressed by tuning the data flow, adding explic
 
     DataProcessorSpec{
       "tpc_processor_1",
-      {InputSpec{"TPC", "CLUSTERS", SubSpec(1)}},
+      Inputs{},
+      Outputs{{"TPC", "CLUSTERS", SubSpec(1)}},
       ...
     },
     DataProcessorSpec{
       "tpc_processor_2",
-      InputSpec{"TPC", "CLUSTERS", SubSpec(2)},
+      Inputs{},
+      Outputs{{"TPC", "CLUSTERS", SubSpec(2)}},
+      ...
+    }
+    ...
+    DataProcessorSpec{
+      "tpc_processor_18",
+      Inputs{},
+      Outputs{{"TPC", "CLUSTERS", SubSpec(18)}},
       ...
     }
 
@@ -199,11 +209,40 @@ or alternatively the parallel workflows part could be generated programmatically
         "tpc_processor",
         {InputSpec{"TPC", "CLUSTERS"}}
       },
-      ParallelInput{"TPC", "CLUSTERS"},  // For each InputSpec matching the signature
-      [](){return {SubSpec(1), SubSpec(2)}} // Replace it with two copies, where subspecification is SubSpec(1) and SubSpec(2) respectively.
+      18,
+      [](DataProcessorSpec &spec, size_t idx) {
+        spec.outputs[0].subSpec = idx; // Each of the 18 DataProcessorSpecs should have a different subSpec
+      }
     )
 
+Similarly this can be done for a component that merges inputs from multiple parallel devices, this time by modifying programmatically the `Inputs`:
 
+
+    ...
+    DataProcessorSpec{
+      "merger",
+      mergeInputs({"TST", "A", InputSpec::Timeframe},
+                  4,
+                  [](InputSpec &input, size_t index) {
+                     input.subSpec = index;
+                  }
+              ),
+      {},
+      AlgorithmSpec{[](const ConfigParamRegistry &params, ServiceRegistry &registry) {
+         return [](const std::vector<DataRef> inputs,
+                   ServiceRegistry& services,
+                   DataAllocator& allocator) {
+      // Create a single output.
+        LOG(DEBUG) << "Invoked" << std::endl;
+      };
+    }
+    ...
+
+When you declare a parallel set of devices you can retrieve the rank (i.e. parallel id) or the number of parallel devices by using the `ParalleContext`, which can be retrieved from the `ServiceRegistry` (see also the `Services`  section below), e.g.:
+
+
+    size_t whoAmI = services.get<ParallelContext>().index1D();
+    size_t howManyAreWe = services.get<ParallelContext>().index1DSize();
 # Services
 
 Services are utility classes which `DataProcessor`s can access to request out-of-bound, deployment dependent, functionalities. For example a service could be used to post metrics to the monitoring system or to get a GPU context. The former would be dependent on whether you are running on your laptop (where monitoring could simply mean print out metrics on the command line) or in a large cluster (where monitoring probably means to send metrics to an aggregator device which then pushes them to the backend.
@@ -285,6 +324,9 @@ however, no API is provided to explicitly send it. All the created DataChunks ar
   - CPUTimer
   - File Reader
   - File Writer
+  - Monitoring
+  - Logging
+  - ParallelContext
 - Thorsten: how do we express data parallelism?
 - Thorsten: should configuration come always from the ccdb?
 - Thorsten: should allow to specify that certain things are processed with the same CCDB conditions.
@@ -299,4 +341,6 @@ however, no API is provided to explicitly send it. All the created DataChunks ar
 - Comment from David / Ruben: sometimes the input data depends on whether or not a detector is active during data taking. We would therefore need a mechanism to mask out inputs (and maybe modules) from the dataflow, based on run control. If only part of the data is available, it might make sense that we offer “fallback” callbacks which can work only on part of the data.
 - Comment from Ruben: most likely people will want to also query the CCDB directly. Does it make sense to offer CCDB querying as a service so that we can intercept (and eventually optimise) multiple queries from the same workflow?
 - Are options scoped? I.e. do we want to have that if two devices, `deviceA` and `deviceB` defining the same option (e.g. `mcEngine`) they will require / support using `--``deviceA-mcEngine` and `--``deviceB-mcEngine`?
-- Mikolaj pointed out that capture by move is possible in `C++14` lambdas, so we should use that for the stateful init.
+- ~~Mikolaj pointed out that capture by move is possible in~~ `~~C++14~~` ~~lambdas, so we should use that for the stateful init~~. Actually this is not working out as expected?
+
+

--- a/Framework/Core/include/Framework/ChannelMatching.h
+++ b/Framework/Core/include/Framework/ChannelMatching.h
@@ -33,7 +33,8 @@ struct PhysicalChannel {
 };
 
 inline LogicalChannel outputSpec2LogicalChannel(const OutputSpec &spec) {
-  return LogicalChannel{std::string("out_") + spec.origin.str + "_" + spec.description.str};
+  auto name = std::string("out_") + spec.origin.str + "_" + spec.description.str + "_" + std::to_string(spec.subSpec);
+  return LogicalChannel{name};
 }
 
 inline PhysicalChannel outputSpec2PhysicalChannel(const OutputSpec &spec, int count) {
@@ -43,7 +44,8 @@ inline PhysicalChannel outputSpec2PhysicalChannel(const OutputSpec &spec, int co
 }
 
 inline LogicalChannel inputSpec2LogicalChannelMatcher(const InputSpec &spec) {
-  return LogicalChannel{std::string("out_") + spec.origin.str + "_" + spec.description.str};
+  auto name = std::string("out_") + spec.origin.str + "_" + spec.description.str + "_" + std::to_string(spec.subSpec);
+  return LogicalChannel{name};
 }
 
 inline PhysicalChannel inputSpec2PhysicalChannelMatcher(const InputSpec&spec, int count) {
@@ -59,7 +61,6 @@ inline bool matchDataSpec2Channel(const InputSpec &spec, const LogicalChannel &c
   auto matcher = inputSpec2LogicalChannelMatcher(spec);
   return matcher.name == channel.name;
 }
-
 
 } // namespace framework
 } // namespace o2

--- a/Framework/Core/include/Framework/DataProcessorSpec.h
+++ b/Framework/Core/include/Framework/DataProcessorSpec.h
@@ -39,6 +39,12 @@ struct DataProcessorSpec {
   Options options;
   // FIXME: not used for now...
   std::vector<std::string> requiredServices;
+  // FIXME: for the moment I put them here, but it's a hack
+  //        since we do not want to expose this to users...
+  //        Maybe we should have a ParallelGroup kind of node
+  //        which embdes them and hides them from users.
+  size_t rank = 0;
+  size_t nSlots = 0;
 };
 
 } // namespace framework

--- a/Framework/Core/include/Framework/DeviceSpec.h
+++ b/Framework/Core/include/Framework/DeviceSpec.h
@@ -34,6 +34,8 @@ struct DeviceSpec {
   std::map<std::string, OutputSpec> outputs;
   std::map<std::string, InputSpec> forwards;
   std::vector<char *> args; // Calculated list of args for the device.
+  size_t rank;
+  size_t nSlots;
 };
 
 void

--- a/Framework/Core/include/Framework/ParallelContext.h
+++ b/Framework/Core/include/Framework/ParallelContext.h
@@ -14,6 +14,18 @@
 namespace o2 {
 namespace framework {
 
+/// Purpose of this class is to provide DataProcessors which
+/// have been instanciated in parallel via the o2::framework::parallel
+/// function with information relevant to the parallel execution,
+/// e.g. how many workers have been created by the above mentioned function
+/// and what's the unique id the caller is associated with.
+/// This context is exposed as a Service and it's therefore available 
+/// to both the init and the processing callbacks via:
+///
+///    auto ctx = services.get<ParallelContext>();
+///
+/// FIXME: should we have convenience methods to address workers using
+///        different parallel topology (e.g. have a index2D, rather than index1D).
 class ParallelContext {
 public:
   // FIXME: find better names... rank1D and rank1DSize?

--- a/Framework/Core/include/Framework/ParallelContext.h
+++ b/Framework/Core/include/Framework/ParallelContext.h
@@ -1,0 +1,35 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef FRAMEWORK_PARALLELCONTEXT_H
+#define FRAMEWORK_PARALLELCONTEXT_H
+
+namespace o2 {
+namespace framework {
+
+class ParallelContext {
+public:
+  // FIXME: find better names... rank1D and rank1DSize?
+  ParallelContext(size_t index1D, size_t index1DSize)
+    : mIndex1D{index1D},
+      mIndex1DSize{index1DSize}
+  {
+  }
+
+  size_t index1D() const { return mIndex1D; }
+  size_t index1DSize() const {return mIndex1DSize; };
+private:
+  size_t mIndex1D;
+  size_t mIndex1DSize;
+};
+
+}
+}
+#endif

--- a/Framework/Core/include/Framework/WorkflowSpec.h
+++ b/Framework/Core/include/Framework/WorkflowSpec.h
@@ -21,10 +21,17 @@ namespace o2 {
 namespace framework {
 using WorkflowSpec = std::vector<DataProcessorSpec>;
 
+/// The purpose of this helper is to duplicate a DataProcessorSpec @a
+/// original as many times as specified in maxIndex and to amend each
+/// instance by invoking amendCallback on them with their own @a id.
 WorkflowSpec parallel(DataProcessorSpec original,
                       size_t maxIndex,
-                      std::function<void(DataProcessorSpec&, size_t)> amendCallback);
+                      std::function<void(DataProcessorSpec&, size_t id)> amendCallback);
 
+/// The purpose of this helper is to duplicate an InputSpec @a original
+/// as many times as specified in maxIndex and to amend each instance
+/// by invoking amendCallback on them with their own @a id. This can be
+/// used to programmatically create mergers.
 Inputs mergeInputs(InputSpec original,
                    size_t maxIndex,
                    std::function<void(InputSpec&, size_t)> amendCallback);

--- a/Framework/Core/src/DeviceSpec.cxx
+++ b/Framework/Core/src/DeviceSpec.cxx
@@ -60,6 +60,8 @@ dataProcessorSpecs2DeviceSpecs(const o2::framework::WorkflowSpec &workflow,
     device.id = processor.name;
     device.algorithm = processor.algorithm;
     device.options = processor.options;
+    device.rank = processor.rank;
+    device.nSlots = processor.nSlots;
 
     // Channels which need to be forwarded (because they are used by
     // a downstream provider).

--- a/Framework/Core/src/WorkflowSpec.cxx
+++ b/Framework/Core/src/WorkflowSpec.cxx
@@ -7,28 +7,39 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#ifndef FRAMEWORK_WORKFLOW_SPEC_H
-#define FRAMEWORK_WORKFLOW_SPEC_H
-
+#include "Framework/WorkflowSpec.h"
 #include "Framework/DataProcessorSpec.h"
-#include "Framework/AlgorithmSpec.h"
-
-#include <vector>
 #include <functional>
+#include <string>
 #include <cstddef>
 
 namespace o2 {
 namespace framework {
-using WorkflowSpec = std::vector<DataProcessorSpec>;
 
 WorkflowSpec parallel(DataProcessorSpec original,
                       size_t maxIndex,
-                      std::function<void(DataProcessorSpec&, size_t)> amendCallback);
+                      std::function<void(DataProcessorSpec&, size_t)> amendCallback) {
+  WorkflowSpec results;
+  for (size_t i = 0; i < maxIndex; ++i) {
+    results.push_back(original);
+    results.back().name = original.name + "_" + std::to_string(i);
+    results.back().rank = i;
+    results.back().nSlots = maxIndex;
+    amendCallback(results.back(), i);
+  }
+  return results;
+}
 
 Inputs mergeInputs(InputSpec original,
                    size_t maxIndex,
-                   std::function<void(InputSpec&, size_t)> amendCallback);
-}
+                   std::function<void(InputSpec &, size_t)> amendCallback) {
+  Inputs results;
+  for (size_t i = 0; i < maxIndex; ++i) {
+    results.push_back(original);
+    amendCallback(results.back(), i);
+  }
+  return results;
 }
 
-#endif // FRAMEWORK_WORKFLOW_SPEC_H
+} // namespace framework
+} // namespace o2

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -23,6 +23,7 @@
 #include "Framework/WorkflowSpec.h"
 #include "Framework/LocalRootFileService.h"
 #include "Framework/TextControlService.h"
+#include "Framework/ParallelContext.h"
 
 #include "GraphvizHelpers.h"
 #include "DDSConfigHelpers.h"
@@ -245,6 +246,7 @@ int doChild(int argc, char **argv, const o2::framework::DeviceSpec &spec) {
     serviceRegistry.registerService<MetricsService>(new SimpleMetricsService());
     serviceRegistry.registerService<RootFileService>(new LocalRootFileService());
     serviceRegistry.registerService<ControlService>(new TextControlService());
+    serviceRegistry.registerService<ParallelContext>(new ParallelContext(spec.rank, spec.nSlots));
 
     std::unique_ptr<FairMQDevice> device;
     if (spec.inputs.empty()) {

--- a/Framework/Core/test/test_Graphviz.cxx
+++ b/Framework/Core/test/test_Graphviz.cxx
@@ -98,14 +98,14 @@ BOOST_AUTO_TEST_CASE(TestGraphviz) {
   dumpDeviceSpec2Graphviz(str, devices);
   BOOST_CHECK(str.str() == R"EXPECTED(digraph structs {
   node[shape=record]
-  A [label="{{}|A(2)|{<out_TST_A1_0>out_TST_A1_0|<out_TST_A2_0>out_TST_A2_0}}"];
-  B [label="{{<in_out_TST_A1_0>in_out_TST_A1_0}|B(2)|{<out_TST_B1_0>out_TST_B1_0}}"];
-  C [label="{{<in_out_TST_A2_0>in_out_TST_A2_0}|C(2)|{<out_TST_C1_0>out_TST_C1_0}}"];
-  D [label="{{<in_out_TST_B1_0>in_out_TST_B1_0|<in_out_TST_C1_0>in_out_TST_C1_0}|D(2)|{}}"];
-  A:out_TST_A1_0-> B:in_out_TST_A1_0 [label="22000"]
-  A:out_TST_A2_0-> C:in_out_TST_A2_0 [label="22001"]
-  B:out_TST_B1_0-> D:in_out_TST_B1_0 [label="22002"]
-  C:out_TST_C1_0-> D:in_out_TST_C1_0 [label="22003"]
+  A [label="{{}|A(2)|{<out_TST_A1_0_0>out_TST_A1_0_0|<out_TST_A2_0_0>out_TST_A2_0_0}}"];
+  B [label="{{<in_out_TST_A1_0_0>in_out_TST_A1_0_0}|B(2)|{<out_TST_B1_0_0>out_TST_B1_0_0}}"];
+  C [label="{{<in_out_TST_A2_0_0>in_out_TST_A2_0_0}|C(2)|{<out_TST_C1_0_0>out_TST_C1_0_0}}"];
+  D [label="{{<in_out_TST_B1_0_0>in_out_TST_B1_0_0|<in_out_TST_C1_0_0>in_out_TST_C1_0_0}|D(2)|{}}"];
+  A:out_TST_A1_0_0-> B:in_out_TST_A1_0_0 [label="22000"]
+  A:out_TST_A2_0_0-> C:in_out_TST_A2_0_0 [label="22001"]
+  B:out_TST_B1_0_0-> D:in_out_TST_B1_0_0 [label="22002"]
+  C:out_TST_C1_0_0-> D:in_out_TST_C1_0_0 [label="22003"]
 }
 )EXPECTED");
 }

--- a/Framework/Core/test/test_ParallelProducer.cxx
+++ b/Framework/Core/test/test_ParallelProducer.cxx
@@ -1,0 +1,85 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/DataRefUtils.h"
+#include "Framework/AlgorithmSpec.h"
+#include "Framework/ServiceRegistry.h"
+#include "Framework/runDataProcessing.h"
+#include "Framework/MetricsService.h"
+#include "Framework/ControlService.h"
+#include "Framework/WorkflowSpec.h"
+#include "Framework/ParallelContext.h"
+#include "FairMQLogger.h"
+
+using namespace o2::framework;
+using DataHeader = o2::Header::DataHeader;
+
+using Inputs = std::vector<InputSpec>;
+using Outputs = std::vector<OutputSpec>;
+
+
+DataProcessorSpec templateProducer() {
+  return {
+    "some-producer",
+    Inputs{},
+    Outputs{
+      {"TST", "A", 0, OutputSpec::Timeframe},
+    },
+    // The producer is stateful, we use a static for the state in this
+    // particular case, but a Singleton or a captured new object would
+    // work as well.
+    AlgorithmSpec{[](const ConfigParamRegistry &params, ServiceRegistry &registry) {
+      srandom(registry.get<ParallelContext>().index1D());
+      return [](const std::vector<DataRef> inputs,
+                ServiceRegistry& services,
+                DataAllocator& allocator) {
+          // Create a single output. 
+          size_t index = services.get<ParallelContext>().index1D();
+          sleep(1);
+          auto aData = allocator.newCollectionChunk<int>(OutputSpec{"TST", "A", index}, 1);
+        };
+      }
+    }
+  };
+}
+
+// This is a simple consumer / producer workflow where both are
+// stateful, i.e. they have context which comes from their initialization.
+void defineDataProcessing(WorkflowSpec &specs) {
+  // This is an example of how we can parallelize by subSpec.
+  // templatedProducer will be instanciated 32 times and the lambda function
+  // passed to the parallel statement will be applied to each one of the
+  // instances in order to modify it. Parallel will also make sure the name of
+  // the instance is amended from "some-producer" to "some-producer-<index>".
+  WorkflowSpec workflow = parallel(templateProducer(), 4, [](DataProcessorSpec &spec, size_t index) {
+      spec.outputs[0].subSpec = index;
+    }
+  );
+  workflow.push_back(DataProcessorSpec{
+      "merger",
+      mergeInputs({"TST", "A", InputSpec::Timeframe},
+                  4,
+                  [](InputSpec &input, size_t index){
+                     input.subSpec = index;
+                  }
+                 ),
+      {},
+      AlgorithmSpec{[](const ConfigParamRegistry &params, ServiceRegistry &registry) {
+        return [](const std::vector<DataRef> inputs,
+                  ServiceRegistry& services,
+                  DataAllocator& allocator) {
+            // Create a single output.
+            LOG(DEBUG) << "Invoked" << std::endl;
+          };
+        }
+      }
+  });
+
+  specs.swap(workflow);
+}

--- a/Framework/Core/test/test_ParallelProducer.cxx
+++ b/Framework/Core/test/test_ParallelProducer.cxx
@@ -35,7 +35,6 @@ DataProcessorSpec templateProducer() {
     // particular case, but a Singleton or a captured new object would
     // work as well.
     AlgorithmSpec{[](const ConfigParamRegistry &params, ServiceRegistry &registry) {
-      srandom(registry.get<ParallelContext>().index1D());
       return [](const std::vector<DataRef> inputs,
                 ServiceRegistry& services,
                 DataAllocator& allocator) {
@@ -43,6 +42,7 @@ DataProcessorSpec templateProducer() {
           size_t index = services.get<ParallelContext>().index1D();
           sleep(1);
           auto aData = allocator.newCollectionChunk<int>(OutputSpec{"TST", "A", index}, 1);
+          services.get<ControlService>().readyToQuit(true);
         };
       }
     }


### PR DESCRIPTION
This is a first attempt at allowing expressing parallel processing
and merging of multiple streams of data in the declarative workflow.

It introduces two helper functions:

    o2::framework::parallel(...)

which allows duplicating and amending a template DataProcessorSpec,
and

    o2::framework::mergeInputs(..)

which allows for duplicating InputSpec of a given device. Context
information for parallel computations (e.g. rank and number of parallel
devices) can be retrieved in the `ProcessCallback` via the
`ParallelContext` service.