### PR TITLE
Composed MC label to encode Track, Event and Source IDs

### DIFF
--- a/DataFormats/simulation/CMakeLists.txt
+++ b/DataFormats/simulation/CMakeLists.txt
@@ -5,6 +5,7 @@ O2_SETUP(NAME ${MODULE_NAME})
 set(SRCS
   src/Stack.cxx
   src/MCTrack.cxx
+  src/MCCompLabel.cxx
 )
 
 Set(HEADERS
@@ -12,6 +13,7 @@ Set(HEADERS
     include/${MODULE_NAME}/MCTrack.h
     include/${MODULE_NAME}/BaseHits.h
     include/${MODULE_NAME}/MCTruthContainer.h
+    include/${MODULE_NAME}/MCCompLabel.h
 )
 
 Set(LINKDEF src/SimulationDataLinkDef.h)
@@ -23,6 +25,7 @@ O2_GENERATE_LIBRARY()
 set(TEST_SRCS
   test/testBasicHits.cxx
   test/testMCTruthContainer.cxx
+  test/testMCCompLabel.cxx
 )
 
 O2_GENERATE_TESTS(

--- a/DataFormats/simulation/include/SimulationDataFormat/MCCompLabel.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCCompLabel.h
@@ -1,0 +1,96 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_MCCOMPLABEL_H
+#define ALICEO2_MCCOMPLABEL_H
+
+#include <Rtypes.h>
+
+namespace o2
+{
+// Composed Label to encode MC track id, event it comes from and the source (file)
+
+class MCCompLabel
+{
+ private:
+  static constexpr ULong64_t ul0x1 = 0x1;
+  static constexpr ULong64_t NotSet = 0xffffffffffffffff;
+
+  ULong64_t mLabel = NotSet; ///< MC label encoding MCtrack ID and MCevent origin
+
+  void checkFieldConsistensy();
+  
+ public:
+
+  // number of bits reserved for MC track ID, DON'T modify this, sine the
+  // track ID might be negative
+  static constexpr int nbitsTrackID = sizeof(int)*8;
+  static constexpr int nbitsEvID = 19;    // number of bits reserved for MC event ID
+  static constexpr int nbitsSrcID = 8;    // number of bits reserved for MC source ID
+  // the rest of the bits is reserved at the moment
+
+  // mask to extract MC track ID
+  static constexpr ULong64_t maskTrackID = (ul0x1 << nbitsTrackID) - 1;
+  // mask to extract MC track ID
+  static constexpr ULong64_t maskEvID = (ul0x1 << nbitsEvID) - 1;
+  // mask to extract MC track ID
+  static constexpr ULong64_t maskSrcID = (ul0x1 << nbitsSrcID) - 1;
+  // mask for all used fields
+  static constexpr ULong64_t maskFull = (ul0x1 << (nbitsTrackID + nbitsEvID + nbitsSrcID)) - 1;
+
+  MCCompLabel(int trackID, int evID = 0, int srcID = 0) { set(trackID, evID, srcID); }
+  MCCompLabel() = default;
+  ~MCCompLabel() = default;
+
+  // check if label was assigned
+  bool isSet() const { return mLabel != NotSet; }
+
+  // check if label was not assigned
+  bool isEmpty() const { return mLabel == NotSet; }
+
+  // check if label was assigned with non-negaive trackID
+  bool isPosTrackID() const { return getTrackID() >= 0; }
+  
+  // conversion op-r
+  operator ULong64_t() const { return mLabel; }
+  // invalidate
+  void unset() { mLabel = NotSet; }
+  void set(int trackID, int evID, int srcID)
+  {
+    /// compose label: the track 1st cast to UInt32_t to preserve the sign!
+    mLabel = (maskTrackID & static_cast<ULong64_t>( static_cast<UInt_t>(trackID))) |
+             (maskEvID & static_cast<ULong64_t>(evID)) << nbitsTrackID |
+             (maskSrcID & static_cast<ULong64_t>(srcID)) << (nbitsTrackID + nbitsEvID);
+  }
+  
+  int getTrackID() const { return static_cast<int>(mLabel & maskTrackID); }
+  int getEventID() const { return (mLabel >> nbitsTrackID) & maskEvID; }
+  int getSourceID() const { return (mLabel >> (nbitsTrackID + nbitsEvID)) & maskSrcID; }
+  void get(int& trackID, int& evID, int& srcID)
+  {
+    /// parse label
+    trackID = getTrackID();
+    evID = getEventID();
+    srcID = getSourceID();
+  }
+
+  void print() const;
+
+  static constexpr int maxSourceID()  { return maskSrcID; }
+  static constexpr int maxEventID()   { return maskEvID; }
+  static constexpr int maxTrackID()   { return maskTrackID; }
+  
+  ClassDefNV(MCCompLabel, 1);
+};
+}
+
+std::ostream& operator<<(std::ostream& os, const o2::MCCompLabel& c);
+
+#endif

--- a/DataFormats/simulation/src/MCCompLabel.cxx
+++ b/DataFormats/simulation/src/MCCompLabel.cxx
@@ -1,0 +1,48 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "SimulationDataFormat/MCCompLabel.h"
+#include <iomanip>
+#include <ios>
+#include <iostream>
+#include <cassert>
+
+using namespace o2;
+
+ClassImp(o2::MCCompLabel);
+
+//_____________________________________________
+void MCCompLabel::print() const
+{
+  // print itself
+  std::cout << (MCCompLabel)*this << std::endl;
+}
+
+//_____________________________________________
+std::ostream& operator<<(std::ostream& os, const o2::MCCompLabel& c)
+{
+  // stream itself
+  if (c.isSet()) {
+    os << '[' << c.getSourceID() << '/' << c.getEventID() << '/'
+       << std::setw(6) << c.getTrackID() << ']';
+  } else {
+    os << "[unset]";
+  }
+  return os;
+}
+
+ //_____________________________________________
+void MCCompLabel::checkFieldConsistensy()
+{
+  // check if the fields are defined consistently
+  static_assert(nbitsTrackID==sizeof(int)*8, "TrackID must have int size");
+  static_assert(nbitsTrackID+nbitsEvID+nbitsSrcID<=sizeof(ULong64_t)*8,
+		"Fields cannot be stored in 64 bits");
+}

--- a/DataFormats/simulation/src/SimulationDataLinkDef.h
+++ b/DataFormats/simulation/src/SimulationDataLinkDef.h
@@ -24,6 +24,7 @@
 
 #pragma link C++ class o2::Data::Stack+;
 #pragma link C++ class MCTrack+;
+#pragma link C++ class o2::MCCompLabel+;
 
 #pragma link C++ class o2::BaseHit+;
 #pragma link C++ class o2::BasicXYZEHit<float,float>+;

--- a/DataFormats/simulation/test/testMCCompLabel.cxx
+++ b/DataFormats/simulation/test/testMCCompLabel.cxx
@@ -1,0 +1,40 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test BasicHits class
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include <iomanip>
+#include <ios>
+#include <iostream>
+#include "SimulationDataFormat/MCCompLabel.h"
+
+using namespace o2;
+
+BOOST_AUTO_TEST_CASE(MCCompLabel_test)
+{
+  MCCompLabel lbUndef;
+  BOOST_CHECK(!lbUndef.isSet()); // test invalid label status
+
+  int ev = 200, src = 10;
+  for (int tr=-100;tr<200;tr+=150) {
+    MCCompLabel lb(tr, ev, src);
+    std::cout << "Input:   [" << src << '/' << ev << '/'
+	      << std::setw(6) << tr << ']' << std::endl;
+    std::cout << "Encoded: " << lb << " (packed: " << ULong_t(lb) << ")" << std::endl;
+    int trE, evE, srcE;
+    lb.get(trE, evE, srcE);
+    std::cout << "Decoded: [" << srcE << '/' << evE << '/'
+	      << std::setw(6) << trE << ']' << std::endl;
+
+    BOOST_CHECK(tr == trE && ev == evE && src == srcE);
+  }
+}


### PR DESCRIPTION
refined version (merge conflicts solved) of #537. 