### PR TITLE
Support for log level understanding and control

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -15,7 +15,8 @@ set(MODULE_BUCKET_NAME O2FrameworkCore_bucket)
 O2_SETUP(NAME ${MODULE_NAME})
 if (GLFW_FOUND)
   set(GUI_SOURCES src/FrameworkGUIDebugger.cxx
-                  src/FrameworkGUIDevicesGraph.cxx)
+                  src/FrameworkGUIDevicesGraph.cxx
+                  src/PaletteHelpers.cxx)
 else()
   set(GUI_SOURCES src/FrameworkDummyDebugger.cxx src/DummyDebugGUI.cxx)
 endif()
@@ -37,6 +38,7 @@ set(SRCS
     src/GraphvizHelpers.cxx
     src/InputRecord.cxx
     src/LocalRootFileService.cxx
+    src/LogParsingHelpers.cxx
     src/ExternalFairMQDeviceProxy.cxx
     src/SimpleMetricsService.cxx
     src/TextControlService.cxx
@@ -78,6 +80,7 @@ set(TEST_SRCS
       test/test_Graphviz.cxx
       test/test_InputRecord.cxx
       test/test_ParallelProducer.cxx
+      test/test_LogParsingHelpers.cxx
       test/test_ExternalFairMQDeviceProxy.cxx
       test/test_Services.cxx
       test/test_SingleDataSource.cxx

--- a/Framework/Core/include/Framework/DeviceControl.h
+++ b/Framework/Core/include/Framework/DeviceControl.h
@@ -12,21 +12,32 @@
 
 #include <map>
 #include <string>
+#include "Framework/LogParsingHelpers.h"
 
 namespace o2 {
 namespace framework {
 
-// Controller state for the Device. This is useful for both GUI and
-// batch operations of the system. Whenever something external to the
-// device wants to modify it, it should be registered here and it will
-// be acted on in the subsequent state update.
+constexpr int MAX_USER_FILTER_SIZE = 256;
+
+/// Controller state for the Device. This is useful for both GUI and batch
+/// operations of the system. Whenever something external to the device wants
+/// to modify it, it should be registered here and it will be acted on in the
+/// subsequent state update.
 struct DeviceControl {
-  bool stopped; // whether the device should start in STOP
-  bool quiet; // wether we should be capturing device output.
-  char logFilter[256] = {0};  // Lines in the log should match this to be displayed
-  char logStartTrigger[256] = {0}; // Start printing log with the last occurence of this
-  char logStopTrigger[256] = {0}; // Stop producing log with the first occurrence of this after the start
-  std::map<std::string, std::string> options; // Where the GUI should store the options it wants.
+  // whether the device should start in STOP
+  bool stopped = false;
+  /// wether we should be capturing device output.
+  bool quiet = false;
+  /// Minimum log level for messages to appear
+  LogParsingHelpers::LogLevel logLevel = LogParsingHelpers::LogLevel::Info;
+  /// Lines in the log should match this to be displayed
+  char logFilter[MAX_USER_FILTER_SIZE] = {0};
+  /// Start printing log with the last occurence of this
+  char logStartTrigger[MAX_USER_FILTER_SIZE] = {0};
+  /// Stop producing log with the first occurrence of this after the start
+  char logStopTrigger[MAX_USER_FILTER_SIZE] = {0};
+  /// Where the GUI should store the options it wants.
+  std::map<std::string, std::string> options;
 };
 
 } // namespace framework

--- a/Framework/Core/include/Framework/DeviceInfo.h
+++ b/Framework/Core/include/Framework/DeviceInfo.h
@@ -11,6 +11,7 @@
 #define FRAMEWORK_DEVICEINFO_H
 
 #include "Framework/Variant.h"
+#include "Framework/LogParsingHelpers.h"
 
 #include <vector>
 #include <string>
@@ -23,12 +24,25 @@ namespace o2 {
 namespace framework {
 
 struct DeviceInfo {
+  /// The pid of the device associated to this device
   pid_t pid;
+  /// The position inside the history circular buffer of this device
   size_t historyPos;
+  /// The size of the history circular buffer
   size_t historySize;
+  /// The maximum log level ever seen by this device
+  LogParsingHelpers::LogLevel maxLogLevel;
+  /// A circular buffer for the history of logs entries received
+  /// by this device
   std::vector<std::string> history;
+  /// A circular buffer for the severity of each of the entries
+  /// in the circular buffer associated to the device.
+  std::vector<LogParsingHelpers::LogLevel> historyLevel;
+  /// An unterminated string which is not ready to be printed yet
   std::string unprinted;
+  /// Whether the device is active (running) or not.
   bool active;
+  /// Whether the device is ready to quit.
   bool readyToQuit;
 };
 

--- a/Framework/Core/include/Framework/LogParsingHelpers.h
+++ b/Framework/Core/include/Framework/LogParsingHelpers.h
@@ -1,0 +1,42 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef FRAMEWORK_LOGPARSINGHELPERS
+#define FRAMEWORK_LOGPARSINGHELPERS
+
+#include <string>
+
+namespace o2 {
+namespace framework {
+
+/// A set of helpers to parse device logs.
+struct LogParsingHelpers {
+  /// Possible log levels for device log entries.
+  enum struct LogLevel {
+    Debug,
+    Info,
+    Warning,
+    Error,
+    Unknown,
+    Size
+  };
+
+  /// Available log levels
+  static char const* const LOG_LEVELS[(int)LogLevel::Size];
+
+  /// Extract the log style from a log string @param s
+  /// Token style can then be used for colouring the logs
+  /// in the GUI or to exit with error if a sufficient
+  /// number of LogLevel::Error is found.
+  static LogLevel parseTokenLevel(const std::string &s);
+};
+
+}
+}
+#endif // FRAMEWORK_LOGPARSINGHELPERS

--- a/Framework/Core/include/Framework/PaletteHelpers.h
+++ b/Framework/Core/include/Framework/PaletteHelpers.h
@@ -1,0 +1,40 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef FRAMEWORK_PALETTE_HELPER_H
+#define FRAMEWORK_PALETTE_HELPER_H
+
+#include "DebugGUI/imgui.h"
+
+namespace o2 {
+namespace framework {
+
+/// An helper class for colors and palettes
+struct PaletteHelpers {
+  static const ImVec4 RED;
+  static const ImVec4 GREEN;
+  static const ImVec4 BLUE;
+  static const ImVec4 YELLOW;
+  static const ImVec4 SHADED_RED;
+  static const ImVec4 SHADED_GREEN;
+  static const ImVec4 SHADED_BLUE;
+  static const ImVec4 SHADED_YELLOW;
+  static const ImVec4 DARK_RED;
+  static const ImVec4 DARK_GREEN;
+  static const ImVec4 DARK_YELLOW;
+  static const ImVec4 WHITE;
+  static const ImVec4 BLACK;
+  static const ImVec4 GRAY;
+  static const ImVec4 LIGHT_GRAY;
+};
+
+} // namespace framework
+} // namespace o2
+
+#endif

--- a/Framework/Core/include/Framework/TextControlService.h
+++ b/Framework/Core/include/Framework/TextControlService.h
@@ -17,11 +17,26 @@
 namespace o2 {
 namespace framework {
 
-// A service that data processors can use to talk to control and ask for
-// their own state change or others.
+/// A service that data processors can use to talk to control and ask for
+/// their own state change or others.
 class TextControlService : public ControlService {
 public:
-  void readyToQuit(bool all = false) final; // Tell the control that I am ready to quit
+  /// Tell the control that I am ready to quit. This will be
+  /// done by printing (only once)
+  ///
+  /// CONTROL_ACTION: READY_TO_QUIT_ME
+  ///
+  /// or
+  ///
+  /// CONTROL_ACTION: READY_TO_QUIT_ALL
+  ///
+  /// depending on the value of \param all.
+  ///
+  /// It's up to the driver to actually react on that and terminate the
+  /// child.
+  void readyToQuit(bool all = false) final;
+private:
+  bool mOnce = false;
 };
 
 bool parseControl(const std::string &s, std::smatch &match);

--- a/Framework/Core/src/LogParsingHelpers.cxx
+++ b/Framework/Core/src/LogParsingHelpers.cxx
@@ -1,0 +1,46 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/LogParsingHelpers.h"
+#include <regex>
+
+namespace o2 {
+namespace framework {
+
+char const* const LogParsingHelpers::LOG_LEVELS[(int)LogParsingHelpers::LogLevel::Size] = {
+    "DEBUG",
+    "INFO",
+    "WARNING",
+    "ERROR",
+    "UNKNOWN"
+  };
+using LogLevel = o2::framework::LogParsingHelpers::LogLevel;
+
+LogLevel LogParsingHelpers::parseTokenLevel(const std::string &s) {
+  std::smatch match;
+  const static std::regex metricsRE(R"regex(^\[[0-9][0-9]:[0-9][0-9]:[0-9][0-9]\]\[(DEBUG|INFO|STATE|WARN|ERROR)\] .*)regex");
+  std::regex_match(s, match, metricsRE);
+
+  if (match.empty()) {
+    return LogLevel::Unknown;
+  }
+  if (match[1] == "DEBUG") {
+    return LogLevel::Debug;
+  } else if (match[1] == "INFO" || match[1] == "STATE") {
+    return LogLevel::Info;
+  } else if (match[1] == "WARN") {
+    return LogLevel::Warning;
+  } else if (match[1] == "ERROR") {
+    return LogLevel::Error;
+  }
+  return LogLevel::Unknown;
+}
+
+}
+}

--- a/Framework/Core/src/PaletteHelpers.cxx
+++ b/Framework/Core/src/PaletteHelpers.cxx
@@ -1,0 +1,32 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/PaletteHelpers.h"
+
+namespace o2 {
+namespace framework {
+
+const ImVec4 PaletteHelpers::RED = ImVec4(0xe3/255., 0x67/255., 0x44/255., 1);
+const ImVec4 PaletteHelpers::GREEN = ImVec4(0x7e/255., 0xc4/255., 0x52/255., 1);
+const ImVec4 PaletteHelpers::BLUE = ImVec4(0x3d/255., 0xb7/255., 0xe0/255., 1);
+const ImVec4 PaletteHelpers::YELLOW = ImVec4(0xea/255., 0xda/255., 0x4a/255., 1);
+const ImVec4 PaletteHelpers::SHADED_RED = ImVec4(0xd5/255., 0x72/255., 0x73/255., 1);
+const ImVec4 PaletteHelpers::SHADED_GREEN = ImVec4(0x98/255., 0xba/255., 0x96/255., 1);
+const ImVec4 PaletteHelpers::SHADED_BLUE = ImVec4(0x7a/255., 0xab/255., 0xea/255., 1);
+const ImVec4 PaletteHelpers::SHADED_YELLOW = ImVec4(0xeb/255., 0xb9/255., 0x7a/255., 1);
+const ImVec4 PaletteHelpers::DARK_RED = ImVec4(153./255, 61./255, 61./255, 255./255);
+const ImVec4 PaletteHelpers::DARK_GREEN = ImVec4(153./255, 61./255, 61./255, 255./255);
+const ImVec4 PaletteHelpers::DARK_YELLOW = ImVec4(153./255, 139./255, 61./255, 255./255);
+const ImVec4 PaletteHelpers::WHITE = ImVec4(0xce/255.,0xbe/255.,0x91/255., 1);
+const ImVec4 PaletteHelpers::BLACK= ImVec4(0x28/255.,0x28/255.,0x28/255., 1);
+const ImVec4 PaletteHelpers::GRAY = ImVec4(60/255.,60/255.,60/255., 1);
+const ImVec4 PaletteHelpers::LIGHT_GRAY = ImVec4(75/255.,75/255.,75/255., 1);
+
+}
+}

--- a/Framework/Core/src/TextControlService.cxx
+++ b/Framework/Core/src/TextControlService.cxx
@@ -18,6 +18,10 @@ namespace framework {
 
 // All we do is to printout
 void TextControlService::readyToQuit(bool all) {
+  if (mOnce == true) {
+    return;
+  }
+  mOnce = true;
   std::cout << "CONTROL_ACTION: READY_TO_QUIT";
   if (all) {
     std::cout << "_ALL";

--- a/Framework/Core/test/test_LogParsingHelpers.cxx
+++ b/Framework/Core/test/test_LogParsingHelpers.cxx
@@ -1,0 +1,29 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#define BOOST_TEST_MODULE Test Framework LogParsingHelpers
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include "Framework/LogParsingHelpers.h"
+#include <boost/test/unit_test.hpp>
+#include <regex>
+
+using namespace o2::framework;
+
+BOOST_AUTO_TEST_CASE(TestParseTokenLevel) {
+  BOOST_CHECK(LogParsingHelpers::parseTokenLevel("[10:10:10][ERROR] Some message") == LogParsingHelpers::LogLevel::Error);
+  BOOST_CHECK(LogParsingHelpers::parseTokenLevel("[10:10:10][WARN] Some message") == LogParsingHelpers::LogLevel::Warning);
+  BOOST_CHECK(LogParsingHelpers::parseTokenLevel("[10:10:10][INFO] Some message") == LogParsingHelpers::LogLevel::Info);
+  BOOST_CHECK(LogParsingHelpers::parseTokenLevel("[10:10:10][DEBUG] Some message") == LogParsingHelpers::LogLevel::Debug);
+  BOOST_CHECK(LogParsingHelpers::parseTokenLevel("[10:10:10][BLAH] Some message") == LogParsingHelpers::LogLevel::Unknown);
+  BOOST_CHECK(LogParsingHelpers::parseTokenLevel("[1010:10][BLAH] Some message") == LogParsingHelpers::LogLevel::Unknown);
+  // This fails because we require at least one space after the tagging
+  BOOST_CHECK(LogParsingHelpers::parseTokenLevel("[10:10:10][ERROR]") == LogParsingHelpers::LogLevel::Unknown);
+}


### PR DESCRIPTION
This allows controlling the log level from the GUI and
colorize things differently depending on it. It also extends
the GUI to allow changing the log level dynamically, on a
per Device level.

Moreover, in case an error is encountered in any of the Data Processors, the application
exits with 1 rather than 0. This should allow us to spot
test that while not crashing, do not behave correctly.