### PR TITLE
Get rid of class template arguments

### DIFF
--- a/Framework/Utils/include/Utils/RootTreeWriter.h
+++ b/Framework/Utils/include/Utils/RootTreeWriter.h
@@ -38,35 +38,46 @@ namespace framework
 /// @class RootTreeWriter
 /// A generic writer interface for ROOT TTrees
 ///
-/// The writer class is configured with a list of types to be processed by defining
-/// the class with the appropriate template argumets. Each type needs to be associated
-/// with an input key and a branch name for the output.
+/// The writer class is configured with a list of branch definitions passed to the
+/// constructor. Each branch definition holds the data type as template parameter,
+/// as well as an input key and a branch name for the output.
 ///
 /// The class is currently fixed to the DPL ProcessingContext and InputRecord for
 /// reading the input.
 ///
 /// Usage:
-///   RootTreeWriter<Types...>("file_name",
-///                            "tree_name",
-///                            "key", "branchname",
-///                            ...// further input and branch config
-///                           ) writer;
+///   RootTreeWriter("file_name",
+///                  "tree_name",
+///                  BranchDef<type>{ "key", "branchname" },
+///                  ...// further input and branch config
+///                 ) writer;
 ///   writer(processingContext);
 ///
 /// See also the MakeRootTreeWriterSpec helper class for easy generation of a
 /// processor spec using RootTreeWriter.
-template <typename... Types>
 class RootTreeWriter
 {
  public:
-  using self_type = RootTreeWriter<Types...>;
+  // use string as input binding to be used with DPL input API
   using key_type = std::string;
-  using store_type = std::tuple<Types...>;
-  static constexpr std::size_t store_size = sizeof...(Types);
-  template <size_t Index>
-  struct element {
-    static_assert(Index < store_size, "Index out of range");
-    using type = typename std::tuple_element<Index, store_type>::type;
+
+  struct DefaultKeyExtractor {
+    template <typename T>
+    static key_type asString(T const& arg)
+    {
+      return arg;
+    }
+  };
+  /// branch definition
+  /// FIXME: could become BranchSpec, but that name is currently used for the elements
+  /// of the internal store
+  template <typename T, typename KeyType = key_type, typename KeyExtractor = DefaultKeyExtractor>
+  struct BranchDef {
+    using type = T;
+    using key_type = KeyType;
+    using key_extractor = KeyExtractor;
+    KeyType key;
+    std::string branchName;
   };
 
   /// default constructor forbidden
@@ -79,29 +90,37 @@ class RootTreeWriter
   template <typename... Args>
   RootTreeWriter(const char* filename, // file name
                  const char* treename, // name of the tree to write to
-                 Args&&... args)       // followed by branch info
+                 Args&&... args)       // followed by branch definition
+  {
+    mTreeStructure = createTreeStructure<TreeStructureInterface>(std::forward<Args>(args)...);
+    if (filename && treename) {
+      init(filename, treename);
+    }
+  }
+
+  void init(const char* filename, const char* treename)
   {
     mFile = std::make_unique<TFile>(filename, "RECREATE");
     mTree = std::make_unique<TTree>(treename, treename);
-    mBranchSpecs.resize(store_size);
-    parseConstructorArgs<0>(std::forward<Args>(args)...);
-    setupBranches<store_size>();
+    mTreeStructure->setup(mBranchSpecs, mTree.get());
   }
 
   /// process functor
   /// It expects a context which is used by lambda capture in the snapshot function.
-  /// Loop over all branch definitions and publish by using the snapshot function.
-  /// The default forwards to DPL DataAllocator snapshot.
+  /// Recursively process all inputs and set the branch address to extracted objects.
+  /// Release function is called on the object after filling the tree.
   template <typename ContextType>
   void operator()(ContextType& context)
   {
     if (!mTree || !mFile || mFile->IsZombie()) {
-      throw std::runtime_error("Writer is invalid state, pabably closed previously");
+      throw std::runtime_error("Writer is invalid state, probably closed previously");
     }
-    process<store_size>(context);
+    mTreeStructure->exec(context, mBranchSpecs);
     mTree->Fill();
     for (auto& spec : mBranchSpecs) {
       spec.releaseFct(spec.data);
+      spec.data = nullptr;
+      spec.releaseFct = nullptr;
     }
   }
 
@@ -117,6 +136,11 @@ class RootTreeWriter
     mFile.reset(nullptr);
   }
 
+  size_t getStoreSize() const
+  {
+    return (mTreeStructure != nullptr ? mTreeStructure->size() : 0);
+  }
+
  private:
   struct BranchSpec {
     key_type key;
@@ -127,99 +151,100 @@ class RootTreeWriter
     TClass* classinfo = nullptr;
   };
 
