### PR TITLE
Add context to documentation

### DIFF
--- a/Detectors/ITSMFT/MFT/base/README.md
+++ b/Detectors/ITSMFT/MFT/base/README.md
@@ -1,4 +1,4 @@
-# Base classes 
+# MFT base classes 
 
 Constants: static constants for the MFT
 

--- a/Detectors/ITSMFT/MFT/reconstruction/include/MFTReconstruction/devices/README.md
+++ b/Detectors/ITSMFT/MFT/reconstruction/include/MFTReconstruction/devices/README.md
@@ -1,4 +1,4 @@
-MFT reconstruction headers
+# MFT reconstruction headers
 
 Header files for the reconstruction devices: the task processor is using a
 template which can be "FindHits" or "FindTracks", for instance.

--- a/Detectors/ITSMFT/MFT/reconstruction/include/MFTReconstruction/devices/README.md
+++ b/Detectors/ITSMFT/MFT/reconstruction/include/MFTReconstruction/devices/README.md
@@ -1,2 +1,5 @@
-Header files for the reconstruction devices: the task processor is using a template which can be "FindHits" or "FindTracks", for instance.
+MFT reconstruction headers
+
+Header files for the reconstruction devices: the task processor is using a
+template which can be "FindHits" or "FindTracks", for instance.
 

--- a/Detectors/ITSMFT/MFT/reconstruction/src/devices/README.md
+++ b/Detectors/ITSMFT/MFT/reconstruction/src/devices/README.md
@@ -1,2 +1,4 @@
+# MFT reconstruction devices
+
 Devices created according to the examples from FairRoot/examples/MQ/9-PixelDetector/
 

--- a/Steer/README.md
+++ b/Steer/README.md
@@ -1,3 +1,5 @@
+# ALICEO2 Steer
+
 This directory contains ALICE O2 specific customizations
 of steering classes from FairRoot
 


### PR DESCRIPTION
Since README files are now showed in our doxygen documentation at:

https://aliceo2group.github.io/AliceO2/

I am adding context to all the README files so that we get a proper
entry in the sidebar menu, rather than a generic "README" one.