### PR TITLE
Resolve conflict of hidden device options with potential config specs.

### DIFF
--- a/Framework/Core/include/Framework/ConfigParamsHelper.h
+++ b/Framework/Core/include/Framework/ConfigParamsHelper.h
@@ -20,21 +20,29 @@
 namespace o2 {
 namespace framework {
 
+using options_description = boost::program_options::options_description;
+
 void populateBoostProgramOptions(
-    boost::program_options::options_description &options,
-    const std::vector<ConfigParamSpec> &specs
+    options_description &options,
+    const std::vector<ConfigParamSpec> &specs,
+    options_description vetos = options_description()
   );
 
 /// populate boost program options making all options of type string
 /// this is used for filtering the command line argument
+/// all options which are found in the vetos are skipped
 bool
 prepareOptionsDescription(const std::vector<ConfigParamSpec> &spec,
-                          boost::program_options::options_description& options);
+                          options_description& options,
+                          options_description vetos = options_description()
+                          );
 
 /// populate boost program options for a complete workflow
 template<typename ContainerType>
 boost::program_options::options_description
-prepareOptionDescriptions(const ContainerType &workflow)
+prepareOptionDescriptions(const ContainerType &workflow,
+                          options_description vetos = options_description()
+                          )
 {
   boost::program_options::options_description specOptions("Spec groups");
   for (const auto & spec : workflow) {
@@ -43,7 +51,7 @@ prepareOptionDescriptions(const ContainerType &workflow)
                               boost::program_options::value<std::string>(),
                               help.c_str());
     boost::program_options::options_description options(spec.name.c_str());
-    if (prepareOptionsDescription(spec.options, options)) {
+    if (prepareOptionsDescription(spec.options, options, vetos)) {
       specOptions.add(options);
     }
   }

--- a/Framework/Core/src/ConfigParamsHelper.cxx
+++ b/Framework/Core/src/ConfigParamsHelper.cxx
@@ -22,10 +22,13 @@ namespace framework {
 /// taking the VariantType into account
 void populateBoostProgramOptions(
     bpo::options_description &options,
-    const std::vector<ConfigParamSpec> &specs
+    const std::vector<ConfigParamSpec> &specs,
+    bpo::options_description vetos
   ) {
   auto proxy = options.add_options();
   for (auto & spec : specs) {
+    // skip everything found in the veto definition
+    if (vetos.find_nothrow(spec.name, false)) continue;
     const char *name = spec.name.c_str();
     const char *help = spec.help.c_str();
 
@@ -60,10 +63,14 @@ void populateBoostProgramOptions(
 /// this is used for filtering the command line argument
 bool
 prepareOptionsDescription(const std::vector<ConfigParamSpec> &spec,
-                          boost::program_options::options_description& options)
+                          boost::program_options::options_description& options,
+                          boost::program_options::options_description vetos
+			  )
 {
   bool haveOption = false;
   for (const auto & configSpec : spec) {
+    // skip everything found in the veto definition
+    if (vetos.find_nothrow(configSpec.name, false)) continue;
     haveOption = true;
     std::stringstream defaultValue;
     defaultValue << configSpec.defaultValue;

--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -561,7 +561,7 @@ DeviceSpecHelpers::prepareArguments(int argc,
         // find the option belonging to key, add if the option has been parsed
         // and is not defaulted
         const auto * description = odesc.find_nothrow(varit.first, false);
-        if (description && varmap.count(varit.first) && !varit.second.defaulted()) {
+        if (description && varmap.count(varit.first)) {
           tmpArgs.emplace_back("--");
           tmpArgs.back() += varit.first;
           // check the semantics of the value


### PR DESCRIPTION
The command line options are populated with a couple of hidden options
by the framework to correctly start the device. Using a key of the
hidden options in the processor config spec resulted in a parser error
due to duplicated definitions.

The allows in particular '--channel-config' to be used in the config
specs to specify external channels

Also forwarding default values of all options to devices. Currently the `ConfigParamSpec` does not foresee _no default_.