### PR TITLE
Update of the DPL I/O API

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -51,6 +51,7 @@ set(SRCS
     src/runDataProcessing.cxx
     src/TMessageSerializer.cxx
     ${GUI_SOURCES}
+    test/TestClasses.cxx
    )
 
 set(HEADERS
@@ -126,6 +127,12 @@ set(HEADERS
 
 set(LIBRARY_NAME ${MODULE_NAME})
 set(BUCKET_NAME ${MODULE_BUCKET_NAME})
+
+# create dictionary for a test class to be serialized in unit test
+set(LINKDEF test/FrameworkCoreTestLinkDef.h)
+set(HEADERS
+     test/TestClasses.h
+   )
 
 O2_GENERATE_LIBRARY()
 

--- a/Framework/Core/include/Framework/DataAllocator.h
+++ b/Framework/Core/include/Framework/DataAllocator.h
@@ -157,6 +157,26 @@ public:
     addPartToContext(std::move(payloadMessage), spec, o2::header::gSerializationMethodROOT);
   }
 
+  /// Serialize a snapshot of a TObject when called, which will then be
+  /// sent once the computation ends.
+  /// Framework does not take ownership of the @a object. Changes to @a object
+  /// after the call will not be sent.
+  template <typename T>
+  void snapshot(const OutputSpec& spec, T& object, o2::header::SerializationMethod method)
+  {
+    FairMQMessagePtr payloadMessage(mDevice->NewMessage());
+    if (method != o2::header::gSerializationMethodROOT) {
+      throw std::runtime_error("unsupported serialization type");
+    }
+    auto* cl = TClass::GetClass(typeid(T));
+    if (cl == nullptr) {
+      throw std::runtime_error("can not serialize class without dictionary");
+    }
+    mDevice->Serialize<TMessageSerializer>(*payloadMessage, &object, cl);
+
+    addPartToContext(std::move(payloadMessage), spec, o2::header::gSerializationMethodROOT);
+  }
+
   /// Serialize a snapshot of a trivially copyable, non-polymorphic type, which
   /// will then be sent once the computation ends.
   /// Framework does not take ownership of @param object. Changes to @param object

--- a/Framework/Core/include/Framework/DataRefUtils.h
+++ b/Framework/Core/include/Framework/DataRefUtils.h
@@ -13,6 +13,7 @@
 #include "Framework/DataRef.h"
 #include "Headers/DataHeader.h"
 #include "Framework/TMessageSerializer.h"
+#include "Framework/SerializationMethods.h"
 #include "Framework/TypeTraits.h"
 #include <TClass.h>
 #include <stdexcept>
@@ -44,34 +45,18 @@ struct DataRefUtils {
     return gsl::span<T>(reinterpret_cast<T *>(const_cast<char *>(ref.payload)), header->payloadSize/sizeof(T));
   }
 
-  // See above. SFINAE allows us to use this to extract a TObject with 
-  // a somewhat uniform API.
+  // See above. SFINAE allows us to use this to extract a ROOT-serialized object
+  // with a somewhat uniform API.
+  // Classes using the ROOT ClassDef/ClassImp macros can be detected automatically
+  // and the serialization method can be deduced. If the class is also
+  // messageable, gSerializationMethodNone is used by default. This substitution
+  // does not apply for such types, the serialization method needs to be specified
+  // explicitely using type wrapper @a ROOTSerialized.
   template <typename T>
-  static typename std::enable_if<std::is_base_of<TObject, T>::value == true, std::unique_ptr<T>>::type
-  as(DataRef const &ref) {
-    using DataHeader = o2::header::DataHeader;
-    auto header = o2::header::get<const DataHeader>(ref.header);
-    if (header->payloadSerializationMethod != o2::header::gSerializationMethodROOT) {
-      throw std::runtime_error("Attempt to extract a TMessage from non-ROOT serialised message");
-    }
-
-    o2::framework::FairTMessage ftm(const_cast<char *>(ref.payload), header->payloadSize);
-    auto cobj = ftm.ReadObject(ftm.GetClass());
-    std::unique_ptr<T> result;
-    result.reset(dynamic_cast<T*>(cobj));
-    if (result.get() == nullptr) {
-      auto* cl = TClass::GetClass(typeid(T));
-      std::ostringstream ss;
-      ss << "Attempting to extract a " << (cl !=nullptr ? cl->GetName() : "unknown")
-         << " but a " << cobj->ClassName()
-         << " is actually stored which cannot be casted to the requested one.";
-      throw std::runtime_error(ss.str());
-    }
-    return std::move(result);
-  }
-
-  template <typename T>
-  static std::unique_ptr<T> extract(DataRef const &ref)
+  static typename std::enable_if<has_root_dictionary<T>::value == true &&
+                                 is_messageable<T>::value == false,
+                                 std::unique_ptr<T>>::type
+  as(DataRef const& ref)
   {
     using DataHeader = o2::header::DataHeader;
     auto header = o2::header::get<const DataHeader>(ref.header);
@@ -79,17 +64,86 @@ struct DataRefUtils {
       throw std::runtime_error("Attempt to extract a TMessage from non-ROOT serialised message");
     }
 
-    o2::framework::FairTMessage ftm(const_cast<char *>(ref.payload), header->payloadSize);
-    auto * cl = ftm.GetClass();
+    o2::framework::FairTMessage ftm(const_cast<char*>(ref.payload), header->payloadSize);
+    auto* storedClass = ftm.GetClass();
+    auto* requestedClass = TClass::GetClass(typeid(T));
+    // should always have the class description if has_root_dictionary is true
+    assert(requestedClass != nullptr);
+
+    auto* object = ftm.ReadObjectAny(storedClass);
+    if (object == nullptr) {
+      std::ostringstream ss;
+      ss << "Failed to read object with name "
+         << (storedClass != nullptr ? storedClass->GetName() : "<unknown>")
+         << " from message using ROOT serialization.";
+      throw std::runtime_error(ss.str());
+    }
+
     std::unique_ptr<T> result;
-    result.reset(static_cast<T*>(ftm.ReadObjectAny(cl)));
+    if (std::is_base_of<TObject, T>::value) { // compile time switch
+      // if the type to be extracted inherits from TObject, the class descriptions
+      // do not need to match exactly, only the dynamic_cast has to work
+      // FIXME: could probably try to extend this to arbitrary types T being a base
+      // to the stored type, but this would require to cast the extracted object to
+      // the actual type. This requires this information to be available as a type
+      // in the ROOT dictionary, check if this is the case or if TClass::DynamicCast
+      // can be used for the test. Right now, this case was and is not covered and
+      // not yet checked in the unit test either.
+      auto* r = dynamic_cast<T*>(static_cast<TObject*>(object));
+      if (r) {
+        result.reset(r);
+      }
+    } else if (storedClass == requestedClass) {
+      result.reset(static_cast<T*>(object));
+    }
+    if (result == nullptr) {
+      // did not manage to cast the pointer to result
+      // delete object via the class info, at this point we know that the
+      // class info is there, the object could not have been read otherwise
+      auto* delfunc = storedClass->GetDelete();
+      assert(delfunc != nullptr);
+      if (delfunc) (*delfunc)(object);
+
+      std::ostringstream ss;
+      ss << "Attempting to extract a "
+         << (requestedClass != nullptr ? requestedClass->GetName() : "<unknown>")
+         << " but a "
+         << (storedClass != nullptr ? storedClass->GetName() : "<unknown>")
+         << " is actually stored which cannot be casted to the requested one.";
+      throw std::runtime_error(ss.str());
+    }
+
+    return std::move(result);
+  }
+
+  // See above. SFINAE allows us to use this to extract a ROOT-serialized object
+  // with a somewhat uniform API. ROOT serialization method is enforced by using
+  // type wrapper @a ROOTSerialized
+  template <typename W>
+  static typename std::enable_if<is_specialization<W, ROOTSerialized>::value == true,
+                                 std::unique_ptr<typename W::wrapped_type>>::type
+  as(DataRef const& ref)
+  {
+    using T = typename W::wrapped_type;
+    using DataHeader = o2::header::DataHeader;
+    auto header = o2::header::get<const DataHeader>(ref.header);
+    if (header->payloadSerializationMethod != o2::header::gSerializationMethodROOT) {
+      throw std::runtime_error("Attempt to extract a TMessage from non-ROOT serialised message");
+    }
+    auto* cl = TClass::GetClass(typeid(T));
+    if (has_root_dictionary<T>::value == false && cl == nullptr) {
+      throw std::runtime_error("ROOT serialization not supported, dictionary not found for data type");
+    }
+
+    o2::framework::FairTMessage ftm(const_cast<char*>(ref.payload), header->payloadSize);
+    std::unique_ptr<T> result(static_cast<T*>(ftm.ReadObjectAny(cl)));
     if (result.get() == nullptr) {
       std::ostringstream ss;
       ss << "Unable to extract class ";
       if (cl == nullptr) {
-	ss << "<not available>";
+        ss << "<name not available>";
       } else {
-	ss << cl->GetName();
+        ss << cl->GetName();
       }
       throw std::runtime_error(ss.str());
     }

--- a/Framework/Core/include/Framework/InputRecord.h
+++ b/Framework/Core/include/Framework/InputRecord.h
@@ -29,77 +29,13 @@
 #include <memory>
 #include <type_traits>
 
-template<typename T>
+template <typename T>
 using default_delete = std::default_delete<T>;
 
 namespace o2 {
 namespace framework {
 
 struct InputSpec;
-
-/// A deleter type to be used with unique_ptr, which can be marked that
-/// it does not own the underlying resource and thus should not delete it.
-/// The resource ownership property controls the behavior and can only be
-/// set at construction of the deleter in the unique_ptr. Falls back to
-/// default_delete if not initialized to 'NotOwning'.
-/// Usage: unique_ptr<T, Deleter<T>> ptr(..., Deleter<T>(false))
-///
-/// By contract, the underlying, not owned resource is supposed to be
-/// available during the lifetime of the object, which is the case in the
-/// InputRecord and DPL processing APIs. The Deleter can be extended
-/// to support a callback to call a resource management outside.
-template<typename T>
-class Deleter : public default_delete<T>
-{
- public:
-  enum class OwnershipProperty : short
-  {
-    Unknown = -1,
-    NotOwning = 0, /// don't delete the underlying buffer
-    Owning = 1     /// normal behavior, falling back to default deleter
-  };
-
-  using base =  default_delete<T>;
-  using self_type = Deleter<T>;
-  //using pointer = typename base::pointer;
-
-  constexpr Deleter() = default;
-  constexpr Deleter(bool isOwning)
-    : base::default_delete()
-    , mProperty(isOwning ? OwnershipProperty::Owning : OwnershipProperty::NotOwning)
-  {
-  }
-
-  // copy constructor is needed in the setup of unique_ptr
-  // check that assignments happen only to uninitialized instances
-  constexpr Deleter(const self_type& other)
-  {
-    if (mProperty == OwnershipProperty::Unknown) {
-      mProperty = other.mProperty;
-    } else if (mProperty != other.mProperty) {
-      throw std::runtime_error("Attemp to change resource control");
-    }
-  }
-
-  // copy constructor for the default delete which simply sets the
-  // resource ownership control to 'Owning'
-  constexpr Deleter(const base& other)
-  {
-    mProperty = OwnershipProperty::Owning;
-  }
-
-  // forbid assignment operator to prohibid changing the Deleter
-  // resource control property once used in the unique_ptr
-  self_type& operator=(const self_type&) = delete;
-
-  void operator()(T* ptr) const
-  {
-    if (mProperty == OwnershipProperty::NotOwning) return;
-    base::operator()(ptr);
-  }
- private:
-  OwnershipProperty mProperty = OwnershipProperty::Unknown;
-};
 
 /// This class holds the inputs which  are being processed by the system while
 /// they are  being processed.  The user can  get an instance  for it  via the
@@ -111,6 +47,67 @@ class InputRecord {
 public:
   InputRecord(std::vector<InputRoute> const &inputs,
               std::vector<std::unique_ptr<FairMQMessage>> const &cache);
+
+  /// A deleter type to be used with unique_ptr, which can be marked that
+  /// it does not own the underlying resource and thus should not delete it.
+  /// The resource ownership property controls the behavior and can only be
+  /// set at construction of the deleter in the unique_ptr. Falls back to
+  /// default_delete if not initialized to 'NotOwning'.
+  /// Usage: unique_ptr<T, Deleter<T>> ptr(..., Deleter<T>(false))
+  ///
+  /// By contract, the underlying, not owned resource is supposed to be
+  /// available during the lifetime of the object, which is the case in the
+  /// InputRecord and DPL processing APIs. The Deleter can be extended
+  /// to support a callback to call a resource management outside.
+  template <typename T>
+  class Deleter : public default_delete<T>
+  {
+   public:
+    enum struct OwnershipProperty : short {
+      Unknown = -1,
+      NotOwning = 0, /// don't delete the underlying buffer
+      Owning = 1     /// normal behavior, falling back to default deleter
+    };
+
+    using base = default_delete<T>;
+    using self_type = Deleter<T>;
+    // using pointer = typename base::pointer;
+
+    constexpr Deleter() = default;
+    constexpr Deleter(bool isOwning)
+      : base::default_delete()
+      , mProperty(isOwning ? OwnershipProperty::Owning : OwnershipProperty::NotOwning)
+    {
+    }
+
+    // copy constructor is needed in the setup of unique_ptr
+    // check that assignments happen only to uninitialized instances
+    constexpr Deleter(const self_type& other)
+    {
+      if (mProperty == OwnershipProperty::Unknown) {
+        mProperty = other.mProperty;
+      } else if (mProperty != other.mProperty) {
+        throw std::runtime_error("Attemp to change resource control");
+      }
+    }
+
+    // copy constructor for the default delete which simply sets the
+    // resource ownership control to 'Owning'
+    constexpr Deleter(const base& other) { mProperty = OwnershipProperty::Owning; }
+
+    // forbid assignment operator to prohibid changing the Deleter
+    // resource control property once used in the unique_ptr
+    self_type& operator=(const self_type&) = delete;
+
+    void operator()(T* ptr) const
+    {
+      if (mProperty == OwnershipProperty::NotOwning) return;
+      base::operator()(ptr);
+    }
+
+   private:
+    OwnershipProperty mProperty = OwnershipProperty::Unknown;
+  };
 
   int getPos(const char *name) const;
   int getPos(const std::string &name) const;
@@ -130,7 +127,9 @@ public:
   // not be used if the type is a TObject as extra deserialization
   // needs to happen.
   template <typename T>
-  typename std::enable_if<is_messageable<T>::value && std::is_same<T, DataRef>::value == false && has_root_dictionary<T>::value == false, T>::type const&
+  typename std::enable_if<is_messageable<T>::value &&
+                          std::is_same<T, DataRef>::value == false &&
+                          has_root_dictionary<T>::value == false, T>::type const&
   get(char const* binding) const
   {
     // TODO: check the serialization type, the cast makes only sense for
@@ -186,17 +185,21 @@ public:
   // objects in a single place so that we can avoid duplicate deserializations?
   template <class T>
   typename std::unique_ptr<typename std::enable_if<has_root_dictionary<T>::value == true && is_messageable<T>::value == false, T>::type const>
-  get(char const *binding) const {
+  get(char const* binding) const
+  {
     using DataHeader = o2::header::DataHeader;
 
     auto ref = this->get(binding);
     return std::move(DataRefUtils::as<T>(ref));
   }
 
-  // substitution for messageable objects with dictionary
+  // substitution for messageable objects with ROOT dictionary
   // the operation depends on the transmitted serialization method
   template <typename T>
-  typename std::enable_if<is_messageable<T>::value && std::is_same<T, DataRef>::value == false && has_root_dictionary<T>::value, std::unique_ptr<T const, Deleter<T const>>>::type
+  typename std::enable_if<is_messageable<T>::value &&
+                          std::is_same<T, DataRef>::value == false &&
+                          has_root_dictionary<T>::value,
+                          std::unique_ptr<T const, Deleter<T const>>>::type
   get(char const* binding) const
   {
     using DataHeader = o2::header::DataHeader;
@@ -205,14 +208,48 @@ public:
     auto header = o2::header::get<const DataHeader>(ref.header);
     auto method = header->payloadSerializationMethod;
     if (method == o2::header::gSerializationMethodNone) {
-      auto const* ptr = reinterpret_cast<T const *>(ref.payload);
+      auto const* ptr = reinterpret_cast<T const*>(ref.payload);
+      // return type with non-owning Deleter instance
       std::unique_ptr<T const, Deleter<T const>> result(ptr, Deleter<T const>(false));
       return std::move(result);
     } else if (method == o2::header::gSerializationMethodROOT) {
-      std::unique_ptr<T const, Deleter<T const>> result(DataRefUtils::extract<T>(ref).release());
+      // explicitely specify serialization method to ROOT-serialized because type T
+      // is messageable and a different method would be deduced in DataRefUtils
+      // return type with owning Deleter instance, forwarding to default_deleter
+      std::unique_ptr<T const, Deleter<T const>> result(DataRefUtils::as<ROOTSerialized<T>>(ref).release());
       return std::move(result);
     } else {
-      throw std::runtime_error("Attempt to extract message with unsupported serializayion type");
+      throw std::runtime_error("Attempt to extract object from message with unsupported serializayion type");
+    }
+  }
+
+  // substitution for non-messageable objects without ROOT dictionary
+  // the operation depends on the transmitted serialization method
+  // FIXME: some of the substitutions can for sure be combined when the return types
+  // will be unified in a later refactoring
+  template <typename T>
+  typename std::enable_if<is_messageable<T>::value == false &&
+                          std::is_same<T, DataRef>::value == false &&
+                          has_root_dictionary<T>::value == false,
+                          std::unique_ptr<T const, Deleter<T const>>>::type
+  get(char const* binding) const
+  {
+    using DataHeader = o2::header::DataHeader;
+
+    auto ref = this->get(binding);
+    auto header = o2::header::get<const DataHeader>(ref.header);
+    auto method = header->payloadSerializationMethod;
+    if (method == o2::header::gSerializationMethodNone) {
+      throw std::runtime_error(
+        "Type mismatch: attempt to extract a non-messagable object from message with unserialized data");
+    } else if (method == o2::header::gSerializationMethodROOT) {
+      // explicitely specify serialization method to ROOT-serialized because type T
+      // is messageable and a different method would be deduced in DataRefUtils
+      // return type with owning Deleter instance, forwarding to default_deleter
+      std::unique_ptr<T const, Deleter<T const>> result(DataRefUtils::as<ROOTSerialized<T>>(ref).release());
+      return std::move(result);
+    } else {
+      throw std::runtime_error("Attempt to extract object from message with unsupported serializayion type");
     }
   }
 

--- a/Framework/Core/include/Framework/SerializationMethods.h
+++ b/Framework/Core/include/Framework/SerializationMethods.h
@@ -1,0 +1,54 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef FRAMEWORK_SERIALIZATIONMETHODS_H
+#define FRAMEWORK_SERIALIZATIONMETHODS_H
+
+/// @file SerializationMethods.h
+/// @brief Type wrappers for enfording a specific serialization method
+
+#include "Framework/TypeTraits.h"
+
+namespace o2
+{
+namespace framework
+{
+
+/// @class ROOTSerialized
+/// Enforce ROOT serialization for a type
+///
+/// Usage: (with 'output' being the DataAllocator of the ProcessingContext)
+///   SomeType object;
+///   ROOTSerialized<decltype(object)> ref(object);
+///   output.snapshot(OutputSpec{}, ref);
+///     - or -
+///   output.snapshot(OutputSpec{}, ROOTSerialized<decltype(object)>(object));
+///
+/// The existence of the ROOT dictionary for the wrapped type can not be
+/// checked at compile time, a runtime check must be performed in the
+/// substitution for the ROOTSerialized type.
+template <typename T>
+class ROOTSerialized
+{
+ public:
+  using non_messageable = o2::framework::MarkAsNonMessageable;
+  using wrapped_type = T;
+  ROOTSerialized() = delete;
+  ROOTSerialized(wrapped_type& ref) : mRef(ref) {}
+
+  T& operator()() { return mRef; }
+  T const& operator()() const { return mRef; }
+
+ private:
+  wrapped_type& mRef;
+};
+}
+}
+
+#endif // FRAMEWORK_SERIALIZATIONMETHODS_H

--- a/Framework/Core/include/Framework/TypeTraits.h
+++ b/Framework/Core/include/Framework/TypeTraits.h
@@ -11,6 +11,7 @@
 #define FRAMEWORK_TYPETRAITS_H
 
 #include <type_traits>
+#include <vector>
 
 namespace o2 {
 namespace framework {
@@ -24,11 +25,99 @@ struct is_specialization : std::false_type {};
 template<template<typename...> class Ref, typename... Args>
 struct is_specialization<Ref<Args...>, Ref>: std::true_type {};
 
+// helper struct to mark a type as non-messageable by defining a type alias
+// with name 'non-messageable'
+struct MarkAsNonMessageable {};
+
+// detect if a type is forced to be non-messageable, this is done by defining
+// a type alias with name 'non-messageable' of the type MarkAsNonMessageable
+template< typename T, typename _ = void >
+struct is_forced_non_messageable : public std::false_type {};
+
+// specialization to detect the type a lias
+template <typename T>
+struct is_forced_non_messageable<
+  T,
+  typename std::enable_if<std::is_same<typename T::non_messageable, MarkAsNonMessageable>::value>::type
+  > : public std::true_type {};
+
 // TODO: extend this to exclude structs with pointer data members
 // see e.g. https://stackoverflow.com/questions/32880990/how-to-check-if-class-has-pointers-in-c14
 template <typename T>
-struct is_messageable : std::conditional<std::is_trivially_copyable<T>::value && !std::is_polymorphic<T>::value,
+struct is_messageable : std::conditional<std::is_trivially_copyable<T>::value &&
+                                         !std::is_polymorphic<T>::value &&
+                                         !is_forced_non_messageable<T>::value,
                                          std::true_type, std::false_type>::type {};
+
+// Detect a container by checking on the container properties
+// this is the default trait implementation inheriting from false_type
+template <typename T, typename _ = void>
+struct is_container : std::false_type {};
+
+// helper to be substituted if the specified template arguments are
+// available
+template <typename... Ts>
+struct class_member_checker {};
+
+// the specialization for container types inheriting from true_type
+// the helper can be substituted if all the specified members are available
+// in the type
+template <typename T>
+struct is_container<
+  T,
+  std::conditional_t<
+    false,
+    class_member_checker<
+      typename T::value_type,
+      typename T::size_type,
+      typename T::allocator_type,
+      typename T::iterator,
+      typename T::const_iterator,
+      decltype(std::declval<T>().size()),
+      decltype(std::declval<T>().begin()),
+      decltype(std::declval<T>().end()),
+      decltype(std::declval<T>().cbegin()),
+      decltype(std::declval<T>().cend())
+      >,
+    void
+    >
+  > : public std::true_type {};
+
+
+// Detect whether a class has a ROOT dictionary
+// This member detector idiom is implemented using SFINAE idiom to look for
+// a 'Class()' method.
+// This is actually only covering classes using the ClasDef/Imp macros. ROOT
+// serialization however is also possible for types only having the link
+// in the LinkDef file. Such types can only be detected at runtime.
+template <typename T, typename _ = void>
+struct has_root_dictionary : std::false_type {};
+
+template <typename T>
+struct has_root_dictionary<
+  T,
+  std::conditional_t<
+    false,
+    class_member_checker<
+      decltype(std::declval<T>().Class())
+      >,
+    void
+    >
+  > : public std::true_type {};
+
+// specialization for containers
+// covers cases with T::value_type having ROOT dictionary, meaning that
+// std::map is not supported out of the box
+//
+// Note: this is only a SFINAE idiom if the default type of the second template
+// argument in the declaration is the same as the conditionally produced one in
+// the specialization (void in this case)
+template <typename T>
+class has_root_dictionary<T, typename std::enable_if<is_container<T>::value>::type>
+  : public has_root_dictionary<typename T::value_type>
+{
+};
+
 }
 }
 #endif // FRAMEWORK_TYPETRAITS_H

--- a/Framework/Core/test/FrameworkCoreTestLinkDef.h
+++ b/Framework/Core/test/FrameworkCoreTestLinkDef.h
@@ -1,0 +1,18 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class o2::test::TriviallyCopyable;
+#pragma link C++ class o2::test::Base;
+#pragma link C++ class o2::test::Polymorphic;
+#pragma link C++ class std::vector<o2::test::Polymorphic>;

--- a/Framework/Core/test/TestClasses.cxx
+++ b/Framework/Core/test/TestClasses.cxx
@@ -1,0 +1,15 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "test/TestClasses.h"
+
+ClassImp(o2::test::TriviallyCopyable);
+ClassImp(o2::test::Base);
+ClassImp(o2::test::Polymorphic);

--- a/Framework/Core/test/TestClasses.h
+++ b/Framework/Core/test/TestClasses.h
@@ -1,0 +1,76 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef FRAMEWORK_TEST_CLASSES_H
+#define FRAMEWORK_TEST_CLASSES_H
+
+#include <Rtypes.h>
+
+namespace o2
+{
+namespace test
+{
+
+class TriviallyCopyable
+{
+ public:
+  TriviallyCopyable() : mX(0), mY(0), mSecret(~((decltype(mSecret))0)) {};
+  TriviallyCopyable(unsigned x, unsigned y, unsigned secret)
+    : mX(x)
+    , mY(y)
+    , mSecret(secret)
+  {
+  }
+
+  bool operator==(const TriviallyCopyable& rhs) const
+  {
+    return mX == rhs.mX || mY == rhs.mY || mSecret == rhs.mSecret;
+  }
+
+  unsigned mX;
+  unsigned mY;
+
+ private:
+  unsigned mSecret;
+
+  ClassDefNV(TriviallyCopyable, 1);
+};
+
+class Base
+{
+ public:
+  Base() : mMember(0) {}
+  virtual ~Base() {}
+  virtual void f() {}
+
+ private:
+  int mMember;
+
+  ClassDef(Base, 1);
+};
+
+class Polymorphic : public Base
+{
+ public:
+  Polymorphic() : mSecret(~((decltype(mSecret))0)) {}
+  Polymorphic(unsigned secret) : mSecret(secret) {}
+
+  bool operator==(const Polymorphic& rhs) const { return mSecret == rhs.mSecret; }
+
+  bool isDefault() const { return mSecret == ~(decltype(mSecret))0; }
+
+ private:
+  unsigned mSecret;
+
+  ClassDefOverride(Polymorphic, 1);
+};
+
+} // namespace test
+} // namespace o2
+#endif // FRAMEWORK_TEST_CLASSES_H

--- a/Framework/Core/test/test_TypeTraits.cxx
+++ b/Framework/Core/test/test_TypeTraits.cxx
@@ -13,6 +13,7 @@
 #define BOOST_TEST_DYN_LINK
 
 #include "Framework/TypeTraits.h"
+#include "TestClasses.h"
 #include <boost/test/unit_test.hpp>
 #include <vector>
 #include <list>
@@ -22,30 +23,6 @@ using namespace o2::framework;
 struct Foo {
   int x;
   int y;
-};
-
-// TODO: extend this by a struct with pointer member
-class TriviallyCopyable
-{
- public:
-  int mX;
-  int mY;
-
- private:
-  int mP;
-};
-
-class Base
-{
- public:
-  virtual void f() {}
-};
-
-class Polymorphic : Base
-{
- public:
- private:
-  int mMember;
 };
 
 // Simple test to do root deserialization.
@@ -69,17 +46,72 @@ BOOST_AUTO_TEST_CASE(TestIsSpecialization) {
   BOOST_REQUIRE_EQUAL(test6, false);
 }
 
+BOOST_AUTO_TEST_CASE(TestForceNonMessageable)
+{
+  // a struct explicitly marked to be non-messageable by defining
+  // a type alias provided by the framework type traits
+  struct ExplicitNonMessageable {
+    using non_messageable = o2::framework::MarkAsNonMessageable;
+  };
+
+  // a struct using the same name for the type alias, but which should
+  // not be forced to be non-messageable
+  struct FailedNonMessageable {
+    using non_messageable = int;
+  };
+
+  ExplicitNonMessageable a;
+  Foo b;
+  FailedNonMessageable c;
+
+  BOOST_REQUIRE_EQUAL(is_forced_non_messageable<decltype(a)>::value, true);
+  BOOST_REQUIRE_EQUAL(is_forced_non_messageable<decltype(b)>::value, false);
+  BOOST_REQUIRE_EQUAL(is_forced_non_messageable<decltype(c)>::value, false);
+}
+
 BOOST_AUTO_TEST_CASE(TestIsMessageable)
 {
   int a;
   Foo b;
   std::vector<int> c;
-  TriviallyCopyable d;
-  Polymorphic e;
+  o2::test::TriviallyCopyable d;
+  o2::test::Polymorphic e;
 
   BOOST_REQUIRE_EQUAL(is_messageable<decltype(a)>::value, true);
   BOOST_REQUIRE_EQUAL(is_messageable<decltype(b)>::value, true);
   BOOST_REQUIRE_EQUAL(is_messageable<decltype(c)>::value, false);
   BOOST_REQUIRE_EQUAL(is_messageable<decltype(d)>::value, true);
   BOOST_REQUIRE_EQUAL(is_messageable<decltype(e)>::value, false);
+}
+
+BOOST_AUTO_TEST_CASE(TestIsStlContainer)
+{
+  int a;
+  o2::test::TriviallyCopyable b;
+  std::vector<o2::test::Polymorphic> c;
+  std::map<int, o2::test::Polymorphic> d;
+
+  BOOST_REQUIRE_EQUAL(is_container<decltype(a)>::value, false);
+  BOOST_REQUIRE_EQUAL(is_container<decltype(b)>::value, false);
+  BOOST_REQUIRE_EQUAL(is_container<decltype(c)>::value, true);
+  BOOST_REQUIRE_EQUAL(is_container<decltype(d)>::value, true);
+}
+
+BOOST_AUTO_TEST_CASE(TestHasRootStreamer)
+{
+  o2::test::TriviallyCopyable a;
+  o2::test::Polymorphic b;
+  std::vector<o2::test::Polymorphic> c;
+  int d;
+  Foo e;
+  std::list<o2::test::TriviallyCopyable> f;
+  std::list<int> g;
+
+  BOOST_REQUIRE_EQUAL(has_root_dictionary<decltype(a)>::value, true);
+  BOOST_REQUIRE_EQUAL(has_root_dictionary<decltype(b)>::value, true);
+  BOOST_REQUIRE_EQUAL(has_root_dictionary<decltype(c)>::value, true);
+  BOOST_REQUIRE_EQUAL(has_root_dictionary<decltype(d)>::value, false);
+  BOOST_REQUIRE_EQUAL(has_root_dictionary<decltype(e)>::value, false);
+  BOOST_REQUIRE_EQUAL(has_root_dictionary<decltype(f)>::value, true);
+  BOOST_REQUIRE_EQUAL(has_root_dictionary<decltype(g)>::value, false);
 }

--- a/Framework/Core/test/test_TypeTraits.cxx
+++ b/Framework/Core/test/test_TypeTraits.cxx
@@ -13,6 +13,7 @@
 #define BOOST_TEST_DYN_LINK
 
 #include "Framework/TypeTraits.h"
+#include "Framework/SerializationMethods.h"
 #include "TestClasses.h"
 #include <boost/test/unit_test.hpp>
 #include <vector>
@@ -44,6 +45,10 @@ BOOST_AUTO_TEST_CASE(TestIsSpecialization) {
   BOOST_REQUIRE_EQUAL(test4, true);
   BOOST_REQUIRE_EQUAL(test5, false);
   BOOST_REQUIRE_EQUAL(test6, false);
+
+  ROOTSerialized<decltype(d)> e(d);
+  bool test7 = is_specialization<decltype(e), ROOTSerialized>::value;
+  BOOST_REQUIRE_EQUAL(test7, true);
 }
 
 BOOST_AUTO_TEST_CASE(TestForceNonMessageable)
@@ -82,6 +87,7 @@ BOOST_AUTO_TEST_CASE(TestIsMessageable)
   BOOST_REQUIRE_EQUAL(is_messageable<decltype(c)>::value, false);
   BOOST_REQUIRE_EQUAL(is_messageable<decltype(d)>::value, true);
   BOOST_REQUIRE_EQUAL(is_messageable<decltype(e)>::value, false);
+  BOOST_REQUIRE_EQUAL(is_messageable<ROOTSerialized<decltype(e)>>::value, false);
 }
 
 BOOST_AUTO_TEST_CASE(TestIsStlContainer)


### PR DESCRIPTION
- added support for ROOT serialization of non-TObject objects
- automatically deduce serialization method for messageable and ROOT-serializable objects and handle ambiguity for those which are both
- adding type wrapper to force ROOT-serialization method