### PR TITLE
cuts/processes via MaterialManager; TPC, HALL as proof of concept

### DIFF
--- a/Detectors/Base/include/DetectorsBase/Detector.h
+++ b/Detectors/Base/include/DetectorsBase/Detector.h
@@ -16,6 +16,7 @@
 
 #include <map>
 #include <vector>
+#include <initializer_list>
 #include <memory>
 
 #include "FairDetector.h"  // for FairDetector
@@ -54,6 +55,16 @@ class Detector : public FairDetector
     void Medium(Int_t numed, const char *name, Int_t nmat, Int_t isvol, Int_t ifield, Float_t fieldm,
                 Float_t tmaxfd, Float_t stemax, Float_t deemax, Float_t epsil, Float_t stmin, Float_t *ubuf = nullptr,
                 Int_t nbuf = 0);
+
+    /// Custom processes and transport cuts
+    void SpecialCuts(Int_t numed, const std::initializer_list<std::pair<MaterialManager::ECut, Float_t>>& parIDValMap);
+    /// Set cut by name and value
+    void SpecialCut(Int_t numed, MaterialManager::ECut parID, Float_t val);
+
+    void SpecialProcesses(Int_t numed,
+                          const std::initializer_list<std::pair<MaterialManager::EProc, int>>& parIDValMap);
+    /// Set process by name and value
+    void SpecialProcess(Int_t numed, MaterialManager::EProc parID, int val);
 
     /// Define a rotation matrix. angles are in degrees.
     /// \param nmat on output contains the number assigned to the rotation matrix

--- a/Detectors/Base/include/DetectorsBase/MaterialManager.h
+++ b/Detectors/Base/include/DetectorsBase/MaterialManager.h
@@ -16,6 +16,7 @@
 
 #include "Rtypes.h"
 #include <map>
+#include <initializer_list>
 
 class TGeoMedium;
 
@@ -47,13 +48,87 @@ class MaterialManager
               Float_t tmaxfd, Float_t stemax, Float_t deemax, Float_t epsil, Float_t stmin, Float_t* ubuf = nullptr,
               Int_t nbuf = 0);
 
+  /// In Geant3/4 there is the possibility to set custom production cuts and to enable/disable certain processes.
+  /// This can be done globally as well as for each medium separately. Hence, for both cases there is one method
+  /// to set default processes and cuts and another 2 methods to set cuts and processes per medium. In any case,
+  /// the respective cut/process setting method is a wrapper around a private, more general, method.
+  /// processes available
+  enum EProc { kPAIR = 0, kCOMP, kPHOT, kPFIS, kDRAY, kANNI, kBREM, kHADR, kMUNU, kDCAY, kLOSS, kMULS, kCKOV };
+  /// cuts available
+  enum ECut { kCUTGAM = 0, kCUTELE, kCUTNEU, kCUTHAD, kCUTMUO, kBCUTE, kBCUTM, kDCUTE, kDCUTM, kPPCUTM, kTOFMAX };
+
+  /// Global settings of processes.
+  /// To ignore a certain process to be set explicitly, just set it to o2::Base::MaterialManager::NOPROCESS
+  void DefaultProcesses(const std::initializer_list<std::pair<EProc, int>>& parIDValMap)
+  {
+    Processes(false, -1, parIDValMap);
+  }
+  /// Set processes per medium providing the module name and the local ID of the medium.
+  /// To ignore a certain process to be set explicitly (default or Geant settings will be used in that case) use
+  /// o2::Base::MaterialManager::NOPROCESS
+  void SpecialProcesses(const char* modname, int localindex,
+                        const std::initializer_list<std::pair<EProc, int>>& parIDValMap)
+  {
+    int globalindex = getMediumID(modname, localindex);
+    if (globalindex != -1) {
+      Processes(true, globalindex, parIDValMap);
+    }
+  }
+  /// set default process
+  void DefaultProcess(EProc parID, int val) { Process(false, -1, parID, val); }
+  /// Custom setting of process or cut given parameter name and value
+  void SpecialProcess(const char* modname, int localindex, EProc parID, int val)
+  {
+    int globalindex = getMediumID(modname, localindex);
+    if (globalindex != -1) {
+      Process(true, globalindex, parID, val);
+    }
+  }
+  /// Global settings of cuts.
+  /// To ignore a certain cut to be set, just set it to o2::Base::MaterialManager::NOPROCESS
+  void DefaultCuts(const std::initializer_list<std::pair<ECut, Float_t>>& parIDValMap) { Cuts(false, -1, parIDValMap); }
+  /// Set cuts per medium providing the module name and the local ID of the medium.
+  /// To ignore a certain cut to be set explicitly (default or Geant settings will be used in that case) use
+  /// o2::Base::MaterialManager::NOPROCESS
+  void SpecialCuts(const char* modname, int localindex,
+                   const std::initializer_list<std::pair<ECut, Float_t>>& parIDValMap)
+  {
+    int globalindex = getMediumID(modname, localindex);
+    if (globalindex != -1) {
+      Cuts(true, globalindex, parIDValMap);
+    }
+  }
+  /// set default cut
+  void DefaultCut(ECut parID, Float_t val) { Cut(false, -1, parID, val); }
+  /// Custom setting of process or cut given parameter name and value
+  void SpecialCut(const char* modname, int localindex, ECut parID, Float_t val)
+  {
+    int globalindex = getMediumID(modname, localindex);
+    if (globalindex != -1) {
+      Cut(true, globalindex, parID, val);
+    }
+  }
+
  private:
+  // Hide details by providing these private methods so it cannot happen that special settings
+  // are applied as default settings by accident using a boolean flag
+  void Processes(bool special, int globalindex, const std::initializer_list<std::pair<EProc, int>>& parIDValMap);
+  void Cuts(bool special, int globalindex, const std::initializer_list<std::pair<ECut, Float_t>>& parIDValMap);
+  void Process(bool special, int globalindex, EProc parID, int val);
+  void Cut(bool special, int globalindex, ECut parID, Float_t val);
+
   // insert material name
   void insertMaterialName(const char* uniquename, int index);
   void insertMediumName(const char* uniquename, int index);
   void insertTGeoMedium(std::string modname, int localindex);
 
  public:
+  /// Set flags whether to use special cuts and process settings
+  void enableSpecialProcesses(bool val = true) { mApplySpecialProcesses = val; }
+  bool specialProcessesEnabled() const { return mApplySpecialProcesses; }
+  void enableSpecialCuts(bool val = true) { mApplySpecialCuts = val; }
+  bool specialCutsEnabled() const { return mApplySpecialCuts; }
+
   // returns global material ID given a "local" material ID for this detector
   // returns -1 in case local ID not found
   int getMaterialID(const char* modname, int imat) const
