### PR TITLE
Fix Typo

### DIFF
--- a/Framework/Core/src/FrameworkGUIDebugger.cxx
+++ b/Framework/Core/src/FrameworkGUIDebugger.cxx
@@ -544,7 +544,7 @@ std::function<void(void)> getGUIDebugger(const std::vector<DeviceInfo>& infos, c
   static gui::WorkspaceGUIState globalGUIState;
   gui::WorkspaceGUIState& guiState = globalGUIState;
   guiState.selectedMetric = -1;
-  guiState.metricMaxRange = 0UI;
+  guiState.metricMaxRange = 0UL;
   guiState.metricMinRange = -1;
   // FIXME: this should probaly have a better mapping between our window state and
   guiState.devices.resize(infos.size());


### PR DESCRIPTION
Compilation fails with GCC 7.3. No idea why this is not catched by CI, probably old gcc doesn't check the literal correctly.