### PR TITLE
Reworked output API

### DIFF
--- a/Framework/Core/include/Framework/DataProcessingDevice.h
+++ b/Framework/Core/include/Framework/DataProcessingDevice.h
@@ -45,7 +45,6 @@ private:
   ServiceRegistry mServiceRegistry;
   MessageContext mContext;
   RootObjectContext mRootContext;
-  DataAllocator mAllocator;
   DataRelayer mRelayer;
 
   std::vector<InputChannelSpec> mInputChannels;

--- a/Framework/Core/include/Framework/DataSourceDevice.h
+++ b/Framework/Core/include/Framework/DataSourceDevice.h
@@ -43,7 +43,6 @@ private:
   ServiceRegistry mServiceRegistry;
   MessageContext mContext;
   RootObjectContext mRootContext;
-  DataAllocator mAllocator;
   size_t mCurrentTimeslice;
   float mRate;
   size_t mLastTime;

--- a/Framework/Core/include/Framework/ProcessingContext.h
+++ b/Framework/Core/include/Framework/ProcessingContext.h
@@ -30,7 +30,7 @@ public:
 
   InputRecord & inputs() {return mInputs;}
   ServiceRegistry & services() {return mServices;}
-  DataAllocator & allocator(){return mAllocator;}
+  DataAllocator & outputs(){return mAllocator;}
 
   InputRecord &mInputs;
   ServiceRegistry &mServices;

