### PR TITLE
Interaction record sampler class + its test

### DIFF
--- a/DataFormats/simulation/CMakeLists.txt
+++ b/DataFormats/simulation/CMakeLists.txt
@@ -14,6 +14,7 @@ Set(HEADERS
     include/${MODULE_NAME}/BaseHits.h
     include/${MODULE_NAME}/MCTruthContainer.h
     include/${MODULE_NAME}/MCCompLabel.h
+    include/${MODULE_NAME}/MCInteractionRecord.h
 )
 
 Set(LINKDEF src/SimulationDataLinkDef.h)

--- a/DataFormats/simulation/include/SimulationDataFormat/MCInteractionRecord.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCInteractionRecord.h
@@ -1,0 +1,40 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @brief  Simulated interaction record
+
+#ifndef ALICEO2_MCINTERACTIONRECORD_H
+#define ALICEO2_MCINTERACTIONRECORD_H
+
+#include <Rtypes.h>
+#include <iostream>
+
+namespace o2
+{
+struct MCInteractionRecord {
+  double timeNS = 0.; ///< time in NANOSECONDS from start of run (period=0, orbit=0)
+  int bc = 0;         ///< bunch crossing ID of interaction
+  int orbit = 0;      ///< LHC orbit
+  int period = 0;     ///< LHC period since beginning of run (if >0 -> time precision loss)
+
+  MCInteractionRecord(double tNS, int bcr = 0, int orb = 0, int per = 0) : timeNS(tNS), bc(bcr), orbit(orb), period(per)
+  {
+  }
+
+  void print()
+  {
+    std::cout << "BCid: " << bc << " Orbit: " << orbit << " Period: " << period << " T(ns): " << timeNS << std::endl;
+  }
+
+  ClassDefNV(MCInteractionRecord, 1);
+};
+}
+
+#endif

--- a/DataFormats/simulation/src/SimulationDataLinkDef.h
+++ b/DataFormats/simulation/src/SimulationDataLinkDef.h
@@ -30,6 +30,7 @@
 #pragma link C++ class std::vector<o2::MCTrackT<double>>+;
 #pragma link C++ class std::vector<o2::MCTrackT<float>>+;
 #pragma link C++ class o2::MCCompLabel+;
+#pragma link C++ class o2::MCInteractionRecord+;
 
 #pragma link C++ class o2::BaseHit+;
 #pragma link C++ class o2::BasicXYZEHit<float,float>+;

--- a/Steer/CMakeLists.txt
+++ b/Steer/CMakeLists.txt
@@ -4,10 +4,12 @@ O2_SETUP(NAME ${MODULE_NAME})
 
 set(SRCS
   src/O2RunAna.cxx
+  src/InteractionSampler.cxx
 )
 
 set(HEADERS
   include/${MODULE_NAME}/O2RunAna.h
+  include/${MODULE_NAME}/InteractionSampler.h
 )
 
 set(LINKDEF src/SteerLinkDef.h)
@@ -15,3 +17,13 @@ set(LIBRARY_NAME ${MODULE_NAME})
 set(BUCKET_NAME data_format_simulation_bucket)
 
 O2_GENERATE_LIBRARY()
+
+set(TEST_SRCS
+  test/testInteractionSampler.cxx
+)
+
+O2_GENERATE_TESTS(
+  MODULE_LIBRARY_NAME ${LIBRARY_NAME}
+  BUCKET_NAME ${BUCKET_NAME}
+  TEST_SRCS ${TEST_SRCS}
+)

