### PR TITLE
Alpide clusterer can mask pixels fired in previous ROFrame

### DIFF
--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/Cluster.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/Cluster.h
@@ -18,7 +18,7 @@
 // uncomment this to have cluster topology stored
 #define _ClusterTopology_
 
-#define CLUSTER_VERSION 2
+#define CLUSTER_VERSION 3
 
 namespace o2
 {
@@ -61,7 +61,7 @@ class Cluster : public o2::BaseCluster<float>
  public:
   static constexpr int maxLabels = 10;
 
-  ~Cluster() override = default;
+  ~Cluster() = default;
 
   Cluster& operator=(const Cluster& cluster) = delete; // RS why?
 
@@ -129,9 +129,9 @@ class Cluster : public o2::BaseCluster<float>
   UShort_t mPatternColMin = 0;                ///< pattern start column
   UChar_t mPattern[kMaxPatternBytes] = { 0 }; ///< cluster topology
   //
-  ClassDefOverride(Cluster, CLUSTER_VERSION + 1)
+  ClassDefNV(Cluster, CLUSTER_VERSION + 1)
 #else
-  ClassDefOverride(Cluster, CLUSTER_VERSION)
+  ClassDefNV(Cluster, CLUSTER_VERSION)
 #endif
 };
 //______________________________________________________

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/Cluster.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/Cluster.h
@@ -93,6 +93,10 @@ class Cluster : public o2::BaseCluster<float>
   UInt_t getROFrame() const { return mROFrame; }
   void setROFrame(UInt_t v) { mROFrame = v; }
   //
+  // methods for indexing. Consider to eliminate the index at all
+  int getIndex() const { return mIndex; }
+  void setIndex(int i) { mIndex = i; }
+
   // bool hasCommonTrack(const Cluster* cl) const;
   //
   void print() const;
@@ -118,6 +122,8 @@ class Cluster : public o2::BaseCluster<float>
  protected:
   //
   UInt_t mROFrame;  ///< RO Frame
+  int mIndex = -1;  // origianl index of this cluster in its vector (consider to drop it)
+
   Int_t mNxNzN = 0; ///< effective cluster size in X (1st byte) and Z (2nd byte) directions
                     ///< and total Npix(next 9 bits).
                     ///> The last 7 bits are used for clusters usage counter

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/BaseCluster.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/BaseCluster.h
@@ -35,7 +35,6 @@ class BaseCluster
   T mSigmaY2;                  // error in Y direction (usually rphi)
   T mSigmaZ2;                  // error in Z direction (usually Z)
   T mSigmaYZ;                  // non-diagonal term of error matrix
-  int mIndex = -1;             // origianl index of this cluster in its vector (consider to drop it)
   std::uint16_t mSensorID = 0; // the sensor id
   std::int8_t mCount = 0;      // user field reserved for counting
   std::uint8_t mBits = 0;      // user field reserved for bit flags
@@ -55,10 +54,6 @@ class BaseCluster
     : mPos(x, y, z), mSigmaY2(sy2), mSigmaZ2(sz2), mSigmaYZ(syz), mSensorID(sensid)
   {
   }
-
-  // methods for indexing. Consider to eliminate the index at all
-  int getIndex() const { return mIndex; }
-  void setIndex(int i) { mIndex = i; }
 
   // getting the cartesian coordinates and errors
   T getX() const { return mPos.X(); }

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/BaseCluster.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/BaseCluster.h
@@ -28,13 +28,14 @@ namespace o2
 // planes etc.) internal sensor ID within detector
 // Detector specific clusters should be composed by including it as data member
 template <typename T>
-class BaseCluster : public TObject // temprarily derive from TObject
+class BaseCluster
 {
  private:
   Point3D<T> mPos;             // cartesian position
   T mSigmaY2;                  // error in Y direction (usually rphi)
   T mSigmaZ2;                  // error in Z direction (usually Z)
   T mSigmaYZ;                  // non-diagonal term of error matrix
+  int mIndex = -1;             // origianl index of this cluster in its vector (consider to drop it)
   std::uint16_t mSensorID = 0; // the sensor id
   std::int8_t mCount = 0;      // user field reserved for counting
   std::uint8_t mBits = 0;      // user field reserved for bit flags
@@ -54,6 +55,10 @@ class BaseCluster : public TObject // temprarily derive from TObject
     : mPos(x, y, z), mSigmaY2(sy2), mSigmaZ2(sz2), mSigmaYZ(syz), mSensorID(sensid)
   {
   }
+
+  // methods for indexing. Consider to eliminate the index at all
+  int getIndex() const { return mIndex; }
+  void setIndex(int i) { mIndex = i; }
 
   // getting the cartesian coordinates and errors
   T getX() const { return mPos.X(); }
@@ -113,10 +118,9 @@ class BaseCluster : public TObject // temprarily derive from TObject
   }
 
  protected:
-  ~BaseCluster() override = default;
+  ~BaseCluster() = default;
 
-  //  ClassDefNV(BaseCluster, 1);
-  ClassDefOverride(BaseCluster, 1); // temporarily
+  ClassDefNV(BaseCluster, 2);
 };
 
 template <class T>

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/ClustererTask.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/ClustererTask.h
@@ -47,6 +47,7 @@ class ClustererTask : public FairTask
 
   InitStatus Init() override;
   void Exec(Option_t* option) override;
+  Clusterer& getClusterer() { return mClusterer; }
 
  private:
   bool mUseMCTruth = true;                                ///< flag to use MCtruth if available

--- a/Detectors/ITSMFT/ITS/reconstruction/src/ClustererTask.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/ClustererTask.cxx
@@ -75,6 +75,9 @@ InitStatus ClustererTask::Init()
   mGeometry = geom;
   mClusterer.setGeometry(geom);
 
+  printf("%s | MCTruth: %s\n", Class()->GetName(), arrDigLbl ? "ON" : "OFF");
+  mClusterer.print();
+
   return kSUCCESS;
 }
 

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CookedTracker.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CookedTracker.cxx
@@ -99,7 +99,7 @@ Label CookedTracker::cookLabel(TrackITS& t, Float_t wrong) const
   for (int i = noc; i--;) {
     Int_t index = t.getClusterIndex(i);
     const Cluster* c = getCluster(index);
-    auto labels = mClsLabels->getLabels(c->GetUniqueID());
+    auto labels = mClsLabels->getLabels(c->getIndex()); // RS consider not using the stored index
 
     for (auto lab : labels) { // check all labels of the cluster
       if (lab.isEmpty())
@@ -147,7 +147,7 @@ void CookedTracker::setExternalIndices(TrackITS& t) const
   for (Int_t i = 0; i < noc; i++) {
     Int_t index = t.getClusterIndex(i);
     const Cluster* c = getCluster(index);
-    Int_t idx = c->GetUniqueID();
+    Int_t idx = c->getIndex(); // RS: consided not using stored index
     t.setExternalClusterIndex(i, idx);
   }
 }

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/DigitizerTask.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/DigitizerTask.h
@@ -56,8 +56,8 @@ class DigitizerTask : public FairTask
   bool isContinuous() const { return mParams.isContinuous(); }
   void setFairTimeUnitInNS(double tinNS) { mFairTimeUnitInNS = tinNS < 1. ? 1. : tinNS; }
   double getFairTimeUnitInNS() const { return mFairTimeUnitInNS; }
-  void setAlpideROFramLength(float l) { mParams.setROFrameLenght(l); }
-  float getAlpideROFramLength() const { return mParams.getROFrameLenght(); }
+  void setAlpideROFramLength(float l) { mParams.setROFrameLength(l); }
+  float getAlpideROFramLength() const { return mParams.getROFrameLength(); }
 
  private:
   o2::ITSMFT::DigiParams mParams; // settings, eventually load this from the CCDB

--- a/Detectors/ITSMFT/MFT/reconstruction/include/MFTReconstruction/ClustererTask.h
+++ b/Detectors/ITSMFT/MFT/reconstruction/include/MFTReconstruction/ClustererTask.h
@@ -50,7 +50,8 @@ class ClustererTask : public FairTask
   ~ClustererTask() override;
 
   InitStatus Init() override;
-  void Exec(Option_t* opt) override;
+  void Exec(Option_t* option) override;
+  Clusterer& getClusterer() { return mClusterer; }
 
  private:
   bool mUseMCTruth = true;                             ///< flag to use MCtruth if available

--- a/Detectors/ITSMFT/MFT/reconstruction/src/ClustererTask.cxx
+++ b/Detectors/ITSMFT/MFT/reconstruction/src/ClustererTask.cxx
@@ -77,6 +77,9 @@ InitStatus ClustererTask::Init()
   mGeometry = geom;
   mClusterer.setGeometry(geom);
 
+  printf("%s | MCTruth: %s\n", Class()->GetName(), arrDigLbl ? "ON" : "OFF");
+  mClusterer.print();
+
   return kSUCCESS;
 }
 

