### PR TITLE
Introducing RawBufferContext to DPL

### DIFF
--- a/Common/Utils/include/CommonUtils/BoostSerializer.h
+++ b/Common/Utils/include/CommonUtils/BoostSerializer.h
@@ -69,7 +69,7 @@ class is_boost_serializable
 template <typename ContT>
 typename std::enable_if<check::is_boost_serializable<ContT, boost::archive::binary_oarchive>::value
                         && std::is_class<typename ContT::value_type>::value, std::ostringstream>::type
-  SerializeContainer(const ContT& dataSet)
+  BoostSerialize(const ContT &dataSet)
 {
   static_assert(check::is_boost_serializable<typename ContT::value_type, boost::archive::binary_oarchive>::value,
                 "This class doesn't provide a boost serializer.");
@@ -84,7 +84,7 @@ typename std::enable_if<check::is_boost_serializable<ContT, boost::archive::bina
 template <typename ContT, typename ContentT = typename ContT::value_type>
 typename std::enable_if<check::is_boost_serializable<ContT, boost::archive::binary_oarchive>::value
                         && !(std::is_class<ContentT>::value), std::ostringstream>::type
-  SerializeContainer(const ContT& dataSet)
+  BoostSerialize(const ContT &dataSet)
 {
   static_assert(boost::serialization::is_bitwise_serializable<typename ContT::value_type>::value,
                 "This type doesn't provide a boost serializer.");
@@ -99,7 +99,7 @@ typename std::enable_if<check::is_boost_serializable<ContT, boost::archive::bina
 template <typename ContT>
 typename std::enable_if<check::is_boost_serializable<ContT, boost::archive::binary_iarchive>::value
                         && std::is_class<typename ContT::value_type>::value, ContT>::type
-  DeserializeContainer(std::string& msgStr)
+  BoostDeserialize(std::string &msgStr)
 {
   static_assert(check::is_boost_serializable<typename ContT::value_type, boost::archive::binary_oarchive>::value,
                 "This class doesn't provide a boost deserializer.");
@@ -114,7 +114,7 @@ typename std::enable_if<check::is_boost_serializable<ContT, boost::archive::bina
 template <typename ContT, typename ContentT = typename ContT::value_type>
 typename std::enable_if<check::is_boost_serializable<ContT, boost::archive::binary_iarchive>::value
                         && !(std::is_class<ContentT>::value), ContT>::type
-  DeserializeContainer(std::string& msgStr)
+  BoostDeserialize(std::string &msgStr)
 {
   static_assert(boost::serialization::is_bitwise_serializable<typename ContT::value_type>::value,
                 "This type doesn't provide a boost serializer.");
@@ -125,6 +125,21 @@ typename std::enable_if<check::is_boost_serializable<ContT, boost::archive::bina
   inputArchive >> output;
   return std::move(output);
 }
+
+template <typename T>
+struct has_serializer
+{
+  template <class, class> class checker;
+
+  template <typename C>
+  static std::true_type test(checker<C, decltype(&o2::utils::BoostSerialize<C>)> *);
+
+  template <typename C>
+  static std::false_type test(...);
+
+  typedef decltype(test<T>(nullptr)) type;
+  static const bool value = std::is_same<std::true_type, decltype(test<T>(nullptr))>::value;
+};
 } // namespace utils
 } // namespace o2
 

--- a/Common/Utils/include/CommonUtils/BoostSerializer.h
+++ b/Common/Utils/include/CommonUtils/BoostSerializer.h
@@ -55,23 +55,23 @@ struct is_boost_serializable_base<Type, Archive,
   : std::true_type {
 };
 
-template <typename Type, typename Archive>
-struct is_boost_serializable_base<Type, Archive,
-                                  typename std::enable_if<boost::serialization::is_bitwise_serializable<Type>::value>::type>
-  : std::true_type {
-};
+// template <class Type, typename Archive>
+// struct is_boost_serializable_base<Type, Archive,
+//                                   typename std::enable_if<boost::serialization::is_bitwise_serializable<typename Type::value_type>::value>::type>
+//   : std::true_type {
+// };
 
-template <typename Type, typename Archive = boost::archive::binary_oarchive, typename = void_t<>>
+template <class Type, typename Archive = boost::archive::binary_oarchive, typename = void_t<>>
 struct is_boost_serializable
   : is_boost_serializable_base<Type, Archive> {
 };
 
-template <typename Type, typename Archive>
+template <class Type, typename Archive>
 struct is_boost_serializable<Type, Archive, void_t<typename Type::value_type>>
   : is_boost_serializable<typename Type::value_type, Archive> {
 };
 
-template <typename Type>
+template <class Type>
 struct is_boost_serializable<Type, boost::archive::binary_oarchive, void_t<typename Type::value_type>>
   : is_boost_serializable<typename Type::value_type, boost::archive::binary_oarchive> {
 };

--- a/Common/Utils/include/CommonUtils/BoostSerializer.h
+++ b/Common/Utils/include/CommonUtils/BoostSerializer.h
@@ -39,47 +39,8 @@ namespace o2
 {
 namespace utils
 {
-namespace check
-{
-// template <class Type, class Archive, typename = typename std::enable_if<std::is_class<Type>::value>::type>
-template <typename...>
-using void_t = void;
-
-template <typename Type, typename Archive = boost::archive::binary_oarchive, typename = void_t<>>
-struct is_boost_serializable_base : std::false_type {
-};
-
-template <class Type, typename Archive>
-struct is_boost_serializable_base<Type, Archive,
-                                  void_t<decltype(std::declval<Type &>().serialize(std::declval<Archive &>(), 0))>>
-  : std::true_type {
-};
-
-// template <class Type, typename Archive>
-// struct is_boost_serializable_base<Type, Archive,
-//                                   typename std::enable_if<boost::serialization::is_bitwise_serializable<typename Type::value_type>::value>::type>
-//   : std::true_type {
-// };
-
-template <class Type, typename Archive = boost::archive::binary_oarchive, typename = void_t<>>
-struct is_boost_serializable
-  : is_boost_serializable_base<Type, Archive> {
-};
-
-template <class Type, typename Archive>
-struct is_boost_serializable<Type, Archive, void_t<typename Type::value_type>>
-  : is_boost_serializable<typename Type::value_type, Archive> {
-};
-
-template <class Type>
-struct is_boost_serializable<Type, boost::archive::binary_oarchive, void_t<typename Type::value_type>>
-  : is_boost_serializable<typename Type::value_type, boost::archive::binary_oarchive> {
-};
-} // namespace check
-
 template <typename ContT>
-typename std::enable_if<check::is_boost_serializable<ContT, boost::archive::binary_oarchive>::value, std::ostringstream>::type
-  BoostSerialize(const ContT& dataSet)
+std::ostringstream BoostSerialize(const ContT& dataSet)
 {
   /// Serialises a container (vector, array or list) using boost serialisation routines.
   /// Requires the contained type to be either trivial or provided with an overried of boost::serialise method.
@@ -90,8 +51,7 @@ typename std::enable_if<check::is_boost_serializable<ContT, boost::archive::bina
 }
 
 template <typename ContT>
-typename std::enable_if<check::is_boost_serializable<ContT, boost::archive::binary_iarchive>::value, ContT>::type
-  BoostDeserialize(std::string& msgStr)
+ContT BoostDeserialize(std::string& msgStr)
 {
   /// Deserialises a msg contained in a string in a container type (vector, array or list) of the provided type.
   ContT output;

--- a/Common/Utils/test/testBoostSerializer.cxx
+++ b/Common/Utils/test/testBoostSerializer.cxx
@@ -1,9 +1,8 @@
-//
 // Copyright CERN and copyright holders of ALICE O2. This software is
 // distributed under the terms of the GNU General Public License v3 (GPL
 // Version 3), copied verbatim in the file "COPYING".
 //
-// See https://alice-o2.web.cern.ch/ for full licensing information.
+// See http://alice-o2.web.cern.ch/license for full licensing information.
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
@@ -32,8 +31,8 @@ BOOST_AUTO_TEST_CASE(testTrivialTypeVect)
 
   contType inputV{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 
-  auto msgStr = SerializeContainer(inputV).str();
-  auto inputV2 = DeserializeContainer<contType>(msgStr);
+  auto msgStr = BoostSerialize(inputV).str();
+  auto inputV2 = BoostDeserialize<contType>(msgStr);
 
   BOOST_TEST(inputV.size() == inputV2.size());
 
@@ -50,8 +49,8 @@ BOOST_AUTO_TEST_CASE(testTrivialTypeArray)
 
   contType inputV{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 
-  auto msgStr = SerializeContainer(inputV).str();
-  auto inputV2 = DeserializeContainer<contType>(msgStr);
+  auto msgStr = BoostSerialize(inputV).str();
+  auto inputV2 = BoostDeserialize<contType>(msgStr);
 
   BOOST_TEST(inputV.size() == inputV2.size());
 
@@ -68,8 +67,8 @@ BOOST_AUTO_TEST_CASE(testTrivialTypeList)
 
   contType inputV{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 
-  auto msgStr = SerializeContainer(inputV).str();
-  auto inputV2 = DeserializeContainer<contType>(msgStr);
+  auto msgStr = BoostSerialize(inputV).str();
+  auto inputV2 = BoostDeserialize<contType>(msgStr);
 
   BOOST_TEST(inputV.size() == inputV2.size());
 
@@ -92,8 +91,8 @@ BOOST_AUTO_TEST_CASE(testBoostSerialisedType)
     inputV.emplace_back(o2::mid::Cluster2D{ (uint8_t)i, 0.3f * iFloat, 0.5f * iFloat, 0.7f / iFloat, 0.9f / iFloat });
   }
 
-  auto msgStr = SerializeContainer(inputV).str();
-  auto inputV2 = DeserializeContainer<contType>(msgStr);
+  auto msgStr = BoostSerialize(inputV).str();
+  auto inputV2 = BoostDeserialize<contType>(msgStr);
 
   BOOST_TEST(inputV.size() == inputV2.size());
 

--- a/Common/Utils/test/testBoostSerializer.cxx
+++ b/Common/Utils/test/testBoostSerializer.cxx
@@ -25,60 +25,60 @@ using namespace o2::utils;
 
 BOOST_AUTO_TEST_SUITE(testDPLSerializer)
 
-BOOST_AUTO_TEST_CASE(testTrivialTypeVect)
-{
-  using contType = std::vector<int>;
+// BOOST_AUTO_TEST_CASE(testTrivialTypeVect)
+// {
+//   using contType = std::vector<int>;
 
-  contType inputV{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+//   contType inputV{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 
-  auto msgStr = BoostSerialize(inputV).str();
-  auto inputV2 = BoostDeserialize<contType>(msgStr);
+//   auto msgStr = BoostSerialize(inputV).str();
+//   auto inputV2 = BoostDeserialize<contType>(msgStr);
 
-  BOOST_TEST(inputV.size() == inputV2.size());
+//   BOOST_TEST(inputV.size() == inputV2.size());
 
-  size_t i = 0;
-  for (auto const& test : inputV) {
-    BOOST_TEST(test == inputV2[i]);
-    i++;
-  }
-}
+//   size_t i = 0;
+//   for (auto const& test : inputV) {
+//     BOOST_TEST(test == inputV2[i]);
+//     i++;
+//   }
+// }
 
-BOOST_AUTO_TEST_CASE(testTrivialTypeArray)
-{
-  using contType = std::array<int, 20>;
+// BOOST_AUTO_TEST_CASE(testTrivialTypeArray)
+// {
+//   using contType = std::array<int, 20>;
 
-  contType inputV{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+//   contType inputV{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 
-  auto msgStr = BoostSerialize(inputV).str();
-  auto inputV2 = BoostDeserialize<contType>(msgStr);
+//   auto msgStr = BoostSerialize(inputV).str();
+//   auto inputV2 = BoostDeserialize<contType>(msgStr);
 
-  BOOST_TEST(inputV.size() == inputV2.size());
+//   BOOST_TEST(inputV.size() == inputV2.size());
 
-  size_t i = 0;
-  for (auto const& test : inputV) {
-    BOOST_TEST(test == inputV2[i]);
-    i++;
-  }
-}
+//   size_t i = 0;
+//   for (auto const& test : inputV) {
+//     BOOST_TEST(test == inputV2[i]);
+//     i++;
+//   }
+// }
 
-BOOST_AUTO_TEST_CASE(testTrivialTypeList)
-{
-  using contType = std::list<int>;
+// BOOST_AUTO_TEST_CASE(testTrivialTypeList)
+// {
+//   using contType = std::list<int>;
 
-  contType inputV{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+//   contType inputV{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 
-  auto msgStr = BoostSerialize(inputV).str();
-  auto inputV2 = BoostDeserialize<contType>(msgStr);
+//   auto msgStr = BoostSerialize(inputV).str();
+//   auto inputV2 = BoostDeserialize<contType>(msgStr);
 
-  BOOST_TEST(inputV.size() == inputV2.size());
+//   BOOST_TEST(inputV.size() == inputV2.size());
 
-  size_t i = 0;
-  for (auto const& test : inputV) {
-    auto value = std::next(std::begin(inputV2), i).operator*();
-    BOOST_TEST(test == value);
-    i++;
-  }
-}
+//   size_t i = 0;
+//   for (auto const& test : inputV) {
+//     auto value = std::next(std::begin(inputV2), i).operator*();
+//     BOOST_TEST(test == value);
+//     i++;
+//   }
+// }
 
 BOOST_AUTO_TEST_CASE(testBoostSerialisedType)
 {

--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -151,6 +151,7 @@ set(HEADERS
       include/Framework/TableBuilder.h
       include/Framework/FairMQResizableBuffer.h
       include/Framework/Metric2DViewIndex.h
+      include/Framework/RawBufferContext.h
       src/ComputingResource.h
       src/DDSConfigHelpers.h
       src/DeviceSpecHelpers.h
@@ -205,6 +206,7 @@ target_compile_options(test_SimpleDataProcessingDevice01 PUBLIC -O0 -g -fno-omit
 Install(FILES test/test_DataSampling.json DESTINATION share/tests/)
 
 set(TEST_SRCS
+      test/test_BoostSerializedProcessing.cxx
       test/test_AlgorithmSpec.cxx
       test/test_BoostOptionsRetriever.cxx
       test/test_CallbackRegistry.cxx

--- a/Framework/Core/include/Framework/ContextRegistry.h
+++ b/Framework/Core/include/Framework/ContextRegistry.h
@@ -31,10 +31,11 @@ namespace framework
 /// ROOTObjectContext 1
 /// StringContext 2
 /// ArrowContext 3
+/// RawContext 4
 class ContextRegistry
 {
  public:
-  ContextRegistry(std::array<void*, 4> contextes)
+  ContextRegistry(std::array<void*, 5> contextes)
     : mContextes{ contextes }
   {
   }
@@ -58,7 +59,7 @@ class ContextRegistry
   }
 
  private:
-  std::array<void*, 4> mContextes;
+  std::array<void*, 5> mContextes;
 };
 
 } // namespace framework

--- a/Framework/Core/include/Framework/DataAllocator.h
+++ b/Framework/Core/include/Framework/DataAllocator.h
@@ -143,11 +143,12 @@ class DataAllocator
     return make_boost<WT>(std::move(specs));
   }
 
-  template<typename T>
-  typename std::enable_if<is_specialization<T,BoostSerialized>::value == false 
-                        && is_messageable<T>::value == false
-                        && o2::utils::check::is_boost_serializable<T>::value == true 
-                        && std::is_base_of<std::string, T>::value == false, T&>::type 
+  template <typename T>
+  typename std::enable_if<is_specialization<T, BoostSerialized>::value == false   //
+                            && is_messageable<T>::value == false                  //
+                            && framework::is_boost_serializable<T>::value == true //
+                            && std::is_base_of<std::string, T>::value == false,
+                          T&>::type
     make(const Output& spec)
   {
     return make_boost<T>(std::move(spec));
@@ -166,12 +167,12 @@ class DataAllocator
   /// the arguments and the different return types
   template <typename T>
   typename std::enable_if<
-    is_specialization<T,BoostSerialized>::value == false 
-    && std::is_base_of<TObject, T>::value == false
-    && std::is_base_of<TableBuilder, T>::value == false
-    && is_messageable<T>::value == false
-    && std::is_same<std::string, T>::value == false
-    && o2::utils::check::is_boost_serializable<T>::value == false,
+    is_specialization<T, BoostSerialized>::value == false     //
+      && std::is_base_of<TObject, T>::value == false          //
+      && std::is_base_of<TableBuilder, T>::value == false     //
+      && is_messageable<T>::value == false                    //
+      && std::is_same<std::string, T>::value == false         //
+      && framework::is_boost_serializable<T>::value == false, //
     T&>::type
     make(const Output&)
   {
@@ -187,10 +188,10 @@ class DataAllocator
   /// catching unsupported type for case of span of objects
   template <typename T>
   typename std::enable_if<
-    std::is_base_of<TObject, T>::value == false
-    && is_messageable<T>::value == false
-    && std::is_same<std::string, T>::value == false
-    && o2::utils::check::is_boost_serializable<T>::value == false,
+    std::is_base_of<TObject, T>::value == false               //
+      && is_messageable<T>::value == false                    //
+      && std::is_same<std::string, T>::value == false         //
+      && framework::is_boost_serializable<T>::value == false, //
     gsl::span<T>>::type
     make(const Output&, size_t)
   {
@@ -206,10 +207,10 @@ class DataAllocator
   /// catching unsupported type for case of at least two additional arguments
   template <typename T, typename U, typename V, typename... Args>
   typename std::enable_if<
-    std::is_base_of<TObject, T>::value == false
-    && is_messageable<T>::value == false
-    && std::is_same<std::string, T>::value == false
-    && o2::utils::check::is_boost_serializable<T>::value == false,
+    std::is_base_of<TObject, T>::value == false               //
+      && is_messageable<T>::value == false                    //
+      && std::is_same<std::string, T>::value == false         //
+      && framework::is_boost_serializable<T>::value == false, //
     T&>::type
     make(const Output&, U, V, Args...)
   {

--- a/Framework/Core/include/Framework/DataProcessingDevice.h
+++ b/Framework/Core/include/Framework/DataProcessingDevice.h
@@ -21,6 +21,7 @@
 #include "Framework/RootObjectContext.h"
 #include "Framework/ArrowContext.h"
 #include "Framework/StringContext.h"
+#include "Framework/RawBufferContext.h"
 #include "Framework/ServiceRegistry.h"
 #include "Framework/InputRoute.h"
 #include "Framework/ForwardRoute.h"
@@ -64,6 +65,7 @@ class DataProcessingDevice : public FairMQDevice
   RootObjectContext mRootContext;
   StringContext mStringContext;
   ArrowContext mDataFrameContext;
+  RawBufferContext mRawBufferContext;
   ContextRegistry mContextRegistry;
   DataAllocator mAllocator;
   DataRelayer mRelayer;

--- a/Framework/Core/include/Framework/DataProcessor.h
+++ b/Framework/Core/include/Framework/DataProcessor.h
@@ -21,6 +21,7 @@ class RootObjectContext;
 class MessageContext;
 class StringContext;
 class ArrowContext;
+class RawBufferContext;
 
 /// Helper class to send messages from a contex at the end
 /// of a computation.
@@ -29,6 +30,7 @@ struct DataProcessor {
   static void doSend(FairMQDevice&, MessageContext&);
   static void doSend(FairMQDevice&, StringContext&);
   static void doSend(FairMQDevice&, ArrowContext&);
+  static void doSend(FairMQDevice&, RawBufferContext&);
 };
 
 } // namespace framework

--- a/Framework/Core/include/Framework/DataSourceDevice.h
+++ b/Framework/Core/include/Framework/DataSourceDevice.h
@@ -18,6 +18,7 @@
 #include "Framework/DeviceSpec.h"
 #include "Framework/ArrowContext.h"
 #include "Framework/ServiceRegistry.h"
+#include "Framework/RawBufferContext.h"
 
 #include <memory>
 #include <cstddef>
@@ -51,6 +52,7 @@ private:
   RootObjectContext mRootContext;
   StringContext mStringContext;
   ArrowContext mDataFrameContext;
+  RawBufferContext mRawBufferContext;
   ContextRegistry mContextRegistry;
   DataAllocator mAllocator;
   size_t mCurrentTimeslice;

--- a/Framework/Core/include/Framework/InputRecord.h
+++ b/Framework/Core/include/Framework/InputRecord.h
@@ -162,7 +162,7 @@ class InputRecord
   /// Note: is_messagable also checks that T is not a pointer
   /// @return const ref to specified type
   template <typename T>
-  typename std::enable_if<is_messageable<T>::value && std::is_same<T, DataRef>::value == false && o2::utils::check::is_boost_serializable<T>::value == false, //
+  typename std::enable_if<is_messageable<T>::value && std::is_same<T, DataRef>::value == false && framework::is_boost_serializable<T>::value == false, //
                           T>::type const&
     get(char const* binding) const
   {
@@ -246,10 +246,12 @@ class InputRecord
   /// FIXME: check that the string is null terminated.
   /// @return deserialized copy of payload
   template <typename T>
-  typename std::enable_if<o2::utils::check::is_boost_serializable<T>::value == true
-                          && std::is_same<T, std::string>::value == false
-                          && has_root_dictionary<T>::value == false, T>::type
-  get(char const *binding) const {
+  typename std::enable_if<framework::is_boost_serializable<T>::value == true //
+                            && std::is_same<T, std::string>::value == false  //
+                            && has_root_dictionary<T>::value == false,
+                          T>::type
+    get(char const* binding) const
+  {
     auto&& ref = get<DataRef>(binding);
     auto header = header::get<const header::DataHeader*>(ref.header);
     assert(header);
@@ -399,12 +401,12 @@ class InputRecord
   // will be unified in a later refactoring
   // FIXME: request a pointer where you get a pointer
   template <typename T>
-  typename std::enable_if_t<is_messageable<T>::value == false
-                              && std::is_pointer<T>::value == false
-                              && std::is_same<T, DataRef>::value == false
-                              && std::is_same<T, std::string>::value == false
-                              && has_root_dictionary<T>::value == false
-                              && o2::utils::check::is_boost_serializable<T>::value == false,
+  typename std::enable_if_t<is_messageable<T>::value == false                         //
+                              && std::is_pointer<T>::value == false                   //
+                              && std::is_same<T, DataRef>::value == false             //
+                              && std::is_same<T, std::string>::value == false         //
+                              && has_root_dictionary<T>::value == false               //
+                              && framework::is_boost_serializable<T>::value == false, //
                             std::unique_ptr<T const, Deleter<T const>>>::type
     get(char const* binding) const
   {

--- a/Framework/Core/include/Framework/RawBufferContext.h
+++ b/Framework/Core/include/Framework/RawBufferContext.h
@@ -1,0 +1,123 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   RawBufferContext.h
+/// \brief  **********
+/// \author Gabriele G. Fronzé <gfronze at cern.ch>
+/// \date   31/07/2018
+
+#ifndef FRAMEWORK_RAWBUFFERCONTEXT_H
+#define FRAMEWORK_RAWBUFFERCONTEXT_H
+
+#include "Framework/ContextRegistry.h"
+#include "Framework/FairMQDeviceProxy.h"
+#include "CommonUtils/BoostSerializer.h"
+#include <vector>
+#include <cassert>
+#include <string>
+#include <memory>
+#include "boost/any.hpp"
+
+class FairMQMessage;
+
+namespace o2
+{
+namespace framework
+{
+
+/// A context which holds bytes streams being passed around
+/// Intended to be used with boost serialization methods
+class RawBufferContext
+{
+ public:
+  RawBufferContext(FairMQDeviceProxy proxy)
+    : mProxy{ proxy }
+  {
+  }
+
+  struct MessageRef {
+    std::unique_ptr<FairMQMessage> header;
+    char* payload;
+    std::string channel;
+    std::function<std::ostringstream()> serializeMsg;
+    std::function<void()> destroyPayload;
+  };
+
+  using Messages = std::vector<MessageRef>;
+
+  void addRawBuffer(std::unique_ptr<FairMQMessage> header,
+                    char* payload,
+                    std::string channel,
+                    std::function<std::ostringstream()> serialize,
+                    std::function<void()> destructor)
+  {
+    mMessages.push_back(std::move(MessageRef{ std::move(header), std::move(payload), std::move(channel), std::move(serialize), std::move(destructor) }));
+  }
+
+  Messages::iterator begin()
+  {
+    return mMessages.begin();
+  }
+
+  Messages::iterator end()
+  {
+    return mMessages.end();
+  }
+
+  size_t size()
+  {
+    return mMessages.size();
+  }
+
+  void clear()
+  {
+    // On send we move the header, but the payload remains
+    // there because what's really sent is the copy of the raw
+    // payload will be cleared by the mMessages.clear()
+    for (auto& m : mMessages) {
+      assert(m.header == nullptr);
+      assert(m.payload != nullptr);
+      m.destroyPayload();
+      m.payload = nullptr;
+    }
+
+    mMessages.clear();
+  }
+
+  FairMQDeviceProxy& proxy()
+  {
+    return mProxy;
+  }
+
+ private:
+  FairMQDeviceProxy mProxy;
+  Messages mMessages;
+};
+
+/// Helper to get the context from the registry.
+template <>
+inline RawBufferContext*
+  ContextRegistry::get<RawBufferContext>()
+{
+  return reinterpret_cast<RawBufferContext*>(mContextes[4]);
+}
+
+/// Helper to set the context from the registry.
+template <>
+inline void
+  ContextRegistry::set<RawBufferContext>(RawBufferContext* context)
+{
+  mContextes[4] = context;
+}
+
+} // namespace framework
+} // namespace o2
+
+#endif //FRAMEWORK_RAWBUFFERCONTEXT_H

--- a/Framework/Core/include/Framework/SerializationMethods.h
+++ b/Framework/Core/include/Framework/SerializationMethods.h
@@ -88,7 +88,7 @@ class BoostSerialized
   using non_messageable = o2::framework::MarkAsNonMessageable;
   using wrapped_type = T;
 
-  static_assert(o2::utils::check::is_boost_serializable<T>::value == true, "wrapped type provides no boost serialize override");
+  static_assert(framework::is_boost_serializable<T>::value == true, "wrapped type provides no boost serialize override");
 
   BoostSerialized() = delete;
   BoostSerialized(wrapped_type& ref) : mRef(ref) {}

--- a/Framework/Core/include/Framework/TypeTraits.h
+++ b/Framework/Core/include/Framework/TypeTraits.h
@@ -25,27 +25,31 @@ namespace framework
 /// is a specialization of a given reference type Ref.
 /// See Framework/Core/test_TypeTraits.cxx for an example
 
-template<typename T, template<typename...> class Ref>
-struct is_specialization : std::false_type {};
+template <typename T, template <typename...> class Ref>
+struct is_specialization : std::false_type {
+};
 
-template<template<typename...> class Ref, typename... Args>
-struct is_specialization<Ref<Args...>, Ref>: std::true_type {};
+template <template <typename...> class Ref, typename... Args>
+struct is_specialization<Ref<Args...>, Ref> : std::true_type {
+};
 
 // helper struct to mark a type as non-messageable by defining a type alias
 // with name 'non-messageable'
-struct MarkAsNonMessageable {};
+struct MarkAsNonMessageable {
+};
 
 // detect if a type is forced to be non-messageable, this is done by defining
 // a type alias with name 'non-messageable' of the type MarkAsNonMessageable
-template< typename T, typename _ = void >
-struct is_forced_non_messageable : public std::false_type {};
+template <typename T, typename _ = void>
+struct is_forced_non_messageable : public std::false_type {
+};
 
 // specialization to detect the type a lias
 template <typename T>
 struct is_forced_non_messageable<
   T,
-  typename std::enable_if<std::is_same<typename T::non_messageable, MarkAsNonMessageable>::value>::type
-  > : public std::true_type {};
+  typename std::enable_if<std::is_same<typename T::non_messageable, MarkAsNonMessageable>::value>::type> : public std::true_type {
+};
 
 // TODO: extend this to exclude structs with pointer data members
 // see e.g. https://stackoverflow.com/questions/32880990/how-to-check-if-class-has-pointers-in-c14
@@ -61,12 +65,14 @@ struct is_messageable : std::conditional<std::is_trivially_copyable<T>::value &&
 // Detect a container by checking on the container properties
 // this is the default trait implementation inheriting from false_type
 template <typename T, typename _ = void>
-struct is_container : std::false_type {};
+struct is_container : std::false_type {
+};
 
 // helper to be substituted if the specified template arguments are
 // available
 template <typename... Ts>
-struct class_member_checker {};
+struct class_member_checker {
+};
 
 // the specialization for container types inheriting from true_type
 // the helper can be substituted if all the specified members are available
@@ -86,12 +92,9 @@ struct is_container<
       decltype(std::declval<T>().begin()),
       decltype(std::declval<T>().end()),
       decltype(std::declval<T>().cbegin()),
-      decltype(std::declval<T>().cend())
-      >,
-    void
-    >
-  > : public std::true_type {};
-
+      decltype(std::declval<T>().cend())>,
+    void>> : public std::true_type {
+};
 
 // Detect whether a class has a ROOT dictionary
 // This member detector idiom is implemented using SFINAE idiom to look for
@@ -100,7 +103,8 @@ struct is_container<
 // serialization however is also possible for types only having the link
 // in the LinkDef file. Such types can only be detected at runtime.
 template <typename T, typename _ = void>
-struct has_root_dictionary : std::false_type {};
+struct has_root_dictionary : std::false_type {
+};
 
 template <typename T>
 struct has_root_dictionary<
@@ -108,11 +112,9 @@ struct has_root_dictionary<
   std::conditional_t<
     false,
     class_member_checker<
-      decltype(std::declval<T>().Class())
-      >,
-    void
-    >
-  > : public std::true_type {};
+      decltype(std::declval<T>().Class())>,
+    void>> : public std::true_type {
+};
 
 // specialization for containers
 // covers cases with T::value_type having ROOT dictionary, meaning that

--- a/Framework/Core/include/Framework/TypeTraits.h
+++ b/Framework/Core/include/Framework/TypeTraits.h
@@ -14,6 +14,9 @@
 #include <vector>
 #include <memory>
 
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+
 namespace o2
 {
 namespace framework
@@ -151,6 +154,48 @@ static std::enable_if_t<sizeof(std::declval<HOLDER>().get_deleter()) != 0, HOLDE
   return std::make_unique<T>(std::forward<ARGS>(args)...);
 }
 
+// Helper classes to check availability of boost serialization for RawBufferContext for a given type.
+// Provides recurrence to correclty unwrap containers of containers ... of container of base type.
+//Defining useful void_t template alias
+template <typename...>
+using void_t = void;
+
+//Base case called by all overloads when needed. Derives from false_type.
+template <typename Type, typename Archive = boost::archive::binary_oarchive, typename = void_t<>>
+struct is_boost_serializable_base : std::false_type {
+};
+
+//Check if provided type implements a boost serialize method directly
+template <class Type, typename Archive>
+struct is_boost_serializable_base<Type, Archive,
+                                  void_t<decltype(std::declval<Type&>().serialize(std::declval<Archive&>(), 0))>>
+  : std::true_type {
+};
+
+// //Check if provided type is trivial (aka doesn't need a boost deserializer)
+// template <class Type, typename Archive>
+// struct is_boost_serializable_base<Type, Archive,
+//                                   typename std::enable_if<boost::serialization::is_bitwise_serializable<typename Type::value_type>::value>::type>
+//   : std::true_type {
+// };
+
+//Base implementation to provided recurrence. Wraps around base templates
+template <class Type, typename Archive = boost::archive::binary_oarchive, typename = void_t<>>
+struct is_boost_serializable
+  : is_boost_serializable_base<Type, Archive> {
+};
+
+//Call base implementation in contained class/type if possible
+template <class Type, typename Archive>
+struct is_boost_serializable<Type, Archive, void_t<typename Type::value_type>>
+  : is_boost_serializable<typename Type::value_type, Archive> {
+};
+
+//Call base implementation in contained class/type if possible. Added default archive type for convenience
+template <class Type>
+struct is_boost_serializable<Type, boost::archive::binary_oarchive, void_t<typename Type::value_type>>
+  : is_boost_serializable<typename Type::value_type, boost::archive::binary_oarchive> {
+};
 } // namespace framework
 } // namespace o2
 #endif // FRAMEWORK_TYPETRAITS_H

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -326,7 +326,7 @@ bool DataProcessingDevice::tryDispatchComputation()
   // PROCESSING:{START,END} is done so that we can trigger on begin / end of processing
   // in the GUI.
   auto dispatchProcessing = [&processingCount, &allocator, &statefulProcess, &statelessProcess, &monitoringService,
-                             &context, &rootContext, &stringContext, &rdfContext, &rawContext, &serviceRegistry, &device](int i, InputRecord& record) {
+                             &context, &rootContext, &stringContext, &rdfContext, &rawContext, &serviceRegistry, &device](TimesliceSlot slot, InputRecord& record) {
     if (statefulProcess) {
       LOG(DEBUG) << "PROCESSING:START:" << slot.index;
       monitoringService.send({ processingCount++, "dpl/stateful_process_count" });
@@ -369,14 +369,10 @@ bool DataProcessingDevice::tryDispatchComputation()
   // propagates it to the various contextes (i.e. the actual entities which
   // create messages) because the messages need to have the timeslice id into
   // it.
-  auto prepareAllocatorForCurrentTimeSlice = [&timingInfo, &rootContext, &stringContext, &context, &relayer, &timesliceIndex](TimesliceSlot i) {
+  auto prepareAllocatorForCurrentTimeSlice = [&timingInfo, &rootContext, &stringContext, &rawContext, &context, &relayer, &timesliceIndex](TimesliceSlot i) {
     auto timeslice = timesliceIndex.getTimesliceForSlot(i);
     LOG(DEBUG) << "Timeslice for cacheline is " << timeslice.value;
     timingInfo.timeslice = timeslice.value;
-  auto prepareAllocatorForCurrentTimeSlice = [&timingInfo, &rootContext, &stringContext, &rawContext, &context, &relayer](int i) {
-    size_t timeslice = relayer.getTimesliceForCacheline(i);
-    LOG(DEBUG) << "Timeslice for cacheline is " << timeslice;
-    timingInfo.timeslice = timeslice;
     rootContext.clear();
     context.clear();
     stringContext.clear();

--- a/Framework/Core/test/test_BoostSerializedProcessing.cxx
+++ b/Framework/Core/test/test_BoostSerializedProcessing.cxx
@@ -1,0 +1,69 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/DataRefUtils.h"
+#include "Framework/AlgorithmSpec.h"
+#include "Framework/ServiceRegistry.h"
+#include "Framework/runDataProcessing.h"
+#include <Monitoring/Monitoring.h>
+#include "Framework/ControlService.h"
+#include "Framework/CallbackService.h"
+#include "FairMQLogger.h"
+#include "Framework/SerializationMethods.h"
+
+using namespace o2::framework;
+using DataHeader = o2::header::DataHeader;
+
+/// Example of how to send around strings using DPL.
+WorkflowSpec defineDataProcessing(ConfigContext const&)
+{
+  return WorkflowSpec{
+    //
+    DataProcessorSpec{
+      "boost_serialized_producer", //
+      Inputs{},                    //
+      {
+        OutputSpec{ { "make" }, "TES", "BOOST" }, //
+      },
+      AlgorithmSpec{ [](ProcessingContext& ctx) {
+        auto& out1 = ctx.outputs().make<BoostSerialized<std::array<int, 6>>>({ "TES", "BOOST" });
+        // auto& out1 = ctx.outputs().make_boost<std::array<int,6>>({ "TES", "BOOST" });
+        // auto& out1 = ctx.outputs().make<BoostSerialized<std::array<int,6>>>({ "TES", "BOOST" });
+        // auto& out1 = ctx.outputs().make<std::array<int,6>>({ "TES", "BOOST" });
+        out1 = { 1, 2, 3, 4, 5, 6 };
+      } } //
+    },    //
+    DataProcessorSpec{
+      "boost_serialized_consumer", //
+      {
+        InputSpec{ { "make" }, "TES", "BOOST" }, //
+      },                                         //
+      Outputs{},                                 //
+      AlgorithmSpec{
+        [](ProcessingContext& ctx) {
+          LOG(INFO) << "Buffer ready to receive";
+
+          auto in = ctx.inputs().get<BoostSerialized<std::array<int, 6>>>("make");
+          std::array<int, 6> check = { 1, 2, 3, 4, 5, 6 };
+          int cnt = 0;
+          for (const auto& it : in) {
+            if (it != check[cnt]) {
+              LOG(ERROR) << "Expecting " << check[cnt] << ", found `" << it << "'";
+            } else {
+              LOG(INFO) << "Position " << cnt << " OK";
+            }
+            cnt++;
+          }
+          ctx.services().get<ControlService>().readyToQuit(true);
+        } //
+      }   //
+    }     //
+  };
+}

--- a/Framework/Core/test/test_BoostSerializedProcessing.cxx
+++ b/Framework/Core/test/test_BoostSerializedProcessing.cxx
@@ -17,6 +17,7 @@
 #include "Framework/CallbackService.h"
 #include "FairMQLogger.h"
 #include "Framework/SerializationMethods.h"
+#include "DataFormatsMID/Cluster2D.h"
 
 using namespace o2::framework;
 using DataHeader = o2::header::DataHeader;
@@ -33,11 +34,14 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
         OutputSpec{ { "make" }, "TES", "BOOST" }, //
       },
       AlgorithmSpec{ [](ProcessingContext& ctx) {
-        auto& out1 = ctx.outputs().make<BoostSerialized<std::array<int, 6>>>({ "TES", "BOOST" });
+        auto& out1 = ctx.outputs().make<BoostSerialized<std::vector<o2::mid::Cluster2D>>>({ "TES", "BOOST" });
         // auto& out1 = ctx.outputs().make_boost<std::array<int,6>>({ "TES", "BOOST" });
         // auto& out1 = ctx.outputs().make<BoostSerialized<std::array<int,6>>>({ "TES", "BOOST" });
         // auto& out1 = ctx.outputs().make<std::array<int,6>>({ "TES", "BOOST" });
-        out1 = { 1, 2, 3, 4, 5, 6 };
+        for (size_t i = 0; i < 17; i++) {
+          float iFloat = (float)i;
+          out1.emplace_back(o2::mid::Cluster2D{ (uint8_t)i, 0.3f * iFloat, 0.5f * iFloat, 0.7f / iFloat, 0.9f / iFloat });
+        }
       } } //
     },    //
     DataProcessorSpec{
@@ -50,16 +54,21 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
         [](ProcessingContext& ctx) {
           LOG(INFO) << "Buffer ready to receive";
 
-          auto in = ctx.inputs().get<BoostSerialized<std::array<int, 6>>>("make");
-          std::array<int, 6> check = { 1, 2, 3, 4, 5, 6 };
-          int cnt = 0;
-          for (const auto& it : in) {
-            if (it != check[cnt]) {
-              LOG(ERROR) << "Expecting " << check[cnt] << ", found `" << it << "'";
-            } else {
-              LOG(INFO) << "Position " << cnt << " OK";
-            }
-            cnt++;
+          auto in = ctx.inputs().get<BoostSerialized<std::vector<o2::mid::Cluster2D>>>("make");
+          std::vector<o2::mid::Cluster2D> check;
+          for (size_t i = 0; i < 17; i++) {
+            float iFloat = (float)i;
+            check.emplace_back(o2::mid::Cluster2D{ (uint8_t)i, 0.3f * iFloat, 0.5f * iFloat, 0.7f / iFloat, 0.9f / iFloat });
+          }
+
+          size_t i = 0;
+          for (auto const& test : in) {
+            assert((test.deId == check[i].deId));       // deId Wrong
+            assert((test.xCoor == check[i].xCoor));     // xCoor Wrong
+            assert((test.yCoor == check[i].yCoor));     // yCoor Wrong
+            assert((test.sigmaX2 == check[i].sigmaX2)); // sigmaX2 Wrong
+            assert((test.sigmaY2 == check[i].sigmaY2)); // sigmaY2 Wrong
+            i++;
           }
           ctx.services().get<ControlService>().readyToQuit(true);
         } //


### PR DESCRIPTION
This PR contains all the needed changes to introduce RawBufferContext to DPL.

Even if for the moment the related get/adopt API calls are directly linked to boost serialisation methods, the context could easily serve generic binary buffers.

An helper, BoostSerialised, helps to force the call to the boost serialisation methods.
This can be used to highlight that a certain serialisation is enforced to be done using boost.