### PR TITLE
Implementation of a look-up table for small topologies and changes in the dimensions of the groups of rare topology.

### DIFF
--- a/DataFormats/Detectors/ITSMFT/common/CMakeLists.txt
+++ b/DataFormats/Detectors/ITSMFT/common/CMakeLists.txt
@@ -4,12 +4,14 @@ O2_SETUP(NAME ${MODULE_NAME})
 
 set(SRCS
   src/Cluster.cxx
+  src/ClusterPattern.cxx
   src/ClusterTopology.cxx
   src/TopologyDictionary.cxx
 )
 
 Set(HEADERS
   include/${MODULE_NAME}/Cluster.h
+  include/${MODULE_NAME}/ClusterPattern.h
   include/${MODULE_NAME}/ClusterTopology.h
   include/${MODULE_NAME}/TopologyDictionary.h
 )
@@ -19,5 +21,3 @@ Set(LIBRARY_NAME ${MODULE_NAME})
 set(BUCKET_NAME data_format_itsmft_bucket)
 
 O2_GENERATE_LIBRARY()
-
-

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/ClusterPattern.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/ClusterPattern.h
@@ -1,0 +1,83 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file ClusterTopology.h
+/// \brief Definition of the ClusterTopology class.
+///
+/// \author Luca Barioglio, University and INFN of Torino
+///
+/// Short ClusterPattern descritpion
+///
+/// This class contains the information of the pattern of a cluster of pixels (bitmask), together with the number of
+/// rows and columns of the vinding box.
+///
+
+#ifndef ALICEO2_ITSMFT_CLUSTERPATTERN_H
+#define ALICEO2_ITSMFT_CLUSTERPATTERN_H
+#include <Rtypes.h>
+#include <array>
+#include <iosfwd>
+#include "DataFormatsITSMFT/Cluster.h"
+
+namespace o2
+{
+namespace ITSMFT
+{
+class ClusterTopology;
+class TopologyDictionary;
+class BuildTopologyDictionary;
+
+class ClusterPattern
+{
+ public:
+  /// Default constructor
+  ClusterPattern();
+  /// Standard constructor
+  ClusterPattern(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes]);
+  /// Returns the pattern
+  void getPattern(unsigned char destination[Cluster::kMaxPatternBytes + 2]) const
+  {
+    memcpy(destination, mBitmap, Cluster::kMaxPatternBytes + 2);
+  }
+  /// Returns a specific byte of the pattern
+  unsigned char getByte(int n) const;
+  /// Returns the number of rows
+  int getRowSpan() const { return (int)mBitmap[0]; }
+  /// Returns the number of columns
+  int getColumnSpan() const { return (int)mBitmap[1]; }
+  /// Returns the number of bytes used for the pattern
+  int getUsedBytes() const;
+  /// Prints the pattern
+  friend std::ostream& operator<<(std::ostream& os, const ClusterPattern& top);
+  /// Sets the pattern
+  void setPattern(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes]);
+  /// Sets the whole bitmask: the number of rows, the number of columns and the pattern
+  void setPattern(const unsigned char bitmask[Cluster::kMaxPatternBytes + 2]);
+
+  friend ClusterTopology;
+  friend TopologyDictionary;
+  friend BuildTopologyDictionary;
+
+ private:
+  /// Pattern:
+  ///
+  /// - 1st byte: number of rows
+  /// - 2nd byte: number of columns
+  /// - remainig bytes : pixels of the cluster, where 1 is a fired pixel and 0
+  /// is a non-fired pixel. The number of bytes used for the pixels depends on
+  /// the size of the bounding box
+  unsigned char
+    mBitmap[Cluster::kMaxPatternBytes + 2]; ///< Cluster pattern: 1 is a fired pixel and 0 is a non-fired pixel
+
+  ClassDefNV(ClusterPattern, 1);
+};
+}
+}
+#endif /* ALICEO2_ITS_CLUSTERPATTERN_H */

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/ClusterPattern.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/ClusterPattern.h
@@ -41,11 +41,10 @@ class ClusterPattern
   ClusterPattern();
   /// Standard constructor
   ClusterPattern(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes]);
+  /// Maximum number of bytes for the cluster puttern + 2 bytes respectively for the number of rows and columns of the bounding box
+  static constexpr int kExtendedPatternBytes = Cluster::kMaxPatternBytes + 2;
   /// Returns the pattern
-  void getPattern(unsigned char destination[Cluster::kMaxPatternBytes + 2]) const
-  {
-    memcpy(destination, mBitmap, Cluster::kMaxPatternBytes + 2);
-  }
+  std::array<unsigned char, kExtendedPatternBytes> getPattern() const { return mBitmap; }
   /// Returns a specific byte of the pattern
   unsigned char getByte(int n) const;
   /// Returns the number of rows
@@ -59,7 +58,7 @@ class ClusterPattern
   /// Sets the pattern
   void setPattern(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes]);
   /// Sets the whole bitmask: the number of rows, the number of columns and the pattern
-  void setPattern(const unsigned char bitmask[Cluster::kMaxPatternBytes + 2]);
+  void setPattern(const unsigned char bitmask[kExtendedPatternBytes]);
 
   friend ClusterTopology;
   friend TopologyDictionary;
@@ -73,8 +72,8 @@ class ClusterPattern
   /// - remainig bytes : pixels of the cluster, where 1 is a fired pixel and 0
   /// is a non-fired pixel. The number of bytes used for the pixels depends on
   /// the size of the bounding box
-  unsigned char
-    mBitmap[Cluster::kMaxPatternBytes + 2]; ///< Cluster pattern: 1 is a fired pixel and 0 is a non-fired pixel
+
+  std::array<unsigned char, kExtendedPatternBytes> mBitmap; ///< Cluster pattern: 1 is a fired pixel and 0 is a non-fired pixel
 
   ClassDefNV(ClusterPattern, 1);
 };

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/ClusterTopology.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/ClusterTopology.h
@@ -39,7 +39,7 @@ class ClusterTopology
   /// Returns a specific byte of the pattern
   unsigned char getByte(int n) const { return mPattern.getByte(n); }
   /// Returns the pattern
