### PR TITLE
DPL: Use ConditionalRun() to steer the inner loop

### DIFF
--- a/Framework/Core/include/Framework/DataProcessingDevice.h
+++ b/Framework/Core/include/Framework/DataProcessingDevice.h
@@ -35,18 +35,21 @@ namespace o2
 namespace framework
 {
 
-class DataProcessingDevice : public FairMQDevice {
-public:
-  DataProcessingDevice(const DeviceSpec &spec, ServiceRegistry &);
+class DataProcessingDevice : public FairMQDevice
+{
+ public:
+  DataProcessingDevice(const DeviceSpec& spec, ServiceRegistry&);
   void Init() final;
   void PreRun() final;
   void PostRun() final;
   void Reset() final;
+  bool ConditionalRun() final;
 
  protected:
-  bool HandleData(FairMQParts &parts, int index);
-  void error(const char *msg);
-private:
+  bool handleData(FairMQParts&);
+  void error(const char* msg);
+
+ private:
   AlgorithmSpec::InitCallback mInit;
   AlgorithmSpec::ProcessCallback mStatefulProcess;
   AlgorithmSpec::ProcessCallback mStatelessProcess;


### PR DESCRIPTION
This paves the way to fix several limitation of the current
DataProcessingDevice like the ability to limit polling
on channels which are faster than others or the ability to
have time triggered inputs rather then those which are data
triggered, rendering the "DataSourceDevice" effectively useless.