### PR TITLE
cuts/processes via MaterialManager; TPC, HALL as proof of concept

### DIFF
--- a/Detectors/Base/include/DetectorsBase/Detector.h
+++ b/Detectors/Base/include/DetectorsBase/Detector.h
@@ -55,6 +55,18 @@ class Detector : public FairDetector
                 Float_t tmaxfd, Float_t stemax, Float_t deemax, Float_t epsil, Float_t stmin, Float_t *ubuf = nullptr,
                 Int_t nbuf = 0);
 
+    /// Custom processes and transport cuts
+    void Cuts( Int_t numed, Float_t cutgam, Float_t cutele, Float_t cutneu, Float_t cuthad, 
+                                  Float_t cutmuo, Float_t bcute, Float_t bcutm, Float_t dcute, 
+                                  Float_t dcutm, Float_t ppcutm, Float_t tofmax );
+    /// Set cut by name and value
+    void Cut( Int_t numed, int parID, Float_t val );
+
+    void Processes( Int_t numed, int pair, int comp, int phot, int pfis, int dray, int anni, int brem,
+                                 int hadr, int munu, int dcay, int loss, int muls, int ckov );
+    /// Set process by name and value
+    void Process( Int_t numed, int parID, int val );
+
     /// Define a rotation matrix. angles are in degrees.
     /// \param nmat on output contains the number assigned to the rotation matrix
     /// \param theta1 polar angle for axis I

--- a/Detectors/Base/include/DetectorsBase/MaterialManager.h
+++ b/Detectors/Base/include/DetectorsBase/MaterialManager.h
@@ -47,13 +47,139 @@ class MaterialManager
               Float_t tmaxfd, Float_t stemax, Float_t deemax, Float_t epsil, Float_t stmin, Float_t* ubuf = nullptr,
               Int_t nbuf = 0);
 
+  /// In Geant3/4 there is the possibility to set custom production cuts and to enable/disable certain processes.
+  /// This can be done globally as well as for each medium separately. Hence, for both cases there is one method 
+  /// to set default processes and cuts and another 2 methods to set cuts and processes per medium. In any case, 
+  /// the respective cut/process setting method is a wrapper around a private, more general, method.
+
+  /// Global settings of processes.
+  /// To ignore a certain process to be set explicitly, just set it to o2::Base::MaterialManager::NOPROCESS
+  void Processes( int pair, int comp, int phot, int pfis, int dray, int anni, int brem, int hadr, int munu, 
+                  int dcay, int loss, int muls, int ckov )
+  {
+    Processes( false, -1, pair, comp, phot, pfis, dray, anni, brem, hadr, munu, dcay, loss, muls, ckov );
+  }
+  /// Set processes per medium providing the module name and the local ID of the medium.
+  /// To ignore a certain process to be set explicitly (default or Geant settings will be used in that case) use
+  /// o2::Base::MaterialManager::NOPROCESS
+  void Processes( const char* modname, int localindex, int pair, int comp, int phot, int pfis, int dray, int anni,
+                                                       int brem, int hadr, int munu, int dcay, int loss, int muls, 
+                                                       int ckov )
+  {
+    int globalindex = getMediumID( modname, localindex );
+    if( globalindex != -1 )
+    {
+      Processes( true, globalindex, pair, comp, phot, pfis, dray, anni, brem, 
+                                    hadr, munu, dcay, loss, muls, ckov );
+    }
+  }
+  /// Global settings of cuts.
+  /// To ignore a certain cut to be set, just set it to o2::Base::MaterialManager::NOPROCESS
+  void Cuts( Float_t cutgam, Float_t cutele, Float_t cutneu, Float_t cuthad, Float_t cutmuo, Float_t bcute, 
+             Float_t bcutm, Float_t dcute, Float_t dcutm,  Float_t ppcutm, Float_t tofmax )
+  {
+    Cuts( false, -1, cutgam, cutele, cutneu, cuthad, cutmuo, bcute, bcutm, dcute, dcutm, ppcutm, tofmax );
+  }
+  /// Set cuts per medium providing the module name and the local ID of the medium.
+  /// To ignore a certain cut to be set explicitly (default or Geant settings will be used in that case) use
+  /// o2::Base::MaterialManager::NOPROCESS
+  void Cuts( const char* modname, int localindex, Float_t cutgam, Float_t cutele, Float_t cutneu, Float_t cuthad, 
+                                                  Float_t cutmuo, Float_t bcute, Float_t bcutm, Float_t dcute, 
+                                                  Float_t dcutm,  Float_t ppcutm, Float_t tofmax )
+  {
+    int globalindex = getMediumID( modname, localindex );
+    if( globalindex != -1 )
+    {
+      Cuts( true, globalindex, cutgam, cutele, cutneu, cuthad, cutmuo, bcute, 
+                               bcutm, dcute, dcutm, ppcutm, tofmax );
+    }
+  }
+  /// Custom setting of process or cut given parameter name and value
+  void Process( const char* modname, int localindex, int parID, int val )
+  {
+    int globalindex = getMediumID( modname, localindex );
+    // do that here because user might give wrong parameter.
+    if( isValidProcess( parID ) && globalindex != -1 )
+    {
+      Process( true, globalindex, parID, val );
+    }
+  }
+  /// set default process
+  void Process( int parID, int val )
+  {
+    // do that here because user might give wrong parameter.
+    if( isValidProcess( parID ) )
+    {
+      Process( false, -1, parID, val );
+    }
+  }
+  /// Custom setting of process or cut given parameter name and value
+  void Cut( const char* modname, int localindex, int parID, Float_t val )
+  {
+    int globalindex = getMediumID( modname, localindex );
+    // do that here because user might give wrong parameter.
+    if( isValidCut( parID ) && globalindex != -1 )
+    {
+      Cut( true, globalindex, parID, val );
+    }
+  }
+  /// set default cut
+  void Cut( int parID, Float_t val )
+  {
+    // do that here because user might give wrong parameter.
+    if( isValidCut( parID ) )
+    {
+      Cut( false, -1, parID, val );
+    }
+  }
  private:
