### PR TITLE
Possibility to run with randomly distributed primary vertices

### DIFF
--- a/Detectors/ITSMFT/ITS/macros/test/run_test.sh
+++ b/Detectors/ITSMFT/ITS/macros/test/run_test.sh
@@ -24,5 +24,5 @@ root.exe -b -q $O2_ROOT/share/macro/run_trac_its.C+\($nEvents,$mcEngine,$rate\) 
 
 root.exe -b -q CheckTracks.C+\($nEvents,$mcEngine\) >& CheckTracks.log
 
-root.exe DisplayTrack.C +\($nEvents,$mcEngine\)
+root.exe DisplayTrack.C+\($nEvents,$mcEngine\)
 

--- a/Detectors/ITSMFT/ITS/reconstruction/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/reconstruction/CMakeLists.txt
@@ -14,6 +14,7 @@ set(HEADERS
     )
 set(NO_DICT_SRCS # sources not for the dictionary
     src/TrivialClusterer.cxx
+    src/TrivialVertexer.cxx
     src/CAaux.cxx
     src/CATracker.cxx
     src/CATrackingStation.cxx
@@ -21,6 +22,7 @@ set(NO_DICT_SRCS # sources not for the dictionary
     )
 set(NO_DICT_HEADERS # sources not for the dictionary
     include/${MODULE_NAME}/TrivialClusterer.h
+    include/${MODULE_NAME}/TrivialVertexer.h
     include/${MODULE_NAME}/CAaux.h
     include/${MODULE_NAME}/CATracker.h
     include/${MODULE_NAME}/CATrackingStation.h

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTracker.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTracker.h
@@ -51,17 +51,11 @@ public:
   CookedTracker& operator=(const CookedTracker& tr) = delete;
   ~CookedTracker() = default;
 
-  void setVertex(const Double_t* xyz, const Double_t* ers = nullptr)
+  void setVertices(std::vector<std::array<Double_t,3>> &vertices)
   {
-    mX = xyz[0];
-    mY = xyz[1];
-    mZ = xyz[2];
-    if (ers) {
-      mSigmaX = ers[0];
-      mSigmaY = ers[1];
-      mSigmaZ = ers[2];
-    }
+    mVertices = std::move(vertices);
   }
+  
   Double_t getX() const { return mX; }
   Double_t getY() const { return mY; }
   Double_t getZ() const { return mZ; }
@@ -126,13 +120,15 @@ public:
   Int_t mNumOfThreads; ///< Number of tracking threads
   
   Double_t mBz;///< Effective Z-component of the magnetic field (kG)
-  Double_t mX; ///< X-coordinate of the primary vertex
-  Double_t mY; ///< Y-coordinate of the primary vertex
-  Double_t mZ; ///< Z-coordinate of the primary vertex
 
-  Double_t mSigmaX; ///< error of the primary vertex position in X
-  Double_t mSigmaY; ///< error of the primary vertex position in Y
-  Double_t mSigmaZ; ///< error of the primary vertex position in Z
+  std::vector<std::array<Double_t,3>> mVertices;
+  Double_t mX = 0.; ///< X-coordinate of the primary vertex
+  Double_t mY = 0.; ///< Y-coordinate of the primary vertex
+  Double_t mZ = 0.; ///< Z-coordinate of the primary vertex
+
+  Double_t mSigmaX = 2.; ///< error of the primary vertex position in X
+  Double_t mSigmaY = 2.; ///< error of the primary vertex position in Y
+  Double_t mSigmaZ = 2.; ///< error of the primary vertex position in Z
 
   static Layer sLayers[kNLayers];  ///< Layers filled with clusters
   std::vector<TrackITS> mSeeds;    ///< Track seeds

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTracker.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTracker.h
@@ -30,32 +30,29 @@ namespace o2
 class MCCompLabel;
 namespace dataformats
 {
-  template<typename T>
-  class MCTruthContainer;
+template <typename T>
+class MCTruthContainer;
 }
 
 namespace ITSMFT
 {
-  class Cluster;
+class Cluster;
 }
-  
+
 namespace ITS
 {
 class CookedTracker
 {
   using Cluster = o2::ITSMFT::Cluster;
 
-public:
-  CookedTracker(Int_t nThreads=1);
+ public:
+  CookedTracker(Int_t nThreads = 1);
   CookedTracker(const CookedTracker&) = delete;
   CookedTracker& operator=(const CookedTracker& tr) = delete;
   ~CookedTracker() = default;
 
-  void setVertices(std::vector<std::array<Double_t,3>> &vertices)
-  {
-    mVertices = std::move(vertices);
-  }
-  
+  void setVertices(std::vector<std::array<Double_t, 3>>& vertices) { mVertices = std::move(vertices); }
+
   Double_t getX() const { return mX; }
   Double_t getY() const { return mY; }
   Double_t getZ() const { return mZ; }
@@ -67,9 +64,9 @@ public:
   Double_t getBz() const;
   void setBz(Double_t bz) { mBz = bz; }
 
-  void setNumberOfThreads(Int_t n) { mNumOfThreads=n; }
+  void setNumberOfThreads(Int_t n) { mNumOfThreads = n; }
   Int_t getNumberOfThreads() const { return mNumOfThreads; }
-  
+
   // These functions must be implemented
   void process(const std::vector<Cluster>& clusters, std::vector<TrackITS>& tracks);
   void processFrame(std::vector<TrackITS>& tracks);
@@ -79,23 +76,23 @@ public:
   const Cluster* getCluster(Int_t index) const;
 
   void setGeometry(o2::ITS::GeometryTGeo* geom);
-  void setMCTruthContainers(const o2::dataformats::MCTruthContainer<o2::MCCompLabel> *clsLabels,
-                            o2::dataformats::MCTruthContainer<o2::MCCompLabel> *trkLabels) {
-    mClsLabels=clsLabels;
-    mTrkLabels=trkLabels;
+  void setMCTruthContainers(const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* clsLabels,
+                            o2::dataformats::MCTruthContainer<o2::MCCompLabel>* trkLabels)
+  {
+    mClsLabels = clsLabels;
+    mTrkLabels = trkLabels;
   }
 
   void setContinuousMode(bool mode) { mContinuousMode = mode; }
   bool getContinuousMode() { return mContinuousMode; }
 
-  
   // internal helper classes
   class ThreadData;
   class Layer;
 
  protected:
   static constexpr int kNLayers = 7;
-  int loadClusters(const std::vector<Cluster> &clusters);
+  int loadClusters(const std::vector<Cluster>& clusters);
   void unloadClusters();
 
   std::vector<TrackITS> trackInThread(Int_t first, Int_t last);
@@ -108,20 +105,18 @@ public:
   bool makeBackPropParam(TrackITS& track) const;
 
  private:
+  bool mContinuousMode = true;                                                    ///< triggered or cont. mode
+  const o2::ITS::GeometryTGeo* mGeom = nullptr;                                   /// interface to geometry
+  const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* mClsLabels = nullptr; /// Cluster MC labels
+  o2::dataformats::MCTruthContainer<o2::MCCompLabel>* mTrkLabels = nullptr;       /// Track MC labels
 
-  bool mContinuousMode = true; ///< triggered or cont. mode
-  const o2::ITS::GeometryTGeo* mGeom = nullptr; /// interface to geometry
-  const
-  o2::dataformats::MCTruthContainer<o2::MCCompLabel> *mClsLabels = nullptr; /// Cluster MC labels
-  o2::dataformats::MCTruthContainer<o2::MCCompLabel> *mTrkLabels = nullptr; /// Track MC labels
+  std::uint32_t mROFrame = 0; ///< last frame processed
 
-  std::uint32_t mROFrame=0;  ///< last frame processed
-  
   Int_t mNumOfThreads; ///< Number of tracking threads
-  
-  Double_t mBz;///< Effective Z-component of the magnetic field (kG)
 
-  std::vector<std::array<Double_t,3>> mVertices;
+  Double_t mBz; ///< Effective Z-component of the magnetic field (kG)
+
+  std::vector<std::array<Double_t, 3>> mVertices;
   Double_t mX = 0.; ///< X-coordinate of the primary vertex
   Double_t mY = 0.; ///< Y-coordinate of the primary vertex
   Double_t mZ = 0.; ///< Z-coordinate of the primary vertex
@@ -130,8 +125,8 @@ public:
   Double_t mSigmaY = 2.; ///< error of the primary vertex position in Y
   Double_t mSigmaZ = 2.; ///< error of the primary vertex position in Z
 
-  static Layer sLayers[kNLayers];  ///< Layers filled with clusters
-  std::vector<TrackITS> mSeeds;    ///< Track seeds
+  static Layer sLayers[kNLayers]; ///< Layers filled with clusters
+  std::vector<TrackITS> mSeeds;   ///< Track seeds
 };
 
 class CookedTracker::Layer
@@ -145,25 +140,25 @@ class CookedTracker::Layer
   Bool_t insertCluster(const Cluster* c);
   void setR(Double_t r) { mR = r; }
   void unloadClusters();
-  void selectClusters(std::vector<Int_t> &s, Float_t phi, Float_t dy, Float_t z, Float_t dz);
+  void selectClusters(std::vector<Int_t>& s, Float_t phi, Float_t dy, Float_t z, Float_t dz);
   Int_t findClusterIndex(Double_t z) const;
   Float_t getR() const { return mR; }
   const Cluster* getCluster(Int_t i) const { return mClusters[i]; }
   Float_t getAlphaRef(Int_t i) const { return mAlphaRef[i]; }
   Float_t getClusterPhi(Int_t i) const { return mPhi[i]; }
   Int_t getNumberOfClusters() const { return mClusters.size(); }
-  void  setGeometry(o2::ITS::GeometryTGeo* geom) { mGeom = geom; }
+  void setGeometry(o2::ITS::GeometryTGeo* geom) { mGeom = geom; }
 
  protected:
-  enum {kNSectors=21};
+  enum { kNSectors = 21 };
 
-  Float_t mR; ///< mean radius of this layer
+  Float_t mR;                                   ///< mean radius of this layer
   const o2::ITS::GeometryTGeo* mGeom = nullptr; /// interface to geometry
-  std::vector<const Cluster*>mClusters;          ///< All clusters
-  std::vector<Float_t> mAlphaRef;          ///< alpha of the reference plane
-  std::vector<Float_t> mPhi;               ///< cluster phi
-  std::vector<Int_t> mSectors[kNSectors];  ///< Cluster indices sector-by-sector
+  std::vector<const Cluster*> mClusters;        ///< All clusters
+  std::vector<Float_t> mAlphaRef;               ///< alpha of the reference plane
+  std::vector<Float_t> mPhi;                    ///< cluster phi
+  std::vector<Int_t> mSectors[kNSectors];       ///< Cluster indices sector-by-sector
 };
-}
-}
+} // namespace ITS
+} // namespace o2
 #endif /* ALICEO2_ITS_COOKEDTRACKER_H */

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTrackerTask.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTrackerTask.h
@@ -18,6 +18,7 @@
 #include "FairTask.h" 
 
 #include "ITSBase/GeometryTGeo.h"
