### PR TITLE
CCDB: generalization; refactoring; new server query example

### DIFF
--- a/CCDB/CMakeLists.txt
+++ b/CCDB/CMakeLists.txt
@@ -39,6 +39,7 @@ set(HEADERS
   include/${MODULE_NAME}/ObjectHandler.h
   include/${MODULE_NAME}/Storage.h
   include/${MODULE_NAME}/XmlHandler.h
+  test/TestClass.h
 )
 
 Set(NO_DICT_SRCS
@@ -57,11 +58,13 @@ O2_GENERATE_LIBRARY()
 Set(Exe_Names
   conditions-server
   conditions-client
+  standalone-client
 )
 
 Set(Exe_Source
   src/runConditionsServer.cxx
   src/runConditionsClient.cxx
+  test/testQueryServerStandalone.cxx
 )
 
 list(LENGTH Exe_Names _length)
@@ -87,3 +90,15 @@ install(
     example/fill_local_ocdb.C
     DESTINATION bin/config
 )
+
+set(TEST_SRCS
+   test/testWriteReadAny.cxx
+)
+
+O2_GENERATE_TESTS(
+  BUCKET_NAME ${BUCKET_NAME}
+  MODULE_LIBRARY_NAME ${MODULE_NAME}
+  TEST_SRCS ${TEST_SRCS}
+)
+
+

--- a/CCDB/README.md
+++ b/CCDB/README.md
@@ -26,6 +26,10 @@ conditions-server --id parmq-server --mq-config <installation directory>/bin/con
 conditions-client --id parmq-client --mq-config <installation directory>/bin/config/conditions-client.json --data-source OCDB --object-path <installation directory>/bin/config/O2CDB
 ```
 
+* We can also query the running conditions-server using any user code as
+  demonstrated in `standalone-client` which works for an O2CDB
+  generated from the unit test `testWriteReadAny`
+
 ### Riak backend
 
 To run the MQ server-client example with the MQ server executing PUT or GET commands to a Riak cluster through an MQ broker, the steps below should be followed:

--- a/CCDB/config/conditions-client.json
+++ b/CCDB/config/conditions-client.json
@@ -11,7 +11,7 @@
                 {
                     "type": "push",
                     "method": "connect",
-                    "address": "tcp://localhost:5005",
+                    "address": "tcp://localhost:25005",
                     "sndBufSize": "200",
                     "rcvBufSize": "1000",
                     "rateLogging": "0"
@@ -24,7 +24,7 @@
                 {
                     "type": "req",
                     "method": "connect",
-                    "address": "tcp://localhost:5006",
+                    "address": "tcp://localhost:25006",
                     "sndBufSize": "1000",
                     "rcvBufSize": "1000",
                     "rateLogging": "0"

--- a/CCDB/config/conditions-server.json
+++ b/CCDB/config/conditions-server.json
@@ -11,7 +11,7 @@
                 {
                     "type": "pull",
                     "method": "bind",
-                    "address": "tcp://*:5005",
+                    "address": "tcp://*:25005",
                     "sndBufSize": "1000",
                     "rcvBufSize": "1000",
                     "rateLogging": "0"
@@ -24,7 +24,7 @@
                 {
                     "type": "rep",
                     "method": "bind",
-                    "address": "tcp://*:5006",
+                    "address": "tcp://*:25006",
                     "sndBufSize": "1000",
                     "rcvBufSize": "1000",
                     "rateLogging": "0"

--- a/CCDB/include/CCDB/Backend.h
+++ b/CCDB/include/CCDB/Backend.h
@@ -27,6 +27,8 @@
 namespace o2 {
 namespace CDB {
 
+class Condition;
+
 class Backend {
 public:
   virtual ~Backend()= default;
@@ -35,7 +37,7 @@ public:
   virtual void Pack(const std::string& path, const std::string& key, std::string*& messageString) = 0;
 
   /// UnPack
-  virtual void UnPack(std::unique_ptr<FairMQMessage> msg) = 0;
+  virtual Condition* UnPack(std::unique_ptr<FairMQMessage> msg) = 0;
 
   /// Serializes a key (and optionally value) to an std::string using Protocol Buffers
   void Serialize(std::string*& messageString, const std::string& key, const std::string& operationType,

--- a/CCDB/include/CCDB/BackendOCDB.h
+++ b/CCDB/include/CCDB/BackendOCDB.h
@@ -34,7 +34,7 @@ public:
   void Pack(const std::string& path, const std::string& key, std::string*& messageString) override;
 
   /// Parses an incoming message from the CCDB server and prints the metadata of the included object
-  void UnPack(std::unique_ptr<FairMQMessage> msg) override;
+  Condition* UnPack(std::unique_ptr<FairMQMessage> msg) override;
 };
 }
 }

--- a/CCDB/include/CCDB/BackendRiak.h
+++ b/CCDB/include/CCDB/BackendRiak.h
@@ -40,7 +40,7 @@ public:
   void Pack(const std::string& path, const std::string& key, std::string*& messageString) override;
 
   /// Deserializes and uncompresses an incoming message from the CCDB server
-  void UnPack(std::unique_ptr<FairMQMessage> msg) override;
+  Condition* UnPack(std::unique_ptr<FairMQMessage> msg) override;
 };
 }
 }

--- a/CCDB/include/CCDB/Condition.h
+++ b/CCDB/include/CCDB/Condition.h
@@ -17,6 +17,7 @@
 #include "CCDB/ConditionId.h"        // for ConditionId
 #include "CCDB/ConditionMetaData.h"  // for ConditionMetaData
 #include "CCDB/IdPath.h"             // for IdPath
+#include <CCDB/TObjectWrapper.h>
 #include "Rtypes.h"             // for Int_t, kFALSE, Bool_t, etc
 #include "TObject.h"            // for TObject
 #include "TString.h"            // for TString
@@ -108,6 +109,19 @@ class Condition : public TObject
     {
       return mObject;
     };
+
+    /// retrieve object as specified type
+    /// return false if failed/true otherwise
+    template<typename T>
+    bool getObjectAs(T *& obj) {
+      obj = nullptr;
+      // test if saved object was a wrapped object
+      if(auto wrapped = dynamic_cast<TObjectWrapper<T>*>(mObject)) {
+        obj = wrapped->getObj();
+        return true;
+      }
+      return false; 
+   }
 
     void setConditionMetaData(ConditionMetaData *metaData)
     {

--- a/CCDB/include/CCDB/Manager.h
+++ b/CCDB/include/CCDB/Manager.h
@@ -17,6 +17,7 @@
 #include <cstddef>   // for NULL
 #include "Rtypes.h"   // for Int_t, Bool_t, kFALSE, kTRUE, ClassDef, etc
 #include "TString.h"  // for TString
+#include <CCDB/TObjectWrapper.h>
 
 class TFile;
 namespace o2 { namespace CDB { class Condition; }}  // lines 20-20
@@ -133,11 +134,11 @@ class Manager : public TObject
       return mOcdbUploadMode;
     }
 
-    Condition *getObject(const ConditionId &query, Bool_t forceCaching = kFALSE);
+    Condition *getCondition(const ConditionId &query, Bool_t forceCaching = kFALSE);
 
-    Condition *getObject(const IdPath &path, Int_t runNumber = -1, Int_t version = -1, Int_t subVersion = -1);
+    Condition *getCondition(const IdPath &path, Int_t runNumber = -1, Int_t version = -1, Int_t subVersion = -1);
 
-    Condition *getObject(const IdPath &path, const IdRunRange &runRange, Int_t version = -1, Int_t subVersion = -1);
+    Condition *getCondition(const IdPath &path, const IdRunRange &runRange, Int_t version = -1, Int_t subVersion = -1);
 
     Condition *getConditionFromSnapshot(const char *path);
 
@@ -151,7 +152,13 @@ class Manager : public TObject
 
     Bool_t putObject(TObject *object, const ConditionId &id, ConditionMetaData *metaData, const char *mirrors = "");
 
-    Bool_t putObject(Condition *entry, const char *mirrors = "");
+    template <typename T>
+    Bool_t putObjectAny(T *ptr, const ConditionId &id, ConditionMetaData *metaData, const char *mirrors = "") {
+      TObjectWrapper<T> local(ptr);
+      return putObject(&local, id, metaData, mirrors);
+    }
+
+    Bool_t putCondition(Condition *entry, const char *mirrors = "");
 
     void setCacheFlag(Bool_t cacheFlag)
     {

--- a/CCDB/include/CCDB/TObjectWrapper.h
+++ b/CCDB/include/CCDB/TObjectWrapper.h
@@ -1,0 +1,67 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TOBJECTWRAPPER_H
+#define O2_TOBJECTWRAPPER_H
+#include <TClass.h>
+#include <TObject.h>
+#include <cxxabi.h>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <typeinfo>
+
+namespace o2
+{
+// anonymous namespace to prevent usage outside of this file
+namespace
+{
+/// utility function to demangle cxx type names
+std::string demangle(const char* name)
+{
+  int status = -4; // some arbitrary value to eliminate the compiler warning
+  std::unique_ptr<char, void (*)(void*)> res{ abi::__cxa_demangle(name, nullptr, nullptr, &status), std::free };
+  return (status == 0) ? res.get() : name;
+}
+} // end anonymous namespace
+
+/// A wrapper class to easily promote any type to a TObject
+/// does not take ownership of wrapped object and should not be used
+/// in tight loops since construction expensive
+template <typename T>
+class TObjectWrapper : public TObject
+{
+ public:
+  TObjectWrapper(T* obj) : mObj(obj), TObject()
+  {
+    // make sure that a dictionary for this wrapper exists
+    auto& t = typeid(*this);
+    std::string message("Need dicionary for type ");
+    auto typestring = demangle(t.name());
+    message.append(typestring);
+    message.append("\n");
+    auto hasdict = TClass::HasDictionarySelection(typestring.c_str());
+    if (!hasdict) {
+      throw std::runtime_error(message);
+    }
+  }
+
+  TObjectWrapper() : TObjectWrapper(nullptr) {}
+  void setObj(T* obj) { mObj = obj; }
+  T* getObj() const { return mObj; }
+  ~TObjectWrapper() override = default;
+
+ private:
+  T* mObj;
+  ClassDefOverride(TObjectWrapper, 1);
+};
+}
+
+#endif

--- a/CCDB/src/BackendOCDB.cxx
+++ b/CCDB/src/BackendOCDB.cxx
@@ -38,10 +38,11 @@ void BackendOCDB::Pack(const std::string& path, const std::string& key, std::str
   LOG(ERROR) << "The PUT operation is not supported for the OCDB backend yet";
 }
 
-void BackendOCDB::UnPack(std::unique_ptr<FairMQMessage> msg)
+Condition* BackendOCDB::UnPack(std::unique_ptr<FairMQMessage> msg)
 {
   WrapTMessage tmsg(msg->GetData(), msg->GetSize());
   Condition* aCondition = (Condition*)(tmsg.ReadObject(tmsg.GetClass()));
   LOG(DEBUG) << "Received a condition from the server:";
   aCondition->printConditionMetaData();
+  return aCondition;
 }

--- a/CCDB/src/BackendRiak.cxx
+++ b/CCDB/src/BackendRiak.cxx
@@ -127,8 +127,9 @@ void BackendRiak::Pack(const std::string& path, const std::string& key, std::str
   Serialize(messageString, key, "PUT", "Riak", compressed_object);
 }
 
-void BackendRiak::UnPack(std::unique_ptr<FairMQMessage> msg)
+Condition* BackendRiak::UnPack(std::unique_ptr<FairMQMessage> msg)
 {
+  // FIXME: how to actually extract a condition or a binary blob here?
   std::string brokerString(static_cast<char*>(msg->GetData()), msg->GetSize());
 
   // Deserialize the received string
@@ -138,4 +139,7 @@ void BackendRiak::UnPack(std::unique_ptr<FairMQMessage> msg)
   // Decompress the compressed object
   std::string object;
   Decompress(object, compressedObject);
+  
+  // nullptr since no other possibility at moment
+  return nullptr;
 }

--- a/CCDB/src/CCDBLinkDef.h
+++ b/CCDB/src/CCDBLinkDef.h
@@ -33,5 +33,9 @@
 #pragma link C++ class o2::CDB::GridStorageFactory+;
 #pragma link C++ class o2::CDB::GridStorageParameters+;
 #pragma link C++ class o2::CDB::XmlHandler+;
+/// for the unit test
+#pragma link C++ class TestClass+;
+#pragma link C++ class o2::TObjectWrapper<TestClass>+;
+
 
 #endif

--- a/CCDB/src/ConditionsMQServer.cxx
+++ b/CCDB/src/ConditionsMQServer.cxx
@@ -168,7 +168,7 @@ void ConditionsMQServer::getFromOCDB(std::string key)
   Condition* aCondition = nullptr;
 
   mCdbManager->setRun(runId);
-  aCondition = mCdbManager->getObject(IdPath(identifier), runId);
+  aCondition = mCdbManager->getCondition(IdPath(identifier), runId);
 
   if (aCondition) {
     LOG(DEBUG) << "Sending following parameter to the client:";

--- a/CCDB/src/Manager.cxx
+++ b/CCDB/src/Manager.cxx
@@ -947,7 +947,7 @@ StorageParameters *Manager::selectSpecificStorage(const TString &path)
   return aPar;
 }
 
-Condition *Manager::getObject(const IdPath &path, Int_t runNumber, Int_t version, Int_t subVersion)
+Condition *Manager::getCondition(const IdPath &path, Int_t runNumber, Int_t version, Int_t subVersion)
 {
   // get an  Condition object from the database
 
@@ -961,17 +961,17 @@ Condition *Manager::getObject(const IdPath &path, Int_t runNumber, Int_t version
     runNumber = mRun;
   }
 
-  return getObject(ConditionId(path, runNumber, runNumber, version, subVersion));
+  return getCondition(ConditionId(path, runNumber, runNumber, version, subVersion));
 }
 
-Condition *Manager::getObject(const IdPath &path, const IdRunRange &runRange, Int_t version, Int_t subVersion)
+Condition *Manager::getCondition(const IdPath &path, const IdRunRange &runRange, Int_t version, Int_t subVersion)
 {
   // get an  Condition object from the database!
 
-  return getObject(ConditionId(path, runRange, version, subVersion));
+  return getCondition(ConditionId(path, runRange, version, subVersion));
 }
 
-Condition *Manager::getObject(const ConditionId &queryId, Bool_t forceCaching)
+Condition *Manager::getCondition(const ConditionId &queryId, Bool_t forceCaching)
 {
   // get an  Condition object from the database
 
@@ -1409,10 +1409,10 @@ Bool_t Manager::putObject(TObject *object, const ConditionId &id, ConditionMetaD
   }
 
   Condition anCondition(object, id, metaData);
-  return putObject(&anCondition, mirrors);
+  return putCondition(&anCondition, mirrors);
 }
 
-Bool_t Manager::putObject(Condition *entry, const char *mirrors)
+Bool_t Manager::putCondition(Condition *entry, const char *mirrors)
 {
   // store an  Condition object into the database
 

--- a/CCDB/test/TestClass.h
+++ b/CCDB/test/TestClass.h
@@ -1,0 +1,20 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_CCDB_TESTCLASS
+#define O2_CCDB_TESTCLASS
+
+// a private test class to be stored inside the CCDB; just used in a unit test
+// the header is not public
+struct TestClass {
+  double mD = 1.;
+};
+
+#endif

--- a/CCDB/test/testQueryServerStandalone.cxx
+++ b/CCDB/test/testQueryServerStandalone.cxx
@@ -1,0 +1,69 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <CCDB/BackendOCDB.h>
+#include <CCDB/Condition.h>
+#include <FairMQChannel.h>
+#include <FairMQLogger.h>
+#include <FairMQParts.h>
+#include <FairMQTransportFactory.h>
+#include <algorithm>
+#include <memory>
+#include <sstream>
+#include <string>
+#include "TestClass.h"
+
+using namespace std;
+
+void CustomCleanup(void* data, void* hint) { delete static_cast<std::string*>(hint); }
+void queryConditionServer(string transport, string address)
+{
+  auto factory = FairMQTransportFactory::CreateTransportFactory(transport);
+  auto channel = FairMQChannel{ "data-get", "req", factory };
+  channel.Connect(address);
+  channel.ValidateChannel();
+
+  auto backend = new o2::CDB::BackendOCDB();
+
+  std::string* messageString = new string();
+  std::string operationType("GET");
+  // FIXME: how to setup the key?
+  // just a test key -- corresponding to example from unit test testWriteReadAny.cxx
+  std::string key("TestParam/Test/Test/Run1_1_v1_s0");
+  std::string source("OCDB");
+  backend->Serialize(messageString, key, operationType, source);
+
+  std::cerr << messageString->c_str() << "\n";
+  unique_ptr<FairMQMessage> request(factory->CreateMessage(const_cast<char*>(messageString->c_str()),
+                                                           messageString->length(), CustomCleanup, messageString));
+
+  unique_ptr<FairMQMessage> reply(factory->CreateMessage());
+
+  channel.Send(request);
+  if (channel.Receive(reply) > 0) {
+    LOG(DEBUG) << "Received a condition with a size of " << reply->GetSize();
+    auto condition = backend->UnPack(std::move(reply));
+    LOG(DEBUG) << "TYPE " << condition->getObject()->IsA()->GetName() << "\n";
+
+    // retrieve concrete type
+    TestClass* c = nullptr;
+    condition->getObjectAs(c);
+    if (c) {
+      LOG(DEBUG) << "RECEIVED parameter value is " << c->mD << "\n";
+    }
+  }
+}
+
+int main()
+{
+  // assuming that conditions-server is running and listening on port 25006
+  // see conditions-server.json
+  queryConditionServer("zeromq", "tcp://localhost:25006");
+}

--- a/CCDB/test/testWriteReadAny.cxx
+++ b/CCDB/test/testWriteReadAny.cxx
@@ -1,0 +1,48 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test CCDB TestReadWriteAny
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <CCDB/TObjectWrapper.h>
+#include <boost/test/unit_test.hpp>
+#include "CCDB/Condition.h"
+#include "CCDB/Manager.h"
+#include "TestClass.h" // local header
+
+namespace o2
+{
+namespace CCDB
+{
+/// \brief Test writing/reading arbitrary (non TObject) classes A to CCDB
+// a dictionary for TObjectWrapper<A> must exist (next to the one for A)
+BOOST_AUTO_TEST_CASE(ReadWriteTest1)
+{
+  auto cdb = o2::CDB::Manager::Instance();
+  cdb->setDefaultStorage("local://O2CDB");
+
+  TestClass parameter;
+  const double TESTVALUE = 20.;
+  parameter.mD = TESTVALUE;
+
+  int run = 1;
+  auto id = new o2::CDB::ConditionId("TestParam/Test/Test", run, run, 1, 0);
+  auto md = new o2::CDB::ConditionMetaData();
+  cdb->putObjectAny(&parameter, *id, md);
+
+  auto condread = cdb->getCondition("TestParam/Test/Test", run);
+
+  TestClass* readbackparameter = nullptr;
+  condread->getObjectAs(readbackparameter);
+  BOOST_CHECK(readbackparameter);
+  BOOST_CHECK_CLOSE(readbackparameter->mD, TESTVALUE, 1E-6);
+}
+}
+}


### PR DESCRIPTION
* Introduction of TObjectWrapper to be able to put any class with
  a dictionary inside a Condition (no more required to be of TObject type initially)
* Unit test to read/write a non TObject class
* Some renaming of functions to better express the return value of "Condition" rather
  than "Object"
* The Backend::Unpack function now returns a condition; Otherwise the user can not get
  hold of the unpacked blob
* A new example demonstrating that we can quere the conditions-server from any
  (even non-device) user code; The example is very prototypic

@authors: J. Wiechula, S. Wenzel