### PR TITLE
Introduce customizable CompletionPolicy

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -24,6 +24,8 @@ endif()
 set(SRCS
     src/BoostOptionsRetriever.cxx
     src/ConfigParamsHelper.cxx
+    src/CompletionPolicy.cxx
+    src/CompletionPolicyHelpers.cxx
     src/ChannelConfigurationPolicy.cxx
     src/ChannelConfigurationPolicyHelpers.cxx
     src/DataAllocator.cxx

--- a/Framework/Core/include/Framework/CompletionPolicy.h
+++ b/Framework/Core/include/Framework/CompletionPolicy.h
@@ -1,0 +1,72 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef FRAMEWORK_COMPLETIONPOLICY_H
+#define FRAMEWORK_COMPLETIONPOLICY_H
+
+#include "Framework/PartRef.h"
+
+#include <functional>
+#include <string>
+#include <vector>
+
+#include <gsl/span>
+
+namespace o2
+{
+namespace framework
+{
+
+struct DeviceSpec;
+struct InputRecord;
+
+/// Policy to describe what to do for a matching DeviceSpec
+/// whenever a new message arrives. The InputRecord being passed to 
+/// Callback is the partial input record received that far.
+struct CompletionPolicy {
+  /// Action to take with the InputRecord:
+  ///
+  enum struct CompletionOp {
+    /// Run the ProcessCallback on the InputRecord, consuming
+    /// its contents. Messages which have to be forwarded downstream
+    /// will be forwarded.
+    Consume,
+    /// Process: run the ProcessCallback on the InputRecord. Its contents /
+    /// will be kept but they will not be forwarded downstream.
+    Process,
+    /// Do not run the ProcessCallback. Its contents will be kept
+    /// and they will be proposed again when a new message for the same
+    /// record arrives. They will not be forwarded downstream.
+    Wait,
+    /// Do not run the ProcessCallback. Contents of the record will
+    /// be forwarded to the next consumer, if any.
+    Discard
+  };
+
+  using Matcher = std::function<bool(DeviceSpec const& device)>;
+  using Callback = std::function<CompletionOp(gsl::span<PartRef const> const &)>;
+
+  /// Name of the policy itself.
+  std::string name;
+  /// Callback to be used to understand if the policy should apply 
+  /// to the given device.
+  Matcher matcher;
+  /// Actual policy which decides what to do with a partial InputRecord.
+  Callback callback;
+
+  /// Helper to create the default configuration.
+  static std::vector<CompletionPolicy> createDefaultPolicies();
+};
+
+std::ostream& operator<<(std::ostream& oss, CompletionPolicy::CompletionOp const& val);
+
+} // namespace framework
+} // namespace o2
+
+#endif // FRAMEWORK_COMPLETIONPOLICY_H

--- a/Framework/Core/include/Framework/CompletionPolicyHelpers.h
+++ b/Framework/Core/include/Framework/CompletionPolicyHelpers.h
@@ -1,0 +1,42 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef FRAMEWORK_COMPLETIONPOLICYHELPERS_H
+#define FRAMEWORK_COMPLETIONPOLICYHELPERS_H
+
+#include "Framework/ChannelSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
+#include "Framework/CompletionPolicy.h"
+
+#include <functional>
+#include <string>
+
+namespace o2
+{
+namespace framework
+{
+
+/// Helper class which holds commonly used policies.
+struct CompletionPolicyHelpers {
+  /// Default Completion policy. When all the parts of a record have
+  /// arrived, consume them.
+  static CompletionPolicy consumeWhenAll();
+  /// When any of the parts of the record have been received, consume them.
+  static CompletionPolicy consumeWhenAny();
+  /// When any of the parts of the record have been received, process them,
+  /// without actually consuming them.
+  static CompletionPolicy processWhenAny();
+  /// Attach a given @a op to a device matching @name.
+  static CompletionPolicy defineByName(std::string const &name, CompletionPolicy::CompletionOp op);
+};
+
+} // namespace framework
+} // namespace o2
+
+#endif // FRAMEWORK_COMPLETIONPOLICYHELPERS_H

--- a/Framework/Core/include/Framework/DataRelayer.h
+++ b/Framework/Core/include/Framework/DataRelayer.h
@@ -12,6 +12,9 @@
 
 #include "Framework/InputRoute.h"
 #include "Framework/ForwardRoute.h"
+#include "Framework/CompletionPolicy.h"
+#include "Framework/PartRef.h"
+
 #include <cstddef>
 #include <vector>
 
@@ -37,13 +40,15 @@ public:
     int64_t value;
   };
 
-  // Reference to an inflight part.
-  struct PartRef {
-    std::unique_ptr<FairMQMessage> header;
-    std::unique_ptr<FairMQMessage> payload;
+  struct RecordAction {
+    size_t cacheLineIdx;
+    CompletionPolicy::CompletionOp op;
   };
 
-  DataRelayer(std::vector<InputRoute> const&, std::vector<ForwardRoute> const&, monitoring::Monitoring&);
+  DataRelayer(CompletionPolicy const&,
+              std::vector<InputRoute> const&,
+              std::vector<ForwardRoute> const&,
+              monitoring::Monitoring&);
 
   /// This is used to ask for relaying a given (header,payload) pair.
   /// Notice that we expect that the header is an O2 Header Stack
@@ -51,8 +56,8 @@ public:
   RelayChoice relay(std::unique_ptr<FairMQMessage> &&header,
                     std::unique_ptr<FairMQMessage> &&payload);
 
-  /// Returns the lines in the cache which are ready to be completed.
-  std::vector<int> getReadyToProcess();
+  /// @returns the actions ready to be performed.
+  std::vector<RecordAction> getReadyToProcess();
 
   /// Returns an input registry associated to the given timeslice and gives
   /// ownership to the caller. This is because once the inputs are out of the
@@ -88,8 +93,12 @@ private:
 
   /// This is the timeslices for all the in flight parts.
   std::vector<TimesliceId> mTimeslices;
+  /// This keeps track whether or not something was relayed
+  /// since last time we called getReadyToProcess()
+  std::vector<bool> mDirty;
 
   std::vector<bool> mForwardingMask;
+  CompletionPolicy mCompletionPolicy;
 };
 
 } // namespace framework

