### PR TITLE
Code reduction: Automatically implement CloneModule for detectors

### DIFF
--- a/Detectors/Base/include/DetectorsBase/Detector.h
+++ b/Detectors/Base/include/DetectorsBase/Detector.h
@@ -295,6 +295,13 @@ class DetImpl : public o2::Base::Detector
     }
   }
 
+  // implementing CloneModule (for G4-MT mode) automatically for each deriving
+  // Detector class "Det"; calls copy constructor of Det
+  FairModule* CloneModule() const final
+  {
+    return new Det(static_cast<const Det&>(*this));
+  }
+
   ClassDefOverride(DetImpl, 0)
 };
 }

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/Detector.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/Detector.h
@@ -59,11 +59,6 @@ class Detector : public o2::Base::DetImpl<Detector>
   ~Detector() override = default;
 
   ///
-  /// Clone this object (used in MT mode only)
-  ///
-  FairModule *CloneModule() const override;
-
-  ///
   /// Initializing detector
   ///
   void Initialize() final;
@@ -194,7 +189,9 @@ class Detector : public o2::Base::DetImpl<Detector>
   Double_t mInnerEdge;   //!<! Inner edge of DCAL super module
   Double_t mParEMOD[5];  //!<! parameters of EMCAL module (TRD1,2)
 
-  ClassDefOverride(Detector, 1)
+  template <typename Det>
+  friend class o2::Base::DetImpl;
+  ClassDefOverride(Detector, 1);
 };
 }
 }

--- a/Detectors/EMCAL/simulation/src/Detector.cxx
+++ b/Detectors/EMCAL/simulation/src/Detector.cxx
@@ -88,11 +88,6 @@ Detector::Detector(const Detector& rhs)
   }
 }
 
-FairModule* Detector::CloneModule() const
-{
-  return new Detector(*this);
-}
-
 void Detector::Initialize()
 {
   // Define sensitive volume

--- a/Detectors/FIT/simulation/include/FITSimulation/Detector.h
+++ b/Detectors/FIT/simulation/include/FITSimulation/Detector.h
@@ -18,8 +18,6 @@
 #include "DetectorsBase/Detector.h" // for Detector
 #include "FITBase/Geometry.h"
 
-class FairModule;
-
 class FairVolume;
 class TGeoVolume;
 class TGraph;
@@ -59,9 +57,6 @@ class Detector : public o2::Base::DetImpl<Detector>
 
   /// Default constructor
   Detector() = default;
-
-  /// Clone this object (used in MT mode only)
-  FairModule* CloneModule() const override;
 
   /// Initialization of the detector is done here
   void Initialize() override;
@@ -136,6 +131,8 @@ class Detector : public o2::Base::DetImpl<Detector>
 
   Geometry* mGeometry = nullptr; //! Geometry
 
+  template <typename Det>
+  friend class o2::Base::DetImpl;
   ClassDefOverride(Detector, 1)
 };
 

--- a/Detectors/FIT/simulation/src/Detector.cxx
+++ b/Detectors/FIT/simulation/src/Detector.cxx
@@ -46,11 +46,6 @@ Detector::Detector(const Detector& rhs)
 {
 }
 
