### PR TITLE
Use GRP information to influence digitization workflow

### DIFF
--- a/Steer/DigitizerWorkflow/src/SimReaderSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/SimReaderSpec.cxx
@@ -35,8 +35,8 @@ namespace steer
 DataProcessorSpec getSimReaderSpec(int fanoutsize, std::shared_ptr<std::vector<int>> tpcsectors,
                                    std::shared_ptr<std::vector<int>> tpcsubchannels)
 {
-  // this container will contain the TPC sector assignment per subchannel per invokation
-  // it will allow that we snapshot/send exactly one sector assignement per algorithm invokation
+  // this container will contain the TPC sector assignment per subchannel per invocation
+  // it will allow that we snapshot/send exactly one sector assignment per algorithm invocation
   // to ensure that they all have different timeslice ids
   auto tpcsectormessages = std::make_shared<std::vector<std::vector<int>>>();
   tpcsectormessages->resize(tpcsubchannels->size());
@@ -120,7 +120,7 @@ DataProcessorSpec getSimReaderSpec(int fanoutsize, std::shared_ptr<std::vector<i
         context);
     }
     counter++;
-    if (counter == tpcinvocations) {
+    if (tpcinvocations == 0 || counter == tpcinvocations) {
       finished = true;
     }
   };


### PR DESCRIPTION
We should only digitize detectors which are present in the simulation
file (or which are set as active in the GRP).
This commit makes a first step into this direction by reading
the GRP at startup to influence the workflow setup.

It is hence now possible to start the workflow for selected
components only.
A second way to influence this, might be added later via command line
arguments.

This is related to https://alice.its.cern.ch/jira/browse/O2-356.