### PR TITLE
Introduce ability to customize channel configuration

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -24,6 +24,8 @@ endif()
 set(SRCS
     src/BoostOptionsRetriever.cxx
     src/ConfigParamsHelper.cxx
+    src/ChannelConfigurationPolicy.cxx
+    src/ChannelConfigurationPolicyHelpers.cxx
     src/DataAllocator.cxx
     src/DataProcessingDevice.cxx
     src/DataProcessingHeader.cxx

--- a/Framework/Core/README.md
+++ b/Framework/Core/README.md
@@ -592,6 +592,27 @@ through such a channel.
 [specifyExternalFairMQDeviceProxy]: https://github.com/AliceO2Group/AliceO2/blob/dev/Framework/Core/include/Framework/ExternalFairMQDeviceProxy.h
 [rawDeviceInjectorExample]: https://github.com/AliceO2Group/AliceO2/blob/dev/Framework/TestWorkflows/src/test_RawDeviceInjector.cxx
 
+## Customizing deployment configuration (WIP)
+
+By default every device instanciated by the Data Processing Layer connects to
+the others using the PUB/SUB paradigm. This might or might not be desiderable
+for some or even all of the connections. For this reason there is now a way to
+customise the connections based on the ids of the devices being instanciated.
+
+In order to do so, one needs to implement the function
+
+    customize(std::vector<o2::framework::ChannelConfigurationPolicy> &policies)
+
+**before** including `Framework/runDataProcessing.h` (this will most likely
+change in the future). You can then extend the policies vector with your own 
+`ChannelConfigurationPolicy`. For each device to device edge, the system will
+invoke the `ChannelConfigurationPolicy::match` callback with the ids of the
+producer and of the consumer as arguments. If the callback returns `true`,
+the `ChannelConfigurationPolicy::modifyInput` and
+`ChannelConfigurationPolicy::modifyOutput` will be invoked passing the input and 
+output channel associated to the two devices, giving the opportunity to modify 
+the matching channels.
+
 ## Current Demonstrator (WIP)
 
 An demonstrator illustrating a possible implementation of the design described

--- a/Framework/Core/include/Framework/ChannelConfigurationPolicy.h
+++ b/Framework/Core/include/Framework/ChannelConfigurationPolicy.h
@@ -1,0 +1,45 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef FRAMEWORK_CHANNELCONFIGURATIONPOLICY_H
+#define FRAMEWORK_CHANNELCONFIGURATIONPOLICY_H
+
+#include <functional>
+#include "Framework/ChannelConfigurationPolicyHelpers.h"
+#include "Framework/ChannelSpec.h"
+#include "Framework/DeviceSpec.h"
+
+namespace o2
+{
+namespace framework
+{
+
+/// A ChannelConfigurationPolicy allows the user
+/// to customise connection method and type
+/// for a channel created between two devices.
+///
+///
+/// NOTE: is this a device to device decision or an
+///       input to output decision? Do we want to allow two
+///       devices to exchange different kind of data using
+///       diffent channels, with different policies?
+struct ChannelConfigurationPolicy {
+  using Helpers = ChannelConfigurationPolicyHelpers;
+
+  Helpers::PolicyMatcher match = nullptr;
+  Helpers::InputChannelModifier modifyInput = nullptr;
+  Helpers::OutputChannelModifier modifyOutput = nullptr;
+
+  static std::vector<ChannelConfigurationPolicy> createDefaultPolicies();
+};
+
+} // namespace framework
+} // namespace o2
+
+#endif // FRAMEWORK_CHANNELCONFIGURATIONPOLICY_H

--- a/Framework/Core/include/Framework/ChannelConfigurationPolicyHelpers.h
+++ b/Framework/Core/include/Framework/ChannelConfigurationPolicyHelpers.h
@@ -1,0 +1,60 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef FRAMEWORK_CHANNELCONFIGURATIONPOLICYHELPERS_H
+#define FRAMEWORK_CHANNELCONFIGURATIONPOLICYHELPERS_H
+
+#include "Framework/ChannelSpec.h"
+
+#include <functional>
+
+namespace o2
+{
+namespace framework
+{
+
+/// A set of helpers for common ChannelConfigurationPolicy behaviors
+struct ChannelConfigurationPolicyHelpers {
+  // TODO: currently we allow matching of the policy only based on
+  //       the id of the device. Best would be to be able to use the
+  //       DeviceSpec itself to do the matching. This would allow
+  //       fancy behaviors like "use shared memory if the device is on the
+  //       same node, something else if remote".
+  using PolicyMatcher = std::function<bool(std::string const& producer, std::string const& consumer)>;
+  using OutputChannelModifier = std::function<void(OutputChannelSpec& spec)>;
+  using InputChannelModifier = std::function<void(InputChannelSpec& spec)>;
+
+  /// Catch all policy, used by the last rule.
+  static PolicyMatcher matchAny;
+
+  // Example on how to write an helper which allows matching
+  // based on some DeviceSpec property.
+  ///
+  static PolicyMatcher matchByProducerName(const char* name);
+  static PolicyMatcher matchByConsumerName(const char* name);
+
+  // Some trivial modifier which can be used by the policy.
+  /// Makes the passed input channel connect and subscribe
+  static InputChannelModifier subscribeInput;
+  /// Makes the passed output channel bind and subscribe
+  static OutputChannelModifier publishOutput;
+  /// Makes the passed input channel connect and pull
+  static InputChannelModifier pullInput;
+  /// Makes the passed output channel bind and push
+  static OutputChannelModifier pushOutput;
+  /// Makes the passed input channel connect and request
+  static InputChannelModifier reqInput;
+  /// Makes the passed output channel bind and reply
+  static OutputChannelModifier replyOutput;
+};
+
+} // namespace framework
+} // namespace o2
+
+#endif // FRAMEWORK_CHANNELCONFIGURATIONPOLICY_H

--- a/Framework/Core/include/Framework/ChannelSpec.h
+++ b/Framework/Core/include/Framework/ChannelSpec.h
@@ -15,19 +15,23 @@
 namespace o2 {
 namespace framework {
 
+/// These map to zeromq connection
+/// methods.
 enum ChannelMethod {
   Bind,
   Connect
 };
 
+/// These map to zeromq types for the channels.
 enum ChannelType {
   Pub,
-  Sub
+  Sub,
+  Push,
+  Pull,
 };
 
 /// This describes an input channel. Since they are point to 
 /// point connections, there is not much to say about them.
-/// Notice that their name is always of the kind in_<output-channel name>
 struct InputChannelSpec {
   std::string name;
   enum ChannelType type;

--- a/Framework/Core/src/ChannelConfigurationPolicy.cxx
+++ b/Framework/Core/src/ChannelConfigurationPolicy.cxx
@@ -1,0 +1,28 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/ChannelConfigurationPolicy.h"
+
+namespace o2
+{
+namespace framework
+{
+
+std::vector<ChannelConfigurationPolicy> ChannelConfigurationPolicy::createDefaultPolicies()
+{
+  ChannelConfigurationPolicy defaultPolicy;
+  defaultPolicy.match = ChannelConfigurationPolicyHelpers::matchAny;
+  defaultPolicy.modifyInput = ChannelConfigurationPolicyHelpers::pullInput;
+  defaultPolicy.modifyOutput = ChannelConfigurationPolicyHelpers::pushOutput;
+  return { defaultPolicy };
+}
+
+} // namespace framework
+} // namespace o2

--- a/Framework/Core/src/ChannelConfigurationPolicyHelpers.cxx
+++ b/Framework/Core/src/ChannelConfigurationPolicyHelpers.cxx
@@ -1,0 +1,65 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/ChannelConfigurationPolicyHelpers.h"
+#include <functional>
+#include <string>
+#include "Framework/ChannelSpec.h"
+
+namespace o2
+{
+namespace framework
+{
+
+ChannelConfigurationPolicyHelpers::PolicyMatcher ChannelConfigurationPolicyHelpers::matchAny =
+  [](std::string const&, std::string const&) { return true; };
+
+ChannelConfigurationPolicyHelpers::PolicyMatcher ChannelConfigurationPolicyHelpers::matchByProducerName(
+  const char* name)
+{
+  std::string nameString = name;
+
+  return [nameString](std::string const& producerId, std::string const&) -> bool { return producerId == nameString; };
+}
+
+ChannelConfigurationPolicyHelpers::PolicyMatcher ChannelConfigurationPolicyHelpers::matchByConsumerName(
+  const char* name)
+{
+  std::string nameString = name;
+
+  return [nameString](std::string const&, std::string const& consumerId) -> bool { return consumerId == nameString; };
+}
+
+ChannelConfigurationPolicyHelpers::InputChannelModifier ChannelConfigurationPolicyHelpers::subscribeInput =
+  [](InputChannelSpec& channel) {
+    channel.method = ChannelMethod::Connect;
+    channel.type = ChannelType::Sub;
+  };
+
+ChannelConfigurationPolicyHelpers::OutputChannelModifier ChannelConfigurationPolicyHelpers::publishOutput =
+  [](OutputChannelSpec& channel) {
+    channel.method = ChannelMethod::Bind;
+    channel.type = ChannelType::Pub;
+  };
+
+ChannelConfigurationPolicyHelpers::InputChannelModifier ChannelConfigurationPolicyHelpers::pullInput =
+  [](InputChannelSpec& channel) {
+    channel.method = ChannelMethod::Connect;
+    channel.type = ChannelType::Pull;
+  };
+
+ChannelConfigurationPolicyHelpers::OutputChannelModifier ChannelConfigurationPolicyHelpers::pushOutput =
+  [](OutputChannelSpec& channel) {
+    channel.method = ChannelMethod::Bind;
+    channel.type = ChannelType::Push;
+  };
+
+} // namespace framework
+} // namespace o2

--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -9,6 +9,7 @@
 // or submit itself to any jurisdiction.
 #include "WorkflowHelpers.h"
 #include "DeviceSpecHelpers.h"
+#include "Framework/ChannelConfigurationPolicy.h"
 #include "Framework/DeviceSpec.h"
 #include "Framework/WorkflowSpec.h"
 #include "Framework/ChannelMatching.h"
@@ -33,6 +34,19 @@ namespace framework {
 
 using LogicalChannelsMap = std::map<LogicalChannel, size_t>;
 
+char const *channelTypeFromEnum(enum ChannelType type) {
+  switch (type) {
+    case Pub:
+      return "pub";
+    case Sub:
+      return "sub";
+    case Push:
+      return "push";
+    case Pull:
+      return "pull";
+  }
+}
+
 /// This creates a string to configure channels of a FairMQDevice
 /// FIXME: support shared memory
 std::string inputChannel2String(const InputChannelSpec &channel) {
@@ -41,7 +55,7 @@ std::string inputChannel2String(const InputChannelSpec &channel) {
   auto addressFormat = (channel.method == Bind ? "tcp://*:%d" : "tcp://127.0.0.1:%d");
 
   result += "name=" + channel.name + ",";
-  result += std::string("type=") + (channel.type == Pub ? "pub" : "sub") + ",";
+  result += std::string("type=") + channelTypeFromEnum(channel.type) + ",";
   result += std::string("method=") + (channel.method == Bind ? "bind" : "connect") + ",";
   result += std::string("address=") + (snprintf(buffer,32,addressFormat, channel.port), buffer);
 
@@ -54,7 +68,7 @@ std::string outputChannel2String(const OutputChannelSpec &channel) {
   auto addressFormat = (channel.method == Bind ? "tcp://*:%d" : "tcp://127.0.0.1:%d");
 
   result += "name=" + channel.name + ",";
-  result += std::string("type=") + (channel.type == Pub ? "pub" : "sub") + ",";
+  result += std::string("type=") + channelTypeFromEnum(channel.type) + ",";
   result += std::string("method=") + (channel.method == Bind ? "bind" : "connect") + ",";
   result += std::string("address=") + (snprintf(buffer,32,addressFormat, channel.port), buffer);
 
@@ -71,7 +85,8 @@ DeviceSpecHelpers::processOutEdgeActions(
       const std::vector<DeviceConnectionEdge> &logicalEdges,
       const std::vector<EdgeAction> &actions,
       const WorkflowSpec &workflow,
-      const std::vector<OutputSpec> &outputsMatchers
+      const std::vector<OutputSpec> &outputsMatchers,
+      const std::vector<ChannelConfigurationPolicy> &channelPolicies
     ) {
   // The topology cannot be empty or not connected. If that is the case, than
   // something before this went wrong.
@@ -104,18 +119,22 @@ DeviceSpecHelpers::processOutEdgeActions(
     return devices.size() - 1;
   };
 
-  auto channelFromDeviceEdgeAndPort = [&workflow]
+  auto channelFromDeviceEdgeAndPort = [&workflow,&channelPolicies]
     (const DeviceSpec &device, const DeviceConnectionEdge &edge, short port) {
     OutputChannelSpec channel;
     auto &consumer = workflow[edge.consumer];
-    std::string consumerName = workflow[edge.consumer].name;
+    std::string consumerDeviceId = consumer.name;
     if (consumer.maxInputTimeslices != 1) {
-      consumerName += "_t" + std::to_string(edge.timeIndex);
+      consumerDeviceId += "_t" + std::to_string(edge.timeIndex);
     }
-    channel.name = "from_" + device.id + "_to_" + consumerName;
-    channel.method = Bind;
-    channel.type = Pub;
+    channel.name = "from_" + device.id + "_to_" + consumerDeviceId;
     channel.port = port;
+    for (auto &policy : channelPolicies) {
+      if (policy.match(device.id, consumerDeviceId)) {
+        policy.modifyOutput(channel);
+        break;
+      }
+    }
     return std::move(channel);
   };
 
@@ -235,7 +254,8 @@ DeviceSpecHelpers::processInEdgeActions(
       const std::vector<DeviceConnectionEdge> &logicalEdges,
       const std::vector<EdgeAction> &actions,
       const WorkflowSpec &workflow,
-      std::vector<LogicalForwardInfo> const &availableForwardsInfo
+      std::vector<LogicalForwardInfo> const &availableForwardsInfo,
+      std::vector<ChannelConfigurationPolicy> const &channelPolicies
     ) {
   auto const &constDeviceIndex = deviceIndex;
 
@@ -335,15 +355,22 @@ DeviceSpecHelpers::processInEdgeActions(
     }
     return true;
   };
-  auto appendInputChannelForConsumerDevice = [&devices,&connections,&checkNoDuplicatesFor]
+  auto appendInputChannelForConsumerDevice = [&devices,
+                                              &connections,
+                                              &checkNoDuplicatesFor,
+                                              &channelPolicies]
         (size_t pi, size_t ci, int16_t port) {
     auto const &producerDevice = devices[pi];
     auto &consumerDevice = devices[ci];
     InputChannelSpec channel;
     channel.name = "from_" + producerDevice.id + "_to_" + consumerDevice.id;
-    channel.method = ChannelMethod::Connect;
-    channel.type = ChannelType::Sub;
     channel.port = port;
+    for (auto &policy : channelPolicies) {
+      if (policy.match(producerDevice.id, consumerDevice.id)) {
+        policy.modifyInput(channel);
+        break;
+      }
+    }
     assert(checkNoDuplicatesFor(consumerDevice.inputChannels, channel.name));
     consumerDevice.inputChannels.push_back(channel);
     return consumerDevice.inputChannels.size() - 1;
@@ -406,8 +433,9 @@ DeviceSpecHelpers::processInEdgeActions(
 // FIXME: make start port configurable?
 void
 DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(
-    const o2::framework::WorkflowSpec &workflow,
-    std::vector<o2::framework::DeviceSpec> &devices) {
+    WorkflowSpec const &workflow,
+    std::vector<ChannelConfigurationPolicy> const &channelPolicies,
+    std::vector<DeviceSpec> &devices) {
 
   std::vector<LogicalForwardInfo> availableForwardsInfo;
   std::vector<DeviceConnectionEdge> logicalEdges;
@@ -451,7 +479,8 @@ DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(
       logicalEdges,
       actions,
       workflow,
-      outputs
+      outputs,
+      channelPolicies
       );
 
 
@@ -471,7 +500,8 @@ DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(
       logicalEdges,
       inActions,
       workflow,
-      availableForwardsInfo
+      availableForwardsInfo,
+      channelPolicies
       );
 }
 

--- a/Framework/Core/src/DeviceSpecHelpers.h
+++ b/Framework/Core/src/DeviceSpecHelpers.h
@@ -11,6 +11,7 @@
 #define FRAMEWORK_DEVICESPECHELPERS_H
 
 #include "Framework/WorkflowSpec.h"
+#include "Framework/ChannelConfigurationPolicy.h"
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/ChannelSpec.h"
 #include "Framework/DeviceControl.h"
@@ -34,7 +35,9 @@ struct DeviceSpecHelpers {
   /// to an actual set of devices which will have to run.
   static void dataProcessorSpecs2DeviceSpecs(
       const WorkflowSpec &workflow,
-      std::vector<DeviceSpec> &devices);
+      std::vector<ChannelConfigurationPolicy> const &channelPolicies,
+      std::vector<DeviceSpec> &devices
+      );
 
   /// Helper to prepare the arguments which will be used to 
   /// start the various devices.
@@ -60,7 +63,8 @@ struct DeviceSpecHelpers {
       const std::vector<DeviceConnectionEdge> &logicalEdges,
       const std::vector<EdgeAction> &actions,
       const WorkflowSpec &workflow,
-      const std::vector<OutputSpec> &outputs
+      const std::vector<OutputSpec> &outputs,
+      std::vector<ChannelConfigurationPolicy> const &channelPolicies
   );
 
   /// This takes the list of preprocessed edges of a graph
@@ -76,7 +80,8 @@ struct DeviceSpecHelpers {
         const std::vector<DeviceConnectionEdge> &logicalEdges,
         const std::vector<EdgeAction> &actions,
         const WorkflowSpec &workflow,
-        const std::vector<LogicalForwardInfo> &availableForwardsInfo
+        const std::vector<LogicalForwardInfo> &availableForwardsInfo,
+        std::vector<ChannelConfigurationPolicy> const &channelPolicies
   );
 
   /// return a description of all options to be forwarded to the device

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -12,6 +12,7 @@
 #include "Framework/DataProcessingDevice.h"
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/DataSourceDevice.h"
+#include "Framework/ChannelConfigurationPolicy.h"
 #include "Framework/ConfigParamsHelper.h"
 #include "Framework/DebugGUI.h"
 #include "Framework/DeviceControl.h"
@@ -443,7 +444,9 @@ void handle_sigchld(int sig) {
 //     killing them all on ctrl-c).
 //   - Child, pick the data-processor ID and start a O2DataProcessorDevice for
 //     each DataProcessorSpec
-int doMain(int argc, char **argv, const o2::framework::WorkflowSpec & specs) {
+int doMain(int argc, char **argv,
+           const o2::framework::WorkflowSpec & specs,
+           std::vector<ChannelConfigurationPolicy> const &channelPolicies) {
   bpo::options_description executorOptions("Executor options");
   executorOptions.add_options()
     ((std::string("help") + ",h").c_str(),
@@ -516,7 +519,7 @@ int doMain(int argc, char **argv, const o2::framework::WorkflowSpec & specs) {
   std::vector<DeviceSpec> deviceSpecs;
 
   try {
-    DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(specs, deviceSpecs);
+    DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(specs, channelPolicies, deviceSpecs);
     // This should expand nodes so that we can build a consistent DAG.
   } catch (std::runtime_error &e) {
     std::cerr << "Invalid workflow: " << e.what() << std::endl;

--- a/Framework/Core/test/test_DeviceSpec.cxx
+++ b/Framework/Core/test/test_DeviceSpec.cxx
@@ -43,19 +43,52 @@ WorkflowSpec defineDataProcessing1() {
 
 BOOST_AUTO_TEST_CASE(TestDeviceSpec1) {
   auto workflow = defineDataProcessing1();
+  auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
+  BOOST_REQUIRE_EQUAL(channelPolicies.empty(), false);
   std::vector<DeviceSpec> devices;
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, devices);
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, devices);
   BOOST_CHECK_EQUAL(devices.size(), 2);
   BOOST_CHECK_EQUAL(devices[0].outputChannels.size(), 1);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, Bind);
-  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].type, Pub);
+  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].type, Push);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].name, "from_A_to_B");
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].port, 22000);
   BOOST_CHECK_EQUAL(devices[0].outputs.size(), 1);
 
   BOOST_CHECK_EQUAL(devices[1].inputChannels.size(), 1);
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].method, Connect);
-  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].type, Sub);
+  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].type, Pull);
+  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].name, "from_A_to_B");
+  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].port, 22000);
+
+  BOOST_CHECK_EQUAL(devices[1].inputs.size(), 1);
+  BOOST_CHECK_EQUAL(devices[1].inputs[0].sourceChannel, "from_A_to_B");
+}
+
+// Same as before, but using PUSH/PULL as policy
+BOOST_AUTO_TEST_CASE(TestDeviceSpec1PushPull) {
+  auto workflow = defineDataProcessing1();
+  ChannelConfigurationPolicy pushPullPolicy;
+  pushPullPolicy.match = ChannelConfigurationPolicyHelpers::matchAny;
+  pushPullPolicy.modifyInput = ChannelConfigurationPolicyHelpers::pullInput;
+  pushPullPolicy.modifyOutput = ChannelConfigurationPolicyHelpers::pushOutput;
+
+  std::vector<ChannelConfigurationPolicy> channelPolicies = {pushPullPolicy};
+
+  BOOST_REQUIRE_EQUAL(channelPolicies.empty(), false);
+  std::vector<DeviceSpec> devices;
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, devices);
+  BOOST_CHECK_EQUAL(devices.size(), 2);
+  BOOST_CHECK_EQUAL(devices[0].outputChannels.size(), 1);
+  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, Bind);
+  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].type, Push);
+  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].name, "from_A_to_B");
+  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].port, 22000);
+  BOOST_CHECK_EQUAL(devices[0].outputs.size(), 1);
+
+  BOOST_CHECK_EQUAL(devices[1].inputChannels.size(), 1);
+  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].method, Connect);
+  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].type, Pull);
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].name, "from_A_to_B");
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].port, 22000);
 