+#include "ITSReconstruction/TrivialVertexer.h"
 #include "ITSReconstruction/CookedTracker.h"
 
 namespace o2
@@ -43,10 +44,13 @@ class CookedTrackerTask : public FairTask
 
   void setContinuousMode(bool mode) { mContinuousMode = mode; }
   bool getContinuousMode() { return mContinuousMode; }
+
+  TrivialVertexer &getVertexer() { return mVertexer; }
   
  private:
   bool mContinuousMode = true; ///< triggered or cont. mode
-  CookedTracker mTracker; ///< Track finder
+  CookedTracker mTracker;    ///< Track finder
+  TrivialVertexer mVertexer; ///< Vertex finder
 
   const
   std::vector<o2::ITSMFT::Cluster>* mClustersArray=nullptr;   ///< Array of clusters
@@ -56,7 +60,7 @@ class CookedTrackerTask : public FairTask
   std::vector<TrackITS>* mTracksArray = nullptr;                          ///< Array of tracks
   o2::dataformats::MCTruthContainer<o2::MCCompLabel> *mTrkLabels=nullptr; ///< Track MC labels
 
-  ClassDefOverride(CookedTrackerTask, 1)
+  ClassDefOverride(CookedTrackerTask, 2)
 };
 }
 }

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTrackerTask.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTrackerTask.h
@@ -15,7 +15,7 @@
 #ifndef ALICEO2_ITS_COOKEDTRACKERTASK_H
 #define ALICEO2_ITS_COOKEDTRACKERTASK_H
 
