### PR TITLE
Support for different SAMPA versions in TPC RawReader

### DIFF
--- a/Detectors/TPC/calibration/src/CalibRawBase.cxx
+++ b/Detectors/TPC/calibration/src/CalibRawBase.cxx
@@ -67,16 +67,17 @@ void CalibRawBase::setupContainers(TString fileInfo)
       TString& filename = static_cast<TObjString*>(arrDataInfo->At(0))->String();
       iCRU = static_cast<TObjString*>(arrDataInfo->At(1))->String().Atoi();
       iLink = static_cast<TObjString*>(arrDataInfo->At(2))->String().Atoi();
-      iSampaVersion = static_cast<TObjString*>(arrDataInfo->At(3))->String().Atoi();
+      if (arrDataInfo->GetEntriesFast() > 3)
+        iSampaVersion = static_cast<TObjString*>(arrDataInfo->At(3))->String().Atoi();
 
-      auto cont = new GBTFrameContainer(iSize,iCRU,iLink);
+      auto cont = new GBTFrameContainer(iSize,iCRU,iLink,iSampaVersion);
 
       cont->setEnableAdcClockWarning(false);
       cont->setEnableSyncPatternWarning(false);
       cont->setEnableStoreGBTFrames(false);
       cont->setEnableCompileAdcValues(true);
 
-      std::cout << "Read digits from file " << filename << " with cru " << iCRU << ", link " << iLink << ", rorc type " << rorcType << "...\n";
+      std::cout << "Read digits from file " << filename << " with cru " << iCRU << ", link " << iLink << ", rorc type " << rorcType << ", SAMPA Version " << iSampaVersion << "...\n";
       cont->addGBTFramesFromBinaryFile(filename.Data(), rorcType.Data(), -1);
       std::cout << " ... done. Read " << cont->getSize() << "\n";
 

--- a/Detectors/TPC/calibration/src/CalibRawBase.cxx
+++ b/Detectors/TPC/calibration/src/CalibRawBase.cxx
@@ -49,9 +49,9 @@ void CalibRawBase::setupContainers(TString fileInfo)
       std::cout << "Found decoder type: " << rorcType << "\n";
       delete arrDataInfo;
       continue;
-    }
-    else if (arrDataInfo->GetEntriesFast() < 3) {
-      printf("Error, badly formatte input data string: %s, expected format is <filename:cru:link[:sampaVersion]>\n", data.Data());
+    } else if (arrDataInfo->GetEntriesFast() < 3) {
+      printf("Error, badly formatte input data string: %s, expected format is <filename:cru:link[:sampaVersion]>\n",
+             data.Data());
       delete arrDataInfo;
       continue;
     }
@@ -70,14 +70,15 @@ void CalibRawBase::setupContainers(TString fileInfo)
       if (arrDataInfo->GetEntriesFast() > 3)
         iSampaVersion = static_cast<TObjString*>(arrDataInfo->At(3))->String().Atoi();
 
-      auto cont = new GBTFrameContainer(iSize,iCRU,iLink,iSampaVersion);
+      auto cont = new GBTFrameContainer(iSize, iCRU, iLink, iSampaVersion);
 
       cont->setEnableAdcClockWarning(false);
       cont->setEnableSyncPatternWarning(false);
       cont->setEnableStoreGBTFrames(false);
       cont->setEnableCompileAdcValues(true);
 
-      std::cout << "Read digits from file " << filename << " with cru " << iCRU << ", link " << iLink << ", rorc type " << rorcType << ", SAMPA Version " << iSampaVersion << "...\n";
+      std::cout << "Read digits from file " << filename << " with cru " << iCRU << ", link " << iLink << ", rorc type "
+                << rorcType << ", SAMPA Version " << iSampaVersion << "...\n";
       cont->addGBTFramesFromBinaryFile(filename.Data(), rorcType.Data(), -1);
       std::cout << " ... done. Read " << cont->getSize() << "\n";
 

--- a/Detectors/TPC/calibration/src/CalibRawBase.cxx
+++ b/Detectors/TPC/calibration/src/CalibRawBase.cxx
@@ -23,6 +23,7 @@ void CalibRawBase::setupContainers(TString fileInfo)
   int iSize = 4000000;
   int iCRU = 0;
   int iLink = 0;
+  int iSampaVersion = -1;
 
   //auto contPtr = std::unique_ptr<GBTFrameContainer>(new GBTFrameContainer(iSize,iCRU,iLink));
   // input data
@@ -49,8 +50,8 @@ void CalibRawBase::setupContainers(TString fileInfo)
       delete arrDataInfo;
       continue;
     }
