### PR TITLE
Revert GRP timing to time_t (chrono is not root-persistent)

### DIFF
--- a/DataFormats/Parameters/include/DataFormatsParameters/GRPObject.h
+++ b/DataFormats/Parameters/include/DataFormatsParameters/GRPObject.h
@@ -16,8 +16,8 @@
 #define ALICEO2_DATA_GRPOBJECT_H_
 
 #include <Rtypes.h>
-#include <chrono>
 #include <cstdint>
+#include <ctime>
 #include "CommonConstants/LHCConstants.h"
 #include "CommonTypes/Units.h"
 #include "DetectorsBase/DetID.h"
@@ -36,7 +36,7 @@ class GRPObject
   using beamDirection = o2::constants::lhc::BeamDirection;
 
  public:
-  using timePoint = std::chrono::system_clock::time_point;
+  using timePoint = std::time_t;
 
   GRPObject() = default;
   ~GRPObject() = default;
@@ -100,8 +100,8 @@ class GRPObject
   void print() const;
 
  private:
-  timePoint mTimeStart; ///< DAQ_time_start entry from DAQ logbook
-  timePoint mTimeEnd;   ///< DAQ_time_end entry from DAQ logbook
+  timePoint mTimeStart = 0; ///< DAQ_time_start entry from DAQ logbook
+  timePoint mTimeEnd = 0;   ///< DAQ_time_end entry from DAQ logbook
 
   o2::Base::DetID::mask_t mDetsReadout; ///< mask of detectors which are read out
   o2::Base::DetID::mask_t mDetsTrigger; ///< mask of detectors which provide trigger

--- a/DataFormats/Parameters/src/GRPObject.cxx
+++ b/DataFormats/Parameters/src/GRPObject.cxx
@@ -14,13 +14,11 @@
 
 #include "DataFormatsParameters/GRPObject.h"
 #include <cmath>
-#include <ctime>
 #include "CommonConstants/PhysicsConstants.h"
 
 using namespace o2::parameters;
 using namespace o2::constants::physics;
 using namespace o2::constants::lhc;
-using namespace std::chrono;
 using o2::Base::DetID;
 
 //_______________________________________________
@@ -46,9 +44,9 @@ void GRPObject::print() const
   // print itself
   printf("Run: %8d\nFill: %6d\nPeriod: %s\n", getRun(), getFill(), getDataPeriod().data());
   printf("LHC State: %s\n", getLHCState().data());
-  std::time_t t = system_clock::to_time_t(mTimeStart);
+  std::time_t t = mTimeStart; //system_clock::to_time_t(mTimeStart);
   printf("Start: %s", std::ctime(&t));
-  t = system_clock::to_time_t(mTimeEnd);
+  t = mTimeEnd; //system_clock::to_time_t(mTimeEnd);
   printf("End  : %s", std::ctime(&t));
   printf("Beam0: Z:A = %3d:%3d, Energy = %.3f\n", getBeamZ(BeamClockWise), getBeamA(BeamClockWise),
          getBeamEnergyPerNucleon(BeamClockWise));

--- a/macro/o2sim.C
+++ b/macro/o2sim.C
@@ -93,11 +93,25 @@ void o2sim()
   run->Init();
   gGeoManager->Export("O2geometry.root");
 
+  std::time_t runStart = std::time(nullptr);
+    
+  // runtime database
+  bool kParameterMerged = true;
+  auto rtdb = run->GetRuntimeDb();
+  auto parOut = new FairParRootFileIo(kParameterMerged);
+  parOut->open("o2sim_par.root");
+  rtdb->setOutput(parOut);
+  rtdb->saveOutput();
+  rtdb->print();
+
+  run->Run(confref.getNEvents());
 
   {
     // store GRPobject
     o2::parameters::GRPObject grp;
-    grp.setRun(run->GetRunId());  
+    grp.setRun(run->GetRunId());
+    grp.setTimeStart( runStart );
+    grp.setTimeEnd( std::time(nullptr) );
     TObjArray* modArr = run->GetListOfModules();
     TIter next(modArr);
     FairModule* module = nullptr;
@@ -126,17 +140,6 @@ void o2sim()
     grpF.WriteObjectAny(&grp,grp.Class(),"GRP");    
   }
   
-  // runtime database
-  bool kParameterMerged = true;
-  auto rtdb = run->GetRuntimeDb();
-  auto parOut = new FairParRootFileIo(kParameterMerged);
-  parOut->open("o2sim_par.root");
-  rtdb->setOutput(parOut);
-  rtdb->saveOutput();
-  rtdb->print();
-
-  run->Run(confref.getNEvents());
-
   // needed ... otherwise nothing flushed?
   delete run;
 


### PR DESCRIPTION
root does not know how to save chrono::time_point, at the moment change to time_t.
o2sim will set a GRP start/end times the actual processing times