@@ -87,19 +120,20 @@ WorkflowSpec defineDataProcessing2() {
 
 BOOST_AUTO_TEST_CASE(TestDeviceSpec2) {
   auto workflow = defineDataProcessing2();
+  auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
   std::vector<DeviceSpec> devices;
 
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, devices);
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, devices);
   BOOST_CHECK_EQUAL(devices.size(), 2);
   BOOST_CHECK_EQUAL(devices[0].outputChannels.size(), 1);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, Bind);
-  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].type, Pub);
+  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].type, Push);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].name, "from_A_to_B");
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].port, 22000);
 
   BOOST_CHECK_EQUAL(devices[1].inputChannels.size(), 1);
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].method, Connect);
-  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].type, Sub);
+  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].type, Pull);
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].name, "from_A_to_B");
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].port, 22000);
 }
@@ -134,29 +168,30 @@ WorkflowSpec defineDataProcessing3() {
 
 BOOST_AUTO_TEST_CASE(TestDeviceSpec3) {
   auto workflow = defineDataProcessing3();
+  auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
   std::vector<DeviceSpec> devices;
 
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, devices);
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, devices);
   BOOST_CHECK_EQUAL(devices.size(), 3);
   BOOST_CHECK_EQUAL(devices[0].outputChannels.size(), 2);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, Bind);
