### PR TITLE
First version of clustering for MID

### DIFF
--- a/DataFormats/Detectors/CMakeLists.txt
+++ b/DataFormats/Detectors/CMakeLists.txt
@@ -3,3 +3,4 @@
 add_subdirectory (Common)
 add_subdirectory (TPC)
 add_subdirectory (ITSMFT)
+add_subdirectory (MUON)

--- a/DataFormats/Detectors/MUON/CMakeLists.txt
+++ b/DataFormats/Detectors/MUON/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(MID)

--- a/DataFormats/Detectors/MUON/MID/CMakeLists.txt
+++ b/DataFormats/Detectors/MUON/MID/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SRCS
 )
 
 set(NO_DICT_HEADERS
+  include/${MODULE_NAME}/Cluster2D.h
   include/${MODULE_NAME}/StripPattern.h
 )
 

--- a/DataFormats/Detectors/MUON/MID/CMakeLists.txt
+++ b/DataFormats/Detectors/MUON/MID/CMakeLists.txt
@@ -1,0 +1,23 @@
+set(MODULE_NAME "DataFormatsMID")
+
+O2_SETUP(NAME ${MODULE_NAME})
+
+set(SRCS
+)
+
+set(NO_DICT_HEADERS
+  include/${MODULE_NAME}/StripPattern.h
+)
+
+set(LIBRARY_NAME ${MODULE_NAME})
+set(BUCKET_NAME data_format_mid_bucket)
+
+# The O2_GENERATE_LIBRARY does not work properly if there are no SRCS
+# and there is no linkdef, since it fails in determining if is a C++ file.
+# Let us install the headers directly
+# Install all the public headers
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/include/${MODULE_NAME})
+  install(DIRECTORY include/${MODULE_NAME} DESTINATION include)
+endif()
+
+# O2_GENERATE_LIBRARY()

