### PR TITLE
[WIP] New Detector interface to allow updating track indices on hits

### DIFF
--- a/DataFormats/simulation/src/Stack.cxx
+++ b/DataFormats/simulation/src/Stack.cxx
@@ -13,6 +13,7 @@
 /// \author M. Al-Turany - June 2014
 
 #include "DetectorsBase/DetID.h"
+#include "DetectorsBase/Detector.h"
 #include "SimulationDataFormat/Stack.h"
 #include "SimulationDataFormat/MCTrack.h"
 
@@ -316,6 +317,12 @@ void Stack::UpdateTrackIndex(TRefArray *detList)
 
   FairDetector *det = nullptr;
   while ((det = (FairDetector *) fDetIter->Next())) {
+
+    // in future we will update track indices like this:
+    // (where the dynamic cast should be avoided and
+    // rather the list of o2::Base::Detectors cached somewhere)
+    auto o2det = dynamic_cast<o2::Base::Detector*>(det);
+    o2det->updateHitTrackIndices(mIndexMap);
 
     // Get hit collections from detector
     Int_t iColl = 0;

--- a/Detectors/TRD/simulation/include/TRDSimulation/Detector.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Detector.h
@@ -27,7 +27,8 @@ class TRDGeometry;
 // define TRD hit type
 using HitType = o2::BasicXYZEHit<float>;
 
-class Detector : public o2::Base::Detector
+class Detector : public o2::Base::Detector,
+                 public o2::Base::DetectorImplHelper<Detector>
 {
  public:
 
@@ -42,6 +43,10 @@ class Detector : public o2::Base::Detector
   void Register() override;
 
   TClonesArray* GetCollection(int iColl) const final;
+  std::vector<HitType>* GetHits(int iColl) {
+    if(iColl==0) return mHits;
+    return nullptr;
+  }
 
   void Reset() override;
   void EndOfEvent() override;

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -376,7 +376,7 @@ o2_define_bucket(
     fairroot_base_bucket
     root_physics_bucket
     common_math_bucket
-    detectors_base_bucket
+    DetectorsBase
     RIO
 
     INCLUDE_DIRECTORIES


### PR DESCRIPTION
With the move away from using TClonesArrays as hit containers, as well
as not storing hits as pointers, we can no longer use the GetCollection
interface to generically update the trackID on hits -- as done by the Stack now.

This commit implements an alternative solution, where the Stack does no
longer needs to retrieve the hits, but delegates the updating task to the individual
detectors.
Detectors now offer a new interface "updateHitTrackIndices". This interface
is implemented generically and specialized for each detector
using a helper implementation class.

This PR addresses one step of #610.