### PR TITLE
Impose naming convention to tests

### DIFF
--- a/cmake/O2Utils.cmake
+++ b/cmake/O2Utils.cmake
@@ -412,6 +412,7 @@ function(O2_GENERATE_TESTS)
   foreach (test ${PARSED_ARGS_TEST_SRCS})
     string(REGEX REPLACE ".*/" "" test_name ${test})
     string(REGEX REPLACE "\\..*" "" test_name ${test_name})
+    set(test_name test_${MODULE_NAME}${test_name})
 
     message(STATUS "Generate test ${test_name}")
 


### PR DESCRIPTION
This modifies O2_GENERATE_TESTS to impose a strict naming convention:

    test_${MODULE_NAME}<actual name call>

This is to accomplish the following:

- Ensure that tests are well identifiable by the test_ prefix.
- Ensure that we do not have generic names like `test_Fifo` or
  `test_Collections` like we do now.
- Ensure the origin of the source (i.e. which module) is clear
  without having to grep for the test name through the codebase.