### PR TITLE
DPL: add InfoLogger as FairLogger stream

### DIFF
--- a/Framework/Core/README.md
+++ b/Framework/Core/README.md
@@ -330,6 +330,27 @@ Some suffix for the metrics are reserved to represent vector and tabular metrics
 * `<some-metric-name>/m` contains the secondary size of a matrix metric at a given moment.
 * `<some-metric-name>/<i>` where `<i>` is an integer contains the values of the i-th element in a vector metric or of the `<i>%n` column, `<i>/m` row of a matrix metric.
 
+#### InfoLogger service
+
+Integration with the InfoLogger subsystem of O2 happens in two way:
+
+* Explicitly, by getting the `AliceO2::InfoLogger::InfoLogger` service from the registry, like done in the monitoring case:
+
+```c++
+#include <InfoLogger/InfoLogger.hxx>
+//...
+auto logger = context.services().get<InfoLogger>(); // In the DataProcessor lambda
+```
+
+* Implicitly, by using the standard FairLogger `LOG` macro. In order to enable this
+  the user needs to specify the minimum severity to send to the `InfoLogger` via the
+  `--infologger-severity` option, e.g.:
+
+```bash
+... --infologger-severity WARNING
+```
+
+Finally, one can configure the bahavior of the InfoLogger by using the `--infologger-mode` option.
 
 #### Callback service
 

--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -592,11 +592,12 @@ boost::program_options::options_description DeviceSpecHelpers::getForwardedDevic
   // - rate is an option of FairMQ device for ConditionalRun
   // - child-driver is not a FairMQ device option but used per device to start to process
   bpo::options_description forwardedDeviceOptions;
-  forwardedDeviceOptions.add_options()                                                                   //
-    ("rate", bpo::value<std::string>(), "rate for a data source device (Hz)")                            //
-    ("monitoring-backend", bpo::value<std::string>(), "monitoring connection string")                    //
-    ("infologger-mode", bpo::value<std::string>(), "INFOLOGGER_MODE override")                           //
-    ("child-driver", bpo::value<std::string>(), "external driver to start childs with (e.g. valgrind)"); //
+  forwardedDeviceOptions.add_options()                                                                          //
+    ("rate", bpo::value<std::string>(), "rate for a data source device (Hz)")                                   //
+    ("monitoring-backend", bpo::value<std::string>(), "monitoring connection string")                           //
+    ("infologger-mode", bpo::value<std::string>(), "INFOLOGGER_MODE override")                                  //
+    ("infologger-severity", bpo::value<std::string>(), "minimun FairLogger severity which goes to info logger") //
+    ("child-driver", bpo::value<std::string>(), "external driver to start childs with (e.g. valgrind)");        //
 
   return forwardedDeviceOptions;
 }

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -585,6 +585,62 @@ struct TurnOffColors {
   }
 };
 
