### PR TITLE
DPL: Cleanup ChannelSpec details and related helpers

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -23,6 +23,7 @@ set(SRCS
     src/BoostOptionsRetriever.cxx
     src/ConfigParamsHelper.cxx
     src/CompletionPolicy.cxx
+    src/ChannelSpecHelpers.cxx
     src/CompletionPolicyHelpers.cxx
     src/ChannelConfigurationPolicy.cxx
     src/ChannelConfigurationPolicyHelpers.cxx
@@ -199,6 +200,7 @@ set(TEST_SRCS
       test/test_AlgorithmSpec.cxx
       test/test_BoostOptionsRetriever.cxx
       test/test_CompletionPolicy.cxx
+      test/test_ChannelSpecHelpers.cxx
       test/test_DataRelayer.cxx
       test/test_DataSampling.cxx
       test/test_DataSamplingCondition.cxx

--- a/Framework/Core/include/Framework/ChannelSpec.h
+++ b/Framework/Core/include/Framework/ChannelSpec.h
@@ -19,13 +19,13 @@ namespace framework
 
 /// These map to zeromq connection
 /// methods.
-enum ChannelMethod {
+enum struct ChannelMethod {
   Bind,
   Connect
 };
 
 /// These map to zeromq types for the channels.
-enum ChannelType {
+enum struct ChannelType {
   Pub,
   Sub,
   Push,

--- a/Framework/Core/src/ChannelSpecHelpers.cxx
+++ b/Framework/Core/src/ChannelSpecHelpers.cxx
@@ -1,0 +1,62 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "ChannelSpecHelpers.h"
+#include <ostream>
+
+namespace o2
+{
+namespace framework
+{
+
+char const* ChannelSpecHelpers::typeAsString(enum ChannelType type)
+{
+  switch (type) {
+    case ChannelType::Pub:
+      return "pub";
+    case ChannelType::Sub:
+      return "sub";
+    case ChannelType::Push:
+      return "push";
+    case ChannelType::Pull:
+      return "pull";
+  }
+}
+
+char const* ChannelSpecHelpers::methodAsString(enum ChannelMethod method)
+{
+  switch (method) {
+    case ChannelMethod::Bind:
+      return "bind";
+    case ChannelMethod::Connect:
+      return "connect";
+  }
+}
+
+char const* ChannelSpecHelpers::methodAsUrl(enum ChannelMethod method)
+{
+  return (method == ChannelMethod::Bind ? "tcp://*:%d" : "tcp://127.0.0.1:%d");
+}
+
+/// Stream operators so that we can use ChannelType with Boost.Test
+std::ostream& operator<<(std::ostream& s, ChannelType const& type)
+{
+  s << ChannelSpecHelpers::typeAsString(type);
+  return s;
+}
+
+/// Stream operators so that we can use ChannelString with Boost.Test
+std::ostream& operator<<(std::ostream& s, ChannelMethod const& method)
+{
+  s << ChannelSpecHelpers::methodAsString(method);
+  return s;
+}
+
+} // namespace framework
+} // namespace o2

--- a/Framework/Core/src/ChannelSpecHelpers.h
+++ b/Framework/Core/src/ChannelSpecHelpers.h
@@ -1,0 +1,43 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef FRAMEWORK_CHANNELSPECHELPERS_H
+#define FRAMEWORK_CHANNELSPECHELPERS_H
+
+#include "Framework/ChannelSpec.h"
+#include <iosfwd>
+
+namespace o2
+{
+namespace framework
+{
+
+/// A few helpers to convert enums to their actual representation in
+/// configuration files / GUI / string based APIs. Never too late
+/// for C++ to get multimethods.
+struct ChannelSpecHelpers {
+  /// return a ChannelType as a lowercase string
+  static char const* typeAsString(enum ChannelType type);
+  /// return a ChannelMethod as a lowercase string
+  static char const* methodAsString(enum ChannelMethod method);
+  /// return a ChannelMethod as a connection url
+  /// FIXME: currently it only supports tcp://127.0.0.1 and tcp://*, we should
+  ///        have the actual address customizable.
+  static char const* methodAsUrl(enum ChannelMethod method);
+};
+
+/// Stream operators so that we can use ChannelType with Boost.Test
+std::ostream& operator<<(std::ostream& s, ChannelType const& type);
+/// Stream operators so that we can use ChannelString with Boost.Test
+std::ostream& operator<<(std::ostream& s, ChannelMethod const& method);
+
+} // namespace framework
+} // namespace o2
+
+#endif // FRAMEWORK_CHANNELSPECHELPERS_H

--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -8,6 +8,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 #include "DeviceSpecHelpers.h"
+#include "ChannelSpecHelpers.h"
 #include <wordexp.h>
 #include <algorithm>
 #include <boost/program_options.hpp>
@@ -36,31 +37,17 @@ namespace o2
 namespace framework
 {
 
-char const* channelTypeFromEnum(enum ChannelType type)
-{
-  switch (type) {
-    case Pub:
-      return "pub";
-    case Sub:
-      return "sub";
-    case Push:
-      return "push";
-    case Pull:
-      return "pull";
-  }
-}
-
 /// This creates a string to configure channels of a FairMQDevice
 /// FIXME: support shared memory
 std::string inputChannel2String(const InputChannelSpec& channel)
 {
   std::string result;
   char buffer[32];
-  auto addressFormat = (channel.method == Bind ? "tcp://*:%d" : "tcp://127.0.0.1:%d");
+  auto addressFormat = ChannelSpecHelpers::methodAsUrl(channel.method);
 
   result += "name=" + channel.name + ",";
-  result += std::string("type=") + channelTypeFromEnum(channel.type) + ",";
-  result += std::string("method=") + (channel.method == Bind ? "bind" : "connect") + ",";
+  result += std::string("type=") + ChannelSpecHelpers::typeAsString(channel.type) + ",";
+  result += std::string("method=") + ChannelSpecHelpers::methodAsString(channel.method) + ",";
   result += std::string("address=") + (snprintf(buffer, 32, addressFormat, channel.port), buffer);
 
   return result;
@@ -70,11 +57,11 @@ std::string outputChannel2String(const OutputChannelSpec& channel)
 {
   std::string result;
   char buffer[32];
-  auto addressFormat = (channel.method == Bind ? "tcp://*:%d" : "tcp://127.0.0.1:%d");
+  auto addressFormat = ChannelSpecHelpers::methodAsUrl(channel.method);
 
   result += "name=" + channel.name + ",";
-  result += std::string("type=") + channelTypeFromEnum(channel.type) + ",";
-  result += std::string("method=") + (channel.method == Bind ? "bind" : "connect") + ",";
+  result += std::string("type=") + ChannelSpecHelpers::typeAsString(channel.type) + ",";
+  result += std::string("method=") + ChannelSpecHelpers::methodAsString(channel.method) + ",";
   result += std::string("address=") + (snprintf(buffer, 32, addressFormat, channel.port), buffer);
 
   return result;

--- a/Framework/Core/test/test_ChannelSpecHelpers.cxx
+++ b/Framework/Core/test/test_ChannelSpecHelpers.cxx
@@ -1,0 +1,45 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test Framework ChannelSpecHelpers
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+#include "../src/ChannelSpecHelpers.h"
+
+using namespace o2::framework;
+
+BOOST_AUTO_TEST_CASE(TestChannelMethod)
+{
+  std::ostringstream oss;
+  oss << ChannelSpecHelpers::methodAsString(ChannelMethod::Bind)
+      << ChannelSpecHelpers::methodAsString(ChannelMethod::Connect);
+
+  BOOST_REQUIRE_EQUAL(oss.str(), "bindconnect");
+  std::ostringstream oss2;
+
+  oss2 << ChannelSpecHelpers::methodAsUrl(ChannelMethod::Bind)
+       << "\n"
+       << ChannelSpecHelpers::methodAsUrl(ChannelMethod::Connect);
+
+  BOOST_REQUIRE_EQUAL(oss2.str(), "tcp://*:%d\ntcp://127.0.0.1:%d");
+}
+
+BOOST_AUTO_TEST_CASE(TestChannelType)
+{
+  std::ostringstream oss;
+  oss << ChannelSpecHelpers::typeAsString(ChannelType::Pub)
+      << ChannelSpecHelpers::typeAsString(ChannelType::Sub)
+      << ChannelSpecHelpers::typeAsString(ChannelType::Push)
+      << ChannelSpecHelpers::typeAsString(ChannelType::Pull);
+
+  BOOST_REQUIRE_EQUAL(oss.str(), "pubsubpushpull");
+}

--- a/Framework/Core/test/test_DeviceSpec.cxx
+++ b/Framework/Core/test/test_DeviceSpec.cxx
@@ -12,6 +12,7 @@
 #define BOOST_TEST_DYN_LINK
 
 #include <boost/test/unit_test.hpp>
+#include "../src/ChannelSpecHelpers.h"
 #include "../src/DeviceSpecHelpers.h"
 #include "../src/GraphvizHelpers.h"
 #include "../src/WorkflowHelpers.h"
@@ -47,15 +48,15 @@ BOOST_AUTO_TEST_CASE(TestDeviceSpec1)
   DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, resources);
   BOOST_CHECK_EQUAL(devices.size(), 2);
   BOOST_CHECK_EQUAL(devices[0].outputChannels.size(), 1);
-  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, Bind);
-  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].type, Push);
+  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, ChannelMethod::Bind);
+  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].type, ChannelType::Push);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].name, "from_A_to_B");
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].port, 22000);
   BOOST_CHECK_EQUAL(devices[0].outputs.size(), 1);
 
   BOOST_CHECK_EQUAL(devices[1].inputChannels.size(), 1);
