### PR TITLE
Unifying the return type of the DPL input API 

### DIFF
--- a/Detectors/TPC/workflow/src/ClusterConverterSpec.cxx
+++ b/Detectors/TPC/workflow/src/ClusterConverterSpec.cxx
@@ -44,7 +44,7 @@ DataProcessorSpec getClusterConverterSpec()
     auto processingFct = [](ProcessingContext& pc) {
       // this will return a span of TPC clusters
       auto inClusters = pc.inputs().get<std::vector<o2::TPC::Cluster>>("clusterin");
-      int nClusters = inClusters->size();
+      int nClusters = inClusters.size();
       LOG(INFO) << "got clusters from input: " << nClusters;
 
       std::vector<ClusterHardwareContainer> containerMetrics;
@@ -52,7 +52,7 @@ DataProcessorSpec getClusterConverterSpec()
       for (; clusterIndex < nClusters; clusterIndex++) {
         // clusters are supposed to be sorted in CRU number, start a new entry
         // for every new CRU, a map is needed if the clusters are not ordered
-        auto inputcluster = (*inClusters)[clusterIndex];
+        auto inputcluster = inClusters[clusterIndex];
         uint16_t CRU = inputcluster.getCRU();
         if (containerMetrics.size() == 0 || containerMetrics.back().CRU != CRU) {
           containerMetrics.emplace_back(ClusterHardwareContainer{ 0, 0, 0, 0, 0, 0, 0, 0, 0xFFFFFFFF, 0, CRU });
@@ -90,7 +90,7 @@ DataProcessorSpec getClusterConverterSpec()
           LOG(DEBUG) << "writing " << clusterContainer->numberOfClusters << " cluster(s) of CRU "
                      << clusterContainer->CRU;
           for (unsigned int clusterInPage = 0; clusterInPage < clusterContainer->numberOfClusters; clusterInPage++) {
-            const auto& inputCluster = (*inClusters)[clusterIndex + clusterInPage];
+            const auto& inputCluster = inClusters[clusterIndex + clusterInPage];
             auto& outputCluster = clusterContainer->clusters[clusterInPage];
             outputCluster.setCluster(inputCluster.getPadMean(),
                                      inputCluster.getTimeMean() - clusterContainer->timeBinOffset,

--- a/Detectors/TPC/workflow/src/ClustererSpec.cxx
+++ b/Detectors/TPC/workflow/src/ClustererSpec.cxx
@@ -46,14 +46,11 @@ DataProcessorSpec getClustererSpec()
     auto processingFct = [clusterer, clusterArray, mctruthArray](ProcessingContext& pc) {
       auto inDigits = pc.inputs().get<std::vector<o2::TPC::Digit>>("digits");
       auto inMCLabels = pc.inputs().get<MCLabelContainer>("mclabels");
-      if (!inDigits) {
-        return;
-      }
 
-      LOG(INFO) << "processing " << inDigits->size() << " digit object(s)";
+      LOG(INFO) << "processing " << inDigits.size() << " digit object(s)";
       clusterArray->clear();
       mctruthArray->clear();
-      clusterer->Process(*(inDigits.get()), inMCLabels.get(), 1);
+      clusterer->Process(inDigits, inMCLabels.get(), 1);
       LOG(INFO) << "clusterer produced " << clusterArray->size() << " cluster(s)";
       pc.outputs().snapshot(OutputRef{ "clusters" }, *clusterArray.get());
       pc.outputs().snapshot(OutputRef{ "clusterlbl" }, *mctruthArray.get());

--- a/Detectors/TPC/workflow/src/RootFileWriterSpec.cxx
+++ b/Detectors/TPC/workflow/src/RootFileWriterSpec.cxx
@@ -54,8 +54,8 @@ DataProcessorSpec getRootFileWriterSpec()
     // function gets out of scope
     auto processingFct = [outputfile, outputtree, tracks](ProcessingContext& pc) {
       auto indata = pc.inputs().get<std::vector<o2::TPC::TrackTPC>>("input");
-      LOG(INFO) << "RootFileWriter: get " << indata->size() << " track(s)";
-      *tracks.get() = std::move(*indata.get());
+      LOG(INFO) << "RootFileWriter: get " << indata.size() << " track(s)";
+      *tracks.get() = std::move(indata);
       LOG(INFO) << "RootFileWriter: write " << tracks->size() << " track(s)";
       outputtree->Fill();
     };

--- a/Framework/Core/README.md
+++ b/Framework/Core/README.md
@@ -280,12 +280,15 @@ DataRef ref = args.get("points");
 You can then use the `DataRef` `header` and `payload` raw pointers to access
 the data in the messages.
 
-If the message is of a known type, you can automatically get a casted reference
+If the message is of a known type, you can automatically get a a smart pointer
 to the contents of the message by passing it as template argument, e.g.:
 
 ```cpp
-XYZ &p = args.get<XYZ>("points");
+auto v = args.get<XYZ>("points");
+XYZ &p = *v;
 ```
+
+The framework will also take care of necessary deserialization.
 
 [InputRecord]: https://github.com/AliceO2Group/AliceO2/blob/HEAD/Framework/Core/include/Framework/InputRecord.h
 

--- a/Framework/Core/include/Framework/InputRecord.h
+++ b/Framework/Core/include/Framework/InputRecord.h
@@ -49,7 +49,7 @@ struct InputSpec;
 /// - (a) const char*
 /// - (b) std::string
 /// - (c) messageable type T
-/// - (d) pointer type T* for types with ROOT dictionary or messageable types
+/// - (d) types T with ROOT dictionary
 /// - (e) std container of type T with ROOT dictionary
 /// - (f) DataRef holding header and payload information, this is also the default
 ///       get method without template parameter
@@ -57,8 +57,8 @@ struct InputSpec;
 /// The return type of get<T>(binding) is:
 /// - (a) const char* to payload content
 /// - (b) std::string copy of the payload
-/// - (c) const ref for messageable types T, the payload content casted to the type
-/// - (d) object with pointer-like behavior (unique_ptr) if T* specified
+/// - (c) object with pointer-like behavior (unique_ptr)
+/// - (d) object with pointer-like behavior (unique_ptr)
 /// - (e) std::container object returned by std::move
 /// - (f) DataRef object returned by copy
 ///
@@ -148,14 +148,14 @@ public:
                    static_cast<char const*>(mCache[pos*2+1]->GetData())};
   }
 
-  /// Generic function to extract a messageable type by reference
+  /// Generic function to extract a messageable type
   /// Cast content of payload bound by @a binding to known type.
   /// Will not be used for types needing extra serialization
-  /// Note: is_messagable also checks that T is not a pointer
   /// @return const ref to specified type
   template <typename T>
-  typename std::enable_if<is_messageable<T>::value && std::is_same<T, DataRef>::value == false, //
-                          T>::type const&
+  typename std::enable_if<is_messageable<T>::value && has_root_dictionary<T>::value == false &&
+                            std::is_same<T, DataRef>::value == false,
+                          std::unique_ptr<T const, Deleter<T const>>>::type
     get(char const* binding) const
   {
     // we need to check the serialization type, the cast makes only sense for
@@ -169,7 +169,10 @@ public:
     if (method != o2::header::gSerializationMethodNone) {
       throw std::runtime_error("Can not extract a plain object from serialized message");
     }
-    return *reinterpret_cast<T const *>(get<DataRef>(binding).payload);
+    auto const* ptr = reinterpret_cast<T const*>(ref.payload);
+    // return type with non-owning Deleter instance
+    std::unique_ptr<T const, Deleter<T const>> result(ptr, Deleter<T const>(false));
+    return std::move(result);
   }
 
   /// substitution for const char*
@@ -225,23 +228,19 @@ public:
     }
   }
 
-  /// substitution for pointer to non-messageable objects with ROOT dictionary
-  /// Template parameter is a pointer
+  /// substitution non-messageable objects with ROOT dictionary
   /// This supports the common case of retrieving a root object and getting pointer.
   /// Notice that this will return a copy of the actual contents of the buffer, because
   /// the buffer is actually serialised, for this reason we return a unique_ptr<T>.
   /// FIXME: does it make more sense to keep ownership of all the deserialised
   /// objects in a single place so that we can avoid duplicate deserializations?
   /// @return unique_ptr to deserialized content
-  template <class PtrT>
-  typename std::enable_if<                                                            //
-    std::is_pointer<PtrT>::value == true &&                                           //
-      has_root_dictionary<typename std::remove_pointer<PtrT>::type>::value == true && //
-      is_messageable<typename std::remove_pointer<PtrT>::type>::value == false,       //
-    std::unique_ptr<typename std::remove_pointer<PtrT>::type const>>::type            //
+  template <class T>
+  typename std::enable_if<has_root_dictionary<T>::value == true && is_messageable<T>::value == false &&
+                            is_container<T>::value == false,
+                          std::unique_ptr<T const>>::type
     get(char const* binding) const
   {
-    using T = typename std::remove_pointer<PtrT>::type;
     auto ref = this->get(binding);
     return std::move(DataRefUtils::as<T>(ref));
   }
@@ -263,19 +262,16 @@ public:
     return std::move(*(DataRefUtils::as<T>(ref).release()));
   }
 
-  /// substitution for pointer to messageable objects with ROOT dictionary
+  /// substitution for messageable objects with ROOT dictionary
   /// the operation depends on the transmitted serialization method
   /// @return unique_ptr to deserialized content
-  template <typename PtrT>
-  typename std::enable_if<std::is_pointer<PtrT>::value == true &&                                           //
-                            has_root_dictionary<typename std::remove_pointer<PtrT>::type>::value == true && //
-                            is_messageable<typename std::remove_pointer<PtrT>::type>::value == true,        //
-                          std::unique_ptr<typename std::remove_pointer<PtrT>::type const,
-                                          Deleter<typename std::remove_pointer<PtrT>::type const>>>::type
+  template <typename T>
+  typename std::enable_if<has_root_dictionary<T>::value == true && is_messageable<T>::value == true &&
+                            is_container<T>::value == false,
+                          std::unique_ptr<T const, Deleter<T const>>>::type
     get(char const* binding) const
   {
     using DataHeader = o2::header::DataHeader;
-    using T = typename std::remove_pointer<PtrT>::type;
 
     auto ref = this->get(binding);
     auto header = o2::header::get<const DataHeader*>(ref.header);
@@ -300,10 +296,9 @@ public:
   // be derived by type, the operation depends on the transmitted serialization method
   // FIXME: some of the substitutions can for sure be combined when the return types
   // will be unified in a later refactoring
-  // FIXME: request a pointer where you get a pointer
   template <typename T>
-  typename std::enable_if<is_messageable<T>::value == false && std::is_pointer<T>::value == false &&
-                            std::is_same<T, DataRef>::value == false && has_root_dictionary<T>::value == false,
+  typename std::enable_if<is_messageable<T>::value == false && has_root_dictionary<T>::value == false &&
+                            std::is_pointer<T>::value == false,
                           std::unique_ptr<T const, Deleter<T const>>>::type
     get(char const* binding) const
   {
@@ -324,6 +319,13 @@ public:
     } else {
       throw std::runtime_error("Attempt to extract object from message with unsupported serialization type");
     }
+  }
+
+  template <typename T>
+  typename std::enable_if<std::is_pointer<T>::value && !std::is_same<T, char const*>::value>::type //
+    get(char const* binding) const
+  {
+    static_assert(std::is_pointer<T>::value == true, "template argument must not be a pointer type");
   }
 
   size_t size() const {

--- a/Framework/Core/include/Framework/InputRecord.h
+++ b/Framework/Core/include/Framework/InputRecord.h
@@ -36,12 +36,39 @@ namespace framework
 
 struct InputSpec;
 
+/// @class InputRecord
+/// @brief The input API of the Data Processing Layer
 /// This class holds the inputs which  are being processed by the system while
 /// they are  being processed.  The user can  get an instance  for it  via the
 /// ProcessingContext and can use it to retrieve the inputs, either by name or
 /// by index.  A few utility  methods are  provided to automatically  cast the
 /// inputs to  known types. The user is also allowed to  override the `get`
 /// template and provide his own serialization mechanism.
+///
+/// The @ref get<T>(binding) method is implemeted for the following types:
+/// - (a) const char*
+/// - (b) std::string
+/// - (c) messageable type T
+/// - (d) pointer type T* for types with ROOT dictionary or messageable types
+/// - (e) std container of type T with ROOT dictionary
+/// - (f) DataRef holding header and payload information, this is also the default
+///       get method without template parameter
+///
+/// The return type of get<T>(binding) is:
+/// - (a) const char* to payload content
+/// - (b) std::string copy of the payload
+/// - (c) const ref for messageable types T, the payload content casted to the type
+/// - (d) object with pointer-like behavior (unique_ptr) if T* specified
+/// - (e) std::container object returned by std::move
+/// - (f) DataRef object returned by copy
+///
+/// Iterator functionality is implemented to iterate over the list of DataRef objects,
+/// including begin() and end() methods.
+/// <pre>
+///    for (auto const& ref : inputs) {
+///      // do something with DataRef object ref
+///    }
+/// </pre>
 class InputRecord {
 public:
   InputRecord(std::vector<InputRoute> const &inputs,
@@ -121,10 +148,11 @@ public:
                    static_cast<char const*>(mCache[pos*2+1]->GetData())};
   }
 
-  // Generic function to extract a messageable type by reference
-  // Cast content of payload bound by @a binding to known type.
-  // Will not be used for types needing extra serialization
-  // Note: is_messagable also checks that T is not a pointer
+  /// Generic function to extract a messageable type by reference
+  /// Cast content of payload bound by @a binding to known type.
+  /// Will not be used for types needing extra serialization
+  /// Note: is_messagable also checks that T is not a pointer
+  /// @return const ref to specified type
   template <typename T>
   typename std::enable_if<is_messageable<T>::value && std::is_same<T, DataRef>::value == false, //
                           T>::type const&
@@ -144,28 +172,34 @@ public:
     return *reinterpret_cast<T const *>(get<DataRef>(binding).payload);
   }
 
-  // If we ask for a char const *, we simply point to the payload. Notice this
-  // is meant for C-style strings. If you want to actually get hold of the buffer,
-  // use get<DataRef> (or simply get) as that will give you the size as well.
-  // FIXME: check that the string is null terminated.
+  /// substitution for const char*
+  /// If we ask for a char const *, we simply point to the payload. Notice this
+  /// is meant for C-style strings. If you want to actually get hold of the buffer,
+  /// use get<DataRef> (or simply get) as that will give you the size as well.
+  /// FIXME: check that the string is null terminated.
+  /// @return pointer to payload content
   template <typename T>
   typename std::enable_if<std::is_same<T, char const *>::value, T>::type
   get(char const *binding) const {
     return reinterpret_cast<char const *>(get<DataRef>(binding).payload);
   }
 
-  // If we ask for a string, we need to duplicate it because we do not want
-  // the buffer to be deleted when it goes out of scope.
-  // FIXME: check that the string is null terminated.
+  /// substitution for std::string
+  /// If we ask for a string, we need to duplicate it because we do not want
+  /// the buffer to be deleted when it goes out of scope.
+  /// FIXME: check that the string is null terminated.
+  /// @return std::string object
   template <typename T>
   typename std::enable_if<std::is_same<T, std::string>::value, T>::type
   get(char const *binding) const {
     return std::move(std::string(get<DataRef>(binding).payload));
   }
 
-  // DataRef is special. Since there is no point in storing one in a payload,
-  // what it actually does is to return the DataRef used to hold the 
-  // (header, payload) pair.
+  /// substitution for DataRef
+  /// DataRef is special. Since there is no point in storing one in a payload,
+  /// what it actually does is to return the DataRef used to hold the
+  /// (header, payload) pair.
+  /// @return DataRef object
   template <typename T = DataRef>
   typename std::enable_if<std::is_same<T, DataRef>::value, T>::type
   get(const char *binding) const {
@@ -176,9 +210,11 @@ public:
     }
   }
 