-  void getPattern(unsigned char destination[Cluster::kMaxPatternBytes + 2]) const { mPattern.getPattern(destination); }
+  std::array<unsigned char, ClusterPattern::kExtendedPatternBytes> getPattern() const { return mPattern.getPattern(); }
   /// Returns the number of rows
   int getRowSpan() const { return mPattern.getRowSpan(); }
   /// Returns the number of columns

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/ClusterTopology.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/ClusterTopology.h
@@ -22,11 +22,7 @@
 
 #ifndef ALICEO2_ITSMFT_CLUSTERTOPOLOGY_H
 #define ALICEO2_ITSMFT_CLUSTERTOPOLOGY_H
-#include <Rtypes.h>
-#include <array>
-#include <iosfwd>
-#include <string>
-#include "DataFormatsITSMFT/Cluster.h"
+#include "DataFormatsITSMFT/ClusterPattern.h"
 
 namespace o2
 {
@@ -40,14 +36,16 @@ class ClusterTopology
   /// Standard constructor
   ClusterTopology(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes]);
 
+  /// Returns a specific byte of the pattern
+  unsigned char getByte(int n) const { return mPattern.getByte(n); }
   /// Returns the pattern
-  const std::array<unsigned char, Cluster::kMaxPatternBytes + 2>& getPattern() const { return mPattern; }
+  void getPattern(unsigned char destination[Cluster::kMaxPatternBytes + 2]) const { mPattern.getPattern(destination); }
   /// Returns the number of rows
-  int getRowSpan() const { return (int)mPattern[0]; }
+  int getRowSpan() const { return mPattern.getRowSpan(); }
   /// Returns the number of columns
-  int getColumnSpan() const { return (int)mPattern[1]; }
+  int getColumnSpan() const { return mPattern.getColumnSpan(); }
   /// Returns the number of used bytes
-  int getUsedBytes() const { return mNbytes; }
+  int getUsedBytes() const { return mPattern.getUsedBytes(); }
   /// Returns the hashcode
   unsigned long getHash() const { return mHash; }
   /// Prints the topology
@@ -55,23 +53,13 @@ class ClusterTopology
   /// MurMur2 hash fucntion
   static unsigned int hashFunction(const void* key, int len);
   /// Compute the complete hash as defined for mHash
-  static unsigned long getCompleteHash(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes],
-                                       int nBytesUsed);
+  static unsigned long getCompleteHash(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes]);
   static unsigned long getCompleteHash(const ClusterTopology& topology);
   /// Sets the pattern
   void setPattern(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes]);
 
  private:
-  /// Pattern:
-  ///
-  /// - 1st byte: number of rows
-  /// - 2nd byte: number of columns
-  /// - remainig bytes : pixels of the cluster, where 1 is a fired pixel and 0
-  /// is a non-fired pixel. The number of pixels used for the pixel depends on
-  /// the size of the bounding box
-  std::array<unsigned char, Cluster::kMaxPatternBytes + 2>
-    mPattern;  ///< Cluster pattern: 1 is a fired pixel and 0 is a non-fired pixel
-  int mNbytes; ///< Number of bytes that are effectively used in mPattern
+  ClusterPattern mPattern; ///< Pattern of pixels
   /// Hashcode computed from the pattern
   ///
   /// The first four bytes are computed with MurMur2 hash-function. The remaining
@@ -79,7 +67,7 @@ class ClusterTopology
   /// is less than 32, the remaining bits are set to 0.
   unsigned long mHash;
 