-  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].method, Connect);
-  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].type, Pull);
+  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].method, ChannelMethod::Connect);
+  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].type, ChannelType::Pull);
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].name, "from_A_to_B");
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].port, 22000);
 
@@ -82,15 +83,15 @@ BOOST_AUTO_TEST_CASE(TestDeviceSpec1PushPull)
   DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, resources);
   BOOST_CHECK_EQUAL(devices.size(), 2);
   BOOST_CHECK_EQUAL(devices[0].outputChannels.size(), 1);
-  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, Bind);
-  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].type, Push);
+  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, ChannelMethod::Bind);
+  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].type, ChannelType::Push);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].name, "from_A_to_B");
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].port, 22000);
   BOOST_CHECK_EQUAL(devices[0].outputs.size(), 1);
 
   BOOST_CHECK_EQUAL(devices[1].inputChannels.size(), 1);
-  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].method, Connect);
-  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].type, Pull);
+  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].method, ChannelMethod::Connect);
+  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].type, ChannelType::Pull);
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].name, "from_A_to_B");
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].port, 22000);
 
@@ -126,14 +127,14 @@ BOOST_AUTO_TEST_CASE(TestDeviceSpec2)
   DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, resources);
   BOOST_CHECK_EQUAL(devices.size(), 2);
   BOOST_CHECK_EQUAL(devices[0].outputChannels.size(), 1);
