### PR TITLE
Bugfix: using object copy instead of address to extracted object

### DIFF
--- a/Framework/Core/include/Framework/InputRecord.h
+++ b/Framework/Core/include/Framework/InputRecord.h
@@ -137,10 +137,10 @@ public:
 
   DataRef getByPos(int pos) const {
     if (pos*2+1 > mCache.size() || pos < 0) {
-      throw std::runtime_error("Unknown argument requested at position " + std::to_string(pos));
+      throw std::runtime_error("Unknown message requested at position " + std::to_string(pos));
     }
     if (pos > mInputsSchema.size()) {
-      throw std::runtime_error("Unknown schema at position");
+      throw std::runtime_error("Unknown schema at position" + std::to_string(pos));
     }
     if (mCache[pos*2] != nullptr && mCache[pos*2+1] != nullptr) {
       return DataRef{&mInputsSchema[pos].matcher,
@@ -227,9 +227,14 @@ public:
   typename std::enable_if<std::is_same<T, DataRef>::value, T>::type
   get(const char *binding) const {
     try {
-      return getByPos(getPos(binding));
-    } catch(...) {
-      throw std::runtime_error("Unknown argument requested " + std::string(binding));
+      auto pos = getPos(binding);
+      if (pos < 0) {
+        throw std::invalid_argument("no matching route found for " + std::string(binding));
+      }
+      return getByPos(pos);
+    } catch (const std::exception& e) {
+      throw std::runtime_error("Unknown argument requested " + std::string(binding) +
+                               " - " + e.what());
     }
   }
 
@@ -242,9 +247,14 @@ public:
   typename std::enable_if<std::is_same<T, DataRef>::value, T>::type
   get(std::string const &binding) const {
     try {
-      return getByPos(getPos(binding));
-    } catch (...) {
-      throw std::runtime_error("Unknown argument requested " + std::string(binding));
+      auto pos = getPos(binding);
+      if (pos < 0) {
+        throw std::invalid_argument("no matching route found for " + binding);
+      }
+      return getByPos(pos);
+    } catch (const std::exception& e) {
+      throw std::runtime_error("Unknown argument requested " + std::string(binding) +
+                               " - " + e.what());
     }
   }
 

--- a/Framework/Utils/include/Utils/MakeRootTreeWriterSpec.h
+++ b/Framework/Utils/include/Utils/MakeRootTreeWriterSpec.h
@@ -124,7 +124,7 @@ class MakeRootTreeWriterSpec
       ic.services().get<CallbackService>().set(CallbackService::Id::Stop, finishWriting);
 
       auto processingFct = [writer, nEvents, counter](ProcessingContext& pc) {
-        (*writer)(pc);
+        (*writer)(pc.inputs());
         *counter = *counter + 1;
         if (nEvents >= 0 && *counter >= nEvents) {
           pc.services().get<ControlService>().readyToQuit(true);

--- a/Framework/Utils/test/test_RootTreeWriter.cxx
+++ b/Framework/Utils/test/test_RootTreeWriter.cxx
@@ -76,9 +76,19 @@ BOOST_AUTO_TEST_CASE(test_RootTreeWriter)
   createPlainMessage(o2::header::DataHeader{ "INT", "TST", 0 }, a);
   createSerializedMessage(o2::header::DataHeader{ "CONTAINER", "TST", 0 }, b);
 
+  // Note: InputRecord works on references to the schema and the message vector
+  // so we can not specify the schema definition directly in the definition of
+  // the InputRecord. Intrestingly enough, the compiler does not complain about
+  // getting reference to temporary rvalue argument. So it might work if the
+  // temporary argument is still in memory
+  // FIXME: check why the compiler does not detect this
+  std::vector<InputRoute> schema = {
+    { InputSpec{ "input1", "TST", "INT" }, "input1", 0 },      //
+    { InputSpec{ "input2", "TST", "CONTAINER" }, "input2", 0 } //
+  };
+
   InputRecord inputs{
-    { { InputSpec{ "input1", "TST", "INT" }, "input1", 0 },
-      { InputSpec{ "input2", "TST", "CONTAINER" }, "input2", 0 } },
+    schema,
     messages
   };
 

--- a/Framework/Utils/test/test_RootTreeWriter.cxx
+++ b/Framework/Utils/test/test_RootTreeWriter.cxx
@@ -14,29 +14,82 @@
 #include <boost/test/unit_test.hpp>
 #include <iostream>
 #include <iomanip>
+#include "Headers/DataHeader.h"
+#include <fairmq/FairMQMessage.h>
+#include <fairmq/FairMQTransportFactory.h>
+#include "Framework/DataProcessingHeader.h"
+#include "Framework/InputRecord.h"
 #include "Utils/RootTreeWriter.h"
 #include "Utils/MakeRootTreeWriterSpec.h"
+#include "../../Core/test/TestClasses.h"
 #include <vector>
 #include <memory>
+#include <TClass.h>
 
 using namespace o2::framework;
+using DataHeader = o2::header::DataHeader;
 
-BOOST_AUTO_TEST_CASE(test_RootTreeWriter_static)
+BOOST_AUTO_TEST_CASE(test_RootTreeWriter)
 {
   // need to mimic a context to actually call the processing
   // for now just test the besic compilation and setup
-  RootTreeWriter writer("test.root", "testtree",                                    // file and tree name
-                        RootTreeWriter::BranchDef<int>{ "input1", "branchint" },    // branch definition
-                        RootTreeWriter::BranchDef<float>{ "input2", "branchfloat" } // branch definition
+  using Container = std::vector<o2::test::Polymorphic>;
+  RootTreeWriter writer("test.root", "testtree",                                            // file and tree name
+                        RootTreeWriter::BranchDef<int>{ "input1", "intbranch" },            // branch definition
+                        RootTreeWriter::BranchDef<Container>{ "input2", "containerbranch" } // branch definition
                         );
 
   BOOST_CHECK(writer.getStoreSize() == 2);
+
+  auto transport = FairMQTransportFactory::CreateTransportFactory("zeromq");
+  std::vector<FairMQMessagePtr> messages;
+
+  auto createPlainMessage = [&transport, &messages](DataHeader&& dh, auto& data) {
+    dh.payloadSize = sizeof(data);
+    dh.payloadSerializationMethod = o2::header::gSerializationMethodNone;
+    DataProcessingHeader dph{ 0, 1 };
+    o2::header::Stack stack{ dh, dph };
+    FairMQMessagePtr header = transport->CreateMessage(stack.size());
+    FairMQMessagePtr payload = transport->CreateMessage(sizeof(data));
+    memcpy(header->GetData(), stack.data(), stack.size());
+    memcpy(payload->GetData(), &data, sizeof(data));
+    messages.emplace_back(std::move(header));
+    messages.emplace_back(std::move(payload));
+  };
+
+  auto createSerializedMessage = [&transport, &messages](DataHeader&& dh, auto& data) {
+    FairMQMessagePtr payload = transport->CreateMessage();
+    auto* cl = TClass::GetClass(typeid(decltype(data)));
+    TMessageSerializer().Serialize(*payload, &data, cl);
+    dh.payloadSize = payload->GetSize();
+    dh.payloadSerializationMethod = o2::header::gSerializationMethodROOT;
+    DataProcessingHeader dph{ 0, 1 };
+    o2::header::Stack stack{ dh, dph };
+    FairMQMessagePtr header = transport->CreateMessage(stack.size());
+    memcpy(header->GetData(), stack.data(), stack.size());
+    messages.emplace_back(std::move(header));
+    messages.emplace_back(std::move(payload));
+  };
+
+  int a = 23;
+  Container b{ { 0 } };
+  createPlainMessage(o2::header::DataHeader{ "INT", "TST", 0 }, a);
+  createSerializedMessage(o2::header::DataHeader{ "CONTAINER", "TST", 0 }, b);
+
+  InputRecord inputs{
+    { { InputSpec{ "input1", "TST", "INT" }, "input1", 0 },
+      { InputSpec{ "input2", "TST", "CONTAINER" }, "input2", 0 } },
+    messages
+  };
+
+  writer(inputs);
+  writer.close();
 }
 
 template <typename T>
 using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
 
-BOOST_AUTO_TEST_CASE(test_RootTreeWriterSpec)
+BOOST_AUTO_TEST_CASE(test_MakeRootTreeWriterSpec)
 {
   // setup the spec helper and retrieve the spec by calling the operator
   MakeRootTreeWriterSpec("writer-process",                                                                   //

--- a/Framework/Utils/test/test_RootTreeWriterWorkflow.cxx
+++ b/Framework/Utils/test/test_RootTreeWriterWorkflow.cxx
@@ -83,7 +83,7 @@ DataProcessorSpec getSinkSpec()
     ic.services().get<CallbackService>().set(CallbackService::Id::Stop, finishWriting);
 
     auto processingFct = [writer, counter](ProcessingContext& pc) {
-      (*writer)(pc);
+      (*writer)(pc.inputs());
       *counter = *counter + 1;
       if (*counter >= kTreeSize) {
         pc.services().get<ControlService>().readyToQuit(true);


### PR DESCRIPTION
Filling of tree fails in some cases with segfault if the address
of the extracted object is used directly. Using a copy until the
problem is solved generically. The problem has been encountered
with std::vector of objects, no investigation so far whether that
is the only case.

Changes in detail:
- Copy extracted object to store variable for filling
- Extending unit test to include all steps of the processing.
- Using InputRecord instead of ProcessingContext as input context