--- a/Steer/include/Steer/InteractionSampler.h
+++ b/Steer/include/Steer/InteractionSampler.h
@@ -1,0 +1,133 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @brief Simulated interaction record sampler
+
+#ifndef ALICEO2_INTERACTIONSAMPLER_H
+#define ALICEO2_INTERACTIONSAMPLER_H
+
+#include <Rtypes.h>
+#include <TMath.h>
+#include <TRandom.h>
+#include <bitset>
+#include <vector>
+#include "SimulationDataFormat/MCInteractionRecord.h"
+
+namespace o2
+{
+namespace steer
+{
+class InteractionSampler
+{
+ public:
+  static constexpr double Sec2NanoSec = 1.e9;   // s->ns conversion
+  static constexpr double LHCRevFreq = 11245.5; // LHC revolution frequenct in Hz
+  static constexpr int LHCBCSlots = 3564;       // Max N BC slots on LHC (including abort gap)
+  static constexpr int MaxNOrbits = 0x1 << 24;  // above this (~24min) period is incremented
+  static constexpr int MaxNPeriods = 0x1 << 28; // above this period is incremented
+  //
+  static constexpr double OrbitDuration = Sec2NanoSec / LHCRevFreq; // min spacing between BCs in ns
+  static constexpr double PeriodDuration =
+    OrbitDuration * MaxNOrbits; // duration of period in ns (Prec.loss for periods>1)
+  static constexpr double BCSpacingLHC = OrbitDuration / LHCBCSlots; // min spacing between BCs in ns
+
+  using BunchFilling = std::bitset<LHCBCSlots>;
+
+  o2::MCInteractionRecord generateCollisionTime();
+  void generateCollisionTimes(std::vector<o2::MCInteractionRecord>& dest);
+
+  void init();
+
+  void setInteractionRate(double rateHz) { mIntRate = rateHz; }
+  double getInteractionRate() const { return mIntRate; }
+  void setMuPerBC(double mu) { mMuBC = mu; }
+  double getMuPerBC() const { return mMuBC; }
+  void setBCTimeRMS(double tNS = 0.2) { mBCTimeRMS = tNS; }
+  double getBCTimeRMS() const { return mBCTimeRMS; }
+  const BunchFilling& getBunchFilling() const { return mBCFilling; }
+  BunchFilling& getBunchFilling() { return mBCFilling; }
+  int getNCollidingBC() const { return mBCFilling.count(); }
+  int getBCMin() const { return mBCMin; }
+  int getBCMax() const { return mBCMax; }
+  bool getBC(int bcID) const { return mBCFilling.test(bcID); }
+  void setBC(int bcID, bool active = true);
+  void setBCTrain(int nBC, int bcSpacing, int firstBC);
+  void setBCTrains(int nTrains, int trainSpacingInBC, int nBC, int bcSpacing, int firstBC);
+  void setDefaultBunchFilling();
+
+  void print() const;
+  void printBunchFilling(int bcPerLine = 100) const;
+
+ protected:
+  int simulateInteractingBC();
+  int genPoissonZT();
+  void nextCollidingBC();
+
+  int mIntBCCache = 0;            ///< N interactions left for current BC
+  int mBCCurrent = 0;             ///< current BC
+  int mOrbit = 0;                 ///< current orbit
+  int mPeriod = 0;                ///< current period
+  int mBCMin = 0;                 ///< 1st filled BCID
+  int mBCMax = -1;                ///< last filled BCID
+  double mIntRate = -1.;          ///< total interaction rate in Hz
+  double mBCTimeRMS = 0.2;        ///< BC time spread in NANOSECONDS
+  double mMuBC = -1.;             ///< interaction probability per BC
+  double mProbNoInteraction = 1.; ///< probability of BC w/o interaction
+  double mMuBCZTRed = 0;          ///< reduced mu for fast zero-truncated Poisson derivation
+
+  BunchFilling mBCFilling;       ///< patter of active BCs
+  std::vector<double> mTimeInBC; ///< interaction times within single BC
+
+  static constexpr double DefIntRate = 50e3; ///< default interaction rate
+
+  ClassDefNV(InteractionSampler, 1);
+};
+
+//_________________________________________________
+inline void InteractionSampler::generateCollisionTimes(std::vector<o2::MCInteractionRecord>& dest)
+{
+  // fill vector with interaction records
+  dest.clear();
+  for (int i = dest.capacity(); i--;) {
+    dest.push_back(generateCollisionTime());
+  }
+}
+
+//_________________________________________________
+inline void InteractionSampler::nextCollidingBC()
+{
+  // increment bunch ID till next colliding bunch
+  do {
+    if (++mBCCurrent > mBCMax) { // did we exhaust full orbit?
+      mBCCurrent = mBCMin;
+      if (++mOrbit >= MaxNOrbits) { // did we exhaust full period?
+        mOrbit = 0;
+        mPeriod++;
+      }
+    }
+  } while (!mBCFilling[mBCCurrent]);
+}
+
+//_________________________________________________
+inline int InteractionSampler::genPoissonZT()
+{
+  // generate 0-truncated poisson number
+  // https://en.wikipedia.org/wiki/Zero-truncated_Poisson_distribution
+  int k = 1;
+  double t = mMuBCZTRed, u = gRandom->Rndm(), s = t;
+  while (s < u) {
+    s += t *= mMuBC / (++k);
+  }
+  return k;
+}
+}
+}
+
+#endif