-  // DataRef is special. Since there is no point in storing one in a payload,
-  // what it actually does is to return the DataRef used to hold the 
-  // (header, payload) pair.
+  /// substitution for DataRef
+  /// DataRef is special. Since there is no point in storing one in a payload,
+  /// what it actually does is to return the DataRef used to hold the
+  /// (header, payload) pair.
+  /// @return DataRef object
   template <class T = DataRef>
   typename std::enable_if<std::is_same<T, DataRef>::value, T>::type
   get(std::string const &binding) const {
@@ -189,12 +225,14 @@ public:
     }
   }
 
-  // substitution for pointer to non-messageable objects with ROOT dictionary
-  // This supports the common case of retrieving a root object and getting pointer.
-  // Notice that this will return a copy of the actual contents of the buffer, because
-  // the buffer is actually serialised, for this reason we return a unique_ptr<T>.
-  // FIXME: does it make more sense to keep ownership of all the deserialised
-  // objects in a single place so that we can avoid duplicate deserializations?
+  /// substitution for pointer to non-messageable objects with ROOT dictionary
+  /// Template parameter is a pointer
+  /// This supports the common case of retrieving a root object and getting pointer.
+  /// Notice that this will return a copy of the actual contents of the buffer, because
+  /// the buffer is actually serialised, for this reason we return a unique_ptr<T>.
+  /// FIXME: does it make more sense to keep ownership of all the deserialised
+  /// objects in a single place so that we can avoid duplicate deserializations?
+  /// @return unique_ptr to deserialized content
   template <class PtrT>
   typename std::enable_if<                                                            //
     std::is_pointer<PtrT>::value == true &&                                           //
