### PR TITLE
DataHeader: Using constexpr for all defined constants and minor cleanup

### DIFF
--- a/DataFormats/Headers/include/Headers/DataHeader.h
+++ b/DataFormats/Headers/include/Headers/DataHeader.h
@@ -311,11 +311,11 @@ using HeaderType = Descriptor<gSizeHeaderDescriptionString>;
 using SerializationMethod = Descriptor<gSizeSerializationMethodString>;
 
 //possible serialization types
-extern const o2::header::SerializationMethod gSerializationMethodAny;
-extern const o2::header::SerializationMethod gSerializationMethodInvalid;
-extern const o2::header::SerializationMethod gSerializationMethodNone;
-extern const o2::header::SerializationMethod gSerializationMethodROOT;
-extern const o2::header::SerializationMethod gSerializationMethodFlatBuf;
+constexpr o2::header::SerializationMethod gSerializationMethodAny{ "*******" };
+constexpr o2::header::SerializationMethod gSerializationMethodInvalid{ "INVALID" };
+constexpr o2::header::SerializationMethod gSerializationMethodNone{ "NONE" };
+constexpr o2::header::SerializationMethod gSerializationMethodROOT{ "ROOT" };
+constexpr o2::header::SerializationMethod gSerializationMethodFlatBuf{ "FLATBUF" };
 
 //__________________________________________________________________________________________________
 /// @struct BaseHeader
@@ -607,34 +607,34 @@ struct DataHeader : public BaseHeader
 
 //__________________________________________________________________________________________________
 //possible data origins
-extern const o2::header::DataOrigin gDataOriginAny;
-extern const o2::header::DataOrigin gDataOriginInvalid;
-extern const o2::header::DataOrigin gDataOriginFLP;
-extern const o2::header::DataOrigin gDataOriginACO;
-extern const o2::header::DataOrigin gDataOriginCPV;
-extern const o2::header::DataOrigin gDataOriginCTP;
-extern const o2::header::DataOrigin gDataOriginEMC;
-extern const o2::header::DataOrigin gDataOriginFIT;
-extern const o2::header::DataOrigin gDataOriginHMP;
-extern const o2::header::DataOrigin gDataOriginITS;
-extern const o2::header::DataOrigin gDataOriginMCH;
-extern const o2::header::DataOrigin gDataOriginMFT;
-extern const o2::header::DataOrigin gDataOriginMID;
-extern const o2::header::DataOrigin gDataOriginPHS;
-extern const o2::header::DataOrigin gDataOriginTOF;
-extern const o2::header::DataOrigin gDataOriginTPC;
-extern const o2::header::DataOrigin gDataOriginTRD;
-extern const o2::header::DataOrigin gDataOriginZDC;
+constexpr o2::header::DataOrigin gDataOriginAny{ "***" };
+constexpr o2::header::DataOrigin gDataOriginInvalid{ "NIL" };
+constexpr o2::header::DataOrigin gDataOriginFLP{ "FLP" };
+constexpr o2::header::DataOrigin gDataOriginACO{ "ACO" };
+constexpr o2::header::DataOrigin gDataOriginCPV{ "CPV" };
+constexpr o2::header::DataOrigin gDataOriginCTP{ "CTP" };
+constexpr o2::header::DataOrigin gDataOriginEMC{ "EMC" };
+constexpr o2::header::DataOrigin gDataOriginFIT{ "FIT" };
+constexpr o2::header::DataOrigin gDataOriginHMP{ "HMP" };
+constexpr o2::header::DataOrigin gDataOriginITS{ "ITS" };
+constexpr o2::header::DataOrigin gDataOriginMCH{ "MCH" };
+constexpr o2::header::DataOrigin gDataOriginMFT{ "MFT" };
+constexpr o2::header::DataOrigin gDataOriginMID{ "MID" };
+constexpr o2::header::DataOrigin gDataOriginPHS{ "PHS" };
+constexpr o2::header::DataOrigin gDataOriginTOF{ "TOF" };
+constexpr o2::header::DataOrigin gDataOriginTPC{ "TPC" };
+constexpr o2::header::DataOrigin gDataOriginTRD{ "TRD" };
+constexpr o2::header::DataOrigin gDataOriginZDC{ "ZDC" };
 
 //possible data types
