### PR TITLE
Add native support to send around strings

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -190,6 +190,7 @@ Install(FILES test/test_DataSamplingDPL.json test/test_DataSamplingFairMQ.json D
 
 set(TEST_SRCS
       test/test_SimpleStatefulProcessing01.cxx
+      test/test_SimpleStringProcessing.cxx
       test/test_AlgorithmSpec.cxx
       test/test_BoostOptionsRetriever.cxx
       test/test_DataRelayer.cxx

--- a/Framework/Core/include/Framework/ContextRegistry.h
+++ b/Framework/Core/include/Framework/ContextRegistry.h
@@ -1,0 +1,65 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef FRAMEWORK_CONTEXTREGISTRY_H
+#define FRAMEWORK_CONTEXTREGISTRY_H
+
+#include <array>
+
+namespace o2
+{
+namespace framework
+{
+
+/// Decouples getting the various contextes from the actual type
+/// of context, so that the DataAllocator does not need to know
+/// about the various serialization methods. Since there is only
+/// a few context types we support, this can be done in an ad hoc
+/// manner making sure each overload of ContextRegistry<T>::get()
+/// uses a different entry in ContextRegistry::contextes;
+///
+/// Right now we use:
+///
+/// MessageContext 0
+/// ROOTObjectContext 1
+/// StringContext 2
+class ContextRegistry
+{
+ public:
+  ContextRegistry(std::array<void*, 2> contextes)
+    : mContextes{ contextes }
+  {
+  }
+
+  /// Default getter does nothing. Each Context needs
+  /// to override the get method and return a unique
+  /// entry in the mContextes.
+  template <class T, size_t S = sizeof(T)>
+  T* get()
+  {
+    static_assert(sizeof(T) == -1, "Unsupported backend");
+  }
+
+  /// Default setter does nothing. Each Context needs
+  /// to override the set method and store the agreed
+  /// pointer in the right position.
+  template <class T, size_t S = sizeof(T)>
+  void set(T*)
+  {
+    static_assert(sizeof(T) == -1, "Unsupported backend");
+  }
+
+ private:
+  std::array<void*, 2> mContextes;
+};
+
+} // namespace framework
+} // namespace o2
+#endif // FRAMEWORK_CONTEXTREGISTRY_H

--- a/Framework/Core/include/Framework/ContextRegistry.h
+++ b/Framework/Core/include/Framework/ContextRegistry.h
@@ -33,7 +33,7 @@ namespace framework
 class ContextRegistry
 {
  public:
-  ContextRegistry(std::array<void*, 2> contextes)
+  ContextRegistry(std::array<void*, 3> contextes)
     : mContextes{ contextes }
   {
   }
@@ -57,7 +57,7 @@ class ContextRegistry
   }
 
  private:
-  std::array<void*, 2> mContextes;
+  std::array<void*, 3> mContextes;
 };
 
 } // namespace framework

--- a/Framework/Core/include/Framework/DataProcessingDevice.h
+++ b/Framework/Core/include/Framework/DataProcessingDevice.h
@@ -21,6 +21,7 @@
 #include "Framework/DeviceSpec.h"
 #include "Framework/MessageContext.h"
 #include "Framework/RootObjectContext.h"
+#include "Framework/StringContext.h"
 #include "Framework/ServiceRegistry.h"
 #include "Framework/InputRoute.h"
 #include "Framework/ForwardRoute.h"
@@ -54,6 +55,7 @@ private:
   TimingInfo mTimingInfo;
   MessageContext mFairMQContext;
   RootObjectContext mRootContext;
+  StringContext mStringContext;
   ContextRegistry mContextRegistry;
   DataAllocator mAllocator;
   DataRelayer mRelayer;

--- a/Framework/Core/include/Framework/DataProcessingDevice.h
+++ b/Framework/Core/include/Framework/DataProcessingDevice.h
@@ -15,12 +15,13 @@
 
 #include "Framework/AlgorithmSpec.h"
 #include "Framework/ConfigParamRegistry.h"
+#include "Framework/ContextRegistry.h"
 #include "Framework/DataAllocator.h"
 #include "Framework/DataRelayer.h"
 #include "Framework/DeviceSpec.h"
-#include "Framework/ServiceRegistry.h"
 #include "Framework/MessageContext.h"
 #include "Framework/RootObjectContext.h"
