### PR TITLE
Do not try to be smart about long lines

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -13,7 +13,7 @@ BreakBeforeBinaryOperators: false
 BreakBeforeBraces: Linux
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false
-ColumnLimit: 120
+ColumnLimit: 0 
 CommentPragmas:  '^ IWYU pragma:'
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,14 @@ script: |
         COMMIT_FILES=$(git diff --name-only $BASE_COMMIT | grep -i -v LinkDef)
         RESULT_OUTPUT="$(git-clang-format-3.9 --commit $BASE_COMMIT --diff --binary `which clang-format-3.9` $COMMIT_FILES)"
 
+        for x in $COMMIT_FILES; do
+          case $x in
+            *.h|*.cxx) grep '.\{120,\}' $x && { echo "Line longer than 120 chars in $x." && exit 1; } ;;
+            *.hxx|*.cc|*.hpp) echo "$x uses non-allowed extension." && exit 1 ;;
+            *) ;;
+          esac
+        done
+
         if [ "$RESULT_OUTPUT" == "no modified files to format" ] \
           || [ "$RESULT_OUTPUT" == "clang-format did not modify any files" ] ; then
           echo "clang-format passed."


### PR DESCRIPTION
Too many things fall apart when clang-format tries to be smart about
reflowing long lines, resulting in a clearly more confusing resulting
code.

This prevents the reflowing, but results in less far positives. While
I fully agree that long lines are bad, I guess people in general tend
to avoid those and the benefit for the number of false positives is too
low.