### PR TITLE
Update to TPCCATracking

### DIFF
--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/HardwareClusterDecoder.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/HardwareClusterDecoder.h
@@ -38,7 +38,7 @@ public:
   static void sortClustersAndMC(std::vector<o2::DataFormat::TPC::ClusterNative> clusters, o2::dataformats::MCTruthContainer<o2::MCCompLabel> mcTruth);
 
 private:
-  DigitalCurrentClusterIntegrator mIntegrator;
+  std::unique_ptr<DigitalCurrentClusterIntegrator> mIntegrator;
 };
 
 }}

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/TrackTPC.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/TrackTPC.h
@@ -55,12 +55,17 @@ class TrackTPC :public o2::Base::Track::TrackParCov {
     /// \return mean energy loss
     float getTruncatedMean(float low=0.05, float high=0.7, int type=1, int removeRows=0, int *nclPID=nullptr) const;
     
-    float getTime0() const {return mTime0;}
+    float getTime0() const {return mTime0;} //Reference time of the track, i.e. timebins of a primary track with eta=0.
+    float getTimeVertex(float vDrift) const; //Absolute time of the vertex assumed for the track, shifted by time0 by one drift time.
     float getLastClusterZ() const {return mLastClusterZ;}
     Side getSide() const {return (Side) mSide;}
+    float getChi2() const {return mChi2;}
+    const o2::Base::Track::TrackParCov& getOuterParam() const {return mOuterParam;}
     void setTime0(float v) {mTime0 = v;}
     void setLastClusterZ(float v) {mLastClusterZ = v;}
     void setSide(Side v) {mSide = v;}
+    void setChi2(float v) {mChi2 = v;}
+    void setOuterParam(o2::Base::Track::TrackParCov&& v) {mOuterParam = v;}
     
     void resetClusterReferences(int nClusters);
     int getNClusterReferences() {return mNClusters;}
@@ -88,7 +93,9 @@ class TrackTPC :public o2::Base::Track::TrackParCov {
     std::vector<Cluster> mClusterVector;
     float mTime0 = 0.f; //Reference Z of the track assumed for the vertex, scaled with pseudo VDrift and reference timeframe length.
     float mLastClusterZ = 0.f; //Z position of last cluster
-    char mSide = Side::UNDEFINED;
+    char mSide = Side::UNDEFINED; //TPC Side (A or C) where the track is located (seeding start of the track for those crossing the central electrode)
+    float mChi2 = 0.f; //Chi2 of the track
+    o2::Base::Track::TrackParCov mOuterParam; //Track parameters at outer end of TPC.
     
     //New structure to store cluster references
     int mNClusters = 0;

--- a/Detectors/TPC/reconstruction/src/HardwareClusterDecoder.cxx
+++ b/Detectors/TPC/reconstruction/src/HardwareClusterDecoder.cxx
@@ -35,6 +35,7 @@ using MCLabelContainer = MCTruthContainer<MCCompLabel>;
 
 int HardwareClusterDecoder::decodeClusters(std::vector<std::pair<const ClusterHardwareContainer*, std::size_t>>& inputClusters, std::vector<ClusterNativeContainer>& outputClusters, const std::vector<MCLabelContainer>* inMCLabels, std::vector<MCLabelContainer>* outMCLabels)
 {
+  if (mIntegrator == nullptr) mIntegrator.reset(new DigitalCurrentClusterIntegrator);
   if (!inMCLabels) outMCLabels = nullptr;
   int nRowClusters[Constants::MAXSECTOR][Constants::MAXGLOBALPADROW] = {0};
   int containerRowCluster[Constants::MAXSECTOR][Constants::MAXGLOBALPADROW] =  {0};
@@ -76,7 +77,7 @@ int HardwareClusterDecoder::decodeClusters(std::vector<std::pair<const ClusterHa
             cOut.setSigmaTime(std::sqrt(cIn.getSigmaTime2()));
             cOut.qMax = cIn.qMax;
             cOut.qTot = cIn.qTot;
-            mIntegrator.integrateCluster(sector, padRowGlobal, pad, cIn.qTot);
+            mIntegrator->integrateCluster(sector, padRowGlobal, pad, cIn.qTot);
             if (outMCLabels)
             {
               for (const auto& element : (*inMCLabels)[i].getLabels(k)) {
@@ -121,7 +122,7 @@ int HardwareClusterDecoder::decodeClusters(std::vector<std::pair<const ClusterHa
           outputClusters[numberOfOutputContainers].sector = i;
           outputClusters[numberOfOutputContainers].globalPadRow = j;
           containerRowCluster[i][j] = numberOfOutputContainers++;
-          mIntegrator.initRow(i, j);
+          mIntegrator->initRow(i, j);
         }
       }
       memset(nRowClusters, 0, sizeof(nRowClusters));

--- a/Detectors/TPC/reconstruction/src/TPCCATracking.cxx
+++ b/Detectors/TPC/reconstruction/src/TPCCATracking.cxx
@@ -214,17 +214,17 @@ int TPCCATracking::runTracking(const ClusterNativeAccessFullTPC& clusters, std::
   {
     std::vector<std::pair<int, float>> trackSort(nTracks);
     int tmp = 0, tmp2 = 0;
-    for (char side = 0;side < 2;side++)
+    for (char cside = 0;cside < 2;cside++)
     {
       for (int i = 0;i < nTracks;i++)
       {
-        if (tracks[i].OK() && tracks[i].Side() == side) trackSort[tmp++] = {i, (side == 0 ? -1.f : 1.f) * tracks[i].GetParam().GetZOffset()};
+        if (tracks[i].OK() && tracks[i].CSide() == cside) trackSort[tmp++] = {i, (cside == 0 ? 1.f : -1.f) * tracks[i].GetParam().GetZOffset()};
       }
       std::sort(trackSort.data() + tmp2, trackSort.data() + tmp, [](const auto& a, const auto& b) {
         return(a.second > b.second);
       });
       tmp2 = tmp;
-      if (side == 0) mNTracksASide = tmp;
+      if (cside == 0) mNTracksASide = tmp;
     }
     nTracks = tmp;
     
@@ -245,7 +245,7 @@ int TPCCATracking::runTracking(const ClusterNativeAccessFullTPC& clusters, std::
       if (!mTrackingCAO2Interface->GetParamContinuous())
         oTrack.setTime0(0);
       else
-        oTrack.setTime0(sContinuousTFReferenceLength - (tracks[i].Side() ? 1.f : -1.f) * tracks[i].GetParam().GetZOffset() / (elParam.getZBinWidth() * gasParam.getVdrift()));
+        oTrack.setTime0(sContinuousTFReferenceLength - (tracks[i].CSide() ? -1.f : 1.f) * tracks[i].GetParam().GetZOffset() / (elParam.getZBinWidth() * gasParam.getVdrift()));
       oTrack.setLastClusterZ(trackClusters[tracks[i].FirstClusterRef()].fZ - tracks[i].GetParam().GetZOffset());
       oTrack.resetClusterReferences(tracks[i].NClusters());
       std::vector<std::pair<MCCompLabel, unsigned int>> labels;
@@ -289,7 +289,7 @@ int TPCCATracking::runTracking(const ClusterNativeAccessFullTPC& clusters, std::
         outputTracksMCTruth->addElement(iTmp, bestLabel);
       }
       int lastSector = trackClusters[tracks[i].FirstClusterRef() + tracks[i].NClusters() - 1].fId >> 24;
-      oTrack.setSide((Side) tracks[i].Side());
+      oTrack.setSide((Side) tracks[i].CSide());
     }
   }
   mTrackingCAO2Interface->Cleanup();

--- a/Detectors/TPC/reconstruction/src/TPCCATracking.cxx
+++ b/Detectors/TPC/reconstruction/src/TPCCATracking.cxx
@@ -175,7 +175,7 @@ int TPCCATracking::runTracking(const ClusterNativeAccessFullTPC& clusters, std::
         const int padNumber = int(padY);
         const GlobalPadNumber pad = mapper.globalPadNumber(PadPos(j, padNumber));
         const PadCentre& padCentre = mapper.padCentre(pad);
-        const float localY = padCentre.Y() - (padY - padNumber - 0.5) * region.getPadWidth();
+        const float localY = padCentre.Y() - (padY - padNumber) * region.getPadWidth();
         const float localYfactor = (cru.side() == Side::A) ? -1.f : 1.f;
         float zPositionAbs = cluster.getTime()*elParam.getZBinWidth() * gasParam.getVdrift();
         if (!mTrackingCAO2Interface->GetParamContinuous())

--- a/Detectors/TPC/reconstruction/src/TPCCATracking.cxx
+++ b/Detectors/TPC/reconstruction/src/TPCCATracking.cxx
@@ -244,9 +244,17 @@ int TPCCATracking::runTracking(const ClusterNativeAccessFullTPC& clusters, std::
           
       if (!mTrackingCAO2Interface->GetParamContinuous())
         oTrack.setTime0(0);
-      else
-        oTrack.setTime0(sContinuousTFReferenceLength - (tracks[i].CSide() ? -1.f : 1.f) * tracks[i].GetParam().GetZOffset() / (elParam.getZBinWidth() * gasParam.getVdrift()));
+      else {
+        float zoffset = tracks[i].CSide() ?  -tracks[i].GetParam().GetZOffset() : tracks[i].GetParam().GetZOffset();
+        oTrack.setTime0(sContinuousTFReferenceLength - zoffset / (elParam.getZBinWidth() * gasParam.getVdrift()));
+      }
       oTrack.setLastClusterZ(trackClusters[tracks[i].FirstClusterRef()].fZ - tracks[i].GetParam().GetZOffset());
+      oTrack.setChi2(tracks[i].GetParam().GetChi2());
+      auto& outerPar = tracks[i].GetParam().OuterParam();
+      oTrack.setOuterParam(o2::Base::Track::TrackParCov(outerPar.fX, outerPar.fAlpha,
+        {outerPar.fP[0], outerPar.fP[1], outerPar.fP[2], outerPar.fP[3], outerPar.fP[4]},
+        {outerPar.fC[0], outerPar.fC[1], outerPar.fC[2], outerPar.fC[3], outerPar.fC[4], outerPar.fC[5], outerPar.fC[6], outerPar.fC[7],
+        outerPar.fC[8], outerPar.fC[9], outerPar.fC[10], outerPar.fC[11], outerPar.fC[12], outerPar.fC[13], outerPar.fC[14]}));
       oTrack.resetClusterReferences(tracks[i].NClusters());
       std::vector<std::pair<MCCompLabel, unsigned int>> labels;
       for (int j = 0; j < tracks[i].NClusters(); j++) {

--- a/Detectors/TPC/reconstruction/src/TrackTPC.cxx
+++ b/Detectors/TPC/reconstruction/src/TrackTPC.cxx
@@ -13,6 +13,9 @@
 /// \author Thomas Klemenz, TU Muenchen, thomas.klemenz@tum.de
 
 #include "TPCReconstruction/TrackTPC.h"
+#include "TPCBase/ParameterDetector.h"
+#include "TPCBase/ParameterGas.h"
+#include "TPCBase/ParameterElectronics.h"
 
 using namespace o2::TPC;
 
@@ -52,4 +55,11 @@ void TrackTPC::resetClusterReferences(int nClusters)
 {
   mNClusters = nClusters;
   mClusterReferences.resize(nClusters + (nClusters + 1) / 2);
+}
+
+float TrackTPC::getTimeVertex(float vDrift) const
+{
+  //TODO: This is currently quite inefficient! Should be solved by making all these defaultInstance() functions constexpr or so. On could then also think about moving this into TrackTPC.h
+  //For the time, it provides the required functionality.
+  return mTime0 - ParameterDetector::defaultInstance().getTPClength() / vDrift;
 }


### PR DESCRIPTION
- fix shift in cluster coordinates
- add chi2 / vertex time / outerparam
- unify TPC side definition between o2 and standalone tracking library
- compatibility fix for root 6 with gcc 7
The "Side" variable (1 for A, 0 for C) from the standalone library has been replaced by a new CSide variable (1 for C, 0 for A), which is the same numbering as in other TPC / O2 code.
In order to not simply negate the Side variable, which could cause some confusion, I introduced the new CSide getter. This patch adapts O2 to the new interface of the standalone library. The old Side getter will be removed thereafter.