### PR TITLE
DPL: Improve GUI usability

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -16,6 +16,7 @@ O2_SETUP(NAME ${MODULE_NAME})
 if (GLFW_FOUND)
   set(GUI_SOURCES src/FrameworkGUIDebugger.cxx
                   src/FrameworkGUIDevicesGraph.cxx
+                  src/FrameworkGUIDeviceInspector.cxx
                   src/FrameworkGUIDataRelayerUsage.cxx
                   src/PaletteHelpers.cxx)
 else()

--- a/Framework/Core/include/Framework/DeviceControl.h
+++ b/Framework/Core/include/Framework/DeviceControl.h
@@ -30,6 +30,8 @@ struct DeviceControl {
   bool stopped = false;
   /// wether we should be capturing device output.
   bool quiet = false;
+  /// wether the log window should be opened.
+  bool logVisible = false;
   /// Minimum log level for messages to appear
   LogParsingHelpers::LogLevel logLevel = LogParsingHelpers::LogLevel::Info;
   /// Lines in the log should match this to be displayed

--- a/Framework/Core/include/Framework/FrameworkGUIState.h
+++ b/Framework/Core/include/Framework/FrameworkGUIState.h
@@ -7,13 +7,11 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#ifndef FRAMEWORK_FRAMEWORKGUIDEVICEGRAPH_H
-#define FRAMEWORK_FRAMEWORKGUIDEVICEGRAPH_H
-#include "Framework/DeviceSpec.h"
-#include "Framework/DeviceInfo.h"
-#include "Framework/DeviceMetricsInfo.h"
+
+/// State for the main GUI window
 
 #include <vector>
+#include <string>
 
 namespace o2
 {
@@ -22,16 +20,24 @@ namespace framework
 namespace gui
 {
 
-class WorkspaceGUIState;
+/// State for the Device specific inspector
+struct DeviceGUIState {
+  std::string label;
+};
 
-void showTopologyNodeGraph(WorkspaceGUIState &state,
-                           const std::vector<DeviceInfo> &infos,
-                           const std::vector<DeviceSpec> &specs,
-                           std::vector<DeviceControl> &controls,
-                           const std::vector<DeviceMetricsInfo> &metricsInfos);
+/// State for the workspace
+struct WorkspaceGUIState {
+  int selectedMetric;
+  std::vector<std::string> availableMetrics;
+  std::vector<DeviceGUIState> devices;
+  float leftPaneSize;
+  float rightPaneSize;
+  float bottomPaneSize;
+  bool leftPaneVisible;
+  bool rightPaneVisible;
+  bool bottomPaneVisible;
+};
 
 } // namespace gui
 } // namespace framework
 } // namespace o2
-
-#endif // FRAMEWORK_FRAMEWORKGUIDEVICEGRAPH_H

--- a/Framework/Core/src/FrameworkGUIDebugger.cxx
+++ b/Framework/Core/src/FrameworkGUIDebugger.cxx
@@ -17,9 +17,11 @@
 #include "DebugGUI/imgui.h"
 #include "DriverControl.cxx"
 #include "DriverInfo.cxx"
+#include "FrameworkGUIDeviceInspector.h"
 #include "Framework/FrameworkGUIDevicesGraph.h"
 #include "Framework/FrameworkGUIDataRelayerUsage.h"
 #include "Framework/PaletteHelpers.h"
+#include "Framework/FrameworkGUIState.h"
 
 static inline ImVec2 operator+(const ImVec2& lhs, const ImVec2& rhs) { return ImVec2(lhs.x + rhs.x, lhs.y + rhs.y); }
 static inline ImVec2 operator-(const ImVec2& lhs, const ImVec2& rhs) { return ImVec2(lhs.x - rhs.x, lhs.y - rhs.y); }