@@ -208,9 +246,10 @@ public:
     return std::move(DataRefUtils::as<T>(ref));
   }
 
-  // substitution for container of non-messageable objects with ROOT dictionary
-  // Notice that this will return a copy of the actual contents of the buffer, because
-  // the buffer is actually serialised. The extracted container is returned by std::move
+  /// substitution for container of non-messageable objects with ROOT dictionary
+  /// Notice that this will return a copy of the actual contents of the buffer, because
+  /// the buffer is actually serialised. The extracted container is returned by std::move
+  /// @return std container object
   template <class T>
   typename std::enable_if<is_container<T>::value == true &&          //
                             has_root_dictionary<T>::value == true && //
@@ -224,8 +263,9 @@ public:
     return std::move(*(DataRefUtils::as<T>(ref).release()));
   }
 
-  // substitution for pointer to messageable objects with ROOT dictionary
-  // the operation depends on the transmitted serialization method
+  /// substitution for pointer to messageable objects with ROOT dictionary
+  /// the operation depends on the transmitted serialization method
+  /// @return unique_ptr to deserialized content
   template <typename PtrT>
   typename std::enable_if<std::is_pointer<PtrT>::value == true &&                                           //
                             has_root_dictionary<typename std::remove_pointer<PtrT>::type>::value == true && //

