### PR TITLE
Make sure you use the same boost as FairSoft and fixed a bug that whe…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,10 @@ IF (NOT ALICEO2_MODULAR_BUILD)
   set(CMAKE_MODULE_PATH "${FAIRROOTPATH}/share/fairbase/cmake/modules" ${CMAKE_MODULE_PATH})
   set(CMAKE_MODULE_PATH "${FAIRROOTPATH}/share/fairbase/cmake/modules_old" ${CMAKE_MODULE_PATH})
   set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules" ${CMAKE_MODULE_PATH})
-
+  
+  # Use the same boost library as the one used in FairSoft
+  # No need to install it :)
+  set(BOOST_ROOT $ENV{SIMPATH})
   Set(CheckSrcDir "${FAIRROOTPATH}/share/fairbase/cmake/checks")
 ELSE (NOT ALICEO2_MODULAR_BUILD)
   find_package(Boost REQUIRED)

--- a/Examples/flp2epn-distributed/src/FLPSyncSampler.cxx
+++ b/Examples/flp2epn-distributed/src/FLPSyncSampler.cxx
@@ -78,7 +78,7 @@ bool FLPSyncSampler::ConditionalRun()
 
   // rate limiting
   --mEventCounter;
-  while (mEventCounter == 0) {
+  while (mEventCounter <= 0) {
     this_thread::sleep_for(milliseconds(1));
   }
 


### PR DESCRIPTION
One suggestion and a bug fix,

The first is an addition to the root CMakeLists.txt, to search for the boost root in the FairSoft directory, This makes sure that boost is alway found and that FairRoot and the local boost libraries don't conflict

The bug fix regards to flp-epn distributed example, when you place a really low event rate(lower then 5) it will jump to a negative number and spam everything. This is fixed by checking if variable is or is lower then zero