### PR TITLE
Adding definition of ReadoutDataHeader, moving DataHeader printout functionality

### DIFF
--- a/Algorithm/test/headerstack.cxx
+++ b/Algorithm/test/headerstack.cxx
@@ -21,6 +21,7 @@
 #include <iomanip>
 #include <cstring> // memcmp
 #include "Headers/DataHeader.h" // hexdump
+#include "Headers/NameHeader.h"
 #include "../include/Algorithm/HeaderStack.h"
 
 using DataHeader = o2::Header::DataHeader;

--- a/DataFormats/Headers/CMakeLists.txt
+++ b/DataFormats/Headers/CMakeLists.txt
@@ -7,12 +7,14 @@ O2_SETUP(NAME ${MODULE_NAME})
 # Define the source and header files
 set(SRCS
   src/DataHeader.cxx
+  src/NameHeader.cxx
   src/HeartbeatFrame.cxx
   src/TimeStamp.cxx
 )
 
 set(HEADERS
   include/${MODULE_NAME}/DataHeader.h
+  include/${MODULE_NAME}/NameHeader.h
   include/${MODULE_NAME}/HeartbeatFrame.h
   include/${MODULE_NAME}/TimeStamp.h
 )

--- a/DataFormats/Headers/CMakeLists.txt
+++ b/DataFormats/Headers/CMakeLists.txt
@@ -26,6 +26,7 @@ set(TEST_SRCS
   test/testDataHeader.cxx
   test/testTimeStamp.cxx
   test/test_HeartbeatFrame.cxx
+  test/test_RAWDataHeader.cxx
 )
 
 O2_GENERATE_TESTS(

--- a/DataFormats/Headers/include/Headers/DataHeader.h
+++ b/DataFormats/Headers/include/Headers/DataHeader.h
@@ -31,8 +31,6 @@
 #define ALICEO2_BASE_DATA_HEADER_
 
 #include <cstdint>
-#include <cstdio>
-#include <iostream>
 #include <memory>
 #include <cassert>
 #include <cstring> //needed for memcmp
@@ -576,7 +574,7 @@ const uint32_t NameHeader<N>::sVersion = 1;
 //__________________________________________________________________________________________________
 /// this 128 bit type for a header field describing the payload data type
 struct printDataDescription {
-  void operator()(const char* str) const { printf("Data origin  : %s\n", str); }
+  void operator()(const char* str) const;
 };
 
 using DataDescription = Descriptor<gSizeDataDescriptionString, printDataDescription>;

--- a/DataFormats/Headers/include/Headers/DataHeader.h
+++ b/DataFormats/Headers/include/Headers/DataHeader.h
@@ -520,58 +520,6 @@ private:
 };
 
 //__________________________________________________________________________________________________
