### PR TITLE
Introduce global workflow options

### DIFF
--- a/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
+++ b/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
@@ -50,9 +50,9 @@ using namespace o2::framework;
 /// - add propagation of MC information
 /// - add writing of the CA Tracker output to ROOT file
 /// This function is required to be implemented to define the workflow specifications
-void defineDataProcessing(WorkflowSpec& specs)
+WorkflowSpec defineDataProcessing(ConfigContext const&)
 {
-  specs.clear();
+  WorkflowSpec specs;
 
   // choose whether to start from the digits or from the clusters
   // these are just temporary switches
@@ -113,4 +113,5 @@ void defineDataProcessing(WorkflowSpec& specs)
                                             { "outfile", VariantType::String, { "Name of the output file" } },
                                           } });
   }
+  return specs;
 }

--- a/Framework/Core/README.md
+++ b/Framework/Core/README.md
@@ -70,19 +70,21 @@ and given these premises it actually guarantees:
 The description of  the computation in such the Data  Processing Layer is done
 via instances  of the [`DataProcessorSpec`][DataProcessorSpec]  class, grouped
 in a  so called `WorkflowSpec` instance.  In order to provide  a description a
-computation to  be run, the user  must implement a callback  which modifies an
-empty `WorkflowSpec` instance provided by the system. E.g.:
+computation to  be run,  the user  must implement a  callback which  return an
+filled `WorkflowSpec`. E.g.:
 
 ```cpp
 #include "Framework/Utils/runDataProcessing.h"
 
-void defineDataProcessing(WorkflowSpec &workflow) {
-  auto spec = DataProcessorSpec{
-    ...
+WorkflowSpec defineDataProcessing(ConfigContext &context) {
+  return WorkflowSpec {
+    DataProcessorSpec{
+      ...
+    },
+    DataProcessorSpec{
+    }
   };
-  // Fill a DataProcessingSpec "spec"
-  workflow.push_back(spec);
-}
+};
 ```
 
 See   next    section,   for    a   more    detailed   description    of   the
@@ -94,6 +96,9 @@ to form a so called driver executable which if run will:
   (using 1-1 correspondence, in the current implementation).
 - Instanciate and start all the devices resulted from the previous step.
 - (Optionally) start a GUI which allows to monitor the running of the system.
+
+The ConfigContext object being passed to the function contains a set of user
+provided options to customise the creation of the workflow.
 
 [DataProcessorSpec]: https://github.com/AliceO2Group/AliceO2/blob/dev/Framework/Core/include/Framework/DataProcessorSpec.h
 
@@ -620,6 +625,24 @@ the `ChannelConfigurationPolicy::modifyInput` and
 `ChannelConfigurationPolicy::modifyOutput` will be invoked passing the input and 
 output channel associated to the two devices, giving the opportunity to modify 
 the matching channels.
+
+## Customizing workflows creation (WIP)
+
+Sometimes it's handy to customise or generalise the workflow creation based on
+external inputs. For example you might want to change the number of workers for
+a given task or disable part of the topology if a given detector should not be
+enabled. 
+
+This can be done by implementing the function:
+
+    customise(std::vector<o2::framework::ConfigParamSpec> &workflowOptions)
+
+**before** including the `Framework/runDataProcessing.h` (this will most likely 
+change in the future). Each ConfigParamSpec will be added to the configuration
+mechanism (e.g. the command line options) allowing you to modify them. Such options
+will then be made available at workflow creation time via the `ConfigContext`
+passed to the `defineDataProcessing` function, using the `ConfigContext::options()`
+getter.
 
 ## Current Demonstrator (WIP)
 

--- a/Framework/Core/include/Framework/BoostOptionsRetriever.h
+++ b/Framework/Core/include/Framework/BoostOptionsRetriever.h
@@ -26,18 +26,19 @@ namespace framework {
 //        using the FairMQ plugin directly
 class BoostOptionsRetriever : public ParamRetriever {
 public:
-  BoostOptionsRetriever(std::vector<ConfigParamSpec> &specs);
-  void parseArgs(int argc, char **argv);
+  BoostOptionsRetriever(std::vector<ConfigParamSpec> &specs, bool ignoreUnknown, int &argc, char **&argv);
 
-  virtual int getInt(const char *name) final;
-  virtual float getFloat(const char *name) final;
-  virtual double getDouble(const char *name) final;
-  virtual bool getBool(const char *name) final;
-  virtual std::string getString(const char *name) final;
-  virtual std::vector<std::string> getVString(const char *name) final;
+  virtual int getInt(const char *name) const final;
+  virtual float getFloat(const char *name) const final;
+  virtual double getDouble(const char *name) const final;
+  virtual bool getBool(const char *name) const final;
+  virtual std::string getString(const char *name) const final;
+  virtual std::vector<std::string> getVString(const char *name) const final;
 private:
+  void parseArgs(int &argc, char **&argv);
   boost::program_options::variables_map mVariables;
   boost::program_options::options_description mDescription;
+  bool mIgnoreUnknown;
 };
 
 }

--- a/Framework/Core/include/Framework/ConfigContext.h
+++ b/Framework/Core/include/Framework/ConfigContext.h
@@ -1,0 +1,38 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef FRAMEWORK_CONFIG_CONTEXT_H
+#define FRAMEWORK_CONFIG_CONTEXT_H
+
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ServiceRegistry.h"
+
+namespace o2
+{
+namespace framework
+{
+
+/// This is the context class for information which are available at
+/// (re)configuration of the topology. It's automatically filled by the data
+/// processing layer and passed to the user `defineDataProcessing` function.
+class ConfigContext
+{
+ public:
+  ConfigContext(ConfigParamRegistry& options) : mOptions{ options } {}
+
+  ConfigParamRegistry& options() const { return mOptions; }
+
+ private:
+  ConfigParamRegistry& mOptions;
+};
+
+} // namespace framework
+} // namespace o2
+
+#endif

