### PR TITLE
Fix API issue with Lifetime

### DIFF
--- a/Framework/Core/README.md
+++ b/Framework/Core/README.md
@@ -151,7 +151,7 @@ kind of the produced outputs.
 The `lifetime` property:
 
 ```cpp
-enum Lifetime {
+enum struct Lifetime {
   Timeframe,
   Condition,
   QA,
@@ -489,7 +489,7 @@ parallel devices, this time by modifying programmatically the `Inputs`:
 // ...
 DataProcessorSpec{
   "merger",
-  mergeInputs({"a", "TST", "A", InputSpec::Timeframe},
+  mergeInputs({"a", "TST", "A", 0, Lifetime::Timeframe},
               4,
               [](InputSpec &input, size_t index) {
                  input.subSpec = index;

--- a/Framework/Core/include/Framework/Dispatcher.h
+++ b/Framework/Core/include/Framework/Dispatcher.h
@@ -89,8 +89,7 @@ class Dispatcher
       description.str[len + 1] = 'S';
     }
 
-    return OutputSpec{ dispatcherInput.origin, description, 0,
-                       static_cast<OutputSpec::Lifetime>(dispatcherInput.lifetime) };
+    return OutputSpec{ dispatcherInput.origin, description, 0, dispatcherInput.lifetime };
   }
 
  protected:

--- a/Framework/Core/include/Framework/Lifetime.h
+++ b/Framework/Core/include/Framework/Lifetime.h
@@ -7,25 +7,19 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#ifndef FRAMEWORK_INPUTSPEC_H
-#define FRAMEWORK_INPUTSPEC_H
-
-#include <string>
-#include "Framework/Lifetime.h"
-#include "Headers/DataHeader.h"
+#ifndef FRAMEWORK_LIFETIME_H
+#define FRAMEWORK_LIFETIME_H
 
 namespace o2 {
 namespace framework {
 
-/// A selector for some kind of data being processed, either in
-/// input or in output. This can be used, for example to match
-/// specific payloads in a timeframe.
-struct InputSpec {
-  std::string binding;
-  header::DataOrigin origin;
-  header::DataDescription description;
-  header::DataHeader::SubSpecificationType subSpec = 0;
-  enum Lifetime lifetime = Lifetime::Timeframe;
+/// Possible Lifetime of objects being exchanged by the DPL.
+/// FIXME: currently only Timeframe behaves as expected.
+enum struct Lifetime {
+  Timeframe,
+  Condition,
+  QA,
+  Transient
 };
 
 }

--- a/Framework/Core/include/Framework/OutputSpec.h
+++ b/Framework/Core/include/Framework/OutputSpec.h
@@ -11,6 +11,7 @@
 #define FRAMEWORK_OUTPUTSPEC_H
 
 #include "Headers/DataHeader.h"
+#include "Framework/Lifetime.h"
 
 namespace o2 {
 namespace framework {
@@ -19,18 +20,10 @@ namespace framework {
 /// input or in output. This can be used, for example to match
 /// specific payloads in a timeframe.
 struct OutputSpec {
-  /// The lifetime of objects being referred here.
-  enum Lifetime {
-    Timeframe,
-    Condition,
-    QA,
-    Transient
-  };
-
   header::DataOrigin origin;
   header::DataDescription description;
-  header::DataHeader::SubSpecificationType subSpec;
-  enum Lifetime lifetime;
+  header::DataHeader::SubSpecificationType subSpec = 0;
+  enum Lifetime lifetime = Lifetime::Timeframe;
 
   bool operator==(const OutputSpec& that)
   {

--- a/Framework/Core/src/DispatcherDPL.cxx
+++ b/Framework/Core/src/DispatcherDPL.cxx
@@ -68,7 +68,7 @@ void DispatcherDPL::addSource(const DataProcessorSpec& externalDataProcessor, co
     externalOutput.origin,
     externalOutput.description,
     externalOutput.subSpec,
-    static_cast<InputSpec::Lifetime>(externalOutput.lifetime),
+    externalOutput.lifetime
   };
 
   mDataProcessorSpec.inputs.push_back(newInput);

--- a/Framework/Core/src/DispatcherFairMQ.cxx
+++ b/Framework/Core/src/DispatcherFairMQ.cxx
@@ -85,7 +85,7 @@ void DispatcherFairMQ::addSource(const DataProcessorSpec& externalDataProcessor,
     externalOutput.origin,
     externalOutput.description,
     externalOutput.subSpec,
-    static_cast<InputSpec::Lifetime>(externalOutput.lifetime),
+    externalOutput.lifetime
   };
 
   mDataProcessorSpec.inputs.push_back(newInput);

--- a/Framework/Core/src/DispatcherFlpProto.cxx
+++ b/Framework/Core/src/DispatcherFlpProto.cxx
@@ -119,7 +119,7 @@ void DispatcherFlpProto::addSource(const DataProcessorSpec& externalDataProcesso
     externalOutput.origin,
     externalOutput.description,
     externalOutput.subSpec,
-    static_cast<InputSpec::Lifetime>(externalOutput.lifetime),
+    externalOutput.lifetime
   };
 
   mDataProcessorSpec.inputs.push_back(newInput);

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -120,7 +120,7 @@ WorkflowHelpers::constructGraph(const WorkflowSpec &workflow,
   // Notice that if the output is actually a forward, we need to store that
   // information so that when we add it at device level we know which output
   // channel we need to connect it too.
-  auto hasMatchingOutputFor = [&workflow, &constOutputs, 
+  auto hasMatchingOutputFor = [&workflow, &constOutputs,
                                &availableOutputsInfo, &oif,
                                &forwardedInputsInfo](size_t ci, size_t ii) {
     assert(ci < workflow.size());

--- a/Framework/Core/test/test_DataAllocator.cxx
+++ b/Framework/Core/test/test_DataAllocator.cxx
@@ -22,19 +22,7 @@
 #include "FairMQLogger.h"
 #include <vector>
 
-using DataProcessorSpec = o2::framework::DataProcessorSpec;
-using WorkflowSpec = o2::framework::WorkflowSpec;
-using ProcessingContext = o2::framework::ProcessingContext;
-using OutputSpec = o2::framework::OutputSpec;
-using InputSpec = o2::framework::InputSpec;
-using Inputs = o2::framework::Inputs;
-using Outputs = o2::framework::Outputs;
-using AlgorithmSpec = o2::framework::AlgorithmSpec;
-using InitContext = o2::framework::InitContext;
-using ProcessingContext = o2::framework::ProcessingContext;
-using DataRef = o2::framework::DataRef;
-using DataRefUtils = o2::framework::DataRefUtils;
-using ControlService = o2::framework::ControlService;
+using namespace o2::framework;
 
 #define ASSERT_ERROR(condition)                                   \
   if ((condition) == false) {                                     \
@@ -46,7 +34,7 @@ DataProcessorSpec getTimeoutSpec()
   // a timer process to terminate the workflow after a timeout
   auto processingFct = [](ProcessingContext& pc) {
     static int counter = 0;
-    pc.outputs().snapshot(OutputSpec{ "TST", "TIMER", 0, OutputSpec::Timeframe }, counter);
+    pc.outputs().snapshot(OutputSpec{ "TST", "TIMER", 0, Lifetime::Timeframe }, counter);
 
     sleep(1);
     if (counter++ > 10) {
@@ -57,7 +45,7 @@ DataProcessorSpec getTimeoutSpec()
 
   return DataProcessorSpec{ "timer",  // name of the processor
                             Inputs{}, // inputs empty
-                            { OutputSpec{ "TST", "TIMER", 0, OutputSpec::Timeframe } },
+                            { OutputSpec{ "TST", "TIMER", 0, Lifetime::Timeframe } },
                             AlgorithmSpec(processingFct) };
 }
 
@@ -70,32 +58,32 @@ DataProcessorSpec getSourceSpec()
     std::vector<o2::test::Polymorphic> c{ { 0xaffe }, { 0xd00f } };
     // class TriviallyCopyable is both messageable and has a dictionary, the default
     // picked by the framework is no serialization
-    pc.outputs().snapshot(OutputSpec{ "TST", "MESSAGEABLE", 0, OutputSpec::Timeframe }, a);
-    pc.outputs().snapshot(OutputSpec{ "TST", "MSGBLEROOTSRLZ", 0, OutputSpec::Timeframe },
+    pc.outputs().snapshot(OutputSpec{ "TST", "MESSAGEABLE", 0, Lifetime::Timeframe }, a);
+    pc.outputs().snapshot(OutputSpec{ "TST", "MSGBLEROOTSRLZ", 0, Lifetime::Timeframe },
                           o2::framework::ROOTSerialized<decltype(a)>(a));
     // class Polymorphic is not messageable, so the serialization type is deduced
     // from the fact that the type has a dictionary and can be ROOT-serialized.
-    pc.outputs().snapshot(OutputSpec{ "TST", "ROOTNONTOBJECT", 0, OutputSpec::Timeframe }, b);
+    pc.outputs().snapshot(OutputSpec{ "TST", "ROOTNONTOBJECT", 0, Lifetime::Timeframe }, b);
     // vector of ROOT serializable class
-    pc.outputs().snapshot(OutputSpec{ "TST", "ROOTVECTOR", 0, OutputSpec::Timeframe }, c);
+    pc.outputs().snapshot(OutputSpec{ "TST", "ROOTVECTOR", 0, Lifetime::Timeframe }, c);
     // likewise, passed anonymously with char type and class name
     o2::framework::ROOTSerialized<char, const char> d(*((char*)&c), "vector<o2::test::Polymorphic>");
-    pc.outputs().snapshot(OutputSpec{ "TST", "ROOTSERLZDVEC", 0, OutputSpec::Timeframe }, d);
+    pc.outputs().snapshot(OutputSpec{ "TST", "ROOTSERLZDVEC", 0, Lifetime::Timeframe }, d);
     // vector of ROOT serializable class wrapped with TClass info as hint
     auto* cl = TClass::GetClass(typeid(decltype(c)));
     ASSERT_ERROR(cl != nullptr);
     o2::framework::ROOTSerialized<char, TClass> e(*((char*)&c), cl);
-    pc.outputs().snapshot(OutputSpec{ "TST", "ROOTSERLZDVEC2", 0, OutputSpec::Timeframe }, e);
+    pc.outputs().snapshot(OutputSpec{ "TST", "ROOTSERLZDVEC2", 0, Lifetime::Timeframe }, e);
   };
 
   return DataProcessorSpec{ "source", // name of the processor
-                            { InputSpec{ "timer", "TST", "TIMER", 0, InputSpec::Timeframe } },
-                            { OutputSpec{ "TST", "MESSAGEABLE", 0, OutputSpec::Timeframe },
-                              OutputSpec{ "TST", "MSGBLEROOTSRLZ", 0, OutputSpec::Timeframe },
-                              OutputSpec{ "TST", "ROOTNONTOBJECT", 0, OutputSpec::Timeframe },
-                              OutputSpec{ "TST", "ROOTVECTOR", 0, OutputSpec::Timeframe },
-                              OutputSpec{ "TST", "ROOTSERLZDVEC", 0, OutputSpec::Timeframe },
-                              OutputSpec{ "TST", "ROOTSERLZDVEC2", 0, OutputSpec::Timeframe } },
+                            { InputSpec{ "timer", "TST", "TIMER", 0, Lifetime::Timeframe } },
+                            { OutputSpec{ "TST", "MESSAGEABLE", 0, Lifetime::Timeframe },
+                              OutputSpec{ "TST", "MSGBLEROOTSRLZ", 0, Lifetime::Timeframe },
+                              OutputSpec{ "TST", "ROOTNONTOBJECT", 0, Lifetime::Timeframe },
+                              OutputSpec{ "TST", "ROOTVECTOR", 0, Lifetime::Timeframe },
+                              OutputSpec{ "TST", "ROOTSERLZDVEC", 0, Lifetime::Timeframe },
+                              OutputSpec{ "TST", "ROOTSERLZDVEC2", 0, Lifetime::Timeframe } },
                             AlgorithmSpec(processingFct) };
 }
 
@@ -139,12 +127,12 @@ DataProcessorSpec getSinkSpec()
   };
 
   return DataProcessorSpec{ "sink", // name of the processor
-                            { InputSpec{ "input1", "TST", "MESSAGEABLE", 0, InputSpec::Timeframe },
-                              InputSpec{ "input2", "TST", "MSGBLEROOTSRLZ", 0, InputSpec::Timeframe },
-                              InputSpec{ "input3", "TST", "ROOTNONTOBJECT", 0, InputSpec::Timeframe },
-                              InputSpec{ "input4", "TST", "ROOTVECTOR", 0, InputSpec::Timeframe },
-                              InputSpec{ "input5", "TST", "ROOTSERLZDVEC", 0, InputSpec::Timeframe },
-                              InputSpec{ "input6", "TST", "ROOTSERLZDVEC2", 0, InputSpec::Timeframe } },
+                            { InputSpec{ "input1", "TST", "MESSAGEABLE", 0, Lifetime::Timeframe },
+                              InputSpec{ "input2", "TST", "MSGBLEROOTSRLZ", 0, Lifetime::Timeframe },
+                              InputSpec{ "input3", "TST", "ROOTNONTOBJECT", 0, Lifetime::Timeframe },
+                              InputSpec{ "input4", "TST", "ROOTVECTOR", 0, Lifetime::Timeframe },
+                              InputSpec{ "input5", "TST", "ROOTSERLZDVEC", 0, Lifetime::Timeframe },
+                              InputSpec{ "input6", "TST", "ROOTSERLZDVEC2", 0, Lifetime::Timeframe } },
                             Outputs{},
                             AlgorithmSpec(processingFct) };
 }

--- a/Framework/Core/test/test_DataRelayer.cxx
+++ b/Framework/Core/test/test_DataRelayer.cxx
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE(TestNoWait) {
   spec.description = "CLUSTERS";
   spec.origin = "TPC";
   spec.subSpec = 0;
-  spec.lifetime = InputSpec::Timeframe;
+  spec.lifetime = Lifetime::Timeframe;
 
   InputRoute route;
   route.sourceChannel = "Fake";
@@ -77,14 +77,14 @@ BOOST_AUTO_TEST_CASE(TestRelay) {
   spec1.description = "CLUSTERS";
   spec1.origin = "TPC";
   spec1.subSpec = 0;
-  spec1.lifetime = InputSpec::Timeframe;
+  spec1.lifetime = Lifetime::Timeframe;
 
   InputSpec spec2;
   spec2.binding = "clusters_its";
   spec2.description = "CLUSTERS";
   spec2.origin = "ITS";
   spec2.subSpec = 0;
-  spec2.lifetime = InputSpec::Timeframe;
+  spec2.lifetime = Lifetime::Timeframe;
 
   InputRoute route1;
   route1.sourceChannel = "Fake";
@@ -145,7 +145,7 @@ BOOST_AUTO_TEST_CASE(TestCache) {
   spec.description = "CLUSTERS";
   spec.origin = "TPC";
   spec.subSpec = 0;
-  spec.lifetime = InputSpec::Timeframe;
+  spec.lifetime = Lifetime::Timeframe;
 
   InputRoute route;
   route.sourceChannel = "Fake";

--- a/Framework/Core/test/test_DataSampling.cxx
+++ b/Framework/Core/test/test_DataSampling.cxx
@@ -28,7 +28,7 @@ BOOST_AUTO_TEST_CASE(DataSamplingSimpleFlow)
       "producer",
       Inputs{},
       {
-        OutputSpec{"TPC", "CLUSTERS", 0, OutputSpec::Timeframe}
+        OutputSpec{"TPC", "CLUSTERS", 0, Lifetime::Timeframe}
       },
       AlgorithmSpec{
         [](ProcessingContext& ctx) {}
@@ -37,10 +37,10 @@ BOOST_AUTO_TEST_CASE(DataSamplingSimpleFlow)
     {
       "processingStage",
       Inputs{
-        {"dataTPC", "TPC", "CLUSTERS", 0, InputSpec::Timeframe}
+        {"dataTPC", "TPC", "CLUSTERS", 0, Lifetime::Timeframe}
       },
       Outputs{
-        {"TPC", "CLUSTERS_P", 0, OutputSpec::Timeframe}
+        {"TPC", "CLUSTERS_P", 0, Lifetime::Timeframe}
       },
       AlgorithmSpec{
         [](ProcessingContext& ctx) {}
@@ -49,8 +49,8 @@ BOOST_AUTO_TEST_CASE(DataSamplingSimpleFlow)
     {
       "qcTaskTpc",
       Inputs{
-        {"TPC_CLUSTERS_S",   "TPC", "CLUSTERS_S",   0, InputSpec::Timeframe},
-        {"TPC_CLUSTERS_P_S", "TPC", "CLUSTERS_P_S", 0, InputSpec::Timeframe}
+        {"TPC_CLUSTERS_S",   "TPC", "CLUSTERS_S"},
+        {"TPC_CLUSTERS_P_S", "TPC", "CLUSTERS_P_S"}
       },
       Outputs{},
       AlgorithmSpec{
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE(DataSamplingSimpleFlow)
                                      in.origin == DataOrigin("TPC") &&
                                      in.description == DataDescription("CLUSTERS") &&
                                      in.subSpec == 0 &&
-                                     in.lifetime == InputSpec::Timeframe;
+                                     in.lifetime == Lifetime::Timeframe;
                             });
   BOOST_CHECK(input != disp->inputs.end());
 
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(DataSamplingSimpleFlow)
                                 in.origin == DataOrigin("TPC") &&
                                 in.description == DataDescription("CLUSTERS_P") &&
                                 in.subSpec == 0 &&
-                                in.lifetime == InputSpec::Timeframe;
+                                in.lifetime == Lifetime::Timeframe;
                        });
   BOOST_CHECK(input != disp->inputs.end());
 
@@ -93,7 +93,7 @@ BOOST_AUTO_TEST_CASE(DataSamplingSimpleFlow)
                                return out.origin == DataOrigin("TPC") &&
                                       out.description == DataDescription("CLUSTERS_P_S") &&
                                       out.subSpec == 0 &&
-                                      out.lifetime == OutputSpec::Timeframe;
+                                      out.lifetime == Lifetime::Timeframe;
                              });
   BOOST_CHECK(output != disp->outputs.end());
 
@@ -102,7 +102,7 @@ BOOST_AUTO_TEST_CASE(DataSamplingSimpleFlow)
                           return out.origin == DataOrigin("TPC") &&
                                  out.description == DataDescription("CLUSTERS_S") &&
                                  out.subSpec == 0 &&
-                                 out.lifetime == OutputSpec::Timeframe;
+                                 out.lifetime == Lifetime::Timeframe;
                         });
   BOOST_CHECK(output != disp->outputs.end());
 
@@ -117,9 +117,9 @@ BOOST_AUTO_TEST_CASE(DataSamplingParallelFlow)
       "producer",
       Inputs{},
       {
-        OutputSpec{"TPC", "CLUSTERS", 0, OutputSpec::Timeframe},
-        OutputSpec{"TPC", "CLUSTERS", 1, OutputSpec::Timeframe},
-        OutputSpec{"TPC", "CLUSTERS", 2, OutputSpec::Timeframe}
+        OutputSpec{"TPC", "CLUSTERS", 0, Lifetime::Timeframe},
+        OutputSpec{"TPC", "CLUSTERS", 1, Lifetime::Timeframe},
+        OutputSpec{"TPC", "CLUSTERS", 2, Lifetime::Timeframe}
       },
       AlgorithmSpec{
         [](ProcessingContext& ctx) {}
@@ -128,8 +128,8 @@ BOOST_AUTO_TEST_CASE(DataSamplingParallelFlow)
     {
       "qcTaskTpc",
       Inputs{
-        {"TPC_CLUSTERS_S",   "TPC", "CLUSTERS_S",   0, InputSpec::Timeframe},
-        {"TPC_CLUSTERS_P_S", "TPC", "CLUSTERS_P_S", 0, InputSpec::Timeframe}
+        {"TPC_CLUSTERS_S",   "TPC", "CLUSTERS_S",   0},
+        {"TPC_CLUSTERS_P_S", "TPC", "CLUSTERS_P_S", 0}
       },
       Outputs{},
       AlgorithmSpec{
@@ -142,10 +142,10 @@ BOOST_AUTO_TEST_CASE(DataSamplingParallelFlow)
     DataProcessorSpec{
       "processingStage",
       Inputs{
-        {"dataTPC", "TPC", "CLUSTERS", InputSpec::Timeframe}
+        {"dataTPC", "TPC", "CLUSTERS"}
       },
       Outputs{
-        {"TPC", "CLUSTERS_P", OutputSpec::Timeframe}
+        {"TPC", "CLUSTERS_P"}
       },
       AlgorithmSpec{
         [](ProcessingContext& ctx) {}
@@ -176,7 +176,7 @@ BOOST_AUTO_TEST_CASE(DataSamplingParallelFlow)
                                        in.origin == DataOrigin("TPC") &&
                                        in.description == DataDescription("CLUSTERS") &&
                                        in.subSpec == i &&
-                                       in.lifetime == InputSpec::Timeframe;
+                                       in.lifetime == Lifetime::Timeframe;
                               });
     BOOST_CHECK(input != disp->inputs.end());
 
@@ -186,7 +186,7 @@ BOOST_AUTO_TEST_CASE(DataSamplingParallelFlow)
                                   in.origin == DataOrigin("TPC") &&
                                   in.description == DataDescription("CLUSTERS_P") &&
                                   in.subSpec == i &&
-                                  in.lifetime == InputSpec::Timeframe;
+                                  in.lifetime == Lifetime::Timeframe;
                          });
     BOOST_CHECK(input != disp->inputs.end());
 
@@ -195,7 +195,7 @@ BOOST_AUTO_TEST_CASE(DataSamplingParallelFlow)
                                  return out.origin == DataOrigin("TPC") &&
                                         out.description == DataDescription("CLUSTERS_P_S") &&
                                         out.subSpec == 0 &&
-                                        out.lifetime == OutputSpec::Timeframe;
+                                        out.lifetime == Lifetime::Timeframe;
                                });
     BOOST_CHECK(output != disp->outputs.end());
 
@@ -204,7 +204,7 @@ BOOST_AUTO_TEST_CASE(DataSamplingParallelFlow)
                             return out.origin == DataOrigin("TPC") &&
                                    out.description == DataDescription("CLUSTERS_S") &&
                                    out.subSpec == 0 &&
-                                   out.lifetime == OutputSpec::Timeframe;
+                                   out.lifetime == Lifetime::Timeframe;
                           });
     BOOST_CHECK(output != disp->outputs.end());
 
@@ -220,7 +220,7 @@ BOOST_AUTO_TEST_CASE(DataSamplingTimePipelineFlow)
       "producer",
       Inputs{},
       {
-        OutputSpec{"TPC", "CLUSTERS", 0, OutputSpec::Timeframe}
+        OutputSpec{"TPC", "CLUSTERS", 0, Lifetime::Timeframe}
       },
       AlgorithmSpec{
         [](ProcessingContext& ctx) {}
@@ -230,10 +230,10 @@ BOOST_AUTO_TEST_CASE(DataSamplingTimePipelineFlow)
       DataProcessorSpec{
         "processingStage",
         Inputs{
-          {"dataTPC", "TPC", "CLUSTERS", 0, InputSpec::Timeframe}
+          {"dataTPC", "TPC", "CLUSTERS", 0, Lifetime::Timeframe}
         },
         Outputs{
-          {"TPC", "CLUSTERS_P", 0, OutputSpec::Timeframe}
+          {"TPC", "CLUSTERS_P", 0, Lifetime::Timeframe}
         },
         AlgorithmSpec{
           [](ProcessingContext& ctx) {}
@@ -242,8 +242,8 @@ BOOST_AUTO_TEST_CASE(DataSamplingTimePipelineFlow)
     {
       "qcTaskTpc",
       Inputs{
-        {"TPC_CLUSTERS_S",   "TPC", "CLUSTERS_S",   0, InputSpec::Timeframe},
-        {"TPC_CLUSTERS_P_S", "TPC", "CLUSTERS_P_S", 0, InputSpec::Timeframe}
+        {"TPC_CLUSTERS_S",   "TPC", "CLUSTERS_S",   0, Lifetime::Timeframe},
+        {"TPC_CLUSTERS_P_S", "TPC", "CLUSTERS_P_S", 0, Lifetime::Timeframe}
       },
       Outputs{},
       AlgorithmSpec{
@@ -285,7 +285,7 @@ BOOST_AUTO_TEST_CASE(DataSamplingFairMq)
                                return out.origin == DataOrigin("TPC") &&
                                       out.description == DataDescription("RAWDATA") &&
                                       out.subSpec == 0 &&
-                                      out.lifetime == OutputSpec::Timeframe;
+                                      out.lifetime == Lifetime::Timeframe;
                              });
   BOOST_CHECK(output != fairMqProxy->outputs.end());
 
@@ -301,7 +301,7 @@ BOOST_AUTO_TEST_CASE(DataSamplingFairMq)
                                      in.origin == DataOrigin("TPC") &&
                                      in.description == DataDescription("RAWDATA") &&
                                      in.subSpec == 0 &&
-                                     in.lifetime == InputSpec::Timeframe;
+                                     in.lifetime == Lifetime::Timeframe;
                             });
   BOOST_CHECK(input != disp->inputs.end());
   BOOST_CHECK_EQUAL(disp->outputs.size(), 0);

--- a/Framework/Core/test/test_DeviceSpec.cxx
+++ b/Framework/Core/test/test_DeviceSpec.cxx
@@ -25,11 +25,11 @@ using namespace o2::framework;
 WorkflowSpec defineDataProcessing1()
 {
   return { { "A", Inputs{},
-             Outputs{ OutputSpec{ "TST", "A1", OutputSpec::Timeframe },
-                      OutputSpec{ "TST", "A2", OutputSpec::Timeframe } } },
+             Outputs{ OutputSpec{ "TST", "A1" },
+                      OutputSpec{ "TST", "A2" } } },
            {
              "B",
-             Inputs{ InputSpec{ "a", "TST", "A1", InputSpec::Timeframe } },
+             Inputs{ InputSpec{ "a", "TST", "A1" } },
            } };
 }
 
@@ -95,13 +95,13 @@ BOOST_AUTO_TEST_CASE(TestDeviceSpec1PushPull)
 WorkflowSpec defineDataProcessing2()
 {
   return { { "A", Inputs{},
-             Outputs{ OutputSpec{ "TST", "A1", OutputSpec::Timeframe },
-                      OutputSpec{ "TST", "A2", OutputSpec::Timeframe } } },
+             Outputs{ OutputSpec{ "TST", "A1" },
+                      OutputSpec{ "TST", "A2" } } },
            {
              "B",
              Inputs{
-               InputSpec{ "a", "TST", "A1", InputSpec::Timeframe },
-               InputSpec{ "b", "TST", "A2", InputSpec::Timeframe },
+               InputSpec{ "a", "TST", "A1" },
+               InputSpec{ "b", "TST", "A2" },
              },
            } };
 }
@@ -132,16 +132,16 @@ BOOST_AUTO_TEST_CASE(TestDeviceSpec2)
 WorkflowSpec defineDataProcessing3()
 {
   return { { "A", Inputs{},
-             Outputs{ OutputSpec{ "TST", "A1", OutputSpec::Timeframe },
-                      OutputSpec{ "TST", "A2", OutputSpec::Timeframe } } },
+             Outputs{ OutputSpec{ "TST", "A1" },
+                      OutputSpec{ "TST", "A2" } } },
            {
              "B",
              Inputs{
-               InputSpec{ "a", "TST", "A1", InputSpec::Timeframe },
+               InputSpec{ "a", "TST", "A1" },
              },
            },
            { "C", Inputs{
-                    InputSpec{ "a", "TST", "A2", InputSpec::Timeframe },
+                    InputSpec{ "a", "TST", "A2" },
                   } } };
 }
 
@@ -180,14 +180,14 @@ BOOST_AUTO_TEST_CASE(TestDeviceSpec3)
 WorkflowSpec defineDataProcessing4()
 {
   return { { "A", Inputs{},
-             Outputs{ OutputSpec{ "TST", "A1", OutputSpec::Timeframe },
-                      OutputSpec{ "TST", "A2", OutputSpec::Timeframe } } },
-           { "B", Inputs{ InputSpec{ "input", "TST", "A1", InputSpec::Timeframe } },
-             Outputs{ OutputSpec{ "TST", "B1", OutputSpec::Timeframe } } },
-           { "C", Inputs{ InputSpec{ "input", "TST", "A2", InputSpec::Timeframe } },
-             Outputs{ OutputSpec{ "TST", "C1", OutputSpec::Timeframe } } },
-           { "D", Inputs{ InputSpec{ "a", "TST", "B1", InputSpec::Timeframe },
-                          InputSpec{ "b", "TST", "C1", InputSpec::Timeframe } } } };
+             Outputs{ OutputSpec{ "TST", "A1" },
+                      OutputSpec{ "TST", "A2" } } },
+           { "B", Inputs{ InputSpec{ "input", "TST", "A1" } },
+             Outputs{ OutputSpec{ "TST", "B1" } } },
+           { "C", Inputs{ InputSpec{ "input", "TST", "A2" } },
+             Outputs{ OutputSpec{ "TST", "C1" } } },
+           { "D", Inputs{ InputSpec{ "a", "TST", "B1" },
+                          InputSpec{ "b", "TST", "C1" } } } };
 }
 
 BOOST_AUTO_TEST_CASE(TestDeviceSpec4)
@@ -245,14 +245,14 @@ BOOST_AUTO_TEST_CASE(TestDeviceSpec4)
 // need to forward (assuming we are in shared memory).
 WorkflowSpec defineDataProcessing5()
 {
-  return { { "A", Inputs{}, Outputs{ OutputSpec{ "TST", "A1", OutputSpec::Timeframe } } },
+  return { { "A", Inputs{}, Outputs{ OutputSpec{ "TST", "A1" } } },
            {
              "B",
-             Inputs{ InputSpec{ "x", "TST", "A1", InputSpec::Timeframe } },
+             Inputs{ InputSpec{ "x", "TST", "A1" } },
            },
            {
              "C",
-             Inputs{ InputSpec{ "y", "TST", "A1", InputSpec::Timeframe } },
+             Inputs{ InputSpec{ "y", "TST", "A1" } },
            } };
 }
 
@@ -309,23 +309,23 @@ BOOST_AUTO_TEST_CASE(TestTopologyForwarding)
 // need to forward (assuming we are in shared memory).
 WorkflowSpec defineDataProcessing6()
 {
-  return { { "A", Inputs{}, Outputs{ OutputSpec{ "TST", "A1", OutputSpec::Timeframe } } },
-           timePipeline({ "B", Inputs{ InputSpec{ "a", "TST", "A1", InputSpec::Timeframe } } }, 2) };
+  return { { "A", Inputs{}, Outputs{ OutputSpec{ "TST", "A1" } } },
+           timePipeline({ "B", Inputs{ InputSpec{ "a", "TST", "A1" } } }, 2) };
 }
 
 // This is three explicit layers, last two with
 // multiple (non commensurable) timeslice setups.
 WorkflowSpec defineDataProcessing7()
 {
-  return { { "A", Inputs{}, { OutputSpec{ "TST", "A", OutputSpec::Timeframe } } },
+  return { { "A", Inputs{}, { OutputSpec{ "TST", "A" } } },
            timePipeline(
              {
                "B",
-               Inputs{ InputSpec{ "x", "TST", "A", InputSpec::Timeframe } },
-               Outputs{ OutputSpec{ "TST", "B", OutputSpec::Timeframe } },
+               Inputs{ InputSpec{ "x", "TST", "A" } },
+               Outputs{ OutputSpec{ "TST", "B" } },
              },
              3),
-           timePipeline({ "C", Inputs{ InputSpec{ "x", "TST", "B", InputSpec::Timeframe } } }, 2) };
+           timePipeline({ "C", Inputs{ InputSpec{ "x", "TST", "B" } } }, 2) };
 }
 
 BOOST_AUTO_TEST_CASE(TestOutEdgeProcessingHelpers)
@@ -344,8 +344,8 @@ BOOST_AUTO_TEST_CASE(TestOutEdgeProcessingHelpers)
   std::vector<DeviceConnectionId> connections;
   std::vector<LogicalForwardInfo> availableForwardsInfo;
 
-  std::vector<OutputSpec> globalOutputs = { OutputSpec{ "TST", "A", OutputSpec::Timeframe },
-                                            OutputSpec{ "TST", "B", OutputSpec::Timeframe } };
+  std::vector<OutputSpec> globalOutputs = { OutputSpec{ "TST", "A" },
+                                            OutputSpec{ "TST", "B" } };
 
   unsigned short nextPort = 22000;
   std::vector<size_t> edgeOutIndex{ 0, 1, 2, 3, 6, 4, 7, 5, 8 };

--- a/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
+++ b/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
@@ -35,25 +35,25 @@ AlgorithmSpec simplePipe(o2::header::DataDescription what)
 WorkflowSpec defineDataProcessing()
 {
   return { { "A", Inputs{},
-             Outputs{ OutputSpec{ "TST", "A1", OutputSpec::Timeframe },
-                      OutputSpec{ "TST", "A2", OutputSpec::Timeframe } },
+             Outputs{ OutputSpec{ "TST", "A1" },
+                      OutputSpec{ "TST", "A2" } },
              AlgorithmSpec{ [](ProcessingContext& ctx) {
                sleep(1);
                auto aData = ctx.outputs().make<int>(OutputSpec{ "TST", "A1", 0 }, 1);
                auto bData = ctx.outputs().make<int>(OutputSpec{ "TST", "A2", 0 }, 1);
              } } },
            { "B",
-             { InputSpec{ "x", "TST", "A1", InputSpec::Timeframe } },
-             Outputs{ OutputSpec{ "TST", "B1", OutputSpec::Timeframe } },
+             { InputSpec{ "x", "TST", "A1" } },
+             Outputs{ OutputSpec{ "TST", "B1" } },
              simplePipe(o2::header::DataDescription{ "B1" }) },
            { "C",
-             { InputSpec{ "y", "TST", "A2", InputSpec::Timeframe } },
-             Outputs{ OutputSpec{ "TST", "C1", OutputSpec::Timeframe } },
+             { InputSpec{ "y", "TST", "A2" } },
+             Outputs{ OutputSpec{ "TST", "C1" } },
              simplePipe(o2::header::DataDescription{ "C1" }) },
            { "D",
              {
-               InputSpec{ "x", "TST", "B1", InputSpec::Timeframe },
-               InputSpec{ "y", "TST", "C1", InputSpec::Timeframe },
+               InputSpec{ "x", "TST", "B1" },
+               InputSpec{ "y", "TST", "C1" },
              },
              Outputs{},
              AlgorithmSpec{

--- a/Framework/Core/test/test_GenericSource.cxx
+++ b/Framework/Core/test/test_GenericSource.cxx
@@ -18,7 +18,7 @@ void defineDataProcessing(WorkflowSpec &specs) {
     "A",
     Inputs{},
     Outputs{
-      {"TST", "A1", OutputSpec::Timeframe}
+      {"TST", "A1", Lifetime::Timeframe}
     },
     AlgorithmSpec{
       [](const InputRecord &inputs,

--- a/Framework/Core/test/test_Graphviz.cxx
+++ b/Framework/Core/test/test_Graphviz.cxx
@@ -43,16 +43,16 @@ void lineByLineComparision(const std::string& as, const std::string& bs)
 WorkflowSpec defineDataProcessing()
 {
   return { { "A", Inputs{},
-             Outputs{ OutputSpec{ "TST", "A1", OutputSpec::Timeframe },
-                      OutputSpec{ "TST", "A2", OutputSpec::Timeframe } } },
+             Outputs{ OutputSpec{ "TST", "A1" },
+                      OutputSpec{ "TST", "A2" } } },
            { "B",
-             { InputSpec{ "x", "TST", "A1", InputSpec::Timeframe } },
-             Outputs{ OutputSpec{ "TST", "B1", OutputSpec::Timeframe } } },
-           { "C", Inputs{ InputSpec{ "x", "TST", "A2", InputSpec::Timeframe } },
-             Outputs{ OutputSpec{ "TST", "C1", OutputSpec::Timeframe } } },
+             { InputSpec{ "x", "TST", "A1" } },
+             Outputs{ OutputSpec{ "TST", "B1" } } },
+           { "C", Inputs{ InputSpec{ "x", "TST", "A2" } },
+             Outputs{ OutputSpec{ "TST", "C1" } } },
            { "D",
-             Inputs{ InputSpec{ "i1", "TST", "B1", InputSpec::Timeframe },
-                     InputSpec{ "i2", "TST", "C1", InputSpec::Timeframe } },
+             Inputs{ InputSpec{ "i1", "TST", "B1" },
+                     InputSpec{ "i2", "TST", "C1" } },
              Outputs{} } };
 }
 
@@ -62,15 +62,15 @@ WorkflowSpec defineDataProcessing2()
     { "A",
       {},
       {
-        OutputSpec{ "TST", "A", OutputSpec::Timeframe },
+        OutputSpec{ "TST", "A" },
       } },
     timePipeline({ "B",
-                   { InputSpec{ "a", "TST", "A", InputSpec::Timeframe } },
-                   { OutputSpec{ "TST", "B", OutputSpec::Timeframe } } },
+                   { InputSpec{ "a", "TST", "A" } },
+                   { OutputSpec{ "TST", "B" } } },
                  3),
     timePipeline({ "C",
-                   { InputSpec{ "b", "TST", "B", InputSpec::Timeframe } },
-                   { OutputSpec{ "TST", "C", OutputSpec::Timeframe } } },
+                   { InputSpec{ "b", "TST", "B" } },
+                   { OutputSpec{ "TST", "C" } } },
                  2),
   };
 }

--- a/Framework/Core/test/test_InputRecord.cxx
+++ b/Framework/Core/test/test_InputRecord.cxx
@@ -32,14 +32,14 @@ BOOST_AUTO_TEST_CASE(TestInputRecord) {
   spec1.description = "CLUSTERS";
   spec1.origin = "TPC";
   spec1.subSpec = 0;
-  spec1.lifetime = InputSpec::Timeframe;
+  spec1.lifetime = Lifetime::Timeframe;
 
   InputSpec spec2;
   spec2.binding = "y";
   spec2.description = "CLUSTERS";
   spec2.origin = "ITS";
   spec2.subSpec = 0;
-  spec2.lifetime = InputSpec::Timeframe;
+  spec2.lifetime = Lifetime::Timeframe;
 
   auto createRoute = [](const char *source, InputSpec &spec) {
     InputRoute route;

--- a/Framework/Core/test/test_ParallelProducer.cxx
+++ b/Framework/Core/test/test_ParallelProducer.cxx
@@ -22,7 +22,7 @@ DataProcessorSpec templateProducer() {
     "some-producer",
     Inputs{},
     {
-      OutputSpec{"TST", "A", 0, OutputSpec::Timeframe},
+      OutputSpec{"TST", "A", 0, Lifetime::Timeframe},
     },
     // The producer is stateful, we use a static for the state in this
     // particular case, but a Singleton or a captured new object would
@@ -54,7 +54,7 @@ void defineDataProcessing(o2::framework::WorkflowSpec &specs) {
   );
   workflow.push_back(DataProcessorSpec{
       "merger",
-      mergeInputs(InputSpec{"x", "TST", "A", InputSpec::Timeframe},
+      mergeInputs(InputSpec{"x", "TST", "A", 0, Lifetime::Timeframe},
                   4,
                   [](InputSpec &input, size_t index){
                      input.subSpec = index;

--- a/Framework/Core/test/test_RootTreeReader.cxx
+++ b/Framework/Core/test/test_RootTreeReader.cxx
@@ -25,19 +25,7 @@
 #include <TFile.h>
 #include <vector>
 
-using DataProcessorSpec = o2::framework::DataProcessorSpec;
-using WorkflowSpec = o2::framework::WorkflowSpec;
-using ProcessingContext = o2::framework::ProcessingContext;
-using OutputSpec = o2::framework::OutputSpec;
-using InputSpec = o2::framework::InputSpec;
-using Inputs = o2::framework::Inputs;
-using Outputs = o2::framework::Outputs;
-using AlgorithmSpec = o2::framework::AlgorithmSpec;
-using InitContext = o2::framework::InitContext;
-using ProcessingContext = o2::framework::ProcessingContext;
-using DataRef = o2::framework::DataRef;
-using DataRefUtils = o2::framework::DataRefUtils;
-using ControlService = o2::framework::ControlService;
+using namespace o2::framework;
 
 #define ASSERT_ERROR(condition)                                   \
   if ((condition) == false) {                                     \
@@ -71,7 +59,7 @@ DataProcessorSpec getSourceSpec()
       testFile->Close();
     }
 
-    constexpr auto persistency = OutputSpec::Transient;
+    constexpr auto persistency = Lifetime::Transient;
     using TreeReader = o2::framework::RootTreeReader<OutputSpec>;
     auto reader = std::make_shared<TreeReader>("testtree",       // tree name
                                                fileName.c_str(), // input file name
@@ -86,7 +74,7 @@ DataProcessorSpec getSourceSpec()
 
   return DataProcessorSpec{ "source", // name of the processor
                             {},
-                            { OutputSpec{ "TST", "ARRAYOFDATA", 0, OutputSpec::Timeframe } },
+                            { OutputSpec{ "TST", "ARRAYOFDATA"} },
                             AlgorithmSpec(initFct) };
 }
 
@@ -113,7 +101,7 @@ DataProcessorSpec getSinkSpec()
   };
 
   return DataProcessorSpec{ "sink", // name of the processor
-                            { InputSpec{ "input", "TST", "ARRAYOFDATA", 0, InputSpec::Timeframe } },
+                            { InputSpec{ "input", "TST", "ARRAYOFDATA" } },
                             Outputs{},
                             AlgorithmSpec(processingFct) };
 }

--- a/Framework/Core/test/test_SimpleDataProcessingDevice01.cxx
+++ b/Framework/Core/test/test_SimpleDataProcessingDevice01.cxx
@@ -36,8 +36,8 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
     "simple",
     Inputs{},
     {
-      OutputSpec{"TPC", "CLUSTERS", OutputSpec::Timeframe},
-      OutputSpec{"ITS", "CLUSTERS", OutputSpec::Timeframe}
+      OutputSpec{"TPC", "CLUSTERS"},
+      OutputSpec{"ITS", "CLUSTERS"}
     },
     AlgorithmSpec{
       [](ProcessingContext &ctx) {

--- a/Framework/Core/test/test_SimpleStatefulProcessing01.cxx
+++ b/Framework/Core/test/test_SimpleStatefulProcessing01.cxx
@@ -29,7 +29,7 @@ void defineDataProcessing(WorkflowSpec &specs) {
       "producer",
       Inputs{},
       Outputs{
-        {"TES", "STATEFUL", OutputSpec::Timeframe},
+        {"TES", "STATEFUL", Lifetime::Timeframe},
       },
       // The producer is stateful, we use a static for the state in this
       // particular case, but a Singleton or a captured new object would
@@ -48,7 +48,7 @@ void defineDataProcessing(WorkflowSpec &specs) {
     {
       "consumer",
       Inputs{
-        {"test", "TES", "STATEFUL", OutputSpec::Timeframe},
+        {"test", "TES", "STATEFUL", Lifetime::Timeframe},
       },
       Outputs{},
       AlgorithmSpec{[](InitContext &) {

--- a/Framework/Core/test/test_SingleDataSource.cxx
+++ b/Framework/Core/test/test_SingleDataSource.cxx
@@ -20,12 +20,12 @@ void defineDataProcessing(WorkflowSpec &specs) {
     "A",
     {},
     {
-      OutputSpec{"TST", "A1", OutputSpec::Timeframe}
+      OutputSpec{"TST", "A1", 0, Lifetime::Timeframe}
     },
     AlgorithmSpec{
       [](ProcessingContext &ctx) {
        sleep(1);
-       auto aData = ctx.outputs().make<int>(OutputSpec{ "TST", "A1", 0 }, 1);
+       auto aData = ctx.outputs().make<int>(OutputSpec{ "TST", "A1", 0}, 1);
        ctx.services().get<ControlService>().readyToQuit(true);
       }
     },

--- a/Framework/Core/test/test_TimeParallelPipelining.cxx
+++ b/Framework/Core/test/test_TimeParallelPipelining.cxx
@@ -26,21 +26,21 @@ WorkflowSpec defineSimplePipelining()
                                 "A",
                                 Inputs{},
                                 {
-                                  OutputSpec{ "TST", "A", OutputSpec::Timeframe },
+                                  OutputSpec{ "TST", "A" },
                                 },
                               },
                               timePipeline(
                                 {
                                   "B",
-                                  Inputs{ InputSpec{ "a", "TST", "A", InputSpec::Timeframe } },
+                                  Inputs{ InputSpec{ "a", "TST", "A" } },
                                   Outputs{
-                                    OutputSpec{ "TST", "B", OutputSpec::Timeframe },
+                                    OutputSpec{ "TST", "B" },
                                   },
                                 },
                                 2),
                               {
                                 "C",
-                                { InputSpec{ "b", "TST", "B", InputSpec::Timeframe } },
+                                { InputSpec{ "b", "TST", "B" } },
                               } };
 
   return result;
@@ -71,24 +71,24 @@ WorkflowSpec defineDataProcessing()
       "A",
       Inputs{},
       {
-        OutputSpec{ "TST", "A", OutputSpec::Timeframe },
+        OutputSpec{ "TST", "A" },
       },
     },
     timePipeline(
       {
         "B",
-        Inputs{ InputSpec{ "a", "TST", "A", InputSpec::Timeframe } },
-        Outputs{ OutputSpec{ "TST", "B1", OutputSpec::Timeframe }, OutputSpec{ "TST", "B2", OutputSpec::Timeframe } },
+        Inputs{ InputSpec{ "a", "TST", "A" } },
+        Outputs{ OutputSpec{ "TST", "B1" }, OutputSpec{ "TST", "B2" } },
       },
       2),
     timePipeline({ "C",
-                   { InputSpec{ "b", "TST", "B1", InputSpec::Timeframe } },
-                   { OutputSpec{ "TST", "C", OutputSpec::Timeframe } } },
+                   { InputSpec{ "b", "TST", "B1" } },
+                   { OutputSpec{ "TST", "C" } } },
                  3),
     timePipeline(
       {
         "D",
-        { InputSpec{ "c", "TST", "C", InputSpec::Timeframe }, InputSpec{ "d", "TST", "B2", InputSpec::Timeframe } },
+        { InputSpec{ "c", "TST", "C" }, InputSpec{ "d", "TST", "B2" } },
       },
       1)
   };

--- a/Framework/Core/test/test_TimePipeline.cxx
+++ b/Framework/Core/test/test_TimePipeline.cxx
@@ -39,7 +39,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
     "dataProducer",
     Inputs{},
     {
-      OutputSpec{ "TPC", "CLUSTERS", 0, OutputSpec::Timeframe },
+      OutputSpec{ "TPC", "CLUSTERS" },
     },
     AlgorithmSpec{
       (AlgorithmSpec::ProcessCallback) someDataProducerAlgorithm
@@ -50,10 +50,10 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
     DataProcessorSpec{
       "processingStage",
       Inputs{
-        { "dataTPC", "TPC", "CLUSTERS", InputSpec::Timeframe }
+        { "dataTPC", "TPC", "CLUSTERS" }
       },
       Outputs{
-        { "TPC", "CLUSTERS_P", OutputSpec::Timeframe }
+        { "TPC", "CLUSTERS_P" }
       },
       AlgorithmSpec{
         (AlgorithmSpec::ProcessCallback) someProcessingStageAlgorithm
@@ -65,7 +65,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
   DataProcessorSpec dataSampler{
     "dataSampler",
     Inputs{
-      { "dataTPC-sampled", "TPC", "CLUSTERS", 0, InputSpec::Timeframe },
+      { "dataTPC-sampled", "TPC", "CLUSTERS", 0, Lifetime::Timeframe },
     },
     Outputs{},
     AlgorithmSpec{

--- a/Framework/Core/test/test_WorkflowHelpers.cxx
+++ b/Framework/Core/test/test_WorkflowHelpers.cxx
@@ -98,8 +98,8 @@ BOOST_AUTO_TEST_CASE(TestWorkflowHelpers) {
 //
 // A->B
 BOOST_AUTO_TEST_CASE(TestSimpleConnection) {
-  std::vector<InputSpec> expectedInputs = {InputSpec{"y", "TST", "A", InputSpec::Timeframe}};
-  std::vector<OutputSpec> expectedOutputs = {OutputSpec{"TST", "A", OutputSpec::Timeframe}};
+  std::vector<InputSpec> expectedInputs = {InputSpec{"y", "TST", "A" }};
+  std::vector<OutputSpec> expectedOutputs = {OutputSpec{"TST", "A" }};
   WorkflowSpec workflow{
     {
       "A",
@@ -137,8 +137,8 @@ BOOST_AUTO_TEST_CASE(TestSimpleConnection) {
 //  \
 //   C
 BOOST_AUTO_TEST_CASE(TestSimpleForward) {
-  std::vector<InputSpec> expectedInputs = {InputSpec{"y", "TST", "A", InputSpec::Timeframe}};
-  std::vector<OutputSpec> expectedOutputs = {OutputSpec{"TST", "A", OutputSpec::Timeframe}};
+  std::vector<InputSpec> expectedInputs = {InputSpec{"y", "TST", "A" }};
+  std::vector<OutputSpec> expectedOutputs = {OutputSpec{"TST", "A" }};
   WorkflowSpec workflow{
     {
       "A",
@@ -187,17 +187,17 @@ BOOST_AUTO_TEST_CASE(TestGraphConstruction) {
       "A",
       Inputs{},
       Outputs{
-        OutputSpec{"TST", "A", OutputSpec::Timeframe}
+        OutputSpec{"TST", "A"}
       }
     },
     timePipeline({
       "B",
-      Inputs{InputSpec{"b", "TST", "A", InputSpec::Timeframe}},
-      Outputs{OutputSpec{"TST", "B", OutputSpec::Timeframe}},
+      Inputs{InputSpec{"b", "TST", "A"}},
+      Outputs{OutputSpec{"TST", "B"}},
     }, 3),
     timePipeline({
       "C",
-      Inputs{InputSpec{"c", "TST", "B", InputSpec::Timeframe}}
+      Inputs{InputSpec{"c", "TST", "B" }}
     }, 2)
   };
 
@@ -228,8 +228,8 @@ BOOST_AUTO_TEST_CASE(TestGraphConstruction) {
   BOOST_CHECK_EQUAL(outputs.size(), 2); // FIXME: Is this what we actually want? We need
                                         // different matchers depending on the different timeframe ID.
   Outputs expectedOutputs = {
-    OutputSpec{"TST", "A", OutputSpec::Timeframe},
-    OutputSpec{"TST", "B", OutputSpec::Timeframe},
+    OutputSpec{"TST", "A"},
+    OutputSpec{"TST", "B"},
   };
 
   for (size_t i = 0; i < outputs.size(); ++i) {

--- a/Framework/Core/test/test_WorkflowOptions.cxx
+++ b/Framework/Core/test/test_WorkflowOptions.cxx
@@ -24,7 +24,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
       "producer",
       Inputs{},
       {
-        OutputSpec{ "TST", "TEST", OutputSpec::Timeframe },
+        OutputSpec{ "TST", "TEST" },
       },
       AlgorithmSpec{
         // define init callback
@@ -50,7 +50,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
     DataProcessorSpec{
       "consumer",
       Inputs{
-        InputSpec{ "in", "TST", "TEST", OutputSpec::Timeframe },
+        InputSpec{ "in", "TST", "TEST" },
       },
       {},
       AlgorithmSpec{

--- a/Framework/TestWorkflows/src/dataSamplingParallel.cxx
+++ b/Framework/TestWorkflows/src/dataSamplingParallel.cxx
@@ -41,7 +41,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
       "dataProducer",
       Inputs{},
       {
-        OutputSpec{ "TPC", "CLUSTERS", OutputSpec::Timeframe }
+        OutputSpec{ "TPC", "CLUSTERS"}
       },
       AlgorithmSpec{
         (AlgorithmSpec::ProcessCallback) someDataProducerAlgorithm
@@ -57,10 +57,10 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
     DataProcessorSpec{
       "processingStage",
       Inputs{
-        { "dataTPC", "TPC", "CLUSTERS", InputSpec::Timeframe }
+        { "dataTPC", "TPC", "CLUSTERS"}
       },
       Outputs{
-        { "TPC", "CLUSTERS_P", OutputSpec::Timeframe }
+        { "TPC", "CLUSTERS_P"}
       },
       AlgorithmSpec{
         (AlgorithmSpec::ProcessCallback) someProcessingStageAlgorithm
@@ -75,7 +75,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
 
 
   auto inputsSink = mergeInputs(
-    { "dataTPC-proc", "TPC", "CLUSTERS_P", InputSpec::Timeframe },
+    { "dataTPC-proc", "TPC", "CLUSTERS_P" },
     parallelSize,
     [](InputSpec& input, size_t index) {
       input.subSpec = index;
@@ -95,8 +95,8 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
   DataProcessorSpec simpleQcTask{
     "simpleQcTask",
     Inputs{
-      { "TPC_CLUSTERS_S",   "TPC", "CLUSTERS_S",   0, InputSpec::Timeframe },
-      { "TPC_CLUSTERS_P_S", "TPC", "CLUSTERS_P_S", 0, InputSpec::Timeframe }
+      { "TPC_CLUSTERS_S",   "TPC", "CLUSTERS_S",   0, Lifetime::Timeframe },
+      { "TPC_CLUSTERS_P_S", "TPC", "CLUSTERS_P_S", 0, Lifetime::Timeframe }
     },
     Outputs{},
     AlgorithmSpec{

--- a/Framework/TestWorkflows/src/dataSamplingPodAndRoot.cxx
+++ b/Framework/TestWorkflows/src/dataSamplingPodAndRoot.cxx
@@ -43,8 +43,8 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
     "podDataProducer",
     Inputs{},
     {
-      OutputSpec{ "TPC", "CLUSTERS", 0, OutputSpec::Timeframe },
-      OutputSpec{ "ITS", "CLUSTERS", 0, OutputSpec::Timeframe }
+      OutputSpec{ "TPC", "CLUSTERS", 0, Lifetime::Timeframe },
+      OutputSpec{ "ITS", "CLUSTERS", 0, Lifetime::Timeframe }
     },
     AlgorithmSpec{
       (AlgorithmSpec::ProcessCallback) someDataProducerAlgorithm
@@ -54,12 +54,12 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
   DataProcessorSpec processingStage{
     "processingStage",
     Inputs{
-      { "dataTPC", "TPC", "CLUSTERS", 0, InputSpec::Timeframe },
-      { "dataITS", "ITS", "CLUSTERS", 0, InputSpec::Timeframe }
+      { "dataTPC", "TPC", "CLUSTERS", 0, Lifetime::Timeframe },
+      { "dataITS", "ITS", "CLUSTERS", 0, Lifetime::Timeframe }
     },
     Outputs{
-      { "TPC", "CLUSTERS_P", 0, OutputSpec::Timeframe },
-      { "ITS", "CLUSTERS_P", 0, OutputSpec::Timeframe }
+      { "TPC", "CLUSTERS_P", 0, Lifetime::Timeframe },
+      { "ITS", "CLUSTERS_P", 0, Lifetime::Timeframe }
     },
     AlgorithmSpec{
       (AlgorithmSpec::ProcessCallback) someProcessingStageAlgorithm
@@ -70,8 +70,8 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
   DataProcessorSpec podSink{
     "podSink",
     Inputs{
-      { "dataTPC-proc", "TPC", "CLUSTERS_P", 0, InputSpec::Timeframe },
-      { "dataITS-proc", "ITS", "CLUSTERS_P", 0, InputSpec::Timeframe }
+      { "dataTPC-proc", "TPC", "CLUSTERS_P", 0, Lifetime::Timeframe },
+      { "dataITS-proc", "ITS", "CLUSTERS_P", 0, Lifetime::Timeframe }
     },
     Outputs{},
     AlgorithmSpec{
@@ -82,8 +82,8 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
   DataProcessorSpec qcTaskTpc{
     "qcTaskTpc",
     Inputs{
-      { "TPC_CLUSTERS_S",   "TPC", "CLUSTERS_S",   0, InputSpec::Timeframe },
-      { "TPC_CLUSTERS_P_S", "TPC", "CLUSTERS_P_S", 0, InputSpec::Timeframe }
+      { "TPC_CLUSTERS_S",   "TPC", "CLUSTERS_S",   0, Lifetime::Timeframe },
+      { "TPC_CLUSTERS_P_S", "TPC", "CLUSTERS_P_S", 0, Lifetime::Timeframe }
     },
     Outputs{},
     AlgorithmSpec{
@@ -115,8 +115,8 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
     "rootDataProducer",
     {},
     {
-      OutputSpec{ "TST", "HISTOS", OutputSpec::Timeframe },
-      OutputSpec{ "TST", "STRING", OutputSpec::Timeframe }
+      OutputSpec{ "TST", "HISTOS", 0, Lifetime::Timeframe },
+      OutputSpec{ "TST", "STRING", 0, Lifetime::Timeframe }
     },
     AlgorithmSpec{
       [](ProcessingContext& ctx) {
@@ -138,8 +138,8 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
   DataProcessorSpec rootSink{
     "rootSink",
     {
-      InputSpec{ "histos", "TST", "HISTOS", InputSpec::Timeframe },
-      InputSpec{ "string", "TST", "STRING", InputSpec::Timeframe },
+      InputSpec{ "histos", "TST", "HISTOS", 0, Lifetime::Timeframe },
+      InputSpec{ "string", "TST", "STRING", 0, Lifetime::Timeframe },
     },
     {},
     AlgorithmSpec{
@@ -164,8 +164,8 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
   DataProcessorSpec rootQcTask{
     "rootQcTask",
     {
-      InputSpec{ "TST_HISTOS_S", "TST", "HISTOS_S", InputSpec::Timeframe },
-      InputSpec{ "TST_STRING_S", "TST", "STRING_S", InputSpec::Timeframe },
+      InputSpec{ "TST_HISTOS_S", "TST", "HISTOS_S", 0, Lifetime::Timeframe },
+      InputSpec{ "TST_STRING_S", "TST", "STRING_S", 0, Lifetime::Timeframe },
     },
     Outputs{},
     AlgorithmSpec{

--- a/Framework/TestWorkflows/src/dataSamplingTimePipeline.cxx
+++ b/Framework/TestWorkflows/src/dataSamplingTimePipeline.cxx
@@ -40,7 +40,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
     "dataProducer",
     Inputs{},
     {
-      OutputSpec{ "TPC", "CLUSTERS", 0, OutputSpec::Timeframe },
+      OutputSpec{ "TPC", "CLUSTERS"},
     },
     AlgorithmSpec{
       (AlgorithmSpec::ProcessCallback) someDataProducerAlgorithm
@@ -51,10 +51,10 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
     DataProcessorSpec{
       "processingStage",
       Inputs{
-        { "dataTPC", "TPC", "CLUSTERS", InputSpec::Timeframe }
+        { "dataTPC", "TPC", "CLUSTERS" }
       },
       Outputs{
-        { "TPC", "CLUSTERS_P", OutputSpec::Timeframe }
+        { "TPC", "CLUSTERS_P" }
       },
       AlgorithmSpec{
         (AlgorithmSpec::ProcessCallback) someProcessingStageAlgorithm
@@ -66,7 +66,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
   DataProcessorSpec sink{
     "sink",
     Inputs{
-      { "dataTPC-proc", "TPC", "CLUSTERS_P", 0, InputSpec::Timeframe }
+      { "dataTPC-proc", "TPC", "CLUSTERS_P", 0 }
     },
     Outputs{},
     AlgorithmSpec{
@@ -78,8 +78,8 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
   DataProcessorSpec simpleQcTask{
     "simpleQcTask",
     Inputs{
-      { "TPC_CLUSTERS_S",   "TPC", "CLUSTERS_S",   0, InputSpec::Timeframe },
-      { "TPC_CLUSTERS_P_S", "TPC", "CLUSTERS_P_S", 0, InputSpec::Timeframe }
+      { "TPC_CLUSTERS_S",   "TPC", "CLUSTERS_S",   0 },
+      { "TPC_CLUSTERS_P_S", "TPC", "CLUSTERS_P_S", 0 }
     },
     Outputs{},
     AlgorithmSpec{

--- a/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
@@ -24,8 +24,8 @@ void defineDataProcessing(WorkflowSpec &specs) {
     "A",
     Inputs{},
     {
-      OutputSpec{"TST", "A1", OutputSpec::Timeframe},
-      OutputSpec{"TST", "A2", OutputSpec::Timeframe}
+      OutputSpec{"TST", "A1"},
+      OutputSpec{"TST", "A2"}
     },
     AlgorithmSpec{
       [](ProcessingContext &ctx) {
@@ -37,21 +37,21 @@ void defineDataProcessing(WorkflowSpec &specs) {
   },
   {
     "B",
-    {InputSpec{"x", "TST", "A1", InputSpec::Timeframe}},
-    {OutputSpec{"TST", "B1", OutputSpec::Timeframe}},
+    {InputSpec{"x", "TST", "A1"}},
+    {OutputSpec{"TST", "B1"}},
     simplePipe(o2::header::DataDescription{"B1"})
   },
   {
     "C",
-    Inputs{InputSpec{"x", "TST", "A2", InputSpec::Timeframe}},
-    Outputs{OutputSpec{"TST", "C1", OutputSpec::Timeframe}},
+    Inputs{InputSpec{"x", "TST", "A2"}},
+    Outputs{OutputSpec{"TST", "C1"}},
     simplePipe(o2::header::DataDescription{"C1"})
   },
   {
     "D",
     Inputs{
-      InputSpec{"b", "TST", "B1", InputSpec::Timeframe},
-      InputSpec{"c", "TST", "C1", InputSpec::Timeframe},
+      InputSpec{"b", "TST", "B1"},
+      InputSpec{"c", "TST", "C1"},
     },
     Outputs{},
     AlgorithmSpec{

--- a/Framework/TestWorkflows/src/o2DummyWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DummyWorkflow.cxx
@@ -35,8 +35,8 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
     "reader",
     Inputs{},
     {
-      OutputSpec{"TPC", "CLUSTERS", OutputSpec::Timeframe},
-      OutputSpec{"ITS", "CLUSTERS", OutputSpec::Timeframe}
+      OutputSpec{"TPC", "CLUSTERS"},
+      OutputSpec{"ITS", "CLUSTERS"}
     },
     AlgorithmSpec{
       [](ProcessingContext &ctx) {
@@ -72,8 +72,8 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
 
   DataProcessorSpec tpcClusterSummary{
     "tpc-cluster-summary",
-    { InputSpec{ "clusters", "TPC", "CLUSTERS", InputSpec::Timeframe } },
-    { OutputSpec{ "TPC", "SUMMARY", OutputSpec::Timeframe } },
+    { InputSpec{ "clusters", "TPC", "CLUSTERS"} },
+    { OutputSpec{ "TPC", "SUMMARY"} },
     AlgorithmSpec{ [](ProcessingContext& ctx) {
       auto tpcSummary = ctx.outputs().make<Summary>(OutputSpec{ "TPC", "SUMMARY", 0 }, 1);
       tpcSummary.at(0).inputCount = ctx.inputs().size();
@@ -84,9 +84,9 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
 
   DataProcessorSpec itsClusterSummary{
     "its-cluster-summary",
-    { InputSpec{ "clusters", "ITS", "CLUSTERS", InputSpec::Timeframe } },
+    { InputSpec{ "clusters", "ITS", "CLUSTERS" } },
     {
-      OutputSpec{ "ITS", "SUMMARY", OutputSpec::Timeframe },
+      OutputSpec{ "ITS", "SUMMARY" },
     },
     AlgorithmSpec{ [](ProcessingContext& ctx) {
       auto itsSummary = ctx.outputs().make<Summary>(OutputSpec{ "ITS", "SUMMARY", 0 }, 1);
@@ -99,9 +99,9 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
   DataProcessorSpec merger{
     "merger",
     {
-      InputSpec{"clusters", "TPC", "CLUSTERS", InputSpec::Timeframe},
-      InputSpec{"summary", "TPC", "SUMMARY", InputSpec::Timeframe},
-      InputSpec{"other_summary", "ITS", "SUMMARY", InputSpec::Timeframe}
+      InputSpec{"clusters", "TPC", "CLUSTERS"},
+      InputSpec{"summary", "TPC", "SUMMARY"},
+      InputSpec{"other_summary", "ITS", "SUMMARY"}
     },
     Outputs{},
     AlgorithmSpec{

--- a/Framework/TestWorkflows/src/o2ParallelWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2ParallelWorkflow.cxx
@@ -21,10 +21,10 @@ DataProcessorSpec templateProcessor() {
   return DataProcessorSpec{
     "some-processor",
     {
-      InputSpec{"x", "TST", "A", 0, InputSpec::Timeframe},
+      InputSpec{"x", "TST", "A", 0, Lifetime::Timeframe},
     },
     {
-      OutputSpec{"TST", "P", 0, OutputSpec::Timeframe},
+      OutputSpec{"TST", "P", 0, Lifetime::Timeframe},
     },
     // The producer is stateful, we use a static for the state in this
     // particular case, but a Singleton or a captured new object would
@@ -69,7 +69,7 @@ void defineDataProcessing(o2::framework::WorkflowSpec &specs) {
   });
   workflow.push_back(timePipeline(DataProcessorSpec{
       "merger",
-      mergeInputs(InputSpec{"x", "TST", "P", InputSpec::Timeframe},
+      mergeInputs(InputSpec{"x", "TST", "P"},
                   4,
                   [](InputSpec &input, size_t index){
                      input.subSpec = index;

--- a/Framework/TestWorkflows/src/o2_sim_its_ALP3.cxx
+++ b/Framework/TestWorkflows/src/o2_sim_its_ALP3.cxx
@@ -44,7 +44,7 @@ DataProcessorSpec sim_its_ALP3() {
     "sim_its_ALP3",
     Inputs{},
     {
-      OutputSpec{"ITS", "HITS", OutputSpec::Timeframe}
+      OutputSpec{"ITS", "HITS"}
     },
     AlgorithmSpec{
       [](InitContext &setup) {

--- a/Framework/TestWorkflows/src/o2_sim_tpc.cxx
+++ b/Framework/TestWorkflows/src/o2_sim_tpc.cxx
@@ -43,7 +43,7 @@ DataProcessorSpec sim_tpc() {
     "sim_tpc",
     Inputs{},
     {
-      OutputSpec{"TPC", "GEN", OutputSpec::Timeframe}
+      OutputSpec{"TPC", "GEN"}
     },
     AlgorithmSpec{
       [](InitContext &setup) {

--- a/Framework/TestWorkflows/src/test_RawDeviceInjector.cxx
+++ b/Framework/TestWorkflows/src/test_RawDeviceInjector.cxx
@@ -26,8 +26,7 @@ void defineDataProcessing(WorkflowSpec &specs) {
                             o2::header::gDataDescriptionHeartbeatFrame};
   auto inspec = InputSpec{"heatbeat",
                           o2::header::DataOrigin("SMPL"),
-                          o2::header::gDataDescriptionHeartbeatFrame,
-                          InputSpec::Timeframe};
+                          o2::header::gDataDescriptionHeartbeatFrame};
   WorkflowSpec workflow = {
     specifyExternalFairMQDeviceProxy("foreign-source",
                     {outspec},

--- a/Framework/TestWorkflows/src/test_o2RootMessageWorkflow.cxx
+++ b/Framework/TestWorkflows/src/test_o2RootMessageWorkflow.cxx
@@ -32,8 +32,8 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
       "producer",
       {},
       {
-        OutputSpec{"TST", "HISTOS", OutputSpec::Timeframe},
-        OutputSpec{"TST", "STRING", OutputSpec::Timeframe}
+        OutputSpec{"TST", "HISTOS"},
+        OutputSpec{"TST", "STRING"}
       },
       AlgorithmSpec{
         [](ProcessingContext &ctx) {
@@ -54,8 +54,8 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
     {
       "consumer",
       {
-         InputSpec{"histos", "TST", "HISTOS", InputSpec::Timeframe},
-         InputSpec{"string", "TST", "STRING", InputSpec::Timeframe},
+         InputSpec{"histos", "TST", "HISTOS"},
+         InputSpec{"string", "TST", "STRING"},
       },
       {},
       AlgorithmSpec{

--- a/Utilities/QC/Workflow/src/RootObjectMergerSpec.cxx
+++ b/Utilities/QC/Workflow/src/RootObjectMergerSpec.cxx
@@ -27,16 +27,7 @@
 #include <utility> // std::forward
 #include <iostream>
 
-using DataProcessorSpec = o2::framework::DataProcessorSpec;
-using Inputs = o2::framework::Inputs;
-using Outputs = o2::framework::Outputs;
-using Options = o2::framework::Options;
-using InputSpec = o2::framework::InputSpec;
-using OutputSpec = o2::framework::OutputSpec;
-using AlgorithmSpec = o2::framework::AlgorithmSpec;
-using InitContext = o2::framework::InitContext;
-using ProcessingContext = o2::framework::ProcessingContext;
-using VariantType = o2::framework::VariantType;
+using namespace o2::framework;
 
 namespace o2 {
 namespace qc {
@@ -70,7 +61,7 @@ DataProcessorSpec getRootObjectMergerSpec() {
 
   return {
     "qc_merger",
-    {InputSpec{"qc_producer", "QC", "ROOTOBJECT", 0, InputSpec::QA}},
+    {InputSpec{"qc_producer", "QC", "ROOTOBJECT", 0, Lifetime::QA}},
     Outputs{},
     AlgorithmSpec(processingFct)
   };

--- a/Utilities/QC/Workflow/src/RootObjectProducerSpec.cxx
+++ b/Utilities/QC/Workflow/src/RootObjectProducerSpec.cxx
@@ -30,15 +30,7 @@
 #include <stdexcept> // std::runtime_error
 #include <type_traits>  // std::conditional
 
-using DataProcessorSpec = o2::framework::DataProcessorSpec;
-using Inputs = o2::framework::Inputs;
-//using Outputs = o2::framework::Outputs;
-using Options = o2::framework::Options;
-using OutputSpec = o2::framework::OutputSpec;
-using AlgorithmSpec = o2::framework::AlgorithmSpec;
-using InitContext = o2::framework::InitContext;
-using ProcessingContext = o2::framework::ProcessingContext;
-using VariantType = o2::framework::VariantType;
+using namespace o2::framework;
 
 namespace o2 {
 namespace qc {
@@ -109,7 +101,7 @@ DataProcessorSpec getRootObjectProducerSpec() {
     "qc_producer",
     Inputs{},
     {
-      OutputSpec{"QC", "ROOTOBJECT", 0, OutputSpec::QA}
+      OutputSpec{"QC", "ROOTOBJECT", 0, Lifetime::QA}
     },
     AlgorithmSpec{
       [](InitContext &ic) {
@@ -136,7 +128,7 @@ DataProcessorSpec getRootObjectProducerSpec() {
         // the shared pointer makes sure to clean up the instance when the processing
         // function gets out of scope
         auto processingFct = [producer](ProcessingContext& pc) {
-          pc.outputs().adopt(OutputSpec{ "QC", "ROOTOBJECT", 0, OutputSpec::QA }, producer->produceData());
+          pc.outputs().adopt(OutputSpec{ "QC", "ROOTOBJECT", 0, Lifetime::QA }, producer->produceData());
         };
 
         // return the actual processing function as a lambda function using variables


### PR DESCRIPTION
This fixes a serious API issue with Lifetime which could be erroneously
be used as subspecification due to the fact they both could decay to an
int. This makes sure that an explicit cast is required, hence raising
an error when a Lifetime is naively used in place of a subspecification.

This also armonises OutputSpec::Lifetime and InputSpec::Lifetime into a
single `o2::framework::Lifetime` since there is no reason for them to be
separate.

I've also cleaned up a few default places where the default
"Lifetime::Timeframe" was used to reduce verbosity of the examples /
tests.