### PR TITLE
Supporting header stack in the DPL output API

### DIFF
--- a/DataFormats/Headers/include/Headers/DataHeader.h
+++ b/DataFormats/Headers/include/Headers/DataHeader.h
@@ -524,12 +524,33 @@ private:
   static byte* inject(byte* here, const T& h, const Args... args) noexcept {
     auto alsohere = inject(here, h);
     // the type might be a stack itself, loop through headers and set the flag in the last one
-    BaseHeader* next = BaseHeader::get(here);
-    while (next->flagsNextHeader) {
-      next = next->next();
+    if (h.size() > 0) {
+      BaseHeader* next = BaseHeader::get(here);
+      while (next->flagsNextHeader) {
+        next = next->next();
+      }
+      next->flagsNextHeader = hasNonEmptyArg(args...);
     }
-    next->flagsNextHeader = true;
     return inject(alsohere, args...);
+  }
+
+  // helper function to check if there is at least one non-empty header/stack in the argument pack
+  template <typename T, typename... Args>
+  static bool hasNonEmptyArg(const T& h, const Args&... args) noexcept
+  {
+    if (h.size() > 0) {
+      return true;
+    }
+    return hasNonEmptyArg(args...);
+  }
+
+  template <typename T>
+  static bool hasNonEmptyArg(const T& h) noexcept
+  {
+    if (h.size() > 0) {
+      return true;
+    }
+    return false;
   }
 };
 

--- a/Detectors/TPC/workflow/src/ClusterReaderSpec.cxx
+++ b/Detectors/TPC/workflow/src/ClusterReaderSpec.cxx
@@ -38,15 +38,14 @@ DataProcessorSpec getClusterReaderSpec()
     // set up the tree interface
     // TODO: parallelism on sectors needs to be implemented as selector in the reader
     constexpr auto persistency = Lifetime::Timeframe;
-    using TreeReader = o2::framework::RootTreeReader<Output>;
-    auto reader = std::make_shared<TreeReader>(treename.c_str(), // tree name
-                                               nofEvents,        // number of entries to publish
-                                               filename.c_str(), // input file name
-                                               Output{ "TPC", "CLUSTERSIM", 0, persistency },
-                                               clbrName.c_str(), // name of cluster branch
-                                               Output{ "TPC", "CLUSTERMCLBL", 0, persistency },
-                                               mcbrName.c_str() // name of mc label branch
-                                               );
+    auto reader = std::make_shared<RootTreeReader>(treename.c_str(), // tree name
+                                                   nofEvents,        // number of entries to publish
+                                                   filename.c_str(), // input file name
+                                                   Output{ "TPC", "CLUSTERSIM", 0, persistency },
+                                                   clbrName.c_str(), // name of cluster branch
+                                                   Output{ "TPC", "CLUSTERMCLBL", 0, persistency },
+                                                   mcbrName.c_str() // name of mc label branch
+                                                   );
 
     // set up the processing function
     // using by-copy capture of the worker instance shared pointer

--- a/Detectors/TPC/workflow/src/DigitReaderSpec.cxx
+++ b/Detectors/TPC/workflow/src/DigitReaderSpec.cxx
@@ -40,15 +40,14 @@ DataProcessorSpec getDigitReaderSpec()
     // set up the tree interface
     // TODO: parallelism on sectors needs to be implemented as selector in the reader
     constexpr auto persistency = Lifetime::Timeframe;
-    using TreeReader = o2::framework::RootTreeReader<Output>;
-    auto reader = std::make_shared<TreeReader>(treename.c_str(), // tree name
-                                               nofEvents,        // number of entries to publish
-                                               filename.c_str(), // input file name
-                                               Output{ gDataOriginTPC, "DIGIT", 0, persistency },
-                                               clbrName.c_str(), // name of digit branch
-                                               Output{ gDataOriginTPC, "DIGITMCLBL", 0, persistency },
-                                               mcbrName.c_str() // name of mc label branch
-                                               );
+    auto reader = std::make_shared<RootTreeReader>(treename.c_str(), // tree name
+                                                   nofEvents,        // number of entries to publish
+                                                   filename.c_str(), // input file name
+                                                   Output{ gDataOriginTPC, "DIGIT", 0, persistency },
+                                                   clbrName.c_str(), // name of digit branch
+                                                   Output{ gDataOriginTPC, "DIGITMCLBL", 0, persistency },
+                                                   mcbrName.c_str() // name of mc label branch
+                                                   );
 
     // set up the processing function
     // using by-copy capture of the worker instance shared pointer