@@ -128,11 +203,15 @@ class MaterialManager
     mMaterialMap; // map of name -> map of local index to global index for Materials
   std::map<std::string, std::map<int, int>> mMediumMap; // map of name -> map of local index to global index for Media
 
+  std::map<int, std::map<EProc, int>> mMediumProcessMap; // map of global medium id to parameter-value map of processes
+  std::map<int, std::map<ECut, Float_t>> mMediumCutMap;  // map of global medium id to parameter-value map of cuts
+  std::map<ECut, Float_t> mDefaultCutMap;                // map of global cuts
+  std::map<EProc, int> mDefaultProcessMap;               // map of global processes
+
   // a map allowing to lookup TGeoMedia from detector name and local medium index
   std::map<std::pair<std::string, int>, TGeoMedium*> mTGeoMediumMap;
 
   // finally, I would like to keep track of tracking parameters and processes activated per medium
-
 
   std::map<std::string, int> mMaterialNameToGlobalIndexMap; // map of unique material name to global index
   std::map<std::string, int> mMediumNameToGlobalIndexMap;
@@ -140,9 +219,28 @@ class MaterialManager
   Float_t mDensityFactor = 1.; //! factor that is multiplied to all material densities (ONLY for
   // systematic studies)
 
+  /// In general, transport cuts and processes are properties of detector media. On the other hand different
+  /// engines might provide different cuts and processes. Further, the naming convention might differ among
+  /// engines.
+  /// This must be handled by the MaterialManager to fit to the engine in use. In that way, the user does not need
+  /// to care about the engine in use but only needs to set cuts according to ONE naming scheme.
+  // \note Currently, the naming convention of GEANT4 v10.3.3 is used.
+  // \note This might be overhead so far but makes the MaterialManager and therefore O2 finally capable of
+  // forwarding cuts/processe to arbitrary engines.
+  // \todo Is there a more elegant implementation?
+  /// fixed names of cuts
+  const static std::vector<std::string> mCutIDToName;
+  /// fixed names of processes
+  const static std::vector<std::string> mProcessIDToName;
+
+  /// Decide whether special process and cut settings should be applied
+  bool mApplySpecialProcesses = true;
+  bool mApplySpecialCuts = true;
+
+ public:
   ClassDefNV(MaterialManager, 0);
 };
-}
-}
+} // namespace Base
+} // namespace o2
 
 #endif

--- a/Detectors/Base/src/Detector.cxx
+++ b/Detectors/Base/src/Detector.cxx
@@ -75,6 +75,32 @@ void Detector::Medium(Int_t numed, const char* name, Int_t nmat, Int_t isvol, In
   mgr.Medium(GetName(), numed, name, nmat, isvol, ifield, fieldm, tmaxfd, stemax, deemax, epsil, stmin, ubuf, nbuf);
 }
 
