### PR TITLE
fix MaxROFrame calculation: avoid UInt of t<0

### DIFF
--- a/Detectors/ITSMFT/common/simulation/src/Digitizer.cxx
+++ b/Detectors/ITSMFT/common/simulation/src/Digitizer.cxx
@@ -62,8 +62,9 @@ void Digitizer::process(TClonesArray* hits, TClonesArray* digits)
 		 << mParams.getTimeOffset() << FairLogger::endl;
     return;
   }
-  
-  UInt_t minNewROFrame = static_cast<UInt_t>(hTime0)/mParams.getROFrameLenght();
+
+  if (hTime0<0) hTime0 = 0.;
+  UInt_t minNewROFrame = static_cast<UInt_t>(hTime0/mParams.getROFrameLenght());
 
   LOG(INFO) << "Digitizing ITS event at time " << mEventTime
 	    << " (TOffset= " << mParams.getTimeOffset() << " ROFrame= " << minNewROFrame << ")"

--- a/Detectors/ITSMFT/common/simulation/src/SimulationAlpide.cxx
+++ b/Detectors/ITSMFT/common/simulation/src/SimulationAlpide.cxx
@@ -130,8 +130,8 @@ void SimulationAlpide::Hits2Digits(const SegmentationPixel *seg, Double_t eventT
     }
     
     // calculate RO Frame for this hit
-    UInt_t roframe = static_cast<UInt_t>(hTime0);
-    roframe /= mParams->getROFrameLenght();
+    if (hTime0<0) hTime0 = 0.;
+    UInt_t roframe = static_cast<UInt_t>(hTime0/mParams->getROFrameLenght());
     if (roframe<minFr) minFr = roframe;
     if (roframe>maxFr) maxFr = roframe;
     


### PR DESCRIPTION
This is a bug fix, in some situations UInt_t of negative value was calculated, leading to overflow in the ROFrame