### PR TITLE
Better container adopt using polymorphic allocators

### DIFF
--- a/DataFormats/MemoryResources/include/MemoryResources/MemoryResources.h
+++ b/DataFormats/MemoryResources/include/MemoryResources/MemoryResources.h
@@ -56,6 +56,7 @@ class FairMQMemoryResource : public boost::container::pmr::memory_resource
   /// e.g. pointer returned by std::vector::data()
   /// return nullptr if returning a message does not make sense!
   virtual FairMQMessagePtr getMessage(void* p) = 0;
+  virtual void* setMessage(FairMQMessagePtr) = 0;
   virtual const FairMQTransportFactory* getTransportFactory() const noexcept = 0;
   virtual size_t getNumberOfMessages() const noexcept = 0;
 };
@@ -68,7 +69,8 @@ class ChannelResource : public FairMQMemoryResource
 {
  protected:
   const FairMQTransportFactory* factory{ nullptr };
-  // TODO: for now a map to keep track of allocations, something else would probably be faster, but for now this does not need to be fast.
+  // TODO: for now a map to keep track of allocations, something else would probably be faster, but for now this does
+  // not need to be fast.
   boost::container::flat_map<void*, FairMQMessagePtr> messageMap;
 
  public:
@@ -79,13 +81,21 @@ class ChannelResource : public FairMQMemoryResource
       throw std::runtime_error("Tried to construct from a nullptr FairMQTransportFactory");
     }
   };
-  FairMQMessagePtr getMessage(void* p) override { return std::move(messageMap[p]); };
+  FairMQMessagePtr getMessage(void* p) override
+  {
+    auto mes = std::move(messageMap[p]);
+    messageMap.erase(p);
+    return mes;
+  }
+  void* setMessage(FairMQMessagePtr message) override
+  {
+    void* addr = message->GetData();
+    messageMap[addr] = std::move(message);
+    return addr;
+  }
   const FairMQTransportFactory* getTransportFactory() const noexcept override { return factory; }
 
-  size_t getNumberOfMessages() const noexcept override
-  {
-    return messageMap.size();
-  }
+  size_t getNumberOfMessages() const noexcept override { return messageMap.size(); }
 
  protected:
   void* do_allocate(std::size_t bytes, std::size_t alignment) override
@@ -99,11 +109,7 @@ class ChannelResource : public FairMQMemoryResource
 
   void do_deallocate(void* p, std::size_t bytes, std::size_t alignment) override
   {
-    if (1 > messageMap.erase(p)) {
-      // so destructors should not throw, but deallocate maybe should?
-      throw std::runtime_error("bad dealloc: not my resource");
-    }
-    return;
+    messageMap.erase(p);
   };
 
   bool do_is_equal(const boost::container::pmr::memory_resource& other) const noexcept override
@@ -111,30 +117,6 @@ class ChannelResource : public FairMQMemoryResource
     return this == &other;
   };
 };
-
-//__________________________________________________________________________________________________
-// This in general (as in STL) is a bad idea, but here it is safe to inherit from an allocator since we
-// have no additional data and only override some methods so we don't get into slicing and other problems.
-template <typename T>
-class SpectatorAllocator : public boost::container::pmr::polymorphic_allocator<T>
-{
- public:
-  using boost::container::pmr::polymorphic_allocator<T>::polymorphic_allocator;
-
-  // skip default construction of empty elements
-  // this is important for two reasons: one: it allows us to adopt an existing buffer (e.g. incoming message) and
-  // quickly construct large vectors while skipping the element initialization.
-  template <typename... U>
-  void construct(U*...){};
-
-  // dont try to call destructors, makes no sense since resource is managed externally AND allowed
-  // types cannot have side effects
-  template <typename... U>
-  void destroy(U*...){};
-};
-
-using ByteSpectatorAllocator = SpectatorAllocator<byte>;
-using BytePmrAllocator = boost::container::pmr::polymorphic_allocator<byte>;
 
 //__________________________________________________________________________________________________
 /// This memory resource only watches, does not allocate/deallocate anything.
