### PR TITLE
Introducing a CallbackService to the DPL

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -125,6 +125,7 @@ set(HEADERS
       include/Framework/Variant.h
       include/Framework/RootTreeReader.h
       include/Framework/CallbackRegistry.h
+      include/Framework/CallbackService.h
       src/ComputingResource.h
       src/DDSConfigHelpers.h
       src/DeviceSpecHelpers.h

--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -180,6 +180,7 @@ target_compile_options(test_SimpleDataProcessingDevice01 PUBLIC -O0 -g -fno-omit
 Install(FILES test/test_DataSamplingDPL.ini test/test_DataSamplingFairMQ.ini DESTINATION share/tests/)
 
 set(TEST_SRCS
+      test/test_SimpleStatefulProcessing01.cxx
       test/test_AlgorithmSpec.cxx
       test/test_BoostOptionsRetriever.cxx
       test/test_DataRelayer.cxx

--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -124,6 +124,7 @@ set(HEADERS
       include/Framework/DataProcessingDevice.h
       include/Framework/Variant.h
       include/Framework/RootTreeReader.h
+      include/Framework/CallbackRegistry.h
       src/ComputingResource.h
       src/DDSConfigHelpers.h
       src/DeviceSpecHelpers.h
@@ -202,6 +203,7 @@ set(TEST_SRCS
       test/test_TMessageSerializer.cxx
       test/test_DataAllocator.cxx
       test/test_RootTreeReader.cxx
+      test/test_CallbackRegistry.cxx
    )
 
 O2_GENERATE_TESTS(

--- a/Framework/Core/include/Framework/CallbackRegistry.h
+++ b/Framework/Core/include/Framework/CallbackRegistry.h
@@ -1,0 +1,147 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef FRAMEWORK_CALLBACKREGISTRY_H
+#define FRAMEWORK_CALLBACKREGISTRY_H
+
+/// @file   CallbackRegistry.h
+/// @author Matthias Richter
+/// @since  2018-04-26
+/// @brief  A generic registry for callbacks
+
+#include "Framework/TypeTraits.h"
+#include <tuple>
+#include <stdexcept> // runtime_error
+#include <utility>   // declval
+
+namespace o2
+{
+namespace framework
+{
+
+template <typename KeyT, KeyT _id, typename CallbackT>
+struct RegistryPair {
+  using id = std::integral_constant<KeyT, _id>;
+  using type = CallbackT;
+  type callback;
+};
+
+template <typename CallbackId, typename... Args>
+class CallbackRegistry
+{
+ public:
+  // FIXME:
+  // - add more checks
+  //   - recursive check of the argument pack
+  //   - required to be of type RegistryPair
+  //   - callback type is specialization of std::function
+  // - extend to variable return type
+
+  static constexpr std::size_t size = sizeof...(Args);
+
+  // set callback for slot
+  template <typename U>
+  void set(CallbackId id, U&& cb)
+  {
+    set<size>(id, cb);
+  }
+
+  // execute callback at specified slot with argument pack
+  template <typename... TArgs>
+  auto operator()(CallbackId id, TArgs&&... args)
+  {
+    exec<size>(id, std::forward<TArgs>(args)...);
+  }
+
+ private:
+  // helper trait to check whether class has a constructor taking callback as argument
+  template <class T, typename CB>
+  struct has_matching_callback {
+    template <class U, typename V>
+    static int check(decltype(U(std::declval<V>())) *);
+
+    template <typename U, typename V>
+    static char check(...);
+
+    static const bool value = sizeof(check<T, CB>(nullptr)) == sizeof(int);
+  };
+
+  // set the callback function of the specified id
+  // this iterates over defined slots and sets the matching callback
+  template <std::size_t pos, typename U>
+  typename std::enable_if<pos != 0>::type set(CallbackId id, U&& cb)
+  {
+    if (std::tuple_element<pos - 1, decltype(mStore)>::type::id::value != id) {
+      return set<pos - 1>(id, cb);
+    }
+    // note: there are two substitutions, the one for callback matching the slot type sets the
+    // callback, while the other substitution should never be called
+    setAt<pos - 1, typename std::tuple_element<pos - 1, decltype(mStore)>::type::type>(cb);
+  }
+  // termination of the recursive loop
+  template <std::size_t pos, typename U>
+  typename std::enable_if<pos == 0>::type set(CallbackId id, U&& cb)
+  {
+  }
+
+  // set the callback at specified slot position
+  template <std::size_t pos, typename U, typename F>
+  typename std::enable_if<has_matching_callback<U, F>::value == true>::type setAt(F&& cb)
+  {
+    // create a new std::function object and init with the callback function
+    std::get<pos>(mStore).callback = (U)(cb);
+  }
+  // substitution for not matching callback
+  template <std::size_t pos, typename U, typename F>
+  typename std::enable_if<has_matching_callback<U, F>::value == false>::type setAt(F&& cb)
+  {
+    throw std::runtime_error("mismatch in function substitution at position " + std::to_string(pos));
+  }
+
+  // exec callback of specified id
+  template <std::size_t pos, typename... TArgs>
+  typename std::enable_if<pos != 0>::type exec(CallbackId id, TArgs&&... args)
+  {
+    if (std::tuple_element<pos - 1, decltype(mStore)>::type::id::value != id) {
+      return exec<pos - 1>(id, std::forward<TArgs>(args)...);
+    }
+    // build a callable function type from the result type of the slot and the
+    // argument pack, this is used to selcet the matching substitution
+    using FunT = typename std::tuple_element<pos - 1, decltype(mStore)>::type::type;
+    using ResT = typename FunT::result_type;
+    using CheckT = std::function<ResT(TArgs...)>;
+    FunT& fct = std::get<pos - 1>(mStore).callback;
+    auto& storedTypeId = fct.target_type();
+    execAt<pos - 1, FunT, CheckT>(std::forward<TArgs>(args)...);
+  }
+  // termination of the recursive loop
+  template <std::size_t pos, typename... TArgs>
+  typename std::enable_if<pos == 0>::type exec(CallbackId id, TArgs&&... args)
+  {
+  }
+  // exec callback at specified slot
+  template <std::size_t pos, typename U, typename V, typename... TArgs>
+  typename std::enable_if<std::is_same<U, V>::value == true>::type execAt(TArgs&&... args)
+  {
+    if (std::get<pos>(mStore).callback) {
+      std::get<pos>(mStore).callback(std::forward<TArgs>(args)...);
+    }
+  }
+  // substitution for not matching argument pack
+  template <std::size_t pos, typename U, typename V, typename... TArgs>
+  typename std::enable_if<std::is_same<U, V>::value == false>::type execAt(TArgs&&... args)
+  {
+  }
+
+  // store of RegistryPairs
+  std::tuple<Args...> mStore;
+};
+}
+}
+#endif // FRAMEWORK_CALLBACKREGISTRY_H

--- a/Framework/Core/include/Framework/CallbackService.h
+++ b/Framework/Core/include/Framework/CallbackService.h
@@ -1,0 +1,65 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef FRAMEWORK_CALLBACKSERVICE_H
+#define FRAMEWORK_CALLBACKSERVICE_H
+
+#include "CallbackRegistry.h"
+#include <tuple>
+
+namespace o2
+{
+namespace framework
+{
+
+// A service that data processors can register callback functions invoked by the
+// framework at defined steps in the process flow
+class CallbackService
+{
+ public:
+  // the defined processing steps at which a callback can be invoked
+  enum class Id { Start, Stop, Reset };
+
+  template <typename T, T... v>
+  class EnumRegistry
+  {
+    constexpr static T values[] = { v... };
+    constexpr static std::size_t size = sizeof...(v);
+  };
+
+  using StartCallback = std::function<void()>;
+  using StopCallback = std::function<void()>;
+  using ResetCallback = std::function<void()>;
+  using Callbacks = CallbackRegistry<Id,                                         //
+                                     RegistryPair<Id, Id::Start, StartCallback>, //
+                                     RegistryPair<Id, Id::Stop, StopCallback>,   //
+                                     RegistryPair<Id, Id::Reset, ResetCallback>  //
+                                     >;                                          //
+
+  // set callback for specified processing step
+  template <typename U>
+  void set(Id id, U&& cb)
+  {
+    mCallbacks.set(id, std::forward<U>(cb));
+  }
+
+  // execute callback for specified processing step with argument pack
+  template <typename... TArgs>
+  auto operator()(Id id, TArgs&&... args)
+  {
+    mCallbacks(id, std::forward<TArgs>(args)...);
+  }
+
+ private:
+  Callbacks mCallbacks;
+};
+
+} // framework
+} // o2
+#endif // FRAMEWORK_CALLBACKSERVICE_H

--- a/Framework/Core/include/Framework/DataProcessingDevice.h
+++ b/Framework/Core/include/Framework/DataProcessingDevice.h
@@ -33,7 +33,11 @@ class DataProcessingDevice : public FairMQDevice {
 public:
   DataProcessingDevice(const DeviceSpec &spec, ServiceRegistry &);
   void Init() final;
-protected:
+  void PreRun() final;
+  void PostRun() final;
+  void Reset() final;
+
+ protected:
   bool HandleData(FairMQParts &parts, int index);
   void error(const char *msg);
 private:

--- a/Framework/Core/include/Framework/DataProcessingDevice.h
+++ b/Framework/Core/include/Framework/DataProcessingDevice.h
@@ -42,7 +42,7 @@ private:
   AlgorithmSpec::ProcessCallback mStatelessProcess;
   AlgorithmSpec::ErrorCallback mError;
   std::unique_ptr<ConfigParamRegistry> mConfigRegistry;
-  ServiceRegistry mServiceRegistry;
+  ServiceRegistry& mServiceRegistry;
   MessageContext mContext;
   RootObjectContext mRootContext;
   DataAllocator mAllocator;

--- a/Framework/Core/include/Framework/DataSourceDevice.h
+++ b/Framework/Core/include/Framework/DataSourceDevice.h
@@ -31,7 +31,11 @@ class DataSourceDevice : public FairMQDevice {
 public:
   DataSourceDevice(const DeviceSpec &spec, ServiceRegistry &registry);
   void Init() final;
-protected:
+  void PreRun() final;
+  void PostRun() final;
+  void Reset() final;
+
+ protected:
   bool ConditionalRun() final;
 private:
   AlgorithmSpec::InitCallback mInit;

--- a/Framework/Core/include/Framework/DataSourceDevice.h
+++ b/Framework/Core/include/Framework/DataSourceDevice.h
@@ -40,7 +40,7 @@ private:
   AlgorithmSpec::ErrorCallback mError;
 
   std::unique_ptr<ConfigParamRegistry> mConfigRegistry;
-  ServiceRegistry mServiceRegistry;
+  ServiceRegistry& mServiceRegistry;
   MessageContext mContext;
   RootObjectContext mRootContext;
   DataAllocator mAllocator;

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -14,6 +14,7 @@
 #include "Framework/DataSpecUtils.h"
 #include "Framework/FairOptionsRetriever.h"
 #include "Framework/MetricsService.h"
+#include "Framework/CallbackService.h"
 #include "Framework/TMessageSerializer.h"
 #include "Framework/InputRecord.h"
 #include <fairmq/FairMQParts.h>
@@ -72,6 +73,12 @@ void DataProcessingDevice::Init() {
   }
   LOG(DEBUG) << "DataProcessingDevice::InitTask::END";
 }
+
+void DataProcessingDevice::PreRun() { mServiceRegistry.get<CallbackService>()(CallbackService::Id::Start); }
+
+void DataProcessingDevice::PostRun() { mServiceRegistry.get<CallbackService>()(CallbackService::Id::Stop); }
+
+void DataProcessingDevice::Reset() { mServiceRegistry.get<CallbackService>()(CallbackService::Id::Reset); }
 
 /// This is the inner loop of our framework. The actual implementation
 /// is divided in two parts. In the first one we define a set of lambdas

--- a/Framework/Core/src/DataSourceDevice.cxx
+++ b/Framework/Core/src/DataSourceDevice.cxx
@@ -13,6 +13,7 @@
 #include "Framework/DataProcessor.h"
 #include "Framework/FairOptionsRetriever.h"
 #include "Framework/DataProcessingHeader.h"
+#include "Framework/CallbackService.h"
 #include <cassert>
 #include <chrono>
 #include <thread> // this_thread::sleep_for
@@ -49,6 +50,12 @@ void DataSourceDevice::Init() {
   }
   LOG(DEBUG) << "DataSourceDevice::InitTask::END";
 }
+
+void DataSourceDevice::PreRun() { mServiceRegistry.get<CallbackService>()(CallbackService::Id::Start); }
+
+void DataSourceDevice::PostRun() { mServiceRegistry.get<CallbackService>()(CallbackService::Id::Stop); }
+
+void DataSourceDevice::Reset() { mServiceRegistry.get<CallbackService>()(CallbackService::Id::Reset); }
 
 bool DataSourceDevice::ConditionalRun() {
   static const auto reftime = std::chrono::system_clock::now();

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -28,6 +28,7 @@
 #include "Framework/SimpleMetricsService.h"
 #include "Framework/SimpleRawDeviceService.h"
 #include "Framework/TextControlService.h"
+#include "Framework/CallbackService.h"
 #include "Framework/WorkflowSpec.h"
 
 #include "DDSConfigHelpers.h"
@@ -554,11 +555,13 @@ int doChild(int argc, char** argv, const o2::framework::DeviceSpec& spec)
     auto textControlService = std::make_unique<TextControlService>();
     auto parallelContext = std::make_unique<ParallelContext>(spec.rank, spec.nSlots);
     auto simpleRawDeviceService = std::make_unique<SimpleRawDeviceService>(device.get());
+    auto callbackService = std::make_unique<CallbackService>();
     serviceRegistry.registerService<MetricsService>(simpleMetricsService.get());
     serviceRegistry.registerService<RootFileService>(localRootFileService.get());
     serviceRegistry.registerService<ControlService>(textControlService.get());
     serviceRegistry.registerService<ParallelContext>(parallelContext.get());
     serviceRegistry.registerService<RawDeviceService>(simpleRawDeviceService.get());
+    serviceRegistry.registerService<CallbackService>(callbackService.get());
 
     runner.AddHook<fair::mq::hooks::InstantiateDevice>([&device](fair::mq::DeviceRunner& r) {
       r.fDevice = std::shared_ptr<FairMQDevice>{ std::move(device) };

--- a/Framework/Core/test/test_CallbackRegistry.cxx
+++ b/Framework/Core/test/test_CallbackRegistry.cxx
@@ -1,0 +1,51 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test Framework CallbackRegistry
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+#include "Framework/CallbackRegistry.h"
+#include <iostream>
+
+using namespace o2::framework;
+
+BOOST_AUTO_TEST_CASE(TestCallbackregistry)
+{
+  enum class StepId { StateChange, Exit };
+
+  using ExitCallback = std::function<void()>;
+  using StateChangeCallback = std::function<void(int)>;
+
+  using Callbacks = CallbackRegistry<StepId,                                                          //
+                                     RegistryPair<StepId, StepId::Exit, ExitCallback>,                //
+                                     RegistryPair<StepId, StepId::StateChange, StateChangeCallback>>; //
+  Callbacks callbacks;
+  BOOST_REQUIRE(callbacks.size == 2);
+
+  bool exitcbWasCalled = false;
+  auto exitcb = [&]() {
+    exitcbWasCalled = true;
+    std::cout << "Exit callback executed" << std::endl;
+  };
+  callbacks.set(StepId::Exit, exitcb);
+  int statechangecbWasCalled = -1;
+  auto statechangecb = [&](int val) {
+    statechangecbWasCalled = val;
+    std::cout << "StateChange callback executed with argument " << val << std::endl;
+  };
+  callbacks.set(StepId::StateChange, statechangecb);
+
+  callbacks(StepId::Exit);
+  BOOST_CHECK(exitcbWasCalled);
+  callbacks(StepId::StateChange, 5);
+  BOOST_CHECK(statechangecbWasCalled == 5);
+}

--- a/Framework/Core/test/test_Services.cxx
+++ b/Framework/Core/test/test_Services.cxx
@@ -12,9 +12,10 @@
 #define BOOST_TEST_DYN_LINK
 
 #include "Framework/ServiceRegistry.h"
+#include "Framework/CallbackService.h"
 #include <boost/test/unit_test.hpp>
 #include <iostream>
-
+#include <memory>
 
 BOOST_AUTO_TEST_CASE(TestServiceRegistry) {
   using namespace o2::framework;
@@ -47,4 +48,24 @@ BOOST_AUTO_TEST_CASE(TestServiceRegistry) {
   BOOST_CHECK(registry.get<InterfaceA>().method() == true);
   BOOST_CHECK(registry.get<InterfaceB>().method() == false);
   BOOST_CHECK_THROW(registry.get<InterfaceC>().method(), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(TestCallbackService)
+{
+  using namespace o2::framework;
+  ServiceRegistry registry;
+  auto service = std::make_unique<CallbackService>();
+  registry.registerService<CallbackService>(service.get());
+
+  // the callback simply sets the captured variable to indicated that it was called
+  bool cbCalled = false;
+  auto cb = [&]() { cbCalled = true; };
+  registry.get<CallbackService>().set(CallbackService::Id::Stop, cb);
+
+  // check to set with the wrong type
+  BOOST_CHECK_THROW(registry.get<CallbackService>().set(CallbackService::Id::Stop, [](int) {}), std::runtime_error);
+
+  // execute and check
+  registry.get<CallbackService>()(CallbackService::Id::Stop);
+  BOOST_CHECK(cbCalled);
 }

--- a/Framework/Core/test/test_SimpleStatefulProcessing01.cxx
+++ b/Framework/Core/test/test_SimpleStatefulProcessing01.cxx
@@ -13,13 +13,11 @@
 #include "Framework/runDataProcessing.h"
 #include "Framework/MetricsService.h"
 #include "Framework/ControlService.h"
+#include "Framework/CallbackService.h"
 #include "FairMQLogger.h"
 
 using namespace o2::framework;
 using DataHeader = o2::header::DataHeader;
-
-using Inputs = std::vector<InputSpec>;
-using Outputs = std::vector<OutputSpec>;
 
 // This is a simple consumer / producer workflow where both are
 // stateful, i.e. they have context which comes from their initialization.
@@ -29,13 +27,20 @@ void defineDataProcessing(WorkflowSpec &specs) {
       "producer",
       Inputs{},
       Outputs{
-        {"TES", "STATEFUL", Lifetime::Timeframe},
+        {"TES", "STATEFUL", 0, Lifetime::Timeframe},
       },
       // The producer is stateful, we use a static for the state in this
       // particular case, but a Singleton or a captured new object would
       // work as well.
       AlgorithmSpec{[](InitContext &setup) {
         static int foo = 0;
+	static int step = 0; // incremented in registered callbacks
+	auto startcb = []() {++step; LOG(INFO) << "start " << step;};
+	auto stopcb = []() {++step; LOG(INFO) << "stop " << step;};
+	auto resetcb = []() {++step; LOG(INFO) << "reset " << step;};
+	setup.services().get<CallbackService>().set(CallbackService::Id::Start, startcb);
+	setup.services().get<CallbackService>().set(CallbackService::Id::Stop, stopcb);
+	setup.services().get<CallbackService>().set(CallbackService::Id::Reset, resetcb);
         return [](ProcessingContext &ctx) {
             sleep(1);
             auto out = ctx.outputs().newChunk({ "TES", "STATEFUL", 0 }, sizeof(int));
@@ -48,7 +53,7 @@ void defineDataProcessing(WorkflowSpec &specs) {
     {
       "consumer",
       Inputs{
-        {"test", "TES", "STATEFUL", Lifetime::Timeframe},
+        {"test", "TES", "STATEFUL", 0, Lifetime::Timeframe},
       },
       Outputs{},
       AlgorithmSpec{[](InitContext &) {
@@ -60,7 +65,7 @@ void defineDataProcessing(WorkflowSpec &specs) {
               LOG(ERROR) << "Expecting " << expected << " found " << *in;
             } else {
               LOG(INFO) << "Everything OK for " << expected << std::endl;
-              services.get<ControlService>().readyToQuit(true);
+              ctx.services().get<ControlService>().readyToQuit(true);
             }
           };
         }

--- a/Framework/Core/test/test_SimpleStatefulProcessing01.cxx
+++ b/Framework/Core/test/test_SimpleStatefulProcessing01.cxx
@@ -23,43 +23,51 @@ using DataHeader = o2::header::DataHeader;
 // stateful, i.e. they have context which comes from their initialization.
 void defineDataProcessing(WorkflowSpec &specs) {
   WorkflowSpec workflow = {
-    {
-      "producer",
-      Inputs{},
-      Outputs{
-        {"TES", "STATEFUL", 0, Lifetime::Timeframe},
-      },
+    //
+    DataProcessorSpec{
+      "producer",                                                  //
+      Inputs{},                                                    //
+      { OutputSpec{ "TES", "STATEFUL", 0, Lifetime::Timeframe } }, //
       // The producer is stateful, we use a static for the state in this
       // particular case, but a Singleton or a captured new object would
       // work as well.
-      AlgorithmSpec{[](InitContext &setup) {
-        static int foo = 0;
-	static int step = 0; // incremented in registered callbacks
-	auto startcb = []() {++step; LOG(INFO) << "start " << step;};
-	auto stopcb = []() {++step; LOG(INFO) << "stop " << step;};
-	auto resetcb = []() {++step; LOG(INFO) << "reset " << step;};
-	setup.services().get<CallbackService>().set(CallbackService::Id::Start, startcb);
-	setup.services().get<CallbackService>().set(CallbackService::Id::Stop, stopcb);
-	setup.services().get<CallbackService>().set(CallbackService::Id::Reset, resetcb);
-        return [](ProcessingContext &ctx) {
+      AlgorithmSpec{
+        [](InitContext& setup) {
+          static int foo = 0;
+          static int step = 0; // incremented in registered callbacks
+          auto startcb = []() {
+            ++step;
+            LOG(INFO) << "start " << step;
+          };
+          auto stopcb = []() {
+            ++step;
+            LOG(INFO) << "stop " << step;
+          };
+          auto resetcb = []() {
+            ++step;
+            LOG(INFO) << "reset " << step;
+          };
+          setup.services().get<CallbackService>().set(CallbackService::Id::Start, startcb);
+          setup.services().get<CallbackService>().set(CallbackService::Id::Stop, stopcb);
+          setup.services().get<CallbackService>().set(CallbackService::Id::Reset, resetcb);
+          return [](ProcessingContext& ctx) {
             sleep(1);
             auto out = ctx.outputs().newChunk({ "TES", "STATEFUL", 0 }, sizeof(int));
-            auto outI = reinterpret_cast<int *>(out.data);
+            auto outI = reinterpret_cast<int*>(out.data);
             outI[0] = foo++;
           };
-        }
-      }
-    },
-    {
-      "consumer",
-      Inputs{
-        {"test", "TES", "STATEFUL", 0, Lifetime::Timeframe},
-      },
-      Outputs{},
-      AlgorithmSpec{[](InitContext &) {
+        } //
+      }   //
+    },    //
+    DataProcessorSpec{
+      "consumer",                                                         //
+      { InputSpec{ "test", "TES", "STATEFUL", 0, Lifetime::Timeframe } }, //
+      Outputs{},                                                          //
+      AlgorithmSpec{
+        [](InitContext&) {
           static int expected = 0;
-          return [](ProcessingContext &ctx) {
-            const int *in = reinterpret_cast<const int *>(ctx.inputs().get("test").payload);
+          return [](ProcessingContext& ctx) {
+            const int* in = reinterpret_cast<const int*>(ctx.inputs().get("test").payload);
 
             if (*in != expected++) {
               LOG(ERROR) << "Expecting " << expected << " found " << *in;
@@ -68,9 +76,9 @@ void defineDataProcessing(WorkflowSpec &specs) {
               ctx.services().get<ControlService>().readyToQuit(true);
             }
           };
-        }
-      }
-    }
+        } //
+      }   //
+    }     //
   };
 
   specs.swap(workflow);


### PR DESCRIPTION
The `CallbackService` can be used to register hooks to be invoked by the framework at different processing stages, currently `Start`, `Stop`, and `Reset` are supported which correspond to the `PreRun`, `PostRun`, and `Reset` methods of `FairMQDevice`.

There has also been a modification to store service registry by reference in the DPL devices.
The service registry is passed by reference to the constructor but inside a copy was stored, likely by accident, fixed with this commit.