### PR TITLE
Small and flexible MCStepLogger analysis framework

### DIFF
--- a/Utilities/MCStepLogger/CMakeLists.txt
+++ b/Utilities/MCStepLogger/CMakeLists.txt
@@ -9,19 +9,47 @@ set(SRCS
     src/MCStepInterceptor.cxx
     src/MCStepLoggerImpl.cxx
     src/StepInfo.cxx
+    src/MCAnalysis.cxx
+    src/BasicMCAnalysis.cxx
+    src/MCAnalysisManager.cxx
+    src/MCAnalysisFileWrapper.cxx
+    src/MCAnalysisUtilities.cxx
+    src/ROOTIOUtilities.cxx
    )
 
 set(HEADERS
-   src/StepInfo.h
+   include/${MODULE_NAME}/StepInfo.h
+   include/${MODULE_NAME}/MetaInfo.h
+   include/${MODULE_NAME}/MCAnalysis.h
+   include/${MODULE_NAME}/BasicMCAnalysis.h
+   include/${MODULE_NAME}/MCAnalysisManager.h
+   include/${MODULE_NAME}/MCAnalysisFileWrapper.h
+   include/${MODULE_NAME}/MCAnalysisUtilities.h
+   include/${MODULE_NAME}/ROOTIOUtilities.h
   )
 
 set(LIBRARY_NAME ${MODULE_NAME})
 set(BUCKET_NAME ${MODULE_BUCKET_NAME})
 set(LINKDEF src/MCStepLoggerLinkDef.h)
 
+
 O2_GENERATE_LIBRARY()
 
-# check correct functioning of the logger
+O2_GENERATE_EXECUTABLE(
+  EXE_NAME mcStepAnalysis
+  SOURCES src/analyseMCSteps.cxx
+  MODULE_LIBRARY_NAME ${LIBRARY_NAME}
+  BUCKET_NAME ${BUCKET_NAME}
+)
+
+O2_GENERATE_EXECUTABLE(
+  EXE_NAME runTestBasicMCAnalysis
+  SOURCES src/basicMCAnalysisCI.cxx
+  MODULE_LIBRARY_NAME ${LIBRARY_NAME}
+  BUCKET_NAME ${BUCKET_NAME}
+)
+
+# check correct functioning of the logger and the MC analysis chain
 if (HAVESIMULATION)
   add_test(NAME mcloggertest COMMAND ${CMAKE_BINARY_DIR}/bin/runTPC -n 1 -e TGeant3)
   # tests if the logger was active
@@ -33,4 +61,21 @@ if (HAVESIMULATION)
   endif()
     set_tests_properties(mcloggertest PROPERTIES ENVIRONMENT ${PRELOAD}=${CMAKE_BINARY_DIR}/lib/libMCStepLogger${CMAKE_SHARED_LIBRARY_SUFFIX})
     set_property(TEST mcloggertest APPEND PROPERTY ENVIRONMENT VMCWORKDIR=${CMAKE_SOURCE_DIR})
+
+  # check whether StepLogger output can be written to ROOT file
+  # fix output file name for logged data
+  set(STEPLOGGER_ROOTFILE "MCStepLoggerOutput_test.root")
+  add_test(NAME mcloggertest_tofile COMMAND ${CMAKE_BINARY_DIR}/bin/runTPC -n 1 -e TGeant3)
+  set_tests_properties(mcloggertest_tofile PROPERTIES ENVIRONMENT ${PRELOAD}=${CMAKE_BINARY_DIR}/lib/libMCStepLogger${CMAKE_SHARED_LIBRARY_SUFFIX})
+  # set environment accordingly
+  set_property(TEST mcloggertest_tofile APPEND PROPERTY ENVIRONMENT VMCWORKDIR=${CMAKE_SOURCE_DIR} MCSTEPLOG_TTREE=1 MCSTEPLOG_OUTFILE=${STEPLOGGER_ROOTFILE})
+
+  # check for working analysis
+  # fix output file name for analysis
+  set(MCANALYSIS_ROOTFILE "BasicMCAnalysis.root")
+  add_test(NAME basicmcanalysis COMMAND ${CMAKE_BINARY_DIR}/bin/mcStepAnalysis analyze -f ${STEPLOGGER_ROOTFILE} -o ${MCANALYSIS_ROOTFILE} -l testLabel)
+  set_tests_properties(basicmcanalysis PROPERTIES DEPENDS mcloggertest_tofile)
+  # set environment accordingly
+  set_property(TEST basicmcanalysis APPEND PROPERTY ENVIRONMENT VMCWORKDIR=${CMAKE_SOURCE_DIR})
+
 endif()

--- a/Utilities/MCStepLogger/README.md
+++ b/Utilities/MCStepLogger/README.md
@@ -2,7 +2,7 @@
 
 Detailed debug information about stepping can be directed to standard output using the `LD_PRELOAD` env variable, which "injects" a
  special logging library (which intercepts some calls) in the executable that follows in the command line.
- 
+
 ```bash
 LD_PRELOAD=path_to/libMCStepLogger.so o2sim -m MCH -n 10
 ```