+  // Hide details by providing these private methods so it cannot happen that special settings 
+  // are applied as default settings by accident using a boolean flag
+  void Processes( bool special, int globalindex, int pair, int comp, int phot, int pfis, int dray, int anni, 
+                                                 int brem, int hadr, int munu, int dcay, int loss, int muls, 
+                                                 int ckov );
+  void Cuts( bool special, int globalindex, Float_t cutgam, Float_t cutele, Float_t cutneu, Float_t cuthad, 
+                                            Float_t cutmuo, Float_t bcute, Float_t bcutm, Float_t dcute, 
+                                            Float_t dcutm, Float_t ppcutm, Float_t tofmax );
+  void Process( bool special, int globalindex, int parID, int val );
+  void Cut( bool special, int globalindex, int parID, Float_t val );
+  
   // insert material name
   void insertMaterialName(const char* uniquename, int index);
   void insertMediumName(const char* uniquename, int index);
   void insertTGeoMedium(std::string modname, int localindex);
 
  public:
+  /// Set flags whether to use special cuts and process settings
+  void applySpecialProcesses( bool val = true )
+  {
+    mApplySpecialProcesses = val;
+  }
+  void applySpecialCuts( bool val = true )
+  {
+    mApplySpecialCuts = val;
+  }
+
+  /// Check whether it is a valid process parameter
+  bool isValidProcess( int parID ) const
+  {
+    if( parID >= mProcessIDToName.size() )
+    {
+      return false;
+    }
+    return true;
+  }
+
+  /// Check whether it is a valid cut parameter
+  bool isValidCut( int parID ) const
+  {
+    if( parID >= mCutIDToName.size() )
+    {
+      return false;
+    }
+    return true;
+  }
+
   // returns global material ID given a "local" material ID for this detector
   // returns -1 in case local ID not found
   int getMaterialID(const char* modname, int imat) const
@@ -128,6 +254,11 @@ class MaterialManager
     mMaterialMap; // map of name -> map of local index to global index for Materials
   std::map<std::string, std::map<int, int>> mMediumMap; // map of name -> map of local index to global index for Media
 
+  std::map< int, std::map< int, int >> mMediumProcessMap; // map of global medium id to parameter-value map of processes
+  std::map< int, std::map< int, Float_t >> mMediumCutMap; // map of global medium id to parameter-value map of cuts
+  std::map< int, Float_t > mDefaultCutMap; // map of global cuts
+  std::map< int, int > mDefaultProcessMap; // map of global processes
+
   // a map allowing to lookup TGeoMedia from detector name and local medium index
   std::map<std::pair<std::string, int>, TGeoMedium*> mTGeoMediumMap;
 
@@ -139,6 +270,34 @@ class MaterialManager
 
   Float_t mDensityFactor = 1.; //! factor that is multiplied to all material densities (ONLY for
   // systematic studies)
