### PR TITLE
QCProducer: bugfix - storing string parameters correctly

### DIFF
--- a/Utilities/QC/QCProducer/include/QCProducer/TH1Producer.h
+++ b/Utilities/QC/QCProducer/include/QCProducer/TH1Producer.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "Producer.h"
+#include <string>
 
 namespace o2
 {
@@ -23,8 +24,8 @@ class TH1Producer : public Producer
   TObject* produceData() const override;
 
  private:
-  const char* mHistogramName;
-  const char* mHistogramTitle;
+  std::string mHistogramName;
+  std::string mHistogramTitle;
 
   const int mBeansNumber;
   const double mXLow{ -10 };

--- a/Utilities/QC/QCProducer/include/QCProducer/TH2Producer.h
+++ b/Utilities/QC/QCProducer/include/QCProducer/TH2Producer.h
@@ -13,6 +13,7 @@
 #include <Rtypes.h>
 
 #include "Producer.h"
+#include <string>
 
 namespace o2
 {
@@ -25,8 +26,8 @@ class TH2Producer : public Producer
   TObject* produceData() const override;
 
  private:
-  const char* mHistogramName;
-  const char* mHistogramTitle;
+  std::string mHistogramName;
+  std::string mHistogramTitle;
 
   const Int_t mNbinsx;
   const Int_t mNbinsy;

--- a/Utilities/QC/QCProducer/include/QCProducer/TH3Producer.h
+++ b/Utilities/QC/QCProducer/include/QCProducer/TH3Producer.h
@@ -13,6 +13,7 @@
 #include <Rtypes.h>
 
 #include "Producer.h"
+#include <string>
 
 namespace o2
 {
@@ -25,8 +26,8 @@ class TH3Producer : public Producer
   TObject* produceData() const override;
 
  private:
-  const char* mHistogramName;
-  const char* mHistogramTitle;
+  std::string mHistogramName;
+  std::string mHistogramTitle;
 
   const Int_t mNbinsx;
   const Int_t mNbinsy;

--- a/Utilities/QC/QCProducer/include/QCProducer/THnProducer.h
+++ b/Utilities/QC/QCProducer/include/QCProducer/THnProducer.h
@@ -13,6 +13,7 @@
 #include <Rtypes.h>
 
 #include "Producer.h"
+#include <string>
 
 namespace o2
 {
@@ -26,8 +27,8 @@ class THnProducer : public Producer
 
  private:
   const int mBins;
-  const char* mHistogramName;
-  const char* mHistogramTitle;
+  std::string mHistogramName;
+  std::string mHistogramTitle;
 };
 }
 }

--- a/Utilities/QC/QCProducer/include/QCProducer/TreeProducer.h
+++ b/Utilities/QC/QCProducer/include/QCProducer/TreeProducer.h
@@ -13,6 +13,7 @@
 #include <TTree.h>
 
 #include "QCProducer/Producer.h"
+#include <string>
 
 namespace o2
 {
@@ -26,8 +27,8 @@ class TreeProducer : public Producer
   TObject* produceData() const override;
 
  private:
-  const char* mTreeName;
-  const char* mTreeTitle;
+  std::string mTreeName;
+  std::string mTreeTitle;
   const int mNumberOfBranches;
   const int mNumberOfEntriesInEachBranch;
 

--- a/Utilities/QC/QCProducer/src/TH1Producer.cxx
+++ b/Utilities/QC/QCProducer/src/TH1Producer.cxx
@@ -25,7 +25,7 @@ TH1Producer::TH1Producer(const char* histogramName, const char* histogramTitle, 
 
 TObject* TH1Producer::produceData() const
 {
-  auto* histogram = new TH1F(mHistogramName, mHistogramTitle, mBeansNumber, mXLow, mXUp);
+  auto* histogram = new TH1F(mHistogramName.c_str(), mHistogramTitle.c_str(), mBeansNumber, mXLow, mXUp);
   histogram->FillRandom("gaus", 1000);
 
   return histogram;

--- a/Utilities/QC/QCProducer/src/TH2Producer.cxx
+++ b/Utilities/QC/QCProducer/src/TH2Producer.cxx
@@ -26,7 +26,7 @@ TH2Producer::TH2Producer(const char* histogramName, const char* histogramTitle, 
 
 TObject* TH2Producer::produceData() const
 {
-  auto* histogram = new TH2F(mHistogramName, mHistogramTitle, mNbinsx, mXlow, mXup, mNbinsy, mYlow, mYup);
+  auto* histogram = new TH2F(mHistogramName.c_str(), mHistogramTitle.c_str(), mNbinsx, mXlow, mXup, mNbinsy, mYlow, mYup);
 
   for (int i = 0; i < mNbinsx; ++i) {
     for (int j = 0; j < mNbinsy; ++j) {

--- a/Utilities/QC/QCProducer/src/TH3Producer.cxx
+++ b/Utilities/QC/QCProducer/src/TH3Producer.cxx
@@ -27,7 +27,7 @@ TH3Producer::TH3Producer(const char* histogramName, const char* histogramTitle, 
 TObject* TH3Producer::produceData() const
 {
   auto* histogram =
-    new TH3F(mHistogramName, mHistogramTitle, mNbinsx, mXlow, mXup, mNbinsy, mYlow, mYup, mNbinsz, mZlow, mZup);
+    new TH3F(mHistogramName.c_str(), mHistogramTitle.c_str(), mNbinsx, mXlow, mXup, mNbinsy, mYlow, mYup, mNbinsz, mZlow, mZup);
 
   Double_t x, y, z;
 

--- a/Utilities/QC/QCProducer/src/THnProducer.cxx
+++ b/Utilities/QC/QCProducer/src/THnProducer.cxx
@@ -32,7 +32,7 @@ TObject* THnProducer::produceData() const
   const Int_t valuesNumber = 1000;
   auto* values = new Double_t[valuesNumber];
 
-  auto* histogram = new THnF(mHistogramName, mHistogramTitle, dim, bins, xmin, xmax);
+  auto* histogram = new THnF(mHistogramName.c_str(), mHistogramTitle.c_str(), dim, bins, xmin, xmax);
 
   for (int i = 0; i < dim; ++i) {
     for (int j = 0; j < valuesNumber; ++j) {

--- a/Utilities/QC/QCProducer/src/TreeProducer.cxx
+++ b/Utilities/QC/QCProducer/src/TreeProducer.cxx
@@ -33,7 +33,7 @@ TreeProducer::TreeProducer(const char* treeName, const char* treeTitle, const in
 
 TObject* TreeProducer::produceData() const
 {
-  auto* tree = new TTree(mTreeName, mTreeTitle);
+  auto* tree = new TTree(mTreeName.c_str(), mTreeTitle.c_str());
 
   for (int i = 0; i < mNumberOfBranches; ++i) {
     createBranch(tree, i);


### PR DESCRIPTION
store string parameters in members of type std::string instead of raw
const char pointers from the program options