### PR TITLE
Include cluster topology classes

### DIFF
--- a/Detectors/ITSMFT/ITS/macros/test/CheckClusters.C
+++ b/Detectors/ITSMFT/ITS/macros/test/CheckClusters.C
@@ -23,8 +23,8 @@ void CheckClusters(Int_t nEvents = 10, TString mcEngine = "TGeant3")
   using namespace o2::Base;
   using namespace o2::ITS;
 
-  using o2::ITSMFT::Hit;
   using o2::ITSMFT::Cluster;
+  using o2::ITSMFT::Hit;
 
   TFile* f = TFile::Open("CheckClusters.root", "recreate");
   TNtuple* nt = new TNtuple("ntc", "cluster ntuple", "x:y:z:dx:dz:lab:rof:ev:hlx:hlz:clx:clz");

--- a/Detectors/ITSMFT/ITS/macros/test/CheckTopologies.C
+++ b/Detectors/ITSMFT/ITS/macros/test/CheckTopologies.C
@@ -2,75 +2,77 @@
 /// \brief Simple macro to check ITSU clusters
 
 #if !defined(__CLING__) || defined(__ROOTCLING__)
-  #include <TFile.h>
-  #include <TTree.h>
-  #include <TH2F.h>
-  #include <TH1F.h>
-  #include <TNtuple.h>
-  #include <TCanvas.h>
-  #include <TString.h>
-  #include <TAxis.h>
-  #include <TStyle.h>
-  #include <fstream>
-  #include <string>
+#include <TAxis.h>
+#include <TCanvas.h>
+#include <TFile.h>
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TNtuple.h>
+#include <TString.h>
+#include <TStyle.h>
+#include <TTree.h>
+#include <fstream>
+#include <string>
 
-  #include "ITSMFTSimulation/Hit.h"
-  #include "DetectorsBase/Utils.h"
-  #include "MathUtils/Cartesian3D.h"
-  #include "ITSBase/GeometryTGeo.h"
-  #include "ITSMFTReconstruction/Cluster.h"
-  #include "ITSMFTReconstruction/ClusterTopology.h"
-  #include "ITSMFTReconstruction/BuildTopologyDictionary.h"
-  #include "SimulationDataFormat/MCCompLabel.h"
-  #include "SimulationDataFormat/MCTruthContainer.h"
+#include "DetectorsBase/Utils.h"
+#include "ITSBase/GeometryTGeo.h"
+#include "ITSMFTReconstruction/BuildTopologyDictionary.h"
+#include "ITSMFTReconstruction/Cluster.h"
+#include "ITSMFTReconstruction/ClusterTopology.h"
+#include "ITSMFTSimulation/Hit.h"
+#include "MathUtils/Cartesian3D.h"
+#include "SimulationDataFormat/MCCompLabel.h"
+#include "SimulationDataFormat/MCTruthContainer.h"
 
 #endif
 
