### PR TITLE
Disable IWYU integration because of compilation failure

### DIFF
--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -19,7 +19,11 @@ else (ALICEO2_MODULAR_BUILD)
 endif (ALICEO2_MODULAR_BUILD)
 find_package(CERNLIB)
 find_package(HEPMC)
-find_package(IWYU)
+# FIXME: the way, iwyu is integrated now conflicts with the possibility to add
+# custom rules for individual modules, e.g. the custom targets introduced in
+# PR #886 depending on some header files conflict with the IWYU setup
+# disable package for the moment
+#find_package(IWYU)
 find_package(DDS)
 
 find_package(Boost 1.59 COMPONENTS thread system timer program_options random filesystem chrono exception regex serialization log log_setup unit_test_framework date_time signals REQUIRED)


### PR DESCRIPTION
In PR #886 some compilation errors have been introduced, triggered only
when IWYU is installed.
```
CMake Error: Attempt to add a custom rule to output "/home/richter/src/alisw/sw/BUILD/aa1513468d78797f9c98e17f41686f1676d4ca5c/O2/Detectors/MUON/MCH/Mapping/Impl3/GenDetElemId2SegType.iwyu.rule" which already has a custom rule.
CMake Error: Attempt to add a custom rule to output "/home/richter/src/alisw/sw/BUILD/aa1513468d78797f9c98e17f41686f1676d4ca5c/O2/Detectors/MUON/MCH/Mapping/Impl3/PadGroupType.iwyu.rule" which already has a custom rule.
CMake Error: Attempt to add a custom rule to output "/home/richter/src/alisw/sw/BUILD/aa1513468d78797f9c98e17f41686f1676d4ca5c/O2/Detectors/MUON/MCH/Mapping/Impl3/SegmentationCreator.iwyu.rule" which already has a custom rule.
CMake Error: Attempt to add a custom rule to output "/home/richter/src/alisw/sw/BUILD/aa1513468d78797f9c98e17f41686f1676d4ca5c/O2/Detectors/MUON/MCH/Mapping/Impl3/SegmentationImpl3.iwyu.rule" which already has a custom rule.
```

Actually this points more towards a problem with the integration of IWYU
into AliceO2 cmake. We have to disable the feature and at some point fix
the integration.