--- a/Framework/Core/test/test_DataAllocator.cxx
+++ b/Framework/Core/test/test_DataAllocator.cxx
@@ -95,33 +95,38 @@ DataProcessorSpec getSinkSpec()
       auto dh = o2::header::get<const DataHeader*>(input.header);
       LOG(INFO) << dh->dataOrigin.str << " " << dh->dataDescription.str << " " << dh->payloadSize;
     }
+    // plain, unserialized object in input1 channel
     auto object1 = pc.inputs().get<o2::test::TriviallyCopyable>("input1");
+    ASSERT_ERROR(object1 != nullptr);
     ASSERT_ERROR(*object1 == o2::test::TriviallyCopyable(42, 23, 0xdead));
 
+    // ROOT-serialized messageable object in input2 channel
     auto object2 = pc.inputs().get<o2::test::TriviallyCopyable>("input2");
+    ASSERT_ERROR(object2 != nullptr);
     ASSERT_ERROR(*object2 == o2::test::TriviallyCopyable(42, 23, 0xdead));
 
+    // ROOT-serialized, non-messageable object in input3 channel
     auto object3 = pc.inputs().get<o2::test::Polymorphic>("input3");
     ASSERT_ERROR(object3 != nullptr);
-    ASSERT_ERROR(*(object3.get()) == o2::test::Polymorphic(0xbeef));
+    ASSERT_ERROR(*object3 == o2::test::Polymorphic(0xbeef));
 
