### PR TITLE
Forbid importing TGeo to VMC to avoid duplication

### DIFF
--- a/macro/o2sim.C
+++ b/macro/o2sim.C
@@ -31,6 +31,7 @@ void o2sim()
   auto genconfig = confref.getGenerator();
 
   auto run = new FairRunSim();
+  run->SetImportTGeoToVMC(false);              // do not import TGeo to VMC since the latter is built together with TGeo
   run->SetOutputFile("o2sim.root");            // Output file
   run->SetName(confref.getMCEngine().c_str()); // Transport engine
   run->SetIsMT(confref.getIsMT());             // MT mode


### PR DESCRIPTION
Since the VMC materials and media are created in parallel with those of TGeo, importing the TGeo to VMC leads to duplication of media (and loss of special properties of some media, set directly via VMC).
@sawenzel , @AllaMaevskaya, with this patch (requires updated alidist) the Cerenkov generation in FIT works.