### PR TITLE
Delete a copy of DataBlockHeader structure and refer to its header

### DIFF
--- a/Framework/Core/src/DataSamplingReadoutAdapter.cxx
+++ b/Framework/Core/src/DataSamplingReadoutAdapter.cxx
@@ -8,6 +8,8 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#include <Common/DataBlock.h>
+
 #include "Framework/DataSamplingReadoutAdapter.h"
 #include "Headers/DataHeader.h"
 #include "Framework/DataProcessingHeader.h"
@@ -21,17 +23,6 @@ using DataHeader = o2::header::DataHeader;
 
 InjectorFunction dataSamplingReadoutAdapter(OutputSpec const& spec)
 {
-
-  // copied from Common/DataBlock.h
-  using DataBlockId = uint64_t;
-  struct DataBlockHeaderBase {
-    uint32_t blockType;  ///< ID to identify structure type
-    uint32_t headerSize; ///< header size in bytes
-    uint32_t dataSize;   ///< data size following this structure (until next header, if this is not a toplevel block header)
-    DataBlockId id;      ///< id of the block (monotonic increasing sequence)
-    uint32_t linkId;     ///< id of link
-  };
-
   return [spec](FairMQDevice& device, FairMQParts& parts, int index) {
     for (size_t i = 0; i < parts.Size() / 2; ++i) {
 

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -67,6 +67,7 @@ find_package(Protobuf REQUIRED)
 find_package(InfoLogger REQUIRED)
 find_package(Configuration REQUIRED)
 find_package(Monitoring REQUIRED)
+find_package(Common REQUIRED)
 find_package(RapidJSON REQUIRED)
 find_package(GLFW)
 find_package(benchmark QUIET)
@@ -273,6 +274,7 @@ o2_define_bucket(
     SYSTEMINCLUDE_DIRECTORIES
     ${Monitoring_INCLUDE_DIRS}
     ${Configuration_INCLUDE_DIRS}
+    ${COMMON_INCLUDE_DIR}/include
 )
 
 o2_define_bucket(


### PR DESCRIPTION
Common is now a dependency of O2, so the copy of DataBlockHeader declaration can be deleted. It addressed [this comment on PR](https://github.com/AliceO2Group/AliceO2/pull/1276#discussion_r207128672).