### PR TITLE
Allow referencing outputs by label

### DIFF
--- a/Framework/Core/include/Framework/DataAllocator.h
+++ b/Framework/Core/include/Framework/DataAllocator.h
@@ -320,28 +320,24 @@ public:
   {
     return make<T>(getOutputByBind(ref), std::forward<Args>(args)...);
   }
+
  private:
-  FairMQDevice *mDevice;
+  FairMQDevice* mDevice;
   AllowedOutputRoutes mAllowedOutputRoutes;
-  MessageContext *mContext;
-  RootObjectContext *mRootContext;
+  MessageContext* mContext;
+  RootObjectContext* mRootContext;
 
   std::string matchDataHeader(const Output &spec, size_t timeframeId);
   FairMQMessagePtr headerMessageFromOutput(Output const &spec,
                                            std::string const &channel,
                                            o2::header::SerializationMethod serializationMethod);
 
-  Output getOutputByBind(OutputRef const &ref)
+  Output getOutputByBind(OutputRef const& ref)
   {
     for (size_t ri = 0, re = mAllowedOutputRoutes.size(); ri != re; ++ri) {
       if (mAllowedOutputRoutes[ri].matcher.binding.value == ref.label) {
         auto spec = mAllowedOutputRoutes[ri].matcher;
-        return Output{
-          spec.origin,
-          spec.description,
-          ref.subSpec,
-          spec.lifetime
-        };
+        return Output{ spec.origin, spec.description, ref.subSpec, spec.lifetime };
       }
     }
     throw std::runtime_error("Unable to find OutputSpec with label " + ref.label);

--- a/Framework/Core/include/Framework/DataAllocator.h
+++ b/Framework/Core/include/Framework/DataAllocator.h
@@ -12,8 +12,9 @@
 
 #include <fairmq/FairMQDevice.h>
 #include "Headers/DataHeader.h"
-#include "Framework/OutputRoute.h"
 #include "Framework/Output.h"
+#include "Framework/OutputRef.h"
+#include "Framework/OutputRoute.h"
 #include "Framework/DataChunk.h"
 #include "Framework/MessageContext.h"
 #include "Framework/RootObjectContext.h"
@@ -29,6 +30,7 @@
 #include <utility>
 #include <type_traits>
 #include <gsl/span>
+#include <utility>
 
 #include <TClass.h>
 
@@ -42,7 +44,7 @@ namespace framework {
 class DataAllocator
 {
 public:
-  using AllowedOutputsMap = std::vector<OutputRoute>;
+  using AllowedOutputRoutes = std::vector<OutputRoute>;
   using DataHeader = o2::header::DataHeader;
   using DataOrigin = o2::header::DataOrigin;
   using DataDescription = o2::header::DataDescription;
@@ -51,7 +53,7 @@ public:
   DataAllocator(FairMQDevice *device,
                 MessageContext *context,
                 RootObjectContext *rootContext,
-                const AllowedOutputsMap &outputs);
+                const AllowedOutputRoutes &routes);
 
   DataChunk newChunk(const Output&, size_t);
   DataChunk adoptChunk(const Output&, char *, size_t, fairmq_free_fn*, void *);
@@ -313,20 +315,43 @@ public:
                   "pointer to data type not supported by API. Please pass object by reference");
   }
 
+  template <typename T, typename... Args>
+  auto make(OutputRef const& ref, Args&&... args)
+  {
+    return make<T>(getOutputByBind(ref), std::forward<Args>(args)...);
+  }
  private:
+  FairMQDevice *mDevice;
+  AllowedOutputRoutes mAllowedOutputRoutes;
+  MessageContext *mContext;
+  RootObjectContext *mRootContext;
+
   std::string matchDataHeader(const Output &spec, size_t timeframeId);
   FairMQMessagePtr headerMessageFromOutput(Output const &spec,
                                            std::string const &channel,
                                            o2::header::SerializationMethod serializationMethod);
 
+  Output getOutputByBind(OutputRef const &ref)
+  {
+    for (size_t ri = 0, re = mAllowedOutputRoutes.size(); ri != re; ++ri) {
+      if (mAllowedOutputRoutes[ri].matcher.binding.value == ref.label) {
+        auto spec = mAllowedOutputRoutes[ri].matcher;
+        return Output{
+          spec.origin,
+          spec.description,
+          ref.subSpec,
+          spec.lifetime
+        };
+      }
+    }
+    throw std::runtime_error("Unable to find OutputSpec with label " + ref.label);
+    assert(false);
+  }
+
   void addPartToContext(FairMQMessagePtr&& payload,
                         const Output &spec,
                         o2::header::SerializationMethod serializationMethod);
 
