### PR TITLE
Add missing <functional> library include

### DIFF
--- a/DataFormats/Headers/include/Headers/HeartbeatFrame.h
+++ b/DataFormats/Headers/include/Headers/HeartbeatFrame.h
@@ -19,6 +19,7 @@
 // @brief  Definition of the heartbeat frame layout
 
 #include "Headers/DataHeader.h"
+#include <functional>
 #include <map>
 #include <vector>
 


### PR DESCRIPTION
Without this compilation fails on GCC 7.2.1 with
error: ‘function’ in namespace ‘std’ does not name a template type

Probably this was hidden by some implicit inclusion of
<functional> so far.