### PR TITLE
Fix problem with duplicate dictionary entries due to alias types

### DIFF
--- a/Detectors/Base/include/DetectorsBase/Detector.h
+++ b/Detectors/Base/include/DetectorsBase/Detector.h
@@ -156,8 +156,8 @@ inline std::string demangle(const char* name)
 
 // a utility function to get the unmangled original (un-aliased)
 // type name given a type to be used as arguments for TClonesArray constructor
-// (which cannot otherwise resolve alias typenames); This function also performs also strong
-// requirements check if T is compatible with a TClonesArray (needs to inherit from TObject)
+// (which cannot otherwise resolve alias typenames); This function also performs strong
+// requirements checks if T is compatible with a TClonesArray (needs to inherit from TObject)
 // AT COMPILE TIME
 template <typename T>
 inline std::string getTClArrTrueTypeName()

--- a/Detectors/EMCAL/simulation/src/Detector.cxx
+++ b/Detectors/EMCAL/simulation/src/Detector.cxx
@@ -40,7 +40,7 @@ Detector::Detector(const char* Name, Bool_t Active)
     mBirkC0(0),
     mBirkC1(0.),
     mBirkC2(0.),
-    mPointCollection(new TClonesArray("o2::EMCAL::Hit")),
+    mPointCollection(new TClonesArray(o2::Base::getTClArrTrueTypeName<Hit>().c_str())),
     mGeometry(nullptr),
     mCurrentTrackID(-1),
     mCurrentCellID(-1),

--- a/Detectors/TOF/simulation/src/Detector.cxx
+++ b/Detectors/TOF/simulation/src/Detector.cxx
@@ -32,7 +32,7 @@ Detector::Detector(const char* Name, Bool_t Active)
   : o2::Base::Detector(Name, Active),
     mEventNr(0),
     mTOFHoles(kTRUE),
-    mHitCollection(new TClonesArray("o2::tof::HitType")),
+    mHitCollection(new TClonesArray(o2::Base::getTClArrTrueTypeName<HitType>().c_str())),
     mMCTrackBranchId(-1)
 {
   for (Int_t i = 0; i < Geo::NSECTORS; i++)

--- a/Detectors/TOF/simulation/src/TOFSimulationLinkDef.h
+++ b/Detectors/TOF/simulation/src/TOFSimulationLinkDef.h
@@ -15,6 +15,5 @@
 #pragma link off all functions;
 
 #pragma link C++ class o2::tof::Detector+;
-#pragma link C++ class o2::tof::HitType+;
 
 #endif

--- a/Detectors/TRD/simulation/src/Detector.cxx
+++ b/Detectors/TRD/simulation/src/Detector.cxx
@@ -21,7 +21,8 @@
 using namespace o2::trd;
 
 Detector::Detector(const char* Name, bool Active)
-  : o2::Base::Detector(Name, Active), mHitCollection(new TClonesArray("o2::trd::HitType"))
+  : o2::Base::Detector(Name, Active), 
+    mHitCollection(new TClonesArray(o2::Base::getTClArrTrueTypeName<HitType>().c_str()))
 {
 }
 

--- a/Detectors/TRD/simulation/src/TRDSimulationLinkDef.h
+++ b/Detectors/TRD/simulation/src/TRDSimulationLinkDef.h
@@ -15,6 +15,5 @@
 #pragma link off all functions;
 
 #pragma link C++ class o2::trd::Detector+;
-#pragma link C++ class o2::trd::HitType+;
 
 #endif


### PR DESCRIPTION
We had a problem with duplicate dictionary entries coming from initiating
TClonesArrays with alias type names:

using T=X;
TClonesArray("T");

Unfortunately, this does not work unless we created a dictionary for T
next to the one for X; This was a requirement from ROOT.

This commit fixes the issue by providing a standalone function which converts a type T
into its original type name "X"; In addition this function performs other important type
checks on T which is otherwise only done during runtime.