### PR TITLE
Fix issues in Pythia8Generator header

### DIFF
--- a/Generators/include/Generators/Pythia8Generator.h
+++ b/Generators/include/Generators/Pythia8Generator.h
@@ -25,6 +25,7 @@
 
 #include "FairGenerator.h"   // for FairGenerator
 #include "Rtypes.h"          // for Double_t, Bool_t, Int_t, etc
+#include <memory>
 
 class FairPrimaryGenerator;
 namespace Pythia8
@@ -62,8 +63,8 @@ class Pythia8Generator : public FairGenerator
   void GetPythiaInstance(int);
 
  private:
-  Pythia8::Pythia* mPythia;           //!
-  Pythia8::RndmEngine* mRandomEngine; //!
+  std::unique_ptr<Pythia8::Pythia> mPythia;           //!
+  std::unique_ptr<Pythia8::RndmEngine> mRandomEngine; //!
 
  protected:
 

--- a/Generators/include/Generators/Pythia8Generator.h
+++ b/Generators/include/Generators/Pythia8Generator.h
@@ -23,54 +23,19 @@
 #ifndef PNDP8GENERATOR_H
 #define PNDP8GENERATOR_H 1
 
-// Avoid the inclusion of dlfcn.h by Pyhtia.h that CINT is not able to process (avoid compile error on GCC > 5)
-#ifdef __CLING__
-#define _DLFCN_H_
-#define _DLFCN_H
-#endif
-
-#include "Pythia8/Basics.h"          // for RndmEngine
 #include "FairGenerator.h"   // for FairGenerator
-#include "Pythia8/Pythia.h"  // for Pythia
 #include "Rtypes.h"          // for Double_t, Bool_t, Int_t, etc
-#include "TRandom.h"         // for TRandom
-#include "TRandom1.h"        // for TRandom1
-#include "TRandom3.h"        // for TRandom3, gRandom
-class FairPrimaryGenerator;  // lines 22-22
 
 class FairPrimaryGenerator;