--- a/Steer/src/InteractionSampler.cxx
+++ b/Steer/src/InteractionSampler.cxx
@@ -1,0 +1,171 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Steer/InteractionSampler.h"
+#include <FairLogger.h>
+
+using namespace o2::steer;
+
+//_________________________________________________
+void InteractionSampler::init()
+{
+  // (re-)initialize sample and check parameters consistency
+
+  int nBCSet = mBCFilling.count();
+  if (!nBCSet) {
+    LOG(WARNING) << "No bunch filling provided, impose default one" << FairLogger::endl;
+    ;
+    setDefaultBunchFilling();
+    nBCSet = mBCFilling.count();
+  }
+
+  if (mMuBC < 0. && mIntRate < 0.) {
+    LOG(WARNING) << "No IR or muBC is provided, setting default IR" << FairLogger::endl;
+    ;
+    mIntRate = DefIntRate;
+  }
+
+  if (mMuBC > 0.) {
+    mIntRate = mMuBC * nBCSet * LHCRevFreq;
+    LOG(INFO) << "Deducing IR=" << mIntRate << "Hz from " << nBCSet << " BCs at mu=" << mMuBC << FairLogger::endl;
+  } else {
+    mMuBC = mIntRate / (nBCSet * LHCRevFreq);
+    LOG(INFO) << "Deducing mu=" << mMuBC << " per BC from IR=" << mIntRate << " with " << nBCSet << " BCs"
+              << FairLogger::endl;
+  }
+
+  mBCMin = 0;
+  mBCMax = -1;
+  for (int i = 0; i < LHCBCSlots; i++) {
+    if (!mBCFilling[i])
+      continue;
+    if (mBCMin > i)
+      mBCMin = i;
+    if (mBCMax < i)
+      mBCMax = i;
+  }
+  double muexp = TMath::Exp(-mMuBC);
+  mProbNoInteraction = 1. - muexp;
+  mMuBCZTRed = mMuBC * muexp / mProbNoInteraction;
+  mBCCurrent = mBCMin + gRandom->Integer(mBCMax - mBCMin + 1);
+  mIntBCCache = 0;
+  mOrbit = mPeriod = 0;
+}
+
+//_________________________________________________
+void InteractionSampler::print() const
+{
+  if (mIntRate < 0) {
+    LOG(ERROR) << "not yet initialized";
+    return;
+  }
+  LOG(INFO) << "InteractionSampler with " << getNCollidingBC() << " colliding BCs in [" << mBCMin << '-' << mBCMax
+            << "], mu(BC)= " << getMuPerBC() << " with " << getNCollidingBC()
+            << " -> total IR= " << getInteractionRate() << FairLogger::endl;
+  LOG(INFO) << "Current BC= " << mBCCurrent << '(' << mIntBCCache << " coll left) at orbit " << mOrbit << " period "
+            << mPeriod << FairLogger::endl;
+}
+
+//_________________________________________________
+void InteractionSampler::printBunchFilling(int bcPerLine) const
+{
+  bool endlOK = false;
+  for (int i = 0; i < LHCBCSlots; i++) {
+    printf("%c", mBCFilling[i] ? '+' : '-');
+    if (((i + 1) % bcPerLine) == 0) {
+      printf("\n");
+      endlOK = true;
+    } else {
+      endlOK = false;
+    }
+  }
+  if (!endlOK)
+    printf("\n");
+}
+//_________________________________________________
+void InteractionSampler::setBC(int bcID, bool active)
+{
+  // add interacting BC slot
+  if (bcID >= LHCBCSlots) {
+    LOG(FATAL) << "BCid is limited to " << mBCMin << '-' << mBCMax << FairLogger::endl;
+  }
+  mBCFilling.set(bcID, active);
+}
+
+//_________________________________________________
+void InteractionSampler::setBCTrain(int nBC, int bcSpacing, int firstBC)
+{
+  // add interacting BC train with given spacing starting at given place, i.e.
+  // train with 25ns spacing should have bcSpacing = 1
+  for (int i = 0; i < nBC; i++) {
+    setBC(firstBC);
+    firstBC += bcSpacing;
+  }
+}
+
+//_________________________________________________
+void InteractionSampler::setBCTrains(int nTrains, int trainSpacingInBC, int nBC, int bcSpacing, int firstBC)
+{
+  // add nTrains trains of interacting BCs with bcSpacing within the train and trainSpacingInBC empty slots
+  // between the trains
+  for (int it = 0; it < nTrains; it++) {
+    setBCTrain(nBC, bcSpacing, firstBC);
+    firstBC += nBC * bcSpacing + trainSpacingInBC;
+  }
+}
+
+//_________________________________________________
+void InteractionSampler::setDefaultBunchFilling()
+{
+  // set BC filling a la TPC TDR, 12 50ns trains of 48 BCs
+  // but instead of uniform train spacing we add 96empty BCs after each train
+  setBCTrains(12, 96, 48, 2, 0);
+}
+//_________________________________________________
+o2::MCInteractionRecord InteractionSampler::generateCollisionTime()
+{
+  // generate single interaction record
+  if (mIntRate < 0)
+    init();
+
+  if (mIntBCCache < 1) {                   // do we still have interaction in current BC?
+    mIntBCCache = simulateInteractingBC(); // decide which BC interacts and N collisions
+  }
+  double timeInt = mTimeInBC.back();
+  timeInt += mBCCurrent * BCSpacingLHC + mOrbit * OrbitDuration;
+  if (mPeriod)
+    timeInt += mPeriod * PeriodDuration;
+  mTimeInBC.pop_back();
+  mIntBCCache--;
+  return o2::MCInteractionRecord(timeInt, mBCCurrent, mOrbit, mPeriod);
+}
+
+//_________________________________________________
+int InteractionSampler::simulateInteractingBC()
+{
+  // in order not to test random numbers for too many BC's with low mu,
+  // we estimate from very beginning how many BC's happen w/o interaction
+  // Returns number of collisions assigned to selected BC
+  double prob = gRandom->Rndm();
+  while (prob > 0.) {  // skip BCs w/o interaction
+    nextCollidingBC(); // pick next interacting bunch
+    prob -= mProbNoInteraction;
+  }
+  // once BC is decided, enforce at least one interaction
+  int ncoll = genPoissonZT();
+  // assign random time withing a bunch
+  for (int i = ncoll; i--;) {
+    mTimeInBC.push_back(gRandom->Gaus(mBCTimeRMS));
+  }
+  if (ncoll > 1) { // sort in DECREASING time order (we are reading vector from the end)
+    std::sort(mTimeInBC.begin(), mTimeInBC.end(), [](const double a, const double b) { return a > b; });
+  }
+  return ncoll;
+}

