### PR TITLE
Next round of improvements to Stack class

### DIFF
--- a/DataFormats/simulation/CMakeLists.txt
+++ b/DataFormats/simulation/CMakeLists.txt
@@ -26,6 +26,7 @@ set(TEST_SRCS
   test/testBasicHits.cxx
   test/testMCTruthContainer.cxx
   test/testMCCompLabel.cxx
+  test/MCTrack.cxx
 )
 
 O2_GENERATE_TESTS(

--- a/DataFormats/simulation/include/SimulationDataFormat/MCTrack.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCTrack.h
@@ -10,7 +10,7 @@
 
 /// \file MCTrack.h
 /// \brief Definition of the MCTrack class
-/// \author M. Al-Turany - June 2014
+/// \author M. Al-Turany - June 2014; S. Wenzel - October 2017
 
 #ifndef ALICEO2_DATA_MCTRACK_H_
 #define ALICEO2_DATA_MCTRACK_H_
@@ -20,8 +20,10 @@
 #include "TMath.h"
 #include "TVector3.h"
 #include "DetectorsBase/DetID.h"
-
-class TParticle;
+#include "TDatabasePDG.h"
+#include "TParticle.h"
+#include "TParticlePDG.h"
+#include "TMCProcess.h"
 
 namespace o2 {
 
@@ -30,25 +32,26 @@ namespace o2 {
 /// secondary one produced by the transport through decay or interaction.
 /// This is a light weight particle class that is saved to disk
 /// instead of saving the TParticle class. It is also used for filtering the stack
-class MCTrack
+template <class T>
+class MCTrackT
 {
 
   public:
     ///  Default constructor
-    MCTrack();
+    MCTrackT();
 
     ///  Standard constructor
-    MCTrack(Int_t pdgCode, Int_t motherID, Double_t px, Double_t py, Double_t pz, Double_t x, Double_t y, Double_t z,
+    MCTrackT(Int_t pdgCode, Int_t motherID, Double_t px, Double_t py, Double_t pz, Double_t x, Double_t y, Double_t z,
             Double_t t, Int_t nPoints);
 
     ///  Copy constructor
-    MCTrack(const MCTrack &track);
+    MCTrackT(const MCTrackT &track) = default;
 
     ///  Constructor from TParticle
-    MCTrack(TParticle *particle);
+    MCTrackT(const TParticle &particle);
 
     ///  Destructor
-    ~MCTrack();
+    ~MCTrackT() = default;
 
     ///  Output to screen
     void Print(Int_t iTrack = 0) const;
@@ -105,13 +108,17 @@ class MCTrack
 
     Double_t GetPt() const
     {
-      return TMath::Sqrt(mStartVertexMomentumX * mStartVertexMomentumX + mStartVertexMomentumY * mStartVertexMomentumY);
+      double mx(mStartVertexMomentumX);
+      double my(mStartVertexMomentumY);
+      return std::sqrt(mx * mx + my * my); 
     }
 
     Double_t GetP() const
     {
-      return TMath::Sqrt(mStartVertexMomentumX * mStartVertexMomentumX + mStartVertexMomentumY * mStartVertexMomentumY +
-                         mStartVertexMomentumZ * mStartVertexMomentumZ);
+      double mx(mStartVertexMomentumX);
+      double my(mStartVertexMomentumY);
+      double mz(mStartVertexMomentumZ);
+      return std::sqrt(mx*mx + my*my + mz*mz);
     }
 
     Double_t GetRapidity() const;
@@ -123,8 +130,8 @@ class MCTrack
     void GetStartVertex(TVector3 &vertex);
 
     /// Accessors to the hit mask
-    Int_t getHitMask() const { return mHitMask; }
-    void setHitMask(Int_t m) { mHitMask = m; }
+    Int_t getHitMask() const { return ((PropEncoding)mProp).hitmask; }
+    void setHitMask(Int_t m) { ((PropEncoding)mProp).hitmask = m; }
 
     ///  Modifiers
     void SetMotherTrackId(Int_t id)
@@ -132,18 +139,18 @@ class MCTrack
       mMotherTrackId = id;
     }
 
-    static void setHit(Int_t iDet, int& encoding) { encoding |= 1 << iDet; }
-
     // set bit indicating that this track
     // left a hit in detector with id iDet
     void setHit(Int_t iDet) {
       assert(0<=iDet && iDet < o2::Base::DetID::nDetectors);
-      MCTrack::setHit(iDet, mHitMask);
+      auto prop = ((PropEncoding)mProp);
+      prop.hitmask |= 1 << iDet;
+      mProp = prop.i;
     }
 
     // did detector iDet see this track?
     bool leftTrace(Int_t iDet) const {
-      return (mHitMask & ( 1 << iDet )) > 0;
+      return (((PropEncoding)mProp).hitmask & ( 1 << iDet )) > 0;
     }
 
     // determine how many detectors "saw" this track
@@ -157,48 +164,155 @@ class MCTrack
       return count;
     }
 
-   private:
+    // keep track if this track will be persistet
+    // using last bit in mHitMask to do so
+    void setStore(bool f) { auto prop = ((PropEncoding)mProp); prop.storage = f; mProp=prop.i; }
+    bool getStore() const { return ((PropEncoding)mProp).storage; }
+    // determine if this track has hits
+    bool hasHits() const { return ((PropEncoding)mProp).hitmask!=0; }  
+
+    // set process property
+    void setProcess(int proc) { auto prop = ((PropEncoding)mProp); prop.process = proc; mProp=prop.i; }
+    int getProcess() const { return ((PropEncoding)mProp).process; }
+
+ private:
+    /// Momentum components at start vertex [GeV]
+    T mStartVertexMomentumX, mStartVertexMomentumY, mStartVertexMomentumZ;
+
+    /// Coordinates of start vertex [cm, ns]
+    T mStartVertexCoordinatesX, mStartVertexCoordinatesY, mStartVertexCoordinatesZ, mStartVertexCoordinatesT;
+
     ///  PDG particle code
     Int_t mPdgCode;
 
     ///  Index of mother track. -1 for primary particles.
     Int_t mMotherTrackId;
-
-    /// Momentum components at start vertex [GeV]
-    Double32_t mStartVertexMomentumX, mStartVertexMomentumY, mStartVertexMomentumZ;
-
-    /// Coordinates of start vertex [cm, ns]
-    Double32_t mStartVertexCoordinatesX, mStartVertexCoordinatesY, mStartVertexCoordinatesZ, mStartVertexCoordinatesT;
-
+    
     // hitmask stored as an int
     // if bit i is set it means that this track left a trace in detector i
     // we should have sizeof(int) < o2::Base::DetId::nDetectors
-    Int_t mHitMask = 0;
+    Int_t mProp = 0;
 
-  ClassDefNV(MCTrack, 1);
+    // internal structure to allow convenient manipulation
+    // of properties as bits on an int
+    union PropEncoding {
+      PropEncoding(int a) : i(a) {}
+      int i;
+      struct {
+        int storage : 1; // encoding whether to store this track to the output
+        int process : 6; // encoding process that created this track (enough to store TMCProcess from ROOT)
+        int hitmask : 25; // encoding hits per detector
+      };
+    };
+
+    ClassDefNV(MCTrackT, 1);
 };
 
-inline Double_t MCTrack::GetEnergy() const
+template <typename T>
+inline Double_t MCTrackT<T>::GetEnergy() const
 {
-  Double_t mass = GetMass();
-  return TMath::Sqrt(mass * mass + mStartVertexMomentumX * mStartVertexMomentumX +
-                     mStartVertexMomentumY * mStartVertexMomentumY + mStartVertexMomentumZ * mStartVertexMomentumZ);
+  const auto mass = GetMass();
+  return std::sqrt(mass * mass + mStartVertexMomentumX * mStartVertexMomentumX +
+                   mStartVertexMomentumY * mStartVertexMomentumY + mStartVertexMomentumZ * mStartVertexMomentumZ);
 }
-
-inline void MCTrack::GetMomentum(TVector3 &momentum)
+ 
+template <typename T>
+inline void MCTrackT<T>::GetMomentum(TVector3 &momentum)
 {
   momentum.SetXYZ(mStartVertexMomentumX, mStartVertexMomentumY, mStartVertexMomentumZ);
 }
-
-inline void MCTrack::Get4Momentum(TLorentzVector &momentum)
+ 
+template <typename T>
+inline void MCTrackT<T>::Get4Momentum(TLorentzVector &momentum)
 {
   momentum.SetXYZT(mStartVertexMomentumX, mStartVertexMomentumY, mStartVertexMomentumZ, GetEnergy());
 }
 
-inline void MCTrack::GetStartVertex(TVector3 &vertex)
+ template <typename T>
+inline void MCTrackT<T>::GetStartVertex(TVector3 &vertex)
 {
   vertex.SetXYZ(mStartVertexCoordinatesX, mStartVertexCoordinatesY, mStartVertexCoordinatesZ);
 }
+
+template <typename T>
+inline MCTrackT<T>::MCTrackT()
+  : mPdgCode(0),
+    mMotherTrackId(-1),
+    mStartVertexMomentumX(0.),
+    mStartVertexMomentumY(0.),
+    mStartVertexMomentumZ(0.),
+    mStartVertexCoordinatesX(0.),
+    mStartVertexCoordinatesY(0.),
+    mStartVertexCoordinatesZ(0.),
+    mStartVertexCoordinatesT(0.),
+    mProp(0)
+{
+}
+
+template <typename T>
+inline MCTrackT<T>::MCTrackT(Int_t pdgCode, Int_t motherId, Double_t px, Double_t py, Double_t pz, Double_t x,
+                             Double_t y, Double_t z, Double_t t, Int_t mask)
+  : mPdgCode(pdgCode),
+    mMotherTrackId(motherId),
+    mStartVertexMomentumX(px),
+    mStartVertexMomentumY(py),
+    mStartVertexMomentumZ(pz),
+    mStartVertexCoordinatesX(x),
+    mStartVertexCoordinatesY(y),
+    mStartVertexCoordinatesZ(z),
+    mStartVertexCoordinatesT(t),
+    mProp(mask)
+{
+}
+
+template <typename T>
+inline MCTrackT<T>::MCTrackT(const TParticle& part)
+  : mPdgCode(part.GetPdgCode()),
+    mMotherTrackId(part.GetMother(0)),
+    mStartVertexMomentumX(part.Px()),
+    mStartVertexMomentumY(part.Py()),
+    mStartVertexMomentumZ(part.Pz()),
+    mStartVertexCoordinatesX(part.Vx()),
+    mStartVertexCoordinatesY(part.Vy()),
+    mStartVertexCoordinatesZ(part.Vz()),
+    mStartVertexCoordinatesT(part.T() * 1e09),
+    mProp(0)
+{
+}
+
+template <typename T>
+inline
+void MCTrackT<T>::Print(Int_t trackId) const
+{
+  //LOG(DEBUG) << "Track " << trackId << ", mother : " << mMotherTrackId << ", Type " << mPdgCode << ", momentum ("
+  //           << mStartVertexMomentumX << ", " << mStartVertexMomentumY << ", " << mStartVertexMomentumZ << ") GeV"
+  //           << FairLogger::endl;
+}
+
+template <typename T>
+inline Double_t MCTrackT<T>::GetMass() const
+{
+  if (TDatabasePDG::Instance()) {
+    TParticlePDG* particle = TDatabasePDG::Instance()->GetParticle(mPdgCode);
+    if (particle) {
+      return particle->Mass();
+    } else {
+      return 0.;
+    }
+  }
+  return 0.;
+}
+
+template <typename T>
+inline Double_t MCTrackT<T>::GetRapidity() const
+{
+  const auto e = GetEnergy();
+  Double_t y =
+    0.5 * std::log((e + static_cast<double>(mStartVertexMomentumZ)) / (e - static_cast<double>(mStartVertexMomentumZ)));
+  return y;
+}
+
+using MCTrack = MCTrackT<float>;
 
 }
  

--- a/DataFormats/simulation/include/SimulationDataFormat/Stack.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/Stack.h
@@ -25,11 +25,10 @@
 #include <map>
 #include <stack>
 #include <utility>
+#include <memory>
 
 class TClonesArray;
-
 class TRefArray;
-
 class FairLogger;
 
 namespace o2 {
@@ -79,35 +78,30 @@ class Stack : public FairGenericStack
     /// \param ntr Track number (filled by the stack)
     /// \param weight Particle weight
     /// \param is Generation status code (whatever that means)
-    void PushTrack(Int_t toBeDone, Int_t parentID, Int_t pdgCode, Double_t px, Double_t py, Double_t pz,
-                           Double_t e, Double_t vx, Double_t vy, Double_t vz, Double_t time, Double_t polx,
-                           Double_t poly,
-                           Double_t polz, TMCProcess proc, Int_t &ntr, Double_t weight, Int_t is) override;
+    void PushTrack(Int_t toBeDone, Int_t parentID, Int_t pdgCode, Double_t px, Double_t py, Double_t pz, Double_t e,
+                   Double_t vx, Double_t vy, Double_t vz, Double_t time, Double_t polx, Double_t poly, Double_t polz,
+                   TMCProcess proc, Int_t& ntr, Double_t weight, Int_t is) override;
 
-    void PushTrack(Int_t toBeDone, Int_t parentID, Int_t pdgCode, Double_t px, Double_t py, Double_t pz,
-                           Double_t e, Double_t vx, Double_t vy, Double_t vz, Double_t time, Double_t polx,
-                           Double_t poly,
-                           Double_t polz, TMCProcess proc, Int_t &ntr, Double_t weight, Int_t is, Int_t secondParentId) override;
+    void PushTrack(Int_t toBeDone, Int_t parentID, Int_t pdgCode, Double_t px, Double_t py, Double_t pz, Double_t e,
+                   Double_t vx, Double_t vy, Double_t vz, Double_t time, Double_t polx, Double_t poly, Double_t polz,
+                   TMCProcess proc, Int_t& ntr, Double_t weight, Int_t is, Int_t secondParentId) override;
 
     /// Get next particle for tracking from the stack.
     /// Declared in TVirtualMCStack
     /// Returns a pointer to the TParticle of the track
     /// \param iTrack index of popped track (return)
-    TParticle *PopNextTrack(Int_t &iTrack) override;
+    TParticle* PopNextTrack(Int_t& iTrack) override;
 
     /// Get primary particle by index for tracking from stack
     /// Declared in TVirtualMCStack
     /// Returns a pointer to the TParticle of the track
     /// \param iPrim index of primary particle
-    TParticle *PopPrimaryForTracking(Int_t iPrim) override;
+    TParticle* PopPrimaryForTracking(Int_t iPrim) override;
 
     /// Set the current track number
     /// Declared in TVirtualMCStack
     /// \param iTrack track number
-    void SetCurrentTrack(Int_t iTrack) override
-    {
-      mIndexOfCurrentTrack = iTrack;
-    }
+    void SetCurrentTrack(Int_t iTrack) override;
 
     /// Get total number of tracks
     /// Declared in TVirtualMCStack
@@ -125,7 +119,11 @@ class Stack : public FairGenericStack
 
     /// Get the current track's particle
     /// Declared in TVirtualMCStack
-    TParticle *GetCurrentTrack() const override;
+    TParticle* GetCurrentTrack() const override
+    {
+      // the const cast is necessary ... the interface should have been `const TParticle* GetCurrentParticle() const`
+      return const_cast<TParticle*>(&mCurrentParticle);
+    }
 
     /// Get the number of the current track
     /// Declared in TVirtualMCStack
@@ -140,6 +138,7 @@ class Stack : public FairGenericStack
 
     /// Fill the MCTrack output array, applying filter criteria
     void FillTrackArray() override;
+
 
     /// Update the track index in the MCTracks and data produced by detectors
     void UpdateTrackIndex(TRefArray *detArray = nullptr) override;
@@ -184,59 +183,45 @@ class Stack : public FairGenericStack
     /// \param iDet  Detector unique identifier
     void addHit(int iDet);
 
-    /// Increment number of hits for an arbitrary track in a given detector
-    /// \param iDet    Detector unique identifier
-    /// \param iTrack  Track number
-    void addHit(int iDet, Int_t iTrack);
-
-    /// Accessors
-    TParticle *GetParticle(Int_t trackId) const;
-    
-    TClonesArray *GetListOfParticles() override
-    {
-      return mParticles;
-    }
+    TClonesArray *GetListOfParticles() override;
 
     /// Clone for worker (used in MT mode only)
     FairGenericStack *CloneStack() const override;
 
-    // encode whether to store the particle or not as part of the TParticles (user) bits
-    static void setStore(TParticle &p, bool store) {
-      // using the first available user-bit (according to TObject docu)
-      p.SetBit(BIT(14), store);
-    }
-    static bool isStore(const TParticle& p) {
-      return p.TestBit(BIT(14));
-    }
-    // store integer encoding hits/detector information inside the TParticle
-    static void setHitEncoding(TParticle &p, Int_t i) {
-      p.SetUniqueID(i);
-    }
-    static Int_t getHitEncoding(const TParticle &p) {
-      return p.GetUniqueID();
-    }
-    
+    // receive notification that primary is finished
+    void notifyFinishPrimary();
+
   private:
     FairLogger *mLogger;
 
     /// STL stack (FILO) used to handle the TParticles for tracking
-    std::stack<TParticle *> mStack; //!
+    /// stack entries refer to
+    std::stack<TParticle> mStack; //!
 
     /// Array of TParticles (contains all TParticles put into or created
-    /// by the transport
-    TClonesArray* mParticles; //!
+    /// by the transport)
+    std::vector<o2::MCTrack> mParticles; //!
+    std::vector<int> mTransportedIDs; //! prim + sec trackIDs transported for "current" primary
+    std::vector<int> mIndexOfPrimaries; //! index of primaries in mParticles
+
+    /// the current TParticle object
+    TParticle mCurrentParticle;
     
+    // keep primary particles in its original form
+    // (mainly for the PopPrimaryParticleInterface
+    std::vector<TParticle> mPrimaryParticles;
+
     /// vector of reducded tracks written to the output
     std::vector<o2::MCTrack>* mTracks;
     
-    /// STL map from particle index to track index
+    /// STL map from particle index to persistent track index
     std::map<Int_t, Int_t> mIndexMap;                //!
 
     /// cache active O2 detectors
     std::vector<o2::Base::Detector *> mActiveDetectors; //!
     
     /// Some indices and counters
-    Int_t mIndexOfCurrentTrack;        //! Index of current track
+    Int_t mIndexOfCurrentTrack;        //! Global index of current track
     Int_t mNumberOfPrimaryParticles;   //! Number of primary particles
     Int_t mNumberOfEntriesInParticles; //! Number of entries in mParticles
     Int_t mNumberOfEntriesInTracks;    //! Number of entries in mTracks
@@ -248,6 +233,14 @@ class Stack : public FairGenericStack
     Int_t mMinHits;
     Double32_t mEnergyCut;
 
+    // variables for the cleanup / filtering procedure
+    Int_t mCleanupCounter = 0; //!
+    Int_t mCleanupThreshold = 1; //! a cleanup is initiated every mCleanupThreshold primaries
+    Int_t mPrimariesDone = 0; //!    
+    Int_t mTracksDone = 0; //! number of tracks already done 
+
+    bool mIsG4Like = false; //! flag indicating if the stack is used in a manner done by Geant4
+
     /// Mark tracks for output using selection criteria
     /// returns true if all available tracks are selected
     /// returns false if some tracks are discarded
@@ -257,15 +250,19 @@ class Stack : public FairGenericStack
 
     Stack &operator=(const Stack &);
 
+    /// function called after each primary
+    /// and all its secondaries where transported
+    /// this allows applying selection criteria at a much finer granularity
+    /// than donw with FillTrackArray which is only called once per event
+    void finishPrimary();
+
+    /// Increment number of hits for an arbitrary track in a given detector
+    /// \param iDet    Detector unique identifier
+    /// \param iTrack  Track number
+    void addHit(int iDet, Int_t iTrack);
+
   ClassDefOverride(Stack, 1)
 };
-
-
-inline
-TParticle *Stack::GetParticle(Int_t trackID) const
-{
-  return (TParticle *) mParticles->At(trackID);
-}
 
 }
 }

