### PR TITLE
Fix ITS CA tracker crash

### DIFF
--- a/Detectors/ITSMFT/ITS/reconstruction/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/reconstruction/CMakeLists.txt
@@ -33,6 +33,12 @@ string(REPLACE "src" "include/${MODULE_NAME}" HEADERS "${HEADERS}")
 string(REPLACE ".cxx" ".h" NO_DICT_HEADERS "${NO_DICT_SRCS}")
 string(REPLACE "src" "include/${MODULE_NAME}" NO_DICT_HEADERS "${NO_DICT_HEADERS}")
 
+set(NO_DICT_HEADERS
+    ${NO_DICT_HEADERS}
+    include/${MODULE_NAME}/CA/Config.h
+    include/${MODULE_NAME}/CA/Definitions.h
+    )
+
 Set(LINKDEF src/ITSReconstructionLinkDef.h)
 Set(LIBRARY_NAME ${MODULE_NAME})
 Set(BUCKET_NAME its_reconstruction_bucket)

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/ArrayUtils.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/ArrayUtils.h
@@ -32,7 +32,7 @@ template <typename T, std::size_t... Is, typename Initializer>
 constexpr std::array<T, sizeof...(Is)> fillArray(Initializer, std::index_sequence<Is...>);
 template <typename T, std::size_t N, typename Initializer>
 constexpr std::array<T, N> fillArray(Initializer);
-}
+} // namespace ArrayUtils
 
 template <typename T, std::size_t... Is, typename Initializer>
 constexpr std::array<T, sizeof...(Is)> ArrayUtils::fillArray(Initializer initializer, std::index_sequence<Is...>)
@@ -45,8 +45,8 @@ constexpr std::array<T, N> ArrayUtils::fillArray(Initializer initializer)
 {
   return ArrayUtils::fillArray<T>(initializer, std::make_index_sequence<N>{});
 }
-}
-}
-}
+} // namespace CA
+} // namespace ITS
+} // namespace o2
 
 #endif /* TRACKINGITSU_INCLUDE_ARRAYUTILS_H_ */

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/Cell.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/Cell.h
@@ -70,7 +70,7 @@ inline float Cell::getCurvature() const { return mCurvature; }
 inline const float3& Cell::getNormalVectorCoordinates() const { return mNormalVectorCoordinates; }
 
 inline void Cell::setLevel(const int level) { mLevel = level; }
-}
-}
-}
+} // namespace CA
+} // namespace ITS
+} // namespace o2
 #endif /* TRACKINGITSU_INCLUDE_CACELL_H_ */

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/Cluster.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/Cluster.h
@@ -50,8 +50,8 @@ struct TrackingFrameInfo {
   std::array<float, 2> positionTrackingFrame;
   std::array<float, 3> covarianceTrackingFrame;
 };
-}
-}
-}
+} // namespace CA
+} // namespace ITS
+} // namespace o2
 
 #endif /* TRACKINGITSU_INCLUDE_CACLUSTER_H_ */

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/Constants.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/Constants.h
@@ -36,7 +36,7 @@ namespace Math
 constexpr float Pi{ 3.14159265359f };
 constexpr float TwoPi{ 2.0f * Pi };
 constexpr float FloatMinThreshold{ 1e-20f };
-}
+} // namespace Math
 
 namespace ITS
 {
@@ -55,7 +55,7 @@ GPU_HOST_DEVICE constexpr GPUArray<float, LayersNumber> LayersRCoordinate()
 {
   return GPUArray<float, LayersNumber>{ { 2.33959f, 3.14076f, 3.91924f, 19.6213f, 24.5597f, 34.388f, 39.3329f } };
 }
-}
+} // namespace ITS
 
 namespace Thresholds
 {
@@ -80,7 +80,7 @@ constexpr GPUArray<float, ITS::CellsPerRoad - 1> NeighbourCellMaxNormalVectorsDe
 constexpr GPUArray<float, ITS::CellsPerRoad - 1> NeighbourCellMaxCurvaturesDelta{ { 0.008f, 0.0025f, 0.003f,
                                                                                     0.0035f } };
 constexpr int CellsMinLevel{ 5 };
-}
+} // namespace Thresholds
 
 namespace IndexTable
 {
@@ -93,7 +93,7 @@ GPU_HOST_DEVICE constexpr GPUArray<float, ITS::LayersNumber> InverseZBinSize()
                                                0.5 * ZBins / 42.140f, 0.5 * ZBins / 42.140f, 0.5 * ZBins / 73.745f,
                                                0.5 * ZBins / 73.745f } };
 }
