### PR TITLE
Add --timeout option to DPL

### DIFF
--- a/Framework/Core/src/DriverInfo.h
+++ b/Framework/Core/src/DriverInfo.h
@@ -11,6 +11,7 @@
 #ifndef FRAMEWORK_DRIVER_INFO_H
 #define FRAMEWORK_DRIVER_INFO_H
 
+#include <chrono>
 #include <cstddef>
 #include <map>
 #include <vector>
@@ -93,6 +94,11 @@ struct DriverInfo {
   char** argv;
   /// Whether the driver was started in batch mode or not.
   bool batch;
+  /// The offset at which the process was started.
+  std::chrono::time_point<std::chrono::steady_clock> startTime;
+  /// The optional timeout after which the driver will request
+  /// all the children to quit.
+  double timeout;
 };
 
 } // namespace framework


### PR DESCRIPTION
It's now possible to quit any workflow after a predetermined amount of
time by using the --timeout <period> option. The option will trigger a
graceful exit after the period has ellapsed.