### PR TITLE
reducing namespace o2::DataFormat::TPC to o2::TPC

### DIFF
--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/ClusterHardware.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/ClusterHardware.h
@@ -19,8 +19,6 @@
 
 namespace o2
 {
-namespace DataFormat
-{
 namespace TPC
 {
 struct ClusterHardware { // Temporary draft of hardware clusters. The ...Pre members are yet to be defined, and will
@@ -53,7 +51,6 @@ struct ClusterHardwareContainer { // Temporary struct to hold a set of hardware 
   uint16_t CRU;                //< CRU of the cluster
   ClusterHardware clusters[0]; //< Clusters
 };
-}
 }
 }
 

--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/ClusterNative.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/ClusterNative.h
@@ -29,8 +29,6 @@ class MCTruthContainer;
 
 namespace o2
 {
-namespace DataFormat
-{
 namespace TPC
 {
 /**
@@ -134,7 +132,6 @@ struct ClusterNativeAccessFullTPC {
   o2::dataformats::MCTruthContainer<o2::MCCompLabel>* clustersMCTruth[o2::TPC::Constants::MAXSECTOR]
                                                                      [o2::TPC::Constants::MAXGLOBALPADROW];
 };
-}
 }
 }
 #endif

--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/Helpers.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/Helpers.h
@@ -31,8 +31,6 @@ class MCTruthContainer;
 
 namespace o2
 {
-namespace DataFormat
-{
 namespace TPC
 {
 class TPCClusterFormatHelper
@@ -64,7 +62,6 @@ class ClusterHardwareContainerFixedSize
   static_assert(size >= sizeof(ClusterHardwareContainer), "Size must be at least sizeof(ClusterHardwareContainer)");
 };
 typedef ClusterHardwareContainerFixedSize<8192> ClusterHardwareContainer8kb;
-}
 }
 }
 

--- a/DataFormats/Detectors/TPC/src/DataFormatsTPCLinkDef.h
+++ b/DataFormats/Detectors/TPC/src/DataFormatsTPCLinkDef.h
@@ -14,15 +14,15 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
-#pragma link C++ class o2::DataFormat::TPC::ClusterHardware + ;
-#pragma link C++ class o2::DataFormat::TPC::ClusterHardwareContainer + ;
-#pragma link C++ class o2::DataFormat::TPC::ClusterNative + ;
-#pragma link C++ class o2::DataFormat::TPC::ClusterHardwareContainer8kb + ;
-#pragma link C++ class o2::DataFormat::TPC::ClusterHardwareContainerFixedSize < 8192 > +;
-#pragma link C++ class o2::DataFormat::TPC::ClusterNativeContainer + ;
-#pragma link C++ class std::vector < o2::DataFormat::TPC::ClusterNative > +;
-#pragma link C++ class std::vector < o2::DataFormat::TPC::ClusterNativeContainer > +;
-#pragma link C++ class std::vector < o2::DataFormat::TPC::ClusterHardwareContainer8kb > +;
-#pragma link C++ class o2::DataFormat::TPC::TPCClusterFormatHelper + ;
+#pragma link C++ class o2::TPC::ClusterHardware + ;
+#pragma link C++ class o2::TPC::ClusterHardwareContainer + ;
+#pragma link C++ class o2::TPC::ClusterNative + ;
+#pragma link C++ class o2::TPC::ClusterHardwareContainer8kb + ;
+#pragma link C++ class o2::TPC::ClusterHardwareContainerFixedSize < 8192 > +;
+#pragma link C++ class o2::TPC::ClusterNativeContainer + ;
+#pragma link C++ class std::vector < o2::TPC::ClusterNative > +;
+#pragma link C++ class std::vector < o2::TPC::ClusterNativeContainer > +;
+#pragma link C++ class std::vector < o2::TPC::ClusterHardwareContainer8kb > +;
+#pragma link C++ class o2::TPC::TPCClusterFormatHelper + ;
 
 #endif

--- a/DataFormats/Detectors/TPC/src/Helpers.cxx
+++ b/DataFormats/Detectors/TPC/src/Helpers.cxx
@@ -16,7 +16,6 @@
 #include "SimulationDataFormat/MCTruthContainer.h"
 #include "TPCBase/Constants.h"
 
-using namespace o2::DataFormat::TPC;
 using namespace o2::TPC;
 
 std::unique_ptr<ClusterNativeAccessFullTPC> TPCClusterFormatHelper::accessNativeContainerArray(

--- a/DataFormats/Detectors/TPC/test/ClusterNative.cxx
+++ b/DataFormats/Detectors/TPC/test/ClusterNative.cxx
@@ -22,8 +22,6 @@
 
 namespace o2
 {
-namespace DataFormat
-{
 namespace TPC
 {
 // check function for different versions of the cluster type, versions
@@ -86,5 +84,4 @@ bool checkClusterType()
 
 BOOST_AUTO_TEST_CASE(test_tpc_clusternative) { checkClusterType<ClusterNative>(); }
 } // namespace TPC
-} // namespace DataFormat
 } // namespace o2

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/HardwareClusterDecoder.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/HardwareClusterDecoder.h
@@ -18,9 +18,13 @@
 #include "TPCReconstruction/DigitalCurrentClusterIntegrator.h"
 #include "DataFormatsTPC/ClusterNative.h"
 
-namespace o2 { namespace TPC {
+namespace o2
+{
+namespace TPC
+{
 class ClusterHardwareContainer;
-}}
+}
+}
 
 namespace o2 { namespace dataformats { template <typename TruthElement> class MCTruthContainer; } class MCCompLabel; }
 
@@ -32,12 +36,15 @@ class HardwareClusterDecoder
 public:
   HardwareClusterDecoder() = default;
   ~HardwareClusterDecoder() = default;
-  
-  int decodeClusters(std::vector<std::pair<const o2::TPC::ClusterHardwareContainer*, std::size_t>>& inputClusters, std::vector<o2::TPC::ClusterNativeContainer>& outputClusters,
-    const std::vector<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>* inMCLabels = nullptr, std::vector<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>* outMCLabels = nullptr);
-  static void sortClustersAndMC(std::vector<o2::TPC::ClusterNative> clusters, o2::dataformats::MCTruthContainer<o2::MCCompLabel> mcTruth);
 
-private:
+  int decodeClusters(std::vector<std::pair<const o2::TPC::ClusterHardwareContainer*, std::size_t>>& inputClusters,
+                     std::vector<o2::TPC::ClusterNativeContainer>& outputClusters,
+                     const std::vector<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>* inMCLabels = nullptr,
+                     std::vector<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>* outMCLabels = nullptr);
+  static void sortClustersAndMC(std::vector<o2::TPC::ClusterNative> clusters,
+                                o2::dataformats::MCTruthContainer<o2::MCCompLabel> mcTruth);
+
+ private:
   std::unique_ptr<DigitalCurrentClusterIntegrator> mIntegrator;
 };
 

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/HardwareClusterDecoder.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/HardwareClusterDecoder.h
@@ -18,9 +18,9 @@
 #include "TPCReconstruction/DigitalCurrentClusterIntegrator.h"
 #include "DataFormatsTPC/ClusterNative.h"
 
-namespace o2 { namespace DataFormat { namespace TPC {
+namespace o2 { namespace TPC {
 class ClusterHardwareContainer;
-}}}
+}}
 
 namespace o2 { namespace dataformats { template <typename TruthElement> class MCTruthContainer; } class MCCompLabel; }
 
@@ -33,9 +33,9 @@ public:
   HardwareClusterDecoder() = default;
   ~HardwareClusterDecoder() = default;
   
-  int decodeClusters(std::vector<std::pair<const o2::DataFormat::TPC::ClusterHardwareContainer*, std::size_t>>& inputClusters, std::vector<o2::DataFormat::TPC::ClusterNativeContainer>& outputClusters,
+  int decodeClusters(std::vector<std::pair<const o2::TPC::ClusterHardwareContainer*, std::size_t>>& inputClusters, std::vector<o2::TPC::ClusterNativeContainer>& outputClusters,
     const std::vector<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>* inMCLabels = nullptr, std::vector<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>* outMCLabels = nullptr);
-  static void sortClustersAndMC(std::vector<o2::DataFormat::TPC::ClusterNative> clusters, o2::dataformats::MCTruthContainer<o2::MCCompLabel> mcTruth);
+  static void sortClustersAndMC(std::vector<o2::TPC::ClusterNative> clusters, o2::dataformats::MCTruthContainer<o2::MCCompLabel> mcTruth);
 
 private:
   std::unique_ptr<DigitalCurrentClusterIntegrator> mIntegrator;

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/TPCCATracking.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/TPCCATracking.h
@@ -45,18 +45,29 @@ public:
   
   
   //Input: cluster structure, possibly including MC labels, pointers to std::vectors for tracks and track MC labels. outputTracksMCTruth may be nullptr to indicate missing cluster MC labels. Otherwise, cluster MC labels are assumed to be present.
-  int runTracking(const o2::TPC::ClusterNativeAccessFullTPC& clusters, std::vector<TrackTPC>* outputTracks, o2::dataformats::MCTruthContainer<o2::MCCompLabel>* outputTracksMCTruth = nullptr);
-  
-  int convertClusters(const std::vector<Cluster>* inputClusters, o2::TPC::ClusterNativeAccessFullTPC& outputClusters, std::unique_ptr<o2::TPC::ClusterNative[]>& clusterMemory) {return convertClusters(nullptr, inputClusters, outputClusters, clusterMemory);}
-  int convertClusters(TChain* inputClusters, o2::TPC::ClusterNativeAccessFullTPC& outputClusters, std::unique_ptr<o2::TPC::ClusterNative[]>& clusterMemory) {return convertClusters(inputClusters, nullptr, outputClusters, clusterMemory);}
-  
+  int runTracking(const o2::TPC::ClusterNativeAccessFullTPC& clusters, std::vector<TrackTPC>* outputTracks,
+                  o2::dataformats::MCTruthContainer<o2::MCCompLabel>* outputTracksMCTruth = nullptr);
+
+  int convertClusters(const std::vector<Cluster>* inputClusters, o2::TPC::ClusterNativeAccessFullTPC& outputClusters,
+                      std::unique_ptr<o2::TPC::ClusterNative[]>& clusterMemory)
+  {
+    return convertClusters(nullptr, inputClusters, outputClusters, clusterMemory);
+  }
+  int convertClusters(TChain* inputClusters, o2::TPC::ClusterNativeAccessFullTPC& outputClusters,
+                      std::unique_ptr<o2::TPC::ClusterNative[]>& clusterMemory)
+  {
+    return convertClusters(inputClusters, nullptr, outputClusters, clusterMemory);
+  }
+
   float getPseudoVDrift();                                            //Return artificial VDrift used to convert time to Z
   float getTFReferenceLength() {return sContinuousTFReferenceLength;} //Return reference time frame length used to obtain Z from T in continuous data
   int getNTracksASide() {return mNTracksASide;}
 
 private:
   int runTracking(TChain* inputClustersChain, const std::vector<Cluster>* inputClustersArray, std::vector<TrackTPC>* outputTracks);
-  int convertClusters(TChain* inputClustersChain, const std::vector<Cluster>* inputClustersArray, o2::TPC::ClusterNativeAccessFullTPC& outputClusters, std::unique_ptr<o2::TPC::ClusterNative[]>& clusterMemory);
+  int convertClusters(TChain* inputClustersChain, const std::vector<Cluster>* inputClustersArray,
+                      o2::TPC::ClusterNativeAccessFullTPC& outputClusters,
+                      std::unique_ptr<o2::TPC::ClusterNative[]>& clusterMemory);
 
   std::unique_ptr<AliHLTTPCCAO2Interface> mTrackingCAO2Interface; //Pointer to Interface class in HLT O2 CA Tracking library.
                                                                   //The tracking code itself is not included in the O2 package, but contained in the CA library.

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/TPCCATracking.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/TPCCATracking.h
@@ -45,10 +45,10 @@ public:
   
   
   //Input: cluster structure, possibly including MC labels, pointers to std::vectors for tracks and track MC labels. outputTracksMCTruth may be nullptr to indicate missing cluster MC labels. Otherwise, cluster MC labels are assumed to be present.
-  int runTracking(const o2::DataFormat::TPC::ClusterNativeAccessFullTPC& clusters, std::vector<TrackTPC>* outputTracks, o2::dataformats::MCTruthContainer<o2::MCCompLabel>* outputTracksMCTruth = nullptr);
+  int runTracking(const o2::TPC::ClusterNativeAccessFullTPC& clusters, std::vector<TrackTPC>* outputTracks, o2::dataformats::MCTruthContainer<o2::MCCompLabel>* outputTracksMCTruth = nullptr);
   
-  int convertClusters(const std::vector<Cluster>* inputClusters, o2::DataFormat::TPC::ClusterNativeAccessFullTPC& outputClusters, std::unique_ptr<o2::DataFormat::TPC::ClusterNative[]>& clusterMemory) {return convertClusters(nullptr, inputClusters, outputClusters, clusterMemory);}
-  int convertClusters(TChain* inputClusters, o2::DataFormat::TPC::ClusterNativeAccessFullTPC& outputClusters, std::unique_ptr<o2::DataFormat::TPC::ClusterNative[]>& clusterMemory) {return convertClusters(inputClusters, nullptr, outputClusters, clusterMemory);}
+  int convertClusters(const std::vector<Cluster>* inputClusters, o2::TPC::ClusterNativeAccessFullTPC& outputClusters, std::unique_ptr<o2::TPC::ClusterNative[]>& clusterMemory) {return convertClusters(nullptr, inputClusters, outputClusters, clusterMemory);}
+  int convertClusters(TChain* inputClusters, o2::TPC::ClusterNativeAccessFullTPC& outputClusters, std::unique_ptr<o2::TPC::ClusterNative[]>& clusterMemory) {return convertClusters(inputClusters, nullptr, outputClusters, clusterMemory);}
   
   float getPseudoVDrift();                                            //Return artificial VDrift used to convert time to Z
   float getTFReferenceLength() {return sContinuousTFReferenceLength;} //Return reference time frame length used to obtain Z from T in continuous data
@@ -56,7 +56,7 @@ public:
 
 private:
   int runTracking(TChain* inputClustersChain, const std::vector<Cluster>* inputClustersArray, std::vector<TrackTPC>* outputTracks);
-  int convertClusters(TChain* inputClustersChain, const std::vector<Cluster>* inputClustersArray, o2::DataFormat::TPC::ClusterNativeAccessFullTPC& outputClusters, std::unique_ptr<o2::DataFormat::TPC::ClusterNative[]>& clusterMemory);
+  int convertClusters(TChain* inputClustersChain, const std::vector<Cluster>* inputClustersArray, o2::TPC::ClusterNativeAccessFullTPC& outputClusters, std::unique_ptr<o2::TPC::ClusterNative[]>& clusterMemory);
 
   std::unique_ptr<AliHLTTPCCAO2Interface> mTrackingCAO2Interface; //Pointer to Interface class in HLT O2 CA Tracking library.
                                                                   //The tracking code itself is not included in the O2 package, but contained in the CA library.

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/TrackTPC.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/TrackTPC.h
@@ -81,16 +81,16 @@ class TrackTPC : public o2::track::TrackParCov
     sectorIndex = reinterpret_cast<const uint8_t*>(mClusterReferences.data())[4 * mNClusters + nCluster];
     rowIndex = reinterpret_cast<const uint8_t*>(mClusterReferences.data())[5 * mNClusters + nCluster];
   }
-  const o2::DataFormat::TPC::ClusterNative& getCluster(int nCluster,
-                                                       const o2::DataFormat::TPC::ClusterNativeAccessFullTPC& clusters,
+  const o2::TPC::ClusterNative& getCluster(int nCluster,
+                                                       const o2::TPC::ClusterNativeAccessFullTPC& clusters,
                                                        uint8_t& sectorIndex, uint8_t& rowIndex) const
   {
     uint32_t clusterIndex;
     getClusterReference(nCluster, sectorIndex, rowIndex, clusterIndex);
     return (clusters.clusters[sectorIndex][rowIndex][clusterIndex]);
   }
-  const o2::DataFormat::TPC::ClusterNative& getCluster(
-    int nCluster, const o2::DataFormat::TPC::ClusterNativeAccessFullTPC& clusters) const
+  const o2::TPC::ClusterNative& getCluster(
+    int nCluster, const o2::TPC::ClusterNativeAccessFullTPC& clusters) const
   {
     uint8_t sectorIndex, rowIndex;
     return (getCluster(nCluster, clusters, sectorIndex, rowIndex));

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/TrackTPC.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/TrackTPC.h
@@ -81,16 +81,14 @@ class TrackTPC : public o2::track::TrackParCov
     sectorIndex = reinterpret_cast<const uint8_t*>(mClusterReferences.data())[4 * mNClusters + nCluster];
     rowIndex = reinterpret_cast<const uint8_t*>(mClusterReferences.data())[5 * mNClusters + nCluster];
   }
-  const o2::TPC::ClusterNative& getCluster(int nCluster,
-                                                       const o2::TPC::ClusterNativeAccessFullTPC& clusters,
-                                                       uint8_t& sectorIndex, uint8_t& rowIndex) const
+  const o2::TPC::ClusterNative& getCluster(int nCluster, const o2::TPC::ClusterNativeAccessFullTPC& clusters,
+                                           uint8_t& sectorIndex, uint8_t& rowIndex) const
   {
     uint32_t clusterIndex;
     getClusterReference(nCluster, sectorIndex, rowIndex, clusterIndex);
     return (clusters.clusters[sectorIndex][rowIndex][clusterIndex]);
   }
-  const o2::TPC::ClusterNative& getCluster(
-    int nCluster, const o2::TPC::ClusterNativeAccessFullTPC& clusters) const
+  const o2::TPC::ClusterNative& getCluster(int nCluster, const o2::TPC::ClusterNativeAccessFullTPC& clusters) const
   {
     uint8_t sectorIndex, rowIndex;
     return (getCluster(nCluster, clusters, sectorIndex, rowIndex));

--- a/Detectors/TPC/reconstruction/macro/convertClusterToClusterHardware.C
+++ b/Detectors/TPC/reconstruction/macro/convertClusterToClusterHardware.C
@@ -33,7 +33,6 @@
 #endif
 
 using namespace o2;
-using namespace o2::DataFormat::TPC;
 using namespace o2::TPC;
 using namespace o2::dataformats;
 using namespace std;

--- a/Detectors/TPC/reconstruction/macro/runCATrackingClusterNative.C
+++ b/Detectors/TPC/reconstruction/macro/runCATrackingClusterNative.C
@@ -35,7 +35,6 @@
 
 using namespace o2;
 using namespace o2::TPC;
-using namespace o2::DataFormat::TPC;
 using namespace o2::dataformats;
 using namespace std;
 

--- a/Detectors/TPC/reconstruction/macro/runHardwareClusterDecoderRaw.C
+++ b/Detectors/TPC/reconstruction/macro/runHardwareClusterDecoderRaw.C
@@ -29,7 +29,6 @@
 #endif
 
 using namespace o2::TPC;
-using namespace o2::DataFormat::TPC;
 using namespace std;
 
 int runHardwareClusterDecoderRaw(TString outfile = "", int tf = 0) {

--- a/Detectors/TPC/reconstruction/macro/runHardwareClusterDecoderRoot.C
+++ b/Detectors/TPC/reconstruction/macro/runHardwareClusterDecoderRoot.C
@@ -33,7 +33,6 @@
 #endif
 
 using namespace o2;
-using namespace o2::DataFormat::TPC;
 using namespace o2::TPC;
 using namespace o2::dataformats;
 using namespace std;

--- a/Detectors/TPC/reconstruction/src/HardwareClusterDecoder.cxx
+++ b/Detectors/TPC/reconstruction/src/HardwareClusterDecoder.cxx
@@ -27,7 +27,6 @@
 #include "TPCBase/ParameterElectronics.h"
 
 using namespace o2::TPC;
-using namespace o2::DataFormat::TPC;
 using namespace o2;
 using namespace o2::dataformats;
 

--- a/Detectors/TPC/reconstruction/src/TPCCATracking.cxx
+++ b/Detectors/TPC/reconstruction/src/TPCCATracking.cxx
@@ -40,7 +40,6 @@
 #include "AliHLTTPCCAO2Interface.h"
 
 using namespace o2::TPC;
-using namespace o2::DataFormat::TPC;
 using namespace o2;
 using namespace o2::dataformats;
 


### PR DESCRIPTION
TPC data format definitions in DataFormats/Detectors/TPC got an extra
level of namespace which is not necessary.

@wiechula, @davidrohr, @sawenzel, @ktf, what do you think? I suggest removing one namespace level from the TPC data format definitions. 