-  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, Bind);
-  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].type, Push);
+  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, ChannelMethod::Bind);
+  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].type, ChannelType::Push);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].name, "from_A_to_B");
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].port, 22000);
 
   BOOST_CHECK_EQUAL(devices[1].inputChannels.size(), 1);
-  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].method, Connect);
-  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].type, Pull);
+  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].method, ChannelMethod::Connect);
+  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].type, ChannelType::Pull);
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].name, "from_A_to_B");
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].port, 22000);
 }
@@ -168,24 +169,24 @@ BOOST_AUTO_TEST_CASE(TestDeviceSpec3)
   DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, resources);
   BOOST_CHECK_EQUAL(devices.size(), 3);
   BOOST_CHECK_EQUAL(devices[0].outputChannels.size(), 2);
-  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, Bind);
-  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].type, Push);
+  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, ChannelMethod::Bind);
+  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].type, ChannelType::Push);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].name, "from_A_to_B");
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].port, 22000);
-  BOOST_CHECK_EQUAL(devices[0].outputChannels[1].method, Bind);
-  BOOST_CHECK_EQUAL(devices[0].outputChannels[1].type, Push);
+  BOOST_CHECK_EQUAL(devices[0].outputChannels[1].method, ChannelMethod::Bind);
+  BOOST_CHECK_EQUAL(devices[0].outputChannels[1].type, ChannelType::Push);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[1].name, "from_A_to_C");
   BOOST_CHECK_EQUAL(devices[0].outputChannels[1].port, 22001);
 
   BOOST_CHECK_EQUAL(devices[1].inputChannels.size(), 1);
