### PR TITLE
Adding a frame collection parser and heartbeat sequence container

### DIFF
--- a/DataFormats/Headers/CMakeLists.txt
+++ b/DataFormats/Headers/CMakeLists.txt
@@ -25,6 +25,7 @@ O2_GENERATE_LIBRARY()
 set(TEST_SRCS
   test/testDataHeader.cxx
   test/testTimeStamp.cxx
+  test/test_HeartbeatFrame.cxx
 )
 
 O2_GENERATE_TESTS(

--- a/DataFormats/Headers/include/Headers/HeartbeatFrame.h
+++ b/DataFormats/Headers/include/Headers/HeartbeatFrame.h
@@ -19,6 +19,8 @@
 // @brief  Definition of the heartbeat frame layout
 
 #include "Headers/DataHeader.h"
+#include <map>
+#include <vector>
 
 namespace o2 {
 namespace Header {
@@ -48,24 +50,31 @@ struct HeartbeatHeader
     // the complete 64 bit header word, initialize with blockType 1 and size 1
     uint64_t headerWord = 0x1100000000000000;
     struct {
-	// bit 0 to 31: orbit number
-	uint32_t orbit;
-	// bit 32 to 43: bunch crossing id
-	uint16_t bcid:12;
-	// bit 44 to 47: reserved
-	uint16_t reserved:4;
-	// bit 48 to 51: trigger type
-	uint8_t triggerType:4;
-	// bit 52 to 55: reserved
-	uint8_t reservedTriggerType:4;
-	// bit 56 to 59: header length
-	uint8_t headerLength:4;
-	// bit 60 to 63: block type (=1 HBF/trigger Header)
-	uint8_t blockType:4;
+        // bit 0 to 31: orbit number
+        uint32_t orbit;
+        // bit 32 to 43: bunch crossing id
+        uint16_t bcid:12;
+        // bit 44 to 47: reserved
+        uint16_t reserved:4;
+        // bit 48 to 51: trigger type
+        uint8_t triggerType:4;
+        // bit 52 to 55: reserved
+        uint8_t reservedTriggerType:4;
+        // bit 56 to 59: header length
+        uint8_t headerLength:4;
+        // bit 60 to 63: block type (=1 HBF/trigger Header)
+        uint8_t blockType:4;
     };
+
   };
 
   operator bool() const {return headerWord != 0 && blockType == 0x1;}
+
+  bool operator<(const HeartbeatHeader& other) const {
+    return this->orbit < other.orbit;
+  }
+
+  operator uint64_t() const {return headerWord;}
 };
 
 struct HeartbeatTrailer
@@ -74,24 +83,26 @@ struct HeartbeatTrailer
     // the complete 64 bit trailer word, initialize with blockType 5 and size 1
     uint64_t trailerWord = 0x5100000000000000;
     struct {
-	// bit 0 to 31: data length in words
-	uint32_t dataLength;
-	// bit 32 to 52: detector specific status words
-	uint32_t status:21;
-	// bit 53: =1 in case a new physics trigger arrived within read-out period
-	uint16_t hbfTruncated:1;
-	// bit 54: =0 HBF correctly transmitted
-	uint16_t hbfStatus:1;
-	// bit 55: =1 HBa/0 HBr received
-	uint16_t hbAccept:1;
-	// bit 56 to 59: trailer length
-	uint16_t trailerLength:4;
-	// bit 60 to 63: block type (=5 HBF Trailer)
-	uint8_t blockType:4;
+        // bit 0 to 31: data length in words
+        uint32_t dataLength;
+        // bit 32 to 52: detector specific status words
+        uint32_t status:21;
+        // bit 53: =1 in case a new physics trigger arrived within read-out period
+        uint16_t hbfTruncated:1;
+        // bit 54: =0 HBF correctly transmitted
+        uint16_t hbfStatus:1;
+        // bit 55: =1 HBa/0 HBr received
+        uint16_t hbAccept:1;
+        // bit 56 to 59: trailer length
+        uint16_t trailerLength:4;
+        // bit 60 to 63: block type (=5 HBF Trailer)
+        uint8_t blockType:4;
     };
   };
 
   operator bool() const {return trailerWord != 0 && blockType == 0x5;}