-  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].type, Pub);
+  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].type, Push);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].name, "from_A_to_B");
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].port, 22000);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[1].method, Bind);
-  BOOST_CHECK_EQUAL(devices[0].outputChannels[1].type, Pub);
+  BOOST_CHECK_EQUAL(devices[0].outputChannels[1].type, Push);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[1].name, "from_A_to_C");
   BOOST_CHECK_EQUAL(devices[0].outputChannels[1].port, 22001);
 
   BOOST_CHECK_EQUAL(devices[1].inputChannels.size(), 1);
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].method, Connect);
-  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].type, Sub);
+  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].type, Pull);
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].name, "from_A_to_B");
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].port, 22000);
 
   BOOST_CHECK_EQUAL(devices[2].inputChannels.size(), 1);
   BOOST_CHECK_EQUAL(devices[2].inputChannels[0].method, Connect);
-  BOOST_CHECK_EQUAL(devices[2].inputChannels[0].type, Sub);
+  BOOST_CHECK_EQUAL(devices[2].inputChannels[0].type, Pull);
   BOOST_CHECK_EQUAL(devices[2].inputChannels[0].name, "from_A_to_C");
   BOOST_CHECK_EQUAL(devices[2].inputChannels[0].port, 22001);
 }
@@ -202,49 +237,50 @@ WorkflowSpec defineDataProcessing4() {
 
 BOOST_AUTO_TEST_CASE(TestDeviceSpec4) {
   auto workflow = defineDataProcessing4();
+  auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
   std::vector<DeviceSpec> devices;
 
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, devices);
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, devices);
   BOOST_CHECK_EQUAL(devices.size(), 4);
   BOOST_CHECK_EQUAL(devices[0].outputChannels.size(), 2);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, Bind);