-  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].method, Connect);
-  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].type, Pull);
+  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].method, ChannelMethod::Connect);
+  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].type, ChannelType::Pull);
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].name, "from_A_to_B");
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].port, 22000);
 
   BOOST_CHECK_EQUAL(devices[2].inputChannels.size(), 1);
-  BOOST_CHECK_EQUAL(devices[2].inputChannels[0].method, Connect);
-  BOOST_CHECK_EQUAL(devices[2].inputChannels[0].type, Pull);
+  BOOST_CHECK_EQUAL(devices[2].inputChannels[0].method, ChannelMethod::Connect);
+  BOOST_CHECK_EQUAL(devices[2].inputChannels[0].type, ChannelType::Pull);
   BOOST_CHECK_EQUAL(devices[2].inputChannels[0].name, "from_A_to_C");
   BOOST_CHECK_EQUAL(devices[2].inputChannels[0].port, 22001);
 }
@@ -216,44 +217,44 @@ BOOST_AUTO_TEST_CASE(TestDeviceSpec4)
   DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, resources);
   BOOST_CHECK_EQUAL(devices.size(), 4);
   BOOST_CHECK_EQUAL(devices[0].outputChannels.size(), 2);
-  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, Bind);
-  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].type, Push);
+  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, ChannelMethod::Bind);
+  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].type, ChannelType::Push);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].name, "from_A_to_B");
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].port, 22000);
-  BOOST_CHECK_EQUAL(devices[0].outputChannels[1].method, Bind);
-  BOOST_CHECK_EQUAL(devices[0].outputChannels[1].type, Push);
+  BOOST_CHECK_EQUAL(devices[0].outputChannels[1].method, ChannelMethod::Bind);
+  BOOST_CHECK_EQUAL(devices[0].outputChannels[1].type, ChannelType::Push);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[1].name, "from_A_to_C");
   BOOST_CHECK_EQUAL(devices[0].outputChannels[1].port, 22001);
 
   BOOST_CHECK_EQUAL(devices[1].inputChannels.size(), 1);
-  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].method, Connect);
-  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].type, Pull);
+  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].method, ChannelMethod::Connect);
+  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].type, ChannelType::Pull);
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].name, "from_A_to_B");
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].port, 22000);
   BOOST_CHECK_EQUAL(devices[1].outputChannels.size(), 1);
-  BOOST_CHECK_EQUAL(devices[1].outputChannels[0].method, Bind);
-  BOOST_CHECK_EQUAL(devices[1].outputChannels[0].type, Push);
+  BOOST_CHECK_EQUAL(devices[1].outputChannels[0].method, ChannelMethod::Bind);
+  BOOST_CHECK_EQUAL(devices[1].outputChannels[0].type, ChannelType::Push);
   BOOST_CHECK_EQUAL(devices[1].outputChannels[0].name, "from_B_to_D");
   BOOST_CHECK_EQUAL(devices[1].outputChannels[0].port, 22002);
 
   BOOST_CHECK_EQUAL(devices[2].inputChannels.size(), 1);
-  BOOST_CHECK_EQUAL(devices[2].inputChannels[0].method, Connect);
-  BOOST_CHECK_EQUAL(devices[2].inputChannels[0].type, Pull);
+  BOOST_CHECK_EQUAL(devices[2].inputChannels[0].method, ChannelMethod::Connect);
+  BOOST_CHECK_EQUAL(devices[2].inputChannels[0].type, ChannelType::Pull);
   BOOST_CHECK_EQUAL(devices[2].inputChannels[0].name, "from_A_to_C");
   BOOST_CHECK_EQUAL(devices[2].inputChannels[0].port, 22001);
   BOOST_CHECK_EQUAL(devices[2].outputChannels.size(), 1);