@@ -149,6 +131,7 @@ class SpectatorMessageResource : public FairMQMemoryResource
   FairMQMessagePtr getMessage(void* p) override { return nullptr; }
   const FairMQTransportFactory* getTransportFactory() const noexcept override { return nullptr; }
   size_t getNumberOfMessages() const noexcept override { return 0; }
+  void* setMessage(FairMQMessagePtr) override { return nullptr; }
 
  protected:
   const FairMQMessage* message;
@@ -183,25 +166,173 @@ class SpectatorMessageResource : public FairMQMemoryResource
 };
 
 //__________________________________________________________________________________________________
+/// This memory resource only watches, does not allocate/deallocate anything.
+/// Ownership of hte message is taken. Meant to be used for transparent data adoption in containers.
+/// In combination with the SpectatorAllocator this is an alternative to using span, as raw memory
+/// (e.g. an existing buffer message) will be accessible with appropriate container.
+class MessageResource : public FairMQMemoryResource
+{
+
+ public:
+  MessageResource() noexcept = delete;
+  MessageResource(const MessageResource&) noexcept = default;
+  MessageResource(MessageResource&&) noexcept = default;
+  MessageResource& operator=(const MessageResource&) = default;
+  MessageResource& operator=(MessageResource&&) = default;
+  MessageResource(FairMQMessagePtr message, FairMQMemoryResource* upstream)
+    : mUpstream{ upstream },
+      mMessageSize{ message->GetSize() },
+      mMessageData{ mUpstream ? mUpstream->setMessage(std::move(message))
+                              : throw std::runtime_error("MessageResource::MessageResource upstream is nullptr") }
+  {
+  }
+  FairMQMessagePtr getMessage(void* p) override { return mUpstream->getMessage(p); }
+  void* setMessage(FairMQMessagePtr message) override { return mUpstream->setMessage(std::move(message)); }
+  const FairMQTransportFactory* getTransportFactory() const noexcept override { return nullptr; }
+  size_t getNumberOfMessages() const noexcept override { return mMessageData ? 1 : 0; }
+
+ protected:
+  FairMQMemoryResource* mUpstream{ nullptr };
+  size_t mMessageSize{ 0 };
+  void* mMessageData{ nullptr };
+
+  virtual void* do_allocate(std::size_t bytes, std::size_t alignment) override
+  {
+    if (bytes > mMessageSize) {
+      throw std::bad_alloc();
+    }
+    return mMessageData;
+  }
+  virtual void do_deallocate(void* p, std::size_t bytes, std::size_t alignment) override
+  {
+    getMessage(mMessageData); //let the message die.
+    return;
+  }
+  virtual bool do_is_equal(const memory_resource& other) const noexcept override
+  {
+    // since this uniquely owns the message it can never be equal to anybody else
+    return false;
+  }
+};
+
+//__________________________________________________________________________________________________
+// This in general (as in STL) is a bad idea, but here it is safe to inherit from an allocator since we
+// have no additional data and only override some methods so we don't get into slicing and other problems.
+template <typename T>
+class SpectatorAllocator : public boost::container::pmr::polymorphic_allocator<T>
+{
+ public:
+  using boost::container::pmr::polymorphic_allocator<T>::polymorphic_allocator;
+
+  // skip default construction of empty elements
+  // this is important for two reasons: one: it allows us to adopt an existing buffer (e.g. incoming message) and
+  // quickly construct large vectors while skipping the element initialization.
+  template <class U>
+  void construct(U*)
+  {
+  }
+
+  // dont try to call destructors, makes no sense since resource is managed externally AND allowed
+  // types cannot have side effects
+  template <typename U>
+  void destroy(U*)
+  {
+  }
+
+  T* allocate(size_t size) { return reinterpret_cast<T*>(this->resource()->allocate(size * sizeof(T), 0)); }
+  void deallocate(T* ptr, size_t size)
+  {
+    this->resource()->deallocate(const_cast<typename std::remove_cv<T>::type*>(ptr), size);
+  }
+};
+
+//__________________________________________________________________________________________________
+/// This allocator has a pmr-like interface, but keeps the unique MessageResource as internal state,
+/// allowing full resource (associated message) management internally without any global state.
+template <typename T>
+class OwningMessageSpectatorAllocator
+{
+ public:
+  using value_type = T;
+
+  MessageResource mResource;
+
+  OwningMessageSpectatorAllocator() noexcept = default;
+  OwningMessageSpectatorAllocator(const OwningMessageSpectatorAllocator&) noexcept = default;
+  OwningMessageSpectatorAllocator(OwningMessageSpectatorAllocator&&) noexcept = default;
+  OwningMessageSpectatorAllocator(MessageResource&& resource) noexcept : mResource{ resource } {}
+
+  template <class U>
+  OwningMessageSpectatorAllocator(const OwningMessageSpectatorAllocator<U>& other) noexcept : mResource(other.mResource)
+  {
+  }
+
+  OwningMessageSpectatorAllocator& operator=(const OwningMessageSpectatorAllocator& other)
+  {
+    mResource = other.mResource;
+    return *this;
+  }
+
+  OwningMessageSpectatorAllocator select_on_container_copy_construction() const
+  {
+    return OwningMessageSpectatorAllocator();
+  }
+
+  boost::container::pmr::memory_resource* resource() { return &mResource; }
+
+  // skip default construction of empty elements
+  // this is important for two reasons: one: it allows us to adopt an existing buffer (e.g. incoming message) and
+  // quickly construct large vectors while skipping the element initialization.
+  template <class U>
+  void construct(U*)
+  {
+  }
+
+  // dont try to call destructors, makes no sense since resource is managed externally AND allowed
+  // types cannot have side effects
+  template <typename U>
+  void destroy(U*)
+  {
+  }
+
+  T* allocate(size_t size) { return reinterpret_cast<T*>(mResource.allocate(size * sizeof(T), 0)); }
+  void deallocate(T* ptr, size_t size)
+  {
+    mResource.deallocate(const_cast<typename std::remove_cv<T>::type*>(ptr), size);
+  }
+};
+
+//__________________________________________________________________________________________________
+//__________________________________________________________________________________________________
+//__________________________________________________________________________________________________
+//__________________________________________________________________________________________________
+
+using ByteSpectatorAllocator = SpectatorAllocator<byte>;
+using BytePmrAllocator = boost::container::pmr::polymorphic_allocator<byte>;
+
+//__________________________________________________________________________________________________
 // return the message associated with the container or nullptr if it does not make sense (e.g. when we are just
 // watching an existing message or when the container is not using FairMQMemoryResource as backend).
 template <typename ContainerT>
