### PR TITLE
Provide concrete implementation for default constructors of TOF/TRD

### DIFF
--- a/Detectors/TOF/simulation/include/TOFSimulation/Detector.h
+++ b/Detectors/TOF/simulation/include/TOFSimulation/Detector.h
@@ -21,6 +21,7 @@
 class FairVolume;
 class TClonesArray;
 
+
 namespace o2
 {
 namespace tof

--- a/Detectors/TOF/simulation/include/TOFSimulation/Detector.h
+++ b/Detectors/TOF/simulation/include/TOFSimulation/Detector.h
@@ -49,7 +49,7 @@ class Detector : public o2::Base::Detector
     kHoneyHoles = 16
   };
 
-  Detector() = default;
+  Detector();
 
   Detector(const char* Name, Bool_t Active);
 

--- a/Detectors/TOF/simulation/src/Detector.cxx
+++ b/Detectors/TOF/simulation/src/Detector.cxx
@@ -28,6 +28,15 @@ using namespace o2::tof;
 
 ClassImp(Detector);
 
+Detector::Detector()
+  : o2::Base::Detector("TOF", kTRUE), 
+    mEventNr(0),
+    mTOFHoles(kTRUE),
+    mHitCollection(new TClonesArray(o2::Base::getTClArrTrueTypeName<HitType>().c_str())),
+    mMCTrackBranchId(-1)
+{
+}
+
 Detector::Detector(const char* Name, Bool_t Active)
   : o2::Base::Detector(Name, Active),
     mEventNr(0),

--- a/Detectors/TRD/simulation/include/TRDSimulation/Detector.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Detector.h
@@ -30,7 +30,7 @@ using HitType = o2::BasicXYZEHit<float>;
 class Detector : public o2::Base::Detector
 {
  public:
-  Detector() = default;
+  Detector();
 
   Detector(const char* Name, bool Active);
 
@@ -58,13 +58,13 @@ class Detector : public o2::Base::Detector
   template <typename T>
   void addHit(T x, T y, T z, T time, T energy, int trackId, int detId);
 
-  TClonesArray* mHitCollection; ///< Collection of TRD hits
+  TClonesArray* mHitCollection; ///!< Collection of TRD hits
 
   float mFoilDensity;
   float mGasNobleFraction;
   float mGasDensity;
 
-  TRDGeometry* mGeom = nullptr;
+  TRDGeometry* mGeom = nullptr; //!
 
   ClassDefOverride(Detector, 1)
 };

--- a/Detectors/TRD/simulation/src/Detector.cxx
+++ b/Detectors/TRD/simulation/src/Detector.cxx
@@ -21,7 +21,13 @@
 using namespace o2::trd;
 
 Detector::Detector(const char* Name, bool Active)
-  : o2::Base::Detector(Name, Active), 
+  : o2::Base::Detector(Name, Active),
+    mHitCollection(new TClonesArray(o2::Base::getTClArrTrueTypeName<HitType>().c_str()))
+{
+}
+
+Detector::Detector()
+  : o2::Base::Detector("TRD", kTRUE),
     mHitCollection(new TClonesArray(o2::Base::getTClArrTrueTypeName<HitType>().c_str()))
 {
 }


### PR DESCRIPTION
It seems we need a concrete implementation of constructors for detector modules, as
otherwise FairRunAna crashes when reading FairBaseParSets.

The present commit fixes this problem, but it is not clear whether this
is the best solution. More investigation might be needed.

Relates to issue #600.