### PR TITLE
Introducing optional hint for the class info to be used in ROOTSerialized type wrapper

### DIFF
--- a/Framework/Core/include/Framework/SerializationMethods.h
+++ b/Framework/Core/include/Framework/SerializationMethods.h
@@ -14,6 +14,7 @@
 /// @brief Type wrappers for enfording a specific serialization method
 
 #include "Framework/TypeTraits.h"
+#include "string"
 
 namespace o2
 {
@@ -40,13 +41,16 @@ class ROOTSerialized
   using non_messageable = o2::framework::MarkAsNonMessageable;
   using wrapped_type = T;
   ROOTSerialized() = delete;
-  ROOTSerialized(wrapped_type& ref) : mRef(ref) {}
+  ROOTSerialized(wrapped_type& ref, const char* refName = "") : mRef(ref), mRefName(refName) {}
 
   T& operator()() { return mRef; }
   T const& operator()() const { return mRef; }
 
+  const std::string& getName() const { return mRefName; }
+
  private:
   wrapped_type& mRef;
+  std::string mRefName; // optional name of the ref type
 };
 }
 }

--- a/Framework/Core/include/Framework/TMessageSerializer.h
+++ b/Framework/Core/include/Framework/TMessageSerializer.h
@@ -54,9 +54,9 @@ struct TMessageSerializer {
                         CacheStreamers streamers = CacheStreamers::no,
                         CompressionLevel compressionLevel = -1);
 