--- a/DataFormats/simulation/src/MCTrack.cxx
+++ b/DataFormats/simulation/src/MCTrack.cxx
@@ -15,88 +15,8 @@
 #include "SimulationDataFormat/MCTrack.h"
 
 #include "FairLogger.h"
-#include "TDatabasePDG.h"
-#include "TParticle.h"
-#include "TParticlePDG.h"
-
-ClassImp(o2::MCTrack);
 
 namespace o2 {
 
-MCTrack::MCTrack()
-  : mPdgCode(0),
-    mMotherTrackId(-1),
-    mStartVertexMomentumX(0.),
-    mStartVertexMomentumY(0.),
-    mStartVertexMomentumZ(0.),
-    mStartVertexCoordinatesX(0.),
-    mStartVertexCoordinatesY(0.),
-    mStartVertexCoordinatesZ(0.),
-    mStartVertexCoordinatesT(0.),
-    mHitMask(0)
-{
-}
-
-MCTrack::MCTrack(Int_t pdgCode, Int_t motherId, Double_t px, Double_t py, Double_t pz, Double_t x, Double_t y,
-                 Double_t z, Double_t t, Int_t nPoints = 0)
-  : mPdgCode(pdgCode),
-    mMotherTrackId(motherId),
-    mStartVertexMomentumX(px),
-    mStartVertexMomentumY(py),
-    mStartVertexMomentumZ(pz),
-    mStartVertexCoordinatesX(x),
-    mStartVertexCoordinatesY(y),
-    mStartVertexCoordinatesZ(z),
-    mStartVertexCoordinatesT(t),
-    mHitMask(nPoints)
-{
-}
-
-MCTrack::MCTrack(const MCTrack &track)
-  = default;
-
-MCTrack::MCTrack(TParticle *part)
-  : mPdgCode(part->GetPdgCode()),
-    mMotherTrackId(part->GetMother(0)),
-    mStartVertexMomentumX(part->Px()),
-    mStartVertexMomentumY(part->Py()),
-    mStartVertexMomentumZ(part->Pz()),
-    mStartVertexCoordinatesX(part->Vx()),
-    mStartVertexCoordinatesY(part->Vy()),
-    mStartVertexCoordinatesZ(part->Vz()),
-    mStartVertexCoordinatesT(part->T() * 1e09),
-    mHitMask(0)
-{
-}
-
-MCTrack::~MCTrack()
-= default;
-
-void MCTrack::Print(Int_t trackId) const
-{
-  LOG(DEBUG) << "Track " << trackId << ", mother : " << mMotherTrackId << ", Type " << mPdgCode << ", momentum ("
-             << mStartVertexMomentumX << ", " << mStartVertexMomentumY << ", " << mStartVertexMomentumZ << ") GeV"
-             << FairLogger::endl;
-}
-
-Double_t MCTrack::GetMass() const
-{
-  if (TDatabasePDG::Instance()) {
-    TParticlePDG *particle = TDatabasePDG::Instance()->GetParticle(mPdgCode);
-    if (particle) {
-      return particle->Mass();
-    } else {
-      return 0.;
-    }
-  }
-  return 0.;
-}
-
-Double_t MCTrack::GetRapidity() const
-{
-  Double_t e = GetEnergy();
-  Double_t y = 0.5 * TMath::Log((e + mStartVertexMomentumZ) / (e - mStartVertexMomentumZ));
-  return y;
-}
 
 }

