### PR TITLE
Quote some strings to allow e.g. for dashes in processor names

### DIFF
--- a/Framework/Core/src/GraphvizHelpers.cxx
+++ b/Framework/Core/src/GraphvizHelpers.cxx
@@ -18,7 +18,7 @@ namespace framework {
 
 namespace
 {
-std::string quote(std::string s) { return "\"" + s + "\""; }
+std::string quote(std::string s) { return R"(")" + s + R"(")"; }
 } // namespace
 
 /// Helper to dump a workflow as a graphviz file
@@ -75,11 +75,9 @@ GraphvizHelpers::dumpDeviceSpec2Graphviz(std::ostream &out, const std::vector<De
     for (auto &input : spec.inputChannels) {
       // input and output name are now the same
       auto outputName = input.name;
-      out << "  " << quote(outputChannel2Device[outputName]) << ":" << quote(outputName)
-                  << "-> "
-                  << quote(spec.id) << ":" << quote(input.name)
-                  << R"( [label=")" << input.port << R"(")"
-                  << "]\n";
+      out << "  " << quote(outputChannel2Device[outputName]) << ":" << quote(outputName) << "-> " << quote(spec.id)
+          << ":" << quote(input.name) << R"( [label=")" << input.port << R"(")"
+          << "]\n";
     }
   }
   out << "}\n";

--- a/Framework/Core/src/GraphvizHelpers.cxx
+++ b/Framework/Core/src/GraphvizHelpers.cxx
@@ -16,6 +16,11 @@
 namespace o2 {
 namespace framework {
 
+namespace
+{
+std::string quote(std::string s) { return "\"" + s + "\""; }
+} // namespace
+
 /// Helper to dump a workflow as a graphviz file
 void
 GraphvizHelpers::dumpDataProcessorSpec2Graphviz(std::ostream &out, const std::vector<DataProcessorSpec> &specs)
@@ -40,8 +45,7 @@ GraphvizHelpers::dumpDeviceSpec2Graphviz(std::ostream &out, const std::vector<De
 
   for (auto &spec : specs) {
     auto id = spec.id;
-    std::replace(id.begin(), id.end(), '-', '_'); // replace all 'x' to 'y'
-    out << "  " << id << R"( [label="{{)";
+    out << "  " << quote(id) << R"( [label="{{)";
     bool firstInput = true;
     for (auto && input : spec.inputChannels) {
       if (firstInput == false) {
@@ -69,14 +73,11 @@ GraphvizHelpers::dumpDeviceSpec2Graphviz(std::ostream &out, const std::vector<De
   }
   for (auto &spec : specs) {
     for (auto &input : spec.inputChannels) {
-      auto id = spec.id;
-      std::replace(id.begin(), id.end(), '-', '_'); // replace all 'x' to 'y'
       // input and output name are now the same
       auto outputName = input.name;
-      // outputName.erase(0, 3);
-      out << "  " << outputChannel2Device[outputName] << ":" << outputName
+      out << "  " << quote(outputChannel2Device[outputName]) << ":" << quote(outputName)
                   << "-> "
-                  << id << ":" << input.name
+                  << quote(spec.id) << ":" << quote(input.name)
                   << R"( [label=")" << input.port << R"(")"
                   << "]\n";
     }

--- a/Framework/Core/test/test_Graphviz.cxx
+++ b/Framework/Core/test/test_Graphviz.cxx
@@ -30,11 +30,20 @@ void lineByLineComparision(const std::string& as, const std::string& bs)
 
   char bufferA[1024];
   char bufferB[1024];
-
+ 
+  bool same{true};
   while (a.good() && b.good()) {
     a.getline(bufferA, 1024);
     b.getline(bufferB, 1024);
     BOOST_CHECK_EQUAL(std::string(bufferA), std::string(bufferB));
+    if (std::string(bufferA) != std::string(bufferB)) {
+      same=false;
+    }
+  }
+  if (!same){
+  std::cout << as << "\n";
+  std::cout << "\n";
+  std::cout << bs << "\n";
   }
   BOOST_CHECK(a.eof());
   BOOST_CHECK(b.eof());
@@ -100,14 +109,14 @@ BOOST_AUTO_TEST_CASE(TestGraphviz)
   GraphvizHelpers::dumpDeviceSpec2Graphviz(str, devices);
   lineByLineComparision(str.str(), R"EXPECTED(digraph structs {
   node[shape=record]
-  A [label="{{}|A(2)|{<from_A_to_B>from_A_to_B|<from_A_to_C>from_A_to_C}}"];
-  B [label="{{<from_A_to_B>from_A_to_B}|B(2)|{<from_B_to_D>from_B_to_D}}"];
-  C [label="{{<from_A_to_C>from_A_to_C}|C(2)|{<from_C_to_D>from_C_to_D}}"];
-  D [label="{{<from_B_to_D>from_B_to_D|<from_C_to_D>from_C_to_D}|D(2)|{}}"];
-  A:from_A_to_B-> B:from_A_to_B [label="22000"]
-  A:from_A_to_C-> C:from_A_to_C [label="22001"]
-  B:from_B_to_D-> D:from_B_to_D [label="22002"]
-  C:from_C_to_D-> D:from_C_to_D [label="22003"]
+  "A" [label="{{}|A(2)|{<from_A_to_B>from_A_to_B|<from_A_to_C>from_A_to_C}}"];
+  "B" [label="{{<from_A_to_B>from_A_to_B}|B(2)|{<from_B_to_D>from_B_to_D}}"];
+  "C" [label="{{<from_A_to_C>from_A_to_C}|C(2)|{<from_C_to_D>from_C_to_D}}"];
+  "D" [label="{{<from_B_to_D>from_B_to_D|<from_C_to_D>from_C_to_D}|D(2)|{}}"];
+  "A":"from_A_to_B"-> "B":"from_A_to_B" [label="22000"]
+  "A":"from_A_to_C"-> "C":"from_A_to_C" [label="22001"]
+  "B":"from_B_to_D"-> "D":"from_B_to_D" [label="22002"]
+  "C":"from_C_to_D"-> "D":"from_C_to_D" [label="22003"]
 }
 )EXPECTED");
 }
@@ -135,21 +144,21 @@ BOOST_AUTO_TEST_CASE(TestGraphvizWithPipeline)
   GraphvizHelpers::dumpDeviceSpec2Graphviz(str, devices);
   lineByLineComparision(str.str(), R"EXPECTED(digraph structs {
   node[shape=record]
-  A [label="{{}|A(3)|{<from_A_to_B_t0>from_A_to_B_t0|<from_A_to_B_t1>from_A_to_B_t1|<from_A_to_B_t2>from_A_to_B_t2}}"];
-  B_t0 [label="{{<from_A_to_B_t0>from_A_to_B_t0}|B_t0(3)|{<from_B_t0_to_C_t0>from_B_t0_to_C_t0|<from_B_t0_to_C_t1>from_B_t0_to_C_t1}}"];
-  B_t1 [label="{{<from_A_to_B_t1>from_A_to_B_t1}|B_t1(3)|{<from_B_t1_to_C_t0>from_B_t1_to_C_t0|<from_B_t1_to_C_t1>from_B_t1_to_C_t1}}"];
-  B_t2 [label="{{<from_A_to_B_t2>from_A_to_B_t2}|B_t2(3)|{<from_B_t2_to_C_t0>from_B_t2_to_C_t0|<from_B_t2_to_C_t1>from_B_t2_to_C_t1}}"];
-  C_t0 [label="{{<from_B_t0_to_C_t0>from_B_t0_to_C_t0|<from_B_t1_to_C_t0>from_B_t1_to_C_t0|<from_B_t2_to_C_t0>from_B_t2_to_C_t0}|C_t0(3)|{}}"];
-  C_t1 [label="{{<from_B_t0_to_C_t1>from_B_t0_to_C_t1|<from_B_t1_to_C_t1>from_B_t1_to_C_t1|<from_B_t2_to_C_t1>from_B_t2_to_C_t1}|C_t1(3)|{}}"];
-  A:from_A_to_B_t0-> B_t0:from_A_to_B_t0 [label="22000"]
-  A:from_A_to_B_t1-> B_t1:from_A_to_B_t1 [label="22001"]
-  A:from_A_to_B_t2-> B_t2:from_A_to_B_t2 [label="22002"]
-  B_t0:from_B_t0_to_C_t0-> C_t0:from_B_t0_to_C_t0 [label="22003"]
-  B_t1:from_B_t1_to_C_t0-> C_t0:from_B_t1_to_C_t0 [label="22005"]
-  B_t2:from_B_t2_to_C_t0-> C_t0:from_B_t2_to_C_t0 [label="22007"]
-  B_t0:from_B_t0_to_C_t1-> C_t1:from_B_t0_to_C_t1 [label="22004"]
-  B_t1:from_B_t1_to_C_t1-> C_t1:from_B_t1_to_C_t1 [label="22006"]
-  B_t2:from_B_t2_to_C_t1-> C_t1:from_B_t2_to_C_t1 [label="22008"]
+  "A" [label="{{}|A(3)|{<from_A_to_B_t0>from_A_to_B_t0|<from_A_to_B_t1>from_A_to_B_t1|<from_A_to_B_t2>from_A_to_B_t2}}"];
+  "B_t0" [label="{{<from_A_to_B_t0>from_A_to_B_t0}|B_t0(3)|{<from_B_t0_to_C_t0>from_B_t0_to_C_t0|<from_B_t0_to_C_t1>from_B_t0_to_C_t1}}"];
+  "B_t1" [label="{{<from_A_to_B_t1>from_A_to_B_t1}|B_t1(3)|{<from_B_t1_to_C_t0>from_B_t1_to_C_t0|<from_B_t1_to_C_t1>from_B_t1_to_C_t1}}"];
+  "B_t2" [label="{{<from_A_to_B_t2>from_A_to_B_t2}|B_t2(3)|{<from_B_t2_to_C_t0>from_B_t2_to_C_t0|<from_B_t2_to_C_t1>from_B_t2_to_C_t1}}"];
+  "C_t0" [label="{{<from_B_t0_to_C_t0>from_B_t0_to_C_t0|<from_B_t1_to_C_t0>from_B_t1_to_C_t0|<from_B_t2_to_C_t0>from_B_t2_to_C_t0}|C_t0(3)|{}}"];
+  "C_t1" [label="{{<from_B_t0_to_C_t1>from_B_t0_to_C_t1|<from_B_t1_to_C_t1>from_B_t1_to_C_t1|<from_B_t2_to_C_t1>from_B_t2_to_C_t1}|C_t1(3)|{}}"];
+  "A":"from_A_to_B_t0"-> "B_t0":"from_A_to_B_t0" [label="22000"]
+  "A":"from_A_to_B_t1"-> "B_t1":"from_A_to_B_t1" [label="22001"]
+  "A":"from_A_to_B_t2"-> "B_t2":"from_A_to_B_t2" [label="22002"]
+  "B_t0":"from_B_t0_to_C_t0"-> "C_t0":"from_B_t0_to_C_t0" [label="22003"]
+  "B_t1":"from_B_t1_to_C_t0"-> "C_t0":"from_B_t1_to_C_t0" [label="22005"]
+  "B_t2":"from_B_t2_to_C_t0"-> "C_t0":"from_B_t2_to_C_t0" [label="22007"]
+  "B_t0":"from_B_t0_to_C_t1"-> "C_t1":"from_B_t0_to_C_t1" [label="22004"]
+  "B_t1":"from_B_t1_to_C_t1"-> "C_t1":"from_B_t1_to_C_t1" [label="22006"]
+  "B_t2":"from_B_t2_to_C_t1"-> "C_t1":"from_B_t2_to_C_t1" [label="22008"]
 }
 )EXPECTED");
 }

--- a/Framework/Core/test/test_Graphviz.cxx
+++ b/Framework/Core/test/test_Graphviz.cxx
@@ -30,20 +30,10 @@ void lineByLineComparision(const std::string& as, const std::string& bs)
 
   char bufferA[1024];
   char bufferB[1024];
- 
-  bool same{true};
   while (a.good() && b.good()) {
     a.getline(bufferA, 1024);
     b.getline(bufferB, 1024);
     BOOST_CHECK_EQUAL(std::string(bufferA), std::string(bufferB));
-    if (std::string(bufferA) != std::string(bufferB)) {
-      same=false;
-    }
-  }
-  if (!same){
-  std::cout << as << "\n";
-  std::cout << "\n";
-  std::cout << bs << "\n";
   }
   BOOST_CHECK(a.eof());
   BOOST_CHECK(b.eof());


### PR DESCRIPTION
@ktf 

Got a few issues with an invalid (because of dashes in names) dot file generated by "my workflow -g"
Seems the replace of dashes by underscores was not done in all required places.

But anyway why not simply quote the strings instead ?
I tested my mods on a few workflows and it seems to work... e.g. : 

```bash
rm -rf toto.html && o2DummyWorkflow -g | grep -v '^\[INFO' | dot -Tsvg > toto.html
```