### PR TITLE
Improve the driver control facilities

### DIFF
--- a/Framework/Core/src/DriverControl.h
+++ b/Framework/Core/src/DriverControl.h
@@ -18,10 +18,19 @@ namespace o2
 namespace framework
 {
 
+/// These are the possible states for the driver controller
+/// and determine what should happen of state machine transitions.
+enum struct DriverControlState {
+  STEP,
+  PLAY,
+  PAUSE
+};
+
 /// Information about the driver process (i.e.  / the one which calculates the
 /// topology and actually spawns the devices )
 struct DriverControl {
   std::vector<DriverState> forcedTransitions;
+  DriverControlState state;
 };
 
 } // namespace framework

--- a/Framework/Core/src/DriverInfo.h
+++ b/Framework/Core/src/DriverInfo.h
@@ -42,6 +42,9 @@ namespace framework
 ///   RUNNING -> RUNNING
 ///   RUNNING -> GUI
 ///   GUI -> RUNNING
+///   NONE -> QUIT_REQUESTED
+///   QUIT_REQUESTED -> HANDLE_CHILDREN
+///   RUNNING -> HANDLE_CHILDREN
 ///   RUNNING -> SCHEDULE
 ///   RUNNING -> EXIT
 /// ]"
@@ -52,6 +55,8 @@ enum struct DriverState {
   RUNNING,
   GUI,
   REDEPLOY_GUI,
+  QUIT_REQUESTED,
+  HANDLE_CHILDREN,
   EXIT,
   UNKNOWN,
   LAST
@@ -71,6 +76,8 @@ struct DriverInfo {
 
   // Signal handler for children
   struct sigaction sa_handle_child;
+  bool sigintRequested;
+  bool sigchldRequested;
 };
 
 } // namespace framework


### PR DESCRIPTION
- More resilient quit behavior is now implemented thanks
to the state machine introduced in #832. The signal handlers
are now fully signal safe.
- Add working controller window which allows to pause and single step
through the execution of all the devices. The quantum is given by the
children blocking when writing output.
- Add --single-step option to start in single step mode, if needed.