### PR TITLE
Dev framework update

### DIFF
--- a/Framework/Core/include/Framework/ConfigParamsHelper.h
+++ b/Framework/Core/include/Framework/ConfigParamsHelper.h
@@ -23,7 +23,28 @@ void populateBoostProgramOptions(
     boost::program_options::options_description &options,
     const std::vector<ConfigParamSpec> &specs
   );
+
+/// populate boost program options making all options of type string
+/// this is used for filtering the command line argument
+bool
+prepareOptionsDescription(const std::vector<ConfigParamSpec> &spec,
+                          boost::program_options::options_description& options);
+
+/// populate boost program options for a complete workflow
+template<typename ContainerType>
+boost::program_options::options_description
+prepareOptionDescriptions(const ContainerType &workflow)
+{
+  boost::program_options::options_description specOptions("Spec options");
+  for (const auto & spec : workflow) {
+    boost::program_options::options_description options(spec.name.c_str());
+    if (prepareOptionsDescription(spec.options, options)) {
+      specOptions.add(options);
+    }
+  }
+  return specOptions;
 }
 
+}
 }
 #endif // FRAMEWORK_CONFIGPARAMSHELPER_H

--- a/Framework/Core/include/Framework/DataRef.h
+++ b/Framework/Core/include/Framework/DataRef.h
@@ -16,9 +16,11 @@ namespace framework {
 struct InputSpec;
 
 struct DataRef {
-  const InputSpec *const spec;
-  const char *const header;
-  const char *const payload;
+  // FIXME: had to remove the second 'const' in const T* const
+  // to allow assignment
+  const InputSpec * spec;
+  const char * header;
+  const char * payload;
 };
 
 }

--- a/Framework/Core/include/Framework/DataRefUtils.h
+++ b/Framework/Core/include/Framework/DataRefUtils.h
@@ -22,7 +22,7 @@ struct DataRefUtils {
   template <typename T>
   static Collection<T> as(const DataRef &ref) {
     using DataHeader = o2::Header::DataHeader;
-    auto header = reinterpret_cast<const DataHeader*const>(ref.header);
+    auto header = o2::Header::get<const DataHeader>(ref.header);
     assert((header->payloadSize % sizeof(T)) == 0);
     //FIXME: provide a const collection
     return Collection<T>(reinterpret_cast<void *>(const_cast<char *>(ref.payload)), header->payloadSize/sizeof(T));

--- a/Framework/Core/include/Framework/DataSourceDevice.h
+++ b/Framework/Core/include/Framework/DataSourceDevice.h
@@ -45,6 +45,8 @@ private:
   RootObjectContext mRootContext;
   DataAllocator mAllocator;
   size_t mCurrentTimeslice;
+  float mRate;
+  size_t mLastTime;
 };
 
 }

--- a/Framework/Core/include/Framework/Variant.h
+++ b/Framework/Core/include/Framework/Variant.h
@@ -63,6 +63,34 @@ template <> struct variant_trait<bool> {
   static VariantType type() { return VariantType::Bool; }
 };
 