-#include "FairTask.h" 
+#include "FairTask.h"
 
 #include "ITSBase/GeometryTGeo.h"
 #include "ITSReconstruction/TrivialVertexer.h"
@@ -26,16 +26,16 @@ namespace o2
 class MCCompLabel;
 namespace dataformats
 {
-  template<typename T>
-  class MCTruthContainer;
+template <typename T>
+class MCTruthContainer;
 }
- 
+
 namespace ITS
 {
 class CookedTrackerTask : public FairTask
 {
  public:
-  CookedTrackerTask(Int_t nThreads=1, Bool_t useMCTruth=kTRUE);
+  CookedTrackerTask(Int_t nThreads = 1, Bool_t useMCTruth = kTRUE);
   ~CookedTrackerTask() override;
 
   InitStatus Init() override;
@@ -45,24 +45,22 @@ class CookedTrackerTask : public FairTask
   void setContinuousMode(bool mode) { mContinuousMode = mode; }
   bool getContinuousMode() { return mContinuousMode; }
 
-  TrivialVertexer &getVertexer() { return mVertexer; }
-  
+  TrivialVertexer& getVertexer() { return mVertexer; }
+
  private:
   bool mContinuousMode = true; ///< triggered or cont. mode
-  CookedTracker mTracker;    ///< Track finder
-  TrivialVertexer mVertexer; ///< Vertex finder
+  CookedTracker mTracker;      ///< Track finder
+  TrivialVertexer mVertexer;   ///< Vertex finder
 
-  const
-  std::vector<o2::ITSMFT::Cluster>* mClustersArray=nullptr;   ///< Array of clusters
-  const
-  o2::dataformats::MCTruthContainer<o2::MCCompLabel> *mClsLabels=nullptr; ///< Cluster MC labels
+  const std::vector<o2::ITSMFT::Cluster>* mClustersArray = nullptr;               ///< Array of clusters
+  const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* mClsLabels = nullptr; ///< Cluster MC labels
 
-  std::vector<TrackITS>* mTracksArray = nullptr;                          ///< Array of tracks
-  o2::dataformats::MCTruthContainer<o2::MCCompLabel> *mTrkLabels=nullptr; ///< Track MC labels
+  std::vector<TrackITS>* mTracksArray = nullptr;                            ///< Array of tracks
+  o2::dataformats::MCTruthContainer<o2::MCCompLabel>* mTrkLabels = nullptr; ///< Track MC labels
 
   ClassDefOverride(CookedTrackerTask, 2)
 };
-}
-}
+} // namespace ITS
+} // namespace o2
 
 #endif /* ALICEO2_ITS_COOKEDTRACKERTASK */

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/TrivialVertexer.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/TrivialVertexer.h
@@ -1,0 +1,68 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TrivialVertexer.h
+/// \brief Definition of the ITS trivial vertex finder
+#ifndef ALICEO2_ITS_TRIVIALVERTEXER_H
+#define ALICEO2_ITS_TRIVIALVERTEXER_H
+
+#include <array>
+
+#include "Rtypes.h"  // for TrivialVertexer::Class, Double_t, ClassDef, etc
+
+class TFile;
+class TTree;
+class FairMCEventHeader;
+
+namespace o2 {
+  namespace ITSMFT {
+    class Cluster;
+  }
+}
+
+namespace o2
+{
+class MCCompLabel;
+namespace dataformats
+{
+  template<typename T>
+  class MCTruthContainer;
+}
+namespace ITS
+{
+  class TrivialVertexer
+{
+  using Cluster = o2::ITSMFT::Cluster;
+  using Label = o2::MCCompLabel;
+ public:
+  TrivialVertexer();
+  ~TrivialVertexer();
+
+  TrivialVertexer(const TrivialVertexer&) = delete;
+  TrivialVertexer& operator=(const TrivialVertexer&) = delete;
+
+  Bool_t openInputFile(const Char_t *);
+  
+  void process(const std::vector<Cluster>& clusters, std::vector<std::array<Double_t,3>>& vertices);
+  void setMCTruthContainer(const o2::dataformats::MCTruthContainer<o2::MCCompLabel> *truth) {
+    mClsLabels = truth;
+  }
+
+ private:
+  const o2::dataformats::MCTruthContainer<o2::MCCompLabel> *mClsLabels=nullptr; //Cluster MC labels
+
+  TFile *mFile = nullptr;
+  TTree *mTree = nullptr;
+  FairMCEventHeader *mHeader = nullptr;
+};
+}
+}
+
+#endif /* ALICEO2_ITS_TRIVIALVERTEXER_H */

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/TrivialVertexer.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/TrivialVertexer.h
@@ -15,32 +15,35 @@
 
 #include <array>
 
