### PR TITLE
Better (less error prone) detector initialization

### DIFF
--- a/Detectors/Base/include/DetectorsBase/Detector.h
+++ b/Detectors/Base/include/DetectorsBase/Detector.h
@@ -149,6 +149,21 @@ class Detector : public FairDetector
     virtual void attachHits(FairMQChannel&, FairMQParts&) = 0;
     virtual void fillHitBranch(TTree& tr, FairMQParts& parts, int& index) = 0;
 
+    // hook which is called automatically to custom initialize the O2 detectors
+    // all initialization not able to do in constructors should be done here
+    // (typically the case for geometry related stuff, etc)
+    virtual void InitializeO2Detector() = 0;
+
+    // the original FairModule/Detector virtual Initialize function
+    // calls individual customized initializations and makes sure that the mother Initialize
+    // is called as well. Marked final for this reason!
+    void Initialize() final
+    {
+      InitializeO2Detector();
+      // make sure the basic initialization is also done
+      FairDetector::Initialize();
+    }
+
     // The GetCollection interface is made final and deprecated since
     // we no longer support TClonesArrays
     [[deprecated("Use getHits API on concrete detectors!")]]

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/Detector.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/Detector.h
@@ -61,7 +61,7 @@ class Detector : public o2::Base::DetImpl<Detector>
   ///
   /// Initializing detector
   ///
-  void Initialize() final;
+  void InitializeO2Detector() override;
 
   ///
   /// Processing hit creation in the EMCAL scintillator volume

--- a/Detectors/EMCAL/simulation/src/Detector.cxx
+++ b/Detectors/EMCAL/simulation/src/Detector.cxx
@@ -88,7 +88,7 @@ Detector::Detector(const Detector& rhs)
   }
 }
 
-void Detector::Initialize()
+void Detector::InitializeO2Detector()
 {
   // Define sensitive volume
   TGeoVolume* vsense = gGeoManager->GetVolume("SCMX");
@@ -96,8 +96,6 @@ void Detector::Initialize()
     AddSensitiveVolume(vsense);
   else
     LOG(ERROR) << "EMCAL Sensitive volume SCMX not found ... No hit creation!\n";
-
-  o2::Base::Detector::Initialize();
 }
 
 void Detector::EndOfEvent() { Reset(); }

--- a/Detectors/FIT/simulation/include/FITSimulation/Detector.h
+++ b/Detectors/FIT/simulation/include/FITSimulation/Detector.h
@@ -59,7 +59,7 @@ class Detector : public o2::Base::DetImpl<Detector>
   Detector() = default;
 
   /// Initialization of the detector is done here
-  void Initialize() override;
+  void InitializeO2Detector() override;
 
   /// This method is called for each step during simulation (see FairMCApplication::Stepping())
   Bool_t ProcessHits(FairVolume* v) override;

--- a/Detectors/FIT/simulation/src/Detector.cxx
+++ b/Detectors/FIT/simulation/src/Detector.cxx
@@ -46,7 +46,7 @@ Detector::Detector(const Detector& rhs)
 {
 }
 
-void Detector::Initialize()
+void Detector::InitializeO2Detector()
 {
   // FIXME: we need to register the sensitive volumes with FairRoot
   TGeoVolume* v = gGeoManager->GetVolume("0REG");
@@ -55,8 +55,6 @@ void Detector::Initialize()
   else {
     AddSensitiveVolume(v);
   }
-
-  o2::Base::Detector::Initialize();
 }
 
 void Detector::ConstructGeometry()

--- a/Detectors/HMPID/simulation/include/HMPIDSimulation/Detector.h
+++ b/Detectors/HMPID/simulation/include/HMPIDSimulation/Detector.h
@@ -40,7 +40,7 @@ class Detector : public o2::Base::DetImpl<Detector>
     return nullptr;
   }
 
-  void Initialize() override;
+  void InitializeO2Detector() override;
   bool ProcessHits(FairVolume* v) override;
   HitType* AddHit(float x, float y, float z, float time, float energy, Int_t trackId, Int_t detId);
   void GenFee(float qtot);

