### PR TITLE
Introducing type trait is_messageable and replacing is_trivially_copyable/is_pod with this

### DIFF
--- a/Framework/Core/include/Framework/DataRefUtils.h
+++ b/Framework/Core/include/Framework/DataRefUtils.h
@@ -13,6 +13,7 @@
 #include "Framework/DataRef.h"
 #include "Headers/DataHeader.h"
 #include "Framework/TMessageSerializer.h"
+#include "Framework/TypeTraits.h"
 #include <TClass.h>
 #include <stdexcept>
 #include <sstream>
@@ -25,11 +26,12 @@ namespace framework {
 // FIXME: Should enforce the fact that DataRefs are read only...
 struct DataRefUtils {
   // SFINAE makes this available only for the case we are using
-  // a POD, this is to distinguish it from the alternative below,
-  // which works for TObject (which are serialised).
+  // trivially copyable type, this is to distinguish it from the
+  // alternative below, which works for TObject (which are serialised).
   template <typename T>
-  static typename std::enable_if<std::is_pod<T>::value == true, gsl::span<T>>::type
-  as(DataRef const &ref) {
+  static typename std::enable_if<is_messageable<T>::value == true, gsl::span<T>>::type
+  as(DataRef const& ref)
+  {
     using DataHeader = o2::header::DataHeader;
     auto header = o2::header::get<const DataHeader>(ref.header);
     if (header->payloadSerializationMethod != o2::header::gSerializationMethodNone) {

--- a/Framework/Core/include/Framework/InputRecord.h
+++ b/Framework/Core/include/Framework/InputRecord.h
@@ -13,6 +13,7 @@
 #include "Framework/DataRef.h"
 #include "Framework/DataRefUtils.h"
 #include "Framework/InputRoute.h"
+#include "Framework/TypeTraits.h"
 
 #include <fairmq/FairMQMessage.h>
 #include <Framework/TMessageSerializer.h>
@@ -62,7 +63,7 @@ public:
   // not be used if the type is a TObject as extra deserialization
   // needs to happen.
   template <typename T>
-  typename std::enable_if<std::is_pod<T>::value && std::is_same<T, DataRef>::value == false, T>::type const&
+  typename std::enable_if<is_messageable<T>::value && std::is_same<T, DataRef>::value == false, T>::type const&
   get(char const *binding) const {
     return *reinterpret_cast<T const *>(get<DataRef>(binding).payload);
   }

--- a/Framework/Core/include/Framework/TypeTraits.h
+++ b/Framework/Core/include/Framework/TypeTraits.h
@@ -7,6 +7,8 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
+#ifndef FRAMEWORK_TYPETRAITS_H
+#define FRAMEWORK_TYPETRAITS_H
 
 #include <type_traits>
 
@@ -22,5 +24,11 @@ struct is_specialization : std::false_type {};
 template<template<typename...> class Ref, typename... Args>
 struct is_specialization<Ref<Args...>, Ref>: std::true_type {};
 
+// TODO: extend this to exclude structs with pointer data members
+// see e.g. https://stackoverflow.com/questions/32880990/how-to-check-if-class-has-pointers-in-c14
+template <typename T>
+struct is_messageable : std::conditional<std::is_trivially_copyable<T>::value && !std::is_polymorphic<T>::value,
+                                         std::true_type, std::false_type>::type {};
 }
 }
+#endif // FRAMEWORK_TYPETRAITS_H

--- a/Framework/Core/test/test_TypeTraits.cxx
+++ b/Framework/Core/test/test_TypeTraits.cxx
@@ -24,6 +24,30 @@ struct Foo {
   int y;
 };
 
+// TODO: extend this by a struct with pointer member
+class TriviallyCopyable
+{
+ public:
+  int mX;
+  int mY;
+
+ private:
+  int mP;
+};
+
+class Base
+{
+ public:
+  virtual void f() {}
+};
+
+class Polymorphic : Base
+{
+ public:
+ private:
+  int mMember;
+};
+
 // Simple test to do root deserialization.
 BOOST_AUTO_TEST_CASE(TestIsSpecialization) {
   std::vector<int> a;
@@ -43,4 +67,19 @@ BOOST_AUTO_TEST_CASE(TestIsSpecialization) {
   BOOST_REQUIRE_EQUAL(test4, true);
   BOOST_REQUIRE_EQUAL(test5, false);
   BOOST_REQUIRE_EQUAL(test6, false);
+}
+
+BOOST_AUTO_TEST_CASE(TestIsMessageable)
+{
+  int a;
+  Foo b;
+  std::vector<int> c;
+  TriviallyCopyable d;
+  Polymorphic e;
+
+  BOOST_REQUIRE_EQUAL(is_messageable<decltype(a)>::value, true);
+  BOOST_REQUIRE_EQUAL(is_messageable<decltype(b)>::value, true);
+  BOOST_REQUIRE_EQUAL(is_messageable<decltype(c)>::value, false);
+  BOOST_REQUIRE_EQUAL(is_messageable<decltype(d)>::value, true);
+  BOOST_REQUIRE_EQUAL(is_messageable<decltype(e)>::value, false);
 }


### PR DESCRIPTION
Extending snapshot method of framework::DataAllocator to support
trivially copyable objects in general in all specializations. On the
receiving side, DataRefUtils::as has been made consistent to that.