### PR TITLE
Stack/MCTrack: Cleanup + memory improvement

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/MCTrack.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCTrack.h
@@ -23,12 +23,14 @@
 
 class TParticle;
 
+namespace o2 {
+
 /// Data class for storing Monte Carlo tracks processed by the Stack.
 /// An MCTrack can be a primary track put into the simulation or a
 /// secondary one produced by the transport through decay or interaction.
 /// This is a light weight particle class that is saved to disk
 /// instead of saving the TParticle class. It is also used for filtering the stack
-class MCTrack : public TObject
+class MCTrack
 {
 
   public:
@@ -46,7 +48,7 @@ class MCTrack : public TObject
     MCTrack(TParticle *particle);
 
     ///  Destructor
-    ~MCTrack() override;
+    ~MCTrack();
 
     ///  Output to screen
     void Print(Int_t iTrack = 0) const;
@@ -161,7 +163,7 @@ class MCTrack : public TObject
 
     Int_t mNumberOfPoints;
 
-  ClassDefOverride(MCTrack, 1);
+  ClassDefNV(MCTrack, 1);
 };
 
 inline Double_t MCTrack::GetEnergy() const
@@ -186,4 +188,6 @@ inline void MCTrack::GetStartVertex(TVector3 &vertex)
   vertex.SetXYZ(mStartVertexCoordinatesX, mStartVertexCoordinatesY, mStartVertexCoordinatesZ);
 }
 
+}
+ 
 #endif

--- a/DataFormats/simulation/include/SimulationDataFormat/Stack.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/Stack.h
@@ -16,6 +16,7 @@
 #define ALICEO2_DATA_STACK_H_
 
 #include "FairGenericStack.h"
+#include "SimulationDataFormat/MCTrack.h"
 
 #include "Rtypes.h"
 #include "TMCProcess.h"
@@ -133,9 +134,6 @@ class Stack : public FairGenericStack
     /// Declared in TVirtualMCStack
     Int_t GetCurrentParentTrackNumber() const override;
 
-    /// Add a TParticle to the mParticles array
-    virtual void AddParticle(TParticle *part);
-
     /// Fill the MCTrack output array, applying filter criteria
     void FillTrackArray() override;
 
@@ -207,11 +205,11 @@ class Stack : public FairGenericStack
 
     /// Array of TParticles (contains all TParticles put into or created
     /// by the transport
-    TClonesArray *mParticles; //!
-
-    /// Array of FairMCTracks containg the tracks written to the output
-    TClonesArray *mTracks;
-
+    TClonesArray* mParticles; //!
+    
+    /// vector of reducded tracks written to the output
+    std::vector<o2::MCTrack>* mTracks;
+    
     /// STL map from particle index to storage flag
     std::map<Int_t, Bool_t> mStoreMap;                //!
     std::map<Int_t, Bool_t>::iterator mStoreIterator; //!
@@ -219,7 +217,8 @@ class Stack : public FairGenericStack
     /// STL map from particle index to track index
     std::map<Int_t, Int_t> mIndexMap;                //!
     std::map<Int_t, Int_t>::iterator mIndexIterator; //!
-
+    std::vector<Int_t> mIndexVector; //!
+    
     /// STL map from track index and detector ID to number of MCPoints
     std::map<std::pair<Int_t, Int_t>, Int_t> mPointsMap; //!
 

--- a/DataFormats/simulation/src/MCTrack.cxx
+++ b/DataFormats/simulation/src/MCTrack.cxx
@@ -10,7 +10,7 @@
 
 /// \file MCTrack.cxx
 /// \brief Implementation of the MCTrack class
-/// \author M. Al-Turany - June 2014
+/// \author M. Al-Turany, S. Wenzel - June 2014
 
 #include "SimulationDataFormat/MCTrack.h"
 
@@ -19,9 +19,12 @@
 #include "TParticle.h"
 #include "TParticlePDG.h"
 
