### PR TITLE
Fix segfault in destructor of TPC::DigitizerTask

### DIFF
--- a/Detectors/TPC/simulation/src/DigitizerTask.cxx
+++ b/Detectors/TPC/simulation/src/DigitizerTask.cxx
@@ -56,7 +56,7 @@ DigitizerTask::~DigitizerTask()
   delete mDigitizer;
   delete mDigitsArray;
   delete mDigitsDebugArray;
-  if (mHitFileName.c_str()) {
+  if (mHitFileName.size()) {
     mPointsArray->Delete();
     delete mPointsArray;
   }


### PR DESCRIPTION
fixing a segfault which derived from deleting a container
based on an inconsistent condition