### PR TITLE
Ignore vscode folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ compile_commands.json
 .project
 .idea
 .settings
+.vscode
 .ycm_extra_conf.py
 
 # Datafiles


### PR DESCRIPTION
Ignores the .vscode folder for changes. Useful for vscode users as this folder otherwise keeps hanging in the unstaged changes.