### PR TITLE
**WIP**: Use global LabelContainer instead of std::vector in data objects

### DIFF
--- a/DataFormats/simulation/CMakeLists.txt
+++ b/DataFormats/simulation/CMakeLists.txt
@@ -14,6 +14,7 @@ Set(HEADERS
     include/${MODULE_NAME}/BaseHits.h
     include/${MODULE_NAME}/MCTruthContainer.h
     include/${MODULE_NAME}/MCCompLabel.h
+    include/${MODULE_NAME}/LabelContainer.h
 )
 
 Set(LINKDEF src/SimulationDataLinkDef.h)

--- a/DataFormats/simulation/include/SimulationDataFormat/LabelContainer.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/LabelContainer.h
@@ -194,7 +194,7 @@ class LabelContainer : public TNamed
     }
   }
  
-  ClassDefOverride(LabelContainer, 1);
+ //  ClassDefOverride(LabelContainer, 1);
 }; // end class
 
 }

--- a/DataFormats/simulation/include/SimulationDataFormat/LabelContainer.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/LabelContainer.h
@@ -1,0 +1,203 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file MCTruthContainer.h
+/// \brief Definition of a container to keep Monte Carlo truth external to simulation objects
+/// \author Sandro Wenzel - June 2017
+
+#ifndef ALICEO2_DATAFORMATS_LABELCONTAINER_H_
+#define ALICEO2_DATAFORMATS_LABELCONTAINER_H_
+
+#include <TNamed.h>
+#include <cassert>
+#include <stdexcept>
+#include <type_traits>
+#include <iterator>
+#include <gsl/gsl> // for guideline support library; array_view
+#include <iostream>
+
+namespace o2
+{
+namespace dataformats
+{
+   
+template <typename LabelType, bool isContiguousStorage = true>
+class LabelContainer : public TNamed
+{
+ public:
+  struct HeaderElementContinuous {
+    HeaderElementContinuous() = default; // for ROOT IO
+    HeaderElementContinuous(ushort s, uint i) : size(s), index(i) {}
+    uint index = 0; // index of first label in the actual label storage
+    ushort size = 0; // total number of labels
+    ClassDefNV(HeaderElementContinuous, 1);
+  };
+
+  struct HeaderElementLinked {
+    HeaderElementLinked() = default; // for ROOT IO
+    HeaderElementLinked(uint i, int l, ushort s) : index(i), lastindex(l), size(s) {}
+    uint index = 0; // index of first label in the actual label storage
+    uint lastindex = 0; // index of last label in the actual label storage
+    ushort size = 0; // total number of labels
+    ClassDefNV(HeaderElementLinked, 1);
+  };
+
+  using HeaderElement = typename std::conditional<isContiguousStorage, HeaderElementContinuous, HeaderElementLinked>::type;
+  using StoredLabelType = typename std::conditional<isContiguousStorage, LabelType, std::pair<LabelType, int>>::type;
+
+  // internal functions allowing the iterator implementation to be completely generic
+  static uint getNextIndex(uint index, std::vector<LabelType> const &/*labels*/) {
+    return index+1;
+  }
+  static uint getNextIndex(uint index, std::vector<std::pair<LabelType, int>> const &labels) {
+    return labels[index].second;
+  }
+  static LabelType& dereference(std::vector<LabelType> &v, int index) {
+    return v[index];
+  }
+  static LabelType& dereference(std::vector<std::pair<LabelType,int>> &v, int index) {
+    return v[index].first;
+  }
+  static int lastIndex(HeaderElementContinuous const &h) {
+    return h.index + h.size;
+  }
+  static int lastIndex(HeaderElementLinked const &h) {
+    // -1 since this is indication of end of linked list
+    return -1;
+  }
+  
+  // an iterator class to iterate over truthelements 
+  class Iterator : public std::iterator<std::input_iterator_tag, LabelType>
+  {
+    private:
+      std::vector<StoredLabelType> &mLabelsRef; // reference to labels vector
+      int index; // startindex
+    public:
+      Iterator(std::vector<StoredLabelType> &v, int i) : mLabelsRef(v), index(i) {}
+      Iterator(const Iterator& it) : mLabelsRef(it.mLabelsRef), index(it.index) {}
+      Iterator& operator=(const Iterator& it) {
+        mLabelsRef = it.mLabelsRef;
+	index = it.index;
+     	return *this;
+      }
+      
+      // go to the next element as indicated by second entry of StoredLabelType
+      Iterator& operator++() {index=getNextIndex(index, mLabelsRef);return *this;}
+
+      bool operator==(const Iterator& rhs) const {return index==rhs.index;}
+      bool operator!=(const Iterator& rhs) const {return index!=rhs.index;}
+      LabelType& operator*() {return dereference(mLabelsRef, index);}
+  };
+
+  // a proxy class offering a (non-owning) container view on labels of a given data index
+  // container offers basic forward iterator functionality
+  class LabelView {
+   private:
+    int dataindex;
+    std::vector<HeaderElement>& mHeaderArrayRef;
+    std::vector<StoredLabelType>& mLabelArrayRef;
+    
+   public:
+    constexpr LabelView(int i, std::vector<HeaderElement> &v1, std::vector<StoredLabelType> &v2) : dataindex(i), mHeaderArrayRef(v1), mLabelArrayRef(v2) {}
+    
+    // begin + end iterators to loop over the labels
+    Iterator begin() {return dataindex < mHeaderArrayRef.size() ?
+	Iterator(mLabelArrayRef, mHeaderArrayRef[dataindex].index) : Iterator(mLabelArrayRef, 0);
+    }
+
+    Iterator end() {return dataindex < mHeaderArrayRef.size() ?
+	Iterator(mLabelArrayRef, lastIndex(mHeaderArrayRef[dataindex])) : Iterator(mLabelArrayRef, 0);
+    }
+
+    // get number of labels
+    size_t size() const {return dataindex < mHeaderArrayRef.size() ? mHeaderArrayRef[dataindex].size : 0;}
+  };
+
+  static void addLabelImpl(int dataindex, std::vector<HeaderElementContinuous> &headerv, std::vector<LabelType> &labelv, LabelType const &label) {
+    if (dataindex < headerv.size()) {
+      // look if we have something for this dataindex already
+      // must currently be the last one
+      if (dataindex != (headerv.size() - 1)) {
+        throw std::runtime_error("LabelContainer: unsupported code path");
+      }
+    } else {
+      assert(dataindex == headerv.size());
+      // add a new one
+      headerv.emplace_back(0, labelv.size());
+    }
+    auto& header = headerv[dataindex];
+    header.size++;
+    labelv.emplace_back(label);
+  }
+
+  static void addLabelImpl(int dataindex, std::vector<HeaderElementLinked> &headerv, std::vector<std::pair<LabelType,int>> &labelv, LabelType const &label) {
+    labelv.emplace_back(std::make_pair(label,-1));
+    // something exists for this dataindex already
+    if (dataindex < headerv.size()) {
+      auto& header = headerv[dataindex];
+      // increase size
+      header.size++;
+      const auto lastindex = labelv.size();
+      // fix link at previous last index
+      labelv[header.lastindex].second = lastindex;
+      // new last index
+      header.lastindex = lastindex;
+    }
+    else {
+      // we support only appending in order?
+      assert(dataindex == headerv.size());
+      // add a new header element; pointing to last slot in mTruthArray
+      const auto lastpos = labelv.size()-1;
+      headerv.emplace_back(lastpos, lastpos, 1);
+    }
+  }
+
+  // declaring the data members
+  std::vector<HeaderElement> mHeaderArray;  // the header structure array serves as an index into the actual storage
+  std::vector<StoredLabelType> mLabelArray; // the buffer containing the actual truth information
+
+ public:
+  // constructor
+  LabelContainer() = default;
+  ~LabelContainer() final = default;
+
+  void clear()
+  {
+    mHeaderArray.clear();
+    mLabelArray.clear();
+  }
+
+  /// add a label for a dataindex
+ void addLabel(uint dataindex, LabelType const& label) {
+   // refer to concrete specialized implementation
+   addLabelImpl(dataindex, mHeaderArray, mLabelArray, label);
+ }
+
+  /// get a container view on labels allowing use standard forward iteration in user code
+  LabelView getLabels(int dataindex) {return LabelView(dataindex, mHeaderArray, mLabelArray);}
+
+  /// fill an external vector container with labels
+  /// might be useful to perform additional operations such as sorting on the labels;
+  /// the external vector can be reused to avoid allocations/deallocs)
+  void fillVectorOfLabels(int dataindex, std::vector<LabelType> &v) {
+    /// fixme: provide a template specialized fast version for contiguous storage
+    v.clear();
+    for(auto &e : getLabels(dataindex)) {
+      v.push_back(e);
+    }
+  }
+ 
+  ClassDefOverride(LabelContainer, 1);
+}; // end class
+
+}
+}
+
+#endif