-/// @struct NameHeader
-/// @brief an example data header containing a name of an object as a null terminated char arr.
-/// this is a template! at instantiation the template parameter determines the
-/// size of the held string array.
-/// a caveat with decoding is you have to use Header::get<NameHeader<0>>(buffer)
-/// to get it out of a buffer. May improve in the future if enough people complain.
-/// @ingroup aliceo2_dataformats_dataheader
-template <size_t N>
-struct NameHeader : public BaseHeader {
-  static const uint32_t sVersion;
-  static const o2::Header::HeaderType sHeaderType;
-  static const o2::Header::SerializationMethod sSerializationMethod;
-  NameHeader()
-  : BaseHeader(sizeof(NameHeader), sHeaderType, sSerializationMethod, sVersion)
-  , name()
-  {
-    memset(&name[0],'\0',N);
-  }
-
-  NameHeader(std::string in)
-  : BaseHeader(sizeof(NameHeader), sHeaderType, sSerializationMethod, sVersion)
-  , name()
-  {
-    //std::copy(in.begin(), in.begin()+N, name);
-    // here we actually wnat a null terminated string
-    strncpy(name,in.c_str(),N);
-    name[N-1] = '\0';
-  }
-
-  NameHeader& operator=(const std::string string) {
-    std::copy(string.begin(), string.begin()+N, name);
-    return *this;
-  }
-private:
-  char name[N];
-};
-
-template <size_t N>
-const o2::Header::HeaderType NameHeader<N>::sHeaderType = "NameHead";
-
-// dirty trick to always have access to the headertypeID of a templated header type
-// TODO: find out if this can be done in a nicer way + is this realy necessary?
-template <>
-const o2::Header::HeaderType NameHeader<0>::sHeaderType;
-
-template <size_t N>
-const SerializationMethod NameHeader<N>::sSerializationMethod = gSerializationMethodNone;
-
-template <size_t N>
-const uint32_t NameHeader<N>::sVersion = 1;
-
-//__________________________________________________________________________________________________
 /// this 128 bit type for a header field describing the payload data type
 struct printDataDescription {
   void operator()(const char* str) const;

--- a/DataFormats/Headers/include/Headers/NameHeader.h
+++ b/DataFormats/Headers/include/Headers/NameHeader.h
@@ -1,0 +1,80 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @brief O2 data header classes, header example
+///
+/// origin: CWG4
+/// @author Mikolaj Krzewicki, mkrzewic@cern.ch
+/// @author Matthias Richter, Matthias.Richter@cern.ch
+/// @author David Rohr, drohr@cern.ch
+
+#ifndef NAMEHEADER_H
+#define NAMEHEADER_H
+
+#include <string>
+#include "Headers/DataHeader.h"
+
+namespace o2 {
+namespace Header {
+
+/// @struct NameHeader
+/// @brief an example data header containing a name of an object as a null terminated char arr.
+/// this is a template! at instantiation the template parameter determines the
+/// size of the held string array.
+/// a caveat with decoding is you have to use Header::get<NameHeader<0>>(buffer)
+/// to get it out of a buffer. May improve in the future if enough people complain.
+/// @ingroup aliceo2_dataformats_dataheader
+template <size_t N>
+struct NameHeader : public BaseHeader {
+  static const uint32_t sVersion;
+  static const o2::Header::HeaderType sHeaderType;
+  static const o2::Header::SerializationMethod sSerializationMethod;
+  NameHeader()
+  : BaseHeader(sizeof(NameHeader), sHeaderType, sSerializationMethod, sVersion)
+  , name()
+  {
+    memset(&name[0],'\0',N);
+  }
+
+  NameHeader(std::string in)
+  : BaseHeader(sizeof(NameHeader), sHeaderType, sSerializationMethod, sVersion)
+  , name()
+  {
+    // here we actually want a null terminated string
+    strncpy(name, in.c_str(), N);
+    name[N-1] = '\0';
+  }
+
+  NameHeader& operator=(const std::string string) {
+    std::copy(string.begin(), string.begin()+N, name);
+    return *this;
+  }
+private:
+  char name[N];
+};
+
+template <size_t N>
+const o2::Header::HeaderType NameHeader<N>::sHeaderType = "NameHead";
+
+// dirty trick to always have access to the headertypeID of a templated header type
+// TODO: find out if this can be done in a nicer way + is this realy necessary?
+template <>
+const o2::Header::HeaderType NameHeader<0>::sHeaderType;
+
+template <size_t N>
+const SerializationMethod NameHeader<N>::sSerializationMethod = gSerializationMethodNone;
+
+template <size_t N>
+const uint32_t NameHeader<N>::sVersion = 1;
+
+}
+}
+
+#endif //NAMEHEADER_H

--- a/DataFormats/Headers/include/Headers/RAWDataHeader.h
+++ b/DataFormats/Headers/include/Headers/RAWDataHeader.h
@@ -1,0 +1,111 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_HEADER_RAWDATAHEADER_H
+#define ALICEO2_HEADER_RAWDATAHEADER_H
+
+// @file   RAWDataHeader.h
+// @since  2017-11-22
+// @brief  Definition of the RAW Data Header
+
+#include <cstdint>
+
+namespace o2 {
+namespace Header {
+
+/// The definition of the RAW Data Header v2 (RDH) is specified in
+/// https://docs.google.com/document/d/1IxCCa1ZRpI3J9j3KCmw2htcOLIRVVdEcO-DDPcLNFM0
+/// preliminary description of the fields can be found here
+/// https://docs.google.com/document/d/1FLcBrPaF3Bg1Pnm17nwaxNlenKtEk3ocizEAiGP58J8
+/// FIXME: replace citation with correct ALICE note reference when published
+///
+/// Note: the definition requires little endian architecture, for the moment we
+/// assume that this is the only type the software has to support (based on
+/// experience with previous systems)
+///
+/// RDH consists of 4 64 bit words
+///       63     56      48      40      32      24      16       8       0
+///       |---------------|---------------|---------------|---------------|
+///
+/// 0     | zero  |  size |link id|    FEE id     |  block length | vers  |
+///
+/// 1     |      heartbeat orbit          |       trigger orbit           |
+///
+/// 2     | zero  |heartbeatBC|      trigger type             | trigger BC|
+///
+/// 3     | zero  |      par      | detector field| stop  |  page count   |
+///
+/// Field description:
+/// - version:      the header version number
+/// - block length: assumed to be in byte, but discussion not yet finalized
+/// - FEE ID:       unique id of the Frontend equipment
+/// - Link ID:      id of the link within CRU
+/// - header size:  number of 64 bit words
+/// - heartbeat and trigger orbit/BC: LHC clock parameters, still under
+///                 discussion whether separate fields for HB and trigger
+///                 information needed
+/// - trigger type: bit fiels fir the trigger type yet to be decided
+/// - page count:   incremented if data is bigger than the page size, pages are
+///                 incremented starting from 0
+/// - stop:         bit 0 of the stop field is set if this is the last page
+/// - detector field and par are detector specific fields
+struct RAWDataHeaderV2
+{
+  union {
+    // default value
+    uint64_t word0 = 0x0004ffffff000002;
+    //                   | | |   |   | version 2
+    //                   | | |   | block length 0
+    //                   | | | invalid FEE id
+    //                   | | invalid link id
+    //                   | header size 4 x 64 bit
+    struct {
+      uint64_t version:8;        /// bit 0 to 8: header version
+      uint64_t blockLength:16;   /// bit 9 to 23: block length
+      uint64_t feeId:16;         /// bit 24 to 39: FEE identifier
+      uint64_t linkId:8;         /// bit 40 to 47: link identifier
+      uint64_t headerSize:8;     /// bit 48 to 55: header size
+      uint64_t zero0:8;          /// bit 56 to 63: zeroed
+    };
+  };
+  union {
+    uint64_t word1 = 0x0;
+    struct {
+      uint32_t triggerOrbit;     /// bit 0 to 31: trigger orbit
+      uint32_t heartbeatOrbit;   /// bit 32 to 63: trigger orbit
+    };
+  };
+  union {
+    uint64_t word2 = 0x0;
+    struct {
+      uint64_t triggerBC:12;     /// bit 0 to 11: trigger BC ID
+      uint64_t triggerType:32;   /// bit 12 to 43: trigger type
+      uint64_t heartbeatBC:12;   /// bit 44 to 55: heartbeat BC ID
+      uint64_t zero2:8;          /// bit 56 to 63: zeroed
+    };
+  };
+  union {
+    uint64_t word3 = 0x0;
+    struct {
+      uint64_t pageCnt:16;       /// bit 0 to 15: pages counter
+      uint64_t stop:8;           /// bit 13 to 23: stop code
+      uint64_t detectorField:16; /// bit 24 to 39: detector field
+      uint64_t par:16;           /// bit 40 to 55: par
+      uint64_t zero3:8;          /// bit 56 to 63: zeroed
+    };
+  };
+};
+
+using RAWDataHeader = RAWDataHeaderV2;
+
+}
+}
+
+#endif // ALICEO2_HEADER_RAWDATAHEADER_H

--- a/DataFormats/Headers/src/DataHeader.cxx
+++ b/DataFormats/Headers/src/DataHeader.cxx
@@ -77,10 +77,6 @@ const uint32_t o2::Header::DataHeader::sVersion = 1;
 const o2::Header::HeaderType o2::Header::DataHeader::sHeaderType = String2<uint64_t>("DataHead");
 const o2::Header::SerializationMethod o2::Header::DataHeader::sSerializationMethod = o2::Header::gSerializationMethodNone;
 
-//storage fr NameHeader static
-template <>
-const o2::Header::HeaderType o2::Header::NameHeader<0>::sHeaderType = "NameHead";
-
 using namespace o2::Header;
 
 //__________________________________________________________________________________________________

--- a/DataFormats/Headers/src/DataHeader.cxx
+++ b/DataFormats/Headers/src/DataHeader.cxx
@@ -215,6 +215,12 @@ bool o2::Header::DataHeader::operator==(const DataHeader& that) const
 }
 
 //__________________________________________________________________________________________________