--- a/Framework/Core/include/Framework/DataRelayer.h
+++ b/Framework/Core/include/Framework/DataRelayer.h
@@ -81,8 +81,8 @@ public:
   /// Tune the maximum number of in flight timeslices this can handle.
   void setPipelineLength(size_t s);
 private:
-  std::vector<InputRoute> mInputs;
-  std::vector<ForwardRoute> mForwards;
+  std::vector<InputRoute> mInputRoutes;
+  std::vector<ForwardRoute> mForwardRoutes;
   monitoring::Monitoring& mMetrics;
 
   /// This is the actual cache of all the parts in flight. 

--- a/Framework/Core/include/Framework/DeviceSpec.h
+++ b/Framework/Core/include/Framework/DeviceSpec.h
@@ -19,6 +19,7 @@
 #include "Framework/ForwardRoute.h"
 #include "Framework/InputRoute.h"
 #include "Framework/OutputRoute.h"
+#include "Framework/CompletionPolicy.h"
 
 #include <vector>
 #include <string>
@@ -48,6 +49,8 @@ struct DeviceSpec {
   size_t rank; // Id of a parallel processing I am part of
   size_t nSlots; // Total number of parallel units I am part of
   size_t inputTimesliceId;
+  /// The completion policy to use for this device.
+  CompletionPolicy completionPolicy;
 };
 
 } // namespace framework