+#include "Framework/ServiceRegistry.h"
 #include "Framework/InputRoute.h"
 #include "Framework/ForwardRoute.h"
 #include "Framework/TimingInfo.h"
@@ -51,8 +52,9 @@ private:
   std::unique_ptr<ConfigParamRegistry> mConfigRegistry;
   ServiceRegistry& mServiceRegistry;
   TimingInfo mTimingInfo;
-  MessageContext mContext;
+  MessageContext mFairMQContext;
   RootObjectContext mRootContext;
+  ContextRegistry mContextRegistry;
   DataAllocator mAllocator;
   DataRelayer mRelayer;
 

--- a/Framework/Core/include/Framework/DataProcessor.h
+++ b/Framework/Core/include/Framework/DataProcessor.h
@@ -19,10 +19,14 @@ namespace framework
 
 class RootObjectContext;
 class MessageContext;
+class StringContext;
 
+/// Helper class to send messages from a contex at the end
+/// of a computation.
 struct DataProcessor {
-  static void doSend(FairMQDevice &device, RootObjectContext &);
-  static void doSend(FairMQDevice &device, MessageContext &);
+  static void doSend(FairMQDevice&, RootObjectContext&);
+  static void doSend(FairMQDevice&, MessageContext&);
+  static void doSend(FairMQDevice&, StringContext&);
 };
 
 } // namespace framework

--- a/Framework/Core/include/Framework/DataSourceDevice.h
+++ b/Framework/Core/include/Framework/DataSourceDevice.h
@@ -16,8 +16,6 @@
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/DataAllocator.h"
 #include "Framework/DeviceSpec.h"
-#include "Framework/MessageContext.h"
-#include "Framework/RootObjectContext.h"
 #include "Framework/ServiceRegistry.h"
 
 #include <memory>
@@ -48,8 +46,9 @@ private:
   std::unique_ptr<ConfigParamRegistry> mConfigRegistry;
   ServiceRegistry& mServiceRegistry;
   TimingInfo mTimingInfo;
-  MessageContext mContext;
+  MessageContext mFairMQContext;
   RootObjectContext mRootContext;
+  ContextRegistry mContextRegistry;
   DataAllocator mAllocator;
   size_t mCurrentTimeslice;
   float mRate;

--- a/Framework/Core/include/Framework/DataSourceDevice.h
+++ b/Framework/Core/include/Framework/DataSourceDevice.h
@@ -48,6 +48,7 @@ private:
   TimingInfo mTimingInfo;
   MessageContext mFairMQContext;
   RootObjectContext mRootContext;
+  StringContext mStringContext;
   ContextRegistry mContextRegistry;
   DataAllocator mAllocator;
   size_t mCurrentTimeslice;

--- a/Framework/Core/include/Framework/MessageContext.h
+++ b/Framework/Core/include/Framework/MessageContext.h
@@ -11,9 +11,13 @@
 #define FRAMEWORK_MESSAGECONTEXT_H
 
 #include <fairmq/FairMQParts.h>
+#include "Framework/ContextRegistry.h"
+#include "Framework/FairMQDeviceProxy.h"
 #include <vector>
 #include <cassert>
 #include <string>
+
+class FairMQDevice;
 
 namespace o2
 {
@@ -22,9 +26,14 @@ namespace framework
 
 class MessageContext {
 public:
-  struct MessageRef {
-    FairMQParts parts;
-    std::string channel;
+ MessageContext(FairMQDeviceProxy proxy)
+   : mProxy{ proxy }
+ {
+ }
+
+ struct MessageRef {
+   FairMQParts parts;
+   std::string channel;
   };
   using Messages = std::vector<MessageRef>;
 
@@ -61,9 +70,32 @@ public:
     }
     mMessages.clear();
   }
-private:
+
+  FairMQDeviceProxy& proxy()
+  {
+    return mProxy;
+  }
+
+ private:
+  FairMQDeviceProxy mProxy;
   Messages mMessages;
 };
+
+/// Helper to get the context from the registry.
+template <>
+inline MessageContext*
+  ContextRegistry::get<MessageContext>()
+{
+  return reinterpret_cast<MessageContext*>(mContextes[0]);
+}
+
+/// Helper to set the context from the registry.
+template <>
+inline void
+  ContextRegistry::set<MessageContext>(MessageContext* context)
+{
+  mContextes[0] = context;
+}
 
 } // namespace framework
 } // namespace o2

