### PR TITLE
Add Boost::serialization

### DIFF
--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -365,6 +365,7 @@ o2_define_bucket(
     FairRoot::FairMQ
     common_boost_bucket
     Boost::thread
+    Boost::serialization
     pthread
 
     INCLUDE_DIRECTORIES


### PR DESCRIPTION
Apparently some people started to use Boost::serialization in
simulation / reconstruction breaking the builds. This is hopefully the reason we have tests failures in (some) macros. I am not actually sure how things could work before and how they can work in the dev-fairroot branch.