### PR TITLE
LinkDef cleanup after moving of TPC::Cluster

### DIFF
--- a/DataFormats/Detectors/TPC/src/DataFormatsTPCLinkDef.h
+++ b/DataFormats/Detectors/TPC/src/DataFormatsTPCLinkDef.h
@@ -26,5 +26,7 @@
 #pragma link C++ class o2::TPC::TPCClusterFormatHelper + ;
 #pragma link C++ class o2::TPC::TrackTPC + ;
 #pragma link C++ class o2::TPC::Cluster + ;
+#pragma link C++ class std::vector < o2::TPC::Cluster > +;
+#pragma link C++ class std::vector < o2::TPC::TrackTPC > +;
 
 #endif

--- a/Detectors/TPC/reconstruction/src/TPCReconstructionLinkDef.h
+++ b/Detectors/TPC/reconstruction/src/TPCReconstructionLinkDef.h
@@ -32,7 +32,4 @@
 #pragma link C++ class o2::TPC::HwClusterFinder+;
 #pragma link C++ class o2::TPC::HwFixedPoint+;
 
-#pragma link C++ class std::vector<o2::TPC::Cluster>+;
-#pragma link C++ class std::vector<o2::TPC::TrackTPC>+;
-
 #endif


### PR DESCRIPTION
After moving TPC::Cluster to DataFormats/Detectors/TPC, this is also
the better place to define the dictionary generation of vector<TPC::Cluster>.