@@ -22,7 +22,7 @@ LD_PRELOAD=path_to/libMCStepLogger.so o2sim -m MCH -n 10
 [MCLOGGER:] END FLUSHING ----
 ```
 
-The stepping logger information can also be directed to an output tree for more detailed investigations. 
+The stepping logger information can also be directed to an output tree for more detailed investigations.
 Default name is `MCStepLoggerOutput.root` (and can be changed
 by setting the `MCSTEPLOG_OUTFILE` env variable).
 
@@ -65,10 +65,189 @@ LD_DEBUG=help o2sim
 ```bash
 DYLD_INSERT_LIBRARIES=/Users/laurent/alice/sw/osx_x86-64/O2/latest-clion-o2/lib/libMCStepLogger.dylib MCSTEPLOG_TTREE=1 MCSTEPLOG_OUTFILE=toto.root o2sim -m MCH -g mugen -n 1
 ```
- 
+
 `LD_DEBUG=libs` must be replaced by `DYLD_PRINT_LIBRARIES=1`
 
 `LD_DEBUG=statistics` must be replaced by `DYLD_PRINT_STATISTICS=1`
 
 
+## MCStepLogAnalysis
 
+Information collected and stored in `MCStepLoggerOutput.root` can be further investigated using the excutable `mcStepAnalysis`. This executable is independent of the simulation itself and produces therefore no overhead when running a simulation. 2 commands are so far available (`analyze`, `checkFile`) including useful help message when typing
+```bash
+mcStepAnalysis <command> --help
+```
+
+### File formats
+
+2 file formats having a standardised structure play a role. On one hand, these are the files produced by the step logging which are the input files for the analysis as explained in the following. On the other hand, each analysis produces an output file containing histograms along with some meta information. Sanity and the type of the file can be checked via
+```bash
+mcStepAnalysis checkFile -f <FileToBeChecked>
+```
+### Analysing the steps
+
+The basic command containing all required parameters is
+```bash
+mcStepAnalysis analyze -f <MCStepLoggerOutputFile> -o <parent/output/dir> -l <label>
+```
+where  
+* `-f <MCStepLoggerOutputFile>` passes the input file produced with the `MCStepLogger` as explained above (default name is `MCStepLoggerOutput.root`)
+* `-o <parent/output/dir>` provides the top directory for the analysis output (if this does not exist, it is created automatically)
+* `-l <label>` adds a label, e.g. for plots produced later.
+
+A `ROOT` file at `parent/output/dir/MetaAnalysis/Analysis.root` is produced containing all histograms as well as important meta information. Histogram objects are derived from `ROOT`s `TH1` classes.
+
+### Further processing of analysis files
+
+Files produced as described before can be investigated further or used to plot the histograms therein. The interface to read these files is the class `AnalysisFile` and histograms can be requested by their names.
+```c++
+// somthing...
+#include "MCStepLogger/AnalysisFile.h"
+// some code
+AnalysisFile af;
+af.read("path/to/file.root");
+// print meta info
+af.printMetaInfo();
+// get a histogram by name (program will exit if name not found)
+TH1& histogram = af.getHistogram("nameOfHistogram");
+// if you know the underlying object is, e.g. of derived class TH1D and you really need that you can do
+TH1D& otherHistogramCasted = af.getHistogram<TH1D>("nameOfOtherHistogram");
+// where the program will safely exit immediately in case the casting was not successful
+//...
+// modify histogram or do other things
+//...
+//to save changes made to histograms do
+af.write("path/to/output/file.root");
+```
+### Additional information about the `MCAnalysisManager`
+
+There is the staic method `MCAnalysisManager::Instance()` which returns a reference to a static instance. So always make sure you don't copy it but get the reference in case you want to work with that instance on a global scope, i.e.
+```c++
+// some code
+auto& anamgr = MCAnalysisManager::Instance();
+```
+### Additional information about the analysis objects
+
+Histograms which should be written to disk in an analysis are managed by `MCAnalysisFileWrapper` objects. These also make sure that no histogram is created twice. Therefore, all of these histograms should be created like `T* myHisto = MCAnalysis::getHistogram<T>(...)` where the template parameter `T` must be a class deriving from ROOT's `TH1`. It then returns a pointer to the desired object. Managing histograms not on the level of an analysis also enables for requesting histograms from another analysis. In that way one can write a custom analysis for a specific use case but can still ask for e.g. for a histogram from the `BasicMCAnalysis` to derive some additional and more generic information about a simulation run. Hence, never manually delete an object obtained like this.
+
+### Comparing analysis values to reference reference values
+
+For the `BasicMCAnalysis` there is a small test suite to compare the obtained values from a simulation run to reference values contained in a JSON file. So far, that is a prototype only caring about the total number of steps and total number of tracks obtained in the simulation. The `JSON` file looks as follows
+```json
+{
+  "analysisName": "BasicMCAnalysis",
+  "nSteps": [absoluteNumberOfSteps, relativeTolerance],
+  "nTracks": [absoluteNumberOfTracks, relativeTolerance]
+}
+```
+The test is steered via
+```bash
+runTestBasicMCAnalysis -- <path/to/Analysis.root> <reference.json>
+```
+Note, that the test does not know anything about the settings of the simulation run, i.e. there are no information about the primary generator of the transport engine etc. The user has to make sure to apply this coherently.
+
+### Writing/running a custom analysis
+
+Although providing already a number of different observables, users might want to add custom observables for their analysis. To do so, a directory for custom analyses has to be created where analysis macros can be provided and loaded at run-time. Note, that only the basic analysis is actually contained in the compiled code. One of the main reasons for that is to enable for a coherent comparison between different points in the git history. However, if you feel like there is an important observable missing, feel free to report that.
+
+The logic of adding a custom analysis is very similar to that of `Rivet` and the general workflow should look familiar in any case. Say, your analysis macro directory is `$ANALYSIS_MACROS/` where you have your macro `mySimulationAnalysisc.C` (don't place any other files there since these cannot be read...). A skeleton looks as follows, also containing more information on how and why things are implemented like they are:
+
+```c++
+// myMCStepAnalysis.C
+//
+// headers you need
+
+/* Your analysis class has to derive from the base o2::mcstepanalysis::MCAnalysis. All
+ * methods to be implemented are mentioned below.
+ */
+class MyMCStepAnalysis : public MCAnalysis
+{
+  public:
+  	/* You don't need a fancy constructor, that's it. The base constructor takes care
+  	 * of registering this analysis to the global o2::MCStepAnalysis::MCAnalysisManager
+  	 * object. An MCAnalysis object cannot exist without the MCAnalysisManager.
+  	 */
+    MySimulationAnalysis()
+      : MCAnalysis("MyMCStepAnalysis")
+    {}
+
+    /* There are 3 methods covering the analysis: initialize, analyze and finalize.
+     * The first two need to be overriden in any case.
+     * These methods are called by the MCAnalysisManager. Other custom methods
+     * can hence only be used for class-internal purposes only.
+     */
+
+    /* All histograms used in the analysis must be defined here. This is done using
+     * the method MCAnalysis::getHistogram<T>(...) where the template paramter T has to
+     * be a deriving class of ROOT's TH1. The histogram pointers are the managed
+     * globally for further processing, saving, plotting etc. It is also taken care
+     * of the deletion of the pointers. Do not attempt to delete histograms obtained by
+     * MCAnalysis::getHistogram<T>(...). Histograms are uniquely identified by there
+     * name and an MCAnalysis will stop immediately at the initialisation stage if
+     * two histograms with the same name are detected.
+     */
+    void initialize() override {
+
+    	// monitor calls to the magnetic field per volume
+    	histMyFirstObservable = getHistogram<TH1D>("myFirstObservable", 1, 0., 1.);
+    	// monitor the steps in the r-z plane
+    	histMySecondObservable = getHistogram<TH2D>("mySecondObservable", 1, 0., 1., 2, 0., 2.);
+    	// more histograms?! Other things to do?
+
+    }
+
+    /* This method is used to extract the step information in order to fill histograms
+     * accordingly.
+     */
+    void analyze(const std::vector<StepInfo>* const steps,
+    			       const std::vector<MagCallInfo>* const magCalls) override {
+
+      // loop over mag field calls and match to step ID
+    	for(const auto& call : *magCalls) {
+		    auto step = steps->operator[](call.stepid);
+		    mAnalysisManager->getLookupVolName(step.volId, volName);
+		    histMyFirstObservable->Fill(volName.c_str(), 1.);
+	    }
+
+      // loop over steps and get z-position and other things as you like
+	    for(const auto& step : *steps) {
+	    	histMySecondObservable->Fill(step.z, std::sqrt( step.x*step.x + step.y*step.y ));
+	    	// ...and do more, as you like
+	    }
+    }
+
+    /* the finalyze method can be used to do necessary adjustments like scaling or adding
+     * histograms or whatever must be done to them.
+     */
+    void finalize() override {
+    	histMyFirstObservable->Scale( 1. / histMyFirstObservable->GetEntries() );
+    	// ...and more...
+    }
+
+  private:
+  	// you might want to provide some useful methods for internal use...
+
+  private:
+  	TH1D* histMyFirstObservable;
+  	TH2D* histMySecondObservable;
+  	// other histogram pointers and/or members for internal usage
+ };
+
+/* The hook to bring your analysis into existence so that the MCAnalysisManager
+ * knows. Don't be scared about the way the pointer of the analysis is created. It is all
+ * taken care of by the MCAnalysisManager since the base MCAnalysis constructor
+ * automatically registeres itself to the MCAnalysisManager. So don't worry about
+ * pointers flying around.
+ */
+void declareAnalysis() {
+	new MySimulationAnalysis("mySimulationAnalysis");
+}
+```
+After having this, you are ready to include this in the analysis run by typing
+```bash
+runMCAnalysis analyze -f <MCStepLoggerOutputFile> -o <parent/output/dir> -l <label> -d $ANALYSIS_MACROS -a mySimulationAnalysis
+```
+where now
+* `-d $ANALYSIS_MACROS` points the executable to the directory of where your macros are located
+* `-a  mySimulationAnalysis` tells which analysis to load. In case you have more analyses in that directory you want to load, just append the names of all analyses you want to run.
+The output of the custom analysis is written to `parent/output/dir/mySimulationAnalysis/` and that's it.

--- a/Utilities/MCStepLogger/include/MCStepLogger/BasicMCAnalysis.h
+++ b/Utilities/MCStepLogger/include/MCStepLogger/BasicMCAnalysis.h
@@ -1,0 +1,133 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/* This class analyses properties of a simulation run which are directly accessible in 
+ * the ROOT files created with the MCStepLogger. No complex parameters are derived from 
+ * what is available and it therefore provides a first immediate conclusion on the 
+ * simulation in terms of:
+ *
+ * -> number of simulated events
+ * -> number of tracks
+ *    -> total
+ *    -> per PDG ID
+ * -> number of steps (smallest accessible granularity of the particle transport)
+ *    -> total
+ *    -> per volume (absolute and relative)
+ *    -> per PDG ID (absolute and relative)
+ * -> spatial distribution of steps
+ *    -> position
+ *    -> steps in r-z plane
+ *    -> step sizes
+ *       -> all
+ *       -> mean step size per event
+ *       -> mean step size per volume per event
+ *       -> mean step size per PDG ID per event
+ * -> number of secondaries
+ *    -> total
+ *    -> per volume
+ * -> number of calls to magnetic field
+ * -> number of volumes traversed
+ *
+ * Note that all histograms are normalized to the number of simulated events in 
+ * order to enable for an analysis comparison given 2 runs with different number 
+ * of events (of course, statistics need to be large enough to make sure the phase
+ * space is sufficiently scanned in both analyses in order to draw reliable 
+ * conclusions from a comparison).
+ * 
+ * Nevertheless, this analysis can be used to compare simulations with benchmarked
+ * events directly.
+ */
+
+#ifndef BASIC_MCANALYSIS_H_
+#define BASIC_MCANALYSIS_H_
+
+#include <unordered_map>
+
+#include "MCStepLogger/MCAnalysis.h"
+
+namespace o2
+{
+namespace mcstepanalysis
+{
+
+class BasicMCAnalysis : public MCAnalysis
+{
+ public:
+  BasicMCAnalysis();
+
+ protected:
+  /// custom initialization of histograms
+  void initialize() override;
+  /// custom event loop
+  void analyze(const std::vector<StepInfo>* const steps, const std::vector<MagCallInfo>* const magCalls) override;
+  /// custom finalizations of produced histograms
+  void finalize() override;
+
+ private:
+  // number of events
+  TH1D* histNEvents;
+  // number of tracks over all events
+  TH1D* histNTracks;
+  // number of tracks averaged over number of events
+  TH1D* histNTracksPerEvent;
+  // number of tracks mapped to particles' PDG ID averaged over number of events
+  TH1D* histNTracksPerPDGPerEvent;
+  // relative number of tracks mapped to particles' PDG ID averaged over number of events
+  TH1D* histRelNTracksPerPDGPerEvent;
+  // count total number of steps including all events
+  TH1D* histNSteps;
+  // number of steps averaged over number of events
+  TH1D* histNStepsPerEvent;
+  // number of steps per volume averaged over number of events
+  TH1D* histNStepsPerVolPerEvent;
+  // relative number of steps per volume averaged over number of events
+  TH1D* histRelNStepsPerVolPerEvent;
+  // number of steps made by particles of certain PDG ID averaged over number of events
+  TH1D* histNStepsPerPDGPerEvent;
+  // relative number of steps made by particles of certain PDG ID averaged over number of events
+  TH1D* histRelNStepsPerPDGPerEvent;
+  // histogram of x coordinates of steps averaged over number of events
+  TH1D* histStepsXPerEvent;
+  // histogram of y coordinates of steps averaged over number of events
+  TH1D* histStepsYPerEvent;
+  // histogram of z coordinates of steps averaged over number of events
+  TH1D* histStepsZPerEvent;
+  // average step size per event per volume averaged over number of events
+  TH1D* histMeanStepSizePerVolPerEvent;
+  // average step size per event per PDG averaged over number of events
+  TH1D* histMeanStepSizePerPDGPerEvent;
+  // overall average step size per event averaged over number of events
+  TH1D* histMeanStepSizePerEvent;
+  // counting all step sizes per event averaged over number of events
+  TH1D* histStepSizesPerEvent;
+  // steps in the r-z plane
+  TH2D* histRZ;
+  // total number of secondaries averaged over number of events
+  TH1D* histNSecondariesPerEvent;
+  // total number of secondaries per volume averaged over number of events
+  TH1D* histNSecondariesPerVolPerEvent;
+  // number of calls to magnetic field per volume averaged over number of events
+  TH1D* histMagFieldCallsPerVolPerEvent;
+  // number of calls to magnetic field (with small abs. value) per volume averaged over number of events
+  TH1D* histSmallMagFieldCallsPerVolPerEvent;
+  // count the number of volumes traversed
+  TH1I* histNVols;
+  // helper to keep track of all different volume IDs accross events
+  std::vector<int> volIds;
+  // helper to check in how many events a certain PDG was present
+  std::unordered_map<std::string, float> pdgPresent;
+  // helper to check in how many events a certain volume was traversed
+  std::unordered_map<std::string, float> volPresent;
+
+  ClassDefNV(MCAnalysis, 1);
+};
+} // namespace mcstepanalysis
+} // namespace o2
+#endif /* BASIC_MCANALYSIS_H_ */

--- a/Utilities/MCStepLogger/include/MCStepLogger/MCAnalysis.h
+++ b/Utilities/MCStepLogger/include/MCStepLogger/MCAnalysis.h
@@ -1,0 +1,136 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/* Base class for Analyses
+ * All concrete analyses must inherit from this class in order to be handled by the MCAnalysisManager.
+ * The constructor registeres an analysis automatically to the MCAnalysisManager
+ */
+
+#ifndef MCANALYSIS_H_
+#define MCANALYSIS_H_
+
+#include <string>
+#include <vector>
+
+// covers all histograms
+#include "TProfile.h"
+#include "TProfile2D.h"
+#include "TProfile3D.h"
+
+#include "MCStepLogger/StepInfo.h"
+#include "MCStepLogger/MCAnalysisManager.h"
+#include "MCStepLogger/MCAnalysisFileWrapper.h"
+
+namespace o2
+{
+namespace mcstepanalysis
+{
+
+// /class MCAnalysisManager;
+
+class MCAnalysis
+{
+  /// Add as friend so it can access protected (private) members in order to use this class
+  friend class MCAnalysisManager;
+
+ public:
+  /// only constructor allowed
+  MCAnalysis(const std::string& name);
+  virtual ~MCAnalysis() = default;
+
+ protected:
+  //
+  // steering
+  //
+  /// this must be overwridden, otherwise it is not possible to register histograms
+  virtual void initialize() = 0;
+  /// this has to be overwridden
+  virtual void analyze(const std::vector<StepInfo>* const steps,
+                       const std::vector<MagCallInfo>* const magCalls) = 0;
+  /// this can be overwridden
+  virtual void finalize() { ; }
+  //
+  // internal histogram managing
+  //
+  /// get a 1D histogram and directly register it to this analysis
+  template <typename T>
+  T* getHistogram(const std::string& name, int nBins, double lower, double upper)
+  {
+    return &mAnalysisFile->getHistogram<T>(name, nBins, lower, upper);
+  }
+  /// get a 2D histogram and directly register it to this analysis
+  template <typename T>
+  T* getHistogram(const std::string& name, int nBinsX, double lowerX, double upperX,
+                  int nBinsY, double lowerY, double upperY)
+  {
+    return &mAnalysisFile->getHistogram<T>(name, nBinsX, lowerX, upperX, nBinsY, lowerY, upperY);
+  }
+  /// get a 2D histogram and directly register it to this analysis
+  template <typename T>
+  T* getHistogram(const std::string& name, int nBinsX, double lowerX, double upperX,
+                  int nBinsY, double lowerY, double upperY,
+                  int nBinsZ, double lowerZ, double upperZ)
+  {
+    return &mAnalysisFile->getHistogram<T>(name, nBinsX, lowerX, upperX, nBinsY, lowerY, upperY, nBinsZ, lowerZ, upperZ);
+  }
+  //
+  // setting
+  //
+  /// set analysis file to write histograms to
+  void setAnalysisFile(MCAnalysisFileWrapper& analysisFile)
+  {
+    mAnalysisFile = &analysisFile;
+  }
+  //
+  // getting
+  //
+  /// get and set some status of the analysis. All of these methods are only used by the MCAnalysisManager
+  bool isInitialized() const
+  {
+    return mIsInitialized;
+  }
+  /// retrieve name of the analysis
+  const std::string& name() const
+  {
+    return mName;
+  }
+
+ private:
+  /// don't allow default construction operations
+  MCAnalysis() = delete;
+  MCAnalysis& operator=(const MCAnalysis&) = delete;
+  MCAnalysis(const MCAnalysis&) = delete;
+  /// only the AnalysisManager is allowed to set this
+  void isInitialized(bool val)
+  {
+    mIsInitialized = val;
+  }
+
+ protected:
+  /// pointer to MCAnalysisManager
+  // \note \todo given that derived classes have non acces to private members like void isInitialized(bool val)
+  // making the MCAnalysisManager available to derived class is somehow breaking this logic since as a friend this
+  // actually can access these methods. So a derived analysis can recursively access the private member functions
+  // via the MCAnalysisManager pointer.
+  MCAnalysisManager* mAnalysisManager;
+
+ private:
+  /// the analysis name
+  std::string mName;
+  /// initialisation flag
+  bool mIsInitialized;
+  /// save all histograms used in this analysis
+  MCAnalysisFileWrapper* mAnalysisFile;
+
+  ClassDefNV(MCAnalysis, 1);
+};
+} // end namespace mcstepanalysis
+} // end namespace o2
+#endif /* MCANALYSIS_H_ */

--- a/Utilities/MCStepLogger/include/MCStepLogger/MCAnalysisFileWrapper.h
+++ b/Utilities/MCStepLogger/include/MCStepLogger/MCAnalysisFileWrapper.h
@@ -1,0 +1,162 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef MCANALYSIS_FILE_WRAPPER_H_
+#define MCANALYSIS_FILE_WRAPPER_H_
+
+#include <string>
+#include <vector>
+#include <memory> // std::unique_ptr
+
+#include "FairLogger.h"
+
+#include "MCStepLogger/MetaInfo.h"
+
+#include "TH1.h"
+#include "TH2.h"
+#include "TH3.h"
+
+namespace o2
+{
+namespace mcstepanalysis
+{
+
+/*
+ * Interface to files produced with the analysis framework
+ * Write files, read them form disk and provide access to histograms and meta information
+ */
+class MCAnalysisFileWrapper
+{
+ public:
+  MCAnalysisFileWrapper();
+  ~MCAnalysisFileWrapper() = default;
+  // \todo make a deep copy?!
+  MCAnalysisFileWrapper(const MCAnalysisFileWrapper&) = default;
+  MCAnalysisFileWrapper& operator=(const MCAnalysisFileWrapper&) = default;
+  //
+  // monitoring, control
+  //
+  bool isSane() const;
+  //
+  // file system methods
+  //
+  /// read analysis obects from file
+  bool read(const std::string& filepath);
+  /// write to a directory, analysis name and file name are derived here
+  void write(const std::string& directory) const;
+  //
+  // retrieve and modify histogram content
+  //
+  /// check if some histogram is present in general
+  bool hasHistogram(const std::string& name);
+  /// get one histogram by name, exit if not present
+  template <typename T = TH1>
+  T& getHistogram(const std::string& name)
+  {
+    return *castHistogram<T>(findHistogram(name), false);
+  }
+  /// get a 1D histogram and directly register it to this this wrapper
+  template <typename T>
+  T& getHistogram(const std::string& name, int nBins, double lower, double upper)
+  {
+    static_assert(std::is_base_of<TH1, T>::value, "the requested object type does not derive from TH1");
+    T* histogramSearch = castHistogram<T>(findHistogram(name));
+    if (histogramSearch) {
+      return *histogramSearch;
+    }
+    mHistograms.push_back(std::make_shared<T>(name.c_str(), "", nBins, lower, upper));
+    mAnalysisMetaInfo.nHistograms++;
+    mHasChanged = true;
+    return *(dynamic_cast<T*>(mHistograms.back().get()));
+  }
+  /// get a 2D histogram and directly register it to this this wrapper
+  template <typename T>
+  T& getHistogram(const std::string& name, int nBinsX, double lowerX, double upperX,
+                  int nBinsY, double lowerY, double upperY)
+  {
+    static_assert(std::is_base_of<TH2, T>::value, "the requested object type does not derive from TH2");
+    T* histogramSearch = castHistogram<T>(findHistogram(name));
+    if (histogramSearch) {
+      return *histogramSearch;
+    }
+    mHistograms.push_back(std::make_shared<T>(name.c_str(), "", nBinsX, lowerX, upperX, nBinsY, lowerY, upperY));
+    mAnalysisMetaInfo.nHistograms++;
+    mHasChanged = true;
+    return *(dynamic_cast<T*>(mHistograms.back().get()));
+  }
+  /// get a 3D histogram and directly register it to this this wrapper
+  template <typename T>
+  T& getHistogram(const std::string& name, int nBinsX, double lowerX, double upperX,
+                  int nBinsY, double lowerY, double upperY,
+                  int nBinsZ, double lowerZ, double upperZ)
+  {
+    T* histogramSearch = castHistogram<T>(findHistogram(name));
+    if (histogramSearch) {
+      return *histogramSearch;
+    }
+    static_assert(std::is_base_of<TH3, T>::value, "the requested object type does not derive from TH3");
+    mHistograms.push_back(std::make_shared<T>(name.c_str(), "", nBinsX, lowerX, upperX, nBinsY, lowerY, upperY, nBinsZ, lowerZ, upperZ));
+    mAnalysisMetaInfo.nHistograms++;
+    mHasChanged = true;
+    return *(dynamic_cast<T*>(mHistograms.back().get()));
+  }
+  //
+  // retrieving meta information
+  //
+  /// getting the meta info of the analysis run
+  MCAnalysisMetaInfo& getAnalysisMetaInfo();
+  //
+  // verbosity
+  //
+  /// print separate the meta info
+  void printAnalysisMetaInfo() const;
+  // print histogram names, available options are "base", "range", "all". For more information see documenation of TH1::Print()
+  void printHistogramInfo(const std::string& option = "") const;
+  /// check for and create a directory
+  static bool createDirectory(const std::string& dir);
+
+ private:
+  /// convert between histogram types, accept/don't accept a nullptr as argument
+  template <typename T>
+  T* castHistogram(TH1* histogram, bool acceptNull = true)
+  {
+    if (!histogram && acceptNull) {
+      return nullptr;
+    }
+    if (!histogram) {
+      LOG(FATAL) << "Not casting nullptr.";
+      exit(1);
+    }
+    T* histoCasted = dynamic_cast<T*>(histogram);
+    if (!histoCasted) {
+      LOG(FATAL) << histogram->GetName() << " cannot be casted to " << typeid(T).name();
+      exit(1);
+    }
+    return histoCasted;
+  }
+  /// find a histogram, return nullptr if not present
+  TH1* findHistogram(const std::string& name);
+
+ private:
+  /// input file path
+  std::string mInputFilepath;
+  /// meta info of the analysis run
+  MCAnalysisMetaInfo mAnalysisMetaInfo;
+  /// histograms
+  std::vector<std::shared_ptr<TH1>> mHistograms;
+  /// flag to check whether object has been changed (since reading from file)
+  bool mHasChanged;
+
+  ClassDefNV(MCAnalysisFileWrapper, 1);
+};
+
+} // end namespace mcstepanalysis
+} // end namespace o2
+#endif /* MCANALYSIS_FILE_WRAPPER_H_ */

--- a/Utilities/MCStepLogger/include/MCStepLogger/MCAnalysisManager.h
+++ b/Utilities/MCStepLogger/include/MCStepLogger/MCAnalysisManager.h
@@ -1,0 +1,143 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/* Singleton class handling/steering single analyses and their lifecycle
+ * 1. registration
+ *    -> each analysis is automatically registered
+ *    -> the Analysis base class provides registration during construction so there is no
+ *       stand-alone analysis
+ * 2. bookkeeping of analyses objects (histograms and meta info)
+ *    -> an AnalysisFileHandler does the Bookkeeping of all objects produced during the analyses
+ * 3. initialize
+ *    -> steering all registered analyses to initialize their analysis objects
+ * 4. analyze
+ *    -> forwarding the steps and magnetic field calls per event to registered analyses
+ * 5. finalize
+ *    -> steering all analyses to finalize its objects
+ */
+#ifndef MCANALYSIS_MANAGER_H_
+#define MCANALYSIS_MANAGER_H_
+
+#include <string>
+#include <vector>
+
+#include "MCStepLogger/StepInfo.h"
+#include "MCStepLogger/MetaInfo.h"
+
+namespace o2
+{
+namespace mcstepanalysis
+{
+
+class MCAnalysis;
+class MCAnalysisFileWrapper;
+
+class MCAnalysisManager
+{
+ public:
+  // get singleton instance
+  static MCAnalysisManager& Instance()
+  {
+    static MCAnalysisManager inst;
+    return inst;
+  }
+  //
+  // steering from the outside world
+  //
+  /// check whether everything is fine before the run
+  bool checkReadiness() const;
+  /// run tha chain depending on the mode
+  void run(int nEvents = -1);
+  /// do a dryrun just to see what's in the MCStepLogger ROOT file
+  bool dryrun();
+  /// write produced analysis data to disk
+  void write(const std::string& directory) const;
+  /// terminate, reset everything
+  void terminate();
+  //
+  // setting
+  //
+  /// set the path to the MCStepLogger input file path
+  void setInputFilepath(const std::string& filepath);
+  // register analysis to manager, done implicitly in the base Analysis class during construction
+  void registerAnalysis(MCAnalysis* analysis);
+  /// label for an analysis run (e.g. 'GEANT4_allModules')
+  void setLabel(const std::string& label);
+  /// name of the TTree of the MCStepLogger output
+  void setStepLoggerTreename(const std::string& treename);
+  //
+  // getting
+  //
+  /// get current event number
+  int getEventNumber() const;
+  // volume name by id
+  void getLookupVolName(int volId, std::string& name) const;
+  /// module name by volume ID
+  void getLookupModName(int volId, std::string& name) const;
+  /// medium name by volume ID
+  void getLookupMedName(int volId, std::string& name) const;
+  /// PDG ID by track ID
+  void getLookupPDG(int trackId, int& id) const;
+  /// parent track ID by track ID
+  void getLookupParent(int trackId, int& parentId) const;
+  //
+  // verbosity
+  //
+  /// print registered analyses
+  void printAnalyses() const;
+
+ private:
+  // don't allow uncontrolled construction of AnalysisManager objects
+  MCAnalysisManager() = default;
+  MCAnalysisManager operator=(const MCAnalysisManager&) = delete;
+  MCAnalysisManager(const MCAnalysisManager&) = delete;
+  //
+  // running the machinery
+  //
+  /// initialize AnalysisManager and registered analyses
+  void initialize();
+  /// analyse events and forward vectors of step and magnetic field info to single analyses
+  bool analyze(int nEvents = -1, bool isDryrun = false);
+  /// finalize all analyses
+  void finalize();
+
+ private:
+  /// holding the pointers to registered analyses
+  std::vector<MCAnalysis*> mAnalyses;
+  /// collect pointers which will be safely deleted which happens e.g. when the same analysis is registered twice
+  std::vector<MCAnalysis*> mAnalysesToDump;
+  /// keep track of status of MCAnalysisManager
+  bool mIsInitialized = false;
+  bool mIsAnalyzed = false;
+  /// the input file the analysis is conducted on
+  std::string mInputFilepath = "";
+  /// treename of step log data
+  std::string mAnalysisTreename = defaults::defaultStepLoggerTTreeName;
+  /// label for analyses, this is the same for all analyses since it depends on the simulation run and not on a specific analysis
+  std::string mLabel = defaults::defaultLabel;
+  /// keep track of which event is currently analysed
+  int mCurrentEventNumber = 0;
+  /// count overall number of steps
+  long mNSteps = 0;
+  // holding current step and magnetic field information of current event
+  /// information of single steps
+  std::vector<o2::StepInfo>* mCurrentStepInfo = nullptr;
+  /// information of magnetic field calls
+  std::vector<o2::MagCallInfo>* mCurrentMagCallInfo = nullptr;
+  /// some lookups to map IDs to names
+  o2::StepLookups* mCurrentLookups = nullptr;
+  /// analysis files histograms are written to
+  std::vector<MCAnalysisFileWrapper> mAnalysisFiles;
+
+  ClassDefNV(MCAnalysisManager, 1);
+};
+} // end namespace mcstepanalysis
+} // end namespace o2
+#endif /* MCANALYSISMANAGER_H_ */

--- a/Utilities/MCStepLogger/include/MCStepLogger/MCAnalysisUtilities.h
+++ b/Utilities/MCStepLogger/include/MCStepLogger/MCAnalysisUtilities.h
@@ -1,0 +1,36 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef MCANALYSIS_UTILITIES_H_
+#define MCANALYSIS_UTILITIES_H_
+
+#include <unordered_map>
+#include <vector>
+#include <string>
+
+#include "TH1.h"
+
+namespace o2
+{
+namespace mcstepanalysis
+{
+namespace utilities
+{
+/// compressing a histogram with alphanumeric bins and sorting accordingly
+/// for sorting option see ROOT's TH1::LabelsOption
+void ompressHistogram(TH1* histo, const char* sortOption);
+/// scale bin i by scaleVector[i-1]
+void scalePerBin(TH1* histo, const std::vector<float>& scaleVector);
+/// for histograms with alphanumeric labels scale bin with name "name" by scaleMap["name"]
+void scalePerBin(TH1* histo, const std::unordered_map<std::string, float>& scaleMap);
+} // namespace utilities
+} // namespace mstepanalysis
+} // o2
+#endif /* MCANALYSIS_UTILITIES_H_ */

--- a/Utilities/MCStepLogger/include/MCStepLogger/MetaInfo.h
+++ b/Utilities/MCStepLogger/include/MCStepLogger/MetaInfo.h
@@ -1,0 +1,60 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef MC_META_INFO_H_
+#define MC_META_INFO_H_
+
+#include <string>
+#include <vector>
+#include <iostream>
+
+namespace o2
+{
+namespace mcstepanalysis
+{
+namespace defaults
+{
+
+const std::string mcAnalysisMetaInfoName = "MCAnalysisMetaInfo";
+const std::string mcAnalysisObjectsDirName = "MCAnalysisObjects";
+const std::string defaultMCAnalysisName = "defaultMCAnalysisName";
+const std::string defaultLabel = "defaultLabel";
+const std::string defaultStepLoggerTTreeName = "StepLoggerTree";
+
+} // end namespace metainfonames
+
+struct MCAnalysisMetaInfo {
+  MCAnalysisMetaInfo()
+    : MCAnalysisMetaInfo(defaults::defaultMCAnalysisName, defaults::defaultLabel)
+  {
+  }
+  MCAnalysisMetaInfo(const std::string& an, const std::string& la)
+    : analysisName(an), nHistograms(0), label(la)
+  {
+  }
+  /// name of the analysis
+  std::string analysisName;
+  /// provide number of histograms for later sanity check
+  int nHistograms;
+  /// label, also shown in plots, especially useful for comparison plots
+  std::string label;
+  /// verbosity
+  void print() const
+  {
+    std::cout << "Analysis name: " << analysisName << "\n";
+    std::cout << "Label " << label << "\n";
+  }
+
+  ClassDefNV(MCAnalysisMetaInfo, 1);
+};
+
+} // end namespace mcstepanalysis
+} // end namespace o2
+#endif /* MC_META_INFO_H_ */

--- a/Utilities/MCStepLogger/include/MCStepLogger/ROOTIOUtilities.h
+++ b/Utilities/MCStepLogger/include/MCStepLogger/ROOTIOUtilities.h
@@ -1,0 +1,221 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/* Wrapping some functionality of handling ROOT files
+ * Hides details of tree and directory access and modification
+ */
+#ifndef ROOT_IO_UTILITIES_H_
+#define ROOT_IO_UTILITIES_H_
+
+#include <type_traits> // for std::is_pointer
+#include <string>
+#include <unordered_map>
+
+#include "TFile.h"
+#include "TTree.h"
+#include "TBranch.h"
+
+namespace o2
+{
+namespace mcstepanalysis
+{
+
+enum class ETFileMode : int { kREAD = 0,
+                              kUPDATE = 1,
+                              kRECREATE = 2 };
+
+class ROOTIOUtilities
+{
+ public:
+  /// default constructor
+  ROOTIOUtilities(const std::string& path = "", ETFileMode mode = ETFileMode::kREAD);
+  /// provide explicit desctructor
+  ~ROOTIOUtilities();
+  //
+  // additional steering
+  //
+  /// close everything and reset
+  void close(bool finalAction = true);
+  //
+  // TDirectory operations
+  //
+  /// change to directory sticking to current ETFileMode
+  bool changeToTDirectory(const std::string& dirname = "");
+  /// check whether an object with desired name is in current directory
+  bool hasObject(const std::string& name);
+  /// write method for standard ROOT TObjects
+  bool writeObject(const TObject* object);
+  /// write any object to a directory
+  template <typename T>
+  bool writeObject(const T object, const std::string& name)
+  {
+    static_assert(std::is_pointer<T>::value, "ROOTIOUtilities::writeObject: Expected a pointer for the object to be written.");
+    changeToTDirectory(mTDirectoryName);
+    return (mTDirectory->WriteObject(object, name.c_str()) > 0);
+  }
+  /// reading objects of any type by number of entry
+  template <typename T>
+  void readObject(T*& object, int entry = -1)
+  {
+    static_assert(std::is_pointer<T*>::value, "ROOTIOUtilities::readObject: Expected a pointer for the object to be read.");
+    changeToTDirectory(mTDirectoryName);
+    TKey* key = nullptr;
+
+    if (entry > -1 && entry < mTDirectoryEntries) {
+      key = dynamic_cast<TKey*>(mObjectList->At(entry));
+      object = key->ReadObject<T>();
+    } else if (entry < 0 && mTDirectoryCounter < mTDirectoryEntries) {
+      key = dynamic_cast<TKey*>(mObjectList->At(mTDirectoryCounter++));
+      object = key->ReadObject<T>();
+    } else {
+      object = nullptr;
+    }
+  }
+
+  template <typename T>
+  void readObject(T& object, int entry = -1)
+  {
+    changeToTDirectory(mTDirectoryName);
+    TKey* key = nullptr;
+    if (entry > -1 && entry < mTDirectoryEntries) {
+      key = dynamic_cast<TKey*>(mObjectList->At(entry));
+      object = *(key->ReadObject<T>());
+    } else if (entry < 0 && mTDirectoryCounter < mTDirectoryEntries) {
+      key = dynamic_cast<TKey*>(mObjectList->At(mTDirectoryCounter++));
+      object = *(key->ReadObject<T>());
+    }
+  }
+
+  /// reading objects of any type by name
+  template <typename T>
+  void readObject(T*& object, const std::string& name)
+  {
+    static_assert(std::is_pointer<T*>::value, "ROOTIOUtilities::readObject: Expected a pointer for the object to be read.");
+    changeToTDirectory(mTDirectoryName);
+    if (mTDirectoryEntries > 0) {
+      mTDirectory->GetObject(name.c_str(), object);
+    } else {
+      object = nullptr;
+    }
+  }
+
+  /// reading objects of any type by name
+  template <typename T>
+  void readObject(T& object, const std::string& name)
+  {
+    changeToTDirectory(mTDirectoryName);
+    if (mTDirectoryEntries > 0) {
+      T* objectCast = nullptr;
+      mTDirectory->GetObject(name.c_str(), objectCast);
+      if (objectCast) {
+        object = *(objectCast);
+      }
+    }
+  }
+  //
+  // TTree operations
+  //
+  /// silently change TTree sticking to current ETFileMode
+  bool changeToTTree(const std::string& treename);
+  /// silently change TTree changing ETFileMode on the fly
+  bool changeToTTree(const std::string& treename, ETFileMode mode);
+  /// set an address to some branchname
+  template <typename T>
+  bool setBranch(const std::string& branchname, T** address)
+  {
+    if (mTTreeOpened) {
+      // check whether branch is available
+      if (mTTree->GetBranch(branchname.c_str())) {
+        mTTree->SetBranchAddress(branchname.c_str(), address);
+        return true;
+      }
+      // if update or recreate, the branch might not be there yet, create it
+      else if (mTFileMode == ETFileMode::kRECREATE || mTFileMode == ETFileMode::kUPDATE) {
+        mTTree->Branch(branchname.c_str(), address);
+        return true;
+      }
+    }
+    return false;
+  }
+  /// reset internal counters
+  void resetTTreeCounter();
+  /// reset branch addresses
+  void resetTTreeConnection();
+  /// disconect from current TTree
+  bool closeTTree(bool finalAction = true);
+  /// either read or write. The decision is made automatically by checking the opening mode
+  /// of the TFile
+  bool processTTree(int event = -1);
+  /// do final actions depending on TFile mode
+  bool finalizeTTree();
+  //
+  // setting
+  //
+  /// set path to file to be accessed
+  void changeTFile(const std::string& path, ETFileMode mode = ETFileMode::kREAD);
+  /// set another ETFileMode
+  void changeTFileMode(ETFileMode mode);
+  //
+  // getting
+  //
+  /// return treename
+  std::string getTTreename() const;
+  /// get number of entries in TTree
+  int nEntries() const;
+
+ private:
+  /// open and close the TFile
+  bool openTFile();
+  /// close the TFile
+  void closeTFile(bool finalAction = true);
+  /// reset the object list read?written to a TDirectory
+  void resetKeyList();
+  /// fetch data from tree, event-wise
+  bool fetchData(int event = -1);
+  /// flush data to TTree
+  bool flushToTTree();
+
+ private:
+  /// from where the ROOT file was opened
+  std::string mFilepath;
+  /// internal pointer to ROOT file
+  TFile* mTFile;
+  /// additional flag to check whether ROOT file is opened
+  // \todo may be removed
+  bool mTFileOpened;
+  /// mode of the opened ROOT file
+  ETFileMode mTFileMode;
+  /// internal pointer to current TDirectory in ROOT file to easily jump
+  /// between directories
+  TDirectory* mTDirectory;
+  /// current name of directory
+  std::string mTDirectoryName;
+  /// list of objects in the current TDirectory
+  TList* mObjectList;
+  /// number of entries in the current TDirectory
+  int mTDirectoryEntries;
+  /// internal counter/position in current TDirectory
+  int mTDirectoryCounter;
+  /// pointer to current TTree
+  TTree* mTTree;
+  /// additional flag to check whether TTree is in use
+  bool mTTreeOpened;
+  /// internal position in current TTree
+  int mTTreeCounter;
+  /// number of entries in current TTree
+  int mTTreeEntries;
+  /// file modes
+  static const std::unordered_map<ETFileMode, const char*> mTFileModesNames;
+
+  ClassDefNV(ROOTIOUtilities, 1);
+};
+} // end of namespace mcstepanalysis
+} // end of namespace o2
+#endif /* ROOT_IO_UTILITIES_H_ */

--- a/Utilities/MCStepLogger/include/MCStepLogger/StepInfo.h
+++ b/Utilities/MCStepLogger/include/MCStepLogger/StepInfo.h
@@ -8,18 +8,6 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-//****************************************************************************
-//* This file is free software: you can redistribute it and/or modify        *
-//* it under the terms of the GNU General Public License as published by     *
-//* the Free Software Foundation, either version 3 of the License, or        *
-//* (at your option) any later version.                                      *
-//*                                                                          *
-//* Primary Authors: Sandro Wenzel <sandro.wenzel@cern.ch>                   *
-//*                                                                          *
-//* The authors make no claims about the suitability of this software for    *
-//* any purpose. It is provided "as is" without express or implied warranty. *
-//****************************************************************************
-
 #ifndef O2_STEPINFO
 #define O2_STEPINFO
 

--- a/Utilities/MCStepLogger/src/BasicMCAnalysis.cxx
+++ b/Utilities/MCStepLogger/src/BasicMCAnalysis.cxx
@@ -1,0 +1,279 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <algorithm>
+#include <iostream>
+
+#include "MCStepLogger/BasicMCAnalysis.h"
+#include "MCStepLogger/MCAnalysisUtilities.h"
+
+ClassImp(o2::mcstepanalysis::BasicMCAnalysis);
+
+using namespace o2::mcstepanalysis;
+
+BasicMCAnalysis::BasicMCAnalysis()
+  : MCAnalysis("BasicMCAnalysis")
+{
+}
+
+void BasicMCAnalysis::initialize()
+{
+  // number of events
+  histNEvents = getHistogram<TH1D>("nEvents", 1, 0., 1.);
+  // number of tracks over all events
+  histNTracks = getHistogram<TH1D>("nTracks", 1, 0., 1.);
+  // number of tracks averaged over number of events
+  histNTracksPerEvent = getHistogram<TH1D>("nTracksPerEvent", 1, 0., 1.);
+  // number of tracks mapped to particles' PDG ID averaged over number of events
+  histNTracksPerPDGPerEvent = getHistogram<TH1D>("nTracksPerPDGPerEvent", 1, 0., 1.);
+  // relative number of tracks mapped to particles' PDG ID averaged over number of events
+  histRelNTracksPerPDGPerEvent = getHistogram<TH1D>("relNTracksPerPDGPerEvent", 1, 0., 1.);
+  // count total number of steps including all events
+  histNSteps = getHistogram<TH1D>("nSteps", 1, 0., 1.);
+  // number of steps averaged over number of events
+  histNStepsPerEvent = getHistogram<TH1D>("nStepsPerEvent", 1, 0., 1.);
+  // number of steps per volume averaged over number of events
+  histNStepsPerVolPerEvent = getHistogram<TH1D>("nStepsPerVolPerEvent", 1, 0., 1.);
+  // relative number of steps per volume averaged over number of events
+  histRelNStepsPerVolPerEvent = getHistogram<TH1D>("relNStepsPerVolPerEvent", 1, 0., 1.);
+  // number of steps made by particles of certain PDG ID averaged over number of events
+  histNStepsPerPDGPerEvent = getHistogram<TH1D>("nStepsPerPDGPerEvent", 1, 0., 1.);
+  // relative number of steps made by particles of certain PDG ID averaged over number of events
+  histRelNStepsPerPDGPerEvent = getHistogram<TH1D>("relNStepsPerPDGPerEvent", 1, 0., 1.);
+  // histogram of x coordinates of steps averaged over number of events
+  histStepsXPerEvent = getHistogram<TH1D>("stepsXPerEvent", 100, -2100., 2100.);
+  // histogram of y coordinates of steps averaged over number of events
+  histStepsYPerEvent = getHistogram<TH1D>("stepsYPerEvent", 100, -2100., 2100.);
+  // histogram of z coordinates of steps averaged over number of events
+  histStepsZPerEvent = getHistogram<TH1D>("stepsZPerEvent", 100, -3100., 3100.);
+  // overall average step size per event averaged over number of events
+  histMeanStepSizePerEvent = getHistogram<TH1D>("meanStepSizePerEvent", 1, 0., 1.);
+  // average step size per event per volume averaged over number of events
+  histMeanStepSizePerVolPerEvent = getHistogram<TH1D>("meanStepSizePerVolPerEvent", 1, 0., 1.);
+  // average step size per event per PDG averaged over number of events
+  histMeanStepSizePerPDGPerEvent = getHistogram<TH1D>("meanStepSizePerPDGPerEvent", 1, 0., 1.);
+  // counting all step sizes per event averaged over number of events
+  histStepSizesPerEvent = getHistogram<TH1D>("stepSizesPerEvent", 50, 0., 250.);
+  // steps in the r-z plane
+  histRZ = getHistogram<TH2D>("RZOccupancy", 200, -3000., 3000., 200, 0., 3000.);
+  // total number of secondaries averaged over number of events
+  histNSecondariesPerEvent = getHistogram<TH1D>("nSecondariesPerEvent", 1, 0., 1.);
+  // number of secondaries per volume averaged over number of events
+  histNSecondariesPerVolPerEvent = getHistogram<TH1D>("nSecondariesPerVolPerEvent", 1, 0., 1.);
+  // number of calls to magnetic field per volume averaged over number of events
+  histMagFieldCallsPerVolPerEvent = getHistogram<TH1D>("magFieldCallsPerVolPerEvent", 1, 0., 1.);
+  // number of calls to magnetic field (with small abs. value) per volume averaged over number of events
+  histSmallMagFieldCallsPerVolPerEvent = getHistogram<TH1D>("smallMagFieldCallsPerVolPerEvent", 1, 0., 1.);
+  // count the number of volumes traversed
+  histNVols = getHistogram<TH1I>("nVolumes", 1, 0., 1.);
+  // helper to keep track of all different volume IDs accross events
+  volIds.clear();
+  // helper to check in how many events a certain PDG was present
+  volPresent.clear();
+  // helper to check in how many events a certain volume was traversed
+  pdgPresent.clear();
+}
+
+void BasicMCAnalysis::analyze(const std::vector<StepInfo>* const steps, const std::vector<MagCallInfo>* const magCalls)
+{
+  // first of all, count events
+  histNEvents->Fill(0.5);
+  // to store the volume name
+  std::string volName = "";
+  // loop over magnetic field calls
+  for (const auto& call : *magCalls) {
+    if (call.stepid < 0) {
+      continue;
+    }
+    auto step = steps->operator[](call.stepid);
+    mAnalysisManager->getLookupVolName(step.volId, volName);
+    if (call.B < 0.01) {
+      histSmallMagFieldCallsPerVolPerEvent->Fill(volName.c_str(), 1.);
+    }
+    histMagFieldCallsPerVolPerEvent->Fill(volName.c_str(), 1.);
+  }
+
+  // total number of steps in this event
+  int nSteps = 0;
+  // to store particle ID
+  int pdgId = 0;
+  // get the mean step size per event
+  float meanStepSizePerEvent = 0.;
+  // monitor number of different tracks
+  std::vector<int> tracks;
+  // step sizes per volume id in one event
+  std::vector<float> stepSizesPerVol;
+  // number of steps per volume ID in this event
+  std::vector<int> nStepsPerVol;
+  // steps sizes per PDG ID in one event, use a map here since PDG IDs can be large (~10^10)
+  // don't attempt to handle such a vector
+  std::unordered_map<int, float> stepSizesPerPDGMap;
+  // number of steps per PDG ID in this event
+  std::unordered_map<int, int> nStepsPerPDGMap;
+
+  // loop over all steps in an event
+  for (const auto& step : *steps) {
+    // prepare for PDG ids and volume names
+    mAnalysisManager->getLookupPDG(step.trackID, pdgId);
+    mAnalysisManager->getLookupVolName(step.volId, volName);
+    // first increment the total number of steps over all events
+    nSteps++;
+
+    // avoid double counting of tracks in an event, so check if track ID is already registered
+    if (std::find(tracks.begin(), tracks.end(), step.trackID) == tracks.end() && step.trackID > -1) {
+      // if not, there is a new track
+      tracks.push_back(step.trackID);
+      // increment track per PDG ID and treat PDGs as alphanumeric labels, so we can easily deflate later
+      histNTracksPerPDGPerEvent->Fill(std::to_string(pdgId).c_str(), 1.);
+    }
+    // summarize all volume Ids over all events to see, how many volumes were traversed in total
+    if (std::find(volIds.begin(), volIds.end(), step.volId) == volIds.end() && step.volId > -1) {
+      volIds.push_back(step.volId);
+    }
+
+    // get the spatial coordinates of this step
+    histStepsXPerEvent->Fill(step.x);
+    histStepsYPerEvent->Fill(step.y);
+    histStepsZPerEvent->Fill(step.z);
+    histRZ->Fill(step.z, std::sqrt(step.x * step.x + step.y * step.y));
+    // extract the step length
+    float stepLength = 0.;
+    // be save and check whether there are e.g. NaNs (happened!)
+    if (std::isfinite(step.step) && step.step > 0.) {
+      stepLength = step.step;
+    }
+    // summarise all steps sizes
+    histStepSizesPerEvent->Fill(stepLength);
+    // summarise steps sizes per volume in this event
+    if (stepSizesPerVol.size() <= step.volId) {
+      stepSizesPerVol.resize(step.volId + 1, 0.);
+      nStepsPerVol.resize(step.volId + 1, 0);
+    }
+    stepSizesPerVol[step.volId] += stepLength;
+    nStepsPerVol[step.volId]++;
+    // summarise step sizes per PDG ID in this event
+    if (stepSizesPerPDGMap.find(pdgId) == stepSizesPerPDGMap.end()) {
+      stepSizesPerPDGMap[pdgId] = stepLength;
+      nStepsPerPDGMap[pdgId] = 1;
+    } else {
+      stepSizesPerPDGMap[pdgId] += stepLength;
+      nStepsPerPDGMap[pdgId]++;
+    }
+
+    // secondaries
+    histNSecondariesPerEvent->Fill(0.5, step.nsecondaries);
+    histNSecondariesPerVolPerEvent->Fill(volName.c_str(), step.nsecondaries);
+  }
+  // add number of steps
+  histNSteps->Fill(0.5, nSteps);
+  histNSteps->SetEntries(nSteps);
+  histNStepsPerEvent->Fill(0.5, nSteps);
+  histNStepsPerEvent->SetEntries(nSteps);
+
+  // add number of tracks
+  histNTracks->Fill(0.5, tracks.size());
+  histNTracks->SetEntries(tracks.size());
+  histNTracksPerEvent->Fill(0.5, tracks.size());
+  histNTracksPerEvent->SetEntries(tracks.size());
+  // update number of steps, number of steps per volume, mean step length and mean step length per volume
+  float meanStepSizes = 0.;
+  for (int i = 0; i < nStepsPerVol.size(); i++) {
+    // if no step was made with that volume id, continue
+    if (nStepsPerVol[i] < 1) {
+      continue;
+    }
+    mAnalysisManager->getLookupVolName(i, volName);
+    // number of steps per volume
+    histNStepsPerVolPerEvent->Fill(volName.c_str(), nStepsPerVol[i]);
+    meanStepSizes += stepSizesPerVol[i];
+    histMeanStepSizePerVolPerEvent->Fill(volName.c_str(), stepSizesPerVol[i] / float(nStepsPerVol[i]));
+    // check in how many events a certain volume was present
+    if (volPresent.find(volName) == volPresent.end()) {
+      volPresent.insert(std::pair<std::string, float>(volName, 1.));
+    } else {
+      volPresent[volName]++;
+    }
+  }
+  histNStepsPerVolPerEvent->SetEntries(nSteps);
+  histMeanStepSizePerEvent->Fill(0.5, meanStepSizes / float(nSteps));
+  // since the step size is the difference between 2 points in 3D space,
+  // the exact number of entries is nSteps-nTracks, however nTracks << nSteps is expected
+  histMeanStepSizePerEvent->SetEntries(nSteps);
+  histMeanStepSizePerVolPerEvent->SetEntries(nSteps);
+  // number of steps per PDG ID and mean step length per PDG ID
+  for (auto& sp : nStepsPerPDGMap) {
+    std::string pdgString(std::to_string(sp.first));
+    // number of steps per volume
+    histNStepsPerPDGPerEvent->Fill(pdgString.c_str(), sp.second);
+    histMeanStepSizePerPDGPerEvent->Fill(pdgString.c_str(), stepSizesPerPDGMap[sp.first] / float(sp.second));
+    // check in how many events a certain volume was present
+    if (pdgPresent.find(pdgString) == pdgPresent.end()) {
+      pdgPresent.insert(std::pair<std::string, float>(pdgString, 1.));
+    } else {
+      pdgPresent[pdgString]++;
+    }
+  }
+  histNStepsPerPDGPerEvent->SetEntries(nSteps);
+  histMeanStepSizePerPDGPerEvent->SetEntries(nSteps);
+}
+
+void BasicMCAnalysis::finalize()
+{
+  // fill and update (e.g. scaling) some histograms
+  histNVols->Fill(0.5, volIds.size());
+  histNVols->SetEntries(volIds.size());
+
+  // just normalise over all events
+  histNStepsPerEvent->Scale(1. / histNEvents->GetEntries());
+  histNTracksPerEvent->Scale(1. / histNEvents->GetEntries());
+  histNSecondariesPerEvent->Scale(1. / histNEvents->GetEntries());
+  histStepsXPerEvent->Scale(1. / histNEvents->GetEntries());
+  histStepsYPerEvent->Scale(1. / histNEvents->GetEntries());
+  histStepsZPerEvent->Scale(1. / histNEvents->GetEntries());
+  histStepSizesPerEvent->Scale(1. / histNEvents->GetEntries());
+  histMeanStepSizePerEvent->Scale(1. / histNEvents->GetEntries());
+  // normalize per volume to number of events where a certain volume was present
+  for (auto& vp : volPresent) {
+    vp.second = 1. / vp.second;
+  }
+  for (auto& pp : pdgPresent) {
+    pp.second = 1. / pp.second;
+  }
+  // scale histograms bin-wise
+  utilities::scalePerBin(histNStepsPerVolPerEvent, volPresent);
+  utilities::scalePerBin(histMagFieldCallsPerVolPerEvent, volPresent);
+  utilities::scalePerBin(histSmallMagFieldCallsPerVolPerEvent, volPresent);
+  utilities::scalePerBin(histNSecondariesPerVolPerEvent, volPresent);
+  utilities::scalePerBin(histMeanStepSizePerVolPerEvent, volPresent);
+  utilities::scalePerBin(histMeanStepSizePerPDGPerEvent, pdgPresent);
+  utilities::scalePerBin(histNStepsPerPDGPerEvent, pdgPresent);
+  utilities::scalePerBin(histNTracksPerPDGPerEvent, pdgPresent);
+
+  int nVolBins = histNStepsPerVolPerEvent->GetNbinsX();
+  for (int i = 1; i < nVolBins + 1; i++) {
+    histRelNStepsPerVolPerEvent->Fill(histNStepsPerVolPerEvent->GetXaxis()->GetBinLabel(i), histNStepsPerVolPerEvent->GetBinContent(i));
+  }
+  histRelNStepsPerVolPerEvent->Scale(1. / double(histNStepsPerEvent->GetMaximum()));
+  histRelNStepsPerVolPerEvent->SetEntries(histNSteps->GetEntries());
+
+  int nPDGBins = histNTracksPerPDGPerEvent->GetNbinsX();
+  for (int i = 1; i < nPDGBins + 1; i++) {
+    histRelNTracksPerPDGPerEvent->Fill(histNTracksPerPDGPerEvent->GetXaxis()->GetBinLabel(i), histNTracksPerPDGPerEvent->GetBinContent(i));
+  }
+  histRelNTracksPerPDGPerEvent->Scale(1. / double(histNTracksPerEvent->GetMaximum()));
+  histRelNTracksPerPDGPerEvent->SetEntries(histNTracks->GetEntries());
+
+  nPDGBins = histNStepsPerPDGPerEvent->GetNbinsX();
+  for (int i = 1; i < nPDGBins + 1; i++) {
+    histRelNStepsPerPDGPerEvent->Fill(histNStepsPerPDGPerEvent->GetXaxis()->GetBinLabel(i), histNStepsPerPDGPerEvent->GetBinContent(i));
+  }
+  histRelNStepsPerPDGPerEvent->Scale(1. / double(histNStepsPerEvent->GetMaximum()));
+  histRelNStepsPerPDGPerEvent->SetEntries(histNSteps->GetEntries());
+}

--- a/Utilities/MCStepLogger/src/MCAnalysis.cxx
+++ b/Utilities/MCStepLogger/src/MCAnalysis.cxx
@@ -1,0 +1,25 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "MCStepLogger/MCAnalysis.h"
+#include "MCStepLogger/MCAnalysisManager.h"
+
+ClassImp(o2::mcstepanalysis::MCAnalysis);
+
+using namespace o2::mcstepanalysis;
+
+MCAnalysis::MCAnalysis(const std::string& name)
+  : mName(name), mIsInitialized(false), mAnalysisFile(nullptr)
+{
+  // Automatically register to manager
+  auto& anamgr = MCAnalysisManager::Instance();
+  anamgr.registerAnalysis(this);
+  mAnalysisManager = &anamgr;
+}

--- a/Utilities/MCStepLogger/src/MCAnalysisFileWrapper.cxx
+++ b/Utilities/MCStepLogger/src/MCAnalysisFileWrapper.cxx
@@ -1,0 +1,139 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <iostream>
+
+#include "TSystem.h" // to check for and create directories
+
+#include "FairLogger.h"
+
+#include "MCStepLogger/MCAnalysisFileWrapper.h"
+#include "MCStepLogger/ROOTIOUtilities.h"
+
+ClassImp(o2::mcstepanalysis::MCAnalysisFileWrapper);
+
+using namespace o2::mcstepanalysis;
+
+MCAnalysisFileWrapper::MCAnalysisFileWrapper()
+  : mInputFilepath(""), mAnalysisMetaInfo(MCAnalysisMetaInfo()), mHasChanged(false)
+{
+  mHistograms.clear();
+}
+
+bool MCAnalysisFileWrapper::isSane() const
+{
+  bool sane = true;
+  // so far only check number of histograms vs. expected number of histograms
+  if (mAnalysisMetaInfo.nHistograms != mHistograms.size()) {
+    LOG(WARNING) << "Histograms are corrupted: found " << mHistograms.size() << " but " << mAnalysisMetaInfo.nHistograms << " expected.";
+    sane = false;
+  }
+  return sane;
+}
+
+bool MCAnalysisFileWrapper::read(const std::string& filepath)
+{
+  ROOTIOUtilities rootutil(filepath);
+  // look for and read meta info of step logger and analysis run
+  if (!rootutil.hasObject(defaults::mcAnalysisMetaInfoName)) {
+    rootutil.close();
+    return false;
+  }
+  rootutil.readObject(mAnalysisMetaInfo, defaults::mcAnalysisMetaInfoName);
+
+  // try to recover histograms
+  TH1* histoRecover = nullptr;
+
+  if (!rootutil.changeToTDirectory(defaults::mcAnalysisObjectsDirName)) {
+    rootutil.close();
+    return false;
+  }
+  while (true) {
+    rootutil.readObject(histoRecover);
+    // assuming that all objects have been read
+    if (!histoRecover) {
+      break;
+    }
+    TH1* histo = dynamic_cast<TH1*>(histoRecover->Clone());
+    histo->SetDirectory(0);
+    mHistograms.push_back(std::shared_ptr<TH1>(histo));
+  }
+  rootutil.close();
+  isSane();
+  return true;
+}
+
+void MCAnalysisFileWrapper::write(const std::string& filedir) const
+{
+  if (!isSane()) {
+    LOG(ERROR) << "Analysis file cannot be written, see above.";
+    return;
+  }
+  const std::string outputDir = filedir + "/" + mAnalysisMetaInfo.analysisName;
+  if (!createDirectory(outputDir)) {
+    LOG(ERROR) << "Directory " << outputDir << " could not be created for analysis " << mAnalysisMetaInfo.analysisName << ". Skip...\n";
+    return;
+  }
+  ROOTIOUtilities rootutil(outputDir + "/Analysis.root", ETFileMode::kRECREATE);
+
+  LOG(INFO) << "Save histograms of analysis " << mAnalysisMetaInfo.analysisName << "\n\tat " << filedir << "\n";
+  rootutil.writeObject(&mAnalysisMetaInfo, defaults::mcAnalysisMetaInfoName);
+  rootutil.changeToTDirectory(defaults::mcAnalysisObjectsDirName);
+  for (const auto& h : mHistograms) {
+    rootutil.writeObject(h.get());
+  }
+  rootutil.close();
+}
+
+TH1* MCAnalysisFileWrapper::findHistogram(const std::string& name)
+{
+  for (auto& h : mHistograms) {
+    if (name.compare(h->GetName()) == 0) {
+      return h.get();
+    }
+  }
+  return nullptr;
+}
+
+bool MCAnalysisFileWrapper::hasHistogram(const std::string& name)
+{
+  return (findHistogram(name) != nullptr);
+}
+
+bool MCAnalysisFileWrapper::createDirectory(const std::string& dir)
+{
+  gSystem->mkdir(dir.c_str(), true);
+  // according to documentation returns false if possible to access
+  return (gSystem->AccessPathName(dir.c_str()) == 0);
+}
+
+/// getting the meta info of the analysis run
+MCAnalysisMetaInfo& MCAnalysisFileWrapper::getAnalysisMetaInfo()
+{
+  return mAnalysisMetaInfo;
+}
+
+void MCAnalysisFileWrapper::printAnalysisMetaInfo() const
+{
+  LOG(INFO) << "Meta info of analysis file";
+  mAnalysisMetaInfo.print();
+}
+
+void MCAnalysisFileWrapper::printHistogramInfo(const std::string& option) const
+{
+  if (mHistograms.empty()) {
+    return;
+  }
+  LOG(INFO) << "Histograms of analysis file";
+  for (auto& h : mHistograms) {
+    std::cout << "Histogram of class " << h->ClassName() << std::endl;
+    h->Print(option.c_str());
+  }
+}

--- a/Utilities/MCStepLogger/src/MCAnalysisManager.cxx
+++ b/Utilities/MCStepLogger/src/MCAnalysisManager.cxx
@@ -1,0 +1,285 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <iostream>
+
+#include "FairLogger.h"
+
+#include "MCStepLogger/MCAnalysisManager.h"
+#include "MCStepLogger/MCAnalysis.h"
+#include "MCStepLogger/MCAnalysisFileWrapper.h"
+#include "MCStepLogger/ROOTIOUtilities.h"
+
+ClassImp(o2::mcstepanalysis::MCAnalysisManager);
+
+using namespace o2::mcstepanalysis;
+
+void MCAnalysisManager::setInputFilepath(const std::string& filepath)
+{
+  mInputFilepath = filepath;
+}
+
+void MCAnalysisManager::registerAnalysis(MCAnalysis* analysis)
+{
+  if (!mIsInitialized) {
+    for (auto& a : mAnalyses) {
+      if (a->name().compare(analysis->name()) == 0) {
+        LOG(ERROR) << "Analysis " << analysis->name() << " already present...skip";
+        mAnalysesToDump.push_back(analysis);
+      }
+    }
+    mAnalyses.push_back(analysis);
+  }
+}
+
+bool MCAnalysisManager::checkReadiness() const
+{
+  std::string errorMessage;
+  if (mInputFilepath.empty()) {
+    errorMessage += "Input file required...\n";
+  }
+  if (mLabel.empty()) {
+    errorMessage += "Label required...\n";
+  }
+  if (errorMessage.empty()) {
+    return true;
+  }
+  LOG(ERROR) << errorMessage;
+  return false;
+}
+
+void MCAnalysisManager::run(int nEvents)
+{
+  if (!checkReadiness()) {
+    LOG(ERROR) << "MCAnalysisManager not ready to run, errors occured";
+    exit(1);
+  }
+  initialize();
+  analyze(nEvents);
+  finalize();
+}
+
+bool MCAnalysisManager::dryrun()
+{
+  if (mInputFilepath.empty()) {
+    LOG(FATAL) << "Input file required...\n";
+    exit(1);
+  }
+  return analyze(-1, true);
+}
+
+void MCAnalysisManager::initialize()
+{
+  if (mIsInitialized) {
+    LOG(ERROR) << "Already initialized ==> not initialized again...";
+    return;
+  }
+  // get rid of all analyses not needed anymore
+  for (auto& a : mAnalysesToDump) {
+    delete a;
+  }
+  mAnalysesToDump.clear();
+
+  for (auto& a : mAnalyses) {
+    // prepare an analysis file and set first analysis meta info
+    mAnalysisFiles.emplace_back();
+    mAnalysisFiles.back().getAnalysisMetaInfo().label = mLabel;
+    mAnalysisFiles.back().getAnalysisMetaInfo().analysisName = a->name();
+    a->setAnalysisFile(mAnalysisFiles.back());
+    a->initialize();
+    a->isInitialized(true);
+  }
+  mIsInitialized = true;
+}
+
+bool MCAnalysisManager::analyze(int nEvents, bool isDryrun)
+{
+  if (!mIsInitialized && !isDryrun) {
+    LOG(ERROR) << "Not yet initialized ==> nothing to analyze...";
+    return false;
+  }
+  // taking only the first entry is a hack! \todo change this by enabling also for TChains
+  ROOTIOUtilities rootutil(mInputFilepath);
+
+  // this is by default opening the file in READ mode
+  if (!rootutil.changeToTTree(mAnalysisTreename)) {
+    rootutil.close();
+    if (isDryrun) {
+      return false;
+    }
+    LOG(FATAL) << "Tree " << mAnalysisTreename << " could not be found in file " << mInputFilepath;
+    exit(1);
+  }
+  // print warning if desired number of entries is bigger than number of present entries
+  if (nEvents > rootutil.nEntries()) {
+    LOG(WARNING) << "You want to process " << nEvents << ", however only " << rootutil.nEntries() << " are present.";
+  }
+
+  // prepare variables and connect to branches
+  // \todo align branch names with MCStepLogger and get rid of hard coded names
+  if (!rootutil.setBranch("Steps", &mCurrentStepInfo) || !rootutil.setBranch("Calls", &mCurrentMagCallInfo) || !rootutil.setBranch("Lookups", &mCurrentLookups)) {
+    rootutil.close();
+    if (isDryrun) {
+      return false;
+    }
+    LOG(FATAL) << "Cannot find required branches in TTree " << mAnalysisTreename;
+    exit(1);
+  }
+  // process tree and analyze
+  while (rootutil.processTTree()) {
+    if (nEvents <= mCurrentEventNumber && nEvents > 0) {
+      break;
+    }
+    // check whether all pointers to MCStepLogger branches are set...
+    if (mCurrentStepInfo == nullptr || mCurrentMagCallInfo == nullptr || mCurrentLookups == nullptr) {
+      rootutil.close();
+      if (isDryrun) {
+        return false;
+      }
+      LOG(FATAL) << "Obtained nullptrs while processing TTree " << mAnalysisTreename;
+      exit(1);
+    }
+    // ... if so, next event
+    mCurrentEventNumber++;
+    mNSteps += mCurrentStepInfo->size();
+
+    std::cout << "---> Event " << mCurrentEventNumber << " <---\n";
+    std::cout << "#steps: " << mCurrentStepInfo->size() << "\n";
+    std::cout << "#mag field calls: " << mCurrentMagCallInfo->size() << "\n";
+    if (!isDryrun) {
+      std::cout << "\nStart..." << std::endl;
+      for (auto& a : mAnalyses) {
+        std::cout << "\t\tCall analysis " << a->name() << std::endl;
+        a->analyze(mCurrentStepInfo, mCurrentMagCallInfo);
+      }
+      std::cout << "Done\n";
+    }
+  }
+  rootutil.close();
+  if (!isDryrun) {
+    LOG(INFO) << "Analysis run on file " << mInputFilepath << " done.";
+    mIsAnalyzed = true;
+  } else {
+    mCurrentEventNumber = 0;
+    mNSteps = 0;
+  }
+  return true;
+}
+
+void MCAnalysisManager::finalize()
+{
+  if (!mIsAnalyzed) {
+    LOG(ERROR) << "Not yet analyzed ==> nothing to finalize...";
+    return;
+  }
+  for (auto& a : mAnalyses) {
+    a->finalize();
+  }
+}
+
+void MCAnalysisManager::write(const std::string& directory) const
+{
+  for (auto& af : mAnalysisFiles) {
+    af.write(directory);
+  }
+}
+
+void MCAnalysisManager::terminate()
+{
+  LOG(DEBUG) << "Terminate MCAnalysisManager...";
+  mIsInitialized = false;
+  mIsAnalyzed = false;
+  mCurrentEventNumber = 0;
+  mNSteps = 0;
+  mCurrentStepInfo = nullptr;
+  mCurrentMagCallInfo = nullptr;
+  mCurrentLookups = nullptr;
+  // tell each analysis to terminat/reset
+  for (auto& a : mAnalyses) {
+    a->isInitialized(false);
+  }
+}
+
+void MCAnalysisManager::setLabel(const std::string& label)
+{
+  mLabel = label;
+}
+
+void MCAnalysisManager::setStepLoggerTreename(const std::string& treename)
+{
+  mAnalysisTreename = treename;
+}
+
+void MCAnalysisManager::printAnalyses() const
+{
+  LOG(INFO) << "Analyses registered with MCAnalysisManager are:";
+  for (auto& a : mAnalyses) {
+    std::cout << "\t" << a->name() << "\n";
+  }
+}
+
+int MCAnalysisManager::getEventNumber() const
+{
+  return mCurrentEventNumber;
+}
+
+void MCAnalysisManager::getLookupVolName(int volId, std::string& name) const
+{
+  if (volId > -1 && volId < mCurrentLookups->volidtovolname.size()) {
+    if (mCurrentLookups->volidtovolname[volId] != nullptr ||
+        mCurrentLookups->volidtovolname[volId]->size() != 0) {
+      name = *(mCurrentLookups->volidtovolname[volId]);
+      return;
+    }
+  }
+  name = "UNKNOWNVOLNAME";
+}
+
+void MCAnalysisManager::getLookupModName(int volId, std::string& name) const
+{
+  if (volId > -1 && volId < mCurrentLookups->volidtomodule.size()) {
+    if (mCurrentLookups->volidtomodule[volId] != nullptr ||
+        mCurrentLookups->volidtomodule[volId]->size() != 0) {
+      name = *(mCurrentLookups->volidtomodule[volId]);
+      return;
+    }
+  }
+  name = "UNKNOWNMODNAME";
+}
+
+void MCAnalysisManager::getLookupMedName(int volId, std::string& name) const
+{
+  if (volId > -1 && volId < mCurrentLookups->volidtomedium.size()) {
+    if (mCurrentLookups->volidtomedium[volId] != nullptr ||
+        mCurrentLookups->volidtomedium[volId]->size() != 0) {
+      name = *(mCurrentLookups->volidtomedium[volId]);
+      return;
+    }
+  }
+  name = "UNKNOWNMEDNAME";
+}
+
+void MCAnalysisManager::getLookupPDG(int trackId, int& id) const
+{
+  if (trackId > -1 && trackId < mCurrentLookups->tracktopdg.size()) {
+    id = mCurrentLookups->tracktopdg[trackId];
+    return;
+  }
+  id = -2;
+}
+
+void MCAnalysisManager::getLookupParent(int trackId, int& parentId) const
+{
+  parentId = -2;
+  if (trackId > -1 && trackId < mCurrentLookups->tracktoparent.size()) {
+    parentId = mCurrentLookups->tracktoparent[trackId];
+    return;
+  }
+}

--- a/Utilities/MCStepLogger/src/MCAnalysisUtilities.cxx
+++ b/Utilities/MCStepLogger/src/MCAnalysisUtilities.cxx
@@ -1,0 +1,63 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "TH1.h"
+
+#include "MCStepLogger/MCAnalysisUtilities.h"
+
+namespace o2
+{
+namespace mcstepanalysis
+{
+namespace utilities
+{
+
+void compressHistogram(TH1* histo, const char* sortOption)
+{
+  if (histo->GetXaxis()->IsAlphanumeric() && histo->GetEntries() > 0) {
+    // first get rid of all bins without entries
+    histo->LabelsOption(">", "X");
+    histo->LabelsDeflate("X");
+    if (strcmp(sortOption, "") != 0) {
+      histo->LabelsOption(sortOption, "X");
+    }
+  }
+}
+void scalePerBin(TH1* histo, const std::vector<float>& scaleVector)
+{
+  if (histo->GetXaxis()->IsAlphanumeric()) {
+    return;
+  }
+  for (int i = 1; scaleVector.size() + 1; i++) {
+    int bin = histo->FindBin(i);
+    if (bin == i) {
+      histo->SetBinContent(bin, histo->GetBinContent(bin) * scaleVector[i]);
+      // to avoid incrementing the number of entries
+      histo->SetEntries(histo->GetEntries() - 1);
+    }
+  }
+}
+void scalePerBin(TH1* histo, const std::unordered_map<std::string, float>& scaleMap)
+{
+  if (histo->GetXaxis()->IsAlphanumeric()) {
+    for (const auto& sm : scaleMap) {
+      int bin = histo->GetXaxis()->FindFixBin(sm.first.c_str());
+      if (bin > -1) {
+        histo->SetBinContent(bin, histo->GetBinContent(bin) * sm.second);
+        // to avoid incrementing the number of entries
+        histo->SetEntries(histo->GetEntries() - 1);
+      }
+    }
+  }
+}
+
+} // namespace utilities
+} // namespace mstepanalysis
+} // o2

--- a/Utilities/MCStepLogger/src/MCStepInterceptor.cxx
+++ b/Utilities/MCStepLogger/src/MCStepInterceptor.cxx
@@ -8,18 +8,6 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-//****************************************************************************
-//* This file is free software: you can redistribute it and/or modify        *
-//* it under the terms of the GNU General Public License as published by     *
-//* the Free Software Foundation, either version 3 of the License, or        *
-//* (at your option) any later version.                                      *
-//*                                                                          *
-//* Primary Authors: Sandro Wenzel <sandro.wenzel@cern.ch>                   *
-//*                                                                          *
-//* The authors make no claims about the suitability of this software for    *
-//* any purpose. It is provided "as is" without express or implied warranty. *
-//****************************************************************************
-
 //  @file   MCStepInterceptor.cxx
 //  @author Sandro Wenzel
 //  @since  2017-06-29

--- a/Utilities/MCStepLogger/src/MCStepLoggerLinkDef.h
+++ b/Utilities/MCStepLogger/src/MCStepLoggerLinkDef.h
@@ -24,6 +24,12 @@
 #pragma link C++ class std::vector<std::vector<TGeoVolume const *> *>+;
 #pragma link C++ class o2::VolInfoContainer+;
 #pragma link C++ class o2::StepLookups+;
-
+#pragma link C++ class o2::mcstepanalysis::MCAnalysis + ;
+#pragma link C++ class o2::mcstepanalysis::BasicMCAnalysis + ;
+#pragma link C++ class o2::mcstepanalysis::MCStepLoggerMetaInfo + ;
+#pragma link C++ class o2::mcstepanalysis::MCAnalysisMetaInfo + ;
+#pragma link C++ class o2::mcstepanalysis::MCAnalysisManager + ;
+#pragma link C++ class o2::mcstepanalysis::MCAnalysisFileWrapper + ;
+#pragma link C++ class o2::mcstepanalysis::ROOTIOUtilities + ;
 
 #endif

--- a/Utilities/MCStepLogger/src/ROOTIOUtilities.cxx
+++ b/Utilities/MCStepLogger/src/ROOTIOUtilities.cxx
@@ -1,0 +1,282 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "MCStepLogger/ROOTIOUtilities.h"
+
+ClassImp(o2::mcstepanalysis::ROOTIOUtilities);
+
+using namespace o2::mcstepanalysis;
+
+const std::unordered_map<ETFileMode, const char*> ROOTIOUtilities::mTFileModesNames = {
+  { ETFileMode::kREAD, "READ" },
+  { ETFileMode::kUPDATE, "UPDATE" },
+  { ETFileMode::kRECREATE, "RECREATE" }
+};
+
+ROOTIOUtilities::ROOTIOUtilities(const std::string& path, ETFileMode mode)
+  : mFilepath(path), mTFile(nullptr), mTFileOpened(false), mTFileMode(mode), mTDirectory(nullptr), mTDirectoryName(""), mObjectList(nullptr), mTDirectoryEntries(0), mTDirectoryCounter(0), mTTree(nullptr), mTTreeOpened(false), mTTreeCounter(0), mTTreeEntries(0)
+{
+}
+
+ROOTIOUtilities::~ROOTIOUtilities()
+{
+  close();
+}
+
+void ROOTIOUtilities::changeTFile(const std::string& path, ETFileMode mode)
+{
+  closeTFile();
+  mFilepath = path;
+  mTFileMode = mode;
+  mTDirectoryName = "";
+}
+
+void ROOTIOUtilities::changeTFileMode(ETFileMode mode)
+{
+  if (mode == mTFileMode) {
+    return;
+  }
+  mTFileMode = mode;
+  openTFile();
+  changeToTDirectory();
+  closeTTree();
+}
+
+bool ROOTIOUtilities::openTFile()
+{
+  auto it = mTFileModesNames.find(mTFileMode);
+
+  if (mTFileOpened) {
+    // check whether changing the mode is successful, if not, close the TFile
+    if (mTFile->ReOpen(it->second) < 0) {
+      closeTFile();
+    }
+  }
+  // if no TFile was opened or if it was closed due to failed mode change, try to open it again from scratch
+  if (!mTFileOpened && !mFilepath.empty()) {
+    mTFile = new TFile(mFilepath.c_str(), it->second);
+  }
+  if (mTFile) {
+    mTFile->cd();
+    mTDirectory = mTFile->GetDirectory(0);
+    mTFileOpened = true;
+  }
+  return mTFileOpened;
+}
+
+void ROOTIOUtilities::closeTFile(bool finalAction)
+{
+  if (mTFileOpened) {
+    // do final stuff if finalAction flag is set
+    if (finalAction) {
+      finalizeTTree();
+    }
+    // disconnect addresses from TTree and reset internals
+    closeTTree();
+    mTFile->Close();
+    // free memory and reset open status
+    delete mTFile;
+    mTFile = nullptr;
+    mObjectList = nullptr;
+    mTDirectory = nullptr;
+    mTFileOpened = false;
+  }
+}
+void ROOTIOUtilities::close(bool finalAction)
+{
+  // so far, only the TFile needs to be closed
+  closeTFile(finalAction);
+}
+
+bool ROOTIOUtilities::changeToTDirectory(const std::string& dirname)
+{
+  // if file not yet opened
+  if (!mTFileOpened) {
+    openTFile();
+  }
+  // if it was already opened, check if we are already in the desired directory
+  else if (dirname.compare(mTDirectoryName) == 0) {
+    return true;
+  }
+  // now the file might be open
+  if (mTFileOpened) {
+    // update pointer to directory
+    mTDirectory = mTFile->GetDirectory(dirname.c_str());
+
+    if (mTDirectory) {
+      mTFile->cd(dirname.c_str());
+      mTDirectoryName = dirname;
+    } else if (mTFileMode == ETFileMode::kRECREATE || mTFileMode == ETFileMode::kUPDATE) {
+      mTDirectory = mTFile->mkdir(dirname.c_str());
+      // this could also fail e.g. if a directory above the root directory was desired
+      if (mTDirectory) {
+        mTFile->cd(dirname.c_str());
+        mTDirectoryName = dirname;
+      }
+    }
+  }
+  resetKeyList();
+  return (mTDirectory != nullptr);
+}
+
+bool ROOTIOUtilities::hasObject(const std::string& name)
+{
+  changeToTDirectory(mTDirectoryName);
+  TKey* key = nullptr;
+  TIter next(mObjectList);
+  while ((key = dynamic_cast<TKey*>(next()))) {
+    if (name.compare(key->GetName()) == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void ROOTIOUtilities::resetKeyList()
+{
+  if (mTDirectory) {
+    mObjectList = mTDirectory->GetListOfKeys();
+    mTDirectoryEntries = mObjectList->GetEntries();
+  } else {
+    mObjectList = nullptr;
+    mTDirectoryEntries = 0;
+  }
+  mTDirectoryCounter = 0;
+}
+
+bool ROOTIOUtilities::changeToTTree(const std::string& treename)
+{
+  // if file not yet opened
+  if (!mTFileOpened) {
+    // if it's not possible to open the desired file, just return
+    if (!openTFile()) {
+      return false;
+    }
+  }
+
+  // If desired treename is the same as the opened tree, keep it open but reset counters etc.
+  else if (mTTreeOpened) {
+    if (treename.compare(mTTree->GetName()) == 0) {
+      resetTTreeConnection();
+      return true;
+    }
+    // if it's a different tree, close it entirely
+    closeTTree();
+  }
+
+  // first, try to get existing TTree by name
+  mTTree = dynamic_cast<TTree*>(mTFile->Get(treename.c_str()));
+  // If it does not exist, try to create one depending on the file mode
+  if (!mTTree && (mTFileMode == ETFileMode::kRECREATE || mTFileMode == ETFileMode::kUPDATE)) {
+    mTTree = new TTree(treename.c_str(), treename.c_str());
+  }
+  // check, whether on of the former attempts was successful
+  if (mTTree) {
+    mTTreeOpened = true;
+    resetTTreeCounter();
+  }
+  return mTTreeOpened;
+}
+void ROOTIOUtilities::resetTTreeCounter()
+{
+  mTTreeCounter = 0;
+  if (mTTreeOpened) {
+    mTTreeEntries = mTTree->GetEntries();
+  } else {
+    mTTreeEntries = 0;
+  }
+}
+void ROOTIOUtilities::resetTTreeConnection()
+{
+  if (mTTreeOpened) {
+    mTTree->ResetBranchAddresses();
+    resetTTreeCounter();
+  }
+}
+bool ROOTIOUtilities::closeTTree(bool finalAction)
+{
+  bool success = true;
+  if (mTTreeOpened) {
+    if (finalAction) {
+      success = finalizeTTree();
+    }
+    resetTTreeConnection();
+    delete mTTree;
+    mTTreeOpened = false;
+    resetTTreeCounter();
+  }
+  return success;
+}
+
+bool ROOTIOUtilities::fetchData(int event)
+{
+  // is the tree even open?
+  if (!mTTreeOpened) {
+    return false;
+  }
+  // out of bounds?
+  if (event >= mTTreeEntries) {
+    return false;
+  }
+  int gotten = 0;
+  // specific entry required
+  if (event > -1) {
+    gotten = mTTree->GetEntry(event);
+  }
+  // just get the next one
+  else {
+    gotten = mTTree->GetEntry(mTTreeCounter++);
+  }
+  return (gotten > 0);
+}
+bool ROOTIOUtilities::flushToTTree()
+{
+  if (!mTTreeOpened) {
+    return false;
+  }
+  int success = mTTree->Fill();
+  return (success > -1);
+}
+bool ROOTIOUtilities::processTTree(int event)
+{
+  if ((mTFileOpened && mTFileMode == ETFileMode::kRECREATE) || mTFileMode == ETFileMode::kUPDATE) {
+    return flushToTTree();
+  } else {
+    return fetchData(event);
+  }
+}
+bool ROOTIOUtilities::finalizeTTree()
+{
+  if ((mTFileOpened && mTFileMode == ETFileMode::kRECREATE) || mTFileMode == ETFileMode::kUPDATE) {
+    return (mTFile->Write() > 0);
+  }
+  return false;
+}
+std::string ROOTIOUtilities::getTTreename() const
+{
+  if (mTTree) {
+    return mTTree->GetName();
+  }
+  return "UNKNOWNTTREE";
+}
+
+int ROOTIOUtilities::nEntries() const
+{
+  if (mTTreeOpened) {
+    return mTTreeEntries;
+  }
+  return -1;
+}
+
+bool ROOTIOUtilities::writeObject(const TObject* object)
+{
+  changeToTDirectory(mTDirectoryName);
+  return (object->Write() > 0);
+}

--- a/Utilities/MCStepLogger/src/StepInfo.cxx
+++ b/Utilities/MCStepLogger/src/StepInfo.cxx
@@ -8,24 +8,12 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-//****************************************************************************
-//* This file is free software: you can redistribute it and/or modify        *
-//* it under the terms of the GNU General Public License as published by     *
-//* the Free Software Foundation, either version 3 of the License, or        *
-//* (at your option) any later version.                                      *
-//*                                                                          *
-//* Primary Authors: Sandro Wenzel <sandro.wenzel@cern.ch>                   *
-//*                                                                          *
-//* The authors make no claims about the suitability of this software for    *
-//* any purpose. It is provided "as is" without express or implied warranty. *
-//****************************************************************************
-
 //  @file   StepInfo.cxx
 //  @author Sandro Wenzel
 //  @since  2017-06-29
 //  @brief  structures encapsulating information about MC stepping
 
-#include <StepInfo.h>
+#include "MCStepLogger/StepInfo.h"
 #include <TArrayI.h>
 #include <TParticle.h>
 #include <TVirtualMC.h>

--- a/Utilities/MCStepLogger/src/analyseMCSteps.cxx
+++ b/Utilities/MCStepLogger/src/analyseMCSteps.cxx
@@ -1,0 +1,230 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <iostream>
+#include <string>
+#include <vector>
+#include <functional>
+
+#include <boost/program_options.hpp>
+
+#include "TROOT.h"
+#include "TInterpreter.h"
+#include "TSystemDirectory.h"
+
+#include "FairLogger.h"
+
+#include "MCStepLogger/MCAnalysisManager.h"
+#include "MCStepLogger/MCAnalysisFileWrapper.h"
+#include "MCStepLogger/BasicMCAnalysis.h"
+
+using namespace o2::mcstepanalysis;
+
+namespace bpo = boost::program_options;
+
+std::vector<std::string> availableCommands = { "analyze", "checkFile" };
+
+// print help message
+void helpMessage(const bpo::options_description& desc)
+{
+  std::cout << desc << std::endl;
+}
+/// pass macros in analysisDir to ROOT interpreter
+void registerAnalyses(const std::string& analysisDir)
+{
+  // try to read analyses from analyis directory
+  // \todo try-catch to only read analysis macros and skip other files or non-conforming
+  //       analysis classes ==> print warnings/errors
+  TSystemDirectory macroDir(analysisDir.c_str(), analysisDir.c_str());
+  if (macroDir.IsDirectory()) {
+    TList* macros = macroDir.GetListOfFiles();
+    TIter next(macros);
+    TSystemFile* file = nullptr;
+    while ((file = (TSystemFile*)next())) {
+      if (!file->IsDirectory()) {
+        const std::string& filepath = analysisDir + "/" + file->GetName();
+        LOG(DEBUG) << "Try to load analysis from " << filepath << "\n";
+        gROOT->LoadMacro(filepath.c_str());
+        gInterpreter->ProcessLine("declareAnalysis()");
+      }
+    }
+  }
+}
+/// analyze function
+int analyze(const bpo::variables_map& vm, std::string& errorMessage)
+{
+  //////////////////////////////////////////////////////////////////////////////////////////////
+  // if external analyses are desired but no analysis directory is passed, fail
+  if (vm.count("analyses") && !vm.count("analysis-dir") && !vm.count("list-analyses")) {
+    errorMessage += "Analysis names but no analysis directory passed.\n";
+  }
+  //////////////////////////////////////////////////////////////////////////////////////////////
+  // now the check for ROOT files
+  if (!vm.count("root-file") && !vm.count("list-analyses")) {
+    errorMessage += "Need ROOT file from MCStepLogger.\n";
+  }
+  //////////////////////////////////////////////////////////////////////////////////////////////
+  // is there an output directory?
+  if (!vm.count("output-dir") && !vm.count("list-analyses")) {
+    errorMessage += "Need an output directory.\n";
+  }
+  //////////////////////////////////////////////////////////////////////////////////////////////
+  // a label needs to be given to identify this analysis run
+  if (!vm.count("label") && !vm.count("list-analyses")) {
+    errorMessage += "Need a label for this analysis.\n";
+  }
+  if (!errorMessage.empty()) {
+    return 1;
+  }
+  //////////////////////////////////////////////////////////////////////////////////////////////
+  // try to read analyses from analyis directory
+  // \todo try-catch to only read analysis macros and skip other files or non-conforming
+  //       analysis classes ==> print warnings/errors
+  if (vm.count("analysis-dir") && vm.count("analyses")) {
+    const std::string analysisDir = vm["analysis-dir"].as<std::string>().c_str();
+    registerAnalyses(analysisDir);
+  }
+  // create basic analysis by default, is registered automaticallyt to AnalysisManager
+  new BasicMCAnalysis();
+  //////////////////////////////////////////////////////////////////////////////////////////////
+  // List analyses and quit. This has to be done here after analyses are read from analysis-dir
+  // the first time the AnalysisManager is needed
+  auto& anamgr = MCAnalysisManager::Instance();
+  if (vm.count("list-analyses")) {
+    anamgr.printAnalyses();
+    return 0;
+  }
+  //////////////////////////////////////////////////////////////////////////////////////////////
+  // set a label and the input file from MCStepLogger
+  anamgr.setLabel(vm["label"].as<std::string>());
+  anamgr.setInputFilepath(vm["root-file"].as<std::string>());
+  // if ready, run
+  if (!anamgr.checkReadiness()) {
+    return 1;
+  }
+  anamgr.run(vm["number-events"].as<int>());
+  // save what the AnalysisFileHandler has gotten during the analysis run
+  anamgr.write(vm["output-dir"].as<std::string>());
+  return 0;
+}
+
+// check type and sanity of a file
+// \note this is a beta version which will always complain unless an analysis file was passed.
+//       In that case, the meta info is printed
+int checkFile(const bpo::variables_map& vm, std::string& errorMessage)
+{
+  if (!vm.count("root-file")) {
+    errorMessage += "ROOT file required.\n";
+  }
+  if (!errorMessage.empty()) {
+    return 1;
+  }
+  LOG(INFO) << "Check type and sanity of the input file " << vm["root-file"].as<std::string>();
+  MCAnalysisFileWrapper fileWrapper;
+  if (fileWrapper.read(vm["root-file"].as<std::string>())) {
+    fileWrapper.printAnalysisMetaInfo();
+    fileWrapper.printHistogramInfo();
+    return 0;
+  }
+  auto& anamgr = MCAnalysisManager::Instance();
+  anamgr.setInputFilepath(vm["root-file"].as<std::string>());
+  if (anamgr.dryrun()) {
+    return 0;
+  }
+  LOG(INFO) << "This ROOT file is neither an MCStepLogger nor an MCAnalysis file.";
+  return 1;
+}
+
+// Initialize everything for the final run depending on the command
+void initializeForRun(const std::string& cmd, bpo::options_description& cmdOptionsDescriptions, std::function<int(const bpo::variables_map&, std::string&)>& cmdFunction)
+{
+  if (cmd == "analyze") {
+    cmdOptionsDescriptions.add_options()("help,h", "show this help message and exit")("analyses,a", bpo::value<std::vector<std::string>>()->multitoken(), "analyses to be run")("analysis-dir,d", bpo::value<std::string>(), "directory containing analysis macros (required, if --analyses is used)")("list-analyses,s", "list available analyses and exit")("root-file,f", bpo::value<std::string>(), "ROOT file from MCStepLogger to be analysed (required)")("label,l", bpo::value<std::string>(), "custom label for the analysis (required)")("output-dir,o", bpo::value<std::string>(), "output directory for analyses (required)")("number-events,n", bpo::value<int>()->default_value(-1), "only analyse a certain number of events");
+    cmdFunction = analyze;
+  } else if (cmd == "checkFile") {
+    cmdOptionsDescriptions.add_options()("help,h", "show this help message and exit")("root-file,f", bpo::value<std::string>(), "ROOT file to be checked");
+    cmdFunction = checkFile;
+  }
+}
+
+int main(int argc, char* argv[])
+{
+  // Global variables map mapping the command line options to their values
+  bpo::variables_map vm;
+  // Description of the available top-level commands/options
+  bpo::options_description desc("Available commands/options");
+  desc.add_options()("help,h", "show this help message and exit")("command", bpo::value<std::string>(), "command to be executed (\"analyze\", \"checkFile\"")("positional", bpo::value<std::vector<std::string>>(), "positional arguments");
+  // Dedicated description for positional arguments
+  bpo::positional_options_description pos;
+  // First positional argument is actually the command, all others are real positional arguments "( "positional", -1 )"
+  pos.add("command", 1).add("positional", -1);
+  // Parse and store in variables map, allow unregistered since these are not yet specified but will be so as soon as
+  // the command name is checked
+  bpo::parsed_options parsed = bpo::command_line_parser(argc, argv).options(desc).positional(pos).allow_unregistered().run();
+  bpo::store(parsed, vm);
+
+  // check whether 'command' is missing or if there is even no option at all; show global help message in that case
+  // and return
+  if (!vm.count("command") || vm.empty()) {
+    if (!vm.count("help")) {
+      LOG(FATAL) << "Need command to execute.";
+    }
+    // Print global help message in any case...
+    helpMessage(desc);
+    // ...but check whther it was explicitly asked for it and return accordingly
+    return (!vm.count("help"));
+  }
+
+  // Extract command
+  const std::string& cmd = vm["command"].as<std::string>();
+  if (std::find(availableCommands.begin(), availableCommands.end(), cmd) == availableCommands.end()) {
+    LOG(ERROR) << "Command \"" << cmd << "\" unknown.";
+    helpMessage(desc);
+    return 1;
+  }
+
+  // extract all positional arguments passed which are unrecognized by desc
+  std::vector<std::string> opts = bpo::collect_unrecognized(parsed.options, bpo::include_positional);
+  // since 'command' as positional argument is unknown, it needs to be erased explicitly
+  opts.erase(opts.begin());
+
+  // Preprocessing done.
+  // Track return value
+  int returnValue = 0;
+  // function to be run
+  std::function<int(const bpo::variables_map&, std::string&)> cmdFunction;
+  // corresponding options with description
+  bpo::options_description cmdOptionsDescriptions;
+  // initialize command function and corresponding options description
+  initializeForRun(cmd, cmdOptionsDescriptions, cmdFunction);
+  // Parse again to get positional arguments correctly labelled for analysis run
+  bpo::store(bpo::command_line_parser(opts).options(cmdOptionsDescriptions).run(), vm);
+  // Notify and fix variables map
+  bpo::notify(vm);
+  // To collect error messsages
+  std::string errorMessage("");
+  if (vm.size() == 1) {
+    errorMessage += "Options required...\n";
+    returnValue = 1;
+  }
+  // check if specific help message is desired
+  else if (!vm.count("help")) {
+    returnValue = cmdFunction(vm, errorMessage);
+  }
+  // check return value
+  if (returnValue > 0) {
+    LOG(ERROR) << "Errors occured:";
+    std::cerr << errorMessage << "\n";
+  }
+  if (returnValue > 0 || vm.count("help")) {
+    helpMessage(cmdOptionsDescriptions);
+  }
+  return returnValue;
+}

--- a/Utilities/MCStepLogger/src/basicMCAnalysisCI.cxx
+++ b/Utilities/MCStepLogger/src/basicMCAnalysisCI.cxx
@@ -1,0 +1,97 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/*
+ * few basic checks for analysis BasicMCAnalysisTest
+ * can be used for CI in the future as soon as events are fully benchmarked
+ *
+ * This test requires a JSON file conatining the reference values to be tested
+ * against. It has the following from
+ * -----refValues.json---------
+ * {
+ *   "analysisName": "<analysisName>",
+ *   "nSteps": [absoluteNumberOfSteps, relativeTolerance],
+ *   "nTracks": [absoluteNumberOfTracks, relativeTolerance]
+ * }
+ * ----------------------------
+ *
+ * Basic usage
+ * $> runTestAnalysisBasic -- <path/to/Analysis.root> <reference.json>
+ */
+
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE BasicMCAnalysisTest
+#include <boost/test/unit_test.hpp>
+#include <boost/test/results_collector.hpp>
+#include <boost/test/floating_point_comparison.hpp>
+
+// to parse the reference JSON files
+#include "rapidjson/document.h"
+#include "rapidjson/filereadstream.h"
+
+#include <string>
+#include <utility>
+#include <vector>
+#include <iostream>
+#include <cstdio> // to read JSON file from disk
+
+#include "MCStepLogger/MCAnalysisFileWrapper.h"
+
+using namespace o2::mcstepanalysis;
+namespace utf = boost::unit_test;
+namespace tt = boost::test_tools;
+
+namespace rj = rapidjson;
+
+float integral(const TH1& histogram)
+{
+  return histogram.Integral();
+}
+
+// checking meta info and whether there is a value container the analysis can be conpared with
+BOOST_AUTO_TEST_CASE(meta_mcbasicanalysis_test)
+{
+  // a path to a ROOT file containing the analysis histograms and a JSON file containing reference values, hence 3 arguments
+  BOOST_REQUIRE(boost::unit_test::framework::master_test_suite().argc == 3);
+  // read the file to a file wrapper
+  MCAnalysisFileWrapper fileWrapper;
+  BOOST_REQUIRE(fileWrapper.read(boost::unit_test::framework::master_test_suite().argv[1]));
+  // read the reference JSON file
+  rj::Document doc;
+  std::FILE* referenceFile = std::fopen(boost::unit_test::framework::master_test_suite().argv[2], "r");
+  // make sure a file was read
+  BOOST_REQUIRE(referenceFile != nullptr);
+  char readBuffer[65536];
+  rj::FileReadStream is(referenceFile, readBuffer, sizeof(readBuffer));
+  // read the JSON assuming that it's same
+  doc.ParseStream(is);
+  //std::cerr << doc.Size() << std::endl;
+  // meta info from step logging and analysis run
+  MCAnalysisMetaInfo& anaMetaInfo = fileWrapper.getAnalysisMetaInfo();
+  // check only for the right analysis name, considering that the user knows which histograms to expect from this analysis
+  BOOST_REQUIRE(doc.HasMember("analysisName"));
+  BOOST_REQUIRE(anaMetaInfo.analysisName.compare(doc["analysisName"].GetString()) == 0);
+
+  // require histograms, so fail if not there
+  BOOST_REQUIRE(fileWrapper.hasHistogram("nSteps"));
+  BOOST_REQUIRE(fileWrapper.hasHistogram("nTracks"));
+
+  // have checked that histograms are there, so get them
+  TH1& histNSteps = fileWrapper.getHistogram("nSteps");
+  TH1& histNTracks = fileWrapper.getHistogram("nTracks");
+
+  // again assuming the user passed JSON containing what is needed
+  const rj::Value& nSteps = doc["nSteps"];
+  const rj::Value& nTracks = doc["nTracks"];
+  // ...and perform tests, assuming the JSON values are arrays
+  BOOST_TEST(nSteps[0].GetFloat() == float(histNSteps.GetEntries()), tt::tolerance(nSteps[1].GetFloat()));
+  BOOST_TEST(nTracks[0].GetFloat() == float(histNTracks.GetEntries()), tt::tolerance(nTracks[1].GetFloat()));
+}

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -646,9 +646,19 @@ o2_define_bucket(
     VMC
     EG
     Tree
+    Hist
+    Graf
+    Gpad
     Geom
+    common_boost_bucket
+    Boost::unit_test_framework
+    ${FairLogger_DEP}
+    RapidJSON
 
     INCLUDE_DIRECTORIES
+    ${FairLogger_INCDIR}
+    ${FAIRROOT_INCLUDE_DIR}
+    ${RAPIDJSON_INCLUDEDIR}/include
 )
 
 o2_define_bucket(
@@ -988,13 +998,13 @@ o2_define_bucket(
 o2_define_bucket(
     NAME
     TPCCAGPUTracking_bucket
-    
+
     DEPENDENCIES
     dl
     pthread
     root_base_bucket
     common_vc_bucket
-    
+
     INCLUDE_DIRECTORIES
     ${ROOT_INCLUDE_DIR}
     ${ALITPCCOMMON_DIR}/sources/TPCCAGPUTracking/SliceTracker
@@ -1351,7 +1361,7 @@ o2_define_bucket(
     Core Hist # ROOT
     CommonDataFormat
     detectors_base_bucket
- 
+
     INCLUDE_DIRECTORIES
     ${FAIRROOT_INCLUDE_DIR}
     ${ROOT_INCLUDE_DIR}


### PR DESCRIPTION
The framework aims at analysing the step information collected with
the MCStepLogger library during a simulation run. One of the main
goals is the implementation of a CI for O2 detector simulation to be
able to investigate sanity of the simulation at PR-time.

Providing one analysis by default, custom analyses can be added on
the fly and are steered by a central executable.

Interfaces for reading and writing analysis files are provided and
these are hecnce standardised. This enables for straight-forward
plotting and further investigation of the analysis.

Proof-of-concept executable for a possible CI is included for the
default analysis called 'runTestAnalysisBasic'.