### PR TITLE
Defining stream output operator for Framework/InputSpec.h

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -54,6 +54,7 @@ set(SRCS
     src/WorkflowSpec.cxx
     src/runDataProcessing.cxx
     src/TMessageSerializer.cxx
+    src/StreamOperators.cxx
     ${GUI_SOURCES}
     test/TestClasses.cxx
    )

--- a/Framework/Core/include/Framework/InputSpec.h
+++ b/Framework/Core/include/Framework/InputSpec.h
@@ -11,6 +11,7 @@
 #define FRAMEWORK_INPUTSPEC_H
 
 #include <string>
+#include <ostream>
 #include "Framework/Lifetime.h"
 #include "Headers/DataHeader.h"
 
@@ -26,6 +27,8 @@ struct InputSpec {
   header::DataDescription description;
   header::DataHeader::SubSpecificationType subSpec = 0;
   enum Lifetime lifetime = Lifetime::Timeframe;
+
+  friend std::ostream& operator<<(std::ostream& stream, InputSpec const& arg);
 };
 
 }

--- a/Framework/Core/src/StreamOperators.cxx
+++ b/Framework/Core/src/StreamOperators.cxx
@@ -1,0 +1,27 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <ostream>
+#include "Framework/InputSpec.h"
+
+namespace o2
+{
+namespace framework
+{
+
+std::ostream& operator<<(std::ostream& stream, o2::framework::InputSpec const& arg)
+{
+  // FIXME: should have stream operators for the header fields
+  stream << arg.binding << " {" << arg.origin.str << ":" << arg.description.str << ":" << arg.subSpec << "}";
+  return stream;
+}
+
+} // namespace framework
+} // namespace o2


### PR DESCRIPTION
This is a small addition to allow convenient printout, more operators like this can go into the same file