### PR TITLE
Digitizer-workflow: Communicate TPC sector as part of the header stack

### DIFF
--- a/Steer/DigitizerWorkflow/CMakeLists.txt
+++ b/Steer/DigitizerWorkflow/CMakeLists.txt
@@ -26,6 +26,7 @@ O2_GENERATE_EXECUTABLE(
   src/CollisionTimePrinter.cxx
   src/TPCDriftTimeDigitizerSpec.cxx
   src/TPCDigitRootWriterSpec.cxx
+  src/TPCSectorHeader.cxx
 
   BUCKET_NAME ${MODULE_BUCKET_NAME}
 )

--- a/Steer/DigitizerWorkflow/src/TPCDriftTimeDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TPCDriftTimeDigitizerSpec.cxx
@@ -104,7 +104,7 @@ DataProcessorSpec getTPCDriftTimeDigitizer(int channel, bool cachehits)
     auto snapshotLabels = [&sector, &pc, &channel](o2::dataformats::MCTruthContainer<o2::MCCompLabel> const& labels) {
       o2::tpc::TPCSectorHeader header{ sector };
       pc.outputs().snapshot(Output{ "TPC", "DIGITSMCTR", static_cast<SubSpecificationType>(channel),
-                                    Lifetime::Timeframe /*, header */ },
+                                    Lifetime::Timeframe, header },
                             const_cast<o2::dataformats::MCTruthContainer<o2::MCCompLabel>&>(labels));
     };
 

--- a/Steer/DigitizerWorkflow/src/TPCDriftTimeDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TPCDriftTimeDigitizerSpec.cxx
@@ -31,6 +31,7 @@
 #include <sstream>
 #include <algorithm>
 #include "TPCBase/CDBInterface.h"
+#include "TPCSectorHeader.h"
 
 using namespace o2::framework;
 using SubSpecificationType = o2::framework::DataAllocator::SubSpecificationType;
@@ -91,20 +92,33 @@ DataProcessorSpec getTPCDriftTimeDigitizer(int channel, bool cachehits)
     auto digitArrayRaw = digitArray.get();
     auto mcTruthArrayRaw = mcTruthArray.get();
 
+    // lambda that snapshots digits to be sent out; prepares and attaches header with sector information
+    auto snapshotDigits = [sector, &pc, channel](std::vector<o2::TPC::Digit> const& digits) {
+      o2::tpc::TPCSectorHeader header{ sector };
+      // note that snapshoting only works with non-const references (to be fixed?)
+      pc.outputs().snapshot(Output{ "TPC", "DIGITS", static_cast<SubSpecificationType>(channel), Lifetime::Timeframe,
+                                    header },
+                            const_cast<std::vector<o2::TPC::Digit>&>(digits));
+    };
+    // lambda that snapshots labels to be sent out; prepares and attaches header with sector information
+    auto snapshotLabels = [&sector, &pc, &channel](o2::dataformats::MCTruthContainer<o2::MCCompLabel> const& labels) {
+      o2::tpc::TPCSectorHeader header{ sector };
+      pc.outputs().snapshot(Output{ "TPC", "DIGITSMCTR", static_cast<SubSpecificationType>(channel),
+                                    Lifetime::Timeframe /*, header */ },
+                            const_cast<o2::dataformats::MCTruthContainer<o2::MCCompLabel>&>(labels));
+    };
+
     // no more tasks can be marked with a negative sector
     if (sector < 0) {
       // we are ready to quit or we received a NOP
 
       // notify channels further down the road that we are done (why do I have to send digitArray here????)
+      // (we are essentially sending empty messages with a header containing the stop signal)
       digitArrayRaw->clear();
       mcTruthArrayRaw->clear();
-      pc.outputs().snapshot(Output{ "TPC", "DIGITS", static_cast<SubSpecificationType>(channel), Lifetime::Timeframe },
-                            *digitArrayRaw);
-      pc.outputs().snapshot(
-        Output{ "TPC", "DIGITSMCTR", static_cast<SubSpecificationType>(channel), Lifetime::Timeframe },
-        *mcTruthArrayRaw);
-      pc.outputs().snapshot(Output{ "TPC", "SECTOR", static_cast<SubSpecificationType>(channel), Lifetime::Timeframe },
-                            sector);
+
+      snapshotDigits(*digitArrayRaw);
+      snapshotLabels(*mcTruthArrayRaw);
       if (sector == -1) {
         pc.services().get<ControlService>().readyToQuit(false);
         finished = true;
@@ -189,16 +203,10 @@ DataProcessorSpec getTPCDriftTimeDigitizer(int channel, bool cachehits)
         // NOTE: we would like to send it here in order to avoid copying/accumulating !!
       }
     }