-}
+} // namespace IndexTable
 
 namespace Memory
 {
@@ -103,15 +103,15 @@ constexpr GPUArray<float, ITS::TrackletsPerRoad> TrackletsMemoryCoefficients{
 constexpr GPUArray<float, ITS::CellsPerRoad> CellsMemoryCoefficients{ { 2.3208e-08f, 2.104e-08f, 1.6432e-08f,
                                                                         1.2412e-08f, 1.3543e-08f } };
 constexpr int Offset = 256; /// Required for low multiplicity events
-}
+} // namespace Memory
 
 namespace PDGCodes
 {
 constexpr int PionCode{ 211 };
 }
-}
-}
-}
-}
+} // namespace Constants
+} // namespace CA
+} // namespace ITS
+} // namespace o2
 
 #endif /* TRACKINGITSU_INCLUDE_CONSTANTS_H_ */

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/Constants.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/Constants.h
@@ -42,7 +42,7 @@ namespace ITS
 {
 constexpr int LayersNumber{ 7 };
 constexpr int LayersNumberVertexer{ 3 };
-constexpr int TrackletsPerRoad{ 6 };
+constexpr int TrackletsPerRoad{ LayersNumber - 1 };
 constexpr int CellsPerRoad{ LayersNumber - 2 };
 constexpr int UnusedIndex{ -1 };
 constexpr float Resolution{ 0.0005f };
@@ -102,6 +102,7 @@ constexpr GPUArray<float, ITS::TrackletsPerRoad> TrackletsMemoryCoefficients{
 };
 constexpr GPUArray<float, ITS::CellsPerRoad> CellsMemoryCoefficients{ { 2.3208e-08f, 2.104e-08f, 1.6432e-08f,
                                                                         1.2412e-08f, 1.3543e-08f } };
+constexpr int Offset = 256; /// Required for low multiplicity events
 }
 
 namespace PDGCodes

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/Event.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/Event.h
@@ -95,8 +95,8 @@ inline void Event::clear()
   }
   mPrimaryVertices.clear();
 }
-}
-}
-}
+} // namespace CA
+} // namespace ITS
+} // namespace o2
 
 #endif /* TRACKINGITSU_INCLUDE_EVENT_H_ */

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/IOUtils.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/IOUtils.h
@@ -55,9 +55,9 @@ int loadROFrameData(std::uint32_t roFrame, Event& events, const std::vector<ITSM
 std::vector<std::unordered_map<int, Label>> loadLabels(const int, const std::string&);
 void writeRoadsReport(std::ofstream&, std::ofstream&, std::ofstream&, const std::vector<std::vector<Road>>&,
                       const std::unordered_map<int, Label>&);
-}
-}
-}
-}
+} // namespace IOUtils
+} // namespace CA
+} // namespace ITS
+} // namespace o2
 
 #endif /* TRACKINGITSU_INCLUDE_EVENTLOADER_H_ */

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/IndexTableUtils.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/IndexTableUtils.h
@@ -38,7 +38,7 @@ GPU_HOST_DEVICE int getBinIndex(const int, const int);
 GPU_HOST_DEVICE int countRowSelectedBins(
   const GPUArray<int, Constants::IndexTable::ZBins * Constants::IndexTable::PhiBins + 1>&, const int, const int,
   const int);
-}
+} // namespace IndexTableUtils
 
 inline float getInverseZCoordinate(const int layerIndex)
 {
@@ -71,8 +71,8 @@ GPU_HOST_DEVICE inline int IndexTableUtils::countRowSelectedBins(
 
   return indexTable[maxBinIndex] - indexTable[firstBinIndex];
 }
-}
-}
-}
+} // namespace CA
+} // namespace ITS
+} // namespace o2
 
 #endif /* TRACKINGITSU_INCLUDE_INDEXTABLEUTILS_H_ */

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/Label.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/Label.h
@@ -36,8 +36,8 @@ struct Label final {
 
   friend std::ostream& operator<<(std::ostream&, const Label&);
 };
-}
-}
-}
+} // namespace CA
+} // namespace ITS
+} // namespace o2
 
 #endif /* TRACKINGITSU_INCLUDE_LABEL_H_ */

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/Layer.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/Layer.h
@@ -94,8 +94,8 @@ inline void Layer::clear()
   mTrackingFrameInfo.clear();
   mClusterLabels.clear();
 }