--- a/Detectors/ITSMFT/MFT/simulation/include/MFTSimulation/DigitizerTask.h
+++ b/Detectors/ITSMFT/MFT/simulation/include/MFTSimulation/DigitizerTask.h
@@ -52,8 +52,8 @@ class DigitizerTask : public FairTask
   bool isContinuous() const { return mParams.isContinuous(); }
   void setFairTimeUnitInNS(double tinNS) { mFairTimeUnitInNS = tinNS < 1. ? 1. : tinNS; }
   double getFairTimeUnitInNS() const { return mFairTimeUnitInNS; }
-  void setAlpideROFramLength(float l) { mParams.setROFrameLenght(l); }
-  float getAlpideROFramLength() const { return mParams.getROFrameLenght(); }
+  void setAlpideROFramLength(float l) { mParams.setROFrameLength(l); }
+  float getAlpideROFramLength() const { return mParams.getROFrameLength(); }
 
  private:
   o2::ITSMFT::DigiParams mParams; // settings, eventually load this from the CCDB

--- a/Detectors/ITSMFT/common/reconstruction/CMakeLists.txt
+++ b/Detectors/ITSMFT/common/reconstruction/CMakeLists.txt
@@ -5,12 +5,14 @@ O2_SETUP(NAME ${MODULE_NAME})
 set(SRCS
   src/PixelReader.cxx
   src/Clusterer.cxx
+  src/PixelData.cxx
   src/BuildTopologyDictionary.cxx
   src/LookUp.cxx
   src/TopologyFastSimulation.cxx
 )
 set(HEADERS
   include/${MODULE_NAME}/PixelReader.h
+  include/${MODULE_NAME}/PixelData.h
   include/${MODULE_NAME}/Clusterer.h
   include/${MODULE_NAME}/BuildTopologyDictionary.h
   include/${MODULE_NAME}/LookUp.h

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
@@ -78,11 +78,12 @@ class Clusterer
   void finishChip(std::vector<Cluster>& clusters);
   void fetchMCLabels(int digID, std::array<Label, Cluster::maxLabels>& labels, int& nfilled) const;
 
-  ChipPixelData mChipData; ///< single chip data provided by the reader
+  ChipPixelData* mChipData = nullptr; //! pointer on the current single chip data provided by the reader
 
   ///< array of chips, at the moment index corresponds to chip ID.
   ///< for the processing of fraction of chips only consider mapping of IDs range on mChips
   std::vector<ChipPixelData> mChips;
+  std::vector<ChipPixelData> mChipsOld;
 
   bool mMaskOverflowPixels = true; ///< flag to mask oveflow pixels (fired from hit in prev. ROF)
   Int_t mColumn1[kMaxRow + 2];

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
@@ -13,14 +13,21 @@
 #ifndef ALICEO2_ITS_CLUSTERER_H
 #define ALICEO2_ITS_CLUSTERER_H
 
+#define _PERFORM_TIMING_
+
 #include <utility>
 #include <vector>
 #include "ITSMFTBase/GeometryTGeo.h"
 #include "DataFormatsITSMFT/Cluster.h"
 #include "ITSMFTReconstruction/PixelReader.h"
+#include "ITSMFTReconstruction/PixelData.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 
 #include "Rtypes.h"
+
+#ifdef _PERFORM_TIMING_
+#include <TStopwatch.h>
+#endif
 
 namespace o2
 {
@@ -36,8 +43,8 @@ namespace ITSMFT
 class Clusterer
 {
   using PixelReader = o2::ITSMFT::PixelReader;
-  using PixelData = o2::ITSMFT::PixelReader::PixelData;
-  using ChipPixelData = o2::ITSMFT::PixelReader::ChipPixelData;
+  using PixelData = o2::ITSMFT::PixelData;
+  using ChipPixelData = o2::ITSMFT::ChipPixelData;
   using Cluster = o2::ITSMFT::Cluster;
   using Label = o2::MCCompLabel;
   using MCTruth = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
@@ -56,21 +63,35 @@ class Clusterer
   void setClustersMCTruthContainer(MCTruth* truth) { mClsLabels = truth; }
   void setDigitsMCTruthContainer(const MCTruth* truth) { mDigLabels = truth; }
 
+  void setMaskOverflowPixels(bool v) { mMaskOverflowPixels = v; }
+  bool isMaskOverflowPixels() const { return mMaskOverflowPixels; }
+
+  UInt_t getCurrROF() const { return mCurrROF; }
+  UShort_t getCurrChipID() const { return mCurrChipID; }
+
+  void print() const;
+
  private:
   enum { kMaxRow = 650 }; // Anything larger than the real number of rows (512 for ALPIDE)
-  void initChip();
-  void updateChip(int ip);
+  void initChip(UInt_t first);
+  void updateChip(UInt_t ip);
   void finishChip(std::vector<Cluster>& clusters);
   void fetchMCLabels(int digID, std::array<Label, Cluster::maxLabels>& labels, int& nfilled) const;
 
   ChipPixelData mChipData; ///< single chip data provided by the reader
 
+  ///< array of chips, at the moment index corresponds to chip ID.
+  ///< for the processing of fraction of chips only consider mapping of IDs range on mChips
+  std::vector<ChipPixelData> mChips;
+
+  bool mMaskOverflowPixels = true; ///< flag to mask oveflow pixels (fired from hit in prev. ROF)
   Int_t mColumn1[kMaxRow + 2];
   Int_t mColumn2[kMaxRow + 2];
   Int_t *mCurr, *mPrev;
-
+  UInt_t mCurrROF = o2::ITSMFT::PixelData::DummyROF;
+  UShort_t mCurrChipID = o2::ITSMFT::PixelData::DummyChipID;
   using NextIndex = int;
-  std::vector<std::pair<NextIndex, int>> mPixels;
+  std::vector<std::pair<NextIndex, UInt_t>> mPixels;
 
   using FirstIndex = Int_t;
   std::vector<FirstIndex> mPreClusterHeads;
@@ -82,6 +103,10 @@ class Clusterer
   const o2::ITSMFT::GeometryTGeo* mGeometry = nullptr; //! ITS OR MFT upgrade geometry
   const MCTruth* mDigLabels = nullptr;                 //! Digits MC labels
   MCTruth* mClsLabels = nullptr;                       //! Cluster MC labels
+
+#ifdef _PERFORM_TIMING_
+  TStopwatch mTimer;
+#endif
 };
 
 } // namespace ITSMFT

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/PixelData.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/PixelData.h
@@ -1,0 +1,163 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file PixelData.h
+/// \brief Transient data classes for single pixel and set of pixels from current chip
+#ifndef ALICEO2_ITSMFT_PIXELDATA_H
+#define ALICEO2_ITSMFT_PIXELDATA_H
+
+#include "ITSMFTBase/Digit.h"
+#include <vector>
+#include <utility>
+
+namespace o2
+{
+namespace ITSMFT
+{
+
+///< single pixel datum, with possibility to set a flag of pixel being masked out
+class PixelData
+{
+
+ public:
+  PixelData(const Digit* dig) : mRow(dig->getRow()), mCol(dig->getColumn()) {}
+  PixelData(UShort_t r = 0, UShort_t c = 0) : mRow(r), mCol(c) {}
+  UShort_t getRow() const { return mRow & RowMask; }
+  UShort_t getCol() const { return mCol; }
+  bool isMasked() const { return mRow & MaskBit; }
+  void setMask() { mRow |= MaskBit; }
+  void unsetMask() { mRow &= RowMask; }
+
+  /// for faster access when the pixel is guaranteed to not be masked
+  UShort_t getRowDirect() const { return mRow; }
+
+  bool operator==(const PixelData& dt) const
+  {
+    ///< check if one pixel is equal to another
+    return (getCol() == dt.getCol()) && (getRow() == dt.getRow());
+  }
+
+  bool operator>(const PixelData& dt) const
+  {
+    ///< check if one pixel is greater than another (first column then row)
+    if (getCol() == dt.getCol()) {
+      return getRow() > dt.getRow();
+    }
+    return getCol() > dt.getCol();
+  }
+
+  bool operator<(const PixelData& dt) const
+  {
+    ///< check if one pixel is lesser than another (first column then row)
+    if (getCol() == dt.getCol()) {
+      return getRow() < dt.getRow();
+    }
+    return getCol() < dt.getCol();
+  }
+
+  int compare(const PixelData& dt) const
+  {
+    ///< compare to pixels (first column then row)
+    return operator==(dt) ? 0 : (operator>(dt) ? 1 : -1);
+  }
+
+  static constexpr UInt_t DummyROF = 0xffffffff;
+  static constexpr UInt_t DummyChipID = 0xffff;
+
+ private:
+  void sanityCheck() const;
+  static constexpr int RowMask = 0x1ff; ///< 512 rows are supported
+  static constexpr int MaskBit = 0x200; ///< 10-th bit is used to flag masked pixel
+  UShort_t mRow = 0;                    ///< pixel row
+  UShort_t mCol = 0;                    ///< pixel column
+
+  ClassDefNV(PixelData, 1);
+};
+
+///< Transient data for single chip fired pixeld
+///< Assumes that the digits data is sorted in chip/col/row
+class ChipPixelData
+{
+
+ public:
+  ChipPixelData() = default;
+  ~ChipPixelData() = default;
+  UShort_t getChipID() const { return mChipID; }
+  UInt_t getROFrame() const { return mROFrame; }
+  UInt_t getStartID() const { return mStartID; }
+  UInt_t getFirstUnmasked() const { return mFirstUnmasked; }
+  const std::vector<PixelData>& getData() const { return mPixels; }
+  std::vector<PixelData>& getData() { return (std::vector<PixelData>&)mPixels; }
+
+  void setChipID(UShort_t id) { mChipID = id; }
+  void setROFrame(UInt_t r) { mROFrame = r; }
+  void setStartID(UInt_t id) { mStartID = id; }
+  void setFirstUnmasked(UInt_t n) { mFirstUnmasked = n; }
+
+  void clear()
+  {
+    mPixels.clear();
+    mFirstUnmasked = 0;
+  }
+
+  void swap(ChipPixelData& other)
+  {
+    // swap content of two objects
+    mPixels.swap(other.mPixels);
+    std::swap(mROFrame, other.mROFrame);
+    std::swap(mChipID, other.mChipID);
+    // strictly speaking, swapping the data below is not needed
+    std::swap(mStartID, other.mStartID);
+    std::swap(mFirstUnmasked, other.mFirstUnmasked);
+  }
+
+  void maskFiredInSample(const ChipPixelData& sample)
+  {
+    ///< mask in the current data pixels fired in provided sample
+    const auto& pixelsS = sample.getData();
+    UInt_t nC = mPixels.size();
+    if (!nC) {
+      return;
+    }
+    UInt_t nS = pixelsS.size();
+    if (!nS) {
+      return;
+    }
+    UInt_t itC = 0, itS = 0;
+    while (itC < nC && itS < nS) {
+      auto& pix0 = mPixels[itC];
+      const auto& pixC = pixelsS[itS];
+      if (pix0 == pixC) { // same
+        pix0.setMask();
+        if (mFirstUnmasked == itC++) { // mFirstUnmasked should flag 1st unmasked pixel entry
+          mFirstUnmasked = itC;
+        }
+        itS++;
+      } else if (pix0 < pixC) {
+        itC++;
+      } else {
+        itS++;
+      }
+    }
+  }
+
+ private:
+  UShort_t mChipID = 0;           // chip id within the detector
+  UInt_t mROFrame = 0;            // readout frame ID
+  UInt_t mFirstUnmasked = 0;      // first unmasked entry in the mPixels
+  UInt_t mStartID = 0;            // entry of the 1st pixel data in the whole detector data, for MCtruth access
+  std::vector<PixelData> mPixels; // vector of pixeld
+
+  ClassDefNV(ChipPixelData, 1);
+};
+}
+}
+
+#endif //ALICEO2_ITSMFT_PIXELDATA_H

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/PixelReader.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/PixelReader.h
@@ -14,6 +14,7 @@
 #define ALICEO2_ITSMFT_PIXELREADER_H
 
 #include <Rtypes.h>
+#include "ITSMFTReconstruction/PixelData.h"
 #include "ITSMFTBase/Digit.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 
@@ -30,27 +31,10 @@ class PixelReader
 
  public:
   /// Transient data for single fired pixel
-  struct PixelData {
-    UShort_t row;
-    UShort_t col;
-    PixelData(const Digit* dig) : row(dig->getRow()), col(dig->getColumn()) {}
-    PixelData(UShort_t r = 0, UShort_t c = 0) : row(r), col(c) {}
-  };
-
-  /// Transient data for single chip fired pixeld
-  /// In case of MC it assumes that the digits data is sorted in chip/col/row
-  struct ChipPixelData {
-    UShort_t chipID = 0;           // chip id within detector
-    UInt_t roFrame = 0;            // readout frame ID
-    UInt_t startID = 0;            // entry of the 1st pixel data, for MCtruth access
-    std::vector<PixelData> pixels; // vector of pixeld
-
-    void clear() { pixels.clear(); }
-  };
 
   PixelReader() = default;
-  PixelReader(const PixelReader& cluster) = delete;
   virtual ~PixelReader() = default;
+  PixelReader(const PixelReader& cluster) = delete;
 
   PixelReader& operator=(const PixelReader& src) = delete;
 
@@ -59,6 +43,7 @@ class PixelReader
   //
  protected:
   //
+  ClassDef(PixelReader, 1);
 };
 
 /// \class DigitPixelReader
