### PR TITLE
Fix flagging in GRP file for CRO

### DIFF
--- a/macro/run_digi_its.C
+++ b/macro/run_digi_its.C
@@ -2,7 +2,7 @@
 #include <sstream>
 
 #include <TStopwatch.h>
-
+#include "DataFormatsParameters/GRPObject.h"
 #include "FairLogger.h"
 #include "FairRunAna.h"
 #include "FairFileSource.h"
@@ -13,74 +13,114 @@
 #include "ITSSimulation/DigitizerTask.h"
 #endif
 
-void run_digi_its(Int_t nEvents = 10, TString mcEngine = "TGeant3", Bool_t alp=kTRUE, Float_t rate=50.e3)
+int updateITSinGRP(std::string inputGRP, std::string grpName = "GRP");
+
+void run_digi_its(float rate = 50e3, std::string outputfile = "o2dig.root", std::string inputfile = "o2sim.root",
+                  std::string paramfile = "o2sim_par.root", std::string inputGRP = "o2sim_grp.root"
+                  //
+                  // misc options
+                  ,
+                  bool useALPIDE = true)
+// Int_t nEvents = 10, TString mcEngine = "TGeant3", Bool_t useALPIDE=kTRUE, Float_t rate=50.e3, std::string inputGRP =
+// "o2sim_grp.root")
 {
   // if rate>0 then continuous simulation for this rate will be performed
-  
-        // Initialize logger
-        FairLogger *logger = FairLogger::GetLogger();
-        logger->SetLogVerbosityLevel("LOW");
-        logger->SetLogScreenLevel("INFO");
 
-        // Input and output file name
-        std::stringstream inputfile, outputfile, paramfile;
-        inputfile << "AliceO2_" << mcEngine << ".mc_" << nEvents << "_event.root";
-        paramfile << "AliceO2_" << mcEngine << ".params_" << nEvents << ".root";
-        outputfile << "AliceO2_" << mcEngine << ".digi_" << nEvents << "_event.root";
+  // Initialize logger
+  FairLogger* logger = FairLogger::GetLogger();
+  logger->SetLogVerbosityLevel("LOW");
+  logger->SetLogScreenLevel("INFO");
 
-        // Setup timer
-        TStopwatch timer;
+  // Input and output file name
+  // std::stringstream inputfile, outputfile, paramfile;
+  // inputfile << "AliceO2_" << mcEngine << ".mc_" << nEvents << "_event.root";
+  // paramfile << "AliceO2_" << mcEngine << ".params_" << nEvents << ".root";
+  // outputfile << "AliceO2_" << mcEngine << ".digi_" << nEvents << "_event.root";
 
-        // Setup FairRoot analysis manager
-        FairRunAna * fRun = new FairRunAna();
-        FairFileSource *fFileSource = new FairFileSource(inputfile.str().c_str());
-        fRun->SetSource(fFileSource);
-        fRun->SetOutputFile(outputfile.str().c_str());
+  // Setup timer
+  TStopwatch timer;
 
-	if (rate>0) fFileSource->SetEventMeanTime(1.e9/rate); //is in us
-	
-        // Setup Runtime DB
-        FairRuntimeDb* rtdb = fRun->GetRuntimeDb();
-        FairParRootFileIo* parInput1 = new FairParRootFileIo();
-        parInput1->open(paramfile.str().c_str());
-        rtdb->setFirstInput(parInput1);
+  // Setup FairRoot analysis manager
+  FairRunAna* fRun = new FairRunAna();
+  FairFileSource* fFileSource = new FairFileSource(inputfile);
+  fRun->SetSource(fFileSource);
+  fRun->SetOutputFile(outputfile.data());
 
-        // Setup digitizer
-        // Call o2::ITS::DigitizerTask(kTRUE) to activate the ALPIDE simulation
-        o2::ITS::DigitizerTask *digi = new o2::ITS::DigitizerTask(alp);
-	digi->setContinuous(rate>0);
-	digi->setFairTimeUnitInNS(1.0); // tell in which units (wrt nanosecond) FAIT timestamps are
-        fRun->AddTask(digi);
+  if (rate > 0) {
+    fFileSource->SetEventMeanTime(1.e9 / rate); // is in us
+    updateITSinGRP(inputGRP);
+  }
 
-        fRun->Init();
+  // Setup Runtime DB
+  FairRuntimeDb* rtdb = fRun->GetRuntimeDb();
+  FairParRootFileIo* parInput1 = new FairParRootFileIo();
+  parInput1->open(paramfile.data());
+  rtdb->setFirstInput(parInput1);
 
-        timer.Start();
-        fRun->Run();
+  // Setup digitizer
+  // Call o2::ITS::DigitizerTask(kTRUE) to activate the ALPIDE simulation
+  o2::ITS::DigitizerTask* digi = new o2::ITS::DigitizerTask(useALPIDE);
+  digi->setContinuous(rate > 0);
+  digi->setFairTimeUnitInNS(1.0); // tell in which units (wrt nanosecond) FAIT timestamps are
+  fRun->AddTask(digi);
 
-        std::cout << std::endl << std::endl;
+  fRun->Init();
 
-        // Extract the maximal used memory an add is as Dart measurement
-        // This line is filtered by CTest and the value send to CDash
-        FairSystemInfo sysInfo;
-        Float_t maxMemory=sysInfo.GetMaxMemory();
-        std::cout << "<DartMeasurement name=\"MaxMemory\" type=\"numeric/double\">";
-        std::cout << maxMemory;
-        std::cout << "</DartMeasurement>" << std::endl;
+  timer.Start();
+  fRun->Run();
 
-        timer.Stop();
-        Double_t rtime = timer.RealTime();
-        Double_t ctime = timer.CpuTime();
+  std::cout << std::endl << std::endl;
 
-        Float_t cpuUsage=ctime/rtime;
-        cout << "<DartMeasurement name=\"CpuLoad\" type=\"numeric/double\">";
-        cout << cpuUsage;
-        cout << "</DartMeasurement>" << endl;
-        cout << endl << endl;
-        std::cout << "Macro finished succesfully" << std::endl;
+  // Extract the maximal used memory an add is as Dart measurement
+  // This line is filtered by CTest and the value send to CDash
+  FairSystemInfo sysInfo;
+  Float_t maxMemory = sysInfo.GetMaxMemory();
+  std::cout << "<DartMeasurement name=\"MaxMemory\" type=\"numeric/double\">";
+  std::cout << maxMemory;
+  std::cout << "</DartMeasurement>" << std::endl;
 
-        std::cout << endl << std::endl;
-        std::cout << "Output file is "    << outputfile.str() << std::endl;
-        //std::cout << "Parameter file is " << parFile << std::endl;
-        std::cout << "Real time " << rtime << " s, CPU time " << ctime
-                  << "s" << endl << endl;
+  timer.Stop();
+  Double_t rtime = timer.RealTime();
+  Double_t ctime = timer.CpuTime();
+
+  Float_t cpuUsage = ctime / rtime;
+  cout << "<DartMeasurement name=\"CpuLoad\" type=\"numeric/double\">";
+  cout << cpuUsage;
+  cout << "</DartMeasurement>" << endl;
+  cout << endl << endl;
+  std::cout << "Macro finished succesfully" << std::endl;
+
+  std::cout << endl << std::endl;
+  std::cout << "Output file is " << outputfile << std::endl;
+  // std::cout << "Parameter file is " << parFile << std::endl;
+  std::cout << "Real time " << rtime << " s, CPU time " << ctime << "s" << endl << endl;
+}
+
+int updateITSinGRP(std::string inputGRP, std::string grpName)
+{
+  TFile flGRP(inputGRP.data(), "update");
+  if (flGRP.IsZombie()) {
+    LOG(ERROR) << "Failed to open in update mode " << inputGRP << FairLogger::endl;
+    return -10;
+  }
+  auto grp =
+    static_cast<o2::parameters::GRPObject*>(flGRP.GetObjectChecked(grpName.data(), o2::parameters::GRPObject::Class()));
+  if (!grp) {
+    LOG(ERROR) << "Did not find GRP object named " << inputGRP << FairLogger::endl;
+    return -12;
+  }
+
+  vector<o2::detectors::DetID> contDet = { o2::detectors::DetID::ITS };
+
+  for (auto det : contDet) {
+    if (grp->isDetReadOut(det)) {
+      grp->addDetContinuousReadOut(det);
+    }
+  }
+
+  LOG(INFO) << "Updated GRP in " << inputGRP << " flagging continously read-out detector(s)" << FairLogger::endl;
+  grp->print();
+  flGRP.WriteObjectAny(grp, grp->Class(), grpName.data());
+  flGRP.Close();
+  return 0;
 }

