### PR TITLE
Take out unused Vc include

### DIFF
--- a/Detectors/TPC/base/include/TPCBase/CalDet.h
+++ b/Detectors/TPC/base/include/TPCBase/CalDet.h
@@ -11,7 +11,6 @@
 #ifndef ALICEO2_TPC_CALDET_H_
 #define ALICEO2_TPC_CALDET_H_
 
-#include <Vc/Vc>
 #include <memory>
 #include <vector>
 #include <string>


### PR DESCRIPTION
This is related to a reported issue #843. The include is not needed and we might have to revisit when needed.