--- a/Framework/Core/include/Framework/RootObjectContext.h
+++ b/Framework/Core/include/Framework/RootObjectContext.h
@@ -10,6 +10,8 @@
 #ifndef FRAMEWORK_ROOTOBJETCONTEXT_H
 #define FRAMEWORK_ROOTOBJETCONTEXT_H
 
+#include "Framework/ContextRegistry.h"
+#include "Framework/FairMQDeviceProxy.h"
 #include <vector>
 #include <cassert>
 #include <string>
@@ -27,10 +29,15 @@ namespace framework
 /// computation.
 class RootObjectContext {
 public:
-  struct MessageRef {
-    std::unique_ptr<FairMQMessage> header;
-    std::unique_ptr<TObject> payload;
-    std::string channel;
+ RootObjectContext(FairMQDeviceProxy proxy)
+   : mProxy{ proxy }
+ {
+ }
+
+ struct MessageRef {
+   std::unique_ptr<FairMQMessage> header;
+   std::unique_ptr<TObject> payload;
+   std::string channel;
   };
 
   using Messages = std::vector<MessageRef>;
@@ -71,9 +78,31 @@ public:
     mMessages.clear();
   }
 
-private:
+  FairMQDeviceProxy& proxy()
+  {
+    return mProxy;
+  }
+
+ private:
+  FairMQDeviceProxy mProxy;
   Messages mMessages;
 };
+
+/// Helper to get the context from the registry.
+template <>
+inline RootObjectContext*
+  ContextRegistry::get<RootObjectContext>()
+{
+  return reinterpret_cast<RootObjectContext*>(mContextes[1]);
+}
+
+/// Helper to set the context from the registry.
+template <>
+inline void
+  ContextRegistry::set<RootObjectContext>(RootObjectContext* context)
+{
+  mContextes[1] = context;
+}
 
 } // namespace framework
 } // namespace o2

--- a/Framework/Core/include/Framework/StringContext.h
+++ b/Framework/Core/include/Framework/StringContext.h
@@ -1,0 +1,110 @@
+
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef FRAMEWORK_STRINGCONTEXT_H
+#define FRAMEWORK_STRINGCONTEXT_H
+
+#include "Framework/ContextRegistry.h"
+#include "Framework/FairMQDeviceProxy.h"
+#include <vector>
+#include <cassert>
+#include <string>
+#include <memory>
+
+class FairMQMessage;
+
+namespace o2
+{
+namespace framework
+{
+
+/// A context which holds `std::string`s being passed around
+/// useful for debug purposes and as an illustration of
+/// how to add a context for a new kind of object.
+class StringContext
+{
+ public:
+  StringContext(FairMQDeviceProxy proxy)
+    : mProxy{ proxy }
+  {
+  }
+
+  struct MessageRef {
+    std::unique_ptr<FairMQMessage> header;
+    std::unique_ptr<std::string> payload;
+    std::string channel;
+  };
+
+  using Messages = std::vector<MessageRef>;
+
+  void addString(std::unique_ptr<FairMQMessage> header,
+                 std::unique_ptr<std::string> s,
+                 const std::string& channel)
+  {
+    mMessages.push_back(std::move(MessageRef{ std::move(header),
+                                              std::move(s),
+                                              channel }));
+  }
+
+  Messages::iterator begin()
+  {
+    return mMessages.begin();
+  }
+
+  Messages::iterator end()
+  {
+    return mMessages.end();
+  }
+
+  size_t size()
+  {
+    return mMessages.size();
+  }
+
+  void clear()
+  {
+    // On send we move the header, but the payload remains
+    // there because what's really sent is the copy of the string
+    // payload will be cleared by the mMessages.clear()
+    for (auto& m : mMessages) {
+      assert(m.header.get() == nullptr);
+      assert(m.payload.get() != nullptr);
+    }
+    mMessages.clear();
+  }
+
+  FairMQDeviceProxy& proxy()
+  {
+    return mProxy;
+  }
+
+ private:
+  FairMQDeviceProxy mProxy;
+  Messages mMessages;
+};
+
+/// Helper to get the context from the registry.
+template <>
+inline StringContext*
+  ContextRegistry::get<StringContext>()
+{
+  return reinterpret_cast<StringContext*>(mContextes[2]);
+}
+
+/// Helper to set the context from the registry.
+template <>
+inline void
+  ContextRegistry::set<StringContext>(StringContext* context)
+{
+  mContextes[2] = context;
+}
+
+} // namespace framework
+} // namespace o2
+#endif // FRAMEWORK_STRINGCONTEXT_H

