### PR TITLE
A concept for configurable parameters

### DIFF
--- a/Common/SimConfig/CMakeLists.txt
+++ b/Common/SimConfig/CMakeLists.txt
@@ -4,10 +4,14 @@ O2_SETUP(NAME ${MODULE_NAME})
 
 set(SRCS
     src/SimConfig.cxx
+    src/ConfigurableParam.cxx
+    src/ConfigurableParamHelper.cxx
    )
 
 set(HEADERS
     include/${MODULE_NAME}/SimConfig.h
+    include/${MODULE_NAME}/ConfigurableParam.h
+    include/${MODULE_NAME}/ConfigurableParamHelper.h
    )
 
 set(LINKDEF src/SimConfigLinkDef.h)
@@ -17,9 +21,16 @@ set(BUCKET_NAME configuration_bucket)
 O2_GENERATE_LIBRARY()
 
  O2_GENERATE_EXECUTABLE(
-      EXE_NAME testSimConf
-      SOURCES test/TestConfig.cxx
-      MODULE_LIBRARY_NAME ${LIBRARY_NAME}
-      BUCKET_NAME ${BUCKET_NAME}
-  )
+   EXE_NAME testSimConf
+   SOURCES test/TestConfig.cxx
+   MODULE_LIBRARY_NAME ${LIBRARY_NAME}
+   BUCKET_NAME ${BUCKET_NAME}
+ )
+
+O2_GENERATE_EXECUTABLE(
+  EXE_NAME testConfigurableParam
+  SOURCES test/TestConfigurableParam.cxx
+  MODULE_LIBRARY_NAME ${LIBRARY_NAME}
+  BUCKET_NAME ${BUCKET_NAME}
+)
 

