### PR TITLE
Fix messup by clang-format

### DIFF
--- a/Framework/DebugGUI/src/DebugGUI.cxx
+++ b/Framework/DebugGUI/src/DebugGUI.cxx
@@ -1,9 +1,9 @@
+#include "imgui.h"
+#include "imgui_impl_glfw_gl3.h"
+#include "GL/gl3w.h" // This example is using gl3w to access OpenGL functions (because it is small). You may use glew/glad/glLoadGen/etc. whatever already works for you.
 #include <GLFW/glfw3.h>
 #include <stdio.h>
 #include <functional>
-#include "GL/gl3w.h" // This example is using gl3w to access OpenGL functions (because it is small). You may use glew/glad/glLoadGen/etc. whatever already works for you.
-#include "imgui.h"
-#include "imgui_impl_glfw_gl3.h"
 
 static void error_callback(int error, const char* description)
 {


### PR DESCRIPTION
Header files where reordered by clang format, but apparently this triggers errors on mac. Rolling back that `clang-format` issue. 