### PR TITLE
Make TrackParCov base class of other tracks + extra methods for matching

### DIFF
--- a/Detectors/Base/include/DetectorsBase/Track.h
+++ b/Detectors/Base/include/DetectorsBase/Track.h
@@ -93,7 +93,7 @@ class TrackPar
   // derived getters
   float getCurvature(float b) const { return mP[kQ2Pt] * b * Constants::kB2C; }
   float getSign() const { return mP[kQ2Pt] > 0 ? 1.f : -1.f; }
-  float getPhi() const { return asinf(getSnp()) + getAlpha(); }
+  float getPhi() const;
   float getPhiPos() const;
 
   float getP() const;
@@ -226,6 +226,14 @@ inline void TrackPar::getXYZGlo(std::array<float, 3>& xyz) const
 }
 
 //_______________________________________________________
+inline float TrackPar::getPhi() const
+{
+  float phi = asinf(getSnp()) + getAlpha();
+  Utils::BringToPMPi(phi);
+  return phi;
+}
+ 
+//_______________________________________________________
 inline Point3D<float> TrackPar::getXYZGlo() const
 {
   return Rotation2D(getAlpha())(Point3D<float>(getX(), getY(), getZ()));
@@ -246,8 +254,7 @@ inline Point3D<float> TrackPar::getXYZGloAt(float xk, float b, bool& ok) const
 inline float TrackPar::getPhiPos() const
 {
   // angle of track position
-  float xy[2] = { getX(), getY() };
-  return atan2(xy[1], xy[0]);
+  return atan2f(getY(),getX());
 }
 
 //____________________________________________________________

--- a/Detectors/Base/src/BaseLinkDef.h
+++ b/Detectors/Base/src/BaseLinkDef.h
@@ -15,9 +15,8 @@
 #pragma link off all classes;
 #pragma link off all functions;
 #pragma link C++ enum o2::Base::TransformType;
-
+ 
 #pragma link C++ class o2::Base::Detector+;
-#pragma link C++ class o2::Base::Track::TrackParBase+;
 #pragma link C++ class o2::Base::Track::TrackPar+;
 #pragma link C++ class o2::Base::Track::TrackParCov+;
 #pragma link C++ class o2::Base::TrackReference+;

--- a/Detectors/ITSMFT/ITS/macros/test/CheckTracks.C
+++ b/Detectors/ITSMFT/ITS/macros/test/CheckTracks.C
@@ -48,7 +48,7 @@ void CheckTracks(Int_t nEvents = 10, TString mcEngine = "TGeant3") {
 
   
   Int_t nev=mcTree->GetEntries();
-  for (Int_t n=0; n<nev; n++) {
+  for (Int_t n=0;n<nev;n++) {
     std::cout<<"Event "<<n<<'/'<<nev<<std::endl;
     Int_t nGen=0, nGoo=0;
     mcTree->GetEvent(n);
@@ -58,40 +58,40 @@ void CheckTracks(Int_t nEvents = 10, TString mcEngine = "TGeant3") {
     while(nmc--) {
       const auto& mcTrack = (*mcArr)[nmc];
       Int_t mID = mcTrack.getMotherTrackId();
-      if (mID >= 0) continue; // Select primary particles 
+      if (mID >= 0) continue;// Select primary particles 
       Int_t pdg = mcTrack.GetPdgCode();
-      if (TMath::Abs(pdg) != 211) continue;  // Select pions
+      if (TMath::Abs(pdg) != 211) continue; // Select pions
 
-      nGen++; // Generated tracks for the efficiency calculation 
+      nGen++;// Generated tracks for the efficiency calculation 
       
-      Double_t mcPx = mcTrack.GetStartVertexMomentumX();
-      Double_t mcPy = mcTrack.GetStartVertexMomentumY();
-      Double_t mcPz = mcTrack.GetStartVertexMomentumZ();
-      Double_t mcPt = mcTrack.GetPt();
-      Double_t mcPhi= TMath::ATan2(mcPy,mcPx);
-      Double_t mcLam= TMath::ATan2(mcPz,mcPt);
-      Double_t recPhi=-1.; 
-      Double_t recLam=-1.; 
-      Double_t recPt=-1.; 
-      Double_t ip[2]{0.,0.}; 
-      Double_t label=-123456789.; 
+      Float_t mcPx = mcTrack.GetStartVertexMomentumX();
+      Float_t mcPy = mcTrack.GetStartVertexMomentumY();
+      Float_t mcPz = mcTrack.GetStartVertexMomentumZ();
+      Float_t mcPt = mcTrack.GetPt();
+      Float_t mcPhi= TMath::ATan2(mcPy,mcPx);
+      Float_t mcLam= TMath::ATan2(mcPz,mcPt);
+      Float_t recPhi=-1.;
+      Float_t recLam=-1.;
+      Float_t recPt=-1.;
+      Float_t ip[2]{0.,0.};
+      Float_t label=-123456789.;
       
-      for (Int_t i=0; i<nrec; i++) {
+      for (Int_t i=0;i<nrec;i++) {
 	 const CookedTrack &recTrack = (*recArr)[i];
 	 auto mclab = (trkLabArr->getLabels(i))[0];
 	 Int_t lab = mclab.getTrackID();
 	 if (TMath::Abs(lab) != nmc) continue;
 	 std::array<float,3> p;
-	 recTrack.getPxPyPz(p);
+	 recTrack.getPxPyPzGlo(p);
 	 recPt = recTrack.getPt();
          recPhi = TMath::ATan2(p[1],p[0]);
 	 recLam = TMath::ATan2(p[2],recPt);
-	 Double_t vx=0., vy=0., vz=0.;  // Assumed primary vertex
-	 Double_t bz=5.;                // Assumed magnetic field 
+	 Float_t vx=0., vy=0., vz=0.; // Assumed primary vertex
+	 Float_t bz=5.;               // Assumed magnetic field 
          recTrack.getImpactParams(vx, vy, vz, bz, ip);
          label = lab;
 	 
-	 if (label>0) nGoo++; // Good found tracks for the efficiency calculation
+	 if (label>0) nGoo++;// Good found tracks for the efficiency calculation
       }
 
       nt->Fill(mcPhi,mcLam,mcPt,recPhi,recLam,recPt,ip[0],ip[1],label);
@@ -103,9 +103,9 @@ void CheckTracks(Int_t nEvents = 10, TString mcEngine = "TGeant3") {
   
   // "recPt>0" means "found tracks only"  
   // "label>0" means "found good tracks only"  
-  new TCanvas; nt->Draw("ipD","recPt>0 && label>0");
-  new TCanvas; nt->Draw("mcLam-recLam","recPt>0 && label>0");
-  new TCanvas; nt->Draw("mcPt-recPt","recPt>0 && label>0");
+  new TCanvas;nt->Draw("ipD","recPt>0 && label>0");
+  new TCanvas;nt->Draw("mcLam-recLam","recPt>0 && label>0");
+  new TCanvas;nt->Draw("mcPt-recPt","recPt>0 && label>0");
   f->Write();
   f->Close();
 }

--- a/Detectors/ITSMFT/ITS/macros/test/run_test.sh
+++ b/Detectors/ITSMFT/ITS/macros/test/run_test.sh
@@ -5,13 +5,12 @@ mcEngine=\"TGeant3\"
 alp=kTRUE
 #To activate the continuos readout, assign a positive value to the rate 
 rate=0. # 50.e3 (Hz)
-
 root.exe -b -q $O2_ROOT/share/macro/run_sim_its_ALP3.C+\($nEvents,$mcEngine\) >& sim.log
 root.exe -b -q $O2_ROOT/share/macro/run_digi_its.C+\($nEvents,$mcEngine,$alp,$rate\) >& digi.log
 root.exe -b -q CheckDigits.C+\($nEvents,$mcEngine\) >& CheckDigits.log
 root.exe -b -q $O2_ROOT/share/macro/run_clus_its.C+\($nEvents,$mcEngine\) >& clus.log
 root.exe -b -q CheckClusters.C+\($nEvents,$mcEngine\) >& CheckClusters.log
-root.exe -b -q $O2_ROOT/share/macro/run_trac_its.C+\($nEvents,$mcEngine\) >& trac.log
+root.exe -b -q $O2_ROOT/share/macro/run_trac_its.C+\($nEvents,$mcEngine,$rate\) >& trac.log
 root.exe -b -q CheckTracks.C+\($nEvents,$mcEngine\) >& CheckTracks.log
 root.exe DisplayTrack.C+\($nEvents,$mcEngine\)
 

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CAaux.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CAaux.h
@@ -98,12 +98,12 @@ namespace o2 {
       };
       typedef struct Cluster ClsInfo_t;
 
-      class Track {
+      class Track : public o2::Base::Track::TrackParCov {
         public:
+          using o2::Base::Track::TrackParCov::TrackParCov;
           Track(float x, float a, std::array<float,Base::Track::kNParams> p, std::array<float,Base::Track::kCovMatSize> c, int *cl);
 
           int* Clusters() { return mCl; }
-          Base::Track::TrackParCov& Param() { return mT; }
 
           int GetLabel() const { return mLabel; }
           float GetChi2() const { return mChi2; }
@@ -114,10 +114,9 @@ namespace o2 {
           bool Update(const Cluster& cl);
           bool GetPhiZat(float r, float bfield,float &phi, float &z) const;
         private:
-          Base::Track::TrackParCov mT;
-          int mCl[7];
-          int mLabel;
-          float mChi2;
+          int mCl[7] = {0};
+          int mLabel = -1;
+          float mChi2 = 0.f;
       };
 
       class Doublets {

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTrack.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTrack.h
@@ -29,56 +29,45 @@ class Cluster;
 namespace ITS
 {
 
-class CookedTrack
+class CookedTrack : public o2::Base::Track::TrackParCov
 {
   using Cluster = o2::ITSMFT::Cluster;
-  
-public:
-  CookedTrack();
-  CookedTrack(float x, float alpha, const std::array<float,o2::Base::Track::kNParams> &par, const std::array<float,o2::Base::Track::kCovMatSize> &cov);
-  CookedTrack(const CookedTrack& t);
-  CookedTrack& operator=(const CookedTrack& tr);
+
+ public:
+
+  using o2::Base::Track::TrackParCov::TrackParCov; // inherit base constructors
+  static constexpr int MaxClusters = 7;
+
+  CookedTrack() = default;
+  CookedTrack(const CookedTrack& t) = default;
+  CookedTrack& operator=(const CookedTrack& tr) = default;
   ~CookedTrack()=default;
 
   // These functions must be provided
-  Double_t getPredictedChi2(const Cluster* c) const;
-  Bool_t propagate(Double_t alpha, Double_t x, Double_t bz);
-  Bool_t correctForMeanMaterial(Double_t x2x0, Double_t xrho, Bool_t anglecorr = kTRUE);
-  Bool_t update(const Cluster* c, Double_t chi2, Int_t idx);
+  Bool_t propagate(Float_t alpha, Float_t x, Float_t bz);
+  Bool_t update(const Cluster& c, Float_t chi2, Int_t idx);
 
   // Other functions
   Int_t getChi2() const { return mChi2; }
-  Int_t getNumberOfClusters() const { return mIndex.size(); }
+  Int_t getNumberOfClusters() const { return mNClusters; }
   Int_t getClusterIndex(Int_t i) const { return mIndex[i]; }
   bool operator<(const CookedTrack& o) const;
-  void getImpactParams(Double_t x, Double_t y, Double_t z, Double_t bz, Double_t ip[2]) const;
-  // Bool_t getPhiZat(Double_t r,Double_t &phi,Double_t &z) const;
+  void getImpactParams(Float_t x, Float_t y, Float_t z, Float_t bz, Float_t ip[2]) const;
+  // Bool_t getPhiZat(Float_t r,Float_t &phi,Float_t &z) const;
 
   void setClusterIndex(Int_t layer, Int_t index);
   void setExternalClusterIndex(Int_t layer, Int_t idx);
   void resetClusters();
 
-  Bool_t isBetter(const CookedTrack& best, Double_t maxChi2) const;
-
-  Double_t getCurvature(Double_t bz) const { return mTrack.GetCurvature(float(bz)); }
-  Double_t getAlpha() const { return mTrack.GetAlpha(); }
-  Double_t getX() const { return mTrack.GetX(); }
-  Double_t getY() const { return mTrack.GetY(); }
-  Double_t getZ() const { return mTrack.GetZ(); }
-  Double_t getSnp() const { return mTrack.GetSnp(); }
-  Double_t getTgl() const { return mTrack.GetTgl(); }
-  Double_t getPt() const { return mTrack.GetPt(); }
-  Bool_t getPxPyPz(std::array<float,3> &pxyz) const { return mTrack.GetPxPyPzGlo(pxyz); }
-  void resetCovariance(Double_t s2 = 0.) { mTrack.ResetCovariance(float(s2)); }
-
-  const o2::Base::Track::TrackParCov&  getBaseTrack() const {return mTrack;}
+  Bool_t isBetter(const CookedTrack& best, Float_t maxChi2) const;
   
  private:
-  o2::Base::Track::TrackParCov mTrack; ///< Base track
-  Double_t mMass;            ///< Assumed mass for this track
-  Double_t mChi2;            ///< Chi2 for this track
-  std::vector<Int_t> mIndex; ///< Indices of associated clusters
 
+  short mNClusters = 0;
+  float mMass = 0.14;            ///< Assumed mass for this track
+  float mChi2 = 0.;            ///< Chi2 for this track
+  std::array<Int_t,MaxClusters> mIndex; ///< Indices of associated clusters
+  
   ClassDef(CookedTrack, 1)
 };
 }

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTracker.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTracker.h
@@ -78,6 +78,7 @@ public:
   
   // These functions must be implemented
   void process(const std::vector<Cluster> &clusters, std::vector<CookedTrack> &tracks);
+  void processFrame(std::vector<CookedTrack> &tracks);
   // Int_t propagateBack(std::vector<CookedTrack> *event);
   // Int_t RefitInward(std::vector<CookedTrack> *event);
   // Bool_t refitAt(Double_t x, CookedTrack *seed, const CookedTrack *t);
@@ -89,6 +90,10 @@ public:
     mClsLabels=clsLabels;
     mTrkLabels=trkLabels;
   }
+
+  void setContinuousMode(bool mode) { mContinuousMode = mode; }
+  bool getContinuousMode() { return mContinuousMode; }
+
   
   // internal helper classes
   class ThreadData;
@@ -96,7 +101,7 @@ public:
 
  protected:
   static constexpr int kNLayers = 7;
-  void loadClusters(const std::vector<Cluster> &clusters);
+  int loadClusters(const std::vector<Cluster> &clusters);
   void unloadClusters();
   
   std::vector<CookedTrack> trackInThread(Int_t first, Int_t last);
@@ -107,10 +112,13 @@ public:
 
  private:
 
+  bool mContinuousMode = true; ///< triggered or cont. mode
   const o2::ITS::GeometryTGeo* mGeom = nullptr; /// interface to geometry
   const
   o2::dataformats::MCTruthContainer<o2::MCCompLabel> *mClsLabels = nullptr; /// Cluster MC labels
   o2::dataformats::MCTruthContainer<o2::MCCompLabel> *mTrkLabels = nullptr; /// Track MC labels
+
+  std::uint32_t mROFrame=0;  ///< last frame processed
   
   Int_t mNumOfThreads; ///< Number of tracking threads
   

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTrackerTask.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTrackerTask.h
@@ -41,7 +41,11 @@ class CookedTrackerTask : public FairTask
   void Exec(Option_t* option) override;
   void setBz(Double_t bz) { mTracker.setBz(bz); }
 
+  void setContinuousMode(bool mode) { mContinuousMode = mode; }
+  bool getContinuousMode() { return mContinuousMode; }
+  
  private:
+  bool mContinuousMode = true; ///< triggered or cont. mode
   CookedTracker mTracker; ///< Track finder
 
   const

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CATracker.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CATracker.cxx
@@ -496,10 +496,9 @@ bool Tracker::RefitAt(float xx, Track *track) {
 
   const int nLayers = 7;
   int* index = track->Clusters();
-  TrackPC* t = &(track->Param());
 
   int from, to, step;
-  if (xx > t->GetX()) {
+  if (xx > track->getX()) {
     from = 0;
     to = nLayers;
     step = +1;
@@ -514,7 +513,7 @@ bool Tracker::RefitAt(float xx, Track *track) {
     if (idx >= 0) {
       const Cluster &cl = (*mLayer[i])[idx];
       float xr = cl.x, ar = mLayer[i]->GetDetInfo(cl.detid).phiTF;
-      if (!t->Rotate(ar) || !t->PropagateTo(xr, mBz)) {
+      if (!track->rotate(ar) || !track->propagateTo(xr, mBz)) {
         return false;
       }
       track->Update(cl);
@@ -524,7 +523,7 @@ bool Tracker::RefitAt(float xx, Track *track) {
       if (!track->GetPhiZat(r,mBz,phi,z)) {
         return false;
       }
-      if (!t->Rotate(phi) || !t->PropagateTo(r, mBz)) {
+      if (!track->rotate(phi) || !track->propagateTo(r, mBz)) {
         return false;
       }
     }
@@ -532,10 +531,10 @@ bool Tracker::RefitAt(float xx, Track *track) {
     float x0  = 9.36; // Radiation length of Si [cm]
     float rho = 2.33; // Density of Si [g/cm^3]
     float mass = 1.39569997787475586e-01; // pion mass
-    t->CorrectForMaterial(xx0, - step * xx0 * x0 * rho, mass, true);
+    track->correctForMaterial(xx0, - step * xx0 * x0 * rho, mass, true);
   }
 
-  if (!t->PropagateTo(xx,mBz)) return false;
+  if (!track->propagateTo(xx,mBz)) return false;
   return true;
 }
 

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CAaux.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CAaux.cxx
@@ -36,33 +36,31 @@ bool Cell::Combine(Cell &neigh, int idd) {
 }
 
 Track::Track(float x, float a, array<float,Base::Track::kNParams> p, array<float,Base::Track::kCovMatSize> c, int *cl) :
-  mT{x,a,p,c},
-  mCl{},
-  mLabel{-1},
-  mChi2{0.f} {
+  Track{x,a,p,c}
+ {
     for (int i = 0; i < 7; ++i) mCl[i] = cl[i];
-  }
+ }
 
 bool Track::Update(const Cluster &cl) {
   array<float,2> p{cl.y,cl.z};
-  const float dChi2 = mT.GetPredictedChi2(p,cl.cov);
-  if (!mT.Update(p,cl.cov)) return false;
+  const float dChi2 = getPredictedChi2(p,cl.cov);
+  if (!update(p,cl.cov)) return false;
   else mChi2 += dChi2;
   return true;
 }
 
 bool Track::GetPhiZat(float r, float bfield,float &phi, float &z) const {
-  float rp4=mT.GetCurvature(bfield);
+  float rp4=getCurvature(bfield);
 
-  float xt=mT.GetY(), yt=mT.GetY();
+  float xt=getY(), yt=getY();
   float x = 0.f, y = 0.f;
-  float sn=sin(mT.GetAlpha()), cs=cos(mT.GetAlpha());
+  float sn=sin(getAlpha()), cs=cos(getAlpha());
   float a = x*cs + y*sn;
   y = -x*sn + y*cs; x=a;
   xt-=x; yt-=y;
 
-  sn=rp4*xt - mT.GetSnp(); cs=rp4*yt + sqrt((1.- mT.GetSnp())*(1.+mT.GetSnp()));
-  a=2*(xt*mT.GetSnp() - yt*sqrt((1.-mT.GetSnp())*(1.+mT.GetSnp())))-rp4*(xt*xt + yt*yt);
+  sn=rp4*xt - getSnp(); cs=rp4*yt + sqrt((1.- getSnp())*(1.+getSnp()));
+  a=2*(xt*getSnp() - yt*sqrt((1.-getSnp())*(1.+getSnp())))-rp4*(xt*xt + yt*yt);
   float d =  -a/(1 + sqrt(sn*sn + cs*cs));
 
   if (fabs(d) > r) {
@@ -70,10 +68,10 @@ bool Track::GetPhiZat(float r, float bfield,float &phi, float &z) const {
     r = fabs(d);
   }
 
-  float rcurr=sqrt(mT.GetX()*mT.GetX() + mT.GetY()*mT.GetY());
-  float phicurr=mT.GetPhi();
+  float rcurr=sqrt(getX()*getX() + getY()*getY());
+  float phicurr=getPhi();
 
-  if (mT.GetX()>=0.) {
+  if (getX()>=0.) {
     phi=phicurr+asin(d/r)-asin(d/rcurr);
   } else {
     phi=phicurr+asin(d/r)+asin(d/rcurr)-kPI;
@@ -82,7 +80,7 @@ bool Track::GetPhiZat(float r, float bfield,float &phi, float &z) const {
   //return a phi in [0,2pi
   if (phi<0.) phi+=2.*kPI;
   else if (phi>=2.*kPI) phi-=2.*kPI;
-  z=mT.GetZ()+mT.GetTgl()*(sqrt((r-d)*(r+d))-sqrt((rcurr-d)*(rcurr+d)));
+  z=getZ()+getTgl()*(sqrt((r-d)*(r+d))-sqrt((rcurr-d)*(rcurr+d)));
 
   return true;
 }

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CookedTrack.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CookedTrack.cxx
@@ -25,71 +25,36 @@ using namespace o2::ITS;
 using namespace o2::Base::Constants;
 using namespace o2::Base::Track;
 
-CookedTrack::CookedTrack() : mTrack(), mMass(0.14), mChi2(0.)
-{
-  //--------------------------------------------------------------------
-  // This default constructor needs to be provided
-  //--------------------------------------------------------------------
-  mIndex.reserve(7);
-}
-
-CookedTrack::CookedTrack(float x, float alpha, const std::array<float,kNParams> &par, const std::array<float,kCovMatSize> &cov)
-  : mTrack(x, alpha, par, cov), mMass(0.14), mChi2(0.)
-{
-  //--------------------------------------------------------------------
-  // Main constructor
-  //--------------------------------------------------------------------
-}
-
-CookedTrack::CookedTrack(const CookedTrack& t)
-  : mTrack(t.mTrack), mMass(t.mMass), mChi2(t.mChi2), mIndex(t.mIndex)
-{
-  //--------------------------------------------------------------------
-  // Copy constructor
-  //--------------------------------------------------------------------
-}
-
-CookedTrack& CookedTrack::operator=(const CookedTrack& t)
-{
-  if (&t != this) {
-    mTrack=t.mTrack;
-    mMass = t.mMass;
-    mChi2 = t.mChi2;
-    mIndex = t.mIndex;
-  }
-  return *this;
-}
-
 bool CookedTrack::operator<(const CookedTrack& o) const
 {
   //-----------------------------------------------------------------
   // This function compares tracks according to the their curvature
   //-----------------------------------------------------------------
-  Double_t co = TMath::Abs(o.getPt());
-  Double_t c = TMath::Abs(getPt());
-  // Double_t co=o.GetSigmaY2()*o.GetSigmaZ2();
-  // Double_t c =GetSigmaY2()*GetSigmaZ2();
+  Float_t co = TMath::Abs(o.getPt());
+  Float_t c = TMath::Abs(getPt());
+  // Float_t co=o.GetSigmaY2()*o.GetSigmaZ2();
+  // Float_t c =GetSigmaY2()*GetSigmaZ2();
 
   return (c > co);
 }
 
-void CookedTrack::getImpactParams(Double_t x, Double_t y, Double_t z, Double_t bz, Double_t ip[2]) const
+void CookedTrack::getImpactParams(Float_t x, Float_t y, Float_t z, Float_t bz, Float_t ip[2]) const
 {
   //------------------------------------------------------------------
   // This function calculates the transverse and longitudinal impact parameters
   // with respect to a point with global coordinates (x,y,0)
   // in the magnetic field "bz" (kG)
   //------------------------------------------------------------------
-  Double_t f1 = getSnp(), r1 = TMath::Sqrt((1. - f1) * (1. + f1));
-  Double_t xt = getX(), yt = getY();
-  Double_t sn = TMath::Sin(getAlpha()), cs = TMath::Cos(getAlpha());
-  Double_t a = x * cs + y * sn;
+  Float_t f1 = getSnp(), r1 = TMath::Sqrt((1. - f1) * (1. + f1));
+  Float_t xt = getX(), yt = getY();
+  Float_t sn = TMath::Sin(getAlpha()), cs = TMath::Cos(getAlpha());
+  Float_t a = x * cs + y * sn;
   y = -x * sn + y * cs;
   x = a;
   xt -= x;
   yt -= y;
 
-  Double_t rp4 = getCurvature(bz);
+  Float_t rp4 = getCurvature(bz);
   if ((TMath::Abs(bz) < kAlmost0) || (TMath::Abs(rp4) < kAlmost0)) {
     ip[0] = -(xt * f1 - yt * r1);
     ip[1] = getZ() + (ip[0] * f1 - xt) / r1 * getTgl() - z;
@@ -99,9 +64,9 @@ void CookedTrack::getImpactParams(Double_t x, Double_t y, Double_t z, Double_t b
   sn = rp4 * xt - f1;
   cs = rp4 * yt + r1;
   a = 2 * (xt * f1 - yt * r1) - rp4 * (xt * xt + yt * yt);
-  Double_t rr = TMath::Sqrt(sn * sn + cs * cs);
+  Float_t rr = TMath::Sqrt(sn * sn + cs * cs);
   ip[0] = -a / (1 + rr);
-  Double_t f2 = -sn / rr, r2 = TMath::Sqrt((1. - f2) * (1. + f2));
+  Float_t f2 = -sn / rr, r2 = TMath::Sqrt((1. - f2) * (1. + f2));
   ip[1] = getZ() + getTgl() / rp4 * TMath::ASin(f2 * r1 - f1 * r2) - z;
 }
 
@@ -111,7 +76,7 @@ void CookedTrack::resetClusters()
   // Reset the array of attached clusters.
   //------------------------------------------------------------------
   mChi2 = -1.;
-  mIndex.clear();
+  mNClusters = 0;
 }
 
 void CookedTrack::setClusterIndex(Int_t l, Int_t i)
@@ -120,7 +85,7 @@ void CookedTrack::setClusterIndex(Int_t l, Int_t i)
   // Set the cluster index
   //--------------------------------------------------------------------
   Int_t idx = (l << 28) + i;
-  mIndex.push_back(idx);
+  mIndex[mNClusters++] = idx;
 }
 
 void CookedTrack::setExternalClusterIndex(Int_t layer, Int_t idx)
@@ -128,63 +93,50 @@ void CookedTrack::setExternalClusterIndex(Int_t layer, Int_t idx)
   //--------------------------------------------------------------------
   // Set the cluster index within an external cluster array 
   //--------------------------------------------------------------------
-  mIndex.at(layer)=idx;
+  mIndex[layer]=idx;
 }
 
-Double_t CookedTrack::getPredictedChi2(const Cluster* c) const
+Bool_t CookedTrack::propagate(Float_t alpha, Float_t x, Float_t bz)
 {
-  //-----------------------------------------------------------------
-  // This function calculates a predicted chi2 increment.
-  //-----------------------------------------------------------------
-  return mTrack.GetPredictedChi2(*c);
-}
-
-Bool_t CookedTrack::propagate(Double_t alpha, Double_t x, Double_t bz)
-{
-  if (mTrack.Rotate(float(alpha)))
-    if (mTrack.PropagateTo(float(x), float(bz)))
+  if (rotate(alpha))
+    if (propagateTo(x, bz))
       return kTRUE;
 
   return kFALSE;
 }
 
-Bool_t CookedTrack::correctForMeanMaterial(Double_t x2x0, Double_t xrho, Bool_t anglecorr)
-{
-  return mTrack.CorrectForMaterial(float(x2x0), float(xrho), float(mMass), anglecorr);
-}
-
-Bool_t CookedTrack::update(const Cluster* c, Double_t chi2, Int_t idx)
+Bool_t CookedTrack::update(const Cluster& c, Float_t chi2, Int_t idx)
 {
   //--------------------------------------------------------------------
   // Update track params
   //--------------------------------------------------------------------
-  if (!mTrack.Update(*c))
+  if (!o2::Base::Track::TrackParCov::update(static_cast<const o2::Base::BaseCluster<float>&>(c)))
     return kFALSE;
 
   mChi2 += chi2;
-  mIndex.push_back(idx);
+  mIndex[mNClusters++] = idx;
 
   return kTRUE;
 }
 
 /*
-Bool_t CookedTrack::getPhiZat(Double_t r, Double_t &phi, Double_t &z) const
+Bool_t CookedTrack::getPhiZat(Float_t r, Float_t &phi, Float_t &z) const
 {
   //------------------------------------------------------------------
   // This function returns the global cylindrical (phi,z) of the track
   // position estimated at the radius r.
   // The track curvature is neglected.
   //------------------------------------------------------------------
-  Double_t d=GetD(0., 0., GetBz());
+  Float_t d=GetD(0., 0., GetBz());
   if (TMath::Abs(d) > r) {
     if (r>1e-1) return kFALSE;
     r = TMath::Abs(d);
   }
 
-  Double_t rcurr=TMath::Sqrt(GetX()*GetX() + GetY()*GetY());
+  Float_t rcurr=TMath::Sqrt(GetX()*GetX() + GetY()*GetY());
   if (TMath::Abs(d) > rcurr) return kFALSE;
-  Double_t globXYZcurr[3]; GetXYZ(globXYZcurr);
-  Double_t phicurr=TMath::ATan2(globXYZcurr[1],globXYZcurr[0]);
+  Float_t globXYZcurr[3]; GetXYZ(globXYZcurr);
+  Float_t phicurr=TMath::ATan2(globXYZcurr[1],globXYZcurr[0]);
 
   if (GetX()>=0.) {
     phi=phicurr+TMath::ASin(d/r)-TMath::ASin(d/rcurr);
@@ -201,13 +153,13 @@ Bool_t CookedTrack::getPhiZat(Double_t r, Double_t &phi, Double_t &z) const
 }
 */
 
-Bool_t CookedTrack::isBetter(const CookedTrack& best, Double_t maxChi2) const
+Bool_t CookedTrack::isBetter(const CookedTrack& best, Float_t maxChi2) const
 {
   Int_t ncl = getNumberOfClusters();
   Int_t nclb = best.getNumberOfClusters();
 
   if (ncl >= nclb) {
-    Double_t chi2 = getChi2();
+    Float_t chi2 = getChi2();
     if (chi2 < maxChi2) {
       if (ncl > nclb || chi2 < best.getChi2()) {
         return kTRUE;

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CookedTracker.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CookedTracker.cxx
@@ -346,7 +346,7 @@ void CookedTracker::makeSeeds(std::vector<CookedTrack> &seeds, Int_t first, Int_
 
 	CookedTrack seed = cookSeed(xyz1, xyz3, txyz2, layer2.getR(), layer3.getR(), layer2.getAlphaRef(n2), getBz());
 
-	Double_t ip[2];
+	float ip[2];
         seed.getImpactParams(getX(), getY(), getZ(), getBz(), ip);
         if (TMath::Abs(ip[0]) > kmaxDCAxy) continue;
         if (TMath::Abs(ip[1]) > kmaxDCAz ) continue;
@@ -354,7 +354,7 @@ void CookedTracker::makeSeeds(std::vector<CookedTrack> &seeds, Int_t first, Int_
 	  Double_t xx0 = 0.008; // Rough layer thickness
 	  Double_t radl = 9.36; // Radiation length of Si [cm]
 	  Double_t rho = 2.33;  // Density of Si [g/cm^3]
-	  if (!seed.correctForMeanMaterial(xx0, xx0 * radl * rho, kTRUE)) continue;
+	  if (!seed.correctForMaterial(xx0, xx0 * radl * rho, kTRUE)) continue;
 	}
         seed.setClusterIndex(kSeedingLayer1, n1);
         seed.setClusterIndex(kSeedingLayer3, n3);
@@ -868,18 +868,18 @@ Bool_t CookedTracker::attachCluster(Int_t& volID, Int_t nl, Int_t ci, CookedTrac
       return kFALSE;
   }
 
-  Double_t chi2 = t.getPredictedChi2(c);
+  Double_t chi2 = t.getPredictedChi2(*c);
 
   if (chi2 > kmaxChi2PerCluster)
     return kFALSE;
 
-  if (!t.update(c, chi2, (nl << 28) + ci))
+  if (!t.update(*c, chi2, (nl << 28) + ci))
     return kFALSE;
 
   Double_t xx0 = (nl > 2) ? 0.008 : 0.003; // Rough layer thickness
   Double_t x0 = 9.36;                      // Radiation length of Si [cm]
   Double_t rho = 2.33;                     // Density of Si [g/cm^3]
-  t.correctForMeanMaterial(xx0, xx0 * x0 * rho, kTRUE);
+  t.correctForMaterial(xx0, xx0 * x0 * rho, kTRUE);
   return kTRUE;
 }
 

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CookedTrackerTask.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CookedTrackerTask.cxx
@@ -83,6 +83,7 @@ InitStatus CookedTrackerTask::Init()
   geom->fillMatrixCache( bit2Mask(TransformType::T2GRot) ); // make sure T2GRot matrices are loaded
   mTracker.setGeometry(geom);
   mTracker.setMCTruthContainers(mClsLabels, mTrkLabels);
+  mTracker.setContinuousMode(mContinuousMode);
   
   return kSUCCESS;
 }

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/TrackTPC.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/TrackTPC.h
@@ -24,24 +24,13 @@ namespace TPC {
 /// This is the definition of the TPC Track Object
 
 
-class TrackTPC {
+class TrackTPC :public o2::Base::Track::TrackParCov {
   public:
 
+    using o2::Base::Track::TrackParCov::TrackParCov; // inherit
+
     /// Default constructor
-    TrackTPC();
-
-    /// Constructor, initializing values for x, alpha and an array with Y, Z, sin(phi), tg(lambda) and q/pT
-    /// \param x X of track evaluation
-    /// \param alpha track frame angle
-    /// \param std::array par contains Y, Z, sin(phi), tg(lambda) and q/pT
-    TrackTPC(float x, float alpha, const std::array<float, o2::Base::Track::kNParams> &par, const std::array<float, o2::Base::Track::kCovMatSize> &cov);
-
-    /// Constructor, initializing values for x,y and z in an array, momenta px, py and pz in an array
-    /// \param std::array xyz contains x, y and z coordinates of the vertex of the origin
-    /// \param std::array pxpypz contains momenta in x, y and z direction
-    /// \param sign sign of the charge of the particle
-    /// \param sectorAlpha false: angle of pT direction, true: angle of the sector from X, Y coordinate for r>1; angle of pT direction for r==0
-    TrackTPC(const std::array<float,3> &xyz, const std::array<float,3> &pxpypz, const std::array<float, o2::Base::Track::kLabCovMatSize> &cv, int sign, bool sectorAlpha=true);
+    TrackTPC() = default;
 
     /// Destructor
     ~TrackTPC() = default;
@@ -66,69 +55,13 @@ class TrackTPC {
     /// \return mean energy loss
     float getTruncatedMean(float low=0.05, float high=0.7, int type=1, int removeRows=0, int *nclPID=nullptr) const;
 
-
-    /// Get the TrackParCov object
-    o2::Base::Track::TrackParCov getTrack() { return mTrackParCov; }
-
-
-
-    float getX()                         const { return mTrackParCov.GetX(); }
-    float getAlpha()                     const { return mTrackParCov.GetAlpha(); }
-    float getY()                         const { return mTrackParCov.GetY(); }
-    float getZ()                         const { return mTrackParCov.GetZ(); }
-    float getSnp()                       const { return mTrackParCov.GetSnp(); }
-    float getTgl()                       const { return mTrackParCov.GetTgl(); }
-    float getQ2Pt()                      const { return mTrackParCov.GetQ2Pt(); }
-
-    // derived getters
-    float getCurvature(float b)          const { return mTrackParCov.GetCurvature(float(b));}
-    float getSign()                      const { return mTrackParCov.GetSign();}
-    float getPhi()                       const { return mTrackParCov.GetPhi();}
-    float getPhiPos()                    const { return mTrackParCov.GetPhiPos(); }
-
-    float getP()                         const { return mTrackParCov.GetP(); }
-    float getPt()                        const { return mTrackParCov.GetPt(); }
-    void  getXYZ(std::array<float,3> &xyz)           const { mTrackParCov.GetXYZGlo(xyz); }
-    bool  getPxPyPz(std::array<float,3> &pxyz)       const { return mTrackParCov.GetPxPyPzGlo(pxyz); }
-    bool  getPosDir(std::array<float,9> &posdirp)    const { return mTrackParCov.GetPosDirGlo(posdirp); }
-
-    /// \todo implement getters for covariance (missing access to full covariance in Track.h)
-
-
-    // parameters manipulation
-    bool  rotateParam(float alpha)       { return mTrackParCov.Rotate(alpha); }
-    bool  propagateParamTo(float xk, float b)        { return mTrackParCov.PropagateParamTo(xk, b); }
-    bool  propagateParamTo(float xk, const std::array<float,3> &b)    { return mTrackParCov.PropagateParamTo(xk, b); }
-    void  invertParam()                  { mTrackParCov.InvertParam(); }
-
-    void  printParam()                   { mTrackParCov.PrintParam(); }
-
-
   private:
-    o2::Base::Track::TrackParCov mTrackParCov;
     std::vector<Cluster> mClusterVector;
 
 };
 
 inline
-TrackTPC::TrackTPC()
-  : mTrackParCov()
-  , mClusterVector()
-{}
-
-inline
-TrackTPC::TrackTPC(float x,float alpha, const std::array<float, o2::Base::Track::kNParams> &par, const std::array<float,o2::Base::Track::kCovMatSize> &cov)
-  : mTrackParCov(x, alpha, par, cov)
-  , mClusterVector()
-{}
-
-inline
-TrackTPC::TrackTPC(const std::array<float,3> &xyz,const std::array<float,3> &pxpypz, const std::array<float,o2::Base::Track::kLabCovMatSize> &cv, int sign, bool sectorAlpha)
-  : mTrackParCov(xyz, pxpypz, cv, sign, sectorAlpha)
-  , mClusterVector()
-{}
-
-inline void TrackTPC::addCluster(const Cluster& c)
+void TrackTPC::addCluster(const Cluster &c)
 {
   mClusterVector.push_back(c);
 }

--- a/Detectors/TPC/reconstruction/macro/testTracks.C
+++ b/Detectors/TPC/reconstruction/macro/testTracks.C
@@ -143,7 +143,7 @@ void testTracks(int checkEvent = 0,
         GlobalPosition3D clusGlob = Mapper::LocalToGlobal(clusLoc, cru.sector());
 
         // Track parameters are in local coordinate system - propagate to pad row of the cluster
-        trackObject.propagateParamTo(clusLoc.X(), bField);
+        trackObject.propagateTo(clusLoc.X(), bField);
 
         LocalPosition3D trackLoc(trackObject.getX(), trackObject.getY(), trackObject.getZ());
         /// \todo sector hardcoded for the time  being

--- a/Detectors/TPC/reconstruction/src/Cluster.cxx
+++ b/Detectors/TPC/reconstruction/src/Cluster.cxx
@@ -13,7 +13,8 @@
 
 #include "TPCReconstruction/Cluster.h"
 
-ClassImp(o2::TPC::Cluster)
+ClassImp(o2::TPC::ClusterTimeStamp);
+ClassImp(o2::TPC::Cluster);
 
 using namespace o2::TPC;
 

--- a/macro/run_trac_its.C
+++ b/macro/run_trac_its.C
@@ -14,7 +14,8 @@
 #include "ITSReconstruction/CookedTrackerTask.h"
 #endif
 
-void run_trac_its(Int_t nEvents = 10, TString mcEngine = "TGeant3"){
+void run_trac_its(Int_t nEvents = 10, TString mcEngine = "TGeant3",
+		  float rate = 0.){
         // Initialize logger
         FairLogger *logger = FairLogger::GetLogger();
         logger->SetLogVerbosityLevel("LOW");
@@ -45,7 +46,8 @@ void run_trac_its(Int_t nEvents = 10, TString mcEngine = "TGeant3"){
         Int_t n=1;            // Number of threads
         Bool_t mcTruth=kTRUE; // kFALSE if no comparison with MC is needed
         o2::ITS::CookedTrackerTask *trac = new o2::ITS::CookedTrackerTask(n,mcTruth);
-
+	trac->setContinuousMode(rate>0.);
+	
         fRun->AddTask(trac);
 
         fRun->Init();


### PR DESCRIPTION
@iouribelikov when deriving CookedTrack from TrackParCov I saw that
the clusters indices are kept in the std::vector which is expanded to 7 slots in track
constructor. To make the tracks POD-like copyable (and smaller) I changed
this to array<int,7>.