### PR TITLE
DPL: create index of distinct InputRoutes

### DIFF
--- a/Framework/Core/include/Framework/DataRelayer.h
+++ b/Framework/Core/include/Framework/DataRelayer.h
@@ -99,6 +99,7 @@ private:
 
   std::vector<bool> mForwardingMask;
   CompletionPolicy mCompletionPolicy;
+  std::vector<size_t> mDistinctRoutesIndex;
 };
 
 } // namespace framework


### PR DESCRIPTION
While being just a minor performance improvement, this refactoring
will come useful with the coming integration of proper Lifetime for
objects.