### PR TITLE
Better resource management for MagneticField (unique_ptr)

### DIFF
--- a/Common/Field/include/Field/MagFieldFact.h
+++ b/Common/Field/include/Field/MagFieldFact.h
@@ -17,6 +17,8 @@
 #define ALICEO2_FIELD_MAGFIELDFACT_H
 
 #include "FairFieldFactory.h"
+#include "Field/MagneticField.h"
+#include <memory>
 class FairField;
 
 namespace o2 {
@@ -33,14 +35,14 @@ class MagFieldFact : public FairFieldFactory
   FairField* createFairField() override;
   void SetParm() override;
   
- protected:
-  MagFieldParam* mFieldPar;
-  
  private:
   MagFieldFact(const MagFieldFact&);
   MagFieldFact& operator=(const MagFieldFact&);
 
-  ClassDefOverride(MagFieldFact,1)
+  MagFieldParam* mFieldPar;
+  std::unique_ptr<MagneticField> mField;  // the resource-owning handle to a field
+
+  ClassDefOverride(MagFieldFact,2)
 };
 
 }

--- a/Common/Field/src/MagFieldFact.cxx
+++ b/Common/Field/src/MagFieldFact.cxx
@@ -29,7 +29,8 @@ static MagFieldFact gMagFieldFact;
 
 MagFieldFact::MagFieldFact()
   :FairFieldFactory(),
-   mFieldPar(nullptr)
+   mFieldPar(nullptr),
+   mField()
 {
 	fCreator=this;
 }
@@ -45,15 +46,14 @@ void MagFieldFact::SetParm()
 
 FairField* MagFieldFact::createFairField()
 { 
-  FairField *fMagneticField=nullptr;
-  
   if ( !mFieldPar ) {
     FairLogger::GetLogger()->Error(MESSAGE_ORIGIN, "No field parameters available");
     return nullptr;
   }
   // since we have just 1 field class, we don't need to consider fFieldPar->GetType()
-  fMagneticField = new MagneticField(*mFieldPar);
-  return fMagneticField;
+  mField = std::make_unique<MagneticField>(*mFieldPar);
+  std::cerr << "creating the field\n";
+  return mField.get();
 }
 
 

--- a/macro/run_sim_tpc.C
+++ b/macro/run_sim_tpc.C
@@ -71,8 +71,8 @@ void run_sim_tpc(Int_t nEvents = 10, TString mcEngine = "TGeant3")
   cave->SetGeometryFileName("cave.geo");
   run->AddModule(cave);
 
-  o2::field::MagneticField *magField = new o2::field::MagneticField("Maps","Maps", -1., -1., o2::field::MagFieldParam::k5kG);
-  run->SetField(magField);
+  auto magField = std::make_unique<o2::field::MagneticField>("Maps","Maps", -1., -1., o2::field::MagFieldParam::k5kG);
+  run->SetField(magField.get());
 
   // ===| Add TPC |============================================================
   o2::TPC::Detector* tpc = new o2::TPC::Detector("TPC", kTRUE);


### PR DESCRIPTION
* do not leak memory from MagFieldFact
* use unique_ptr in run_sim_tpc since field is not cleaned up in FairRunSim