### PR TITLE
Adding table view abstraction for data sequences

### DIFF
--- a/Algorithm/CMakeLists.txt
+++ b/Algorithm/CMakeLists.txt
@@ -40,6 +40,7 @@ endif()
 set(TEST_SRCS
   test/headerstack.cxx
   test/parser.cxx
+  test/tableview.cxx
 )
 
 O2_GENERATE_TESTS(

--- a/Algorithm/include/Algorithm/TableView.h
+++ b/Algorithm/include/Algorithm/TableView.h
@@ -86,7 +86,6 @@ public:
   size_t addRow(RowDescType rowData, byte* seqData, size_t seqSize) {
     unsigned nFrames = mFrames.size();
     unsigned currentRow = mRowData.size();
-    mRowData.emplace_back(rowData);
     ParserType p;
     p.parse(seqData, seqSize,
             [](const typename ParserT::HeaderType& h) {return (h);},
@@ -110,7 +109,11 @@ public:
               return result.second;
             }
             );
-    return mFrames.size() - nFrames;
+    auto insertedFrames = mFrames.size() - nFrames;
+    if (insertedFrames > 0) {
+      mRowData.emplace_back(rowData);
+    }
+    return insertedFrames;
   }
 
   /// clear the index, i.e. all internal lists

--- a/Algorithm/include/Algorithm/TableView.h
+++ b/Algorithm/include/Algorithm/TableView.h
@@ -1,0 +1,308 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALGORITHM_TABLEVIEW_H
+#define ALGORITHM_TABLEVIEW_H
+
+/// @file   TableView.h
+/// @author Matthias Richter
+/// @since  2017-09-21
+/// @brief  Container class for multiple sequences of data wrapped by markers
+
+namespace o2 {
+
+namespace algorithm {
+
+/**
+ * @class TableView
+ * Container class for multiple sequences of data wrapped by markers.
+ *
+ * This is a container for data sequences of multiple frames consisting
+ * of a header marker struct, a payload, and an optional trailer marker
+ * struct. Each sequence forms a row in the TableView, the columns
+ * are provided by the markers/frames.
+ *
+ * A parser is used to step through the data sequence and extract
+ * headers, trailers and payload positions.
+ *
+ * Requirements:
+ * - both header and trailer type must provide an operator bool() method
+ *   to check validity
+ * - the size of one frame needs to be extracted either from the header
+ *   marker or the trailer marker. The first requires forward, the latter
+ *   backward parsing. In the first case, the trailer is optional, while
+ *   in the latter required
+ *
+ */
+template<typename RowDescT, // row description
+         typename ColumnDescT, // column description
+         typename ParserT // parser type (forward/backward)
+         >
+class TableView {
+public:
+  TableView() = default;
+  ~TableView() = default;
+
+  using RowDescType = RowDescT;
+  using ColumnIndexType = ColumnDescT;
+  using ParserType = ParserT;
+
+  /// FrameIndex is composed from column description and row number
+  struct FrameIndex {
+    ColumnIndexType columnIndex;
+    unsigned row;
+
+    bool operator<(const FrameIndex& rh) const {
+      if (rh.columnIndex < columnIndex) return false;
+      if (columnIndex < rh.columnIndex) return true;
+      return row < rh.row;
+    }
+  };
+
+  /// descriptor pointing to payload of one frame
+  struct FrameData {
+    const byte* buffer = nullptr;
+    size_t size = 0;
+  };
+
+  /**
+   * Add a new data sequence, the set is traversed according to parser
+   *
+   * TODO: functors to check header and trailer validity as well as retrieving
+   * the frame size could be passed as arguments.
+   *
+   * @param rowData   Descriptive data struct for the sequence
+   * @param seqData    Pointer to sequence
+   * @param seqSize    Length of sequence
+   * @return number of inserted elements
+   */
+  size_t addRow(RowDescType rowData, byte* seqData, size_t seqSize) {
+    unsigned nFrames = mFrames.size();
+    unsigned currentRow = mRowData.size();
+    mRowData.emplace_back(rowData);
+    ParserType p;
+    p.parse(seqData, seqSize,
+            [](const typename ParserT::HeaderType& h) {return (h);},
+            [](const typename ParserT::TrailerType& t) {return (t);},
+            [](const typename ParserT::TrailerType& t) {
+              return t.dataLength + ParserT::totalOffset;
+            },
+            [this, currentRow](typename ParserT::FrameInfo entry) {
+              // insert the header as column index in ascending order
+              auto position = mColumns.begin();
+              while (position != mColumns.end() && *position < *entry.header) {
+                position++;
+              }
+              if (position == mColumns.end() || *entry.header < *position) {
+                mColumns.emplace(position, *entry.header);
+              }
+
+              // insert frame descriptor under key composed from header and row
+              auto result = mFrames.emplace(FrameIndex{*entry.header, currentRow},
+                                            FrameData{entry.payload, entry.length});
+              return result.second;
+            }
+            );
+    return mFrames.size() - nFrames;
+  }
+
+  /// clear the index, i.e. all internal lists
+  void clear() {
+    mFrames.clear();
+    mColumns.clear();
+    mRowData.clear();
+  }
+
+  /// get number of columns in the created index
+  size_t getNColumns() const {return mColumns.size();}
+
+  /// get number of rows, i.e. number rows in the created index
+  size_t getNRows() const {return mRowData.size();}
+
+  /// get row data for a data set
+  const RowDescType& getRowData(size_t row) const {
+    if (row < mRowData.size()) return mRowData[row];
+    // TODO: better to throw exception?
+    static RowDescType dummy;
+    return dummy;
+  }
+
+  // TODO:
+  // instead of a member with this pointer of parent class, the access
+  // function was supposed to be specified as a lambda. This definition
+  // was supposed to be the type of the function member.
+  // passing the access function to the iterator did not work because
+  // the typedef for the access function is without the capture, so there
+  // is no matching conversion.
+  // Solution would be to use std::function but that's probably slow and
+  // the function is called often. Can be checked later.
+  typedef FrameData (*AccessFct)(unsigned, unsigned);
+
+  /// Iterator class for configurable direction, i.e. either row or column
+  class iterator { // TODO: derive from forward_iterator
+  public:
+    using self_type = iterator;
+    using value_type = FrameData;
+
+    enum IteratorDirections {
+      kAlongRow,
+      kAlongColumn
+    };
+
+    iterator() = delete;
+    ~iterator() = default;
+    iterator(IteratorDirections direction, TableView* parent, unsigned row = 0, unsigned column = 0)
+      : mDirection(direction)
+      , mRow(row)
+      , mColumn(column)
+      , mEnd(direction==kAlongRow?parent->getNColumns():parent->getNRows())
+      , mParent(parent)
+      , mCache()
+      , mIsCached(false)
+    {
+      while (!isValid() && !isEnd()) operator++();
+    }
+
+    self_type& operator++() {
+      mIsCached = false;
+      if (mDirection==kAlongRow) {
+        if (mColumn<mEnd) mColumn++;
+      } else {
+        if (mRow<mEnd) mRow++;
+      }
+      while (!isEnd() && !isValid()) operator++();
+      return *this;
+    }
+
+    value_type operator*() const {
+      if (!mIsCached) {
+        self_type* ncthis = const_cast<self_type*>(this);
+        mParent->get(mRow, mColumn, ncthis->mCache);
+        ncthis->mIsCached = true;
+      }
+      return mCache;
+    }
+
+    bool operator==(const self_type& other) const {
+      return mDirection==kAlongRow?(mColumn == other.mColumn):(mRow == other.mRow);
+    }
+
+    bool operator!=(const self_type& other) const {
+      return mDirection==kAlongRow?(mColumn != other.mColumn):(mRow != other.mRow);
+    }
+
+    bool isEnd() const {
+      return (mDirection==kAlongRow)?(mColumn>=mEnd):(mRow>=mEnd);
+    }
+
+    bool isValid() const {
+      if (!mIsCached) {
+        self_type* ncthis = const_cast<self_type*>(this);
+        ncthis->mIsCached = mParent->get(mRow, mColumn, ncthis->mCache);
+      }
+      return mIsCached;
+    }
+
+    const RowDescType& getRowData() const {
+      static RowDescType invalid;
+      return invalid;
+    }
+
+  protected:
+    IteratorDirections mDirection;
+    unsigned mRow;
+    unsigned mColumn;
+    unsigned mEnd;
+    TableView* mParent;
+    value_type mCache;
+    bool mIsCached;
+  };
+
+  /// iterator for the outer access of the index, either row or column direction
+  template<unsigned Direction>
+  class outerIterator : public iterator {
+  public:
+    using base = iterator;
+    using value_type = typename base::value_type;
+    using self_type = outerIterator;
+    static const unsigned direction = Direction;
+
+    outerIterator() = delete;
+    ~outerIterator() = default;
+    outerIterator(TableView* parent, unsigned index)
+      : iterator(typename iterator::IteratorDirections(direction), parent, direction==iterator::kAlongColumn?index:0, direction==iterator::kAlongRow?index:0) {
+    }
+
+    self_type& operator++() {
+      if (base::mDirection==iterator::kAlongRow) {
+        if (base::mColumn<base::mEnd) base::mColumn++;
+      } else {
+        if (base::mRow<base::mEnd) base::mRow++;
+      }
+      return *this;
+    }
+
+    /// begin the inner iteration
+    iterator begin() {
+      return iterator((base::mDirection==iterator::kAlongColumn)?iterator::kAlongRow:iterator::kAlongColumn,
+                      base::mParent,
+                      (base::mDirection==iterator::kAlongColumn)?base::mRow:0,
+                      (base::mDirection==iterator::kAlongRow)?base::mColumn:0);
+    }
+
+    /// end of the inner iteration
+    iterator end() {
+      return iterator((base::mDirection==iterator::kAlongColumn)?iterator::kAlongRow:iterator::kAlongColumn,
+                      base::mParent,
+                      (base::mDirection==iterator::kAlongRow)?base::mParent->getNRows():0,
+                      (base::mDirection==iterator::kAlongColumn)?base::mParent->getNColumns():0);
+    }
+  };
+
+  /// definition of the outer iterator over column
+  using ColumnIterator = outerIterator<iterator::kAlongRow>;
+  /// definition of the outer iterator over row
+  using RowIterator = outerIterator<iterator::kAlongColumn>;
+
+  /// begin of the outer iteration
+  ColumnIterator begin() {
+    return ColumnIterator(this, 0);
+  }
+
+  /// end of outer iteration
+  ColumnIterator end() {
+    return ColumnIterator(this, mColumns.size());
+  }
+
+private:
+  /// private access function for the iterators
+  bool get(unsigned row, unsigned column, FrameData& data) {
+    if (this->mColumns.size() == 0) return false;
+    auto element = this->mFrames.find(FrameIndex{this->mColumns[column], row});
+    if (element != this->mFrames.end()) {
+      data = element->second;
+      return true;
+    }
+    return false;
+  }
+
+  /// map of frame descriptors with key composed from header and row number
+  std::map<FrameIndex, FrameData> mFrames;
+  /// list of indices in row direction
+  std::vector<ColumnIndexType> mColumns;
+  /// data descriptor of each row forming the columns
+  std::vector<RowDescType> mRowData;
+};
+
+} // namespace algorithm
+
+} // namespace o2
+
+#endif // ALGORITHM_TABLEVIEW_H

