### PR TITLE
Cleanup O2Device

### DIFF
--- a/DataFormats/Headers/include/Headers/DataHeader.h
+++ b/DataFormats/Headers/include/Headers/DataHeader.h
@@ -668,7 +668,7 @@ struct DataHeader : public BaseHeader
 
   //___the functions:
   DataHeader(); ///ctor
-  explicit DataHeader(DataDescription desc, DataOrigin origin, SubSpecificationType subspec, uint64_t size); /// ctor
+  explicit DataHeader(DataDescription desc, DataOrigin origin, SubSpecificationType subspec, uint64_t size = 0); /// ctor
 
   DataHeader(const DataHeader&) = default;
   DataHeader& operator=(const DataHeader&) = default; //assignment

--- a/Utilities/DataFlow/src/HeartbeatSampler.cxx
+++ b/Utilities/DataFlow/src/HeartbeatSampler.cxx
@@ -48,7 +48,7 @@ bool o2::DataFlow::HeartbeatSampler::ConditionalRun()
   O2Message outgoing;
 
   // build multipart message from header and payload
-  o2::Base::AddDataBlock(outgoing, { dh, specificHeader }, NewSimpleMessage(hbfPayload));
+  o2::Base::addDataBlock(outgoing, { dh, specificHeader }, NewSimpleMessage(hbfPayload));
 
   // send message
   Send(outgoing, mOutputChannelName.c_str());

--- a/Utilities/DataFlow/src/HeartbeatSampler.cxx
+++ b/Utilities/DataFlow/src/HeartbeatSampler.cxx
@@ -48,7 +48,7 @@ bool o2::DataFlow::HeartbeatSampler::ConditionalRun()
   O2Message outgoing;
 
   // build multipart message from header and payload
-  AddMessage(outgoing, {dh, specificHeader}, NewSimpleMessage(hbfPayload));
+  o2::Base::AddDataBlock(outgoing, { dh, specificHeader }, NewSimpleMessage(hbfPayload));
 
   // send message
   Send(outgoing, mOutputChannelName.c_str());

