### PR TITLE
DPL: Add TableBuilder / TableConsumer for arrow

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -53,6 +53,8 @@ set(SRCS
     src/ExternalFairMQDeviceProxy.cxx
     src/SimpleResourceManager.cxx
     src/TextControlService.cxx
+    src/TableBuilder.cxx
+    src/TableConsumer.cxx
     src/WorkflowHelpers.cxx
     src/WorkflowSpec.cxx
     src/runDataProcessing.cxx
@@ -135,6 +137,7 @@ set(HEADERS
       include/Framework/DataSamplingCondition.h
       include/Framework/DataSamplingReadoutAdapter.h
       include/Framework/DPLBoostSerializer.h
+      include/Framework/TableBuilder.h
       src/ComputingResource.h
       src/DDSConfigHelpers.h
       src/DeviceSpecHelpers.h
@@ -218,6 +221,7 @@ set(TEST_SRCS
       test/test_DataAllocator.cxx
       test/test_CallbackRegistry.cxx
       test/test_Task.cxx
+      test/test_TableBuilder.cxx
    )
 
 O2_GENERATE_TESTS(

--- a/Framework/Core/include/Framework/TableBuilder.h
+++ b/Framework/Core/include/Framework/TableBuilder.h
@@ -1,0 +1,187 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef FRAMEWORK_TABLEBUILDER_H
+#define FRAMEWORK_TABLEBUILDER_H
+
+#include <arrow/stl.h>
+#include <arrow/type_traits.h>
+#include <arrow/table.h>
+#include <arrow/builder.h>
+#include <vector>
+#include <string>
+#include <memory>
+#include <tuple>
+
+namespace arrow
+{
+class ArrayBuilder;
+class Table;
+class Array;
+} // namespace arrow
+
+namespace o2
+{
+namespace framework
+{
+
+template <typename T>
+struct BuilderMaker {
+  using ArrowType = typename arrow::stl::ConversionTraits<T>::ArrowType;
+  using BuilderType = typename arrow::TypeTraits<ArrowType>::BuilderType;
+
+  static BuilderType&& make()
+  {
+    BuilderType builder;
+    return std::move(builder);
+  }
+};
+
+template <typename... ARGS>
+auto make_builders()
+{
+  return std::make_tuple(std::make_unique<ARGS>()...);
+}
+
+/// Helper functions to create components of an arrow::Table
+struct TableBuilderHelper {
+  template <typename... ARGS>
+  static auto makeFields(std::vector<std::string> const& names)
+  {
+    std::vector<std::shared_ptr<arrow::DataType>> types{ arrow::TypeTraits<typename BuilderMaker<ARGS>::ArrowType>::type_singleton()... };
+    std::vector<std::shared_ptr<arrow::Field>> result;
+    for (size_t i = 0; i < names.size(); ++i) {
+      result.emplace_back(std::make_shared<arrow::Field>(names[i], types[i], true, nullptr));
+    }
+    return std::move(result);
+  }
+};
+
+template <typename T>
+struct BuilderTraits {
+  using ArrowType = typename arrow::stl::ConversionTraits<T>::ArrowType;
+  using BuilderType = typename arrow::TypeTraits<ArrowType>::BuilderType;
+};
+
+/// Invokes the right appender for each one of the builders.
+template <int N, int I>
+struct Appender {
+  /// Invokes the append method for each entry in the tuple
+  template <typename TUPLE, typename T, typename... ARGS>
+  static void append(TUPLE& builders, T value, ARGS... rest)
+  {
+    auto& builder = std::get<N - I>(builders);
+    auto status = builder->Append(value);
+    if (status.ok() == false) {
+      throw std::runtime_error("Unable to append");
+    }
+    Appender<N, I - 1>::append(builders, rest...);
+  }
+};
+
+template <int N>
+struct Appender<N, 1> {
+  /// Invokes the append method for each entry in the tuple
+  template <typename TUPLE, typename T>
+  static void append(TUPLE& builders, T value)
+  {
+    auto& builder = std::get<N - 1>(builders);
+    auto status = builder->Append(value);
+    if (status.ok() == false) {
+      throw std::runtime_error("Unable to append");
+    }
+  }
+};
+
+/// Invokes the right appender for each one of the builders.
+template <int N, int I>
+struct Finalizer {
+  /// Invokes the append method for each entry in the tuple
+  template <typename TUPLE>
+  static void finalize(std::vector<std::shared_ptr<arrow::Array>>& arrays, TUPLE& builders)
+  {
+    auto& builder = std::get<N - I>(builders);
+    auto status = builder->Finish(&arrays[N - I]);
+    if (status.ok() == false) {
+      throw std::runtime_error("Unable to finalize");
+    }
+    Finalizer<N, I - 1>::finalize(arrays, builders);
+  }
+};
+
+template <int N>
+struct Finalizer<N, 1> {
+  /// Invokes the append method for each entry in the tuple
+  template <typename TUPLE>
+  static void finalize(std::vector<std::shared_ptr<arrow::Array>>& arrays, TUPLE& builders)
+  {
+    auto& builder = std::get<N - 1>(builders);
+    auto status = builder->Finish(&arrays[N - 1]);
+    if (status.ok() == false) {
+      throw std::runtime_error("Unable to finalize");
+    }
+  }
+};
+
+/// Helper class which creates a lambda suitable for building
+/// an arrow table from a tuple. This can be used, for example
+/// to build an arrow::Table from a TDataFrame.
+class TableBuilder
+{
+ public:
+  TableBuilder(arrow::MemoryPool* pool = arrow::default_memory_pool())
+    : mBuilders{ nullptr },
+      mMemoryPool{ pool }
+  {
+  }
+  /// Creates a lambda which is suitable to persist things
+  /// in an arrow::Table
+  template <typename... ARGS>
+  auto persist(std::vector<std::string> const& columnNames)
+  {
+    constexpr int nColumns = sizeof...(ARGS);
+    if (nColumns != columnNames.size()) {
+      throw std::runtime_error("Mismatching number of column types and names");
+    }
+    if (mBuilders != nullptr) {
+      throw std::runtime_error("TableBuilder::persist can only be invoked once per instance");
+    }
+    mArrays.resize(nColumns);
+
+    using BuildersTuple = typename std::tuple<std::unique_ptr<typename BuilderTraits<ARGS>::BuilderType>...>;
+    mSchema = std::make_shared<arrow::Schema>(TableBuilderHelper::makeFields<ARGS...>(columnNames));
+
+    BuildersTuple* builders = new BuildersTuple(std::make_unique<typename BuilderTraits<ARGS>::BuilderType>(mMemoryPool)...);
+    mBuilders = builders; // We store the builders
+    /// Callback used to finalize the table.
+    mFinalizer = [schema = mSchema, &arrays = mArrays, builders = builders]() -> std::shared_ptr<arrow::Table> {
+      Finalizer<nColumns, nColumns>::finalize(arrays, *builders);
+      return arrow::Table::Make(schema, arrays);
+    };
+    // Callback used to fill the builders
+    return [builders = builders](unsigned int slot, ARGS... args) -> void {
+      Appender<nColumns, nColumns>::append(*builders, args...);
+    };
+  }
+
+  /// Actually creates the arrow::Table from the builders
+  std::shared_ptr<arrow::Table> finalize();
+
+ private:
+  std::function<void(void)> mFinalizer;
+  void* mBuilders;
+  arrow::MemoryPool* mMemoryPool;
+  std::shared_ptr<arrow::Schema> mSchema;
+  std::vector<std::shared_ptr<arrow::Array>> mArrays;
+};
+
+} // namespace framework
+} // namespace o2
+#endif // FRAMEWORK_TABLEBUILDER_H

--- a/Framework/Core/include/Framework/TableConsumer.h
+++ b/Framework/Core/include/Framework/TableConsumer.h
@@ -1,0 +1,43 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef FRAMEWORK_TABLECONSUMER_H
+#define FRAMEWORK_TABLECONSUMER_H
+
+#include <memory>
+
+namespace arrow
+{
+class Table;
+class Buffer;
+} // namespace arrow
+
+namespace o2
+{
+namespace framework
+{
+/// Helper class which creates a lambda suitable for building
+/// an arrow table from a tuple. This can be used, for example
+/// to build an arrow::Table from a TDataFrame.
+class TableConsumer
+{
+ public:
+  TableConsumer(const uint8_t* data, int64_t size);
+  /// Return the table in the message as a arrow::Table instance.
+  std::shared_ptr<arrow::Table> asArrowTable();
+
+ private:
+  std::shared_ptr<arrow::Buffer> mBuffer;
+};
+
+} // namespace framework
+} // namespace o2
+
+#endif // FRAMEWORK_TABLECONSUMER_H

--- a/Framework/Core/src/TableBuilder.cxx
+++ b/Framework/Core/src/TableBuilder.cxx
@@ -1,0 +1,67 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/TableBuilder.h"
+#include <memory>
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
+#endif
+#include <arrow/builder.h>
+#include <arrow/memory_pool.h>
+#include <arrow/record_batch.h>
+#include <arrow/table.h>
+#include <arrow/type_traits.h>
+#include <arrow/status.h>
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
+using namespace arrow;
+
+namespace
+{
+
+// FIXME: Dummy schema, to compile.
+template <typename TYPE, typename C_TYPE>
+void ArrayFromVector(const std::vector<C_TYPE>& values, std::shared_ptr<arrow::Array>* out)
+{
+  typename arrow::TypeTraits<TYPE>::BuilderType builder;
+  for (size_t i = 0; i < values.size(); ++i) {
+    auto status = builder.Append(values[i]);
+    assert(status.ok());
+  }
+  auto status = builder.Finish(out);
+  assert(status.ok());
+}
+
+} // namespace
+
+namespace o2
+{
+namespace framework
+{
+
+std::shared_ptr<arrow::Table>
+  TableBuilder::finalize()
+{
+  mFinalizer();
+  std::vector<std::shared_ptr<arrow::Column>> columns;
+  columns.reserve(mArrays.size());
+  for (size_t i = 0; i < mSchema->num_fields(); ++i) {
+    auto column = std::make_shared<arrow::Column>(mSchema->field(i), mArrays[i]);
+    columns.emplace_back(column);
+  }
+  auto table_ = arrow::Table::Make(mSchema, columns);
+  return table_;
+}
+
+} // namespace framework
+} // namespace o2

--- a/Framework/Core/src/TableConsumer.cxx
+++ b/Framework/Core/src/TableConsumer.cxx
@@ -1,0 +1,66 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/TableConsumer.h"
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
+#endif
+#include <arrow/builder.h>
+#include <arrow/memory_pool.h>
+#include <arrow/record_batch.h>
+#include <arrow/table.h>
+#include <arrow/type_traits.h>
+#include <arrow/status.h>
+#include <arrow/io/memory.h>
+#include <arrow/ipc/reader.h>
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
+using namespace arrow;
+
+namespace o2
+{
+namespace framework
+{
+
+TableConsumer::TableConsumer(const uint8_t* data, int64_t size)
+  : mBuffer{ std::make_shared<Buffer>(data, size) }
+{
+}
+
+std::shared_ptr<arrow::Table>
+  TableConsumer::asArrowTable()
+{
+  /// Reading back from the stream
+  std::shared_ptr<io::InputStream> bufferReader = std::make_shared<io::BufferReader>(mBuffer);
+  std::shared_ptr<ipc::RecordBatchReader> batchReader;
+
+  auto readerOk = ipc::RecordBatchStreamReader::Open(bufferReader, &batchReader);
+  std::vector<std::shared_ptr<RecordBatch>> batches;
+  while (true) {
+    std::shared_ptr<RecordBatch> batch;
+    auto next = batchReader->ReadNext(&batch);
+    if (batch.get() == nullptr) {
+      break;
+    }
+    batches.push_back(batch);
+  }
+
+  std::shared_ptr<Table> inTable;
+  auto inStatus = Table::FromRecordBatches(batches, &inTable);
+
+  return inTable;
+}
+
+} // namespace framework
+} // namespace o2

--- a/Framework/Core/test/test_TableBuilder.cxx
+++ b/Framework/Core/test/test_TableBuilder.cxx
@@ -1,0 +1,135 @@
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test Framework TableBuilder
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+
+#include "Framework/TableBuilder.h"
+#include "Framework/TableConsumer.h"
+#include <arrow/table.h>
+#include <ROOT/RDataFrame.hxx>
+#include <ROOT/RArrowDS.hxx>
+#include <arrow/ipc/writer.h>
+#include <arrow/io/memory.h>
+#include <arrow/ipc/writer.h>
+#include <arrow/ipc/reader.h>
+
+using namespace o2::framework;
+
+template class std::shared_ptr<arrow::Schema>;
+template class std::shared_ptr<arrow::Column>;
+template class std::vector<std::shared_ptr<arrow::Column>>;
+template class std::shared_ptr<arrow::Array>;
+template class std::vector<std::shared_ptr<arrow::Field>>;
+template class std::shared_ptr<arrow::ChunkedArray>;
+
+BOOST_AUTO_TEST_CASE(TestTableBuilderHelper)
+{
+  using namespace o2::framework;
+
+  auto fields = TableBuilderHelper::makeFields<int, float>({ "x", "y" });
+  BOOST_REQUIRE_EQUAL(fields.size(), 2);
+  BOOST_REQUIRE_EQUAL(fields[0]->name(), "x");
+  BOOST_REQUIRE_EQUAL(fields[1]->name(), "y");
+  BOOST_REQUIRE_EQUAL(fields[0]->type()->id(), arrow::int32()->id());
+  BOOST_REQUIRE_EQUAL(fields[1]->type()->id(), arrow::float32()->id());
+}
+
+BOOST_AUTO_TEST_CASE(TestTableBuilder)
+{
+  using namespace o2::framework;
+  TableBuilder builder;
+  auto rowWriter = builder.persist<int, int>({ "x", "y" });
+  rowWriter(0, 0, 0);
+  rowWriter(0, 1, 1);
+  rowWriter(0, 2, 2);
+  rowWriter(0, 3, 3);
+  rowWriter(0, 4, 4);
+  rowWriter(0, 5, 5);
+  rowWriter(0, 6, 6);
+  rowWriter(0, 7, 7);
+  auto table = builder.finalize();
+  BOOST_REQUIRE_EQUAL(table->num_columns(), 2);
+  BOOST_REQUIRE_EQUAL(table->num_rows(), 8);
+  BOOST_REQUIRE_EQUAL(table->column(0)->name(), "x");
+  BOOST_REQUIRE_EQUAL(table->column(1)->name(), "y");
+  BOOST_REQUIRE_EQUAL(table->column(0)->type()->id(), arrow::int32()->id());
+  BOOST_REQUIRE_EQUAL(table->column(1)->type()->id(), arrow::int32()->id());
+}
+
+BOOST_AUTO_TEST_CASE(TestTableBuilderMore)
+{
+  using namespace o2::framework;
+  TableBuilder builder;
+  auto rowWriter = builder.persist<int, float, std::string, bool>({ "x", "y", "s", "b" });
+  rowWriter(0, 0, 0., "foo", true);
+  rowWriter(0, 1, 1., "bar", false);
+  rowWriter(0, 2, 2., "fbr", false);
+  rowWriter(0, 3, 3., "bar", false);
+  rowWriter(0, 4, 4., "abr", true);
+  rowWriter(0, 5, 5., "aaa", false);
+  rowWriter(0, 6, 6., "bbb", true);
+  rowWriter(0, 7, 7., "ccc", false);
+  auto table = builder.finalize();
+  BOOST_REQUIRE_EQUAL(table->num_columns(), 4);
+  BOOST_REQUIRE_EQUAL(table->num_rows(), 8);
+  BOOST_REQUIRE_EQUAL(table->column(0)->name(), "x");
+  BOOST_REQUIRE_EQUAL(table->column(1)->name(), "y");
+  BOOST_REQUIRE_EQUAL(table->column(2)->name(), "s");
+  BOOST_REQUIRE_EQUAL(table->column(3)->name(), "b");
+  BOOST_REQUIRE_EQUAL(table->column(0)->type()->id(), arrow::int32()->id());
+  BOOST_REQUIRE_EQUAL(table->column(1)->type()->id(), arrow::float32()->id());
+  BOOST_REQUIRE_EQUAL(table->column(2)->type()->id(), arrow::utf8()->id());
+  BOOST_REQUIRE_EQUAL(table->column(3)->type()->id(), arrow::boolean()->id());
+}
+
+// Use RDataFrame to build the table
+BOOST_AUTO_TEST_CASE(TestRDataFrame)
+{
+  using namespace o2::framework;
+  TableBuilder builder;
+  ROOT::RDataFrame rdf(100);
+  auto t = rdf.Define("x", "1")
+             .Define("y", "2")
+             .Define("z", "x+y");
+  t.ForeachSlot(builder.persist<int, int>({ "x", "z" }), { "x", "z" });
+
+  auto table = builder.finalize();
+  BOOST_REQUIRE_EQUAL(table->num_rows(), 100);
+  BOOST_REQUIRE_EQUAL(table->num_columns(), 2);
+  BOOST_REQUIRE_EQUAL(table->column(0)->type()->id(), arrow::int32()->id());
+  BOOST_REQUIRE_EQUAL(table->column(1)->type()->id(), arrow::int32()->id());
+
+  /// Writing to a stream
+  std::shared_ptr<arrow::io::BufferOutputStream> stream;
+  auto streamOk = arrow::io::BufferOutputStream::Create(100000, arrow::default_memory_pool(), &stream);
+  BOOST_REQUIRE_EQUAL(streamOk.ok(), true);
+  std::shared_ptr<arrow::ipc::RecordBatchWriter> writer;
+  auto outBatch = arrow::ipc::RecordBatchStreamWriter::Open(stream.get(), table->schema(), &writer);
+  auto outStatus = writer->WriteTable(*table);
+  BOOST_REQUIRE_EQUAL(writer->Close().ok(), true);
+
+  std::shared_ptr<arrow::Buffer> inBuffer;
+  BOOST_REQUIRE_EQUAL(stream->Finish(&inBuffer).ok(), true);
+
+  BOOST_REQUIRE_EQUAL(outStatus.ok(), true);
+
+  /// Reading back from the stream
+  TableConsumer consumer(inBuffer->data(), inBuffer->size());
+  std::shared_ptr<arrow::Table> inTable = consumer.asArrowTable();
+
+  BOOST_REQUIRE_EQUAL(inTable->num_columns(), 2);
+  BOOST_REQUIRE_EQUAL(inTable->num_rows(), 100);
+
+  auto source = std::make_unique<ROOT::RDF::RArrowDS>(inTable, std::vector<std::string>{});
+  ROOT::RDataFrame finalDF{ std::move(source) };
+  BOOST_REQUIRE_EQUAL(*finalDF.Count(), 100);
+}

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -244,6 +244,7 @@ o2_define_bucket(
     O2FrameworkCore_bucket
 
     DEPENDENCIES
+    arrow_bucket
     O2DeviceApplication_bucket
     common_utils_bucket
     ROOTDataFrame

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -246,7 +246,11 @@ o2_define_bucket(
     DEPENDENCIES
     O2DeviceApplication_bucket
     common_utils_bucket
+    ROOTDataFrame
+    ROOTVecOps
     Core
+    Tree
+    TreePlayer
     Net
     MathUtils
     DebugGUI


### PR DESCRIPTION
This introduces a new TableBuilder helper which allows creating
`arrow::Table` objects in a simple manner. For the moment the type of
each column has to be known at compile time, but it should be fairly
straightforward to make it dynamic.

Paired to that comes a TableConsumer which can be used to create
`arrow::Table` from a previously serialized `arrow::RecordBatch`.