-  ClassDefNV(ClusterTopology, 1);
+  ClassDefNV(ClusterTopology, 2);
 };
 } // namespace ITSMFT
 } // namespace o2

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TopologyDictionary.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TopologyDictionary.h
@@ -58,22 +58,40 @@ struct GroupStruct {
 class TopologyDictionary
 {
  public:
-
   /// Default constructor
   TopologyDictionary();
-  /// constexpr for the definition of the groups of rare topologies
-  static constexpr int NumberOfRowClasses = 7; ///< Number of row classes for the groups of rare topologies
-  static constexpr int NumberOfColClasses = 7; ///< Number of column classes for the groups of rare topologies
-  static constexpr int RowClassSpan = 5;       ///< Row span of the classes of rare topologies
-  static constexpr int ColClassSpan = 5;       ///< Column span of the classes of rare topologies
-  static constexpr int MaxRowSpan = 32;        ///< Maximum row span
-  static constexpr int MaxColSpan = 32;        ///< Maximum column span
+  /// constexpr for the definition of the groups of rare topologies.
+  /// The attritbution of the group ID is stringly dependent on the following parameters: it must be a power of 2.
+  static constexpr int RowClassSpan = 4;                                                 ///< Row span of the classes of rare topologies
+  static constexpr int ColClassSpan = 4;                                                 ///< Column span of the classes of rare topologies
+  static constexpr int MinimumClassArea = RowClassSpan * ColClassSpan;                   ///< Area of the smallest class of rare topologies (used as reference)
+  static constexpr int MaxNumberOfClasses = Cluster::kMaxPatternBits / MinimumClassArea; ///< Maximum number of row/column classes for the groups of rare topologies
+  static constexpr int NumberOfRareGroups = MaxNumberOfClasses * MaxNumberOfClasses;     ///< Number of entries corresponding to groups of rare topologies (those whos matrix exceed the max number of bytes are empty).
   /// Prints the dictionary
   friend std::ostream& operator<<(std::ostream& os, const TopologyDictionary& dictionary);
   /// Prints the dictionary in a binary file
   void WriteBinaryFile(std::string outputFile);
   /// Reads the dictionary from a binary file
   void ReadBinaryFile(std::string fileName);
+  /// Returns the x position of the COG for the n_th element
+  float GetXcog(int n);
+  /// Returns the error on the x position of the COG for the n_th element
+  float GetErrX(int n);
+  /// Returns the z position of the COG for the n_th element
+  float GetZcog(int n);
+  /// Returns the error on the z position of the COG for the n_th element
+  float GetErrZ(int n);
+  /// Returns the hash of the n_th element
+  unsigned long GetHash(int n);
+  /// Returns the number of fired pixels of the n_th element
+  int GetNpixels(int n);
+  /// Returns the pattern of the topology
+  ClusterPattern GetPattern(int n);
+  /// Returns the frequency of the n_th element;
+  double GetFrequency(int n);
+  /// Returns the number of elements in the dicionary;
+  int GetSize() { return (int)mVectorOfGroupIDs.size(); }
+
   friend BuildTopologyDictionary;
   friend LookUp;
   friend TopologyFastSimulation;

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TopologyDictionary.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TopologyDictionary.h
@@ -15,21 +15,21 @@
 ///
 /// Short TopologyDictionary descritpion
 ///
-/// The entries of the dictionaries are the cluster topologies, with all the indormation
+/// The entries of the dictionaries are the cluster topologies, with all the information
 /// which is common to the clusters with the same topology:
 /// - number of rows
 /// - number of columns
+/// - pixel bitmask
 /// - position of the Centre Of Gravity (COG) wrt the bottom left corner pixel of the bounding box
 /// - error associated to the position of the hit point
 /// Rare topologies, i.e. with a frequency below a threshold defined a priori, have not their own entries
 /// in the dictionaries, but are grouped together with topologies with similar dimensions.
-///
+/// For the groups of rare topollogies a dummy bitmask is used.
 
 #ifndef ALICEO2_ITSMFT_TOPOLOGYDICTIONARY_H
 #define ALICEO2_ITSMFT_TOPOLOGYDICTIONARY_H
-#include <Rtypes.h>
+#include "DataFormatsITSMFT/ClusterPattern.h"
 #include <fstream>
-#include <iosfwd>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -44,18 +44,23 @@ class TopologyFastSimulation;
 
 /// Structure containing the most relevant pieces of information of a topology
 struct GroupStruct {
-  unsigned long mHash; ///< Hashcode
-  float mErrX;         ///< Error associated to the hit point in the x direction.
-  float mErrZ;         ///< Error associated to the hit point in the z direction.
-  float mXCOG;         ///< x position of te COG wrt the boottom left corner of the bounding box
-  float mZCOG;         ///< z position of te COG wrt the boottom left corner of the bounding box
-  int mNpixels;        ///< Number of fired pixels
-  double mFrequency;   ///< Frequency of the topology
+  unsigned long mHash;     ///< Hashcode
+  float mErrX;             ///< Error associated to the hit point in the x direction.
+  float mErrZ;             ///< Error associated to the hit point in the z direction.
+  float mXCOG;             ///< x position of te COG wrt the boottom left corner of the bounding box
+  float mZCOG;             ///< z position of te COG wrt the boottom left corner of the bounding box
+  int mNpixels;            ///< Number of fired pixels
+  ClusterPattern mPattern; ///< Bitmask of pixels. For groups the biggest bounding box for the group is taken, with all
+                           ///the bits set to 1.
+  double mFrequency;       ///< Frequency of the topology
 };
 
 class TopologyDictionary
 {
  public:
+
+  /// Default constructor
+  TopologyDictionary();
   /// constexpr for the definition of the groups of rare topologies
   static constexpr int NumberOfRowClasses = 7; ///< Number of row classes for the groups of rare topologies
   static constexpr int NumberOfColClasses = 7; ///< Number of column classes for the groups of rare topologies
@@ -67,8 +72,6 @@ class TopologyDictionary
   friend std::ostream& operator<<(std::ostream& os, const TopologyDictionary& dictionary);
   /// Prints the dictionary in a binary file
   void WriteBinaryFile(std::string outputFile);
-  /// Reads the dictionary from a file
-  void ReadFile(std::string fileName);
   /// Reads the dictionary from a binary file
   void ReadBinaryFile(std::string fileName);
   friend BuildTopologyDictionary;
@@ -77,9 +80,10 @@ class TopologyDictionary
 
  private:
   std::unordered_map<unsigned long, int> mFinalMap; ///< Map of pair <hash, position in mVectorOfGroupIDs>
+  int mSmallTopologiesLUT[8 * 255];                 ///< Look-Up Table for the topologies with 1-byte linearised matrix
   std::vector<GroupStruct> mVectorOfGroupIDs;       ///< Vector of topologies and groups
 
-  ClassDefNV(TopologyDictionary, 1);
+  ClassDefNV(TopologyDictionary, 2);
 };
 } // namespace ITSMFT
 } // namespace o2

--- a/DataFormats/Detectors/ITSMFT/common/src/ClusterPattern.cxx
+++ b/DataFormats/Detectors/ITSMFT/common/src/ClusterPattern.cxx
@@ -57,9 +57,9 @@ ClassImp(o2::ITSMFT::ClusterPattern)
     memcpy(&mBitmap[2], patt, nBytes);
   }
 
-  void ClusterPattern::setPattern(const unsigned char patt[Cluster::kMaxPatternBytes + 2])
+  void ClusterPattern::setPattern(const unsigned char patt[ClusterPattern::kExtendedPatternBytes])
   {
-    memcpy(&mBitmap[0], patt, Cluster::kMaxPatternBytes + 2);
+    memcpy(&mBitmap[0], patt, ClusterPattern::kExtendedPatternBytes);
   }
 
   std::ostream& operator<<(std::ostream& os, const ClusterPattern& pattern)
@@ -73,21 +73,26 @@ ClassImp(o2::ITSMFT::ClusterPattern)
       tempChar = pattern.mBitmap[i];
       s = 128; // 0b10000000
       while (s > 0) {
-        if (ic % pattern.getColumnSpan() == 0)
+        if (ic % pattern.getColumnSpan() == 0) {
           os << "|";
+        }
         ic++;
-        if ((tempChar & s) != 0)
+        if ((tempChar & s) != 0) {
           os << '+';
-        else
+        } else {
           os << ' ';
+        }
         s /= 2;
-        if (ic % pattern.getColumnSpan() == 0)
+        if (ic % pattern.getColumnSpan() == 0) {
           os << "|" << std::endl;
-        if (ic == (pattern.getRowSpan() * pattern.getColumnSpan()))
+        }
+        if (ic == (pattern.getRowSpan() * pattern.getColumnSpan())) {
           break;
+        }
       }
-      if (ic == (pattern.getRowSpan() * pattern.getColumnSpan()))
+      if (ic == (pattern.getRowSpan() * pattern.getColumnSpan())) {
         break;
+      }
     }
     os << std::endl;
     return os;

