### PR TITLE
Update for MT simulation (version 2):

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/Stack.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/Stack.h
@@ -129,6 +129,9 @@ class Stack : public FairGenericStack
   /// Update the track index in the MCTracks and data produced by detectors
   void UpdateTrackIndex(TRefArray* detArray = nullptr) override;
 
+  /// Finish primary
+  void FinishPrimary() override;
+
   /// Resets arrays and stack and deletes particles and tracks
   void Reset() override;
 
@@ -222,7 +225,7 @@ class Stack : public FairGenericStack
   /// and all its secondaries where transported
   /// this allows applying selection criteria at a much finer granularity
   /// than donw with FillTrackArray which is only called once per event
-  void finishPrimary();
+  void finishCurrentPrimary();
 
   /// Increment number of hits for an arbitrary track in a given detector
   /// \param iDet    Detector unique identifier

--- a/DataFormats/simulation/src/Stack.cxx
+++ b/DataFormats/simulation/src/Stack.cxx
@@ -77,8 +77,9 @@ Stack::Stack(const Stack& rhs)
     mEnergyCut(rhs.mEnergyCut),
     mIsG4Like(rhs.mIsG4Like)
 {
-  LOG(FATAL) << "copy constructor called" << FairLogger::endl;
-  mTracks = new std::vector<MCTrack>(rhs.mTracks->size());
+  LOG(DEBUG) << "copy constructor called" << FairLogger::endl;
+  mTracks = new std::vector<MCTrack>();
+  // LOG(INFO) << "Stack::Stack(rhs) " << this << " mTracks " << mTracks << std::endl;
 }
 
 Stack::~Stack()
@@ -331,6 +332,13 @@ void Stack::UpdateTrackIndex(TRefArray* detList)
   LOG(DEBUG) << "Stack::UpdateTrackIndex: ...stack and " << nColl << " collections updated.";
 }
 
+void Stack::FinishPrimary()
+{
+  if ( mIsG4Like ) {
+    notifyFinishPrimary();
+  }
+}
+
 void Stack::Reset()
 {
   mIndex = 0;
@@ -350,6 +358,7 @@ void Stack::Reset()
 }
 
 void Stack::Register() { FairRootManager::Instance()->RegisterAny("MCTrack", mTracks, kTRUE); }
+
 void Stack::Print(Int_t iVerbose) const
 {
   cout << "-I- Stack: Number of primaries        = " << mNumberOfPrimaryParticles << endl;

--- a/DataFormats/simulation/src/Stack.cxx
+++ b/DataFormats/simulation/src/Stack.cxx
@@ -194,7 +194,7 @@ void Stack::notifyFinishPrimary()
   mCleanupCounter++;
   if (mCleanupCounter == mCleanupThreshold || mCleanupCounter == mPrimaryParticles.size() ||
       mPrimariesDone == mPrimaryParticles.size()) {
-    finishPrimary();
+    finishCurrentPrimary();
     mCleanupCounter = 0;
   }
 }
@@ -255,7 +255,7 @@ void Stack::FillTrackArray()
   LOG(INFO) << "Stack: " << mTracks->size() << " out of " << mNumberOfEntriesInParticles << " stored \n";
 }
 
-void Stack::finishPrimary()
+void Stack::finishCurrentPrimary()
 {
   // Here transport of a primary and all its secondaries is finished
   // we can do some cleanup of the memory structures

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/Detector.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/Detector.h
@@ -59,6 +59,11 @@ class Detector : public o2::Base::DetImpl<Detector>
   ~Detector() override = default;
 
   ///
+  /// Clone this object (used in MT mode only)
+  ///
+  FairModule *CloneModule() const override;
+
+  ///
   /// Initializing detector
   ///
   void Initialize() final;
@@ -165,6 +170,11 @@ class Detector : public o2::Base::DetImpl<Detector>
   Double_t CalculateLightYield(Double_t energydeposit, Double_t tracklength, Int_t charge) const;
 
  private:
+  ///
+  /// Copy constructor (used in MT)
+  ///
+  Detector(const Detector& rhs);
+
   Int_t mBirkC0;
   Double_t mBirkC1;
   Double_t mBirkC2;

--- a/Detectors/EMCAL/simulation/src/Detector.cxx
+++ b/Detectors/EMCAL/simulation/src/Detector.cxx
@@ -66,7 +66,44 @@ Detector::Detector(Bool_t active)
     mSampleWidth += 2. * geo->GetTrd1BondPaperThick();
 }
 
