### PR TITLE
Compiled sim setup

### DIFF
--- a/Detectors/CMakeLists.txt
+++ b/Detectors/CMakeLists.txt
@@ -26,5 +26,8 @@ add_subdirectory(FIT)
 add_subdirectory(PHOS)
 add_subdirectory(MUON)
 add_subdirectory(GlobalTracking)
+IF (HAVESIMULATION)
+  add_subdirectory(gconfig)
+ENDIF (HAVESIMULATION)
 
 Install(DIRECTORY Geometry gconfig DESTINATION share/Detectors/)

--- a/Detectors/gconfig/CMakeLists.txt
+++ b/Detectors/gconfig/CMakeLists.txt
@@ -1,0 +1,19 @@
+set(MODULE_NAME "SimSetup")
+
+O2_SETUP(NAME ${MODULE_NAME})
+
+set(SRCS
+     src/G3Config.cxx
+     src/G4Config.cxx
+     src/SimSetup.cxx
+   )
+
+set(HEADERS
+    include/${MODULE_NAME}/SimSetup.h
+   )
+
+Set(LINKDEF src/GConfLinkDef.h)
+set(LIBRARY_NAME ${MODULE_NAME})
+set(BUCKET_NAME simulation_setup_bucket)
+
+O2_GENERATE_LIBRARY()

--- a/Detectors/gconfig/include/SimSetup/SimSetup.h
+++ b/Detectors/gconfig/include/SimSetup/SimSetup.h
@@ -1,0 +1,20 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_SIMSETUP_H
+
+namespace o2
+{
+struct SimSetup {
+  static void setup(const char* engine);
+};
+}
+
+#endif

--- a/Detectors/gconfig/src/G3Config.cxx
+++ b/Detectors/gconfig/src/G3Config.cxx
@@ -1,0 +1,38 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "FairRunSim.h"
+#include "TGeant3.h"
+#include "TGeant3TGeo.h"
+#include "SimulationDataFormat/Stack.h"
+#include <iostream>
+#include "FairLogger.h"
+#include "FairModule.h"
+#include <DetectorsPassive/Cave.h>
+
+using std::cout;
+using std::endl;
+#include <SimSetup/SimSetup.h>
+
+namespace o2
+{
+namespace g3config
+{
+#include "../g3Config.C"
+#include "../SetCuts.C"
+
+void G3Config()
+{
+  LOG(INFO) << "Setting up G3 sim from library code" << FairLogger::endl;
+  Config();
+  SetCuts();
+}
+}
+}

--- a/Detectors/gconfig/src/G4Config.cxx
+++ b/Detectors/gconfig/src/G4Config.cxx
@@ -1,0 +1,38 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "FairRunSim.h"
+#include "SimulationDataFormat/Stack.h"
+#include <iostream>
+#include "FairLogger.h"
+#include "TGeant4.h"
+#include "TG4RunConfiguration.h"
+#include "TPythia6Decayer.h"
+#include "FairModule.h"
+#include <DetectorsPassive/Cave.h>
+
+using std::cout;
+using std::endl;
+
+namespace o2
+{
+namespace g4config
+{
+#include "../g4Config.C"
+#include "../SetCuts.C"
+
+void G4Config()
+{
+  LOG(INFO) << "Setting up G4 sim from library code" << FairLogger::endl;
+  Config();
+  SetCuts();
+}
+}
+}

--- a/Detectors/gconfig/src/GConfLinkDef.h
+++ b/Detectors/gconfig/src/GConfLinkDef.h
@@ -1,0 +1,19 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+
+#ifdef __CLING__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+#pragma link C++ class o2::SimSetup+;
+
+#endif

--- a/Detectors/gconfig/src/SimSetup.cxx
+++ b/Detectors/gconfig/src/SimSetup.cxx
@@ -1,0 +1,37 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <cstring>
+#include "SimSetup/SimSetup.h"
+#include "FairLogger.h"
+
+namespace o2
+{
+// forward declarations of functions
+namespace g3config
+{
+void G3Config();
+}
+namespace g4config
+{
+void G4Config();
+}
+
+void SimSetup::setup(const char* engine)
+{
+  if (strcmp(engine, "TGeant3") == 0) {
+    g3config::G3Config();
+  } else if (strcmp(engine, "TGeant4") == 0) {
+    g4config::G4Config();
+  } else {
+    LOG(FATAL) << "Unsupported engine " << engine << FairLogger::endl;
+  }
+}
+}

