### PR TITLE
Adding options TIMEOUT and COMMAND_LINE_ARGS to O2_GENERATE_TESTS

### DIFF
--- a/cmake/O2Utils.cmake
+++ b/cmake/O2Utils.cmake
@@ -404,8 +404,8 @@ function(O2_GENERATE_TESTS)
   cmake_parse_arguments(
       PARSED_ARGS
       "" # bool args
-      "BUCKET_NAME;MODULE_LIBRARY_NAME" # mono-valued arguments
-      "TEST_SRCS" # multi-valued arguments
+      "BUCKET_NAME;MODULE_LIBRARY_NAME;TIMEOUT" # mono-valued arguments
+      "TEST_SRCS;COMMAND_LINE_ARGS" # multi-valued arguments
       ${ARGN} # arguments
   )
 
@@ -427,7 +427,10 @@ function(O2_GENERATE_TESTS)
         NO_INSTALL FALSE
     )
     target_link_libraries(${test_name} Boost::unit_test_framework)
-    add_test(NAME ${test_name} COMMAND ${test_name})
+    add_test(NAME ${test_name} COMMAND ${test_name} ${PARSED_ARGS_COMMAND_LINE_ARGS})
+    if (PARSED_ARGS_TIMEOUT)
+      set_tests_properties(${test_name} PROPERTIES TIMEOUT ${PARSED_ARGS_TIMEOUT})
+    endif()
   endforeach ()
 endfunction()
 


### PR DESCRIPTION
This allows now to specify ctest timeout and optional command line arguments
for a test target. Different command line arguments can be specified by
invoking O2_GENERATE_TESTS individually for tests having different command line
arguments.