### PR TITLE
Added row/col flipping for negative x,y

### DIFF
--- a/Detectors/ITSMFT/common/simulation/src/ITSMFTSimulationLinkDef.h
+++ b/Detectors/ITSMFT/common/simulation/src/ITSMFTSimulationLinkDef.h
@@ -20,7 +20,7 @@
 #pragma link C++ class o2::ITSMFT::SimuClusterShaper+;
 #pragma link C++ class o2::ITSMFT::SimuClusterShaper+;
 #pragma link C++ class o2::ITSMFT::AlpideSimResponse+;
-#pragma link C++ class o2::ITSMFT::RespSimMat+;
+#pragma link C++ class o2::ITSMFT::AlpideRespSimMat+;
 #pragma link C++ class o2::ITSMFT::DigiParams+;
 
 #endif

--- a/Detectors/ITSMFT/common/simulation/test/testAlpideSimResponse.cxx
+++ b/Detectors/ITSMFT/common/simulation/test/testAlpideSimResponse.cxx
@@ -25,20 +25,21 @@ BOOST_AUTO_TEST_CASE(AlpideSimResponse_test)
   resp.initData();
   float x=1.e-4, y=1.e-4, z=10.e-4;
   LOG(INFO) << "Checking response from X:" << x << " Y:" << y << " Z:" << z << FairLogger::endl;
-  auto rspmat = resp.getResponse(1e-4,1e-4,resp.getZMax()-10e-04);
-  BOOST_CHECK(rspmat != nullptr);
-  rspmat->print();
+  bool flipX, flipY;
+  auto respMat = resp.getResponse(1e-4,1e-4,resp.getZMax()-10e-04,flipX,flipY);
+  BOOST_CHECK( respMat!=nullptr );
+  respMat->print();
   // repsonse at central pixel for electron close to the surface should be >>0
-  int pixCen = resp.getNPix()/2;
+  int pixCen = respMat->getNPix()/2;
   LOG(INFO) << "Response at central pixel " << pixCen << ":" << pixCen
-	    << " is " << rspmat->getValue(pixCen,pixCen) << FairLogger::endl;
-  BOOST_CHECK(rspmat->getValue(pixCen,pixCen) > 1e-6);
+	    << " is " << respMat->getValue(pixCen,pixCen,flipX,flipY) << FairLogger::endl;
+  BOOST_CHECK(respMat->getValue(pixCen,pixCen,flipX,flipY) > 1e-6);
   //
   // check normalization
   float norm = 0.f;
-  for (int ix=resp.getNPix();ix--;) {
-    for (int iy=resp.getNPix();iy--;) {
-      norm += rspmat->getValue(ix,iy);
+  for (int ix=respMat->getNPix();ix--;) {
+    for (int iy=respMat->getNPix();iy--;) {
+      norm += respMat->getValue(ix,iy,flipX,flipY);
     }
   }
   LOG(INFO) << "Total response to 1 electron: " << norm << FairLogger::endl;


### PR DESCRIPTION
Hi @dr4kan 

Alpide response was not flipped for negative x and y. Also, half-Zbin shift is corrected.
The flipped response matrix should be obtained as:
```` 
AlpideSimResponse resp;
resp.initData();
AlpideRespSimMat rspmat;
constexpr int npix = resp.getNPix();
// get x,y,z in pixel frame...
if ( resp.getResponse(x,y,z, rspmat) ) {  // use repsonse 
    for (int i=npix;i--;) {
      for (int j=npix;j--;) {
	float o2r = rspmat.getValue(i,j); // o2 response
     }
   }
}
````
Faster way (avoid copy of the flipped response) is to get unflipped repsonse *pointer* together with
flipping flags:
````
AlpideSimResponse resp;
resp.initData();
bool flipX,flipY;
constexpr int npix = resp.getNPix();
// get x,y,z in pixel frame...
auto rspmat = resp.getResponse(x,y,z, flipX, flipY); 
if (rsmpat) {
    for (int i=npix;i--;) {
      for (int j=npix;j--;) {
        int bin = (flipY ? npix-1-i : i)*npix + (flipX ? npix-1-j : j);
	float o2r = rspmat->getValue(i,j); // o2 response
     }
   }
}
````
Attached macro makes benchmark of 2 methods of AlpideSimResponse and compares them
with original Miko's code:
````
Timing O2 flipped     : 9.800000e-08 per call (10000000 calls)
Timing O2 nonflipped  : 3.400000e-08 per call (10000000 calls)
Timing Miko           : 1.252000e-04 per call (100000 calls)
````
(call as comp(100,true) from directory where Miko's code is located, will compare/print random 100 responses and perform benchmark) 
[comp.C.zip](https://github.com/AliceO2Group/AliceO2/files/1308448/comp.C.zip)
