### PR TITLE
Opt for the safer variant of allocator is_equal check

### DIFF
--- a/DataFormats/MemoryResources/include/MemoryResources/MemoryResources.h
+++ b/DataFormats/MemoryResources/include/MemoryResources/MemoryResources.h
@@ -108,11 +108,7 @@ class ChannelResource : public FairMQMemoryResource
 
   bool do_is_equal(const boost::container::pmr::memory_resource& other) const noexcept override
   {
-    const FairMQMemoryResource* that = dynamic_cast<const FairMQMemoryResource*>(&other);
-    if (that && that->getTransportFactory() == factory) {
-      return true;
-    }
-    return false;
+    return this == &other;
   };
 };
 


### PR DESCRIPTION
This is the only safe thing to do unless pointer-to-message association
is kept within the transport factory. In this case we just have to make
sure to have exactly one allocator per transport factory (so always use
getTransportAllocator(...)).
This was a case of a brown-paper-bag bug. Will add some testing functionality to catch these kinds of bugs at some point.