### PR TITLE
Use LOG(INFO), rather than std::cout for commands

### DIFF
--- a/Framework/Core/src/TextControlService.cxx
+++ b/Framework/Core/src/TextControlService.cxx
@@ -22,13 +22,11 @@ void TextControlService::readyToQuit(bool all) {
     return;
   }
   mOnce = true;
-  std::cout << "CONTROL_ACTION: READY_TO_QUIT";
   if (all) {
-    std::cout << "_ALL";
+    LOG(INFO) << "CONTROL_ACTION: READY_TO_QUIT_ALL";
   } else {
-    std::cout << "_ME";
+    LOG(INFO) << "CONTROL_ACTION: READY_TO_QUIT_ME";
   }
-  std::cout << std::endl;
 }
 
 bool parseControl(const std::string &s, std::smatch &match) {


### PR DESCRIPTION
The current implementation of the driver has a naive way
of sending control requests from the child to the parent
via std::cout. It seems possible that sometimes this
is garbled by the actual Logger output, so I use the
Logger for the commands themselves assuming messages there
are atomic.