-  BOOST_CHECK_EQUAL(devices[2].outputChannels[0].method, Bind);
-  BOOST_CHECK_EQUAL(devices[2].outputChannels[0].type, Push);
+  BOOST_CHECK_EQUAL(devices[2].outputChannels[0].method, ChannelMethod::Bind);
+  BOOST_CHECK_EQUAL(devices[2].outputChannels[0].type, ChannelType::Push);
   BOOST_CHECK_EQUAL(devices[2].outputChannels[0].name, "from_C_to_D");
   BOOST_CHECK_EQUAL(devices[2].outputChannels[0].port, 22003);
 
   BOOST_CHECK_EQUAL(devices[3].inputChannels.size(), 2);
-  BOOST_CHECK_EQUAL(devices[3].inputChannels[0].method, Connect);
-  BOOST_CHECK_EQUAL(devices[3].inputChannels[0].type, Pull);
+  BOOST_CHECK_EQUAL(devices[3].inputChannels[0].method, ChannelMethod::Connect);
+  BOOST_CHECK_EQUAL(devices[3].inputChannels[0].type, ChannelType::Pull);
   BOOST_CHECK_EQUAL(devices[3].inputChannels[0].name, "from_B_to_D");
   BOOST_CHECK_EQUAL(devices[3].inputChannels[0].port, 22002);
-  BOOST_CHECK_EQUAL(devices[3].inputChannels[1].method, Connect);
-  BOOST_CHECK_EQUAL(devices[3].inputChannels[1].type, Pull);
+  BOOST_CHECK_EQUAL(devices[3].inputChannels[1].method, ChannelMethod::Connect);
+  BOOST_CHECK_EQUAL(devices[3].inputChannels[1].type, ChannelType::Pull);
   BOOST_CHECK_EQUAL(devices[3].inputChannels[1].name, "from_C_to_D");
   BOOST_CHECK_EQUAL(devices[3].inputChannels[1].port, 22003);
 }
@@ -285,25 +286,25 @@ BOOST_AUTO_TEST_CASE(TestTopologyForwarding)
   DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, resources);
   BOOST_CHECK_EQUAL(devices.size(), 3);
   BOOST_CHECK_EQUAL(devices[0].outputChannels.size(), 1);
-  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, Bind);
-  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].type, Push);
+  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, ChannelMethod::Bind);
+  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].type, ChannelType::Push);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].name, "from_A_to_B");
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].port, 22000);
 
   BOOST_CHECK_EQUAL(devices[1].inputChannels.size(), 1);
-  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].method, Connect);
-  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].type, Pull);
+  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].method, ChannelMethod::Connect);
+  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].type, ChannelType::Pull);
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].name, "from_A_to_B");
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].port, 22000);
   BOOST_CHECK_EQUAL(devices[1].outputChannels.size(), 1);
-  BOOST_CHECK_EQUAL(devices[1].outputChannels[0].method, Bind);
-  BOOST_CHECK_EQUAL(devices[1].outputChannels[0].type, Push);
+  BOOST_CHECK_EQUAL(devices[1].outputChannels[0].method, ChannelMethod::Bind);
+  BOOST_CHECK_EQUAL(devices[1].outputChannels[0].type, ChannelType::Push);
   BOOST_CHECK_EQUAL(devices[1].outputChannels[0].name, "from_B_to_C");
   BOOST_CHECK_EQUAL(devices[1].outputChannels[0].port, 22001);
 
   BOOST_CHECK_EQUAL(devices[2].inputChannels.size(), 1);
