### PR TITLE
Split LogicalChannel and PhysicalChannel classes

### DIFF
--- a/Framework/Core/include/Framework/ChannelMatching.h
+++ b/Framework/Core/include/Framework/ChannelMatching.h
@@ -21,51 +21,73 @@ namespace o2
 namespace framework
 {
 
-struct LogicalChannel {
+struct LogicalChannelRange {
+  LogicalChannelRange(const OutputSpec& spec)
+  {
+    name = std::string("out_") +
+           spec.origin.as<std::string>() + "_" +
+           spec.description.as<std::string>() + "_" +
+           std::to_string(spec.subSpec);
+  }
+
   std::string name;
-  bool operator<(LogicalChannel const&other) const {
+  bool operator<(LogicalChannelRange const& other) const
+  {
     return this->name < other.name;
   }
 };
 
-struct PhysicalChannel {
+struct DomainId {
+  std::string value;
+};
+
+struct LogicalChannelDomain {
+  LogicalChannelDomain(const InputSpec& spec)
+  {
+    name.value = std::string("out_") + spec.origin.as<std::string>() + "_" + spec.description.as<std::string>() + "_" + std::to_string(spec.subSpec);
+  }
+  DomainId name;
+  bool operator<(LogicalChannelDomain const& other) const
+  {
+    return this->name.value < other.name.value;
+  }
+};
+
+struct PhysicalChannelRange {
+  PhysicalChannelRange(const OutputSpec& spec, int count)
+  {
+    char buffer[16];
+    auto channel = LogicalChannelRange(spec);
+    id = channel.name + (snprintf(buffer, 16, "_%d", count), buffer);
+  }
+
   std::string id;
-  bool operator<(PhysicalChannel const&other) const {
+  bool operator<(PhysicalChannelRange const& other) const
+  {
     return this->id < other.id;
   }
 };
 
-inline LogicalChannel outputSpec2LogicalChannel(const OutputSpec &spec) {
-  auto name = std::string("out_") +
-              spec.origin.as<std::string>() + "_" +
-              spec.description.as<std::string>() + "_" +
-              std::to_string(spec.subSpec);
-  return LogicalChannel{name};
-}
+struct PhysicalChannelDomain {
+  PhysicalChannelDomain(const InputSpec& spec, int count)
+  {
+    char buffer[16];
+    auto channel = LogicalChannelDomain(spec);
+    id.value = channel.name.value + (snprintf(buffer, 16, "_%d", count), buffer);
+  }
+  DomainId id;
+  bool operator<(PhysicalChannelDomain const& other) const
+  {
+    return this->id.value < other.id.value;
+  }
+};
 
-inline PhysicalChannel outputSpec2PhysicalChannel(const OutputSpec &spec, int count) {
-  char buffer[16];
-  auto channel = outputSpec2LogicalChannel(spec);
-  return PhysicalChannel{channel.name + (snprintf(buffer, 16, "_%d", count), buffer)};
-}
-
-inline LogicalChannel inputSpec2LogicalChannelMatcher(const InputSpec &spec) {
-  auto name = std::string("out_") + spec.origin.as<std::string>() + "_" + spec.description.as<std::string>() + "_" + std::to_string(spec.subSpec);
-  return LogicalChannel{name};
-}
-
-inline PhysicalChannel inputSpec2PhysicalChannelMatcher(const InputSpec&spec, int count) {
-  char buffer[16];
-  auto channel = inputSpec2LogicalChannelMatcher(spec);
-  return PhysicalChannel{channel.name + (snprintf(buffer, 16, "_%d", count), buffer)};
-}
-
-/// @return true if a given DataSpec can use the provided channel.
+/// @return true if the doma
 /// FIXME: for the moment we require a full match, however matcher could really be
 ///        a *-expression or even a regular expression.
-inline bool matchDataSpec2Channel(const InputSpec &spec, const LogicalChannel &channel) {
-  auto matcher = inputSpec2LogicalChannelMatcher(spec);
-  return matcher.name == channel.name;
+inline bool intersect(const LogicalChannelDomain& targetDomain, const LogicalChannelRange& sourceRange)
+{
+  return targetDomain.name.value == sourceRange.name;
 }
 
 } // namespace framework

--- a/Framework/Core/src/DeviceSpec.cxx
+++ b/Framework/Core/src/DeviceSpec.cxx
@@ -23,7 +23,7 @@ namespace o2
 namespace framework
 {
 
-using LogicalChannelsMap = std::map<LogicalChannel, size_t>;
+using LogicalChannelsMap = std::map<LogicalChannelRange, size_t>;
 
 // This calculates the distance between two strings. See:
 //

--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -36,8 +36,6 @@ namespace o2
 namespace framework
 {
 
-using LogicalChannelsMap = std::map<LogicalChannel, size_t>;
-
 char const* channelTypeFromEnum(enum ChannelType type)
 {
   switch (type) {

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -130,7 +130,7 @@ WorkflowHelpers::constructGraph(const WorkflowSpec &workflow,
     auto &input = workflow[ci].inputs[ii];
     auto matcher = [&input, &constOutputs](const LogicalOutputInfo &outputInfo) -> bool {
       auto &output = constOutputs[outputInfo.outputGlobalIndex];
-      return matchDataSpec2Channel(input, outputSpec2LogicalChannel(output));
+      return intersect(LogicalChannelDomain(input), LogicalChannelRange(output));
     };
     oif = std::find_if(availableOutputsInfo.begin(),
                        availableOutputsInfo.end(),
@@ -152,7 +152,7 @@ WorkflowHelpers::constructGraph(const WorkflowSpec &workflow,
     auto &input = workflow[ci].inputs[ii];
     auto matcher = [&input, &constOutputs](const LogicalOutputInfo &outputInfo) -> bool {
       auto &output = constOutputs[outputInfo.outputGlobalIndex];
-      return matchDataSpec2Channel(input, outputSpec2LogicalChannel(output));
+      return intersect(LogicalChannelDomain(input), LogicalChannelRange(output));
     };
     oif = availableOutputsInfo.erase(oif);
     oif = std::find_if(oif, availableOutputsInfo.end(), matcher);


### PR DESCRIPTION
This fixes another place where we have a mix between what is the valid
range of outputs and what is the expected input domain.

This cleanup is needed as a first step towards supporting wildcard
expressions.