--- a/Detectors/HMPID/simulation/src/Detector.cxx
+++ b/Detectors/HMPID/simulation/src/Detector.cxx
@@ -42,13 +42,12 @@ Detector::Detector(Bool_t active) : o2::Base::DetImpl<Detector>("HMP", active), 
 Detector::Detector(const Detector& other) : mSensitiveVolumes(other.mSensitiveVolumes),
                                             mHits(new std::vector<HitType>) {}
 
-void Detector::Initialize()
+void Detector::InitializeO2Detector()
 {
   for (auto sensitiveHpad : mSensitiveVolumes) {
     LOG(INFO) << "HMPID: registering sensitive " << sensitiveHpad->GetName();
     AddSensitiveVolume(sensitiveHpad);
   }
-  o2::Base::Detector::Initialize();
 }
 //*********************************************************************************************************
 bool Detector::ProcessHits(FairVolume* v)

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
@@ -94,7 +94,7 @@ class Detector : public o2::Base::DetImpl<Detector>
   ~Detector() override;
 
   /// Initialization of the detector is done here
-  void Initialize() override;
+  void InitializeO2Detector() override;
 
   /// This method is called for each step during simulation (see FairMCApplication::Stepping())
   Bool_t ProcessHits(FairVolume* v = nullptr) override;

--- a/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
@@ -243,7 +243,7 @@ Detector& Detector::operator=(const Detector& rhs)
   return *this;
 }
 
-void Detector::Initialize()
+void Detector::InitializeO2Detector()
 {
   // Define the list of sensitive volumes
   defineSensitiveVolumes();
@@ -253,9 +253,6 @@ void Detector::Initialize()
   }
 
   mGeometryTGeo = GeometryTGeo::Instance();
-
-  FairDetector::Initialize();
-
   //  FairRuntimeDb* rtdb= FairRun::Instance()->GetRuntimeDb();
   //  O2itsGeoPar* par=(O2itsGeoPar*)(rtdb->getContainer("O2itsGeoPar"));
 }

--- a/Detectors/ITSMFT/MFT/simulation/include/MFTSimulation/Detector.h
+++ b/Detectors/ITSMFT/MFT/simulation/include/MFTSimulation/Detector.h
@@ -55,7 +55,7 @@ class Detector : public o2::Base::DetImpl<Detector>
   ~Detector() override;
 
   /// Initialization of the detector is done here
-  void Initialize() override;
+  void InitializeO2Detector() override;
 
   /// This method is called for each step during simulation (see FairMCApplication::Stepping())
   Bool_t ProcessHits(FairVolume* v = nullptr) override;

--- a/Detectors/ITSMFT/MFT/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/MFT/simulation/src/Detector.cxx
@@ -90,14 +90,11 @@ Detector::~Detector()
 }
 
 //_____________________________________________________________________________
-void Detector::Initialize()
+void Detector::InitializeO2Detector()
 {
-
   mGeometryTGeo = GeometryTGeo::Instance();
 
   defineSensitiveVolumes();
-
-  FairDetector::Initialize();
 }
 
 //_____________________________________________________________________________

--- a/Detectors/MUON/MCH/Simulation/include/MCHSimulation/Detector.h
+++ b/Detectors/MUON/MCH/Simulation/include/MCHSimulation/Detector.h
@@ -32,7 +32,7 @@ class Detector : public o2::Base::DetImpl<Detector>
 
   Bool_t ProcessHits(FairVolume* v = nullptr) override;
 
-  void Initialize() override;
+  void InitializeO2Detector() override;
 
   void Register() override;
 

--- a/Detectors/MUON/MCH/Simulation/src/Detector.cxx
+++ b/Detectors/MUON/MCH/Simulation/src/Detector.cxx
@@ -46,10 +46,9 @@ void Detector::defineSensitiveVolumes()
   }
 }
 
-void Detector::Initialize()
+void Detector::InitializeO2Detector()
 {
   defineSensitiveVolumes();
-  o2::Base::Detector::Initialize();
 }
 
 void Detector::ConstructGeometry()

--- a/Detectors/PHOS/simulation/include/PHOSSimulation/Detector.h
+++ b/Detectors/PHOS/simulation/include/PHOSSimulation/Detector.h
@@ -75,7 +75,7 @@ class Detector : public o2::Base::DetImpl<Detector>
   ///
   /// Initializing detector
   ///