-void CheckTopologies(Int_t nEvents = 10, TString mcEngine = "TGeant3") {
+void CheckTopologies(Int_t nEvents = 10, TString mcEngine = "TGeant3")
+{
   using namespace o2::Base;
   using namespace o2::ITS;
 
-  using o2::ITSMFT::Hit;
+  using o2::ITSMFT::BuildTopologyDictionary;
   using o2::ITSMFT::Cluster;
   using o2::ITSMFT::ClusterTopology;
-  using o2::ITSMFT::BuildTopologyDictionary;
+  using o2::ITSMFT::Hit;
 
   char filename[100];
 
   // Geometry
   sprintf(filename, "AliceO2_%s.params_%i.root", mcEngine.Data(), nEvents);
-  TFile *file = TFile::Open(filename);
+  TFile* file = TFile::Open(filename);
   gFile->Get("FairGeoParSet");
 
-  auto gman =  o2::ITS::GeometryTGeo::Instance();
-  gman->fillMatrixCache( Utils::bit2Mask(TransformType::T2L, TransformType::T2GRot, TransformType::L2G) ); // request cached transforms
+  auto gman = o2::ITS::GeometryTGeo::Instance();
+  gman->fillMatrixCache(o2::utils::bit2Mask(o2::TransformType::T2L, o2::TransformType::T2GRot,
+                                            o2::TransformType::L2G)); // request cached transforms
 
   // Hits
   sprintf(filename, "AliceO2_%s.mc_%i_event.root", mcEngine.Data(), nEvents);
-  TFile *file0 = TFile::Open(filename);
-  TTree *hitTree=(TTree*)gFile->Get("o2sim");
-  std::vector<Hit> *hitArray = nullptr;
+  TFile* file0 = TFile::Open(filename);
+  TTree* hitTree = (TTree*)gFile->Get("o2sim");
+  std::vector<Hit>* hitArray = nullptr;
   hitTree->SetBranchAddress("ITSHit", &hitArray);
 
   // Clusters
   sprintf(filename, "AliceO2_%s.clus_%i_event.root", mcEngine.Data(), nEvents);
-  TFile *file1 = TFile::Open(filename);
-  TTree *clusTree=(TTree*)gFile->Get("o2sim");
-  std::vector<Cluster> *clusArr=nullptr;
-  //clusTree->SetBranchAddress("ITSCluster",&clusArr); // Why this does not work ???
-  auto *branch = clusTree->GetBranch("ITSCluster");
+  TFile* file1 = TFile::Open(filename);
+  TTree* clusTree = (TTree*)gFile->Get("o2sim");
+  std::vector<Cluster>* clusArr = nullptr;
+  // clusTree->SetBranchAddress("ITSCluster",&clusArr); // Why this does not work ???
+  auto* branch = clusTree->GetBranch("ITSCluster");
   if (!branch) {
-    std::cout<<"No clusters !"<<std::endl;
+    std::cout << "No clusters !" << std::endl;
     return;
   }
   branch->SetAddress(&clusArr);
   // Cluster MC labels
-  o2::dataformats::MCTruthContainer<o2::MCCompLabel> *clusLabArr=nullptr;
-  clusTree->SetBranchAddress("ITSClusterMCTruth",&clusLabArr);
+  o2::dataformats::MCTruthContainer<o2::MCCompLabel>* clusLabArr = nullptr;
+  clusTree->SetBranchAddress("ITSClusterMCTruth", &clusLabArr);
 
   Int_t nevCl = clusTree->GetEntries(); // clusters in cont. readout may be grouped as few events per entry
-  Int_t nevH = hitTree->GetEntries(); // hits are stored as one event per entry
-  int ievC=0,ievH=0;
+  Int_t nevH = hitTree->GetEntries();   // hits are stored as one event per entry
+  int ievC = 0, ievH = 0;
   int lastReadHitEv = -1;
 
   // Topologies dictionaries: 1) all clusters 2) signal clusters only 3) noise clusters only
@@ -78,83 +80,84 @@ void CheckTopologies(Int_t nEvents = 10, TString mcEngine = "TGeant3") {
   BuildTopologyDictionary signalDictionary;
   BuildTopologyDictionary noiseDictionary;
 
-  for (ievC=0;ievC<nevCl;ievC++) {
+  for (ievC = 0; ievC < nevCl; ievC++) {
     clusTree->GetEvent(ievC);
     Int_t nc = clusArr->size();
-    printf("processing cluster event %d\n",ievC);
+    printf("processing cluster event %d\n", ievC);
 
-    while(nc--) {
+    while (nc--) {
       // cluster is in tracking coordinates always
-      Cluster &c=(*clusArr)[nc];
+      Cluster& c = (*clusArr)[nc];
       Int_t chipID = c.getSensorID();
-      const auto locC = c.getXYZLoc(*gman); // convert from tracking to local frame
+      const auto locC = c.getXYZLoc(*gman);    // convert from tracking to local frame
       const auto gloC = c.getXYZGloRot(*gman); // convert from tracking to global frame
       auto lab = (clusLabArr->getLabels(nc))[0];
 
       int rowSpan = c.getPatternRowSpan();
       int columnSpan = c.getPatternColSpan();
-      int nBytes = (rowSpan*columnSpan)>>3;
-      if(((rowSpan*columnSpan)%8)!=0) nBytes++;
+      int nBytes = (rowSpan * columnSpan) >> 3;
+      if (((rowSpan * columnSpan) % 8) != 0)
+        nBytes++;
       unsigned char patt[Cluster::kMaxPatternBytes];
-      c.getPattern(&patt[0],nBytes);
-      ClusterTopology topology(rowSpan,columnSpan,patt);
+      c.getPattern(&patt[0], nBytes);
+      ClusterTopology topology(rowSpan, columnSpan, patt);
 
-      float dx=0,dz=0;
+      float dx = 0, dz = 0;
       int trID = lab.getTrackID();
       int ievH = lab.getEventID();
-      Point3D<float> locH,locHsta;
-      if (trID>=0) { // is this cluster from hit or noise ?
+      Point3D<float> locH, locHsta;
+      if (trID >= 0) { // is this cluster from hit or noise ?
         Hit* p = nullptr;
-        if (lastReadHitEv!=ievH) {
+        if (lastReadHitEv != ievH) {
           hitTree->GetEvent(ievH);
           lastReadHitEv = ievH;
         }
-        for(auto& ptmp : *hitArray){
-          if (ptmp.GetDetectorID() != chipID) continue;
-          if (ptmp.GetTrackID() != trID) continue;
+        for (auto& ptmp : *hitArray) {
+          if (ptmp.GetDetectorID() != chipID)
+            continue;
+          if (ptmp.GetTrackID() != trID)
+            continue;
           p = &ptmp;
           break;
         }
-        if(!p){
-          printf("did not find hit (scanned HitEvs %d %d) for cluster of tr%d on chip %d\n",ievH,nevH,trID,chipID);
-          locH.SetXYZ(0.f,0.f,0.f);
-        }
-        else{
+        if (!p) {
+          printf("did not find hit (scanned HitEvs %d %d) for cluster of tr%d on chip %d\n", ievH, nevH, trID, chipID);
+          locH.SetXYZ(0.f, 0.f, 0.f);
+        } else {
           // mean local position of the hit
-          locH    = gman->getMatrixL2G(chipID)^( p->GetPos() );  // inverse conversion from global to local
-          locHsta = gman->getMatrixL2G(chipID)^( p->GetPosStart() );
-          locH.SetXYZ( 0.5*(locH.X()+locHsta.X()),0.5*(locH.Y()+locHsta.Y()),0.5*(locH.Z()+locHsta.Z()) );
-          //std::cout << "chip "<< p->GetDetectorID() << "  PposGlo " << p->GetPos() << std::endl;
-          //std::cout << "chip "<< c->getSensorID() << "  PposLoc " << locH << std::endl;
-          dx = locH.X()-locC.X();
-          dz = locH.Z()-locC.Z();
+          locH = gman->getMatrixL2G(chipID) ^ (p->GetPos()); // inverse conversion from global to local
+          locHsta = gman->getMatrixL2G(chipID) ^ (p->GetPosStart());
+          locH.SetXYZ(0.5 * (locH.X() + locHsta.X()), 0.5 * (locH.Y() + locHsta.Y()), 0.5 * (locH.Z() + locHsta.Z()));
+          // std::cout << "chip "<< p->GetDetectorID() << "  PposGlo " << p->GetPos() << std::endl;
+          // std::cout << "chip "<< c->getSensorID() << "  PposLoc " << locH << std::endl;
+          dx = locH.X() - locC.X();
+          dz = locH.Z() - locC.Z();
         }
-        signalDictionary.accountTopology(topology,dx,dz);
+        signalDictionary.accountTopology(topology, dx, dz);
+      } else {
+        noiseDictionary.accountTopology(topology, dx, dz);
       }
-      else{
-        noiseDictionary.accountTopology(topology,dx,dz);
-      }
-      completeDictionary.accountTopology(topology,dx,dz);
+      completeDictionary.accountTopology(topology, dx, dz);
     }
   }
   completeDictionary.setThreshold(0.00001);
   completeDictionary.groupRareTopologies();
   completeDictionary.printDictionaryBinary("complete_dictionary.bin");
   ofstream completeDictionaryOutput("complete_dictionary.txt");
-  completeDictionaryOutput<<completeDictionary;
+  completeDictionaryOutput << completeDictionary;
   noiseDictionary.setThreshold(0.00001);
   noiseDictionary.groupRareTopologies();
   noiseDictionary.printDictionaryBinary("noise_dictionary.bin");
   ofstream noiseDictionaryOutput("noise_dictionary.txt");
-  noiseDictionaryOutput<<noiseDictionary;
+  noiseDictionaryOutput << noiseDictionary;
   signalDictionary.setThreshold(0.00001);
   signalDictionary.groupRareTopologies();
   signalDictionary.printDictionaryBinary("signal_dictionary.bin");
   ofstream signalDictionaryOutput("signal_dictionary.txt");
-  signalDictionaryOutput<<signalDictionary;
+  signalDictionaryOutput << signalDictionary;
 
-  TFile histogramOutput("histograms.root","recreate");
-  TCanvas* cComplete = new TCanvas("cComplete","Distribution of all the topologies");
+  TFile histogramOutput("histograms.root", "recreate");
+  TCanvas* cComplete = new TCanvas("cComplete", "Distribution of all the topologies");
   cComplete->cd();
   cComplete->SetLogy();
   TH1F* hComplete = (TH1F*)completeDictionary.mHdist.Clone("hComplete");
@@ -165,7 +168,7 @@ void CheckTopologies(Int_t nEvents = 10, TString mcEngine = "TGeant3") {
   hComplete->SetFillStyle(3005);
   hComplete->Draw("hist");
   cComplete->Write();
-  TCanvas* cNoise = new TCanvas("cNoise","Distribution of noise topologies");
+  TCanvas* cNoise = new TCanvas("cNoise", "Distribution of noise topologies");
   cNoise->cd();
   cNoise->SetLogy();
   TH1F* hNoise = (TH1F*)noiseDictionary.mHdist.Clone("hNoise");
@@ -176,7 +179,7 @@ void CheckTopologies(Int_t nEvents = 10, TString mcEngine = "TGeant3") {
   hNoise->SetFillStyle(3005);
   hNoise->Draw("hist");
   cNoise->Write();
-  TCanvas* cProper = new TCanvas("cProper","cProper");
+  TCanvas* cProper = new TCanvas("cProper", "cProper");
   cProper->cd();
   cProper->SetLogy();
   TH1F* hProper = (TH1F*)signalDictionary.mHdist.Clone("hProper");

--- a/Detectors/ITSMFT/ITS/macros/test/CheckTopologies.C
+++ b/Detectors/ITSMFT/ITS/macros/test/CheckTopologies.C
@@ -1,0 +1,190 @@
+/// \file CheckDigits.C
+/// \brief Simple macro to check ITSU clusters
+
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+  #include <TFile.h>
+  #include <TTree.h>
+  #include <TH2F.h>
+  #include <TH1F.h>
+  #include <TNtuple.h>
+  #include <TCanvas.h>
+  #include <TString.h>
+  #include <TAxis.h>
+  #include <TStyle.h>
+  #include <fstream>
+  #include <string>
+
+  #include "ITSMFTSimulation/Hit.h"
+  #include "DetectorsBase/Utils.h"
+  #include "MathUtils/Cartesian3D.h"
+  #include "ITSBase/GeometryTGeo.h"
+  #include "ITSMFTReconstruction/Cluster.h"
+  #include "ITSMFTReconstruction/ClusterTopology.h"
+  #include "ITSMFTReconstruction/BuildTopologyDictionary.h"
+  #include "SimulationDataFormat/MCCompLabel.h"
+  #include "SimulationDataFormat/MCTruthContainer.h"
+
+#endif
+
+void CheckTopologies(Int_t nEvents = 10, TString mcEngine = "TGeant3") {
+  using namespace o2::Base;
+  using namespace o2::ITS;
+
+  using o2::ITSMFT::Hit;
+  using o2::ITSMFT::Cluster;
+  using o2::ITSMFT::ClusterTopology;
+  using o2::ITSMFT::BuildTopologyDictionary;
+
+  char filename[100];
+
+  // Geometry
+  sprintf(filename, "AliceO2_%s.params_%i.root", mcEngine.Data(), nEvents);
+  TFile *file = TFile::Open(filename);
+  gFile->Get("FairGeoParSet");
+
+  auto gman =  o2::ITS::GeometryTGeo::Instance();
+  gman->fillMatrixCache( Utils::bit2Mask(TransformType::T2L, TransformType::T2GRot, TransformType::L2G) ); // request cached transforms
+
+  // Hits
+  sprintf(filename, "AliceO2_%s.mc_%i_event.root", mcEngine.Data(), nEvents);
+  TFile *file0 = TFile::Open(filename);
+  TTree *hitTree=(TTree*)gFile->Get("o2sim");
+  std::vector<Hit> *hitArray = nullptr;
+  hitTree->SetBranchAddress("ITSHit", &hitArray);
+
+  // Clusters
+  sprintf(filename, "AliceO2_%s.clus_%i_event.root", mcEngine.Data(), nEvents);
+  TFile *file1 = TFile::Open(filename);
+  TTree *clusTree=(TTree*)gFile->Get("o2sim");
+  std::vector<Cluster> *clusArr=nullptr;
+  //clusTree->SetBranchAddress("ITSCluster",&clusArr); // Why this does not work ???
+  auto *branch = clusTree->GetBranch("ITSCluster");
+  if (!branch) {
+    std::cout<<"No clusters !"<<std::endl;
+    return;
+  }
+  branch->SetAddress(&clusArr);
+  // Cluster MC labels
+  o2::dataformats::MCTruthContainer<o2::MCCompLabel> *clusLabArr=nullptr;
+  clusTree->SetBranchAddress("ITSClusterMCTruth",&clusLabArr);
+
+  Int_t nevCl = clusTree->GetEntries(); // clusters in cont. readout may be grouped as few events per entry
+  Int_t nevH = hitTree->GetEntries(); // hits are stored as one event per entry
+  int ievC=0,ievH=0;
+  int lastReadHitEv = -1;
+
+  // Topologies dictionaries: 1) all clusters 2) signal clusters only 3) noise clusters only
+  BuildTopologyDictionary completeDictionary;
+  BuildTopologyDictionary signalDictionary;
+  BuildTopologyDictionary noiseDictionary;
+
+  for (ievC=0;ievC<nevCl;ievC++) {
+    clusTree->GetEvent(ievC);
+    Int_t nc = clusArr->size();
+    printf("processing cluster event %d\n",ievC);
+
+    while(nc--) {
+      // cluster is in tracking coordinates always
+      Cluster &c=(*clusArr)[nc];
+      Int_t chipID = c.getSensorID();
+      const auto locC = c.getXYZLoc(*gman); // convert from tracking to local frame
+      const auto gloC = c.getXYZGloRot(*gman); // convert from tracking to global frame
+      auto lab = (clusLabArr->getLabels(nc))[0];
+
+      int rowSpan = c.getPatternRowSpan();
+      int columnSpan = c.getPatternColSpan();
+      int nBytes = (rowSpan*columnSpan)>>3;
+      if(((rowSpan*columnSpan)%8)!=0) nBytes++;
+      unsigned char patt[Cluster::kMaxPatternBytes];
+      c.getPattern(&patt[0],nBytes);
+      ClusterTopology topology(rowSpan,columnSpan,patt);
+
+      float dx=0,dz=0;
+      int trID = lab.getTrackID();
+      int ievH = lab.getEventID();
+      Point3D<float> locH,locHsta;
+      if (trID>=0) { // is this cluster from hit or noise ?
+        Hit* p = nullptr;
+        if (lastReadHitEv!=ievH) {
+          hitTree->GetEvent(ievH);
+          lastReadHitEv = ievH;
+        }
+        for(auto& ptmp : *hitArray){
+          if (ptmp.GetDetectorID() != chipID) continue;
+          if (ptmp.GetTrackID() != trID) continue;
+          p = &ptmp;
+          break;
+        }
+        if(!p){
+          printf("did not find hit (scanned HitEvs %d %d) for cluster of tr%d on chip %d\n",ievH,nevH,trID,chipID);
+          locH.SetXYZ(0.f,0.f,0.f);
+        }
+        else{
+          // mean local position of the hit
+          locH    = gman->getMatrixL2G(chipID)^( p->GetPos() );  // inverse conversion from global to local
+          locHsta = gman->getMatrixL2G(chipID)^( p->GetPosStart() );
+          locH.SetXYZ( 0.5*(locH.X()+locHsta.X()),0.5*(locH.Y()+locHsta.Y()),0.5*(locH.Z()+locHsta.Z()) );
+          //std::cout << "chip "<< p->GetDetectorID() << "  PposGlo " << p->GetPos() << std::endl;
+          //std::cout << "chip "<< c->getSensorID() << "  PposLoc " << locH << std::endl;
+          dx = locH.X()-locC.X();
+          dz = locH.Z()-locC.Z();
+        }
+        signalDictionary.accountTopology(topology,dx,dz);
+      }
+      else{
+        noiseDictionary.accountTopology(topology,dx,dz);
+      }
+      completeDictionary.accountTopology(topology,dx,dz);
+    }
+  }
+  completeDictionary.setThreshold(0.00001);
+  completeDictionary.groupRareTopologies();
+  completeDictionary.printDictionaryBinary("complete_dictionary.bin");
+  ofstream completeDictionaryOutput("complete_dictionary.txt");
+  completeDictionaryOutput<<completeDictionary;
+  noiseDictionary.setThreshold(0.00001);
+  noiseDictionary.groupRareTopologies();
+  noiseDictionary.printDictionaryBinary("noise_dictionary.bin");
+  ofstream noiseDictionaryOutput("noise_dictionary.txt");
+  noiseDictionaryOutput<<noiseDictionary;
+  signalDictionary.setThreshold(0.00001);
+  signalDictionary.groupRareTopologies();
+  signalDictionary.printDictionaryBinary("signal_dictionary.bin");
+  ofstream signalDictionaryOutput("signal_dictionary.txt");
+  signalDictionaryOutput<<signalDictionary;
+
+  TFile histogramOutput("histograms.root","recreate");
+  TCanvas* cComplete = new TCanvas("cComplete","Distribution of all the topologies");
+  cComplete->cd();
+  cComplete->SetLogy();
+  TH1F* hComplete = (TH1F*)completeDictionary.mHdist.Clone("hComplete");
+  hComplete->SetDirectory(0);
+  hComplete->SetTitle("Topology distribution");
+  hComplete->GetXaxis()->SetTitle("Topology ID");
+  hComplete->SetFillColor(kRed);
+  hComplete->SetFillStyle(3005);
+  hComplete->Draw("hist");
+  cComplete->Write();
+  TCanvas* cNoise = new TCanvas("cNoise","Distribution of noise topologies");
+  cNoise->cd();
+  cNoise->SetLogy();
+  TH1F* hNoise = (TH1F*)noiseDictionary.mHdist.Clone("hNoise");
+  hNoise->SetDirectory(0);
+  hNoise->SetTitle("Topology distribution");
+  hNoise->GetXaxis()->SetTitle("Topology ID");
+  hNoise->SetFillColor(kRed);
+  hNoise->SetFillStyle(3005);
+  hNoise->Draw("hist");
+  cNoise->Write();
+  TCanvas* cProper = new TCanvas("cProper","cProper");
+  cProper->cd();
+  cProper->SetLogy();
+  TH1F* hProper = (TH1F*)signalDictionary.mHdist.Clone("hProper");
+  hProper->SetDirectory(0);
+  hProper->SetTitle("Topology distribution");
+  hProper->GetXaxis()->SetTitle("Topology ID");
+  hProper->SetFillColor(kRed);
+  hProper->SetFillStyle(3005);
+  hProper->Draw("hist");
+  cProper->Write();
+}

--- a/Detectors/ITSMFT/ITS/macros/test/run_test.sh
+++ b/Detectors/ITSMFT/ITS/macros/test/run_test.sh
@@ -1,16 +1,15 @@
 #
-nEvents=10
-mcEngine=\"TGeant3\"
-#To de-activate the ALPIDE response, set alp=kFALSE
-alp=kTRUE
+nEvents = 10 mcEngine =\"TGeant3\"
+#To de - activate the ALPIDE response, set alp = kFALSE
+  alp = kTRUE
 #To activate the continuos readout, assign a positive value to the rate
-rate=0. # 50.e3 (Hz)
-root.exe -b -q $O2_ROOT/share/macro/run_sim_its_ALP3.C+\($nEvents,$mcEngine\) >& sim.log
-root.exe -b -q $O2_ROOT/share/macro/run_digi_its.C+\($nEvents,$mcEngine,$alp,$rate\) >& digi.log
-root.exe -b -q CheckDigits.C+\($nEvents,$mcEngine\) >& CheckDigits.log
-root.exe -b -q $O2_ROOT/share/macro/run_clus_its.C+\($nEvents,$mcEngine\) >& clus.log
-root.exe -b -q CheckClusters.C+\($nEvents,$mcEngine\) >& CheckClusters.log
-root.exe -b -q CheckTopologies.C+\($nEvents,$mcEngine\) >& CheckTopologies.log
-root.exe -b -q $O2_ROOT/share/macro/run_trac_its.C+\($nEvents,$mcEngine,$rate\) >& trac.log
-root.exe -b -q CheckTracks.C+\($nEvents,$mcEngine\) >& CheckTracks.log
-root.exe DisplayTrack.C+\($nEvents,$mcEngine\)
+    rate = 0. #50.e3(Hz)root.exe - b - q $O2_ROOT / share / macro / run_sim_its_ALP3.C +\($nEvents, $mcEngine\) >
+           &sim.log root.exe - b - q $O2_ROOT / share / macro / run_digi_its.C +\($nEvents, $mcEngine, $alp, $rate\) >
+           &digi.log root.exe - b - q CheckDigits.C +\($nEvents, $mcEngine\) >
+           &CheckDigits.log root.exe - b - q $O2_ROOT / share / macro / run_clus_its.C +\($nEvents, $mcEngine\) >
+           &clus.log root.exe - b - q CheckClusters.C +\($nEvents, $mcEngine\) >
+           &CheckClusters.log root.exe - b - q CheckTopologies.C +\($nEvents, $mcEngine\) >
+           &CheckTopologies.log root.exe - b - q $O2_ROOT / share / macro / run_trac_its.C
+             +\($nEvents, $mcEngine, $rate\) >
+           &trac.log root.exe - b - q CheckTracks.C +\($nEvents, $mcEngine\) >
+           &CheckTracks.log root.exe DisplayTrack.C +\($nEvents, $mcEngine\)

--- a/Detectors/ITSMFT/ITS/macros/test/run_test.sh
+++ b/Detectors/ITSMFT/ITS/macros/test/run_test.sh
@@ -3,14 +3,14 @@ nEvents=10
 mcEngine=\"TGeant3\"
 #To de-activate the ALPIDE response, set alp=kFALSE
 alp=kTRUE
-#To activate the continuos readout, assign a positive value to the rate 
+#To activate the continuos readout, assign a positive value to the rate
 rate=0. # 50.e3 (Hz)
 root.exe -b -q $O2_ROOT/share/macro/run_sim_its_ALP3.C+\($nEvents,$mcEngine\) >& sim.log
 root.exe -b -q $O2_ROOT/share/macro/run_digi_its.C+\($nEvents,$mcEngine,$alp,$rate\) >& digi.log
 root.exe -b -q CheckDigits.C+\($nEvents,$mcEngine\) >& CheckDigits.log
 root.exe -b -q $O2_ROOT/share/macro/run_clus_its.C+\($nEvents,$mcEngine\) >& clus.log
 root.exe -b -q CheckClusters.C+\($nEvents,$mcEngine\) >& CheckClusters.log
+root.exe -b -q CheckTopologies.C+\($nEvents,$mcEngine\) >& CheckTopologies.log
 root.exe -b -q $O2_ROOT/share/macro/run_trac_its.C+\($nEvents,$mcEngine,$rate\) >& trac.log
 root.exe -b -q CheckTracks.C+\($nEvents,$mcEngine\) >& CheckTracks.log
 root.exe DisplayTrack.C+\($nEvents,$mcEngine\)
-

--- a/Detectors/ITSMFT/common/reconstruction/CMakeLists.txt
+++ b/Detectors/ITSMFT/common/reconstruction/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SRCS
   src/ClusterTopology.cxx
   src/TopologyDictionary.cxx
   src/BuildTopologyDictionary.cxx
+  src/LookUp.cxx
 )
 set(HEADERS
   include/${MODULE_NAME}/Cluster.h
@@ -17,6 +18,7 @@ set(HEADERS
   include/${MODULE_NAME}/ClusterTopology.h
   include/${MODULE_NAME}/TopologyDictionary.h
   include/${MODULE_NAME}/BuildTopologyDictionary.h
+  include/${MODULE_NAME}/LookUp.h
 )
 Set(LINKDEF src/ITSMFTReconstructionLinkDef.h)
 Set(LIBRARY_NAME ${MODULE_NAME})

--- a/Detectors/ITSMFT/common/reconstruction/CMakeLists.txt
+++ b/Detectors/ITSMFT/common/reconstruction/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SRCS
   src/Clusterer.cxx
   src/ClusterTopology.cxx
   src/TopologyDictionary.cxx
+  src/BuildTopologyDictionary.cxx
 )
 set(HEADERS
   include/${MODULE_NAME}/Cluster.h
@@ -15,6 +16,7 @@ set(HEADERS
   include/${MODULE_NAME}/Clusterer.h
   include/${MODULE_NAME}/ClusterTopology.h
   include/${MODULE_NAME}/TopologyDictionary.h
+  include/${MODULE_NAME}/BuildTopologyDictionary.h
 )
 Set(LINKDEF src/ITSMFTReconstructionLinkDef.h)
 Set(LIBRARY_NAME ${MODULE_NAME})

--- a/Detectors/ITSMFT/common/reconstruction/CMakeLists.txt
+++ b/Detectors/ITSMFT/common/reconstruction/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SRCS
   src/TopologyDictionary.cxx
   src/BuildTopologyDictionary.cxx
   src/LookUp.cxx
+  src/TopologyFastSimulation.cxx
 )
 set(HEADERS
   include/${MODULE_NAME}/Cluster.h
@@ -19,6 +20,7 @@ set(HEADERS
   include/${MODULE_NAME}/TopologyDictionary.h
   include/${MODULE_NAME}/BuildTopologyDictionary.h
   include/${MODULE_NAME}/LookUp.h
+  include/${MODULE_NAME}/TopologyFastSimulation.h
 )
 Set(LINKDEF src/ITSMFTReconstructionLinkDef.h)
 Set(LIBRARY_NAME ${MODULE_NAME})

--- a/Detectors/ITSMFT/common/reconstruction/CMakeLists.txt
+++ b/Detectors/ITSMFT/common/reconstruction/CMakeLists.txt
@@ -6,14 +6,15 @@ set(SRCS
   src/Cluster.cxx
   src/PixelReader.cxx
   src/Clusterer.cxx
+  src/ClusterTopology.cxx
 )
 set(HEADERS
   include/${MODULE_NAME}/Cluster.h
   include/${MODULE_NAME}/PixelReader.h
   include/${MODULE_NAME}/Clusterer.h
+  include/${MODULE_NAME}/ClusterTopology.h
 )
 Set(LINKDEF src/ITSMFTReconstructionLinkDef.h)
 Set(LIBRARY_NAME ${MODULE_NAME})
 Set(BUCKET_NAME itsmft_reconstruction_bucket)
 O2_GENERATE_LIBRARY()
-

--- a/Detectors/ITSMFT/common/reconstruction/CMakeLists.txt
+++ b/Detectors/ITSMFT/common/reconstruction/CMakeLists.txt
@@ -7,12 +7,14 @@ set(SRCS
   src/PixelReader.cxx
   src/Clusterer.cxx
   src/ClusterTopology.cxx
+  src/TopologyDictionary.cxx
 )
 set(HEADERS
   include/${MODULE_NAME}/Cluster.h
   include/${MODULE_NAME}/PixelReader.h
   include/${MODULE_NAME}/Clusterer.h
   include/${MODULE_NAME}/ClusterTopology.h
+  include/${MODULE_NAME}/TopologyDictionary.h
 )
 Set(LINKDEF src/ITSMFTReconstructionLinkDef.h)
 Set(LIBRARY_NAME ${MODULE_NAME})

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/BuildTopologyDictionary.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/BuildTopologyDictionary.h
@@ -1,12 +1,33 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file BuildTopologyDictionary.h
+/// \brief Definition of the BuildTopologyDictionary class.
+///
+/// \author Luca Barioglio, University and INFN of Torino
+///
+/// Short BuildTopologyDictionary descritpion
+///
+/// This class is used to build the dictionary of topologies, storing the information
+/// concerning topologies with their own entry and groups of rare topologies
+///
+
 #ifndef ALICEO2_ITSMFT_BUILDTOPOLOGYDICTIONARY_H
 #define ALICEO2_ITSMFT_BUILDTOPOLOGYDICTIONARY_H
 #include "ITSMFTReconstruction/ClusterTopology.h"
 #include "ITSMFTReconstruction/TopologyDictionary.h"
+#include "ITSMFTBase/SegmentationAlpide.h"
 #include <array>
 #include <algorithm>
 
-#define _STUDY_
-//#define _HISTO_ //in order to have a histogram with the ditribution of groupIDs
+#define _HISTO_ //in order to have a histogram with the ditribution of groupIDs
 
 #ifdef _HISTO_
   #include "TH1F.h"
@@ -16,25 +37,17 @@ namespace o2
 {
 namespace ITSMFT
 {
-#ifdef _STUDY_
-  struct TopologyInfo{
-    int sizeX;
-    int sizeZ;
-    float xCOG;
-    float zCOG;
-    float xMean;
-    float xSigma2;
-    float zMean;
-    float zSigma2;
-    int nPixels;
-  };
-#endif
 
-struct groupTmp{
-  unsigned long GroupCounts;
-  int tempGroupID;
-  vector<unsigned long> GrHashes;
-  int groupID;
+struct TopologyInfo{
+  int mSizeX;
+  int mSizeZ;
+  float mCOGx;
+  float mCOGz;
+  float mXmean;
+  float mXsigma2;
+  float mZmean;
+  float mZsigma2;
+  int mNpixels;
 };
 
 class BuildTopologyDictionary {
@@ -45,39 +58,33 @@ class BuildTopologyDictionary {
       TH1F mHdist; //Distribution of groupIDs
     #endif
 
-    #ifndef _STUDY_
-      void accountTopology(const std::string &cluster);
-    #else
-      void accountTopology(const std::string &cluster, float dX, float dZ);
-    #endif
-
     BuildTopologyDictionary();
 
+    void accountTopology(const ClusterTopology &cluster, float dX, float dZ);
     void setNGroups(unsigned int ngr); //set number of groups
     void setThreshold(double thr);
     void setThresholdCumulative(double cumulative); //Considering the integral
     void groupRareTopologies();
     friend std::ostream& operator<<(std::ostream& os, const BuildTopologyDictionary& BD);
-    void printDictionary(string fname);
-    void printDictionaryBinary(string fname);
-    unsigned long checkHash(const std::string& clust);
+    void printDictionary(std::string fname);
+    void printDictionaryBinary(std::string fname);
 
     int getTotClusters() const {return mTotClusters;}
     int getNotInGroups() const {return mNotInGroups;}
     int getNGroups() const {return mNumberOfGroups;}
 
   private:
-    TopologyDictionary mDictionary;
-    unordered_map<unsigned long,std::pair<ClusterTopology,unsigned long>> mTopologyMap; //<hash,<topology,counts>>,
-    vector <std::pair<unsigned long,unsigned long>> mTopologyFrequency; //<freq,hash>, needed to define threshold
+    TopologyDictionary mDictionary; ///< Dictionary of topologies
+    std::unordered_map<unsigned long,std::pair<ClusterTopology,unsigned long>> mTopologyMap; ///< Temporary map of type <hash,<topology,counts>>
+    std::vector <std::pair<unsigned long,unsigned long>> mTopologyFrequency; ///< <freq,hash>, needed to define threshold
     int mTotClusters;
     int mNumberOfGroups;
     int mNotInGroups;
     double mFrequencyThreshold;
-    #ifdef _STUDY_
-      unordered_map<long unsigned,TopologyInfo> fMapInfo;
-    #endif
-    ClusterTopology mTopology;
+
+    std::unordered_map<long unsigned,TopologyInfo> mMapInfo;
+
+  ClassDefNV(BuildTopologyDictionary,1);
 };
 }
 }

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/BuildTopologyDictionary.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/BuildTopologyDictionary.h
@@ -21,24 +21,23 @@
 
 #ifndef ALICEO2_ITSMFT_BUILDTOPOLOGYDICTIONARY_H
 #define ALICEO2_ITSMFT_BUILDTOPOLOGYDICTIONARY_H
+#include <algorithm>
+#include <array>
+#include "ITSMFTBase/SegmentationAlpide.h"
 #include "ITSMFTReconstruction/ClusterTopology.h"
 #include "ITSMFTReconstruction/TopologyDictionary.h"
-#include "ITSMFTBase/SegmentationAlpide.h"
-#include <array>
-#include <algorithm>
 
-#define _HISTO_ //in order to have a histogram with the ditribution of groupIDs
+#define _HISTO_ // in order to have a histogram with the ditribution of groupIDs
 
 #ifdef _HISTO_
-  #include "TH1F.h"
+#include "TH1F.h"
 #endif
 
 namespace o2
 {
 namespace ITSMFT
 {
-
-struct TopologyInfo{
+struct TopologyInfo {
   int mSizeX;
   int mSizeZ;
   float mCOGx;
@@ -50,42 +49,42 @@ struct TopologyInfo{
   int mNpixels;
 };
 
-class BuildTopologyDictionary {
+class BuildTopologyDictionary
+{
+ public:
+#ifdef _HISTO_
+  TH1F mHdist; // Distribution of groupIDs
+#endif
 
-  public:
+  BuildTopologyDictionary();
 
-    #ifdef _HISTO_
-      TH1F mHdist; //Distribution of groupIDs
-    #endif
+  void accountTopology(const ClusterTopology& cluster, float dX, float dZ);
+  void setNGroups(unsigned int ngr); // set number of groups
+  void setThreshold(double thr);
+  void setThresholdCumulative(double cumulative); // Considering the integral
+  void groupRareTopologies();
+  friend std::ostream& operator<<(std::ostream& os, const BuildTopologyDictionary& BD);
+  void printDictionary(std::string fname);
+  void printDictionaryBinary(std::string fname);
 
-    BuildTopologyDictionary();
+  int getTotClusters() const { return mTotClusters; }
+  int getNotInGroups() const { return mNotInGroups; }
+  int getNGroups() const { return mNumberOfGroups; }
 
-    void accountTopology(const ClusterTopology &cluster, float dX, float dZ);
-    void setNGroups(unsigned int ngr); //set number of groups
-    void setThreshold(double thr);
-    void setThresholdCumulative(double cumulative); //Considering the integral
-    void groupRareTopologies();
-    friend std::ostream& operator<<(std::ostream& os, const BuildTopologyDictionary& BD);
-    void printDictionary(std::string fname);
-    void printDictionaryBinary(std::string fname);
+ private:
+  TopologyDictionary mDictionary; ///< Dictionary of topologies
+  std::unordered_map<unsigned long, std::pair<ClusterTopology, unsigned long>>
+    mTopologyMap; ///< Temporary map of type <hash,<topology,counts>>
+  std::vector<std::pair<unsigned long, unsigned long>> mTopologyFrequency; ///< <freq,hash>, needed to define threshold
+  int mTotClusters;
+  int mNumberOfGroups;
+  int mNotInGroups;
+  double mFrequencyThreshold;
 
-    int getTotClusters() const {return mTotClusters;}
-    int getNotInGroups() const {return mNotInGroups;}
-    int getNGroups() const {return mNumberOfGroups;}
+  std::unordered_map<long unsigned, TopologyInfo> mMapInfo;
 
-  private:
-    TopologyDictionary mDictionary; ///< Dictionary of topologies
-    std::unordered_map<unsigned long,std::pair<ClusterTopology,unsigned long>> mTopologyMap; ///< Temporary map of type <hash,<topology,counts>>
-    std::vector <std::pair<unsigned long,unsigned long>> mTopologyFrequency; ///< <freq,hash>, needed to define threshold
-    int mTotClusters;
-    int mNumberOfGroups;
-    int mNotInGroups;
-    double mFrequencyThreshold;
-
-    std::unordered_map<long unsigned,TopologyInfo> mMapInfo;
-
-  ClassDefNV(BuildTopologyDictionary,1);
+  ClassDefNV(BuildTopologyDictionary, 1);
 };
-}
-}
+} // namespace ITSMFT
+} // namespace o2
 #endif

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/BuildTopologyDictionary.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/BuildTopologyDictionary.h
@@ -1,0 +1,84 @@
+#ifndef ALICEO2_ITSMFT_BUILDTOPOLOGYDICTIONARY_H
+#define ALICEO2_ITSMFT_BUILDTOPOLOGYDICTIONARY_H
+#include "ITSMFTReconstruction/ClusterTopology.h"
+#include "ITSMFTReconstruction/TopologyDictionary.h"
+#include <array>
+#include <algorithm>
+
+#define _STUDY_
+//#define _HISTO_ //in order to have a histogram with the ditribution of groupIDs
+
+#ifdef _HISTO_
+  #include "TH1F.h"
+#endif
+
+namespace o2
+{
+namespace ITSMFT
+{
+#ifdef _STUDY_
+  struct TopologyInfo{
+    int sizeX;
+    int sizeZ;
+    float xCOG;
+    float zCOG;
+    float xMean;
+    float xSigma2;
+    float zMean;
+    float zSigma2;
+    int nPixels;
+  };
+#endif
+
+struct groupTmp{
+  unsigned long GroupCounts;
+  int tempGroupID;
+  vector<unsigned long> GrHashes;
+  int groupID;
+};
+
+class BuildTopologyDictionary {
+
+  public:
+
+    #ifdef _HISTO_
+      TH1F mHdist; //Distribution of groupIDs
+    #endif
+
+    #ifndef _STUDY_
+      void accountTopology(const std::string &cluster);
+    #else
+      void accountTopology(const std::string &cluster, float dX, float dZ);
+    #endif
+
+    BuildTopologyDictionary();
+
+    void setNGroups(unsigned int ngr); //set number of groups
+    void setThreshold(double thr);
+    void setThresholdCumulative(double cumulative); //Considering the integral
+    void groupRareTopologies();
+    friend std::ostream& operator<<(std::ostream& os, const BuildTopologyDictionary& BD);
+    void printDictionary(string fname);
+    void printDictionaryBinary(string fname);
+    unsigned long checkHash(const std::string& clust);
+
+    int getTotClusters() const {return mTotClusters;}
+    int getNotInGroups() const {return mNotInGroups;}
+    int getNGroups() const {return mNumberOfGroups;}
+
+  private:
+    TopologyDictionary mDictionary;
+    unordered_map<unsigned long,std::pair<ClusterTopology,unsigned long>> mTopologyMap; //<hash,<topology,counts>>,
+    vector <std::pair<unsigned long,unsigned long>> mTopologyFrequency; //<freq,hash>, needed to define threshold
+    int mTotClusters;
+    int mNumberOfGroups;
+    int mNotInGroups;
+    double mFrequencyThreshold;
+    #ifdef _STUDY_
+      unordered_map<long unsigned,TopologyInfo> fMapInfo;
+    #endif
+    ClusterTopology mTopology;
+};
+}
+}
+#endif

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Cluster.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Cluster.h
@@ -31,7 +31,6 @@ class GeometryTGeo;
 
 class Cluster : public o2::BaseCluster<float>
 {
-
  public:
   enum { // frame in which the track is currently defined
     kUsed,
@@ -111,7 +110,7 @@ class Cluster : public o2::BaseCluster<float>
   void resetPattern();
   bool testPixel(UShort_t row, UShort_t col) const;
   void setPixel(UShort_t row, UShort_t col, bool fired = kTRUE);
-  void getPattern(void* destination,int nbytes) const { memcpy(destination,mPattern,nbytes); }
+  void getPattern(void* destination, int nbytes) const { memcpy(destination, mPattern, nbytes); }
   int getPatternRowMin() const { return mPatternRowMin; }
   int getPatternColMin() const { return mPatternColMin; }
 #endif
@@ -156,7 +155,7 @@ inline void Cluster::setClusterUsage(Int_t n)
   if (!n)
     resetBit(kUsed);
 }
-}
-}
+} // namespace ITSMFT
+} // namespace o2
 
 #endif /* ALICEO2_ITSMFT_CLUSTER_H */

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Cluster.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Cluster.h
@@ -31,6 +31,7 @@ class GeometryTGeo;
 
 class Cluster : public o2::BaseCluster<float>
 {
+
  public:
   enum { // frame in which the track is currently defined
     kUsed,
@@ -110,11 +111,7 @@ class Cluster : public o2::BaseCluster<float>
   void resetPattern();
   bool testPixel(UShort_t row, UShort_t col) const;
   void setPixel(UShort_t row, UShort_t col, bool fired = kTRUE);
-  void getPattern(UChar_t patt[kMaxPatternBytes])
-  {
-    for (int i = kMaxPatternBytes; i--;)
-      patt[i] = mPattern[i];
-  }
+  void getPattern(void* destination,int nbytes) const { memcpy(destination,mPattern,nbytes); }
   int getPatternRowMin() const { return mPatternRowMin; }
   int getPatternColMin() const { return mPatternColMin; }
 #endif

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Cluster.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Cluster.h
@@ -102,7 +102,7 @@ class Cluster : public o2::BaseCluster<float>
   int getPatternRowSpan() const { return mPatternNRows & kSpanMask; }
   int getPatternColSpan() const { return mPatternNCols & kSpanMask; }
   bool isPatternRowsTruncated() const { return mPatternNRows & kTruncateMask; }
-  bool isPatternColsTruncated() const { return mPatternNRows & kTruncateMask; }
+  bool isPatternColsTruncated() const { return mPatternNCols & kTruncateMask; }
   bool isPatternTruncated() const { return isPatternRowsTruncated() || isPatternColsTruncated(); }
   void setPatternRowSpan(UShort_t nr, bool truncated);
   void setPatternColSpan(UShort_t nc, bool truncated);

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ClusterTopology.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ClusterTopology.h
@@ -20,69 +20,68 @@
 /// bit-mask corresponding to the pixels of the cluster.
 ///
 
-
 #ifndef ALICEO2_ITSMFT_CLUSTERTOPOLOGY_H
 #define ALICEO2_ITSMFT_CLUSTERTOPOLOGY_H
-#include "ITSMFTReconstruction/Cluster.h"
+#include <Rtypes.h>
+#include <array>
 #include <iostream>
 #include <string>
-#include <array>
-#include <Rtypes.h>
+#include "ITSMFTReconstruction/Cluster.h"
 
 namespace o2
 {
 namespace ITSMFT
 {
+class ClusterTopology
+{
+ public:
+  /// Default constructor
+  ClusterTopology();
+  /// Standard constructor
+  ClusterTopology(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes]);
 
-class ClusterTopology {
+  /// Returns the pattern
+  const std::array<unsigned char, Cluster::kMaxPatternBytes + 2>& getPattern() const { return mPattern; }
+  /// Returns the number of rows
+  int getRowSpan() const { return (int)mPattern[0]; }
+  /// Returns the number of columns
+  int getColumnSpan() const { return (int)mPattern[1]; }
+  /// Returns the number of used bytes
+  int getUsedBytes() const { return mNbytes; }
+  /// Returns the hashcode
+  unsigned long getHash() const { return mHash; }
+  /// Prints the topology
+  friend std::ostream& operator<<(std::ostream& os, const ClusterTopology& top);
+  /// MurMur2 hash fucntion
+  static unsigned int hashFunction(const void* key, int len);
+  /// Compute the complete hash as defined for mHash
+  static unsigned long getCompleteHash(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes],
+                                       int nBytesUsed);
+  static unsigned long getCompleteHash(const ClusterTopology& topology);
+  /// Sets the pattern
+  void setPattern(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes]);
 
-  public:
-    /// Default constructor
-    ClusterTopology();
-    /// Standard constructor
-    ClusterTopology(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes]);
+ private:
+  /// Pattern:
+  ///
+  /// - 1st byte: number of rows
+  /// - 2nd byte: number of columns
+  /// - remainig bytes : pixels of the cluster, where 1 is a fired pixel and 0
+  /// is a non-fired pixel. The number of pixels used for the pixel depends on
+  /// the size of the bounding box
+  std::array<unsigned char, Cluster::kMaxPatternBytes + 2>
+    mPattern;  ///< Cluster pattern: 1 is a fired pixel and 0 is a non-fired pixel
+  int mNbytes; ///< Number of bytes that are effectively used in mPattern
+  /// Hashcode computed from the pattern
+  ///
+  /// The first four bytes are computed with MurMur2 hash-function. The remaining
+  /// four bytes are the first 32 pixels of the pattern. If the number of pixles
+  /// is less than 32, the remaining bits are set to 0.
+  unsigned long mHash;
 
-    /// Returns the pattern
-    const std::array<unsigned char,Cluster::kMaxPatternBytes+2>& getPattern() const { return mPattern; }
-    /// Returns the number of rows
-    int getRowSpan() const { return (int)mPattern[0]; }
-    /// Returns the number of columns
-    int getColumnSpan() const { return  (int)mPattern[1]; }
-    /// Returns the number of used bytes
-    int getUsedBytes() const { return mNbytes; }
-    /// Returns the hashcode
-    unsigned long getHash() const { return mHash; }
-    /// Prints the topology
-    friend std::ostream& operator<<(std::ostream& os, const ClusterTopology& top);
-    /// MurMur2 hash fucntion
-    static unsigned int hashFunction(const void * key, int len);
-    /// Compute the complete hash as defined for mHash
-    static unsigned long getCompleteHash(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes], int nBytesUsed);
-    static unsigned long getCompleteHash(const ClusterTopology& topology);
-    /// Sets the pattern
-    void setPattern(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes]);
-
-  private:
-    /// Pattern:
-    ///
-    /// - 1st byte: number of rows
-    /// - 2nd byte: number of columns
-    /// - remainig bytes : pixels of the cluster, where 1 is a fired pixel and 0
-    /// is a non-fired pixel. The number of pixels used for the pixel depends on
-    /// the size of the bounding box
-    std::array<unsigned char,Cluster::kMaxPatternBytes+2> mPattern; ///< Cluster pattern: 1 is a fired pixel and 0 is a non-fired pixel
-    int mNbytes; ///< Number of bytes that are effectively used in mPattern
-    /// Hashcode computed from the pattern
-    ///
-    /// The first four bytes are computed with MurMur2 hash-function. The remaining
-    /// four bytes are the first 32 pixels of the pattern. If the number of pixles
-    /// is less than 32, the remaining bits are set to 0.
-    unsigned long mHash;
-
-  ClassDefNV(ClusterTopology,1);
-
+  ClassDefNV(ClusterTopology, 1);
 };
-}
-}
+} // namespace ITSMFT
+} // namespace o2
 
 #endif /* ALICEO2_ITS_CLUSTERTOPOLOGY_H */

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ClusterTopology.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ClusterTopology.h
@@ -1,33 +1,85 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file ClusterTopology.h
+/// \brief Definition of the ClusterTopology class.
+///
+/// \author Luca Barioglio, University and INFN of Torino
+///
+/// Short ClusterTopology descritpion
+///
+/// This class is used to store the information concerning the shape of a cluster (topology),
+/// such as the size of the bounding box of the cluster (number of rows/columns) and the
+/// bit-mask corresponding to the pixels of the cluster.
+///
+
+
 #ifndef ALICEO2_ITSMFT_CLUSTERTOPOLOGY_H
 #define ALICEO2_ITSMFT_CLUSTERTOPOLOGY_H
 #include "ITSMFTReconstruction/Cluster.h"
 #include <iostream>
 #include <string>
+#include <array>
+#include <Rtypes.h>
 
 namespace o2
 {
 namespace ITSMFT
 {
 
-void convertClusterToString(const Cluster &cluster, std::string &str);
-
 class ClusterTopology {
 
   public:
+    /// Default constructor
     ClusterTopology();
-    ClusterTopology(const std::string &str);
+    /// Standard constructor
+    ClusterTopology(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes]);
 
-    std::string& getPattern() { return mPattern; }
-    int getRowSpan() const { return static_cast<int>(mPattern[0]); }
-    int getColumnSpan() const { return static_cast<int>(mPattern[1]); }
+    /// Returns the pattern
+    const std::array<unsigned char,Cluster::kMaxPatternBytes+2>& getPattern() const { return mPattern; }
+    /// Returns the number of rows
+    int getRowSpan() const { return (int)mPattern[0]; }
+    /// Returns the number of columns
+    int getColumnSpan() const { return  (int)mPattern[1]; }
+    /// Returns the number of used bytes
+    int getUsedBytes() const { return mNbytes; }
+    /// Returns the hashcode
     unsigned long getHash() const { return mHash; }
+    /// Prints the topology
     friend std::ostream& operator<<(std::ostream& os, const ClusterTopology& top);
+    /// MurMur2 hash fucntion
     static unsigned int hashFunction(const void * key, int len);
-    void setPattern(const std::string &str);
+    /// Compute the complete hash as defined for mHash
+    static unsigned long getCompleteHash(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes], int nBytesUsed);
+    static unsigned long getCompleteHash(const ClusterTopology& topology);
+    /// Sets the pattern
+    void setPattern(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes]);
 
   private:
-    std::string mPattern;
+    /// Pattern:
+    ///
+    /// - 1st byte: number of rows
+    /// - 2nd byte: number of columns
+    /// - remainig bytes : pixels of the cluster, where 1 is a fired pixel and 0
+    /// is a non-fired pixel. The number of pixels used for the pixel depends on
+    /// the size of the bounding box
+    std::array<unsigned char,Cluster::kMaxPatternBytes+2> mPattern; ///< Cluster pattern: 1 is a fired pixel and 0 is a non-fired pixel
+    int mNbytes; ///< Number of bytes that are effectively used in mPattern
+    /// Hashcode computed from the pattern
+    ///
+    /// The first four bytes are computed with MurMur2 hash-function. The remaining
+    /// four bytes are the first 32 pixels of the pattern. If the number of pixles
+    /// is less than 32, the remaining bits are set to 0.
     unsigned long mHash;
+
+  ClassDefNV(ClusterTopology,1);
 
 };
 }

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ClusterTopology.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ClusterTopology.h
@@ -1,0 +1,36 @@
+#ifndef ALICEO2_ITSMFT_CLUSTERTOPOLOGY_H
+#define ALICEO2_ITSMFT_CLUSTERTOPOLOGY_H
+#include "ITSMFTReconstruction/Cluster.h"
+#include <iostream>
+#include <string>
+
+namespace o2
+{
+namespace ITSMFT
+{
+
+void convertClusterToString(const Cluster &cluster, std::string &str);
+
+class ClusterTopology {
+
+  public:
+    ClusterTopology();
+    ClusterTopology(const std::string &str);
+
+    std::string& getPattern() { return mPattern; }
+    int getRowSpan() const { return static_cast<int>(mPattern[0]); }
+    int getColumnSpan() const { return static_cast<int>(mPattern[1]); }
+    unsigned long getHash() const { return mHash; }
+    friend std::ostream& operator<<(std::ostream& os, const ClusterTopology& top);
+    static unsigned int hashFunction(const void * key, int len);
+    void setPattern(const std::string &str);
+
+  private:
+    std::string mPattern;
+    unsigned long mHash;
+
+};
+}
+}
+
+#endif /* ALICEO2_ITS_CLUSTERTOPOLOGY_H */

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
@@ -13,11 +13,11 @@
 #ifndef ALICEO2_ITS_CLUSTERER_H
 #define ALICEO2_ITS_CLUSTERER_H
 
-#include "ITSMFTReconstruction/Cluster.h"
-#include "ITSMFTBase/GeometryTGeo.h"
-#include "ITSMFTReconstruction/PixelReader.h"
 #include <utility>
 #include <vector>
+#include "ITSMFTBase/GeometryTGeo.h"
+#include "ITSMFTReconstruction/Cluster.h"
+#include "ITSMFTReconstruction/PixelReader.h"
 
 #include "Rtypes.h"
 
@@ -26,21 +26,20 @@ namespace o2
 class MCCompLabel;
 namespace dataformats
 {
-  template<typename T>
-  class MCTruthContainer;
+template <typename T>
+class MCTruthContainer;
 }
 
 namespace ITSMFT
 {
-  
-class Clusterer {
-  
+class Clusterer
+{
   using PixelReader = o2::ITSMFT::PixelReader;
   using PixelData = o2::ITSMFT::PixelReader::PixelData;
   using ChipPixelData = o2::ITSMFT::PixelReader::ChipPixelData;
   using Cluster = o2::ITSMFT::Cluster;
   using Label = o2::MCCompLabel;
-  
+
  public:
   Clusterer();
   ~Clusterer() = default;
@@ -48,44 +47,39 @@ class Clusterer {
   Clusterer(const Clusterer&) = delete;
   Clusterer& operator=(const Clusterer&) = delete;
 
-  void process(PixelReader &r, std::vector<Cluster> &clusters);
-  
+  void process(PixelReader& r, std::vector<Cluster>& clusters);
+
   // provide the common ITSMFT::GeometryTGeo to access matrices
-  void setGeometry(const o2::ITSMFT::GeometryTGeo* gm) { mGeometry = gm;}
-  void setMCTruthContainer(o2::dataformats::MCTruthContainer<o2::MCCompLabel> *truth) {
-    mClsLabels = truth;
-  }
-  
+  void setGeometry(const o2::ITSMFT::GeometryTGeo* gm) { mGeometry = gm; }
+  void setMCTruthContainer(o2::dataformats::MCTruthContainer<o2::MCCompLabel>* truth) { mClsLabels = truth; }
+
  private:
-  
-  enum {kMaxRow=650}; //Anything larger than the real number of rows (512 for ALPIDE)
+  enum { kMaxRow = 650 }; // Anything larger than the real number of rows (512 for ALPIDE)
   void initChip();
   void updateChip(int ip);
-  void finishChip(std::vector<Cluster> &clusters);
-  void fetchMCLabels(const PixelData* pix, std::array<Label,Cluster::maxLabels> &labels, int &nfilled) const;
+  void finishChip(std::vector<Cluster>& clusters);
+  void fetchMCLabels(const PixelData* pix, std::array<Label, Cluster::maxLabels>& labels, int& nfilled) const;
 
-  ChipPixelData mChipData;   ///< single chip data provided by the reader
-  
-  Int_t mColumn1[kMaxRow+2];
-  Int_t mColumn2[kMaxRow+2];
+  ChipPixelData mChipData; ///< single chip data provided by the reader
+
+  Int_t mColumn1[kMaxRow + 2];
+  Int_t mColumn2[kMaxRow + 2];
   Int_t *mCurr, *mPrev;
-  
+
   using NextIndex = Int_t;
-  std::vector< std::pair<NextIndex, const PixelData*> > mPixels;
+  std::vector<std::pair<NextIndex, const PixelData*>> mPixels;
 
   using FirstIndex = Int_t;
-  std::vector< FirstIndex > mPreClusterHeads;
-  
-  std::vector<Int_t> mPreClusterIndices;
-  
-  UShort_t mCol = 0xffff;    ///< Column being processed
+  std::vector<FirstIndex> mPreClusterHeads;
 
-  const o2::ITSMFT::GeometryTGeo* mGeometry = nullptr;    ///< ITS OR MFT upgrade geometry
-  o2::dataformats::MCTruthContainer<o2::MCCompLabel> *mClsLabels = nullptr; // Cluster MC labels
+  std::vector<Int_t> mPreClusterIndices;
+
+  UShort_t mCol = 0xffff; ///< Column being processed
+
+  const o2::ITSMFT::GeometryTGeo* mGeometry = nullptr;                      ///< ITS OR MFT upgrade geometry
+  o2::dataformats::MCTruthContainer<o2::MCCompLabel>* mClsLabels = nullptr; // Cluster MC labels
 };
 
-
-
-}
-}
+} // namespace ITSMFT
+} // namespace o2
 #endif /* ALICEO2_ITS_CLUSTERER_H */

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/LookUp.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/LookUp.h
@@ -21,28 +21,28 @@
 
 #ifndef ALICEO2_ITSMFT_LOOKUP_H
 #define ALICEO2_ITSMFT_LOOKUP_H
-#include "ITSMFTReconstruction/TopologyDictionary.h"
-#include "ITSMFTReconstruction/ClusterTopology.h"
 #include <array>
+#include "ITSMFTReconstruction/ClusterTopology.h"
+#include "ITSMFTReconstruction/TopologyDictionary.h"
 
 namespace o2
 {
 namespace ITSMFT
 {
-class LookUp{
+class LookUp
+{
+ public:
+  LookUp(std::string fileName);
+  int findGroupID(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes], int nBytesUsed);
+  int getTopologiesOverThreshold() { return mTopologiesOverThreshold; }
 
-  public:
-    LookUp(std::string fileName);
-    int findGroupID(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes], int nBytesUsed);
-    int getTopologiesOverThreshold() {return mTopologiesOverThreshold;}
+ private:
+  TopologyDictionary mDictionary;
+  int mTopologiesOverThreshold;
 
-  private:
-    TopologyDictionary mDictionary;
-    int mTopologiesOverThreshold;
-
-  ClassDefNV(LookUp,1);
+  ClassDefNV(LookUp, 1);
 };
-}
-}
+} // namespace ITSMFT
+} // namespace o2
 
 #endif

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/LookUp.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/LookUp.h
@@ -1,0 +1,27 @@
+#ifndef ALICEO2_ITSMFT_LOOKUP_H
+#define ALICEO2_ITSMFT_LOOKUP_H
+#include "ITSMFTReconstruction/TopologyDictionary.h"
+#include "ITSMFTReconstruction/ClusterTopology.h"
+
+using std::vector;
+using std::unordered_map;
+
+namespace o2
+{
+namespace ITSMFT
+{
+class LookUp{
+  public:
+    LookUp(std::string fileName);
+    int findGroupID(const std::string& cluster);
+    int getTopologiesOverThreshold() {return mTopologiesOverThreshold;}
+
+  private:
+    TopologyDictionary mDictionary;
+    int mTopologiesOverThreshold;
+    ClusterTopology mTopology;
+};
+}
+}
+
+#endif

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/PixelReader.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/PixelReader.h
@@ -21,43 +21,38 @@ namespace o2
 {
 namespace ITSMFT
 {
- 
-  
 /// \class PixelReader
 /// \brief PixelReader class for the ITSMFT
 ///
-class PixelReader {
-
+class PixelReader
+{
   using Label = o2::MCCompLabel;
 
-  public:
-
+ public:
   /// Transient data for single fired pixel
   struct PixelData {
     UShort_t row;
-    UShort_t col;  
+    UShort_t col;
     Label labels[Digit::maxLabels];
-    
-    PixelData(const Digit* dig) :
-    row(dig->getRow()), col(dig->getColumn())
+
+    PixelData(const Digit* dig) : row(dig->getRow()), col(dig->getColumn())
     {
-      for (int i=Digit::maxLabels;i--;) labels[i]=dig->getLabel(i);
+      for (int i = Digit::maxLabels; i--;)
+        labels[i] = dig->getLabel(i);
     }
     PixelData(UShort_t r, UShort_t c) : row(r), col(c) {}
   };
 
   /// Transient data for single chip fired pixeld
   struct ChipPixelData {
-    UShort_t chipID = 0;               // chip id within detector
-    UInt_t   roFrame = 0;              // readout frame ID
-    Double_t timeStamp = 0.;                 // Fair time ?
-    std::vector<PixelData> pixels;     // vector of pixeld
-    
-    void clear() {
-      pixels.clear();
-    }
+    UShort_t chipID = 0;           // chip id within detector
+    UInt_t roFrame = 0;            // readout frame ID
+    Double_t timeStamp = 0.;       // Fair time ?
+    std::vector<PixelData> pixels; // vector of pixeld
+
+    void clear() { pixels.clear(); }
   };
-  
+
   PixelReader() = default;
   PixelReader(const PixelReader& cluster) = delete;
   virtual ~PixelReader() = default;
@@ -65,51 +60,55 @@ class PixelReader {
   PixelReader& operator=(const PixelReader& src) = delete;
 
   virtual void init() = 0;
-  virtual Bool_t getNextChipData(ChipPixelData &chipData) = 0;
+  virtual Bool_t getNextChipData(ChipPixelData& chipData) = 0;
   //
  protected:
   //
-
 };
 
 /// \class DigitPixelReader
 /// \brief DigitPixelReader class for the ITS. Feeds the MC digits to the Cluster Finder
 ///
-class DigitPixelReader : public PixelReader {
-  
+class DigitPixelReader : public PixelReader
+{
  public:
   DigitPixelReader() = default;
-  void setDigitArray(const std::vector<o2::ITSMFT::Digit> *a) { mDigitArray=a; mIdx=0; }
+  void setDigitArray(const std::vector<o2::ITSMFT::Digit>* a)
+  {
+    mDigitArray = a;
+    mIdx = 0;
+  }
 
-  void init() override {
-    mIdx=0;
+  void init() override
+  {
+    mIdx = 0;
     mLastDigit = nullptr;
   }
-  
-  Bool_t getNextChipData(ChipPixelData &chipData) override;
+
+  Bool_t getNextChipData(ChipPixelData& chipData) override;
 
  private:
-
-  void addPixel(PixelReader::ChipPixelData &chipData, const Digit* dig) {
+  void addPixel(PixelReader::ChipPixelData& chipData, const Digit* dig)
+  {
     // add new fired pixel
     chipData.pixels.emplace_back(dig);
   }
-  
-  const std::vector<o2::ITSMFT::Digit> *mDigitArray = nullptr;
+
+  const std::vector<o2::ITSMFT::Digit>* mDigitArray = nullptr;
   const Digit* mLastDigit = nullptr;
-  Int_t        mIdx = 0;
+  Int_t mIdx = 0;
 };
- 
+
 /// \class RawPixelReader
 /// \brief RawPixelReader class for the ITS. Feeds raw data to the Cluster Finder
 ///
-class RawPixelReader : public PixelReader {
+class RawPixelReader : public PixelReader
+{
  public:
-  Bool_t getNextChipData(ChipPixelData &chipData) override;
+  Bool_t getNextChipData(ChipPixelData& chipData) override;
 };
 
-
-}
-}
+} // namespace ITSMFT
+} // namespace o2
 
 #endif /* ALICEO2_ITS_PIXELREADER_H */

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/TopologyDictionary.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/TopologyDictionary.h
@@ -27,60 +27,61 @@
 
 #ifndef ALICEO2_ITSMFT_TOPOLOGYDICTIONARY_H
 #define ALICEO2_ITSMFT_TOPOLOGYDICTIONARY_H
-#include <vector>
-#include <unordered_map>
-#include <string>
-#include <iostream>
-#include <fstream>
 #include <Rtypes.h>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 namespace o2
 {
 namespace ITSMFT
 {
-
 class BuildTopologyDictionary;
 class LookUp;
 class TopologyFastSimulation;
 
 /// Structure containing the most relevant pieces of information of a topology
-struct GroupStruct{
+struct GroupStruct {
   unsigned long mHash; ///< Hashcode
-  float mErrX; ///< Error associated to the hit point in the x direction.
-  float mErrZ; ///< Error associated to the hit point in the z direction.
-  float mXCOG; ///< x position of te COG wrt the boottom left corner of the bounding box
-  float mZCOG; ///< z position of te COG wrt the boottom left corner of the bounding box
-  int mNpixels; ///< Number of fired pixels
-  double mFrequency; ///< Frequency of the topology
+  float mErrX;         ///< Error associated to the hit point in the x direction.
+  float mErrZ;         ///< Error associated to the hit point in the z direction.
+  float mXCOG;         ///< x position of te COG wrt the boottom left corner of the bounding box
+  float mZCOG;         ///< z position of te COG wrt the boottom left corner of the bounding box
+  int mNpixels;        ///< Number of fired pixels
+  double mFrequency;   ///< Frequency of the topology
 };
 
-class TopologyDictionary{
-  public:
-    /// constexpr for the definition of the groups of rare topologies
-    static constexpr int NumberOfRowClasses = 7; ///< Number of row classes for the groups of rare topologies
-    static constexpr int NumberOfColClasses = 7; ///< Number of column classes for the groups of rare topologies
-    static constexpr int RowClassSpan = 5; ///< Row span of the classes of rare topologies
-    static constexpr int ColClassSpan = 5; ///< Column span of the classes of rare topologies
-    static constexpr int MaxRowSpan = 32; ///< Maximum row span
-    static constexpr int MaxColSpan = 32; ///< Maximum column span
-    /// Prints the dictionary
-    friend std::ostream& operator<<(std::ostream& os, const TopologyDictionary& dictionary);
-    /// Prints the dictionary in a binary file
-    void WriteBinaryFile(std::string outputFile);
-    /// Reads the dictionary from a file
-    void ReadFile(std::string fileName);
-    /// Reads the dictionary from a binary file
-    void ReadBinaryFile(std::string fileName);
-    friend BuildTopologyDictionary;
-    friend LookUp;
-    friend TopologyFastSimulation;
-  private:
-    std::unordered_map<unsigned long, int> mFinalMap; ///< Map of pair <hash, position in mVectorOfGroupIDs>
-    std::vector<GroupStruct> mVectorOfGroupIDs; ///< Vector of topologies and groups
+class TopologyDictionary
+{
+ public:
+  /// constexpr for the definition of the groups of rare topologies
+  static constexpr int NumberOfRowClasses = 7; ///< Number of row classes for the groups of rare topologies
+  static constexpr int NumberOfColClasses = 7; ///< Number of column classes for the groups of rare topologies
+  static constexpr int RowClassSpan = 5;       ///< Row span of the classes of rare topologies
+  static constexpr int ColClassSpan = 5;       ///< Column span of the classes of rare topologies
+  static constexpr int MaxRowSpan = 32;        ///< Maximum row span
+  static constexpr int MaxColSpan = 32;        ///< Maximum column span
+  /// Prints the dictionary
+  friend std::ostream& operator<<(std::ostream& os, const TopologyDictionary& dictionary);
+  /// Prints the dictionary in a binary file
+  void WriteBinaryFile(std::string outputFile);
+  /// Reads the dictionary from a file
+  void ReadFile(std::string fileName);
+  /// Reads the dictionary from a binary file
+  void ReadBinaryFile(std::string fileName);
+  friend BuildTopologyDictionary;
+  friend LookUp;
+  friend TopologyFastSimulation;
 
-  ClassDefNV(TopologyDictionary,1);
+ private:
+  std::unordered_map<unsigned long, int> mFinalMap; ///< Map of pair <hash, position in mVectorOfGroupIDs>
+  std::vector<GroupStruct> mVectorOfGroupIDs;       ///< Vector of topologies and groups
+
+  ClassDefNV(TopologyDictionary, 1);
 };
-}
-}
+} // namespace ITSMFT
+} // namespace o2
 
 #endif

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/TopologyDictionary.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/TopologyDictionary.h
@@ -1,3 +1,30 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TopologyDictionary.h
+/// \brief Definition of the ClusterTopology class.
+///
+/// \author Luca Barioglio, University and INFN of Torino
+///
+/// Short TopologyDictionary descritpion
+///
+/// The entries of the dictionaries are the cluster topologies, with all the indormation
+/// which is common to the clusters with the same topology:
+/// - number of rows
+/// - number of columns
+/// - position of the Centre Of Gravity (COG) wrt the bottom left corner pixel of the bounding box
+/// - error associated to the position of the hit point
+/// Rare topologies, i.e. with a frequency below a threshold defined a priori, have not their own entries
+/// in the dictionaries, but are grouped together with topologies with similar dimensions.
+///
+
 #ifndef ALICEO2_ITSMFT_TOPOLOGYDICTIONARY_H
 #define ALICEO2_ITSMFT_TOPOLOGYDICTIONARY_H
 #include <vector>
@@ -5,10 +32,7 @@
 #include <string>
 #include <iostream>
 #include <fstream>
-
-using std::vector;
-using std::unordered_map;
-using std::string;
+#include <Rtypes.h>
 
 namespace o2
 {
@@ -17,25 +41,44 @@ namespace ITSMFT
 
 class BuildTopologyDictionary;
 class LookUp;
+class TopologyFastSimulation;
 
+/// Structure containing the most relevant pieces of information of a topology
 struct GroupStruct{
-  unsigned long hash;
-  float errX;
-  float errZ;
-  double frequency;
+  unsigned long mHash; ///< Hashcode
+  float mErrX; ///< Error associated to the hit point in the x direction.
+  float mErrZ; ///< Error associated to the hit point in the z direction.
+  float mXCOG; ///< x position of te COG wrt the boottom left corner of the bounding box
+  float mZCOG; ///< z position of te COG wrt the boottom left corner of the bounding box
+  int mNpixels; ///< Number of fired pixels
+  double mFrequency; ///< Frequency of the topology
 };
 
 class TopologyDictionary{
   public:
+    /// constexpr for the definition of the groups of rare topologies
+    static constexpr int NumberOfRowClasses = 7; ///< Number of row classes for the groups of rare topologies
+    static constexpr int NumberOfColClasses = 7; ///< Number of column classes for the groups of rare topologies
+    static constexpr int RowClassSpan = 5; ///< Row span of the classes of rare topologies
+    static constexpr int ColClassSpan = 5; ///< Column span of the classes of rare topologies
+    static constexpr int MaxRowSpan = 32; ///< Maximum row span
+    static constexpr int MaxColSpan = 32; ///< Maximum column span
+    /// Prints the dictionary
     friend std::ostream& operator<<(std::ostream& os, const TopologyDictionary& dictionary);
-    void WriteBinaryFile(string outputFile);
-    void ReadFile(string fileName);
-    void ReadBinaryFile(string fileName);
+    /// Prints the dictionary in a binary file
+    void WriteBinaryFile(std::string outputFile);
+    /// Reads the dictionary from a file
+    void ReadFile(std::string fileName);
+    /// Reads the dictionary from a binary file
+    void ReadBinaryFile(std::string fileName);
     friend BuildTopologyDictionary;
     friend LookUp;
+    friend TopologyFastSimulation;
   private:
-    unordered_map<unsigned long, int> mFinalMap; //<hash,groupID> just for topologies over threshold
-    vector<GroupStruct> mVectorOfGroupIDs;
+    std::unordered_map<unsigned long, int> mFinalMap; ///< Map of pair <hash, position in mVectorOfGroupIDs>
+    std::vector<GroupStruct> mVectorOfGroupIDs; ///< Vector of topologies and groups
+
+  ClassDefNV(TopologyDictionary,1);
 };
 }
 }

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/TopologyDictionary.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/TopologyDictionary.h
@@ -15,6 +15,8 @@ namespace o2
 namespace ITSMFT
 {
 
+class BuildTopologyDictionary;
+
 struct GroupStruct{
   unsigned long hash;
   float errX;
@@ -28,6 +30,7 @@ class TopologyDictionary{
     void WriteBinaryFile(string outputFile);
     void ReadFile(string fileName);
     void ReadBinaryFile(string fileName);
+    friend BuildTopologyDictionary;
   private:
     unordered_map<unsigned long, int> mFinalMap; //<hash,groupID> just for topologies over threshold
     vector<GroupStruct> mVectorOfGroupIDs;

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/TopologyDictionary.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/TopologyDictionary.h
@@ -16,6 +16,7 @@ namespace ITSMFT
 {
 
 class BuildTopologyDictionary;
+class LookUp;
 
 struct GroupStruct{
   unsigned long hash;
@@ -31,6 +32,7 @@ class TopologyDictionary{
     void ReadFile(string fileName);
     void ReadBinaryFile(string fileName);
     friend BuildTopologyDictionary;
+    friend LookUp;
   private:
     unordered_map<unsigned long, int> mFinalMap; //<hash,groupID> just for topologies over threshold
     vector<GroupStruct> mVectorOfGroupIDs;

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/TopologyDictionary.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/TopologyDictionary.h
@@ -1,0 +1,38 @@
+#ifndef ALICEO2_ITSMFT_TOPOLOGYDICTIONARY_H
+#define ALICEO2_ITSMFT_TOPOLOGYDICTIONARY_H
+#include <vector>
+#include <unordered_map>
+#include <string>
+#include <iostream>
+#include <fstream>
+
+using std::vector;
+using std::unordered_map;
+using std::string;
+
+namespace o2
+{
+namespace ITSMFT
+{
+
+struct GroupStruct{
+  unsigned long hash;
+  float errX;
+  float errZ;
+  double frequency;
+};
+
+class TopologyDictionary{
+  public:
+    friend std::ostream& operator<<(std::ostream& os, const TopologyDictionary& dictionary);
+    void WriteBinaryFile(string outputFile);
+    void ReadFile(string fileName);
+    void ReadBinaryFile(string fileName);
+  private:
+    unordered_map<unsigned long, int> mFinalMap; //<hash,groupID> just for topologies over threshold
+    vector<GroupStruct> mVectorOfGroupIDs;
+};
+}
+}
+
+#endif

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/TopologyFastSimulation.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/TopologyFastSimulation.h
@@ -19,30 +19,29 @@
 /// to the frequencies of the entries in the dictionary
 ///
 
-
 #ifndef ALICEO2_ITSMFT_TOPOLOGYFASTSIMULATION_H
 #define ALICEO2_ITSMFT_TOPOLOGYFASTSIMULATION_H
-#include "ITSMFTReconstruction/TopologyDictionary.h"
 #include <random>
+#include "ITSMFTReconstruction/TopologyDictionary.h"
 
 namespace o2
 {
 namespace ITSMFT
 {
-class TopologyFastSimulation{
+class TopologyFastSimulation
+{
+ public:
+  TopologyFastSimulation(std::string fileName, unsigned seed = 0xdeadbeef);
+  int getRandom();
 
-  public:
-    TopologyFastSimulation(std::string fileName, unsigned seed=0xdeadbeef);
-    int getRandom();
+ private:
+  TopologyDictionary mDictionary;
+  std::mt19937 mGenerator;
+  std::uniform_real_distribution<double> mDistribution;
 
-  private:
-    TopologyDictionary mDictionary;
-    std::mt19937 mGenerator;
-    std::uniform_real_distribution<double> mDistribution;
-
-  ClassDefNV(TopologyFastSimulation,1);
+  ClassDefNV(TopologyFastSimulation, 1);
 };
-}
-}
+} // namespace ITSMFT
+} // namespace o2
 
 #endif

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/TopologyFastSimulation.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/TopologyFastSimulation.h
@@ -8,39 +8,39 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file LookUp.h
-/// \brief Definition of the LookUp class.
+/// \file TopologyFastSimulation.h
+/// \brief Definition of the TopologyFastSimulation class.
 ///
 /// \author Luca Barioglio, University and INFN of Torino
 ///
-/// Short LookUp descritpion
+/// Short TopologyFastSimulation descritpion
 ///
-/// This class is for the association of the cluster topology with the corresponding
-/// entry in the dictionary
+/// This class is used for the generation of a distribution of topologies according to
+/// to the frequencies of the entries in the dictionary
 ///
 
-#ifndef ALICEO2_ITSMFT_LOOKUP_H
-#define ALICEO2_ITSMFT_LOOKUP_H
+
+#ifndef ALICEO2_ITSMFT_TOPOLOGYFASTSIMULATION_H
+#define ALICEO2_ITSMFT_TOPOLOGYFASTSIMULATION_H
 #include "ITSMFTReconstruction/TopologyDictionary.h"
-#include "ITSMFTReconstruction/ClusterTopology.h"
-#include <array>
+#include <random>
 
 namespace o2
 {
 namespace ITSMFT
 {
-class LookUp{
+class TopologyFastSimulation{
 
   public:
-    LookUp(std::string fileName);
-    int findGroupID(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes], int nBytesUsed);
-    int getTopologiesOverThreshold() {return mTopologiesOverThreshold;}
+    TopologyFastSimulation(std::string fileName, unsigned seed=0xdeadbeef);
+    int getRandom();
 
   private:
     TopologyDictionary mDictionary;
-    int mTopologiesOverThreshold;
+    std::mt19937 mGenerator;
+    std::uniform_real_distribution<double> mDistribution;
 
-  ClassDefNV(LookUp,1);
+  ClassDefNV(TopologyFastSimulation,1);
 };
 }
 }

--- a/Detectors/ITSMFT/common/reconstruction/src/BuildTopologyDictionary.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/BuildTopologyDictionary.cxx
@@ -1,0 +1,250 @@
+#include "ITSMFTReconstruction/BuildTopologyDictionary.h"
+#include <cmath>
+
+using namespace std;
+
+namespace o2
+{
+namespace ITSMFT
+{
+  BuildTopologyDictionary::BuildTopologyDictionary():mTotClusters(0){}
+
+#ifndef _STUDY_
+  void BuildTopologyDictionary::accountTopology(const std::string &cluster){
+    mTotClusters++;
+    fTtop.setPattern(cluster);
+    //pair<unordered_map<unsigned long, pair<ClusterTopology,unsigned long>>::iterator,bool> ret;
+    auto ret = mTopologyMap.insert(make_pair(mTopology.getHash(),make_pair(mTopology,1)));
+    if(ret.second==false) ret.first->second.second++;
+  }
+#else
+  void BuildTopologyDictionary::accountTopology(const std::string &cluster, float dX, float dZ){
+    mTotClusters++;
+    mTopology.setPattern(cluster);
+    //pair<unordered_map<unsigned long, pair<ClusterTopology,unsigned long>>::iterator,bool> ret;
+    auto ret = mTopologyMap.insert(make_pair(mTopology.getHash(),make_pair(mTopology,1)));
+    if(ret.second==true){
+      //___________________DEFINING_TOPOLOGY_CHARACTERISTICS__________________
+      TopologyInfo topInf;
+      int &rs = topInf.sizeX = mTopology.getRowSpan();
+      int &cs = topInf.sizeZ = mTopology.getColumnSpan();
+      //__________________COG_Deterrmination_____________
+      int tempyCOG = 0;
+      int tempzCOG = 0;
+      int tempFiredPixels = 0;
+      unsigned char tempChar = 0;
+      int s = 0;
+      int ic = 0;
+      int ir = 0;
+      for(unsigned int i=2; i<mTopology.getPattern().length(); i++){
+        tempChar = mTopology.getPattern()[i];
+        s=128;//0b10000000
+        while(s>0){
+          if((tempChar&s)!=0){
+            tempFiredPixels++;
+            tempyCOG+=ir;
+            tempzCOG+=ic;
+          }
+          ic++;
+          s/=2;
+          if((ir+1)*ic==(rs*cs)) break;
+          if(ic==cs){
+            ic=0;
+            ir++;
+          }
+        }
+        if((ir+1)*ic==(rs*cs)) break;
+      }
+      topInf.xCOG = 0.5 + (float)tempyCOG/(float)tempFiredPixels;
+      topInf.zCOG = 0.5 + (float)tempzCOG/(float)tempFiredPixels;
+      topInf.nPixels = tempFiredPixels;
+      topInf.xMean = dX;
+      topInf.xSigma2 = 0;
+      topInf.zMean = dZ;
+      topInf.zSigma2 = 0;
+      fMapInfo.insert(make_pair(mTopology.getHash(),topInf));
+    }
+    else{
+      int num = (ret.first->second.second++);
+      auto ind = fMapInfo.find(mTopology.getHash());
+      float tmpxMean = ind->second.xMean;
+      float newxMean = ind->second.xMean = ( (tmpxMean)*num + dX ) / (num+1);
+      float tmpxSigma2 = ind->second.xSigma2;
+      ind->second.xSigma2 = ( num*tmpxSigma2 + (dX - tmpxMean)*(dX - newxMean) ) / (num+1); //online variance algorithm
+      float tmpzMean = ind->second.zMean;
+      float newzMean = ind->second.zMean = ( (tmpzMean)*num + dZ ) / (num+1);
+      float tmpzSigma2 = ind->second.zSigma2;
+      ind->second.zSigma2 = ( num*tmpzSigma2 + (dZ - tmpzMean)*(dZ - newzMean) ) / (num+1); //online variance algorithm
+    }
+  }
+#endif
+
+unsigned long BuildTopologyDictionary::checkHash(const std::string &clust){
+  mTopology.setPattern(clust);
+  return mTopology.getHash();
+}
+
+void BuildTopologyDictionary::setThreshold(double thr){
+  for(auto &&p : mTopologyMap){
+    mTopologyFrequency.push_back(make_pair(p.second.second,p.first));
+  }
+  std::sort(mTopologyFrequency.begin(),mTopologyFrequency.end(), [] (const pair<unsigned long, unsigned long> &couple1, const pair<unsigned long, unsigned long> &couple2){return (couple1.first > couple2.first);});
+  mNotInGroups = 0;
+  mNumberOfGroups = 0;
+  mDictionary.mFinalMap.clear();
+  mFrequencyThreshold=thr;
+  for(auto &q : mTopologyFrequency){
+    if( ((double)q.first)/mTotClusters > thr ) mNotInGroups++;
+    else break;
+  }
+  mNumberOfGroups=mNotInGroups;
+}
+
+void BuildTopologyDictionary::setNGroups(unsigned int ngr){
+  for(auto &&p : mTopologyMap){
+    mTopologyFrequency.push_back(make_pair(p.second.second,p.first));
+  }
+  std::sort(mTopologyFrequency.begin(),mTopologyFrequency.end(), [] (const pair<unsigned long, unsigned long> &couple1, const pair<unsigned long, unsigned long> &couple2){return (couple1.first > couple2.first);});
+  if(ngr<10 || ngr > (mTopologyFrequency.size()-49)){
+    cout << "BuildTopologyDictionary::setNGroups : Invalid number of groups" << endl;
+    exit(1);
+  }
+  mNumberOfGroups = mNotInGroups = ngr-49;
+  mDictionary.mFinalMap.clear();
+  mFrequencyThreshold=((double)mTopologyFrequency[mNotInGroups-1].first)/mTotClusters;
+}
+
+void BuildTopologyDictionary::setThresholdCumulative(double cumulative){
+  cout<<"setThresholdCumulative: mTotClusters: " << mTotClusters << endl;
+  if(cumulative<=0. || cumulative >=1.) cumulative = 0.99;
+  double totFreq = 0.;
+  for(auto &&p : mTopologyMap){
+    mTopologyFrequency.push_back(make_pair(p.second.second,p.first));
+  }
+  std::sort(mTopologyFrequency.begin(),mTopologyFrequency.end(), [] (const pair<unsigned long, unsigned long> &couple1, const pair<unsigned long, unsigned long> &couple2){return (couple1.first > couple2.first);});
+  mNotInGroups = 0;
+  mNumberOfGroups = 0;
+  mDictionary.mFinalMap.clear();
+  for(auto &q : mTopologyFrequency){
+    totFreq += ((double)(q.first))/mTotClusters;
+    if(totFreq<cumulative){
+      mNotInGroups++;
+    }
+    else break;
+  }
+  mFrequencyThreshold=((double)(mTopologyFrequency[--mNotInGroups].first))/mTotClusters;
+  while(((double)mTopologyFrequency[mNotInGroups].first)/mTotClusters == mFrequencyThreshold) mNotInGroups--;
+  mFrequencyThreshold=((double)mTopologyFrequency[mNotInGroups++].first)/mTotClusters;
+  mNumberOfGroups=mNotInGroups;
+}
+
+void BuildTopologyDictionary::groupRareTopologies(){
+
+  cout<<"groupRareTopologies: mTotClusters: " << mTotClusters << endl;
+  #ifdef _HISTO_
+    mHdist = TH1F("mHdist", "Groups distribution", mNumberOfGroups+49, -0.5, mNumberOfGroups+48.5);
+    mHdist.getXaxis()->setTitle("GroupID");
+    mHdist.setFillColor(kRed);
+    mHdist.setFillStyle(3005);
+  #endif
+
+  double totFreq=0.;
+  for(int j=0; j<mNotInGroups; j++){
+    #ifdef _HISTO_
+      mHdist.Fill(j,mTopologyFrequency[j].first);
+    #endif
+    totFreq+=((double)(mTopologyFrequency[j].first))/mTotClusters;
+    GroupStruct gr;
+    gr.hash=mTopologyFrequency[j].second;
+    gr.frequency=totFreq;
+    //rough estimation for the error considering a uniform distribution
+    gr.errX = std::sqrt(fMapInfo.find(gr.hash)->second.xSigma2);
+    gr.errZ = std::sqrt(fMapInfo.find(gr.hash)->second.zSigma2);
+    mDictionary.mVectorOfGroupIDs.push_back(gr);
+    mDictionary.mFinalMap.insert(make_pair(gr.hash,j));
+  }
+  //groupRareTopologies based on binning over number of rows and columns (7*7)
+  mNumberOfGroups+=49; //(7*7)
+  //array of groups
+  std::array<GroupStruct,49> GroupArray;
+  std::array<unsigned long,49> groupCounts{0};
+  auto func = [&GroupArray] (int rowBinEdge, int colBinEdge, int &index) {
+    unsigned long provvHash = 0;
+    provvHash = ( ((unsigned long)(index+1)) << 32 ) & 0xffffffff00000000;
+    GroupArray[index].hash = provvHash;
+    GroupArray[index].errX = (rowBinEdge)*2e-3/std::sqrt(12); // 2e-3 is the pitch
+    GroupArray[index].errZ = (colBinEdge)*2e-3/std::sqrt(12); // 2e-3 is the pitch
+    index++;
+    return;
+  };
+  int grNum=0;
+  for(int ir=0; ir<6; ir++){ //row bins: {[0;4],[5;9],[10;14],[15;19],[20;24],[25,29]} (+ [30;32] later)
+    for(int ic=0; ic<6; ic++){ //col bins: {[0;4],[5;9],[10;14],[15;19],[20;24],[25,29]} (+ [30;32] later)
+      func((ir+1)*5-1, (ic+1)*5-1, grNum);
+    }
+    // col bin [30;32]
+    func((ir+1)*5-1, 32, grNum);
+  }
+  // row bin [30;32]
+  for(int ic=0; ic<6; ic++){ //col bins: {[0;4],[5;9],[10;14],[15;19],[20;24],[25,29]} (+ [30;32] later)
+    func(32, (ic+1)*5-1, grNum);
+    unsigned long provvHash = 0;
+  }
+  func(32, 32, grNum);
+  if(grNum!=49){
+    cout << "Wrong number of groups" << endl;
+    exit(1);
+  }
+  int rs;
+  int cs;
+  int index;
+
+  for(unsigned int j = (unsigned int)mNotInGroups; j<mTopologyFrequency.size(); j++){
+    unsigned long
+    hash1 = mTopologyFrequency[j].second;
+    rs = mTopologyMap.find(hash1)->second.first.getRowSpan();
+    cs = mTopologyMap.find(hash1)->second.first.getColumnSpan();
+    index = (rs/5)*7 + cs/5;
+    if(index >48) index = 48;
+    groupCounts[index]+=mTopologyFrequency[j].first;
+  }
+
+  for(int i=0; i<49; i++){
+    totFreq+=((double)groupCounts[i])/mTotClusters;
+    GroupArray[i].frequency = totFreq;
+    #ifdef _HISTO_
+      mHdist.Fill(mNotInGroups+i,groupCounts[i]);
+    #endif
+    mDictionary.mVectorOfGroupIDs.push_back(GroupArray[i]);
+  }
+  #ifdef _HISTO_
+    mHdist.Scale(1./mHdist.Integral());
+  #endif
+}
+
+
+std::ostream& operator<<(std::ostream& os, const BuildTopologyDictionary& DB){
+  for(int i=0; i<DB.mNotInGroups; i++){
+    const unsigned long &hash = DB.mTopologyFrequency[i].second;
+    os << "Hash: " << hash << endl;
+    os << "counts: " << DB.mTopologyMap.find(hash)->second.second << endl;
+    os << "sigmaX: " << std::sqrt(DB.fMapInfo.find(hash)->second.xSigma2) << endl;
+    os << "sigmaZ: " << std::sqrt(DB.fMapInfo.find(hash)->second.zSigma2) << endl;
+    os << DB.mTopologyMap.find(hash)->second.first;
+  }
+  return os;
+}
+
+void BuildTopologyDictionary::printDictionary(string fname){
+  ofstream out(fname);
+  out << mDictionary;
+  out.close();
+}
+
+void BuildTopologyDictionary::printDictionaryBinary(string fname){
+  ofstream out(fname);
+  mDictionary.WriteBinaryFile(fname);
+  out.close();
+}
+}
+}

--- a/Detectors/ITSMFT/common/reconstruction/src/BuildTopologyDictionary.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/BuildTopologyDictionary.cxx
@@ -18,240 +18,267 @@
 
 ClassImp(o2::ITSMFT::BuildTopologyDictionary)
 
-namespace o2
+  namespace o2
 {
-namespace ITSMFT
-{
+  namespace ITSMFT
+  {
+  BuildTopologyDictionary::BuildTopologyDictionary() : mTotClusters(0) {}
 
-BuildTopologyDictionary::BuildTopologyDictionary():mTotClusters(0){}
+  void BuildTopologyDictionary::accountTopology(const ClusterTopology& cluster, float dX, float dZ)
+  {
+    mTotClusters++;
 
-void BuildTopologyDictionary::accountTopology(const ClusterTopology &cluster,float dX, float dZ){
-  mTotClusters++;
-
-  //std::pair<unordered_map<unsigned long, std::pair<ClusterTopology,unsigned long>>::iterator,bool> ret;
-  auto ret = mTopologyMap.insert(std::make_pair(cluster.getHash(),std::make_pair(cluster,1)));
-  if(ret.second==true){
-    //___________________DEFINING_TOPOLOGY_CHARACTERISTICS__________________
-    TopologyInfo topInf;
-    int &rs = topInf.mSizeX = cluster.getRowSpan();
-    int &cs = topInf.mSizeZ = cluster.getColumnSpan();
-    //__________________COG_Deterrmination_____________
-    int tempyCOG = 0;
-    int tempzCOG = 0;
-    int tempFiredPixels = 0;
-    unsigned char tempChar = 0;
-    int s = 0;
-    int ic = 0;
-    int ir = 0;
-    for(unsigned int i=0; i<cluster.getUsedBytes(); i++){
-      tempChar = cluster.getPattern()[i];
-      s=128; //0b10000000
-      while(s>0){
-        if((tempChar&s)!=0){
-          tempFiredPixels++;
-          tempyCOG+=ir;
-          tempzCOG+=ic;
+    // std::pair<unordered_map<unsigned long, std::pair<ClusterTopology,unsigned long>>::iterator,bool> ret;
+    auto ret = mTopologyMap.insert(std::make_pair(cluster.getHash(), std::make_pair(cluster, 1)));
+    if (ret.second == true) {
+      //___________________DEFINING_TOPOLOGY_CHARACTERISTICS__________________
+      TopologyInfo topInf;
+      int& rs = topInf.mSizeX = cluster.getRowSpan();
+      int& cs = topInf.mSizeZ = cluster.getColumnSpan();
+      //__________________COG_Deterrmination_____________
+      int tempyCOG = 0;
+      int tempzCOG = 0;
+      int tempFiredPixels = 0;
+      unsigned char tempChar = 0;
+      int s = 0;
+      int ic = 0;
+      int ir = 0;
+      for (unsigned int i = 2; i < cluster.getUsedBytes() + 2; i++) {
+        tempChar = cluster.getPattern()[i];
+        s = 128; // 0b10000000
+        while (s > 0) {
+          if ((tempChar & s) != 0) {
+            tempFiredPixels++;
+            tempyCOG += ir;
+            tempzCOG += ic;
+          }
+          ic++;
+          s /= 2;
+          if ((ir + 1) * ic == (rs * cs))
+            break;
+          if (ic == cs) {
+            ic = 0;
+            ir++;
+          }
         }
-        ic++;
-        s/=2;
-        if((ir+1)*ic==(rs*cs)) break;
-        if(ic==cs){
-          ic=0;
-          ir++;
-        }
+        if ((ir + 1) * ic == (rs * cs))
+          break;
       }
-      if((ir+1)*ic==(rs*cs)) break;
+      topInf.mCOGx = 0.5 + (float)tempyCOG / (float)tempFiredPixels;
+      topInf.mCOGz = 0.5 + (float)tempzCOG / (float)tempFiredPixels;
+      topInf.mNpixels = tempFiredPixels;
+      topInf.mXmean = dX;
+      topInf.mXsigma2 = 0;
+      topInf.mZmean = dZ;
+      topInf.mZsigma2 = 0;
+      mMapInfo.insert(std::make_pair(cluster.getHash(), topInf));
+    } else {
+      int num = (ret.first->second.second++);
+      auto ind = mMapInfo.find(cluster.getHash());
+      float tmpxMean = ind->second.mXmean;
+      float newxMean = ind->second.mXmean = ((tmpxMean)*num + dX) / (num + 1);
+      float tmpxSigma2 = ind->second.mXsigma2;
+      ind->second.mXsigma2 =
+        (num * tmpxSigma2 + (dX - tmpxMean) * (dX - newxMean)) / (num + 1); // online variance algorithm
+      float tmpzMean = ind->second.mZmean;
+      float newzMean = ind->second.mZmean = ((tmpzMean)*num + dZ) / (num + 1);
+      float tmpzSigma2 = ind->second.mZsigma2;
+      ind->second.mZsigma2 =
+        (num * tmpzSigma2 + (dZ - tmpzMean) * (dZ - newzMean)) / (num + 1); // online variance algorithm
     }
-    topInf.mCOGx = 0.5 + (float)tempyCOG/(float)tempFiredPixels;
-    topInf.mCOGz = 0.5 + (float)tempzCOG/(float)tempFiredPixels;
-    topInf.mNpixels = tempFiredPixels;
-    topInf.mXmean = dX;
-    topInf.mXsigma2 = 0;
-    topInf.mZmean = dZ;
-    topInf.mZsigma2 = 0;
-    mMapInfo.insert(std::make_pair(cluster.getHash(),topInf));
   }
-  else{
-    int num = (ret.first->second.second++);
-    auto ind = mMapInfo.find(cluster.getHash());
-    float tmpxMean = ind->second.mXmean;
-    float newxMean = ind->second.mXmean = ( (tmpxMean)*num + dX ) / (num+1);
-    float tmpxSigma2 = ind->second.mXsigma2;
-    ind->second.mXsigma2 = ( num*tmpxSigma2 + (dX - tmpxMean)*(dX - newxMean) ) / (num+1); //online variance algorithm
-    float tmpzMean = ind->second.mZmean;
-    float newzMean = ind->second.mZmean = ( (tmpzMean)*num + dZ ) / (num+1);
-    float tmpzSigma2 = ind->second.mZsigma2;
-    ind->second.mZsigma2 = ( num*tmpzSigma2 + (dZ - tmpzMean)*(dZ - newzMean) ) / (num+1); //online variance algorithm
-  }
-}
 
-void BuildTopologyDictionary::setThreshold(double thr){
-  mTopologyFrequency.clear();
-  for(auto &&p : mTopologyMap){
-    mTopologyFrequency.push_back(std::make_pair(p.second.second,p.first));
-  }
-  std::sort(mTopologyFrequency.begin(),mTopologyFrequency.end(), [] (const std::pair<unsigned long, unsigned long> &couple1, const std::pair<unsigned long, unsigned long> &couple2){return (couple1.first > couple2.first);});
-  mNotInGroups = 0;
-  mNumberOfGroups = 0;
-  mDictionary.mFinalMap.clear();
-  mFrequencyThreshold=thr;
-  for(auto &q : mTopologyFrequency){
-    if( ((double)q.first)/mTotClusters > thr ) mNotInGroups++;
-    else break;
-  }
-  mNumberOfGroups=mNotInGroups;
-}
-
-void BuildTopologyDictionary::setNGroups(unsigned int ngr){
-  mTopologyFrequency.clear();
-  for(auto &&p : mTopologyMap){
-    mTopologyFrequency.push_back(std::make_pair(p.second.second,p.first));
-  }
-  std::sort(mTopologyFrequency.begin(),mTopologyFrequency.end(), [] (const std::pair<unsigned long, unsigned long> &couple1, const std::pair<unsigned long, unsigned long> &couple2){return (couple1.first > couple2.first);});
-  if(ngr<10 || ngr > (mTopologyFrequency.size()-TopologyDictionary::NumberOfRowClasses*TopologyDictionary::NumberOfColClasses)){
-    std::cout << "BuildTopologyDictionary::setNGroups : Invalid number of groups" << std::endl;
-    exit(1);
-  }
-  mNumberOfGroups = mNotInGroups = ngr-TopologyDictionary::NumberOfRowClasses*TopologyDictionary::NumberOfColClasses;
-  mDictionary.mFinalMap.clear();
-  mFrequencyThreshold=((double)mTopologyFrequency[mNotInGroups-1].first)/mTotClusters;
-}
-
-void BuildTopologyDictionary::setThresholdCumulative(double cumulative){
-  mTopologyFrequency.clear();
-  if(cumulative<=0. || cumulative >=1.) cumulative = 0.99;
-  double totFreq = 0.;
-  for(auto &&p : mTopologyMap){
-    mTopologyFrequency.push_back(std::make_pair(p.second.second,p.first));
-  }
-  std::sort(mTopologyFrequency.begin(),mTopologyFrequency.end(), [] (const std::pair<unsigned long, unsigned long> &couple1, const std::pair<unsigned long, unsigned long> &couple2){return (couple1.first > couple2.first);});
-  mNotInGroups = 0;
-  mNumberOfGroups = 0;
-  mDictionary.mFinalMap.clear();
-  for(auto &q : mTopologyFrequency){
-    totFreq += ((double)(q.first))/mTotClusters;
-    if(totFreq<cumulative){
-      mNotInGroups++;
+  void BuildTopologyDictionary::setThreshold(double thr)
+  {
+    mTopologyFrequency.clear();
+    for (auto&& p : mTopologyMap) {
+      mTopologyFrequency.push_back(std::make_pair(p.second.second, p.first));
     }
-    else break;
+    std::sort(mTopologyFrequency.begin(), mTopologyFrequency.end(),
+              [](const std::pair<unsigned long, unsigned long>& couple1,
+                 const std::pair<unsigned long, unsigned long>& couple2) { return (couple1.first > couple2.first); });
+    mNotInGroups = 0;
+    mNumberOfGroups = 0;
+    mDictionary.mFinalMap.clear();
+    mFrequencyThreshold = thr;
+    for (auto& q : mTopologyFrequency) {
+      if (((double)q.first) / mTotClusters > thr)
+        mNotInGroups++;
+      else
+        break;
+    }
+    mNumberOfGroups = mNotInGroups;
   }
-  mFrequencyThreshold=((double)(mTopologyFrequency[--mNotInGroups].first))/mTotClusters;
-  while(((double)mTopologyFrequency[mNotInGroups].first)/mTotClusters == mFrequencyThreshold) mNotInGroups--;
-  mFrequencyThreshold=((double)mTopologyFrequency[mNotInGroups++].first)/mTotClusters;
-  mNumberOfGroups=mNotInGroups;
-}
 
-void BuildTopologyDictionary::groupRareTopologies(){
+  void BuildTopologyDictionary::setNGroups(unsigned int ngr)
+  {
+    mTopologyFrequency.clear();
+    for (auto&& p : mTopologyMap) {
+      mTopologyFrequency.push_back(std::make_pair(p.second.second, p.first));
+    }
+    std::sort(mTopologyFrequency.begin(), mTopologyFrequency.end(),
+              [](const std::pair<unsigned long, unsigned long>& couple1,
+                 const std::pair<unsigned long, unsigned long>& couple2) { return (couple1.first > couple2.first); });
+    if (ngr < 10 ||
+        ngr > (mTopologyFrequency.size() -
+               TopologyDictionary::NumberOfRowClasses * TopologyDictionary::NumberOfColClasses)) {
+      std::cout << "BuildTopologyDictionary::setNGroups : Invalid number of groups" << std::endl;
+      exit(1);
+    }
+    mNumberOfGroups = mNotInGroups =
+      ngr - TopologyDictionary::NumberOfRowClasses * TopologyDictionary::NumberOfColClasses;
+    mDictionary.mFinalMap.clear();
+    mFrequencyThreshold = ((double)mTopologyFrequency[mNotInGroups - 1].first) / mTotClusters;
+  }
 
-  std::cout<<"groupRareTopologies: mTotClusters: " << mTotClusters << std::endl;
-  #ifdef _HISTO_
-    mHdist = TH1F("mHdist", "Groups distribution", mNumberOfGroups+TopologyDictionary::NumberOfRowClasses*TopologyDictionary::NumberOfColClasses,-0.5, mNumberOfGroups+TopologyDictionary::NumberOfRowClasses*TopologyDictionary::NumberOfColClasses-0.5);
+  void BuildTopologyDictionary::setThresholdCumulative(double cumulative)
+  {
+    mTopologyFrequency.clear();
+    if (cumulative <= 0. || cumulative >= 1.)
+      cumulative = 0.99;
+    double totFreq = 0.;
+    for (auto&& p : mTopologyMap) {
+      mTopologyFrequency.push_back(std::make_pair(p.second.second, p.first));
+    }
+    std::sort(mTopologyFrequency.begin(), mTopologyFrequency.end(),
+              [](const std::pair<unsigned long, unsigned long>& couple1,
+                 const std::pair<unsigned long, unsigned long>& couple2) { return (couple1.first > couple2.first); });
+    mNotInGroups = 0;
+    mNumberOfGroups = 0;
+    mDictionary.mFinalMap.clear();
+    for (auto& q : mTopologyFrequency) {
+      totFreq += ((double)(q.first)) / mTotClusters;
+      if (totFreq < cumulative) {
+        mNotInGroups++;
+      } else
+        break;
+    }
+    mFrequencyThreshold = ((double)(mTopologyFrequency[--mNotInGroups].first)) / mTotClusters;
+    while (((double)mTopologyFrequency[mNotInGroups].first) / mTotClusters == mFrequencyThreshold)
+      mNotInGroups--;
+    mFrequencyThreshold = ((double)mTopologyFrequency[mNotInGroups++].first) / mTotClusters;
+    mNumberOfGroups = mNotInGroups;
+  }
+
+  void BuildTopologyDictionary::groupRareTopologies()
+  {
+    std::cout << "groupRareTopologies: mTotClusters: " << mTotClusters << std::endl;
+#ifdef _HISTO_
+    mHdist =
+      TH1F("mHdist", "Groups distribution",
+           mNumberOfGroups + TopologyDictionary::NumberOfRowClasses * TopologyDictionary::NumberOfColClasses, -0.5,
+           mNumberOfGroups + TopologyDictionary::NumberOfRowClasses * TopologyDictionary::NumberOfColClasses - 0.5);
     mHdist.GetXaxis()->SetTitle("GroupID");
     mHdist.SetFillColor(kRed);
     mHdist.SetFillStyle(3005);
-  #endif
+#endif
 
-  double totFreq=0.;
-  for(int j=0; j<mNotInGroups; j++){
-    #ifdef _HISTO_
-      mHdist.Fill(j,mTopologyFrequency[j].first);
-    #endif
-    totFreq+=((double)(mTopologyFrequency[j].first))/mTotClusters;
-    GroupStruct gr;
-    gr.mHash=mTopologyFrequency[j].second;
-    gr.mFrequency=totFreq;
-    //rough estimation for the error considering a uniform distribution
-    gr.mErrX = std::sqrt(mMapInfo.find(gr.mHash)->second.mXsigma2);
-    gr.mErrZ = std::sqrt(mMapInfo.find(gr.mHash)->second.mZsigma2);
-    gr.mXCOG = mMapInfo.find(gr.mHash)->second.mCOGx;
-    gr.mZCOG = mMapInfo.find(gr.mHash)->second.mCOGz;
-    gr.mNpixels = mMapInfo.find(gr.mHash)->second.mNpixels;
-    mDictionary.mVectorOfGroupIDs.push_back(gr);
-    mDictionary.mFinalMap.insert(std::make_pair(gr.mHash,j));
-  }
-  //groupRareTopologies based on binning over number of rows and columns (TopologyDictionary::NumberOfRowClasses * NumberOfColClasse)
-  mNumberOfGroups+=TopologyDictionary::NumberOfRowClasses*TopologyDictionary::NumberOfColClasses;
-  //array of groups
-  std::array<GroupStruct,TopologyDictionary::NumberOfRowClasses*TopologyDictionary::NumberOfColClasses> GroupArray;
-  std::array<unsigned long,TopologyDictionary::NumberOfRowClasses*TopologyDictionary::NumberOfColClasses> groupCounts{0};
-  auto func = [&GroupArray] (int rowBinEdge, int colBinEdge, int &index) {
-    unsigned long provvHash = 0;
-    provvHash = ( ((unsigned long)(index+1)) << 32 ) & 0xffffffff00000000;
-    GroupArray[index].mHash = provvHash;
-    GroupArray[index].mErrX = (rowBinEdge)*o2::ITSMFT::SegmentationAlpide::PitchRow/std::sqrt(12);
-    GroupArray[index].mErrZ = (colBinEdge)*o2::ITSMFT::SegmentationAlpide::PitchCol/std::sqrt(12);
-    GroupArray[index].mXCOG = rowBinEdge/2;
-    GroupArray[index].mZCOG = colBinEdge/2;
-    GroupArray[index].mNpixels = rowBinEdge*colBinEdge;
-    index++;
-    return;
-  };
-  int grNum=0;
-  for(int ir=0; ir<TopologyDictionary::NumberOfRowClasses-1; ir++){
-    for(int ic=0; ic<TopologyDictionary::NumberOfColClasses-1; ic++){
-      func((ir+1)*TopologyDictionary::RowClassSpan-1, (ic+1)*TopologyDictionary::ColClassSpan-1, grNum);
+    double totFreq = 0.;
+    for (int j = 0; j < mNotInGroups; j++) {
+#ifdef _HISTO_
+      mHdist.Fill(j, mTopologyFrequency[j].first);
+#endif
+      totFreq += ((double)(mTopologyFrequency[j].first)) / mTotClusters;
+      GroupStruct gr;
+      gr.mHash = mTopologyFrequency[j].second;
+      gr.mFrequency = totFreq;
+      // rough estimation for the error considering a uniform distribution
+      gr.mErrX = std::sqrt(mMapInfo.find(gr.mHash)->second.mXsigma2);
+      gr.mErrZ = std::sqrt(mMapInfo.find(gr.mHash)->second.mZsigma2);
+      gr.mXCOG = mMapInfo.find(gr.mHash)->second.mCOGx;
+      gr.mZCOG = mMapInfo.find(gr.mHash)->second.mCOGz;
+      gr.mNpixels = mMapInfo.find(gr.mHash)->second.mNpixels;
+      mDictionary.mVectorOfGroupIDs.push_back(gr);
+      mDictionary.mFinalMap.insert(std::make_pair(gr.mHash, j));
     }
-    func((ir+1)*TopologyDictionary::RowClassSpan-1, TopologyDictionary::MaxColSpan, grNum);
-  }
-  for(int ic=0; ic<TopologyDictionary::NumberOfColClasses-1; ic++){
-    func(TopologyDictionary::MaxRowSpan, (ic+1)*TopologyDictionary::ColClassSpan-1, grNum);
-    unsigned long provvHash = 0;
-  }
-  func(TopologyDictionary::MaxRowSpan, TopologyDictionary::MaxColSpan, grNum);
-  if(grNum!=TopologyDictionary::NumberOfColClasses*TopologyDictionary::NumberOfRowClasses){
-    std::cout << "Wrong number of groups" << std::endl;
-    exit(1);
-  }
-  int rs;
-  int cs;
-  int index;
+    // groupRareTopologies based on binning over number of rows and columns (TopologyDictionary::NumberOfRowClasses *
+    // NumberOfColClasse)
+    mNumberOfGroups += TopologyDictionary::NumberOfRowClasses * TopologyDictionary::NumberOfColClasses;
+    // array of groups
+    std::array<GroupStruct, TopologyDictionary::NumberOfRowClasses * TopologyDictionary::NumberOfColClasses> GroupArray;
+    std::array<unsigned long, TopologyDictionary::NumberOfRowClasses * TopologyDictionary::NumberOfColClasses>
+      groupCounts{ 0 };
+    auto func = [&GroupArray](int rowBinEdge, int colBinEdge, int& index) {
+      unsigned long provvHash = 0;
+      provvHash = (((unsigned long)(index + 1)) << 32) & 0xffffffff00000000;
+      GroupArray[index].mHash = provvHash;
+      GroupArray[index].mErrX = (rowBinEdge)*o2::ITSMFT::SegmentationAlpide::PitchRow / std::sqrt(12);
+      GroupArray[index].mErrZ = (colBinEdge)*o2::ITSMFT::SegmentationAlpide::PitchCol / std::sqrt(12);
+      GroupArray[index].mXCOG = rowBinEdge / 2;
+      GroupArray[index].mZCOG = colBinEdge / 2;
+      GroupArray[index].mNpixels = rowBinEdge * colBinEdge;
+      index++;
+      return;
+    };
+    int grNum = 0;
+    for (int ir = 0; ir < TopologyDictionary::NumberOfRowClasses - 1; ir++) {
+      for (int ic = 0; ic < TopologyDictionary::NumberOfColClasses - 1; ic++) {
+        func((ir + 1) * TopologyDictionary::RowClassSpan - 1, (ic + 1) * TopologyDictionary::ColClassSpan - 1, grNum);
+      }
+      func((ir + 1) * TopologyDictionary::RowClassSpan - 1, TopologyDictionary::MaxColSpan, grNum);
+    }
+    for (int ic = 0; ic < TopologyDictionary::NumberOfColClasses - 1; ic++) {
+      func(TopologyDictionary::MaxRowSpan, (ic + 1) * TopologyDictionary::ColClassSpan - 1, grNum);
+      unsigned long provvHash = 0;
+    }
+    func(TopologyDictionary::MaxRowSpan, TopologyDictionary::MaxColSpan, grNum);
+    if (grNum != TopologyDictionary::NumberOfColClasses * TopologyDictionary::NumberOfRowClasses) {
+      std::cout << "Wrong number of groups" << std::endl;
+      exit(1);
+    }
+    int rs;
+    int cs;
+    int index;
 
-  for(unsigned int j = (unsigned int)mNotInGroups; j<mTopologyFrequency.size(); j++){
-    unsigned long
-    hash1 = mTopologyFrequency[j].second;
-    rs = mTopologyMap.find(hash1)->second.first.getRowSpan();
-    cs = mTopologyMap.find(hash1)->second.first.getColumnSpan();
-    index = (rs/TopologyDictionary::RowClassSpan)*TopologyDictionary::NumberOfRowClasses + cs/TopologyDictionary::ColClassSpan;
-    if(index > TopologyDictionary::NumberOfRowClasses*TopologyDictionary::NumberOfColClasses - 1) index = TopologyDictionary::NumberOfRowClasses*TopologyDictionary::NumberOfColClasses - 1;
-    groupCounts[index]+=mTopologyFrequency[j].first;
+    for (unsigned int j = (unsigned int)mNotInGroups; j < mTopologyFrequency.size(); j++) {
+      unsigned long hash1 = mTopologyFrequency[j].second;
+      rs = mTopologyMap.find(hash1)->second.first.getRowSpan();
+      cs = mTopologyMap.find(hash1)->second.first.getColumnSpan();
+      index = (rs / TopologyDictionary::RowClassSpan) * TopologyDictionary::NumberOfRowClasses +
+              cs / TopologyDictionary::ColClassSpan;
+      if (index > TopologyDictionary::NumberOfRowClasses * TopologyDictionary::NumberOfColClasses - 1)
+        index = TopologyDictionary::NumberOfRowClasses * TopologyDictionary::NumberOfColClasses - 1;
+      groupCounts[index] += mTopologyFrequency[j].first;
+    }
+
+    for (int i = 0; i < TopologyDictionary::NumberOfRowClasses * TopologyDictionary::NumberOfColClasses; i++) {
+      totFreq += ((double)groupCounts[i]) / mTotClusters;
+      GroupArray[i].mFrequency = totFreq;
+#ifdef _HISTO_
+      mHdist.Fill(mNotInGroups + i, groupCounts[i]);
+#endif
+      mDictionary.mVectorOfGroupIDs.push_back(GroupArray[i]);
+    }
+#ifdef _HISTO_
+    mHdist.Scale(1. / mHdist.Integral());
+#endif
   }
 
-  for(int i=0; i<TopologyDictionary::NumberOfRowClasses*TopologyDictionary::NumberOfColClasses; i++){
-    totFreq+=((double)groupCounts[i])/mTotClusters;
-    GroupArray[i].mFrequency = totFreq;
-    #ifdef _HISTO_
-      mHdist.Fill(mNotInGroups+i,groupCounts[i]);
-    #endif
-    mDictionary.mVectorOfGroupIDs.push_back(GroupArray[i]);
+  std::ostream& operator<<(std::ostream& os, const BuildTopologyDictionary& DB)
+  {
+    for (int i = 0; i < DB.mNotInGroups; i++) {
+      const unsigned long& hash = DB.mTopologyFrequency[i].second;
+      os << "Hash: " << hash << std::endl;
+      os << "counts: " << DB.mTopologyMap.find(hash)->second.second << std::endl;
+      os << "sigmaX: " << std::sqrt(DB.mMapInfo.find(hash)->second.mXsigma2) << std::endl;
+      os << "sigmaZ: " << std::sqrt(DB.mMapInfo.find(hash)->second.mZsigma2) << std::endl;
+      os << DB.mTopologyMap.find(hash)->second.first;
+    }
+    return os;
   }
-  #ifdef _HISTO_
-    mHdist.Scale(1./mHdist.Integral());
-  #endif
-}
 
-
-std::ostream& operator<<(std::ostream& os, const BuildTopologyDictionary& DB){
-  for(int i=0; i<DB.mNotInGroups; i++){
-    const unsigned long &hash = DB.mTopologyFrequency[i].second;
-    os << "Hash: " << hash << std::endl;
-    os << "counts: " << DB.mTopologyMap.find(hash)->second.second << std::endl;
-    os << "sigmaX: " << std::sqrt(DB.mMapInfo.find(hash)->second.mXsigma2) << std::endl;
-    os << "sigmaZ: " << std::sqrt(DB.mMapInfo.find(hash)->second.mZsigma2) << std::endl;
-    os << DB.mTopologyMap.find(hash)->second.first;
+  void BuildTopologyDictionary::printDictionary(std::string fname)
+  {
+    std::ofstream out(fname);
+    out << mDictionary;
+    out.close();
   }
-  return os;
-}
 
-void BuildTopologyDictionary::printDictionary(std::string fname){
-  std::ofstream out(fname);
-  out << mDictionary;
-  out.close();
-}
-
-void BuildTopologyDictionary::printDictionaryBinary(std::string fname){
-  std::ofstream out(fname);
-  mDictionary.WriteBinaryFile(fname);
-  out.close();
-}
-}
+  void BuildTopologyDictionary::printDictionaryBinary(std::string fname)
+  {
+    std::ofstream out(fname);
+    mDictionary.WriteBinaryFile(fname);
+    out.close();
+  }
+  } // namespace ITSMFT
 }

--- a/Detectors/ITSMFT/common/reconstruction/src/Cluster.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/Cluster.cxx
@@ -24,8 +24,8 @@ using namespace o2::ITSMFT;
 ClassImp(o2::ITSMFT::Cluster)
 
 #ifdef _ClusterTopology_
-//______________________________________________________________________________
-void Cluster::resetPattern()
+  //______________________________________________________________________________
+  void Cluster::resetPattern()
 {
   // reset pixels pattern
   memset(mPattern, 0, kMaxPatternBytes * sizeof(UChar_t));
@@ -105,22 +105,24 @@ Bool_t Cluster::hasCommonTrack(const Cluster* cl) const
 void Cluster::print() const
 {
   // print itself
-  printf("Sensor %5d, nRow:%3d nCol:%3d n:%d |Err^2:%.3e %.3e %+.3e |",getSensorID(),getNx(),getNz(),
-         getNPix(),getSigmaY2(),getSigmaZ2(),getSigmaYZ());
-  printf("XYZ: %+.4e %+.4e %+.4e\n",getX(),getY(),getZ());
+  printf("Sensor %5d, nRow:%3d nCol:%3d n:%d |Err^2:%.3e %.3e %+.3e |", getSensorID(), getNx(), getNz(), getNPix(),
+         getSigmaY2(), getSigmaZ2(), getSigmaYZ());
+  printf("XYZ: %+.4e %+.4e %+.4e\n", getX(), getY(), getZ());
   //
- #ifdef _ClusterTopology_
+#ifdef _ClusterTopology_
   int nr = getPatternRowSpan();
   int nc = getPatternColSpan();
-  printf("Pattern: %d rows from %d",nr,mPatternRowMin);
-  if (isPatternRowsTruncated()) printf("(truncated)");
-  printf(", %d cols from %d",nc,mPatternColMin);
-  if (isPatternColsTruncated()) printf("(truncated)");
+  printf("Pattern: %d rows from %d", nr, mPatternRowMin);
+  if (isPatternRowsTruncated())
+    printf("(truncated)");
+  printf(", %d cols from %d", nc, mPatternColMin);
+  if (isPatternColsTruncated())
+    printf("(truncated)");
   printf("\n");
-  for (int ir=0;ir<nr;ir++) {
-    for (int ic=0;ic<nc;ic++) printf("%c",testPixel(ir,ic) ? '+':'-');
+  for (int ir = 0; ir < nr; ir++) {
+    for (int ic = 0; ic < nc; ic++)
+      printf("%c", testPixel(ir, ic) ? '+' : '-');
     printf("\n");
   }
 #endif
-
 }

--- a/Detectors/ITSMFT/common/reconstruction/src/ClusterTopology.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/ClusterTopology.cxx
@@ -1,0 +1,120 @@
+#include "ITSMFTReconstruction/ClusterTopology.h"
+//#include <stdlib.h>
+//#include <stdio.h>
+
+//using namespace o2::ITSMFT;
+
+namespace o2
+{
+namespace ITSMFT{
+void convertCluster2String(const Cluster &cluster, std::string &str)
+{
+  int rowSpan = cluster.getPatternRowSpan();
+  int columnSpan = cluster.getPatternColSpan();
+  int nBytes = (rowSpan*columnSpan)>>3;
+  if(((rowSpan*columnSpan)%8)!=0) nBytes++;
+  str.resize(nBytes+2,0);
+  str[0]=rowSpan;
+  str[1]=columnSpan;
+  cluster.getPattern(&str[2],nBytes);
+}
+
+ClusterTopology::ClusterTopology() : mPattern(), mHash(0)
+{
+}
+
+ClusterTopology::ClusterTopology(const std::string &str) : mHash(0)
+{
+  setPattern(str);
+}
+
+void ClusterTopology::setPattern(const std::string &str)
+{
+  int nBytes = (int)str.size();
+  mPattern.resize(nBytes,0);
+  memcpy(&mPattern[0],&str[0],nBytes);
+  nBytes-=2;
+  mHash = ((unsigned long)(hashFunction(mPattern.data(),mPattern.length())))<<32;
+  if(nBytes>=4){
+    mHash += ((((unsigned long)mPattern[2])<<24) + (((unsigned long)mPattern[3])<<16) + (((unsigned long)mPattern[4])<<8) + ((unsigned long)mPattern[5]));
+  }
+  else if(nBytes==3){
+    mHash += ((((unsigned long)mPattern[2])<<24) + (((unsigned long)mPattern[3])<<16) + (((unsigned long)mPattern[4])<<8));
+  }
+  else if(nBytes==2){
+    mHash += ((((unsigned long)mPattern[2])<<24) + (((unsigned long)mPattern[3])<<16));
+  }
+  else if(nBytes==1){
+    mHash += ((((unsigned long)mPattern[2])<<24));
+  }
+  else{
+    std::cout << "ERROR: no fired pixels\n";
+    exit(1);
+  }
+}
+
+unsigned int ClusterTopology::hashFunction(const void* key, int len)
+{
+  //
+  //Developed from https://github.com/rurban/smhasher , function MurMur2
+  //
+  // 'm' and 'r' are mixing constants generated offline.
+  const unsigned int m =0x5bd1e995;
+  const int r = 24;
+  // Initialize the hash
+  unsigned int h = len^0xdeadbeef;
+  // Mix 4 bytes at a time into the hash
+  const unsigned char* data = (const unsigned char *)key;
+  //int recIndex=0;
+  while(len >= 4){
+    unsigned int k = *(unsigned int*)data;
+    k *= m;
+    k ^= k >> r;
+    k *= m;
+    h *= m;
+    h ^= k;
+    data += 4;
+    len -= 4;
+  }
+  // Handle the last few bytes of the input array
+  switch(len){
+    case 3: h ^= data[2] << 16;
+    case 2: h ^= data[1] << 8;
+    case 1: h ^= data[0];
+    h *= m;
+  };
+  // Do a few final mixes of the hash to ensure the last few
+  // bytes are well-incorporated.
+  h ^= h >> 13;
+  h *= m;
+  h ^= h >> 15;
+  return h;
+}
+
+std::ostream& operator<<(std::ostream& os, const ClusterTopology& topology)
+{
+  int rowSpan = topology.mPattern[0];
+  int columnSpan = topology.mPattern[1];
+  os << "rowSpan: " << rowSpan << " columnSpan: " << columnSpan << " #bytes: " << topology.mPattern.length() << std::endl;
+  unsigned char tempChar = 0;
+  int s=0;
+  int ic = 0;
+  for (unsigned int i=2; i<topology.mPattern.length(); i++){
+    tempChar = topology.mPattern[i];
+    s=128; //0b10000000
+    while(s>0){
+      if(ic%columnSpan==0) os << "|";
+      ic++;
+      if((tempChar&s)!=0) os << '+';
+      else os << ' ';
+      s/=2;
+      if(ic%columnSpan==0) os << "|" << std::endl;
+      if(ic==(rowSpan*columnSpan)) break;
+    }
+    if(ic==(rowSpan*columnSpan)) break;
+  }
+  os<< std::endl;
+  return os;
+}
+}
+}

--- a/Detectors/ITSMFT/common/reconstruction/src/ClusterTopology.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/ClusterTopology.cxx
@@ -1,8 +1,4 @@
 #include "ITSMFTReconstruction/ClusterTopology.h"
-//#include <stdlib.h>
-//#include <stdio.h>
-
-//using namespace o2::ITSMFT;
 
 namespace o2
 {

--- a/Detectors/ITSMFT/common/reconstruction/src/ClusterTopology.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/ClusterTopology.cxx
@@ -17,149 +17,154 @@
 
 ClassImp(o2::ITSMFT::ClusterTopology)
 
-namespace o2
+  namespace o2
 {
-namespace ITSMFT
-{
+  namespace ITSMFT
+  {
+  ClusterTopology::ClusterTopology() : mPattern{ 0 }, mHash{ 0 }, mNbytes{ 0 } {}
 
-ClusterTopology::ClusterTopology() : mPattern{0}, mHash{0}, mNbytes{0}
-{
-}
+  ClusterTopology::ClusterTopology(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes]) : mHash{ 0 }
+  {
+    setPattern(nRow, nCol, patt);
+  }
 
-ClusterTopology::ClusterTopology(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes]) : mHash{0}
-{
-  setPattern(nRow,nCol,patt);
-}
+  void ClusterTopology::setPattern(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes])
+  {
+    mPattern[0] = (unsigned char)nRow;
+    mPattern[1] = (unsigned char)nCol;
+    mNbytes = nRow * nCol / 8;
+    if (((nRow * nCol) % 8) != 0)
+      mNbytes++;
+    memcpy(&mPattern[2], patt, mNbytes);
+    mHash = getCompleteHash(*this);
+  }
 
-void ClusterTopology::setPattern(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes])
-{
-  mPattern[0]=(unsigned char)nRow;
-  mPattern[1]=(unsigned char)nCol;
-  mNbytes = nRow*nCol/8;
-  if(((nRow*nCol)%8)!=0) mNbytes++;
-  memcpy(&mPattern[2],patt,mNbytes);
-  mHash = getCompleteHash(*this);
-}
-
-unsigned int ClusterTopology::hashFunction(const void* key, int len)
-{
-  //
-  //Developed from https://github.com/rurban/smhasher , function MurMur2
-  //
-  // 'm' and 'r' are mixing constants generated offline.
-  const unsigned int m =0x5bd1e995;
-  const int r = 24;
-  // Initialize the hash
-  unsigned int h = len^0xdeadbeef;
-  // Mix 4 bytes at a time into the hash
-  const unsigned char* data = (const unsigned char *)key;
-  //int recIndex=0;
-  while(len >= 4){
-    unsigned int k = *(unsigned int*)data;
-    k *= m;
-    k ^= k >> r;
-    k *= m;
-    h *= m;
-    h ^= k;
-    data += 4;
-    len -= 4;
-  }
-  // Handle the last few bytes of the input array
-  switch(len){
-    case 3: h ^= data[2] << 16;
-    case 2: h ^= data[1] << 8;
-    case 1: h ^= data[0];
-    h *= m;
-  };
-  // Do a few final mixes of the hash to ensure the last few
-  // bytes are well-incorporated.
-  h ^= h >> 13;
-  h *= m;
-  h ^= h >> 15;
-  return h;
-}
-
-unsigned long ClusterTopology::getCompleteHash(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes], int nBytesUsed)
-{
-  unsigned long extended_pattern[Cluster::kMaxPatternBytes+2]={0};
-  extended_pattern[0]=(unsigned char)nRow;
-  extended_pattern[1]=(unsigned char)nCol;
-  memcpy(&extended_pattern[2],patt,nBytesUsed);
-
-  unsigned long partialHash = (unsigned long)hashFunction(extended_pattern,nBytesUsed);
-  // The first four bytes are directly taken from partialHash
-  unsigned long completeHash = partialHash<<32;
-  // The last four bytes of the hash are the first 32 pixels of the topology.
-  // The bits reserved for the pattern that are not used are set to 0.
-  if(nBytesUsed==1){
-    completeHash += ((((unsigned long)extended_pattern[2])<<24));
-  }
-  else if(nBytesUsed==2){
-    completeHash += ((((unsigned long)extended_pattern[2])<<24) + (((unsigned long)extended_pattern[3])<<16));
-  }
-  else if(nBytesUsed==3){
-    completeHash += ((((unsigned long)extended_pattern[2])<<24) + (((unsigned long)extended_pattern[3])<<16) + (((unsigned long)extended_pattern[4])<<8));
-  }
-  else if(nBytesUsed>=4){
-    completeHash += ((((unsigned long)extended_pattern[2])<<24) + (((unsigned long)extended_pattern[3])<<16) + (((unsigned long)extended_pattern[4])<<8) + ((unsigned long)extended_pattern[5]));
-  }
-  else{
-    std::cout << "ERROR: no fired pixels\n";
-    exit(1);
-  }
-  return completeHash;
-}
-
-unsigned long ClusterTopology::getCompleteHash(const ClusterTopology& topology)
-{
-  std::array<unsigned char,Cluster::kMaxPatternBytes+2> patt = topology.getPattern();
-  int nBytesUsed = topology.getUsedBytes();
-  unsigned long partialHash = (unsigned long)hashFunction(patt.data(),nBytesUsed);
-  // The first four bytes are directly taken from partialHash
-  unsigned long completeHash = partialHash<<32;
-  // The last four bytes of the hash are the first 32 pixels of the topology.
-  // The bits reserved for the pattern that are not used are set to 0.
-  if(nBytesUsed==1){
-    completeHash += ((((unsigned long)patt[2])<<24));
-  }
-  else if(nBytesUsed==2){
-    completeHash += ((((unsigned long)patt[2])<<24) + (((unsigned long)patt[3])<<16));
-  }
-  else if(nBytesUsed==3){
-    completeHash += ((((unsigned long)patt[2])<<24) + (((unsigned long)patt[3])<<16) + (((unsigned long)patt[4])<<8));
-  }
-  else if(nBytesUsed>=4){
-    completeHash += ((((unsigned long)patt[2])<<24) + (((unsigned long)patt[3])<<16) + (((unsigned long)patt[4])<<8) + ((unsigned long)patt[5]));
-  }
-  else{
-    std::cout << "ERROR: no fired pixels\n";
-    exit(1);
-  }
-  return completeHash;
-}
-
-std::ostream& operator<<(std::ostream& os, const ClusterTopology& topology)
-{
-  os << "rowSpan: " << topology.getRowSpan() << " columnSpan: " << topology.getColumnSpan() << " #bytes: " << topology.getUsedBytes() << std::endl;
-  unsigned char tempChar = 0;
-  int s=0;
-  int ic = 0;
-  for (unsigned int i=2; i<topology.getUsedBytes()+2; i++){
-    tempChar = topology.mPattern[i];
-    s=128; //0b10000000
-    while(s>0){
-      if(ic%topology.getColumnSpan()==0) os << "|";
-      ic++;
-      if((tempChar&s)!=0) os << '+';
-      else os << ' ';
-      s/=2;
-      if(ic%topology.getColumnSpan()==0) os << "|" << std::endl;
-      if(ic==(topology.getRowSpan()*topology.getColumnSpan())) break;
+  unsigned int ClusterTopology::hashFunction(const void* key, int len)
+  {
+    //
+    // Developed from https://github.com/rurban/smhasher , function MurMur2
+    //
+    // 'm' and 'r' are mixing constants generated offline.
+    const unsigned int m = 0x5bd1e995;
+    const int r = 24;
+    // Initialize the hash
+    unsigned int h = len ^ 0xdeadbeef;
+    // Mix 4 bytes at a time into the hash
+    const unsigned char* data = (const unsigned char*)key;
+    // int recIndex=0;
+    while (len >= 4) {
+      unsigned int k = *(unsigned int*)data;
+      k *= m;
+      k ^= k >> r;
+      k *= m;
+      h *= m;
+      h ^= k;
+      data += 4;
+      len -= 4;
     }
-    if(ic==(topology.getRowSpan()*topology.getColumnSpan())) break;
+    // Handle the last few bytes of the input array
+    switch (len) {
+      case 3:
+        h ^= data[2] << 16;
+      case 2:
+        h ^= data[1] << 8;
+      case 1:
+        h ^= data[0];
+        h *= m;
+    };
+    // Do a few final mixes of the hash to ensure the last few
+    // bytes are well-incorporated.
+    h ^= h >> 13;
+    h *= m;
+    h ^= h >> 15;
+    return h;
   }
-  os<< std::endl;
-  return os;
-}
-}
+
+  unsigned long ClusterTopology::getCompleteHash(int nRow, int nCol,
+                                                 const unsigned char patt[Cluster::kMaxPatternBytes], int nBytesUsed)
+  {
+    unsigned long extended_pattern[Cluster::kMaxPatternBytes + 2] = { 0 };
+    extended_pattern[0] = (unsigned char)nRow;
+    extended_pattern[1] = (unsigned char)nCol;
+    memcpy(&extended_pattern[2], patt, nBytesUsed);
+
+    unsigned long partialHash = (unsigned long)hashFunction(extended_pattern, nBytesUsed);
+    // The first four bytes are directly taken from partialHash
+    unsigned long completeHash = partialHash << 32;
+    // The last four bytes of the hash are the first 32 pixels of the topology.
+    // The bits reserved for the pattern that are not used are set to 0.
+    if (nBytesUsed == 1) {
+      completeHash += ((((unsigned long)extended_pattern[2]) << 24));
+    } else if (nBytesUsed == 2) {
+      completeHash += ((((unsigned long)extended_pattern[2]) << 24) + (((unsigned long)extended_pattern[3]) << 16));
+    } else if (nBytesUsed == 3) {
+      completeHash += ((((unsigned long)extended_pattern[2]) << 24) + (((unsigned long)extended_pattern[3]) << 16) +
+                       (((unsigned long)extended_pattern[4]) << 8));
+    } else if (nBytesUsed >= 4) {
+      completeHash += ((((unsigned long)extended_pattern[2]) << 24) + (((unsigned long)extended_pattern[3]) << 16) +
+                       (((unsigned long)extended_pattern[4]) << 8) + ((unsigned long)extended_pattern[5]));
+    } else {
+      std::cout << "ERROR: no fired pixels\n";
+      exit(1);
+    }
+    return completeHash;
+  }
+
+  unsigned long ClusterTopology::getCompleteHash(const ClusterTopology& topology)
+  {
+    std::array<unsigned char, Cluster::kMaxPatternBytes + 2> patt = topology.getPattern();
+    int nBytesUsed = topology.getUsedBytes();
+    unsigned long partialHash = (unsigned long)hashFunction(patt.data(), nBytesUsed);
+    // The first four bytes are directly taken from partialHash
+    unsigned long completeHash = partialHash << 32;
+    // The last four bytes of the hash are the first 32 pixels of the topology.
+    // The bits reserved for the pattern that are not used are set to 0.
+    if (nBytesUsed == 1) {
+      completeHash += ((((unsigned long)patt[2]) << 24));
+    } else if (nBytesUsed == 2) {
+      completeHash += ((((unsigned long)patt[2]) << 24) + (((unsigned long)patt[3]) << 16));
+    } else if (nBytesUsed == 3) {
+      completeHash +=
+        ((((unsigned long)patt[2]) << 24) + (((unsigned long)patt[3]) << 16) + (((unsigned long)patt[4]) << 8));
+    } else if (nBytesUsed >= 4) {
+      completeHash += ((((unsigned long)patt[2]) << 24) + (((unsigned long)patt[3]) << 16) +
+                       (((unsigned long)patt[4]) << 8) + ((unsigned long)patt[5]));
+    } else {
+      std::cout << "ERROR: no fired pixels\n";
+      exit(1);
+    }
+    return completeHash;
+  }
+
+  std::ostream& operator<<(std::ostream& os, const ClusterTopology& topology)
+  {
+    os << "rowSpan: " << topology.getRowSpan() << " columnSpan: " << topology.getColumnSpan()
+       << " #bytes: " << topology.getUsedBytes() << std::endl;
+    unsigned char tempChar = 0;
+    int s = 0;
+    int ic = 0;
+    for (unsigned int i = 2; i < topology.getUsedBytes() + 2; i++) {
+      tempChar = topology.mPattern[i];
+      s = 128; // 0b10000000
+      while (s > 0) {
+        if (ic % topology.getColumnSpan() == 0)
+          os << "|";
+        ic++;
+        if ((tempChar & s) != 0)
+          os << '+';
+        else
+          os << ' ';
+        s /= 2;
+        if (ic % topology.getColumnSpan() == 0)
+          os << "|" << std::endl;
+        if (ic == (topology.getRowSpan() * topology.getColumnSpan()))
+          break;
+      }
+      if (ic == (topology.getRowSpan() * topology.getColumnSpan()))
+        break;
+    }
+    os << std::endl;
+    return os;
+  }
+  } // namespace ITSMFT
 }

--- a/Detectors/ITSMFT/common/reconstruction/src/Clusterer.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/Clusterer.cxx
@@ -11,11 +11,11 @@
 /// \file Clusterer.cxx
 /// \brief Implementation of the ITS cluster finder
 #include <algorithm>
-#include "FairLogger.h"      // for LOG
+#include "FairLogger.h" // for LOG
 
-#include "ITSMFTReconstruction/Clusterer.h"
-#include "ITSMFTReconstruction/Cluster.h"
 #include "ITSMFTBase/SegmentationAlpide.h"
+#include "ITSMFTReconstruction/Cluster.h"
+#include "ITSMFTReconstruction/Clusterer.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
 
@@ -23,220 +23,238 @@ using namespace o2::ITSMFT;
 using Segmentation = o2::ITSMFT::SegmentationAlpide;
 
 //__________________________________________________
-Clusterer::Clusterer()
-  :mCurr(mColumn2+1)
-  ,mPrev(mColumn1+1)
+Clusterer::Clusterer() : mCurr(mColumn2 + 1), mPrev(mColumn1 + 1)
 {
   std::fill(std::begin(mColumn1), std::end(mColumn1), -1);
   std::fill(std::begin(mColumn2), std::end(mColumn2), -1);
 
 #ifdef _ClusterTopology_
   LOG(INFO) << "*********************************************************************" << FairLogger::endl;
-  LOG(INFO) << "ATTENTION: YOU ARE RUNNING IN SPECIAL MODE OF STORING CLUSTER PATTERN"  << FairLogger::endl;
+  LOG(INFO) << "ATTENTION: YOU ARE RUNNING IN SPECIAL MODE OF STORING CLUSTER PATTERN" << FairLogger::endl;
   LOG(INFO) << "*********************************************************************" << FairLogger::endl;
 #endif //_ClusterTopology_
-
-  
 }
 
 //__________________________________________________
-void Clusterer::process(PixelReader &reader, std::vector<Cluster> &clusters)
+void Clusterer::process(PixelReader& reader, std::vector<Cluster>& clusters)
 {
   reader.init();
 
   while (reader.getNextChipData(mChipData)) {
-    LOG(DEBUG) <<"ITSClusterer got Chip " << mChipData.chipID << " ROFrame " << mChipData.roFrame
-               << " Nhits " << mChipData.pixels.size() << FairLogger::endl;
+    LOG(DEBUG) << "ITSClusterer got Chip " << mChipData.chipID << " ROFrame " << mChipData.roFrame << " Nhits "
+               << mChipData.pixels.size() << FairLogger::endl;
     initChip();
-    for (int ip=1;ip<mChipData.pixels.size();ip++) updateChip(ip);
+    for (int ip = 1; ip < mChipData.pixels.size(); ip++)
+      updateChip(ip);
     finishChip(clusters);
   }
-
 }
 
 //__________________________________________________
 void Clusterer::initChip()
 {
-  mPrev=mColumn1+1;
-  mCurr=mColumn2+1;
+  mPrev = mColumn1 + 1;
+  mCurr = mColumn2 + 1;
   std::fill(std::begin(mColumn1), std::end(mColumn1), -1);
   std::fill(std::begin(mColumn2), std::end(mColumn2), -1);
 
   mPixels.clear();
   mPreClusterHeads.clear();
   mPreClusterIndices.clear();
-  PixelReader::PixelData* pix = &mChipData.pixels[0]; 
+  PixelReader::PixelData* pix = &mChipData.pixels[0];
   mCol = pix->col;
   mCurr[pix->row] = 0;
-  //start the first pre-cluster
+  // start the first pre-cluster
   mPreClusterHeads.push_back(0);
   mPreClusterIndices.push_back(0);
-  mPixels.emplace_back(-1,pix);
+  mPixels.emplace_back(-1, pix);
 }
 
 //__________________________________________________
 void Clusterer::updateChip(int ip)
 {
-  PixelReader::PixelData* pix = &mChipData.pixels[ip]; 
+  PixelReader::PixelData* pix = &mChipData.pixels[ip];
   if (mCol != pix->col) { // switch the buffers
-    Int_t *tmp = mCurr;
+    Int_t* tmp = mCurr;
     mCurr = mPrev;
     mPrev = tmp;
-    if (pix->col > mCol+1) std::fill(mPrev, mPrev+kMaxRow, -1);
-    std::fill(mCurr, mCurr+kMaxRow, -1);
+    if (pix->col > mCol + 1)
+      std::fill(mPrev, mPrev + kMaxRow, -1);
+    std::fill(mCurr, mCurr + kMaxRow, -1);
     mCol = pix->col;
   }
 
-  Bool_t attached=false;
+  Bool_t attached = false;
   UShort_t row = pix->row;
-  Int_t neighbours[]{mCurr[row-1], mPrev[row], mPrev[row+1], mPrev[row-1]};
+  Int_t neighbours[]{ mCurr[row - 1], mPrev[row], mPrev[row + 1], mPrev[row - 1] };
   for (auto pci : neighbours) {
-     if (pci<0) continue;
-     auto &ci = mPreClusterIndices[pci];
-     if (attached) {
-        auto &newci = mPreClusterIndices[mCurr[row]];
-        if (ci < newci) newci = ci;
-        else ci = newci;
-     } else {
-       auto &firstIndex = mPreClusterHeads[ci];
-        mPixels.emplace_back(firstIndex, pix);
-        firstIndex = mPixels.size() - 1;
-        mCurr[row] = pci;
-        attached = true;
-     }
+    if (pci < 0)
+      continue;
+    auto& ci = mPreClusterIndices[pci];
+    if (attached) {
+      auto& newci = mPreClusterIndices[mCurr[row]];
+      if (ci < newci)
+        newci = ci;
+      else
+        ci = newci;
+    } else {
+      auto& firstIndex = mPreClusterHeads[ci];
+      mPixels.emplace_back(firstIndex, pix);
+      firstIndex = mPixels.size() - 1;
+      mCurr[row] = pci;
+      attached = true;
+    }
   }
-  
-  if (attached) return;
 
-  //start new precluster
+  if (attached)
+    return;
+
+  // start new precluster
   mPreClusterHeads.push_back(mPixels.size());
-  mPixels.emplace_back(-1,pix);
+  mPixels.emplace_back(-1, pix);
   Int_t lastIndex = mPreClusterIndices.size();
   mPreClusterIndices.push_back(lastIndex);
   mCurr[row] = lastIndex;
-
 }
 
 //__________________________________________________
-void Clusterer::finishChip(std::vector<Cluster> &clusters)
+void Clusterer::finishChip(std::vector<Cluster>& clusters)
 {
-  constexpr Float_t SigmaX2 = Segmentation::PitchRow*Segmentation::PitchRow / 12.; //FIXME
-  constexpr Float_t SigmaY2 = Segmentation::PitchCol*Segmentation::PitchCol / 12.; //FIXME
+  constexpr Float_t SigmaX2 = Segmentation::PitchRow * Segmentation::PitchRow / 12.; // FIXME
+  constexpr Float_t SigmaY2 = Segmentation::PitchCol * Segmentation::PitchCol / 12.; // FIXME
 
-  std::array<Label,Cluster::maxLabels> labels;
-  std::array<const PixelData*,Cluster::kMaxPatternBits*2> pixArr;
-  
-  Int_t noc = clusters.size();  
-  for (Int_t i1=0; i1<mPreClusterHeads.size(); ++i1) {
+  std::array<Label, Cluster::maxLabels> labels;
+  std::array<const PixelData*, Cluster::kMaxPatternBits * 2> pixArr;
+
+  Int_t noc = clusters.size();
+  for (Int_t i1 = 0; i1 < mPreClusterHeads.size(); ++i1) {
     const auto ci = mPreClusterIndices[i1];
-    if (ci<0) continue;
-    UShort_t rowMax=0, rowMin=65535;
-    UShort_t colMax=0, colMin=65535;
-    Float_t x=0., z=0.;
+    if (ci < 0)
+      continue;
+    UShort_t rowMax = 0, rowMin = 65535;
+    UShort_t colMax = 0, colMin = 65535;
+    Float_t x = 0., z = 0.;
     int nlab = 0, npix = 0;
     Int_t next = mPreClusterHeads[i1];
     while (next >= 0) {
-      const auto &dig = mPixels[next];
+      const auto& dig = mPixels[next];
       const auto pix = dig.second; // PixelReader.PixelData*
       x += pix->row;
       z += pix->col;
-      if (pix->row < rowMin) rowMin = pix->row;
-      if (pix->row > rowMax) rowMax = pix->row;
-      if (pix->col < colMin) colMin = pix->col;
-      if (pix->col > colMax) colMax = pix->col;
-      if (npix<pixArr.size()) pixArr[npix] = pix;  // needed for cluster topology
-      fetchMCLabels(pix, labels, nlab);      
+      if (pix->row < rowMin)
+        rowMin = pix->row;
+      if (pix->row > rowMax)
+        rowMax = pix->row;
+      if (pix->col < colMin)
+        colMin = pix->col;
+      if (pix->col > colMax)
+        colMax = pix->col;
+      if (npix < pixArr.size())
+        pixArr[npix] = pix; // needed for cluster topology
+      fetchMCLabels(pix, labels, nlab);
       npix++;
       next = dig.first;
     }
     mPreClusterIndices[i1] = -1;
-    for (Int_t i2=i1+1; i2<mPreClusterHeads.size(); ++i2) {
-      if (mPreClusterIndices[i2] != ci) continue;
+    for (Int_t i2 = i1 + 1; i2 < mPreClusterHeads.size(); ++i2) {
+      if (mPreClusterIndices[i2] != ci)
+        continue;
       next = mPreClusterHeads[i2];
       while (next >= 0) {
-        const auto &dig = mPixels[next];
+        const auto& dig = mPixels[next];
         const auto pix = dig.second; // PixelReader.PixelData*
         x += pix->row;
         z += pix->col;
-        if (pix->row < rowMin) rowMin = pix->row;
-        if (pix->row > rowMax) rowMax = pix->row;
-        if (pix->col < colMin) colMin = pix->col;
-        if (pix->col > colMax) colMax = pix->col;
-        if (npix<pixArr.size()) pixArr[npix] = pix;  // needed for cluster topology
+        if (pix->row < rowMin)
+          rowMin = pix->row;
+        if (pix->row > rowMax)
+          rowMax = pix->row;
+        if (pix->col < colMin)
+          colMin = pix->col;
+        if (pix->col > colMax)
+          colMax = pix->col;
+        if (npix < pixArr.size())
+          pixArr[npix] = pix; // needed for cluster topology
         // add labels
-        fetchMCLabels(pix, labels, nlab);   
+        fetchMCLabels(pix, labels, nlab);
         npix++;
         next = dig.first;
       }
       mPreClusterIndices[i2] = -1;
-    }    
+    }
 
-    Point3D<float> xyzLoc( Segmentation::getFirstRowCoordinate() + x*Segmentation::PitchRow/npix, 0.f,
-                           Segmentation::getFirstColCoordinate() + z*Segmentation::PitchCol/npix );
-    auto xyzTra = mGeometry->getMatrixT2L(mChipData.chipID)^(xyzLoc); // inverse transform from Local to Tracking frame
+    Point3D<float> xyzLoc(Segmentation::getFirstRowCoordinate() + x * Segmentation::PitchRow / npix, 0.f,
+                          Segmentation::getFirstColCoordinate() + z * Segmentation::PitchCol / npix);
+    auto xyzTra =
+      mGeometry->getMatrixT2L(mChipData.chipID) ^ (xyzLoc); // inverse transform from Local to Tracking frame
 
     clusters.emplace_back();
-    Cluster &c = clusters[noc];
+    Cluster& c = clusters[noc];
     c.SetUniqueID(noc); // Let the cluster remember its position within the cluster array
     c.setROFrame(mChipData.roFrame);
     c.setSensorID(mChipData.chipID);
     c.setPos(xyzTra);
     c.setErrors(SigmaX2, SigmaY2, 0.f);
-    c.setNxNzN(rowMax-rowMin+1,colMax-colMin+1,npix);
+    c.setNxNzN(rowMax - rowMin + 1, colMax - colMin + 1, npix);
     if (mClsLabels) {
-      for (int i=nlab;i--;) mClsLabels->addElement(noc,labels[i]);
+      for (int i = nlab; i--;)
+        mClsLabels->addElement(noc, labels[i]);
     }
     noc++;
 
 #ifdef _ClusterTopology_
-    unsigned short colSpan=(colMax+1-colMin), rowSpan=(rowMax+1-rowMin), colSpanW=colSpan, rowSpanW=rowSpan;
-    if (colSpan*rowSpan>Cluster::kMaxPatternBits) { // need to store partial info
+    unsigned short colSpan = (colMax + 1 - colMin), rowSpan = (rowMax + 1 - rowMin), colSpanW = colSpan,
+                   rowSpanW = rowSpan;
+    if (colSpan * rowSpan > Cluster::kMaxPatternBits) { // need to store partial info
       // will curtail largest dimension
-      if (colSpan>rowSpan) {
-        if ( (colSpanW=Cluster::kMaxPatternBits/rowSpan)==0 ) {
+      if (colSpan > rowSpan) {
+        if ((colSpanW = Cluster::kMaxPatternBits / rowSpan) == 0) {
           colSpanW = 1;
           rowSpanW = Cluster::kMaxPatternBits;
         }
-      }
-      else {
-        if ( (rowSpanW=Cluster::kMaxPatternBits/colSpan)==0 ) {
+      } else {
+        if ((rowSpanW = Cluster::kMaxPatternBits / colSpan) == 0) {
           rowSpanW = 1;
           colSpanW = Cluster::kMaxPatternBits;
         }
       }
     }
-    c.setPatternRowSpan(rowSpanW,rowSpanW<rowSpan);
-    c.setPatternColSpan(colSpanW,colSpanW<colSpan);
+    c.setPatternRowSpan(rowSpanW, rowSpanW < rowSpan);
+    c.setPatternColSpan(colSpanW, colSpanW < colSpan);
     c.setPatternRowMin(rowMin);
     c.setPatternColMin(colMin);
-    if (npix>pixArr.size()) npix = pixArr.size();
-    for (int i=0;i<npix;i++) {
+    if (npix > pixArr.size())
+      npix = pixArr.size();
+    for (int i = 0; i < npix; i++) {
       const auto pix = pixArr[i];
       unsigned short ir = pix->row - rowMin, ic = pix->col - colMin;
-      if (ir<rowSpanW && ic<colSpanW) c.setPixel(ir,ic);
+      if (ir < rowSpanW && ic < colSpanW)
+        c.setPixel(ir, ic);
     }
-#endif //_ClusterTopology_  
-    
+#endif //_ClusterTopology_
   }
 }
 
 //__________________________________________________
-void Clusterer::fetchMCLabels(const PixelReader::PixelData* pix,
-                              std::array<Label,Cluster::maxLabels> &labels,
-                              int &nfilled) const
+void Clusterer::fetchMCLabels(const PixelReader::PixelData* pix, std::array<Label, Cluster::maxLabels>& labels,
+                              int& nfilled) const
 {
   // transfer MC labels to cluster
-  if (nfilled>=Cluster::maxLabels) return;
-  for (int id=0;id<Digit::maxLabels;id++) {
+  if (nfilled >= Cluster::maxLabels)
+    return;
+  for (int id = 0; id < Digit::maxLabels; id++) {
     Label lbl = pix->labels[id];
-    if ( lbl.isEmpty() ) return; // all following labels will be invalid
+    if (lbl.isEmpty())
+      return; // all following labels will be invalid
     int ic = nfilled;
-    for (;ic--;) { // check if the label is already present
-      if (labels[ic]==lbl) break;
+    for (; ic--;) { // check if the label is already present
+      if (labels[ic] == lbl)
+        break;
     }
-    if (ic<0) { // label not found
+    if (ic < 0) { // label not found
       labels[nfilled++] = lbl;
-      if (nfilled>=Cluster::maxLabels) break;
+      if (nfilled >= Cluster::maxLabels)
+        break;
     }
   }
   //

--- a/Detectors/ITSMFT/common/reconstruction/src/ITSMFTReconstructionLinkDef.h
+++ b/Detectors/ITSMFT/common/reconstruction/src/ITSMFTReconstructionLinkDef.h
@@ -16,5 +16,10 @@
 
 #pragma link C++ class o2::ITSMFT::Cluster+;
 #pragma link C++ class o2::ITSMFT::Clusterer+;
+#pragma link C++ class o2::ITSMFT::ClusterTopology+;
+#pragma link C++ class o2::ITSMFT::TopologyDictionary+;
+#pragma link C++ class o2::ITSMFT::BuildTopologyDictionary+;
+#pragma link C++ class o2::ITSMFT::LookUp+;
+#pragma link C++ class o2::ITSMFT::TopologyFastSimulation+;
 
 #endif

--- a/Detectors/ITSMFT/common/reconstruction/src/ITSMFTReconstructionLinkDef.h
+++ b/Detectors/ITSMFT/common/reconstruction/src/ITSMFTReconstructionLinkDef.h
@@ -14,12 +14,12 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
-#pragma link C++ class o2::ITSMFT::Cluster+;
-#pragma link C++ class o2::ITSMFT::Clusterer+;
-#pragma link C++ class o2::ITSMFT::ClusterTopology+;
-#pragma link C++ class o2::ITSMFT::TopologyDictionary+;
-#pragma link C++ class o2::ITSMFT::BuildTopologyDictionary+;
-#pragma link C++ class o2::ITSMFT::LookUp+;
-#pragma link C++ class o2::ITSMFT::TopologyFastSimulation+;
+#pragma link C++ class o2::ITSMFT::Cluster + ;
+#pragma link C++ class o2::ITSMFT::Clusterer + ;
+#pragma link C++ class o2::ITSMFT::ClusterTopology + ;
+#pragma link C++ class o2::ITSMFT::TopologyDictionary + ;
+#pragma link C++ class o2::ITSMFT::BuildTopologyDictionary + ;
+#pragma link C++ class o2::ITSMFT::LookUp + ;
+#pragma link C++ class o2::ITSMFT::TopologyFastSimulation + ;
 
 #endif

--- a/Detectors/ITSMFT/common/reconstruction/src/LookUp.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/LookUp.cxx
@@ -1,0 +1,25 @@
+#include "ITSMFTReconstruction/LookUp.h"
+
+namespace o2
+{
+namespace ITSMFT
+{
+LookUp::LookUp(std::string fileName){
+  mDictionary.ReadBinaryFile(fileName);
+  mTopologiesOverThreshold = mDictionary.mFinalMap.size();
+}
+
+int LookUp::findGroupID(const std::string& cluster){
+  mTopology.setPattern(cluster);
+  auto ret = mDictionary.mFinalMap.find(mTopology.getHash());
+  if(ret!=mDictionary.mFinalMap.end()) return ret->second;
+  else{
+    int rs = mTopology.getRowSpan();
+    int cs = mTopology.getColumnSpan();
+    int index = (rs/5)*7 + cs/5;
+    if(index >48) index = 48;
+    return (mTopologiesOverThreshold+index);
+  }
+}
+}
+}

--- a/Detectors/ITSMFT/common/reconstruction/src/LookUp.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/LookUp.cxx
@@ -17,27 +17,31 @@
 
 ClassImp(o2::ITSMFT::LookUp)
 
-using std::array;
+  using std::array;
 
 namespace o2
 {
 namespace ITSMFT
 {
-
-LookUp::LookUp(std::string fileName){
+LookUp::LookUp(std::string fileName)
+{
   mDictionary.ReadBinaryFile(fileName);
   mTopologiesOverThreshold = mDictionary.mFinalMap.size();
 }
 
-int LookUp::findGroupID(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes], int nBytesUsed){
-  unsigned long hash = ClusterTopology::getCompleteHash(nRow,nCol,patt,nBytesUsed);
+int LookUp::findGroupID(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes], int nBytesUsed)
+{
+  unsigned long hash = ClusterTopology::getCompleteHash(nRow, nCol, patt, nBytesUsed);
   auto ret = mDictionary.mFinalMap.find(hash);
-  if(ret!=mDictionary.mFinalMap.end()) return ret->second;
-  else{
-    int index = (nRow/TopologyDictionary::RowClassSpan)*TopologyDictionary::NumberOfRowClasses + nCol/TopologyDictionary::ColClassSpan;
-    if(index>=TopologyDictionary::NumberOfRowClasses*TopologyDictionary::NumberOfColClasses) index = TopologyDictionary::NumberOfRowClasses*TopologyDictionary::NumberOfColClasses;
-    return (mTopologiesOverThreshold+index);
+  if (ret != mDictionary.mFinalMap.end())
+    return ret->second;
+  else {
+    int index = (nRow / TopologyDictionary::RowClassSpan) * TopologyDictionary::NumberOfRowClasses +
+                nCol / TopologyDictionary::ColClassSpan;
+    if (index >= TopologyDictionary::NumberOfRowClasses * TopologyDictionary::NumberOfColClasses)
+      index = TopologyDictionary::NumberOfRowClasses * TopologyDictionary::NumberOfColClasses;
+    return (mTopologiesOverThreshold + index);
   }
 }
-}
-}
+} // namespace ITSMFT
+} // namespace o2

--- a/Detectors/ITSMFT/common/reconstruction/src/LookUp.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/LookUp.cxx
@@ -1,23 +1,41 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file LookUp.cxx
+/// \brief Implementation of the LookUp class.
+///
+/// \author Luca Barioglio, University and INFN of Torino
+
 #include "ITSMFTReconstruction/LookUp.h"
+
+ClassImp(o2::ITSMFT::LookUp)
+
+using std::array;
 
 namespace o2
 {
 namespace ITSMFT
 {
+
 LookUp::LookUp(std::string fileName){
   mDictionary.ReadBinaryFile(fileName);
   mTopologiesOverThreshold = mDictionary.mFinalMap.size();
 }
 
-int LookUp::findGroupID(const std::string& cluster){
-  mTopology.setPattern(cluster);
-  auto ret = mDictionary.mFinalMap.find(mTopology.getHash());
+int LookUp::findGroupID(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes], int nBytesUsed){
+  unsigned long hash = ClusterTopology::getCompleteHash(nRow,nCol,patt,nBytesUsed);
+  auto ret = mDictionary.mFinalMap.find(hash);
   if(ret!=mDictionary.mFinalMap.end()) return ret->second;
   else{
-    int rs = mTopology.getRowSpan();
-    int cs = mTopology.getColumnSpan();
-    int index = (rs/5)*7 + cs/5;
-    if(index >48) index = 48;
+    int index = (nRow/TopologyDictionary::RowClassSpan)*TopologyDictionary::NumberOfRowClasses + nCol/TopologyDictionary::ColClassSpan;
+    if(index>=TopologyDictionary::NumberOfRowClasses*TopologyDictionary::NumberOfColClasses) index = TopologyDictionary::NumberOfRowClasses*TopologyDictionary::NumberOfColClasses;
     return (mTopologiesOverThreshold+index);
   }
 }

--- a/Detectors/ITSMFT/common/reconstruction/src/PixelReader.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/PixelReader.cxx
@@ -17,7 +17,7 @@ using namespace o2::ITSMFT;
 using o2::ITSMFT::Digit;
 
 //______________________________________________________________________________
-Bool_t DigitPixelReader::getNextChipData(PixelReader::ChipPixelData &chipData)
+Bool_t DigitPixelReader::getNextChipData(PixelReader::ChipPixelData& chipData)
 {
   chipData.clear();
   if (!mLastDigit) {
@@ -26,25 +26,24 @@ Bool_t DigitPixelReader::getNextChipData(PixelReader::ChipPixelData &chipData)
     }
     mLastDigit = &((*mDigitArray)[mIdx++]);
   }
-  chipData.chipID  = mLastDigit->getChipIndex();
+  chipData.chipID = mLastDigit->getChipIndex();
   chipData.roFrame = mLastDigit->getROFrame();
   chipData.timeStamp =
     mLastDigit->getTimeStamp(); // time difference within the same TFrame does not matter, take 1st one
   chipData.pixels.emplace_back(mLastDigit);
   mLastDigit = nullptr;
-  
+
   while (mIdx < mDigitArray->size()) {
     mLastDigit = &((*mDigitArray)[mIdx++]);
-    if (chipData.chipID  != mLastDigit->getChipIndex()) break;
-    if (chipData.roFrame != mLastDigit->getROFrame()) break;
+    if (chipData.chipID != mLastDigit->getChipIndex())
+      break;
+    if (chipData.roFrame != mLastDigit->getROFrame())
+      break;
     chipData.pixels.emplace_back(mLastDigit);
     mLastDigit = nullptr;
   }
   return kTRUE;
 }
-  
+
 //______________________________________________________________________________
-Bool_t RawPixelReader::getNextChipData(PixelReader::ChipPixelData &chipData)
-{
-  return kTRUE;
-}
+Bool_t RawPixelReader::getNextChipData(PixelReader::ChipPixelData& chipData) { return kTRUE; }

--- a/Detectors/ITSMFT/common/reconstruction/src/TopologyDictionary.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/TopologyDictionary.cxx
@@ -1,0 +1,72 @@
+#include "ITSMFTReconstruction/TopologyDictionary.h"
+
+using std::cout;
+using std::endl;
+
+namespace o2
+{
+namespace ITSMFT
+{
+std::ostream& operator<<(std::ostream& os, const TopologyDictionary& dict)
+{
+  for(auto &p : dict.mVectorOfGroupIDs){
+    os << p.hash << " " << p.errX << " " << p.errZ << " " << p.frequency << std::endl;
+  }
+  return os;
+}
+
+void TopologyDictionary::WriteBinaryFile(string outputfile){
+  std::ofstream file_output(outputfile, std::ios::out | std::ios::binary);
+  for(auto &p : mVectorOfGroupIDs){
+    file_output.write(reinterpret_cast<char *>(&p.hash),sizeof(unsigned long));
+    file_output.write(reinterpret_cast<char *>(&p.errX),sizeof(float));
+    file_output.write(reinterpret_cast<char *>(&p.errZ),sizeof(float));
+    file_output.write(reinterpret_cast<char *>(&p.frequency),sizeof(double));
+  }
+  file_output.close();
+}
+
+void TopologyDictionary::ReadFile(string fname){
+  mVectorOfGroupIDs.clear();
+  mFinalMap.clear();
+  std::ifstream in(fname);
+  GroupStruct gr;
+  int groupID=0;
+  if(!in.is_open()){
+    cout << "The file could not be opened" << endl;
+    exit(1);
+  }
+  else{
+    while(in >> gr.hash >> gr.errX >> gr.errZ >> gr.frequency){
+      mVectorOfGroupIDs.push_back(gr);
+      if(((gr.hash)&0xffffffff) != 0) mFinalMap.insert(std::make_pair(gr.hash,groupID));
+      groupID++;
+    }
+  }
+  in.close();
+}
+
+void TopologyDictionary::ReadBinaryFile(string fname){
+  mVectorOfGroupIDs.clear();
+  mFinalMap.clear();
+  std::ifstream in(fname.data(),std::ios::in | std::ios::binary);
+  GroupStruct gr;
+  int groupID=0;
+  if(!in.is_open()){
+    cout << "The file could not be opened" << endl;
+    exit(1);
+  }
+  else{
+    while(in.read(reinterpret_cast<char*>(&gr.hash), sizeof(unsigned long))){
+      in.read(reinterpret_cast<char*>(&gr.errX), sizeof(float));
+      in.read(reinterpret_cast<char*>(&gr.errZ), sizeof(float));
+      in.read(reinterpret_cast<char*>(&gr.frequency), sizeof(double));
+      mVectorOfGroupIDs.push_back(gr);
+      if(((gr.hash)&0xffffffff) != 0) mFinalMap.insert(std::make_pair(gr.hash,groupID));
+      groupID++;
+    }
+  }
+  in.close();
+}
+}
+}

--- a/Detectors/ITSMFT/common/reconstruction/src/TopologyDictionary.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/TopologyDictionary.cxx
@@ -1,7 +1,27 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TopologyDictionary.cxx
+/// \brief Implementation of the TopologyDictionary class.
+///
+/// \author Luca Barioglio, University and INFN of Torino
+
 #include "ITSMFTReconstruction/TopologyDictionary.h"
 
 using std::cout;
 using std::endl;
+using std::string;
+using std::vector;
+using std::unordered_map;
+
+ClassImp(o2::ITSMFT::TopologyDictionary)
 
 namespace o2
 {
@@ -10,7 +30,7 @@ namespace ITSMFT
 std::ostream& operator<<(std::ostream& os, const TopologyDictionary& dict)
 {
   for(auto &p : dict.mVectorOfGroupIDs){
-    os << p.hash << " " << p.errX << " " << p.errZ << " " << p.frequency << std::endl;
+    os << p.mHash << " " << p.mErrX << " " << p.mErrZ << " " << p.mXCOG << " " << p.mZCOG << " " << p.mNpixels << " " << p.mFrequency << std::endl;
   }
   return os;
 }
@@ -18,10 +38,13 @@ std::ostream& operator<<(std::ostream& os, const TopologyDictionary& dict)
 void TopologyDictionary::WriteBinaryFile(string outputfile){
   std::ofstream file_output(outputfile, std::ios::out | std::ios::binary);
   for(auto &p : mVectorOfGroupIDs){
-    file_output.write(reinterpret_cast<char *>(&p.hash),sizeof(unsigned long));
-    file_output.write(reinterpret_cast<char *>(&p.errX),sizeof(float));
-    file_output.write(reinterpret_cast<char *>(&p.errZ),sizeof(float));
-    file_output.write(reinterpret_cast<char *>(&p.frequency),sizeof(double));
+    file_output.write(reinterpret_cast<char *>(&p.mHash),sizeof(unsigned long));
+    file_output.write(reinterpret_cast<char *>(&p.mErrX),sizeof(float));
+    file_output.write(reinterpret_cast<char *>(&p.mErrZ),sizeof(float));
+    file_output.write(reinterpret_cast<char *>(&p.mXCOG),sizeof(float));
+    file_output.write(reinterpret_cast<char *>(&p.mZCOG),sizeof(float));
+    file_output.write(reinterpret_cast<char *>(&p.mNpixels),sizeof(int));
+    file_output.write(reinterpret_cast<char *>(&p.mFrequency),sizeof(double));
   }
   file_output.close();
 }
@@ -37,9 +60,9 @@ void TopologyDictionary::ReadFile(string fname){
     exit(1);
   }
   else{
-    while(in >> gr.hash >> gr.errX >> gr.errZ >> gr.frequency){
+    while(in >> gr.mHash >> gr.mErrX >> gr.mErrZ >> gr.mXCOG >> gr.mZCOG >> gr.mNpixels >> gr.mFrequency){
       mVectorOfGroupIDs.push_back(gr);
-      if(((gr.hash)&0xffffffff) != 0) mFinalMap.insert(std::make_pair(gr.hash,groupID));
+      if(((gr.mHash)&0xffffffff) != 0) mFinalMap.insert(std::make_pair(gr.mHash,groupID));
       groupID++;
     }
   }
@@ -57,12 +80,15 @@ void TopologyDictionary::ReadBinaryFile(string fname){
     exit(1);
   }
   else{
-    while(in.read(reinterpret_cast<char*>(&gr.hash), sizeof(unsigned long))){
-      in.read(reinterpret_cast<char*>(&gr.errX), sizeof(float));
-      in.read(reinterpret_cast<char*>(&gr.errZ), sizeof(float));
-      in.read(reinterpret_cast<char*>(&gr.frequency), sizeof(double));
+    while(in.read(reinterpret_cast<char*>(&gr.mHash), sizeof(unsigned long))){
+      in.read(reinterpret_cast<char*>(&gr.mErrX), sizeof(float));
+      in.read(reinterpret_cast<char*>(&gr.mErrZ), sizeof(float));
+      in.read(reinterpret_cast<char*>(&gr.mXCOG), sizeof(float));
+      in.read(reinterpret_cast<char*>(&gr.mZCOG), sizeof(float));
+      in.read(reinterpret_cast<char*>(&gr.mNpixels), sizeof(int));
+      in.read(reinterpret_cast<char*>(&gr.mFrequency), sizeof(double));
       mVectorOfGroupIDs.push_back(gr);
-      if(((gr.hash)&0xffffffff) != 0) mFinalMap.insert(std::make_pair(gr.hash,groupID));
+      if(((gr.mHash)&0xffffffff) != 0) mFinalMap.insert(std::make_pair(gr.mHash,groupID));
       groupID++;
     }
   }

--- a/Detectors/ITSMFT/common/reconstruction/src/TopologyDictionary.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/TopologyDictionary.cxx
@@ -18,81 +18,85 @@
 using std::cout;
 using std::endl;
 using std::string;
-using std::vector;
 using std::unordered_map;
+using std::vector;
 
 ClassImp(o2::ITSMFT::TopologyDictionary)
 
-namespace o2
+  namespace o2
 {
-namespace ITSMFT
-{
-std::ostream& operator<<(std::ostream& os, const TopologyDictionary& dict)
-{
-  for(auto &p : dict.mVectorOfGroupIDs){
-    os << p.mHash << " " << p.mErrX << " " << p.mErrZ << " " << p.mXCOG << " " << p.mZCOG << " " << p.mNpixels << " " << p.mFrequency << std::endl;
-  }
-  return os;
-}
-
-void TopologyDictionary::WriteBinaryFile(string outputfile){
-  std::ofstream file_output(outputfile, std::ios::out | std::ios::binary);
-  for(auto &p : mVectorOfGroupIDs){
-    file_output.write(reinterpret_cast<char *>(&p.mHash),sizeof(unsigned long));
-    file_output.write(reinterpret_cast<char *>(&p.mErrX),sizeof(float));
-    file_output.write(reinterpret_cast<char *>(&p.mErrZ),sizeof(float));
-    file_output.write(reinterpret_cast<char *>(&p.mXCOG),sizeof(float));
-    file_output.write(reinterpret_cast<char *>(&p.mZCOG),sizeof(float));
-    file_output.write(reinterpret_cast<char *>(&p.mNpixels),sizeof(int));
-    file_output.write(reinterpret_cast<char *>(&p.mFrequency),sizeof(double));
-  }
-  file_output.close();
-}
-
-void TopologyDictionary::ReadFile(string fname){
-  mVectorOfGroupIDs.clear();
-  mFinalMap.clear();
-  std::ifstream in(fname);
-  GroupStruct gr;
-  int groupID=0;
-  if(!in.is_open()){
-    cout << "The file could not be opened" << endl;
-    exit(1);
-  }
-  else{
-    while(in >> gr.mHash >> gr.mErrX >> gr.mErrZ >> gr.mXCOG >> gr.mZCOG >> gr.mNpixels >> gr.mFrequency){
-      mVectorOfGroupIDs.push_back(gr);
-      if(((gr.mHash)&0xffffffff) != 0) mFinalMap.insert(std::make_pair(gr.mHash,groupID));
-      groupID++;
+  namespace ITSMFT
+  {
+  std::ostream& operator<<(std::ostream& os, const TopologyDictionary& dict)
+  {
+    for (auto& p : dict.mVectorOfGroupIDs) {
+      os << p.mHash << " " << p.mErrX << " " << p.mErrZ << " " << p.mXCOG << " " << p.mZCOG << " " << p.mNpixels << " "
+         << p.mFrequency << std::endl;
     }
+    return os;
   }
-  in.close();
-}
 
-void TopologyDictionary::ReadBinaryFile(string fname){
-  mVectorOfGroupIDs.clear();
-  mFinalMap.clear();
-  std::ifstream in(fname.data(),std::ios::in | std::ios::binary);
-  GroupStruct gr;
-  int groupID=0;
-  if(!in.is_open()){
-    cout << "The file could not be opened" << endl;
-    exit(1);
-  }
-  else{
-    while(in.read(reinterpret_cast<char*>(&gr.mHash), sizeof(unsigned long))){
-      in.read(reinterpret_cast<char*>(&gr.mErrX), sizeof(float));
-      in.read(reinterpret_cast<char*>(&gr.mErrZ), sizeof(float));
-      in.read(reinterpret_cast<char*>(&gr.mXCOG), sizeof(float));
-      in.read(reinterpret_cast<char*>(&gr.mZCOG), sizeof(float));
-      in.read(reinterpret_cast<char*>(&gr.mNpixels), sizeof(int));
-      in.read(reinterpret_cast<char*>(&gr.mFrequency), sizeof(double));
-      mVectorOfGroupIDs.push_back(gr);
-      if(((gr.mHash)&0xffffffff) != 0) mFinalMap.insert(std::make_pair(gr.mHash,groupID));
-      groupID++;
+  void TopologyDictionary::WriteBinaryFile(string outputfile)
+  {
+    std::ofstream file_output(outputfile, std::ios::out | std::ios::binary);
+    for (auto& p : mVectorOfGroupIDs) {
+      file_output.write(reinterpret_cast<char*>(&p.mHash), sizeof(unsigned long));
+      file_output.write(reinterpret_cast<char*>(&p.mErrX), sizeof(float));
+      file_output.write(reinterpret_cast<char*>(&p.mErrZ), sizeof(float));
+      file_output.write(reinterpret_cast<char*>(&p.mXCOG), sizeof(float));
+      file_output.write(reinterpret_cast<char*>(&p.mZCOG), sizeof(float));
+      file_output.write(reinterpret_cast<char*>(&p.mNpixels), sizeof(int));
+      file_output.write(reinterpret_cast<char*>(&p.mFrequency), sizeof(double));
     }
+    file_output.close();
   }
-  in.close();
-}
-}
+
+  void TopologyDictionary::ReadFile(string fname)
+  {
+    mVectorOfGroupIDs.clear();
+    mFinalMap.clear();
+    std::ifstream in(fname);
+    GroupStruct gr;
+    int groupID = 0;
+    if (!in.is_open()) {
+      cout << "The file could not be opened" << endl;
+      exit(1);
+    } else {
+      while (in >> gr.mHash >> gr.mErrX >> gr.mErrZ >> gr.mXCOG >> gr.mZCOG >> gr.mNpixels >> gr.mFrequency) {
+        mVectorOfGroupIDs.push_back(gr);
+        if (((gr.mHash) & 0xffffffff) != 0)
+          mFinalMap.insert(std::make_pair(gr.mHash, groupID));
+        groupID++;
+      }
+    }
+    in.close();
+  }
+
+  void TopologyDictionary::ReadBinaryFile(string fname)
+  {
+    mVectorOfGroupIDs.clear();
+    mFinalMap.clear();
+    std::ifstream in(fname.data(), std::ios::in | std::ios::binary);
+    GroupStruct gr;
+    int groupID = 0;
+    if (!in.is_open()) {
+      cout << "The file could not be opened" << endl;
+      exit(1);
+    } else {
+      while (in.read(reinterpret_cast<char*>(&gr.mHash), sizeof(unsigned long))) {
+        in.read(reinterpret_cast<char*>(&gr.mErrX), sizeof(float));
+        in.read(reinterpret_cast<char*>(&gr.mErrZ), sizeof(float));
+        in.read(reinterpret_cast<char*>(&gr.mXCOG), sizeof(float));
+        in.read(reinterpret_cast<char*>(&gr.mZCOG), sizeof(float));
+        in.read(reinterpret_cast<char*>(&gr.mNpixels), sizeof(int));
+        in.read(reinterpret_cast<char*>(&gr.mFrequency), sizeof(double));
+        mVectorOfGroupIDs.push_back(gr);
+        if (((gr.mHash) & 0xffffffff) != 0)
+          mFinalMap.insert(std::make_pair(gr.mHash, groupID));
+        groupID++;
+      }
+    }
+    in.close();
+  }
+  } // namespace ITSMFT
 }

--- a/Detectors/ITSMFT/common/reconstruction/src/TopologyFastSimulation.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/TopologyFastSimulation.cxx
@@ -18,20 +18,23 @@
 
 ClassImp(o2::ITSMFT::TopologyFastSimulation)
 
-namespace o2
+  namespace o2
 {
-namespace ITSMFT
-{
-TopologyFastSimulation::TopologyFastSimulation(std::string fileName,unsigned seed){
-  mDictionary.ReadBinaryFile(fileName);
-  mGenerator = std::mt19937(seed);
-  mDistribution = std::uniform_real_distribution<double>(0.0,1.0);
-}
+  namespace ITSMFT
+  {
+  TopologyFastSimulation::TopologyFastSimulation(std::string fileName, unsigned seed)
+  {
+    mDictionary.ReadBinaryFile(fileName);
+    mGenerator = std::mt19937(seed);
+    mDistribution = std::uniform_real_distribution<double>(0.0, 1.0);
+  }
 
-int TopologyFastSimulation::getRandom(){
-  double rnd = mDistribution(mGenerator);
-  auto ind = std::upper_bound(mDictionary.mVectorOfGroupIDs.begin(),mDictionary.mVectorOfGroupIDs.end(),rnd, [] (const double &comp1, const GroupStruct &comp2) {return comp1<comp2.mFrequency;});
-  return std::distance(mDictionary.mVectorOfGroupIDs.begin(),ind);
-}
-}
+  int TopologyFastSimulation::getRandom()
+  {
+    double rnd = mDistribution(mGenerator);
+    auto ind = std::upper_bound(mDictionary.mVectorOfGroupIDs.begin(), mDictionary.mVectorOfGroupIDs.end(), rnd,
+                                [](const double& comp1, const GroupStruct& comp2) { return comp1 < comp2.mFrequency; });
+    return std::distance(mDictionary.mVectorOfGroupIDs.begin(), ind);
+  }
+  } // namespace ITSMFT
 }

--- a/Detectors/ITSMFT/common/reconstruction/src/TopologyFastSimulation.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/TopologyFastSimulation.cxx
@@ -1,0 +1,37 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TopologyFastSimulation.cxx
+/// \brief Implementation of the TopologyFastSimulation class.
+///
+/// \author Luca Barioglio, University and INFN of Torino
+
+#include "ITSMFTReconstruction/TopologyFastSimulation.h"
+#include <algorithm>
+
+ClassImp(o2::ITSMFT::TopologyFastSimulation)
+
+namespace o2
+{
+namespace ITSMFT
+{
+TopologyFastSimulation::TopologyFastSimulation(std::string fileName,unsigned seed){
+  mDictionary.ReadBinaryFile(fileName);
+  mGenerator = std::mt19937(seed);
+  mDistribution = std::uniform_real_distribution<double>(0.0,1.0);
+}
+
+int TopologyFastSimulation::getRandom(){
+  double rnd = mDistribution(mGenerator);
+  auto ind = std::upper_bound(mDictionary.mVectorOfGroupIDs.begin(),mDictionary.mVectorOfGroupIDs.end(),rnd, [] (const double &comp1, const GroupStruct &comp2) {return comp1<comp2.mFrequency;});
+  return std::distance(mDictionary.mVectorOfGroupIDs.begin(),ind);
+}
+}
+}


### PR DESCRIPTION
Some classes for the study of the topologies of the clusters of the ITS are added:

- ClusterTopology, which is the base class

- TopologyDictionary, i.e. the dictionary with all the cluster topologies

- BuildClusterTopology, necessary for the construction of the dictionary

- LookUp, necessary for the identification of the topology wih the corresponding key in the dictionary

-FastSimulation, to generate a distribution of cluster topologies according to the dictionary

This PR has been discussed with @shahor02 and @iouribelikov.