### PR TITLE
common ITS/MFT clusterer must be in ITSMFT namespace

### DIFF
--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/ClustererTask.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/ClustererTask.h
@@ -30,6 +30,7 @@ namespace ITS
 class ClustererTask : public FairTask
 {
   using DigitPixelReader = o2::ITSMFT::DigitPixelReader;
+  using Clusterer = o2::ITSMFT::Clusterer;
   
  public:
   ClustererTask();

--- a/Detectors/ITSMFT/MFT/reconstruction/include/MFTReconstruction/ClustererTask.h
+++ b/Detectors/ITSMFT/MFT/reconstruction/include/MFTReconstruction/ClustererTask.h
@@ -32,7 +32,7 @@ namespace o2
     class ClustererTask : public FairTask
     {
       using DigitPixelReader = o2::ITSMFT::DigitPixelReader;
-      using Clusterer        = o2::ITS::Clusterer;
+      using Clusterer        = o2::ITSMFT::Clusterer;
   
     public:
       

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
@@ -26,7 +26,7 @@ class TClonesArray;
 
 namespace o2
 {
-namespace ITS
+namespace ITSMFT
 {
   
 class Clusterer {

--- a/Detectors/ITSMFT/common/reconstruction/src/Clusterer.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/Clusterer.cxx
@@ -18,7 +18,6 @@
 #include "ITSMFTReconstruction/Clusterer.h"
 #include "ITSMFTReconstruction/Cluster.h"
 
-using namespace o2::ITS;
 using namespace o2::ITSMFT;
 
 Float_t Clusterer::mPitchX=0.002;


### PR DESCRIPTION
This is a trivial namespace fix, can this be merged quickly?