--- a/Framework/Core/include/Framework/RootTreeReader.h
+++ b/Framework/Core/include/Framework/RootTreeReader.h
@@ -155,7 +155,7 @@ class RootTreeReader
   {
     if (!snapshot) {
       snapshot = [&context](const KeyType& key, const ROOTSerializedByClass& object) {
-        context.allocator().snapshot(key, object);
+        context.outputs().snapshot(key, object);
       };
     }
 

--- a/Framework/Core/src/DataAllocator.cxx
+++ b/Framework/Core/src/DataAllocator.cxx
@@ -21,17 +21,6 @@ using DataHeader = o2::header::DataHeader;
 using DataDescription = o2::header::DataDescription;
 using DataProcessingHeader = o2::framework::DataProcessingHeader;
 
-DataAllocator::DataAllocator(FairMQDevice *device,
-                             MessageContext *context,
-                             RootObjectContext *rootContext,
-                             const AllowedOutputsMap &outputs)
-: mDevice{device},
-  mAllowedOutputs{outputs},
-  mContext{context},
-  mRootContext{rootContext}
-{
-}
-
 std::string
 DataAllocator::matchDataHeader(const OutputSpec &spec, size_t timeslice) {
   // FIXME: we should take timeframeId into account as well.

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -38,7 +38,6 @@ DataProcessingDevice::DataProcessingDevice(const DeviceSpec &spec,
   mStatelessProcess{spec.algorithm.onProcess},
   mError{spec.algorithm.onError},
   mConfigRegistry{nullptr},
-  mAllocator{this, &mContext, &mRootContext, spec.outputs},
   mRelayer{spec.inputs, spec.forwards, registry.get<MetricsService>()},
   mInputChannels{spec.inputChannels},
   mOutputChannels{spec.outputChannels},
@@ -48,6 +47,7 @@ DataProcessingDevice::DataProcessingDevice(const DeviceSpec &spec,
   mErrorCount{0},
   mProcessingCount{0}
 {
+  DataAllocator::getInstance().configure(this, &mContext, &mRootContext, spec.outputs);
 }
 
 /// This  takes care  of initialising  the device  from its  specification. In
@@ -92,7 +92,7 @@ DataProcessingDevice::HandleData(FairMQParts &iParts, int /*index*/) {
   auto &statelessProcess = mStatelessProcess;
   auto &errorCallback = mError;
   auto &serviceRegistry = mServiceRegistry;
-  auto &allocator = mAllocator;
+  auto &allocator = DataAllocator::getInstance();
   auto &processingCount = mProcessingCount;
   auto &relayer = mRelayer;
   auto &device = *this;

--- a/Framework/Core/src/DataSourceDevice.cxx
+++ b/Framework/Core/src/DataSourceDevice.cxx
@@ -29,12 +29,12 @@ DataSourceDevice::DataSourceDevice(const DeviceSpec &spec, ServiceRegistry &regi
   mStatelessProcess{spec.algorithm.onProcess},
   mError{spec.algorithm.onError},
   mConfigRegistry{nullptr},
-  mAllocator{this,&mContext, &mRootContext, spec.outputs},
   mServiceRegistry{registry},
   mCurrentTimeslice{0},
   mRate{0.},
   mLastTime{0}
 {
+  DataAllocator::getInstance().configure(this,&mContext, &mRootContext, spec.outputs);
 }
 
 void DataSourceDevice::Init() {
@@ -79,7 +79,7 @@ bool DataSourceDevice::ConditionalRun() {
       sleep(1);
     }
 
-    ProcessingContext processingContext{dummyInputs, mServiceRegistry, mAllocator};
+    ProcessingContext processingContext{dummyInputs, mServiceRegistry, DataAllocator::getInstance()};
     if (mStatelessProcess) {
       LOG(DEBUG) << "Has stateless process callback";
       mStatelessProcess(processingContext);

--- a/Framework/Core/src/DispatcherDPL.cxx
+++ b/Framework/Core/src/DispatcherDPL.cxx
@@ -48,10 +48,10 @@ void DispatcherDPL::processCallback(ProcessingContext& ctx, BernoulliGenerator& 
                    << "', description '" << inputHeader->dataDescription.str
                    << "' has gSerializationMethodInvalid.";
       } else*/ if (inputHeader->payloadSerializationMethod == header::gSerializationMethodROOT) {
-        ctx.allocator().adopt(outputSpec, DataRefUtils::as<TObject>(input).release());
+        ctx.outputs().adopt(outputSpec, DataRefUtils::as<TObject>(input).release());
       } else { // POD
         // todo: use API for that when it is available
-        ctx.allocator().adoptChunk(outputSpec, const_cast<char*>(input.payload), inputHeader->size(),
+        ctx.outputs().adoptChunk(outputSpec, const_cast<char*>(input.payload), inputHeader->size(),
                                    &header::Stack::freefn, nullptr);
       }
 

--- a/Framework/Core/test/test_DataAllocator.cxx
+++ b/Framework/Core/test/test_DataAllocator.cxx
@@ -46,7 +46,7 @@ DataProcessorSpec getTimeoutSpec()
   // a timer process to terminate the workflow after a timeout
   auto processingFct = [](ProcessingContext& pc) {
     static int counter = 0;
-    pc.allocator().snapshot(OutputSpec{ "TST", "TIMER", 0, OutputSpec::Timeframe }, counter);
+    pc.outputs().snapshot(OutputSpec{ "TST", "TIMER", 0, OutputSpec::Timeframe }, counter);
 
     sleep(1);
     if (counter++ > 10) {
@@ -70,22 +70,22 @@ DataProcessorSpec getSourceSpec()
     std::vector<o2::test::Polymorphic> c{ { 0xaffe }, { 0xd00f } };
     // class TriviallyCopyable is both messageable and has a dictionary, the default
     // picked by the framework is no serialization
-    pc.allocator().snapshot(OutputSpec{ "TST", "MESSAGEABLE", 0, OutputSpec::Timeframe }, a);
-    pc.allocator().snapshot(OutputSpec{ "TST", "MSGBLEROOTSRLZ", 0, OutputSpec::Timeframe },
+    pc.outputs().snapshot(OutputSpec{ "TST", "MESSAGEABLE", 0, OutputSpec::Timeframe }, a);
+    pc.outputs().snapshot(OutputSpec{ "TST", "MSGBLEROOTSRLZ", 0, OutputSpec::Timeframe },
                             o2::framework::ROOTSerialized<decltype(a)>(a));
     // class Polymorphic is not messageable, so the serialization type is deduced
     // from the fact that the type has a dictionary and can be ROOT-serialized.
-    pc.allocator().snapshot(OutputSpec{ "TST", "ROOTNONTOBJECT", 0, OutputSpec::Timeframe }, b);
+    pc.outputs().snapshot(OutputSpec{ "TST", "ROOTNONTOBJECT", 0, OutputSpec::Timeframe }, b);
     // vector of ROOT serializable class
-    pc.allocator().snapshot(OutputSpec{ "TST", "ROOTVECTOR", 0, OutputSpec::Timeframe }, c);
+    pc.outputs().snapshot(OutputSpec{ "TST", "ROOTVECTOR", 0, OutputSpec::Timeframe }, c);
     // likewise, passed anonymously with char type and class name
     o2::framework::ROOTSerialized<char, const char> d(*((char*)&c), "vector<o2::test::Polymorphic>");
-    pc.allocator().snapshot(OutputSpec{ "TST", "ROOTSERLZDVEC", 0, OutputSpec::Timeframe }, d);
+    pc.outputs().snapshot(OutputSpec{ "TST", "ROOTSERLZDVEC", 0, OutputSpec::Timeframe }, d);
     // vector of ROOT serializable class wrapped with TClass info as hint
     auto* cl = TClass::GetClass(typeid(decltype(c)));
     ASSERT_ERROR(cl != nullptr);
     o2::framework::ROOTSerialized<char, TClass> e(*((char*)&c), cl);
-    pc.allocator().snapshot(OutputSpec{ "TST", "ROOTSERLZDVEC2", 0, OutputSpec::Timeframe }, e);
+    pc.outputs().snapshot(OutputSpec{ "TST", "ROOTSERLZDVEC2", 0, OutputSpec::Timeframe }, e);
   };
 
   return DataProcessorSpec{ "source", // name of the processor

--- a/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
+++ b/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
@@ -27,7 +27,7 @@ using namespace o2::framework;
 AlgorithmSpec simplePipe(o2::header::DataDescription what)
 {
   return AlgorithmSpec{ [what](ProcessingContext& ctx) {
-    auto bData = ctx.allocator().make<int>(OutputSpec{ "TST", what, 0 }, 1);
+    auto bData = ctx.outputs().make<int>(OutputSpec{ "TST", what, 0 }, 1);
   } };
 }
 
@@ -39,8 +39,8 @@ WorkflowSpec defineDataProcessing()
                       OutputSpec{ "TST", "A2", OutputSpec::Timeframe } },
              AlgorithmSpec{ [](ProcessingContext& ctx) {
                sleep(1);
-               auto aData = ctx.allocator().make<int>(OutputSpec{ "TST", "A1", 0 }, 1);
-               auto bData = ctx.allocator().make<int>(OutputSpec{ "TST", "A2", 0 }, 1);
+               auto aData = ctx.outputs().make<int>(OutputSpec{ "TST", "A1", 0 }, 1);
+               auto bData = ctx.outputs().make<int>(OutputSpec{ "TST", "A2", 0 }, 1);
              } } },
            { "B",
              { InputSpec{ "x", "TST", "A1", InputSpec::Timeframe } },

--- a/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
+++ b/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
@@ -27,7 +27,7 @@ using namespace o2::framework;
 AlgorithmSpec simplePipe(o2::header::DataDescription what)
 {
   return AlgorithmSpec{ [what](ProcessingContext& ctx) {
-    auto bData = ctx.outputs().make<int>(OutputSpec{ "TST", what, 0 }, 1);
+    auto bData = o2::framework::make<int>(OutputSpec{ "TST", what, 0 }, 1);
   } };
 }
 
@@ -39,8 +39,8 @@ WorkflowSpec defineDataProcessing()
                       OutputSpec{ "TST", "A2", OutputSpec::Timeframe } },
              AlgorithmSpec{ [](ProcessingContext& ctx) {
                sleep(1);
-               auto aData = ctx.outputs().make<int>(OutputSpec{ "TST", "A1", 0 }, 1);
-               auto bData = ctx.outputs().make<int>(OutputSpec{ "TST", "A2", 0 }, 1);
+               auto aData = o2::framework::make<int>(OutputSpec{ "TST", "A1", 0 }, 1);
+               auto bData = o2::framework::make<int>(OutputSpec{ "TST", "A2", 0 }, 1);
              } } },
            { "B",
              { InputSpec{ "x", "TST", "A1", InputSpec::Timeframe } },

--- a/Framework/Core/test/test_Parallel.cxx
+++ b/Framework/Core/test/test_Parallel.cxx
@@ -121,7 +121,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
           LOG(DEBUG) << "DataSampler sends data from subSpec: " << inputSpec->subSpec;
 
           const auto* inputHeader = o2::header::get<o2::header::DataHeader*>(input.header);
-          auto output = ctx.outputs().make<char>(outputSpec, inputHeader->size());
+          auto output = make<char>(outputSpec, inputHeader->size());
 
           //todo: use some std function or adopt(), when it is available for POD data
           const char* input_ptr = input.payload;
@@ -193,7 +193,7 @@ void someDataProducerAlgorithm(ProcessingContext& ctx)
   sleep(1);
   // Creates a new message of size collectionChunkSize which
   // has "TPC" as data origin and "CLUSTERS" as data description.
-  auto tpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS", index }, collectionChunkSize);
+  auto tpcClusters = make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS", index }, collectionChunkSize);
   int i = 0;
 
   for (auto& cluster : tpcClusters) {
@@ -213,8 +213,7 @@ void someProcessingStageAlgorithm(ProcessingContext& ctx)
 
   const FakeCluster* inputDataTpc = reinterpret_cast<const FakeCluster*>(ctx.inputs().get("dataTPC").payload);
 
-  auto processedTpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", index },
-                                                                collectionChunkSize);
+  auto processedTpcClusters = make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", index }, collectionChunkSize);
 
   int i = 0;
   for (auto& cluster : processedTpcClusters) {

--- a/Framework/Core/test/test_Parallel.cxx
+++ b/Framework/Core/test/test_Parallel.cxx
@@ -121,7 +121,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
           LOG(DEBUG) << "DataSampler sends data from subSpec: " << inputSpec->subSpec;
 
           const auto* inputHeader = o2::header::get<o2::header::DataHeader*>(input.header);
-          auto output = ctx.allocator().make<char>(outputSpec, inputHeader->size());
+          auto output = ctx.outputs().make<char>(outputSpec, inputHeader->size());
 
           //todo: use some std function or adopt(), when it is available for POD data
           const char* input_ptr = input.payload;
@@ -193,7 +193,7 @@ void someDataProducerAlgorithm(ProcessingContext& ctx)
   sleep(1);
   // Creates a new message of size collectionChunkSize which
   // has "TPC" as data origin and "CLUSTERS" as data description.
-  auto tpcClusters = ctx.allocator().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS", index }, collectionChunkSize);
+  auto tpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS", index }, collectionChunkSize);
   int i = 0;
 
   for (auto& cluster : tpcClusters) {
@@ -213,7 +213,7 @@ void someProcessingStageAlgorithm(ProcessingContext& ctx)
 
   const FakeCluster* inputDataTpc = reinterpret_cast<const FakeCluster*>(ctx.inputs().get("dataTPC").payload);
 
-  auto processedTpcClusters = ctx.allocator().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", index },
+  auto processedTpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", index },
                                                                 collectionChunkSize);
 
   int i = 0;

--- a/Framework/Core/test/test_ParallelProducer.cxx
+++ b/Framework/Core/test/test_ParallelProducer.cxx
@@ -32,7 +32,7 @@ DataProcessorSpec templateProducer() {
           // Create a single output. 
           size_t index = ctx.services().get<ParallelContext>().index1D();
           sleep(1);
-          auto aData = ctx.outputs().make<int>(OutputSpec{"TST", "A", index}, 1);
+          auto aData = o2::framework::make<int>(OutputSpec{"TST", "A", index}, 1);
           ctx.services().get<ControlService>().readyToQuit(true);
         };
       }

--- a/Framework/Core/test/test_ParallelProducer.cxx
+++ b/Framework/Core/test/test_ParallelProducer.cxx
@@ -32,7 +32,7 @@ DataProcessorSpec templateProducer() {
           // Create a single output. 
           size_t index = ctx.services().get<ParallelContext>().index1D();
           sleep(1);
-          auto aData = ctx.allocator().make<int>(OutputSpec{"TST", "A", index}, 1);
+          auto aData = ctx.outputs().make<int>(OutputSpec{"TST", "A", index}, 1);
           ctx.services().get<ControlService>().readyToQuit(true);
         };
       }

--- a/Framework/Core/test/test_SimpleDataProcessingDevice01.cxx
+++ b/Framework/Core/test/test_SimpleDataProcessingDevice01.cxx
@@ -44,7 +44,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
         sleep(1);
         // Creates a new message of size 1000 which
         // has "TPC" as data origin and "CLUSTERS" as data description.
-        auto tpcClusters = ctx.allocator().make<FakeCluster>(OutputSpec{"TPC", "CLUSTERS", 0}, 1000);
+        auto tpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{"TPC", "CLUSTERS", 0}, 1000);
         int i = 0;
 
         for (auto &cluster : tpcClusters) {
@@ -56,7 +56,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
           i++;
         }
 
-        auto itsClusters = ctx.allocator().make<FakeCluster>(OutputSpec{"ITS", "CLUSTERS", 0}, 1000);
+        auto itsClusters = ctx.outputs().make<FakeCluster>(OutputSpec{"ITS", "CLUSTERS", 0}, 1000);
         i = 0;
         for (auto &cluster : itsClusters) {
           assert(i < 1000);

--- a/Framework/Core/test/test_SimpleDataProcessingDevice01.cxx
+++ b/Framework/Core/test/test_SimpleDataProcessingDevice01.cxx
@@ -44,7 +44,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
         sleep(1);
         // Creates a new message of size 1000 which
         // has "TPC" as data origin and "CLUSTERS" as data description.
-        auto tpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{"TPC", "CLUSTERS", 0}, 1000);
+        auto tpcClusters = o2::framework::make<FakeCluster>(OutputSpec{"TPC", "CLUSTERS", 0}, 1000);
         int i = 0;
 
         for (auto &cluster : tpcClusters) {
@@ -56,7 +56,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
           i++;
         }
 
-        auto itsClusters = ctx.outputs().make<FakeCluster>(OutputSpec{"ITS", "CLUSTERS", 0}, 1000);
+        auto itsClusters = o2::framework::make<FakeCluster>(OutputSpec{"ITS", "CLUSTERS", 0}, 1000);
         i = 0;
         for (auto &cluster : itsClusters) {
           assert(i < 1000);

--- a/Framework/Core/test/test_SimpleStatefulProcessing01.cxx
+++ b/Framework/Core/test/test_SimpleStatefulProcessing01.cxx
@@ -38,7 +38,7 @@ void defineDataProcessing(WorkflowSpec &specs) {
         static int foo = 0;
         return [](ProcessingContext &ctx) {
             sleep(1);
-            auto out = ctx.allocator().newChunk({"TES", "STATEFUL", 0}, sizeof(int));
+            auto out = ctx.outputs().newChunk({"TES", "STATEFUL", 0}, sizeof(int));
             auto outI = reinterpret_cast<int *>(out.data);
             outI[0] = foo++;
           };

--- a/Framework/Core/test/test_SingleDataSource.cxx
+++ b/Framework/Core/test/test_SingleDataSource.cxx
@@ -25,7 +25,7 @@ void defineDataProcessing(WorkflowSpec &specs) {
     AlgorithmSpec{
       [](ProcessingContext &ctx) {
        sleep(1);
-       auto aData = ctx.outputs().make<int>(OutputSpec{"TST", "A1", 0}, 1);
+       auto aData = o2::framework::make<int>(OutputSpec{"TST", "A1", 0}, 1);
        ctx.services().get<ControlService>().readyToQuit(true);
       }
     },

--- a/Framework/Core/test/test_SingleDataSource.cxx
+++ b/Framework/Core/test/test_SingleDataSource.cxx
@@ -25,7 +25,7 @@ void defineDataProcessing(WorkflowSpec &specs) {
     AlgorithmSpec{
       [](ProcessingContext &ctx) {
        sleep(1);
-       auto aData = ctx.allocator().make<int>(OutputSpec{"TST", "A1", 0}, 1);
+       auto aData = ctx.outputs().make<int>(OutputSpec{"TST", "A1", 0}, 1);
        ctx.services().get<ControlService>().readyToQuit(true);
       }
     },

--- a/Framework/Core/test/test_TimePipeline.cxx
+++ b/Framework/Core/test/test_TimePipeline.cxx
@@ -86,7 +86,7 @@ void someDataProducerAlgorithm(ProcessingContext& ctx)
   sleep(1);
   // Creates a new message of size collectionChunkSize which
   // has "TPC" as data origin and "CLUSTERS" as data description.
-  auto tpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS", index }, collectionChunkSize);
+  auto tpcClusters = o2::framework::make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS", index }, collectionChunkSize);
   int i = 0;
 
   for (auto& cluster : tpcClusters) {
@@ -106,7 +106,7 @@ void someProcessingStageAlgorithm(ProcessingContext& ctx)
 
   const FakeCluster* inputDataTpc = reinterpret_cast<const FakeCluster*>(ctx.inputs().get("dataTPC").payload);
 
-  auto processedTpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", index },
+  auto processedTpcClusters = o2::framework::make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", index },
                                                                 collectionChunkSize);
 
   int i = 0;

--- a/Framework/Core/test/test_TimePipeline.cxx
+++ b/Framework/Core/test/test_TimePipeline.cxx
@@ -86,7 +86,7 @@ void someDataProducerAlgorithm(ProcessingContext& ctx)
   sleep(1);
   // Creates a new message of size collectionChunkSize which
   // has "TPC" as data origin and "CLUSTERS" as data description.
-  auto tpcClusters = ctx.allocator().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS", index }, collectionChunkSize);
+  auto tpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS", index }, collectionChunkSize);
   int i = 0;
 
   for (auto& cluster : tpcClusters) {
@@ -106,7 +106,7 @@ void someProcessingStageAlgorithm(ProcessingContext& ctx)
 
   const FakeCluster* inputDataTpc = reinterpret_cast<const FakeCluster*>(ctx.inputs().get("dataTPC").payload);
 
-  auto processedTpcClusters = ctx.allocator().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", index },
+  auto processedTpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", index },
                                                                 collectionChunkSize);
 
   int i = 0;

--- a/Framework/TestWorkflows/src/dataSamplingParallel.cxx
+++ b/Framework/TestWorkflows/src/dataSamplingParallel.cxx
@@ -142,7 +142,7 @@ void someDataProducerAlgorithm(ProcessingContext& ctx)
   sleep(1);
   // Creates a new message of size collectionChunkSize which
   // has "TPC" as data origin and "CLUSTERS" as data description.
-  auto tpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS", index }, collectionChunkSize);
+  auto tpcClusters = o2::framework::make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS", index }, collectionChunkSize);
   int i = 0;
 
   for (auto& cluster : tpcClusters) {
@@ -161,7 +161,7 @@ void someProcessingStageAlgorithm(ProcessingContext& ctx)
   size_t index = ctx.services().get<ParallelContext>().index1D();
 
   const FakeCluster* inputDataTpc = reinterpret_cast<const FakeCluster*>(ctx.inputs().get("dataTPC").payload);
-  auto processedTpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", index },
+  auto processedTpcClusters = o2::framework::make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", index },
                                                                 collectionChunkSize);
 
   int i = 0;

--- a/Framework/TestWorkflows/src/dataSamplingParallel.cxx
+++ b/Framework/TestWorkflows/src/dataSamplingParallel.cxx
@@ -142,7 +142,7 @@ void someDataProducerAlgorithm(ProcessingContext& ctx)
   sleep(1);
   // Creates a new message of size collectionChunkSize which
   // has "TPC" as data origin and "CLUSTERS" as data description.
-  auto tpcClusters = ctx.allocator().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS", index }, collectionChunkSize);
+  auto tpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS", index }, collectionChunkSize);
   int i = 0;
 
   for (auto& cluster : tpcClusters) {
@@ -161,7 +161,7 @@ void someProcessingStageAlgorithm(ProcessingContext& ctx)
   size_t index = ctx.services().get<ParallelContext>().index1D();
 
   const FakeCluster* inputDataTpc = reinterpret_cast<const FakeCluster*>(ctx.inputs().get("dataTPC").payload);
-  auto processedTpcClusters = ctx.allocator().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", index },
+  auto processedTpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", index },
                                                                 collectionChunkSize);
 
   int i = 0;

--- a/Framework/TestWorkflows/src/dataSamplingPodAndRoot.cxx
+++ b/Framework/TestWorkflows/src/dataSamplingPodAndRoot.cxx
@@ -122,9 +122,9 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
       [](ProcessingContext& ctx) {
         sleep(1);
         // Create an histogram
-        auto& singleHisto = ctx.outputs().make<TH1F>(OutputSpec{ "TST", "HISTOS", 0 },
+        auto& singleHisto = o2::framework::make<TH1F>(OutputSpec{ "TST", "HISTOS", 0 },
                                                        "h1", "test", 100, -10., 10.);
-        auto& aString = ctx.outputs().make<TObjString>(OutputSpec{ "TST", "STRING", 0 }, "foo");
+        auto& aString = o2::framework::make<TObjString>(OutputSpec{ "TST", "STRING", 0 }, "foo");
         singleHisto.FillRandom("gaus", 1000);
         Double_t stats[4];
         singleHisto.GetStats(stats);
@@ -209,7 +209,7 @@ void someDataProducerAlgorithm(ProcessingContext& ctx)
   sleep(1);
   // Creates a new message of size collectionChunkSize which
   // has "TPC" as data origin and "CLUSTERS" as data description.
-  auto tpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS", 0 }, collectionChunkSize);
+  auto tpcClusters = o2::framework::make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS", 0 }, collectionChunkSize);
   int i = 0;
 
   for (auto& cluster : tpcClusters) {
@@ -221,7 +221,7 @@ void someDataProducerAlgorithm(ProcessingContext& ctx)
     i++;
   }
 
-  auto itsClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "ITS", "CLUSTERS", 0 }, collectionChunkSize);
+  auto itsClusters = o2::framework::make<FakeCluster>(OutputSpec{ "ITS", "CLUSTERS", 0 }, collectionChunkSize);
   i = 0;
   for (auto& cluster : itsClusters) {
     assert(i < collectionChunkSize);
@@ -239,9 +239,9 @@ void someProcessingStageAlgorithm(ProcessingContext& ctx)
   const FakeCluster* inputDataTpc = reinterpret_cast<const FakeCluster*>(ctx.inputs().get("dataTPC").payload);
   const FakeCluster* inputDataIts = reinterpret_cast<const FakeCluster*>(ctx.inputs().get("dataITS").payload);
 
-  auto processedTpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", 0 },
+  auto processedTpcClusters = o2::framework::make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", 0 },
                                                                 collectionChunkSize);
-  auto processedItsClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "ITS", "CLUSTERS_P", 0 },
+  auto processedItsClusters = o2::framework::make<FakeCluster>(OutputSpec{ "ITS", "CLUSTERS_P", 0 },
                                                                 collectionChunkSize);
 
   int i = 0;

--- a/Framework/TestWorkflows/src/dataSamplingPodAndRoot.cxx
+++ b/Framework/TestWorkflows/src/dataSamplingPodAndRoot.cxx
@@ -122,9 +122,9 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
       [](ProcessingContext& ctx) {
         sleep(1);
         // Create an histogram
-        auto& singleHisto = ctx.allocator().make<TH1F>(OutputSpec{ "TST", "HISTOS", 0 },
+        auto& singleHisto = ctx.outputs().make<TH1F>(OutputSpec{ "TST", "HISTOS", 0 },
                                                        "h1", "test", 100, -10., 10.);
-        auto& aString = ctx.allocator().make<TObjString>(OutputSpec{ "TST", "STRING", 0 }, "foo");
+        auto& aString = ctx.outputs().make<TObjString>(OutputSpec{ "TST", "STRING", 0 }, "foo");
         singleHisto.FillRandom("gaus", 1000);
         Double_t stats[4];
         singleHisto.GetStats(stats);
@@ -209,7 +209,7 @@ void someDataProducerAlgorithm(ProcessingContext& ctx)
   sleep(1);
   // Creates a new message of size collectionChunkSize which
   // has "TPC" as data origin and "CLUSTERS" as data description.
-  auto tpcClusters = ctx.allocator().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS", 0 }, collectionChunkSize);
+  auto tpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS", 0 }, collectionChunkSize);
   int i = 0;
 
   for (auto& cluster : tpcClusters) {
@@ -221,7 +221,7 @@ void someDataProducerAlgorithm(ProcessingContext& ctx)
     i++;
   }
 
-  auto itsClusters = ctx.allocator().make<FakeCluster>(OutputSpec{ "ITS", "CLUSTERS", 0 }, collectionChunkSize);
+  auto itsClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "ITS", "CLUSTERS", 0 }, collectionChunkSize);
   i = 0;
   for (auto& cluster : itsClusters) {
     assert(i < collectionChunkSize);
@@ -239,9 +239,9 @@ void someProcessingStageAlgorithm(ProcessingContext& ctx)
   const FakeCluster* inputDataTpc = reinterpret_cast<const FakeCluster*>(ctx.inputs().get("dataTPC").payload);
   const FakeCluster* inputDataIts = reinterpret_cast<const FakeCluster*>(ctx.inputs().get("dataITS").payload);
 
-  auto processedTpcClusters = ctx.allocator().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", 0 },
+  auto processedTpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", 0 },
                                                                 collectionChunkSize);
-  auto processedItsClusters = ctx.allocator().make<FakeCluster>(OutputSpec{ "ITS", "CLUSTERS_P", 0 },
+  auto processedItsClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "ITS", "CLUSTERS_P", 0 },
                                                                 collectionChunkSize);
 
   int i = 0;

--- a/Framework/TestWorkflows/src/dataSamplingTimePipeline.cxx
+++ b/Framework/TestWorkflows/src/dataSamplingTimePipeline.cxx
@@ -124,7 +124,7 @@ void someDataProducerAlgorithm(ProcessingContext& ctx)
   sleep(1);
   // Creates a new message of size collectionChunkSize which
   // has "TPC" as data origin and "CLUSTERS" as data description.
-  auto tpcClusters = ctx.allocator().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS", index }, collectionChunkSize);
+  auto tpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS", index }, collectionChunkSize);
   int i = 0;
 
   for (auto& cluster : tpcClusters) {
@@ -144,7 +144,7 @@ void someProcessingStageAlgorithm(ProcessingContext& ctx)
 
   const FakeCluster* inputDataTpc = reinterpret_cast<const FakeCluster*>(ctx.inputs().get("dataTPC").payload);
 
-  auto processedTpcClusters = ctx.allocator().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", index },
+  auto processedTpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", index },
                                                                 collectionChunkSize);
 
   int i = 0;

--- a/Framework/TestWorkflows/src/dataSamplingTimePipeline.cxx
+++ b/Framework/TestWorkflows/src/dataSamplingTimePipeline.cxx
@@ -124,7 +124,7 @@ void someDataProducerAlgorithm(ProcessingContext& ctx)
   sleep(1);
   // Creates a new message of size collectionChunkSize which
   // has "TPC" as data origin and "CLUSTERS" as data description.
-  auto tpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS", index }, collectionChunkSize);
+  auto tpcClusters = o2::framework::make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS", index }, collectionChunkSize);
   int i = 0;
 
   for (auto& cluster : tpcClusters) {
@@ -144,7 +144,7 @@ void someProcessingStageAlgorithm(ProcessingContext& ctx)
 
   const FakeCluster* inputDataTpc = reinterpret_cast<const FakeCluster*>(ctx.inputs().get("dataTPC").payload);
 
-  auto processedTpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", index },
+  auto processedTpcClusters = o2::framework::make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", index },
                                                                 collectionChunkSize);
 
   int i = 0;

--- a/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
@@ -15,7 +15,7 @@ AlgorithmSpec simplePipe(o2::header::DataDescription what) {
   return AlgorithmSpec{
     [what](ProcessingContext &ctx)
       {
-        auto bData = ctx.outputs().make<int>(OutputSpec{"TST", what, 0}, 1);
+        auto bData = o2::framework::make<int>(OutputSpec{"TST", what, 0}, 1);
       }
     };
 }
@@ -33,8 +33,8 @@ void defineDataProcessing(WorkflowSpec &specs) {
     AlgorithmSpec{
       [](ProcessingContext &ctx) {
        sleep(1);
-       auto aData = ctx.outputs().make<int>(OutputSpec{"TST", "A1", 0}, 1);
-       auto bData = ctx.outputs().make<int>(OutputSpec{"TST", "A2", 0}, 1);
+       auto aData = o2::framework::make<int>(OutputSpec{"TST", "A1", 0}, 1);
+       auto bData = o2::framework::make<int>(OutputSpec{"TST", "A2", 0}, 1);
       }
     }
   },

--- a/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
@@ -15,7 +15,7 @@ AlgorithmSpec simplePipe(o2::header::DataDescription what) {
   return AlgorithmSpec{
     [what](ProcessingContext &ctx)
       {
-        auto bData = ctx.allocator().make<int>(OutputSpec{"TST", what, 0}, 1);
+        auto bData = ctx.outputs().make<int>(OutputSpec{"TST", what, 0}, 1);
       }
     };
 }
@@ -33,8 +33,8 @@ void defineDataProcessing(WorkflowSpec &specs) {
     AlgorithmSpec{
       [](ProcessingContext &ctx) {
        sleep(1);
-       auto aData = ctx.allocator().make<int>(OutputSpec{"TST", "A1", 0}, 1);
-       auto bData = ctx.allocator().make<int>(OutputSpec{"TST", "A2", 0}, 1);
+       auto aData = ctx.outputs().make<int>(OutputSpec{"TST", "A1", 0}, 1);
+       auto bData = ctx.outputs().make<int>(OutputSpec{"TST", "A2", 0}, 1);
       }
     }
   },

--- a/Framework/TestWorkflows/src/o2DummyWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DummyWorkflow.cxx
@@ -43,7 +43,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
        sleep(1);
        // Creates a new message of size 1000 which
        // has "TPC" as data origin and "CLUSTERS" as data description.
-       auto tpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{"TPC", "CLUSTERS", 0}, 1000);
+       auto tpcClusters = o2::framework::make<FakeCluster>(OutputSpec{"TPC", "CLUSTERS", 0}, 1000);
        int i = 0;
 
        for (auto &cluster : tpcClusters) {
@@ -55,7 +55,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
          i++;
        }
 
-       auto itsClusters = ctx.outputs().make<FakeCluster>(OutputSpec{"ITS", "CLUSTERS", 0}, 1000);
+       auto itsClusters = o2::framework::make<FakeCluster>(OutputSpec{"ITS", "CLUSTERS", 0}, 1000);
        i = 0;
        for (auto &cluster : itsClusters) {
          assert(i < 1000);
@@ -81,7 +81,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
     AlgorithmSpec{
     [](ProcessingContext &ctx)
       {
-        auto tpcSummary = ctx.outputs().make<Summary>(OutputSpec{"TPC", "SUMMARY", 0}, 1);
+        auto tpcSummary = o2::framework::make<Summary>(OutputSpec{"TPC", "SUMMARY", 0}, 1);
         tpcSummary.at(0).inputCount = ctx.inputs().size();
       }
     },
@@ -103,7 +103,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
     },
     AlgorithmSpec{
       [](ProcessingContext &ctx) {
-        auto itsSummary = ctx.outputs().make<Summary>(OutputSpec{"ITS", "SUMMARY", 0}, 1);
+        auto itsSummary = o2::framework::make<Summary>(OutputSpec{"ITS", "SUMMARY", 0}, 1);
         itsSummary.at(0).inputCount = ctx.inputs().size();
       }
     },

--- a/Framework/TestWorkflows/src/o2DummyWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DummyWorkflow.cxx
@@ -43,7 +43,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
        sleep(1);
        // Creates a new message of size 1000 which
        // has "TPC" as data origin and "CLUSTERS" as data description.
-       auto tpcClusters = ctx.allocator().make<FakeCluster>(OutputSpec{"TPC", "CLUSTERS", 0}, 1000);
+       auto tpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{"TPC", "CLUSTERS", 0}, 1000);
        int i = 0;
 
        for (auto &cluster : tpcClusters) {
@@ -55,7 +55,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
          i++;
        }
 
-       auto itsClusters = ctx.allocator().make<FakeCluster>(OutputSpec{"ITS", "CLUSTERS", 0}, 1000);
+       auto itsClusters = ctx.outputs().make<FakeCluster>(OutputSpec{"ITS", "CLUSTERS", 0}, 1000);
        i = 0;
        for (auto &cluster : itsClusters) {
          assert(i < 1000);
@@ -81,7 +81,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
     AlgorithmSpec{
     [](ProcessingContext &ctx)
       {
-        auto tpcSummary = ctx.allocator().make<Summary>(OutputSpec{"TPC", "SUMMARY", 0}, 1);
+        auto tpcSummary = ctx.outputs().make<Summary>(OutputSpec{"TPC", "SUMMARY", 0}, 1);
         tpcSummary.at(0).inputCount = ctx.inputs().size();
       }
     },
@@ -103,7 +103,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
     },
     AlgorithmSpec{
       [](ProcessingContext &ctx) {
-        auto itsSummary = ctx.allocator().make<Summary>(OutputSpec{"ITS", "SUMMARY", 0}, 1);
+        auto itsSummary = ctx.outputs().make<Summary>(OutputSpec{"ITS", "SUMMARY", 0}, 1);
         itsSummary.at(0).inputCount = ctx.inputs().size();
       }
     },

--- a/Framework/TestWorkflows/src/o2ParallelWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2ParallelWorkflow.cxx
@@ -34,7 +34,7 @@ DataProcessorSpec templateProcessor() {
           // Create a single output. 
           size_t index = ctx.services().get<ParallelContext>().index1D();
           sleep(1);
-          auto aData = ctx.allocator().make<int>(OutputSpec{"TST", "P", index}, 1);
+          auto aData = ctx.outputs().make<int>(OutputSpec{"TST", "P", index}, 1);
         };
       }
     }

--- a/Framework/TestWorkflows/src/o2ParallelWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2ParallelWorkflow.cxx
@@ -34,7 +34,7 @@ DataProcessorSpec templateProcessor() {
           // Create a single output. 
           size_t index = ctx.services().get<ParallelContext>().index1D();
           sleep(1);
-          auto aData = ctx.outputs().make<int>(OutputSpec{"TST", "P", index}, 1);
+          auto aData = make<int>(OutputSpec{"TST", "P", index}, 1);
         };
       }
     }

--- a/Framework/TestWorkflows/src/test_o2RootMessageWorkflow.cxx
+++ b/Framework/TestWorkflows/src/test_o2RootMessageWorkflow.cxx
@@ -39,9 +39,9 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
         [](ProcessingContext &ctx) {
           sleep(1);
           // Create an histogram 
-          auto &singleHisto = ctx.outputs().make<TH1F>(OutputSpec{"TST", "HISTOS", 0},
+          auto &singleHisto = make<TH1F>(OutputSpec{"TST", "HISTOS", 0},
                                                          "h1", "test", 100, -10., 10.);
-          auto &aString = ctx.outputs().make<TObjString>(OutputSpec{"TST", "STRING", 0}, "foo");
+          auto &aString = make<TObjString>(OutputSpec{"TST", "STRING", 0}, "foo");
           singleHisto.FillRandom("gaus", 1000);
           Double_t stats[4];
           singleHisto.GetStats(stats);

--- a/Framework/TestWorkflows/src/test_o2RootMessageWorkflow.cxx
+++ b/Framework/TestWorkflows/src/test_o2RootMessageWorkflow.cxx
@@ -39,9 +39,9 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
         [](ProcessingContext &ctx) {
           sleep(1);
           // Create an histogram 
-          auto &singleHisto = ctx.allocator().make<TH1F>(OutputSpec{"TST", "HISTOS", 0},
+          auto &singleHisto = ctx.outputs().make<TH1F>(OutputSpec{"TST", "HISTOS", 0},
                                                          "h1", "test", 100, -10., 10.);
-          auto &aString = ctx.allocator().make<TObjString>(OutputSpec{"TST", "STRING", 0}, "foo");
+          auto &aString = ctx.outputs().make<TObjString>(OutputSpec{"TST", "STRING", 0}, "foo");
           singleHisto.FillRandom("gaus", 1000);
           Double_t stats[4];
           singleHisto.GetStats(stats);

--- a/Framework/TestWorkflows/test/test_MakeDPLObjects.cxx
+++ b/Framework/TestWorkflows/test/test_MakeDPLObjects.cxx
@@ -38,14 +38,14 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
       AlgorithmSpec{
         [](ProcessingContext &ctx) {
           // A new message with 1 XYZ instance in it
-          XYZ &x = ctx.outputs().make<XYZ>(OutputSpec{"TST", "POINT", 0});
+          XYZ &x = make<XYZ>(OutputSpec{"TST", "POINT", 0});
           // A new message with a gsl::span<XYZ> with 1000 items
-          gsl::span<XYZ> y = ctx.outputs().make<XYZ>(OutputSpec{"TST", "POINTS", 0}, 1000);
+          gsl::span<XYZ> y = make<XYZ>(OutputSpec{"TST", "POINTS", 0}, 1000);
           y[0] = XYZ{1,2,3};
           y[999] = XYZ{1,2,3};
           // A new message with a TH1F inside
-          auto h = ctx.outputs().make<TH1F>(OutputSpec{"TST", "HISTO"},
-                                             "h", "test", 100, -10., 10.);
+          auto h = make<TH1F>(OutputSpec{"TST", "HISTO"},
+                                         "h", "test", 100, -10., 10.);
           // A snapshot for an std::vector
           std::vector<XYZ> v{1000};
           v[0] = XYZ{1,2,3};

--- a/Framework/TestWorkflows/test/test_MakeDPLObjects.cxx
+++ b/Framework/TestWorkflows/test/test_MakeDPLObjects.cxx
@@ -38,19 +38,19 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
       AlgorithmSpec{
         [](ProcessingContext &ctx) {
           // A new message with 1 XYZ instance in it
-          XYZ &x = ctx.allocator().make<XYZ>(OutputSpec{"TST", "POINT", 0});
+          XYZ &x = ctx.outputs().make<XYZ>(OutputSpec{"TST", "POINT", 0});
           // A new message with a gsl::span<XYZ> with 1000 items
-          gsl::span<XYZ> y = ctx.allocator().make<XYZ>(OutputSpec{"TST", "POINTS", 0}, 1000);
+          gsl::span<XYZ> y = ctx.outputs().make<XYZ>(OutputSpec{"TST", "POINTS", 0}, 1000);
           y[0] = XYZ{1,2,3};
           y[999] = XYZ{1,2,3};
           // A new message with a TH1F inside
-          auto h = ctx.allocator().make<TH1F>(OutputSpec{"TST", "HISTO"},
+          auto h = ctx.outputs().make<TH1F>(OutputSpec{"TST", "HISTO"},
                                              "h", "test", 100, -10., 10.);
           // A snapshot for an std::vector
           std::vector<XYZ> v{1000};
           v[0] = XYZ{1,2,3};
           v[999] = XYZ{1,2,3};
-          ctx.allocator().snapshot(OutputSpec{"TST", "VECTOR"}, v);
+          ctx.outputs().snapshot(OutputSpec{"TST", "VECTOR"}, v);
           v[999] = XYZ{2,3,4};
 
           // A snapshot for an std::vector of pointers to objects
@@ -58,11 +58,11 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
           // change, but not the one which is done after taking the snapshot
           std::vector<XYZ*> p;
           for (auto & i : v) p.push_back(&i);
-          ctx.allocator().snapshot(OutputSpec{"TST", "LINEARIZED"}, p);
+          ctx.outputs().snapshot(OutputSpec{"TST", "LINEARIZED"}, p);
           v[999] = XYZ{3,4,5};
 
           TNamed named("named", "a named test object");
-          ctx.allocator().snapshot(OutputSpec{"TST", "OBJECT"}, named);
+          ctx.outputs().snapshot(OutputSpec{"TST", "OBJECT"}, named);
         }
       }
     },

--- a/Utilities/QC/Workflow/src/RootObjectProducerSpec.cxx
+++ b/Utilities/QC/Workflow/src/RootObjectProducerSpec.cxx
@@ -136,7 +136,7 @@ DataProcessorSpec getRootObjectProducerSpec() {
         // the shared pointer makes sure to clean up the instance when the processing
         // function gets out of scope
         auto processingFct = [producer] (ProcessingContext &pc) {
-          pc.allocator().adopt(OutputSpec{"QC", "ROOTOBJECT", 0, OutputSpec::QA},
+          pc.outputs().adopt(OutputSpec{"QC", "ROOTOBJECT", 0, OutputSpec::QA},
                                producer->produceData());
         };
 


### PR DESCRIPTION
Up for discussion. If people agree, I will complete the work by adding `o2::framework::snapshot` and `o2::framework::adopt`.

As discussed in various meetings the current API for creating outputs
is a bit convoluted with the allocator hanging from the context. E.g.

    context.allocator().make<T>(OutputSpec{});

the proposal is to rework things so that people can use a free function:

    o2::framework::make<T>(OutputSpec{});

similarly to what happens when you create objects on the heap via
`make_unique`, `make_shared`. The guarantees remaing the same.

This approach has the advantage of better readability, but the
disadvantage that it requires a singleton for the allocator. Given that
the current implementation of FairMQ is not thread safe when creating
messages in any case, I guess we do not care. If FairMQ starts supporting multithreaded
HandleData and Send, I guess what we should do is to make the allocator
thread aware e.g. by using a thread id inside the singleton and hide complexity from the user,
rather than explicitly exposing the safety mechanism like we do now (i.e. via different allocators
for different contextes).

While doing so I also rename `ProcessingContext::allocator()` to `ProcessingContext::outputs()` as suggested, although I was thinking this would really not be required anymore if people are not exposed to it (we could even use `getAllocator()` at that point).