-  template<typename T>
-  static void Serialize(FairMQMessage& msg, const T* input, TClass* cl,
-                        CacheStreamers streamers = CacheStreamers::no,
+  template <typename T>
+  static void Serialize(FairMQMessage& msg, const T* input, const TClass* cl, //
+                        CacheStreamers streamers = CacheStreamers::no,        //
                         CompressionLevel compressionLevel = -1);
 
   static void Deserialize(const FairMQMessage& msg, std::unique_ptr<TObject>& output);
@@ -65,9 +65,9 @@ struct TMessageSerializer {
                         CacheStreamers streamers = CacheStreamers::no,
                         CompressionLevel compressionLevel = -1);
 
-  template<typename T>
-  static void serialize(FairTMessage& msg, const T* input,
-                        TClass* cl, CacheStreamers streamers = CacheStreamers::no,
+  template <typename T>
+  static void serialize(FairTMessage& msg, const T* input,                               //
+                        const TClass* cl, CacheStreamers streamers = CacheStreamers::no, //
                         CompressionLevel compressionLevel = -1);
   static std::unique_ptr<TObject> deserialize(gsl::span<byte> buffer);
 
@@ -101,9 +101,9 @@ inline void TMessageSerializer::serialize(FairTMessage& tm, const TObject* input
   return serialize(tm, input, nullptr, streamers, compressionLevel);
 }
 
-template<typename T>
-inline void TMessageSerializer::serialize(FairTMessage& tm, const T* input,
-                                          TClass* cl, CacheStreamers streamers,
+template <typename T>
+inline void TMessageSerializer::serialize(FairTMessage& tm, const T* input,           //
+                                          const TClass* cl, CacheStreamers streamers, //
                                           CompressionLevel compressionLevel)
 {
   if (streamers == CacheStreamers::yes) {
@@ -151,10 +151,10 @@ inline void TMessageSerializer::Serialize(FairMQMessage& msg, const TObject* inp
   tm.release();
 }
 
-template<typename T>
-inline void TMessageSerializer::Serialize(FairMQMessage& msg, const T* input,
-					  TClass* cl,
-                                          TMessageSerializer::CacheStreamers streamers,
+template <typename T>
+inline void TMessageSerializer::Serialize(FairMQMessage& msg, const T* input,           //
+                                          const TClass* cl,                             //
+                                          TMessageSerializer::CacheStreamers streamers, //
                                           TMessageSerializer::CompressionLevel compressionLevel)
 {
   std::unique_ptr<FairTMessage> tm = std::make_unique<FairTMessage>(kMESS_OBJECT);

--- a/Framework/Core/test/test_DataAllocator.cxx
+++ b/Framework/Core/test/test_DataAllocator.cxx
@@ -78,6 +78,9 @@ DataProcessorSpec getSourceSpec()
     pc.allocator().snapshot(OutputSpec{ "TST", "ROOTNONTOBJECT", 0, OutputSpec::Timeframe }, b);
     // vector of ROOT serializable class
     pc.allocator().snapshot(OutputSpec{ "TST", "ROOTVECTOR", 0, OutputSpec::Timeframe }, c);
+    // likewise, passed anonymously with char type and class name
+    o2::framework::ROOTSerialized<char> d(*((char*)&c), "vector<o2::test::Polymorphic>");
+    pc.allocator().snapshot(OutputSpec{ "TST", "ROOTSERLZDVEC", 0, OutputSpec::Timeframe }, d);
   };
 
   return DataProcessorSpec{ "source", // name of the processor
@@ -85,7 +88,8 @@ DataProcessorSpec getSourceSpec()
                             { OutputSpec{ "TST", "MESSAGEABLE", 0, OutputSpec::Timeframe },
                               OutputSpec{ "TST", "MSGBLEROOTSRLZ", 0, OutputSpec::Timeframe },
                               OutputSpec{ "TST", "ROOTNONTOBJECT", 0, OutputSpec::Timeframe },
-                              OutputSpec{ "TST", "ROOTVECTOR", 0, OutputSpec::Timeframe } },
+                              OutputSpec{ "TST", "ROOTVECTOR", 0, OutputSpec::Timeframe },
+                              OutputSpec{ "TST", "ROOTSERLZDVEC", 0, OutputSpec::Timeframe } },
                             AlgorithmSpec(processingFct) };
 }
 
@@ -100,27 +104,34 @@ DataProcessorSpec getSinkSpec()
     auto object1 = pc.inputs().get<o2::test::TriviallyCopyable>("input1");
     ASSERT_ERROR(*object1 == o2::test::TriviallyCopyable(42, 23, 0xdead));
 
-    auto object4 = pc.inputs().get<o2::test::TriviallyCopyable>("input4");
-    ASSERT_ERROR(*object4 == o2::test::TriviallyCopyable(42, 23, 0xdead));
+    auto object2 = pc.inputs().get<o2::test::TriviallyCopyable>("input2");
+    ASSERT_ERROR(*object2 == o2::test::TriviallyCopyable(42, 23, 0xdead));
 
-    auto object2 = pc.inputs().get<o2::test::Polymorphic>("input2");
-    ASSERT_ERROR(object2 != nullptr);
-    ASSERT_ERROR(*(object2.get()) == o2::test::Polymorphic(0xbeef));
-
-    auto object3 = pc.inputs().get<std::vector<o2::test::Polymorphic>>("input3");
+    auto object3 = pc.inputs().get<o2::test::Polymorphic>("input3");
     ASSERT_ERROR(object3 != nullptr);
-    ASSERT_ERROR(object3->size() == 2);
-    ASSERT_ERROR((*object3.get())[0] == o2::test::Polymorphic(0xaffe));
-    ASSERT_ERROR((*object3.get())[1] == o2::test::Polymorphic(0xd00f));
+    ASSERT_ERROR(*(object3.get()) == o2::test::Polymorphic(0xbeef));
+
+    auto object4 = pc.inputs().get<std::vector<o2::test::Polymorphic>>("input4");
+    ASSERT_ERROR(object4 != nullptr);
+    ASSERT_ERROR(object4->size() == 2);
+    ASSERT_ERROR((*object4.get())[0] == o2::test::Polymorphic(0xaffe));
+    ASSERT_ERROR((*object4.get())[1] == o2::test::Polymorphic(0xd00f));
+
+    auto object5 = pc.inputs().get<std::vector<o2::test::Polymorphic>>("input5");
+    ASSERT_ERROR(object5 != nullptr);
+    ASSERT_ERROR(object5->size() == 2);
+    ASSERT_ERROR((*object5.get())[0] == o2::test::Polymorphic(0xaffe));
+    ASSERT_ERROR((*object5.get())[1] == o2::test::Polymorphic(0xd00f));
 
     pc.services().get<ControlService>().readyToQuit(true);
   };
 
   return DataProcessorSpec{ "sink", // name of the processor
                             { InputSpec{ "input1", "TST", "MESSAGEABLE", 0, InputSpec::Timeframe },
-                              InputSpec{ "input4", "TST", "MSGBLEROOTSRLZ", 0, InputSpec::Timeframe },
-                              InputSpec{ "input2", "TST", "ROOTNONTOBJECT", 0, InputSpec::Timeframe },
-                              InputSpec{ "input3", "TST", "ROOTVECTOR", 0, InputSpec::Timeframe } },
+                              InputSpec{ "input2", "TST", "MSGBLEROOTSRLZ", 0, InputSpec::Timeframe },
+                              InputSpec{ "input3", "TST", "ROOTNONTOBJECT", 0, InputSpec::Timeframe },
+                              InputSpec{ "input4", "TST", "ROOTVECTOR", 0, InputSpec::Timeframe },
+                              InputSpec{ "input5", "TST", "ROOTSERLZDVEC", 0, InputSpec::Timeframe } },
                             Outputs{},
                             AlgorithmSpec(processingFct) };
 }


### PR DESCRIPTION
This allows for ROOT serialization by class name instead of class type,
e.g. to generically process data from branches of a TTree.

EDIT: updated more generic version uses either const char names or the TClass object directly, the latter for better performance.