### PR TITLE
Shield DPL workflows from FairMQDevice

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -43,6 +43,7 @@ set(SRCS
     src/DriverControl.cxx
     src/DriverInfo.cxx
     src/FairOptionsRetriever.cxx
+    src/FairMQDeviceProxy.cxx
     src/GraphvizHelpers.cxx
     src/InputRecord.cxx
     src/LocalRootFileService.cxx

--- a/Framework/Core/include/Framework/DataRelayer.h
+++ b/Framework/Core/include/Framework/DataRelayer.h
@@ -10,11 +10,12 @@
 #ifndef FRAMEWORK_DATARELAYER_H
 #define FRAMEWORK_DATARELAYER_H
 
-#include <fairmq/FairMQMessage.h>
 #include "Framework/InputRoute.h"
 #include "Framework/ForwardRoute.h"
 #include <cstddef>
 #include <vector>
+
+class FairMQMessage;
 
 namespace o2 {
 namespace framework {

--- a/Framework/Core/include/Framework/FairMQDeviceProxy.h
+++ b/Framework/Core/include/Framework/FairMQDeviceProxy.h
@@ -1,0 +1,50 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef FRAMEWORK_FAIRMQDEVICEPROXY_H
+#define FRAMEWORK_FAIRMQDEVICEPROXY_H
+
+#include <memory>
+
+class FairMQDevice;
+class FairMQMessage;
+class FairMQTransportFactory;
+
+namespace o2
+{
+namespace framework
+{
+/// Helper class to hide FairMQDevice headers in the DataAllocator header.
+/// This is done because FairMQDevice brings in a bunch of boost.mpl /
+/// boost.fusion stuff, slowing down compilation times enourmously.
+class FairMQDeviceProxy
+{
+public:
+  FairMQDeviceProxy(FairMQDevice *device)
+  : mDevice{device}
+  {}
+
+  /// To be used in DataAllocator.cxx to avoid reimplenting any device
+  /// API.
+  FairMQDevice *getDevice() {
+    return mDevice;
+  }
+
+  /// Looks like what we really need in the headers is just the transport.
+  const FairMQTransportFactory* getTransport();
+  std::unique_ptr<FairMQMessage> createMessage() const;
+  std::unique_ptr<FairMQMessage> createMessage(const size_t size) const;
+private:
+  FairMQDevice* mDevice;
+};
+
+} // namespace framework
+} // namespace o2
+
+#endif // FRAMEWORK_FAIRMQDEVICEPROXY_H

--- a/Framework/Core/include/Framework/InputRecord.h
+++ b/Framework/Core/include/Framework/InputRecord.h
@@ -15,9 +15,6 @@
 #include "Framework/InputRoute.h"
 #include "Framework/TypeTraits.h"
 
-#include <fairmq/FairMQMessage.h>
-#include <Framework/TMessageSerializer.h>
-
 #include <TClass.h>
 
 #include <iterator>
@@ -28,6 +25,8 @@
 #include <exception>
 #include <memory>
 #include <type_traits>
+
+class FairMQMessage;
 
 namespace o2
 {

--- a/Framework/Core/include/Framework/RootObjectContext.h
+++ b/Framework/Core/include/Framework/RootObjectContext.h
@@ -13,6 +13,7 @@
 #include <vector>
 #include <cassert>
 #include <string>
+#include <memory>
 
 class TObject;
 class FairMQMessage;

--- a/Framework/Core/include/Framework/RootObjectContext.h
+++ b/Framework/Core/include/Framework/RootObjectContext.h
@@ -10,12 +10,12 @@
 #ifndef FRAMEWORK_ROOTOBJETCONTEXT_H
 #define FRAMEWORK_ROOTOBJETCONTEXT_H
 
-#include <fairmq/FairMQMessage.h>
-#include <TObject.h>
-
 #include <vector>
 #include <cassert>
 #include <string>
+
+class TObject;
+class FairMQMessage;
 
 namespace o2 {
 namespace framework {
@@ -23,14 +23,14 @@ namespace framework {
 class RootObjectContext {
 public:
   struct MessageRef {
-    FairMQMessagePtr header;
+    std::unique_ptr<FairMQMessage> header;
     std::unique_ptr<TObject> payload;
     std::string channel;
   };
 
   using Messages = std::vector<MessageRef>;
 
-  void addObject(FairMQMessagePtr header,
+  void addObject(std::unique_ptr<FairMQMessage> header,
                  std::unique_ptr<TObject> obj,
                  const std::string &channel)
   {

--- a/Framework/Core/src/DataAllocator.cxx
+++ b/Framework/Core/src/DataAllocator.cxx
@@ -12,7 +12,11 @@
 #include "Framework/RootObjectContext.h"
 #include "Framework/DataSpecUtils.h"
 #include "Framework/DataProcessingHeader.h"
+
+#include <fairmq/FairMQDevice.h>
+
 #include <TClonesArray.h>
+
 
 namespace o2 {
 namespace framework {
@@ -21,11 +25,12 @@ using DataHeader = o2::header::DataHeader;
 using DataDescription = o2::header::DataDescription;
 using DataProcessingHeader = o2::framework::DataProcessingHeader;
 
-DataAllocator::DataAllocator(FairMQDevice *device,
+DataAllocator::DataAllocator(FairMQDeviceProxy proxy,
                              MessageContext *context,
                              RootObjectContext *rootContext,
                              const AllowedOutputRoutes &routes)
-: mDevice{device},
+: mProxy{proxy},
+  mDevice{proxy.getDevice()},
   mAllowedOutputRoutes{routes},
   mContext{context},
   mRootContext{rootContext}

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -13,6 +13,7 @@
 #include "Framework/DataProcessor.h"
 #include "Framework/DataSpecUtils.h"
 #include "Framework/FairOptionsRetriever.h"
+#include "Framework/FairMQDeviceProxy.h"
 #include "Framework/MetricsService.h"
 #include "Framework/CallbackService.h"
 #include "Framework/TMessageSerializer.h"
@@ -39,7 +40,7 @@ DataProcessingDevice::DataProcessingDevice(const DeviceSpec &spec,
   mStatelessProcess{spec.algorithm.onProcess},
   mError{spec.algorithm.onError},
   mConfigRegistry{nullptr},
-  mAllocator{this, &mContext, &mRootContext, spec.outputs},
+  mAllocator{FairMQDeviceProxy{this}, &mContext, &mRootContext, spec.outputs},
   mRelayer{spec.inputs, spec.forwards, registry.get<MetricsService>()},
   mInputChannels{spec.inputChannels},
   mOutputChannels{spec.outputChannels},

--- a/Framework/Core/src/DataSourceDevice.cxx
+++ b/Framework/Core/src/DataSourceDevice.cxx
@@ -12,6 +12,7 @@
 #include "Framework/TMessageSerializer.h"
 #include "Framework/DataProcessor.h"
 #include "Framework/FairOptionsRetriever.h"
+#include "Framework/FairMQDeviceProxy.h"
 #include "Framework/DataProcessingHeader.h"
 #include "Framework/CallbackService.h"
 #include <cassert>
@@ -30,7 +31,7 @@ DataSourceDevice::DataSourceDevice(const DeviceSpec &spec, ServiceRegistry &regi
   mStatelessProcess{spec.algorithm.onProcess},
   mError{spec.algorithm.onError},
   mConfigRegistry{nullptr},
-  mAllocator{this,&mContext, &mRootContext, spec.outputs},
+  mAllocator{FairMQDeviceProxy{this},&mContext, &mRootContext, spec.outputs},
   mServiceRegistry{registry},
   mCurrentTimeslice{0},
   mRate{0.},

--- a/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
+++ b/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
@@ -16,6 +16,7 @@
 #include "Headers/DataHeader.h"
 #include "Framework/DataProcessingHeader.h"
 #include <fairmq/FairMQParts.h>
+#include <fairmq/FairMQDevice.h>
 #include <cstring>
 #include <cassert>
 #include <memory>

--- a/Framework/Core/src/FairMQDeviceProxy.cxx
+++ b/Framework/Core/src/FairMQDeviceProxy.cxx
@@ -1,0 +1,35 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/FairMQDeviceProxy.h"
+
+#include <fairmq/FairMQDevice.h>
+#include <fairmq/FairMQMessage.h>
+
+namespace o2
+{
+namespace framework
+{
+const FairMQTransportFactory *FairMQDeviceProxy::getTransport() {
+  return mDevice->Transport();
+}
+
+std::unique_ptr<FairMQMessage> FairMQDeviceProxy::createMessage() const
+{
+  return mDevice->Transport()->CreateMessage();
+}
+
+std::unique_ptr<FairMQMessage> FairMQDeviceProxy::createMessage(const size_t size) const
+{
+  return mDevice->Transport()->CreateMessage(size);
+}
+
+} // namespace framework
+} // namespace o2


### PR DESCRIPTION
Because of its dependency on Boost mpl and Boost fusion,
including FairMQDevice.h is very heavy duty for the compiler.

Given that the FairMQDevice is not really needed, but only the Transport
and the correct serialization policy, we simply move to use those
directly.