### PR TITLE
Strongly typed hits in ITS + other minor changes

### DIFF
--- a/Detectors/ITSMFT/ITS/macros/test/CheckClusters.C
+++ b/Detectors/ITSMFT/ITS/macros/test/CheckClusters.C
@@ -16,6 +16,7 @@
   #include "ITSBase/GeometryTGeo.h"
   #include "ITSMFTReconstruction/Cluster.h"
   #include "SimulationDataFormat/MCCompLabel.h"
+  #include <vector>
 #endif
 
 using namespace o2::Base;
@@ -42,9 +43,10 @@ void CheckClusters(Int_t nEvents = 10, TString mcEngine = "TGeant3") {
   sprintf(filename, "AliceO2_%s.mc_%i_event.root", mcEngine.Data(), nEvents);
   TFile *file0 = TFile::Open(filename);
   TTree *hitTree=(TTree*)gFile->Get("o2sim");
-  TClonesArray hitArr("o2::ITSMFT::Hit"), *phitArr(&hitArr);
-  hitTree->SetBranchAddress("ITSHit",&phitArr);
+  std::vector<o2::ITSMFT::Hit> *hitArray = nullptr;
+  hitTree->SetBranchAddress("ITSHit", &hitArray);
 
+  
   // Clusters
   sprintf(filename, "AliceO2_%s.clus_%i_event.root", mcEngine.Data(), nEvents);
   TFile *file1 = TFile::Open(filename);
@@ -79,12 +81,10 @@ void CheckClusters(Int_t nEvents = 10, TString mcEngine = "TGeant3") {
 	  hitTree->GetEvent(ievH);
 	  lastReadHitEv = ievH;
 	}
-	Int_t nh = hitArr.GetEntriesFast();
-	for (Int_t i=0; i<nh; i++) {
-	  Hit* ptmp = static_cast<Hit *>(hitArr.UncheckedAt(i));
-	  if (ptmp->GetDetectorID() != chipID) continue; 
-	  if (ptmp->GetTrackID() != trID) continue;
-	  p = ptmp;
+	for (auto& ptmp : *hitArray) {
+	  if (ptmp.GetDetectorID() != chipID) continue; 
+	  if (ptmp.GetTrackID() != trID) continue;
+	  p = &ptmp;
 	  break;
 	}
 	if (!p) {

--- a/Detectors/ITSMFT/ITS/macros/test/CheckDigits.C
+++ b/Detectors/ITSMFT/ITS/macros/test/CheckDigits.C
@@ -15,6 +15,7 @@
   #include "ITSMFTBase/Digit.h"
   #include "ITSMFTSimulation/Hit.h"
   #include "ITSBase/GeometryTGeo.h"
+  #include <vector>
 #endif
 
 using namespace o2::Base;
@@ -44,8 +45,8 @@ void CheckDigits(Int_t nEvents = 10, TString mcEngine = "TGeant3") {
   sprintf(filename, "AliceO2_%s.mc_%i_event.root", mcEngine.Data(), nEvents);
   TFile *file0 = TFile::Open(filename);
   TTree *hitTree=(TTree*)gFile->Get("o2sim");
-  TClonesArray hitArr("o2::ITSMFT::Hit"), *phitArr(&hitArr);
-  hitTree->SetBranchAddress("ITSHit",&phitArr);
+  std::vector<o2::ITSMFT::Hit> *hitArray = nullptr;
+  hitTree->SetBranchAddress("ITSHit", &hitArray);
 
   // Digits
   sprintf(filename, "AliceO2_%s.digi_%i_event.root", mcEngine.Data(), nEvents);
@@ -83,14 +84,12 @@ void CheckDigits(Int_t nEvents = 10, TString mcEngine = "TGeant3") {
 	  hitTree->GetEvent(ievH);
 	  lastReadHitEv = ievH;
 	}
-	Int_t nh=hitArr.GetEntriesFast();
 
-	for (Int_t i=0; i<nh; i++) {
-	  Hit *p=(Hit *)hitArr.UncheckedAt(i);
-	  if (p->GetDetectorID() != chipID) continue; 
-	  if (p->GetTrackID() != trID) continue;
-	  auto locH    = gman->getMatrixL2G(chipID)^( p->GetPos() );  // inverse conversion from global to local
-	  auto locHsta = gman->getMatrixL2G(chipID)^( p->GetPosStart() );
+	for (auto& p : *hitArray) {
+	  if (p.GetDetectorID() != chipID) continue; 
+	  if (p.GetTrackID() != trID) continue;
+	  auto locH    = gman->getMatrixL2G(chipID)^( p.GetPos() );  // inverse conversion from global to local
+	  auto locHsta = gman->getMatrixL2G(chipID)^( p.GetPosStart() );
 	  locH.SetXYZ( 0.5*(locH.X()+locHsta.X()),0.5*(locH.Y()+locHsta.Y()),0.5*(locH.Z()+locHsta.Z()) );
 	  int row,col;
 	  float xlc,zlc;

--- a/Detectors/ITSMFT/ITS/macros/test/DisplayTrack.C
+++ b/Detectors/ITSMFT/ITS/macros/test/DisplayTrack.C
@@ -16,6 +16,7 @@
   #include <TClonesArray.h>
   #include <TMath.h>
   #include <TString.h>
+  #include <vector>
 
   #include "SimulationDataFormat/MCCompLabel.h"
   #include "ITSMFTSimulation/Hit.h"
@@ -88,19 +89,19 @@ void DisplayTrack(Int_t nEvents = 10, TString mcEngine = "TGeant3", Int_t event=
   TEvePointSet* points = new TEvePointSet(s.data());
   points->SetMarkerColor(kBlue);
 
-  TClonesArray pntArr("o2::ITSMFT::Hit"), *ppntArr(&pntArr);
-  tree->SetBranchAddress("ITSHit",&ppntArr);
+  std::vector<o2::ITSMFT::Hit>* hitArr = nullptr;
+  tree->SetBranchAddress("ITSHit", &hitArr);
 
   tree->GetEvent(event);
 
-  Int_t nc=pntArr.GetEntriesFast(), n=0;
+  Int_t nc=hitArr->size(), n=0;
   while(nc--) {
-      Hit *c=static_cast<Hit *>(pntArr.UncheckedAt(nc));
-      if (c->GetTrackID() == track) {
-         points->SetNextPoint(c->GetX(),c->GetY(),c->GetZ());
-         n++;
-      }      
-  } 
+    Hit& c=(*hitArr)[nc];
+    if (c.GetTrackID() == track) {
+      points->SetNextPoint(c.GetX(),c.GetY(),c.GetZ());
+      n++;
+    }
+  }
   cout<<"Number of points: "<<n<<endl;
 
   gEve->AddElement(points,0);

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
@@ -16,16 +16,17 @@
 
 #include "DetectorsBase/Detector.h"   // for Detector
 #include "DetectorsBase/DetID.h"   // for Detector
+#include "ITSMFTSimulation/Hit.h"     // for Hit
 #include "Rtypes.h"          // for Int_t, Double_t, Float_t, Bool_t, etc
 #include "TArrayD.h"         // for TArrayD
 #include "TGeoManager.h"     // for gGeoManager, TGeoManager (ptr only)
 #include "TLorentzVector.h"  // for TLorentzVector
 #include "TVector3.h"        // for TVector3
+#include <vector>            // for vector
 
 class FairModule;
 
 class FairVolume;
-class TClonesArray;
 class TGeoVolume;
 
 class TParticle;
@@ -154,7 +155,7 @@ class Detector : public o2::Base::Detector
                                     UInt_t &dettype) const;
 
     /// This method is an example of how to add your own point of type Hit to the clones array
-    o2::ITSMFT::Hit *addHit(int trackID, int detID, TVector3 startPos, TVector3 endPos, TVector3 startMom,
+    o2::ITSMFT::Hit *addHit(int trackID, int detID, const TVector3& startPos, const TVector3& endPos, const TVector3& startMom,
 				   double startE, double endTime, double eLoss,
 				   unsigned char startStatus, unsigned char endStatus);
 
@@ -296,8 +297,9 @@ class Detector : public o2::Base::Detector
     UInt_t *mChipTypeID;           //! Vector of detector type id
     Int_t *mBuildLevel;            //! Vector of Material Budget Studies
 
-    /// Container for data points
-    TClonesArray *mHitCollection;
+    /// Container for hit data
+    // TClonesArray *mHitCollection;
+    std::vector<o2::ITSMFT::Hit>* mHits;
 
     /// Creates an air-filled wrapper cylindrical volume
     TGeoVolume *createWrapperVolume(const Int_t nLay);

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/DigitizerTask.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/DigitizerTask.h
@@ -25,6 +25,8 @@
 
 #include "ITSMFTSimulation/DigiParams.h"
 #include "ITSMFTSimulation/Digitizer.h"
+#include "ITSMFTSimulation/Hit.h"
+#include <vector>
 
 class TClonesArray;
 
@@ -64,7 +66,7 @@ class DigitizerTask : public FairTask
   Int_t mSourceID = 0;                  ///< current source
   Int_t mEventID = 0;                   ///< current event id from the source
   Digitizer mDigitizer;                 ///< Digitizer
-  TClonesArray* mHitsArray = nullptr;   ///< Array of MC hits
+  const std::vector<o2::ITSMFT::Hit>* mHitsArray = nullptr;   ///< Array of MC hits
   TClonesArray* mDigitsArray = nullptr; ///< Array of digits
 
   ClassDefOverride(DigitizerTask, 1);

--- a/Detectors/ITSMFT/ITS/simulation/src/DigitizerTask.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/DigitizerTask.cxx
@@ -17,6 +17,7 @@
 //
 
 #include "ITSSimulation/DigitizerTask.h"
+#include "ITSMFTSimulation/Hit.h"
 #include "DetectorsBase/Utils.h"
 #include "ITSBase/GeometryTGeo.h"
 
@@ -58,7 +59,7 @@ InitStatus DigitizerTask::Init()
     return kERROR;
   }
 
-  mHitsArray = dynamic_cast<TClonesArray*>(mgr->GetObject("ITSHit"));
+  mHitsArray = mgr->InitObjectAs<const std::vector<o2::ITSMFT::Hit>*>("ITSHit");
   if (!mHitsArray) {
     LOG(ERROR) << "ITS hits not registered in the FairRootManager. Exiting ..." << FairLogger::endl;
     return kERROR;
@@ -102,7 +103,7 @@ void DigitizerTask::Exec(Option_t* option)
   mDigitizer.setCurrSrcID( mSourceID );
   mDigitizer.setCurrEvID( mEventID );
   
-  mDigitizer.process(mHitsArray,mDigitsArray);
+  mDigitizer.process(const_cast<std::vector<o2::ITSMFT::Hit>*>(mHitsArray),mDigitsArray);
 
   mEventID++;
 }

--- a/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Digitizer.h
+++ b/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Digitizer.h
@@ -44,7 +44,9 @@ namespace o2
 
       /// Steer conversion of points to digits
       void   process(TClonesArray* points, TClonesArray* digits);
-
+      /// new version
+      void   process(std::vector<Hit>* hits, TClonesArray* digits);
+      
       void   setEventTime(double t);
       double getEventTime()        const  {return mEventTime;}
 

--- a/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Hit.h
+++ b/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Hit.h
@@ -124,9 +124,6 @@ class Hit : public o2::BasicXYZEHit<Float_t,Float_t>
     }
     
   private:
-    /// Copy constructor
-    Hit(const Hit &point);
-    Hit operator=(const Hit &point);
     Vector3D<Float_t> mMomentum;              ///< momentum at entrance
     Point3D<Float_t> mPosStart;               ///< position at entrance (base mPos give position on exit)
     Float_t mE;                               ///< total energy at entrance

--- a/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Hit.h
+++ b/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Hit.h
@@ -52,7 +52,7 @@ class Hit : public o2::BasicXYZEHit<Float_t,Float_t>
     /// \param eLoss Energy deposit [GeV]
     /// \param startStatus: status at entrance
     /// \param endStatus: status at exit
-    inline Hit(int trackID, unsigned short detID, TVector3 startPos, TVector3 pos, TVector3 mom, double startE,
+    inline Hit(int trackID, unsigned short detID, const TVector3& startPos, const TVector3& pos, const TVector3& mom, double startE,
 		 double endTime, double eLoss,unsigned char statusStart, unsigned char status);
 
 
@@ -110,16 +110,16 @@ class Hit : public o2::BasicXYZEHit<Float_t,Float_t>
     void SetSrcEvID(int srcID, int evID) {
       /// RS: ATTENTION! this is just a trick until we clarify how the hits from different source are
       // provided and identified. At the moment we just create a combined identifier from eventID
-      // and sourceID and store it TEMPORARILY in the cached Point's TObject UniqueID
-      SetUniqueID( ( srcID << Label::nbitsEvID ) | evID);
+      // and sourceID
+      mLabel = ( srcID << Label::nbitsEvID ) | evID;
     }
 
     Label getCombLabel() const {
       /// RS: ATTENTION! this is just a trick until we clarify how the hits from different source are
       // provided and identified. At the moment we just create on the fly the label from the track ID
-      // and SrcEv id stored as UniqueID
-      int srcID = ( GetUniqueID()>>Label::nbitsEvID ) & Label::maskSrcID;
-      int evID = GetUniqueID() & Label::maskEvID;
+      // and SrcEv id stored as mLabel
+      int srcID = ( mLabel>>Label::nbitsEvID ) & Label::maskSrcID;
+      int evID = mLabel & Label::maskEvID;
       return Label( GetTrackID(), evID, srcID );
     }
     
@@ -130,13 +130,14 @@ class Hit : public o2::BasicXYZEHit<Float_t,Float_t>
     Vector3D<Float_t> mMomentum;              ///< momentum at entrance
     Point3D<Float_t> mPosStart;               ///< position at entrance (base mPos give position on exit)
     Float_t mE;                               ///< total energy at entrance
+    UInt_t  mLabel;                           ///< member to store a composed MC label
     UChar_t mTrackStatusEnd;                  ///< MC status flag at exit
     UChar_t mTrackStatusStart;                ///< MC status at starting point
 
   ClassDefOverride(Hit, 3)
 };
 
-Hit::Hit(int trackID, unsigned short detID, TVector3 startPos, TVector3 endPos, TVector3 startMom,
+Hit::Hit(int trackID, unsigned short detID, const TVector3& startPos, const TVector3& endPos, const TVector3& startMom,
              double startE,double endTime, double eLoss, unsigned char startStatus, unsigned char endStatus)
   : BasicXYZEHit(endPos.X(),endPos.Y(),endPos.Z(),endTime,eLoss,trackID,detID),
     mMomentum(startMom.Px(),startMom.Py(),startMom.Pz()),

--- a/Detectors/ITSMFT/common/simulation/src/Digitizer.cxx
+++ b/Detectors/ITSMFT/common/simulation/src/Digitizer.cxx
@@ -52,6 +52,7 @@ void Digitizer::init()
   }
 }
 
+// this version should be deprecated once we are not using TClonesArrays anymore
 //_______________________________________________________________________
 void Digitizer::process(TClonesArray* hits, TClonesArray* digits)
 {
@@ -110,6 +111,63 @@ void Digitizer::process(TClonesArray* hits, TClonesArray* digits)
     fillOutputContainer(digits, mROFrameMax);
   }
 }
+
+//_______________________________________________________________________
+void Digitizer::process(std::vector<Hit>* hits, TClonesArray* digits)
+{
+  // digitize single event
+  
+  const Int_t numOfChips = mGeometry->getNumberOfChips();  
+  const SegmentationPixel* seg = (SegmentationPixel*)mGeometry->getSegmentationById(0);
+  
+  // estimate the smalles RO Frame this event may have
+  double hTime0 = mEventTime - mParams.getTimeOffset();
+  if (hTime0 > UINT_MAX) {
+    LOG(WARNING) << "min Hit RO Frame undefined: time: " << hTime0 << " is in far future: "
+		 << " EventTime: " << mEventTime << " TimeOffset: "
+		 << mParams.getTimeOffset() << FairLogger::endl;
+    return;
+  }
+
+  if (hTime0<0) hTime0 = 0.;
+  UInt_t minNewROFrame = static_cast<UInt_t>(hTime0/mParams.getROFrameLenght());
+
+  LOG(INFO) << "Digitizing ITS event at time " << mEventTime
+	    << " (TOffset= " << mParams.getTimeOffset() << " ROFrame= " << minNewROFrame << ")"
+	    << " cont.mode: " << isContinuous() << " current Min/Max RO Frames "
+	    << mROFrameMin << "/" << mROFrameMax << FairLogger::endl ;
+  
+  if (mParams.isContinuous() && minNewROFrame>mROFrameMin) {
+    // if there are already digits cached for previous RO Frames AND the new event
+    // cannot contribute to these digits, move them to the output container
+    if (mROFrameMax<minNewROFrame) mROFrameMax = minNewROFrame-1;
+    for (auto rof=mROFrameMin; rof<minNewROFrame; rof++) {
+      fillOutputContainer(digits, rof);
+    }
+    //    fillOutputContainer(digits, minNewROFrame-1);
+  }
+  
+  // accumulate hits for every chip
+  for(auto& hit : *hits) {
+    // RS: ATTENTION: this is just a trick until we clarify how the hits from different source are
+    // provided and identified. At the moment we just create a combined identifier from eventID
+    // and sourceID and store it TEMPORARILY in the cached Point's TObject UniqueID  
+    hit.SetSrcEvID(mCurrSrcID,mCurrEvID); 
+    mSimulations[hit.GetDetectorID()].InsertHit(&hit);
+  }
+    
+  // Convert hits to digits  
+  for (auto &simulation : mSimulations) {
+    simulation.Hits2Digits(seg, mEventTime, mROFrameMin, mROFrameMax);
+    simulation.ClearHits();
+  }
+
+  // in the triggered mode store digits after every MC event
+  if (!mParams.isContinuous()) {
+    fillOutputContainer(digits, mROFrameMax);
+  }
+}
+
 
 //_______________________________________________________________________
 void Digitizer::setEventTime(double t)

--- a/Detectors/ITSMFT/test/HitAnalysis/include/HitAnalysis/HitAnalysis.h
+++ b/Detectors/ITSMFT/test/HitAnalysis/include/HitAnalysis/HitAnalysis.h
@@ -22,15 +22,14 @@
 #include <map>
 #include "FairTask.h"  // for FairTask, InitStatus
 #include "Rtypes.h"    // for Bool_t, HitAnalysis::Class, ClassDef, etc
+#include "ITSMFTSimulation/Hit.h"
+#include <vector>
 
-class TClonesArray;  // lines 17-17
 class TH1;  // lines 16-16
 namespace o2 { namespace ITS { class GeometryTGeo; }}  // lines 23-23
 
 
 class TH1;
-
-class TClonesArray;
 
 namespace o2 {
 namespace ITSMFT {
@@ -69,7 +68,7 @@ class HitAnalysis : public FairTask
     Bool_t mIsInitialized;       ///< Check whether task is initialized
     Bool_t mProcessChips;        ///< Process chips or hits
     std::map<int, o2::ITSMFT::Chip *> mChips; ///< lookup map for ITS chips
-    TClonesArray *mHitsArray;        ///< Array with ITS space points, filled by the FairRootManager
+    const std::vector<o2::ITSMFT::Hit>* mHits;     ///< Array with ITS hits, filled by the FairRootManager
     const GeometryTGeo *mGeometry;           ///<  geometry
     TH1 *mLineSegment;        ///< Histogram for line segment
     TH1 *mLocalX0;            ///< Histogram for Starting X position in local coordinates

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -534,11 +534,17 @@ o2_define_bucket(
 
     DEPENDENCIES
     ITSSimulation
-
+    
     INCLUDE_DIRECTORIES
     ${FAIRROOT_INCLUDE_DIR}
     ${CMAKE_SOURCE_DIR}/Detectors/ITSMFT/ITS/base/include
-)
+    ${CMAKE_SOURCE_DIR}/Detectors/ITSMFT/common/simulation/include
+    ${CMAKE_SOURCE_DIR}/DataFormats/simulation/include
+    ${CMAKE_SOURCE_DIR}/Common/MathUtils/include
+
+    SYSTEMINCLUDE_DIRECTORIES
+    ${Boost_INCLUDE_DIR}
+    )
 
 o2_define_bucket(
     NAME


### PR DESCRIPTION
This PR provides the replacement of TClonsArrays -> std::vector for hits for ITS as important steps for #610.

some other smaller optimization fixes:
a) use const ref for TVector3
b) use cached reference to TVirtualMC::GetMC