-  /// recursively step through all members of the store and set up corresponding branch
-  template <size_t N>
-  typename std::enable_if<(N != 0)>::type setupBranches()
-  {
-    setupBranches<N - 1>();
-    setupBranch<N - 1>();
-  }
-
-  // specializtion to end the recursive loop
-  template <size_t N>
-  typename std::enable_if<(N == 0)>::type setupBranches()
-  {
-  }
-
-  /// set up a branch for the store type at Index position
-  template <size_t Index>
-  void setupBranch()
-  {
-    using ElementT = typename element<Index>::type;
-    // the variable from the store is actually only used when setting up the branch, during
-    // processing of input, the branch address is directly set to the extracted object
-    ElementT& storeRef = std::get<Index>(mStore);
-    mBranchSpecs[Index].branch = mTree->Branch(mBranchSpecs[Index].name.c_str(), &storeRef);
-    mBranchSpecs[Index].classinfo = TClass::GetClass(typeid(ElementT));
-    LOG(INFO) << "branch set up: " << mBranchSpecs[Index].name;
-  }
-
-  /// helper function to read branch config from vector, this excludes other variadic arguments
-  template <size_t N>
-  void parseConstructorArgs(const std::vector<std::pair<key_type, std::string>>& branchconfig)
-  {
-    static_assert(N == 0, "can not mix variadic arguments and vector config");
-    if (branchconfig.size() != store_size) {
-      throw std::runtime_error("number of branch specifications has to match number of types");
-    }
-    size_t index = 0;
-    for (auto& config : branchconfig) {
-      mBranchSpecs[index].key = config.first;
-      mBranchSpecs[index].name = config.second;
-      index++;
-    }
-  }
-
-  /// helper function to recursively parse constructor arguments
-  /// parse the branch definitions with key and branch name.
-  template <size_t N, typename... Args>
-  void parseConstructorArgs(key_type key, const char* name, Args&&... args)
-  {
-    static_assert(N < store_size, "too many branch arguments");
-    // init branch spec
-    using ElementT = typename element<N>::type;
-    mBranchSpecs[N].key = key;
-    mBranchSpecs[N].name = name;
-
-    parseConstructorArgs<N + 1>(std::forward<Args>(args)...);
-  }
-
-  // this terminates the argument parsing, at this point we should have
-  // parsed as many arguments as we have types
-  template <size_t N>
-  void parseConstructorArgs()
-  {
-    // at this point we should have processed argument pairs for all types in the stare
-    static_assert(N == store_size, "too few branch arguments");
-  }
-
-  // want to have the ContextType as a template parameter, but the compiler
-  // complains about calling the templated get function, to be investigated
   using ContextType = ProcessingContext;
