### PR TITLE
Root streamers

### DIFF
--- a/DataFormats/Headers/include/Headers/DataHeader.h
+++ b/DataFormats/Headers/include/Headers/DataHeader.h
@@ -649,6 +649,7 @@ extern const o2::Header::DataDescription gDataDescriptionClusters;
 extern const o2::Header::DataDescription gDataDescriptionTracks;
 extern const o2::Header::DataDescription gDataDescriptionConfig;
 extern const o2::Header::DataDescription gDataDescriptionInfo;
+extern const o2::Header::DataDescription gDataDescriptionROOTStreamers;
 /// @} // end of doxygen group
 
 //__________________________________________________________________________________________________

--- a/DataFormats/Headers/src/DataHeader.cxx
+++ b/DataFormats/Headers/src/DataHeader.cxx
@@ -63,6 +63,7 @@ const o2::Header::DataDescription o2::Header::gDataDescriptionClusters("CLUSTERS
 const o2::Header::DataDescription o2::Header::gDataDescriptionTracks  ("TRACKS");
 const o2::Header::DataDescription o2::Header::gDataDescriptionConfig  ("CONFIGURATION");
 const o2::Header::DataDescription o2::Header::gDataDescriptionInfo    ("INFORMATION");
+const o2::Header::DataDescription o2::Header::gDataDescriptionROOTStreamers("ROOT STREAMERS");
 
 //definitions for Stack statics
 std::default_delete<byte[]> o2::Header::Stack::sDeleter;

--- a/Detectors/ITSMFT/MFT/reconstruction/src/devices/Sampler.cxx
+++ b/Detectors/ITSMFT/MFT/reconstruction/src/devices/Sampler.cxx
@@ -24,13 +24,6 @@ using namespace o2::MFT;
 using namespace std;
 
 //_____________________________________________________________________________
-// helper function to clean up the object holding the data after it is transported.
-void free_tmessage2(void* /*data*/, void *hint)
-{
-    delete (TMessage*)hint;
-}
-
-//_____________________________________________________________________________
 Sampler::Sampler()
   : FairMQDevice()
   , mOutputChannelName("data-out")

--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -42,6 +42,7 @@ set(SRCS
     src/WorkflowHelpers.cxx
     src/WorkflowSpec.cxx
     src/runDataProcessing.cxx
+    src/TMessageSerializer.cxx
     ${GUI_SOURCES}
    )
 

--- a/Framework/Core/src/TMessageSerializer.cxx
+++ b/Framework/Core/src/TMessageSerializer.cxx
@@ -1,0 +1,86 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include <Framework/TMessageSerializer.h>
+#include <memory>
+#include <algorithm>
+
+using namespace o2::framework;
+
+TMessageSerializer::StreamerList TMessageSerializer::sStreamers{};
+std::mutex TMessageSerializer::sStreamersLock{};
+
+void TMessageSerializer::loadSchema(const FairMQMessage& msg)
+{
+  std::unique_ptr<TObject> obj{};
+  Deserialize(msg, obj);
+
+  TObjArray* pSchemas = dynamic_cast<TObjArray*>(obj.get());
+  if (!pSchemas) {
+    return;
+  }
+
+  // TODO: this is a bit of a problem in general: non-owning ROOT containers should become
+  // owners at deserialize, otherwise there is a leak. Switch to a better container.
+  pSchemas->SetOwner(kTRUE);
+
+  for (int i = 0; i < pSchemas->GetEntriesFast(); i++) {
+    TStreamerInfo* pSchema = dynamic_cast<TStreamerInfo*>(pSchemas->At(i));
+    if (!pSchema) {
+      continue;
+    }
+    int version = pSchema->GetClassVersion();
+    TClass* pClass = TClass::GetClass(pSchema->GetName());
+    if (!pClass) {
+      continue;
+    }
+    if (pClass->GetClassVersion() == version) {
+      continue;
+    }
+    TObjArray* pInfos = const_cast<TObjArray*>(pClass->GetStreamerInfos());
+    if (!pInfos) {
+      continue;
+    }
+    TVirtualStreamerInfo* pInfo = dynamic_cast<TVirtualStreamerInfo*>(pInfos->At(version));
+    if (pInfo) {
+      continue;
+    }
+    pSchema->SetClass(pClass);
+    pSchema->BuildOld();
+    pInfos->AddAtAndExpand(pSchema, version);
+    pSchemas->Remove(pSchema);
+  }
+}
+
+void TMessageSerializer::fillSchema(FairMQMessage& msg, const StreamerList& streamers)
+{
+  // TODO: this is a bit of a problem in general: non-owning ROOT containers should become
+  // owners at deserialize, otherwise there is a leak. Switch to a better container.
+  TObjArray infoArray{};
+  for (const auto& info:streamers) {
+    infoArray.Add(info);
+  }
+  Serialize(msg,&infoArray);
+}
+
+void TMessageSerializer::updateStreamers(const TMessage& message, StreamerList& streamers)
+{
+  std::lock_guard<std::mutex> lock{ TMessageSerializer::sStreamersLock };
+
+  TIter nextStreamer(message.GetStreamerInfos()); // unfortunately ROOT uses TList* here
+  //this looks like we could use std::map here.
+  while (TVirtualStreamerInfo* in = static_cast<TVirtualStreamerInfo*>(nextStreamer())) {
+    auto found = std::find_if(streamers.begin(), streamers.end(), [&](const auto& old) {
+      return (old->GetName() == in->GetName() && old->GetClassVersion() == in->GetClassVersion());
+    });
+    if (found == streamers.end()) {
+      streamers.push_back(in);
+    }
+  }
+}


### PR DESCRIPTION
This provides rudimentary support for handling ROOT schema information when communicating via messages. The framework integration part is missing, should be easy to do if this interface is accepted, of course there are other ways of doing this. This one is based on the code and logic we use in the HLT ZMQ framework.
The functionality included allows for (optionally) caching the streamers for objects that are serialized, constructing a FairMQMessage containing those streamers and a method to decode a message containing streamers and update ROOT internals.

idea is to use it like this (when streamers should be created/updated while serializing):
`mDevice->Serialize<TMessageSerializer>(*payloadMessage, object, TMessageSerializer::CacheStreamers::yes, TMessageSerializer::CompressionLevel{2});`