### PR TITLE
Add type trait to check for template specialization

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -81,6 +81,7 @@ set(TEST_SRCS
       test/test_SingleDataSource.cxx
       test/test_SuppressionGenerator.cxx
       test/test_TimeParallelPipelining.cxx
+      test/test_TypeTraits.cxx
       test/test_Variants.cxx
       test/test_WorkflowHelpers.cxx
    )

--- a/Framework/Core/include/Framework/TypeTraits.h
+++ b/Framework/Core/include/Framework/TypeTraits.h
@@ -1,0 +1,26 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <type_traits>
+
+namespace o2 {
+namespace framework {
+/// Helper trait to determine if a given type T
+/// is a specialization of a given reference type Ref.
+/// See Framework/Core/test_TypeTraits.cxx for an example
+
+template<typename T, template<typename...> class Ref>
+struct is_specialization : std::false_type {};
+
+template<template<typename...> class Ref, typename... Args>
+struct is_specialization<Ref<Args...>, Ref>: std::true_type {};
+
+}
+}

--- a/Framework/Core/test/test_TypeTraits.cxx
+++ b/Framework/Core/test/test_TypeTraits.cxx
@@ -1,0 +1,46 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test Framework TypeTraits
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include "Framework/TypeTraits.h"
+#include <boost/test/unit_test.hpp>
+#include <vector>
+#include <list>
+
+using namespace o2::framework;
+
+struct Foo {
+  int x;
+  int y;
+};
+
+// Simple test to do root deserialization.
+BOOST_AUTO_TEST_CASE(TestIsSpecialization) {
+  std::vector<int> a;
+  std::vector<Foo> b;
+  std::list<int> c;
+  int d;
+
+  bool test1 = is_specialization<decltype(a),std::vector>::value;
+  bool test2 = is_specialization<decltype(b),std::vector>::value;
+  bool test3 = is_specialization<decltype(b),std::list>::value;
+  bool test4 = is_specialization<decltype(c),std::list>::value;
+  bool test5 = is_specialization<decltype(c),std::vector>::value;
+  bool test6 = is_specialization<decltype(d),std::vector>::value;
+  BOOST_REQUIRE_EQUAL(test1, true);
+  BOOST_REQUIRE_EQUAL(test2, true);
+  BOOST_REQUIRE_EQUAL(test3, false);
+  BOOST_REQUIRE_EQUAL(test4, true);
+  BOOST_REQUIRE_EQUAL(test5, false);
+  BOOST_REQUIRE_EQUAL(test6, false);
+}


### PR DESCRIPTION
This is useful to specialize behavior of templated functions based on
the kind of collection they belong to.