### PR TITLE
Preparations for AliTPCCommon v1.4

### DIFF
--- a/Detectors/TPC/reconstruction/src/TPCCATracking.cxx
+++ b/Detectors/TPC/reconstruction/src/TPCCATracking.cxx
@@ -293,7 +293,7 @@ int TPCCATracking::runTracking(const ClusterNativeAccessFullTPC& clusters, std::
       }
 
       oTrack.setChi2(tracks[i].GetParam().GetChi2());
-      auto& outerPar = tracks[i].GetParam().OuterParam();
+      auto& outerPar = tracks[i].OuterParam();
       oTrack.setOuterParam(o2::track::TrackParCov(
         outerPar.fX, outerPar.fAlpha,
         { outerPar.fP[0], outerPar.fP[1], outerPar.fP[2], outerPar.fP[3], outerPar.fP[4] },


### PR DESCRIPTION
The GetParam().OuterParam() interface will be dropped in favor of OuterParam() directly.