+ClassImp(o2::MCTrack);
+
+namespace o2 {
+
 MCTrack::MCTrack()
-  : TObject(),
-    mPdgCode(0),
+  : mPdgCode(0),
     mMotherTrackId(-1),
     mStartVertexMomentumX(0.),
     mStartVertexMomentumY(0.),
@@ -36,8 +39,7 @@ MCTrack::MCTrack()
 
 MCTrack::MCTrack(Int_t pdgCode, Int_t motherId, Double_t px, Double_t py, Double_t pz, Double_t x, Double_t y,
                  Double_t z, Double_t t, Int_t nPoints = 0)
-  : TObject(),
-    mPdgCode(pdgCode),
+  : mPdgCode(pdgCode),
     mMotherTrackId(motherId),
     mStartVertexMomentumX(px),
     mStartVertexMomentumY(py),
@@ -54,8 +56,7 @@ MCTrack::MCTrack(const MCTrack &track)
   = default;
 
 MCTrack::MCTrack(TParticle *part)
-  : TObject(),
-    mPdgCode(part->GetPdgCode()),
+  : mPdgCode(part->GetPdgCode()),
     mMotherTrackId(part->GetMother(0)),
     mStartVertexMomentumX(part->Px()),
     mStartVertexMomentumY(part->Py()),
@@ -76,11 +77,6 @@ void MCTrack::Print(Int_t trackId) const
   LOG(DEBUG) << "Track " << trackId << ", mother : " << mMotherTrackId << ", Type " << mPdgCode << ", momentum ("
              << mStartVertexMomentumX << ", " << mStartVertexMomentumY << ", " << mStartVertexMomentumZ << ") GeV"
              << FairLogger::endl;
-  // LOG(DEBUG2) << "       Ref " << getNumberOfPoints(kREF)
-  //           << ", TutDet " << getNumberOfPoints(kTutDet)
-  //           << ", Rutherford " << getNumberOfPoints(kFairRutherford)
-  //           << FairLogger::endl;
-  //
 }
 
 Double_t MCTrack::GetMass() const
@@ -143,4 +139,6 @@ void MCTrack::setNumberOfPoints(Int_t iDet, Int_t nPoints)
   //
 }
 
-ClassImp(MCTrack)
+
+
+}

--- a/DataFormats/simulation/src/SimulationDataLinkDef.h
+++ b/DataFormats/simulation/src/SimulationDataLinkDef.h
@@ -23,7 +23,7 @@
 #pragma link off all functions;
 
 #pragma link C++ class o2::Data::Stack+;
-#pragma link C++ class MCTrack+;
+#pragma link C++ class o2::MCTrack+;
 #pragma link C++ class o2::MCCompLabel+;
 
 #pragma link C++ class o2::BaseHit+;

--- a/Detectors/ITSMFT/ITS/macros/test/CheckTracks.C
+++ b/Detectors/ITSMFT/ITS/macros/test/CheckTracks.C
@@ -33,7 +33,7 @@ void CheckTracks(Int_t nEvents = 10, TString mcEngine = "TGeant3") {
   sprintf(filename, "AliceO2_%s.mc_%i_event.root", mcEngine.Data(), nEvents);
   TFile *file0 = TFile::Open(filename);
   TTree *mcTree=(TTree*)gFile->Get("o2sim");
-  TClonesArray *mcArr=nullptr;
+  std::vector<o2::MCTrack>* mcArr = nullptr;
   mcTree->SetBranchAddress("MCTrack",&mcArr);
 
   // Reconstructed tracks
@@ -52,22 +52,22 @@ void CheckTracks(Int_t nEvents = 10, TString mcEngine = "TGeant3") {
     std::cout<<"Event "<<n<<'/'<<nev<<std::endl;
     Int_t nGen=0, nGoo=0;
     mcTree->GetEvent(n);
-    Int_t nmc=mcArr->GetEntriesFast();
+    Int_t nmc=mcArr->size();
     recTree->GetEvent(n);
     Int_t nrec=recArr->size();
     while(nmc--) {
-      MCTrack *mcTrack = (MCTrack *)mcArr->UncheckedAt(nmc);
-      Int_t mID = mcTrack->getMotherTrackId();
+      const auto& mcTrack = (*mcArr)[nmc];
+      Int_t mID = mcTrack.getMotherTrackId();
       if (mID >= 0) continue; // Select primary particles 
-      Int_t pdg = mcTrack->GetPdgCode();
+      Int_t pdg = mcTrack.GetPdgCode();
       if (TMath::Abs(pdg) != 211) continue;  // Select pions
 
       nGen++; // Generated tracks for the efficiency calculation 
       
-      Double_t mcPx = mcTrack->GetStartVertexMomentumX();
-      Double_t mcPy = mcTrack->GetStartVertexMomentumY();
-      Double_t mcPz = mcTrack->GetStartVertexMomentumZ();
-      Double_t mcPt = mcTrack->GetPt();
+      Double_t mcPx = mcTrack.GetStartVertexMomentumX();
+      Double_t mcPy = mcTrack.GetStartVertexMomentumY();
+      Double_t mcPz = mcTrack.GetStartVertexMomentumZ();
+      Double_t mcPt = mcTrack.GetPt();
       Double_t mcPhi= TMath::ATan2(mcPy,mcPx);
       Double_t mcLam= TMath::ATan2(mcPz,mcPt);
       Double_t recPhi=-1.; 


### PR DESCRIPTION
* MCTrack no longer inherits from TObject
* particle and track vectors use std::vector instead of TClonesArray
  (saving 8byte due to not using pointers)
* put MCTrack in o2 namespace
* some cleanup (removal of unused functions, etc)