### PR TITLE
clang-format: disallow sorting of includes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -37,6 +37,7 @@ PenaltyBreakFirstLessLess: 120
 PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
+SortIncludes: false
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: ControlStatements
 SpaceInEmptyParentheses: false


### PR DESCRIPTION
This should solve the problem with messing up our include order.