--- a/DataFormats/simulation/src/SimulationDataLinkDef.h
+++ b/DataFormats/simulation/src/SimulationDataLinkDef.h
@@ -23,8 +23,12 @@
 #pragma link off all functions;
 
 #pragma link C++ class o2::Data::Stack+;
+#pragma link C++ class o2::MCTrackT<double>+;
+#pragma link C++ class o2::MCTrackT<float>+;
 #pragma link C++ class o2::MCTrack+;
 #pragma link C++ class std::vector<o2::MCTrack>+;
+#pragma link C++ class std::vector<o2::MCTrackT<double>>+;
+#pragma link C++ class std::vector<o2::MCTrackT<float>>+;
 #pragma link C++ class o2::MCCompLabel+;
 
 #pragma link C++ class o2::BaseHit+;

--- a/DataFormats/simulation/src/Stack.cxx
+++ b/DataFormats/simulation/src/Stack.cxx
@@ -23,11 +23,10 @@
 #include "FairGenericRootManager.h"  // for FairGenericRootManager
 #include "FairRootManager.h"
 
-#include "TClonesArray.h"     // for TClonesArray
-#include "TIterator.h"        // for TIterator
 #include "TLorentzVector.h"   // for TLorentzVector
 #include "TParticle.h"        // for TParticle
 #include "TRefArray.h"        // for TRefArray
