### PR TITLE
Minor bug fixes and improvements for TPC digitization

### DIFF
--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitTime.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitTime.h
@@ -79,7 +79,7 @@ class DigitTime{
 
   private:
     float                   mTotalChargeTimeBin;        ///< Total accumulated charge in that time bin
-    unsigned short          mTimeBin;                   ///< Time bin of that ADC value
+    unsigned int            mTimeBin;                   ///< Time bin of that ADC value
     std::vector <std::unique_ptr<DigitRow>> mRows;      ///< Row Container for the ADC value
 };
 

--- a/Detectors/TPC/simulation/src/DigitCRU.cxx
+++ b/Detectors/TPC/simulation/src/DigitCRU.cxx
@@ -40,7 +40,7 @@ void DigitCRU::setDigit(size_t hitID, int timeBin, int row, int pad, float charg
   }
   else {
     const Mapper& mapper = Mapper::instance();
-    mTimeBins[mEffectiveTimeBin] = std::unique_ptr<DigitTime> (new DigitTime(timeBin, mapper.getPadRegionInfo(CRU(mCRU).region()).getNumberOfPadRows()));
+    mTimeBins[mEffectiveTimeBin] = std::make_unique<DigitTime> (timeBin, mapper.getPadRegionInfo(CRU(mCRU).region()).getNumberOfPadRows());
     mTimeBins[mEffectiveTimeBin]->setDigit(hitID, mCRU, row, pad, charge);
   }
 }

--- a/Detectors/TPC/simulation/src/DigitRow.cxx
+++ b/Detectors/TPC/simulation/src/DigitRow.cxx
@@ -25,7 +25,7 @@ void DigitRow::setDigit(size_t hitID, int pad, float charge)
     mPads[pad]->setDigit(hitID, charge);
   }
   else{
-    mPads[pad] = std::unique_ptr<DigitPad> (new DigitPad(pad));
+    mPads[pad] = std::make_unique<DigitPad> (pad);
     mPads[pad]->setDigit(hitID, charge);
   }
 }

--- a/Detectors/TPC/simulation/src/DigitTime.cxx
+++ b/Detectors/TPC/simulation/src/DigitTime.cxx
@@ -27,7 +27,7 @@ void DigitTime::setDigit(size_t hitID, int cru, int row, int pad, float charge)
   }
   else{
     const Mapper& mapper = Mapper::instance();
-    mRows[row] = std::unique_ptr<DigitRow> (new DigitRow(row, mapper.getPadRegionInfo(CRU(cru).region()).getPadsInRowRegion(row)));
+    mRows[row] = std::make_unique<DigitRow> (row, mapper.getPadRegionInfo(CRU(cru).region()).getPadsInRowRegion(row));
     mRows[row]->setDigit(hitID, pad, charge);
   }
   mTotalChargeTimeBin+=charge;

--- a/Detectors/TPC/simulation/src/ElectronTransport.cxx
+++ b/Detectors/TPC/simulation/src/ElectronTransport.cxx
@@ -13,6 +13,7 @@
 /// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
 
 #include "TPCSimulation/ElectronTransport.h"
+#include "TPCBase/ParameterDetector.h"
 
 #include <cmath>
 
