### PR TITLE
Add support for code coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,17 @@ if (G4RUNLIB AND G3RUNLIB AND VMCLIB)
   message(STATUS "Simulation environment found")
 endif()
 
+# Build type for coverage builds
+set(CMAKE_CXX_FLAGS_COVERAGE "-g -O2 -fprofile-arcs -ftest-coverage")
+set(CMAKE_C_FLAGS_COVERAGE "${CMAKE_CXX_FLAGS_COVERAGE}")
+set(CMAKE_Fortran_FLAGS_COVERAGE "-g -O2 -fprofile-arcs -ftest-coverage")
+set(CMAKE_LINK_FLAGS_COVERAGE "--coverage -fprofile-arcs  -fPIC")
+
+MARK_AS_ADVANCED(
+    CMAKE_CXX_FLAGS_COVERAGE
+    CMAKE_C_FLAGS_COVERAGE
+    CMAKE_Fortran_FLAGS_COVERAGE
+    CMAKE_LINK_FLAGS_COVERAGE)
 
 
 #Check the compiler and set the compile and link flags


### PR DESCRIPTION
This introduces a new COVERAGE mode for CMake which will embed code coverage
information. In order to fully exploit this we need to enable it at alidist
level, e.g. by switching defaults-o2-dev-fairroot to use it and push results
to a code coverage service like codecov.io.