-void Detector::Initialize() { o2::Base::Detector::Initialize(); }
+Detector::Detector(const Detector& rhs)
+  : o2::Base::DetImpl<Detector>(rhs),
+    mBirkC0(rhs.mBirkC0),
+    mBirkC1(rhs.mBirkC1),
+    mBirkC2(rhs.mBirkC2),
+    mHits(new std::vector<Hit>),
+    mGeometry(rhs.mGeometry),
+    mCurrentTrackID(-1),
+    mCurrentCellID(-1),
+    mCurrentHit(nullptr),
+    mSampleWidth(rhs.mSampleWidth),
+    mSmodPar0(rhs.mSmodPar0),
+    mSmodPar1(rhs.mSmodPar1),
+    mSmodPar2(rhs.mSmodPar2),
+    mInnerEdge(rhs.mInnerEdge)
+
+{
+  for ( int i=0; i<5; ++i) {
+    mParEMOD[i] = rhs.mParEMOD[i];
+  }
+}
+
+FairModule* Detector::CloneModule() const
+{
+  return new Detector(*this);
+}
+
+void Detector::Initialize()
+{
+  // Define sensitive volume
+  TGeoVolume* vsense = gGeoManager->GetVolume("SCMX");
+  if (vsense)
+    AddSensitiveVolume(vsense);
+  else
+    LOG(ERROR) << "EMCAL Sensitive volume SCMX not found ... No hit creation!\n";
+
+  o2::Base::Detector::Initialize();
+}
 
 void Detector::EndOfEvent() { Reset(); }
 
@@ -92,13 +129,6 @@ void Detector::ConstructGeometry()
   CreateShiskebabGeometry();
 
   gGeoManager->CheckGeometry();
-
-  // Define sensitive volume
-  TGeoVolume* vsense = gGeoManager->GetVolume("SCMX");
-  if (vsense)
-    AddSensitiveVolume(vsense);
-  else
-    LOG(ERROR) << "EMCAL Sensitive volume SCMX not found ... No hit creation!\n";
 }
 
 Bool_t Detector::ProcessHits(FairVolume* v)

--- a/Detectors/EMCAL/simulation/src/Detector.cxx
+++ b/Detectors/EMCAL/simulation/src/Detector.cxx
@@ -181,14 +181,14 @@ Bool_t Detector::ProcessHits(FairVolume* v)
     // - First track of the event
     // std::cout << "New track / cell started\n";
     Float_t posX, posY, posZ, momX, momY, momZ, energy;
-    mcapp->TrackPosition(posX, posY, posZ);
-    mcapp->TrackMomentum(momX, momY, momZ, energy);
-    Double_t estart = mcapp->Etot(), time = mcapp->TrackTime() * 1e9; // time in ns
+    fMC->TrackPosition(posX, posY, posZ);
+    fMC->TrackMomentum(momX, momY, momZ, energy);
+    Double_t estart = fMC->Etot(), time = fMC->TrackTime() * 1e9; // time in ns
 
     /// check handling of primary particles
     mCurrentHit = AddHit(partID, parent, 0, estart, detID, Point3D<float>(posX, posY, posZ),
                          Vector3D<float>(momX, momY, momZ), time, lightyield);