+#include "TVirtualMC.h"       // for VMC
 
 #include <cstddef>           // for NULL
 
@@ -39,8 +38,9 @@ using namespace o2::Data;
 Stack::Stack(Int_t size)
   : FairGenericStack(),
     mStack(),
-    mParticles(new TClonesArray("TParticle", size)),
-    mTracks(new std::vector<o2::MCTrack>),
+    //mParticles(new TClonesArray("TParticle", size)),
+    mParticles(),
+	mTracks(new std::vector<o2::MCTrack>),
     mIndexMap(),
     mIndexOfCurrentTrack(-1),
     mNumberOfPrimaryParticles(0),
@@ -53,13 +53,19 @@ Stack::Stack(Int_t size)
     mEnergyCut(0.),
     mLogger(FairLogger::GetLogger())
 {
-  // LOG(INFO) << "Stack::Stack(Int_t) " << this << " mTracks " << mTracks << std::endl;
+  auto vmc = TVirtualMC::GetMC();
+  if (!vmc) {
+    LOG(FATAL) << "Must have VMC initialized before Stack construction" << FairLogger::endl;
+  }
+  if (strcmp(vmc->GetName(), "TGeant4") == 0 ) {
+    mIsG4Like = true;
+  }
 }
 
 Stack::Stack(const Stack &rhs)
   : FairGenericStack(rhs),
     mStack(),
-    mParticles(nullptr),
+    mParticles(),
     mTracks(nullptr),
     mIndexMap(),
     mIndexOfCurrentTrack(-1),
@@ -71,20 +77,15 @@ Stack::Stack(const Stack &rhs)
     mStoreSecondaries(rhs.mStoreSecondaries),
     mMinHits(rhs.mMinHits),
     mEnergyCut(rhs.mEnergyCut),
