### PR TITLE
MCTruthContainer: copy constructor, no TNamed, memory reduction

### DIFF
--- a/DataFormats/simulation/test/testMCTruthContainer.cxx
+++ b/DataFormats/simulation/test/testMCTruthContainer.cxx
@@ -30,11 +30,8 @@ BOOST_AUTO_TEST_CASE(MCTruth)
   // container.addElement(0,TruthElement(0));
 
   // check header/index information
-  BOOST_CHECK(container.getMCTruthHeader(0).size == 2);
   BOOST_CHECK(container.getMCTruthHeader(0).index == 0);
-  BOOST_CHECK(container.getMCTruthHeader(1).size == 1);
   BOOST_CHECK(container.getMCTruthHeader(1).index == 2);
-  BOOST_CHECK(container.getMCTruthHeader(2).size == 1);
   BOOST_CHECK(container.getMCTruthHeader(2).index == 3);
 
   // check MC truth information
@@ -61,6 +58,12 @@ BOOST_AUTO_TEST_CASE(MCTruth)
   // try to get something invalid
   view = container.getLabels(10);
   BOOST_CHECK(view.size() == 0);
+
+  // test assignment/copy
+  auto copy = container;
+  view = copy.getLabels(2);
+  BOOST_CHECK(view.size() == 1);
+  BOOST_CHECK(view[0] == 10);
 }
 
 } // end namespace

--- a/Detectors/TPC/reconstruction/macro/readClusterMCtruth.C
+++ b/Detectors/TPC/reconstruction/macro/readClusterMCtruth.C
@@ -32,7 +32,7 @@ void readClusterMCtruth(std::string filename)
 
   o2::dataformats::MCTruthContainer<o2::MCCompLabel> mMCTruthArray;
   o2::dataformats::MCTruthContainer<o2::MCCompLabel> *mcTruthArray(&mMCTruthArray);
