### PR TITLE
Finish refactoring to the new Logger infrastructure

### DIFF
--- a/Common/Field/include/Field/MagneticField.h
+++ b/Common/Field/include/Field/MagneticField.h
@@ -24,7 +24,6 @@
 #include "TNamed.h"            // for TNamed
 #include <memory>              // for str::unique_ptr
 
-class FairLogger;  // lines 14-14
 class FairParamList;
 
 namespace o2 { namespace field { class MagneticWrapperChebyshev; }}  // lines 19-19
@@ -284,8 +283,6 @@ class MagneticField : public FairField
 
     static const Double_t sSolenoidToDipoleZ;  ///< conventional Z of transition from L3 to Dipole field
     static const UShort_t sPolarityConvention; ///< convention for the mapping of the curr.sign on main component sign
-
-    FairLogger *mLogger;
 
     MagneticField(const MagneticField &src);
 

--- a/Common/Field/include/Field/MagneticWrapperChebyshev.h
+++ b/Common/Field/include/Field/MagneticWrapperChebyshev.h
@@ -22,8 +22,6 @@
 #include "MathUtils/Chebyshev3DCalc.h"  // for _INC_CREATION_Chebyshev3D_
 #include "Rtypes.h"                     // for Double_t, Int_t, Float_t, etc
 
