### PR TITLE
Bugfix: make pointer data types non-messageable

### DIFF
--- a/Framework/Core/include/Framework/DataAllocator.h
+++ b/Framework/Core/include/Framework/DataAllocator.h
@@ -247,11 +247,12 @@ public:
 
   /// specialization to catch unsupported types and throw a detailed compiler error
   template <typename T>
-  typename std::enable_if<has_root_dictionary<T>::value == false &&
-                          is_specialization<T, ROOTSerialized>::value == false &&
-                          is_messageable<T>::value == false &&
-                          is_specialization<T, std::vector>::value == false>::type
-  snapshot(const OutputSpec& spec, T const&)
+  typename std::enable_if<has_root_dictionary<T>::value == false &&                //
+                          is_specialization<T, ROOTSerialized>::value == false &&  //
+                          is_messageable<T>::value == false &&                     //
+                          std::is_pointer<T>::value == false &&                    //
+                          is_specialization<T, std::vector>::value == false>::type //
+    snapshot(const OutputSpec& spec, T const&)
   {
     static_assert(has_root_dictionary<T>::value == true ||
                   is_specialization<T, ROOTSerialized>::value == true ||
@@ -281,7 +282,16 @@ public:
                   "\n - object with dictionary by reference");
   }
 
-private:
+  /// specialization to catch the case where a pointer to an object has been
+  /// accidentally given as parameter
+  template <typename T>
+  typename std::enable_if<std::is_pointer<T>::value>::type snapshot(const OutputSpec& spec, T const&)
+  {
+    static_assert(std::is_pointer<T>::value == false,
+                  "pointer to data type not supported by API. Please pass object by reference");
+  }
+
+ private:
   std::string matchDataHeader(const OutputSpec &spec, size_t timeframeId);
   FairMQMessagePtr headerMessageFromSpec(OutputSpec const &spec,
                                          std::string const &channel,

--- a/Framework/Core/include/Framework/DataRefUtils.h
+++ b/Framework/Core/include/Framework/DataRefUtils.h
@@ -149,6 +149,16 @@ struct DataRefUtils {
     }
     return std::move(result);
   }
+
+  static unsigned getPayloadSize(const DataRef& ref)
+  {
+    using DataHeader = o2::header::DataHeader;
+    auto header = o2::header::get<const DataHeader>(ref.header);
+    if (!header) {
+      return 0;
+    }
+    return header->payloadSize;
+  }
 };
 
 }

--- a/Framework/Core/include/Framework/TypeTraits.h
+++ b/Framework/Core/include/Framework/TypeTraits.h
@@ -44,10 +44,13 @@ struct is_forced_non_messageable<
 // TODO: extend this to exclude structs with pointer data members
 // see e.g. https://stackoverflow.com/questions/32880990/how-to-check-if-class-has-pointers-in-c14
 template <typename T>
-struct is_messageable : std::conditional<std::is_trivially_copyable<T>::value &&
-                                         !std::is_polymorphic<T>::value &&
-                                         !is_forced_non_messageable<T>::value,
-                                         std::true_type, std::false_type>::type {};
+struct is_messageable : std::conditional<std::is_trivially_copyable<T>::value && //
+                                           !std::is_polymorphic<T>::value &&     //
+                                           !std::is_pointer<T>::value &&         //
+                                           !is_forced_non_messageable<T>::value, //
+                                         std::true_type,
+                                         std::false_type>::type {
+};
 
 // Detect a container by checking on the container properties
 // this is the default trait implementation inheriting from false_type


### PR DESCRIPTION
The type trait was classifying pointers as messageable because they are
trivially copyable. But this is not what we want. Pointers are easy to
pass to the DataAllocator API by mistake, catching this case with a
proper compile error now.

Adding a helper function to DataRefUtils to estract the payload size from
DataRef.