--- a/Steer/src/SteerLinkDef.h
+++ b/Steer/src/SteerLinkDef.h
@@ -15,5 +15,6 @@
 #pragma link off all functions;
 
 #pragma link C++ class o2::steer::O2RunAna;
+#pragma link C++ class o2::steer::InteractionSampler+;
 
 #endif

--- a/Steer/test/testInteractionSampler.cxx
+++ b/Steer/test/testInteractionSampler.cxx
@@ -1,0 +1,79 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test InteractionSampler class
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <algorithm>
+#include <boost/test/unit_test.hpp>
+#include "SimulationDataFormat/MCInteractionRecord.h"
+#include "Steer/InteractionSampler.h"
+
+namespace o2
+{
+BOOST_AUTO_TEST_CASE(InteractionSampler)
+{
+  using Sampler = o2::steer::InteractionSampler;
+
+  const int ntest = 100;
+  std::vector<o2::MCInteractionRecord> records; // destination for records
+  records.reserve(ntest);
+
+  printf("Testing sampler with default settings\n");
+  // default sampler with BC filling like in TPC TDR, 50kHz
+  Sampler defSampler;
+  defSampler.init();
+  defSampler.generateCollisionTimes(records);
+  double t = -1.;
+  for (const auto& rec : records) {
+    BOOST_CHECK(rec.timeNS >= t); // make sure time is non-decreasing
+    t = rec.timeNS;
+  }
+
+  printf("\nTesting sampler with custom bunch filling and low mu\n");
+  // configure sampler with custom bunch filling and mu per BC
+  Sampler sampler1;
+  // train of 100 bunches spaced by 25 ns (1slot) and staring at BC=0
+  sampler1.setBCTrain(100, 1, 0);
+  // train of 100 bunches spaced by 50 ns (2slots) and staring at BC=200
+  sampler1.setBCTrain(200, 2, 200);
+  // add isolated BC at slot 1600
+  sampler1.setBC(1600);
+  // add 5 trains of 20 bunches with 100ns(4slots) spacing, separated by 10 slots and
+  // starting at bunch 700
+  sampler1.setBCTrains(5, 10, 20, 4, 700);
+  // set total interaction rate in Hz
+  sampler1.setInteractionRate(40e3);
+  sampler1.init();
+  sampler1.generateCollisionTimes(records);
+  t = -1.;
+  for (const auto& rec : records) {
+    BOOST_CHECK(rec.timeNS >= t); // make sure time is non-decreasing
+    t = rec.timeNS;
+  }
+
+  // reconfigure w/o modifying BC filling but setting per bunch
+  // mu (large -> lot of in-bunch pile-up)
+  printf("\nResetting/testing sampler with same bunch filling but high mu\n");
+  sampler1.setMuPerBC(0.5);
+  sampler1.init(); // this will reset all counters from previous calls
+  // instead of filling the vector records, we can sample one by one
+  t = -1.;
+  for (int i = 0; i < ntest; i++) {
+    auto rec = sampler1.generateCollisionTime();
+    rec.print();
+    // make sure time is non-decreasing and the BC is interacting
+    BOOST_CHECK(rec.timeNS >= t && sampler1.getBC(rec.bc));
+    t = rec.timeNS;
+  }
+  sampler1.print();
+  sampler1.printBunchFilling();
+}
+}


### PR DESCRIPTION
@sawenzel : please check. In principle, would be good to extract the LHC-related constants to separate header, eventually other classes will need them, but I was not sure that Steer is a correct location for this sample at 1st place, so did not want to complicate dependencies.