### PR TITLE
MFT: TClonesArray -> std::vector for hits; smaller cleanup

### DIFF
--- a/Detectors/ITSMFT/MFT/simulation/include/MFTSimulation/Detector.h
+++ b/Detectors/ITSMFT/MFT/simulation/include/MFTSimulation/Detector.h
@@ -19,11 +19,10 @@
 #include "TLorentzVector.h"
 
 #include "DetectorsBase/Detector.h"
+#include "ITSMFTSimulation/Hit.h"
+#include <vector>
 
-class TClonesArray;
 class TVector3;
-
-namespace o2 { namespace ITSMFT { class Hit; } }
 
 namespace o2 { namespace MFT { class GeometryTGeo; } }
 
@@ -94,15 +93,15 @@ protected:
 
   Int_t mVersion;                  //
   Double_t mDensitySupportOverSi;  //
-  TClonesArray *mHits;             //!
+  std::vector<o2::ITSMFT::Hit>* mHits;  //! The hit container
  
 private:
 
   Detector(const Detector&);
   Detector& operator=(const Detector&);
 
-  o2::ITSMFT::Hit* addHit(int trackID, int detID, TVector3 startPos, TVector3 endPos,
-			  TVector3 startMom, double startE, double endTime, double eLoss,
+  o2::ITSMFT::Hit* addHit(int trackID, int detID, const TVector3& startPos, const TVector3& endPos,
+			  const TVector3& startMom, double startE, double endTime, double eLoss,
 			  unsigned char startStatus, unsigned char endStatus);
 
   /// this is transient data about track passing the sensor

--- a/Detectors/ITSMFT/MFT/simulation/include/MFTSimulation/DigitizerTask.h
+++ b/Detectors/ITSMFT/MFT/simulation/include/MFTSimulation/DigitizerTask.h
@@ -59,7 +59,7 @@ namespace o2
       Int_t mSourceID = 0;                  ///< current source
       Int_t mEventID = 0;                   ///< current event id from the source
       Digitizer mDigitizer;                 ///< Digitizer      
-      TClonesArray* mHitsArray = nullptr;   ///< Array of MC hits
+      const std::vector<o2::ITSMFT::Hit>* mHitsArray = nullptr;   ///< Array of MC hits
       TClonesArray* mDigitsArray = nullptr; ///< Array of digits
       
       ClassDefOverride(DigitizerTask, 1);

--- a/Detectors/ITSMFT/MFT/simulation/src/DigitizerTask.cxx
+++ b/Detectors/ITSMFT/MFT/simulation/src/DigitizerTask.cxx
@@ -14,6 +14,7 @@
 /// \date 03/05/2017
 
 #include "MFTSimulation/DigitizerTask.h"
+#include "ITSMFTSimulation/Hit.h"
 #include "DetectorsBase/Utils.h"
 #include "MFTBase/GeometryTGeo.h"
 
@@ -60,7 +61,7 @@ InitStatus DigitizerTask::Init()
     return kERROR;
   }
 
-  mHitsArray = dynamic_cast<TClonesArray*>(mgr->GetObject("MFTHits"));
+  mHitsArray = mgr->InitObjectAs<const std::vector<o2::ITSMFT::Hit>*>("MFTHits");
   if (!mHitsArray) {
     LOG(ERROR) << "MFT hits not registered in the FairRootManager. Exiting ..." << FairLogger::endl;
     return kERROR;
@@ -106,8 +107,9 @@ void DigitizerTask::Exec(Option_t* option)
   /// provided and identified.
   mDigitizer.setCurrSrcID( mSourceID );
   mDigitizer.setCurrEvID( mEventID );
-  
-  mDigitizer.process(mHitsArray,mDigitsArray);
+
+  // FIXME: the const_cast is a workaround as usually the hits are consumed and are read only
+  mDigitizer.process(const_cast<std::vector<o2::ITSMFT::Hit>*>(mHitsArray),mDigitsArray);
 
   mEventID++;
 

--- a/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Chip.h
+++ b/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Chip.h
@@ -28,8 +28,6 @@
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "MathUtils/Cartesian3D.h"
 
-namespace o2 { namespace ITSMFT { class Hit; }}
-
 namespace o2 {
 
 namespace ITSMFT {

--- a/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Digitizer.h
+++ b/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Digitizer.h
@@ -43,8 +43,6 @@ namespace o2
       void init();
 
       /// Steer conversion of points to digits
-      void   process(TClonesArray* points, TClonesArray* digits);
-      /// new version
       void   process(std::vector<Hit>* hits, TClonesArray* digits);
       
       void   setEventTime(double t);


### PR DESCRIPTION
Move from TClonesArray to std::vector<Hit>

Remove old version of Digitizer::process, leaving only new
interface.

Some smaller optimization fixes:
 * use cached reference to TVirtualMC
 * use const reference to TVector3