-  template <size_t N>
-  typename std::enable_if<(N != 0)>::type process(ContextType& context)
+
+  /// polymorphic interface for the mixin stack of branch type descriptions
+  /// it implements the entry point for processing through exec method
+  class TreeStructureInterface
   {
-    constexpr static size_t Index = N - 1;
-    process<Index>(context);
-    using ElementT = typename element<Index>::type;
-    auto data = context.inputs().get<ElementT*>(mBranchSpecs[Index].key.c_str());
-    // could either copy to the corresponding store variable or use the object
-    // directly. TBranch::SetAddress supports only non-const pointers, so this is
-    // a hack
-    // FIXME: get rid of the const_cast
-    mBranchSpecs[Index].branch->SetAddress(const_cast<ElementT*>(data.get()));
-    // the data object is a smart pointer and we have to keep the data alieve
-    // until the tree is actually filled after the recursive processing of inputs
-    // release the base pointer from the smart pointer instance and keep the
-    // daleter to be called after tree fill.
-    mBranchSpecs[Index].data = const_cast<ElementT*>(data.release());
-    auto deleter = data.get_deleter();
-    mBranchSpecs[Index].releaseFct = [deleter](void* buffer) { deleter(reinterpret_cast<ElementT*>(buffer)); };
+   public:
+    static const size_t STAGE = 0;
+    TreeStructureInterface() = default;
+    virtual ~TreeStructureInterface() = default;
+
+    virtual void setup(std::vector<BranchSpec>&, TTree*) {}
+    virtual void exec(ProcessingContext&, std::vector<BranchSpec>&) {}
+    virtual size_t size() const { return STAGE; }
+
+    // a dummy method called in the recursive processing
+    void setupInstance(std::vector<BranchSpec>&, TTree*) {}
+    // a dummy method called in the recursive processing
+    void process(ProcessingContext&, std::vector<BranchSpec>&) {}
+  };
+
+  template <typename DataT, typename BASE>
+  class TreeStructureElement : public BASE
+  {
+   public:
+    using PrevT = BASE;
+    using type = DataT;
+    static const size_t STAGE = BASE::STAGE + 1;
+    TreeStructureElement() = default;
+    ~TreeStructureElement() override = default;
+
+    void setup(std::vector<BranchSpec>& specs, TTree* tree) override
+    {
+      setupInstance(specs, tree);
+    }
+
+    // this is the polymorphic entry point for processing of branch specs
+    // recursive processing starting from the highest instance
+    void exec(ProcessingContext& context, std::vector<BranchSpec>& specs) override
+    {
+      process(context, specs);
+    }
+    virtual size_t size() const override { return STAGE; }
+
+    /// setup this instance and recurse to the parent one
+    void setupInstance(std::vector<BranchSpec>& specs, TTree* tree)
+    {
+      static_cast<PrevT>(*this).setupInstance(specs, tree);
+      constexpr size_t Index = STAGE - 1;
+      specs[Index].branch = tree->Branch(specs[Index].name.c_str(), &mStore);
+      specs[Index].classinfo = TClass::GetClass(typeid(type));
+      LOG(INFO) << Index << ": branch  " << specs[Index].name << " set up";
+    }
+
+    // process previous stage and this stage
+    void process(ProcessingContext& context, std::vector<BranchSpec>& specs)
+    {
+      static_cast<PrevT>(*this).process(context, specs);
+      constexpr size_t Index = STAGE - 1;
+      auto data = context.inputs().get<type*>(specs[Index].key.c_str());
+      // could either copy to the corresponding store variable or use the object
+      // directly. TBranch::SetAddress supports only non-const pointers, so this is
+      // a hack
+      // FIXME: get rid of the const_cast
+      specs[Index].branch->SetAddress(const_cast<type*>(data.get()));
+      // the data object is a smart pointer and we have to keep the data alieve
+      // until the tree is actually filled after the recursive processing of inputs
+      // release the base pointer from the smart pointer instance and keep the
+      // daleter to be called after tree fill.
+      specs[Index].data = const_cast<type*>(data.release());
+      auto deleter = data.get_deleter();
+      specs[Index].releaseFct = [deleter](void* buffer) { deleter(reinterpret_cast<type*>(buffer)); };
+    }
+
+   private:
+    /// internal store variable of the type wraped by this instance
+    type mStore;
+  };
+
+  /// recursively step through all members of the store and set up corresponding branch
+  template <typename BASE, typename T, typename... Args>
+  std::enable_if_t<is_specialization<T, BranchDef>::value, std::unique_ptr<TreeStructureInterface>>
+    createTreeStructure(T def, Args&&... args)
+  {
+    mBranchSpecs.push_back({ T::key_extractor::asString(def.key), def.branchName });
+    using type = TreeStructureElement<typename T::type, BASE>;
+    return std::move(createTreeStructure<type>(std::forward<Args>(args)...));
   }
 
-  template <size_t N, typename ContextType>
-  typename std::enable_if<(N == 0)>::type process(ContextType& context)
+  template <typename T>
+  std::unique_ptr<TreeStructureInterface> createTreeStructure()
   {
+    std::unique_ptr<TreeStructureInterface> ret(new T);
+    return std::move(ret);
   }
 
   template <typename T>
@@ -240,8 +265,8 @@ class RootTreeWriter
   std::unique_ptr<TTree> mTree;
   /// definitions of branch specs
   std::vector<BranchSpec> mBranchSpecs;
-  // store of underlying branch variables
-  store_type mStore;
+  /// the underlying tree structure
+  std::unique_ptr<TreeStructureInterface> mTreeStructure;
 };
 
 } // namespace framework

--- a/Framework/Utils/test/test_RootTreeWriter.cxx
+++ b/Framework/Utils/test/test_RootTreeWriter.cxx
@@ -25,38 +25,22 @@ BOOST_AUTO_TEST_CASE(test_RootTreeWriter_static)
 {
   // need to mimic a context to actually call the processing
   // for now just test the besic compilation and setup
-  using WriterT = RootTreeWriter<int, float>;
-  WriterT writer("test.root", "testtree", // file and tree name
-                 "input1", "branchint",   // branch config pair
-                 "input2", "branchfloat"  // branch config pair
-                 );
+  RootTreeWriter writer("test.root", "testtree",                                    // file and tree name
+                        RootTreeWriter::BranchDef<int>{ "input1", "branchint" },    // branch definition
+                        RootTreeWriter::BranchDef<float>{ "input2", "branchfloat" } // branch definition
+                        );
 
-  BOOST_CHECK(writer.store_size == 2);
-  BOOST_CHECK((std::is_same<typename WriterT::element<0>::type, int>::value == true));
-  BOOST_CHECK((std::is_same<typename WriterT::element<1>::type, float>::value == true));
+  BOOST_CHECK(writer.getStoreSize() == 2);
 }
 
