### PR TITLE
Updating the DataAllocator API

### DIFF
--- a/Framework/Core/README.md
+++ b/Framework/Core/README.md
@@ -267,7 +267,7 @@ to the contents of the message by passing it as template argument, e.g.:
 
 ### Creating outputs - the DataAllocator API
 
-In order  to prevent  algorithms to create  data they do  are not  supposed to
+In order  to prevent  algorithms  to  create  data they  are  not  supposed to
 create, a special `DataAllocator` object is passed to the process callback, so
 that only messages for declared outputs  can be created. A `DataAllocator` can
 create Framework owned resources via the `make<T>` method. In case you ask the
@@ -286,6 +286,15 @@ Currently supported data types are:
 - TObject derived classes. These are actually serialised via a TMessage
   and therefore are only suitable for the cases in which the cost of such a
   serialization is not an issue.
+
+Currently supported data types for snapshot functionality, the state at time of
+calling snapshot is captured in a copy:
+- POD types
+- TObject derived classes, serialized
+- std::vector of POD type, at the receiver side the collection is exposed
+  as gsl::span
+- std::vector pointer to POD type, the objects are linearized in the message
+  and exposed as gsl::span on the receiver side
 
 The DataChunk object resembles a `iovec`:
 

--- a/Framework/Core/include/Framework/DataAllocator.h
+++ b/Framework/Core/include/Framework/DataAllocator.h
@@ -143,9 +143,9 @@ public:
   /// after the call will not be sent.
   template <typename T>
   typename std::enable_if<std::is_base_of<TObject, T>::value == true, void>::type
-  snapshot(const OutputSpec &spec, T *const object) {
+  snapshot(const OutputSpec &spec, T & object) {
     FairMQMessagePtr payloadMessage(mDevice->NewMessage());
-    mDevice->Serialize<TMessageSerializer>(*payloadMessage, object);
+    mDevice->Serialize<TMessageSerializer>(*payloadMessage, &object);
 
     addPartToContext(std::move(payloadMessage), spec, o2::Header::gSerializationMethodROOT);
   }
@@ -158,7 +158,7 @@ public:
   typename std::enable_if<std::is_pod<T>::value == true, void>::type
   snapshot(const OutputSpec &spec, T const &object) {
     FairMQMessagePtr payloadMessage(mDevice->NewMessage(sizeof(T)));
-    memcpy(payloadMessage->GetData(), reinterpret_cast<void*>(&object), sizeof(T));
+    memcpy(payloadMessage->GetData(), &object, sizeof(T));
 
     addPartToContext(std::move(payloadMessage), spec, o2::Header::gSerializationMethodNone);
   }

--- a/Framework/TestWorkflows/test/test_MakeDPLObjects.cxx
+++ b/Framework/TestWorkflows/test/test_MakeDPLObjects.cxx
@@ -11,6 +11,7 @@
 #include "Framework/DataRefUtils.h"
 #include "Framework/ControlService.h"
 #include <TH1F.h>
+#include <TNamed.h>
 #include <gsl/gsl>
 
 using namespace o2::framework;
@@ -31,7 +32,8 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
         OutputSpec{"TST", "POINT"},
         OutputSpec{"TST", "POINTS"},
         OutputSpec{"TST", "VECTOR"},
-        OutputSpec{"TST", "LINEARIZED"}
+        OutputSpec{"TST", "LINEARIZED"},
+        OutputSpec{"TST", "OBJECT"}
       },
       AlgorithmSpec{
         [](ProcessingContext &ctx) {
@@ -58,6 +60,9 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
           for (auto & i : v) p.push_back(&i);
           ctx.allocator().snapshot(OutputSpec{"TST", "LINEARIZED"}, p);
           v[999] = XYZ{3,4,5};
+
+          TNamed named("named", "a named test object");
+          ctx.allocator().snapshot(OutputSpec{"TST", "OBJECT"}, named);
         }
       }
     },
@@ -69,6 +74,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
         InputSpec{"histo", "TST", "HISTO"},
         InputSpec{"vector", "TST", "VECTOR"},
         InputSpec{"linearized", "TST", "LINEARIZED"},
+        InputSpec{"object", "TST", "OBJECT"},
       },
       {},
       AlgorithmSpec{
@@ -103,6 +109,9 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
           assert(c3[999].y == 3);
           assert(c3[999].z == 4);
           ctx.services().get<ControlService>().readyToQuit(true);
+          auto o = ctx.inputs().get<TNamed>("object");
+          assert(strcmp(o->GetName(), "named") == 0 &&
+                 strcmp(o->GetTitle(), "a named test object") == 0);
         }
       }
     }


### PR DESCRIPTION
__Extending DataAllocator API to support vector of pointers__

Adding snapshot support for vector of pointers to trivially copyable
objects. The data set is linearized and can be retrieved as a gsl::span
on the receiver side.

Combining duplicated code in a dedicated function adding parts to context.

__Adding specialization to catch unsupported types as template arguments__

This allows to produce a more descriptive compiler error if unsupported
types are used in 'make' and 'snapshot' API methods.

__Consistent API, bugfix__

Passing the TObject by reference to snapshot method to be consistent
with other specializations.

Bugfix for the single POD snapshot method, const'ness violating cast
removed