### PR TITLE
Rename `ProcessingContext::allocator()` to `outputs()`

### DIFF
--- a/Framework/Core/include/Framework/ProcessingContext.h
+++ b/Framework/Core/include/Framework/ProcessingContext.h
@@ -30,7 +30,7 @@ public:
 
   InputRecord & inputs() {return mInputs;}
   ServiceRegistry & services() {return mServices;}
-  DataAllocator & outputs(){return mAllocator;}
+  DataAllocator& outputs() { return mAllocator; }
 
   InputRecord &mInputs;
   ServiceRegistry &mServices;

--- a/Framework/Core/include/Framework/ProcessingContext.h
+++ b/Framework/Core/include/Framework/ProcessingContext.h
@@ -30,7 +30,7 @@ public:
 
   InputRecord & inputs() {return mInputs;}
   ServiceRegistry & services() {return mServices;}
-  DataAllocator & allocator(){return mAllocator;}
+  DataAllocator & outputs(){return mAllocator;}
 
   InputRecord &mInputs;
   ServiceRegistry &mServices;

--- a/Framework/Core/include/Framework/RootTreeReader.h
+++ b/Framework/Core/include/Framework/RootTreeReader.h
@@ -155,7 +155,7 @@ class RootTreeReader
   {
     if (!snapshot) {
       snapshot = [&context](const KeyType& key, const ROOTSerializedByClass& object) {
-        context.allocator().snapshot(key, object);
+        context.outputs().snapshot(key, object);
       };
     }
 

--- a/Framework/Core/src/DispatcherDPL.cxx
+++ b/Framework/Core/src/DispatcherDPL.cxx
@@ -52,7 +52,7 @@ void DispatcherDPL::processCallback(ProcessingContext& ctx, BernoulliGenerator& 
       } else { // POD
         // todo: use API for that when it is available
         ctx.outputs().adoptChunk(outputSpec, const_cast<char*>(input.payload), inputHeader->size(),
-                                   &header::Stack::freefn, nullptr);
+                                 &header::Stack::freefn, nullptr);
       }
 
       LOG(DEBUG) << "DataSampler sends data from subspec " << input.spec->subSpec;

