### PR TITLE
Fix the dependency of checksimkinematics_G3 test.

### DIFF
--- a/run/CMakeLists.txt
+++ b/run/CMakeLists.txt
@@ -44,15 +44,15 @@ if (HAVESIMULATION)
   add_test(NAME o2sim_G3
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   COMMAND ${CMAKE_BINARY_DIR}/bin/o2sim -n 2 -m PIPE ITS TPC TRD TOF EMC PHS -e TGeant3)
-  set_tests_properties(o2sim_G3 PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished succesfully")
-  # sets the necessary environment
-  set_tests_properties(o2sim_G3 PROPERTIES ENVIRONMENT VMCWORKDIR=${CMAKE_SOURCE_DIR})  # o2sim_G4
+  set_tests_properties(o2sim_G3 PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished succesfully"
+                                           ENVIRONMENT VMCWORKDIR=${CMAKE_SOURCE_DIR} FIXTURES_SETUP G3) 
+  
   add_test(NAME checksimkinematics_G3
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     COMMAND root -n -b -l -q ${CMAKE_SOURCE_DIR}/DataFormats/simulation/test/checkStack.C)
-  set_property(TEST checksimkinematics_G3 PROPERTY DEPENDS o2sim_G3 PASS_REGULAR_EXPRESSION "STACK TEST SUCCESSFULL")
-  set_property(TEST checksimkinematics_G3 APPEND PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}:${CMAKE_BINARY_DIR}/lib")
-  set_property(TEST checksimkinematics_G3 APPEND PROPERTY ENVIRONMENT "DYLD_LIBRARY_PATH=$ENV{DYLD_LIBRARY_PATH}:${CMAKE_BINARY_DIR}/lib")
+  set_tests_properties(checksimkinematics_G3 PROPERTIES FIXTURES_REQUIRED G3 
+                                                        ENVIRONMENT "LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}:${CMAKE_BINARY_DIR}/lib")
+
   #set_property(TEST checksimkinematics_G4 PROPERTY DEPENDS o2sim_G4 PASS_REGULAR_EXPRESSION "STACK TEST SUCCESSFULL")
   #set_property(TEST checksimkinematics_G4 APPEND PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}:${CMAKE_BINARY_DIR}/lib")
   #set_property(TEST checksimkinematics_G4 APPEND PROPERTY ENVIRONMENT "DYLD_LIBRARY_PATH=$ENV{DYLD_LIBRARY_PATH}:${CMAKE_BINARY_DIR}/lib")


### PR DESCRIPTION
so that `ctest -R checksim` will run first o2sim_G3 and then (if successfull) checksimkinematics_G3.

Before this PR : 

```
> ctest -R checksim -N
Test #101: checksimkinematics_G3
```

showing only one test would be ran.

After this PR : 

```
❯ ctest -R checksim -N
  Test  #99: o2sim_G3
  Test #100: checksimkinematics_G3
```

correctly showing the dependent test.
 