-}
-}
-}
+} // namespace CA
+} // namespace ITS
+} // namespace o2
 
 #endif /* TRACKINGITSU_INCLUDE_LAYER_H_ */

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/MathUtils.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/MathUtils.h
@@ -33,7 +33,7 @@ float calculatePhiCoordinate(const float, const float);
 float calculateRCoordinate(const float, const float);
 GPU_HOST_DEVICE constexpr float getNormalizedPhiCoordinate(const float);
 GPU_HOST_DEVICE constexpr float3 crossProduct(const float3&, const float3&);
-}
+} // namespace MathUtils
 
 inline float MathUtils::calculatePhiCoordinate(const float xCoordinate, const float yCoordinate)
 {
@@ -59,8 +59,8 @@ GPU_HOST_DEVICE constexpr float3 MathUtils::crossProduct(const float3& firstVect
                  (firstVector.z * secondVector.x) - (firstVector.x * secondVector.z),
                  (firstVector.x * secondVector.y) - (firstVector.y * secondVector.x) };
 }
-}
-}
-}
+} // namespace CA
+} // namespace ITS
+} // namespace o2
 
 #endif /* TRACKINGITSU_INCLUDE_CAUTILS_H_ */

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/PrimaryVertexContext.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/PrimaryVertexContext.h
@@ -220,8 +220,8 @@ inline std::array<std::vector<int>, Constants::ITS::CellsPerRoad>& PrimaryVertex
   return mTrackletsLookupTable;
 }
 #endif
-}
-}
-}
+} // namespace CA
+} // namespace ITS
+} // namespace o2
 
 #endif /* TRACKINGITSU_INCLUDE_PRIMARYVERTEXCONTEXT_H_ */

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/Road.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/Road.h
@@ -60,8 +60,8 @@ inline int& Road::operator[](const int& i) { return mCellIds[i]; }
 inline bool Road::isFakeRoad() const { return mIsFakeRoad; }
 
 inline void Road::setFakeRoad(const bool isFakeRoad) { mIsFakeRoad = isFakeRoad; }
-}
-}
-}
+} // namespace CA
+} // namespace ITS
+} // namespace o2
 
 #endif /* TRACKINGITSU_INCLUDE_ROAD_H_ */

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/Tracker.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/Tracker.h
@@ -161,8 +161,8 @@ template <>
 void TrackerTraits<TRACKINGITSU_GPU_MODE>::computeLayerTracklets(PrimaryVertexContext&);
 template <>
 void TrackerTraits<TRACKINGITSU_GPU_MODE>::computeLayerCells(PrimaryVertexContext&);
-}
-}
-}
+} // namespace CA
+} // namespace ITS
+} // namespace o2
 
 #endif /* TRACKINGITSU_INCLUDE_TRACKER_H_ */

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/TrackingUtils.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/TrackingUtils.h
@@ -33,9 +33,9 @@ GPU_DEVICE const int4 getBinsRect(const Cluster&, const int, const float);
 float computeCurvature(float x1, float y1, float x2, float y2, float x3, float y3);
 float computeCurvatureCentreX(float x1, float y1, float x2, float y2, float x3, float y3);
 float computeTanDipAngle(float x1, float y1, float x2, float y2, float z1, float z2);
-}
-}
-}
-}
+} // namespace TrackingUtils
+} // namespace CA
+} // namespace ITS
+} // namespace o2
 
 #endif /* TRACKINGITSU_INCLUDE_CATRACKINGUTILS_H_ */

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/Tracklet.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/Tracklet.h
@@ -33,8 +33,8 @@ struct Tracklet final {
   const float tanLambda;
   const float phiCoordinate;
 };
-}
-}
-}
+} // namespace CA
+} // namespace ITS
+} // namespace o2
 
 #endif /* TRACKINGITSU_INCLUDE_TRACKLET_H_ */

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CA/Cell.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CA/Cell.cxx
@@ -35,6 +35,6 @@ GPU_DEVICE Cell::Cell(const int firstClusterIndex, const int secondClusterIndex,
 {
   // Nothing to do
 }
-}
-}
-}
+} // namespace CA
+} // namespace ITS
+} // namespace o2

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CA/Cluster.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CA/Cluster.cxx
@@ -24,9 +24,9 @@ namespace ITS
 namespace CA
 {
 
-using MathUtils::getNormalizedPhiCoordinate;
 using MathUtils::calculatePhiCoordinate;
 using MathUtils::calculateRCoordinate;
+using MathUtils::getNormalizedPhiCoordinate;
 
 Cluster::Cluster(const float x, const float y, const float z, const int index)
   : xCoordinate{ x },
@@ -73,6 +73,6 @@ TrackingFrameInfo::TrackingFrameInfo(float xTF, float alpha, std::array<float, 2
 {
   // Nothing to do
 }
-}
-}
-}
+} // namespace CA
+} // namespace ITS
+} // namespace o2

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CA/Event.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CA/Event.cxx
@@ -59,6 +59,6 @@ int Event::getTotalClusters() const
 
   return totalClusters;
 }
