### PR TITLE
Allow driver state machine to perform callbacks

### DIFF
--- a/Framework/Core/src/DriverControl.h
+++ b/Framework/Core/src/DriverControl.h
@@ -45,6 +45,8 @@ struct DriverControl {
   /// Callbacks to be performed by the driver next time it
   /// goes in the "PERFORM_CALLBACK" state.
   std::vector<Callback> callbacks;
+  bool defaultQuiet;
+  bool defaultStopped;
 };
 
 } // namespace framework

--- a/Framework/Core/src/DriverControl.h
+++ b/Framework/Core/src/DriverControl.h
@@ -24,19 +24,14 @@ namespace framework
 
 /// These are the possible states for the driver controller
 /// and determine what should happen of state machine transitions.
-enum struct DriverControlState {
-  STEP,
-  PLAY,
-  PAUSE
-};
+enum struct DriverControlState { STEP, PLAY, PAUSE };
 
 /// Controller for the driver process (i.e. / the one which calculates the
 /// topology and actually spawns the devices ). Any operation to be done by
 /// the driver process should be recorded in an instance of this, so that the
 /// changes can be applied at the correct moment / state.
 struct DriverControl {
-  using Callback = std::function<void(std::vector<DeviceSpec> const&,
-                                      std::vector<DeviceExecution> const&)>;
+  using Callback = std::function<void(std::vector<DeviceSpec> const&, std::vector<DeviceExecution> const&)>;
   /// States to be added to the stack on next iteration
   /// of the state machine processing.
   std::vector<DriverState> forcedTransitions;

--- a/Framework/Core/src/DriverControl.h
+++ b/Framework/Core/src/DriverControl.h
@@ -10,8 +10,12 @@
 #ifndef FRAMEWORK_DRIVERCONTROL_H
 #define FRAMEWORK_DRIVERCONTROL_H
 
+#include <functional>
 #include <vector>
+
 #include "DriverInfo.h"
+#include "Framework/DeviceSpec.h"
+#include "Framework/DeviceExecution.h"
 
 namespace o2
 {
@@ -26,11 +30,21 @@ enum struct DriverControlState {
   PAUSE
 };
 
-/// Information about the driver process (i.e.  / the one which calculates the
-/// topology and actually spawns the devices )
+/// Controller for the driver process (i.e. / the one which calculates the
+/// topology and actually spawns the devices ). Any operation to be done by
+/// the driver process should be recorded in an instance of this, so that the
+/// changes can be applied at the correct moment / state.
 struct DriverControl {
+  using Callback = std::function<void(std::vector<DeviceSpec> const&,
+                                      std::vector<DeviceExecution> const&)>;
+  /// States to be added to the stack on next iteration
+  /// of the state machine processing.
   std::vector<DriverState> forcedTransitions;
+  /// Current state of the state machine player.
   DriverControlState state;
+  /// Callbacks to be performed by the driver next time it
+  /// goes in the "PERFORM_CALLBACK" state.
+  std::vector<Callback> callbacks;
 };
 
 } // namespace framework

--- a/Framework/Core/src/DriverInfo.h
+++ b/Framework/Core/src/DriverInfo.h
@@ -18,6 +18,8 @@
 #include <csignal>
 #include <sys/select.h>
 
+#include "Framework/ChannelConfigurationPolicy.h"
+
 namespace o2
 {
 namespace framework
@@ -60,6 +62,8 @@ enum struct DriverState {
   EXIT,
   UNKNOWN,
   PERFORM_CALLBACKS,
+  MATERIALISE_WORKFLOW,
+  DO_CHILD,
   LAST
 };
 
@@ -79,6 +83,16 @@ struct DriverInfo {
   struct sigaction sa_handle_child;
   bool sigintRequested;
   bool sigchldRequested;
+  /// These are the configuration policies for the channel creation.
+  /// Since they are decided by the toplevel configuration, they belong
+  /// to the driver process.
+  std::vector<ChannelConfigurationPolicy> channelPolicies;
+  /// The argc with which the driver was started.
+  int argc;
+  /// The argv with which the driver was started.
+  char **argv;
+  /// Whether the driver was started in batch mode or not.
+  bool batch;
 };
 
 } // namespace framework

--- a/Framework/Core/src/DriverInfo.h
+++ b/Framework/Core/src/DriverInfo.h
@@ -59,6 +59,7 @@ enum struct DriverState {
   HANDLE_CHILDREN,
   EXIT,
   UNKNOWN,
+  PERFORM_CALLBACKS,
   LAST
 };
 

--- a/Framework/Core/src/DriverInfo.h
+++ b/Framework/Core/src/DriverInfo.h
@@ -90,7 +90,7 @@ struct DriverInfo {
   /// The argc with which the driver was started.
   int argc;
   /// The argv with which the driver was started.
-  char **argv;
+  char** argv;
   /// Whether the driver was started in batch mode or not.
   bool batch;
 };

--- a/Framework/Core/src/FrameworkGUIDebugger.cxx
+++ b/Framework/Core/src/FrameworkGUIDebugger.cxx
@@ -373,15 +373,16 @@ struct DriverHelper {
   static char const* stateToString(enum DriverState state)
   {
     static const char* names[static_cast<int>(DriverState::LAST)] = {
-      "INIT",            //
-      "SCHEDULE",        //
-      "RUNNING",         //
-      "GUI",             //
-      "REDEPLOY_GUI",    //
-      "QUIT_REQUESTED",  //
-      "HANDLE_CHILDREN", //
-      "EXIT",            //
-      "UNKNOWN"          //
+      "INIT",             //
+      "SCHEDULE",         //
+      "RUNNING",          //
+      "GUI",              //
+      "REDEPLOY_GUI",     //
+      "QUIT_REQUESTED",   //
+      "HANDLE_CHILDREN",  //
+      "EXIT",             //
+      "UNKNOWN"           //
+      "PERFORM_CALLBACKS" //
     };
     return names[static_cast<int>(state)];
   }

--- a/Framework/Core/src/FrameworkGUIDebugger.cxx
+++ b/Framework/Core/src/FrameworkGUIDebugger.cxx
@@ -398,8 +398,10 @@ void displayDriverInfo(DriverInfo const& driverInfo, DriverControl& driverContro
     driverControl.state = DriverControlState::PAUSE;
   }
   auto state = reinterpret_cast<int*>(&driverControl.state);
-  ImGui::RadioButton("Play", state, static_cast<int>(DriverControlState::PLAY)); ImGui::SameLine();
-  ImGui::RadioButton("Pause", state, static_cast<int>(DriverControlState::PAUSE)); ImGui::SameLine();
+  ImGui::RadioButton("Play", state, static_cast<int>(DriverControlState::PLAY));
+  ImGui::SameLine();
+  ImGui::RadioButton("Pause", state, static_cast<int>(DriverControlState::PAUSE));
+  ImGui::SameLine();
   ImGui::RadioButton("Step", state, static_cast<int>(DriverControlState::STEP));
 
   if (driverControl.state == DriverControlState::PAUSE) {

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -133,7 +133,8 @@ void killChildren(std::vector<DeviceInfo>& infos, int sig)
 }
 
 /// Check the state of the children
-bool areAllChildrenGone(std::vector<DeviceInfo>& infos) {
+bool areAllChildrenGone(std::vector<DeviceInfo>& infos)
+{
   for (auto& info : infos) {
     if (info.active) {
       return false;
@@ -143,7 +144,8 @@ bool areAllChildrenGone(std::vector<DeviceInfo>& infos) {
 }
 
 /// Calculate exit code
-int calculateExitCode(std::vector<DeviceInfo>& infos) {
+int calculateExitCode(std::vector<DeviceInfo>& infos)
+{
   int exitCode = 0;
   for (auto& info : infos) {
     if (exitCode == 0 && info.maxLogLevel >= LogParsingHelpers::LogLevel::Error) {
@@ -269,7 +271,7 @@ void spawnDevice(DeviceSpec const& spec, std::map<int, size_t>& socket2DeviceInf
 }
 
 void processChildrenOutput(DriverInfo& driverInfo, std::vector<DeviceInfo>& infos, std::vector<DeviceSpec> const& specs,
-               std::vector<DeviceControl>& controls, std::vector<DeviceMetricsInfo>& metricsInfos)
+                           std::vector<DeviceControl>& controls, std::vector<DeviceMetricsInfo>& metricsInfos)
 {
   // Wait for children to say something. When they do
   // print it.
@@ -374,9 +376,9 @@ void processChildrenOutput(DriverInfo& driverInfo, std::vector<DeviceInfo>& info
   //        passed.
 }
 
-
 // Process all the sigchld which are pending
-void processSigChild(std::vector<DeviceInfo> &infos) {
+void processSigChild(std::vector<DeviceInfo>& infos)
+{
   while (true) {
     pid_t pid = waitpid((pid_t)(-1), nullptr, WNOHANG);
     if (pid > 0) {
@@ -394,9 +396,9 @@ void processSigChild(std::vector<DeviceInfo> &infos) {
 
 /// Remove all the GUI states from the tail of
 /// the stack unless that's the only state on the stack.
-void pruneGUI(std::vector<DriverState> &states) {
-  while(states.size() > 1
-        && states.back() == DriverState::GUI) {
+void pruneGUI(std::vector<DriverState>& states)
+{
+  while (states.size() > 1 && states.back() == DriverState::GUI) {
     states.pop_back();
   }
 }
@@ -445,7 +447,7 @@ int doParent(std::vector<DeviceInfo>& infos,
   while (true) {
     // If control forced some transition on us, we push it to the queue.
     if (driverControl.forcedTransitions.empty() == false) {
-      for(auto transition : driverControl.forcedTransitions) {
+      for (auto transition : driverControl.forcedTransitions) {
         driverInfo.states.push_back(transition);
       }
       driverControl.forcedTransitions.resize(0);


### PR DESCRIPTION
It is now possible to customise the behavior of the state machine via
callbacks. This allows, for example to express the dumping of DDS and
graphviz configuration files as state machine programs, rather than
ad-hoc functions.

This will also allow the GUI to be more flexible, e.g. to dump a text
representation of the current state, without having to introduce new
ad-hoc states.