### PR TITLE
 DPL input API: returning smart pointer also for std containers

### DIFF
--- a/Detectors/TPC/workflow/src/ClusterConverterSpec.cxx
+++ b/Detectors/TPC/workflow/src/ClusterConverterSpec.cxx
@@ -44,7 +44,7 @@ DataProcessorSpec getClusterConverterSpec()
     auto processingFct = [](ProcessingContext& pc) {
       // this will return a span of TPC clusters
       auto inClusters = pc.inputs().get<std::vector<o2::TPC::Cluster>>("clusterin");
-      int nClusters = inClusters.size();
+      int nClusters = inClusters->size();
       LOG(INFO) << "got clusters from input: " << nClusters;
 
       std::vector<ClusterHardwareContainer> containerMetrics;
@@ -52,7 +52,7 @@ DataProcessorSpec getClusterConverterSpec()
       for (; clusterIndex < nClusters; clusterIndex++) {
         // clusters are supposed to be sorted in CRU number, start a new entry
         // for every new CRU, a map is needed if the clusters are not ordered
-        auto inputcluster = inClusters[clusterIndex];
+        auto inputcluster = (*inClusters)[clusterIndex];
         uint16_t CRU = inputcluster.getCRU();
         if (containerMetrics.size() == 0 || containerMetrics.back().CRU != CRU) {
           containerMetrics.emplace_back(ClusterHardwareContainer{ 0, 0, 0, 0, 0, 0, 0, 0, 0xFFFFFFFF, 0, CRU });
@@ -90,7 +90,7 @@ DataProcessorSpec getClusterConverterSpec()
           LOG(DEBUG) << "writing " << clusterContainer->numberOfClusters << " cluster(s) of CRU "
                      << clusterContainer->CRU;
           for (unsigned int clusterInPage = 0; clusterInPage < clusterContainer->numberOfClusters; clusterInPage++) {
-            const auto& inputCluster = inClusters[clusterIndex + clusterInPage];
+            const auto& inputCluster = (*inClusters)[clusterIndex + clusterInPage];
             auto& outputCluster = clusterContainer->clusters[clusterInPage];
             outputCluster.setCluster(inputCluster.getPadMean(),
                                      inputCluster.getTimeMean() - clusterContainer->timeBinOffset,

--- a/Detectors/TPC/workflow/src/ClustererSpec.cxx
+++ b/Detectors/TPC/workflow/src/ClustererSpec.cxx
@@ -47,10 +47,10 @@ DataProcessorSpec getClustererSpec()
       auto inDigits = pc.inputs().get<std::vector<o2::TPC::Digit>>("digits");
       auto inMCLabels = pc.inputs().get<MCLabelContainer>("mclabels");
 
-      LOG(INFO) << "processing " << inDigits.size() << " digit object(s)";
+      LOG(INFO) << "processing " << inDigits->size() << " digit object(s)";
       clusterArray->clear();
       mctruthArray->clear();
-      clusterer->Process(inDigits, inMCLabels.get(), 1);
+      clusterer->Process(*inDigits, inMCLabels.get(), 1);
       LOG(INFO) << "clusterer produced " << clusterArray->size() << " cluster(s)";
       pc.outputs().snapshot(OutputRef{ "clusters" }, *clusterArray.get());
       pc.outputs().snapshot(OutputRef{ "clusterlbl" }, *mctruthArray.get());

--- a/Detectors/TPC/workflow/src/RootFileWriterSpec.cxx
+++ b/Detectors/TPC/workflow/src/RootFileWriterSpec.cxx
@@ -54,8 +54,8 @@ DataProcessorSpec getRootFileWriterSpec()
     // function gets out of scope
     auto processingFct = [outputfile, outputtree, tracks](ProcessingContext& pc) {
       auto indata = pc.inputs().get<std::vector<o2::TPC::TrackTPC>>("input");
-      LOG(INFO) << "RootFileWriter: get " << indata.size() << " track(s)";
-      *tracks.get() = std::move(indata);
+      LOG(INFO) << "RootFileWriter: get " << indata->size() << " track(s)";
+      *tracks.get() = std::move(*indata);
       LOG(INFO) << "RootFileWriter: write " << tracks->size() << " track(s)";
       outputtree->Fill();
     };

--- a/Framework/Core/README.md
+++ b/Framework/Core/README.md
@@ -265,21 +265,21 @@ the `ProcessingContext`  your computation  lambda is  passed and  contains one
 value for each of the `InputSpec` you specified. E.g.:
 
 ```cpp
-InputRecord &args = ctx.inputs();
+InputRecord &inputs = ctx.inputs();
 ```
 
 From the `InputRecord` instance you can get the arguments either via their positional
 index:
 
 ```cpp
-DataRef ref = args.getByPos(0);
+DataRef ref = inputs.getByPos(0);
 ```
 
 or using the mnemonics-label which was used as first argument in the associated
 `InputSpec`.
 
 ```cpp
-DataRef ref = args.get("points");
+DataRef ref = inputs.get("points");
 ```
 
 You can then use the `DataRef` `header` and `payload` raw pointers to access
@@ -289,16 +289,35 @@ If the message is of a known type, you can automatically get a a smart pointer
 to the contents of the message by passing it as template argument, e.g.:
 
 ```cpp
-auto v = args.get<XYZ>("points");
-XYZ &p = *v;
+auto v = inputs.get<XYZ>("points");
+const XYZ &p = *v;
 ```
 
-The framework will also take care of necessary deserialization.
+Check next  section  for known types.  The framework  will  also take  care of
+necessary deserialization.
 
 [InputRecord]: https://github.com/AliceO2Group/AliceO2/blob/HEAD/Framework/Core/include/Framework/InputRecord.h
 
-### Creating outputs - the DataAllocator API
+#### Utilities for working with `DataRef`
+Get payload size:
+```cpp
+size_t payloadSize = DataRefUtils::getPayloadSize(ref);
+```
 
+Extract a header from the header stack:
+```cpp
+const HeaderType* header = DataRefUtils::getHeader<HeaderType*>(ref);
+```
+
+Get the payload of messageable type as `gsl::span`
+```cpp
+auto data = DataRefUtils::as<T>(ref);
+for (const auto& element : data) {
+  // do something on element, remember it's const
+}
+```
+
+### Creating outputs - the DataAllocator API
 In order  to prevent  algorithms  to  create  data they  are  not  supposed to
 create, a special `DataAllocator` object is passed to the process callback, so
 that only messages for declared outputs  can be created. A `DataAllocator` can
@@ -308,25 +327,29 @@ wrapper around the collection. A  `DataAllocator` can adopt externally created
 resources via  the `adopt` method. A  `DataAllocator` can create a  copy of an
 externally owned resource via the `snapshot` method.
 
-Currently supported data types are:
+Currently supported data types for `make<T>` are:
 
 - Vanilla `char *` buffers with associated size. This is the actual contents of
   the FairMQ message.
-- POD types. These get directly mapped on the message exchanged by FairMQ and 
-  are therefore "zerocopy" for what the DataProcessingLayer is concerned.
-- POD collections, which are exposed to the user as `gsl::span`.
+- Messageable types. trivially copyable, non-polymorphic types.\
+  These get directly mapped on the message exchanged by FairMQ and are therefore
+  "zerocopy" for what the DataProcessingLayer is concerned.
+- Collections of messageable types, exposed to the user as `gsl::span`.
 - TObject derived classes. These are actually serialised via a TMessage
   and therefore are only suitable for the cases in which the cost of such a
   serialization is not an issue.
 
-Currently supported data types for snapshot functionality, the state at time of
-calling snapshot is captured in a copy:
-- POD types
-- TObject derived classes, serialized
-- std::vector of POD type, at the receiver side the collection is exposed
+Currently supported data types for `snapshot` functionality, state at time of
+calling `snapshot` is captured in a copy, and sent when processing is done:
+- Messageable types
+- ROOT-serializable classes. serialised via a TMessage.\
+  Classes implementing ROOT's TClass interface and std containers of those are
+  automatically detected. ROOT-serialization can be forced using type converter
+  `ROOTSerialized`, e.g. for types which can not be detected automatically
+- std::vector of messageable type, at receiver side the collection is exposed
   as gsl::span
-- std::vector pointer to POD type, the objects are linearized in the message
-  and exposed as gsl::span on the receiver side
+- std::vector of pointers to messageable type, the objects are linearized in the
+  message and exposed as gsl::span on the receiver side
 
 The DataChunk object resembles a `iovec`:
 

--- a/Framework/Core/test/test_DataAllocator.cxx
+++ b/Framework/Core/test/test_DataAllocator.cxx
@@ -149,21 +149,21 @@ DataProcessorSpec getSinkSpec()
 
     // container of objects
     auto object4 = pc.inputs().get<std::vector<o2::test::Polymorphic>>("input4");
-    ASSERT_ERROR(object4.size() == 2);
-    ASSERT_ERROR(object4[0] == o2::test::Polymorphic(0xaffe));
-    ASSERT_ERROR(object4[1] == o2::test::Polymorphic(0xd00f));
+    ASSERT_ERROR(object4->size() == 2);
+    ASSERT_ERROR((*object4)[0] == o2::test::Polymorphic(0xaffe));
+    ASSERT_ERROR((*object4)[1] == o2::test::Polymorphic(0xd00f));
 
     // container of objects
     auto object5 = pc.inputs().get<std::vector<o2::test::Polymorphic>>("input5");
-    ASSERT_ERROR(object5.size() == 2);
-    ASSERT_ERROR(object5[0] == o2::test::Polymorphic(0xaffe));
-    ASSERT_ERROR(object5[1] == o2::test::Polymorphic(0xd00f));
+    ASSERT_ERROR(object5->size() == 2);
+    ASSERT_ERROR((*object5)[0] == o2::test::Polymorphic(0xaffe));
+    ASSERT_ERROR((*object5)[1] == o2::test::Polymorphic(0xd00f));
 
     // container of objects
     auto object6 = pc.inputs().get<std::vector<o2::test::Polymorphic>>("input6");
-    ASSERT_ERROR(object6.size() == 2);
-    ASSERT_ERROR(object6[0] == o2::test::Polymorphic(0xaffe));
-    ASSERT_ERROR(object6[1] == o2::test::Polymorphic(0xd00f));
+    ASSERT_ERROR(object6->size() == 2);
+    ASSERT_ERROR((*object6)[0] == o2::test::Polymorphic(0xaffe));
+    ASSERT_ERROR((*object6)[1] == o2::test::Polymorphic(0xd00f));
 
     // checking retrieving buffer as raw char*, and checking content by cast
     auto rawchar = pc.inputs().get<const char*>("input1");

--- a/Framework/Utils/test/test_RootTreeReader.cxx
+++ b/Framework/Utils/test/test_RootTreeReader.cxx
@@ -88,11 +88,11 @@ DataProcessorSpec getSinkSpec()
     }
     auto data = pc.inputs().get<std::vector<o2::test::Polymorphic>>("input");
 
-    LOG(INFO) << "count: " << counter << "  data elements:" << data.size();
-    ASSERT_ERROR(counter + 1 == data.size());
-    for (int idx = 0; idx < data.size(); idx++) {
-      LOG(INFO) << data[idx].get();
-      ASSERT_ERROR(data[idx].get() == 10 * counter + idx);
+    LOG(INFO) << "count: " << counter << "  data elements:" << data->size();
+    ASSERT_ERROR(counter + 1 == data->size());
+    for (int idx = 0; idx < data->size(); idx++) {
+      LOG(INFO) << (*data)[idx].get();
+      ASSERT_ERROR((*data)[idx].get() == 10 * counter + idx);
     }
     if (++counter >= kTreeSize) {
       pc.services().get<ControlService>().readyToQuit(true);

--- a/Steer/DigitizerWorkflow/src/TPCDigitRootWriterSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TPCDigitRootWriterSpec.cxx
@@ -158,8 +158,8 @@ DataProcessorSpec getTPCDigitRootWriterSpec(int numberofsourcedevices)
           // have to do work ...
           // the digits
           auto indata = pc.inputs().get<std::vector<o2::TPC::Digit>>(cname.c_str());
-          LOG(INFO) << "DIGIT SIZE " << indata.size();
-          *digits.get() = std::move(indata);
+          LOG(INFO) << "DIGIT SIZE " << indata->size();
+          *digits.get() = std::move(*indata);
           {
             // connect this to a particular branch
             auto br = getOrMakeBranch(*outputtree.get(), "TPCDigit", sector, digits.get());


### PR DESCRIPTION
Instead of returning container instance by move, a smart pointer of
the container is now returned. The return type is now a smart pointer
in all cases but retrieving input as const char* and std::string.
get<DataRef> (also default without template type) returns still the
reference to DataRef.

The special treatment of containers of ROOT-serializable types was a
remnant of 6257473, where the template type parameter could be a pointer
or plain type allowing more fine-grained substitutions.