### PR TITLE
Fix duplicate dictionary

### DIFF
--- a/Detectors/TOF/simulation/src/TOFSimulationLinkDef.h
+++ b/Detectors/TOF/simulation/src/TOFSimulationLinkDef.h
@@ -15,6 +15,5 @@
 #pragma link off all functions;
 
 #pragma link C++ class o2::tof::Detector+;
-#pragma link C++ class o2::tof::HitType+;
 
 #endif

--- a/Detectors/TRD/simulation/src/TRDSimulationLinkDef.h
+++ b/Detectors/TRD/simulation/src/TRDSimulationLinkDef.h
@@ -15,6 +15,5 @@
 #pragma link off all functions;
 
 #pragma link C++ class o2::trd::Detector+;
-#pragma link C++ class o2::trd::HitType+;
 
 #endif


### PR DESCRIPTION
The clang version shipping with XCode 9 spotted what seems
to be dictionary duplications for `o2::BasicHitXYZ<float, float>`
probably missed previously because it's actually due to three
different names (`o2::BasicHitXYZ<float, float>`, `o2::trd::HitType`,
`o2::tof::HitType`). `using TypeAlias = Type;` actually defines an alias,
not a new type.