### PR TITLE
Add missing material definition for ITSU OB volumes

### DIFF
--- a/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
@@ -485,11 +485,30 @@ void Detector::createMaterials()
   Float_t wWater[2] = {0.111894, 0.888106};
   Float_t dWater = 1.0;
 
+  // PEEK CF30
+  Float_t aPEEK[3]={12.0107,1.00794,15.9994};
+  Float_t zPEEK[3]={6.,1.,8.};
+  Float_t wPEEK[3]={19.,12.,3};
+  Float_t dPEEK   = 1.32;
+
   // Kapton
   Float_t aKapton[4] = {1.00794, 12.0107, 14.010, 15.9994};
   Float_t zKapton[4] = {1., 6., 7., 8.};
   Float_t wKapton[4] = {0.026362, 0.69113, 0.07327, 0.209235};
   Float_t dKapton = 1.42;
+
+  // Tungsten Carbide
+  Float_t aWC[2]={183.84, 12.0107};
+  Float_t zWC[2]={74, 6};
+  Float_t wWC[2]={0.5, 0.5};
+  Float_t dWC   = 15.63;
+
+  // Inox 304
+  Float_t aInox304[4]={12.0107,51.9961,58.6928,55.845};
+  Float_t zInox304[4]={6.,24.,28,26}; // C, Cr, Ni, Fe
+  Float_t wInox304[4]={0.0003,0.18,0.10,0}; // [3] will be computed
+  Float_t dInox304   = 7.85;
+
 
   o2::Base::Detector::Mixture(1, "AIR$", aAir, zAir, dAir, 4, wAir);
   o2::Base::Detector::Medium(1, "AIR$", 1, 0, ifield, fieldm, tmaxfdAir, stemaxAir, deemaxAir,
@@ -531,6 +550,13 @@ void Detector::createMaterials()
   o2::Base::Detector::Material(8, "K13D2U2k$", 12.0107, 6, 1.643, 999, 999);
   o2::Base::Detector::Medium(8, "K13D2U2k$", 8, 0, ifield, fieldm, tmaxfdSi, stemaxSi,
                                   deemaxSi, epsilSi, stminSi);
+  o2::Base::Detector::Material(17, "K13D2U120$", 12.0107, 6, 1.583, 999, 999);
+  o2::Base::Detector::Medium(17, "K13D2U120$", 17, 0, ifield, fieldm, tmaxfdSi, stemaxSi,
+                                  deemaxSi, epsilSi, stminSi);
+  // Carbon prepreg woven
+  o2::Base::Detector::Material(18, "F6151B05M$", 12.0107, 6, 2.133, 999, 999);
+  o2::Base::Detector::Medium(18, "F6151B05M$", 18, 0, ifield, fieldm, tmaxfdSi, stemaxSi,
+			          deemaxSi,epsilSi,stminSi);
   // Impregnated thread
   o2::Base::Detector::Material(9, "M60J3K$", 12.0107, 6, 2.21, 999, 999);
   o2::Base::Detector::Medium(9, "M60J3K$", 9, 0, ifield, fieldm, tmaxfdSi, stemaxSi, deemaxSi,
@@ -551,6 +577,11 @@ void Detector::createMaterials()
   o2::Base::Detector::Material(13, "CarbonFleece$", 12.0107, 6, 0.4, 999, 999);
   o2::Base::Detector::Medium(13, "CarbonFleece$", 13, 0, ifield, fieldm, tmaxfdSi, stemaxSi,
                                   deemaxSi, epsilSi, stminSi);
+
+  // PEEK CF30
+  o2::Base::Detector::Mixture(19, "PEEKCF30$", aPEEK, zPEEK, dPEEK, -3, wPEEK);
+  o2::Base::Detector::Medium(19,"PEEKCF30$", 19, 0, ifield, fieldm, tmaxfdSi, stemaxSi,
+			          deemaxSi,epsilSi,stminSi);
 
   // Flex cable
   Float_t aFCm[5] = {12.0107, 1.00794, 14.0067, 15.9994, 26.981538};
@@ -575,6 +606,20 @@ void Detector::createMaterials()
                                     0.89000E+01, 0.99900E+03);
   o2::Base::Detector::Medium(16, "ALUMINUM$", 16, 0, ifield, fieldm, tmaxfd, stemax, deemax,
                                   epsil, stmin);
+
+  o2::Base::Detector::Mixture(20, "TUNGCARB$", aWC, zWC, dWC, 2, wWC);
+  o2::Base::Detector::Medium(20, "TUNGCARB$", 20, 0, ifield, fieldm, tmaxfd, stemax,
+			          deemaxSi,epsilSi,stminSi);
+
+  wInox304[3] = 1. - wInox304[0] - wInox304[1] - wInox304[2];
+  o2::Base::Detector::Mixture(21, "INOX304$", aInox304, zInox304, dInox304, 4, wInox304);
+  o2::Base::Detector::Medium(21, "INOX304$", 21, 0, ifield, fieldm, tmaxfd, stemax,
+			          deemaxSi,epsilSi,stminSi);
+
+  //Tungsten (for gamma converter rods)
+  o2::Base::Detector::Material(28, "TUNGSTEN$", 183.84, 74, 19.25, 999, 999);
+  o2::Base::Detector::Medium(28, "TUNGSTEN$", 28,0, ifield, fieldm, tmaxfdSi, stemaxSi,
+			          deemaxSi,epsilSi,stminSi);
 }
 
 void Detector::EndOfEvent()


### PR DESCRIPTION
The definition of some materials used in the Outer Barrel volumes was missing. Among the other issues, this was causing all hits in OB layers to be lost. All missing materials were added.