-FairModule* Detector::CloneModule() const
-{
-  return new Detector(*this);
-}
-
 void Detector::Initialize()
 {
   // FIXME: we need to register the sensitive volumes with FairRoot

--- a/Detectors/HMPID/simulation/include/HMPIDSimulation/Detector.h
+++ b/Detectors/HMPID/simulation/include/HMPIDSimulation/Detector.h
@@ -62,6 +62,9 @@ class Detector : public o2::Base::DetImpl<Detector>
   TGeoVolume* CradleBaseVolume(TGeoMedium* med, double l[7], const char* name);
 
  private:
+  // copy constructor for CloneModule
+  Detector(const Detector&);
+
   std::vector<HitType>* mHits = nullptr; ///!< Collection of HMPID hits
   enum EMedia {
     kAir = 1,
@@ -79,6 +82,8 @@ class Detector : public o2::Base::DetImpl<Detector>
 
   std::vector<TGeoVolume*> mSensitiveVolumes; //!
 
+  template <typename Det>
+  friend class o2::Base::DetImpl;
   ClassDefOverride(Detector, 1);
 };
 

--- a/Detectors/HMPID/simulation/src/Detector.cxx
+++ b/Detectors/HMPID/simulation/src/Detector.cxx
@@ -39,6 +39,9 @@ namespace hmpid
 
 Detector::Detector(Bool_t active) : o2::Base::DetImpl<Detector>("HMP", active), mHits(new std::vector<HitType>) {}
 
+Detector::Detector(const Detector& other) : mSensitiveVolumes(other.mSensitiveVolumes),
+                                            mHits(new std::vector<HitType>) {}
+
 void Detector::Initialize()
 {
   for (auto sensitiveHpad : mSensitiveVolumes) {

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
@@ -25,8 +25,6 @@
 #include "TLorentzVector.h"                   // for TLorentzVector
 #include "TVector3.h"                         // for TVector3
 
-class FairModule;
-
 class FairVolume;
 class TGeoVolume;
 
@@ -250,8 +248,6 @@ class Detector : public o2::Base::DetImpl<Detector>
   virtual void setStaveModelOB(Model model) { mStaveModelOuterBarrel = model; }
   virtual Model getStaveModelIB() const { return mStaveModelInnerBarrel; }
   virtual Model getStaveModelOB() const { return mStaveModelOuterBarrel; }
-  /// Clone this object (used in MT mode only)
-  FairModule* CloneModule() const override;
 
   GeometryTGeo* mGeometryTGeo; //! access to geometry details
 
@@ -313,6 +309,8 @@ class Detector : public o2::Base::DetImpl<Detector>
   Model mStaveModelOuterBarrel;      //! The stave model for the Outer Barrel
   V3Layer* mGeometry[sNumberLayers]; //! Geometry
 
+  template <typename Det>
+  friend class o2::Base::DetImpl;
   ClassDefOverride(Detector, 1)
 };
 

--- a/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
@@ -1087,8 +1087,6 @@ void Detector::Read(std::istream* is)
   return;
 }
 
-FairModule* Detector::CloneModule() const { return new Detector(*this); }
-
 std::ostream& operator<<(std::ostream& os, Detector& p)
 {
   // Standard output streaming function.

--- a/Detectors/ITSMFT/MFT/simulation/include/MFTSimulation/Detector.h
+++ b/Detectors/ITSMFT/MFT/simulation/include/MFTSimulation/Detector.h
@@ -23,7 +23,6 @@
 #include "DetectorsCommonDataFormats/DetID.h" // for Detector
 #include "ITSMFTSimulation/Hit.h"             // for Hit
 
-class TClonesArray;
 class TVector3;
 
 namespace o2
@@ -78,7 +77,6 @@ class Detector : public o2::Base::DetImpl<Detector>
 
   void EndOfEvent() override;
 
-  void CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset) override { ; }
   void FinishPrimary() override { ; }
   void FinishRun() override { ; }
   void BeginPrimary() override { ; }
@@ -159,6 +157,8 @@ class Detector : public o2::Base::DetImpl<Detector>
     double mEnergyLoss;            //! energy loss
   } mTrackData;                    //!
 
+  template <typename Det>
+  friend class o2::Base::DetImpl;
   ClassDefOverride(Detector, 1)
 };
 

--- a/Detectors/ITSMFT/MFT/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/MFT/simulation/src/Detector.cxx
@@ -26,7 +26,6 @@
 #include "TVirtualMC.h"
 #include "TLorentzVector.h"
 #include "TVector3.h"
-#include "TClonesArray.h"
 #include "TGeoManager.h"
 
 #include "FairLogger.h"

--- a/Detectors/MUON/MCH/Simulation/include/MCHSimulation/Detector.h
+++ b/Detectors/MUON/MCH/Simulation/include/MCHSimulation/Detector.h
@@ -30,8 +30,6 @@ class Detector : public o2::Base::DetImpl<Detector>
 
   ~Detector() override;
 
-  FairModule* CloneModule() const override;
-
   Bool_t ProcessHits(FairVolume* v = nullptr) override;
 
   void Initialize() override;
@@ -55,6 +53,8 @@ class Detector : public o2::Base::DetImpl<Detector>
  private:
   o2::mch::Stepper* mStepper{ nullptr }; //!
 
+  template <typename Det>
+  friend class o2::Base::DetImpl;
   ClassDefOverride(Detector, 1);
 };
 

--- a/Detectors/MUON/MCH/Simulation/src/Detector.cxx
+++ b/Detectors/MUON/MCH/Simulation/src/Detector.cxx
@@ -39,11 +39,6 @@ Detector::~Detector()
   delete mStepper;
 }
 
-FairModule* Detector::CloneModule() const
-{
-  return new Detector(*this);
-}
-
 void Detector::defineSensitiveVolumes()
 {
   for (auto* vol : getSensitiveVolumes()) {

--- a/Detectors/PHOS/simulation/include/PHOSSimulation/Detector.h
+++ b/Detectors/PHOS/simulation/include/PHOSSimulation/Detector.h
@@ -73,11 +73,6 @@ class Detector : public o2::Base::DetImpl<Detector>
   ~Detector() override = default;
 
   ///
-  ///  Clone this object (used in MT mode only)
-  ///
-  FairModule* CloneModule() const override;
-
-  ///
   /// Initializing detector
   ///
   void Initialize() final;
@@ -191,6 +186,8 @@ class Detector : public o2::Base::DetImpl<Detector>
   Int_t mCurentSuperParent;         //! current SuperParent ID: particle entered PHOS
   Hit* mCurrentHit;                 //! current Hit
 
+  template <typename Det>
+  friend class o2::Base::DetImpl;
   ClassDefOverride(Detector, 1)
 };
 }

