### PR TITLE
DPL: Fix bug in o2ParallelWorkflow

### DIFF
--- a/Framework/TestWorkflows/src/o2ParallelWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2ParallelWorkflow.cxx
@@ -104,23 +104,19 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
                                     },
                                     AlgorithmSpec{ [](InitContext& setup) {
                                       return [](ProcessingContext& ctx) {
-                                        ctx.outputs().make<int>(OutputRef("out"), 1);
+                                        ctx.outputs().make<int>(OutputRef("out", 0), 1);
                                       };
                                     } } },
                                   stages));
 
-  workflow.push_back(timePipeline(DataProcessorSpec{
+  workflow.push_back(DataProcessorSpec{
                                     "writer",
-                                    mergeInputs(InputSpec{ "x", "TST", "M" },
-                                                jobs,
-                                                [](InputSpec& input, size_t index) {
-                                                  input.subSpec = index;
-                                                }),
+                                    {InputSpec{ "x", "TST", "M" }},
                                     {},
                                     AlgorithmSpec{ [](InitContext& setup) {
                                       return [](ProcessingContext& ctx) {
                                       };
-                                    } } },
-                                  1));
+                                    } } }
+                                  );
   return workflow;
 }


### PR DESCRIPTION
The final writer does not need to merge the previous layer
because they are time pipelined.