### PR TITLE
Fix following elimination of FairGenericRootManager

### DIFF
--- a/DataFormats/TPC/include/DataFormatsTPC/ClusterHardware.h
+++ b/DataFormats/TPC/include/DataFormatsTPC/ClusterHardware.h
@@ -16,7 +16,7 @@
 
 #include <cstdint>
 
-namespace o2 { namespace DataFormat { namespace TPC{
+namespace o2 { namespace DataFormat { namespace TPC{ 
 
 struct ClusterHardware { //Temporary draft of hardware clusters. The ...Pre members are yet to be defined, and will most likely either be floats or fixed point integers.
   float padPre;                //< Quantity needed to compute the pad

--- a/Detectors/FIT/simulation/src/Detector.cxx
+++ b/Detectors/FIT/simulation/src/Detector.cxx
@@ -17,7 +17,7 @@
 #include "TSystem.h"
 #include "TVirtualMC.h"
 
-#include "FairGenericRootManager.h" // for FairGenericRootManager
+#include "FairRootManager.h" // for FairRootManager
 #include "FairLogger.h"
 #include "FairVolume.h"
 
@@ -302,8 +302,8 @@ void Detector::Register()
   // parameter to kFALSE means that this collection will not be written to the file,
   // it will exist only during the simulation
 
-  if (FairGenericRootManager::Instance()) {
-    FairGenericRootManager::Instance()->GetFairRootManager()->RegisterAny(addNameTo("Hit").data(), mHits, kTRUE);
+  if (FairRootManager::Instance()) {
+    FairRootManager::Instance()->RegisterAny(addNameTo("Hit").data(), mHits, kTRUE);
   }
 }
 

--- a/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
@@ -24,7 +24,7 @@
 //FairRoot includes
 #include "FairDetector.h"           // for FairDetector
 #include "FairLogger.h"             // for LOG, LOG_IF
-#include "FairGenericRootManager.h"        // for FairGenericRootManager
+#include "FairRootManager.h"        // for FairRootManager
 #include "FairRun.h"                // for FairRun
 #include "FairRuntimeDb.h"          // for FairRuntimeDb
 #include "FairVolume.h"             // for FairVolume
@@ -593,8 +593,8 @@ void Detector::Register()
   // it will exist only during the simulation
 
   // FIXME: fix MT interface
-  if (FairGenericRootManager::Instance()) {
-    FairGenericRootManager::Instance()->GetFairRootManager()->RegisterAny(addNameTo("Hit").data(), mHits, kTRUE);
+  if (FairRootManager::Instance()) {
+    FairRootManager::Instance()->RegisterAny(addNameTo("Hit").data(), mHits, kTRUE);
   }
 }
 

--- a/Detectors/ITSMFT/MFT/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/MFT/simulation/src/Detector.cxx
@@ -30,7 +30,7 @@
 #include "TGeoManager.h"
 
 #include "FairLogger.h"
-#include "FairGenericRootManager.h"
+#include "FairRootManager.h"
 #include "FairVolume.h"
 
 using o2::ITSMFT::Hit;
@@ -471,8 +471,8 @@ void Detector::Register()
   // parameter to kFALSE means that this collection will not be written to the file,
   // it will exist only during the simulation
 
-  if (FairGenericRootManager::Instance()) {
-    FairGenericRootManager::Instance()->GetFairRootManager()->RegisterAny(addNameTo("Hit").data(), mHits, kTRUE);
+  if (FairRootManager::Instance()) {
+    FairRootManager::Instance()->RegisterAny(addNameTo("Hit").data(), mHits, kTRUE);
   }
 
 }

--- a/Detectors/TPC/simulation/src/Detector.cxx
+++ b/Detectors/TPC/simulation/src/Detector.cxx
@@ -20,7 +20,6 @@
 
 #include <cstddef>             // for NULL
 
-#include "FairGenericRootManager.h"
 #include "FairGeoVolume.h"
 #include "FairGeoNode.h"
 #include "FairGeoLoader.h"


### PR DESCRIPTION
The FairGenericRootManager is not activated anymore, detectors must register their branches
via FaitRootManager::Instance()