--- a/Framework/Core/src/DispatcherDPL.cxx
+++ b/Framework/Core/src/DispatcherDPL.cxx
@@ -48,10 +48,10 @@ void DispatcherDPL::processCallback(ProcessingContext& ctx, BernoulliGenerator& 
                    << "', description '" << inputHeader->dataDescription.str
                    << "' has gSerializationMethodInvalid.";
       } else*/ if (inputHeader->payloadSerializationMethod == header::gSerializationMethodROOT) {
-        ctx.allocator().adopt(outputSpec, DataRefUtils::as<TObject>(input).release());
+        ctx.outputs().adopt(outputSpec, DataRefUtils::as<TObject>(input).release());
       } else { // POD
         // todo: use API for that when it is available
-        ctx.allocator().adoptChunk(outputSpec, const_cast<char*>(input.payload), inputHeader->size(),
+        ctx.outputs().adoptChunk(outputSpec, const_cast<char*>(input.payload), inputHeader->size(),
                                    &header::Stack::freefn, nullptr);
       }
 

--- a/Framework/Core/test/test_DataAllocator.cxx
+++ b/Framework/Core/test/test_DataAllocator.cxx
@@ -46,7 +46,7 @@ DataProcessorSpec getTimeoutSpec()
   // a timer process to terminate the workflow after a timeout
   auto processingFct = [](ProcessingContext& pc) {
     static int counter = 0;
-    pc.allocator().snapshot(OutputSpec{ "TST", "TIMER", 0, OutputSpec::Timeframe }, counter);
+    pc.outputs().snapshot(OutputSpec{ "TST", "TIMER", 0, OutputSpec::Timeframe }, counter);
 
     sleep(1);
     if (counter++ > 10) {
@@ -70,22 +70,22 @@ DataProcessorSpec getSourceSpec()
     std::vector<o2::test::Polymorphic> c{ { 0xaffe }, { 0xd00f } };
     // class TriviallyCopyable is both messageable and has a dictionary, the default
     // picked by the framework is no serialization
-    pc.allocator().snapshot(OutputSpec{ "TST", "MESSAGEABLE", 0, OutputSpec::Timeframe }, a);
-    pc.allocator().snapshot(OutputSpec{ "TST", "MSGBLEROOTSRLZ", 0, OutputSpec::Timeframe },
+    pc.outputs().snapshot(OutputSpec{ "TST", "MESSAGEABLE", 0, OutputSpec::Timeframe }, a);
+    pc.outputs().snapshot(OutputSpec{ "TST", "MSGBLEROOTSRLZ", 0, OutputSpec::Timeframe },
                             o2::framework::ROOTSerialized<decltype(a)>(a));
     // class Polymorphic is not messageable, so the serialization type is deduced
     // from the fact that the type has a dictionary and can be ROOT-serialized.
-    pc.allocator().snapshot(OutputSpec{ "TST", "ROOTNONTOBJECT", 0, OutputSpec::Timeframe }, b);
+    pc.outputs().snapshot(OutputSpec{ "TST", "ROOTNONTOBJECT", 0, OutputSpec::Timeframe }, b);
     // vector of ROOT serializable class
-    pc.allocator().snapshot(OutputSpec{ "TST", "ROOTVECTOR", 0, OutputSpec::Timeframe }, c);
+    pc.outputs().snapshot(OutputSpec{ "TST", "ROOTVECTOR", 0, OutputSpec::Timeframe }, c);
     // likewise, passed anonymously with char type and class name
     o2::framework::ROOTSerialized<char, const char> d(*((char*)&c), "vector<o2::test::Polymorphic>");
-    pc.allocator().snapshot(OutputSpec{ "TST", "ROOTSERLZDVEC", 0, OutputSpec::Timeframe }, d);
+    pc.outputs().snapshot(OutputSpec{ "TST", "ROOTSERLZDVEC", 0, OutputSpec::Timeframe }, d);
     // vector of ROOT serializable class wrapped with TClass info as hint
     auto* cl = TClass::GetClass(typeid(decltype(c)));
     ASSERT_ERROR(cl != nullptr);
     o2::framework::ROOTSerialized<char, TClass> e(*((char*)&c), cl);
-    pc.allocator().snapshot(OutputSpec{ "TST", "ROOTSERLZDVEC2", 0, OutputSpec::Timeframe }, e);
+    pc.outputs().snapshot(OutputSpec{ "TST", "ROOTSERLZDVEC2", 0, OutputSpec::Timeframe }, e);
   };
 
   return DataProcessorSpec{ "source", // name of the processor

--- a/Framework/Core/test/test_DataAllocator.cxx
+++ b/Framework/Core/test/test_DataAllocator.cxx
@@ -72,7 +72,7 @@ DataProcessorSpec getSourceSpec()
     // picked by the framework is no serialization
     pc.outputs().snapshot(OutputSpec{ "TST", "MESSAGEABLE", 0, OutputSpec::Timeframe }, a);
     pc.outputs().snapshot(OutputSpec{ "TST", "MSGBLEROOTSRLZ", 0, OutputSpec::Timeframe },
-                            o2::framework::ROOTSerialized<decltype(a)>(a));
+                          o2::framework::ROOTSerialized<decltype(a)>(a));
     // class Polymorphic is not messageable, so the serialization type is deduced
     // from the fact that the type has a dictionary and can be ROOT-serialized.
     pc.outputs().snapshot(OutputSpec{ "TST", "ROOTNONTOBJECT", 0, OutputSpec::Timeframe }, b);

--- a/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
+++ b/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
@@ -27,7 +27,7 @@ using namespace o2::framework;
 AlgorithmSpec simplePipe(o2::header::DataDescription what)
 {
   return AlgorithmSpec{ [what](ProcessingContext& ctx) {
-    auto bData = ctx.allocator().make<int>(OutputSpec{ "TST", what, 0 }, 1);
+    auto bData = ctx.outputs().make<int>(OutputSpec{ "TST", what, 0 }, 1);
   } };
 }
 
@@ -39,8 +39,8 @@ WorkflowSpec defineDataProcessing()
                       OutputSpec{ "TST", "A2", OutputSpec::Timeframe } },
              AlgorithmSpec{ [](ProcessingContext& ctx) {
                sleep(1);
-               auto aData = ctx.allocator().make<int>(OutputSpec{ "TST", "A1", 0 }, 1);
-               auto bData = ctx.allocator().make<int>(OutputSpec{ "TST", "A2", 0 }, 1);
+               auto aData = ctx.outputs().make<int>(OutputSpec{ "TST", "A1", 0 }, 1);
+               auto bData = ctx.outputs().make<int>(OutputSpec{ "TST", "A2", 0 }, 1);
              } } },
            { "B",
              { InputSpec{ "x", "TST", "A1", InputSpec::Timeframe } },

--- a/Framework/Core/test/test_Parallel.cxx
+++ b/Framework/Core/test/test_Parallel.cxx
@@ -213,8 +213,8 @@ void someProcessingStageAlgorithm(ProcessingContext& ctx)
 
   const FakeCluster* inputDataTpc = reinterpret_cast<const FakeCluster*>(ctx.inputs().get("dataTPC").payload);
 
-  auto processedTpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", index },
-                                                                collectionChunkSize);
+  auto processedTpcClusters =
+    ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", index }, collectionChunkSize);
 
   int i = 0;
   for (auto& cluster : processedTpcClusters) {

--- a/Framework/Core/test/test_Parallel.cxx
+++ b/Framework/Core/test/test_Parallel.cxx
@@ -121,7 +121,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
           LOG(DEBUG) << "DataSampler sends data from subSpec: " << inputSpec->subSpec;
 
           const auto* inputHeader = o2::header::get<o2::header::DataHeader*>(input.header);
-          auto output = ctx.allocator().make<char>(outputSpec, inputHeader->size());
+          auto output = ctx.outputs().make<char>(outputSpec, inputHeader->size());
 
           //todo: use some std function or adopt(), when it is available for POD data
           const char* input_ptr = input.payload;
@@ -193,7 +193,7 @@ void someDataProducerAlgorithm(ProcessingContext& ctx)
   sleep(1);
   // Creates a new message of size collectionChunkSize which
   // has "TPC" as data origin and "CLUSTERS" as data description.
-  auto tpcClusters = ctx.allocator().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS", index }, collectionChunkSize);
+  auto tpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS", index }, collectionChunkSize);
   int i = 0;
 
   for (auto& cluster : tpcClusters) {
@@ -213,7 +213,7 @@ void someProcessingStageAlgorithm(ProcessingContext& ctx)
 
   const FakeCluster* inputDataTpc = reinterpret_cast<const FakeCluster*>(ctx.inputs().get("dataTPC").payload);
 
-  auto processedTpcClusters = ctx.allocator().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", index },
+  auto processedTpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", index },
                                                                 collectionChunkSize);
 
   int i = 0;

--- a/Framework/Core/test/test_ParallelProducer.cxx
+++ b/Framework/Core/test/test_ParallelProducer.cxx
@@ -32,7 +32,7 @@ DataProcessorSpec templateProducer() {
           // Create a single output. 
           size_t index = ctx.services().get<ParallelContext>().index1D();
           sleep(1);
-          auto aData = ctx.allocator().make<int>(OutputSpec{"TST", "A", index}, 1);
+          auto aData = ctx.outputs().make<int>(OutputSpec{"TST", "A", index}, 1);
           ctx.services().get<ControlService>().readyToQuit(true);
         };
       }

--- a/Framework/Core/test/test_ParallelProducer.cxx
+++ b/Framework/Core/test/test_ParallelProducer.cxx
@@ -32,7 +32,7 @@ DataProcessorSpec templateProducer() {
           // Create a single output. 
           size_t index = ctx.services().get<ParallelContext>().index1D();
           sleep(1);
-          auto aData = ctx.outputs().make<int>(OutputSpec{"TST", "A", index}, 1);
+          auto aData = ctx.outputs().make<int>(OutputSpec{ "TST", "A", index }, 1);
           ctx.services().get<ControlService>().readyToQuit(true);
         };
       }