--- a/DataFormats/Detectors/ITSMFT/common/src/ClusterPattern.cxx
+++ b/DataFormats/Detectors/ITSMFT/common/src/ClusterPattern.cxx
@@ -1,0 +1,96 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file ClusterTopology.cxx
+/// \brief Implementation of the ClusterPattern class.
+///
+/// \author Luca Barioglio, University and INFN of Torino
+#include "DataFormatsITSMFT/ClusterTopology.h"
+#include <iostream>
+
+ClassImp(o2::ITSMFT::ClusterPattern)
+
+  namespace o2
+{
+  namespace ITSMFT
+  {
+  ClusterPattern::ClusterPattern() : mBitmap{ 0 } {}
+
+  ClusterPattern::ClusterPattern(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes])
+  {
+    setPattern(nRow, nCol, patt);
+  }
+
+  unsigned char ClusterPattern::getByte(int n) const
+  {
+    if (n < 0 || n > Cluster::kMaxPatternBytes + 1) {
+      std::cout << "Invalid element of the pattern" << std::endl;
+      return -1;
+    } else {
+      return mBitmap[n];
+    }
+  }
+
+  int ClusterPattern::getUsedBytes() const
+  {
+    int nBits = (int)mBitmap[0] * (int)mBitmap[1];
+    int nBytes = nBits / 8;
+    if (nBits % 8 != 0)
+      nBytes++;
+    return nBytes;
+  }
+
+  void ClusterPattern::setPattern(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes])
+  {
+    mBitmap[0] = (unsigned char)nRow;
+    mBitmap[1] = (unsigned char)nCol;
+    int nBytes = nRow * nCol / 8;
+    if (((nRow * nCol) % 8) != 0)
+      nBytes++;
+    memcpy(&mBitmap[2], patt, nBytes);
+  }
+
+  void ClusterPattern::setPattern(const unsigned char patt[Cluster::kMaxPatternBytes + 2])
+  {
+    memcpy(&mBitmap[0], patt, Cluster::kMaxPatternBytes + 2);
+  }
+
+  std::ostream& operator<<(std::ostream& os, const ClusterPattern& pattern)
+  {
+    os << "rowSpan: " << pattern.getRowSpan() << " columnSpan: " << pattern.getColumnSpan()
+       << " #bytes: " << pattern.getUsedBytes() << std::endl;
+    unsigned char tempChar = 0;
+    int s = 0;
+    int ic = 0;
+    for (unsigned int i = 2; i < pattern.getUsedBytes() + 2; i++) {
+      tempChar = pattern.mBitmap[i];
+      s = 128; // 0b10000000
+      while (s > 0) {
+        if (ic % pattern.getColumnSpan() == 0)
+          os << "|";
+        ic++;
+        if ((tempChar & s) != 0)
+          os << '+';
+        else
+          os << ' ';
+        s /= 2;
+        if (ic % pattern.getColumnSpan() == 0)
+          os << "|" << std::endl;
+        if (ic == (pattern.getRowSpan() * pattern.getColumnSpan()))
+          break;
+      }
+      if (ic == (pattern.getRowSpan() * pattern.getColumnSpan()))
+        break;
+    }
+    os << std::endl;
+    return os;
+  }
+  }
+}