-    mLogger(FairLogger::GetLogger())
+    mLogger(FairLogger::GetLogger()),
+    mIsG4Like(rhs.mIsG4Like)
 {
-  mParticles = new TClonesArray("TParticle", rhs.mParticles->GetSize());
+  LOG(FATAL) << "copy constructor called" << FairLogger::endl;
   mTracks = new std::vector<MCTrack>(rhs.mTracks->size());
-
-  // LOG(INFO) << "Stack::Stack(rhs) " << this << " mTracks " << mTracks << std::endl;
 }
 
 Stack::~Stack()
 {
-  if (mParticles) {
-    mParticles->Delete();
-    delete mParticles;
-  }
   if (mTracks) {
     delete mTracks;
   }
@@ -92,6 +93,7 @@ Stack::~Stack()
 
 Stack &Stack::operator=(const Stack &rhs)
 {
+  LOG(FATAL) << "operator= called" << FairLogger::endl;
   // check assignment to self
   if (this == &rhs) { return *this; }
 
@@ -99,7 +101,7 @@ Stack &Stack::operator=(const Stack &rhs)
   FairGenericStack::operator=(rhs);
 
   // assignment operator
-  mParticles = new TClonesArray("TParticle", rhs.mParticles->GetSize());
+ // mParticles = new std::vector<TParticle*>;//new TClonesArray("TParticle", rhs.mParticles->GetSize());
   mTracks = new std::vector<MCTrack>(rhs.mTracks->size());
   mIndexOfCurrentTrack = -1;
   mNumberOfPrimaryParticles = 0;
@@ -111,6 +113,7 @@ Stack &Stack::operator=(const Stack &rhs)
   mMinHits = rhs.mMinHits;
   mEnergyCut = rhs.mEnergyCut;
   mLogger = nullptr;
+  mIsG4Like = rhs.mIsG4Like;
 
   return *this;
 }
@@ -127,28 +130,33 @@ void Stack::PushTrack(Int_t toBeDone, Int_t parentId, Int_t pdgCode, Double_t px
                       Double_t vx, Double_t vy, Double_t vz, Double_t time, Double_t polx, Double_t poly, Double_t polz,
                       TMCProcess proc, Int_t &ntr, Double_t weight, Int_t is, Int_t secondparentID)
 {
-
-  // Get TParticle array
-  TClonesArray &partArray = *mParticles;
-
   // Create new TParticle and add it to the TParticle array
   Int_t trackId = mNumberOfEntriesInParticles;
   Int_t nPoints = 0;
   Int_t daughter1Id = -1;
   Int_t daughter2Id = -1;
-  auto *particle = new(partArray[mNumberOfEntriesInParticles++])
-    TParticle(pdgCode, trackId, parentId, nPoints, daughter1Id, daughter2Id, px, py, pz, e, vx, vy, vz, time);
-  particle->SetPolarisation(polx, poly, polz);
-  particle->SetWeight(weight);
 
-  // BEWARE: we are currently using the UniqueID inherited from TObject to
-  // store information concerning hits per detector originating from this particle.
-  // We could pack additional information into this integer.
-  particle->SetUniqueID(0);
+  // LOG(INFO) << "Pushing " << trackId << " with parent " << parentId << FairLogger::endl;
+  
+  TParticle p(pdgCode, trackId, parentId, nPoints, daughter1Id, daughter2Id, px, py, pz, e, vx, vy, vz, time);
+  p.SetPolarisation(polx, poly, polz);
+  p.SetWeight(weight);
+  p.SetUniqueID(proc); // using the unique ID to transfer process ID
+  mNumberOfEntriesInParticles++;
 
+  // currently I only know of G4 who pushes particles like this (but never pops)
+  // so we have to register the particles here
+  if (mIsG4Like && parentId >= 0) {
+    //p.SetStatusCode(mParticles.size());
+    mParticles.emplace_back(p);
+    mTransportedIDs.emplace_back(p.GetStatusCode());
+    mCurrentParticle = p;
+  }
+  
   // Increment counter
   if (parentId < 0) {
     mNumberOfPrimaryParticles++;
+    mPrimaryParticles.push_back(p);
   }
 
   // Set argument variable
@@ -156,39 +164,82 @@ void Stack::PushTrack(Int_t toBeDone, Int_t parentId, Int_t pdgCode, Double_t px
 
   // Push particle on the stack if toBeDone is set
   if (toBeDone == 1) {
-    mStack.push(particle);
+    mStack.push(p);
   }
 }
 
-TParticle *Stack::PopNextTrack(Int_t &iTrack)
+/// Set the current track number
+/// Declared in TVirtualMCStack
+/// \param iTrack track number
+void Stack::SetCurrentTrack(Int_t iTrack)
 {
+   mIndexOfCurrentTrack = iTrack;
+  
+   if(mIsG4Like) {
+     if(iTrack < mPrimaryParticles.size()) {   
+       // This interface is called by Geant4 when activating a certain primary
+       auto& p = mPrimaryParticles[iTrack];
+       mIndexOfPrimaries.emplace_back(mParticles.size());
+       mParticles.emplace_back(p);
+       mTransportedIDs.emplace_back(p.GetStatusCode());
+       mCurrentParticle=p;
+     }
+   }
+}
 
+
+void Stack::notifyFinishPrimary() {
+  // someone notifies us that a primary is finished
+  // this means we can do some filtering and cleanup
+  mPrimariesDone++;
+  LOG(DEBUG) << "Finish primary hook " << mPrimariesDone << FairLogger::endl;
+  mCleanupCounter++;
+  if (mCleanupCounter == mCleanupThreshold 
+      || mCleanupCounter == mPrimaryParticles.size()
+      || mPrimariesDone == mPrimaryParticles.size() ) {
+    finishPrimary();
+    mCleanupCounter = 0;
+  }
+}
+
+TParticle* Stack::PopNextTrack(Int_t& iTrack)
+{
+  // This functions is mainly used by Geant3?
+  
   // If end of stack: Return empty pointer
   if (mStack.empty()) {
+    notifyFinishPrimary();
     iTrack = -1;
     return nullptr;
   }
 
   // If not, get next particle from stack
-  TParticle *thisParticle = mStack.top();
+  mCurrentParticle = mStack.top();
   mStack.pop();
-
-  if (!thisParticle) {
-    iTrack = 0;
-    return nullptr;
+  
+  if (mCurrentParticle.GetMother(0) < 0) {
+    // particle is primary -> indicates that previous particle finished
+    if(mParticles.size() > 0){
+      notifyFinishPrimary();
+    }
+    mIndexOfPrimaries.emplace_back(mParticles.size());
   }
+  mParticles.emplace_back(mCurrentParticle);
+  mTransportedIDs.emplace_back(mCurrentParticle.GetStatusCode());
 
-  mIndexOfCurrentTrack = thisParticle->GetStatusCode();
+  mIndexOfCurrentTrack = mCurrentParticle.GetStatusCode();
   iTrack = mIndexOfCurrentTrack;
-
-  return thisParticle;
+  
+  // LOG(INFO) << "transporting ID " << mIndexOfCurrentTrack << "\n"; 
+  return &mCurrentParticle;
 }
 
-TParticle *Stack::PopPrimaryForTracking(Int_t iPrim)
+TParticle* Stack::PopPrimaryForTracking(Int_t iPrim)
 {
+  // This function is used by Geant4 to setup their own onternal stack
 
-  // Get the iPrimth particle from the mStack TClonesArray. This
-  // should be a primary (if the index is correct).
+  // Remark: Contrary to what the interface name is suggesting
+  // this is not a pop operation (but rather a get)
 
   // Test for index
   if (iPrim < 0 || iPrim >= mNumberOfPrimaryParticles) {
@@ -196,65 +247,41 @@ TParticle *Stack::PopPrimaryForTracking(Int_t iPrim)
       mLogger->Fatal(MESSAGE_ORIGIN, "Stack: Primary index out of range! %i ", iPrim);
     }
     Fatal("Stack::PopPrimaryForTracking", "Index out of range");
+    return nullptr;
   }
-
   // Return the iPrim-th TParticle from the fParticle array. This should be
   // a primary.
-  TParticle *part = (TParticle *) mParticles->At(iPrim);
-  if (!(part->GetMother(0) < 0)) {
-    if (mLogger) {
-      mLogger->Fatal(MESSAGE_ORIGIN, "Stack:: Not a primary track! %i ", iPrim);
-    }
-    Fatal("Stack::PopPrimaryForTracking", "Not a primary track");
-  }
-
-  return part;
-}
-
-TParticle *Stack::GetCurrentTrack() const
-{
-  TParticle *currentPart = GetParticle(mIndexOfCurrentTrack);
-  if (!currentPart) {
-    if (mLogger) {
-      mLogger->Warning(MESSAGE_ORIGIN, "Stack: Current track not found in stack!");
-    }
-    Warning("Stack::GetCurrentTrack", "Track not found in stack");
-  }
-  return currentPart;
+  return &mPrimaryParticles[iPrim];
 }
 
 void Stack::FillTrackArray()
 {
-  if (mLogger) {
-    mLogger->Debug(MESSAGE_ORIGIN, "Stack: Filling MCTrack array...");
-  } else {
-    cout << "Stack: Filling MCTrack array..." << endl;
-  }
-
-  // Reset index map and number of output tracks
-  mIndexMap.clear();
-  mNumberOfEntriesInTracks = 0;
-
-  // Check tracks for selection criteria
-  // if allselected is true we can avoid some computation below
-  auto allselected = selectTracks();
-  LOG(INFO) << " All tracks selected ? : " << allselected << "\n";
-
-  // Loop over mParticles array and copy selected tracks
-  for (Int_t iPart = 0; iPart < mNumberOfEntriesInParticles; iPart++) {
-    const auto particle = GetParticle(iPart);
-    if (Stack::isStore(*particle)) {
-      mTracks->emplace_back(particle);
-      auto& track = mTracks->back();			    
-      if (!allselected) {
-        mIndexMap[iPart] = mNumberOfEntriesInTracks;
-      }
-      // store hit information inside persistent track
-      track.setHitMask(Stack::getHitEncoding(*particle));
-      mNumberOfEntriesInTracks++;
-    }
-  }
+  /// This interface is not implemented since we are filtering/filling the output array
+  /// after each primary ... just give a summary message
   LOG(INFO) << "Stack: " << mTracks->size() << " out of " << mNumberOfEntriesInParticles << " stored \n";
+}
+
+void Stack::finishPrimary() {
+  // Here transport of a primary and all its secondaries is finished
+  // we can do some cleanup of the memory structures
+  LOG(DEBUG) << "STACK: Cleaning up" << FairLogger::endl;
+  auto selected = selectTracks();
+  // loop over current particle buffer
+  int index=0;
+  for(const auto& particle : mParticles) {
+    if (particle.getStore()) {
+      // map the global track index to the new persistent index
+      // FIXME: only fill the map for non-trivial mappings in which mTransportedIDs[index]!=mTracks->size();
+      mIndexMap[mTransportedIDs[index]] = mTracks->size();
+      mTracks->emplace_back(particle);
+    }
+    index++;
+    mTracksDone++;
+  }
+  // we can now clear the particles buffer!
+  mParticles.clear();
+  mTransportedIDs.clear();
+  mIndexOfPrimaries.clear();
 }
 
 void Stack::UpdateTrackIndex(TRefArray *detList)
@@ -279,7 +306,7 @@ void Stack::UpdateTrackIndex(TRefArray *detList)
       if (o2det) {
         mActiveDetectors.emplace_back(o2det);
       } else {
-        LOG(FATAL) << "Found nonconforming detector" << FairLogger::endl;
+        LOG(INFO) << "Found nonconforming detector" << FairLogger::endl;
       }
     }
   }
