### PR TITLE
Make header::Stack allocator aware

### DIFF
--- a/DataFormats/Headers/src/DataHeader.cxx
+++ b/DataFormats/Headers/src/DataHeader.cxx
@@ -27,9 +27,6 @@
 //the answer to life and everything
 const uint32_t o2::header::BaseHeader::sMagicString = String2<uint32_t>("O2O2");
 
-//definitions for Stack statics
-std::default_delete<byte[]> o2::header::Stack::sDeleter;
-
 //storage for BaseHeader static members, all invalid
 const uint32_t o2::header::BaseHeader::sVersion = o2::header::gInvalidToken32;
 const o2::header::HeaderType o2::header::BaseHeader::sHeaderType = o2::header::gInvalidToken64;

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -50,7 +50,7 @@ find_package(HEPMC)
 #find_package(IWYU)
 find_package(DDS)
 
-find_package(Boost 1.59 COMPONENTS thread system timer program_options random filesystem chrono exception regex serialization log log_setup unit_test_framework date_time signals REQUIRED)
+find_package(Boost 1.59 COMPONENTS container thread system timer program_options random filesystem chrono exception regex serialization log log_setup unit_test_framework date_time signals REQUIRED)
 # for the guideline support library
 include_directories(${MS_GSL_INCLUDE_DIR})
 
@@ -433,6 +433,7 @@ o2_define_bucket(
     common_boost_bucket
     Boost::thread
     Boost::serialization
+    Boost::container
     pthread
 
     INCLUDE_DIRECTORIES


### PR DESCRIPTION
- add possibility to specify a polymorphic allocator (now boost, switch
  to std::pmr after switch to C++17)
- Require that the stack starts with a DataHeader
- avoid unnecessary copy constructions by using perfect forwarding

The defaults are backward compatible with what we have so far. I'll add allocators that will couple this to FairMQ + example use in a different pull request.