--- a/DataFormats/Detectors/ITSMFT/common/src/ClusterTopology.cxx
+++ b/DataFormats/Detectors/ITSMFT/common/src/ClusterTopology.cxx
@@ -79,7 +79,7 @@ ClassImp(o2::ITSMFT::ClusterTopology)
   unsigned long ClusterTopology::getCompleteHash(int nRow, int nCol,
                                                  const unsigned char patt[Cluster::kMaxPatternBytes])
   {
-    unsigned char extended_pattern[Cluster::kMaxPatternBytes + 2] = { 0 };
+    unsigned char extended_pattern[ClusterPattern::kExtendedPatternBytes] = { 0 };
     extended_pattern[0] = (unsigned char)nRow;
     extended_pattern[1] = (unsigned char)nCol;
     int nBits = nRow * nCol;
@@ -112,10 +112,9 @@ ClassImp(o2::ITSMFT::ClusterTopology)
 
   unsigned long ClusterTopology::getCompleteHash(const ClusterTopology& topology)
   {
-    unsigned char patt[Cluster::kMaxPatternBytes + 2];
-    topology.getPattern(patt);
+    auto patt = topology.getPattern();
     int nBytesUsed = topology.getUsedBytes();
-    unsigned long partialHash = (unsigned long)hashFunction(patt, nBytesUsed);
+    unsigned long partialHash = (unsigned long)hashFunction(patt.data(), nBytesUsed);
     // The first four bytes are directly taken from partialHash
     unsigned long completeHash = partialHash << 32;
     // The last four bytes of the hash are the first 32 pixels of the topology.

--- a/DataFormats/Detectors/ITSMFT/common/src/ClusterTopology.cxx
+++ b/DataFormats/Detectors/ITSMFT/common/src/ClusterTopology.cxx
@@ -22,7 +22,7 @@ ClassImp(o2::ITSMFT::ClusterTopology)
 {
   namespace ITSMFT
   {
-  ClusterTopology::ClusterTopology() : mPattern{ 0 }, mHash{ 0 }, mNbytes{ 0 } {}
+  ClusterTopology::ClusterTopology() : mPattern{}, mHash{ 0 } {}
 
   ClusterTopology::ClusterTopology(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes]) : mHash{ 0 }
   {
@@ -31,12 +31,7 @@ ClassImp(o2::ITSMFT::ClusterTopology)
 
   void ClusterTopology::setPattern(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes])
   {
-    mPattern[0] = (unsigned char)nRow;
-    mPattern[1] = (unsigned char)nCol;
-    mNbytes = nRow * nCol / 8;
-    if (((nRow * nCol) % 8) != 0)
-      mNbytes++;
-    memcpy(&mPattern[2], patt, mNbytes);
+    mPattern.setPattern(nRow, nCol, patt);
     mHash = getCompleteHash(*this);
   }
 
@@ -82,26 +77,30 @@ ClassImp(o2::ITSMFT::ClusterTopology)
   }
 
   unsigned long ClusterTopology::getCompleteHash(int nRow, int nCol,
-                                                 const unsigned char patt[Cluster::kMaxPatternBytes], int nBytesUsed)
+                                                 const unsigned char patt[Cluster::kMaxPatternBytes])
   {
-    unsigned long extended_pattern[Cluster::kMaxPatternBytes + 2] = { 0 };
+    unsigned char extended_pattern[Cluster::kMaxPatternBytes + 2] = { 0 };
     extended_pattern[0] = (unsigned char)nRow;
     extended_pattern[1] = (unsigned char)nCol;
-    memcpy(&extended_pattern[2], patt, nBytesUsed);
+    int nBits = nRow * nCol;
+    int nBytes = nBits / 8;
+    if (nBits % 8 != 0)
+      nBytes++;
+    memcpy(&extended_pattern[2], patt, nBytes);
 
-    unsigned long partialHash = (unsigned long)hashFunction(extended_pattern, nBytesUsed);
+    unsigned long partialHash = (unsigned long)hashFunction(extended_pattern, nBytes);
     // The first four bytes are directly taken from partialHash
     unsigned long completeHash = partialHash << 32;
     // The last four bytes of the hash are the first 32 pixels of the topology.
     // The bits reserved for the pattern that are not used are set to 0.
-    if (nBytesUsed == 1) {
+    if (nBytes == 1) {
       completeHash += ((((unsigned long)extended_pattern[2]) << 24));
-    } else if (nBytesUsed == 2) {
+    } else if (nBytes == 2) {
       completeHash += ((((unsigned long)extended_pattern[2]) << 24) + (((unsigned long)extended_pattern[3]) << 16));
-    } else if (nBytesUsed == 3) {
+    } else if (nBytes == 3) {
       completeHash += ((((unsigned long)extended_pattern[2]) << 24) + (((unsigned long)extended_pattern[3]) << 16) +
                        (((unsigned long)extended_pattern[4]) << 8));
-    } else if (nBytesUsed >= 4) {
+    } else if (nBytes >= 4) {
       completeHash += ((((unsigned long)extended_pattern[2]) << 24) + (((unsigned long)extended_pattern[3]) << 16) +
                        (((unsigned long)extended_pattern[4]) << 8) + ((unsigned long)extended_pattern[5]));
     } else {
@@ -113,9 +112,10 @@ ClassImp(o2::ITSMFT::ClusterTopology)
 
   unsigned long ClusterTopology::getCompleteHash(const ClusterTopology& topology)
   {
-    std::array<unsigned char, Cluster::kMaxPatternBytes + 2> patt = topology.getPattern();
+    unsigned char patt[Cluster::kMaxPatternBytes + 2];
+    topology.getPattern(patt);
     int nBytesUsed = topology.getUsedBytes();
-    unsigned long partialHash = (unsigned long)hashFunction(patt.data(), nBytesUsed);
+    unsigned long partialHash = (unsigned long)hashFunction(patt, nBytesUsed);
     // The first four bytes are directly taken from partialHash
     unsigned long completeHash = partialHash << 32;
     // The last four bytes of the hash are the first 32 pixels of the topology.
@@ -139,32 +139,7 @@ ClassImp(o2::ITSMFT::ClusterTopology)
 
   std::ostream& operator<<(std::ostream& os, const ClusterTopology& topology)
   {
-    os << "rowSpan: " << topology.getRowSpan() << " columnSpan: " << topology.getColumnSpan()
-       << " #bytes: " << topology.getUsedBytes() << std::endl;
-    unsigned char tempChar = 0;
-    int s = 0;
-    int ic = 0;
-    for (unsigned int i = 2; i < topology.getUsedBytes() + 2; i++) {
-      tempChar = topology.mPattern[i];
-      s = 128; // 0b10000000
-      while (s > 0) {
-        if (ic % topology.getColumnSpan() == 0)
-          os << "|";
-        ic++;
-        if ((tempChar & s) != 0)
-          os << '+';
-        else
-          os << ' ';
-        s /= 2;
-        if (ic % topology.getColumnSpan() == 0)
-          os << "|" << std::endl;
-        if (ic == (topology.getRowSpan() * topology.getColumnSpan()))
-          break;
-      }
-      if (ic == (topology.getRowSpan() * topology.getColumnSpan()))
-        break;
-    }
-    os << std::endl;
+    os << topology.mPattern << std::endl;
     return os;
   }
   } // namespace ITSMFT

--- a/DataFormats/Detectors/ITSMFT/common/src/ITSMFTDataFormatsLinkDef.h
+++ b/DataFormats/Detectors/ITSMFT/common/src/ITSMFTDataFormatsLinkDef.h
@@ -16,6 +16,7 @@
 
 #pragma link C++ class o2::ITSMFT::Cluster + ;
 #pragma link C++ class std::vector < o2::ITSMFT::Cluster > +;
+#pragma link C++ class o2::ITSMFT::ClusterPattern + ;
 #pragma link C++ class o2::ITSMFT::ClusterTopology + ;
 #pragma link C++ class o2::ITSMFT::TopologyDictionary + ;
 

--- a/DataFormats/Detectors/ITSMFT/common/src/TopologyDictionary.cxx
+++ b/DataFormats/Detectors/ITSMFT/common/src/TopologyDictionary.cxx
@@ -28,11 +28,14 @@ ClassImp(o2::ITSMFT::TopologyDictionary)
 {
   namespace ITSMFT
   {
+
+  TopologyDictionary::TopologyDictionary() : mSmallTopologiesLUT{-1} {}
+
   std::ostream& operator<<(std::ostream& os, const TopologyDictionary& dict)
   {
     for (auto& p : dict.mVectorOfGroupIDs) {
       os << p.mHash << " " << p.mErrX << " " << p.mErrZ << " " << p.mXCOG << " " << p.mZCOG << " " << p.mNpixels << " "
-         << p.mFrequency << std::endl;
+         << p.mFrequency << p.mPattern << std::endl;
     }
     return os;
   }
@@ -48,35 +51,17 @@ ClassImp(o2::ITSMFT::TopologyDictionary)
       file_output.write(reinterpret_cast<char*>(&p.mZCOG), sizeof(float));
       file_output.write(reinterpret_cast<char*>(&p.mNpixels), sizeof(int));
       file_output.write(reinterpret_cast<char*>(&p.mFrequency), sizeof(double));
+      file_output.write(reinterpret_cast<char*>(&p.mPattern.mBitmap),
+                        sizeof(unsigned char) * (Cluster::kMaxPatternBytes + 2));
     }
     file_output.close();
-  }
-
-  void TopologyDictionary::ReadFile(string fname)
-  {
-    mVectorOfGroupIDs.clear();
-    mFinalMap.clear();
-    std::ifstream in(fname);
-    GroupStruct gr;
-    int groupID = 0;
-    if (!in.is_open()) {
-      cout << "The file could not be opened" << endl;
-      exit(1);
-    } else {
-      while (in >> gr.mHash >> gr.mErrX >> gr.mErrZ >> gr.mXCOG >> gr.mZCOG >> gr.mNpixels >> gr.mFrequency) {
-        mVectorOfGroupIDs.push_back(gr);
-        if (((gr.mHash) & 0xffffffff) != 0)
-          mFinalMap.insert(std::make_pair(gr.mHash, groupID));
-        groupID++;
-      }
-    }
-    in.close();
   }
 
   void TopologyDictionary::ReadBinaryFile(string fname)
   {
     mVectorOfGroupIDs.clear();
     mFinalMap.clear();
+    for(auto &p : mSmallTopologiesLUT) p = -1;
     std::ifstream in(fname.data(), std::ios::in | std::ios::binary);
     GroupStruct gr;
     int groupID = 0;
@@ -91,7 +76,10 @@ ClassImp(o2::ITSMFT::TopologyDictionary)
         in.read(reinterpret_cast<char*>(&gr.mZCOG), sizeof(float));
         in.read(reinterpret_cast<char*>(&gr.mNpixels), sizeof(int));
         in.read(reinterpret_cast<char*>(&gr.mFrequency), sizeof(double));
+        in.read(reinterpret_cast<char*>(&gr.mPattern.mBitmap), sizeof(unsigned char) * (Cluster::kMaxPatternBytes + 2));
         mVectorOfGroupIDs.push_back(gr);
+        if (gr.mPattern.getUsedBytes() == 1)
+          mSmallTopologiesLUT[(gr.mPattern.getRowSpan() - 1) * 255 + (int)gr.mPattern.mBitmap[2]] = groupID;
         if (((gr.mHash) & 0xffffffff) != 0)
           mFinalMap.insert(std::make_pair(gr.mHash, groupID));
         groupID++;

--- a/DataFormats/Detectors/ITSMFT/common/src/TopologyDictionary.cxx
+++ b/DataFormats/Detectors/ITSMFT/common/src/TopologyDictionary.cxx
@@ -29,13 +29,16 @@ ClassImp(o2::ITSMFT::TopologyDictionary)
   namespace ITSMFT
   {
 
-  TopologyDictionary::TopologyDictionary() : mSmallTopologiesLUT{-1} {}
+  TopologyDictionary::TopologyDictionary() : mSmallTopologiesLUT{ -1 } {}
 
   std::ostream& operator<<(std::ostream& os, const TopologyDictionary& dict)
   {
     for (auto& p : dict.mVectorOfGroupIDs) {
-      os << p.mHash << " " << p.mErrX << " " << p.mErrZ << " " << p.mXCOG << " " << p.mZCOG << " " << p.mNpixels << " "
-         << p.mFrequency << p.mPattern << std::endl;
+      os << "Hash: " << p.mHash << " ErrX: " << p.mErrX << " ErrZ : " << p.mErrZ << " xCOG: " << p.mXCOG << " zCOG: " << p.mZCOG << " Npixles: " << p.mNpixels << " Frequency: "
+         << p.mFrequency << std::endl
+         << p.mPattern << std::endl
+         << "*********************************************************" << std::endl
+         << std::endl;
     }
     return os;
   }
@@ -52,7 +55,7 @@ ClassImp(o2::ITSMFT::TopologyDictionary)
       file_output.write(reinterpret_cast<char*>(&p.mNpixels), sizeof(int));
       file_output.write(reinterpret_cast<char*>(&p.mFrequency), sizeof(double));
       file_output.write(reinterpret_cast<char*>(&p.mPattern.mBitmap),
-                        sizeof(unsigned char) * (Cluster::kMaxPatternBytes + 2));
+                        sizeof(unsigned char) * (ClusterPattern::kExtendedPatternBytes));
     }
     file_output.close();
   }
@@ -61,7 +64,8 @@ ClassImp(o2::ITSMFT::TopologyDictionary)
   {
     mVectorOfGroupIDs.clear();
     mFinalMap.clear();
-    for(auto &p : mSmallTopologiesLUT) p = -1;
+    for (auto& p : mSmallTopologiesLUT)
+      p = -1;
     std::ifstream in(fname.data(), std::ios::in | std::ios::binary);
     GroupStruct gr;
     int groupID = 0;
@@ -76,7 +80,7 @@ ClassImp(o2::ITSMFT::TopologyDictionary)
         in.read(reinterpret_cast<char*>(&gr.mZCOG), sizeof(float));
         in.read(reinterpret_cast<char*>(&gr.mNpixels), sizeof(int));
         in.read(reinterpret_cast<char*>(&gr.mFrequency), sizeof(double));
-        in.read(reinterpret_cast<char*>(&gr.mPattern.mBitmap), sizeof(unsigned char) * (Cluster::kMaxPatternBytes + 2));
+        in.read(reinterpret_cast<char*>(&gr.mPattern.mBitmap), sizeof(unsigned char) * (ClusterPattern::kExtendedPatternBytes));
         mVectorOfGroupIDs.push_back(gr);
         if (gr.mPattern.getUsedBytes() == 1)
           mSmallTopologiesLUT[(gr.mPattern.getRowSpan() - 1) * 255 + (int)gr.mPattern.mBitmap[2]] = groupID;
@@ -86,6 +90,80 @@ ClassImp(o2::ITSMFT::TopologyDictionary)
       }
     }
     in.close();
+  }
+
+  float TopologyDictionary::GetXcog(int n)
+  {
+    if (n < 0 || n >= (int)mVectorOfGroupIDs.size()) {
+      printf("Incorrect element\n");
+      exit(1);
+    } else
+      return mVectorOfGroupIDs[n].mXCOG;
+  }
+  float TopologyDictionary::GetErrX(int n)
+  {
+    if (n < 0 || n >= (int)mVectorOfGroupIDs.size()) {
+      printf("Incorrect element\n");
+      exit(1);
+    } else
+      return mVectorOfGroupIDs[n].mErrX;
+  }
+
+  float TopologyDictionary::GetZcog(int n)
+  {
+    if (n < 0 || n >= (int)mVectorOfGroupIDs.size()) {
+      printf("Incorrect element\n");
+      exit(1);
+    } else
+      return mVectorOfGroupIDs[n].mZCOG;
+  }
+
+  float TopologyDictionary::GetErrZ(int n)
+  {
+    if (n < 0 || n >= (int)mVectorOfGroupIDs.size()) {
+      printf("Incorrect element\n");
+      exit(1);
+    } else
+      return mVectorOfGroupIDs[n].mErrZ;
+  }
+
+  unsigned long TopologyDictionary::GetHash(int n)
+  {
+    if (n < 0 || n >= (int)mVectorOfGroupIDs.size()) {
+      printf("Incorrect element\n");
+      exit(1);
+    } else
+      return mVectorOfGroupIDs[n].mHash;
+  }
+
+  int TopologyDictionary::GetNpixels(int n)
+  {
+    if (n < 0 || n >= (int)mVectorOfGroupIDs.size()) {
+      printf("Incorrect element\n");
+      exit(1);
+    } else
+      return mVectorOfGroupIDs[n].mNpixels;
+  }
+
+  ClusterPattern TopologyDictionary::GetPattern(int n)
+  {
+    if (n < 0 || n >= (int)mVectorOfGroupIDs.size()) {
+      printf("Incorrect element\n");
+      exit(1);
+    } else
+      return mVectorOfGroupIDs[n].mPattern;
+  }
+
+  double TopologyDictionary::GetFrequency(int n)
+  {
+    if (n < 0 || n >= (int)mVectorOfGroupIDs.size()) {
+      printf("Incorrect element\n");
+      exit(1);
+    } else if (n == 0) {
+      return mVectorOfGroupIDs[n].mFrequency;
+    } else {
+      return mVectorOfGroupIDs[n].mFrequency - mVectorOfGroupIDs[n - 1].mFrequency;
+    }
   }
   } // namespace ITSMFT
 }

