### PR TITLE
[WIP] More work on DPL input API

### DIFF
--- a/Framework/Core/include/Framework/InputRecord.h
+++ b/Framework/Core/include/Framework/InputRecord.h
@@ -36,12 +36,39 @@ namespace framework
 
 struct InputSpec;
 
+/// @class InputRecord
+/// @brief The input API of the Data Processing Layer
 /// This class holds the inputs which  are being processed by the system while
 /// they are  being processed.  The user can  get an instance  for it  via the
 /// ProcessingContext and can use it to retrieve the inputs, either by name or
 /// by index.  A few utility  methods are  provided to automatically  cast the
 /// inputs to  known types. The user is also allowed to  override the `get`
 /// template and provide his own serialization mechanism.
+///
+/// The @ref get<T>(binding) method is implemeted for the following types:
+/// - (a) const char*
+/// - (b) std::string
+/// - (c) messageable type T
+/// - (d) pointer type T* for types with ROOT dictionary or messageable types
+/// - (e) std container of type T with ROOT dictionary
+/// - (f) DataRef holding header and payload information, this is also the default
+///       get method without template parameter
+///
+/// The return type of get<T>(binding) is:
+/// - (a) const char* to payload content
+/// - (b) std::string copy of the payload
+/// - (c) const ref for messageable types T, the payload content casted to the type
+/// - (d) object with pointer-like behavior (unique_ptr) if T* specified
+/// - (e) std::container object returned by std::move
+/// - (f) DataRef object returned by copy
+///
+/// Iterator functionality is implemented to iterate over the list of DataRef objects,
+/// including begin() and end() methods.
+/// <pre>
+///    for (auto const& ref : inputs) {
+///      // do something with DataRef object ref
+///    }
+/// </pre>
 class InputRecord {
 public:
   InputRecord(std::vector<InputRoute> const &inputs,
@@ -121,10 +148,11 @@ public:
                    static_cast<char const*>(mCache[pos*2+1]->GetData())};
   }
 
-  // Generic function to extract a messageable type by reference
-  // Cast content of payload bound by @a binding to known type.
-  // Will not be used for types needing extra serialization
-  // Note: is_messagable also checks that T is not a pointer
+  /// Generic function to extract a messageable type by reference
+  /// Cast content of payload bound by @a binding to known type.
+  /// Will not be used for types needing extra serialization
+  /// Note: is_messagable also checks that T is not a pointer
+  /// @return const ref to specified type
   template <typename T>
   typename std::enable_if<is_messageable<T>::value && std::is_same<T, DataRef>::value == false, //
                           T>::type const&
@@ -144,28 +172,34 @@ public:
     return *reinterpret_cast<T const *>(get<DataRef>(binding).payload);
   }
 
-  // If we ask for a char const *, we simply point to the payload. Notice this
-  // is meant for C-style strings. If you want to actually get hold of the buffer,
-  // use get<DataRef> (or simply get) as that will give you the size as well.
-  // FIXME: check that the string is null terminated.
+  /// substitution for const char*
+  /// If we ask for a char const *, we simply point to the payload. Notice this
+  /// is meant for C-style strings. If you want to actually get hold of the buffer,
+  /// use get<DataRef> (or simply get) as that will give you the size as well.
+  /// FIXME: check that the string is null terminated.
+  /// @return pointer to payload content
   template <typename T>
   typename std::enable_if<std::is_same<T, char const *>::value, T>::type
   get(char const *binding) const {
     return reinterpret_cast<char const *>(get<DataRef>(binding).payload);
   }
 
-  // If we ask for a string, we need to duplicate it because we do not want
-  // the buffer to be deleted when it goes out of scope.
-  // FIXME: check that the string is null terminated.
+  /// substitution for std::string
+  /// If we ask for a string, we need to duplicate it because we do not want
+  /// the buffer to be deleted when it goes out of scope.
+  /// FIXME: check that the string is null terminated.
+  /// @return std::string object
   template <typename T>
   typename std::enable_if<std::is_same<T, std::string>::value, T>::type
   get(char const *binding) const {
     return std::move(std::string(get<DataRef>(binding).payload));
   }
 
