### PR TITLE
Rename GPU CMAKE build options

### DIFF
--- a/Detectors/TPC/reconstruction/CMakeLists.txt
+++ b/Detectors/TPC/reconstruction/CMakeLists.txt
@@ -1,5 +1,5 @@
-option(HLT_CUDA   "Build HLT GPU tracker using CUDA"   OFF)
-option(HLT_OPENCL "Build HLT GPU tracker using OpenCL" OFF)
+option(ENABLE_CUDA   "Build HLT GPU tracker using CUDA"   OFF)
+option(ENABLE_OPENCL "Build HLT GPU tracker using OpenCL" OFF)
 
 if(DEFINED ALITPCCOMMON_DIR)
     set(ALITPCCOMMON_BUILD_TYPE "O2")


### PR DESCRIPTION
Rename cmake option as discussed with Max and Dario (use same common name for AliRoot / O2; TPC / ITS)
O2 version of alisw/AliRoot#720
At some point we should perhaps move it further up in the cmake hierarchy, perhaps even to top level.
@dberzano @mpuccio : ping