### PR TITLE
First version of tracking for MID

### DIFF
--- a/DataFormats/Detectors/MUON/MID/CMakeLists.txt
+++ b/DataFormats/Detectors/MUON/MID/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SRCS
 
 set(NO_DICT_HEADERS
   include/${MODULE_NAME}/Cluster2D.h
+  include/${MODULE_NAME}/Cluster3D.h
   include/${MODULE_NAME}/StripPattern.h
   include/${MODULE_NAME}/Track.h
 )

--- a/DataFormats/Detectors/MUON/MID/CMakeLists.txt
+++ b/DataFormats/Detectors/MUON/MID/CMakeLists.txt
@@ -3,11 +3,13 @@ set(MODULE_NAME "DataFormatsMID")
 O2_SETUP(NAME ${MODULE_NAME})
 
 set(SRCS
+  src/Track.cxx
 )
 
 set(NO_DICT_HEADERS
   include/${MODULE_NAME}/Cluster2D.h
   include/${MODULE_NAME}/StripPattern.h
+  include/${MODULE_NAME}/Track.h
 )
 
 set(LIBRARY_NAME ${MODULE_NAME})
@@ -17,8 +19,8 @@ set(BUCKET_NAME data_format_mid_bucket)
 # and there is no linkdef, since it fails in determining if is a C++ file.
 # Let us install the headers directly
 # Install all the public headers
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/include/${MODULE_NAME})
-  install(DIRECTORY include/${MODULE_NAME} DESTINATION include)
-endif()
+#if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/include/${MODULE_NAME})
+#  install(DIRECTORY include/${MODULE_NAME} DESTINATION include)
+#endif()
 
-# O2_GENERATE_LIBRARY()
+O2_GENERATE_LIBRARY()

