### PR TITLE
Fix name clash of default_delete

### DIFF
--- a/Framework/Core/include/Framework/InputRecord.h
+++ b/Framework/Core/include/Framework/InputRecord.h
@@ -29,12 +29,12 @@
 #include <memory>
 #include <type_traits>
 
-template <typename T>
-using default_delete = std::default_delete<T>;
-
 namespace o2 {
 namespace framework {
-
+  
+template <typename T>
+using default_delete = std::default_delete<T>;
+  
 struct InputSpec;
 
 /// This class holds the inputs which  are being processed by the system while


### PR DESCRIPTION
@matthiasrichter
Could `using default_delete` be moved into `o2::framework` namespace? It caused some name clash when using O2 DPL inside QualityControl:
```
/home/pkonopka/alice/sw/slc7_x86-64/O2/0_O2_DATAFLOW-1/lib/../include/Framework/InputRecord.h:63:26: error: unknown template name 'default_delete'
  class Deleter : public default_delete<T>
```