--- a/DataFormats/simulation/include/SimulationDataFormat/MCTruthContainer.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCTruthContainer.h
@@ -108,6 +108,140 @@ class MCTruthContainer : public TNamed
 
   ClassDefOverride(MCTruthContainer, 1);
 }; // end class
+
+// -------------------- similar structure resembling more a list ---------------------
+ 
+// a simple struct having information about truth elements for particular indices:
+// how many associations we have and where they start in the storage
+struct MCTruthLinkableHeaderElement {
+  MCTruthLinkableHeaderElement() = default; // for ROOT IO
+
+  MCTruthLinkableHeaderElement(uint i, int l, ushort s) : index(i), lastindex(l), size(s) {}
+  uint index = 0; // the index into the actual MC track storage
+  uint lastindex = 0; // pointer to current last element
+  ushort size = 0; // the number of entries
+  ClassDefNV(MCTruthLinkableHeaderElement, 1);
+};
+
+#include <iterator>  // std::iterator, std::input_iterator_tag
+
+// a container to hold and manage MC truth information
+// the actual MCtruth type is a generic template type and can be supplied by the user
+// It is meant to manage associations from one "dataobject" identified by an index into an array
+// to multiple TruthElements
+
+// note that we inherit from TObject just to be able to register this thing with the FairRootManager
+// (which might not be necessary in the future)
+template <typename TruthElement>
+class MCTruthContainerList : public TNamed
+{
+ private:
+  std::vector<MCTruthLinkableHeaderElement>
+    mHeaderArray;                        // the header structure array serves as an index into the actual storage
+  using StoredLabelType = std::pair<TruthElement, int>; // the element as well as index/location of next label
+  std::vector<StoredLabelType> mTruthArray; // the buffer containing the actual truth information
+
+  // an iterator class to iterate over truthelements 
+  class Iterator : public std::iterator<std::input_iterator_tag, TruthElement>
+  {
+    private:
+      std::vector<StoredLabelType> &mLabelsRef; // reference to labels vector
+      int index; // startindex
+    public:
+      Iterator(std::vector<StoredLabelType> &v, int i) : mLabelsRef(v), index(i) {}
+      Iterator(const Iterator& it) : mLabelsRef(it.mLabelsRef), index(it.index) {}
+      Iterator& operator=(const Iterator& it) {
+        mLabelsRef = it.mLabelsRef;
+	index = it.index;
+        return *this;
+      }
+      
+      // go to the next element as indicated by second entry of StoredLabelType
+      Iterator& operator++() {index=mLabelsRef[index].second;return *this;}
+
+      // pointing to same storage??
+      bool operator==(const Iterator& rhs) const {return index==rhs.index;}
+      bool operator!=(const Iterator& rhs) const {return index!=rhs.index;}
+      TruthElement& operator*() {return mLabelsRef[index].first;}
+  };
+
+  // a proxy class offering a (non-owning) container view on labels of a certain data index
+  // container offers basic forward iterator functionality
+  class LabelView {
+   private:
+    int dataindex;
+    std::vector<MCTruthLinkableHeaderElement>& mHeaderArrayRef;
+    std::vector<StoredLabelType>& mTruthArrayRef;
+    
+    
+   public:
+    constexpr LabelView(int i, std::vector<MCTruthLinkableHeaderElement> &v1, std::vector<StoredLabelType> &v2) : dataindex(i), mHeaderArrayRef(v1), mTruthArrayRef(v2) {}
+    // iterators to access and loop over the elements
+    Iterator begin() { return Iterator(mTruthArrayRef, mHeaderArrayRef[dataindex].index); }
+    Iterator end() { return Iterator(mTruthArrayRef, -1); }
+
+    // get number of labels
+    size_t size() const {return mHeaderArrayRef[dataindex].size;}
+  };
+  
+ public:
+  // constructor
+  MCTruthContainerList() = default;
+  ~MCTruthContainerList() final = default;
+
+  // access
+  MCTruthLinkableHeaderElement getMCTruthHeader(uint dataindex) const { return mHeaderArray[dataindex]; }
+  // access the element directly (can be encapsulated better away)... needs proper element index
+  // which can be obtained from the MCTruthHeader startposition and size
+  TruthElement const& getElement(uint elementindex) const { return mTruthArray[elementindex].first; }
+
+  // return the number of original data indexed here
+  size_t getIndexedSize() const { return mHeaderArray.size(); }
+  // return the number of elements managed in this container
+  size_t getNElements() const { return mTruthArray.size(); }
+
+  // return an iterator over labels for this container
+  // try it out just for zero element
+  Iterator begin(int dataindex) { return Iterator(mTruthArray, mHeaderArray[dataindex].index); }
+  Iterator end() { return Iterator(mTruthArray, -1); }
+
+  LabelView getLabels(int dataindex) { return LabelView(dataindex, mHeaderArray, mTruthArray); }
+  
+  void clear()
+  {
+    mHeaderArray.clear();
+    mTruthArray.clear();
+  }
+
+  // add element for a particular dataindex
+  // this version supports random insertion naturally
+  void addElement(uint dataindex, TruthElement const& element)
+  {
+    mTruthArray.emplace_back(std::make_pair(element,-1));
+    // something exists for this dataindex already
+    if (dataindex < mHeaderArray.size()) {
+      auto& header = mHeaderArray[dataindex];
+      // increase size
+      header.size++;
+      const auto lastindex = mTruthArray.size();
+      // fix link at previous last index
+      mTruthArray[header.lastindex].second = lastindex;
+      // new last index
+      header.lastindex = lastindex;
+    }
+    else {
+      // we support only appending in order?
+      assert(dataindex == mHeaderArray.size());
+      // add a new header element; pointing to last slot in mTruthArray
+      mHeaderArray.emplace_back(mTruthArray.size()-1, mTruthArray.size()-1, 1);
+    }
+  }
+
+  ClassDefOverride(MCTruthContainerList, 1);
+}; // end class
+
+
+
 }
 }
 

