### PR TITLE
Ask for pointer to get a pointer in header::get<T>

### DIFF
--- a/Algorithm/include/Algorithm/HeaderStack.h
+++ b/Algorithm/include/Algorithm/HeaderStack.h
@@ -67,7 +67,7 @@ void dispatchHeaderStackCallback(PtrType ptr,
                                  HeaderType /*dummy*/,
                                  HeaderCallbackType onHeader)
 {
-  const HeaderType* h = o2::header::get<HeaderType>(ptr, size);
+  const HeaderType* h = o2::header::get<HeaderType*>(ptr, size);
   if (h) {
     onHeader(*h);
   }
@@ -134,7 +134,7 @@ void parseHeaderStack(PtrType ptr,
                       SizeType size,
                       HeaderType & header)
 {
-  const HeaderType* h = o2::header::get<HeaderType>(ptr, size);
+  const HeaderType* h = o2::header::get<HeaderType*>(ptr, size);
   if (h) {
     header = *h;
   }

--- a/Algorithm/include/Algorithm/O2FormatParser.h
+++ b/Algorithm/include/Algorithm/O2FormatParser.h
@@ -69,7 +69,7 @@ int parseO2Format(const InputListT& list,
   for (auto & part : list) {
     if (!dh) {
       // new header - payload pair, read DataHeader
-      dh = o2::header::get<o2::header::DataHeader>(getPointer(part), getSize(part));
+      dh = o2::header::get<o2::header::DataHeader*>(getPointer(part), getSize(part));
       if (!dh) {
         return -ENOMSG;
       }

--- a/DataFormats/Headers/include/Headers/DataHeader.h
+++ b/DataFormats/Headers/include/Headers/DataHeader.h
@@ -406,22 +406,28 @@ struct BaseHeader
 
 /// find a header of type HeaderType in a buffer
 /// use like this:
-/// HeaderType* h = get<HeaderType>(buffer)
-template<typename HeaderType>
-const HeaderType* get(const byte* buffer, size_t /*len*/=0) {
+/// HeaderType* h = get<HeaderType*>(buffer)
+template <typename HeaderType, typename std::enable_if_t<std::is_pointer<HeaderType>::value, int> = 0>
+auto get(const byte* buffer, size_t /*len*/ = 0)
+{
+  using HeaderConstPtrType = const typename std::remove_pointer<HeaderType>::type*;
+  using HeaderValueType = typename std::remove_pointer<HeaderType>::type;
+
   const BaseHeader* current = BaseHeader::get(buffer);
-  if (!current) return nullptr;
-  if (current->description==HeaderType::sHeaderType)
-    return reinterpret_cast<const HeaderType*>(current);
+  if (!current)
+    return HeaderConstPtrType{ nullptr };
+  if (current->description == HeaderValueType::sHeaderType)
+    return reinterpret_cast<HeaderConstPtrType>(current);
   while ((current = current->next())) {
-    if (current->description==HeaderType::sHeaderType)
-      return reinterpret_cast<const HeaderType*>(current);
+    if (current->description == HeaderValueType::sHeaderType)
+      return reinterpret_cast<HeaderConstPtrType>(current);
   }
-  return nullptr;
+  return HeaderConstPtrType{ nullptr };
 }
 
-template<typename HeaderType>
-const HeaderType* get(const void* buffer, size_t len=0) {
+template <typename HeaderType, typename std::enable_if_t<std::is_pointer<HeaderType>::value, int> = 0>
+auto get(const void* buffer, size_t len = 0)
+{
   return get<HeaderType>(reinterpret_cast<const byte *>(buffer), len);
 }
 

--- a/DataFormats/Headers/test/testDataHeader.cxx
+++ b/DataFormats/Headers/test/testDataHeader.cxx
@@ -166,10 +166,10 @@ namespace o2 {
       Stack s1{ DataHeader{ gDataDescriptionInvalid, gDataOriginInvalid, DataHeader::SubSpecificationType{ 0 }, 0 },
                 NameHeader<9>{ "somename" } };
 
-      const DataHeader* h1 = get<DataHeader>(s1.buffer.get());
+      const DataHeader* h1 = get<DataHeader*>(s1.buffer.get());
       BOOST_CHECK(h1 != nullptr);
       BOOST_CHECK(*h1 == dh1);
-      const NameHeader<0>* h2 = get<NameHeader<0>>(s1.buffer.get());
+      const NameHeader<0>* h2 = get<NameHeader<0>*>(s1.buffer.get());
       BOOST_CHECK(h2 != nullptr);
       BOOST_CHECK(0 == std::strcmp(h2->getName(), "somename"));
       BOOST_CHECK(h2->description == NameHeader<0>::sHeaderType);

--- a/Framework/Core/include/Framework/DataRefUtils.h
+++ b/Framework/Core/include/Framework/DataRefUtils.h
@@ -34,7 +34,7 @@ struct DataRefUtils {
   as(DataRef const& ref)
   {
     using DataHeader = o2::header::DataHeader;
-    auto header = o2::header::get<const DataHeader>(ref.header);
+    auto header = o2::header::get<const DataHeader*>(ref.header);
     if (header->payloadSerializationMethod != o2::header::gSerializationMethodNone) {
       throw std::runtime_error("Attempt to extract a POD from a wrong message kind");
     }
@@ -59,7 +59,7 @@ struct DataRefUtils {
   as(DataRef const& ref)
   {
     using DataHeader = o2::header::DataHeader;
-    auto header = o2::header::get<const DataHeader>(ref.header);
+    auto header = o2::header::get<const DataHeader*>(ref.header);
     if (header->payloadSerializationMethod != o2::header::gSerializationMethodROOT) {
       throw std::runtime_error("Attempt to extract a TMessage from non-ROOT serialised message");
     }
@@ -126,7 +126,7 @@ struct DataRefUtils {
   {
     using T = typename W::wrapped_type;
     using DataHeader = o2::header::DataHeader;
-    auto header = o2::header::get<const DataHeader>(ref.header);
+    auto header = o2::header::get<const DataHeader*>(ref.header);
     if (header->payloadSerializationMethod != o2::header::gSerializationMethodROOT) {
       throw std::runtime_error("Attempt to extract a TMessage from non-ROOT serialised message");
     }
@@ -153,7 +153,7 @@ struct DataRefUtils {
   static unsigned getPayloadSize(const DataRef& ref)
   {
     using DataHeader = o2::header::DataHeader;
-    auto header = o2::header::get<const DataHeader>(ref.header);
+    auto header = o2::header::get<const DataHeader*>(ref.header);
     if (!header) {
       return 0;
     }

--- a/Framework/Core/include/Framework/InputRecord.h
+++ b/Framework/Core/include/Framework/InputRecord.h
@@ -202,7 +202,7 @@ public:
     using DataHeader = o2::header::DataHeader;
 
     auto ref = this->get(binding);
-    auto header = o2::header::get<const DataHeader>(ref.header);
+    auto header = o2::header::get<const DataHeader*>(ref.header);
     auto method = header->payloadSerializationMethod;
     if (method == o2::header::gSerializationMethodNone) {
       auto const* ptr = reinterpret_cast<T const*>(ref.payload);
@@ -234,7 +234,7 @@ public:
     using DataHeader = o2::header::DataHeader;
 
     auto ref = this->get(binding);
-    auto header = o2::header::get<const DataHeader>(ref.header);
+    auto header = o2::header::get<const DataHeader*>(ref.header);
     auto method = header->payloadSerializationMethod;
     if (method == o2::header::gSerializationMethodNone) {
       throw std::runtime_error(

--- a/Framework/Core/src/DataAllocator.cxx
+++ b/Framework/Core/src/DataAllocator.cxx
@@ -155,7 +155,7 @@ DataAllocator::addPartToContext(FairMQMessagePtr&& payloadMessage,
 
     // FIXME: this is kind of ugly, we know that we can change the content of the
     // header message because we have just created it, but the API declares it const
-    const DataHeader *cdh = o2::header::get<DataHeader>(headerMessage->GetData());
+    const DataHeader* cdh = o2::header::get<DataHeader*>(headerMessage->GetData());
     DataHeader *dh = const_cast<DataHeader *>(cdh);
     dh->payloadSize = payloadMessage->GetSize();
     parts.AddPart(std::move(headerMessage));

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -127,7 +127,7 @@ DataProcessingDevice::HandleData(FairMQParts &iParts, int /*index*/) {
     }
     for (size_t hi = 0; hi < parts.Size()/2; ++hi) {
       auto pi = hi*2;
-      auto dh = o2::header::get<DataHeader>(parts.At(pi)->GetData());
+      auto dh = o2::header::get<DataHeader*>(parts.At(pi)->GetData());
       if (!dh) {
         LOG(ERROR) << "Header is not a DataHeader?";
         return false;
@@ -136,7 +136,7 @@ DataProcessingDevice::HandleData(FairMQParts &iParts, int /*index*/) {
         LOG(ERROR) << "DataHeader payloadSize mismatch";
         return false;
       }
-      auto dph = o2::header::get<DataProcessingHeader>(parts.At(pi)->GetData());
+      auto dph = o2::header::get<DataProcessingHeader*>(parts.At(pi)->GetData());
       if (!dph) {
         LOG(ERROR) << "Header stack does not contain DataProcessingHeader";
         return false;
@@ -270,12 +270,12 @@ DataProcessingDevice::HandleData(FairMQParts &iParts, int /*index*/) {
     for (size_t ii = 0, ie = record.size(); ii != ie; ++ii) {
       DataRef input = record.getByPos(ii);
       assert(input.header);
-      auto dh = o2::header::get<DataHeader>(input.header);
+      auto dh = o2::header::get<DataHeader*>(input.header);
       if (!dh) {
         reportError("Header is not a DataHeader?");
         continue;
       }
-      auto dph = o2::header::get<DataProcessingHeader>(input.header);
+      auto dph = o2::header::get<DataProcessingHeader*>(input.header);
       if (!dph) {
         reportError("Header stack does not contain DataProcessingHeader");
         continue;
@@ -297,12 +297,12 @@ DataProcessingDevice::HandleData(FairMQParts &iParts, int /*index*/) {
             LOG(ERROR) << "Missing header!";
             continue;
           }
-          auto fdph = o2::header::get<DataProcessingHeader>(header.get()->GetData());
+          auto fdph = o2::header::get<DataProcessingHeader*>(header.get()->GetData());
           if (fdph == nullptr) {
             LOG(ERROR) << "Forwarded data does not have a DataProcessingHeader";
             continue;
           }
-          auto fdh = o2::header::get<DataHeader>(header.get()->GetData());
+          auto fdh = o2::header::get<DataHeader*>(header.get()->GetData());
           if (fdh == nullptr) {
             LOG(ERROR) << "Forwarded data does not have a DataHeader";
             continue;
@@ -314,8 +314,8 @@ DataProcessingDevice::HandleData(FairMQParts &iParts, int /*index*/) {
           forwardedParts.AddPart(std::move(header));
           forwardedParts.AddPart(std::move(payload));
           assert(forwardedParts.Size() == 2);
-          assert(o2::header::get<DataProcessingHeader>(forwardedParts.At(0)->GetData()));
-          LOG(DEBUG) << o2::header::get<DataProcessingHeader>(forwardedParts.At(0)->GetData())->startTime;
+          assert(o2::header::get<DataProcessingHeader*>(forwardedParts.At(0)->GetData()));
+          LOG(DEBUG) << o2::header::get<DataProcessingHeader*>(forwardedParts.At(0)->GetData())->startTime;
           LOG(DEBUG) << forwardedParts.At(0)->GetSize();
           // FIXME: this should use a correct subchannel
           device.Send(forwardedParts, forward.channel, 0);

--- a/Framework/Core/src/DataProcessor.cxx
+++ b/Framework/Core/src/DataProcessor.cxx
@@ -40,7 +40,7 @@ void DataProcessor::doSend(FairMQDevice &device, RootObjectContext &context) {
     FairMQMessagePtr payload(device.NewMessage());
     auto a = messageRef.payload.get();
     device.Serialize<TMessageSerializer>(*payload, a);
-    const DataHeader *cdh = o2::header::get<DataHeader>(messageRef.header->GetData());
+    const DataHeader* cdh = o2::header::get<DataHeader*>(messageRef.header->GetData());
     // sigh... See if we can avoid having it const by not
     // exposing it to the user in the first place.
     DataHeader *dh = const_cast<DataHeader *>(cdh);

--- a/Framework/Core/src/DataRelayer.cxx
+++ b/Framework/Core/src/DataRelayer.cxx
@@ -46,7 +46,7 @@ size_t
 assignInputSpecId(void *data, std::vector<InputRoute> const &routes) {
   for (size_t ri = 0, re = routes.size(); ri < re; ++ri) {
     auto &route = routes[ri];
-    const DataHeader *h = o2::header::get<DataHeader>(data);
+    const DataHeader* h = o2::header::get<DataHeader*>(data);
     if (h == nullptr) {
       return re;
     }
@@ -101,8 +101,8 @@ DataRelayer::relay(std::unique_ptr<FairMQMessage> &&header,
   // header stack. This is an extension to the DataHeader, because apparently
   // we do have data which comes without a timestamp, although I am personally
   // not sure what that would be.
-  auto getTimeslice = [&header,&timeslices]() -> int64_t {
-    const DataProcessingHeader *dph = o2::header::get<DataProcessingHeader>(header->GetData());
+  auto getTimeslice = [&header, &timeslices]() -> int64_t {
+    const DataProcessingHeader* dph = o2::header::get<DataProcessingHeader*>(header->GetData());
     if (dph == nullptr) {
       return -1;
     }

--- a/Framework/Core/src/DispatcherDPL.cxx
+++ b/Framework/Core/src/DispatcherDPL.cxx
@@ -41,7 +41,7 @@ void DispatcherDPL::processCallback(ProcessingContext& ctx, BernoulliGenerator& 
 
       OutputSpec outputSpec = createDispatcherOutputSpec(*input.spec);
 
-      const auto* inputHeader = header::get<header::DataHeader>(input.header);
+      const auto* inputHeader = header::get<header::DataHeader*>(input.header);
 
       /*if (inputHeader->payloadSerializationMethod == header::gSerializationMethodInvalid) {
         LOG(ERROR) << "DataSampling::dispatcherCallback: input of origin'" << inputHeader->dataOrigin.str

--- a/Framework/Core/src/DispatcherFairMQ.cxx
+++ b/Framework/Core/src/DispatcherFairMQ.cxx
@@ -65,7 +65,7 @@ void DispatcherFairMQ::processCallback(ProcessingContext& ctx, Dispatcher::Berno
 
     auto cleanupFcn = [](void* data, void* hint) { delete[] reinterpret_cast<char*>(data); };
     for (auto& input : inputs) {
-      const auto* header = header::get<header::DataHeader>(input.header);
+      const auto* header = header::get<header::DataHeader*>(input.header);
 
       char* payloadCopy = new char[header->payloadSize];
       memcpy(payloadCopy, input.payload, header->payloadSize);

--- a/Framework/Core/src/DispatcherFlpProto.cxx
+++ b/Framework/Core/src/DispatcherFlpProto.cxx
@@ -61,7 +61,7 @@ void DispatcherFlpProto::processCallback(ProcessingContext& ctx, BernoulliGenera
   assert(ctx.inputs().size() == 1);
 
   auto input = ctx.inputs().getByPos(0);
-  const auto* header = header::get<header::DataHeader>(input.header);
+  const auto* header = header::get<header::DataHeader*>(input.header);
 
   if (state == FlpProtoState::Idle) {
     // wait until EOM

--- a/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
+++ b/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
@@ -55,7 +55,7 @@ InjectorFunction o2DataModelAdaptor(OutputSpec const &spec, uint64_t startTime, 
   auto timesliceId = std::make_shared<size_t>(startTime);
   return [timesliceId, step](FairMQDevice &device, FairMQParts &parts, int index) {
     for (size_t i = 0; i < parts.Size()/2; ++i) {
-      auto dh = o2::header::get<DataHeader>(parts.At(i*2)->GetData());
+      auto dh = o2::header::get<DataHeader*>(parts.At(i * 2)->GetData());
 
       DataProcessingHeader dph{*timesliceId, 0};
       o2::header::Stack headerStack{*dh, dph};

--- a/Framework/Core/test/test_DataAllocator.cxx
+++ b/Framework/Core/test/test_DataAllocator.cxx
@@ -104,7 +104,7 @@ DataProcessorSpec getSinkSpec()
   auto processingFct = [](ProcessingContext& pc) {
     using DataHeader = o2::header::DataHeader;
     for (auto& input : pc.inputs()) {
-      auto dh = o2::header::get<const DataHeader>(input.header);
+      auto dh = o2::header::get<const DataHeader*>(input.header);
       LOG(INFO) << dh->dataOrigin.str << " " << dh->dataDescription.str << " " << dh->payloadSize;
     }
     auto object1 = pc.inputs().get<o2::test::TriviallyCopyable>("input1");

--- a/Framework/Core/test/test_Parallel.cxx
+++ b/Framework/Core/test/test_Parallel.cxx
@@ -120,7 +120,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
 
           LOG(DEBUG) << "DataSampler sends data from subSpec: " << inputSpec->subSpec;
 
-          const auto* inputHeader = o2::header::get<o2::header::DataHeader>(input.header);
+          const auto* inputHeader = o2::header::get<o2::header::DataHeader*>(input.header);
           auto output = ctx.allocator().make<char>(outputSpec, inputHeader->size());
 
           //todo: use some std function or adopt(), when it is available for POD data

--- a/Framework/Core/test/test_RootTreeReader.cxx
+++ b/Framework/Core/test/test_RootTreeReader.cxx
@@ -96,7 +96,7 @@ DataProcessorSpec getSinkSpec()
     static int counter = 0;
     using DataHeader = o2::header::DataHeader;
     for (auto& input : pc.inputs()) {
-      auto dh = o2::header::get<const DataHeader>(input.header);
+      auto dh = o2::header::get<const DataHeader*>(input.header);
       LOG(INFO) << dh->dataOrigin.str << " " << dh->dataDescription.str << " " << dh->payloadSize;
     }
     auto data = pc.inputs().get<std::vector<o2::test::Polymorphic>>("input");

--- a/Framework/TestWorkflows/src/dataSamplingParallel.cxx
+++ b/Framework/TestWorkflows/src/dataSamplingParallel.cxx
@@ -105,7 +105,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
         auto inputDataTpcProcessed = reinterpret_cast<const FakeCluster*>(ctx.inputs().get(
           "TPC_CLUSTERS_P_S").payload);
 
-        const auto* header = o2::header::get<DataHeader>(ctx.inputs().get("TPC_CLUSTERS_S").header);
+        const auto* header = o2::header::get<DataHeader*>(ctx.inputs().get("TPC_CLUSTERS_S").header);
 
         bool dataGood = true;
         for (int j = 0; j < header->payloadSize / sizeof(FakeCluster); ++j) {

--- a/Framework/TestWorkflows/src/dataSamplingPodAndRoot.cxx
+++ b/Framework/TestWorkflows/src/dataSamplingPodAndRoot.cxx
@@ -92,7 +92,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
         auto inputDataTpcProcessed = reinterpret_cast<const FakeCluster*>(ctx.inputs().get(
           "TPC_CLUSTERS_P_S").payload);
 
-        const auto* header = o2::header::get<DataHeader>(ctx.inputs().get("TPC_CLUSTERS_S").header);
+        const auto* header = o2::header::get<DataHeader*>(ctx.inputs().get("TPC_CLUSTERS_S").header);
 
         bool dataGood = true;
         for (int j = 0; j < header->payloadSize / sizeof(FakeCluster); ++j) {

--- a/Framework/TestWorkflows/src/dataSamplingTimePipeline.cxx
+++ b/Framework/TestWorkflows/src/dataSamplingTimePipeline.cxx
@@ -88,7 +88,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
         auto inputDataTpcProcessed = reinterpret_cast<const FakeCluster*>(ctx.inputs().get(
           "TPC_CLUSTERS_P_S").payload);
 
-        const auto* header = o2::header::get<DataHeader>(ctx.inputs().get("TPC_CLUSTERS_S").header);
+        const auto* header = o2::header::get<DataHeader*>(ctx.inputs().get("TPC_CLUSTERS_S").header);
 
         bool dataGood = true;
         for (int j = 0; j < header->payloadSize / sizeof(FakeCluster); ++j) {

--- a/Framework/TestWorkflows/src/o2DummyWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DummyWorkflow.cxx
@@ -126,9 +126,9 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
     AlgorithmSpec{
       [](ProcessingContext &ctx) {
         // We verify we got inputs in the correct order
-        auto h0 = o2::header::get<DataHeader>(ctx.inputs().get("clusters").header);
-        auto h1 = o2::header::get<DataHeader>(ctx.inputs().get("summary").header);
-        auto h2 = o2::header::get<DataHeader>(ctx.inputs().get("other_summary").header);
+        auto h0 = o2::header::get<DataHeader*>(ctx.inputs().get("clusters").header);
+        auto h1 = o2::header::get<DataHeader*>(ctx.inputs().get("summary").header);
+        auto h2 = o2::header::get<DataHeader*>(ctx.inputs().get("other_summary").header);
         // This should always be the case, since the 
         // test for an actual DataHeader should happen in the device itself.
         assert(h0 && h1 && h2);

--- a/Utilities/DataFlow/src/EPNReceiverDevice.cxx
+++ b/Utilities/DataFlow/src/EPNReceiverDevice.cxx
@@ -97,7 +97,7 @@ void EPNReceiverDevice::Run()
 
     assert(subtimeframeParts.Size() >= 2);
 
-    const auto* dh = o2::header::get<header::DataHeader>(subtimeframeParts.At(0)->GetData());
+    const auto* dh = o2::header::get<header::DataHeader*>(subtimeframeParts.At(0)->GetData());
     assert(strncmp(dh->dataDescription.str, "SUBTIMEFRAMEMD", 16) == 0);
     SubframeMetadata* sfm = reinterpret_cast<SubframeMetadata*>(subtimeframeParts.At(1)->GetData());
     id = o2::DataFlow::timeframeIdFromTimestamp(sfm->startTime, sfm->duration);
@@ -123,7 +123,7 @@ void EPNReceiverDevice::Run()
       {
         if (i % 2 == 0)
         {
-          const auto * adh = o2::header::get<header::DataHeader>(subtimeframeParts.At(i)->GetData());
+          const auto* adh = o2::header::get<header::DataHeader*>(subtimeframeParts.At(i)->GetData());
           auto ie = std::make_pair(*adh, index.count(id)*2);
           index.insert(std::make_pair(id, ie));
         }

--- a/Utilities/DataFlow/src/FLPSenderDevice.cxx
+++ b/Utilities/DataFlow/src/FLPSenderDevice.cxx
@@ -55,7 +55,7 @@ void FLPSenderDevice::Run()
 
     assert(subtimeframeParts.Size() != 0);
     assert(subtimeframeParts.Size() >= 2);
-    const auto* dh = o2::header::get<header::DataHeader>(subtimeframeParts.At(0)->GetData());
+    const auto* dh = o2::header::get<header::DataHeader*>(subtimeframeParts.At(0)->GetData());
     assert(strncmp(dh->dataDescription.str, "SUBTIMEFRAMEMD", 16) == 0);
 
     SubframeMetadata* sfm = reinterpret_cast<SubframeMetadata*>(subtimeframeParts.At(1)->GetData());

--- a/Utilities/DataFlow/src/SubframeBuilderDevice.cxx
+++ b/Utilities/DataFlow/src/SubframeBuilderDevice.cxx
@@ -102,7 +102,7 @@ bool o2::DataFlow::SubframeBuilderDevice::BuildAndSendFrame(FairMQParts &inParts
   dh.subSpecification = mFLPId;
   dh.payloadSize = sizeof(SubframeMetadata);
 
-  DataHeader payloadheader(*o2::header::get<DataHeader>((byte*)inParts.At(0)->GetData()));
+  DataHeader payloadheader(*o2::header::get<DataHeader*>((byte*)inParts.At(0)->GetData()));
 
   // subframe meta information as payload
   SubframeMetadata md;

--- a/Utilities/DataFlow/src/TimeframeParser.cxx
+++ b/Utilities/DataFlow/src/TimeframeParser.cxx
@@ -174,7 +174,7 @@ void streamTimeframe(std::ostream &stream, FairMQParts &parts) {
     throw std::runtime_error("Expecting at least 2 parts\n");
   }
 
-  auto indexHeader = o2::header::get<DataHeader>(parts.At(parts.Size() - 2)->GetData());
+  auto indexHeader = o2::header::get<DataHeader*>(parts.At(parts.Size() - 2)->GetData());
   // FIXME: Provide iterator pair API for the index
   //        Index should really be something which provides an
   //        iterator pair API so that we can sort / find / lower_bound

--- a/Utilities/DataFlow/src/TimeframeValidatorDevice.cxx
+++ b/Utilities/DataFlow/src/TimeframeValidatorDevice.cxx
@@ -49,7 +49,7 @@ void o2::DataFlow::TimeframeValidatorDevice::Run()
     if (timeframeParts.Size() < 2)
       LOG(ERROR) << "Expecting at least 2 parts\n";
 
-    auto indexHeader = o2::header::get<header::DataHeader>(timeframeParts.At(timeframeParts.Size() - 2)->GetData());
+    auto indexHeader = o2::header::get<header::DataHeader*>(timeframeParts.At(timeframeParts.Size() - 2)->GetData());
     // FIXME: Provide iterator pair API for the index
     //        Index should really be something which provides an
     //        iterator pair API so that we can sort / find / lower_bound

--- a/Utilities/O2MessageMonitor/src/O2MessageMonitor.cxx
+++ b/Utilities/O2MessageMonitor/src/O2MessageMonitor.cxx
@@ -99,7 +99,7 @@ bool O2MessageMonitor::HandleO2frame(const byte* headerBuffer, size_t headerBuff
   hexDump("headerBuffer", headerBuffer, headerBufferSize);
   hexDump("dataBuffer", dataBuffer, dataBufferSize, mLimitOutputCharacters);
 
-  const DataHeader* dataHeader = get<DataHeader>(headerBuffer);
+  const DataHeader* dataHeader = get<DataHeader*>(headerBuffer);
   if (!dataHeader) {
     LOG(INFO) << "data header empty!";
     return false;
@@ -107,7 +107,7 @@ bool O2MessageMonitor::HandleO2frame(const byte* headerBuffer, size_t headerBuff
   if ((*dataHeader) == gDataDescriptionInfo) {
   }
 
-  const NameHeader<0>* nameHeader = get<NameHeader<0>>(headerBuffer);
+  const NameHeader<0>* nameHeader = get<NameHeader<0>*>(headerBuffer);
   if (nameHeader) {
     size_t sizeNameHeader = nameHeader->size();
   }

--- a/Utilities/Publishers/src/DataPublisherDevice.cxx
+++ b/Utilities/Publishers/src/DataPublisherDevice.cxx
@@ -133,8 +133,8 @@ bool DataPublisherDevice::HandleO2LogicalBlock(const byte* headerBuffer,
                                                size_t dataBufferSize)
 {
   //  AliceO2::header::hexDump("data buffer", dataBuffer, dataBufferSize);
-  const auto* dataHeader = o2::header::get<o2::header::DataHeader>(headerBuffer);
-  const auto* hbfEnvelope = o2::header::get<o2::header::HeartbeatFrameEnvelope>(headerBuffer);
+  const auto* dataHeader = o2::header::get<o2::header::DataHeader*>(headerBuffer);
+  const auto* hbfEnvelope = o2::header::get<o2::header::HeartbeatFrameEnvelope*>(headerBuffer);
 
   // TODO: not sure what the return value is supposed to indicate, it's
   // not handled in O2Device::ForEach at the moment

--- a/Utilities/QC/Workflow/src/RootObjectMergerSpec.cxx
+++ b/Utilities/QC/Workflow/src/RootObjectMergerSpec.cxx
@@ -53,7 +53,7 @@ DataProcessorSpec getRootObjectMergerSpec() {
   auto processingFct = [merger = std::make_shared<Merger>(10)] (ProcessingContext &pc) {
     using DataHeader = o2::header::DataHeader;
     for (auto & input : pc.inputs()) {
-      auto dh = o2::header::get<const DataHeader>(input.header);
+      auto dh = o2::header::get<const DataHeader*>(input.header);
       std::cout << dh->dataOrigin.str
       << " " << dh->dataDescription.str
       << " " << dh->payloadSize

--- a/Utilities/aliceHLTwrapper/src/MessageFormat.cxx
+++ b/Utilities/aliceHLTwrapper/src/MessageFormat.cxx
@@ -141,7 +141,7 @@ int MessageFormat::addMessages(const vector<BufferDesc_t>& list)
   bool tryO2format = true;
   for (auto & data : list) {
     if (tryO2format) {
-      if (o2::header::get<o2::header::DataHeader>(data.mP, data.mSize)) {
+      if (o2::header::get<o2::header::DataHeader*>(data.mP, data.mSize)) {
         return readO2Format(list, mBlockDescriptors, mHeartbeatHeader, mHeartbeatTrailer);
       }
       tryO2format = false;
@@ -230,7 +230,7 @@ int MessageFormat::readO2Format(const vector<BufferDesc_t>& list, std::vector<Bl
   for (auto part : list) {
     if (!dh) {
       // new header - payload pair, read DataHeader
-      dh = o2::header::get<o2::header::DataHeader>(part.mP, part.mSize);
+      dh = o2::header::get<o2::header::DataHeader*>(part.mP, part.mSize);
       if (!dh) {
         cerr << "can not find DataHeader" << endl;
         return -ENOMSG;
@@ -238,7 +238,7 @@ int MessageFormat::readO2Format(const vector<BufferDesc_t>& list, std::vector<Bl
       // extract the heartbeat information if available and keep it to
       // envelope the data blocks in the output message
       if (dh->dataDescription == o2::header::gDataDescriptionHeartbeatFrame) {
-        const HeartbeatFrameEnvelope* hbf = o2::header::get<HeartbeatFrameEnvelope>(part.mP, part.mSize);
+        const HeartbeatFrameEnvelope* hbf = o2::header::get<HeartbeatFrameEnvelope*>(part.mP, part.mSize);
         if (hbf) {
           hbh = hbf->header;
           hbt = hbf->trailer;


### PR DESCRIPTION
this changes the signature of the header::get<> : the template parameter must be a pointer type in order to have a pointer returned, e.g.
`DataHeader* h = header::get<DataHeader*>(buffer)`
