### PR TITLE
Fix #884: fixed creation of channel names to make DPL I/O matching reliable

### DIFF
--- a/DataFormats/Headers/include/Headers/DataHeader.h
+++ b/DataFormats/Headers/include/Headers/DataHeader.h
@@ -36,6 +36,7 @@
 #include <cstring> //needed for memcmp
 #include <algorithm> // std::min
 #include <stdexcept>
+#include <string>
 #include "MemoryResources/MemoryResources.h"
 
 using byte = unsigned char;
@@ -299,6 +300,16 @@ struct Descriptor {
   bool operator==(const T*) const = delete;
   template<typename T>
   bool operator!=(const T*) const = delete;
+
+  /// get the descriptor as std::string
+  template <typename T>
+  std::enable_if_t<std::is_same<T, std::string>::value == true, T> as() const
+  {
+    // init from the complete str member including space for a trailing 0
+    std::string ret(str, size + 1);
+    ret[size] = 0;
+    return std::move(ret);
+  }
   // print function needs to be implemented for every derivation
   void print() const {
     // eventually terminate string before printing

--- a/Framework/Core/include/Framework/ChannelMatching.h
+++ b/Framework/Core/include/Framework/ChannelMatching.h
@@ -37,8 +37,8 @@ struct PhysicalChannel {
 
 inline LogicalChannel outputSpec2LogicalChannel(const OutputSpec &spec) {
   auto name = std::string("out_") +
-              spec.origin.str + "_" +
-              spec.description.str + "_" +
+              spec.origin.as<std::string>() + "_" +
+              spec.description.as<std::string>() + "_" +
               std::to_string(spec.subSpec);
   return LogicalChannel{name};
 }
@@ -50,7 +50,7 @@ inline PhysicalChannel outputSpec2PhysicalChannel(const OutputSpec &spec, int co
 }
 
 inline LogicalChannel inputSpec2LogicalChannelMatcher(const InputSpec &spec) {
-  auto name = std::string("out_") + spec.origin.str + "_" + spec.description.str + "_" + std::to_string(spec.subSpec);
+  auto name = std::string("out_") + spec.origin.as<std::string>() + "_" + spec.description.as<std::string>() + "_" + std::to_string(spec.subSpec);
   return LogicalChannel{name};
 }
 

--- a/Framework/Core/src/DataAllocator.cxx
+++ b/Framework/Core/src/DataAllocator.cxx
@@ -50,8 +50,8 @@ DataAllocator::matchDataHeader(const Output& spec, size_t timeslice) {
   }
   std::ostringstream str;
   str << "Worker is not authorised to create message with "
-      << "origin(" << spec.origin.str << ")"
-      << "description(" << spec.description.str << ")"
+      << "origin(" << spec.origin.as<std::string>() << ")"
+      << "description(" << spec.description.as<std::string>() << ")"
       << "subSpec(" << spec.subSpec << ")";
   throw std::runtime_error(str.str());
 }

--- a/Framework/Core/src/StreamOperators.cxx
+++ b/Framework/Core/src/StreamOperators.cxx
@@ -19,7 +19,7 @@ namespace framework
 std::ostream& operator<<(std::ostream& stream, o2::framework::InputSpec const& arg)
 {
   // FIXME: should have stream operators for the header fields
-  stream << arg.binding << " {" << arg.origin.str << ":" << arg.description.str << ":" << arg.subSpec << "}";
+  stream << arg.binding << " {" << arg.origin.as<std::string>() << ":" << arg.description.as<std::string>() << ":" << arg.subSpec << "}";
   return stream;
 }
 

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -204,8 +204,8 @@ WorkflowHelpers::constructGraph(const WorkflowSpec &workflow,
   auto errorDueToMissingOutputFor = [&workflow](size_t ci, size_t ii) {
     auto input = workflow[ci].inputs[ii];
     std::ostringstream str;
-    str << "No matching output found for " << input.origin.str << " "
-        << input.description.str << " "
+    str << "No matching output found for " << input.origin.as<std::string>() << " "
+        << input.description.as<std::string>() << " "
         << input.subSpec << "\n";
     throw std::runtime_error(str.str());
   };

--- a/Framework/Core/test/test_DataAllocator.cxx
+++ b/Framework/Core/test/test_DataAllocator.cxx
@@ -51,7 +51,7 @@ DataProcessorSpec getTimeoutSpec()
   // a timer process to terminate the workflow after a timeout
   auto processingFct = [](ProcessingContext& pc) {
     static int counter = 0;
-    pc.outputs().snapshot(Output{ "TST", "TIMER", 0, Lifetime::Timeframe }, counter);
+    pc.outputs().snapshot(Output{ "TEST", "TIMER", 0, Lifetime::Timeframe }, counter);
 
     sleep(1);
     if (counter++ > 10) {
@@ -62,7 +62,7 @@ DataProcessorSpec getTimeoutSpec()
 
   return DataProcessorSpec{ "timer",  // name of the processor
                             Inputs{}, // inputs empty
-                            { OutputSpec{ "TST", "TIMER", 0, Lifetime::Timeframe } },
+                            { OutputSpec{ "TEST", "TIMER", 0, Lifetime::Timeframe } },
                             AlgorithmSpec(processingFct) };
 }
 
@@ -96,7 +96,7 @@ DataProcessorSpec getSourceSpec()
   };
 
   return DataProcessorSpec{ "source", // name of the processor
-                            { InputSpec{ "timer", "TST", "TIMER", 0, Lifetime::Timeframe } },
+                            { InputSpec{ "timer", "TEST", "TIMER", 0, Lifetime::Timeframe } },
                             { OutputSpec{ "TST", "MESSAGEABLE", 0, Lifetime::Timeframe },
                               OutputSpec{ "TST", "MSGBLEROOTSRLZ", 0, Lifetime::Timeframe },
                               OutputSpec{ "TST", "ROOTNONTOBJECT", 0, Lifetime::Timeframe },

--- a/Framework/Core/test/test_DeviceSpec.cxx
+++ b/Framework/Core/test/test_DeviceSpec.cxx
@@ -497,7 +497,7 @@ BOOST_AUTO_TEST_CASE(TestOutEdgeProcessingHelpers)
     auto& device = devices[di];
     for (size_t ri = 0; ri < device.outputs.size(); ri++) {
       // FIXME: check that the matchers are the same
-      BOOST_CHECK_EQUAL(std::string(device.outputs[ri].matcher.origin.str), std::string(routes[ri].matcher.origin.str));
+      BOOST_CHECK_EQUAL(std::string(device.outputs[ri].matcher.origin.as<std::string>()), std::string(routes[ri].matcher.origin.as<std::string>()));
       BOOST_CHECK_EQUAL(device.outputs[ri].channel, routes[ri].channel);
       BOOST_CHECK_EQUAL(device.outputs[ri].timeslice, routes[ri].timeslice);
     }


### PR DESCRIPTION
Channel matching is based on the created channel names rather than data origin and description fields. For this logic to be reliable, the individual strings to build the name from have to be zero terminated.