### PR TITLE
CachingTF1: A variant of TF1 able to persist integral caches

### DIFF
--- a/Common/MathUtils/CMakeLists.txt
+++ b/Common/MathUtils/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SRCS
   src/MathBase.cxx
   src/Cartesian2D.cxx
   src/Cartesian3D.cxx
+  src/CachingTF1.cxx
 )
 
 set(HEADERS
@@ -16,6 +17,7 @@ set(HEADERS
   include/${MODULE_NAME}/MathBase.h
   include/${MODULE_NAME}/Cartesian2D.h
   include/${MODULE_NAME}/Cartesian3D.h
+  include/${MODULE_NAME}/CachingTF1.h
 )
 
 set(LINKDEF src/MathUtilsLinkDef.h)
@@ -27,6 +29,7 @@ O2_GENERATE_LIBRARY()
 
 set(TEST_SRCS
   test/testCartesian3D.cxx
+  test/testCachingTF1.cxx
 )
 
 O2_GENERATE_TESTS(

--- a/Common/MathUtils/include/MathUtils/CachingTF1.h
+++ b/Common/MathUtils/include/MathUtils/CachingTF1.h
@@ -1,0 +1,51 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @brief Extension to ROOT::TF1 allowing to cache integral
+/// @author Sandro Wenzel, sandro.wenzel@cern.ch
+
+#ifndef ALICEO2_CACHINGTF1_H
+#define ALICEO2_CACHINGTF1_H
+
+#include <TF1.h>
+
+namespace o2
+{
+namespace Base
+{
+class CachingTF1 : public TF1
+{
+  ///
+  /// Class extending TF1 with capability to store expensive
+  /// internal caches (integral, etc) when streaming out
+  /// This can immensely speed up the construction of the TF1
+  /// (e.g., for the purpose of random number generation from arbitrary distributions)
+  ///
+ public:
+  using TF1::TF1;
+  ~CachingTF1() override = default;
+
+  // get reading access to fIntegral member
+  std::vector<double> const& getIntegralVector() const { return fIntegral; }
+
+ private:
+  // in the original TF1 implementation, these members
+  // are marked transient; by simply introducing something that
+  // points to them they will now be written correctly to disc
+  std::vector<double>* mIntegralCache = &fIntegral;
+  std::vector<double>* mAlphaCache = &fAlpha;
+  std::vector<double>* mBetaCache = &fBeta;
+  std::vector<double>* mGammaCache = &fGamma;
+  ClassDefOverride(CachingTF1,1);
+};
+}
+}
+
+#endif

--- a/Common/MathUtils/src/CachingTF1.cxx
+++ b/Common/MathUtils/src/CachingTF1.cxx
@@ -1,0 +1,15 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "MathUtils/CachingTF1.h"
+
+using namespace o2::Base;
+
+ClassImp(o2::Base::CachingTF1);

--- a/Common/MathUtils/src/MathUtilsLinkDef.h
+++ b/Common/MathUtils/src/MathUtilsLinkDef.h
@@ -24,5 +24,6 @@
 
 #pragma link C++ class o2::Base::Transform3D+;
 #pragma link C++ class o2::Base::Rotation2D+;
+#pragma link C++ class o2::Base::CachingTF1+;
 
 #endif

--- a/Common/MathUtils/test/testCachingTF1.cxx
+++ b/Common/MathUtils/test/testCachingTF1.cxx
@@ -1,0 +1,43 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test CachingTF1
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include "MathUtils/CachingTF1.h"
+#include <TFile.h>
+
+using namespace o2::Base;
+
+BOOST_AUTO_TEST_CASE(CachingTF1_test)
+{
+  std::string s("std::pow(x, 1.2)*std::exp(-x/3.)");
+  CachingTF1 func("testfunction", s.c_str(), 0, 100.);
+  const int kNPoints=500;
+  func.SetNpx(kNPoints);
+  BOOST_CHECK(func.getIntegralVector().size() == 0);
+
+  BOOST_CHECK(func.GetRandom()>0);
+  auto f = TFile::Open("tmpTF1Cache.root", "recreate");
+  BOOST_CHECK(f);
+  f->WriteTObject(&func,"func");
+  f->Close();
+  // open for reading and verify that integral was cached
+  f = TFile::Open("tmpTF1Cache.root");
+  BOOST_CHECK(f);
+  volatile auto func2 = (CachingTF1*)f->Get("func");
+  BOOST_CHECK(func2);
+  BOOST_CHECK(func2->getIntegralVector().size() == kNPoints+1);
+
+  // check reference
+  auto &ref = *func2;
+  BOOST_CHECK(ref.getIntegralVector().size() == kNPoints+1);
+}

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -259,7 +259,7 @@ o2_define_bucket(
 
     DEPENDENCIES
     common_boost_bucket
-    FairRoot::FairMQ Base FairTools Core MathCore Matrix Minuit Hist Geom GenVector
+    FairRoot::FairMQ Base FairTools Core MathCore Matrix Minuit Hist Geom GenVector RIO
 
     INCLUDE_DIRECTORIES
     ${FAIRROOT_INCLUDE_DIR}
@@ -376,6 +376,7 @@ o2_define_bucket(
     fairroot_base_bucket
     root_physics_bucket
     common_math_bucket
+    RIO
 
     INCLUDE_DIRECTORIES
     ${CMAKE_SOURCE_DIR}/Common/MathUtils/include
@@ -630,6 +631,7 @@ o2_define_bucket(
     root_base_bucket
     fairroot_base_bucket
     common_vc_bucket
+    common_math_bucket
     ParBase
     MathUtils
     Core Hist Gpad
@@ -651,6 +653,7 @@ o2_define_bucket(
     SimulationDataFormat
     Geom
     MathCore
+    MathUtils
     RIO
     Hist
     DetectorsPassive


### PR DESCRIPTION
* The ordinary TF1 does not write state information such as
  internally calculated integrals;
  This extension provides this feature; This was suggested by
  the ROOT team who did not want to change this behaviour in the
  base class

* Application of CachingTF1 in the initialization of the GEMAmplification
  response which is quite compute intensive due to evaluation of integrals
  for the random number generation
  (The idea is that we can put this CachingTF1 into the conditions database
   in the future)
  This caching might be a temporary solution, but until something better is found
  removes a 4s initialization overhead (for each TPC sector).