-    static_cast<o2::Data::Stack*>(mcapp->GetStack())->addHit(GetDetId());
+    static_cast<o2::Data::Stack*>(fMC->GetStack())->addHit(GetDetId());
     mCurrentTrackID = partID;
     mCurrentCellID = detID;
     

--- a/Detectors/FIT/simulation/src/Detector.cxx
+++ b/Detectors/FIT/simulation/src/Detector.cxx
@@ -41,7 +41,18 @@ Detector::Detector(Bool_t Active)
   //  TString gn(geo->GetName());
 }
 
-void Detector::Initialize() { o2::Base::Detector::Initialize(); }
+void Detector::Initialize()
+{
+  // FIXME: we need to register the sensitive volumes with FairRoot
+  TGeoVolume* v = gGeoManager->GetVolume("0REG");
+  if (v == nullptr)
+    printf("Sensitive volume 0REG not found!!!!!!!!");
+  else {
+    AddSensitiveVolume(v);
+  }
+
+  o2::Base::Detector::Initialize();
+}
 
 void Detector::ConstructGeometry()
 {
@@ -180,14 +191,6 @@ void Detector::ConstructGeometry()
 
   // MCP + 4 x wrapped radiator + 4xphotocathod + MCP + Al top in front of radiators
   SetOneMCP(ins);
-
-  // FIXME: we need to register the sensitive volumes with FairRoot
-  TGeoVolume* v = gGeoManager->GetVolume("0REG");
-  if (v == nullptr)
-    printf("Sensitive volume 0REG not found!!!!!!!!");
-  else {
-    AddSensitiveVolume(v);
-  }
 }
 
 //_________________________________________