@@ -32,8 +33,9 @@ ElectronTransport::~ElectronTransport()
 GlobalPosition3D ElectronTransport::getElectronDrift(GlobalPosition3D posEle)
 {
   const static ParameterGas &gasParam = ParameterGas::defaultInstance();
+  const static ParameterDetector &detParam = ParameterDetector::defaultInstance();
   /// For drift lengths shorter than 1 mm, the drift length is set to that value
-  float driftl = posEle.Z();
+  float driftl = std::abs(detParam.getTPClength()-posEle.Z());
   if(driftl<0.01) {
     driftl=0.01;
   }

--- a/Detectors/TPC/simulation/src/PadResponse.cxx
+++ b/Detectors/TPC/simulation/src/PadResponse.cxx
@@ -29,9 +29,9 @@ PadResponse::PadResponse()
     mOROC12(),
     mOROC3()
 {
-  mIROC   = std::unique_ptr<TGraph2D> (new TGraph2D());
-  mOROC12 = std::unique_ptr<TGraph2D> (new TGraph2D());
-  mOROC3  = std::unique_ptr<TGraph2D> (new TGraph2D());
+  mIROC   = std::make_unique<TGraph2D>();
+  mOROC12 = std::make_unique<TGraph2D>();
+  mOROC3  = std::make_unique<TGraph2D>();
   
   importPRF("PRF_IROC.dat", mIROC);
   importPRF("PRF_OROC1-2.dat", mOROC12);

--- a/Detectors/TPC/simulation/test/testTPCElectronTransport.cxx
+++ b/Detectors/TPC/simulation/test/testTPCElectronTransport.cxx
@@ -18,6 +18,7 @@
 #include <boost/test/unit_test.hpp>
 #include "TPCSimulation/ElectronTransport.h"
 #include "TPCBase/ParameterGas.h"
+#include "TPCBase/ParameterDetector.h"
 
 #include "TH1D.h"
 #include "TF1.h"
@@ -34,7 +35,8 @@ namespace TPC {
   BOOST_AUTO_TEST_CASE(ElectronDiffusion_test1)
   {
     const static ParameterGas &gasParam = ParameterGas::defaultInstance();
-    const GlobalPosition3D posEle(10.f, 10.f, 250.f);
+    const static ParameterDetector &detParam = ParameterDetector::defaultInstance();
+    const GlobalPosition3D posEle(10.f, 10.f, 10.f);
     TH1D hTestDiffX("hTestDiffX", "", 500, posEle.X()-10., posEle.X()+10.);
     TH1D hTestDiffY("hTestDiffY", "", 500, posEle.Y()-10., posEle.Y()+10.);
     TH1D hTestDiffZ("hTestDiffZ", "", 500, posEle.Z()-10., posEle.Z()+10.);
@@ -62,8 +64,8 @@ namespace TPC {
     BOOST_CHECK_CLOSE(gausZ.GetParameter(1), posEle.Z(), 0.5);
     
     // check whether the width of the distribution matches the expected one
-    const float sigT = std::sqrt(posEle.Z()) * gasParam.getDiffT();
-    const float sigL = std::sqrt(posEle.Z()) * gasParam.getDiffL();
+    const float sigT = std::sqrt(detParam.getTPClength()-posEle.Z()) * gasParam.getDiffT();
+    const float sigL = std::sqrt(detParam.getTPClength()-posEle.Z()) * gasParam.getDiffL();
         
     BOOST_CHECK_CLOSE(gausX.GetParameter(2), sigT, 0.5);
     BOOST_CHECK_CLOSE(gausY.GetParameter(2), sigT, 0.5);
@@ -79,7 +81,8 @@ namespace TPC {
   BOOST_AUTO_TEST_CASE(ElectronDiffusion_test2)
   {
     const static ParameterGas &gasParam = ParameterGas::defaultInstance();
-    const GlobalPosition3D posEle(1.f, 1.f, 1.f);
+    const static ParameterDetector &detParam = ParameterDetector::defaultInstance();
+    const GlobalPosition3D posEle(1.f, 1.f, detParam.getTPClength()-1.f);
     TH1D hTestDiffX("hTestDiffX", "", 500, posEle.X()-1., posEle.X()+1.);
     TH1D hTestDiffY("hTestDiffY", "", 500, posEle.Y()-1., posEle.Y()+1.);
     TH1D hTestDiffZ("hTestDiffZ", "", 500, posEle.Z()-1., posEle.Z()+1.);


### PR DESCRIPTION
- Bug fix for electron drift (proper drift distance)
- Bug fix for digit containers (short instead of int prevented simulation of more than ~65k time bins)
- Use make_unique where applicable instead of unique_ptr<> (new ...)