### PR TITLE
Be able to store/load RunContext

### DIFF
--- a/Steer/include/Steer/HitProcessingManager.h
+++ b/Steer/include/Steer/HitProcessingManager.h
@@ -43,6 +43,8 @@ struct EventPart {
 class RunContext
 {
  public:
+  RunContext() : mNofEntries{ 0 }, mMaxPartNumber{ 0 }, mEventRecords(), mEventParts() {}
+
   TBranch* getBranch(std::string_view name, int sourceid = 0) const
   {
     if (mChains[sourceid]) {
@@ -63,8 +65,8 @@ class RunContext
   void printCollisionSummary() const;
 
  private:
-  int mNofEntries;
-  int mMaxPartNumber; // max number of parts in any given collision
+  int mNofEntries = 0;
+  int mMaxPartNumber = 0; // max number of parts in any given collision
   std::vector<o2::MCInteractionRecord> mEventRecords;
   // for each collision we record the constituents (which shall not exceed mMaxPartNumber)
   std::vector<std::vector<EventPart>> mEventParts;
@@ -112,6 +114,11 @@ class HitProcessingManager
   void setupRun(int ncollisions = -1);
 
   const RunContext& getRunContext() { return mRunContext; }
+
+  // serializes the runcontext to file
+  void writeRunContext(const char* filename) const;
+  // setup run from serialized context; returns true if ok
+  bool setupRunFromExistingContext(const char* filename);
 
  private:
   HitProcessingManager() : mSimChains() {}

--- a/Steer/src/HitProcessingManager.cxx
+++ b/Steer/src/HitProcessingManager.cxx
@@ -13,6 +13,8 @@
 #include <vector>
 #include <map>
 #include <iostream>
+#include <TFile.h>
+#include <TClass.h>
 
 ClassImp(o2::steer::HitProcessingManager);
 
@@ -99,6 +101,8 @@ void HitProcessingManager::setupRun(int ncollisions)
 
 void RunContext::printCollisionSummary() const
 {
+  std::cout << "Summary of RunContext --\n";
+  std::cout << "Number of Collisions " << mEventRecords.size() << "\n";
   for (int i = 0; i < mEventRecords.size(); ++i) {
     std::cout << "Collision " << i << " TIME " << mEventRecords[i].timeNS;
     for (auto& e : mEventParts[i]) {
@@ -107,5 +111,28 @@ void RunContext::printCollisionSummary() const
     std::cout << "\n";
   }
 }
+
+void HitProcessingManager::writeRunContext(const char* filename) const
+{
+  TFile file(filename, "RECREATE");
+  auto cl = TClass::GetClass(typeid(mRunContext));
+  file.WriteObjectAny(&mRunContext, cl, "RunContext");
+  file.Close();
 }
+
+bool HitProcessingManager::setupRunFromExistingContext(const char* filename)
+{
+  RunContext* incontext = nullptr;
+  TFile file(filename, "OPEN");
+  file.GetObject("RunContext", incontext);
+
+  if (incontext) {
+    incontext->printCollisionSummary();
+    mRunContext = *incontext;
+    return true;
+  }
+  LOG(INFO) << "NO COLLISIONOBJECT FOUND";
+  return false;
 }
+} // end namespace steer
+} // end namespace o2


### PR DESCRIPTION
This should allow to execute (DPL) workflows for say the digitization of TPC and ITS separately since we can backup the sampled collisions and reuse them.