### PR TITLE
Add playground for Apache Arrow examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,8 @@ ELSE (NOT ALICEO2_MODULAR_BUILD)
   find_package(Boost REQUIRED)
 ENDIF (NOT ALICEO2_MODULAR_BUILD)
 
+find_package(Arrow)
+
 # Load some basic macros which are needed later on
 include(O2Utils)
 include(O2Dependencies)

--- a/Framework/ArrowTests/CMakeLists.txt
+++ b/Framework/ArrowTests/CMakeLists.txt
@@ -1,0 +1,33 @@
+# Copyright CERN and copyright holders of ALICE O2. This software is
+# distributed under the terms of the GNU General Public License v3 (GPL
+# Version 3), copied verbatim in the file "COPYING".
+#
+# See https://alice-o2.web.cern.ch/ for full licensing information.
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+set(MODULE_NAME "ArrowTests")
+set(MODULE_BUCKET_NAME arrow_bucket)
+
+O2_SETUP(NAME ${MODULE_NAME})
+set(SRCS
+    src/dummy.cxx
+   )
+
+## TODO: feature of macro, it deletes the variables we pass to it, set them again
+## this has to be fixed in the macro implementation
+set(LIBRARY_NAME ${MODULE_NAME})
+set(BUCKET_NAME ${MODULE_BUCKET_NAME})
+
+O2_GENERATE_LIBRARY()
+
+
+O2_GENERATE_TESTS(
+  MODULE_LIBRARY_NAME ${LIBRARY_NAME}
+  BUCKET_NAME ${BUCKET_NAME}
+  TEST_SRCS "test/test_Arrow01.cxx"
+)
+
+target_compile_options(test_ArrowTests_test_Arrow01 PUBLIC -O0 -g -fno-omit-frame-pointer)

--- a/Framework/ArrowTests/src/dummy.cxx
+++ b/Framework/ArrowTests/src/dummy.cxx
@@ -1,0 +1,9 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.

--- a/Framework/ArrowTests/test/test_Arrow01.cxx
+++ b/Framework/ArrowTests/test/test_Arrow01.cxx
@@ -1,0 +1,53 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#define BOOST_TEST_MODULE Test Framework WorkflowHelpers
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+
+#include <arrow/builder.h>
+#include <arrow/array.h>
+#include <arrow/compute/kernel.h>
+#include <arrow/compute/context.h>
+#include <memory>
+#include <iostream>
+
+class ARROW_EXPORT PrintingKernel : public arrow::compute::UnaryKernel
+{
+ public:
+  virtual arrow::Status Call(arrow::compute::FunctionContext* ctx, const arrow::compute::Datum& input,
+                             arrow::compute::Datum* output)
+  {
+    return arrow::Status::OK();
+  }
+};
+
+BOOST_AUTO_TEST_CASE(TestArrow01)
+{
+  arrow::Int64Builder builder;
+  builder.Append(1);
+  builder.Append(2);
+  builder.Append(3);
+  builder.AppendNull();
+  builder.Append(5);
+  builder.Append(6);
+  builder.Append(7);
+  builder.Append(8);
+
+  std::shared_ptr<arrow::Array> input;
+  builder.Finish(&input);
+
+  std::shared_ptr<arrow::Array> output;
+  PrintingKernel kernel;
+  arrow::compute::FunctionContext ctx(arrow::default_memory_pool());
+  auto status = kernel.Call(&ctx, arrow::compute::Datum(input), nullptr);
+  assert(status.ok() == true);
+}

--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -1,6 +1,9 @@
 add_subdirectory(Core)
 add_subdirectory(TestWorkflows)
 # FIXME: only run if glfw3 is detected.