--- a/Framework/Core/include/Framework/DataRefUtils.h
+++ b/Framework/Core/include/Framework/DataRefUtils.h
@@ -155,11 +155,20 @@ struct DataRefUtils {
   static unsigned getPayloadSize(const DataRef& ref)
   {
     using DataHeader = o2::header::DataHeader;
-    auto header = o2::header::get<const DataHeader*>(ref.header);
+    auto* header = o2::header::get<const DataHeader*>(ref.header);
     if (!header) {
       return 0;
     }
     return header->payloadSize;
+  }
+
+  template <typename T>
+  static auto getHeader(const DataRef& ref)
+  {
+    using HeaderT = typename std::remove_pointer<T>::type;
+    static_assert(std::is_pointer<T>::value && std::is_base_of<o2::header::BaseHeader, HeaderT>::value,
+                  "pointer to BaseHeader-derived type required");
+    return o2::header::get<T>(ref.header);
   }
 };
 

--- a/Framework/Core/include/Framework/Output.h
+++ b/Framework/Core/include/Framework/Output.h
@@ -24,6 +24,34 @@ struct Output {
   header::DataDescription description;
   header::DataHeader::SubSpecificationType subSpec = 0;
   enum Lifetime lifetime = Lifetime::Timeframe;
+  header::Stack metaHeader = {};
+
+  Output(header::DataOrigin o, header::DataDescription d) : origin(o), description(d) {}
+
+  Output(header::DataOrigin o, header::DataDescription d, header::DataHeader::SubSpecificationType s)
+    : origin(o), description(d), subSpec(s)
+  {
+  }
+
+  Output(header::DataOrigin o, header::DataDescription d, header::DataHeader::SubSpecificationType s, Lifetime l)
+    : origin(o), description(d), subSpec(s), lifetime(l)
+  {
+  }
+
+  Output(header::DataOrigin o, header::DataDescription d, header::DataHeader::SubSpecificationType s, Lifetime l,
+         header::Stack&& stack)
+    : origin(o), description(d), subSpec(s), lifetime(l), metaHeader(std::move(stack))
+  {
+  }
+
+  Output(const Output&& rhs)
+    : origin(rhs.origin),
+      description(rhs.description),
+      subSpec(rhs.subSpec),
+      lifetime(rhs.lifetime),
+      metaHeader(std::move(rhs.metaHeader))
+  {
+  }
 
   bool operator==(const Output& that)
   {

--- a/Framework/Core/include/Framework/Output.h
+++ b/Framework/Core/include/Framework/Output.h
@@ -19,6 +19,11 @@ namespace framework
 {
 
 /// A concrete description of the output to be created
+///
+/// Note that header::Stack forbids copy constructor and so it is for Output.
+/// As a consequence it can not be used in standard containers. This is however
+/// not a limitation which is expected to cause problems because Output is mostly
+/// used as rvalue in specifying output route.
 struct Output {
   header::DataOrigin origin;
   header::DataDescription description;

--- a/Framework/Core/include/Framework/OutputRef.h
+++ b/Framework/Core/include/Framework/OutputRef.h
@@ -20,9 +20,23 @@ namespace framework
 {
 
 /// A reference to an output spec
+///
+/// OutputRef descriptors are expected to be passed as rvalue, i.e. a temporary object in the
+/// function call. This is due to the fact that the header stack has no ordinary copy
+/// constructor but only a move constructor
 struct OutputRef {
   std::string label;
   header::DataHeader::SubSpecificationType subSpec;
+  header::Stack headerStack = {};
+
+  OutputRef(std::string&& l, header::DataHeader::SubSpecificationType s = 0) : label(std::move(l)), subSpec(s) {}
+
+  OutputRef(const std::string& l, header::DataHeader::SubSpecificationType s = 0) : label(l), subSpec(s) {}
+
+  OutputRef(std::string&& l, header::DataHeader::SubSpecificationType s, o2::header::Stack&& stack)
+    : label(std::move(l)), subSpec(s), headerStack(std::move(stack))
+  {
+  }
 };
 
 } // namespace framework

--- a/Framework/Core/src/DataAllocator.cxx
+++ b/Framework/Core/src/DataAllocator.cxx
@@ -60,22 +60,10 @@ DataChunk
 DataAllocator::newChunk(const Output& spec, size_t size) {
   std::string channel = matchDataHeader(spec, mContext->timeslice());
 
-  DataHeader dh;
-  dh.dataOrigin = spec.origin;
-  dh.dataDescription = spec.description;
-  dh.subSpecification = spec.subSpec;
-  dh.payloadSize = size;
-  dh.payloadSerializationMethod = o2::header::gSerializationMethodNone;
-
-  DataProcessingHeader dph{mContext->timeslice(), 1};
-  //we have to move the incoming data
-  o2::header::Stack headerStack{dh, dph};
-  FairMQMessagePtr headerMessage = mDevice->NewMessageFor(channel, 0,
-                                                          headerStack.data(),
-                                                          headerStack.size(),
-                                                          &o2::header::Stack::freefn,
-                                                          headerStack.data());
-  headerStack.release();
+  FairMQMessagePtr headerMessage = headerMessageFromOutput(spec, channel,                        //
+                                                           o2::header::gSerializationMethodNone, //
+                                                           size                                  //
+                                                           );
   FairMQMessagePtr payloadMessage = mDevice->NewMessageFor(channel, 0, size);
   auto dataPtr = payloadMessage->GetData();
   auto dataSize = payloadMessage->GetSize();
@@ -95,22 +83,10 @@ DataAllocator::adoptChunk(const Output& spec, char *buffer, size_t size, fairmq_
   // queue to be sent at the end of the processing
   std::string channel = matchDataHeader(spec, mContext->timeslice());
 
-  DataHeader dh;
-  dh.dataOrigin = spec.origin;
-  dh.dataDescription = spec.description;
-  dh.subSpecification = spec.subSpec;
-  dh.payloadSize = size;
-  dh.payloadSerializationMethod = o2::header::gSerializationMethodNone;
-
-  DataProcessingHeader dph{mContext->timeslice(), 1};
-  //we have to move the incoming data
-  o2::header::Stack headerStack{dh, dph};
-  FairMQMessagePtr headerMessage = mDevice->NewMessageFor(channel, 0,
-                                                          headerStack.data(),
-                                                          headerStack.size(),
-                                                          &o2::header::Stack::freefn,
-                                                          headerStack.data());
-  headerStack.release();
+  FairMQMessagePtr headerMessage = headerMessageFromOutput(spec, channel,                        //
+                                                           o2::header::gSerializationMethodNone, //
+                                                           size                                  //
+                                                           );
 
   FairMQParts parts;
 
@@ -125,22 +101,21 @@ DataAllocator::adoptChunk(const Output& spec, char *buffer, size_t size, fairmq_
   return DataChunk{reinterpret_cast<char *>(dataPtr), dataSize};
 }
 
-FairMQMessagePtr
-DataAllocator::headerMessageFromOutput(Output const &spec,
-                                       std::string const &channel,
-                                       o2::header::SerializationMethod method) {
+FairMQMessagePtr DataAllocator::headerMessageFromOutput(Output const& spec,                     //
+                                                        std::string const& channel,             //
+                                                        o2::header::SerializationMethod method, //
+                                                        size_t payloadSize)                     //
+{
   DataHeader dh;
   dh.dataOrigin = spec.origin;
   dh.dataDescription = spec.description;
   dh.subSpecification = spec.subSpec;
-  // the correct payload size is st later when sending the
-  // RootObjectContext, see DataProcessor::doSend
-  dh.payloadSize = 0;
+  dh.payloadSize = payloadSize;
   dh.payloadSerializationMethod = method;
 
   DataProcessingHeader dph{mContext->timeslice(), 1};
   //we have to move the incoming data
-  o2::header::Stack headerStack{dh, dph};
+  o2::header::Stack headerStack{ dh, dph, spec.metaHeader };
   FairMQMessagePtr headerMessage = mDevice->NewMessageFor(channel, 0,
                                                           headerStack.data(),
                                                           headerStack.size(),
@@ -150,31 +125,33 @@ DataAllocator::headerMessageFromOutput(Output const &spec,
   return std::move(headerMessage);
 }
 
-void
-DataAllocator::addPartToContext(FairMQMessagePtr&& payloadMessage,
-                                const Output &spec,
-                                o2::header::SerializationMethod serializationMethod)
+void DataAllocator::addPartToContext(FairMQMessagePtr&& payloadMessage, const Output& spec,
+                                     o2::header::SerializationMethod serializationMethod)
 {
-    std::string channel = matchDataHeader(spec, mRootContext->timeslice());
-    auto headerMessage = headerMessageFromOutput(spec, channel, serializationMethod);
+  std::string channel = matchDataHeader(spec, mRootContext->timeslice());
+  // the correct payload size is st later when sending the
+  // RootObjectContext, see DataProcessor::doSend
+  auto headerMessage = headerMessageFromOutput(spec, channel, serializationMethod, 0);
 
-    FairMQParts parts;
+  FairMQParts parts;
 
-    // FIXME: this is kind of ugly, we know that we can change the content of the
-    // header message because we have just created it, but the API declares it const
-    const DataHeader* cdh = o2::header::get<DataHeader*>(headerMessage->GetData());
-    DataHeader *dh = const_cast<DataHeader *>(cdh);
-    dh->payloadSize = payloadMessage->GetSize();
-    parts.AddPart(std::move(headerMessage));
-    parts.AddPart(std::move(payloadMessage));
-    mContext->addPart(std::move(parts), channel);
+  // FIXME: this is kind of ugly, we know that we can change the content of the
+  // header message because we have just created it, but the API declares it const
+  const DataHeader* cdh = o2::header::get<DataHeader*>(headerMessage->GetData());
+  DataHeader* dh = const_cast<DataHeader*>(cdh);
+  dh->payloadSize = payloadMessage->GetSize();
+  parts.AddPart(std::move(headerMessage));
+  parts.AddPart(std::move(payloadMessage));
+  mContext->addPart(std::move(parts), channel);
 }
 
-void
-DataAllocator::adopt(const Output &spec, TObject*ptr) {
+void DataAllocator::adopt(const Output& spec, TObject* ptr)
+{
   std::unique_ptr<TObject> payload(ptr);
   std::string channel = matchDataHeader(spec, mRootContext->timeslice());
-  auto header = headerMessageFromOutput(spec, channel, o2::header::gSerializationMethodROOT);
+  // the correct payload size is set later when sending the
+  // RootObjectContext, see DataProcessor::doSend
+  auto header = headerMessageFromOutput(spec, channel, o2::header::gSerializationMethodROOT, 0);
   mRootContext->addObject(std::move(header), std::move(payload), channel);
   assert(payload.get() == nullptr);
 }

--- a/Framework/Utils/test/test_RootTreeReader.cxx
+++ b/Framework/Utils/test/test_RootTreeReader.cxx
@@ -60,12 +60,11 @@ DataProcessorSpec getSourceSpec()
     }
 
     constexpr auto persistency = Lifetime::Transient;
-    using TreeReader = o2::framework::RootTreeReader<Output>;
-    auto reader = std::make_shared<TreeReader>("testtree",       // tree name
-                                               fileName.c_str(), // input file name
-                                               Output{ "TST", "ARRAYOFDATA", 0, persistency },
-                                               "dataarray" // name of cluster branch
-                                               );
+    auto reader = std::make_shared<RootTreeReader>("testtree",       // tree name
+                                                   fileName.c_str(), // input file name
+                                                   Output{ "TST", "ARRAYOFDATA", 0, persistency },
+                                                   "dataarray" // name of cluster branch
+                                                   );
 
     auto processingFct = [reader](ProcessingContext& pc) { (++(*reader))(pc); };
 


### PR DESCRIPTION
Supporting header stack in the DPL output API

- Introducing optional header stack parameter to Output description
- Adding helper method to access headers from the header stack at DPL input
- removing code duplication


Closes #950 