-  BOOST_CHECK_EQUAL(devices[2].inputChannels[0].method, Connect);
-  BOOST_CHECK_EQUAL(devices[2].inputChannels[0].type, Pull);
+  BOOST_CHECK_EQUAL(devices[2].inputChannels[0].method, ChannelMethod::Connect);
+  BOOST_CHECK_EQUAL(devices[2].inputChannels[0].type, ChannelType::Pull);
   BOOST_CHECK_EQUAL(devices[2].inputChannels[0].name, "from_B_to_C");
   BOOST_CHECK_EQUAL(devices[2].inputChannels[0].port, 22001);
 
@@ -551,90 +552,90 @@ BOOST_AUTO_TEST_CASE(TestTopologyLayeredTimePipeline)
 
   BOOST_REQUIRE_EQUAL(devices[0].inputChannels.size(), 0);
   BOOST_REQUIRE_EQUAL(devices[0].outputChannels.size(), 3);
-  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, Bind);
-  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].type, Push);
+  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, ChannelMethod::Bind);
+  BOOST_CHECK_EQUAL(devices[0].outputChannels[0].type, ChannelType::Push);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].name, "from_A_to_B_t0");
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].port, 22000);
-  BOOST_CHECK_EQUAL(devices[0].outputChannels[1].method, Bind);
-  BOOST_CHECK_EQUAL(devices[0].outputChannels[1].type, Push);
+  BOOST_CHECK_EQUAL(devices[0].outputChannels[1].method, ChannelMethod::Bind);
+  BOOST_CHECK_EQUAL(devices[0].outputChannels[1].type, ChannelType::Push);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[1].name, "from_A_to_B_t1");
   BOOST_CHECK_EQUAL(devices[0].outputChannels[1].port, 22001);
-  BOOST_CHECK_EQUAL(devices[0].outputChannels[2].method, Bind);
-  BOOST_CHECK_EQUAL(devices[0].outputChannels[2].type, Push);
+  BOOST_CHECK_EQUAL(devices[0].outputChannels[2].method, ChannelMethod::Bind);
+  BOOST_CHECK_EQUAL(devices[0].outputChannels[2].type, ChannelType::Push);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[2].name, "from_A_to_B_t2");
   BOOST_CHECK_EQUAL(devices[0].outputChannels[2].port, 22002);
 
   BOOST_REQUIRE_EQUAL(devices[1].inputChannels.size(), 1);
-  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].method, Connect);
-  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].type, Pull);
+  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].method, ChannelMethod::Connect);
+  BOOST_CHECK_EQUAL(devices[1].inputChannels[0].type, ChannelType::Pull);
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].name, "from_A_to_B_t0");
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].port, 22000);
   BOOST_CHECK_EQUAL(devices[1].outputChannels.size(), 2);
-  BOOST_CHECK_EQUAL(devices[1].outputChannels[0].method, Bind);
-  BOOST_CHECK_EQUAL(devices[1].outputChannels[0].type, Push);
+  BOOST_CHECK_EQUAL(devices[1].outputChannels[0].method, ChannelMethod::Bind);
+  BOOST_CHECK_EQUAL(devices[1].outputChannels[0].type, ChannelType::Push);
   BOOST_CHECK_EQUAL(devices[1].outputChannels[0].name, "from_B_t0_to_C_t0");
   BOOST_CHECK_EQUAL(devices[1].outputChannels[0].port, 22003);
-  BOOST_CHECK_EQUAL(devices[1].outputChannels[1].method, Bind);
-  BOOST_CHECK_EQUAL(devices[1].outputChannels[1].type, Push);
+  BOOST_CHECK_EQUAL(devices[1].outputChannels[1].method, ChannelMethod::Bind);
+  BOOST_CHECK_EQUAL(devices[1].outputChannels[1].type, ChannelType::Push);
   BOOST_CHECK_EQUAL(devices[1].outputChannels[1].name, "from_B_t0_to_C_t1");
   BOOST_CHECK_EQUAL(devices[1].outputChannels[1].port, 22004);
 
   BOOST_REQUIRE_EQUAL(devices[2].inputChannels.size(), 1);