-  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].type, Pub);
+  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].type, Push);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].name, "from_A_to_B");
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].port, 22000);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[1].method, Bind);
-  BOOST_CHECK_EQUAL(devices[0].outputChannels[1].type, Pub);
+  BOOST_CHECK_EQUAL(devices[0].outputChannels[1].type, Push);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[1].name, "from_A_to_C");
   BOOST_CHECK_EQUAL(devices[0].outputChannels[1].port, 22001);
 
   BOOST_CHECK_EQUAL(devices[1].inputChannels.size(), 1);
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].method, Connect);
-  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].type, Sub);
+  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].type, Pull);
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].name, "from_A_to_B");
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].port, 22000);
   BOOST_CHECK_EQUAL(devices[1].outputChannels.size(), 1);
   BOOST_CHECK_EQUAL(devices[1].outputChannels[0].method, Bind);
-  BOOST_CHECK_EQUAL(devices[1].outputChannels[0].type, Pub);
+  BOOST_CHECK_EQUAL(devices[1].outputChannels[0].type, Push);
   BOOST_CHECK_EQUAL(devices[1].outputChannels[0].name, "from_B_to_D");
   BOOST_CHECK_EQUAL(devices[1].outputChannels[0].port, 22002);
 
   BOOST_CHECK_EQUAL(devices[2].inputChannels.size(), 1);
   BOOST_CHECK_EQUAL(devices[2].inputChannels[0].method, Connect);
