### PR TITLE
Bugfix: allow multiple occurence of '--channel-config' option

### DIFF
--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -372,6 +372,7 @@ int doMain(int argc, char **argv, const o2::framework::WorkflowSpec & specs) {
      bpo::value<std::string>(),
      "device id for child spawning")
     ("channel-config",
+     bpo::value<std::vector<std::string>>(),
      "channel configuration")
     ("control",
      "control plugin")


### PR DESCRIPTION
This handles a boost exception for processors with more than one channel.
Introduced when the framework argument scan was changed to boost program
options. The child processes are started with one or more '--channel-config'
option(s)

Initially, also a unit test to handle this case was planned, but it turned out to be more complex as expected. The error condition of the the failing child process is not caught in the main process, and
thus the unit test is not failing.