--- a/Framework/Core/test/test_SimpleDataProcessingDevice01.cxx
+++ b/Framework/Core/test/test_SimpleDataProcessingDevice01.cxx
@@ -44,7 +44,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
         sleep(1);
         // Creates a new message of size 1000 which
         // has "TPC" as data origin and "CLUSTERS" as data description.
-        auto tpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{"TPC", "CLUSTERS", 0}, 1000);
+        auto tpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS", 0 }, 1000);
         int i = 0;
 
         for (auto &cluster : tpcClusters) {
@@ -56,7 +56,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
           i++;
         }
 
-        auto itsClusters = ctx.outputs().make<FakeCluster>(OutputSpec{"ITS", "CLUSTERS", 0}, 1000);
+        auto itsClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "ITS", "CLUSTERS", 0 }, 1000);
         i = 0;
         for (auto &cluster : itsClusters) {
           assert(i < 1000);

--- a/Framework/Core/test/test_SimpleDataProcessingDevice01.cxx
+++ b/Framework/Core/test/test_SimpleDataProcessingDevice01.cxx
@@ -44,7 +44,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
         sleep(1);
         // Creates a new message of size 1000 which
         // has "TPC" as data origin and "CLUSTERS" as data description.
-        auto tpcClusters = ctx.allocator().make<FakeCluster>(OutputSpec{"TPC", "CLUSTERS", 0}, 1000);
+        auto tpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{"TPC", "CLUSTERS", 0}, 1000);
         int i = 0;
 
         for (auto &cluster : tpcClusters) {
@@ -56,7 +56,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
           i++;
         }
 
