### PR TITLE
Adding a .clang-tidy configurations file

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,3 @@
+CheckOptions:
+  - key: CheckPathRegex
+    value: '.*/O2/.*'


### PR DESCRIPTION
This file contains (just like .clang-format) project
specific configuration passed to the O2codechecker (or clang-tidy)