### PR TITLE
Fix headers for EMCAL test macros

### DIFF
--- a/Detectors/EMCAL/testsimulation/PutEmcalInTop.C
+++ b/Detectors/EMCAL/testsimulation/PutEmcalInTop.C
@@ -4,8 +4,10 @@
   #include "TSystem.h"
 
   #include "FairRunSim.h"
+  #include "FairLogger.h"
   #include "DetectorsPassive/Cave.h"
   #include "DetectorsPassive/FrameStructure.h"
+  #include "EMCALSimulation/Detector.h"
 #endif
 
 

--- a/Detectors/EMCAL/testsimulation/PutEmcalInTop.C
+++ b/Detectors/EMCAL/testsimulation/PutEmcalInTop.C
@@ -1,40 +1,40 @@
 #if !defined(__CLING__) || defined(__ROOTCLING__)
-  #include "TGeoManager.h"
-  #include "TString.h"
-  #include "TSystem.h"
+#include "TGeoManager.h"
+#include "TString.h"
+#include "TSystem.h"
 
-  #include "FairRunSim.h"
-  #include "FairLogger.h"
-  #include "DetectorsPassive/Cave.h"
-  #include "DetectorsPassive/FrameStructure.h"
-  #include "EMCALSimulation/Detector.h"
+#include "DetectorsPassive/Cave.h"
+#include "DetectorsPassive/FrameStructure.h"
+#include "EMCALSimulation/Detector.h"
+#include "FairLogger.h"
+#include "FairRunSim.h"
 #endif
 
-
-void PutEmcalInTop() {
+void PutEmcalInTop()
+{
   // minimal macro to test setup of the geometry
   FairLogger::GetLogger()->SetLogScreenLevel("DEBUG3");
-  
+
   TString dir = getenv("VMCWORKDIR");
   TString geom_dir = dir + "/Detectors/Geometry/";
-  gSystem->Setenv("GEOMPATH",geom_dir.Data());
+  gSystem->Setenv("GEOMPATH", geom_dir.Data());
 
   TString tut_configdir = dir + "/Detectors/gconfig";
-  gSystem->Setenv("CONFIG_DIR",tut_configdir.Data());
+  gSystem->Setenv("CONFIG_DIR", tut_configdir.Data());
 
   // Create simulation run
   FairRunSim* run = new FairRunSim();
   run->SetOutputFile("foo.root"); // Output file
-  run->SetName("TGeant3");      // Transport engine
+  run->SetName("TGeant3");        // Transport engine
   // Create media
   run->SetMaterials("media.geo"); // Materials
-   
+
   // Create geometry
   o2::Passive::Cave* cave = new o2::Passive::Cave("CAVE");
   cave->SetGeometryFileName("cave.geo");
   run->AddModule(cave);
 
-  o2::EMCAL::Detector *emcdet = new o2::EMCAL::Detector(kTRUE);
+  o2::EMCAL::Detector* emcdet = new o2::EMCAL::Detector(kTRUE);
   run->AddModule(emcdet);
 
   run->Init();

--- a/Detectors/EMCAL/testsimulation/drawEMCALgeometry.C
+++ b/Detectors/EMCAL/testsimulation/drawEMCALgeometry.C
@@ -1,12 +1,12 @@
 #if !defined(__CLING__) || defined(__ROOTCLING__)
 #include "DetectorsPassive/Cave.h"
 #include "DetectorsPassive/FrameStructure.h"
+#include "EMCALSimulation/Detector.h"
 #include "FairRunSim.h"
 #include "TGeoManager.h"
-#include "EMCALSimulation/Detector.h"
-#include "TROOT.h"
 #include "TObjArray.h"
 #include "TObjString.h"
+#include "TROOT.h"
 #include "TString.h"
 #include "TSystem.h"
 
@@ -47,8 +47,7 @@ void drawEMCALgeometry()
 
   run->Init();
   {
-    const TString ToHide =
-      "cave";
+    const TString ToHide = "cave";
 
     TObjArray* lToHide = ToHide.Tokenize(" ");
     TIter* iToHide = new TIter(lToHide);
@@ -56,8 +55,7 @@ void drawEMCALgeometry()
     while ((name = (TObjString*)iToHide->Next()))
       gGeoManager->GetVolume(name->GetName())->SetVisibility(kFALSE);
 
-    TString ToShow =
-      "SMOD SM3rd DCSM DCEXT";
+    TString ToShow = "SMOD SM3rd DCSM DCEXT";
     // ToShow.ReplaceAll("FCOV", "");//Remove external cover but PHOS hole
     // ToShow.ReplaceAll("FLTA", "");//Remove internal cover but PHOS hole
 
@@ -70,10 +68,12 @@ void drawEMCALgeometry()
 
     TObjArray* lToTrans = ToTrans.Tokenize(" ");
     TIter* iToTrans = new TIter(lToTrans);
-    while ((name = (TObjString*)iToTrans->Next())){
-      auto v  = gGeoManager->GetVolume(name->GetName());
-      if(v) v->SetTransparency(50);
-      else printf("Volume %s not found ...\n", name->GetName());
+    while ((name = (TObjString*)iToTrans->Next())) {
+      auto v = gGeoManager->GetVolume(name->GetName());
+      if (v)
+        v->SetTransparency(50);
+      else
+        printf("Volume %s not found ...\n", name->GetName());
     }
   }
 

--- a/Detectors/EMCAL/testsimulation/drawEMCALgeometry.C
+++ b/Detectors/EMCAL/testsimulation/drawEMCALgeometry.C
@@ -3,9 +3,10 @@
 #include "DetectorsPassive/FrameStructure.h"
 #include "FairRunSim.h"
 #include "TGeoManager.h"
-#include "TOFSimulation/Detector.h"
+#include "EMCALSimulation/Detector.h"
 #include "TROOT.h"
-#include "TString.h"
+#include "TObjArray.h"
+#include "TObjString.h"
 #include "TString.h"
 #include "TSystem.h"
 
@@ -41,8 +42,8 @@ void drawEMCALgeometry()
   o2::passive::FrameStructure* frame = new o2::passive::FrameStructure("Frame", "Frame");
   run->AddModule(frame);
 
-  o2::EMCAL::Detector* tof = new o2::EMCAL::Detector(kTRUE);
-  run->AddModule(tof);
+  o2::EMCAL::Detector* emcal = new o2::EMCAL::Detector(kTRUE);
+  run->AddModule(emcal);
 
   run->Init();
   {
@@ -65,12 +66,15 @@ void drawEMCALgeometry()
     while ((name = (TObjString*)iToShow->Next()))
       gGeoManager->GetVolume(name->GetName())->SetVisibility(kTRUE);
 
-    const TString ToTrans = "SCM0 SCMCX SCMY";
+    const TString ToTrans = "SCM0 SCMX SCMY";
 
     TObjArray* lToTrans = ToTrans.Tokenize(" ");
     TIter* iToTrans = new TIter(lToTrans);
-    while ((name = (TObjString*)iToTrans->Next()))
-      gGeoManager->GetVolume(name->GetName())->SetTransparency(50);
+    while ((name = (TObjString*)iToTrans->Next())){
+      auto v  = gGeoManager->GetVolume(name->GetName());
+      if(v) v->SetTransparency(50);
+      else printf("Volume %s not found ...\n", name->GetName());
+    }
   }
 
   gGeoManager->GetListOfVolumes()->ls();


### PR DESCRIPTION
Fix some copy/paste errors and add forgotten
header files needed to run macros in compiled
mode. Note this should have no effects in
JIT-compiled mode as the headers are protected
by a guard.