### PR TITLE
Do not parse stored field-map path

### DIFF
--- a/Common/Field/include/Field/MagneticField.h
+++ b/Common/Field/include/Field/MagneticField.h
@@ -15,21 +15,28 @@
 #ifndef ALICEO2_FIELD_MAGNETICFIELD_H_
 #define ALICEO2_FIELD_MAGNETICFIELD_H_
 
-#include "FairField.h"         // for FairField
+#include "FairField.h" // for FairField
 #include "Field/MagFieldParam.h"
 #include "Field/MagneticWrapperChebyshev.h" // for MagneticWrapperChebyshev
 #include "Field/MagFieldFast.h"
 #include "TSystem.h"
-#include "Rtypes.h"            // for Double_t, Char_t, Int_t, Float_t, etc
-#include "TNamed.h"            // for TNamed
-#include <memory>              // for str::unique_ptr
+#include "Rtypes.h" // for Double_t, Char_t, Int_t, Float_t, etc
+#include "TNamed.h" // for TNamed
+#include <memory>   // for str::unique_ptr
 
 class FairParamList;
 
-namespace o2 { namespace field { class MagneticWrapperChebyshev; }}  // lines 19-19
-namespace o2 {
-namespace field {
-
+namespace o2
+{
+namespace field
+{
+class MagneticWrapperChebyshev;
+}
+} // lines 19-19
+namespace o2
+{
+namespace field
+{
 
 /// Interface between the TVirtualMagField and MagneticWrapperChebyshev: wrapper to the set of magnetic field data +
 /// Tosca
@@ -37,259 +44,198 @@ namespace field {
 class MagneticField : public FairField
 {
 
-  public:
-    enum PolarityConvention_t
-    {
-        kConvLHC, kConvDCS2008, kConvMap2005
-    };
-    enum
-    {
-        kOverrideGRP = BIT(14)
-    }; // don't recreate from GRP if set
+ public:
+  enum PolarityConvention_t { kConvLHC, kConvDCS2008, kConvMap2005 };
+  enum { kOverrideGRP = BIT(14) }; // don't recreate from GRP if set
 
-    /// Default constructor
-    MagneticField();
+  /// Default constructor
+  MagneticField();
 
-    /// Initialize the field with Geant integration option "integ" and max field "fmax",
-    /// Impose scaling of parameterized L3 field by factorSol and of dipole by factorDip.
-    /// The "be" is the energy of the beam in GeV/nucleon
-    MagneticField(const char *name, const char *title, Double_t factorSol = 1., Double_t factorDip = 1.,
-                  MagFieldParam::BMap_t maptype = MagFieldParam::k5kG,
-		  MagFieldParam::BeamType_t btype = MagFieldParam::kBeamTypepp,
-		  Double_t benergy = -1, Int_t integ = 2,
-                  Double_t fmax = 15, const std::string path = std::string(gSystem->ExpandPathName("$(O2_ROOT)"))
-		  + std::string("/share/Common/maps/mfchebKGI_sym.root")
-    );
+  /// Initialize the field with Geant integration option "integ" and max field "fmax",
+  /// Impose scaling of parameterized L3 field by factorSol and of dipole by factorDip.
+  /// The "be" is the energy of the beam in GeV/nucleon
+  MagneticField(const char* name, const char* title, Double_t factorSol = 1., Double_t factorDip = 1.,
+                MagFieldParam::BMap_t maptype = MagFieldParam::k5kG,
+                MagFieldParam::BeamType_t btype = MagFieldParam::kBeamTypepp, Double_t benergy = -1, Int_t integ = 2,
+                Double_t fmax = 15, const std::string path = "$(O2_ROOT)/share/Common/maps/mfchebKGI_sym.root");
 
+  MagneticField(const MagFieldParam& param);
 
-    MagneticField(const MagFieldParam& param);
+  MagneticField& operator=(const MagneticField& src);
 
-    MagneticField &operator=(const MagneticField &src);
+  /// Default destructor
+  ~MagneticField() override = default;
 
-    /// Default destructor
-    ~MagneticField() override = default;
+  /// real field creation is here
+  void CreateField();
 
-    /// real field creation is here
-    void CreateField();
+  /// allow fast field param
+  void AllowFastField(bool v = true);
 
-    /// allow fast field param
-    void        AllowFastField(bool v=true);
-    
-    /// Virtual methods from FairField
+  /// Virtual methods from FairField
 
-    /// X component, avoid using since slow
-    Double_t GetBx(Double_t x, Double_t y, Double_t z) override {
-      double xyz[3]={x,y,z},b[3];
-      MagneticField::Field(xyz,b);
-      return b[0];
-    } 
+  /// X component, avoid using since slow
+  Double_t GetBx(Double_t x, Double_t y, Double_t z) override
+  {
+    double xyz[3] = { x, y, z }, b[3];
+    MagneticField::Field(xyz, b);
+    return b[0];
+  }
 
-    /// Y component, avoid using since slow
-    Double_t GetBy(Double_t x, Double_t y, Double_t z) override {
-      double xyz[3]={x,y,z},b[3];
-      MagneticField::Field(xyz,b);
-      return b[1];
-    }
+  /// Y component, avoid using since slow
+  Double_t GetBy(Double_t x, Double_t y, Double_t z) override
+  {
+    double xyz[3] = { x, y, z }, b[3];
+    MagneticField::Field(xyz, b);
+    return b[1];
+  }
 
-    /// Z component
-    Double_t GetBz(Double_t x, Double_t y, Double_t z) override {
-      double xyz[3]={x,y,z};
-      return getBz(xyz); 
-    } 
+  /// Z component
+  Double_t GetBz(Double_t x, Double_t y, Double_t z) override
+  {
+    double xyz[3] = { x, y, z };
+    return getBz(xyz);
+  }
 
-    /// Method to calculate the field at point xyz
-    /// Main interface from TVirtualMagField used in simulation
-    void Field(const Double_t* __restrict__ point, Double_t* __restrict__ bField) override;
+  /// Method to calculate the field at point xyz
+  /// Main interface from TVirtualMagField used in simulation
+  void Field(const Double_t* __restrict__ point, Double_t* __restrict__ bField) override;
 
-    /// 3d field query alias for Alias Method to calculate the field at point xyz
-    void GetBxyz(const Double_t p[3], Double_t* b) override { MagneticField::Field(p,b); }
+  /// 3d field query alias for Alias Method to calculate the field at point xyz
+  void GetBxyz(const Double_t p[3], Double_t* b) override { MagneticField::Field(p, b); }
 
-    /// Fill Paramater
-    void FillParContainer() override;
-    
-    /// Method to calculate the integral_0^z of br,bt,bz
-    void getTPCIntegral(const Double_t *xyz, Double_t *b) const;
+  /// Fill Paramater
+  void FillParContainer() override;
 
-    /// Method to calculate the integral_0^z of br,bt,bz
-    void getTPCRatIntegral(const Double_t *xyz, Double_t *b) const;
+  /// Method to calculate the integral_0^z of br,bt,bz
+  void getTPCIntegral(const Double_t* xyz, Double_t* b) const;
 
-    /// Method to calculate the integral_0^z of br,bt,bz in cylindrical coordinates ( -pi<phi<pi convention )
-    void getTPCIntegralCylindrical(const Double_t *rphiz, Double_t *b) const;
+  /// Method to calculate the integral_0^z of br,bt,bz
+  void getTPCRatIntegral(const Double_t* xyz, Double_t* b) const;
 
-    /// Method to calculate the integral_0^z of bx/bz,by/bz and (bx/bz)^2+(by/bz)^2 in
-    /// cylindrical coordinates ( -pi<phi<pi convention )
-    void getTPCRatIntegralCylindrical(const Double_t *rphiz, Double_t *b) const;
+  /// Method to calculate the integral_0^z of br,bt,bz in cylindrical coordinates ( -pi<phi<pi convention )
+  void getTPCIntegralCylindrical(const Double_t* rphiz, Double_t* b) const;
 
-    /// Method to calculate the field at point xyz
-    Double_t getBz(const Double_t *xyz) const;
+  /// Method to calculate the integral_0^z of bx/bz,by/bz and (bx/bz)^2+(by/bz)^2 in
+  /// cylindrical coordinates ( -pi<phi<pi convention )
+  void getTPCRatIntegralCylindrical(const Double_t* rphiz, Double_t* b) const;
 
-    MagneticWrapperChebyshev *getMeasuredMap() const { return mMeasuredMap.get();}
-    
-    /// get fast field direct pointer
-    const MagFieldFast* getFastField() const {return mFastField.get();}
-    
-    // Former MagF methods or their aliases
+  /// Method to calculate the field at point xyz
+  Double_t getBz(const Double_t* xyz) const;
 
-    /// Sets the sign/scale of the current in the L3 according to sPolarityConvention
-    void setFactorSolenoid(Float_t fc = 1.);
+  MagneticWrapperChebyshev* getMeasuredMap() const { return mMeasuredMap.get(); }
 
-    /// Sets the sign*scale of the current in the Dipole according to sPolarityConvention
-    void setFactorDipole(Float_t fc = 1.);
+  /// get fast field direct pointer
+  const MagFieldFast* getFastField() const { return mFastField.get(); }
 
-    /// Returns the sign*scale of the current in the Dipole according to sPolarityConventionthe
-    Double_t getFactorSolenoid() const;
+  // Former MagF methods or their aliases
 
-    /// Return the sign*scale of the current in the Dipole according to sPolarityConventionthe
-    Double_t getFactorDipole() const;
+  /// Sets the sign/scale of the current in the L3 according to sPolarityConvention
+  void setFactorSolenoid(Float_t fc = 1.);
 
-    Double_t Factor() const
-    {
-      return getFactorSolenoid();
-    }
+  /// Sets the sign*scale of the current in the Dipole according to sPolarityConvention
+  void setFactorDipole(Float_t fc = 1.);
 
-    Double_t getCurrentSolenoid() const
-    {
-      return getFactorSolenoid() * (mMapType == MagFieldParam::k2kG ? 12000 : 30000);
-    }
+  /// Returns the sign*scale of the current in the Dipole according to sPolarityConventionthe
+  Double_t getFactorSolenoid() const;
 
-    Double_t getCurrentDipole() const
-    {
-      return getFactorDipole() * 6000;
-    }
+  /// Return the sign*scale of the current in the Dipole according to sPolarityConventionthe
+  Double_t getFactorDipole() const;
 
-    Bool_t IsUniform() const
-    {
-      return mMapType == MagFieldParam::k5kGUniform;
-    }
+  Double_t Factor() const { return getFactorSolenoid(); }
 
-    void MachineField(const Double_t * __restrict__ x, Double_t * __restrict__ b) const;
+  Double_t getCurrentSolenoid() const
+  {
+    return getFactorSolenoid() * (mMapType == MagFieldParam::k2kG ? 12000 : 30000);
+  }
 
-    MagFieldParam::BMap_t getMapType() const
-    {
-      return mMapType;
-    }
+  Double_t getCurrentDipole() const { return getFactorDipole() * 6000; }
 
-    MagFieldParam::BeamType_t getBeamType() const
-    {
-      return mBeamType;
-    }
+  Bool_t IsUniform() const { return mMapType == MagFieldParam::k5kGUniform; }
 
-    /// Returns beam type in text form
-    const char *getBeamTypeText() const;
+  void MachineField(const Double_t* __restrict__ x, Double_t* __restrict__ b) const;
 
-    Double_t getBeamEnergy() const
-    {
-      return mBeamEnergy;
-    }
+  MagFieldParam::BMap_t getMapType() const { return mMapType; }
 
-    Double_t Max() const
-    {
-      return mMaxField;
-    }
+  MagFieldParam::BeamType_t getBeamType() const { return mBeamType; }
 
-    Int_t Integral() const
-    {
-      return mDefaultIntegration;
-    }
+  /// Returns beam type in text form
+  const char* getBeamTypeText() const;
 
-    Int_t precIntegral() const
-    {
-      return mPrecisionInteg;
-    }
+  Double_t getBeamEnergy() const { return mBeamEnergy; }
 
-    Double_t solenoidField() const
-    {
-      return mSolenoid;
-    }
+  Double_t Max() const { return mMaxField; }
 
-    Char_t *getDataFileName() const
-    {
-      return (Char_t *) mParameterNames.GetName();
-    }
+  Int_t Integral() const { return mDefaultIntegration; }
 
-    Char_t *getParameterName() const
-    {
-      return (Char_t *) mParameterNames.GetTitle();
-    }
+  Int_t precIntegral() const { return mPrecisionInteg; }
 
-    void setDataFileName(const Char_t *nm)
-    {
-      mParameterNames.SetName(nm);
-    }
+  Double_t solenoidField() const { return mSolenoid; }
 
-    void setParameterName(const Char_t *nm)
-    {
-      mParameterNames.SetTitle(nm);
-    }
+  Char_t* getDataFileName() const { return (Char_t*)mParameterNames.GetName(); }
 
-    /// Prints short or long info
-    void Print(Option_t *opt) const override;
+  Char_t* getParameterName() const { return (Char_t*)mParameterNames.GetTitle(); }
 
-    Bool_t loadParameterization();
+  void setDataFileName(const Char_t* nm) { mParameterNames.SetName(nm); }
 
-    static Int_t getPolarityConvention()
-    {
-      return Int_t(sPolarityConvention);
-    }
+  void setParameterName(const Char_t* nm) { mParameterNames.SetTitle(nm); }
 
-    /// The magnetic field map, defined externally...
-    /// L3 current 30000 A  -> 0.5 T
-    /// L3 current 12000 A  -> 0.2 T
-    /// dipole current 6000 A
-    /// The polarities must match the convention (LHC or DCS2008)
-    /// unless the special uniform map was used for MC
-    static MagneticField *createFieldMap(Float_t l3Current = -30000., Float_t diCurrent = -6000., Int_t convention = 0,
-                                         Bool_t uniform = kFALSE, Float_t beamenergy = 7000, const Char_t *btype = "pp",
-                                         const std::string path = std::string(gSystem->Getenv("VMCWORKDIR")) +
-                                                                  std::string("/Common/maps/mfchebKGI_sym.root")
-    );
+  /// Prints short or long info
+  void Print(Option_t* opt) const override;
 
-  protected:
-    // not supposed to be changed during the run, set only at the initialization via constructor
-    void initializeMachineField(MagFieldParam::BeamType_t btype, Double_t benergy);
+  Bool_t loadParameterization();
 
-    void setBeamType(MagFieldParam::BeamType_t type)
-    {
-      mBeamType = type;
-    }
+  static Int_t getPolarityConvention() { return Int_t(sPolarityConvention); }
 
-    void setBeamEnergy(Float_t energy)
-    {
-      mBeamEnergy = energy;
-    }
+  /// The magnetic field map, defined externally...
+  /// L3 current 30000 A  -> 0.5 T
+  /// L3 current 12000 A  -> 0.2 T
+  /// dipole current 6000 A
+  /// The polarities must match the convention (LHC or DCS2008)
+  /// unless the special uniform map was used for MC
+  static MagneticField* createFieldMap(Float_t l3Current = -30000., Float_t diCurrent = -6000., Int_t convention = 0,
+                                       Bool_t uniform = kFALSE, Float_t beamenergy = 7000, const Char_t* btype = "pp",
+                                       const std::string path = std::string(gSystem->Getenv("VMCWORKDIR")) +
+                                                                std::string("/Common/maps/mfchebKGI_sym.root"));
 
-  private:
-    std::unique_ptr<MagneticWrapperChebyshev> mMeasuredMap; //! Measured part of the field map
-    std::unique_ptr<MagFieldFast>             mFastField; // ! optional fast parametrization
-    MagFieldParam::BMap_t mMapType;         ///< field map type
-    Double_t mSolenoid;                     ///< Solenoid field setting
-    MagFieldParam::BeamType_t mBeamType;    ///< Beam type: A-A (mBeamType=0) or p-p (mBeamType=1)
-    Double_t mBeamEnergy;                   ///< Beam energy in GeV
+ protected:
+  // not supposed to be changed during the run, set only at the initialization via constructor
+  void initializeMachineField(MagFieldParam::BeamType_t btype, Double_t benergy);
 
-    Int_t mDefaultIntegration;             ///< Default integration method as indicated in Geant
-    Int_t mPrecisionInteg;                 ///< Alternative integration method, e.g. for higher precision
-    Double_t mMultipicativeFactorSolenoid; ///< Multiplicative factor for solenoid
-    Double_t mMultipicativeFactorDipole;   ///< Multiplicative factor for dipole
-    Double_t mMaxField;                    ///< Max Field as indicated in Geant
-    Bool_t mDipoleOnOffFlag;               ///< Dipole ON/OFF flag
+  void setBeamType(MagFieldParam::BeamType_t type) { mBeamType = type; }
 
-    Double_t mQuadrupoleGradient; ///< Gradient field for inner triplet quadrupoles
-    Double_t mDipoleField;        ///< Field value for D1 and D2 dipoles
-    Double_t mCompensatorField2C; ///< Side C 2nd compensator field
-    Double_t mCompensatorField1A; ///< Side A 1st compensator field
-    Double_t mCompensatorField2A; ///< Side A 2nd compensator field
+  void setBeamEnergy(Float_t energy) { mBeamEnergy = energy; }
 
-    TNamed mParameterNames; ///< file and parameterization loaded
+ private:
+  std::unique_ptr<MagneticWrapperChebyshev> mMeasuredMap; //! Measured part of the field map
+  std::unique_ptr<MagFieldFast> mFastField;               // ! optional fast parametrization
+  MagFieldParam::BMap_t mMapType;                         ///< field map type
+  Double_t mSolenoid;                                     ///< Solenoid field setting
+  MagFieldParam::BeamType_t mBeamType;                    ///< Beam type: A-A (mBeamType=0) or p-p (mBeamType=1)
+  Double_t mBeamEnergy;                                   ///< Beam energy in GeV
 
-    static const Double_t sSolenoidToDipoleZ;  ///< conventional Z of transition from L3 to Dipole field
-    static const UShort_t sPolarityConvention; ///< convention for the mapping of the curr.sign on main component sign
+  Int_t mDefaultIntegration;             ///< Default integration method as indicated in Geant
+  Int_t mPrecisionInteg;                 ///< Alternative integration method, e.g. for higher precision
+  Double_t mMultipicativeFactorSolenoid; ///< Multiplicative factor for solenoid
+  Double_t mMultipicativeFactorDipole;   ///< Multiplicative factor for dipole
+  Double_t mMaxField;                    ///< Max Field as indicated in Geant
+  Bool_t mDipoleOnOffFlag;               ///< Dipole ON/OFF flag
 
-    MagneticField(const MagneticField &src);
+  Double_t mQuadrupoleGradient; ///< Gradient field for inner triplet quadrupoles
+  Double_t mDipoleField;        ///< Field value for D1 and D2 dipoles
+  Double_t mCompensatorField2C; ///< Side C 2nd compensator field
+  Double_t mCompensatorField1A; ///< Side A 1st compensator field
+  Double_t mCompensatorField2A; ///< Side A 2nd compensator field
 
+  TNamed mParameterNames; ///< file and parameterization loaded
 
-    
-    ClassDefOverride(o2::field::MagneticField,
-    3) // Class for all Alice MagField wrapper for measured data + Tosca parameterization
+  static const Double_t sSolenoidToDipoleZ;  ///< conventional Z of transition from L3 to Dipole field
+  static const UShort_t sPolarityConvention; ///< convention for the mapping of the curr.sign on main component sign
+
+  MagneticField(const MagneticField& src);
+
+  ClassDefOverride(o2::field::MagneticField,
+                   3) // Class for all Alice MagField wrapper for measured data + Tosca parameterization
 };
 }
 }

--- a/Common/Field/src/MagneticField.cxx
+++ b/Common/Field/src/MagneticField.cxx
@@ -13,10 +13,10 @@
 /// \author ruben.shahoyan@cern.ch
 
 #include "Field/MagneticField.h"
-#include <TFile.h>                     // for TFile
-#include <TPRegexp.h>                  // for TPRegexp
-#include <TSystem.h>                   // for TSystem, gSystem
-#include "FairLogger.h"                // for FairLogger
+#include <TFile.h>      // for TFile
+#include <TPRegexp.h>   // for TPRegexp
+#include <TSystem.h>    // for TSystem, gSystem
+#include "FairLogger.h" // for FairLogger
 #include "FairParamList.h"
 #include "FairRun.h"
 #include "FairRuntimeDb.h"
@@ -25,8 +25,7 @@ using namespace o2::field;
 
 ClassImp(MagneticField)
 
-  const
-Double_t MagneticField::sSolenoidToDipoleZ = -700.;
+  const Double_t MagneticField::sSolenoidToDipoleZ = -700.;
 
 /// Explanation for polarity conventions: these are the mapping between the
 /// current signs and main field components in L3 (Bz) and Dipole (Bx) (in Alice frame)
@@ -86,13 +85,13 @@ MagneticField::MagneticField()
   /*
    * Default constructor
    */
-  fType = 2; // flag non-constant field 
+  fType = 2; // flag non-constant field
 }
 
-MagneticField::MagneticField(const char *name, const char *title, Double_t factorSol, Double_t factorDip,
-                             MagFieldParam::BMap_t maptype, MagFieldParam::BeamType_t bt,
-                             Double_t be, Int_t integ, Double_t fmax,const std::string path)
-  : FairField(name,title),
+MagneticField::MagneticField(const char* name, const char* title, Double_t factorSol, Double_t factorDip,
+                             MagFieldParam::BMap_t maptype, MagFieldParam::BeamType_t bt, Double_t be, Int_t integ,
+                             Double_t fmax, const std::string path)
+  : FairField(name, title),
     mMeasuredMap(nullptr),
     mFastField(nullptr),
     mMapType(maptype),
@@ -121,7 +120,7 @@ MagneticField::MagneticField(const char *name, const char *title, Double_t facto
 }
 
 MagneticField::MagneticField(const MagFieldParam& param)
-  : FairField(param.GetName(),param.GetTitle()),
+  : FairField(param.GetName(), param.GetTitle()),
     mMeasuredMap(nullptr),
     mFastField(nullptr),
     mMapType(param.GetMapType()),
@@ -131,7 +130,7 @@ MagneticField::MagneticField(const MagFieldParam& param)
     mDefaultIntegration(param.GetDefInt()),
     mPrecisionInteg(1),
     mMultipicativeFactorSolenoid(param.GetFactorSol()), // temporary
-    mMultipicativeFactorDipole(param.GetFactorDip()), // temporary
+    mMultipicativeFactorDipole(param.GetFactorDip()),   // temporary
     mMaxField(param.GetMaxField()),
     mDipoleOnOffFlag(param.GetFactorDip() == 0.),
     mQuadrupoleGradient(0),
@@ -155,25 +154,29 @@ void MagneticField::CreateField()
    * field initialization
    */
 
-  fType = 2; // flag non-constant field 
+  fType = 2; // flag non-constant field
 
   // does real creation of the field
   if (mDefaultIntegration < 0 || mDefaultIntegration > 2) {
-    LOG(WARNING) << "MagneticField::CreateField: Invalid magnetic field flag: " << mDefaultIntegration << "; Helix tracking chosen instead";
+    LOG(WARNING) << "MagneticField::CreateField: Invalid magnetic field flag: " << mDefaultIntegration
+                 << "; Helix tracking chosen instead";
     mDefaultIntegration = 2;
   }
-  if (mDefaultIntegration == 0) mPrecisionInteg = 0;
+  if (mDefaultIntegration == 0)
+    mPrecisionInteg = 0;
 
   if (mBeamEnergy <= 0 && mBeamType != MagFieldParam::kNoBeamField) {
-    if (mBeamType == MagFieldParam::kBeamTypepp) mBeamEnergy = 7000.; // max proton energy
-    else if (mBeamType == MagFieldParam::kBeamTypeAA) mBeamEnergy = 2760; // max PbPb energy
-    else if (mBeamType == MagFieldParam::kBeamTypepA || mBeamType == MagFieldParam::kBeamTypeAp) 
+    if (mBeamType == MagFieldParam::kBeamTypepp)
+      mBeamEnergy = 7000.; // max proton energy
+    else if (mBeamType == MagFieldParam::kBeamTypeAA)
+      mBeamEnergy = 2760; // max PbPb energy
+    else if (mBeamType == MagFieldParam::kBeamTypepA || mBeamType == MagFieldParam::kBeamTypeAp)
       mBeamEnergy = 2760; // same rigitiy max PbPb energy
     //
     LOG(INFO) << "MagneticField::CreateField: Maximim possible beam energy for requested beam is assumed";
   }
 
-  const char *parname = nullptr;
+  const char* parname = nullptr;
 
   if (mMapType == MagFieldParam::k2kG) {
     parname = mDipoleOnOffFlag ? "Sol12_Dip0_Hole" : "Sol12_Dip6_Hole";
@@ -190,8 +193,8 @@ void MagneticField::CreateField()
   loadParameterization();
   initializeMachineField(mBeamType, mBeamEnergy);
   setFactorSolenoid(mMultipicativeFactorSolenoid);
-  setFactorDipole(mMultipicativeFactorDipole); 
-  double xyz[3] = {0., 0., 0.};
+  setFactorDipole(mMultipicativeFactorDipole);
+  double xyz[3] = { 0., 0., 0. };
   mSolenoid = getBz(xyz);
   Print("a");
   //
@@ -202,36 +205,38 @@ Bool_t MagneticField::loadParameterization()
   /*
    * load parametrization for measured field
    */
-  
-  if (mMeasuredMap) {
-    LOG(FATAL) << "MagneticField::loadParameterization: Field data " <<  getParameterName()  << " are already loaded from " << getDataFileName() << "\n";
-  }
 
-  char *fname = gSystem->ExpandPathName(getDataFileName());
-  TFile *file = TFile::Open(fname);
+  if (mMeasuredMap) {
+    LOG(FATAL) << "MagneticField::loadParameterization: Field data " << getParameterName()
+               << " are already loaded from " << getDataFileName() << "\n";
+  }
+  const char* fname = gSystem->ExpandPathName(getDataFileName());
+  TFile* file = TFile::Open(fname);
   if (!file) {
     LOG(FATAL) << "MagneticField::loadParameterization: Failed to open magnetic field data file " << fname << "\n";
   }
 
-  mMeasuredMap = std::unique_ptr<MagneticWrapperChebyshev>
-    (dynamic_cast<MagneticWrapperChebyshev *>(file->Get(getParameterName())));
+  mMeasuredMap =
+    std::unique_ptr<MagneticWrapperChebyshev>(dynamic_cast<MagneticWrapperChebyshev*>(file->Get(getParameterName())));
   if (!mMeasuredMap) {
-    LOG(FATAL) << "MagneticField::loadParameterization: Did not find field " << getParameterName() << " in " << fname << "%s\n";
+    LOG(FATAL) << "MagneticField::loadParameterization: Did not find field " << getParameterName() << " in " << fname
+               << "%s\n";
   }
   file->Close();
   delete file;
   return kTRUE;
 }
 
-void MagneticField::Field(const Double_t * __restrict__ xyz, Double_t * __restrict__ b)
+void MagneticField::Field(const Double_t* __restrict__ xyz, Double_t* __restrict__ b)
 {
   /*
    * query field value at point
    */
 
   //  b[0]=b[1]=b[2]=0.0;
-  if (mFastField && mFastField->Field(xyz,b)) return;
-  
+  if (mFastField && mFastField->Field(xyz, b))
+    return;
+
   if (mMeasuredMap && xyz[2] > mMeasuredMap->getMinZ() && xyz[2] < mMeasuredMap->getMaxZ()) {
     mMeasuredMap->Field(xyz, b);
     if (xyz[2] > sSolenoidToDipoleZ || mDipoleOnOffFlag) {
@@ -248,15 +253,16 @@ void MagneticField::Field(const Double_t * __restrict__ xyz, Double_t * __restri
   }
 }
 
-Double_t MagneticField::getBz(const Double_t *xyz) const
+Double_t MagneticField::getBz(const Double_t* xyz) const
 {
   /*
    * query field Bz component at point
    */
 
   if (mFastField) {
-    double bz=0;
-    if (mFastField->GetBz(xyz,bz)) return bz;
+    double bz = 0;
+    if (mFastField->GetBz(xyz, bz))
+      return bz;
   }
   if (mMeasuredMap && xyz[2] > mMeasuredMap->getMinZ() && xyz[2] < mMeasuredMap->getMaxZ()) {
     double bz = mMeasuredMap->getBz(xyz);
@@ -267,12 +273,12 @@ Double_t MagneticField::getBz(const Double_t *xyz) const
   }
 }
 
-MagneticField &MagneticField::operator=(const MagneticField &src)
+MagneticField& MagneticField::operator=(const MagneticField& src)
 {
   /*
    * assignment operator
    */
-  
+
   if (this != &src) {
     if (src.mMeasuredMap) {
       mMeasuredMap.reset(new MagneticWrapperChebyshev(*src.getMeasuredMap()));
@@ -288,7 +294,7 @@ MagneticField &MagneticField::operator=(const MagneticField &src)
     mMaxField = src.mMaxField;
     mDipoleOnOffFlag = src.mDipoleOnOffFlag;
     mParameterNames = src.mParameterNames;
-    mFastField.reset( src.mFastField ? new MagFieldFast(*src.getFastField()) : nullptr);
+    mFastField.reset(src.mFastField ? new MagFieldFast(*src.getFastField()) : nullptr);
   }
   return *this;
 }
@@ -318,7 +324,7 @@ void MagneticField::initializeMachineField(MagFieldParam::BeamType_t btype, Doub
   mCompensatorField2A = 11.7905;
 }
 
-void MagneticField::MachineField(const Double_t * __restrict__ x, Double_t * __restrict__ b) const
+void MagneticField::MachineField(const Double_t* __restrict__ x, Double_t* __restrict__ b) const
 {
   // ---- This is the ZDC part
   // Compansators for Alice Muon Arm Dipole
@@ -364,7 +370,7 @@ void MagneticField::MachineField(const Double_t * __restrict__ x, Double_t * __r
     }
   }
 
-    // SIDE A
+  // SIDE A
   else {
     if (TMath::Abs(x[2] - kBComp1CZ) < kBComp1hDZ && rad2 < kBComp1SqR) {
       // Compensator magnet at z = 1075 m
@@ -396,7 +402,7 @@ void MagneticField::MachineField(const Double_t * __restrict__ x, Double_t * __r
   }
 }
 
-void MagneticField::getTPCIntegral(const Double_t *xyz, Double_t *b) const
+void MagneticField::getTPCIntegral(const Double_t* xyz, Double_t* b) const
 {
   b[0] = b[1] = b[2] = 0.0;
   if (mMeasuredMap) {
@@ -407,7 +413,7 @@ void MagneticField::getTPCIntegral(const Double_t *xyz, Double_t *b) const
   }
 }
 
-void MagneticField::getTPCRatIntegral(const Double_t *xyz, Double_t *b) const
+void MagneticField::getTPCRatIntegral(const Double_t* xyz, Double_t* b) const
 {
   b[0] = b[1] = b[2] = 0.0;
   if (mMeasuredMap) {
@@ -416,7 +422,7 @@ void MagneticField::getTPCRatIntegral(const Double_t *xyz, Double_t *b) const
   }
 }
 
-void MagneticField::getTPCIntegralCylindrical(const Double_t *rphiz, Double_t *b) const
+void MagneticField::getTPCIntegralCylindrical(const Double_t* rphiz, Double_t* b) const
 {
   b[0] = b[1] = b[2] = 0.0;
   if (mMeasuredMap) {
@@ -427,7 +433,7 @@ void MagneticField::getTPCIntegralCylindrical(const Double_t *rphiz, Double_t *b
   }
 }
 
-void MagneticField::getTPCRatIntegralCylindrical(const Double_t *rphiz, Double_t *b) const
+void MagneticField::getTPCRatIntegralCylindrical(const Double_t* rphiz, Double_t* b) const
 {
   b[0] = b[1] = b[2] = 0.0;
   if (mMeasuredMap) {
@@ -449,7 +455,8 @@ void MagneticField::setFactorSolenoid(Float_t fc)
       mMultipicativeFactorSolenoid = fc;
       break; // case kConvMap2005: mMultipicativeFactorSolenoid =  fc; break;
   }
-  if (mFastField) mFastField->setFactorSol(getFactorSolenoid());
+  if (mFastField)
+    mFastField->setFactorSol(getFactorSolenoid());
 }
 
 void MagneticField::setFactorDipole(Float_t fc)
@@ -491,15 +498,15 @@ Double_t MagneticField::getFactorDipole() const
   }
 }
 
-MagneticField *MagneticField::createFieldMap(Float_t l3Cur, Float_t diCur, Int_t convention, Bool_t uniform,
-                                             Float_t beamenergy, const Char_t *beamtype, const std::string path)
+MagneticField* MagneticField::createFieldMap(Float_t l3Cur, Float_t diCur, Int_t convention, Bool_t uniform,
+                                             Float_t beamenergy, const Char_t* beamtype, const std::string path)
 {
   const Float_t l3NominalCurrent1 = 30000.f; // (A)
   const Float_t l3NominalCurrent2 = 12000.f; // (A)
   const Float_t diNominalCurrent = 6000.f;   // (A)
 
   const Float_t tolerance = 0.03; // relative current tolerance
-  const Float_t zero = 77.f;       // "zero" current (A)
+  const Float_t zero = 77.f;      // "zero" current (A)
 
   MagFieldParam::BMap_t map = MagFieldParam::k5kG;
   double sclL3, sclDip;
@@ -541,8 +548,8 @@ MagneticField *MagneticField::createFieldMap(Float_t l3Cur, Float_t diCur, Int_t
     if ((l3Cur <= zero) ||
         ((convention == kConvLHC && l3Pol != diPol) || (convention == kConvDCS2008 && l3Pol == diPol))) {
       LOG(FATAL) << "MagneticField::createFieldMap: Wrong combination for L3/Dipole polarities ("
-                 << (l3Pol > 0 ? '+' : '-') << "/"
-                 << (diPol > 0 ? '+' : '-') << ") for convention " << getPolarityConvention();
+                 << (l3Pol > 0 ? '+' : '-') << "/" << (diPol > 0 ? '+' : '-') << ") for convention "
+                 << getPolarityConvention();
     }
   }
 
@@ -572,8 +579,8 @@ MagneticField *MagneticField::createFieldMap(Float_t l3Cur, Float_t diCur, Int_t
     LOG(INFO) << "Assume no LHC magnet field for the beam type " << beamtype;
   }
   char ttl[80];
-  snprintf(ttl, 79, "L3: %+5d Dip: %+4d kA; %s | Polarities in %s convention", (int) TMath::Sign(l3Cur, float(sclL3)),
-           (int) TMath::Sign(diCur, float(sclDip)), uniform ? " Constant" : "",
+  snprintf(ttl, 79, "L3: %+5d Dip: %+4d kA; %s | Polarities in %s convention", (int)TMath::Sign(l3Cur, float(sclL3)),
+           (int)TMath::Sign(diCur, float(sclDip)), uniform ? " Constant" : "",
            convention == kConvLHC ? "LHC" : "DCS2008");
   // LHC and DCS08 conventions have opposite dipole polarities
   if (getPolarityConvention() != convention) {
@@ -583,13 +590,13 @@ MagneticField *MagneticField::createFieldMap(Float_t l3Cur, Float_t diCur, Int_t
   return new MagneticField("MagneticFieldMap", ttl, sclL3, sclDip, map, btype, beamenergy, 2, 10., path);
 }
 
-const char *MagneticField::getBeamTypeText() const
+const char* MagneticField::getBeamTypeText() const
 {
-  const char *beamNA = "No Beam";
-  const char *beamPP = "p-p";
-  const char *beamPbPb = "A-A";
-  const char *beamPPb = "p-A";
-  const char *beamPbP = "A-p";
+  const char* beamNA = "No Beam";
+  const char* beamPP = "p-p";
+  const char* beamPbPb = "A-A";
+  const char* beamPPb = "p-A";
+  const char* beamPbP = "A-p";
   switch (mBeamType) {
     case MagFieldParam::kBeamTypepp:
       return beamPP;
@@ -605,18 +612,18 @@ const char *MagneticField::getBeamTypeText() const
   }
 }
 
-void MagneticField::Print(Option_t *opt) const
+void MagneticField::Print(Option_t* opt) const
 {
   TString opts = opt;
   opts.ToLower();
   LOG(INFO) << "MagneticField::Print: " << GetName() << ":" << GetTitle();
   LOG(INFO) << "MagneticField::Print: Solenoid (" << getFactorSolenoid() << "*)"
-            << ((mMapType == MagFieldParam::k5kG || mMapType == MagFieldParam::k5kGUniform) ? 5. : 2)
-            << " kG, Dipole " << (mDipoleOnOffFlag ? "OFF" : "ON")<< " (" << getFactorDipole() << ") "
+            << ((mMapType == MagFieldParam::k5kG || mMapType == MagFieldParam::k5kGUniform) ? 5. : 2) << " kG, Dipole "
+            << (mDipoleOnOffFlag ? "OFF" : "ON") << " (" << getFactorDipole() << ") "
             << (mMapType == MagFieldParam::k5kGUniform ? " |Constant Field!" : "");
   if (opts.Contains("a")) {
-    LOG(INFO) << "MagneticField::Print: Machine B fields for " <<  getBeamTypeText()
-              << "  beam (" << mBeamEnergy << " GeV): QGrad: " << mQuadrupoleGradient << " Dipole: " << mDipoleField;
+    LOG(INFO) << "MagneticField::Print: Machine B fields for " << getBeamTypeText() << "  beam (" << mBeamEnergy
+              << " GeV): QGrad: " << mQuadrupoleGradient << " Dipole: " << mDipoleField;
     LOG(INFO) << "MagneticField::Print: Uses " << getParameterName() << "  of " << getDataFileName();
   }
 }
@@ -635,10 +642,9 @@ void MagneticField::FillParContainer()
 void MagneticField::AllowFastField(bool v)
 {
   if (v) {
-    if (!mFastField) mFastField = std::make_unique<MagFieldFast>
-                       (getFactorSolenoid(),mMapType==MagFieldParam::k2kG ? 2:5);
-  }
-  else {
+    if (!mFastField)
+      mFastField = std::make_unique<MagFieldFast>(getFactorSolenoid(), mMapType == MagFieldParam::k2kG ? 2 : 5);
+  } else {
     mFastField.reset(nullptr);
   }
 }


### PR DESCRIPTION
To make the MC production usable on the system different from where it was generated
we should store unparsed path to the data file