-#include "Rtypes.h"  // for TrivialVertexer::Class, Double_t, ClassDef, etc
+#include "Rtypes.h" // for TrivialVertexer::Class, Double_t, ClassDef, etc
 
 class TFile;
 class TTree;
 class FairMCEventHeader;
 
-namespace o2 {
-  namespace ITSMFT {
-    class Cluster;
-  }
+namespace o2
+{
+namespace ITSMFT
+{
+class Cluster;
 }
+} // namespace o2
 
 namespace o2
 {
 class MCCompLabel;
 namespace dataformats
 {
-  template<typename T>
-  class MCTruthContainer;
+template <typename T>
+class MCTruthContainer;
 }
 namespace ITS
 {
-  class TrivialVertexer
+class TrivialVertexer
 {
   using Cluster = o2::ITSMFT::Cluster;
   using Label = o2::MCCompLabel;
+
  public:
   TrivialVertexer();
   ~TrivialVertexer();
@@ -48,21 +51,19 @@ namespace ITS
   TrivialVertexer(const TrivialVertexer&) = delete;
   TrivialVertexer& operator=(const TrivialVertexer&) = delete;
 
-  Bool_t openInputFile(const Char_t *);
-  
-  void process(const std::vector<Cluster>& clusters, std::vector<std::array<Double_t,3>>& vertices);
-  void setMCTruthContainer(const o2::dataformats::MCTruthContainer<o2::MCCompLabel> *truth) {
-    mClsLabels = truth;
-  }
+  Bool_t openInputFile(const Char_t*);
+
+  void process(const std::vector<Cluster>& clusters, std::vector<std::array<Double_t, 3>>& vertices);
+  void setMCTruthContainer(const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* truth) { mClsLabels = truth; }
 
  private:
-  const o2::dataformats::MCTruthContainer<o2::MCCompLabel> *mClsLabels=nullptr; //Cluster MC labels
+  const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* mClsLabels = nullptr; // Cluster MC labels
 
-  TFile *mFile = nullptr;
-  TTree *mTree = nullptr;
-  FairMCEventHeader *mHeader = nullptr;
+  TFile* mFile = nullptr;
+  TTree* mTree = nullptr;
+  FairMCEventHeader* mHeader = nullptr;
 };
-}
-}
+} // namespace ITS
+} // namespace o2
 
 #endif /* ALICEO2_ITS_TRIVIALVERTEXER_H */

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CookedTracker.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CookedTracker.cxx
@@ -81,7 +81,6 @@ CookedTracker::CookedTracker(Int_t n) : mNumOfThreads(n), mBz(0.)
 
   for (Int_t i = 0; i < kNLayers; i++)
     sLayers[i].setR(klRadius[i]);
-
 }
 
 //__________________________________________________________________________
@@ -477,7 +476,7 @@ std::vector<TrackITS> CookedTracker::trackInThread(Int_t first, Int_t last)
   std::vector<TrackITS> seeds;
   seeds.reserve(last - first + 1);
 