@@ -68,6 +53,7 @@ class DigitPixelReader : public PixelReader
 {
  public:
   DigitPixelReader() = default;
+  ~DigitPixelReader() override = default;
   void setDigitArray(const std::vector<o2::ITSMFT::Digit>* a)
   {
     mDigitArray = a;
@@ -83,15 +69,17 @@ class DigitPixelReader : public PixelReader
   Bool_t getNextChipData(ChipPixelData& chipData) override;
 
  private:
-  void addPixel(PixelReader::ChipPixelData& chipData, const Digit* dig)
+  void addPixel(ChipPixelData& chipData, const Digit* dig)
   {
     // add new fired pixel
-    chipData.pixels.emplace_back(dig);
+    chipData.getData().emplace_back(dig);
   }
 
   const std::vector<o2::ITSMFT::Digit>* mDigitArray = nullptr;
   const Digit* mLastDigit = nullptr;
   Int_t mIdx = 0;
+
+  ClassDefOverride(DigitPixelReader, 1);
 };
 
 /// \class RawPixelReader
@@ -100,7 +88,11 @@ class DigitPixelReader : public PixelReader
 class RawPixelReader : public PixelReader
 {
  public:
+  RawPixelReader() = default;
+  ~RawPixelReader() override = default;
   Bool_t getNextChipData(ChipPixelData& chipData) override;
+
+  ClassDefOverride(RawPixelReader, 1);
 };
 
 } // namespace ITSMFT

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/PixelReader.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/PixelReader.h
@@ -17,6 +17,7 @@
 #include "ITSMFTReconstruction/PixelData.h"
 #include "ITSMFTBase/Digit.h"
 #include "SimulationDataFormat/MCCompLabel.h"
+#include <vector>
 
 namespace o2
 {
@@ -39,7 +40,8 @@ class PixelReader
   PixelReader& operator=(const PixelReader& src) = delete;
 
   virtual void init() = 0;
-  virtual Bool_t getNextChipData(ChipPixelData& chipData) = 0;
+  virtual bool getNextChipData(ChipPixelData& chipData) = 0;
+  virtual ChipPixelData* getNextChipData(std::vector<ChipPixelData>& chipDataVec) = 0;
   //
  protected:
   //
@@ -66,7 +68,8 @@ class DigitPixelReader : public PixelReader
     mLastDigit = nullptr;
   }
 
-  Bool_t getNextChipData(ChipPixelData& chipData) override;
+  bool getNextChipData(ChipPixelData& chipData) override;
+  ChipPixelData* getNextChipData(std::vector<ChipPixelData>& chipDataVec) override;
 
  private:
   void addPixel(ChipPixelData& chipData, const Digit* dig)
@@ -90,7 +93,8 @@ class RawPixelReader : public PixelReader
  public:
   RawPixelReader() = default;
   ~RawPixelReader() override = default;
-  Bool_t getNextChipData(ChipPixelData& chipData) override;
+  bool getNextChipData(ChipPixelData& chipData) override;
+  ChipPixelData* getNextChipData(std::vector<ChipPixelData>& chipDataVec) override;
 
   ClassDefOverride(RawPixelReader, 1);
 };

--- a/Detectors/ITSMFT/common/reconstruction/src/Clusterer.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/Clusterer.cxx
@@ -32,27 +32,68 @@ Clusterer::Clusterer() : mCurr(mColumn2 + 1), mPrev(mColumn1 + 1)
   LOG(INFO) << "ATTENTION: YOU ARE RUNNING IN SPECIAL MODE OF STORING CLUSTER PATTERN" << FairLogger::endl;
   LOG(INFO) << "*********************************************************************" << FairLogger::endl;
 #endif //_ClusterTopology_
