### PR TITLE
Introduce a state machine for the DPL driver process

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -36,6 +36,8 @@ set(SRCS
     src/DeviceSpec.cxx
     src/DeviceSpecHelpers.cxx
     src/DDSConfigHelpers.cxx
+    src/DriverControl.cxx
+    src/DriverInfo.cxx
     src/FairOptionsRetriever.cxx
     src/GraphvizHelpers.cxx
     src/InputRecord.cxx

--- a/Framework/Core/include/Framework/DeviceInfo.h
+++ b/Framework/Core/include/Framework/DeviceInfo.h
@@ -38,6 +38,7 @@ struct DeviceInfo {
   /// A circular buffer for the severity of each of the entries
   /// in the circular buffer associated to the device.
   std::vector<LogParsingHelpers::LogLevel> historyLevel;
+  std::string lastError;
   /// An unterminated string which is not ready to be printed yet
   std::string unprinted;
   /// Whether the device is active (running) or not.

--- a/Framework/Core/include/Framework/DeviceInfo.h
+++ b/Framework/Core/include/Framework/DeviceInfo.h
@@ -10,18 +10,20 @@
 #ifndef FRAMEWORK_DEVICEINFO_H
 #define FRAMEWORK_DEVICEINFO_H
 
-#include "Framework/Variant.h"
 #include "Framework/LogParsingHelpers.h"
+#include "Framework/Variant.h"
 
-#include <vector>
-#include <string>
 #include <cstddef>
+#include <string>
+#include <vector>
 // For pid_t
 #include <unistd.h>
 #include <array>
 
-namespace o2 {
-namespace framework {
+namespace o2
+{
+namespace framework
+{
 
 struct DeviceInfo {
   /// The pid of the device associated to this device
@@ -46,7 +48,6 @@ struct DeviceInfo {
   /// Whether the device is ready to quit.
   bool readyToQuit;
 };
-
 
 } // namespace framework
 } // namespace o2

--- a/Framework/Core/include/Framework/FrameworkGUIDebugger.h
+++ b/Framework/Core/include/Framework/FrameworkGUIDebugger.h
@@ -14,17 +14,24 @@
 #include "Framework/DeviceSpec.h"
 #include "Framework/DeviceMetricsInfo.h"
 #include "Framework/DeviceControl.h"
+
 #include <functional>
 #include <vector>
 
 namespace o2 {
 namespace framework {
 
-std::function<void(void)> getGUIDebugger(const std::vector<DeviceInfo> &infos,
-                                         const std::vector<DeviceSpec> &specs,
-                                         const std::vector<DeviceMetricsInfo> &metricsInfos,
-                                         std::vector<DeviceControl> &controls);
+class DriverInfo;
+class DriverControl;
 
+std::function<void(void)>
+getGUIDebugger(const std::vector<DeviceInfo> &infos,
+               const std::vector<DeviceSpec> &devices,
+               const std::vector<DeviceMetricsInfo> &metricsInfos,
+               const DriverInfo &driverInfo,
+               std::vector<DeviceControl> &controls,
+               DriverControl &driverControl
+               );
 }
 }
 #endif // FRAMEWORK_FRAMEWORKGUIDEBUGGER_H

--- a/Framework/Core/include/Framework/FrameworkGUIDebugger.h
+++ b/Framework/Core/include/Framework/FrameworkGUIDebugger.h
@@ -10,28 +10,26 @@
 #ifndef FRAMEWORK_FRAMEWORKGUIDEBUGGER_H
 #define FRAMEWORK_FRAMEWORKGUIDEBUGGER_H
 
-#include "Framework/DeviceInfo.h"
-#include "Framework/DeviceSpec.h"
-#include "Framework/DeviceMetricsInfo.h"
 #include "Framework/DeviceControl.h"
+#include "Framework/DeviceInfo.h"
+#include "Framework/DeviceMetricsInfo.h"
+#include "Framework/DeviceSpec.h"
 
 #include <functional>
 #include <vector>
 
-namespace o2 {
-namespace framework {
+namespace o2
+{
+namespace framework
+{
 
 class DriverInfo;
 class DriverControl;
 
-std::function<void(void)>
-getGUIDebugger(const std::vector<DeviceInfo> &infos,
-               const std::vector<DeviceSpec> &devices,
-               const std::vector<DeviceMetricsInfo> &metricsInfos,
-               const DriverInfo &driverInfo,
-               std::vector<DeviceControl> &controls,
-               DriverControl &driverControl
-               );
-}
-}
+std::function<void(void)> getGUIDebugger(const std::vector<DeviceInfo>& infos, const std::vector<DeviceSpec>& devices,
+                                         const std::vector<DeviceMetricsInfo>& metricsInfos,
+                                         const DriverInfo& driverInfo, std::vector<DeviceControl>& controls,
+                                         DriverControl& driverControl);
+} // namespace framework
+} // namespace o2
 #endif // FRAMEWORK_FRAMEWORKGUIDEBUGGER_H

--- a/Framework/Core/include/Framework/runDataProcessing.h
+++ b/Framework/Core/include/Framework/runDataProcessing.h
@@ -90,7 +90,7 @@ int main(int argc, char** argv)
   // the default one.
   UserCustomizationsHelper::userDefinedCustomization(channelPolicies, 0);
   auto result = doMain(argc, argv, specs, channelPolicies);
-  std::cout << "Process " << getpid() << " is exiting." << std::endl;
+  LOG(INFO) << "Process " << getpid() << " is exiting.";
   return result;
 }
 

--- a/Framework/Core/include/Framework/runDataProcessing.h
+++ b/Framework/Core/include/Framework/runDataProcessing.h
@@ -10,33 +10,35 @@
 #ifndef FRAMEWORK_RUN_DATA_PROCESSING_H
 #define FRAMEWORK_RUN_DATA_PROCESSING_H
 
-#include "Framework/WorkflowSpec.h"
-#include "Framework/DataProcessorSpec.h"
-#include "Framework/ChannelConfigurationPolicy.h"
-#include <vector>
 #include <unistd.h>
+#include <vector>
+#include "Framework/ChannelConfigurationPolicy.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/WorkflowSpec.h"
 
-namespace o2 {
-namespace framework {
+namespace o2
+{
+namespace framework
+{
 using WorkflowSpec = std::vector<DataProcessorSpec>;
 using Inputs = std::vector<InputSpec>;
 using Outputs = std::vector<OutputSpec>;
 using Options = std::vector<ConfigParamSpec>;
 
-}
-}
+} // namespace framework
+} // namespace o2
 
 /// To be implemented by the user to specify one or more DataProcessorSpec.
 /// The reason why this passes a preallocated specs, rather than asking the
 /// caller to allocate his / her own is that if we end up wrapping this in
 /// some scripting language, we do not need to delegate the allocation to the
 /// scripting language itself.
-void  defineDataProcessing(o2::framework::WorkflowSpec &specs);
+void defineDataProcessing(o2::framework::WorkflowSpec& specs);
 
 // This template magic allow users to customize the behavior of the process
 // by (optionally) implementing a `configure` method which modifies one of the
 // objects in question.
-// 
+//
 // For example it can be optionally implemented by the user to specify the
 // channel policies for your setup. Use this if you want to customize the way
 // your devices communicate between themself, e.g. if you want to use REQ/REP
@@ -50,8 +52,7 @@ void  defineDataProcessing(o2::framework::WorkflowSpec &specs);
 // By default we leave the channel policies unchanged. Notice that the default still include
 // a "match all" policy which uses pub / sub
 // FIXME: add a debug statement saying that the default policy was used?
-void defaultConfiguration(std::vector<o2::framework::ChannelConfigurationPolicy> &channelPolicies) {
-}
+void defaultConfiguration(std::vector<o2::framework::ChannelConfigurationPolicy>& channelPolicies) {}
 
 struct UserCustomizationsHelper {
   template <typename T>
@@ -68,13 +69,12 @@ struct UserCustomizationsHelper {
   }
 };
 
-
 // This comes from the framework itself. This way we avoid code duplication.
-int doMain(int argc, char **argv,
-           o2::framework::WorkflowSpec const &specs,
-           std::vector<o2::framework::ChannelConfigurationPolicy> const &channelPolicies);
+int doMain(int argc, char** argv, o2::framework::WorkflowSpec const& specs,
+           std::vector<o2::framework::ChannelConfigurationPolicy> const& channelPolicies);
 
-int main(int argc, char**argv) {
+int main(int argc, char** argv)
+{
   using namespace o2::framework;
 
   WorkflowSpec specs;
@@ -83,9 +83,7 @@ int main(int argc, char**argv) {
   // The default policy is a catch all pub/sub setup to be consistent with the past.
   std::vector<ChannelConfigurationPolicy> channelPolicies;
   auto defaultPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
-  channelPolicies.insert(std::end(channelPolicies),
-                         std::begin(defaultPolicies),
-                         std::end(defaultPolicies));
+  channelPolicies.insert(std::end(channelPolicies), std::begin(defaultPolicies), std::end(defaultPolicies));
 
   // The 0 here is an int, therefore having the template matching in the
   // SFINAE expression above fit better the version which invokes user code over

--- a/Framework/Core/src/DriverControl.cxx
+++ b/Framework/Core/src/DriverControl.cxx
@@ -1,0 +1,10 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "DriverControl.h"

--- a/Framework/Core/src/DriverControl.h
+++ b/Framework/Core/src/DriverControl.h
@@ -1,0 +1,28 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef FRAMEWORK_DRIVERCONTROL_H
+#define FRAMEWORK_DRIVERCONTROL_H
+
+#include "DriverInfo.h"
+#include <vector>
+
+namespace o2 {
+namespace  framework {
+
+/// Information about the driver process (i.e.  / the one which calculates the
+/// topology and actually spawns the devices )
+struct DriverControl {
+  std::vector<DriverState> forcedTransitions;
+};
+
+}
+}
+
+#endif

--- a/Framework/Core/src/DriverControl.h
+++ b/Framework/Core/src/DriverControl.h
@@ -10,11 +10,13 @@
 #ifndef FRAMEWORK_DRIVERCONTROL_H
 #define FRAMEWORK_DRIVERCONTROL_H
 
-#include "DriverInfo.h"
 #include <vector>
+#include "DriverInfo.h"
 
-namespace o2 {
-namespace  framework {
+namespace o2
+{
+namespace framework
+{
 
 /// Information about the driver process (i.e.  / the one which calculates the
 /// topology and actually spawns the devices )
@@ -22,7 +24,7 @@ struct DriverControl {
   std::vector<DriverState> forcedTransitions;
 };
 
-}
-}
+} // namespace framework
+} // namespace o2
 
 #endif

--- a/Framework/Core/src/DriverInfo.cxx
+++ b/Framework/Core/src/DriverInfo.cxx
@@ -1,0 +1,10 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "DriverInfo.h"

--- a/Framework/Core/src/DriverInfo.h
+++ b/Framework/Core/src/DriverInfo.h
@@ -1,0 +1,77 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef FRAMEWORK_DRIVER_INFO_H
+#define FRAMEWORK_DRIVER_INFO_H
+
+#include <cstddef>
+#include <map>
+#include <vector>
+
+#include <csignal>
+#include <sys/select.h>
+
+namespace o2 {
+namespace  framework {
+
+/// Possible states for the DPL Driver application
+///
+/// INIT => Initial state where global initialization should happen
+/// SCHEDULE => Invoked whenever the topology or the resources associated
+///             to it change.
+/// RUNNING => At least one device is running and processing data.
+/// GUI => Event loop for the GUI
+/// EXIT => All devices are not running and exit was requested.
+/// UNKNOWN
+/// LAST => used to indicate how many states are defined
+///
+/// The state machine is the following:
+///
+/// @dot << "digraph [
+///   INIT -> SCHEDULE
+///   SCHEDULE -> RUNNING
+///   RUNNING -> RUNNING
+///   RUNNING -> GUI
+///   GUI -> RUNNING 
+///   RUNNING -> SCHEDULE
+///   RUNNING -> EXIT
+/// ]"
+///
+enum struct DriverState {
+  INIT = 0,
+  SCHEDULE,
+  RUNNING,
+  GUI,
+  REDEPLOY_GUI,
+  EXIT,
+  UNKNOWN,
+  LAST
+};
+
+/// Information about the driver process (i.e.  / the one which calculates the
+/// topology and actually spawns the devices )
+struct DriverInfo {
+  /// Stack with the states to be processed next.
+  std::vector<DriverState> states;
+  // Mapping between various pipes and the actual device information.
+  // Key is the file description, value is index in the previous vector.
+  std::map<int, size_t> socket2DeviceInfo;
+  /// The first unused file descriptor
+  int maxFd;
+  fd_set childFdset;
+
+  // Signal handler for children
+  struct sigaction sa_handle_child;
+};
+
+}
+}
+
+#endif

--- a/Framework/Core/src/DriverInfo.h
+++ b/Framework/Core/src/DriverInfo.h
@@ -18,8 +18,10 @@
 #include <csignal>
 #include <sys/select.h>
 
-namespace o2 {
-namespace  framework {
+namespace o2
+{
+namespace framework
+{
 
 /// Possible states for the DPL Driver application
 ///
@@ -39,7 +41,7 @@ namespace  framework {
 ///   SCHEDULE -> RUNNING
 ///   RUNNING -> RUNNING
 ///   RUNNING -> GUI
-///   GUI -> RUNNING 
+///   GUI -> RUNNING
 ///   RUNNING -> SCHEDULE
 ///   RUNNING -> EXIT
 /// ]"
@@ -71,7 +73,7 @@ struct DriverInfo {
   struct sigaction sa_handle_child;
 };
 
-}
-}
+} // namespace framework
+} // namespace o2
 
 #endif

--- a/Framework/Core/src/FrameworkDummyDebugger.cxx
+++ b/Framework/Core/src/FrameworkDummyDebugger.cxx
@@ -19,7 +19,9 @@ std::function<void(void)>
 getGUIDebugger(const std::vector<DeviceInfo> &infos,
                const std::vector<DeviceSpec> &devices,
                const std::vector<DeviceMetricsInfo> &metricsInfos,
-               std::vector<DeviceControl> &controls
+               const DriverInfo &driverInfo,
+               std::vector<DeviceControl> &controls,
+               DriverControl &driverControl
                )
 {
   return [](){};

--- a/Framework/Core/src/FrameworkDummyDebugger.cxx
+++ b/Framework/Core/src/FrameworkDummyDebugger.cxx
@@ -7,24 +7,22 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#include "Framework/FrameworkGUIDebugger.h"
-#include <vector>
 #include <algorithm>
+#include <vector>
+#include "Framework/FrameworkGUIDebugger.h"
 
-namespace o2 {
-namespace framework {
+namespace o2
+{
+namespace framework
+{
 
 // Dummy function in case we want to build without debugger.
-std::function<void(void)>
-getGUIDebugger(const std::vector<DeviceInfo> &infos,
-               const std::vector<DeviceSpec> &devices,
-               const std::vector<DeviceMetricsInfo> &metricsInfos,
-               const DriverInfo &driverInfo,
-               std::vector<DeviceControl> &controls,
-               DriverControl &driverControl
-               )
+std::function<void(void)> getGUIDebugger(const std::vector<DeviceInfo>& infos, const std::vector<DeviceSpec>& devices,
+                                         const std::vector<DeviceMetricsInfo>& metricsInfos,
+                                         const DriverInfo& driverInfo, std::vector<DeviceControl>& controls,
+                                         DriverControl& driverControl)
 {
-  return [](){};
+  return []() {};
 }
 
 void showNodeGraph(bool* opened) {}

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -32,6 +32,8 @@
 
 #include "DDSConfigHelpers.h"
 #include "DeviceSpecHelpers.h"
+#include "DriverInfo.h"
+#include "DriverControl.h"
 #include "GraphvizHelpers.h"
 #include "options/FairMQProgOptions.h"
 
@@ -103,6 +105,287 @@ bool getChildData(int infd, DeviceInfo& outinfo)
   return true;
 }
 
+/// Return true if all the DeviceInfo in \a infos are
+/// ready to quit. false otherwise.
+/// FIXME: move to an helper class
+bool checkIfCanExit(std::vector<DeviceInfo> const& infos) {
+  if (infos.empty()) {
+    return false;
+  }
+  for (auto& info : infos) {
+    if (info.readyToQuit == false) {
+       return false;
+    }
+  }
+  return true;
+}
+
+// Kill all the active children. Exit code
+// is != 0 if any of the children had an error.
+int killChildren(std::vector<DeviceInfo>& infos)
+{
+  int exitCode = 0;
+  for (auto& info : infos) {
+    if (exitCode == 0 && info.maxLogLevel >= LogParsingHelpers::LogLevel::Error) {
+      LOG(ERROR) << "Child " << info.pid << " had at least one "
+                 << "message above severity ERROR: " << info.lastError;
+      exitCode = 1;
+    }
+    if (!info.active) {
+      continue;
+    }
+    kill(info.pid, SIGKILL);
+    int status;
+    waitpid(info.pid, &status, 0);
+  }
+  return exitCode;
+}
+
+int createPipes(int maxFd, int* pipes)
+{
+  auto p = pipe(pipes);
+  maxFd = maxFd > pipes[0] ? maxFd : pipes[0];
+  maxFd = maxFd > pipes[1] ? maxFd : pipes[1];
+
+  if (p == -1) {
+    std::cerr << "Unable to create PIPE: ";
+    switch (errno) {
+      case EFAULT:
+        assert(false && "EFAULT while reading from pipe");
+        break;
+      case EMFILE:
+        std::cerr << "Too many active descriptors";
+        break;
+      case ENFILE:
+        std::cerr << "System file table is full";
+        break;
+      default:
+        std::cerr << "Unknown PIPE" << std::endl;
+    };
+    // Kill immediately both the parent and all the children
+    kill(-1 * getpid(), SIGKILL);
+  }
+  return maxFd;
+}
+
+// FIXME: I should really do this gracefully, by doing the following:
+// - Kill all the children
+// - Set a sig_atomic_t to say we did.
+// - Wait for all the children to exit
+// - Return gracefully.
+static void handle_sigint(int signum)
+{
+  auto exitCode = killChildren(gDeviceInfos);
+  // We kill ourself after having killed all our children (SPOOKY!)
+  signal(SIGINT, SIG_DFL);
+  kill(getpid(), SIGINT);
+}
+
+/// This will start a new device by forking and executing a
+/// new child
+void spawnDevice(DeviceSpec const& spec,
+                 std::map<int, size_t> &socket2DeviceInfo,
+                 DeviceControl &control,
+                 DeviceExecution &execution,
+                 std::vector<DeviceInfo> &deviceInfos,
+                 int &maxFd, fd_set &childFdset) {
+  int childstdout[2];
+  int childstderr[2];
+
+  maxFd = createPipes(maxFd, childstdout);
+  maxFd = createPipes(maxFd, childstderr);
+
+  // If we have a framework id, it means we have already been respawned
+  // and that we are in a child. If not, we need to fork and re-exec, adding
+  // the framework-id as one of the options.
+  pid_t id = 0;
+  id = fork();
+  // We are the child: prepare options and reexec.
+  if (id == 0) {
+    // We allow being debugged and do not terminate on SIGTRAP
+    signal(SIGTRAP, SIG_IGN);
+
+    // We do not start the process if control.noStart is set.
+    if (control.stopped) {
+      kill(getpid(), SIGSTOP);
+    }
+
+    // This is the child. We close the read part of the pipe, stdout
+    // and dup2 the write part of the pipe on it. Then we can restart.
+    close(childstdout[0]);
+    close(childstderr[0]);
+    close(STDOUT_FILENO);
+    close(STDERR_FILENO);
+    dup2(childstdout[1], STDOUT_FILENO);
+    dup2(childstderr[1], STDERR_FILENO);
+    execvp(execution.args[0], execution.args.data());
+  }
+
+  // This is the parent. We close the write end of
+  // the child pipe and and keep track of the fd so
+  // that we can later select on it.
+  struct sigaction sa_handle_int;
+  sa_handle_int.sa_handler = handle_sigint;
+  sigemptyset(&sa_handle_int.sa_mask);
+  sa_handle_int.sa_flags = SA_RESTART;
+  if (sigaction(SIGINT, &sa_handle_int, nullptr) == -1) {
+    perror("Unable to install signal handler");
+    exit(1);
+  }
+
+  std::cout << "Starting " << spec.id << " on pid " << id << "\n";
+  DeviceInfo info;
+  info.pid = id;
+  info.active = true;
+  info.readyToQuit = false;
+  info.historySize = 1000;
+  info.historyPos = 0;
+  info.maxLogLevel = LogParsingHelpers::LogLevel::Debug;
+
+  socket2DeviceInfo.insert(std::make_pair(childstdout[0], deviceInfos.size()));
+  socket2DeviceInfo.insert(std::make_pair(childstderr[0], deviceInfos.size()));
+  deviceInfos.emplace_back(info);
+  // Let's add also metrics information for the given device
+  gDeviceMetricsInfos.emplace_back(DeviceMetricsInfo{});
+
+  close(childstdout[1]);
+  close(childstderr[1]);
+  FD_SET(childstdout[0], &childFdset);
+  FD_SET(childstderr[0], &childFdset);
+}
+
+void doRunning(DriverInfo &driverInfo,
+               std::vector<DeviceInfo> &infos,
+               std::vector<DeviceSpec> const &specs,
+               std::vector<DeviceControl> &controls,
+               std::vector<DeviceMetricsInfo> &metricsInfos) {
+  // Wait for children to say something. When they do
+  // print it.
+  fd_set fdset;
+  timeval timeout;
+  timeout.tv_sec = 0;
+  timeout.tv_usec = 16666; // This should be enough to allow 60 HZ redrawing.
+  memcpy(&fdset, &driverInfo.childFdset, sizeof(fd_set));
+  int numFd = select(driverInfo.maxFd, &fdset, nullptr, nullptr, &timeout);
+  if (numFd == 0) {
+    return;
+  }
+  for (int si = 0; si < driverInfo.maxFd; ++si) {
+    if (FD_ISSET(si, &fdset)) {
+      assert(driverInfo.socket2DeviceInfo.find(si) != driverInfo.socket2DeviceInfo.end());
+      auto& info = infos[driverInfo.socket2DeviceInfo[si]];
+
+      bool fdActive = getChildData(si, info);
+      // If the pipe was closed due to the process exiting, we
+      // can avoid the select.
+      if (!fdActive) {
+        info.active = false;
+        close(si);
+        FD_CLR(si, &driverInfo.childFdset);
+      }
+      --numFd;
+    }
+    // FIXME: no need to check after numFd gets to 0.
+  }
+  // Display part. All you need to display should actually be in
+  // `infos`.
+  // TODO: split at \n
+  // TODO: update this only once per 1/60 of a second or
+  // things like this.
+  // TODO: have multiple display modes
+  // TODO: graphical view of the processing?
+  assert(infos.size() == controls.size());
+  std::smatch match;
+  std::string token;
+  const std::string delimiter("\n");
+  for (size_t di = 0, de = infos.size(); di < de; ++di) {
+    DeviceInfo& info = infos[di];
+    DeviceControl& control = controls[di];
+    DeviceMetricsInfo& metrics = metricsInfos[di];
+
+    if (info.unprinted.empty()) {
+      continue;
+    }
+
+    auto s = info.unprinted;
+    size_t pos = 0;
+    info.history.resize(info.historySize);
+    info.historyLevel.resize(info.historySize);
+
+    while ((pos = s.find(delimiter)) != std::string::npos) {
+      token = s.substr(0, pos);
+      auto logLevel = LogParsingHelpers::parseTokenLevel(token);
+
+      // Check if the token is a metric from SimpleMetricsService
+      // if yes, we do not print it out and simply store it to be displayed
+      // in the GUI.
+      // Then we check if it is part of our Poor man control system
+      // if yes, we execute the associated command.
+      if (parseMetric(token, match)) {
+        LOG(DEBUG) << "Found metric with key " << match[2] << " and value " << match[4];
+        processMetric(match, metrics);
+      } else if (parseControl(token, match)) {
+        auto command = match[1];
+        auto validFor = match[2];
+        LOG(DEBUG) << "Found control command " << command << " from pid " << info.pid << " valid for " << validFor;
+        if (command == "QUIT") {
+          if (validFor == "ALL") {
+            for (auto& deviceInfo : infos) {
+              deviceInfo.readyToQuit = true;
+            }
+          }
+        }
+      } else if (!control.quiet && (strstr(token.c_str(), control.logFilter) != nullptr) &&
+                 logLevel >= control.logLevel) {
+        assert(info.historyPos >= 0);
+        assert(info.historyPos < info.history.size());
+        info.history[info.historyPos] = token;
+        info.historyLevel[info.historyPos] = logLevel;
+        info.historyPos = (info.historyPos + 1) % info.history.size();
+        std::cout << "[" << info.pid << "]: " << token << std::endl;
+      }
+      // We keep track of the maximum log error a
+      // device has seen.
+      if (logLevel > info.maxLogLevel && logLevel > LogParsingHelpers::LogLevel::Info
+          && logLevel != LogParsingHelpers::LogLevel::Unknown) {
+        info.maxLogLevel = logLevel;
+      }
+      if (logLevel == LogParsingHelpers::LogLevel::Error) {
+        info.lastError = token;
+      }
+      s.erase(0, pos + delimiter.length());
+    }
+    info.unprinted = s;
+  }
+  // FIXME: for the gui to work correctly I would actually need to
+  //        run the loop more often and update whenever enough time has
+  //        passed.
+}
+
+void handle_sigchld(int sig)
+{
+  int saved_errno = errno;
+  std::vector<pid_t> pids;
+  while (true) {
+    pid_t pid = waitpid((pid_t)(-1), nullptr, WNOHANG);
+    if (pid > 0) {
+      pids.push_back(pid);
+      continue;
+    } else {
+      break;
+    }
+  }
+  errno = saved_errno;
+  for (auto& pid : pids) {
+    printf("Child exited: %d\n", pid);
+    for (auto& info : gDeviceInfos) {
+      if (info.pid == pid) {
+        info.active = false;
+      }
+    }
+    fflush(stdout);
+  }
+}
 // This is the handler for the parent inner loop.
 // So far the only responsibility for it are:
 //
@@ -112,132 +395,142 @@ bool getChildData(int infd, DeviceInfo& outinfo)
 // - TODO: allow single child view?
 // - TODO: allow last line per child mode?
 // - TODO: allow last error per child mode?
-void doParent(fd_set* in_fdset, int maxFd, std::vector<DeviceInfo> infos, std::vector<DeviceSpec> specs,
-              std::vector<DeviceControl> controls, std::vector<DeviceMetricsInfo> metricsInfos,
-              std::map<int, size_t>& socket2Info, bool batch)
+void doParent(std::vector<DeviceInfo> &infos,
+              std::vector<DeviceSpec> &deviceSpecs,
+              std::vector<DeviceControl> &controls,
+              std::vector<DeviceMetricsInfo> &metricsInfos,
+              std::vector<DeviceExecution> &deviceExecutions,
+              std::vector<DriverState> const &startProgram,
+              bool batch)
 {
+  DriverInfo driverInfo;
+  driverInfo.maxFd = 0;
+  driverInfo.states.reserve(10);
+  driverInfo.states = startProgram;
+  DriverControl driverControl;
+
   void* window = nullptr;
-  decltype(getGUIDebugger(infos, specs, metricsInfos, controls)) debugGUICallback;
+  decltype(getGUIDebugger(infos, deviceSpecs, metricsInfos, driverInfo, controls, driverControl)) debugGUICallback;
 
   if (batch == false) {
     window = initGUI("O2 Framework debug GUI");
-    debugGUICallback = getGUIDebugger(infos, specs, metricsInfos, controls);
   }
   if (batch == false && window == nullptr) {
     LOG(WARN) << "Could not create GUI. Switching to batch mode. Do you have GLFW on your system?";
     batch = true;
   }
+  bool guiQuitRequested = false;
   // FIXME: I should really have some way of exiting the
   // parent..
-  while (batch || pollGUI(window, debugGUICallback)) {
-    // Exit this loop if all the children say they want to quit.
-    bool allReadyToQuit = true;
-    for (auto& info : infos) {
-      allReadyToQuit &= info.readyToQuit;
+  DriverState current;
+  while (true) {
+    if (driverInfo.states.empty() == false) {
+      current = driverInfo.states.back();
+    } else {
+      current = DriverState::UNKNOWN;
     }
-    if (allReadyToQuit) {
-      break;
-    }
+    driverInfo.states.pop_back();
+    switch(current) {
+      case DriverState::INIT:
+        LOG(INFO) << "Initialising O2 Data Processing Layer";
 
-    // Wait for children to say something. When they do
-    // print it.
-    fd_set* fdset = (fd_set*)malloc(sizeof(fd_set));
-    timeval timeout;
-    timeout.tv_sec = 0;
-    timeout.tv_usec = 16666; // This should be enough to allow 60 HZ redrawing.
-    memcpy(fdset, in_fdset, sizeof(fd_set));
-    int numFd = select(maxFd, fdset, nullptr, nullptr, &timeout);
-    if (numFd == 0) {
-      continue;
-    }
-    for (int si = 0; si < maxFd; ++si) {
-      if (FD_ISSET(si, fdset)) {
-        assert(socket2Info.find(si) != socket2Info.end());
-        auto& info = infos[socket2Info[si]];
-
-        bool fdActive = getChildData(si, info);
-        // If the pipe was closed due to the process exiting, we
-        // can avoid the select.
-        if (!fdActive) {
-          info.active = false;
-          close(si);
-          FD_CLR(si, in_fdset);
+        // Install signal handler for quitting children.
+        driverInfo.sa_handle_child.sa_handler = &handle_sigchld;
+        sigemptyset(&driverInfo.sa_handle_child.sa_mask);
+        driverInfo.sa_handle_child.sa_flags = SA_RESTART | SA_NOCLDSTOP;
+        if (sigaction(SIGCHLD, &driverInfo.sa_handle_child, nullptr) == -1) {
+          perror(nullptr);
+          exit(1);
         }
-        --numFd;
-      }
-      // FIXME: no need to check after numFd gets to 0.
-    }
-    // Display part. All you need to display should actually be in
-    // `infos`.
-    // TODO: split at \n
-    // TODO: update this only once per 1/60 of a second or
-    // things like this.
-    // TODO: have multiple display modes
-    // TODO: graphical view of the processing?
-    assert(infos.size() == controls.size());
-    std::smatch match;
-    std::string token;
-    const std::string delimiter("\n");
-    for (size_t di = 0, de = infos.size(); di < de; ++di) {
-      DeviceInfo& info = infos[di];
-      DeviceControl& control = controls[di];
-      DeviceMetricsInfo& metrics = metricsInfos[di];
+        FD_ZERO(&(driverInfo.childFdset));
 
-      if (info.unprinted.empty()) {
-        continue;
-      }
-
-      auto s = info.unprinted;
-      size_t pos = 0;
-      info.history.resize(info.historySize);
-      info.historyLevel.resize(info.historySize);
-
-      while ((pos = s.find(delimiter)) != std::string::npos) {
-        token = s.substr(0, pos);
-        auto logLevel = LogParsingHelpers::parseTokenLevel(token);
-
-        // Check if the token is a metric from SimpleMetricsService
-        // if yes, we do not print it out and simply store it to be displayed
-        // in the GUI.
-        // Then we check if it is part of our Poor man control system
-        // if yes, we execute the associated command.
-        if (parseMetric(token, match)) {
-          LOG(INFO) << "Found metric with key " << match[2] << " and value " << match[4];
-          processMetric(match, metrics);
-        } else if (parseControl(token, match)) {
-          auto command = match[1];
-          auto validFor = match[2];
-          LOG(INFO) << "Found control command " << command << " from pid " << info.pid << " valid for " << validFor;
-          if (command == "QUIT") {
-            if (validFor == "ALL") {
-              for (auto& deviceInfo : infos) {
-                deviceInfo.readyToQuit = true;
-              }
-            }
-          }
-        } else if (!control.quiet && (strstr(token.c_str(), control.logFilter) != nullptr) &&
-                   logLevel >= control.logLevel) {
-          assert(info.historyPos >= 0);
-          assert(info.historyPos < info.history.size());
-          info.history[info.historyPos] = token;
-          info.historyLevel[info.historyPos] = logLevel;
-          info.historyPos = (info.historyPos + 1) % info.history.size();
-          std::cout << "[" << info.pid << "]: " << token << std::endl;
+        /// After INIT we go into RUNNING and eventually to SCHEDULE from
+        /// there and back into running. This is because the general case
+        /// would be that we start an application and then we wait for
+        /// resource offers from DDS or whatever resource manager we use.
+        driverInfo.states.push_back(DriverState::RUNNING);
+        driverInfo.states.push_back(DriverState::GUI);
+//        driverInfo.states.push_back(DriverState::REDEPLOY_GUI);
+        LOG(INFO) << "O2 Data Processing Layer initialised. We brake for nobody.";
+        break;
+      case DriverState::REDEPLOY_GUI:
+        // The callback for the GUI needs to be recalculated every time
+        // the deployed configuration changes, e.g. a new device 
+        // has been added to the topology.
+        // We need to recreate the GUI callback every time we reschedule
+        // because getGUIDebugger actually recreates the GUI state.
+        if (window) {
+          debugGUICallback = getGUIDebugger(infos,
+              deviceSpecs,
+              metricsInfos,
+              driverInfo,
+              controls,
+              driverControl);
         }
-        // We keep track of the maximum log error a
-        // device has seen.
-        if (logLevel > info.maxLogLevel && logLevel > LogParsingHelpers::LogLevel::Info) {
-          info.maxLogLevel = logLevel;
+        break;
+      case DriverState::SCHEDULE:
+        LOG(INFO) << "Redeployment of configuration asked.";
+        for (size_t di = 0; di < deviceSpecs.size(); ++di) {
+          spawnDevice(deviceSpecs[di],
+                      driverInfo.socket2DeviceInfo,
+                      controls[di],
+                      deviceExecutions[di],
+                      infos,
+                      driverInfo.maxFd, driverInfo.childFdset);
         }
-        s.erase(0, pos + delimiter.length());
-      }
-      info.unprinted = s;
+        driverInfo.maxFd += 1;
+        assert(infos.empty() == false);
+        // Go to RUNNING next.
+        driverInfo.states.push_back(DriverState::RUNNING);
+        driverInfo.states.push_back(DriverState::GUI);
+        driverInfo.states.push_back(DriverState::REDEPLOY_GUI);
+        LOG(INFO) << "Redeployment of configuration done.";
+        break;
+      case DriverState::RUNNING:
+        // Calculate what we should do next and eventually
+        // show the GUI
+        if (batch
+            || guiQuitRequested
+            || (checkIfCanExit(infos) == true)) {
+          // Something requested to quit. Let's update the GUI
+          // one more time and then EXIT.
+          LOG(INFO) << "Quitting";
+          driverInfo.states.push_back(DriverState::EXIT);
+          driverInfo.states.push_back(DriverState::GUI);
+        } else if (infos.size() != deviceSpecs.size()) {
+          // If the number of deviceSpecs is different from
+          // the DeviceInfos it means the speicification
+          // does not match what is running, so we need to do
+          // further scheduling.
+          driverInfo.states.push_back(DriverState::SCHEDULE);
+          driverInfo.states.push_back(DriverState::GUI);
+        }
+        else if (deviceSpecs.size() == 0) {
+          LOG(INFO) << "No device resulting from the workflow. Quitting.";
+          // If there are no deviceSpecs, we exit. 
+          driverInfo.states.push_back(DriverState::EXIT);
+        }
+        else {
+          driverInfo.states.push_back(DriverState::RUNNING);
+          driverInfo.states.push_back(DriverState::GUI);
+        }
+        // Update information about devices
+        doRunning(driverInfo, infos, deviceSpecs, controls, metricsInfos);
+        break;
+      case DriverState::GUI:
+        guiQuitRequested = (pollGUI(window, debugGUICallback) == false);
+        break;
+      case DriverState::EXIT:
+        killChildren(infos);
+        return;
+      default:
+        LOG(ERROR) << "Driver transitioned in an unknown state. Shutting down.";
+        killChildren(infos);
+        return;
     }
-    // FIXME: for the gui to work correctly I would actually need to
-    //        run the loop more often and update whenever enough time has
-    //        passed.
   }
 }
+
 
 // Magic to support both old and new FairRoot logger behavior
 // is_define<fair::Logger> only works if Logger is fully defined,
@@ -339,92 +632,6 @@ int doChild(int argc, char** argv, const o2::framework::DeviceSpec& spec)
   return 0;
 }
 
-int createPipes(int maxFd, int* pipes)
-{
-  auto p = pipe(pipes);
-  maxFd = maxFd > pipes[0] ? maxFd : pipes[0];
-  maxFd = maxFd > pipes[1] ? maxFd : pipes[1];
-
-  if (p == -1) {
-    std::cerr << "Unable to create PIPE: ";
-    switch (errno) {
-      case EFAULT:
-        assert(false && "EFAULT while reading from pipe");
-        break;
-      case EMFILE:
-        std::cerr << "Too many active descriptors";
-        break;
-      case ENFILE:
-        std::cerr << "System file table is full";
-        break;
-      default:
-        std::cerr << "Unknown PIPE" << std::endl;
-    };
-    // Kill immediately both the parent and all the children
-    kill(-1 * getpid(), SIGKILL);
-  }
-  return maxFd;
-}
-
-// Kill all the active children. Exit code
-// is != 0 if any of the children had an error.
-int killChildren(std::vector<DeviceInfo>& infos)
-{
-  int exitCode = 0;
-  for (auto& info : infos) {
-    if (exitCode == 0 && info.maxLogLevel >= LogParsingHelpers::LogLevel::Error) {
-      LOG(ERROR) << "Child " << info.pid << " had at least one "
-                 << "message above severity ERROR";
-      exitCode = 1;
-    }
-    if (!info.active) {
-      continue;
-    }
-    kill(info.pid, SIGKILL);
-    int status;
-    waitpid(info.pid, &status, 0);
-  }
-  return exitCode;
-}
-
-// FIXME: I should really do this gracefully, by doing the following:
-// - Kill all the children
-// - Set a sig_atomic_t to say we did.
-// - Wait for all the children to exit
-// - Return gracefully.
-static void handle_sigint(int signum)
-{
-  auto exitCode = killChildren(gDeviceInfos);
-  // We kill ourself after having killed all our children (SPOOKY!)
-  signal(SIGINT, SIG_DFL);
-  kill(getpid(), SIGINT);
-}
-
-void handle_sigchld(int sig)
-{
-  int saved_errno = errno;
-  std::vector<pid_t> pids;
-  while (true) {
-    pid_t pid = waitpid((pid_t)(-1), nullptr, WNOHANG);
-    if (pid > 0) {
-      pids.push_back(pid);
-      continue;
-    } else {
-      break;
-    }
-  }
-  errno = saved_errno;
-  for (auto& pid : pids) {
-    printf("Child exited: %d\n", pid);
-    for (auto& info : gDeviceInfos) {
-      if (info.pid == pid) {
-        info.active = false;
-      }
-    }
-    fflush(stdout);
-  }
-}
-
 // This is a toy executor for the workflow spec
 // What it needs to do is:
 //
@@ -518,104 +725,21 @@ int doMain(int argc, char** argv, const o2::framework::WorkflowSpec& specs,
   DeviceSpecHelpers::prepareArguments(argc, argv, defaultQuiet, defaultStopped, deviceSpecs, gDeviceExecutions,
                                       gDeviceControls);
 
+  std::vector<DriverState> startProgram;
   if (graphViz) {
     // Dump a graphviz representation of what I will do.
     GraphvizHelpers::dumpDeviceSpec2Graphviz(std::cout, deviceSpecs);
     exit(0);
-  }
-
-  if (generateDDS) {
+  } else if (generateDDS) {
     dumpDeviceSpec2DDS(std::cout, deviceSpecs, gDeviceExecutions);
     exit(0);
+  } else {
+    // By default we simply start the main loop
+    startProgram = {DriverState::INIT};
   }
-
-  // Mapping between various pipes and the actual device information.
-  // Key is the file description, value is index in the previous vector.
-  std::map<int, size_t> socket2DeviceInfo;
-  int maxFd = 0;
-
-  fd_set childFdset;
-  FD_ZERO(&childFdset);
-
-  struct sigaction sa_handle_child;
-  sa_handle_child.sa_handler = &handle_sigchld;
-  sigemptyset(&sa_handle_child.sa_mask);
-  sa_handle_child.sa_flags = SA_RESTART | SA_NOCLDSTOP;
-  if (sigaction(SIGCHLD, &sa_handle_child, nullptr) == -1) {
-    perror(nullptr);
-    exit(1);
-  }
-
-  for (size_t di = 0; di < deviceSpecs.size(); ++di) {
-    auto& spec = deviceSpecs[di];
-    auto& control = gDeviceControls[di];
-    auto& execution = gDeviceExecutions[di];
-    int childstdout[2];
-    int childstderr[2];
-
-    maxFd = createPipes(maxFd, childstdout);
-    maxFd = createPipes(maxFd, childstderr);
-
-    // If we have a framework id, it means we have already been respawned
-    // and that we are in a child. If not, we need to fork and re-exec, adding
-    // the framework-id as one of the options.
-    pid_t id = 0;
-    id = fork();
-    // We are the child: prepare options and reexec.
-    if (id == 0) {
-      // We allow being debugged and do not terminate on SIGTRAP
-      signal(SIGTRAP, SIG_IGN);
-
-      // We do not start the process if control.noStart is set.
-      if (control.stopped) {
-        kill(getpid(), SIGSTOP);
-      }
-
-      // This is the child. We close the read part of the pipe, stdout
-      // and dup2 the write part of the pipe on it. Then we can restart.
-      close(childstdout[0]);
-      close(childstderr[0]);
-      close(STDOUT_FILENO);
-      close(STDERR_FILENO);
-      dup2(childstdout[1], STDOUT_FILENO);
-      dup2(childstderr[1], STDERR_FILENO);
-      execvp(execution.args[0], execution.args.data());
-    }
-
-    // This is the parent. We close the write end of
-    // the child pipe and and keep track of the fd so
-    // that we can later select on it.
-    struct sigaction sa_handle_int;
-    sa_handle_int.sa_handler = handle_sigint;
-    sigemptyset(&sa_handle_int.sa_mask);
-    sa_handle_int.sa_flags = SA_RESTART;
-    if (sigaction(SIGINT, &sa_handle_int, nullptr) == -1) {
-      perror("Unable to install signal handler");
-      exit(1);
-    }
-
-    std::cout << "Starting " << spec.id << " on pid " << id << "\n";
-    DeviceInfo info;
-    info.pid = id;
-    info.active = true;
-    info.readyToQuit = false;
-    info.historySize = 1000;
-    info.historyPos = 0;
-    info.maxLogLevel = LogParsingHelpers::LogLevel::Debug;
-
-    socket2DeviceInfo.insert(std::make_pair(childstdout[0], gDeviceInfos.size()));
-    socket2DeviceInfo.insert(std::make_pair(childstderr[0], gDeviceInfos.size()));
-    gDeviceInfos.emplace_back(info);
-    // Let's add also metrics information for the given device
-    gDeviceMetricsInfos.emplace_back(DeviceMetricsInfo{});
-
-    close(childstdout[1]);
-    close(childstderr[1]);
-    FD_SET(childstdout[0], &childFdset);
-    FD_SET(childstderr[0], &childFdset);
-  }
-  maxFd += 1;
-  doParent(&childFdset, maxFd, gDeviceInfos, deviceSpecs, gDeviceControls, gDeviceMetricsInfos, socket2DeviceInfo,
-           batch);
+ 
+  doParent(gDeviceInfos, deviceSpecs, gDeviceControls, gDeviceMetricsInfos,
+           gDeviceExecutions,
+           startProgram, batch);
   return killChildren(gDeviceInfos);
 }

--- a/Framework/Core/test/test_DeviceSpec.cxx
+++ b/Framework/Core/test/test_DeviceSpec.cxx
@@ -11,37 +11,30 @@
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
 
-#include "test_HelperMacros.h"
-#include "Framework/WorkflowSpec.h"
-#include "Framework/DeviceSpec.h"
+#include <boost/test/unit_test.hpp>
+#include "../src/DeviceSpecHelpers.h"
 #include "../src/GraphvizHelpers.h"
 #include "../src/WorkflowHelpers.h"
-#include "../src/DeviceSpecHelpers.h"
-#include <boost/test/unit_test.hpp>
-
+#include "Framework/DeviceSpec.h"
+#include "Framework/WorkflowSpec.h"
+#include "test_HelperMacros.h"
 
 using namespace o2::framework;
 
 // This is how you can define your processing in a declarative way
-WorkflowSpec defineDataProcessing1() {
-  return {
-    {
-      "A",
-      Inputs{},
-      Outputs{
-        OutputSpec{"TST", "A1", OutputSpec::Timeframe},
-        OutputSpec{"TST", "A2", OutputSpec::Timeframe}
-      }
-    },
-    {
-      "B",
-      Inputs{InputSpec{"a", "TST", "A1", InputSpec::Timeframe}},
-    }
-  };
+WorkflowSpec defineDataProcessing1()
+{
+  return { { "A", Inputs{},
+             Outputs{ OutputSpec{ "TST", "A1", OutputSpec::Timeframe },
+                      OutputSpec{ "TST", "A2", OutputSpec::Timeframe } } },
+           {
+             "B",
+             Inputs{ InputSpec{ "a", "TST", "A1", InputSpec::Timeframe } },
+           } };
 }
 
-
-BOOST_AUTO_TEST_CASE(TestDeviceSpec1) {
+BOOST_AUTO_TEST_CASE(TestDeviceSpec1)
+{
   auto workflow = defineDataProcessing1();
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
   BOOST_REQUIRE_EQUAL(channelPolicies.empty(), false);
@@ -66,14 +59,15 @@ BOOST_AUTO_TEST_CASE(TestDeviceSpec1) {
 }
 
 // Same as before, but using PUSH/PULL as policy
-BOOST_AUTO_TEST_CASE(TestDeviceSpec1PushPull) {
+BOOST_AUTO_TEST_CASE(TestDeviceSpec1PushPull)
+{
   auto workflow = defineDataProcessing1();
   ChannelConfigurationPolicy pushPullPolicy;
   pushPullPolicy.match = ChannelConfigurationPolicyHelpers::matchAny;
   pushPullPolicy.modifyInput = ChannelConfigurationPolicyHelpers::pullInput;
   pushPullPolicy.modifyOutput = ChannelConfigurationPolicyHelpers::pushOutput;
 
-  std::vector<ChannelConfigurationPolicy> channelPolicies = {pushPullPolicy};
+  std::vector<ChannelConfigurationPolicy> channelPolicies = { pushPullPolicy };
 
   BOOST_REQUIRE_EQUAL(channelPolicies.empty(), false);
   std::vector<DeviceSpec> devices;
@@ -98,27 +92,22 @@ BOOST_AUTO_TEST_CASE(TestDeviceSpec1PushPull) {
 
 // This should still define only one channel, since there is only
 // two devices to connect
-WorkflowSpec defineDataProcessing2() {
-  return {
-    {
-      "A",
-      Inputs{},
-      Outputs{
-        OutputSpec{"TST", "A1", OutputSpec::Timeframe},
-        OutputSpec{"TST", "A2", OutputSpec::Timeframe}
-      }
-    },
-    {
-      "B",
-      Inputs{
-        InputSpec{"a", "TST", "A1", InputSpec::Timeframe},
-        InputSpec{"b", "TST", "A2", InputSpec::Timeframe},
-      },
-    }
-  };
+WorkflowSpec defineDataProcessing2()
+{
+  return { { "A", Inputs{},
+             Outputs{ OutputSpec{ "TST", "A1", OutputSpec::Timeframe },
+                      OutputSpec{ "TST", "A2", OutputSpec::Timeframe } } },
+           {
+             "B",
+             Inputs{
+               InputSpec{ "a", "TST", "A1", InputSpec::Timeframe },
+               InputSpec{ "b", "TST", "A2", InputSpec::Timeframe },
+             },
+           } };
 }
 
-BOOST_AUTO_TEST_CASE(TestDeviceSpec2) {
+BOOST_AUTO_TEST_CASE(TestDeviceSpec2)
+{
   auto workflow = defineDataProcessing2();
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
   std::vector<DeviceSpec> devices;
@@ -138,35 +127,26 @@ BOOST_AUTO_TEST_CASE(TestDeviceSpec2) {
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].port, 22000);
 }
 
-
 // This should still define only one channel, since there is only
 // two devices to connect
-WorkflowSpec defineDataProcessing3() {
-  return {
-    {
-      "A",
-      Inputs{},
-      Outputs{
-        OutputSpec{"TST", "A1", OutputSpec::Timeframe},
-        OutputSpec{"TST", "A2", OutputSpec::Timeframe}
-      }
-    },
-    {
-      "B",
-      Inputs{
-        InputSpec{"a", "TST", "A1", InputSpec::Timeframe},
-      },
-    },
-    {
-      "C",
-      Inputs{
-        InputSpec{"a", "TST", "A2", InputSpec::Timeframe},
-      }
-    }
-  };
+WorkflowSpec defineDataProcessing3()
+{
+  return { { "A", Inputs{},
+             Outputs{ OutputSpec{ "TST", "A1", OutputSpec::Timeframe },
+                      OutputSpec{ "TST", "A2", OutputSpec::Timeframe } } },
+           {
+             "B",
+             Inputs{
+               InputSpec{ "a", "TST", "A1", InputSpec::Timeframe },
+             },
+           },
+           { "C", Inputs{
+                    InputSpec{ "a", "TST", "A2", InputSpec::Timeframe },
+                  } } };
 }
 
-BOOST_AUTO_TEST_CASE(TestDeviceSpec3) {
+BOOST_AUTO_TEST_CASE(TestDeviceSpec3)
+{
   auto workflow = defineDataProcessing3();
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
   std::vector<DeviceSpec> devices;
@@ -197,45 +177,21 @@ BOOST_AUTO_TEST_CASE(TestDeviceSpec3) {
 }
 
 // Diamond shape.
-WorkflowSpec defineDataProcessing4() {
-  return {
-    {
-      "A",
-      Inputs{},
-      Outputs{
-        OutputSpec{"TST", "A1", OutputSpec::Timeframe},
-        OutputSpec{"TST", "A2", OutputSpec::Timeframe}
-      }
-    },
-    {
-      "B",
-      Inputs{
-        InputSpec{"input", "TST", "A1", InputSpec::Timeframe}
-      },
-      Outputs{
-        OutputSpec{"TST", "B1", OutputSpec::Timeframe}
-      }
-    },
-    {
-      "C",
-      Inputs{
-        InputSpec{"input", "TST", "A2", InputSpec::Timeframe}
-      },
-      Outputs{
-        OutputSpec{"TST", "C1", OutputSpec::Timeframe}
-      }
-    },
-    {
-      "D",
-      Inputs{
-        InputSpec{"a", "TST", "B1", InputSpec::Timeframe},
-        InputSpec{"b", "TST", "C1", InputSpec::Timeframe}
-      }
-    }
-  };
+WorkflowSpec defineDataProcessing4()
+{
+  return { { "A", Inputs{},
+             Outputs{ OutputSpec{ "TST", "A1", OutputSpec::Timeframe },
+                      OutputSpec{ "TST", "A2", OutputSpec::Timeframe } } },
+           { "B", Inputs{ InputSpec{ "input", "TST", "A1", InputSpec::Timeframe } },
+             Outputs{ OutputSpec{ "TST", "B1", OutputSpec::Timeframe } } },
+           { "C", Inputs{ InputSpec{ "input", "TST", "A2", InputSpec::Timeframe } },
+             Outputs{ OutputSpec{ "TST", "C1", OutputSpec::Timeframe } } },
+           { "D", Inputs{ InputSpec{ "a", "TST", "B1", InputSpec::Timeframe },
+                          InputSpec{ "b", "TST", "C1", InputSpec::Timeframe } } } };
 }
 
-BOOST_AUTO_TEST_CASE(TestDeviceSpec4) {
+BOOST_AUTO_TEST_CASE(TestDeviceSpec4)
+{
   auto workflow = defineDataProcessing4();
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
   std::vector<DeviceSpec> devices;
@@ -287,31 +243,21 @@ BOOST_AUTO_TEST_CASE(TestDeviceSpec4) {
 
 // This defines two consumers for the sameproduct, therefore we
 // need to forward (assuming we are in shared memory).
-WorkflowSpec defineDataProcessing5() {
-  return {
-    {
-      "A",
-      Inputs{},
-      Outputs{
-        OutputSpec{"TST", "A1", OutputSpec::Timeframe}
-      }
-    },
-    {
-      "B",
-      Inputs{
-        InputSpec{"x", "TST", "A1", InputSpec::Timeframe}
-      },
-    },
-    {
-      "C",
-      Inputs{
-        InputSpec{"y", "TST", "A1", InputSpec::Timeframe}
-      },
-    }
-  };
+WorkflowSpec defineDataProcessing5()
+{
+  return { { "A", Inputs{}, Outputs{ OutputSpec{ "TST", "A1", OutputSpec::Timeframe } } },
+           {
+             "B",
+             Inputs{ InputSpec{ "x", "TST", "A1", InputSpec::Timeframe } },
+           },
+           {
+             "C",
+             Inputs{ InputSpec{ "y", "TST", "A1", InputSpec::Timeframe } },
+           } };
 }
 
-BOOST_AUTO_TEST_CASE(TestTopologyForwarding) {
+BOOST_AUTO_TEST_CASE(TestTopologyForwarding)
+{
   auto workflow = defineDataProcessing5();
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
   std::vector<DeviceSpec> devices;
@@ -361,57 +307,32 @@ BOOST_AUTO_TEST_CASE(TestTopologyForwarding) {
 
 // This defines two consumers for the sameproduct, therefore we
 // need to forward (assuming we are in shared memory).
-WorkflowSpec defineDataProcessing6() {
-  return {
-    {
-      "A",
-      Inputs{},
-      Outputs{
-        OutputSpec{"TST", "A1", OutputSpec::Timeframe}
-      }
-    },
-    timePipeline({
-      "B",
-      Inputs{
-        InputSpec{"a", "TST", "A1", InputSpec::Timeframe}
-      }
-    }, 2)
-  };
+WorkflowSpec defineDataProcessing6()
+{
+  return { { "A", Inputs{}, Outputs{ OutputSpec{ "TST", "A1", OutputSpec::Timeframe } } },
+           timePipeline({ "B", Inputs{ InputSpec{ "a", "TST", "A1", InputSpec::Timeframe } } }, 2) };
 }
 
-// This is three explicit layers, last two with 
+// This is three explicit layers, last two with
 // multiple (non commensurable) timeslice setups.
-WorkflowSpec defineDataProcessing7() {
-  return {
-    {
-      "A",
-      Inputs{},
-      {
-        OutputSpec{"TST", "A", OutputSpec::Timeframe}
-      }
-    },
-    timePipeline({
-      "B",
-      Inputs{
-        InputSpec{"x", "TST", "A", InputSpec::Timeframe}
-      },
-      Outputs{
-        OutputSpec{"TST", "B", OutputSpec::Timeframe}
-      },
-    }, 3),
-    timePipeline({
-      "C",
-      Inputs{
-        InputSpec{"x", "TST", "B", InputSpec::Timeframe}
-      }
-    }, 2)
-  };
+WorkflowSpec defineDataProcessing7()
+{
+  return { { "A", Inputs{}, { OutputSpec{ "TST", "A", OutputSpec::Timeframe } } },
+           timePipeline(
+             {
+               "B",
+               Inputs{ InputSpec{ "x", "TST", "A", InputSpec::Timeframe } },
+               Outputs{ OutputSpec{ "TST", "B", OutputSpec::Timeframe } },
+             },
+             3),
+           timePipeline({ "C", Inputs{ InputSpec{ "x", "TST", "B", InputSpec::Timeframe } } }, 2) };
 }
 
-BOOST_AUTO_TEST_CASE(TestOutEdgeProcessingHelpers) {
+BOOST_AUTO_TEST_CASE(TestOutEdgeProcessingHelpers)
+{
   // Logical edges for:
   //    b0---\
-  //   /  \___c0  
+  //   /  \___c0
   //  /   /\ /
   // a--b1  X
   //  \   \/_\c1
@@ -423,75 +344,42 @@ BOOST_AUTO_TEST_CASE(TestOutEdgeProcessingHelpers) {
   std::vector<DeviceConnectionId> connections;
   std::vector<LogicalForwardInfo> availableForwardsInfo;
 
-  std::vector<OutputSpec> globalOutputs = {
-    OutputSpec{"TST", "A", OutputSpec::Timeframe},
-    OutputSpec{"TST", "B", OutputSpec::Timeframe}
-  };
+  std::vector<OutputSpec> globalOutputs = { OutputSpec{ "TST", "A", OutputSpec::Timeframe },
+                                            OutputSpec{ "TST", "B", OutputSpec::Timeframe } };
 
   unsigned short nextPort = 22000;
-  std::vector<size_t> edgeOutIndex {
-    0,1,2,3,6,4,7,5,8
-  };
-  std::vector<DeviceConnectionEdge> logicalEdges =
-  {
-    {0, 1, 0, 0, 0, 0, false, ConnectionKind::Out},
-    {0, 1, 1, 0, 0, 0, false, ConnectionKind::Out},
-    {0, 1, 2, 0, 0, 0, false, ConnectionKind::Out},
-    {1, 2, 0, 0, 1, 0, false, ConnectionKind::Out},
-    {1, 2, 0, 1, 1, 0, false, ConnectionKind::Out},
-    {1, 2, 0, 2, 1, 0, false, ConnectionKind::Out},
-    {1, 2, 1, 0, 1, 0, false, ConnectionKind::Out},
-    {1, 2, 1, 1, 1, 0, false, ConnectionKind::Out},
-    {1, 2, 1, 2, 1, 0, false, ConnectionKind::Out},
+  std::vector<size_t> edgeOutIndex{ 0, 1, 2, 3, 6, 4, 7, 5, 8 };
+  std::vector<DeviceConnectionEdge> logicalEdges = {
+    { 0, 1, 0, 0, 0, 0, false, ConnectionKind::Out }, { 0, 1, 1, 0, 0, 0, false, ConnectionKind::Out },
+    { 0, 1, 2, 0, 0, 0, false, ConnectionKind::Out }, { 1, 2, 0, 0, 1, 0, false, ConnectionKind::Out },
+    { 1, 2, 0, 1, 1, 0, false, ConnectionKind::Out }, { 1, 2, 0, 2, 1, 0, false, ConnectionKind::Out },
+    { 1, 2, 1, 0, 1, 0, false, ConnectionKind::Out }, { 1, 2, 1, 1, 1, 0, false, ConnectionKind::Out },
+    { 1, 2, 1, 2, 1, 0, false, ConnectionKind::Out },
   };
 
-  std::vector<EdgeAction> actions {
-    EdgeAction{true, true},
-    EdgeAction{false, true},
-    EdgeAction{false, true},
-    EdgeAction{true, true},
-    EdgeAction{true, true},
-    EdgeAction{true, true},
-    EdgeAction{false, true},
-    EdgeAction{false, true},
-    EdgeAction{false, true},
+  std::vector<EdgeAction> actions{
+    EdgeAction{ true, true },  EdgeAction{ false, true }, EdgeAction{ false, true },
+    EdgeAction{ true, true },  EdgeAction{ true, true },  EdgeAction{ true, true },
+    EdgeAction{ false, true }, EdgeAction{ false, true }, EdgeAction{ false, true },
   };
 
   WorkflowSpec workflow = defineDataProcessing7();
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
 
-  DeviceSpecHelpers::processOutEdgeActions(
-      devices,
-      deviceIndex,
-      connections,
-      nextPort,
-      edgeOutIndex,
-      logicalEdges,
-      actions,
-      workflow,
-      globalOutputs,
-      channelPolicies);
+  DeviceSpecHelpers::processOutEdgeActions(devices, deviceIndex, connections, nextPort, edgeOutIndex, logicalEdges,
+                                           actions, workflow, globalOutputs, channelPolicies);
 
-  std::vector<DeviceId> expectedDeviceIndex = {
-    {0,0,0},
-    {0,0,0},
-    {0,0,0},
-    {1,0,1},
-    {1,0,1},
-    {1,1,2},
-    {1,1,2},
-    {1,2,3},
-    {1,2,3}
-  };
+  std::vector<DeviceId> expectedDeviceIndex = { { 0, 0, 0 }, { 0, 0, 0 }, { 0, 0, 0 }, { 1, 0, 1 }, { 1, 0, 1 },
+                                                { 1, 1, 2 }, { 1, 1, 2 }, { 1, 2, 3 }, { 1, 2, 3 } };
   BOOST_REQUIRE_EQUAL(devices.size(), 4); // For producers
   BOOST_REQUIRE_EQUAL(expectedDeviceIndex.size(), deviceIndex.size());
 
   for (size_t i = 0; i < expectedDeviceIndex.size(); ++i) {
-    DeviceId &expected = expectedDeviceIndex[i];
-    DeviceId &actual = deviceIndex[i];
+    DeviceId& expected = expectedDeviceIndex[i];
+    DeviceId& actual = deviceIndex[i];
     BOOST_CHECK_EQUAL_MESSAGE(expected.processorIndex, actual.processorIndex, i);
-    BOOST_CHECK_EQUAL_MESSAGE(expected.timeslice,  actual.timeslice, i);
-    BOOST_CHECK_EQUAL_MESSAGE(expected.deviceIndex, actual.deviceIndex,i );
+    BOOST_CHECK_EQUAL_MESSAGE(expected.timeslice, actual.timeslice, i);
+    BOOST_CHECK_EQUAL_MESSAGE(expected.deviceIndex, actual.deviceIndex, i);
   }
 
   // Check that all the required channels are there.
@@ -510,66 +398,36 @@ BOOST_AUTO_TEST_CASE(TestOutEdgeProcessingHelpers) {
   BOOST_CHECK_EQUAL(nextPort, 22009);
 
   // Not sure this is correct, but lets assume that's the case..
-  std::vector<size_t> edgeInIndex {
-    0,1,2,3,4,5,6,7,8
-  };
+  std::vector<size_t> edgeInIndex{ 0, 1, 2, 3, 4, 5, 6, 7, 8 };
 
-  std::vector<EdgeAction> inActions {
-    EdgeAction{true, true},
-    EdgeAction{true, true},
-    EdgeAction{true, true},
-    EdgeAction{true, true},
-    EdgeAction{false, true},
-    EdgeAction{false, true},
-    EdgeAction{true, true},
-    EdgeAction{false, true},
-    EdgeAction{false, true},
+  std::vector<EdgeAction> inActions{
+    EdgeAction{ true, true }, EdgeAction{ true, true },  EdgeAction{ true, true },
+    EdgeAction{ true, true }, EdgeAction{ false, true }, EdgeAction{ false, true },
+    EdgeAction{ true, true }, EdgeAction{ false, true }, EdgeAction{ false, true },
   };
 
   std::sort(connections.begin(), connections.end());
 
-  DeviceSpecHelpers::processInEdgeActions(
-    devices,
-    deviceIndex,
-    nextPort,
-    connections,
-    edgeInIndex,
-    logicalEdges,
-    inActions,
-    workflow,
-    availableForwardsInfo,
-    channelPolicies
-  );
-  // 
-  std::vector<DeviceId> expectedDeviceIndexFinal = {
-    {0,0,0},
-    {0,0,0},
-    {0,0,0},
-    {1,0,1},
-    {1,0,1},
-    {1,1,2},
-    {1,1,2},
-    {1,2,3},
-    {1,2,3},
-    {2,0,4},
-    {2,1,5}
-  };
+  DeviceSpecHelpers::processInEdgeActions(devices, deviceIndex, nextPort, connections, edgeInIndex, logicalEdges,
+                                          inActions, workflow, availableForwardsInfo, channelPolicies);
+  //
+  std::vector<DeviceId> expectedDeviceIndexFinal = { { 0, 0, 0 }, { 0, 0, 0 }, { 0, 0, 0 }, { 1, 0, 1 },
+                                                     { 1, 0, 1 }, { 1, 1, 2 }, { 1, 1, 2 }, { 1, 2, 3 },
+                                                     { 1, 2, 3 }, { 2, 0, 4 }, { 2, 1, 5 } };
   BOOST_REQUIRE_EQUAL(expectedDeviceIndexFinal.size(), deviceIndex.size());
 
   for (size_t i = 0; i < expectedDeviceIndexFinal.size(); ++i) {
-    DeviceId &expected = expectedDeviceIndexFinal[i];
-    DeviceId &actual = deviceIndex[i];
+    DeviceId& expected = expectedDeviceIndexFinal[i];
+    DeviceId& actual = deviceIndex[i];
     BOOST_CHECK_EQUAL_MESSAGE(expected.processorIndex, actual.processorIndex, i);
-    BOOST_CHECK_EQUAL_MESSAGE(expected.timeslice,  actual.timeslice, i);
-    BOOST_CHECK_EQUAL_MESSAGE(expected.deviceIndex, actual.deviceIndex,i );
+    BOOST_CHECK_EQUAL_MESSAGE(expected.timeslice, actual.timeslice, i);
+    BOOST_CHECK_EQUAL_MESSAGE(expected.deviceIndex, actual.deviceIndex, i);
   }
 
   // Iterating over the in edges should have created the final 2
   // devices.
   BOOST_CHECK_EQUAL(devices.size(), 6);
-  std::vector<std::string> expectedDeviceNames = {
-    "A", "B_t0", "B_t1", "B_t2", "C_t0", "C_t1"
-  };
+  std::vector<std::string> expectedDeviceNames = { "A", "B_t0", "B_t1", "B_t2", "C_t0", "C_t1" };
 
   for (size_t i = 0; i < devices.size(); ++i) {
     BOOST_CHECK_EQUAL(devices[i].id, expectedDeviceNames[i]);
@@ -594,31 +452,30 @@ BOOST_AUTO_TEST_CASE(TestOutEdgeProcessingHelpers) {
   // Check that the output specs and the timeframe ids are correct
   std::vector<std::vector<OutputRoute>> expectedRoutes = {
     {
-      OutputRoute{0, 3, globalOutputs[0], "from_A_to_B_t0"},
-      OutputRoute{1, 3, globalOutputs[0], "from_A_to_B_t1"},
-      OutputRoute{2, 3, globalOutputs[0], "from_A_to_B_t2"},
+      OutputRoute{ 0, 3, globalOutputs[0], "from_A_to_B_t0" },
+      OutputRoute{ 1, 3, globalOutputs[0], "from_A_to_B_t1" },
+      OutputRoute{ 2, 3, globalOutputs[0], "from_A_to_B_t2" },
     },
     {
-      OutputRoute{0, 2, globalOutputs[1], "from_B_t0_to_C_t0"},
-      OutputRoute{1, 2, globalOutputs[1], "from_B_t0_to_C_t1"},
+      OutputRoute{ 0, 2, globalOutputs[1], "from_B_t0_to_C_t0" },
+      OutputRoute{ 1, 2, globalOutputs[1], "from_B_t0_to_C_t1" },
     },
     {
-      OutputRoute{0, 2, globalOutputs[1], "from_B_t1_to_C_t0"},
-      OutputRoute{1, 2, globalOutputs[1], "from_B_t1_to_C_t1"},
+      OutputRoute{ 0, 2, globalOutputs[1], "from_B_t1_to_C_t0" },
+      OutputRoute{ 1, 2, globalOutputs[1], "from_B_t1_to_C_t1" },
     },
     {
-      OutputRoute{0, 2, globalOutputs[1], "from_B_t2_to_C_t0"},
-      OutputRoute{1, 2, globalOutputs[1], "from_B_t2_to_C_t1"},
+      OutputRoute{ 0, 2, globalOutputs[1], "from_B_t2_to_C_t0" },
+      OutputRoute{ 1, 2, globalOutputs[1], "from_B_t2_to_C_t1" },
     },
   };
 
   for (size_t di = 0; di < expectedRoutes.size(); di++) {
-    auto &routes = expectedRoutes[di];
-    auto &device = devices[di];
+    auto& routes = expectedRoutes[di];
+    auto& device = devices[di];
     for (size_t ri = 0; ri < device.outputs.size(); ri++) {
       // FIXME: check that the matchers are the same
-      BOOST_CHECK_EQUAL(std::string(device.outputs[ri].matcher.origin.str),
-                        std::string(routes[ri].matcher.origin.str));
+      BOOST_CHECK_EQUAL(std::string(device.outputs[ri].matcher.origin.str), std::string(routes[ri].matcher.origin.str));
       BOOST_CHECK_EQUAL(device.outputs[ri].channel, routes[ri].channel);
       BOOST_CHECK_EQUAL(device.outputs[ri].timeslice, routes[ri].timeslice);
     }
@@ -653,7 +510,8 @@ BOOST_AUTO_TEST_CASE(TestOutEdgeProcessingHelpers) {
   BOOST_CHECK_EQUAL(devices[5].inputs[2].sourceChannel, "from_B_t2_to_C_t1");
 }
 
-BOOST_AUTO_TEST_CASE(TestTopologyLayeredTimePipeline) {
+BOOST_AUTO_TEST_CASE(TestTopologyLayeredTimePipeline)
+{
   auto workflow = defineDataProcessing7();
   std::vector<DeviceSpec> devices;
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
@@ -756,4 +614,3 @@ BOOST_AUTO_TEST_CASE(TestTopologyLayeredTimePipeline) {
   BOOST_CHECK_EQUAL(devices[5].inputChannels[2].port, 22008);
   BOOST_REQUIRE_EQUAL(devices[5].outputChannels.size(), 0);
 }
-

--- a/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
+++ b/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
@@ -11,86 +11,69 @@
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
 
-#include "Framework/WorkflowSpec.h"
-#include "Framework/ProcessingContext.h"
-#include "Framework/DataAllocator.h"
-#include "Framework/DeviceSpec.h"
-#include "Framework/DeviceControl.h"
-#include "../src/DDSConfigHelpers.h"
 #include <boost/test/unit_test.hpp>
+#include "../src/DDSConfigHelpers.h"
 #include "../src/DeviceSpecHelpers.h"
+#include "Framework/DataAllocator.h"
+#include "Framework/DeviceControl.h"
+#include "Framework/DeviceSpec.h"
+#include "Framework/ProcessingContext.h"
+#include "Framework/WorkflowSpec.h"
 
 #include <sstream>
 
 using namespace o2::framework;
 
-AlgorithmSpec simplePipe(o2::header::DataDescription what) {
-  return AlgorithmSpec{
-    [what](ProcessingContext &ctx)
-      {
-        auto bData = ctx.allocator().make<int>(OutputSpec{"TST", what, 0}, 1);
-      }
-    };
+AlgorithmSpec simplePipe(o2::header::DataDescription what)
+{
+  return AlgorithmSpec{ [what](ProcessingContext& ctx) {
+    auto bData = ctx.allocator().make<int>(OutputSpec{ "TST", what, 0 }, 1);
+  } };
 }
 
 // This is how you can define your processing in a declarative way
-WorkflowSpec defineDataProcessing() {
-  return {
-  {
-    "A",
-    Inputs{},
-    Outputs{
-      OutputSpec{"TST", "A1", OutputSpec::Timeframe},
-      OutputSpec{"TST", "A2", OutputSpec::Timeframe}
-    },
-    AlgorithmSpec{
-      [](ProcessingContext &ctx) {
-       sleep(1);
-       auto aData = ctx.allocator().make<int>(OutputSpec{"TST", "A1", 0}, 1);
-       auto bData = ctx.allocator().make<int>(OutputSpec{"TST", "A2", 0}, 1);
-      }
-    }
-  },
-  {
-    "B",
-    {InputSpec{"x", "TST", "A1", InputSpec::Timeframe}},
-    Outputs{OutputSpec{"TST", "B1", OutputSpec::Timeframe}},
-    simplePipe(o2::header::DataDescription{"B1"})
-  },
-  {
-    "C",
-    {InputSpec{"y", "TST", "A2", InputSpec::Timeframe}},
-    Outputs{OutputSpec{"TST", "C1", OutputSpec::Timeframe}},
-    simplePipe(o2::header::DataDescription{"C1"})
-  },
-  {
-    "D",
-    {
-      InputSpec{"x", "TST", "B1", InputSpec::Timeframe},
-      InputSpec{"y", "TST", "C1", InputSpec::Timeframe},
-    },
-    Outputs{},
-    AlgorithmSpec{
-      [](ProcessingContext &context) {
-      },
-    }
-  }
-  };
+WorkflowSpec defineDataProcessing()
+{
+  return { { "A", Inputs{},
+             Outputs{ OutputSpec{ "TST", "A1", OutputSpec::Timeframe },
+                      OutputSpec{ "TST", "A2", OutputSpec::Timeframe } },
+             AlgorithmSpec{ [](ProcessingContext& ctx) {
+               sleep(1);
+               auto aData = ctx.allocator().make<int>(OutputSpec{ "TST", "A1", 0 }, 1);
+               auto bData = ctx.allocator().make<int>(OutputSpec{ "TST", "A2", 0 }, 1);
+             } } },
+           { "B",
+             { InputSpec{ "x", "TST", "A1", InputSpec::Timeframe } },
+             Outputs{ OutputSpec{ "TST", "B1", OutputSpec::Timeframe } },
+             simplePipe(o2::header::DataDescription{ "B1" }) },
+           { "C",
+             { InputSpec{ "y", "TST", "A2", InputSpec::Timeframe } },
+             Outputs{ OutputSpec{ "TST", "C1", OutputSpec::Timeframe } },
+             simplePipe(o2::header::DataDescription{ "C1" }) },
+           { "D",
+             {
+               InputSpec{ "x", "TST", "B1", InputSpec::Timeframe },
+               InputSpec{ "y", "TST", "C1", InputSpec::Timeframe },
+             },
+             Outputs{},
+             AlgorithmSpec{
+               [](ProcessingContext& context) {},
+             } } };
 }
 
-BOOST_AUTO_TEST_CASE(TestGraphviz) {
+BOOST_AUTO_TEST_CASE(TestGraphviz)
+{
   auto workflow = defineDataProcessing();
-  std::ostringstream ss{""};
+  std::ostringstream ss{ "" };
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
   std::vector<DeviceSpec> devices;
   DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, devices);
-  char *fakeArgv[] = {strdup("foo"), nullptr};
+  char* fakeArgv[] = { strdup("foo"), nullptr };
   std::vector<DeviceControl> controls;
   std::vector<DeviceExecution> executions;
   controls.resize(devices.size());
   executions.resize(devices.size());
-  DeviceSpecHelpers::prepareArguments(1, fakeArgv, false, false, devices,
-                   executions, controls);
+  DeviceSpecHelpers::prepareArguments(1, fakeArgv, false, false, devices, executions, controls);
   dumpDeviceSpec2DDS(ss, devices, executions);
   BOOST_CHECK_EQUAL(ss.str(), R"EXPECTED(<topology id="o2-dataflow">
    <decltask id="A">

--- a/Framework/Core/test/test_Graphviz.cxx
+++ b/Framework/Core/test/test_Graphviz.cxx
@@ -11,10 +11,10 @@
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
 
-#include "Framework/WorkflowSpec.h"
-#include "Framework/DeviceSpec.h"
 #include "../src/DeviceSpecHelpers.h"
 #include "../src/GraphvizHelpers.h"
+#include "Framework/DeviceSpec.h"
+#include "Framework/WorkflowSpec.h"
 #include "Headers/DataHeader.h"
 
 #include <boost/test/unit_test.hpp>
@@ -23,7 +23,8 @@
 using namespace o2::framework;
 
 // because comparing the whole thing is a pain.
-void lineByLineComparision(const std::string &as, const std::string &bs) {
+void lineByLineComparision(const std::string& as, const std::string& bs)
+{
   std::istringstream a(as);
   std::istringstream b(bs);
 
@@ -33,70 +34,50 @@ void lineByLineComparision(const std::string &as, const std::string &bs) {
   while (a.good() && b.good()) {
     a.getline(bufferA, 1024);
     b.getline(bufferB, 1024);
-   BOOST_CHECK_EQUAL(std::string(bufferA), std::string(bufferB));
+    BOOST_CHECK_EQUAL(std::string(bufferA), std::string(bufferB));
   }
   BOOST_CHECK(a.eof());
   BOOST_CHECK(b.eof());
 }
 
 // This is how you can define your processing in a declarative way
-WorkflowSpec defineDataProcessing() {
+WorkflowSpec defineDataProcessing()
+{
+  return { { "A", Inputs{},
+             Outputs{ OutputSpec{ "TST", "A1", OutputSpec::Timeframe },
+                      OutputSpec{ "TST", "A2", OutputSpec::Timeframe } } },
+           { "B",
+             { InputSpec{ "x", "TST", "A1", InputSpec::Timeframe } },
+             Outputs{ OutputSpec{ "TST", "B1", OutputSpec::Timeframe } } },
+           { "C", Inputs{ InputSpec{ "x", "TST", "A2", InputSpec::Timeframe } },
+             Outputs{ OutputSpec{ "TST", "C1", OutputSpec::Timeframe } } },
+           { "D",
+             Inputs{ InputSpec{ "i1", "TST", "B1", InputSpec::Timeframe },
+                     InputSpec{ "i2", "TST", "C1", InputSpec::Timeframe } },
+             Outputs{} } };
+}
+
+WorkflowSpec defineDataProcessing2()
+{
   return {
-  {
-    "A",
-    Inputs{},
-    Outputs{
-      OutputSpec{"TST", "A1", OutputSpec::Timeframe},
-      OutputSpec{"TST", "A2", OutputSpec::Timeframe}
-    }
-  },
-  {
-    "B",
-    {InputSpec{"x","TST", "A1", InputSpec::Timeframe}},
-    Outputs{
-      OutputSpec{"TST", "B1", OutputSpec::Timeframe}}
-  },
-  {
-    "C",
-    Inputs{InputSpec{"x", "TST", "A2", InputSpec::Timeframe}},
-    Outputs{
-      OutputSpec{"TST", "C1", OutputSpec::Timeframe}
-    }
-  },
-  {
-    "D",
-    Inputs{
-      InputSpec{"i1", "TST", "B1", InputSpec::Timeframe},
-      InputSpec{"i2", "TST", "C1", InputSpec::Timeframe}
-    },
-    Outputs{}
-  }
+    { "A",
+      {},
+      {
+        OutputSpec{ "TST", "A", OutputSpec::Timeframe },
+      } },
+    timePipeline({ "B",
+                   { InputSpec{ "a", "TST", "A", InputSpec::Timeframe } },
+                   { OutputSpec{ "TST", "B", OutputSpec::Timeframe } } },
+                 3),
+    timePipeline({ "C",
+                   { InputSpec{ "b", "TST", "B", InputSpec::Timeframe } },
+                   { OutputSpec{ "TST", "C", OutputSpec::Timeframe } } },
+                 2),
   };
 }
 
-WorkflowSpec defineDataProcessing2() {
-  return {
-  {
-    "A",
-    {},
-    {
-      OutputSpec{"TST", "A", OutputSpec::Timeframe},
-    }
-  },
-  timePipeline({
-    "B",
-    {InputSpec{"a", "TST", "A", InputSpec::Timeframe}},
-    {OutputSpec{"TST", "B", OutputSpec::Timeframe}}
-  }, 3),
-  timePipeline({
-    "C",
-    {InputSpec{"b", "TST", "B", InputSpec::Timeframe}},
-    {OutputSpec{"TST", "C", OutputSpec::Timeframe}}
-  }, 2),
-  };
-}
-
-BOOST_AUTO_TEST_CASE(TestGraphviz) {
+BOOST_AUTO_TEST_CASE(TestGraphviz)
+{
   auto workflow = defineDataProcessing();
   std::ostringstream str;
   auto expectedResult = R"EXPECTED(digraph structs {
@@ -110,7 +91,7 @@ BOOST_AUTO_TEST_CASE(TestGraphviz) {
   GraphvizHelpers::dumpDataProcessorSpec2Graphviz(str, workflow);
   lineByLineComparision(str.str(), expectedResult);
   std::vector<DeviceSpec> devices;
-  for (auto &device : devices) {
+  for (auto& device : devices) {
     BOOST_CHECK(device.id != "");
   }
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
@@ -129,10 +110,10 @@ BOOST_AUTO_TEST_CASE(TestGraphviz) {
   C:from_C_to_D-> D:from_C_to_D [label="22003"]
 }
 )EXPECTED");
-
 }
 
-BOOST_AUTO_TEST_CASE(TestGraphvizWithPipeline) {
+BOOST_AUTO_TEST_CASE(TestGraphvizWithPipeline)
+{
   auto workflow = defineDataProcessing2();
   std::ostringstream str;
   auto expectedResult = R"EXPECTED(digraph structs {
@@ -145,7 +126,7 @@ BOOST_AUTO_TEST_CASE(TestGraphvizWithPipeline) {
   GraphvizHelpers::dumpDataProcessorSpec2Graphviz(str, workflow);
   lineByLineComparision(str.str(), expectedResult);
   std::vector<DeviceSpec> devices;
-  for (auto &device : devices) {
+  for (auto& device : devices) {
     BOOST_CHECK(device.id != "");
   }
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();

--- a/Framework/Core/test/test_TimeParallelPipelining.cxx
+++ b/Framework/Core/test/test_TimeParallelPipelining.cxx
@@ -11,52 +11,52 @@
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
 
-#include "Framework/WorkflowSpec.h"
-#include "Framework/DeviceSpec.h"
-#include "Framework/DeviceControl.h"
-#include "../src/DeviceSpecHelpers.h"
 #include <boost/test/unit_test.hpp>
+#include "../src/DeviceSpecHelpers.h"
+#include "Framework/DeviceControl.h"
+#include "Framework/DeviceSpec.h"
+#include "Framework/WorkflowSpec.h"
 
 using namespace o2::framework;
 
 // This is how you can define your processing in a declarative way
-WorkflowSpec defineSimplePipelining() {
-  auto result = WorkflowSpec{
-    {
-      "A",
-      Inputs{},
-      {
-        OutputSpec{"TST", "A", OutputSpec::Timeframe},
-      },
-    },
-    timePipeline({
-      "B",
-      Inputs{InputSpec{"a", "TST", "A", InputSpec::Timeframe}},
-      Outputs{
-        OutputSpec{"TST", "B", OutputSpec::Timeframe},
-      },
-    }, 2),
-    {
-      "C",
-      {
-        InputSpec{"b", "TST", "B", InputSpec::Timeframe}
-      },
-    }
-  };
+WorkflowSpec defineSimplePipelining()
+{
+  auto result = WorkflowSpec{ {
+                                "A",
+                                Inputs{},
+                                {
+                                  OutputSpec{ "TST", "A", OutputSpec::Timeframe },
+                                },
+                              },
+                              timePipeline(
+                                {
+                                  "B",
+                                  Inputs{ InputSpec{ "a", "TST", "A", InputSpec::Timeframe } },
+                                  Outputs{
+                                    OutputSpec{ "TST", "B", OutputSpec::Timeframe },
+                                  },
+                                },
+                                2),
+                              {
+                                "C",
+                                { InputSpec{ "b", "TST", "B", InputSpec::Timeframe } },
+                              } };
 
   return result;
 }
 
-BOOST_AUTO_TEST_CASE(TimePipeliningSimple) {
+BOOST_AUTO_TEST_CASE(TimePipeliningSimple)
+{
   auto workflow = defineSimplePipelining();
   std::vector<DeviceSpec> devices;
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
   DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, devices);
   BOOST_REQUIRE_EQUAL(devices.size(), 4);
-  auto &producer = devices[0];
-  auto &layer0Consumer0 = devices[1];
-  auto &layer0Consumer1 = devices[2];
-  auto &layer1Consumer0 = devices[3];
+  auto& producer = devices[0];
+  auto& layer0Consumer0 = devices[1];
+  auto& layer0Consumer1 = devices[2];
+  auto& layer1Consumer0 = devices[3];
   BOOST_CHECK_EQUAL(producer.id, "A");
   BOOST_CHECK_EQUAL(layer0Consumer0.id, "B_t0");
   BOOST_CHECK_EQUAL(layer0Consumer1.id, "B_t1");
@@ -64,53 +64,52 @@ BOOST_AUTO_TEST_CASE(TimePipeliningSimple) {
 }
 
 // This is how you can define your processing in a declarative way
-WorkflowSpec defineDataProcessing() {
+WorkflowSpec defineDataProcessing()
+{
   auto result = WorkflowSpec{
     {
       "A",
       Inputs{},
       {
-        OutputSpec{"TST", "A", OutputSpec::Timeframe},
+        OutputSpec{ "TST", "A", OutputSpec::Timeframe },
       },
     },
-    timePipeline({
-      "B",
-      Inputs{InputSpec{"a", "TST", "A", InputSpec::Timeframe}},
-      Outputs{
-        OutputSpec{"TST", "B1", OutputSpec::Timeframe},
-        OutputSpec{"TST", "B2", OutputSpec::Timeframe}
-      },
-    }, 2),
-    timePipeline({
-      "C",
-      {InputSpec{"b", "TST", "B1", InputSpec::Timeframe}},
-      {OutputSpec{"TST", "C", OutputSpec::Timeframe}}
-    }, 3),
-    timePipeline({
-      "D",
+    timePipeline(
       {
-        InputSpec{"c", "TST", "C", InputSpec::Timeframe},
-        InputSpec{"d", "TST", "B2", InputSpec::Timeframe}
+        "B",
+        Inputs{ InputSpec{ "a", "TST", "A", InputSpec::Timeframe } },
+        Outputs{ OutputSpec{ "TST", "B1", OutputSpec::Timeframe }, OutputSpec{ "TST", "B2", OutputSpec::Timeframe } },
       },
-    },1)
+      2),
+    timePipeline({ "C",
+                   { InputSpec{ "b", "TST", "B1", InputSpec::Timeframe } },
+                   { OutputSpec{ "TST", "C", OutputSpec::Timeframe } } },
+                 3),
+    timePipeline(
+      {
+        "D",
+        { InputSpec{ "c", "TST", "C", InputSpec::Timeframe }, InputSpec{ "d", "TST", "B2", InputSpec::Timeframe } },
+      },
+      1)
   };
 
   return result;
 }
 
-BOOST_AUTO_TEST_CASE(TimePipeliningFull) {
+BOOST_AUTO_TEST_CASE(TimePipeliningFull)
+{
   auto workflow = defineDataProcessing();
   std::vector<DeviceSpec> devices;
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
   DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, devices);
   BOOST_REQUIRE_EQUAL(devices.size(), 7);
-  auto &producer = devices[0];
-  auto &layer0Consumer0 = devices[1];
-  auto &layer0Consumer1 = devices[2];
-  auto &layer1Consumer0 = devices[3];
-  auto &layer1Consumer1 = devices[4];
-  auto &layer1Consumer2 = devices[5];
-  auto &layer2Consumer0 = devices[6];
+  auto& producer = devices[0];
+  auto& layer0Consumer0 = devices[1];
+  auto& layer0Consumer1 = devices[2];
+  auto& layer1Consumer0 = devices[3];
+  auto& layer1Consumer1 = devices[4];
+  auto& layer1Consumer2 = devices[5];
+  auto& layer2Consumer0 = devices[6];
   BOOST_CHECK_EQUAL(producer.id, "A");
   BOOST_CHECK_EQUAL(layer0Consumer0.id, "B_t0");
   BOOST_CHECK_EQUAL(layer0Consumer1.id, "B_t1");

--- a/Framework/DebugGUI/src/DebugGUI.cxx
+++ b/Framework/DebugGUI/src/DebugGUI.cxx
@@ -1,54 +1,57 @@
+#include <GLFW/glfw3.h>
+#include <stdio.h>
+#include <functional>
+#include "GL/gl3w.h" // This example is using gl3w to access OpenGL functions (because it is small). You may use glew/glad/glLoadGen/etc. whatever already works for you.
 #include "imgui.h"
 #include "imgui_impl_glfw_gl3.h"
-#include <stdio.h>
-#include "GL/gl3w.h"    // This example is using gl3w to access OpenGL functions (because it is small). You may use glew/glad/glLoadGen/etc. whatever already works for you.
-#include <GLFW/glfw3.h>
-#include <functional>
 
 static void error_callback(int error, const char* description)
 {
-    fprintf(stderr, "Error %d: %s\n", error, description);
+  fprintf(stderr, "Error %d: %s\n", error, description);
 }
 
-namespace o2 {
-namespace framework {
-
+namespace o2
+{
+namespace framework
+{
 
 // @return an object of kind GLFWwindow* as void* to avoid having a direct dependency
-void *initGUI(const char *name) {
-    // Setup window
-    glfwSetErrorCallback(error_callback);
-    if (!glfwInit())
-        return nullptr;
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
-    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+void* initGUI(const char* name)
+{
+  // Setup window
+  glfwSetErrorCallback(error_callback);
+  if (!glfwInit())
+    return nullptr;
+  glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+  glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+  glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 #if __APPLE__
-    glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
+  glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
 #endif
-    GLFWwindow* window = glfwCreateWindow(1280, 720, name, NULL, NULL);
-    glfwMakeContextCurrent(window);
-    gl3wInit();
+  GLFWwindow* window = glfwCreateWindow(1280, 720, name, NULL, NULL);
+  glfwMakeContextCurrent(window);
+  gl3wInit();
 
-    // Setup ImGui binding
-    ImGui_ImplGlfwGL3_Init(window, true);
+  // Setup ImGui binding
+  ImGui_ImplGlfwGL3_Init(window, true);
 
-    // Load Fonts
-    // (there is a default font, this is only if you want to change it. see extra_fonts/README.txt for more details)
-    //ImGuiIO& io = ImGui::GetIO();
-    //io.Fonts->AddFontDefault();
-    //io.Fonts->AddFontFromFileTTF("../../extra_fonts/Cousine-Regular.ttf", 15.0f);
-    //io.Fonts->AddFontFromFileTTF("../../extra_fonts/DroidSans.ttf", 16.0f);
-    //io.Fonts->AddFontFromFileTTF("../../extra_fonts/ProggyClean.ttf", 13.0f);
-    //io.Fonts->AddFontFromFileTTF("../../extra_fonts/ProggyTiny.ttf", 10.0f);
-    //io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\ArialUni.ttf", 18.0f, NULL, io.Fonts->GetGlyphRangesJapanese());
+  // Load Fonts
+  // (there is a default font, this is only if you want to change it. see extra_fonts/README.txt for more details)
+  // ImGuiIO& io = ImGui::GetIO();
+  // io.Fonts->AddFontDefault();
+  // io.Fonts->AddFontFromFileTTF("../../extra_fonts/Cousine-Regular.ttf", 15.0f);
+  // io.Fonts->AddFontFromFileTTF("../../extra_fonts/DroidSans.ttf", 16.0f);
+  // io.Fonts->AddFontFromFileTTF("../../extra_fonts/ProggyClean.ttf", 13.0f);
+  // io.Fonts->AddFontFromFileTTF("../../extra_fonts/ProggyTiny.ttf", 10.0f);
+  // io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\ArialUni.ttf", 18.0f, NULL, io.Fonts->GetGlyphRangesJapanese());
 
-    return window;
+  return window;
 }
 
 /// @return true if we do not need to exit, false if we do.
-bool pollGUI(void *context, std::function<void(void)> guiCallback) {
-  GLFWwindow *window = reinterpret_cast<GLFWwindow *>(context);
+bool pollGUI(void* context, std::function<void(void)> guiCallback)
+{
+  GLFWwindow* window = reinterpret_cast<GLFWwindow*>(context);
   if (glfwWindowShouldClose(window)) {
     return false;
   }
@@ -72,7 +75,8 @@ bool pollGUI(void *context, std::function<void(void)> guiCallback) {
   return true;
 }
 
-void disposeGUI() {
+void disposeGUI()
+{
   // Cleanup
   ImGui_ImplGlfwGL3_Shutdown();
   glfwTerminate();

--- a/Framework/DebugGUI/src/DebugGUI.cxx
+++ b/Framework/DebugGUI/src/DebugGUI.cxx
@@ -49,9 +49,9 @@ void *initGUI(const char *name) {
 /// @return true if we do not need to exit, false if we do.
 bool pollGUI(void *context, std::function<void(void)> guiCallback) {
   GLFWwindow *window = reinterpret_cast<GLFWwindow *>(context);
-  if (glfwWindowShouldClose(window))
+  if (glfwWindowShouldClose(window)) {
     return false;
-
+  }
   glfwPollEvents();
   ImGui_ImplGlfwGL3_NewFrame();
 


### PR DESCRIPTION
This introduces a state machine for the DPL driver process so that more complex behaviours can be implemented in the future, like, for example spawning processes on a cluster using DDS or a web based console.

This will come also handy to implement proper process cleanup on quit, which at the moment is kind of brutal.