### PR TITLE
Adding QC setup using declarative workflow of the framework

### DIFF
--- a/Utilities/QC/CMakeLists.txt
+++ b/Utilities/QC/CMakeLists.txt
@@ -7,4 +7,4 @@ add_subdirectory(QCProducer)
 add_subdirectory(QCMerger)
 add_subdirectory(QCViewer)
 add_subdirectory(QCMetricsExtractor)
-
+add_subdirectory(Workflow)

--- a/Utilities/QC/QCProducer/include/QCProducer/TH1Producer.h
+++ b/Utilities/QC/QCProducer/include/QCProducer/TH1Producer.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "Producer.h"
+#include <string>
 
 namespace o2
 {
@@ -23,8 +24,8 @@ class TH1Producer : public Producer
   TObject* produceData() const override;
 
  private:
-  const char* mHistogramName;
-  const char* mHistogramTitle;
+  std::string mHistogramName;
+  std::string mHistogramTitle;
 
   const int mBeansNumber;
   const double mXLow{ -10 };

--- a/Utilities/QC/QCProducer/include/QCProducer/TH2Producer.h
+++ b/Utilities/QC/QCProducer/include/QCProducer/TH2Producer.h
@@ -13,6 +13,7 @@
 #include <Rtypes.h>
 
 #include "Producer.h"
+#include <string>
 
 namespace o2
 {
@@ -25,8 +26,8 @@ class TH2Producer : public Producer
   TObject* produceData() const override;
 
  private:
-  const char* mHistogramName;
-  const char* mHistogramTitle;
+  std::string mHistogramName;
+  std::string mHistogramTitle;
 
   const Int_t mNbinsx;
   const Int_t mNbinsy;

--- a/Utilities/QC/QCProducer/include/QCProducer/TH3Producer.h
+++ b/Utilities/QC/QCProducer/include/QCProducer/TH3Producer.h
@@ -13,6 +13,7 @@
 #include <Rtypes.h>
 
 #include "Producer.h"
+#include <string>
 
 namespace o2
 {
@@ -25,8 +26,8 @@ class TH3Producer : public Producer
   TObject* produceData() const override;
 
  private:
-  const char* mHistogramName;
-  const char* mHistogramTitle;
+  std::string mHistogramName;
+  std::string mHistogramTitle;
 
   const Int_t mNbinsx;
   const Int_t mNbinsy;

--- a/Utilities/QC/QCProducer/include/QCProducer/THnProducer.h
+++ b/Utilities/QC/QCProducer/include/QCProducer/THnProducer.h
@@ -13,6 +13,7 @@
 #include <Rtypes.h>
 
 #include "Producer.h"
+#include <string>
 
 namespace o2
 {
@@ -26,8 +27,8 @@ class THnProducer : public Producer
 
  private:
   const int mBins;
-  const char* mHistogramName;
-  const char* mHistogramTitle;
+  std::string mHistogramName;
+  std::string mHistogramTitle;
 };
 }
 }

--- a/Utilities/QC/QCProducer/include/QCProducer/TreeProducer.h
+++ b/Utilities/QC/QCProducer/include/QCProducer/TreeProducer.h
@@ -13,6 +13,7 @@
 #include <TTree.h>
 
 #include "QCProducer/Producer.h"
+#include <string>
 
 namespace o2
 {
@@ -26,8 +27,8 @@ class TreeProducer : public Producer
   TObject* produceData() const override;
 
  private:
-  const char* mTreeName;
-  const char* mTreeTitle;
+  std::string mTreeName;
+  std::string mTreeTitle;
   const int mNumberOfBranches;
   const int mNumberOfEntriesInEachBranch;
 

--- a/Utilities/QC/QCProducer/src/TH1Producer.cxx
+++ b/Utilities/QC/QCProducer/src/TH1Producer.cxx
@@ -25,7 +25,7 @@ TH1Producer::TH1Producer(const char* histogramName, const char* histogramTitle, 
 
 TObject* TH1Producer::produceData() const
 {
-  auto* histogram = new TH1F(mHistogramName, mHistogramTitle, mBeansNumber, mXLow, mXUp);
+  auto* histogram = new TH1F(mHistogramName.c_str(), mHistogramTitle.c_str(), mBeansNumber, mXLow, mXUp);
   histogram->FillRandom("gaus", 1000);
 
   return histogram;

--- a/Utilities/QC/QCProducer/src/TH2Producer.cxx
+++ b/Utilities/QC/QCProducer/src/TH2Producer.cxx
@@ -26,7 +26,7 @@ TH2Producer::TH2Producer(const char* histogramName, const char* histogramTitle, 
 
 TObject* TH2Producer::produceData() const
 {
-  auto* histogram = new TH2F(mHistogramName, mHistogramTitle, mNbinsx, mXlow, mXup, mNbinsy, mYlow, mYup);
+  auto* histogram = new TH2F(mHistogramName.c_str(), mHistogramTitle.c_str(), mNbinsx, mXlow, mXup, mNbinsy, mYlow, mYup);
 
   for (int i = 0; i < mNbinsx; ++i) {
     for (int j = 0; j < mNbinsy; ++j) {

--- a/Utilities/QC/QCProducer/src/TH3Producer.cxx
+++ b/Utilities/QC/QCProducer/src/TH3Producer.cxx
@@ -27,7 +27,7 @@ TH3Producer::TH3Producer(const char* histogramName, const char* histogramTitle, 
 TObject* TH3Producer::produceData() const
 {
   auto* histogram =
-    new TH3F(mHistogramName, mHistogramTitle, mNbinsx, mXlow, mXup, mNbinsy, mYlow, mYup, mNbinsz, mZlow, mZup);
+    new TH3F(mHistogramName.c_str(), mHistogramTitle.c_str(), mNbinsx, mXlow, mXup, mNbinsy, mYlow, mYup, mNbinsz, mZlow, mZup);
 
   Double_t x, y, z;
 

--- a/Utilities/QC/QCProducer/src/THnProducer.cxx
+++ b/Utilities/QC/QCProducer/src/THnProducer.cxx
@@ -32,7 +32,7 @@ TObject* THnProducer::produceData() const
   const Int_t valuesNumber = 1000;
   auto* values = new Double_t[valuesNumber];
 
-  auto* histogram = new THnF(mHistogramName, mHistogramTitle, dim, bins, xmin, xmax);
+  auto* histogram = new THnF(mHistogramName.c_str(), mHistogramTitle.c_str(), dim, bins, xmin, xmax);
 
   for (int i = 0; i < dim; ++i) {
     for (int j = 0; j < valuesNumber; ++j) {

--- a/Utilities/QC/QCProducer/src/TreeProducer.cxx
+++ b/Utilities/QC/QCProducer/src/TreeProducer.cxx
@@ -33,7 +33,7 @@ TreeProducer::TreeProducer(const char* treeName, const char* treeTitle, const in
 
 TObject* TreeProducer::produceData() const
 {
-  auto* tree = new TTree(mTreeName, mTreeTitle);
+  auto* tree = new TTree(mTreeName.c_str(), mTreeTitle.c_str());
 
   for (int i = 0; i < mNumberOfBranches; ++i) {
     createBranch(tree, i);

--- a/Utilities/QC/Workflow/CMakeLists.txt
+++ b/Utilities/QC/Workflow/CMakeLists.txt
@@ -1,0 +1,34 @@
+# Copyright CERN and copyright holders of ALICE O2. This software is
+# distributed under the terms of the GNU General Public License v3 (GPL
+# Version 3), copied verbatim in the file "COPYING".
+#
+# See https://alice-o2.web.cern.ch/ for full licensing information.
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+set(MODULE_NAME "Workflow")
+set(MODULE_BUCKET_NAME QC_workflow_bucket)
+
+O2_SETUP(NAME ${MODULE_NAME})
+#set(SRCS
+#   )
+
+## TODO: feature of macro, it deletes the variables we pass to it, set them again
+## this has to be fixed in the macro implementation
+set(LIBRARY_NAME ${MODULE_NAME})
+set(BUCKET_NAME ${MODULE_BUCKET_NAME})
+
+#O2_GENERATE_LIBRARY()
+
+O2_GENERATE_EXECUTABLE(
+  EXE_NAME simple-merger-workflow
+
+  SOURCES
+  src/SimpleMergerWorkflow.cxx
+  src/RootObjectProducerSpec.cxx
+  src/RootObjectMergerSpec.cxx
+
+  BUCKET_NAME ${MODULE_BUCKET_NAME}
+)

--- a/Utilities/QC/Workflow/src/RootObjectMergerSpec.cxx
+++ b/Utilities/QC/Workflow/src/RootObjectMergerSpec.cxx
@@ -1,0 +1,84 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   RootObjectMergerSpec.cxx
+/// @author Matthias Richter
+/// @since  2017-11-10
+/// @brief  Processor spec for a merger for ROOT objects
+
+#include "RootObjectMergerSpec.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Headers/DataHeader.h"
+#include "QCCommon/TMessageWrapper.h"
+#include "QCMerger/Merger.h"
+#include <FairMQLogger.h>
+#include <TMessage.h> // object serialization
+#include <memory>  // std::unique_ptr
+#include <cstring> // memcpy
+#include <string>  // std::string
+#include <utility> // std::forward
+#include <iostream>
+
+using DataProcessorSpec = o2::framework::DataProcessorSpec;
+using Inputs = o2::framework::Inputs;
+using Outputs = o2::framework::Outputs;
+using Options = o2::framework::Options;
+using InputSpec = o2::framework::InputSpec;
+using OutputSpec = o2::framework::OutputSpec;
+using AlgorithmSpec = o2::framework::AlgorithmSpec;
+using InitContext = o2::framework::InitContext;
+using ProcessingContext = o2::framework::ProcessingContext;
+using VariantType = o2::framework::VariantType;
+
+namespace o2 {
+namespace qc {
+
+/// create a processor spec for a ROOT object merger
+/// processor is interfacing the common merger of the QC module
+/// as actual worker class
+DataProcessorSpec getRootObjectMergerSpec() {
+  using DataHeader = o2::Header::DataHeader;
+
+  // merger instance to be used in the processing function
+  auto merger = new Merger(10);
+
+  // set up the processing function
+  // using by-copy capture of the worker instance pointer; the actual variable
+  // in this function will come out of scope => no by-reference capture
+  // FIXME: the object is not cleaned up in the end, framework functionality
+  // going to be added soon
+  auto processingFct = [merger] (ProcessingContext &pc) {
+    for (auto & input : pc.inputs()) {
+      auto dh = o2::Header::get<const DataHeader>(input.header);
+      std::cout << dh->dataOrigin.str
+      << " " << dh->dataDescription.str
+      << " " << dh->payloadSize
+      << std::endl;
+      auto message = std::make_unique<TMessageWrapper>(const_cast<char*>(input.payload),
+                                                       dh->payloadSize);
+      auto object = reinterpret_cast<TObject*>(message->ReadObject(message->GetClass()));
+      if (!object) continue;
+      auto merged = merger->mergeObject(object);
+      if (!merged) continue;
+      std::cout << "Merger: got merged object " << merged->GetTitle() << std::endl;
+      merged->Print();
+    }
+  };
+
+  return {
+    "qc_merger",
+    {InputSpec{"qc_producer", "QC", "ROOTOBJECT", 0, InputSpec::QA}},
+    Outputs{},
+    AlgorithmSpec(processingFct)
+  };
+}
+
+}
+}

--- a/Utilities/QC/Workflow/src/RootObjectMergerSpec.h
+++ b/Utilities/QC/Workflow/src/RootObjectMergerSpec.h
@@ -1,0 +1,21 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ROOTOBJECTMERGERSPEC_H
+#define ROOTOBJECTMERGERSPEC_H
+
+#include "Framework/DataProcessorSpec.h"
+
+namespace o2 {
+namespace qc {
+  o2::framework::DataProcessorSpec getRootObjectMergerSpec();
+}
+}
+#endif //ROOTOBJECTMERGERSPEC_H

--- a/Utilities/QC/Workflow/src/RootObjectProducerSpec.cxx
+++ b/Utilities/QC/Workflow/src/RootObjectProducerSpec.cxx
@@ -1,0 +1,170 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   RootObjectProducerSpec.cxx
+/// @author Matthias Richter
+/// @since  2017-11-10
+/// @brief  Processor spec for a test data producer for ROOT objects
+
+#include "RootObjectProducerSpec.h"
+#include "QCProducer/Producer.h"
+#include "QCProducer/TH1Producer.h"
+#include "QCProducer/TH2Producer.h"
+#include "QCProducer/TH3Producer.h"
+#include "QCProducer/THnProducer.h"
+#include "QCProducer/TreeProducer.h"
+#include "Framework/DataProcessorSpec.h"
+#include <FairMQLogger.h>
+#include <TMessage.h> // object serialization
+#include <memory>  // std::unique_ptr
+#include <cstring> // memcpy
+#include <string>  // std::string
+#include <utility> // std::forward
+#include <stdexcept> // std::runtime_error
+#include <type_traits>  // std::conditional
+
+using DataProcessorSpec = o2::framework::DataProcessorSpec;
+using Inputs = o2::framework::Inputs;
+//using Outputs = o2::framework::Outputs;
+using Options = o2::framework::Options;
+using OutputSpec = o2::framework::OutputSpec;
+using AlgorithmSpec = o2::framework::AlgorithmSpec;
+using InitContext = o2::framework::InitContext;
+using ProcessingContext = o2::framework::ProcessingContext;
+using VariantType = o2::framework::VariantType;
+
+namespace o2 {
+namespace qc {
+
+// the namespace for internal implementations
+namespace impl {
+  // dummy class with variable number of parameters to allow conditional compilation
+  class NeverCalled : public Producer {
+  public:
+    template<typename... Args>
+    NeverCalled(Args&&...) {
+      throw std::runtime_error("incorrect number of parameters provided in createProducer call");
+    }
+    TObject* produceData() const override {return nullptr;}
+  };
+
+  // helper trait for conditional compilation depending on number of parameters
+  template<typename T, size_t N, typename... Args>
+  struct conditional {
+    using type = typename std::conditional<sizeof...(Args) == N, T, impl::NeverCalled>::type;
+  };
+
+  // create the producer instance for given type
+  template<typename T, typename... Args>
+  Producer* createProducer(const char* type, Args&&... args) {
+    LOG(INFO) << "Producing objects of type " << type;
+    return new T(std::forward<Args>(args)...);
+  }
+}
+
+template<typename... Args>
+Producer* createProducer(const char* type, Args&&... args) {
+  if (std::string(type).compare("TH1F") == 0) {
+    using ProducerType = typename impl::conditional<TH1Producer, 3, Args...>::type;
+    return impl::createProducer<ProducerType>(type, std::forward<Args>(args)...);
+  } else if (std::string(type).compare("TH2F") == 0) {
+    using ProducerType = typename impl::conditional<TH2Producer, 3, Args...>::type;
+    return impl::createProducer<ProducerType>(type, std::forward<Args>(args)...);
+  } else if (std::string(type).compare("TH3F") == 0) {
+    using ProducerType = typename impl::conditional<TH3Producer, 3, Args...>::type;
+    return impl::createProducer<ProducerType>(type, std::forward<Args>(args)...);
+  } else if (std::string(type).compare("THnF") == 0) {
+    using ProducerType = typename impl::conditional<THnProducer, 3, Args...>::type;
+    return impl::createProducer<ProducerType>(type, std::forward<Args>(args)...);
+  } else if (std::string(type).compare("TTree") == 0) {
+    using ProducerType = typename impl::conditional<TreeProducer, 4, Args...>::type;
+    return impl::createProducer<ProducerType>(type, std::forward<Args>(args)...);
+  }
+  LOG(ERROR) << "Unknown type of producer: " << type;
+  return nullptr;
+}
+
+/// create a processor spec for a test producer
+/// the processor is interfacing the test producer classes of the QCProducer
+/// module as worker classes.
+///
+/// The processor spec defines the following options to configure the worker
+/// classes:
+///   --objectType          Type of object: TH1F, TH2F, TH3F, THnF, TTree
+///   --objectName          Name of the produced object
+///   --objectTitle         Title of the produced object
+///   --nBins               Number of bins for histogram objects
+///   --nBranches           Number of branches in tree object
+///   --nTreeEntries        Number of entries in tree object
+DataProcessorSpec getRootObjectProducerSpec() {
+  return {
+    "qc_producer",
+    Inputs{},
+    {
+      OutputSpec{"QC", "ROOTOBJECT", 0, OutputSpec::QA}
+    },
+    AlgorithmSpec{
+      [](InitContext &ic) {
+        // get the option from the init context
+        Producer* producer = nullptr;
+        auto type = ic.options().get<std::string>("objectType");
+        auto name = ic.options().get<std::string>("objectName");
+        auto title = ic.options().get<std::string>("objectTitle");
+        if (type != "TTree") {
+          auto nBins = ic.options().get<int>("nBins");
+          producer = createProducer(type.c_str(), name.c_str(), title.c_str(), nBins);
+        } else {
+          auto nBranches = ic.options().get<int>("nBranches");
+          auto nTreeEntries = ic.options().get<int>("nTreeEntries");
+          producer = createProducer(type.c_str(), name.c_str(), title.c_str(), nBranches, nTreeEntries);
+        }
+
+        if (!producer) {
+          throw std::runtime_error("failed to create producer instance");
+        }
+
+        // set up the processing function
+        // using by-copy capture of the worker instance pointer; the actual variable
+        // in this function will come out of scope => no by-reference capture
+        // FIXME: the object is not cleaned up in the end, framework functionality
+        // going to be added soon
+        auto processingFct = [producer] (ProcessingContext &pc) {
+          // get a new object
+          auto dataobject = std::unique_ptr<TObject>(producer->produceData());
+          // serialize the object using TMessage
+          auto serialized = std::make_unique<TMessage>(kMESS_OBJECT);
+          serialized->WriteObject(dataobject.get());
+
+          // allocate the target and copy the data
+          auto tgt = pc.allocator().newChunk(OutputSpec{"QC", "ROOTOBJECT", 0, OutputSpec::QA},
+                                             serialized->BufferSize());
+          // FIXME: didn't check if TMessage supports move semantics nowadays
+          // NOTE: framework functionality going to be developed for ROOT objects
+          memcpy(tgt.data, serialized->Buffer(), tgt.size);
+        };
+
+        // return the actual processing function as a lambda function using variables
+        // of the init function
+        return processingFct;
+      }
+    },
+    Options{
+      {"objectType", VariantType::String, "", "Type of the produced histogram"},
+      {"objectName", VariantType::String, "", "Name of the produced histogram"},
+      {"objectTitle", VariantType::String, "", "Title of the produced histogram"},
+      {"nBins", VariantType::Int, -1, "Number of bins in histogram"},
+      {"nBranches", VariantType::Int, -1, "Number of branches in tree"},
+      {"nTreeEntries", VariantType::Int, -1, "Number of entries in tree"},
+    }
+  };
+}
+
+}
+}

--- a/Utilities/QC/Workflow/src/RootObjectProducerSpec.h
+++ b/Utilities/QC/Workflow/src/RootObjectProducerSpec.h
@@ -1,0 +1,21 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ROOTOBJECTPRODUCERSPEC_H
+#define ROOTOBJECTPRODUCERSPEC_H
+
+#include "Framework/DataProcessorSpec.h"
+
+namespace o2 {
+namespace qc {
+  o2::framework::DataProcessorSpec getRootObjectProducerSpec();
+}
+}
+#endif //ROOTOBJECTPRODUCERSPEC_H

--- a/Utilities/QC/Workflow/src/SimpleMergerWorkflow.cxx
+++ b/Utilities/QC/Workflow/src/SimpleMergerWorkflow.cxx
@@ -1,0 +1,31 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   SimpleMergerWorkflow
+/// @author Matthias Richter
+/// @since  2017-11-10
+/// @brief  A workflow definition for a simple ROOT object merger example
+
+#include "Framework/WorkflowSpec.h"
+#include "Framework/runDataProcessing.h"
+#include "RootObjectProducerSpec.h"
+#include "RootObjectMergerSpec.h"
+
+using namespace o2::framework;
+
+/// This function is required to be implemented to define the workflow
+/// specifications
+///
+/// The example connects a producer for ROOT objects with a merger process
+void defineDataProcessing(WorkflowSpec &specs) {
+  specs.clear();
+  specs.emplace_back(o2::qc::getRootObjectProducerSpec());
+  specs.emplace_back(o2::qc::getRootObjectMergerSpec());
+}

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -627,6 +627,18 @@ o2_define_bucket(
 
 o2_define_bucket(
     NAME
+    QC_workflow_bucket
+
+    DEPENDENCIES
+    QCProducer
+    QCMerger
+    Framework
+
+    INCLUDE_DIRECTORIES
+   )
+
+o2_define_bucket(
+    NAME
     QC_test_bucket
 
     DEPENDENCIES


### PR DESCRIPTION
Setup consists of:
- QCProducerSpec interfacing the four Producer classes of QCProducer module
  available options:
  --objectType TH2F
  --objectName <name>
  --objectTitle <title>
  --nBins <n>
  --nBranches <n>
  --nTreeEntries <n>

- QCMergerSpec interfacing Merger from QCMerger module
  no options at the moment
