### PR TITLE
Allow random appending of labels into MCTruthContainer

### DIFF
--- a/DataFormats/simulation/test/testMCTruthContainer.cxx
+++ b/DataFormats/simulation/test/testMCTruthContainer.cxx
@@ -66,4 +66,39 @@ BOOST_AUTO_TEST_CASE(MCTruth)
   BOOST_CHECK(view[0] == 10);
 }
 
+BOOST_AUTO_TEST_CASE(MCTruth_RandomAccess)
+{
+  using TruthElement = long;
+  dataformats::MCTruthContainer<TruthElement> container;
+  container.addElementRandomAccess(0, TruthElement(1));
+  container.addElementRandomAccess(0, TruthElement(2));
+  container.addElementRandomAccess(1, TruthElement(1));
+  container.addElementRandomAccess(2, TruthElement(10));
+  container.addElementRandomAccess(1, TruthElement(5));
+  container.addElementRandomAccess(0, TruthElement(5));
+  // add element at end
+  container.addElement(3, TruthElement(20));
+  container.addElement(3, TruthElement(21));
+
+  // check header/index information
+  BOOST_CHECK(container.getMCTruthHeader(0).index == 0);
+  BOOST_CHECK(container.getMCTruthHeader(1).index == 3);
+  BOOST_CHECK(container.getMCTruthHeader(2).index == 5);
+  BOOST_CHECK(container.getMCTruthHeader(3).index == 6);
+
+  // get iterable container view on labels
+  {
+    auto view = container.getLabels(1);
+    BOOST_CHECK(view.size() == 2);
+    BOOST_CHECK(view[0] == 1);
+    BOOST_CHECK(view[1] == 5);
+  }
+
+  {
+    auto view = container.getLabels(3);
+    BOOST_CHECK(view.size() == 2);
+    BOOST_CHECK(view[0] == 20);
+    BOOST_CHECK(view[1] == 21);
+  }
+}
 } // end namespace


### PR DESCRIPTION
Providing a function to allow appending
element/labels for abitrary valid dataindices.
Note that the new functions is slow and should only be
used when absolutely required.

Previously it was only possible to append elements
for the last dataindex.