--- a/Detectors/FIT/simulation/src/Detector.cxx
+++ b/Detectors/FIT/simulation/src/Detector.cxx
@@ -269,19 +269,18 @@ Bool_t Detector::ProcessHits(FairVolume* v)
 {
 
   TLorentzVector position;
-  static auto* refMC = TVirtualMC::GetMC();
-  if (refMC->IsTrackEntering()) {
-    refMC->TrackPosition(position);
+  if (fMC->IsTrackEntering()) {
+    fMC->TrackPosition(position);
     float x = position.X();
     float y = position.Y();
     float z = position.Z();
 
-    float time = refMC->TrackTime() * 1.0e12;
-    int trackID = refMC->GetStack()->GetCurrentTrackNumber();
+    float time = fMC->TrackTime() * 1.0e12;
+    int trackID = fMC->GetStack()->GetCurrentTrackNumber();
     int detID = v->getMCid();
-    float etot = refMC->Etot();
-    int iPart = refMC->TrackPid();
-    float enDep = refMC->Edep();
+    float etot = fMC->Etot();
+    int iPart = fMC->TrackPid();
+    float enDep = fMC->Edep();
     if (iPart == 50000050) // If particles is photon then ...
     {
       if (RegisterPhotoE(etot)) {

--- a/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
@@ -28,6 +28,7 @@
 #include "FairRun.h"                // for FairRun
 #include "FairRuntimeDb.h"          // for FairRuntimeDb
 #include "FairVolume.h"             // for FairVolume
+#include "FairRootManager.h"
 
 #include "TGeoManager.h"            // for TGeoManager, gGeoManager
 #include "TGeoTube.h"               // for TGeoTube
@@ -276,6 +277,9 @@ Detector &Detector::operator=(const Detector &rhs)
 
 void Detector::Initialize()
 {
+  // Define the list of sensitive volumes
+  defineSensitiveVolumes();
+
   for (int i = 0; i < sNumberLayers; i++) {
     mLayerID[i] = gMC ? TVirtualMC::GetMC()->VolId(mLayerName[i]) : 0;
   }
@@ -589,7 +593,6 @@ void Detector::Register()
   // parameter to kFALSE means that this collection will not be written to the file,
   // it will exist only during the simulation
 
-  // FIXME: fix MT interface
   if (FairRootManager::Instance()) {
     FairRootManager::Instance()->RegisterAny(addNameTo("Hit").data(), mHits, kTRUE);
   }
@@ -770,9 +773,6 @@ void Detector::ConstructGeometry()
 
   // Construct the detector geometry
   constructDetectorGeometry();
-
-  // Define the list of sensitive volumes
-  defineSensitiveVolumes();
 }
 
 void Detector::constructDetectorGeometry()

--- a/Detectors/ITSMFT/MFT/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/MFT/simulation/src/Detector.cxx
@@ -110,7 +110,7 @@ Bool_t Detector::ProcessHits(FairVolume* vol)
   // This method is called from the MC stepping
 
   // do not track neutral particles
-  if (!(TVirtualMC::GetMC()->TrackCharge())) {
+  if (!(fMC->TrackCharge())) {
     return kFALSE;
   }
 
@@ -118,14 +118,14 @@ Bool_t Detector::ProcessHits(FairVolume* vol)
 
   Int_t copy;
   // Check if hit is into a MFT sensor volume
-  if(TVirtualMC::GetMC()->CurrentVolID(copy) != mftGeo->getSensorVolumeID() ) return kFALSE;
+  if(fMC->CurrentVolID(copy) != mftGeo->getSensorVolumeID() ) return kFALSE;
 
   // Get The Sensor Unique ID
   Int_t sensorID = -1, ladderID = -1, diskID = -1, halfID = -1, level = 0;
-  TVirtualMC::GetMC()->CurrentVolOffID(++level,sensorID);
-  TVirtualMC::GetMC()->CurrentVolOffID(++level,ladderID);
-  TVirtualMC::GetMC()->CurrentVolOffID(++level,diskID);
-  TVirtualMC::GetMC()->CurrentVolOffID(++level,halfID);
+  fMC->CurrentVolOffID(++level,sensorID);
+  fMC->CurrentVolOffID(++level,ladderID);
+  fMC->CurrentVolOffID(++level,diskID);
+  fMC->CurrentVolOffID(++level,halfID);
   
   Int_t sensorIndex = mGeometryTGeo->getSensorIndex(halfID,diskID,ladderID,sensorID);
 
@@ -133,12 +133,12 @@ Bool_t Detector::ProcessHits(FairVolume* vol)
 
   bool startHit=false, stopHit=false;
   unsigned char status = 0;
-  if (TVirtualMC::GetMC()->IsTrackEntering()) { status |= Hit::kTrackEntering; }
-  if (TVirtualMC::GetMC()->IsTrackInside())   { status |= Hit::kTrackInside; }
-  if (TVirtualMC::GetMC()->IsTrackExiting())  { status |= Hit::kTrackExiting; }
-  if (TVirtualMC::GetMC()->IsTrackOut())      { status |= Hit::kTrackOut; }
-  if (TVirtualMC::GetMC()->IsTrackStop())     { status |= Hit::kTrackStopped; }
-  if (TVirtualMC::GetMC()->IsTrackAlive())    { status |= Hit::kTrackAlive; }
+  if (fMC->IsTrackEntering()) { status |= Hit::kTrackEntering; }
+  if (fMC->IsTrackInside())   { status |= Hit::kTrackInside; }
+  if (fMC->IsTrackExiting())  { status |= Hit::kTrackExiting; }
+  if (fMC->IsTrackOut())      { status |= Hit::kTrackOut; }
+  if (fMC->IsTrackStop())     { status |= Hit::kTrackStopped; }
+  if (fMC->IsTrackAlive())    { status |= Hit::kTrackAlive; }
 
   // track is entering or created in the volume
   if ( (status & Hit::kTrackEntering) || (status & Hit::kTrackInside && !mTrackData.mHitStarted) ) {
@@ -149,14 +149,14 @@ Bool_t Detector::ProcessHits(FairVolume* vol)
   }
 
   // increment energy loss at all steps except entrance
-  if (!startHit) mTrackData.mEnergyLoss += TVirtualMC::GetMC()->Edep();
+  if (!startHit) mTrackData.mEnergyLoss += fMC->Edep();
   if (!(startHit|stopHit)) return kFALSE; // do noting
 
   if (startHit) {
 
     mTrackData.mEnergyLoss = 0.;
-    TVirtualMC::GetMC()->TrackMomentum(mTrackData.mMomentumStart);
-    TVirtualMC::GetMC()->TrackPosition(mTrackData.mPositionStart);
+    fMC->TrackMomentum(mTrackData.mMomentumStart);
+    fMC->TrackPosition(mTrackData.mPositionStart);
     mTrackData.mTrkStatusStart = status;
     mTrackData.mHitStarted = true;
 
@@ -165,9 +165,9 @@ Bool_t Detector::ProcessHits(FairVolume* vol)
   if (stopHit) {
 
     TLorentzVector positionStop;
-    TVirtualMC::GetMC()->TrackPosition(positionStop);
+    fMC->TrackPosition(positionStop);
 
-    Int_t trackID  = TVirtualMC::GetMC()->GetStack()->GetCurrentTrackNumber();
+    Int_t trackID  = fMC->GetStack()->GetCurrentTrackNumber();
     //Int_t detID = vol->getMCid();
 
     Hit *p = addHit(trackID,
@@ -181,7 +181,7 @@ Bool_t Detector::ProcessHits(FairVolume* vol)
                     mTrackData.mTrkStatusStart,
                     status);
     
-    o2::Data::Stack *stack = (o2::Data::Stack *) TVirtualMC::GetMC()->GetStack();
+    o2::Data::Stack *stack = (o2::Data::Stack *) fMC->GetStack();
     stack->addHit(GetDetId());
     
   }

--- a/Detectors/ITSMFT/MFT/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/MFT/simulation/src/Detector.cxx
@@ -32,6 +32,7 @@
 #include "FairLogger.h"
 #include "FairRootManager.h"
 #include "FairVolume.h"
+#include "FairRootManager.h"
 
 using o2::ITSMFT::Hit;
 using namespace o2::MFT;
@@ -101,7 +102,6 @@ void Detector::Initialize()
   defineSensitiveVolumes();
 
   FairDetector::Initialize();
-
 }
 
 //_____________________________________________________________________________

--- a/Detectors/Passive/include/DetectorsPassive/FrameStructure.h
+++ b/Detectors/Passive/include/DetectorsPassive/FrameStructure.h
@@ -37,6 +37,9 @@ class FrameStructure : public FairModule
   /**  destructor     */
   ~FrameStructure() override = default;
 
+  /**  Clone this object (used in MT mode only)  */
+  FairModule* CloneModule() const override;
+
   /**  Create the module geometry  */
   void ConstructGeometry() override;
 
@@ -45,6 +48,9 @@ class FrameStructure : public FairModule
   // set if to be constructed with/without holes
   void setHoles(bool flag) { mWithHoles = true; }
  private:
+  /**  copy constructor (used in MT mode only)   */
+  FrameStructure(const FrameStructure& rhs);
+
   void makeHeatScreen(const char* name, float dyP, int rot1, int rot2);
   void createWebFrame(const char* name, float dHz, float theta0, float phi0);
   void createMaterials();

--- a/Detectors/Passive/src/FrameStructure.cxx
+++ b/Detectors/Passive/src/FrameStructure.cxx
@@ -41,6 +41,15 @@ const char* TOPNAME = "cave";
 
 FrameStructure::FrameStructure(const char* name, const char* Title) : FairModule(name, Title) {}
 
+FrameStructure::FrameStructure(const FrameStructure& rhs) : FairModule(rhs)
+{}
+
+FairModule* FrameStructure::CloneModule() const
+{
+  std::cout << "cloning FrameStructure - now the right one !" << std::endl;
+  return new FrameStructure(*this);
+}
+
 void FrameStructure::makeHeatScreen(const char* name, float dyP, int rot1, int rot2)
 {
   // Heat screen panel

--- a/Detectors/TOF/simulation/include/TOFSimulation/Detector.h
+++ b/Detectors/TOF/simulation/include/TOFSimulation/Detector.h
@@ -53,6 +53,8 @@ class Detector : public o2::Base::DetImpl<Detector>
 
   ~Detector() override = default;
 
+  FairModule* CloneModule() const override;
+
   void Initialize() final;
 
   Bool_t ProcessHits(FairVolume* v = nullptr) final;
@@ -80,6 +82,9 @@ class Detector : public o2::Base::DetImpl<Detector>
   virtual void MaterialMixer(Float_t* p, const Float_t* const a, const Float_t* const m, Int_t n) const final;
 
  private:
+  /// copy constructor (used in MT)
+  Detector(const Detector& rhs);
+
   void createModules(Float_t xtof, Float_t ytof, Float_t zlenA, Float_t xFLT, Float_t yFLT, Float_t zFLTA) const;
   void makeStripsInModules(Float_t ytof, Float_t zlenA) const;
   void createModuleCovers(Float_t xtof, Float_t zlenA) const;

--- a/Detectors/TOF/simulation/src/Detector.cxx
+++ b/Detectors/TOF/simulation/src/Detector.cxx
@@ -9,13 +9,12 @@
 // or submit itself to any jurisdiction.
 
 #include "TGeoManager.h" // for TGeoManager
-#include "TLorentzVector.h"
 #include "TMath.h"
 #include "TString.h"
 
 #include "FairLogger.h"
-#include "FairRootManager.h"
 #include "FairVolume.h"
+#include "FairRootManager.h"
 
 #include "TOFSimulation/Detector.h"
 
@@ -34,12 +33,40 @@ Detector::Detector(Bool_t active)
     mTOFSectors[i] = 1;
 }
 
-void Detector::Initialize() { o2::Base::Detector::Initialize(); }
+Detector::Detector(const Detector& rhs)
+  : o2::Base::DetImpl<Detector>(rhs),
+    mEventNr(0),
+    mTOFHoles(rhs.mTOFHoles),
+    mHits(new std::vector<HitType>)
+{
+  for (Int_t i = 0; i < Geo::NSECTORS; i++)
+    mTOFSectors[i] = rhs.mTOFSectors[i];
+}
+
+FairModule* Detector::CloneModule() const
+{
+  return new Detector(*this);
+}
+
+void Detector::Initialize()
+{
+  TGeoVolume* v = gGeoManager->GetVolume("FPAD");
+  if (v == nullptr)
+    printf("Sensitive volume FSEN not found!!!!!!!!");
+  else {
+    AddSensitiveVolume(v);
+  }
+
+  o2::Base::Detector::Initialize();
+}
+
 Bool_t Detector::ProcessHits(FairVolume* v)
 {
-  static auto* refMC = TVirtualMC::GetMC();
+  static thread_local auto* refMC = TVirtualMC::GetMC();
 
-  static TLorentzVector position2;
+  static thread_local TLorentzVector position2;
+  refMC->TrackPosition(position2);
+
   refMC->TrackPosition(position2);
   Float_t radius = TMath::Sqrt(position2.X() * position2.X() + position2.Y() * position2.Y());
   LOG(DEBUG) << "Process hit in TOF volume ar R=" << radius << " - Z=" << position2.Z() << FairLogger::endl;
@@ -56,7 +83,7 @@ Bool_t Detector::ProcessHits(FairVolume* v)
     return kFALSE; // wo se need a threshold?
 
   // ADD HIT
-  static TLorentzVector position;
+  static thread_local TLorentzVector position;
   refMC->TrackPosition(position);
   float time = refMC->TrackTime() * 1.0e09;
   auto stack = static_cast<o2::Data::Stack*>(refMC->GetStack());
@@ -84,8 +111,7 @@ Bool_t Detector::ProcessHits(FairVolume* v)
 
 void Detector::Register()
 {
-  auto* mgr = FairRootManager::Instance();
-  mgr->RegisterAny(addNameTo("Hit").data(), mHits, kTRUE);
+  FairRootManager::Instance()->RegisterAny(addNameTo("Hit").data(), mHits, kTRUE);
 }
 
 void Detector::Reset()
@@ -281,13 +307,6 @@ void Detector::ConstructGeometry()
   DefineGeometry(xTof, yTof, zTof);
 
   LOG(INFO) << "Loaded TOF geometry" << FairLogger::endl;
-
-  TGeoVolume* v = gGeoManager->GetVolume("FPAD");
-  if (v == nullptr)
-    printf("Sensitive volume FSEN not found!!!!!!!!");
-  else {
-    AddSensitiveVolume(v);
-  }
 }
 
 void Detector::EndOfEvent() { Reset(); }

--- a/Detectors/TOF/simulation/src/Detector.cxx
+++ b/Detectors/TOF/simulation/src/Detector.cxx
@@ -62,31 +62,29 @@ void Detector::Initialize()
 
 Bool_t Detector::ProcessHits(FairVolume* v)
 {
-  static thread_local auto* refMC = TVirtualMC::GetMC();
-
   static thread_local TLorentzVector position2;
-  refMC->TrackPosition(position2);
+  fMC->TrackPosition(position2);
 
-  refMC->TrackPosition(position2);
+  fMC->TrackPosition(position2);
   Float_t radius = TMath::Sqrt(position2.X() * position2.X() + position2.Y() * position2.Y());
   LOG(DEBUG) << "Process hit in TOF volume ar R=" << radius << " - Z=" << position2.Z() << FairLogger::endl;
 
   // This method is called from the MC stepping for the sensitive volume only
 
-  if (static_cast<int>(refMC->TrackCharge()) == 0) {
+  if (static_cast<int>(fMC->TrackCharge()) == 0) {
     // set a very large step size for neutral particles
     return kFALSE; // take only charged particles
   }
 
-  Float_t enDep = refMC->Edep();
+  Float_t enDep = fMC->Edep();
   if (enDep < 1E-8)
     return kFALSE; // wo se need a threshold?
 
   // ADD HIT
   static thread_local TLorentzVector position;
-  refMC->TrackPosition(position);
-  float time = refMC->TrackTime() * 1.0e09;
-  auto stack = static_cast<o2::Data::Stack*>(refMC->GetStack());
+  fMC->TrackPosition(position);
+  float time = fMC->TrackTime() * 1.0e09;
+  auto stack = static_cast<o2::Data::Stack*>(fMC->GetStack());
   int trackID = stack->GetCurrentTrackNumber();
   int sensID = v->getMCid();
   Int_t det[5];

--- a/Detectors/TPC/simulation/include/TPCSimulation/Detector.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/Detector.h
@@ -40,6 +40,9 @@ class Detector: public o2::Base::DetImpl<Detector> {
     /**       destructor     */
     ~Detector() override;
 
+    /**      Clone this object (used in MT mode only)    */
+    FairModule *CloneModule() const override;
+
     /**      Initialization of the detector is done here    */
     void   Initialize() override;
 
@@ -136,10 +139,11 @@ class Detector: public o2::Base::DetImpl<Detector> {
     std::vector<HitGroup>*  mHitsPerSectorCollection[Sector::MAXSECTOR]; //! container that keeps track-grouped hits per sector
 
     TString mGeoFileName;                  ///< Name of the file containing the TPC geometry
-    size_t mEventNr;                       //!< current event number
+    // size_t mEventNr;                       //!< current event number
+    // Events are not successive in MT mode
 
-
-    Detector(const Detector&);
+    /// copy constructor (used in MT)
+    Detector(const Detector& rhs);
     Detector& operator=(const Detector&);
 
     ClassDefOverride(Detector,1)

--- a/Detectors/TRD/simulation/include/TRDSimulation/Detector.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Detector.h
@@ -34,6 +34,8 @@ class Detector : public o2::Base::DetImpl<Detector>
 
   ~Detector() override = default;
 
+  FairModule* CloneModule() const override;
+
   void Initialize() override;
 
   bool ProcessHits(FairVolume* v = nullptr) override;
@@ -55,6 +57,9 @@ class Detector : public o2::Base::DetImpl<Detector>
   void ConstructGeometry() override;
 
  private:
+  /// copy constructor (used in MT)
+  Detector(const Detector& rhs);
+
   // defines/sets-up the sensitive volumes
   void defineSensitiveVolumes();
 

--- a/Detectors/TRD/simulation/src/Detector.cxx
+++ b/Detectors/TRD/simulation/src/Detector.cxx
@@ -63,7 +63,7 @@ bool Detector::ProcessHits(FairVolume* v)
   // just record position and basic quantities for the moment
   // TODO: needs to be interpreted properly
   float x, y, z;
-  vmc->TrackPosition(x, y, z);
+  fMC->TrackPosition(x, y, z);
 
   float enDep = fMC->Edep();
   float time = fMC->TrackTime() * 1.0e09;

--- a/Detectors/TRD/simulation/src/Detector.cxx
+++ b/Detectors/TRD/simulation/src/Detector.cxx
@@ -55,11 +55,8 @@ bool Detector::ProcessHits(FairVolume* v)
   // very rudimentatary hit creation
   // TODO: needs upgrade to the level of AliROOT
 
-  // TODO: reference to vmc --> put this as member of detector
-  static thread_local auto vmc = TVirtualMC::GetMC();
-
   // If not charged track or already stopped or disappeared, just return.
-  if ((!vmc->TrackCharge()) || vmc->IsTrackDisappeared()) {
+  if ((!fMC->TrackCharge()) || fMC->IsTrackDisappeared()) {
     return false;
   }
 
@@ -68,8 +65,8 @@ bool Detector::ProcessHits(FairVolume* v)
   float x, y, z;
   vmc->TrackPosition(x, y, z);
 
-  float enDep = vmc->Edep();
-  float time = vmc->TrackTime() * 1.0e09;
+  float enDep = fMC->Edep();
+  float time = fMC->TrackTime() * 1.0e09;
   auto stack = (o2::Data::Stack *) TVirtualMC::GetMC()->GetStack();
   auto trackID = stack->GetCurrentTrackNumber();
   auto sensID = v->getMCid();

--- a/Detectors/gconfig/commonConfig.C
+++ b/Detectors/gconfig/commonConfig.C
@@ -9,6 +9,7 @@ void stackSetup(T* vmc, R* run) {
   st->StoreSecondaries(kTRUE);
   vmc->SetStack(st);
 
+/*
   // register the stack as an observer on FinishPrimary events (managed by Cave)
   bool foundCave = false;
   auto modules = run->GetListOfModules();
@@ -29,4 +30,5 @@ void stackSetup(T* vmc, R* run) {
       LOG(FATAL) << "Cave volume not found; Could not attach observers" << FairLogger::endl;
     }
   }
+*/
 }


### PR DESCRIPTION
- Replaced calls to FairGenericRootManager with FairRootManager
  (now thread-safe)
- Migrated code in Detectors and DataFormats to MT
  - Implemented CloneModule() method where missing
  - Moved definition of sensitive volumes in detectors from
    ConstructGeometry() to Initialize(), to get it called on threads
  - Changed static local variables defined during event processing
    in static thread_local
  - Implemented o2::Stack::FinishPrimary(), which has been added in FairGenericStack
    base class, and removed the hook for calling this code from commonConfig.C.
    The code still requires clean-up by the author of the Stack class to avoid
    mIsG4Like test here.