--- a/Steer/DigitizerWorkflow/CMakeLists.txt
+++ b/Steer/DigitizerWorkflow/CMakeLists.txt
@@ -9,7 +9,7 @@
 # or submit itself to any jurisdiction.
 
 set(MODULE_NAME "DigitizerWorkflow")
-set(MODULE_BUCKET_NAME run_bucket)
+set(MODULE_BUCKET_NAME digitizer_workflow_bucket)
 
 O2_SETUP(NAME ${MODULE_NAME})
 

--- a/Steer/DigitizerWorkflow/src/TPCDriftTimeDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TPCDriftTimeDigitizerSpec.cxx
@@ -24,7 +24,6 @@
 #include <TPCSimulation/Digitizer.h>
 #include <TPCSimulation/DigitizerTask.h>
 #include <functional>
-#include "ITSMFTSimulation/Hit.h"
 #include "TPCSimulation/Point.h"
 #include "TPCSimulation/ElectronTransport.h"
 #include "TPCSimulation/HitDriftFilter.h"

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -7,8 +7,10 @@ find_package(Pythia8)
 find_package(Pythia6)
 if (ALICEO2_MODULAR_BUILD)
   # Geant3, Geant4 installed via cmake
-  find_package(Geant3)
-  find_package(Geant4)
+  find_package(Geant3 NO_MODULE)
+  find_package(Geant4 NO_MODULE)
+  find_package(Geant4VMC NO_MODULE)
+  find_package(VGM NO_MODULE)
 else (ALICEO2_MODULAR_BUILD)
   # For old versions of VMC packages (to be removed)
   find_package(GEANT3)
@@ -1325,6 +1327,7 @@ o2_define_bucket(
 
     #-- precise modules follow
     SimConfig
+    SimSetup
     DetectorsPassive
     TPCSimulation
     TPCReconstruction
@@ -1724,3 +1727,29 @@ o2_define_bucket(
     INCLUDE_DIRECTORIES
     ${CMAKE_SOURCE_DIR}/Detectors/MUON/MID/Tracking/src
 )
+
+
+o2_define_bucket(
+    NAME
+    simulation_setup_bucket
+
+    DEPENDENCIES
+    pythia6 # this is needed by Geant3
+    EGPythia6 # this is needed by Geant4 (TPythia6Decayer)
+    ${Geant3_LIBRARIES}
+    ${Geant4_LIBRARIES}
+    ${Geant4VMC_LIBRARIES}
+    ${VGM_LIBRARIES}
+    fairroot_geom
+    SimulationDataFormat
+    DetectorsPassive
+
+    INCLUDE_DIRECTORIES
+    ${Geant4VMC_INCLUDE_DIRS}
+    ${Geant4_INCLUDE_DIRS}
+    ${Geant3_INCLUDE_DIRS}
+    ${FAIRROOT_INCLUDE_DIR}
+    ${ROOT_INCLUDE_DIR}
+)
+
+

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -1345,6 +1345,21 @@ o2_define_bucket(
     Framework
 )
 
+# a bucket for "global" executables/macros
+o2_define_bucket(
+    NAME
+    digitizer_workflow_bucket
+
+    DEPENDENCIES
+    #-- buckets follow
+    fairroot_base_bucket
+
+    #-- precise modules follow
+    Steer
+    Framework
+    TPCSimulation
+)
+
 o2_define_bucket(
 NAME
     event_visualisation_detectors_bucket

--- a/macro/o2sim.C
+++ b/macro/o2sim.C
@@ -22,7 +22,7 @@
 #include "FairParRootFileIo.h"
 #include "FairSystemInfo.h"
 #include "TVirtualMC.h"
-
+#include <SimSetup/SimSetup.h>
 #endif
 
 void o2sim()
@@ -32,6 +32,7 @@ void o2sim()
 
   auto run = new FairRunSim();
   run->SetImportTGeoToVMC(false); // do not import TGeo to VMC since the latter is built together with TGeo
+  run->SetSimSetup([confref]() { o2::SimSetup::setup(confref.getMCEngine().c_str()); });
   std::string outputfilename = confref.getOutPrefix() + ".root";
   run->SetOutputFile(outputfilename.c_str());  // Output file
   run->SetName(confref.getMCEngine().c_str()); // Transport engine


### PR DESCRIPTION
Compile the simulation configutation into a library;

Avoids macro interpretation at runtime and leads to
visibly faster simulation setup and reduced memory footprint (~40MB)

This needs a syncronized commit in FairRoot