-typename std::enable_if<std::is_base_of<boost::container::pmr::polymorphic_allocator<typename ContainerT::value_type>,
-                                        typename ContainerT::allocator_type>::value == true,
-                        FairMQMessagePtr>::type
-  getMessage(ContainerT&& container_, o2::memoryResources::FairMQMemoryResource* targetResource = nullptr)
+// typename std::enable_if<std::is_base_of<boost::container::pmr::polymorphic_allocator<typename
+// ContainerT::value_type>,
+//                                        typename ContainerT::allocator_type>::value == true,
+//                        FairMQMessagePtr>::type
+FairMQMessagePtr getMessage(ContainerT&& container_, FairMQMemoryResource* targetResource = nullptr)
 {
   auto container = std::move(container_);
   auto alloc = container.get_allocator();
 
-  auto resource = dynamic_cast<o2::memoryResources::FairMQMemoryResource*>(alloc.resource());
+  auto resource = dynamic_cast<FairMQMemoryResource*>(alloc.resource());
   if (!resource && !targetResource) {
     throw std::runtime_error("Neither the container or target resource specified");
   }
   size_t containerSizeBytes = container.size() * sizeof(typename ContainerT::value_type);
   if ((!targetResource && resource) || (resource && targetResource && resource->is_equal(*targetResource))) {
-    auto message = resource->getMessage(static_cast<void*>(container.data()));
-    message->SetUsedSize(containerSizeBytes);
+    auto message = resource->getMessage(static_cast<void*>(
+      const_cast<typename std::remove_const<typename ContainerT::value_type>::type*>(container.data())));
+    if (message)
+      message->SetUsedSize(containerSizeBytes);
     return std::move(message);
   } else {
     auto message = targetResource->getTransportFactory()->CreateMessage(containerSizeBytes);
@@ -211,13 +342,31 @@ typename std::enable_if<std::is_base_of<boost::container::pmr::polymorphic_alloc
 };
 
 //__________________________________________________________________________________________________
+/// Return a vector of const ElemT, resource must be kept alive throughout the lifetime of the container and
+/// associated message.
+template <typename ElemT>
+auto adoptVector(size_t nelem, SpectatorMessageResource* resource)
+{
+  return std::vector<const ElemT, SpectatorAllocator<const ElemT>>(nelem, SpectatorAllocator<ElemT>(resource));
+};
+
+//__________________________________________________________________________________________________
+/// Return a vector of const ElemT, takes ownership of the message, needs an upstream global ChannelResource to register
+/// the message.
+template <typename ElemT>
+auto adoptVector(size_t nelem, ChannelResource* upstream, FairMQMessagePtr message)
+{
+  return std::vector<const ElemT, OwningMessageSpectatorAllocator<const ElemT>>(
+    nelem, OwningMessageSpectatorAllocator<const ElemT>(MessageResource{ std::move(message), upstream }));
+};
+
+//__________________________________________________________________________________________________
 // This returns a unique_ptr of const vector, does not allow modifications at the cost of pointer
 // semantics for access.
 // use auto or decltype to catch the return value (or use span)
 template <typename ElemT>
 auto adoptVector(size_t nelem, FairMQMessage* message)
 {
-  using namespace o2::memoryResources;
   using DataType = std::vector<ElemT, ByteSpectatorAllocator>;
 
   struct doubleDeleter {
@@ -247,7 +396,10 @@ class TransportAllocatorMap
     static TransportAllocatorMap S;
     return S;
   }
-  ChannelResource* operator[](const FairMQTransportFactory* factory) { return std::addressof(map.emplace(factory, factory).first->second); }
+  ChannelResource* operator[](const FairMQTransportFactory* factory)
+  {
+    return std::addressof(map.emplace(factory, factory).first->second);
+  }
 
  private:
   std::unordered_map<const FairMQTransportFactory*, ChannelResource> map{};
@@ -256,7 +408,7 @@ class TransportAllocatorMap
 }
 
 //__________________________________________________________________________________________________
-///Get the allocator associated to a transport factory
+/// Get the allocator associated to a transport factory
 inline static ChannelResource* getTransportAllocator(const FairMQTransportFactory* factory)
 {
   return internal::TransportAllocatorMap::Instance()[factory];

--- a/DataFormats/MemoryResources/include/MemoryResources/MemoryResources.h
+++ b/DataFormats/MemoryResources/include/MemoryResources/MemoryResources.h
@@ -42,7 +42,7 @@
 
 namespace o2
 {
-namespace memoryResources
+namespace memory_resource
 {
 
 using byte = unsigned char;
@@ -414,7 +414,7 @@ inline static ChannelResource* getTransportAllocator(const FairMQTransportFactor
   return internal::TransportAllocatorMap::Instance()[factory];
 }
 
-}; //namespace memoryResources
+}; //namespace memory_resource
 }; //namespace o2
 
 #endif

--- a/DataFormats/MemoryResources/test/testMemoryResources.cxx
+++ b/DataFormats/MemoryResources/test/testMemoryResources.cxx
@@ -19,7 +19,7 @@
 
 namespace o2
 {
-namespace memoryResources
+namespace memory_resource
 {
 auto factoryZMQ = FairMQTransportFactory::CreateTransportFactory("zeromq");
 auto factorySHM = FairMQTransportFactory::CreateTransportFactory("shmem");

--- a/Framework/Core/src/DataAllocator.cxx
+++ b/Framework/Core/src/DataAllocator.cxx
@@ -115,8 +115,8 @@ FairMQMessagePtr DataAllocator::headerMessageFromOutput(Output const& spec,     
 
   DataProcessingHeader dph{mContext->timeslice(), 1};
 
-  auto channelAlloc = o2::memoryResources::getTransportAllocator(mProxy.getTransport(channel, 0));
-  return o2::memoryResources::getMessage(o2::header::Stack{ channelAlloc, dh, dph, spec.metaHeader });
+  auto channelAlloc = o2::memory_resource::getTransportAllocator(mProxy.getTransport(channel, 0));
+  return o2::memory_resource::getMessage(o2::header::Stack{ channelAlloc, dh, dph, spec.metaHeader });
 }
 
 void DataAllocator::addPartToContext(FairMQMessagePtr&& payloadMessage, const Output& spec,

--- a/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
+++ b/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
@@ -40,8 +40,8 @@ void broadcastMessage(FairMQDevice &device, o2::header::Stack &&headerStack, Fai
 
     // FIXME: this assumes there is only one output from here... This should
     //        really do the matchmaking between inputs and output channels.
-    auto channelAlloc = o2::memoryResources::getTransportAllocator(channelInfo.second[index].Transport());
-    FairMQMessagePtr headerMessage = o2::memoryResources::getMessage(std::move(headerStack), channelAlloc);
+    auto channelAlloc = o2::memory_resource::getTransportAllocator(channelInfo.second[index].Transport());
+    FairMQMessagePtr headerMessage = o2::memory_resource::getMessage(std::move(headerStack), channelAlloc);
 
     FairMQParts out;
     out.AddPart(std::move(headerMessage));

--- a/Utilities/O2Device/README.md
+++ b/Utilities/O2Device/README.md
@@ -23,7 +23,7 @@ addDataBlock(O2Message& message, o2::header::Stack&& headerStack, T data);
 - data:
   - ```FairMQMessagePtr``` (```std::unique_ptr<FairMQMessage>```)
   - STL-like container that uses a ```pmr::polymorphic_allocator``` as allocator. Note: this is only efficient if
-    the memory resource used to construct the allocator is ```o2::memoryResources::ChannelResource```, otherwise an implicit copy occurs.
+    the memory resource used to construct the allocator is ```o2::memory_resource::ChannelResource```, otherwise an implicit copy occurs.
 
 ### forEach()
 Executes a function on each data block within the message.
@@ -39,7 +39,7 @@ the function is a callable object (lambda, functor, std::function) and needs to 
 #### basic example, inside a FairMQDevice:
 ```C++
 // make sure we have the allocator associated with the transport appropriate for the selected channel:
-auto outputChannelAllocator = o2::memoryResources::getTransportAllocator(GetChannel("dataOut").Transport());
+auto outputChannelAllocator = o2::memory_resource::getTransportAllocator(GetChannel("dataOut").Transport());
 
 //the data
 using namespace boost::container::pmr;

--- a/Utilities/O2Device/include/O2Device/Utilities.h
+++ b/Utilities/O2Device/include/O2Device/Utilities.h
@@ -42,7 +42,7 @@ using O2Message = FairMQParts;
 //__________________________________________________________________________________________________
 // addDataBlock for generic (compatible) containers, that is contiguous containers using the pmr allocator
 template <typename ContainerT, typename std::enable_if<!std::is_same<ContainerT, FairMQMessagePtr>::value, int>::type = 0>
-bool addDataBlock(O2Message& parts, o2::header::Stack&& inputStack, ContainerT&& inputData, o2::memoryResources::FairMQMemoryResource* targetResource = nullptr)
+bool addDataBlock(O2Message& parts, o2::header::Stack&& inputStack, ContainerT&& inputData, o2::memory_resource::FairMQMemoryResource* targetResource = nullptr)
 {
   using std::move;
   using std::forward;
@@ -60,7 +60,7 @@ bool addDataBlock(O2Message& parts, o2::header::Stack&& inputStack, ContainerT&&
 // addDataBlock for data already wrapped in FairMQMessagePtr
 // note: since we cannot partially specialize function templates, use SFINAE here instead
 template <typename ContainerT, typename std::enable_if<std::is_same<ContainerT, FairMQMessagePtr>::value, int>::type = 0>
-bool addDataBlock(O2Message& parts, o2::header::Stack&& inputStack, ContainerT&& dataMessage, o2::memoryResources::FairMQMemoryResource* targetResource = nullptr)
+bool addDataBlock(O2Message& parts, o2::header::Stack&& inputStack, ContainerT&& dataMessage, o2::memory_resource::FairMQMemoryResource* targetResource = nullptr)
 {
   using std::move;
 

--- a/Utilities/O2Device/test/test_O2Device.cxx
+++ b/Utilities/O2Device/test/test_O2Device.cxx
@@ -20,7 +20,7 @@
 
 using namespace o2::Base;
 using namespace o2::header;
-using namespace o2::memoryResources;
+using namespace o2::memory_resource;
 
 auto factoryZMQ = FairMQTransportFactory::CreateTransportFactory("zeromq");
 auto factorySHM = FairMQTransportFactory::CreateTransportFactory("shmem");
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE(getMessage_Stack)
     Stack s1{ DataHeader{ gDataDescriptionInvalid, gDataOriginInvalid, DataHeader::SubSpecificationType{ 0 } },
               NameHeader<9>{ "somename" } };
 
-    auto message = o2::memoryResources::getMessage(std::move(s1), allocZMQ);
+    auto message = o2::memory_resource::getMessage(std::move(s1), allocZMQ);
 
     BOOST_REQUIRE(s1.data() == nullptr);
     BOOST_REQUIRE(message != nullptr);
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(getMessage_Stack)
               NameHeader<9>{ "somename" } };
     BOOST_TEST(allocZMQ->getNumberOfMessages() == 1);
 
-    auto message = o2::memoryResources::getMessage(std::move(s1), allocSHM);
+    auto message = o2::memory_resource::getMessage(std::move(s1), allocSHM);
 
     BOOST_TEST(allocZMQ->getNumberOfMessages() == 0);
     BOOST_TEST(allocSHM->getNumberOfMessages() == 0);

--- a/Utilities/O2MessageMonitor/src/O2MessageMonitor.cxx
+++ b/Utilities/O2MessageMonitor/src/O2MessageMonitor.cxx
@@ -58,7 +58,7 @@ void O2MessageMonitor::Run()
     type = subChannels[0].GetType();
   }
 
-  auto dataResource = o2::memoryResources::getTransportAllocator(subChannels[0].Transport());
+  auto dataResource = o2::memory_resource::getTransportAllocator(subChannels[0].Transport());
 
   while (CheckCurrentState(RUNNING) && (--mIterations) != 0) {
     this_thread::sleep_for(chrono::milliseconds(mDelay));


### PR DESCRIPTION
Allow adoption of message data by STL containers.
- adoptVector<Elem>(size_t nelem, ChannelResource* upstream, FairMQMessagePtr message): return a std::vector<const Elem> (const data) while taking ownership of the message to avoid global state - container is (almost) fully self-contained - the global state we have are the transport factories and associated allocators, but that is largely invisible. Ownership of the message can be reclaimed using the standard getMessage() mechanism if data is to be forwarded. 
- some minor modifications to the ChannelResource logic to allow for the above.
- simple tests.

It is work in progress, so interfaces can still be tweaked, names changed, more obscure things moved to ::internal namespace etc.