--- a/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/Cluster2D.h
+++ b/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/Cluster2D.h
@@ -1,0 +1,50 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   DataFormatsMID/Cluster2D.h
+/// \brief  Reconstructed cluster per RPC
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   30 August 2017
+
+#ifndef O2_MID_CLUSTER2D_H
+#define O2_MID_CLUSTER2D_H
+
+#include <boost/serialization/access.hpp>
+#include <cstdint>
+
+namespace o2
+{
+namespace mid
+{
+/// 2D cluster structure for MID
+struct Cluster2D {
+  uint8_t deId;  ///< Detection element ID
+  float xCoor;   ///< Local x coordinate
+  float yCoor;   ///< Local y coordinate
+  float sigmaX2; ///< Square of dispersion along x
+  float sigmaY2; ///< Square of dispersion along y
+
+  friend class boost::serialization::access;
+
+  /// Serializes the struct
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version)
+  {
+    ar& deId;
+    ar& xCoor;
+    ar& yCoor;
+    ar& sigmaX2;
+    ar& sigmaY2;
+  }
+};
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_CLUSTER2D_H */

--- a/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/StripPattern.h
+++ b/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/StripPattern.h
@@ -1,0 +1,69 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   DataFormatsMID/StripPattern.h
+/// \brief  Strip pattern (aka digits)
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   19 February 2018
+
+#ifndef O2_MID_STRIPPATTERN_H
+#define O2_MID_STRIPPATTERN_H
+
+#include <boost/serialization/access.hpp>
+#include <cstdint>
+#include <array>
+
+namespace o2
+{
+namespace mid
+{
+/// Strip pattern structure fot MID
+
+struct StripPattern {
+  /// Set non-bending plane pattern
+  void setNonBendPattern(uint16_t pattern) { patterns[4] = pattern; }
+  /// Get non-bending plane pattern
+  uint16_t getNonBendPattern() { return patterns[4]; }
+  /// Set bending plane pattern
+  void setBendPattern(uint16_t pattern, uint16_t line) { patterns[line] = pattern; }
+  /// Get bending plane pattern
+  uint16_t getBendPattern(uint16_t line) { return patterns[line]; }
+
+  /// Check if strip is fired
+  bool isStripFired(uint16_t istrip, uint16_t line) { return patterns[line] & (1 << istrip); }
+  /// Check if strip is fired in the non-bending plane
+  bool isNBPStripFired(uint16_t istrip) { return isStripFired(istrip, 4); }
+  /// Check if strip is fired in the bending plane
+  bool isBPStripFired(uint16_t istrip, uint16_t line) { return isStripFired(istrip, line); }
+
+  std::array<uint16_t, 5> patterns; ///< patterns
+};
+
+/// Column data structure for MID
+struct ColumnData {
+  uint8_t deId;          ///< Index of the detection element
+  uint8_t columnId;      ///< Column in DE
+  StripPattern patterns; ///< Strip patterns
+
+  friend class boost::serialization::access;
+
+  /// Serializes the struct
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version)
+  {
+    ar& deId;
+    ar& columnId;
+    ar& patterns.patterns;
+  }
+};
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_STRIPPATTERN_H */

--- a/Detectors/MUON/MID/Base/CMakeLists.txt
+++ b/Detectors/MUON/MID/Base/CMakeLists.txt
@@ -3,11 +3,13 @@ set(MODULE_NAME "MIDBase")
 O2_SETUP(NAME ${MODULE_NAME})
 
 set(SRCS
+  src/LegacyUtility.cxx
   src/Mapping.cxx
   src/MpArea.cxx
 )
 
 set(NO_DICT_HEADERS
+  include/${MODULE_NAME}/LegacyUtility.h
   include/${MODULE_NAME}/Mapping.h
   include/${MODULE_NAME}/MpArea.h
   include/${MODULE_NAME}/Serializer.h
@@ -22,4 +24,10 @@ O2_GENERATE_TESTS(
   MODULE_LIBRARY_NAME ${LIBRARY_NAME}
   BUCKET_NAME ${BUCKET_NAME}
   TEST_SRCS test/testMapping.cxx
+)
+
+O2_GENERATE_TESTS(
+  MODULE_LIBRARY_NAME ${LIBRARY_NAME}
+  BUCKET_NAME ${BUCKET_NAME}
+  TEST_SRCS test/testDEconversion.cxx
 )

--- a/Detectors/MUON/MID/Base/CMakeLists.txt
+++ b/Detectors/MUON/MID/Base/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SRCS
 set(NO_DICT_HEADERS
   include/${MODULE_NAME}/Mapping.h
   include/${MODULE_NAME}/MpArea.h
+  include/${MODULE_NAME}/Serializer.h
 )
 
 set(LIBRARY_NAME ${MODULE_NAME})

--- a/Detectors/MUON/MID/Base/include/MIDBase/LegacyUtility.h
+++ b/Detectors/MUON/MID/Base/include/MIDBase/LegacyUtility.h
@@ -1,0 +1,47 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDBase/LegacyUtility.h
+/// \brief  Utility for MID detection element IDs
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   31 August 2017
+#ifndef O2_MID_LegacyUtility_H
+#define O2_MID_LegacyUtility_H
+
+#include <cstdint>
+#include <string>
+#include <vector>
+#include "DataFormatsMID/StripPattern.h"
+
+namespace o2
+{
+namespace mid
+{
+/// Set of utilities allowing to pass from the old Run2 formats to the new one
+/// and viceversa.
+/// These utilities are meant for testing, allowing one to compare
+/// with the AliRoot input/output on existing data.
+/// It is of course doomed to disappear with time.
+struct LegacyUtility {
+  static bool assertLegacyDeId(int detElemId);
+  static bool assertDeId(int deId);
+  static int convertFromLegacyDeId(int detElemId);
+  static int convertToLegacyDeId(int deId);
+  static std::string legacyDeIdName(int detElemId);
+  static std::string deIdName(int index);
+  static uint32_t encodeDigit(int detElemId, int boardId, int channel, int cathode);
+  static void decodeDigit(uint32_t uniqueId, int& detElemId, int& boardId, int& strip, int& cathode);
+  static std::vector<ColumnData> digitsToPattern(std::vector<uint32_t> digits);
+  static void boardToPattern(int boardId, int detElemId, int cathode, int& deId, int& column, int& line);
+};
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_LegacyUtility_H */

--- a/Detectors/MUON/MID/Base/include/MIDBase/Serializer.h
+++ b/Detectors/MUON/MID/Base/include/MIDBase/Serializer.h
@@ -1,0 +1,71 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDBase/Serializer.h
+/// \brief  Templated boost serializer/deserializer for MID vectors
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   02 December 2017
+#ifndef O2_MID_SERIALIZER_H
+#define O2_MID_SERIALIZER_H
+
+#include <FairMQMessage.h>
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/serialization/vector.hpp>
+
+namespace o2
+{
+namespace mid
+{
+/// Boost serializer for MID
+template <typename DataType, typename BoostArchiveOut = boost::archive::binary_oarchive>
+class Serializer
+{
+ public:
+  void Serialize(FairMQMessage& msg, const std::vector<DataType>& dataVec)
+  {
+    /// Serislizes a standard vector of template type DataType into a message
+    std::ostringstream buffer;
+    BoostArchiveOut outputArchive(buffer);
+    outputArchive << dataVec;
+    int size = buffer.str().length();
+    msg.Rebuild(size);
+    std::memcpy(msg.GetData(), buffer.str().c_str(), size);
+  }
+
+  void Serialize(FairMQMessage& msg, const std::vector<DataType>& dataVec, const unsigned long nData)
+  {
+    /// Serializes a standard vector of template type DataType into a message
+    /// when the number of elements to serialize is smaller tham the
+    /// vector size
+    std::vector<DataType> copyVec(dataVec.begin(), dataVec.begin() + nData);
+    Serialize(msg, copyVec);
+  }
+};
+
+/// Boost deserializer for MID
+template <typename DataType, typename BoostArchiveIn = boost::archive::binary_iarchive>
+class Deserializer
+{
+ public:
+  void Deserialize(FairMQMessage& msg, std::vector<DataType>& input)
+  {
+    /// Deserializes the message into a standard vector of template type DataType
+    input.clear();
+    std::string msgStr(static_cast<char*>(msg.GetData()), msg.GetSize());
+    std::istringstream buffer(msgStr);
+    BoostArchiveIn inputArchive(buffer);
+    inputArchive >> input;
+  }
+};
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_SERIALIZER_H */

--- a/Detectors/MUON/MID/Base/src/LegacyUtility.cxx
+++ b/Detectors/MUON/MID/Base/src/LegacyUtility.cxx
@@ -1,0 +1,208 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Base/src/LegacyUtility.cxx
+/// \brief  Utility for MID detection element IDs
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   31 August 2017
+#include "MIDBase/LegacyUtility.h"
+#include <iostream>
+
+namespace o2
+{
+namespace mid
+{
+//______________________________________________________________________________
+bool LegacyUtility::assertLegacyDeId(int detElemId)
+{
+  /// Checks if the detection element id is valid (Run2 format)
+  int chamberId = detElemId / 100;
+  int rpcId = detElemId % 100;
+  if (chamberId < 11 || chamberId > 14 || rpcId > 17) {
+    std::cerr << "Invalid detElemId: " << detElemId << std::endl;
+    return false;
+  }
+  return true;
+}
+
+//______________________________________________________________________________
+bool LegacyUtility::assertDeId(int deId)
+{
+  /// Checks if the detection element id is valid
+  if (deId > 71) {
+    std::cerr << "Invalid deId: " << deId << std::endl;
+    return false;
+  }
+  return true;
+}
+
+//______________________________________________________________________________
+int LegacyUtility::convertFromLegacyDeId(int detElemId)
+{
+  /// Converts the detection element ID (Run2 format)
+  /// into the new ID (Run3 format)
+  if (assertLegacyDeId(detElemId)) {
+    int ich = (detElemId / 100 - 11);
+    int irpc = (detElemId % 100 + 4) % 18;
+    if (irpc >= 9) {
+      irpc = 17 - irpc;
+      ich += 4;
+    }
+    return ich * 9 + irpc;
+  }
+
+  return 0xFF;
+}
+
+//______________________________________________________________________________
+int LegacyUtility::convertToLegacyDeId(int deId)
+{
+  /// Converts the detection element ID into the Run2 format
+  if (assertDeId(deId)) {
+    int ich = (deId % 36) / 9;
+    int irpc = 0;
+    if (deId / 36 == 0) {
+      irpc = (deId % 9 + 14) % 18;
+    } else {
+      irpc = 13 - (deId % 9);
+    }
+    return (ich + 11) * 100 + irpc;
+  }
+
+  return 0xFFFF;
+}
+
+//______________________________________________________________________________
+std::string LegacyUtility::deIdName(int deId)
+{
+  /// Returns the name of the detection element
+  if (assertDeId(deId)) {
+    int chId = deId / 18;
+    int stId = 1 + chId / 2;
+    int planeId = 1 + chId % 2;
+    std::string str = "MT";
+    str += stId;
+    str += planeId;
+    str += (deId / 9 == 0) ? "In" : "Out";
+    str += deId % 18;
+    return str;
+  }
+  return "";
+}
+
+//______________________________________________________________________________
+std::string LegacyUtility::legacyDeIdName(int detElemId)
+{
+  /// Returns the name of the detection element (expressed in the Run2 format)
+  if (assertLegacyDeId(detElemId)) {
+    return deIdName(convertFromLegacyDeId(detElemId));
+  }
+  return "";
+}
+
+//______________________________________________________________________________
+uint32_t LegacyUtility::encodeDigit(int detElemId, int boardId, int strip, int cathode)
+{
+  /// Encodes the digit into a uniqueId in the Run2 format
+  uint32_t uniqueId = 0;
+  uniqueId |= detElemId;
+  uniqueId |= (boardId << 12);
+  uniqueId |= (strip << 24);
+  uniqueId |= (cathode << 30);
+  return uniqueId;
+}
+
+//______________________________________________________________________________
+void LegacyUtility::decodeDigit(uint32_t uniqueId, int& detElemId, int& boardId, int& strip, int& cathode)
+{
+  /// Decodes the digit given as a uniqueId in the Run2 format
+  detElemId = uniqueId & 0xFFF;
+  boardId = (uniqueId & 0xFFF000) >> 12;
+  strip = (uniqueId & 0x3F000000) >> 24;
+  cathode = (uniqueId & 0x40000000) >> 30;
+}
+
+//______________________________________________________________________________
+void LegacyUtility::boardToPattern(int boardId, int detElemId, int cathode, int& deId, int& column, int& line)
+{
+  /// Converts old Run2 local board Id into the new format
+  deId = convertFromLegacyDeId(detElemId);
+  int iboard = (boardId - 1) % 117;
+  int halfBoardId = iboard + 1;
+  int endBoard[7] = { 16, 38, 60, 76, 92, 108, 117 };
+  for (int icol = 0; icol < 7; ++icol) {
+    if (halfBoardId > endBoard[icol]) {
+      continue;
+    }
+    column = icol;
+    break;
+  }
+  line = 0;
+
+  if (cathode == 1) {
+    return;
+  }
+
+  std::vector<int> lines[3];
+  lines[0] = { 3,  19,  41, 63, 79, 95, 5,  21,  43, 65, 81, 97, 7,  23,  45, 67, 83, 99, 27, 49, 69,
+               85, 101, 9,  31, 53, 71, 87, 103, 13, 35, 57, 73, 89, 105, 15, 37, 59, 75, 91, 107 };
+  lines[1] = { 8, 24, 46, 28, 50, 10, 32, 54 };
+  lines[2] = { 25, 47, 29, 51, 11, 33, 55 };
+  for (int il = 0; il < 3; ++il) {
+    for (auto& val : lines[il]) {
+      if (halfBoardId == val) {
+        line = il + 1;
+        return;
+      }
+    }
+  }
+}
+
+//______________________________________________________________________________
+std::vector<ColumnData> LegacyUtility::digitsToPattern(std::vector<uint32_t> digits)
+{
+  /// Converts digits in the old Run2 format to StripPattern
+  int detElemId, boardId, channel, cathode, icolumn, iline;
+  int deId;
+  std::vector<ColumnData> columns;
+  for (auto uniqueId : digits) {
+    decodeDigit(uniqueId, detElemId, boardId, channel, cathode);
+    boardToPattern(boardId, detElemId, cathode, deId, icolumn, iline);
+    ColumnData* currentColumn = nullptr;
+    for (auto& column : columns) {
+      if (column.deId != deId) {
+        continue;
+      }
+      if (column.columnId != icolumn) {
+        continue;
+      }
+      currentColumn = &column;
+      break;
+    }
+    if (!currentColumn) {
+      columns.emplace_back(ColumnData());
+      currentColumn = &columns.back();
+      currentColumn->deId = deId;
+      currentColumn->columnId = icolumn;
+    }
+    uint16_t pattern =
+      (cathode == 0) ? currentColumn->patterns.getBendPattern(iline) : currentColumn->patterns.getNonBendPattern();
+    pattern |= (1 << channel);
+    if (cathode == 0) {
+      currentColumn->patterns.setBendPattern(pattern, iline);
+    } else {
+      currentColumn->patterns.setNonBendPattern(pattern);
+    }
+  }
+  return columns;
+}
+
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/Base/test/testDEconversion.cxx
+++ b/Detectors/MUON/MID/Base/test/testDEconversion.cxx
@@ -1,0 +1,41 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE midBaseConversion
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+// Keep this separate or clang format will sort the include
+// thus breaking compilation
+#include <boost/test/data/monomorphic.hpp>
+#include <boost/test/data/test_case.hpp>
+#include "MIDBase/LegacyUtility.h"
+
+namespace bdata = boost::unit_test::data;
+
+namespace o2
+{
+namespace mid
+{
+
+std::vector<int> deIndexes = { 0, 3, 6, 8, 36, 44, 9, 12, 17, 45, 53 };
+std::vector<int> detElemIds = { 1114, 1117, 1102, 1104, 1113, 1105, 1214, 1217, 1204, 1213, 1205 };
+
+BOOST_DATA_TEST_CASE(MID_convertToLegacyDeId, bdata::make(deIndexes) ^ detElemIds, deIndex, detElemId)
+{
+  BOOST_TEST(LegacyUtility::convertToLegacyDeId(deIndex) == detElemId);
+}
+
+BOOST_DATA_TEST_CASE(MID_convertFromLegacyDeId, bdata::make(deIndexes) ^ detElemIds, deIndex, detElemId)
+{
+  BOOST_TEST(LegacyUtility::convertFromLegacyDeId(detElemId) == deIndex);
+}
+
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/CMakeLists.txt
+++ b/Detectors/MUON/MID/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(Base)
+add_subdirectory(Clustering)

--- a/Detectors/MUON/MID/Clustering/CMakeLists.txt
+++ b/Detectors/MUON/MID/Clustering/CMakeLists.txt
@@ -1,0 +1,24 @@
+set(MODULE_NAME "MIDClustering")
+
+O2_SETUP(NAME ${MODULE_NAME})
+
+set(SRCS
+   src/Clusterizer.cxx
+   src/ClusterizerDevice.cxx
+)
+
+set(LIBRARY_NAME ${MODULE_NAME})
+set(BUCKET_NAME mid_clustering_bucket)
+
+O2_GENERATE_LIBRARY()
+
+O2_GENERATE_EXECUTABLE(
+  EXE_NAME runMIDClusterizer
+  SOURCES src/runMIDClusterizer.cxx
+  MODULE_LIBRARY_NAME ${LIBRARY_NAME}
+  BUCKET_NAME ${BUCKET_NAME}
+)
+
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/config/runMIDClusterizer.json DESTINATION etc/config)
+
+add_subdirectory(test)

--- a/Detectors/MUON/MID/Clustering/README.md
+++ b/Detectors/MUON/MID/Clustering/README.md
@@ -1,0 +1,26 @@
+# Running MID clustering
+
+The MID clustering takes as input the "digits" and returns the resulting clusters.
+There is no charge information in MID, so a uniform charge distribution is assumed.
+
+The "digits" data are not yet implemented for MID.
+However, MID is an upgrade of the existing MTR detector, with unchanged segmentation.
+This means that we can test the device right now using the MTR digits as input (that can be broadcast with the HLT wrapper).
+The details of the decoding of the digits will change once we will be able to generate the digits in the new format.
+This will be nevertheless a minor modification of the code, restricted to few lines of the ClusterizerDevice, and will be done in the future.
+
+For the moment it is therefore possible to run the digitizer on the MTR digits in the way explained below.
+
+## Getting the digits
+To produce a digit file suitable as input of the HLT wrapper, the utility O2muon was created in the [alo project](https://github.com/mrrtf/alo), see in particular [r23](https://github.com/mrrtf/alo/tree/master/r23).
+The utility allows to generate a digit file from raw data.
+
+## Execution
+### Start digits reader
+See instructions [here](https://github.com/mrrtf/alo/tree/master/dhlt).
+
+### Start clusterizer
+In another terminal:
+```bash
+runMIDclusterizer --id 'MIDclusterizer' --mq-config "$O2_ROOT/etc/config/runMIDclusterizer.json"
+```

--- a/Detectors/MUON/MID/Clustering/config/runMIDClusterizer.json
+++ b/Detectors/MUON/MID/Clustering/config/runMIDClusterizer.json
@@ -1,0 +1,37 @@
+{
+    "fairMQOptions": {
+        "devices": [
+            {
+                "key": "MIDclusterizer",
+                "channels": [
+                    {
+                        "name": "data-in",
+                        "sockets": [
+                            {
+                                "type": "pull",
+                                "method": "connect",
+                                "address": "tcp://localhost:45000",
+                                "sndBufSize": 1000,
+                                "rcvBufSize": 1000,
+                                "rateLogging": 0
+                            }
+                        ]
+                    },
+                    {
+                        "name": "data-out",
+                        "sockets": [
+                            {
+                                "type": "push",
+                                "method": "bind",
+                                "address": "tcp://*:46000",
+                                "sndBufSize": 1000,
+                                "rcvBufSize": 1000,
+                                "rateLogging": 0
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/Detectors/MUON/MID/Clustering/src/Clusterizer.cxx
+++ b/Detectors/MUON/MID/Clustering/src/Clusterizer.cxx
@@ -1,0 +1,399 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Clustering/src/Clusterizer.cxx
+/// \brief  Implementation of the cluster reconstruction algorithm for MID
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   24 October 2016
+#include "Clusterizer.h"
+#include <cassert>
+
+#include "FairLogger.h"
+
+namespace o2
+{
+namespace mid
+{
+
+//______________________________________________________________________________
+Clusterizer::Clusterizer()
+  : mMapping(), mMpDEs(), mNPreClusters(), mPreClusters(), mActiveDEs(), mClusters(), mNClusters(0)
+{
+  /// Default constructor
+}
+
+//______________________________________________________________________________
+bool Clusterizer::process(const std::vector<ColumnData>& stripPatterns)
+{
+  /// Main function: runs on a data containing the strip patterns
+  /// and builds the clusters
+  /// @param stripPatterns Vector of strip patterns per column
+
+  // Reset fired DEs and cluster information
+  reset();
+
+  // Load the stripPatterns to get the fired strips
+  if (loadPatterns(stripPatterns)) {
+    // Loop only on fired detection elements
+    for (auto& pair : mActiveDEs) {
+      // loop on active DEs
+      int deIndex = pair.first;
+
+      // reset number of preclusters
+      mNPreClusters.fill(0);
+      PatternStruct& de = mMpDEs[deIndex];
+
+      preClusterizeNBP(de);
+      preClusterizeBP(de);
+
+      makeClusters(deIndex);
+      de.firedColumns = 0; // Reset fired columns
+    }
+  }
+
+  return true;
+}
+
+//______________________________________________________________________________
+bool Clusterizer::init()
+{
+  /// Initializes the class
+
+  // prepare storage of clusters and PreClusters
+  for (int iPlane = 0; iPlane < 2; ++iPlane) {
+    mPreClusters[iPlane].reserve(100);
+    mClusters.reserve(100);
+  }
+
+  return true;
+}
+
+//______________________________________________________________________________
+bool Clusterizer::loadPatterns(const std::vector<ColumnData>& stripPatterns)
+{
+  /// Fills the mpDE structure with fired pads
+
+  // Loop on stripPatterns
+  for (auto col : stripPatterns) {
+    int deIndex = col.deId;
+    assert(deIndex < 72);
+
+    auto search = mMpDEs.find(deIndex);
+    PatternStruct* de = nullptr;
+    if (search == mMpDEs.end()) {
+      de = &mMpDEs[deIndex];
+      de->deId = col.deId;
+    } else {
+      de = &(search->second);
+    }
+
+    mActiveDEs[deIndex] = 1;
+
+    de->firedColumns |= (1 << col.columnId);
+    de->columns[col.columnId] = col.patterns;
+  }
+
+  return (stripPatterns.size() > 0);
+}
+
+//______________________________________________________________________________
+Clusterizer::PreCluster* Clusterizer::nextPreCluster(int icolumn)
+{
+  /// Iterates on pre-clusters
+  if (mNPreClusters[icolumn] >= static_cast<int>(mPreClusters[icolumn].size())) {
+    mPreClusters[icolumn].emplace_back(PreCluster());
+  }
+  PreCluster* pc = &(mPreClusters[icolumn][mNPreClusters[icolumn]]);
+  ++mNPreClusters[icolumn];
+  return pc;
+}
+
+//______________________________________________________________________________
+void Clusterizer::preClusterizeNBP(PatternStruct& de)
+{
+  /// PreClusterizes non-bending plane
+  PreCluster* pc = nullptr;
+  double limit = 0;
+  for (int icolumn = 0; icolumn < 7; ++icolumn) {
+    if (de.columns[icolumn].getNonBendPattern() == 0) {
+      continue;
+    }
+    int nStripsNBP = mMapping.getNStripsNBP(icolumn, de.deId);
+    for (int istrip = 0; istrip < nStripsNBP; ++istrip) {
+      if (de.columns[icolumn].isNBPStripFired(istrip)) {
+        if (pc) {
+          if (istrip == 0) {
+            // We're changing column
+            // In principle we could simply add the pitch, but for the cut RPCs
+            // the y dimension changes as well in column 0
+            pc->area[icolumn] = mMapping.stripByLocation(istrip, 1, 0, icolumn, de.deId);
+            limit = pc->area[icolumn].getXmax();
+          } else {
+            limit += mMapping.getStripSize(istrip, 1, icolumn, de.deId);
+          }
+        } else {
+          pc = nextPreCluster(7);
+          pc->paired = 0;
+          pc->firstColumn = icolumn;
+          pc->area[icolumn] = mMapping.stripByLocation(istrip, 1, 0, icolumn, de.deId);
+          limit = pc->area[icolumn].getXmax();
+          LOG(DEBUG) << "New precluster NBP: DE  " << de.deId;
+        }
+        pc->lastColumn = icolumn;
+        pc->area[icolumn].setXmax(limit);
+        LOG(DEBUG) << "  adding col " << icolumn << "  strip " << istrip << "  (" << pc->area[icolumn].getXmin() << ", "
+                   << pc->area[icolumn].getXmax() << ") (" << pc->area[icolumn].getYmin() << ", "
+                   << pc->area[icolumn].getYmax();
+      } else {
+        pc = nullptr;
+      }
+    }
+    de.columns[icolumn].setNonBendPattern(0); // Reset pattern
+  }
+}
+
+//______________________________________________________________________________
+void Clusterizer::preClusterizeBP(PatternStruct& de)
+{
+  /// PreClusterizes bending plane
+  PreCluster* pc = nullptr;
+  double limit = 0;
+  for (int icolumn = mMapping.getFirstColumn(de.deId); icolumn < 7; ++icolumn) {
+    if ((de.firedColumns & (1 << icolumn)) == 0) {
+      continue;
+    }
+    int firstLine = mMapping.getFirstBoardBP(icolumn, de.deId);
+    int lastLine = mMapping.getLastBoardBP(icolumn, de.deId);
+    for (int iline = firstLine; iline <= lastLine; ++iline) {
+      if (de.columns[icolumn].getBendPattern(iline) == 0) {
+        continue;
+      }
+      for (int istrip = 0; istrip < 16; ++istrip) {
+        if (de.columns[icolumn].isBPStripFired(istrip, iline)) {
+          if (pc) {
+            limit += mMapping.getStripSize(istrip, 0, icolumn, de.deId);
+          } else {
+            pc = nextPreCluster(icolumn);
+            pc->paired = 0;
+            pc->firstColumn = icolumn;
+            pc->lastColumn = icolumn;
+            pc->area[icolumn] = mMapping.stripByLocation(istrip, 0, iline, icolumn, de.deId);
+            limit = pc->area[icolumn].getYmax();
+            LOG(DEBUG) << "New precluster BP: DE  " << de.deId << "  icolumn " << icolumn;
+          }
+          pc->area[icolumn].setYmax(limit);
+          LOG(DEBUG) << "  adding line " << iline << "  strip " << istrip << "  (" << pc->area[icolumn].getXmin()
+                     << ", " << pc->area[icolumn].getXmax() << ") (" << pc->area[icolumn].getYmin() << ", "
+                     << pc->area[icolumn].getYmax() << ")";
+        } else {
+          pc = nullptr;
+        }
+      }
+      de.columns[icolumn].setBendPattern(0, iline); // Reset pattern
+    }                                               // loop on lines
+  }                                                 // loop on columns
+}
+
+//______________________________________________________________________________
+void Clusterizer::makeClusters(const int& deIndex)
+{
+  /// Makes the clusters and stores it
+  LOG(DEBUG) << "Clusterizing " << deIndex;
+
+  // loop over pre-clusters in the non-bending plane
+  for (int inb = 0; inb < mNPreClusters[7]; ++inb) {
+    PreCluster& pcNB = mPreClusters[7][inb];
+    int icolumn = pcNB.firstColumn;
+    if (icolumn == pcNB.lastColumn) {
+      // This is the most simple and common case: the NBP pre-cluster is on
+      // on single column. So it can be easily matched with the BP
+      // since the corresponding contours are both rectangles
+      for (int ib = 0; ib < mNPreClusters[icolumn]; ++ib) {
+        PreCluster& pcB = mPreClusters[icolumn][ib];
+        makeCluster(pcB, pcNB, deIndex);
+      }
+    } else {
+      // The NBP pre-cluster spans different columns.
+      // The BP contour is therefore a serie of neighbour rectangles
+      std::vector<std::vector<PreCluster*>> pcBneighbours;
+      LOG(DEBUG) << "Spanning non-bend: " << icolumn << " -> " << pcNB.lastColumn;
+      buildListOfNeighbours(icolumn, pcNB.lastColumn, pcBneighbours);
+      for (const auto pcBlist : pcBneighbours) {
+        makeCluster(pcBlist, deIndex, &pcNB);
+      }
+    }
+
+    if (pcNB.paired > 0) {
+      continue;
+    }
+    // If it is not paired, it means that we have
+    // a monocathodic cluster in the NBP
+    makeCluster(pcNB, pcNB, deIndex);
+  } // loop over pre-clusters in the NBP
+
+  /// Search for monocathodic clusters in the BP
+  std::vector<std::vector<PreCluster*>> pcBneighbours;
+  buildListOfNeighbours(0, 6, pcBneighbours, true);
+  for (const auto pcBlist : pcBneighbours) {
+    makeCluster(pcBlist, deIndex);
+  }
+}
+
+//______________________________________________________________________________
+Cluster2D& Clusterizer::nextCluster()
+{
+  /// Iterates on clusters
+  if (mNClusters >= static_cast<uint32_t>(mClusters.size())) {
+    mClusters.emplace_back(Cluster2D());
+  }
+  Cluster2D& cl = mClusters[mNClusters];
+  ++mNClusters;
+  return cl;
+}
+
+//______________________________________________________________________________
+void Clusterizer::makeCluster(PreCluster& clBend, PreCluster& clNonBend, const int& deIndex)
+{
+  /// Makes the cluster from pre-clusters
+  Cluster2D& cl = nextCluster();
+  int icolumn = clNonBend.firstColumn;
+  cl.deId = (uint8_t)deIndex;
+  cl.xCoor = 0.5 * (clNonBend.area[icolumn].getXmax() + clNonBend.area[icolumn].getXmin());
+  cl.yCoor = 0.5 * (clBend.area[icolumn].getYmax() + clBend.area[icolumn].getYmin());
+  double deltaX = clNonBend.area[icolumn].getXmax() - clNonBend.area[icolumn].getXmin();
+  double deltaY = clBend.area[icolumn].getYmax() - clBend.area[icolumn].getYmin();
+  cl.sigmaX2 = deltaX * deltaX / 12;
+  cl.sigmaY2 = deltaY * deltaY / 12;
+  clBend.paired = 1;
+  clNonBend.paired = 1;
+
+  LOG(DEBUG) << "pos: (" << cl.xCoor << ", " << cl.yCoor << ") err2: (" << cl.sigmaX2 << ", " << cl.sigmaY2 << ")";
+}
+
+//______________________________________________________________________________
+void Clusterizer::makeCluster(std::vector<PreCluster*> pcBlist, const int& deIndex, PreCluster* clNonBend)
+{
+  /// Makes the cluster from pre-clusters
+  // This is the general case:
+  // perform the full calculation assuming a uniform charge distribution
+
+  if (pcBlist.size() == 1) {
+    // We fall back to the simple case:
+    PreCluster* pcBP = pcBlist[0];
+    PreCluster* pcNBP = clNonBend ? clNonBend : pcBP;
+    makeCluster(*pcBP, *pcNBP, deIndex);
+    return;
+  }
+
+  Cluster2D& cl = nextCluster();
+  cl.deId = (uint8_t)deIndex;
+
+  double x2[2][2] = { { 0., 0. }, { 0., 0. } };
+  double x3[2][2] = { { 0., 0. }, { 0., 0. } };
+  double dim[2][2];
+  double delta[2];
+  double sumArea = 0.;
+
+  for (auto* pcBP : pcBlist) {
+    PreCluster* pcNBP = clNonBend ? clNonBend : pcBP;
+    int icolumn = pcBP->firstColumn;
+    dim[0][0] = pcNBP->area[icolumn].getXmin();
+    dim[0][1] = pcNBP->area[icolumn].getXmax();
+    dim[1][0] = pcBP->area[icolumn].getYmin();
+    dim[1][1] = pcBP->area[icolumn].getYmax();
+    for (int iplane = 0; iplane < 2; ++iplane) {
+      delta[iplane] = dim[iplane][1] - dim[iplane][0];
+    }
+    // area = dx * dy
+    sumArea += delta[0] * delta[1];
+    LOG(DEBUG) << "Area += " << delta[0] * delta[1] << " => " << sumArea;
+    for (int iplane = 0; iplane < 2; ++iplane) {
+      for (int ip = 0; ip < 2; ++ip) {
+        // second momentum = x_i * x_i * dy
+        double currX2 = dim[iplane][ip] * dim[iplane][ip] * delta[1 - iplane];
+        x2[iplane][ip] += currX2;
+        // third momentum = x_i * x_i * x_i * dy
+        x3[iplane][ip] += currX2 * dim[iplane][ip];
+        LOG(DEBUG) << "x[" << iplane << "][" << ip << "] => val " << dim[iplane][ip] << " delta " << delta[1 - iplane]
+                   << " => x2 " << x2[iplane][ip] << " x3 " << x3[iplane][ip];
+      }
+    }
+    pcBP->paired = 1;
+    pcNBP->paired = 1;
+  } // loop on column
+
+  double coor[2], sigma2[2];
+  for (int iplane = 0; iplane < 2; ++iplane) {
+    coor[iplane] = (x2[iplane][1] - x2[iplane][0]) / sumArea / 2.;
+    sigma2[iplane] = (x3[iplane][1] - x3[iplane][0]) / sumArea / 3. - coor[iplane] * coor[iplane];
+  }
+
+  cl.xCoor = (float)coor[0];
+  cl.yCoor = (float)coor[1];
+  cl.sigmaX2 = (float)sigma2[0];
+  cl.sigmaY2 = (float)sigma2[1];
+
+  LOG(DEBUG) << "pos: (" << cl.xCoor << ", " << cl.yCoor << ") err2: (" << cl.sigmaX2 << ", " << cl.sigmaY2 << ")";
+}
+
+//______________________________________________________________________________
+bool Clusterizer::buildListOfNeighbours(int icolumn, int lastColumn, std::vector<std::vector<PreCluster*>>& neighbours,
+                                        bool skipPaired, int currentList)
+{
+  /// Build list of neighbours
+  LOG(DEBUG) << "Building list of neighbours in (" << icolumn << ", " << lastColumn << ")";
+  for (int jcolumn = icolumn; jcolumn <= lastColumn; ++jcolumn) {
+    for (int ib = 0; ib < mNPreClusters[jcolumn]; ++ib) {
+      PreCluster* pcB = &mPreClusters[jcolumn][ib];
+      if (skipPaired && pcB->paired > 0) {
+        LOG(DEBUG) << "Column " << jcolumn << "  ib " << ib << "  is already paired => skipPaired";
+        continue;
+      }
+      if (currentList >= neighbours.size()) {
+        // We are starting a new series of neighbour
+        // Let's make sure the pre-cluster is not already part of another list
+        if (pcB->paired == 2) {
+          LOG(DEBUG) << "Column " << jcolumn << "  ib " << ib << "  is already in a list";
+          continue;
+        }
+        LOG(DEBUG) << "New list " << currentList;
+        neighbours.emplace_back(std::vector<PreCluster*>());
+      }
+      std::vector<PreCluster*>& neighList = neighbours[currentList];
+      if (!neighList.empty()) {
+        auto* neigh = neighList.back();
+        if (neigh->area[jcolumn - 1].getYmin() > pcB->area[jcolumn].getYmax())
+          continue;
+        if (neigh->area[jcolumn - 1].getYmax() < pcB->area[jcolumn].getYmin())
+          continue;
+      }
+      pcB->paired = 2;
+      LOG(DEBUG) << "  adding column " << jcolumn << "  ib " << ib << "  to " << currentList;
+      neighList.push_back(pcB);
+      buildListOfNeighbours(jcolumn + 1, lastColumn, neighbours, skipPaired, currentList);
+      ++currentList;
+    }
+  }
+
+  return (neighbours.size() > 0);
+}
+
+//______________________________________________________________________________
+void Clusterizer::reset()
+{
+  /// Resets fired DEs and clusters
+
+  // No need to reset the strip patterns here:
+  // it is done while the patterns are processed to spare a loop
+  mActiveDEs.clear();
+  mNClusters = 0;
+}
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/Clustering/src/Clusterizer.h
+++ b/Detectors/MUON/MID/Clustering/src/Clusterizer.h
@@ -1,0 +1,93 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Clustering/src/Clusterizer.h
+/// \brief  Cluster reconstruction algorithm for MID
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   24 October 2016
+
+#ifndef O2_MID_CLUSTERIZER_H
+#define O2_MID_CLUSTERIZER_H
+
+#include <unordered_map>
+#include <vector>
+#include "MIDBase/Mapping.h"
+#include "DataFormatsMID/Cluster2D.h"
+#include "DataFormatsMID/StripPattern.h"
+
+namespace o2
+{
+namespace mid
+{
+/// Clusterizing algorithm for MID
+class Clusterizer
+{
+ public:
+  Clusterizer();
+  virtual ~Clusterizer() = default;
+
+  Clusterizer(const Clusterizer&) = delete;
+  Clusterizer& operator=(const Clusterizer&) = delete;
+  Clusterizer(Clusterizer&&) = delete;
+  Clusterizer& operator=(Clusterizer&&) = delete;
+
+  bool init();
+  bool process(const std::vector<ColumnData>& stripPatterns);
+
+  /// Gets the array of reconstructes clusters
+  const std::vector<Cluster2D>& getClusters() { return mClusters; }
+
+  /// Gets the number of reconstructed clusters
+  unsigned long int getNClusters() { return mNClusters; }
+
+ private:
+  struct PatternStruct {
+    int deId;                            ///< Detection element ID
+    int firedColumns;                    ///< Fired columns
+    std::array<StripPattern, 7> columns; ///< Array of strip patterns
+  };
+
+  struct PreCluster {
+    int firstColumn;            ///< First fired column
+    int lastColumn;             ///< Last fired column
+    int paired;                 ///< Flag to check if PreCliuster was paired
+    std::array<MpArea, 7> area; ///< 2D area containing the PreCluster per column
+  };
+
+  bool loadPatterns(const std::vector<ColumnData>& stripPatterns);
+  void reset();
+
+  void preClusterizeBP(PatternStruct& de);
+  void preClusterizeNBP(PatternStruct& de);
+  PreCluster* nextPreCluster(int icolumn);
+
+  bool buildListOfNeighbours(int icolumn, int lastColumn, std::vector<std::vector<PreCluster*>>& neighbours,
+                             bool skipPaired = false, int currentList = 0);
+
+  Cluster2D& nextCluster();
+  void makeClusters(const int& deIndex);
+  void makeCluster(PreCluster& clBend, PreCluster& clNonBend, const int& deIndex);
+  void makeCluster(std::vector<PreCluster*> pcBlist, const int& deIndex, PreCluster* clNonBend = nullptr);
+
+  Mapping mMapping;                              ///< Mapping
+  std::unordered_map<int, PatternStruct> mMpDEs; ///< internal mapping
+
+  std::array<int, 8> mNPreClusters; ///< number of PreClusters in each DE per column (last column is the NBP)
+  std::array<std::vector<PreCluster>, 8>
+    mPreClusters; ///< list of PreClusters in each DE per column (last column is the NBP)
+
+  std::unordered_map<int, bool> mActiveDEs; ///< List of active detection elements for event
+  std::vector<Cluster2D> mClusters;         ///< list of clusters
+  unsigned long int mNClusters;             ///< Number of clusters
+};
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_CLUSTERIZER_H */

--- a/Detectors/MUON/MID/Clustering/src/ClusterizerDevice.cxx
+++ b/Detectors/MUON/MID/Clustering/src/ClusterizerDevice.cxx
@@ -1,0 +1,91 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Clustering/src/ClusterizerDevice.cxx
+/// \brief  Implementation of the cluster reconstruction device for MID
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   24 October 2016
+#include "ClusterizerDevice.h"
+
+#include <vector>
+#include "FairMQLogger.h"
+#include "MIDBase/Serializer.h"
+#include "DataFormatsMID/StripPattern.h"
+
+#include "MIDBase/LegacyUtility.h" // FOR TESTING
+
+namespace o2
+{
+namespace mid
+{
+
+//______________________________________________________________________________
+ClusterizerDevice::ClusterizerDevice() : mClusterizer()
+{
+  /// Default constructor
+  // register a handler for data arriving on "data-in" channel
+  OnData("data-in", &ClusterizerDevice::handleData);
+}
+
+//______________________________________________________________________________
+bool ClusterizerDevice::handleData(FairMQMessagePtr& msg, int /*index*/)
+{
+  /// Main function: runs on a data containing the digits
+  /// and builds the clusters
+
+  LOG(INFO) << "Received data of size: " << msg->GetSize();
+
+  // FIXME: This will change when we will have the final format
+  // The HLT adds an header. After 100 bytes, we have the number of digits
+  if (msg->GetSize() < 100) {
+    LOG(INFO) << "Empty message: skip";
+    return true;
+  }
+  uint8_t* data = reinterpret_cast<uint8_t*>(msg->GetData());
+  uint32_t* digitsData = reinterpret_cast<uint32_t*>(data + 100);
+  uint32_t nDigits = digitsData[0];
+  uint32_t offset(1);
+  // Loop on digits
+  std::vector<uint32_t> digits;
+  for (int idig = 0; idig < nDigits; idig++) {
+    uint32_t uniqueID = digitsData[offset++];
+    digits.push_back(uniqueID);
+    ++offset; // skip idx and adc
+  }
+  std::vector<ColumnData> patterns = LegacyUtility::digitsToPattern(digits);
+  // end of the block that will require a change
+
+  mClusterizer.process(patterns);
+
+  if (mClusterizer.getNClusters() > 0) {
+    // Store clusters
+    FairMQMessagePtr msgOut(NewMessage());
+    // Serialize<BoostSerializer<Track>>(*msgOut, mTracks);
+    Serialize<Serializer<Cluster2D>>(*msgOut, mClusterizer.getClusters(), mClusterizer.getNClusters());
+
+    // Send out the output message
+    if (Send(msgOut, "data-out") < 0) {
+      LOG(ERROR) << "problem sending message";
+      return false;
+    }
+  }
+  return true;
+}
+
+//______________________________________________________________________________
+void ClusterizerDevice::InitTask()
+{
+  /// Initializes the task
+  if (!mClusterizer.init()) {
+    LOG(ERROR) << "Initialization of MID clusterizer device failed";
+  }
+}
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/Clustering/src/ClusterizerDevice.h
+++ b/Detectors/MUON/MID/Clustering/src/ClusterizerDevice.h
@@ -1,0 +1,48 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   ClusterizerDevice.h
+/// \brief  Cluster reconstruction device for MID
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   24 October 2016
+
+#ifndef O2_MID_CLUSTERIZERDEVICE_H
+#define O2_MID_CLUSTERIZERDEVICE_H
+
+#include "FairMQDevice.h"
+#include "Clusterizer.h"
+
+namespace o2
+{
+namespace mid
+{
+/// Clusterizing device for MID
+class ClusterizerDevice : public FairMQDevice
+{
+ public:
+  ClusterizerDevice();
+  ~ClusterizerDevice() override = default;
+
+  ClusterizerDevice(const ClusterizerDevice&) = delete;
+  ClusterizerDevice& operator=(const ClusterizerDevice&) = delete;
+  ClusterizerDevice(ClusterizerDevice&&) = delete;
+  ClusterizerDevice& operator=(ClusterizerDevice&&) = delete;
+
+ protected:
+  bool handleData(FairMQMessagePtr&, int);
+  void InitTask() override;
+
+ private:
+  Clusterizer mClusterizer; ///< Clustering algorithm
+};
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_CLUSTERIZERDEVICE_H */

--- a/Detectors/MUON/MID/Clustering/src/runMIDClusterizer.cxx
+++ b/Detectors/MUON/MID/Clustering/src/runMIDClusterizer.cxx
@@ -1,0 +1,26 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   runMIDClusterizer.cxx
+/// \brief  A simple program to reconstruct MID clusters
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   24 October 2016
+
+#include "runFairMQDevice.h"
+#include "ClusterizerDevice.h"
+
+namespace bpo = boost::program_options;
+
+void addCustomOptions(bpo::options_description& options)
+{
+  // options.add_options()("binmapfile", bpo::value<std::string>(), "file with segmentation");
+}
+
+FairMQDevicePtr getDevice(const FairMQProgOptions&) { return new o2::mid::ClusterizerDevice(); }

--- a/Detectors/MUON/MID/Clustering/test/CMakeLists.txt
+++ b/Detectors/MUON/MID/Clustering/test/CMakeLists.txt
@@ -1,0 +1,14 @@
+O2_SETUP(NAME MIDClusteringTest)
+set(BUCKET_NAME mid_clustering_test_bucket)
+
+O2_GENERATE_TESTS(
+  BUCKET_NAME ${BUCKET_NAME}
+  TEST_SRCS testClusterizer.cxx
+)
+
+if (benchmark_FOUND)
+    O2_GENERATE_EXECUTABLE(
+            EXE_NAME benchClusterizer
+            SOURCES bench_Clusterizer.cxx
+            BUCKET_NAME ${BUCKET_NAME})
+endif ()

--- a/Detectors/MUON/MID/Clustering/test/bench_Clusterizer.cxx
+++ b/Detectors/MUON/MID/Clustering/test/bench_Clusterizer.cxx
@@ -1,0 +1,108 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Clustering/test/bench_Clusterizer.cxx
+/// \brief  Benchmark clustering device for MID
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   08 March 2018
+
+#include "benchmark/benchmark.h"
+#include <iostream>
+#include <random>
+#include "MIDBase/Mapping.h"
+#include "DataFormatsMID/StripPattern.h"
+#include "Clusterizer.h"
+
+std::vector<o2::mid::ColumnData> generateTestData(int deId, const o2::mid::Mapping& midMapping)
+{
+  int firstColumnInDE = midMapping.getFirstColumn(deId);
+
+  std::uniform_int_distribution<int> distColumn(firstColumnInDE, 6);
+  std::uniform_int_distribution<int> distStrip(0, 15);
+  std::uniform_int_distribution<int> distNfired(0, 4);
+
+  std::random_device rd;
+  std::mt19937 mt(rd());
+
+  std::vector<o2::mid::ColumnData> patterns;
+  int firstColumn = distColumn(mt);
+  int lastColumn = firstColumn + 1;
+  if (lastColumn > 6) {
+    lastColumn = 6;
+  }
+
+  for (int icol = firstColumn; icol <= lastColumn; ++icol) {
+    o2::mid::ColumnData column;
+    column.deId = (uint8_t)deId;
+    column.columnId = (uint8_t)icol;
+    for (int cathode = 0; cathode < 2; ++cathode) {
+      int firstLine = 0;
+      int lastLine = 0;
+      if (cathode == 0) {
+        firstLine = midMapping.getFirstBoardBP(icol, deId);
+        lastLine = midMapping.getLastBoardBP(icol, deId);
+      }
+      for (int iline = firstLine; iline <= lastLine; ++iline) {
+        uint16_t pattern = 0;
+        int nStrips = distNfired(mt);
+        for (int istrip = 0; istrip < nStrips; ++istrip) {
+          if (midMapping.stripByLocation(istrip, cathode, iline, column.columnId, column.deId).isValid()) {
+            pattern |= (1 << istrip);
+          }
+        }
+        if (cathode == 0) {
+          column.patterns.setBendPattern(pattern, iline);
+        } else {
+          column.patterns.setNonBendPattern(pattern);
+        }
+      }
+    }
+    patterns.emplace_back(column);
+  }
+  return patterns;
+}
+
+static void deList(benchmark::internal::Benchmark* bench)
+{
+  for (int deId = 63; deId < 72; ++deId) {
+    bench->Args({ deId });
+  }
+}
+
+class BenchO2 : public benchmark::Fixture
+{
+};
+BENCHMARK_DEFINE_F(BenchO2, clustering)(benchmark::State& state)
+{
+
+  int deId = state.range(0);
+
+  o2::mid::Mapping midMapping;
+  o2::mid::Clusterizer clusterizer;
+  clusterizer.init();
+
+  double num{ 0 };
+
+  std::vector<o2::mid::ColumnData> inputData;
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    inputData = generateTestData(deId, midMapping);
+    state.ResumeTiming();
+    clusterizer.process(inputData);
+    ++num;
+  }
+
+  state.counters["num"] = benchmark::Counter(num, benchmark::Counter::kIsRate);
+}
+
+BENCHMARK_REGISTER_F(BenchO2, clustering)->Apply(deList)->Unit(benchmark::kNanosecond);
+
+BENCHMARK_MAIN();

--- a/Detectors/MUON/MID/Clustering/test/testClusterizer.cxx
+++ b/Detectors/MUON/MID/Clustering/test/testClusterizer.cxx
@@ -1,0 +1,326 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Clustering/test/testClusterizer.cxx
+/// \brief  Test clustering device for MID
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   08 March 2018
+
+#define BOOST_TEST_MODULE midClustering
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+// Keep this separate or clang format will sort the include
+// thus breaking compilation
+#include <boost/test/data/monomorphic.hpp>
+#include <boost/test/data/monomorphic/generators/xrange.hpp>
+#include <boost/test/data/test_case.hpp>
+#include <cstdint>
+#include <iostream>
+#include <vector>
+#include <random>
+#include "Clusterizer.h"
+
+#include "FairLogger.h"
+
+namespace o2
+{
+namespace mid
+{
+
+// std::vector<uint32_t> getDigits(int event)
+// {
+//   std::vector<uint32_t> digits;
+//   switch (event) {
+//     case 0:
+//       digits.push_back(LegacyUtility::encodeDigit(1400, 26, 14, 0));
+//       digits.push_back(LegacyUtility::encodeDigit(1400, 26, 15, 0));
+//       digits.push_back(LegacyUtility::encodeDigit(1400, 27, 0, 0));
+//       digits.push_back(LegacyUtility::encodeDigit(1400, 27, 1, 0));
+//       digits.push_back(LegacyUtility::encodeDigit(1400, 49, 0, 0));
+//       digits.push_back(LegacyUtility::encodeDigit(1400, 26, 4, 1));
+//       digits.push_back(LegacyUtility::encodeDigit(1400, 26, 5, 1));
+//       digits.push_back(LegacyUtility::encodeDigit(1400, 26, 7, 1));
+//       digits.push_back(LegacyUtility::encodeDigit(1400, 48, 0, 1));
+//       break;
+//     case 1:
+//       digits.push_back(LegacyUtility::encodeDigit(1408, 127, 14, 0));
+//       digits.push_back(LegacyUtility::encodeDigit(1408, 127, 15, 0));
+//       digits.push_back(LegacyUtility::encodeDigit(1408, 128, 0, 0));
+//       digits.push_back(LegacyUtility::encodeDigit(1408, 128, 1, 0));
+//       digits.push_back(LegacyUtility::encodeDigit(1408, 150, 1, 0));
+//       digits.push_back(LegacyUtility::encodeDigit(1408, 126, 2, 1));
+//       digits.push_back(LegacyUtility::encodeDigit(1408, 126, 3, 1));
+//       digits.push_back(LegacyUtility::encodeDigit(1408, 126, 15, 1));
+//       digits.push_back(LegacyUtility::encodeDigit(1408, 147, 0, 1));
+//       break;
+//     case 2:
+//       digits.push_back(LegacyUtility::encodeDigit(1400, 26, 14, 0));
+//       digits.push_back(LegacyUtility::encodeDigit(1400, 26, 15, 0));
+//       digits.push_back(LegacyUtility::encodeDigit(1400, 27, 0, 0));
+//       digits.push_back(LegacyUtility::encodeDigit(1400, 27, 1, 0));
+//       digits.push_back(LegacyUtility::encodeDigit(1400, 48, 14, 0));
+//       digits.push_back(LegacyUtility::encodeDigit(1400, 48, 15, 0));
+//       digits.push_back(LegacyUtility::encodeDigit(1400, 49, 0, 0));
+//       digits.push_back(LegacyUtility::encodeDigit(1400, 49, 1, 0));
+//       digits.push_back(LegacyUtility::encodeDigit(1400, 26, 7, 1));
+//       digits.push_back(LegacyUtility::encodeDigit(1400, 48, 0, 1));
+//       break;
+//     default:
+//       std::cerr << "Event " << event << "not defined" << std::endl;
+//   }
+//
+//   return digits;
+// }
+
+std::vector<ColumnData> getColumnsFixed(int event)
+{
+  std::vector<ColumnData> columns;
+  switch (event) {
+    case 0:
+      columns.emplace_back(ColumnData());
+      columns.back().deId = 31;
+      columns.back().columnId = 1;
+      columns.back().patterns.setNonBendPattern(1 << 4 | 1 << 5 | 1 << 7);
+      columns.back().patterns.setBendPattern(1 << 14 | 1 << 15, 0);
+      columns.back().patterns.setBendPattern(1 << 0 | 1 << 1, 1);
+      columns.emplace_back(ColumnData());
+      columns.back().deId = 31;
+      columns.back().columnId = 2;
+      columns.back().patterns.setNonBendPattern(1 << 0);
+      columns.back().patterns.setBendPattern(1 << 0, 1);
+      break;
+    case 1:
+      columns.emplace_back(ColumnData());
+      columns.back().deId = 68;
+      columns.back().columnId = 0;
+      columns.back().patterns.setNonBendPattern(1 << 2 | 1 << 3 | 1 << 15);
+      columns.back().patterns.setBendPattern(1 << 14 | 1 << 15, 2);
+      columns.back().patterns.setBendPattern(1 << 0 | 1 << 1, 3);
+      columns.emplace_back(ColumnData());
+      columns.back().deId = 68;
+      columns.back().columnId = 1;
+      columns.back().patterns.setNonBendPattern(1 << 0);
+      columns.back().patterns.setBendPattern(1 << 1, 3);
+      break;
+    case 2:
+      columns.emplace_back(ColumnData());
+      columns.back().deId = 31;
+      columns.back().columnId = 1;
+      columns.back().patterns.setNonBendPattern(1 << 7);
+      columns.back().patterns.setBendPattern(1 << 14 | 1 << 15, 0);
+      columns.back().patterns.setBendPattern(1 << 0 | 1 << 1, 1);
+      columns.emplace_back(ColumnData());
+      columns.back().deId = 31;
+      columns.back().columnId = 2;
+      columns.back().patterns.setNonBendPattern(1 << 0);
+      columns.back().patterns.setBendPattern(1 << 14 | 1 << 15, 0);
+      columns.back().patterns.setBendPattern(1 << 0 | 1 << 1, 1);
+      break;
+    default:
+      std::cerr << "Event " << event << "not defined" << std::endl;
+  }
+
+  return columns;
+}
+
+std::vector<Cluster2D> getClusters(int event)
+{
+  std::vector<Cluster2D> clusters;
+  Cluster2D clus;
+  switch (event) {
+    case 0:
+      clus.deId = 31; // LegacyUtility::convertFromLegacyDeId(1400);
+      clus.xCoor = -98.0417;
+      clus.yCoor = -18.2403;
+      clus.sigmaX2 = 1.73286;
+      clus.sigmaY2 = 1.73286;
+      clusters.push_back(clus);
+      clus.deId = 31; // LegacyUtility::convertFromLegacyDeId(1400);
+      clus.xCoor = -91.8856;
+      clus.yCoor = -18.1263;
+      clus.sigmaX2 = 1.26499;
+      clus.sigmaY2 = 1.45994;
+      clusters.push_back(clus);
+      break;
+    case 1:
+      clus.deId = 68; // LegacyUtility::convertFromLegacyDeId(1408);
+      clus.xCoor = -129.962;
+      clus.yCoor = 18.2403;
+      clus.sigmaX2 = 1.73286;
+      clus.sigmaY2 = 1.73286;
+      clusters.push_back(clus);
+      clus.deId = 68; // LegacyUtility::convertFromLegacyDeId(1408);
+      clus.xCoor = -101.006;
+      clus.yCoor = 18.5823;
+      clus.sigmaX2 = 1.26499;
+      clus.sigmaY2 = 1.87579;
+      clusters.push_back(clus);
+      break;
+    case 2:
+      clus.deId = 31; // LegacyUtility::convertFromLegacyDeId(1400);
+      clus.xCoor = -91.2016;
+      clus.yCoor = -18.2403;
+      clus.sigmaX2 = 1.73286;
+      clus.sigmaY2 = 1.73286;
+      clusters.push_back(clus);
+      break;
+    default:
+      std::cerr << "Event " << event << "not defined" << std::endl;
+  }
+
+  return clusters;
+}
+
+bool areClustersEqual(Cluster2D& cl1, Cluster2D& cl2)
+{
+  int nBad = 0;
+  float precision = 1.e-3;
+  if (cl1.deId != cl2.deId) {
+    std::cerr << "Id: " << cl1.deId << " != " << cl2.deId << std::endl;
+    ++nBad;
+  }
+
+  if (std::abs(cl1.xCoor - cl2.xCoor) > precision) {
+    std::cerr << "xCoor: " << cl1.xCoor << " != " << cl2.xCoor << std::endl;
+    ++nBad;
+  }
+
+  if (std::abs(cl1.yCoor - cl2.yCoor) > precision) {
+    std::cerr << "yCoor: " << cl1.yCoor << " != " << cl2.yCoor << std::endl;
+    ++nBad;
+  }
+
+  if (std::abs(cl1.sigmaX2 - cl2.sigmaX2) > precision) {
+    std::cerr << "sigmaX2: " << cl1.sigmaX2 << " != " << cl2.sigmaX2 << std::endl;
+    ++nBad;
+  }
+
+  if (std::abs(cl1.sigmaY2 - cl2.sigmaY2) > precision) {
+    std::cerr << "sigmaY2: " << cl1.sigmaY2 << " != " << cl2.sigmaY2 << std::endl;
+    ++nBad;
+  }
+
+  return (nBad == 0);
+}
+
+class MyFixture
+{
+ public:
+  MyFixture() : clusterizer(), mapping()
+  {
+    clusterizer.init();
+    // fair::Logger::SetConsoleSeverity(fair::Severity::debug);
+  }
+  Clusterizer clusterizer;
+  Mapping mapping;
+};
+
+BOOST_DATA_TEST_CASE_F(MyFixture, MID_Clustering_Fixed, boost::unit_test::data::xrange(3))
+{
+  // std::vector<ColumnData> columns = LegacyUtility::digitsToPattern(getDigits(sample));
+  // clusterizer.process(columns);
+  clusterizer.process(getColumnsFixed(sample));
+  std::vector<Cluster2D> clusters = getClusters(sample);
+  BOOST_TEST(clusters.size() == clusterizer.getNClusters());
+  unsigned long minNcl = clusters.size();
+  if (clusterizer.getNClusters() < minNcl) {
+    minNcl = clusterizer.getNClusters();
+  }
+  std::vector<Cluster2D> recoClusters = clusterizer.getClusters();
+  for (unsigned long icl = 0; icl < clusters.size(); ++icl) {
+    BOOST_TEST(areClustersEqual(clusters[icl], recoClusters[icl]));
+  }
+}
+
+bool isWithinUncertainties(float xPos, float yPos, Cluster2D& cl)
+{
+  std::string str[2] = { "x", "y" };
+  float inputPos[2] = { xPos, yPos };
+  float recoPos[2] = { cl.xCoor, cl.yCoor };
+  float sigma2[2] = { cl.sigmaX2, cl.sigmaY2 };
+  bool isOk = true;
+  for (int icoor = 0; icoor < 2; ++icoor) {
+    float sigma = std::sqrt(sigma2[icoor]);
+    if (sigma > 5. || std::abs(recoPos[icoor] - inputPos[icoor]) > 5 * sigma) {
+      std::cerr << str[icoor] << " position input " << inputPos[icoor] << "  reco " << recoPos[icoor] << "  sigma "
+                << sigma << std::endl;
+      isOk = false;
+    }
+  }
+  return isOk;
+}
+
+std::vector<ColumnData> getFiredStrips(float xPos, float yPos, int deId, Mapping& mapping)
+{
+  // This is a quite simple case just for testing purposes.
+  // The fired strips are simply the fired stripp itself + its neighbours.
+  // However, in the bending plane, this also consists of strips with no overlap
+  // with the non-bending plane
+  std::vector<ColumnData> columns;
+  for (int cathode = 1; cathode >= 0; --cathode) {
+    Mapping::MpStripIndex stripIndex = mapping.stripByPosition(xPos, yPos, cathode, deId, false);
+    if (!stripIndex.isValid()) {
+      continue;
+    }
+    std::vector<Mapping::MpStripIndex> neighbours = mapping.getNeighbours(stripIndex, cathode, deId);
+    neighbours.push_back(stripIndex);
+    for (auto& neigh : neighbours) {
+      ColumnData* columnStruct = nullptr;
+      for (auto& currCol : columns) {
+        if (currCol.columnId == neigh.column) {
+          columnStruct = &currCol;
+          break;
+        }
+      }
+      if (!columnStruct) {
+        if (cathode == 0) {
+          // For the sake of simplicity we reject the neighbour bending strips
+          // that do not overlap to the non-bending plane
+          continue;
+        }
+        columns.emplace_back(ColumnData());
+        columnStruct = &columns.back();
+        columnStruct->deId = deId;
+        columnStruct->columnId = neigh.column;
+      }
+      int line = (cathode == 1) ? 4 : neigh.line;
+      columnStruct->patterns.patterns[line] |= (1 << neigh.strip);
+    }
+  }
+  return columns;
+}
+
+BOOST_DATA_TEST_CASE_F(MyFixture, MID_Clustering_Random, boost::unit_test::data::xrange(72), deId)
+{
+  std::random_device rd;
+  std::mt19937 mt(rd());
+  std::uniform_real_distribution<float> distX(-127.5, 127.5);
+  std::uniform_real_distribution<float> distY(-68., 68.);
+
+  for (int ievt = 0; ievt < 1000; ++ievt) {
+    float xPos = distX(mt);
+    float yPos = distY(mt);
+    std::vector<ColumnData> columns = getFiredStrips(xPos, yPos, deId, mapping);
+    if (columns.size() == 0) {
+      // Position was outside detection element
+      continue;
+    }
+    clusterizer.process(columns);
+    BOOST_TEST(clusterizer.getNClusters() == 1);
+
+    std::vector<Cluster2D> recoClusters = clusterizer.getClusters();
+    for (int icl = 0; icl < clusterizer.getNClusters(); ++icl) {
+      BOOST_TEST(isWithinUncertainties(xPos, yPos, recoClusters[icl]));
+    }
+  }
+}
+
+} // namespace mid
+} // namespace o2

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -1575,10 +1575,22 @@ o2_define_bucket(
 
 o2_define_bucket(
     NAME
+    data_format_mid_bucket
+
+    DEPENDENCIES
+    Boost::serialization
+
+    INCLUDE_DIRECTORIES
+    ${CMAKE_SOURCE_DIR}/DataFormats/Detectors/MUON/MID/include
+)
+
+o2_define_bucket(
+    NAME
     mid_base_bucket
 
     DEPENDENCIES
     common_math_bucket
+    data_format_mid_bucket
 
     INCLUDE_DIRECTORIES
     ${CMAKE_SOURCE_DIR}/Common/MathUtils/include

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -1595,3 +1595,26 @@ o2_define_bucket(
     INCLUDE_DIRECTORIES
     ${CMAKE_SOURCE_DIR}/Common/MathUtils/include
 )
+
+o2_define_bucket(
+    NAME
+    mid_clustering_bucket
+
+    DEPENDENCIES
+    fairroot_base_bucket
+    MIDBase
+)
+
+o2_define_bucket(
+    NAME
+    mid_clustering_test_bucket
+
+    DEPENDENCIES
+    Boost::unit_test_framework
+    $<IF:$<BOOL:${benchmark_FOUND}>,benchmark::benchmark,$<0:"">>
+    mid_clustering_bucket
+    MIDClustering
+
+    INCLUDE_DIRECTORIES
+    ${CMAKE_SOURCE_DIR}/Detectors/MUON/MID/Clustering/src
+)


### PR DESCRIPTION
This is the initial version of a clustering device for MID.
It consists of 4 closely related commits: the first three introduce some necessary classes for the Clustering.
The first commit, in particular, defines a very preliminary version of the expected input "digits" format,
which are indeed strip patterns. This was added to DataFormats/Detectors.
Since it is the first MUON commit in the DataFormats, it also defines the directory structure,
which is chosen to be equivalent to the one in o2/Detectors.