--- a/Detectors/ITSMFT/ITS/macros/test/CheckTopologies.C
+++ b/Detectors/ITSMFT/ITS/macros/test/CheckTopologies.C
@@ -134,21 +134,21 @@ void CheckTopologies(Int_t nEvents = 10, TString mcEngine = "TGeant3")
       completeDictionary.accountTopology(topology, dx, dz);
     }
   }
-  completeDictionary.setThreshold(0.00001);
+  completeDictionary.setThreshold(0.0001);
   completeDictionary.groupRareTopologies();
   completeDictionary.printDictionaryBinary("complete_dictionary.bin");
-  ofstream completeDictionaryOutput("complete_dictionary.txt");
-  completeDictionaryOutput << completeDictionary;
-  noiseDictionary.setThreshold(0.00001);
+  completeDictionary.printDictionary("complete_dictionary.txt");
+  completeDictionary.saveDictionaryRoot("complete_dictionary.root");
+  noiseDictionary.setThreshold(0.0001);
   noiseDictionary.groupRareTopologies();
   noiseDictionary.printDictionaryBinary("noise_dictionary.bin");
-  ofstream noiseDictionaryOutput("noise_dictionary.txt");
-  noiseDictionaryOutput << noiseDictionary;
-  signalDictionary.setThreshold(0.00001);
+  noiseDictionary.printDictionary("noise_dictionary.txt");
+  noiseDictionary.saveDictionaryRoot("noise_dictionary.root");
+  signalDictionary.setThreshold(0.0001);
   signalDictionary.groupRareTopologies();
   signalDictionary.printDictionaryBinary("signal_dictionary.bin");
