### PR TITLE
Optionally QED hits processing by ITS/MFT digitizer

### DIFF
--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/DigitizerTask.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/DigitizerTask.h
@@ -30,6 +30,8 @@
 #include "SimulationDataFormat/MCTruthContainer.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 
+class TBranch;
+
 namespace o2
 {
 
@@ -50,24 +52,34 @@ class DigitizerTask : public FairTask
   void FinishTask() override;
 
   Digitizer& getDigitizer() { return mDigitizer; }
-  o2::ITSMFT::DigiParams& getDigiParams() { return (o2::ITSMFT::DigiParams&)mParams; }
+  o2::ITSMFT::DigiParams& getDigiParams() { return mDigitizer.getParams(); }
+  const o2::ITSMFT::DigiParams& getDigiParams() const { return mDigitizer.getParams(); }
 
-  void setContinuous(bool v) { mParams.setContinuous(v); }
-  bool isContinuous() const { return mParams.isContinuous(); }
+  void setContinuous(bool v) { mDigitizer.getParams().setContinuous(v); }
+  bool isContinuous() const { return mDigitizer.getParams().isContinuous(); }
   void setFairTimeUnitInNS(double tinNS) { mFairTimeUnitInNS = tinNS < 1. ? 1. : tinNS; }
   double getFairTimeUnitInNS() const { return mFairTimeUnitInNS; }
-  void setAlpideROFramLength(float l) { mParams.setROFrameLength(l); }
-  float getAlpideROFramLength() const { return mParams.getROFrameLength(); }
+  void setAlpideROFramLength(float l) { mDigitizer.getParams().setROFrameLength(l); }
+  float getAlpideROFramLength() const { return mDigitizer.getParams().getROFrameLength(); }
+
+  void setQEDInput(TBranch* qed, float timebin, UChar_t srcID);
 
  private:
-  o2::ITSMFT::DigiParams mParams; // settings, eventually load this from the CCDB
+  void processQEDBackground(double tMax);
 
   double mFairTimeUnitInNS = 1; ///< Fair time unit in ns
-
   Int_t mSourceID = 0;                  ///< current source
   Int_t mEventID = 0;                   ///< current event id from the source
   Digitizer mDigitizer;                 ///< Digitizer
+
   const std::vector<o2::ITSMFT::Hit>* mHitsArray = nullptr; //! Array of MC hits
+
+  TBranch* mQEDBranch = nullptr;                               //! optional special branch of hits from QED collitions
+  const std::vector<o2::ITSMFT::Hit>* mHitsArrayQED = nullptr; //! array of MC hits from ED
+  float mQEDEntryTimeBinNS = 0.f;                              ///< every entry in the QED branch integrates QED for so many nanosec.
+  double mLastQEDTimeNS = 0.;                                  ///< center of the time-bin of last added QED bg slot (entry of mQEDBranch)
+  int mLastQEDEntry = -1;                                      ///< last used QED entry
+  UChar_t mQEDSourceID = 0;                                    ///< MC ID source of the QED (stored in the labels)
 
   std::vector<o2::ITSMFT::Digit> mDigitsArray;                     //!  Array of digits
   std::vector<o2::ITSMFT::Digit>* mDigitsArrayPtr = &mDigitsArray; //! pointer on the digits array

--- a/Detectors/ITSMFT/MFT/simulation/include/MFTSimulation/DigitizerTask.h
+++ b/Detectors/ITSMFT/MFT/simulation/include/MFTSimulation/DigitizerTask.h
@@ -27,6 +27,8 @@
 #include "SimulationDataFormat/MCTruthContainer.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 
+class TBranch;
+
 namespace o2
 {
 namespace MFT
@@ -46,24 +48,34 @@ class DigitizerTask : public FairTask
   void FinishTask() override;
 
   Digitizer& getDigitizer() { return mDigitizer; }
-  o2::ITSMFT::DigiParams& getDigiParams() { return (o2::ITSMFT::DigiParams&)mParams; }
+  o2::ITSMFT::DigiParams& getDigiParams() { return mDigitizer.getParams(); }
+  const o2::ITSMFT::DigiParams& getDigiParams() const { return mDigitizer.getParams(); }
 
-  void setContinuous(bool v) { mParams.setContinuous(v); }
-  bool isContinuous() const { return mParams.isContinuous(); }
+  void setContinuous(bool v) { mDigitizer.getParams().setContinuous(v); }
+  bool isContinuous() const { return mDigitizer.getParams().isContinuous(); }
   void setFairTimeUnitInNS(double tinNS) { mFairTimeUnitInNS = tinNS < 1. ? 1. : tinNS; }
   double getFairTimeUnitInNS() const { return mFairTimeUnitInNS; }
-  void setAlpideROFramLength(float l) { mParams.setROFrameLength(l); }
-  float getAlpideROFramLength() const { return mParams.getROFrameLength(); }
+  void setAlpideROFramLength(float l) { mDigitizer.getParams().setROFrameLength(l); }
+  float getAlpideROFramLength() const { return mDigitizer.getParams().getROFrameLength(); }
+
+  void setQEDInput(TBranch* qed, float timebin, UChar_t srcID);
 
  private:
-  o2::ITSMFT::DigiParams mParams; // settings, eventually load this from the CCDB
+  void processQEDBackground(double tMax);
 
   double mFairTimeUnitInNS = 1; ///< Fair time unit in ns
+  Int_t mSourceID = 0;          ///< current source
+  Int_t mEventID = 0;           ///< current event id from the source
+  Digitizer mDigitizer;         ///< Digitizer
 
-  Int_t mSourceID = 0;                                      ///< current source
-  Int_t mEventID = 0;                                       ///< current event id from the source
-  Digitizer mDigitizer;                                     ///< Digitizer
   const std::vector<o2::ITSMFT::Hit>* mHitsArray = nullptr; //! Array of MC hits
+
+  TBranch* mQEDBranch = nullptr;                               //! optional special branch of hits from QED collitions
+  const std::vector<o2::ITSMFT::Hit>* mHitsArrayQED = nullptr; //! array of MC hits from ED
+  float mQEDEntryTimeBinNS = 0.f;                              ///< every entry in the QED branch integrates QED for so many nanosec.
+  double mLastQEDTimeNS = 0.;                                  ///< center of the time-bin of last added QED bg slot (entry of mQEDBranch)
+  int mLastQEDEntry = -1;                                      ///< last used QED entry
+  UChar_t mQEDSourceID = 0;                                    ///< MC ID source of the QED (stored in the labels)
 
   std::vector<o2::ITSMFT::Digit> mDigitsArray;                     //!  Array of digits
   std::vector<o2::ITSMFT::Digit>* mDigitsArrayPtr = &mDigitsArray; //! pointer on the digits array

--- a/Detectors/ITSMFT/MFT/simulation/src/DigitizerTask.cxx
+++ b/Detectors/ITSMFT/MFT/simulation/src/DigitizerTask.cxx
@@ -36,11 +36,12 @@ DigitizerTask::~DigitizerTask()
 {
   mDigitsArray.clear();
   mMCTruthArray.clear();
+  delete mHitsArrayQED; // this special branch is managed by the task
 }
+
 /// \brief Init function
 ///
 /// Inititializes the digitizer and connects input and output container
-//_____________________________________________________________________________
 InitStatus DigitizerTask::Init()
 {
   FairRootManager* mgr = FairRootManager::Instance();
@@ -59,15 +60,10 @@ InitStatus DigitizerTask::Init()
   mgr->RegisterAny("MFTDigit", mDigitsArrayPtr, kTRUE);
   mgr->RegisterAny("MFTDigitMCTruth", mMCTruthArrayPtr, kTRUE);
 
-  mDigitizer.setDigiParams(mParams);
-
-  mDigitizer.setCoeffToNanoSecond(mFairTimeUnitInNS);
-
   GeometryTGeo* geom = GeometryTGeo::Instance();
   geom->fillMatrixCache(o2::utils::bit2Mask(o2::TransformType::L2G)); // make sure L2G matrices are loaded
   mDigitizer.setGeometry(geom);
 
-  mDigitizer.setHits(mHitsArray);
   mDigitizer.setDigits(mDigitsArrayPtr);
   mDigitizer.setMCLabels(mMCTruthArrayPtr);
 
@@ -76,24 +72,26 @@ InitStatus DigitizerTask::Init()
   return kSUCCESS;
 }
 
-//_____________________________________________________________________________
+//________________________________________________________
 void DigitizerTask::Exec(Option_t* option)
 {
   FairRootManager* mgr = FairRootManager::Instance();
 
   mDigitsArray.clear();
   mMCTruthArray.clear();
-  mDigitizer.setEventTime(mgr->GetEventTime());
 
+  double tEvent = mgr->GetEventTime() * mFairTimeUnitInNS; // event time in ns
+
+  // is there QED backgroung provided? Fill QED slots until provided collision time
+  if (mQEDBranch) {
+    processQEDBackground(tEvent);
+  }
+  //
+  mDigitizer.setEventTime(tEvent);
   // the type of digitization is steered by the DigiParams object of the Digitizer
   LOG(DEBUG) << "Running digitization on new event " << mEventID << " from source " << mSourceID << FairLogger::endl;
 
-  /// RS: ATTENTION: this is just a trick until we clarify how the hits from different source are
-  /// provided and identified.
-  mDigitizer.setCurrSrcID(mSourceID);
-  mDigitizer.setCurrEvID(mEventID);
-
-  mDigitizer.process();
+  mDigitizer.process(mHitsArray, mEventID, mSourceID);
 
   mEventID++;
 }
@@ -102,12 +100,61 @@ void DigitizerTask::Exec(Option_t* option)
 void DigitizerTask::FinishTask()
 {
   // finalize digitization, if needed, flash remaining digits
-  if (!mParams.isContinuous()) {
+
+  if (!mDigitizer.getParams().isContinuous()) {
     return;
   }
+
+  // is there QED backgroung provided? Fill QED slots up to the end of reserved ROFrames
+  if (mQEDBranch) {
+    processQEDBackground(mDigitizer.getEndTimeOfROFMax());
+  }
+
   FairRootManager* mgr = FairRootManager::Instance();
   mgr->SetLastFill(kTRUE); /// necessary, otherwise the data is not written out
   mDigitsArray.clear();
   mMCTruthArray.clear();
   mDigitizer.fillOutputContainer();
+}
+
+//________________________________________________________
+void DigitizerTask::processQEDBackground(double tMax)
+{
+  // process QED time-slots until provided collision time (in ns)
+
+  double tQEDNext = mLastQEDTimeNS + mQEDEntryTimeBinNS;
+
+  while (tQEDNext < tMax) {
+    mLastQEDTimeNS = tQEDNext;      // time used for current QED slot
+    tQEDNext += mQEDEntryTimeBinNS; // prepare time for next QED slot
+    if (++mLastQEDEntry >= mQEDBranch->GetEntries()) {
+      mLastQEDEntry = 0; // wrapp if needed
+    }
+    mQEDBranch->GetEntry(mLastQEDEntry);
+    mDigitizer.setEventTime(mLastQEDTimeNS);
+    mDigitizer.process(mHitsArrayQED, mLastQEDEntry, mQEDSourceID);
+    //
+  }
+}
+
+//________________________________________________________
+void DigitizerTask::setQEDInput(TBranch* qed, float timebin, UChar_t srcID)
+{
+  // assign the branch containing hits from QED electrons, whith every entry integrating
+  // timebin ns of collisions
+
+  LOG(INFO) << "Attaching QED ITS hits as sourceID=" << int(srcID) << ", entry integrates "
+            << timebin << " ns" << FairLogger::endl;
+
+  mQEDBranch = qed;
+  mQEDEntryTimeBinNS = timebin;
+  if (mQEDBranch) {
+    assert(mQEDEntryTimeBinNS >= 1.0);
+    mLastQEDTimeNS = -mQEDEntryTimeBinNS / 2; // time will be assigned to the middle of the bin
+    mQEDBranch->SetAddress(&mHitsArrayQED);
+    mLastQEDEntry = -1;
+    mQEDSourceID = srcID;
+    assert(mHitsArrayQED);
+    assert(srcID < o2::MCCompLabel::maxSourceID());
+  }
 }


### PR DESCRIPTION
ITS/MFT digitizer can process hits from QED backgroung, overlaying it on top of the
hits provided by the central digitization manager

Extra modification:
Store DigiParams in the digitizer only, do not duplicate in the task
Digitizer::process takes as arguments hits vector, source and entry ID to process,
rather than take in from data members, assigned in advance by the DigitizerTask