### PR TITLE
CCDB: specify protobuf syntax explicitly

### DIFF
--- a/CCDB/src/request.proto
+++ b/CCDB/src/request.proto
@@ -1,5 +1,7 @@
 package messaging;
 
+syntax = "proto2";
+
 option java_package = "com.cern.messaging";
 option java_outer_classname = "Request";
 


### PR DESCRIPTION
Fixes spurious warning when using new protobuf 3 from the system.