### PR TITLE
Adapt CA ITS tracker for matching + fix in refit after matching

### DIFF
--- a/DataFormats/Detectors/ITSMFT/ITS/include/DataFormatsITS/TrackITS.h
+++ b/DataFormats/Detectors/ITSMFT/ITS/include/DataFormatsITS/TrackITS.h
@@ -75,7 +75,7 @@ class TrackITS : public o2::track::TrackParCov
   o2::track::TrackParCov mParamOut;               /// parameter at largest radius
   std::array<Int_t, MaxClusters> mIndex = { -1 }; ///< Indices of associated clusters
 
-  ClassDef(TrackITS, 2)
+  ClassDefNV(TrackITS, 2)
 };
 }
 }

--- a/DataFormats/Detectors/ITSMFT/ITS/src/TrackITS.cxx
+++ b/DataFormats/Detectors/ITSMFT/ITS/src/TrackITS.cxx
@@ -18,9 +18,7 @@
 #include "DataFormatsITSMFT/Cluster.h"
 #include "DataFormatsITS/TrackITS.h"
 
-ClassImp(o2::ITS::TrackITS)
-
-  using namespace o2::ITSMFT;
+using namespace o2::ITSMFT;
 using namespace o2::ITS;
 using namespace o2::constants::math;
 using namespace o2::track;

--- a/DataFormats/Parameters/include/DataFormatsParameters/GRPObject.h
+++ b/DataFormats/Parameters/include/DataFormatsParameters/GRPObject.h
@@ -108,6 +108,8 @@ class GRPObject
   /// print itself
   void print() const;
 
+  static GRPObject* loadFrom(const std::string grpFileName, std::string grpName = "GRP");
+
  private:
   timePoint mTimeStart = 0; ///< DAQ_time_start entry from DAQ logbook
   timePoint mTimeEnd = 0;   ///< DAQ_time_end entry from DAQ logbook

--- a/DataFormats/Parameters/src/GRPObject.cxx
+++ b/DataFormats/Parameters/src/GRPObject.cxx
@@ -12,6 +12,8 @@
 /// \brief Implementation of General Run Parameters object
 /// \author ruben.shahoyan@cern.ch
 
+#include <FairLogger.h>
+#include <TFile.h>
 #include "DataFormatsParameters/GRPObject.h"
 #include <cmath>
 #include "CommonConstants/PhysicsConstants.h"
@@ -65,4 +67,22 @@ void GRPObject::print() const
     printf("%7s ", isDetTriggers(DetID(i)) ? "   +   " : "   -   ");
     printf("\n");
   }
+}
+
+//_______________________________________________
+GRPObject* GRPObject::loadFrom(const std::string grpFileName, std::string grpName)
+{
+  // load object from file
+  TFile flGRP(grpFileName.data());
+  if (flGRP.IsZombie()) {
+    LOG(ERROR) << "Failed to open " << grpFileName << FairLogger::endl;
+    return nullptr;
+  }
+  auto grp = reinterpret_cast<o2::parameters::GRPObject*>(
+    flGRP.GetObjectChecked(grpName.data(), o2::parameters::GRPObject::Class()));
+  if (!grp) {
+    LOG(ERROR) << "Did not find GRP object named " << grpName << FairLogger::endl;
+    return nullptr;
+  }
+  return grp;
 }

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/Vertex.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/Vertex.h
@@ -128,6 +128,12 @@ std::ostream& operator<<(std::ostream& os, const Vertex<Stamp>& v)
      << "TimeStamp: " << v.getTimeStamp();
   return os;
 }
+
+template <typename Stamp>
+void Vertex<Stamp>::print() const
+{
+  std::cout << *this << std::endl;
+}
 }
 } // end namespace AliceO2
 #endif

--- a/DataFormats/Reconstruction/src/Track.cxx
+++ b/DataFormats/Reconstruction/src/Track.cxx
@@ -16,9 +16,6 @@ using o2::track::TrackPar;
 using o2::track::TrackParCov;
 using namespace o2::constants::math;
 
-ClassImp(o2::track::TrackParCov);
-ClassImp(o2::track::TrackPar);
-
 //______________________________________________________________
 TrackPar::TrackPar(const array<float, 3>& xyz, const array<float, 3>& pxpypz, int charge, bool sectorAlpha)
   : mX{ 0.f }, mAlpha{ 0.f }, mP{ 0.f }

