### PR TITLE
Some helpful message of why a simulation environment cannot be found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,17 @@ find_library(VMCLIB libgeant4vmc.dylib libgeant4vmc.so HINTS ENV LD_LIBRARY_PATH
 if (G4RUNLIB AND G3RUNLIB AND VMCLIB AND Pythia6_FOUND AND PYTHIA8_FOUND)
   SET (HAVESIMULATION 1)
   message(STATUS "Simulation environment found")
+else()
+  message(STATUS "Simulation environment not found : at least one of the variables G4RUNLIB, G3RUNLIB, VMCLIB, Pythia6_FOUND or PYTHIA8_FOUND was not set correctly.")
+  message(STATUS "All of them are needed for a simulation environment.")
+  message(STATUS "That might not be a problem if you don't care about simulation though.")
+  message(STATUS "G4RUNLIB=${G4RUNLIB}")
+  message(STATUS "G3RUNLIB=${G3RUNLIB}")
+  message(STATUS "VMCLIB=${VMCLIB}")
+  message(STATUS "Pythia6_FOUND=${Pythia6_FOUND}")
+  message(STATUS "PYTHIA8_FOUND=${PYTHIA8_FOUND}")
 endif()
+
 
 # Build type for coverage builds
 set(CMAKE_CXX_FLAGS_COVERAGE "-g -O2 -fprofile-arcs -ftest-coverage")


### PR DESCRIPTION
When not using alibuild to configure a build (e.g. from CLion or VSCode with Ninja for instance...), I've ran a couple of times into the issue of not getting the simulation stuff (e.g. o2sim) built (because I  forgot to set the LD_LIBRARY_PATH for Geant3/4 before cmake, or forgot to specify Pythia6 path, or ...)

As the simulation env. depends on 5 variables, having a message printing those out helps finding out which one is causing problem more easily...

