### PR TITLE
DPL: Move timing out of message contextes

### DIFF
--- a/Framework/Core/include/Framework/DataAllocator.h
+++ b/Framework/Core/include/Framework/DataAllocator.h
@@ -18,6 +18,7 @@
 #include "Framework/FairMQDeviceProxy.h"
 #include "Framework/MessageContext.h"
 #include "Framework/RootObjectContext.h"
+#include "Framework/TimingInfo.h"
 #include "Framework/TMessageSerializer.h"
 #include "Framework/TypeTraits.h"
 #include "Framework/SerializationMethods.h"
@@ -55,6 +56,7 @@ public:
   using SubSpecificationType = o2::header::DataHeader::SubSpecificationType;
 
   DataAllocator(FairMQDeviceProxy device,
+                TimingInfo *timingInfo,
                 MessageContext *context,
                 RootObjectContext *rootContext,
                 const AllowedOutputRoutes &routes);
@@ -354,6 +356,7 @@ public:
   FairMQDeviceProxy mProxy;
   FairMQDevice *mDevice;
   AllowedOutputRoutes mAllowedOutputRoutes;
+  TimingInfo *mTimingInfo;
   MessageContext* mContext;
   RootObjectContext* mRootContext;
 

--- a/Framework/Core/include/Framework/DataProcessingDevice.h
+++ b/Framework/Core/include/Framework/DataProcessingDevice.h
@@ -23,6 +23,7 @@
 #include "Framework/RootObjectContext.h"
 #include "Framework/InputRoute.h"
 #include "Framework/ForwardRoute.h"
+#include "Framework/TimingInfo.h"
 
 #include <memory>
 
@@ -49,6 +50,7 @@ private:
   AlgorithmSpec::ErrorCallback mError;
   std::unique_ptr<ConfigParamRegistry> mConfigRegistry;
   ServiceRegistry& mServiceRegistry;
+  TimingInfo mTimingInfo;
   MessageContext mContext;
   RootObjectContext mRootContext;
   DataAllocator mAllocator;

--- a/Framework/Core/include/Framework/DataSourceDevice.h
+++ b/Framework/Core/include/Framework/DataSourceDevice.h
@@ -47,6 +47,7 @@ private:
 
   std::unique_ptr<ConfigParamRegistry> mConfigRegistry;
   ServiceRegistry& mServiceRegistry;
+  TimingInfo mTimingInfo;
   MessageContext mContext;
   RootObjectContext mRootContext;
   DataAllocator mAllocator;

--- a/Framework/Core/include/Framework/MessageContext.h
+++ b/Framework/Core/include/Framework/MessageContext.h
@@ -53,25 +53,16 @@ public:
   /// Prepares the context to create messages for the given timeslice. This
   /// expects that the previous context was already sent and can be completely
   /// discarded.
-  void prepareForTimeslice(size_t timeslice)
+  void clear()
   {
     // Verify that everything has been sent on clear.
     for (auto &m : mMessages) {
       assert(m.parts.Size() == 0);
     }
     mMessages.clear();
-    mTimeslice = timeslice;
-  }
-
-  /// This returns the current timeslice for the context. The value of the
-  /// timeslice is used to determine which downstream device will get the
-  /// message in case we are doing time pipelining.
-  size_t timeslice() const {
-    return mTimeslice;
   }
 private:
   Messages mMessages;
-  size_t mTimeslice;
 };
 
 } // namespace framework

--- a/Framework/Core/include/Framework/RootObjectContext.h
+++ b/Framework/Core/include/Framework/RootObjectContext.h
@@ -23,6 +23,8 @@ namespace o2
 namespace framework
 {
 
+/// Holds ROOT objects which are being processed by a given 
+/// computation.
 class RootObjectContext {
 public:
   struct MessageRef {
@@ -57,7 +59,7 @@ public:
     return mMessages.size();
   }
 
-  void prepareForTimeslice(size_t timeslice)
+  void clear()
   {
     // On send we move the header, but the payload remains
     // there because what's really sent is the TMessage
@@ -67,16 +69,10 @@ public:
       assert(m.payload.get() != nullptr);
     }
     mMessages.clear();
-    mTimeslice = timeslice;
   }
 
-  size_t timeslice() const
-  {
-    return mTimeslice;
-  }
 private:
   Messages mMessages;
-  size_t mTimeslice;
 };
 
 } // namespace framework

--- a/Framework/Core/include/Framework/TimingInfo.h
+++ b/Framework/Core/include/Framework/TimingInfo.h
@@ -1,0 +1,22 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef FRAMEWORK_TIMINGINFO_H
+#define FRAMEWORK_TIMINGINFO_H
+
+#include <cstddef>
+
+/// This class holds the information about timing
+/// of the messages being processed.
+struct TimingInfo {
+  size_t timeslice; /// the timeslice associated to current processing
+};
+
+#endif // Timing information for the current computation

--- a/Framework/Core/src/DataSourceDevice.cxx
+++ b/Framework/Core/src/DataSourceDevice.cxx
@@ -37,7 +37,7 @@ DataSourceDevice::DataSourceDevice(const DeviceSpec &spec, ServiceRegistry &regi
   mStatelessProcess{spec.algorithm.onProcess},
   mError{spec.algorithm.onError},
   mConfigRegistry{nullptr},
-  mAllocator{FairMQDeviceProxy{this},&mContext, &mRootContext, spec.outputs},
+  mAllocator{FairMQDeviceProxy{this},&mTimingInfo, &mContext, &mRootContext, spec.outputs},
   mServiceRegistry{registry},
   mCurrentTimeslice{0},
   mRate{0.},
@@ -91,8 +91,9 @@ bool DataSourceDevice::ConditionalRun() {
   // processing code, we still specify it.
   InputRecord dummyInputs{ {}, { [](size_t) { return nullptr; }, 0 } };
   try {
-    mContext.prepareForTimeslice(mCurrentTimeslice);
-    mRootContext.prepareForTimeslice(mCurrentTimeslice);
+    mTimingInfo.timeslice = mCurrentTimeslice;
+    mContext.clear();
+    mRootContext.clear();
     mCurrentTimeslice += 1;
 
     // Avoid runaway process in case we have nothing to do.


### PR DESCRIPTION
Initially the timing information was hold into MessageContext as that
one was the only one existing. As we add serialization methods and
therefore possibly add new Contextes it makes sense to separate the
timing information out of the context, so that we avoid duplicating it.

This is propedeutic to support Arrow based serialization and
sub timeframe serialization.