### PR TITLE
Introduce standarised Data Sampling condition

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -36,6 +36,7 @@ set(SRCS
     src/DataProcessor.cxx
     src/DataRelayer.cxx
     src/DataSampling.cxx
+    src/DataSamplingConditionRandom.cxx
     src/DataSourceDevice.cxx
     src/DeviceMetricsInfo.cxx
     src/DeviceSpec.cxx
@@ -129,6 +130,8 @@ set(HEADERS
       include/Framework/Variant.h
       include/Framework/CallbackRegistry.h
       include/Framework/CallbackService.h
+      include/Framework/DataSampling.h
+      include/Framework/DataSamplingCondition.h
       src/ComputingResource.h
       src/DDSConfigHelpers.h
       src/DeviceSpecHelpers.h
@@ -188,6 +191,7 @@ set(TEST_SRCS
       test/test_BoostOptionsRetriever.cxx
       test/test_DataRelayer.cxx
       test/test_DataSampling.cxx
+      test/test_DataSamplingCondition.cxx
       test/test_DataRefUtils.cxx
       test/test_DataProcessorSpec.cxx
       test/test_DeviceMetricsInfo.cxx

--- a/Framework/Core/include/Framework/DataSamplingCondition.h
+++ b/Framework/Core/include/Framework/DataSamplingCondition.h
@@ -1,0 +1,49 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_DATASAMPLINGCONDITION_H
+#define ALICEO2_DATASAMPLINGCONDITION_H
+
+/// \file DataSamplingCondition.h
+/// \brief A standarised data sampling condition, to decide if given data sample should be passed forward.
+///
+/// \author Piotr Konopka, piotr.jan.konopka@cern.ch
+
+#include "Framework/DataRef.h"
+#include "Configuration/Tree.h"
+
+namespace o2
+{
+namespace framework
+{
+
+/// A standarised data sampling condition, to decide if given data sample should be passed forward.
+class DataSamplingCondition
+{
+ public:
+  /// \brief Default constructor.
+  DataSamplingCondition() = default;
+  /// \brief Default destructor
+  virtual ~DataSamplingCondition() = default;
+
+  /// \brief Reads custom configuration parameters.
+  virtual void configure(const o2::configuration::tree::Branch&) = 0;
+  /// \brief Makes decision whether to pass a data sample or not.
+  virtual bool decide(const o2::framework::DataRef&) = 0;
+
+  // a list of getters of specific DataSamplingCondition's
+  /// \brief Getter for DataSamplingConditionRandom
+  static std::unique_ptr<DataSamplingCondition> getDataSamplingConditionRandom();
+};
+
+} // namespace framework
+} // namespace o2
+
+#endif //ALICEO2_DATASAMPLINGCONDITION_H

--- a/Framework/Core/src/DataSamplingConditionRandom.cxx
+++ b/Framework/Core/src/DataSamplingConditionRandom.cxx
@@ -24,12 +24,12 @@ namespace framework
 {
 
 // todo: choose the best PRNG (TRandom3 is fast, but i am not sure about its statistical soundness and behaviour with
-// very small percents).
+// very small percents) or use completely different decision mechanism (map or formula f(timeslice) -> {0,1})
 // todo: consider using run number as a seed
 
 using namespace o2::header;
 
-/// \brief A DataSamplingCondition which makes decicions randomly, but with determinism.
+/// \brief A DataSamplingCondition which makes decisions randomly, but with determinism.
 class DataSamplingConditionRandom : public DataSamplingCondition
 {
 

--- a/Framework/Core/src/DataSamplingConditionRandom.cxx
+++ b/Framework/Core/src/DataSamplingConditionRandom.cxx
@@ -1,0 +1,71 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file DataSamplingConditionRandom.cxx
+/// \brief Implementation of random DataSamplingCondition
+///
+/// \author Piotr Konopka, piotr.jan.konopka@cern.ch
+
+#include "Framework/DataSamplingCondition.h"
+#include "Framework/DataProcessingHeader.h"
+
+#include <TRandom3.h>
+
+namespace o2
+{
+namespace framework
+{
+
+// todo: choose the best PRNG (TRandom3 is fast, but i am not sure about its statistical soundness and behaviour with
+// very small percents).
+// todo: consider using run number as a seed
+
+using namespace o2::header;
+
+/// \brief A DataSamplingCondition which makes decicions randomly, but with determinism.
+class DataSamplingConditionRandom : public DataSamplingCondition
+{
+
+ public:
+  /// \brief Constructor.
+  DataSamplingConditionRandom() : DataSamplingCondition(), mSeed(0), mFraction(0.0), mGenerator(0){};
+  /// \brief Default destructor
+  ~DataSamplingConditionRandom() = default;
+
+  /// \brief Reads 'fraction' parameter (type double, between 0 and 1) and seed (int).
+  void configure(const o2::configuration::tree::Branch& cfg) override
+  {
+    mFraction = configuration::tree::getRequired<double>(cfg, "fraction");
+    mSeed = configuration::tree::getRequired<int>(cfg, "seed");
+  };
+  /// \brief Makes pseudo-random, deterministic decision based on TimesliceID.
+  /// The reason behind using TimesliceID is to ensure, that data of the same events is sampled even on different FLPs.
+  bool decide(const o2::framework::DataRef& dataRef) override
+  {
+    const auto* dpHeader = get<DataProcessingHeader*>(dataRef.header);
+    assert(dpHeader);
+
+    mGenerator.SetSeed(dpHeader->startTime + mSeed);
+    return static_cast<bool>(mGenerator.Binomial(1, mFraction));
+  }
+
+ private:
+  int mSeed;
+  double mFraction;
+  TRandom3 mGenerator;
+};
+
+std::unique_ptr<DataSamplingCondition> DataSamplingCondition::getDataSamplingConditionRandom()
+{
+  return std::make_unique<DataSamplingConditionRandom>();
+}
+
+} // namespace framework
+} // namespace o2

--- a/Framework/Core/test/test_DataSamplingCondition.cxx
+++ b/Framework/Core/test/test_DataSamplingCondition.cxx
@@ -1,0 +1,41 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#define BOOST_TEST_MODULE Test Framework DataSamplingCondition
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+
+#include "Framework/DataSamplingCondition.h"
+#include "Framework/DataRef.h"
+#include "Framework/DataProcessingHeader.h"
+
+using namespace o2::framework;
+
+BOOST_AUTO_TEST_CASE(DataSamplingConditionRandom)
+{
+  auto conditionRandom = DataSamplingCondition::getDataSamplingConditionRandom();
+
+  // PRNG should behave the same every time and on every machine.
+  // Of course, the test does not cover full range of timesliceIDs.
+  std::vector<bool> correctDecision{
+    false, true, false, true, true, false, true, false, false, true, false, true, false, false, false, false, false,
+    true, false, false, true, true, false, false, true, true, false, false, false, false, true, true, false, false,
+    true, true, false, false, false, false, false, true, false, false, false, false, false, true, false
+  };
+  conditionRandom->configure({ { "fraction", 0.5 }, { "seed", 943753948 } });
+
+  for (DataProcessingHeader::StartTime id = 1; id < 50; id++) {
+    DataProcessingHeader dph{ id, 0 };
+    o2::header::Stack headerStack{ dph };
+    DataRef dr{ nullptr, reinterpret_cast<const char*>(headerStack.data()), nullptr };
+    BOOST_CHECK_EQUAL(correctDecision[id - 1], conditionRandom->decide(dr));
+  }
+}

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -247,6 +247,7 @@ o2_define_bucket(
     O2DeviceApplication_bucket
     Core
     Net
+    MathUtils
     ${GUI_LIBRARIES}
     ${Monitoring_LIBRARIES}
     ${Configuration_LIBRARIES}


### PR DESCRIPTION
There were feature requests concerning the way of taking decisions about sampling data - some users would like to receive not only random samples, but f.e. 3 consecutive during some periods. This commit prepares place for such a need.
DataSamplingCondition is not used yet by Dispatchers, but it will be when DataSamplingPolicy is implemented.
@Barthelemy 