### PR TITLE
CDB acces for calibration parameter retrieval

### DIFF
--- a/Detectors/TPC/base/include/TPCBase/CDBInterface.h
+++ b/Detectors/TPC/base/include/TPCBase/CDBInterface.h
@@ -70,6 +70,13 @@ class CDBInterface
   /// \return noise object
   const CalPad& getNoise();
 
+  /// Return the gain map object
+  ///
+  /// The function checks if the object is already loaded and returns it
+  /// otherwise the object will be loaded first depending on the configuration
+  /// \return gain map object
+  const CalPad& getGainMap();
+
   /// Return the Detector parameters
   ///
   /// The function checks if the object is already loaded and returns it
@@ -106,16 +113,24 @@ class CDBInterface
   /// \param fileName name of the file containing pedestals and noise
   void setPedestalsAndNoiseFromFile(const std::string fileName) { mPedestalNoiseFileName = fileName; }
 
+  /// Set gain map from file
+  ///
+  /// This assumes that the objects is stored under the name 'Gain'
+  ///
+  /// \param fileName name of the file containing gain map
+  void setGainMapFromFile(const std::string fileName) { mGainMapFileName = fileName; }
+
   /// Force using default values instead of reading the CCDB
   ///
   /// \param default switch if to use default values
   void setUseDefaults(bool defaults = true) { mUseDefaults = defaults; }
 
-  /// Reset the local pedestals and noise
-  void resetLocalPedestalsAndNoise()
+  /// Reset the local calibration
+  void resetLocalCalibration()
   {
     mPedestals.reset();
     mNoise.reset();
+    mGainMap.reset();
   }
 
  private:
@@ -124,18 +139,22 @@ class CDBInterface
   // ===| Pedestal and noise |==================================================
   std::unique_ptr<CalPad> mPedestals; ///< Pedestal object
   std::unique_ptr<CalPad> mNoise;     ///< Noise object
+  std::unique_ptr<CalPad> mGainMap;   ///< Gain map object
 
   // ===| switches and parameters |=============================================
   bool mUseDefaults = false; ///< use defaults instead of CCDB
 
   std::string mPedestalNoiseFileName; ///< optional file name for pedestal and noise data
+  std::string mGainMapFileName;       ///< optional file name for the gain map
 
   // ===========================================================================
   // ===| functions |===========================================================
   //
   void loadNoiseAndPedestalFromFile(); ///< load noise and pedestal values from mPedestalNoiseFileName
+  void loadGainMapFromFile();          ///< load gain map from mGainmapFileName
   void createDefaultPedestals();       ///< creation of default pedestals if requested
   void createDefaultNoise();           ///< creation of default noise if requested
+  void createDefaultGainMap();         ///< creation of default gain map if requested
 
   template <typename T>
   T& getObjectFromCDB(const o2::CDB::IdPath& path);

--- a/Detectors/TPC/base/test/testTPCCDBInterface.cxx
+++ b/Detectors/TPC/base/test/testTPCCDBInterface.cxx
@@ -136,6 +136,31 @@ BOOST_AUTO_TEST_CASE(CDBInterface_test_noise)
   checkCalPadEqual(data, dataRead);
 }
 
+/// \brief Test reading gain map object from the CDB using the TPC CDBInterface
+BOOST_AUTO_TEST_CASE(CDBInterface_test_gainmap)
+{
+  const int run = 2;
+  const int dataOffset = 1;
+  const std::string_view type = "Gain";
+
+  // ===| initialize CDB manager |==============================================
+  auto cdb = o2::CDB::Manager::Instance();
+  cdb->setDefaultStorage("local://O2CDB");
+
+  // ===| write test object |===================================================
+  auto data = writeCalPadObject(type, run, dataOffset);
+
+  // ===| TPC interface |=======================================================
+  auto& tpcCDB = CDBInterface::instance();
+
+  // ===| read object |=========================================================
+  cdb->setRun(run);
+  auto dataRead = tpcCDB.getGainMap();
+
+  // ===| checks |==============================================================
+  checkCalPadEqual(data, dataRead);
+}
+
 /// \brief Test reading ParameterDetector from the CDB using the TPC CDBInterface
 BOOST_AUTO_TEST_CASE(CDBInterface_test_ParameterDetector)
 {
@@ -256,6 +281,7 @@ BOOST_AUTO_TEST_CASE(CDBInterface_test_Default_ReadFromFile)
   // we need a copy here to do the comparison below
   auto pedestals = tpcCDB.getPedestals();
   auto noise = tpcCDB.getNoise();
+  auto gainmap = tpcCDB.getGainMap();
 
   // check interface for defaults
   tpcCDB.getParameterDetector();
@@ -264,22 +290,26 @@ BOOST_AUTO_TEST_CASE(CDBInterface_test_Default_ReadFromFile)
   tpcCDB.getParameterGEM();
 
   // ===| dump to file |========================================================
-  auto f = TFile::Open("Noise_Pedestal.root", "recreate");
+  auto f = TFile::Open("Calibration.root", "recreate");
   f->WriteObject(&pedestals, "Pedestals");
   f->WriteObject(&noise, "Noise");
+  f->WriteObject(&gainmap, "Gain");
   delete f;
 
   // ===| read from file |======================================================
   tpcCDB.setUseDefaults(false);
-  tpcCDB.resetLocalPedestalsAndNoise();
-  tpcCDB.setPedestalsAndNoiseFromFile("Noise_Pedestal.root");
+  tpcCDB.resetLocalCalibration();
+  tpcCDB.setPedestalsAndNoiseFromFile("Calibration.root");
+  tpcCDB.setGainMapFromFile("Calibration.root");
 
   auto& pedestalsFromFile = tpcCDB.getPedestals();
   auto& noiseFromFile = tpcCDB.getNoise();
+  auto& gainmapFromFile = tpcCDB.getGainMap();
 
   // ===| checks |==============================================================
   checkCalPadEqual(noise, noiseFromFile);
   checkCalPadEqual(pedestals, pedestalsFromFile);
+  checkCalPadEqual(gainmap, gainmapFromFile);
 }
 }
 }

