### PR TITLE
Integrate basic version of MFT into o2sim

### DIFF
--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -987,6 +987,7 @@ o2_define_bucket(
     DetectorsPassive
     TPCSimulation
     ITSSimulation
+    MFTSimulation
     TRDSimulation
     EMCALSimulation
     TOFSimulation

--- a/macro/build_geometry.C
+++ b/macro/build_geometry.C
@@ -23,6 +23,7 @@
 #include <Field/MagneticField.h>
 #include <TPCSimulation/Detector.h>
 #include <ITSSimulation/Detector.h>
+#include <MFTSimulation/Detector.h>
 #include <EMCALSimulation/Detector.h>
 #include <TOFSimulation/Detector.h>
 #include <TRDSimulation/Detector.h>
@@ -142,6 +143,12 @@ void build_geometry(FairRunSim* run = nullptr)
     // its
     auto its = new o2::ITS::Detector(true);
     run->AddModule(its);
+  }
+
+  if (isActivated("MFT")){
+    // mft
+    auto mft = new o2::MFT::Detector();
+    run->AddModule(mft);
   }
   
   if (isActivated("EMC")){


### PR DESCRIPTION
MFT detector is now compiled into o2sim executable

By default it is not yet activated as it has problems with the segmentation configuration
which needs to be addressed.