### PR TITLE
Reduce API presence of FairMQParts, FairMQMessage

### DIFF
--- a/Framework/Core/include/Framework/DataProcessingDevice.h
+++ b/Framework/Core/include/Framework/DataProcessingDevice.h
@@ -11,7 +11,6 @@
 #define FRAMEWORK_DATAPROCESSING_DEVICE_H
 
 #include <fairmq/FairMQDevice.h>
-#include <fairmq/FairMQParts.h>
 
 #include "Framework/AlgorithmSpec.h"
 #include "Framework/ConfigParamRegistry.h"
@@ -25,6 +24,8 @@
 #include "Framework/ForwardRoute.h"
 
 #include <memory>
+
+class FairMQParts;
 
 namespace o2 {
 namespace framework {

--- a/Framework/Core/include/Framework/ExternalFairMQDeviceProxy.h
+++ b/Framework/Core/include/Framework/ExternalFairMQDeviceProxy.h
@@ -11,14 +11,16 @@
 #define FRAMEWORK_RAWDEVICESOURCE_H
 
 #include "Framework/DataProcessorSpec.h"
-#include "Framework/OutputSpec.h"
-#include "Framework/DataAllocator.h"
-#include <fairmq/FairMQParts.h>
 #include <vector>
 #include <functional>
 
+class FairMQParts;
+class FairMQDevice;
+
 namespace o2 {
 namespace framework {
+  class OutputSpec;
+
   using InjectorFunction = std::function<void(FairMQDevice &device, FairMQParts& inputs, int index)>;
 
   /// Helper function which takes a set of inputs coming from a device,

--- a/Framework/Core/include/Framework/MessageContext.h
+++ b/Framework/Core/include/Framework/MessageContext.h
@@ -10,27 +10,30 @@
 #ifndef FRAMEWORK_MESSAGECONTEXT_H
 #define FRAMEWORK_MESSAGECONTEXT_H
 
-#include <fairmq/FairMQParts.h>
-#include <vector>
 #include <cassert>
+#include <memory>
 #include <string>
+#include <vector>
+
+class FairMQMessage;
 
 namespace o2 {
 namespace framework {
 
 class MessageContext {
 public:
+  using Parts = std::vector<std::unique_ptr<FairMQMessage>>;
   struct MessageRef {
-    FairMQParts parts;
+    Parts parts;
     std::string channel;
   };
   using Messages = std::vector<MessageRef>;
 
-  void addPart(FairMQParts &&parts, const std::string &channel) {
-    assert(parts.Size() == 2);
+  void addPart(Parts &&parts, const std::string &channel) {
+    assert(parts.size() == 2);
     mMessages.push_back(std::move(MessageRef{std::move(parts), channel}));
-    assert(parts.Size() == 0);
-    assert(mMessages.back().parts.Size() == 2);
+    assert(parts.size() == 0);
+    assert(mMessages.back().parts.size() == 2);
   }
 
   Messages::iterator begin()
@@ -55,7 +58,7 @@ public:
   {
     // Verify that everything has been sent on clear.
     for (auto &m : mMessages) {
-      assert(m.parts.Size() == 0);
+      assert(m.parts.size() == 0);
     }
     mMessages.clear();
     mTimeslice = timeslice;

--- a/Framework/Core/src/DataProcessor.cxx
+++ b/Framework/Core/src/DataProcessor.cxx
@@ -24,12 +24,13 @@ namespace framework {
 void DataProcessor::doSend(FairMQDevice &device, MessageContext &context) {
   for (auto &message : context) {
  //     metricsService.post("outputs/total", message.parts.Size());
-    assert(message.parts.Size() == 2);
-    FairMQParts parts = std::move(message.parts);
-    assert(message.parts.Size() == 0);
+    assert(message.parts.size() == 2);
+    FairMQParts parts;
+    parts.fParts = std::move(message.parts);
+    assert(message.parts.size() == 0);
     assert(parts.Size() == 2);
     device.Send(parts, message.channel, 0);
-    assert(parts.Size() == 2);
+    assert(parts.fParts.size() == 2);
   }
 }
 


### PR DESCRIPTION
Where possible, use forward declarations for FairMQParts, FairMQMessage
in order to reduce chance to bring in Boost stuff.