+
+#ifdef _PERFORM_TIMING_
+  mTimer.Stop();
+#endif
 }
 
 //__________________________________________________
 void Clusterer::process(PixelReader& reader, std::vector<Cluster>& clusters)
 {
+
+#ifdef _PERFORM_TIMING_
+  mTimer.Start(kFALSE);
+#endif
+
   reader.init();
 
   while (reader.getNextChipData(mChipData)) {
-    LOG(DEBUG) << "ITSClusterer got Chip " << mChipData.chipID << " ROFrame " << mChipData.roFrame << " Nhits "
-               << mChipData.pixels.size() << FairLogger::endl;
-    initChip();
-    for (int ip = 1; ip < mChipData.pixels.size(); ip++) {
-      updateChip(ip);
+
+    // if necessary, flush existing data
+    mCurrROF = mChipData.getROFrame();
+    if (mChipData.getChipID() < mCurrChipID) {
+      LOG(INFO) << "ITS: clusterizing new ROFrame " << mCurrROF << FairLogger::endl;
     }
-    finishChip(clusters);
+    mCurrChipID = mChipData.getChipID();
+    // LOG(DEBUG) << "ITSClusterer got Chip " << mCurrChipID << " ROFrame " << mChipData.getROFrame()
+    //            << " Nhits " << mChipData.getData().size() << FairLogger::endl;
+
+    if (mMaskOverflowPixels) { // mask pixels fired from the previous ROF
+      if (mChips.size() <= mCurrChipID) {
+        mChips.resize(mCurrChipID + 1);
+      }
+      const auto& chipInPrevROF = mChips[mCurrChipID];
+      if (chipInPrevROF.getROFrame() + 1 == mCurrROF) {
+        mChipData.maskFiredInSample(mChips[mCurrChipID]);
+      }
+    }
+    auto validPixID = mChipData.getFirstUnmasked();
+    if (validPixID < mChipData.getData().size()) { // chip data may have all of its pixels masked!
+      initChip(validPixID++);
+      for (; validPixID < mChipData.getData().size(); validPixID++) {
+        if (!mChipData.getData()[validPixID].isMasked()) {
+          updateChip(validPixID);
+        }
+      }
+      finishChip(clusters);
+    }
+    if (mMaskOverflowPixels) { // current chip data will be used in the next ROF to mask overflow pixels
+      mChips[mCurrChipID].swap(mChipData);
+    }
   }
+
+#ifdef _PERFORM_TIMING_
+  mTimer.Stop();
+  printf("Clusterization timing (w/o disk IO): ");
+  mTimer.Print();
+#endif
 }
 
 //__________________________________________________
-void Clusterer::initChip()
+void Clusterer::initChip(UInt_t first)
 {
+  // init chip with the 1st unmasked pixel (entry "from" in the mChipData)
   mPrev = mColumn1 + 1;
   mCurr = mColumn2 + 1;
   std::fill(std::begin(mColumn1), std::end(mColumn1), -1);
@@ -61,31 +102,31 @@ void Clusterer::initChip()
   mPixels.clear();
   mPreClusterHeads.clear();
   mPreClusterIndices.clear();
-  PixelReader::PixelData* pix = &mChipData.pixels[0];
-  mCol = pix->col;
-  mCurr[pix->row] = 0;
+  auto pix = mChipData.getData()[first];
+  mCol = pix.getCol();
+  mCurr[pix.getRowDirect()] = 0; // can use getRowDirect since the pixel is not masked
   // start the first pre-cluster
   mPreClusterHeads.push_back(0);
   mPreClusterIndices.push_back(0);
-  mPixels.emplace_back(-1, 0); // id of current pixel
+  mPixels.emplace_back(-1, first); // id of current pixel
 }
 
 //__________________________________________________
-void Clusterer::updateChip(int ip)
+void Clusterer::updateChip(UInt_t ip)
 {
-  const auto pix = mChipData.pixels[ip];
-  if (mCol != pix.col) { // switch the buffers
+  const auto pix = mChipData.getData()[ip];
+  if (mCol != pix.getCol()) { // switch the buffers
     Int_t* tmp = mCurr;
     mCurr = mPrev;
     mPrev = tmp;
-    if (pix.col > mCol + 1)
+    if (pix.getCol() > mCol + 1)
       std::fill(mPrev, mPrev + kMaxRow, -1);
     std::fill(mCurr, mCurr + kMaxRow, -1);
-    mCol = pix.col;
+    mCol = pix.getCol();
   }
 
   Bool_t attached = false;
-  UShort_t row = pix.row;
+  UShort_t row = pix.getRowDirect(); // can use getRowDirect since the pixel is not masked
   Int_t neighbours[]{ mCurr[row - 1], mPrev[row], mPrev[row + 1], mPrev[row - 1] };
   for (auto pci : neighbours) {
     if (pci < 0)
@@ -125,7 +166,7 @@ void Clusterer::finishChip(std::vector<Cluster>& clusters)
 
   std::array<Label, Cluster::maxLabels> labels;
   std::array<PixelData, Cluster::kMaxPatternBits * 2> pixArr;
-
+  const auto& pixData = mChipData.getData();
   Int_t noc = clusters.size();
   for (Int_t i1 = 0; i1 < mPreClusterHeads.size(); ++i1) {
     const auto ci = mPreClusterIndices[i1];
@@ -139,26 +180,26 @@ void Clusterer::finishChip(std::vector<Cluster>& clusters)
     Int_t next = mPreClusterHeads[i1];
     while (next >= 0) {
       const auto& dig = mPixels[next];
-      const auto pix = mChipData.pixels[dig.second]; // PixelReader.PixelData
-      x += pix.row;
-      z += pix.col;
-      if (pix.row < rowMin) {
-        rowMin = pix.row;
+      const auto pix = pixData[dig.second];
+      x += pix.getRowDirect();
+      z += pix.getCol();
+      if (pix.getRowDirect() < rowMin) {
+        rowMin = pix.getRowDirect();
       }
-      if (pix.row > rowMax) {
-        rowMax = pix.row;
+      if (pix.getRowDirect() > rowMax) {
+        rowMax = pix.getRowDirect();
       }
-      if (pix.col < colMin) {
-        colMin = pix.col;
+      if (pix.getCol() < colMin) {
+        colMin = pix.getCol();
       }
-      if (pix.col > colMax) {
-        colMax = pix.col;
+      if (pix.getCol() > colMax) {
+        colMax = pix.getCol();
       }
       if (npix < pixArr.size()) {
         pixArr[npix] = pix; // needed for cluster topology
       }
       if (mDigLabels) { // the MCtruth for this pixel is at mChipData.startID+dig.second
-        fetchMCLabels(dig.second + mChipData.startID, labels, nlab);
+        fetchMCLabels(dig.second + mChipData.getStartID(), labels, nlab);
       }
       npix++;
       next = dig.first;
@@ -171,26 +212,26 @@ void Clusterer::finishChip(std::vector<Cluster>& clusters)
       next = mPreClusterHeads[i2];
       while (next >= 0) {
         const auto& dig = mPixels[next];
-        const auto pix = mChipData.pixels[dig.second]; // PixelReader.PixelData
-        x += pix.row;
-        z += pix.col;
-        if (pix.row < rowMin) {
-          rowMin = pix.row;
+        const auto pix = pixData[dig.second]; // PixelData
+        x += pix.getRowDirect();
+        z += pix.getCol();
+        if (pix.getRowDirect() < rowMin) {
+          rowMin = pix.getRowDirect();
         }
-        if (pix.row > rowMax) {
-          rowMax = pix.row;
+        if (pix.getRowDirect() > rowMax) {
+          rowMax = pix.getRowDirect();
         }
-        if (pix.col < colMin) {
-          colMin = pix.col;
+        if (pix.getCol() < colMin) {
+          colMin = pix.getCol();
         }
-        if (pix.col > colMax) {
-          colMax = pix.col;
+        if (pix.getCol() > colMax) {
+          colMax = pix.getCol();
         }
         if (npix < pixArr.size()) {
           pixArr[npix] = pix; // needed for cluster topology
         }
         if (mDigLabels) { // the MCtruth for this pixel is at mChipData.startID+dig.second
-          fetchMCLabels(dig.second + mChipData.startID, labels, nlab);
+          fetchMCLabels(dig.second + mChipData.getStartID(), labels, nlab);
         }
         npix++;
         next = dig.first;
@@ -201,13 +242,13 @@ void Clusterer::finishChip(std::vector<Cluster>& clusters)
     Point3D<float> xyzLoc(Segmentation::getFirstRowCoordinate() + x * Segmentation::PitchRow / npix, 0.f,
                           Segmentation::getFirstColCoordinate() + z * Segmentation::PitchCol / npix);
     auto xyzTra =
-      mGeometry->getMatrixT2L(mChipData.chipID) ^ (xyzLoc); // inverse transform from Local to Tracking frame
+      mGeometry->getMatrixT2L(mChipData.getChipID()) ^ (xyzLoc); // inverse transform from Local to Tracking frame
 
     clusters.emplace_back();
     Cluster& c = clusters[noc];
     c.SetUniqueID(noc); // Let the cluster remember its position within the cluster array
-    c.setROFrame(mChipData.roFrame);
-    c.setSensorID(mChipData.chipID);
+    c.setROFrame(mChipData.getROFrame());
+    c.setSensorID(mChipData.getChipID());
     c.setPos(xyzTra);
     c.setErrors(SigmaX2, SigmaY2, 0.f);
     c.setNxNzN(rowMax - rowMin + 1, colMax - colMin + 1, npix);
@@ -243,7 +284,7 @@ void Clusterer::finishChip(std::vector<Cluster>& clusters)
       npix = pixArr.size();
     for (int i = 0; i < npix; i++) {
       const auto pix = pixArr[i];
-      unsigned short ir = pix.row - rowMin, ic = pix.col - colMin;
+      unsigned short ir = pix.getRowDirect() - rowMin, ic = pix.getCol() - colMin;
       if (ir < rowSpanW && ic < colSpanW) {
         c.setPixel(ir, ic);
       }
@@ -275,4 +316,11 @@ void Clusterer::fetchMCLabels(int digID, std::array<Label, Cluster::maxLabels>& 
     }
   }
   //
+}
+
+//__________________________________________________
+void Clusterer::print() const
+{
+  // print settings
+  printf("Masking of overflow pixels: %s\n", mMaskOverflowPixels ? "ON" : "OFF");
 }

--- a/Detectors/ITSMFT/common/reconstruction/src/Clusterer.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/Clusterer.cxx
@@ -248,7 +248,7 @@ void Clusterer::finishChip(std::vector<Cluster>& clusters)
 
     clusters.emplace_back();
     Cluster& c = clusters[noc];
-    c.SetUniqueID(noc); // Let the cluster remember its position within the cluster array
+    c.setIndex(noc); // Let the cluster remember its position within the cluster array
     c.setROFrame(mChipData->getROFrame());
     c.setSensorID(mChipData->getChipID());
     c.setPos(xyzTra);

--- a/Detectors/ITSMFT/common/reconstruction/src/ITSMFTReconstructionLinkDef.h
+++ b/Detectors/ITSMFT/common/reconstruction/src/ITSMFTReconstructionLinkDef.h
@@ -16,6 +16,10 @@
 
 #pragma link C++ class o2::ITSMFT::Clusterer + ;
 #pragma link C++ class o2::ITSMFT::PixelReader + ;
+#pragma link C++ class o2::ITSMFT::DigitPixelReader + ;
+#pragma link C++ class o2::ITSMFT::RawPixelReader + ;
+#pragma link C++ class o2::ITSMFT::PixelData + ;
+#pragma link C++ class o2::ITSMFT::ChipPixelData + ;
 #pragma link C++ class o2::ITSMFT::BuildTopologyDictionary + ;
 #pragma link C++ class o2::ITSMFT::LookUp + ;
 #pragma link C++ class o2::ITSMFT::TopologyFastSimulation + ;

--- a/Detectors/ITSMFT/common/reconstruction/src/PixelData.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/PixelData.cxx
@@ -1,0 +1,24 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file PixelData.cxx
+/// \brief Implementation for transient data of single pixel and set of pixels from current chip
+
+#include "ITSMFTReconstruction/PixelData.h"
+#include "ITSMFTBase/SegmentationAlpide.h"
+#include <cassert>
+
+using namespace o2::ITSMFT;
+
+void PixelData::sanityCheck() const
+{
+  // make sure the mask used in this class are compatible with Alpide segmenations
+  static_assert(RowMask + 1 >= o2::ITSMFT::SegmentationAlpide::NRows);
+}

--- a/Detectors/ITSMFT/common/reconstruction/src/PixelReader.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/PixelReader.cxx
@@ -17,34 +17,34 @@ using namespace o2::ITSMFT;
 using o2::ITSMFT::Digit;
 
 //______________________________________________________________________________
-Bool_t DigitPixelReader::getNextChipData(PixelReader::ChipPixelData& chipData)
+Bool_t DigitPixelReader::getNextChipData(ChipPixelData& chipData)
 {
   chipData.clear();
   if (!mLastDigit) {
     if (mIdx >= mDigitArray->size()) {
       return kFALSE;
     }
-    chipData.startID = mIdx;
+    chipData.setStartID(mIdx);
     mLastDigit = &((*mDigitArray)[mIdx++]);
   } else {
-    chipData.startID = mIdx;
+    chipData.setStartID(mIdx);
   }
-  chipData.chipID = mLastDigit->getChipIndex();
-  chipData.roFrame = mLastDigit->getROFrame();
-  chipData.pixels.emplace_back(mLastDigit);
+  chipData.setChipID(mLastDigit->getChipIndex());
+  chipData.setROFrame(mLastDigit->getROFrame());
+  chipData.getData().emplace_back(mLastDigit);
   mLastDigit = nullptr;
 
   while (mIdx < mDigitArray->size()) {
     mLastDigit = &((*mDigitArray)[mIdx++]);
-    if (chipData.chipID != mLastDigit->getChipIndex())
+    if (chipData.getChipID() != mLastDigit->getChipIndex())
       break;
-    if (chipData.roFrame != mLastDigit->getROFrame())
+    if (chipData.getROFrame() != mLastDigit->getROFrame())
       break;
-    chipData.pixels.emplace_back(mLastDigit);
+    chipData.getData().emplace_back(mLastDigit);
     mLastDigit = nullptr;
   }
   return kTRUE;
 }
 
 //______________________________________________________________________________
-Bool_t RawPixelReader::getNextChipData(PixelReader::ChipPixelData& chipData) { return kTRUE; }
+Bool_t RawPixelReader::getNextChipData(ChipPixelData& chipData) { return kTRUE; }

--- a/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/DigiParams.h
+++ b/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/DigiParams.h
@@ -27,75 +27,85 @@
 //                                                        //
 ////////////////////////////////////////////////////////////
 
-namespace o2 {
-namespace ITSMFT {
+namespace o2
+{
+namespace ITSMFT
+{
 
-  class AlpideSimResponse;
-  
-  class DigiParams {
-  public:
+class AlpideSimResponse;
 
-    DigiParams() = default;
-    ~DigiParams() = default;
-    
-    void  setNoisePerPixel(float v)       {mNoisePerPixel = v;}
-    float getNoisePerPixel()        const {return mNoisePerPixel;}
+class DigiParams
+{
 
-    void  setContinuous(bool v)           {mIsContinuous = v;}
-    bool  isContinuous()            const {return mIsContinuous;}
+  using SignalShape = o2::ITSMFT::AlpideSignalTrapezoid;
 
-    void setROFrameLenght(float l);
-    void setROFrameDeadTime(float l) { mROFrameDeadTime = l; }
-    float getROFrameLenght() const { return mROFrameLenght; }
-    float getROFrameLenghtInv() const { return mROFrameLenghtInv; }
-    float getROFrameDeadTime() const { return mROFrameDeadTime; }
+ public:
+  DigiParams();
+  ~DigiParams() = default;
 
-    void   setTimeOffset(double t)        {mTimeOffset = t;}
-    double getTimeOffset()          const {return mTimeOffset;}
+  void setNoisePerPixel(float v) { mNoisePerPixel = v; }
+  float getNoisePerPixel() const { return mNoisePerPixel; }
 
-    void setChargeThreshold(int v, float frac2Account = 0.1);
-    void setNSimSteps(int v);
-    void setEnergyToNElectrons(float v)   {mEnergyToNElectrons = v;}
+  void setContinuous(bool v) { mIsContinuous = v; }
+  bool isContinuous() const { return mIsContinuous; }
 
-    int   getChargeThreshold()      const {return mChargeThreshold;}
-    int getMinChargeToAccount() const { return mMinChargeToAccount; }
-    int   getNSimSteps()            const {return mNSimSteps;}
-    float getNSimStepsInv() const { return mNSimStepsInv; }
-    float getEnergyToNElectrons()   const {return mEnergyToNElectrons;}
+  void setROFrameLength(float ns);
+  float getROFrameLength() const { return mROFrameLength; }
+  float getROFrameLengthInv() const { return mROFrameLengthInv; }
 
-    bool  isTimeOffsetSet()         const {return mTimeOffset>-infTime;}
+  void setStrobeDelay(float ns) { mStrobeDelay = ns; }
+  float getStrobeDelay() const { return mStrobeDelay; }
 
-    const o2::ITSMFT::AlpideSimResponse* getAlpSimResponse() const { return mAlpSimResponse; }
-    void setAlpSimResponse(const o2::ITSMFT::AlpideSimResponse* par) { mAlpSimResponse=par; }
+  void setStrobeLength(float ns) { mStrobeLength = ns; }
+  float getStrobeLength() const { return mStrobeLength; }
 
-    const o2::ITSMFT::AlpideSignalTrapezoid& getSignalShape() const { return mSignalShape; }
-    o2::ITSMFT::AlpideSignalTrapezoid& getSignalShape() { return (o2::ITSMFT::AlpideSignalTrapezoid&)mSignalShape; }
+  void setTimeOffset(double sec) { mTimeOffset = sec; }
+  double getTimeOffset() const { return mTimeOffset; }
 
-   private:
-    static constexpr double infTime = 1e99;
-    bool   mIsContinuous = false;   ///< flag for continuous simulation
-    float  mNoisePerPixel = 1.e-7;  ///< ALPIDE Noise per chip
-    float mROFrameLenght = 4000.;   ///< length of RO frame in ns
-    float  mROFrameDeadTime = 25;   ///< dead time in end of the ROFrame, in ns
-    Double_t mTimeOffset = -2*infTime;   ///< time offset to calculate ROFrame from hit time
+  void setChargeThreshold(int v, float frac2Account = 0.1);
+  void setNSimSteps(int v);
+  void setEnergyToNElectrons(float v) { mEnergyToNElectrons = v; }
 
-    int mChargeThreshold = 150;  ///< charge threshold in Nelectrons
-    int mMinChargeToAccount = 15; ///< minimum charge contribution to account
-    int mNSimSteps       = 7;    ///< number of steps in response simulation
-    float mEnergyToNElectrons = 1./3.6e-9; // conversion of eloss to Nelectrons
+  int getChargeThreshold() const { return mChargeThreshold; }
+  int getMinChargeToAccount() const { return mMinChargeToAccount; }
+  int getNSimSteps() const { return mNSimSteps; }
+  float getNSimStepsInv() const { return mNSimStepsInv; }
+  float getEnergyToNElectrons() const { return mEnergyToNElectrons; }
 
-    o2::ITSMFT::AlpideSignalTrapezoid mSignalShape; ///< signal timeshape parameterization
+  bool isTimeOffsetSet() const { return mTimeOffset > -infTime; }
 
-    const o2::ITSMFT::AlpideSimResponse* mAlpSimResponse = nullptr; //!< pointer on external response
+  const o2::ITSMFT::AlpideSimResponse* getAlpSimResponse() const { return mAlpSimResponse; }
+  void setAlpSimResponse(const o2::ITSMFT::AlpideSimResponse* par) { mAlpSimResponse = par; }
 
-    // auxiliary precalculated parameters
-    float mROFrameLenghtInv = 1. / 4000; ///< inverse length of RO frame in ns
-    float mNSimStepsInv = 1.f / 7;       ///< its inverse
+  const SignalShape& getSignalShape() const { return mSignalShape; }
+  SignalShape& getSignalShape() { return (SignalShape&)mSignalShape; }
 
-    ClassDefNV(DigiParams,1);
-  };
+  void print() const;
 
+ private:
+  static constexpr double infTime = 1e99;
+  bool mIsContinuous = false;          ///< flag for continuous simulation
+  float mNoisePerPixel = 1.e-7;        ///< ALPIDE Noise per chip
+  float mROFrameLength = 6000.;        ///< length of RO frame in ns
+  float mStrobeDelay = 6000.;          ///< strobe start (in ns) wrt ROF start
+  float mStrobeLength = 100.;          ///< length of the strobe in ns (sig. over threshold checked in this window only)
+  Double_t mTimeOffset = -2 * infTime; ///< time offset (in seconds!) to calculate ROFrame from hit time
 
+  int mChargeThreshold = 150;              ///< charge threshold in Nelectrons
+  int mMinChargeToAccount = 15;            ///< minimum charge contribution to account
+  int mNSimSteps = 7;                      ///< number of steps in response simulation
+  float mEnergyToNElectrons = 1. / 3.6e-9; // conversion of eloss to Nelectrons
+
+  o2::ITSMFT::AlpideSignalTrapezoid mSignalShape; ///< signal timeshape parameterization
+
+  const o2::ITSMFT::AlpideSimResponse* mAlpSimResponse = nullptr; //!< pointer on external response
+
+  // auxiliary precalculated parameters
+  float mROFrameLengthInv = 0; ///< inverse length of RO frame in ns
+  float mNSimStepsInv = 0;     ///< its inverse
+
+  ClassDefNV(DigiParams, 1);
+};
 }
 }
 

--- a/Detectors/ITSMFT/common/simulation/src/AlpideSignalTrapezoid.cxx
+++ b/Detectors/ITSMFT/common/simulation/src/AlpideSignalTrapezoid.cxx
@@ -14,33 +14,42 @@
 /*
 
   This is a simple implementation of the ALPIDE signal time shape
-  via trapezoid. Described by the amplitude, rise time, flat-top duration
-  and decay time. The integral is equal to total input charge.
+  via trapezoid. Described by the rise time and the flat-top.
+  Risetime depends on the injected charge linearly: from mMaxRiseTime for 
+  charge=0 to 0. for charge>mChargeRise0.
+  Since for the small signals the duration increases, a fraction of the risetime is
+  added to the flat-top duration
   The time is in nanoseconds
 
  */
 
 #include "ITSMFTSimulation/AlpideSignalTrapezoid.h"
+#include <TClass.h>
 #include <cassert>
 
 using namespace o2::ITSMFT;
 
-AlpideSignalTrapezoid::AlpideSignalTrapezoid(float duration, float rise, float decay)
+//_________________________________________________________________
+AlpideSignalTrapezoid::AlpideSignalTrapezoid(float duration, float rise, float qRise0)
 {
-  init(duration, rise, decay);
+  init(duration, rise, qRise0);
 }
 
-void AlpideSignalTrapezoid::init(float dur, float rise, float decay)
+//_________________________________________________________________
+void AlpideSignalTrapezoid::init(float dur, float rise, float qRise0)
 {
   // init with new parameters
   mDuration = dur;
-  mRiseTime = rise;
-  mDecayTime = decay;
-  mFlatTopTime = dur - rise - decay;
-  assert(mRiseTime >= 0.f && mDecayTime >= 0. && mFlatTopTime > 0.);
-  mNorm = 1.f / (mFlatTopTime + 0.5f * (mRiseTime + mDecayTime));
-  mRiseTimeH = 0.5 * mRiseTime;
-  mDecayTimeH = 0.5 * mDecayTime;
-  mRiseTimeInvH = mRiseTime > 0.f ? 0.5f / mRiseTime : 0.f;
-  mDecayTimeInvH = mDecayTime > 0.f ? 0.5f / mDecayTime : 0.f;
+  mMaxRiseTime = rise;
+  mChargeRise0 = qRise0;
+  assert(mMaxRiseTime > 0.f && qRise0 > 1.f && mDuration > mMaxRiseTime);
+  mChargeRise0Inv = 1. / mChargeRise0;
+}
+
+//_________________________________________________________________
+void AlpideSignalTrapezoid::print() const
+{
+  ///< print parameters
+  printf("%s | Duration: %.1f MaxRiseTime: %.1f (RiseTime=0 at q=%.1f) (ns)\n",
+         Class()->GetName(), mDuration, mMaxRiseTime, mChargeRise0);
 }

--- a/Detectors/ITSMFT/common/simulation/src/DigiParams.cxx
+++ b/Detectors/ITSMFT/common/simulation/src/DigiParams.cxx
@@ -19,12 +19,19 @@ ClassImp(o2::ITSMFT::DigiParams);
 
 using namespace o2::ITSMFT;
 
-void DigiParams::setROFrameLenght(float lNS)
+DigiParams::DigiParams()
+{
+  // make sure the defaults are consistent
+  setROFrameLength(mROFrameLength);
+  setNSimSteps(mNSimSteps);
+}
+
+void DigiParams::setROFrameLength(float lNS)
 {
   // set ROFrame length in nanosecongs
-  mROFrameLenght = lNS;
-  assert(mROFrameLenght > 1.);
-  mROFrameLenghtInv = 1. / mROFrameLenght;
+  mROFrameLength = lNS;
+  assert(mROFrameLength > 1.);
+  mROFrameLengthInv = 1. / mROFrameLength;
 }
 
 void DigiParams::setNSimSteps(int v)
@@ -46,4 +53,22 @@ void DigiParams::setChargeThreshold(int v, float frac2Account)
   LOG(INFO) << "Set Alpide charge threshold to " << mChargeThreshold
             << ", single hit will be accounted from " << mMinChargeToAccount
             << " electrons" << FairLogger::endl;
+}
+
+//______________________________________________
+void DigiParams::print() const
+{
+  // print settings
+  printf("Alpide digitization params:\n");
+  printf("Continuous readout             : %s\n", mIsContinuous ? "ON" : "OFF");
+  printf("Readout Frame Length(ns)       : %f\n", mROFrameLength);
+  printf("Strobe delay (ns)              : %f\n", mStrobeDelay);
+  printf("Strobe length (ns)             : %f\n", mStrobeLength);
+  printf("Threshold (N electrons)        : %d\n", mChargeThreshold);
+  printf("Min N electrons to accoint     : %d\n", mMinChargeToAccount);
+  printf("Number of charge sharing steps : %d\n", mNSimSteps);
+  printf("ELoss to N electrons factor    : %e\n", mEnergyToNElectrons);
+  printf("Noise level per pixel          : %e\n", mNoisePerPixel);
+  printf("Charge time-response:\n");
+  mSignalShape.print();
 }

--- a/Detectors/ITSMFT/common/simulation/src/Digitizer.cxx
+++ b/Detectors/ITSMFT/common/simulation/src/Digitizer.cxx
@@ -45,43 +45,17 @@ void Digitizer::init()
     mAlpSimResp->initData();
     mParams.setAlpSimResponse(mAlpSimResp.get());
   }
-
+  mParams.print();
 }
 
 //_______________________________________________________________________
 void Digitizer::process()
 {
-  // digitize single event
+  // digitize single event, the time must have been set beforehand
 
-  const Int_t numOfChips = mGeometry->getNumberOfChips();
-
-  // estimate the smalles RO Frame this event may have
-  double hTime0 = mEventTime - mParams.getTimeOffset();
-  if (hTime0 > UINT_MAX) {
-    LOG(WARNING) << "min Hit RO Frame undefined: time: " << hTime0 << " is in far future: "
-                 << " EventTime: " << mEventTime << " TimeOffset: " << mParams.getTimeOffset() << FairLogger::endl;
-    return;
-  }
-
-  if (hTime0 < 0) {
-    hTime0 = 0.;
-  }
-  UInt_t minNewROFrame = static_cast<UInt_t>(hTime0 / mParams.getROFrameLenght());
-
-  LOG(INFO) << "Digitizing ITS event at time " << mEventTime << " (TOffset= " << mParams.getTimeOffset()
-            << " ROFrame= " << minNewROFrame << ")"
-            << " cont.mode: " << isContinuous() << " current Min/Max RO Frames " << mROFrameMin << "/" << mROFrameMax
-            << FairLogger::endl;
-
-  if (mParams.isContinuous() && minNewROFrame > mROFrameMin) {
-    // if there are already digits cached for previous RO Frames AND the new event
-    // cannot contribute to these digits, move them to the output container
-    if (mROFrameMax < minNewROFrame) {
-      mROFrameMax = minNewROFrame - 1;
-    }
-    for (auto rof = mROFrameMin; rof < minNewROFrame; rof++) {
-      fillOutputContainer(rof);
-    }
+  // is there something to flush ?
+  if (mNewROFrame > mROFrameMin) {
+    fillOutputContainer(mNewROFrame - 1); // flush out all frame preceding the new one
   }
 
   int nHits = mHits->size();
@@ -96,6 +70,8 @@ void Digitizer::process()
     processHit((*mHits)[i], mROFrameMax);
   }
   // in the triggered mode store digits after every MC event
+  // TODO: in the real triggered mode this will not be needed, this is actually for the
+  // single event processing only
   if (!mParams.isContinuous()) {
     fillOutputContainer(mROFrameMax);
   }
@@ -106,50 +82,67 @@ void Digitizer::setEventTime(double t)
 {
   // assign event time, it should be in a strictly increasing order
   // convert to ns
-  t *= mCoeffToNanoSecond;
+  mEventTime = t * mCoeffToNanoSecond;
 
-  if (t < mEventTime && mParams.isContinuous()) {
-    LOG(FATAL) << "New event time (" << t << ") is < previous event time (" << mEventTime << ")" << FairLogger::endl;
-  }
-  mEventTime = t;
   // to randomize the RO phase wrt the event time we use a random offset
   if (mParams.isContinuous()) {       // in continuous mode we set the offset only in the very beginning
     if (!mParams.isTimeOffsetSet()) { // offset is initially at -inf
-      mParams.setTimeOffset(0);       ///*mEventTime + */ mParams.getROFrameLenght() * (gRandom->Rndm() - 0.5));
+      mParams.setTimeOffset(0);       ///*mEventTime + */ mParams.getROFrameLength() * (gRandom->Rndm() - 0.5));
     }
-  } else { // in the triggered mode we start from 0 ROFrame in every event
-    mParams.setTimeOffset(mEventTime); // + mParams.getROFrameLenght() * (gRandom->Rndm() - 0.5));
+  } else {                             // in the triggered mode we start from 0 ROFrame in every event, is this correct?
+    mParams.setTimeOffset(mEventTime); // + mParams.getROFrameLength() * (gRandom->Rndm() - 0.5));
     mROFrameMin = 0; // so we reset the frame counters
     mROFrameMax = 0;
+  }
+
+  mEventTime -= mParams.getTimeOffset(); // subtract common offset
+  if (mEventTime < 0.) {
+    mEventTime = 0.;
+  } else if (mEventTime > UINT_MAX) {
+    LOG(FATAL) << "ROFrame for event time " << t << " exceeds allowe maximum " << UINT_MAX << FairLogger::endl;
+  }
+
+  // RO frame corresponding to provided time
+  mNewROFrame = static_cast<UInt_t>(mEventTime * mParams.getROFrameLengthInv());
+
+  if (mNewROFrame < mROFrameMin) {
+    LOG(FATAL) << "New ROFrame (time=" << t << ") precedes currently cashed " << mROFrameMin << FairLogger::endl;
+  }
+
+  LOG(INFO) << "Digitizing ITS event at time " << t << " (TOffset= " << mParams.getTimeOffset()
+            << " ROFrame= " << mNewROFrame << ")"
+            << " cont.mode: " << isContinuous()
+            << " current Min/Max RO Frames " << mROFrameMin << "/" << mROFrameMax << FairLogger::endl;
+
+  if (mParams.isContinuous() && mROFrameMax < mNewROFrame) {
+    mROFrameMax = mNewROFrame - 1; // all frames up to this are finished
   }
 }
 
 //_______________________________________________________________________
-void Digitizer::fillOutputContainer(UInt_t maxFrame)
+void Digitizer::fillOutputContainer(UInt_t frameLast)
 {
-  // fill output with digits ready to be stored, generating the noise beforehand
-  if (maxFrame > mROFrameMax) {
-    maxFrame = mROFrameMax;
+  // fill output with digits from min.cached up to requested frame, generating the noise beforehand
+  if (frameLast > mROFrameMax) {
+    frameLast = mROFrameMax;
   }
-  // make sure all buffers for extra digits are created
+  // make sure all buffers for extra digits are created up to the maxFrame
   getExtraDigBuffer(mROFrameMax);
 
-  LOG(INFO) << "Filling ITS digits output for RO frames " << mROFrameMin << ":" << maxFrame << FairLogger::endl;
+  LOG(INFO) << "Filling ITS digits output for RO frames " << mROFrameMin << ":" << frameLast << FairLogger::endl;
 
   // we have to write chips in RO increasing order, therefore have to loop over the frames here
-  auto rof = mROFrameMin;
-  for (; rof <= maxFrame; rof++) {
+  for (; mROFrameMin <= frameLast; mROFrameMin++) {
     auto& extra = *(mExtraBuff.front().get());
     for (auto& chip : mChips) {
-      //      chip.fillOutputContainer(digits, rof, &mParams);
-      chip.addNoise(rof, rof, &mParams);
+      chip.addNoise(mROFrameMin, mROFrameMin, &mParams);
       auto& buffer = chip.getPreDigits();
       if (buffer.empty()) {
         continue;
       }
       auto itBeg = buffer.begin();
       auto iter = itBeg;
-      ULong64_t maxKey = chip.getOrderingKey(rof + 1, 0, 0); // fetch digits with key below that
+      ULong64_t maxKey = chip.getOrderingKey(mROFrameMin + 1, 0, 0); // fetch digits with key below that
       for (; iter != buffer.end(); ++iter) {
         if (iter->first > maxKey) {
           break; // is the digit ROFrame from the key > the max requested frame
@@ -157,7 +150,7 @@ void Digitizer::fillOutputContainer(UInt_t maxFrame)
         auto& preDig = iter->second; // preDigit
         if (preDig.charge >= mParams.getChargeThreshold()) {
           int digID = mDigits->size();
-          mDigits->emplace_back(chip.getChipIndex(), rof, preDig.row, preDig.col, preDig.charge);
+          mDigits->emplace_back(chip.getChipIndex(), mROFrameMin, preDig.row, preDig.col, preDig.charge);
           mMCLabels->addElement(digID, preDig.labelRef.label);
           auto& nextRef = preDig.labelRef; // extra contributors are in extra array
           while (nextRef.next >= 0) {
@@ -168,13 +161,11 @@ void Digitizer::fillOutputContainer(UInt_t maxFrame)
       }
       buffer.erase(itBeg, iter);
     }
-    extra.clear(); // clear container for extra digits of the rof ROFrame
+    extra.clear(); // clear container for extra digits of the mROFrameMin ROFrame
     // and move it as a new slot in the end
     mExtraBuff.emplace_back(mExtraBuff.front().release());
     mExtraBuff.pop_front();
-    mROFrameMin++;
   }
-  mROFrameMin = maxFrame + 1;
 }
 
 //_______________________________________________________________________
@@ -202,41 +193,30 @@ void Digitizer::setCurrEvID(int v)
 //_______________________________________________________________________
 void Digitizer::processHit(const o2::ITSMFT::Hit& hit, UInt_t& maxFr)
 {
-  // conver single hit to digits
+  // convert single hit to digits
 
-  double hTime0 = hit.GetTime() * sec2ns + mEventTime - mParams.getTimeOffset(); // time from the RO start, in ns
-  if (hTime0 > UINT_MAX) {
-    LOG(WARNING) << "Hit RO Frame undefined: time: " << hTime0 << " is in far future: hitTime: "
-                 << hit.GetTime() << " EventTime: " << mEventTime << " ChipOffset: "
-                 << mParams.getTimeOffset() << FairLogger::endl;
-    return;
-  }
+  double hTime0 = hit.GetTime() * sec2ns + mEventTime; // time from the RO start, in ns
+
   // calculate RO Frame for this hit
   if (hTime0 < 0) {
     hTime0 = 0.;
   }
-  float tTot = mParams.getSignalShape().getDuration();
-  UInt_t roFrame = UInt_t(hTime0 * mParams.getROFrameLenghtInv());
-  std::array<float, maxROFPerHit> timesROF; // start/end time in every ROF covered
-  // time till the end of the ROF where the hit was registered, used for signal overflow check
-  float tInt = float((roFrame + 1) * mParams.getROFrameLenght() - hTime0);
-  timesROF[0] = 0.f;
-  timesROF[1] = tInt;
-  int nROFs = 1;
-  while (tInt < tTot) {
-    tInt += mParams.getROFrameLenght();
-    timesROF[++nROFs] = tInt;
+  float tTot = mParams.getSignalShape().getMaxDuration();
+  // frame of the hit signal start
+  UInt_t roFrame = UInt_t(hTime0 * mParams.getROFrameLengthInv());
+  // frame of the hit signal end: in the triggered mode we read just 1 frame
+  UInt_t roFrameMax = mParams.isContinuous() ? UInt_t((hTime0 + tTot) * mParams.getROFrameLengthInv()) : roFrame;
+  int nFrames = roFrameMax + 1 - roFrame;
+  if (roFrameMax > maxFr) {
+    maxFr = roFrameMax; // if signal extends beyond current maxFrame, increase the latter
   }
-  UInt_t roFrameLast = roFrame + (nROFs - 1);
-  if (roFrameLast > maxFr) {
-    maxFr = roFrameLast;
-  }
+  // delay of the signal start wrt 1st ROF start
+  float timeInROF = float(hTime0 - (roFrame * mParams.getROFrameLength()));
 
+  // here we start stepping in the depth of the sensor to generate charge diffision
   float nStepsInv = mParams.getNSimStepsInv();
   int nSteps = mParams.getNSimSteps();
-
   const auto& matrix = mGeometry->getMatrixL2G(hit.GetDetectorID());
-
   Vector3D<float> xyzLocS(matrix ^ (hit.GetPosStart())); // start position in sensor frame
   Vector3D<float> xyzLocE(matrix ^ (hit.GetPos()));      // end position in sensor frame
   Vector3D<float> step(xyzLocE);
@@ -356,7 +336,55 @@ void Digitizer::processHit(const o2::ITSMFT::Hit& hit, UInt_t& maxFr)
       }
       UShort_t colIS = icol + colS;
       //
-      registerDigits(chip, roFrame, nROFs, rowIS, colIS, nEle, lbl, timesROF);
+      registerDigits(chip, roFrame, timeInROF, nFrames, rowIS, colIS, nEle, lbl);
+    }
+  }
+}
+
+//________________________________________________________________________________
+void Digitizer::registerDigits(ChipDigitsContainer& chip, UInt_t roFrame, float tInROF, int nROF,
+                               UShort_t row, UShort_t col, int nEle, o2::MCCompLabel& lbl)
+{
+  // Register digits for given pixel, accounting for the possible signal contribution to
+  // multiple ROFrame. The signal starts at tume tInROF wrt the start of provided roFrame
+  // In every ROFrame we check the collected signal during strobe
+
+  float tStrobe = mParams.getStrobeDelay() - tInROF; // strobe start wrt signal start
+  for (int i = 0; i < nROF; i++) {
+    UInt_t roFr = roFrame + i;
+    int nEleROF = mParams.getSignalShape().getCollectedCharge(nEle, tStrobe, tStrobe + mParams.getStrobeLength());
+    tStrobe += mParams.getROFrameLength(); // for the next ROF
+
+    // discard too small contributions, they have no chance to produce a digit
+    if (nEleROF < mParams.getMinChargeToAccount()) {
+      continue;
+    }
+
+    auto key = chip.getOrderingKey(roFr, row, col);
+    PreDigit* pd = chip.findDigit(key);
+    if (!pd) {
+      chip.addDigit(key, roFr, row, col, nEleROF, lbl);
+    } else { // there is already a digit at this slot, account as PreDigitExtra contribution
+      pd->charge += nEle;
+      if (pd->labelRef.label == lbl) { // don't store the same label twice
+        continue;
+      }
+      ExtraDig* extra = getExtraDigBuffer(roFr);
+      int& nxt = pd->labelRef.next;
+      bool skip = false;
+      while (nxt >= 0) {
+        if ((*extra)[nxt].label == lbl) { // don't store the same label twice
+          skip = true;
+          break;
+        }
+        nxt = (*extra)[nxt].next;
+      }
+      if (skip) {
+        continue;
+      }
+      // new predigit will be added in the end of the chain
+      nxt = extra->size();
+      extra->emplace_back(lbl);
     }
   }
 }

--- a/macro/run_clus_its.C
+++ b/macro/run_clus_its.C
@@ -52,6 +52,8 @@ void run_clus_its(std::string outputfile, std::string inputfile, std::string par
   // Setup clusterizer
   Bool_t useMCTruth = kTRUE; // kFALSE if no comparison with MC needed
   o2::ITS::ClustererTask* clus = new o2::ITS::ClustererTask(useMCTruth);
+  clus->getClusterer().setMaskOverflowPixels(true); // set this to false to switch off masking
+
   fRun->AddTask(clus);
 
   fRun->Init();

--- a/macro/run_digi_its.C
+++ b/macro/run_digi_its.C
@@ -53,9 +53,11 @@ void run_digi_its(float rate = 50e3, std::string outputfile = "o2dig.root", std:
   // ====>>
   // defaults
   digi->getDigiParams().setContinuous(rate > 0); // continuous vs per-event mode
-  digi->getDigiParams().setROFrameLenght(4000);  // RO frame in ns
-  // parameters of signal time response: total duration, rise and decay times in ns
-  digi->getDigiParams().getSignalShape().setParameters(6000., 50., 30.);
+  digi->getDigiParams().setROFrameLength(6000);  // RO frame in ns
+  digi->getDigiParams().setStrobeDelay(6000);    // Strobe delay wrt beginning of the RO frame, in ns
+  digi->getDigiParams().setStrobeLength(100);    // Strobe length in ns
+  // parameters of signal time response: flat-top duration, max rise time and q @ which rise time is 0
+  digi->getDigiParams().getSignalShape().setParameters(7500., 1100., 450.);
   digi->getDigiParams().setChargeThreshold(150); // charge threshold in electrons
   digi->getDigiParams().setNoisePerPixel(1.e-7); // noise level
   // <<===


### PR DESCRIPTION
In the default clusterization mode the o2::ITSMFT::Clusterer will reject in every ROFrame 
those pixels which were fired in the previous ROFrame (due to the long signal over threshold).
Option can be configured via:
clusterer->setMaskOverflowPixels(bool);
e.g.
o2::ITS::ClustererTask task;
task->getClusterer().setMaskOverflowPixels(true);
Same for the o2::MFT::ClustererTask