### PR TITLE
MagFieldFact: Remove strong coupling to FairRunAna

### DIFF
--- a/Common/Field/src/MagFieldFact.cxx
+++ b/Common/Field/src/MagFieldFact.cxx
@@ -11,7 +11,6 @@
 #include "Field/MagFieldFact.h"
 #include "Field/MagFieldParam.h"
 #include "Field/MagneticField.h"
-#include "FairRunAna.h"
 #include "FairRuntimeDb.h"
 #include "FairField.h"
 
@@ -40,8 +39,7 @@ MagFieldFact::~MagFieldFact()
 
 void MagFieldFact::SetParm()
 {
-  FairRunAna *Run = FairRunAna::Instance();
-  FairRuntimeDb *RunDB = Run->GetRuntimeDb();
+  auto RunDB = FairRuntimeDb::instance();
   mFieldPar = (MagFieldParam*) RunDB->getContainer("MagFieldParam");
 }
 


### PR DESCRIPTION
Removing a coupling of MagFieldFact::SetParm() to
FaiRunAna which is
a) not needed since FairRuntimeDb is itself a singleton
b) meant a strong coupling to a FairRunAna which might not be the
   FairRun actually steering the processing