-  ofstream signalDictionaryOutput("signal_dictionary.txt");
-  signalDictionaryOutput << signalDictionary;
+  signalDictionary.printDictionary("signal_dictionary.txt");
+  signalDictionary.saveDictionaryRoot("signal_dictionary.root");
 
   TFile histogramOutput("histograms.root", "recreate");
   TCanvas* cComplete = new TCanvas("cComplete", "Distribution of all the topologies");

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/BuildTopologyDictionary.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/BuildTopologyDictionary.h
@@ -22,9 +22,6 @@
 #ifndef ALICEO2_ITSMFT_BUILDTOPOLOGYDICTIONARY_H
 #define ALICEO2_ITSMFT_BUILDTOPOLOGYDICTIONARY_H
 #include <algorithm>
-#include <array>
-#include <map>
-#include <unordered_map>
 #include "ITSMFTBase/SegmentationAlpide.h"
 #include "DataFormatsITSMFT/ClusterTopology.h"
 #include "DataFormatsITSMFT/TopologyDictionary.h"
@@ -49,6 +46,8 @@ struct TopologyInfo {
   float mZmean;
   float mZsigma2;
   int mNpixels;
+  ClusterPattern mPattern; ///< Bitmask of pixels. For groups the biggest bounding box for the group is taken, with all
+                           ///the bits set to 1.
 };
 
 class BuildTopologyDictionary
@@ -75,7 +74,7 @@ class BuildTopologyDictionary
 
  private:
   TopologyDictionary mDictionary; ///< Dictionary of topologies
-  std::map<unsigned long, std::pair<ClusterTopology, unsigned long>>
+  std::unordered_map<unsigned long, std::pair<ClusterTopology, unsigned long>>
     mTopologyMap; ///< Temporary map of type <hash,<topology,counts>>
   std::vector<std::pair<unsigned long, unsigned long>> mTopologyFrequency; ///< <freq,hash>, needed to define threshold
   int mTotClusters;
@@ -85,7 +84,7 @@ class BuildTopologyDictionary
 
   std::unordered_map<long unsigned, TopologyInfo> mMapInfo;
 
-  ClassDefNV(BuildTopologyDictionary, 1);
+  ClassDefNV(BuildTopologyDictionary, 2);
 };
 } // namespace ITSMFT
 } // namespace o2

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/BuildTopologyDictionary.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/BuildTopologyDictionary.h
@@ -22,6 +22,7 @@
 #ifndef ALICEO2_ITSMFT_BUILDTOPOLOGYDICTIONARY_H
 #define ALICEO2_ITSMFT_BUILDTOPOLOGYDICTIONARY_H
 #include <algorithm>
+#include <map>
 #include "ITSMFTBase/SegmentationAlpide.h"
 #include "DataFormatsITSMFT/ClusterTopology.h"
 #include "DataFormatsITSMFT/TopologyDictionary.h"
@@ -67,6 +68,7 @@ class BuildTopologyDictionary
   friend std::ostream& operator<<(std::ostream& os, const BuildTopologyDictionary& BD);
   void printDictionary(std::string fname);
   void printDictionaryBinary(std::string fname);
+  void saveDictionaryRoot(const char* filename);
 
   int getTotClusters() const { return mTotClusters; }
   int getNotInGroups() const { return mNotInGroups; }
@@ -74,8 +76,8 @@ class BuildTopologyDictionary
 
  private:
   TopologyDictionary mDictionary; ///< Dictionary of topologies