--- a/Detectors/Base/src/Propagator.cxx
+++ b/Detectors/Base/src/Propagator.cxx
@@ -99,16 +99,9 @@ int Propagator::initFieldFromGRP(const std::string grpFileName, std::string grpN
 {
   /// load grp and init magnetic field
   LOG(INFO) << "Loading field from GRP of " << grpFileName << FairLogger::endl;
-  TFile flGRP(grpFileName.data());
-  if (flGRP.IsZombie()) {
-    LOG(ERROR) << "Failed to open " << grpFileName << FairLogger::endl;
-    return -10;
-  }
-  auto grp =
-    static_cast<o2::parameters::GRPObject*>(flGRP.GetObjectChecked(grpName.data(), o2::parameters::GRPObject::Class()));
+  const auto grp = o2::parameters::GRPObject::loadFrom(grpFileName, grpName);
   if (!grp) {
-    LOG(ERROR) << "Did not find GRP object named " << grpName << FairLogger::endl;
-    return -12;
+    return -1;
   }
   grp->print();
 

--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -1110,7 +1110,7 @@ bool MatchTPCITS::refitTrackITSTPC(const TrackLocITS& tITS)
   auto& trfit = mMatchedTracks.back();
   // in continuos mode the Z of TPC track is meaningless, unless it is CE crossing
   // track (currently absent, TODO)
-  if (mCompareTracksDZ) {
+  if (!mCompareTracksDZ) {
     trfit.setZ(tITS.getZ()); // fix the seed Z
   }
   float deltaT = (trfit.getZ() - tTPC.getZ()) * mZ2TPCBin; // time correction in time-bins

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/IOUtils.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/IOUtils.h
@@ -50,6 +50,8 @@ namespace IOUtils
 std::vector<Event> loadEventData(const std::string&);
 void loadEventData(Event& events, const std::vector<ITSMFT::Cluster>* mClustersArray,
                    const dataformats::MCTruthContainer<MCCompLabel>* mClsLabels = nullptr);
+int loadROFrameData(std::uint32_t roFrame, Event& events, const std::vector<ITSMFT::Cluster>* mClustersArray,
+                    const dataformats::MCTruthContainer<MCCompLabel>* mClsLabels = nullptr);
 std::vector<std::unordered_map<int, Label>> loadLabels(const int, const std::string&);
 void writeRoadsReport(std::ofstream&, std::ofstream&, std::ofstream&, const std::vector<std::vector<Road>>&,
                       const std::unordered_map<int, Label>&);

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/Tracker.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/Tracker.h
@@ -71,6 +71,9 @@ class Tracker : private TrackerTraits<IsGPU>
 
   void clustersToTracks(const Event&, std::ostream& = std::cout);
 
+  void setROFrame(std::uint32_t f) { mROFrame = f; }
+  std::uint32_t getROFrame() const { return mROFrame; }
+
  private:
   track::TrackParCov buildTrackSeed(const Cluster& cluster1, const Cluster& cluster2, const Cluster& cluster3,
                                     const TrackingFrameInfo& tf3);
@@ -90,6 +93,7 @@ class Tracker : private TrackerTraits<IsGPU>
   float evaluateTask(void (Tracker<IsGPU>::*)(T...), const char*, std::ostream& ostream, T&&... args);
 
   float mBz = 5.f;
+  std::uint32_t mROFrame = 0;
   PrimaryVertexContext mPrimaryVertexContext;
   std::vector<TrackITS> mTracks;
   dataformats::MCTruthContainer<MCCompLabel> mTrackLabels;

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CA/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CA/Tracker.cxx
@@ -447,7 +447,7 @@ void Tracker<IsGPU>::findTracks(const Event& event)
     fitSuccess = fitTrack(event, temporaryTrack, Constants::ITS::LayersNumber - 1, -1, -1);
     if (!fitSuccess)
       continue;
-
+    temporaryTrack.setROFrame(mROFrame);
     tracks.emplace_back(temporaryTrack);
   }
 

--- a/macro/run_match_TPCITS.C
+++ b/macro/run_match_TPCITS.C
@@ -68,7 +68,7 @@ void run_match_TPCITS(std::string path = "./", std::string outputfile = "o2match
   std::array<float, o2::track::kNParams> cutsNSig2 = { 49.f, 49.f, 49.f, 49.f, 49.f };
   matching.setCrudeAbsDiffCut(cutsAbs);
   matching.setCrudeNSigma2Cut(cutsNSig2);
-
+  matching.setTPCTimeEdgeZSafeMargin(3);
   matching.init();
 
   matching.run();


### PR DESCRIPTION
@mpuccio I see that the tracklet vertexer is still not use for CA tracker. The way you
were imposing the MCtruth vertex will not work cont. mode since the clusters tree entry does not correspond to MCHeader entries. Fixing this will require lengthy loop over MC vertices, don't think it worths it if the real vertexer will be attached soon. Therefore, the run_trac_ca_its at the moment imposes dummy 0,0,0 vertex and will work properly only with MC generated at this vertex (only in cont. mode, which is detected from the GRP). Could you please check if my changes in your code are ok.

Cheers,
 Ruben