--- a/Detectors/TPC/reconstruction/macro/testTracks.C
+++ b/Detectors/TPC/reconstruction/macro/testTracks.C
@@ -72,6 +72,8 @@ void testTracks(
   grClustersLoc3D->SetMarkerColor(kOrange + 2);
   grClustersLoc3D->SetMarkerSize(1);
 
+  SAMPAProcessing& sampaProcessing = SAMPAProcessing::instance();
+
   int clusCounter = 0;
   clusterTree->GetEntry(checkEvent);
   for (auto& clusterObject : *clusters) {
@@ -83,7 +85,7 @@ void testTracks(
     const GlobalPadNumber pad = mapper.globalPadNumber(PadPos(rowInSector, inputcluster->getPadMean()));
     const PadCentre& padCentre = mapper.padCentre(pad);
     const float localYfactor = (cru.side() == Side::A) ? -1.f : 1.f;
-    float zPosition = SAMPAProcessing::getZfromTimeBin(inputcluster->getTimeMean(), cru.side());
+    float zPosition = sampaProcessing.getZfromTimeBin(inputcluster->getTimeMean(), cru.side());
 
     LocalPosition3D posLoc(padCentre.X(), localYfactor * padCentre.Y(), zPosition);
     GlobalPosition3D posGlob = Mapper::LocalToGlobal(posLoc, cru.sector());
@@ -132,7 +134,7 @@ void testTracks(
         const GlobalPadNumber pad = mapper.globalPadNumber(PadPos(rowInSector, clusterObject.getPadMean()));
         const PadCentre& padCentre = mapper.padCentre(pad);
         const float localYfactor = (cru.side() == Side::A) ? -1.f : 1.f;
-        float zPosition = SAMPAProcessing::getZfromTimeBin(clusterObject.getTimeMean(), cru.side());
+        float zPosition = sampaProcessing.getZfromTimeBin(clusterObject.getTimeMean(), cru.side());
 
         LocalPosition3D clusLoc(padCentre.X(), localYfactor * padCentre.Y(), zPosition);
         GlobalPosition3D clusGlob = Mapper::LocalToGlobal(clusLoc, cru.sector());

--- a/Detectors/TPC/simulation/include/TPCSimulation/GEMAmplification.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/GEMAmplification.h
@@ -18,6 +18,9 @@
 #include "TPCBase/RandomRing.h"
 #include "TPCBase/ParameterGas.h"
 #include "TPCBase/ParameterGEM.h"
+#include "TPCBase/CRU.h"
+#include "TPCBase/PadPos.h"
+#include "TPCBase/CalDet.h"
 
 namespace o2
 {
@@ -26,7 +29,8 @@ namespace TPC
 
 /// \class GEMAmplification
 /// This class handles the amplification of electrons in the GEM stack
-/// The full amplification in a stack of four GEMs can be conducted, or each of the individual processes (Electrons collection, amplification and extraction) can be conducted individually
+/// The full amplification in a stack of four GEMs can be conducted, or each of the individual processes (Electrons
+/// collection, amplification and extraction) can be conducted individually
 
 class GEMAmplification
 {
@@ -49,6 +53,14 @@ class GEMAmplification
   /// \return Number of electrons after amplification in a full stack of four GEM foils
   int getStackAmplification(int nElectrons = 1);
 
+  /// Compute the number of electrons after amplification in a full stack of four GEM foils
+  /// taking into account local variations of the electron amplification
+  /// \param nElectrons Number of electrons arriving at the first amplification stage (GEM1)
+  /// \param cru CRU where the electron arrives
+  /// \param pos PadPos where the electron arrives
+  /// \return Number of electrons after amplification in a full stack of four GEM foils
+  int getStackAmplification(const CRU& cru, const PadPos& pos, int nElectrons = 1);
+
   /// Compute the number of electrons after amplification in a single GEM foil
   /// taking into account collection and extraction efficiencies and fluctuations of the GEM amplification
   /// \param nElectrons Number of electrons to be amplified
@@ -63,7 +75,8 @@ class GEMAmplification
   int getElectronLosses(int nElectrons, float probability);
 
   /// Compute the number of electrons after amplification in a single GEM foil
-  /// taking into account avalanche fluctuations (Polya for <500 electrons and Gaus (central limit theorem) for a larger number of electrons)
+  /// taking into account avalanche fluctuations (Polya for <500 electrons and Gaus (central limit theorem) for a
+  /// larger number of electrons)
   /// \param nElectrons Input number of electrons
   /// \param GEM Number of the GEM in the stack (1, 2, 3, 4)
   /// \return Number of electrons after amplification in the GEM
@@ -72,7 +85,8 @@ class GEMAmplification
  private:
   GEMAmplification();
 
-  /// Circular random buffer containing random Gaus values for gain fluctuation if the number of electrons is larger (central limit theorem)
+  /// Circular random buffer containing random Gaus values for gain fluctuation if the number of electrons is larger
+  /// (central limit theorem)
   RandomRing mRandomGaus;
   /// Circular random buffer containing flat random values for the collection/extraction
   RandomRing mRandomFlat;
@@ -81,6 +95,7 @@ class GEMAmplification
 
   const ParameterGEM* mGEMParam; ///< Caching of the parameter class to avoid multiple CDB calls
   const ParameterGas* mGasParam; ///< Caching of the parameter class to avoid multiple CDB calls
+  const CalPad* mGainMap;        ///< Caching of the parameter class to avoid multiple CDB calls
 };
 }
 }

--- a/Detectors/TPC/simulation/include/TPCSimulation/GEMAmplification.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/GEMAmplification.h
@@ -16,58 +16,72 @@
 #define ALICEO2_TPC_GEMAmplification_H_
 
 #include "TPCBase/RandomRing.h"
+#include "TPCBase/ParameterGas.h"
+#include "TPCBase/ParameterGEM.h"
 
-namespace o2 {
-namespace TPC {
-    
+namespace o2
+{
+namespace TPC
+{
+
 /// \class GEMAmplification
 /// This class handles the amplification of electrons in the GEM stack
 /// The full amplification in a stack of four GEMs can be conducted, or each of the individual processes (Electrons collection, amplification and extraction) can be conducted individually
-    
+
 class GEMAmplification
 {
-  public:
-      
-    /// Default constructor
-    GEMAmplification();
+ public:
+  /// Default constructor
+  static GEMAmplification& instance()
+  {
+    static GEMAmplification gemAmplification;
+    return gemAmplification;
+  }
 
-    /// Destructor
-    ~GEMAmplification();
+  /// Destructor
+  ~GEMAmplification();
 
-    /// Compute the number of electrons after amplification in a full stack of four GEM foils
-    /// \param nElectrons Number of electrons arriving at the first amplification stage (GEM1)
-    /// \return Number of electrons after amplification in a full stack of four GEM foils
-    int getStackAmplification(int nElectrons = 1);
-      
-    /// Compute the number of electrons after amplification in a single GEM foil
-    /// taking into account collection and extraction efficiencies and fluctuations of the GEM amplification
-    /// \param nElectrons Number of electrons to be amplified
-    /// \param GEM Number of the GEM in the stack (1, 2, 3, 4)
-    /// \return Number of electrons after amplification in a single GEM foil
-    int getSingleGEMAmplification(int nElectrons, int GEM);
-      
-    /// Compute the electron losses due to extraction or collection efficiencies
-    /// \param nElectrons Input number of electrons
-    /// \param probability Collection or extraction efficiency
-    /// \return Number of electrons after probable losses
-    int getElectronLosses(int nElectrons, float probability);
+  /// Update the OCDB parameters cached in the class. To be called once per event
+  void updateParameters();
 
-    /// Compute the number of electrons after amplification in a single GEM foil
-    /// taking into account avalanche fluctuations (Polya for <500 electrons and Gaus (central limit theorem) for a larger number of electrons)
-    /// \param nElectrons Input number of electrons
-    /// \param GEM Number of the GEM in the stack (1, 2, 3, 4)
-    /// \return Number of electrons after amplification in the GEM
-    int getGEMMultiplication(int nElectrons, int GEM);
+  /// Compute the number of electrons after amplification in a full stack of four GEM foils
+  /// \param nElectrons Number of electrons arriving at the first amplification stage (GEM1)
+  /// \return Number of electrons after amplification in a full stack of four GEM foils
+  int getStackAmplification(int nElectrons = 1);
 
-  private:
-    /// Circular random buffer containing random Gaus values for gain fluctuation if the number of electrons is larger (central limit theorem)
-    RandomRing     mRandomGaus;
-    /// Circular random buffer containing flat random values for the collection/extraction
-    RandomRing     mRandomFlat;
-    /// Container with random Polya distributions, one for each GEM in the stack
-    std::array<RandomRing, 4> mGain;
+  /// Compute the number of electrons after amplification in a single GEM foil
+  /// taking into account collection and extraction efficiencies and fluctuations of the GEM amplification
+  /// \param nElectrons Number of electrons to be amplified
+  /// \param GEM Number of the GEM in the stack (1, 2, 3, 4)
+  /// \return Number of electrons after amplification in a single GEM foil
+  int getSingleGEMAmplification(int nElectrons, int GEM);
+
+  /// Compute the electron losses due to extraction or collection efficiencies
+  /// \param nElectrons Input number of electrons
+  /// \param probability Collection or extraction efficiency
+  /// \return Number of electrons after probable losses
+  int getElectronLosses(int nElectrons, float probability);
+
+  /// Compute the number of electrons after amplification in a single GEM foil
+  /// taking into account avalanche fluctuations (Polya for <500 electrons and Gaus (central limit theorem) for a larger number of electrons)
+  /// \param nElectrons Input number of electrons
+  /// \param GEM Number of the GEM in the stack (1, 2, 3, 4)
+  /// \return Number of electrons after amplification in the GEM
+  int getGEMMultiplication(int nElectrons, int GEM);
+
+ private:
+  GEMAmplification();
+
+  /// Circular random buffer containing random Gaus values for gain fluctuation if the number of electrons is larger (central limit theorem)
+  RandomRing mRandomGaus;
+  /// Circular random buffer containing flat random values for the collection/extraction
+  RandomRing mRandomFlat;
+  /// Container with random Polya distributions, one for each GEM in the stack
+  std::array<RandomRing, 4> mGain;
+
+  const ParameterGEM* mGEMParam; ///< Caching of the parameter class to avoid multiple CDB calls
+  const ParameterGas* mGasParam; ///< Caching of the parameter class to avoid multiple CDB calls
 };
-  
 }
 }
 

--- a/Detectors/TPC/simulation/include/TPCSimulation/HitDriftFilter.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/HitDriftFilter.h
@@ -169,8 +169,9 @@ inline void getHits(std::vector<TChain*> const& chains, const o2::steer::RunCont
 
 // TPC hit selection lambda
 auto calcDriftTime = [](float tNS, float tof, float z) {
+  const static ElectronTransport& eleTrans = ElectronTransport::instance();
   // returns time in NS
-  return tNS + o2::TPC::ElectronTransport::getDriftTime(z) * 1000 + tof;
+  return tNS + eleTrans.getDriftTime(z) * 1000 + tof;
 };
 
 } // end namespace TPC

--- a/Detectors/TPC/simulation/src/DigitGlobalPad.cxx
+++ b/Detectors/TPC/simulation/src/DigitGlobalPad.cxx
@@ -29,15 +29,16 @@ void DigitGlobalPad::fillOutputContainer(std::vector<Digit>* output,
                                          GlobalPadNumber globalPad, float commonMode)
 {
   const static Mapper& mapper = Mapper::instance();
+  const static SAMPAProcessing& sampaProcessing = SAMPAProcessing::instance();
   const PadPos pad = mapper.padPos(globalPad);
 
-  /// The charge accumulated on that pad is converted into ADC counts, saturation of the SAMPA is applied and a Digit is
-  /// created in written out
+  /// The charge accumulated on that pad is converted into ADC counts, saturation of the SAMPA is applied and a Digit
+  /// is created in written out
   const float totalADC = mChargePad - commonMode; // common mode is subtracted here in order to properly apply noise,
                                                   // pedestals and saturation of the SAMPA
 
   float noise, pedestal;
-  const float mADC = SAMPAProcessing::makeSignal(totalADC, PadSecPos(cru.sector(), pad), pedestal, noise);
+  const float mADC = sampaProcessing.makeSignal(totalADC, PadSecPos(cru.sector(), pad), pedestal, noise);
 
   /// only write out the data if there is actually charge on that pad
   if (mADC > 0 && mChargePad > 0) {

--- a/Detectors/TPC/simulation/src/Digitizer.cxx
+++ b/Detectors/TPC/simulation/src/Digitizer.cxx
@@ -74,9 +74,12 @@ void Digitizer::ProcessHitGroup(const HitGroup& inputgroup, const Sector& sector
   const static ParameterDetector& detParam = ParameterDetector::defaultInstance();
   const static ParameterElectronics& eleParam = ParameterElectronics::defaultInstance();
 
-  static GEMAmplification gemAmplification;
-  static ElectronTransport electronTransport;
-  static PadResponse padResponse;
+  static GEMAmplification& gemAmplification = GEMAmplification::instance();
+  gemAmplification.updateParameters();
+  static ElectronTransport& electronTransport = ElectronTransport::instance();
+  electronTransport.updateParameters();
+  static SAMPAProcessing& sampaProcessing = SAMPAProcessing::instance();
+  sampaProcessing.updateParameters();
 
   const int nShapedPoints = eleParam.getNShapedPoints();
   static std::vector<float> signalArray;
@@ -133,12 +136,12 @@ void Digitizer::ProcessHitGroup(const HitGroup& inputgroup, const Sector& sector
       }
 
       const GlobalPadNumber globalPad = mapper.globalPadNumber(digiPadPos.getGlobalPadPos());
-      const float ADCsignal = SAMPAProcessing::getADCvalue(static_cast<float>(nElectronsGEM));
-      SAMPAProcessing::getShapedSignal(ADCsignal, absoluteTime, signalArray);
+      const float ADCsignal = sampaProcessing.getADCvalue(static_cast<float>(nElectronsGEM));
+      sampaProcessing.getShapedSignal(ADCsignal, absoluteTime, signalArray);
       for (float i = 0; i < nShapedPoints; ++i) {
         const float time = absoluteTime + i * eleParam.getZBinWidth();
         const MCCompLabel label(MCTrackID, eventID, sourceID);
-        mDigitContainer->addDigit(label, digiPadPos.getCRU(), SAMPAProcessing::getTimeBinFromTime(time), globalPad,
+        mDigitContainer->addDigit(label, digiPadPos.getCRU(), sampaProcessing.getTimeBinFromTime(time), globalPad,
                                   signalArray[i]);
       }
     }

--- a/Detectors/TPC/simulation/src/Digitizer.cxx
+++ b/Detectors/TPC/simulation/src/Digitizer.cxx
@@ -130,7 +130,7 @@ void Digitizer::ProcessHitGroup(const HitGroup& inputgroup, const Sector& sector
       }
 
       /// Electron amplification
-      const int nElectronsGEM = gemAmplification.getStackAmplification();
+      const int nElectronsGEM = gemAmplification.getStackAmplification(digiPadPos.getCRU(), digiPadPos.getPadPos());
       if (nElectronsGEM == 0) {
         continue;
       }

--- a/Detectors/TPC/simulation/src/GEMAmplification.cxx
+++ b/Detectors/TPC/simulation/src/GEMAmplification.cxx
@@ -81,6 +81,7 @@ void GEMAmplification::updateParameters()
   auto& cdb = CDBInterface::instance();
   mGEMParam = &(cdb.getParameterGEM());
   mGasParam = &(cdb.getParameterGas());
+  mGainMap = &(cdb.getGainMap());
 }
 
 int GEMAmplification::getStackAmplification(int nElectrons)
@@ -93,6 +94,13 @@ int GEMAmplification::getStackAmplification(int nElectrons)
   const int nElectronsGEM3 = getSingleGEMAmplification(nElectronsGEM2, 3);
   const int nElectronsGEM4 = getSingleGEMAmplification(nElectronsGEM3, 4);
   return nElectronsGEM4;
+}
+
+int GEMAmplification::getStackAmplification(const CRU& cru, const PadPos& pos, int nElectrons)
+{
+  /// Additionally to the electron amplification the final number of electrons is multiplied by the local gain on the
+  /// pad
+  return static_cast<int>(static_cast<float>(getStackAmplification(nElectrons)) * mGainMap->getValue(cru, pos.getRow(), pos.getPad()));
 }
 
 int GEMAmplification::getSingleGEMAmplification(int nElectrons, int GEM)

--- a/Detectors/TPC/simulation/src/GEMAmplification.cxx
+++ b/Detectors/TPC/simulation/src/GEMAmplification.cxx
@@ -13,12 +13,11 @@
 /// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
 
 #include "TPCSimulation/GEMAmplification.h"
-#include "TPCBase/ParameterGas.h"
-#include "TPCBase/ParameterGEM.h"
 #include <TStopwatch.h>
 #include <iostream>
 #include "MathUtils/CachingTF1.h"
 #include <TFile.h>
+#include "TPCBase/CDBInterface.h"
 
 using namespace o2::TPC;
 using boost::format;
@@ -28,60 +27,67 @@ GEMAmplification::GEMAmplification()
     mRandomFlat(),
     mGain()
 {
+  updateParameters();
+
   TStopwatch watch;
   watch.Start();
-  const static ParameterGas &gasParam = ParameterGas::defaultInstance();
-  const static ParameterGEM &gemParam = ParameterGEM::defaultInstance();
-  const float sigmaOverMu = gasParam.getSigmaOverMu();
-  const float kappa = 1/(sigmaOverMu*sigmaOverMu);
+  const float sigmaOverMu = mGasParam->getSigmaOverMu();
+  const float kappa = 1 / (sigmaOverMu * sigmaOverMu);
   boost::format polya("1/(TMath::Gamma(%1%)*%2%) *std::pow(x/%3%, %4%) *std::exp(-x/%5%)");
 
   bool cacheexists = false;
   // FIXME: this should come from the CCDB (just as the other parameters)
   auto outfile = TFile::Open(TString::Format("tpc_polyadist.root").Data());
-  if(outfile) {
-    cacheexists=true;
-  }
-  else {
+  if (outfile) {
+    cacheexists = true;
+  } else {
     outfile = TFile::Open(TString::Format("tpc_polyadist.root").Data(), "create");
   }
-    
-  for(int i=0; i<4; ++i) {
-    float s = gemParam.getAbsoluteGain(i+1)/kappa;
-    polya % kappa % s % s % (kappa-1) % s;
-      std::string name = polya.str();
-      o2::Base::CachingTF1* polyaDistribution = nullptr;
-      if (!cacheexists) {
-        polyaDistribution = new o2::Base::CachingTF1("polya", name.c_str(), 0, 10.f*gemParam.getAbsoluteGain(i+1));
-        /// this dramatically alters the speed with which the filling is executed... without this, the distribution makes discrete steps at every int
-        polyaDistribution->SetNpx(100000);
-      }
-      else {
-        polyaDistribution = (o2::Base::CachingTF1*)outfile->Get(TString::Format("func%d",i).Data());
-        // FIXME: verify that distribution corresponds to the parameters used here
-      }
+
+  for (int i = 0; i < 4; ++i) {
+    float s = mGEMParam->getAbsoluteGain(i + 1) / kappa;
+    polya % kappa % s % s % (kappa - 1) % s;
+    std::string name = polya.str();
+    o2::Base::CachingTF1* polyaDistribution = nullptr;
+    if (!cacheexists) {
+      polyaDistribution = new o2::Base::CachingTF1("polya", name.c_str(), 0, 10.f * mGEMParam->getAbsoluteGain(i + 1));
+      /// this dramatically alters the speed with which the filling is executed...
+      /// without this, the distribution makes discrete steps at every int
+      polyaDistribution->SetNpx(100000);
+    } else {
+      polyaDistribution = (o2::Base::CachingTF1*)outfile->Get(TString::Format("func%d", i).Data());
+      // FIXME: verify that distribution corresponds to the parameters used here
+    }
     mGain[i].initialize(*polyaDistribution);
-  
-    if(!cacheexists) {
-        outfile->WriteTObject(polyaDistribution, TString::Format("func%d",i).Data());
+
+    if (!cacheexists) {
+      outfile->WriteTObject(polyaDistribution, TString::Format("func%d", i).Data());
     }
     delete polyaDistribution;
   }
 
-  if(outfile) outfile->Close();
+  if (outfile)
+    outfile->Close();
   mRandomGaus.initialize(RandomRing::RandomType::Gaus);
   mRandomFlat.initialize(RandomRing::RandomType::Flat);
   watch.Stop();
   std::cerr << "GEM SETUP TOOK " << watch.CpuTime() << "\n";
 }
 
-GEMAmplification::~GEMAmplification()
-= default;
+GEMAmplification::~GEMAmplification() = default;
+
+void GEMAmplification::updateParameters()
+{
+  auto& cdb = CDBInterface::instance();
+  mGEMParam = &(cdb.getParameterGEM());
+  mGasParam = &(cdb.getParameterGas());
+}
 
 int GEMAmplification::getStackAmplification(int nElectrons)
 {
   /// We start with an arbitrary number of electrons given to the first amplification stage
-  /// The amplification in the GEM stack is handled for each electron individually and the resulting amplified electrons are passed to the next amplification stage.
+  /// The amplification in the GEM stack is handled for each electron individually and the resulting amplified
+  /// electrons are passed to the next amplification stage.
   const int nElectronsGEM1 = getSingleGEMAmplification(nElectrons, 1);
   const int nElectronsGEM2 = getSingleGEMAmplification(nElectronsGEM1, 2);
   const int nElectronsGEM3 = getSingleGEMAmplification(nElectronsGEM2, 3);
@@ -98,34 +104,33 @@ int GEMAmplification::getSingleGEMAmplification(int nElectrons, int GEM)
   /// The effective gain, and thus the overall amplification of the GEM is then given by
   /// G_eff  = ε_coll * G_abs * ε_extr
   /// Each of the three processes is handled by a sub-routine
-  const static ParameterGEM &gemParam = ParameterGEM::defaultInstance();
-  int collectionGEM    = getElectronLosses(nElectrons, gemParam.getCollectionEfficiency(GEM));
+  int collectionGEM = getElectronLosses(nElectrons, mGEMParam->getCollectionEfficiency(GEM));
   int amplificationGEM = getGEMMultiplication(collectionGEM, GEM);
-  int extractionGEM    = getElectronLosses(amplificationGEM, gemParam.getExtractionEfficiency(GEM));
+  int extractionGEM = getElectronLosses(amplificationGEM, mGEMParam->getExtractionEfficiency(GEM));
   return extractionGEM;
 }
 
 int GEMAmplification::getGEMMultiplication(int nElectrons, int GEM)
 {
-  const static ParameterGas &gasParam = ParameterGas::defaultInstance();
-  const static ParameterGEM &gemParam = ParameterGEM::defaultInstance();
-
   /// Total charge multiplication in the GEM
   /// We take into account fluctuations of the avalanche process
-  if(nElectrons < 1) {
+  if (nElectrons < 1) {
     /// All electrons are lost in case none are given to the GEM
     return 0;
-  }
-  else if(nElectrons > 500) {
-   /// For this condition the central limit theorem holds and we can approximate the amplification fluctuations by a Gaussian for all electrons
-   /// The mean is given by nElectrons * G_abs and the width by sqrt(nElectrons) * Sigma/Mu (Polya) * G_abs
-    return ((mRandomGaus.getNextValue() * std::sqrt(static_cast<float>(nElectrons)) * gasParam.getSigmaOverMu()) + nElectrons) * gemParam.getAbsoluteGain(GEM);
-  }
-  else {
-    /// Otherwise we compute the gain fluctuations as the convolution of many single electron amplification fluctuations
+  } else if (nElectrons > 500) {
+    /// For this condition the central limit theorem holds and we can approximate the amplification fluctuations by
+    ///a Gaussian for all electrons
+    /// The mean is given by nElectrons * G_abs and the width by sqrt(nElectrons) * Sigma/Mu (Polya) * G_abs
+    return ((mRandomGaus.getNextValue() * std::sqrt(static_cast<float>(nElectrons)) *
+             mGasParam->getSigmaOverMu()) +
+            nElectrons) *
+           mGEMParam->getAbsoluteGain(GEM);
+  } else {
+    /// Otherwise we compute the gain fluctuations as the convolution of many single electron amplification
+    /// fluctuations
     int electronsOut = 0;
-    for(int i=0; i<nElectrons; ++i) {
-      electronsOut+=mGain[GEM-1].getNextValue();
+    for (int i = 0; i < nElectrons; ++i) {
+      electronsOut += mGain[GEM - 1].getNextValue();
     }
     return electronsOut;
   }
@@ -135,27 +140,27 @@ int GEMAmplification::getElectronLosses(int nElectrons, float probability)
 {
   /// Electrons losses due to collection or extraction processes
   float electronsFloat = static_cast<float>(nElectrons);
-  if(nElectrons < 1 || probability < 0.00001) {
+  if (nElectrons < 1 || probability < 0.00001) {
     /// All electrons are lost in case none are given to the GEM, or the probability is negligible
     return 0;
-  }
-  else if(probability > 0.99999) {
+  } else if (probability > 0.99999) {
     /// For sufficiently large probabilities all electrons are passed further on
     return nElectrons;
-  }
-  else if(electronsFloat * probability >= 5.f && electronsFloat * (1.f-probability) >= 5.f) {
-    /// Condition whether the binomial distribution can be approximated by a Gaussian with mean n*p+0.5 and width sqrt(n*p*(1-p))
-    return (mRandomGaus.getNextValue() * std::sqrt(electronsFloat*probability*(1-probability))) + electronsFloat*probability +0.5;
-  }
-  else {
+  } else if (electronsFloat * probability >= 5.f && electronsFloat * (1.f - probability) >= 5.f) {
+    /// Condition whether the binomial distribution can be approximated by a Gaussian with mean n*p+0.5 and
+    /// width sqrt(n*p*(1-p))
+    return (mRandomGaus.getNextValue() * std::sqrt(electronsFloat * probability * (1 - probability))) +
+           electronsFloat * probability + 0.5;
+  } else {
     /// Explicit handling of the probability for each individual electron
-    /// \todo For further amplification of the process one could also just draw a random number from a binomial distribution, but it should be checked whether this is faster
+    /// \todo For further amplification of the process one could also just draw a random number from a binomial
+    /// distribution, but it should be checked whether this is faster
     int nElectronsOut = 0;
-    for(int i=0; i<nElectrons; ++i) {
-      if(mRandomFlat.getNextValue() < probability) {
-        ++ nElectronsOut;
+    for (int i = 0; i < nElectrons; ++i) {
+      if (mRandomFlat.getNextValue() < probability) {
+        ++nElectronsOut;
       }
     }
-  return nElectronsOut;
+    return nElectronsOut;
   }
 }

--- a/Detectors/TPC/simulation/test/testTPCDigitContainer.cxx
+++ b/Detectors/TPC/simulation/test/testTPCDigitContainer.cxx
@@ -22,6 +22,7 @@
 #include "TPCSimulation/DigitContainer.h"
 #include "TPCSimulation/DigitMCMetaData.h"
 #include "TPCSimulation/SAMPAProcessing.h"
+#include "TPCBase/CDBInterface.h"
 
 namespace o2
 {
@@ -33,6 +34,8 @@ namespace TPC
 /// conversion to digits
 BOOST_AUTO_TEST_CASE(DigitContainer_test1)
 {
+  auto& cdb = CDBInterface::instance();
+  cdb.setUseDefaults();
   const Mapper& mapper = Mapper::instance();
   const SAMPAProcessing& sampa = SAMPAProcessing::instance();
   DigitContainer digitContainer;
@@ -89,6 +92,8 @@ BOOST_AUTO_TEST_CASE(DigitContainer_test1)
 /// and that the MC labels are right
 BOOST_AUTO_TEST_CASE(DigitContainer_test2)
 {
+  auto& cdb = CDBInterface::instance();
+  cdb.setUseDefaults();
   const Mapper& mapper = Mapper::instance();
   const SAMPAProcessing& sampa = SAMPAProcessing::instance();
   DigitContainer digitContainer;

--- a/Detectors/TPC/simulation/test/testTPCElectronTransport.cxx
+++ b/Detectors/TPC/simulation/test/testTPCElectronTransport.cxx
@@ -19,6 +19,7 @@
 #include "TPCSimulation/ElectronTransport.h"
 #include "TPCBase/ParameterGas.h"
 #include "TPCBase/ParameterDetector.h"
+#include "TPCBase/CDBInterface.h"
 
 #include "TH1D.h"
 #include "TF1.h"
@@ -36,6 +37,8 @@ namespace TPC
 /// Precision: 0.5 %.
 BOOST_AUTO_TEST_CASE(ElectronDiffusion_test1)
 {
+  auto& cdb = CDBInterface::instance();
+  cdb.setUseDefaults();
   const static ParameterGas& gasParam = ParameterGas::defaultInstance();
   const static ParameterDetector& detParam = ParameterDetector::defaultInstance();
   const GlobalPosition3D posEle(10.f, 10.f, 10.f);
@@ -47,7 +50,7 @@ BOOST_AUTO_TEST_CASE(ElectronDiffusion_test1)
   TF1 gausY("gausY", "gaus");
   TF1 gausZ("gausZ", "gaus");
 
-  static ElectronTransport electronTransport;
+  static ElectronTransport& electronTransport = ElectronTransport::instance();
   float driftTime = 0.f;
 
   for (int i = 0; i < 500000; ++i) {
@@ -83,6 +86,8 @@ BOOST_AUTO_TEST_CASE(ElectronDiffusion_test1)
 /// Precision: 0.5 %.
 BOOST_AUTO_TEST_CASE(ElectronDiffusion_test2)
 {
+  auto& cdb = CDBInterface::instance();
+  cdb.setUseDefaults();
   const static ParameterGas& gasParam = ParameterGas::defaultInstance();
   const static ParameterDetector& detParam = ParameterDetector::defaultInstance();
   const GlobalPosition3D posEle(1.f, 1.f, detParam.getTPClength() - 1.f);
@@ -94,7 +99,7 @@ BOOST_AUTO_TEST_CASE(ElectronDiffusion_test2)
   TF1 gausY("gausY", "gaus");
   TF1 gausZ("gausZ", "gaus");
 
-  static ElectronTransport electronTransport;
+  static ElectronTransport& electronTransport = ElectronTransport::instance();
   float driftTime = 0.f;
 
   for (int i = 0; i < 500000; ++i) {
@@ -126,12 +131,14 @@ BOOST_AUTO_TEST_CASE(ElectronDiffusion_test2)
 /// Precision: 0.1 %.
 BOOST_AUTO_TEST_CASE(ElectronAttatchment_test_1)
 {
+  auto& cdb = CDBInterface::instance();
+  cdb.setUseDefaults();
   const static ParameterGas& gasParam = ParameterGas::defaultInstance();
-  static ElectronTransport electronTransport;
+  static ElectronTransport& electronTransport = ElectronTransport::instance();
 
   const float driftTime = 100.f;
   float lostElectrons = 0;
-  const float nEvents = 500000;
+  const float nEvents = 1000000;
   for (int i = 0; i < nEvents; ++i) {
     if (electronTransport.isElectronAttachment(driftTime)) {
       ++lostElectrons;
@@ -139,7 +146,7 @@ BOOST_AUTO_TEST_CASE(ElectronAttatchment_test_1)
   }
 
   BOOST_CHECK_CLOSE(lostElectrons / nEvents,
-                    gasParam.getAttachmentCoefficient() * gasParam.getOxygenContent() * driftTime, 0.1);
+                    gasParam.getAttachmentCoefficient() * gasParam.getOxygenContent() * driftTime, 0.5);
 }
 }
 }

--- a/Detectors/TPC/simulation/test/testTPCGEMAmplification.cxx
+++ b/Detectors/TPC/simulation/test/testTPCGEMAmplification.cxx
@@ -19,120 +19,137 @@
 #include "TPCSimulation/GEMAmplification.h"
 #include "TPCBase/ParameterGas.h"
 #include "TPCBase/ParameterGEM.h"
+#include "TPCBase/CDBInterface.h"
 
 #include "TH1D.h"
 #include "TF1.h"
 
-namespace o2 {
-namespace TPC {
+namespace o2
+{
+namespace TPC
+{
 
-  /// \brief Test of the full GEM amplification
-  /// The full GEM amplification process is simulated and
-  /// the correct gain and energy resolution is tested
-  BOOST_AUTO_TEST_CASE(GEMamplification_test)
-  {
-    const static ParameterGEM &gemParam = ParameterGEM::defaultInstance();
-    static GEMAmplification gemStack;
-    TH1D hTest("hTest", "", 10000, 0, 1000000);
-    TF1 gaus("gaus", "gaus");
-    
-    const int nEleIn = 158; /// Number of electrons liberated in Ne-CO2-N2 by an incident Fe-55 photon
+/// \brief Test of the full GEM amplification
+/// The full GEM amplification process is simulated and
+/// the correct gain and energy resolution is tested
+BOOST_AUTO_TEST_CASE(GEMamplification_test)
+{
+  auto& cdb = CDBInterface::instance();
+  cdb.setUseDefaults();
+  const ParameterGEM& gemParam = cdb.getParameterGEM();
+  static GEMAmplification& gemStack = GEMAmplification::instance();
+  TH1D hTest("hTest", "", 10000, 0, 1000000);
+  TF1 gaus("gaus", "gaus");
 
-    for(int i=0; i < 100000; ++i) {
-      hTest.Fill(gemStack.getStackAmplification(nEleIn));
-    }
-    
-    hTest.Fit("gaus", "Q0");
-    float energyResolution = gaus.GetParameter(2)/gaus.GetParameter(1) *100.f;
+  const int nEleIn = 158; /// Number of electrons liberated in Ne-CO2-N2 by an incident Fe-55 photon
 
-    /// Check the resulting gain
-    /// \todo should be more restrictive
-    BOOST_CHECK_CLOSE(gaus.GetParameter(1)/static_cast<float>(nEleIn), (gemParam.getEffectiveGain(1) * gemParam.getEffectiveGain(2) * gemParam.getEffectiveGain(3)* gemParam.getEffectiveGain(4)), 20.f);
-    /// Check the resulting energy resolution
-    /// we allow for 5% variation which is given by the uncertainty of the experimental determination of the energy resolution (12.1 +/- 0.5) %
-    BOOST_CHECK_CLOSE(energyResolution, 12.1, 5);
+  for (int i = 0; i < 100000; ++i) {
+    hTest.Fill(gemStack.getStackAmplification(nEleIn));
   }
 
-  /// \brief Test of the getSingleGEMAmplification function
-  /// We filter 1000 electrons through a single GEM and compare to the outcome
-  BOOST_AUTO_TEST_CASE(GEMamplification_singleGEM_test)
-  {
-    const static ParameterGEM &gemParam = ParameterGEM::defaultInstance();
-    static GEMAmplification gemStack;
-    TH1D hTest("hTest", "", 10000, 0, 10000);
-    TF1 gaus("gaus", "gaus");
+  hTest.Fit("gaus", "Q0");
+  float energyResolution = gaus.GetParameter(2) / gaus.GetParameter(1) * 100.f;
 
-    for(int i=0; i < 100000; ++i) {
-      hTest.Fill(gemStack.getSingleGEMAmplification(1000, 1));
-    }
-
-    hTest.Fit("gaus", "Q0");
-
-    /// check the resulting gain
-    const float multiplication = gemParam.getEffectiveGain(1);
-    BOOST_CHECK_CLOSE(gaus.GetParameter(1), multiplication*1000.f, 0.1);
-  }
-
-  /// \brief Test of the getGEMMultiplication function
-  /// Different numbers of electrons are filtered through the loss function
-  /// which follows a binomial distribution
-  /// The outcome is compared to the expected value
-  BOOST_AUTO_TEST_CASE(GEMamplification_singleGEMmultiplication_test)
-  {
-    const static ParameterGEM &gemParam = ParameterGEM::defaultInstance();
-    const static ParameterGas &gasParam = ParameterGas::defaultInstance();
-    static GEMAmplification gemStack;
-    TH1D hTest("hTest", "", 10000, 0, 10000);
-    TH1D hTest2("hTest2", "", 10000, 0, 10000);
-    TF1 gaus("gaus", "gaus");
-
-    for(int i=0; i < 100000; ++i) {
-      hTest.Fill(gemStack.getGEMMultiplication(1000, 2));
-      hTest2.Fill(gemStack.getGEMMultiplication(100, 1));
-    }
-
-    hTest.Fit("gaus", "Q0");
-
-    /// All different cases are tested
-    /// -# case nElectrons < 1
-    BOOST_CHECK(gemStack.getGEMMultiplication(0, 1) == 0);
-    /// -# case nElectrons > 500 - Gaussian
-    BOOST_CHECK_CLOSE(gaus.GetParameter(1), gemParam.getAbsoluteGain(2)*1000.f, 0.1);
-    /// As a gaussian is used the mean is tested as well, but with reduced precision
-    BOOST_CHECK_CLOSE(gaus.GetParameter(2), std::sqrt(1000.f)*gasParam.getSigmaOverMu()*gemParam.getAbsoluteGain(2), 2.5);
-    /// -# case the probability is explicitly handled for each electron - the mean is a bad estimator, therefore larger tolerance
-    BOOST_CHECK_CLOSE(hTest2.GetMean(), gemParam.getAbsoluteGain(1)*100.f, 5);
-  }
-
-  /// \brief Test of the getElectronLosses function
-  /// Different numbers of electrons are filtered through the loss function
-  /// which follows a binomial distribution
-  /// The outcome is compared to the expected value
-  BOOST_AUTO_TEST_CASE(GEMamplification_losses_test)
-  {
-    static GEMAmplification gemStack;
-    TH1D hTest("hTest", "", 100, 0, 100);
-    TH1D hTest2("hTest2", "", 10, 0, 10);
-    TF1 gaus("gaus", "gaus");
-
-    for(int i=0; i < 100000; ++i) {
-      hTest.Fill(gemStack.getElectronLosses(100, 0.6));
-      hTest2.Fill(gemStack.getElectronLosses(10, 0.2));
-    }
-
-    hTest.Fit("gaus", "Q0");
-
-    /// All different cases are tested
-    /// -# case nElectrons < 1 || probability < 0.00001
-    BOOST_CHECK(gemStack.getElectronLosses(1, 0.000001) == 0);
-    /// -# case probability > 0.99999
-    BOOST_CHECK(gemStack.getElectronLosses(100, 1) == 100);
-    /// -# case binomial distribution can be approximated by gaussian
-    BOOST_CHECK_CLOSE(gaus.GetParameter(1), 60, 1.5);
-    /// As a gaussian is used the mean is tested as well
-    BOOST_CHECK_CLOSE(gaus.GetParameter(2), std::sqrt(100.f*0.6*(1-0.6)), 1.5);
-    /// -# case the probability is explicitly handled for each electron
-    BOOST_CHECK_CLOSE(hTest2.GetMean(), 2, 0.5);
-  }
+  /// Check the resulting gain
+  /// \todo should be more restrictive
+  BOOST_CHECK_CLOSE(gaus.GetParameter(1) / static_cast<float>(nEleIn),
+                    (gemParam.getEffectiveGain(1) *
+                     gemParam.getEffectiveGain(2) * gemParam.getEffectiveGain(3) * gemParam.getEffectiveGain(4)),
+                    20.f);
+  /// Check the resulting energy resolution
+  /// we allow for 5% variation which is given by the uncertainty of the experimental determination of the
+  /// energy resolution (12.1 +/- 0.5) %
+  BOOST_CHECK_CLOSE(energyResolution, 12.1, 5);
 }
-} 
+
+/// \brief Test of the getSingleGEMAmplification function
+/// We filter 1000 electrons through a single GEM and compare to the outcome
+BOOST_AUTO_TEST_CASE(GEMamplification_singleGEM_test)
+{
+  auto& cdb = CDBInterface::instance();
+  cdb.setUseDefaults();
+  const ParameterGEM& gemParam = cdb.getParameterGEM();
+  static GEMAmplification& gemStack = GEMAmplification::instance();
+  TH1D hTest("hTest", "", 10000, 0, 10000);
+  TF1 gaus("gaus", "gaus");
+
+  for (int i = 0; i < 100000; ++i) {
+    hTest.Fill(gemStack.getSingleGEMAmplification(1000, 1));
+  }
+
+  hTest.Fit("gaus", "Q0");
+
+  /// check the resulting gain
+  const float multiplication = gemParam.getEffectiveGain(1);
+  BOOST_CHECK_CLOSE(gaus.GetParameter(1), multiplication * 1000.f, 0.1);
+}
+
+/// \brief Test of the getGEMMultiplication function
+/// Different numbers of electrons are filtered through the loss function
+/// which follows a binomial distribution
+/// The outcome is compared to the expected value
+BOOST_AUTO_TEST_CASE(GEMamplification_singleGEMmultiplication_test)
+{
+  auto& cdb = CDBInterface::instance();
+  cdb.setUseDefaults();
+  const ParameterGEM& gemParam = cdb.getParameterGEM();
+  const ParameterGas& gasParam = cdb.getParameterGas();
+  static GEMAmplification& gemStack = GEMAmplification::instance();
+  TH1D hTest("hTest", "", 10000, 0, 10000);
+  TH1D hTest2("hTest2", "", 10000, 0, 10000);
+  TF1 gaus("gaus", "gaus");
+
+  for (int i = 0; i < 100000; ++i) {
+    hTest.Fill(gemStack.getGEMMultiplication(1000, 2));
+    hTest2.Fill(gemStack.getGEMMultiplication(100, 1));
+  }
+
+  hTest.Fit("gaus", "Q0");
+
+  /// All different cases are tested
+  /// -# case nElectrons < 1
+  BOOST_CHECK(gemStack.getGEMMultiplication(0, 1) == 0);
+  /// -# case nElectrons > 500 - Gaussian
+  BOOST_CHECK_CLOSE(gaus.GetParameter(1), gemParam.getAbsoluteGain(2) * 1000.f, 0.1);
+  /// As a gaussian is used the mean is tested as well, but with reduced precision
+  BOOST_CHECK_CLOSE(gaus.GetParameter(2),
+                    std::sqrt(1000.f) * gasParam.getSigmaOverMu() * gemParam.getAbsoluteGain(2), 2.5);
+  /// -# case the probability is explicitly handled for each electron - the mean is a bad estimator,
+  /// therefore larger tolerance
+  BOOST_CHECK_CLOSE(hTest2.GetMean(), gemParam.getAbsoluteGain(1) * 100.f, 5);
+}
+
+/// \brief Test of the getElectronLosses function
+/// Different numbers of electrons are filtered through the loss function
+/// which follows a binomial distribution
+/// The outcome is compared to the expected value
+BOOST_AUTO_TEST_CASE(GEMamplification_losses_test)
+{
+  auto& cdb = CDBInterface::instance();
+  cdb.setUseDefaults();
+  static GEMAmplification& gemStack = GEMAmplification::instance();
+  TH1D hTest("hTest", "", 100, 0, 100);
+  TH1D hTest2("hTest2", "", 10, 0, 10);
+  TF1 gaus("gaus", "gaus");
+
+  for (int i = 0; i < 1000000; ++i) {
+    hTest.Fill(gemStack.getElectronLosses(100, 0.6));
+    hTest2.Fill(gemStack.getElectronLosses(10, 0.2));
+  }
+
+  hTest.Fit("gaus", "Q0");
+
+  /// All different cases are tested
+  /// -# case nElectrons < 1 || probability < 0.00001
+  BOOST_CHECK(gemStack.getElectronLosses(1, 0.000001) == 0);
+  /// -# case probability > 0.99999
+  BOOST_CHECK(gemStack.getElectronLosses(100, 1) == 100);
+  /// -# case binomial distribution can be approximated by gaussian
+  BOOST_CHECK_CLOSE(gaus.GetParameter(1), 60, 1.5);
+  /// As a gaussian is used the mean is tested as well
+  BOOST_CHECK_CLOSE(gaus.GetParameter(2), std::sqrt(100.f * 0.6 * (1 - 0.6)), 1.5);
+  /// -# case the probability is explicitly handled for each electron
+  BOOST_CHECK_CLOSE(hTest2.GetMean(), 2, 1.5);
+}
+}
+}

--- a/Steer/DigitizerWorkflow/src/TPCDriftTimeDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TPCDriftTimeDigitizerSpec.cxx
@@ -30,6 +30,7 @@
 #include "TStopwatch.h"
 #include <sstream>
 #include <algorithm>
+#include "TPCBase/CDBInterface.h"
 
 using namespace o2::framework;
 using SubSpecificationType = o2::framework::DataAllocator::SubSpecificationType;
@@ -55,6 +56,11 @@ std::string getBranchNameRight(int sector)
 DataProcessorSpec getTPCDriftTimeDigitizer(int channel, bool cachehits)
 {
   TChain* simChain = new TChain("o2sim");
+
+  /// For the time being use the defaults for the CDB
+  auto& cdb = o2::TPC::CDBInterface::instance();
+  cdb.setUseDefaults();
+
   //
   auto simChains = std::make_shared<std::vector<TChain*>>();
   auto digitizertask = std::make_shared<o2::TPC::DigitizerTask>();


### PR DESCRIPTION
o temporarily cached in the corresponding classes to avoid performance bias due to many CDB queries
o cached parameters are updated for every event
o removal of many static functions as a preparation for code re-structurization
o Prepare option to decalibrate with a gain map