--- a/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/Cluster3D.h
+++ b/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/Cluster3D.h
@@ -1,0 +1,37 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   DataFormatsMID/Cluster3D.h
+/// \brief  Reconstructed MID cluster (global coordinates)
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   31 August 2017
+
+#ifndef O2_MID_CLUSTER3D_H
+#define O2_MID_CLUSTER3D_H
+
+#include <cstdint>
+#include "MathUtils/Cartesian3D.h"
+
+namespace o2
+{
+namespace mid
+{
+/// 3D cluster structure for MID
+struct Cluster3D {
+  uint16_t id;             ///< Unique Id of the cluster in the detection element
+  uint8_t deId;            ///< Index of the detection element
+  Point3D<float> position; ///< Global position
+  float sigmaX2;           ///< Dispersion along x
+  float sigmaY2;           ///< Dispersion along y
+};
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_CLUSTER3D_H */

--- a/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/Track.h
+++ b/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/Track.h
@@ -1,0 +1,131 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   DataFormatsMID/Track.h
+/// \brief  Reconstructed MID track
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   04 September 2017
+#ifndef O2_MID_TRACK_H
+#define O2_MID_TRACK_H
+
+#include <array>
+#include <ostream>
+#include <boost/serialization/split_member.hpp>
+#include <boost/serialization/array.hpp>
+#include "MathUtils/Cartesian3D.h"
+
+namespace o2
+{
+namespace mid
+{
+/// This class defines the MID track
+class Track
+{
+ public:
+  Track();
+  virtual ~Track() = default;
+
+  Track(const Track&) = default;
+  Track& operator=(const Track&) = default;
+  Track(Track&&) = default;
+  Track& operator=(Track&&) = default;
+
+  /// Gets the track starting position
+  const Point3D<float> getPosition() const { return mPosition; }
+  void setPosition(float xPos, float yPos, float zPos);
+
+  /// Gets the track direction parameters
+  const Vector3D<float> getDirection() const { return mDirection; }
+  void setDirection(float xDir, float yDir, float zDir);
+
+  enum class CovarianceParamIndex : int {
+    VarX,       ///< Variance on X position
+    VarY,       ///< Variance on Y position
+    VarSlopeX,  ///< Variance on X slope
+    VarSlopeY,  ///< Variance on Y slope
+    CovXSlopeX, ///< Covariance on X position and slope
+    CovYSlopeY  ///< Covariance on Y position and slope
+  };
+
+  /// Gets the covariance parameters
+  const std::array<float, 6> getCovarianceParameters() const { return mCovarianceParameters; }
+  /// returns the covariance parameter covParam
+  float getCovarianceParameter(CovarianceParamIndex covParam) const
+  {
+    return mCovarianceParameters[static_cast<int>(covParam)];
+  }
+  void setCovarianceParameters(float xErr2, float yErr2, float slopeXErr2, float slopeYErr2, float covXSlopeX,
+                               float covYSlopeY);
+
+  /// Sets the covariance matrix
+  void setCovarianceParameters(const std::array<float, 6>& covParam) { mCovarianceParameters = covParam; }
+
+  /// Checks if covariance is set
+  bool isCovarianceSet() { return (mCovarianceParameters[0] != 0.); }
+
+  bool propagateToZ(float zPosition);
+
+  int getClusterMatched(int chamber) const;
+  void setClusterMatched(int chamber, int id);
+
+  /// Returns the chi2 of the track
+  float getChi2() const { return mChi2; }
+  /// Sets the chi2 of the track
+  void setChi2(float chi2) { mChi2 = chi2; }
+  /// Returns the number of degrees of freedom of the track
+  int getNDF() const { return mNDF; }
+  /// Sets the number of degrees of freedom of the track
+  void setNDF(int ndf) { mNDF = ndf; }
+  /// Returns the normalized chi2 of the track
+  float getChi2OverNDF() const { return mChi2 / (float)mNDF; }
+
+  bool isCompatible(const Track& track, float chi2Cut) const;
+
+  friend std::ostream& operator<<(std::ostream& stream, const Track& track);
+
+ private:
+  Point3D<float> mPosition;                   ///< Position
+  Vector3D<float> mDirection;                 ///< Direction
+  std::array<float, 6> mCovarianceParameters; ///< Covariance parameters
+  std::array<int, 4> mClusterMatched;         ///< Matched cluster index
+  float mChi2;                                ///< Chi2 of track
+  int mNDF;                                   ///< Number of degree of freedom for chi2
+
+  friend class boost::serialization::access;
+
+  /// Serializes the track
+  template <class Archive>
+  void save(Archive& ar, const unsigned int version) const
+  {
+    ar& mPosition.x() & mPosition.y() & mPosition.z();
+    ar& mDirection.x() & mDirection.y() & mDirection.z();
+    ar& mCovarianceParameters;
+    ar& mClusterMatched;
+  }
+
+  /// Deserializes the track
+  template <class Archive>
+  void load(Archive& ar, const unsigned int version)
+  {
+    float xp, yp, zp, xd, yd, zd;
+    ar& xp& yp& zp;
+    mPosition.SetXYZ(xp, yp, zp);
+    ar& xd& yd& zd;
+    mDirection.SetXYZ(xd, yd, zd);
+    ar& mCovarianceParameters;
+    ar& mClusterMatched;
+  }
+
+  BOOST_SERIALIZATION_SPLIT_MEMBER()
+};
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_TRACK_H */

--- a/DataFormats/Detectors/MUON/MID/src/Track.cxx
+++ b/DataFormats/Detectors/MUON/MID/src/Track.cxx
@@ -1,0 +1,176 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/src/Track.cxx
+/// \brief  Reconstructed MID track
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   04 September 2017
+
+#include "DataFormatsMID/Track.h"
+
+namespace o2
+{
+namespace mid
+{
+
+//______________________________________________________________________________
+Track::Track() : mPosition(), mDirection(), mCovarianceParameters(), mClusterMatched(), mChi2(0.), mNDF(0)
+{
+  /// Default constructor
+}
+
+//______________________________________________________________________________
+void Track::setCovarianceParameters(float xErr2, float yErr2, float slopeXErr2, float slopeYErr2, float covXSlopeX,
+                                    float covYSlopeY)
+{
+  /// Sets the covariance parameters
+  mCovarianceParameters[static_cast<int>(CovarianceParamIndex::VarX)] = xErr2;
+  mCovarianceParameters[static_cast<int>(CovarianceParamIndex::VarY)] = yErr2;
+  mCovarianceParameters[static_cast<int>(CovarianceParamIndex::VarSlopeX)] = slopeXErr2;
+  mCovarianceParameters[static_cast<int>(CovarianceParamIndex::VarSlopeY)] = slopeYErr2;
+  mCovarianceParameters[static_cast<int>(CovarianceParamIndex::CovXSlopeX)] = covXSlopeX;
+  mCovarianceParameters[static_cast<int>(CovarianceParamIndex::CovYSlopeY)] = covYSlopeY;
+}
+
+//______________________________________________________________________________
+void Track::setDirection(float xDir, float yDir, float zDir)
+{
+  /// Sets the track direction parameters
+  mDirection.SetXYZ(xDir, yDir, zDir);
+}
+
+//______________________________________________________________________________
+void Track::setPosition(float xPos, float yPos, float zPos)
+{
+  /// Sets the track starting position
+  mPosition.SetXYZ(xPos, yPos, zPos);
+}
+
+//______________________________________________________________________________
+int Track::getClusterMatched(int chamber) const
+{
+  /// Gets the matched clusters
+  if (chamber > 3) {
+    std::cerr << "Error: chamber must be in range [0, 4]\n";
+    return 0;
+  }
+  return mClusterMatched[chamber];
+}
+
+//______________________________________________________________________________
+void Track::setClusterMatched(int chamber, int id)
+{
+  /// Sets the matched clusters
+  if (chamber > 3) {
+    std::cerr << "Error: chamber must be in range [0, 4]\n";
+    return;
+  }
+  mClusterMatched[chamber] = id;
+}
+
+//______________________________________________________________________________
+bool Track::propagateToZ(float zPosition)
+{
+  /// Propagate track to the specified zPosition
+  /// A linear extraplation is performed
+
+  // Nothing to be done if we're already at zPosition
+  if (mPosition.z() == zPosition) {
+    return false;
+  }
+
+  // Propagate the track position parameters
+  float dZ = zPosition - mPosition.z();
+  float newX = mPosition.x() + mDirection.x() * dZ;
+  float newY = mPosition.y() + mDirection.y() * dZ;
+  setPosition(newX, newY, zPosition);
+
+  // Propagate the covariance matrix
+  std::array<float, 6> newCovParams;
+  float dZ2 = dZ * dZ;
+  for (int idx = 0; idx < 2; ++idx) {
+    int slopeIdx = idx + 2;
+    int covIdx = idx + 4;
+    // s_x^2 -> s_x^2 + 2*cov(x,slopeX)*dZ + s_slopeX^2*dZ^2
+    newCovParams[idx] =
+      mCovarianceParameters[idx] + 2. * mCovarianceParameters[covIdx] * dZ + mCovarianceParameters[slopeIdx] * dZ2;
+    // cov(x,slopeX) -> cov(x,slopeX) + s_slopeX^2*dZ
+    newCovParams[covIdx] = mCovarianceParameters[covIdx] + mCovarianceParameters[slopeIdx] * dZ;
+    // s_slopeX^2 -> s_slopeX^2
+    newCovParams[slopeIdx] = mCovarianceParameters[slopeIdx];
+  }
+
+  mCovarianceParameters.swap(newCovParams);
+
+  return true;
+}
+
+//______________________________________________________________________________
+bool Track::isCompatible(const Track& track, float chi2Cut) const
+{
+  /// Check if tracks are compatible within uncertainties
+  if (track.getPosition().z() != getPosition().z()) {
+    Track copyTrack(track);
+    copyTrack.propagateToZ(getPosition().z());
+    return isCompatible(copyTrack, chi2Cut);
+  }
+
+  // // method 1: chi2 calculation accounting for covariance between slope and position.
+  // // This is the full calculation. However, if we have two parallel tracks with same x
+  // // but different ( > Nsigmas) y position, the algorithm will return true since the
+  // // difference in one of the parameters is compensated by the similarity of the others.
+  // // This is probably not what we need.
+  // double chi2 = 0.;
+  // double pos1[2] = { getPosition().x(), getPosition().y() };
+  // double dir1[2] = { getDirection().x(), getDirection().y() };
+  // double pos2[2] = { track.getPosition().x(), track.getPosition().y() };
+  // double dir2[2] = { track.getDirection().x(), track.getDirection().y() };
+  //
+  // for (int icoor = 0; icoor < 2; ++icoor) {
+  //   double diffPos = pos1[icoor] - pos2[icoor];
+  //   double diffSlope = dir1[icoor] - dir2[icoor];
+  //   double varPos = mCovarianceParameters[icoor] + track.mCovarianceParameters[icoor];
+  //   double varSlope = mCovarianceParameters[icoor + 2] + track.mCovarianceParameters[icoor + 2];
+  //   double cov = mCovarianceParameters[icoor + 4] + track.mCovarianceParameters[icoor + 4];
+  //   chi2 += (diffPos * diffPos * varSlope + diffSlope * diffSlope * varPos - 2. * diffPos * diffSlope * cov) /
+  //           (varPos * varSlope - cov * cov);
+  // }
+  //
+  // return (chi2 / 4.) < chi2Cut;
+
+  // method 2: apply the cut on each parameter
+  // This method avoids the issue of method 1
+  double p1[4] = { getPosition().x(), getPosition().y(), getDirection().x(), getDirection().y() };
+  double p2[4] = { track.getPosition().x(), track.getPosition().y(), track.getDirection().x(),
+                   track.getDirection().y() };
+  for (int ipar = 0; ipar < 4; ++ipar) {
+    double diff = p1[ipar] - p2[ipar];
+    if (diff * diff / (mCovarianceParameters[ipar] + track.mCovarianceParameters[ipar]) > chi2Cut) {
+      return false;
+    };
+  }
+  return true;
+}
+
+//______________________________________________________________________________
+std::ostream& operator<<(std::ostream& stream, const Track& track)
+{
+  /// Overload ostream operator
+  stream << "Position: " << track.mPosition << "  Direction: " << track.mDirection
+         << " Covariance (X, Y, SlopeX, SlopeY, X-SlopeX, Y-SlopeY): (";
+  for (int ival = 0; ival < 6; ++ival) {
+    stream << track.mCovarianceParameters[ival];
+    stream << ((ival == 5) ? ")" : ", ");
+  }
+  return stream;
+}
+
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/Base/CMakeLists.txt
+++ b/Detectors/MUON/MID/Base/CMakeLists.txt
@@ -5,6 +5,7 @@ O2_SETUP(NAME ${MODULE_NAME})
 set(SRCS
   src/Constants.cxx
   src/GeometryTransformer.cxx
+  src/HitFinder.cxx
   src/LegacyUtility.cxx
   src/Mapping.cxx
   src/MpArea.cxx
@@ -13,6 +14,7 @@ set(SRCS
 set(NO_DICT_HEADERS
   include/${MODULE_NAME}/Constants.h
   include/${MODULE_NAME}/GeometryTransformer.h
+  include/${MODULE_NAME}/HitFinder.h
   include/${MODULE_NAME}/LegacyUtility.h
   include/${MODULE_NAME}/Mapping.h
   include/${MODULE_NAME}/MpArea.h

--- a/Detectors/MUON/MID/Base/include/MIDBase/HitFinder.h
+++ b/Detectors/MUON/MID/Base/include/MIDBase/HitFinder.h
@@ -1,0 +1,55 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDBase/HitFinder.h
+/// \brief  Hit finder for MID
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   14 March 2018
+
+#ifndef O2_MID_HITFINDER_H
+#define O2_MID_HITFINDER_H
+
+#include "MathUtils/Cartesian3D.h"
+#include "DataFormatsMID/Track.h"
+#include "MIDBase/GeometryTransformer.h"
+#include "MIDBase/Constants.h"
+
+namespace o2
+{
+namespace mid
+{
+/// Class to find the impact point of a track on the chamber
+class HitFinder
+{
+ public:
+  HitFinder();
+  virtual ~HitFinder() = default;
+
+  HitFinder(const HitFinder&) = delete;
+  HitFinder& operator=(const HitFinder&) = delete;
+  HitFinder(HitFinder&&) = delete;
+  HitFinder& operator=(HitFinder&&) = delete;
+
+  std::vector<int> getFiredDE(const Track& track, int chamber) const;
+  std::vector<std::pair<int, Point3D<float>>> getLocalPositions(const Track& track, int chamber) const;
+
+ private:
+  Point3D<double> getIntersectInDefaultPlane(const Track& track, int chamber) const;
+  Point3D<float> getIntersect(const Track& track, int deId) const;
+  int guessRPC(double yPos, int chamber) const;
+
+  GeometryTransformer mGeometryTransformer; ///< Geometry transformer
+  const double mTanTheta;                   ///< Tangent of the angle between y and z
+  const double mCosTheta;                   ///< Cosinus of the beam angle
+};
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_HITFINDER_H */

--- a/Detectors/MUON/MID/Base/src/HitFinder.cxx
+++ b/Detectors/MUON/MID/Base/src/HitFinder.cxx
@@ -1,0 +1,147 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Base/src/HitFinder.cxx
+/// \brief  Implementation of the hit finder for MID
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   14 March 2018
+
+#include "MIDBase/HitFinder.h"
+
+#include <cmath>
+#include "MIDBase/Constants.h"
+
+namespace o2
+{
+namespace mid
+{
+//______________________________________________________________________________
+HitFinder::HitFinder()
+  : mGeometryTransformer(),
+    mTanTheta(std::tan((90. - Constants::sBeamAngle) * std::atan(1) / 45.)),
+    mCosTheta(std::cos(Constants::sBeamAngle * std::atan(1) / 45.))
+{
+  /// default constructor
+}
+
+//______________________________________________________________________________
+Point3D<double> HitFinder::getIntersectInDefaultPlane(const Track& track, int chamber) const
+{
+  /// Get the intersection point in the default chamber plane
+  double defaultZ = Constants::sDefaultChamberZ[chamber];
+  double linePar = ((track.getPosition().z() - defaultZ) * mTanTheta - track.getPosition().y()) /
+                   (track.getDirection().y() - track.getDirection().z() * mTanTheta);
+  Point3D<double> point;
+  point.SetX(track.getPosition().x() + linePar * track.getDirection().x());
+  point.SetY(track.getPosition().y() + linePar * track.getDirection().y());
+  point.SetZ(track.getPosition().z() + linePar * track.getDirection().z());
+  return point;
+}
+
+//______________________________________________________________________________
+Point3D<float> HitFinder::getIntersect(const Track& track, int deId) const
+{
+  /// Get the intersection point in the specified detection elements
+  /// The point is expressed in local coordinates
+  Point3D<float> localPoint = mGeometryTransformer.globalToLocal(deId, track.getPosition());
+
+  // Track localTrack(track);
+  // localTrack.propagateToZ(localTrack.getPosition().z() + 20.);
+  // Point3D<float> localPoint2 = mGeometryTransformer.globalToLocal(deId, localTrack.getPosition());
+  // localTrack.setPosition(localPoint.x(), localPoint.y(), localPoint.z());
+  // float dZ = localPoint2.z() - localPoint.z();
+  // localTrack.setDirection((localPoint2.x() - localPoint.x()) / dZ, (localPoint2.y() - localPoint.y()) / dZ, 1.);
+
+  Vector3D<float> localDirection = mGeometryTransformer.globalToLocal(deId, track.getDirection());
+  Track localTrack;
+  localTrack.setPosition(localPoint.x(), localPoint.y(), localPoint.z());
+  localTrack.setDirection(localDirection.x() / localDirection.z(), localDirection.y() / localDirection.z(), 1.);
+
+  localTrack.propagateToZ(0);
+  return localTrack.getPosition();
+}
+
+//______________________________________________________________________________
+int HitFinder::guessRPC(double yPos, int chamber) const
+{
+  /// Guesses the RPC form the y position
+  return (int)(yPos / (2. * Constants::getRPCHalfHeight(chamber)) + 4.5);
+}
+
+//______________________________________________________________________________
+std::vector<int> HitFinder::getFiredDE(const Track& track, int chamber) const
+{
+  /// Gets the potentially fired detection elements
+  /// @param track MID track
+  /// @param chamber Chamber ID (0-3)
+  /// @return Vector with the list of the detection element IDs potentially fired
+  std::vector<int> deIdList;
+  Point3D<double> defPos = getIntersectInDefaultPlane(track, chamber);
+  double xPos = defPos.x();
+  double xErr = std::sqrt(track.getCovarianceParameter(Track::CovarianceParamIndex::VarX));
+  double yPos = defPos.y() / mCosTheta;
+  double yErr = std::sqrt(track.getCovarianceParameter(Track::CovarianceParamIndex::VarY));
+  double positions[3] = { yPos, yPos - yErr, yPos + yErr };
+  int centerRpc = -1;
+  for (int ipos = 0; ipos < 3; ++ipos) {
+    int rpc = guessRPC(positions[ipos], chamber);
+    if (rpc < 0 || rpc > 8) {
+      continue;
+    }
+    if (ipos == 0) {
+      centerRpc = rpc;
+    } else if (rpc == centerRpc) {
+      continue;
+    }
+    if (xPos > 0) {
+      deIdList.push_back(Constants::getDEId(true, chamber, rpc));
+      if (xPos - xErr < 0) {
+        deIdList.push_back(Constants::getDEId(false, chamber, rpc));
+      }
+    } else {
+      deIdList.push_back(Constants::getDEId(false, chamber, rpc));
+      if (xPos + xErr > 0) {
+        deIdList.push_back(Constants::getDEId(true, chamber, rpc));
+      }
+    }
+  }
+
+  return deIdList;
+}
+
+//______________________________________________________________________________
+std::vector<std::pair<int, Point3D<float>>> HitFinder::getLocalPositions(const Track& track, int chamber) const
+{
+  /// Gets the list of fired Points in local coordinates
+  /// @param track MID track
+  /// @param chamber Chamber ID (0-3)
+  /// @return Vector with the pairs of detection element Ids and intersection point
+  std::vector<int> deIdList = getFiredDE(track, chamber);
+
+  std::vector<std::pair<int, Point3D<float>>> points;
+  for (auto& deId : deIdList) {
+    Point3D<float> point = getIntersect(track, deId);
+    int rpc = deId % 9;
+    double hw = Constants::getRPCHalfWidth(chamber, rpc);
+    double hh = Constants::getRPCHalfHeight(chamber);
+    if (point.x() < -hw || point.x() > hw) {
+      continue;
+    }
+    if (point.y() < -hh || point.y() > hh) {
+      continue;
+    }
+    points.emplace_back(std::pair<int, Point3D<float>>(deId, point));
+  }
+
+  return points;
+}
+
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/CMakeLists.txt
+++ b/Detectors/MUON/MID/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(Base)
 add_subdirectory(Clustering)
+add_subdirectory(TestingSimTools)

--- a/Detectors/MUON/MID/CMakeLists.txt
+++ b/Detectors/MUON/MID/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(Base)
 add_subdirectory(Clustering)
 add_subdirectory(TestingSimTools)
+add_subdirectory(Tracking)

--- a/Detectors/MUON/MID/TestingSimTools/CMakeLists.txt
+++ b/Detectors/MUON/MID/TestingSimTools/CMakeLists.txt
@@ -1,0 +1,16 @@
+set(MODULE_NAME "MIDTestingSimTools")
+
+O2_SETUP(NAME ${MODULE_NAME})
+
+set(SRCS
+   src/TrackGenerator.cxx
+)
+
+set(HEADERS
+   include/${MODULE_NAME}/TrackGenerator.h
+)
+
+Set(LIBRARY_NAME ${MODULE_NAME})
+set(BUCKET_NAME mid_testingSimTools_bucket)
+
+O2_GENERATE_LIBRARY()

--- a/Detectors/MUON/MID/TestingSimTools/include/MIDTestingSimTools/TrackGenerator.h
+++ b/Detectors/MUON/MID/TestingSimTools/include/MIDTestingSimTools/TrackGenerator.h
@@ -1,0 +1,67 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDTestingSimTools/TrackGenerator.h
+/// \brief  Fast track generator for MID
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   11 December 2017
+
+#ifndef O2_MID_TRACKGENERATOR_H
+#define O2_MID_TRACKGENERATOR_H
+
+#include <array>
+#include <vector>
+#include <random>
+#include "DataFormatsMID/Track.h"
+
+namespace o2
+{
+namespace mid
+{
+/// Class to generate tracks for MID
+class TrackGenerator
+{
+ public:
+  TrackGenerator();
+  virtual ~TrackGenerator() = default;
+
+  TrackGenerator(const TrackGenerator&) = delete;
+  TrackGenerator& operator=(const TrackGenerator&) = delete;
+  TrackGenerator(TrackGenerator&&) = delete;
+  TrackGenerator& operator=(TrackGenerator&&) = delete;
+
+  std::vector<Track> generate();
+  std::vector<Track> generate(int nTracks);
+
+  /// Sets the mean number of track per events
+  void setMeanTracksPerEvent(int meanTracksPerEvent) { mMeanTracksPerEvent = meanTracksPerEvent; }
+  /// Sets the limits of the track slope
+  void setSlopeLimits(float slopeXmin, float slopeXmax, float slopeYmin, float slopeYmax)
+  {
+    mSlopeLimits = { { slopeXmin, slopeXmax, slopeYmin, slopeYmax } };
+  }
+  /// Sets the limits of the track origin
+  void setPositionLimits(float xMin, float xMax, float yMin, float yMax, float zMin, float zMax)
+  {
+    mPositionLimits = { { xMin, xMax, yMin, yMax, zMin, zMax } };
+  }
+
+ private:
+  std::array<float, 4> getLimitsForAcceptance(std::array<float, 3> pos);
+
+  int mMeanTracksPerEvent;               ///< Mean tracks per event
+  std::array<float, 4> mSlopeLimits;     ///< Limits for track slope
+  std::array<float, 6> mPositionLimits;  ///< x,y,z position limits
+  std::default_random_engine mGenerator; ///< Random numbers generator
+};
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_TRACKGENERATOR_H */

--- a/Detectors/MUON/MID/TestingSimTools/src/TrackGenerator.cxx
+++ b/Detectors/MUON/MID/TestingSimTools/src/TrackGenerator.cxx
@@ -1,0 +1,96 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/TestingSimTools/src/TrackGenerator.cxx
+/// \brief  Implementation of a fast track generator for MID
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   11 December 2017
+
+#include "MIDTestingSimTools/TrackGenerator.h"
+
+namespace o2
+{
+namespace mid
+{
+//______________________________________________________________________________
+TrackGenerator::TrackGenerator()
+  : mMeanTracksPerEvent(1),
+    mSlopeLimits{ { -0.2, 0.2, -0.5, 0.5 } },
+    mPositionLimits{ { -2., 2, -2., 2., -5., 5. } },
+    mGenerator(std::default_random_engine())
+{
+  /// Default constructor
+}
+
+//______________________________________________________________________________
+std::vector<Track> TrackGenerator::generate()
+{
+  /// Generate tracks. The number of tracks follows a poissonian distribution
+  std::poisson_distribution<> distTracks(mMeanTracksPerEvent);
+  int nTracks = distTracks(mGenerator);
+  return generate(nTracks);
+}
+
+//______________________________________________________________________________
+std::vector<Track> TrackGenerator::generate(int nTracks)
+{
+  /// Generate N tracks
+  /// @param nTracks Number of tracks to generate
+  std::vector<Track> tracks;
+  Track track;
+  std::array<float, 3> pos;
+  std::array<float, 2> dir;
+  for (int itrack = 0; itrack < nTracks; ++itrack) {
+    for (int ipos = 0; ipos < 3; ++ipos) {
+      pos[ipos] =
+        std::uniform_real_distribution<float>{ mPositionLimits[2 * ipos], mPositionLimits[2 * ipos + 1] }(mGenerator);
+    }
+    track.setPosition(pos[0], pos[1], pos[2]);
+
+    std::array<float, 4> limits = getLimitsForAcceptance(pos);
+
+    for (int idir = 0; idir < 2; ++idir) {
+      dir[idir] = std::uniform_real_distribution<float>{ limits[2 * idir], limits[2 * idir + 1] }(mGenerator);
+    }
+    track.setDirection(dir[0], dir[1], 1.);
+    tracks.push_back(track);
+  }
+  return tracks;
+}
+
+//______________________________________________________________________________
+std::array<float, 4> TrackGenerator::getLimitsForAcceptance(std::array<float, 3> pos)
+{
+  /// Restricts the limits of the slopes
+  /// so that the track enters in the spectrometer acceptance
+  std::array<float, 4> limits = mSlopeLimits;
+  float dZ = -1600. - pos[2];
+  if (dZ == 0.) {
+    dZ = 0.0001;
+  }
+
+  // These are the maximum x and y position of MT11 with the standard alignment
+  std::array<float, 2> maxValues{ { 257., 306.7 } };
+  for (int icoor = 0; icoor < 2; ++icoor) {
+    int imin = 2 * icoor;
+    int imax = 2 * icoor + 1;
+    float minSlope = (pos[icoor] - maxValues[icoor]) / dZ;
+    float maxSlope = (maxValues[icoor] - pos[icoor]) / dZ;
+    if (minSlope > limits[imin]) {
+      limits[imin] = minSlope;
+    }
+    if (maxSlope < limits[imax]) {
+      limits[imax] = maxSlope;
+    }
+  }
+  return limits;
+}
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/Tracking/CMakeLists.txt
+++ b/Detectors/MUON/MID/Tracking/CMakeLists.txt
@@ -1,0 +1,25 @@
+set(MODULE_NAME "MIDTracking")
+
+O2_SETUP(NAME ${MODULE_NAME})
+
+set(SRCS
+   src/Tracker.cxx
+   src/TrackerDevice.cxx
+)
+
+set(LIBRARY_NAME ${MODULE_NAME})
+set(BUCKET_NAME mid_tracking_bucket)
+
+O2_GENERATE_LIBRARY()
+
+O2_GENERATE_EXECUTABLE(
+    EXE_NAME runMIDTracking
+    SOURCES src/runMIDTracking.cxx
+    MODULE_LIBRARY_NAME ${LIBRARY_NAME}
+    BUCKET_NAME ${BUCKET_NAME}
+)
+
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/config/runMIDtracking.json
+        DESTINATION etc/config)
+
+add_subdirectory(test)

--- a/Detectors/MUON/MID/Tracking/README.md
+++ b/Detectors/MUON/MID/Tracking/README.md
@@ -1,0 +1,15 @@
+# Running MID Tracking
+
+The MID tracking takes as input the clusters and returns a vector of reconstructed tracks.
+The magnetic field in the trigger chambers, placed behind an iron wall, is negligible, so a straight track is used.
+
+
+## Execution
+### Start clusterizer
+See instructions [here](../Clustering/README.md).
+
+### Start tracker
+In another terminal:
+```bash
+runMIDTracking --id 'MIDtracker' --mq-config "$O2_ROOT/etc/config/runMIDtracking.json"
+```

--- a/Detectors/MUON/MID/Tracking/config/runMIDtracking.json
+++ b/Detectors/MUON/MID/Tracking/config/runMIDtracking.json
@@ -1,0 +1,37 @@
+{
+    "fairMQOptions": {
+        "devices": [
+            {
+                "key": "MIDtracker",
+                "channels": [
+                    {
+                        "name": "data-in",
+                        "sockets": [
+                            {
+                                "type": "pull",
+                                "method": "connect",
+                                "address": "tcp://localhost:46000",
+                                "sndBufSize": 1000,
+                                "rcvBufSize": 1000,
+                                "rateLogging": 0
+                            }
+                        ]
+                    },
+                    {
+                        "name": "data-out",
+                        "sockets": [
+                            {
+                                "type": "push",
+                                "method": "bind",
+                                "address": "tcp://*:47000",
+                                "sndBufSize": 1000,
+                                "rcvBufSize": 1000,
+                                "rateLogging": 0
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/Detectors/MUON/MID/Tracking/src/Tracker.cxx
+++ b/Detectors/MUON/MID/Tracking/src/Tracker.cxx
@@ -1,0 +1,448 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Tracking/src/Tracker.cxx
+/// \brief  Implementation of the tracker algorithm for the MID
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   09 May 2017
+#include "Tracker.h"
+
+#include <cmath>
+#include "FairLogger.h"
+#include "MIDBase/Constants.h"
+
+namespace o2
+{
+namespace mid
+{
+
+//______________________________________________________________________________
+Tracker::Tracker() : mImpactParamCut(210.), mSigmaCut(5.), mMaxChi2(1.e6), mNTracks(0)
+{
+  /// Default constructor
+}
+
+//______________________________________________________________________________
+bool Tracker::init()
+{
+  /// Initializes the task
+
+  // Reset the ordered array of clusters
+  for (int deId = 0; deId < 72; ++deId) {
+    mClusters[deId].reserve(20);
+    mNClusters[deId] = 0;
+  }
+
+  // Prepare storage of tracks
+  mTracks.reserve(30);
+
+  return true;
+}
+
+//______________________________________________________________________________
+void Tracker::reset()
+{
+  /// Resets clusters and the number of tracks
+  for (int deId = 0; deId < 72; ++deId) {
+    mNClusters[deId] = 0;
+  }
+
+  mNTracks = 0;
+}
+
+//______________________________________________________________________________
+int Tracker::getFirstNeighbourRPC(int rpc) const
+{
+  /// Gets first neighbour RPC
+  return (rpc == 0) ? rpc : rpc - 1;
+}
+
+//______________________________________________________________________________
+int Tracker::getLastNeighbourRPC(int rpc) const
+{
+  /// Gets first neighbour RPC
+  return (rpc == 8) ? rpc : rpc + 1;
+}
+
+//______________________________________________________________________________
+int Tracker::getClusterId(int id, int deId) const
+{
+  /// Gets first neighbour RPC
+  return 1000 * deId + id;
+}
+
+//______________________________________________________________________________
+bool Tracker::loadClusters(const std::vector<Cluster2D>& clusters)
+{
+  /// Fills the array of clusters per detection element
+
+  for (auto& currData : clusters) {
+    int deId = currData.deId;
+    if (mNClusters[deId] >= static_cast<unsigned long int>(mClusters[deId].size())) {
+      mClusters[deId].emplace_back(Cluster3D());
+    }
+    Cluster3D& cl(mClusters[deId][mNClusters[deId]]);
+    ++mNClusters[deId];
+    cl.deId = currData.deId;
+    cl.id = mNClusters[deId];
+    cl.position = mTransformer.localToGlobal(deId, currData.xCoor, currData.yCoor);
+    cl.sigmaX2 = currData.sigmaX2;
+    cl.sigmaY2 = currData.sigmaY2;
+
+    LOG(DEBUG) << "deId " << deId << " pos: (" << currData.xCoor << ", " << currData.yCoor << ") err2: ("
+               << currData.sigmaX2 << ", " << currData.sigmaY2 << ") => (" << cl.position.x() << "," << cl.position.y()
+               << "," << cl.position.z() << ")";
+  }
+
+  return (clusters.size() > 0);
+}
+
+//______________________________________________________________________________
+bool Tracker::process(const std::vector<Cluster2D>& clusters)
+{
+  /// Main function: runs on a data containing the clusters
+  /// and builds the tracks
+
+  // Reset cluster and tracks information
+  reset();
+
+  // Load the digits to get the fired pads
+  if (loadClusters(clusters)) {
+    // Right and left side can be processed in parallel
+    // Right inward
+    processSide(true, true);
+    // Right outward
+    processSide(true, false);
+    // Left inward
+    processSide(false, true);
+    // left outward
+    processSide(false, false);
+  }
+
+  return true;
+}
+
+//______________________________________________________________________________
+bool Tracker::processSide(bool isRight, bool isInward)
+{
+  /// Make tracks on one side of the detector
+  int firstCh = (isInward) ? 3 : 0;
+  int secondCh = (isInward) ? 2 : 1;
+  int rpcOffset1 = Constants::getDEId(isRight, firstCh, 0);
+  int rpcOffset2 = Constants::getDEId(isRight, secondCh, 0);
+
+  // loop on RPCs in first plane
+  Track track;
+  for (int irpc = 0; irpc < 9; ++irpc) {
+    int deId1 = rpcOffset1 + irpc;
+    for (int icl1 = 0; icl1 < mNClusters[deId1]; ++icl1) {
+      // loop on clusters of the RPC in the first plane
+      auto& cl1 = mClusters[deId1][icl1];
+      int firstRpc = getFirstNeighbourRPC(irpc);
+      int lastRpc = getLastNeighbourRPC(irpc);
+      for (int irpc2 = firstRpc; irpc2 <= lastRpc; ++irpc2) {
+        // loop on (neighbour) RPCs in second plane
+        int deId2 = rpcOffset2 + irpc2;
+        for (int icl2 = 0; icl2 < mNClusters[deId2]; ++icl2) {
+          // loop on clusters of the RPC in the second plane
+          auto& cl2 = mClusters[deId2][icl2];
+
+          if (!makeTrackSeed(track, cl1, cl2)) {
+            continue;
+          }
+
+          track.setClusterMatched(firstCh, getClusterId(cl1.id, deId1));
+          track.setClusterMatched(secondCh, getClusterId(cl2.id, deId2));
+          track.setClusterMatched(3 - firstCh, 0);
+          track.setClusterMatched(3 - secondCh, 0);
+          LOG(DEBUG) << deId1 << " - " << deId2;
+          LOG(DEBUG) << "Position: " << track.getPosition();
+          // LOG(DEBUG) << "Covariance: " << track.getCovarianceParameters();
+          followTrack(track, isRight, isInward);
+        } // loop on clusters in second plane
+      }   // loop on RPCs in second plane
+    }     // loop on clusters in first plane
+  }       // loop on RPCs in first plane
+  return true;
+}
+
+//______________________________________________________________________________
+bool Tracker::makeTrackSeed(Track& track, const Cluster3D& cl1, const Cluster3D& cl2) const
+{
+  /// Make a track seed from two clusters
+
+  // First check if the delta_x between the two clusters is not too large
+  double dZ = cl2.position.z() - cl1.position.z();
+  double dZ2 = dZ * dZ;
+  double nonBendingSlope = (cl2.position.x() - cl1.position.x()) / dZ;
+  double nonBendingImpactParam = std::abs(cl2.position.x() - cl2.position.z() * nonBendingSlope);
+  double nonBendingImpactParamErr = std::sqrt(
+    (cl1.position.z() * cl1.position.z() * cl2.sigmaX2 + cl2.position.z() * cl2.position.z() * cl1.sigmaX2) / dZ2);
+  if ((nonBendingImpactParam - mSigmaCut * nonBendingImpactParamErr) > mImpactParamCut) {
+    LOG(DEBUG) << "NB slope: " << nonBendingSlope << " NB impact param: " << nonBendingImpactParam << " - " << mSigmaCut
+               << " * " << nonBendingImpactParamErr << " > " << mImpactParamCut;
+    return false;
+  }
+
+  // Then start making the track (from 2 points)
+  track.setPosition(cl2.position.x(), cl2.position.y(), cl2.position.z());
+  track.setDirection(nonBendingSlope, (cl2.position.y() - cl1.position.y()) / dZ, 1.);
+  track.setCovarianceParameters(cl2.sigmaX2,                       // x-x
+                                cl2.sigmaY2,                       // y-y
+                                (cl1.sigmaX2 + cl2.sigmaX2) / dZ2, // slopeX-slopeX
+                                (cl1.sigmaY2 + cl2.sigmaY2) / dZ2, // slopeY-slopeY
+                                cl2.sigmaX2 / dZ,                  // x-slopeX
+                                cl2.sigmaY2 / dZ);                 // y-slopeY
+
+  return true;
+}
+
+//______________________________________________________________________________
+bool Tracker::followTrack(const Track& track, bool isRight, bool isInward)
+{
+  /// Follows the track segment in the other station
+  double bestChi2 = 2. * mSigmaCut * mSigmaCut;
+  int nFiredChambers = 0;
+  int chamberOrder[2];
+  chamberOrder[0] = isInward ? 1 : 2;
+  chamberOrder[1] = isInward ? 0 : 3;
+
+  // Add the track to the list
+  if (mNTracks >= static_cast<unsigned long int>(mTracks.size())) {
+    mTracks.emplace_back(Track());
+  }
+  Track& bestTrack(mTracks[mNTracks]);
+
+  // loop on next two chambers
+  for (int ich = 0; ich < 2; ++ich) {
+    findNextCluster(track, isRight, isInward, chamberOrder[ich], 0, 8, nFiredChambers, bestChi2, bestTrack);
+    if (nFiredChambers == 2) {
+      // We already found all clusters: no need to search for mono-cathodic clusters
+      // in the next chamber
+      break;
+    }
+  }
+
+  if (nFiredChambers == 0) {
+    // No track found
+    return false;
+  }
+
+  // Extrapolate to first cluster in MT11 and compute the chi2
+  finalizeTrack(bestTrack);
+
+  // Add the track if it is not compatible or better than the ones we already have
+  return addTrack(bestTrack);
+}
+
+//______________________________________________________________________________
+bool Tracker::findNextCluster(const Track& track, bool isRight, bool isInward, int chamber, int firstRPC, int lastRPC,
+                              int& nFiredChambers, double& bestChi2, Track& bestTrack, double chi2, int depth) const
+{
+  /// Find next best cluster
+  int nextChamber = (isInward) ? chamber - 1 : chamber + 1;
+  int rpcOffset = Constants::getDEId(isRight, chamber, 0);
+  Track newTrack;
+  for (int irpc = firstRPC; irpc <= lastRPC; ++irpc) {
+    int deId = rpcOffset + irpc;
+    for (int icl = 0; icl < mNClusters[deId]; ++icl) {
+      auto& cl = mClusters[deId][icl];
+      double addChi2AtCluster = tryOneCluster(track, cl, newTrack);
+      double sumChi2 = chi2 + addChi2AtCluster;
+      if (sumChi2 > bestChi2) {
+        continue;
+      }
+      if (nextChamber >= 0 && nextChamber <= 3) {
+        findNextCluster(newTrack, isRight, isInward, nextChamber, getFirstNeighbourRPC(irpc), getLastNeighbourRPC(irpc),
+                        nFiredChambers, bestChi2, bestTrack, sumChi2, depth + 1);
+      }
+      if (depth >= nFiredChambers && sumChi2 < bestChi2) {
+        nFiredChambers = depth;
+        bestChi2 = sumChi2;
+        bestTrack = newTrack;
+        LOG(DEBUG) << "DeId " << deId << "  cluster " << icl << "  nFiredChambers " << nFiredChambers << "  chi2 "
+                   << bestChi2;
+      }
+    } // loop on clusters
+  }   // loop on RPC
+
+  return (nFiredChambers > 0);
+}
+
+//______________________________________________________________________________
+double Tracker::tryOneCluster(const Track& track, const Cluster3D& cluster, Track& newTrack) const
+{
+  /// Tests the compatibility between the track and the cluster
+  /// given the track and cluster resolutions + the maximum-distance-to-track value
+  /// If the cluster is compatible, it propagates a copy of the track to the z of the cluster,
+  /// runs the kalman filter and returns the additional chi2.
+  /// It returns twice the maximum allowd chi2 otherwise
+  double dZ = cluster.position.z() - track.getPosition().z();
+  double dZ2 = dZ * dZ;
+  double cpos[2] = { cluster.position.x(), cluster.position.y() };
+  double cerr2[2] = { cluster.sigmaX2, cluster.sigmaY2 };
+  double pos[2] = { track.getPosition().x(), track.getPosition().y() };
+  double newPos[2] = { 0., 0. };
+  double dist[2] = { 0., 0. };
+  double dir[2] = { track.getDirection().x(), track.getDirection().y() };
+  const std::array<float, 6> covParams = track.getCovarianceParameters();
+  for (int icoor = 0; icoor < 2; ++icoor) {
+    newPos[icoor] = pos[icoor] + dir[icoor] * dZ;
+    dist[icoor] = cpos[icoor] - newPos[icoor];
+    double err2 = covParams[icoor] + dZ2 * covParams[icoor + 2] + 2. * dZ * covParams[icoor + 4] + cerr2[icoor];
+    double distMax = mSigmaCut * std::sqrt(2. * err2) + 4.;
+    if (std::abs(dist[icoor]) > distMax) {
+      LOG(DEBUG) << "Coordinate " << icoor << "  cl " << cpos[icoor] << " tr " << newPos[icoor] << " err "
+                 << std::sqrt(err2);
+      return 2. * mMaxChi2;
+    }
+  }
+
+  newTrack = track;
+  newTrack.propagateToZ(cluster.position.z());
+  newTrack.setClusterMatched(Constants::getChamber(cluster.deId), getClusterId(cluster.id, cluster.deId));
+
+  return runKalmanFilter(newTrack, cluster);
+}
+
+//__________________________________________________________________________
+double Tracker::runKalmanFilter(Track& track, const Cluster3D& cluster) const
+{
+  /// Computes new track parameters and their covariances including new cluster using kalman filter.
+  /// Returns the additional track chi2
+
+  double pos[2] = { track.getPosition().x(), track.getPosition().y() };
+  double dir[2] = { track.getDirection().x(), track.getDirection().y() };
+  double clusPos[2] = { cluster.position.x(), cluster.position.y() };
+
+  std::array<float, 6> newCovParams;
+  const std::array<float, 6> covParams = track.getCovarianceParameters();
+  double newPos[2], newDir[2];
+  double clusterSigma[2] = { cluster.sigmaX2, cluster.sigmaY2 };
+  double chi2 = 0.;
+  for (int idx = 0; idx < 2; ++idx) {
+    int slopeIdx = idx + 2;
+    int covIdx = idx + 4;
+
+    double den = clusterSigma[idx] + covParams[idx];
+    assert(den != 0.);
+    // if ( den == 0. ) return 2.*mMaxChi2;
+
+    // Compute the new covariance
+    // cov -> (W+U)^-1
+    // where W = (old_cov)^-1
+    // and U = inverse of uncertainties of cluster
+    // s_x^2 -> s_x^2 * cl_s_x^2 / (s_x^2 + cl_s_x^2)
+    newCovParams[idx] = covParams[idx] * clusterSigma[idx] / den;
+    // cov(x,slopeX) -> cov(x,slopeX) * cl_s_x^2 / (s_x^2 + cl_s_x^2)
+    newCovParams[covIdx] = covParams[covIdx] * clusterSigma[idx] / den;
+    // s_slopeX^2 -> s_slopeX^2 - cov(x,slopeX)^2 / (s_x^2 + cl_s_x^2)
+    newCovParams[slopeIdx] = covParams[slopeIdx] - covParams[covIdx] * covParams[covIdx] / den;
+
+    double diff = clusPos[idx] - pos[idx];
+
+    // New parameters: p' = ((W+U)^-1)U(m-p) + p
+    // x -> x + ( cl_x - x ) * s_x^2 / (s_x^2 + cl_s_x^2)
+    newPos[idx] = pos[idx] + diff * covParams[idx] / den;
+    // slopeX -> slopeX + ( cl_x - x ) * s_slopeX^2 / (s_x^2 + cl_s_x^2)
+    newDir[idx] = dir[idx] + diff * covParams[covIdx] / den;
+
+    chi2 += diff * diff / den;
+  }
+
+  // Save the new parameters
+  track.setPosition(newPos[0], newPos[1], cluster.position.z());
+  track.setDirection(newDir[0], newDir[1], 1.);
+
+  // Save the new parameters covariance matrix
+  track.setCovarianceParameters(newCovParams);
+
+  return chi2;
+}
+
+//______________________________________________________________________________
+void Tracker::finalizeTrack(Track& track)
+{
+  /// Computes the chi2 of the track
+  /// and extrapolate it to the first cluster
+  int ndf = 0;
+  double chi2 = 0.;
+  for (int ich = 3; ich >= 0; --ich) {
+    int matchedClusterIdx = track.getClusterMatched(ich);
+    if (matchedClusterIdx == 0) {
+      continue;
+    }
+    ++ndf;
+    int deId = matchedClusterIdx / 1000;
+    int icl = matchedClusterIdx % 1000 - 1;
+    Cluster3D& cl(mClusters[deId][icl]);
+    track.propagateToZ(cl.position.z());
+    double clPos[2] = { cl.position.x(), cl.position.y() };
+    double clErr2[2] = { cl.sigmaX2, cl.sigmaY2 };
+    double trackPos[2] = { track.getPosition().x(), track.getPosition().y() };
+    double trackCov[2] = { track.getCovarianceParameter(Track::CovarianceParamIndex::VarX),
+                           track.getCovarianceParameter(Track::CovarianceParamIndex::VarY) };
+    for (int icoor = 0; icoor < 2; ++icoor) {
+      double diff = trackPos[icoor] - clPos[icoor];
+      chi2 += diff * diff / (trackCov[icoor] + clErr2[icoor]);
+    }
+  }
+  track.setChi2(chi2);
+  track.setNDF(ndf);
+  LOG(DEBUG) << track;
+}
+
+//______________________________________________________________________________
+bool Tracker::addTrack(const Track& track)
+{
+  /// Adds the track to the list
+  /// Does not add identical tracks (i.e. sharing the same clusters)
+  /// If track parameters are compatible, selects the track with the
+  /// smallest chi2
+
+  float chi2OverNDF = track.getChi2OverNDF();
+  // We divide the chi2 by two since we want to consider only the uncertainty
+  // on one of the two tracks. We further reduce to 0.4 since we want to account
+  // for the case where one of the two reconstructed tracks has a much better precision
+  // of the other
+  float chi2Cut = 0.4 * mSigmaCut * mSigmaCut;
+  for (int itrack = 0; itrack < mNTracks; ++itrack) {
+    int nCommonClusters = 0;
+    auto& checkTrack = mTracks[itrack];
+    for (int ich = 0; ich < 4; ++ich) {
+      if (track.getClusterMatched(ich) == checkTrack.getClusterMatched(ich)) {
+        ++nCommonClusters;
+      }
+    }
+    if (nCommonClusters == 4) {
+      return false;
+    }
+    if (track.isCompatible(checkTrack, chi2Cut)) {
+      // The new track is compatible with an existing one
+      if (chi2OverNDF < checkTrack.getChi2OverNDF()) {
+        // The new track is more precise than the old one: replace it!
+        LOG(DEBUG) << "Replacing track " << checkTrack << "\n with " << track;
+        checkTrack = track;
+        return true;
+      } else {
+        LOG(DEBUG) << "Rejecting track " << track << "\n compatible with " << checkTrack;
+        // The new track is less precise than the old one: reject it
+        return false;
+      }
+    }
+  }
+
+  // The new track is not compatible with the previous ones: add the track to the list
+  ++mNTracks;
+  return true;
+}
+
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/Tracking/src/Tracker.h
+++ b/Detectors/MUON/MID/Tracking/src/Tracker.h
@@ -1,0 +1,90 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Tracking/src/Tracker.h
+/// \brief  Track reconstruction algorithm for MID
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   09 May 2017
+
+#ifndef O2_MID_TRACKER_H
+#define O2_MID_TRACKER_H
+
+#include <vector>
+#include "DataFormatsMID/Cluster2D.h"
+#include "DataFormatsMID/Cluster3D.h"
+#include "DataFormatsMID/Track.h"
+#include "MIDBase/GeometryTransformer.h"
+
+namespace o2
+{
+namespace mid
+{
+/// Tracking algorithm for MID
+class Tracker
+{
+ public:
+  Tracker();
+  virtual ~Tracker() = default;
+
+  Tracker(const Tracker&) = delete;
+  Tracker& operator=(const Tracker&) = delete;
+  Tracker(Tracker&&) = delete;
+  Tracker& operator=(Tracker&&) = delete;
+
+  /// Sets impact parameter cut
+  void setImpactParamCut(float impactParamCut) { mImpactParamCut = impactParamCut; }
+  /// Gets the impact parameter cut
+  inline float getImpactParamCut() const { return mImpactParamCut; }
+  /// Sets number of sigmas for cuts
+  void setSigmaCut(float sigmaCut) { mImpactParamCut = mSigmaCut; }
+  /// Gets number of sigmas for cuts
+  inline float getSigmaCut() const { return mSigmaCut; }
+
+  bool process(const std::vector<Cluster2D>& clusters);
+  bool init();
+
+  /// Gets the array of reconstructes tracks
+  const std::vector<Track>& getTracks() { return mTracks; }
+
+  /// Gets the number of reconstructed tracks
+  unsigned long int getNTracks() { return mNTracks; }
+
+ private:
+  bool processSide(bool isRight, bool isInward);
+  bool addTrack(const Track& track);
+  bool followTrack(const Track& track, bool isRight, bool isInward);
+  bool findNextCluster(const Track& track, bool isRight, bool isInward, int chamber, int firstRPC, int lastRPC,
+                       int& nFiredChambers, double& bestChi2, Track& bestTrack, double chi2 = 0., int depth = 1) const;
+  int getClusterId(int id, int deId) const;
+  int getFirstNeighbourRPC(int rpc) const;
+  int getLastNeighbourRPC(int rpc) const;
+  bool loadClusters(const std::vector<Cluster2D>& clusters);
+  bool makeTrackSeed(Track& track, const Cluster3D& cl1, const Cluster3D& cl2) const;
+  void reset();
+  double runKalmanFilter(Track& track, const Cluster3D& cluster) const;
+  double tryOneCluster(const Track& track, const Cluster3D& cluster, Track& newTrack) const;
+  void finalizeTrack(Track& track);
+
+  float mImpactParamCut; ///< Cut on impact parameter
+  float mSigmaCut;       ///< Number of sigmas cut
+  float mMaxChi2;        ///< Maximum cut on chi2
+
+  std::vector<Cluster3D> mClusters[72]; ///< Ordered arrays of clusters
+  unsigned long int mNClusters[72];     ///< Number of clusters per RPC
+
+  std::vector<Track> mTracks; ///< Array of tracks
+  unsigned long int mNTracks; ///< Number of tracks
+
+  GeometryTransformer mTransformer; ///< Geometry transformer
+};
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_TRACKER_H */

--- a/Detectors/MUON/MID/Tracking/src/TrackerDevice.cxx
+++ b/Detectors/MUON/MID/Tracking/src/TrackerDevice.cxx
@@ -1,0 +1,68 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Tracking/src/TrackerDevice.cxx
+/// \brief  Implementation of tracker device for the MID
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   09 May 2017
+#include "TrackerDevice.h"
+
+#include "FairMQLogger.h"
+#include "options/FairMQProgOptions.h"
+#include "MIDBase/Serializer.h"
+
+namespace o2
+{
+namespace mid
+{
+
+//______________________________________________________________________________
+TrackerDevice::TrackerDevice() : FairMQDevice(), mTracker()
+{
+  /// Default constructor
+  // register a handler for data arriving on "data-in" channel
+  OnData("data-in", &TrackerDevice::handleData);
+}
+
+//______________________________________________________________________________
+bool TrackerDevice::handleData(FairMQMessagePtr& msg, int /*index*/)
+{
+  /// Main function: runs on a data containing the clusters
+  /// and builds the tracks
+
+  LOG(INFO) << "Received data of size: " << msg->GetSize();
+
+  if (msg->GetSize() == 0) {
+    LOG(INFO) << "Empty message: skip";
+    return true;
+  }
+
+  std::vector<Cluster2D> clusters;
+  Deserialize<Deserializer<Cluster2D>>(*msg, clusters);
+
+  mTracker.process(clusters);
+
+  if (mTracker.getNTracks() > 0) {
+    FairMQMessagePtr msgOut(NewMessage());
+    // Serialize<BoostSerializer<Track>>(*msgOut, mTracks);
+    Serialize<Serializer<Track>>(*msgOut, mTracker.getTracks(), mTracker.getNTracks());
+
+    // Send out the output message
+    if (Send(msgOut, "data-out") < 0) {
+      LOG(ERROR) << "problem sending message";
+      return false;
+    }
+  }
+
+  return true;
+}
+
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/Tracking/src/TrackerDevice.h
+++ b/Detectors/MUON/MID/Tracking/src/TrackerDevice.h
@@ -1,0 +1,45 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   TrackerDevice.h
+/// \brief  Track reconstruction device for MID
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   09 May 2017
+
+#ifndef O2_MID_TRACKERDEVICE_H
+#define O2_MID_TRACKERDEVICE_H
+
+#include "FairMQDevice.h"
+#include "Tracker.h"
+
+namespace o2
+{
+namespace mid
+{
+/// Tracking device for MID
+class TrackerDevice : public FairMQDevice
+{
+ public:
+  TrackerDevice();
+  ~TrackerDevice() override = default;
+
+  TrackerDevice(const TrackerDevice&) = delete;
+  TrackerDevice& operator=(const TrackerDevice&) = delete;
+  TrackerDevice(TrackerDevice&&) = delete;
+  TrackerDevice& operator=(TrackerDevice&&) = delete;
+
+ private:
+  bool handleData(FairMQMessagePtr&, int);
+  Tracker mTracker; ///< Tracking class
+};
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_TRACKERDEVICE_H */

--- a/Detectors/MUON/MID/Tracking/src/runMIDTracking.cxx
+++ b/Detectors/MUON/MID/Tracking/src/runMIDTracking.cxx
@@ -1,0 +1,23 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   runMIDClusterizer.cxx
+/// \brief  A simple program to reconstruct MID tracks
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   09 May 2017
+
+#include "runFairMQDevice.h"
+#include "TrackerDevice.h"
+
+namespace bpo = boost::program_options;
+
+void addCustomOptions(bpo::options_description& options) {}
+
+FairMQDevicePtr getDevice(const FairMQProgOptions&) { return new o2::mid::TrackerDevice(); }

--- a/Detectors/MUON/MID/Tracking/test/CMakeLists.txt
+++ b/Detectors/MUON/MID/Tracking/test/CMakeLists.txt
@@ -1,0 +1,14 @@
+O2_SETUP(NAME MIDTrackingTest)
+set(BUCKET_NAME mid_tracking_test_bucket)
+
+O2_GENERATE_TESTS(
+  BUCKET_NAME ${BUCKET_NAME}
+  TEST_SRCS testTracker.cxx
+)
+
+if (benchmark_FOUND)
+    O2_GENERATE_EXECUTABLE(
+      EXE_NAME benchTracker
+      SOURCES bench_Tracker.cxx
+      BUCKET_NAME ${BUCKET_NAME})
+endif ()

--- a/Detectors/MUON/MID/Tracking/test/bench_Tracker.cxx
+++ b/Detectors/MUON/MID/Tracking/test/bench_Tracker.cxx
@@ -1,0 +1,102 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Tracking/test/bench_Tracker.cxx
+/// \brief  Benchmark tracker device for MID
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   17 March 2018
+
+#include "benchmark/benchmark.h"
+#include <iostream>
+#include <random>
+#include "DataFormatsMID/Cluster2D.h"
+#include "DataFormatsMID/Track.h"
+#include "MIDBase/Mapping.h"
+#include "MIDBase/MpArea.h"
+#include "MIDBase/HitFinder.h"
+#include "MIDTestingSimTools/TrackGenerator.h"
+#include "Tracker.h"
+
+std::vector<o2::mid::Cluster2D> generateTestData(int nTracks, o2::mid::TrackGenerator& trackGen,
+                                                 const o2::mid::HitFinder& hitFinder, const o2::mid::Mapping& mapping)
+{
+  o2::mid::Mapping::MpStripIndex stripIndex;
+  o2::mid::MpArea area;
+  std::vector<o2::mid::Cluster2D> clusters;
+  o2::mid::Cluster2D cl;
+  std::vector<o2::mid::Track> tracks = trackGen.generate(nTracks);
+  for (auto& track : tracks) {
+    for (int ich = 0; ich < 4; ++ich) {
+      std::vector<std::pair<int, Point3D<float>>> pairs = hitFinder.getLocalPositions(track, ich);
+      bool isFired = false;
+      for (auto& pair : pairs) {
+        int deId = pair.first;
+        float xPos = pair.second.x();
+        float yPos = pair.second.y();
+        stripIndex = mapping.stripByPosition(xPos, yPos, 0, deId, false);
+        if (!stripIndex.isValid()) {
+          continue;
+        }
+        cl.deId = deId;
+        area = mapping.stripByLocation(stripIndex.strip, 0, stripIndex.line, stripIndex.column, deId);
+        cl.yCoor = area.getCenterY();
+        float halfSize = area.getHalfSizeY();
+        cl.sigmaY2 = halfSize * halfSize / 3.;
+        stripIndex = mapping.stripByPosition(xPos, yPos, 1, deId, false);
+        area = mapping.stripByLocation(stripIndex.strip, 1, stripIndex.line, stripIndex.column, deId);
+        cl.xCoor = area.getCenterX();
+        halfSize = area.getHalfSizeX();
+        cl.sigmaX2 = halfSize * halfSize / 3.;
+        clusters.push_back(cl);
+      } // loop on fired pos
+    }   // loop on chambers
+  }     // loop on tracks
+  return clusters;
+}
+
+class BenchTracking : public benchmark::Fixture
+{
+ public:
+  BenchTracking() : trackGen(), hitFinder(), mapping(), tracker() { tracker.init(); }
+  o2::mid::TrackGenerator trackGen;
+  o2::mid::HitFinder hitFinder;
+  o2::mid::Mapping mapping;
+  o2::mid::Tracker tracker;
+};
+
+BENCHMARK_DEFINE_F(BenchTracking, tracking)(benchmark::State& state)
+{
+
+  int nTracksPerEvent = state.range(0);
+  double num{ 0 };
+
+  std::vector<o2::mid::Cluster2D> inputData;
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    inputData = generateTestData(nTracksPerEvent, trackGen, hitFinder, mapping);
+    state.ResumeTiming();
+    tracker.process(inputData);
+    ++num;
+  }
+
+  state.counters["num"] = benchmark::Counter(num, benchmark::Counter::kIsRate);
+}
+
+static void CustomArguments(benchmark::internal::Benchmark* bench)
+{
+  for (int itrack = 1; itrack <= 8; ++itrack) {
+    bench->Arg(itrack);
+  }
+}
+
+BENCHMARK_REGISTER_F(BenchTracking, tracking)->Apply(CustomArguments)->Unit(benchmark::kNanosecond);
+
+BENCHMARK_MAIN();

--- a/Detectors/MUON/MID/Tracking/test/testTracker.cxx
+++ b/Detectors/MUON/MID/Tracking/test/testTracker.cxx
@@ -1,0 +1,179 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Tracking/test/testTracker.cxx
+/// \brief  Test tracking device for MID
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   15 March 2018
+
+#define BOOST_TEST_MODULE midTracking
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+
+#include <boost/test/data/monomorphic/generators/xrange.hpp>
+#include <boost/test/data/test_case.hpp>
+#include <cstdint>
+#include <sstream>
+#include <vector>
+#include <random>
+#include "DataFormatsMID/Cluster2D.h"
+#include "DataFormatsMID/Track.h"
+#include "MIDBase/Mapping.h"
+#include "MIDBase/MpArea.h"
+#include "MIDBase/HitFinder.h"
+#include "MIDTestingSimTools/TrackGenerator.h"
+#include "Tracker.h"
+
+#include "FairLogger.h"
+
+namespace o2
+{
+namespace mid
+{
+
+struct TrackClusters {
+  Track track;
+  std::vector<Cluster2D> clusters;
+  int nFiredChambers;
+  bool isReconstructible() { return nFiredChambers > 2; }
+};
+
+struct MyFixture {
+  static HitFinder hitFinder;
+  static TrackGenerator trackGen;
+  static Tracker tracker;
+  static Mapping mapping;
+};
+
+HitFinder MyFixture::hitFinder;
+TrackGenerator MyFixture::trackGen;
+Tracker MyFixture::tracker;
+Mapping MyFixture::mapping;
+
+TrackClusters getTrackClusters(const Track& track)
+{
+  TrackClusters trCl;
+  trCl.track = track;
+  trCl.nFiredChambers = 0;
+  Mapping::MpStripIndex stripIndex;
+  MpArea area;
+  Cluster2D cl;
+  for (int ich = 0; ich < 4; ++ich) {
+    std::vector<std::pair<int, Point3D<float>>> pairs = MyFixture::hitFinder.getLocalPositions(track, ich);
+    bool isFired = false;
+    for (auto& pair : pairs) {
+      int deId = pair.first;
+      float xPos = pair.second.x();
+      float yPos = pair.second.y();
+      stripIndex = MyFixture::mapping.stripByPosition(xPos, yPos, 0, deId, false);
+      if (!stripIndex.isValid()) {
+        continue;
+      }
+      cl.deId = deId;
+      area = MyFixture::mapping.stripByLocation(stripIndex.strip, 0, stripIndex.line, stripIndex.column, deId);
+      cl.yCoor = area.getCenterY();
+      float halfSize = area.getHalfSizeY();
+      cl.sigmaY2 = halfSize * halfSize / 3.;
+      stripIndex = MyFixture::mapping.stripByPosition(xPos, yPos, 1, deId, false);
+      area = MyFixture::mapping.stripByLocation(stripIndex.strip, 1, stripIndex.line, stripIndex.column, deId);
+      cl.xCoor = area.getCenterX();
+      halfSize = area.getHalfSizeX();
+      cl.sigmaX2 = halfSize * halfSize / 3.;
+      trCl.clusters.push_back(cl);
+      isFired = true;
+    } // loop on fired pos
+    if (isFired) {
+      ++(trCl.nFiredChambers);
+    }
+  }
+  return trCl;
+}
+
+std::vector<TrackClusters> getTrackClusters(int nTracks)
+{
+  std::vector<TrackClusters> trackClusters;
+  std::vector<Track> tracks = MyFixture::trackGen.generate(nTracks);
+  for (auto& track : tracks) {
+    trackClusters.push_back(getTrackClusters(track));
+  }
+  return trackClusters;
+}
+
+BOOST_DATA_TEST_CASE_F(MyFixture, TestMultipleTracks, boost::unit_test::data::xrange(1, 9), nTracksPerEvent)
+{
+  // fair::Logger::SetConsoleSeverity(fair::Severity::debug);
+  float chi2Cut = tracker.getSigmaCut() * tracker.getSigmaCut();
+  int nTotFakes = 0, nTotReconstructible = 0;
+  for (int ievt = 0; ievt < 1000; ++ievt) {
+    std::vector<TrackClusters> trackClusters = getTrackClusters(nTracksPerEvent);
+    std::vector<Cluster2D> clusters;
+
+    // Fill string for debugging
+    std::stringstream ss;
+    ss << "\n";
+    int itr = -1;
+    for (auto& trCl : trackClusters) {
+      ++itr;
+      ss << "Track " << itr << ": " << trCl.track << "\n";
+      for (auto& cl : trCl.clusters) {
+        clusters.push_back(cl);
+        ss << "  deId " << (int)cl.deId << " pos: (" << cl.xCoor << ", " << cl.yCoor << ")";
+      }
+      ss << "\n";
+    }
+
+    // Run tracker algorithm
+    tracker.process(clusters);
+
+    // Further strings for debugging
+    ss << "  Reconstructed tracks:\n";
+    for (int ireco = 0; ireco < tracker.getNTracks(); ++ireco) {
+      ss << "  " << tracker.getTracks()[ireco] << "\n";
+    }
+
+    // Check that all reconstructible tracks are reconstructed
+    int nReconstructible = 0;
+    itr = -1;
+    for (auto& trCl : trackClusters) {
+      ++itr;
+      bool isReco = false;
+      for (int ireco = 0; ireco < tracker.getNTracks(); ++ireco) {
+        if (tracker.getTracks()[ireco].isCompatible(trCl.track, chi2Cut)) {
+          isReco = true;
+          break;
+        }
+      }
+      bool isReconstructible = trCl.isReconstructible();
+      // If the number of tracks is small, we can check that:
+      // 1) all reconstructible tracks are reconstructed
+      // 2) all non-reconstructible tracks are not
+      // Case 2), however, is not always valid when we have many tracks,
+      // since we can combine clusters from different tracks to build fakes
+      bool testTrack = (isReconstructible || nTracksPerEvent < 4);
+      if (testTrack) {
+        BOOST_TEST(isReco == isReconstructible, ss.str() << "  track " << itr << " reco " << isReco
+                                                         << " != reconstructible " << isReconstructible);
+      }
+      if (isReconstructible) {
+        ++nReconstructible;
+      }
+    } // loop on input tracks
+    nTotReconstructible += nReconstructible;
+    int nFakes = tracker.getNTracks() - nReconstructible;
+    if (nFakes > 0) {
+      ++nTotFakes;
+    }
+  } // loop on events
+  // To show the following message, run the test with: --log_level=message
+  BOOST_TEST_MESSAGE("Fraction of fake tracks: " << (double)nTotFakes / (double)nTotReconstructible);
+}
+
+} // namespace mid
+} // namespace o2

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -1583,8 +1583,10 @@ o2_define_bucket(
 
     DEPENDENCIES
     Boost::serialization
+    common_math_bucket
 
     INCLUDE_DIRECTORIES
+    ${CMAKE_SOURCE_DIR}/Common/MathUtils/include
     ${CMAKE_SOURCE_DIR}/DataFormats/Detectors/MUON/MID/include
 )
 
@@ -1593,11 +1595,8 @@ o2_define_bucket(
     mid_base_bucket
 
     DEPENDENCIES
-    common_math_bucket
     data_format_mid_bucket
-
-    INCLUDE_DIRECTORIES
-    ${CMAKE_SOURCE_DIR}/Common/MathUtils/include
+    DataFormatsMID
 )
 
 o2_define_bucket(

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -1629,3 +1629,31 @@ o2_define_bucket(
     DEPENDENCIES
     MIDBase
 )
+
+o2_define_bucket(
+    NAME
+    mid_tracking_bucket
+
+    DEPENDENCIES
+    fairroot_base_bucket
+    MIDBase
+
+    INCLUDE_DIRECTORIES
+    ${CMAKE_SOURCE_DIR}/Detectors/MUON/MID/TestingSimTools/include
+)
+
+o2_define_bucket(
+    NAME
+    mid_tracking_test_bucket
+
+    DEPENDENCIES
+    Boost::unit_test_framework
+    $<IF:$<BOOL:${benchmark_FOUND}>,benchmark::benchmark,$<0:"">>
+    mid_tracking_bucket
+    mid_testingSimTools_bucket
+    MIDTracking
+    MIDTestingSimTools
+
+    INCLUDE_DIRECTORIES
+    ${CMAKE_SOURCE_DIR}/Detectors/MUON/MID/Tracking/src
+)

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -1621,3 +1621,11 @@ o2_define_bucket(
     INCLUDE_DIRECTORIES
     ${CMAKE_SOURCE_DIR}/Detectors/MUON/MID/Clustering/src
 )
+
+o2_define_bucket(
+    NAME
+    mid_testingSimTools_bucket
+
+    DEPENDENCIES
+    MIDBase
+)


### PR DESCRIPTION
This pull-request consists of 4 closely related commits:
- the first commit defines a track for MID
- the second and third define some tools which allow for testing the tracking. In particular they add:
  * a class to find the impact point of the (generated) track on a chamber
  * a fast track generator
- the last commit is the tracking device itself with the corresponding tests.

Although they are closely related, it would be good if they can be merged without squashing since they are "atomic" commits.