### PR TITLE
Introducing option groups for processing specs and forwarding --rate to device

### DIFF
--- a/Framework/Core/include/Framework/ConfigParamsHelper.h
+++ b/Framework/Core/include/Framework/ConfigParamsHelper.h
@@ -35,8 +35,12 @@ template<typename ContainerType>
 boost::program_options::options_description
 prepareOptionDescriptions(const ContainerType &workflow)
 {
-  boost::program_options::options_description specOptions("Spec options");
+  boost::program_options::options_description specOptions("Spec groups");
   for (const auto & spec : workflow) {
+    std::string help = "Usage: --" + spec.name + R"( "spec options")";
+    specOptions.add_options()(spec.name.c_str(),
+                              boost::program_options::value<std::string>(),
+                              help.c_str());
     boost::program_options::options_description options(spec.name.c_str());
     if (prepareOptionsDescription(spec.options, options)) {
       specOptions.add(options);

--- a/Framework/Core/include/Framework/DeviceSpec.h
+++ b/Framework/Core/include/Framework/DeviceSpec.h
@@ -31,6 +31,7 @@ namespace framework {
 /// Concrete description of the device which will actually run 
 /// a DataProcessor.
 struct DeviceSpec {
+  std::string name;
   std::string id;
   std::vector<InputChannelSpec> inputChannels;
   std::vector<OutputChannelSpec> outputChannels;

--- a/Framework/Core/src/DeviceSpecHelpers.h
+++ b/Framework/Core/src/DeviceSpecHelpers.h
@@ -20,6 +20,7 @@
 #include "Framework/ConfigParamSpec.h"
 #include "Framework/OutputRoute.h"
 #include "WorkflowHelpers.h"
+#include <boost/program_options.hpp>
 
 #include <vector>
 #include <string>
@@ -77,6 +78,10 @@ struct DeviceSpecHelpers {
         const WorkflowSpec &workflow,
         const std::vector<LogicalForwardInfo> &availableForwardsInfo
   );
+
+  /// return a description of all options to be forwarded to the device
+  /// by default
+  static boost::program_options::options_description getForwardedDeviceOptions();
 };
 
 }

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -365,6 +365,9 @@ int doMain(int argc, char **argv, const o2::framework::WorkflowSpec & specs) {
      bpo::value<bool>()->zero_tokens()->default_value(false),
      "create DDS configuration");
 
+  // some of the options must be forwarded by default to the device
+  executorOptions.add(DeviceSpecHelpers::getForwardedDeviceOptions());
+
   // FIXME: acquire those options from the code generating the child options
   bpo::options_description hiddenOptions("Hidden child options");
   hiddenOptions.add_options()


### PR DESCRIPTION
The options defined in a `ProcessorSpec` can now be grouped together on the command line,
an option is created from the spec name, e.g. 
`--my_spec_name  "--myoption1 arg myoption2 arg --rate 1"`
will forward the options only to devices of spec `my_spec_name`

Rate control for ConditionalRun is going to be introduced to FairMQDevice in PR
https://github.com/FairRootGroup/FairRoot/pull/675, option `--rate` is now forwarded.
