### PR TITLE
Fixing build problem with libSimSetup.so

### DIFF
--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -1783,8 +1783,6 @@ o2_define_bucket(
     simulation_setup_bucket
 
     DEPENDENCIES
-    pythia6 # this is needed by Geant3
-    EGPythia6 # this is needed by Geant4 (TPythia6Decayer)
     ${Geant3_LIBRARIES}
     ${Geant4_LIBRARIES}
     ${Geant4VMC_LIBRARIES}
@@ -1792,6 +1790,8 @@ o2_define_bucket(
     fairroot_geom
     SimulationDataFormat
     DetectorsPassive
+    pythia6 # this is needed by Geant3 and EGPythia6
+    EGPythia6 # this is needed by Geant4 (TPythia6Decayer)
 
     INCLUDE_DIRECTORIES
     ${Geant4VMC_INCLUDE_DIRS}


### PR DESCRIPTION
On ubuntu 16.04 gcc (Ubuntu 6.4.0-17ubuntu1~16.04) 6.4.0 20180424
there has been a problem after commits 9361b501d3c6e89710bff41d57a5527166eb1a28 and ed822260d877af5b079172420ec840ed92bc3893, symbols from libpythia6.so could not be found in `EGPythia6`.

```
sw/ubuntu1604_x86-64/ROOT/v6-12-04-1/lib/libEGPythia6.so: undefined reference to `pyinit_'
sw/ubuntu1604_x86-64/ROOT/v6-12-04-1/lib/libEGPythia6.so: undefined reference to `py1ent_'
sw/ubuntu1604_x86-64/GEANT3/v2-5-1/lib/libgeant321.so: undefined reference to `pyeevt_'
collect2: error: ld returned 1 exit status
```

It turned out that `libEGPythia6` is in the list of dependencies of `libSimSetup`
but not `libpythia6` despite both are specified as dependencies. Moving the
two lines further down makes also `libpythia6` appear as dependency.

This commit thus fixes a symptom rather than the cause. There seems to be an
issue in the cmake setup (bucket definition or library setup)