+
+  /// In general, transport cuts and processes are properties of detector media. On the other hand different 
+  /// engines might provide different cuts and processes. Further, the naming convention might differ among 
+  /// engines.
+  /// This must be handled by the MaterialManager to fit to the engine in use. In that way, the user does not need
+  /// to care about the engine in use but only needs to set cuts according to ONE naming scheme.
+  // \note Currently, the naming convention of GEANT4 v10.3.3 is used.
+  // \note This might be overhead so far but makes the MaterialManager and therefore O2 finally capable of
+  // forwarding cuts/processe to arbitrary engines.
+  // \todo Is there a more elegant implementation?
+  /// fixed names of cuts
+  const static std::vector< std::string > mCutIDToName;
+  /// fixed names of processes
+  const static std::vector< std::string > mProcessIDToName;
+
+  /// Decide whether special process and cut settings should be applied
+  bool mApplySpecialProcesses = true;
+  bool mApplySpecialCuts = true;
+  
+ public:
+  /// processes available
+  enum { PAIR = 0, COMP, PHOT, PFIS, DRAY, ANNI, BREM, HADR, MUNU, DCAY, LOSS, MULS, CKOV };
+  /// cuts available
+  enum { CUTGAM = 0, CUTELE, CUTNEU, CUTHAD, CUTMUO, BCUTE, BCUTM, DCUTE, DCUTM, PPCUTM, TOFMAX };
+  /// can be used to ignore cut setting for a medium
+  constexpr static Float_t NOCUT = -1.;
+  /// can be used to ignore the process setting for a medium
+  constexpr static int NOPROCESS = -1;
 
   ClassDefNV(MaterialManager, 0);
 };

--- a/Detectors/Base/src/Detector.cxx
+++ b/Detectors/Base/src/Detector.cxx
@@ -75,6 +75,37 @@ void Detector::Medium(Int_t numed, const char* name, Int_t nmat, Int_t isvol, In
   mgr.Medium(GetName(), numed, name, nmat, isvol, ifield, fieldm, tmaxfd, stemax, deemax, epsil, stmin, ubuf, nbuf);
 }
 
+void Detector::Cuts( Int_t numed, Float_t cutgam, Float_t cutele, Float_t cutneu, Float_t cuthad, 
+                                  Float_t cutmuo, Float_t bcute, Float_t bcutm, Float_t dcute, 
+                                  Float_t dcutm, Float_t ppcutm, Float_t tofmax )
+{
+  auto& mgr = o2::Base::MaterialManager::Instance();
+  mgr.Cuts( GetName(), numed, cutgam, cutele, cutneu, cuthad, cutmuo, bcute, bcutm, 
+                              dcute, dcutm, ppcutm, tofmax );
+
+}
+
+void Detector::Cut( Int_t numed, int parID, Float_t val )
+{
+  auto& mgr = o2::Base::MaterialManager::Instance();
+  mgr.Cut( GetName(), numed, parID, val );
+}
+
+
+void Detector::Processes( Int_t numed, int pair, int comp, int phot, int pfis, int dray, int anni, int brem,
+                                       int hadr, int munu, int dcay, int loss, int muls, int ckov )
+{
+  auto& mgr = o2::Base::MaterialManager::Instance();
+  mgr.Processes( GetName(), numed, pair, comp, phot, pfis, dray, anni, brem, hadr, munu, dcay, loss, muls, ckov );
+}
+
+
+void Detector::Process( Int_t numed, int parID, int val )
+{
+  auto& mgr = o2::Base::MaterialManager::Instance();
+  mgr.Process( GetName(), numed, parID, val );
+}
+
 void Detector::Matrix(Int_t& nmat, Float_t theta1, Float_t phi1, Float_t theta2, Float_t phi2, Float_t theta3,
                       Float_t phi3) const
 {

--- a/Detectors/Passive/include/DetectorsPassive/Hall.h
+++ b/Detectors/Passive/include/DetectorsPassive/Hall.h
@@ -24,6 +24,7 @@ class Hall : public FairModule
   Hall();
   ~Hall() override;
   void ConstructGeometry() override;
+  void SetSpecialPhysicsCuts() override;
 
   /// Clone this object (used in MT mode only)
   FairModule* CloneModule() const override;

--- a/Detectors/Passive/src/Hall.cxx
+++ b/Detectors/Passive/src/Hall.cxx
@@ -102,6 +102,23 @@ void Hall::createMaterials()
   matmgr.Medium("HALL", 52, "FE_C2", 52, 0, isxfld, sxmgmx, tmaxfd, stemax, deemax, epsil, stmin);
 }
 