-using namespace Pythia8;
+namespace Pythia8
+{
+class Pythia;
+class RndmEngine;
+}
 namespace o2
 {
 namespace eventgen
 {
-
-class PyTr1Rng : public RndmEngine
-{
- public:
-  PyTr1Rng() {  rng = new TRandom1(gRandom->GetSeed()); };
-  ~PyTr1Rng() override = default;
-
-  Double_t flat() override { return rng->Rndm(); };
-
- private:
-  TRandom1 *rng; //!
-};
-
-class PyTr3Rng : public RndmEngine
-{
- public:
-  PyTr3Rng() {  rng = new TRandom3(gRandom->GetSeed()); };
-  ~PyTr3Rng() override = default;
-
-  Double_t flat() override { return rng->Rndm(); };
-
- private:
-  TRandom3 *rng; //!
-};
-
-
-
 
 class Pythia8Generator : public FairGenerator
 {
@@ -97,9 +62,8 @@ class Pythia8Generator : public FairGenerator
   void GetPythiaInstance(int);
 
  private:
-
-  Pythia mPythia;             //!
-  RndmEngine* mRandomEngine;  //!
+  Pythia8::Pythia* mPythia;           //!
+  Pythia8::RndmEngine* mRandomEngine; //!
 
  protected:
 

--- a/Generators/src/Pythia8Generator.cxx
+++ b/Generators/src/Pythia8Generator.cxx
@@ -22,9 +22,13 @@
 
 #include <cmath>
 #include "TROOT.h"
+#include "Pythia8/Basics.h"          // for RndmEngine
 #include "Pythia8/Pythia.h"
 #include "FairPrimaryGenerator.h"
 //#include "FairGenerator.h"
+#include "TRandom.h"         // for TRandom
+#include "TRandom1.h"        // for TRandom1
+#include "TRandom3.h"        // for TRandom3, gRandom
 
 #include "Generators/Pythia8Generator.h"
 
@@ -35,6 +39,30 @@ namespace o2
 namespace eventgen
 {
 
+class PyTr1Rng : public RndmEngine
+{
+ public:
+  PyTr1Rng() { rng = new TRandom1(gRandom->GetSeed()); };
+  ~PyTr1Rng() override = default;
+
+  Double_t flat() override { return rng->Rndm(); };
+
+ private:
+  TRandom1* rng; //!
+};
+
+class PyTr3Rng : public RndmEngine
+{
+ public:
+  PyTr3Rng() { rng = new TRandom3(gRandom->GetSeed()); };
+  ~PyTr3Rng() override = default;
+
+  Double_t flat() override { return rng->Rndm(); };
+
+ private:
+  TRandom3* rng; //!
+};
+
 // -----   Default constructor   -------------------------------------------
 Pythia8Generator::Pythia8Generator()
 {
@@ -43,6 +71,7 @@ Pythia8Generator::Pythia8Generator()
   mId         = 2212; // proton
   mMom        = 400;  // proton
   mHNL        = 0;    // HNL  if set to !=0, for example 9900014, only track
+  mPythia = new Pythia();
 }
 // -------------------------------------------------------------------------
 
@@ -52,7 +81,7 @@ Bool_t Pythia8Generator::Init()
   if (mUseRandom1) mRandomEngine = new PyTr1Rng();
   if (mUseRandom3) mRandomEngine = new PyTr3Rng();
 
-  mPythia.setRndmEnginePtr(mRandomEngine);
+  mPythia->setRndmEnginePtr(mRandomEngine);
 
   /** commenting these lines  
       as they would override external settings **/
@@ -69,7 +98,7 @@ Bool_t Pythia8Generator::Init()
   mPythia.settings.parm("Beams:pyB",    0.);
   mPythia.settings.parm("Beams:pzB",    0.);
   **/
-  mPythia.init();
+  mPythia->init();
   return kTRUE;
 }
 // -------------------------------------------------------------------------
@@ -86,19 +115,19 @@ Bool_t Pythia8Generator::ReadEvent(FairPrimaryGenerator* cpg)
   Int_t npart = 0;
   while(npart == 0)
     {
-      mPythia.next();
-      for(int i=0; i<mPythia.event.size(); i++)
+      mPythia->next();
+      for(int i=0; i<mPythia->event.size(); i++)
         {
-          if(mPythia.event[i].isFinal())
+          if(mPythia->event[i].isFinal())
             {
 // only send HNL decay products to G4
               if (mHNL != 0){
-                Int_t im = mPythia.event[i].mother1();
-                if (mPythia.event[im].id()==mHNL ){
+                Int_t im = mPythia->event[i].mother1();
+                if (mPythia->event[im].id()==mHNL ){
 // for the moment, hardcode 110m is maximum decay length
-                 Double_t z = mPythia.event[i].zProd();
-                 Double_t x = abs(mPythia.event[i].xProd());
-                 Double_t y = abs(mPythia.event[i].yProd());
+                 Double_t z = mPythia->event[i].zProd();
+                 Double_t x = abs(mPythia->event[i].xProd());
+                 Double_t y = abs(mPythia->event[i].yProd());
                  // cout<<"debug HNL decay pos "<<x<<" "<< y<<" "<< z <<endl;
                  if ( z < 11000. && z > 7000. && x<250. && y<250.) {
                    npart++;
@@ -109,42 +138,42 @@ Bool_t Pythia8Generator::ReadEvent(FairPrimaryGenerator* cpg)
             };
         };
 // happens if a charm particle being produced which does decay without producing a HNL. Try another event.
-//       if (npart == 0){ mPythia.event.list();}
+//       if (npart == 0){ mPythia->event.list();}
     };
-// cout<<"debug p8 event 0 " << mPythia.event[0].id()<< " "<< mPythia.event[1].id()<< " "<< mPythia.event[2].id()<< " "<< npart <<endl;
-  for(Int_t ii=0; ii<mPythia.event.size(); ii++){
-    if(mPythia.event[ii].isFinal())
+// cout<<"debug p8 event 0 " << mPythia->event[0].id()<< " "<< mPythia->event[1].id()<< " "<< mPythia->event[2].id()<< " "<< npart <<endl;
+  for(Int_t ii=0; ii<mPythia->event.size(); ii++){
+    if(mPythia->event[ii].isFinal())
       {
         Bool_t wanttracking=true;
         if (mHNL != 0){
-           Int_t im = mPythia.event[ii].mother1();
-           if (mPythia.event[im].id() != mHNL) {wanttracking=false;}
+           Int_t im = mPythia->event[ii].mother1();
+           if (mPythia->event[im].id() != mHNL) {wanttracking=false;}
         }
         if (  wanttracking ) {
-          Double_t z  = mPythia.event[ii].zProd();
-          Double_t x  = mPythia.event[ii].xProd();
-          Double_t y  = mPythia.event[ii].yProd();
-          Double_t pz = mPythia.event[ii].pz();
-          Double_t px = mPythia.event[ii].px();
-          Double_t py = mPythia.event[ii].py();
-          cpg->AddTrack((Int_t)mPythia.event[ii].id(),px,py,pz,x,y,z,
-                      (Int_t)mPythia.event[ii].mother1(),wanttracking);
-          // cout<<"debug p8->geant4 "<< wanttracking << " "<< ii <<  " " << mPythia.event[ii].id()<< " "<< mPythia.event[ii].mother1()<<" "<<x<<" "<< y<<" "<< z <<endl;
+          Double_t z  = mPythia->event[ii].zProd();
+          Double_t x  = mPythia->event[ii].xProd();
+          Double_t y  = mPythia->event[ii].yProd();
+          Double_t pz = mPythia->event[ii].pz();
+          Double_t px = mPythia->event[ii].px();
+          Double_t py = mPythia->event[ii].py();
+          cpg->AddTrack((Int_t)mPythia->event[ii].id(),px,py,pz,x,y,z,
+                      (Int_t)mPythia->event[ii].mother1(),wanttracking);
+          // cout<<"debug p8->geant4 "<< wanttracking << " "<< ii <<  " " << mPythia->event[ii].id()<< " "<< mPythia->event[ii].mother1()<<" "<<x<<" "<< y<<" "<< z <<endl;
         }
 //    virtual void AddTrack(Int_t pdgid, Double_t px, Double_t py, Double_t pz,
 //                          Double_t vx, Double_t vy, Double_t vz, Int_t parent=-1,Bool_t wanttracking=true,Double_t e=-9e9);
     };
-    if (mHNL != 0 && mPythia.event[ii].id() == mHNL){
-         Int_t im = (Int_t)mPythia.event[ii].mother1();
-         Double_t z  = mPythia.event[ii].zProd();
-         Double_t x  = mPythia.event[ii].xProd();
-         Double_t y  = mPythia.event[ii].yProd();
-         Double_t pz = mPythia.event[ii].pz();
-         Double_t px = mPythia.event[ii].px();
-         Double_t py = mPythia.event[ii].py();
-         cpg->AddTrack((Int_t)mPythia.event[im].id(),px,py,pz,x,y,z,0,false);
-         cpg->AddTrack((Int_t)mPythia.event[ii].id(),px,py,pz,x,y,z, im,false);
-         //cout<<"debug p8->geant4 "<< 0 << " "<< ii <<  " " << fake<< " "<< mPythia.event[ii].mother1()<<endl;
+    if (mHNL != 0 && mPythia->event[ii].id() == mHNL){
+         Int_t im = (Int_t)mPythia->event[ii].mother1();
+         Double_t z  = mPythia->event[ii].zProd();
+         Double_t x  = mPythia->event[ii].xProd();
+         Double_t y  = mPythia->event[ii].yProd();
+         Double_t pz = mPythia->event[ii].pz();
+         Double_t px = mPythia->event[ii].px();
+         Double_t py = mPythia->event[ii].py();
+         cpg->AddTrack((Int_t)mPythia->event[im].id(),px,py,pz,x,y,z,0,false);
+         cpg->AddTrack((Int_t)mPythia->event[ii].id(),px,py,pz,x,y,z, im,false);
+         //cout<<"debug p8->geant4 "<< 0 << " "<< ii <<  " " << fake<< " "<< mPythia->event[ii].mother1()<<endl;
       };
   }
 
@@ -158,18 +187,18 @@ Bool_t Pythia8Generator::ReadEvent(FairPrimaryGenerator* cpg)
 void Pythia8Generator::SetParameters(const char* par)
 {
   // Set Parameters
-    mPythia.readString(par);
-    cout<<R"(mPythia.readString(")"<<par<<R"("))"<<endl;
+    mPythia->readString(par);
+    cout<<R"(mPythia->readString(")"<<par<<R"("))"<<endl;
 }
 
 // -------------------------------------------------------------------------
 void Pythia8Generator::Print(){
-  mPythia.settings.listAll();
+  mPythia->settings.listAll();
 }
 // -------------------------------------------------------------------------
 void Pythia8Generator::GetPythiaInstance(int arg){
-  mPythia.particleData.list(arg) ;
-  cout<<"canDecay "<<mPythia.particleData.canDecay(arg)<<" "<<mPythia.particleData.mayDecay(arg)<<endl ;
+  mPythia->particleData.list(arg) ;
+  cout<<"canDecay "<<mPythia->particleData.canDecay(arg)<<" "<<mPythia->particleData.mayDecay(arg)<<endl ;
 }
 // -------------------------------------------------------------------------
 

--- a/Generators/src/Pythia8Generator.cxx
+++ b/Generators/src/Pythia8Generator.cxx
@@ -42,25 +42,25 @@ namespace eventgen
 class PyTr1Rng : public RndmEngine
 {
  public:
-  PyTr1Rng() { rng = new TRandom1(gRandom->GetSeed()); };
+  PyTr1Rng() { mRng = std::make_unique<TRandom1>(gRandom->GetSeed()); };
   ~PyTr1Rng() override = default;
 
-  Double_t flat() override { return rng->Rndm(); };
+  Double_t flat() override { return mRng->TRandom1::Rndm(); };
 
  private:
-  TRandom1* rng; //!
+  std::unique_ptr<TRandom1> mRng; //!
 };
 
 class PyTr3Rng : public RndmEngine
 {
  public:
-  PyTr3Rng() { rng = new TRandom3(gRandom->GetSeed()); };
+  PyTr3Rng() { mRng = std::make_unique<TRandom3>(gRandom->GetSeed()); };
   ~PyTr3Rng() override = default;
 
-  Double_t flat() override { return rng->Rndm(); };
+  Double_t flat() override { return mRng->TRandom3::Rndm(); };
 
  private:
-  TRandom3* rng; //!
+  std::unique_ptr<TRandom3> mRng; //!
 };
 
 // -----   Default constructor   -------------------------------------------
@@ -71,17 +71,17 @@ Pythia8Generator::Pythia8Generator()
   mId         = 2212; // proton
   mMom        = 400;  // proton
   mHNL        = 0;    // HNL  if set to !=0, for example 9900014, only track
-  mPythia = new Pythia();
+  mPythia = std::make_unique<Pythia>();
 }
 // -------------------------------------------------------------------------
 
 // -----   Default constructor   -------------------------------------------
 Bool_t Pythia8Generator::Init()
 {
-  if (mUseRandom1) mRandomEngine = new PyTr1Rng();
-  if (mUseRandom3) mRandomEngine = new PyTr3Rng();
+  if (mUseRandom1) mRandomEngine = std::make_unique<PyTr1Rng>();
+  if (mUseRandom3) mRandomEngine = std::make_unique<PyTr3Rng>();
 
-  mPythia->setRndmEnginePtr(mRandomEngine);
+  mPythia->setRndmEnginePtr(mRandomEngine.get());
 
   /** commenting these lines  
       as they would override external settings **/


### PR DESCRIPTION
The Pythia8Generator header had several issues:

- it included lots of header files from Pythia8, which notably
  let to a problem when dlfn is included as well
  (as Pythia8 redefines a symbol from dlfn for whatever reason)

- This problem is now solved by forward declarations, also
  leading to faster compilation

- Also avoiding a global "using namespace" in a header file