-BOOST_AUTO_TEST_CASE(test_RootTreeWriter_runtime)
-{
-  // use the writer with runtime init from a vector of config pairs
-  using WriterT = RootTreeWriter<int, float>;
-  std::vector<std::pair<std::string, std::string>> branchConfig;
-
-  // exception must be raised because of incomplete configuration
-  branchConfig.emplace_back("input1", "branchint");
-  auto createWriterFct = [&branchConfig]() { return std::make_unique<WriterT>("test.root", "tree", branchConfig); };
-  BOOST_CHECK_THROW(createWriterFct(), std::runtime_error);
-
-  // test with correct configuration
-  branchConfig.emplace_back("input2", "branchfloat");
-  auto writer = createWriterFct();
-}
+template <typename T>
+using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
 
 BOOST_AUTO_TEST_CASE(test_RootTreeWriterSpec)
 {
   // setup the spec helper and retrieve the spec by calling the operator
-  MakeRootTreeWriterSpec<int, float>("writer-process",                                        //
-                                     InputSpec{ "input1", "TST", "INTDATA" }, "intbranch",    //
-                                     InputSpec{ "input2", "TST", "FLOATDATA" }, "floatbranch" //
-                                     )();
+  MakeRootTreeWriterSpec("writer-process",                                                                   //
+                         BranchDefinition<int>{ InputSpec{ "input1", "TST", "INTDATA" }, "intbranch" },      //
+                         BranchDefinition<float>{ InputSpec{ "input2", "TST", "FLOATDATA" }, "floatbranch" } //
+                         )();
 }

--- a/Framework/Utils/test/test_RootTreeWriterWorkflow.cxx
+++ b/Framework/Utils/test/test_RootTreeWriterWorkflow.cxx
@@ -69,12 +69,12 @@ DataProcessorSpec getSinkSpec()
   auto initFct = [](InitContext& ic) {
     std::string fileName = gSystem->TempDirectory();
     fileName += "/test_RootTreeWriter.root";
-    using WriterType = RootTreeWriter<o2::test::Polymorphic, int>;
-    auto writer = std::make_shared<WriterType>(fileName.c_str(),      // output file name
-                                               "testtree",            // tree name
-                                               "input", "polyobject", // input key and branch name
-                                               "meta", "counter"      // input key and branch name
-                                               );
+    using Polymorphic = o2::test::Polymorphic;
+    using WriterType = RootTreeWriter;
+    auto writer = std::make_shared<WriterType>(fileName.c_str(), // output file name
+                                               "testtree",       // tree name
+                                               WriterType::BranchDef<Polymorphic>{ "input", "polyobject" },
+                                               WriterType::BranchDef<int>{ "meta", "counter" });
     auto counter = std::make_shared<int>();
     *counter = 0;
 
@@ -100,21 +100,24 @@ DataProcessorSpec getSinkSpec()
                             AlgorithmSpec(initFct) };
 }
 
+template <typename T>
+using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
 WorkflowSpec defineDataProcessing(ConfigContext const&)
 {
   std::string fileName = gSystem->TempDirectory();
   fileName += "/test_RootTreeWriter.root";
 
+  using Polymorphic = o2::test::Polymorphic;
   return WorkflowSpec{
     getSourceSpec(),
-    MakeRootTreeWriterSpec<o2::test::Polymorphic, int>         // type setup
-    (                                                          //
-      "sink",                                                  // process name
-      fileName.c_str(),                                        // default file name
-      "testtree",                                              // default tree name
-      1,                                                       // default number of events
-      InputSpec{ "input", "TST", "SOMEOBJECT" }, "polyobject", // input and branch config
-      InputSpec{ "meta", "TST", "METADATA" }, "counter"        // input and branch config
-      )()                                                      // call the generator
+    MakeRootTreeWriterSpec                                                                      //
+    (                                                                                           //
+      "sink",                                                                                   // process name
+      fileName.c_str(),                                                                         // default file name
+      "testtree",                                                                               // default tree name
+      1,                                                                                        // default number of events
+      BranchDefinition<Polymorphic>{ InputSpec{ "input", "TST", "SOMEOBJECT" }, "polyobject" }, // branch config
+      BranchDefinition<int>{ InputSpec{ "meta", "TST", "METADATA" }, "counter" }                // branch config
+      )()                                                                                       // call the generator
   };
 }


### PR DESCRIPTION
Removing the necessity to specify the configuration in two places, first part
as template arguments and second part as arguments to the constructor.

Now the constructor takes a variadic argument list of BranchDef holding type,
input key and branch name. The DPL spec generator is adjusted accordingly.

Here, ```MakeRootTreeWriterSpec::BranchDefinition<T>{ InputSpec{...}, "branchname"}```
is used to specify the input and corresponding branches.