@@ -329,8 +356,14 @@ void Stack::Reset()
   while (!mStack.empty()) {
     mStack.pop();
   }
-  mParticles->Clear("C");
+  mParticles.clear();
   mTracks->clear();
+  if (mPrimariesDone != mPrimaryParticles.size()) {
+    LOG(FATAL) << "Inconsistency in primary particles treated vs expected (This points " 
+               << "to a flaw in the stack logic)" << FairLogger::endl; 
+  }
+  mPrimariesDone = 0;
+  mPrimaryParticles.clear();
 }
 
 void Stack::Register()
@@ -363,18 +396,13 @@ void Stack::Print(Option_t* option) const
 
 void Stack::addHit(int iDet)
 {
-  addHit(iDet, mIndexOfCurrentTrack);
+  addHit(iDet, mParticles.size()-1);
 }
 
 void Stack::addHit(int iDet, Int_t iTrack)
 {
-  if (iTrack < 0) {
-    return;
-  }
-  auto part=GetParticle(iTrack);
-  auto encoding = Stack::getHitEncoding(*part);
-  MCTrack::setHit(iDet, encoding);
-  Stack::setHitEncoding(*part, encoding);
+  auto& part=mParticles[iTrack];
+  part.setHit(iDet);
 }
 
 Int_t Stack::GetCurrentParentTrackNumber() const
