### PR TITLE
Add .travis.yml file which creates doxygen pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+sudo: false
+script: |
+    cat > CMakeLists.txt <<\EOF
+    add_subdirectory(doc)
+    EOF
+    cmake .
+    make doc
+# Install dependencies
+addons:
+  apt:
+    packages:
+      - doxygen
+      - doxygen-doc
+      - doxygen-latex
+      - doxygen-gui
+      - graphviz
+      - cmake
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $GITHUB_API_KEY # Set in travis-ci.org dashboard
+  local_dir: doc/html
+  on:
+    branch: dev


### PR DESCRIPTION
This will create and deploy doxygen generated pages every time
the dev branch is updated. They will be visible under:

    https://aliceo2group.github.io/AliceO2/