### PR TITLE
Templetize the geometry transformer

### DIFF
--- a/Detectors/MUON/MID/Base/include/MIDBase/GeometryTransformer.h
+++ b/Detectors/MUON/MID/Base/include/MIDBase/GeometryTransformer.h
@@ -36,12 +36,42 @@ class GeometryTransformer
   GeometryTransformer(GeometryTransformer&&) = delete;
   GeometryTransformer& operator=(GeometryTransformer&&) = delete;
 
-  Point3D<float> localToGlobal(int deId, const Point3D<float>& position) const;
-  Point3D<float> globalToLocal(int deId, const Point3D<float>& position) const;
-  Point3D<float> localToGlobal(int deId, float xPos, float yPos) const;
-  Point3D<float> globalToLocal(int deId, float xPos, float yPos, float zPos) const;
-  Vector3D<float> localToGlobal(int deId, const Vector3D<float>& direction) const;
-  Vector3D<float> globalToLocal(int deId, const Vector3D<float>& direction) const;
+  template <typename T>
+  Point3D<T> localToGlobal(int deId, const Point3D<T>& position) const
+  {
+    /// Converts local coordinates into global ones
+    return mTransformations[deId](position);
+  }
+  template <typename T>
+  Point3D<T> globalToLocal(int deId, const Point3D<T>& position) const
+  {
+    /// Converts global coordinates into local ones
+    return mTransformations[deId].ApplyInverse(position);
+  }
+  template <typename T>
+  Point3D<T> localToGlobal(int deId, T xPos, T yPos) const
+  {
+    /// Converts local coordinates into global ones
+    return localToGlobal(deId, Point3D<T>(xPos, yPos, 0.));
+  }
+  template <typename T>
+  Point3D<T> globalToLocal(int deId, T xPos, T yPos, T zPos) const
+  {
+    /// Converts global coordinates into local ones
+    return globalToLocal(deId, Point3D<T>(xPos, yPos, zPos));
+  }
+  template <typename T>
+  Vector3D<T> localToGlobal(int deId, const Vector3D<T>& direction) const
+  {
+    /// Converts direction in local coordinates into global ones
+    return mTransformations[deId](direction);
+  }
+  template <typename T>
+  Vector3D<T> globalToLocal(int deId, const Vector3D<T>& direction) const
+  {
+    /// Converts direction in global coordinates into a local ones
+    return mTransformations[deId].ApplyInverse(direction);
+  }
 
  private:
   void init();

--- a/Detectors/MUON/MID/Base/src/GeometryTransformer.cxx
+++ b/Detectors/MUON/MID/Base/src/GeometryTransformer.cxx
@@ -63,52 +63,10 @@ void GeometryTransformer::init()
         int deId = Constants::getDEId(isRight, ichamber, irpc);
         ROOT::Math::Translation3D trans(xPos, yPos, zPos);
         mTransformations[deId] = planeTrans * planeRot * trans * rot;
-        LOG(DEBUG) << "DeID " << deId << ")\n" << mTransformations[deId];
+        LOG(DEBUG) << "DeID " << deId << "\n" << mTransformations[deId];
       }
     }
   }
-}
-
-//______________________________________________________________________________
-Point3D<float> GeometryTransformer::localToGlobal(int deId, const Point3D<float>& position) const
-{
-  /// Converts local coordinates into global ones
-  return mTransformations[deId](position);
-}
-
-//______________________________________________________________________________
-Point3D<float> GeometryTransformer::globalToLocal(int deId, const Point3D<float>& position) const
-{
-  /// Converts global coordinates into local ones
-  return mTransformations[deId].ApplyInverse(position);
-}
-
-//______________________________________________________________________________
-Point3D<float> GeometryTransformer::localToGlobal(int deId, float xPos, float yPos) const
-{
-  /// Converts local coordinates into global ones
-  return localToGlobal(deId, Point3D<float>(xPos, yPos, 0.));
-}
-
-//______________________________________________________________________________
-Point3D<float> GeometryTransformer::globalToLocal(int deId, float xPos, float yPos, float zPos) const
-{
-  /// Converts global coordinates into local ones
-  return globalToLocal(deId, Point3D<float>(xPos, yPos, zPos));
-}
-
-//______________________________________________________________________________
-Vector3D<float> GeometryTransformer::localToGlobal(int deId, const Vector3D<float>& direction) const
-{
-  /// Converts direction in local coordinates into global ones
-  return mTransformations[deId](direction);
-}
-
-//______________________________________________________________________________
-Vector3D<float> GeometryTransformer::globalToLocal(int deId, const Vector3D<float>& direction) const
-{
-  /// Converts direction in global coordinates into a local ones
-  return mTransformations[deId].ApplyInverse(direction);
 }
 
 } // namespace mid

