### PR TITLE
Geant3 or 4 libs are one step above the [package]Config.cmake file

### DIFF
--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -8,7 +8,7 @@ function(guess_append_libpath _libname _root)
   # not being relocated properly, leading to broken builds if reusing builds
   # produced under different hosts/paths.
   unset(_lib CACHE)  # force find_library to look again
-  find_library(_lib "${_libname}" HINTS "${_root}" NO_DEFAULT_PATH PATH_SUFFIXES lib lib64)
+  find_library(_lib "${_libname}" HINTS "${_root}" "${_root}/.." NO_DEFAULT_PATH PATH_SUFFIXES lib lib64)
   if(_lib)
     get_filename_component(_libdir "${_lib}" DIRECTORY)
     message(STATUS "Adding library path: ${_libdir}")


### PR DESCRIPTION
Trying to compile #1144 on Linux I noticed the simulation build was not correctly setup (which btw can also be seen in the CI logs). This PR should fix that.