-}
-}
-}
+} // namespace CA
+} // namespace ITS
+} // namespace o2

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CA/IOUtils.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CA/IOUtils.cxx
@@ -32,7 +32,7 @@ namespace
 {
 constexpr int PrimaryVertexLayerId{ -1 };
 constexpr int EventLabelsSeparator{ -1 };
-}
+} // namespace
 
 namespace o2
 {
@@ -242,6 +242,6 @@ void IOUtils::writeRoadsReport(std::ofstream& correctRoadsOutputStream, std::ofs
     }
   }
 }
-}
-}
-}
+} // namespace CA
+} // namespace ITS
+} // namespace o2

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CA/IndexTableUtils.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CA/IndexTableUtils.cxx
@@ -46,6 +46,6 @@ const std::vector<std::pair<int, int>> IndexTableUtils::selectClusters(
 
   return filteredBins;
 }
-}
-}
-}
+} // namespace CA
+} // namespace ITS
+} // namespace o2

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CA/Label.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CA/Label.cxx
@@ -39,6 +39,6 @@ std::ostream& operator<<(std::ostream& outputStream, const Label& label)
 
   return outputStream;
 }
-}
-}
-}
+} // namespace CA
+} // namespace ITS
+} // namespace o2

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CA/Layer.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CA/Layer.cxx
@@ -32,6 +32,6 @@ Layer::Layer(const int layerIndex) : mLayerIndex{ layerIndex }
 {
   // Nothing to do
 }
-}
-}
-}
+} // namespace CA
+} // namespace ITS
+} // namespace o2

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CA/PrimaryVertexContext.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CA/PrimaryVertexContext.cxx
@@ -57,10 +57,9 @@ void PrimaryVertexContext::initialise(const Event& event, const int primaryVerte
       mCells[iLayer].clear();
       float cellsMemorySize =
         Constants::Memory::Offset +
-        std::ceil(((Constants::Memory::CellsMemoryCoefficients[iLayer] *
-        event.getLayer(iLayer).getClustersSize()) *
-        event.getLayer(iLayer + 1).getClustersSize()) *
-        event.getLayer(iLayer + 2).getClustersSize());
+        std::ceil(((Constants::Memory::CellsMemoryCoefficients[iLayer] * event.getLayer(iLayer).getClustersSize()) *
+                   event.getLayer(iLayer + 1).getClustersSize()) *
+                  event.getLayer(iLayer + 2).getClustersSize());
 
       if (cellsMemorySize > mCells[iLayer].capacity()) {
         mCells[iLayer].reserve(cellsMemorySize);
@@ -70,12 +69,12 @@ void PrimaryVertexContext::initialise(const Event& event, const int primaryVerte
     if (iLayer < Constants::ITS::CellsPerRoad - 1) {
 
       mCellsLookupTable[iLayer].clear();
-      mCellsLookupTable[iLayer].resize(std::max(event.getLayer(iLayer + 1).getClustersSize(),
-                                                event.getLayer(iLayer + 2).getClustersSize()) +
-                                       std::ceil((Constants::Memory::TrackletsMemoryCoefficients[iLayer + 1] *
-                                       event.getLayer(iLayer + 1).getClustersSize()) *
-                                       event.getLayer(iLayer + 2).getClustersSize()),
-                                       Constants::ITS::UnusedIndex);
+      mCellsLookupTable[iLayer].resize(
+        std::max(event.getLayer(iLayer + 1).getClustersSize(), event.getLayer(iLayer + 2).getClustersSize()) +
+          std::ceil((Constants::Memory::TrackletsMemoryCoefficients[iLayer + 1] *
+                     event.getLayer(iLayer + 1).getClustersSize()) *
+                    event.getLayer(iLayer + 2).getClustersSize()),
+        Constants::ITS::UnusedIndex);
 
       mCellsNeighbours[iLayer].clear();
     }
@@ -125,8 +124,7 @@ void PrimaryVertexContext::initialise(const Event& event, const int primaryVerte
 
       float trackletsMemorySize =
         std::max(event.getLayer(iLayer).getClustersSize(), event.getLayer(iLayer + 1).getClustersSize()) +
-        std::ceil((Constants::Memory::TrackletsMemoryCoefficients[iLayer] *
-                  event.getLayer(iLayer).getClustersSize()) *
+        std::ceil((Constants::Memory::TrackletsMemoryCoefficients[iLayer] * event.getLayer(iLayer).getClustersSize()) *
                   event.getLayer(iLayer + 1).getClustersSize());
 
       if (trackletsMemorySize > mTracklets[iLayer].capacity()) {
@@ -142,6 +140,6 @@ void PrimaryVertexContext::initialise(const Event& event, const int primaryVerte
   }
 #endif
 }
-}
-}
-}
+} // namespace CA
+} // namespace ITS
+} // namespace o2

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CA/PrimaryVertexContext.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CA/PrimaryVertexContext.cxx
@@ -56,13 +56,13 @@ void PrimaryVertexContext::initialise(const Event& event, const int primaryVerte
 
       mCells[iLayer].clear();
       float cellsMemorySize =
-        200 +
-        std::ceil(((Constants::Memory::CellsMemoryCoefficients[iLayer] * event.getLayer(iLayer).getClustersSize()) *
-                   event.getLayer(iLayer + 1).getClustersSize()) *
-                  event.getLayer(iLayer + 2).getClustersSize());
+        Constants::Memory::Offset +
+        std::ceil(((Constants::Memory::CellsMemoryCoefficients[iLayer] *
+        event.getLayer(iLayer).getClustersSize()) *
+        event.getLayer(iLayer + 1).getClustersSize()) *
+        event.getLayer(iLayer + 2).getClustersSize());
 
       if (cellsMemorySize > mCells[iLayer].capacity()) {
-
         mCells[iLayer].reserve(cellsMemorySize);
       }
     }