+// Creates the sink for FairLogger / InfoLogger integration
+auto createInfoLoggerSinkHelper(std::unique_ptr<InfoLogger>& logger, std::unique_ptr<InfoLoggerContext>& ctx)
+{
+  return [&logger,
+          &ctx](const std::string& content, const fair::LogMetaData& metadata) {
+    // translate FMQ metadata
+    InfoLogger::InfoLogger::Severity severity = InfoLogger::Severity::Undefined;
+    int level = InfoLogger::undefinedMessageOption.level;
+
+    if (metadata.severity_name == fair::Logger::SeverityName(fair::Severity::nolog)) {
+      // discard
+      return;
+    } else if (metadata.severity_name == fair::Logger::SeverityName(fair::Severity::fatal)) {
+      severity = InfoLogger::Severity::Fatal;
+    } else if (metadata.severity_name == fair::Logger::SeverityName(fair::Severity::error)) {
+      severity = InfoLogger::Severity::Error;
+    } else if (metadata.severity_name == fair::Logger::SeverityName(fair::Severity::warn)) {
+      severity = InfoLogger::Severity::Warning;
+    } else if (metadata.severity_name == fair::Logger::SeverityName(fair::Severity::state)) {
+      severity = InfoLogger::Severity::Info;
+      level = 10;
+    } else if (metadata.severity_name == fair::Logger::SeverityName(fair::Severity::info)) {
+      severity = InfoLogger::Severity::Info;
+    } else if (metadata.severity_name == fair::Logger::SeverityName(fair::Severity::debug)) {
+      severity = InfoLogger::Severity::Debug;
+    } else if (metadata.severity_name == fair::Logger::SeverityName(fair::Severity::debug1)) {
+      severity = InfoLogger::Severity::Debug;
+      level = 10;
+    } else if (metadata.severity_name == fair::Logger::SeverityName(fair::Severity::debug2)) {
+      severity = InfoLogger::Severity::Debug;
+      level = 20;
+    } else if (metadata.severity_name == fair::Logger::SeverityName(fair::Severity::debug3)) {
+      severity = InfoLogger::Severity::Debug;
+      level = 30;
+    } else if (metadata.severity_name == fair::Logger::SeverityName(fair::Severity::debug4)) {
+      severity = InfoLogger::Severity::Debug;
+      level = 40;
+    } else if (metadata.severity_name == fair::Logger::SeverityName(fair::Severity::trace)) {
+      severity = InfoLogger::Severity::Debug;
+      level = 50;
+    }
+
+    InfoLogger::InfoLoggerMessageOption opt = {
+      severity,
+      level,
+      InfoLogger::undefinedMessageOption.errorCode,
+      metadata.file.c_str(),
+      atoi(metadata.line.c_str())
+    };
+
+    if (logger) {
+      logger->log(opt, *ctx, "DPL: %s", content.c_str());
+    }
+  };
+};
+
 int doChild(int argc, char** argv, const o2::framework::DeviceSpec& spec)
 {
   TurnOffColors::apply(false, 0);
@@ -599,7 +655,8 @@ int doChild(int argc, char** argv, const o2::framework::DeviceSpec& spec)
       boost::program_options::options_description optsDesc;
       ConfigParamsHelper::populateBoostProgramOptions(optsDesc, spec.options, gHiddenDeviceOptions);
       optsDesc.add_options()("monitoring-backend", bpo::value<std::string>()->default_value("infologger://"), "monitoring backend info") //
-                            ("infologger-mode", bpo::value<std::string>()->default_value(""), "INFOLOGGER_MODE override");
+        ("infologger-severity", bpo::value<std::string>()->default_value(""), "minimum FairLogger severity to send to InfoLogger")       //
+        ("infologger-mode", bpo::value<std::string>()->default_value(""), "INFOLOGGER_MODE override");
       r.fConfig.AddToCmdLineOptions(optsDesc, true);
     });
 
@@ -616,6 +673,7 @@ int doChild(int argc, char** argv, const o2::framework::DeviceSpec& spec)
     std::unique_ptr<CallbackService> callbackService;
     std::unique_ptr<Monitoring> monitoringService;
     std::unique_ptr<InfoLogger> infoLoggerService;
+    std::unique_ptr<InfoLoggerContext> infoLoggerContext;
 
     auto afterConfigParsingCallback = [&localRootFileService,
                                        &textControlService,
@@ -625,17 +683,25 @@ int doChild(int argc, char** argv, const o2::framework::DeviceSpec& spec)
                                        &monitoringService,
                                        &infoLoggerService,
                                        &spec,
-                                       &serviceRegistry](fair::mq::DeviceRunner& r) {
+                                       &serviceRegistry,
+                                       &infoLoggerContext](fair::mq::DeviceRunner& r) {
       localRootFileService = std::make_unique<LocalRootFileService>();
       textControlService = std::make_unique<TextControlService>();
       parallelContext = std::make_unique<ParallelContext>(spec.rank, spec.nSlots);
       simpleRawDeviceService = std::make_unique<SimpleRawDeviceService>(nullptr);
       callbackService = std::make_unique<CallbackService>();
       monitoringService = MonitoringFactory::Get(r.fConfig.GetStringValue("monitoring-backend"));
-      if (r.fConfig.GetStringValue("infologger-mode") != "") {
+      auto infoLoggerMode = r.fConfig.GetStringValue("infologger-mode");
+      if (infoLoggerMode != "") {
         setenv("INFOLOGGER_MODE", r.fConfig.GetStringValue("infologger-mode").c_str(), 1);
       }
       infoLoggerService = std::make_unique<InfoLogger>();
+      infoLoggerContext = std::make_unique<InfoLoggerContext>();
+
+      auto infoLoggerSeverity = r.fConfig.GetStringValue("infologger-severity");
+      if (infoLoggerSeverity != "") {
+        fair::Logger::AddCustomSink("infologger", infoLoggerSeverity, createInfoLoggerSinkHelper(infoLoggerService, infoLoggerContext));
+      }
 
       serviceRegistry.registerService<Monitoring>(monitoringService.get());
       serviceRegistry.registerService<InfoLogger>(infoLoggerService.get());


### PR DESCRIPTION
This enables using the standard LOG macros to sent data to the
InfoLogger. See README.md for more details of how to configure this.