-  // DataRef is special. Since there is no point in storing one in a payload,
-  // what it actually does is to return the DataRef used to hold the 
-  // (header, payload) pair.
+  /// substitution for DataRef
+  /// DataRef is special. Since there is no point in storing one in a payload,
+  /// what it actually does is to return the DataRef used to hold the
+  /// (header, payload) pair.
+  /// @return DataRef object
   template <typename T = DataRef>
   typename std::enable_if<std::is_same<T, DataRef>::value, T>::type
   get(const char *binding) const {
@@ -176,9 +210,11 @@ public:
     }
   }
 
-  // DataRef is special. Since there is no point in storing one in a payload,
-  // what it actually does is to return the DataRef used to hold the 
-  // (header, payload) pair.
+  /// substitution for DataRef
+  /// DataRef is special. Since there is no point in storing one in a payload,
+  /// what it actually does is to return the DataRef used to hold the
+  /// (header, payload) pair.
+  /// @return DataRef object
   template <class T = DataRef>
   typename std::enable_if<std::is_same<T, DataRef>::value, T>::type
   get(std::string const &binding) const {
@@ -189,12 +225,14 @@ public:
     }
   }
 
-  // substitution for pointer to non-messageable objects with ROOT dictionary
-  // This supports the common case of retrieving a root object and getting pointer.
-  // Notice that this will return a copy of the actual contents of the buffer, because
-  // the buffer is actually serialised, for this reason we return a unique_ptr<T>.
-  // FIXME: does it make more sense to keep ownership of all the deserialised
-  // objects in a single place so that we can avoid duplicate deserializations?
+  /// substitution for pointer to non-messageable objects with ROOT dictionary
+  /// Template parameter is a pointer
+  /// This supports the common case of retrieving a root object and getting pointer.
+  /// Notice that this will return a copy of the actual contents of the buffer, because
+  /// the buffer is actually serialised, for this reason we return a unique_ptr<T>.
+  /// FIXME: does it make more sense to keep ownership of all the deserialised
+  /// objects in a single place so that we can avoid duplicate deserializations?
+  /// @return unique_ptr to deserialized content
   template <class PtrT>
   typename std::enable_if<                                                            //
     std::is_pointer<PtrT>::value == true &&                                           //
@@ -208,9 +246,10 @@ public:
     return std::move(DataRefUtils::as<T>(ref));
   }
 
-  // substitution for container of non-messageable objects with ROOT dictionary
-  // Notice that this will return a copy of the actual contents of the buffer, because
-  // the buffer is actually serialised. The extracted container is returned by std::move
+  /// substitution for container of non-messageable objects with ROOT dictionary
+  /// Notice that this will return a copy of the actual contents of the buffer, because
+  /// the buffer is actually serialised. The extracted container is returned by std::move
+  /// @return std container object
   template <class T>
   typename std::enable_if<is_container<T>::value == true &&          //
                             has_root_dictionary<T>::value == true && //
@@ -224,8 +263,9 @@ public:
     return std::move(*(DataRefUtils::as<T>(ref).release()));
   }
 
-  // substitution for pointer to messageable objects with ROOT dictionary
-  // the operation depends on the transmitted serialization method
+  /// substitution for pointer to messageable objects with ROOT dictionary
+  /// the operation depends on the transmitted serialization method
+  /// @return unique_ptr to deserialized content
   template <typename PtrT>
   typename std::enable_if<std::is_pointer<PtrT>::value == true &&                                           //
                             has_root_dictionary<typename std::remove_pointer<PtrT>::type>::value == true && //

