### PR TITLE
MCStepLogger: Clear lookup structure for each entry

### DIFF
--- a/Utilities/MCStepLogger/src/MCStepLoggerImpl.cxx
+++ b/Utilities/MCStepLogger/src/MCStepLoggerImpl.cxx
@@ -307,6 +307,9 @@ class StepLogger
     } else {
       flushToTTree("Steps", &container);
       flushToTTree("Lookups", &StepInfo::lookupstructures);
+      // we need to reset some parts of the lookupstructures for the next event
+      StepInfo::lookupstructures.tracktoparent.clear();
+      StepInfo::lookupstructures.tracktopdg.clear();
     }
     clear();
   }


### PR DESCRIPTION
Some lookup structures need to be cleared for each logged event;
This was previously forgotten.