### PR TITLE
Hide header::Stack internals in preparation of future updates

### DIFF
--- a/Algorithm/test/headerstack.cxx
+++ b/Algorithm/test/headerstack.cxx
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE(test_headerstack)
   o2::header::Stack stack(dh, nh);
 
   // check that the call without any other arguments is compiling
-  o2::algorithm::dispatchHeaderStackCallback(stack.buffer.get(), stack.bufferSize);
+  o2::algorithm::dispatchHeaderStackCallback(stack.data(), stack.size());
 
   // lambda functor given as argument for dispatchHeaderStackCallback
   auto checkDataHeader = [&dh] (const auto & header) {
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE(test_headerstack)
   };
 
   // check extraction of headers via callbacks
-  o2::algorithm::dispatchHeaderStackCallback(stack.buffer.get(), stack.bufferSize,
+  o2::algorithm::dispatchHeaderStackCallback(stack.data(), stack.size(),
                                              o2::header::DataHeader(),
                                              checkDataHeader,
                                              Name8Header(),
@@ -68,18 +68,18 @@ BOOST_AUTO_TEST_CASE(test_headerstack)
                                              );
 
   // check extraction of only one header via callback
-  o2::algorithm::dispatchHeaderStackCallback(stack.buffer.get(), stack.bufferSize,
+  o2::algorithm::dispatchHeaderStackCallback(stack.data(), stack.size(),
                                              Name8Header(),
                                              checkNameHeader
                                              );
 
   // check that the call without any other arguments is compiling
-  o2::algorithm::parseHeaderStack(stack.buffer.get(), stack.bufferSize);
+  o2::algorithm::parseHeaderStack(stack.data(), stack.size());
 
   // check extraction of headers via object references
   o2::header::DataHeader targetDataHeader;
   Name8Header targetNameHeader;
-  o2::algorithm::parseHeaderStack(stack.buffer.get(), stack.bufferSize,
+  o2::algorithm::parseHeaderStack(stack.data(), stack.size(),
                                   targetDataHeader,
                                   targetNameHeader
                                   );

--- a/DataFormats/Headers/test/testDataHeader.cxx
+++ b/DataFormats/Headers/test/testDataHeader.cxx
@@ -166,10 +166,10 @@ namespace o2 {
       Stack s1{ DataHeader{ gDataDescriptionInvalid, gDataOriginInvalid, DataHeader::SubSpecificationType{ 0 }, 0 },
                 NameHeader<9>{ "somename" } };
 
-      const DataHeader* h1 = get<DataHeader*>(s1.buffer.get());
+      const DataHeader* h1 = get<DataHeader*>(s1.data());
       BOOST_CHECK(h1 != nullptr);
       BOOST_CHECK(*h1 == dh1);
-      const NameHeader<0>* h2 = get<NameHeader<0>*>(s1.buffer.get());
+      const NameHeader<0>* h2 = get<NameHeader<0>*>(s1.data());
       BOOST_CHECK(h2 != nullptr);
       BOOST_CHECK(0 == std::strcmp(h2->getName(), "somename"));
       BOOST_CHECK(h2->description == NameHeader<0>::sHeaderType);

--- a/Framework/Core/src/DataAllocator.cxx
+++ b/Framework/Core/src/DataAllocator.cxx
@@ -64,11 +64,11 @@ DataAllocator::newChunk(const Output& spec, size_t size) {
   //we have to move the incoming data
   o2::header::Stack headerStack{dh, dph};
   FairMQMessagePtr headerMessage = mDevice->NewMessageFor(channel, 0,
-                                                          headerStack.buffer.get(),
-                                                          headerStack.bufferSize,
+                                                          headerStack.data(),
+                                                          headerStack.size(),
                                                           &o2::header::Stack::freefn,
-                                                          headerStack.buffer.get());
-  headerStack.buffer.release();
+                                                          headerStack.data());
+  headerStack.release();
   FairMQMessagePtr payloadMessage = mDevice->NewMessageFor(channel, 0, size);
   auto dataPtr = payloadMessage->GetData();
   auto dataSize = payloadMessage->GetSize();
@@ -99,11 +99,11 @@ DataAllocator::adoptChunk(const Output& spec, char *buffer, size_t size, fairmq_
   //we have to move the incoming data
   o2::header::Stack headerStack{dh, dph};
   FairMQMessagePtr headerMessage = mDevice->NewMessageFor(channel, 0,
-                                                          headerStack.buffer.get(),
-                                                          headerStack.bufferSize,
+                                                          headerStack.data(),
+                                                          headerStack.size(),
                                                           &o2::header::Stack::freefn,
-                                                          headerStack.buffer.get());
-  headerStack.buffer.release();
+                                                          headerStack.data());
+  headerStack.release();
 
   FairMQParts parts;
 
@@ -135,11 +135,11 @@ DataAllocator::headerMessageFromOutput(Output const &spec,
   //we have to move the incoming data
   o2::header::Stack headerStack{dh, dph};
   FairMQMessagePtr headerMessage = mDevice->NewMessageFor(channel, 0,
-                                                          headerStack.buffer.get(),
-                                                          headerStack.bufferSize,
+                                                          headerStack.data(),
+                                                          headerStack.size(),
                                                           &o2::header::Stack::freefn,
-                                                          headerStack.buffer.get());
-  headerStack.buffer.release();
+                                                          headerStack.data());
+  headerStack.release();
   return std::move(headerMessage);
 }
 

--- a/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
+++ b/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
@@ -38,11 +38,11 @@ void broadcastMessage(FairMQDevice &device, o2::header::Stack &&headerStack, Fai
     // FIXME: this assumes there is only one output from here... This should
     //        really do the matchmaking between inputs and output channels.
     FairMQMessagePtr headerMessage = device.NewMessageFor(channel, index,
-                                                          headerStack.buffer.get(),
-                                                          headerStack.bufferSize,
+                                                          headerStack.data(),
+                                                          headerStack.size(),
                                                           &o2::header::Stack::freefn,
-                                                          headerStack.buffer.get());
-    headerStack.buffer.release();
+                                                          headerStack.data());
+    headerStack.release();
     FairMQParts out;
     out.AddPart(std::move(headerMessage));
     out.AddPart(std::move(payloadMessage));

--- a/Utilities/O2Device/include/O2Device/O2Device.h
+++ b/Utilities/O2Device/include/O2Device/O2Device.h
@@ -74,11 +74,11 @@ public:
     o2::header::Stack headerStack{std::move(incomingStack)};
     FairMQMessagePtr dataMessage{std::move(incomingDataMessage)};
 
-    FairMQMessagePtr headerMessage = NewMessage(headerStack.buffer.get(),
-                                                headerStack.bufferSize,
+    FairMQMessagePtr headerMessage = NewMessage(headerStack.data(),
+                                                headerStack.size(),
                                                 &o2::header::Stack::freefn,
-                                                headerStack.buffer.get());
-    headerStack.buffer.release();
+                                                headerStack.data());
+    headerStack.release();
 
     parts.AddPart(std::move(headerMessage));
     parts.AddPart(std::move(dataMessage));


### PR DESCRIPTION
I think in the end it was not such a great idea to expose the internals, in the future maybe Stack should become a class instead of struct.