--- a/Framework/Core/include/Framework/ConfigParamRegistry.h
+++ b/Framework/Core/include/Framework/ConfigParamRegistry.h
@@ -13,6 +13,7 @@
 #include "Framework/ParamRetriever.h"
 #include <memory>
 #include <string>
+#include <cassert>
 
 namespace o2 {
 namespace framework {

--- a/Framework/Core/include/Framework/ConfigParamsHelper.h
+++ b/Framework/Core/include/Framework/ConfigParamsHelper.h
@@ -23,72 +23,80 @@ namespace framework {
 
 using options_description = boost::program_options::options_description;
 
-void populateBoostProgramOptions(
-    options_description &options,
-    const std::vector<ConfigParamSpec> &specs,
-    options_description vetos = options_description()
-  );
-
-/// populate boost program options making all options of type string
-/// this is used for filtering the command line argument
-/// all options which are found in the vetos are skipped
-bool
-prepareOptionsDescription(const std::vector<ConfigParamSpec> &spec,
-                          options_description& options,
-                          options_description vetos = options_description()
-                          );
-
-/// populate boost program options for a complete workflow
-template<typename ContainerType>
-boost::program_options::options_description
-prepareOptionDescriptions(const ContainerType &workflow,
-                          options_description vetos = options_description()
-                          )
+struct ConfigParamsHelper
 {
-  boost::program_options::options_description specOptions("Spec groups");
-  for (const auto & spec : workflow) {
-    std::string help = "Usage: --" + spec.name + R"( "spec options")";
-    specOptions.add_options()(spec.name.c_str(),
-                              boost::program_options::value<std::string>(),
-                              help.c_str());
-    std::string name = "Processor spec: " + spec.name;
-    boost::program_options::options_description options(name);
-    if (prepareOptionsDescription(spec.options, options, vetos)) {
-      specOptions.add(options);
-      // if vetos have been provided to the function we also need to make
-      // sure that there are no duplicate option definitions for the individual
-      // processor specs, so we add in order to be vetos for all subsequent specs.
-      // Note: this only concerns the main parser, all individual options are
-      // handled when starting individual processors.
-      if (vetos.options().size() > 0) {
-        vetos.add(options);
+  static void populateBoostProgramOptions(
+      options_description &options,
+      const std::vector<ConfigParamSpec> &specs,
+      options_description vetos = options_description()
+    );
+
+  /// populate boost program options making all options of type string
+  /// this is used for filtering the command line argument
+  /// all options which are found in the vetos are skipped
+  static bool prepareOptionsDescription(const std::vector<ConfigParamSpec> &spec,
+                                        options_description& options,
+                                        options_description vetos = options_description()
+                                       );
+
+  /// populate boost program options for a complete workflow
+  template<typename ContainerType>
+  static boost::program_options::options_description
+  prepareOptionDescriptions(const ContainerType &workflow,
+                            const std::vector<ConfigParamSpec> &workflowOptions,
+                            options_description vetos = options_description()
+                            )
+  {
+    boost::program_options::options_description toplevel;
+    boost::program_options::options_description wo("Global workflow options");
+    if (prepareOptionsDescription(workflowOptions, wo, vetos)) {
+      toplevel.add(wo);
+    }
+    boost::program_options::options_description specOptions("Available data processors");
+    for (const auto & spec : workflow) {
+      std::string help = "Usage: --" + spec.name + R"( "<data processor options>")";
+      specOptions.add_options()(spec.name.c_str(),
+                                boost::program_options::value<std::string>(),
+                                help.c_str());
+      std::string name = "Data processor options: " + spec.name;
+      boost::program_options::options_description options(name);
+      if (prepareOptionsDescription(spec.options, options, vetos)) {
+        specOptions.add(options);
+        // if vetos have been provided to the function we also need to make
+        // sure that there are no duplicate option definitions for the individual
+        // processor specs, so we add in order to be vetos for all subsequent specs.
+        // Note: this only concerns the main parser, all individual options are
+        // handled when starting individual processors.
+        if (vetos.options().size() > 0) {
+          vetos.add(options);
+        }
       }
     }
+    toplevel.add(specOptions);
+    return toplevel;
   }
-  return specOptions;
-}
 
-template<VariantType V>
-void
-addConfigSpecOption(const ConfigParamSpec & spec,
-                   boost::program_options::options_description& options)
-{
-  const char *name = spec.name.c_str();
-  const char *help = spec.help.c_str();
-  using Type = typename variant_type<V>::type;
-  using BoostType = typename std::conditional<V == VariantType::String, std::string, Type>::type;
-  auto value = boost::program_options::value<BoostType>();
-  if (spec.defaultValue.type() != VariantType::Empty) {
-    // set the default value if provided in the config spec
-    value = value->default_value(spec.defaultValue.get<Type>());
+  template<VariantType V>
+  static void addConfigSpecOption(const ConfigParamSpec & spec,
+                                  boost::program_options::options_description& options)
+  {
+    const char *name = spec.name.c_str();
+    const char *help = spec.help.c_str();
+    using Type = typename variant_type<V>::type;
+    using BoostType = typename std::conditional<V == VariantType::String, std::string, Type>::type;
+    auto value = boost::program_options::value<BoostType>();
+    if (spec.defaultValue.type() != VariantType::Empty) {
+      // set the default value if provided in the config spec
+      value = value->default_value(spec.defaultValue.get<Type>());
+    }
+    if (V == VariantType::Bool) {
+      // for bool values we also support the zero_token option to make
+      // the option usable as a single switch
+      value = value->zero_tokens();
+    }
+    options.add_options()(name, value, help);
   }
-  if (V == VariantType::Bool) {
-    // for bool values we also support the zero_token option to make
-    // the option usable as a single switch
-    value = value->zero_tokens();
-  }
-  options.add_options()(name, value, help);
-}
+};
 
 }
 }

--- a/Framework/Core/include/Framework/DataSampling.h
+++ b/Framework/Core/include/Framework/DataSampling.h
@@ -48,7 +48,7 @@ using namespace o2::framework::DataSamplingConfig;
 ///
 /// In-code usage:
 /// \code{.cxx}
-/// void defineDataProcessing(std::vector<DataProcessorSpec> &workflow)
+/// std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext &ctx)
 /// {
 ///
 /// // <declaration of other DPL processors>

--- a/Framework/Core/src/ConfigParamsHelper.cxx
+++ b/Framework/Core/src/ConfigParamsHelper.cxx
@@ -21,7 +21,7 @@ namespace framework {
 
 /// this creates the boost program options description from the ConfigParamSpec
 /// taking the VariantType into account
-void populateBoostProgramOptions(
+void ConfigParamsHelper::populateBoostProgramOptions(
     bpo::options_description &options,
     const std::vector<ConfigParamSpec> &specs,
     bpo::options_description vetos
@@ -61,10 +61,9 @@ void populateBoostProgramOptions(
 
 /// populate boost program options making all options of type string
 /// this is used for filtering the command line argument
-bool
-prepareOptionsDescription(const std::vector<ConfigParamSpec> &spec,
-                          boost::program_options::options_description& options,
-                          boost::program_options::options_description vetos
+bool ConfigParamsHelper::prepareOptionsDescription(const std::vector<ConfigParamSpec> &spec,
+                                                   boost::program_options::options_description& options,
+                                                   boost::program_options::options_description vetos
 			  )
 {
   bool haveOption = false;

--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -453,6 +453,7 @@ void DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(WorkflowSpec const& workf
 
 void DeviceSpecHelpers::prepareArguments(int argc, char** argv, bool defaultQuiet, bool defaultStopped,
                                          const std::vector<DeviceSpec>& deviceSpecs,
+                                         const std::vector<ConfigParamSpec> &workflowOptions,
                                          std::vector<DeviceExecution>& deviceExecutions,
                                          std::vector<DeviceControl>& deviceControls)
 {
@@ -489,8 +490,11 @@ void DeviceSpecHelpers::prepareArguments(int argc, char** argv, bool defaultQuie
     // DeviceSpec, and some global options from getForwardedDeviceOptions
     const char* name = spec.name.c_str();
     bpo::options_description od;
-    prepareOptionsDescription(spec.options, od);
+    bpo::options_description wo;
+    ConfigParamsHelper::prepareOptionsDescription(spec.options, od);
+    ConfigParamsHelper::prepareOptionsDescription(workflowOptions, wo);
     od.add(getForwardedDeviceOptions());
+    od.add(wo);
     od.add_options()(name, bpo::value<std::string>());
 
     using FilterFunctionT = std::function<void(decltype(argc), decltype(argv), decltype(od))>;

--- a/Framework/Core/src/DeviceSpecHelpers.h
+++ b/Framework/Core/src/DeviceSpecHelpers.h
@@ -49,6 +49,7 @@ struct DeviceSpecHelpers {
       bool defaultQuiet,
       bool defaultStopped,
       const std::vector<DeviceSpec> &deviceSpecs,
+      const std::vector<ConfigParamSpec> &workflowOptions,
       std::vector<DeviceExecution> &deviceExecutions,
       std::vector<DeviceControl> &deviceControls);
 

--- a/Framework/Core/src/DriverInfo.h
+++ b/Framework/Core/src/DriverInfo.h
@@ -20,6 +20,7 @@
 #include <sys/select.h>
 
 #include "Framework/ChannelConfigurationPolicy.h"
+#include "Framework/ConfigParamSpec.h"
 
 namespace o2
 {
@@ -110,6 +111,8 @@ struct DriverInfo {
   unsigned short startPort;
   /// The size of the port range to consider allocated
   unsigned short portRange;
+  /// The current set of workflow options 
+  std::vector<ConfigParamSpec> workflowOptions;
 };
 
 } // namespace framework

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -533,7 +533,7 @@ int doChild(int argc, char** argv, const o2::framework::DeviceSpec& spec)
     // declared in the workflow definition are allowed.
     runner.AddHook<fair::mq::hooks::SetCustomCmdLineOptions>([&spec](fair::mq::DeviceRunner& r) {
       boost::program_options::options_description optsDesc;
-      populateBoostProgramOptions(optsDesc, spec.options, gHiddenDeviceOptions);
+      ConfigParamsHelper::populateBoostProgramOptions(optsDesc, spec.options, gHiddenDeviceOptions);
       r.fConfig.AddToCmdLineOptions(optsDesc, true);
     });
 
@@ -716,7 +716,8 @@ int runStateMachine(DataProcessorSpecs const& workflow, DriverControl& driverCon
         deviceExecutions.resize(deviceSpecs.size());
 
         DeviceSpecHelpers::prepareArguments(driverInfo.argc, driverInfo.argv, driverControl.defaultQuiet,
-                                            driverControl.defaultStopped, deviceSpecs, deviceExecutions, controls);
+                                            driverControl.defaultStopped, deviceSpecs,
+                                            driverInfo.workflowOptions, deviceExecutions, controls);
         for (size_t di = 0; di < deviceSpecs.size(); ++di) {
           spawnDevice(deviceSpecs[di], driverInfo.socket2DeviceInfo, controls[di], deviceExecutions[di], infos,
                       driverInfo.maxFd, driverInfo.childFdset);
@@ -873,7 +874,8 @@ void initialiseDriverControl(bpo::variables_map const& varmap, DriverControl& co
 //   - Child, pick the data-processor ID and start a O2DataProcessorDevice for
 //     each DataProcessorSpec
 int doMain(int argc, char** argv, const o2::framework::WorkflowSpec& workflow,
-           std::vector<ChannelConfigurationPolicy> const& channelPolicies)
+           std::vector<ChannelConfigurationPolicy> const& channelPolicies,
+           std::vector<ConfigParamSpec> const &workflowOptions)
 {
   enum CompletionPolicy policy;
   bpo::options_description executorOptions("Executor options");
@@ -903,7 +905,7 @@ int doMain(int argc, char** argv, const o2::framework::WorkflowSpec& workflow,
   // Use the hidden options as veto, all config specs matching a definition
   // in the hidden options are skipped in order to avoid duplicate definitions
   // in the main parser. Note: all config specs are forwarded to devices
-  visibleOptions.add(prepareOptionDescriptions(workflow, gHiddenDeviceOptions));
+  visibleOptions.add(ConfigParamsHelper::prepareOptionDescriptions(workflow, workflowOptions, gHiddenDeviceOptions));
 
   bpo::options_description od;
   od.add(visibleOptions);
@@ -923,7 +925,7 @@ int doMain(int argc, char** argv, const o2::framework::WorkflowSpec& workflow,
     bpo::options_description helpOptions;
     helpOptions.add(executorOptions);
     // this time no veto is applied, so all the options are added for printout
-    helpOptions.add(prepareOptionDescriptions(workflow));
+    helpOptions.add(ConfigParamsHelper::prepareOptionDescriptions(workflow, workflowOptions));
     std::cout << helpOptions << std::endl;
     exit(0);
   }
@@ -945,6 +947,7 @@ int doMain(int argc, char** argv, const o2::framework::WorkflowSpec& workflow,
   driverInfo.timeout = varmap["timeout"].as<double>();
   driverInfo.startPort = varmap["start-port"].as<unsigned short>();
   driverInfo.portRange = varmap["port-range"].as<unsigned short>();
+  driverInfo.workflowOptions = workflowOptions;
 
   std::string frameworkId;
   // If the id is set, this means this is a device,

--- a/Framework/Core/test/test_BoostOptionsRetriever.cxx
+++ b/Framework/Core/test/test_BoostOptionsRetriever.cxx
@@ -7,7 +7,7 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#define BOOST_TEST_MODULE Test Framework ConfigParamsHelper
+#define BOOST_TEST_MODULE Test Framework BoostOptionsRetriever
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
 
@@ -21,7 +21,7 @@
 
 using namespace o2::framework;
 
-BOOST_AUTO_TEST_CASE(ConfigParamsHelper) {
+BOOST_AUTO_TEST_CASE(TrivialBoostOptionsRetrieverTest) {
   using namespace o2::framework;
   namespace bpo = boost::program_options;
 
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(ConfigParamsHelper) {
   bpo::variables_map vm;
   bpo::options_description opts;
 
-  populateBoostProgramOptions(opts, specs);
+  ConfigParamsHelper::populateBoostProgramOptions(opts, specs);
 
   bpo::store(parse_command_line(sizeof(args)/sizeof(char*), args, opts), vm);
   bpo::notify(vm);

--- a/Framework/Core/test/test_DataAllocator.cxx
+++ b/Framework/Core/test/test_DataAllocator.cxx
@@ -147,9 +147,11 @@ DataProcessorSpec getSinkSpec()
                             AlgorithmSpec(processingFct) };
 }
 
-void defineDataProcessing(WorkflowSpec& specs)
+WorkflowSpec defineDataProcessing(ConfigContext const&)
 {
-  specs.emplace_back(getTimeoutSpec());
-  specs.emplace_back(getSourceSpec());
-  specs.emplace_back(getSinkSpec());
+  return WorkflowSpec{
+    getTimeoutSpec(),
+    getSourceSpec(),
+    getSinkSpec()
+  };
 }

--- a/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
+++ b/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
@@ -76,20 +76,25 @@ BOOST_AUTO_TEST_CASE(TestGraphviz)
   std::vector<DeviceExecution> executions;
   controls.resize(devices.size());
   executions.resize(devices.size());
-  DeviceSpecHelpers::prepareArguments(1, fakeArgv, false, false, devices, executions, controls);
+
+  std::vector<ConfigParamSpec> workflowOptions = {
+    ConfigParamSpec{"jobs", VariantType::Int, 4, {"number of producer jobs"}}
+  };
+
+  DeviceSpecHelpers::prepareArguments(1, fakeArgv, false, false, devices, workflowOptions, executions, controls);
   dumpDeviceSpec2DDS(ss, devices, executions);
   BOOST_CHECK_EQUAL(ss.str(), R"EXPECTED(<topology id="o2-dataflow">
    <decltask id="A">
-       <exe reachable="true">foo --id A --control static --log-color false --color false </exe>
+       <exe reachable="true">foo --id A --control static --log-color false --color false --jobs 4 </exe>
    </decltask>
    <decltask id="B">
-       <exe reachable="true">foo --id B --control static --log-color false --color false </exe>
+       <exe reachable="true">foo --id B --control static --log-color false --color false --jobs 4 </exe>
    </decltask>
    <decltask id="C">
-       <exe reachable="true">foo --id C --control static --log-color false --color false </exe>
+       <exe reachable="true">foo --id C --control static --log-color false --color false --jobs 4 </exe>
    </decltask>
    <decltask id="D">
-       <exe reachable="true">foo --id D --control static --log-color false --color false </exe>
+       <exe reachable="true">foo --id D --control static --log-color false --color false --jobs 4 </exe>
    </decltask>
 </topology>
 )EXPECTED");

--- a/Framework/Core/test/test_GenericSource.cxx
+++ b/Framework/Core/test/test_GenericSource.cxx
@@ -12,8 +12,8 @@
 using namespace o2::framework;
 
 // This is how you can define your processing in a declarative way
-void defineDataProcessing(WorkflowSpec &specs) {
-  WorkflowSpec workflow = {
+WorkflowSpec defineDataProcessing(ConfigContext const&specs) {
+  return WorkflowSpec{
   {
     "A",
     Inputs{},
@@ -31,5 +31,4 @@ void defineDataProcessing(WorkflowSpec &specs) {
     Options{{"test-option", VariantType::String, "test", "A test option"}},
   }
   };
-  specs.swap(workflow);
 }

--- a/Framework/Core/test/test_Parallel.cxx
+++ b/Framework/Core/test/test_Parallel.cxx
@@ -32,8 +32,9 @@ size_t collectionChunkSize = 1000;
 void someDataProducerAlgorithm(ProcessingContext& ctx);
 void someProcessingStageAlgorithm(ProcessingContext& ctx);
 
-void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
+std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
 {
+  std::vector<DataProcessorSpec> specs;
   auto dataProducers = parallel(
     DataProcessorSpec{
       "dataProducer",
@@ -184,6 +185,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
 //  specs.push_back(qcTask);
 //  specs.push_back(sink);
 
+  return specs;
 }
 
 

--- a/Framework/Core/test/test_RootTreeReader.cxx
+++ b/Framework/Core/test/test_RootTreeReader.cxx
@@ -106,8 +106,10 @@ DataProcessorSpec getSinkSpec()
                             AlgorithmSpec(processingFct) };
 }
 
-void defineDataProcessing(WorkflowSpec& specs)
+WorkflowSpec defineDataProcessing(ConfigContext const&)
 {
-  specs.emplace_back(getSourceSpec());
-  specs.emplace_back(getSinkSpec());
+  return WorkflowSpec{
+    getSourceSpec(),
+    getSinkSpec()
+  };
 }

--- a/Framework/Core/test/test_SimpleDataProcessingDevice01.cxx
+++ b/Framework/Core/test/test_SimpleDataProcessingDevice01.cxx
@@ -31,44 +31,44 @@ struct Summary {
 using DataHeader = o2::header::DataHeader;
 
 // This is how you can define your processing in a declarative way
-void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
-  DataProcessorSpec simple{
-    "simple",
-    Inputs{},
-    {
-      OutputSpec{"TPC", "CLUSTERS"},
-      OutputSpec{"ITS", "CLUSTERS"}
-    },
-    AlgorithmSpec{
-      [](ProcessingContext &ctx) {
-        sleep(1);
-        // Creates a new message of size 1000 which
-        // has "TPC" as data origin and "CLUSTERS" as data description.
-        auto tpcClusters = ctx.outputs().make<FakeCluster>(Output{ "TPC", "CLUSTERS", 0 }, 1000);
-        int i = 0;
+std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const &) {
+  return {
+    DataProcessorSpec{
+      "simple",
+      Inputs{},
+      {
+        OutputSpec{"TPC", "CLUSTERS"},
+        OutputSpec{"ITS", "CLUSTERS"}
+      },
+      AlgorithmSpec{
+        [](ProcessingContext &ctx) {
+          sleep(1);
+          // Creates a new message of size 1000 which
+          // has "TPC" as data origin and "CLUSTERS" as data description.
+          auto tpcClusters = ctx.outputs().make<FakeCluster>(Output{ "TPC", "CLUSTERS", 0 }, 1000);
+          int i = 0;
 
-        for (auto &cluster : tpcClusters) {
-          assert(i < 1000);
-          cluster.x = i;
-          cluster.y = i;
-          cluster.z = i;
-          cluster.q = i;
-          i++;
-        }
+          for (auto &cluster : tpcClusters) {
+            assert(i < 1000);
+            cluster.x = i;
+            cluster.y = i;
+            cluster.z = i;
+            cluster.q = i;
+            i++;
+          }
 
-        auto itsClusters = ctx.outputs().make<FakeCluster>(Output{ "ITS", "CLUSTERS", 0 }, 1000);
-        i = 0;
-        for (auto &cluster : itsClusters) {
-          assert(i < 1000);
-          cluster.x = i;
-          cluster.y = i;
-          cluster.z = i;
-          cluster.q = i;
-          i++;
+          auto itsClusters = ctx.outputs().make<FakeCluster>(Output{ "ITS", "CLUSTERS", 0 }, 1000);
+          i = 0;
+          for (auto &cluster : itsClusters) {
+            assert(i < 1000);
+            cluster.x = i;
+            cluster.y = i;
+            cluster.z = i;
+            cluster.q = i;
+            i++;
+          }
         }
       }
     }
   };
-
-  specs.push_back(simple);
 }

--- a/Framework/Core/test/test_SimpleStatefulProcessing01.cxx
+++ b/Framework/Core/test/test_SimpleStatefulProcessing01.cxx
@@ -21,8 +21,8 @@ using DataHeader = o2::header::DataHeader;
 
 // This is a simple consumer / producer workflow where both are
 // stateful, i.e. they have context which comes from their initialization.
-void defineDataProcessing(WorkflowSpec &specs) {
-  WorkflowSpec workflow = {
+WorkflowSpec defineDataProcessing(ConfigContext const&) {
+  return WorkflowSpec{
     //
     DataProcessorSpec{
       "producer",                                                  //
@@ -80,6 +80,4 @@ void defineDataProcessing(WorkflowSpec &specs) {
       }   //
     }     //
   };
-
-  specs.swap(workflow);
 }

--- a/Framework/Core/test/test_SingleDataSource.cxx
+++ b/Framework/Core/test/test_SingleDataSource.cxx
@@ -14,23 +14,22 @@
 using namespace o2::framework;
 
 // This is how you can define your processing in a declarative way
-void defineDataProcessing(WorkflowSpec &specs) {
-  WorkflowSpec workflow = {
-  {
-    "A",
-    {},
+WorkflowSpec defineDataProcessing(ConfigContext const&) {
+  return WorkflowSpec{
     {
-      OutputSpec{"TST", "A1", 0, Lifetime::Timeframe}
-    },
-    AlgorithmSpec{
-      [](ProcessingContext &ctx) {
-       sleep(1);
-       auto aData = ctx.outputs().make<int>(Output{ "TST", "A1", 0}, 1);
-       ctx.services().get<ControlService>().readyToQuit(true);
-      }
-    },
-    Options{{"test-option", VariantType::String, "test", {"A test option"}}},
-  }
+      "A",
+      {},
+      {
+        OutputSpec{"TST", "A1", 0, Lifetime::Timeframe}
+      },
+      AlgorithmSpec{
+        [](ProcessingContext &ctx) {
+         sleep(1);
+         auto aData = ctx.outputs().make<int>(Output{ "TST", "A1", 0}, 1);
+         ctx.services().get<ControlService>().readyToQuit(true);
+        }
+      },
+      Options{{"test-option", VariantType::String, "test", {"A test option"}}},
+    }
   };
-  specs.swap(workflow);
 }

--- a/Framework/Core/test/test_TimePipeline.cxx
+++ b/Framework/Core/test/test_TimePipeline.cxx
@@ -32,51 +32,46 @@ size_t collectionChunkSize = 1000;
 void someDataProducerAlgorithm(ProcessingContext& ctx);
 void someProcessingStageAlgorithm(ProcessingContext& ctx);
 
-void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
+WorkflowSpec defineDataProcessing(ConfigContext const&)
 {
-
-  DataProcessorSpec dataProducer{
-    "dataProducer",
-    Inputs{},
+  return WorkflowSpec {
     {
-      OutputSpec{ "TPC", "CLUSTERS" },
-    },
-    AlgorithmSpec{
-      (AlgorithmSpec::ProcessCallback) someDataProducerAlgorithm
-    }
-  };
-
-  auto processingStage = timePipeline(
-    DataProcessorSpec{
-      "processingStage",
-      Inputs{
-        { "dataTPC", "TPC", "CLUSTERS" }
-      },
-      Outputs{
-        { "TPC", "CLUSTERS_P" }
+      "dataProducer",
+      Inputs{},
+      {
+        OutputSpec{ "TPC", "CLUSTERS" },
       },
       AlgorithmSpec{
-        (AlgorithmSpec::ProcessCallback) someProcessingStageAlgorithm
+        (AlgorithmSpec::ProcessCallback) someDataProducerAlgorithm
       }
     },
-    parallelSize
-  );
-
-  DataProcessorSpec dataSampler{
-    "dataSampler",
-    Inputs{
-      { "dataTPC-sampled", "TPC", "CLUSTERS", 0, Lifetime::Timeframe },
-    },
-    Outputs{},
-    AlgorithmSpec{
-      (AlgorithmSpec::ProcessCallback) [](ProcessingContext& ctx) {
+    timePipeline(
+      DataProcessorSpec{
+        "processingStage",
+        Inputs{
+          { "dataTPC", "TPC", "CLUSTERS" }
+        },
+        Outputs{
+          { "TPC", "CLUSTERS_P" }
+        },
+        AlgorithmSpec{
+          (AlgorithmSpec::ProcessCallback) someProcessingStageAlgorithm
+        }
+      },
+      parallelSize
+    ),
+    DataProcessorSpec{
+      "dataSampler",
+      Inputs{
+        { "dataTPC-sampled", "TPC", "CLUSTERS", 0, Lifetime::Timeframe },
+      },
+      Outputs{},
+      AlgorithmSpec{
+        (AlgorithmSpec::ProcessCallback) [](ProcessingContext& ctx) {
+        }
       }
     }
   };
-
-  specs.push_back(dataProducer);
-  specs.push_back(processingStage);
-  specs.push_back(dataSampler);
 }
 
 

--- a/Framework/Core/test/test_WorkflowOptions.cxx
+++ b/Framework/Core/test/test_WorkflowOptions.cxx
@@ -18,8 +18,8 @@ using namespace o2::framework;
   }
 
 // This is how you can define your processing in a declarative way
-void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
-  WorkflowSpec w = {
+WorkflowSpec defineDataProcessing(ConfigContext const&) {
+  return WorkflowSpec{
     DataProcessorSpec{
       "producer",
       Inputs{},
@@ -74,5 +74,4 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
       },
     }
   };
-  specs.swap(w);
 }

--- a/Framework/TestWorkflows/src/dataSamplingFullChain.cxx
+++ b/Framework/TestWorkflows/src/dataSamplingFullChain.cxx
@@ -53,11 +53,13 @@
 
 using namespace o2::framework;
 
-void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
+WorkflowSpec defineDataProcessing(ConfigContext const&)
 {
   std::string configFilePath =
     std::string("file://") + getenv("O2_ROOT") + "/share/config/dataSamplingFullChainConfig.ini";
   LOG(INFO) << "Using config file '" << configFilePath << "'";
 
+  WorkflowSpec specs;
   DataSampling::GenerateInfrastructure(specs, configFilePath);
+  return specs;
 }

--- a/Framework/TestWorkflows/src/dataSamplingParallel.cxx
+++ b/Framework/TestWorkflows/src/dataSamplingParallel.cxx
@@ -34,7 +34,7 @@ void someDataProducerAlgorithm(ProcessingContext& ctx);
 void someProcessingStageAlgorithm(ProcessingContext& ctx);
 void someSinkAlgorithm(ProcessingContext& ctx);
 
-void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
+WorkflowSpec defineDataProcessing(ConfigContext const&)
 {
   auto dataProducers = parallel(
     DataProcessorSpec{
@@ -124,6 +124,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
     }
   };
 
+  WorkflowSpec specs;
   specs.swap(dataProducers);
   specs.insert(std::end(specs), std::begin(processingStages), std::end(processingStages));
   specs.push_back(sink);
@@ -133,6 +134,7 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
                                     + "/../../O2/Framework/TestWorkflows/exampleDataSamplerConfig.ini";
 
   DataSampling::GenerateInfrastructure(specs, configurationSource);
+  return specs;
 }
 
 

--- a/Framework/TestWorkflows/src/dataSamplingPodAndRoot.cxx
+++ b/Framework/TestWorkflows/src/dataSamplingPodAndRoot.cxx
@@ -37,7 +37,7 @@ void someDataProducerAlgorithm(ProcessingContext& ctx);
 void someProcessingStageAlgorithm(ProcessingContext& ctx);
 void someSinkAlgorithm(ProcessingContext& ctx);
 
-void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
+WorkflowSpec defineDataProcessing(ConfigContext const&)
 {
   DataProcessorSpec podDataProducer{
     "podDataProducer",
@@ -187,19 +187,22 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
     }
   };
 
-  specs.push_back(podDataProducer);
-  specs.push_back(processingStage);
-  specs.push_back(podSink);
-  specs.push_back(qcTaskTpc);
+  WorkflowSpec specs{
+    podDataProducer,
+    processingStage,
+    podSink,
+    qcTaskTpc,
 
-  specs.push_back(rootDataProducer);
-  specs.push_back(rootSink);
-  specs.push_back(rootQcTask);
+    rootDataProducer,
+    rootSink,
+    rootQcTask
+  };
 
   std::string configurationSource = std::string("file://") + getenv("BASEDIR")
                                     + "/../../O2/Framework/TestWorkflows/exampleDataSamplerConfig.ini";
 
   DataSampling::GenerateInfrastructure(specs, configurationSource);
+  return specs;
 }
 
 

--- a/Framework/TestWorkflows/src/dataSamplingTimePipeline.cxx
+++ b/Framework/TestWorkflows/src/dataSamplingTimePipeline.cxx
@@ -34,7 +34,7 @@ void someDataProducerAlgorithm(ProcessingContext& ctx);
 void someProcessingStageAlgorithm(ProcessingContext& ctx);
 void someSinkAlgorithm(ProcessingContext& ctx);
 
-void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
+WorkflowSpec defineDataProcessing(ConfigContext const&)
 {
   DataProcessorSpec dataProducer{
     "dataProducer",
@@ -106,15 +106,18 @@ void defineDataProcessing(std::vector<DataProcessorSpec>& specs)
     }
   };
 
-  specs.push_back(dataProducer);
-  specs.push_back(processingStage);
-  specs.push_back(sink);
-  specs.push_back(simpleQcTask);
+  WorkflowSpec specs = {
+    dataProducer,
+    processingStage,
+    sink,
+    simpleQcTask
+  };
 
   std::string configurationSource = std::string("file://") + getenv("BASEDIR")
                                     + "/../../O2/Framework/TestWorkflows/exampleDataSamplerConfig.ini";
 
   DataSampling::GenerateInfrastructure(specs, configurationSource);
+  return specs;
 }
 
 

--- a/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
@@ -18,8 +18,8 @@ AlgorithmSpec simplePipe(std::string const &what) {
 }
 
 // This is how you can define your processing in a declarative way
-void defineDataProcessing(WorkflowSpec &specs) {
-  WorkflowSpec workflow = {
+WorkflowSpec defineDataProcessing(ConfigContext const&specs) {
+  return WorkflowSpec{
   {
     "A",
     Inputs{},
@@ -60,5 +60,4 @@ void defineDataProcessing(WorkflowSpec &specs) {
     }
   }
   };
-  specs.swap(workflow);
 }

--- a/Framework/TestWorkflows/src/o2DummyWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DummyWorkflow.cxx
@@ -30,7 +30,7 @@ using DataHeader = o2::header::DataHeader;
 using DataOrigin = o2::header::DataOrigin;
 
 // This is how you can define your processing in a declarative way
-void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
+std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&) {
   DataProcessorSpec timeframeReader{
     "reader",
     Inputs{},
@@ -131,8 +131,10 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
       },
     }
   };
-  specs.push_back(timeframeReader);
-  specs.push_back(tpcClusterSummary);
-  specs.push_back(itsClusterSummary);
-  specs.push_back(merger);
+  return {
+    timeframeReader,
+    tpcClusterSummary,
+    itsClusterSummary,
+    merger
+  };
 }

--- a/Framework/TestWorkflows/src/o2ParallelWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2ParallelWorkflow.cxx
@@ -43,7 +43,7 @@ DataProcessorSpec templateProcessor() {
 
 // This is a simple consumer / producer workflow where both are
 // stateful, i.e. they have context which comes from their initialization.
-void defineDataProcessing(o2::framework::WorkflowSpec &specs) {
+WorkflowSpec defineDataProcessing(ConfigContext const&) {
   // This is an example of how we can parallelize by subSpec.
   // templatedProducer will be instanciated 32 times and the lambda function
   // passed to the parallel statement will be applied to each one of the
@@ -85,5 +85,5 @@ void defineDataProcessing(o2::framework::WorkflowSpec &specs) {
       }
   }, 3));
 
-  specs.swap(workflow);
+  return workflow;
 }

--- a/Framework/TestWorkflows/src/test_RawDeviceInjector.cxx
+++ b/Framework/TestWorkflows/src/test_RawDeviceInjector.cxx
@@ -21,13 +21,13 @@ using DataOrigin = o2::header::DataOrigin;
 // A simple workflow which takes heartbeats from
 // a raw FairMQ device as input and uses them as 
 // part of the DPL.
-void defineDataProcessing(WorkflowSpec &specs) {
+WorkflowSpec defineDataProcessing(ConfigContext const&specs) {
   auto outspec = OutputSpec{o2::header::DataOrigin("SMPL"),
                             o2::header::gDataDescriptionHeartbeatFrame};
   auto inspec = InputSpec{"heatbeat",
                           o2::header::DataOrigin("SMPL"),
                           o2::header::gDataDescriptionHeartbeatFrame};
-  WorkflowSpec workflow = {
+  return WorkflowSpec{
     specifyExternalFairMQDeviceProxy("foreign-source",
                     {outspec},
                     "type=sub,method=connect,address=tcp://localhost:5450,rateLogging=1",
@@ -44,6 +44,4 @@ void defineDataProcessing(WorkflowSpec &specs) {
       }
     }
   };
-
-  specs.swap(workflow);
 }

--- a/Framework/TestWorkflows/src/test_o2ITSCluserizer.cxx
+++ b/Framework/TestWorkflows/src/test_o2ITSCluserizer.cxx
@@ -27,10 +27,8 @@ using DataOrigin = o2::header::DataOrigin;
 using DataDescription = o2::header::DataDescription;
 
 // This is how you can define your processing in a declarative way
-void defineDataProcessing(WorkflowSpec &specs) {
-  WorkflowSpec workflow{
+WorkflowSpec defineDataProcessing(ConfigContext const&) {
+  return WorkflowSpec{
     sim_its_ALP3(),
   };
-
-  specs.swap(workflow);
 }

--- a/Framework/TestWorkflows/src/test_o2RootMessageWorkflow.cxx
+++ b/Framework/TestWorkflows/src/test_o2RootMessageWorkflow.cxx
@@ -26,8 +26,8 @@ using DataOrigin = o2::header::DataOrigin;
 using DataDescription = o2::header::DataDescription;
 
 // This is how you can define your processing in a declarative way
-void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
-    std::vector<DataProcessorSpec> workflow = {
+WorkflowSpec defineDataProcessing(ConfigContext const&) {
+  return WorkflowSpec{
     {
       "producer",
       {},
@@ -80,5 +80,4 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
       }
     }
   };
-  specs.swap(workflow);
 }

--- a/Framework/TestWorkflows/src/test_o2TPCSimulation.cxx
+++ b/Framework/TestWorkflows/src/test_o2TPCSimulation.cxx
@@ -22,10 +22,8 @@ using namespace o2::framework;
 using namespace o2::workflows;
 
 // This is how you can define your processing in a declarative way
-void defineDataProcessing(WorkflowSpec &specs) {
-  WorkflowSpec workflow{
+WorkflowSpec defineDataProcessing(ConfigContext const&specs) {
+  return WorkflowSpec{
     sim_tpc(),
   };
-
-  specs.swap(workflow);
 }

--- a/Framework/TestWorkflows/test/test_MakeDPLObjects.cxx
+++ b/Framework/TestWorkflows/test/test_MakeDPLObjects.cxx
@@ -22,8 +22,8 @@ struct XYZ {
   float z;
 };
 
-void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
-  WorkflowSpec workflow = {
+WorkflowSpec defineDataProcessing(ConfigContext const&) {
+  return WorkflowSpec{
     DataProcessorSpec{
       "source",
       Inputs{},
@@ -116,6 +116,4 @@ void defineDataProcessing(std::vector<DataProcessorSpec> &specs) {
       }
     }
   };
-
-  specs.swap(workflow);
 }

--- a/Framework/Utils/test/test_DPLBroadcasterMerger.cxx
+++ b/Framework/Utils/test/test_DPLBroadcasterMerger.cxx
@@ -24,11 +24,7 @@
 using namespace o2::framework;
 
 // This is how you can define your processing in a declarative way
-void defineDataProcessing(WorkflowSpec& specs)
+WorkflowSpec defineDataProcessing(ConfigContext const &)
 {
-  WorkflowSpec workflow{
-    o2::workflows::DPLBroadcasterMergerWorkflow(),
-  };
-
-  specs.swap(workflow);
+  return o2::workflows::DPLBroadcasterMergerWorkflow();
 }

--- a/Framework/Utils/test/test_DPLOutputTest.cxx
+++ b/Framework/Utils/test/test_DPLOutputTest.cxx
@@ -24,11 +24,7 @@
 using namespace o2::framework;
 
 // This is how you can define your processing in a declarative way
-void defineDataProcessing(WorkflowSpec& specs)
+WorkflowSpec defineDataProcessing(ConfigContext const&)
 {
-  WorkflowSpec workflow{
-    o2::workflows::DPLOutputTest(),
-  };
-
-  specs.swap(workflow);
+  return o2::workflows::DPLOutputTest();
 }

--- a/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
+++ b/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
@@ -77,9 +77,10 @@ bool wantCollisionTimePrinter()
 
 /// This function is required to be implemented to define the workflow
 /// specifications
-void defineDataProcessing(WorkflowSpec& specs)
+WorkflowSpec defineDataProcessing(ConfigContext const&)
 {
-  specs.clear();
+  WorkflowSpec specs;
+
   int fanoutsize = 0;
   if (wantCollisionTimePrinter()) {
     specs.emplace_back(o2::steer::getCollisionTimePrinter(fanoutsize++));
@@ -99,4 +100,5 @@ void defineDataProcessing(WorkflowSpec& specs)
   }
 
   specs.emplace_back(o2::steer::getSimReaderSpec(fanoutsize, tpcsectors, tpclanes));
+  return specs;
 }

--- a/Utilities/QC/Workflow/src/SimpleMergerWorkflow.cxx
+++ b/Utilities/QC/Workflow/src/SimpleMergerWorkflow.cxx
@@ -24,8 +24,9 @@ using namespace o2::framework;
 /// specifications
 ///
 /// The example connects a producer for ROOT objects with a merger process
-void defineDataProcessing(WorkflowSpec &specs) {
-  specs.clear();
-  specs.emplace_back(o2::qc::getRootObjectProducerSpec());
-  specs.emplace_back(o2::qc::getRootObjectMergerSpec());
+WorkflowSpec defineDataProcessing(ConfigContext const &) {
+  return WorkflowSpec{
+    o2::qc::getRootObjectProducerSpec(),
+    o2::qc::getRootObjectMergerSpec()
+  };
 }


### PR DESCRIPTION
This introduces the ability to specify options which are global to
the workflow and available at topology generation time.

For example it can be used to enable or disable the creation of certain
part of the topology.

An example of how to use it can be found it can be found in
the test_ParallelProducer.