+void Detector::SpecialCuts(Int_t numed,
+                           const std::initializer_list<std::pair<MaterialManager::ECut, Float_t>>& parIDValMap)
+{
+  auto& mgr = o2::Base::MaterialManager::Instance();
+  mgr.SpecialCuts(GetName(), numed, parIDValMap);
+}
+
+void Detector::SpecialCut(Int_t numed, MaterialManager::ECut parID, Float_t val)
+{
+  auto& mgr = o2::Base::MaterialManager::Instance();
+  mgr.SpecialCut(GetName(), numed, parID, val);
+}
+
+void Detector::SpecialProcesses(Int_t numed,
+                                const std::initializer_list<std::pair<MaterialManager::EProc, int>>& parIDValMap)
+{
+  auto& mgr = o2::Base::MaterialManager::Instance();
+  mgr.SpecialProcesses(GetName(), numed, parIDValMap);
+}
+
+void Detector::SpecialProcess(Int_t numed, MaterialManager::EProc parID, int val)
+{
+  auto& mgr = o2::Base::MaterialManager::Instance();
+  mgr.SpecialProcess(GetName(), numed, parID, val);
+}
+
 void Detector::Matrix(Int_t& nmat, Float_t theta1, Float_t phi1, Float_t theta2, Float_t phi2, Float_t theta3,
                       Float_t phi3) const
 {

--- a/Detectors/Passive/include/DetectorsPassive/Hall.h
+++ b/Detectors/Passive/include/DetectorsPassive/Hall.h
@@ -20,10 +20,13 @@ namespace passive
 class Hall : public FairModule
 {
  public:
+  enum EMedium { kSTST_C2 = 50, kAIR_C2 = 55, kCC_C2 = 57, kFE_C2 = 52 };
+
   Hall(const char* name, const char* Title = "ALICE Experimental Hall");
   Hall();
   ~Hall() override;
   void ConstructGeometry() override;
+  void SetSpecialPhysicsCuts() override;
 
   /// Clone this object (used in MT mode only)
   FairModule* CloneModule() const override;

--- a/Detectors/Passive/src/Hall.cxx
+++ b/Detectors/Passive/src/Hall.cxx
@@ -19,6 +19,7 @@
 #include <TGeoTrd1.h>
 #include <TGeoTube.h>
 #include <TGeoVolume.h>
+#include <initializer_list>
 using namespace o2::passive;
 
 Hall::~Hall() = default;
@@ -86,20 +87,41 @@ void Hall::createMaterials()
   // only media needed for geometry are created
 
   //  Stainless Steel
-  matmgr.Mixture("HALL", 50, "STAINLESS STEEL3", asteel, zsteel, 7.88, 4, wsteel);
-  matmgr.Medium("HALL", 50, "STST_C2", 50, 0, isxfld, sxmgmx, tmaxfd, stemax, deemax, epsil, stmin);
+  matmgr.Mixture("HALL", kSTST_C2, "STAINLESS STEEL3", asteel, zsteel, 7.88, 4, wsteel);
+  matmgr.Medium("HALL", kSTST_C2, "STST_C2", 50, 0, isxfld, sxmgmx, tmaxfd, stemax, deemax, epsil, stmin);
 
   //  Air
-  matmgr.Mixture("HALL", 55, "AIR2", aAir, zAir, dAir, 4, wAir);
-  matmgr.Medium("HALL", 55, "AIR_C2", 55, 0, isxfld, sxmgmx, tmaxfd, stemax, deemax, epsil, stmin);
+  matmgr.Mixture("HALL", kAIR_C2, "AIR2", aAir, zAir, dAir, 4, wAir);
+  matmgr.Medium("HALL", kAIR_C2, "AIR_C2", 55, 0, isxfld, sxmgmx, tmaxfd, stemax, deemax, epsil, stmin);
 
   // Concrete
-  matmgr.Mixture("HALL", 57, "CONCRETE2", aconc, zconc, 2.35, 10, wconc);
-  matmgr.Medium("HALL", 57, "CC_C2", 57, 0, isxfld, sxmgmx, tmaxfd, stemax, deemax, epsil, stmin);
+  matmgr.Mixture("HALL", kCC_C2, "CONCRETE2", aconc, zconc, 2.35, 10, wconc);
+  matmgr.Medium("HALL", kCC_C2, "CC_C2", 57, 0, isxfld, sxmgmx, tmaxfd, stemax, deemax, epsil, stmin);
 
   //  Iron
-  matmgr.Material("HALL", 52, "IRON", 55.85, 26., 7.87, 1.76, 17.1);
-  matmgr.Medium("HALL", 52, "FE_C2", 52, 0, isxfld, sxmgmx, tmaxfd, stemax, deemax, epsil, stmin);
+  matmgr.Material("HALL", kFE_C2, "IRON", 55.85, 26., 7.87, 1.76, 17.1);
+  matmgr.Medium("HALL", kFE_C2, "FE_C2", 52, 0, isxfld, sxmgmx, tmaxfd, stemax, deemax, epsil, stmin);
+}
+
+void Hall::SetSpecialPhysicsCuts()
+{
+
+  // MaterialManager used to set physics cuts
+  auto& matmgr = o2::Base::MaterialManager::Instance();
+  // prepare available cuts
+  const o2::Base::MaterialManager::ECut cutgam = o2::Base::MaterialManager::kCUTGAM;
+  const o2::Base::MaterialManager::ECut cutele = o2::Base::MaterialManager::kCUTELE;
+  const o2::Base::MaterialManager::ECut cutneu = o2::Base::MaterialManager::kCUTNEU;
+  const o2::Base::MaterialManager::ECut cuthad = o2::Base::MaterialManager::kCUTHAD;
+
+  const Float_t cut1 = 1.e00;
+  const Float_t cut2 = 1.e-1;
+  const Float_t cut3 = 1.e-3;
+
+  // \note ported from AliRoot
+  matmgr.SpecialCuts("HALL", kSTST_C2, { { cutgam, cut1 }, { cutele, cut1 }, { cutneu, cut2 }, { cuthad, cut3 } });
+  matmgr.SpecialCuts("HALL", kAIR_C2, { { cutgam, cut1 }, { cutele, cut1 }, { cutneu, cut2 }, { cuthad, cut3 } });
+  matmgr.SpecialCuts("HALL", kCC_C2, { { cutgam, cut1 }, { cutele, cut1 }, { cutneu, cut2 }, { cuthad, cut3 } });
 }
 
 void Hall::ConstructGeometry()

--- a/Detectors/TPC/simulation/include/TPCSimulation/Detector.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/Detector.h
@@ -28,40 +28,70 @@ namespace TPC {
 class Detector: public o2::Base::DetImpl<Detector> {
 
   public:
-    /**      Name :  Detector Name
-     *       Active: kTRUE for active detectors (ProcessHits() will be called)
-     *               kFALSE for inactive detectors
+   /** Local material/media IDs for TPC */
+   enum EMaterial {
+     kAir = 0,
+     kDriftGas1 = 1,
+     kDriftGas2 = 2,
+     kCO2 = 3,
+     kDriftGas3 = 20,
+     kAl = 4,
+     kKevlar = 5,
+     kNomex = 6,
+     kMakrolon = 7,
+     kMylar = 8,
+     kTedlar = 9,
+     kPrepreg1 = 10,
+     kPrepreg2 = 11,
+     kPrepreg3 = 12,
+     kEpoxy = 13,
+     kCu = 14,
+     kSi = 15,
+     kG10 = 16,
+     kPlexiglas = 17,
+     kSteel = 18,
+     kPeek = 19,
+     kAlumina = 21,
+     kWater = 22,
+     kBrass = 23,
+     kEpoxyfm = 24,
+     kEpoxy1 = 25,
+     kAlumina1 = 26
+   };
+   /**      Name :  Detector Name
+    *       Active: kTRUE for active detectors (ProcessHits() will be called)
+    *               kFALSE for inactive detectors
     */
-    Detector(Bool_t Active);
+   Detector(Bool_t Active);
 
-    /**      default constructor    */
-    Detector();
+   /**      default constructor    */
+   Detector();
 
-    /**       destructor     */
-    ~Detector() override;
+   /**       destructor     */
+   ~Detector() override;
 
-    /**      Clone this object (used in MT mode only)    */
-    FairModule *CloneModule() const override;
+   /**      Clone this object (used in MT mode only)    */
+   FairModule* CloneModule() const override;
 
-    /**      Initialization of the detector is done here    */
-    void   Initialize() override;
+   /**      Initialization of the detector is done here    */
+   void Initialize() override;
 
-    /**       this method is called for each step during simulation
-     *       (see FairMCApplication::Stepping())
+   /**       this method is called for each step during simulation
+    *       (see FairMCApplication::Stepping())
     */
-//     virtual Bool_t ProcessHitsOrig( FairVolume* v=0);
-    Bool_t ProcessHits( FairVolume* v=nullptr) override;
+   //     virtual Bool_t ProcessHitsOrig( FairVolume* v=0);
+   Bool_t ProcessHits(FairVolume* v = nullptr) override;
 
-    /**       Registers the produced collections in FAIRRootManager.     */
-    void   Register() override;
+   /**       Registers the produced collections in FAIRRootManager.     */
+   void Register() override;
 
-    /** Get the produced hits */
-    std::vector<HitGroup>* getHits(Int_t iColl) const
-    {
-      if (iColl >= 0 && iColl < Sector::MAXSECTOR) {
-        return mHitsPerSectorCollection[iColl];
-      }
-      return nullptr;
+   /** Get the produced hits */
+   std::vector<HitGroup>* getHits(Int_t iColl) const
+   {
+     if (iColl >= 0 && iColl < Sector::MAXSECTOR) {
+       return mHitsPerSectorCollection[iColl];
+     }
+     return nullptr;
     }
 
     /**      has to be called after each event to reset the containers      */

--- a/Detectors/TPC/simulation/src/Detector.cxx
+++ b/Detectors/TPC/simulation/src/Detector.cxx
@@ -109,84 +109,68 @@ void Detector::Initialize()
 
 void Detector::SetSpecialPhysicsCuts()
 {
-  FairRun* fRun = FairRun::Instance();
+  using o2::Base::MaterialManager;
+  // provide available cuts
+  const MaterialManager::ECut cutgam = MaterialManager::kCUTGAM;
+  const MaterialManager::ECut cutele = MaterialManager::kCUTELE;
+  const MaterialManager::ECut cutneu = MaterialManager::kCUTNEU;
+  const MaterialManager::ECut cuthad = MaterialManager::kCUTHAD;
+  const MaterialManager::ECut cutmuo = MaterialManager::kCUTMUO;
+  const MaterialManager::ECut bcute = MaterialManager::kBCUTE;
+  const MaterialManager::ECut bcutm = MaterialManager::kBCUTM;
+  const MaterialManager::ECut dcute = MaterialManager::kDCUTE;
+  const MaterialManager::ECut dcutm = MaterialManager::kDCUTM;
+  const MaterialManager::ECut ppcutm = MaterialManager::kPPCUTM;
+  const MaterialManager::ECut tofmax = MaterialManager::kTOFMAX;
 
-  // check for GEANT3, else abort
-  if (strcmp(fRun->GetName(), "TGeant3") == 0) {
+  // provide available processes
+  const MaterialManager::EProc pair = MaterialManager::kPAIR;
+  const MaterialManager::EProc comp = MaterialManager::kCOMP;
+  const MaterialManager::EProc phot = MaterialManager::kPHOT;
+  const MaterialManager::EProc pfis = MaterialManager::kPFIS;
+  const MaterialManager::EProc dray = MaterialManager::kDRAY;
+  const MaterialManager::EProc anni = MaterialManager::kANNI;
+  const MaterialManager::EProc brem = MaterialManager::kBREM;
+  const MaterialManager::EProc hadr = MaterialManager::kHADR;
+  const MaterialManager::EProc munu = MaterialManager::kMUNU;
+  const MaterialManager::EProc dcay = MaterialManager::kDCAY;
+  const MaterialManager::EProc loss = MaterialManager::kLOSS;
+  const MaterialManager::EProc muls = MaterialManager::kMULS;
 
-    // get material ID for customs settings
-    std::string fMixture("TPC_DriftGas2");
-    bool fAliMC = false; // implemented the e-loss now on our own -> use default model
-    std::cout << "TpcDetector::SetSpecialPhysicsCuts() "
-              << "Working on medium " << fMixture.c_str() << std::endl;
-    int matIdVMC = gGeoManager->GetMedium(fMixture.c_str())->GetId();
+  const Float_t cut1 = 1e-5;
+  const Float_t cutTofmax = 1e10;
 
-    double tofmax = 1.E10; // (s)
-
-    // Set new properties, physics cuts etc. for the TPCmixture
-
-    // gMC->Gstpar(matIdVMC,"PAIR",1); /** pair production*/
-    // gMC->Gstpar(matIdVMC,"COMP",1); /**Compton scattering*/
-    // gMC->Gstpar(matIdVMC,"PHOT",1); /** photo electric effect */
-    // gMC->Gstpar(matIdVMC,"PFIS",0); /**photofission*/
-    // gMC->Gstpar(matIdVMC,"DRAY",1); /**delta-ray*/
-    // gMC->Gstpar(matIdVMC,"ANNI",1); /**annihilation*/
-    // gMC->Gstpar(matIdVMC,"BREM",1); /**bremsstrahlung*/
-    // gMC->Gstpar(matIdVMC,"HADR",1); /**hadronic process*/
-    // gMC->Gstpar(matIdVMC,"MUNU",1); /**muon nuclear interaction*/
-    // gMC->Gstpar(matIdVMC,"DCAY",1); /**decay*/
-    // gMC->Gstpar(matIdVMC,"LOSS",1); /**energy loss*/
-    // gMC->Gstpar(matIdVMC,"MULS",1); /**multiple scattering*/
-    // gMC->Gstpar(matIdVMC,"STRA",0);
-    // gMC->Gstpar(matIdVMC,"RAYL",1);
-
-    // gMC->Gstpar(matIdVMC,"CUTGAM",fCut_el); /** gammas (GeV)*/
-    // gMC->Gstpar(matIdVMC,"CUTELE",fCut_el); /** electrons (GeV)*/
-    // gMC->Gstpar(matIdVMC,"CUTNEU",fCut_had); /** neutral hadrons (GeV)*/
-    // gMC->Gstpar(matIdVMC,"CUTHAD",fCut_had); /** charged hadrons (GeV)*/
-    // gMC->Gstpar(matIdVMC,"CUTMUO",fCut_el); /** muons (GeV)*/
-    // gMC->Gstpar(matIdVMC,"BCUTE",fCut_el);  /** electron bremsstrahlung (GeV)*/
-    // gMC->Gstpar(matIdVMC,"BCUTM",fCut_el);  /** muon and hadron bremsstrahlung(GeV)*/
-    // gMC->Gstpar(matIdVMC,"DCUTE",fCut_el);  /** delta-rays by electrons (GeV)*/
-    // gMC->Gstpar(matIdVMC,"DCUTM",fCut_el);  /** delta-rays by muons (GeV)*/
-    // gMC->Gstpar(matIdVMC,"PPCUTM",fCut_el); /** direct pair production by muons (GeV)*/
-    gMC->Gstpar(matIdVMC, "PAIR", 1);
-    gMC->Gstpar(matIdVMC, "COMP", 1);
-    gMC->Gstpar(matIdVMC, "PHOT", 1);
-    gMC->Gstpar(matIdVMC, "PFIS", 0);
-    gMC->Gstpar(matIdVMC, "DRAY", 1);
-    gMC->Gstpar(matIdVMC, "ANNI", 1);
-    gMC->Gstpar(matIdVMC, "BREM", 1);
-    gMC->Gstpar(matIdVMC, "HADR", 1);
-    gMC->Gstpar(matIdVMC, "MUNU", 1);
-    gMC->Gstpar(matIdVMC, "DCAY", 1);
-    gMC->Gstpar(matIdVMC, "LOSS", 1);
-    gMC->Gstpar(matIdVMC, "MULS", 1);
-    Double_t cut1 = 1.0E-5; // GeV --> 1 MeV
-    Double_t cutel = 1.0E-5;
-
-    gMC->SetCut("CUTGAM", cutel);
-    gMC->SetCut("CUTELE", cutel);
-    gMC->SetCut("CUTNEU", cut1);
-    gMC->SetCut("CUTHAD", cut1);
-    gMC->SetCut("CUTMUO", cut1);
-    gMC->SetCut("BCUTE", cutel);
-    gMC->SetCut("BCUTM", cut1);
-    gMC->SetCut("DCUTE", cutel);
-    gMC->SetCut("DCUTM", cut1);
-    gMC->SetCut("PPCUTM", cut1);
-    gMC->SetCut("TOFMAX", tofmax);
-    gMC->SetMaxNStep((int)1E6);
-
-    std::cout << "\n************************************************************\n"
-              << "TpcDetector::SetSpecialPhysicsCuts():\n"
-              << "   using special physics cuts ...\n";
-    if (fAliMC) {
-      std::cout << "   using LOSS=5 for ALICE MC model\n";
-      gMC->Gstpar(matIdVMC, "LOSS", 5);
-    }
-    std::cout << "************************************************************" << std::endl;
-  }
+  // Some cuts implemented in AliRoot
+  // \note
+  //    Cuts in TPC were set globally before and hence affected the default settings of all other media,
+  //    also outside of TPC. Also, settings were just done for G3.
+  //    Now cuts are set in both cases, for G3 and G4; Further cuts are only set for TPC medium DriftGas2.
+  // \todo discussion needed!!
+  // cut settings for DriftGas2
+  SpecialCuts(kDriftGas2, { { cutgam, cut1 },
+                            { cutele, cut1 },
+                            { cutneu, cut1 },
+                            { cuthad, cut1 },
+                            { cutmuo, cut1 },
+                            { bcute, cut1 },
+                            { bcutm, cut1 },
+                            { dcute, cut1 },
+                            { dcutm, cut1 },
+                            { ppcutm, cut1 },
+                            { tofmax, cutTofmax } });
+  // process settings for DriftGas2
+  SpecialProcesses(kDriftGas2, { { pair, 1 },
+                                 { comp, 1 },
+                                 { phot, 1 },
+                                 { pfis, 0 },
+                                 { dray, 1 },
+                                 { anni, 1 },
+                                 { brem, 1 },
+                                 { hadr, 1 },
+                                 { munu, 1 },
+                                 { dcay, 1 },
+                                 { loss, 1 },
+                                 { muls, 1 } });
 }
 
 Bool_t Detector::ProcessHits(FairVolume* vol)
@@ -372,9 +356,6 @@ void Detector::ConstructGeometry()
   // Load geometry
   //   LoadGeometryFromFile();
   ConstructTPCGeometry();
-
-  // GeantHack
-  // GeantHack();
 }
 
 void Detector::CreateMaterials()
@@ -934,39 +915,39 @@ void Detector::CreateMaterials()
   // tracking media for gases
   //----------------------------------------------------------
 
-  o2::Base::Detector::Medium(0, "Air", 11, 0, iSXFLD, sXMGMX, 10., 999., .1, .01, .1);
-  o2::Base::Detector::Medium(1, "DriftGas1", 12, 0, iSXFLD, sXMGMX, 10., 999., .1, .001, .001);
-  o2::Base::Detector::Medium(2, "DriftGas2", 13, 1, iSXFLD, sXMGMX, 10., 999., .1, .001, .001);
-  o2::Base::Detector::Medium(3, "CO2", 10, 0, iSXFLD, sXMGMX, 10., 999., .1, .001, .001);
-  o2::Base::Detector::Medium(20, "DriftGas3", 40, 1, iSXFLD, sXMGMX, 10., 999., .1, .001, .001);
+  o2::Base::Detector::Medium(kAir, "Air", 11, 0, iSXFLD, sXMGMX, 10., 999., .1, .01, .1);
+  o2::Base::Detector::Medium(kDriftGas1, "DriftGas1", 12, 0, iSXFLD, sXMGMX, 10., 999., .1, .001, .001);
+  o2::Base::Detector::Medium(kDriftGas2, "DriftGas2", 13, 1, iSXFLD, sXMGMX, 10., 999., .1, .001, .001);
+  o2::Base::Detector::Medium(kCO2, "CO2", 10, 0, iSXFLD, sXMGMX, 10., 999., .1, .001, .001);
+  o2::Base::Detector::Medium(kDriftGas3, "DriftGas3", 40, 1, iSXFLD, sXMGMX, 10., 999., .1, .001, .001);
   //-----------------------------------------------------------
   // tracking media for solids
   //-----------------------------------------------------------
 
-  o2::Base::Detector::Medium(4, "Al", 23, 0, iSXFLD, sXMGMX, 10., 999., .1, .0005, .001);
-  o2::Base::Detector::Medium(5, "Kevlar", 14, 0, iSXFLD, sXMGMX, 10., 999., .1, .0005, .001);
-  o2::Base::Detector::Medium(6, "Nomex", 15, 0, iSXFLD, sXMGMX, 10., 999., .1, .001, .001);
-  o2::Base::Detector::Medium(7, "Makrolon", 16, 0, iSXFLD, sXMGMX, 10., 999., .1, .001, .001);
-  o2::Base::Detector::Medium(8, "Mylar", 18, 0, iSXFLD, sXMGMX, 10., 999., .1, .0005, .001);
-  o2::Base::Detector::Medium(9, "Tedlar", 17, 0, iSXFLD, sXMGMX, 10., 999., .1, .0005, .001);
+  o2::Base::Detector::Medium(kAl, "Al", 23, 0, iSXFLD, sXMGMX, 10., 999., .1, .0005, .001);
+  o2::Base::Detector::Medium(kKevlar, "Kevlar", 14, 0, iSXFLD, sXMGMX, 10., 999., .1, .0005, .001);
+  o2::Base::Detector::Medium(kNomex, "Nomex", 15, 0, iSXFLD, sXMGMX, 10., 999., .1, .001, .001);
+  o2::Base::Detector::Medium(kMakrolon, "Makrolon", 16, 0, iSXFLD, sXMGMX, 10., 999., .1, .001, .001);
+  o2::Base::Detector::Medium(kMylar, "Mylar", 18, 0, iSXFLD, sXMGMX, 10., 999., .1, .0005, .001);
+  o2::Base::Detector::Medium(kTedlar, "Tedlar", 17, 0, iSXFLD, sXMGMX, 10., 999., .1, .0005, .001);
   //
-  o2::Base::Detector::Medium(10, "Prepreg1", 19, 0, iSXFLD, sXMGMX, 10., 999., .1, .0005, .001);
-  o2::Base::Detector::Medium(11, "Prepreg2", 20, 0, iSXFLD, sXMGMX, 10., 999., .1, .0005, .001);
-  o2::Base::Detector::Medium(12, "Prepreg3", 21, 0, iSXFLD, sXMGMX, 10., 999., .1, .0005, .001);
-  o2::Base::Detector::Medium(13, "Epoxy", 26, 0, iSXFLD, sXMGMX, 10., 999., .1, .0005, .001);
+  o2::Base::Detector::Medium(kPrepreg1, "Prepreg1", 19, 0, iSXFLD, sXMGMX, 10., 999., .1, .0005, .001);
+  o2::Base::Detector::Medium(kPrepreg2, "Prepreg2", 20, 0, iSXFLD, sXMGMX, 10., 999., .1, .0005, .001);
+  o2::Base::Detector::Medium(kPrepreg3, "Prepreg3", 21, 0, iSXFLD, sXMGMX, 10., 999., .1, .0005, .001);
+  o2::Base::Detector::Medium(kEpoxy, "Epoxy", 26, 0, iSXFLD, sXMGMX, 10., 999., .1, .0005, .001);
 
-  o2::Base::Detector::Medium(14, "Cu", 25, 0, iSXFLD, sXMGMX, 10., 999., .1, .001, .001);
-  o2::Base::Detector::Medium(15, "Si", 24, 0, iSXFLD, sXMGMX, 10., 999., .1, .001, .001);
-  o2::Base::Detector::Medium(16, "G10", 22, 0, iSXFLD, sXMGMX, 10., 999., .1, .001, .001);
-  o2::Base::Detector::Medium(17, "Plexiglas", 27, 0, iSXFLD, sXMGMX, 10., 999., .1, .001, .001);
-  o2::Base::Detector::Medium(18, "Steel", 29, 0, iSXFLD, sXMGMX, 10., 999., .1, .001, .001);
-  o2::Base::Detector::Medium(19, "Peek", 30, 0, iSXFLD, sXMGMX, 10., 999., .1, .001, .001);
-  o2::Base::Detector::Medium(21, "Alumina", 31, 0, iSXFLD, sXMGMX, 10., 999., .1, .001, .001);
-  o2::Base::Detector::Medium(22, "Water", 32, 0, iSXFLD, sXMGMX, 10., 999., .1, .001, .001);
-  o2::Base::Detector::Medium(23, "Brass", 33, 0, iSXFLD, sXMGMX, 10., 999., .1, .001, .001);
-  o2::Base::Detector::Medium(24, "Epoxyfm", 34, 0, iSXFLD, sXMGMX, 10., 999., .1, .0005, .001);
-  o2::Base::Detector::Medium(25, "Epoxy1", 35, 0, iSXFLD, sXMGMX, 10., 999., .1, .0005, .001);
-  o2::Base::Detector::Medium(26, "Alumina1", 36, 0, iSXFLD, sXMGMX, 10., 999., .1, .001, .001);
+  o2::Base::Detector::Medium(kCu, "Cu", 25, 0, iSXFLD, sXMGMX, 10., 999., .1, .001, .001);
+  o2::Base::Detector::Medium(kSi, "Si", 24, 0, iSXFLD, sXMGMX, 10., 999., .1, .001, .001);
+  o2::Base::Detector::Medium(kG10, "G10", 22, 0, iSXFLD, sXMGMX, 10., 999., .1, .001, .001);
+  o2::Base::Detector::Medium(kPlexiglas, "Plexiglas", 27, 0, iSXFLD, sXMGMX, 10., 999., .1, .001, .001);
+  o2::Base::Detector::Medium(kSteel, "Steel", 29, 0, iSXFLD, sXMGMX, 10., 999., .1, .001, .001);
+  o2::Base::Detector::Medium(kPeek, "Peek", 30, 0, iSXFLD, sXMGMX, 10., 999., .1, .001, .001);
+  o2::Base::Detector::Medium(kAlumina, "Alumina", 31, 0, iSXFLD, sXMGMX, 10., 999., .1, .001, .001);
+  o2::Base::Detector::Medium(kWater, "Water", 32, 0, iSXFLD, sXMGMX, 10., 999., .1, .001, .001);
+  o2::Base::Detector::Medium(kBrass, "Brass", 33, 0, iSXFLD, sXMGMX, 10., 999., .1, .001, .001);
+  o2::Base::Detector::Medium(kEpoxyfm, "Epoxyfm", 34, 0, iSXFLD, sXMGMX, 10., 999., .1, .0005, .001);
+  o2::Base::Detector::Medium(kEpoxy1, "Epoxy1", 35, 0, iSXFLD, sXMGMX, 10., 999., .1, .0005, .001);
+  o2::Base::Detector::Medium(kAlumina1, "Alumina1", 36, 0, iSXFLD, sXMGMX, 10., 999., .1, .001, .001);
 }
 
 void Detector::ConstructTPCGeometry()
@@ -3140,85 +3121,5 @@ Double_t Detector::Gamma(Double_t k)
   return TMath::Exp(x);
 }
 
-#include <sstream>
-#include <string>
-#include "TVirtualMC.h"
-void Detector::GeantHack()
-{
-  //   Med  GAM   ELEC  NHAD  CHAD  MUON  EBREM MUHAB EDEL  MUDEL MUPA ANNI BREM COMP DCAY DRAY HADR LOSS MULS PAIR PHOT
-  //   RAYL STRA
-  std::stringstream data(
-    "\
-  TPC    0    -1.   -1.   -1.  -1.   -1.    -1.   -1.  -1.    -1.   -1.  -1   -1   -1    1    1    1    3    1    1    1    1\n\
-  TPC     1 1e-5  1e-5  1e-3 1e-3  1e-5   1e-5   1e-5  1e-5 1e-5    -1.   1    1    1    1    1    1    3    1    1    1    1\n\
-  TPC     2 1e-5  1e-5  1e-3 1e-3  1e-5   1e-5   1e-5  1e-5 1e-5    -1.   1    1    1    1    1    1    5    1    1    1    1\n\
-  TPC     3 1e-5  1e-5  1e-3 1e-3  1e-5   1e-5   1e-5  1e-5 1e-5    -1.  -1   -1   -1    1    1    1    3    1    1    1    1 \n\
-  TPC    20 1e-6  1e-6  1e-3 1e-3  1e-6   1e-6   1e-6  1e-6 1e-6    -1.   1    1    1    1    1    1    5    1    1    1    1\n\
-  TPC     4   -1.   -1.   -1.  -1.   -1.    -1.   -1.  -1.    -1.   -1.  -1   -1   -1    1    1    1    3    1    1    1    1\n\
-  TPC     5   -1.   -1.   -1.  -1.   -1.    -1.   -1.  -1.    -1.   -1.  -1   -1   -1    1    1    1    3    1    1    1    1\n\
-  TPC     6   -1.   -1.   -1.  -1.   -1.    -1.   -1.  -1.    -1.   -1.  -1   -1   -1    1    1    1    3    1    1    1    1\n\
-  TPC     7   -1.   -1.   -1.  -1.   -1.    -1.   -1.  -1.    -1.   -1.  -1   -1   -1    1    1    1    3    1    1    1    1\n\
-  TPC     8   -1.   -1.   -1.  -1.   -1.    -1.   -1.  -1.    -1.   -1.  -1   -1   -1    1    1    1    3    1    1    1    1\n\
-  TPC     9   -1.   -1.   -1.  -1.   -1.    -1.   -1.  -1.    -1.   -1.  -1   -1   -1    1    1    1    3    1    1    1    1\n\
-  TPC    10   -1.   -1.   -1.  -1.   -1.    -1.   -1.  -1.    -1.   -1.  -1   -1   -1    1    1    1    3    1    1    1    1\n\
-  TPC    11   -1.   -1.   -1.  -1.   -1.    -1.   -1.  -1.    -1.   -1.  -1   -1   -1    1    1    1    3    1    1    1    1\n\
-  TPC    12   -1.   -1.   -1.  -1.   -1.    -1.   -1.  -1.    -1.   -1.  -1   -1   -1    1    1    1    3    1    1    1    1\n\
-  TPC    13   -1.   -1.   -1.  -1.   -1.    -1.   -1.  -1.    -1.   -1.  -1   -1   -1    1    1    1    3    1    1    1    1\n\
-  TPC    14   -1.   -1.   -1.  -1.   -1.    -1.   -1.  -1.    -1.   -1.  -1   -1   -1    1    1    1    3    1    1    1    1\n\
-  TPC    15   -1.   -1.   -1.  -1.   -1.    -1.   -1.  -1.    -1.   -1.  -1   -1   -1    1    1    1    3    1    1    1    1");
-
-  const Int_t kncuts = 10;
-  const Int_t knflags = 12;
-  const Int_t knpars = kncuts + knflags;
-  const char kpars[knpars][7] = { "CUTGAM", "CUTELE", "CUTNEU", "CUTHAD", "CUTMUO", "BCUTE", "BCUTM", "DCUTE",
-                                  "DCUTM",  "PPCUTM", "ANNI",   "BREM",   "COMP",   "DCAY",  "DRAY",  "HADR",
-                                  "LOSS",   "MULS",   "PAIR",   "PHOT",   "RAYL",   "STRA" };
-  std::string detName;
-  char* filtmp;
-  Float_t cut[kncuts];
-  Int_t flag[knflags];
-  Int_t i, itmed, iret, jret, ktmed, kz;
-
-  std::string line;
-  while (std::getline(data, line)) {
-    std::cout << line << endl;
-    for (i = 0; i < kncuts; i++)
-      cut[i] = -99;
-    for (i = 0; i < knflags; i++)
-      flag[i] = -99;
-    itmed = 0;
-
-    std::stringstream linedata(line);
-    linedata >> detName >> itmed >> cut[0] >> cut[1] >> cut[2] >> cut[3] >> cut[4] >> cut[5] >> cut[6] >> cut[7] >>
-      cut[8] >> cut[9] >> flag[0] >> flag[1] >> flag[2] >> flag[3] >> flag[4] >> flag[5] >> flag[6] >> flag[7] >>
-      flag[8] >> flag[9] >> flag[10] >> flag[11];
-
-    if (0 <= itmed && itmed < 100) {
-      ktmed = getMediumID(itmed);
-      if (ktmed == -1) {
-        LOG(INFO) << Form("Invalid tracking medium code %d for %s", itmed, GetName()) << FairLogger::endl;
-        continue;
-      }
-      // Set energy thresholds
-      for (kz = 0; kz < kncuts; kz++) {
-        if (cut[kz] >= 0) {
-          LOG(INFO) << Form("%-6s set to %10.3E for tracking medium code %4d (%4d) for %s", kpars[kz], cut[kz], itmed,
-                            ktmed, GetName())
-                    << FairLogger::endl;
-          TVirtualMC::GetMC()->Gstpar(ktmed, kpars[kz], cut[kz]);
-        }
-      }
-      // Set transport mechanisms
-      for (kz = 0; kz < knflags; kz++) {
-        if (flag[kz] >= 0) {
-          LOG(INFO) << Form("%-6s set to %10d for tracking medium code %4d (%4d) for %s", kpars[kncuts + kz], flag[kz],
-                            itmed, ktmed, GetName())
-                    << FairLogger::endl;
-          TVirtualMC::GetMC()->Gstpar(ktmed, kpars[kncuts + kz], Float_t(flag[kz]));
-        }
-      }
-    }
-  }
-}
 
 ClassImp(o2::TPC::Detector)

--- a/Detectors/gconfig/SetCuts.C
+++ b/Detectors/gconfig/SetCuts.C
@@ -13,6 +13,7 @@
 
 void SetCuts()
 {
+  using o2::Base::MaterialManager;
   cout << "SetCuts Macro: Setting Processes.." <<endl;
    
   // ------>>>> IMPORTANT!!!!
@@ -25,41 +26,79 @@ void SetCuts()
   // or to message #5362 in the PandaRoot Forum >> Monte Carlo Engines >> g3Config.C thread)
   // 
   // The default settings refer to a complete simulation which generates and follows also the secondary particles.
-  
 
-  TVirtualMC::GetMC()->SetProcess("PAIR",1); /** pair production*/
-  TVirtualMC::GetMC()->SetProcess("COMP",1); /**Compton scattering*/
-  TVirtualMC::GetMC()->SetProcess("PHOT",1); /** photo electric effect */
-  TVirtualMC::GetMC()->SetProcess("PFIS",0); /**photofission*/
-  TVirtualMC::GetMC()->SetProcess("DRAY",0); /**delta-ray*/
-  TVirtualMC::GetMC()->SetProcess("ANNI",1); /**annihilation*/
-  TVirtualMC::GetMC()->SetProcess("BREM",1); /**bremsstrahlung*/
-  TVirtualMC::GetMC()->SetProcess("HADR",1); /**hadronic process*/
-  TVirtualMC::GetMC()->SetProcess("MUNU",1); /**muon nuclear interaction*/
-  TVirtualMC::GetMC()->SetProcess("DCAY",1); /**decay*/
-  TVirtualMC::GetMC()->SetProcess("LOSS",2); /**energy loss*/
-  TVirtualMC::GetMC()->SetProcess("MULS",1); /**multiple scattering*/
-  TVirtualMC::GetMC()->SetProcess("CKOV",1); /**cherenkov */
+  // \note All following settings could also be set in Cave since it is always loaded.
+  // Use MaterialManager to set processes and cuts
+  auto& mgr = MaterialManager::Instance();
+  // En- or disable setting of special cuts depending on ENV variable \note temorary
 
-  
-    
-  
+  // \note Enable and disable via env variable. Change this or completely get rid of
+  //       the possibility to disabled cuts in general?
+  if (!getenv("SPECIALPROCSCUTS")) {
+    mgr.enableSpecialProcesses(false);
+    mgr.enableSpecialCuts(false);
+  }
+
+  LOG(INFO) << "Set default settings for processes and cuts.";
+  // provide available processes
+  const MaterialManager::EProc pair = MaterialManager::kPAIR; /** pair production */
+  const MaterialManager::EProc comp = MaterialManager::kCOMP; /** Compton scattering */
+  const MaterialManager::EProc phot = MaterialManager::kPHOT; /** photo electric effect */
+  const MaterialManager::EProc pfis = MaterialManager::kPFIS; /** photofission */
+  const MaterialManager::EProc dray = MaterialManager::kDRAY; /** delta ray */
+  const MaterialManager::EProc anni = MaterialManager::kANNI; /** annihilation */
+  const MaterialManager::EProc brem = MaterialManager::kBREM; /** bremsstrahlung */
+  const MaterialManager::EProc hadr = MaterialManager::kHADR; /** hadronic process */
+  const MaterialManager::EProc munu = MaterialManager::kMUNU; /** muon nuclear interaction */
+  const MaterialManager::EProc dcay = MaterialManager::kDCAY; /** decay */
+  const MaterialManager::EProc loss = MaterialManager::kLOSS; /** energy loss */
+  const MaterialManager::EProc muls = MaterialManager::kMULS; /** multiple scattering */
+  const MaterialManager::EProc ckov = MaterialManager::kCKOV; /** Cherenkov */
+  mgr.DefaultProcesses({ { pair, 1 },
+                         { comp, 1 },
+                         { phot, 1 },
+                         { pfis, 0 },
+                         { dray, 0 },
+                         { anni, 1 },
+                         { brem, 1 },
+                         { hadr, 1 },
+                         { munu, 1 },
+                         { dcay, 1 },
+                         { loss, 2 },
+                         { muls, 1 },
+                         { ckov, 1 } });
+
+  // provide available cuts
+  const MaterialManager::ECut cutgam = MaterialManager::kCUTGAM; /** gammas */
+  const MaterialManager::ECut cutele = MaterialManager::kCUTELE; /** electrons */
+  const MaterialManager::ECut cutneu = MaterialManager::kCUTNEU; /** neutral hadrons */
+  const MaterialManager::ECut cuthad = MaterialManager::kCUTHAD; /** charged hadrons */
+  const MaterialManager::ECut cutmuo = MaterialManager::kCUTMUO; /** muons */
+  const MaterialManager::ECut bcute = MaterialManager::kBCUTE;   /** electron bremsstrahlung */
+  const MaterialManager::ECut bcutm = MaterialManager::kBCUTM;   /** muon and hadron bremsstrahlung */
+  const MaterialManager::ECut dcute = MaterialManager::kDCUTE;   /** delta-rays by electrons */
+  const MaterialManager::ECut dcutm = MaterialManager::kDCUTM;   /** delta-rays by muons */
+  const MaterialManager::ECut ppcutm = MaterialManager::kPPCUTM; /** direct pair production by muons */
+  const MaterialManager::ECut tofmax = MaterialManager::kTOFMAX; /** time of flight */
+
   Double_t cut1 = 1.0E-3;         // GeV --> 1 MeV
   Double_t cutb = 1.0E4;          // GeV --> 10 TeV
-  Double_t tofmax = 1.E10;        // seconds
-  cout << "SetCuts Macro: Setting cuts.." <<endl;
-  
-  TVirtualMC::GetMC()->SetCut("CUTGAM",cut1);   /** gammas (GeV)*/
-  TVirtualMC::GetMC()->SetCut("CUTELE",cut1);   /** electrons (GeV)*/
-  TVirtualMC::GetMC()->SetCut("CUTNEU",cut1);   /** neutral hadrons (GeV)*/
-  TVirtualMC::GetMC()->SetCut("CUTHAD",cut1);   /** charged hadrons (GeV)*/
-  TVirtualMC::GetMC()->SetCut("CUTMUO",cut1);   /** muons (GeV)*/
-  TVirtualMC::GetMC()->SetCut("BCUTE",cut1);    /** electron bremsstrahlung (GeV)*/
-  TVirtualMC::GetMC()->SetCut("BCUTM",cut1);    /** muon and hadron bremsstrahlung(GeV)*/ 
-  TVirtualMC::GetMC()->SetCut("DCUTE",cut1);    /** delta-rays by electrons (GeV)*/
-  TVirtualMC::GetMC()->SetCut("DCUTM",cut1);    /** delta-rays by muons (GeV)*/
-  TVirtualMC::GetMC()->SetCut("PPCUTM",cut1);   /** direct pair production by muons (GeV)*/
-  TVirtualMC::GetMC()->SetCut("TOFMAX",tofmax); /**time of flight cut in seconds*/
-  
-   
+  Double_t cutTofmax = 1.E10;     // seconds
+
+  mgr.DefaultCuts({ { cutgam, cut1 },
+                    { cutele, cut1 },
+                    { cutneu, cut1 },
+                    { cuthad, cut1 },
+                    { cutmuo, cut1 },
+                    { bcute, cut1 },
+                    { bcutm, cut1 },
+                    { dcute, cut1 },
+                    { dcutm, cut1 },
+                    { ppcutm, cut1 },
+                    { tofmax, cutTofmax } });
+
+  const char* settingProc = mgr.specialProcessesEnabled() ? "enabled" : "disabled";
+  const char* settingCut = mgr.specialCutsEnabled() ? "enabled" : "disabled";
+  LOG(INFO) << "Special process settings are " << settingProc << ".";
+  LOG(INFO) << "Special cut settings are " << settingCut << ".";
 }


### PR DESCRIPTION
Production cuts and settings of processes for GEANT (or other possible engines) are now done via the MaterilaManager. This applies to both global settings and those for single media.
In order to have the cuts correctly available the MaterialManager helds a list of the respective parameters. In that way O2 is capable to abstract from specific engines later on making the processes/cuts O2 dependend and not engine dependent having the MaterialManager as an interface.

Proof-of-concept implementations have been done for the TPC and HALL. In the former case the old implementation in O2 was changed now unsing the MaterialManager interface; for the HALL cuts were ported from in AliRoot.

Medium IDs of TPC and HALL are now stored as enums to avoid hard-coded ones.

For the TPC the method GeantHack() has been removed entirely