### PR TITLE
Skip non-trackable particles when reading AliRoot kinematics

### DIFF
--- a/Generators/include/Generators/GeneratorFromFile.h
+++ b/Generators/include/Generators/GeneratorFromFile.h
@@ -44,10 +44,12 @@ class GeneratorFromFile : public FairGenerator
   // Set from which event to start
   void SetStartEvent(int start);
 
+  void SetSkipNonTrackable(bool b) { mSkipNonTrackable = b; }
  private:
   TFile* mEventFile = nullptr; //! the file containing the persistent events
   int mEventCounter = 0;
   int mEventsAvailable = 0;
+  bool mSkipNonTrackable = true; //! whether to pass non-trackable (decayed particles) to the MC stack
 
   ClassDefOverride(GeneratorFromFile, 1);
 };

--- a/Generators/src/GeneratorFromFile.cxx
+++ b/Generators/src/GeneratorFromFile.cxx
@@ -78,12 +78,16 @@ Bool_t GeneratorFromFile::ReadEvent(FairPrimaryGenerator* primGen)
       auto vy = primary->Vy();
       auto vz = primary->Vz();
 
-      auto parent = -1;
-      bool wanttracking = true;
-      auto e = primary->Energy();
-      auto tof = primary->T();
-      auto weight = primary->GetWeight();
-      primGen->AddTrack(pdgid, px, py, pz, vx, vy, vz, parent, wanttracking, e, tof, weight);
+      // a status of 1 means "trackable" in AliRoot kinematics
+      auto status = primary->GetStatusCode();
+      bool wanttracking = status == 1;
+      if (wanttracking || !mSkipNonTrackable) {
+        auto parent = -1;
+        auto e = primary->Energy();
+        auto tof = primary->T();
+        auto weight = primary->GetWeight();
+        primGen->AddTrack(pdgid, px, py, pz, vx, vy, vz, parent, wanttracking, e, tof, weight);
+      }
     }
     mEventCounter++;
     return kTRUE;


### PR DESCRIPTION
Generalize GeneratorFromFile to skip non-trackable particles (do
not pass them to the primary generator) when reading from an
external kinematics file.

Later on -- when the MC stack has been improved to deal with non-trackable
primaries -- we can make this a real configuration option.