### PR TITLE
Adding generic DPL reader utility for ROOT TTree

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -118,6 +118,7 @@ set(HEADERS
       include/Framework/RootObjectContext.h
       include/Framework/DataProcessingDevice.h
       include/Framework/Variant.h
+      include/Framework/RootTreeReader.h
       src/DDSConfigHelpers.h
       src/DeviceSpecHelpers.h
       src/DriverControl.h
@@ -192,6 +193,7 @@ set(TEST_SRCS
       test/test_WorkflowHelpers.cxx
       test/test_TMessageSerializer.cxx
       test/test_DataAllocator.cxx
+      test/test_RootTreeReader.cxx
    )
 
 O2_GENERATE_TESTS(

--- a/Framework/Core/include/Framework/RootTreeReader.h
+++ b/Framework/Core/include/Framework/RootTreeReader.h
@@ -1,0 +1,251 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef FRAMEWORK_ROOTTREEREADER_H
+#define FRAMEWORK_ROOTTREEREADER_H
+
+/// @file   RootTreeReader.h
+/// @author Matthias Richter
+/// @since  2018-03-15
+/// @brief  A generic reader for ROOT TTrees
+
+#include "Framework/OutputSpec.h"
+#include <TChain.h>
+#include <TTree.h>
+#include <TBranch.h>
+#include <TClass.h>
+#include <vector>
+#include <string>
+#include <stdexcept> // std::runtime_error
+#include <type_traits>
+#include <memory>     // std::make_unique
+#include <functional> // std::function
+#include <utility>    // std::forward
+
+namespace o2
+{
+namespace framework
+{
+
+/// @class RootTreeReader
+/// A generic reader interface for ROOT TTrees
+///
+/// The reader interfaces one TTree specified by its name, and supports this
+/// tree to be distributed over multiple files multiple files.
+///
+/// The class uses a KeyType to define sinks for specific branches, the default
+/// key type is OutputSpec. Branches are defined for processing by pairs of
+/// key type and branch name.
+///
+/// Usage (for the default KeyType):
+///   RootTreeReader(treename,
+///                  filename1, filename2, ...,
+///                  OutputSpec{...}, branchname1,
+///                  OutputSpec{...}, branchname2,
+///                 ) reader;
+///   auto processSomething = [] (auto& key, auto& object) {/*do something*/};
+///   while (reader.next()) {
+///     reader.process(processSomething);
+///   }
+///   // -- or --
+///   while ((++reader)(processSomething));
+///
+/// In the DPL AlgorithmSpec the processing lambda can simple look like
+///   auto processingFct = [reader](ProcessingContext& pc) {
+///     // increment the reader and invoke it for the processing context
+///     (++reader)(pc);
+///   };
+/// Note that reader has to be set up in the init callback and it must
+/// be static there to persist. It can also be a shared_pointer, which then
+/// requires additional dereferencing in the syntax.
+///
+template <typename KeyType = OutputSpec>
+class RootTreeReader
+{
+ public:
+  using self_type = RootTreeReader<KeyType>;
+  using key_type = KeyType;
+
+  // the key must not be of type const char* to make sure that the variable argument
+  // list of the constructor can be parsed
+  static_assert(std::is_same<KeyType, const char*>::value == false, "the key type must not be const char*");
+
+  /// default constructor
+  RootTreeReader();
+
+  /// constructor
+  /// @param treename  name of tree to process
+  /// variable argument list of file names followed by pairs of KeyType and branch name
+  template <typename... Args>
+  RootTreeReader(const char* treename, // name of the tree to read from
+                 Args&&... args)       // file names, followed by branch info
+    : mInput(treename)
+  {
+    parseConstructorArgs(std::forward<Args>(args)...);
+  }
+
+  /// constructor
+  /// @param treename  name of tree to process
+  /// @nMaxEntries maximum number of entries to be processed
+  /// variable argument list of file names followed by pairs of KeyType and branch name
+  template <typename... Args>
+  RootTreeReader(const char* treename, // name of the tree to read from
+                 int nMaxEntries,      // max number of entries to be read
+                 Args&&... args)       // file names, followed by branch info
+    : mInput(treename),
+      mMaxEntries(nMaxEntries)
+  {
+    parseConstructorArgs(std::forward<Args>(args)...);
+  }
+
+  /// add a file as source for the tree
+  void addFile(const char* fileName)
+  {
+    mInput.AddFile(fileName);
+    mNEntries = mInput.GetEntries();
+  }
+
+  /// move to the next entry
+  /// @return true if data is available
+  bool next()
+  {
+    if ((mEntry + 1) >= mNEntries || mNEntries == 0) {
+      // TODO: decide what to do, maybe different modes can be supported
+      // e.g. loop or single shot mode
+      ++mEntry;
+      return false;
+    }
+    if (mMaxEntries > 0 && (mEntry + 1) >= mMaxEntries) {
+      ++mEntry;
+      return false;
+    }
+    mInput.GetEntry(++mEntry);
+    return true;
+  }
+
+  /// prefix increment, move to the next entry
+  self_type& operator++()
+  {
+    next();
+    return *this;
+  }
+  /// postfix increment forbidden
+  self_type& operator++(int) = delete;
+
+  /// the type wrapper to mark the data to be ROOT serialized, object is passed
+  /// by not-type-aware char*, and the actual class info is provided.
+  using ROOTSerializedByClass = o2::framework::ROOTSerialized<char, TClass>;
+
+  /// process functor
+  /// It expects a context which is used by lambda capture in the snapshot function.
+  /// Loop over all branch definitions and publish by using the snapshot function.
+  /// The default forwards to DPL DataAllocator snapshot.
+  ///
+  /// Note: For future extension we probably get rid of the context and want to use
+  /// o2::snapshot, can be easily adjusted by exchanging the lambda.
+  template <typename ContextType>
+  bool operator()(ContextType& context,
+                  std::function<void(const KeyType&, const ROOTSerializedByClass&)> snapshot = nullptr)
+  {
+    if (!snapshot) {
+      snapshot = [&context](const KeyType& key, const ROOTSerializedByClass& object) {
+        context.allocator().snapshot(key, object);
+      };
+    }
+
+    return process(snapshot);
+  }
+
+  bool process(std::function<void(const KeyType&, const ROOTSerializedByClass&)> snapshot = nullptr)
+  {
+    if (!snapshot) {
+      return false;
+    }
+
+    if (mEntry >= mNEntries || mNEntries == 0 || (mMaxEntries > 0 && mEntry >= mMaxEntries)) {
+      return false;
+    }
+
+    for (auto& spec : mBranchSpecs) {
+      if (spec.second->data == nullptr) {
+        // FIXME: is this an error?
+        continue;
+      }
+      snapshot(spec.first, ROOTSerializedByClass(*spec.second->data, spec.second->classinfo));
+    }
+    return true;
+  }
+
+ private:
+  struct BranchSpec {
+    std::string name;
+    char* data = nullptr;
+    TBranch* branch = nullptr;
+    TClass* classinfo = nullptr;
+  };
+
+  /// add a new branch definition
+  /// we allow for multiple branch definition for the same key
+  void addBranchSpec(KeyType key, const char* branchName)
+  {
+    // right now we allow the same key to appear for multiple branches
+    mBranchSpecs.emplace_back(key, std::make_unique<BranchSpec>(BranchSpec{ branchName }));
+    auto branch = mInput.GetBranch(mBranchSpecs.back().second->name.c_str());
+    if (branch) {
+      branch->SetAddress(&(mBranchSpecs.back().second->data));
+      mBranchSpecs.back().second->branch = branch;
+      mBranchSpecs.back().second->classinfo = TClass::GetClass(branch->GetClassName());
+      LOG(INFO) << "branch set up: " << branchName;
+    } else {
+      std::string msg("can not find branch ");
+      msg += branchName;
+      throw std::runtime_error(msg);
+    }
+  }
+
+  /// helper function to recursively parse constructor arguments
+  /// this is the first part pasing all the file name, stops when the first key
+  /// is found
+  template <typename... Args>
+  void parseConstructorArgs(const char* fileName, Args&&... args)
+  {
+    addFile(fileName);
+    parseConstructorArgs(std::forward<Args>(args)...);
+  }
+
+  /// helper function to recursively parse constructor arguments
+  /// parse the branch definitions with key and branch name.
+  template <typename... Args>
+  void parseConstructorArgs(KeyType key, const char* name, Args&&... args)
+  {
+    if (name != nullptr && *name != 0) {
+      // add branch spec if the name is not empty
+      addBranchSpec(key, name);
+    }
+    parseConstructorArgs(std::forward<Args>(args)...);
+  }
+
+  // this terminates the argument parsing
+  void parseConstructorArgs() {}
+
+  /// the input tree, using TChain to support multiple input files
+  TChain mInput;
+  /// definitions of branch specs
+  std::vector<std::pair<KeyType, std::unique_ptr<BranchSpec>>> mBranchSpecs;
+  /// number of entries in the tree
+  int mNEntries = 0;
+  /// current entry
+  int mEntry = -1;
+  /// maximum number of entries to be processed
+  int mMaxEntries = -1;
+};
+
+} // namespace framework
+} // namespace o2
+#endif

--- a/Framework/Core/test/TestClasses.h
+++ b/Framework/Core/test/TestClasses.h
@@ -65,6 +65,8 @@ class Polymorphic : public Base
 
   bool isDefault() const { return mSecret == ~(decltype(mSecret))0; }
 
+  unsigned get() const { return mSecret; }
+
  private:
   unsigned mSecret;
 

--- a/Framework/Core/test/test_RootTreeReader.cxx
+++ b/Framework/Core/test/test_RootTreeReader.cxx
@@ -1,0 +1,125 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/WorkflowSpec.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/runDataProcessing.h"
+#include "Framework/DataAllocator.h"
+#include "Framework/InputRecord.h"
+#include "Framework/InputSpec.h"
+#include "Framework/OutputSpec.h"
+#include "Framework/ControlService.h"
+#include "Framework/RootTreeReader.h"
+#include "Headers/DataHeader.h"
+#include "TestClasses.h"
+#include "FairMQLogger.h"
+#include <TSystem.h>
+#include <TTree.h>
+#include <TFile.h>
+#include <vector>
+
+using DataProcessorSpec = o2::framework::DataProcessorSpec;
+using WorkflowSpec = o2::framework::WorkflowSpec;
+using ProcessingContext = o2::framework::ProcessingContext;
+using OutputSpec = o2::framework::OutputSpec;
+using InputSpec = o2::framework::InputSpec;
+using Inputs = o2::framework::Inputs;
+using Outputs = o2::framework::Outputs;
+using AlgorithmSpec = o2::framework::AlgorithmSpec;
+using InitContext = o2::framework::InitContext;
+using ProcessingContext = o2::framework::ProcessingContext;
+using DataRef = o2::framework::DataRef;
+using DataRefUtils = o2::framework::DataRefUtils;
+using ControlService = o2::framework::ControlService;
+
+#define ASSERT_ERROR(condition)                                   \
+  if ((condition) == false) {                                     \
+    LOG(ERROR) << R"(Test condition ")" #condition R"(" failed)"; \
+  }
+
+constexpr int kTreeSize = 10; // elements in the test tree
+DataProcessorSpec getSourceSpec()
+{
+  auto initFct = [](InitContext& ic) {
+    // create a test tree in a temporary file
+    std::string fileName = gSystem->TempDirectory();
+    fileName += "/test_RootTreeReader.root";
+
+    {
+      std::unique_ptr<TFile> testFile(TFile::Open(fileName.c_str(), "RECREATE"));
+      std::unique_ptr<TTree> testTree = std::make_unique<TTree>("testtree", "testtree");
+
+      std::vector<o2::test::Polymorphic> valarray;
+      auto* branch = testTree->Branch("dataarray", &valarray);
+
+      for (int entry = 0; entry < kTreeSize; entry++) {
+        valarray.clear();
+        for (int idx = 0; idx < entry + 1; ++idx) {
+          valarray.emplace_back((entry * 10) + idx);
+        }
+        testTree->Fill();
+      }
+      testTree->Write();
+      testTree->SetDirectory(nullptr);
+      testFile->Close();
+    }
+
+    constexpr auto persistency = OutputSpec::Transient;
+    using TreeReader = o2::framework::RootTreeReader<OutputSpec>;
+    auto reader = std::make_shared<TreeReader>("testtree",       // tree name
+                                               fileName.c_str(), // input file name
+                                               OutputSpec{ "TST", "ARRAYOFDATA", 0, persistency },
+                                               "dataarray" // name of cluster branch
+                                               );
+
+    auto processingFct = [reader](ProcessingContext& pc) { (++(*reader))(pc); };
+
+    return processingFct;
+  };
+
+  return DataProcessorSpec{ "source", // name of the processor
+                            {},
+                            { OutputSpec{ "TST", "ARRAYOFDATA", 0, OutputSpec::Timeframe } },
+                            AlgorithmSpec(initFct) };
+}
+
+DataProcessorSpec getSinkSpec()
+{
+  auto processingFct = [](ProcessingContext& pc) {
+    static int counter = 0;
+    using DataHeader = o2::header::DataHeader;
+    for (auto& input : pc.inputs()) {
+      auto dh = o2::header::get<const DataHeader>(input.header);
+      LOG(INFO) << dh->dataOrigin.str << " " << dh->dataDescription.str << " " << dh->payloadSize;
+    }
+    auto data = pc.inputs().get<std::vector<o2::test::Polymorphic>>("input");
+
+    LOG(INFO) << "count: " << counter << "  data elements:" << data->size();
+    ASSERT_ERROR(counter + 1 == data->size());
+    for (int idx = 0; idx < data->size(); idx++) {
+      LOG(INFO) << (*data)[idx].get();
+      ASSERT_ERROR((*data)[idx].get() == 10 * counter + idx);
+    }
+    if (++counter >= kTreeSize) {
+      pc.services().get<ControlService>().readyToQuit(true);
+    }
+  };
+
+  return DataProcessorSpec{ "sink", // name of the processor
+                            { InputSpec{ "input", "TST", "ARRAYOFDATA", 0, InputSpec::Timeframe } },
+                            Outputs{},
+                            AlgorithmSpec(processingFct) };
+}
+
+void defineDataProcessing(WorkflowSpec& specs)
+{
+  specs.emplace_back(getSourceSpec());
+  specs.emplace_back(getSinkSpec());
+}


### PR DESCRIPTION
The reader interfaces one TTree specified by its name, and supports this
tree to be distributed over multiple files multiple files.

The class uses a KeyType to define sinks for specific branches, the default
key type is OutputSpec. Branches are defined for processing by pairs of
key type and branch name.

Usage (for the default KeyType):
```
  RootTreeReader(treename,
                 filename1, filename2, ...,
                 OutputSpec{...}, branchname1,
                 OutputSpec{...}, branchname2,
                ) reader;
  auto processSomething = [] (auto& key, auto& object) {/*do something*/};
  while (reader.next()) {
    reader.process(processSomething);
  }
  // -- or --
  while ((++reader)(processSomething));
```

In the DPL AlgorithmSpec the processing lambda can simple look like
```
  auto processingFct = [reader](ProcessingContext& pc) {
    // increment the reader and invoke it for the processing context
    (++reader)(pc);
  };
```
Note that reader has to be set up in the init callback and it must
be static there to persist. It can also be a shared_pointer, which then
requires additional dereferencing in the syntax.