+    // container of objects
     auto object4 = pc.inputs().get<std::vector<o2::test::Polymorphic>>("input4");
-    ASSERT_ERROR(object4 != nullptr);
-    ASSERT_ERROR(object4->size() == 2);
-    ASSERT_ERROR((*object4.get())[0] == o2::test::Polymorphic(0xaffe));
-    ASSERT_ERROR((*object4.get())[1] == o2::test::Polymorphic(0xd00f));
+    ASSERT_ERROR(object4.size() == 2);
+    ASSERT_ERROR(object4[0] == o2::test::Polymorphic(0xaffe));
+    ASSERT_ERROR(object4[1] == o2::test::Polymorphic(0xd00f));
 
+    // container of objects
     auto object5 = pc.inputs().get<std::vector<o2::test::Polymorphic>>("input5");
-    ASSERT_ERROR(object5 != nullptr);
-    ASSERT_ERROR(object5->size() == 2);
-    ASSERT_ERROR((*object5.get())[0] == o2::test::Polymorphic(0xaffe));
-    ASSERT_ERROR((*object5.get())[1] == o2::test::Polymorphic(0xd00f));
+    ASSERT_ERROR(object5.size() == 2);
+    ASSERT_ERROR(object5[0] == o2::test::Polymorphic(0xaffe));
+    ASSERT_ERROR(object5[1] == o2::test::Polymorphic(0xd00f));
 