--- a/Algorithm/test/StaticSequenceAllocator.h
+++ b/Algorithm/test/StaticSequenceAllocator.h
@@ -1,0 +1,135 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   StaticSequenceAllocator.h
+/// @author Matthias Richter, based on work by Mikolaj Krzewicki
+/// @since  2017-09-21
+/// @brief  An allocator for static sequences of object types
+
+namespace o2 {
+namespace algorithm {
+
+/**
+ * Helper struct to define a composite element from a header, some payload
+ * and a trailer
+ */
+template <typename HeaderT
+          , typename TrailerT>
+struct Composite {
+  using HeaderType = HeaderT;
+  using TrailerType = TrailerT;
+  size_t compositeLength = 0;
+  size_t dataLength = 0;
+
+  template<size_t N>
+  constexpr Composite(const HeaderType& h, const char  (&d)[N], const TrailerType& t)
+    : header(h)
+    , data(d)
+    , trailer(t)
+  {
+    dataLength = N;
+    compositeLength = sizeof(HeaderType) + dataLength + sizeof(TrailerType);
+  }
+
+  constexpr size_t getLength() const noexcept {
+    return compositeLength;
+  }
+
+  constexpr size_t getDataLength() const noexcept {
+    return dataLength;
+  }
+
+  template<typename BufferT>
+  constexpr size_t insert(BufferT* buffer) const noexcept {
+    static_assert(sizeof(BufferT) == 1, "buffer required to be of byte-type");
+    size_t length = 0;
+    memcpy(buffer + length, &header, sizeof(HeaderType));
+    length += sizeof(HeaderType);
+    memcpy(buffer + length, data, dataLength);
+    length += dataLength;
+    memcpy(buffer + length, &trailer, sizeof(TrailerType));
+    length += sizeof(TrailerType);
+    return length;
+  }
+
+  const HeaderType& header;
+  const char* data = nullptr;
+  const TrailerType& trailer;
+};
+
+/// recursively calculate the length of the sequence
+/// object types are fixed at compile time and so is the total length of the
+/// sequence. The function is recursively invoked for all arguments of the
+// variable list
+template <typename T, typename... TArgs>
+constexpr size_t sequenceLength(const T& first, const TArgs... args) noexcept {
+  return sequenceLength(first) + sequenceLength(args...);
+}
+
+/// template secialization of sequence length calculation for one argument,
+/// this is also the terminating instance for the last argument of the recursive
+/// invocation of the function template.
+template <typename T>
+constexpr size_t sequenceLength(const T& first) noexcept {
+  return first.getLength();
+}
+
+/// recursive insert of variable number of objects
+template <typename BufferT, typename T, typename... TArgs>
+constexpr size_t sequenceInsert(BufferT* buffer, const T& first, const TArgs... args) noexcept
+{
+  static_assert(sizeof(BufferT) == 1, "buffer required to be of byte-type");
+  auto length = sequenceInsert(buffer, first);
+  length += sequenceInsert(buffer + length, args...);
+  return length;
+}
+
+/// terminating template specialization, i.e. for the last element
+template <typename BufferT, typename T>
+constexpr size_t sequenceInsert(BufferT* buffer, const T& element) noexcept
+{
+  // TODO: make a general algorithm, at the moment this serves the
+  // Composite class as a special case
+  return element.insert(buffer);
+}
+
+/**
+ * Allocator for a buffer of a static sequence of multiple objects.
+ *
+ * The sequence of object types is fixed at compile time and given as
+ * a variable list of arguments to the constructor. The data of the objects
+ * is runtime dependent.
+ *
+ * TODO: probably the Composite struct needs to be reworked to allow this
+ * allocator to be more general
+ */
+struct StaticSequenceAllocator {
+  using value_type = unsigned char;
+  using BufferType = std::unique_ptr<value_type[]>;
+
+  BufferType buffer;
+  size_t bufferSize;
+
+  size_t size() const {return bufferSize;}
+
+  StaticSequenceAllocator() = delete;
+
+  template <typename... Targs>
+  StaticSequenceAllocator(Targs... args)
+  {
+    bufferSize = sequenceLength(args...);
+    buffer = std::make_unique<value_type[]>(bufferSize);
+    sequenceInsert(buffer.get(), args...);
+  }
+};
+
+
+} // namespace algorithm
+} // namespace o2

