### PR TITLE
Provide updateHitTrackIndices interface and fully deprecate GetCollec…

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/Stack.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/Stack.h
@@ -34,6 +34,11 @@ class TRefArray;
 class FairLogger;
 
 namespace o2 {
+
+namespace Base {
+class Detector;
+}
+
 namespace Data {
 
 /// This class handles the particle stack for the transport simulation.
@@ -221,6 +226,9 @@ class Stack : public FairGenericStack
     
     /// STL map from track index and detector ID to number of MCPoints
     std::map<std::pair<Int_t, Int_t>, Int_t> mPointsMap; //!
+
+    /// cache active O2 detectors
+    std::vector<o2::Base::Detector *> mActiveDetectors;
 
     /// Some indices and counters
     Int_t mIndexOfCurrentTrack;        //! Index of current track

--- a/Detectors/Base/src/Detector.cxx
+++ b/Detectors/Base/src/Detector.cxx
@@ -147,4 +147,11 @@ void Detector::initFieldTrackingParams(int& integration, float& maxfield)
   }
 }
 
+TClonesArray* Detector::GetCollection(int) const
+{
+  LOG(WARNING) << "GetCollection interface no longer supported" << FairLogger::endl;
+  LOG(WARNING) << "Use the GetHits function on invidiual detectors" << FairLogger::endl;
+  return nullptr;
+}
+
 ClassImp(o2::Base::Detector)

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/Detector.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/Detector.h
@@ -36,7 +36,7 @@ class Geometry;
 /// The detector class handles the implementation of the EMCAL detector
 /// within the virtual Monte-Carlo framework and the simulation of the
 /// EMCAL detector up to hit generation
