### PR TITLE
SimReader device + TPC digitization using DPL

### DIFF
--- a/Detectors/TPC/simulation/include/TPCSimulation/HitDriftFilter.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/HitDriftFilter.h
@@ -1,0 +1,92 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file HitDriftFiler.h
+/// \brief Utility functions to filter hits within a given time window
+/// \author sandro.wenzel@cern.ch
+
+#ifndef ALICEO2_TPC_HitDriftFilter_H_
+#define ALICEO2_TPC_HitDriftFilter_H_
+
+namespace o2
+{
+namespace TPC
+{
+
+template <typename Collection>
+void getHits(TChain& chain, const Collection& eventrecords, std::vector<std::vector<o2::TPC::HitGroup>*>& hitvectors,
+             std::vector<o2::TPC::TPCHitGroupID>& hitids, const char* branchname, float tmin /*NS*/, float tmax /*NS*/,
+             std::function<float(float, float, float)>&& f)
+{
+  // f is some function taking event time + z of hit and returns final "digit" time
+  LOG(DEBUG) << "BR NAME " << branchname;
+  auto br = chain.GetBranch(branchname);
+  if (!br) {
+    LOG(ERROR) << "No branch found";
+    return;
+  }
+
+  auto nentries = br->GetEntries();
+
+  // do the filtering
+  for (int entry = 0; entry < nentries; ++entry) {
+    if (tmin > f(eventrecords[entry].timeNS, 0, 0)) {
+      continue;
+    }
+    if (tmax < f(eventrecords[entry].timeNS, 0, 250)) {
+      break;
+    }
+
+    // This needs to be done only once for any entry
+    if (hitvectors[entry] == nullptr) {
+      br->SetAddress(&hitvectors[entry]);
+      br->GetEntry(entry);
+    }
+
+    int groupid = -1;
+    auto groups = hitvectors[entry];
+    for (auto& singlegroup : *groups) {
+      if (singlegroup.getSize() == 0) {
+        // there are not hits in this group .. so continue
+        // TODO: figure out why such a group would exist??
+        continue;
+      }
+      const auto& pos = singlegroup.getHit(0).getPos();
+      // std::cout << "This Group is in sector " << o2::TPC::Sector::ToSector(pos.X(), pos.Y(), pos.Z()) << "\n";
+      groupid++;
+      auto zmax = singlegroup.mZAbsMax;
+      auto zmin = singlegroup.mZAbsMin;
+      // in case of secondaries, the time ordering may be reversed
+      if (zmax < zmin) {
+        std::swap(zmax, zmin);
+      }
+      // auto tof = singlegroup.
+      float tmaxtrack = f(eventrecords[entry].timeNS, 0., zmin);
+      float tmintrack = f(eventrecords[entry].timeNS, 0., zmax);
+      if (tmin > tmaxtrack || tmax < tmintrack) {
+        // std::cout << "DISCARDING " << groupid << " OF ENTRY " << entry << "\n";
+        continue;
+      }
+      // need to record index of the group
+      hitids.emplace_back(entry, groupid);
+    }
+  }
+}
+
+// TPC hit selection lambda
+auto calcDriftTime = [](float tNS, float tof, float z) {
+  // returns time in NS
+  return tNS + o2::TPC::ElectronTransport::getDriftTime(z) * 1000 + tof;
+};
+
+} // end namespace TPC
+} // end namespace o2
+
+#endif