--- a/Utilities/DataFlow/src/SubframeBuilderDevice.cxx
+++ b/Utilities/DataFlow/src/SubframeBuilderDevice.cxx
@@ -116,12 +116,12 @@ bool o2::DataFlow::SubframeBuilderDevice::BuildAndSendFrame(FairMQParts &inParts
   // Add the metadata about the merged subtimeframes
   // FIXME: do we really need this?
   O2Message outgoing;
-  AddMessage(outgoing, dh, NewSimpleMessage(md));
+  o2::Base::AddDataBlock(outgoing, dh, NewSimpleMessage(md));
 
   // Add the actual merged payload.
-  AddMessage(outgoing, payloadheader,
-             NewMessage(*outBuffer, outSize,
-                        [](void* data, void* hint) { delete[] reinterpret_cast<char *>(hint); }, *outBuffer));
+  o2::Base::AddDataBlock(outgoing, payloadheader,
+                         NewMessage(*outBuffer, outSize,
+                                    [](void* data, void* hint) { delete[] reinterpret_cast<char*>(hint); }, *outBuffer));
   // send message
   Send(outgoing, mOutputChannelName.c_str());
   // FIXME: do we actually need this? outgoing should go out of scope

--- a/Utilities/DataFlow/src/SubframeBuilderDevice.cxx
+++ b/Utilities/DataFlow/src/SubframeBuilderDevice.cxx
@@ -116,10 +116,10 @@ bool o2::DataFlow::SubframeBuilderDevice::BuildAndSendFrame(FairMQParts &inParts
   // Add the metadata about the merged subtimeframes
   // FIXME: do we really need this?
   O2Message outgoing;
-  o2::Base::AddDataBlock(outgoing, dh, NewSimpleMessage(md));
+  o2::Base::addDataBlock(outgoing, dh, NewSimpleMessage(md));
 
   // Add the actual merged payload.
-  o2::Base::AddDataBlock(outgoing, payloadheader,
+  o2::Base::addDataBlock(outgoing, payloadheader,
                          NewMessage(*outBuffer, outSize,
                                     [](void* data, void* hint) { delete[] reinterpret_cast<char*>(hint); }, *outBuffer));
   // send message

--- a/Utilities/O2Device/README.md
+++ b/Utilities/O2Device/README.md
@@ -1,0 +1,74 @@
+# O2Device
+
+The O2Device is meant to build O2 specific behaviours on top of plain FairMQDevices.
+
+# O2Device utilities
+
+The header **O2Device/Utilities.h** contains utilities that enable consistent handling of 
+data in the O2 format and some useful definitions.
+
+```O2Message``` - currently alias of FairMQPArts, contains FairMQMessages in header-payload order
+
+### addDataBlock()
+Allows to consistently create O2 compatible messages for FairMQ transport.
+Appends a header::Stack-data pair to message. Sets the data size in the DataHeader inside the stack based either on the message/container size.
+
+```
+template <typename T>
+addDataBlock(O2Message& message, o2::header::Stack&& headerStack, T data);
+```
+#### arguments:
+- headerStack: as the name implies.
+
+- data:
+  - ```FairMQMessagePtr``` (```std::unique_ptr<FairMQMessage>```)
+  - STL-like container that uses a ```pmr::polymorphic_allocator``` as allocator. Note: this is only efficient if
+    the memory resource used to construct the allocator is ```o2::memoryResources::ChannelResource```, otherwise an implicit copy occurs.
+
+### forEach()
+Executes a function on each data block within the message.
+
+```
+template<typename T>
+T forEach(O2Message& message, T function);
+```
+#### arguments:
+the function is a callable object (lambda, functor, std::function) and needs to take two arguents of type gsl::span, first one points to the header buffer, second one points to the payload buffer, e.g. ```[](span header, span payload) {}```.
+
+
+#### basic example, inside a FairMQDevice:
+```C++
+// make sure we have the allocator associated with the transport appropriate for the selected channel:
+auto outputChannelAllocator = o2::memoryResources::getTransportAllocator(GetChannel("dataOut").Transport());
+
+//the data
+using namespace boost::container::pmr;
+std::vector<int, polymorphic_allocator<int>> dataVector(polymorphic_allocator<int>{outputChannelAllocator});
+dataVector.reserve(10);
+dataVector.push_back(1);
+dataVector.push_back(2);
+
+//create the message
+O2message message;
+addDataBlock(message,
+             o2::header::Stack{outputChannelAllocator, DataHeader{<args>}},
+             std::move(dataVector));
+
+addDataBlock(message,
+             o2::header::Stack{outputChannelAllocator, DataHeader{<args>}},
+             NewMessageFor("dataOut",0,"some message string"));
+
+Send(message,"dataOut");
+
+//On the receiving end:
+O2Message messageIn;
+Receive(messageIn, "dataIn");
+forEach(messageIn, [](span header, span payload) {
+  auto dataHeader = get<DataHeader*>(header.data());
+  if (dataHeader->dataDescription==gDataDescriptionMyDataType) {
+    MyDataType* myData = reinterpret_cast<MyDataType*>(payload.data());
+  }
+});
+
+```
+

--- a/Utilities/O2Device/include/O2Device/Utilities.h
+++ b/Utilities/O2Device/include/O2Device/Utilities.h
@@ -45,8 +45,14 @@ template <typename ContainerT, typename std::enable_if<!std::is_same<ContainerT,
 bool addDataBlock(O2Message& parts, o2::header::Stack&& inputStack, ContainerT&& inputData, o2::memoryResources::FairMQMemoryResource* targetResource = nullptr)
 {
   using std::move;
-  auto dataMessage = getMessage(move(inputData), targetResource);
-  return addDataBlock(parts, move(inputStack), move(dataMessage), targetResource);
+  using std::forward;
+
+  auto headerMessage = getMessage(move(inputStack), targetResource);
+  auto dataMessage = getMessage(forward<ContainerT>(inputData), targetResource);
+
+  parts.AddPart(move(headerMessage));
+  parts.AddPart(move(dataMessage));
+
   return true;
 }
 

--- a/Utilities/O2Device/include/O2Device/Utilities.h
+++ b/Utilities/O2Device/include/O2Device/Utilities.h
@@ -20,7 +20,7 @@
 /// granted to it by virtue of its status as an Intergovernmental Organization
 /// or submit itself to any jurisdiction.
 
-/// @brief standalone tools to interact with the O2 data modl
+/// @brief standalone tools to interact with the O2 data model
 ///
 /// @author Mikolaj Krzewicki, mkrzewic@cern.ch
 

--- a/Utilities/O2Device/include/O2Device/Utilities.h
+++ b/Utilities/O2Device/include/O2Device/Utilities.h
@@ -40,21 +40,21 @@ namespace Base
 using O2Message = FairMQParts;
 
 //__________________________________________________________________________________________________
-// AddDataBlock for generic (compatible) containers, that is contiguous containers using the pmr allocator
+// addDataBlock for generic (compatible) containers, that is contiguous containers using the pmr allocator
 template <typename ContainerT, typename std::enable_if<!std::is_same<ContainerT, FairMQMessagePtr>::value, int>::type = 0>
-bool AddDataBlock(O2Message& parts, o2::header::Stack&& inputStack, ContainerT&& inputData, o2::memoryResources::FairMQMemoryResource* targetResource = nullptr)
+bool addDataBlock(O2Message& parts, o2::header::Stack&& inputStack, ContainerT&& inputData, o2::memoryResources::FairMQMemoryResource* targetResource = nullptr)
 {
   using std::move;
   auto dataMessage = getMessage(move(inputData), targetResource);
-  return AddDataBlock(parts, move(inputStack), move(dataMessage), targetResource);
+  return addDataBlock(parts, move(inputStack), move(dataMessage), targetResource);
   return true;
 }
 
 //__________________________________________________________________________________________________
-// AddDataBlock for data already wrapped in FairMQMessagePtr
+// addDataBlock for data already wrapped in FairMQMessagePtr
 // note: since we cannot partially specialize function templates, use SFINAE here instead
 template <typename ContainerT, typename std::enable_if<std::is_same<ContainerT, FairMQMessagePtr>::value, int>::type = 0>
-bool AddDataBlock(O2Message& parts, o2::header::Stack&& inputStack, ContainerT&& dataMessage, o2::memoryResources::FairMQMemoryResource* targetResource = nullptr)
+bool addDataBlock(O2Message& parts, o2::header::Stack&& inputStack, ContainerT&& dataMessage, o2::memoryResources::FairMQMemoryResource* targetResource = nullptr)
 {
   using std::move;
 
@@ -75,7 +75,7 @@ namespace internal
 {
 
 template <typename I, typename F>
-auto ForEach(I begin, I end, F function)
+auto forEach(I begin, I end, F function)
 {
   using span = gsl::span<const byte>;
   using gsl::narrow_cast;
@@ -104,14 +104,14 @@ auto ForEach(I begin, I end, F function)
 /// Execute user code (e.g. a lambda) on each data block (header-payload pair)
 /// returns the function (same as std::for_each)
 template <typename F>
-auto ForEach(O2Message& parts, F function)
+auto forEach(O2Message& parts, F function)
 {
   if ((parts.Size() % 2) != 0) {
     throw std::invalid_argument(
       "number of parts in message not even (n%2 != 0), cannot be considered an O2 compliant message");
   }
 
-  return internal::ForEach(parts.begin(), parts.end(), function);
+  return internal::forEach(parts.begin(), parts.end(), function);
 }
 
 }; //namespace o2

--- a/Utilities/O2Device/include/O2Device/Utilities.h
+++ b/Utilities/O2Device/include/O2Device/Utilities.h
@@ -81,7 +81,7 @@ namespace internal
 {
 
 template <typename I, typename F>
-auto forEach(I begin, I end, F function)
+auto forEach(I begin, I end, F&& function)
 {
   using span = gsl::span<const byte>;
   using gsl::narrow_cast;
@@ -110,14 +110,14 @@ auto forEach(I begin, I end, F function)
 /// Execute user code (e.g. a lambda) on each data block (header-payload pair)
 /// returns the function (same as std::for_each)
 template <typename F>
-auto forEach(O2Message& parts, F function)
+auto forEach(O2Message& parts, F&& function)
 {
   if ((parts.Size() % 2) != 0) {
     throw std::invalid_argument(
       "number of parts in message not even (n%2 != 0), cannot be considered an O2 compliant message");
   }
 
-  return internal::forEach(parts.begin(), parts.end(), function);
+  return internal::forEach(parts.begin(), parts.end(), std::forward<F>(function));
 }
 
 }; //namespace o2

--- a/Utilities/O2Device/test/test_O2Device.cxx
+++ b/Utilities/O2Device/test/test_O2Device.cxx
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_CASE(getMessage_Stack)
 {
   {
     //check that a message is constructed properly with the default new_delete_resource
-    Stack s1{ DataHeader{ gDataDescriptionInvalid, gDataOriginInvalid, DataHeader::SubSpecificationType{ 0 }, 0 },
+    Stack s1{ DataHeader{ gDataDescriptionInvalid, gDataOriginInvalid, DataHeader::SubSpecificationType{ 0 } },
               NameHeader<9>{ "somename" } };
 
     auto message = o2::memoryResources::getMessage(std::move(s1), allocZMQ);
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE(getMessage_Stack)
   }
   {
     //check that a message is constructed properly, cross resource
-    Stack s1{ allocZMQ, DataHeader{ gDataDescriptionInvalid, gDataOriginInvalid, DataHeader::SubSpecificationType{ 0 }, 0 },
+    Stack s1{ allocZMQ, DataHeader{ gDataDescriptionInvalid, gDataOriginInvalid, DataHeader::SubSpecificationType{ 0 } },
               NameHeader<9>{ "somename" } };
     BOOST_TEST(allocZMQ->getNumberOfMessages() == 1);
 
@@ -71,7 +71,7 @@ BOOST_AUTO_TEST_CASE(addDataBlockForEach_test)
     O2Message message;
     auto simpleMessage = factoryZMQ->CreateMessage(10);
     addDataBlock(message,
-                 Stack{ allocZMQ, DataHeader{ gDataDescriptionInvalid, gDataOriginInvalid, DataHeader::SubSpecificationType{ 0 }, 0 } },
+                 Stack{ allocZMQ, DataHeader{ gDataDescriptionInvalid, gDataOriginInvalid, DataHeader::SubSpecificationType{ 0 } } },
                  std::move(simpleMessage));
     BOOST_CHECK(message.Size() == 2);
   }
@@ -89,12 +89,12 @@ BOOST_AUTO_TEST_CASE(addDataBlockForEach_test)
     vec.push_back({ 3, 4 });
 
     addDataBlock(message,
-                 Stack{ allocZMQ, DataHeader{ gDataDescriptionInvalid, gDataOriginInvalid, DataHeader::SubSpecificationType{ 0 }, 0 } },
+                 Stack{ allocZMQ, DataHeader{ gDataDescriptionInvalid, gDataOriginInvalid, DataHeader::SubSpecificationType{ 0 } } },
                  std::move(vec));
     BOOST_CHECK(message.Size() == 2);
     BOOST_CHECK(vec.size() == 0);
     BOOST_CHECK(message[0].GetSize() == 80);
-    BOOST_CHECK(message[1].GetSize() == 2 * sizeof(elem)); //check the size of the buffer is set
+    BOOST_CHECK(message[1].GetSize() == 2 * sizeof(elem)); //check the size of the buffer is set correctly
 
     //check contents
     int sum{ 0 };
@@ -106,7 +106,7 @@ BOOST_AUTO_TEST_CASE(addDataBlockForEach_test)
 
     //add one more data block and check total size using forEach;
     addDataBlock(message,
-                 Stack{ allocZMQ, DataHeader{ gDataDescriptionInvalid, gDataOriginInvalid, DataHeader::SubSpecificationType{ 0 }, 0 } },
+                 Stack{ allocZMQ, DataHeader{ gDataDescriptionInvalid, gDataOriginInvalid, DataHeader::SubSpecificationType{ 0 } } },
                  factoryZMQ->CreateMessage(10));
     int size{ 0 };
     forEach(message, [&](auto header, auto data) { size += header.size() + data.size(); });

--- a/Utilities/O2MessageMonitor/include/O2MessageMonitor/O2MessageMonitor.h
+++ b/Utilities/O2MessageMonitor/include/O2MessageMonitor/O2MessageMonitor.h
@@ -28,7 +28,6 @@
 #ifndef O2MESSAGEMONITOR_H_
 #define O2MESSAGEMONITOR_H_
 
-#include "Headers/DataHeader.h"
 #include "O2Device/O2Device.h"
 
 /// This is a simple FairMQ monitoring class
@@ -47,7 +46,6 @@ class O2MessageMonitor : public o2::Base::O2Device
  protected:
   void Run() override;
   void InitTask() override;
-  bool HandleData(o2::Base::O2Message& parts, int index);
 
  private:
   std::string mPayload{ "I am the info payload" };

--- a/Utilities/O2MessageMonitor/src/O2MessageMonitor.cxx
+++ b/Utilities/O2MessageMonitor/src/O2MessageMonitor.cxx
@@ -67,7 +67,7 @@ void O2MessageMonitor::Run()
 
     // maybe send a request
     if (type == "req") {
-      addDataBlock(message, { dataResource, DataHeader{ gDataDescriptionInfo, gDataOriginAny, DataHeader::SubSpecificationType{ 0 }, 0 } },
+      addDataBlock(message, { dataResource, DataHeader{ gDataDescriptionInfo, gDataOriginAny, DataHeader::SubSpecificationType{ 0 } } },
                    NewSimpleMessageFor("data", 0, mPayload));
       Send(message, "data");
       message.fParts.clear();
@@ -85,7 +85,7 @@ void O2MessageMonitor::Run()
     // maybe a reply message
     if (type == "rep") {
       o2::Base::addDataBlock(message,
-                             { dataResource, DataHeader{ gDataDescriptionInfo, gDataOriginAny, DataHeader::SubSpecificationType{ 0 }, 0 } },
+                             { dataResource, DataHeader{ gDataDescriptionInfo, gDataOriginAny, DataHeader::SubSpecificationType{ 0 } } },
                              NewSimpleMessageFor("data", 0, ""));
       Send(message, "data");
     }

--- a/Utilities/O2MessageMonitor/src/O2MessageMonitor.cxx
+++ b/Utilities/O2MessageMonitor/src/O2MessageMonitor.cxx
@@ -67,7 +67,7 @@ void O2MessageMonitor::Run()
 
     // maybe send a request
     if (type == "req") {
-      AddDataBlock(message, { dataResource, DataHeader{ gDataDescriptionInfo, gDataOriginAny, DataHeader::SubSpecificationType{ 0 }, 0 } },
+      addDataBlock(message, { dataResource, DataHeader{ gDataDescriptionInfo, gDataOriginAny, DataHeader::SubSpecificationType{ 0 }, 0 } },
                    NewSimpleMessageFor("data", 0, mPayload));
       Send(message, "data");
       message.fParts.clear();
@@ -76,7 +76,7 @@ void O2MessageMonitor::Run()
     // message in;
     Receive(message, "data");
     LOG(INFO) << "== New message=============================";
-    o2::Base::ForEach(message, [&](auto header, auto data) {
+    o2::Base::forEach(message, [&](auto header, auto data) {
       hexDump("headerBuffer", header.data(), header.size());
       hexDump("dataBuffer", data.data(), data.size(), mLimitOutputCharacters);
     });
@@ -84,7 +84,7 @@ void O2MessageMonitor::Run()
 
     // maybe a reply message
     if (type == "rep") {
-      o2::Base::AddDataBlock(message,
+      o2::Base::addDataBlock(message,
                              { dataResource, DataHeader{ gDataDescriptionInfo, gDataOriginAny, DataHeader::SubSpecificationType{ 0 }, 0 } },
                              NewSimpleMessageFor("data", 0, ""));
       Send(message, "data");

--- a/Utilities/O2MessageMonitor/src/O2MessageMonitor.cxx
+++ b/Utilities/O2MessageMonitor/src/O2MessageMonitor.cxx
@@ -30,15 +30,11 @@
 
 #include <FairMQLogger.h>
 #include <options/FairMQProgOptions.h>
-#include "Headers/DataHeader.h"
-#include "Headers/NameHeader.h"
 #include "O2MessageMonitor/O2MessageMonitor.h"
 
 using namespace std;
 using namespace o2::header;
 using namespace o2::Base;
-
-using NameHeader48 = NameHeader<48>; // header holding 16 characters
 
 //__________________________________________________________________________________________________
 void O2MessageMonitor::InitTask()
@@ -57,12 +53,12 @@ void O2MessageMonitor::Run()
 {
   // check socket type of data channel
   std::string type;
-  std::vector<FairMQChannel> subChannels = fChannels["data"];
+  std::vector<FairMQChannel>& subChannels = fChannels["data"];
   if (subChannels.size() > 0) {
     type = subChannels[0].GetType();
   }
 
-  o2::memoryResources::ChannelResource dataResource(subChannels[0].Transport());
+  auto dataResource = o2::memoryResources::getTransportAllocator(subChannels[0].Transport());
 
   while (CheckCurrentState(RUNNING) && (--mIterations) != 0) {
     this_thread::sleep_for(chrono::milliseconds(mDelay));
@@ -71,7 +67,7 @@ void O2MessageMonitor::Run()
 
     // maybe send a request
     if (type == "req") {
-      AddDataBlock(message, { &dataResource, DataHeader{ gDataDescriptionInfo, gDataOriginAny, DataHeader::SubSpecificationType{ 0 }, 0 } },
+      AddDataBlock(message, { dataResource, DataHeader{ gDataDescriptionInfo, gDataOriginAny, DataHeader::SubSpecificationType{ 0 }, 0 } },
                    NewSimpleMessageFor("data", 0, mPayload));
       Send(message, "data");
       message.fParts.clear();
@@ -80,7 +76,7 @@ void O2MessageMonitor::Run()
     // message in;
     Receive(message, "data");
     LOG(INFO) << "== New message=============================";
-    ForEach(message, [&](auto header, auto data) {
+    o2::Base::ForEach(message, [&](auto header, auto data) {
       hexDump("headerBuffer", header.data(), header.size());
       hexDump("dataBuffer", data.data(), data.size(), mLimitOutputCharacters);
     });
@@ -88,9 +84,9 @@ void O2MessageMonitor::Run()
 
     // maybe a reply message
     if (type == "rep") {
-      AddMessage(message,
-                 { &dataResource, DataHeader{ gDataDescriptionInfo, gDataOriginAny, DataHeader::SubSpecificationType{ 0 }, 0 } },
-                 NewSimpleMessageFor("data", 0, "I am a reply"));
+      o2::Base::AddDataBlock(message,
+                             { dataResource, DataHeader{ gDataDescriptionInfo, gDataOriginAny, DataHeader::SubSpecificationType{ 0 }, 0 } },
+                             NewSimpleMessageFor("data", 0, ""));
       Send(message, "data");
     }
   }

--- a/Utilities/Publishers/src/DataPublisherDevice.cxx
+++ b/Utilities/Publishers/src/DataPublisherDevice.cxx
@@ -122,7 +122,7 @@ void DataPublisherDevice::InitTask()
 
 bool DataPublisherDevice::HandleData(FairMQParts& msgParts, int index)
 {
-  ForEach(msgParts, &DataPublisherDevice::HandleO2LogicalBlock);
+  o2::Base::ForEach(msgParts, [&](auto header, auto payload) { this->HandleO2LogicalBlock(header.data(), header.size(), payload.data(), payload.size()); });
 
   return true;
 }
@@ -191,8 +191,8 @@ bool DataPublisherDevice::HandleO2LogicalBlock(const byte* headerBuffer,
   // TODO: fix payload size in dh
   auto *buffer = new char[mFileBuffer.size()];
   memcpy(buffer, mFileBuffer.data(), mFileBuffer.size());
-  AddMessage(outgoing, dh, NewMessage(buffer, mFileBuffer.size(),
-                        [](void* data, void* hint) { delete[] reinterpret_cast<char *>(data); }, nullptr));
+  o2::Base::AddDataBlock(outgoing, dh, NewMessage(buffer, mFileBuffer.size(),
+                                                  [](void* data, void* hint) { delete[] reinterpret_cast<char*>(data); }, nullptr));
 
   // send message
   Send(outgoing, mOutputChannelName.c_str());

--- a/Utilities/Publishers/src/DataPublisherDevice.cxx
+++ b/Utilities/Publishers/src/DataPublisherDevice.cxx
@@ -122,7 +122,7 @@ void DataPublisherDevice::InitTask()
 
 bool DataPublisherDevice::HandleData(FairMQParts& msgParts, int index)
 {
-  o2::Base::ForEach(msgParts, [&](auto header, auto payload) { this->HandleO2LogicalBlock(header.data(), header.size(), payload.data(), payload.size()); });
+  o2::Base::forEach(msgParts, [&](auto header, auto payload) { this->HandleO2LogicalBlock(header.data(), header.size(), payload.data(), payload.size()); });
 
   return true;
 }
@@ -191,7 +191,7 @@ bool DataPublisherDevice::HandleO2LogicalBlock(const byte* headerBuffer,
   // TODO: fix payload size in dh
   auto *buffer = new char[mFileBuffer.size()];
   memcpy(buffer, mFileBuffer.data(), mFileBuffer.size());
-  o2::Base::AddDataBlock(outgoing, dh, NewMessage(buffer, mFileBuffer.size(),
+  o2::Base::addDataBlock(outgoing, dh, NewMessage(buffer, mFileBuffer.size(),
                                                   [](void* data, void* hint) { delete[] reinterpret_cast<char*>(data); }, nullptr));
 
   // send message


### PR DESCRIPTION
This cleans up most of current O2Device and moves most functionality out to O2Device/Utilities.h as free standing functions that can be used from any FairMQDevice. It builds on #1140 which enables this split. Also additional tests are added and some documentation. As always, this is work in progress and more is coming in other PRs.