+if(ARROW_FOUND)
+add_subdirectory(ArrowTests)
+endif()
 if(GLFW_FOUND)
 add_subdirectory(DebugGUI)
 endif()

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -106,6 +106,18 @@ o2_define_bucket(
 
 o2_define_bucket(
     NAME
+    arrow_bucket
+
+    DEPENDENCIES
+    common_boost_bucket
+    ${ARROW_SHARED_LIB}
+
+    SYSTEMINCLUDE_DIRECTORIES
+    ${ARROW_INCLUDE_DIR}
+  )
+
+o2_define_bucket(
+    NAME
     ExampleModule1_bucket
 
     DEPENDENCIES # library names and other buckets

--- a/cmake/modules/FindArrow.cmake
+++ b/cmake/modules/FindArrow.cmake
@@ -1,0 +1,122 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# - Find ARROW (arrow/api.h, libarrow.a, libarrow.so)
+# This module defines
+#  ARROW_INCLUDE_DIR, directory containing headers
+#  ARROW_STATIC_LIB, path to libarrow.a
+#  ARROW_SHARED_LIB, path to libarrow's shared library
+#  ARROW_FOUND, whether arrow has been found
+
+if (DEFINED ENV{ARROW_HOME})
+  set(ARROW_HOME "$ENV{ARROW_HOME}")
+endif()
+
+if ("${ARROW_HOME}" STREQUAL "")
+  # PARQUET-955. If the user has set $ARROW_HOME in the environment, we respect
+  # this, otherwise try to locate the pkgconfig in the system environment
+  if (ARROW_FOUND)
+    # We found the pkgconfig
+    set(ARROW_INCLUDE_DIR ${ARROW_INCLUDE_DIRS})
+
+    if (COMMAND pkg_get_variable)
+      pkg_get_variable(ARROW_ABI_VERSION arrow abi_version)
+    else()
+      set(ARROW_ABI_VERSION "")
+    endif()
+    if (ARROW_ABI_VERSION STREQUAL "")
+      set(ARROW_SHARED_LIB_SUFFIX "")
+    else()
+      set(ARROW_SHARED_LIB_SUFFIX ".${ARROW_ABI_VERSION}")
+    endif()
+
+    set(ARROW_LIB_NAME ${CMAKE_SHARED_LIBRARY_PREFIX}arrow)
+
+    if (APPLE)
+      set(ARROW_SHARED_LIB ${ARROW_LIBDIR}/${ARROW_LIB_NAME}${ARROW_SHARED_LIB_SUFFIX}${CMAKE_SHARED_LIBRARY_SUFFIX})
+    else()
+      set(ARROW_SHARED_LIB ${ARROW_LIBDIR}/${ARROW_LIB_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}${ARROW_SHARED_LIB_SUFFIX})
+    endif()
+    set(ARROW_STATIC_LIB ${ARROW_LIBDIR}/${ARROW_LIB_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX})
+  endif()
+else()
+  set(ARROW_HOME "${ARROW_HOME}")
+
+  if (MSVC AND NOT ARROW_MSVC_STATIC_LIB_SUFFIX)
+    set(ARROW_MSVC_STATIC_LIB_SUFFIX _static)
+  endif()
+
+  set(ARROW_SEARCH_HEADER_PATHS
+    ${ARROW_HOME}/include
+    )
+
+  set(ARROW_SEARCH_LIB_PATH
+    ${ARROW_HOME}/lib
+    )
+
+  find_path(ARROW_INCLUDE_DIR arrow/array.h PATHS
+    ${ARROW_SEARCH_HEADER_PATHS}
+    # make sure we don't accidentally pick up a different version
+    NO_DEFAULT_PATH
+    )
+
+  find_library(ARROW_LIB_PATH NAMES arrow arrow${ARROW_MSVC_STATIC_LIB_SUFFIX}
+    PATHS
+    ${ARROW_SEARCH_LIB_PATH}
+    NO_DEFAULT_PATH)
+
+  if (ARROW_INCLUDE_DIR AND (PARQUET_MINIMAL_DEPENDENCY OR ARROW_LIB_PATH))
+    set(ARROW_FOUND TRUE)
+    set(ARROW_HEADER_NAME arrow/api.h)
+    set(ARROW_HEADER ${ARROW_INCLUDE_DIR}/${ARROW_HEADER_NAME})
+    set(ARROW_LIB_NAME arrow)
+
+    get_filename_component(ARROW_LIBS ${ARROW_LIB_PATH} DIRECTORY)
+    set(ARROW_STATIC_LIB ${ARROW_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${ARROW_LIB_NAME}${ARROW_MSVC_STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX})
+    set(ARROW_SHARED_LIB ${ARROW_LIBS}/${CMAKE_SHARED_LIBRARY_PREFIX}${ARROW_LIB_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX})
+    set(ARROW_SHARED_IMPLIB ${ARROW_LIBS}/${ARROW_LIB_NAME}.lib)
+  endif ()
+endif()
+
+if (ARROW_FOUND)
+  if (NOT Arrow_FIND_QUIETLY)
+    message(STATUS "Arrow include path: ${ARROW_INCLUDE_DIR}")
+    if (PARQUET_MINIMAL_DEPENDENCY)
+      message(STATUS "Found the Arrow header: ${ARROW_HEADER}")
+    else ()
+      message(STATUS "Found the Arrow library: ${ARROW_LIB_PATH}")
+    endif ()
+  endif ()
+else()
+  if (NOT Arrow_FIND_QUIETLY)
+    set(ARROW_ERR_MSG "Could not find the Arrow library. Looked for headers")
+    set(ARROW_ERR_MSG "${ARROW_ERR_MSG} in ${ARROW_SEARCH_HEADER_PATHS}, and for libs")
+    set(ARROW_ERR_MSG "${ARROW_ERR_MSG} in ${ARROW_SEARCH_LIB_PATH}")
+    if (Arrow_FIND_REQUIRED)
+      message(FATAL_ERROR "${ARROW_ERR_MSG}")
+    else (Arrow_FIND_REQUIRED)
+      message(STATUS "${ARROW_ERR_MSG}")
+    endif (Arrow_FIND_REQUIRED)
+  endif ()
+endif()
+
+mark_as_advanced(
+  ARROW_FOUND
+  ARROW_INCLUDE_DIR
+  ARROW_STATIC_LIB
+  ARROW_SHARED_LIB
+)


### PR DESCRIPTION
This adds a package as a playground for Apache Arrow and does
all the ancillary related work.