-  FairMQDevice *mDevice;
-  AllowedOutputsMap mAllowedOutputs;
-  MessageContext *mContext;
-  RootObjectContext *mRootContext;
 };
 
 }

--- a/Framework/Core/include/Framework/OutputRef.h
+++ b/Framework/Core/include/Framework/OutputRef.h
@@ -1,0 +1,30 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef FRAMEWORK_OUTPUTREF_H
+#define FRAMEWORK_OUTPUTREF_H
+
+#include "Headers/DataHeader.h"
+
+#include <string>
+
+namespace o2
+{
+namespace framework
+{
+
+/// A reference to an output spec
+struct OutputRef {
+  std::string label;
+  header::DataHeader::SubSpecificationType subSpec;
+};
+
+} // namespace framework
+} // namespace o2
+#endif

--- a/Framework/Core/include/Framework/OutputSpec.h
+++ b/Framework/Core/include/Framework/OutputSpec.h
@@ -30,49 +30,41 @@ struct OutputSpec {
   header::DataHeader::SubSpecificationType subSpec = 0;
   enum Lifetime lifetime = Lifetime::Timeframe;
 
-  OutputSpec(OutputLabel const&inBinding,
-             header::DataOrigin inOrigin,
-             header::DataDescription inDescription,
-             header::DataHeader::SubSpecificationType inSubSpec,
-             enum Lifetime inLifetime = Lifetime::Timeframe)
-  : binding{inBinding},
-    origin{inOrigin},
-    description{inDescription},
-    subSpec{inSubSpec},
-    lifetime{inLifetime}
-  {}
+  OutputSpec(OutputLabel const& inBinding, header::DataOrigin inOrigin, header::DataDescription inDescription,
+             header::DataHeader::SubSpecificationType inSubSpec, enum Lifetime inLifetime = Lifetime::Timeframe)
+    : binding{ inBinding },
+      origin{ inOrigin },
+      description{ inDescription },
+      subSpec{ inSubSpec },
+      lifetime{ inLifetime }
+  {
+  }
 
-  OutputSpec(header::DataOrigin inOrigin,
-             header::DataDescription inDescription,
-             header::DataHeader::SubSpecificationType inSubSpec,
-             enum Lifetime inLifetime = Lifetime::Timeframe)
-  : binding{OutputLabel{""}},
-    origin{inOrigin},
-    description{inDescription},
-    subSpec{inSubSpec},
-    lifetime{inLifetime}
-  {}
+  OutputSpec(header::DataOrigin inOrigin, header::DataDescription inDescription,
+             header::DataHeader::SubSpecificationType inSubSpec, enum Lifetime inLifetime = Lifetime::Timeframe)
+    : binding{ OutputLabel{ "" } },
+      origin{ inOrigin },
+      description{ inDescription },
+      subSpec{ inSubSpec },
+      lifetime{ inLifetime }
+  {
+  }
 
-  OutputSpec(OutputLabel const &inBinding,
-             header::DataOrigin inOrigin,
-             header::DataDescription inDescription,
+  OutputSpec(OutputLabel const& inBinding, header::DataOrigin inOrigin, header::DataDescription inDescription,
              enum Lifetime inLifetime = Lifetime::Timeframe)
-  : binding{inBinding},
-    origin{inOrigin},
-    description{inDescription},
-    subSpec{0},
-    lifetime{inLifetime}
-  {}
+    : binding{ inBinding }, origin{ inOrigin }, description{ inDescription }, subSpec{ 0 }, lifetime{ inLifetime }
+  {
+  }
 
-  OutputSpec(header::DataOrigin inOrigin,
-             header::DataDescription inDescription,
+  OutputSpec(header::DataOrigin inOrigin, header::DataDescription inDescription,
              enum Lifetime inLifetime = Lifetime::Timeframe)
-  : binding{OutputLabel{""}},
-    origin{inOrigin},
-    description{inDescription},
-    subSpec{0},
-    lifetime{inLifetime}
-  {}
+    : binding{ OutputLabel{ "" } },
+      origin{ inOrigin },
+      description{ inDescription },
+      subSpec{ 0 },
+      lifetime{ inLifetime }
+  {
+  }
 
   bool operator==(const OutputSpec& that)
   {

--- a/Framework/Core/include/Framework/OutputSpec.h
+++ b/Framework/Core/include/Framework/OutputSpec.h
@@ -16,14 +16,63 @@
 namespace o2 {
 namespace framework {
 
+struct OutputLabel {
+  std::string value;
+};
+
 /// A selector for some kind of data being processed, either in
 /// input or in output. This can be used, for example to match
 /// specific payloads in a timeframe.
 struct OutputSpec {
+  OutputLabel binding;
   header::DataOrigin origin;
   header::DataDescription description;
   header::DataHeader::SubSpecificationType subSpec = 0;
   enum Lifetime lifetime = Lifetime::Timeframe;
+
+  OutputSpec(OutputLabel const&inBinding,
+             header::DataOrigin inOrigin,
+             header::DataDescription inDescription,
+             header::DataHeader::SubSpecificationType inSubSpec,
+             enum Lifetime inLifetime = Lifetime::Timeframe)
+  : binding{inBinding},
+    origin{inOrigin},
+    description{inDescription},
+    subSpec{inSubSpec},
+    lifetime{inLifetime}
+  {}
+
+  OutputSpec(header::DataOrigin inOrigin,
+             header::DataDescription inDescription,
+             header::DataHeader::SubSpecificationType inSubSpec,
+             enum Lifetime inLifetime = Lifetime::Timeframe)
+  : binding{OutputLabel{""}},
+    origin{inOrigin},
+    description{inDescription},
+    subSpec{inSubSpec},
+    lifetime{inLifetime}
+  {}
+
+  OutputSpec(OutputLabel const &inBinding,
+             header::DataOrigin inOrigin,
+             header::DataDescription inDescription,
+             enum Lifetime inLifetime = Lifetime::Timeframe)
+  : binding{inBinding},
+    origin{inOrigin},
+    description{inDescription},
+    subSpec{0},
+    lifetime{inLifetime}
+  {}
+
+  OutputSpec(header::DataOrigin inOrigin,
+             header::DataDescription inDescription,
+             enum Lifetime inLifetime = Lifetime::Timeframe)
+  : binding{OutputLabel{""}},
+    origin{inOrigin},
+    description{inDescription},
+    subSpec{0},
+    lifetime{inLifetime}
+  {}
 
   bool operator==(const OutputSpec& that)
   {

--- a/Framework/Core/src/DataAllocator.cxx
+++ b/Framework/Core/src/DataAllocator.cxx
@@ -24,9 +24,9 @@ using DataProcessingHeader = o2::framework::DataProcessingHeader;
 DataAllocator::DataAllocator(FairMQDevice *device,
                              MessageContext *context,
                              RootObjectContext *rootContext,
-                             const AllowedOutputsMap &outputs)
+                             const AllowedOutputRoutes &routes)
 : mDevice{device},
-  mAllowedOutputs{outputs},
+  mAllowedOutputRoutes{routes},
   mContext{context},
   mRootContext{rootContext}
 {
@@ -35,7 +35,7 @@ DataAllocator::DataAllocator(FairMQDevice *device,
 std::string
 DataAllocator::matchDataHeader(const Output& spec, size_t timeslice) {
   // FIXME: we should take timeframeId into account as well.
-  for (auto &output : mAllowedOutputs) {
+  for (auto &output : mAllowedOutputRoutes) {
     if (DataSpecUtils::match(output.matcher, spec.origin, spec.description, spec.subSpec)
         && ((timeslice % output.maxTimeslices) == output.timeslice)) {
       return output.channel;

--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -187,11 +187,12 @@ void DeviceSpecHelpers::processOutEdgeActions(std::vector<DeviceSpec>& devices, 
     assert(edge.outputGlobalIndex < outputsMatchers.size());
 
     if (edge.isForward == false) {
-      OutputRoute route;
-      route.matcher = outputsMatchers[edge.outputGlobalIndex];
-      route.timeslice = edge.timeIndex;
-      route.maxTimeslices = consumer.maxInputTimeslices;
-      route.channel = channel.name;
+      OutputRoute route{
+        edge.timeIndex,
+        consumer.maxInputTimeslices,
+        outputsMatchers[edge.outputGlobalIndex],
+        channel.name
+      };
       device.outputs.emplace_back(route);
     } else {
       ForwardRoute route;

--- a/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
@@ -11,9 +11,9 @@
 
 using namespace o2::framework;
 
-AlgorithmSpec simplePipe(o2::header::DataDescription what) {
+AlgorithmSpec simplePipe(std::string const &what) {
   return AlgorithmSpec{ [what](ProcessingContext& ctx) {
-    auto bData = ctx.outputs().make<int>(Output{ "TST", what, 0 }, 1);
+    auto bData = ctx.outputs().make<int>(OutputRef{what}, 1);
   } };
 }
 
@@ -24,28 +24,28 @@ void defineDataProcessing(WorkflowSpec &specs) {
     "A",
     Inputs{},
     {
-      OutputSpec{"TST", "A1"},
-      OutputSpec{"TST", "A2"}
+      OutputSpec{{"a1"}, "TST", "A1"},
+      OutputSpec{{"a2"}, "TST", "A2"}
     },
     AlgorithmSpec{
       [](ProcessingContext &ctx) {
        sleep(1);
-       auto aData = ctx.outputs().make<int>(Output{ "TST", "A1", 0 }, 1);
-       auto bData = ctx.outputs().make<int>(Output{ "TST", "A2", 0 }, 1);
+       auto aData = ctx.outputs().make<int>(OutputRef{ "a1" }, 1);
+       auto bData = ctx.outputs().make<int>(OutputRef{ "a2" }, 1);
       }
     }
   },
   {
     "B",
     {InputSpec{"x", "TST", "A1"}},
-    {OutputSpec{"TST", "B1"}},
-    simplePipe(o2::header::DataDescription{"B1"})
+    {OutputSpec{{"b1"}, "TST", "B1"}},
+    simplePipe("b1")
   },
   {
     "C",
     Inputs{InputSpec{"x", "TST", "A2"}},
-    Outputs{OutputSpec{"TST", "C1"}},
-    simplePipe(o2::header::DataDescription{"C1"})
+    Outputs{OutputSpec{{"c1"}, "TST", "C1"}},
+    simplePipe("c1")
   },
   {
     "D",

--- a/Framework/TestWorkflows/src/o2DummyWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DummyWorkflow.cxx
@@ -35,15 +35,15 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
     "reader",
     Inputs{},
     {
-      OutputSpec{"TPC", "CLUSTERS"},
-      OutputSpec{"ITS", "CLUSTERS"}
+      OutputSpec{{"tpc"}, "TPC", "CLUSTERS"},
+      OutputSpec{{"its"}, "ITS", "CLUSTERS"}
     },
     AlgorithmSpec{
       [](ProcessingContext &ctx) {
        sleep(1);
        // Creates a new message of size 1000 which
        // has "TPC" as data origin and "CLUSTERS" as data description.
-       auto tpcClusters = ctx.outputs().make<FakeCluster>(Output{ "TPC", "CLUSTERS", 0 }, 1000);
+       auto tpcClusters = ctx.outputs().make<FakeCluster>(OutputRef{"tpc"}, 1000);
        int i = 0;
 
        for (auto &cluster : tpcClusters) {
@@ -55,7 +55,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
          i++;
        }
 
-       auto itsClusters = ctx.outputs().make<FakeCluster>(Output{ "ITS", "CLUSTERS", 0 }, 1000);
+       auto itsClusters = ctx.outputs().make<FakeCluster>(OutputRef{"its"}, 1000);
        i = 0;
        for (auto &cluster : itsClusters) {
          assert(i < 1000);
@@ -73,9 +73,9 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
   DataProcessorSpec tpcClusterSummary{
     "tpc-cluster-summary",
     { InputSpec{ "clusters", "TPC", "CLUSTERS"} },
-    { OutputSpec{ "TPC", "SUMMARY"} },
+    { OutputSpec{ {"summary"}, "TPC", "SUMMARY"} },
     AlgorithmSpec{ [](ProcessingContext& ctx) {
-      auto tpcSummary = ctx.outputs().make<Summary>(Output{ "TPC", "SUMMARY", 0 }, 1);
+      auto tpcSummary = ctx.outputs().make<Summary>(OutputRef{"summary"}, 1);
       tpcSummary.at(0).inputCount = ctx.inputs().size();
     } },
     { ConfigParamSpec{ "some-cut", VariantType::Float, 1.0f, { "some cut" } } },
@@ -86,10 +86,10 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
     "its-cluster-summary",
     { InputSpec{ "clusters", "ITS", "CLUSTERS" } },
     {
-      OutputSpec{ "ITS", "SUMMARY" },
+      OutputSpec{ {"summary"}, "ITS", "SUMMARY" },
     },
     AlgorithmSpec{ [](ProcessingContext& ctx) {
-      auto itsSummary = ctx.outputs().make<Summary>(Output{ "ITS", "SUMMARY", 0 }, 1);
+      auto itsSummary = ctx.outputs().make<Summary>(OutputRef{"summary"}, 1);
       itsSummary.at(0).inputCount = ctx.inputs().size();
     } },
     { ConfigParamSpec{ "some-cut", VariantType::Float, 1.0f, { "some cut" } } },


### PR DESCRIPTION
This should reduce the verbosity of the output API by allowing assigning
a label to the OutputSpec and use such a label to refer to it.