--- a/DataFormats/simulation/src/SimulationDataLinkDef.h
+++ b/DataFormats/simulation/src/SimulationDataLinkDef.h
@@ -31,8 +31,14 @@
 #pragma link C++ class o2::BasicXYZEHit<double,double>+;
 #pragma link C++ struct o2::dataformats::MCTruthHeaderElement+;
 #pragma link C++ class o2::dataformats::MCTruthContainer<long>+;
+#pragma link C++ class o2::dataformats::MCTruthContainerList<long>+;
 #pragma link C++ class o2::dataformats::MCTruthContainer<o2::MCCompLabel>+;
-#pragma link C++ class std::vector<o2::MCCompLabel>+;
-#pragma link C++ class std::vector<o2::dataformats::MCTruthHeaderElement>+;
+#pragma link C++ class o2::vector<o2::MCCompLabel>+;
+#pragma link C++ class o2::vector<o2::dataformats::MCTruthHeaderElement>+;
+
+//#pragma link C++ class o2::dataformats::LabelContainer<long,true>::HeaderElementCont+;
+//#pragma link C++ class o2::dataformats::LabelContainer<long,true>::HeaderElementLinked+;
+#pragma link C++ class o2::dataformats::LabelContainer<long,true>+;
+#pragma link C++ class o2::dataformats::LabelContainer<long,false>+;
 
 #endif