-  BOOST_CHECK_EQUAL(devices[2].inputChannels[0].type, Sub);
+  BOOST_CHECK_EQUAL(devices[2].inputChannels[0].type, Pull);
   BOOST_CHECK_EQUAL(devices[2].inputChannels[0].name, "from_A_to_C");
   BOOST_CHECK_EQUAL(devices[2].inputChannels[0].port, 22001);
   BOOST_CHECK_EQUAL(devices[2].outputChannels.size(), 1);
   BOOST_CHECK_EQUAL(devices[2].outputChannels[0].method, Bind);
-  BOOST_CHECK_EQUAL(devices[2].outputChannels[0].type, Pub);
+  BOOST_CHECK_EQUAL(devices[2].outputChannels[0].type, Push);
   BOOST_CHECK_EQUAL(devices[2].outputChannels[0].name, "from_C_to_D");
   BOOST_CHECK_EQUAL(devices[2].outputChannels[0].port, 22003);
 
   BOOST_CHECK_EQUAL(devices[3].inputChannels.size(), 2);
   BOOST_CHECK_EQUAL(devices[3].inputChannels[0].method, Connect);
-  BOOST_CHECK_EQUAL(devices[3].inputChannels[0].type, Sub);
+  BOOST_CHECK_EQUAL(devices[3].inputChannels[0].type, Pull);
   BOOST_CHECK_EQUAL(devices[3].inputChannels[0].name, "from_B_to_D");
   BOOST_CHECK_EQUAL(devices[3].inputChannels[0].port, 22002);
   BOOST_CHECK_EQUAL(devices[3].inputChannels[1].method, Connect);