+
+  operator uint64_t() const {return trailerWord;}
 };
 
 // composite struct for the HBH and HBT which are the envelope for the payload
@@ -128,6 +139,343 @@ struct HeartbeatStatistics
   uint64_t durationNanoSeconds;
 
   HeartbeatStatistics() : timeTickNanoSeconds(0), durationNanoSeconds(0) {}
+};
+
+/**
+ * @class ReverseParser
+ * Parser for a sequence of frames with header, trailer and variable payload.
+ * The size is expected to be part of the trailer, the parsing is thus in
+ * reverse direction.
+ */
+template<typename HeaderT, typename TrailerT>
+class ReverseParser {
+public:
+  using HeaderType = HeaderT;
+  using TrailerType = TrailerT;
+
+  struct FrameEntry {
+    const HeaderType* header = nullptr;
+    const TrailerType* trailer = nullptr;
+    const byte* payload = nullptr;
+    size_t length = 0;
+  };
+  static const size_t envelopeLength = sizeof(HeaderType) + sizeof(TrailerType);
+
+  using CheckHeaderFct = std::function<bool(const HeaderType*)>;
+  using CheckTrailerFct = std::function<bool(const TrailerType*)>;
+  using GetFrameSizeFct = std::function<size_t(const TrailerType& )>;
+  using InsertFct = std::function<bool(FrameEntry )>;
+
+  int parse(const byte* buffer, size_t bufferSize,
+            CheckHeaderFct checkHeader,
+            CheckTrailerFct checkTrailer,
+            GetFrameSizeFct getFrameSize,
+            InsertFct insert) {
+    if (buffer == nullptr || bufferSize == 0) return 0;
+    unsigned nFrames = 0;
+    auto position = bufferSize;
+    do {
+      FrameEntry entry;
+      if (sizeof(TrailerType) > position) break;
+      entry.trailer = reinterpret_cast<const TrailerType*>(buffer + position - sizeof(TrailerType));
+      if (!checkTrailer(entry.trailer)) break;
+      auto frameSize = getFrameSize(*entry.trailer);
+      if (frameSize > position) break;
+      entry.header = reinterpret_cast<const HeaderType*>(buffer + position - frameSize);
+      if (!checkHeader(entry.header)) break;
+      entry.payload = reinterpret_cast<const byte*>(entry.header + 1);
+      entry.length = frameSize - sizeof(HeaderType) - sizeof(TrailerType);
+      if (!insert(entry)) break;
+      ++nFrames;
+      position -= frameSize;
+    } while (position > 0);
+
+    if (position == 0) {
+      // frames found and format consistent
+      return nFrames;
+    } else if (nFrames == 0) {
+      // no frames found at all, th buffer does not contain any
+      return 0;
+    }
+
+    // format error detected
+    // TODO: decide about error policy
+    return -1;
+  }
+};
+
+/**
+ * @class HeartbeatFrameSequence
+ * Container class for multiple sequences of heartbeat frames
+ *
+ * Multiple sequences can be added as "slot", a descriptive data
+ * structure per slot of type specified as template parameter can
+ * be provided. Each sequence of heartbeatframes is passed recursively
+ * to extract information about the individual heartbeatframes in the
+ * sequence. An index is created with the slots as rows and the frames
+ * as columns.
+ */
+template<typename SlotDataT>
+class HeartbeatFrameSequence {
+public:
+  HeartbeatFrameSequence() {}
+  ~HeartbeatFrameSequence() = default;
+
+  using SlotDataType = SlotDataT;
+  using ColumnIndexType = HeartbeatHeader;
+
+  /// FrameIndex is composed from HB header and slot number
+  struct FrameIndex {
+    ColumnIndexType columnIndex;
+    unsigned slot;
+
+    bool operator<(const FrameIndex& other) const {
+      // std::map.find uses the logic !(a < b) && !(b < a)
+      // have to combine the two fields in one variable for
+      // comparison
+      uint64_t us = columnIndex;
+      us &= 0x00000fffffffffff;
+      us <<= 20;
+      us |= slot & 0xfffff;
+      uint64_t them = other.columnIndex;
+      them &= 0x00000fffffffffff;
+      them <<= 20;
+      them |= other.slot & 0xfffff;
+      return us < them;
+    }
+  };
+
+  /// descriptor pointing to one frame
+  struct FrameData {
+    const byte* buffer = nullptr;
+    size_t size = 0;
+  };
+
+  /**
+   * Add a new data sequence, the set is parsed recursively
+   *
+   * @param slotData   Descriptive data struct for the sequence
+   * @param seqData    Pointer to sequence
+   * @param seqSize    Length of sequence
+   * @return number of inserted elements
+   */
+  size_t addSlot(SlotDataType slotData, byte* seqData, size_t seqSize) {
+    unsigned nFrames = mFrames.size();
+    unsigned currentSlot = mSlotData.size();
+    mSlotData.emplace_back(slotData);
+    using ParserT = o2::Header::ReverseParser<HeartbeatHeader, HeartbeatTrailer>;
+    ParserT p;
+    p.parse(seqData, seqSize,
+            [](const typename ParserT::HeaderType* h) {return (*h);},
+            [](const typename ParserT::TrailerType* t) {return (*t);},
+            [](const typename ParserT::TrailerType& t) {
+              return t.dataLength + ParserT::envelopeLength;
+            },
+            [this, currentSlot](typename ParserT::FrameEntry entry) {
+              // insert the heartbeat header as column index in ascending
+              // order
+              auto position = mColumns.begin();
+              while (position != mColumns.end() && *position < *entry.header) {
+                position++;
+              }
+              if (position == mColumns.end() || *entry.header < *position) {
+                mColumns.emplace(position, *entry.header);
+              }
+
+              // insert frame descriptor under key composed from header and slot
+              auto result = mFrames.emplace(FrameIndex{*entry.header, currentSlot},
+                                            FrameData{entry.payload, entry.length});
+              return result.second;
+            }
+            );
+    return mFrames.size() - nFrames;
+  }
+
+  /// clear the index, i.e. all internal lists
+  void clear() {
+    mFrames.clear();
+    mColumns.clear();
+    mSlotData.clear();
+  }
+
+  /// get number of columns in the created index
+  size_t getNColumns() const {return mColumns.size();}
+
+  /// get number of slots, i.e. number rows in the created index
+  size_t getNSlots() const {return mSlotData.size();}
+
+  /// get slot data for a data set
+  const SlotDataType& getSlotData(size_t slot) const {
+    if (slot < mSlotData.size()) return mSlotData[slot];
+    // TODO: better to throw exception?
+    static SlotDataType dummy;
+    return dummy;
+  }
+
+  // TODO:
+  // instead of a member with this pointer of parent class, the access
+  // function was supposed to be specified as a lambda. This definition
+  // was supposed to be the type of the function member.
+  // passing the access function to the iterator did not work because
+  // the typedef for the access function is without the capture, so there
+  // is no matching conversion.
+  // Solution would be to use std::function but that's probably slow and
+  // the function is called often. Can be checked later.
+  typedef FrameData (*AccessFct)(unsigned, unsigned);
+
+  /// Iterator class for configurable direction, i.e. either row or column
+  class iterator { // TODO: derive from forward_iterator
+  public:
+    using self_type = iterator;
+    using value_type = FrameData;
+
+    enum IteratorDirections {
+      kAlongRow,
+      kAlongColumn
+    };
+
+    iterator() = delete;
+    ~iterator() = default;
+    iterator(IteratorDirections direction, HeartbeatFrameSequence* parent, unsigned row = 0, unsigned column = 0)
+      : mDirection(direction)
+      , mRow(row)
+      , mColumn(column)
+      , mEnd(direction==kAlongRow?parent->getNColumns():parent->getNSlots())
+      , mParent(parent)
+      , mCache()
+      , mIsCached(false)
+    {
+      while (!isValid() && !isEnd()) operator++();
+    }
+
+    self_type& operator++() {
+      mIsCached = false;
+      if (mDirection==kAlongRow) {
+        if (mColumn<mEnd) mColumn++;
+      } else {
+        if (mRow<mEnd) mRow++;
+      }
+      while (!isEnd() && !isValid()) operator++();
+      return *this;
+    }
+
+    value_type operator*() const {
+      if (!mIsCached) {
+        self_type* ncthis = const_cast<self_type*>(this);
+        mParent->get(mRow, mColumn, ncthis->mCache);
+        ncthis->mIsCached = true;
+      }
+      return mCache;
+    }
+
+    bool operator==(const self_type& other) const {
+      return mDirection==kAlongRow?(mColumn == other.mColumn):(mRow == other.mRow);
+    }
+
+    bool operator!=(const self_type& other) const {
+      return mDirection==kAlongRow?(mColumn != other.mColumn):(mRow != other.mRow);
+    }
+
+    bool isEnd() const {
+      return (mDirection==kAlongRow)?(mColumn>=mEnd):(mRow>=mEnd);
+    }
+
+    bool isValid() const {
+      if (!mIsCached) {
+        self_type* ncthis = const_cast<self_type*>(this);
+        ncthis->mIsCached = mParent->get(mRow, mColumn, ncthis->mCache);
+      }
+      return mIsCached;
+    }
+
+    const SlotDataType& getSlotData() const {
+      static SlotDataType invalid;
+      return invalid;
+    }
+
+  protected:
+    IteratorDirections mDirection;
+    unsigned mRow;
+    unsigned mColumn;
+    unsigned mEnd;
+    HeartbeatFrameSequence* mParent;
+    value_type mCache;
+    bool mIsCached;
+  };
+
+  /// iterator for the outer access of the index, either row or column direction
+  template<unsigned Direction>
+  class outerIterator : public iterator {
+  public:
+    using base = iterator;
+    using value_type = typename base::value_type;
+    using self_type = outerIterator;
+    static const unsigned direction = Direction;
+
+    outerIterator() = delete;
+    ~outerIterator() = default;
+    outerIterator(HeartbeatFrameSequence* parent, unsigned index)
+      : iterator(typename iterator::IteratorDirections(direction), parent, direction==iterator::kAlongColumn?index:0, direction==iterator::kAlongRow?index:0) {
+    }
+
+    self_type& operator++() {
+      if (base::mDirection==iterator::kAlongRow) {
+        if (base::mColumn<base::mEnd) base::mColumn++;
+      } else {
+        if (base::mRow<base::mEnd) base::mRow++;
+      }
+      return *this;
+    }
+
+    /// begin the inner iteration
+    iterator begin() {
+      return iterator((base::mDirection==iterator::kAlongColumn)?iterator::kAlongRow:iterator::kAlongColumn,
+                      base::mParent,
+                      (base::mDirection==iterator::kAlongColumn)?base::mRow:0,
+                      (base::mDirection==iterator::kAlongRow)?base::mColumn:0);
+    }
+
+    /// end of the inner iteration
+    iterator end() {
+      return iterator((base::mDirection==iterator::kAlongColumn)?iterator::kAlongRow:iterator::kAlongColumn,
+                      base::mParent,
+                      (base::mDirection==iterator::kAlongRow)?base::mParent->getNSlots():0,
+                      (base::mDirection==iterator::kAlongColumn)?base::mParent->getNColumns():0);
+    }
+  };
+
+  /// definition of the outer iterator over column
+  using columnIterator = outerIterator<iterator::kAlongRow>;
+  /// definition of the outer iterator over row
+  using rowIterator = outerIterator<iterator::kAlongColumn>;
+
+  /// begin of the outer iteration
+  columnIterator begin() {
+    return columnIterator(this, 0);
+  }
+
+  /// end of outer iteration
+  columnIterator end() {
+    return columnIterator(this, mColumns.size());
+  }
+
+private:
+  /// private access function for the iterators
+  bool get(unsigned row, unsigned column, FrameData& data) {
+    auto element = this->mFrames.find(FrameIndex{this->mColumns[column], row});
+    if (element != this->mFrames.end()) {
+      data = element->second;
+      return true;
+    }
+    return false;
+  }
+
+  /// map of frame descriptors with key composed from header and slot number
+  std::map<FrameIndex, FrameData> mFrames;
+  /// list of indices in row direction
+  std::vector<ColumnIndexType> mColumns;
+  /// data descriptor of each slot forming the columns
+  std::vector<SlotDataType> mSlotData;
 };
 
 };