+void Hall::SetSpecialPhysicsCuts()
+{
+
+  // MaterialManager used to set physics cuts
+  auto& matmgr = o2::Base::MaterialManager::Instance();
+
+  const Float_t cut1 = 1.e00;
+  const Float_t cut2 = 1.e-1;
+  const Float_t cut3 = 1.e-3;
+  const Float_t noCut = o2::Base::MaterialManager::NOCUT;
+
+  matmgr.Cuts( "HALL", 50, cut1, cut1, cut2, cut3, noCut, noCut, noCut, noCut, noCut, noCut, noCut ); // STST_C2
+  matmgr.Cuts( "HALL", 55, cut1, cut1, cut2, cut3, noCut, noCut, noCut, noCut, noCut, noCut, noCut ); // AIR_C2
+  matmgr.Cuts( "HALL", 57, cut1, cut1, cut2, cut3, noCut, noCut, noCut, noCut, noCut, noCut, noCut ); // CC_C2 
+
+}
+
 void Hall::ConstructGeometry()
 {
   createMaterials();

--- a/Detectors/TPC/simulation/src/Detector.cxx
+++ b/Detectors/TPC/simulation/src/Detector.cxx
@@ -109,84 +109,21 @@ void Detector::Initialize()
 
 void Detector::SetSpecialPhysicsCuts()
 {
-  FairRun* fRun = FairRun::Instance();
+  // Cuts set by forwarding to MaterialManager
+  const Float_t cut1 = 1e-3;
+  const Float_t cut2 = 1e-5;
+  const Float_t cut3 = 1e-6;
+  const Float_t cut4 = o2::Base::MaterialManager::NOCUT;
+  
+  // Some cuts implemented in AliRoot
+  Cuts( 1, cut2, cut2, cut1, cut1, cut2, cut2, cut2, cut2, cut2, cut4, cut4); //DriftGas1
+  Cuts( 2, cut2, cut2, cut1, cut1, cut2, cut2, cut2, cut2, cut2, cut4, cut4 ); //DriftGas2
+  Cuts( 3, cut2, cut2, cut1, cut1, cut2, cut2, cut2, cut2, cut2, cut4, cut4 ); //CO2
+  Cuts( 20, cut3, cut3, cut1, cut1, cut3, cut3, cut3, cut3, cut3, cut4, cut4); //DriftGas3
 
-  // check for GEANT3, else abort
-  if (strcmp(fRun->GetName(), "TGeant3") == 0) {
-
-    // get material ID for customs settings
-    std::string fMixture("TPC_DriftGas2");
-    bool fAliMC = false; // implemented the e-loss now on our own -> use default model
-    std::cout << "TpcDetector::SetSpecialPhysicsCuts() "
-              << "Working on medium " << fMixture.c_str() << std::endl;
-    int matIdVMC = gGeoManager->GetMedium(fMixture.c_str())->GetId();
-
-    double tofmax = 1.E10; // (s)
-
-    // Set new properties, physics cuts etc. for the TPCmixture
-
-    // gMC->Gstpar(matIdVMC,"PAIR",1); /** pair production*/
-    // gMC->Gstpar(matIdVMC,"COMP",1); /**Compton scattering*/
-    // gMC->Gstpar(matIdVMC,"PHOT",1); /** photo electric effect */
-    // gMC->Gstpar(matIdVMC,"PFIS",0); /**photofission*/
-    // gMC->Gstpar(matIdVMC,"DRAY",1); /**delta-ray*/
-    // gMC->Gstpar(matIdVMC,"ANNI",1); /**annihilation*/
-    // gMC->Gstpar(matIdVMC,"BREM",1); /**bremsstrahlung*/
-    // gMC->Gstpar(matIdVMC,"HADR",1); /**hadronic process*/
-    // gMC->Gstpar(matIdVMC,"MUNU",1); /**muon nuclear interaction*/
-    // gMC->Gstpar(matIdVMC,"DCAY",1); /**decay*/
-    // gMC->Gstpar(matIdVMC,"LOSS",1); /**energy loss*/
-    // gMC->Gstpar(matIdVMC,"MULS",1); /**multiple scattering*/
-    // gMC->Gstpar(matIdVMC,"STRA",0);
-    // gMC->Gstpar(matIdVMC,"RAYL",1);
-
-    // gMC->Gstpar(matIdVMC,"CUTGAM",fCut_el); /** gammas (GeV)*/
-    // gMC->Gstpar(matIdVMC,"CUTELE",fCut_el); /** electrons (GeV)*/
-    // gMC->Gstpar(matIdVMC,"CUTNEU",fCut_had); /** neutral hadrons (GeV)*/
-    // gMC->Gstpar(matIdVMC,"CUTHAD",fCut_had); /** charged hadrons (GeV)*/
-    // gMC->Gstpar(matIdVMC,"CUTMUO",fCut_el); /** muons (GeV)*/
-    // gMC->Gstpar(matIdVMC,"BCUTE",fCut_el);  /** electron bremsstrahlung (GeV)*/
-    // gMC->Gstpar(matIdVMC,"BCUTM",fCut_el);  /** muon and hadron bremsstrahlung(GeV)*/
-    // gMC->Gstpar(matIdVMC,"DCUTE",fCut_el);  /** delta-rays by electrons (GeV)*/
-    // gMC->Gstpar(matIdVMC,"DCUTM",fCut_el);  /** delta-rays by muons (GeV)*/
-    // gMC->Gstpar(matIdVMC,"PPCUTM",fCut_el); /** direct pair production by muons (GeV)*/
-    gMC->Gstpar(matIdVMC, "PAIR", 1);
-    gMC->Gstpar(matIdVMC, "COMP", 1);
-    gMC->Gstpar(matIdVMC, "PHOT", 1);
-    gMC->Gstpar(matIdVMC, "PFIS", 0);
-    gMC->Gstpar(matIdVMC, "DRAY", 1);
-    gMC->Gstpar(matIdVMC, "ANNI", 1);
-    gMC->Gstpar(matIdVMC, "BREM", 1);
-    gMC->Gstpar(matIdVMC, "HADR", 1);
-    gMC->Gstpar(matIdVMC, "MUNU", 1);
-    gMC->Gstpar(matIdVMC, "DCAY", 1);
-    gMC->Gstpar(matIdVMC, "LOSS", 1);
-    gMC->Gstpar(matIdVMC, "MULS", 1);
-    Double_t cut1 = 1.0E-5; // GeV --> 1 MeV
-    Double_t cutel = 1.0E-5;
-
-    gMC->SetCut("CUTGAM", cutel);
-    gMC->SetCut("CUTELE", cutel);
-    gMC->SetCut("CUTNEU", cut1);
-    gMC->SetCut("CUTHAD", cut1);
-    gMC->SetCut("CUTMUO", cut1);
-    gMC->SetCut("BCUTE", cutel);
-    gMC->SetCut("BCUTM", cut1);
-    gMC->SetCut("DCUTE", cutel);
-    gMC->SetCut("DCUTM", cut1);
-    gMC->SetCut("PPCUTM", cut1);
-    gMC->SetCut("TOFMAX", tofmax);
-    gMC->SetMaxNStep((int)1E6);
-
-    std::cout << "\n************************************************************\n"
-              << "TpcDetector::SetSpecialPhysicsCuts():\n"
-              << "   using special physics cuts ...\n";
-    if (fAliMC) {
-      std::cout << "   using LOSS=5 for ALICE MC model\n";
-      gMC->Gstpar(matIdVMC, "LOSS", 5);
-    }
-    std::cout << "************************************************************" << std::endl;
-  }
+  // as an example get parameterID for dcute and set explicitly
+  int dcute = o2::Base::MaterialManager::DCUTE;
+  Cut( 1, dcute, cut3 );
 }
 
 Bool_t Detector::ProcessHits(FairVolume* vol)
@@ -372,9 +309,6 @@ void Detector::ConstructGeometry()
   // Load geometry
   //   LoadGeometryFromFile();
   ConstructTPCGeometry();
-
-  // GeantHack
-  // GeantHack();
 }
 
 void Detector::CreateMaterials()