-  BOOST_CHECK_EQUAL(devices[3].inputChannels[1].type, Sub);
+  BOOST_CHECK_EQUAL(devices[3].inputChannels[1].type, Pull);
   BOOST_CHECK_EQUAL(devices[3].inputChannels[1].name, "from_C_to_D");
   BOOST_CHECK_EQUAL(devices[3].inputChannels[1].port, 22003);
 }
@@ -277,29 +313,31 @@ WorkflowSpec defineDataProcessing5() {
 
 BOOST_AUTO_TEST_CASE(TestTopologyForwarding) {
   auto workflow = defineDataProcessing5();
+  auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
   std::vector<DeviceSpec> devices;
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, devices);
+
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, devices);
   BOOST_CHECK_EQUAL(devices.size(), 3);
   BOOST_CHECK_EQUAL(devices[0].outputChannels.size(), 1);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, Bind);
-  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].type, Pub);
+  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].type, Push);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].name, "from_A_to_B");
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].port, 22000);
 
   BOOST_CHECK_EQUAL(devices[1].inputChannels.size(), 1);
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].method, Connect);
-  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].type, Sub);
+  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].type, Pull);
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].name, "from_A_to_B");
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].port, 22000);
   BOOST_CHECK_EQUAL(devices[1].outputChannels.size(), 1);
   BOOST_CHECK_EQUAL(devices[1].outputChannels[0].method, Bind);
-  BOOST_CHECK_EQUAL(devices[1].outputChannels[0].type, Pub);
+  BOOST_CHECK_EQUAL(devices[1].outputChannels[0].type, Push);
   BOOST_CHECK_EQUAL(devices[1].outputChannels[0].name, "from_B_to_C");
   BOOST_CHECK_EQUAL(devices[1].outputChannels[0].port, 22001);
 
   BOOST_CHECK_EQUAL(devices[2].inputChannels.size(), 1);
   BOOST_CHECK_EQUAL(devices[2].inputChannels[0].method, Connect);
-  BOOST_CHECK_EQUAL(devices[2].inputChannels[0].type, Sub);
+  BOOST_CHECK_EQUAL(devices[2].inputChannels[0].type, Pull);
   BOOST_CHECK_EQUAL(devices[2].inputChannels[0].name, "from_B_to_C");
   BOOST_CHECK_EQUAL(devices[2].inputChannels[0].port, 22001);
 
@@ -420,6 +458,7 @@ BOOST_AUTO_TEST_CASE(TestOutEdgeProcessingHelpers) {
   };
 
   WorkflowSpec workflow = defineDataProcessing7();
+  auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
 
   DeviceSpecHelpers::processOutEdgeActions(
       devices,
@@ -430,7 +469,8 @@ BOOST_AUTO_TEST_CASE(TestOutEdgeProcessingHelpers) {
       logicalEdges,
       actions,
       workflow,
-      globalOutputs);
+      globalOutputs,
+      channelPolicies);
 
   std::vector<DeviceId> expectedDeviceIndex = {
     {0,0,0},
@@ -497,7 +537,8 @@ BOOST_AUTO_TEST_CASE(TestOutEdgeProcessingHelpers) {
     logicalEdges,
     inActions,
     workflow,
-    availableForwardsInfo
+    availableForwardsInfo,
+    channelPolicies
   );
   // 
   std::vector<DeviceId> expectedDeviceIndexFinal = {
@@ -615,7 +656,8 @@ BOOST_AUTO_TEST_CASE(TestOutEdgeProcessingHelpers) {
 BOOST_AUTO_TEST_CASE(TestTopologyLayeredTimePipeline) {
   auto workflow = defineDataProcessing7();
   std::vector<DeviceSpec> devices;
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, devices);
+  auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, devices);
   BOOST_CHECK_EQUAL(devices.size(), 6);
   BOOST_CHECK_EQUAL(devices[0].id, "A");
   BOOST_CHECK_EQUAL(devices[1].id, "B_t0");
@@ -627,89 +669,89 @@ BOOST_AUTO_TEST_CASE(TestTopologyLayeredTimePipeline) {
   BOOST_REQUIRE_EQUAL(devices[0].inputChannels.size(), 0);
   BOOST_REQUIRE_EQUAL(devices[0].outputChannels.size(), 3);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, Bind);
-  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].type, Pub);
+  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].type, Push);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].name, "from_A_to_B_t0");
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].port, 22000);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[1].method, Bind);
-  BOOST_CHECK_EQUAL(devices[0].outputChannels[1].type, Pub);
+  BOOST_CHECK_EQUAL(devices[0].outputChannels[1].type, Push);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[1].name, "from_A_to_B_t1");
   BOOST_CHECK_EQUAL(devices[0].outputChannels[1].port, 22001);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[2].method, Bind);