-  BOOST_CHECK_EQUAL(devices[2].inputChannels[0].method, Connect);
-  BOOST_CHECK_EQUAL(devices[2].inputChannels[0].type, Pull);
+  BOOST_CHECK_EQUAL(devices[2].inputChannels[0].method, ChannelMethod::Connect);
+  BOOST_CHECK_EQUAL(devices[2].inputChannels[0].type, ChannelType::Pull);
   BOOST_CHECK_EQUAL(devices[2].inputChannels[0].name, "from_A_to_B_t1");
   BOOST_CHECK_EQUAL(devices[2].inputChannels[0].port, 22001);
   BOOST_REQUIRE_EQUAL(devices[2].outputChannels.size(), 2);
-  BOOST_CHECK_EQUAL(devices[2].outputChannels[0].method, Bind);
-  BOOST_CHECK_EQUAL(devices[2].outputChannels[0].type, Push);
+  BOOST_CHECK_EQUAL(devices[2].outputChannels[0].method, ChannelMethod::Bind);
+  BOOST_CHECK_EQUAL(devices[2].outputChannels[0].type, ChannelType::Push);
   BOOST_CHECK_EQUAL(devices[2].outputChannels[0].name, "from_B_t1_to_C_t0");
   BOOST_CHECK_EQUAL(devices[2].outputChannels[0].port, 22005);
-  BOOST_CHECK_EQUAL(devices[2].outputChannels[1].method, Bind);
-  BOOST_CHECK_EQUAL(devices[2].outputChannels[1].type, Push);
+  BOOST_CHECK_EQUAL(devices[2].outputChannels[1].method, ChannelMethod::Bind);
+  BOOST_CHECK_EQUAL(devices[2].outputChannels[1].type, ChannelType::Push);
   BOOST_CHECK_EQUAL(devices[2].outputChannels[1].name, "from_B_t1_to_C_t1");
   BOOST_CHECK_EQUAL(devices[2].outputChannels[1].port, 22006);
 
   BOOST_REQUIRE_EQUAL(devices[3].inputChannels.size(), 1);
-  BOOST_CHECK_EQUAL(devices[3].inputChannels[0].method, Connect);
-  BOOST_CHECK_EQUAL(devices[3].inputChannels[0].type, Pull);
+  BOOST_CHECK_EQUAL(devices[3].inputChannels[0].method, ChannelMethod::Connect);
+  BOOST_CHECK_EQUAL(devices[3].inputChannels[0].type, ChannelType::Pull);
   BOOST_CHECK_EQUAL(devices[3].inputChannels[0].name, "from_A_to_B_t2");
   BOOST_CHECK_EQUAL(devices[3].inputChannels[0].port, 22002);
   BOOST_REQUIRE_EQUAL(devices[3].outputChannels.size(), 2);
-  BOOST_CHECK_EQUAL(devices[3].outputChannels[0].method, Bind);
-  BOOST_CHECK_EQUAL(devices[3].outputChannels[0].type, Push);
+  BOOST_CHECK_EQUAL(devices[3].outputChannels[0].method, ChannelMethod::Bind);
+  BOOST_CHECK_EQUAL(devices[3].outputChannels[0].type, ChannelType::Push);
   BOOST_CHECK_EQUAL(devices[3].outputChannels[0].name, "from_B_t2_to_C_t0");
   BOOST_CHECK_EQUAL(devices[3].outputChannels[0].port, 22007);
-  BOOST_CHECK_EQUAL(devices[3].outputChannels[1].method, Bind);
-  BOOST_CHECK_EQUAL(devices[3].outputChannels[1].type, Push);
+  BOOST_CHECK_EQUAL(devices[3].outputChannels[1].method, ChannelMethod::Bind);
+  BOOST_CHECK_EQUAL(devices[3].outputChannels[1].type, ChannelType::Push);
   BOOST_CHECK_EQUAL(devices[3].outputChannels[1].name, "from_B_t2_to_C_t1");
   BOOST_CHECK_EQUAL(devices[3].outputChannels[1].port, 22008);
 
   BOOST_REQUIRE_EQUAL(devices[4].inputChannels.size(), 3);
