### PR TITLE
Fix in pythia8: limit decays dist + correct dimensions

### DIFF
--- a/Generators/src/GeneratorFactory.cxx
+++ b/Generators/src/GeneratorFactory.cxx
@@ -83,6 +83,8 @@ void GeneratorFactory::setPrimaryGenerator(o2::conf::SimConfig const& conf, Fair
     py8Gen->SetParameters("Beams:idB 2212");       // p
     py8Gen->SetParameters("Beams:eCM 14000.");     // [GeV]
     py8Gen->SetParameters("SoftQCD:inelastic on"); // all inelastic processes
+    py8Gen->SetParameters("ParticleDecays:rMax 0.1");
+    py8Gen->SetParameters("ParticleDecays:limitRadius on");
     primGen->AddGenerator(py8Gen);
   } else if (genconfig.compare("pythia8hi") == 0) {
     // pythia8 heavy-ion
@@ -97,6 +99,8 @@ void GeneratorFactory::setPrimaryGenerator(o2::conf::SimConfig const& conf, Fair
     py8Gen->SetParameters("HeavyIon:SigFitDefPar 14.82,1.82,0.25,0.0,0.0,0.0,0.0,0.0"); // valid for Pb-Pb 5520 only
     py8Gen->SetParameters(
       ("HeavyIon:bWidth " + std::to_string(conf.getBMax())).c_str()); // impact parameter from 0-x [fm]
+    py8Gen->SetParameters("ParticleDecays:rMax 0.1");
+    py8Gen->SetParameters("ParticleDecays:limitRadius on");
     primGen->AddGenerator(py8Gen);
   } else {
     LOG(FATAL) << "Invalid generator" << FairLogger::endl;

--- a/Generators/src/Pythia8Generator.cxx
+++ b/Generators/src/Pythia8Generator.cxx
@@ -112,6 +112,8 @@ Pythia8Generator::~Pythia8Generator() = default;
 // -----   Passing the event   ---------------------------------------------
 Bool_t Pythia8Generator::ReadEvent(FairPrimaryGenerator* cpg)
 {
+  const double mm2cm = 0.1;
+  const double clight = 2.997924580e10; //cm/c
   Int_t npart = 0;
   while (npart == 0) {
     mPythia->next();
@@ -156,8 +158,15 @@ Bool_t Pythia8Generator::ReadEvent(FairPrimaryGenerator* cpg)
         Double_t pz = mPythia->event[ii].pz();
         Double_t px = mPythia->event[ii].px();
         Double_t py = mPythia->event[ii].py();
+        Double_t t = mPythia->event[ii].tProd();
+        if (t > 0.) {
+          x *= mm2cm;
+          y *= mm2cm;
+          z *= mm2cm;
+          t *= mm2cm / clight;
+        }
         cpg->AddTrack((Int_t)mPythia->event[ii].id(), px, py, pz, x, y, z,
-                      (Int_t)mPythia->event[ii].mother1(), wanttracking);
+                      (Int_t)mPythia->event[ii].mother1(), wanttracking, -9e9, t);
         // cout<<"debug p8->geant4 "<< wanttracking << " "<< ii <<  " "
         // << mPythia->event[ii].id()<< " "<< mPythia->event[ii].mother1()<<" "<<x<<" "<< y<<" "<< z <<endl;
       }
@@ -170,8 +179,15 @@ Bool_t Pythia8Generator::ReadEvent(FairPrimaryGenerator* cpg)
       Double_t pz = mPythia->event[ii].pz();
       Double_t px = mPythia->event[ii].px();
       Double_t py = mPythia->event[ii].py();
-      cpg->AddTrack((Int_t)mPythia->event[im].id(), px, py, pz, x, y, z, 0, false);
-      cpg->AddTrack((Int_t)mPythia->event[ii].id(), px, py, pz, x, y, z, im, false);
+      Double_t t = mPythia->event[ii].tProd();
+      if (t > 0.) {
+        x *= mm2cm;
+        y *= mm2cm;
+        z *= mm2cm;
+        t *= mm2cm / clight;
+      }
+      cpg->AddTrack((Int_t)mPythia->event[im].id(), px, py, pz, x, y, z, 0, false, -9e9, t);
+      cpg->AddTrack((Int_t)mPythia->event[ii].id(), px, py, pz, x, y, z, im, false, -9e9, t);
       //cout<<"debug p8->geant4 "<< 0 << " "<< ii <<  " " << fake<< " "<< mPythia->event[ii].mother1()<<endl;
     };
   }


### PR DESCRIPTION
1) decays performed by pythia are limited to 0.1mm (no B-field assumed), TOF of decayed track is
propagated to the FairPrimaryGenerator.
2) Pythia uses mm and mm/c units, when adding its particles to FairPrimaryGenerator, convert
them to cm, s.