--- a/Framework/Core/src/DataAllocator.cxx
+++ b/Framework/Core/src/DataAllocator.cxx
@@ -150,5 +150,15 @@ void DataAllocator::adopt(const Output& spec, TObject* ptr)
   assert(payload.get() == nullptr);
 }
 
+void DataAllocator::adopt(const Output& spec, std::string* ptr)
+{
+  std::unique_ptr<std::string> payload(ptr);
+  std::string channel = matchDataHeader(spec, mTimingInfo->timeslice);
+  // the correct payload size is set later when sending the
+  // StringContext, see DataProcessor::doSend
+  auto header = headerMessageFromOutput(spec, channel, o2::header::gSerializationMethodNone, 0);
+  mContextRegistry->get<StringContext>()->addString(std::move(header), std::move(payload), channel);
+  assert(payload.get() == nullptr);
+}
 }
 }

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -44,7 +44,10 @@ DataProcessingDevice::DataProcessingDevice(const DeviceSpec& spec, ServiceRegist
     mStatelessProcess{ spec.algorithm.onProcess },
     mError{ spec.algorithm.onError },
     mConfigRegistry{ nullptr },
-    mAllocator{ this, &mTimingInfo, &mContext, &mRootContext, spec.outputs },
+    mFairMQContext{ FairMQDeviceProxy{ this } },
+    mRootContext{ FairMQDeviceProxy{ this } },
+    mContextRegistry{ { &mFairMQContext, &mRootContext } },
+    mAllocator{ &mTimingInfo, &mContextRegistry, spec.outputs },
     mRelayer{ spec.completionPolicy, spec.inputs, spec.forwards, registry.get<Monitoring>() },
     mInputChannels{ spec.inputChannels },
     mOutputChannels{ spec.outputChannels },
@@ -117,7 +120,7 @@ DataProcessingDevice::HandleData(FairMQParts &iParts, int /*index*/) {
   auto &relayer = mRelayer;
   auto &device = *this;
   auto &timingInfo = mTimingInfo;
-  auto &context = mContext;
+  auto& context = mFairMQContext;
   auto &rootContext = mRootContext;
   auto &forwards = mForwards;
   auto &inputsSchema = mInputs;

--- a/Framework/Core/test/test_SimpleStringProcessing.cxx
+++ b/Framework/Core/test/test_SimpleStringProcessing.cxx
@@ -1,0 +1,59 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/DataRefUtils.h"
+#include "Framework/AlgorithmSpec.h"
+#include "Framework/ServiceRegistry.h"
+#include "Framework/runDataProcessing.h"
+#include <Monitoring/Monitoring.h>
+#include "Framework/ControlService.h"
+#include "Framework/CallbackService.h"
+#include "FairMQLogger.h"
+
+using namespace o2::framework;
+using DataHeader = o2::header::DataHeader;
+
+/// Example of how to send around strings using DPL.
+WorkflowSpec defineDataProcessing(ConfigContext const&)
+{
+  return WorkflowSpec{
+    //
+    DataProcessorSpec{
+      "string_producer", //
+      Inputs{},          //
+      {
+        OutputSpec{ { "make" }, "TES", "STRING" }, //
+      },
+      AlgorithmSpec{ [](ProcessingContext& ctx) {
+        auto& out1 = ctx.outputs().make<std::string>(Output{ "TES", "STRING" }, "default");
+        assert(out1 == "default");
+        out1 = "Hello";
+      } } //
+    },    //
+    DataProcessorSpec{
+      "string_consumer", //
+      {
+        InputSpec{ "make", "TES", "STRING" }, //
+      },                                      //
+      Outputs{},                              //
+      AlgorithmSpec{
+        [](ProcessingContext& ctx) {
+          auto s = ctx.inputs().get<std::string>("make");
+
+          if (s != "Hello") {
+            LOG(ERROR) << "Expecting `Hello', found `" << s << "'";
+          } else {
+            LOG(INFO) << "Everything OK";
+          }
+          ctx.services().get<ControlService>().readyToQuit(true);
+        } //
+      }   //
+    }     //
+  };
+}


### PR DESCRIPTION
This introduces preliminary support to create and send around `std::string`s. While this could have been done in other ways (e.g. using root serialization) we use this as a prototype of what is needed to create yet another serialization backend.