### PR TITLE
Improve log parsing speed for control and metrics

### DIFF
--- a/Framework/Core/src/DeviceMetricsInfo.cxx
+++ b/Framework/Core/src/DeviceMetricsInfo.cxx
@@ -28,8 +28,8 @@ namespace framework
 // [METRIC] <name>,<type> <value> <timestamp> [<tags>]
 bool DeviceMetricsHelper::parseMetric(const std::string& s, std::smatch& match)
 {
-  const static std::regex metricsRE(".*METRIC.* ([a-zA-Z0-9/_-]+),(0|1|2|4) ([0-9.]+) ([0-9]+) (.*)");
-  return std::regex_match(s, match, metricsRE);
+  const static std::regex metricsRE(R"regex(\[METRIC\] ([a-zA-Z0-9/_-]+),(0|1|2|4) ([0-9.]+) ([0-9]+))regex", std::regex::optimize);
+  return std::regex_search(s, match, metricsRE);
 }
 
 bool DeviceMetricsHelper::processMetric(const std::smatch& match,

--- a/Framework/Core/src/LogParsingHelpers.cxx
+++ b/Framework/Core/src/LogParsingHelpers.cxx
@@ -25,20 +25,31 @@ char const* const LogParsingHelpers::LOG_LEVELS[(int)LogParsingHelpers::LogLevel
 using LogLevel = o2::framework::LogParsingHelpers::LogLevel;
 
 LogLevel LogParsingHelpers::parseTokenLevel(const std::string &s) {
-  std::smatch match;
-  const static std::regex metricsRE(R"regex(^\[[0-9][0-9]:[0-9][0-9]:[0-9][0-9]\]\[(DEBUG|INFO|STATE|WARN|ERROR)\] .*)regex");
-  std::regex_match(s, match, metricsRE);
 
-  if (match.empty()) {
+  // Example format: [99:99:99][ERROR] (string begins with that, longest is 17 chars)
+  constexpr size_t MAXPREFLEN = 17;
+  constexpr size_t LABELPOS = 10;
+  if (s.size() < MAXPREFLEN) {
     return LogLevel::Unknown;
   }
-  if (match[1] == "DEBUG") {
+
+  // Check if first chars match [NN:NN:NN]
+  //                            0123456789
+  if ((unsigned char)s[0] != '[' || (unsigned char)s[9] != ']' ||
+      (unsigned char)s[3] != ':' || (unsigned char)s[6] != ':' ||
+      (unsigned char)s[1] - '0' > 9 || (unsigned char)s[2] - '0' > 9 ||
+      (unsigned char)s[4] - '0' > 9 || (unsigned char)s[5] - '0' > 9 ||
+      (unsigned char)s[7] - '0' > 9 || (unsigned char)s[8] - '0' > 9) {
+    return LogLevel::Unknown;
+  }
+
+  if (s.compare(LABELPOS, 7, "[DEBUG]") == 0) {
     return LogLevel::Debug;
-  } else if (match[1] == "INFO" || match[1] == "STATE") {
+  } else if (s.compare(LABELPOS, 6, "[INFO]") == 0 || s.compare(LABELPOS, 7, "[STATE]") == 0) {
     return LogLevel::Info;
-  } else if (match[1] == "WARN") {
+  } else if (s.compare(LABELPOS, 6, "[WARN]") == 0) {
     return LogLevel::Warning;
-  } else if (match[1] == "ERROR") {
+  } else if (s.compare(LABELPOS, 7, "[ERROR]") == 0) {
     return LogLevel::Error;
   }
   return LogLevel::Unknown;

--- a/Framework/Core/src/TextControlService.cxx
+++ b/Framework/Core/src/TextControlService.cxx
@@ -32,8 +32,11 @@ void TextControlService::readyToQuit(bool all) {
 }
 
 bool parseControl(const std::string &s, std::smatch &match) {
-  const static std::regex controlRE(".*CONTROL_ACTION: READY_TO_(QUIT)_(ME|ALL)");
-  return std::regex_match(s, match, controlRE);
+  const static std::regex controlRE("CONTROL_ACTION: READY_TO_(QUIT)_(ME|ALL)", std::regex::optimize);
+  if (s.find("CONTROL_ACTION: ", 0, 50) == std::string::npos) {
+    return false;
+  }
+  return std::regex_search(s, match, controlRE);
 }
 
 } // framework

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -466,7 +466,7 @@ void processChildrenOutput(DriverInfo& driverInfo, DeviceInfos& infos, DeviceSpe
         // We use this callback to cache which metrics are needed to provide a
         // the DataRelayer view.
         DeviceMetricsHelper::processMetric(match, metrics, updateDataRelayerViewIndex);
-      } else if (parseControl(token, match)) {
+      } else if (logLevel == LogParsingHelpers::LogLevel::Info && parseControl(token, match)) {
         auto command = match[1];
         auto validFor = match[2];
         LOG(DEBUG) << "Found control command " << command << " from pid " << info.pid << " valid for " << validFor;


### PR DESCRIPTION
Regular expressions were avoided/optimized as much as possible. This code is
executed very frequently on the control process and profiling shows it had,
before optimization, a heavy impact on the workflow.

After optimization, the vast majority of the CPU time is spent in the regular
expression parsing metrics. There are still margins of optimization there.

Note that we rely on the fact that:

* control messages use log level "INFO"
* metrics use an unknown log level