### PR TITLE
Extending the DataAllocator by TObject snapshot functionality

### DIFF
--- a/Framework/Core/include/Framework/DataAllocator.h
+++ b/Framework/Core/include/Framework/DataAllocator.h
@@ -91,6 +91,10 @@ public:
   void
   adopt(const OutputSpec &spec, TObject*obj);
 
+  /// Serialize a snapshot of a TObject and send it
+  /// framework does not take ownership og the object
+  void serializeSnapshot(const OutputSpec &spec, TObject* const object);
+
 private:
   std::string matchDataHeader(const OutputSpec &spec, size_t timeframeId);
   FairMQMessagePtr headerMessageFromSpec(OutputSpec const &spec,

--- a/Framework/Core/include/Framework/DataAllocator.h
+++ b/Framework/Core/include/Framework/DataAllocator.h
@@ -91,8 +91,10 @@ public:
   void
   adopt(const OutputSpec &spec, TObject*obj);
 
-  /// Serialize a snapshot of a TObject and send it
-  /// framework does not take ownership og the object
+  /// Serialize a snapshot of a TObject when called, which will then
+  /// sent once the computation ends.
+  /// Framework does not take ownership of the @a object. Changes to @a object
+  /// after the call will not be sent.
   void serializeSnapshot(const OutputSpec &spec, TObject* const object);
 
 private:

--- a/Framework/Core/src/DataAllocator.cxx
+++ b/Framework/Core/src/DataAllocator.cxx
@@ -150,5 +150,25 @@ DataAllocator::adopt(const OutputSpec &spec, TObject*ptr) {
   assert(payload.get() == nullptr);
 }
 
+void
+DataAllocator::serializeSnapshot(const OutputSpec &spec, TObject* const object)
+{
+  std::string channel = matchDataHeader(spec, mRootContext->timeslice());
+  auto headerMessage = headerMessageFromSpec(spec, channel, o2::Header::gSerializationMethodROOT);
+
+  FairMQParts parts;
+
+  FairMQMessagePtr payloadMessage(mDevice->NewMessage());
+  mDevice->Serialize<TMessageSerializer>(*payloadMessage, object);
+  // FIXME: this is kind of ugly, we know that we can change the content of the
+  // header message because we have just created it, but the API declares it const
+  const DataHeader *cdh = o2::Header::get<DataHeader>(headerMessage->GetData());
+  DataHeader *dh = const_cast<DataHeader *>(cdh);
+  dh->payloadSize = payloadMessage->GetSize();
+  parts.AddPart(std::move(headerMessage));
+  parts.AddPart(std::move(payloadMessage));
+  mContext->addPart(std::move(parts), channel);
+}
+
 }
 }


### PR DESCRIPTION
This handles the case when the processor keeps a TObject over multiple calls of the processing function and wants to send a serialized snapshot while keeping the ownership.