### PR TITLE
Support config spec with empty default value

### DIFF
--- a/Framework/Core/include/Framework/ConfigParamSpec.h
+++ b/Framework/Core/include/Framework/ConfigParamSpec.h
@@ -16,13 +16,49 @@
 namespace o2 {
 namespace framework {
 
+/// @class ConfigParamSpec Definition of options for a processor
+/// An option definition consists of a name, a type, a help message, and
+/// an optional default value. The type of the argument has to be specified
+/// in terms of VariantType
+///
+/// Options and arguments can be retrieved from the init context in the
+/// initialization function:
+///   context.options().get<TYPE>("NAME")
+///
+/// All options are also forwarded to the device.
 struct ConfigParamSpec {
   using ParamType = VariantType;
+
+  struct HelpString {
+    const char* c_str() const {return str.c_str();}
+    std::string str;
+  };
+  template<typename T>
+  ConfigParamSpec(std::string, ParamType, Variant, T)
+    : type(VariantType::Unknown) {
+    static_assert(std::is_same<T, HelpString>::value,
+		  R"(help string must be brace-enclosed, e.g. '{"help"}')");
+  }
+
+  ConfigParamSpec(std::string _name, ParamType _type,
+                  Variant _defaultValue, HelpString _help)
+    : name(_name)
+    , type(_type)
+    , defaultValue(_defaultValue)
+    , help(_help) {}
+
+  /// config spec without default value, explicitely marked as 'empty'
+  /// and will be ignored at other places
+  ConfigParamSpec(std::string _name, ParamType _type, HelpString _help)
+    : name(_name)
+    , type(_type)
+    , defaultValue(VariantType::Empty)
+    , help(_help) {}
 
   std::string name;
   ParamType type;
   Variant defaultValue;
-  std::string help;
+  HelpString help;
 };
 
 }

--- a/Framework/Core/include/Framework/Variant.h
+++ b/Framework/Core/include/Framework/Variant.h
@@ -16,6 +16,7 @@
 #include <stdexcept>
 #include <iosfwd>
 #include <iostream>
+#include <initializer_list>
 
 namespace o2 {
 namespace framework {
@@ -27,6 +28,7 @@ enum class VariantType : int {
   Double,
   String,
   Bool,
+  Empty,
   Unknown
 };
 
@@ -123,9 +125,18 @@ struct variant_helper<S, const char *> {
 class Variant {
   using storage_t = std::aligned_union<8, int, int64_t, const char *, float, double, bool>::type;
 public:
+  Variant(VariantType type = VariantType::Unknown) : mType{type} {}
+
   template <typename T> Variant(T value)
   : mType{variant_trait<T>::type()} {
     variant_helper<storage_t, decltype(value)>::set(&mStore, value);
+  }
+
+  template <typename T> Variant(std::initializer_list<T>)
+    : mType{VariantType::Unknown} {
+    static_assert(sizeof(T) == 0,
+		  "brace-enclosed initializer list forbidden for Variant"
+		  "\n did you accidentally put braces around the default value?");
   }
 
   Variant(const Variant &other)
@@ -203,6 +214,8 @@ public:
         break;
       case VariantType::Bool:
         oss << val.get<bool>();
+        break;
+      case VariantType::Empty:
         break;
       default:
         oss << "undefined";

--- a/Framework/Core/src/BoostOptionsRetriever.cxx
+++ b/Framework/Core/src/BoostOptionsRetriever.cxx
@@ -28,6 +28,7 @@ BoostOptionsRetriever::BoostOptionsRetriever(std::vector<ConfigParamSpec> &specs
   for (auto & spec : specs) {
     const char *name = spec.name.c_str();
     const char *help = spec.help.c_str();
+    // FIXME: propagate default value?
     switch(spec.type) {
       case VariantType::Int:
       case VariantType::Int64:
@@ -46,6 +47,7 @@ BoostOptionsRetriever::BoostOptionsRetriever(std::vector<ConfigParamSpec> &specs
         options = options(name, bpo::value<bool>(), help);
         break;
       case VariantType::Unknown:
+      case VariantType::Empty:
         break;
     };
   }

--- a/Framework/Core/src/ConfigParamsHelper.cxx
+++ b/Framework/Core/src/ConfigParamsHelper.cxx
@@ -7,6 +7,7 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
+#include "Framework/ConfigParamsHelper.h"
 #include "Framework/ConfigParamSpec.h"
 #include <boost/program_options.hpp>
 
@@ -37,23 +38,22 @@ void populateBoostProgramOptions(
       // FIXME: We should probably raise an error if the type is unknown
       case VariantType::Int:
       case VariantType::Int64:
-        proxy = proxy(name, bpo::value<int>()->default_value(spec.defaultValue.get<int>()), help);
+        addConfigSpecOption<VariantType::Int>(spec, options);
         break;
       case VariantType::Float:
-        proxy = proxy(name, bpo::value<float>()->default_value(spec.defaultValue.get<float>()), help);
+        addConfigSpecOption<VariantType::Float>(spec, options);
         break;
       case VariantType::Double:
-        proxy = proxy(name, bpo::value<double>()->default_value(spec.defaultValue.get<double>()), help);
+        addConfigSpecOption<VariantType::Double>(spec, options);
         break;
       case VariantType::String:
-        proxy = proxy(name, bpo::value<std::string>()->default_value(spec.defaultValue.get<const char *>()), help);
+        addConfigSpecOption<VariantType::String>(spec, options);
         break;
       case VariantType::Bool:
-        // for bool values we also support the zero_token option to make
-        // the option usable as a single switch
-        proxy = proxy(name, bpo::value<bool>()->zero_tokens()->default_value(spec.defaultValue.get<bool>()), help);
+        addConfigSpecOption<VariantType::Bool>(spec, options);
         break;
       case VariantType::Unknown:
+      case VariantType::Empty:
         break;
     };
   }

--- a/Framework/Core/src/FrameworkGUIDebugger.cxx
+++ b/Framework/Core/src/FrameworkGUIDebugger.cxx
@@ -60,6 +60,8 @@ optionsTable(const DeviceSpec &spec, const DeviceControl &control) {
           case VariantType::Double:
             ImGui::Text("%f (default)", option.defaultValue.get<double>());
             break;
+          case VariantType::Empty:
+            ImGui::TextUnformatted(""); // no default value
           default:
             ImGui::TextUnformatted("unknown");
         }

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -371,7 +371,8 @@ WorkflowHelpers::verifyWorkflow(const o2::framework::WorkflowSpec &workflow) {
     if (validNames.find(spec.name) != validNames.end())
       throw std::runtime_error("Name " + spec.name + " is used twice.");
     for (auto &option : spec.options) {
-      if (option.type != option.defaultValue.type()) {
+      if (option.defaultValue.type() != VariantType::Empty &&
+          option.type != option.defaultValue.type()) {
         ss << "Mismatch between declared option type and default value type"
            << " for " << option.name << " in DataProcessorSpec of "
            << spec.name;

--- a/Framework/Core/test/test_BoostOptionsRetriever.cxx
+++ b/Framework/Core/test/test_BoostOptionsRetriever.cxx
@@ -26,11 +26,11 @@ BOOST_AUTO_TEST_CASE(ConfigParamsHelper) {
   namespace bpo = boost::program_options;
 
   auto specs = std::vector<ConfigParamSpec>{
-    {"someInt", VariantType::Int, 2, "some int option"},
-    {"someBool", VariantType::Bool, false,"some bool option"},
-    {"someFloat", VariantType::Float, 2.0f, "some float option"},
-    {"someDouble", VariantType::Double, 2.0, "some double option"},
-    {"someString", VariantType::String, strdup("barfoo"), "some string option"}
+    {"someInt", VariantType::Int, 2, {"some int option"}},
+    {"someBool", VariantType::Bool, false,{"some bool option"}},
+    {"someFloat", VariantType::Float, 2.0f, {"some float option"}},
+    {"someDouble", VariantType::Double, 2.0, {"some double option"}},
+    {"someString", VariantType::String, strdup("barfoo"), {"some string option"}}
   };
   const char* args[] = {
     "test",

--- a/Framework/Core/test/test_SingleDataSource.cxx
+++ b/Framework/Core/test/test_SingleDataSource.cxx
@@ -29,7 +29,7 @@ void defineDataProcessing(WorkflowSpec &specs) {
        ctx.services().get<ControlService>().readyToQuit(true);
       }
     },
-    Options{{"test-option", VariantType::String, "test", "A test option"}},
+    Options{{"test-option", VariantType::String, "test", {"A test option"}}},
   }
   };
   specs.swap(workflow);

--- a/Framework/Core/test/test_Variants.cxx
+++ b/Framework/Core/test/test_Variants.cxx
@@ -42,9 +42,9 @@ BOOST_AUTO_TEST_CASE(VariantTest) {
   BOOST_CHECK(ss.str() == "1010.110.2foo");
   // Spotted valgrind error while deleting a vector of variants.
   std::vector<Variant> vector{1, 1.2, 1.1f, "foo"};
-  Variant sa{"foo"};
-  Variant sb{sa}; // Copy constructor
-  Variant sc{std::move(sa)}; // Move constructor
+  Variant sa("foo");
+  Variant sb(sa); // Copy constructor
+  Variant sc(std::move(sa)); // Move constructor
   Variant sd = sc; // Copy operator
 
   BOOST_CHECK(std::string(sb.get<const char *>()) == "foo");

--- a/Framework/TestWorkflows/src/o2DummyWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DummyWorkflow.cxx
@@ -86,7 +86,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
       }
     },
     {
-      ConfigParamSpec{"some-cut", VariantType::Float, 1.0f}
+      ConfigParamSpec{"some-cut", VariantType::Float, 1.0f, {"some cut"}}
     },
     {
       "CPUTimer"
@@ -108,7 +108,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
       }
     },
     {
-      ConfigParamSpec{"some-cut", VariantType::Float, 1.0f}
+      ConfigParamSpec{"some-cut", VariantType::Float, 1.0f, {"some cut"}}
     },
     {
       "CPUTimer"

--- a/Framework/TestWorkflows/src/o2_sim_tpc.cxx
+++ b/Framework/TestWorkflows/src/o2_sim_tpc.cxx
@@ -146,10 +146,10 @@ DataProcessorSpec sim_tpc() {
         }
       },
     Options{
-      {"mcEngine", VariantType::String, "TGeant3", "Engine to use"},
-      {"nEvents", VariantType::Int, 10, "Events to process"},
-      {"extKinFile", VariantType::String, "Kinematics.root", "name of kinematics file for event generator from file (when applicable)"},
-      {"startEvent", VariantType::Int, 2, "Events to skip"}
+      {"mcEngine", VariantType::String, "TGeant3", {"Engine to use"}},
+      {"nEvents", VariantType::Int, 10, {"Events to process"}},
+      {"extKinFile", VariantType::String, "Kinematics.root", {"name of kinematics file for event generator from file (when applicable)"}},
+      {"startEvent", VariantType::Int, 2, {"Events to skip"}}
     }
     };
   };

--- a/Utilities/QC/Workflow/src/RootObjectProducerSpec.cxx
+++ b/Utilities/QC/Workflow/src/RootObjectProducerSpec.cxx
@@ -146,12 +146,12 @@ DataProcessorSpec getRootObjectProducerSpec() {
       }
     },
     Options{
-      {"objectType", VariantType::String, "", "Type of the produced histogram"},
-      {"objectName", VariantType::String, "", "Name of the produced histogram"},
-      {"objectTitle", VariantType::String, "", "Title of the produced histogram"},
-      {"nBins", VariantType::Int, -1, "Number of bins in histogram"},
-      {"nBranches", VariantType::Int, -1, "Number of branches in tree"},
-      {"nTreeEntries", VariantType::Int, -1, "Number of entries in tree"},
+      {"objectType", VariantType::String, "", {"Type of the produced histogram"}},
+      {"objectName", VariantType::String, "", {"Name of the produced histogram"}},
+      {"objectTitle", VariantType::String, "", {"Title of the produced histogram"}},
+      {"nBins", VariantType::Int, -1, {"Number of bins in histogram"}},
+      {"nBranches", VariantType::Int, -1, {"Number of branches in tree"}},
+      {"nTreeEntries", VariantType::Int, -1, {"Number of entries in tree"}},
     }
   };
 }


### PR DESCRIPTION
The variant can now be explicitely empty and a dedicated constructor
can be used to define config specs without default value. The boost option
semantics is only populated with default value when specified.

The help string is now mandatory for config specs and is represented as
a dedicated type. This requires the string to be brace-enclosed.

In order to destinguish between help string and default variant value,
brace-enclosed constructor is now forbidden for Variant.