@@ -3140,85 +3074,5 @@ Double_t Detector::Gamma(Double_t k)
   return TMath::Exp(x);
 }
 
-#include <sstream>
-#include <string>
-#include "TVirtualMC.h"
-void Detector::GeantHack()
-{
-  //   Med  GAM   ELEC  NHAD  CHAD  MUON  EBREM MUHAB EDEL  MUDEL MUPA ANNI BREM COMP DCAY DRAY HADR LOSS MULS PAIR PHOT
-  //   RAYL STRA
-  std::stringstream data(
-    "\
-  TPC    0    -1.   -1.   -1.  -1.   -1.    -1.   -1.  -1.    -1.   -1.  -1   -1   -1    1    1    1    3    1    1    1    1\n\
-  TPC     1 1e-5  1e-5  1e-3 1e-3  1e-5   1e-5   1e-5  1e-5 1e-5    -1.   1    1    1    1    1    1    3    1    1    1    1\n\
-  TPC     2 1e-5  1e-5  1e-3 1e-3  1e-5   1e-5   1e-5  1e-5 1e-5    -1.   1    1    1    1    1    1    5    1    1    1    1\n\
-  TPC     3 1e-5  1e-5  1e-3 1e-3  1e-5   1e-5   1e-5  1e-5 1e-5    -1.  -1   -1   -1    1    1    1    3    1    1    1    1 \n\
-  TPC    20 1e-6  1e-6  1e-3 1e-3  1e-6   1e-6   1e-6  1e-6 1e-6    -1.   1    1    1    1    1    1    5    1    1    1    1\n\
-  TPC     4   -1.   -1.   -1.  -1.   -1.    -1.   -1.  -1.    -1.   -1.  -1   -1   -1    1    1    1    3    1    1    1    1\n\
-  TPC     5   -1.   -1.   -1.  -1.   -1.    -1.   -1.  -1.    -1.   -1.  -1   -1   -1    1    1    1    3    1    1    1    1\n\
-  TPC     6   -1.   -1.   -1.  -1.   -1.    -1.   -1.  -1.    -1.   -1.  -1   -1   -1    1    1    1    3    1    1    1    1\n\
-  TPC     7   -1.   -1.   -1.  -1.   -1.    -1.   -1.  -1.    -1.   -1.  -1   -1   -1    1    1    1    3    1    1    1    1\n\
-  TPC     8   -1.   -1.   -1.  -1.   -1.    -1.   -1.  -1.    -1.   -1.  -1   -1   -1    1    1    1    3    1    1    1    1\n\
-  TPC     9   -1.   -1.   -1.  -1.   -1.    -1.   -1.  -1.    -1.   -1.  -1   -1   -1    1    1    1    3    1    1    1    1\n\
-  TPC    10   -1.   -1.   -1.  -1.   -1.    -1.   -1.  -1.    -1.   -1.  -1   -1   -1    1    1    1    3    1    1    1    1\n\
-  TPC    11   -1.   -1.   -1.  -1.   -1.    -1.   -1.  -1.    -1.   -1.  -1   -1   -1    1    1    1    3    1    1    1    1\n\
-  TPC    12   -1.   -1.   -1.  -1.   -1.    -1.   -1.  -1.    -1.   -1.  -1   -1   -1    1    1    1    3    1    1    1    1\n\
-  TPC    13   -1.   -1.   -1.  -1.   -1.    -1.   -1.  -1.    -1.   -1.  -1   -1   -1    1    1    1    3    1    1    1    1\n\
-  TPC    14   -1.   -1.   -1.  -1.   -1.    -1.   -1.  -1.    -1.   -1.  -1   -1   -1    1    1    1    3    1    1    1    1\n\
-  TPC    15   -1.   -1.   -1.  -1.   -1.    -1.   -1.  -1.    -1.   -1.  -1   -1   -1    1    1    1    3    1    1    1    1");
-
-  const Int_t kncuts = 10;
-  const Int_t knflags = 12;
-  const Int_t knpars = kncuts + knflags;
-  const char kpars[knpars][7] = { "CUTGAM", "CUTELE", "CUTNEU", "CUTHAD", "CUTMUO", "BCUTE", "BCUTM", "DCUTE",
-                                  "DCUTM",  "PPCUTM", "ANNI",   "BREM",   "COMP",   "DCAY",  "DRAY",  "HADR",
-                                  "LOSS",   "MULS",   "PAIR",   "PHOT",   "RAYL",   "STRA" };
-  std::string detName;
-  char* filtmp;
-  Float_t cut[kncuts];
-  Int_t flag[knflags];
-  Int_t i, itmed, iret, jret, ktmed, kz;
-
-  std::string line;
-  while (std::getline(data, line)) {
-    std::cout << line << endl;
-    for (i = 0; i < kncuts; i++)
-      cut[i] = -99;
-    for (i = 0; i < knflags; i++)
-      flag[i] = -99;
-    itmed = 0;
-
-    std::stringstream linedata(line);
-    linedata >> detName >> itmed >> cut[0] >> cut[1] >> cut[2] >> cut[3] >> cut[4] >> cut[5] >> cut[6] >> cut[7] >>
-      cut[8] >> cut[9] >> flag[0] >> flag[1] >> flag[2] >> flag[3] >> flag[4] >> flag[5] >> flag[6] >> flag[7] >>
-      flag[8] >> flag[9] >> flag[10] >> flag[11];
-
-    if (0 <= itmed && itmed < 100) {
-      ktmed = getMediumID(itmed);
-      if (ktmed == -1) {
-        LOG(INFO) << Form("Invalid tracking medium code %d for %s", itmed, GetName()) << FairLogger::endl;
-        continue;
-      }
-      // Set energy thresholds
-      for (kz = 0; kz < kncuts; kz++) {
-        if (cut[kz] >= 0) {
-          LOG(INFO) << Form("%-6s set to %10.3E for tracking medium code %4d (%4d) for %s", kpars[kz], cut[kz], itmed,
-                            ktmed, GetName())
-                    << FairLogger::endl;
-          TVirtualMC::GetMC()->Gstpar(ktmed, kpars[kz], cut[kz]);
-        }
-      }
-      // Set transport mechanisms
-      for (kz = 0; kz < knflags; kz++) {
-        if (flag[kz] >= 0) {
-          LOG(INFO) << Form("%-6s set to %10d for tracking medium code %4d (%4d) for %s", kpars[kncuts + kz], flag[kz],
-                            itmed, ktmed, GetName())
-                    << FairLogger::endl;
-          TVirtualMC::GetMC()->Gstpar(ktmed, kpars[kncuts + kz], Float_t(flag[kz]));
-        }
-      }
-    }
-  }
-}
 
 ClassImp(o2::TPC::Detector)