--- a/DataFormats/Headers/test/test_HeartbeatFrame.cxx
+++ b/DataFormats/Headers/test/test_HeartbeatFrame.cxx
@@ -1,0 +1,167 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test HeartbeatFrame
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include <iostream>
+#include <iomanip>
+#include "Headers/DataHeader.h"
+#include "Headers/HeartbeatFrame.h"
+
+using DataHeader = o2::Header::DataHeader;
+using HeartbeatHeader = o2::Header::HeartbeatHeader;
+using HeartbeatTrailer = o2::Header::HeartbeatTrailer;
+
+/**
+ * Helper struct to define a composite element from a header, some payload
+ * and a trailer
+ */
+template <typename HeaderT
+          , typename TrailerT>
+struct Composite {
+  using HeaderType = HeaderT;
+  using TrailerType = TrailerT;
+  size_t length = 0;
+
+  template<size_t N>
+  constexpr Composite(const HeaderType& h, const char  (&d)[N], const TrailerType& t)
+    : header(h)
+    , data(d)
+    , trailer(t)
+  {
+    length = sizeof(HeaderType) + N + sizeof(TrailerType);
+  }
+
+  constexpr size_t getDataLength() const noexcept {
+    return length - sizeof(HeaderType) - sizeof(TrailerType);
+  }
+
+  const HeaderType& header;
+  const char* data = nullptr;
+  const TrailerType& trailer;
+};
+
+/// recursively calculate the length of the sequence
+template <typename T, typename... TArgs>
+constexpr size_t sequenceLength(const T& first, const TArgs... args) noexcept {
+  return sequenceLength(first) + sequenceLength(args...);
+}
+
+/// terminating template secialization of sequence length calculation
+template <typename T>
+constexpr size_t sequenceLength(const T& first) noexcept {
+  return first.length;
+}
+
+/// recursive insert of variable number of elements
+template <typename T, typename... TArgs>
+constexpr size_t sequenceInsert(byte* buffer, const T& first, const TArgs... args) noexcept {
+  size_t length = sequenceLength(first);
+  sequenceInsert(buffer, first);
+  buffer += length;
+  length += sequenceInsert(buffer, args...);
+  return length;
+}
+
+/// terminating template specialization, i.e. for the last element
+template <typename T>
+constexpr size_t sequenceInsert(byte* buffer, const T& element) noexcept {
+  size_t length = 0;
+  memcpy(buffer + length, &element.header, sizeof(typename T::HeaderType));
+  length += sizeof(typename T::HeaderType);
+  memcpy(buffer + length, element.data, element.getDataLength());
+  length += element.getDataLength();
+  memcpy(buffer + length, &element.trailer, sizeof(typename T::TrailerType));
+  length += sizeof(typename T::TrailerType);
+  return length;
+}
+
+/**
+ * Helper struct to create a buffer from multiple blocks
+ */
+struct TestFrame {
+  using BufferType = std::unique_ptr<byte[]>;
+
+  BufferType buffer;
+  size_t length;
+
+  TestFrame() = delete;
+
+  template <typename CompositeType, typename... Targs>
+  TestFrame(CompositeType block, Targs... args)
+  {
+    length = sequenceLength(block, args...);
+    std::cout << "make TestFrame length " << length << std::endl;
+    buffer  = std::make_unique<byte[]>(length);
+    sequenceInsert(buffer.get(), block, args...);
+  }
+};
+
+BOOST_AUTO_TEST_CASE(test_parser)
+{
+  using FrameT = Composite<HeartbeatHeader, HeartbeatTrailer>;
+  // note: the length of the data is set in the trailer word
+  TestFrame tf(FrameT({0x1100000000000000}, "heartbeatdata", {0x510000000000000e}),
+               FrameT({0x1100000000000001}, "test", {0x5100000000000005}),
+               FrameT({0x1100000000000003}, "dummydata", {0x510000000000000a})
+               );
+  o2::Header::hexDump("Test frame", tf.buffer.get(), tf.length);
+
+  using ParserT = o2::Header::ReverseParser<typename FrameT::HeaderType,
+                                            typename FrameT::TrailerType>;
+  ParserT parser;
+  parser.parse(tf.buffer.get(), tf.length,
+               [](const typename ParserT::HeaderType* header) {return (*header);},
+               [](const typename ParserT::TrailerType* trailer) {return (*trailer);},
+               [](const typename ParserT::TrailerType& trailer) {
+                 return trailer.dataLength + ParserT::envelopeLength;
+               },
+               [](typename ParserT::FrameEntry entry) {
+                 o2::Header::hexDump("Entry", entry.payload, entry.length);
+                 return true;
+               }
+               );
+}
+
+BOOST_AUTO_TEST_CASE(test_heartbeat_sequence)
+{
+  using FrameT = Composite<HeartbeatHeader, HeartbeatTrailer>;
+  // note: the length of the data is set in the trailer word
+  TestFrame tf1(FrameT({0x1100000000000000}, "heartbeatdata", {0x510000000000000e}),
+                FrameT({0x1100000000000001}, "test", {0x5100000000000005}),
+                FrameT({0x1100000000000003}, "dummydata", {0x510000000000000a})
+                );
+  TestFrame tf2(FrameT({0x1100000000000000}, "frame2a", {0x5100000000000008}),
+                FrameT({0x1100000000000002}, "frame2b", {0x5100000000000008}),
+                FrameT({0x1100000000000003}, "frame2c", {0x5100000000000008})
+                );
+
+  o2::Header::HeartbeatFrameSequence<o2::Header::DataHeader> seqHandler;
+  o2::Header::DataHeader dh;
+  dh.dataDescription = o2::Header::DataDescription("FIRSTSLOT");
+  dh.dataOrigin = o2::Header::DataOrigin("TST");
+  dh.subSpecification = 0;
+  dh.payloadSize = 0;
+
+  seqHandler.addSlot(dh, tf1.buffer.get(), tf1.length);
+  seqHandler.addSlot(dh, tf2.buffer.get(), tf2.length);
+
+  std::cout << "slots: " << seqHandler.getNSlots() << " columns: " << seqHandler.getNColumns() << std::endl;
+
+  for (auto columnIt = seqHandler.begin(), end = seqHandler.end();
+       columnIt != end; ++columnIt) {
+    std::cout << "---------------------------------------" << std::endl;
+    for (auto row : columnIt) {
+      o2::Header::hexDump("Entry", row.buffer, row.size);
+    }
+  }
+}


### PR DESCRIPTION
- adding a generic reverse parser for sequences of blocks composed
  of header - payload - trailer with variable payload length
- adding container class for multiple sequences of heartbeat frames
  with row and column access iterators

Further comments:
passing the access function to the iterator did not work because
the typedef for the access function is without the capture, so there
is no matching conversion.

Solution would be to use std::function but that's probably slow and
the function is called often. Can be checked later.