### PR TITLE
Update code affected by breaking FairMQ changes.

### DIFF
--- a/Examples/flp2epn-distributed/src/EPNReceiver.cxx
+++ b/Examples/flp2epn-distributed/src/EPNReceiver.cxx
@@ -23,6 +23,8 @@
 
 #include "FLP2EPNex_distributed/EPNReceiver.h"
 
+#include <iomanip>
+
 using namespace std;
 using namespace std::chrono;
 using namespace o2::Devices;

--- a/Framework/Core/src/TextControlService.cxx
+++ b/Framework/Core/src/TextControlService.cxx
@@ -11,6 +11,7 @@
 #include "FairMQLogger.h"
 #include <string>
 #include <regex>
+#include <iostream>
 
 namespace o2 {
 namespace framework {

--- a/Utilities/DataFlow/src/EPNReceiverDevice.cxx
+++ b/Utilities/DataFlow/src/EPNReceiverDevice.cxx
@@ -20,6 +20,8 @@
 #include "Headers/SubframeMetadata.h"
 #include "TimeFrame/TimeFrame.h"
 
+#include <iomanip>
+
 using namespace std;
 using namespace std::chrono;
 using namespace o2::Devices;

--- a/Utilities/DataFlow/src/TimeframeValidationTool.cxx
+++ b/Utilities/DataFlow/src/TimeframeValidationTool.cxx
@@ -16,6 +16,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <unistd.h>
+#include <fstream>
 
 // A simple tool which verifies timeframe files
 int main(int argc, char **argv) {

--- a/Utilities/QC/QCMerger/src/Merger.cxx
+++ b/Utilities/QC/QCMerger/src/Merger.cxx
@@ -18,6 +18,8 @@
 
 #include "QCMerger/Merger.h"
 
+#include <sstream>
+
 using namespace std;
 
 namespace o2

--- a/Utilities/QC/QCMerger/src/runMerger.cxx
+++ b/Utilities/QC/QCMerger/src/runMerger.cxx
@@ -97,7 +97,6 @@ int main(int argc, char** argv)
   bpo::notify(vm);
 
   MergerDevice mergerDevice(unique_ptr<Merger>(new Merger(NUMBER_OF_QC_OBJECTS_FOR_COMPLETE_DATA)), MERGER_DEVICE_ID);
-  mergerDevice.CatchSignals();
 
   LOG(INFO) << "PID: " << getpid();
   LOG(INFO) << "Merger id: " << mergerDevice.GetId();

--- a/Utilities/QC/QCProducer/src/runProducer.cxx
+++ b/Utilities/QC/QCProducer/src/runProducer.cxx
@@ -77,7 +77,6 @@ int main(int argc, char** argv)
   }
 
   ProducerDevice producerDevice(producerId, producer);
-  producerDevice.CatchSignals();
 
   LOG(INFO) << "PID: " << getpid();
   LOG(INFO) << "Producer id: " << producerDevice.GetId();

--- a/Utilities/QC/QCViewer/src/runViewerDevice.cxx
+++ b/Utilities/QC/QCViewer/src/runViewerDevice.cxx
@@ -25,7 +25,6 @@ int main(int argc, char** argv)
     drawingOptions = argv[1];
   }
   ViewerDevice viewerDevice("Viewer_1", drawingOptions);
-  viewerDevice.CatchSignals();
   auto* app = new TApplication("app1", &argc, argv);
 
   LOG(INFO) << "PID: " << getpid();

--- a/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/EventSampler.h
+++ b/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/EventSampler.h
@@ -83,10 +83,6 @@ public:
   /// sampler loop started in a separate thread
   void samplerLoop();
 
-  /////////////////////////////////////////////////////////////////
-  // device property identifier
-  enum { Id = FairMQDevice::Last, PollingTimeout, SkipProcessing, EventPeriod, InitialDelay, OutputFile, Last };
-
 protected:
 
 private:

--- a/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/WrapperDevice.h
+++ b/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/WrapperDevice.h
@@ -76,10 +76,6 @@ public:
   /// inherited from FairMQDevice
   void Run() override;
 
-  /////////////////////////////////////////////////////////////////
-  // device property identifier
-  enum { Id = FairMQDevice::Last, PollingPeriod, SkipProcessing, Last };
-
 protected:
 
 private:


### PR DESCRIPTION
This patch adapts O2 code to breaking FairMQ changes (coming to FairRoot dev branch when FairRootGroup/FairRoot#607 is merged). Merge after the FairRoot PR is merged (and O2 fork is updated).

Following changes require update of O2 code (done in this PR):

- removal of `FairMQConfigurable`.
  - Since long unused by O2, but still some remaining dead code (`FairMQDevice::Last`). (**backwards-compatible**)
- FairMQLogger header no longer includes `<iostream>`.
  - Some includes must be added in O2. (**backwards-compatible**)
- introduction of `DeviceRunner`, control/config plugins, removal of `runSimpleMQStateMachine`.
  - This simplifies some of the setup code for devices that have custom `main()`. For O2 this is `Framework/Core/src/runDataProcessing` (fixed in this PR) and QC devices (this PR brings them to working state, however maintainers should consider switching them to use DeviceRunner/plugins, as no custom main is required for them. Feel free to contact me if help with this is needed). (**non-backwards-compatible**)