-  void Initialize() final;
+  void InitializeO2Detector() final;
 
   ///
   /// Processing hit creation in the PHOS crystalls

--- a/Detectors/PHOS/simulation/src/Detector.cxx
+++ b/Detectors/PHOS/simulation/src/Detector.cxx
@@ -54,9 +54,8 @@ Detector::Detector(const Detector& rhs)
 {
 }
 
-void Detector::Initialize()
+void Detector::InitializeO2Detector()
 {
-  o2::Base::Detector::Initialize();
   Reset();
 }
 

--- a/Detectors/TOF/simulation/include/TOFSimulation/Detector.h
+++ b/Detectors/TOF/simulation/include/TOFSimulation/Detector.h
@@ -17,7 +17,6 @@
 #include "SimulationDataFormat/BaseHits.h"
 
 class FairVolume;
-class TClonesArray;
 
 namespace o2
 {
@@ -53,7 +52,7 @@ class Detector : public o2::Base::DetImpl<Detector>
 
   ~Detector() override = default;
 
-  void Initialize() final;
+  void InitializeO2Detector() final;
 
   Bool_t ProcessHits(FairVolume* v = nullptr) final;
 

--- a/Detectors/TOF/simulation/src/Detector.cxx
+++ b/Detectors/TOF/simulation/src/Detector.cxx
@@ -43,7 +43,7 @@ Detector::Detector(const Detector& rhs)
     mTOFSectors[i] = rhs.mTOFSectors[i];
 }
 
-void Detector::Initialize()
+void Detector::InitializeO2Detector()
 {
   TGeoVolume* v = gGeoManager->GetVolume("FPAD");
   if (v == nullptr)
@@ -51,8 +51,6 @@ void Detector::Initialize()
   else {
     AddSensitiveVolume(v);
   }
-
-  o2::Base::Detector::Initialize();
 }
 
 Bool_t Detector::ProcessHits(FairVolume* v)

--- a/Detectors/TPC/simulation/include/TPCSimulation/Detector.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/Detector.h
@@ -71,7 +71,7 @@ class Detector: public o2::Base::DetImpl<Detector> {
    ~Detector() override;
 
    /**      Initialization of the detector is done here    */
-   void Initialize() override;
+   void InitializeO2Detector() override;
 
    /**       this method is called for each step during simulation
     *       (see FairMCApplication::Stepping())

--- a/Detectors/TPC/simulation/src/Detector.cxx
+++ b/Detectors/TPC/simulation/src/Detector.cxx
@@ -92,17 +92,10 @@ Detector::~Detector()
   std::cout << "Stepping called " << mStepCounter << "\n";
 }
 
-void Detector::Initialize()
+void Detector::InitializeO2Detector()
 {
   // Define the list of sensitive volumes
   DefineSensitiveVolumes();
-
-  // Register defined detectors in FairRoot maps
-  o2::Base::Detector::Initialize();
-  //     LOG(INFO) << "Initialize" << FairLogger::endl;
-
-  // Set the simulation type
-  FairRun* fRun = FairRun::Instance();
 }
 
 void Detector::SetSpecialPhysicsCuts()

--- a/Detectors/TRD/simulation/include/TRDSimulation/Detector.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Detector.h
@@ -33,7 +33,7 @@ class Detector : public o2::Base::DetImpl<Detector>
 
   ~Detector() override = default;
 
-  void Initialize() override;
+  void InitializeO2Detector() override;
 
   bool ProcessHits(FairVolume* v = nullptr) override;
 

--- a/Detectors/TRD/simulation/src/Detector.cxx
+++ b/Detectors/TRD/simulation/src/Detector.cxx
@@ -37,12 +37,10 @@ Detector::Detector(const Detector& rhs)
 {
 }
 
-void Detector::Initialize()
+void Detector::InitializeO2Detector()
 {
   // register the sensitive volumes with FairRoot
   defineSensitiveVolumes();
-
-  o2::Base::Detector::Initialize();
 }
 
 bool Detector::ProcessHits(FairVolume* v)


### PR DESCRIPTION
Provide a stricter detector initialization mechanism.
In the past, each detector was expected/obliged to call
the init function of the mother class itself. This is now
expressed in a better mechanism.
Also leads to less code.