### PR TITLE
Use std::vector for Hits in TPC + Cleanup 

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/BaseHits.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/BaseHits.h
@@ -31,7 +31,7 @@ class BaseHit : public FairMultiLinkedData_Interface
   void SetTrackID(int id) { mTrackID = id; }
 
  private:
-  int mTrackID; // track_id
+  int mTrackID = 0; // track_id
   ClassDefOverride(BaseHit, 1);
 };
 

--- a/Detectors/TPC/simulation/include/TPCSimulation/Detector.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/Detector.h
@@ -15,9 +15,7 @@
 #include "DetectorsBase/Detector.h"   // for Detector
 #include "Rtypes.h"          // for Int_t, Double32_t, Double_t, Bool_t, etc
 #include "TLorentzVector.h"  // for TLorentzVector
-#include "TClonesArray.h"
 #include "TString.h"
-#include "FairLink.h"
 
 #include "TPCSimulation/Point.h"
 #include "TPCBase/Sector.h"
@@ -96,9 +94,6 @@ class Detector: public o2::Base::Detector {
     /** The following methods can be implemented if you need to make
      *  any optional action in your detector during the transport.
     */
-
-    void   CopyClones( TClonesArray* cl1,  TClonesArray* cl2 ,
-                               Int_t offset) override {;}
     void   SetSpecialPhysicsCuts() override;// {;}
     void   EndOfEvent() override;
     void   FinishPrimary() override {;}
@@ -131,10 +126,8 @@ class Detector: public o2::Base::Detector {
     /** Define the sensitive volumes of the geometry */
     void DefineSensitiveVolumes();
 
-    /** container for data points */
-    TClonesArray*  mPointCollection;
-    TClonesArray*  mHitGroupCollection;    //! container that keeps track-grouped hits
-    TClonesArray*  mHitsPerSectorCollection[Sector::MAXSECTOR];
+    /** container for produced hits */
+    TClonesArray*  mHitsPerSectorCollection[Sector::MAXSECTOR]; //! container that keeps track-grouped hits per sector
 
     TString mGeoFileName;                  ///< Name of the file containing the TPC geometry
     size_t mEventNr;                       //!< current event number
@@ -146,16 +139,6 @@ class Detector: public o2::Base::Detector {
 
     ClassDefOverride(Detector,1)
 };
-
-inline
-Point* Detector::addHit(float x, float y, float z, float time, float nElectrons, float trackID, float detID)
-{
-  TClonesArray& clref = *mPointCollection;
-  Int_t size = clref.GetEntriesFast();
-  Point *point = new(clref[size]) Point(x, y, z, time, nElectrons, trackID, detID);
-  point->SetLink(FairLink(-1, mEventNr, mMCTrackBranchId, trackID));
-  return point;
-}
 
 template<typename T>
 inline

--- a/Detectors/TPC/simulation/include/TPCSimulation/Detector.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/Detector.h
@@ -127,7 +127,7 @@ class Detector: public o2::Base::Detector {
     void DefineSensitiveVolumes();
 
     /** container for produced hits */
-    TClonesArray*  mHitsPerSectorCollection[Sector::MAXSECTOR]; //! container that keeps track-grouped hits per sector
+    std::vector<LinkableHitGroup>*  mHitsPerSectorCollection[Sector::MAXSECTOR]; //! container that keeps track-grouped hits per sector
 
     TString mGeoFileName;                  ///< Name of the file containing the TPC geometry
     size_t mEventNr;                       //!< current event number

--- a/Detectors/TPC/simulation/include/TPCSimulation/Digitizer.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/Digitizer.h
@@ -17,6 +17,7 @@
 
 #include "TPCSimulation/DigitContainer.h"
 #include "TPCSimulation/PadResponse.h"
+#include "TPCSimulation/Point.h"
 #include "TPCBase/ParameterDetector.h"
 #include "TPCBase/ParameterElectronics.h"
 #include "TPCBase/ParameterGas.h"
@@ -28,7 +29,6 @@
 using std::vector;
 
 class TTree;
-class TClonesArray;
 
 namespace o2 {
 namespace TPC {
@@ -71,7 +71,7 @@ class Digitizer {
     /// Steer conversion of points to digits
     /// \param points Container with TPC points
     /// \return digits container
-    DigitContainer *Process(TClonesArray *points);
+    DigitContainer* Process(const std::vector<o2::TPC::LinkableHitGroup>& hits);
 
     DigitContainer *getDigitContainer() const { return mDigitContainer; }
 

--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitizerTask.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitizerTask.h
@@ -46,8 +46,6 @@ class DigitizerTask : public FairTask{
     /// Inititializes the digitizer and connects input and output container
     InitStatus Init() override;
 
-    void setHitFileName(std::string name) { mHitFileName = name; }
-
     /// Sets the debug flags for the sub-tasks
     /// \param debugsString String containing the debug flags
     ///        o PRFdebug - Debug output after application of the PRF
@@ -69,18 +67,13 @@ class DigitizerTask : public FairTask{
     void FinishTask() override;
 
   private:
-    void fillHitArrayFromFile();
-
     Digitizer           *mDigitizer;    ///< Digitization process
     DigitContainer      *mDigitContainer;
       
-    TClonesArray        *mPointsArray;  ///< Array of detector hits, passed to the digitization
     TClonesArray        *mDigitsArray;  ///< Array of the Digits, passed from the digitization
     o2::dataformats::MCTruthContainer<o2::MCCompLabel> mMCTruthArray; ///< Array for MCTruth information associated to digits in mDigitsArrray. Passed from the digitization
     TClonesArray        *mDigitsDebugArray;  ///< Array of the Digits, for debugging purposes only, passed from the digitization
     
-    std::string         mHitFileName;  ///< External hit file exported from AliRoot
-
     int                 mTimeBinMax;   ///< Maximum time bin to be written out
     bool                mIsContinuousReadout; ///< Switch for continuous readout
     bool                mDigitDebugOutput;    ///< Switch for the debug output of the DigitMC

--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitizerTask.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitizerTask.h
@@ -79,7 +79,7 @@ class DigitizerTask : public FairTask{
     bool                mDigitDebugOutput;    ///< Switch for the debug output of the DigitMC
     int                 mHitSector=-1; ///< which sector to treat
 
-    TClonesArray        *mSectorHitsArray[Sector::MAXSECTOR];
+    const std::vector<o2::TPC::LinkableHitGroup> *mSectorHitsArray[Sector::MAXSECTOR];
 
     ClassDefOverride(DigitizerTask, 1);
 };

--- a/Detectors/TPC/simulation/include/TPCSimulation/Point.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/Point.h
@@ -16,10 +16,6 @@
 #include "SimulationDataFormat/BaseHits.h"
 #include <vector>
 
-// this decides if TPC hits are grouped into
-// a LinkableHitGroup container
-#define TPC_GROUPED_HITS 1
-
 namespace o2 {
 namespace TPC {
 

--- a/Detectors/TPC/simulation/include/TPCSimulation/Point.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/Point.h
@@ -36,7 +36,8 @@ class ElementalHit {
  public:
   ElementalHit() = default; // for ROOT IO
   ~ElementalHit() = default;
-
+  ElementalHit(ElementalHit const &) = default;
+  
   // constructor
   ElementalHit(float x, float y, float z, float time, float e)
     :  mPos(x, y, z), mTime(time), mELoss(e) {}
@@ -52,6 +53,7 @@ class ElementalHit {
 class LinkableHitGroup : public o2::BaseHit {
 public:
   LinkableHitGroup() :
+  o2::BaseHit(),
 #ifdef HIT_AOS
   mHits()
 #else
@@ -59,18 +61,13 @@ public:
   mHitsYVctr(),
   mHitsZVctr(),
   mHitsTVctr(),
-  mHitsEVctr(),
-  mHitsX(nullptr),
-  mHitsY(nullptr),
-  mHitsZ(nullptr),
-  mHitsT(nullptr),
-  mHitsE(nullptr),
-  mSize(0)
+  mHitsEVctr()
 #endif
     {
     }
 
   LinkableHitGroup(int trackID) :
+  o2::BaseHit(trackID),
 #ifdef HIT_AOS
   mHits()
 #else
@@ -78,20 +75,13 @@ public:
   mHitsYVctr(),
   mHitsZVctr(),
   mHitsTVctr(),
-  mHitsEVctr(),
-  mHitsX(nullptr),
-  mHitsY(nullptr),
-  mHitsZ(nullptr),
-  mHitsT(nullptr),
-  mHitsE(nullptr),
-  mSize(0)
+  mHitsEVctr()
 #endif
   {
-    SetTrackID(trackID);
   }
 
   ~LinkableHitGroup() override = default;
-
+  
   void addHit(float x, float y, float z, float time, short e) {
 #ifdef HIT_AOS
     mHits.emplace_back(x,y,z,time,e);
@@ -101,12 +91,6 @@ public:
     mHitsZVctr.emplace_back(z);
     mHitsTVctr.emplace_back(time);
     mHitsEVctr.emplace_back(e);
-    mSize=mHitsXVctr.size();
-    mHitsX=&mHitsXVctr[0];
-    mHitsY=&mHitsYVctr[0];
-    mHitsZ=&mHitsZVctr[0];
-    mHitsT=&mHitsTVctr[0];
-    mHitsE=&mHitsEVctr[0];
 #endif
   }
 
@@ -114,7 +98,7 @@ public:
 #ifdef HIT_AOS
     return mHits.size();
 #else
-    return mSize;
+    return mHitsXVctr.size();
 #endif
   }
 
@@ -123,7 +107,7 @@ public:
     // std::vector storage
     return mHits[index];
 #else
-    return ElementalHit(mHitsX[index],mHitsY[index],mHitsZ[index],mHitsT[index],mHitsE[index]);
+    return ElementalHit(mHitsXVctr[index],mHitsYVctr[index],mHitsZVctr[index],mHitsTVctr[index],mHitsEVctr[index]);
 #endif
   }
 
@@ -154,12 +138,6 @@ public:
     mHitsZVctr.shrink_to_fit();
     mHitsTVctr.shrink_to_fit();
     mHitsEVctr.shrink_to_fit();
-    mHitsX=&mHitsXVctr[0];
-    mHitsY=&mHitsYVctr[0];
-    mHitsZ=&mHitsZVctr[0];
-    mHitsT=&mHitsTVctr[0];
-    mHitsE=&mHitsEVctr[0];
-    mSize=mHitsXVctr.size();
 #endif
   }
 
@@ -171,18 +149,11 @@ public:
 #ifdef HIT_AOS
   std::vector<o2::TPC::ElementalHit> mHits; // the hits for this group
 #else
-  std::vector<float> mHitsXVctr; //! do not stream this (just for memory handling convenience)
-  std::vector<float> mHitsYVctr; //! do not stream this
-  std::vector<float> mHitsZVctr; //! do not stream this
-  std::vector<float> mHitsTVctr; //! do not stream this
-  std::vector<short> mHitsEVctr; //! do not stream this
-  // let us stream ordinary buffers for compression AND ROOT IO/speed!!
-  Int_t mSize;
-  float* mHitsX = nullptr; //[mSize]
-  float* mHitsY = nullptr; //[mSize]
-  float* mHitsZ = nullptr; //[mSize]
-  float* mHitsT = nullptr; //[mSize]
-  short* mHitsE = nullptr; //[mSize]
+  std::vector<float> mHitsXVctr; 
+  std::vector<float> mHitsYVctr; 
+  std::vector<float> mHitsZVctr; 
+  std::vector<float> mHitsTVctr; 
+  std::vector<short> mHitsEVctr; 
 #endif
   ClassDefOverride(LinkableHitGroup, 1);
 };

--- a/Detectors/TPC/simulation/src/Digitizer.cxx
+++ b/Detectors/TPC/simulation/src/Digitizer.cxx
@@ -72,16 +72,11 @@ DigitContainer *Digitizer::Process(TClonesArray *points)
 
   static size_t hitCounter=0;
   for(auto pointObject : *points) {
-#ifdef TPC_GROUPED_HITS
     auto *inputgroup = static_cast<LinkableHitGroup*>(pointObject);
     const int MCTrackID = inputgroup->GetTrackID();
     for(size_t hitindex = 0; hitindex<inputgroup->getSize(); ++hitindex){
       ElementalHit eh = inputgroup->getHit(hitindex);
       auto *inputpoint = &eh;
-#else
-    Point *inputpoint = static_cast<Point *>(pointObject);
-    const int MCTrackID = inputpoint->GetTrackID();
-#endif
 
     const GlobalPosition3D posEle(inputpoint->GetX(), inputpoint->GetY(), inputpoint->GetZ());
 
@@ -155,9 +150,7 @@ DigitContainer *Digitizer::Process(TClonesArray *points)
     }
     /// end of loop over electrons
     ++hitCounter;
-#ifdef TPC_GROUPED_HITS
     }
-#endif
   }
   /// end of loop over points
 

--- a/Detectors/TPC/simulation/src/Digitizer.cxx
+++ b/Detectors/TPC/simulation/src/Digitizer.cxx
@@ -51,7 +51,7 @@ void Digitizer::init()
 //  mDebugTreePRF->Branch("GEMresponse", &GEMresponse, "CRU:timeBin:row:pad:nElectrons");
 }
 
-DigitContainer *Digitizer::Process(TClonesArray *points)
+DigitContainer* Digitizer::Process(const std::vector<o2::TPC::LinkableHitGroup>& hits)
 {
 //  mDigitContainer->reset();
   const static Mapper& mapper = Mapper::instance();
@@ -71,83 +71,82 @@ DigitContainer *Digitizer::Process(TClonesArray *points)
   signalArray.resize(nShapedPoints);
 
   static size_t hitCounter=0;
-  for(auto pointObject : *points) {
-    auto *inputgroup = static_cast<LinkableHitGroup*>(pointObject);
-    const int MCTrackID = inputgroup->GetTrackID();
-    for(size_t hitindex = 0; hitindex<inputgroup->getSize(); ++hitindex){
-      ElementalHit eh = inputgroup->getHit(hitindex);
-      auto *inputpoint = &eh;
+  for(auto& inputgroup : hits) {
+    //    auto *inputgroup = static_cast<LinkableHitGroup*>(pointObject);
+    const int MCTrackID = inputgroup.GetTrackID();
+    for(size_t hitindex = 0; hitindex < inputgroup.getSize(); ++hitindex){
+      const auto& eh = inputgroup.getHit(hitindex);
 
-    const GlobalPosition3D posEle(inputpoint->GetX(), inputpoint->GetY(), inputpoint->GetZ());
+      const GlobalPosition3D posEle(eh.GetX(), eh.GetY(), eh.GetZ());
 
-    // The energy loss stored is really nElectrons
-    const int nPrimaryElectrons = static_cast<int>(inputpoint->GetEnergyLoss());
+      // The energy loss stored is really nElectrons
+      const int nPrimaryElectrons = static_cast<int>(eh.GetEnergyLoss());
 
-    /// Loop over electrons
-    /// \todo can be vectorized?
-    /// \todo split transport and signal formation in two separate loops?
-    for(int iEle=0; iEle < nPrimaryElectrons; ++iEle) {
+      /// Loop over electrons
+      /// \todo can be vectorized?
+      /// \todo split transport and signal formation in two separate loops?
+      for(int iEle=0; iEle < nPrimaryElectrons; ++iEle) {
 
-      /// Drift and Diffusion
-      const GlobalPosition3D posEleDiff = electronTransport.getElectronDrift(posEle);
+        /// Drift and Diffusion
+        const GlobalPosition3D posEleDiff = electronTransport.getElectronDrift(posEle);
 
-      /// \todo Time management in continuous mode (adding the time of the event?)
-      const float driftTime = getTime(posEleDiff.Z()) + inputpoint->GetTime() * 0.001; /// in us
-      const float absoluteTime = driftTime + eventTime;
+        /// \todo Time management in continuous mode (adding the time of the event?)
+        const float driftTime = getTime(posEleDiff.Z()) + eh.GetTime() * 0.001; /// in us
+        const float absoluteTime = driftTime + eventTime;
 
-      /// Attachment
-      if(electronTransport.isElectronAttachment(driftTime)) continue;
+        /// Attachment
+        if(electronTransport.isElectronAttachment(driftTime)) continue;
 
-      /// Remove electrons that end up outside the active volume
-      /// \todo should go to mapper?
-      if(fabs(posEleDiff.Z()) > detParam.getTPClength()) continue;
+        /// Remove electrons that end up outside the active volume
+        /// \todo should go to mapper?
+        if(fabs(posEleDiff.Z()) > detParam.getTPClength()) continue;
 
-      const DigitPos digiPadPos = mapper.findDigitPosFromGlobalPosition(posEleDiff);
-      if(!digiPadPos.isValid()) continue;
+        const DigitPos digiPadPos = mapper.findDigitPosFromGlobalPosition(posEleDiff);
+        if(!digiPadPos.isValid()) continue;
 
-      const int nElectronsGEM = gemAmplification.getStackAmplification();
-      if ( nElectronsGEM ==0 ) continue;
+        const int nElectronsGEM = gemAmplification.getStackAmplification();
+        if ( nElectronsGEM ==0 ) continue;
 
-      /// Loop over all individual pads with signal due to pad response function
-      /// Currently the PRF is not applied yet due to some problems with the mapper
-      /// which results in most of the cases in a normalized pad response = 0
-      /// \todo Problems of the mapper to be fixed
-      /// \todo Mapper should provide a functionality which finds the adjacent pads of a given pad
-      // for(int ipad = -2; ipad<3; ++ipad) {
-      //   for(int irow = -2; irow<3; ++irow) {
-      //     PadPos padPos(digiPadPos.getPadPos().getRow() + irow, digiPadPos.getPadPos().getPad() + ipad);
-      //     DigitPos digiPos(digiPadPos.getCRU(), padPos);
+        /// Loop over all individual pads with signal due to pad response function
+        /// Currently the PRF is not applied yet due to some problems with the mapper
+        /// which results in most of the cases in a normalized pad response = 0
+        /// \todo Problems of the mapper to be fixed
+        /// \todo Mapper should provide a functionality which finds the adjacent pads of a given pad
+        // for(int ipad = -2; ipad<3; ++ipad) {
+        //   for(int irow = -2; irow<3; ++irow) {
+        //     PadPos padPos(digiPadPos.getPadPos().getRow() + irow, digiPadPos.getPadPos().getPad() + ipad);
+        //     DigitPos digiPos(digiPadPos.getCRU(), padPos);
 
-      DigitPos digiPos = digiPadPos;
-      if (!digiPos.isValid()) continue;
-      // const float normalizedPadResponse = padResponse.getPadResponse(posEleDiff, digiPos);
+        DigitPos digiPos = digiPadPos;
+        if (!digiPos.isValid()) continue;
+        // const float normalizedPadResponse = padResponse.getPadResponse(posEleDiff, digiPos);
 
-      const float normalizedPadResponse = 1.f;
-      if (normalizedPadResponse <= 0) continue;
-      const int pad = digiPos.getPadPos().getPad();
-      const int row = digiPos.getPadPos().getRow();
+        const float normalizedPadResponse = 1.f;
+        if (normalizedPadResponse <= 0) continue;
+        const int pad = digiPos.getPadPos().getPad();
+        const int row = digiPos.getPadPos().getRow();
 
-      if(mDebugFlagPRF) {
-        /// \todo Write out the debug output
-        GEMresponse.CRU = digiPos.getCRU().number();
-        GEMresponse.time = absoluteTime;
-        GEMresponse.row = row;
-        GEMresponse.pad = pad;
-        GEMresponse.nElectrons = nElectronsGEM * normalizedPadResponse;
-        //mDebugTreePRF->Fill();
-      }
+        if(mDebugFlagPRF) {
+          /// \todo Write out the debug output
+          GEMresponse.CRU = digiPos.getCRU().number();
+          GEMresponse.time = absoluteTime;
+          GEMresponse.row = row;
+          GEMresponse.pad = pad;
+          GEMresponse.nElectrons = nElectronsGEM * normalizedPadResponse;
+          //mDebugTreePRF->Fill();
+        }
 
-      const float ADCsignal = SAMPAProcessing::getADCvalue(nElectronsGEM * normalizedPadResponse);
-      SAMPAProcessing::getShapedSignal(ADCsignal, absoluteTime, signalArray);
-      for(float i=0; i<nShapedPoints; ++i) {
-        const float time = absoluteTime + i * eleParam.getZBinWidth();
-        mDigitContainer->addDigit(MCTrackID, digiPos.getCRU().number(), getTimeBinFromTime(time), row, pad, signalArray[i]);
-      }
+        const float ADCsignal = SAMPAProcessing::getADCvalue(nElectronsGEM * normalizedPadResponse);
+        SAMPAProcessing::getShapedSignal(ADCsignal, absoluteTime, signalArray);
+        for(float i=0; i<nShapedPoints; ++i) {
+          const float time = absoluteTime + i * eleParam.getZBinWidth();
+          mDigitContainer->addDigit(MCTrackID, digiPos.getCRU().number(), getTimeBinFromTime(time), row, pad, signalArray[i]);
+        }
 
       // }
       // }
       /// end of loop over prf
-    }
+      }
     /// end of loop over electrons
     ++hitCounter;
     }

--- a/Detectors/TPC/simulation/src/DigitizerTask.cxx
+++ b/Detectors/TPC/simulation/src/DigitizerTask.cxx
@@ -74,7 +74,7 @@ InitStatus DigitizerTask::Init()
     std::stringstream sectornamestr;
     sectornamestr << "TPCHitsSector" << mHitSector;
     LOG(INFO) << "FETCHING HITS FOR SECTOR " << mHitSector << "\n";
-    mSectorHitsArray[mHitSector] = dynamic_cast<TClonesArray *>(mgr->GetObject(sectornamestr.str().c_str()));
+    mSectorHitsArray[mHitSector] = mgr->InitObjectAs<const std::vector<LinkableHitGroup>*>(sectornamestr.str().c_str());
   }
   else {
     // in case we are treating all sectors
@@ -82,7 +82,7 @@ InitStatus DigitizerTask::Init()
       std::stringstream sectornamestr;
       sectornamestr << "TPCHitsSector" << s;
       LOG(INFO) << "FETCHING HITS FOR SECTOR " << s << "\n";
-      mSectorHitsArray[s] = dynamic_cast<TClonesArray *>(mgr->GetObject(sectornamestr.str().c_str()));
+      mSectorHitsArray[s] = mgr->InitObjectAs<const std::vector<LinkableHitGroup>*>(sectornamestr.str().c_str());
     }
   }
   
@@ -123,12 +123,12 @@ void DigitizerTask::Exec(Option_t *option)
     // treat all sectors
     for (int s=0; s<Sector::MAXSECTOR; ++s){
       LOG(DEBUG) << "Processing sector " << s << "\n";
-      mDigitContainer = mDigitizer->Process(mSectorHitsArray[s]);
+      mDigitContainer = mDigitizer->Process(*mSectorHitsArray[s]);
     }
   }
   else {
     // treat only chosen sector
-    mDigitContainer = mDigitizer->Process(mSectorHitsArray[mHitSector]);
+    mDigitContainer = mDigitizer->Process(*mSectorHitsArray[mHitSector]);
   }
   mDigitContainer->fillOutputContainer(mDigitsArray, mMCTruthArray, mDigitsDebugArray, eventTime, mIsContinuousReadout);
 }

--- a/Detectors/TPC/simulation/src/TPCSimulationLinkDef.h
+++ b/Detectors/TPC/simulation/src/TPCSimulationLinkDef.h
@@ -45,5 +45,6 @@
 #pragma link C++ class o2::TPC::SAMPAProcessing+;
 
 #pragma link C++ class std::vector<o2::TPC::Cluster>+;
+#pragma link C++ class std::vector<o2::TPC::LinkableHitGroup>+;
 
 #endif


### PR DESCRIPTION
Partial step towards #610.

Removal of old code (protected by macro) for non-sectorwise processing.