### PR TITLE
DPL: adapt to support new FairMQ versions

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -215,6 +215,7 @@ set(TEST_SRCS
       test/test_GUITests.cxx
       test/test_InputRecord.cxx
       test/test_ParallelProducer.cxx
+      test/test_PtrHelpers.cxx
       test/test_LogParsingHelpers.cxx
       test/test_ExternalFairMQDeviceProxy.cxx
       test/test_Services.cxx

--- a/Framework/Core/include/Framework/TypeTraits.h
+++ b/Framework/Core/include/Framework/TypeTraits.h
@@ -12,6 +12,7 @@
 
 #include <type_traits>
 #include <vector>
+#include <memory>
 
 namespace o2
 {
@@ -122,6 +123,33 @@ class has_root_dictionary<T, typename std::enable_if<is_container<T>::value>::ty
   : public has_root_dictionary<typename T::value_type>
 {
 };
+
+/// Helper class to deal with the case we are creating the first instance of a
+/// (possibly) shared resource.
+///
+/// works for both:
+///
+/// std::shared_ptr<Base> storage = make_matching<decltype(storage), Concrete1>(args...);
+///
+/// or
+///
+/// std::unique_ptr<Base> storage = make_matching<decltype(storage), Concrete1>(args...);
+///
+/// Useful to deal with those who cannot make up their mind about ownership.
+/// ;-)
+template <typename HOLDER, typename T, typename... ARGS>
+static std::enable_if_t<sizeof(std::declval<HOLDER>().unique()) != 0, HOLDER>
+  make_matching(ARGS&&... args)
+{
+  return std::make_shared<T>(std::forward<ARGS>(args)...);
+}
+
+template <typename HOLDER, typename T, typename... ARGS>
+static std::enable_if_t<sizeof(std::declval<HOLDER>().get_deleter()) != 0, HOLDER>
+  make_matching(ARGS&&... args)
+{
+  return std::make_unique<T>(std::forward<ARGS>(args)...);
+}
 
 } // namespace framework
 } // namespace o2

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -711,13 +711,15 @@ int doChild(int argc, char** argv, const o2::framework::DeviceSpec& spec)
       serviceRegistry.registerService<RawDeviceService>(simpleRawDeviceService.get());
       serviceRegistry.registerService<CallbackService>(callbackService.get());
 
-      std::shared_ptr<FairMQDevice> device;
+      // The decltype stuff is to be able to compile with both new and old
+      // FairMQ API (one which uses a shared_ptr, the other one a unique_ptr.
+      decltype(r.fDevice) device;
       if (spec.inputs.empty()) {
         LOG(DEBUG) << spec.id << " is a source\n";
-        device = std::make_shared<DataSourceDevice>(spec, serviceRegistry);
+        device = make_matching<decltype(device), DataSourceDevice>(spec, serviceRegistry);
       } else {
         LOG(DEBUG) << spec.id << " is a processor\n";
-        device = std::make_shared<DataProcessingDevice>(spec, serviceRegistry);
+        device = make_matching<decltype(device), DataProcessingDevice>(spec, serviceRegistry);
       }
 
       serviceRegistry.get<RawDeviceService>().setDevice(device.get());

--- a/Framework/Core/test/test_PtrHelpers.cxx
+++ b/Framework/Core/test/test_PtrHelpers.cxx
@@ -1,0 +1,43 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test Framework PtrHelpers
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+#include "Framework/TypeTraits.h"
+#include <memory>
+
+struct Base {
+  int v;
+};
+struct A : public Base {
+  A(int v_, int va_) : Base{ v_ }, va{ va_ } {}
+  int va;
+};
+struct B : public Base {
+  B(int v_, int vb_) : Base{ v_ }, vb{ vb_ } {}
+  int vb;
+};
+
+BOOST_AUTO_TEST_CASE(MatchingPtrMaker)
+{
+
+  std::shared_ptr<Base> s = std::move(o2::framework::make_matching<decltype(s), A>(1, 3));
+  std::unique_ptr<Base> u = std::move(o2::framework::make_matching<decltype(u), B>(2, 4));
+
+  BOOST_REQUIRE(s != nullptr);
+  BOOST_REQUIRE(u != nullptr);
+  BOOST_CHECK_EQUAL(s->v, 1);
+  BOOST_CHECK_EQUAL(u->v, 2);
+  BOOST_CHECK_EQUAL(static_cast<A*>(s.get())->va, 3);
+  BOOST_CHECK_EQUAL(static_cast<B*>(u.get())->vb, 4);
+}


### PR DESCRIPTION
FairMQ changed `FairMQDevice::fDevice` to a shared_ptr from a
unique_ptr. This makes sure we can compile DPL with both version and
introduces an helper to handle this kind of situations in the future
when updating might not be an option.