### PR TITLE
TPC digits + clusters: TClonesArray -> std::vector treatment

### DIFF
--- a/Detectors/TPC/base/include/TPCBase/Digit.h
+++ b/Detectors/TPC/base/include/TPCBase/Digit.h
@@ -23,15 +23,16 @@ namespace TPC {
 // A minimal (temporary) TimeStamp class, introduced here for
 // reducing memory consumption to a minimum.
 // This can be used only when MCtruth is not done using FairLinks.
-class TimeStamp : public TObject {
+class TimeStamp {
 public:
   TimeStamp() {}
   TimeStamp(int time) {
-    // we use the TObjectID for the time
-    SetUniqueID(time);
+    mTimeStamp = time;
   }
-  int GetTimeStamp() const { return TObject::GetUniqueID(); }
-  ClassDef(TimeStamp, 1);
+  int GetTimeStamp() const { return mTimeStamp; }
+private:
+  int mTimeStamp = 0;
+  ClassDefNV(TimeStamp, 1);
 };
 using DigitBase = TimeStamp;
 
@@ -55,7 +56,7 @@ class Digit : public DigitBase {
     Digit(int cru, float charge, int row, int pad, int time);
 
     /// Destructor
-    ~Digit() final = default;
+    ~Digit() = default;
 
     /// Get the accumulated charged of the Digit in ADC counts.
     /// The conversion is such that the decimals are simply stripped
@@ -91,8 +92,7 @@ class Digit : public DigitBase {
     unsigned char           mPad;             ///< Pad of the Digit
 
 
-    ClassDef(Digit, 1);
-
+    ClassDefNV(Digit, 1);
 };
 
 inline

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/TPCCATracking.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/TPCCATracking.h
@@ -16,7 +16,7 @@
 
 #include <memory>
 #include <vector>
-class TClonesArray;
+#include "TPCSimulation/HwCluster.h"
 class TChain;
 class AliHLTTPCCAO2Interface;
 class AliHLTTPCCAClusterData;
@@ -37,11 +37,11 @@ public:
   int initialize(const char* options = nullptr);
   void deinitialize();
 
-  int runTracking(const TClonesArray* inputClusters, std::vector<TrackTPC>* outputTracks) {return runTracking(nullptr, inputClusters, outputTracks);}
+  int runTracking(const std::vector<HwCluster>* inputClusters, std::vector<TrackTPC>* outputTracks) {return runTracking(nullptr, inputClusters, outputTracks);}
   int runTracking(TChain* inputClusters, std::vector<TrackTPC>* outputTracks) {return runTracking(inputClusters, nullptr, outputTracks);}
 
 private:
-  int runTracking(TChain* inputClustersChain, const TClonesArray* inputClustersArray, std::vector<TrackTPC>* outputTracks);
+  int runTracking(TChain* inputClustersChain, const std::vector<HwCluster>* inputClustersArray, std::vector<TrackTPC>* outputTracks);
 
   std::unique_ptr<AliHLTTPCCAO2Interface> mTrackingCAO2Interface; //Pointer to Interface class in HLT O2 CA Tracking library.
                                                                   //The tracking code itself is not included in the O2 package, but contained in the CA library.

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/TrackTPC.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/TrackTPC.h
@@ -16,8 +16,6 @@
 #include "TPCBase/Defs.h"
 #include "TPCSimulation/Cluster.h"
 
-#include <TClonesArray.h>
-
 
 namespace o2 {
 namespace TPC {
@@ -49,10 +47,11 @@ class TrackTPC {
     ~TrackTPC() = default;
 
     /// Add a single cluster to the track
-    void addCluster(Cluster &c);
+    void addCluster(const Cluster &c);
 
-    /// Add an array of clusters to the track
-    void addClusterArray(TClonesArray *arr);
+    /// Add an array/vector of clusters to the track; ClusterType needs to inherit from o2::TPC::Cluster
+    template <typename ClusterType>
+    void addClusterArray(std::vector<ClusterType> *arr);
 
     /// Get the clusters which are associated with the track
     /// \return clusters of the track as a std::vector
@@ -129,18 +128,18 @@ TrackTPC::TrackTPC(const std::array<float,3> &xyz,const std::array<float,3> &pxp
   , mClusterVector()
 {}
 
-inline
-void TrackTPC::addCluster(Cluster &c)
+inline void TrackTPC::addCluster(const Cluster& c)
 {
   mClusterVector.push_back(c);
 }
 
+template<typename ClusterType>
 inline
-void TrackTPC::addClusterArray(TClonesArray *arr)
+void TrackTPC::addClusterArray(std::vector<ClusterType> *arr)
 {
+  static_assert(std::is_base_of<o2::TPC::Cluster, ClusterType>::value, "ClusterType needs to inherit from o2::TPC::Cluster");
   for (auto clusterObject : *arr){
-    Cluster *inputcluster = static_cast<Cluster*>(clusterObject);
-    addCluster(*inputcluster);
+    addCluster(clusterObject);
   }
 }
 

--- a/Detectors/TPC/reconstruction/macro/convertTracks.C
+++ b/Detectors/TPC/reconstruction/macro/convertTracks.C
@@ -58,7 +58,7 @@ void convertTracks(TString inputBinaryFile, TString inputClusters, TString chere
   float cherenkovValue = 0.;
   int runNumber = 0;
 
-  TClonesArray *clusters=0x0;
+  std::vector<o2::TPC::HwCluster> *clusters=nullptr;
   c.SetBranchAddress("TPCClusterHW", &clusters);
   //c.SetBranchAddress("TPC_Cluster", &clusters);
   c.SetBranchAddress("cherenkovValue", &cherenkovValue);
@@ -132,7 +132,7 @@ void convertTracks(TString inputBinaryFile, TString inputClusters, TString chere
       {
         //printf(" %d", ClusterIDs[iCluster]);
 
-        Cluster& tempCluster = *(static_cast<Cluster*>(clusters->At(ClusterIDs[iCluster])));
+        const auto& tempCluster = (*clusters)[ClusterIDs[iCluster]];
         storedTrack.addCluster(tempCluster);
       }
       //printf("\n");

--- a/Detectors/TPC/reconstruction/macro/runCATracking.C
+++ b/Detectors/TPC/reconstruction/macro/runCATracking.C
@@ -21,6 +21,7 @@
 #include "TClonesArray.h"
 
 #include "TPCSimulation/Cluster.h"
+#include "TPCSimulation/HwCluster.h"
 #include "TPCReconstruction/TPCCATracking.h"
 #include "TPCReconstruction/TrackTPC.h"
 #include "DetectorsBase/Track.h"
@@ -41,7 +42,7 @@ void runCATracking(TString filename, TString outputFile, TString options, bool m
   }
 
   // ===| input chain initialisation |==========================================
-  TChain c("cbmsim");
+  TChain c("o2sim");
   c.AddFile(filename);
 
   // ===| output tree |=========================================================
@@ -59,7 +60,7 @@ void runCATracking(TString filename, TString outputFile, TString options, bool m
     }
     tout.Fill();
   } else {
-    TClonesArray *clusters = nullptr;
+    std::vector<o2::TPC::HwCluster>* clusters=nullptr;
     c.SetBranchAddress("TPCClusterHW", &clusters);
 
     // ===| event ranges |========================================================
@@ -71,8 +72,8 @@ void runCATracking(TString filename, TString outputFile, TString options, bool m
     for (int iEvent=0; iEvent<max; ++iEvent)   {
       c.GetEntry(start+iEvent);
 
-      printf("Processing event %d with %d clusters\n", iEvent, clusters->GetEntries());
-      if (!clusters->GetEntries()) continue;
+      printf("Processing event %lu with %d clusters\n", iEvent, clusters->size());
+      if (!clusters->size()) continue;
 
       tracks.clear();
       if (tracker.runTracking(clusters, &tracks) == 0)     {
@@ -86,5 +87,6 @@ void runCATracking(TString filename, TString outputFile, TString options, bool m
   fout.Write();
   fout.Close();
 
+  
   tracker.deinitialize();
 }

--- a/Detectors/TPC/reconstruction/macro/testTracks.C
+++ b/Detectors/TPC/reconstruction/macro/testTracks.C
@@ -22,6 +22,7 @@
 #include "TPCReconstruction/TrackTPC.h"
 #include "DetectorsBase/Track.h"
 #include "TPCSimulation/Cluster.h"
+#include "TPCSimulation/HwCluster.h"
 #include "TPCBase/Mapper.h"
 #endif
 
@@ -43,8 +44,7 @@ void testTracks(int checkEvent = 0,
   TFile *clusFile = TFile::Open(clusterFile.data());
   TTree *clusterTree = (TTree *)gDirectory->Get("cbmsim");
 
-  TClonesArray clusterArr("Cluster");
-  TClonesArray *clusters(&clusterArr);
+  std::vector<o2::TPC::HwCluster> *clusters=nullptr;
   clusterTree->SetBranchAddress("TPCClusterHW",&clusters);
 
   TGraph *grClusters   = new TGraph();
@@ -76,8 +76,8 @@ void testTracks(int checkEvent = 0,
 
   int clusCounter = 0;
   clusterTree->GetEntry(checkEvent);
-  for(auto clusterObject : *clusters) {
-    Cluster *inputcluster = static_cast<Cluster *>(clusterObject);
+  for(auto& clusterObject : *clusters) {
+    Cluster* inputcluster = &clusterObject;
     const CRU cru(inputcluster->getCRU());
 
     const PadRegionInfo& region = mapper.getPadRegionInfo(cru.region());
@@ -129,7 +129,7 @@ void testTracks(int checkEvent = 0,
     for (auto trackObject : *arrTracks) {
       std::vector<Cluster> clCont;
       trackObject.getClusterVector(clCont);
-      for(auto clusterObject : clCont) {
+      for(auto& clusterObject : clCont) {
         const CRU cru(clusterObject.getCRU());
 
         const PadRegionInfo& region = mapper.getPadRegionInfo(cru.region());

--- a/Detectors/TPC/simulation/include/TPCSimulation/BoxCluster.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/BoxCluster.h
@@ -53,7 +53,7 @@ namespace o2{
 		 Short_t size);
 
       /// Destructor
-      ~BoxCluster() override = default;
+      ~BoxCluster() = default;
 
       /// Setter for special Box cluster parameters
       /// @param pad Pad with the maximum charge
@@ -74,7 +74,7 @@ namespace o2{
       /// @param output stream
       /// @return The output stream
       friend std::ostream& operator<< (std::ostream& out, const BoxCluster &c) { return c.print(out); }
-      std::ostream& print(std::ostream &output) const override;
+      std::ostream& print(std::ostream &output) const;
 
     private:
 #ifndef __CINT__
@@ -85,7 +85,7 @@ namespace o2{
       Short_t                   mTime;
       Short_t                   mSize;
 
-      ClassDefOverride(BoxCluster, 1);
+      ClassDefNV(BoxCluster, 1);
     };
   }
 }

--- a/Detectors/TPC/simulation/include/TPCSimulation/BoxClusterer.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/BoxClusterer.h
@@ -18,9 +18,8 @@
 
 #include "Rtypes.h"
 #include "TPCSimulation/Clusterer.h"
+#include "TPCSimulation/BoxCluster.h"
 #include "TPCBase/CalDet.h"
-
-class TClonesArray;
 
 namespace o2{
   
@@ -30,7 +29,7 @@ namespace o2{
     
     class BoxClusterer : public Clusterer {
     public:
-      BoxClusterer();
+      BoxClusterer(std::vector<o2::TPC::BoxCluster> *output);
       
       /// Destructor
       ~BoxClusterer() override;
@@ -42,8 +41,8 @@ namespace o2{
       /// Steer conversion of points to digits
       /// @param digits Container with TPC digits
       /// @return Container with clusters
-      ClusterContainer* Process(TClonesArray *digits) override;
-      ClusterContainer* Process(std::vector<std::unique_ptr<Digit>>& digits) override;
+      void Process(std::vector<o2::TPC::Digit> const & digits) override;
+      void Process(std::vector<std::unique_ptr<Digit>>& digits) override;
       
       /// Set a pedestal object
       void setPedestals(CalPad* pedestals) { mPedestals = pedestals; }
@@ -74,6 +73,8 @@ namespace o2{
       Int_t**   mAllSigBins;   //!<! Array of pointers to the indexes over threshold
       Int_t*    mAllNSigBins;  //!<! Array with number of signals in each row
       CalPad*   mPedestals;    //!<! Pedestal data
+
+      std::vector<o2::TPC::BoxCluster>* mClusterArray; ///< Internal cluster storage
       
       ClassDefNV(BoxClusterer, 1);
     };

--- a/Detectors/TPC/simulation/include/TPCSimulation/Cluster.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/Cluster.h
@@ -22,11 +22,25 @@ namespace boost { namespace serialization { class access; } }
 
 namespace o2{
 namespace TPC{
+
+class ClusterTimeStamp {
+ public:
+  ClusterTimeStamp() {};
+  ClusterTimeStamp(float t, float te) : mTimeStamp(t), mTimeStampError(te) {}
+  float getTimeStamp() const {return mTimeStamp;}
+  float getTimeStampError() const {return mTimeStampError;}
+  void setTimeStamp(float t) {mTimeStamp = t;}
+  void setTimeStampError(float te) {mTimeStampError = te;}
+ private:
+  float mTimeStamp = 0.f;
+  float mTimeStampError = 0.f;
+  ClassDefNV(ClusterTimeStamp, 1);
+};
   
 /// \class Cluster
 /// \brief Cluster class for the TPC
 ///
-class Cluster : public FairTimeStamp {
+class Cluster : public ClusterTimeStamp {
   public:
     
     /// Default constructor
@@ -45,7 +59,7 @@ class Cluster : public FairTimeStamp {
         float padmean, float padsigma, float timemean, float timesigma);
     
     /// Destructor
-    ~Cluster() override = default;
+    ~Cluster() = default;
 
     /// Copy Constructor
     Cluster(const Cluster& other);
@@ -67,9 +81,9 @@ class Cluster : public FairTimeStamp {
     float getQ() const { return mQ; }
     float getQmax() const { return mQmax; }
     float getPadMean() const { return mPadMean; }
-    float getTimeMean() const { return GetTimeStamp(); }
+    float getTimeMean() const { return getTimeStamp(); }
     float getPadSigma() const { return mPadSigma; }
-    float getTimeSigma() const { return GetTimeStampError(); }
+    float getTimeSigma() const { return getTimeStampError(); }
     
     /// Print function: Print basic digit information on the  output stream
     /// \param output Stream to put the digit on
@@ -77,7 +91,7 @@ class Cluster : public FairTimeStamp {
     friend std::ostream& operator<< (std::ostream& out, const Cluster &c) { return c.print(out); }; 
 
   protected:      
-    virtual std::ostream& print(std::ostream& out) const;
+    std::ostream& print(std::ostream& out) const;
     
   private:
 #ifndef __CINT__
@@ -91,7 +105,7 @@ class Cluster : public FairTimeStamp {
     float   mPadMean;
     float   mPadSigma;
           
-    ClassDefOverride(Cluster, 1);
+    ClassDefNV(Cluster, 1);
 };
 //________________________________________________________________________
 inline 
@@ -105,7 +119,7 @@ inline
 Cluster::Cluster(short cru, short row, float q, float qmax,
 		 float padmean, float padsigma,
 		 float timemean, float timesigma)
-  : FairTimeStamp(timemean, timesigma)
+  : ClusterTimeStamp(timemean, timesigma)
   , mCRU(cru)
   , mRow(row)
   , mQ(q)
@@ -118,7 +132,7 @@ Cluster::Cluster(short cru, short row, float q, float qmax,
 //________________________________________________________________________
 inline
 Cluster::Cluster(const Cluster& other)
-  : FairTimeStamp(other)
+  : ClusterTimeStamp(other)
   , mCRU(other.mCRU)
   , mRow(other.mRow)
   , mQ(other.mQ)
@@ -140,8 +154,8 @@ void Cluster::setParameters(short cru, short row, float q, float qmax,
   mQmax = qmax;
   mPadMean = padmean;
   mPadSigma = padsigma;
-  SetTimeStamp(timemean);
-  SetTimeStampError(timesigma);
+  setTimeStamp(timemean);
+  setTimeStampError(timesigma);
 }
 
 }

--- a/Detectors/TPC/simulation/include/TPCSimulation/ClusterContainer.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/ClusterContainer.h
@@ -13,29 +13,23 @@
 #ifndef _ALICEO2_TPC_ClusterContainer_
 #define _ALICEO2_TPC_ClusterContainer_
 
-#include "TPCSimulation/Cluster.h"
-#include "Rtypes.h"
-#include "TClonesArray.h"
+#include <vector>
+#include <cassert>
+#include <Rtypes.h> // for Float_t etc
 
 namespace o2 {
   namespace TPC{
-    class Cluster;
 
     /// \class ClusterContainer
     /// \brief Container class for TPC clusters
-    class ClusterContainer{
+    class ClusterContainer {
     public:
-      ClusterContainer();
-      ~ClusterContainer();
-
       // Initialize the clones array
       // @param clusterType Possibility to store different types of clusters
-      void InitArray(const Char_t* clusterType="o2::TPC::Cluster");
-
-      // Empty array
-      void Reset();
+      // void InitArray(const Char_t* clusterType="o2::TPC::Cluster");
 
       /// Add cluster to array
+      /// @param output, the vector to append to
       /// @param cru CRU (sector)
       /// @param row Row
       /// @param q Total charge of cluster
@@ -44,18 +38,21 @@ namespace o2 {
       /// @param padsigma Sigma of cluster in pad direction
       /// @param timemean Mean position of cluster in time direction
       /// @param timesigma Sigma of cluster in time direction
-      Cluster* AddCluster(Int_t cru, Int_t row, Float_t qTot, Float_t qMax,
-			  Float_t pad, Float_t time, Float_t sigmapad,
-			  Float_t sigmatime);
-
-      // Copy container info into the output container
-      void FillOutputContainer(TClonesArray *outputcont);
-
-      Int_t GetEntries() { return mClusterArray->GetEntries(); };
-
-    private:
-      Int_t         mNclusters;        // number of clusters
-      TClonesArray* mClusterArray;      // array for clusters
+      template<typename ClusterType>
+      static ClusterType* AddCluster(std::vector<ClusterType> *output,
+		             Int_t cru, Int_t row, Float_t qTot, Float_t qMax,
+			     Float_t meanpad, Float_t meantime, Float_t sigmapad,
+			     Float_t sigmatime) {
+        assert(output);
+        output->emplace_back(); // emplace_back a defaut constructed cluster of type ClusterType
+        auto& cluster = output->back();
+        // set its concrete parameters:
+        // ATTENTION: the order of parameters in setParameters is different than in AddCluster!
+        cluster.setParameters(cru, row, qTot, qMax,
+                              meanpad, sigmapad,
+                              meantime, sigmatime);
+        return &cluster;
+      }
     };
   }
 }

--- a/Detectors/TPC/simulation/include/TPCSimulation/Clusterer.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/Clusterer.h
@@ -19,15 +19,13 @@
 
 #include "TPCSimulation/ClusterContainer.h"
 
-class TClonesArray;
-
 namespace o2{
 namespace TPC {
     
 class Digit;
 
 /// \class Clusterer
-/// \brief Base Class fot TPC clusterer
+/// \brief Base Class for TPC clusterer
 class Clusterer {
   public:
 
@@ -53,8 +51,8 @@ class Clusterer {
     /// Processing all digits
     /// \param digits Container with TPC digits
     /// \return Container with clusters
-    virtual ClusterContainer* Process(TClonesArray *digits) = 0;
-    virtual ClusterContainer* Process(std::vector<std::unique_ptr<Digit>>& digits) = 0;
+    virtual void Process(std::vector<o2::TPC::Digit> const &digits) = 0;
+    virtual void Process(std::vector<std::unique_ptr<Digit>>& digits) = 0;
 
     void setRowsMax(int val)                    { mRowsMax = val; };
     void setPadsMax(int val)                    { mPadsMax = val; };
@@ -72,7 +70,6 @@ class Clusterer {
     
   protected:
     
-    ClusterContainer* mClusterContainer;    ///< Internal cluster storage
     
     int     mRowsMax;                       ///< Maximum row number
     int     mPadsMax;                       ///< Maximum pad number

--- a/Detectors/TPC/simulation/include/TPCSimulation/ClustererTask.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/ClustererTask.h
@@ -24,8 +24,7 @@
 #include "TPCSimulation/Clusterer.h"       // for Clusterer
 #include "TPCSimulation/BoxClusterer.h"       // for Clusterer
 #include "TPCSimulation/HwClusterer.h"       // for Clusterer
-
-class TClonesArray;
+#include <vector>
 
 namespace o2 {
 namespace TPC{
@@ -76,9 +75,10 @@ class ClustererTask : public FairTask{
     BoxClusterer        *mBoxClusterer;
     HwClusterer         *mHwClusterer;
     
-    TClonesArray        *mDigitsArray;
-    TClonesArray        *mClustersArray;
-    TClonesArray        *mHwClustersArray;
+    std::vector<o2::TPC::Digit> const  *mDigitsArray;
+    // produced data containers
+    std::vector<o2::TPC::BoxCluster>  *mClustersArray;
+    std::vector<o2::TPC::HwCluster>  *mHwClustersArray;
     
     ClassDefOverride(ClustererTask, 1)
 };

--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitCRU.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitCRU.h
@@ -20,8 +20,6 @@
 
 #include <deque>
 
-class TClonesArray;
-
 namespace o2 {
 namespace TPC {
 
@@ -67,14 +65,15 @@ class DigitCRU{
     /// \param charge Charge of the digit
     void setDigit(size_t hitID, int timeBin, int row, int pad, float charge);
 
-    /// Fill output TClonesArray
+    /// Fill output vector
     /// \param output Output container
     /// \param mcTruth MC Truth container
     /// \param debug Optional debug output container
     /// \param cruID CRU ID
     /// \param eventTime time stamp of the event
     /// \param isContinuous Switch for continuous readout
-    void fillOutputContainer(TClonesArray *output, o2::dataformats::MCTruthContainer<o2::MCCompLabel> &mcTruth, TClonesArray *debug, int cru, int eventTime=0, bool isContinuous=true);
+    void fillOutputContainer(std::vector<o2::TPC::Digit> *output, o2::dataformats::MCTruthContainer<o2::MCCompLabel> &mcTruth,
+			     std::vector<o2::TPC::DigitMCMetaData> *debug, int cru, int eventTime=0, bool isContinuous=true);
 
   private:
     int                    mFirstTimeBin;

--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitContainer.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitContainer.h
@@ -19,11 +19,12 @@
 #include "TPCSimulation/DigitCRU.h"
 #include "TPCSimulation/CommonModeContainer.h"
 
-class TClonesArray;
-
 namespace o2 {
 namespace TPC {
 
+class Digit;
+class DigitMCMetaData;
+  
 /// \class DigitContainer
 /// This is the base class of the intermediate Digit Containers, in which all incoming electrons from the hits are sorted into after amplification
 /// The structure assures proper sorting of the Digits when later on written out for further processing.
@@ -57,13 +58,14 @@ class DigitContainer{
     /// \param charge Charge of the digit
     void addDigit(size_t hitID, int cru, int timeBin, int row, int pad, float charge);
 
-    /// Fill output TClonesArray
+    /// Fill output vector
     /// \param output Output container
     /// \param mcTruth MC Truth container
     /// \param debug Optional debug output container
     /// \param eventTime time stamp of the event
     /// \param isContinuous Switch for continuous readout
-    void fillOutputContainer(TClonesArray *output, o2::dataformats::MCTruthContainer<o2::MCCompLabel> &mcTruth, TClonesArray *debug, int eventTime=0, bool isContinuous=true);
+    void fillOutputContainer(std::vector<o2::TPC::Digit> *output, o2::dataformats::MCTruthContainer<o2::MCCompLabel> &mcTruth,
+			     std::vector<o2::TPC::DigitMCMetaData> *debug, int eventTime=0, bool isContinuous=true);
 
   private:
     std::array<std::unique_ptr<DigitCRU> , CRU::MaxCRU> mCRU;   ///< CRU Container for the ADC value

--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitMCMetaData.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitMCMetaData.h
@@ -16,7 +16,6 @@
 #define ALICEO2_TPC_DigitMCMetaData_H_
 
 #include <Rtypes.h>
-#include <TObject.h>
 
 namespace o2 {
 namespace TPC {
@@ -26,7 +25,7 @@ namespace TPC {
 /// It holds auxilliary information relevant for debugging:
 /// ADC value, Common Mode, Pedestal and Noise
 
-class DigitMCMetaData : public TObject {
+class DigitMCMetaData {
   public:
 
     /// Default constructor
@@ -40,7 +39,7 @@ class DigitMCMetaData : public TObject {
     DigitMCMetaData(float ADC, float commonMode, float pedestal, float noise);
 
     /// Destructor
-    ~DigitMCMetaData() final = default;
+    ~DigitMCMetaData() = default;
 
     /// Get the raw ADC value
     /// \return Raw ADC value of the corresponding DigitMC (before saturation)
@@ -64,7 +63,7 @@ class DigitMCMetaData : public TObject {
     float         mPedestal;        ///< Pedestal value of the DigitMCMetaData
     float         mNoise;           ///< Noise value of the DigitMCMetaData
 
-  ClassDef(DigitMCMetaData, 1);
+  ClassDefNV(DigitMCMetaData, 1);
 };
 
 inline

--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitPad.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitPad.h
@@ -21,17 +21,19 @@
 #include "FairRootManager.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
 #include "SimulationDataFormat/MCCompLabel.h"
-#include <TClonesArray.h>
 
 namespace o2 {
 namespace TPC {
 
+class Digit;
+class DigitMCMetaData;
+  
 /// \class DigitPad
 /// This is the fifth and lowest class of the intermediate Digit Containers, in which all incoming electrons from the hits are sorted into after amplification
 /// The structure assures proper sorting of the Digits when later on written out for further processing.
 /// This class holds the individual pad containers and is contained within the Row Container.
 
-class DigitPad{
+class DigitPad {
   public:
 
     /// Constructor
@@ -57,7 +59,7 @@ class DigitPad{
     /// \param charge Charge of the digit
     void setDigit(size_t hitID, float charge);
 
-    /// Fill output TClonesArray
+    /// Fill output vector
     /// \param output Output container
     /// \param mcTruth MC Truth container
     /// \param debug Optional debug output container
@@ -66,7 +68,8 @@ class DigitPad{
     /// \param row Row ID
     /// \param pad pad ID
     /// \param commonMode Common mode value of that specific ROC
-    void fillOutputContainer(TClonesArray *output, o2::dataformats::MCTruthContainer<o2::MCCompLabel> &mcTruth, TClonesArray *debug, int cru, int timeBin, int row, int pad, float commonMode = 0.f);
+    void fillOutputContainer(std::vector<o2::TPC::Digit> *output, o2::dataformats::MCTruthContainer<o2::MCCompLabel> &mcTruth,
+			     std::vector<o2::TPC::DigitMCMetaData> *debug, int cru, int timeBin, int row, int pad, float commonMode = 0.f);
 
   private:
 

--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitRow.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitRow.h
@@ -16,9 +16,10 @@
 #define ALICEO2_TPC_DigitRow_H_
 
 #include "TPCSimulation/DigitPad.h"
-#include <memory>
+#include "TPCBase/Digit.h"
+#include "TPCSimulation/DigitMCMetaData.h"
 
-class TClonesArray;
+#include <memory>
 
 namespace o2 {
 namespace TPC {
@@ -28,7 +29,7 @@ namespace TPC {
 /// The structure assures proper sorting of the Digits when later on written out for further processing.
 /// This class holds the individual Pad containers and is contained within the Time Bin Container.
 
-class DigitRow{
+class DigitRow {
   public:
 
     /// Constructor
@@ -64,7 +65,7 @@ class DigitRow{
     /// \param charge Charge of the digit
     void setDigit(size_t hitID, int pad, float charge);
 
-    /// Fill output TClonesArray
+    /// Fill output vector
     /// \param output Output container
     /// \param mcTruth MC Truth container
     /// \param debug Optional debug output container
@@ -72,7 +73,8 @@ class DigitRow{
     /// \param timeBin Time bin
     /// \param row Row ID
     /// \param commonMode Common mode value of that specific ROC
-    void fillOutputContainer(TClonesArray *output, o2::dataformats::MCTruthContainer<o2::MCCompLabel> &mcTruth, TClonesArray *debug, int cru, int timeBin, int row, float commonMode = 0.f);
+    void fillOutputContainer(std::vector<o2::TPC::Digit> *output, o2::dataformats::MCTruthContainer<o2::MCCompLabel> &mcTruth,
+			     std::vector<o2::TPC::DigitMCMetaData> *debug, int cru, int timeBin, int row, float commonMode = 0.f);
 
   private:
     unsigned char          mRow;                ///< Row of the ADC value

--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitTime.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitTime.h
@@ -17,8 +17,6 @@
 
 #include "TPCSimulation/DigitRow.h"
 
-class TClonesArray;
-
 namespace o2 {
 namespace TPC {
     
@@ -69,14 +67,15 @@ class DigitTime{
     /// \param charge Charge of the digit
     void setDigit(size_t hitID, int cru, int row, int pad, float charge);
 
-    /// Fill output TClonesArray
+    /// Fill output vector
     /// \param output Output container
     /// \param mcTruth MC Truth container
     /// \param debug Optional debug output container
     /// \param cru CRU ID
     /// \param timeBin Time bin
     /// \param commonMode Common mode value of that specific ROC
-    void fillOutputContainer(TClonesArray *output, o2::dataformats::MCTruthContainer<o2::MCCompLabel> &mcTruth, TClonesArray *debug, int cru, int timeBin, float commonMode = 0.f);
+    void fillOutputContainer(std::vector<o2::TPC::Digit> *output, o2::dataformats::MCTruthContainer<o2::MCCompLabel> &mcTruth,
+			     std::vector<o2::TPC::DigitMCMetaData> *debug, int cru, int timeBin, float commonMode = 0.f);
 
   private:
     float                   mTotalChargeTimeBin;        ///< Total accumulated charge in that time bin

--- a/Detectors/TPC/simulation/include/TPCSimulation/Digitizer.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/Digitizer.h
@@ -54,7 +54,7 @@ static GEMRESPONSE GEMresponse;
 /// -# Induction of the signal on the pad plane, including a spread of the signal due to the pad response (PadResponse)
 /// -# Shaping and further signal processing in the Front-End Cards (SampaProcessing)
 /// The such created Digits and then sorted in an intermediate Container (DigitContainer) and after processing of the full event/drift time summed up
-/// and sorted as Digits into a TClonesArray which is then passed further on
+/// and sorted as Digits into a vector which is then passed further on
 
 class Digitizer {
   public:

--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitizerTask.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitizerTask.h
@@ -23,8 +23,6 @@
 #include "TPCBase/Sector.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
 
-#include <TClonesArray.h>
-
 namespace o2 {
 namespace TPC { 
 
@@ -70,9 +68,9 @@ class DigitizerTask : public FairTask{
     Digitizer           *mDigitizer;    ///< Digitization process
     DigitContainer      *mDigitContainer;
       
-    TClonesArray        *mDigitsArray;  ///< Array of the Digits, passed from the digitization
+    std::vector<o2::TPC::Digit> *mDigitsArray = nullptr;  ///< Array of the Digits, passed from the digitization
     o2::dataformats::MCTruthContainer<o2::MCCompLabel> mMCTruthArray; ///< Array for MCTruth information associated to digits in mDigitsArrray. Passed from the digitization
-    TClonesArray        *mDigitsDebugArray;  ///< Array of the Digits, for debugging purposes only, passed from the digitization
+    std::vector<o2::TPC::DigitMCMetaData> *mDigitsDebugArray = nullptr;  ///< Array of the Digits, for debugging purposes only, passed from the digitization
     
     int                 mTimeBinMax;   ///< Maximum time bin to be written out
     bool                mIsContinuousReadout; ///< Switch for continuous readout

--- a/Detectors/TPC/simulation/include/TPCSimulation/HwCluster.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/HwCluster.h
@@ -47,7 +47,7 @@ class HwCluster : public Cluster {
         float** clusterData, short maxPad, short maxTime);
 
     /// Destructor
-    ~HwCluster() override = default;
+    ~HwCluster() = default;
 
     /// Copy Constructor
     /// \param other HwCluster to be copied
@@ -73,7 +73,7 @@ class HwCluster : public Cluster {
     /// \param output Stream to put the HwCluster on
     /// \return The output stream
     friend std::ostream& operator<< (std::ostream& out, const HwCluster &c) { return c.print(out); }
-    std::ostream& print(std::ostream &output) const override;
+    std::ostream& print(std::ostream &output) const;
     std::ostream& PrintDetails(std::ostream &output) const;
 
   private:
@@ -88,7 +88,7 @@ class HwCluster : public Cluster {
 
     std::vector<std::vector<float>> mClusterData;  ///< CLuster data
 
-    ClassDefOverride(HwCluster, 1);
+    ClassDefNV(HwCluster, 1);
   };
 }
 }

--- a/Detectors/TPC/simulation/include/TPCSimulation/HwClusterer.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/HwClusterer.h
@@ -15,11 +15,10 @@
 #define ALICEO2_TPC_HWClusterer_H_
 
 #include "TPCSimulation/Clusterer.h"
+#include "TPCSimulation/HwCluster.h"
 #include "TPCBase/CalDet.h" 
 
 #include <vector>
-
-class TClonesArray;
 
 namespace o2{
 namespace TPC {
@@ -37,6 +36,7 @@ class HwClusterer : public Clusterer {
     enum class Processing : int { Sequential, Parallel};
 
     /// Constructor
+    /// \param output is pointer to vector to be filled with clusters
     /// \param processingType parallel or sequential
     /// \param globalTime value of first timebin
     /// \param cru Number of CRUs to process
@@ -48,7 +48,8 @@ class HwClusterer : public Clusterer {
     /// \param timebinsPerCF Timebins per cluster finder
     /// \param cfPerRow Number of cluster finder in each row
     HwClusterer(
-        Processing processingType = Processing::Parallel,
+	std::vector<o2::TPC::HwCluster> *output,
+	Processing processingType = Processing::Parallel,
         int globalTime = 0, 
         int cruMin = 0,
         int cruMax = 360, 
@@ -70,8 +71,8 @@ class HwClusterer : public Clusterer {
     /// Steer conversion of points to digits
     /// @param digits Container with TPC digits
     /// @return Container with clusters
-    ClusterContainer* Process(TClonesArray *digits) override;
-    ClusterContainer* Process(std::vector<std::unique_ptr<Digit>>& digits) override;
+    void Process(std::vector<o2::TPC::Digit> const &digits) override;
+    void Process(std::vector<std::unique_ptr<Digit>>& digits) override;
 
     void setProcessingType(Processing processing)    { mProcessingType = processing; };   
 
@@ -104,7 +105,7 @@ class HwClusterer : public Clusterer {
     };
     
     static void processDigits(
-        const std::vector<std::vector<Digit*>>& digits, 
+        const std::vector<std::vector<Digit const*>>& digits, 
         const std::vector<std::vector<HwClusterFinder*>>& clusterFinder, 
               std::vector<HwCluster>& cluster, 
               CfConfig config);
@@ -114,10 +115,10 @@ class HwClusterer : public Clusterer {
 //              unsigned minTimeBin,
 //              unsigned maxTimeBin);
     
-    ClusterContainer* ProcessTimeBins(int iTimeBinMin, int iTimeBinMax);
+    void ProcessTimeBins(int iTimeBinMin, int iTimeBinMax);
 
     std::vector<std::vector<std::vector<HwClusterFinder*>>> mClusterFinder;
-    std::vector<std::vector<std::vector<Digit*>>> mDigitContainer;
+    std::vector<std::vector<std::vector<Digit const*>>> mDigitContainer;
 
     std::vector<std::vector<HwCluster>> mClusterStorage;
     
@@ -136,6 +137,8 @@ class HwClusterer : public Clusterer {
     int     mCfPerRow;
     int     mLastTimebin;
 
+    std::vector<o2::TPC::HwCluster>* mClusterArray;    ///< Internal cluster storage
+    
     CalDet<float>* mNoiseObject;
     CalDet<float>* mPedestalObject;
   };

--- a/Detectors/TPC/simulation/macro/readMCtruth.C
+++ b/Detectors/TPC/simulation/macro/readMCtruth.C
@@ -12,14 +12,14 @@
 /// \brief This macro demonstrates how to extract the MC truth information from
 /// the digits
 /// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
+#include <vector>
 
 void readMCtruth(std::string filename)
 {
   TFile *digitFile = TFile::Open(filename.data());
   TTree *digitTree = (TTree*)digitFile->Get("o2sim");
 
-  TClonesArray digitArr("o2::TPC::Digit");
-  TClonesArray *digits(&digitArr);
+  std::vector<o2::TPC::Digit>* digits = nullptr;
   digitTree->SetBranchAddress("TPCDigit",&digits);
 
   o2::dataformats::MCTruthContainer<o2::MCCompLabel> mMCTruthArray;
@@ -29,8 +29,7 @@ void readMCtruth(std::string filename)
   for(int iEvent=0; iEvent<digitTree->GetEntriesFast(); ++iEvent) {
     int digit = 0;
     digitTree->GetEntry(iEvent);
-    for(auto digitObject : *digits) {
-      o2::TPC::Digit *inputdigit = static_cast<o2::TPC::Digit*>(digitObject);
+    for(auto& inputdigit : *digits) {
       gsl::span<const o2::MCCompLabel> mcArray = mMCTruthArray.getLabels(digit);
       for(int j=0; j<static_cast<int>(mcArray.size()); ++j) {
         std::cout << "Digit " << digit << " from Event " <<

--- a/Detectors/TPC/simulation/src/Cluster.cxx
+++ b/Detectors/TPC/simulation/src/Cluster.cxx
@@ -23,8 +23,8 @@ std::ostream& Cluster::print(std::ostream& out) const {
 //{
   out << "TPC Cluster in CRU [" << mCRU << "], pad row ["
 	 << mRow << "] with charge/maxCharge " << mQ << "/" << mQmax
-	 << " and coordinates (" << mPadMean << ", " << GetTimeStamp() << ")"
-	 << " and width (" << mPadSigma << ", " << GetTimeStampError() << ")";
+	 << " and coordinates (" << mPadMean << ", " << getTimeStamp() << ")"
+	 << " and width (" << mPadSigma << ", " << getTimeStampError() << ")";
   return out;
 }
 

--- a/Detectors/TPC/simulation/src/ClusterContainer.cxx
+++ b/Detectors/TPC/simulation/src/ClusterContainer.cxx
@@ -12,72 +12,7 @@
 #include "TPCSimulation/Cluster.h"
 
 #include "FairLogger.h"
-
-#include "TClonesArray.h"
-#include "TError.h"                // for R__ASSERT
+#include <cassert>
 
 using namespace o2::TPC;
 
-//________________________________________________________________________
-ClusterContainer::ClusterContainer():
-  mNclusters(0),
-  mClusterArray(nullptr)
-{}
-
-//________________________________________________________________________
-ClusterContainer::~ClusterContainer()
-{
-  delete mClusterArray;
-}
-
-//________________________________________________________________________
-void ClusterContainer::InitArray(const Char_t* clusterType)
-{
-  R__ASSERT(!mClusterArray);
-  mClusterArray = new TClonesArray(clusterType);
-
-  // Brute force test that clusterType is derived from AliceO2::TPC::Cluster
-  Cluster *cluster =
-    dynamic_cast<Cluster*>(mClusterArray->ConstructedAt(mNclusters));
-  R__ASSERT(cluster);
-
-  // reset array after test
-  Reset();
-}
-
-//________________________________________________________________________
-void ClusterContainer::Reset()
-{
-  R__ASSERT(mClusterArray);
-  mClusterArray->Clear();
-  mNclusters = 0;
-}
-
-//________________________________________________________________________
-Cluster* ClusterContainer::AddCluster(Int_t cru, Int_t row,
-				      Float_t qtot, Float_t qmax,
-				      Float_t meanpad, Float_t meantime,
-				      Float_t sigmapad, Float_t sigmatime)
-{
-  R__ASSERT(mClusterArray);
-  Cluster *cluster =
-    dynamic_cast<Cluster*>(mClusterArray->ConstructedAt(mNclusters));
-  mNclusters++;
-  // ATTENTION: the order of parameters in setParameters is different than in AddCluster!
-  cluster->setParameters(cru, row, qtot, qmax,
-                         meanpad, sigmapad,
-                         meantime, sigmatime);
-  return cluster;
-}
-
-
-//________________________________________________________________________
-void ClusterContainer::FillOutputContainer(TClonesArray *output)
-{
-  output->Expand(mNclusters);
-  TClonesArray &outputRef = *output;
-  for(Int_t n = 0; n < mNclusters; n++) {
-    Cluster* cluster = dynamic_cast<Cluster*>(mClusterArray->At(n));
-    new (outputRef[n]) Cluster(*cluster);
-  }
-}

--- a/Detectors/TPC/simulation/src/Clusterer.cxx
+++ b/Detectors/TPC/simulation/src/Clusterer.cxx
@@ -25,8 +25,7 @@ Clusterer::Clusterer()
 //________________________________________________________________________
 Clusterer::Clusterer(int rowsMax, int padsMax, int timeBinsMax, int minQMax,
     bool requirePositiveCharge, bool requireNeighbouringPad)
-  : mClusterContainer(nullptr)
-  , mRowsMax(rowsMax)
+  : mRowsMax(rowsMax)
   , mPadsMax(padsMax)
   , mTimeBinsMax(timeBinsMax)
   , mMinQMax(minQMax)

--- a/Detectors/TPC/simulation/src/DigitCRU.cxx
+++ b/Detectors/TPC/simulation/src/DigitCRU.cxx
@@ -45,7 +45,8 @@ void DigitCRU::setDigit(size_t hitID, int timeBin, int row, int pad, float charg
   }
 }
 
-void DigitCRU::fillOutputContainer(TClonesArray *output, o2::dataformats::MCTruthContainer<o2::MCCompLabel> &mcTruth, TClonesArray *debug, int cru, int eventTime, bool isContinuous)
+void DigitCRU::fillOutputContainer(std::vector<o2::TPC::Digit> *output, o2::dataformats::MCTruthContainer<o2::MCCompLabel> &mcTruth,
+        			   std::vector<o2::TPC::DigitMCMetaData> *debug, int cru, int eventTime, bool isContinuous)
 {
   int nProcessedTimeBins = 0;
   for(auto &aTime : mTimeBins) {

--- a/Detectors/TPC/simulation/src/DigitContainer.cxx
+++ b/Detectors/TPC/simulation/src/DigitContainer.cxx
@@ -35,7 +35,8 @@ void DigitContainer::addDigit(size_t hitID, int cru, int timeBin, int row, int p
 }
 
 
-void DigitContainer::fillOutputContainer(TClonesArray *output, o2::dataformats::MCTruthContainer<o2::MCCompLabel>  &mcTruth, TClonesArray *debug, int eventTime, bool isContinuous)
+void DigitContainer::fillOutputContainer(std::vector<o2::TPC::Digit> *output, o2::dataformats::MCTruthContainer<o2::MCCompLabel> &mcTruth,
+					 std::vector<o2::TPC::DigitMCMetaData> *debug, int eventTime, bool isContinuous)
 {
   for(auto &aCRU : mCRU) {
     if(aCRU == nullptr) continue;

--- a/Detectors/TPC/simulation/src/DigitRow.cxx
+++ b/Detectors/TPC/simulation/src/DigitRow.cxx
@@ -30,7 +30,8 @@ void DigitRow::setDigit(size_t hitID, int pad, float charge)
   }
 }
 
-void DigitRow::fillOutputContainer(TClonesArray *output, o2::dataformats::MCTruthContainer<o2::MCCompLabel> &mcTruth, TClonesArray *debug, int cru, int timeBin, int row, float commonMode)
+void DigitRow::fillOutputContainer(std::vector<o2::TPC::Digit> *output, o2::dataformats::MCTruthContainer<o2::MCCompLabel> &mcTruth,
+				   std::vector<o2::TPC::DigitMCMetaData> *debug, int cru, int timeBin, int row, float commonMode)
 {
   for(auto &aPad : mPads) {
     if(aPad == nullptr) continue;

--- a/Detectors/TPC/simulation/src/DigitTime.cxx
+++ b/Detectors/TPC/simulation/src/DigitTime.cxx
@@ -33,7 +33,8 @@ void DigitTime::setDigit(size_t hitID, int cru, int row, int pad, float charge)
   mTotalChargeTimeBin+=charge;
 }
 
-void DigitTime::fillOutputContainer(TClonesArray *output, o2::dataformats::MCTruthContainer<o2::MCCompLabel> &mcTruth, TClonesArray *debug, int cru, int timeBin, float commonMode)
+void DigitTime::fillOutputContainer(std::vector<o2::TPC::Digit> *output, o2::dataformats::MCTruthContainer<o2::MCCompLabel> &mcTruth,
+         			    std::vector<o2::TPC::DigitMCMetaData> *debug, int cru, int timeBin, float commonMode)
 {
   for(auto &aRow : mRows) {
     if(aRow == nullptr) continue;

--- a/Detectors/TPC/simulation/src/Digitizer.cxx
+++ b/Detectors/TPC/simulation/src/Digitizer.cxx
@@ -12,7 +12,6 @@
 /// \brief Implementation of the ALICE TPC digitizer
 /// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
 
-#include <TClonesArray.h>
 #include "TPCSimulation/Digitizer.h"
 #include "TPCSimulation/ElectronTransport.h"
 #include "TPCSimulation/GEMAmplification.h"

--- a/Detectors/TPC/simulation/src/DigitizerTask.cxx
+++ b/Detectors/TPC/simulation/src/DigitizerTask.cxx
@@ -20,6 +20,8 @@
 #include "TPCSimulation/Digitizer.h"
 #include "TPCSimulation/Point.h"
 #include "TPCBase/Sector.h"
+#include "TPCBase/Digit.h"
+#include "TPCSimulation/DigitMCMetaData.h"
 
 #include "FairLogger.h"
 #include "FairRootManager.h"
@@ -87,18 +89,16 @@ InitStatus DigitizerTask::Init()
   }
   
   // Register output container
-  mDigitsArray = new TClonesArray("o2::TPC::Digit");
-  mDigitsArray->BypassStreamer(true);
-  mgr->Register("TPCDigit", "TPC", mDigitsArray, kTRUE);
+  mDigitsArray = new std::vector<o2::TPC::Digit>;
+  mgr->RegisterAny("TPCDigit", mDigitsArray, kTRUE);
 
   // Register MC Truth container
   mgr->Register("TPCDigitMCTruth", "TPC", &mMCTruthArray, kTRUE);
 
   // Register additional (optional) debug output
   if(mDigitDebugOutput) {
-    mDigitsDebugArray = new TClonesArray("o2::TPC::DigitMCMetaData");
-    mDigitsDebugArray->BypassStreamer(true);
-    mgr->Register("TPCDigitMCMetaData", "TPC", mDigitsDebugArray, kTRUE);
+    mDigitsDebugArray = new std::vector<o2::TPC::DigitMCMetaData>;
+    mgr->RegisterAny("TPCDigitMCMetaData", mDigitsDebugArray, kTRUE);
   }
   
   mDigitizer->init();
@@ -113,10 +113,10 @@ void DigitizerTask::Exec(Option_t *option)
   const int eventTime = Digitizer::getTimeBinFromTime(mgr->GetEventTime() * 0.001);
 
   LOG(DEBUG) << "Running digitization on new event at time bin " << eventTime << FairLogger::endl;
-  mDigitsArray->Delete();
+  mDigitsArray->clear();
   mMCTruthArray.clear();
   if(mDigitDebugOutput) {
-    mDigitsDebugArray->Delete();
+    mDigitsDebugArray->clear();
   }
 
   if (mHitSector == -1){
@@ -138,10 +138,10 @@ void DigitizerTask::FinishTask()
   if(!mIsContinuousReadout) return;
   FairRootManager *mgr = FairRootManager::Instance();
   mgr->SetLastFill(kTRUE); /// necessary, otherwise the data is not written out
-  mDigitsArray->Delete();
+  mDigitsArray->clear();
   mMCTruthArray.clear();
   if(mDigitDebugOutput) {
-    mDigitsDebugArray->Delete();
+    mDigitsDebugArray->clear();
   }
   mDigitContainer->fillOutputContainer(mDigitsArray, mMCTruthArray, mDigitsDebugArray, mTimeBinMax, mIsContinuousReadout);
 }

--- a/Detectors/TPC/simulation/src/HwClusterFinder.cxx
+++ b/Detectors/TPC/simulation/src/HwClusterFinder.cxx
@@ -17,7 +17,6 @@
 #include "TPCSimulation/HwCluster.h"
 
 #include "FairLogger.h"
-#include "TClonesArray.h"
 
 
 using namespace o2::TPC;

--- a/Detectors/TPC/simulation/src/TPCSimulationLinkDef.h
+++ b/Detectors/TPC/simulation/src/TPCSimulationLinkDef.h
@@ -18,6 +18,7 @@
 #pragma link C++ class o2::TPC::BoxCluster+;
 #pragma link C++ class o2::TPC::BoxClusterer+;
 #pragma link C++ class o2::TPC::CommonModeContainer+;
+#pragma link C++ class o2::TPC::ClusterTimeStamp+;
 #pragma link C++ class o2::TPC::Cluster+;
 #pragma link C++ class o2::TPC::Clusterer+;
 #pragma link C++ class o2::TPC::ClusterContainer+;


### PR DESCRIPTION
Refactoring of TPC digits and clusters to use strongly typed std::vectors; 
some accompanying cleanup/simplifications.