-    else if (arrDataInfo->GetEntriesFast() != 3) {
-      printf("Error, badly formatte input data string: %s, expected format is <filename:cru:link>\n", data.Data());
+    else if (arrDataInfo->GetEntriesFast() < 3) {
+      printf("Error, badly formatte input data string: %s, expected format is <filename:cru:link[:sampaVersion]>\n", data.Data());
       delete arrDataInfo;
       continue;
     }
@@ -66,6 +67,7 @@ void CalibRawBase::setupContainers(TString fileInfo)
       TString& filename = static_cast<TObjString*>(arrDataInfo->At(0))->String();
       iCRU = static_cast<TObjString*>(arrDataInfo->At(1))->String().Atoi();
       iLink = static_cast<TObjString*>(arrDataInfo->At(2))->String().Atoi();
+      iSampaVersion = static_cast<TObjString*>(arrDataInfo->At(3))->String().Atoi();
 
       auto cont = new GBTFrameContainer(iSize,iCRU,iLink);
 

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/GBTFrameContainer.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/GBTFrameContainer.h
@@ -216,11 +216,11 @@ class GBTFrameContainer {
 
     std::mutex mAdcMutex;
 
-    std::vector<GBTFrame> mGBTFrames; ///< GBT Frames container
-    std::array<AdcClockMonitor, 3> mAdcClock; ///< ADC clock monitor for the 3 SAMPAs
+    std::vector<GBTFrame> mGBTFrames;               ///< GBT Frames container
+    std::array<AdcClockMonitor, 3> mAdcClock;       ///< ADC clock monitor for the 3 SAMPAs
     std::array<SyncPatternMonitor, 5> mSyncPattern; ///< Synchronization pattern monitor for the 5 half SAMPAs
-    std::array<short, 10> mPositionForHalfSampa; ///< Start position of data for all 5 half SAMPAs
-    std::array<std::queue<short>*, 5> mAdcValues; ///< Vector to buffer the decoded ADC values, one deque per half SAMPA
+    std::array<short, 10> mPositionForHalfSampa;    ///< Start position of data for all 5 half SAMPAs
+    std::array<std::queue<short>*, 5> mAdcValues;   ///< Vector to buffer the decoded ADC values, one deque per half SAMPA
 
     bool mEnableAdcClockWarning;                    ///< enables the ADC clock warnings
     bool mEnableSyncPatternWarning;                 ///< enables the Sync Pattern warnings
@@ -248,7 +248,8 @@ class GBTFrameContainer {
 //  processFrame(mGBTFrames.end()-1);
 //};
 
-inline void GBTFrameContainer::addGBTFrame(unsigned word3, unsigned word2, unsigned word1, unsigned word0) {
+inline void GBTFrameContainer::addGBTFrame(unsigned word3, unsigned word2, unsigned word1, unsigned word0)
+{
   if (!mEnableStoreGBTFrames && (mGBTFrames.size() > 1)) {
     mGBTFrames[0] = mGBTFrames[1];
     mGBTFrames[1].setData(word3, word2, word1, word0);

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/GBTFrameContainer.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/GBTFrameContainer.h
@@ -19,8 +19,8 @@
 #include "TPCReconstruction/SyncPatternMonitor.h"
 #include "TPCReconstruction/HalfSAMPAData.h"
 #include "TPCBase/Digit.h"
-#include "TPCBase/Mapper.h" 
-//#include <TClonesArray.h>  
+#include "TPCBase/Mapper.h"
+//#include <TClonesArray.h>
 
 #include <iterator>
 #include <vector>
@@ -57,7 +57,8 @@ class GBTFrameContainer {
     /// @param size Size of GBT frame container to avoid unnecessary reallocation of memory
     /// @param cru CRU ID
     /// @param link Link ID
-    GBTFrameContainer(int size, int cru, int link);
+    /// @param sampaVersion SAMPA version
+    GBTFrameContainer(int size, int cru, int link, int sampaVersion=-1);
 
     /// Destructor
     ~GBTFrameContainer();
@@ -85,22 +86,22 @@ class GBTFrameContainer {
     void addGBTFrame(unsigned word3, unsigned word2, unsigned word1, unsigned word0);
 
     /// Add frame to the container
-    /// @param s0hw0l half-word 0 from SAMPA 0 low channel numbers 
-    /// @param s0hw1l half-word 1 from SAMPA 0 low channel numbers 
-    /// @param s0hw2l half-word 2 from SAMPA 0 low channel numbers 
-    /// @param s0hw3l half-word 3 from SAMPA 0 low channel numbers 
-    /// @param s0hw0h half-word 0 from SAMPA 0 high channel numbers 
-    /// @param s0hw1h half-word 1 from SAMPA 0 high channel numbers 
-    /// @param s0hw2h half-word 2 from SAMPA 0 high channel numbers 
-    /// @param s0hw3h half-word 3 from SAMPA 0 high channel numbers 
-    /// @param s1hw0l half-word 0 from SAMPA 1 low channel numbers 
-    /// @param s1hw1l half-word 1 from SAMPA 1 low channel numbers 
-    /// @param s1hw2l half-word 2 from SAMPA 1 low channel numbers 
-    /// @param s1hw3l half-word 3 from SAMPA 1 low channel numbers 
-    /// @param s1hw0h half-word 0 from SAMPA 1 high channel numbers 
-    /// @param s1hw1h half-word 1 from SAMPA 1 high channel numbers 
-    /// @param s1hw2h half-word 2 from SAMPA 1 high channel numbers 
-    /// @param s1hw3h half-word 3 from SAMPA 1 high channel numbers 
+    /// @param s0hw0l half-word 0 from SAMPA 0 low channel numbers
+    /// @param s0hw1l half-word 1 from SAMPA 0 low channel numbers
+    /// @param s0hw2l half-word 2 from SAMPA 0 low channel numbers
+    /// @param s0hw3l half-word 3 from SAMPA 0 low channel numbers
+    /// @param s0hw0h half-word 0 from SAMPA 0 high channel numbers
+    /// @param s0hw1h half-word 1 from SAMPA 0 high channel numbers
+    /// @param s0hw2h half-word 2 from SAMPA 0 high channel numbers
+    /// @param s0hw3h half-word 3 from SAMPA 0 high channel numbers
+    /// @param s1hw0l half-word 0 from SAMPA 1 low channel numbers
+    /// @param s1hw1l half-word 1 from SAMPA 1 low channel numbers
+    /// @param s1hw2l half-word 2 from SAMPA 1 low channel numbers
+    /// @param s1hw3l half-word 3 from SAMPA 1 low channel numbers
+    /// @param s1hw0h half-word 0 from SAMPA 1 high channel numbers
+    /// @param s1hw1h half-word 1 from SAMPA 1 high channel numbers
+    /// @param s1hw2h half-word 2 from SAMPA 1 high channel numbers
+    /// @param s1hw3h half-word 3 from SAMPA 1 high channel numbers
     /// @param s2hw0 half-word 0 from SAMPA 2
     /// @param s2hw1 half-word 1 from SAMPA 2
     /// @param s2hw2 half-word 2 from SAMPA 2
@@ -113,7 +114,7 @@ class GBTFrameContainer {
                      short s0hw0h, short s0hw1h, short s0hw2h, short s0hw3h,
                      short s1hw0l, short s1hw1l, short s1hw2l, short s1hw3l,
                      short s1hw0h, short s1hw1h, short s1hw2h, short s1hw3h,
-                     short s2hw0,  short s2hw1,  short s2hw2,  short s2hw3, 
+                     short s2hw0,  short s2hw1,  short s2hw2,  short s2hw3,
                      short s0adc,  short s1adc,  short s2adc,  unsigned marker = 0);
 
 //    template<typename... Args> void addGBTFrame(Args&&... args);
@@ -224,7 +225,7 @@ class GBTFrameContainer {
     std::array<AdcClockMonitor,3> mAdcClock;        ///< ADC clock monitor for the 3 SAMPAs
     std::array<SyncPatternMonitor,5> mSyncPattern;  ///< Synchronization pattern monitor for the 5 half SAMPAs
     std::array<short,10> mPositionForHalfSampa;      ///< Start position of data for all 5 half SAMPAs
-    std::array<std::queue<short>*,5> mAdcValues;    ///< Vector to buffer the decoded ADC values, one deque per half SAMPA 
+    std::array<std::queue<short>*,5> mAdcValues;    ///< Vector to buffer the decoded ADC values, one deque per half SAMPA
 
     bool mEnableAdcClockWarning;                    ///< enables the ADC clock warnings
     bool mEnableSyncPatternWarning;                 ///< enables the Sync Pattern warnings
@@ -232,10 +233,11 @@ class GBTFrameContainer {
     bool mEnableCompileAdcValues;                   ///<
     int mCRU;                                       ///< CRU ID of the GBT frames
     int mLink;                                      ///< Link ID of the GBT frames
-    int mTimebin;                                   ///< Timebin of last digits extraction 
-    int mGBTFramesAnalyzed;                         
+    int mSampaVersion;                              ///< Version of SAMPA chip
+    int mTimebin;                                   ///< Timebin of last digits extraction
+    int mGBTFramesAnalyzed;
 
-    std::array<std::array<short,16>,5> mTmpData; 
+    std::array<std::array<short,16>,5> mTmpData;
 };
 
 //template<typename... Args>
@@ -267,7 +269,7 @@ void GBTFrameContainer::addGBTFrame(short s0hw0l, short s0hw1l, short s0hw2l, sh
                                     short s0hw0h, short s0hw1h, short s0hw2h, short s0hw3h,
                                     short s1hw0l, short s1hw1l, short s1hw2l, short s1hw3l,
                                     short s1hw0h, short s1hw1h, short s1hw2h, short s1hw3h,
-                                    short s2hw0,  short s2hw1,  short s2hw2,  short s2hw3, 
+                                    short s2hw0,  short s2hw1,  short s2hw2,  short s2hw3,
                                     short s0adc,  short s1adc,  short s2adc,  unsigned marker) {
   if (!mEnableStoreGBTFrames && (mGBTFrames.size() > 1)) {
     mGBTFrames[0] = mGBTFrames[1];
@@ -283,7 +285,7 @@ void GBTFrameContainer::addGBTFrame(short s0hw0l, short s0hw1l, short s0hw2l, sh
 };
 
 inline
-void GBTFrameContainer::addGBTFrame(GBTFrame& frame) 
+void GBTFrameContainer::addGBTFrame(GBTFrame& frame)
 {
   if (!mEnableStoreGBTFrames && (mGBTFrames.size() > 1)) {
     mGBTFrames[0] = mGBTFrames[1];

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/GBTFrameContainer.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/GBTFrameContainer.h
@@ -220,7 +220,7 @@ class GBTFrameContainer {
     std::array<AdcClockMonitor, 3> mAdcClock;       ///< ADC clock monitor for the 3 SAMPAs
     std::array<SyncPatternMonitor, 5> mSyncPattern; ///< Synchronization pattern monitor for the 5 half SAMPAs
     std::array<short, 10> mPositionForHalfSampa;    ///< Start position of data for all 5 half SAMPAs
-    std::array<std::queue<short>*, 5> mAdcValues;   ///< Vector to buffer the decoded ADC values, one deque per half SAMPA
+    std::array<std::queue<short>*, 5> mAdcValues; ///< Vector to buffer the decoded ADC values, one deque per half SAMPA
 
     bool mEnableAdcClockWarning;                    ///< enables the ADC clock warnings
     bool mEnableSyncPatternWarning;                 ///< enables the Sync Pattern warnings

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/GBTFrameContainer.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/GBTFrameContainer.h
@@ -14,13 +14,12 @@
 #ifndef ALICEO2_TPC_GBTFRAMECONTAINER_H_
 #define ALICEO2_TPC_GBTFRAMECONTAINER_H_
 
-#include "TPCReconstruction/GBTFrame.h"
-#include "TPCReconstruction/AdcClockMonitor.h"
-#include "TPCReconstruction/SyncPatternMonitor.h"
-#include "TPCReconstruction/HalfSAMPAData.h"
 #include "TPCBase/Digit.h"
 #include "TPCBase/Mapper.h"
-//#include <TClonesArray.h>
+#include "TPCReconstruction/AdcClockMonitor.h"
+#include "TPCReconstruction/GBTFrame.h"
+#include "TPCReconstruction/HalfSAMPAData.h"
+#include "TPCReconstruction/SyncPatternMonitor.h"
 
 #include <iterator>
 #include <vector>
@@ -58,7 +57,7 @@ class GBTFrameContainer {
     /// @param cru CRU ID
     /// @param link Link ID
     /// @param sampaVersion SAMPA version
-    GBTFrameContainer(int size, int cru, int link, int sampaVersion=-1);
+    GBTFrameContainer(int size, int cru, int link, int sampaVersion = -1);
 
     /// Destructor
     ~GBTFrameContainer();
@@ -110,14 +109,10 @@ class GBTFrameContainer {
     /// @param s1adc ADC clock from SAMPA 1
     /// @param s2adc ADC clock from SAMPA 2
     /// @param marker additional 16 bit marker which is not part of the actual frame
-    void addGBTFrame(short s0hw0l, short s0hw1l, short s0hw2l, short s0hw3l,
-                     short s0hw0h, short s0hw1h, short s0hw2h, short s0hw3h,
-                     short s1hw0l, short s1hw1l, short s1hw2l, short s1hw3l,
-                     short s1hw0h, short s1hw1h, short s1hw2h, short s1hw3h,
-                     short s2hw0,  short s2hw1,  short s2hw2,  short s2hw3,
-                     short s0adc,  short s1adc,  short s2adc,  unsigned marker = 0);
-
-//    template<typename... Args> void addGBTFrame(Args&&... args);
+    void addGBTFrame(short s0hw0l, short s0hw1l, short s0hw2l, short s0hw3l, short s0hw0h, short s0hw1h, short s0hw2h,
+                     short s0hw3h, short s1hw0l, short s1hw1l, short s1hw2l, short s1hw3l, short s1hw0h, short s1hw1h,
+                     short s1hw2h, short s1hw3h, short s2hw0,  short s2hw1,  short s2hw2,  short s2hw3, short s0adc,
+                     short s1adc,  short s2adc,  unsigned marker = 0);
 
     /// Add all frames from file to conatiner
     /// @param fileName Path to file
@@ -222,10 +217,10 @@ class GBTFrameContainer {
     std::mutex mAdcMutex;
 
     std::vector<GBTFrame> mGBTFrames;                ///< GBT Frames container
-    std::array<AdcClockMonitor,3> mAdcClock;        ///< ADC clock monitor for the 3 SAMPAs
-    std::array<SyncPatternMonitor,5> mSyncPattern;  ///< Synchronization pattern monitor for the 5 half SAMPAs
-    std::array<short,10> mPositionForHalfSampa;      ///< Start position of data for all 5 half SAMPAs
-    std::array<std::queue<short>*,5> mAdcValues;    ///< Vector to buffer the decoded ADC values, one deque per half SAMPA
+    std::array<AdcClockMonitor, 3> mAdcClock;        ///< ADC clock monitor for the 3 SAMPAs
+    std::array<SyncPatternMonitor, 5> mSyncPattern;  ///< Synchronization pattern monitor for the 5 half SAMPAs
+    std::array<short, 10> mPositionForHalfSampa;     ///< Start position of data for all 5 half SAMPAs
+    std::array<std::queue<short>*, 5> mAdcValues;    ///< Vector to buffer the decoded ADC values, one deque per half SAMPA
 
     bool mEnableAdcClockWarning;                    ///< enables the ADC clock warnings
     bool mEnableSyncPatternWarning;                 ///< enables the Sync Pattern warnings
@@ -237,7 +232,7 @@ class GBTFrameContainer {
     int mTimebin;                                   ///< Timebin of last digits extraction
     int mGBTFramesAnalyzed;
 
-    std::array<std::array<short,16>,5> mTmpData;
+    std::array<std::array<short, 16>, 5> mTmpData;
 };
 
 //template<typename... Args>
@@ -265,12 +260,12 @@ void GBTFrameContainer::addGBTFrame(unsigned word3, unsigned word2, unsigned wor
 };
 
 inline
-void GBTFrameContainer::addGBTFrame(short s0hw0l, short s0hw1l, short s0hw2l, short s0hw3l,
-                                    short s0hw0h, short s0hw1h, short s0hw2h, short s0hw3h,
-                                    short s1hw0l, short s1hw1l, short s1hw2l, short s1hw3l,
-                                    short s1hw0h, short s1hw1h, short s1hw2h, short s1hw3h,
-                                    short s2hw0,  short s2hw1,  short s2hw2,  short s2hw3,
-                                    short s0adc,  short s1adc,  short s2adc,  unsigned marker) {
+void GBTFrameContainer::addGBTFrame(short s0hw0l, short s0hw1l, short s0hw2l, short s0hw3l, short s0hw0h,
+                                    short s0hw1h, short s0hw2h, short s0hw3h, short s1hw0l, short s1hw1l,
+                                    short s1hw2l, short s1hw3l, short s1hw0h, short s1hw1h, short s1hw2h,
+                                    short s1hw3h, short s2hw0,  short s2hw1,  short s2hw2,  short s2hw3,
+                                    short s0adc,  short s1adc,  short s2adc,  unsigned marker)
+{
   if (!mEnableStoreGBTFrames && (mGBTFrames.size() > 1)) {
     mGBTFrames[0] = mGBTFrames[1];
     mGBTFrames[1].setData(s0hw0l, s0hw1l, s0hw2l, s0hw3l, s0hw0h, s0hw1h, s0hw2h, s0hw3h,

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/GBTFrameContainer.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/GBTFrameContainer.h
@@ -111,8 +111,8 @@ class GBTFrameContainer {
     /// @param marker additional 16 bit marker which is not part of the actual frame
     void addGBTFrame(short s0hw0l, short s0hw1l, short s0hw2l, short s0hw3l, short s0hw0h, short s0hw1h, short s0hw2h,
                      short s0hw3h, short s1hw0l, short s1hw1l, short s1hw2l, short s1hw3l, short s1hw0h, short s1hw1h,
-                     short s1hw2h, short s1hw3h, short s2hw0,  short s2hw1,  short s2hw2,  short s2hw3, short s0adc,
-                     short s1adc,  short s2adc,  unsigned marker = 0);
+                     short s1hw2h, short s1hw3h, short s2hw0, short s2hw1, short s2hw2, short s2hw3, short s0adc,
+                     short s1adc, short s2adc, unsigned marker = 0);
 
     /// Add all frames from file to conatiner
     /// @param fileName Path to file
@@ -216,11 +216,11 @@ class GBTFrameContainer {
 
     std::mutex mAdcMutex;
 
-    std::vector<GBTFrame> mGBTFrames;                ///< GBT Frames container
-    std::array<AdcClockMonitor, 3> mAdcClock;        ///< ADC clock monitor for the 3 SAMPAs
-    std::array<SyncPatternMonitor, 5> mSyncPattern;  ///< Synchronization pattern monitor for the 5 half SAMPAs
-    std::array<short, 10> mPositionForHalfSampa;     ///< Start position of data for all 5 half SAMPAs
-    std::array<std::queue<short>*, 5> mAdcValues;    ///< Vector to buffer the decoded ADC values, one deque per half SAMPA
+    std::vector<GBTFrame> mGBTFrames; ///< GBT Frames container
+    std::array<AdcClockMonitor, 3> mAdcClock; ///< ADC clock monitor for the 3 SAMPAs
+    std::array<SyncPatternMonitor, 5> mSyncPattern; ///< Synchronization pattern monitor for the 5 half SAMPAs
+    std::array<short, 10> mPositionForHalfSampa; ///< Start position of data for all 5 half SAMPAs
+    std::array<std::queue<short>*, 5> mAdcValues; ///< Vector to buffer the decoded ADC values, one deque per half SAMPA
 
     bool mEnableAdcClockWarning;                    ///< enables the ADC clock warnings
     bool mEnableSyncPatternWarning;                 ///< enables the Sync Pattern warnings
@@ -248,8 +248,7 @@ class GBTFrameContainer {
 //  processFrame(mGBTFrames.end()-1);
 //};
 
-inline
-void GBTFrameContainer::addGBTFrame(unsigned word3, unsigned word2, unsigned word1, unsigned word0) {
+inline void GBTFrameContainer::addGBTFrame(unsigned word3, unsigned word2, unsigned word1, unsigned word0) {
   if (!mEnableStoreGBTFrames && (mGBTFrames.size() > 1)) {
     mGBTFrames[0] = mGBTFrames[1];
     mGBTFrames[1].setData(word3, word2, word1, word0);
@@ -259,12 +258,11 @@ void GBTFrameContainer::addGBTFrame(unsigned word3, unsigned word2, unsigned wor
   processFrame(mGBTFrames.end()-1);
 };
 
-inline
-void GBTFrameContainer::addGBTFrame(short s0hw0l, short s0hw1l, short s0hw2l, short s0hw3l, short s0hw0h,
-                                    short s0hw1h, short s0hw2h, short s0hw3h, short s1hw0l, short s1hw1l,
-                                    short s1hw2l, short s1hw3l, short s1hw0h, short s1hw1h, short s1hw2h,
-                                    short s1hw3h, short s2hw0,  short s2hw1,  short s2hw2,  short s2hw3,
-                                    short s0adc,  short s1adc,  short s2adc,  unsigned marker)
+inline void GBTFrameContainer::addGBTFrame(short s0hw0l, short s0hw1l, short s0hw2l, short s0hw3l, short s0hw0h,
+                                           short s0hw1h, short s0hw2h, short s0hw3h, short s1hw0l, short s1hw1l,
+                                           short s1hw2l, short s1hw3l, short s1hw0h, short s1hw1h, short s1hw2h,
+                                           short s1hw3h, short s2hw0, short s2hw1, short s2hw2, short s2hw3,
+                                           short s0adc, short s1adc, short s2adc, unsigned marker)
 {
   if (!mEnableStoreGBTFrames && (mGBTFrames.size() > 1)) {
     mGBTFrames[0] = mGBTFrames[1];
@@ -279,8 +277,7 @@ void GBTFrameContainer::addGBTFrame(short s0hw0l, short s0hw1l, short s0hw2l, sh
   processFrame(mGBTFrames.end()-1);
 };
 
-inline
-void GBTFrameContainer::addGBTFrame(GBTFrame& frame)
+inline void GBTFrameContainer::addGBTFrame(GBTFrame& frame)
 {
   if (!mEnableStoreGBTFrames && (mGBTFrames.size() > 1)) {
     mGBTFrames[0] = mGBTFrames[1];

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/RawReader.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/RawReader.h
@@ -84,7 +84,8 @@ class RawReader {
     /// @param region Region of the data
     /// @param link FEC of the data
     /// @param run RUN number of the data
-    RawReader(int region=-1, int link=-1, int run=-1);
+    /// @param sampaVersion Version of SAMPA chips, -1 is latest
+    RawReader(int region=-1, int link=-1, int run=-1, int sampaVersion=-1);
 
     /// Copy constructor
     RawReader(const RawReader& other) = default;
@@ -114,22 +115,23 @@ class RawReader {
     bool loadEvent(int64_t event);
 
     /// Add input file for decoding
-    /// @param infile Input file string in the format "path_to_file:#region:#fec", where #region/#fec is a number
+    /// @param infile Input file string in the format "path_to_file:#region:#fec[:sampaVersion]", where #region/#fec/sampaVersion is a number and sampaVersion optional
     /// @return True if string has correct format and file can be opened
     bool addInputFile(std::string infile);
 
     /// Add several input files for decoding
-    /// @param infiles vector of input file strings, each formatted as "path_to_file:#region:#fec"
+    /// @param infiles vector if input file strings, each formatted as "path_to_file:#region:#fec[:sampaVersion]", where #region/#fec/sampaVersion is a number and sampaVersion optional
     /// @return True if at least one string has correct format and file can be opened
     bool addInputFile(const std::vector<std::string>* infiles);
 
     /// Add input file for decoding
     /// @param region Region of the data
     /// @param link FEC of the data
+    /// @param sampaVersion Version of SAMPA chip
     /// @param path Path to data
     /// @param run Run number
     /// @return True file can be opened
-    bool addInputFile(int region, int link, std::string path, int run=-1);
+    bool addInputFile(int region, int link, int sampaVersion, std::string path, int run=-1);
 
     /// Get the first event
     /// @return Event number of first event in data
@@ -180,6 +182,10 @@ class RawReader {
     /// @param checkAdc Checks for a valid ADC clock in the data stream
     void setCheckAdcClock(bool checkAdc) { mCheckAdcClock = checkAdc; };
 
+    /// Set the SAMPA version
+    /// @param sampaVersion Version to be set
+    void setSampaVersion(int sampaVerson) { mSampaVersion = sampaVerson; };
+
     /// Returns some information about the event, e.g. the header
     /// @param event Event number
     /// @return shared pointer to vector with event informations
@@ -204,6 +210,7 @@ class RawReader {
     int mRegion;                        ///< Region of the data
     int mLink;                          ///< FEC of the data
     int mRun;                           ///< Run number
+    int mSampaVersion;                  ///< Version of SAMPA chip
     int64_t mLastEvent;                 ///< Number of last loaded event
     std::array<uint64_t,5> mTimestampOfFirstData;   ///< Time stamp of first decoded ADC value, individually for each half SAMPA
     std::map<uint64_t, std::shared_ptr<std::vector<EventInfo>>> mEvents;                ///< all "event data" - headers, file path, etc. NOT actual data

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/RawReader.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/RawReader.h
@@ -183,11 +183,9 @@ class RawReader {
     /// Does the ADC clock check
     /// @param checkAdc Checks for a valid ADC clock in the data stream
     void setCheckAdcClock(bool checkAdc) { mCheckAdcClock = checkAdc; };
-
     /// Set the SAMPA version
     /// @param sampaVersion Version to be set
     void setSampaVersion(int sampaVerson) { mSampaVersion = sampaVerson; };
-
     /// Returns some information about the event, e.g. the header
     /// @param event Event number
     /// @return shared pointer to vector with event informations

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/RawReader.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/RawReader.h
@@ -85,7 +85,7 @@ class RawReader {
     /// @param link FEC of the data
     /// @param run RUN number of the data
     /// @param sampaVersion Version of SAMPA chips, -1 is latest
-    RawReader(int region=-1, int link=-1, int run=-1, int sampaVersion=-1);
+    RawReader(int region = -1, int link = -1, int run = -1, int sampaVersion = -1);
 
     /// Copy constructor
     RawReader(const RawReader& other) = default;
@@ -115,12 +115,14 @@ class RawReader {
     bool loadEvent(int64_t event);
 
     /// Add input file for decoding
-    /// @param infile Input file string in the format "path_to_file:#region:#fec[:sampaVersion]", where #region/#fec/sampaVersion is a number and sampaVersion optional
+    /// @param infile Input file string in the format "path_to_file:#region:#fec[:sampaVersion]", where
+    //                #region/#fec/sampaVersion is a number and sampaVersion optional
     /// @return True if string has correct format and file can be opened
     bool addInputFile(std::string infile);
 
     /// Add several input files for decoding
-    /// @param infiles vector if input file strings, each formatted as "path_to_file:#region:#fec[:sampaVersion]", where #region/#fec/sampaVersion is a number and sampaVersion optional
+    /// @param infiles Vector of input file strings, each formatted as "path_to_file:#region:#fec[:sampaVersion]", where
+    //                 #region/#fec/sampaVersion is a number and sampaVersion optional
     /// @return True if at least one string has correct format and file can be opened
     bool addInputFile(const std::vector<std::string>* infiles);
 
@@ -131,7 +133,7 @@ class RawReader {
     /// @param path Path to data
     /// @param run Run number
     /// @return True file can be opened
-    bool addInputFile(int region, int link, int sampaVersion, std::string path, int run=-1);
+    bool addInputFile(int region, int link, int sampaVersion, std::string path, int run = -1);
 
     /// Get the first event
     /// @return Event number of first event in data

--- a/Detectors/TPC/reconstruction/run/readRawData.cxx
+++ b/Detectors/TPC/reconstruction/run/readRawData.cxx
@@ -34,10 +34,10 @@ int main(int argc, char *argv[])
 {
 
   // Arguments parsing
-  std::vector<std::string> infile(1,"NOFILE");
-  std::vector<unsigned> region(1,0);
-  std::vector<unsigned> link(1,0);
-  std::vector<int> sampaVersion(1,-1);
+  std::vector<std::string> infile(1, "NOFILE");
+  std::vector<unsigned> region(1, 0);
+  std::vector<unsigned> link(1, 0);
+  std::vector<int> sampaVersion(1, -1);
   int readEvents = -1;
   bool useRawInMode3 = true;
   std::string verbLevel = "LOW";
@@ -47,14 +47,14 @@ int main(int argc, char *argv[])
   bpo::options_description desc("Allowed options");
   desc.add_options()
     ("help,h", "Produce help message.")
-    ("infile,i",    bpo::value<std::vector<std::string>>(&infile),   "Input data files")
-    ("vl,",         bpo::value<std::string>(&verbLevel),"Fairlogger verbosity level (LOW, MED, HIGH)")
-    ("ll,",         bpo::value<std::string>(&logLevel), "Fairlogger screen log level (FATAL, ERROR, WARNING, INFO, DEBUG, DEBUG1, DEBUG2, DEBUG3, DEBUG4)")
-    ("region,r",    bpo::value<std::vector<unsigned>>(&region),      "Region for mapping")
-    ("link,l",      bpo::value<std::vector<unsigned>>(&link),        "Link for mapping")
-    ("sVersion,s",  bpo::value<std::vector<int>>(&sampaVersion),     "SAMPA version for decoding")
-    ("rawInMode3",  bpo::value<bool>(&useRawInMode3),   "Use Raw data in mode 3 instead of decoded one")
-    (",n",          bpo::value<int>(&readEvents),       "Events to read");
+    ("infile,i", bpo::value<std::vector<std::string>>(&infile), "Input data files")
+    ("vl,", bpo::value<std::string>(&verbLevel), "Fairlogger verbosity level (LOW, MED, HIGH)")
+    ("ll,", bpo::value<std::string>(&logLevel), "Fairlogger screen log level (FATAL, ERROR, WARNING, INFO, DEBUG, DEBUG1, DEBUG2, DEBUG3, DEBUG4)")
+    ("region,r", bpo::value<std::vector<unsigned>>(&region), "Region for mapping")
+    ("link,l", bpo::value<std::vector<unsigned>>(&link), "Link for mapping")
+    ("sVersion,s", bpo::value<std::vector<int>>(&sampaVersion), "SAMPA version for decoding")
+    ("rawInMode3", bpo::value<bool>(&useRawInMode3), "Use Raw data in mode 3 instead of decoded one")
+    (",n", bpo::value<int>(&readEvents), "Events to read");
 
   bpo::store(parse_command_line(argc, argv, desc), vm);
   bpo::notify(vm);
@@ -80,11 +80,11 @@ int main(int argc, char *argv[])
     readers.emplace_back();
     readers[i].addEventSynchronizer(eventSync);
     if (region.size() != infile.size() && link.size() == infile.size())
-      readers[i].addInputFile(region[0],link[i],sampaVersion[i],infile[i]);
+      readers[i].addInputFile(region[0], link[i], sampaVersion[i], infile[i]);
     else if (region.size() == infile.size() && link.size() != infile.size())
-      readers[i].addInputFile(region[i],link[0],sampaVersion[i],infile[i]);
+      readers[i].addInputFile(region[i], link[0], sampaVersion[i], infile[i]);
     else
-      readers[i].addInputFile(region[i],link[i],sampaVersion[i],infile[i]);
+      readers[i].addInputFile(region[i], link[i], sampaVersion[i], infile[i]);
     readers[i].setUseRawInMode3(useRawInMode3);
     readers[i].setCheckAdcClock(false);
   }

--- a/Detectors/TPC/reconstruction/run/readRawData.cxx
+++ b/Detectors/TPC/reconstruction/run/readRawData.cxx
@@ -37,6 +37,7 @@ int main(int argc, char *argv[])
   std::vector<std::string> infile(1,"NOFILE");
   std::vector<unsigned> region(1,0);
   std::vector<unsigned> link(1,0);
+  std::vector<int> sampaVersion(1,-1);
   int readEvents = -1;
   bool useRawInMode3 = true;
   std::string verbLevel = "LOW";
@@ -51,6 +52,7 @@ int main(int argc, char *argv[])
     ("ll,",         bpo::value<std::string>(&logLevel), "Fairlogger screen log level (FATAL, ERROR, WARNING, INFO, DEBUG, DEBUG1, DEBUG2, DEBUG3, DEBUG4)")
     ("region,r",    bpo::value<std::vector<unsigned>>(&region),      "Region for mapping")
     ("link,l",      bpo::value<std::vector<unsigned>>(&link),        "Link for mapping")
+    ("sVersion,s",  bpo::value<std::vector<int>>(&sampaVersion),     "SAMPA version for decoding")
     ("rawInMode3",  bpo::value<bool>(&useRawInMode3),   "Use Raw data in mode 3 instead of decoded one")
     (",n",          bpo::value<int>(&readEvents),       "Events to read");
 
@@ -78,11 +80,11 @@ int main(int argc, char *argv[])
     readers.emplace_back();
     readers[i].addEventSynchronizer(eventSync);
     if (region.size() != infile.size() && link.size() == infile.size())
-      readers[i].addInputFile(region[0],link[i],infile[i]);
+      readers[i].addInputFile(region[0],link[i],sampaVersion[i],infile[i]);
     else if (region.size() == infile.size() && link.size() != infile.size())
-      readers[i].addInputFile(region[i],link[0],infile[i]);
+      readers[i].addInputFile(region[i],link[0],sampaVersion[i],infile[i]);
     else
-      readers[i].addInputFile(region[i],link[i],infile[i]);
+      readers[i].addInputFile(region[i],link[i],sampaVersion[i],infile[i]);
     readers[i].setUseRawInMode3(useRawInMode3);
     readers[i].setCheckAdcClock(false);
   }

--- a/Detectors/TPC/reconstruction/run/readRawData.cxx
+++ b/Detectors/TPC/reconstruction/run/readRawData.cxx
@@ -45,16 +45,16 @@ int main(int argc, char *argv[])
 
   bpo::variables_map vm;
   bpo::options_description desc("Allowed options");
-  desc.add_options()
-    ("help,h", "Produce help message.")
-    ("infile,i", bpo::value<std::vector<std::string>>(&infile), "Input data files")
-    ("vl,", bpo::value<std::string>(&verbLevel), "Fairlogger verbosity level (LOW, MED, HIGH)")
-    ("ll,", bpo::value<std::string>(&logLevel), "Fairlogger screen log level (FATAL, ERROR, WARNING, INFO, DEBUG, DEBUG1, DEBUG2, DEBUG3, DEBUG4)")
-    ("region,r", bpo::value<std::vector<unsigned>>(&region), "Region for mapping")
-    ("link,l", bpo::value<std::vector<unsigned>>(&link), "Link for mapping")
-    ("sVersion,s", bpo::value<std::vector<int>>(&sampaVersion), "SAMPA version for decoding")
-    ("rawInMode3", bpo::value<bool>(&useRawInMode3), "Use Raw data in mode 3 instead of decoded one")
-    (",n", bpo::value<int>(&readEvents), "Events to read");
+  desc.add_options() ("help,h", "Produce help message.") ("infile,i", bpo::value<std::vector<std::string>>(&infile),
+                                                          "Input data files")(
+    "vl,", bpo::value<std::string>(&verbLevel), "Fairlogger verbosity level (LOW, MED, HIGH)")(
+    "ll,", bpo::value<std::string>(&logLevel),
+    "Fairlogger screen log level (FATAL, ERROR, WARNING, INFO, DEBUG, DEBUG1, DEBUG2, DEBUG3, DEBUG4)")(
+    "region,r", bpo::value<std::vector<unsigned>>(&region), "Region for mapping")(
+    "link,l", bpo::value<std::vector<unsigned>>(&link), "Link for mapping")(
+    "sVersion,s", bpo::value<std::vector<int>>(&sampaVersion), "SAMPA version for decoding")(
+    "rawInMode3", bpo::value<bool>(&useRawInMode3), "Use Raw data in mode 3 instead of decoded one")(
+    ",n", bpo::value<int>(&readEvents), "Events to read");
 
   bpo::store(parse_command_line(argc, argv, desc), vm);
   bpo::notify(vm);

--- a/Detectors/TPC/reconstruction/run/readRawData.cxx
+++ b/Detectors/TPC/reconstruction/run/readRawData.cxx
@@ -45,8 +45,8 @@ int main(int argc, char *argv[])
 
   bpo::variables_map vm;
   bpo::options_description desc("Allowed options");
-  desc.add_options() ("help,h", "Produce help message.") ("infile,i", bpo::value<std::vector<std::string>>(&infile),
-                                                          "Input data files")(
+  desc.add_options()("help,h", "Produce help message.")("infile,i", bpo::value<std::vector<std::string>>(&infile),
+                                                        "Input data files")(
     "vl,", bpo::value<std::string>(&verbLevel), "Fairlogger verbosity level (LOW, MED, HIGH)")(
     "ll,", bpo::value<std::string>(&logLevel),
     "Fairlogger screen log level (FATAL, ERROR, WARNING, INFO, DEBUG, DEBUG1, DEBUG2, DEBUG3, DEBUG4)")(

--- a/Detectors/TPC/reconstruction/src/GBTFrameContainer.cxx
+++ b/Detectors/TPC/reconstruction/src/GBTFrameContainer.cxx
@@ -16,15 +16,15 @@
 
 using namespace o2::TPC;
 
-GBTFrameContainer::GBTFrameContainer() : GBTFrameContainer(0,0) {}
-GBTFrameContainer::GBTFrameContainer(int cru, int link) : GBTFrameContainer(0,cru,link,-1) {}
+GBTFrameContainer::GBTFrameContainer() : GBTFrameContainer(0, 0) {}
+GBTFrameContainer::GBTFrameContainer(int cru, int link) : GBTFrameContainer(0, cru, link, -1) {}
 GBTFrameContainer::GBTFrameContainer(int size, int cru, int link, int sampaVersion)
   : mAdcMutex(),
     mEnableAdcClockWarning(true),
     mEnableSyncPatternWarning(true),
     mEnableStoreGBTFrames(true),
     mEnableCompileAdcValues(true),
-    mAdcClock({AdcClockMonitor(0), AdcClockMonitor(1), AdcClockMonitor(2)}),
+    mAdcClock({ AdcClockMonitor(0), AdcClockMonitor(1), AdcClockMonitor(2) }),
     mSyncPattern({ SyncPatternMonitor(0, 0), SyncPatternMonitor(0, 1), SyncPatternMonitor(1, 0),
                    SyncPatternMonitor(1, 1), SyncPatternMonitor(2, 0) }),
     mPositionForHalfSampa({ -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 }),
@@ -482,8 +482,7 @@ bool GBTFrameContainer::getData(std::vector<Digit>& container)
   {
     iSampaChannel =
       (iHalfSampa == 4)                // 5th half SAMPA corresponds to  SAMPA2
-        ?
-        ((mCRU % 2) ? 16 : 0)          // every even CRU receives channel 0-15 from SAMPA 2, the odd ones channel 16-31
+        ? ((mCRU % 2) ? 16 : 0)        // every even CRU receives channel 0-15 from SAMPA 2, the odd ones channel 16-31
         : ((iHalfSampa % 2) ? 16 : 0); // every even half SAMPA containes channel 0-15, the odd ones channel 16-31
     iSampa =  (iHalfSampa == 4) ?
         2 :

--- a/Detectors/TPC/reconstruction/src/GBTFrameContainer.cxx
+++ b/Detectors/TPC/reconstruction/src/GBTFrameContainer.cxx
@@ -16,37 +16,26 @@
 
 using namespace o2::TPC;
 
-GBTFrameContainer::GBTFrameContainer()
-  : GBTFrameContainer(0,0)
-{}
+GBTFrameContainer::GBTFrameContainer() : GBTFrameContainer(0,0) {}
 
-GBTFrameContainer::GBTFrameContainer(int cru, int link)
-  : GBTFrameContainer(0,cru,link,-1)
-{}
+GBTFrameContainer::GBTFrameContainer(int cru, int link) : GBTFrameContainer(0,cru,link,-1) {}
 
 GBTFrameContainer::GBTFrameContainer(int size, int cru, int link, int sampaVersion)
-  : mAdcMutex()
-  , mEnableAdcClockWarning(true)
-  , mEnableSyncPatternWarning(true)
-  , mEnableStoreGBTFrames(true)
-  , mEnableCompileAdcValues(true)
-  , mAdcClock({
-      AdcClockMonitor(0),
-      AdcClockMonitor(1),
-      AdcClockMonitor(2)})
-  , mSyncPattern({
-      SyncPatternMonitor(0,0),
-      SyncPatternMonitor(0,1),
-      SyncPatternMonitor(1,0),
-      SyncPatternMonitor(1,1),
-      SyncPatternMonitor(2,0)})
-  , mPositionForHalfSampa({-1,-1,-1,-1,-1,-1,-1,-1,-1,-1})
-  , mGBTFrames()
-  , mGBTFramesAnalyzed(0)
-  , mCRU(cru)
-  , mLink(link)
-  , mSampaVersion(sampaVersion)
-  , mTimebin(0)
+  : mAdcMutex(),
+  mEnableAdcClockWarning(true),
+  mEnableSyncPatternWarning(true),
+  mEnableStoreGBTFrames(true),
+  mEnableCompileAdcValues(true),
+  mAdcClock({AdcClockMonitor(0), AdcClockMonitor(1), AdcClockMonitor(2)}),
+  mSyncPattern({ SyncPatternMonitor(0, 0), SyncPatternMonitor(0, 1), SyncPatternMonitor(1, 0),
+                 SyncPatternMonitor(1, 1), SyncPatternMonitor(2, 0) }),
+  mPositionForHalfSampa({ -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 }),
+  mGBTFrames(),
+  mGBTFramesAnalyzed(0),
+  mCRU(cru),
+  mLink(link),
+  mSampaVersion(sampaVersion),
+  mTimebin(0)
 {
   mGBTFrames.reserve(size);
 
@@ -119,13 +108,13 @@ void GBTFrameContainer::addGBTFramesFromBinaryFile(std::string fileName, std::st
       rawMarker = rawData & 0xFFFF0000;
       if ((rawMarker == 0xDEF10000) || (rawMarker == 0xDEF40000)) {
         file.read((char*)&words,3*sizeof(words[0]));
-        addGBTFrame(rawData,words[0],words[1],words[2]);
+        addGBTFrame(rawData, words[0], words[1], words[2]);
       }
     }
   } else if (type == "trorc") {
     while (!file.eof() && ((frames == -1) || (mGBTFramesAnalyzed < frames))) {
       file.read((char*)&words,4*sizeof(words[0]));
-      addGBTFrame(words[0],words[1],words[2],words[3]);
+      addGBTFrame(words[0], words[1], words[2], words[3]);
     }
   } else if (type == "trorc2") {
     //
@@ -156,7 +145,7 @@ void GBTFrameContainer::addGBTFramesFromBinaryFile(std::string fileName, std::st
         case 1: {// raw GBT frames
           for (int i=0; i<(n_words-8); i= i+4) {
             file.read((char*)&words,4*sizeof(words[0]));
-            addGBTFrame(words[0],words[1],words[2],words[3]);
+            addGBTFrame(words[0], words[1], words[2], words[3]);
           }
           break;
           }
@@ -254,20 +243,20 @@ void GBTFrameContainer::addGBTFramesFromBinaryFile(std::string fileName, std::st
           mAdcMutex.unlock();
           break;
           }
-//          for (int i=0; i<(n_words-8); i= i+8) {
-//            file.read((char*)&words,8*sizeof(words[0]));
-//            addGBTFrame(words[0],words[1],words[2],words[3]);
-//          }
-//          break;
+                //          for (int i=0; i<(n_words-8); i= i+8) {
+                //            file.read((char*)&words,8*sizeof(words[0]));
+                //            addGBTFrame(words[0],words[1],words[2],words[3]);
+                //          }
+                //          break;
 
         default:
-          break;
+                break;
       }
     }
-//    while (!file.eof() && ((frames == -1) || (mGBTFramesAnalyzed < frames))) {
-//      file.read((char*)&words,8*sizeof(words[0]));
-//      addGBTFrame(words[0],words[1],words[2],words[3]);
-//    }
+    //    while (!file.eof() && ((frames == -1) || (mGBTFramesAnalyzed < frames))) {
+    //      file.read((char*)&words,8*sizeof(words[0]));
+    //      addGBTFrame(words[0],words[1],words[2],words[3]);
+    //    }
   }
 }
 
@@ -298,9 +287,8 @@ void GBTFrameContainer::processAllFrames()
   mAdcMutex.lock();
   for (std::array<std::queue<short>*,5>::iterator it = mAdcValues.begin(); it != mAdcValues.end(); ++it) {
     if ((*it)->size() > 0) {
-      LOG(WARNING) << "There are already some ADC values for half SAMPA "
-        << std::distance(mAdcValues.begin(),it)
-        << " , maybe the frames were already processed." << FairLogger::endl;
+      LOG(WARNING) << "There are already some ADC values for half SAMPA " << std::distance(mAdcValues.begin(), it)
+                   << " , maybe the frames were already processed." << FairLogger::endl;
     }
   }
   mAdcMutex.unlock();
@@ -332,39 +320,31 @@ void GBTFrameContainer::compileAdcValues(std::vector<GBTFrame>::iterator iFrame)
 
     switch(mPositionForHalfSampa[iHalfSampa]) {
       case 0:
-        value1 =
-            (iFrame->getHalfWord(iHalfSampa/2,1,iHalfSampa%2) << 5) |
-             iFrame->getHalfWord(iHalfSampa/2,0,iHalfSampa%2);
-        value2 =
-            (iFrame->getHalfWord(iHalfSampa/2,3,iHalfSampa%2) << 5) |
-             iFrame->getHalfWord(iHalfSampa/2,2,iHalfSampa%2);
+        value1 = (iFrame->getHalfWord(iHalfSampa / 2, 1, iHalfSampa % 2) << 5) |
+                  iFrame->getHalfWord(iHalfSampa / 2, 0, iHalfSampa % 2);
+        value2 = (iFrame->getHalfWord(iHalfSampa / 2, 3, iHalfSampa % 2) << 5) |
+                  iFrame->getHalfWord(iHalfSampa / 2, 2, iHalfSampa % 2);
         break;
 
       case 1:
-        value1 =
-            ((iFrame-1)->getHalfWord(iHalfSampa/2,2,iHalfSampa%2) << 5) |
-             (iFrame-1)->getHalfWord(iHalfSampa/2,1,iHalfSampa%2);
-        value2 =
-            (iFrame   ->getHalfWord(iHalfSampa/2,0,iHalfSampa%2) << 5) |
-            (iFrame-1)->getHalfWord(iHalfSampa/2,3,iHalfSampa%2);
+        value1 = ((iFrame - 1)->getHalfWord(iHalfSampa / 2, 2, iHalfSampa % 2) << 5) |
+                  (iFrame - 1)->getHalfWord(iHalfSampa / 2, 1, iHalfSampa % 2);
+        value2 = (iFrame->getHalfWord(iHalfSampa / 2, 0, iHalfSampa % 2) << 5) |
+                 (iFrame - 1)->getHalfWord(iHalfSampa / 2, 3, iHalfSampa % 2);
         break;
 
       case 2:
-        value1 =
-            ((iFrame-1)->getHalfWord(iHalfSampa/2,3,iHalfSampa%2) << 5) |
-             (iFrame-1)->getHalfWord(iHalfSampa/2,2,iHalfSampa%2);
-        value2 =
-            (iFrame->getHalfWord(iHalfSampa/2,1,iHalfSampa%2) << 5) |
-             iFrame->getHalfWord(iHalfSampa/2,0,iHalfSampa%2);
+        value1 = ((iFrame - 1)->getHalfWord(iHalfSampa / 2, 3, iHalfSampa % 2) << 5) |
+                  (iFrame - 1)->getHalfWord(iHalfSampa / 2, 2, iHalfSampa % 2);
+        value2 = (iFrame->getHalfWord(iHalfSampa / 2, 1, iHalfSampa % 2) << 5) |
+                  iFrame->getHalfWord(iHalfSampa / 2, 0, iHalfSampa % 2);
         break;
 
       case 3:
-        value1 =
-            (iFrame   ->getHalfWord(iHalfSampa/2,0,iHalfSampa%2) << 5) |
-            (iFrame-1)->getHalfWord(iHalfSampa/2,3,iHalfSampa%2);
-        value2 =
-            (iFrame->getHalfWord(iHalfSampa/2,2,iHalfSampa%2) << 5) |
-             iFrame->getHalfWord(iHalfSampa/2,1,iHalfSampa%2);
+        value1 = (iFrame->getHalfWord(iHalfSampa / 2, 0, iHalfSampa % 2) << 5) |
+                 (iFrame - 1)->getHalfWord(iHalfSampa / 2, 3, iHalfSampa % 2);
+        value2 = (iFrame->getHalfWord(iHalfSampa / 2, 2, iHalfSampa % 2) << 5) |
+                  iFrame->getHalfWord(iHalfSampa / 2, 1, iHalfSampa % 2);
         break;
 
       default:
@@ -373,15 +353,15 @@ void GBTFrameContainer::compileAdcValues(std::vector<GBTFrame>::iterator iFrame)
     }
 
     if (mSampaVersion == 1 || mSampaVersion == 2) {
-      mAdcValues[iHalfSampa]->emplace(value1 ^ (1 << 9));   // Invert bit 9 vor SAMPA v1 and v2
-      mAdcValues[iHalfSampa]->emplace(value2 ^ (1 << 9));   // Invert bit 9 vor SAMPA v1 and v2
+      mAdcValues[iHalfSampa]->emplace(value1 ^ (1 << 9)); // Invert bit 9 vor SAMPA v1 and v2
+      mAdcValues[iHalfSampa]->emplace(value2 ^ (1 << 9)); // Invert bit 9 vor SAMPA v1 and v2
     } else {
       mAdcValues[iHalfSampa]->emplace(value1);
       mAdcValues[iHalfSampa]->emplace(value2);
     }
-//  std::cout << iHalfSampa << " " << std::hex
-//     << "0x" << std::setfill('0') << std::setw(3) << *(mAdcValues[iHalfSampa]->rbegin()+1) << " "
-//     << "0x" << std::setfill('0') << std::setw(3) << *(mAdcValues[iHalfSampa]->rbegin()) << std::dec << std::endl;
+    //  std::cout << iHalfSampa << " " << std::hex
+    //     << "0x" << std::setfill('0') << std::setw(3) << *(mAdcValues[iHalfSampa]->rbegin()+1) << " "
+    //     << "0x" << std::setfill('0') << std::setw(3) << *(mAdcValues[iHalfSampa]->rbegin()) << std::dec << std::endl;
   }
   mAdcMutex.unlock();
 }
@@ -442,20 +422,21 @@ void GBTFrameContainer::searchSyncPattern(std::vector<GBTFrame>::iterator iFrame
     mPositionForHalfSampa[4] = mSyncPattern[4].getPosition();
   }
 
-//  std::cout << mPositionForHalfSampa[0] << " " << mPositionForHalfSampa[1] << " " << mPositionForHalfSampa[2] << " " << mPositionForHalfSampa[3] << " " << mPositionForHalfSampa[4] << std::endl;
+  //  std::cout << mPositionForHalfSampa[0] << " " << mPositionForHalfSampa[1] << " " << mPositionForHalfSampa[2] << " " << mPositionForHalfSampa[3] << " " << mPositionForHalfSampa[4] << std::endl;
 
   if (mEnableSyncPatternWarning) {
     if (mPositionForHalfSampa[0] != mPositionForHalfSampa[1]) {
       LOG(WARNING) << "The two half words from SAMPA 0 don't start at the same position, lower bits start at "
-        << mPositionForHalfSampa[0] << ", higher bits at " << mPositionForHalfSampa[1] << FairLogger::endl;
+                   << mPositionForHalfSampa[0] << ", higher bits at " << mPositionForHalfSampa[1] << FairLogger::endl;
     }
     if (mPositionForHalfSampa[2] != mPositionForHalfSampa[3]) {
       LOG(WARNING) << "The two half words from SAMPA 1 don't start at the same position, lower bits start at "
-        << mPositionForHalfSampa[2] << ", higher bits at " << mPositionForHalfSampa[3] << FairLogger::endl;
+                   << mPositionForHalfSampa[2] << ", higher bits at " << mPositionForHalfSampa[3] << FairLogger::endl;
     }
     if (mPositionForHalfSampa[0] != mPositionForHalfSampa[2] || mPositionForHalfSampa[0] != mPositionForHalfSampa[4]) {
       LOG(WARNING) << "The three SAMPAs don't have the same position, SAMPA0 = " << mPositionForHalfSampa[0]
-        << ", SAMPA1 = " << mPositionForHalfSampa[2] << ", SAMPA2 = " << mPositionForHalfSampa[4] << FairLogger::endl;
+                   << ", SAMPA1 = " << mPositionForHalfSampa[2] << ", SAMPA2 = " << mPositionForHalfSampa[4]
+                   << FairLogger::endl;
     }
   }
 }
@@ -479,7 +460,7 @@ bool GBTFrameContainer::getData(std::vector<Digit>& container)
   mAdcMutex.lock();
   for (int iHalfSampa = 0; iHalfSampa < 5; ++iHalfSampa)
   {
-    if (mAdcValues[iHalfSampa]->size() < 16){
+    if (mAdcValues[iHalfSampa]->size() < 16) {
       mTmpData[iHalfSampa].fill(0);
       continue;
     }
@@ -503,9 +484,11 @@ bool GBTFrameContainer::getData(std::vector<Digit>& container)
   int iPad;
   for (int iHalfSampa = 0; iHalfSampa < 5; ++iHalfSampa)
   {
-    iSampaChannel = (iHalfSampa == 4) ?     // 5th half SAMPA corresponds to  SAMPA2
-        ((mCRU%2) ? 16 : 0) :                   // every even CRU receives channel 0-15 from SAMPA 2, the odd ones channel 16-31
-        ((iHalfSampa%2) ? 16 : 0);              // every even half SAMPA containes channel 0-15, the odd ones channel 16-31
+    iSampaChannel =
+      (iHalfSampa == 4) ? // 5th half SAMPA corresponds to  SAMPA2
+        ((mCRU%2) ? 16 : 0) // every even CRU receives channel 0-15 from SAMPA 2, the odd ones channel 16-31
+                        :
+        ((iHalfSampa%2) ? 16 : 0); // every even half SAMPA containes channel 0-15, the odd ones channel 16-31
     iSampa =  (iHalfSampa == 4) ?
         2 :
         (mCRU%2) ? iHalfSampa/2+3 : iHalfSampa/2;
@@ -519,7 +502,6 @@ bool GBTFrameContainer::getData(std::vector<Digit>& container)
       iRow = padPos.getRow();
       iPad = padPos.getPad();
       iCharge = *it;
-//      std::cout << mCRU/2 << " " << mLink << " " << iSampa << " " << iSampaChannel << " " << iRow << " " << iPad << " " << iTimeBin << " " << iCharge << std::endl;
 
       container.emplace_back(mCRU, iCharge, iRow, iPad, iTimeBin);
       ++iSampaChannel;
@@ -571,11 +553,11 @@ bool GBTFrameContainer::getData(std::vector<HalfSAMPAData>& container)
 //    iSampaChannel = (iHalfSampa == 4) ?         // 5th half SAMPA corresponds to  SAMPA2
 //        ((mCRU%2) ? 16 : 0) :                   // every even CRU receives channel 0-15 from SAMPA 2, the odd ones channel 16-31
 //        ((iHalfSampa%2) ? 16 : 0);              // every even half SAMPA containes channel 0-15, the odd ones channel 16-31
-    iSampa =  (iHalfSampa == 4) ?
+    iSampa = (iHalfSampa == 4) ?
         2 :
         (mCRU%2) ? iHalfSampa/2+3 : iHalfSampa/2;
 
-    container.emplace_back(iSampa,!((bool)mCRU%2),mTmpData[iHalfSampa]);
+    container.emplace_back(iSampa, !((bool)mCRU % 2), mTmpData[iHalfSampa]);
 //    container.at(iHalfSampa).setID(iSampa);
 //    for (std::array<short,16>::iterator it = mTmpData[iHalfSampa].begin(); it != mTmpData[iHalfSampa].end(); ++it)
 //    {

--- a/Detectors/TPC/reconstruction/src/GBTFrameContainer.cxx
+++ b/Detectors/TPC/reconstruction/src/GBTFrameContainer.cxx
@@ -17,25 +17,23 @@
 using namespace o2::TPC;
 
 GBTFrameContainer::GBTFrameContainer() : GBTFrameContainer(0,0) {}
-
 GBTFrameContainer::GBTFrameContainer(int cru, int link) : GBTFrameContainer(0,cru,link,-1) {}
-
 GBTFrameContainer::GBTFrameContainer(int size, int cru, int link, int sampaVersion)
   : mAdcMutex(),
-  mEnableAdcClockWarning(true),
-  mEnableSyncPatternWarning(true),
-  mEnableStoreGBTFrames(true),
-  mEnableCompileAdcValues(true),
-  mAdcClock({AdcClockMonitor(0), AdcClockMonitor(1), AdcClockMonitor(2)}),
-  mSyncPattern({ SyncPatternMonitor(0, 0), SyncPatternMonitor(0, 1), SyncPatternMonitor(1, 0),
-                 SyncPatternMonitor(1, 1), SyncPatternMonitor(2, 0) }),
-  mPositionForHalfSampa({ -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 }),
-  mGBTFrames(),
-  mGBTFramesAnalyzed(0),
-  mCRU(cru),
-  mLink(link),
-  mSampaVersion(sampaVersion),
-  mTimebin(0)
+    mEnableAdcClockWarning(true),
+    mEnableSyncPatternWarning(true),
+    mEnableStoreGBTFrames(true),
+    mEnableCompileAdcValues(true),
+    mAdcClock({AdcClockMonitor(0), AdcClockMonitor(1), AdcClockMonitor(2)}),
+    mSyncPattern({ SyncPatternMonitor(0, 0), SyncPatternMonitor(0, 1), SyncPatternMonitor(1, 0),
+                   SyncPatternMonitor(1, 1), SyncPatternMonitor(2, 0) }),
+    mPositionForHalfSampa({ -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 }),
+    mGBTFrames(),
+    mGBTFramesAnalyzed(0),
+    mCRU(cru),
+    mLink(link),
+    mSampaVersion(sampaVersion),
+    mTimebin(0)
 {
   mGBTFrames.reserve(size);
 
@@ -243,14 +241,14 @@ void GBTFrameContainer::addGBTFramesFromBinaryFile(std::string fileName, std::st
           mAdcMutex.unlock();
           break;
           }
-                //          for (int i=0; i<(n_words-8); i= i+8) {
-                //            file.read((char*)&words,8*sizeof(words[0]));
-                //            addGBTFrame(words[0],words[1],words[2],words[3]);
-                //          }
-                //          break;
+          //          for (int i=0; i<(n_words-8); i= i+8) {
+          //            file.read((char*)&words,8*sizeof(words[0]));
+          //            addGBTFrame(words[0],words[1],words[2],words[3]);
+          //          }
+          //          break;
 
-        default:
-                break;
+          default:
+            break;
       }
     }
     //    while (!file.eof() && ((frames == -1) || (mGBTFramesAnalyzed < frames))) {
@@ -321,30 +319,30 @@ void GBTFrameContainer::compileAdcValues(std::vector<GBTFrame>::iterator iFrame)
     switch(mPositionForHalfSampa[iHalfSampa]) {
       case 0:
         value1 = (iFrame->getHalfWord(iHalfSampa / 2, 1, iHalfSampa % 2) << 5) |
-                  iFrame->getHalfWord(iHalfSampa / 2, 0, iHalfSampa % 2);
+                 iFrame->getHalfWord(iHalfSampa / 2, 0, iHalfSampa % 2);
         value2 = (iFrame->getHalfWord(iHalfSampa / 2, 3, iHalfSampa % 2) << 5) |
-                  iFrame->getHalfWord(iHalfSampa / 2, 2, iHalfSampa % 2);
+                 iFrame->getHalfWord(iHalfSampa / 2, 2, iHalfSampa % 2);
         break;
 
       case 1:
         value1 = ((iFrame - 1)->getHalfWord(iHalfSampa / 2, 2, iHalfSampa % 2) << 5) |
-                  (iFrame - 1)->getHalfWord(iHalfSampa / 2, 1, iHalfSampa % 2);
+                 (iFrame - 1)->getHalfWord(iHalfSampa / 2, 1, iHalfSampa % 2);
         value2 = (iFrame->getHalfWord(iHalfSampa / 2, 0, iHalfSampa % 2) << 5) |
                  (iFrame - 1)->getHalfWord(iHalfSampa / 2, 3, iHalfSampa % 2);
         break;
 
       case 2:
         value1 = ((iFrame - 1)->getHalfWord(iHalfSampa / 2, 3, iHalfSampa % 2) << 5) |
-                  (iFrame - 1)->getHalfWord(iHalfSampa / 2, 2, iHalfSampa % 2);
+                 (iFrame - 1)->getHalfWord(iHalfSampa / 2, 2, iHalfSampa % 2);
         value2 = (iFrame->getHalfWord(iHalfSampa / 2, 1, iHalfSampa % 2) << 5) |
-                  iFrame->getHalfWord(iHalfSampa / 2, 0, iHalfSampa % 2);
+                 iFrame->getHalfWord(iHalfSampa / 2, 0, iHalfSampa % 2);
         break;
 
       case 3:
         value1 = (iFrame->getHalfWord(iHalfSampa / 2, 0, iHalfSampa % 2) << 5) |
                  (iFrame - 1)->getHalfWord(iHalfSampa / 2, 3, iHalfSampa % 2);
         value2 = (iFrame->getHalfWord(iHalfSampa / 2, 2, iHalfSampa % 2) << 5) |
-                  iFrame->getHalfWord(iHalfSampa / 2, 1, iHalfSampa % 2);
+                 iFrame->getHalfWord(iHalfSampa / 2, 1, iHalfSampa % 2);
         break;
 
       default:
@@ -422,8 +420,6 @@ void GBTFrameContainer::searchSyncPattern(std::vector<GBTFrame>::iterator iFrame
     mPositionForHalfSampa[4] = mSyncPattern[4].getPosition();
   }
 
-  //  std::cout << mPositionForHalfSampa[0] << " " << mPositionForHalfSampa[1] << " " << mPositionForHalfSampa[2] << " " << mPositionForHalfSampa[3] << " " << mPositionForHalfSampa[4] << std::endl;
-
   if (mEnableSyncPatternWarning) {
     if (mPositionForHalfSampa[0] != mPositionForHalfSampa[1]) {
       LOG(WARNING) << "The two half words from SAMPA 0 don't start at the same position, lower bits start at "
@@ -485,10 +481,10 @@ bool GBTFrameContainer::getData(std::vector<Digit>& container)
   for (int iHalfSampa = 0; iHalfSampa < 5; ++iHalfSampa)
   {
     iSampaChannel =
-      (iHalfSampa == 4) ? // 5th half SAMPA corresponds to  SAMPA2
-        ((mCRU%2) ? 16 : 0) // every even CRU receives channel 0-15 from SAMPA 2, the odd ones channel 16-31
-                        :
-        ((iHalfSampa%2) ? 16 : 0); // every even half SAMPA containes channel 0-15, the odd ones channel 16-31
+      (iHalfSampa == 4)                // 5th half SAMPA corresponds to  SAMPA2
+        ?
+        ((mCRU % 2) ? 16 : 0)          // every even CRU receives channel 0-15 from SAMPA 2, the odd ones channel 16-31
+        : ((iHalfSampa % 2) ? 16 : 0); // every even half SAMPA containes channel 0-15, the odd ones channel 16-31
     iSampa =  (iHalfSampa == 4) ?
         2 :
         (mCRU%2) ? iHalfSampa/2+3 : iHalfSampa/2;
@@ -549,21 +545,9 @@ bool GBTFrameContainer::getData(std::vector<HalfSAMPAData>& container)
 
   for (int iHalfSampa = 0; iHalfSampa < 5; ++iHalfSampa)
   {
-//    iSampaChannel = 0;
-//    iSampaChannel = (iHalfSampa == 4) ?         // 5th half SAMPA corresponds to  SAMPA2
-//        ((mCRU%2) ? 16 : 0) :                   // every even CRU receives channel 0-15 from SAMPA 2, the odd ones channel 16-31
-//        ((iHalfSampa%2) ? 16 : 0);              // every even half SAMPA containes channel 0-15, the odd ones channel 16-31
-    iSampa = (iHalfSampa == 4) ?
-        2 :
-        (mCRU%2) ? iHalfSampa/2+3 : iHalfSampa/2;
+    iSampa = (iHalfSampa == 4) ? 2 : (mCRU % 2) ? iHalfSampa / 2 + 3 : iHalfSampa / 2;
 
     container.emplace_back(iSampa, !((bool)mCRU % 2), mTmpData[iHalfSampa]);
-//    container.at(iHalfSampa).setID(iSampa);
-//    for (std::array<short,16>::iterator it = mTmpData[iHalfSampa].begin(); it != mTmpData[iHalfSampa].end(); ++it)
-//    {
-//      container.at(iHalfSampa).setChannel(iSampaChannel,*it);
-//      ++iSampaChannel;
-//    }
   }
   return dataAvailable;
 }

--- a/Detectors/TPC/reconstruction/src/RawReader.cxx
+++ b/Detectors/TPC/reconstruction/src/RawReader.cxx
@@ -28,21 +28,21 @@ using namespace o2::TPC;
 
 RawReader::RawReader(int region, int link, int run, int sampaVersion)
   : mUseRawInMode3(true),
-  mApplyChannelMask(false),
-  mCheckAdcClock(false),
-  mRegion(region),
-  mLink(link),
-  mRun(run),
-  mSampaVersion(sampaVersion),
-  mLastEvent(-1),
-  mTimestampOfFirstData({ 0, 0, 0, 0, 0}),
-  mEvents(),
-  mData(),
-  mDataIterator(mData.end()),
-  mSyncPos(),
-  mChannelMask(nullptr),
-  mAdcError(std::make_shared<std::vector<std::tuple<short,short,short>>>()),
-  mEventSynchronizer(std::make_shared<RawReaderEventSync>())
+    mApplyChannelMask(false),
+    mCheckAdcClock(false),
+    mRegion(region),
+    mLink(link),
+    mRun(run),
+    mSampaVersion(sampaVersion),
+    mLastEvent(-1),
+    mTimestampOfFirstData({ 0, 0, 0, 0, 0}),
+    mEvents(),
+    mData(),
+    mDataIterator(mData.end()),
+    mSyncPos(),
+    mChannelMask(nullptr),
+    mAdcError(std::make_shared<std::vector<std::tuple<short,short,short>>>()),
+    mEventSynchronizer(std::make_shared<RawReaderEventSync>())
 {
   mSyncPos.fill(-1);
 }
@@ -103,10 +103,9 @@ bool RawReader::addInputFile(std::string infile) {
 
 bool RawReader::addInputFile(int region, int link, int sampaVersion, std::string path, int run)
 {
-
   if (mRun == -1)
     mRun = run;
-  if (mRegion == -1 )
+  if (mRegion == -1)
     mRegion = region;
   if (mLink == -1)
     mLink = link;

--- a/Detectors/TPC/reconstruction/src/RawReader.cxx
+++ b/Detectors/TPC/reconstruction/src/RawReader.cxx
@@ -35,13 +35,13 @@ RawReader::RawReader(int region, int link, int run, int sampaVersion)
     mRun(run),
     mSampaVersion(sampaVersion),
     mLastEvent(-1),
-    mTimestampOfFirstData({ 0, 0, 0, 0, 0}),
+    mTimestampOfFirstData({ 0, 0, 0, 0, 0 }),
     mEvents(),
     mData(),
     mDataIterator(mData.end()),
     mSyncPos(),
     mChannelMask(nullptr),
-    mAdcError(std::make_shared<std::vector<std::tuple<short,short,short>>>()),
+    mAdcError(std::make_shared<std::vector<std::tuple<short, short, short>>>()),
     mEventSynchronizer(std::make_shared<RawReaderEventSync>())
 {
   mSyncPos.fill(-1);

--- a/Detectors/TPC/reconstruction/src/RawReader.cxx
+++ b/Detectors/TPC/reconstruction/src/RawReader.cxx
@@ -27,22 +27,22 @@
 using namespace o2::TPC;
 
 RawReader::RawReader(int region, int link, int run, int sampaVersion)
-  : mUseRawInMode3(true)
-  , mApplyChannelMask(false)
-  , mCheckAdcClock(false)
-  , mRegion(region)
-  , mLink(link)
-  , mRun(run)
-  , mSampaVersion(sampaVersion)
-  , mLastEvent(-1)
-  , mTimestampOfFirstData({0,0,0,0,0})
-  , mEvents()
-  , mData()
-  , mDataIterator(mData.end())
-  , mSyncPos()
-  , mChannelMask(nullptr)
-  , mAdcError(std::make_shared<std::vector<std::tuple<short,short,short>>>())
-  , mEventSynchronizer(std::make_shared<RawReaderEventSync>())
+  : mUseRawInMode3(true),
+  mApplyChannelMask(false),
+  mCheckAdcClock(false),
+  mRegion(region),
+  mLink(link),
+  mRun(run),
+  mSampaVersion(sampaVersion),
+  mLastEvent(-1),
+  mTimestampOfFirstData({ 0, 0, 0, 0, 0}),
+  mEvents(),
+  mData(),
+  mDataIterator(mData.end()),
+  mSyncPos(),
+  mChannelMask(nullptr),
+  mAdcError(std::make_shared<std::vector<std::tuple<short,short,short>>>()),
+  mEventSynchronizer(std::make_shared<RawReaderEventSync>())
 {
   mSyncPos.fill(-1);
 }
@@ -73,7 +73,7 @@ bool RawReader::addInputFile(std::string infile) {
   try {
     ++it1;
     region = boost::lexical_cast<int>(*it1);
-  } catch(boost::bad_lexical_cast) {
+  } catch (boost::bad_lexical_cast) {
     LOG(ERROR) << "Please enter a region for " << path << FairLogger::endl;
     return false;
   }
@@ -81,7 +81,7 @@ bool RawReader::addInputFile(std::string infile) {
   try {
     ++it1;
     link = boost::lexical_cast<int>(*it1);
-  } catch(boost::bad_lexical_cast) {
+  } catch (boost::bad_lexical_cast) {
     LOG(ERROR) << "Please enter a link number for " << path << FairLogger::endl;
     return false;
   }
@@ -92,7 +92,7 @@ bool RawReader::addInputFile(std::string infile) {
   } else {
     try {
       sampaVersion = boost::lexical_cast<int>(*it1);
-    } catch(boost::bad_lexical_cast) {
+    } catch (boost::bad_lexical_cast) {
       LOG(ERROR) << "Please enter a valid SAMPA version for " << path << FairLogger::endl;
       return false;
     }
@@ -101,12 +101,17 @@ bool RawReader::addInputFile(std::string infile) {
   return addInputFile(region, link, sampaVersion, path, run);
 }
 
-bool RawReader::addInputFile(int region, int link, int sampaVersion, std::string path, int run){
+bool RawReader::addInputFile(int region, int link, int sampaVersion, std::string path, int run)
+{
 
-  if (mRun == -1) mRun = run;
-  if (mRegion == -1 ) mRegion = region;
-  if (mLink == -1) mLink = link;
-  if (mSampaVersion == -1) mSampaVersion = sampaVersion;
+  if (mRun == -1)
+    mRun = run;
+  if (mRegion == -1 )
+    mRegion = region;
+  if (mLink == -1)
+    mLink = link;
+  if (mSampaVersion == -1)
+    mSampaVersion = sampaVersion;
 
   if (run != mRun) {
     LOG(DEBUG) << "Run of RawReader is " << mRun << " and not " << run << FairLogger::endl;
@@ -472,11 +477,11 @@ bool RawReader::decodeRawGBTFrames(EventInfo eventInfo) {
       }
 
       if (mSampaVersion == 1 || mSampaVersion == 2) {
-        adcValues[iHalfSampa].emplace_back( value1 ^ (1 << 9)); // Invert bit 9 vor SAMPA v1 and v2
-        adcValues[iHalfSampa].emplace_back( value2 ^ (1 << 9)); // Invert bit 9 vor SAMPA v1 and v2
+        adcValues[iHalfSampa].emplace_back(value1 ^ (1 << 9)); // Invert bit 9 vor SAMPA v1 and v2
+        adcValues[iHalfSampa].emplace_back(value2 ^ (1 << 9)); // Invert bit 9 vor SAMPA v1 and v2
       } else {
-        adcValues[iHalfSampa].emplace_back( value1 );
-        adcValues[iHalfSampa].emplace_back( value2 );
+        adcValues[iHalfSampa].emplace_back(value1);
+        adcValues[iHalfSampa].emplace_back(value2);
       }
     }
 


### PR DESCRIPTION
New SAMPA v3 and v4 do flipping of bit9 now internally, therefore the decoding should not do this as well. To keep backwards compatibility, the SMAPA version can be set for the decoding.