--- a/Detectors/PHOS/simulation/src/Detector.cxx
+++ b/Detectors/PHOS/simulation/src/Detector.cxx
@@ -54,8 +54,6 @@ Detector::Detector(const Detector& rhs)
 {
 }
 
-FairModule* Detector::CloneModule() const { return new Detector(*this); }
-
 void Detector::Initialize()
 {
   o2::Base::Detector::Initialize();

--- a/Detectors/TOF/simulation/include/TOFSimulation/Detector.h
+++ b/Detectors/TOF/simulation/include/TOFSimulation/Detector.h
@@ -53,8 +53,6 @@ class Detector : public o2::Base::DetImpl<Detector>
 
   ~Detector() override = default;
 
-  FairModule* CloneModule() const override;
-
   void Initialize() final;
 
   Bool_t ProcessHits(FairVolume* v = nullptr) final;
@@ -121,6 +119,8 @@ class Detector : public o2::Base::DetImpl<Detector>
   /// container for data points
   std::vector<HitType>* mHits; //!
 
+  template <typename Det>
+  friend class o2::Base::DetImpl;
   ClassDefOverride(Detector, 1);
 };
 }

--- a/Detectors/TOF/simulation/src/Detector.cxx
+++ b/Detectors/TOF/simulation/src/Detector.cxx
@@ -43,11 +43,6 @@ Detector::Detector(const Detector& rhs)
     mTOFSectors[i] = rhs.mTOFSectors[i];
 }
 
-FairModule* Detector::CloneModule() const
-{
-  return new Detector(*this);
-}
-
 void Detector::Initialize()
 {
   TGeoVolume* v = gGeoManager->GetVolume("FPAD");

--- a/Detectors/TPC/simulation/include/TPCSimulation/Detector.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/Detector.h
@@ -70,9 +70,6 @@ class Detector: public o2::Base::DetImpl<Detector> {
    /**       destructor     */
    ~Detector() override;
 
-   /**      Clone this object (used in MT mode only)    */
-   FairModule* CloneModule() const override;
-
    /**      Initialization of the detector is done here    */
    void Initialize() override;
 
@@ -179,7 +176,9 @@ class Detector: public o2::Base::DetImpl<Detector> {
     Detector(const Detector& rhs);
     Detector& operator=(const Detector&);
 
-    ClassDefOverride(Detector,1)
+    template <typename Det>
+    friend class o2::Base::DetImpl;
+    ClassDefOverride(Detector, 1)
 };
 
 template<typename T>

--- a/Detectors/TPC/simulation/src/Detector.cxx
+++ b/Detectors/TPC/simulation/src/Detector.cxx
@@ -92,8 +92,6 @@ Detector::~Detector()
   std::cout << "Stepping called " << mStepCounter << "\n";
 }
 
-FairModule* Detector::CloneModule() const { return new Detector(*this); }
-
 void Detector::Initialize()
 {
   // Define the list of sensitive volumes

--- a/Detectors/TRD/simulation/include/TRDSimulation/Detector.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Detector.h
@@ -16,7 +16,6 @@
 #include "SimulationDataFormat/BaseHits.h"
 
 class FairVolume;
-class TClonesArray;
 
 namespace o2
 {
@@ -33,8 +32,6 @@ class Detector : public o2::Base::DetImpl<Detector>
   Detector(Bool_t active=true);
 
   ~Detector() override = default;
-
-  FairModule* CloneModule() const override;
 
   void Initialize() override;
 
@@ -75,6 +72,8 @@ class Detector : public o2::Base::DetImpl<Detector>
 
   TRDGeometry* mGeom = nullptr;
 
+  template <typename Det>
+  friend class o2::Base::DetImpl;
   ClassDefOverride(Detector, 1)
 };
 

--- a/Detectors/TRD/simulation/src/Detector.cxx
+++ b/Detectors/TRD/simulation/src/Detector.cxx
@@ -37,11 +37,6 @@ Detector::Detector(const Detector& rhs)
 {
 }
 
-FairModule* Detector::CloneModule() const
-{
-  return new Detector(*this);
-}
-
 void Detector::Initialize()
 {
   // register the sensitive volumes with FairRoot


### PR DESCRIPTION
This commit provides a more "framework" like approach to implementing
CloneModule for detectors. From now on this function can no longer be forgotten
and the requirements for G4-MT are automatically satisfied. This works
by using the templated DetImpl class.

This commit follows the "dont-repeat-yourself" principle. I plan to extend
it to other common functions in simulation detector code.