+    // container of objects
     auto object6 = pc.inputs().get<std::vector<o2::test::Polymorphic>>("input6");
-    ASSERT_ERROR(object6 != nullptr);
-    ASSERT_ERROR(object6->size() == 2);
-    ASSERT_ERROR((*object6.get())[0] == o2::test::Polymorphic(0xaffe));
-    ASSERT_ERROR((*object6.get())[1] == o2::test::Polymorphic(0xd00f));
+    ASSERT_ERROR(object6.size() == 2);
+    ASSERT_ERROR(object6[0] == o2::test::Polymorphic(0xaffe));
+    ASSERT_ERROR(object6[1] == o2::test::Polymorphic(0xd00f));
 
     pc.services().get<ControlService>().readyToQuit(true);
   };

--- a/Framework/Core/test/test_DataAllocator.cxx
+++ b/Framework/Core/test/test_DataAllocator.cxx
@@ -128,6 +128,11 @@ DataProcessorSpec getSinkSpec()
     ASSERT_ERROR(object6[0] == o2::test::Polymorphic(0xaffe));
     ASSERT_ERROR(object6[1] == o2::test::Polymorphic(0xd00f));
 
+    // checking retrieving buffer as raw char*, and checking content by cast
+    auto rawchar = pc.inputs().get<const char*>("input1");
+    const auto& data1 = *reinterpret_cast<const o2::test::TriviallyCopyable*>(rawchar);
+    ASSERT_ERROR(data1 == o2::test::TriviallyCopyable(42, 23, 0xdead));
+
     pc.services().get<ControlService>().readyToQuit(true);
   };
 