--- a/Detectors/gconfig/SetCuts.C
+++ b/Detectors/gconfig/SetCuts.C
@@ -26,20 +26,29 @@ void SetCuts()
   // 
   // The default settings refer to a complete simulation which generates and follows also the secondary particles.
   
+  // use MaterialManager to set processes and cuts
+  auto& mgr = o2::Base::MaterialManager::Instance();
+  // En- or disable setting of special cuts depending on ENV variable \note temorary
+  if( !getenv("SPECIALCUTSPROC") )
+  {
+    mgr.applySpecialProcesses(false);
+    mgr.applySpecialCuts(false);
+  }
 
-  TVirtualMC::GetMC()->SetProcess("PAIR",1); /** pair production*/
-  TVirtualMC::GetMC()->SetProcess("COMP",1); /**Compton scattering*/
-  TVirtualMC::GetMC()->SetProcess("PHOT",1); /** photo electric effect */
-  TVirtualMC::GetMC()->SetProcess("PFIS",0); /**photofission*/
-  TVirtualMC::GetMC()->SetProcess("DRAY",0); /**delta-ray*/
-  TVirtualMC::GetMC()->SetProcess("ANNI",1); /**annihilation*/
-  TVirtualMC::GetMC()->SetProcess("BREM",1); /**bremsstrahlung*/
-  TVirtualMC::GetMC()->SetProcess("HADR",1); /**hadronic process*/
-  TVirtualMC::GetMC()->SetProcess("MUNU",1); /**muon nuclear interaction*/
-  TVirtualMC::GetMC()->SetProcess("DCAY",1); /**decay*/
-  TVirtualMC::GetMC()->SetProcess("LOSS",2); /**energy loss*/
-  TVirtualMC::GetMC()->SetProcess("MULS",1); /**multiple scattering*/
-  TVirtualMC::GetMC()->SetProcess("CKOV",1); /**cherenkov */
+  //TVirtualMC::GetMC()->SetProcess("PAIR",1); /** pair production*/
+  //TVirtualMC::GetMC()->SetProcess("COMP",1); /**Compton scattering*/
+  //TVirtualMC::GetMC()->SetProcess("PHOT",1); /** photo electric effect */
+  //TVirtualMC::GetMC()->SetProcess("PFIS",0); /**photofission*/
+  //TVirtualMC::GetMC()->SetProcess("DRAY",0); /**delta-ray*/
+  //TVirtualMC::GetMC()->SetProcess("ANNI",1); /**annihilation*/
+  //TVirtualMC::GetMC()->SetProcess("BREM",1); /**bremsstrahlung*/
+  //TVirtualMC::GetMC()->SetProcess("HADR",1); /**hadronic process*/
+  //TVirtualMC::GetMC()->SetProcess("MUNU",1); /**muon nuclear interaction*/
+  //TVirtualMC::GetMC()->SetProcess("DCAY",1); /**decay*/
+  //TVirtualMC::GetMC()->SetProcess("LOSS",2); /**energy loss*/
+  //TVirtualMC::GetMC()->SetProcess("MULS",1); /**multiple scattering*/
+  //TVirtualMC::GetMC()->SetProcess("CKOV",1); /**cherenkov */
+  mgr.Processes( 1, 1, 1, 0, 0, 1, 1, 1, 1, 1, 2, 1, 1 );
 
   
     
