### PR TITLE
Eliminate more spurious README files

### DIFF
--- a/Detectors/FIT/base/README.md
+++ b/Detectors/FIT/base/README.md
@@ -1,1 +1,0 @@
-# Base classes 

--- a/Detectors/ITSMFT/ITS/base/README.md
+++ b/Detectors/ITSMFT/ITS/base/README.md
@@ -1,1 +1,0 @@
-# Base classes 


### PR DESCRIPTION
Files with empty or trivial content are polluting the doxygen
documentation. Whenever you add a README you should make
sure you have at least one section, either via:

```
# Meaningful section name
```

or via

```
Meaningful section name
=======================
```

give it a meaningful name. Such a name will appear at toplevel
under the Project navigation in the doxygen documentation at:

http://aliceo2group.github.io/AliceO2/