### PR TITLE
Implementation of DPL serializer using boost serialization routines

### DIFF
--- a/Common/Utils/CMakeLists.txt
+++ b/Common/Utils/CMakeLists.txt
@@ -12,6 +12,7 @@ Set(HEADERS
   include/${MODULE_NAME}/TreeStream.h
   include/${MODULE_NAME}/TreeStreamRedirector.h
   include/${MODULE_NAME}/RootChain.h
+  include/${MODULE_NAME}/BoostSerializer.h
 )
 
 Set(LINKDEF src/CommonUtilsLinkDef.h)
@@ -22,6 +23,7 @@ O2_GENERATE_LIBRARY()
 
 set(TEST_SRCS
   test/testTreeStream.cxx
+  test/testBoostSerializer.cxx
 )
 
 O2_GENERATE_TESTS(

--- a/Common/Utils/include/CommonUtils/BoostSerializer.h
+++ b/Common/Utils/include/CommonUtils/BoostSerializer.h
@@ -1,0 +1,131 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   BoostSerializer.h
+/// \brief  Templatised boost serializer/deserializer for containers and base types
+/// \author Gabriele G. Fronzé <gfronze at cern.ch>
+/// \date   17 July 2018
+
+#ifndef ALICEO2_BOOSTSERIALIZER_H
+#define ALICEO2_BOOSTSERIALIZER_H
+
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/serialization/is_bitwise_serializable.hpp>
+#include <boost/serialization/serialization.hpp>
+#include <boost/serialization/array.hpp>
+#include <boost/serialization/vector.hpp>
+#include <boost/serialization/list.hpp>
+#include <boost/serialization/map.hpp>
+#include <boost/serialization/set.hpp>
+#include <boost/type_traits.hpp>
+
+namespace o2
+{
+namespace utils
+{
+namespace check
+{
+///A set of classes and struct to be sure the serialised object is either trivial or implementing custom serialize
+template <class Type, class Archive, typename = typename std::enable_if<std::is_class<Type>::value>::type>
+class is_boost_serializable
+{
+ private:
+  struct TypeOverloader {
+    void serialize(Archive& ar, const unsigned int version) {}
+  };
+  struct TypeExt : public Type, public TypeOverloader {
+  };
+  template <typename T, T t>
+  class DeductionHelper
+  {
+  };
+
+  class True
+  {
+    char m;
+  };
+  class False
+  {
+    True m[2];
+  };
+
+  template <typename TestType>
+  static False deduce(TestType*, DeductionHelper<void (TypeOverloader::*)(), &TestType::serialize>* = 0);
+  static True deduce(...);
+
+ public:
+  static const bool value = (sizeof(True) == sizeof(deduce((TypeExt*)(0))));
+};
+} // namespace check
+
+template <typename ContT>
+typename std::enable_if<check::is_boost_serializable<ContT, boost::archive::binary_oarchive>::value
+                        && std::is_class<typename ContT::value_type>::value, std::ostringstream>::type
+  SerializeContainer(const ContT& dataSet)
+{
+  static_assert(check::is_boost_serializable<typename ContT::value_type, boost::archive::binary_oarchive>::value,
+                "This class doesn't provide a boost serializer.");
+  /// Serialises a container (vector, array or list) using boost serialisation routines.
+  /// Requires the contained type to be either trivial or provided with an overried of boost::serialise method.
+  std::ostringstream buffer;
+  boost::archive::binary_oarchive outputArchive(buffer);
+  outputArchive << dataSet;
+  return buffer;
+}
+
+template <typename ContT, typename ContentT = typename ContT::value_type>
+typename std::enable_if<check::is_boost_serializable<ContT, boost::archive::binary_oarchive>::value
+                        && !(std::is_class<ContentT>::value), std::ostringstream>::type
+  SerializeContainer(const ContT& dataSet)
+{
+  static_assert(boost::serialization::is_bitwise_serializable<typename ContT::value_type>::value,
+                "This type doesn't provide a boost serializer.");
+  /// Serialises a container (vector, array or list) using boost serialisation routines.
+  /// Requires the contained type to be either trivial or provided with an overried of boost::serialise method.
+  std::ostringstream buffer;
+  boost::archive::binary_oarchive outputArchive(buffer);
+  outputArchive << dataSet;
+  return buffer;
+}
+
+template <typename ContT>
+typename std::enable_if<check::is_boost_serializable<ContT, boost::archive::binary_iarchive>::value
+                        && std::is_class<typename ContT::value_type>::value, ContT>::type
+  DeserializeContainer(std::string& msgStr)
+{
+  static_assert(check::is_boost_serializable<typename ContT::value_type, boost::archive::binary_oarchive>::value,
+                "This class doesn't provide a boost deserializer.");
+  /// Deserialises a msg contained in a string in a container type (vector, array or list) of the provided type.
+  ContT output;
+  std::istringstream buffer(msgStr);
+  boost::archive::binary_iarchive inputArchive(buffer);
+  inputArchive >> output;
+  return std::move(output);
+}
+
+template <typename ContT, typename ContentT = typename ContT::value_type>
+typename std::enable_if<check::is_boost_serializable<ContT, boost::archive::binary_iarchive>::value
+                        && !(std::is_class<ContentT>::value), ContT>::type
+  DeserializeContainer(std::string& msgStr)
+{
+  static_assert(boost::serialization::is_bitwise_serializable<typename ContT::value_type>::value,
+                "This type doesn't provide a boost serializer.");
+  /// Deserialises a msg contained in a string in a container type (vector, array or list) of the provided type.
+  ContT output;
+  std::istringstream buffer(msgStr);
+  boost::archive::binary_iarchive inputArchive(buffer);
+  inputArchive >> output;
+  return std::move(output);
+}
+} // namespace utils
+} // namespace o2
+
+#endif //ALICEO2_BOOSTSERIALIZER_H

--- a/Common/Utils/test/testBoostSerializer.cxx
+++ b/Common/Utils/test/testBoostSerializer.cxx
@@ -1,0 +1,111 @@
+//
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See https://alice-o2.web.cern.ch/ for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// @author  Gabriele Gaetano Fronzé
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MAIN
+
+#include <boost/test/unit_test.hpp>
+#include <boost/test/data/test_case.hpp>
+#include <iostream>
+#include <vector>
+#include "CommonUtils/BoostSerializer.h"
+#include "DataFormatsMID/Cluster2D.h"
+
+using namespace o2::utils;
+
+BOOST_AUTO_TEST_SUITE(testDPLSerializer)
+
+BOOST_AUTO_TEST_CASE(testTrivialTypeVect)
+{
+  using contType = std::vector<int>;
+
+  contType inputV{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+
+  auto msgStr = SerializeContainer(inputV).str();
+  auto inputV2 = DeserializeContainer<contType>(msgStr);
+
+  BOOST_TEST(inputV.size() == inputV2.size());
+
+  size_t i = 0;
+  for (auto const& test : inputV) {
+    BOOST_TEST(test == inputV2[i]);
+    i++;
+  }
+}
+
+BOOST_AUTO_TEST_CASE(testTrivialTypeArray)
+{
+  using contType = std::array<int, 20>;
+
+  contType inputV{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+
+  auto msgStr = SerializeContainer(inputV).str();
+  auto inputV2 = DeserializeContainer<contType>(msgStr);
+
+  BOOST_TEST(inputV.size() == inputV2.size());
+
+  size_t i = 0;
+  for (auto const& test : inputV) {
+    BOOST_TEST(test == inputV2[i]);
+    i++;
+  }
+}
+
+BOOST_AUTO_TEST_CASE(testTrivialTypeList)
+{
+  using contType = std::list<int>;
+
+  contType inputV{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+
+  auto msgStr = SerializeContainer(inputV).str();
+  auto inputV2 = DeserializeContainer<contType>(msgStr);
+
+  BOOST_TEST(inputV.size() == inputV2.size());
+
+  size_t i = 0;
+  for (auto const& test : inputV) {
+    auto value = std::next(std::begin(inputV2), i).operator*();
+    BOOST_TEST(test == value);
+    i++;
+  }
+}
+
+BOOST_AUTO_TEST_CASE(testBoostSerialisedType)
+{
+  using contType = std::vector<o2::mid::Cluster2D>;
+
+  contType inputV;
+
+  for (size_t i = 0; i < 17; i++) {
+    float iFloat = (float)i;
+    inputV.emplace_back(o2::mid::Cluster2D{ (uint8_t)i, 0.3f * iFloat, 0.5f * iFloat, 0.7f / iFloat, 0.9f / iFloat });
+  }
+
+  auto msgStr = SerializeContainer(inputV).str();
+  auto inputV2 = DeserializeContainer<contType>(msgStr);
+
+  BOOST_TEST(inputV.size() == inputV2.size());
+
+  size_t i = 0;
+  for (auto const& test : inputV) {
+    BOOST_TEST(test.deId == inputV2[i].deId);
+    BOOST_TEST(test.xCoor == inputV2[i].xCoor);
+    BOOST_TEST(test.yCoor == inputV2[i].yCoor);
+    BOOST_TEST(test.sigmaX2 == inputV2[i].sigmaX2);
+    BOOST_TEST(test.sigmaY2 == inputV2[i].sigmaY2);
+    i++;
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -132,6 +132,7 @@ set(HEADERS
       include/Framework/CallbackService.h
       include/Framework/DataSampling.h
       include/Framework/DataSamplingCondition.h
+      include/Framework/DPLBoostSerializer.h
       src/ComputingResource.h
       src/DDSConfigHelpers.h
       src/DeviceSpecHelpers.h

--- a/Framework/Core/include/Framework/DPLBoostSerializer.h
+++ b/Framework/Core/include/Framework/DPLBoostSerializer.h
@@ -1,0 +1,62 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   Framework/DPLBoostSerializer.h
+/// \brief  DPL wrapper of common utils BoostSeralizer
+/// \author Gabriele G. Fronzé <gfronze at cern.ch>
+/// \date   17 July 2018
+
+#ifndef ALICEO2_DPLBOOSTSERIALIZER_H
+#define ALICEO2_DPLBOOSTSERIALIZER_H
+
+#include "Framework/DataRef.h"
+#include "Framework/Output.h"
+#include "CommonUtils/BoostSerializer.h"
+#include "ProcessingContext.h"
+
+namespace o2
+{
+namespace framework
+{
+
+template <typename ContT>
+void DPLBoostSerialize(o2::framework::ProcessingContext& ctx, const std::string& outBinding,
+                       const ContT& dataSet)
+{
+  /// Serialises a data set (in the form of vector, array or list) in a message
+  auto buffer = o2::utils::SerializeContainer<ContT>(dataSet);
+  int size = buffer.str().length();
+  auto msg = ctx.outputs().make<char>({ outBinding }, size);
+  std::memcpy(&(msg[0]), buffer.str().c_str(), size);
+}
+
+template <typename ContT>
+void DPLBoostSerialize(o2::framework::ProcessingContext& ctx, const std::string& outBinding,
+                       const ContT& dataSet, const unsigned long& nData)
+{
+  /// Serialises the nData elements of a data set (in the form of vector, array or list) in a message
+  ContT subSet(std::begin(dataSet), std::next(std::begin(dataSet), nData));
+  DPLBoostSerialize(ctx, outBinding, subSet);
+}
+
+template <typename ContT>
+void DPLBoostDeserialize(const o2::framework::DataRef& msg, ContT& output)
+{
+  /// Deserialises a DPL msg to a container type (vector, array or list) of the provided type.
+  using dataH = o2::header::DataHeader;
+  auto payloadSize = const_cast<dataH*>(reinterpret_cast<const dataH*>(msg.header))->payloadSize;
+  output.clear();
+  std::string msgStr(msg.payload, payloadSize);
+  output = std::move(o2::utils::DeserializeContainer<ContT>(msgStr));
+}
+} // namespace framework
+} // namespace o2
+
+#endif //ALICEO2_DPLBOOSTSERIALIZER_H

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -243,8 +243,10 @@ o2_define_bucket(
 o2_define_bucket(
     NAME
     O2FrameworkCore_bucket
+
     DEPENDENCIES
     O2DeviceApplication_bucket
+    common_utils_bucket
     Core
     Net
     MathUtils

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -1704,9 +1704,13 @@ o2_define_bucket(
   DEPENDENCIES
   Core Tree
   ReconstructionDataFormats # for test dependency only
+  common_boost_bucket
+  DataFormatsMID
 
   INCLUDE_DIRECTORIES
   ${ROOT_INCLUDE_DIR}
+  ${Boost_INCLUDE_DIR}
+  ${CMAKE_SOURCE_DIR}/Common/Utils/include
   ${CMAKE_SOURCE_DIR}/include/ReconstructionDataFormats # for test dependency only
 )
 


### PR DESCRIPTION
Implementation of A DPL-compliant dataset serialiser.
It works flawlessly for STL containers such as vectors, arrays and lists.
It can be used for raw arrays.
This utility makes use of boost serialisation routines.
Various tests are performed on the DPL-independent methods.
A DPL workflow will be added to the tests to perform top-level checks.