-  clusterTree->SetBranchAddress("TPCClusterHWMCTruth.", &mcTruthArray);
+  clusterTree->SetBranchAddress("TPCClusterHWMCTruth", &mcTruthArray);
 
   for(int iEvent=0; iEvent<clusterTree->GetEntriesFast(); ++iEvent) {
     int cluster = 0;

--- a/Detectors/TPC/reconstruction/src/ClustererTask.cxx
+++ b/Detectors/TPC/reconstruction/src/ClustererTask.cxx
@@ -90,7 +90,9 @@ InitStatus ClustererTask::Init()
 
     // Register MC Truth output container
     mClustersMCTruthArray = std::make_unique<MCLabelContainer>();
-    mgr->Register("TPCClusterMCTruth.", "TPC", mClustersMCTruthArray.get(), kTRUE);
+    // a trick to register the unique pointer with FairRootManager
+    static auto tmp = mClustersMCTruthArray.get();
+    mgr->RegisterAny("TPCClusterMCTruth", tmp, kTRUE);
 
     // create clusterer and pass output pointer
     mBoxClusterer = std::make_unique<BoxClusterer>(mClustersArray);
@@ -103,7 +105,9 @@ InitStatus ClustererTask::Init()
 
     // Register MC Truth output container
     mHwClustersMCTruthArray = std::make_unique<MCLabelContainer>();
-    mgr->Register("TPCClusterHWMCTruth.", "TPC", mHwClustersMCTruthArray.get(), kTRUE);
+    // a trick to register the unique pointer with FairRootManager
+    static auto tmp = mHwClustersMCTruthArray.get();
+    mgr->RegisterAny("TPCClusterHWMCTruth", tmp, kTRUE);
 
      // create clusterer and pass output pointer
     mHwClusterer = std::make_unique<HwClusterer>(mHwClustersArray,mHwClustersMCTruthArray.get());//,0,359);

--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitizerTask.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitizerTask.h
@@ -74,7 +74,7 @@ class DigitizerTask : public FairTask{
     DigitContainer      *mDigitContainer;
       
     std::vector<o2::TPC::Digit> *mDigitsArray = nullptr;  ///< Array of the Digits, passed from the digitization
-    o2::dataformats::MCTruthContainer<o2::MCCompLabel> mMCTruthArray; ///< Array for MCTruth information associated to digits in mDigitsArrray. Passed from the digitization
+    o2::dataformats::MCTruthContainer<o2::MCCompLabel> *mMCTruthArray = nullptr; ///< Array for MCTruth information associated to digits in mDigitsArrray. Passed from the digitization
     std::vector<o2::TPC::DigitMCMetaData> *mDigitsDebugArray = nullptr;  ///< Array of the Digits, for debugging purposes only, passed from the digitization
     
     int                 mTimeBinMax;   ///< Maximum time bin to be written out

--- a/Detectors/TPC/simulation/src/DigitizerTask.cxx
+++ b/Detectors/TPC/simulation/src/DigitizerTask.cxx
@@ -40,7 +40,7 @@ DigitizerTask::DigitizerTask(int sectorid)
     mDigitizer(nullptr),
     mDigitContainer(nullptr),
     mDigitsArray(nullptr),
-    mMCTruthArray(),
+    mMCTruthArray(nullptr),
     mDigitsDebugArray(nullptr),
     mTimeBinMax(1000000),
     mIsContinuousReadout(true),
@@ -94,7 +94,8 @@ InitStatus DigitizerTask::Init()
   mgr->RegisterAny("TPCDigit", mDigitsArray, kTRUE);
 
   // Register MC Truth container
-  mgr->Register("TPCDigitMCTruth", "TPC", &mMCTruthArray, kTRUE);
+  mMCTruthArray = new typename std::remove_pointer<decltype(mMCTruthArray)>::type;
+  mgr->RegisterAny("TPCDigitMCTruth", mMCTruthArray, kTRUE);
 
   // Register additional (optional) debug output
   if(mDigitDebugOutput) {
@@ -121,7 +122,7 @@ void DigitizerTask::Exec(Option_t *option)
 
   LOG(DEBUG) << "Running digitization on new event at time " << eventTime << " us in time bin " << eventTimeBin << FairLogger::endl;
   mDigitsArray->clear();
-  mMCTruthArray.clear();
+  mMCTruthArray->clear();
   if(mDigitDebugOutput) {
     mDigitsDebugArray->clear();
   }
@@ -137,7 +138,7 @@ void DigitizerTask::Exec(Option_t *option)
     // treat only chosen sector
     mDigitContainer = mDigitizer->Process(*mSectorHitsArray[mHitSector], eventTime);
   }
-  mDigitContainer->fillOutputContainer(mDigitsArray, mMCTruthArray, mDigitsDebugArray, eventTimeBin, mIsContinuousReadout);
+  mDigitContainer->fillOutputContainer(mDigitsArray, *mMCTruthArray, mDigitsDebugArray, eventTimeBin, mIsContinuousReadout);
 }
 
 void DigitizerTask::FinishTask()
@@ -146,11 +147,11 @@ void DigitizerTask::FinishTask()
   FairRootManager *mgr = FairRootManager::Instance();
   mgr->SetLastFill(kTRUE); /// necessary, otherwise the data is not written out
   mDigitsArray->clear();
-  mMCTruthArray.clear();
+  mMCTruthArray->clear();
   if(mDigitDebugOutput) {
     mDigitsDebugArray->clear();
   }
-  mDigitContainer->fillOutputContainer(mDigitsArray, mMCTruthArray, mDigitsDebugArray, mTimeBinMax, mIsContinuousReadout);
+  mDigitContainer->fillOutputContainer(mDigitsArray, *mMCTruthArray, mDigitsDebugArray, mTimeBinMax, mIsContinuousReadout);
 }
 
 void DigitizerTask::initBunchTrainStructure(const size_t numberOfEvents)


### PR DESCRIPTION
Several improvements on MCTruthContainer:

* cut inheritance from TNamed as this is no longer
  necessary (since we can register arbitrary types with FairRoot now)
  This means:
  - need to register the object with RegisterAny
  - no longer need a trailing dot (.) in the branch name

* offer copy/assignment operator on MCTruthContainer as requested
  by @KlewinS

* reduce memory footprint by deleting the size field in
  MCTruthHeaderElement; This size can in fact be calculated on the fly
  as pointed out by David Rohr (@davidrohr).