-    // write digits + MC truth
-    pc.outputs().snapshot(Output{ "TPC", "DIGITS", static_cast<SubSpecificationType>(channel), Lifetime::Timeframe },
-                          digitAccum);
-    pc.outputs().snapshot(
-      Output{ "TPC", "DIGITSMCTR", static_cast<SubSpecificationType>(channel), Lifetime::Timeframe }, labelAccum);
-    pc.outputs().snapshot(Output{ "TPC", "SECTOR", static_cast<SubSpecificationType>(channel), Lifetime::Timeframe },
-                          sector);
+    // snapshot / "send" digits + MC truth
+    snapshotDigits(digitAccum);
+    snapshotLabels(labelAccum);
 
-    //# outtree->SetDirectory(file.get());
-    //# file->Write();
     timer.Stop();
     LOG(INFO) << "Digitization took " << timer.CpuTime() << "s";
   };
@@ -231,8 +239,7 @@ DataProcessorSpec getTPCDriftTimeDigitizer(int channel, bool cachehits)
                                          static_cast<SubSpecificationType>(channel), Lifetime::Condition } },
     Outputs{ // define channel by triple of (origin, type id of data to be sent on this channel, subspecification)
              OutputSpec{ "TPC", "DIGITS", static_cast<SubSpecificationType>(channel), Lifetime::Timeframe },
-             OutputSpec{ "TPC", "DIGITSMCTR", static_cast<SubSpecificationType>(channel), Lifetime::Timeframe },
-             OutputSpec{ "TPC", "SECTOR", static_cast<SubSpecificationType>(channel), Lifetime::Timeframe } },
+             OutputSpec{ "TPC", "DIGITSMCTR", static_cast<SubSpecificationType>(channel), Lifetime::Timeframe } },
     AlgorithmSpec{ initIt },
     Options{ { "simFile", VariantType::String, "o2sim.root", { "Sim (background) input filename" } },
              { "simFileS", VariantType::String, "", { "Sim (signal) input filename" } } }

--- a/Steer/DigitizerWorkflow/src/TPCSectorHeader.cxx
+++ b/Steer/DigitizerWorkflow/src/TPCSectorHeader.cxx
@@ -1,0 +1,13 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "TPCSectorHeader.h"
+
+constexpr o2::header::HeaderType o2::tpc::TPCSectorHeader::sHeaderType = "TPCSectH";

--- a/Steer/DigitizerWorkflow/src/TPCSectorHeader.h
+++ b/Steer/DigitizerWorkflow/src/TPCSectorHeader.h
@@ -1,0 +1,36 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TPCSECTORHEADER_H
+#define O2_TPCSECTORHEADER_H
+
+#include "Headers/DataHeader.h"
+
+namespace o2
+{
+namespace tpc
+{
+
+struct TPCSectorHeader : public o2::header::BaseHeader {
+  // Required to do the lookup
+  static const o2::header::HeaderType sHeaderType;
+  static const uint32_t sVersion = 1;
+
+  TPCSectorHeader(int s)
+    : BaseHeader(sizeof(TPCSectorHeader), sHeaderType, o2::header::gSerializationMethodNone, sVersion), sector(s)
+  {
+  }
+
+  int sector;
+};
+} // namespace tpc
+} // namespace o2
+
+#endif // O2_TPCSECTORHEADER_H


### PR DESCRIPTION
This commit simplifies the communication of the sector number
to which the digit data belongs.

So far this needed to be communicated via a separate channel.
Now it is done using the header stack feature, which allows to attach
meta-information to messages.