### PR TITLE
Removing obsolete commented lines in the cmake setup

### DIFF
--- a/CCDB/CMakeLists.txt
+++ b/CCDB/CMakeLists.txt
@@ -73,8 +73,6 @@ math(EXPR _length ${_length}-1)
 foreach (_file RANGE 0 ${_length}) # loop over a range because we traverse 2 lists and not 1
   list(GET Exe_Names ${_file} _name)
   list(GET Exe_Source ${_file} _src)
-#  Set(EXE_NAME ${_name})
-#  Set(SRCS ${_src})
 #  Set(DEPENDENCIES CCDB)
   O2_GENERATE_EXECUTABLE(
       EXE_NAME ${_name}

--- a/Detectors/TPC/monitor/CMakeLists.txt
+++ b/Detectors/TPC/monitor/CMakeLists.txt
@@ -50,8 +50,7 @@ math(EXPR _length ${_length}-1)
 foreach (_file RANGE 0 ${_length}) # loop over a range because we traverse 2 lists and not 1
   list(GET Exe_Names ${_file} _name)
   list(GET Exe_Source ${_file} _src)
-#  Set(EXE_NAME ${_name})
-#  Set(SRCS ${_src})
+  # FIXME: propably a copy paste remnant, remove?
 #  Set(DEPENDENCIES CCDB)
   O2_GENERATE_EXECUTABLE(
       EXE_NAME ${_name}

--- a/Detectors/TPC/reconstruction/CMakeLists.txt
+++ b/Detectors/TPC/reconstruction/CMakeLists.txt
@@ -85,8 +85,7 @@ math(EXPR _length ${_length}-1)
 foreach (_file RANGE 0 ${_length}) # loop over a range because we traverse 2 lists and not 1
   list(GET Exe_Names ${_file} _name)
   list(GET Exe_Source ${_file} _src)
-#  Set(EXE_NAME ${_name})
-#  Set(SRCS ${_src})
+  # FIXME: propably a copy paste remnant, remove?
 #  Set(DEPENDENCIES CCDB)
   O2_GENERATE_EXECUTABLE(
       EXE_NAME ${_name}

--- a/Detectors/TPC/simulation/CMakeLists.txt
+++ b/Detectors/TPC/simulation/CMakeLists.txt
@@ -52,12 +52,6 @@ install(
   DESTINATION share/Detectors/TPC/
 )
 
-#Set(Exe_Names
-#)
-
-#Set(Exe_Source
-#)
-
 # todo we repeat ourselves because the macro O2_GENERATE_LIBRARY dares deleting the variables we pass to it.
 set(BUCKET_NAME tpc_simulation_bucket)
 set(LIBRARY_NAME ${MODULE_NAME})
@@ -68,8 +62,7 @@ set(LIBRARY_NAME ${MODULE_NAME})
 #foreach (_file RANGE 0 ${_length}) # loop over a range because we traverse 2 lists and not 1
   #list(GET Exe_Names ${_file} _name)
   #list(GET Exe_Source ${_file} _src)
-##  Set(EXE_NAME ${_name})
-##  Set(SRCS ${_src})
+  ## FIXME: propably a copy paste remnant, remove?
 ##  Set(DEPENDENCIES CCDB)
   #O2_GENERATE_EXECUTABLE(
       #EXE_NAME ${_name}

--- a/run/CMakeLists.txt
+++ b/run/CMakeLists.txt
@@ -25,11 +25,3 @@ foreach (_file RANGE 0 ${_length}) # loop over a range because we traverse 2 lis
       BUCKET_NAME ${BUCKET_NAME}
   )
 endforeach (_file RANGE 0 ${_length})
-
-#O2_GENERATE_EXECUTABLE(
-  #EXE_NAME ${Exe_Names}
-  #SOURCES ${Exe_Source}
-  #MODULE_LIBRARY_NAME ${LIBRARY_NAME}
-  #BUCKET_NAME ${BUCKET_NAME}
-#)
-


### PR DESCRIPTION
Those lines are likely to be remnants of restructering the repository
and utilization of the O2_GENERATE_EXECUTABLE macro

@sawenzel, @wiechula I came across those lines when I tried to understand how the tests are generated and looked a bit in the file history. Please check if we can clean this up, I did a search for similar lines in the repository after finding the obsolete commented code in `run/CMakeLists.txt`