### PR TITLE
 Fixing sporadically failing unit test 

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -222,10 +222,10 @@ O2_GENERATE_TESTS(
   TIMEOUT 30
 
   TEST_SRCS
-  test/test_WorkflowOptions.cxx
+  test/test_ProcessorOptions.cxx
 
   COMMAND_LINE_ARGS
   --global-config require-me
   # Note: the group switch makes process consumer parse only the group arguments
-  --consumer "--global-config require-me --local-option hello-aliceo2"
+  --consumer "--global-config consumer-config --local-option hello-aliceo2"
 )

--- a/Framework/Core/test/test_ProcessorOptions.cxx
+++ b/Framework/Core/test/test_ProcessorOptions.cxx
@@ -18,7 +18,8 @@ using namespace o2::framework;
   }
 
 // This is how you can define your processing in a declarative way
-WorkflowSpec defineDataProcessing(ConfigContext const&) {
+WorkflowSpec defineDataProcessing(ConfigContext const&)
+{
   return WorkflowSpec{
     DataProcessorSpec{
       "producer",
@@ -61,7 +62,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const&) {
           // read back the option from the command line, see CMakeLists.txt
           auto configstring = ic.options().get<std::string>("global-config");
           auto anotheroption = ic.options().get<std::string>("local-option");
-          ASSERT_ERROR(configstring == "require-me");
+          ASSERT_ERROR(configstring == "consumer-config");
           ASSERT_ERROR(anotheroption == "hello-aliceo2");
 
           return [](ProcessingContext& ctx) {

--- a/Framework/Core/test/test_WorkflowOptions.cxx
+++ b/Framework/Core/test/test_WorkflowOptions.cxx
@@ -34,7 +34,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const&) {
           ASSERT_ERROR(configstring == "require-me");
 
           return [](ProcessingContext& ctx) {
-            // there is nothing to do, simply stop the workflow
+            // there is nothing to do, simply stop the workflow but we have to send at least one message
+            // to make sure that the callback of the consumer is called
+            ctx.outputs().make<int>(Output{ "TST", "TEST", 0, Lifetime::Timeframe }) = 42;
             ctx.services().get<ControlService>().readyToQuit(true);
           };
         },


### PR DESCRIPTION
    We have to send at least one message to make sure that the callback of the consumer
    is called to request termination via the ControlService. Depending on the scheduler,
    the ControlService of the consumer might not be running when the producer sends the
    termination command for all devices. And then termiation for the consumer is never
    triggered.
    
    This will however not fix the problem that sometimes the device does not terminate
    correctly. The typical signature is that the device gets the terminate signal and
    leaves the RUNNING state, entering READY state is the last message.
