### PR TITLE
Add Labels to DataProcessorSpec

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -74,6 +74,7 @@ set(TEST_SRCS
       test/test_BoostOptionsRetriever.cxx
       test/test_DataRelayer.cxx
       test/test_DataRefUtils.cxx
+      test/test_DataProcessorSpec.cxx
       test/test_DeviceMetricsInfo.cxx
       test/test_DeviceSpec.cxx
       test/test_FrameworkDataFlowToDDS.cxx

--- a/Framework/Core/include/Framework/DataProcessorLabel.h
+++ b/Framework/Core/include/Framework/DataProcessorLabel.h
@@ -1,0 +1,20 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+namespace o2
+{
+namespace framework
+{
+/// A label that can be associated to a DataProcessorSpec
+struct DataProcessorLabel {
+  std::string value;
+};
+} // namespace framework
+} // namespace o2

--- a/Framework/Core/include/Framework/DataProcessorSpec.h
+++ b/Framework/Core/include/Framework/DataProcessorSpec.h
@@ -10,19 +10,21 @@
 #ifndef FRAMEWORK_DATAPROCESSORSPEC_H
 #define FRAMEWORK_DATAPROCESSORSPEC_H
 
+#include "Framework/AlgorithmSpec.h"
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/DataAllocator.h"
+#include "Framework/DataProcessorLabel.h"
+#include "Framework/DataRef.h"
 #include "Framework/InputSpec.h"
 #include "Framework/OutputSpec.h"
-#include "Framework/ConfigParamSpec.h"
-#include "Framework/DataRef.h"
-#include "Framework/DataAllocator.h"
-#include "Framework/AlgorithmSpec.h"
-#include "Framework/DataProcessorLabel.h"
 
-#include <vector>
 #include <string>
+#include <vector>
 
-namespace o2 {
-namespace framework {
+namespace o2
+{
+namespace framework
+{
 
 using Inputs = std::vector<InputSpec>;
 using Outputs = std::vector<OutputSpec>;

--- a/Framework/Core/include/Framework/DataProcessorSpec.h
+++ b/Framework/Core/include/Framework/DataProcessorSpec.h
@@ -16,6 +16,7 @@
 #include "Framework/DataRef.h"
 #include "Framework/DataAllocator.h"
 #include "Framework/AlgorithmSpec.h"
+#include "Framework/DataProcessorLabel.h"
 
 #include <vector>
 #include <string>
@@ -39,6 +40,14 @@ struct DataProcessorSpec {
   Options options;
   // FIXME: not used for now...
   std::vector<std::string> requiredServices;
+  /// Labels associated to the DataProcessor. These can
+  /// be used to group different DataProcessor together
+  /// and they can allow to filter different groups, e.g.
+  /// use push/pull rather than pub/sub for all the edges
+  /// which involve a DataProcessorSpec with a given label.
+  /// Examples labels could be "reco", "qc".
+  std::vector<DataProcessorLabel> labels;
+
   // FIXME: for the moment I put them here, but it's a hack
   //        since we do not want to expose this to users...
   //        Maybe we should have a ParallelGroup kind of node

--- a/Framework/Core/test/test_DataProcessorSpec.cxx
+++ b/Framework/Core/test/test_DataProcessorSpec.cxx
@@ -1,0 +1,36 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+
+#define BOOST_TEST_MODULE Test Framework DataProcessorSpec
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include "Framework/DataProcessorSpec.h"
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE(TestServiceRegistry) {
+  using namespace o2::framework;
+  DataProcessorSpec spec{
+    "test",
+    {},
+    {},
+    AlgorithmSpec{
+      [](ProcessingContext &ctx) {}
+    },
+    {
+      ConfigParamSpec{"channel-config", VariantType::String, "name=foo,type=sub,method=connect,address=tcp://localhost:5450,rateLogging=1", {"Out-of-band channel config"}}
+    },
+    {},
+    {DataProcessorLabel{"label"}}
+  };
+
+  BOOST_CHECK_EQUAL(spec.labels.size(), 1);
+}

--- a/Framework/Core/test/test_DataProcessorSpec.cxx
+++ b/Framework/Core/test/test_DataProcessorSpec.cxx
@@ -8,29 +8,27 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-
 #define BOOST_TEST_MODULE Test Framework DataProcessorSpec
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
 
-#include "Framework/DataProcessorSpec.h"
 #include <boost/test/unit_test.hpp>
+#include "Framework/DataProcessorSpec.h"
 
-BOOST_AUTO_TEST_CASE(TestServiceRegistry) {
+BOOST_AUTO_TEST_CASE(TestServiceRegistry)
+{
   using namespace o2::framework;
-  DataProcessorSpec spec{
-    "test",
-    {},
-    {},
-    AlgorithmSpec{
-      [](ProcessingContext &ctx) {}
-    },
-    {
-      ConfigParamSpec{"channel-config", VariantType::String, "name=foo,type=sub,method=connect,address=tcp://localhost:5450,rateLogging=1", {"Out-of-band channel config"}}
-    },
-    {},
-    {DataProcessorLabel{"label"}}
-  };
+  DataProcessorSpec spec{ "test",
+                          {},
+                          {},
+                          AlgorithmSpec{ [](ProcessingContext& ctx) {} },
+                          { ConfigParamSpec{
+                            "channel-config",
+                            VariantType::String,
+                            "name=foo,type=sub,method=connect,address=tcp://localhost:5450,rateLogging=1",
+                            { "Out-of-band channel config" } } },
+                          {},
+                          { DataProcessorLabel{ "label" } } };
 
   BOOST_CHECK_EQUAL(spec.labels.size(), 1);
 }


### PR DESCRIPTION
This allows optionally specifying one or more label to be associated
to the DataProcessorSpec, to be later used for things like generating
sub-topologies for a given label or to customize behavior for devices
associated with a DataProcessorSpec with a given label.