-class FairLogger;  // lines 16-16
-
 namespace o2 {
 namespace field {
 
@@ -413,7 +411,6 @@ class MagneticWrapperChebyshev : public TNamed
     Float_t mMaxDipoleZ;     ///< Max Z of Dipole parameterization
     TObjArray *mParameterizationDipole; ///< Parameterization pieces for Dipole field
 
-    FairLogger *mLogger; //!
     ClassDefOverride(o2::field::MagneticWrapperChebyshev,
     2) // Wrapper class for the set of Chebishev parameterizations of Alice mag.field
 };

--- a/Common/Field/src/MagneticField.cxx
+++ b/Common/Field/src/MagneticField.cxx
@@ -81,8 +81,7 @@ MagneticField::MagneticField()
     mCompensatorField2C(0),
     mCompensatorField1A(0),
     mCompensatorField2A(0),
-    mParameterNames("", ""),
-    mLogger(FairLogger::GetLogger())
+    mParameterNames("", "")
 {
   /*
    * Default constructor
@@ -111,8 +110,7 @@ MagneticField::MagneticField(const char *name, const char *title, Double_t facto
     mCompensatorField2C(0),
     mCompensatorField1A(0),
     mCompensatorField2A(0),
-    mParameterNames("", ""),
-    mLogger(FairLogger::GetLogger())
+    mParameterNames("", "")
 {
   /*
    * Constructor for human readable params
@@ -141,8 +139,7 @@ MagneticField::MagneticField(const MagFieldParam& param)
     mCompensatorField2C(0),
     mCompensatorField1A(0),
     mCompensatorField2A(0),
-    mParameterNames("", ""),
-    mLogger(FairLogger::GetLogger())
+    mParameterNames("", "")
 {
   /*
    * Constructor for FairParam derived params

--- a/Common/Field/src/MagneticWrapperChebyshev.cxx
+++ b/Common/Field/src/MagneticWrapperChebyshev.cxx
@@ -93,8 +93,7 @@ MagneticWrapperChebyshev::MagneticWrapperChebyshev()
     mSegmentIdDipole(nullptr),
     mMinDipoleZ(1.e6),
     mMaxDipoleZ(-1.e6),
-    mParameterizationDipole(nullptr),
-    mLogger(FairLogger::GetLogger())
+    mParameterizationDipole(nullptr)
 {
 }
 
@@ -162,8 +161,7 @@ MagneticWrapperChebyshev::MagneticWrapperChebyshev(const MagneticWrapperChebyshe
     mSegmentIdDipole(nullptr),
     mMinDipoleZ(1.e6),
     mMaxDipoleZ(-1.e6),
-    mParameterizationDipole(nullptr),
-    mLogger(FairLogger::GetLogger())
+    mParameterizationDipole(nullptr)
 {
   copyFrom(src);
 }

--- a/Common/MathUtils/include/MathUtils/Chebyshev3D.h
+++ b/Common/MathUtils/include/MathUtils/Chebyshev3D.h
@@ -22,7 +22,6 @@
 #include "Rtypes.h"           // for Float_t, Int_t, Double_t, Bool_t, etc
 #include "TString.h"          // for TString
 
-class FairLogger;  // lines 20-20
 class TH1;  // lines 15-15
 class TMethodCall;  // lines 16-16
 
@@ -250,7 +249,6 @@ class Chebyshev3D : public TNamed
     Int_t mTemporaryChebyshevGridOffs[3]; //! start of grid for each dimension
     TString mUserFunctionName; //! name of user macro containing the function of  "void (*fcn)(float*,float*)" format
     TMethodCall *mUserMacro;   //! Pointer to MethodCall for function from user macro
-    FairLogger *mLogger;       //!
 
     static const Float_t sMinimumPrecision; ///< minimum precision allowed
 

--- a/Common/MathUtils/src/Chebyshev3D.cxx
+++ b/Common/MathUtils/src/Chebyshev3D.cxx
@@ -42,8 +42,7 @@ Chebyshev3D::Chebyshev3D()
     mTemporaryUserResults(nullptr),
     mTemporaryChebyshevGrid(nullptr),
     mUserFunctionName(""),
-    mUserMacro(nullptr),
-    mLogger(FairLogger::GetLogger())
+    mUserMacro(nullptr)
 {
   // Default constructor
   for (int i = 3; i--;) {
@@ -63,8 +62,7 @@ Chebyshev3D::Chebyshev3D(const Chebyshev3D &src)
     mTemporaryUserResults(nullptr),
     mTemporaryChebyshevGrid(nullptr),
     mUserFunctionName(src.mUserFunctionName),
-    mUserMacro(nullptr),
-    mLogger(FairLogger::GetLogger())
+    mUserMacro(nullptr)
 {
   // read coefs from text file
   for (int i = 3; i--;) {
@@ -92,8 +90,7 @@ Chebyshev3D::Chebyshev3D(const char *inpFile)
     mTemporaryUserResults(nullptr),
     mTemporaryChebyshevGrid(nullptr),
     mUserFunctionName(""),
-    mUserMacro(nullptr),
-    mLogger(FairLogger::GetLogger())
+    mUserMacro(nullptr)
 {
   // read coefs from text file
   for (int i = 3; i--;) {
@@ -113,8 +110,7 @@ Chebyshev3D::Chebyshev3D(FILE *stream)
     mTemporaryUserResults(nullptr),
     mTemporaryChebyshevGrid(nullptr),
     mUserFunctionName(""),
-    mUserMacro(nullptr),
-    mLogger(FairLogger::GetLogger())
+    mUserMacro(nullptr)
 {
   // read coefs from stream
   for (int i = 3; i--;) {
@@ -137,8 +133,7 @@ Chebyshev3D::Chebyshev3D(const char* funName, int dimOut, const Float_t* bmin, c
     mTemporaryUserResults(nullptr),
     mTemporaryChebyshevGrid(nullptr),
     mUserFunctionName(""),
-    mUserMacro(nullptr),
-    mLogger(FairLogger::GetLogger())
+    mUserMacro(nullptr)
 {
   if (dimOut < 1) {
     LOG(ERROR) << "Chebyshev3D: Requested output dimension is " << mOutputArrayDimension << "\nStop\n";
@@ -168,8 +163,7 @@ Chebyshev3D::Chebyshev3D(void (*ptr)(float*, float*), int dimOut, const Float_t*
     mTemporaryUserResults(nullptr),
     mTemporaryChebyshevGrid(nullptr),
     mUserFunctionName(""),
-    mUserMacro(nullptr),
-    mLogger(FairLogger::GetLogger())
+    mUserMacro(nullptr)
 {
   if (dimOut < 1) {
     LOG(ERROR) << "Chebyshev3D: Requested output dimension is " << mOutputArrayDimension << " \nStop\n";
@@ -199,8 +193,7 @@ Chebyshev3D::Chebyshev3D(void (*ptr)(float*, float*), int dimOut, const Float_t*
     mTemporaryUserResults(nullptr),
     mTemporaryChebyshevGrid(nullptr),
     mUserFunctionName(""),
-    mUserMacro(nullptr),
-    mLogger(FairLogger::GetLogger())
+    mUserMacro(nullptr)
 {
   if (dimOut < 1) {
     LOG(ERROR) << "Chebyshev3D: Requested output dimension is " << mOutputArrayDimension << "%d\nStop\n";
@@ -235,8 +228,7 @@ Chebyshev3D::Chebyshev3D(void (*ptr)(float*, float*), int dimOut, const Float_t*
     mTemporaryUserResults(nullptr),
     mTemporaryChebyshevGrid(nullptr),
     mUserFunctionName(""),
-    mUserMacro(nullptr),
-    mLogger(FairLogger::GetLogger())
+    mUserMacro(nullptr)
 {
   if (dimOut != 3) {
     LOG(ERROR) << "Chebyshev3D: This constructor works only for 3D fits, " << mOutputArrayDimension << "D fit was requested\n";

--- a/DataFormats/simulation/include/SimulationDataFormat/Stack.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/Stack.h
@@ -29,7 +29,6 @@
 
 class TClonesArray;
 class TRefArray;
-class FairLogger;
 
 namespace o2 {
 
@@ -192,8 +191,6 @@ class Stack : public FairGenericStack
     void notifyFinishPrimary();
 
   private:
-    FairLogger *mLogger;
-
     /// STL stack (FILO) used to handle the TParticles for tracking
     /// stack entries refer to
     std::stack<TParticle> mStack; //!

--- a/DataFormats/simulation/src/Stack.cxx
+++ b/DataFormats/simulation/src/Stack.cxx
@@ -49,8 +49,7 @@ Stack::Stack(Int_t size)
     mStoreMothers(kTRUE),
     mStoreSecondaries(kTRUE),
     mMinHits(1),
-    mEnergyCut(0.),
-    mLogger(FairLogger::GetLogger())
+    mEnergyCut(0.)
 {
   auto vmc = TVirtualMC::GetMC();
   if (!vmc) {
@@ -76,7 +75,6 @@ Stack::Stack(const Stack &rhs)
     mStoreSecondaries(rhs.mStoreSecondaries),
     mMinHits(rhs.mMinHits),
     mEnergyCut(rhs.mEnergyCut),
-    mLogger(FairLogger::GetLogger()),
     mIsG4Like(rhs.mIsG4Like)
 {
   LOG(FATAL) << "copy constructor called" << FairLogger::endl;
@@ -111,7 +109,6 @@ Stack &Stack::operator=(const Stack &rhs)
   mStoreSecondaries = rhs.mStoreSecondaries;
   mMinHits = rhs.mMinHits;
   mEnergyCut = rhs.mEnergyCut;
-  mLogger = nullptr;
   mIsG4Like = rhs.mIsG4Like;
 
   return *this;
@@ -242,10 +239,7 @@ TParticle* Stack::PopPrimaryForTracking(Int_t iPrim)
 
   // Test for index
   if (iPrim < 0 || iPrim >= mNumberOfPrimaryParticles) {
-    if (mLogger) {
-      LOG(FATAL) << "Stack::PopPrimaryForTracking: Stack: Primary index out of range! " << iPrim << " ";
-    }
-    LOG(FATAL) << "Stack::PopPrimaryForTracking: Index out of range";
+    LOG(FATAL) << "Stack::PopPrimaryForTracking: Stack: Primary index out of range! " << iPrim << " ";
     return nullptr;
   }
   // Return the iPrim-th TParticle from the fParticle array. This should be
@@ -310,11 +304,7 @@ void Stack::UpdateTrackIndex(TRefArray *detList)
     }
   }
 
-  if (mLogger) {
-    LOG(DEBUG) << "Stack::UpdateTrackIndex: Stack: Updating track indices...";
-  } else {
-    cout << "Stack: Updating track indices..." << endl;
-  }
+  LOG(DEBUG) << "Stack::UpdateTrackIndex: Stack: Updating track indices...";
   Int_t nColl = 0;
 
   // First update mother ID in MCTracks
@@ -327,11 +317,8 @@ void Stack::UpdateTrackIndex(TRefArray *detList)
     }
     auto iter = mIndexMap.find(iMotherOld);
     if (iter == mIndexMap.end()) {
-      if (mLogger) {
-        LOG(FATAL) << "Stack::UpdateTrackIndex: Stack: Track index "
-                   << iMotherOld << " not found index map! ";
-      }
-      Fatal("Stack::UpdateTrackIndex", "Track index not found in map");
+      LOG(FATAL) << "Stack::UpdateTrackIndex: Stack: Track index "
+                 << iMotherOld << " not found index map! ";
     }
     track.SetMotherTrackId(iter->second);
   }
@@ -341,11 +328,7 @@ void Stack::UpdateTrackIndex(TRefArray *detList)
     det->updateHitTrackIndices(mIndexMap);
   } // List of active detectors
 
-  if (mLogger) {
-    LOG(DEBUG) << "Stack::UpdateTrackIndex: ...stack and " << nColl << " collections updated.";
-  } else {
-    cout << "...stack and  " << nColl << " collections updated." << endl;
-  }
+  LOG(DEBUG) << "Stack::UpdateTrackIndex: ...stack and " << nColl << " collections updated.";
 }
 
 void Stack::Reset()


### PR DESCRIPTION
The new logging infrastructure in FairRoot makes direct usage of
FairLogger unnecessary and the old version is still able to compile
in a forward compatible mode.