### PR TITLE
clang-format: avoid removal of empty lines

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -27,6 +27,7 @@ IndentWidth:     2
 # It is broken on windows. Breaks all #include "header.h"
 Language:        Cpp
 MaxEmptyLinesToKeep: 1
+KeepEmptyLinesAtTheStartOfBlocks: true
 NamespaceIndentation: None
 ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: false


### PR DESCRIPTION
Adding a new configuration key. This fixes an unwanted behaviour where
empty lines, for example between function declarations, were removed by clang-format.