-  for (auto &vtx : mVertices) {
+  for (auto& vtx : mVertices) {
     mX = vtx[0];
     mY = vtx[1];
     mZ = vtx[2];

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CookedTracker.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CookedTracker.cxx
@@ -82,11 +82,6 @@ CookedTracker::CookedTracker(Int_t n) : mNumOfThreads(n), mBz(0.)
   for (Int_t i = 0; i < kNLayers; i++)
     sLayers[i].setR(klRadius[i]);
 
-  // Some default primary vertex
-  Double_t xyz[] = { 0., 0., 0. };
-  Double_t ers[] = { 2., 2., 2. };
-
-  setVertex(xyz, ers);
 }
 
 //__________________________________________________________________________
@@ -482,7 +477,13 @@ std::vector<TrackITS> CookedTracker::trackInThread(Int_t first, Int_t last)
   std::vector<TrackITS> seeds;
   seeds.reserve(last - first + 1);
 
-  makeSeeds(seeds, first, last);
+  for (auto &vtx : mVertices) {
+    mX = vtx[0];
+    mY = vtx[1];
+    mZ = vtx[2];
+    makeSeeds(seeds, first, last);
+  }
+
   std::sort(seeds.begin(), seeds.end());
 
   trackSeeds(seeds);
@@ -546,21 +547,6 @@ void CookedTracker::processFrame(std::vector<TrackITS>& tracks)
   //--------------------------------------------------------------------
   LOG(INFO) << "CookedTracker::process(), number of threads: " << mNumOfThreads << FairLogger::endl;
 
-  Double_t xyz[3]{ 0, 0, 0 }; // FIXME
-  setVertex(xyz);
-  // mSeeds = makeSeeds(0, sLayers[kSeedingLayer1].getNumberOfClusters());
-  // Seeding with the pileup primary vertices
-  /* FIXME
-     TClonesArray *verticesSPD=tracks->GetPileupVerticesSPD();
-     Int_t nfoundSPD=verticesSPD->GetEntries();
-     for (Int_t v=0; v<nfoundSPD; v++) {
-     vtx=(AliESDVertex *)verticesSPD->UncheckedAt(v);
-     if (!vtx->GetStatus()) continue;
-     xyz[0]=vtx->getX(); xyz[1]=vtx->getY(); xyz[2]=vtx->getZ();
-     setVertex(xyz);
-     makeSeeds();
-     }
-  */
   std::vector<std::future<std::vector<TrackITS>>> futures(mNumOfThreads);
   std::vector<std::vector<TrackITS>> seedArray(mNumOfThreads);
 

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CookedTrackerTask.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CookedTrackerTask.cxx
@@ -76,6 +76,7 @@ InitStatus CookedTrackerTask::Init()
       LOG(ERROR) << "ITS cluster labels not registered in the FairRootManager. Exiting ..." << FairLogger::endl;
       return kERROR;
     }
+    mVertexer.setMCTruthContainer(mClsLabels);
   }
 
   GeometryTGeo* geom = GeometryTGeo::Instance();
@@ -96,5 +97,9 @@ void CookedTrackerTask::Exec(Option_t* option)
     mTrkLabels->clear();
   LOG(DEBUG) << "Running digitization on new event" << FairLogger::endl;
 
+  std::vector<std::array<Double_t,3>> vertices;
+  mVertexer.process(*mClustersArray, vertices);
+
+  mTracker.setVertices(vertices);
   mTracker.process(*mClustersArray, *mTracksArray);
 }

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CookedTrackerTask.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CookedTrackerTask.cxx
@@ -97,7 +97,7 @@ void CookedTrackerTask::Exec(Option_t* option)
     mTrkLabels->clear();
   LOG(DEBUG) << "Running digitization on new event" << FairLogger::endl;
 
-  std::vector<std::array<Double_t,3>> vertices;
+  std::vector<std::array<Double_t, 3>> vertices;
   mVertexer.process(*mClustersArray, vertices);
 
   mTracker.setVertices(vertices);

