### PR TITLE
Allow the creation of a(n almost) full geometry w/o a prior VMC instance

### DIFF
--- a/Detectors/Base/src/Detector.cxx
+++ b/Detectors/Base/src/Detector.cxx
@@ -18,8 +18,8 @@
 #include "Field/MagneticField.h"
 #include "TString.h" // for TString
 
-using std::endl;
 using std::cout;
+using std::endl;
 using std::fstream;
 using std::ios;
 using std::ostream;
@@ -95,19 +95,21 @@ void Detector::defineLayerTurbo(Int_t nlay, Double_t phi0, Double_t r, Int_t nla
 
 void Detector::initFieldTrackingParams(int& integration, float& maxfield)
 {
-  auto vmc = TVirtualMC::GetMC();
-  auto field = vmc->GetMagField();
   // set reasonable default values
   integration = 2;
   maxfield = 10;
-  // see if we can query the o2 field
-  if (auto o2field = dynamic_cast<o2::field::MagneticField*>(field)) {
-    integration = o2field->Integral(); // default integration method?
-    maxfield = o2field->Max();
-  } else {
-    LOG(INFO) << "No magnetic field found; using default tracking values " << integration << " " << maxfield
-              << " to initialize media\n";
+  auto vmc = TVirtualMC::GetMC();
+  if (vmc) {
+    auto field = vmc->GetMagField();
+    // see if we can query the o2 field
+    if (auto o2field = dynamic_cast<o2::field::MagneticField*>(field)) {
+      integration = o2field->Integral(); // default integration method?
+      maxfield = o2field->Max();
+      return;
+    }
   }
+  LOG(INFO) << "No magnetic field found; using default tracking values " << integration << " " << maxfield
+            << " to initialize media\n";
 }
 
 TClonesArray* Detector::GetCollection(int) const

--- a/macro/o2sim.C
+++ b/macro/o2sim.C
@@ -31,7 +31,7 @@ void o2sim()
   auto genconfig = confref.getGenerator();
 
   auto run = new FairRunSim();
-  run->SetImportTGeoToVMC(false); // do not import TGeo to VMC since the latter is built together with TGeo
+  run->SetImportTGeoToVMC(true); // geometry is created by TGeo and then fed to VMC
   run->SetSimSetup([confref]() { o2::SimSetup::setup(confref.getMCEngine().c_str()); });
   std::string outputfilename = confref.getOutPrefix() + ".root";
   run->SetOutputFile(outputfilename.c_str());  // Output file

--- a/macro/o2sim.C
+++ b/macro/o2sim.C
@@ -31,7 +31,8 @@ void o2sim()
   auto genconfig = confref.getGenerator();
 
   auto run = new FairRunSim();
-  run->SetImportTGeoToVMC(true); // geometry is created by TGeo and then fed to VMC
+  //run->SetImportTGeoToVMC(true); // geometry is created by TGeo and then fed to VMC
+  run->SetImportTGeoToVMC(false); // do not import TGeo to VMC since the latter is built together with TGeo
   run->SetSimSetup([confref]() { o2::SimSetup::setup(confref.getMCEngine().c_str()); });
   std::string outputfilename = confref.getOutPrefix() + ".root";
   run->SetOutputFile(outputfilename.c_str());  // Output file


### PR DESCRIPTION
Decoupling TGeo material creation from VMC (i.e. can now build TGeo material without having to instantiate first a TGeant3TGeo or TGeant4 object)

This is done by inverting the current responsabilities. TGeo is now the master in charge of
 creating the geometry, and VMC is just the client taking the geometry
 from TGeo (and possibly tweaking media properties which cannot be
 handled by TGeo itself).

The net advantage is to get a lighter dependency tree and is useful e.g. to build a geometry within a unit test.