-  BOOST_CHECK_EQUAL(devices[0].outputChannels[2].type, Pub);
+  BOOST_CHECK_EQUAL(devices[0].outputChannels[2].type, Push);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[2].name, "from_A_to_B_t2");
   BOOST_CHECK_EQUAL(devices[0].outputChannels[2].port, 22002);
 
   BOOST_REQUIRE_EQUAL(devices[1].inputChannels.size(), 1);
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].method, Connect);
-  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].type, Sub);
+  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].type, Pull);
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].name, "from_A_to_B_t0");
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].port, 22000);
   BOOST_CHECK_EQUAL(devices[1].outputChannels.size(), 2);
   BOOST_CHECK_EQUAL(devices[1].outputChannels[0].method, Bind);
-  BOOST_CHECK_EQUAL(devices[1].outputChannels[0].type, Pub);
+  BOOST_CHECK_EQUAL(devices[1].outputChannels[0].type, Push);
   BOOST_CHECK_EQUAL(devices[1].outputChannels[0].name, "from_B_t0_to_C_t0");
   BOOST_CHECK_EQUAL(devices[1].outputChannels[0].port, 22003);
   BOOST_CHECK_EQUAL(devices[1].outputChannels[1].method, Bind);
-  BOOST_CHECK_EQUAL(devices[1].outputChannels[1].type, Pub);
+  BOOST_CHECK_EQUAL(devices[1].outputChannels[1].type, Push);
   BOOST_CHECK_EQUAL(devices[1].outputChannels[1].name, "from_B_t0_to_C_t1");
   BOOST_CHECK_EQUAL(devices[1].outputChannels[1].port, 22004);
 
   BOOST_REQUIRE_EQUAL(devices[2].inputChannels.size(), 1);
   BOOST_CHECK_EQUAL(devices[2].inputChannels[0].method, Connect);
-  BOOST_CHECK_EQUAL(devices[2].inputChannels[0].type, Sub);
+  BOOST_CHECK_EQUAL(devices[2].inputChannels[0].type, Pull);
   BOOST_CHECK_EQUAL(devices[2].inputChannels[0].name, "from_A_to_B_t1");
   BOOST_CHECK_EQUAL(devices[2].inputChannels[0].port, 22001);
   BOOST_REQUIRE_EQUAL(devices[2].outputChannels.size(), 2);
   BOOST_CHECK_EQUAL(devices[2].outputChannels[0].method, Bind);
-  BOOST_CHECK_EQUAL(devices[2].outputChannels[0].type, Pub);
+  BOOST_CHECK_EQUAL(devices[2].outputChannels[0].type, Push);
   BOOST_CHECK_EQUAL(devices[2].outputChannels[0].name, "from_B_t1_to_C_t0");
   BOOST_CHECK_EQUAL(devices[2].outputChannels[0].port, 22005);
   BOOST_CHECK_EQUAL(devices[2].outputChannels[1].method, Bind);
-  BOOST_CHECK_EQUAL(devices[2].outputChannels[1].type, Pub);
+  BOOST_CHECK_EQUAL(devices[2].outputChannels[1].type, Push);
   BOOST_CHECK_EQUAL(devices[2].outputChannels[1].name, "from_B_t1_to_C_t1");
   BOOST_CHECK_EQUAL(devices[2].outputChannels[1].port, 22006);
 
   BOOST_REQUIRE_EQUAL(devices[3].inputChannels.size(), 1);
   BOOST_CHECK_EQUAL(devices[3].inputChannels[0].method, Connect);
-  BOOST_CHECK_EQUAL(devices[3].inputChannels[0].type, Sub);
+  BOOST_CHECK_EQUAL(devices[3].inputChannels[0].type, Pull);
   BOOST_CHECK_EQUAL(devices[3].inputChannels[0].name, "from_A_to_B_t2");
   BOOST_CHECK_EQUAL(devices[3].inputChannels[0].port, 22002);
   BOOST_REQUIRE_EQUAL(devices[3].outputChannels.size(), 2);
   BOOST_CHECK_EQUAL(devices[3].outputChannels[0].method, Bind);
-  BOOST_CHECK_EQUAL(devices[3].outputChannels[0].type, Pub);
+  BOOST_CHECK_EQUAL(devices[3].outputChannels[0].type, Push);
   BOOST_CHECK_EQUAL(devices[3].outputChannels[0].name, "from_B_t2_to_C_t0");
   BOOST_CHECK_EQUAL(devices[3].outputChannels[0].port, 22007);
   BOOST_CHECK_EQUAL(devices[3].outputChannels[1].method, Bind);
-  BOOST_CHECK_EQUAL(devices[3].outputChannels[1].type, Pub);
+  BOOST_CHECK_EQUAL(devices[3].outputChannels[1].type, Push);
   BOOST_CHECK_EQUAL(devices[3].outputChannels[1].name, "from_B_t2_to_C_t1");
   BOOST_CHECK_EQUAL(devices[3].outputChannels[1].port, 22008);
 
   BOOST_REQUIRE_EQUAL(devices[4].inputChannels.size(), 3);
   BOOST_CHECK_EQUAL(devices[4].inputChannels[0].method, Connect);
-  BOOST_CHECK_EQUAL(devices[4].inputChannels[0].type, Sub);
+  BOOST_CHECK_EQUAL(devices[4].inputChannels[0].type, Pull);
   BOOST_CHECK_EQUAL(devices[4].inputChannels[0].name, "from_B_t0_to_C_t0");
   BOOST_CHECK_EQUAL(devices[4].inputChannels[0].port, 22003);
   BOOST_CHECK_EQUAL(devices[4].inputChannels[1].method, Connect);