-        auto itsClusters = ctx.allocator().make<FakeCluster>(OutputSpec{"ITS", "CLUSTERS", 0}, 1000);
+        auto itsClusters = ctx.outputs().make<FakeCluster>(OutputSpec{"ITS", "CLUSTERS", 0}, 1000);
         i = 0;
         for (auto &cluster : itsClusters) {
           assert(i < 1000);

--- a/Framework/Core/test/test_SimpleStatefulProcessing01.cxx
+++ b/Framework/Core/test/test_SimpleStatefulProcessing01.cxx
@@ -38,7 +38,7 @@ void defineDataProcessing(WorkflowSpec &specs) {
         static int foo = 0;
         return [](ProcessingContext &ctx) {
             sleep(1);
-            auto out = ctx.outputs().newChunk({"TES", "STATEFUL", 0}, sizeof(int));
+            auto out = ctx.outputs().newChunk({ "TES", "STATEFUL", 0 }, sizeof(int));
             auto outI = reinterpret_cast<int *>(out.data);
             outI[0] = foo++;
           };

--- a/Framework/Core/test/test_SimpleStatefulProcessing01.cxx
+++ b/Framework/Core/test/test_SimpleStatefulProcessing01.cxx
@@ -38,7 +38,7 @@ void defineDataProcessing(WorkflowSpec &specs) {
         static int foo = 0;
         return [](ProcessingContext &ctx) {
             sleep(1);
-            auto out = ctx.allocator().newChunk({"TES", "STATEFUL", 0}, sizeof(int));
+            auto out = ctx.outputs().newChunk({"TES", "STATEFUL", 0}, sizeof(int));
             auto outI = reinterpret_cast<int *>(out.data);
             outI[0] = foo++;
           };

--- a/Framework/Core/test/test_SingleDataSource.cxx
+++ b/Framework/Core/test/test_SingleDataSource.cxx
@@ -25,7 +25,7 @@ void defineDataProcessing(WorkflowSpec &specs) {
     AlgorithmSpec{
       [](ProcessingContext &ctx) {
        sleep(1);
-       auto aData = ctx.allocator().make<int>(OutputSpec{"TST", "A1", 0}, 1);
+       auto aData = ctx.outputs().make<int>(OutputSpec{"TST", "A1", 0}, 1);
        ctx.services().get<ControlService>().readyToQuit(true);
       }
     },

--- a/Framework/Core/test/test_SingleDataSource.cxx
+++ b/Framework/Core/test/test_SingleDataSource.cxx
@@ -25,7 +25,7 @@ void defineDataProcessing(WorkflowSpec &specs) {
     AlgorithmSpec{
       [](ProcessingContext &ctx) {
        sleep(1);
-       auto aData = ctx.outputs().make<int>(OutputSpec{"TST", "A1", 0}, 1);
+       auto aData = ctx.outputs().make<int>(OutputSpec{ "TST", "A1", 0 }, 1);
        ctx.services().get<ControlService>().readyToQuit(true);
       }
     },

--- a/Framework/Core/test/test_TimePipeline.cxx
+++ b/Framework/Core/test/test_TimePipeline.cxx
@@ -106,8 +106,8 @@ void someProcessingStageAlgorithm(ProcessingContext& ctx)
 
   const FakeCluster* inputDataTpc = reinterpret_cast<const FakeCluster*>(ctx.inputs().get("dataTPC").payload);
 
-  auto processedTpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", index },
-                                                                collectionChunkSize);
+  auto processedTpcClusters =
+    ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", index }, collectionChunkSize);
 
   int i = 0;
   for (auto& cluster : processedTpcClusters) {

--- a/Framework/Core/test/test_TimePipeline.cxx
+++ b/Framework/Core/test/test_TimePipeline.cxx
@@ -86,7 +86,7 @@ void someDataProducerAlgorithm(ProcessingContext& ctx)
   sleep(1);
   // Creates a new message of size collectionChunkSize which
   // has "TPC" as data origin and "CLUSTERS" as data description.
-  auto tpcClusters = ctx.allocator().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS", index }, collectionChunkSize);
+  auto tpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS", index }, collectionChunkSize);
   int i = 0;
 
   for (auto& cluster : tpcClusters) {
@@ -106,7 +106,7 @@ void someProcessingStageAlgorithm(ProcessingContext& ctx)
 
   const FakeCluster* inputDataTpc = reinterpret_cast<const FakeCluster*>(ctx.inputs().get("dataTPC").payload);
 
-  auto processedTpcClusters = ctx.allocator().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", index },
+  auto processedTpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", index },
                                                                 collectionChunkSize);
 
   int i = 0;

--- a/Framework/TestWorkflows/src/dataSamplingParallel.cxx
+++ b/Framework/TestWorkflows/src/dataSamplingParallel.cxx
@@ -161,8 +161,8 @@ void someProcessingStageAlgorithm(ProcessingContext& ctx)
   size_t index = ctx.services().get<ParallelContext>().index1D();
 
   const FakeCluster* inputDataTpc = reinterpret_cast<const FakeCluster*>(ctx.inputs().get("dataTPC").payload);
-  auto processedTpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", index },
-                                                                collectionChunkSize);
+  auto processedTpcClusters =
+    ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", index }, collectionChunkSize);
 
   int i = 0;
   for (auto& cluster : processedTpcClusters) {

--- a/Framework/TestWorkflows/src/dataSamplingParallel.cxx
+++ b/Framework/TestWorkflows/src/dataSamplingParallel.cxx
@@ -142,7 +142,7 @@ void someDataProducerAlgorithm(ProcessingContext& ctx)
   sleep(1);
   // Creates a new message of size collectionChunkSize which
   // has "TPC" as data origin and "CLUSTERS" as data description.
-  auto tpcClusters = ctx.allocator().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS", index }, collectionChunkSize);
+  auto tpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS", index }, collectionChunkSize);
   int i = 0;
 
   for (auto& cluster : tpcClusters) {
@@ -161,7 +161,7 @@ void someProcessingStageAlgorithm(ProcessingContext& ctx)
   size_t index = ctx.services().get<ParallelContext>().index1D();
 
   const FakeCluster* inputDataTpc = reinterpret_cast<const FakeCluster*>(ctx.inputs().get("dataTPC").payload);
-  auto processedTpcClusters = ctx.allocator().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", index },
+  auto processedTpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", index },
                                                                 collectionChunkSize);
 
   int i = 0;

--- a/Framework/TestWorkflows/src/dataSamplingPodAndRoot.cxx
+++ b/Framework/TestWorkflows/src/dataSamplingPodAndRoot.cxx
@@ -122,8 +122,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
       [](ProcessingContext& ctx) {
         sleep(1);
         // Create an histogram
-        auto& singleHisto = ctx.outputs().make<TH1F>(OutputSpec{ "TST", "HISTOS", 0 },
-                                                       "h1", "test", 100, -10., 10.);
+        auto& singleHisto = ctx.outputs().make<TH1F>(OutputSpec{ "TST", "HISTOS", 0 }, "h1", "test", 100, -10., 10.);
         auto& aString = ctx.outputs().make<TObjString>(OutputSpec{ "TST", "STRING", 0 }, "foo");
         singleHisto.FillRandom("gaus", 1000);
         Double_t stats[4];
@@ -239,10 +238,10 @@ void someProcessingStageAlgorithm(ProcessingContext& ctx)
   const FakeCluster* inputDataTpc = reinterpret_cast<const FakeCluster*>(ctx.inputs().get("dataTPC").payload);
   const FakeCluster* inputDataIts = reinterpret_cast<const FakeCluster*>(ctx.inputs().get("dataITS").payload);
 
-  auto processedTpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", 0 },
-                                                                collectionChunkSize);
-  auto processedItsClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "ITS", "CLUSTERS_P", 0 },
-                                                                collectionChunkSize);
+  auto processedTpcClusters =
+    ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", 0 }, collectionChunkSize);
+  auto processedItsClusters =
+    ctx.outputs().make<FakeCluster>(OutputSpec{ "ITS", "CLUSTERS_P", 0 }, collectionChunkSize);
 
   int i = 0;
   for (auto& cluster : processedTpcClusters) {

--- a/Framework/TestWorkflows/src/dataSamplingPodAndRoot.cxx
+++ b/Framework/TestWorkflows/src/dataSamplingPodAndRoot.cxx
@@ -122,9 +122,9 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
       [](ProcessingContext& ctx) {
         sleep(1);
         // Create an histogram
-        auto& singleHisto = ctx.allocator().make<TH1F>(OutputSpec{ "TST", "HISTOS", 0 },
+        auto& singleHisto = ctx.outputs().make<TH1F>(OutputSpec{ "TST", "HISTOS", 0 },
                                                        "h1", "test", 100, -10., 10.);
-        auto& aString = ctx.allocator().make<TObjString>(OutputSpec{ "TST", "STRING", 0 }, "foo");
+        auto& aString = ctx.outputs().make<TObjString>(OutputSpec{ "TST", "STRING", 0 }, "foo");
         singleHisto.FillRandom("gaus", 1000);
         Double_t stats[4];
         singleHisto.GetStats(stats);
@@ -209,7 +209,7 @@ void someDataProducerAlgorithm(ProcessingContext& ctx)
   sleep(1);
   // Creates a new message of size collectionChunkSize which
   // has "TPC" as data origin and "CLUSTERS" as data description.
-  auto tpcClusters = ctx.allocator().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS", 0 }, collectionChunkSize);
+  auto tpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS", 0 }, collectionChunkSize);
   int i = 0;
 
   for (auto& cluster : tpcClusters) {
@@ -221,7 +221,7 @@ void someDataProducerAlgorithm(ProcessingContext& ctx)
     i++;
   }
 
-  auto itsClusters = ctx.allocator().make<FakeCluster>(OutputSpec{ "ITS", "CLUSTERS", 0 }, collectionChunkSize);
+  auto itsClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "ITS", "CLUSTERS", 0 }, collectionChunkSize);
   i = 0;
   for (auto& cluster : itsClusters) {
     assert(i < collectionChunkSize);
@@ -239,9 +239,9 @@ void someProcessingStageAlgorithm(ProcessingContext& ctx)
   const FakeCluster* inputDataTpc = reinterpret_cast<const FakeCluster*>(ctx.inputs().get("dataTPC").payload);
   const FakeCluster* inputDataIts = reinterpret_cast<const FakeCluster*>(ctx.inputs().get("dataITS").payload);
 
-  auto processedTpcClusters = ctx.allocator().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", 0 },
+  auto processedTpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", 0 },
                                                                 collectionChunkSize);
-  auto processedItsClusters = ctx.allocator().make<FakeCluster>(OutputSpec{ "ITS", "CLUSTERS_P", 0 },
+  auto processedItsClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "ITS", "CLUSTERS_P", 0 },
                                                                 collectionChunkSize);
 
   int i = 0;

--- a/Framework/TestWorkflows/src/dataSamplingTimePipeline.cxx
+++ b/Framework/TestWorkflows/src/dataSamplingTimePipeline.cxx
@@ -144,8 +144,8 @@ void someProcessingStageAlgorithm(ProcessingContext& ctx)
 
   const FakeCluster* inputDataTpc = reinterpret_cast<const FakeCluster*>(ctx.inputs().get("dataTPC").payload);
 
-  auto processedTpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", index },
-                                                                collectionChunkSize);
+  auto processedTpcClusters =
+    ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", index }, collectionChunkSize);
 
   int i = 0;
   for (auto& cluster : processedTpcClusters) {

--- a/Framework/TestWorkflows/src/dataSamplingTimePipeline.cxx
+++ b/Framework/TestWorkflows/src/dataSamplingTimePipeline.cxx
@@ -124,7 +124,7 @@ void someDataProducerAlgorithm(ProcessingContext& ctx)
   sleep(1);
   // Creates a new message of size collectionChunkSize which
   // has "TPC" as data origin and "CLUSTERS" as data description.
-  auto tpcClusters = ctx.allocator().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS", index }, collectionChunkSize);
+  auto tpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS", index }, collectionChunkSize);
   int i = 0;
 
   for (auto& cluster : tpcClusters) {
@@ -144,7 +144,7 @@ void someProcessingStageAlgorithm(ProcessingContext& ctx)
 
   const FakeCluster* inputDataTpc = reinterpret_cast<const FakeCluster*>(ctx.inputs().get("dataTPC").payload);
 
-  auto processedTpcClusters = ctx.allocator().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", index },
+  auto processedTpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS_P", index },
                                                                 collectionChunkSize);
 
   int i = 0;

--- a/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
@@ -15,7 +15,7 @@ AlgorithmSpec simplePipe(o2::header::DataDescription what) {
   return AlgorithmSpec{
     [what](ProcessingContext &ctx)
       {
-        auto bData = ctx.allocator().make<int>(OutputSpec{"TST", what, 0}, 1);
+        auto bData = ctx.outputs().make<int>(OutputSpec{"TST", what, 0}, 1);
       }
     };
 }
@@ -33,8 +33,8 @@ void defineDataProcessing(WorkflowSpec &specs) {
     AlgorithmSpec{
       [](ProcessingContext &ctx) {
        sleep(1);
-       auto aData = ctx.allocator().make<int>(OutputSpec{"TST", "A1", 0}, 1);
-       auto bData = ctx.allocator().make<int>(OutputSpec{"TST", "A2", 0}, 1);
+       auto aData = ctx.outputs().make<int>(OutputSpec{"TST", "A1", 0}, 1);
+       auto bData = ctx.outputs().make<int>(OutputSpec{"TST", "A2", 0}, 1);
       }
     }
   },

--- a/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
@@ -12,12 +12,9 @@
 using namespace o2::framework;
 
 AlgorithmSpec simplePipe(o2::header::DataDescription what) {
-  return AlgorithmSpec{
-    [what](ProcessingContext &ctx)
-      {
-        auto bData = ctx.outputs().make<int>(OutputSpec{"TST", what, 0}, 1);
-      }
-    };
+  return AlgorithmSpec{ [what](ProcessingContext& ctx) {
+    auto bData = ctx.outputs().make<int>(OutputSpec{ "TST", what, 0 }, 1);
+  } };
 }
 
 // This is how you can define your processing in a declarative way
@@ -33,8 +30,8 @@ void defineDataProcessing(WorkflowSpec &specs) {
     AlgorithmSpec{
       [](ProcessingContext &ctx) {
        sleep(1);
-       auto aData = ctx.outputs().make<int>(OutputSpec{"TST", "A1", 0}, 1);
-       auto bData = ctx.outputs().make<int>(OutputSpec{"TST", "A2", 0}, 1);
+       auto aData = ctx.outputs().make<int>(OutputSpec{ "TST", "A1", 0 }, 1);
+       auto bData = ctx.outputs().make<int>(OutputSpec{ "TST", "A2", 0 }, 1);
       }
     }
   },

--- a/Framework/TestWorkflows/src/o2DummyWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DummyWorkflow.cxx
@@ -43,7 +43,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
        sleep(1);
        // Creates a new message of size 1000 which
        // has "TPC" as data origin and "CLUSTERS" as data description.
-       auto tpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{"TPC", "CLUSTERS", 0}, 1000);
+       auto tpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "TPC", "CLUSTERS", 0 }, 1000);
        int i = 0;
 
        for (auto &cluster : tpcClusters) {
@@ -55,7 +55,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
          i++;
        }
 