-  std::unordered_map<unsigned long, std::pair<ClusterTopology, unsigned long>>
-    mTopologyMap; ///< Temporary map of type <hash,<topology,counts>>
+  std::map<unsigned long, std::pair<ClusterTopology, unsigned long>>
+    mTopologyMap;                                                         ///< Temporary map of type <hash,<topology,counts>>
   std::vector<std::pair<unsigned long, unsigned long>> mTopologyFrequency; ///< <freq,hash>, needed to define threshold
   int mTotClusters;
   int mNumberOfGroups;

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/LookUp.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/LookUp.h
@@ -33,6 +33,7 @@ class LookUp
 {
  public:
   LookUp(std::string fileName);
+  static int groupFinder(int nRow, int nCol);
   int findGroupID(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes]);
   int getTopologiesOverThreshold() { return mTopologiesOverThreshold; }
 

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/LookUp.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/LookUp.h
@@ -33,7 +33,7 @@ class LookUp
 {
  public:
   LookUp(std::string fileName);
-  int findGroupID(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes], int nBytesUsed);
+  int findGroupID(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes]);
   int getTopologiesOverThreshold() { return mTopologiesOverThreshold; }
 
  private:

--- a/Detectors/ITSMFT/common/reconstruction/src/LookUp.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/LookUp.cxx
@@ -29,9 +29,24 @@ LookUp::LookUp(std::string fileName)
   mTopologiesOverThreshold = mDictionary.mFinalMap.size();
 }
 
-int LookUp::findGroupID(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes], int nBytesUsed)
+int LookUp::findGroupID(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes])
 {
-  unsigned long hash = ClusterTopology::getCompleteHash(nRow, nCol, patt, nBytesUsed);
+  int nBits = nRow * nCol;
+  int nBytes = nBits / 8;
+  if (nBits % 8 != 0)
+    nBytes++;
+  if (nBytes == 1){
+    int ID = mDictionary.mSmallTopologiesLUT[(nRow - 1) * 255 + (int)patt[0]];
+    if(ID>=0) return ID;
+    else{
+      int index = (nRow / TopologyDictionary::RowClassSpan) * TopologyDictionary::NumberOfRowClasses +
+                  nCol / TopologyDictionary::ColClassSpan;
+      if (index >= TopologyDictionary::NumberOfRowClasses * TopologyDictionary::NumberOfColClasses)
+        index = TopologyDictionary::NumberOfRowClasses * TopologyDictionary::NumberOfColClasses;
+      return (mTopologiesOverThreshold + index);
+    }
+  }
+  unsigned long hash = ClusterTopology::getCompleteHash(nRow, nCol, patt);
   auto ret = mDictionary.mFinalMap.find(hash);
   if (ret != mDictionary.mFinalMap.end())
     return ret->second;

--- a/Detectors/ITSMFT/common/reconstruction/src/LookUp.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/LookUp.cxx
@@ -29,32 +29,43 @@ LookUp::LookUp(std::string fileName)
   mTopologiesOverThreshold = mDictionary.mFinalMap.size();
 }
 
+int LookUp::groupFinder(int nRow, int nCol)
+{
+  int row_index = nRow / TopologyDictionary::RowClassSpan;
+  if (nRow % TopologyDictionary::RowClassSpan == 0) {
+    row_index--;
+  }
+  int col_index = nCol / TopologyDictionary::ColClassSpan;
+  if (nCol % TopologyDictionary::RowClassSpan == 0) {
+    col_index--;
+  }
+  if (row_index > TopologyDictionary::MaxNumberOfClasses || col_index > TopologyDictionary::MaxNumberOfClasses) {
+    return TopologyDictionary::NumberOfRareGroups - 1;
+  } else {
+    return row_index * TopologyDictionary::MaxNumberOfClasses + col_index;
+  }
+}
+
 int LookUp::findGroupID(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes])
 {
   int nBits = nRow * nCol;
-  int nBytes = nBits / 8;
-  if (nBits % 8 != 0)
-    nBytes++;
-  if (nBytes == 1){
+  // Small topology
+  if (nBits < 9) {
     int ID = mDictionary.mSmallTopologiesLUT[(nRow - 1) * 255 + (int)patt[0]];
-    if(ID>=0) return ID;
-    else{
-      int index = (nRow / TopologyDictionary::RowClassSpan) * TopologyDictionary::NumberOfRowClasses +
-                  nCol / TopologyDictionary::ColClassSpan;
-      if (index >= TopologyDictionary::NumberOfRowClasses * TopologyDictionary::NumberOfColClasses)
-        index = TopologyDictionary::NumberOfRowClasses * TopologyDictionary::NumberOfColClasses;
+    if (ID >= 0)
+      return ID;
+    else { //small rare topology (inside groups)
+      int index = groupFinder(nRow, nCol);
       return (mTopologiesOverThreshold + index);
     }
   }
+  // Big topology
   unsigned long hash = ClusterTopology::getCompleteHash(nRow, nCol, patt);
   auto ret = mDictionary.mFinalMap.find(hash);
   if (ret != mDictionary.mFinalMap.end())
     return ret->second;
-  else {
-    int index = (nRow / TopologyDictionary::RowClassSpan) * TopologyDictionary::NumberOfRowClasses +
-                nCol / TopologyDictionary::ColClassSpan;
-    if (index >= TopologyDictionary::NumberOfRowClasses * TopologyDictionary::NumberOfColClasses)
-      index = TopologyDictionary::NumberOfRowClasses * TopologyDictionary::NumberOfColClasses;
+  else { // Big rare topology (inside groups)
+    int index = groupFinder(nRow, nCol);
     return (mTopologiesOverThreshold + index);
   }
 }


### PR DESCRIPTION
A look-up table containing all the IDs of topologies whose bitmap is contained in 1B has been added. Thus it is possible to avoid the computation of the hashcode for the smallest (and very common) topologies when ecountered. Indeed, the LUT element is directly accessed through its 1-Byte bitmap.

Then the dimensions of the groups of rare topologies have changed. Previously, the maximum size of the pattern was 32x32 (defined in `TopologyDictionary`). However, all the topologies with one dimensions exceeding this limit belonged to the group with 32 as number of row or columns. Now, the maximum number of rows/columns has been increased to the highest possible number for a topology with 512 pixels (`Cluster::kMaxPatternBits`).