-  BOOST_CHECK_EQUAL(devices[4].inputChannels[0].method, Connect);
-  BOOST_CHECK_EQUAL(devices[4].inputChannels[0].type, Pull);
+  BOOST_CHECK_EQUAL(devices[4].inputChannels[0].method, ChannelMethod::Connect);
+  BOOST_CHECK_EQUAL(devices[4].inputChannels[0].type, ChannelType::Pull);
   BOOST_CHECK_EQUAL(devices[4].inputChannels[0].name, "from_B_t0_to_C_t0");
   BOOST_CHECK_EQUAL(devices[4].inputChannels[0].port, 22003);
-  BOOST_CHECK_EQUAL(devices[4].inputChannels[1].method, Connect);
-  BOOST_CHECK_EQUAL(devices[4].inputChannels[1].type, Pull);
+  BOOST_CHECK_EQUAL(devices[4].inputChannels[1].method, ChannelMethod::Connect);
+  BOOST_CHECK_EQUAL(devices[4].inputChannels[1].type, ChannelType::Pull);
   BOOST_CHECK_EQUAL(devices[4].inputChannels[1].name, "from_B_t1_to_C_t0");
   BOOST_CHECK_EQUAL(devices[4].inputChannels[1].port, 22005);
-  BOOST_CHECK_EQUAL(devices[4].inputChannels[2].method, Connect);
-  BOOST_CHECK_EQUAL(devices[4].inputChannels[2].type, Pull);
+  BOOST_CHECK_EQUAL(devices[4].inputChannels[2].method, ChannelMethod::Connect);
+  BOOST_CHECK_EQUAL(devices[4].inputChannels[2].type, ChannelType::Pull);
   BOOST_CHECK_EQUAL(devices[4].inputChannels[2].name, "from_B_t2_to_C_t0");
   BOOST_CHECK_EQUAL(devices[4].inputChannels[2].port, 22007);
   BOOST_REQUIRE_EQUAL(devices[4].outputChannels.size(), 0);
 
   BOOST_REQUIRE_EQUAL(devices[5].inputChannels.size(), 3);
-  BOOST_CHECK_EQUAL(devices[5].inputChannels[0].method, Connect);
-  BOOST_CHECK_EQUAL(devices[5].inputChannels[0].type, Pull);
+  BOOST_CHECK_EQUAL(devices[5].inputChannels[0].method, ChannelMethod::Connect);
+  BOOST_CHECK_EQUAL(devices[5].inputChannels[0].type, ChannelType::Pull);
   BOOST_CHECK_EQUAL(devices[5].inputChannels[0].name, "from_B_t0_to_C_t1");
   BOOST_CHECK_EQUAL(devices[5].inputChannels[0].port, 22004);
-  BOOST_CHECK_EQUAL(devices[5].inputChannels[1].method, Connect);
-  BOOST_CHECK_EQUAL(devices[5].inputChannels[1].type, Pull);
+  BOOST_CHECK_EQUAL(devices[5].inputChannels[1].method, ChannelMethod::Connect);
+  BOOST_CHECK_EQUAL(devices[5].inputChannels[1].type, ChannelType::Pull);
   BOOST_CHECK_EQUAL(devices[5].inputChannels[1].name, "from_B_t1_to_C_t1");
   BOOST_CHECK_EQUAL(devices[5].inputChannels[1].port, 22006);
-  BOOST_CHECK_EQUAL(devices[5].inputChannels[2].method, Connect);
-  BOOST_CHECK_EQUAL(devices[5].inputChannels[2].type, Pull);
+  BOOST_CHECK_EQUAL(devices[5].inputChannels[2].method, ChannelMethod::Connect);
+  BOOST_CHECK_EQUAL(devices[5].inputChannels[2].type, ChannelType::Pull);
   BOOST_CHECK_EQUAL(devices[5].inputChannels[2].name, "from_B_t2_to_C_t1");
   BOOST_CHECK_EQUAL(devices[5].inputChannels[2].port, 22008);
   BOOST_REQUIRE_EQUAL(devices[5].outputChannels.size(), 0);


### PR DESCRIPTION
* Promote scattered functionality to convert ChannelSpec fields to
string / urls to a separate class.
* Make ChannelMethod and ChannelType scoped enumerations