### PR TITLE
FIT: Use new TVirtual::TrackPosition interface

### DIFF
--- a/Detectors/FIT/simulation/src/Detector.cxx
+++ b/Detectors/FIT/simulation/src/Detector.cxx
@@ -8,9 +8,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#include "TClonesArray.h"
 #include "TGeoManager.h" // for TGeoManager
-#include "TLorentzVector.h"
 #include "TMath.h"
 #include "TGraph.h"
 #include "TString.h"
@@ -269,12 +267,9 @@ Bool_t Detector::ProcessHits(FairVolume* v)
 {
   Int_t quadrant, mcp;
 
-  TLorentzVector position;
   if (fMC->IsTrackEntering()) {
-    fMC->TrackPosition(position);
-    float x = position.X();
-    float y = position.Y();
-    float z = position.Z();
+    float x, y, z;
+    fMC->TrackPosition(x, y, z);
     fMC->CurrentVolID(quadrant);
     fMC->CurrentVolOffID(1, mcp);
     float time = fMC->TrackTime() * 1.0e12;


### PR DESCRIPTION
* remove unused includes
* remove use of TLorentzVector in favour of faster
  TVirtualTrackPosition(float, float, float) interface