--- a/Detectors/MUON/MID/Base/test/testGeometryTransformer.cxx
+++ b/Detectors/MUON/MID/Base/test/testGeometryTransformer.cxx
@@ -37,35 +37,58 @@ o2::mid::GeometryTransformer GEOM::geoTrans;
 BOOST_AUTO_TEST_SUITE(o2_mid_geometryTransformer)
 BOOST_FIXTURE_TEST_SUITE(geo, GEOM)
 
-std::vector<Point3D<float>> generatePoints(int ntimes)
+std::vector<Point3D<double>> generatePoints(int ntimes)
 {
   std::random_device rd;
   std::mt19937 mt(rd());
   std::uniform_real_distribution<double> distX(-127.5, 127.5);
   std::uniform_real_distribution<double> distY(-40., 40.);
 
-  std::vector<Point3D<float>> points;
+  std::vector<Point3D<double>> points;
 
   for (int itime = 0; itime < ntimes; ++itime) {
-    points.emplace_back(Point3D<float>(distX(mt), distY(mt), 0.));
+    points.emplace_back(distX(mt), distY(mt), 0.);
   }
 
   return points;
 }
 
+BOOST_TEST_DECORATOR(*boost::unit_test::tolerance(0.00001))
 BOOST_DATA_TEST_CASE(InverseTransformation, boost::unit_test::data::xrange(72) * generatePoints(1000), deId, point)
 {
-  Point3D<float> globalPoint = GEOM::geoTrans.localToGlobal(deId, point.x(), point.y());
-  Point3D<float> localPoint = GEOM::geoTrans.globalToLocal(deId, globalPoint.x(), globalPoint.y(), globalPoint.z());
-  float relTolerance = 0.001;
-  float absTolerance = 1.;
-  float minValue = 0.02;
-  float tolerance = (std::abs(localPoint.x()) < minValue) ? absTolerance : relTolerance;
-  BOOST_TEST(localPoint.x() == point.x(), boost::test_tools::tolerance(tolerance));
-  tolerance = (std::abs(localPoint.y()) < minValue) ? absTolerance : relTolerance;
-  BOOST_TEST(localPoint.y() == point.y(), boost::test_tools::tolerance(tolerance));
-  tolerance = (std::abs(localPoint.z()) < minValue) ? absTolerance : relTolerance;
-  BOOST_TEST(localPoint.z() == point.z(), boost::test_tools::tolerance(tolerance));
+  Point3D<double> globalPoint = GEOM::geoTrans.localToGlobal(deId, point.x(), point.y());
+  Point3D<double> localPoint = GEOM::geoTrans.globalToLocal(deId, globalPoint.x(), globalPoint.y(), globalPoint.z());
+
+  BOOST_TEST(localPoint.x() == point.x());
+  BOOST_TEST(localPoint.y() == point.y());
+  BOOST_TEST(localPoint.z() == point.z());
+}
+
+std::vector<Vector3D<double>> generateSlopes(int ntimes)
+{
+  std::random_device rd;
+  std::mt19937 mt(rd());
+  std::uniform_real_distribution<double> distX(-1., 1.);
+  std::uniform_real_distribution<double> distY(-1., 1.);
+
+  std::vector<Vector3D<double>> slopes;
+
+  for (int itime = 0; itime < ntimes; ++itime) {
+    slopes.emplace_back(distX(mt), distY(mt), 1.);
+  }
+
+  return slopes;
+}
+
+BOOST_TEST_DECORATOR(*boost::unit_test::tolerance(0.00001))
+BOOST_DATA_TEST_CASE(InverseTransformationSlope, boost::unit_test::data::xrange(72) * generateSlopes(1000), deId, slope)
+{
+  Vector3D<double> globalSlope = GEOM::geoTrans.localToGlobal(deId, slope);
+  Vector3D<double> localSlope = GEOM::geoTrans.globalToLocal(deId, globalSlope);
+
+  BOOST_TEST(localSlope.x() == slope.x());
+  BOOST_TEST(localSlope.y() == slope.y());
+  BOOST_TEST(localSlope.z() == slope.z());
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
So that it can be used with either float or double.
This is particularly useful to circumvent floating point precision in boost tests.