--- a/Framework/Core/test/test_InputRecord.cxx
+++ b/Framework/Core/test/test_InputRecord.cxx
@@ -79,10 +79,12 @@ BOOST_AUTO_TEST_CASE(TestInputRecord) {
   dh1.dataDescription = "CLUSTERS";
   dh1.dataOrigin = "TPC";
   dh1.subSpecification = 0;
+  dh1.payloadSerializationMethod = o2::header::gSerializationMethodNone;
   DataHeader dh2;
   dh2.dataDescription = "CLUSTERS";
   dh2.dataOrigin = "ITS";
   dh2.subSpecification = 0;
+  dh2.payloadSerializationMethod = o2::header::gSerializationMethodNone;
   createMessage(dh1, 1);
   createMessage(dh2, 2);
   InputRecord registry(schema, inputs);

--- a/Framework/Core/test/test_RootTreeReader.cxx
+++ b/Framework/Core/test/test_RootTreeReader.cxx
@@ -89,11 +89,11 @@ DataProcessorSpec getSinkSpec()
     }
     auto data = pc.inputs().get<std::vector<o2::test::Polymorphic>>("input");
 
-    LOG(INFO) << "count: " << counter << "  data elements:" << data->size();
-    ASSERT_ERROR(counter + 1 == data->size());
-    for (int idx = 0; idx < data->size(); idx++) {
-      LOG(INFO) << (*data)[idx].get();
-      ASSERT_ERROR((*data)[idx].get() == 10 * counter + idx);
+    LOG(INFO) << "count: " << counter << "  data elements:" << data.size();
+    ASSERT_ERROR(counter + 1 == data.size());
+    for (int idx = 0; idx < data.size(); idx++) {
+      LOG(INFO) << data[idx].get();
+      ASSERT_ERROR(data[idx].get() == 10 * counter + idx);
     }
     if (++counter >= kTreeSize) {
       pc.services().get<ControlService>().readyToQuit(true);

--- a/Framework/TestWorkflows/src/dataSamplingPodAndRoot.cxx
+++ b/Framework/TestWorkflows/src/dataSamplingPodAndRoot.cxx
@@ -144,7 +144,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
     {},
     AlgorithmSpec{
       [](ProcessingContext& ctx) {
-        auto h = ctx.inputs().get<TH1F>("histos");
+        auto h = ctx.inputs().get<TH1F*>("histos");
         if (h.get() == nullptr) {
           throw std::runtime_error("Missing output");
         }
@@ -154,7 +154,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
                   << "sumw2" << stats[1] << "\n"
                   << "sumwx" << stats[2] << "\n"
                   << "sumwx2" << stats[3] << "\n";
-        auto s = ctx.inputs().get<TObjString>("string");
+        auto s = ctx.inputs().get<TObjString*>("string");
 
         LOG(INFO) << "String is " << s->GetString().Data();
       }
@@ -170,7 +170,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
     Outputs{},
     AlgorithmSpec{
       (AlgorithmSpec::ProcessCallback) [](ProcessingContext& ctx) {
-        auto h = ctx.inputs().get<TH1F>("TST_HISTOS_S");
+        auto h = ctx.inputs().get<TH1F*>("TST_HISTOS_S");
         if (h.get() == nullptr) {
           throw std::runtime_error("Missing TST_HISTOS_S");
         }
@@ -180,7 +180,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
                   << "sumw2" << stats[1] << "\n"
                   << "sumwx" << stats[2] << "\n"
                   << "sumwx2" << stats[3] << "\n";
-        auto s = ctx.inputs().get<TObjString>("TST_STRING_S");
+        auto s = ctx.inputs().get<TObjString*>("TST_STRING_S");
 
         LOG(INFO) << "qcTaskTst: TObjString is " << (std::string("foo") == s->GetString().Data() ? "correct" : "wrong");
       }

--- a/Framework/TestWorkflows/src/dataSamplingPodAndRoot.cxx
+++ b/Framework/TestWorkflows/src/dataSamplingPodAndRoot.cxx
@@ -135,57 +135,50 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
     }
   };
 
-  DataProcessorSpec rootSink{
-    "rootSink",
-    {
-      InputSpec{ "histos", "TST", "HISTOS", 0, Lifetime::Timeframe },
-      InputSpec{ "string", "TST", "STRING", 0, Lifetime::Timeframe },
-    },
-    {},
-    AlgorithmSpec{
-      [](ProcessingContext& ctx) {
-        auto h = ctx.inputs().get<TH1F*>("histos");
-        if (h.get() == nullptr) {
-          throw std::runtime_error("Missing output");
-        }
-        Double_t stats[4];
-        h->GetStats(stats);
-        LOG(INFO) << "sumw" << stats[0] << "\n"
-                  << "sumw2" << stats[1] << "\n"
-                  << "sumwx" << stats[2] << "\n"
-                  << "sumwx2" << stats[3] << "\n";
-        auto s = ctx.inputs().get<TObjString*>("string");
+  DataProcessorSpec rootSink{ "rootSink",
+                              {
+                                InputSpec{ "histos", "TST", "HISTOS", 0, Lifetime::Timeframe },
+                                InputSpec{ "string", "TST", "STRING", 0, Lifetime::Timeframe },
+                              },
+                              {},
+                              AlgorithmSpec{ [](ProcessingContext& ctx) {
+                                auto h = ctx.inputs().get<TH1F*>("histos");
+                                if (h.get() == nullptr) {
+                                  throw std::runtime_error("Missing output");
+                                }
+                                Double_t stats[4];
+                                h->GetStats(stats);
+                                LOG(INFO) << "sumw" << stats[0] << "\n"
+                                          << "sumw2" << stats[1] << "\n"
+                                          << "sumwx" << stats[2] << "\n"
+                                          << "sumwx2" << stats[3] << "\n";
+                                auto s = ctx.inputs().get<TObjString*>("string");
 
-        LOG(INFO) << "String is " << s->GetString().Data();
-      }
-    }
-  };
+                                LOG(INFO) << "String is " << s->GetString().Data();
+                              } } };
 
-  DataProcessorSpec rootQcTask{
-    "rootQcTask",
-    {
-      InputSpec{ "TST_HISTOS_S", "TST", "HISTOS_S", 0, Lifetime::Timeframe },
-      InputSpec{ "TST_STRING_S", "TST", "STRING_S", 0, Lifetime::Timeframe },
-    },
-    Outputs{},
-    AlgorithmSpec{
-      (AlgorithmSpec::ProcessCallback) [](ProcessingContext& ctx) {
-        auto h = ctx.inputs().get<TH1F*>("TST_HISTOS_S");
-        if (h.get() == nullptr) {
-          throw std::runtime_error("Missing TST_HISTOS_S");
-        }
-        Double_t stats[4];
-        h->GetStats(stats);
-        LOG(INFO) << "sumw" << stats[0] << "\n"
-                  << "sumw2" << stats[1] << "\n"
-                  << "sumwx" << stats[2] << "\n"
-                  << "sumwx2" << stats[3] << "\n";
-        auto s = ctx.inputs().get<TObjString*>("TST_STRING_S");
+  DataProcessorSpec rootQcTask{ "rootQcTask",
+                                {
+                                  InputSpec{ "TST_HISTOS_S", "TST", "HISTOS_S", 0, Lifetime::Timeframe },
+                                  InputSpec{ "TST_STRING_S", "TST", "STRING_S", 0, Lifetime::Timeframe },
+                                },
+                                Outputs{},
+                                AlgorithmSpec{ [](ProcessingContext& ctx) {
+                                  auto h = ctx.inputs().get<TH1F*>("TST_HISTOS_S");
+                                  if (h.get() == nullptr) {
+                                    throw std::runtime_error("Missing TST_HISTOS_S");
+                                  }
+                                  Double_t stats[4];
+                                  h->GetStats(stats);
+                                  LOG(INFO) << "sumw" << stats[0] << "\n"
+                                            << "sumw2" << stats[1] << "\n"
+                                            << "sumwx" << stats[2] << "\n"
+                                            << "sumwx2" << stats[3] << "\n";
+                                  auto s = ctx.inputs().get<TObjString*>("TST_STRING_S");
 
-        LOG(INFO) << "qcTaskTst: TObjString is " << (std::string("foo") == s->GetString().Data() ? "correct" : "wrong");
-      }
-    }
-  };
+                                  LOG(INFO) << "qcTaskTst: TObjString is "
+                                            << (std::string("foo") == s->GetString().Data() ? "correct" : "wrong");
+                                } } };
 
   specs.push_back(podDataProducer);
   specs.push_back(processingStage);

--- a/Framework/TestWorkflows/src/test_o2RootMessageWorkflow.cxx
+++ b/Framework/TestWorkflows/src/test_o2RootMessageWorkflow.cxx
@@ -63,7 +63,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
           // FIXME: for the moment we need to do the deserialization ourselves.
           //        this should probably be encoded in the serialization field
           //        of the DataHeader and done automatically by the framework
-          auto h = ctx.inputs().get<TH1F>("histos");
+          auto h = ctx.inputs().get<TH1F*>("histos");
           if (h.get() == nullptr) {
             throw std::runtime_error("Missing output");
           }
@@ -73,7 +73,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
                     << "sumw2" << stats[1] << "\n"
                     << "sumwx" << stats[2] << "\n"
                     << "sumwx2" << stats[3] << "\n";
-          auto s = ctx.inputs().get<TObjString>("string");
+          auto s = ctx.inputs().get<TObjString*>("string");
 
           LOG(INFO) << "String is " << s->GetString().Data();
         }

--- a/Framework/TestWorkflows/test/test_MakeDPLObjects.cxx
+++ b/Framework/TestWorkflows/test/test_MakeDPLObjects.cxx
@@ -79,7 +79,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
       AlgorithmSpec{
         [](ProcessingContext &ctx) {
           // A new message with a TH1F inside
-          auto h = ctx.inputs().get<TH1F>("histo");
+          auto h = ctx.inputs().get<TH1F*>("histo");
           // A new message with 1 XYZ instance in it
           XYZ const &x = ctx.inputs().get<XYZ>("point");
           // A new message with a gsl::span<XYZ> with 1000 items
@@ -108,7 +108,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
           assert(c3[999].y == 3);
           assert(c3[999].z == 4);
           ctx.services().get<ControlService>().readyToQuit(true);
-          auto o = ctx.inputs().get<TNamed>("object");
+          auto o = ctx.inputs().get<TNamed*>("object");
           assert(strcmp(o->GetName(), "named") == 0 &&
                  strcmp(o->GetTitle(), "a named test object") == 0);
         }


### PR DESCRIPTION
EDIT: short summary of the discussion over (virtual) coffee and the conclusions.
We consolidate the API, that
- substitutions are always selected by type not by pointer to type
- the consolidated API returns either a smart pointer (both for non-serialized and serialized data) or a container-like object of the requested type, with guaranteed  begin and end methods and iterator functionality.

TODO
- [ ] factor out the `observer_ptr`
- [ ] change the substitution for messageable types to return the `observer_ptr` instead of the reference
- [ ] add substitution for `vector` of messageable objects returning `span`

**ORIGINAL PR description**
Apply a request-pointer-to-get-a-pointer policy for root-serializable objects.
The rule of thumb is now: to get an object with pointer-like behavior as return
one has to specify the pointer to type as template parameter.
    
    What has been changed in practice:
    ==================================
    - support extraction of messageable types with root dictionary by type, now
      a reference is returned to the (catsed) payload content if the type is
      requested
    - all serialized objects extracted by pointer
    - also supporting containers of root-serializable objects by type in
      addition to pointer to type.
    
    In summary
    ==========
    The get<T>(binding) method is by default implemeted for the following types:
     - (a) const char*
     - (b) std::string
     - (c) messageable type T
     - (d) pointer type T* for types with ROOT dictionary or messageable types
     - (e) std container of type T with ROOT dictionary
     - (f) DataRef holding header and payload information, this is also the default
           get method without template parameter
    
    The return type of get<T>(binding) is:
     - (a) const char* to payload content
     - (b) std::string copy of the payload
     - (c) const ref for messageable types T, the payload content casted to the type
     - (d) object with pointer-like behavior (unique_ptr) if T* specified
     - (e) std::container object returned by std::move
    
    Additional check:
    =================
    - checking serialization type when extracting messageable object by type
      to return a valid reference

A somehow bigger clang format was triggered by small changes, leaving it in a separate commit.