--- a/macro/run_digi_its.C
+++ b/macro/run_digi_its.C
@@ -21,8 +21,6 @@ void run_digi_its(float rate = 50e3, std::string outputfile = "o2dig.root", std:
                   // misc options
                   ,
                   bool useALPIDE = true)
-// Int_t nEvents = 10, TString mcEngine = "TGeant3", Bool_t useALPIDE=kTRUE, Float_t rate=50.e3, std::string inputGRP =
-// "o2sim_grp.root")
 {
   // if rate>0 then continuous simulation for this rate will be performed
 
@@ -30,12 +28,6 @@ void run_digi_its(float rate = 50e3, std::string outputfile = "o2dig.root", std:
   FairLogger* logger = FairLogger::GetLogger();
   logger->SetLogVerbosityLevel("LOW");
   logger->SetLogScreenLevel("INFO");
-
-  // Input and output file name
-  // std::stringstream inputfile, outputfile, paramfile;
-  // inputfile << "AliceO2_" << mcEngine << ".mc_" << nEvents << "_event.root";
-  // paramfile << "AliceO2_" << mcEngine << ".params_" << nEvents << ".root";
-  // outputfile << "AliceO2_" << mcEngine << ".digi_" << nEvents << "_event.root";
 
   // Setup timer
   TStopwatch timer;
@@ -123,4 +115,14 @@ int updateITSinGRP(std::string inputGRP, std::string grpName)
   flGRP.WriteObjectAny(grp, grp->Class(), grpName.data());
   flGRP.Close();
   return 0;
+}
+
+void run_digi_its(Int_t nEvents = 10, TString mcEngine = "TGeant3", Bool_t alp = kTRUE, Float_t rate = 50.e3)
+{
+  // Input and output file name
+  std::stringstream inputfile, outputfile, paramfile;
+  inputfile << "AliceO2_" << mcEngine << ".mc_" << nEvents << "_event.root";
+  paramfile << "AliceO2_" << mcEngine << ".params_" << nEvents << ".root";
+  outputfile << "AliceO2_" << mcEngine << ".digi_" << nEvents << "_event.root";
+  run_digi_its(rate, outputfile.str().c_str(), inputfile.str().c_str(), paramfile.str().c_str(), "", alp);
 }

--- a/macro/run_digi_its.sh
+++ b/macro/run_digi_its.sh
@@ -1,1 +1,1 @@
-root.exe -b  -q SetIncludePath.C run_digi_its.C++\($1,\""$2"\"\)
+root.exe -b -q SetIncludePath.C run_digi_its.C++""

--- a/macro/run_digi_its.sh
+++ b/macro/run_digi_its.sh
@@ -1,1 +1,1 @@
-root.exe -b -q SetIncludePath.C run_digi_its.C++""
+root.exe -b -q SetIncludePath.C run_digi_its.C++\($1,\""$2"\"\)


### PR DESCRIPTION
- Current macro for digitization does not set the proper flag for continuous readout mode in ITS in the `o2sim_grp.root` file.
- Adapted the function to be more friendly when working with files generated with `o2sim`.
- The changes are freely picked up from the `run_digi_all.C` macro in the same directory, adapted to work with ITS only.
- Notice that this can be taken as a proposal, but my idea is that eventually we would have something that works properly with continuous readout. 