@@ -29,63 +31,7 @@ namespace o2
 namespace framework
 {
 
-struct DeviceGUIState {
-  std::string label;
-};
-
-struct WorkspaceGUIState {
-  int selectedMetric;
-  std::vector<std::string> availableMetrics;
-  std::vector<DeviceGUIState> devices;
-};
-
-static WorkspaceGUIState gState;
-
-void optionsTable(const DeviceSpec& spec, const DeviceControl& control)
-{
-  if (spec.options.empty()) {
-    return;
-  }
-  if (ImGui::CollapsingHeader("Options:")) {
-    ImGui::Columns(2);
-    auto labels = { "Name", "Value" };
-    for (auto& label : labels) {
-      ImGui::TextUnformatted(label);
-      ImGui::NextColumn();
-    }
-    for (auto& option : spec.options) {
-      ImGui::TextUnformatted(option.name.c_str());
-      ImGui::NextColumn();
-      auto currentValueIt = control.options.find(option.name);
-
-      // Did not find the option
-      if (currentValueIt == control.options.end()) {
-        switch (option.type) {
-          case VariantType::String:
-            ImGui::Text("\"%s\" (default)", option.defaultValue.get<const char*>());
-            break;
-          case VariantType::Int:
-            ImGui::Text("%d (default)", option.defaultValue.get<int>());
-            break;
-          case VariantType::Float:
-            ImGui::Text("%f (default)", option.defaultValue.get<float>());
-            break;
-          case VariantType::Double:
-            ImGui::Text("%f (default)", option.defaultValue.get<double>());
-            break;
-          case VariantType::Empty:
-            ImGui::TextUnformatted(""); // no default value
-          default:
-            ImGui::TextUnformatted("unknown");
-        }
-      } else {
-        ImGui::TextUnformatted(currentValueIt->second.c_str());
-      }
-      ImGui::NextColumn();
-    }
-  }
-  ImGui::Columns(1);
-}
+static gui::WorkspaceGUIState gState;
 
 ImVec4 colorForLogLevel(LogParsingHelpers::LogLevel logLevel)
 {
@@ -197,7 +143,7 @@ struct HistoData {
   const T* points;
 };
 
-void historyBar(DeviceGUIState& state, const DeviceSpec& spec, const DeviceMetricsInfo& metricsInfo)
+void historyBar(gui::DeviceGUIState& state, const DeviceSpec& spec, const DeviceMetricsInfo& metricsInfo)
 {
   bool open = ImGui::TreeNode(state.label.c_str());
   if (open) {
@@ -261,128 +207,115 @@ void historyBar(DeviceGUIState& state, const DeviceSpec& spec, const DeviceMetri
   }
 }
 
-void displayDeviceHistograms(const std::vector<DeviceInfo>& infos, const std::vector<DeviceSpec>& devices,
+void displayDeviceHistograms(gui::WorkspaceGUIState &state,
+                             const std::vector<DeviceInfo>& infos, const std::vector<DeviceSpec>& devices,
                              std::vector<DeviceControl>& controls, const std::vector<DeviceMetricsInfo>& metricsInfos)
 {
-  bool graphNodes = true;
-  showTopologyNodeGraph(&graphNodes, infos, devices, metricsInfos);
-  ImGui::SetNextWindowPos(ImVec2(0, ImGui::GetIO().DisplaySize.y - 300), 0);
-  ImGui::SetNextWindowSize(ImVec2(ImGui::GetIO().DisplaySize.x, 300), 0);
+  showTopologyNodeGraph(state, infos, devices, controls, metricsInfos);
+  if (state.bottomPaneVisible == true) {
+    ImGui::SetNextWindowPos(ImVec2(0, ImGui::GetIO().DisplaySize.y - state.bottomPaneSize), 0);
+    ImGui::SetNextWindowSize(ImVec2(ImGui::GetIO().DisplaySize.x, state.bottomPaneSize), 0);
 
-  // Calculate the unique set of metrics, as available in the metrics service
-  std::set<std::string> allMetricsNames;
-  for (const auto& metricsInfo : metricsInfos) {
-    for (const auto& labelsPairs : metricsInfo.metricLabelsIdx) {
-      allMetricsNames.insert(labelsPairs.first);
-    }
-  }
-  using NamesIndex = std::vector<std::string>;
-  gState.availableMetrics.clear();
-  std::copy(allMetricsNames.begin(), allMetricsNames.end(), std::back_inserter(gState.availableMetrics));
-
-  ImGui::Begin("Devices");
-  ImGui::Combo("Select metric", &gState.selectedMetric,
-               [](void* data, int idx, const char** outText) -> bool {
-                 NamesIndex* v = reinterpret_cast<NamesIndex*>(data);
-                 if (idx >= v->size()) {
-                   return false;
-                 }
-                 *outText = v->at(idx).c_str();
-                 return true;
-               },
-               &gState.availableMetrics, gState.availableMetrics.size());
-
-  // Calculate the full timestamp range for the selected metric
-  if (gState.selectedMetric >= 0) {
-    auto currentMetricName = gState.availableMetrics[gState.selectedMetric];
-    size_t minTime = -1;
-    size_t maxTime = 0;
-    for (auto& metricInfo : metricsInfos) {
-      size_t mi = DeviceMetricsHelper::metricIdxByName(currentMetricName, metricInfo);
-      if (mi == metricInfo.metricLabelsIdx.size()) {
-        continue;
+    // Calculate the unique set of metrics, as available in the metrics service
+    std::set<std::string> allMetricsNames;
+    for (const auto& metricsInfo : metricsInfos) {
+      for (const auto& labelsPairs : metricsInfo.metricLabelsIdx) {
+        allMetricsNames.insert(labelsPairs.first);
       }
-      auto& metric = metricInfo.metrics[mi];
-      size_t minRangePos = metric.pos % metricInfo.timestamps.size();
-      size_t maxRangePos = (size_t)(metric.pos) - 1 % metricInfo.timestamps.size();
-      auto& timestamps = metricInfo.timestamps[mi];
-      size_t curMinTime = timestamps[minRangePos];
-      size_t curMaxTime = timestamps[maxRangePos];
-      minTime = minTime < curMinTime ? minTime : curMinTime;
-      maxTime = maxTime > curMaxTime ? maxTime : curMaxTime;
     }
-    ImGui::Text("min timestamp: %zu, max timestamp: %zu", minTime, maxTime);
-  }
-  ImGui::BeginChild("ScrollingRegion", ImVec2(0, -ImGui::GetItemsLineHeightWithSpacing()), false,
-                    ImGuiWindowFlags_HorizontalScrollbar);
-  ImGui::Columns(2);
-  ImGui::SetColumnOffset(1, 300);
-  for (size_t i = 0; i < gState.devices.size(); ++i) {
-    DeviceGUIState& guiState = gState.devices[i];
-    const DeviceSpec& spec = devices[i];
-    const DeviceMetricsInfo& metricsInfo = metricsInfos[i];
+    using NamesIndex = std::vector<std::string>;
+    gState.availableMetrics.clear();
+    std::copy(allMetricsNames.begin(), allMetricsNames.end(), std::back_inserter(gState.availableMetrics));
 
-    historyBar(guiState, spec, metricsInfo);
-  }
-  ImGui::Columns(1);
-  ImGui::EndChild();
-  ImGui::End();
-}
+    ImGui::Begin("Devices", nullptr, ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize);
+    ImGui::Combo("Select metric", &gState.selectedMetric,
+                 [](void* data, int idx, const char** outText) -> bool {
+                   NamesIndex* v = reinterpret_cast<NamesIndex*>(data);
+                   if (idx >= v->size()) {
+                     return false;
+                   }
+                   *outText = v->at(idx).c_str();
+                   return true;
+                 },
+                 &gState.availableMetrics, gState.availableMetrics.size());
 
-struct ChannelsTableHelper {
-  template <typename C>
-  static void channelsTable(const char* title, const C& channels)
-  {
-    ImGui::TextUnformatted(title);
+    // Calculate the full timestamp range for the selected metric
+    if (gState.selectedMetric >= 0) {
+      auto currentMetricName = gState.availableMetrics[gState.selectedMetric];
+      size_t minTime = -1;
+      size_t maxTime = 0;
+      for (auto& metricInfo : metricsInfos) {
+        size_t mi = DeviceMetricsHelper::metricIdxByName(currentMetricName, metricInfo);
+        if (mi == metricInfo.metricLabelsIdx.size()) {
+          continue;
+        }
+        auto& metric = metricInfo.metrics[mi];
+        size_t minRangePos = metric.pos % metricInfo.timestamps.size();
+        size_t maxRangePos = (size_t)(metric.pos) - 1 % metricInfo.timestamps.size();
+        auto& timestamps = metricInfo.timestamps[mi];
+        size_t curMinTime = timestamps[minRangePos];
+        size_t curMaxTime = timestamps[maxRangePos];
+        minTime = minTime < curMinTime ? minTime : curMinTime;
+       maxTime = maxTime > curMaxTime ? maxTime : curMaxTime;
+      }
+      ImGui::Text("min timestamp: %zu, max timestamp: %zu", minTime, maxTime);
+    }
+    ImGui::BeginChild("ScrollingRegion", ImVec2(0, -ImGui::GetItemsLineHeightWithSpacing()), false,
+                      ImGuiWindowFlags_HorizontalScrollbar);
     ImGui::Columns(2);
-    ImGui::TextUnformatted("Name");
-    ImGui::NextColumn();
-    ImGui::TextUnformatted("Port");
-    ImGui::NextColumn();
-    for (auto channel : channels) {
-      ImGui::TextUnformatted(channel.name.c_str());
-      ImGui::NextColumn();
-      ImGui::Text("%d", channel.port);
-      ImGui::NextColumn();
+    ImGui::SetColumnOffset(1, 300);
+    for (size_t i = 0; i < gState.devices.size(); ++i) {
+      gui::DeviceGUIState& guiState = gState.devices[i];
+      const DeviceSpec& spec = devices[i];
+      const DeviceMetricsInfo& metricsInfo = metricsInfos[i];
+
+      historyBar(guiState, spec, metricsInfo);
     }
     ImGui::Columns(1);
+    ImGui::EndChild();
+    ImGui::End();
   }
-};
+}
 
 void pushWindowColorDueToStatus(const DeviceInfo& info)
 {
   using LogLevel = LogParsingHelpers::LogLevel;
+  ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 4.);
   if (info.active == false) {
      ImGui::PushStyleColor(ImGuiCol_TitleBg, PaletteHelpers::DARK_RED);
      ImGui::PushStyleColor(ImGuiCol_TitleBgActive, PaletteHelpers::RED);
      ImGui::PushStyleColor(ImGuiCol_TitleBgCollapsed, PaletteHelpers::RED);
      return;
-   }
-   switch (info.maxLogLevel) {
-     case LogLevel::Error:
-       ImGui::PushStyleColor(ImGuiCol_TitleBg, PaletteHelpers::SHADED_RED);
-       ImGui::PushStyleColor(ImGuiCol_TitleBgActive, PaletteHelpers::RED);
-       ImGui::PushStyleColor(ImGuiCol_TitleBgCollapsed, PaletteHelpers::SHADED_RED);
-       break;
-     case LogLevel::Warning:
-       ImGui::PushStyleColor(ImGuiCol_TitleBg, PaletteHelpers::SHADED_YELLOW);
-       ImGui::PushStyleColor(ImGuiCol_TitleBgActive, PaletteHelpers::YELLOW);
-       ImGui::PushStyleColor(ImGuiCol_TitleBgCollapsed, PaletteHelpers::SHADED_YELLOW);
-       break;
-     case LogLevel::Info:
-       ImGui::PushStyleColor(ImGuiCol_TitleBg, PaletteHelpers::SHADED_GREEN);
-       ImGui::PushStyleColor(ImGuiCol_TitleBgActive, PaletteHelpers::GREEN);
-       ImGui::PushStyleColor(ImGuiCol_TitleBgCollapsed, PaletteHelpers::SHADED_GREEN);
-       break;
-     default:
-       ImGui::PushStyleColor(ImGuiCol_TitleBg, PaletteHelpers::SHADED_BLUE);
-       ImGui::PushStyleColor(ImGuiCol_TitleBgActive, PaletteHelpers::BLUE);
-       ImGui::PushStyleColor(ImGuiCol_TitleBgCollapsed, PaletteHelpers::SHADED_BLUE);
-       break;
-   }
+  }
+  switch (info.maxLogLevel) {
+    case LogLevel::Error:
+      ImGui::PushStyleColor(ImGuiCol_TitleBg, PaletteHelpers::SHADED_RED);
+      ImGui::PushStyleColor(ImGuiCol_TitleBgActive, PaletteHelpers::RED);
+      ImGui::PushStyleColor(ImGuiCol_TitleBgCollapsed, PaletteHelpers::SHADED_RED);
+      break;
+    case LogLevel::Warning:
+      ImGui::PushStyleColor(ImGuiCol_TitleBg, PaletteHelpers::SHADED_YELLOW);
+      ImGui::PushStyleColor(ImGuiCol_TitleBgActive, PaletteHelpers::YELLOW);
+      ImGui::PushStyleColor(ImGuiCol_TitleBgCollapsed, PaletteHelpers::SHADED_YELLOW);
+      break;
+    case LogLevel::Info:
+      ImGui::PushStyleColor(ImGuiCol_TitleBg, PaletteHelpers::SHADED_GREEN);
+      ImGui::PushStyleColor(ImGuiCol_TitleBgActive, PaletteHelpers::GREEN);
+      ImGui::PushStyleColor(ImGuiCol_TitleBgCollapsed, PaletteHelpers::SHADED_GREEN);
+      break;
+    default:
+      ImGui::PushStyleColor(ImGuiCol_TitleBg, PaletteHelpers::SHADED_BLUE);
+      ImGui::PushStyleColor(ImGuiCol_TitleBgActive, PaletteHelpers::BLUE);
+      ImGui::PushStyleColor(ImGuiCol_TitleBgCollapsed, PaletteHelpers::SHADED_BLUE);
+      break;
+  }
 }
 
-void popWindowColorDueToStatus() { ImGui::PopStyleColor(3); }
+void popWindowColorDueToStatus()
+{
+  ImGui::PopStyleColor(3);
+  ImGui::PopStyleVar(1);
+}
 
 struct DriverHelper {
   static char const* stateToString(enum DriverState state)
@@ -476,49 +409,53 @@ std::function<void(void)> getGUIDebugger(const std::vector<DeviceInfo>& infos, c
   // FIXME: this should probaly have a better mapping between our window state and
   gState.devices.resize(infos.size());
   for (size_t i = 0; i < gState.devices.size(); ++i) {
-    DeviceGUIState& state = gState.devices[i];
+    gui::DeviceGUIState& state = gState.devices[i];
     state.label = devices[i].id + "(" + std::to_string(infos[i].pid) + ")";
   }
+  gState.bottomPaneSize = 300;
+  gState.leftPaneSize = 100;
+  gState.rightPaneSize = 300;
+
+  // Show all the panes by default.
+  gState.bottomPaneVisible = true;
+  gState.leftPaneVisible = true;
+  gState.rightPaneVisible = true;
 
   return [&infos, &devices, &controls, &metricsInfos, &driverInfo, &driverControl]() {
     ImGuiStyle& style = ImGui::GetStyle();
-    style.Colors[ImGuiCol_WindowBg] = ImVec4(0.09f, 0.09f, 0.09f, 1.00f);
+    style.FrameRounding = 0.;
+    style.WindowRounding = 0.;
+    style.Colors[ImGuiCol_WindowBg] = ImVec4(0x1b / 255.f, 0x1b / 255.f, 0x1b / 255.f, 1.00f);
+    style.Colors[ImGuiCol_ScrollbarBg] = ImVec4(0x1b / 255.f, 0x1b / 255.f, 0x1b / 255.f, 1.00f);
 
-    displayDeviceHistograms(infos, devices, controls, metricsInfos);
+    displayDeviceHistograms(gState, infos, devices, controls, metricsInfos);
     displayDriverInfo(driverInfo, driverControl);
 
     int windowPosStepping = (ImGui::GetIO().DisplaySize.y - 500) / gState.devices.size();
 
     for (size_t i = 0; i < gState.devices.size(); ++i) {
-      DeviceGUIState& state = gState.devices[i];
+      gui::DeviceGUIState& state = gState.devices[i];
       assert(i < infos.size());
       assert(i < devices.size());
       const DeviceInfo& info = infos[i];
       const DeviceSpec& spec = devices[i];
       const DeviceMetricsInfo& metrics = metricsInfos[i];
 
+      assert(controls.size() == devices.size());
       DeviceControl& control = controls[i];
-      ImGui::SetNextWindowPos(ImVec2(ImGui::GetIO().DisplaySize.x / 3 * 2, i * windowPosStepping), ImGuiSetCond_Once);
-      ImGui::SetNextWindowSize(ImVec2(ImGui::GetIO().DisplaySize.x / 3, ImGui::GetIO().DisplaySize.y - 300),
-                               ImGuiSetCond_Once);
 
       pushWindowColorDueToStatus(info);
+      if (control.logVisible) {
+        ImGui::Begin(state.label.c_str(), &control.logVisible);
+        ImGui::SetNextWindowPos(ImVec2(ImGui::GetIO().DisplaySize.x / 3 * 2, i * windowPosStepping), ImGuiSetCond_Once);
+        ImGui::SetNextWindowSize(ImVec2(ImGui::GetIO().DisplaySize.x / 3, ImGui::GetIO().DisplaySize.y - 300),
+                                 ImGuiSetCond_Once);
 
-      ImGui::Begin(state.label.c_str());
-      if (ImGui::CollapsingHeader("Channels")) {
-        ImGui::Text("# channels: %lu", spec.inputChannels.size() + spec.outputChannels.size());
-        ChannelsTableHelper::channelsTable("Inputs:", spec.inputChannels);
-        ChannelsTableHelper::channelsTable("Outputs:", spec.outputChannels);
-      }
-      optionsTable(spec, control);
-      if (ImGui::CollapsingHeader("Data relayer")) {
-        ImGui::Text("Completion policy: %s", spec.completionPolicy.name.c_str());
-      }
-      if (ImGui::CollapsingHeader("Logs", ImGuiTreeNodeFlags_DefaultOpen)) {
-        ImGui::Checkbox("Stop logging", &control.quiet);
         ImGui::InputText("Log filter", control.logFilter, sizeof(control.logFilter));
         ImGui::InputText("Log start trigger", control.logStartTrigger, sizeof(control.logStartTrigger));
         ImGui::InputText("Log stop trigger", control.logStopTrigger, sizeof(control.logStopTrigger));
+        ImGui::Checkbox("Stop logging", &control.quiet);
+        ImGui::SameLine();
         ImGui::Combo("Log level", reinterpret_cast<int*>(&control.logLevel), LogParsingHelpers::LOG_LEVELS,
                      (int)LogParsingHelpers::LogLevel::Size, 5);
 
@@ -527,8 +464,8 @@ std::function<void(void)> getGUIDebugger(const std::vector<DeviceInfo>& infos, c
                           ImGuiWindowFlags_HorizontalScrollbar);
         displayHistory(info, control);
         ImGui::EndChild();
+        ImGui::End();
       }
-      ImGui::End();
       popWindowColorDueToStatus();
     }
   };

--- a/Framework/Core/src/FrameworkGUIDeviceInspector.cxx
+++ b/Framework/Core/src/FrameworkGUIDeviceInspector.cxx
@@ -1,0 +1,105 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "FrameworkGUIDeviceInspector.h"
+#include "Framework/DeviceControl.h"
+#include "Framework/DeviceSpec.h"
+#include "Framework/ChannelSpec.h"
+#include "DebugGUI/imgui.h"
+
+namespace o2
+{
+namespace framework
+{
+namespace gui
+{
+
+struct ChannelsTableHelper {
+  template <typename C>
+  static void channelsTable(const char* title, const C& channels)
+  {
+    ImGui::TextUnformatted(title);
+    ImGui::Columns(2);
+    ImGui::TextUnformatted("Name");
+    ImGui::NextColumn();
+    ImGui::TextUnformatted("Port");
+    ImGui::NextColumn();
+    for (auto channel : channels) {
+      ImGui::TextUnformatted(channel.name.c_str());
+      ImGui::NextColumn();
+      ImGui::Text("%d", channel.port);
+      ImGui::NextColumn();
+    }
+    ImGui::Columns(1);
+  }
+};
+
+void optionsTable(const DeviceSpec& spec, const DeviceControl& control)
+{
+  if (spec.options.empty()) {
+    return;
+  }
+  if (ImGui::CollapsingHeader("Options:", ImGuiTreeNodeFlags_DefaultOpen)) {
+    ImGui::Columns(2);
+    auto labels = { "Name", "Value" };
+    for (auto& label : labels) {
+      ImGui::TextUnformatted(label);
+      ImGui::NextColumn();
+    }
+    for (auto& option : spec.options) {
+      ImGui::TextUnformatted(option.name.c_str());
+      ImGui::NextColumn();
+      auto currentValueIt = control.options.find(option.name);
+
+      // Did not find the option
+      if (currentValueIt == control.options.end()) {
+        switch (option.type) {
+          case VariantType::String:
+            ImGui::Text("\"%s\" (default)", option.defaultValue.get<const char*>());
+            break;
+          case VariantType::Int:
+            ImGui::Text("%d (default)", option.defaultValue.get<int>());
+            break;
+          case VariantType::Float:
+            ImGui::Text("%f (default)", option.defaultValue.get<float>());
+            break;
+          case VariantType::Double:
+            ImGui::Text("%f (default)", option.defaultValue.get<double>());
+            break;
+          case VariantType::Empty:
+            ImGui::TextUnformatted(""); // no default value
+          default:
+            ImGui::TextUnformatted("unknown");
+        }
+      } else {
+        ImGui::TextUnformatted(currentValueIt->second.c_str());
+      }
+      ImGui::NextColumn();
+    }
+  }
+  ImGui::Columns(1);
+}
+
+void displayDeviceInspector(DeviceSpec const& spec, DeviceControl& control)
+{
+  if (ImGui::CollapsingHeader("Channels", ImGuiTreeNodeFlags_DefaultOpen)) {
+    ImGui::Text("# channels: %lu", spec.inputChannels.size() + spec.outputChannels.size());
+    ChannelsTableHelper::channelsTable("Inputs:", spec.inputChannels);
+    ChannelsTableHelper::channelsTable("Outputs:", spec.outputChannels);
+  }
+  optionsTable(spec, control);
+  if (ImGui::CollapsingHeader("Data relayer")) {
+    ImGui::Text("Completion policy: %s", spec.completionPolicy.name.c_str());
+  }
+}
+
+} // namespace gui
+} // namespace framework
+} // namespace o2

--- a/Framework/Core/src/FrameworkGUIDeviceInspector.h
+++ b/Framework/Core/src/FrameworkGUIDeviceInspector.h
@@ -1,0 +1,28 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// Helper to display information about a device
+
+namespace o2
+{
+namespace framework
+{
+
+struct DeviceSpec;
+struct DeviceControl;
+
+namespace gui
+{
+
+void displayDeviceInspector(DeviceSpec const& spec, DeviceControl& control);
+
+} // namespace gui
+} // namespace framework
+} // namespace o2


### PR DESCRIPTION
It's now possible to hide the device tree, the metrics and the logs
so that the node graph canvas takes 100% of the real estate. Useful
to take better snapshots.