### PR TITLE
Use LOG(INFO) instead of Info()

### DIFF
--- a/Detectors/TOF/base/src/Geo.cxx
+++ b/Detectors/TOF/base/src/Geo.cxx
@@ -29,7 +29,7 @@ Float_t Geo::mRotationMatrixPlateStrip[NPLATES][NMAXNSTRIP][3][3];
 
 void Geo::Init()
 {
-  Info("tof::Geo::Init", "Initialization of TOF rotation parameters");
+  LOG(INFO) << "tof::Geo: Initialization of TOF rotation parameters";
 
   Double_t rotationAngles[6] =
     { 90., 90. /*+ (isector + 0.5) * PHISEC*/, 0., 0., 90., 0 /* + (isector + 0.5) * PHISEC*/ };


### PR DESCRIPTION
This is a bug fix. I found that the Info() API (from ROOT?) interferes
with the LOG(INFO) system from FairLogger. Since the latter is also used for
control in DPL, some control messages were sometimes not dispatched
correctly leading to non-exiting DPL workflows.