### PR TITLE
Update Data Sampling

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -37,6 +37,8 @@ set(SRCS
     src/DeviceSpec.cxx
     src/DeviceSpecHelpers.cxx
     src/DDSConfigHelpers.cxx
+    src/DispatcherDPL.cxx
+    src/DispatcherFairMQ.cxx
     src/DriverControl.cxx
     src/DriverInfo.cxx
     src/FairOptionsRetriever.cxx

--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -39,6 +39,7 @@ set(SRCS
     src/DDSConfigHelpers.cxx
     src/DispatcherDPL.cxx
     src/DispatcherFairMQ.cxx
+    src/DispatcherFlpProto.cxx
     src/DriverControl.cxx
     src/DriverInfo.cxx
     src/FairOptionsRetriever.cxx

--- a/Framework/Core/include/Framework/DataSampling.h
+++ b/Framework/Core/include/Framework/DataSampling.h
@@ -32,8 +32,6 @@
 #include "Framework/DispatcherFlpProto.h"
 #include "Framework/DataSamplingConfig.h"
 
-
-
 namespace o2
 {
 namespace framework
@@ -49,6 +47,7 @@ using namespace o2::framework::DataSamplingConfig;
 /// inputs/outputs in configuration file.
 ///
 /// In-code usage:
+/// \code{.cxx}
 /// void defineDataProcessing(std::vector<DataProcessorSpec> &workflow)
 /// {
 ///
@@ -58,6 +57,7 @@ using namespace o2::framework::DataSamplingConfig;
 /// DataSampling::GenerateInfrastructure(workflow, configurationFilePath);
 ///
 /// }
+/// \endcode
 
 class DataSampling
 {
@@ -73,11 +73,10 @@ class DataSampling
  private:
   using SubSpecificationType = o2::header::DataHeader::SubSpecificationType;
 
-
   // Internal functions, used by GenerateInfrastructure()
   static auto getEdgeMatcher(const QcTaskConfiguration& taskCfg);
   static std::unique_ptr<Dispatcher> createDispatcher(SubSpecificationType subSpec, const QcTaskConfiguration& taskCfg,
-                                                        InfrastructureConfig infCfg);
+                                                      InfrastructureConfig infCfg);
   static QcTaskConfigurations readQcTasksConfiguration(const std::string& configurationSource);
   static InfrastructureConfig readInfrastructureConfiguration(const std::string& configurationSource);
 };

--- a/Framework/Core/include/Framework/DataSampling.h
+++ b/Framework/Core/include/Framework/DataSampling.h
@@ -71,9 +71,11 @@ class DataSampling
  private:
   using SubSpecificationType = o2::header::DataHeader::SubSpecificationType;
 
+
   // Internal functions, used by GenerateInfrastructure()
   static auto getEdgeMatcher(const QcTaskConfiguration& taskCfg);
-  static auto getDispatcherCreator(const QcTaskConfiguration& taskCfg);
+  static std::unique_ptr<Dispatcher> createDispatcher(SubSpecificationType subSpec, const QcTaskConfiguration& taskCfg,
+                                                        InfrastructureConfig infCfg);
   static QcTaskConfigurations readQcTasksConfiguration(const std::string& configurationSource);
   static InfrastructureConfig readInfrastructureConfiguration(const std::string& configurationSource);
 };

--- a/Framework/Core/include/Framework/DataSampling.h
+++ b/Framework/Core/include/Framework/DataSampling.h
@@ -29,6 +29,7 @@
 #include "Framework/Dispatcher.h"
 #include "Framework/DispatcherDPL.h"
 #include "Framework/DispatcherFairMQ.h"
+#include "Framework/DispatcherFlpProto.h"
 #include "Framework/DataSamplingConfig.h"
 
 namespace o2

--- a/Framework/Core/include/Framework/DataSampling.h
+++ b/Framework/Core/include/Framework/DataSampling.h
@@ -32,6 +32,8 @@
 #include "Framework/DispatcherFlpProto.h"
 #include "Framework/DataSamplingConfig.h"
 
+using namespace o2::framework::DataSamplingConfig;
+
 namespace o2
 {
 namespace framework
@@ -68,9 +70,6 @@ class DataSampling
 
  private:
   using SubSpecificationType = o2::header::DataHeader::SubSpecificationType;
-  using QcTaskConfiguration = DataSamplingConfig::QcTaskConfiguration;
-  using QcTaskConfigurations = std::vector<QcTaskConfiguration>;
-  using InfrastructureConfig = DataSamplingConfig::InfrastructureConfig;
 
   // Internal functions, used by GenerateInfrastructure()
   static auto getEdgeMatcher(const QcTaskConfiguration& taskCfg);

--- a/Framework/Core/include/Framework/DataSampling.h
+++ b/Framework/Core/include/Framework/DataSampling.h
@@ -32,12 +32,14 @@
 #include "Framework/DispatcherFlpProto.h"
 #include "Framework/DataSamplingConfig.h"
 
-using namespace o2::framework::DataSamplingConfig;
+
 
 namespace o2
 {
 namespace framework
 {
+
+using namespace o2::framework::DataSamplingConfig;
 
 /// A class responsible for providing data from main processing flow to QC tasks.
 ///

--- a/Framework/Core/include/Framework/DataSamplingConfig.h
+++ b/Framework/Core/include/Framework/DataSamplingConfig.h
@@ -48,6 +48,7 @@ struct QcTaskConfiguration {
   std::vector<InputSpec> desiredDataSpecs;
   SubSpecificationType subSpec;
   double fractionOfDataToSample;
+  std::string dispatcherType;
   std::string fairMqOutputChannelConfig;
 };
 using QcTaskConfigurations = std::vector<QcTaskConfiguration>;

--- a/Framework/Core/include/Framework/DataSamplingConfig.h
+++ b/Framework/Core/include/Framework/DataSamplingConfig.h
@@ -11,6 +11,11 @@
 #ifndef ALICEO2_DATASAMPLINGCONFIG_H
 #define ALICEO2_DATASAMPLINGCONFIG_H
 
+/// \file DataSamplingConfig.h
+/// \brief Helper structures for O2 Data Sampling configuration
+///
+/// \author Piotr Konopka, piotr.jan.konopka@cern.ch
+
 #include <vector>
 #include <string>
 
@@ -22,7 +27,9 @@ namespace o2
 {
 namespace framework
 {
+// consider: make that just a boost variable map?
 
+/// A bunch of helper structures for DataSampling configuration.
 namespace DataSamplingConfig
 {
 using SubSpecificationType = o2::header::DataHeader::SubSpecificationType;
@@ -43,6 +50,7 @@ struct QcTaskConfiguration {
   double fractionOfDataToSample;
   std::string fairMqOutputChannelConfig;
 };
+using QcTaskConfigurations = std::vector<QcTaskConfiguration>;
 
 /// Structure that holds general data sampling infrastructure configuration
 struct InfrastructureConfig {

--- a/Framework/Core/include/Framework/DataSamplingConfig.h
+++ b/Framework/Core/include/Framework/DataSamplingConfig.h
@@ -1,0 +1,62 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_DATASAMPLINGCONFIG_H
+#define ALICEO2_DATASAMPLINGCONFIG_H
+
+#include <vector>
+#include <string>
+
+#include "Framework/InputSpec.h"
+#include "Framework/OutputSpec.h"
+#include "Headers/DataHeader.h"
+
+namespace o2
+{
+namespace framework
+{
+
+namespace DataSamplingConfig
+{
+using SubSpecificationType = o2::header::DataHeader::SubSpecificationType;
+
+/// Structure that holds requirements for external FairMQ data. Probably temporary.
+struct FairMqInput {
+  OutputSpec outputSpec;
+  std::string channelConfig;
+  std::string converterType;
+};
+
+/// Structure that holds QC task requirements for sampled data.
+struct QcTaskConfiguration {
+  std::string name;
+  std::vector<FairMqInput> desiredFairMqData; // for temporary feature
+  std::vector<InputSpec> desiredDataSpecs;
+  SubSpecificationType subSpec;
+  double fractionOfDataToSample;
+  std::string fairMqOutputChannelConfig;
+};
+
+/// Structure that holds general data sampling infrastructure configuration
+struct InfrastructureConfig {
+  bool enableTimePipeliningDispatchers;
+  bool enableParallelDispatchers;
+  bool enableProxy;
+
+  InfrastructureConfig()
+    : enableTimePipeliningDispatchers(false), enableParallelDispatchers(false), enableProxy(false){};
+};
+
+} // namespace DataSamplingConfig
+
+} // namespace framework
+} // namespace o2
+
+#endif // ALICEO2_DATASAMPLINGCONFIG_H

--- a/Framework/Core/include/Framework/Dispatcher.h
+++ b/Framework/Core/include/Framework/Dispatcher.h
@@ -21,14 +21,14 @@
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/DataSamplingConfig.h"
 
-using namespace o2::framework;
-using namespace o2::framework::DataSamplingConfig;
-using SubSpecificationType = o2::header::DataHeader::SubSpecificationType;
-
 namespace o2
 {
 namespace framework
 {
+
+using namespace o2::framework;
+using namespace o2::framework::DataSamplingConfig;
+using SubSpecificationType = o2::header::DataHeader::SubSpecificationType;
 
 /// \brief A base class for dispatcher used by DataSampling.
 ///

--- a/Framework/Core/include/Framework/Dispatcher.h
+++ b/Framework/Core/include/Framework/Dispatcher.h
@@ -1,0 +1,91 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_DISPATCHER_H
+#define ALICEO2_DISPATCHER_H
+
+#include <random>
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/DataSamplingConfig.h"
+
+using namespace o2::framework;
+using namespace o2::framework::DataSamplingConfig;
+using SubSpecificationType = o2::header::DataHeader::SubSpecificationType;
+
+namespace o2
+{
+namespace framework
+{
+
+class Dispatcher
+{
+ public:
+  Dispatcher() = delete;
+  Dispatcher(const SubSpecificationType dispatcherSubSpec, const QcTaskConfiguration& task,
+             const InfrastructureConfig& cfg)
+    : mSubSpec(dispatcherSubSpec),
+      mCfg(cfg),
+      mDataProcessorSpec()
+  {}
+  virtual ~Dispatcher() = default;
+
+  DataProcessorSpec getDataProcessorSpec() { return mDataProcessorSpec; };
+  SubSpecificationType getSubSpec() { return mSubSpec; };
+  virtual void addSource(const DataProcessorSpec& externalDataProcessor, const OutputSpec& externalOutput,
+                         const std::string& binding) = 0;
+
+ protected:
+  /// Bernoulli distribution pseudo-random numbers generator. Used to decide, which data should be bypassed to
+  /// QC tasks, in order to achieve certain fraction of data passing through. For example, generator initialized with
+  /// value 0.1 returns true *approximately* once per 10 times.
+  class BernoulliGenerator
+  {
+   public:
+    BernoulliGenerator(double probabilityOfTrue = 1.0,
+                       unsigned int seed = (unsigned int)std::chrono::system_clock::now().time_since_epoch().count())
+      : mGenerator(seed),
+        mDistribution(probabilityOfTrue){};
+    bool drawLots() { return mDistribution(mGenerator); }
+
+   private:
+    std::default_random_engine mGenerator;
+    std::bernoulli_distribution mDistribution;
+  };
+
+  /// Creates dispatcher output specification basing on input specification of the same data. Basically, it adds '_S' at
+  /// the end of description, which makes data stream distinctive from the main flow (which is not sampled/filtered).
+  static OutputSpec createDispatcherOutputSpec(const InputSpec& dispatcherInput)
+  {
+    header::DataDescription description = dispatcherInput.description;
+    size_t len = strlen(description.str);
+    if (len < description.size - 2) {
+      description.str[len] = '_';
+      description.str[len + 1] = 'S';
+    }
+
+    return OutputSpec{
+      dispatcherInput.origin,
+      description,
+      0,
+      static_cast<OutputSpec::Lifetime>(dispatcherInput.lifetime)
+    };
+  }
+
+ protected:
+  SubSpecificationType mSubSpec;
+  InfrastructureConfig mCfg;
+  DataProcessorSpec mDataProcessorSpec;
+};
+
+} // namespace framework
+} // namespace o2
+
+#endif // ALICEO2_DISPATCHER_H

--- a/Framework/Core/include/Framework/Dispatcher.h
+++ b/Framework/Core/include/Framework/Dispatcher.h
@@ -34,7 +34,9 @@ class Dispatcher
     : mSubSpec(dispatcherSubSpec),
       mCfg(cfg),
       mDataProcessorSpec()
-  {}
+  {
+    mDataProcessorSpec.name = "Dispatcher" + std::to_string(dispatcherSubSpec) + "_for_" + task.name;
+  }
   virtual ~Dispatcher() = default;
 
   DataProcessorSpec getDataProcessorSpec() { return mDataProcessorSpec; };

--- a/Framework/Core/include/Framework/Dispatcher.h
+++ b/Framework/Core/include/Framework/Dispatcher.h
@@ -44,9 +44,7 @@ class Dispatcher
   /// \brief Constructor.
   Dispatcher(const SubSpecificationType dispatcherSubSpec, const QcTaskConfiguration& task,
              const InfrastructureConfig& cfg)
-    : mSubSpec(dispatcherSubSpec),
-      mCfg(cfg),
-      mDataProcessorSpec()
+    : mSubSpec(dispatcherSubSpec), mCfg(cfg), mDataProcessorSpec()
   {
     mDataProcessorSpec.name = "Dispatcher" + std::to_string(dispatcherSubSpec) + "_for_" + task.name;
   }
@@ -72,8 +70,7 @@ class Dispatcher
    public:
     BernoulliGenerator(double probabilityOfTrue = 1.0,
                        unsigned int seed = (unsigned int)std::chrono::system_clock::now().time_since_epoch().count())
-      : mGenerator(seed),
-        mDistribution(probabilityOfTrue){};
+      : mGenerator(seed), mDistribution(probabilityOfTrue){};
     bool drawLots() { return mDistribution(mGenerator); }
 
    private:
@@ -92,12 +89,8 @@ class Dispatcher
       description.str[len + 1] = 'S';
     }
 
-    return OutputSpec{
-      dispatcherInput.origin,
-      description,
-      0,
-      static_cast<OutputSpec::Lifetime>(dispatcherInput.lifetime)
-    };
+    return OutputSpec{ dispatcherInput.origin, description, 0,
+                       static_cast<OutputSpec::Lifetime>(dispatcherInput.lifetime) };
   }
 
  protected:

--- a/Framework/Core/include/Framework/Dispatcher.h
+++ b/Framework/Core/include/Framework/Dispatcher.h
@@ -11,6 +11,11 @@
 #ifndef ALICEO2_DISPATCHER_H
 #define ALICEO2_DISPATCHER_H
 
+/// \file Dispatcher.h
+/// \brief Definition of Dispatcher for O2 Data Sampling
+///
+/// \author Piotr Konopka, piotr.jan.konopka@cern.ch
+
 #include <random>
 
 #include "Framework/DataProcessorSpec.h"
@@ -25,10 +30,18 @@ namespace o2
 namespace framework
 {
 
+/// \brief A base class for dispatcher used by DataSampling.
+///
+/// An abstract class to be inherited by different implementations of Data Sampling dispatchers. It is responsible
+/// initializing some common class members and includes some functionalities used by all of children dispatchers.
+/// The algorithm implementation and adding new data source is left to child class.
+
 class Dispatcher
 {
  public:
+  /// \brief Deleted default constructor
   Dispatcher() = delete;
+  /// \brief Constructor.
   Dispatcher(const SubSpecificationType dispatcherSubSpec, const QcTaskConfiguration& task,
              const InfrastructureConfig& cfg)
     : mSubSpec(dispatcherSubSpec),
@@ -37,14 +50,20 @@ class Dispatcher
   {
     mDataProcessorSpec.name = "Dispatcher" + std::to_string(dispatcherSubSpec) + "_for_" + task.name;
   }
+  /// \brief Destructor
   virtual ~Dispatcher() = default;
 
+  // getters
   DataProcessorSpec getDataProcessorSpec() { return mDataProcessorSpec; };
   SubSpecificationType getSubSpec() { return mSubSpec; };
+
+  /// \brief Function responsible for adding new data source to dispatcher. Needs to be overriden by a child.
   virtual void addSource(const DataProcessorSpec& externalDataProcessor, const OutputSpec& externalOutput,
                          const std::string& binding) = 0;
 
  protected:
+  /// \brief Bernoulli distribution pseudo-random numbers generator.
+  ///
   /// Bernoulli distribution pseudo-random numbers generator. Used to decide, which data should be bypassed to
   /// QC tasks, in order to achieve certain fraction of data passing through. For example, generator initialized with
   /// value 0.1 returns true *approximately* once per 10 times.

--- a/Framework/Core/include/Framework/DispatcherDPL.h
+++ b/Framework/Core/include/Framework/DispatcherDPL.h
@@ -19,13 +19,13 @@
 #include "Framework/Dispatcher.h"
 #include "Framework/DataSamplingConfig.h"
 
-using namespace o2::framework;
-using namespace o2::framework::DataSamplingConfig;
-
 namespace o2
 {
 namespace framework
 {
+
+using namespace o2::framework;
+using namespace o2::framework::DataSamplingConfig;
 
 /// \brief A dispatcher for clients inside Data Processing Layer.
 class DispatcherDPL : public Dispatcher

--- a/Framework/Core/include/Framework/DispatcherDPL.h
+++ b/Framework/Core/include/Framework/DispatcherDPL.h
@@ -1,0 +1,45 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_DISPATCHERDPL_H
+#define ALICEO2_DISPATCHERDPL_H
+
+#include "Framework/Dispatcher.h"
+#include "Framework/DataSamplingConfig.h"
+
+using namespace o2::framework;
+using namespace o2::framework::DataSamplingConfig;
+
+namespace o2
+{
+namespace framework
+{
+
+class DispatcherDPL : public Dispatcher
+{
+
+ public:
+  DispatcherDPL() = delete;
+  DispatcherDPL(const SubSpecificationType dispatcherSubSpec, const QcTaskConfiguration& task,
+                const InfrastructureConfig& cfg);
+  ~DispatcherDPL() override;
+
+  void addSource(const DataProcessorSpec& externalDataProcessor, const OutputSpec& externalOutput,
+                 const std::string& binding) override;
+
+ private:
+  /// Dispatcher callback with DPL outputs
+  static void processCallback(ProcessingContext& ctx, Dispatcher::BernoulliGenerator& bernoulliGenerator);
+};
+
+} // namespace framework
+} // namespace o2
+
+#endif // ALICEO2_DISPATCHERDPL_H

--- a/Framework/Core/include/Framework/DispatcherDPL.h
+++ b/Framework/Core/include/Framework/DispatcherDPL.h
@@ -11,6 +11,11 @@
 #ifndef ALICEO2_DISPATCHERDPL_H
 #define ALICEO2_DISPATCHERDPL_H
 
+/// \file DispatcherDPL.h
+/// \brief Definition of DispatcherDPL for O2 Data Sampling
+///
+/// \author Piotr Konopka, piotr.jan.konopka@cern.ch
+
 #include "Framework/Dispatcher.h"
 #include "Framework/DataSamplingConfig.h"
 
@@ -22,15 +27,19 @@ namespace o2
 namespace framework
 {
 
+/// \brief A dispatcher for clients inside Data Processing Layer.
 class DispatcherDPL : public Dispatcher
 {
 
  public:
-  DispatcherDPL() = delete;
+  /// \brief Constructor.
   DispatcherDPL(const SubSpecificationType dispatcherSubSpec, const QcTaskConfiguration& task,
                 const InfrastructureConfig& cfg);
+  /// \brief Destructor
   ~DispatcherDPL() override;
 
+  /// \brief Function responsible for adding new data source to dispatcher. It has different behaviour dependent
+  /// on infrastructure configuration.
   void addSource(const DataProcessorSpec& externalDataProcessor, const OutputSpec& externalOutput,
                  const std::string& binding) override;
 

--- a/Framework/Core/include/Framework/DispatcherFairMQ.h
+++ b/Framework/Core/include/Framework/DispatcherFairMQ.h
@@ -1,0 +1,49 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_DISPATCHERFAIRMQ_H
+#define ALICEO2_DISPATCHERFAIRMQ_H
+
+#include "Framework/Dispatcher.h"
+#include "Framework/DataSamplingConfig.h"
+
+using namespace o2::framework;
+using namespace o2::framework::DataSamplingConfig;
+
+// class Dispatcher;
+
+namespace o2
+{
+namespace framework
+{
+
+class DispatcherFairMQ : public Dispatcher
+{
+ public:
+  DispatcherFairMQ() = delete;
+  DispatcherFairMQ(const SubSpecificationType dispatcherSubSpec, const QcTaskConfiguration& task,
+                   const InfrastructureConfig& cfg);
+  ~DispatcherFairMQ() override;
+
+  void addSource(const DataProcessorSpec& externalDataProcessor, const OutputSpec& externalOutput,
+                 const std::string& binding) override;
+
+ private:
+  /// Dispatcher init callback
+  static AlgorithmSpec::ProcessCallback initCallback(InitContext& ctx, const std::string& channel, double fraction);
+  /// Dispatcher callback with FairMQ output
+  static void processCallback(ProcessingContext& ctx, Dispatcher::BernoulliGenerator& bernoulliGenerator,
+                              FairMQDevice* device, const std::string& channel);
+};
+
+} // namespace framework
+} // namespace o2
+
+#endif // ALICEO2_DISPATCHERFAIRMQ_H

--- a/Framework/Core/include/Framework/DispatcherFairMQ.h
+++ b/Framework/Core/include/Framework/DispatcherFairMQ.h
@@ -19,13 +19,13 @@
 #include "Framework/Dispatcher.h"
 #include "Framework/DataSamplingConfig.h"
 
-using namespace o2::framework;
-using namespace o2::framework::DataSamplingConfig;
-
 namespace o2
 {
 namespace framework
 {
+
+using namespace o2::framework;
+using namespace o2::framework::DataSamplingConfig;
 
 /// \brief A dispatcher for clients that are FairMQDevices using O2 Data Model.
 ///

--- a/Framework/Core/include/Framework/DispatcherFairMQ.h
+++ b/Framework/Core/include/Framework/DispatcherFairMQ.h
@@ -11,27 +11,37 @@
 #ifndef ALICEO2_DISPATCHERFAIRMQ_H
 #define ALICEO2_DISPATCHERFAIRMQ_H
 
+/// \file DispatcherFairMQ.h
+/// \brief Definition of DispatcherFairMQ for O2 Data Sampling
+///
+/// \author Piotr Konopka, piotr.jan.konopka@cern.ch
+
 #include "Framework/Dispatcher.h"
 #include "Framework/DataSamplingConfig.h"
 
 using namespace o2::framework;
 using namespace o2::framework::DataSamplingConfig;
 
-// class Dispatcher;
-
 namespace o2
 {
 namespace framework
 {
 
+/// \brief A dispatcher for clients that are FairMQDevices using O2 Data Model.
+///
+/// A dispatcher for clients outside of Data Processing Layer, specifically FairMQ devices using O2 Data Model.
+/// For now, it sends only the payload, without the header - it will be added later probably.
+
 class DispatcherFairMQ : public Dispatcher
 {
  public:
-  DispatcherFairMQ() = delete;
+  /// \brief Constructor.
   DispatcherFairMQ(const SubSpecificationType dispatcherSubSpec, const QcTaskConfiguration& task,
                    const InfrastructureConfig& cfg);
+  /// \brief Destructor
   ~DispatcherFairMQ() override;
 
+  /// \brief Function responsible for adding new data source to dispatcher.
   void addSource(const DataProcessorSpec& externalDataProcessor, const OutputSpec& externalOutput,
                  const std::string& binding) override;
 

--- a/Framework/Core/include/Framework/DispatcherFlpProto.h
+++ b/Framework/Core/include/Framework/DispatcherFlpProto.h
@@ -20,13 +20,13 @@
 #include "Framework/DataSamplingConfig.h"
 #include "FairMQDevice.h"
 
-using namespace o2::framework;
-using namespace o2::framework::DataSamplingConfig;
-
 namespace o2
 {
 namespace framework
 {
+
+using namespace o2::framework;
+using namespace o2::framework::DataSamplingConfig;
 
 /// \brief A special dispatcher for QC tasks that are FairMQ devices, using FLP Proto data model.
 class DispatcherFlpProto : public Dispatcher

--- a/Framework/Core/include/Framework/DispatcherFlpProto.h
+++ b/Framework/Core/include/Framework/DispatcherFlpProto.h
@@ -11,6 +11,11 @@
 #ifndef ALICEO2_DISPATCHERFLPPROTO_H
 #define ALICEO2_DISPATCHERFLPPROTO_H
 
+/// \file DispatcherFlpProto.h
+/// \brief Definition of DispatcherFlpProto for O2 Data Sampling
+///
+/// \author Piotr Konopka, piotr.jan.konopka@cern.ch
+
 #include "Framework/Dispatcher.h"
 #include "Framework/DataSamplingConfig.h"
 #include "FairMQDevice.h"
@@ -18,25 +23,27 @@
 using namespace o2::framework;
 using namespace o2::framework::DataSamplingConfig;
 
-// class Dispatcher;
-
 namespace o2
 {
 namespace framework
 {
 
+/// \brief A special dispatcher for QC tasks that are FairMQ devices, using FLP Proto data model.
 class DispatcherFlpProto : public Dispatcher
 {
  public:
-  DispatcherFlpProto() = delete;
+  /// \brief Constructor.
   DispatcherFlpProto(const SubSpecificationType dispatcherSubSpec, const QcTaskConfiguration& task,
                      const InfrastructureConfig& cfg);
+  /// \brief Destructor
   ~DispatcherFlpProto() override;
 
+  /// \brief Function responsible for adding new data source to dispatcher.
   void addSource(const DataProcessorSpec& externalDataProcessor, const OutputSpec& externalOutput,
                  const std::string& binding) override;
 
  private:
+  /// Class used to keep track of protocol state. Expected message order: Header-Payload-Header-Payload-...-EOM
   enum class FlpProtoState { Idle, ExpectingHeaderOrEOM, ExpectingPayload };
   /// Dispatcher init callback
   static AlgorithmSpec::ProcessCallback initCallback(InitContext& ctx, const std::string& channel, double fraction);

--- a/Framework/Core/include/Framework/DispatcherFlpProto.h
+++ b/Framework/Core/include/Framework/DispatcherFlpProto.h
@@ -1,0 +1,51 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_DISPATCHERFLPPROTO_H
+#define ALICEO2_DISPATCHERFLPPROTO_H
+
+#include "Framework/Dispatcher.h"
+#include "Framework/DataSamplingConfig.h"
+#include "FairMQDevice.h"
+
+using namespace o2::framework;
+using namespace o2::framework::DataSamplingConfig;
+
+// class Dispatcher;
+
+namespace o2
+{
+namespace framework
+{
+
+class DispatcherFlpProto : public Dispatcher
+{
+ public:
+  DispatcherFlpProto() = delete;
+  DispatcherFlpProto(const SubSpecificationType dispatcherSubSpec, const QcTaskConfiguration& task,
+                     const InfrastructureConfig& cfg);
+  ~DispatcherFlpProto() override;
+
+  void addSource(const DataProcessorSpec& externalDataProcessor, const OutputSpec& externalOutput,
+                 const std::string& binding) override;
+
+ private:
+  enum class FlpProtoState { Idle, ExpectingHeaderOrEOM, ExpectingPayload };
+  /// Dispatcher init callback
+  static AlgorithmSpec::ProcessCallback initCallback(InitContext& ctx, const std::string& channel, double fraction);
+  /// Dispatcher callback with FairMQ output
+  static void processCallback(ProcessingContext& ctx, Dispatcher::BernoulliGenerator& bernoulliGenerator,
+                              FairMQDevice* device, const std::string& channel, FlpProtoState& state);
+};
+
+} // namespace framework
+} // namespace o2
+
+#endif // ALICEO2_DISPATCHERFLPPROTO_H

--- a/Framework/Core/src/DataSampling.cxx
+++ b/Framework/Core/src/DataSampling.cxx
@@ -105,10 +105,9 @@ void DataSampling::GenerateInfrastructure(WorkflowSpec& workflow, const std::str
             SubSpecificationType dispatcherSubSpec = infrastructureCfg.enableParallelDispatchers ?
                                                      externalOutput.subSpec : 0;
 
-            auto res = std::find_if(dispatchers.begin(), dispatchers.end(),
-                                    [dispatcherSubSpec](const auto& d) {
-                                      return d->getSubSpec() == dispatcherSubSpec;
-                                    });
+            auto res = std::find_if(dispatchers.begin(), dispatchers.end(), [dispatcherSubSpec](const auto& d) {
+              return d->getSubSpec() == dispatcherSubSpec;
+            });
 
             if (res != dispatchers.end()) {
               (*res)->addSource(dataProcessor, externalOutput, desiredData.binding);

--- a/Framework/Core/src/DataSampling.cxx
+++ b/Framework/Core/src/DataSampling.cxx
@@ -216,18 +216,18 @@ void DataSampling::dispatcherCallback(ProcessingContext& ctx, BernoulliGenerator
 
       OutputSpec outputSpec = createDispatcherOutputSpec(*input.spec);
 
-      const auto* inputHeader = Header::get<Header::DataHeader>(input.header);
+      const auto* inputHeader = header::get<header::DataHeader>(input.header);
 
-      if (inputHeader->payloadSerializationMethod == Header::gSerializationMethodInvalid) {
+      /*if (inputHeader->payloadSerializationMethod == header::gSerializationMethodInvalid) {
         LOG(ERROR) << "DataSampling::dispatcherCallback: input of origin'" << inputHeader->dataOrigin.str
                    << "', description '" << inputHeader->dataDescription.str
                    << "' has gSerializationMethodInvalid.";
-      } else if (inputHeader->payloadSerializationMethod == Header::gSerializationMethodROOT) {
+      } else*/ if (inputHeader->payloadSerializationMethod == header::gSerializationMethodROOT) {
         ctx.allocator().adopt(outputSpec, DataRefUtils::as<TObject>(input).release());
       } else { //POD
         //todo: use API for that when it is available
         ctx.allocator().adoptChunk(outputSpec, const_cast<char*>(input.payload), inputHeader->size(),
-                                   &Header::Stack::freefn, nullptr);
+                                   &header::Stack::freefn, nullptr);
       }
 
       LOG(DEBUG) << "DataSampler sends data from subspec " << input.spec->subSpec;
@@ -255,7 +255,7 @@ void DataSampling::dispatcherCallbackFairMQ(ProcessingContext& ctx, BernoulliGen
 
     auto cleanupFcn = [](void* data, void* hint) { delete[] reinterpret_cast<char*>(data); };
     for (auto& input : inputs) {
-      const auto* header = Header::get<header::DataHeader>(input.header);
+      const auto* header = header::get<header::DataHeader>(input.header);
 
       char* payloadCopy = new char[header->payloadSize];
       memcpy(payloadCopy, input.payload, header->payloadSize);

--- a/Framework/Core/src/DataSampling.cxx
+++ b/Framework/Core/src/DataSampling.cxx
@@ -25,6 +25,7 @@
 #include "FairLogger.h"
 
 using namespace o2::framework;
+using namespace o2::framework::DataSamplingConfig;
 using namespace AliceO2::Configuration;
 
 namespace o2 {
@@ -134,9 +135,9 @@ void DataSampling::GenerateInfrastructure(WorkflowSpec& workflow, const std::str
 
 /// Reads QC Tasks configuration from given filepath. Uses Configuration dependency and handles most of its exceptions.
 /// When some obligatory value is missing, it shows ERROR in logs, but continues to read another QC tasks.
-DataSampling::QcTaskConfigurations DataSampling::readQcTasksConfiguration(const std::string& configurationSource)
+QcTaskConfigurations DataSampling::readQcTasksConfiguration(const std::string& configurationSource)
 {
-  std::vector<QcTaskConfiguration> tasks;
+  QcTaskConfigurations tasks;
   std::unique_ptr<ConfigurationInterface> configFile = ConfigurationFactory::getConfiguration(configurationSource);
 
   std::vector<std::string> taskNames;
@@ -226,7 +227,7 @@ DataSampling::QcTaskConfigurations DataSampling::readQcTasksConfiguration(const 
 }
 
 /// Reads general Data Sampling infrastructure configuration.
-DataSampling::InfrastructureConfig DataSampling::readInfrastructureConfiguration(const std::string& configurationSource)
+InfrastructureConfig DataSampling::readInfrastructureConfiguration(const std::string& configurationSource)
 {
 
   InfrastructureConfig cfg;

--- a/Framework/Core/src/DispatcherDPL.cxx
+++ b/Framework/Core/src/DispatcherDPL.cxx
@@ -15,6 +15,9 @@
 
 #include "Framework/DispatcherDPL.h"
 
+namespace o2 {
+namespace framework {
+
 DispatcherDPL::DispatcherDPL(const SubSpecificationType dispatcherSubSpec,
                              const QcTaskConfiguration& task,
                              const InfrastructureConfig& cfg) : Dispatcher(dispatcherSubSpec, task, cfg)
@@ -80,3 +83,6 @@ void DispatcherDPL::addSource(const DataProcessorSpec& externalDataProcessor, co
     mDataProcessorSpec.maxInputTimeslices = externalDataProcessor.maxInputTimeslices;
   }
 }
+
+} // namespace framework
+} // namespace o2

--- a/Framework/Core/src/DispatcherDPL.cxx
+++ b/Framework/Core/src/DispatcherDPL.cxx
@@ -8,6 +8,11 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+/// \file DispatcherDPL.cxx
+/// \brief Implementation of DispatcherDPL for O2 Data Sampling
+///
+/// \author Piotr Konopka, piotr.jan.konopka@cern.ch
+
 #include "Framework/DispatcherDPL.h"
 
 DispatcherDPL::DispatcherDPL(const SubSpecificationType dispatcherSubSpec,

--- a/Framework/Core/src/DispatcherDPL.cxx
+++ b/Framework/Core/src/DispatcherDPL.cxx
@@ -14,16 +14,10 @@ DispatcherDPL::DispatcherDPL(const SubSpecificationType dispatcherSubSpec,
                              const QcTaskConfiguration& task,
                              const InfrastructureConfig& cfg) : Dispatcher(dispatcherSubSpec, task, cfg)
 {
-  mDataProcessorSpec = DataProcessorSpec{
-    "Dispatcher" + std::to_string(dispatcherSubSpec) + "_for_" + task.name,
-    Inputs{},
-    Outputs{},
-    AlgorithmSpec{
-      [gen = Dispatcher::BernoulliGenerator(task.fractionOfDataToSample)](ProcessingContext& ctx) mutable {
-        processCallback(ctx, gen);
-      }
-    }
-  };
+  mDataProcessorSpec.algorithm =
+    AlgorithmSpec{[gen = Dispatcher::BernoulliGenerator(task.fractionOfDataToSample)](ProcessingContext& ctx) mutable {
+      processCallback(ctx, gen);
+    }};
 }
 
 DispatcherDPL::~DispatcherDPL() {}

--- a/Framework/Core/src/DispatcherDPL.cxx
+++ b/Framework/Core/src/DispatcherDPL.cxx
@@ -15,17 +15,19 @@
 
 #include "Framework/DispatcherDPL.h"
 
-namespace o2 {
-namespace framework {
-
-DispatcherDPL::DispatcherDPL(const SubSpecificationType dispatcherSubSpec,
-                             const QcTaskConfiguration& task,
-                             const InfrastructureConfig& cfg) : Dispatcher(dispatcherSubSpec, task, cfg)
+namespace o2
 {
-  mDataProcessorSpec.algorithm =
-    AlgorithmSpec{[gen = Dispatcher::BernoulliGenerator(task.fractionOfDataToSample)](ProcessingContext& ctx) mutable {
-      processCallback(ctx, gen);
-    }};
+namespace framework
+{
+
+DispatcherDPL::DispatcherDPL(const SubSpecificationType dispatcherSubSpec, const QcTaskConfiguration& task,
+                             const InfrastructureConfig& cfg)
+  : Dispatcher(dispatcherSubSpec, task, cfg)
+{
+  mDataProcessorSpec.algorithm = AlgorithmSpec{[gen = Dispatcher::BernoulliGenerator(task.fractionOfDataToSample)](
+    ProcessingContext & ctx) mutable { processCallback(ctx, gen);
+}
+};
 }
 
 DispatcherDPL::~DispatcherDPL() {}

--- a/Framework/Core/src/DispatcherDPL.cxx
+++ b/Framework/Core/src/DispatcherDPL.cxx
@@ -1,0 +1,83 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/DispatcherDPL.h"
+
+DispatcherDPL::DispatcherDPL(const SubSpecificationType dispatcherSubSpec,
+                             const QcTaskConfiguration& task,
+                             const InfrastructureConfig& cfg) : Dispatcher(dispatcherSubSpec, task, cfg)
+{
+  mDataProcessorSpec = DataProcessorSpec{
+    "Dispatcher" + std::to_string(dispatcherSubSpec) + "_for_" + task.name,
+    Inputs{},
+    Outputs{},
+    AlgorithmSpec{
+      [gen = Dispatcher::BernoulliGenerator(task.fractionOfDataToSample)](ProcessingContext& ctx) mutable {
+        processCallback(ctx, gen);
+      }
+    }
+  };
+}
+
+DispatcherDPL::~DispatcherDPL() {}
+
+void DispatcherDPL::processCallback(ProcessingContext& ctx, BernoulliGenerator& bernoulliGenerator)
+{
+  InputRecord& inputs = ctx.inputs();
+
+  if (bernoulliGenerator.drawLots()) {
+    for (auto& input : inputs) {
+
+      OutputSpec outputSpec = createDispatcherOutputSpec(*input.spec);
+
+      const auto* inputHeader = header::get<header::DataHeader>(input.header);
+
+      /*if (inputHeader->payloadSerializationMethod == header::gSerializationMethodInvalid) {
+        LOG(ERROR) << "DataSampling::dispatcherCallback: input of origin'" << inputHeader->dataOrigin.str
+                   << "', description '" << inputHeader->dataDescription.str
+                   << "' has gSerializationMethodInvalid.";
+      } else*/ if (inputHeader->payloadSerializationMethod == header::gSerializationMethodROOT) {
+        ctx.allocator().adopt(outputSpec, DataRefUtils::as<TObject>(input).release());
+      } else { // POD
+        // todo: use API for that when it is available
+        ctx.allocator().adoptChunk(outputSpec, const_cast<char*>(input.payload), inputHeader->size(),
+                                   &header::Stack::freefn, nullptr);
+      }
+
+      LOG(DEBUG) << "DataSampler sends data from subspec " << input.spec->subSpec;
+    }
+  }
+}
+
+void DispatcherDPL::addSource(const DataProcessorSpec& externalDataProcessor, const OutputSpec& externalOutput,
+                              const std::string& binding)
+{
+  InputSpec newInput{
+    binding,
+    externalOutput.origin,
+    externalOutput.description,
+    externalOutput.subSpec,
+    static_cast<InputSpec::Lifetime>(externalOutput.lifetime),
+  };
+
+  mDataProcessorSpec.inputs.push_back(newInput);
+  OutputSpec newOutput = createDispatcherOutputSpec(newInput);
+  if (mCfg.enableParallelDispatchers ||
+      std::find(mDataProcessorSpec.outputs.begin(), mDataProcessorSpec.outputs.end(), newOutput) ==
+        mDataProcessorSpec.outputs.end()) {
+
+    mDataProcessorSpec.outputs.push_back(newOutput);
+  }
+
+  if (mCfg.enableTimePipeliningDispatchers &&
+      mDataProcessorSpec.maxInputTimeslices < externalDataProcessor.maxInputTimeslices) {
+    mDataProcessorSpec.maxInputTimeslices = externalDataProcessor.maxInputTimeslices;
+  }
+}

--- a/Framework/Core/src/DispatcherFairMQ.cxx
+++ b/Framework/Core/src/DispatcherFairMQ.cxx
@@ -1,0 +1,91 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/DispatcherFairMQ.h"
+
+#include "FairLogger.h"
+#include "FairMQDevice.h"
+#include "FairMQTransportFactory.h"
+#include "Framework/SimpleRawDeviceService.h"
+
+DispatcherFairMQ::DispatcherFairMQ(const SubSpecificationType dispatcherSubSpec,
+                                   const QcTaskConfiguration& task,
+                                   const InfrastructureConfig& cfg) : Dispatcher(dispatcherSubSpec, task, cfg)
+{
+
+  //todo: throw an exception when 'name=' not found?
+  size_t nameBegin = task.fairMqOutputChannelConfig.find("name=") + sizeof("name=") - 1;
+  size_t nameEnd = task.fairMqOutputChannelConfig.find_first_of(',', nameBegin);
+  std::string channel = task.fairMqOutputChannelConfig.substr(nameBegin, nameEnd - nameBegin);
+
+  mDataProcessorSpec = DataProcessorSpec{
+    "Dispatcher" + std::to_string(dispatcherSubSpec) + "_for_" + task.name,
+    Inputs{},
+    Outputs{},
+    AlgorithmSpec{
+      [fraction = task.fractionOfDataToSample, channel](InitContext& ctx) {
+        return initCallback(ctx, channel, fraction);
+      }
+    },
+    {
+      ConfigParamSpec{
+        "channel-config", VariantType::String,
+        task.fairMqOutputChannelConfig.c_str(), { "Out-of-band channel config" }}
+    }
+  };
+}
+
+DispatcherFairMQ::~DispatcherFairMQ() {}
+
+AlgorithmSpec::ProcessCallback DispatcherFairMQ::initCallback(InitContext& ctx, const std::string& channel,
+                                                              double fraction)
+{
+  auto device = ctx.services().get<RawDeviceService>().device();
+  auto gen = Dispatcher::BernoulliGenerator(fraction);
+
+  return [gen, device, channel](o2::framework::ProcessingContext& pCtx) mutable {
+    processCallback(pCtx, gen, device, channel);
+  };
+}
+
+void DispatcherFairMQ::processCallback(ProcessingContext& ctx, Dispatcher::BernoulliGenerator& bernoulliGenerator,
+                                       FairMQDevice* device, const std::string& channel)
+{
+  InputRecord& inputs = ctx.inputs();
+
+  if (bernoulliGenerator.drawLots()) {
+
+    auto cleanupFcn = [](void* data, void* hint) { delete[] reinterpret_cast<char*>(data); };
+    for (auto& input : inputs) {
+      const auto* header = header::get<header::DataHeader>(input.header);
+
+      char* payloadCopy = new char[header->payloadSize];
+      memcpy(payloadCopy, input.payload, header->payloadSize);
+      FairMQMessagePtr msgPayload(device->NewMessage(payloadCopy, header->payloadSize, cleanupFcn, payloadCopy));
+
+      int bytesSent = device->Send(msgPayload, channel);
+      LOG(DEBUG) << "Payload bytes sent: " << bytesSent;
+    }
+  }
+}
+
+void DispatcherFairMQ::addSource(const DataProcessorSpec& externalDataProcessor, const OutputSpec& externalOutput,
+                                 const std::string& binding)
+{
+  InputSpec newInput{
+    binding,
+    externalOutput.origin,
+    externalOutput.description,
+    externalOutput.subSpec,
+    static_cast<InputSpec::Lifetime>(externalOutput.lifetime),
+  };
+
+  mDataProcessorSpec.inputs.push_back(newInput);
+}

--- a/Framework/Core/src/DispatcherFairMQ.cxx
+++ b/Framework/Core/src/DispatcherFairMQ.cxx
@@ -25,21 +25,14 @@ DispatcherFairMQ::DispatcherFairMQ(const SubSpecificationType dispatcherSubSpec,
   size_t nameEnd = task.fairMqOutputChannelConfig.find_first_of(',', nameBegin);
   std::string channel = task.fairMqOutputChannelConfig.substr(nameBegin, nameEnd - nameBegin);
 
-  mDataProcessorSpec = DataProcessorSpec{
-    "Dispatcher" + std::to_string(dispatcherSubSpec) + "_for_" + task.name,
-    Inputs{},
-    Outputs{},
-    AlgorithmSpec{
-      [fraction = task.fractionOfDataToSample, channel](InitContext& ctx) {
-        return initCallback(ctx, channel, fraction);
-      }
-    },
-    {
-      ConfigParamSpec{
-        "channel-config", VariantType::String,
-        task.fairMqOutputChannelConfig.c_str(), { "Out-of-band channel config" }}
+  mDataProcessorSpec.algorithm = AlgorithmSpec{
+    [fraction = task.fractionOfDataToSample, channel](InitContext& ctx) {
+      return initCallback(ctx, channel, fraction);
     }
   };
+  mDataProcessorSpec.options.push_back({
+      "channel-config", VariantType::String, task.fairMqOutputChannelConfig.c_str(), { "Out-of-band channel config" }
+    });
 }
 
 DispatcherFairMQ::~DispatcherFairMQ() {}

--- a/Framework/Core/src/DispatcherFairMQ.cxx
+++ b/Framework/Core/src/DispatcherFairMQ.cxx
@@ -20,12 +20,14 @@
 #include "FairMQTransportFactory.h"
 #include "Framework/SimpleRawDeviceService.h"
 
-namespace o2 {
-namespace framework {
+namespace o2
+{
+namespace framework
+{
 
-DispatcherFairMQ::DispatcherFairMQ(const SubSpecificationType dispatcherSubSpec,
-                                   const QcTaskConfiguration& task,
-                                   const InfrastructureConfig& cfg) : Dispatcher(dispatcherSubSpec, task, cfg)
+DispatcherFairMQ::DispatcherFairMQ(const SubSpecificationType dispatcherSubSpec, const QcTaskConfiguration& task,
+                                   const InfrastructureConfig& cfg)
+  : Dispatcher(dispatcherSubSpec, task, cfg)
 {
 
   // todo: throw an exception when 'name=' not found?
@@ -33,14 +35,12 @@ DispatcherFairMQ::DispatcherFairMQ(const SubSpecificationType dispatcherSubSpec,
   size_t nameEnd = task.fairMqOutputChannelConfig.find_first_of(',', nameBegin);
   std::string channel = task.fairMqOutputChannelConfig.substr(nameBegin, nameEnd - nameBegin);
 
-  mDataProcessorSpec.algorithm = AlgorithmSpec{
-    [fraction = task.fractionOfDataToSample, channel](InitContext& ctx) {
-      return initCallback(ctx, channel, fraction);
-    }
-  };
-  mDataProcessorSpec.options.push_back({
-      "channel-config", VariantType::String, task.fairMqOutputChannelConfig.c_str(), { "Out-of-band channel config" }
-    });
+  mDataProcessorSpec.algorithm = AlgorithmSpec{[fraction = task.fractionOfDataToSample, channel](InitContext & ctx){
+    return initCallback(ctx, channel, fraction);
+}
+};
+mDataProcessorSpec.options.push_back(
+  { "channel-config", VariantType::String, task.fairMqOutputChannelConfig.c_str(), { "Out-of-band channel config" } });
 }
 
 DispatcherFairMQ::~DispatcherFairMQ() {}

--- a/Framework/Core/src/DispatcherFairMQ.cxx
+++ b/Framework/Core/src/DispatcherFairMQ.cxx
@@ -20,12 +20,15 @@
 #include "FairMQTransportFactory.h"
 #include "Framework/SimpleRawDeviceService.h"
 
+namespace o2 {
+namespace framework {
+
 DispatcherFairMQ::DispatcherFairMQ(const SubSpecificationType dispatcherSubSpec,
                                    const QcTaskConfiguration& task,
                                    const InfrastructureConfig& cfg) : Dispatcher(dispatcherSubSpec, task, cfg)
 {
 
-  //todo: throw an exception when 'name=' not found?
+  // todo: throw an exception when 'name=' not found?
   size_t nameBegin = task.fairMqOutputChannelConfig.find("name=") + sizeof("name=") - 1;
   size_t nameEnd = task.fairMqOutputChannelConfig.find_first_of(',', nameBegin);
   std::string channel = task.fairMqOutputChannelConfig.substr(nameBegin, nameEnd - nameBegin);
@@ -87,3 +90,6 @@ void DispatcherFairMQ::addSource(const DataProcessorSpec& externalDataProcessor,
 
   mDataProcessorSpec.inputs.push_back(newInput);
 }
+
+} // namespace framework
+} // namespace o2

--- a/Framework/Core/src/DispatcherFairMQ.cxx
+++ b/Framework/Core/src/DispatcherFairMQ.cxx
@@ -8,6 +8,11 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+/// \file DispatcherFairMQ.cxx
+/// \brief Implementation of DispatcherFairMQ for O2 Data Sampling
+///
+/// \author Piotr Konopka, piotr.jan.konopka@cern.ch
+
 #include "Framework/DispatcherFairMQ.h"
 
 #include "FairLogger.h"

--- a/Framework/Core/src/DispatcherFlpProto.cxx
+++ b/Framework/Core/src/DispatcherFlpProto.cxx
@@ -16,26 +16,26 @@
 #include "Framework/DispatcherFlpProto.h"
 #include "Framework/SimpleRawDeviceService.h"
 
-namespace o2 {
-namespace framework {
+namespace o2
+{
+namespace framework
+{
 
-DispatcherFlpProto::DispatcherFlpProto(const SubSpecificationType dispatcherSubSpec,
-                                       const QcTaskConfiguration& task,
-                                       const InfrastructureConfig& cfg) : Dispatcher(dispatcherSubSpec, task, cfg)
+DispatcherFlpProto::DispatcherFlpProto(const SubSpecificationType dispatcherSubSpec, const QcTaskConfiguration& task,
+                                       const InfrastructureConfig& cfg)
+  : Dispatcher(dispatcherSubSpec, task, cfg)
 {
   // todo: throw an exception when 'name=' not found?
   size_t nameBegin = task.fairMqOutputChannelConfig.find("name=") + sizeof("name=") - 1;
   size_t nameEnd = task.fairMqOutputChannelConfig.find_first_of(',', nameBegin);
   std::string channel = task.fairMqOutputChannelConfig.substr(nameBegin, nameEnd - nameBegin);
 
-  mDataProcessorSpec.algorithm = AlgorithmSpec{
-    [fraction = task.fractionOfDataToSample, channel](InitContext& ctx) {
-      return initCallback(ctx, channel, fraction);
-    }
-  };
-  mDataProcessorSpec.options.push_back({
-      "channel-config", VariantType::String, task.fairMqOutputChannelConfig.c_str(), { "Out-of-band channel config" }
-    });
+  mDataProcessorSpec.algorithm = AlgorithmSpec{[fraction = task.fractionOfDataToSample, channel](InitContext & ctx){
+    return initCallback(ctx, channel, fraction);
+}
+};
+mDataProcessorSpec.options.push_back(
+  { "channel-config", VariantType::String, task.fairMqOutputChannelConfig.c_str(), { "Out-of-band channel config" } });
 }
 
 DispatcherFlpProto::~DispatcherFlpProto() {}

--- a/Framework/Core/src/DispatcherFlpProto.cxx
+++ b/Framework/Core/src/DispatcherFlpProto.cxx
@@ -1,0 +1,126 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/DispatcherFlpProto.h"
+
+#include "Framework/SimpleRawDeviceService.h"
+
+DispatcherFlpProto::DispatcherFlpProto(const SubSpecificationType dispatcherSubSpec,
+                                       const QcTaskConfiguration& task,
+                                       const InfrastructureConfig& cfg) : Dispatcher(dispatcherSubSpec, task, cfg)
+{
+  //todo: throw an exception when 'name=' not found?
+  size_t nameBegin = task.fairMqOutputChannelConfig.find("name=") + sizeof("name=") - 1;
+  size_t nameEnd = task.fairMqOutputChannelConfig.find_first_of(',', nameBegin);
+  std::string channel = task.fairMqOutputChannelConfig.substr(nameBegin, nameEnd - nameBegin);
+
+  mDataProcessorSpec = DataProcessorSpec{
+    "Dispatcher" + std::to_string(dispatcherSubSpec) + "_for_" + task.name,
+    Inputs{},
+    Outputs{},
+    AlgorithmSpec{
+      [fraction = task.fractionOfDataToSample, channel](InitContext& ctx) {
+        return initCallback(ctx, channel, fraction);
+      }
+    },
+    {
+      ConfigParamSpec{
+        "channel-config", VariantType::String,
+        task.fairMqOutputChannelConfig.c_str(), { "Out-of-band channel config" }}
+    }
+  };
+}
+
+DispatcherFlpProto::~DispatcherFlpProto() {}
+
+AlgorithmSpec::ProcessCallback DispatcherFlpProto::initCallback(InitContext& ctx, const std::string& channel,
+                                                                double fraction)
+{
+  auto device = ctx.services().get<RawDeviceService>().device();
+  auto gen = Dispatcher::BernoulliGenerator(fraction);
+  FlpProtoState state = FlpProtoState::Idle;
+
+  return [gen, device, channel, state](o2::framework::ProcessingContext& pCtx) mutable {
+    processCallback(pCtx, gen, device, channel, state);
+  };
+}
+
+void DispatcherFlpProto::processCallback(ProcessingContext& ctx, BernoulliGenerator& bernoulliGenerator,
+                                         FairMQDevice* device, const std::string& channel, FlpProtoState& state)
+{
+  auto cleanupFcn = [](void* data, void* hint) { delete[] reinterpret_cast<char*>(data); };
+
+  // only one input at a time expected
+  assert(ctx.inputs().size() == 1);
+
+  auto input = ctx.inputs().getByPos(0);
+  const auto* header = header::get<header::DataHeader>(input.header);
+
+  if (state == FlpProtoState::Idle) {
+    // wait until EOM
+    if (header->payloadSize == 96 && input.payload[0] == char(0xFF)) {
+      // decide in advance whether to take next messages until another EOM
+      if (bernoulliGenerator.drawLots()) {
+        state = FlpProtoState::ExpectingHeaderOrEOM;
+      } else {
+        state = FlpProtoState::Idle;
+      }
+    }
+  } else if (state == FlpProtoState::ExpectingHeaderOrEOM) {
+
+    // check what is it
+    if (header->payloadSize == 32 && input.payload[0] == char(0xBB)) {
+      // it is a header
+      char* payloadCopy = new char[header->payloadSize];
+      memcpy(payloadCopy, input.payload, header->payloadSize);
+      FairMQMessagePtr msgPayload(device->NewMessage(payloadCopy, header->payloadSize, cleanupFcn, payloadCopy));
+
+      device->Send(msgPayload, channel);
+      state = FlpProtoState::ExpectingPayload;
+
+    } else if (header->payloadSize == 96 && input.payload[0] == char(0xFF)) {
+      // it is an EOM
+      char* payloadCopy = new char[header->payloadSize];
+      memcpy(payloadCopy, input.payload, header->payloadSize);
+      FairMQMessagePtr msgPayload(device->NewMessage(payloadCopy, header->payloadSize, cleanupFcn, payloadCopy));
+      device->Send(msgPayload, channel);
+
+      state = bernoulliGenerator.drawLots() ? FlpProtoState::ExpectingHeaderOrEOM : FlpProtoState::Idle;
+
+    } else {
+      state = FlpProtoState::Idle;
+    }
+  } else if (state == FlpProtoState::ExpectingPayload) {
+
+    char* payloadCopy = new char[header->payloadSize];
+    memcpy(payloadCopy, input.payload, header->payloadSize);
+    FairMQMessagePtr msgPayload(device->NewMessage(payloadCopy, header->payloadSize, cleanupFcn, payloadCopy));
+    device->Send(msgPayload, channel);
+
+    // decide in advance whether to take next messages until another EOM
+    state = FlpProtoState::ExpectingHeaderOrEOM;
+  } else {
+    state = FlpProtoState::Idle;
+  }
+}
+
+void DispatcherFlpProto::addSource(const DataProcessorSpec& externalDataProcessor, const OutputSpec& externalOutput,
+                                   const std::string& binding)
+{
+  InputSpec newInput{
+    binding,
+    externalOutput.origin,
+    externalOutput.description,
+    externalOutput.subSpec,
+    static_cast<InputSpec::Lifetime>(externalOutput.lifetime),
+  };
+
+  mDataProcessorSpec.inputs.push_back(newInput);
+}

--- a/Framework/Core/src/DispatcherFlpProto.cxx
+++ b/Framework/Core/src/DispatcherFlpProto.cxx
@@ -16,11 +16,14 @@
 #include "Framework/DispatcherFlpProto.h"
 #include "Framework/SimpleRawDeviceService.h"
 
+namespace o2 {
+namespace framework {
+
 DispatcherFlpProto::DispatcherFlpProto(const SubSpecificationType dispatcherSubSpec,
                                        const QcTaskConfiguration& task,
                                        const InfrastructureConfig& cfg) : Dispatcher(dispatcherSubSpec, task, cfg)
 {
-  //todo: throw an exception when 'name=' not found?
+  // todo: throw an exception when 'name=' not found?
   size_t nameBegin = task.fairMqOutputChannelConfig.find("name=") + sizeof("name=") - 1;
   size_t nameEnd = task.fairMqOutputChannelConfig.find_first_of(',', nameBegin);
   std::string channel = task.fairMqOutputChannelConfig.substr(nameBegin, nameEnd - nameBegin);
@@ -121,3 +124,6 @@ void DispatcherFlpProto::addSource(const DataProcessorSpec& externalDataProcesso
 
   mDataProcessorSpec.inputs.push_back(newInput);
 }
+
+} // namespace framework
+} // namespace o2

--- a/Framework/Core/src/DispatcherFlpProto.cxx
+++ b/Framework/Core/src/DispatcherFlpProto.cxx
@@ -21,21 +21,14 @@ DispatcherFlpProto::DispatcherFlpProto(const SubSpecificationType dispatcherSubS
   size_t nameEnd = task.fairMqOutputChannelConfig.find_first_of(',', nameBegin);
   std::string channel = task.fairMqOutputChannelConfig.substr(nameBegin, nameEnd - nameBegin);
 
-  mDataProcessorSpec = DataProcessorSpec{
-    "Dispatcher" + std::to_string(dispatcherSubSpec) + "_for_" + task.name,
-    Inputs{},
-    Outputs{},
-    AlgorithmSpec{
-      [fraction = task.fractionOfDataToSample, channel](InitContext& ctx) {
-        return initCallback(ctx, channel, fraction);
-      }
-    },
-    {
-      ConfigParamSpec{
-        "channel-config", VariantType::String,
-        task.fairMqOutputChannelConfig.c_str(), { "Out-of-band channel config" }}
+  mDataProcessorSpec.algorithm = AlgorithmSpec{
+    [fraction = task.fractionOfDataToSample, channel](InitContext& ctx) {
+      return initCallback(ctx, channel, fraction);
     }
   };
+  mDataProcessorSpec.options.push_back({
+      "channel-config", VariantType::String, task.fairMqOutputChannelConfig.c_str(), { "Out-of-band channel config" }
+    });
 }
 
 DispatcherFlpProto::~DispatcherFlpProto() {}

--- a/Framework/Core/test/test_DataSamplingFairMQ.ini
+++ b/Framework/Core/test/test_DataSamplingFairMQ.ini
@@ -10,6 +10,7 @@ taskDefinition=FairQcTaskDefinition
 [FairQcTaskDefinition]
 inputs=fairTpcRaw
 fraction=0.2
+dispatcherType=FairMQ
 channelConfig=name=fairTpcRawOut,type=pub,method=bind,address=tcp://127.0.0.1:26525,rateLogging=1
 
 [fairTpcRaw]

--- a/Framework/Core/test/test_Parallel.cxx
+++ b/Framework/Core/test/test_Parallel.cxx
@@ -25,7 +25,7 @@ struct FakeCluster {
   float z;
   float q;
 };
-using DataHeader = o2::Header::DataHeader;
+using DataHeader = o2::header::DataHeader;
 
 size_t parallelSize = 4;
 size_t collectionChunkSize = 1000;
@@ -102,7 +102,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
         for (auto& input : inputs) {
 
           const InputSpec* inputSpec = input.spec;
-          o2::Header::DataDescription outputDescription = inputSpec->description;
+          o2::header::DataDescription outputDescription = inputSpec->description;
 
           //todo: better sampled data flagging
           size_t len = strlen(outputDescription.str);
@@ -120,7 +120,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
 
           LOG(DEBUG) << "DataSampler sends data from subSpec: " << inputSpec->subSpec;
 
-          const auto* inputHeader = o2::Header::get<o2::Header::DataHeader>(input.header);
+          const auto* inputHeader = o2::header::get<o2::header::DataHeader>(input.header);
           auto output = ctx.allocator().make<char>(outputSpec, inputHeader->size());
 
           //todo: use some std function or adopt(), when it is available for POD data

--- a/Framework/Core/test/test_TimePipeline.cxx
+++ b/Framework/Core/test/test_TimePipeline.cxx
@@ -25,7 +25,7 @@ struct FakeCluster {
   float z;
   float q;
 };
-using DataHeader = o2::Header::DataHeader;
+using DataHeader = o2::header::DataHeader;
 
 size_t parallelSize = 4;
 size_t collectionChunkSize = 1000;

--- a/Framework/TestWorkflows/CMakeLists.txt
+++ b/Framework/TestWorkflows/CMakeLists.txt
@@ -97,6 +97,8 @@ O2_GENERATE_EXECUTABLE(
   MODULE_LIBRARY_NAME ${LIBRARY_NAME}
   BUCKET_NAME ${MODULE_BUCKET_NAME}
 )
+Install(FILES dataSamplingFullChainConfig.ini DESTINATION share/config/)
+
 
 
 # These should be enabled only if one uses the full O2 default

--- a/Framework/TestWorkflows/dataSamplingFullChainConfig.ini
+++ b/Framework/TestWorkflows/dataSamplingFullChainConfig.ini
@@ -23,7 +23,9 @@ taskDefinition=readoutQcTaskDefinition
 inputs=readoutInput
 # Fraction of data that should be bypassed to QC task. The less, the better performance.
 fraction=0.1
-# dispatcher FairMQ output channel configuration. If it is empty or absent, DPL output is applied instead.
+# choose dispatcher type: DPL, FairMQ, FlpProto. DPL is default (when there is no entry)
+dispatcherType=FlpProto
+# dispatcher FairMQ output channel configuration. Specify if you use FairMQ or FlpProto dispatcher
 channelConfig=name=dpl-out,type=pub,method=bind,address=tcp://127.0.0.1:26525,rateLogging=1
 
 [readoutInput]

--- a/Framework/TestWorkflows/src/dataSamplingFullChain.cxx
+++ b/Framework/TestWorkflows/src/dataSamplingFullChain.cxx
@@ -30,6 +30,7 @@
 ///
 /// To obtain full chain (FMQ Readout -> DPL Data Sampling -> FMQ Quality Control) with default configuration:
 /// - Readout - set following options in Readout/configDummy.cfg file:
+///     \code{.ini}
 ///     ...
 ///     exitTimeout=-1
 ///     ...
@@ -39,10 +40,12 @@
 ///     # which class of datasampling to use (FairInjector, MockInjector)
 ///     class=FairInjector
 ///     ...
+///     \endcode
 ///   And run:
+///   \code{}
 ///   > alienv load Readout/latest
 ///   > readout.exe file:///your/absolute/path/to/Readout/configDummy.cfg
-///
+///   \endcode
 /// - Quality Control - configure Quality Control to subscribe for data at port 26525 (or any other, if you change it
 ///                     in Data Sampling config file). More information on running Quality Control can be found here:
 ///                     https://github.com/AliceO2Group/QualityControl
@@ -51,7 +54,8 @@ using namespace o2::framework;
 
 void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
 {
-  std::string configFilePath = std::string("file://") + getenv("O2_ROOT") + "/share/config/dataSamplingFullChainConfig.ini";
+  std::string configFilePath =
+    std::string("file://") + getenv("O2_ROOT") + "/share/config/dataSamplingFullChainConfig.ini";
   LOG(INFO) << "Using config file '" << configFilePath << "'";
 
   DataSampling::GenerateInfrastructure(specs, configFilePath);

--- a/Framework/TestWorkflows/src/dataSamplingFullChain.cxx
+++ b/Framework/TestWorkflows/src/dataSamplingFullChain.cxx
@@ -21,9 +21,11 @@
 #include "Framework/ParallelContext.h"
 #include "Framework/runDataProcessing.h"
 
-/// This is an example of using Data Sampling with both FairMQ inputs and outputs and no processing inside DPL workflow.
-/// It is configurable by config file. At first, it looks for 'dataSamplingFullChainConfig.ini' in current working
-/// directory. If it is not found there, it tries to use 'O2/Framework/TestWorkflows/dataSamplingFullChainConfig.ini'.
+/// This is an executable allowing to run Data Sampling with FLP Proto, in between FairInjector and FairSampler.
+///
+/// It also serves as an example of using Data Sampling with both FairMQ inputs and outputs and no processing inside DPL
+/// workflow. It is configurable by config file, which is installed at /share/config/dataSamplingFullChainConfig.ini.
+/// In source files it is located at O2/Framework/TestWorkflows/dataSamplingFullChainConfig.ini.
 /// You can use this file as a template to adapt Data Sampling to your own needs. Input channel configuration is
 /// declared in readoutInput/channelConfig, while output channel at readoutQcTaskDefinition/channelConfig. More details
 /// regarding options are provided inside config file.
@@ -48,18 +50,14 @@
 ///   > readout.exe file:///your/absolute/path/to/Readout/configDummy.cfg
 ///
 /// - Quality Control - configure Quality Control to subscribe for data at port 26525 (or any other, if you change it
-///                     in config file). More information on running Quality Control can be found here:
+///                     in Data Sampling config file). More information on running Quality Control can be found here:
 ///                     https://github.com/AliceO2Group/QualityControl
 
 using namespace o2::framework;
 
 void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
 {
-  std::string configFilePath = std::ifstream(std::string(getenv("PWD")) + "/dataSamplingFullChainConfig.ini").good()
-                                 ? std::string("file://") + getenv("PWD") + "/dataSamplingFullChainConfig.ini"
-                                 : std::string("file://") + getenv("BASEDIR") +
-                                     "/../../O2/Framework/TestWorkflows/dataSamplingFullChainConfig.ini";
-
+  std::string configFilePath = std::string("file://") + getenv("O2_ROOT") + "/share/config/dataSamplingFullChainConfig.ini";
   LOG(INFO) << "Using config file '" << configFilePath << "'";
 
   DataSampling::GenerateInfrastructure(specs, configFilePath);

--- a/Framework/TestWorkflows/src/dataSamplingFullChain.cxx
+++ b/Framework/TestWorkflows/src/dataSamplingFullChain.cxx
@@ -12,13 +12,7 @@
 #include <iostream>
 #include <memory>
 
-#include "FairMQDevice.h"
-#include "FairMQTransportFactory.h"
-#include "Framework/DataProcessorSpec.h"
 #include "Framework/DataSampling.h"
-#include "Framework/ExternalFairMQDeviceProxy.h"
-#include "Framework/InputSpec.h"
-#include "Framework/ParallelContext.h"
 #include "Framework/runDataProcessing.h"
 
 /// This is an executable allowing to run Data Sampling with FLP Proto, in between FairInjector and FairSampler.

--- a/Framework/TestWorkflows/src/dataSamplingParallel.cxx
+++ b/Framework/TestWorkflows/src/dataSamplingParallel.cxx
@@ -26,7 +26,7 @@ struct FakeCluster {
   float z;
   float q;
 };
-using DataHeader = o2::Header::DataHeader;
+using DataHeader = o2::header::DataHeader;
 
 size_t parallelSize = 4;
 size_t collectionChunkSize = 1000;
@@ -105,7 +105,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
         auto inputDataTpcProcessed = reinterpret_cast<const FakeCluster*>(ctx.inputs().get(
           "TPC_CLUSTERS_P_S").payload);
 
-        const auto* header = o2::Header::get<DataHeader>(ctx.inputs().get("TPC_CLUSTERS_S").header);
+        const auto* header = o2::header::get<DataHeader>(ctx.inputs().get("TPC_CLUSTERS_S").header);
 
         bool dataGood = true;
         for (int j = 0; j < header->payloadSize / sizeof(FakeCluster); ++j) {

--- a/Framework/TestWorkflows/src/dataSamplingPodAndRoot.cxx
+++ b/Framework/TestWorkflows/src/dataSamplingPodAndRoot.cxx
@@ -30,7 +30,7 @@ struct FakeCluster {
   float z;
   float q;
 };
-using DataHeader = o2::Header::DataHeader;
+using DataHeader = o2::header::DataHeader;
 
 size_t collectionChunkSize = 1000;
 void someDataProducerAlgorithm(ProcessingContext& ctx);
@@ -92,7 +92,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
         auto inputDataTpcProcessed = reinterpret_cast<const FakeCluster*>(ctx.inputs().get(
           "TPC_CLUSTERS_P_S").payload);
 
-        const auto* header = o2::Header::get<DataHeader>(ctx.inputs().get("TPC_CLUSTERS_S").header);
+        const auto* header = o2::header::get<DataHeader>(ctx.inputs().get("TPC_CLUSTERS_S").header);
 
         bool dataGood = true;
         for (int j = 0; j < header->payloadSize / sizeof(FakeCluster); ++j) {

--- a/Framework/TestWorkflows/src/dataSamplingTimePipeline.cxx
+++ b/Framework/TestWorkflows/src/dataSamplingTimePipeline.cxx
@@ -26,7 +26,7 @@ struct FakeCluster {
   float z;
   float q;
 };
-using DataHeader = o2::Header::DataHeader;
+using DataHeader = o2::header::DataHeader;
 
 size_t parallelSize = 4;
 size_t collectionChunkSize = 1000;
@@ -88,7 +88,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
         auto inputDataTpcProcessed = reinterpret_cast<const FakeCluster*>(ctx.inputs().get(
           "TPC_CLUSTERS_P_S").payload);
 
-        const auto* header = o2::Header::get<DataHeader>(ctx.inputs().get("TPC_CLUSTERS_S").header);
+        const auto* header = o2::header::get<DataHeader>(ctx.inputs().get("TPC_CLUSTERS_S").header);
 
         bool dataGood = true;
         for (int j = 0; j < header->payloadSize / sizeof(FakeCluster); ++j) {


### PR DESCRIPTION
Changes:
- Major refactoring, due to growing size of Data Sampling - created Dispatcher base class which is inherited by different kinds of dispatchers. Also moved some configuration structures to separate header.
- added more explicit way of choosing dispatcher type
- introduced DispatcherFlpProto, which behaves properly with Readout and QualityControl using 'FLP proto data model'
- updated DataSamplingFullChain to work properly in between Readout and QC
- changed 'Headers' to 'headers'