### PR TITLE
Compute X and Z dimensions internally in the code

### DIFF
--- a/Detectors/Base/include/DetectorsBase/Detector.h
+++ b/Detectors/Base/include/DetectorsBase/Detector.h
@@ -81,10 +81,10 @@ class Detector : public FairDetector
     /// Books arrays for wrapper volumes
     virtual void setNumberOfWrapperVolumes(Int_t n);
 
-    virtual void defineLayer(Int_t nlay, Double_t phi0, Double_t r, Double_t zlen, Int_t nladd, Int_t nmod,
+    virtual void defineLayer(Int_t nlay, Double_t phi0, Double_t r, Int_t nladd, Int_t nmod,
                              Double_t lthick = 0., Double_t dthick = 0., UInt_t detType = 0, Int_t buildFlag = 0);
 
-    virtual void defineLayerTurbo(Int_t nlay, Double_t phi0, Double_t r, Double_t zlen, Int_t nladd, Int_t nmod,
+    virtual void defineLayerTurbo(Int_t nlay, Double_t phi0, Double_t r, Int_t nladd, Int_t nmod,
                                   Double_t width, Double_t tilt, Double_t lthick = 0., Double_t dthick = 0.,
                                   UInt_t detType = 0, Int_t buildFlag = 0);
 

--- a/Detectors/Base/src/Detector.cxx
+++ b/Detectors/Base/src/Detector.cxx
@@ -118,13 +118,13 @@ void Detector::setNumberOfWrapperVolumes(Int_t n)
 }
 
 void Detector::defineLayer(const Int_t nlay, const double phi0, const Double_t r,
-                           const Double_t zlen, const Int_t nladd, const Int_t nmod,
+                           const Int_t nladd, const Int_t nmod,
                            const Double_t lthick, const Double_t dthick, const UInt_t dettypeID,
                            const Int_t buildLevel)
 {
 }
 
-void Detector::defineLayerTurbo(Int_t nlay, Double_t phi0, Double_t r, Double_t zlen, Int_t nladd,
+void Detector::defineLayerTurbo(Int_t nlay, Double_t phi0, Double_t r, Int_t nladd,
                                 Int_t nmod, Double_t width, Double_t tilt, Double_t lthick,
                                 Double_t dthick, UInt_t dettypeID, Int_t buildLevel)
 {

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
@@ -117,7 +117,6 @@ class Detector : public o2::Base::DetImpl<Detector>
     /// \param nlay layer number
     /// \param phi0 layer phi0
     /// \param r layer radius
-    /// \param zlen layer length
     /// \param nstav number of staves
     /// \param nunit IB: number of chips per stave
     /// \param OB: number of modules per half stave
@@ -125,7 +124,7 @@ class Detector : public o2::Base::DetImpl<Detector>
     /// \param dthick detector thickness (if omitted, defaults to 0)
     /// \param dettypeID ??
     /// \param buildLevel (if 0, all geometry is build, used for material budget studies)
-    void defineLayer(Int_t nlay, Double_t phi0, Double_t r, Double_t zlen, Int_t nladd, Int_t nmod,
+    void defineLayer(Int_t nlay, Double_t phi0, Double_t r, Int_t nladd, Int_t nmod,
                              Double_t lthick = 0., Double_t dthick = 0., UInt_t detType = 0, Int_t buildFlag = 0) override;
 
     /// Sets the layer parameters for a "turbo" layer
@@ -133,7 +132,6 @@ class Detector : public o2::Base::DetImpl<Detector>
     /// \param nlay layer number
     /// \param phi0 phi of 1st stave
     /// \param r layer radius
-    /// \param zlen layer length
     /// \param nstav number of staves
     /// \param nunit IB: number of chips per stave
     /// \param OB: number of modules per half stave
@@ -143,7 +141,7 @@ class Detector : public o2::Base::DetImpl<Detector>
     /// \param dthick detector thickness (if omitted, defaults to 0)
     /// \param dettypeID ??
     /// \param buildLevel (if 0, all geometry is build, used for material budget studies)
-    void defineLayerTurbo(Int_t nlay, Double_t phi0, Double_t r, Double_t zlen, Int_t nladd, Int_t nmod,
+    void defineLayerTurbo(Int_t nlay, Double_t phi0, Double_t r, Int_t nladd, Int_t nmod,
                                   Double_t width, Double_t tilt, Double_t lthick = 0., Double_t dthick = 0.,
                                   UInt_t detType = 0, Int_t buildFlag = 0) override;
 
@@ -151,7 +149,6 @@ class Detector : public o2::Base::DetImpl<Detector>
     /// \param nlay layer number
     /// \param phi0 phi of 1st stave
     /// \param r layer radius
-    /// \param zlen layer length
     /// \param nstav number of staves
     /// \param nmod IB: number of chips per stave
     /// \param OB: number of modules per half stave
@@ -160,7 +157,7 @@ class Detector : public o2::Base::DetImpl<Detector>
     /// \param lthick stave thickness
     /// \param dthick detector thickness
     /// \param dettype detector type
-    virtual void getLayerParameters(Int_t nlay, Double_t &phi0, Double_t &r, Double_t &zlen, Int_t &nladd, Int_t &nmod,
+    virtual void getLayerParameters(Int_t nlay, Double_t &phi0, Double_t &r, Int_t &nladd, Int_t &nmod,
                                     Double_t &width, Double_t &tilt, Double_t &lthick, Double_t &mthick,
                                     UInt_t &dettype) const;
 
@@ -280,7 +277,6 @@ class Detector : public o2::Base::DetImpl<Detector>
     Bool_t mTurboLayer[sNumberLayers];     //! True for "turbo" layers
     Double_t mLayerPhi0[sNumberLayers];    //! Vector of layer's 1st stave phi in lab
     Double_t mLayerRadii[sNumberLayers];   //! Vector of layer radii
-    Double_t mLayerZLength[sNumberLayers]; //! Vector of layer length along Z
     Int_t mStavePerLayer[sNumberLayers];   //! Vector of number of staves per layer
     Int_t mUnitPerStave[sNumberLayers];    //! Vector of number of "units" per stave
     Double_t mChipThickness[sNumberLayers];//! Vector of chip thicknesses

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/V3Layer.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/V3Layer.h
@@ -107,9 +107,14 @@ class V3Layer : public V11Geometry
       return mPhi0;
     };
 
-    Double_t getZLength() const
+    Double_t getIBModuleZLength() const
     {
-      return mZLength;
+      return mIBModuleZLength;
+    };
+
+    Double_t getOBModuleZLength() const
+    {
+      return mOBModuleZLength;
     };
 
     Int_t getChipType() const
@@ -193,11 +198,6 @@ class V3Layer : public V11Geometry
       mPhi0 = phi;
     }
 
-    void setZLength(Double_t z)
-    {
-      mZLength = z;
-    };
-
     void setChipType(Int_t tp)
     {
       mChipTypeID = tp;
@@ -242,9 +242,8 @@ class V3Layer : public V11Geometry
 
     /// Creates the IB Module: (only the chips for the time being)
     /// Returns the module as a TGeoVolume
-    /// \param xmod, ymod, zmod X, Y, Z module half lengths
     /// \param mgr The GeoManager (used only to get the proper material)
-    TGeoVolume *createModuleInnerB(Double_t x, Double_t y, Double_t z, const TGeoManager *mgr = gGeoManager);
+    TGeoVolume *createModuleInnerB(const TGeoManager *mgr = gGeoManager);
 
     /// Creates the OB Module: HIC + FPC + Carbon plate
     /// Returns the module as a TGeoVolume
@@ -266,27 +265,26 @@ class V3Layer : public V11Geometry
 
     /// Create the chip stave for the Inner Barrel(Here we fake the halfstave volume to have the
     /// same formal geometry hierarchy as for the Outer Barrel)
-    /// \param xsta, ysta, zsta X, Y, Z stave half lengths
     /// \param mgr The GeoManager (used only to get the proper material)
-    TGeoVolume *createStaveInnerB(Double_t x, Double_t y, Double_t z, const TGeoManager *mgr = gGeoManager);
+    TGeoVolume *createStaveInnerB(const TGeoManager *mgr = gGeoManager);
 
     /// Create the mechanical stave structure
     /// \param xsta X length
     /// \param zsta Z length
     /// \param mgr  The GeoManager (used only to get the proper material)
-    TGeoVolume *createStaveStructInnerB(Double_t x, Double_t z, const TGeoManager *mgr = gGeoManager);
+    TGeoVolume *createStaveStructInnerB(Double_t x, const TGeoManager *mgr = gGeoManager);
 
     /// Create a dummy stave
     /// \param xsta X length
     /// \param zsta Z length
     /// \param mgr The GeoManager (used only to get the proper material)
-    TGeoVolume *createStaveModelInnerBDummy(Double_t x, Double_t z, const TGeoManager *mgr = gGeoManager) const;
+    TGeoVolume *createStaveModelInnerBDummy(Double_t x, const TGeoManager *mgr = gGeoManager) const;
 
     /// Create the mechanical stave structure for Model 4 of TDR
     /// \param xsta X length
     /// \param zsta Z length
     /// \param mgr The GeoManager (used only to get the proper material)
-    TGeoVolume *createStaveModelInnerB4(Double_t x, Double_t z, const TGeoManager *mgr = gGeoManager);
+    TGeoVolume *createStaveModelInnerB4(Double_t x, const TGeoManager *mgr = gGeoManager);
 
     /// Create the Inner Barrel End Stave connectors
     /// \param mgr The GeoManager (used only to get the proper material)
@@ -367,7 +365,6 @@ class V3Layer : public V11Geometry
     Int_t mLayerNumber;        ///< Current layer number
     Double_t mPhi0;            ///< lab phi of 1st stave, in degrees!!!
     Double_t mLayerRadius;     ///< Inner radius of this layer
-    Double_t mZLength;         ///< Z length of this layer
     Double_t mSensorThickness; ///< Sensor thickness
     Double_t mChipThickness;   ///< Chip thickness
     Double_t mStaveWidth;      ///< Stave width (for turbo layers only)
@@ -389,6 +386,10 @@ class V3Layer : public V11Geometry
     Double_t mGammaConvDiam; ///< Gamma Conversion Rod Diameter
     Double_t mGammaConvXPos; ///< Gamma Conversion Rod X Position
 
+    // Dimensions computed during geometry build-up
+    Double_t mIBModuleZLength; ///< IB Module Length along Z
+    Double_t mOBModuleZLength; ///< OB Module Length along Z
+
     // Parameters for the  geometry
 
     // General Parameters
@@ -403,6 +404,7 @@ class V3Layer : public V11Geometry
     static const Int_t sIBNChipRows;   ///< IB chip rows in module
     static const Double_t sIBChipZGap;         ///< Gap between IB chips on Z
 
+    static const Double_t sIBModuleZLength;    ///< IB Module Length along Z
     static const Double_t sIBFPCWiderXPlus;    ///< FPC protrusion at X>0
     static const Double_t sIBFPCWiderXNeg ;    ///< FPC protrusion at X<0
     static const Double_t sIBFlexCableAlThick; ///< Thickness of FPC Aluminum
@@ -485,7 +487,7 @@ class V3Layer : public V11Geometry
     static const Double_t sOBColdPlateThick;    ///< OB Cold Plate Thickness
     static const Double_t sOBGlueThickM1;       ///< OB Glue Thickness (Model1)
     static const Double_t sOBGlueThick;         ///< OB Glue Thickness
-    static const Double_t sOBModuleZLength;     ///< OB Chip Length along Z
+    static const Double_t sOBModuleZLength;     ///< OB Module Length along Z
     static const Double_t sOBHalfStaveYPos;     ///< OB half staves Y position
     static const Double_t sOBHalfStaveYTrans;   ///< OB half staves Y transl.
     static const Double_t sOBHalfStaveXOverlap; ///< OB half staves X overlap

--- a/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
@@ -130,13 +130,11 @@ static void configITS(Detector *its) {
     nModPerStaveLr = TMath::Nint(tdr5dat[idLr][kNModPerStave]);
     int nChipsPerStaveLr = nModPerStaveLr;
     if (idLr >= kNLrInner) {
-      double modlen = nChipsPerModule*Segmentation::SensorSizeCols + (nChipsPerModule-1)*zChipGap;
-      double zlen = nModPerStaveLr*modlen + (nModPerStaveLr-1)*zModuleGap;
-      its->defineLayer(idLr, phi0, rLr, zlen, nStaveLr, nModPerStaveLr,
+      its->defineLayer(idLr, phi0, rLr, nStaveLr, nModPerStaveLr,
                        kSiThickOB, Segmentation::SensorThickness, kSensTypeID, kBuildLevel);
     } else {
       turbo = -radii2Turbo(tdr5dat[idLr][kRmn], rLr, tdr5dat[idLr][kRmx], Segmentation::SensorSizeRows);
-      its->defineLayerTurbo(idLr, phi0, rLr, nChipsPerStaveLr * Segmentation::SensorSizeCols, nStaveLr,
+      its->defineLayerTurbo(idLr, phi0, rLr, nStaveLr,
                             nChipsPerStaveLr, Segmentation::SensorSizeRows, turbo, kSiThickIB,
                             Segmentation::SensorThickness, kSensTypeID, kBuildLevel);
     }
@@ -178,7 +176,6 @@ Detector::Detector(Bool_t active)
     for (Int_t j = 0; j < sNumberLayers; j++) {
       mLayerPhi0[j] = 0;
       mLayerRadii[j] = 0.;
-      mLayerZLength[j] = 0.;
       mStavePerLayer[j] = 0;
       mUnitPerStave[j] = 0;
       mChipThickness[j] = 0.;
@@ -617,8 +614,8 @@ void Detector::defineWrapperVolume(Int_t id, Double_t rmin, Double_t rmax,
   mWrapperZSpan[id] = zspan;
 }
 
-void Detector::defineLayer(Int_t nlay, double phi0, Double_t r, Double_t zlen,
-                           Int_t nstav, Int_t nunit, Double_t lthick, Double_t dthick,
+void Detector::defineLayer(Int_t nlay, double phi0, Double_t r, Int_t nstav,
+                           Int_t nunit, Double_t lthick, Double_t dthick,
                            UInt_t dettypeID, Int_t buildLevel)
 {
   //     Sets the layer parameters
@@ -626,7 +623,6 @@ void Detector::defineLayer(Int_t nlay, double phi0, Double_t r, Double_t zlen,
   //          nlay    layer number
   //          phi0    layer phi0
   //          r       layer radius
-  //          zlen    layer length
   //          nstav   number of staves
   //          nunit   IB: number of chips per stave
   //                  OB: number of modules per half stave
@@ -639,7 +635,7 @@ void Detector::defineLayer(Int_t nlay, double phi0, Double_t r, Double_t zlen,
   // Return:
   //   none.
 
-  LOG(INFO) << "L# " << nlay << " Phi:" << phi0 << " R:" << r << " DZ:" << zlen << " Nst:" << nstav
+  LOG(INFO) << "L# " << nlay << " Phi:" << phi0 << " R:" << r << " Nst:" << nstav
             << " Nunit:" << nunit << " Lthick:" << lthick << " Dthick:" << dthick
             << " DetID:" << dettypeID << " B:" << buildLevel << FairLogger::endl;
 
@@ -651,7 +647,6 @@ void Detector::defineLayer(Int_t nlay, double phi0, Double_t r, Double_t zlen,
   mTurboLayer[nlay] = kFALSE;
   mLayerPhi0[nlay] = phi0;
   mLayerRadii[nlay] = r;
-  mLayerZLength[nlay] = zlen;
   mStavePerLayer[nlay] = nstav;
   mUnitPerStave[nlay] = nunit;
   mChipThickness[nlay] = lthick;
@@ -660,7 +655,7 @@ void Detector::defineLayer(Int_t nlay, double phi0, Double_t r, Double_t zlen,
   mBuildLevel[nlay] = buildLevel;
 }
 
-void Detector::defineLayerTurbo(Int_t nlay, Double_t phi0, Double_t r, Double_t zlen,
+void Detector::defineLayerTurbo(Int_t nlay, Double_t phi0, Double_t r,
                                 Int_t nstav, Int_t nunit, Double_t width,
                                 Double_t tilt, Double_t lthick, Double_t dthick,
                                 UInt_t dettypeID, Int_t buildLevel)
@@ -671,7 +666,6 @@ void Detector::defineLayerTurbo(Int_t nlay, Double_t phi0, Double_t r, Double_t 
   //          nlay    layer number
   //          phi0    phi of 1st stave
   //          r       layer radius
-  //          zlen    layer length
   //          nstav   number of staves
   //          nunit   IB: number of chips per stave
   //                  OB: number of modules per half stave
@@ -686,7 +680,7 @@ void Detector::defineLayerTurbo(Int_t nlay, Double_t phi0, Double_t r, Double_t 
   // Return:
   //   none.
 
-  LOG(INFO) << "L# " << nlay << " Phi:" << phi0 << " R:" << r << " DZ:" << zlen << " Nst:" << nstav
+  LOG(INFO) << "L# " << nlay << " Phi:" << phi0 << " R:" << r << " Nst:" << nstav
             << " Nunit:" << nunit << " W:" << width << " Tilt:" << tilt << " Lthick:" << lthick
             << " Dthick:" << dthick << " DetID:" << dettypeID << " B:" << buildLevel
             << FairLogger::endl;
@@ -699,7 +693,6 @@ void Detector::defineLayerTurbo(Int_t nlay, Double_t phi0, Double_t r, Double_t 
   mTurboLayer[nlay] = kTRUE;
   mLayerPhi0[nlay] = phi0;
   mLayerRadii[nlay] = r;
-  mLayerZLength[nlay] = zlen;
   mStavePerLayer[nlay] = nstav;
   mUnitPerStave[nlay] = nunit;
   mChipThickness[nlay] = lthick;
@@ -711,8 +704,8 @@ void Detector::defineLayerTurbo(Int_t nlay, Double_t phi0, Double_t r, Double_t 
 }
 
 void Detector::getLayerParameters(Int_t nlay, Double_t &phi0, Double_t &r,
-                                  Double_t &zlen, Int_t &nstav, Int_t &nmod,
-                                  Double_t &width, Double_t &tilt, Double_t &lthick,
+                                  Int_t &nstav, Int_t &nmod, Double_t &width,
+                                  Double_t &tilt, Double_t &lthick,
                                   Double_t &dthick, UInt_t &dettype) const
 {
   //     Gets the layer parameters
@@ -721,7 +714,6 @@ void Detector::getLayerParameters(Int_t nlay, Double_t &phi0, Double_t &r,
   // Outputs:
   //          phi0    phi of 1st stave
   //          r       layer radius
-  //          zlen    layer length
   //          nstav   number of staves
   //          nmod    IB: number of chips per stave
   //                  OB: number of modules per half stave
@@ -740,7 +732,6 @@ void Detector::getLayerParameters(Int_t nlay, Double_t &phi0, Double_t &r,
 
   phi0 = mLayerPhi0[nlay];
   r = mLayerRadii[nlay];
-  zlen = mLayerZLength[nlay];
   nstav = mStavePerLayer[nlay];
   nmod = mUnitPerStave[nlay];
   width = mStaveWidth[nlay];
@@ -809,10 +800,6 @@ void Detector::constructDetectorGeometry()
       LOG(FATAL) << "Wrong layer radius for layer " << j << "(" << mLayerRadii[j] << ")"
                  << FairLogger::endl;
     }
-    if (mLayerZLength[j] <= 0) {
-      LOG(FATAL) << "Wrong layer length for layer " << j << "(" << mLayerZLength[j] << ")"
-                 << FairLogger::endl;
-    }
     if (mStavePerLayer[j] <= 0) {
       LOG(FATAL) << "Wrong number of staves for layer " << j << "(" << mStavePerLayer[j] << ")"
                  << FairLogger::endl;
@@ -877,7 +864,6 @@ void Detector::constructDetectorGeometry()
 
     mGeometry[j]->setPhi0(mLayerPhi0[j]);
     mGeometry[j]->setRadius(mLayerRadii[j]);
-    mGeometry[j]->setZLength(mLayerZLength[j]);
     mGeometry[j]->setNumberOfStaves(mStavePerLayer[j]);
     mGeometry[j]->setNumberOfUnits(mUnitPerStave[j]);
     mGeometry[j]->setChipType(mChipTypeID[j]);
@@ -901,12 +887,6 @@ void Detector::constructDetectorGeometry()
     for (int iw = 0; iw < sNumberOfWrapperVolumes; iw++) {
       if (mLayerRadii[j] > mWrapperMinRadius[iw] && mLayerRadii[j] < mWrapperMaxRadius[iw]) {
         LOG(INFO) << "Will embed layer " << j << " in wrapper volume " << iw << FairLogger::endl;
-
-        if (mLayerZLength[j] >= mWrapperZSpan[iw]) {
-          LOG(FATAL) << "ZSpan " << mWrapperZSpan[iw] << " of wrapper volume " << iw
-                     << " is less than ZSpan " << mLayerZLength[j] << " of layer " << j
-                     << FairLogger::endl;
-        }
 
         dest = wrapVols[iw];
         mWrapperLayerId[j] = iw;


### PR DESCRIPTION
X and Z dimensions of many IB and OB volumes were set in different places using different static constants or passed as parameters. Though all values are not in conflict with each other, this approach could lead to inconsistencies in the long term. With the proposed changes, all dimensions are properly computed internally using the chip dimensions as building block.