### PR TITLE
Use VMC::TrackPosition in float mode

### DIFF
--- a/Detectors/Base/src/TrackReference.cxx
+++ b/Detectors/Base/src/TrackReference.cxx
@@ -87,7 +87,7 @@ TrackReference::TrackReference(Int_t label, Int_t id)
 
   //
 
-  Double_t vec[4];
+  Float_t vec[4];
 
   TVirtualMC::GetMC()->TrackPosition(vec[0], vec[1], vec[2]);
 

--- a/Detectors/EMCAL/simulation/src/Detector.cxx
+++ b/Detectors/EMCAL/simulation/src/Detector.cxx
@@ -151,15 +151,14 @@ Bool_t Detector::ProcessHits(FairVolume* v)
     // - Inside different cell
     // - First track of the event
     // std::cout << "New track / cell started\n";
-    Double_t posX, posY, posZ, momX, momY, momZ, energy;
+    Float_t posX, posY, posZ, momX, momY, momZ, energy;
     mcapp->TrackPosition(posX, posY, posZ);
     mcapp->TrackMomentum(momX, momY, momZ, energy);
     Double_t estart = mcapp->Etot(), time = mcapp->TrackTime() * 1e9; // time in ns
 
     /// check handling of primary particles
-    mCurrentHit =
-      AddHit(partID, parent, 0, estart, detID, Point3D<float>(float(posX), float(posY), float(posZ)),
-             Vector3D<float>(float(momX), float(momY), float(momZ)), time, lightyield);
+    mCurrentHit = AddHit(partID, parent, 0, estart, detID, Point3D<float>(posX, posY, posZ),
+                         Vector3D<float>(momX, momY, momZ), time, lightyield);
     static_cast<o2::Data::Stack*>(mcapp->GetStack())->addHit(GetDetId());
     mCurrentTrackID = partID;
     mCurrentCellID = detID;

--- a/Detectors/PHOS/simulation/src/Detector.cxx
+++ b/Detectors/PHOS/simulation/src/Detector.cxx
@@ -172,7 +172,7 @@ Bool_t Detector::ProcessHits(FairVolume* v)
     }
   }
   // Create new Hit
-  Double_t posX = 0., posY = 0., posZ = 0., momX = 0, momY = 0., momZ = 0., energy = 0.;
+  Float_t posX = 0., posY = 0., posZ = 0., momX = 0, momY = 0., momZ = 0., energy = 0.;
   fMC->TrackPosition(posX, posY, posZ);
   fMC->TrackMomentum(momX, momY, momZ, energy);
   Double_t estart = fMC->Etot();

--- a/Detectors/TRD/simulation/src/Detector.cxx
+++ b/Detectors/TRD/simulation/src/Detector.cxx
@@ -44,7 +44,7 @@ bool Detector::ProcessHits(FairVolume* v)
 
   // just record position and basic quantities for the moment
   // TODO: needs to be interpreted properly
-  double x, y, z;
+  float x, y, z;
   vmc->TrackPosition(x, y, z);
 
   float enDep = vmc->Edep();
@@ -52,7 +52,7 @@ bool Detector::ProcessHits(FairVolume* v)
   auto stack = (o2::Data::Stack *) TVirtualMC::GetMC()->GetStack();
   auto trackID = stack->GetCurrentTrackNumber();
   auto sensID = v->getMCid();
-  addHit((float)x, (float)y, (float)z, time, enDep, trackID, sensID);
+  addHit(x, y, z, time, enDep, trackID, sensID);
   stack->addHit(GetDetId());
 
   return true;


### PR DESCRIPTION
Fixes #563.
Uses newly introduced float API in VMC and avoids
useless type conversions.