### PR TITLE
Adding module Common/Types with ValuePack as first type

### DIFF
--- a/Common/CMakeLists.txt
+++ b/Common/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_subdirectory(MathUtils)
 add_subdirectory(Field)
 add_subdirectory(Configuration)
+add_subdirectory(Types)
 
 install(
     DIRECTORY maps

--- a/Common/Types/CMakeLists.txt
+++ b/Common/Types/CMakeLists.txt
@@ -1,0 +1,47 @@
+# @author Matthias Richter
+# @brief  cmake setup for module Common/Types
+
+set(MODULE_NAME "CommonTypes")
+
+O2_SETUP(NAME ${MODULE_NAME})
+
+set(SRCS
+    )
+
+set(LIBRARY_NAME ${MODULE_NAME})
+
+set(BUCKET_NAME CommonTypes_bucket)
+
+# no library for the moment
+#O2_GENERATE_LIBRARY()
+
+Set(Exe_Names
+    )
+
+set(Exe_Source
+    )
+
+list(LENGTH Exe_Names _length)
+if (LENGTH)
+math(EXPR _length ${_length}-1)
+
+ForEach (_file RANGE 0 ${_length})
+  list(GET Exe_Names ${_file} _name)
+  list(GET Exe_Source ${_file} _src)
+  O2_GENERATE_EXECUTABLE(
+      EXE_NAME ${_name}
+      SOURCES ${_src}
+      MODULE_LIBRARY_NAME ${LIBRARY_NAME}
+      BUCKET_NAME ${BUCKET_NAME}
+  )
+EndForEach (_file RANGE 0 ${_length})
+endif()
+
+set(TEST_SRCS
+  test/valuepack.cxx
+)
+
+O2_GENERATE_TESTS(
+  BUCKET_NAME ${BUCKET_NAME}
+  TEST_SRCS ${TEST_SRCS}
+)

--- a/Common/Types/include/Types/ValuePack.h
+++ b/Common/Types/include/Types/ValuePack.h
@@ -1,0 +1,170 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef TYPES_VALUEPACK_H
+#define TYPES_VALUEPACK_H
+/// @file   ValuePack.h
+/// @author Matthias Richter, Sandro Wenzel
+/// @since  2017-09-28
+/// @brief  A compact representation of bits from multiple values
+
+#include <boost/mpl/vector_c.hpp>
+#include <boost/mpl/vector.hpp>
+#include "boost/mpl/size.hpp"
+#include <boost/mpl/pair.hpp>
+#include <boost/mpl/push_back.hpp>
+#include <boost/mpl/int.hpp>
+#include "boost/mpl/at.hpp"
+#include <boost/mpl/fold.hpp>
+#include <boost/mpl/placeholders.hpp>
+
+namespace mpl = boost::mpl;
+using _1 = mpl::_1;
+using _2 = mpl::_2;
+
+namespace o2 {
+namespace types {
+
+//////////////////////////////////////////////////////////////////////////
+/// Recurssively build the code
+template<typename Rep, typename Iterator, typename End>
+struct CodeInit {
+  using Shift = typename boost::mpl::deref<Iterator>::type;
+  static const Rep mask = (Rep(0x1) << Shift::value) - 1;
+
+  template<typename... Types>
+  static Rep value(size_t arg, Types... args) {
+    return (arg & mask) | CodeInit<Rep, typename boost::mpl::next<Iterator>::type,
+                                   End
+                                   >::value(args...) << Shift::value;
+  }
+};
+
+// specialization terminating the recursive meta function
+template<typename Rep, typename End>
+struct CodeInit<Rep, End, End> {
+  static Rep value() {return 0;}
+};
+
+/**
+* @class ValuePack
+*
+*/
+template<typename Rep, size_t... Layout>
+class ValuePack {
+public:
+  using self_type = ValuePack;
+  using value_type = Rep;
+  using Fields = typename boost::mpl::vector_c<size_t, Layout...>;
+  static const size_t size = sizeof(value_type);
+  static const size_t nbits = mpl::fold<
+    Fields, mpl::int_<0>, mpl::plus<_1, _2>
+    >::type::value;
+  static const size_t nfields = boost::mpl::size<Fields>::type::value;
+  static_assert(nbits <= size * 8, "representing type too narrow");
+
+  /// default constructor all fields will be 0
+  ValuePack() = default;
+
+  /// constructor, the number of arguments must match the Layout
+  /// template parameter
+  template<typename... Types>
+  ValuePack(Types... args) {
+    static_assert(sizeof...(Types) == nfields, "incorrect number of arguments");
+    valuepack = 0;
+    valuepack |= CodeInit<
+      value_type,
+      typename boost::mpl::begin<Fields>::type,
+      typename boost::mpl::end<Fields>::type
+      >::value(args...);
+  }
+
+  ValuePack(const self_type& rhs)
+    : valuepack(rhs.valuepack)
+  {
+    // TODO: could support a type which is effectively a subset of this type
+  }
+
+  decltype(auto) operator=(const self_type& rhs) {
+    // TODO: could support a type which is effectively a subset of this type
+    valuepack = rhs.valuepack;
+    return *this;
+  }
+
+  bool operator==(const self_type& rhs) const {return valuepack == rhs.valuepack;}
+
+  bool operator!=(const self_type& rhs) const {return valuepack != rhs.valuepack;}
+
+  /// operator less than required for maps
+  /// TODO: think about a customn function which can be provided as functor
+  /// type or a lambda
+  bool operator<(const self_type& rhs) const {return valuepack < rhs.valuepack;}
+
+  /// type cast operator
+  operator value_type() const {return valuepack;}
+
+  /// set the field at position
+  template<size_t Position, typename T>
+  void set(T fieldvalue) {
+    static_assert(Position < nfields, "index out of range");
+    using FieldWidth = typename boost::mpl::at_c<Fields, Position>::type;
+    static_assert(FieldWidth::value <= sizeof(T) * 8, "type too narrow to get value");
+    using Shift = GetShift<Fields, Position>;
+    static const auto mask = (value_type(0x1) << FieldWidth::value) - 1;
+
+    valuepack &= ~(mask << Shift::value);
+    valuepack |= (fieldvalue & mask) << Shift::value;
+  }
+
+  /// get the value of field at position
+  template<size_t Position, typename T>
+  T get() const {
+    static_assert(Position < nfields, "index out of range");
+    using FieldWidth = typename boost::mpl::at_c<Fields, Position>::type;
+    static_assert(FieldWidth::value <= sizeof(T) * 8, "type too narrow to get value");
+    using Shift = GetShift<Fields, Position>;
+    static const auto mask = (value_type(0x1) << FieldWidth::value) - 1;
+
+    return (valuepack >> Shift::value) & mask;
+  }
+
+private:
+  /// calculate bit shift for field at position, i.e. sum of width of
+  /// preceeding fields
+  template<typename Sequence, size_t Position>
+  struct GetShift {
+    using type = typename mpl::fold<
+      // the sequence to iterate over, elements provided in placeholder _2
+      Sequence,
+      // initial condition with a pair of two numbers, first one is increment
+      // for every element and checked against position argument, second number
+      // accumulates the sum until position is reached
+      mpl::pair<mpl::int_<0>, mpl::int_<0>>,
+      // the operation for every element of the sequence
+      mpl::pair<mpl::next< mpl::first<_1>>,
+              // if first is less than position, add element to second
+              // forward second unchanged otherwise
+                mpl::if_<mpl::less<mpl::first<_1>, mpl::int_<Position>>,
+                         mpl::plus< mpl::second<_1>, _2 >,
+                         mpl::second<_1>
+                         >
+                >
+      >::type::second; // take the second number which accumulated the sum
+    static const size_t value = type::value;
+  };
+
+  value_type valuepack = 0;
+};
+
+
+} // namespace types
+} // namespace o2
+
+#endif //TYPES_VALUEPACK_H

--- a/Common/Types/test/valuepack.cxx
+++ b/Common/Types/test/valuepack.cxx
@@ -1,0 +1,53 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   valuepack.cxx
+/// @author Matthias Richter
+/// @since  2017-09-28
+/// @brief  Unit test for ValuePack type
+
+#define BOOST_TEST_MODULE Test Type Value Pack
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include <iostream>
+#include <iomanip>
+#include <vector>
+#include <bitset>
+#include "../include/Types/ValuePack.h"
+
+BOOST_AUTO_TEST_CASE(test_valuepack)
+{
+  using TwoFourNinePack = o2::types::ValuePack<unsigned int, 2, 4, 9>;
+  std::cout << TwoFourNinePack::nbits << " "
+            << TwoFourNinePack::nfields << " "
+            << TwoFourNinePack::size << " "
+            << std::endl;
+
+  BOOST_CHECK(TwoFourNinePack::nbits == 15);
+  BOOST_CHECK(TwoFourNinePack::nfields == 3);
+
+  TwoFourNinePack pack(3, 6, 1022);
+  std::cout << "pack from values 3, 6, 1022:" << std::endl;
+
+  std::cout << "0x" << std::hex << pack
+            << ": " << std::bitset<TwoFourNinePack::nbits>(pack) << std::endl;
+
+  BOOST_CHECK((pack.get<0, unsigned int>()) == 3);
+  BOOST_CHECK((pack.get<1, unsigned int>()) == 6);
+  BOOST_CHECK((pack.get<2, unsigned int>()) == 510);
+
+  pack.set<1>(0xa);
+  std::cout << "0x" << std::hex << pack
+            << ": " << std::bitset<TwoFourNinePack::nbits>(pack) << std::endl;
+  BOOST_CHECK((pack.get<1, unsigned int>()) == 10);
+
+  TwoFourNinePack copy = pack;
+}

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -1062,3 +1062,13 @@ o2_define_bucket(
 
     INCLUDE_DIRECTORIES
 )
+
+o2_define_bucket(
+    NAME
+    CommonTypes_bucket
+
+    DEPENDENCIES
+    common_boost_bucket
+
+    INCLUDE_DIRECTORIES
+)


### PR DESCRIPTION
ValuePack allows to assemble multiple values with a fixed layout
of bit widths in one type T. Name is tentative

@sawenzel this is the prototype we have been discussing today, I have added some more operators and also the field setter.