### PR TITLE
MFT: add mapping information for raw data

### DIFF
--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/GeometryTGeo.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/GeometryTGeo.h
@@ -89,6 +89,23 @@ class GeometryTGeo : public o2::ITSMFT::GeometryTGeo
   /// get layer index (0:9) from the chip index
   Int_t getLayer(Int_t index) const;
 
+  /// This routine computes the half, disk, ladder and sensor number
+  /// given the sensor index number
+  /// \param int index The sensor index number, starting from zero.
+  /// \param int half The half number. Starting from 0
+  /// \param int disk The disk number in a half. Starting from 0
+  /// \param int ladder The ladder number in a disk. Starting from 0
+  /// \param int sensor The sensor number in a ladder. Starting from 0
+  Bool_t getSensorID(Int_t index, Int_t& half, Int_t& disk, Int_t& ladder, Int_t& sensor) const;
+
+  /// Returns the number of sensors in each ladder of each disk of each half
+  /// ladder is the matrix ID and is converted to geometry ID
+  Int_t getNumberOfSensorsPerLadder(Int_t half, Int_t disk, Int_t ladder) const
+  {
+    Int_t ladderID = mLadderIndex2Id[disk][ladder];
+    return extractNumberOfSensorsPerLadder(half, disk, ladderID);
+  }
+
  protected:
   /// Determines the number of detector halves in the Geometry
   Int_t extractNumberOfHalves();
@@ -119,22 +136,13 @@ class GeometryTGeo : public o2::ITSMFT::GeometryTGeo
   /// intersects the sensor surface
   void extractSensorXAlpha(int index, float& x, float& alp);
 
-  /// This routine computes the half, disk, ladder and sensor number
-  /// given the sensor index number
-  /// \param int index The sensor index number, starting from zero.
-  /// \param int half The half number. Starting from 0
-  /// \param int disk The disk number in a half. Starting from 0
-  /// \param int ladder The ladder number in a disk. Starting from 0
-  /// \param int sensor The sensor number in a ladder. Starting from 0
-  Bool_t getSensorID(Int_t index, Int_t& half, Int_t& disk, Int_t& ladder, Int_t& sensor) const;
-
   /// From matrix index to half ID
   Int_t getHalf(Int_t index) const;
 
   /// From matrix index to disk ID
   Int_t getDisk(Int_t index) const;
 
-  /// From matrix index to ladder ID
+  /// From matrix index to ladder ID (matrix)
   Int_t getLadder(Int_t index) const;
 
   /// In a disk start numbering the sensors from zero

--- a/Detectors/ITSMFT/MFT/macros/test/extractMFTMapping.C
+++ b/Detectors/ITSMFT/MFT/macros/test/extractMFTMapping.C
@@ -1,0 +1,87 @@
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include <FairLogger.h>
+#include <stdio.h>
+#include <vector>
+#include "MFTBase/GeometryTGeo.h"
+#endif
+/*
+  This macro generates the mapping 
+  global chipID  <-> {global module ID, chip in module}
+  needed for the raw data pixel reader
+  The mapping is generated from the local geometry file and
+  should be put in the directory on which the PixelReader may depend
+*/
+void extractMFTMapping(const std::string inputGeom = "O2geometry.root")
+{
+
+  o2::Base::GeometryManager::loadGeometry(inputGeom, "FAIRGeom");
+  auto gm = o2::MFT::GeometryTGeo::Instance(); // geometry manager for mapping
+
+  // ladder (MFT) = module (ITS)
+  Int_t chip, ladder, layer, disk, half, ladderP = -1, layerP = -1, halfP = -1;
+  Int_t sensor, nChipsPerLadder;
+  Int_t nModules = 0;
+  Int_t nChips = gm->getNumberOfChips();
+  std::vector<Int_t> modFirstChip, modNChips;
+
+  FILE* srcFile = fopen("ChipMappingMFT.cxx", "w");
+
+  fprintf(srcFile,
+          "// Copyright CERN and copyright holders of ALICE O2. This software is\n"
+          "// distributed under the terms of the GNU General Public License v3 (GPL\n"
+          "// Version 3), copied verbatim in the file \"COPYING\".\n"
+          "//\n"
+          "// See http://alice-o2.web.cern.ch/license for full licensing information.\n"
+          "//\n"
+          "// In applying this license CERN does not waive the privileges and immunities\n"
+          "// granted to it by virtue of its status as an Intergovernmental Organization\n"
+          "// or submit itself to any jurisdiction.\n\n"
+          "// \\file ChipMappingITS.cxx \n"
+          "// \\brief Automatically generated MFT chip <-> module mapping\n");
+
+  fprintf(srcFile, "%s\n\n", R"(#include "ITSMFTReconstruction/ChipMappingMFT.h")");
+  fprintf(srcFile, "using namespace o2::ITSMFT;\n");
+  fprintf(srcFile, "const std::array<MFTChipMappingData,ChipMappingMFT::NChips> ChipMappingMFT::ChipMappingData\n{{\n");
+
+  for (Int_t iChip = 0; iChip < nChips; iChip++) {
+    gm->getSensorID(iChip, half, disk, ladder, sensor);
+    layer = gm->getLayer(iChip);
+    //printf("%4d   %1d   %2d   %1d   %1d   %1d \n",iChip,sensor,ladder,layer,disk,half);
+    if (layer != layerP || ladder != ladderP || half != halfP) { // new module
+      layerP = layer;
+      ladderP = ladder;
+      halfP = half;
+      modFirstChip.push_back(iChip);
+      nChipsPerLadder = gm->getNumberOfSensorsPerLadder(half, disk, ladder);
+      modNChips.push_back(nChipsPerLadder);
+      nModules++;
+      fprintf(srcFile, "// chip: %3d (%1d), ladder: %2d, layer: %1d, disk: %1d, half: %1d\n", iChip, nChipsPerLadder, ladder, layer, disk, half);
+    }
+    fprintf(srcFile, "{%d, %d}%s\n", (nModules - 1), sensor, (iChip < nChips - 1 ? "," : ""));
+  }
+
+  fprintf(srcFile, "\n}};\n\n");
+
+  fprintf(srcFile,
+          "const std::array<MFTModuleMappingData,ChipMappingMFT::NModules> "
+          "ChipMappingMFT::ModuleMappingData\n{{\n");
+
+  layerP = -1;
+  for (int iMod = 0; iMod < nModules; iMod++) {
+    gm->getSensorID(modFirstChip[iMod], half, disk, ladder, sensor);
+    layer = gm->getLayer(modFirstChip[iMod]);
+    if (layer != layerP) {
+      layerP = layer;
+      fprintf(srcFile, "\n// layer: %d\n", layer);
+    }
+    fprintf(srcFile, " {%d, %d, %d}%s\n", layer, modNChips[iMod], modFirstChip[iMod], (iMod < nModules - 1 ? "," : ""));
+    /*
+    if (iMod && (iMod % 7) == 0) {
+      fprintf(srcFile, "\n");
+    }
+    */
+  }
+
+  fprintf(srcFile, "\n}};\n");
+  fclose(srcFile);
+}

--- a/Detectors/ITSMFT/MFT/reconstruction/src/ClustererTask.cxx
+++ b/Detectors/ITSMFT/MFT/reconstruction/src/ClustererTask.cxx
@@ -103,10 +103,10 @@ void ClustererTask::attachFairManagerIO()
     LOG(WARNING) << "MFT clusters storage is not requested, suppressing MCTruth storage" << FairLogger::endl;
   }
 
