### PR TITLE
Move MID constants to a separate class

### DIFF
--- a/Detectors/MUON/MID/Base/CMakeLists.txt
+++ b/Detectors/MUON/MID/Base/CMakeLists.txt
@@ -3,12 +3,14 @@ set(MODULE_NAME "MIDBase")
 O2_SETUP(NAME ${MODULE_NAME})
 
 set(SRCS
+  src/Constants.cxx
   src/LegacyUtility.cxx
   src/Mapping.cxx
   src/MpArea.cxx
 )
 
 set(NO_DICT_HEADERS
+  include/${MODULE_NAME}/Constants.h
   include/${MODULE_NAME}/LegacyUtility.h
   include/${MODULE_NAME}/Mapping.h
   include/${MODULE_NAME}/MpArea.h

--- a/Detectors/MUON/MID/Base/include/MIDBase/Constants.h
+++ b/Detectors/MUON/MID/Base/include/MIDBase/Constants.h
@@ -1,0 +1,115 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDBase/Constants.h
+/// \brief  Useful constants for MID
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   08 March 2018
+#ifndef O2_MID_CONSTANTS_H
+#define O2_MID_CONSTANTS_H
+
+#include <array>
+
+namespace o2
+{
+namespace mid
+{
+class Constants
+{
+ public:
+  Constants() = default;
+  virtual ~Constants() = default;
+
+  Constants(const Constants&) = delete;
+  Constants& operator=(const Constants&) = delete;
+  Constants(Constants&&) = delete;
+  Constants& operator=(Constants&&) = delete;
+
+  /// The RPC is a short one
+  /// @param deId The detection element ID
+  inline static bool isShortRPC(int deId) { return (deId % 9 == 4); }
+
+  /// Returns the height of the local board in the chamber
+  /// @param chamber The chamber ID (0-3)
+  inline static double getLocalBoardHeight(int chamber) { return mLocalBoardHeight * mScaleFactors[chamber]; }
+
+  /// Returns the height of the local board in the chamber
+  /// @param chamber The chamber ID (0-3)
+  inline static double getLocalBoardWidth(int chamber) { return mLocalBoardWidth * mScaleFactors[chamber]; }
+
+  /// Returns the position of the center of the RPC in the chamber
+  /// @param chamber The chamber ID (0-3)
+  /// @param rpc The RPC ID (0-9)
+  inline static double getRPCCenterPosX(int chamber, int rpc)
+  {
+    return isShortRPC(rpc) ? mRPCShortCenterPos * mScaleFactors[chamber] : mRPCCenterPos * mScaleFactors[chamber];
+  }
+
+  /// Returns the half width of the RPC in the chamber
+  /// @param chamber The chamber ID (0-3)
+  /// @param rpc The RPC ID (0-9)
+  inline static double getRPCHalfWidth(int chamber, int rpc)
+  {
+    return isShortRPC(rpc) ? mRPCShortHalfWidth * mScaleFactors[chamber] : mRPCHalfWidth * mScaleFactors[chamber];
+  }
+
+  /// Returns the half height of the RPC in the chamber
+  /// @param chamber The chamber ID (0-3)
+  inline static double getRPCHalfHeight(int chamber) { return 2. * mLocalBoardHeight * mScaleFactors[chamber]; }
+
+  /// Returns the unit strip pitch size in the chamber
+  /// @param chamber The chamber ID (0-3)
+  inline static double getStripUnitPitchSize(int chamber) { return mStripUnitPitchSize * mScaleFactors[chamber]; }
+
+  /// Get chamber index from detection element ID
+  inline static int getChamber(int deId) { return (deId % 36) / 9; }
+
+  /// Gets detection element Id
+  /// @param isRight RPC is in right side
+  /// @param chamber The chamber ID (0-3)
+  /// @param rpc RPC ID (0-8)
+  inline static int getDEId(bool isRight, int chamber, int rpc)
+  {
+    int deOffset = (isRight) ? 0 : 36;
+    return deOffset + 9 * chamber + rpc;
+  }
+
+  static constexpr int mNChambers = 4;           ///< Number of chambers
+  static constexpr int mNDetectionElements = 72; ///< Number of RPCs
+  static constexpr int mNLocalBoards = 234;      ///< Number of local boards per chamber
+  static constexpr int mNStripsBP = 16;          ///< Number of strips in the Bending Plane
+
+  // Standard sizes/position in the first chamber.
+  // The values for the other chambers can be obtained multiplying by the scaling factors below
+  static constexpr double mLocalBoardHeight = 17.; ///< Local board height in the first chamber
+  static constexpr double mLocalBoardWidth = 34.;  ///< Local board width in the first chamber
+  static constexpr double mRPCCenterPos = 129.5;   ///< Position of most RPCs in the right side of the first chamber
+  static constexpr double mRPCHalfWidth = 127.5;   ///< Half width of most RPCs in the first chamber
+  static constexpr double mRPCShortCenterPos =
+    155.; ///< Position of the short RPC in the right side of the first chamber
+  static constexpr double mRPCShortHalfWidth = 102.;    ///< Half width of the short RPC in the first chamber
+  static constexpr double mStripUnitPitchSize = 1.0625; ///< Unit pitch size of the strip in the first chamber
+
+  static constexpr double mRPCZShift =
+    3.6; ///< Default shift of the RPC z position with respect to the average chamber position
+
+  static constexpr double mBeamAngle = -0.794; ///< Angle between beam position and horizontal
+
+  static constexpr std::array<const double, 4> mScaleFactors{
+    { 1., 1.01060, 1.06236, 1.07296 }
+  }; ///< Array of scale factors for projective geometry
+  static constexpr std::array<const double, 4> mDefaultChamberZ{
+    { -1603.5, -1620.5, -1703.5, -1720.5 }
+  }; ///< Array of default z position of the chamber
+};
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_MAPPING_H */

--- a/Detectors/MUON/MID/Base/include/MIDBase/Mapping.h
+++ b/Detectors/MUON/MID/Base/include/MIDBase/Mapping.h
@@ -86,10 +86,9 @@ class Mapping
   void buildDETypeMedium(int rpcType, std::array<int, 7> boards, bool largeNonBend);
   void buildDETypeCut(int rpcType, std::array<int, 7> boards, bool isBelowBeamPipe);
   void buildDETypeShort(int rpcType, std::array<int, 7> boards);
-  int getChamber(int deId) const;
-  int getRPCType(int deId) const;
+  /// Gets the RPC type of detection element deId
+  inline int getRPCType(int deId) const { return deId % 9; }
   double getStripSize(int chamber, int stripPitch, int strip = 0) const;
-  double getRPCCenterX(int chamber, int rpcType) const;
   double getColumnLeftPosition(int column, int chamber, int rpcType) const;
   double getColumnBottomPosition(int column, int chamber, int rpcType) const;
   double getColumnHeight(int column, int chamber, int rpcType) const;
@@ -103,13 +102,8 @@ class Mapping
   std::vector<MpStripIndex> getNeighboursBP(const MpStripIndex& stripIndex, int rpcType) const;
   std::vector<MpStripIndex> getNeighboursNBP(const MpStripIndex& stripIndex, int rpcType) const;
 
-  const double mUnitPitchSize;                 ///< Unit pitch size
-  const double mBaseRPCHalfWidth;              ///< Typical half width of the RPC
-  const double mBaseBoardWidth;                ///< Local board width in chamber 11
-  const double mBaseBoardHeight;               ///< Local board height in chamber 11
   std::array<MpDE, 9> mDetectionElements;      ///< Array of detection element
   std::array<MpBoardIndex, 118> mBoardIndexes; ///< Array of board indexes
-  std::array<double, 4> mScaleFactors;         ///< Array of scale factors for projective geometry
 };
 } // namespace mid
 } // namespace o2

--- a/Detectors/MUON/MID/Base/src/Constants.cxx
+++ b/Detectors/MUON/MID/Base/src/Constants.cxx
@@ -1,0 +1,25 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Base/src/Constants.cxx
+/// \brief  Implementation of constants for MID
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   08 March 2018
+#include "MIDBase/Constants.h"
+
+namespace o2
+{
+namespace mid
+{
+constexpr std::array<const double, 4> Constants::mScaleFactors;
+constexpr std::array<const double, 4> Constants::mDefaultChamberZ;
+
+} // namespace mid
+} // namespace o2


### PR DESCRIPTION
This allows a re-use of code in existing and future classes.