### PR TITLE
Improve API for creating and receiving messages 

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -70,6 +70,7 @@ set(TEST_SRCS
       test/test_BoostOptionsRetriever.cxx
       test/test_Collections.cxx
       test/test_DataRelayer.cxx
+      test/test_DataRefUtils.cxx
       test/test_DeviceMetricsInfo.cxx
       test/test_DeviceSpec.cxx
       test/test_FrameworkDataFlowToDDS.cxx

--- a/Framework/Core/README.md
+++ b/Framework/Core/README.md
@@ -442,20 +442,14 @@ that only  messages for declared  outputs can be created.  The `DataAllocator`
 provides methods  to create and adopt  data in a number  of formats. Currently
 supported formats are:
 
-- Vanilla `char *` buffers with associated size
-- TClonesArray (which gets serialised to a TMessage for exchange)
-- PoD collection, as  defined in `Framework/Collection.h` .  The available API
-  is the following:
-
-
-    class DataAllocator {
-    public:
-      ...
-      DataChunk newChunk(const OutputSpec &, size_t);
-      DataChunk adoptChunk(const OutputSpec &, char *, size_t, fairmq_free_fn*, void *);
-      TClonesArray &newTClonesArray(const OutputSpec &, const char *, size_t);
-      template <class T>  Collection<T> newCollectionChunk(const OutputSpec &spec, size_t nElements);
-    };
+- Vanilla `char *` buffers with associated size. This is the actual contents of
+  the FairMQ message.
+- POD types. These get directly mapped on the message exchanged by FairMQ and 
+  are therefore "zerocopy" for what the DataProcessingLayer is concerned.
+- POD collections, as defined in `Framework/Collection.h`
+- TObject derived classes. These are actually serialised via a TMessage
+  and therefore are only suitable for the cases in which the cost of such a 
+  serialization is not an issue.
 
 The DataChunk object resembles a `iovec`:
 

--- a/Framework/Core/include/Framework/DataAllocator.h
+++ b/Framework/Core/include/Framework/DataAllocator.h
@@ -15,19 +15,21 @@
 #include "Framework/OutputRoute.h"
 #include "Framework/DataChunk.h"
 #include "Framework/Collection.h"
+#include "Framework/MessageContext.h"
+#include "Framework/RootObjectContext.h"
+#include "Framework/TMessageSerializer.h"
+#include "fairmq/FairMQMessage.h"
 
 #include <vector>
 #include <map>
 #include <string>
 #include <utility>
+#include <type_traits>
 
-class TClonesArray;
+#include <TClass.h>
 
 namespace o2 {
 namespace framework {
-
-class MessageContext;
-class RootObjectContext;
 
 /// This allocator is responsible to make sure that the messages created match
 /// the provided spec and that depending on how many pipelined reader we
@@ -45,20 +47,56 @@ public:
                 MessageContext *context,
                 RootObjectContext *rootContext,
                 const AllowedOutputsMap &outputs);
+
   DataChunk newChunk(const OutputSpec &, size_t);
   DataChunk adoptChunk(const OutputSpec &, char *, size_t, fairmq_free_fn*, void *);
-  TClonesArray &newTClonesArray(const OutputSpec &, const char *, size_t);
 
-  template <class T>
-  Collection<T> newCollectionChunk(const OutputSpec &spec, size_t nElements) {
-    static_assert(std::is_pod<T>::value == true, "Type must be a PoD");
+  // In case no extra argument is provided and the passed type is a POD,
+  // the most likely wanted behavior is to create a message with that POD,
+  // and so we do.
+  template <typename T>
+  typename std::enable_if<std::is_pod<T>::value == true, T &>::type
+  make(const OutputSpec &spec) {
+    DataChunk chunk = newChunk(spec, sizeof(T));
+    return *reinterpret_cast<T>(chunk.data);
+  }
+
+  // In case an extra argument is provided, we consider this an array / 
+  // collection elements of that type
+  template <typename T>
+  typename std::enable_if<std::is_pod<T>::value == true, Collection<T>>::type
+  make(const OutputSpec &spec, size_t nElements) {
     auto size = nElements*sizeof(T);
     DataChunk chunk = newChunk(spec, size);
     return Collection<T>(chunk.data, nElements);
   }
 
+  /// Use this in case you want to leave the creation
+  /// of a TObject to be transmitted to the framework.
+  /// @a spec is the specification for the output
+  /// @a args is the arguments for the constructor of T
+  /// @return a reference to the constructed object. Such an object
+  /// will be sent to all the consumers of the output @a spec
+  /// once the processing callback completes.
+  template <typename T, typename... Args>
+  typename std::enable_if<std::is_base_of<TObject, T>::value == true, T&>::type
+  make(const OutputSpec &spec, Args... args) {
+    auto obj = new T(args...);
+    adopt(spec, obj);
+    return *obj;
+  }
+
+  /// Adopt a TObject in the framework and serialize / send
+  /// it to the consumers of @a spec once done.
+  void
+  adopt(const OutputSpec &spec, TObject*obj);
+
 private:
   std::string matchDataHeader(const OutputSpec &spec, size_t timeframeId);
+  FairMQMessagePtr headerMessageFromSpec(OutputSpec const &spec,
+                                         std::string const &channel,
+                                         o2::Header::SerializationMethod serializationMethod);
+
   FairMQDevice *mDevice;
   AllowedOutputsMap mAllowedOutputs;
   MessageContext *mContext;

--- a/Framework/Core/include/Framework/DataRefUtils.h
+++ b/Framework/Core/include/Framework/DataRefUtils.h
@@ -13,19 +13,53 @@
 #include "Framework/DataRef.h"
 #include "Framework/Collection.h"
 #include "Headers/DataHeader.h"
+#include "Framework/TMessageSerializer.h"
+#include <TClass.h>
+#include <stdexcept>
+#include <sstream>
+#include <type_traits>
 
 namespace o2 {
 namespace framework {
 
 // FIXME: Should enforce the fact that DataRefs are read only...
 struct DataRefUtils {
+  // SFINAE makes this available only for the case we are using
+  // a POD, this is to distinguish it from the alternative below,
+  // which works for TObject (which are serialised).
   template <typename T>
-  static Collection<T> as(const DataRef &ref) {
+  static typename std::enable_if<std::is_pod<T>::value == true, Collection<T>>::type
+  as(DataRef const &ref) {
     using DataHeader = o2::Header::DataHeader;
     auto header = o2::Header::get<const DataHeader>(ref.header);
     assert((header->payloadSize % sizeof(T)) == 0);
     //FIXME: provide a const collection
     return Collection<T>(reinterpret_cast<void *>(const_cast<char *>(ref.payload)), header->payloadSize/sizeof(T));
+  }
+
+  // See above. SFINAE allows us to use this to extract a TObject with 
+  // a somewhat uniform API.
+  template <typename T>
+  static typename std::enable_if<std::is_base_of<TObject, T>::value == true, std::unique_ptr<T>>::type
+  as(DataRef const &ref) {
+    using DataHeader = o2::Header::DataHeader;
+    auto header = o2::Header::get<const DataHeader>(ref.header);
+    if (header->payloadSerializationMethod != o2::Header::gSerializationMethodROOT) {
+      throw std::runtime_error("Attempt to extract a TMessage from non-ROOT serialised message");
+    }
+
+    o2::framework::FairTMessage ftm(const_cast<char *>(ref.payload), header->payloadSize);
+    auto cobj = ftm.ReadObject(ftm.GetClass());
+    std::unique_ptr<T> result;
+    result.reset(dynamic_cast<T*>(cobj));
+    if (result.get() == nullptr) {
+      std::ostringstream ss;
+      ss << "Attempting to extract a " << T::Class()->GetName() 
+         << " but a " << cobj->ClassName()
+         << " is actually stored which cannot be casted to the requested one.";
+      throw std::runtime_error(ss.str());
+    }
+    return std::move(result);
   }
 };
 

--- a/Framework/Core/include/Framework/TMessageSerializer.h
+++ b/Framework/Core/include/Framework/TMessageSerializer.h
@@ -10,6 +10,8 @@
 #ifndef FRAMEWORK_TMESSAGESERIALIZER_H
 #define FRAMEWORK_TMESSAGESERIALIZER_H
 
+#include <fairmq/FairMQMessage.h>
+
 #include <TMessage.h>
 #include <TClonesArray.h>
 
@@ -34,17 +36,17 @@ static void free_tmessage(void* /*data*/, void* hint)
 
 struct TMessageSerializer
 {
-  void Serialize(FairMQMessage& msg, TClonesArray* input)
+  void Serialize(FairMQMessage& msg, TObject* input)
   {
     TMessage* tm = new TMessage(kMESS_OBJECT);
     tm->WriteObject(static_cast<TObject *>(input));
     msg.Rebuild(tm->Buffer(), tm->BufferSize(), free_tmessage, tm);
   }
 
-  void Deserialize(FairMQMessage& msg, TClonesArray*& output)
+  void Deserialize(FairMQMessage& msg, TObject*& output)
   {
     FairTMessage tm(msg.GetData(), msg.GetSize());
-    output = reinterpret_cast<TClonesArray*>(tm.ReadObject(tm.GetClass()));
+    output = reinterpret_cast<TObject*>(tm.ReadObject(tm.GetClass()));
   }
 };
 

--- a/Framework/Core/src/DataProcessor.cxx
+++ b/Framework/Core/src/DataProcessor.cxx
@@ -12,7 +12,6 @@
 #include "Framework/MessageContext.h"
 #include "Framework/TMessageSerializer.h"
 #include "Headers/DataHeader.h"
-#include <TClonesArray.h>
 #include <fairmq/FairMQParts.h>
 #include <fairmq/FairMQDevice.h>
 
@@ -35,20 +34,20 @@ void DataProcessor::doSend(FairMQDevice &device, MessageContext &context) {
 }
 
 void DataProcessor::doSend(FairMQDevice &device, RootObjectContext &context) {
-  for (auto &message : context) {
-    assert(message.payload.get());
+  for (auto &messageRef : context) {
+    assert(messageRef.payload.get());
     FairMQParts parts;
     FairMQMessagePtr payload(device.NewMessage());
-    TClonesArray *a = reinterpret_cast<TClonesArray*>(message.payload.get());
+    auto a = messageRef.payload.get();
     device.Serialize<TMessageSerializer>(*payload, a);
-    const DataHeader *cdh = o2::Header::get<DataHeader>(message.header->GetData());
+    const DataHeader *cdh = o2::Header::get<DataHeader>(messageRef.header->GetData());
     // sigh... See if we can avoid having it const by not
     // exposing it to the user in the first place.
     DataHeader *dh = const_cast<DataHeader *>(cdh);
     dh->payloadSize = payload->GetSize();
-    parts.AddPart(std::move(message.header));
+    parts.AddPart(std::move(messageRef.header));
     parts.AddPart(std::move(payload));
-    device.Send(parts, message.channel, 0);
+    device.Send(parts, messageRef.channel, 0);
   }
 }
 

--- a/Framework/Core/src/FrameworkGUIDebugger.cxx
+++ b/Framework/Core/src/FrameworkGUIDebugger.cxx
@@ -236,8 +236,7 @@ displayDeviceHistograms(const std::vector<DeviceInfo> &infos,
   ImGui::SetNextWindowPos(ImVec2(0, ImGui::GetIO().DisplaySize.y - 300), 0);
   ImGui::SetNextWindowSize(ImVec2(ImGui::GetIO().DisplaySize.x, 300), 0);
 
-  // Calculate the unique set of metrics, as available in the metrics
-  // service
+  // Calculate the unique set of metrics, as available in the metrics service
   std::set<std::string> allMetricsNames;
   for (const auto &metricsInfo : metricsInfos) {
     for (const auto &labelsPairs : metricsInfo.metricLabelsIdx) {

--- a/Framework/Core/src/InputRecord.cxx
+++ b/Framework/Core/src/InputRecord.cxx
@@ -24,10 +24,10 @@ InputRecord::InputRecord(std::vector<InputRoute> const &inputsSchema,
 }
 
 int
-InputRecord::getPos(const char *name) const {
+InputRecord::getPos(const char *binding) const {
   for (int i = 0; i < mInputsSchema.size(); ++i) {
     auto &route = mInputsSchema[i];
-    if (route.matcher.binding == name) {
+    if (route.matcher.binding == binding) {
       return i;
     }
   }
@@ -35,10 +35,10 @@ InputRecord::getPos(const char *name) const {
 }
 
 int
-InputRecord::getPos(std::string const &name) const {
+InputRecord::getPos(std::string const &binding) const {
   for (size_t i = 0; i < mInputsSchema.size(); ++i) {
     auto &route = mInputsSchema[i];
-    if (route.matcher.binding == name) {
+    if (route.matcher.binding == binding) {
       return i;
     }
   }

--- a/Framework/Core/test/test_DataRefUtils.cxx
+++ b/Framework/Core/test/test_DataRefUtils.cxx
@@ -1,0 +1,42 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test Framework DataRefUtils
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include "Framework/DataRefUtils.h"
+#include <boost/test/unit_test.hpp>
+#include <TMessage.h>
+#include <TObjString.h>
+
+using namespace o2::framework;
+
+// Simple test to do root deserialization.
+BOOST_AUTO_TEST_CASE(TestRootSerialization) {
+  DataRef ref;
+  TMessage* tm = new TMessage(kMESS_OBJECT);
+  auto sOrig = std::make_unique<TObjString>("test");
+  tm->WriteObject(sOrig.get());
+  o2::Header::DataHeader dh;
+  dh.payloadSerializationMethod = o2::Header::gSerializationMethodROOT;
+  ref.payload = tm->Buffer();
+  dh.payloadSize = tm->BufferSize();
+  ref.header = reinterpret_cast<char const*>(&dh);
+
+  // Check by using the same type
+  auto s = DataRefUtils::as<TObjString>(ref);
+  BOOST_CHECK_EQUAL(s->GetString(), TString("test"));
+  BOOST_CHECK_EQUAL(std::string(s->GetName()), "test");
+
+  // Check by using the base type.
+  auto o = DataRefUtils::as<TObject>(ref);
+  BOOST_CHECK_EQUAL(std::string(o->GetName()), "test");
+}

--- a/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
+++ b/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
@@ -28,7 +28,7 @@ AlgorithmSpec simplePipe(o2::Header::DataDescription what) {
   return AlgorithmSpec{
     [what](ProcessingContext &ctx)
       {
-        auto bData = ctx.allocator().newCollectionChunk<int>(OutputSpec{"TST", what, 0}, 1);
+        auto bData = ctx.allocator().make<int>(OutputSpec{"TST", what, 0}, 1);
       }
     };
 }
@@ -46,8 +46,8 @@ WorkflowSpec defineDataProcessing() {
     AlgorithmSpec{
       [](ProcessingContext &ctx) {
        sleep(1);
-       auto aData = ctx.allocator().newCollectionChunk<int>(OutputSpec{"TST", "A1", 0}, 1);
-       auto bData = ctx.allocator().newCollectionChunk<int>(OutputSpec{"TST", "A2", 0}, 1);
+       auto aData = ctx.allocator().make<int>(OutputSpec{"TST", "A1", 0}, 1);
+       auto bData = ctx.allocator().make<int>(OutputSpec{"TST", "A2", 0}, 1);
       }
     }
   },

--- a/Framework/Core/test/test_GenericSource.cxx
+++ b/Framework/Core/test/test_GenericSource.cxx
@@ -25,7 +25,7 @@ void defineDataProcessing(WorkflowSpec &specs) {
          ServiceRegistry& services,
          DataAllocator& allocator) {
        sleep(1);
-       auto aData = allocator.newCollectionChunk<int>(OutputSpec{"TST", "A1", 0}, 1);
+       auto aData = allocator.make<int>(OutputSpec{"TST", "A1", 0}, 1);
       }
     },
     Options{{"test-option", VariantType::String, "test", "A test option"}},

--- a/Framework/Core/test/test_InputRecord.cxx
+++ b/Framework/Core/test/test_InputRecord.cxx
@@ -110,9 +110,9 @@ BOOST_AUTO_TEST_CASE(TestInputRecord) {
   //
   // *static_cast<int const *>(registry.get("x").payload);
   //
-  BOOST_CHECK_EQUAL(registry.getAs<int>("x"),1);
-  BOOST_CHECK_EQUAL(registry.getAs<int>("y"),2);
+  BOOST_CHECK_EQUAL(registry.get<int>("x"),1);
+  BOOST_CHECK_EQUAL(registry.get<int>("y"),2);
   // A few more time just to make sure we are not stateful..
-  BOOST_CHECK_EQUAL(registry.getAs<int>("x"),1);
-  BOOST_CHECK_EQUAL(registry.getAs<int>("x"),1);
+  BOOST_CHECK_EQUAL(registry.get<int>("x"),1);
+  BOOST_CHECK_EQUAL(registry.get<int>("x"),1);
 }

--- a/Framework/Core/test/test_ParallelProducer.cxx
+++ b/Framework/Core/test/test_ParallelProducer.cxx
@@ -32,7 +32,7 @@ DataProcessorSpec templateProducer() {
           // Create a single output. 
           size_t index = ctx.services().get<ParallelContext>().index1D();
           sleep(1);
-          auto aData = ctx.allocator().newCollectionChunk<int>(OutputSpec{"TST", "A", index}, 1);
+          auto aData = ctx.allocator().make<int>(OutputSpec{"TST", "A", index}, 1);
           ctx.services().get<ControlService>().readyToQuit(true);
         };
       }

--- a/Framework/Core/test/test_SimpleDataProcessingDevice01.cxx
+++ b/Framework/Core/test/test_SimpleDataProcessingDevice01.cxx
@@ -44,7 +44,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
         sleep(1);
         // Creates a new message of size 1000 which
         // has "TPC" as data origin and "CLUSTERS" as data description.
-        auto tpcClusters = ctx.allocator().newCollectionChunk<FakeCluster>(OutputSpec{"TPC", "CLUSTERS", 0}, 1000);
+        auto tpcClusters = ctx.allocator().make<FakeCluster>(OutputSpec{"TPC", "CLUSTERS", 0}, 1000);
         int i = 0;
 
         for (auto &cluster : tpcClusters) {
@@ -56,7 +56,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
           i++;
         }
 
-        auto itsClusters = ctx.allocator().newCollectionChunk<FakeCluster>(OutputSpec{"ITS", "CLUSTERS", 0}, 1000);
+        auto itsClusters = ctx.allocator().make<FakeCluster>(OutputSpec{"ITS", "CLUSTERS", 0}, 1000);
         i = 0;
         for (auto &cluster : itsClusters) {
           assert(i < 1000);

--- a/Framework/Core/test/test_SingleDataSource.cxx
+++ b/Framework/Core/test/test_SingleDataSource.cxx
@@ -25,7 +25,7 @@ void defineDataProcessing(WorkflowSpec &specs) {
     AlgorithmSpec{
       [](ProcessingContext &ctx) {
        sleep(1);
-       auto aData = ctx.allocator().newCollectionChunk<int>(OutputSpec{"TST", "A1", 0}, 1);
+       auto aData = ctx.allocator().make<int>(OutputSpec{"TST", "A1", 0}, 1);
        ctx.services().get<ControlService>().readyToQuit(true);
       }
     },

--- a/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
@@ -15,7 +15,7 @@ AlgorithmSpec simplePipe(o2::Header::DataDescription what) {
   return AlgorithmSpec{
     [what](ProcessingContext &ctx)
       {
-        auto bData = ctx.allocator().newCollectionChunk<int>(OutputSpec{"TST", what, 0}, 1);
+        auto bData = ctx.allocator().make<int>(OutputSpec{"TST", what, 0}, 1);
       }
     };
 }
@@ -33,8 +33,8 @@ void defineDataProcessing(WorkflowSpec &specs) {
     AlgorithmSpec{
       [](ProcessingContext &ctx) {
        sleep(1);
-       auto aData = ctx.allocator().newCollectionChunk<int>(OutputSpec{"TST", "A1", 0}, 1);
-       auto bData = ctx.allocator().newCollectionChunk<int>(OutputSpec{"TST", "A2", 0}, 1);
+       auto aData = ctx.allocator().make<int>(OutputSpec{"TST", "A1", 0}, 1);
+       auto bData = ctx.allocator().make<int>(OutputSpec{"TST", "A2", 0}, 1);
       }
     }
   },

--- a/Framework/TestWorkflows/src/o2DummyWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DummyWorkflow.cxx
@@ -43,7 +43,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
        sleep(1);
        // Creates a new message of size 1000 which
        // has "TPC" as data origin and "CLUSTERS" as data description.
-       auto tpcClusters = ctx.allocator().newCollectionChunk<FakeCluster>(OutputSpec{"TPC", "CLUSTERS", 0}, 1000);
+       auto tpcClusters = ctx.allocator().make<FakeCluster>(OutputSpec{"TPC", "CLUSTERS", 0}, 1000);
        int i = 0;
 
        for (auto &cluster : tpcClusters) {
@@ -55,7 +55,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
          i++;
        }
 
-       auto itsClusters = ctx.allocator().newCollectionChunk<FakeCluster>(OutputSpec{"ITS", "CLUSTERS", 0}, 1000);
+       auto itsClusters = ctx.allocator().make<FakeCluster>(OutputSpec{"ITS", "CLUSTERS", 0}, 1000);
        i = 0;
        for (auto &cluster : itsClusters) {
          assert(i < 1000);
@@ -81,7 +81,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
     AlgorithmSpec{
     [](ProcessingContext &ctx)
       {
-        auto tpcSummary = ctx.allocator().newCollectionChunk<Summary>(OutputSpec{"TPC", "SUMMARY", 0}, 1);
+        auto tpcSummary = ctx.allocator().make<Summary>(OutputSpec{"TPC", "SUMMARY", 0}, 1);
         tpcSummary.at(0).inputCount = ctx.inputs().size();
       }
     },
@@ -103,7 +103,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
     },
     AlgorithmSpec{
       [](ProcessingContext &ctx) {
-        auto itsSummary = ctx.allocator().newCollectionChunk<Summary>(OutputSpec{"ITS", "SUMMARY", 0}, 1);
+        auto itsSummary = ctx.allocator().make<Summary>(OutputSpec{"ITS", "SUMMARY", 0}, 1);
         itsSummary.at(0).inputCount = ctx.inputs().size();
       }
     },

--- a/Framework/TestWorkflows/src/o2ParallelWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2ParallelWorkflow.cxx
@@ -34,7 +34,7 @@ DataProcessorSpec templateProcessor() {
           // Create a single output. 
           size_t index = ctx.services().get<ParallelContext>().index1D();
           sleep(1);
-          auto aData = ctx.allocator().newCollectionChunk<int>(OutputSpec{"TST", "P", index}, 1);
+          auto aData = ctx.allocator().make<int>(OutputSpec{"TST", "P", index}, 1);
         };
       }
     }

--- a/Utilities/QC/Workflow/src/RootObjectMergerSpec.cxx
+++ b/Utilities/QC/Workflow/src/RootObjectMergerSpec.cxx
@@ -15,6 +15,7 @@
 
 #include "RootObjectMergerSpec.h"
 #include "Framework/DataProcessorSpec.h"
+#include "Framework/DataRefUtils.h"
 #include "Headers/DataHeader.h"
 #include "QCCommon/TMessageWrapper.h"
 #include "QCMerger/Merger.h"
@@ -57,11 +58,10 @@ DataProcessorSpec getRootObjectMergerSpec() {
       << " " << dh->dataDescription.str
       << " " << dh->payloadSize
       << std::endl;
-      auto message = std::make_unique<TMessageWrapper>(const_cast<char*>(input.payload),
-                                                       dh->payloadSize);
-      auto object = reinterpret_cast<TObject*>(message->ReadObject(message->GetClass()));
-      if (!object) continue;
-      auto merged = merger->mergeObject(object);
+      auto obj = framework::DataRefUtils::as<TObject>(input);
+      // FIXME: mergeObject should probably use either a shared_ptr
+      // or a unique_ptr to indicate ownership.
+      auto merged = merger->mergeObject(obj.release());
       if (!merged) continue;
       std::cout << "Merger: got merged object " << merged->GetTitle() << std::endl;
       merged->Print();


### PR DESCRIPTION
This improves the API for both InputRecord and DataAllocator to
simplify creation of objects which are to be sent via the framework
or their retrivial on the sink side.
In particular the new API is much more orthogonal WRT the types and
it basically has only three templated methods:

- `DataAllocator::make<T>()` to create objects which are owned by the
  framework and that will be sent and the end of the processing.
- `DataAllocator::adopt()` to adopt preexisting objects and send them
  once the processing ends.
- `InputRecord::get<T>` to extract a T& from the message.

The methods are smart enough to do the right thing depending wether
the type T in question is a POD, a Collection of POD or a TObjetct
derived one. Moreover as a side effect this greatly simplifies the ROOT
based message passing by:

- Removing the TClonesArray based API.
- Introduce an helper method to get a TObject derived class from a
  DataRef.
- Introduces a generic API to send around TObject derived instances. In
  particular `DataAllocator::make<T>` can be used to create
  TObject derived T instances which will be serialised and sent as
  TMessages once the Processing is done. Alternatively,
  `DataAllocator::adopt()` can be used to inject in the system
  an already created TObject derived instance.
- It similarly introduces a `InputRecord::get<T>` API for
  InputRecord which allows to extract the objects created with the API
  aforementioned.