-  const auto arrDigLbl = mUseMCTruth ? mgr->InitObjectAs<const MCTruth*>("ITSDigitMCTruth") : nullptr;
+  const auto arrDigLbl = mUseMCTruth ? mgr->InitObjectAs<const MCTruth*>("MFTDigitMCTruth") : nullptr;
 
   if (!arrDigLbl && mUseMCTruth) {
-    LOG(WARNING) << "MFT digits labeals are not registered in the FairRootManager. Continue w/o MC truth ..."
+    LOG(WARNING) << "MFT digits labels are not registered in the FairRootManager. Continue w/o MC truth ..."
                  << FairLogger::endl;
   }
   mReaderMC->setDigitsMCTruth(arrDigLbl);

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ChipMappingMFT.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ChipMappingMFT.h
@@ -22,6 +22,19 @@ namespace o2
 namespace ITSMFT
 {
 
+struct MFTChipMappingData {
+  UShort_t module = 0;      // global module ID
+  UChar_t chipInModule = 0; // chip within the module
+  ClassDefNV(MFTChipMappingData, 1);
+};
+
+struct MFTModuleMappingData {
+  UChar_t layer = 0;        // layer id
+  UChar_t nChips = 0;       // number of chips
+  UShort_t firstChipID = 0; // global id of 1st chip
+  ClassDefNV(MFTModuleMappingData, 1);
+};
+
 class ChipMappingMFT
 {
  public:
@@ -30,39 +43,42 @@ class ChipMappingMFT
 
   int chipID2Module(int chipID, int& chipInModule) const
   {
-    chipInModule = -1;
-    return invalid();
+    chipInModule = ChipMappingData[chipID].chipInModule;
+    return ChipMappingData[chipID].module;
   }
 
   int chipID2Module(int chipID) const
   {
-    return invalid();
+    return ChipMappingData[chipID].module;
   }
 
   int getNChipsInModule(int modID) const
   {
-    return invalid();
+    return ModuleMappingData[modID].nChips;
   }
 
   int module2ChipID(int modID, int chipInModule) const
   {
-    return invalid();
+    return ModuleMappingData[modID].firstChipID + chipInModule;
   }
 
   int module2Layer(int modID) const
   {
-    return invalid();
+    return ModuleMappingData[modID].layer;
   }
 
   int chip2Layer(int chipID) const
   {
-    return invalid();
+    return ModuleMappingData[ChipMappingData[chipID].module].layer;
   }
 
  private:
   int invalid() const;
-  static constexpr int NModules = -1;
+  static constexpr int NModules = 280;
   static constexpr int NChips = 920;
+
+  static const std::array<MFTChipMappingData, NChips> ChipMappingData;
+  static const std::array<MFTModuleMappingData, NModules> ModuleMappingData;
 
   ClassDefNV(ChipMappingMFT, 1)
 };

--- a/Detectors/ITSMFT/common/reconstruction/src/ChipMappingMFT.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/ChipMappingMFT.cxx
@@ -8,16 +8,1606 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-// \file ChipMappingMFT.cxx
-// \brief DUMMY MFT chip <-> module mapping
-
+// \file ChipMappingITS.cxx
+// \brief Automatically generated MFT chip <-> module mapping
 #include "ITSMFTReconstruction/ChipMappingMFT.h"
-#include "FairLogger.h"
 
 using namespace o2::ITSMFT;
+const std::array<MFTChipMappingData, ChipMappingMFT::NChips> ChipMappingMFT::ChipMappingData{ { // chip:   0 (2), ladder:  0, layer: 0, disk: 0, half: 0
+                                                                                                { 0, 0 },
+                                                                                                { 0, 1 },
+                                                                                                // chip:   2 (2), ladder:  1, layer: 0, disk: 0, half: 0
+                                                                                                { 1, 0 },
+                                                                                                { 1, 1 },
+                                                                                                // chip:   4 (2), ladder:  2, layer: 0, disk: 0, half: 0
+                                                                                                { 2, 0 },
+                                                                                                { 2, 1 },
+                                                                                                // chip:   6 (2), ladder:  3, layer: 1, disk: 0, half: 0
+                                                                                                { 3, 0 },
+                                                                                                { 3, 1 },
+                                                                                                // chip:   8 (2), ladder:  4, layer: 1, disk: 0, half: 0
+                                                                                                { 4, 0 },
+                                                                                                { 4, 1 },
+                                                                                                // chip:  10 (2), ladder:  5, layer: 1, disk: 0, half: 0
+                                                                                                { 5, 0 },
+                                                                                                { 5, 1 },
+                                                                                                // chip:  12 (3), ladder:  6, layer: 0, disk: 0, half: 0
+                                                                                                { 6, 0 },
+                                                                                                { 6, 1 },
+                                                                                                { 6, 2 },
+                                                                                                // chip:  15 (3), ladder:  7, layer: 0, disk: 0, half: 0
+                                                                                                { 7, 0 },
+                                                                                                { 7, 1 },
+                                                                                                { 7, 2 },
+                                                                                                // chip:  18 (3), ladder:  8, layer: 0, disk: 0, half: 0
+                                                                                                { 8, 0 },
+                                                                                                { 8, 1 },
+                                                                                                { 8, 2 },
+                                                                                                // chip:  21 (3), ladder:  9, layer: 0, disk: 0, half: 0
+                                                                                                { 9, 0 },
+                                                                                                { 9, 1 },
+                                                                                                { 9, 2 },
+                                                                                                // chip:  24 (3), ladder: 10, layer: 0, disk: 0, half: 0
+                                                                                                { 10, 0 },
+                                                                                                { 10, 1 },
+                                                                                                { 10, 2 },
+                                                                                                // chip:  27 (3), ladder: 11, layer: 0, disk: 0, half: 0
+                                                                                                { 11, 0 },
+                                                                                                { 11, 1 },
+                                                                                                { 11, 2 },
+                                                                                                // chip:  30 (3), ladder: 12, layer: 0, disk: 0, half: 0
+                                                                                                { 12, 0 },
+                                                                                                { 12, 1 },
+                                                                                                { 12, 2 },
+                                                                                                // chip:  33 (3), ladder: 13, layer: 0, disk: 0, half: 0
+                                                                                                { 13, 0 },
+                                                                                                { 13, 1 },
+                                                                                                { 13, 2 },
+                                                                                                // chip:  36 (3), ladder: 14, layer: 0, disk: 0, half: 0
+                                                                                                { 14, 0 },
+                                                                                                { 14, 1 },
+                                                                                                { 14, 2 },
+                                                                                                // chip:  39 (3), ladder: 15, layer: 1, disk: 0, half: 0
+                                                                                                { 15, 0 },
+                                                                                                { 15, 1 },
+                                                                                                { 15, 2 },
+                                                                                                // chip:  42 (3), ladder: 16, layer: 1, disk: 0, half: 0
+                                                                                                { 16, 0 },
+                                                                                                { 16, 1 },
+                                                                                                { 16, 2 },
+                                                                                                // chip:  45 (3), ladder: 17, layer: 1, disk: 0, half: 0
+                                                                                                { 17, 0 },
+                                                                                                { 17, 1 },
+                                                                                                { 17, 2 },
+                                                                                                // chip:  48 (3), ladder: 18, layer: 1, disk: 0, half: 0
+                                                                                                { 18, 0 },
+                                                                                                { 18, 1 },
+                                                                                                { 18, 2 },
+                                                                                                // chip:  51 (3), ladder: 19, layer: 1, disk: 0, half: 0
+                                                                                                { 19, 0 },
+                                                                                                { 19, 1 },
+                                                                                                { 19, 2 },
+                                                                                                // chip:  54 (3), ladder: 20, layer: 1, disk: 0, half: 0
+                                                                                                { 20, 0 },
+                                                                                                { 20, 1 },
+                                                                                                { 20, 2 },
+                                                                                                // chip:  57 (3), ladder: 21, layer: 1, disk: 0, half: 0
+                                                                                                { 21, 0 },
+                                                                                                { 21, 1 },
+                                                                                                { 21, 2 },
+                                                                                                // chip:  60 (3), ladder: 22, layer: 1, disk: 0, half: 0
+                                                                                                { 22, 0 },
+                                                                                                { 22, 1 },
+                                                                                                { 22, 2 },
+                                                                                                // chip:  63 (3), ladder: 23, layer: 1, disk: 0, half: 0
+                                                                                                { 23, 0 },
+                                                                                                { 23, 1 },
+                                                                                                { 23, 2 },
+                                                                                                // chip:  66 (2), ladder:  0, layer: 2, disk: 1, half: 0
+                                                                                                { 24, 0 },
+                                                                                                { 24, 1 },
+                                                                                                // chip:  68 (2), ladder:  1, layer: 2, disk: 1, half: 0
+                                                                                                { 25, 0 },
+                                                                                                { 25, 1 },
+                                                                                                // chip:  70 (2), ladder:  2, layer: 2, disk: 1, half: 0
+                                                                                                { 26, 0 },
+                                                                                                { 26, 1 },
+                                                                                                // chip:  72 (2), ladder:  3, layer: 3, disk: 1, half: 0
+                                                                                                { 27, 0 },
+                                                                                                { 27, 1 },
+                                                                                                // chip:  74 (2), ladder:  4, layer: 3, disk: 1, half: 0
+                                                                                                { 28, 0 },
+                                                                                                { 28, 1 },
+                                                                                                // chip:  76 (2), ladder:  5, layer: 3, disk: 1, half: 0
+                                                                                                { 29, 0 },
+                                                                                                { 29, 1 },
+                                                                                                // chip:  78 (3), ladder:  6, layer: 2, disk: 1, half: 0
+                                                                                                { 30, 0 },
+                                                                                                { 30, 1 },
+                                                                                                { 30, 2 },
+                                                                                                // chip:  81 (3), ladder:  7, layer: 2, disk: 1, half: 0
+                                                                                                { 31, 0 },
+                                                                                                { 31, 1 },
+                                                                                                { 31, 2 },
+                                                                                                // chip:  84 (3), ladder:  8, layer: 2, disk: 1, half: 0
+                                                                                                { 32, 0 },
+                                                                                                { 32, 1 },
+                                                                                                { 32, 2 },
+                                                                                                // chip:  87 (3), ladder:  9, layer: 2, disk: 1, half: 0
+                                                                                                { 33, 0 },
+                                                                                                { 33, 1 },
+                                                                                                { 33, 2 },
+                                                                                                // chip:  90 (3), ladder: 10, layer: 2, disk: 1, half: 0
+                                                                                                { 34, 0 },
+                                                                                                { 34, 1 },
+                                                                                                { 34, 2 },
+                                                                                                // chip:  93 (3), ladder: 11, layer: 2, disk: 1, half: 0
+                                                                                                { 35, 0 },
+                                                                                                { 35, 1 },
+                                                                                                { 35, 2 },
+                                                                                                // chip:  96 (3), ladder: 12, layer: 2, disk: 1, half: 0
+                                                                                                { 36, 0 },
+                                                                                                { 36, 1 },
+                                                                                                { 36, 2 },
+                                                                                                // chip:  99 (3), ladder: 13, layer: 2, disk: 1, half: 0
+                                                                                                { 37, 0 },
+                                                                                                { 37, 1 },
+                                                                                                { 37, 2 },
+                                                                                                // chip: 102 (3), ladder: 14, layer: 2, disk: 1, half: 0
+                                                                                                { 38, 0 },
+                                                                                                { 38, 1 },
+                                                                                                { 38, 2 },
+                                                                                                // chip: 105 (3), ladder: 15, layer: 3, disk: 1, half: 0
+                                                                                                { 39, 0 },
+                                                                                                { 39, 1 },
+                                                                                                { 39, 2 },
+                                                                                                // chip: 108 (3), ladder: 16, layer: 3, disk: 1, half: 0
+                                                                                                { 40, 0 },
+                                                                                                { 40, 1 },
+                                                                                                { 40, 2 },
+                                                                                                // chip: 111 (3), ladder: 17, layer: 3, disk: 1, half: 0
+                                                                                                { 41, 0 },
+                                                                                                { 41, 1 },
+                                                                                                { 41, 2 },
+                                                                                                // chip: 114 (3), ladder: 18, layer: 3, disk: 1, half: 0
+                                                                                                { 42, 0 },
+                                                                                                { 42, 1 },
+                                                                                                { 42, 2 },
+                                                                                                // chip: 117 (3), ladder: 19, layer: 3, disk: 1, half: 0
+                                                                                                { 43, 0 },
+                                                                                                { 43, 1 },
+                                                                                                { 43, 2 },
+                                                                                                // chip: 120 (3), ladder: 20, layer: 3, disk: 1, half: 0
+                                                                                                { 44, 0 },
+                                                                                                { 44, 1 },
+                                                                                                { 44, 2 },
+                                                                                                // chip: 123 (3), ladder: 21, layer: 3, disk: 1, half: 0
+                                                                                                { 45, 0 },
+                                                                                                { 45, 1 },
+                                                                                                { 45, 2 },
+                                                                                                // chip: 126 (3), ladder: 22, layer: 3, disk: 1, half: 0
+                                                                                                { 46, 0 },
+                                                                                                { 46, 1 },
+                                                                                                { 46, 2 },
+                                                                                                // chip: 129 (3), ladder: 23, layer: 3, disk: 1, half: 0
+                                                                                                { 47, 0 },
+                                                                                                { 47, 1 },
+                                                                                                { 47, 2 },
+                                                                                                // chip: 132 (2), ladder:  0, layer: 4, disk: 2, half: 0
+                                                                                                { 48, 0 },
+                                                                                                { 48, 1 },
+                                                                                                // chip: 134 (2), ladder:  1, layer: 4, disk: 2, half: 0
+                                                                                                { 49, 0 },
+                                                                                                { 49, 1 },
+                                                                                                // chip: 136 (2), ladder:  2, layer: 5, disk: 2, half: 0
+                                                                                                { 50, 0 },
+                                                                                                { 50, 1 },
+                                                                                                // chip: 138 (2), ladder:  3, layer: 5, disk: 2, half: 0
+                                                                                                { 51, 0 },
+                                                                                                { 51, 1 },
+                                                                                                // chip: 140 (3), ladder:  4, layer: 4, disk: 2, half: 0
+                                                                                                { 52, 0 },
+                                                                                                { 52, 1 },
+                                                                                                { 52, 2 },
+                                                                                                // chip: 143 (3), ladder:  5, layer: 4, disk: 2, half: 0
+                                                                                                { 53, 0 },
+                                                                                                { 53, 1 },
+                                                                                                { 53, 2 },
+                                                                                                // chip: 146 (3), ladder:  6, layer: 4, disk: 2, half: 0
+                                                                                                { 54, 0 },
+                                                                                                { 54, 1 },
+                                                                                                { 54, 2 },
+                                                                                                // chip: 149 (3), ladder:  7, layer: 4, disk: 2, half: 0
+                                                                                                { 55, 0 },
+                                                                                                { 55, 1 },
+                                                                                                { 55, 2 },
+                                                                                                // chip: 152 (3), ladder:  8, layer: 4, disk: 2, half: 0
+                                                                                                { 56, 0 },
+                                                                                                { 56, 1 },
+                                                                                                { 56, 2 },
+                                                                                                // chip: 155 (3), ladder:  9, layer: 4, disk: 2, half: 0
+                                                                                                { 57, 0 },
+                                                                                                { 57, 1 },
+                                                                                                { 57, 2 },
+                                                                                                // chip: 158 (3), ladder: 10, layer: 4, disk: 2, half: 0
+                                                                                                { 58, 0 },
+                                                                                                { 58, 1 },
+                                                                                                { 58, 2 },
+                                                                                                // chip: 161 (3), ladder: 11, layer: 5, disk: 2, half: 0
+                                                                                                { 59, 0 },
+                                                                                                { 59, 1 },
+                                                                                                { 59, 2 },
+                                                                                                // chip: 164 (3), ladder: 12, layer: 5, disk: 2, half: 0
+                                                                                                { 60, 0 },
+                                                                                                { 60, 1 },
+                                                                                                { 60, 2 },
+                                                                                                // chip: 167 (3), ladder: 13, layer: 5, disk: 2, half: 0
+                                                                                                { 61, 0 },
+                                                                                                { 61, 1 },
+                                                                                                { 61, 2 },
+                                                                                                // chip: 170 (3), ladder: 14, layer: 5, disk: 2, half: 0
+                                                                                                { 62, 0 },
+                                                                                                { 62, 1 },
+                                                                                                { 62, 2 },
+                                                                                                // chip: 173 (3), ladder: 15, layer: 5, disk: 2, half: 0
+                                                                                                { 63, 0 },
+                                                                                                { 63, 1 },
+                                                                                                { 63, 2 },
+                                                                                                // chip: 176 (3), ladder: 16, layer: 5, disk: 2, half: 0
+                                                                                                { 64, 0 },
+                                                                                                { 64, 1 },
+                                                                                                { 64, 2 },
+                                                                                                // chip: 179 (3), ladder: 17, layer: 5, disk: 2, half: 0
+                                                                                                { 65, 0 },
+                                                                                                { 65, 1 },
+                                                                                                { 65, 2 },
+                                                                                                // chip: 182 (4), ladder: 18, layer: 4, disk: 2, half: 0
+                                                                                                { 66, 0 },
+                                                                                                { 66, 1 },
+                                                                                                { 66, 2 },
+                                                                                                { 66, 3 },
+                                                                                                // chip: 186 (4), ladder: 19, layer: 4, disk: 2, half: 0
+                                                                                                { 67, 0 },
+                                                                                                { 67, 1 },
+                                                                                                { 67, 2 },
+                                                                                                { 67, 3 },
+                                                                                                // chip: 190 (4), ladder: 20, layer: 4, disk: 2, half: 0
+                                                                                                { 68, 0 },
+                                                                                                { 68, 1 },
+                                                                                                { 68, 2 },
+                                                                                                { 68, 3 },
+                                                                                                // chip: 194 (4), ladder: 21, layer: 4, disk: 2, half: 0
+                                                                                                { 69, 0 },
+                                                                                                { 69, 1 },
+                                                                                                { 69, 2 },
+                                                                                                { 69, 3 },
+                                                                                                // chip: 198 (4), ladder: 22, layer: 5, disk: 2, half: 0
+                                                                                                { 70, 0 },
+                                                                                                { 70, 1 },
+                                                                                                { 70, 2 },
+                                                                                                { 70, 3 },
+                                                                                                // chip: 202 (4), ladder: 23, layer: 5, disk: 2, half: 0
+                                                                                                { 71, 0 },
+                                                                                                { 71, 1 },
+                                                                                                { 71, 2 },
+                                                                                                { 71, 3 },
+                                                                                                // chip: 206 (4), ladder: 24, layer: 5, disk: 2, half: 0
+                                                                                                { 72, 0 },
+                                                                                                { 72, 1 },
+                                                                                                { 72, 2 },
+                                                                                                { 72, 3 },
+                                                                                                // chip: 210 (4), ladder: 25, layer: 5, disk: 2, half: 0
+                                                                                                { 73, 0 },
+                                                                                                { 73, 1 },
+                                                                                                { 73, 2 },
+                                                                                                { 73, 3 },
+                                                                                                // chip: 214 (2), ladder:  0, layer: 6, disk: 3, half: 0
+                                                                                                { 74, 0 },
+                                                                                                { 74, 1 },
+                                                                                                // chip: 216 (2), ladder:  1, layer: 6, disk: 3, half: 0
+                                                                                                { 75, 0 },
+                                                                                                { 75, 1 },
+                                                                                                // chip: 218 (2), ladder:  2, layer: 7, disk: 3, half: 0
+                                                                                                { 76, 0 },
+                                                                                                { 76, 1 },
+                                                                                                // chip: 220 (2), ladder:  3, layer: 7, disk: 3, half: 0
+                                                                                                { 77, 0 },
+                                                                                                { 77, 1 },
+                                                                                                // chip: 222 (3), ladder:  4, layer: 6, disk: 3, half: 0
+                                                                                                { 78, 0 },
+                                                                                                { 78, 1 },
+                                                                                                { 78, 2 },
+                                                                                                // chip: 225 (3), ladder:  5, layer: 6, disk: 3, half: 0
+                                                                                                { 79, 0 },
+                                                                                                { 79, 1 },
+                                                                                                { 79, 2 },
+                                                                                                // chip: 228 (3), ladder:  6, layer: 6, disk: 3, half: 0
+                                                                                                { 80, 0 },
+                                                                                                { 80, 1 },
+                                                                                                { 80, 2 },
+                                                                                                // chip: 231 (3), ladder:  7, layer: 7, disk: 3, half: 0
+                                                                                                { 81, 0 },
+                                                                                                { 81, 1 },
+                                                                                                { 81, 2 },
+                                                                                                // chip: 234 (3), ladder:  8, layer: 7, disk: 3, half: 0
+                                                                                                { 82, 0 },
+                                                                                                { 82, 1 },
+                                                                                                { 82, 2 },
+                                                                                                // chip: 237 (3), ladder:  9, layer: 7, disk: 3, half: 0
+                                                                                                { 83, 0 },
+                                                                                                { 83, 1 },
+                                                                                                { 83, 2 },
+                                                                                                // chip: 240 (4), ladder: 10, layer: 6, disk: 3, half: 0
+                                                                                                { 84, 0 },
+                                                                                                { 84, 1 },
+                                                                                                { 84, 2 },
+                                                                                                { 84, 3 },
+                                                                                                // chip: 244 (4), ladder: 11, layer: 6, disk: 3, half: 0
+                                                                                                { 85, 0 },
+                                                                                                { 85, 1 },
+                                                                                                { 85, 2 },
+                                                                                                { 85, 3 },
+                                                                                                // chip: 248 (4), ladder: 12, layer: 6, disk: 3, half: 0
+                                                                                                { 86, 0 },
+                                                                                                { 86, 1 },
+                                                                                                { 86, 2 },
+                                                                                                { 86, 3 },
+                                                                                                // chip: 252 (4), ladder: 13, layer: 6, disk: 3, half: 0
+                                                                                                { 87, 0 },
+                                                                                                { 87, 1 },
+                                                                                                { 87, 2 },
+                                                                                                { 87, 3 },
+                                                                                                // chip: 256 (4), ladder: 14, layer: 6, disk: 3, half: 0
+                                                                                                { 88, 0 },
+                                                                                                { 88, 1 },
+                                                                                                { 88, 2 },
+                                                                                                { 88, 3 },
+                                                                                                // chip: 260 (4), ladder: 15, layer: 6, disk: 3, half: 0
+                                                                                                { 89, 0 },
+                                                                                                { 89, 1 },
+                                                                                                { 89, 2 },
+                                                                                                { 89, 3 },
+                                                                                                // chip: 264 (4), ladder: 16, layer: 6, disk: 3, half: 0
+                                                                                                { 90, 0 },
+                                                                                                { 90, 1 },
+                                                                                                { 90, 2 },
+                                                                                                { 90, 3 },
+                                                                                                // chip: 268 (4), ladder: 17, layer: 6, disk: 3, half: 0
+                                                                                                { 91, 0 },
+                                                                                                { 91, 1 },
+                                                                                                { 91, 2 },
+                                                                                                { 91, 3 },
+                                                                                                // chip: 272 (4), ladder: 18, layer: 6, disk: 3, half: 0
+                                                                                                { 92, 0 },
+                                                                                                { 92, 1 },
+                                                                                                { 92, 2 },
+                                                                                                { 92, 3 },
+                                                                                                // chip: 276 (4), ladder: 19, layer: 6, disk: 3, half: 0
+                                                                                                { 93, 0 },
+                                                                                                { 93, 1 },
+                                                                                                { 93, 2 },
+                                                                                                { 93, 3 },
+                                                                                                // chip: 280 (4), ladder: 20, layer: 6, disk: 3, half: 0
+                                                                                                { 94, 0 },
+                                                                                                { 94, 1 },
+                                                                                                { 94, 2 },
+                                                                                                { 94, 3 },
+                                                                                                // chip: 284 (4), ladder: 21, layer: 7, disk: 3, half: 0
+                                                                                                { 95, 0 },
+                                                                                                { 95, 1 },
+                                                                                                { 95, 2 },
+                                                                                                { 95, 3 },
+                                                                                                // chip: 288 (4), ladder: 22, layer: 7, disk: 3, half: 0
+                                                                                                { 96, 0 },
+                                                                                                { 96, 1 },
+                                                                                                { 96, 2 },
+                                                                                                { 96, 3 },
+                                                                                                // chip: 292 (4), ladder: 23, layer: 7, disk: 3, half: 0
+                                                                                                { 97, 0 },
+                                                                                                { 97, 1 },
+                                                                                                { 97, 2 },
+                                                                                                { 97, 3 },
+                                                                                                // chip: 296 (4), ladder: 24, layer: 7, disk: 3, half: 0
+                                                                                                { 98, 0 },
+                                                                                                { 98, 1 },
+                                                                                                { 98, 2 },
+                                                                                                { 98, 3 },
+                                                                                                // chip: 300 (4), ladder: 25, layer: 7, disk: 3, half: 0
+                                                                                                { 99, 0 },
+                                                                                                { 99, 1 },
+                                                                                                { 99, 2 },
+                                                                                                { 99, 3 },
+                                                                                                // chip: 304 (4), ladder: 26, layer: 7, disk: 3, half: 0
+                                                                                                { 100, 0 },
+                                                                                                { 100, 1 },
+                                                                                                { 100, 2 },
+                                                                                                { 100, 3 },
+                                                                                                // chip: 308 (4), ladder: 27, layer: 7, disk: 3, half: 0
+                                                                                                { 101, 0 },
+                                                                                                { 101, 1 },
+                                                                                                { 101, 2 },
+                                                                                                { 101, 3 },
+                                                                                                // chip: 312 (4), ladder: 28, layer: 7, disk: 3, half: 0
+                                                                                                { 102, 0 },
+                                                                                                { 102, 1 },
+                                                                                                { 102, 2 },
+                                                                                                { 102, 3 },
+                                                                                                // chip: 316 (4), ladder: 29, layer: 7, disk: 3, half: 0
+                                                                                                { 103, 0 },
+                                                                                                { 103, 1 },
+                                                                                                { 103, 2 },
+                                                                                                { 103, 3 },
+                                                                                                // chip: 320 (4), ladder: 30, layer: 7, disk: 3, half: 0
+                                                                                                { 104, 0 },
+                                                                                                { 104, 1 },
+                                                                                                { 104, 2 },
+                                                                                                { 104, 3 },
+                                                                                                // chip: 324 (4), ladder: 31, layer: 7, disk: 3, half: 0
+                                                                                                { 105, 0 },
+                                                                                                { 105, 1 },
+                                                                                                { 105, 2 },
+                                                                                                { 105, 3 },
+                                                                                                // chip: 328 (2), ladder:  0, layer: 8, disk: 4, half: 0
+                                                                                                { 106, 0 },
+                                                                                                { 106, 1 },
+                                                                                                // chip: 330 (2), ladder:  1, layer: 8, disk: 4, half: 0
+                                                                                                { 107, 0 },
+                                                                                                { 107, 1 },
+                                                                                                // chip: 332 (2), ladder:  2, layer: 9, disk: 4, half: 0
+                                                                                                { 108, 0 },
+                                                                                                { 108, 1 },
+                                                                                                // chip: 334 (2), ladder:  3, layer: 9, disk: 4, half: 0
+                                                                                                { 109, 0 },
+                                                                                                { 109, 1 },
+                                                                                                // chip: 336 (3), ladder:  4, layer: 8, disk: 4, half: 0
+                                                                                                { 110, 0 },
+                                                                                                { 110, 1 },
+                                                                                                { 110, 2 },
+                                                                                                // chip: 339 (3), ladder:  5, layer: 8, disk: 4, half: 0
+                                                                                                { 111, 0 },
+                                                                                                { 111, 1 },
+                                                                                                { 111, 2 },
+                                                                                                // chip: 342 (3), ladder:  6, layer: 9, disk: 4, half: 0
+                                                                                                { 112, 0 },
+                                                                                                { 112, 1 },
+                                                                                                { 112, 2 },
+                                                                                                // chip: 345 (3), ladder:  7, layer: 9, disk: 4, half: 0
+                                                                                                { 113, 0 },
+                                                                                                { 113, 1 },
+                                                                                                { 113, 2 },
+                                                                                                // chip: 348 (4), ladder:  8, layer: 8, disk: 4, half: 0
+                                                                                                { 114, 0 },
+                                                                                                { 114, 1 },
+                                                                                                { 114, 2 },
+                                                                                                { 114, 3 },
+                                                                                                // chip: 352 (4), ladder:  9, layer: 8, disk: 4, half: 0
+                                                                                                { 115, 0 },
+                                                                                                { 115, 1 },
+                                                                                                { 115, 2 },
+                                                                                                { 115, 3 },
+                                                                                                // chip: 356 (4), ladder: 10, layer: 8, disk: 4, half: 0
+                                                                                                { 116, 0 },
+                                                                                                { 116, 1 },
+                                                                                                { 116, 2 },
+                                                                                                { 116, 3 },
+                                                                                                // chip: 360 (4), ladder: 11, layer: 8, disk: 4, half: 0
+                                                                                                { 117, 0 },
+                                                                                                { 117, 1 },
+                                                                                                { 117, 2 },
+                                                                                                { 117, 3 },
+                                                                                                // chip: 364 (4), ladder: 12, layer: 8, disk: 4, half: 0
+                                                                                                { 118, 0 },
+                                                                                                { 118, 1 },
+                                                                                                { 118, 2 },
+                                                                                                { 118, 3 },
+                                                                                                // chip: 368 (4), ladder: 13, layer: 8, disk: 4, half: 0
+                                                                                                { 119, 0 },
+                                                                                                { 119, 1 },
+                                                                                                { 119, 2 },
+                                                                                                { 119, 3 },
+                                                                                                // chip: 372 (4), ladder: 14, layer: 8, disk: 4, half: 0
+                                                                                                { 120, 0 },
+                                                                                                { 120, 1 },
+                                                                                                { 120, 2 },
+                                                                                                { 120, 3 },
+                                                                                                // chip: 376 (4), ladder: 15, layer: 8, disk: 4, half: 0
+                                                                                                { 121, 0 },
+                                                                                                { 121, 1 },
+                                                                                                { 121, 2 },
+                                                                                                { 121, 3 },
+                                                                                                // chip: 380 (4), ladder: 16, layer: 8, disk: 4, half: 0
+                                                                                                { 122, 0 },
+                                                                                                { 122, 1 },
+                                                                                                { 122, 2 },
+                                                                                                { 122, 3 },
+                                                                                                // chip: 384 (4), ladder: 17, layer: 9, disk: 4, half: 0
+                                                                                                { 123, 0 },
+                                                                                                { 123, 1 },
+                                                                                                { 123, 2 },
+                                                                                                { 123, 3 },
+                                                                                                // chip: 388 (4), ladder: 18, layer: 9, disk: 4, half: 0
+                                                                                                { 124, 0 },
+                                                                                                { 124, 1 },
+                                                                                                { 124, 2 },
+                                                                                                { 124, 3 },
+                                                                                                // chip: 392 (4), ladder: 19, layer: 9, disk: 4, half: 0
+                                                                                                { 125, 0 },
+                                                                                                { 125, 1 },
+                                                                                                { 125, 2 },
+                                                                                                { 125, 3 },
+                                                                                                // chip: 396 (4), ladder: 20, layer: 9, disk: 4, half: 0
+                                                                                                { 126, 0 },
+                                                                                                { 126, 1 },
+                                                                                                { 126, 2 },
+                                                                                                { 126, 3 },
+                                                                                                // chip: 400 (4), ladder: 21, layer: 9, disk: 4, half: 0
+                                                                                                { 127, 0 },
+                                                                                                { 127, 1 },
+                                                                                                { 127, 2 },
+                                                                                                { 127, 3 },
+                                                                                                // chip: 404 (4), ladder: 22, layer: 9, disk: 4, half: 0
+                                                                                                { 128, 0 },
+                                                                                                { 128, 1 },
+                                                                                                { 128, 2 },
+                                                                                                { 128, 3 },
+                                                                                                // chip: 408 (4), ladder: 23, layer: 9, disk: 4, half: 0
+                                                                                                { 129, 0 },
+                                                                                                { 129, 1 },
+                                                                                                { 129, 2 },
+                                                                                                { 129, 3 },
+                                                                                                // chip: 412 (4), ladder: 24, layer: 9, disk: 4, half: 0
+                                                                                                { 130, 0 },
+                                                                                                { 130, 1 },
+                                                                                                { 130, 2 },
+                                                                                                { 130, 3 },
+                                                                                                // chip: 416 (4), ladder: 25, layer: 9, disk: 4, half: 0
+                                                                                                { 131, 0 },
+                                                                                                { 131, 1 },
+                                                                                                { 131, 2 },
+                                                                                                { 131, 3 },
+                                                                                                // chip: 420 (5), ladder: 26, layer: 8, disk: 4, half: 0
+                                                                                                { 132, 0 },
+                                                                                                { 132, 1 },
+                                                                                                { 132, 2 },
+                                                                                                { 132, 3 },
+                                                                                                { 132, 4 },
+                                                                                                // chip: 425 (5), ladder: 27, layer: 8, disk: 4, half: 0
+                                                                                                { 133, 0 },
+                                                                                                { 133, 1 },
+                                                                                                { 133, 2 },
+                                                                                                { 133, 3 },
+                                                                                                { 133, 4 },
+                                                                                                // chip: 430 (5), ladder: 28, layer: 8, disk: 4, half: 0
+                                                                                                { 134, 0 },
+                                                                                                { 134, 1 },
+                                                                                                { 134, 2 },
+                                                                                                { 134, 3 },
+                                                                                                { 134, 4 },
+                                                                                                // chip: 435 (5), ladder: 29, layer: 8, disk: 4, half: 0
+                                                                                                { 135, 0 },
+                                                                                                { 135, 1 },
+                                                                                                { 135, 2 },
+                                                                                                { 135, 3 },
+                                                                                                { 135, 4 },
+                                                                                                // chip: 440 (5), ladder: 30, layer: 9, disk: 4, half: 0
+                                                                                                { 136, 0 },
+                                                                                                { 136, 1 },
+                                                                                                { 136, 2 },
+                                                                                                { 136, 3 },
+                                                                                                { 136, 4 },
+                                                                                                // chip: 445 (5), ladder: 31, layer: 9, disk: 4, half: 0
+                                                                                                { 137, 0 },
+                                                                                                { 137, 1 },
+                                                                                                { 137, 2 },
+                                                                                                { 137, 3 },
+                                                                                                { 137, 4 },
+                                                                                                // chip: 450 (5), ladder: 32, layer: 9, disk: 4, half: 0
+                                                                                                { 138, 0 },
+                                                                                                { 138, 1 },
+                                                                                                { 138, 2 },
+                                                                                                { 138, 3 },
+                                                                                                { 138, 4 },
+                                                                                                // chip: 455 (5), ladder: 33, layer: 9, disk: 4, half: 0
+                                                                                                { 139, 0 },
+                                                                                                { 139, 1 },
+                                                                                                { 139, 2 },
+                                                                                                { 139, 3 },
+                                                                                                { 139, 4 },
+                                                                                                // chip: 460 (2), ladder:  0, layer: 0, disk: 0, half: 1
+                                                                                                { 140, 0 },
+                                                                                                { 140, 1 },
+                                                                                                // chip: 462 (2), ladder:  1, layer: 0, disk: 0, half: 1
+                                                                                                { 141, 0 },
+                                                                                                { 141, 1 },
+                                                                                                // chip: 464 (2), ladder:  2, layer: 0, disk: 0, half: 1
+                                                                                                { 142, 0 },
+                                                                                                { 142, 1 },
+                                                                                                // chip: 466 (2), ladder:  3, layer: 1, disk: 0, half: 1
+                                                                                                { 143, 0 },
+                                                                                                { 143, 1 },
+                                                                                                // chip: 468 (2), ladder:  4, layer: 1, disk: 0, half: 1
+                                                                                                { 144, 0 },
+                                                                                                { 144, 1 },
+                                                                                                // chip: 470 (2), ladder:  5, layer: 1, disk: 0, half: 1
+                                                                                                { 145, 0 },
+                                                                                                { 145, 1 },
+                                                                                                // chip: 472 (3), ladder:  6, layer: 0, disk: 0, half: 1
+                                                                                                { 146, 0 },
+                                                                                                { 146, 1 },
+                                                                                                { 146, 2 },
+                                                                                                // chip: 475 (3), ladder:  7, layer: 0, disk: 0, half: 1
+                                                                                                { 147, 0 },
+                                                                                                { 147, 1 },
+                                                                                                { 147, 2 },
+                                                                                                // chip: 478 (3), ladder:  8, layer: 0, disk: 0, half: 1
+                                                                                                { 148, 0 },
+                                                                                                { 148, 1 },
+                                                                                                { 148, 2 },
+                                                                                                // chip: 481 (3), ladder:  9, layer: 0, disk: 0, half: 1
+                                                                                                { 149, 0 },
+                                                                                                { 149, 1 },
+                                                                                                { 149, 2 },
+                                                                                                // chip: 484 (3), ladder: 10, layer: 0, disk: 0, half: 1
+                                                                                                { 150, 0 },
+                                                                                                { 150, 1 },
+                                                                                                { 150, 2 },
+                                                                                                // chip: 487 (3), ladder: 11, layer: 0, disk: 0, half: 1
+                                                                                                { 151, 0 },
+                                                                                                { 151, 1 },
+                                                                                                { 151, 2 },
+                                                                                                // chip: 490 (3), ladder: 12, layer: 0, disk: 0, half: 1
+                                                                                                { 152, 0 },
+                                                                                                { 152, 1 },
+                                                                                                { 152, 2 },
+                                                                                                // chip: 493 (3), ladder: 13, layer: 0, disk: 0, half: 1
+                                                                                                { 153, 0 },
+                                                                                                { 153, 1 },
+                                                                                                { 153, 2 },
+                                                                                                // chip: 496 (3), ladder: 14, layer: 0, disk: 0, half: 1
+                                                                                                { 154, 0 },
+                                                                                                { 154, 1 },
+                                                                                                { 154, 2 },
+                                                                                                // chip: 499 (3), ladder: 15, layer: 1, disk: 0, half: 1
+                                                                                                { 155, 0 },
+                                                                                                { 155, 1 },
+                                                                                                { 155, 2 },
+                                                                                                // chip: 502 (3), ladder: 16, layer: 1, disk: 0, half: 1
+                                                                                                { 156, 0 },
+                                                                                                { 156, 1 },
+                                                                                                { 156, 2 },
+                                                                                                // chip: 505 (3), ladder: 17, layer: 1, disk: 0, half: 1
+                                                                                                { 157, 0 },
+                                                                                                { 157, 1 },
+                                                                                                { 157, 2 },
+                                                                                                // chip: 508 (3), ladder: 18, layer: 1, disk: 0, half: 1
+                                                                                                { 158, 0 },
+                                                                                                { 158, 1 },
+                                                                                                { 158, 2 },
+                                                                                                // chip: 511 (3), ladder: 19, layer: 1, disk: 0, half: 1
+                                                                                                { 159, 0 },
+                                                                                                { 159, 1 },
+                                                                                                { 159, 2 },
+                                                                                                // chip: 514 (3), ladder: 20, layer: 1, disk: 0, half: 1
+                                                                                                { 160, 0 },
+                                                                                                { 160, 1 },
+                                                                                                { 160, 2 },
+                                                                                                // chip: 517 (3), ladder: 21, layer: 1, disk: 0, half: 1
+                                                                                                { 161, 0 },
+                                                                                                { 161, 1 },
+                                                                                                { 161, 2 },
+                                                                                                // chip: 520 (3), ladder: 22, layer: 1, disk: 0, half: 1
+                                                                                                { 162, 0 },
+                                                                                                { 162, 1 },
+                                                                                                { 162, 2 },
+                                                                                                // chip: 523 (3), ladder: 23, layer: 1, disk: 0, half: 1
+                                                                                                { 163, 0 },
+                                                                                                { 163, 1 },
+                                                                                                { 163, 2 },
+                                                                                                // chip: 526 (2), ladder:  0, layer: 2, disk: 1, half: 1
+                                                                                                { 164, 0 },
+                                                                                                { 164, 1 },
+                                                                                                // chip: 528 (2), ladder:  1, layer: 2, disk: 1, half: 1
+                                                                                                { 165, 0 },
+                                                                                                { 165, 1 },
+                                                                                                // chip: 530 (2), ladder:  2, layer: 2, disk: 1, half: 1
+                                                                                                { 166, 0 },
+                                                                                                { 166, 1 },
+                                                                                                // chip: 532 (2), ladder:  3, layer: 3, disk: 1, half: 1
+                                                                                                { 167, 0 },
+                                                                                                { 167, 1 },
+                                                                                                // chip: 534 (2), ladder:  4, layer: 3, disk: 1, half: 1
+                                                                                                { 168, 0 },
+                                                                                                { 168, 1 },
+                                                                                                // chip: 536 (2), ladder:  5, layer: 3, disk: 1, half: 1
+                                                                                                { 169, 0 },
+                                                                                                { 169, 1 },
+                                                                                                // chip: 538 (3), ladder:  6, layer: 2, disk: 1, half: 1
+                                                                                                { 170, 0 },
+                                                                                                { 170, 1 },
+                                                                                                { 170, 2 },
+                                                                                                // chip: 541 (3), ladder:  7, layer: 2, disk: 1, half: 1
+                                                                                                { 171, 0 },
+                                                                                                { 171, 1 },
+                                                                                                { 171, 2 },
+                                                                                                // chip: 544 (3), ladder:  8, layer: 2, disk: 1, half: 1
+                                                                                                { 172, 0 },
+                                                                                                { 172, 1 },
+                                                                                                { 172, 2 },
+                                                                                                // chip: 547 (3), ladder:  9, layer: 2, disk: 1, half: 1
+                                                                                                { 173, 0 },
+                                                                                                { 173, 1 },
+                                                                                                { 173, 2 },
+                                                                                                // chip: 550 (3), ladder: 10, layer: 2, disk: 1, half: 1
+                                                                                                { 174, 0 },
+                                                                                                { 174, 1 },
+                                                                                                { 174, 2 },
+                                                                                                // chip: 553 (3), ladder: 11, layer: 2, disk: 1, half: 1
+                                                                                                { 175, 0 },
+                                                                                                { 175, 1 },
+                                                                                                { 175, 2 },
+                                                                                                // chip: 556 (3), ladder: 12, layer: 2, disk: 1, half: 1
+                                                                                                { 176, 0 },
+                                                                                                { 176, 1 },
+                                                                                                { 176, 2 },
+                                                                                                // chip: 559 (3), ladder: 13, layer: 2, disk: 1, half: 1
+                                                                                                { 177, 0 },
+                                                                                                { 177, 1 },
+                                                                                                { 177, 2 },
+                                                                                                // chip: 562 (3), ladder: 14, layer: 2, disk: 1, half: 1
+                                                                                                { 178, 0 },
+                                                                                                { 178, 1 },
+                                                                                                { 178, 2 },
+                                                                                                // chip: 565 (3), ladder: 15, layer: 3, disk: 1, half: 1
+                                                                                                { 179, 0 },
+                                                                                                { 179, 1 },
+                                                                                                { 179, 2 },
+                                                                                                // chip: 568 (3), ladder: 16, layer: 3, disk: 1, half: 1
+                                                                                                { 180, 0 },
+                                                                                                { 180, 1 },
+                                                                                                { 180, 2 },
+                                                                                                // chip: 571 (3), ladder: 17, layer: 3, disk: 1, half: 1
+                                                                                                { 181, 0 },
+                                                                                                { 181, 1 },
+                                                                                                { 181, 2 },
+                                                                                                // chip: 574 (3), ladder: 18, layer: 3, disk: 1, half: 1
+                                                                                                { 182, 0 },
+                                                                                                { 182, 1 },
+                                                                                                { 182, 2 },
+                                                                                                // chip: 577 (3), ladder: 19, layer: 3, disk: 1, half: 1
+                                                                                                { 183, 0 },
+                                                                                                { 183, 1 },
+                                                                                                { 183, 2 },
+                                                                                                // chip: 580 (3), ladder: 20, layer: 3, disk: 1, half: 1
+                                                                                                { 184, 0 },
+                                                                                                { 184, 1 },
+                                                                                                { 184, 2 },
+                                                                                                // chip: 583 (3), ladder: 21, layer: 3, disk: 1, half: 1
+                                                                                                { 185, 0 },
+                                                                                                { 185, 1 },
+                                                                                                { 185, 2 },
+                                                                                                // chip: 586 (3), ladder: 22, layer: 3, disk: 1, half: 1
+                                                                                                { 186, 0 },
+                                                                                                { 186, 1 },
+                                                                                                { 186, 2 },
+                                                                                                // chip: 589 (3), ladder: 23, layer: 3, disk: 1, half: 1
+                                                                                                { 187, 0 },
+                                                                                                { 187, 1 },
+                                                                                                { 187, 2 },
+                                                                                                // chip: 592 (2), ladder:  0, layer: 4, disk: 2, half: 1
+                                                                                                { 188, 0 },
+                                                                                                { 188, 1 },
+                                                                                                // chip: 594 (2), ladder:  1, layer: 4, disk: 2, half: 1
+                                                                                                { 189, 0 },
+                                                                                                { 189, 1 },
+                                                                                                // chip: 596 (2), ladder:  2, layer: 5, disk: 2, half: 1
+                                                                                                { 190, 0 },
+                                                                                                { 190, 1 },
+                                                                                                // chip: 598 (2), ladder:  3, layer: 5, disk: 2, half: 1
+                                                                                                { 191, 0 },
+                                                                                                { 191, 1 },
+                                                                                                // chip: 600 (3), ladder:  4, layer: 4, disk: 2, half: 1
+                                                                                                { 192, 0 },
+                                                                                                { 192, 1 },
+                                                                                                { 192, 2 },
+                                                                                                // chip: 603 (3), ladder:  5, layer: 4, disk: 2, half: 1
+                                                                                                { 193, 0 },
+                                                                                                { 193, 1 },
+                                                                                                { 193, 2 },
+                                                                                                // chip: 606 (3), ladder:  6, layer: 4, disk: 2, half: 1
+                                                                                                { 194, 0 },
+                                                                                                { 194, 1 },
+                                                                                                { 194, 2 },
+                                                                                                // chip: 609 (3), ladder:  7, layer: 4, disk: 2, half: 1
+                                                                                                { 195, 0 },
+                                                                                                { 195, 1 },
+                                                                                                { 195, 2 },
+                                                                                                // chip: 612 (3), ladder:  8, layer: 4, disk: 2, half: 1
+                                                                                                { 196, 0 },
+                                                                                                { 196, 1 },
+                                                                                                { 196, 2 },
+                                                                                                // chip: 615 (3), ladder:  9, layer: 4, disk: 2, half: 1
+                                                                                                { 197, 0 },
+                                                                                                { 197, 1 },
+                                                                                                { 197, 2 },
+                                                                                                // chip: 618 (3), ladder: 10, layer: 4, disk: 2, half: 1
+                                                                                                { 198, 0 },
+                                                                                                { 198, 1 },
+                                                                                                { 198, 2 },
+                                                                                                // chip: 621 (3), ladder: 11, layer: 5, disk: 2, half: 1
+                                                                                                { 199, 0 },
+                                                                                                { 199, 1 },
+                                                                                                { 199, 2 },
+                                                                                                // chip: 624 (3), ladder: 12, layer: 5, disk: 2, half: 1
+                                                                                                { 200, 0 },
+                                                                                                { 200, 1 },
+                                                                                                { 200, 2 },
+                                                                                                // chip: 627 (3), ladder: 13, layer: 5, disk: 2, half: 1
+                                                                                                { 201, 0 },
+                                                                                                { 201, 1 },
+                                                                                                { 201, 2 },
+                                                                                                // chip: 630 (3), ladder: 14, layer: 5, disk: 2, half: 1
+                                                                                                { 202, 0 },
+                                                                                                { 202, 1 },
+                                                                                                { 202, 2 },
+                                                                                                // chip: 633 (3), ladder: 15, layer: 5, disk: 2, half: 1
+                                                                                                { 203, 0 },
+                                                                                                { 203, 1 },
+                                                                                                { 203, 2 },
+                                                                                                // chip: 636 (3), ladder: 16, layer: 5, disk: 2, half: 1
+                                                                                                { 204, 0 },
+                                                                                                { 204, 1 },
+                                                                                                { 204, 2 },
+                                                                                                // chip: 639 (3), ladder: 17, layer: 5, disk: 2, half: 1
+                                                                                                { 205, 0 },
+                                                                                                { 205, 1 },
+                                                                                                { 205, 2 },
+                                                                                                // chip: 642 (4), ladder: 18, layer: 4, disk: 2, half: 1
+                                                                                                { 206, 0 },
+                                                                                                { 206, 1 },
+                                                                                                { 206, 2 },
+                                                                                                { 206, 3 },
+                                                                                                // chip: 646 (4), ladder: 19, layer: 4, disk: 2, half: 1
+                                                                                                { 207, 0 },
+                                                                                                { 207, 1 },
+                                                                                                { 207, 2 },
+                                                                                                { 207, 3 },
+                                                                                                // chip: 650 (4), ladder: 20, layer: 4, disk: 2, half: 1
+                                                                                                { 208, 0 },
+                                                                                                { 208, 1 },
+                                                                                                { 208, 2 },
+                                                                                                { 208, 3 },
+                                                                                                // chip: 654 (4), ladder: 21, layer: 4, disk: 2, half: 1
+                                                                                                { 209, 0 },
+                                                                                                { 209, 1 },
+                                                                                                { 209, 2 },
+                                                                                                { 209, 3 },
+                                                                                                // chip: 658 (4), ladder: 22, layer: 5, disk: 2, half: 1
+                                                                                                { 210, 0 },
+                                                                                                { 210, 1 },
+                                                                                                { 210, 2 },
+                                                                                                { 210, 3 },
+                                                                                                // chip: 662 (4), ladder: 23, layer: 5, disk: 2, half: 1
+                                                                                                { 211, 0 },
+                                                                                                { 211, 1 },
+                                                                                                { 211, 2 },
+                                                                                                { 211, 3 },
+                                                                                                // chip: 666 (4), ladder: 24, layer: 5, disk: 2, half: 1
+                                                                                                { 212, 0 },
+                                                                                                { 212, 1 },
+                                                                                                { 212, 2 },
+                                                                                                { 212, 3 },
+                                                                                                // chip: 670 (4), ladder: 25, layer: 5, disk: 2, half: 1
+                                                                                                { 213, 0 },
+                                                                                                { 213, 1 },
+                                                                                                { 213, 2 },
+                                                                                                { 213, 3 },
+                                                                                                // chip: 674 (2), ladder:  0, layer: 6, disk: 3, half: 1
+                                                                                                { 214, 0 },
+                                                                                                { 214, 1 },
+                                                                                                // chip: 676 (2), ladder:  1, layer: 6, disk: 3, half: 1
+                                                                                                { 215, 0 },
+                                                                                                { 215, 1 },
+                                                                                                // chip: 678 (2), ladder:  2, layer: 7, disk: 3, half: 1
+                                                                                                { 216, 0 },
+                                                                                                { 216, 1 },
+                                                                                                // chip: 680 (2), ladder:  3, layer: 7, disk: 3, half: 1
+                                                                                                { 217, 0 },
+                                                                                                { 217, 1 },
+                                                                                                // chip: 682 (3), ladder:  4, layer: 6, disk: 3, half: 1
+                                                                                                { 218, 0 },
+                                                                                                { 218, 1 },
+                                                                                                { 218, 2 },
+                                                                                                // chip: 685 (3), ladder:  5, layer: 6, disk: 3, half: 1
+                                                                                                { 219, 0 },
+                                                                                                { 219, 1 },
+                                                                                                { 219, 2 },
+                                                                                                // chip: 688 (3), ladder:  6, layer: 6, disk: 3, half: 1
+                                                                                                { 220, 0 },
+                                                                                                { 220, 1 },
+                                                                                                { 220, 2 },
+                                                                                                // chip: 691 (3), ladder:  7, layer: 7, disk: 3, half: 1
+                                                                                                { 221, 0 },
+                                                                                                { 221, 1 },
+                                                                                                { 221, 2 },
+                                                                                                // chip: 694 (3), ladder:  8, layer: 7, disk: 3, half: 1
+                                                                                                { 222, 0 },
+                                                                                                { 222, 1 },
+                                                                                                { 222, 2 },
+                                                                                                // chip: 697 (3), ladder:  9, layer: 7, disk: 3, half: 1
+                                                                                                { 223, 0 },
+                                                                                                { 223, 1 },
+                                                                                                { 223, 2 },
+                                                                                                // chip: 700 (4), ladder: 10, layer: 6, disk: 3, half: 1
+                                                                                                { 224, 0 },
+                                                                                                { 224, 1 },
+                                                                                                { 224, 2 },
+                                                                                                { 224, 3 },
+                                                                                                // chip: 704 (4), ladder: 11, layer: 6, disk: 3, half: 1
+                                                                                                { 225, 0 },
+                                                                                                { 225, 1 },
+                                                                                                { 225, 2 },
+                                                                                                { 225, 3 },
+                                                                                                // chip: 708 (4), ladder: 12, layer: 6, disk: 3, half: 1
+                                                                                                { 226, 0 },
+                                                                                                { 226, 1 },
+                                                                                                { 226, 2 },
+                                                                                                { 226, 3 },
+                                                                                                // chip: 712 (4), ladder: 13, layer: 6, disk: 3, half: 1
+                                                                                                { 227, 0 },
+                                                                                                { 227, 1 },
+                                                                                                { 227, 2 },
+                                                                                                { 227, 3 },
+                                                                                                // chip: 716 (4), ladder: 14, layer: 6, disk: 3, half: 1
+                                                                                                { 228, 0 },
+                                                                                                { 228, 1 },
+                                                                                                { 228, 2 },
+                                                                                                { 228, 3 },
+                                                                                                // chip: 720 (4), ladder: 15, layer: 6, disk: 3, half: 1
+                                                                                                { 229, 0 },
+                                                                                                { 229, 1 },
+                                                                                                { 229, 2 },
+                                                                                                { 229, 3 },
+                                                                                                // chip: 724 (4), ladder: 16, layer: 6, disk: 3, half: 1
+                                                                                                { 230, 0 },
+                                                                                                { 230, 1 },
+                                                                                                { 230, 2 },
+                                                                                                { 230, 3 },
+                                                                                                // chip: 728 (4), ladder: 17, layer: 6, disk: 3, half: 1
+                                                                                                { 231, 0 },
+                                                                                                { 231, 1 },
+                                                                                                { 231, 2 },
+                                                                                                { 231, 3 },
+                                                                                                // chip: 732 (4), ladder: 18, layer: 6, disk: 3, half: 1
+                                                                                                { 232, 0 },
+                                                                                                { 232, 1 },
+                                                                                                { 232, 2 },
+                                                                                                { 232, 3 },
+                                                                                                // chip: 736 (4), ladder: 19, layer: 6, disk: 3, half: 1
+                                                                                                { 233, 0 },
+                                                                                                { 233, 1 },
+                                                                                                { 233, 2 },
+                                                                                                { 233, 3 },
+                                                                                                // chip: 740 (4), ladder: 20, layer: 6, disk: 3, half: 1
+                                                                                                { 234, 0 },
+                                                                                                { 234, 1 },
+                                                                                                { 234, 2 },
+                                                                                                { 234, 3 },
+                                                                                                // chip: 744 (4), ladder: 21, layer: 7, disk: 3, half: 1
+                                                                                                { 235, 0 },
+                                                                                                { 235, 1 },
+                                                                                                { 235, 2 },
+                                                                                                { 235, 3 },
+                                                                                                // chip: 748 (4), ladder: 22, layer: 7, disk: 3, half: 1
+                                                                                                { 236, 0 },
+                                                                                                { 236, 1 },
+                                                                                                { 236, 2 },
+                                                                                                { 236, 3 },
+                                                                                                // chip: 752 (4), ladder: 23, layer: 7, disk: 3, half: 1
+                                                                                                { 237, 0 },
+                                                                                                { 237, 1 },
+                                                                                                { 237, 2 },
+                                                                                                { 237, 3 },
+                                                                                                // chip: 756 (4), ladder: 24, layer: 7, disk: 3, half: 1
+                                                                                                { 238, 0 },
+                                                                                                { 238, 1 },
+                                                                                                { 238, 2 },
+                                                                                                { 238, 3 },
+                                                                                                // chip: 760 (4), ladder: 25, layer: 7, disk: 3, half: 1
+                                                                                                { 239, 0 },
+                                                                                                { 239, 1 },
+                                                                                                { 239, 2 },
+                                                                                                { 239, 3 },
+                                                                                                // chip: 764 (4), ladder: 26, layer: 7, disk: 3, half: 1
+                                                                                                { 240, 0 },
+                                                                                                { 240, 1 },
+                                                                                                { 240, 2 },
+                                                                                                { 240, 3 },
+                                                                                                // chip: 768 (4), ladder: 27, layer: 7, disk: 3, half: 1
+                                                                                                { 241, 0 },
+                                                                                                { 241, 1 },
+                                                                                                { 241, 2 },
+                                                                                                { 241, 3 },
+                                                                                                // chip: 772 (4), ladder: 28, layer: 7, disk: 3, half: 1
+                                                                                                { 242, 0 },
+                                                                                                { 242, 1 },
+                                                                                                { 242, 2 },
+                                                                                                { 242, 3 },
+                                                                                                // chip: 776 (4), ladder: 29, layer: 7, disk: 3, half: 1
+                                                                                                { 243, 0 },
+                                                                                                { 243, 1 },
+                                                                                                { 243, 2 },
+                                                                                                { 243, 3 },
+                                                                                                // chip: 780 (4), ladder: 30, layer: 7, disk: 3, half: 1
+                                                                                                { 244, 0 },
+                                                                                                { 244, 1 },
+                                                                                                { 244, 2 },
+                                                                                                { 244, 3 },
+                                                                                                // chip: 784 (4), ladder: 31, layer: 7, disk: 3, half: 1
+                                                                                                { 245, 0 },
+                                                                                                { 245, 1 },
+                                                                                                { 245, 2 },
+                                                                                                { 245, 3 },
+                                                                                                // chip: 788 (2), ladder:  0, layer: 8, disk: 4, half: 1
+                                                                                                { 246, 0 },
+                                                                                                { 246, 1 },
+                                                                                                // chip: 790 (2), ladder:  1, layer: 8, disk: 4, half: 1
+                                                                                                { 247, 0 },
+                                                                                                { 247, 1 },
+                                                                                                // chip: 792 (2), ladder:  2, layer: 9, disk: 4, half: 1
+                                                                                                { 248, 0 },
+                                                                                                { 248, 1 },
+                                                                                                // chip: 794 (2), ladder:  3, layer: 9, disk: 4, half: 1
+                                                                                                { 249, 0 },
+                                                                                                { 249, 1 },
+                                                                                                // chip: 796 (3), ladder:  4, layer: 8, disk: 4, half: 1
+                                                                                                { 250, 0 },
+                                                                                                { 250, 1 },
+                                                                                                { 250, 2 },
+                                                                                                // chip: 799 (3), ladder:  5, layer: 8, disk: 4, half: 1
+                                                                                                { 251, 0 },
+                                                                                                { 251, 1 },
+                                                                                                { 251, 2 },
+                                                                                                // chip: 802 (3), ladder:  6, layer: 9, disk: 4, half: 1
+                                                                                                { 252, 0 },
+                                                                                                { 252, 1 },
+                                                                                                { 252, 2 },
+                                                                                                // chip: 805 (3), ladder:  7, layer: 9, disk: 4, half: 1
+                                                                                                { 253, 0 },
+                                                                                                { 253, 1 },
+                                                                                                { 253, 2 },
+                                                                                                // chip: 808 (4), ladder:  8, layer: 8, disk: 4, half: 1
+                                                                                                { 254, 0 },
+                                                                                                { 254, 1 },
+                                                                                                { 254, 2 },
+                                                                                                { 254, 3 },
+                                                                                                // chip: 812 (4), ladder:  9, layer: 8, disk: 4, half: 1
+                                                                                                { 255, 0 },
+                                                                                                { 255, 1 },
+                                                                                                { 255, 2 },
+                                                                                                { 255, 3 },
+                                                                                                // chip: 816 (4), ladder: 10, layer: 8, disk: 4, half: 1
+                                                                                                { 256, 0 },
+                                                                                                { 256, 1 },
+                                                                                                { 256, 2 },
+                                                                                                { 256, 3 },
+                                                                                                // chip: 820 (4), ladder: 11, layer: 8, disk: 4, half: 1
+                                                                                                { 257, 0 },
+                                                                                                { 257, 1 },
+                                                                                                { 257, 2 },
+                                                                                                { 257, 3 },
+                                                                                                // chip: 824 (4), ladder: 12, layer: 8, disk: 4, half: 1
+                                                                                                { 258, 0 },
+                                                                                                { 258, 1 },
+                                                                                                { 258, 2 },
+                                                                                                { 258, 3 },
+                                                                                                // chip: 828 (4), ladder: 13, layer: 8, disk: 4, half: 1
+                                                                                                { 259, 0 },
+                                                                                                { 259, 1 },
+                                                                                                { 259, 2 },
+                                                                                                { 259, 3 },
+                                                                                                // chip: 832 (4), ladder: 14, layer: 8, disk: 4, half: 1
+                                                                                                { 260, 0 },
+                                                                                                { 260, 1 },
+                                                                                                { 260, 2 },
+                                                                                                { 260, 3 },
+                                                                                                // chip: 836 (4), ladder: 15, layer: 8, disk: 4, half: 1
+                                                                                                { 261, 0 },
+                                                                                                { 261, 1 },
+                                                                                                { 261, 2 },
+                                                                                                { 261, 3 },
+                                                                                                // chip: 840 (4), ladder: 16, layer: 8, disk: 4, half: 1
+                                                                                                { 262, 0 },
+                                                                                                { 262, 1 },
+                                                                                                { 262, 2 },
+                                                                                                { 262, 3 },
+                                                                                                // chip: 844 (4), ladder: 17, layer: 9, disk: 4, half: 1
+                                                                                                { 263, 0 },
+                                                                                                { 263, 1 },
+                                                                                                { 263, 2 },
+                                                                                                { 263, 3 },
+                                                                                                // chip: 848 (4), ladder: 18, layer: 9, disk: 4, half: 1
+                                                                                                { 264, 0 },
+                                                                                                { 264, 1 },
+                                                                                                { 264, 2 },
+                                                                                                { 264, 3 },
+                                                                                                // chip: 852 (4), ladder: 19, layer: 9, disk: 4, half: 1
+                                                                                                { 265, 0 },
+                                                                                                { 265, 1 },
+                                                                                                { 265, 2 },
+                                                                                                { 265, 3 },
+                                                                                                // chip: 856 (4), ladder: 20, layer: 9, disk: 4, half: 1
+                                                                                                { 266, 0 },
+                                                                                                { 266, 1 },
+                                                                                                { 266, 2 },
+                                                                                                { 266, 3 },
+                                                                                                // chip: 860 (4), ladder: 21, layer: 9, disk: 4, half: 1
+                                                                                                { 267, 0 },
+                                                                                                { 267, 1 },
+                                                                                                { 267, 2 },
+                                                                                                { 267, 3 },
+                                                                                                // chip: 864 (4), ladder: 22, layer: 9, disk: 4, half: 1
+                                                                                                { 268, 0 },
+                                                                                                { 268, 1 },
+                                                                                                { 268, 2 },
+                                                                                                { 268, 3 },
+                                                                                                // chip: 868 (4), ladder: 23, layer: 9, disk: 4, half: 1
+                                                                                                { 269, 0 },
+                                                                                                { 269, 1 },
+                                                                                                { 269, 2 },
+                                                                                                { 269, 3 },
+                                                                                                // chip: 872 (4), ladder: 24, layer: 9, disk: 4, half: 1
+                                                                                                { 270, 0 },
+                                                                                                { 270, 1 },
+                                                                                                { 270, 2 },
+                                                                                                { 270, 3 },
+                                                                                                // chip: 876 (4), ladder: 25, layer: 9, disk: 4, half: 1
+                                                                                                { 271, 0 },
+                                                                                                { 271, 1 },
+                                                                                                { 271, 2 },
+                                                                                                { 271, 3 },
+                                                                                                // chip: 880 (5), ladder: 26, layer: 8, disk: 4, half: 1
+                                                                                                { 272, 0 },
+                                                                                                { 272, 1 },
+                                                                                                { 272, 2 },
+                                                                                                { 272, 3 },
+                                                                                                { 272, 4 },
+                                                                                                // chip: 885 (5), ladder: 27, layer: 8, disk: 4, half: 1
+                                                                                                { 273, 0 },
+                                                                                                { 273, 1 },
+                                                                                                { 273, 2 },
+                                                                                                { 273, 3 },
+                                                                                                { 273, 4 },
+                                                                                                // chip: 890 (5), ladder: 28, layer: 8, disk: 4, half: 1
+                                                                                                { 274, 0 },
+                                                                                                { 274, 1 },
+                                                                                                { 274, 2 },
+                                                                                                { 274, 3 },
+                                                                                                { 274, 4 },
+                                                                                                // chip: 895 (5), ladder: 29, layer: 8, disk: 4, half: 1
+                                                                                                { 275, 0 },
+                                                                                                { 275, 1 },
+                                                                                                { 275, 2 },
+                                                                                                { 275, 3 },
+                                                                                                { 275, 4 },
+                                                                                                // chip: 900 (5), ladder: 30, layer: 9, disk: 4, half: 1
+                                                                                                { 276, 0 },
+                                                                                                { 276, 1 },
+                                                                                                { 276, 2 },
+                                                                                                { 276, 3 },
+                                                                                                { 276, 4 },
+                                                                                                // chip: 905 (5), ladder: 31, layer: 9, disk: 4, half: 1
+                                                                                                { 277, 0 },
+                                                                                                { 277, 1 },
+                                                                                                { 277, 2 },
+                                                                                                { 277, 3 },
+                                                                                                { 277, 4 },
+                                                                                                // chip: 910 (5), ladder: 32, layer: 9, disk: 4, half: 1
+                                                                                                { 278, 0 },
+                                                                                                { 278, 1 },
+                                                                                                { 278, 2 },
+                                                                                                { 278, 3 },
+                                                                                                { 278, 4 },
+                                                                                                // chip: 915 (5), ladder: 33, layer: 9, disk: 4, half: 1
+                                                                                                { 279, 0 },
+                                                                                                { 279, 1 },
+                                                                                                { 279, 2 },
+                                                                                                { 279, 3 },
+                                                                                                { 279, 4 }
 
-int ChipMappingMFT::invalid() const
-{
-  LOG(FATAL) << "This class still has to be implemented by the MFT" << FairLogger::endl;
-  return -1;
-}
+} };
+
+const std::array<MFTModuleMappingData, ChipMappingMFT::NModules> ChipMappingMFT::ModuleMappingData{ {
+
+  // layer: 0
+  { 0, 2, 0 },
+  { 0, 2, 2 },
+  { 0, 2, 4 },
+
+  // layer: 1
+  { 1, 2, 6 },
+  { 1, 2, 8 },
+  { 1, 2, 10 },
+
+  // layer: 0
+  { 0, 3, 12 },
+  { 0, 3, 15 },
+  { 0, 3, 18 },
+  { 0, 3, 21 },
+  { 0, 3, 24 },
+  { 0, 3, 27 },
+  { 0, 3, 30 },
+  { 0, 3, 33 },
+  { 0, 3, 36 },
+
+  // layer: 1
+  { 1, 3, 39 },
+  { 1, 3, 42 },
+  { 1, 3, 45 },
+  { 1, 3, 48 },
+  { 1, 3, 51 },
+  { 1, 3, 54 },
+  { 1, 3, 57 },
+  { 1, 3, 60 },
+  { 1, 3, 63 },
+
+  // layer: 2
+  { 2, 2, 66 },
+  { 2, 2, 68 },
+  { 2, 2, 70 },
+
+  // layer: 3
+  { 3, 2, 72 },
+  { 3, 2, 74 },
+  { 3, 2, 76 },
+
+  // layer: 2
+  { 2, 3, 78 },
+  { 2, 3, 81 },
+  { 2, 3, 84 },
+  { 2, 3, 87 },
+  { 2, 3, 90 },
+  { 2, 3, 93 },
+  { 2, 3, 96 },
+  { 2, 3, 99 },
+  { 2, 3, 102 },
+
+  // layer: 3
+  { 3, 3, 105 },
+  { 3, 3, 108 },
+  { 3, 3, 111 },
+  { 3, 3, 114 },
+  { 3, 3, 117 },
+  { 3, 3, 120 },
+  { 3, 3, 123 },
+  { 3, 3, 126 },
+  { 3, 3, 129 },
+
+  // layer: 4
+  { 4, 2, 132 },
+  { 4, 2, 134 },
+
+  // layer: 5
+  { 5, 2, 136 },
+  { 5, 2, 138 },
+
+  // layer: 4
+  { 4, 3, 140 },
+  { 4, 3, 143 },
+  { 4, 3, 146 },
+  { 4, 3, 149 },
+  { 4, 3, 152 },
+  { 4, 3, 155 },
+  { 4, 3, 158 },
+
+  // layer: 5
+  { 5, 3, 161 },
+  { 5, 3, 164 },
+  { 5, 3, 167 },
+  { 5, 3, 170 },
+  { 5, 3, 173 },
+  { 5, 3, 176 },
+  { 5, 3, 179 },
+
+  // layer: 4
+  { 4, 4, 182 },
+  { 4, 4, 186 },
+  { 4, 4, 190 },
+  { 4, 4, 194 },
+
+  // layer: 5
+  { 5, 4, 198 },
+  { 5, 4, 202 },
+  { 5, 4, 206 },
+  { 5, 4, 210 },
+
+  // layer: 6
+  { 6, 2, 214 },
+  { 6, 2, 216 },
+
+  // layer: 7
+  { 7, 2, 218 },
+  { 7, 2, 220 },
+
+  // layer: 6
+  { 6, 3, 222 },
+  { 6, 3, 225 },
+  { 6, 3, 228 },
+
+  // layer: 7
+  { 7, 3, 231 },
+  { 7, 3, 234 },
+  { 7, 3, 237 },
+
+  // layer: 6
+  { 6, 4, 240 },
+  { 6, 4, 244 },
+  { 6, 4, 248 },
+  { 6, 4, 252 },
+  { 6, 4, 256 },
+  { 6, 4, 260 },
+  { 6, 4, 264 },
+  { 6, 4, 268 },
+  { 6, 4, 272 },
+  { 6, 4, 276 },
+  { 6, 4, 280 },
+
+  // layer: 7
+  { 7, 4, 284 },
+  { 7, 4, 288 },
+  { 7, 4, 292 },
+  { 7, 4, 296 },
+  { 7, 4, 300 },
+  { 7, 4, 304 },
+  { 7, 4, 308 },
+  { 7, 4, 312 },
+  { 7, 4, 316 },
+  { 7, 4, 320 },
+  { 7, 4, 324 },
+
+  // layer: 8
+  { 8, 2, 328 },
+  { 8, 2, 330 },
+
+  // layer: 9
+  { 9, 2, 332 },
+  { 9, 2, 334 },
+
+  // layer: 8
+  { 8, 3, 336 },
+  { 8, 3, 339 },
+
+  // layer: 9
+  { 9, 3, 342 },
+  { 9, 3, 345 },
+
+  // layer: 8
+  { 8, 4, 348 },
+  { 8, 4, 352 },
+  { 8, 4, 356 },
+  { 8, 4, 360 },
+  { 8, 4, 364 },
+  { 8, 4, 368 },
+  { 8, 4, 372 },
+  { 8, 4, 376 },
+  { 8, 4, 380 },
+
+  // layer: 9
+  { 9, 4, 384 },
+  { 9, 4, 388 },
+  { 9, 4, 392 },
+  { 9, 4, 396 },
+  { 9, 4, 400 },
+  { 9, 4, 404 },
+  { 9, 4, 408 },
+  { 9, 4, 412 },
+  { 9, 4, 416 },
+
+  // layer: 8
+  { 8, 5, 420 },
+  { 8, 5, 425 },
+  { 8, 5, 430 },
+  { 8, 5, 435 },
+
+  // layer: 9
+  { 9, 5, 440 },
+  { 9, 5, 445 },
+  { 9, 5, 450 },
+  { 9, 5, 455 },
+
+  // layer: 0
+  { 0, 2, 460 },
+  { 0, 2, 462 },
+  { 0, 2, 464 },
+
+  // layer: 1
+  { 1, 2, 466 },
+  { 1, 2, 468 },
+  { 1, 2, 470 },
+
+  // layer: 0
+  { 0, 3, 472 },
+  { 0, 3, 475 },
+  { 0, 3, 478 },
+  { 0, 3, 481 },
+  { 0, 3, 484 },
+  { 0, 3, 487 },
+  { 0, 3, 490 },
+  { 0, 3, 493 },
+  { 0, 3, 496 },
+
+  // layer: 1
+  { 1, 3, 499 },
+  { 1, 3, 502 },
+  { 1, 3, 505 },
+  { 1, 3, 508 },
+  { 1, 3, 511 },
+  { 1, 3, 514 },
+  { 1, 3, 517 },
+  { 1, 3, 520 },
+  { 1, 3, 523 },
+
+  // layer: 2
+  { 2, 2, 526 },
+  { 2, 2, 528 },
+  { 2, 2, 530 },
+
+  // layer: 3
+  { 3, 2, 532 },
+  { 3, 2, 534 },
+  { 3, 2, 536 },
+
+  // layer: 2
+  { 2, 3, 538 },
+  { 2, 3, 541 },
+  { 2, 3, 544 },
+  { 2, 3, 547 },
+  { 2, 3, 550 },
+  { 2, 3, 553 },
+  { 2, 3, 556 },
+  { 2, 3, 559 },
+  { 2, 3, 562 },
+
+  // layer: 3
+  { 3, 3, 565 },
+  { 3, 3, 568 },
+  { 3, 3, 571 },
+  { 3, 3, 574 },
+  { 3, 3, 577 },
+  { 3, 3, 580 },
+  { 3, 3, 583 },
+  { 3, 3, 586 },
+  { 3, 3, 589 },
+
+  // layer: 4
+  { 4, 2, 592 },
+  { 4, 2, 594 },
+
+  // layer: 5
+  { 5, 2, 596 },
+  { 5, 2, 598 },
+
+  // layer: 4
+  { 4, 3, 600 },
+  { 4, 3, 603 },
+  { 4, 3, 606 },
+  { 4, 3, 609 },
+  { 4, 3, 612 },
+  { 4, 3, 615 },
+  { 4, 3, 618 },
+
+  // layer: 5
+  { 5, 3, 621 },
+  { 5, 3, 624 },
+  { 5, 3, 627 },
+  { 5, 3, 630 },
+  { 5, 3, 633 },
+  { 5, 3, 636 },
+  { 5, 3, 639 },
+
+  // layer: 4
+  { 4, 4, 642 },
+  { 4, 4, 646 },
+  { 4, 4, 650 },
+  { 4, 4, 654 },
+
+  // layer: 5
+  { 5, 4, 658 },
+  { 5, 4, 662 },
+  { 5, 4, 666 },
+  { 5, 4, 670 },
+
+  // layer: 6
+  { 6, 2, 674 },
+  { 6, 2, 676 },
+
+  // layer: 7
+  { 7, 2, 678 },
+  { 7, 2, 680 },
+
+  // layer: 6
+  { 6, 3, 682 },
+  { 6, 3, 685 },
+  { 6, 3, 688 },
+
+  // layer: 7
+  { 7, 3, 691 },
+  { 7, 3, 694 },
+  { 7, 3, 697 },
+
+  // layer: 6
+  { 6, 4, 700 },
+  { 6, 4, 704 },
+  { 6, 4, 708 },
+  { 6, 4, 712 },
+  { 6, 4, 716 },
+  { 6, 4, 720 },
+  { 6, 4, 724 },
+  { 6, 4, 728 },
+  { 6, 4, 732 },
+  { 6, 4, 736 },
+  { 6, 4, 740 },
+
+  // layer: 7
+  { 7, 4, 744 },
+  { 7, 4, 748 },
+  { 7, 4, 752 },
+  { 7, 4, 756 },
+  { 7, 4, 760 },
+  { 7, 4, 764 },
+  { 7, 4, 768 },
+  { 7, 4, 772 },
+  { 7, 4, 776 },
+  { 7, 4, 780 },
+  { 7, 4, 784 },
+
+  // layer: 8
+  { 8, 2, 788 },
+  { 8, 2, 790 },
+
+  // layer: 9
+  { 9, 2, 792 },
+  { 9, 2, 794 },
+
+  // layer: 8
+  { 8, 3, 796 },
+  { 8, 3, 799 },
+
+  // layer: 9
+  { 9, 3, 802 },
+  { 9, 3, 805 },
+
+  // layer: 8
+  { 8, 4, 808 },
+  { 8, 4, 812 },
+  { 8, 4, 816 },
+  { 8, 4, 820 },
+  { 8, 4, 824 },
+  { 8, 4, 828 },
+  { 8, 4, 832 },
+  { 8, 4, 836 },
+  { 8, 4, 840 },
+
+  // layer: 9
+  { 9, 4, 844 },
+  { 9, 4, 848 },
+  { 9, 4, 852 },
+  { 9, 4, 856 },
+  { 9, 4, 860 },
+  { 9, 4, 864 },
+  { 9, 4, 868 },
+  { 9, 4, 872 },
+  { 9, 4, 876 },
+
+  // layer: 8
+  { 8, 5, 880 },
+  { 8, 5, 885 },
+  { 8, 5, 890 },
+  { 8, 5, 895 },
+
+  // layer: 9
+  { 9, 5, 900 },
+  { 9, 5, 905 },
+  { 9, 5, 910 },
+  { 9, 5, 915 }
+
+} };

--- a/macro/README_mft
+++ b/macro/README_mft
@@ -1,10 +1,5 @@
-01.08.2017 (Bogdan Vulpescu, LPC)
----------------------------------
-
-updated: 17.10.2017
-
-Howto check the simulation chain for the MFT detector
------------------------------------------------------
+How to perform a simulation chain with the MFT detector
+-------------------------------------------------------
 
 1) simulation:
 
