### PR TITLE
Improve MID clustering benchmark

### DIFF
--- a/Detectors/MUON/MID/Clustering/test/bench_Clusterizer.cxx
+++ b/Detectors/MUON/MID/Clustering/test/bench_Clusterizer.cxx
@@ -20,81 +20,109 @@
 #include "DataFormatsMID/StripPattern.h"
 #include "Clusterizer.h"
 
-std::vector<o2::mid::ColumnData> generateTestData(int deId, const o2::mid::Mapping& midMapping)
+o2::mid::ColumnData& getColumn(std::vector<o2::mid::ColumnData>& patterns, uint8_t icolumn, uint8_t deId)
+{
+  for (auto& currColumn : patterns) {
+    if (currColumn.columnId == icolumn) {
+      return currColumn;
+    }
+  }
+
+  patterns.emplace_back(o2::mid::ColumnData{ deId, icolumn });
+  return patterns.back();
+}
+
+bool addStrip(o2::mid::ColumnData& column, int cathode, int line, int strip)
+{
+  uint16_t pattern = (cathode == 0) ? column.patterns.getBendPattern(line) : column.patterns.getNonBendPattern();
+  uint16_t currStrip = (1 << strip);
+  if (pattern & currStrip) {
+    return false;
+  }
+  pattern |= currStrip;
+  if (cathode == 0) {
+    column.patterns.setBendPattern(pattern, line);
+  } else {
+    column.patterns.setNonBendPattern(pattern);
+  }
+  return true;
+}
+
+void addNeighbour(std::vector<o2::mid::ColumnData>& patterns, o2::mid::Mapping::MpStripIndex stripIndex, int cathode,
+                  int deId, const o2::mid::Mapping& midMapping, int& nAdded, int maxAdded)
+{
+  std::vector<o2::mid::Mapping::MpStripIndex> neighbours = midMapping.getNeighbours(stripIndex, cathode, deId);
+  for (auto& neigh : neighbours) {
+    o2::mid::ColumnData& column = getColumn(patterns, static_cast<uint8_t>(neigh.column), static_cast<uint8_t>(deId));
+    if (!addStrip(column, cathode, neigh.line, neigh.strip)) {
+      continue;
+    }
+    ++nAdded;
+    if (nAdded >= maxAdded) {
+      return;
+    }
+    addNeighbour(patterns, neigh, cathode, deId, midMapping, nAdded, maxAdded);
+    if (nAdded >= maxAdded) {
+      return;
+    }
+  }
+}
+
+std::vector<o2::mid::ColumnData> generateTestData(int deId, int nClusters, int clusterSize,
+                                                  const o2::mid::Mapping& midMapping)
 {
   int firstColumnInDE = midMapping.getFirstColumn(deId);
 
   std::uniform_int_distribution<int> distColumn(firstColumnInDE, 6);
-  std::uniform_int_distribution<int> distStrip(0, 15);
-  std::uniform_int_distribution<int> distNfired(0, 4);
 
   std::random_device rd;
   std::mt19937 mt(rd());
 
   std::vector<o2::mid::ColumnData> patterns;
-  int firstColumn = distColumn(mt);
-  int lastColumn = firstColumn + 1;
-  if (lastColumn > 6) {
-    lastColumn = 6;
-  }
+  o2::mid::Mapping::MpStripIndex stripIndex;
+  std::vector<o2::mid::Mapping::MpStripIndex> neighbours;
 
-  for (int icol = firstColumn; icol <= lastColumn; ++icol) {
-    o2::mid::ColumnData column;
-    column.deId = (uint8_t)deId;
-    column.columnId = (uint8_t)icol;
+  for (int icl = 0; icl < nClusters; ++icl) {
+    int icolumn = distColumn(mt);
     for (int cathode = 0; cathode < 2; ++cathode) {
-      int firstLine = 0;
-      int lastLine = 0;
-      if (cathode == 0) {
-        firstLine = midMapping.getFirstBoardBP(icol, deId);
-        lastLine = midMapping.getLastBoardBP(icol, deId);
-      }
-      for (int iline = firstLine; iline <= lastLine; ++iline) {
-        uint16_t pattern = 0;
-        int nStrips = distNfired(mt);
-        for (int istrip = 0; istrip < nStrips; ++istrip) {
-          if (midMapping.stripByLocation(istrip, cathode, iline, column.columnId, column.deId).isValid()) {
-            pattern |= (1 << istrip);
-          }
-        }
-        if (cathode == 0) {
-          column.patterns.setBendPattern(pattern, iline);
-        } else {
-          column.patterns.setNonBendPattern(pattern);
-        }
+      int iline = (cathode == 1) ? 0 : midMapping.getFirstBoardBP(icolumn, deId);
+      int nStrips = (cathode == 0) ? 16 : midMapping.getNStripsNBP(icolumn, deId);
+      std::uniform_int_distribution<int> distStrip(0, nStrips - 1);
+      stripIndex.column = icolumn;
+      stripIndex.line = iline;
+      stripIndex.strip = distStrip(mt);
+      o2::mid::ColumnData& column = getColumn(patterns, static_cast<uint8_t>(icolumn), static_cast<uint8_t>(deId));
+      addStrip(column, cathode, iline, stripIndex.strip);
+      int nAdded = 1;
+      if (nAdded < clusterSize) {
+        addNeighbour(patterns, stripIndex, cathode, deId, midMapping, nAdded, clusterSize);
       }
     }
-    patterns.emplace_back(column);
   }
   return patterns;
 }
 
-static void deList(benchmark::internal::Benchmark* bench)
+class BenchClustering : public benchmark::Fixture
 {
-  for (int deId = 63; deId < 72; ++deId) {
-    bench->Args({ deId });
-  }
-}
-
-class BenchO2 : public benchmark::Fixture
-{
+ public:
+  BenchClustering() : midMapping(), clusterizer() { clusterizer.init(); }
+  o2::mid::Mapping midMapping;
+  o2::mid::Clusterizer clusterizer;
 };
-BENCHMARK_DEFINE_F(BenchO2, clustering)(benchmark::State& state)
+
+BENCHMARK_DEFINE_F(BenchClustering, clustering)(benchmark::State& state)
 {
 
   int deId = state.range(0);
-
-  o2::mid::Mapping midMapping;
-  o2::mid::Clusterizer clusterizer;
-  clusterizer.init();
-
+  int nClusters = state.range(1);
+  int clusterSize = state.range(2);
   double num{ 0 };
 
   std::vector<o2::mid::ColumnData> inputData;
 
   for (auto _ : state) {
     state.PauseTiming();
-    inputData = generateTestData(deId, midMapping);
+    inputData = generateTestData(deId, nClusters, clusterSize, midMapping);
     state.ResumeTiming();
     clusterizer.process(inputData);
     ++num;
@@ -103,6 +131,18 @@ BENCHMARK_DEFINE_F(BenchO2, clustering)(benchmark::State& state)
   state.counters["num"] = benchmark::Counter(num, benchmark::Counter::kIsRate);
 }
 
-BENCHMARK_REGISTER_F(BenchO2, clustering)->Apply(deList)->Unit(benchmark::kNanosecond);
+static void CustomArguments(benchmark::internal::Benchmark* bench)
+{
+  std::vector<int> deIdList = { 63, 66, 67, 68, 69 };
+  for (auto& deId : deIdList) {
+    for (int nClusters = 1; nClusters < 4; ++nClusters) {
+      for (int clustSize = 1; clustSize < 4; ++clustSize) {
+        bench->Args({ deId, nClusters, clustSize });
+      }
+    }
+  }
+}
+
+BENCHMARK_REGISTER_F(BenchClustering, clustering)->Apply(CustomArguments)->Unit(benchmark::kNanosecond);
 
 BENCHMARK_MAIN();


### PR DESCRIPTION
Runs a series of benchmarks for different number of clusters and cluster size
so that one can test the timing evolution in different occupancy conditions.