--- a/Algorithm/test/tableview.cxx
+++ b/Algorithm/test/tableview.cxx
@@ -1,0 +1,122 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   headerstack.cxx
+/// @author Matthias Richter
+/// @since  2017-09-21
+/// @brief  Unit test for table view abstraction class
+
+#define BOOST_TEST_MODULE Test Algorithm TableView
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include <iostream>
+#include <iomanip>
+#include <cstring> // memcmp
+#include "Headers/DataHeader.h" // hexdump, DataHeader
+#include "Headers/HeartbeatFrame.h" // HeartbeatHeader, HeartbeatTrailer
+#include "../include/Algorithm/TableView.h"
+#include "../include/Algorithm/Parser.h"
+#include "StaticSequenceAllocator.h"
+
+using DataHeader = o2::Header::DataHeader;
+using HeartbeatHeader = o2::Header::HeartbeatHeader;
+using HeartbeatTrailer = o2::Header::HeartbeatTrailer;
+
+template<typename... Targs>
+void hexDump(Targs... Fargs) {
+  // a simple redirect to enable/disable the hexdump printout
+  o2::Header::hexDump(Fargs...);
+}
+
+BOOST_AUTO_TEST_CASE(test_tableview_reverse)
+{
+  using FrameT = o2::algorithm::Composite<HeartbeatHeader, HeartbeatTrailer>;
+  using TestFrame = o2::algorithm::StaticSequenceAllocator;
+  // the length of the data is set in the trailer word
+  // the header is used as column description, using slightly different
+  // orbit numbers in the to data sets which will result in two complete
+  // columns at beginning and end, while the two in the middle only have
+  // one row entry
+  TestFrame tf1(FrameT({0x1100000000000000}, "heartbeatdata", {0x510000000000000e}),
+                FrameT({0x1100000000000001}, "test", {0x5100000000000005}),
+                FrameT({0x1100000000000003}, "dummydata", {0x510000000000000a})
+                );
+  TestFrame tf2(FrameT({0x1100000000000000}, "frame2a", {0x5100000000000008}),
+                FrameT({0x1100000000000002}, "frame2b", {0x5100000000000008}),
+                FrameT({0x1100000000000003}, "frame2c", {0x5100000000000008})
+                );
+  hexDump("Test frame 1", tf1.buffer.get(), tf1.size());
+  hexDump("Test frame 2", tf2.buffer.get(), tf2.size());
+
+  // the payload length is set in the trailer, so we need a reverse parser
+  using ParserT = o2::algorithm::ReverseParser<typename FrameT::HeaderType,
+                                               typename FrameT::TrailerType>;
+
+  // define the view type for DataHeader as row descriptor,
+  // HeartbeatHeader as column descriptor and the reverse parser
+  using ViewType = o2::algorithm::TableView<o2::Header::DataHeader,
+                                            o2::Header::HeartbeatHeader,
+                                            ParserT>;
+  ViewType heartbeatview;
+
+  o2::Header::DataHeader dh1;
+  dh1.dataDescription = o2::Header::DataDescription("FIRSTROW");
+  dh1.dataOrigin = o2::Header::DataOrigin("TST");
+  dh1.subSpecification = 0;
+  dh1.payloadSize = 0;
+
+  o2::Header::DataHeader dh2;
+  dh2.dataDescription = o2::Header::DataDescription("SECONDROW");
+  dh2.dataOrigin = o2::Header::DataOrigin("TST");
+  dh2.subSpecification = 0xdeadbeef;
+  dh2.payloadSize = 0;
+
+  heartbeatview.addRow(dh1, tf1.buffer.get(), tf1.size());
+  heartbeatview.addRow(dh2, tf2.buffer.get(), tf2.size());
+
+  std::cout << "slots: " << heartbeatview.getNRows()
+            << " columns: " << heartbeatview.getNColumns()
+            << std::endl;
+
+  // definitions for the data check
+  const char* dataset1[] = {
+    "heartbeatdata",
+    "test",
+    "dummydata"
+  };
+  const char* dataset2[] = {
+    "frame2a",
+    "frame2b",
+    "frame2c"
+  };
+
+  // four orbits are populated, 0 and 3 with 2 rows, 1 and 2 with one row
+  BOOST_REQUIRE(heartbeatview.getNColumns() == 4);
+  BOOST_REQUIRE(heartbeatview.getNRows() == 2);
+  unsigned requiredNofRowsInColumn[] = {2, 1, 1, 2};
+
+  unsigned colidx = 0;
+  unsigned dataset1idx = 0;
+  unsigned dataset2idx = 0;
+  for (auto columnIt = heartbeatview.begin(), end = heartbeatview.end();
+       columnIt != end; ++columnIt, ++colidx) {
+    unsigned rowidx = 0;
+    std::cout << "---------------------------------------" << std::endl;
+    for (auto row : columnIt) {
+      auto dataset = (rowidx == 1 || colidx == 2)? dataset2 : dataset1;
+      auto & datasetidx = (rowidx == 1 || colidx == 2)? dataset2idx : dataset1idx;
+      hexDump("Entry", row.buffer, row.size);
+      BOOST_CHECK(memcmp(row.buffer, dataset[datasetidx++], row.size) == 0);
+      ++rowidx;
+    }
+    BOOST_CHECK(rowidx == requiredNofRowsInColumn[colidx]);
+  }
+}


### PR DESCRIPTION
Container class for multiple sequences of data wrapped by markers.

This is a container for data sequences of multiple frames consisting
of a header marker struct, a payload, and an optional trailer marker
struct. Each sequence forms a row in the TableView, the columns
are provided by the markers/frames.

A parser is used to step through the data sequence and extract
headers, trailers and payload positions.

Factoring out the test frame allocator utility to a separate file
to be used in multiple unit tests. Going to be made more general in
the future.