### PR TITLE
Move temporary "byte" definition to o2:: namespace

### DIFF
--- a/DataFormats/MemoryResources/include/MemoryResources/MemoryResources.h
+++ b/DataFormats/MemoryResources/include/MemoryResources/MemoryResources.h
@@ -42,10 +42,11 @@
 
 namespace o2
 {
-namespace memory_resource
-{
 
 using byte = unsigned char;
+
+namespace memory_resource
+{
 
 //__________________________________________________________________________________________________
 /// All FairMQ related memory resources need to inherit from this interface class for the getMessage() api.
@@ -307,8 +308,8 @@ class OwningMessageSpectatorAllocator
 //__________________________________________________________________________________________________
 //__________________________________________________________________________________________________
 
-using ByteSpectatorAllocator = SpectatorAllocator<byte>;
-using BytePmrAllocator = boost::container::pmr::polymorphic_allocator<byte>;
+using ByteSpectatorAllocator = SpectatorAllocator<o2::byte>;
+using BytePmrAllocator = boost::container::pmr::polymorphic_allocator<o2::byte>;
 
 //__________________________________________________________________________________________________
 // return the message associated with the container or nullptr if it does not make sense (e.g. when we are just
@@ -336,7 +337,7 @@ FairMQMessagePtr getMessage(ContainerT&& container_, FairMQMemoryResource* targe
     return std::move(message);
   } else {
     auto message = targetResource->getTransportFactory()->CreateMessage(containerSizeBytes);
-    std::memcpy(static_cast<byte*>(message->GetData()), container.data(), containerSizeBytes);
+    std::memcpy(static_cast<o2::byte*>(message->GetData()), container.data(), containerSizeBytes);
     return std::move(message);
   }
 };

--- a/Framework/Core/src/TMessageSerializer.cxx
+++ b/Framework/Core/src/TMessageSerializer.cxx
@@ -16,7 +16,7 @@ using namespace o2::framework;
 TMessageSerializer::StreamerList TMessageSerializer::sStreamers{};
 std::mutex TMessageSerializer::sStreamersLock{};
 
-void TMessageSerializer::loadSchema(gsl::span<byte> buffer)
+void TMessageSerializer::loadSchema(gsl::span<o2::byte> buffer)
 {
   std::unique_ptr<TObject> obj = deserialize(buffer);
 

--- a/Framework/Core/test/test_DataAllocator.cxx
+++ b/Framework/Core/test/test_DataAllocator.cxx
@@ -118,7 +118,7 @@ DataProcessorSpec getSinkSpec()
       DumpStackFctType dumpStack = [&](const o2::header::BaseHeader* h) {
         o2::header::hexDump("", h, h->size());
         if (h->flagsNextHeader) {
-          auto next = reinterpret_cast<const byte*>(h) + h->size();
+          auto next = reinterpret_cast<const o2::byte*>(h) + h->size();
           dumpStack(reinterpret_cast<const o2::header::BaseHeader*>(next));
         }
       };

--- a/Framework/Core/test/test_TMessageSerializer.cxx
+++ b/Framework/Core/test/test_TMessageSerializer.cxx
@@ -88,7 +88,7 @@ BOOST_AUTO_TEST_CASE(TestTMessageSerializer_InvalidBuffer)
   // FIXME: at the moment, TMessage fails directly with a segfault, which it shouldn't do
   /*
   try {
-    auto out = TMessageSerializer::deserialize((byte*)buffer, strlen(buffer));
+    auto out = TMessageSerializer::deserialize((o2::byte*)buffer, strlen(buffer));
     BOOST_ERROR("here we should never get, the function call must fail with exception");
   } catch (std::exception& e) {
     std::string expected("");
@@ -99,7 +99,7 @@ BOOST_AUTO_TEST_CASE(TestTMessageSerializer_InvalidBuffer)
   try {
     struct Dummy {
     };
-    auto out = TMessageSerializer::deserialize<Dummy>((byte*)buffer, strlen(buffer));
+    auto out = TMessageSerializer::deserialize<Dummy>((o2::byte*)buffer, strlen(buffer));
     BOOST_ERROR("here we should never get, the function call must fail with exception");
   } catch (std::exception& e) {
     BOOST_CHECK_MESSAGE(std::string(e.what()).find("class is not ROOT-serializable") == 0, e.what());

--- a/Utilities/O2Device/include/O2Device/Utilities.h
+++ b/Utilities/O2Device/include/O2Device/Utilities.h
@@ -83,20 +83,20 @@ namespace internal
 template <typename I, typename F>
 auto forEach(I begin, I end, F&& function)
 {
-  using span = gsl::span<const byte>;
+  using span = gsl::span<const o2::byte>;
   using gsl::narrow_cast;
   for (auto it = begin; it != end; ++it) {
-    byte* headerBuffer{ nullptr };
+    o2::byte* headerBuffer{ nullptr };
     span::index_type headerBufferSize{ 0 };
     if (*it != nullptr) {
-      headerBuffer = reinterpret_cast<byte*>((*it)->GetData());
+      headerBuffer = reinterpret_cast<o2::byte*>((*it)->GetData());
       headerBufferSize = narrow_cast<span::index_type>((*it)->GetSize());
     }
     ++it;
-    byte* dataBuffer{ nullptr };
+    o2::byte* dataBuffer{ nullptr };
     span::index_type dataBufferSize{ 0 };
     if (*it != nullptr) {
-      dataBuffer = reinterpret_cast<byte*>((*it)->GetData());
+      dataBuffer = reinterpret_cast<o2::byte*>((*it)->GetData());
       dataBufferSize = narrow_cast<span::index_type>((*it)->GetSize());
     }
 

--- a/Utilities/Publishers/include/Publishers/DataPublisherDevice.h
+++ b/Utilities/Publishers/include/Publishers/DataPublisherDevice.h
@@ -70,9 +70,9 @@ protected:
 			    const byte* dataBuffer, size_t dataBufferSize);
 
   /// Read file and append to the buffer
-  static bool AppendFile(const char* name, std::vector<byte>& buffer);
+  static bool AppendFile(const char* name, std::vector<o2::byte>& buffer);
 
-private:
+ private:
   /// configurable name of input channel
   std::string mInputChannelName;
   /// configurable name of output channel
@@ -87,7 +87,7 @@ private:
   SubSpecificationT mSubSpecification;
   /// buffer for the file to read
   /// Note the shift by sizeof(HeartbeatHeader)
-  std::vector<byte> mFileBuffer;
+  std::vector<o2::byte> mFileBuffer;
   std::string mFileName;
 };
 

--- a/Utilities/Publishers/src/DataPublisherDevice.cxx
+++ b/Utilities/Publishers/src/DataPublisherDevice.cxx
@@ -28,7 +28,8 @@ using DataDescription = o2::header::DataDescription;
 using DataOrigin = o2::header::DataOrigin;
 
 template <typename T>
-void fakePayload(std::vector<byte> &buffer, std::function<void(T&,int)> filler, int numOfElements) {
+void fakePayload(std::vector<o2::byte>& buffer, std::function<void(T&, int)> filler, int numOfElements)
+{
   auto payloadSize = sizeof(T)*numOfElements;
   LOG(INFO) << "Payload size " << payloadSize << "\n";
   buffer.resize(buffer.size() + payloadSize);
@@ -201,7 +202,7 @@ bool DataPublisherDevice::HandleO2LogicalBlock(const byte* headerBuffer,
   return true;
 }
 
-bool DataPublisherDevice::AppendFile(const char* name, std::vector<byte>& buffer)
+bool DataPublisherDevice::AppendFile(const char* name, std::vector<o2::byte>& buffer)
 {
   bool result = true;
   std::ifstream ifile(name, std::ifstream::binary);

--- a/Utilities/aliceHLTwrapper/macros/overlayClusters.C_backup
+++ b/Utilities/aliceHLTwrapper/macros/overlayClusters.C_backup
@@ -56,9 +56,9 @@ int verbosity=1;
 int scanArguments();
 bool checkConsistency(const byte* data, unsigned size);
 int shiftClusters(AliHLTTPCSpacePointData* array, unsigned size, float zshift);
-int readData(std::string fileName, std::vector<byte>& buffer);
-int writeData(std::string fileName, std::vector<byte>& buffer);
-int writeData(std::vector<byte>& buffer, std::ostream& os=std::cout);
+int readData(std::string fileName, std::vector<o2::byte>& buffer);
+int writeData(std::string fileName, std::vector<o2::byte>& buffer);
+int writeData(std::vector<o2::byte>& buffer, std::ostream& os=std::cout);
 void printHelp();
 
 void overlayClusters()
@@ -70,7 +70,7 @@ void overlayClusters()
     return;
   }
   unsigned addedClCount=0;
-  vector<byte> buffer;
+  vector<o2::byte> buffer;
   vector<std::string>::const_iterator fileName=inputFileNames.begin();
   if (readData(*fileName, buffer)<0) {
     std::cerr << "Error: no usable data in file " << *fileName << ", aborting ..." << endl;
@@ -182,7 +182,7 @@ int shiftClusters(AliHLTTPCSpacePointData* array, unsigned count, float zshift)
   return count;
 }
 
-int readData(std::string fileName, std::vector<byte>& buffer)
+int readData(std::string fileName, std::vector<o2::byte>& buffer)
 {
   // read file content as binary block to the end of the buffer
   std::ifstream inputFile(fileName.c_str(), std::ifstream::binary);
@@ -206,7 +206,7 @@ int readData(std::string fileName, std::vector<byte>& buffer)
   return len;
 }
 
-int writeData(std::string fileName, std::vector<byte>& buffer)
+int writeData(std::string fileName, std::vector<o2::byte>& buffer)
 {
   // write buffer to file
   std::ifstream inputFile(fileName.c_str(), std::ifstream::binary);
@@ -226,7 +226,7 @@ int writeData(std::string fileName, std::vector<byte>& buffer)
   return result;
 }
 
-int writeData(std::vector<byte>& buffer, std::ostream& os)
+int writeData(std::vector<o2::byte>& buffer, std::ostream& os)
 {
   // write buffer to stream
   os.write((char*)&buffer[0], buffer.size());


### PR DESCRIPTION
this is to avoid clashes with std::byte of C++17