+template<VariantType type>
+struct variant_type {
+};
+
+template <> struct variant_type<VariantType::Int> {
+  using type = int;
+};
+
+template <> struct variant_type<VariantType::Int64> {
+  using type = int64_t;
+};
+
+template <> struct variant_type<VariantType::Float> {
+  using type = float;
+};
+
+template <> struct variant_type<VariantType::Double> {
+  using type = double;
+};
+
+template <> struct variant_type<VariantType::String> {
+  using type = const char*;
+};
+
+template <> struct variant_type<VariantType::Bool> {
+  using type = bool;
+};
+
 template <typename S, typename T>
 struct variant_helper {
   static void set(S*store, T value)

--- a/Framework/Core/src/DataAllocator.cxx
+++ b/Framework/Core/src/DataAllocator.cxx
@@ -56,6 +56,7 @@ DataAllocator::newChunk(const OutputSpec &spec, size_t size) {
   dh.dataOrigin = spec.origin;
   dh.dataDescription = spec.description;
   dh.subSpecification = spec.subSpec;
+  dh.payloadSize = size;
 
   DataProcessingHeader dph{mContext->timeslice(), 1};
   //we have to move the incoming data
@@ -89,6 +90,7 @@ DataAllocator::adoptChunk(const OutputSpec &spec, char *buffer, size_t size, fai
   dh.dataOrigin = spec.origin;
   dh.dataDescription = spec.description;
   dh.subSpecification = spec.subSpec;
+  dh.payloadSize = size;
 
   DataProcessingHeader dph{mContext->timeslice(), 1};
   //we have to move the incoming data
@@ -121,6 +123,8 @@ DataAllocator::newTClonesArray(const OutputSpec &spec, const char *className, si
   dh.dataOrigin = spec.origin;
   dh.dataDescription = spec.description;
   dh.subSpecification = spec.subSpec;
+  // the correct payload size is st later when sending the
+  // RootObjectContext, see DataProcessor::doSend
   dh.payloadSize = 0;
 
   DataProcessingHeader dph{mContext->timeslice(), 1};

--- a/Framework/Core/src/FrameworkGUIDevicesGraph.cxx
+++ b/Framework/Core/src/FrameworkGUIDevicesGraph.cxx
@@ -62,7 +62,7 @@ void showTopologyNodeGraph(bool* opened,
     static bool show_grid = true;
     static int node_selected = -1;
 
-    auto prepareChannelView = [&specs](ImVector<Node> &nodes) {
+    auto prepareChannelView = [&specs](ImVector<Node> &nodeList) {
       std::map<std::string, std::pair<int, int>> linkToIndex;
       for (int si = 0; si < specs.size(); ++si) {
         int oi = 0;
@@ -74,7 +74,7 @@ void showTopologyNodeGraph(bool* opened,
       for (int si = 0; si < specs.size(); ++si) {
         auto &spec = specs[si];
         // FIXME: display nodes using topological sort
-        nodes.push_back(Node(si, spec.id.c_str(),  ImVec2(40+120*si,50 + (120 * si) % 500), 0.5f,
+        nodeList.push_back(Node(si, spec.id.c_str(),  ImVec2(40+120*si,50 + (120 * si) % 500), 0.5f,
                         ImColor(255,100,100),
                         spec.inputChannels.size(),
                         spec.outputChannels.size()));

--- a/Framework/TestWorkflows/src/o2_sim_tpc.h
+++ b/Framework/TestWorkflows/src/o2_sim_tpc.h
@@ -8,8 +8,8 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifndef WORKFLOWS_O2_SIM_ITS_ALP3
-#define WORKFLOWS_O2_SIM_ITS_ALP3
+#ifndef WORKFLOWS_O2_SIM_TPC
+#define WORKFLOWS_O2_SIM_TPC
 
 #include "Framework/DataProcessorSpec.h"
 
@@ -19,4 +19,4 @@ namespace workflows{
 }
 }
 
-#endif // WORKFLOWS_O2_SIM_ITS_ALP3
+#endif // WORKFLOWS_O2_SIM_TPC


### PR DESCRIPTION
This is a proposal for a couple of bugfixes and enhancements for the framework module
- Implementing argument scan via boost program options
  cures the 'unrecognized option' warnings at child start and adds help printout, provides the basis to
  support options without extra parameter or even multitoken in `ConfigParamSpec`
- adding variant_type trait
- Adding rate control to DataSourceDevice (yet to be configured via command line parameter)
- add iterator for elements of InputRecord
- using o2::Header::get to extract DataHeader
- adding header message size to DataRef and support assignment
- bugfix, set payloadSize in the data header
- fixing a compilation warning (shadowed variable)
- bugfixes for argument forwarding (obsolete with the move to boost program options)
- correcting typos