--- a/Framework/Core/include/Framework/InputRecord.h
+++ b/Framework/Core/include/Framework/InputRecord.h
@@ -136,13 +136,19 @@ public:
   int getPos(const std::string &name) const;
 
   DataRef getByPos(int pos) const {
-    if (pos*2 >= mCache.size() || pos < 0) {
+    if (pos*2+1 > mCache.size() || pos < 0) {
       throw std::runtime_error("Unknown argument requested at position " + std::to_string(pos));
     }
-    assert(pos >= 0);
-    return DataRef{&mInputsSchema[pos].matcher,
-                   static_cast<char const*>(mCache[pos*2]->GetData()),
-                   static_cast<char const*>(mCache[pos*2+1]->GetData())};
+    if (pos > mInputsSchema.size()) {
+      throw std::runtime_error("Unknown schema at position");
+    }
+    if (mCache[pos*2] != nullptr && mCache[pos*2+1] != nullptr) {
+      return DataRef{&mInputsSchema[pos].matcher,
+                     static_cast<char const*>(mCache[pos*2]->GetData()),
+                     static_cast<char const*>(mCache[pos*2+1]->GetData())};
+    } else {
+      return DataRef{ &mInputsSchema[pos].matcher, nullptr, nullptr };
+    }
   }
 
   /// Generic function to extract a messageable type
@@ -324,6 +330,15 @@ public:
   {
     static_assert(std::is_pointer<T>::value == true, "template argument must not be a pointer type");
   }
+
+  /// Helper method to be used to check if a given part of the InputRecord is present.
+  bool isValid(std::string const &s) {
+    return isValid(s.c_str());
+  }
+
+  /// Helper method to be used to check if a given part of the InputRecord is present.
+  bool isValid(char const *s);
+  bool isValid(int pos);
 
   size_t size() const {
     return mCache.size()/2;

--- a/Framework/Core/include/Framework/PartRef.h
+++ b/Framework/Core/include/Framework/PartRef.h
@@ -7,27 +7,24 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#ifndef FRAMEWORK_INPUTROUTE_H
-#define FRAMEWORK_INPUTROUTE_H
+#ifndef FRAMEWORK_PARTREF_H
+#define FRAMEWORK_PARTREF_H
 
-#include "Framework/InputSpec.h"
-#include <cstddef>
-#include <string>
+#include <memory>
+
+class FairMQMessage;
 
 namespace o2
 {
 namespace framework
 {
 
-/// This uniquely identifies a route to from which data matching @a matcher
-/// input spec gets to the device. In case of time pipelining @a timeslice 
-/// refers to the timeslice associated to this route.
-struct InputRoute {
-  InputSpec matcher;
-  std::string sourceChannel;
-  size_t timeslice;
+/// Reference to an inflight part.
+struct PartRef {
+  std::unique_ptr<FairMQMessage> header;
+  std::unique_ptr<FairMQMessage> payload;
 };
 
 } // namespace framework
 } // namespace o2
-#endif // FRAMEWORK_INPUTROUTE_H
+#endif // FRAMEWORK_PARTREF_H

--- a/Framework/Core/src/CompletionPolicy.cxx
+++ b/Framework/Core/src/CompletionPolicy.cxx
@@ -1,0 +1,49 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/CompletionPolicy.h"
+#include "Framework/CompletionPolicyHelpers.h"
+#include "Framework/InputRecord.h"
+#include <functional>
+#include <iostream>
+
+namespace o2
+{
+namespace framework
+{
+
+/// By default the CompletionPolicy matches any Device and only runs a
+/// computation when all the inputs are there.
+std::vector<CompletionPolicy>
+CompletionPolicy::createDefaultPolicies() {
+  return { CompletionPolicyHelpers::consumeWhenAll() };
+}
+
+std::ostream& operator<<(std::ostream& oss, CompletionPolicy::CompletionOp const& val)
+{
+  switch (val) {
+    case CompletionPolicy::CompletionOp::Consume:
+      oss << "consume";
+      break;
+    case CompletionPolicy::CompletionOp::Process:
+      oss << "process";
+      break;
+    case CompletionPolicy::CompletionOp::Wait:
+      oss << "wait";
+      break;
+    case CompletionPolicy::CompletionOp::Discard:
+      oss << "discard";
+      break;
+  };
+  return oss;
+}
+
+} // namespace framework
+} // namespace o2

--- a/Framework/Core/src/CompletionPolicyHelpers.cxx
+++ b/Framework/Core/src/CompletionPolicyHelpers.cxx
@@ -1,0 +1,93 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/CompletionPolicyHelpers.h"
+#include "Framework/CompletionPolicy.h"
+#include "Framework/InputRecord.h"
+#include "Framework/DeviceSpec.h"
+#include "Framework/PartRef.h"
+
+#include <gsl/span>
+
+namespace o2
+{
+namespace framework
+{
+
+CompletionPolicy CompletionPolicyHelpers::defineByName(std::string const&name, CompletionPolicy::CompletionOp op) {
+  auto matcher = [name](DeviceSpec const &device) -> bool {
+    return device.name == name;
+  };
+  auto callback = [op](gsl::span<PartRef const> const &inputs) -> CompletionPolicy::CompletionOp {
+    return op;
+  };
+  switch (op) {
+    case CompletionPolicy::CompletionOp::Consume:
+      return CompletionPolicy{"always-consume", matcher, callback };
+      break;
+    case CompletionPolicy::CompletionOp::Process:
+      return CompletionPolicy{"always-process", matcher, callback };
+      break;
+    case CompletionPolicy::CompletionOp::Wait:
+      return CompletionPolicy{"always-wait", matcher, callback };
+      break;
+    case CompletionPolicy::CompletionOp::Discard:
+      return CompletionPolicy{"always-discard", matcher, callback };
+      break;
+  }
+}
+
+CompletionPolicy CompletionPolicyHelpers::consumeWhenAll() {
+  auto matcher = [](DeviceSpec const &) -> bool { return true; };
+  auto callback = [](gsl::span<PartRef const> const &inputs) -> CompletionPolicy::CompletionOp {
+    for (auto &input : inputs) {
+      if (input.header == nullptr && input.payload == nullptr) {
+        return CompletionPolicy::CompletionOp::Wait;
+      }
+    }
+    return CompletionPolicy::CompletionOp::Consume;
+  };
+  return CompletionPolicy{"consume-all", matcher, callback };
+}
+
+CompletionPolicy CompletionPolicyHelpers::consumeWhenAny() {
+  auto matcher = [](DeviceSpec const &) -> bool { return true; };
+  auto callback = [](gsl::span<PartRef const> const &inputs) -> CompletionPolicy::CompletionOp {
+    for (auto &input : inputs) {
+      if (input.header != nullptr && input.payload != nullptr) {
+        return CompletionPolicy::CompletionOp::Consume;
+      }
+    }
+    return CompletionPolicy::CompletionOp::Wait;
+  };
+  return CompletionPolicy{"consume-any", matcher, callback };
+}
+
+CompletionPolicy CompletionPolicyHelpers::processWhenAny() {
+  auto matcher = [](DeviceSpec const &) -> bool { return true; };
+  auto callback = [](gsl::span<PartRef const> const &inputs) -> CompletionPolicy::CompletionOp {
+    size_t present = 0;
+    for (auto &input : inputs) {
+      if (input.header != nullptr) {
+        present++;
+      }
+    }
+    if (present == inputs.size()) {
+      return CompletionPolicy::CompletionOp::Consume;
+    } else if (present == 0) {
+      return CompletionPolicy::CompletionOp::Wait;
+    }
+    return CompletionPolicy::CompletionOp::Process;
+  };
+  return CompletionPolicy{"process-any", matcher, callback };
+}
+
+} // namespace framework
+} // namespace o2

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -365,12 +365,14 @@ DataProcessingDevice::HandleData(FairMQParts &iParts, int /*index*/) {
     try {
       for (size_t ai = 0; ai != record.size(); ai++) {
         auto cacheId = action.cacheLineIdx * record.size() + ai;
-        monitoringService.send({ 2, "data_relayer/" + std::to_string(cacheId) });
+        auto state = record.isValid(ai) ? 2 : 0;
+        monitoringService.send({ state, "data_relayer/" + std::to_string(cacheId) });
       }
       dispatchProcessing(action.cacheLineIdx, record);
       for (size_t ai = 0; ai != record.size(); ai++) {
         auto cacheId = action.cacheLineIdx * record.size() + ai;
-        monitoringService.send({ 3, "data_relayer/" + std::to_string(cacheId) });
+        auto state = record.isValid(ai) ? 3 : 0;
+        monitoringService.send({ state, "data_relayer/" + std::to_string(cacheId) });
       }
     } catch(std::exception &e) {
       errorHandling(e, record);

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -42,7 +42,7 @@ DataProcessingDevice::DataProcessingDevice(const DeviceSpec& spec, ServiceRegist
     mError{ spec.algorithm.onError },
     mConfigRegistry{ nullptr },
     mAllocator{ this, &mContext, &mRootContext, spec.outputs },
-    mRelayer{ spec.inputs, spec.forwards, registry.get<Monitoring>() },
+    mRelayer{ spec.completionPolicy, spec.inputs, spec.forwards, registry.get<Monitoring>() },
     mInputChannels{ spec.inputChannels },
     mOutputChannels{ spec.outputChannels },
     mInputs{ spec.inputs },
@@ -118,7 +118,7 @@ DataProcessingDevice::HandleData(FairMQParts &iParts, int /*index*/) {
   // move these to some thread local store and the rest of the lambdas
   // should work just fine.
   FairMQParts &parts = iParts;
-  std::vector<int> completed;
+  std::vector<DataRelayer::RecordAction> completed;
 
 
   // This is how we validate inputs. I.e. we try to enforce the O2 Data model
@@ -195,9 +195,8 @@ DataProcessingDevice::HandleData(FairMQParts &iParts, int /*index*/) {
   // indicate a complete set of inputs. Notice how I fill the completed
   // vector and return it, so that I can have a nice for loop iteration later
   // on.
-  auto getCompleteInputSets = [&relayer, &completed, &monitoringService]() -> std::vector<int> {
+  auto getReadyActions = [&relayer, &completed, &monitoringService]() -> std::vector<DataRelayer::RecordAction> {
     LOG(DEBUG) << "Getting parts to process";
-    completed = relayer.getReadyToProcess();
     int pendingInputs = (int)relayer.getParallelTimeslices() - completed.size();
     monitoringService.send({ pendingInputs, "inputs/relayed/pending" });
     if (completed.empty()) {
@@ -253,7 +252,7 @@ DataProcessingDevice::HandleData(FairMQParts &iParts, int /*index*/) {
   // propagates it to the various contextes (i.e. the actual entities which
   // create messages) because the messages need to have the timeslice id into
   // it.
-  auto prepareForCurrentTimeSlice = [&rootContext, &context, &relayer](int i) {
+  auto prepareAllocatorForCurrentTimeSlice = [&rootContext, &context, &relayer](int i) {
     size_t timeslice = relayer.getTimesliceForCacheline(i);
     LOG(DEBUG) << "Timeslice for cacheline is " << timeslice;
     rootContext.prepareForTimeslice(timeslice);
@@ -268,9 +267,16 @@ DataProcessingDevice::HandleData(FairMQParts &iParts, int /*index*/) {
                        (int timeslice, InputRecord &record) {
     assert(record.size()*2 == currentSetOfInputs.size());
     LOG(DEBUG) << "FORWARDING:START:" << timeslice;
-    for (size_t ii = 0, ie = record.size(); ii != ie; ++ii) {
+    for (size_t ii = 0, ie = record.size(); ii < ie; ++ii) {
       DataRef input = record.getByPos(ii);
-      assert(input.header);
+
+      // If is now possible that the record is not complete when
+      // we forward it, because of a custom completion policy.
+      // this means that we need to skip the empty entries in the 
+      // record for being forwarded.
+      if (input.header == nullptr || input.payload == nullptr) {
+        continue;
+      }
       auto dh = o2::header::get<DataHeader*>(input.header);
       if (!dh) {
         reportError("Header is not a DataHeader?");
@@ -331,7 +337,9 @@ DataProcessingDevice::HandleData(FairMQParts &iParts, int /*index*/) {
   // is actually hidden. For example we do not expose what "input" is. This
   // will allow us to keep the same toplevel logic even if the actual meaning
   // of input is changed (for example we might move away from multipart
-  // messages).
+  // messages). Notice also that we need to act diffently depending on the
+  // actual CompletionOp we want to perform. In particular forwarding inputs
+  // also gets rid of them from the cache.
   if (isValidInput() == false) {
     reportError("Parts should come in couples. Dropping it.");
     return true;
@@ -341,23 +349,39 @@ DataProcessingDevice::HandleData(FairMQParts &iParts, int /*index*/) {
     return true;
   }
 
-  for (auto cacheline : getCompleteInputSets()) {
-    prepareForCurrentTimeSlice(cacheline);
-    InputRecord record = fillInputs(cacheline);
+  for (auto action: getReadyActions()) {
+    if (action.op == CompletionPolicy::CompletionOp::Wait) {
+      continue;
+    }
+
+    prepareAllocatorForCurrentTimeSlice(action.cacheLineIdx);
+    InputRecord record = fillInputs(action.cacheLineIdx);
+    if (action.op == CompletionPolicy::CompletionOp::Discard) {
+      if (forwards.empty() == false) {
+        forwardInputs(action.cacheLineIdx, record);
+        continue;
+      }
+    }
     try {
       for (size_t ai = 0; ai != record.size(); ai++) {
-        auto cacheId = cacheline * record.size() + ai;
+        auto cacheId = action.cacheLineIdx * record.size() + ai;
         monitoringService.send({ 2, "data_relayer/" + std::to_string(cacheId) });
       }
-      dispatchProcessing(cacheline, record);
+      dispatchProcessing(action.cacheLineIdx, record);
       for (size_t ai = 0; ai != record.size(); ai++) {
-        auto cacheId = cacheline * record.size() + ai;
+        auto cacheId = action.cacheLineIdx * record.size() + ai;
         monitoringService.send({ 3, "data_relayer/" + std::to_string(cacheId) });
       }
     } catch(std::exception &e) {
       errorHandling(e, record);
     }
-    forwardInputs(cacheline, record);
+    // We forward inputs only when we consume them. If we simply Process them,
+    // we keep them for next message arriving.
+    if (action.op == CompletionPolicy::CompletionOp::Consume) {
+      if (forwards.empty() == false) {
+        forwardInputs(action.cacheLineIdx, record);
+      }
+    }
   }
 
   return true;

--- a/Framework/Core/src/DataRelayer.cxx
+++ b/Framework/Core/src/DataRelayer.cxx
@@ -162,6 +162,8 @@ DataRelayer::relay(std::unique_ptr<FairMQMessage> &&header,
   // simply store the payload in the cache and we mark relevant bit in the
   // hence the first if.
   auto pruneCacheSlotFor = [&cache, &numInputTypes, &timeslices, &metrics](int64_t timeslice) {
+    assert(cache.empty() == false);
+    assert(timeslices.size() * numInputTypes == cache.size());
     size_t slotIndex = timeslice % timeslices.size();
     // Prune old stuff from the cache, hopefully deleting it...
     // We set the current slot to the timeslice value, so that old stuff
@@ -363,6 +365,7 @@ DataRelayer::setPipelineLength(size_t s) {
   mTimeslices.resize(s, INVALID_TIMESLICE_ID);
   mDirty.resize(mTimeslices.size(), false);
   auto numInputTypes = countDistinctTypes(mInputRoutes);
+  assert(numInputTypes);
   mCache.resize(numInputTypes * mTimeslices.size());
   mMetrics.send({ (int)numInputTypes, "data_relayer/h" });
   mMetrics.send({ (int)mTimeslices.size(), "data_relayer/w" });

--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -367,6 +367,7 @@ void DeviceSpecHelpers::processInEdgeActions(std::vector<DeviceSpec>& devices,
     InputRoute route;
     route.matcher = consumer.inputs[edge.consumerInputIndex];
     route.sourceChannel = consumerDevice.inputChannels[ci].name;
+    route.timeslice = edge.producerTimeIndex;
     consumerDevice.inputs.push_back(route);
   };
 
@@ -404,6 +405,7 @@ void DeviceSpecHelpers::processInEdgeActions(std::vector<DeviceSpec>& devices,
 // FIXME: make start port configurable?
 void DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(WorkflowSpec const& workflow,
                                                        std::vector<ChannelConfigurationPolicy> const& channelPolicies,
+                                                       std::vector<CompletionPolicy> const& completionPolicies,
                                                        std::vector<DeviceSpec>& devices,
                                                        std::vector<ComputingResource> &resources)
 {
@@ -449,6 +451,16 @@ void DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(WorkflowSpec const& workf
 
   processInEdgeActions(devices, deviceIndex, resources, connections, inEdgeIndex, logicalEdges, inActions, workflow,
                        availableForwardsInfo, channelPolicies);
+  // We apply the completion policies here since this is where we have all the
+  // devices resolved.
+  for (auto &device : devices) {
+    for (auto &policy : completionPolicies) {
+      if (policy.matcher(device) == true) {
+        device.completionPolicy = policy;
+        break;
+      }
+    }
+  }
 }
 
 void DeviceSpecHelpers::prepareArguments(int argc, char** argv, bool defaultQuiet, bool defaultStopped,

--- a/Framework/Core/src/DeviceSpecHelpers.h
+++ b/Framework/Core/src/DeviceSpecHelpers.h
@@ -14,6 +14,7 @@
 #include "Framework/ChannelConfigurationPolicy.h"
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/ChannelSpec.h"
+#include "Framework/CompletionPolicy.h"
 #include "Framework/DeviceControl.h"
 #include "Framework/DeviceExecution.h"
 #include "Framework/DeviceSpec.h"
@@ -39,6 +40,7 @@ struct DeviceSpecHelpers {
   static void dataProcessorSpecs2DeviceSpecs(
       const WorkflowSpec &workflow,
       std::vector<ChannelConfigurationPolicy> const &channelPolicies,
+      std::vector<CompletionPolicy> const &completionPolicies,
       std::vector<DeviceSpec> &devices,
       std::vector<ComputingResource> &resources
       );

--- a/Framework/Core/src/DriverInfo.h
+++ b/Framework/Core/src/DriverInfo.h
@@ -74,7 +74,7 @@ enum struct DriverState {
 /// These are the possible actions we can do
 /// when a workflow is deemed complete (e.g. when we are done
 /// reading from file).
-enum struct CompletionPolicy { QUIT, WAIT, RESTART };
+enum struct TerminationPolicy { QUIT, WAIT, RESTART };
 
 /// Information about the driver process (i.e.  / the one which calculates the
 /// topology and actually spawns the devices )
@@ -96,6 +96,9 @@ struct DriverInfo {
   /// Since they are decided by the toplevel configuration, they belong
   /// to the driver process.
   std::vector<ChannelConfigurationPolicy> channelPolicies;
+  /// These are the policies which can be applied to decide wether or not
+  /// a given record is complete.
+  std::vector<CompletionPolicy> completionPolicies;
   /// The argc with which the driver was started.
   int argc;
   /// The argv with which the driver was started.
@@ -103,7 +106,7 @@ struct DriverInfo {
   /// Whether the driver was started in batch mode or not.
   bool batch;
   /// What we should do when the workflow is completed.
-  enum CompletionPolicy completionPolicy;
+  enum TerminationPolicy terminationPolicy;
   /// The offset at which the process was started.
   std::chrono::time_point<std::chrono::steady_clock> startTime;
   /// The optional timeout after which the driver will request

--- a/Framework/Core/src/FrameworkGUIDebugger.cxx
+++ b/Framework/Core/src/FrameworkGUIDebugger.cxx
@@ -614,6 +614,7 @@ std::function<void(void)> getGUIDebugger(const std::vector<DeviceInfo>& infos, c
       }
       optionsTable(spec, control);
       if (ImGui::CollapsingHeader("Data relayer")) {
+        ImGui::Text("Completion policy: %s", spec.completionPolicy.name.c_str());
         displayDataRelayer(metrics, info);
       }
       if (ImGui::CollapsingHeader("Logs", ImGuiTreeNodeFlags_DefaultOpen)) {

--- a/Framework/Core/src/InputRecord.cxx
+++ b/Framework/Core/src/InputRecord.cxx
@@ -18,7 +18,7 @@ namespace framework
 {
 
 InputRecord::InputRecord(std::vector<InputRoute> const &inputsSchema,
-                               std::vector<std::unique_ptr<FairMQMessage>> const& cache)
+                         std::vector<std::unique_ptr<FairMQMessage>> const& cache)
 : mInputsSchema{inputsSchema},
   mCache{cache}
 {
@@ -45,6 +45,24 @@ InputRecord::getPos(std::string const &binding) const {
     }
   }
   return -1;
+}
+
+bool
+InputRecord::isValid(char const *s) {
+  DataRef ref = get(s);
+  if (ref.header == nullptr || ref.payload == nullptr) {
+    return false;
+  }
+  return true;
+}
+
+bool
+InputRecord::isValid(int s) {
+  DataRef ref = getByPos(s);
+  if (ref.header == nullptr || ref.payload == nullptr) {
+    return false;
+  }
+  return true;
 }
 
 } // namespace framework

--- a/Framework/Core/test/test_DeviceSpec.cxx
+++ b/Framework/Core/test/test_DeviceSpec.cxx
@@ -38,11 +38,13 @@ BOOST_AUTO_TEST_CASE(TestDeviceSpec1)
 {
   auto workflow = defineDataProcessing1();
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
+  auto completionPolicies = CompletionPolicy::createDefaultPolicies();
   BOOST_REQUIRE_EQUAL(channelPolicies.empty(), false);
+  BOOST_REQUIRE_EQUAL(completionPolicies.empty(), false);
   std::vector<DeviceSpec> devices;
   SimpleResourceManager rm(22000, 1000);
   auto resources = rm.getAvailableResources();
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, devices, resources);
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, resources);
   BOOST_CHECK_EQUAL(devices.size(), 2);
   BOOST_CHECK_EQUAL(devices[0].outputChannels.size(), 1);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, Bind);
@@ -71,12 +73,13 @@ BOOST_AUTO_TEST_CASE(TestDeviceSpec1PushPull)
   pushPullPolicy.modifyOutput = ChannelConfigurationPolicyHelpers::pushOutput;
 
   std::vector<ChannelConfigurationPolicy> channelPolicies = { pushPullPolicy };
+  auto completionPolicies = CompletionPolicy::createDefaultPolicies();
 
   BOOST_REQUIRE_EQUAL(channelPolicies.empty(), false);
   std::vector<DeviceSpec> devices;
   SimpleResourceManager rm(22000, 1000);
   auto resources = rm.getAvailableResources();
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, devices, resources);
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, resources);
   BOOST_CHECK_EQUAL(devices.size(), 2);
   BOOST_CHECK_EQUAL(devices[0].outputChannels.size(), 1);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, Bind);
@@ -115,11 +118,12 @@ BOOST_AUTO_TEST_CASE(TestDeviceSpec2)
 {
   auto workflow = defineDataProcessing2();
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
+  auto completionPolicies = CompletionPolicy::createDefaultPolicies();
   std::vector<DeviceSpec> devices;
 
   SimpleResourceManager rm(22000, 1000);
   auto resources = rm.getAvailableResources();
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, devices, resources);
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, resources);
   BOOST_CHECK_EQUAL(devices.size(), 2);
   BOOST_CHECK_EQUAL(devices[0].outputChannels.size(), 1);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, Bind);
@@ -156,11 +160,12 @@ BOOST_AUTO_TEST_CASE(TestDeviceSpec3)
 {
   auto workflow = defineDataProcessing3();
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
+  auto completionPolicies = CompletionPolicy::createDefaultPolicies();
   std::vector<DeviceSpec> devices;
 
   SimpleResourceManager rm(22000, 1000);
   auto resources = rm.getAvailableResources();
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, devices, resources);
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, resources);
   BOOST_CHECK_EQUAL(devices.size(), 3);
   BOOST_CHECK_EQUAL(devices[0].outputChannels.size(), 2);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, Bind);
@@ -203,11 +208,12 @@ BOOST_AUTO_TEST_CASE(TestDeviceSpec4)
 {
   auto workflow = defineDataProcessing4();
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
+  auto completionPolicies = CompletionPolicy::createDefaultPolicies();
   std::vector<DeviceSpec> devices;
   SimpleResourceManager rm(22000, 1000);
   auto resources = rm.getAvailableResources();
 
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, devices, resources);
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, resources);
   BOOST_CHECK_EQUAL(devices.size(), 4);
   BOOST_CHECK_EQUAL(devices[0].outputChannels.size(), 2);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, Bind);
@@ -271,11 +277,12 @@ BOOST_AUTO_TEST_CASE(TestTopologyForwarding)
 {
   auto workflow = defineDataProcessing5();
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
+  auto completionPolicies = CompletionPolicy::createDefaultPolicies();
   std::vector<DeviceSpec> devices;
 
   SimpleResourceManager rm(22000, 1000);
   auto resources = rm.getAvailableResources();
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, devices, resources);
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, resources);
   BOOST_CHECK_EQUAL(devices.size(), 3);
   BOOST_CHECK_EQUAL(devices[0].outputChannels.size(), 1);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, Bind);
@@ -530,9 +537,10 @@ BOOST_AUTO_TEST_CASE(TestTopologyLayeredTimePipeline)
   auto workflow = defineDataProcessing7();
   std::vector<DeviceSpec> devices;
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
+  auto completionPolicies = CompletionPolicy::createDefaultPolicies();
   SimpleResourceManager rm(22000,1000);
   auto resources = rm.getAvailableResources();
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, devices, resources);
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, resources);
   BOOST_CHECK_EQUAL(devices.size(), 6);
   BOOST_CHECK_EQUAL(devices[0].id, "A");
   BOOST_CHECK_EQUAL(devices[1].id, "B_t0");

--- a/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
+++ b/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
@@ -70,7 +70,8 @@ BOOST_AUTO_TEST_CASE(TestGraphviz)
   std::vector<DeviceSpec> devices;
   SimpleResourceManager rm(22000, 1000);
   auto resources = rm.getAvailableResources();
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, devices, resources);
+  auto completionPolicies = CompletionPolicy::createDefaultPolicies();
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, resources);
   char* fakeArgv[] = { strdup("foo"), nullptr };
   std::vector<DeviceControl> controls;
   std::vector<DeviceExecution> executions;

--- a/Framework/Core/test/test_Graphviz.cxx
+++ b/Framework/Core/test/test_Graphviz.cxx
@@ -95,9 +95,10 @@ BOOST_AUTO_TEST_CASE(TestGraphviz)
     BOOST_CHECK(device.id != "");
   }
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
+  auto completionPolicies = CompletionPolicy::createDefaultPolicies();
   SimpleResourceManager rm(22000, 1000);
   auto resources = rm.getAvailableResources();
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, devices, resources);
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, resources);
   str.str("");
   GraphvizHelpers::dumpDeviceSpec2Graphviz(str, devices);
   lineByLineComparision(str.str(), R"EXPECTED(digraph structs {
@@ -132,9 +133,10 @@ BOOST_AUTO_TEST_CASE(TestGraphvizWithPipeline)
     BOOST_CHECK(device.id != "");
   }
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
+  auto completionPolicies = CompletionPolicy::createDefaultPolicies();
   SimpleResourceManager rm(22000, 1000);
   auto resources = rm.getAvailableResources();
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, devices, resources);
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, resources);
   str.str("");
   GraphvizHelpers::dumpDeviceSpec2Graphviz(str, devices);
   lineByLineComparision(str.str(), R"EXPECTED(digraph structs {

--- a/Framework/Core/test/test_TimeParallelPipelining.cxx
+++ b/Framework/Core/test/test_TimeParallelPipelining.cxx
@@ -52,9 +52,10 @@ BOOST_AUTO_TEST_CASE(TimePipeliningSimple)
   auto workflow = defineSimplePipelining();
   std::vector<DeviceSpec> devices;
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
+  auto completionPolicies = CompletionPolicy::createDefaultPolicies();
   SimpleResourceManager rm(22000, 1000);
   auto resources = rm.getAvailableResources();
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, devices, resources);
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, resources);
   BOOST_REQUIRE_EQUAL(devices.size(), 4);
   auto& producer = devices[0];
   auto& layer0Consumer0 = devices[1];
@@ -104,9 +105,10 @@ BOOST_AUTO_TEST_CASE(TimePipeliningFull)
   auto workflow = defineDataProcessing();
   std::vector<DeviceSpec> devices;
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
+  auto completionPolicies = CompletionPolicy::createDefaultPolicies();
   SimpleResourceManager rm(22000, 1000);
   auto resources = rm.getAvailableResources();
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, devices, resources);
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, resources);
   BOOST_REQUIRE_EQUAL(devices.size(), 7);
   auto& producer = devices[0];
   auto& layer0Consumer0 = devices[1];

--- a/Framework/TestWorkflows/CMakeLists.txt
+++ b/Framework/TestWorkflows/CMakeLists.txt
@@ -79,6 +79,13 @@ O2_GENERATE_EXECUTABLE(
 )
 
 O2_GENERATE_EXECUTABLE(
+  EXE_NAME "test_CompletionPolicies"
+  SOURCES "src/test_CompletionPolicies.cxx"
+  MODULE_LIBRARY_NAME ${LIBRARY_NAME}
+  BUCKET_NAME ${MODULE_BUCKET_NAME}
+)
+
+O2_GENERATE_EXECUTABLE(
   EXE_NAME "dataSamplingPodAndRoot"
   SOURCES "src/dataSamplingPodAndRoot.cxx"
   MODULE_LIBRARY_NAME ${LIBRARY_NAME}

--- a/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
@@ -8,6 +8,8 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 #include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicy.h"
+#include "Framework/DeviceSpec.h"
 #include <vector>
 using namespace o2::framework;
 void customize(std::vector<ConfigParamSpec> &options) {
@@ -17,6 +19,19 @@ void customize(std::vector<ConfigParamSpec> &options) {
   options.push_back(o2::framework::ConfigParamSpec{"aString", VariantType::String, "foo", {"a string option"}});
   options.push_back(o2::framework::ConfigParamSpec{"aBool", VariantType::Bool, true, {"a boolean option"}});
 };
+
+// This completion policy will only be applied to the device called `D` and
+// will process an InputRecord which had any of its constituent updated.
+void customize(std::vector<CompletionPolicy> &policies) {
+  auto matcher = [](DeviceSpec const &device) -> bool {
+    return device.name == "D";
+  };
+  auto policy = [](gsl::span<PartRef const> const &inputs) -> CompletionPolicy::CompletionOp {
+    return CompletionPolicy::CompletionOp::Process;
+  };
+  policies.push_back({CompletionPolicy{"process-any", matcher, policy}});
+}
+
 #include "Framework/runDataProcessing.h"
 
 

--- a/Framework/TestWorkflows/src/o2ParallelWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2ParallelWorkflow.cxx
@@ -99,12 +99,28 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
                                                 [](InputSpec& input, size_t index) {
                                                   input.subSpec = index;
                                                 }),
+                                    {
+                                      OutputSpec{{"out"}, "TST", "M"}
+                                    },
+                                    AlgorithmSpec{ [](InitContext& setup) {
+                                      return [](ProcessingContext& ctx) {
+                                        ctx.outputs().make<int>(OutputRef("out"), 1);
+                                      };
+                                    } } },
+                                  stages));
+
+  workflow.push_back(timePipeline(DataProcessorSpec{
+                                    "writer",
+                                    mergeInputs(InputSpec{ "x", "TST", "M" },
+                                                jobs,
+                                                [](InputSpec& input, size_t index) {
+                                                  input.subSpec = index;
+                                                }),
                                     {},
                                     AlgorithmSpec{ [](InitContext& setup) {
                                       return [](ProcessingContext& ctx) {
                                       };
                                     } } },
-                                  stages));
-
+                                  1));
   return workflow;
 }

--- a/Framework/TestWorkflows/src/test_CompletionPolicies.cxx
+++ b/Framework/TestWorkflows/src/test_CompletionPolicies.cxx
@@ -1,0 +1,85 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/CompletionPolicy.h"
+#include "Framework/CompletionPolicyHelpers.h"
+#include "Framework/DeviceSpec.h"
+#include <vector>
+#include <cassert>
+
+using namespace o2::framework;
+
+void customize(std::vector<CompletionPolicy> &policies) {
+  std::vector<CompletionPolicy> result {
+    CompletionPolicyHelpers::defineByName("discard", CompletionPolicy::CompletionOp::Discard),
+    CompletionPolicyHelpers::defineByName("process", CompletionPolicy::CompletionOp::Process),
+    CompletionPolicyHelpers::defineByName("wait", CompletionPolicy::CompletionOp::Wait),
+    CompletionPolicyHelpers::defineByName("consume", CompletionPolicy::CompletionOp::Consume)
+  };
+  policies.swap(result);
+}
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/DataProcessorSpec.h"
+#include "FairMQLogger.h"
+#include "Framework/ParallelContext.h"
+#include "Framework/ControlService.h"
+#include <vector>
+
+// This is a simple consumer / producer workflow where both are
+// stateful, i.e. they have context which comes from their initialization.
+WorkflowSpec defineDataProcessing(ConfigContext const& config)
+{
+  return WorkflowSpec{
+    DataProcessorSpec{
+      "hearthbeat",
+      {},
+      {
+        OutputSpec{ {"out1"}, "TST", "TST", 0},
+        OutputSpec{ {"out2"}, "TST", "TST", 1}
+      },
+      AlgorithmSpec{
+        [](ProcessingContext& ctx) {
+          // We deliberately make only out1 to test that
+          // the policies for the following dataprocessors are
+          // actually respected.
+          ctx.outputs().make<int>(OutputRef{ "out1" }, 1);
+          sleep(1);
+        } } },
+    DataProcessorSpec{
+      "discard",
+      {
+        InputSpec{ "in1", "TST", "TST", 0 },
+        InputSpec{ "in2", "TST", "TST", 1 },
+      },
+      {
+      },
+      AlgorithmSpec{
+        [](ProcessingContext& ctx) {
+          LOG(ERROR) << "Should have not been invoked";
+          // We deliberately make only out1 to test that
+          // the policies for the following dataprocessors are
+          // actually respected.
+        } } },
+    DataProcessorSpec{
+      "does-use",
+      {
+        InputSpec{ "in1", "TST", "TST", 0 }
+      },
+      {
+      },
+      AlgorithmSpec{
+        [](ProcessingContext& ctx) {
+          // Since this shares a dependency with "discard",
+          // it should be forwarded the messages as soon as the former
+          // discards them.
+        } } },
+  };
+}


### PR DESCRIPTION
This introduces the concept of "completion policies" i.e. the ability to
customize when a record (i.e. a set of inputs) being received by a data
processor is ready to be consumed.

Moreover it also fixes a brown paper bag bug which was preventing merging of different timeslices after a timePipeline to work correctly.
