### PR TITLE
Fix: add missing override for DefineSensitiveVolumes

### DIFF
--- a/Detectors/TPC/simulation/include/TPCSimulation/Detector.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/Detector.h
@@ -133,7 +133,7 @@ class Detector: public o2::Base::DetImpl<Detector> {
     void ConstructTPCGeometry();
 
     /** Define the sensitive volumes of the geometry */
-    void DefineSensitiveVolumes();
+    void DefineSensitiveVolumes() override;
 
     /** container for produced hits */
     std::vector<HitGroup>*  mHitsPerSectorCollection[Sector::MAXSECTOR]; //! container that keeps track-grouped hits per sector


### PR DESCRIPTION
Hi @sawenzel , @matthiasrichter , @ktf , the missing override of TPC::Detector::DefineSensitiveVolumes started to produce an error and blocks other PRs. could you please merge this