@@ -49,17 +58,18 @@ void SetCuts()
   Double_t tofmax = 1.E10;        // seconds
   cout << "SetCuts Macro: Setting cuts.." <<endl;
   
-  TVirtualMC::GetMC()->SetCut("CUTGAM",cut1);   /** gammas (GeV)*/
-  TVirtualMC::GetMC()->SetCut("CUTELE",cut1);   /** electrons (GeV)*/
-  TVirtualMC::GetMC()->SetCut("CUTNEU",cut1);   /** neutral hadrons (GeV)*/
-  TVirtualMC::GetMC()->SetCut("CUTHAD",cut1);   /** charged hadrons (GeV)*/
-  TVirtualMC::GetMC()->SetCut("CUTMUO",cut1);   /** muons (GeV)*/
-  TVirtualMC::GetMC()->SetCut("BCUTE",cut1);    /** electron bremsstrahlung (GeV)*/
-  TVirtualMC::GetMC()->SetCut("BCUTM",cut1);    /** muon and hadron bremsstrahlung(GeV)*/ 
-  TVirtualMC::GetMC()->SetCut("DCUTE",cut1);    /** delta-rays by electrons (GeV)*/
-  TVirtualMC::GetMC()->SetCut("DCUTM",cut1);    /** delta-rays by muons (GeV)*/
-  TVirtualMC::GetMC()->SetCut("PPCUTM",cut1);   /** direct pair production by muons (GeV)*/
-  TVirtualMC::GetMC()->SetCut("TOFMAX",tofmax); /**time of flight cut in seconds*/
+  //TVirtualMC::GetMC()->SetCut("CUTGAM",cut1);   /** gammas (GeV)*/
+  //TVirtualMC::GetMC()->SetCut("CUTELE",cut1);   /** electrons (GeV)*/
+  //TVirtualMC::GetMC()->SetCut("CUTNEU",cut1);   /** neutral hadrons (GeV)*/
+  //TVirtualMC::GetMC()->SetCut("CUTHAD",cut1);   /** charged hadrons (GeV)*/
+  //TVirtualMC::GetMC()->SetCut("CUTMUO",cut1);   /** muons (GeV)*/
+  //TVirtualMC::GetMC()->SetCut("BCUTE",cut1);    /** electron bremsstrahlung (GeV)*/
+  //TVirtualMC::GetMC()->SetCut("BCUTM",cut1);    /** muon and hadron bremsstrahlung(GeV)*/ 
+  //TVirtualMC::GetMC()->SetCut("DCUTE",cut1);    /** delta-rays by electrons (GeV)*/
+  //TVirtualMC::GetMC()->SetCut("DCUTM",cut1);    /** delta-rays by muons (GeV)*/
+  //TVirtualMC::GetMC()->SetCut("PPCUTM",cut1);   /** direct pair production by muons (GeV)*/
+  //TVirtualMC::GetMC()->SetCut("TOFMAX",tofmax); /**time of flight cut in seconds*/
+  mgr.Cuts( cut1, cut1, cut1, cut1, cut1, cut1, cut1, cut1, cut1, cut1, tofmax );
   
    
 }


### PR DESCRIPTION
Production cuts and settings of processes for GEANT (or other possible engines) are now done via the MaterilaManager. This applies to both global settings and those for single media.
In order to have the cuts correctly available the MaterialManager helds a list of the respective parameters. In that way O2 is capable to abstract from specific engines later on making the processes/cuts O2 dependend and not engine dependent having the MaterialManager as an interface.

Proof-of-concept implementations in the case of cuts have been done for the HALL and TPC by porting those from in AliRoot.

For the TPC the method GeantHack() has been removed entirely