--- a/Detectors/TPC/simulation/include/TPCSimulation/Point.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/Point.h
@@ -30,6 +30,7 @@ class ElementalHit {
   float GetX() const { return mPos.X(); }
   float GetY() const { return mPos.Y(); }
   float GetZ() const { return mPos.Z(); }
+  const ::Point3D<float>& getPos() const { return mPos; }
   float GetEnergyLoss() const { return mELoss; }
   float GetTime() const { return mTime; }
 

--- a/Detectors/TPC/simulation/src/DigitizerTask.cxx
+++ b/Detectors/TPC/simulation/src/DigitizerTask.cxx
@@ -55,8 +55,10 @@ DigitizerTask::DigitizerTask(int sectorid)
 DigitizerTask::~DigitizerTask()
 {
   delete mDigitizer;
-  delete mDigitsArray;
-  delete mDigitsDebugArray;
+  // We need to clarify the ownsership of these potentially external containers
+  // and reenable the cleanup
+  // delete mDigitsArray;
+  // delete mDigitsDebugArray;
 }
 
 InitStatus DigitizerTask::Init()

--- a/Steer/CMakeLists.txt
+++ b/Steer/CMakeLists.txt
@@ -28,3 +28,5 @@ O2_GENERATE_TESTS(
   BUCKET_NAME ${BUCKET_NAME}
   TEST_SRCS ${TEST_SRCS}
 )
+
+add_subdirectory(DigitizerWorkflow)

--- a/Steer/DigitizerWorkflow/CMakeLists.txt
+++ b/Steer/DigitizerWorkflow/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Copyright CERN and copyright holders of ALICE O2. This software is
+# distributed under the terms of the GNU General Public License v3 (GPL
+# Version 3), copied verbatim in the file "COPYING".
+#
+# See https://alice-o2.web.cern.ch/ for full licensing information.
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+set(MODULE_NAME "DigitizerWorkflow")
+set(MODULE_BUCKET_NAME run_bucket)
+
+O2_SETUP(NAME ${MODULE_NAME})
+
+## TODO: feature of macro, it deletes the variables we pass to it, set them again
+## this has to be fixed in the macro implementation
+set(BUCKET_NAME ${MODULE_BUCKET_NAME})
+
+O2_GENERATE_EXECUTABLE(
+  EXE_NAME digitizer-workflow
+
+  SOURCES
+  src/SimpleDigitizerWorkflow.cxx
+  src/SimReaderSpec.cxx
+  src/CollisionTimePrinter.cxx
+  src/TPCDriftTimeDigitizerSpec.cxx
+
+  BUCKET_NAME ${MODULE_BUCKET_NAME}
+)

--- a/Steer/DigitizerWorkflow/src/CollisionTimePrinter.cxx
+++ b/Steer/DigitizerWorkflow/src/CollisionTimePrinter.cxx
@@ -1,0 +1,72 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "CollisionTimePrinter.h"
+#include <Steer/InteractionSampler.h>
+#include "Headers/DataHeader.h"
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/DataRefUtils.h"
+#include "Headers/DataHeader.h"
+#include "Framework/Lifetime.h"
+#include "Framework/ControlService.h"
+#include "Steer/HitProcessingManager.h"
+#include <FairMQLogger.h>
+#include <TMessage.h> // object serialization
+#include <memory>     // std::unique_ptr
+#include <cstring>    // memcpy
+#include <string>     // std::string
+
+using namespace o2::framework;
+using SubSpecificationType = o2::framework::DataAllocator::SubSpecificationType;
+namespace o2
+{
+namespace steer
+{
+
+// a very simple DataProcessor consuming data sent
+// from the SimReader
+// mainly here for debugging/demonstration
+DataProcessorSpec getCollisionTimePrinter(int channel)
+{
+  // set up the processing function
+
+  // init function return a lambda taking a ProcessingContext
+  auto doIt = [](ProcessingContext& pc) {
+    std::cout << " ######### ";
+
+    // access data
+    auto dataref = pc.inputs().get("input");
+    auto header = o2::header::get<const o2::header::DataHeader*>(dataref.header);
+    LOG(INFO) << "PAYLOAD SIZE " << header->payloadSize;
+
+    const auto context = pc.inputs().get<o2::steer::RunContext>("input");
+    //    auto view = DataRefUtils::as<o2::MCInteractionRecord>(dataref);
+    auto view = context->getEventRecords();
+    LOG(INFO) << "GOT " << view.size() << "times";
+    int counter = 0;
+    for (auto& collrecord : view) {
+      LOG(INFO) << "TIME " << counter++ << " : " << collrecord.timeNS;
+    }
+    pc.services().get<ControlService>().readyToQuit(false);
+  };
+
+  return DataProcessorSpec{ /*ID*/ "CollTimePrinter",
+                            /*INPUT CHANNELS*/ Inputs{ InputSpec{ "input", "SIM", "EVENTTIMES",
+                                                                  static_cast<SubSpecificationType>(channel),
+                                                                  Lifetime::Timeframe } },
+                            /*OUTPUT CHANNELS*/ Outputs{},
+                            /* ALGORITHM */
+                            AlgorithmSpec(doIt),
+                            /* OPTIONS */
+                            Options{} };
+}
+}
+}

--- a/Steer/DigitizerWorkflow/src/CollisionTimePrinter.h
+++ b/Steer/DigitizerWorkflow/src/CollisionTimePrinter.h
@@ -8,14 +8,17 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#ifndef STEER_DIGITIZERWORKFLOW_SRC_COLLISIONTIMEPRINTER_H_
+#define STEER_DIGITIZERWORKFLOW_SRC_COLLISIONTIMEPRINTER_H_
 
-#ifdef __CLING__
-#pragma link off all globals;
-#pragma link off all classes;
-#pragma link off all functions;
+#include "Framework/DataProcessorSpec.h"
 
-#pragma link C++ class o2::steer::O2RunAna;
-#pragma link C++ class o2::steer::InteractionSampler+;
-#pragma link C++ class o2::steer::RunContext+;
+namespace o2
+{
+namespace steer
+{
+o2::framework::DataProcessorSpec getCollisionTimePrinter(int subchannel);
+}
+}
 
-#endif
+#endif /* STEER_DIGITIZERWORKFLOW_SRC_COLLISIONTIMEPRINTER_H_ */

--- a/Steer/DigitizerWorkflow/src/SimReaderSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/SimReaderSpec.cxx
@@ -1,0 +1,82 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "SimReaderSpec.h"
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/DataRefUtils.h"
+#include "Framework/ControlService.h"
+#include "Framework/Lifetime.h"
+#include "Headers/DataHeader.h"
+#include "Steer/HitProcessingManager.h"
+#include <FairMQLogger.h>
+#include <TMessage.h> // object serialization
+#include <memory>     // std::unique_ptr
+#include <cstring>    // memcpy
+#include <string>     // std::string
+#include <cassert>
+#include <chrono>
+#include <thread>
+
+using namespace o2::framework;
+using SubSpecificationType = o2::framework::DataAllocator::SubSpecificationType;
+namespace o2
+{
+namespace steer
+{
+DataProcessorSpec getSimReaderSpec(int fanoutsize)
+{
+  auto doit = [fanoutsize](ProcessingContext& pc) {
+    auto& mgr = steer::HitProcessingManager::instance();
+    auto eventrecords = mgr.getRunContext().getEventRecords();
+    const auto& context = mgr.getRunContext();
+
+    // counter to make sure we are sending the data only once
+    static int counter = 0;
+    if (counter++ == 0) {
+      // sleep(10);
+      LOG(INFO) << "SENDING " << eventrecords.size() << " records";
+
+      for (int subchannel = 0; subchannel < fanoutsize; ++subchannel) {
+        pc.outputs().snapshot(
+          Output{ "SIM", "EVENTTIMES", static_cast<SubSpecificationType>(subchannel), Lifetime::Timeframe }, context);
+      }
+
+      // do this only one
+      pc.services().get<ControlService>().readyToQuit(false);
+    }
+  };
+
+  // init function return a lambda taking a ProcessingContext
+  auto initIt = [doit](InitContext& ctx) {
+    // initialize fundamental objects
+    auto& mgr = steer::HitProcessingManager::instance();
+    mgr.addInputFile(ctx.options().get<std::string>("simFile").c_str());
+    mgr.setupRun();
+
+    LOG(INFO) << "Initializing Spec ... have " << mgr.getRunContext().getEventRecords().size() << " times ";
+    return doit;
+  };
+
+  std::vector<OutputSpec> outputs;
+  for (int subchannel = 0; subchannel < fanoutsize; ++subchannel) {
+    outputs.emplace_back(
+      OutputSpec{ "SIM", "EVENTTIMES", static_cast<SubSpecificationType>(subchannel), Lifetime::Timeframe });
+  }
+
+  return DataProcessorSpec{ /*ID*/ "SimReader",
+                            /*INPUT CHANNELS*/ Inputs{}, outputs,
+                            /* ALGORITHM */
+                            AlgorithmSpec{ initIt },
+                            /* OPTIONS */
+                            Options{ { "simFile", VariantType::String, "o2sim.root", { "Sim input filename" } } } };
+}
+}
+}

--- a/Steer/DigitizerWorkflow/src/SimReaderSpec.h
+++ b/Steer/DigitizerWorkflow/src/SimReaderSpec.h
@@ -8,14 +8,17 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#ifndef O2_STEER_SIMREADERSPEC_H
+#define O2_STEER_SIMREADERSPEC_H
 
-#ifdef __CLING__
-#pragma link off all globals;
-#pragma link off all classes;
-#pragma link off all functions;
+#include "Framework/DataProcessorSpec.h"
 
-#pragma link C++ class o2::steer::O2RunAna;
-#pragma link C++ class o2::steer::InteractionSampler+;
-#pragma link C++ class o2::steer::RunContext+;
+namespace o2
+{
+namespace steer
+{
+o2::framework::DataProcessorSpec getSimReaderSpec(int fanoutsize);
+}
+}
 
-#endif
+#endif // O2_STEER_SIMREADERSPEC_H

--- a/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
+++ b/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
@@ -1,0 +1,40 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/WorkflowSpec.h"
+#include "Framework/runDataProcessing.h"
+
+#include "SimReaderSpec.h"
+#include "CollisionTimePrinter.h"
+
+// for TPC
+#include "TPCDriftTimeDigitizerSpec.h"
+
+using namespace o2::framework;
+
+/// This function is required to be implemented to define the workflow
+/// specifications
+void defineDataProcessing(WorkflowSpec& specs)
+{
+  specs.clear();
+
+  int fanoutsize = 0;
+
+  //
+  // specs.emplace_back(o2::steer::getCollisionTimePrinter(fanoutsize++));
+
+  // parallely processing the first 6 TPC sectors
+  for (int s = 0; s < 6; ++s) {
+    // probably a parallel construct can be used here
+    specs.emplace_back(o2::steer::getTPCDriftTimeDigitizer(s, fanoutsize++));
+  }
+
+  specs.emplace_back(o2::steer::getSimReaderSpec(fanoutsize));
+}

--- a/Steer/DigitizerWorkflow/src/TPCDriftTimeDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TPCDriftTimeDigitizerSpec.cxx
@@ -1,0 +1,231 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "TPCDriftTimeDigitizerSpec.h"
+#include <FairMQLogger.h>
+#include <TMessage.h> // object serialization
+#include <cassert>
+#include <cstring> // memcpy
+#include <memory>  // std::unique_ptr
+#include <string>  // std::string
+#include "Framework/ControlService.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/DataRefUtils.h"
+#include "Framework/Lifetime.h"
+#include "Headers/DataHeader.h"
+#include "Steer/HitProcessingManager.h"
+#include <TPCSimulation/Digitizer.h>
+#include <TPCSimulation/DigitizerTask.h>
+#include <functional>
+#include "ITSMFTSimulation/Hit.h"
+#include "TPCSimulation/Point.h"
+#include "TPCSimulation/ElectronTransport.h"
+#include "TStopwatch.h"
+#include <sstream>
+#include <algorithm>
+
+using namespace o2::framework;
+using SubSpecificationType = o2::framework::DataAllocator::SubSpecificationType;
+namespace o2
+{
+namespace steer
+{
+
+template <typename Collection>
+void getHits(TChain& chain, const Collection& eventrecords, std::vector<std::vector<o2::TPC::HitGroup>*>& hitvectors,
+             std::vector<o2::TPC::TPCHitGroupID>& hitids, const char* branchname, float tmin /*NS*/, float tmax /*NS*/,
+             std::function<float(float, float, float)>&& f)
+{
+  // f is some function taking event time + z of hit and returns final "digit" time
+  LOG(DEBUG) << "BR NAME " << branchname;
+  auto br = chain.GetBranch(branchname);
+  if (!br) {
+    LOG(ERROR) << "No branch found";
+    return;
+  }
+
+  auto nentries = br->GetEntries();
+
+  // do the filtering
+  for (int entry = 0; entry < nentries; ++entry) {
+    if (tmin > f(eventrecords[entry].timeNS, 0, 0)) {
+      continue;
+    }
+    if (tmax < f(eventrecords[entry].timeNS, 0, 250)) {
+      break;
+    }
+
+    // This needs to be done only once for any entry
+    if (hitvectors[entry] == nullptr) {
+      br->SetAddress(&hitvectors[entry]);
+      br->GetEntry(entry);
+    }
+
+    int groupid = -1;
+    auto groups = hitvectors[entry];
+    for (auto& singlegroup : *groups) {
+      if (singlegroup.getSize() == 0) {
+        // there are not hits in this group .. so continue
+        // TODO: figure out why such a group would exist??
+        continue;
+      }
+      const auto& pos = singlegroup.getHit(0).getPos();
+      // std::cout << "This Group is in sector " << o2::TPC::Sector::ToSector(pos.X(), pos.Y(), pos.Z()) << "\n";
+      groupid++;
+      auto zmax = singlegroup.mZAbsMax;
+      auto zmin = singlegroup.mZAbsMin;
+      // in case of secondaries, the time ordering may be reversed
+      if (zmax < zmin) {
+        std::swap(zmax, zmin);
+      }
+      // auto tof = singlegroup.
+      float tmaxtrack = f(eventrecords[entry].timeNS, 0., zmin);
+      float tmintrack = f(eventrecords[entry].timeNS, 0., zmax);
+      if (tmin > tmaxtrack || tmax < tmintrack) {
+        // std::cout << "DISCARDING " << groupid << " OF ENTRY " << entry << "\n";
+        continue;
+      }
+      // need to record index of the group
+      hitids.emplace_back(entry, groupid);
+    }
+  }
+}
+
+// TPC hit selection lambda
+auto fTPC = [](float tNS, float tof, float z) {
+  // returns time in NS
+  return tNS + o2::TPC::ElectronTransport::getDriftTime(z) * 1000 + tof;
+};
+
+DataProcessorSpec getTPCDriftTimeDigitizer(int sector, int channel, bool cachehits)
+{
+  TChain* simChain = new TChain("o2sim");
+  std::stringstream branchnamestreamleft;
+  branchnamestreamleft << "TPCHitsShiftedSector" << int(o2::TPC::Sector::getLeft(o2::TPC::Sector(sector)));
+  std::string branchnameleft = branchnamestreamleft.str();
+  std::stringstream branchnamestreamright;
+  branchnamestreamright << "TPCHitsShiftedSector" << sector;
+  std::string branchnameright = branchnamestreamright.str();
+
+  auto digitizertask = std::make_shared<o2::TPC::DigitizerTask>();
+  digitizertask->Init2();
+  // the task takes the ownership of digit array + mc truth array
+  // TODO: make this clear in the API
+
+  auto digitArray = std::make_shared<std::vector<o2::TPC::Digit>>();
+  auto mcTruthArray = std::make_shared<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>();
+  digitizertask->setOutputData(digitArray.get(), mcTruthArray.get());
+
+  auto doit = [simChain, branchnameleft, branchnameright, sector, digitizertask, digitArray,
+               mcTruthArray](ProcessingContext& pc) {
+    static int callcounter = 0;
+    callcounter++;
+
+    // ===| open file and register branches |=====================================
+    // this is done at the moment for each worker function invocation
+    // TODO: make this nicer or let the write service be handled outside
+    auto file = std::make_unique<TFile>(Form("tpc_digi_%i_instance%i.root", sector, callcounter), "recreate");
+    auto outtree = std::make_unique<TTree>("o2sim", "TPC digits");
+    outtree->SetDirectory(file.get());
+    auto digitArrayRaw = digitArray.get();
+    auto mcTruthArrayRaw = mcTruthArray.get();
+    auto digitBranch = outtree->Branch(Form("TPCDigit_%i", sector), &digitArrayRaw);
+    auto mcTruthBranch = outtree->Branch(Form("TPCDigitMCTruth_%i", sector), &mcTruthArrayRaw);
+
+    // obtain collision contexts
+    auto dataref = pc.inputs().get("timeinput");
+    auto header = o2::header::get<const o2::header::DataHeader*>(dataref.header);
+
+    auto context = pc.inputs().get<o2::steer::RunContext>("timeinput");
+    auto timesview = context->getEventRecords();
+    LOG(DEBUG) << "GOT " << timesview.size() << " COLLISSION TIMES";
+
+    // if there is nothing ... return
+    if (timesview.size() == 0) {
+      return;
+    }
+
+    TStopwatch timer;
+    timer.Start();
+
+    // detect number of possible drift times (remember that a drift
+    // time is convenient unit for digit pileup), any multiple of this
+    // unit should also be ok
+    const auto TPCDRIFT = 100000;
+    double maxtime = 0;
+    for (auto e : timesview) {
+      maxtime = std::max(maxtime, e.timeNS);
+    }
+
+    // minimum 2 drifts is a safe bet; an electron might
+    // need 1 full drift and might hence land in the second drift time
+    auto ndrifts = 2 + (int)(maxtime / TPCDRIFT);
+
+    std::vector<std::vector<o2::TPC::HitGroup>*> hitvectorsleft;  // "TPCHitVector"
+    std::vector<o2::TPC::TPCHitGroupID> hitidsleft;               // "TPCHitIDs"
+    std::vector<std::vector<o2::TPC::HitGroup>*> hitvectorsright; // "TPCHitVector"
+    std::vector<o2::TPC::TPCHitGroupID> hitidsright;              // "TPCHitIDs"
+    hitvectorsleft.resize(timesview.size(), nullptr);
+    hitvectorsright.resize(timesview.size(), nullptr);
+
+    // have to do a loop over drift times
+    for (int drift = 1; drift <= ndrifts; ++drift) {
+      auto starttime = (drift - 1) * TPCDRIFT;
+      auto endtime = drift * TPCDRIFT;
+      LOG(DEBUG) << "STARTTIME " << starttime << " ENDTIME " << endtime;
+      digitizertask->setStartTime(starttime);
+      digitizertask->setEndTime(endtime);
+
+      // obtain candidate hit(ids) for this time range --> left
+      getHits(*simChain, timesview, hitvectorsleft, hitidsleft, branchnameleft.c_str(), starttime, endtime, fTPC);
+      // --> right
+      getHits(*simChain, timesview, hitvectorsright, hitidsright, branchnameright.c_str(), starttime, endtime, fTPC);
+
+      LOG(DEBUG) << "DRIFTTIME " << drift << " SECTOR " << sector << " : SELECTED LEFT " << hitidsleft.size() << " IDs"
+                 << " SELECTED RIGHT " << hitidsright.size();
+
+      // invoke digitizer if anything to digitize within this drift interval
+      if (hitidsleft.size() > 0 || hitidsright.size() > 0) {
+        digitizertask->setData(&hitvectorsleft, &hitvectorsright, &hitidsleft, &hitidsright, context.get());
+        digitizertask->setupSector(sector);
+        digitizertask->Exec2("");
+
+        // write digits + MC truth
+        outtree->Fill();
+      }
+    }
+    outtree->SetDirectory(file.get());
+    file->Write();
+    timer.Stop();
+    LOG(INFO) << "Digitization took " << timer.CpuTime() << "s";
+
+    pc.services().get<ControlService>().readyToQuit(false);
+  };
+
+  // init function return a lambda taking a ProcessingContext
+  auto initIt = [simChain, doit](InitContext& ctx) {
+    // setup the input chain
+    simChain->AddFile("o2sim.root");
+    return doit;
+  };
+
+  std::stringstream id;
+  id << "TPCDigitizer" << sector;
+  return DataProcessorSpec{
+    id.str().c_str(), Inputs{ InputSpec{ "timeinput", "SIM", "EVENTTIMES", static_cast<SubSpecificationType>(channel),
+                                         Lifetime::Timeframe } },
+    Outputs{
+      // define channel by triple of (origin, type id of data to be sent on this channel, subspecification)
+    },
+    AlgorithmSpec{ initIt }, Options{ /*{ "simFile", VariantType::String, "o2sim.root", { "Sim input filename" } }*/ }
+  };
+}
+}
+}

--- a/Steer/DigitizerWorkflow/src/TPCDriftTimeDigitizerSpec.h
+++ b/Steer/DigitizerWorkflow/src/TPCDriftTimeDigitizerSpec.h
@@ -8,14 +8,17 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#ifndef STEER_DIGITIZERWORKFLOW_SRC_TPCDRIFTTIMEFILTER_H_
+#define STEER_DIGITIZERWORKFLOW_SRC_TPCDRIFTTIMEFILTER_H_
 
-#ifdef __CLING__
-#pragma link off all globals;
-#pragma link off all classes;
-#pragma link off all functions;
+#include "Framework/DataProcessorSpec.h"
 
-#pragma link C++ class o2::steer::O2RunAna;
-#pragma link C++ class o2::steer::InteractionSampler+;
-#pragma link C++ class o2::steer::RunContext+;
+namespace o2
+{
+namespace steer
+{
+o2::framework::DataProcessorSpec getTPCDriftTimeDigitizer(int sector, int channel, bool cachehits = false);
+}
+}
 
-#endif
+#endif /* STEER_DIGITIZERWORKFLOW_SRC_TPCDRIFTTIMEFILTER_H_ */

--- a/Steer/include/Steer/HitProcessingManager.h
+++ b/Steer/include/Steer/HitProcessingManager.h
@@ -38,12 +38,13 @@ class RunContext
   int getNEntries() const { return mNofEntries; }
   const std::vector<o2::MCInteractionRecord>& getEventRecords() const { return mEventRecords; }
  private:
-  int mNofEntries;
+  int mNofEntries; //!
   std::vector<o2::MCInteractionRecord> mEventRecords;
   // std::vector<EventIndices> mEvents; // EventIndices (sourceID, chainID, entry ID)
-  TChain* mChain; // pointer to input chain
+  TChain* mChain; //! pointer to input chain
 
   friend class HitProcessingManager;
+  ClassDef(RunContext, 1);
 };
 
 using RunFunct_t = std::function<void(const RunContext&)>;