--- a/Framework/Core/test/test_InputRecord.cxx
+++ b/Framework/Core/test/test_InputRecord.cxx
@@ -79,10 +79,12 @@ BOOST_AUTO_TEST_CASE(TestInputRecord) {
   dh1.dataDescription = "CLUSTERS";
   dh1.dataOrigin = "TPC";
   dh1.subSpecification = 0;
+  dh1.payloadSerializationMethod = o2::header::gSerializationMethodNone;
   DataHeader dh2;
   dh2.dataDescription = "CLUSTERS";
   dh2.dataOrigin = "ITS";
   dh2.subSpecification = 0;
+  dh2.payloadSerializationMethod = o2::header::gSerializationMethodNone;
   createMessage(dh1, 1);
   createMessage(dh2, 2);
   InputRecord registry(schema, inputs);

--- a/Framework/Core/test/test_InputRecord.cxx
+++ b/Framework/Core/test/test_InputRecord.cxx
@@ -112,9 +112,9 @@ BOOST_AUTO_TEST_CASE(TestInputRecord) {
   //
   // *static_cast<int const *>(registry.get("x").payload);
   //
-  BOOST_CHECK_EQUAL(registry.get<int>("x"),1);
-  BOOST_CHECK_EQUAL(registry.get<int>("y"),2);
+  BOOST_CHECK_EQUAL(*registry.get<int>("x"), 1);
+  BOOST_CHECK_EQUAL(*registry.get<int>("y"), 2);
   // A few more time just to make sure we are not stateful..
-  BOOST_CHECK_EQUAL(registry.get<int>("x"),1);
-  BOOST_CHECK_EQUAL(registry.get<int>("x"),1);
+  BOOST_CHECK_EQUAL(*registry.get<int>("x"), 1);
+  BOOST_CHECK_EQUAL(*registry.get<int>("x"), 1);
 }

--- a/Framework/Core/test/test_RootTreeReader.cxx
+++ b/Framework/Core/test/test_RootTreeReader.cxx
@@ -89,11 +89,11 @@ DataProcessorSpec getSinkSpec()
     }
     auto data = pc.inputs().get<std::vector<o2::test::Polymorphic>>("input");
 
-    LOG(INFO) << "count: " << counter << "  data elements:" << data->size();
-    ASSERT_ERROR(counter + 1 == data->size());
-    for (int idx = 0; idx < data->size(); idx++) {
-      LOG(INFO) << (*data)[idx].get();
-      ASSERT_ERROR((*data)[idx].get() == 10 * counter + idx);
+    LOG(INFO) << "count: " << counter << "  data elements:" << data.size();
+    ASSERT_ERROR(counter + 1 == data.size());
+    for (int idx = 0; idx < data.size(); idx++) {
+      LOG(INFO) << data[idx].get();
+      ASSERT_ERROR(data[idx].get() == 10 * counter + idx);
     }
     if (++counter >= kTreeSize) {
       pc.services().get<ControlService>().readyToQuit(true);

--- a/Framework/TestWorkflows/test/test_MakeDPLObjects.cxx
+++ b/Framework/TestWorkflows/test/test_MakeDPLObjects.cxx
@@ -81,7 +81,8 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
           // A new message with a TH1F inside
           auto h = ctx.inputs().get<TH1F>("histo");
           // A new message with 1 XYZ instance in it
-          XYZ const &x = ctx.inputs().get<XYZ>("point");
+          auto resx = ctx.inputs().get<XYZ>("point");
+          XYZ const& x = *resx;
           // A new message with a gsl::span<XYZ> with 1000 items
           auto ref1 = ctx.inputs().get("points");
           gsl::span<XYZ> c = DataRefUtils::as<XYZ>(ref1);


### PR DESCRIPTION
This reflects the outcome of the discussion following PR #973. The result for
`get<T>` (`T` not being a pointer) is either
- a smart pointer for type `T`, or
- an object providing iterator and begin/end methods to access elements

Special cases like `get<const char*>` and `get<std::string>` are preserved.

The smart-pointer case is fully covered by `unique_ptr` with the custom deleter
already available. We can later consider to factor out to separate file.

As for containers, currently only serialized std containers of types with
ROOT dictionary are supported. A general `container_ref` type implementation is
in progress.

I also want to keep the other approach in a separate commit for the record.