--- a/Detectors/ITSMFT/ITS/reconstruction/src/TrivialVertexer.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/TrivialVertexer.cxx
@@ -1,0 +1,107 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TrivialVertexer.cxx
+/// \brief Implementation of the ITS trivial vertex finder
+
+#include <limits>
+
+#include "TFile.h"
+#include "TTree.h"
+
+#include "FairMCEventHeader.h"
+#include "FairLogger.h"
+
+#include "ITSReconstruction/TrivialVertexer.h"
+#include "DataFormatsITSMFT/Cluster.h"
+#include "SimulationDataFormat/MCCompLabel.h"
+#include "SimulationDataFormat/MCTruthContainer.h"
+
+using namespace o2::ITSMFT;
+using namespace o2::ITS;
+
+using Point3Df = Point3D<float>;
+
+TrivialVertexer::TrivialVertexer() = default;
+
+TrivialVertexer::~TrivialVertexer() {
+  if (mHeader) delete mHeader;
+  if (mTree) delete mTree;
+  if (mFile) delete mFile;
+}
+
+Bool_t TrivialVertexer::openInputFile(const Char_t *fname) {
+  mFile = TFile::Open(fname,"old");
+  if (!mFile) {
+    LOG(ERROR) << "TrivialVertexer::openInputFile() : " 
+               << "Cannot open the input file !"
+               << FairLogger::endl;
+    return kFALSE;
+  }
+  mTree = (TTree *)mFile->Get("o2sim");
+  if (!mTree) {
+    LOG(ERROR) << "TrivialVertexer::openInputFile() : " 
+               << "Cannot get the input tree !"
+               << FairLogger::endl;
+    return kFALSE;
+  }
+  Int_t rc = mTree->SetBranchAddress("MCEventHeader.",&mHeader);
+  if (rc != 0) {
+    LOG(ERROR) << "TrivialVertexer::openInputFile() : " 
+               << "Cannot get the input branch ! rc="<<rc
+               << FairLogger::endl;
+    return kFALSE;
+  }
+  return kTRUE;
+}
+
+void TrivialVertexer::process(const std::vector<Cluster> &clusters,
+			      std::vector<std::array<Double_t,3>> &vertices)
+{
+  if (mClsLabels == nullptr) {
+    LOG(INFO) << "TrivialVertexer::process() : " 
+              <<"No cluster labels available ! Running with a default MC vertex..."
+              << FairLogger::endl;
+    vertices.emplace_back(std::array<Double_t,3>{0.,0.,0.});
+    return;
+  }
+  
+  if (mTree == nullptr) {
+    LOG(INFO) << "TrivialVertexer::process() : " 
+              <<"No MC information available ! Running with a default MC vertex..."
+              << FairLogger::endl;
+    vertices.emplace_back(std::array<Double_t,3>{0.,0.,0.});
+    return;
+  }
+  
+  Int_t lastEventID = 0;
+  Int_t firstEventID = std::numeric_limits<Int_t>::max();
+
+  // Find the first and last MC event within this TF
+  for (Int_t i=0; i<clusters.size(); ++i) {
+    auto mclab = (mClsLabels->getLabels(i))[0];
+    if (mclab.getTrackID() == -1) continue;  // noise
+    auto id = mclab.getEventID();
+    if (id<firstEventID) firstEventID=id;
+    if (id>lastEventID) lastEventID=id;
+  }
+
+  for (Int_t mcEv=firstEventID; mcEv <= lastEventID; ++mcEv) {
+    mTree->GetEvent(mcEv);
+    Double_t vx=mHeader->GetX(); 
+    Double_t vy=mHeader->GetY(); 
+    Double_t vz=mHeader->GetZ(); 
+    vertices.emplace_back(std::array<Double_t,3>{vx,vy,vz});
+    LOG(INFO) << "TrivialVertexer::process() : " 
+              <<"MC event #"<<mcEv<<" with vertex ("<<vx<<','<<vy<<','<<vz<<')'
+              << FairLogger::endl;
+  }
+
+}

--- a/Detectors/ITSMFT/ITS/reconstruction/src/TrivialVertexer.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/TrivialVertexer.cxx
@@ -31,77 +31,77 @@ using Point3Df = Point3D<float>;
 
 TrivialVertexer::TrivialVertexer() = default;
 