@@ -73,9 +74,11 @@ class HitProcessingManager
 
   void registerRunFunction(RunFunct_t&& f);
 
+  void setupRun();
+  const RunContext& getRunContext() { return mRunContext; }
+
  private:
   HitProcessingManager() : mSimChain("o2sim") {}
-  void setupRun();
   void setupChain();
 
   std::vector<RunFunct_t> mRegisteredRunFunctions;

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -1328,6 +1328,7 @@ o2_define_bucket(
     Field
     Generators
     DataFormatsParameters
+    Framework
 )
 
 o2_define_bucket(

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -1310,7 +1310,6 @@ o2_define_bucket(
     DEPENDENCIES
     #-- buckets follow
     fairroot_base_bucket
-    pythia8
 
     #-- precise modules follow
     SimConfig


### PR DESCRIPTION
This commit provides a step/initial components towards
the processing of simulated hits using the O2 Data Processing Layer.

The main components are

a) SimReader:

A device which is supposed to read and preprocess hit files generated
by detector simulation. Main tasks are

  - reading hits from background + signal simulations
  - assigning/sampling collision times based on bunch-crossing parameters
  - sampling of background/signal scenarios
  - propagating generated information to consuming devices (such as digitization)

b) TPCDriftTimeDigitizer:

A device doing (sectorwise) digitization for the TPC.
The digitization is done in units of drift times which makes
the pileup handling convenient.

What this PR achieves:

  - Demonstration of a new parallel workflow using a realistic task
    from simulation

Note that these components are still under heavy development.
The features, names as well as file locations are still likely to change.