--- a/Common/SimConfig/doc/ConfigurableParam.md
+++ b/Common/SimConfig/doc/ConfigurableParam.md
@@ -1,0 +1,109 @@
+# Configurable Parameters
+
+This is a short README for configurable parameters as offered by 
+the ConfigurableParameter class.
+
+# Introduction
+
+The ConfigurableParameter class implements the demand
+* to have simple variables (under a compound namespace) be declared as 'knobs'
+of an algorithm in order to be able to change/configure their value without recompilation.
+* to have such declared variables be automatically registered in a parameter database or manager instance.
+* to be able to configure/change the parameter values in a textual way (for instance from the command line)
+* to provide automatic serialization / deserialization techniques (to text files or binary blobs) -- for instance to load from CCDB or to pass along parameter snapshots to other processing stages.
+* to keep track of who changes parameters (provenance tracking). 
+
+# Example / HowTo:
+
+Imagine some algorithms `algorithmA` depends on 2 parameters `p1` and `p2` which you want to be able to configure.
+
+You would do two steps:
+  1. Declare a parameter class listing the parameters and their default values.
+     ```c++
+     struct ParamA : ConfigurableParamHelper<ParamA> {
+       int p1 = 10;
+       double p2 = 1.23;
+       // boilerplate stuff + make parameters known under key "A"
+       O2ParamDef(ParamA, "A");
+     };
+2. Access and use the parameters in the code.
+   ```c++
+   void algorithmA() {
+     // get the parameter singleton object
+     auto& pa = ParamA::Instance();
+     // access the variables in your code
+     doSomething(pa.p1, pa.p2);
+   }
+   ```
+    
+Thereafter, the parameter `ParamA` is automatically registered in a parameter registry and can be read/influenced/serialized through this. The main influencing functions are implemented as static functions on the `ConfigurableParam` class. For example, the following things will be possible:
+* get a value by string key, addressing a specific parameter:
+  ```
+   auto p = ConfigurableParam::getValue<double>("A.p2");
+  ```
+  where the string keys are composed of a primary key and the variable name of the parameter.
+* set/modify a value by a key string
+  ```
+  ConfigurableParam::setValue<double>("A.p2", 10);
+  ```
+  where the string keys are composed of a primary key and the variable name of the parameter.
+  Side note: This API allows to influence values from a string, for instance obtained from command line:
+  ```
+  ConfigurableParam::fromString("A.p2=10,OtherParam.a=-1.");
+  ```
+  The system will complain if a non-existing string key is used.
+  
+* serialize the configuration to a ROOT snapshot or to formats such as JSON or INI
+  ```
+  ConfigurableParam::toINI(filename);
+  ConfigurableParam::toJSON(filename); // JSON repr. of param registry
+  ConfigurableParam::toCCDB(filename); // CCDB snapshot of param registry
+  ```
+* retrieve parameters from CCDB snapshot
+  ```
+  ConfigurableParam::fromCCDB(filename);
+  ```
+* **Provenance tracking**: The system can keep track of the origin of values. Typically, few stages of modification can be done:
+  - default initialization of parameters from code (CODE)
+  - initialization/overwritting from a (CCDB) snapshot file
+  - overriding by user during runtime (RT)
+
+  The registry can keep track of who supplied the current (decisive) value for each parameter: CODE, CCDB or RT. If a parameter is not changed it keeps the state of the previous stage.
+  
+# Further technical details
+
+* Parameter classes are **read-only** singleton classes/structs. As long as the user follows the pattern to inherit from `ConfigurableParamHelper<T>` and to use the macro `O2ParamDef()` everything is implemented automatically.
+* We use the `ROOT C++` introspection facility to map the class layout to a textual configuration. Hence ROOT dictionaries are needed for parameter classes.
+* BOOST property trees are used for the mapping to JSON/INI files but this is an internal detail and might change in future.
+
+# Limitations
+
+* Parameter classes may only contain simple members! Currently the following types are supported
+    * simple pods (for example `double x; char y;`)
+    * simple char strings (`char *`)
+    * fixed size arrays of pods using the ROOT way to serialize:
+       ```c++
+       static constexpr int N=3; //!
+       double array[N] = {1, 2, 3}; //[N] -- note the [N] after //!!
+       ```
+    * array parameters need to be addressed textual with an index operator:
+      ```
+      ConfigurableParam::fromString("ParamA.array[2]=10");
+      ```
+      It is planned to offer more flexible ways to set arrays (see below).
+    * there is currently no support for pointer types or objects. Parameter classes may not be nested.
+* At the moment serialization works on the whole paramter registry (on the whole set of parameters). Everything is written to the same file or snapshot.
+
+# Wish list / planned improvements
+
+* Offer a more flexible way to set array types (to represent them in strings), for example
+  ```c++
+  ConfigurableParam::fromString("ParamA.array = {5, 6, 7}");
+  ```
+* Offer a better more flexible way to read from CCDB.
+  * read from complete snapshots (give single file name) **or** read from different files reciding in paths corresponding to key/namespace.
+* Of a more flexible way to serialize, for example allowing to output configuration to different files.
+* Be able to change the configuration from a text file (next to current possibility from command line)
+* support for few important stl containers (std::array, std::vector)
+* a better way to define stages (CODE, CCDB, RT) and to transition between them; potentially more allowed stages
+* take away more boilerplate: Automatic creation of dictionaries for parameter classes.

--- a/Common/SimConfig/include/SimConfig/ConfigurableParam.h
+++ b/Common/SimConfig/include/SimConfig/ConfigurableParam.h
@@ -27,7 +27,7 @@ namespace conf
 {
 // Base class for a configurable parameter.
 //
-// A configurable parameter is a simple class, defining
+// A configurable parameter (ConfigurableParameter) is a simple class, defining
 // a few (pod) properties/members which are registered
 // in a global (boost) property tree / structure.
 //
@@ -36,7 +36,7 @@ namespace conf
 //    format via ROOT introspection and boost property trees and
 //    the possibility to readably save the configuration
 // *) Serialization/Deserialization into ROOT binary blobs (for the purpose
-//    of writing/retrieving parameters from CCDB)
+//    of writing/retrieving parameters from CCDB and to pass parameters along the processing chain)
 // *) Automatic integration of sub-classes into a common configuration
 // *) Be able to query properties from high level interfaces (just knowing
 // *) Be able to set properties from high-level interfaces (and modifying the underlying
@@ -95,8 +95,8 @@ class ConfigurableParam
     return names[(int)p];
   }
 
-  //
-  virtual std::string getName() const = 0; // print the name of the configurable Parameter
+  // get the name of the configurable Parameter
+  virtual std::string getName() const = 0;
 
   // print the current keys and values to screen (optionally with provenance information)
   virtual void printKeyValues(bool showprov = true) const = 0;
@@ -104,7 +104,9 @@ class ConfigurableParam
   static void printAllRegisteredParamNames();
   static void printAllKeyValuePairs();
 
+  // writes a human readable JSON file of all parameters
   static void writeJSON(std::string filename);
+  // writes a human readable INI file of all parameters
   static void writeINI(std::string filename);
 
   // can be used instead of using API on concrete child classes
@@ -143,17 +145,13 @@ class ConfigurableParam
     }
   }
 
+  // initializes the parameter database
   static void initialize();
 
+  // create CCDB snapsnot
   static void toCCDB(std::string filename);
+  // load from (CCDB) snapshot
   static void fromCCDB(std::string filename);
-  virtual void serializeTo(TFile*) const = 0;
-  virtual void initFrom(TFile*) = 0;
-
-  // allows to provide a file from which to update
-  // (certain) key-values
-  // propagates changes down to each registered configuration
-  static void updateFromFile(std::string filename);
 
   // allows to provide a string of key-values from which to update
   // (certain) key-values
@@ -174,6 +172,8 @@ class ConfigurableParam
 
   // fill property tree with the key-values from the sub-classes
   virtual void putKeyValues(boost::property_tree::ptree*) = 0;
+  virtual void serializeTo(TFile*) const = 0;
+  virtual void initFrom(TFile*) = 0;
 
   // static map keeping, for each configuration key, its memory location and type
   // (internal use to easily sync updates, this is ok since parameter classes are singletons)

--- a/Common/SimConfig/include/SimConfig/ConfigurableParam.h
+++ b/Common/SimConfig/include/SimConfig/ConfigurableParam.h
@@ -1,0 +1,175 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+//first version 8/2018, Sandro Wenzel
+
+#ifndef COMMON_SIMCONFIG_INCLUDE_SIMCONFIG_CONFIGURABLEPARAM_H_
+#define COMMON_SIMCONFIG_INCLUDE_SIMCONFIG_CONFIGURABLEPARAM_H_
+
+#include <vector>
+#include <map>
+#include <boost/property_tree/ptree.hpp>
+#include <typeinfo>
+
+namespace o2
+{
+namespace conf
+{
+// Base class for a configurable parameter.
+//
+// A configurable parameter is a simple class, defining
+// a few (pod) properties/members which are registered
+// in a global (boost) property tree.
+//
+// The features that we provide here are:
+// a) Automatic translation from C++ data description to INI/JSON/XML
+//    format via ROOT introspection and boost property trees and
+//    the possibility to readably save the configuration
+// b) Automatic integration of sub-classes into a common configuration
+// c) Be able to query properties from high level interfaces (just knowing
+// d) Be able to set properties from high-level interfaces (and modifying the underlying
+//    C++ object)
+// e) Automatic ability to modify parameters from the command-line
+//
+// Note that concrete parameter sub-classes **must** be implemented
+// by inheriting from ConfigurableParamHelper and not from this class.
+//
+// ---------------------
+// Example: To define a parameter class TPCGasParameters, one does the following:
+//
+// class TPCGasParamer : public ConfigurableParamHelper<TPCGasParameter>
+// {
+//   public:
+//     double getGasDensity() const { return mGasDensity; }
+//   private: // define properties AND default values
+//     double mGasDensity = 1.23;
+//     int mGasMaterialID = 1;
+//
+//     O2ParamDef(TPCGasParameter, TPCGas); // a macro implementing some magic
+// }
+//
+//
+// We can now query the parameters in various ways
+// - All parameter classes are singletons and we can say: TPCGasParameter::Instance().getGasDensity();
+// - We can query by key (using classname + parameter name) from the global registry:
+// -    ConfigurableParameter::getValueAs<double>("TPCGas", "mGasDensity");
+//
+// We can modify the parameters via the global registry together with an automatic syncing
+// of the underlying C++ object:
+// - ConfigurableParameter::setValue("TPCGas.mGasDensity", "0.5");
+//
+// - TPCGasParameter::Instance().getGasParameter() will now return 0.5;
+//
+// This feature allows to easily modify parameters at run-time via a textual representation
+// (for example by giving strings on the command line)
+//
+// The collection of all parameter keys and values can be stored to a human/machine readable
+// file
+//  - ConfigurableParameter::writeJSON("thisconfiguration.json")
+class ConfigurableParam
+{
+ public:
+  //
+  virtual std::string getName() = 0; // print the name of the configurable Parameter
+
+  // print the current keys and values to screen
+  virtual void printKeyValues() = 0;
+
+  static void printAllRegisteredParamNames();
+  static void printAllKeyValuePairs();
+
+  static void writeJSON(std::string filename);
+  static void writeINI(std::string filename);
+
+  // can be used instead of using API on concrete child classes
+  template <typename T>
+  static T getValueAs(std::string key)
+  {
+    if (!sIsFullyInitialized) {
+      initialize();
+    }
+    return sPtree->get<T>(key);
+  }
+
+  template <typename T>
+  static void setValue(std::string mainkey, std::string subkey, T x)
+  {
+    auto key = mainkey + "." + subkey;
+    if (sPtree->get_optional<std::string>(key).is_initialized()) {
+      sPtree->put(key, x);
+      updateThroughStorageMap(mainkey, subkey, typeid(T), (void*)&x);
+    }
+  }
+
+  // specialized for std::string
+  // which means that the type will be converted internally
+  static void setValue(std::string key, std::string valuestring)
+  {
+    if (sPtree->get_optional<std::string>(key).is_initialized()) {
+      sPtree->put(key, valuestring);
+      updateThroughStorageMapWithConversion(key, valuestring);
+    }
+  }
+
+  static void initialize();
+
+  // allows to provide a file from which to update
+  // (certain) key-values
+  // propagates changes down to each registered configuration
+  static void updateFromFile(std::string filename);
+
+  // allows to provide a string of key-values from which to update
+  // (certain) key-values
+  // propagates changes down to each registered configuration
+  // might be useful to get stuff from the command line
+  static void updateFromString(std::string);
+
+ protected:
+  // constructor is doing nothing else but
+  // registering the concrete parameters
+  ConfigurableParam();
+
+  static void updatePropertyTree();
+  static void updateThroughStorageMap(std::string, std::string, std::type_info const&, void*);
+  static void updateThroughStorageMapWithConversion(std::string, std::string);
+
+  virtual ~ConfigurableParam() = default;
+
+  // fill property tree with the key-values from the sub-classes
+  virtual void putKeyValues(boost::property_tree::ptree*) = 0;
+
+  // static map keeping, for each configuration key, its memory location and type
+  // (internal use to easily sync updates, this is ok since parameter classes are singletons)
+  static std::map<std::string, std::pair<int, void*>>* sKeyToStorageMap;
+
+ private:
+  // static registry for implementations of this type
+  static std::vector<ConfigurableParam*>* sRegisteredParamClasses; //!
+  // static property tree (stocking all key - value pairs from instances of type ConfigurableParam)
+  static boost::property_tree::ptree* sPtree; //!
+  static bool sIsFullyInitialized;            //!
+};
+
+} // end namespace conf
+} // end namespace o2
+
+// a helper macro for boilerplate code in parameter classes
+#define O2ParamDef(classname, key)               \
+ private:                                        \
+  static constexpr char const* const sKey = key; \
+  static classname sInstance;                    \
+  classname() = default;                         \
+  template <typename T>                          \
+  friend class o2::conf::ConfigurableParamHelper;
+
+// a helper macro to implement necessary symbols in source
+#define O2ParamImpl(classname) classname classname::sInstance;
+
+#endif /* COMMON_SIMCONFIG_INCLUDE_SIMCONFIG_CONFIGURABLEPARAM_H_ */

--- a/Common/SimConfig/include/SimConfig/ConfigurableParamHelper.h
+++ b/Common/SimConfig/include/SimConfig/ConfigurableParamHelper.h
@@ -1,0 +1,89 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+//first version 8/2018, Sandro Wenzel
+
+#ifndef COMMON_SIMCONFIG_INCLUDE_SIMCONFIG_CONFIGURABLEPARAMHELPER_H_
+#define COMMON_SIMCONFIG_INCLUDE_SIMCONFIG_CONFIGURABLEPARAMHELPER_H_
+
+#include "SimConfig/ConfigurableParam.h"
+#include "TClass.h"
+#include <type_traits>
+#include <typeinfo>
+
+namespace o2
+{
+namespace conf
+{
+
+// just a (non-templated) Helper with exclusively private functions
+// used by ConfigurableParamHelper
+class _ParamHelper
+{
+ private:
+  static void printParametersImpl(TClass* cl, void*);
+
+  static void fillKeyValuesImpl(std::string mainkey, TClass* cl, void*, boost::property_tree::ptree*,
+                                std::map<std::string, std::pair<int, void*>>*);
+
+  static void printWarning(std::type_info const&);
+
+  template <typename P>
+  friend class ConfigurableParamHelper;
+};
+
+// implementer (and checker) for concrete ConfigurableParam classes P
+template <typename P>
+class ConfigurableParamHelper : virtual public ConfigurableParam
+{
+ public:
+  using ConfigurableParam::ConfigurableParam;
+  static P& Instance()
+  {
+    return P::sInstance;
+  }
+
+  std::string getName() final
+  {
+    return P::sKey;
+  }
+
+  // one of the key methods, using introspection to print itself
+  void printKeyValues() final
+  {
+    // just a helper line to make sure P::sInstance is looked-up
+    // and that compiler complains about missing static sInstance of type P
+    // volatile void* ptr = (void*)&P::sInstance;
+    // static assert on type of sInstance:
+    static_assert(std::is_same<decltype(P::sInstance), P>::value, "static instance must of same type as class");
+
+    // obtain the TClass for P and delegate further
+    auto cl = TClass::GetClass(typeid(P));
+    if (!cl) {
+      _ParamHelper::printWarning(typeid(P));
+      return;
+    }
+    _ParamHelper::printParametersImpl(cl, (void*)this);
+  }
+
+  void putKeyValues(boost::property_tree::ptree* tree) final
+  {
+    auto cl = TClass::GetClass(typeid(P));
+    if (!cl) {
+      _ParamHelper::printWarning(typeid(P));
+      return;
+    }
+    _ParamHelper::fillKeyValuesImpl(getName(), cl, (void*)this, tree, sKeyToStorageMap);
+  }
+};
+} // namespace conf
+} // namespace o2
+
+#endif /* COMMON_SIMCONFIG_INCLUDE_SIMCONFIG_CONFIGURABLEPARAMHELPER_H_ */

--- a/Common/SimConfig/include/SimConfig/ConfigurableParamHelper.h
+++ b/Common/SimConfig/include/SimConfig/ConfigurableParamHelper.h
@@ -50,7 +50,7 @@ class ConfigurableParamHelper : virtual public ConfigurableParam
 {
  public:
   using ConfigurableParam::ConfigurableParam;
-  static P& Instance()
+  static const P& Instance()
   {
     return P::sInstance;
   }

--- a/Common/SimConfig/include/SimConfig/SimConfig.h
+++ b/Common/SimConfig/include/SimConfig/SimConfig.h
@@ -32,6 +32,10 @@ struct SimConfigData {
   std::string mOutputPrefix;                 // prefix to be used for output files
   std::string mLogSeverity;                  // severity for FairLogger
   std::string mLogVerbosity;                 // loglevel for FairLogger
+  std::string mKeyValueTokens;               // a string holding arbitrary sequence of key-value tokens
+                                             // Foo.parameter1=x,Bar.parameter2=y,Baz.paramter3=hello
+                                             // (can be used to **loosly** change any configuration parameter from
+                                             //  command-line)
   ClassDefNV(SimConfigData, 1);
 };
 
@@ -84,6 +88,7 @@ class SimConfig
   std::string getOutPrefix() const { return mConfigData.mOutputPrefix; }
   std::string getLogVerbosity() const { return mConfigData.mLogVerbosity; }
   std::string getLogSeverity() const { return mConfigData.mLogSeverity; }
+  std::string getKeyValueString() const { return mConfigData.mKeyValueTokens; }
 
  private:
   SimConfigData mConfigData; //!

--- a/Common/SimConfig/src/ConfigurableParam.cxx
+++ b/Common/SimConfig/src/ConfigurableParam.cxx
@@ -1,0 +1,398 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+//first version 8/2018, Sandro Wenzel
+
+#include "SimConfig/ConfigurableParam.h"
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/ini_parser.hpp>
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/tokenizer.hpp>
+#include <boost/lexical_cast.hpp>
+#include <iostream>
+#include <FairLogger.h>
+#include <typeinfo>
+#include <cassert>
+#include "TDataType.h"
+
+namespace o2
+{
+namespace conf
+{
+
+std::vector<ConfigurableParam*>* ConfigurableParam::sRegisteredParamClasses = nullptr;
+boost::property_tree::ptree* ConfigurableParam::sPtree = nullptr;
+std::map<std::string, std::pair<int, void*>>* ConfigurableParam::sKeyToStorageMap = nullptr;
+bool ConfigurableParam::sIsFullyInitialized = false;
+
+void ConfigurableParam::writeINI(std::string filename)
+{
+  updatePropertyTree();
+  boost::property_tree::write_ini(filename, *sPtree);
+}
+
+void ConfigurableParam::writeJSON(std::string filename)
+{
+  updatePropertyTree();
+  boost::property_tree::write_json(filename, *sPtree);
+}
+
+void ConfigurableParam::updatePropertyTree()
+{
+  sPtree->clear();
+  for (auto p : *sRegisteredParamClasses) {
+    p->putKeyValues(sPtree);
+  }
+}
+
+void ConfigurableParam::printAllKeyValuePairs()
+{
+  for (auto p : *sRegisteredParamClasses) {
+    p->printKeyValues();
+  }
+}
+
+ConfigurableParam::ConfigurableParam()
+{
+  if (sRegisteredParamClasses == nullptr) {
+    sRegisteredParamClasses = new std::vector<ConfigurableParam*>;
+  }
+  if (sPtree == nullptr) {
+    sPtree = new boost::property_tree::ptree;
+  }
+  if (sKeyToStorageMap == nullptr) {
+    sKeyToStorageMap = new std::map<std::string, std::pair<int, void*>>;
+  }
+  sRegisteredParamClasses->push_back(this);
+}
+
+void ConfigurableParam::initialize()
+{
+  updatePropertyTree();
+  sIsFullyInitialized = true;
+}
+
+void ConfigurableParam::printAllRegisteredParamNames()
+{
+  for (auto p : *sRegisteredParamClasses) {
+    std::cout << p->getName() << "\n";
+  }
+}
+
+void ConfigurableParam::updateFromString(std::string configstring)
+{
+  if (!sIsFullyInitialized) {
+    initialize();
+  }
+  using Tokenizer = boost::tokenizer<boost::char_separator<char>>;
+  boost::char_separator<char> tokensep{ "," };
+  boost::char_separator<char> keyvaluesep{ "=" };
+  Tokenizer tok{ configstring, tokensep };
+  for (const auto& t : tok) {
+    Tokenizer keyvaluetokenizer{ t, keyvaluesep };
+    std::string extractedkey;
+    std::string extractedvalue;
+    int counter = 0;
+    // TODO: make sure format is correct with a regular expression
+    for (const auto& s : keyvaluetokenizer) {
+      if (counter == 1) {
+        extractedvalue = s;
+      }
+      if (counter == 0) {
+        extractedkey = s;
+      }
+      counter++;
+    }
+    // here we have key and value
+    // ... check whether such a key exists
+    auto optional = sPtree->get_optional<std::string>(extractedkey);
+    if (optional.is_initialized()) {
+      LOG(INFO) << "FOUND KEY ... and the current value is " << optional.get();
+
+      assert(sKeyToStorageMap->find(extractedkey) != sKeyToStorageMap->end());
+
+      setValue(extractedkey, extractedvalue);
+    } else {
+      LOG(WARN) << "Configuration key " << extractedkey << " not valid ... (ignoring)";
+      continue;
+    }
+  }
+}
+
+void unsupp() { std::cerr << "currently unsupported\n"; }
+
+template <typename T>
+void Copy(void const* addr, void* targetaddr)
+{
+  std::memcpy(targetaddr, addr, sizeof(T));
+}
+
+void ConfigurableParam::updateThroughStorageMap(std::string mainkey, std::string subkey, std::type_info const& tinfo,
+                                                void* addr)
+{
+  // check if key_exists
+  auto key = mainkey + "." + subkey;
+  auto iter = sKeyToStorageMap->find(key);
+  if (iter == sKeyToStorageMap->end()) {
+    LOG(WARN) << "Cannot update parameter " << key << " not found";
+    return;
+  }
+
+  // the type we need to convert to
+  int type = TDataType::GetType(tinfo);
+
+  // check that type matches
+  if (iter->second.first != type) {
+    LOG(WARN) << "Types do not match; cannot update value";
+    return;
+  }
+
+  auto targetaddress = iter->second.second;
+  switch (type) {
+    case kChar_t: {
+      Copy<char>(addr, targetaddress);
+      break;
+    }
+    case kUChar_t: {
+      Copy<unsigned char>(addr, targetaddress);
+      break;
+    }
+    case kShort_t: {
+      Copy<short>(addr, targetaddress);
+      break;
+    }
+    case kUShort_t: {
+      Copy<unsigned short>(addr, targetaddress);
+      break;
+    }
+    case kInt_t: {
+      Copy<int>(addr, targetaddress);
+      break;
+    }
+    case kUInt_t: {
+      Copy<unsigned int>(addr, targetaddress);
+      break;
+    }
+    case kLong_t: {
+      Copy<long>(addr, targetaddress);
+      break;
+    }
+    case kULong_t: {
+      Copy<unsigned long>(addr, targetaddress);
+      break;
+    }
+    case kFloat_t: {
+      Copy<float>(addr, targetaddress);
+      break;
+    }
+    case kDouble_t: {
+      Copy<double>(addr, targetaddress);
+      break;
+    }
+    case kDouble32_t: {
+      Copy<double>(addr, targetaddress);
+      break;
+    }
+    case kchar: {
+      unsupp();
+      break;
+    }
+    case kBool_t: {
+      Copy<bool>(addr, targetaddress);
+      break;
+    }
+    case kLong64_t: {
+      Copy<long long>(addr, targetaddress);
+      break;
+    }
+    case kULong64_t: {
+      Copy<unsigned long long>(addr, targetaddress);
+      break;
+    }
+    case kOther_t: {
+      unsupp();
+      break;
+    }
+    case kNoType_t: {
+      unsupp();
+      break;
+    }
+    case kFloat16_t: {
+      unsupp();
+      break;
+    }
+    case kCounter: {
+      unsupp();
+      break;
+    }
+    case kCharStar: {
+      Copy<char*>(addr, targetaddress);
+      break;
+    }
+    case kBits: {
+      unsupp();
+      break;
+    }
+    case kVoid_t: {
+      unsupp();
+      break;
+    }
+    case kDataTypeAliasUnsigned_t: {
+      unsupp();
+      break;
+    }
+    /*
+ 	  case kDataTypeAliasSignedChar_t: {
+ 	    unsupp();
+ 	    break;
+ 	  }
+ 	  case kNumDataTypes: {
+ 	    unsupp();
+ 	    break;
+ 	}*/
+    default: {
+      unsupp();
+      break;
+    }
+  }
+}
+
+template <typename T>
+void ConvertAndCopy(std::string const& valuestring, void* targetaddr)
+{
+  auto addr = boost::lexical_cast<T>(valuestring);
+  std::memcpy(targetaddr, (void*)&addr, sizeof(T));
+}
+
+void ConfigurableParam::updateThroughStorageMapWithConversion(std::string key, std::string valuestring)
+{
+  // check if key_exists
+  auto iter = sKeyToStorageMap->find(key);
+  if (iter == sKeyToStorageMap->end()) {
+    LOG(WARN) << "Cannot update parameter " << key << " not found";
+    return;
+  }
+
+  // the type (aka ROOT::EDataType which the type identification in the map) we need to convert to
+  int targettype = iter->second.first;
+
+  auto targetaddress = iter->second.second;
+  switch (targettype) {
+    case kChar_t: {
+      ConvertAndCopy<char>(valuestring, targetaddress);
+      break;
+    }
+    case kUChar_t: {
+      ConvertAndCopy<unsigned char>(valuestring, targetaddress);
+      break;
+    }
+    case kShort_t: {
+      ConvertAndCopy<short>(valuestring, targetaddress);
+      break;
+    }
+    case kUShort_t: {
+      ConvertAndCopy<unsigned short>(valuestring, targetaddress);
+      break;
+    }
+    case kInt_t: {
+      ConvertAndCopy<int>(valuestring, targetaddress);
+      break;
+    }
+    case kUInt_t: {
+      ConvertAndCopy<unsigned int>(valuestring, targetaddress);
+      break;
+    }
+    case kLong_t: {
+      ConvertAndCopy<long>(valuestring, targetaddress);
+      break;
+    }
+    case kULong_t: {
+      ConvertAndCopy<unsigned long>(valuestring, targetaddress);
+      break;
+    }
+    case kFloat_t: {
+      ConvertAndCopy<float>(valuestring, targetaddress);
+      break;
+    }
+    case kDouble_t: {
+      ConvertAndCopy<double>(valuestring, targetaddress);
+      break;
+    }
+    case kDouble32_t: {
+      ConvertAndCopy<double>(valuestring, targetaddress);
+      break;
+    }
+    case kchar: {
+      unsupp();
+      break;
+    }
+    case kBool_t: {
+      ConvertAndCopy<bool>(valuestring, targetaddress);
+      break;
+    }
+    case kLong64_t: {
+      ConvertAndCopy<long long>(valuestring, targetaddress);
+      break;
+    }
+    case kULong64_t: {
+      ConvertAndCopy<unsigned long long>(valuestring, targetaddress);
+      break;
+    }
+    case kOther_t: {
+      unsupp();
+      break;
+    }
+    case kNoType_t: {
+      unsupp();
+      break;
+    }
+    case kFloat16_t: {
+      unsupp();
+      break;
+    }
+    case kCounter: {
+      unsupp();
+      break;
+    }
+    case kCharStar: {
+      unsupp();
+      // ConvertAndCopy<char*>(valuestring, targetaddress);
+      break;
+    }
+    case kBits: {
+      unsupp();
+      break;
+    }
+    case kVoid_t: {
+      unsupp();
+      break;
+    }
+    case kDataTypeAliasUnsigned_t: {
+      unsupp();
+      break;
+    }
+    /*
+ 	  case kDataTypeAliasSignedChar_t: {
+ 	    unsupp();
+ 	    break;
+ 	  }
+ 	  case kNumDataTypes: {
+ 	    unsupp();
+ 	    break;
+ 	}*/
+    default: {
+      unsupp();
+      break;
+    }
+  }
+}
+
+} // namespace conf
+} // namespace o2

--- a/Common/SimConfig/src/ConfigurableParamHelper.cxx
+++ b/Common/SimConfig/src/ConfigurableParamHelper.cxx
@@ -74,7 +74,7 @@ void _ParamHelper::printParametersImpl(TClass* cl, void* obj)
     // pointer to object
     auto dt = dm->GetDataType();
     char* pointer = ((char*)obj) + dm->GetOffset() + index * dt->Size();
-    std::cout << getName(dm, index, size) << " : " << dt->AsString(pointer);
+    std::cout << getName(dm, index, size) << " : " << dt->AsString(pointer) << "\n";
   };
   loopOverMembers(cl, obj, printMembers);
 }

--- a/Common/SimConfig/src/ConfigurableParamHelper.cxx
+++ b/Common/SimConfig/src/ConfigurableParamHelper.cxx
@@ -1,0 +1,104 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+//first version 8/2018, Sandro Wenzel
+
+#include "SimConfig/ConfigurableParamHelper.h"
+#include <TClass.h>
+#include <TDataMember.h>
+#include <TDataType.h>
+#include <TIterator.h>
+#include <TList.h>
+#include <iostream>
+#include "FairLogger.h"
+#include <boost/property_tree/ptree.hpp>
+#include <functional>
+
+using namespace o2::conf;
+
+// a generic looper of data members of a TClass; calling a callback
+// reused in various functions below
+void loopOverMembers(TClass* cl, void* obj,
+                     std::function<void(const TDataMember*, int, int)>&& callback)
+{
+  auto memberlist = cl->GetListOfDataMembers();
+  for (int i = 0; i < memberlist->GetEntries(); ++i) {
+    auto dm = (TDataMember*)memberlist->At(i);
+
+    // filter out static members for now
+    if (dm->Property() & kIsStatic) {
+      continue;
+    }
+    if (dm->IsaPointer()) {
+      LOG(WARNING) << "Pointer types not supported in ConfigurableParams";
+      continue;
+    }
+    if (!dm->IsBasic()) {
+      LOG(WARNING) << "Complex types not supported in ConfigurableParams";
+      continue;
+    }
+    const auto dim = dm->GetArrayDim();
+    // we support very simple vectored data in 1D for now
+    if (dim > 1) {
+      LOG(WARNING) << "We support at most 1 dimensional arrays in ConfigurableParams";
+      continue;
+    }
+    const auto size = (dim == 1) ? dm->GetMaxIndex(dim - 1) : 1; // size of array (1 if scalar)
+    for (int index = 0; index < size; ++index) {
+      callback(dm, index, size);
+    }
+  }
+}
+
+// construct name (in dependence on vector or scalar data and index)
+std::string getName(const TDataMember* dm, int index, int size)
+{
+  std::stringstream namestream;
+  namestream << dm->GetName();
+  if (size > 1) {
+    namestream << "[" << index << "]";
+  }
+  return namestream.str();
+}
+
+void _ParamHelper::printParametersImpl(TClass* cl, void* obj)
+{
+  auto printMembers = [obj](const TDataMember* dm, int index, int size) {
+    // pointer to object
+    auto dt = dm->GetDataType();
+    char* pointer = ((char*)obj) + dm->GetOffset() + index * dt->Size();
+    std::cout << getName(dm, index, size) << " : " << dt->AsString(pointer);
+  };
+  loopOverMembers(cl, obj, printMembers);
+}
+
+void _ParamHelper::fillKeyValuesImpl(std::string mainkey, TClass* cl, void* obj, boost::property_tree::ptree* tree,
+                                     std::map<std::string, std::pair<int, void*>>* keytostoragemap)
+{
+  boost::property_tree::ptree localtree;
+  auto fillMap = [obj, &mainkey, &localtree, &keytostoragemap](const TDataMember* dm, int index, int size) {
+    const auto name = getName(dm, index, size);
+    auto dt = dm->GetDataType();
+    char* pointer = ((char*)obj) + dm->GetOffset() + index * dt->Size();
+    localtree.put(name, dt->AsString(pointer));
+
+    auto key = mainkey + "." + name;
+    using mapped_t = std::pair<int, void*>;
+    keytostoragemap->insert(std::pair<std::string, mapped_t>(key, mapped_t(dt->GetType(), pointer)));
+  };
+  loopOverMembers(cl, obj, fillMap);
+  tree->add_child(mainkey, localtree);
+}
+
+void _ParamHelper::printWarning(std::type_info const& tinfo)
+{
+  LOG(WARNING) << "Registered parameter class with name " << tinfo.name()
+               << " has no ROOT dictionary and will not be available in the configurable parameter system";
+}

--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -12,6 +12,7 @@
 #include <DetectorsCommonDataFormats/DetID.h>
 #include <boost/program_options.hpp>
 #include <iostream>
+#include <FairLogger.h>
 
 using namespace o2::conf;
 namespace bpo = boost::program_options;
@@ -30,7 +31,8 @@ void SimConfig::initOptions(boost::program_options::options_description& options
     "isMT", bpo::value<bool>()->default_value(false), "multi-threaded mode (Geant4 only")(
     "outPrefix,o", bpo::value<std::string>()->default_value("o2sim"), "prefix of output files")(
     "logseverity", bpo::value<std::string>()->default_value("INFO"), "severity level for FairLogger")(
-    "logverbosity", bpo::value<std::string>()->default_value("low"), "level of verbosity for FairLogger (low, medium, high, veryhigh)");
+    "logverbosity", bpo::value<std::string>()->default_value("low"), "level of verbosity for FairLogger (low, medium, high, veryhigh)")(
+    "configKeyValues", bpo::value<std::string>()->default_value(""), "comma separated key=value strings (e.g.: 'TPC.gasDensity=1,...");
 }
 
 bool SimConfig::resetFromParsedMap(boost::program_options::variables_map const& vm)
@@ -64,6 +66,7 @@ bool SimConfig::resetFromParsedMap(boost::program_options::variables_map const& 
   mConfigData.mOutputPrefix = vm["outPrefix"].as<std::string>();
   mConfigData.mLogSeverity = vm["logseverity"].as<std::string>();
   mConfigData.mLogVerbosity = vm["logverbosity"].as<std::string>();
+  mConfigData.mKeyValueTokens = vm["configKeyValues"].as<std::string>();
   return true;
 }
 

--- a/Common/SimConfig/test/TestConfigurableParam.cxx
+++ b/Common/SimConfig/test/TestConfigurableParam.cxx
@@ -1,0 +1,66 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <SimConfig/ConfigurableParam.h>
+#include <SimConfig/ConfigurableParamHelper.h>
+#include <SimConfig/SimConfig.h>
+#include <iostream>
+#include <TInterpreter.h>
+
+class BazParam : public o2::conf::ConfigurableParamHelper<BazParam>
+{
+ public:
+  double getGasDensity() const { return mGasDensity; }
+
+ private:
+  double mGasDensity = 2.0;
+  std::array<int, 3> mPos = { 1, 2, 3 };
+
+  O2ParamDef(BazParam, "Baz");
+};
+O2ParamImpl(BazParam);
+
+int main(int argc, char* argv[])
+{
+  // generate dictionary for BazParam (done here since this is just
+  // a tmp test class)
+  gInterpreter->GenerateDictionary("BazParam");
+  gInterpreter->GenerateTClass("BazParam", false);
+
+  auto& conf = o2::conf::SimConfig::Instance();
+  conf.resetFromArguments(argc, argv);
+
+  // prints all parameters from any ConfigurableParam
+  o2::conf::ConfigurableParam::printAllKeyValuePairs();
+
+  // writes a configuration file
+  o2::conf::ConfigurableParam::writeINI("initialconf.ini");
+
+  // override some keys from command line
+  o2::conf::ConfigurableParam::updateFromString(conf.getKeyValueString());
+
+  // query using C++ object + API
+  auto d1 = BazParam::Instance().getGasDensity();
+
+  // query from global parameter registry AND by string name
+  auto d2 = o2::conf::ConfigurableParam::getValueAs<double>("Baz.mGasDensity");
+  assert(d1 == d2);
+
+  // update
+  double x = 102;
+  o2::conf::ConfigurableParam::setValue<double>("Baz", "mGasDensity", x);
+
+  // check that update correctly synced
+  auto d3 = o2::conf::ConfigurableParam::getValueAs<double>("Baz.mGasDensity");
+  assert(d3 == BazParam::Instance().getGasDensity());
+  assert(x == BazParam::Instance().getGasDensity());
+
+  o2::conf::ConfigurableParam::writeINI("newconf.ini");
+}

--- a/Detectors/Passive/CMakeLists.txt
+++ b/Detectors/Passive/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SRCS
   src/FrameStructure.cxx
   src/Shil.cxx
   src/Hall.cxx
+  src/HallSimParam.cxx
 )
 
 Set(HEADERS
@@ -24,6 +25,7 @@ Set(HEADERS
     include/${MODULE_NAME}/FrameStructure.h
     include/${MODULE_NAME}/Shil.h
     include/${MODULE_NAME}/Hall.h
+    include/${MODULE_NAME}/HallSimParam.h
 )
 
 Set(LINKDEF src/PassiveLinkDef.h)

--- a/Detectors/Passive/include/DetectorsPassive/HallSimParam.h
+++ b/Detectors/Passive/include/DetectorsPassive/HallSimParam.h
@@ -13,32 +13,22 @@
 
 #include "SimConfig/ConfigurableParam.h"
 #include "SimConfig/ConfigurableParamHelper.h"
-#include <array>
 
 namespace o2
 {
 namespace passive
 {
 
-class HallSimParam : public o2::conf::ConfigurableParamHelper<HallSimParam>
-{
- public:
-  float getCUTGAM() const { return mCUTGAM; }
-  float getCUTELE() const { return mCUTELE; }
-  float getCUTNEU() const { return mCUTNEU; }
-  float getCUTHAD() const { return mCUTHAD; }
-
- private:
+struct HallSimParam : public o2::conf::ConfigurableParamHelper<HallSimParam> {
   float mCUTGAM = 1.e00;
   float mCUTELE = 1.e00;
   float mCUTNEU = 1.e-1;
   float mCUTHAD = 1.e-3;
-  static constexpr int N = 3;
-  int mPos[N] = { 1, 0, -2 }; //[N]
 
   // boilerplate stuff + make principal key "HallSim"
   O2ParamDef(HallSimParam, "HallSim");
 };
+
 } // namespace passive
 } // namespace o2
 

--- a/Detectors/Passive/include/DetectorsPassive/HallSimParam.h
+++ b/Detectors/Passive/include/DetectorsPassive/HallSimParam.h
@@ -1,0 +1,45 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef DETECTORS_PASSIVE_INCLUDE_DETECTORSPASSIVE_HALLSIMPARAM_H_
+#define DETECTORS_PASSIVE_INCLUDE_DETECTORSPASSIVE_HALLSIMPARAM_H_
+
+#include "SimConfig/ConfigurableParam.h"
+#include "SimConfig/ConfigurableParamHelper.h"
+#include <array>
+
+namespace o2
+{
+namespace passive
+{
+
+class HallSimParam : public o2::conf::ConfigurableParamHelper<HallSimParam>
+{
+ public:
+  float getCUTGAM() const { return mCUTGAM; }
+  float getCUTELE() const { return mCUTELE; }
+  float getCUTNEU() const { return mCUTNEU; }
+  float getCUTHAD() const { return mCUTHAD; }
+
+ private:
+  float mCUTGAM = 1.e00;
+  float mCUTELE = 1.e00;
+  float mCUTNEU = 1.e-1;
+  float mCUTHAD = 1.e-3;
+  static constexpr int N = 3;
+  int mPos[N] = { 1, 0, -2 }; //[N]
+
+  // boilerplate stuff + make principal key "HallSim"
+  O2ParamDef(HallSimParam, "HallSim");
+};
+} // namespace passive
+} // namespace o2
+
+#endif /* DETECTORS_PASSIVE_INCLUDE_DETECTORSPASSIVE_HALLSIMPARAM_H_ */

--- a/Detectors/Passive/src/Hall.cxx
+++ b/Detectors/Passive/src/Hall.cxx
@@ -20,6 +20,7 @@
 #include <TGeoTube.h>
 #include <TGeoVolume.h>
 #include <initializer_list>
+#include <DetectorsPassive/HallSimParam.h>
 using namespace o2::passive;
 
 Hall::~Hall() = default;
@@ -111,19 +112,21 @@ void Hall::SetSpecialPhysicsCuts()
   auto& matmgr = MaterialManager::Instance();
 
   // \note ported from AliRoot. People responsible for the HALL implementation must judge and modify cuts if required.
-  const Float_t cut1 = 1.e00;
-  const Float_t cut2 = 1.e-1;
-  const Float_t cut3 = 1.e-3;
+  auto& hallparam = HallSimParam::Instance();
+  const auto cutgam = hallparam.getCUTGAM();
+  const auto cutele = hallparam.getCUTELE();
+  const auto cutneu = hallparam.getCUTNEU();
+  const auto cuthad = hallparam.getCUTHAD();
 
   matmgr.SpecialCuts(
     "HALL", kSTST_C2,
-    { { ECut::kCUTGAM, cut1 }, { ECut::kCUTELE, cut1 }, { ECut::kCUTNEU, cut2 }, { ECut::kCUTHAD, cut3 } });
+    { { ECut::kCUTGAM, cutgam }, { ECut::kCUTELE, cutele }, { ECut::kCUTNEU, cutneu }, { ECut::kCUTHAD, cuthad } });
   matmgr.SpecialCuts(
     "HALL", kAIR_C2,
-    { { ECut::kCUTGAM, cut1 }, { ECut::kCUTELE, cut1 }, { ECut::kCUTNEU, cut2 }, { ECut::kCUTHAD, cut3 } });
+    { { ECut::kCUTGAM, cutgam }, { ECut::kCUTELE, cutele }, { ECut::kCUTNEU, cutneu }, { ECut::kCUTHAD, cuthad } });
   matmgr.SpecialCuts(
     "HALL", kCC_C2,
-    { { ECut::kCUTGAM, cut1 }, { ECut::kCUTELE, cut1 }, { ECut::kCUTNEU, cut2 }, { ECut::kCUTHAD, cut3 } });
+    { { ECut::kCUTGAM, cutgam }, { ECut::kCUTELE, cutele }, { ECut::kCUTNEU, cutneu }, { ECut::kCUTHAD, cuthad } });
 }
 
 void Hall::ConstructGeometry()

--- a/Detectors/Passive/src/Hall.cxx
+++ b/Detectors/Passive/src/Hall.cxx
@@ -112,11 +112,11 @@ void Hall::SetSpecialPhysicsCuts()
   auto& matmgr = MaterialManager::Instance();
 
   // \note ported from AliRoot. People responsible for the HALL implementation must judge and modify cuts if required.
-  auto& hallparam = HallSimParam::Instance();
-  const auto cutgam = hallparam.getCUTGAM();
-  const auto cutele = hallparam.getCUTELE();
-  const auto cutneu = hallparam.getCUTNEU();
-  const auto cuthad = hallparam.getCUTHAD();
+  auto& hp = HallSimParam::Instance();
+  const auto cutgam = hp.mCUTGAM;
+  const auto cutele = hp.mCUTELE;
+  const auto cutneu = hp.mCUTNEU;
+  const auto cuthad = hp.mCUTHAD;
 
   matmgr.SpecialCuts(
     "HALL", kSTST_C2,

--- a/Detectors/Passive/src/HallSimParam.cxx
+++ b/Detectors/Passive/src/HallSimParam.cxx
@@ -1,0 +1,12 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "DetectorsPassive/HallSimParam.h"
+O2ParamImpl(o2::passive::HallSimParam);

--- a/Detectors/Passive/src/PassiveLinkDef.h
+++ b/Detectors/Passive/src/PassiveLinkDef.h
@@ -36,7 +36,8 @@
 #pragma link C++ class  o2::passive::FrameStructure+;
 #pragma link C++ class  o2::passive::Shil+;
 #pragma link C++ class  o2::passive::Hall+;
+#pragma link C++ class  o2::conf::ConfigurableParam+;
 #pragma link C++ class  o2::passive::HallSimParam+;
-
+#pragma link C++ class  o2::conf::ConfigurableParamHelper<o2::passive::HallSimParam>+;
 #endif
 

--- a/Detectors/Passive/src/PassiveLinkDef.h
+++ b/Detectors/Passive/src/PassiveLinkDef.h
@@ -36,6 +36,7 @@
 #pragma link C++ class  o2::passive::FrameStructure+;
 #pragma link C++ class  o2::passive::Shil+;
 #pragma link C++ class  o2::passive::Hall+;
+#pragma link C++ class  o2::passive::HallSimParam+;
 
 #endif
 

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -1351,10 +1351,12 @@ o2_define_bucket(
     fairroot_geom
     Field
     DetectorsBase
+    SimConfig
 
     INCLUDE_DIRECTORIES
     ${CMAKE_SOURCE_DIR}/Common/Field/include
     ${CMAKE_SOURCE_DIR}/Detectors/Passive/include
+    ${CMAKE_SOURCE_DIR}/Common/SimConfig/include
 )
 
 o2_define_bucket(

--- a/macro/o2sim.C
+++ b/macro/o2sim.C
@@ -29,12 +29,16 @@
 FairRunSim* o2sim_init(bool asservice)
 {
   auto& confref = o2::conf::SimConfig::Instance();
-  // update the parameters from local configuration file (TODO)
+  // we can read from CCDB (for the moment faking with a TFile)
+  // o2::conf::ConfigurableParam::fromCCDB("params_ccdb.root", runid);
 
   // update the parameters from stuff given at command line
   o2::conf::ConfigurableParam::updateFromString(confref.getKeyValueString());
   // write the configuration file
   o2::conf::ConfigurableParam::writeINI("o2sim_configuration.ini");
+
+  // we can update the binary CCDB entry something like this ( + timestamp key )
+  // o2::conf::ConfigurableParam::toCCDB("params_ccdb.root");
 
   auto genconfig = confref.getGenerator();
 

--- a/macro/o2sim.C
+++ b/macro/o2sim.C
@@ -14,6 +14,7 @@
 #include <Generators/GeneratorFactory.h>
 #include <Generators/PDG.h>
 #include <SimConfig/SimConfig.h>
+#include <SimConfig/ConfigurableParam.h>
 #include <TStopwatch.h>
 #include <memory>
 #include "DataFormatsParameters/GRPObject.h"
@@ -28,6 +29,13 @@
 FairRunSim* o2sim_init(bool asservice)
 {
   auto& confref = o2::conf::SimConfig::Instance();
+  // update the parameters from local configuration file (TODO)
+
+  // update the parameters from stuff given at command line
+  o2::conf::ConfigurableParam::updateFromString(confref.getKeyValueString());
+  // write the configuration file
+  o2::conf::ConfigurableParam::writeINI("o2sim_configuration.ini");
+
   auto genconfig = confref.getGenerator();
 
   FairRunSim* run;


### PR DESCRIPTION
This commit introduces a concept for configurable parameters, which
means that they are class members which can be, fully-automatic, influenced
from a config file or by other means (command-line, distributed key-value stores).

The commit focuses on providing an automatic mechanism, so that the developer/user
merely needs to declare a parameter class in a special way:

```
class FooParam : public o2::conf::ConfigurableParamHelper<FooParam> {
  double getDensity() const { return mDensity; }
private:
  double mDensity = 1.1;
  int mNPlanes = 2;
  O2ParamDef(FooParam, "Foo")
};
```

After this, parameters Foo.mDensity, Foo.mNPlaces are automatically part of
a global parameter database (using boost property_tree) by means of an introspection
mechanism (using ROOT dictionaries).

Parameters can then be changed (textually) using the parameter database. Changes
are furthermore propagated to the actual C++ singletons of type FooParam.

In particular, the following works:
```
o2::conf::ConfigurableParam::setValue<double>("Foo.mDensity", 2.);
auto d = FooParam::Instance().getDensity(); // will now return 2. instead of default value 1.1
```

This mechanism is used to set/change these parameters from the command line.

As a first example, we provide the simulation cuts of the Hall volume as such parameters
and demonstrate that they can be changed from the simulation command line
```
o2sim -m HALL -n 1 --configKeyValue "HallSim.mCUTELE=10"
```
which should be useful for systematic studies.

Complementary info is available in a README in file `ConfigurableParam.md`.