### PR TITLE
Using enumerator to enumerate Contexts

### DIFF
--- a/Framework/Core/include/Framework/ContextRegistry.h
+++ b/Framework/Core/include/Framework/ContextRegistry.h
@@ -30,10 +30,20 @@ namespace framework
 /// MessageContext 0
 /// ROOTObjectContext 1
 /// StringContext 2
+/// RawContext 3
+
+enum contexts{
+  kMessageContext,
+  kROOTObjectContext,
+  kStringContext,
+  kRawContext,
+  kNContexts
+};
+
 class ContextRegistry
 {
  public:
-  ContextRegistry(std::array<void*, 3> contextes)
+  ContextRegistry(std::array<void*, contexts::kNContexts> contextes)
     : mContextes{ contextes }
   {
   }
@@ -57,7 +67,7 @@ class ContextRegistry
   }
 
  private:
-  std::array<void*, 3> mContextes;
+  std::array<void*, contexts::kNContexts> mContextes;
 };
 
 } // namespace framework

--- a/Framework/Core/include/Framework/MessageContext.h
+++ b/Framework/Core/include/Framework/MessageContext.h
@@ -86,7 +86,7 @@ template <>
 inline MessageContext*
   ContextRegistry::get<MessageContext>()
 {
-  return reinterpret_cast<MessageContext*>(mContextes[0]);
+  return reinterpret_cast<MessageContext*>(mContextes[o2::framework::contexts::kMessageContext]);
 }
 
 /// Helper to set the context from the registry.
@@ -94,7 +94,7 @@ template <>
 inline void
   ContextRegistry::set<MessageContext>(MessageContext* context)
 {
-  mContextes[0] = context;
+  mContextes[o2::framework::contexts::kMessageContext] = context;
 }
 
 } // namespace framework

--- a/Framework/Core/include/Framework/RootObjectContext.h
+++ b/Framework/Core/include/Framework/RootObjectContext.h
@@ -93,7 +93,7 @@ template <>
 inline RootObjectContext*
   ContextRegistry::get<RootObjectContext>()
 {
-  return reinterpret_cast<RootObjectContext*>(mContextes[1]);
+  return reinterpret_cast<RootObjectContext*>(mContextes[o2::framework::contexts::kROOTObjectContext]);
 }
 
 /// Helper to set the context from the registry.
@@ -101,7 +101,7 @@ template <>
 inline void
   ContextRegistry::set<RootObjectContext>(RootObjectContext* context)
 {
-  mContextes[1] = context;
+  mContextes[o2::framework::contexts::kROOTObjectContext] = context;
 }
 
 } // namespace framework

--- a/Framework/Core/include/Framework/StringContext.h
+++ b/Framework/Core/include/Framework/StringContext.h
@@ -94,7 +94,7 @@ template <>
 inline StringContext*
   ContextRegistry::get<StringContext>()
 {
-  return reinterpret_cast<StringContext*>(mContextes[2]);
+  return reinterpret_cast<StringContext*>(mContextes[o2::framework::contexts::kStringContext]);
 }
 
 /// Helper to set the context from the registry.
@@ -102,7 +102,7 @@ template <>
 inline void
   ContextRegistry::set<StringContext>(StringContext* context)
 {
-  mContextes[2] = context;
+  mContextes[o2::framework::contexts::kStringContext] = context;
 }
 
 } // namespace framework


### PR DESCRIPTION
This choice will avoid confusion when implementing new contexts and will automatically update the size of the ContextRegistry array.