-class Detector : public o2::Base::Detector
+class Detector : public o2::Base::DetImpl<Detector>
 {
  public:
   enum { ID_AIR = 0, ID_PB = 1, ID_SC = 2, ID_AL = 3, ID_STEEL = 4, ID_PAPER = 5 };
@@ -92,10 +92,15 @@ class Detector : public o2::Base::Detector
   void Register() override;
 
   ///
-  /// Get access to the point collection
-  /// \return TClonesArray with points
+  /// Get access to the hits
   ///
-  TClonesArray* GetCollection(Int_t iColl) const final;
+  std::vector<Hit>* getHits(Int_t iColl) const
+  {
+    if (iColl == 0) {
+      return mHits;
+    }
+    return nullptr;
+  }
 
   ///
   /// Reset

--- a/Detectors/EMCAL/simulation/src/Detector.cxx
+++ b/Detectors/EMCAL/simulation/src/Detector.cxx
@@ -35,7 +35,7 @@ using namespace o2::EMCAL;
 ClassImp(Detector);
 
 Detector::Detector(Bool_t active)
-  : o2::Base::Detector("EMC", active),
+  : o2::Base::DetImpl<Detector>("EMC", active),
     mBirkC0(0),
     mBirkC1(0.),
     mBirkC2(0.),
@@ -208,12 +208,6 @@ Double_t Detector::CalculateLightYield(Double_t energydeposit, Double_t tracklen
 void Detector::Register()
 {
   FairRootManager::Instance()->RegisterAny(addNameTo("Hit").data(), mHits, kTRUE);
-}
-
-TClonesArray* Detector::GetCollection(Int_t iColl) const
-{
-  LOG(WARNING) << "GetCollection interface no longer supported" << FairLogger::endl;
-  return nullptr;
 }
 
 void Detector::Reset()

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
@@ -44,7 +44,7 @@ namespace ITS {
 
 class V3Layer;
 
-class Detector : public o2::Base::Detector
+class Detector : public o2::Base::DetImpl<Detector>
 {
 
   public:
@@ -84,10 +84,14 @@ class Detector : public o2::Base::Detector
     void Register() override;
 
     /// Gets the produced collections
-    TClonesArray *GetCollection(Int_t iColl) const override {
-       LOG(WARNING) << "GetCollection will be deprecated" << FairLogger::endl;
-       return nullptr;
+    std::vector<o2::ITSMFT::Hit>* getHits(Int_t iColl) const
+    {
+      if (iColl == 0) {
+        return mHits;
+      }
+      return nullptr;
     }
+
     /// Has to be called after each event to reset the containers
     void Reset() override;
 

--- a/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
@@ -52,7 +52,7 @@ using Segmentation = o2::ITSMFT::SegmentationAlpide;
 using namespace o2::ITS;
 
 Detector::Detector()
-  : o2::Base::Detector("ITS", kTRUE),
+  : o2::Base::DetImpl<Detector>("ITS", kTRUE),
     mLayerID(nullptr),
     mNumberLayers(),
     mTrackData(),
@@ -167,7 +167,7 @@ static void configITS(Detector *its) {
 }
 
 Detector::Detector(Bool_t active)
-  : o2::Base::Detector("ITS", active),
+  : o2::Base::DetImpl<Detector>("ITS", active),
     mLayerID(nullptr),
     mNumberLayers(7),
     mLayerName(new TString[mNumberLayers]),
@@ -252,7 +252,7 @@ Detector::Detector(Bool_t active)
 }
 
 Detector::Detector(const Detector &rhs)
-  : o2::Base::Detector(rhs),
+  : o2::Base::DetImpl<Detector>(rhs),
     mLayerID(nullptr),
     mNumberLayers(rhs.mNumberLayers),
     mLayerName(nullptr),

--- a/Detectors/ITSMFT/MFT/simulation/include/MFTSimulation/Detector.h
+++ b/Detectors/ITSMFT/MFT/simulation/include/MFTSimulation/Detector.h
@@ -33,7 +33,7 @@ namespace o2 { namespace MFT { class GeometryTGeo; } }
 namespace o2 {
 namespace MFT {
 
-class Detector : public o2::Base::Detector {
+class Detector : public o2::Base::DetImpl<Detector> {
 
 public:
 
@@ -55,8 +55,14 @@ public:
   /// Registers the produced collections in FAIRRootManager
   void Register() override; 
 
-  /// Gets the produced collections
-  TClonesArray* GetCollection(Int_t iColl) const override;
+  /// Gets the produced hits
+  std::vector<o2::ITSMFT::Hit>* getHits(Int_t iColl) const
+  {
+    if (iColl == 0) {
+      return mHits;
+    }
+    return nullptr;
+  }
 
   void EndOfEvent() override;
 

--- a/Detectors/ITSMFT/MFT/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/MFT/simulation/src/Detector.cxx
@@ -43,7 +43,7 @@ ClassImp(o2::MFT::Detector)
 
 //_____________________________________________________________________________
 Detector::Detector()
-: o2::Base::Detector("MFT", kTRUE),
+: o2::Base::DetImpl<Detector>("MFT", kTRUE),
   mVersion(1),
   mDensitySupportOverSi(0.036),
   mHits(new std::vector<o2::ITSMFT::Hit>),
@@ -54,7 +54,7 @@ Detector::Detector()
 
 //_____________________________________________________________________________
 Detector::Detector(const Detector& src)
-  : o2::Base::Detector(src),
+  : o2::Base::DetImpl<Detector>(src),
     mVersion(src.mVersion),
     mDensitySupportOverSi(src.mDensitySupportOverSi),
     mHits(new std::vector<o2::ITSMFT::Hit>),
@@ -466,14 +466,6 @@ void Detector::Register()
   if (FairGenericRootManager::Instance()) {
     FairGenericRootManager::Instance()->GetFairRootManager()->RegisterAny(addNameTo("Hit").data(), mHits, kTRUE);
   }
-
-}
-//_____________________________________________________________________________
-TClonesArray *Detector::GetCollection(Int_t iColl) const
-{
-
-  LOG(WARNING) << "GetCollection will be deprecated" << FairLogger::endl;
-  return nullptr;
 
 }
 

--- a/Detectors/TOF/simulation/include/TOFSimulation/Detector.h
+++ b/Detectors/TOF/simulation/include/TOFSimulation/Detector.h
@@ -25,7 +25,7 @@ namespace tof
 {
 using HitType = o2::BasicXYZEHit<float>;
 
-class Detector : public o2::Base::Detector
+class Detector : public o2::Base::DetImpl<Detector>
 {
  public:
   enum TOFMaterial {
@@ -59,7 +59,13 @@ class Detector : public o2::Base::Detector
 
   void Register() override;
 
-  TClonesArray* GetCollection(Int_t iColl) const final;
+  std::vector<HitType>* getHits(int iColl) const
+  {
+    if (iColl == 0) {
+      return mHits;
+    }
+    return nullptr;
+  }
 
   void Reset() final;
   void EndOfEvent() final;
@@ -97,7 +103,6 @@ class Detector : public o2::Base::Detector
 
   /// container for data points
   std::vector<HitType>* mHits; //!
-  int mMCTrackBranchId; //! cache for the MCTrackBranchID (to avoid string based query)
 
   ClassDefOverride(Detector, 1);
 };

--- a/Detectors/TOF/simulation/src/Detector.cxx
+++ b/Detectors/TOF/simulation/src/Detector.cxx
@@ -28,11 +28,10 @@ using namespace o2::tof;
 ClassImp(Detector);
 
 Detector::Detector(Bool_t active)
-  : o2::Base::Detector("TOF", active),
+  : o2::Base::DetImpl<Detector>("TOF", active),
     mEventNr(0),
     mTOFHoles(kTRUE),
-    mHits(new std::vector<HitType>),
-    mMCTrackBranchId(-1)
+    mHits(new std::vector<HitType>)
 {
   for (Int_t i = 0; i < Geo::NSECTORS; i++)
     mTOFSectors[i] = 1;
@@ -83,14 +82,6 @@ void Detector::Register()
 {
   auto* mgr = FairRootManager::Instance();
   mgr->RegisterAny(addNameTo("Hit").data(), mHits, kTRUE);
-
-  mMCTrackBranchId = mgr->GetBranchId("MCTrack");
-}
-
-TClonesArray* Detector::GetCollection(Int_t iColl) const
-{
-  LOG(WARNING) << "GetCollection interface no longer supported" << FairLogger::endl;
-  return nullptr;
 }
 
 void Detector::Reset() { mHits->clear(); }

--- a/Detectors/TPC/simulation/include/TPCSimulation/Detector.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/Detector.h
@@ -25,7 +25,7 @@ class FairVolume;  // lines 10-10
 namespace o2 {
 namespace TPC {
 
-class Detector: public o2::Base::Detector {
+class Detector: public o2::Base::DetImpl<Detector> {
 
   public:
   enum class SimulationType : char {
@@ -58,8 +58,14 @@ class Detector: public o2::Base::Detector {
     /**       Registers the produced collections in FAIRRootManager.     */
     void   Register() override;
 
-    /** Gets the produced collections */
-    TClonesArray* GetCollection(Int_t iColl) const override ;
+    /** Get the produced hits */
+    std::vector<HitGroup>* getHits(Int_t iColl) const
+    {
+      if (iColl > 0 && iColl < Sector::MAXSECTOR) {
+        return mHitsPerSectorCollection[iColl];
+      }
+      return nullptr;
+    }
 
     /**      has to be called after each event to reset the containers      */
     void   Reset() override;
@@ -132,7 +138,6 @@ class Detector: public o2::Base::Detector {
     TString mGeoFileName;                  ///< Name of the file containing the TPC geometry
     size_t mEventNr;                       //!< current event number
 
-    int mMCTrackBranchId; //! cache for the MCTrackBranchID (to avoid string based query)
 
     Detector(const Detector&);
     Detector& operator=(const Detector&);

--- a/Detectors/TPC/simulation/src/Detector.cxx
+++ b/Detectors/TPC/simulation/src/Detector.cxx
@@ -61,7 +61,7 @@ using namespace o2::TPC;
 
 
 Detector::Detector(Bool_t active)
-  : o2::Base::Detector("TPC", active),
+  : o2::Base::DetImpl<Detector>("TPC", active),
     mSimulationType(SimulationType::Other),
     mGeoFileName(),
     mEventNr(0)
@@ -325,13 +325,6 @@ void Detector::Register()
     name.Form("%sHitsSector%d", GetName(), i);
     mgr->RegisterAny(name.Data(), mHitsPerSectorCollection[i], kTRUE);
   }
-  mMCTrackBranchId=mgr->GetBranchId("MCTrack");
-}
-
-TClonesArray* Detector::GetCollection(Int_t iColl) const
-{
-  LOG(WARNING) << "GetCollection interface no longer supported" << FairLogger::endl;
-  return nullptr;
 }
 
 void Detector::Reset()

--- a/Detectors/TRD/simulation/include/TRDSimulation/Detector.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Detector.h
@@ -27,7 +27,7 @@ class TRDGeometry;
 // define TRD hit type
 using HitType = o2::BasicXYZEHit<float>;
 
-class Detector : public o2::Base::Detector
+class Detector : public o2::Base::DetImpl<Detector>
 {
  public:
 
@@ -41,7 +41,13 @@ class Detector : public o2::Base::Detector
 
   void Register() override;
 
-  TClonesArray* GetCollection(int iColl) const final;
+  std::vector<HitType>* getHits(int iColl) const
+  {
+    if (iColl == 0) {
+      return mHits;
+    }
+    return nullptr;
+  }
 
   void Reset() override;
   void EndOfEvent() override;

--- a/Detectors/TRD/simulation/src/Detector.cxx
+++ b/Detectors/TRD/simulation/src/Detector.cxx
@@ -22,7 +22,7 @@
 using namespace o2::trd;
 
 Detector::Detector(Bool_t active)
-  : o2::Base::Detector("TRD", active), 
+  : o2::Base::DetImpl<Detector>("TRD", active),
     mHits(new std::vector<HitType>)
 {
 }
@@ -61,12 +61,6 @@ bool Detector::ProcessHits(FairVolume* v)
 void Detector::Register()
 {
   FairRootManager::Instance()->RegisterAny(addNameTo("Hit").data(), mHits, true);
-}
-
-TClonesArray* Detector::GetCollection(int iColl) const
-{
-  LOG(WARNING) << "GetCollection interface no longer supported" << FairLogger::endl;
-  return nullptr;
 }
 
 void Detector::Reset() { mHits->clear(); }

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -377,6 +377,7 @@ o2_define_bucket(
     root_physics_bucket
     common_math_bucket
     detectors_base_bucket
+    DetectorsBase
     RIO
 
     INCLUDE_DIRECTORIES


### PR DESCRIPTION
…tions()

With the move away from using TClonesArrays as hit containers, as well
as not storing hits as pointers, we can no longer use the GetCollection
interface to generically update the trackID on hits -- as done by the Stack now.

This commit implements the new solution, where the Stack does no
longer need to retrieve the hits, but delegates the updating task to the individual
detectors.
Detectors now offer a new interface "updateHitTrackIndices". This interface
is implemented generically and specialized for each detector
using a helper implementation class DetImpl and the CRT pattern.
DetImpl is now the base class of all concrete Detectors.

This commit is the finishing touch to issue #610.

Some secondary cleanup (removal of unused branchID, removal of unused functions)
are also done