-TrivialVertexer::~TrivialVertexer() {
-  if (mHeader) delete mHeader;
-  if (mTree) delete mTree;
-  if (mFile) delete mFile;
+TrivialVertexer::~TrivialVertexer()
+{
+  if (mHeader)
+    delete mHeader;
+  if (mTree)
+    delete mTree;
+  if (mFile)
+    delete mFile;
 }
 
-Bool_t TrivialVertexer::openInputFile(const Char_t *fname) {
-  mFile = TFile::Open(fname,"old");
+Bool_t TrivialVertexer::openInputFile(const Char_t* fname)
+{
+  mFile = TFile::Open(fname, "old");
   if (!mFile) {
-    LOG(ERROR) << "TrivialVertexer::openInputFile() : " 
-               << "Cannot open the input file !"
-               << FairLogger::endl;
+    LOG(ERROR) << "TrivialVertexer::openInputFile() : "
+               << "Cannot open the input file !" << FairLogger::endl;
     return kFALSE;
   }
-  mTree = (TTree *)mFile->Get("o2sim");
+  mTree = (TTree*)mFile->Get("o2sim");
   if (!mTree) {
-    LOG(ERROR) << "TrivialVertexer::openInputFile() : " 
-               << "Cannot get the input tree !"
-               << FairLogger::endl;
+    LOG(ERROR) << "TrivialVertexer::openInputFile() : "
+               << "Cannot get the input tree !" << FairLogger::endl;
     return kFALSE;
   }
-  Int_t rc = mTree->SetBranchAddress("MCEventHeader.",&mHeader);
+  Int_t rc = mTree->SetBranchAddress("MCEventHeader.", &mHeader);
   if (rc != 0) {
-    LOG(ERROR) << "TrivialVertexer::openInputFile() : " 
-               << "Cannot get the input branch ! rc="<<rc
-               << FairLogger::endl;
+    LOG(ERROR) << "TrivialVertexer::openInputFile() : "
+               << "Cannot get the input branch ! rc=" << rc << FairLogger::endl;
     return kFALSE;
   }
   return kTRUE;
 }
 
-void TrivialVertexer::process(const std::vector<Cluster> &clusters,
-			      std::vector<std::array<Double_t,3>> &vertices)
+void TrivialVertexer::process(const std::vector<Cluster>& clusters, std::vector<std::array<Double_t, 3>>& vertices)
 {
   if (mClsLabels == nullptr) {
-    LOG(INFO) << "TrivialVertexer::process() : " 
-              <<"No cluster labels available ! Running with a default MC vertex..."
-              << FairLogger::endl;
-    vertices.emplace_back(std::array<Double_t,3>{0.,0.,0.});
+    LOG(INFO) << "TrivialVertexer::process() : "
+              << "No cluster labels available ! Running with a default MC vertex..." << FairLogger::endl;
+    vertices.emplace_back(std::array<Double_t, 3>{ 0., 0., 0. });
     return;
   }
-  
+
   if (mTree == nullptr) {
-    LOG(INFO) << "TrivialVertexer::process() : " 
-              <<"No MC information available ! Running with a default MC vertex..."
-              << FairLogger::endl;
-    vertices.emplace_back(std::array<Double_t,3>{0.,0.,0.});
+    LOG(INFO) << "TrivialVertexer::process() : "
+              << "No MC information available ! Running with a default MC vertex..." << FairLogger::endl;
+    vertices.emplace_back(std::array<Double_t, 3>{ 0., 0., 0. });
     return;
   }
-  
+
   Int_t lastEventID = 0;
   Int_t firstEventID = std::numeric_limits<Int_t>::max();
 
   // Find the first and last MC event within this TF
-  for (Int_t i=0; i<clusters.size(); ++i) {
+  for (Int_t i = 0; i < clusters.size(); ++i) {
     auto mclab = (mClsLabels->getLabels(i))[0];
-    if (mclab.getTrackID() == -1) continue;  // noise
+    if (mclab.getTrackID() == -1)
+      continue; // noise
     auto id = mclab.getEventID();
-    if (id<firstEventID) firstEventID=id;
-    if (id>lastEventID) lastEventID=id;
+    if (id < firstEventID)
+      firstEventID = id;
+    if (id > lastEventID)
+      lastEventID = id;
   }
 
-  for (Int_t mcEv=firstEventID; mcEv <= lastEventID; ++mcEv) {
+  for (Int_t mcEv = firstEventID; mcEv <= lastEventID; ++mcEv) {
     mTree->GetEvent(mcEv);
-    Double_t vx=mHeader->GetX(); 
-    Double_t vy=mHeader->GetY(); 
-    Double_t vz=mHeader->GetZ(); 
-    vertices.emplace_back(std::array<Double_t,3>{vx,vy,vz});
-    LOG(INFO) << "TrivialVertexer::process() : " 
-              <<"MC event #"<<mcEv<<" with vertex ("<<vx<<','<<vy<<','<<vz<<')'
-              << FairLogger::endl;
+    Double_t vx = mHeader->GetX();
+    Double_t vy = mHeader->GetY();
+    Double_t vz = mHeader->GetZ();
+    vertices.emplace_back(std::array<Double_t, 3>{ vx, vy, vz });
+    LOG(INFO) << "TrivialVertexer::process() : "
+              << "MC event #" << mcEv << " with vertex (" << vx << ',' << vy << ',' << vz << ')' << FairLogger::endl;
   }
-
 }

--- a/macro/run_sim_its_ALP3.C
+++ b/macro/run_sim_its_ALP3.C
@@ -17,17 +17,16 @@
 #include "ITSSimulation/Detector.h"
 #endif
 
-extern TSystem *gSystem;
+extern TSystem* gSystem;
 
 void run_sim_its_ALP3(Int_t nEvents = 10, TString mcEngine = "TGeant3")
 {
   TString dir = getenv("VMCWORKDIR");
   TString geom_dir = dir + "/Detectors/Geometry/";
-  gSystem->Setenv("GEOMPATH",geom_dir.Data());
-
+  gSystem->Setenv("GEOMPATH", geom_dir.Data());
 
   TString tut_configdir = dir + "/Detectors/gconfig";
-  gSystem->Setenv("CONFIG_DIR",tut_configdir.Data());
+  gSystem->Setenv("CONFIG_DIR", tut_configdir.Data());
 
   // Output file name
   char fileout[100];
@@ -53,7 +52,6 @@ void run_sim_its_ALP3(Int_t nEvents = 10, TString mcEngine = "TGeant3")
   //   cdbManager->setDefaultStorage("local://$ALICEO2/tpc/dirty/o2cdb");
   //   cdbManager->setRun(0);
 
-
   // Create simulation run
   FairRunSim* run = new FairRunSim();
   run->SetName(mcEngine);      // Transport engine
@@ -72,7 +70,7 @@ void run_sim_its_ALP3(Int_t nEvents = 10, TString mcEngine = "TGeant3")
    field.SetField(0., 0., 5.); //in kG
    field.SetFieldRegion(-5000.,5000.,-5000.,5000.,-5000.,5000.); //in c
   */
-  o2::field::MagneticField field("field","field +5kG");
+  o2::field::MagneticField field("field", "field +5kG");
   run->SetField(&field);
 
   o2::ITS::Detector* its = new o2::ITS::Detector(kTRUE);
@@ -82,10 +80,10 @@ void run_sim_its_ALP3(Int_t nEvents = 10, TString mcEngine = "TGeant3")
   FairPrimaryGenerator* primGen = new FairPrimaryGenerator();
   primGen->SetTarget(0., 3.);
   primGen->SmearGausVertexZ(kTRUE);
-  FairBoxGenerator* boxGen = new FairBoxGenerator(211, 100); //pions
+  FairBoxGenerator* boxGen = new FairBoxGenerator(211, 100); // pions
 
-  //boxGen->SetThetaRange(0.0, 90.0);
-  boxGen->SetEtaRange(-0.9,0.9);
+  // boxGen->SetThetaRange(0.0, 90.0);
+  boxGen->SetEtaRange(-0.9, 0.9);
   boxGen->SetPtRange(1, 1.01);
   boxGen->SetPhiRange(0., 360.);
   boxGen->SetDebug(kFALSE);
@@ -95,7 +93,7 @@ void run_sim_its_ALP3(Int_t nEvents = 10, TString mcEngine = "TGeant3")
   run->SetGenerator(primGen);
 
   // store track trajectories
-  //run->SetStoreTraj(kTRUE);
+  // run->SetStoreTraj(kTRUE);
 
   // Initialize simulation run
   run->Init();

--- a/macro/run_sim_its_ALP3.C
+++ b/macro/run_sim_its_ALP3.C
@@ -80,6 +80,8 @@ void run_sim_its_ALP3(Int_t nEvents = 10, TString mcEngine = "TGeant3")
 
   // Create PrimaryGenerator
   FairPrimaryGenerator* primGen = new FairPrimaryGenerator();
+  primGen->SetTarget(0., 3.);
+  primGen->SmearGausVertexZ(kTRUE);
   FairBoxGenerator* boxGen = new FairBoxGenerator(211, 100); //pions
 
   //boxGen->SetThetaRange(0.0, 90.0);

--- a/macro/run_trac_its.C
+++ b/macro/run_trac_its.C
@@ -17,7 +17,8 @@
 
 static std::stringstream mcfile;
 
-void run_trac_its(float rate = 0., std::string outputfile = "o2track_its.root", std::string inputfile = "o2clus.root", std::string paramfile = "o2sim_par.root");
+void run_trac_its(float rate = 0., std::string outputfile = "o2track_its.root", std::string inputfile = "o2clus.root",
+                  std::string paramfile = "o2sim_par.root");
 
 void run_trac_its(Int_t nEvents, TString mcEngine = "TGeant3", float rate = 0.)
 {

--- a/macro/run_trac_its.C
+++ b/macro/run_trac_its.C
@@ -11,11 +11,13 @@
 #include "FairSystemInfo.h"
 #include "Field/MagneticField.h"
 
+#include "ITSReconstruction/TrivialVertexer.h"
 #include "ITSReconstruction/CookedTrackerTask.h"
 #endif
 
-void run_trac_its(float rate = 0., std::string outputfile = "o2track_its.root", std::string inputfile = "o2clus.root",
-                  std::string paramfile = "o2sim_par.root");
+static std::stringstream mcfile;
+
+void run_trac_its(float rate = 0., std::string outputfile = "o2track_its.root", std::string inputfile = "o2clus.root", std::string paramfile = "o2sim_par.root");
 
 void run_trac_its(Int_t nEvents, TString mcEngine = "TGeant3", float rate = 0.)
 {
@@ -26,6 +28,7 @@ void run_trac_its(Int_t nEvents, TString mcEngine = "TGeant3", float rate = 0.)
   inputfile << "AliceO2_" << mcEngine << ".clus_" << nEvents << "_event.root";
   paramfile << "AliceO2_" << mcEngine << ".params_" << nEvents << ".root";
   outputfile << "AliceO2_" << mcEngine << ".trac_" << nEvents << "_event.root";
+  mcfile << "AliceO2_" << mcEngine << ".mc_" << nEvents << "_event.root";
   run_trac_its(rate, outputfile.str(), inputfile.str(), paramfile.str());
 }
 
@@ -56,6 +59,9 @@ void run_trac_its(float rate, std::string outputfile, std::string inputfile, std
   Bool_t mcTruth = kTRUE; // kFALSE if no comparison with MC is needed
   o2::ITS::CookedTrackerTask* trac = new o2::ITS::CookedTrackerTask(n, mcTruth);
   trac->setContinuousMode(rate > 0.);
+
+  o2::ITS::TrivialVertexer& vertexer = trac->getVertexer();
+  vertexer.openInputFile(mcfile.str().c_str());
 
   fRun->AddTask(trac);
 


### PR DESCRIPTION
This PR opens the possibility to do basic performance studies on events with randomly distributed primary vertices.  The simulation, reconstruction and comparison work in both triggered and continuous readout mode.  The information about the primary vertices is passed to the tracking via a "primary vertexer".   Limitation of the moment :  this vertexer (TrivialVertexer) takes the vertices directly from the MC.