@@ -41,3 +36,35 @@ root.exe
 6) launch the tracker
 
 ./run_trac_mft.sh 10 100 TGeant3 <rate>
+
+
+
+Conversion to/from raw format
+-----------------------------
+
+1) rename the MC simulations and parameter files as o2sim.root and o2sim_par.root (keep also the old file names if the steps above are to be executed too)
+
+2) run the digitization
+
+./run_digi_mft.sh
+
+this will produce the files o2digi_mft.root and o2sim_grp.root
+
+copy the file o2digi_mft.root to AliceO2_TGeant3.digi_<nev>ev_<nmu>mu.root for
+the clusterization from the ROOT digits directly
+
+previous point 2) becomes obsolete!
+
+3) convert digits to raw format
+
+root.exe -b -q run_digi2raw_mft.C+
+
+this will produce the file o2digi_mft.raw
+
+4) run clusterization from digits in raw format
+
+root.exe -b -q 'run_clus_mftSA.C+("o2clus_mft_raw.root","o2digi_mft.raw",1)'
+
+Note: the macro CheckClusters_mft.C can not be executed because the MC
+information is missing when clusterizing from the raw format digits.
+

--- a/macro/run_clus_mftSA.C
+++ b/macro/run_clus_mftSA.C
@@ -1,0 +1,45 @@
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include <TStopwatch.h>
+#include "DetectorsBase/GeometryManager.h"
+#include "MFTReconstruction/ClustererTask.h"
+#include "ITSMFTReconstruction/Clusterer.h"
+#include "FairLogger.h"
+#endif
+
+// Clusterization avoiding FairRunAna management.
+// Works both with MC digits and with "raw" data (in this case the last argument must be
+// set to true). The raw data should be prepared beforeahand from the MC digits using e.g.
+// o2::ITSMFT::RawPixelReader<o2::ITSMFT::ChipMappingMFT> reader;
+// reader.convertDigits2Raw("dig.raw","o2dig.root","o2sim","MFTDigit");
+//
+// Use for MC mode:
+// root -b -q run_clus_itsSA.C+\(\"o2clus_its.root\",\"o2dig.root\"\) 2>&1 | tee clusSA.log
+//
+// Use for RAW mode:
+// root -b -q run_clus_itsSA.C+\(\"o2clus_its.root\",\"dig.raw\"\) 2>&1 | tee clusSARAW.log
+
+void run_clus_mftSA(std::string outputfile,
+                    std::string inputfile,
+                    bool raw = false)
+{
+  // Initialize logger
+  FairLogger* logger = FairLogger::GetLogger();
+  logger->SetLogVerbosityLevel("LOW");
+  logger->SetLogScreenLevel("INFO");
+
+  TStopwatch timer;
+  o2::Base::GeometryManager::loadGeometry(); // needed provisionary, only to write full clusters
+
+  // Setup clusterizer
+  Bool_t useMCTruth = kTRUE;  // kFALSE if no comparison with MC needed
+  Bool_t entryPerROF = kTRUE; // write single tree entry for every ROF. If false, just 1 entry will be saved
+  o2::MFT::ClustererTask* clus = new o2::MFT::ClustererTask(useMCTruth, raw);
+  clus->getClusterer().setMaskOverflowPixels(true);  // set this to false to switch off masking
+  clus->getClusterer().setWantFullClusters(true);    // require clusters with coordinates and full pattern
+  clus->getClusterer().setWantCompactClusters(true); // require compact clusters with patternID
+
+  clus->run(inputfile, outputfile, entryPerROF);
+
+  timer.Stop();
+  timer.Print();
+}