@@ -390,67 +418,86 @@ Int_t Stack::GetCurrentParentTrackNumber() const
 bool Stack::selectTracks()
 {
   bool tracksdiscarded = false;
-  
-  // Clear storage map
-  TLorentzVector p;
-  
   // Check particles in the fParticle array
-  for (Int_t i = 0; i < mNumberOfEntriesInParticles; i++) {
-
-    TParticle *thisPart = GetParticle(i);
+  int prim = -1; // counter how many primaries seen (mainly to constrain search in motherindex remapping)
+  for(auto& thisPart : mParticles) {
     Bool_t store = kTRUE;
 
     // Get track parameters
-    Int_t iMother = thisPart->GetMother(0);
-
-    thisPart->Momentum(p);
-    Double_t energy = p.E();
-    Double_t mass = p.M();
-    Double_t eKin = energy - mass;
-
-    // Calculate number of hits created by this track
-    // Note: we only distinguish between no hit and more than 0 hits
-    int nHits = Stack::getHitEncoding(*thisPart);
-    nHits = (nHits!=0) ? 1 : 0;
-    
-    // Check for cuts (store primaries in any case)
+    Int_t iMother = thisPart.getMotherTrackId();
     if (iMother < 0) {
+      prim++;
+      // for primaries we are done quickly
       store = kTRUE;
-    } else {
+    }
+    else {
+      // for other particles we (potentially need to correct the mother indices
+      auto rangestart = mTransportedIDs.begin() + mIndexOfPrimaries[prim];
+      auto rangeend = (prim < (mIndexOfPrimaries.size()-1)) ? mTransportedIDs.begin() + mIndexOfPrimaries[prim+1] : mTransportedIDs.end();
+      // auto rangeend = mTransportedIDs.end();
+
+      auto iter = std::find_if(rangestart, rangeend, [iMother](int x){return x == iMother;});
+      if (iter!=rangeend) {
+        // complexity should be constant
+        auto newmother = std::distance(mTransportedIDs.begin(), iter);
+        // LOG(INFO) << "Fixing mother from " << iMother << " to " << newmother << FairLogger::endl;
+        thisPart.SetMotherTrackId(newmother);
+      }
+
+      // no secondaries; also done
       if (!mStoreSecondaries) {
         store = kFALSE;
         tracksdiscarded = true;
       }
-      if (nHits < mMinHits) {
-        store = kFALSE;
-        tracksdiscarded = true;
-      }
-      if (eKin < mEnergyCut) {
-        store = kFALSE;
-        tracksdiscarded = true;
+      else {
+        // Calculate number of hits created by this track
+        // Note: we only distinguish between no hit and more than 0 hits
+        int nHits = thisPart.hasHits();
+     
+        // Check for cuts (store primaries in any case)
+        if (nHits < mMinHits) {
+          store = kFALSE;
+          tracksdiscarded = true;
+        }
+        // only if we have non-trival energy cut
+        if (mEnergyCut > 0.) {
+          Double_t energy = thisPart.GetEnergy();
+          Double_t mass = thisPart.GetMass();
+          Double_t eKin = energy - mass;
+
+          if (eKin < mEnergyCut) {
+            store = kFALSE;
+            tracksdiscarded = true;
+          } 
+        }
       }
     }
-
-    // Set storage flag
-    Stack::setStore(*thisPart, store);
+   // LOG(INFO) << "storing " << store << FairLogger::endl;
+    thisPart.setStore(store);
   }
 
   // If flag is set, flag recursively mothers of selected tracks
   if (mStoreMothers) {
-    for (Int_t i = 0; i < mNumberOfEntriesInParticles; i++) {
-      auto particle = GetParticle(i);
-      if (Stack::isStore(*particle)) {
-        Int_t iMother = particle->GetMother(0);
+    for (auto& particle : mParticles) {
+      if (particle.getStore()) {
+        Int_t iMother = particle.getMotherTrackId();
         while (iMother >= 0) {
-          auto mother = GetParticle(iMother);
-     	  Stack::setStore(*mother, true);
-	      iMother = mother->GetMother(0);
+          auto& mother = mParticles[iMother];
+          mother.setStore(true);
+          iMother = mother.getMotherTrackId();
         }
       }
     }
   }
 
   return !tracksdiscarded;
+}
+
+
+TClonesArray* Stack::GetListOfParticles()
+{
+  LOG(FATAL) << "Stack::GetListOfParticles interface not implemented\n" << FairLogger::endl;
+  return nullptr;
 }
 
 FairGenericStack *Stack::CloneStack() const

--- a/DataFormats/simulation/test/MCTrack.cxx
+++ b/DataFormats/simulation/test/MCTrack.cxx
@@ -1,0 +1,66 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test MCTrack class
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include <iomanip>
+#include <ios>
+#include <iostream>
+#include "SimulationDataFormat/MCTrack.h"
+#include "DetectorsBase/DetID.h"
+#include "TParticle.h"
+#include "TFile.h"
+
+using namespace o2;
+
+BOOST_AUTO_TEST_CASE(MCTrack_test)
+{
+  MCTrack track;
+  // check properties on default constructed object
+  BOOST_CHECK(track.getStore() == false);
+  for (auto i = o2::Base::DetID::First; i < o2::Base::DetID::nDetectors; ++i) {
+    BOOST_CHECK(track.leftTrace(i) == false);
+  }
+  BOOST_CHECK(track.getNumDet() == 0);
+  BOOST_CHECK(track.hasHits() == false);
+
+  // check storing
+  track.setStore(true);
+  BOOST_CHECK(track.getStore() == true);
+  track.setStore(false);
+  BOOST_CHECK(track.getStore() == false);
+  track.setStore(true);
+  BOOST_CHECK(track.getStore() == true);
+
+  
+  // set hit for first detector
+  BOOST_CHECK(track.leftTrace(1) == false);
+  track.setHit(1);
+  BOOST_CHECK(track.hasHits() == true);
+  BOOST_CHECK(track.leftTrace(1) == true);
+  BOOST_CHECK(track.getNumDet() == 1);
+
+  {
+  // serialize it
+  TFile f("MCTrackOut.root", "RECREATE");
+  f.WriteObject(&track, "MCTrack");
+  f.Close();
+  }
+
+  {
+    MCTrack* intrack=nullptr;
+    TFile f("MCTrackOut.root", "OPEN");
+    f.GetObject("MCTrack", intrack);
+    BOOST_CHECK(intrack->getStore() == true);
+    BOOST_CHECK(intrack->hasHits() == true);
+  }
+}

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
@@ -208,11 +208,6 @@ class Detector : public o2::Base::DetImpl<Detector>
       ;
     }
 
-    /// Returns the pointer to the TParticle for the particle that created
-    /// this hit. From the TParticle all kinds of information about this
-    /// particle can be found. See the TParticle class.
-    virtual TParticle *GetParticle() const;
-
     /// Prints out the content of this class in ASCII format
     /// \param ostream *os The output stream
     void Print(std::ostream *os) const;

--- a/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
@@ -1131,21 +1131,6 @@ Hit *Detector::addHit(int trackID, int detID, const TVector3& startPos, const TV
   return &(mHits->back());
 }
 
-TParticle *Detector::GetParticle() const
-{
-  // Returns the pointer to the TParticle for the particle that created
-  // this hit. From the TParticle all kinds of information about this
-  // particle can be found. See the TParticle class.
-  // Inputs:
-  //   none.
-  // Outputs:
-  //   none.
-  // Return:
-  //   The TParticle of the track that created this hit.
-  int trc = TVirtualMC::GetMC()->GetStack()->GetCurrentTrackNumber();
-  return ((o2::Data::Stack *) TVirtualMC::GetMC()->GetStack())->GetParticle(trc);
-}
-
 void Detector::Print(std::ostream *os) const
 {
 // Standard output format for this class.

--- a/Detectors/Passive/src/Cave.cxx
+++ b/Detectors/Passive/src/Cave.cxx
@@ -26,6 +26,7 @@
 #include "FairGeoLoader.h"     // for FairGeoLoader
 #include "include/DetectorsPassive/GeoCave.h"
 #include "TString.h"           // for TString
+#include "FairLogger.h"
 #include <cstddef>            // for NULL
 
 using namespace o2::Passive;
@@ -46,14 +47,14 @@ void Cave::ConstructGeometry()
 
 }
 Cave::Cave()
-:FairModule()
+:FairDetector()
 {
 }
 
 Cave::~Cave()
 = default;
 Cave::Cave(const char* name,  const char* Title)
-  : FairModule(name ,Title)
+  : FairDetector(name ,Title)
 {
   mWorld[0] = 0;
   mWorld[1] = 0;
@@ -61,7 +62,7 @@ Cave::Cave(const char* name,  const char* Title)
 }
 
 Cave::Cave(const Cave& rhs)
-  : FairModule(rhs)
+  : FairDetector(rhs)
 {
   mWorld[0] = rhs.mWorld[0];
   mWorld[1] = rhs.mWorld[1];
@@ -87,4 +88,16 @@ Cave& Cave::operator=(const Cave& rhs)
 FairModule* Cave::CloneModule() const
 {
   return new Cave(*this);
+}
+
+void Cave::FinishPrimary() {
+  LOG(DEBUG) << "CAVE: Primary finished" << FairLogger::endl;
+  for(auto& f : mFinishPrimaryHooks){
+    f();
+  }
+}
+
+bool Cave::ProcessHits(FairVolume*) {
+  LOG(FATAL) << "CAVE ProcessHits called; should never happen" << FairLogger::endl;
+  return false;
 }

--- a/Detectors/gconfig/commonConfig.C
+++ b/Detectors/gconfig/commonConfig.C
@@ -1,0 +1,32 @@
+
+// common piece of code to setup stack and register
+// with VMC instances
+template <typename T, typename R>
+void stackSetup(T* vmc, R* run) {
+  // create the O2 vmc stack instance
+  auto st = new o2::Data::Stack();
+  st->setMinHits(1);
+  st->StoreSecondaries(kTRUE);
+  vmc->SetStack(st);
+
+  // register the stack as an observer on FinishPrimary events (managed by Cave)
+  bool foundCave = false;
+  auto modules = run->GetListOfModules();
+  
+  if( strcmp(vmc->GetName(), "TGeant4")==0 ) {
+    // there is no way to get the module by name, so we have
+    // to iterate through the complete list
+    for (auto m : *modules) {
+      if(strcmp("CAVE", ((FairModule*)m)->GetName()) == 0) {
+        // this thing is the cave
+        if(auto c=dynamic_cast<o2::Passive::Cave*>(m)) {
+          foundCave = true;
+          c->addFinishPrimaryHook([st](){ st->notifyFinishPrimary();});
+        }
+      }
+    }
+    if (!foundCave) {
+      LOG(FATAL) << "Cave volume not found; Could not attach observers" << FairLogger::endl;
+    }
+  }
+}

--- a/Detectors/gconfig/g3Config.C
+++ b/Detectors/gconfig/g3Config.C
@@ -10,10 +10,12 @@
 //
 // Configuration macro for Geant3 VirtualMC
 
+#include "commonConfig.C"
+
 void Config()
 {
-  FairRunSim* fRun = FairRunSim::Instance();
-  TString* gModel = fRun->GetGeoModel();
+  FairRunSim* run = FairRunSim::Instance();
+  TString* gModel = run->GetGeoModel();
   TGeant3* geant3 = nullptr;
   if (strncmp(gModel->Data(), "TGeo", 4) == 0) {
     geant3 = new TGeant3TGeo("C++ Interface to Geant3");
@@ -22,11 +24,7 @@ void Config()
     geant3 = new TGeant3("C++ Interface to Geant3");
     cout << "-I- G3Config: Geant3 native has been created." << endl;
   }
-  // create Fair Specific Stack
-  o2::Data::Stack* st = new o2::Data::Stack();
-  st->setMinHits(1);
-  st->StoreSecondaries(kTRUE);
-  geant3->SetStack(st);
+  stackSetup(geant3, run);
 
   // ******* GEANT3  specific configuration for simulated Runs  *******
   geant3->SetTRIG(1); // Number of events to be processed

--- a/Detectors/gconfig/g4Config.C
+++ b/Detectors/gconfig/g4Config.C
@@ -6,6 +6,8 @@
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
 
+#include "commonConfig.C"
+
 // Configuration macro for Geant4 VirtualMC
 void Config()
 {
@@ -49,15 +51,13 @@ void Config()
    TGeant4* geant4 = new TGeant4("TGeant4", "The Geant4 Monte Carlo", runConfiguration);
    cout << "Geant4 has been created." << endl;
 
-/// create the Specific stack
-   o2::Data::Stack *stack = new o2::Data::Stack(1000);
-   stack->StoreSecondaries(kTRUE);
-   stack->setMinHits(0);
-   geant4->SetStack(stack);
+   // setup the stack
+   stackSetup(geant4, FairRunSim::Instance());
 
+   // setup decayer
    if(FairRunSim::Instance()->IsExtDecayer()){
-      TVirtualMCDecayer* decayer = TPythia6Decayer::Instance();
-      geant4->SetExternalDecayer(decayer);
+     TVirtualMCDecayer* decayer = TPythia6Decayer::Instance();
+     geant4->SetExternalDecayer(decayer);
    }
 
 /// Customise Geant4 setting

--- a/macro/o2sim.C
+++ b/macro/o2sim.C
@@ -53,6 +53,9 @@ void o2sim()
     primGen->AddGenerator(extGen);
     std::cout << "using external kinematics\n";
   }
+  else {
+    LOG(FATAL) << "Invalid generator" << FairLogger::endl;
+  }
   run->SetGenerator(primGen);
 
   // Timer


### PR DESCRIPTION
The stack is a major consumer of memory for big events;

This commit essentially "completely" reduces the memory used by the stack, by

a) making MCTrack objects configurable on floating point type
b) storing lean MCTrack objects instead of TParticles as transient tracks
c) cleaning up + filtering of tracks after each (N-th) primary instead of after each event (as originally foreseen by FairRoot)
