### PR TITLE
Provide monitoring in O2Device

### DIFF
--- a/Utilities/O2Device/include/O2Device/O2Device.h
+++ b/Utilities/O2Device/include/O2Device/O2Device.h
@@ -30,6 +30,7 @@
 
 #include <FairMQDevice.h>
 #include "Headers/DataHeader.h"
+#include "Monitoring/MonitoringFactory.h"
 #include <stdexcept>
 
 namespace o2 {
@@ -44,6 +45,23 @@ class O2Device : public FairMQDevice
 public:
   using FairMQDevice::FairMQDevice;
   ~O2Device() override = default;
+
+  std::unique_ptr<o2::monitoring::Monitoring> monitoring;
+  
+  o2::monitoring::Monitoring* GetMonitoring() {
+    return monitoring.get();
+  }
+
+  void InitTask() {
+    std::string monitoringKey = "monitoring-url";
+    //FairMQDevice::Init();
+    //using o2::monitoring::MonitoringFactory;
+    auto dupa = GetConfig()->Count(monitoringKey);
+      /*monitoring->addBackend(MonitoringFactory::GetBackend(
+        GetConfig()->CountGetValiue<std::string>("monitoring-url")
+      ));*/
+    //}
+  }
 
   /// Here is how to add an annotated data part (with header);
   /// @param[in,out] parts is a reference to the message;

--- a/Utilities/O2Device/include/O2Device/O2Device.h
+++ b/Utilities/O2Device/include/O2Device/O2Device.h
@@ -47,17 +47,15 @@ public:
   using FairMQDevice::FairMQDevice;
   ~O2Device() override = default;
 
-
   /// Monitoring instance
   std::unique_ptr<o2::monitoring::Monitoring> monitoring;
-  
+
   /// Provides monitoring instance
-  auto GetMonitoring() {
-    return monitoring.get();
-  }
+  auto GetMonitoring() { return monitoring.get(); }
 
   /// Connects to a monitoring backend
-  void Init() override {
+  void Init() override
+  {
     FairMQDevice::Init();
     static constexpr const char* MonitoringUrlKey = "monitoring-url";
     std::string monitoringUrl = GetConfig()->GetValue<std::string>(MonitoringUrlKey);

--- a/Utilities/O2Device/include/O2Device/O2Device.h
+++ b/Utilities/O2Device/include/O2Device/O2Device.h
@@ -29,6 +29,7 @@
 #define O2DEVICE_H_
 
 #include <FairMQDevice.h>
+#include <options/FairMQProgOptions.h>
 #include "Headers/DataHeader.h"
 #include "Monitoring/MonitoringFactory.h"
 #include <stdexcept>
@@ -59,7 +60,7 @@ public:
   void Init() override {
     FairMQDevice::Init();
     static constexpr const char* MonitoringUrlKey = "monitoring-url";
-    std::string monitoringUrl = "infologger://"; //GetConfig()->GetValue<std::string>(MonitoringUrlKey);
+    std::string monitoringUrl = GetConfig()->GetValue<std::string>(MonitoringUrlKey);
     monitoring->addBackend(o2::monitoring::MonitoringFactory::GetBackend(monitoringUrl));
   }
 

--- a/Utilities/O2Device/include/O2Device/O2Device.h
+++ b/Utilities/O2Device/include/O2Device/O2Device.h
@@ -46,21 +46,21 @@ public:
   using FairMQDevice::FairMQDevice;
   ~O2Device() override = default;
 
+
+  /// Monitoring instance
   std::unique_ptr<o2::monitoring::Monitoring> monitoring;
   
-  o2::monitoring::Monitoring* GetMonitoring() {
+  /// Provides monitoring instance
+  auto GetMonitoring() {
     return monitoring.get();
   }
 
-  void InitTask() {
-    std::string monitoringKey = "monitoring-url";
-    //FairMQDevice::Init();
-    //using o2::monitoring::MonitoringFactory;
-    auto dupa = GetConfig()->Count(monitoringKey);
-      /*monitoring->addBackend(MonitoringFactory::GetBackend(
-        GetConfig()->CountGetValiue<std::string>("monitoring-url")
-      ));*/
-    //}
+  /// Connects to a monitoring backend
+  void Init() override {
+    FairMQDevice::Init();
+    static constexpr const char* MonitoringUrlKey = "monitoring-url";
+    std::string monitoringUrl = "infologger://"; //GetConfig()->GetValue<std::string>(MonitoringUrlKey);
+    monitoring->addBackend(o2::monitoring::MonitoringFactory::GetBackend(monitoringUrl));
   }
 
   /// Here is how to add an annotated data part (with header);

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -35,6 +35,7 @@ find_package(FairRoot REQUIRED)
 find_package(FairMQ REQUIRED)
 find_package(Protobuf REQUIRED)
 find_package(Configuration REQUIRED)
+find_package(Monitoring REQUIRED)
 
 find_package(GLFW)
 
@@ -163,9 +164,11 @@ o2_define_bucket(
     FairRoot::FairMQ
     pthread
     dl
+    ${Monitoring_LIBRARIES}
 
     INCLUDE_DIRECTORIES
     ${FAIRROOT_INCLUDE_DIR}
+    ${Monitoring_INCLUDE_DIRS}
 )
 
 # a common bucket for the implementation of devices inherited

--- a/cmake/modules/FindMonitoring.cmake
+++ b/cmake/modules/FindMonitoring.cmake
@@ -2,7 +2,6 @@
 # Author: Barthelemy von Haller
 # Author: Adam Wegrzynek
 #
-#
 # This module will set the following non-cached variables:
 #  Monitoring_FOUND - states whether Monitoring package has been found
 #  Monitoring_INCLUDE_DIRS - Monitoring include directory

--- a/cmake/modules/FindMonitoring.cmake
+++ b/cmake/modules/FindMonitoring.cmake
@@ -1,0 +1,43 @@
+# - Tries to find the O2 Monitoring package (include dir and library)
+# Author: Barthelemy von Haller
+# Author: Adam Wegrzynek
+#
+#
+# This module will set the following non-cached variables:
+#  Monitoring_FOUND - states whether Monitoring package has been found
+#  Monitoring_INCLUDE_DIRS - Monitoring include directory
+#  Monitoring_LIBRARIES - Monitoring library filepath
+#  Monitoring_DEFINITIONS - Compiler definitions when comping code using Monitoring
+#
+# Also following cached variables, but not for general use, are defined:
+#  MONITORING_INCLUDE_DIR
+#  MONITORING_LIBRARY
+#
+# This module respects following variables:
+#  Monitoring_ROOT - Installation root directory (otherwise it goes through LD_LIBRARY_PATH and ENV)
+
+# Init
+include(FindPackageHandleStandardArgs)
+
+# find includes
+find_path(MONITORING_INCLUDE_DIR Monitoring.h
+           HINTS ${Monitoring_ROOT}/include ENV LD_LIBRARY_PATH PATH_SUFFIXES "../include/Monitoring" "../../include/Monitoring" )
+
+# Remove the final "Monitoring"
+get_filename_component(MONITORING_INCLUDE_DIR ${MONITORING_INCLUDE_DIR} DIRECTORY)
+set(Monitoring_INCLUDE_DIRS ${MONITORING_INCLUDE_DIR})
+
+# find library
+find_library(MONITORING_LIBRARY NAMES Monitoring HINTS ${Monitoring_ROOT}/lib ENV LD_LIBRARY_PATH)
+set(Monitoring_LIBRARIES ${MONITORING_LIBRARY})
+
+# handle the QUIETLY and REQUIRED arguments and set Monitoring_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(Monitoring  "Monitoring could not be found. Set Monitoring_ROOT as root installation directory."
+                                  MONITORING_LIBRARY MONITORING_INCLUDE_DIR)
+if(${Monitoring_FOUND})
+    set(Monitoring_DEFINITIONS "")
+    message(STATUS "Monitoring found : ${Monitoring_LIBRARIES}")
+endif()
+
+mark_as_advanced(MONITORING_INCLUDE_DIR MONITORING_LIBRARY)


### PR DESCRIPTION
I'm not sure from where I could pick up channel metrics.
This is the code to do so:
```cpp
for (const auto& mi : fChannels) {
  for (const auto& vi : mi.second) {
    monitoring->sendGrouped(vi.GetChannelName(), {
      {(uint64_t) vi.GetBytesTx(), "BytesTx"},
      {(uint64_t) vi.GetBytesRx(), "BytesRx"},
      {(uint64_t) vi.GetMessagesTx(), "MessagesTx"}
      {(uint64_t) vi.GetMessagesRx(), "MessagesRx"}
    }); 
  }   
}
```

Remove `#include "options/FairMQProgOptions.h"` as soon as https://github.com/FairRootGroup/FairRoot/pull/745 is merged and new version of FairRoot released in `alisw`.