-extern const o2::header::DataDescription gDataDescriptionAny;
-extern const o2::header::DataDescription gDataDescriptionInvalid;
-extern const o2::header::DataDescription gDataDescriptionRawData;
-extern const o2::header::DataDescription gDataDescriptionClusters;
-extern const o2::header::DataDescription gDataDescriptionTracks;
-extern const o2::header::DataDescription gDataDescriptionConfig;
-extern const o2::header::DataDescription gDataDescriptionInfo;
-extern const o2::header::DataDescription gDataDescriptionROOTStreamers;
+constexpr o2::header::DataDescription gDataDescriptionAny{ "***************" };
+constexpr o2::header::DataDescription gDataDescriptionInvalid{ "INVALID_DESC" };
+constexpr o2::header::DataDescription gDataDescriptionRawData{ "RAWDATA" };
+constexpr o2::header::DataDescription gDataDescriptionClusters{ "CLUSTERS" };
+constexpr o2::header::DataDescription gDataDescriptionTracks{ "TRACKS" };
+constexpr o2::header::DataDescription gDataDescriptionConfig{ "CONFIGURATION" };
+constexpr o2::header::DataDescription gDataDescriptionInfo{ "INFORMATION" };
+constexpr o2::header::DataDescription gDataDescriptionROOTStreamers{ "ROOT STREAMERS" };
 /// @} // end of doxygen group
 
 //__________________________________________________________________________________________________
@@ -686,9 +686,6 @@ void hexDump (const char* desc, const void* voidaddr, size_t len, size_t max=0);
 
 } //namespace header
 
-// 2017-12-21: keep an alias for a short while after renaming the namespace
-// to lower case, supports pull request currently open
-namespace Header = header;
 } //namespace o2
 
 #endif

--- a/DataFormats/Headers/src/DataHeader.cxx
+++ b/DataFormats/Headers/src/DataHeader.cxx
@@ -27,44 +27,6 @@
 //the answer to life and everything
 const uint32_t o2::header::BaseHeader::sMagicString = String2<uint32_t>("O2O2");
 
-//possible serialization types
-const o2::header::SerializationMethod o2::header::gSerializationMethodAny    ("*******");
-const o2::header::SerializationMethod o2::header::gSerializationMethodInvalid("INVALID");
-const o2::header::SerializationMethod o2::header::gSerializationMethodNone   ("NONE");
-const o2::header::SerializationMethod o2::header::gSerializationMethodROOT   ("ROOT");
-const o2::header::SerializationMethod o2::header::gSerializationMethodFlatBuf("FLATBUF");
-
-//__________________________________________________________________________________________________
-//possible data origins
-const o2::header::DataOrigin o2::header::gDataOriginAny    ("***");
-const o2::header::DataOrigin o2::header::gDataOriginInvalid("NIL");
-const o2::header::DataOrigin o2::header::gDataOriginFLP    ("FLP");
-const o2::header::DataOrigin o2::header::gDataOriginACO    ("ACO");
-const o2::header::DataOrigin o2::header::gDataOriginCPV    ("CPV");
-const o2::header::DataOrigin o2::header::gDataOriginCTP    ("CTP");
-const o2::header::DataOrigin o2::header::gDataOriginEMC    ("EMC");
-const o2::header::DataOrigin o2::header::gDataOriginFIT    ("FIT");
-const o2::header::DataOrigin o2::header::gDataOriginHMP    ("HMP");
-const o2::header::DataOrigin o2::header::gDataOriginITS    ("ITS");
-const o2::header::DataOrigin o2::header::gDataOriginMCH    ("MCH");
-const o2::header::DataOrigin o2::header::gDataOriginMFT    ("MFT");
-const o2::header::DataOrigin o2::header::gDataOriginMID    ("MID");
-const o2::header::DataOrigin o2::header::gDataOriginPHS    ("PHS");
-const o2::header::DataOrigin o2::header::gDataOriginTOF    ("TOF");
-const o2::header::DataOrigin o2::header::gDataOriginTPC    ("TPC");
-const o2::header::DataOrigin o2::header::gDataOriginTRD    ("TRD");
-const o2::header::DataOrigin o2::header::gDataOriginZDC    ("ZDC");
-
-//possible data types
-const o2::header::DataDescription o2::header::gDataDescriptionAny     ("***************");
-const o2::header::DataDescription o2::header::gDataDescriptionInvalid ("INVALID_DESC");
-const o2::header::DataDescription o2::header::gDataDescriptionRawData ("RAWDATA");
-const o2::header::DataDescription o2::header::gDataDescriptionClusters("CLUSTERS");
-const o2::header::DataDescription o2::header::gDataDescriptionTracks  ("TRACKS");
-const o2::header::DataDescription o2::header::gDataDescriptionConfig  ("CONFIGURATION");
-const o2::header::DataDescription o2::header::gDataDescriptionInfo    ("INFORMATION");
-const o2::header::DataDescription o2::header::gDataDescriptionROOTStreamers("ROOT STREAMERS");
-
 //definitions for Stack statics
 std::default_delete<byte[]> o2::header::Stack::sDeleter;
 


### PR DESCRIPTION
@mkrzewic, what was the reason for having the data origin definitions in the compiled library rather than defining them `constexpr`. I simply don't remember, and maybe we can change it.