@@ -70,18 +70,15 @@ void PrimaryVertexContext::initialise(const Event& event, const int primaryVerte
     if (iLayer < Constants::ITS::CellsPerRoad - 1) {
 
       mCellsLookupTable[iLayer].clear();
-      mCellsLookupTable[iLayer].resize(200 + std::ceil((Constants::Memory::TrackletsMemoryCoefficients[iLayer + 1] *
-                                                        event.getLayer(iLayer + 1).getClustersSize()) *
-                                                       event.getLayer(iLayer + 2).getClustersSize()),
+      mCellsLookupTable[iLayer].resize(std::max(event.getLayer(iLayer + 1).getClustersSize(),
+                                                event.getLayer(iLayer + 2).getClustersSize()) +
+                                       std::ceil((Constants::Memory::TrackletsMemoryCoefficients[iLayer + 1] *
+                                       event.getLayer(iLayer + 1).getClustersSize()) *
+                                       event.getLayer(iLayer + 2).getClustersSize()),
                                        Constants::ITS::UnusedIndex);
 
       mCellsNeighbours[iLayer].clear();
     }
-  }
-
-  for (int iLayer{ 0 }; iLayer < Constants::ITS::CellsPerRoad - 1; ++iLayer) {
-
-    mCellsNeighbours[iLayer].clear();
   }
 
   mRoads.clear();
@@ -127,12 +124,12 @@ void PrimaryVertexContext::initialise(const Event& event, const int primaryVerte
       mTracklets[iLayer].clear();
 
       float trackletsMemorySize =
-        200 +
-        std::ceil((Constants::Memory::TrackletsMemoryCoefficients[iLayer] * event.getLayer(iLayer).getClustersSize()) *
+        std::max(event.getLayer(iLayer).getClustersSize(), event.getLayer(iLayer + 1).getClustersSize()) +
+        std::ceil((Constants::Memory::TrackletsMemoryCoefficients[iLayer] *
+                  event.getLayer(iLayer).getClustersSize()) *
                   event.getLayer(iLayer + 1).getClustersSize());
 
       if (trackletsMemorySize > mTracklets[iLayer].capacity()) {
-
         mTracklets[iLayer].reserve(trackletsMemorySize);
       }
     }

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CA/Road.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CA/Road.cxx
@@ -40,6 +40,6 @@ void Road::addCell(int cellLayer, int cellId)
 
   mCellIds[cellLayer] = cellId;
 }
-}
-}
-}
+} // namespace CA
+} // namespace ITS
+} // namespace o2

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CA/Track.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CA/Track.cxx
@@ -31,6 +31,6 @@ ClassImp(o2::ITS::CA::TrackObject)
   TrackObject::TrackObject(const Track& track) : TObject{}, mTrack{ track } {}
 
   TrackObject::~TrackObject() {}
