### PR TITLE
o2sim_parallel: correct stack filtering, add timing information

### DIFF
--- a/Steer/include/Steer/O2MCApplication.h
+++ b/Steer/include/Steer/O2MCApplication.h
@@ -44,14 +44,20 @@ class O2MCApplication : public FairMCApplication
   /** Define actions at the end of event */
   void FinishEvent() override
   {
+    // update the stack
+    fStack->FillTrackArray();
+    fStack->UpdateTrackIndex(fActiveDetectors);
+
     // This special finish event version does not fill the output tree of FairRootManager
     // but forwards the data to the HitMerger
     SendData();
 
     // call end of event on active detectors
     for (auto det : listActiveDetectors) {
+      det->FinishEvent();
       det->EndOfEvent();
     }
+    fStack->Reset();
   }
 
   /** Define actions at the end of run */

--- a/run/o2sim.cxx
+++ b/run/o2sim.cxx
@@ -10,9 +10,13 @@
 
 #include "../macro/o2sim.C"
 #include <SimConfig/SimConfig.h>
+#include <TStopwatch.h>
+#include <FairLogger.h>
 
 int main(int argc, char* argv[])
 {
+  TStopwatch timer;
+  timer.Start();
   auto& conf = o2::conf::SimConfig::Instance();
   if (!conf.resetFromArguments(argc, argv)) {
     return 1;
@@ -20,6 +24,9 @@ int main(int argc, char* argv[])
 
   // call o2sim "macro"
   o2sim(false);
+
+  // print total time
+  LOG(INFO) << "Simulation process took " << timer.RealTime() << " s";
 
   // We do this instead of return 0
   // for the reason that we see lots of problems

--- a/run/o2sim_parallel.cxx
+++ b/run/o2sim_parallel.cxx
@@ -21,6 +21,8 @@
 #include <vector>
 #include <thread>
 #include <signal.h>
+#include "TStopwatch.h"
+#include "FairLogger.h"
 
 const char* serverlogname = "serverlog";
 const char* workerlogname = "workerlog";
@@ -30,6 +32,8 @@ const char* mergerlogname = "mergerlog";
 // for parallel simulation
 int main(int argc, char* argv[])
 {
+  TStopwatch timer;
+  timer.Start();
   std::string rootpath(getenv("O2_ROOT"));
   std::string installpath = rootpath + "/bin";
 
@@ -151,7 +155,9 @@ int main(int argc, char* argv[])
   // wait just blocks and waits until any child returns; make sure that we wait until merger is here
   while ((cpid = wait(&status)) != mergerpid) {
   }
-  std::cout << "Merger process " << mergerpid << " returned\n";
+  // This marks the actual end of the computation (since results are available)
+  LOG(INFO) << "Merger process " << mergerpid << " returned";
+  LOG(INFO) << "Simulation process took " << timer.RealTime() << " s";
 
   // make sure the rest shuts down
   for (auto p : childpids) {


### PR DESCRIPTION
This is providing one more step to be consistent with the serial and parallel
version of the simulation. Up until now, the parallel version did not call
important hooks on the stack object after each event.

Also adding some total timing information to both o2sim and o2sim_parallel
for better systematic comparison.