-       auto itsClusters = ctx.outputs().make<FakeCluster>(OutputSpec{"ITS", "CLUSTERS", 0}, 1000);
+       auto itsClusters = ctx.outputs().make<FakeCluster>(OutputSpec{ "ITS", "CLUSTERS", 0 }, 1000);
        i = 0;
        for (auto &cluster : itsClusters) {
          assert(i < 1000);
@@ -70,49 +70,30 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
     }
   };
 
-  DataProcessorSpec tpcClusterSummary {
+  DataProcessorSpec tpcClusterSummary{
     "tpc-cluster-summary",
-    {
-       InputSpec{"clusters", "TPC", "CLUSTERS", InputSpec::Timeframe}
-    },
-    {
-       OutputSpec{"TPC", "SUMMARY", OutputSpec::Timeframe}
-    },
-    AlgorithmSpec{
-    [](ProcessingContext &ctx)
-      {
-        auto tpcSummary = ctx.outputs().make<Summary>(OutputSpec{"TPC", "SUMMARY", 0}, 1);
-        tpcSummary.at(0).inputCount = ctx.inputs().size();
-      }
-    },
-    {
-      ConfigParamSpec{"some-cut", VariantType::Float, 1.0f, {"some cut"}}
-    },
-    {
-      "CPUTimer"
-    }
+    { InputSpec{ "clusters", "TPC", "CLUSTERS", InputSpec::Timeframe } },
+    { OutputSpec{ "TPC", "SUMMARY", OutputSpec::Timeframe } },
+    AlgorithmSpec{ [](ProcessingContext& ctx) {
+      auto tpcSummary = ctx.outputs().make<Summary>(OutputSpec{ "TPC", "SUMMARY", 0 }, 1);
+      tpcSummary.at(0).inputCount = ctx.inputs().size();
+    } },
+    { ConfigParamSpec{ "some-cut", VariantType::Float, 1.0f, { "some cut" } } },
+    { "CPUTimer" }
   };
 
-  DataProcessorSpec itsClusterSummary {
+  DataProcessorSpec itsClusterSummary{
     "its-cluster-summary",
+    { InputSpec{ "clusters", "ITS", "CLUSTERS", InputSpec::Timeframe } },
     {
-      InputSpec{"clusters", "ITS", "CLUSTERS", InputSpec::Timeframe}
+      OutputSpec{ "ITS", "SUMMARY", OutputSpec::Timeframe },
     },
-    {
-      OutputSpec{"ITS", "SUMMARY", OutputSpec::Timeframe},
-    },
-    AlgorithmSpec{
-      [](ProcessingContext &ctx) {
-        auto itsSummary = ctx.outputs().make<Summary>(OutputSpec{"ITS", "SUMMARY", 0}, 1);
-        itsSummary.at(0).inputCount = ctx.inputs().size();
-      }
-    },
-    {
-      ConfigParamSpec{"some-cut", VariantType::Float, 1.0f, {"some cut"}}
-    },
-    {
-      "CPUTimer"
-    }
+    AlgorithmSpec{ [](ProcessingContext& ctx) {
+      auto itsSummary = ctx.outputs().make<Summary>(OutputSpec{ "ITS", "SUMMARY", 0 }, 1);
+      itsSummary.at(0).inputCount = ctx.inputs().size();
+    } },
+    { ConfigParamSpec{ "some-cut", VariantType::Float, 1.0f, { "some cut" } } },
+    { "CPUTimer" }
   };
 
   DataProcessorSpec merger{

--- a/Framework/TestWorkflows/src/o2DummyWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DummyWorkflow.cxx
@@ -43,7 +43,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
        sleep(1);
        // Creates a new message of size 1000 which
        // has "TPC" as data origin and "CLUSTERS" as data description.
-       auto tpcClusters = ctx.allocator().make<FakeCluster>(OutputSpec{"TPC", "CLUSTERS", 0}, 1000);
+       auto tpcClusters = ctx.outputs().make<FakeCluster>(OutputSpec{"TPC", "CLUSTERS", 0}, 1000);
        int i = 0;
 
        for (auto &cluster : tpcClusters) {
@@ -55,7 +55,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
          i++;
        }
 
-       auto itsClusters = ctx.allocator().make<FakeCluster>(OutputSpec{"ITS", "CLUSTERS", 0}, 1000);
+       auto itsClusters = ctx.outputs().make<FakeCluster>(OutputSpec{"ITS", "CLUSTERS", 0}, 1000);
        i = 0;
        for (auto &cluster : itsClusters) {
          assert(i < 1000);
@@ -81,7 +81,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
     AlgorithmSpec{
     [](ProcessingContext &ctx)
       {
-        auto tpcSummary = ctx.allocator().make<Summary>(OutputSpec{"TPC", "SUMMARY", 0}, 1);
+        auto tpcSummary = ctx.outputs().make<Summary>(OutputSpec{"TPC", "SUMMARY", 0}, 1);
         tpcSummary.at(0).inputCount = ctx.inputs().size();
       }
     },
@@ -103,7 +103,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
     },
     AlgorithmSpec{
       [](ProcessingContext &ctx) {
-        auto itsSummary = ctx.allocator().make<Summary>(OutputSpec{"ITS", "SUMMARY", 0}, 1);
+        auto itsSummary = ctx.outputs().make<Summary>(OutputSpec{"ITS", "SUMMARY", 0}, 1);
         itsSummary.at(0).inputCount = ctx.inputs().size();
       }
     },

--- a/Framework/TestWorkflows/src/o2ParallelWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2ParallelWorkflow.cxx
@@ -34,7 +34,7 @@ DataProcessorSpec templateProcessor() {
           // Create a single output. 
           size_t index = ctx.services().get<ParallelContext>().index1D();
           sleep(1);
-          auto aData = ctx.allocator().make<int>(OutputSpec{"TST", "P", index}, 1);
+          auto aData = ctx.outputs().make<int>(OutputSpec{"TST", "P", index}, 1);
         };
       }
     }

--- a/Framework/TestWorkflows/src/o2ParallelWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2ParallelWorkflow.cxx
@@ -34,7 +34,7 @@ DataProcessorSpec templateProcessor() {
           // Create a single output. 
           size_t index = ctx.services().get<ParallelContext>().index1D();
           sleep(1);
-          auto aData = ctx.outputs().make<int>(OutputSpec{"TST", "P", index}, 1);
+          auto aData = ctx.outputs().make<int>(OutputSpec{ "TST", "P", index }, 1);
         };
       }
     }

