### PR TITLE
DPL: add initial InfoLogger integration to DPL

### DIFF
--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -595,6 +595,7 @@ boost::program_options::options_description DeviceSpecHelpers::getForwardedDevic
   forwardedDeviceOptions.add_options()                                                                   //
     ("rate", bpo::value<std::string>(), "rate for a data source device (Hz)")                            //
     ("monitoring-backend", bpo::value<std::string>(), "monitoring connection string")                    //
+    ("infologger-mode", bpo::value<std::string>(), "INFOLOGGER_MODE override")                           //
     ("child-driver", bpo::value<std::string>(), "external driver to start childs with (e.g. valgrind)"); //
 
   return forwardedDeviceOptions;

--- a/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
@@ -10,8 +10,11 @@
 #include "Framework/ConfigParamSpec.h"
 #include "Framework/CompletionPolicy.h"
 #include "Framework/DeviceSpec.h"
+#include <InfoLogger/InfoLogger.hxx>
 #include <vector>
 using namespace o2::framework;
+using namespace AliceO2::InfoLogger;
+
 void customize(std::vector<ConfigParamSpec> &options) {
   options.push_back(ConfigParamSpec{"anInt", VariantType::Int, 1, {"an int option"}});
   options.push_back(ConfigParamSpec{"aFloat", VariantType::Float, 2.0f, {"a float option"}});
@@ -57,6 +60,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const&specs) {
           sleep(rand() % 2);
           auto aData = ctx.outputs().make<int>(OutputRef{ "a1" }, 1);
           auto bData = ctx.outputs().make<int>(OutputRef{ "a2" }, 1);
+          ctx.services().get<InfoLogger>().log("This goes to infologger");
         } } },
     { "B",
       { InputSpec{ "x", "TST", "A1" } },


### PR DESCRIPTION
InfoLogger can now be used as a Framework service by providing the `--infologger-backend` commandline option.

Further integration with FairLogger coming in a different PR.