### PR TITLE
Framework: Generalize quitting control logic

### DIFF
--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -419,6 +419,14 @@ void processChildrenOutput(DriverInfo& driverInfo, DeviceInfos& infos, DeviceSpe
               deviceInfo.readyToQuit = true;
             }
           }
+          // in case of "ME", fetch the pid and modify only matching deviceInfos
+          if (validFor == "ME") {
+            for (auto& deviceInfo : infos) {
+              if (deviceInfo.pid == info.pid) {
+                deviceInfo.readyToQuit = true;
+              }
+            }
+          }
         }
       } else if (!control.quiet && (strstr(token.c_str(), control.logFilter) != nullptr) &&
                  logLevel >= control.logLevel) {


### PR DESCRIPTION
This generalizes the exit control logic
to allow exiting from devices marked with "readToQuit(false)".

With this, my workflows are now able to quit themselves when work is done using
the "readyToQuit(false)" API.