### PR TITLE
add message to static_assert to comply with C++ standard

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/src/PixelData.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/PixelData.cxx
@@ -20,5 +20,6 @@ using namespace o2::ITSMFT;
 void PixelData::sanityCheck() const
 {
   // make sure the mask used in this class are compatible with Alpide segmenations
-  static_assert(RowMask + 1 >= o2::ITSMFT::SegmentationAlpide::NRows);
+  static_assert(RowMask + 1 >= o2::ITSMFT::SegmentationAlpide::NRows,
+                "incompatible mask, does not match Alpide segmentations");
 }


### PR DESCRIPTION
static_assert with no message is a C++17 extension