### PR TITLE
DPL: fix logic of optimized ctl messages parsing

### DIFF
--- a/Framework/Core/src/LogParsingHelpers.cxx
+++ b/Framework/Core/src/LogParsingHelpers.cxx
@@ -43,13 +43,14 @@ LogLevel LogParsingHelpers::parseTokenLevel(const std::string &s) {
     return LogLevel::Unknown;
   }
 
-  if (s.compare(LABELPOS, 7, "[DEBUG]") == 0) {
+  if (s.compare(LABELPOS, 8, "[DEBUG] ") == 0) {
     return LogLevel::Debug;
-  } else if (s.compare(LABELPOS, 6, "[INFO]") == 0 || s.compare(LABELPOS, 7, "[STATE]") == 0) {
+  } else if (s.compare(LABELPOS, 7, "[INFO] ") == 0 ||
+             s.compare(LABELPOS, 8, "[STATE] ") == 0) {
     return LogLevel::Info;
-  } else if (s.compare(LABELPOS, 6, "[WARN]") == 0) {
+  } else if (s.compare(LABELPOS, 7, "[WARN] ") == 0) {
     return LogLevel::Warning;
-  } else if (s.compare(LABELPOS, 7, "[ERROR]") == 0) {
+  } else if (s.compare(LABELPOS, 8, "[ERROR] ") == 0) {
     return LogLevel::Error;
   }
   return LogLevel::Unknown;

--- a/Framework/Core/src/TextControlService.cxx
+++ b/Framework/Core/src/TextControlService.cxx
@@ -37,7 +37,7 @@ bool parseControl(const std::string &s, std::smatch &match) {
   if (idx == std::string::npos) {
     return false;
   }
-  return std::regex_search(s.begin()+idx, s.end(), match, controlRE);
+  return std::regex_search(s.begin() + idx, s.end(), match, controlRE);
 }
 
 } // framework

--- a/Framework/Core/src/TextControlService.cxx
+++ b/Framework/Core/src/TextControlService.cxx
@@ -32,11 +32,12 @@ void TextControlService::readyToQuit(bool all) {
 }
 
 bool parseControl(const std::string &s, std::smatch &match) {
-  const static std::regex controlRE("CONTROL_ACTION: READY_TO_(QUIT)_(ME|ALL)", std::regex::optimize);
-  if (s.find("CONTROL_ACTION: ", 0, 50) == std::string::npos) {
+  const static std::regex controlRE("READY_TO_(QUIT)_(ME|ALL)", std::regex::optimize);
+  auto idx = s.find("CONTROL_ACTION: ");
+  if (idx == std::string::npos) {
     return false;
   }
-  return std::regex_search(s, match, controlRE);
+  return std::regex_search(s.begin()+idx, s.end(), match, controlRE);
 }
 
 } // framework

--- a/Framework/Core/test/test_LogParsingHelpers.cxx
+++ b/Framework/Core/test/test_LogParsingHelpers.cxx
@@ -21,6 +21,8 @@ BOOST_AUTO_TEST_CASE(TestParseTokenLevel) {
   BOOST_CHECK(LogParsingHelpers::parseTokenLevel("[10:10:10][ERROR] Some message") == LogParsingHelpers::LogLevel::Error);
   BOOST_CHECK(LogParsingHelpers::parseTokenLevel("[10:10:10][WARN] Some message") == LogParsingHelpers::LogLevel::Warning);
   BOOST_CHECK(LogParsingHelpers::parseTokenLevel("[10:10:10][INFO] Some message") == LogParsingHelpers::LogLevel::Info);
+  // Log level STATE is interpreted as INFO
+  BOOST_CHECK(LogParsingHelpers::parseTokenLevel("[10:10:10][STATE] Some message") == LogParsingHelpers::LogLevel::Info);
   BOOST_CHECK(LogParsingHelpers::parseTokenLevel("[10:10:10][DEBUG] Some message") == LogParsingHelpers::LogLevel::Debug);
   BOOST_CHECK(LogParsingHelpers::parseTokenLevel("[10:10:10][BLAH] Some message") == LogParsingHelpers::LogLevel::Unknown);
   BOOST_CHECK(LogParsingHelpers::parseTokenLevel("[1010:10][BLAH] Some message") == LogParsingHelpers::LogLevel::Unknown);


### PR DESCRIPTION
Optimization done in #1172 broke parsing of control messages.

@matthiasrichter the problem of failing tests was NOT in your code
@ktf another shining example of brown paper bag bug