### PR TITLE
Fix wrong initialization of MCTrack vector in Stack

### DIFF
--- a/DataFormats/simulation/src/Stack.cxx
+++ b/DataFormats/simulation/src/Stack.cxx
@@ -40,7 +40,7 @@ Stack::Stack(Int_t size)
   : FairGenericStack(),
     mStack(),
     mParticles(new TClonesArray("TParticle", size)),
-    mTracks(new std::vector<o2::MCTrack>(size)),
+    mTracks(new std::vector<o2::MCTrack>),
     mStoreMap(),
     mStoreIterator(),
     mIndexMap(),


### PR DESCRIPTION
The MCTrack vector was wrongly initialized to be of size 100
in contrast to the desired "capacity of 100".

Thanks to Iouri Belikov for spotting this.