-  BOOST_CHECK_EQUAL(devices[4].inputChannels[1].type, Sub);
+  BOOST_CHECK_EQUAL(devices[4].inputChannels[1].type, Pull);
   BOOST_CHECK_EQUAL(devices[4].inputChannels[1].name, "from_B_t1_to_C_t0");
   BOOST_CHECK_EQUAL(devices[4].inputChannels[1].port, 22005);
   BOOST_CHECK_EQUAL(devices[4].inputChannels[2].method, Connect);
-  BOOST_CHECK_EQUAL(devices[4].inputChannels[2].type, Sub);
+  BOOST_CHECK_EQUAL(devices[4].inputChannels[2].type, Pull);
   BOOST_CHECK_EQUAL(devices[4].inputChannels[2].name, "from_B_t2_to_C_t0");
   BOOST_CHECK_EQUAL(devices[4].inputChannels[2].port, 22007);
   BOOST_REQUIRE_EQUAL(devices[4].outputChannels.size(), 0);
 
   BOOST_REQUIRE_EQUAL(devices[5].inputChannels.size(), 3);
   BOOST_CHECK_EQUAL(devices[5].inputChannels[0].method, Connect);
-  BOOST_CHECK_EQUAL(devices[5].inputChannels[0].type, Sub);
+  BOOST_CHECK_EQUAL(devices[5].inputChannels[0].type, Pull);
   BOOST_CHECK_EQUAL(devices[5].inputChannels[0].name, "from_B_t0_to_C_t1");
   BOOST_CHECK_EQUAL(devices[5].inputChannels[0].port, 22004);
   BOOST_CHECK_EQUAL(devices[5].inputChannels[1].method, Connect);
-  BOOST_CHECK_EQUAL(devices[5].inputChannels[1].type, Sub);
+  BOOST_CHECK_EQUAL(devices[5].inputChannels[1].type, Pull);
   BOOST_CHECK_EQUAL(devices[5].inputChannels[1].name, "from_B_t1_to_C_t1");
   BOOST_CHECK_EQUAL(devices[5].inputChannels[1].port, 22006);
   BOOST_CHECK_EQUAL(devices[5].inputChannels[2].method, Connect);
-  BOOST_CHECK_EQUAL(devices[5].inputChannels[2].type, Sub);
+  BOOST_CHECK_EQUAL(devices[5].inputChannels[2].type, Pull);
   BOOST_CHECK_EQUAL(devices[5].inputChannels[2].name, "from_B_t2_to_C_t1");
   BOOST_CHECK_EQUAL(devices[5].inputChannels[2].port, 22008);
   BOOST_REQUIRE_EQUAL(devices[5].outputChannels.size(), 0);

--- a/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
+++ b/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
@@ -81,8 +81,9 @@ WorkflowSpec defineDataProcessing() {
 BOOST_AUTO_TEST_CASE(TestGraphviz) {
   auto workflow = defineDataProcessing();
   std::ostringstream ss{""};
+  auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
   std::vector<DeviceSpec> devices;
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, devices);
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, devices);
   char *fakeArgv[] = {strdup("foo"), nullptr};
   std::vector<DeviceControl> controls;
   std::vector<DeviceExecution> executions;

--- a/Framework/Core/test/test_Graphviz.cxx
+++ b/Framework/Core/test/test_Graphviz.cxx
@@ -113,7 +113,8 @@ BOOST_AUTO_TEST_CASE(TestGraphviz) {
   for (auto &device : devices) {
     BOOST_CHECK(device.id != "");
   }
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, devices);
+  auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, devices);
   str.str("");
   GraphvizHelpers::dumpDeviceSpec2Graphviz(str, devices);
   lineByLineComparision(str.str(), R"EXPECTED(digraph structs {
@@ -147,7 +148,8 @@ BOOST_AUTO_TEST_CASE(TestGraphvizWithPipeline) {
   for (auto &device : devices) {
     BOOST_CHECK(device.id != "");
   }
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, devices);
+  auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, devices);
   str.str("");
   GraphvizHelpers::dumpDeviceSpec2Graphviz(str, devices);
   lineByLineComparision(str.str(), R"EXPECTED(digraph structs {

--- a/Framework/Core/test/test_TimeParallelPipelining.cxx
+++ b/Framework/Core/test/test_TimeParallelPipelining.cxx
@@ -50,7 +50,8 @@ WorkflowSpec defineSimplePipelining() {
 BOOST_AUTO_TEST_CASE(TimePipeliningSimple) {
   auto workflow = defineSimplePipelining();
   std::vector<DeviceSpec> devices;
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, devices);
+  auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, devices);
   BOOST_REQUIRE_EQUAL(devices.size(), 4);
   auto &producer = devices[0];
   auto &layer0Consumer0 = devices[1];
@@ -100,7 +101,8 @@ WorkflowSpec defineDataProcessing() {
 BOOST_AUTO_TEST_CASE(TimePipeliningFull) {
   auto workflow = defineDataProcessing();
   std::vector<DeviceSpec> devices;
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, devices);
+  auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, devices);
   BOOST_REQUIRE_EQUAL(devices.size(), 7);
   auto &producer = devices[0];
   auto &layer0Consumer0 = devices[1];


### PR DESCRIPTION
This allows users to specify a set of policies on
how the FairMQ channels should be configured, e.g.
using PUSH/PULL rather than PUB/SUB.