### PR TITLE
Correct medium name for EMCAL

### DIFF
--- a/Detectors/EMCAL/simulation/src/SpaceFrame.cxx
+++ b/Detectors/EMCAL/simulation/src/SpaceFrame.cxx
@@ -122,8 +122,8 @@ void SpaceFrame::CreateGeometry()
 
   //////////////////////////////////////Setup/////////////////////////////////////////
   TGeoVolume* top = gGeoManager->GetVolume("cave");
-  TGeoMedium* steel = gGeoManager->GetMedium("EMCAL_S steel$");
-  TGeoMedium* air = gGeoManager->GetMedium("EMCAL_Air$");
+  TGeoMedium* steel = gGeoManager->GetMedium("EMC_S steel$");
+  TGeoMedium* air = gGeoManager->GetMedium("EMC_Air$");
 
   //////////////////////////////////// Volumes ///////////////////////////////////////
   TGeoVolume* calFrameMO = gGeoManager->MakeTubs("CalFrame", air, mBeginRadius - 2.1, mEndRadius, mTotalHalfWidth * 3,


### PR DESCRIPTION
Fixes a bug (segfault with Geant4) introduced due to the earlier introduction of
DetectorID + conversion from EMCAL -> EMC.