### PR TITLE
Fix ambiguity in getter

### DIFF
--- a/DataFormats/Headers/include/Headers/TimeStamp.h
+++ b/DataFormats/Headers/include/Headers/TimeStamp.h
@@ -124,25 +124,24 @@ class TimeStamp
 
   operator uint64_t() const {return mTimeStamp64;}
 
-  template<class Clock>
-  typename Clock::duration get() const {
-    using duration = typename Clock::duration;
+  template<typename Duration>
+  Duration get() const {
     if (mUnit == sClockLHC) {
       // cast each part individually, if the precision of the return type
       // is smaller the values are simply truncated
-      return std::chrono::duration_cast<duration>(LHCOrbitClock::duration(mPeriod) + LHCBunchClock::duration(mBCNumber));
+      return std::chrono::duration_cast<Duration>(LHCOrbitClock::duration(mPeriod) + LHCBunchClock::duration(mBCNumber));
     }
     if (mUnit == sMicroSeconds) {
       // TODO: is there a better way to mark the subticks invalid for the
       // micro seconds representation? First step is probably to remove/rename the
       // variable
       assert(mSubTicks == 0);
-      return std::chrono::duration_cast<duration>(std::chrono::microseconds(mTicks));
+      return std::chrono::duration_cast<Duration>(std::chrono::microseconds(mTicks));
     }
     // invalid time unit identifier
     // TODO: define error policy
     assert(0);
-    return std::chrono::duration_cast<duration>(std::chrono::seconds(0));
+    return std::chrono::duration_cast<Duration>(std::chrono::seconds(0));
   }
 
   // TODO: implement transformation from one unit to the other

--- a/DataFormats/Headers/test/testTimeStamp.cxx
+++ b/DataFormats/Headers/test/testTimeStamp.cxx
@@ -58,8 +58,8 @@ namespace o2 {
       BOOST_CHECK(ts64 == timestamp);
 
       // checking cast to LHCClock
-      auto timeInLHCOrbitClock = timestamp.get<LHCOrbitClock>();
-      auto timeInLHCBunchClock = timestamp.get<LHCBunchClock>();
+      auto timeInLHCOrbitClock = timestamp.get<LHCOrbitClock::duration>();
+      auto timeInLHCBunchClock = timestamp.get<LHCBunchClock::duration>();
       BOOST_CHECK(timeInLHCOrbitClock.count() == orbits);
       BOOST_CHECK(timeInLHCOrbitClock == LHCOrbitClock::duration(orbits));
 
@@ -68,7 +68,7 @@ namespace o2 {
 
       // get explicitely the time ignoring bunch counter and cast to seconds
       // that must be less then 1h
-      auto timeInSeconds = std::chrono::duration_cast<std::chrono::seconds>(timestamp.get<LHCOrbitClock>());
+      auto timeInSeconds = std::chrono::duration_cast<std::chrono::seconds>(timestamp.get<LHCOrbitClock::duration>());
       BOOST_CHECK(timeInSeconds < std::chrono::hours(1));
 
       // directly retrieving time in hours takes both orbits and bunches for
@@ -81,8 +81,8 @@ namespace o2 {
       timestamp = String2<uint16_t>("US") | tenSeconds << 32;
 
       // check conversion of the us value to LHCClock
-      auto timeInOrbitPrecision = timestamp.get<LHCOrbitClock>();
-      auto timeInBunchPrecision = timestamp.get<LHCBunchClock>();
+      auto timeInOrbitPrecision = timestamp.get<LHCOrbitClock::duration>();
+      auto timeInBunchPrecision = timestamp.get<LHCBunchClock::duration>();
       uint64_t expectedOrbits = tenSeconds * 1000 / (LHCClockParameter::gNumberOfBunches * LHCClockParameter::gBunchSpacingNanoSec);
       BOOST_CHECK(timeInOrbitPrecision.count() == expectedOrbits);
 


### PR DESCRIPTION
Because we are missing Concepts, the current template argument will
match both "system_clock" and "system_clock::duration". This aligns the
template type to the return type, avoiding the ambiguity and making the
code compile on the new clang.