### PR TITLE
DPL: rework data dispatching event loop

### DIFF
--- a/Framework/Core/include/Framework/DataProcessingDevice.h
+++ b/Framework/Core/include/Framework/DataProcessingDevice.h
@@ -47,6 +47,7 @@ class DataProcessingDevice : public FairMQDevice
 
  protected:
   bool handleData(FairMQParts&);
+  bool tryDispatchComputation();
   void error(const char* msg);
 
  private:


### PR DESCRIPTION
This will allow to dispatch computation also on non FairMQ data
triggered transitions like a timer or a fetch via curl.