--- a/DataFormats/simulation/test/testMCTruthContainer.cxx
+++ b/DataFormats/simulation/test/testMCTruthContainer.cxx
@@ -13,7 +13,9 @@
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
 #include "SimulationDataFormat/MCTruthContainer.h"
+#include "SimulationDataFormat/LabelContainer.h"
 #include <algorithm>
+#include <iostream>
 
 namespace o2
 {
@@ -61,6 +63,79 @@ BOOST_AUTO_TEST_CASE(MCTruth)
   // try to get something invalid
   view = container.getLabels(10);
   BOOST_CHECK(view.size() == 0);
+}
+
+
+BOOST_AUTO_TEST_CASE(MCTruth_Iter)
+{
+  using TruthElement = long;
+  dataformats::MCTruthContainerList<TruthElement> container;
+  container.addElement(0, TruthElement(1));
+  container.addElement(1, TruthElement(1));
+  container.addElement(0, TruthElement(10));
+  container.addElement(2, TruthElement(20));
+
+  BOOST_CHECK(container.getNElements() == 4);
+
+  auto iter = container.begin(2);
+  for(;iter!=container.end();++iter){
+    std::cerr << *iter << "\n";
+  }
+
+  iter = container.begin(2);
+  for(;iter!=container.end();++iter){
+    std::cerr << *iter << "\n";
+  }
+
+  auto view = container.getLabels(0);
+  for(auto &e : view) {
+    std::cerr << e << "\n";
+  }
+ 
+  // FIXME: sorting
+  // std::sort(view.begin(), view.end(), [](TruthElement a, TruthElement b){return a>b;});
+}
+
+  
+BOOST_AUTO_TEST_CASE(LabelContainer_noncont)
+{
+  using TruthElement = long;
+  // creates a container where labels might not be contiguous
+  dataformats::LabelContainer<TruthElement, false> container;
+  container.addLabel(0, TruthElement(1));
+  container.addLabel(1, TruthElement(1));
+  container.addLabel(0, TruthElement(10));
+  container.addLabel(2, TruthElement(20));
+
+  auto view = container.getLabels(0);
+  BOOST_CHECK(view.size() == 2);
+  for(auto &e : view) {
+    std::cerr << e << "\n";
+  }
+
+  std::vector<TruthElement> v;
+  container.fillVectorOfLabels(0,v);  
+  BOOST_CHECK(v.size()==2);
+  std::sort(v.begin(), v.end(), [](TruthElement a, TruthElement b){return a>b;});
+  for(auto &e : v) {
+    std::cerr << e << "\n";
+  }
+  
+  // in this case we have to add the elements contiguously per dataindex:
+  dataformats::LabelContainer<TruthElement, true> cont2;
+  cont2.addLabel(0, TruthElement(1));
+  cont2.addLabel(0, TruthElement(10));
+  cont2.addLabel(1, TruthElement(1));
+  cont2.addLabel(2, TruthElement(20));
+
+  auto view2 = cont2.getLabels(0);
+  BOOST_CHECK(view2.size() == 2);
+  for(auto &e : view2) {
+    std::cerr << e << "\n";
+  }
+
+  // get labels for nonexisting dataelement
+  BOOST_CHECK(cont2.getLabels(100).size() == 0);
 }
 
 } // end namespace


### PR DESCRIPTION
* A new LabelContainer class improving on MCTruthContainer

* Also use such a global LabelContainer during initial pileup of digits; avoid using a std::vector member per such data object;

This PR is work in progress and just meant to discuss on the code; **DO NOT MERGE**;