### PR TITLE
Add extraction of step length and maxstep length

### DIFF
--- a/Utilities/MCStepLogger/src/StepInfo.cxx
+++ b/Utilities/MCStepLogger/src/StepInfo.cxx
@@ -87,6 +87,8 @@ StepInfo::StepInfo(TVirtualMC* mc)
   x = xd;
   y = yd;
   z = zd;
+  step = mc->TrackStep();
+  maxstep = mc->MaxStep();
   E = curtrack->Energy();
   auto now = std::chrono::high_resolution_clock::now();
   // cputimestamp = std::chrono::duration_cast<std::chrono::nanoseconds>(now - starttime).count();


### PR DESCRIPTION
Use `TVirtualMC::TrackStep()` and `TVirtualMC::MaxStep()` to extract length of current step and maximum step size allowed in current medium, respectively.