### PR TITLE
[AOGM-212] Initial version of the EMCAL digitizer

### DIFF
--- a/Detectors/EMCAL/base/include/EMCALBase/Digit.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/Digit.h
@@ -14,7 +14,7 @@
 #include <iosfwd>
 #include <cmath>
 #include "Rtypes.h"
-#include "SimulationDataFormat/TimeStamp.h"
+#include "CommonDataFormat/TimeStamp.h"
 
 #include <boost/serialization/base_object.hpp> // for base_object
 

--- a/Detectors/EMCAL/base/include/EMCALBase/Digit.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/Digit.h
@@ -11,52 +11,63 @@
 #ifndef ALICEO2_EMCAL_DIGIT_H_
 #define ALICEO2_EMCAL_DIGIT_H_
 
-#include "FairTimeStamp.h"
-#include "Rtypes.h"
 #include <iosfwd>
+#include <cmath>
+#include "Rtypes.h"
+#include "SimulationDataFormat/TimeStamp.h"
 
-#include <boost/serialization/base_object.hpp>  // for base_object
+#include <boost/serialization/base_object.hpp> // for base_object
 
+namespace o2
+{
 
-namespace o2 {
-  namespace EMCAL {
-    
-    /// \class Digit
-    /// \brief EMCAL digit implementation
-    class Digit : public FairTimeStamp {
-    public:
-      Digit() = default;
-      
-      Digit(Int_t module, Int_t tower, Double_t amplitude, Double_t time);
-      ~Digit() override = default;
-      
-      bool operator<(const Digit &ref) const;
-      
-      Int_t GetModule() const { return mModule; }
-      
-      Int_t GetTower() const { return mTower; }
-      
-      Double_t GetAmplitude() const { return mAmplitude; }
-      
-      void SetModule(Int_t module) { mModule = module; }
-      
-      void SetTower(Int_t tower) { mTower = tower; }
-      
-      void SetAmplitude(Double_t amplitude) { mAmplitude = amplitude; }
-      
-      void PrintStream(std::ostream &stream) const;
-      
-    private:
-      friend class boost::serialization::access;
-      
-      Int_t             mModule;                ///< Supermodule index
-      Int_t             mTower;                 ///< Tower index inside supermodule
-      Double_t          mAmplitude;             ///< Amplitude
-      
-      ClassDefOverride(Digit, 1);
-    };
-    
-    std::ostream &operator<<(std::ostream &stream, const Digit &dig);
+namespace EMCAL
+{
+/// \class Digit
+/// \brief EMCAL digit implementation
+
+using DigitBase = o2::dataformats::TimeStamp<double>;
+class Digit : public DigitBase
+{
+ public:
+  Digit() = default;
+
+  Digit(Int_t tower, Double_t amplitude, Double_t time);
+  ~Digit() = default; // override
+
+  bool operator<(const Digit& other) const { return getTimeStamp() < other.getTimeStamp(); }
+  bool operator>(const Digit& other) const { return getTimeStamp() > other.getTimeStamp(); }
+
+  bool canAdd(const Digit other)
+  {
+    return (mTower == other.GetTower() && fabs(getTimeStamp() - other.getTimeStamp()) <= 25);
   }
-}
+
+  Digit& operator+=(const Digit& other);              // Adds energy of other digits to this digit.
+  friend Digit operator+(Digit lhs, const Digit& rhs) // Adds energy of two digits.
+  {
+    lhs += rhs;
+    return lhs;
+  }
+
+  Int_t GetTower() const { return mTower; }
+  void SetTower(Int_t tower) { mTower = tower; }
+
+  Double_t GetAmplitude() const { return mAmplitude; }
+  void SetAmplitude(Double_t amplitude) { mAmplitude = amplitude; }
+
+  void PrintStream(std::ostream& stream) const;
+
+ private:
+  friend class boost::serialization::access;
+
+  Int_t mTower;        ///< Tower index (absolute cell ID)
+  Double_t mAmplitude; ///< Amplitude
+
+  ClassDefNV(Digit, 1);
+};
+
+std::ostream& operator<<(std::ostream& stream, const Digit& dig);
+} // namespace EMCAL
+} // namespace o2
 #endif

--- a/Detectors/EMCAL/base/src/Digit.cxx
+++ b/Detectors/EMCAL/base/src/Digit.cxx
@@ -8,30 +8,33 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#include <iostream>
 #include "EMCALBase/Digit.h"
+#include <iostream>
 
 using namespace o2::EMCAL;
 
 ClassImp(Digit)
 
-Digit::Digit(Int_t module, Int_t tower, Double_t amplitude, Double_t time):
-FairTimeStamp(time),
-mModule(module),
-mTower(tower),
-mAmplitude(amplitude)
+  Digit::Digit(Int_t tower, Double_t amplitude, Double_t time)
+  : DigitBase(time), mTower(tower), mAmplitude(amplitude)
 {
 }
 
-bool Digit::operator<(const Digit &other) const {
-  return GetTimeStamp() < other.GetTimeStamp();
+Digit& Digit::operator+=(const Digit& other)
+{
+  if (canAdd(other))
+    mAmplitude += other.GetAmplitude();
+  // Does nothing if the digits are in different towers.
+  return *this;
 }
 
-void Digit::PrintStream(std::ostream &stream) const {
-  stream << "EMCAL Digit: Module " << mModule <<", Tower " << mTower << ", Time " << GetTimeStamp() << " wiht amplitude " << mAmplitude;
+void Digit::PrintStream(std::ostream& stream) const
+{
+  stream << "EMCAL Digit: Tower " << mTower << ", Time " << getTimeStamp() << " with amplitude " << mAmplitude;
 }
 
-std::ostream& operator<<(std::ostream &stream, const Digit &digi){
+std::ostream& operator<<(std::ostream& stream, const Digit& digi)
+{
   digi.PrintStream(stream);
   return stream;
 }

--- a/Detectors/EMCAL/simulation/CMakeLists.txt
+++ b/Detectors/EMCAL/simulation/CMakeLists.txt
@@ -4,11 +4,15 @@ O2_SETUP(NAME ${MODULE_NAME})
 
 set(SRCS
   src/Detector.cxx
+  src/Digitizer.cxx
+  src/DigitizerTask.cxx
   src/SpaceFrame.cxx
 )
 
 set(HEADERS
   include/EMCALSimulation/Detector.h
+  include/EMCALSimulation/Digitizer.h
+  include/EMCALSimulation/DigitizerTask.h
   include/EMCALSimulation/SpaceFrame.h
 )
 

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/Digitizer.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/Digitizer.h
@@ -1,0 +1,82 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_EMCAL_DIGITIZER_H
+#define ALICEO2_EMCAL_DIGITIZER_H
+
+#include <memory>
+#include <unordered_map>
+#include <vector>
+#include <deque>
+
+#include "Rtypes.h"  // for Digitizer::Class, Double_t, ClassDef, etc
+#include "TObject.h" // for TObject
+
+#include "EMCALBase/Digit.h"
+#include "EMCALBase/Geometry.h"
+#include "EMCALBase/GeometryBase.h"
+#include "EMCALBase/Hit.h"
+
+namespace o2
+{
+namespace EMCAL
+{
+class Digitizer : public TObject
+{
+ public:
+  Digitizer() = default;
+  ~Digitizer() override = default;
+  Digitizer(const Digitizer&) = delete;
+  Digitizer& operator=(const Digitizer&) = delete;
+
+  void init();
+  void finish();
+
+  /// Steer conversion of hits to digits
+  void process(const std::vector<Hit>& hits, std::vector<Digit>& digits);
+
+  void setEventTime(double t);
+  double getEventTime() const { return mEventTime; }
+
+  void setContinuous(bool v) { mContinuous = v; }
+  bool isContinuous() const { return mContinuous; }
+  void fillOutputContainer(std::vector<Digit>& digits);
+
+  void setCoeffToNanoSecond(double cf) { mCoeffToNanoSecond = cf; }
+  double getCoeffToNanoSecond() const { return mCoeffToNanoSecond; }
+
+  void setCurrSrcID(int v);
+  int getCurrSrcID() const { return mCurrSrcID; }
+
+  void setCurrEvID(int v);
+  int getCurrEvID() const { return mCurrEvID; }
+
+  void setGeometry(const o2::EMCAL::Geometry* gm) { mGeometry = gm; }
+
+  Digit hitToDigit(const Hit& hit);
+
+ private:
+  const Geometry* mGeometry = nullptr; // EMCAL geometry
+  double mEventTime = 0;               ///< global event time
+  double mCoeffToNanoSecond = 1.0;     ///< coefficient to convert event time (Fair) to ns
+  bool mContinuous = false;            ///< flag for continuous simulation
+  UInt_t mROFrameMin = 0;              ///< lowest RO frame of current digits
+  UInt_t mROFrameMax = 0;              ///< highest RO frame of current digits
+  int mCurrSrcID = 0;                  ///< current MC source from the manager
+  int mCurrEvID = 0;                   ///< current event ID from the manager
+
+  std::unordered_map<Int_t, std::deque<Digit>> mDigits; ///< used to sort digits by tower
+
+  ClassDefOverride(Digitizer, 1);
+};
+} // namespace EMCAL
+} // namespace o2
+
+#endif /* ALICEO2_EMCAL_DIGITIZER_H */

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/DigitizerTask.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/DigitizerTask.h
@@ -1,0 +1,54 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_EMCAL_DIGITIZERTASK_H
+#define ALICEO2_EMCAL_DIGITIZERTASK_H
+
+#include <cstdio>
+#include "FairTask.h" // for FairTask, InitStatus
+#include "Rtypes.h"   // for DigitizerTask::Class, ClassDef, etc
+
+#include "EMCALBase/Hit.h"
+#include "EMCALSimulation/Digitizer.h"
+
+namespace o2
+{
+namespace EMCAL
+{
+class DigitizerTask : public FairTask
+{
+ public:
+  DigitizerTask();
+  ~DigitizerTask() override;
+
+  InitStatus Init() override;
+
+  void Exec(Option_t* option) override;
+  void FinishTask() override;
+
+  Digitizer& getDigitizer() { return mDigitizer; }
+
+  void setFairTimeUnitInNS(double tinNS) { mFairTimeUnitInNS = tinNS < 1. ? 1. : tinNS; }
+  double getFairTimeUnitInNS() const { return mFairTimeUnitInNS; }
+
+ private:
+  double mFairTimeUnitInNS = 1;                 ///< Fair time unit in ns
+  Int_t mSourceID = 0;                          ///< current source
+  Int_t mEventID = 0;                           ///< current event id from the source
+  Digitizer mDigitizer;                         ///< Digitizer
+  const std::vector<Hit>* mHitsArray = nullptr; ///< Array of MC hits
+  std::vector<Digit>* mDigitsArray = nullptr;   ///< Array of digits
+
+  ClassDefOverride(DigitizerTask, 1);
+};
+} // namespace EMCAL
+} // namespace o2
+
+#endif /* ALICEO2_EMCAL_DIGITIZERTASK_H */

--- a/Detectors/EMCAL/simulation/src/Digitizer.cxx
+++ b/Detectors/EMCAL/simulation/src/Digitizer.cxx
@@ -1,0 +1,130 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "EMCALSimulation/Digitizer.h"
+#include "EMCALBase/Digit.h"
+#include "EMCALBase/Geometry.h"
+#include "EMCALBase/GeometryBase.h"
+#include "EMCALBase/Hit.h"
+#include "MathUtils/Cartesian3D.h"
+#include "SimulationDataFormat/MCCompLabel.h"
+
+#include <TRandom.h>
+#include <climits>
+#include <forward_list>
+#include "FairLogger.h" // for LOG
+
+ClassImp(o2::EMCAL::Digitizer);
+
+using o2::EMCAL::Digit;
+using o2::EMCAL::Hit;
+
+using namespace o2::EMCAL;
+
+//_______________________________________________________________________
+void Digitizer::init() {}
+
+//_______________________________________________________________________
+void Digitizer::finish() {}
+
+//_______________________________________________________________________
+void Digitizer::process(const std::vector<Hit>& hits, std::vector<Digit>& digits)
+{
+  digits.clear();
+  mDigits.clear();
+
+  for (auto hit : hits) {
+    Digit digit = hitToDigit(hit);
+    Int_t id = digit.GetTower();
+
+    if (id < 0 || id > mGeometry->GetNCells()) {
+      LOG(WARNING) << "tower index out of range: " << id << FairLogger::endl;
+      continue;
+    }
+
+    Bool_t flag = false;
+    for (auto& digit0 : mDigits[id]) {
+      if (digit0.canAdd(digit)) {
+        digit0 += digit;
+        flag = true;
+        break;
+      }
+    }
+
+    if (!flag) {
+      mDigits[id].push_front(digit);
+    }
+  }
+
+  fillOutputContainer(digits);
+}
+
+//_______________________________________________________________________
+o2::EMCAL::Digit Digitizer::hitToDigit(const Hit& hit)
+{
+  Point3D<double> pos(hit.GetX(), hit.GetY(), hit.GetZ());
+  Int_t tower = mGeometry->GetAbsCellIdFromEtaPhi(pos.Eta(), pos.Phi());
+  Double_t amplitude = hit.GetEnergyLoss();
+  Digit digit(tower, amplitude, mEventTime);
+  return digit;
+}
+
+//_______________________________________________________________________
+void Digitizer::setEventTime(double t)
+{
+  // assign event time, it should be in a strictly increasing order
+  // convert to ns
+  t *= mCoeffToNanoSecond;
+
+  if (t < mEventTime && mContinuous) {
+    LOG(FATAL) << "New event time (" << t << ") is < previous event time (" << mEventTime << ")" << FairLogger::endl;
+  }
+  mEventTime = t;
+}
+
+//_______________________________________________________________________
+void Digitizer::fillOutputContainer(std::vector<Digit>& digits)
+{
+  std::forward_list<Digit> l;
+
+  for (auto tower : mDigits) {
+    for (auto& digit : tower.second) {
+      l.push_front(digit);
+    }
+  }
+
+  l.sort();
+
+  for (auto digit : l) {
+    digits.push_back(digit);
+  }
+}
+
+//_______________________________________________________________________
+void Digitizer::setCurrSrcID(int v)
+{
+  // set current MC source ID
+  if (v > MCCompLabel::maxSourceID()) {
+    LOG(FATAL) << "MC source id " << v << " exceeds max storable in the label " << MCCompLabel::maxSourceID()
+               << FairLogger::endl;
+  }
+  mCurrSrcID = v;
+}
+
+//_______________________________________________________________________
+void Digitizer::setCurrEvID(int v)
+{
+  // set current MC event ID
+  if (v > MCCompLabel::maxEventID()) {
+    LOG(FATAL) << "MC event id " << v << " exceeds max storable in the label " << MCCompLabel::maxEventID()
+               << FairLogger::endl;
+  }
+  mCurrEvID = v;
+}

--- a/Detectors/EMCAL/simulation/src/DigitizerTask.cxx
+++ b/Detectors/EMCAL/simulation/src/DigitizerTask.cxx
@@ -1,0 +1,99 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "EMCALSimulation/DigitizerTask.h"
+#include "EMCALBase/Geometry.h"
+#include "EMCALBase/GeometryBase.h"
+#include "EMCALBase/Hit.h"
+#include "EMCALSimulation/Digitizer.h"
+
+#include "FairLogger.h"      // for LOG
+#include "FairRootManager.h" // for FairRootManager
+#include "FairTask.h"        // for FairTask, InitStatus
+#include "Rtypes.h"          // for DigitizerTask::Class, ClassDef, etc
+
+ClassImp(o2::EMCAL::DigitizerTask);
+
+using o2::EMCAL::Digit;
+using o2::EMCAL::Digitizer;
+using o2::EMCAL::Hit;
+
+using namespace o2::EMCAL;
+
+DigitizerTask::DigitizerTask() : FairTask("EMCALDigitizerTask"), mDigitizer() {}
+
+DigitizerTask::~DigitizerTask()
+{
+  if (mDigitsArray) {
+    mDigitsArray->clear();
+    delete mDigitsArray;
+  }
+}
+
+/// \brief Init function
+///
+/// Inititializes the digitizer and connects input and output container
+InitStatus DigitizerTask::Init()
+{
+  FairRootManager* mgr = FairRootManager::Instance();
+  if (!mgr) {
+    LOG(ERROR) << "Could not instantiate FairRootManager. Exiting ..." << FairLogger::endl;
+    return kERROR;
+  }
+
+  mHitsArray = mgr->InitObjectAs<const std::vector<o2::EMCAL::Hit>*>("EMCALHit");
+  if (!mHitsArray) {
+    LOG(ERROR) << "EMCAL hits not registered in the FairRootManager. Exiting ..." << FairLogger::endl;
+    return kERROR;
+  }
+
+  // Register output container
+  mgr->RegisterAny("EMCALDigit", mDigitsArray, kTRUE);
+
+  mDigitizer.setCoeffToNanoSecond(mFairTimeUnitInNS);
+
+  Geometry* geom = Geometry::GetInstance();
+  mDigitizer.setGeometry(geom);
+
+  mDigitizer.init();
+
+  return kSUCCESS;
+}
+
+//________________________________________________________
+void DigitizerTask::Exec(Option_t* option)
+{
+  FairRootManager* mgr = FairRootManager::Instance();
+
+  if (mDigitsArray)
+    mDigitsArray->clear();
+  mDigitizer.setEventTime(mgr->GetEventTime());
+
+  LOG(DEBUG) << "Running digitization on new event " << mEventID << " from source " << mSourceID << FairLogger::endl;
+
+  mDigitizer.setCurrSrcID(mSourceID);
+  mDigitizer.setCurrEvID(mEventID);
+
+  mDigitizer.process(*mHitsArray, *mDigitsArray);
+
+  mEventID++;
+}
+
+//________________________________________________________
+void DigitizerTask::FinishTask()
+{
+  // finalize digitization, if needed, flash remaining digits
+  FairRootManager* mgr = FairRootManager::Instance();
+  mgr->SetLastFill(kTRUE); /// necessary, otherwise the data is not written out
+  if (mDigitsArray)
+    mDigitsArray->clear();
+  // mDigitizer.fillOutputContainer(mDigitsArray);
+  mDigitizer.finish();
+}

--- a/Detectors/EMCAL/simulation/src/EMCALSimulationLinkDef.h
+++ b/Detectors/EMCAL/simulation/src/EMCALSimulationLinkDef.h
@@ -16,5 +16,7 @@
 
 #pragma link C++ class o2::EMCAL::Detector+;
 #pragma link C++ class o2::Base::DetImpl<o2::EMCAL::Detector>+;
+#pragma link C++ class o2::EMCAL::Digitizer+;
+#pragma link C++ class o2::EMCAL::DigitizerTask+;
 
 #endif


### PR DESCRIPTION
Modified Digit class: stores absolute cell ID, introduction of + += < and > operators
Introduced Digitizer class: converts Hits to Digits, addes Digits in the same tower and time window, fills output vector of Digits
Introduced DigitizerTask class: interacts with analysis manager, gets vector of Hits, uses Digitizer to convert to vector of Digits
Modified simulation/CMakeLists.txt and simulation/src/EMCALSimulationLinkDef.h files to account for the new classes