+void o2::Header::printDataDescription::operator()(const char* str) const
+{
+  printf("Data description  : %s\n", str);
+}
+
+//__________________________________________________________________________________________________
 void o2::Header::printDataOrigin::operator()(const char* str) const
 {
   printf("Data origin  : %s\n", str);

--- a/DataFormats/Headers/src/NameHeader.cxx
+++ b/DataFormats/Headers/src/NameHeader.cxx
@@ -1,0 +1,15 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Headers/NameHeader.h"
+
+//storage for NameHeader static
+template <>
+const o2::Header::HeaderType o2::Header::NameHeader<0>::sHeaderType = "NameHead";

--- a/DataFormats/Headers/test/testDataHeader.cxx
+++ b/DataFormats/Headers/test/testDataHeader.cxx
@@ -12,6 +12,7 @@
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
+#include <iostream>
 #include <iomanip>
 #include "Headers/DataHeader.h"
 

--- a/DataFormats/Headers/test/test_RAWDataHeader.cxx
+++ b/DataFormats/Headers/test/test_RAWDataHeader.cxx
@@ -1,0 +1,82 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test RAWDataHeader
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include <array>
+#include "Headers/RAWDataHeader.h"
+
+using RDH = o2::Header::RAWDataHeader;
+
+BOOST_AUTO_TEST_CASE(test_rdh)
+{
+  static_assert(sizeof(RDH) == 32, "the RAWDataHeader is supposed to be 256 bit");
+
+  // check the defaults
+  RDH defaultRDH;
+  BOOST_CHECK(defaultRDH.version == 2);
+  BOOST_CHECK(defaultRDH.blockLength == 0);
+  BOOST_CHECK(defaultRDH.feeId == 0xffff);
+  BOOST_CHECK(defaultRDH.linkId == 0xff);
+  BOOST_CHECK(defaultRDH.headerSize == 4); // header size in 64 bit words
+
+  using byte = unsigned char;
+  std::array<byte, sizeof(RDH)> buffer;
+  buffer.fill(0);
+
+  buffer[0] = 0x2; // set version 2
+  buffer[1] = 0x6;
+  buffer[2] = 0x1;
+  buffer[3] = 0xad;
+  buffer[4] = 0xde;
+  buffer[5] = 0xaf;
+  buffer[6] = 0x04;
+  buffer[7] = 0;
+
+  buffer[16] = 0x23;
+  buffer[17] = 0x71;
+  buffer[18] = 0x98;
+  buffer[19] = 0xba;
+  buffer[20] = 0xdc;
+  buffer[21] = 0x3e;
+  buffer[22] = 0x12;
+  buffer[23] = 0;
+
+  buffer[24] = 0x0f;
+  buffer[25] = 0xd0;
+  buffer[26] = 0;
+  buffer[27] = 0xad;
+  buffer[28] = 0xde;
+  buffer[29] = 0;
+
+  auto rdh = reinterpret_cast<RDH*>(buffer.data());
+
+  // if the tests fail, we are probbaly on a big endian architecture or
+  // there are alignment issues
+  BOOST_CHECK(rdh->version == 2);
+  BOOST_CHECK(rdh->blockLength == 262);
+  BOOST_CHECK(rdh->feeId == 0xdead);
+  BOOST_CHECK(rdh->linkId == 0xaf);
+  BOOST_CHECK(rdh->headerSize == 4);
+  BOOST_CHECK(rdh->zero0 == 0);
+  BOOST_CHECK(rdh->triggerOrbit == 0);
+  BOOST_CHECK(rdh->heartbeatOrbit == 0);
+  BOOST_CHECK(rdh->triggerBC == 0x123);
+  BOOST_CHECK(rdh->triggerType == 0xedcba987);
+  BOOST_CHECK(rdh->heartbeatBC == 0x123);
+  BOOST_CHECK(rdh->zero2 == 0);
+  BOOST_CHECK(rdh->pageCnt == 0xd00f);
+  BOOST_CHECK(rdh->stop == 0);
+  BOOST_CHECK(rdh->detectorField == 0xdead);
+  BOOST_CHECK(rdh->par == 0);
+  BOOST_CHECK(rdh->zero3 == 0);
+}

--- a/Framework/Core/include/Framework/ChannelMatching.h
+++ b/Framework/Core/include/Framework/ChannelMatching.h
@@ -14,6 +14,7 @@
 #include "Framework/InputSpec.h"
 #include "Framework/OutputSpec.h"
 #include <vector>
+#include <string>
 
 namespace o2 {
 namespace framework {

--- a/Framework/Core/include/Framework/ChannelSpec.h
+++ b/Framework/Core/include/Framework/ChannelSpec.h
@@ -10,6 +10,8 @@
 #ifndef FRAMEWORK_CHANNELSPEC_H
 #define FRAMEWORK_CHANNELSPEC_H
 
+#include <string>
+
 namespace o2 {
 namespace framework {
 

--- a/Framework/Core/include/Framework/ConfigParamRegistry.h
+++ b/Framework/Core/include/Framework/ConfigParamRegistry.h
@@ -12,6 +12,7 @@
 
 #include "Framework/ParamRetriever.h"
 #include <memory>
+#include <string>
 
 namespace o2 {
 namespace framework {

--- a/Framework/Core/include/Framework/ConfigParamsHelper.h
+++ b/Framework/Core/include/Framework/ConfigParamsHelper.h
@@ -15,6 +15,7 @@
 
 #include <string>
 #include <vector>
+#include <string>
 
 namespace o2 {
 namespace framework {

--- a/Framework/Core/include/Framework/ForwardRoute.h
+++ b/Framework/Core/include/Framework/ForwardRoute.h
@@ -12,6 +12,7 @@
 
 #include "Framework/InputSpec.h"
 #include <cstddef>
+#include <string>
 
 namespace o2 {
 namespace framework {

--- a/Framework/Core/include/Framework/InputSpec.h
+++ b/Framework/Core/include/Framework/InputSpec.h
@@ -10,6 +10,7 @@
 #ifndef FRAMEWORK_INPUTSPEC_H
 #define FRAMEWORK_INPUTSPEC_H
 
+#include <string>
 #include "Headers/DataHeader.h"
 
 namespace o2 {

--- a/Framework/Core/include/Framework/MessageContext.h
+++ b/Framework/Core/include/Framework/MessageContext.h
@@ -13,6 +13,7 @@
 #include <fairmq/FairMQParts.h>
 #include <vector>
 #include <cassert>
+#include <string>
 
 namespace o2 {
 namespace framework {

--- a/Framework/Core/include/Framework/OutputRoute.h
+++ b/Framework/Core/include/Framework/OutputRoute.h
@@ -12,6 +12,7 @@
 
 #include "Framework/OutputSpec.h"
 #include <cstddef>
+#include <string>
 
 namespace o2 {
 namespace framework {

--- a/Framework/Core/include/Framework/RootObjectContext.h
+++ b/Framework/Core/include/Framework/RootObjectContext.h
@@ -15,6 +15,7 @@
 
 #include <vector>
 #include <cassert>
+#include <string>
 
 namespace o2 {
 namespace framework {

--- a/Utilities/O2MessageMonitor/src/O2MessageMonitor.cxx
+++ b/Utilities/O2MessageMonitor/src/O2MessageMonitor.cxx
@@ -32,6 +32,7 @@
 #include <options/FairMQProgOptions.h>
 #include <FairMQLogger.h>
 #include "Headers/DataHeader.h"
+#include "Headers/NameHeader.h"
 
 using namespace std;
 using namespace o2::Header;

--- a/Utilities/aliceHLTwrapper/test/testMessageFormat.cxx
+++ b/Utilities/aliceHLTwrapper/test/testMessageFormat.cxx
@@ -12,6 +12,7 @@
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
+#include <iostream>
 #include <iomanip>
 #include "aliceHLTwrapper/MessageFormat.h"
 #include "Headers/DataHeader.h"


### PR DESCRIPTION
The definition of RDH follows the working document 
https://docs.google.com/document/d/1IxCCa1ZRpI3J9j3KCmw2htcOLIRVVdEcO-DDPcLNFM0

Some cleanup in the DataHeader definition, moving the printout statements to cxx file, and moving example `NameHeader` to separate file.