--- a/macro/run_digi_mft.C
+++ b/macro/run_digi_mft.C
@@ -1,9 +1,8 @@
 #if !defined(__CLING__) || defined(__ROOTCLING__)
-
 #include <sstream>
 
 #include <TStopwatch.h>
-
+#include "DataFormatsParameters/GRPObject.h"
 #include "FairLogger.h"
 #include "FairRunAna.h"
 #include "FairFileSource.h"
@@ -12,66 +11,96 @@
 #include "FairSystemInfo.h"
 
 #include "MFTSimulation/DigitizerTask.h"
-
 #endif
 
-void run_digi_mft(Int_t nEvents = 1, Int_t nMuons = 100, TString mcEngine = "TGeant3", Float_t rate = 50.e3)
-{
+int updateMFTinGRP(std::string inputGRP, std::string grpName = "GRP");
 
+void run_digi_mft(float rate = 50e3,
+                  std::string outputfile = "o2digi_mft.root",
+                  std::string inputfile = "o2sim.root",
+                  std::string paramfile = "o2sim_par.root",
+                  std::string inputGRP = "o2sim_grp.root",
+                  std::string inputfileQED = "", // "o2sim_QED.root" // optional QED hits file
+                  float timebinQEDns = 1000)     // each entry of QED hits file corresponds to as many nanoseconds
+{
   // if rate>0 then continuous simulation for this rate will be performed
 
-  FairLogger *logger = FairLogger::GetLogger();
+  // Initialize logger
+  FairLogger* logger = FairLogger::GetLogger();
   logger->SetLogVerbosityLevel("LOW");
   logger->SetLogScreenLevel("INFO");
-
-  // Input file name
-  char filein[100];
-  sprintf(filein, "AliceO2_%s.mc_%iev_%imu.root", mcEngine.Data(), nEvents, nMuons);
-  TString inFile = filein;
-
-  // Output file name
-  char fileout[100];
-  sprintf(fileout, "AliceO2_%s.digi_%iev_%imu.root", mcEngine.Data(), nEvents, nMuons);
-  TString outFile = fileout;
-
-  // Parameter file name
-  char filepar[100];
-  sprintf(filepar, "AliceO2_%s.params_%iev_%imu.root", mcEngine.Data(), nEvents, nMuons);
-  TString parFile = filepar;
 
   // Setup timer
   TStopwatch timer;
 
   // Setup FairRoot analysis manager
-  FairRunAna * fRun = new FairRunAna();
-  FairFileSource *fFileSource = new FairFileSource(inFile);
+  FairRunAna* fRun = new FairRunAna();
+  FairFileSource* fFileSource = new FairFileSource(inputfile);
   fRun->SetSource(fFileSource);
-  fRun->SetOutputFile(outFile);
+  fRun->SetOutputFile(outputfile.data());
 
-  if (rate>0) fFileSource->SetEventMeanTime(1.e9/rate); //is in us
-        
+  if (rate > 0) {
+    fFileSource->SetEventMeanTime(1.e9 / rate); // is in us
+    updateMFTinGRP(inputGRP);
+  }
+
   // Setup Runtime DB
   FairRuntimeDb* rtdb = fRun->GetRuntimeDb();
   FairParRootFileIo* parInput1 = new FairParRootFileIo();
-  parInput1->open(parFile);
+  parInput1->open(paramfile.data());
   rtdb->setFirstInput(parInput1);
 
   // Setup digitizer
+  // Call o2::MFT::DigitizerTask(kTRUE) to activate the ALPIDE simulation
   o2::MFT::DigitizerTask* digi = new o2::MFT::DigitizerTask();
-  digi->setContinuous(rate>0);
+  //
+  // This is an example of setting the digitization parameters manually
+  // ====>>
+  // defaults
+  digi->getDigiParams().setContinuous(rate > 0);     // continuous vs per-event mode
+  digi->getDigiParams().setROFrameLength(10000);     // RO frame in ns
+  digi->getDigiParams().setStrobeDelay(0);           // Strobe delay wrt beginning of the RO frame, in ns
+  digi->getDigiParams().setStrobeLength(10000 - 25); // Strobe length in ns
+  // parameters of signal time response: flat-top duration, max rise time and q @ which rise time is 0
+  digi->getDigiParams().getSignalShape().setParameters(7500., 1100., 450.);
+  digi->getDigiParams().setChargeThreshold(150); // charge threshold in electrons
+  //digi->getDigiParams().setNoisePerPixel(1.e-6); // noise level
+  digi->getDigiParams().setNoisePerPixel(0.); // noise level
+  // <<===
+
+  //-------------- do we have QED digits file provided ?
+  TFile* qedHitsFile = nullptr;
+  if (!inputfileQED.empty()) {
+    qedHitsFile = TFile::Open(inputfileQED.data());
+    if (!qedHitsFile || qedHitsFile->IsZombie()) {
+      LOG(FATAL) << "Failed to open QED file " << inputfileQED << FairLogger::endl;
+    }
+    TTree* qedTree = (TTree*)qedHitsFile->Get("o2sim");
+    if (!qedTree) {
+      LOG(FATAL) << "No o2sim tree in QED file " << inputfileQED << FairLogger::endl;
+    }
+    TBranch* qedBranch = qedTree->GetBranch("MFTHit");
+    if (!qedBranch) {
+      LOG(FATAL) << "No MFTHit branch in the QED hits tree of file " << inputfileQED << FairLogger::endl;
+    }
+    digi->setQEDInput(qedBranch, timebinQEDns, 99); // the QED is assigned source ID = 99
+  }
+
   digi->setFairTimeUnitInNS(1.0); // tell in which units (wrt nanosecond) FAIT timestamps are
   fRun->AddTask(digi);
-  
+
   fRun->Init();
-  
+
+  timer.Start();
   fRun->Run();
 
-  std::cout << std::endl << std::endl;
-  
+  std::cout << std::endl
+            << std::endl;
+
   // Extract the maximal used memory an add is as Dart measurement
   // This line is filtered by CTest and the value send to CDash
   FairSystemInfo sysInfo;
-  Float_t maxMemory=sysInfo.GetMaxMemory();
+  Float_t maxMemory = sysInfo.GetMaxMemory();
   std::cout << "<DartMeasurement name=\"MaxMemory\" type=\"numeric/double\">";
   std::cout << maxMemory;
   std::cout << "</DartMeasurement>" << std::endl;
@@ -80,19 +109,52 @@ void run_digi_mft(Int_t nEvents = 1, Int_t nMuons = 100, TString mcEngine = "TGe
   Double_t rtime = timer.RealTime();
   Double_t ctime = timer.CpuTime();
 
-  Float_t cpuUsage=ctime/rtime;
+  Float_t cpuUsage = ctime / rtime;
   cout << "<DartMeasurement name=\"CpuLoad\" type=\"numeric/double\">";
   cout << cpuUsage;
   cout << "</DartMeasurement>" << endl;
-  cout << endl << endl;
+  cout << endl
+       << endl;
   std::cout << "Macro finished succesfully" << std::endl;
-  
-  std::cout << endl << std::endl;
-  std::cout << "Output file is "    << fileout << std::endl;
-  //std::cout << "Parameter file is " << parFile << std::endl;
-  std::cout << "Real time " << rtime << " s, CPU time " << ctime
-	    << "s" << endl << endl;
 
+  std::cout << endl
+            << std::endl;
+  std::cout << "Output file is " << outputfile << std::endl;
+  // std::cout << "Parameter file is " << parFile << std::endl;
+  std::cout << "Real time " << rtime << " s, CPU time " << ctime << "s" << endl
+            << endl;
+
+  if (qedHitsFile) {
+    qedHitsFile->Close();
+    delete qedHitsFile;
+  }
 }
 
+int updateMFTinGRP(std::string inputGRP, std::string grpName)
+{
+  TFile flGRP(inputGRP.data(), "update");
+  if (flGRP.IsZombie()) {
+    LOG(ERROR) << "Failed to open in update mode " << inputGRP << FairLogger::endl;
+    return -10;
+  }
+  auto grp =
+    static_cast<o2::parameters::GRPObject*>(flGRP.GetObjectChecked(grpName.data(), o2::parameters::GRPObject::Class()));
+  if (!grp) {
+    LOG(ERROR) << "Did not find GRP object named " << inputGRP << FairLogger::endl;
+    return -12;
+  }
 
+  vector<o2::detectors::DetID> contDet = { o2::detectors::DetID::MFT };
+
+  for (auto det : contDet) {
+    if (grp->isDetReadOut(det)) {
+      grp->addDetContinuousReadOut(det);
+    }
+  }
+
+  LOG(INFO) << "Updated GRP in " << inputGRP << " flagging continously read-out detector(s)" << FairLogger::endl;
+  grp->print();
+  flGRP.WriteObjectAny(grp, grp->Class(), grpName.data());
+  flGRP.Close();
+  return 0;
+}

--- a/macro/run_digi_mft.sh
+++ b/macro/run_digi_mft.sh
@@ -1,1 +1,1 @@
-root.exe -b -q SetIncludePath.C run_digi_mft.C++\($1,$2,\""$3"\",$4\)
+root.exe -b -q SetIncludePath.C run_digi_mft.C++


### PR DESCRIPTION
Provides mapping for MFT used by the raw data en/de-coding (following Ruben's developments), replacing the initial dummy implementation

The macro extractMFTMapping.C generates the content of the file ChipMappingMFT.cxx 

For the moment the "natural" order of modules (chips) used for the transformation matrices is implemented; after exchange with the read-out people this will be modified

See macro/README_mft for information about how to simulate this
