### PR TITLE
Changing namespace 'Header' to lower case 'header'

### DIFF
--- a/Algorithm/include/Algorithm/HeaderStack.h
+++ b/Algorithm/include/Algorithm/HeaderStack.h
@@ -16,11 +16,11 @@
 /// @since  2017-09-19
 /// @brief  Utilities for the O2 header stack
 
-// the implemented functionality relies on o2::Header::get defined in
+// the implemented functionality relies on o2::header::get defined in
 // DataHeader.h; all O2 headers inherit from BaseHeader, this is required
 // to check the consistency of the header stack, also the next-header-flag
 // is part of the BaseHeader
-#include "Headers/DataHeader.h" // for o2::Header::get
+#include "Headers/DataHeader.h" // for o2::header::get
 
 namespace o2 {
 
@@ -67,7 +67,7 @@ void dispatchHeaderStackCallback(PtrType ptr,
                                  HeaderType /*dummy*/,
                                  HeaderCallbackType onHeader)
 {
-  const HeaderType* h = o2::Header::get<HeaderType>(ptr, size);
+  const HeaderType* h = o2::header::get<HeaderType>(ptr, size);
   if (h) {
     onHeader(*h);
   }
@@ -134,7 +134,7 @@ void parseHeaderStack(PtrType ptr,
                       SizeType size,
                       HeaderType & header)
 {
-  const HeaderType* h = o2::Header::get<HeaderType>(ptr, size);
+  const HeaderType* h = o2::header::get<HeaderType>(ptr, size);
   if (h) {
     header = *h;
   }

--- a/Algorithm/include/Algorithm/O2FormatParser.h
+++ b/Algorithm/include/Algorithm/O2FormatParser.h
@@ -65,11 +65,11 @@ int parseO2Format(const InputListT& list,
                   HeaderStackTypes&&... stackArgs
                   )
 {
-  const o2::Header::DataHeader* dh = nullptr;
+  const o2::header::DataHeader* dh = nullptr;
   for (auto & part : list) {
     if (!dh) {
       // new header - payload pair, read DataHeader
-      dh = o2::Header::get<o2::Header::DataHeader>(getPointer(part), getSize(part));
+      dh = o2::header::get<o2::header::DataHeader>(getPointer(part), getSize(part));
       if (!dh) {
         return -ENOMSG;
       }

--- a/Algorithm/test/headerstack.cxx
+++ b/Algorithm/test/headerstack.cxx
@@ -24,44 +24,44 @@
 #include "Headers/NameHeader.h"
 #include "../include/Algorithm/HeaderStack.h"
 
-using DataHeader = o2::Header::DataHeader;
-using HeaderStack = o2::Header::Stack;
+using DataHeader = o2::header::DataHeader;
+using HeaderStack = o2::header::Stack;
 
 BOOST_AUTO_TEST_CASE(test_headerstack)
 {
   // make a header stack consisting of two O2 headers and extract them
   // via function calls using dispatchHeaderStackCallback, and through object
   // references using parseHeaderStack
-  o2::Header::DataHeader dh;
-  dh.dataDescription = o2::Header::DataDescription("SOMEDATA");
-  dh.dataOrigin = o2::Header::DataOrigin("TST");
+  o2::header::DataHeader dh;
+  dh.dataDescription = o2::header::DataDescription("SOMEDATA");
+  dh.dataOrigin = o2::header::DataOrigin("TST");
   dh.subSpecification = 0;
   dh.payloadSize = 0;
 
-  using Name8Header = o2::Header::NameHeader<8>;
+  using Name8Header = o2::header::NameHeader<8>;
   Name8Header nh("NAMEDHDR");
 
-  o2::Header::Stack stack(dh, nh);
+  o2::header::Stack stack(dh, nh);
 
   // check that the call without any other arguments is compiling
   o2::algorithm::dispatchHeaderStackCallback(stack.buffer.get(), stack.bufferSize);
 
   // lambda functor given as argument for dispatchHeaderStackCallback
   auto checkDataHeader = [&dh] (const auto & header) {
-    o2::Header::hexDump("Extracted DataHeader", &header, sizeof(header));
+    o2::header::hexDump("Extracted DataHeader", &header, sizeof(header));
     BOOST_CHECK(header == dh);
   };
 
   // lambda functor given as argument for dispatchHeaderStackCallback
   auto checkNameHeader = [&nh] (const auto & header) {
-    o2::Header::hexDump("Extracted NameHeader", &header, sizeof(header));
+    o2::header::hexDump("Extracted NameHeader", &header, sizeof(header));
     // have to compare on byte level, no operator==
     BOOST_CHECK(memcmp(&header, &nh, sizeof(header)) == 0);
   };
 
   // check extraction of headers via callbacks
   o2::algorithm::dispatchHeaderStackCallback(stack.buffer.get(), stack.bufferSize,
-                                             o2::Header::DataHeader(),
+                                             o2::header::DataHeader(),
                                              checkDataHeader,
                                              Name8Header(),
                                              checkNameHeader
@@ -77,7 +77,7 @@ BOOST_AUTO_TEST_CASE(test_headerstack)
   o2::algorithm::parseHeaderStack(stack.buffer.get(), stack.bufferSize);
 
   // check extraction of headers via object references
-  o2::Header::DataHeader targetDataHeader;
+  o2::header::DataHeader targetDataHeader;
   Name8Header targetNameHeader;
   o2::algorithm::parseHeaderStack(stack.buffer.get(), stack.bufferSize,
                                   targetDataHeader,

--- a/Algorithm/test/o2formatparser.cxx
+++ b/Algorithm/test/o2formatparser.cxx
@@ -26,7 +26,7 @@
 template<typename... Targs>
 void hexDump(Targs... Fargs) {
   // a simple redirect to enable/disable the hexdump printout
-  o2::Header::hexDump(Fargs...);
+  o2::header::hexDump(Fargs...);
 }
 
 BOOST_AUTO_TEST_CASE(test_o2formatparser)
@@ -36,20 +36,20 @@ BOOST_AUTO_TEST_CASE(test_o2formatparser)
     "reconstructed data"
   };
   unsigned dataidx = 0;
-  std::vector<o2::Header::DataHeader> dataheaders;
-  dataheaders.emplace_back(o2::Header::DataDescription("RAWDATA"),
-                           o2::Header::DataOrigin("DET"),
+  std::vector<o2::header::DataHeader> dataheaders;
+  dataheaders.emplace_back(o2::header::DataDescription("RAWDATA"),
+                           o2::header::DataOrigin("DET"),
                            0,
                            strlen(thedata[dataidx++]));
-  dataheaders.emplace_back(o2::Header::DataDescription("RECODATA"),
-                           o2::Header::DataOrigin("DET"),
+  dataheaders.emplace_back(o2::header::DataDescription("RECODATA"),
+                           o2::header::DataOrigin("DET"),
                            0,
                            strlen(thedata[dataidx++]));
 
   std::vector<std::pair<const char*, size_t>> messages;
   for (dataidx = 0; dataidx < thedata.size(); ++dataidx) {
     messages.emplace_back(reinterpret_cast<char*>(&dataheaders[dataidx]),
-                          sizeof(o2::Header::DataHeader));
+                          sizeof(o2::header::DataHeader));
     messages.emplace_back(thedata[dataidx],
                           dataheaders[dataidx].payloadSize);
   }

--- a/Algorithm/test/pageparser.cxx
+++ b/Algorithm/test/pageparser.cxx
@@ -176,14 +176,14 @@ void runParserTest(const DataSetT &dataset)
             << " group header(s)" << std::endl
             << " pagesize " << pagesize << std::endl;
   auto buffer = MakeBuffer<DataSetT, PageHeaderT, GroupHeaderT, GroupHeaderPerPage>(pagesize, PageHeaderT(0), dataset);
-  o2::Header::hexDump("pagebuffer", buffer.first.get(), buffer.second);
+  o2::header::hexDump("pagebuffer", buffer.first.get(), buffer.second);
 
   using RawParser = o2::algorithm::PageParser<PageHeader, pagesize, ClusterData, int>;
   const RawParser parser(buffer.first.get(), buffer.second);
 
   unsigned dataidx = 0;
   for (auto i : parser) {
-    o2::Header::hexDump("clusterdata", &i, sizeof(ClusterData));
+    o2::header::hexDump("clusterdata", &i, sizeof(ClusterData));
     BOOST_REQUIRE( i == dataset[dataidx++]);
   }
 }
@@ -194,14 +194,14 @@ BOOST_AUTO_TEST_CASE(test_pageparser)
   std::vector<ClusterData> dataset;
   FillData(dataset, 20);
   auto buffer = MakeBuffer(pagesize, PageHeader(0), dataset);
-  o2::Header::hexDump("pagebuffer", buffer.first.get(), buffer.second);
+  o2::header::hexDump("pagebuffer", buffer.first.get(), buffer.second);
 
   using RawParser = o2::algorithm::PageParser<PageHeader, pagesize, ClusterData>;
   const RawParser parser(buffer.first.get(), buffer.second);
 
   unsigned dataidx = 0;
   for (auto i : parser) {
-    o2::Header::hexDump("clusterdata", &i, sizeof(ClusterData));
+    o2::header::hexDump("clusterdata", &i, sizeof(ClusterData));
     BOOST_REQUIRE( i == dataset[dataidx++]);
   }
 
@@ -220,11 +220,11 @@ BOOST_AUTO_TEST_CASE(test_pageparser)
     xvalues.emplace_back(i.x, dataidx);
     ++dataidx;
   }
-  o2::Header::hexDump("changed buffer", buffer.first.get(), buffer.second);
+  o2::header::hexDump("changed buffer", buffer.first.get(), buffer.second);
 
   dataidx = 0;
   for (auto i : parser) {
-    o2::Header::hexDump("clusterdata", &i, sizeof(ClusterData));
+    o2::header::hexDump("clusterdata", &i, sizeof(ClusterData));
     BOOST_REQUIRE( i.x == xvalues[dataidx++].first);
   }
 }

--- a/Algorithm/test/tableview.cxx
+++ b/Algorithm/test/tableview.cxx
@@ -26,14 +26,14 @@
 #include "../include/Algorithm/Parser.h"
 #include "StaticSequenceAllocator.h"
 
-using DataHeader = o2::Header::DataHeader;
-using HeartbeatHeader = o2::Header::HeartbeatHeader;
-using HeartbeatTrailer = o2::Header::HeartbeatTrailer;
+using DataHeader = o2::header::DataHeader;
+using HeartbeatHeader = o2::header::HeartbeatHeader;
+using HeartbeatTrailer = o2::header::HeartbeatTrailer;
 
 template<typename... Targs>
 void hexDump(Targs... Fargs) {
   // a simple redirect to enable/disable the hexdump printout
-  o2::Header::hexDump(Fargs...);
+  o2::header::hexDump(Fargs...);
 }
 
 BOOST_AUTO_TEST_CASE(test_tableview_reverse)
@@ -62,20 +62,20 @@ BOOST_AUTO_TEST_CASE(test_tableview_reverse)
 
   // define the view type for DataHeader as row descriptor,
   // HeartbeatHeader as column descriptor and the reverse parser
-  using ViewType = o2::algorithm::TableView<o2::Header::DataHeader,
-                                            o2::Header::HeartbeatHeader,
+  using ViewType = o2::algorithm::TableView<o2::header::DataHeader,
+                                            o2::header::HeartbeatHeader,
                                             ParserT>;
   ViewType heartbeatview;
 
-  o2::Header::DataHeader dh1;
-  dh1.dataDescription = o2::Header::DataDescription("FIRSTROW");
-  dh1.dataOrigin = o2::Header::DataOrigin("TST");
+  o2::header::DataHeader dh1;
+  dh1.dataDescription = o2::header::DataDescription("FIRSTROW");
+  dh1.dataOrigin = o2::header::DataOrigin("TST");
   dh1.subSpecification = 0;
   dh1.payloadSize = 0;
 
-  o2::Header::DataHeader dh2;
-  dh2.dataDescription = o2::Header::DataDescription("SECONDROW");
-  dh2.dataOrigin = o2::Header::DataOrigin("TST");
+  o2::header::DataHeader dh2;
+  dh2.dataDescription = o2::header::DataDescription("SECONDROW");
+  dh2.dataOrigin = o2::header::DataOrigin("TST");
   dh2.subSpecification = 0xdeadbeef;
   dh2.payloadSize = 0;
 

--- a/DataFormats/Headers/include/Headers/DataHeader.h
+++ b/DataFormats/Headers/include/Headers/DataHeader.h
@@ -39,7 +39,7 @@
 using byte = unsigned char;
 
 namespace o2 {
-namespace Header {
+namespace header {
 
 //__________________________________________________________________________________________________
 /// @defgroup aliceo2_dataformat_primitives Primitive data format definitions for ALICE O2
@@ -318,11 +318,11 @@ using HeaderType = Descriptor<gSizeHeaderDescriptionString>;
 using SerializationMethod = Descriptor<gSizeSerializationMethodString>;
 
 //possible serialization types
-extern const o2::Header::SerializationMethod gSerializationMethodAny;
-extern const o2::Header::SerializationMethod gSerializationMethodInvalid;
-extern const o2::Header::SerializationMethod gSerializationMethodNone;
-extern const o2::Header::SerializationMethod gSerializationMethodROOT;
-extern const o2::Header::SerializationMethod gSerializationMethodFlatBuf;
+extern const o2::header::SerializationMethod gSerializationMethodAny;
+extern const o2::header::SerializationMethod gSerializationMethodInvalid;
+extern const o2::header::SerializationMethod gSerializationMethodNone;
+extern const o2::header::SerializationMethod gSerializationMethodROOT;
+extern const o2::header::SerializationMethod gSerializationMethodFlatBuf;
 
 //__________________________________________________________________________________________________
 /// @struct BaseHeader
@@ -348,8 +348,8 @@ struct BaseHeader
   static const uint32_t sMagicString;
 
   static const uint32_t sVersion;
-  static const o2::Header::HeaderType sHeaderType;
-  static const o2::Header::SerializationMethod sSerializationMethod;
+  static const o2::header::HeaderType sHeaderType;
+  static const o2::header::SerializationMethod sSerializationMethod;
 
   //__the data layout:
 
@@ -376,10 +376,10 @@ struct BaseHeader
   uint32_t    headerVersion;
 
   /// header type description, set by derived header
-  o2::Header::HeaderType description;
+  o2::header::HeaderType description;
 
   /// header serialization method, set by derived header
-  o2::Header::SerializationMethod serialization;
+  o2::header::SerializationMethod serialization;
 
   //___the functions:
 
@@ -553,8 +553,8 @@ struct DataHeader : public BaseHeader
 
   //static data for this header type/version
   static const uint32_t sVersion;
-  static const o2::Header::HeaderType sHeaderType;
-  static const o2::Header::SerializationMethod sSerializationMethod;
+  static const o2::header::HeaderType sHeaderType;
+  static const o2::header::SerializationMethod sSerializationMethod;
 
   ///
   /// data type descriptor
@@ -622,34 +622,34 @@ struct DataHeader : public BaseHeader
 
 //__________________________________________________________________________________________________
 //possible data origins
-extern const o2::Header::DataOrigin gDataOriginAny;
-extern const o2::Header::DataOrigin gDataOriginInvalid;
-extern const o2::Header::DataOrigin gDataOriginFLP;
-extern const o2::Header::DataOrigin gDataOriginACO;
-extern const o2::Header::DataOrigin gDataOriginCPV;
-extern const o2::Header::DataOrigin gDataOriginCTP;
-extern const o2::Header::DataOrigin gDataOriginEMC;
-extern const o2::Header::DataOrigin gDataOriginFIT;
-extern const o2::Header::DataOrigin gDataOriginHMP;
-extern const o2::Header::DataOrigin gDataOriginITS;
-extern const o2::Header::DataOrigin gDataOriginMCH;
-extern const o2::Header::DataOrigin gDataOriginMFT;
-extern const o2::Header::DataOrigin gDataOriginMID;
-extern const o2::Header::DataOrigin gDataOriginPHS;
-extern const o2::Header::DataOrigin gDataOriginTOF;
-extern const o2::Header::DataOrigin gDataOriginTPC;
-extern const o2::Header::DataOrigin gDataOriginTRD;
-extern const o2::Header::DataOrigin gDataOriginZDC;
+extern const o2::header::DataOrigin gDataOriginAny;
+extern const o2::header::DataOrigin gDataOriginInvalid;
+extern const o2::header::DataOrigin gDataOriginFLP;
+extern const o2::header::DataOrigin gDataOriginACO;
+extern const o2::header::DataOrigin gDataOriginCPV;
+extern const o2::header::DataOrigin gDataOriginCTP;
+extern const o2::header::DataOrigin gDataOriginEMC;
+extern const o2::header::DataOrigin gDataOriginFIT;
+extern const o2::header::DataOrigin gDataOriginHMP;
+extern const o2::header::DataOrigin gDataOriginITS;
+extern const o2::header::DataOrigin gDataOriginMCH;
+extern const o2::header::DataOrigin gDataOriginMFT;
+extern const o2::header::DataOrigin gDataOriginMID;
+extern const o2::header::DataOrigin gDataOriginPHS;
+extern const o2::header::DataOrigin gDataOriginTOF;
+extern const o2::header::DataOrigin gDataOriginTPC;
+extern const o2::header::DataOrigin gDataOriginTRD;
+extern const o2::header::DataOrigin gDataOriginZDC;
 
 //possible data types
-extern const o2::Header::DataDescription gDataDescriptionAny;
-extern const o2::Header::DataDescription gDataDescriptionInvalid;
-extern const o2::Header::DataDescription gDataDescriptionRawData;
-extern const o2::Header::DataDescription gDataDescriptionClusters;
-extern const o2::Header::DataDescription gDataDescriptionTracks;
-extern const o2::Header::DataDescription gDataDescriptionConfig;
-extern const o2::Header::DataDescription gDataDescriptionInfo;
-extern const o2::Header::DataDescription gDataDescriptionROOTStreamers;
+extern const o2::header::DataDescription gDataDescriptionAny;
+extern const o2::header::DataDescription gDataDescriptionInvalid;
+extern const o2::header::DataDescription gDataDescriptionRawData;
+extern const o2::header::DataDescription gDataDescriptionClusters;
+extern const o2::header::DataDescription gDataDescriptionTracks;
+extern const o2::header::DataDescription gDataDescriptionConfig;
+extern const o2::header::DataDescription gDataDescriptionInfo;
+extern const o2::header::DataDescription gDataDescriptionROOTStreamers;
 /// @} // end of doxygen group
 
 //__________________________________________________________________________________________________
@@ -699,7 +699,11 @@ static_assert(sizeof(BaseHeader::sMagicString) == sizeof(BaseHeader::magicString
 ///helper function to print a hex/ASCII dump of some memory
 void hexDump (const char* desc, const void* voidaddr, size_t len, size_t max=0);
 
-} //namespace Header
+} //namespace header
+
+// 2017-12-21: keep an alias for a short while after renaming the namespace
+// to lower case, supports pull request currently open
+namespace Header = header;
 } //namespace o2
 
 #endif

--- a/DataFormats/Headers/include/Headers/HeartbeatFrame.h
+++ b/DataFormats/Headers/include/Headers/HeartbeatFrame.h
@@ -24,7 +24,7 @@
 #include <vector>
 
 namespace o2 {
-namespace Header {
+namespace header {
 
 // The Heartbeat frame layout is specified in
 // http://svnweb.cern.ch/world/wsvn/alicetdrrun3/Notes/Run34SystemNote/detector-read-alice/ALICErun34_readout.pdf
@@ -43,7 +43,7 @@ namespace Header {
 // check if this is the correct term, we probably won't send what is referred to be
 // the heartbeat frame (composition of HBH - detector payload - HBT); instead, the
 // HBH and HBT can be added to the header stack
-extern const o2::Header::DataDescription gDataDescriptionHeartbeatFrame;
+extern const o2::header::DataDescription gDataDescriptionHeartbeatFrame;
 
 struct HeartbeatHeader
 {
@@ -115,8 +115,8 @@ struct HeartbeatFrameEnvelope : public BaseHeader
 {
   //static data for this header type/version
   static const uint32_t sVersion;
-  static const o2::Header::HeaderType sHeaderType;
-  static const o2::Header::SerializationMethod sSerializationMethod;
+  static const o2::header::HeaderType sHeaderType;
+  static const o2::header::SerializationMethod sSerializationMethod;
 
   HeartbeatHeader header;
   HeartbeatTrailer trailer;
@@ -265,7 +265,7 @@ public:
     unsigned nFrames = mFrames.size();
     unsigned currentSlot = mSlotData.size();
     mSlotData.emplace_back(slotData);
-    using ParserT = o2::Header::ReverseParser<HeartbeatHeader, HeartbeatTrailer>;
+    using ParserT = o2::header::ReverseParser<HeartbeatHeader, HeartbeatTrailer>;
     ParserT p;
     p.parse(seqData, seqSize,
             [](const typename ParserT::HeaderType* h) {return (*h);},

--- a/DataFormats/Headers/include/Headers/NameHeader.h
+++ b/DataFormats/Headers/include/Headers/NameHeader.h
@@ -22,20 +22,20 @@
 #include "Headers/DataHeader.h"
 
 namespace o2 {
-namespace Header {
+namespace header {
 
 /// @struct NameHeader
 /// @brief an example data header containing a name of an object as a null terminated char arr.
 /// this is a template! at instantiation the template parameter determines the
 /// size of the held string array.
-/// a caveat with decoding is you have to use Header::get<NameHeader<0>>(buffer)
+/// a caveat with decoding is you have to use header::get<NameHeader<0>>(buffer)
 /// to get it out of a buffer. May improve in the future if enough people complain.
 /// @ingroup aliceo2_dataformats_dataheader
 template <size_t N>
 struct NameHeader : public BaseHeader {
   static const uint32_t sVersion;
-  static const o2::Header::HeaderType sHeaderType;
-  static const o2::Header::SerializationMethod sSerializationMethod;
+  static const o2::header::HeaderType sHeaderType;
+  static const o2::header::SerializationMethod sSerializationMethod;
   NameHeader()
   : BaseHeader(sizeof(NameHeader), sHeaderType, sSerializationMethod, sVersion)
   , name()
@@ -61,12 +61,12 @@ private:
 };
 
 template <size_t N>
-const o2::Header::HeaderType NameHeader<N>::sHeaderType = "NameHead";
+const o2::header::HeaderType NameHeader<N>::sHeaderType = "NameHead";
 
 // dirty trick to always have access to the headertypeID of a templated header type
 // TODO: find out if this can be done in a nicer way + is this realy necessary?
 template <>
-const o2::Header::HeaderType NameHeader<0>::sHeaderType;
+const o2::header::HeaderType NameHeader<0>::sHeaderType;
 
 template <size_t N>
 const SerializationMethod NameHeader<N>::sSerializationMethod = gSerializationMethodNone;

--- a/DataFormats/Headers/include/Headers/RAWDataHeader.h
+++ b/DataFormats/Headers/include/Headers/RAWDataHeader.h
@@ -18,7 +18,7 @@
 #include <cstdint>
 
 namespace o2 {
-namespace Header {
+namespace header {
 
 /// The definition of the RAW Data Header v2 (RDH) is specified in
 /// https://docs.google.com/document/d/1IxCCa1ZRpI3J9j3KCmw2htcOLIRVVdEcO-DDPcLNFM0

--- a/DataFormats/Headers/include/Headers/TimeStamp.h
+++ b/DataFormats/Headers/include/Headers/TimeStamp.h
@@ -22,7 +22,7 @@
 #include <cassert>
 
 namespace o2 {
-namespace Header {
+namespace header {
 
 // https://lhc-machine-outreach.web.cern.ch/lhc-machine-outreach/collisions.htm
 // https://www.lhc-closer.es/taking_a_closer_look_at_lhc/0.buckets_and_bunches
@@ -40,8 +40,8 @@ namespace LHCClockParameter {
   const int gBunchSpacingNanoSec = 25;
   const int gOrbitTimeNanoSec = std::ratio<gNumberOfBunches*gBunchSpacingNanoSec>::num;
 
-  typedef o2::Header::Internal::intWrapper<0> OrbitPrecision;
-  typedef o2::Header::Internal::intWrapper<1> BunchPrecision;
+  typedef o2::header::Internal::intWrapper<0> OrbitPrecision;
+  typedef o2::header::Internal::intWrapper<1> BunchPrecision;
 
   // the type of the clock tick depends on whether to use also the bunches
   // as substructure of the orbit.
@@ -109,7 +109,7 @@ typedef LHCClock<std::chrono::system_clock::time_point, LHCClockParameter::Bunch
 class TimeStamp
 {
  public:
-  typedef o2::Header::Descriptor<2> TimeUnitID;
+  typedef o2::header::Descriptor<2> TimeUnitID;
   // TODO: typedefs for the types of ticks and subticks
 
   TimeStamp() = default;
@@ -168,7 +168,7 @@ class TimeStamp
     };
   };
 };
-} //namespace Header
+} //namespace header
 } //namespace AliceO2
 
 #endif

--- a/DataFormats/Headers/src/DataHeader.cxx
+++ b/DataFormats/Headers/src/DataHeader.cxx
@@ -25,63 +25,63 @@
 #include <cstring> // strncpy
 
 //the answer to life and everything
-const uint32_t o2::Header::BaseHeader::sMagicString = String2<uint32_t>("O2O2");
+const uint32_t o2::header::BaseHeader::sMagicString = String2<uint32_t>("O2O2");
 
 //possible serialization types
-const o2::Header::SerializationMethod o2::Header::gSerializationMethodAny    ("*******");
-const o2::Header::SerializationMethod o2::Header::gSerializationMethodInvalid("INVALID");
-const o2::Header::SerializationMethod o2::Header::gSerializationMethodNone   ("NONE");
-const o2::Header::SerializationMethod o2::Header::gSerializationMethodROOT   ("ROOT");
-const o2::Header::SerializationMethod o2::Header::gSerializationMethodFlatBuf("FLATBUF");
+const o2::header::SerializationMethod o2::header::gSerializationMethodAny    ("*******");
+const o2::header::SerializationMethod o2::header::gSerializationMethodInvalid("INVALID");
+const o2::header::SerializationMethod o2::header::gSerializationMethodNone   ("NONE");
+const o2::header::SerializationMethod o2::header::gSerializationMethodROOT   ("ROOT");
+const o2::header::SerializationMethod o2::header::gSerializationMethodFlatBuf("FLATBUF");
 
 //__________________________________________________________________________________________________
 //possible data origins
-const o2::Header::DataOrigin o2::Header::gDataOriginAny    ("***");
-const o2::Header::DataOrigin o2::Header::gDataOriginInvalid("NIL");
-const o2::Header::DataOrigin o2::Header::gDataOriginFLP    ("FLP");
-const o2::Header::DataOrigin o2::Header::gDataOriginACO    ("ACO");
-const o2::Header::DataOrigin o2::Header::gDataOriginCPV    ("CPV");
-const o2::Header::DataOrigin o2::Header::gDataOriginCTP    ("CTP");
-const o2::Header::DataOrigin o2::Header::gDataOriginEMC    ("EMC");
-const o2::Header::DataOrigin o2::Header::gDataOriginFIT    ("FIT");
-const o2::Header::DataOrigin o2::Header::gDataOriginHMP    ("HMP");
-const o2::Header::DataOrigin o2::Header::gDataOriginITS    ("ITS");
-const o2::Header::DataOrigin o2::Header::gDataOriginMCH    ("MCH");
-const o2::Header::DataOrigin o2::Header::gDataOriginMFT    ("MFT");
-const o2::Header::DataOrigin o2::Header::gDataOriginMID    ("MID");
-const o2::Header::DataOrigin o2::Header::gDataOriginPHS    ("PHS");
-const o2::Header::DataOrigin o2::Header::gDataOriginTOF    ("TOF");
-const o2::Header::DataOrigin o2::Header::gDataOriginTPC    ("TPC");
-const o2::Header::DataOrigin o2::Header::gDataOriginTRD    ("TRD");
-const o2::Header::DataOrigin o2::Header::gDataOriginZDC    ("ZDC");
+const o2::header::DataOrigin o2::header::gDataOriginAny    ("***");
+const o2::header::DataOrigin o2::header::gDataOriginInvalid("NIL");
+const o2::header::DataOrigin o2::header::gDataOriginFLP    ("FLP");
+const o2::header::DataOrigin o2::header::gDataOriginACO    ("ACO");
+const o2::header::DataOrigin o2::header::gDataOriginCPV    ("CPV");
+const o2::header::DataOrigin o2::header::gDataOriginCTP    ("CTP");
+const o2::header::DataOrigin o2::header::gDataOriginEMC    ("EMC");
+const o2::header::DataOrigin o2::header::gDataOriginFIT    ("FIT");
+const o2::header::DataOrigin o2::header::gDataOriginHMP    ("HMP");
+const o2::header::DataOrigin o2::header::gDataOriginITS    ("ITS");
+const o2::header::DataOrigin o2::header::gDataOriginMCH    ("MCH");
+const o2::header::DataOrigin o2::header::gDataOriginMFT    ("MFT");
+const o2::header::DataOrigin o2::header::gDataOriginMID    ("MID");
+const o2::header::DataOrigin o2::header::gDataOriginPHS    ("PHS");
+const o2::header::DataOrigin o2::header::gDataOriginTOF    ("TOF");
+const o2::header::DataOrigin o2::header::gDataOriginTPC    ("TPC");
+const o2::header::DataOrigin o2::header::gDataOriginTRD    ("TRD");
+const o2::header::DataOrigin o2::header::gDataOriginZDC    ("ZDC");
 
 //possible data types
-const o2::Header::DataDescription o2::Header::gDataDescriptionAny     ("***************");
-const o2::Header::DataDescription o2::Header::gDataDescriptionInvalid ("INVALID_DESC");
-const o2::Header::DataDescription o2::Header::gDataDescriptionRawData ("RAWDATA");
-const o2::Header::DataDescription o2::Header::gDataDescriptionClusters("CLUSTERS");
-const o2::Header::DataDescription o2::Header::gDataDescriptionTracks  ("TRACKS");
-const o2::Header::DataDescription o2::Header::gDataDescriptionConfig  ("CONFIGURATION");
-const o2::Header::DataDescription o2::Header::gDataDescriptionInfo    ("INFORMATION");
-const o2::Header::DataDescription o2::Header::gDataDescriptionROOTStreamers("ROOT STREAMERS");
+const o2::header::DataDescription o2::header::gDataDescriptionAny     ("***************");
+const o2::header::DataDescription o2::header::gDataDescriptionInvalid ("INVALID_DESC");
+const o2::header::DataDescription o2::header::gDataDescriptionRawData ("RAWDATA");
+const o2::header::DataDescription o2::header::gDataDescriptionClusters("CLUSTERS");
+const o2::header::DataDescription o2::header::gDataDescriptionTracks  ("TRACKS");
+const o2::header::DataDescription o2::header::gDataDescriptionConfig  ("CONFIGURATION");
+const o2::header::DataDescription o2::header::gDataDescriptionInfo    ("INFORMATION");
+const o2::header::DataDescription o2::header::gDataDescriptionROOTStreamers("ROOT STREAMERS");
 
 //definitions for Stack statics
-std::default_delete<byte[]> o2::Header::Stack::sDeleter;
+std::default_delete<byte[]> o2::header::Stack::sDeleter;
 
 //storage for BaseHeader static members, all invalid
-const uint32_t o2::Header::BaseHeader::sVersion = o2::Header::gInvalidToken32;
-const o2::Header::HeaderType o2::Header::BaseHeader::sHeaderType = o2::Header::gInvalidToken64;
-const o2::Header::SerializationMethod o2::Header::BaseHeader::sSerializationMethod = o2::Header::gInvalidToken64;
+const uint32_t o2::header::BaseHeader::sVersion = o2::header::gInvalidToken32;
+const o2::header::HeaderType o2::header::BaseHeader::sHeaderType = o2::header::gInvalidToken64;
+const o2::header::SerializationMethod o2::header::BaseHeader::sSerializationMethod = o2::header::gInvalidToken64;
 
 //storage for DataHeader static members
-const uint32_t o2::Header::DataHeader::sVersion = 1;
-const o2::Header::HeaderType o2::Header::DataHeader::sHeaderType = String2<uint64_t>("DataHead");
-const o2::Header::SerializationMethod o2::Header::DataHeader::sSerializationMethod = o2::Header::gSerializationMethodNone;
+const uint32_t o2::header::DataHeader::sVersion = 1;
+const o2::header::HeaderType o2::header::DataHeader::sHeaderType = String2<uint64_t>("DataHead");
+const o2::header::SerializationMethod o2::header::DataHeader::sSerializationMethod = o2::header::gSerializationMethodNone;
 
-using namespace o2::Header;
+using namespace o2::header;
 
 //__________________________________________________________________________________________________
-o2::Header::BaseHeader::BaseHeader(uint32_t mySize, HeaderType desc,
+o2::header::BaseHeader::BaseHeader(uint32_t mySize, HeaderType desc,
                                         SerializationMethod ser, uint32_t version)
   : magicStringInt(sMagicString)
   , headerSize(mySize)
@@ -93,7 +93,7 @@ o2::Header::BaseHeader::BaseHeader(uint32_t mySize, HeaderType desc,
 }
 
 //__________________________________________________________________________________________________
-o2::Header::DataHeader::DataHeader()
+o2::header::DataHeader::DataHeader()
   : BaseHeader(sizeof(DataHeader),sHeaderType,sSerializationMethod,sVersion)
   , dataDescription(gDataDescriptionInvalid)
   , dataOrigin(gDataOriginInvalid)
@@ -105,7 +105,7 @@ o2::Header::DataHeader::DataHeader()
 }
 
 //__________________________________________________________________________________________________
-o2::Header::DataHeader::DataHeader(DataDescription desc,
+o2::header::DataHeader::DataHeader(DataDescription desc,
                                    DataOrigin origin,
                                    SubSpecificationType subspec,
                                    uint64_t size
@@ -121,7 +121,7 @@ o2::Header::DataHeader::DataHeader(DataDescription desc,
 }
 
 //__________________________________________________________________________________________________
-void o2::Header::DataHeader::print() const
+void o2::header::DataHeader::print() const
 {
   printf("Data header version %i, flags: %i\n",headerVersion, flags);
   printf("  origin       : %s\n", dataOrigin.str);
@@ -133,7 +133,7 @@ void o2::Header::DataHeader::print() const
 }
 
 //__________________________________________________________________________________________________
-DataHeader& o2::Header::DataHeader::operator=(const DataHeader& that)
+DataHeader& o2::header::DataHeader::operator=(const DataHeader& that)
 {
   magicStringInt = that.magicStringInt;
   dataOrigin = that.dataOrigin;
@@ -148,35 +148,35 @@ DataHeader& o2::Header::DataHeader::operator=(const DataHeader& that)
 }
 
 //__________________________________________________________________________________________________
-DataHeader& o2::Header::DataHeader::operator=(const DataOrigin& that)
+DataHeader& o2::header::DataHeader::operator=(const DataOrigin& that)
 {
   dataOrigin = that;
   return *this;
 }
 
 //__________________________________________________________________________________________________
-DataHeader& o2::Header::DataHeader::operator=(const DataDescription& that)
+DataHeader& o2::header::DataHeader::operator=(const DataDescription& that)
 {
   dataDescription = that;
   return *this;
 }
 
 //__________________________________________________________________________________________________
-DataHeader& o2::Header::DataHeader::operator=(const SerializationMethod& that)
+DataHeader& o2::header::DataHeader::operator=(const SerializationMethod& that)
 {
   payloadSerializationMethod = that;
   return *this;
 }
 
 //__________________________________________________________________________________________________
-bool o2::Header::DataHeader::operator==(const DataOrigin& that) const
+bool o2::header::DataHeader::operator==(const DataOrigin& that) const
 {
   return (that == gDataOriginAny||
           that == dataOrigin );
 }
 
 //__________________________________________________________________________________________________
-bool o2::Header::DataHeader::operator==(const DataDescription& that) const
+bool o2::header::DataHeader::operator==(const DataDescription& that) const
 {
   return ((that.itg[0] == gDataDescriptionAny.itg[0] &&
            that.itg[1] == gDataDescriptionAny.itg[1]) ||
@@ -185,14 +185,14 @@ bool o2::Header::DataHeader::operator==(const DataDescription& that) const
 }
 
 //__________________________________________________________________________________________________
-bool o2::Header::DataHeader::operator==(const SerializationMethod& that) const
+bool o2::header::DataHeader::operator==(const SerializationMethod& that) const
 {
   return (that == gSerializationMethodAny||
           that == payloadSerializationMethod );
 }
 
 //__________________________________________________________________________________________________
-bool o2::Header::DataHeader::operator==(const DataHeader& that) const
+bool o2::header::DataHeader::operator==(const DataHeader& that) const
 {
   return( magicStringInt == that.magicStringInt &&
           dataOrigin == that.dataOrigin &&
@@ -201,25 +201,25 @@ bool o2::Header::DataHeader::operator==(const DataHeader& that) const
 }
 
 //__________________________________________________________________________________________________
-void o2::Header::printDataDescription::operator()(const char* str) const
+void o2::header::printDataDescription::operator()(const char* str) const
 {
   printf("Data description  : %s\n", str);
 }
 
 //__________________________________________________________________________________________________
-void o2::Header::printDataOrigin::operator()(const char* str) const
+void o2::header::printDataOrigin::operator()(const char* str) const
 {
   printf("Data origin  : %s\n", str);
 }
 
 //__________________________________________________________________________________________________
-o2::Header::DataIdentifier::DataIdentifier()
+o2::header::DataIdentifier::DataIdentifier()
   : dataDescription(), dataOrigin()
 {
 }
 
 //__________________________________________________________________________________________________
-bool o2::Header::DataIdentifier::operator==(const DataIdentifier& other) const {
+bool o2::header::DataIdentifier::operator==(const DataIdentifier& other) const {
   if (other.dataOrigin != gDataOriginAny && dataOrigin != other.dataOrigin) return false;
   if (other.dataDescription != gDataDescriptionAny &&
       dataDescription != other.dataDescription) return false;
@@ -227,14 +227,14 @@ bool o2::Header::DataIdentifier::operator==(const DataIdentifier& other) const {
 }
 
 //__________________________________________________________________________________________________
-void o2::Header::DataIdentifier::print() const
+void o2::header::DataIdentifier::print() const
 {
   dataOrigin.print();
   dataDescription.print();
 }
 
 //__________________________________________________________________________________________________
-void o2::Header::hexDump (const char* desc, const void* voidaddr, size_t len, size_t max)
+void o2::header::hexDump (const char* desc, const void* voidaddr, size_t len, size_t max)
 {
   size_t i;
   unsigned char buff[17];       // stores the ASCII data

--- a/DataFormats/Headers/src/HeartbeatFrame.cxx
+++ b/DataFormats/Headers/src/HeartbeatFrame.cxx
@@ -16,8 +16,8 @@
 #include "Headers/HeartbeatFrame.h"
 
 // define the description with a terminating '0' (meaning 15 characters)
-const o2::Header::DataDescription o2::Header::gDataDescriptionHeartbeatFrame("HEARTBEATFRAME");
+const o2::header::DataDescription o2::header::gDataDescriptionHeartbeatFrame("HEARTBEATFRAME");
 
-const uint32_t o2::Header::HeartbeatFrameEnvelope::sVersion = 1;
-const o2::Header::HeaderType o2::Header::HeartbeatFrameEnvelope::sHeaderType= String2<uint64_t>("HBFEnvel");
-const o2::Header::SerializationMethod o2::Header::HeartbeatFrameEnvelope::sSerializationMethod = o2::Header::gSerializationMethodNone;
+const uint32_t o2::header::HeartbeatFrameEnvelope::sVersion = 1;
+const o2::header::HeaderType o2::header::HeartbeatFrameEnvelope::sHeaderType= String2<uint64_t>("HBFEnvel");
+const o2::header::SerializationMethod o2::header::HeartbeatFrameEnvelope::sSerializationMethod = o2::header::gSerializationMethodNone;

--- a/DataFormats/Headers/src/NameHeader.cxx
+++ b/DataFormats/Headers/src/NameHeader.cxx
@@ -12,4 +12,4 @@
 
 //storage for NameHeader static
 template <>
-const o2::Header::HeaderType o2::Header::NameHeader<0>::sHeaderType = "NameHead";
+const o2::header::HeaderType o2::header::NameHeader<0>::sHeaderType = "NameHead";

--- a/DataFormats/Headers/src/TimeStamp.cxx
+++ b/DataFormats/Headers/src/TimeStamp.cxx
@@ -15,7 +15,7 @@
 
 #include "Headers/TimeStamp.h"
 
-using namespace o2::Header;
+using namespace o2::header;
 
 // the only reason for the cxx file is the implementation of the
 // constants

--- a/DataFormats/Headers/test/testDataHeader.cxx
+++ b/DataFormats/Headers/test/testDataHeader.cxx
@@ -22,7 +22,7 @@ using system_clock = std::chrono::system_clock;
 using TimeScale = std::chrono::nanoseconds;
 
 namespace o2 {
-  namespace Header {
+  namespace header {
 
     BOOST_AUTO_TEST_CASE(Descriptor_test)
     {

--- a/DataFormats/Headers/test/testTimeStamp.cxx
+++ b/DataFormats/Headers/test/testTimeStamp.cxx
@@ -16,7 +16,7 @@
 #include "Headers/TimeStamp.h"
 
 namespace o2 {
-  namespace Header {
+  namespace header {
 
     BOOST_AUTO_TEST_CASE(LHCClock_test)
     {

--- a/DataFormats/Headers/test/test_HeartbeatFrame.cxx
+++ b/DataFormats/Headers/test/test_HeartbeatFrame.cxx
@@ -17,9 +17,9 @@
 #include "Headers/DataHeader.h"
 #include "Headers/HeartbeatFrame.h"
 
-using DataHeader = o2::Header::DataHeader;
-using HeartbeatHeader = o2::Header::HeartbeatHeader;
-using HeartbeatTrailer = o2::Header::HeartbeatTrailer;
+using DataHeader = o2::header::DataHeader;
+using HeartbeatHeader = o2::header::HeartbeatHeader;
+using HeartbeatTrailer = o2::header::HeartbeatTrailer;
 
 /**
  * Helper struct to define a composite element from a header, some payload
@@ -114,9 +114,9 @@ BOOST_AUTO_TEST_CASE(test_parser)
                FrameT({0x1100000000000001}, "test", {0x5100000000000005}),
                FrameT({0x1100000000000003}, "dummydata", {0x510000000000000a})
                );
-  o2::Header::hexDump("Test frame", tf.buffer.get(), tf.length);
+  o2::header::hexDump("Test frame", tf.buffer.get(), tf.length);
 
-  using ParserT = o2::Header::ReverseParser<typename FrameT::HeaderType,
+  using ParserT = o2::header::ReverseParser<typename FrameT::HeaderType,
                                             typename FrameT::TrailerType>;
   ParserT parser;
   parser.parse(tf.buffer.get(), tf.length,
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_CASE(test_parser)
                  return trailer.dataLength + ParserT::envelopeLength;
                },
                [](typename ParserT::FrameEntry entry) {
-                 o2::Header::hexDump("Entry", entry.payload, entry.length);
+                 o2::header::hexDump("Entry", entry.payload, entry.length);
                  return true;
                }
                );
@@ -145,14 +145,14 @@ BOOST_AUTO_TEST_CASE(test_heartbeat_sequence)
                 FrameT({0x1100000000000003}, "frame2c", {0x5100000000000008})
                 );
 
-  o2::Header::HeartbeatFrameSequence<o2::Header::DataHeader> seqHandler;
+  o2::header::HeartbeatFrameSequence<o2::header::DataHeader> seqHandler;
 
   //check iterators of the empty handler
   BOOST_CHECK(seqHandler.begin() == seqHandler.end());
 
-  o2::Header::DataHeader dh;
-  dh.dataDescription = o2::Header::DataDescription("FIRSTSLOT");
-  dh.dataOrigin = o2::Header::DataOrigin("TST");
+  o2::header::DataHeader dh;
+  dh.dataDescription = o2::header::DataDescription("FIRSTSLOT");
+  dh.dataOrigin = o2::header::DataOrigin("TST");
   dh.subSpecification = 0;
   dh.payloadSize = 0;
 
@@ -165,7 +165,7 @@ BOOST_AUTO_TEST_CASE(test_heartbeat_sequence)
        columnIt != end; ++columnIt) {
     std::cout << "---------------------------------------" << std::endl;
     for (auto row : columnIt) {
-      o2::Header::hexDump("Entry", row.buffer, row.size);
+      o2::header::hexDump("Entry", row.buffer, row.size);
     }
   }
 }

--- a/DataFormats/Headers/test/test_RAWDataHeader.cxx
+++ b/DataFormats/Headers/test/test_RAWDataHeader.cxx
@@ -15,7 +15,7 @@
 #include <array>
 #include "Headers/RAWDataHeader.h"
 
-using RDH = o2::Header::RAWDataHeader;
+using RDH = o2::header::RAWDataHeader;
 
 BOOST_AUTO_TEST_CASE(test_rdh)
 {

--- a/DataFormats/TimeFrame/include/TimeFrame/TimeFrame.h
+++ b/DataFormats/TimeFrame/include/TimeFrame/TimeFrame.h
@@ -21,7 +21,7 @@ namespace DataFormat
 {
 
 using PartPosition = int;
-typedef std::pair<o2::Header::DataHeader, PartPosition> IndexElement;
+typedef std::pair<o2::header::DataHeader, PartPosition> IndexElement;
 
 // helper struct so that we can
 // stream messages using ROOT
@@ -48,7 +48,7 @@ class TimeFrame
   }
 
   // return TimeStamp (starttime) of this TimeFrame
-  Header::TimeStamp const& GetTimeStamp() const { return mTimeStamp; }
+  o2::header::TimeStamp const& GetTimeStamp() const { return mTimeStamp; }
 
   // return duration of this TimeFrame
   // allow user to ask for specific unit (needs to be std::chrono unit)
@@ -74,7 +74,7 @@ class TimeFrame
 
 private:
   // FIXME: enable this when we have a dictionary for TimeStamp etc
-  Header::TimeStamp mTimeStamp; //! the TimeStamp for this TimeFrame
+  o2::header::TimeStamp mTimeStamp; //! the TimeStamp for this TimeFrame
 
   size_t mEpnId; // EPN origin of TimeFrame
   std::vector<MessageSizePair> mParts; // the message parts as accumulated by the EPN

--- a/DataFormats/TimeFrame/test/TimeFrameTest.cxx
+++ b/DataFormats/TimeFrame/test/TimeFrameTest.cxx
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE(TimeFrame_test)
   BOOST_CHECK(zmq);
   messages.AddPart(zmq->CreateMessage(1000));
 
-  o2::Header::DataHeader dh;
+  o2::header::DataHeader dh;
   messages.AddPart(NewSimpleMessage(*zmq, dh));
 
   TimeFrame frame(messages);

--- a/Framework/Core/include/Framework/DataAllocator.h
+++ b/Framework/Core/include/Framework/DataAllocator.h
@@ -41,10 +41,10 @@ class DataAllocator
 {
 public:
   using AllowedOutputsMap = std::vector<OutputRoute>;
-  using DataHeader = o2::Header::DataHeader;
-  using DataOrigin = o2::Header::DataOrigin;
-  using DataDescription = o2::Header::DataDescription;
-  using SubSpecificationType = o2::Header::DataHeader::SubSpecificationType;
+  using DataHeader = o2::header::DataHeader;
+  using DataOrigin = o2::header::DataOrigin;
+  using DataDescription = o2::header::DataDescription;
+  using SubSpecificationType = o2::header::DataHeader::SubSpecificationType;
 
   DataAllocator(FairMQDevice *device,
                 MessageContext *context,
@@ -147,7 +147,7 @@ public:
     FairMQMessagePtr payloadMessage(mDevice->NewMessage());
     mDevice->Serialize<TMessageSerializer>(*payloadMessage, &object);
 
-    addPartToContext(std::move(payloadMessage), spec, o2::Header::gSerializationMethodROOT);
+    addPartToContext(std::move(payloadMessage), spec, o2::header::gSerializationMethodROOT);
   }
 
   /// Serialize a snapshot of a POD type, which will then be sent
@@ -160,7 +160,7 @@ public:
     FairMQMessagePtr payloadMessage(mDevice->NewMessage(sizeof(T)));
     memcpy(payloadMessage->GetData(), &object, sizeof(T));
 
-    addPartToContext(std::move(payloadMessage), spec, o2::Header::gSerializationMethodNone);
+    addPartToContext(std::move(payloadMessage), spec, o2::header::gSerializationMethodNone);
   }
 
   /// Serialize a snapshot of a std::vector of trivially copyable elements,
@@ -180,7 +180,7 @@ public:
     typename C::value_type *tmp = const_cast<typename C::value_type*>(v.data());
     memcpy(payloadMessage->GetData(), reinterpret_cast<void*>(tmp), sizeInBytes);
 
-    addPartToContext(std::move(payloadMessage), spec, o2::Header::gSerializationMethodNone);
+    addPartToContext(std::move(payloadMessage), spec, o2::header::gSerializationMethodNone);
   }
 
   /// Serialize a snapshot of a std::vector of pointers to trivially copyable
@@ -205,7 +205,7 @@ public:
       target += elementSizeInBytes;
     }
 
-    addPartToContext(std::move(payloadMessage), spec, o2::Header::gSerializationMethodNone);
+    addPartToContext(std::move(payloadMessage), spec, o2::header::gSerializationMethodNone);
   }
 
   /// specialization to catch unsupported types and throw a detailed compiler error
@@ -248,11 +248,11 @@ private:
   std::string matchDataHeader(const OutputSpec &spec, size_t timeframeId);
   FairMQMessagePtr headerMessageFromSpec(OutputSpec const &spec,
                                          std::string const &channel,
-                                         o2::Header::SerializationMethod serializationMethod);
+                                         o2::header::SerializationMethod serializationMethod);
 
   void addPartToContext(FairMQMessagePtr&& payload,
                         const OutputSpec &spec,
-                        o2::Header::SerializationMethod serializationMethod);
+                        o2::header::SerializationMethod serializationMethod);
 
   FairMQDevice *mDevice;
   AllowedOutputsMap mAllowedOutputs;

--- a/Framework/Core/include/Framework/DataProcessingHeader.h
+++ b/Framework/Core/include/Framework/DataProcessingHeader.h
@@ -40,10 +40,10 @@ namespace framework {
 /// The information consists of two parts: start time id and duration
 ///
 /// @ingroup aliceo2_dataformats_dataheader
-struct DataProcessingHeader : public Header::BaseHeader
+struct DataProcessingHeader : public header::BaseHeader
 {
   // Required to do the lookup
-  static const o2::Header::HeaderType sHeaderType;
+  static const o2::header::HeaderType sHeaderType;
   static const uint32_t sVersion = 1;
 
   // allows DataHeader::SubSpecificationType to be used as generic type in the code
@@ -75,7 +75,7 @@ struct DataProcessingHeader : public Header::BaseHeader
   }
 
   DataProcessingHeader(StartTime s, Duration d)
-  : BaseHeader(sizeof(DataProcessingHeader),sHeaderType,Header::gSerializationMethodNone,sVersion),
+  : BaseHeader(sizeof(DataProcessingHeader), sHeaderType, header::gSerializationMethodNone,sVersion),
     startTime(s),
     duration(d)
   {

--- a/Framework/Core/include/Framework/DataRefUtils.h
+++ b/Framework/Core/include/Framework/DataRefUtils.h
@@ -30,9 +30,9 @@ struct DataRefUtils {
   template <typename T>
   static typename std::enable_if<std::is_pod<T>::value == true, gsl::span<T>>::type
   as(DataRef const &ref) {
-    using DataHeader = o2::Header::DataHeader;
-    auto header = o2::Header::get<const DataHeader>(ref.header);
-    if (header->payloadSerializationMethod != o2::Header::gSerializationMethodNone) {
+    using DataHeader = o2::header::DataHeader;
+    auto header = o2::header::get<const DataHeader>(ref.header);
+    if (header->payloadSerializationMethod != o2::header::gSerializationMethodNone) {
       throw std::runtime_error("Attempt to extract a POD from a wrong message kind");
     }
     if ((header->payloadSize % sizeof(T)) != 0) {
@@ -47,9 +47,9 @@ struct DataRefUtils {
   template <typename T>
   static typename std::enable_if<std::is_base_of<TObject, T>::value == true, std::unique_ptr<T>>::type
   as(DataRef const &ref) {
-    using DataHeader = o2::Header::DataHeader;
-    auto header = o2::Header::get<const DataHeader>(ref.header);
-    if (header->payloadSerializationMethod != o2::Header::gSerializationMethodROOT) {
+    using DataHeader = o2::header::DataHeader;
+    auto header = o2::header::get<const DataHeader>(ref.header);
+    if (header->payloadSerializationMethod != o2::header::gSerializationMethodROOT) {
       throw std::runtime_error("Attempt to extract a TMessage from non-ROOT serialised message");
     }
 

--- a/Framework/Core/include/Framework/DataSpecUtils.h
+++ b/Framework/Core/include/Framework/DataSpecUtils.h
@@ -19,25 +19,25 @@ namespace framework {
 
 struct DataSpecUtils {
   static bool match(const InputSpec &spec,
-                    const o2::Header::DataOrigin &origin,
-                    const o2::Header::DataDescription &description,
-                    const o2::Header::DataHeader::SubSpecificationType &subSpec) {
+                    const o2::header::DataOrigin &origin,
+                    const o2::header::DataDescription &description,
+                    const o2::header::DataHeader::SubSpecificationType &subSpec) {
     return spec.origin == origin &&
            spec.description == description &&
            spec.subSpec == subSpec;
   }
 
   static bool match(const OutputSpec &spec,
-                    const o2::Header::DataOrigin &origin,
-                    const o2::Header::DataDescription &description,
-                    const o2::Header::DataHeader::SubSpecificationType &subSpec) {
+                    const o2::header::DataOrigin &origin,
+                    const o2::header::DataDescription &description,
+                    const o2::header::DataHeader::SubSpecificationType &subSpec) {
     return spec.origin == origin &&
            spec.description == description &&
            spec.subSpec == subSpec;
   }
 
   template <typename T>
-  static bool match(const T&spec, const o2::Header::DataHeader &header) {
+  static bool match(const T&spec, const o2::header::DataHeader &header) {
     return DataSpecUtils::match(spec,
                                 header.dataOrigin,
                                 header.dataDescription,

--- a/Framework/Core/include/Framework/InputRecord.h
+++ b/Framework/Core/include/Framework/InputRecord.h
@@ -116,7 +116,7 @@ public:
   template <class T>
   typename std::unique_ptr<typename std::enable_if<std::is_base_of<TObject, T>::value == true, T>::type>
   get(char const *binding) const {
-    using DataHeader = o2::Header::DataHeader;
+    using DataHeader = o2::header::DataHeader;
 
     auto ref = this->get(binding);
     return std::move(DataRefUtils::as<T>(ref));

--- a/Framework/Core/include/Framework/InputSpec.h
+++ b/Framework/Core/include/Framework/InputSpec.h
@@ -29,9 +29,9 @@ struct InputSpec {
   };
 
   std::string binding;
-  Header::DataOrigin origin;
-  Header::DataDescription description;
-  Header::DataHeader::SubSpecificationType subSpec;
+  header::DataOrigin origin;
+  header::DataDescription description;
+  header::DataHeader::SubSpecificationType subSpec;
   enum Lifetime lifetime;
 };
 

--- a/Framework/Core/include/Framework/OutputSpec.h
+++ b/Framework/Core/include/Framework/OutputSpec.h
@@ -27,9 +27,9 @@ struct OutputSpec {
     Transient
   };
 
-  Header::DataOrigin origin;
-  Header::DataDescription description;
-  Header::DataHeader::SubSpecificationType subSpec;
+  header::DataOrigin origin;
+  header::DataDescription description;
+  header::DataHeader::SubSpecificationType subSpec;
   enum Lifetime lifetime;
 };
 

--- a/Framework/Core/src/DataAllocator.cxx
+++ b/Framework/Core/src/DataAllocator.cxx
@@ -17,8 +17,8 @@
 namespace o2 {
 namespace framework {
 
-using DataHeader = o2::Header::DataHeader;
-using DataDescription = o2::Header::DataDescription;
+using DataHeader = o2::header::DataHeader;
+using DataDescription = o2::header::DataDescription;
 using DataProcessingHeader = o2::framework::DataProcessingHeader;
 
 DataAllocator::DataAllocator(FairMQDevice *device,
@@ -58,15 +58,15 @@ DataAllocator::newChunk(const OutputSpec &spec, size_t size) {
   dh.dataDescription = spec.description;
   dh.subSpecification = spec.subSpec;
   dh.payloadSize = size;
-  dh.payloadSerializationMethod = o2::Header::gSerializationMethodNone;
+  dh.payloadSerializationMethod = o2::header::gSerializationMethodNone;
 
   DataProcessingHeader dph{mContext->timeslice(), 1};
   //we have to move the incoming data
-  o2::Header::Stack headerStack{dh, dph};
+  o2::header::Stack headerStack{dh, dph};
   FairMQMessagePtr headerMessage = mDevice->NewMessageFor(channel, 0,
                                                           headerStack.buffer.get(),
                                                           headerStack.bufferSize,
-                                                          &o2::Header::Stack::freefn,
+                                                          &o2::header::Stack::freefn,
                                                           headerStack.buffer.get());
   headerStack.buffer.release();
   FairMQMessagePtr payloadMessage = mDevice->NewMessageFor(channel, 0, size);
@@ -93,15 +93,15 @@ DataAllocator::adoptChunk(const OutputSpec &spec, char *buffer, size_t size, fai
   dh.dataDescription = spec.description;
   dh.subSpecification = spec.subSpec;
   dh.payloadSize = size;
-  dh.payloadSerializationMethod = o2::Header::gSerializationMethodNone;
+  dh.payloadSerializationMethod = o2::header::gSerializationMethodNone;
 
   DataProcessingHeader dph{mContext->timeslice(), 1};
   //we have to move the incoming data
-  o2::Header::Stack headerStack{dh, dph};
+  o2::header::Stack headerStack{dh, dph};
   FairMQMessagePtr headerMessage = mDevice->NewMessageFor(channel, 0,
                                                           headerStack.buffer.get(),
                                                           headerStack.bufferSize,
-                                                          &o2::Header::Stack::freefn,
+                                                          &o2::header::Stack::freefn,
                                                           headerStack.buffer.get());
   headerStack.buffer.release();
 
@@ -121,7 +121,7 @@ DataAllocator::adoptChunk(const OutputSpec &spec, char *buffer, size_t size, fai
 FairMQMessagePtr
 DataAllocator::headerMessageFromSpec(OutputSpec const &spec,
                                      std::string const &channel,
-                                     o2::Header::SerializationMethod method) {
+                                     o2::header::SerializationMethod method) {
   DataHeader dh;
   dh.dataOrigin = spec.origin;
   dh.dataDescription = spec.description;
@@ -133,11 +133,11 @@ DataAllocator::headerMessageFromSpec(OutputSpec const &spec,
 
   DataProcessingHeader dph{mContext->timeslice(), 1};
   //we have to move the incoming data
-  o2::Header::Stack headerStack{dh, dph};
+  o2::header::Stack headerStack{dh, dph};
   FairMQMessagePtr headerMessage = mDevice->NewMessageFor(channel, 0,
                                                           headerStack.buffer.get(),
                                                           headerStack.bufferSize,
-                                                          &o2::Header::Stack::freefn,
+                                                          &o2::header::Stack::freefn,
                                                           headerStack.buffer.get());
   headerStack.buffer.release();
   return std::move(headerMessage);
@@ -146,7 +146,7 @@ DataAllocator::headerMessageFromSpec(OutputSpec const &spec,
 void
 DataAllocator::addPartToContext(FairMQMessagePtr&& payloadMessage,
                                 const OutputSpec &spec,
-                                o2::Header::SerializationMethod serializationMethod)
+                                o2::header::SerializationMethod serializationMethod)
 {
     std::string channel = matchDataHeader(spec, mRootContext->timeslice());
     auto headerMessage = headerMessageFromSpec(spec, channel, serializationMethod);
@@ -155,7 +155,7 @@ DataAllocator::addPartToContext(FairMQMessagePtr&& payloadMessage,
 
     // FIXME: this is kind of ugly, we know that we can change the content of the
     // header message because we have just created it, but the API declares it const
-    const DataHeader *cdh = o2::Header::get<DataHeader>(headerMessage->GetData());
+    const DataHeader *cdh = o2::header::get<DataHeader>(headerMessage->GetData());
     DataHeader *dh = const_cast<DataHeader *>(cdh);
     dh->payloadSize = payloadMessage->GetSize();
     parts.AddPart(std::move(headerMessage));
@@ -167,7 +167,7 @@ void
 DataAllocator::adopt(const OutputSpec &spec, TObject*ptr) {
   std::unique_ptr<TObject> payload(ptr);
   std::string channel = matchDataHeader(spec, mRootContext->timeslice());
-  auto header = headerMessageFromSpec(spec, channel, o2::Header::gSerializationMethodROOT);
+  auto header = headerMessageFromSpec(spec, channel, o2::header::gSerializationMethodROOT);
   mRootContext->addObject(std::move(header), std::move(payload), channel);
   assert(payload.get() == nullptr);
 }

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -26,7 +26,7 @@
 
 using namespace o2::framework;
 
-using DataHeader = o2::Header::DataHeader;
+using DataHeader = o2::header::DataHeader;
 
 namespace o2 {
 namespace framework {
@@ -127,7 +127,7 @@ DataProcessingDevice::HandleData(FairMQParts &iParts, int /*index*/) {
     }
     for (size_t hi = 0; hi < parts.Size()/2; ++hi) {
       auto pi = hi*2;
-      auto dh = o2::Header::get<DataHeader>(parts.At(pi)->GetData());
+      auto dh = o2::header::get<DataHeader>(parts.At(pi)->GetData());
       if (!dh) {
         LOG(ERROR) << "Header is not a DataHeader?";
         return false;
@@ -136,7 +136,7 @@ DataProcessingDevice::HandleData(FairMQParts &iParts, int /*index*/) {
         LOG(ERROR) << "DataHeader payloadSize mismatch";
         return false;
       }
-      auto dph = o2::Header::get<DataProcessingHeader>(parts.At(pi)->GetData());
+      auto dph = o2::header::get<DataProcessingHeader>(parts.At(pi)->GetData());
       if (!dph) {
         LOG(ERROR) << "Header stack does not contain DataProcessingHeader";
         return false;
@@ -270,12 +270,12 @@ DataProcessingDevice::HandleData(FairMQParts &iParts, int /*index*/) {
     for (size_t ii = 0, ie = record.size(); ii != ie; ++ii) {
       DataRef input = record.getByPos(ii);
       assert(input.header);
-      auto dh = o2::Header::get<DataHeader>(input.header);
+      auto dh = o2::header::get<DataHeader>(input.header);
       if (!dh) {
         reportError("Header is not a DataHeader?");
         continue;
       }
-      auto dph = o2::Header::get<DataProcessingHeader>(input.header);
+      auto dph = o2::header::get<DataProcessingHeader>(input.header);
       if (!dph) {
         reportError("Header stack does not contain DataProcessingHeader");
         continue;
@@ -297,12 +297,12 @@ DataProcessingDevice::HandleData(FairMQParts &iParts, int /*index*/) {
             LOG(ERROR) << "Missing header!";
             continue;
           }
-          auto fdph = o2::Header::get<DataProcessingHeader>(header.get()->GetData());
+          auto fdph = o2::header::get<DataProcessingHeader>(header.get()->GetData());
           if (fdph == nullptr) {
             LOG(ERROR) << "Forwarded data does not have a DataProcessingHeader";
             continue;
           }
-          auto fdh = o2::Header::get<DataHeader>(header.get()->GetData());
+          auto fdh = o2::header::get<DataHeader>(header.get()->GetData());
           if (fdh == nullptr) {
             LOG(ERROR) << "Forwarded data does not have a DataHeader";
             continue;
@@ -314,8 +314,8 @@ DataProcessingDevice::HandleData(FairMQParts &iParts, int /*index*/) {
           forwardedParts.AddPart(std::move(header));
           forwardedParts.AddPart(std::move(payload));
           assert(forwardedParts.Size() == 2);
-          assert(o2::Header::get<DataProcessingHeader>(forwardedParts.At(0)->GetData()));
-          LOG(DEBUG) << o2::Header::get<DataProcessingHeader>(forwardedParts.At(0)->GetData())->startTime;
+          assert(o2::header::get<DataProcessingHeader>(forwardedParts.At(0)->GetData()));
+          LOG(DEBUG) << o2::header::get<DataProcessingHeader>(forwardedParts.At(0)->GetData())->startTime;
           LOG(DEBUG) << forwardedParts.At(0)->GetSize();
           // FIXME: this should use a correct subchannel
           device.Send(forwardedParts, forward.channel, 0);

--- a/Framework/Core/src/DataProcessingHeader.cxx
+++ b/Framework/Core/src/DataProcessingHeader.cxx
@@ -14,7 +14,7 @@
 namespace o2 {
 namespace framework {
 
-constexpr o2::Header::HeaderType DataProcessingHeader::sHeaderType = "DataFlow";
+constexpr o2::header::HeaderType DataProcessingHeader::sHeaderType = "DataFlow";
 
 } // namespace framework
 } // namespace o2

--- a/Framework/Core/src/DataProcessor.cxx
+++ b/Framework/Core/src/DataProcessor.cxx
@@ -16,7 +16,7 @@
 #include <fairmq/FairMQDevice.h>
 
 using namespace o2::framework;
-using DataHeader = o2::Header::DataHeader;
+using DataHeader = o2::header::DataHeader;
 
 namespace o2 {
 namespace framework {
@@ -40,7 +40,7 @@ void DataProcessor::doSend(FairMQDevice &device, RootObjectContext &context) {
     FairMQMessagePtr payload(device.NewMessage());
     auto a = messageRef.payload.get();
     device.Serialize<TMessageSerializer>(*payload, a);
-    const DataHeader *cdh = o2::Header::get<DataHeader>(messageRef.header->GetData());
+    const DataHeader *cdh = o2::header::get<DataHeader>(messageRef.header->GetData());
     // sigh... See if we can avoid having it const by not
     // exposing it to the user in the first place.
     DataHeader *dh = const_cast<DataHeader *>(cdh);

--- a/Framework/Core/src/DataRelayer.cxx
+++ b/Framework/Core/src/DataRelayer.cxx
@@ -15,7 +15,7 @@
 #include "Framework/InputRecord.h"
 #include "fairmq/FairMQLogger.h"
 
-using DataHeader = o2::Header::DataHeader;
+using DataHeader = o2::header::DataHeader;
 using DataProcessingHeader = o2::framework::DataProcessingHeader;
 
 constexpr size_t MAX_PARALLEL_TIMESLICES = 256;
@@ -46,7 +46,7 @@ size_t
 assignInputSpecId(void *data, std::vector<InputRoute> const &routes) {
   for (size_t ri = 0, re = routes.size(); ri < re; ++ri) {
     auto &route = routes[ri];
-    const DataHeader *h = o2::Header::get<DataHeader>(data);
+    const DataHeader *h = o2::header::get<DataHeader>(data);
     if (h == nullptr) {
       return re;
     }
@@ -102,7 +102,7 @@ DataRelayer::relay(std::unique_ptr<FairMQMessage> &&header,
   // we do have data which comes without a timestamp, although I am personally
   // not sure what that would be.
   auto getTimeslice = [&header,&timeslices]() -> int64_t {
-    const DataProcessingHeader *dph = o2::Header::get<DataProcessingHeader>(header->GetData());
+    const DataProcessingHeader *dph = o2::header::get<DataProcessingHeader>(header->GetData());
     if (dph == nullptr) {
       return -1;
     }

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -382,8 +382,8 @@ WorkflowHelpers::verifyWorkflow(const o2::framework::WorkflowSpec &workflow) {
     for (size_t ii = 0; ii < spec.inputs.size(); ++ii) {
       InputSpec const &input = spec.inputs[ii];
       if (input.binding.empty()
-          || input.description == o2::Header::DataDescription("")
-          || input.origin == o2::Header::DataOrigin("")) {
+          || input.description == o2::header::DataDescription("")
+          || input.origin == o2::header::DataOrigin("")) {
         ss << "In spec " << spec.name << " input specification " 
            << ii << " requires binding, description and origin"
            " to be fully specified";

--- a/Framework/Core/test/test_DataRefUtils.cxx
+++ b/Framework/Core/test/test_DataRefUtils.cxx
@@ -25,8 +25,8 @@ BOOST_AUTO_TEST_CASE(TestRootSerialization) {
   TMessage* tm = new TMessage(kMESS_OBJECT);
   auto sOrig = std::make_unique<TObjString>("test");
   tm->WriteObject(sOrig.get());
-  o2::Header::DataHeader dh;
-  dh.payloadSerializationMethod = o2::Header::gSerializationMethodROOT;
+  o2::header::DataHeader dh;
+  dh.payloadSerializationMethod = o2::header::gSerializationMethodROOT;
   ref.payload = tm->Buffer();
   dh.payloadSize = tm->BufferSize();
   ref.header = reinterpret_cast<char const*>(&dh);

--- a/Framework/Core/test/test_DataRelayer.cxx
+++ b/Framework/Core/test/test_DataRelayer.cxx
@@ -21,8 +21,8 @@
 #include <cstring>
 
 using namespace o2::framework;
-using DataHeader = o2::Header::DataHeader;
-using Stack = o2::Header::Stack;
+using DataHeader = o2::header::DataHeader;
+using Stack = o2::header::Stack;
 
 
 // A simple test where an input is provided

--- a/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
+++ b/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
@@ -24,7 +24,7 @@
 
 using namespace o2::framework;
 
-AlgorithmSpec simplePipe(o2::Header::DataDescription what) {
+AlgorithmSpec simplePipe(o2::header::DataDescription what) {
   return AlgorithmSpec{
     [what](ProcessingContext &ctx)
       {
@@ -55,13 +55,13 @@ WorkflowSpec defineDataProcessing() {
     "B",
     {InputSpec{"x", "TST", "A1", InputSpec::Timeframe}},
     Outputs{OutputSpec{"TST", "B1", OutputSpec::Timeframe}},
-    simplePipe(o2::Header::DataDescription{"B1"})
+    simplePipe(o2::header::DataDescription{"B1"})
   },
   {
     "C",
     {InputSpec{"y", "TST", "A2", InputSpec::Timeframe}},
     Outputs{OutputSpec{"TST", "C1", OutputSpec::Timeframe}},
-    simplePipe(o2::Header::DataDescription{"C1"})
+    simplePipe(o2::header::DataDescription{"C1"})
   },
   {
     "D",

--- a/Framework/Core/test/test_InputRecord.cxx
+++ b/Framework/Core/test/test_InputRecord.cxx
@@ -20,8 +20,8 @@
 #include <fairmq/FairMQTransportFactory.h>
 
 using namespace o2::framework;
-using DataHeader = o2::Header::DataHeader;
-using Stack = o2::Header::Stack;
+using DataHeader = o2::header::DataHeader;
+using Stack = o2::header::Stack;
 
 bool any_exception( std::exception const& ex ) { return true; }
 

--- a/Framework/Core/test/test_ParallelProducer.cxx
+++ b/Framework/Core/test/test_ParallelProducer.cxx
@@ -15,7 +15,7 @@
 #include <vector>
 
 using namespace o2::framework;
-using DataHeader = o2::Header::DataHeader;
+using DataHeader = o2::header::DataHeader;
 
 DataProcessorSpec templateProducer() {
   return DataProcessorSpec{

--- a/Framework/Core/test/test_SimpleDataProcessingDevice01.cxx
+++ b/Framework/Core/test/test_SimpleDataProcessingDevice01.cxx
@@ -28,7 +28,7 @@ struct Summary {
   int clustersCount;
 };
 
-using DataHeader = o2::Header::DataHeader;
+using DataHeader = o2::header::DataHeader;
 
 // This is how you can define your processing in a declarative way
 void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {

--- a/Framework/Core/test/test_SimpleStatefulProcessing01.cxx
+++ b/Framework/Core/test/test_SimpleStatefulProcessing01.cxx
@@ -16,7 +16,7 @@
 #include "FairMQLogger.h"
 
 using namespace o2::framework;
-using DataHeader = o2::Header::DataHeader;
+using DataHeader = o2::header::DataHeader;
 
 using Inputs = std::vector<InputSpec>;
 using Outputs = std::vector<OutputSpec>;

--- a/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
@@ -11,7 +11,7 @@
 
 using namespace o2::framework;
 
-AlgorithmSpec simplePipe(o2::Header::DataDescription what) {
+AlgorithmSpec simplePipe(o2::header::DataDescription what) {
   return AlgorithmSpec{
     [what](ProcessingContext &ctx)
       {
@@ -42,13 +42,13 @@ void defineDataProcessing(WorkflowSpec &specs) {
     "B",
     {InputSpec{"x", "TST", "A1", InputSpec::Timeframe}},
     {OutputSpec{"TST", "B1", OutputSpec::Timeframe}},
-    simplePipe(o2::Header::DataDescription{"B1"})
+    simplePipe(o2::header::DataDescription{"B1"})
   },
   {
     "C",
     Inputs{InputSpec{"x", "TST", "A2", InputSpec::Timeframe}},
     Outputs{OutputSpec{"TST", "C1", OutputSpec::Timeframe}},
-    simplePipe(o2::Header::DataDescription{"C1"})
+    simplePipe(o2::header::DataDescription{"C1"})
   },
   {
     "D",

--- a/Framework/TestWorkflows/src/o2DummyWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DummyWorkflow.cxx
@@ -26,8 +26,8 @@ struct Summary {
   int clustersCount;
 };
 
-using DataHeader = o2::Header::DataHeader;
-using DataOrigin = o2::Header::DataOrigin;
+using DataHeader = o2::header::DataHeader;
+using DataOrigin = o2::header::DataOrigin;
 
 // This is how you can define your processing in a declarative way
 void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
@@ -126,21 +126,21 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
     AlgorithmSpec{
       [](ProcessingContext &ctx) {
         // We verify we got inputs in the correct order
-        auto h0 = o2::Header::get<DataHeader>(ctx.inputs().get("clusters").header);
-        auto h1 = o2::Header::get<DataHeader>(ctx.inputs().get("summary").header);
-        auto h2 = o2::Header::get<DataHeader>(ctx.inputs().get("other_summary").header);
+        auto h0 = o2::header::get<DataHeader>(ctx.inputs().get("clusters").header);
+        auto h1 = o2::header::get<DataHeader>(ctx.inputs().get("summary").header);
+        auto h2 = o2::header::get<DataHeader>(ctx.inputs().get("other_summary").header);
         // This should always be the case, since the 
         // test for an actual DataHeader should happen in the device itself.
         assert(h0 && h1 && h2);
-        if (h0->dataOrigin != o2::Header::DataOrigin("TPC")) {
+        if (h0->dataOrigin != o2::header::DataOrigin("TPC")) {
           throw std::runtime_error("Unexpected data origin" + std::string(h0->dataOrigin.str));
         }
 
-        if (h1->dataOrigin != o2::Header::DataOrigin("TPC")) {
+        if (h1->dataOrigin != o2::header::DataOrigin("TPC")) {
           throw std::runtime_error("Unexpected data origin" + std::string(h1->dataOrigin.str));
         }
 
-        if (h2->dataOrigin != o2::Header::DataOrigin("ITS")) {
+        if (h2->dataOrigin != o2::header::DataOrigin("ITS")) {
           throw std::runtime_error("Unexpected data origin" + std::string(h2->dataOrigin.str));
         }
 

--- a/Framework/TestWorkflows/src/o2ParallelWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2ParallelWorkflow.cxx
@@ -15,7 +15,7 @@
 #include <vector>
 
 using namespace o2::framework;
-using DataHeader = o2::Header::DataHeader;
+using DataHeader = o2::header::DataHeader;
 
 DataProcessorSpec templateProcessor() {
   return DataProcessorSpec{

--- a/Framework/TestWorkflows/src/o2_sim_its_ALP3.cxx
+++ b/Framework/TestWorkflows/src/o2_sim_its_ALP3.cxx
@@ -28,7 +28,7 @@
 
 using namespace o2::framework;
 
-using DataHeader = o2::Header::DataHeader;
+using DataHeader = o2::header::DataHeader;
 
 using Inputs = std::vector<InputSpec>;
 using Outputs = std::vector<OutputSpec>;

--- a/Framework/TestWorkflows/src/o2_sim_tpc.cxx
+++ b/Framework/TestWorkflows/src/o2_sim_tpc.cxx
@@ -30,7 +30,7 @@
 
 using namespace o2::framework;
 
-using DataHeader = o2::Header::DataHeader;
+using DataHeader = o2::header::DataHeader;
 
 
 #define BOX_GENERATOR 1

--- a/Framework/TestWorkflows/src/test_RawDeviceInjector.cxx
+++ b/Framework/TestWorkflows/src/test_RawDeviceInjector.cxx
@@ -14,19 +14,19 @@
 
 using namespace o2::framework;
 
-using DataHeader = o2::Header::DataHeader;
-using DataOrigin = o2::Header::DataOrigin;
+using DataHeader = o2::header::DataHeader;
+using DataOrigin = o2::header::DataOrigin;
 
 
 // A simple workflow which takes heartbeats from
 // a raw FairMQ device as input and uses them as 
 // part of the DPL.
 void defineDataProcessing(WorkflowSpec &specs) {
-  auto outspec = OutputSpec{o2::Header::DataOrigin("SMPL"),
-                            o2::Header::gDataDescriptionHeartbeatFrame};
+  auto outspec = OutputSpec{o2::header::DataOrigin("SMPL"),
+                            o2::header::gDataDescriptionHeartbeatFrame};
   auto inspec = InputSpec{"heatbeat",
-                          o2::Header::DataOrigin("SMPL"),
-                          o2::Header::gDataDescriptionHeartbeatFrame,
+                          o2::header::DataOrigin("SMPL"),
+                          o2::header::gDataDescriptionHeartbeatFrame,
                           InputSpec::Timeframe};
   WorkflowSpec workflow = {
     specifyExternalFairMQDeviceProxy("foreign-source",

--- a/Framework/TestWorkflows/src/test_o2ITSCluserizer.cxx
+++ b/Framework/TestWorkflows/src/test_o2ITSCluserizer.cxx
@@ -22,9 +22,9 @@
 using namespace o2::framework;
 using namespace o2::workflows;
 
-using DataHeader = o2::Header::DataHeader;
-using DataOrigin = o2::Header::DataOrigin;
-using DataDescription = o2::Header::DataDescription;
+using DataHeader = o2::header::DataHeader;
+using DataOrigin = o2::header::DataOrigin;
+using DataDescription = o2::header::DataDescription;
 
 // This is how you can define your processing in a declarative way
 void defineDataProcessing(WorkflowSpec &specs) {

--- a/Framework/TestWorkflows/src/test_o2RootMessageWorkflow.cxx
+++ b/Framework/TestWorkflows/src/test_o2RootMessageWorkflow.cxx
@@ -21,9 +21,9 @@
 #include <TString.h>
 
 using namespace o2::framework;
-using DataHeader = o2::Header::DataHeader;
-using DataOrigin = o2::Header::DataOrigin;
-using DataDescription = o2::Header::DataDescription;
+using DataHeader = o2::header::DataHeader;
+using DataOrigin = o2::header::DataOrigin;
+using DataDescription = o2::header::DataDescription;
 
 // This is how you can define your processing in a declarative way
 void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {

--- a/Utilities/DataFlow/include/DataFlow/SubframeBuilderDevice.h
+++ b/Utilities/DataFlow/include/DataFlow/SubframeBuilderDevice.h
@@ -114,14 +114,14 @@ private:
   template <typename T>
   size_t fakeHBHPayloadHBT(char **buffer, std::function<void(T&,int)> filler, int numOfElements) {
     // LOG(INFO) << "SENDING TPC PAYLOAD\n";
-    auto payloadSize = sizeof(Header::HeartbeatHeader)+sizeof(T)*numOfElements+sizeof(Header::HeartbeatTrailer);
+    auto payloadSize = sizeof(header::HeartbeatHeader)+sizeof(T)*numOfElements+sizeof(header::HeartbeatTrailer);
     *buffer = new char[payloadSize];
-    auto *hbh = reinterpret_cast<Header::HeartbeatHeader*>(*buffer);
+    auto *hbh = reinterpret_cast<header::HeartbeatHeader*>(*buffer);
     assert(payloadSize > 0);
-    assert(payloadSize - sizeof(Header::HeartbeatTrailer) > 0);
-    auto *hbt = reinterpret_cast<Header::HeartbeatTrailer*>(payloadSize - sizeof(Header::HeartbeatTrailer));
+    assert(payloadSize - sizeof(header::HeartbeatTrailer) > 0);
+    auto *hbt = reinterpret_cast<header::HeartbeatTrailer*>(payloadSize - sizeof(header::HeartbeatTrailer));
 
-    T *payload = reinterpret_cast<T*>(*buffer + sizeof(Header::HeartbeatHeader));
+    T *payload = reinterpret_cast<T*>(*buffer + sizeof(header::HeartbeatHeader));
     for (int i = 0; i < numOfElements; ++i) {
       new (payload + i) T;
       // put some random toy time stamp to each cluster

--- a/Utilities/DataFlow/include/DataFlow/SubframeUtils.h
+++ b/Utilities/DataFlow/include/DataFlow/SubframeUtils.h
@@ -17,8 +17,8 @@
 namespace o2 { namespace dataflow {
 
 int64_t extractDetectorPayloadStrip(char **payload, char *buffer, size_t bufferSize) {
-  *payload = buffer + sizeof(o2::Header::HeartbeatHeader);
-  return bufferSize - sizeof(o2::Header::HeartbeatHeader) - sizeof(o2::Header::HeartbeatTrailer);
+  *payload = buffer + sizeof(o2::header::HeartbeatHeader);
+  return bufferSize - sizeof(o2::header::HeartbeatHeader) - sizeof(o2::header::HeartbeatTrailer);
 }
 
 
@@ -32,7 +32,7 @@ struct SubframeId {
   }
 };
 
-SubframeId makeIdFromHeartbeatHeader(const Header::HeartbeatHeader &header, size_t socketId, size_t orbitsPerTimeframe) {
+SubframeId makeIdFromHeartbeatHeader(const header::HeartbeatHeader &header, size_t socketId, size_t orbitsPerTimeframe) {
   SubframeId id = {
     .timeframeId = header.orbit / orbitsPerTimeframe,
     .socketId = socketId

--- a/Utilities/DataFlow/src/EPNReceiverDevice.cxx
+++ b/Utilities/DataFlow/src/EPNReceiverDevice.cxx
@@ -97,7 +97,7 @@ void EPNReceiverDevice::Run()
 
     assert(subtimeframeParts.Size() >= 2);
 
-    Header::DataHeader* dh = reinterpret_cast<Header::DataHeader*>(subtimeframeParts.At(0)->GetData());
+    const auto* dh = o2::header::get<header::DataHeader>(subtimeframeParts.At(0)->GetData());
     assert(strncmp(dh->dataDescription.str, "SUBTIMEFRAMEMD", 16) == 0);
     SubframeMetadata* sfm = reinterpret_cast<SubframeMetadata*>(subtimeframeParts.At(1)->GetData());
     id = o2::DataFlow::timeframeIdFromTimestamp(sfm->startTime, sfm->duration);
@@ -123,7 +123,7 @@ void EPNReceiverDevice::Run()
       {
         if (i % 2 == 0)
         {
-          auto adh = reinterpret_cast<Header::DataHeader*>(subtimeframeParts.At(i)->GetData());
+          const auto * adh = o2::header::get<header::DataHeader>(subtimeframeParts.At(i)->GetData());
           auto ie = std::make_pair(*adh, index.count(id)*2);
           index.insert(std::make_pair(id, ie));
         }
@@ -138,11 +138,11 @@ void EPNReceiverDevice::Run()
 
     if (flpIds.count(id) == mNumFLPs) {
       LOG(INFO) << "Timeframe " << id << " complete. Publishing.\n";
-      o2::Header::DataHeader tih;
+      o2::header::DataHeader tih;
       std::vector<IndexElement> flattenedIndex;
 
-      tih.dataDescription = o2::Header::DataDescription("TIMEFRAMEINDEX");
-      tih.dataOrigin = o2::Header::DataOrigin("EPN");
+      tih.dataDescription = o2::header::DataDescription("TIMEFRAMEINDEX");
+      tih.dataOrigin = o2::header::DataOrigin("EPN");
       tih.subSpecification = 0;
       tih.payloadSize = index.count(id) * sizeof(flattenedIndex.front());
       void *indexData = malloc(tih.payloadSize);

--- a/Utilities/DataFlow/src/FLPSenderDevice.cxx
+++ b/Utilities/DataFlow/src/FLPSenderDevice.cxx
@@ -55,7 +55,7 @@ void FLPSenderDevice::Run()
 
     assert(subtimeframeParts.Size() != 0);
     assert(subtimeframeParts.Size() >= 2);
-    Header::DataHeader* dh = reinterpret_cast<Header::DataHeader*>(subtimeframeParts.At(0)->GetData());
+    const auto* dh = o2::header::get<header::DataHeader>(subtimeframeParts.At(0)->GetData());
     assert(strncmp(dh->dataDescription.str, "SUBTIMEFRAMEMD", 16) == 0);
 
     SubframeMetadata* sfm = reinterpret_cast<SubframeMetadata*>(subtimeframeParts.At(1)->GetData());

--- a/Utilities/DataFlow/src/FakeTimeframeBuilder.cxx
+++ b/Utilities/DataFlow/src/FakeTimeframeBuilder.cxx
@@ -16,36 +16,36 @@
 #include <functional>
 #include <cstring>
 
-using DataHeader = o2::Header::DataHeader;
-using DataDescription = o2::Header::DataDescription;
-using DataOrigin = o2::Header::DataOrigin;
+using DataHeader = o2::header::DataHeader;
+using DataDescription = o2::header::DataDescription;
+using DataOrigin = o2::header::DataOrigin;
 using IndexElement = o2::DataFormat::IndexElement;
 
 namespace {
-  o2::Header::DataDescription lookupDataDescription(const char *key) {
+  o2::header::DataDescription lookupDataDescription(const char *key) {
     if (strcmp(key, "RAWDATA") == 0)
-      return o2::Header::gDataDescriptionRawData;
+      return o2::header::gDataDescriptionRawData;
     else if (strcmp(key, "CLUSTERS") == 0)
-      return o2::Header::gDataDescriptionClusters;
+      return o2::header::gDataDescriptionClusters;
     else if (strcmp(key, "TRACKS") == 0)
-      return o2::Header::gDataDescriptionTracks;
+      return o2::header::gDataDescriptionTracks;
     else if (strcmp(key, "CONFIG") == 0)
-      return o2::Header::gDataDescriptionConfig;
+      return o2::header::gDataDescriptionConfig;
     else if (strcmp(key, "INFO") == 0)
-      return o2::Header::gDataDescriptionInfo;
-    return o2::Header::gDataDescriptionInvalid;
+      return o2::header::gDataDescriptionInfo;
+    return o2::header::gDataDescriptionInvalid;
   }
 
-  o2::Header::DataOrigin lookupDataOrigin(const char *key) {
+  o2::header::DataOrigin lookupDataOrigin(const char *key) {
     if (strcmp(key, "TPC") == 0)
-      return o2::Header::gDataOriginTPC;
+      return o2::header::gDataOriginTPC;
     if (strcmp(key, "TRD") == 0)
-      return o2::Header::gDataOriginTRD;
+      return o2::header::gDataOriginTRD;
     if (strcmp(key, "TOF") == 0)
-      return o2::Header::gDataOriginTOF;
+      return o2::header::gDataOriginTOF;
     if (strcmp(key, "ITS") == 0)
-      return o2::Header::gDataOriginITS;
-    return o2::Header::gDataOriginInvalid;
+      return o2::header::gDataOriginITS;
+    return o2::header::gDataOriginInvalid;
   }
 
 

--- a/Utilities/DataFlow/src/FakeTimeframeGeneratorDevice.cxx
+++ b/Utilities/DataFlow/src/FakeTimeframeGeneratorDevice.cxx
@@ -18,7 +18,7 @@
 #include <options/FairMQProgOptions.h>
 #include <vector>
 
-using DataHeader = o2::Header::DataHeader;
+using DataHeader = o2::header::DataHeader;
 
 namespace {
 struct OneShotReadBuf : public std::streambuf

--- a/Utilities/DataFlow/src/HeartbeatSampler.cxx
+++ b/Utilities/DataFlow/src/HeartbeatSampler.cxx
@@ -30,18 +30,18 @@ bool o2::DataFlow::HeartbeatSampler::ConditionalRun()
 {
   std::this_thread::sleep_for(std::chrono::nanoseconds(mPeriod));
 
-  o2::Header::HeartbeatStatistics hbfPayload;
+  o2::header::HeartbeatStatistics hbfPayload;
 
-  o2::Header::DataHeader dh;
-  dh.dataDescription = o2::Header::gDataDescriptionHeartbeatFrame;
-  dh.dataOrigin = o2::Header::DataOrigin("SMPL");
+  o2::header::DataHeader dh;
+  dh.dataDescription = o2::header::gDataDescriptionHeartbeatFrame;
+  dh.dataOrigin = o2::header::DataOrigin("SMPL");
   dh.subSpecification = 0;
   dh.payloadSize = sizeof(hbfPayload);
 
   // Note: the block type of both header an trailer members of the envelope
   // structure are autmatically initialized to the appropriate block type
   // and size '1' (i.e. only one 64bit word)
-  o2::Header::HeartbeatFrameEnvelope specificHeader;
+  o2::header::HeartbeatFrameEnvelope specificHeader;
   specificHeader.header.orbit = mCount;
   specificHeader.trailer.hbAccept = 1;
 

--- a/Utilities/DataFlow/src/SubframeBuilderDevice.cxx
+++ b/Utilities/DataFlow/src/SubframeBuilderDevice.cxx
@@ -24,9 +24,9 @@
 #include "Headers/DataHeader.h"
 #include <options/FairMQProgOptions.h>
 
-using HeartbeatHeader = o2::Header::HeartbeatHeader;
-using HeartbeatTrailer = o2::Header::HeartbeatTrailer;
-using DataHeader = o2::Header::DataHeader;
+using HeartbeatHeader = o2::header::HeartbeatHeader;
+using HeartbeatTrailer = o2::header::HeartbeatTrailer;
+using DataHeader = o2::header::DataHeader;
 using SubframeId = o2::dataflow::SubframeId;
 
 o2::DataFlow::SubframeBuilderDevice::SubframeBuilderDevice()
@@ -96,13 +96,13 @@ bool o2::DataFlow::SubframeBuilderDevice::BuildAndSendFrame(FairMQParts &inParts
   // this should be defined in a common place, and also the origin
   // the origin can probably name a detector identifier, but not sure if
   // all CRUs of a FLP in all cases serve a single detector
-  o2::Header::DataHeader dh;
-  dh.dataDescription = o2::Header::DataDescription("SUBTIMEFRAMEMD");
-  dh.dataOrigin = o2::Header::DataOrigin("FLP");
+  o2::header::DataHeader dh;
+  dh.dataDescription = o2::header::DataDescription("SUBTIMEFRAMEMD");
+  dh.dataOrigin = o2::header::DataOrigin("FLP");
   dh.subSpecification = mFLPId;
   dh.payloadSize = sizeof(SubframeMetadata);
 
-  DataHeader payloadheader(*o2::Header::get<DataHeader>((byte*)inParts.At(0)->GetData()));
+  DataHeader payloadheader(*o2::header::get<DataHeader>((byte*)inParts.At(0)->GetData()));
 
   // subframe meta information as payload
   SubframeMetadata md;

--- a/Utilities/DataFlow/src/TimeframeParser.cxx
+++ b/Utilities/DataFlow/src/TimeframeParser.cxx
@@ -26,8 +26,8 @@
 #include <FairMQParts.h>
 
 
-using DataHeader = o2::Header::DataHeader;
-using DataDescription = o2::Header::DataDescription;
+using DataHeader = o2::header::DataHeader;
+using DataDescription = o2::header::DataDescription;
 using IndexElement = o2::DataFormat::IndexElement;
 
 namespace o2 { namespace DataFlow {
@@ -174,7 +174,7 @@ void streamTimeframe(std::ostream &stream, FairMQParts &parts) {
     throw std::runtime_error("Expecting at least 2 parts\n");
   }
 
-  auto indexHeader = o2::Header::get<DataHeader>(parts.At(parts.Size() - 2)->GetData());
+  auto indexHeader = o2::header::get<DataHeader>(parts.At(parts.Size() - 2)->GetData());
   // FIXME: Provide iterator pair API for the index
   //        Index should really be something which provides an
   //        iterator pair API so that we can sort / find / lower_bound

--- a/Utilities/DataFlow/src/TimeframeReaderDevice.cxx
+++ b/Utilities/DataFlow/src/TimeframeReaderDevice.cxx
@@ -16,7 +16,7 @@
 #include "Headers/DataHeader.h"
 #include <options/FairMQProgOptions.h>
 
-using DataHeader = o2::Header::DataHeader;
+using DataHeader = o2::header::DataHeader;
 
 namespace o2 { namespace DataFlow {
 

--- a/Utilities/DataFlow/src/TimeframeValidatorDevice.cxx
+++ b/Utilities/DataFlow/src/TimeframeValidatorDevice.cxx
@@ -23,9 +23,9 @@
 
 #include <options/FairMQProgOptions.h>
 
-using DataHeader = o2::Header::DataHeader;
-using DataOrigin = o2::Header::DataOrigin;
-using DataDescription = o2::Header::DataDescription;
+using DataHeader = o2::header::DataHeader;
+using DataOrigin = o2::header::DataOrigin;
+using DataDescription = o2::header::DataDescription;
 using IndexElement = o2::DataFormat::IndexElement;
 
 o2::DataFlow::TimeframeValidatorDevice::TimeframeValidatorDevice()
@@ -49,7 +49,7 @@ void o2::DataFlow::TimeframeValidatorDevice::Run()
     if (timeframeParts.Size() < 2)
       LOG(ERROR) << "Expecting at least 2 parts\n";
 
-    auto indexHeader = o2::Header::get<Header::DataHeader>(timeframeParts.At(timeframeParts.Size() - 2)->GetData());
+    auto indexHeader = o2::header::get<header::DataHeader>(timeframeParts.At(timeframeParts.Size() - 2)->GetData());
     // FIXME: Provide iterator pair API for the index
     //        Index should really be something which provides an
     //        iterator pair API so that we can sort / find / lower_bound
@@ -78,12 +78,12 @@ void o2::DataFlow::TimeframeValidatorDevice::Run()
       assert(ie.second >= 0);
       LOG(DEBUG) << ie.first.dataDescription.str << " "
                  << ie.first.dataOrigin.str << std::endl;
-      if ((ie.first.dataOrigin == Header::gDataOriginTPC)
-          && (ie.first.dataDescription == Header::gDataDescriptionClusters)) {
+      if ((ie.first.dataOrigin == header::gDataOriginTPC)
+          && (ie.first.dataDescription == header::gDataDescriptionClusters)) {
         tpcIndex = ie.second;
       }
-      if ((ie.first.dataOrigin == Header::gDataOriginITS)
-          && (ie.first.dataDescription == Header::gDataDescriptionClusters)) {
+      if ((ie.first.dataOrigin == header::gDataOriginITS)
+          && (ie.first.dataDescription == header::gDataDescriptionClusters)) {
         itsIndex = ie.second;
       }
     }
@@ -103,8 +103,8 @@ void o2::DataFlow::TimeframeValidatorDevice::Run()
 
     // Data header it at position - 1
     auto tpcHeader = reinterpret_cast<DataHeader *>(timeframeParts.At(tpcIndex)->GetData());
-    if ((tpcHeader->dataDescription != Header::gDataDescriptionClusters) ||
-        (tpcHeader->dataOrigin != Header::gDataOriginTPC))
+    if ((tpcHeader->dataDescription != header::gDataDescriptionClusters) ||
+        (tpcHeader->dataOrigin != header::gDataOriginTPC))
     {
       LOG(ERROR) << "Wrong data description. Expecting TPC - CLUSTERS, found "
                  << tpcHeader->dataOrigin.str << " - "
@@ -132,8 +132,8 @@ void o2::DataFlow::TimeframeValidatorDevice::Run()
 
     // Data header it at position - 1
     auto itsHeader = reinterpret_cast<DataHeader *>(timeframeParts.At(itsIndex)->GetData());
-    if ((itsHeader->dataDescription != Header::gDataDescriptionClusters)
-        || (itsHeader->dataOrigin != Header::gDataOriginITS))
+    if ((itsHeader->dataDescription != header::gDataDescriptionClusters)
+        || (itsHeader->dataOrigin != header::gDataOriginITS))
     {
       LOG(ERROR) << "Wrong data description. Expecting ITS - CLUSTERS, found "
                  << itsHeader->dataOrigin.str << " - " << itsHeader->dataDescription.str << "\n";

--- a/Utilities/DataFlow/src/TimeframeWriterDevice.cxx
+++ b/Utilities/DataFlow/src/TimeframeWriterDevice.cxx
@@ -25,7 +25,7 @@
 #include <boost/filesystem.hpp>
 
 
-using DataHeader = o2::Header::DataHeader;
+using DataHeader = o2::header::DataHeader;
 using IndexElement = o2::DataFormat::IndexElement;
 
 namespace o2 { namespace DataFlow {

--- a/Utilities/DataFlow/test/test_PayloadMerger01.cxx
+++ b/Utilities/DataFlow/test/test_PayloadMerger01.cxx
@@ -23,8 +23,8 @@
 #include "fairmq/FairMQParts.h"
 
 using SubframeId = o2::dataflow::SubframeId;
-using HeartbeatHeader = o2::Header::HeartbeatHeader;
-using HeartbeatTrailer = o2::Header::HeartbeatTrailer;
+using HeartbeatHeader = o2::header::HeartbeatHeader;
+using HeartbeatTrailer = o2::header::HeartbeatTrailer;
 
 SubframeId fakeAddition(o2::dataflow::PayloadMerger<SubframeId> &merger,
                   std::shared_ptr<FairMQTransportFactory> &transport,
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(PayloadMergerTest) {
 
   // Id is given by the orbit, 2 orbits per timeframe
   auto makeId = [](std::unique_ptr<FairMQMessage> &msg) {
-    auto header = reinterpret_cast<o2::Header::HeartbeatHeader const*>(msg->GetData());
+    auto header = reinterpret_cast<o2::header::HeartbeatHeader const*>(msg->GetData());
     return o2::dataflow::makeIdFromHeartbeatHeader(*header, 0, 2);
   };
 

--- a/Utilities/DataFlow/test/test_SubframeUtils01.cxx
+++ b/Utilities/DataFlow/test/test_SubframeUtils01.cxx
@@ -26,25 +26,25 @@ BOOST_AUTO_TEST_CASE(SubframeUtils01) {
   BOOST_CHECK(a < b);
   char *buf = new char[1000];
   memset(buf, 126, 1000);
-  for (size_t i = sizeof(o2::Header::HeartbeatHeader); i < 1000 - sizeof(o2::Header::HeartbeatHeader); ++i)
+  for (size_t i = sizeof(o2::header::HeartbeatHeader); i < 1000 - sizeof(o2::header::HeartbeatHeader); ++i)
   {
     buf[i] = 0;
   }
   BOOST_CHECK(buf[0] == 126);
-  BOOST_CHECK(buf[sizeof(o2::Header::HeartbeatHeader)] == 0);
-  BOOST_CHECK(buf[sizeof(o2::Header::HeartbeatHeader)-1] == 126);
+  BOOST_CHECK(buf[sizeof(o2::header::HeartbeatHeader)] == 0);
+  BOOST_CHECK(buf[sizeof(o2::header::HeartbeatHeader)-1] == 126);
   char *realPayload = nullptr;
   size_t realSize = o2::dataflow::extractDetectorPayloadStrip(&realPayload, buf, 1000);
   BOOST_CHECK(realPayload != nullptr);
-  BOOST_CHECK(realSize == 1000 - sizeof(o2::Header::HeartbeatHeader) - sizeof(o2::Header::HeartbeatTrailer));
-  BOOST_CHECK(realPayload == buf + sizeof(o2::Header::HeartbeatHeader));
+  BOOST_CHECK(realSize == 1000 - sizeof(o2::header::HeartbeatHeader) - sizeof(o2::header::HeartbeatTrailer));
+  BOOST_CHECK(realPayload == buf + sizeof(o2::header::HeartbeatHeader));
   BOOST_CHECK(realPayload[0] == 0);
 
-  o2::Header::HeartbeatHeader header1;
+  o2::header::HeartbeatHeader header1;
   header1.orbit = 0;
-  o2::Header::HeartbeatHeader header2;
+  o2::header::HeartbeatHeader header2;
   header2.orbit = 255;
-  o2::Header::HeartbeatHeader header3;
+  o2::header::HeartbeatHeader header3;
   header3.orbit = 256;
 
   auto id1 = o2::dataflow::makeIdFromHeartbeatHeader(header1, 1, 256);

--- a/Utilities/DataFlow/test/test_TimeframeParser.cxx
+++ b/Utilities/DataFlow/test/test_TimeframeParser.cxx
@@ -23,7 +23,7 @@ struct OneShotReadBuf : public std::streambuf
     }
 };
 
-using DataHeader = o2::Header::DataHeader;
+using DataHeader = o2::header::DataHeader;
 
 int
 main(int argc, char **argv) {

--- a/Utilities/O2Device/include/O2Device/O2Device.h
+++ b/Utilities/O2Device/include/O2Device/O2Device.h
@@ -50,16 +50,16 @@ public:
   /// @param[] incomingStack header block must be MOVED in (rvalue ref)
   /// @param[] dataMessage the data message must be MOVED in (unique_ptr by value)
   bool AddMessage(O2Message& parts,
-                  o2::Header::Stack&& incomingStack,
+                  o2::header::Stack&& incomingStack,
                   FairMQMessagePtr incomingDataMessage) {
 
     //we have to move the incoming data
-    o2::Header::Stack headerStack{std::move(incomingStack)};
+    o2::header::Stack headerStack{std::move(incomingStack)};
     FairMQMessagePtr dataMessage{std::move(incomingDataMessage)};
 
     FairMQMessagePtr headerMessage = NewMessage(headerStack.buffer.get(),
                                                 headerStack.bufferSize,
-                                                &o2::Header::Stack::freefn,
+                                                &o2::header::Stack::freefn,
                                                 headerStack.buffer.get());
     headerStack.buffer.release();
 

--- a/Utilities/O2MessageMonitor/include/O2MessageMonitor/O2MessageMonitor.h
+++ b/Utilities/O2MessageMonitor/include/O2MessageMonitor/O2MessageMonitor.h
@@ -52,7 +52,7 @@ protected:
       const byte* dataBuffer,   size_t dataBufferSize);
 
 private:
-  o2::Header::DataHeader mDataHeader;
+  o2::header::DataHeader mDataHeader;
   std::string mPayload;
   std::string mName;
   long long mDelay;

--- a/Utilities/O2MessageMonitor/src/O2MessageMonitor.cxx
+++ b/Utilities/O2MessageMonitor/src/O2MessageMonitor.cxx
@@ -35,7 +35,7 @@
 #include "Headers/NameHeader.h"
 
 using namespace std;
-using namespace o2::Header;
+using namespace o2::header;
 using namespace o2::Base;
 
 using NameHeader48 = NameHeader<48>; //header holding 16 characters

--- a/Utilities/Publishers/include/Publishers/DataPublisherDevice.h
+++ b/Utilities/Publishers/include/Publishers/DataPublisherDevice.h
@@ -80,9 +80,9 @@ private:
   /// index of the previously handled data channel in HandleData
   int mLastIndex;
   /// the default data description
-  o2::Header::DataDescription mDataDescription;
+  o2::header::DataDescription mDataDescription;
   /// the default data description
-  o2::Header::DataOrigin mDataOrigin;
+  o2::header::DataOrigin mDataOrigin;
   /// the default data sub specification
   SubSpecificationT mSubSpecification;
   /// buffer for the file to read

--- a/Utilities/QC/Workflow/src/RootObjectMergerSpec.cxx
+++ b/Utilities/QC/Workflow/src/RootObjectMergerSpec.cxx
@@ -51,9 +51,9 @@ DataProcessorSpec getRootObjectMergerSpec() {
   // the shared pointer makes sure to clean up the instance when the processing
   // function gets out of scope
   auto processingFct = [merger = std::make_shared<Merger>(10)] (ProcessingContext &pc) {
-    using DataHeader = o2::Header::DataHeader;
+    using DataHeader = o2::header::DataHeader;
     for (auto & input : pc.inputs()) {
-      auto dh = o2::Header::get<const DataHeader>(input.header);
+      auto dh = o2::header::get<const DataHeader>(input.header);
       std::cout << dh->dataOrigin.str
       << " " << dh->dataDescription.str
       << " " << dh->payloadSize

--- a/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/MessageFormat.h
+++ b/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/MessageFormat.h
@@ -73,7 +73,7 @@ struct BlockDescriptor : public AliHLTComponentBlockData {
 
   BlockDescriptor(void* ptr,
                   AliHLTUInt32_t size,
-                  const o2::Header::DataHeader& o2dh)
+                  const o2::header::DataHeader& o2dh)
     : BlockDescriptor(0, ptr, size, AliHLTComponentDataTypeInitializer(o2dh.dataDescription.str, o2dh.dataOrigin.str), o2dh.subSpecification) {}
 };
 
@@ -93,10 +93,10 @@ public:
   /// destructor
   ~MessageFormat();
 
-  using DataHeader = o2::Header::DataHeader;
-  using HeartbeatFrameEnvelope = o2::Header::HeartbeatFrameEnvelope;
-  using HeartbeatHeader = o2::Header::HeartbeatHeader;
-  using HeartbeatTrailer = o2::Header::HeartbeatTrailer;
+  using DataHeader = o2::header::DataHeader;
+  using HeartbeatFrameEnvelope = o2::header::HeartbeatFrameEnvelope;
+  using HeartbeatHeader = o2::header::HeartbeatHeader;
+  using HeartbeatTrailer = o2::header::HeartbeatTrailer;
 
   struct BufferDesc_t {
     using PtrT = unsigned char*;

--- a/Utilities/aliceHLTwrapper/test/testMessageFormat.cxx
+++ b/Utilities/aliceHLTwrapper/test/testMessageFormat.cxx
@@ -22,10 +22,10 @@ namespace o2 {
 namespace alice_hlt {
   template<typename... Targs>
   void hexDump(Targs... Fargs) {
-    //o2::Header::hexDump(Fargs...);
+    //o2::header::hexDump(Fargs...);
   }
 
-  using DataHeader = o2::Header::DataHeader;
+  using DataHeader = o2::header::DataHeader;
 
   BOOST_AUTO_TEST_CASE(test_createMessagesModeMultiPart)
   {
@@ -178,10 +178,10 @@ namespace alice_hlt {
 
   BOOST_AUTO_TEST_CASE(test_createHeartbeatFrame)
   {
-    using HeartbeatFrameEnvelope = o2::Header::HeartbeatFrameEnvelope;
-    using HeartbeatHeader = o2::Header::HeartbeatHeader;
-    using HeartbeatTrailer = o2::Header::HeartbeatTrailer;
-    using HeartbeatStatistics = o2::Header::HeartbeatStatistics;
+    using HeartbeatFrameEnvelope = o2::header::HeartbeatFrameEnvelope;
+    using HeartbeatHeader = o2::header::HeartbeatHeader;
+    using HeartbeatTrailer = o2::header::HeartbeatTrailer;
+    using HeartbeatStatistics = o2::header::HeartbeatStatistics;
     std::cout << "Testing HearbeatFrame propagation" << std::endl;
     MessageFormat handler;
     handler.setOutputMode(MessageFormat::kOutputModeO2);
@@ -191,14 +191,14 @@ namespace alice_hlt {
     // header stack
     HeartbeatStatistics hbfPayload;
     DataHeader dh;
-    dh.dataDescription = o2::Header::gDataDescriptionHeartbeatFrame;
-    dh.dataOrigin = o2::Header::DataOrigin("TEST");
+    dh.dataDescription = o2::header::gDataDescriptionHeartbeatFrame;
+    dh.dataOrigin = o2::header::DataOrigin("TEST");
     dh.subSpecification = 0;
     dh.payloadSize = sizeof(hbfPayload);
 
     // create incoming header stack
     HeartbeatFrameEnvelope hbfHeader;
-    o2::Header::Stack headerMessage(dh, hbfHeader);
+    o2::header::Stack headerMessage(dh, hbfHeader);
 
     std::vector<MessageFormat::BufferDesc_t> incomingMessages;
     incomingMessages.emplace_back((MessageFormat::BufferDesc_t::PtrT)headerMessage.data(), headerMessage.size());
@@ -236,7 +236,7 @@ namespace alice_hlt {
     for (auto & output : outputs) {
       if (dataidx % 2 == 0) {
         hexDump("Header block", output.mP, output.mSize);
-        BOOST_CHECK(output.mSize >= sizeof(o2::Header::DataHeader));
+        BOOST_CHECK(output.mSize >= sizeof(o2::header::DataHeader));
       } else {
         hexDump("Payload block", output.mP, output.mSize);
         hexDump("  Data string", dataFields[datafieldidx].c_str(), dataFields[datafieldidx].size() + 1);


### PR DESCRIPTION
This is to follow the naming scheme for namespaces, keeping an alias
of the old upper case name for a while until pull requests which are
currently open are processed.