-  }
-  }
+  } // namespace CA
+  } // namespace ITS
 }

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CA/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CA/Tracker.cxx
@@ -216,7 +216,7 @@ void TrackerTraits<false>::computeLayerCells(PrimaryVertexContext& primaryVertex
                 primaryVertexContext.getCells()[iLayer].size();
             }
 
-            primaryVertexContext.getCells()[iLayer].emplace_back(
+           primaryVertexContext.getCells()[iLayer].emplace_back(
               currentTracklet.firstClusterIndex, nextTracklet.firstClusterIndex, nextTracklet.secondClusterIndex,
               iTracklet, iNextLayerTracklet, normalizedPlaneVector, cellTrajectoryCurvature);
           }
@@ -255,6 +255,7 @@ void Tracker<IsGPU>::clustersToTracks(const Event& event, std::ostream& timeBenc
                           timeBenchmarkOutputStream, event);
     total += evaluateTask(&Tracker<IsGPU>::computeTracksMClabels, "Tracks Monte Carlo labels computation",
                           timeBenchmarkOutputStream, event);
+
     if (Constants::DoTimeBenchmarks)
       timeBenchmarkOutputStream << std::setw(2) << " - "
                                 << "Vertex processing completed in: " << total << "ms" << std::endl;
@@ -296,7 +297,6 @@ void Tracker<IsGPU>::findCellsNeighbours()
       const Cell& currentCell{ mPrimaryVertexContext.getCells()[iLayer][iCell] };
       const int nextLayerTrackletIndex{ currentCell.getSecondTrackletIndex() };
       const int nextLayerFirstCellIndex{ mPrimaryVertexContext.getCellsLookupTable()[iLayer][nextLayerTrackletIndex] };
-
       if (nextLayerFirstCellIndex != Constants::ITS::UnusedIndex &&
           mPrimaryVertexContext.getCells()[iLayer + 1][nextLayerFirstCellIndex].getFirstTrackletIndex() ==
             nextLayerTrackletIndex) {

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CA/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CA/Tracker.cxx
@@ -216,7 +216,7 @@ void TrackerTraits<false>::computeLayerCells(PrimaryVertexContext& primaryVertex
                 primaryVertexContext.getCells()[iLayer].size();
             }
 
-           primaryVertexContext.getCells()[iLayer].emplace_back(
+            primaryVertexContext.getCells()[iLayer].emplace_back(
               currentTracklet.firstClusterIndex, nextTracklet.firstClusterIndex, nextTracklet.secondClusterIndex,
               iTracklet, iNextLayerTracklet, normalizedPlaneVector, cellTrajectoryCurvature);
           }
@@ -701,6 +701,6 @@ track::TrackParCov Tracker<IsGPU>::buildTrackSeed(const Cluster& cluster1, const
 }
 
 template class Tracker<TRACKINGITSU_GPU_MODE>;
-}
-}
-}
+} // namespace CA
+} // namespace ITS
+} // namespace o2

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CA/TrackingUtils.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CA/TrackingUtils.cxx
@@ -68,6 +68,6 @@ float TrackingUtils::computeTanDipAngle(float x1, float y1, float x2, float y2, 
 {
   return (z1 - z2) / std::sqrt((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2));
 }
-}
-}
-}
+} // namespace CA
+} // namespace ITS
+} // namespace o2

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CA/Tracklet.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CA/Tracklet.cxx
@@ -39,6 +39,6 @@ GPU_DEVICE Tracklet::Tracklet(const int firstClusterOrderingIndex, const int sec
 {
   // Nothing to do
 }
-}
-}
-}
+} // namespace CA
+} // namespace ITS
+} // namespace o2


### PR DESCRIPTION
Hi @shahor02 , @iouribelikov ,

this is the fix I was mentioning, sorry it took longer than expected. The allocation for the lookup table has been fixed adding a linear term to our formula. However this might not be the _final_ solution: in the cases I have tested it always give a 30-40% margin where it was failing before, however I will have to test it on larger pp and Pb-Pb samples and with continuous readout.
Only the first commit contains the relevant changes, the second one is only clang-format noise...

Cheers,
Max