--- a/Framework/TestWorkflows/src/test_o2RootMessageWorkflow.cxx
+++ b/Framework/TestWorkflows/src/test_o2RootMessageWorkflow.cxx
@@ -38,10 +38,9 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
       AlgorithmSpec{
         [](ProcessingContext &ctx) {
           sleep(1);
-          // Create an histogram 
-          auto &singleHisto = ctx.outputs().make<TH1F>(OutputSpec{"TST", "HISTOS", 0},
-                                                         "h1", "test", 100, -10., 10.);
-          auto &aString = ctx.outputs().make<TObjString>(OutputSpec{"TST", "STRING", 0}, "foo");
+          // Create an histogram
+          auto& singleHisto = ctx.outputs().make<TH1F>(OutputSpec{ "TST", "HISTOS", 0 }, "h1", "test", 100, -10., 10.);
+          auto& aString = ctx.outputs().make<TObjString>(OutputSpec{ "TST", "STRING", 0 }, "foo");
           singleHisto.FillRandom("gaus", 1000);
           Double_t stats[4];
           singleHisto.GetStats(stats);

--- a/Framework/TestWorkflows/src/test_o2RootMessageWorkflow.cxx
+++ b/Framework/TestWorkflows/src/test_o2RootMessageWorkflow.cxx
@@ -39,9 +39,9 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
         [](ProcessingContext &ctx) {
           sleep(1);
           // Create an histogram 
-          auto &singleHisto = ctx.allocator().make<TH1F>(OutputSpec{"TST", "HISTOS", 0},
+          auto &singleHisto = ctx.outputs().make<TH1F>(OutputSpec{"TST", "HISTOS", 0},
                                                          "h1", "test", 100, -10., 10.);
-          auto &aString = ctx.allocator().make<TObjString>(OutputSpec{"TST", "STRING", 0}, "foo");
+          auto &aString = ctx.outputs().make<TObjString>(OutputSpec{"TST", "STRING", 0}, "foo");
           singleHisto.FillRandom("gaus", 1000);
           Double_t stats[4];
           singleHisto.GetStats(stats);

--- a/Framework/TestWorkflows/test/test_MakeDPLObjects.cxx
+++ b/Framework/TestWorkflows/test/test_MakeDPLObjects.cxx
@@ -38,19 +38,18 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
       AlgorithmSpec{
         [](ProcessingContext &ctx) {
           // A new message with 1 XYZ instance in it
-          XYZ &x = ctx.outputs().make<XYZ>(OutputSpec{"TST", "POINT", 0});
+          XYZ& x = ctx.outputs().make<XYZ>(OutputSpec{ "TST", "POINT", 0 });
           // A new message with a gsl::span<XYZ> with 1000 items
-          gsl::span<XYZ> y = ctx.outputs().make<XYZ>(OutputSpec{"TST", "POINTS", 0}, 1000);
+          gsl::span<XYZ> y = ctx.outputs().make<XYZ>(OutputSpec{ "TST", "POINTS", 0 }, 1000);
           y[0] = XYZ{1,2,3};
           y[999] = XYZ{1,2,3};
           // A new message with a TH1F inside
-          auto h = ctx.outputs().make<TH1F>(OutputSpec{"TST", "HISTO"},
-                                             "h", "test", 100, -10., 10.);
+          auto h = ctx.outputs().make<TH1F>(OutputSpec{ "TST", "HISTO" }, "h", "test", 100, -10., 10.);
           // A snapshot for an std::vector
           std::vector<XYZ> v{1000};
           v[0] = XYZ{1,2,3};
           v[999] = XYZ{1,2,3};
-          ctx.outputs().snapshot(OutputSpec{"TST", "VECTOR"}, v);
+          ctx.outputs().snapshot(OutputSpec{ "TST", "VECTOR" }, v);
           v[999] = XYZ{2,3,4};
 
           // A snapshot for an std::vector of pointers to objects
@@ -58,11 +57,11 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
           // change, but not the one which is done after taking the snapshot
           std::vector<XYZ*> p;
           for (auto & i : v) p.push_back(&i);
-          ctx.outputs().snapshot(OutputSpec{"TST", "LINEARIZED"}, p);
+          ctx.outputs().snapshot(OutputSpec{ "TST", "LINEARIZED" }, p);
           v[999] = XYZ{3,4,5};
 
           TNamed named("named", "a named test object");
-          ctx.outputs().snapshot(OutputSpec{"TST", "OBJECT"}, named);
+          ctx.outputs().snapshot(OutputSpec{ "TST", "OBJECT" }, named);
         }
       }
     },

--- a/Framework/TestWorkflows/test/test_MakeDPLObjects.cxx
+++ b/Framework/TestWorkflows/test/test_MakeDPLObjects.cxx
@@ -38,19 +38,19 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
       AlgorithmSpec{
         [](ProcessingContext &ctx) {
           // A new message with 1 XYZ instance in it
-          XYZ &x = ctx.allocator().make<XYZ>(OutputSpec{"TST", "POINT", 0});
+          XYZ &x = ctx.outputs().make<XYZ>(OutputSpec{"TST", "POINT", 0});
           // A new message with a gsl::span<XYZ> with 1000 items
-          gsl::span<XYZ> y = ctx.allocator().make<XYZ>(OutputSpec{"TST", "POINTS", 0}, 1000);
+          gsl::span<XYZ> y = ctx.outputs().make<XYZ>(OutputSpec{"TST", "POINTS", 0}, 1000);
           y[0] = XYZ{1,2,3};
           y[999] = XYZ{1,2,3};
           // A new message with a TH1F inside
-          auto h = ctx.allocator().make<TH1F>(OutputSpec{"TST", "HISTO"},
+          auto h = ctx.outputs().make<TH1F>(OutputSpec{"TST", "HISTO"},
                                              "h", "test", 100, -10., 10.);
           // A snapshot for an std::vector
           std::vector<XYZ> v{1000};
           v[0] = XYZ{1,2,3};
           v[999] = XYZ{1,2,3};
-          ctx.allocator().snapshot(OutputSpec{"TST", "VECTOR"}, v);
+          ctx.outputs().snapshot(OutputSpec{"TST", "VECTOR"}, v);
           v[999] = XYZ{2,3,4};
 
           // A snapshot for an std::vector of pointers to objects
@@ -58,11 +58,11 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
           // change, but not the one which is done after taking the snapshot
           std::vector<XYZ*> p;
           for (auto & i : v) p.push_back(&i);
-          ctx.allocator().snapshot(OutputSpec{"TST", "LINEARIZED"}, p);
+          ctx.outputs().snapshot(OutputSpec{"TST", "LINEARIZED"}, p);
           v[999] = XYZ{3,4,5};
 
           TNamed named("named", "a named test object");
-          ctx.allocator().snapshot(OutputSpec{"TST", "OBJECT"}, named);
+          ctx.outputs().snapshot(OutputSpec{"TST", "OBJECT"}, named);
         }
       }
     },

--- a/Utilities/QC/Workflow/src/RootObjectProducerSpec.cxx
+++ b/Utilities/QC/Workflow/src/RootObjectProducerSpec.cxx
@@ -135,9 +135,8 @@ DataProcessorSpec getRootObjectProducerSpec() {
         // using by-copy capture of the worker instance shared pointer
         // the shared pointer makes sure to clean up the instance when the processing
         // function gets out of scope
-        auto processingFct = [producer] (ProcessingContext &pc) {
-          pc.outputs().adopt(OutputSpec{"QC", "ROOTOBJECT", 0, OutputSpec::QA},
-                               producer->produceData());
+        auto processingFct = [producer](ProcessingContext& pc) {
+          pc.outputs().adopt(OutputSpec{ "QC", "ROOTOBJECT", 0, OutputSpec::QA }, producer->produceData());
         };
 
         // return the actual processing function as a lambda function using variables

--- a/Utilities/QC/Workflow/src/RootObjectProducerSpec.cxx
+++ b/Utilities/QC/Workflow/src/RootObjectProducerSpec.cxx
@@ -136,7 +136,7 @@ DataProcessorSpec getRootObjectProducerSpec() {
         // the shared pointer makes sure to clean up the instance when the processing
         // function gets out of scope
         auto processingFct = [producer] (ProcessingContext &pc) {
-          pc.allocator().adopt(OutputSpec{"QC", "ROOTOBJECT", 0, OutputSpec::QA},
+          pc.outputs().adopt(OutputSpec{"QC", "ROOTOBJECT", 0, OutputSpec::QA},
                                producer->produceData());
         };
 


### PR DESCRIPTION
As agreed in a past WP4 meeting, we rename allocator to outputs as it
apparently is less confusing.