### PR TITLE
Updating RAWDataHeader to version 3

### DIFF
--- a/DataFormats/Headers/include/Headers/RAWDataHeader.h
+++ b/DataFormats/Headers/include/Headers/RAWDataHeader.h
@@ -20,17 +20,130 @@
 namespace o2 {
 namespace header {
 
-/// The definition of the RAW Data Header v2 (RDH) is specified in
+/// The definition of the RAW Data Header is specified in
 /// https://docs.google.com/document/d/1IxCCa1ZRpI3J9j3KCmw2htcOLIRVVdEcO-DDPcLNFM0
 /// preliminary description of the fields can be found here
-/// https://docs.google.com/document/d/1FLcBrPaF3Bg1Pnm17nwaxNlenKtEk3ocizEAiGP58J8
+/// https://docs.google.com/document/d/1otkSDYasqpVBDnxplBI7dWNxaZohctA-bvhyrzvtLoQ
 /// FIXME: replace citation with correct ALICE note reference when published
 ///
 /// Note: the definition requires little endian architecture, for the moment we
 /// assume that this is the only type the software has to support (based on
 /// experience with previous systems)
 ///
-/// RDH consists of 4 64 bit words
+/// RDH v3 consists of 4 64 bit words, each of the words is extended to 128 bits
+/// by the CRU
+/// https://docs.google.com/document/d/1otkSDYasqpVBDnxplBI7dWNxaZohctA-bvhyrzvtLoQ
+/// accessed on Sep 12 2018, a pdf version is available under this link
+/// https://alice-o2-project.web.cern.ch/_webdav/files/pdf/RDH%20V3_2.pdf
+///
+///
+///       63     56      48      40      32      24      16       8       0
+///       |---------------|---------------|---------------|---------------|
+///
+///       |reserve| prior |                               |    header     |
+/// 0     | zero  |ity bit|    FEE id     | block length  | size  | vers  |
+///
+/// 1     |         reserved     |link id |  memory size  |offset nxt pack|
+///
+/// 2     |      heartbeat orbit          |       trigger orbit           |
+///
+/// 3     |                          reserved                             |
+///
+/// 4     |res|   HB BC   |res|trigger BC |      trigger type             |
+///
+/// 5     |                          reserved                             |
+///
+/// 6     | detector par  |detector field |res|    page count     | stop  |
+///
+/// 5     |                          reserved                             |
+///
+/// Field 1,3,5,7 are reserved fields and added to extend each word to 128 bit,
+/// marked grey in the documentation to indicate that those fields must be zero.
+/// In contrast to the description, word 1 has some labeled fields, so this
+/// has to be clarifid.
+///
+/// Field description:
+/// -  8 header version: the header version number
+/// -  8 header size:    the header size, number of 64 bit words
+/// - 16 block length:   assumed to be in byte, but discussion not yet finalized
+/// - 16 FEE ID:         unique id of the Frontend equipment
+/// -  8 priority bit:   indicates packet packet transport of higher priority
+/// - 16 next package:   not documented (offset of next package?)
+/// - 16 memory size:    not documented
+/// -  8 Link ID:        not documented
+/// - 32 trigger orbit:  trigger timing
+/// - 32 heartbeat orbit: heartbeat timing
+/// - 32 trigger type:   bit fiels for the trigger type yet to be decided
+/// - 12 trigger BC:     bunch crossing parameter for trigger
+/// - 12 beartbeat BC:   bunch crossing parameter for heartbeat
+/// -  8 stop:           bit 0 of the stop field is set if this is the last page
+/// - 16 page count:     incremented if data is bigger than the page size, pages are
+///                      incremented starting from 0
+/// - 16 detector field: detector specific field
+/// - 16 detector par:   detector specific field
+struct RAWDataHeaderV3 {
+  union {
+    // default value
+    uint64_t word0 = 0x0000ffff00000803;
+    //                   | | | |     | version 3
+    //                   | | | |   | 8 64 bit words
+    //                   | | | | block length 0
+    //                   | | invalid FEE id
+    //                   | priority bit 0
+    struct {
+      uint64_t version : 8;        /// bit  0 to  7: header version
+      uint64_t headerSize : 8;     /// bit  9 to 15: header size
+      uint64_t blockLength : 16;   /// bit 16 to 31: block length
+      uint64_t feeId : 16;         /// bit 32 to 47: FEE identifier
+      uint64_t priority : 8;       /// bit 48 to 55: priority bit
+      uint64_t zero0 : 8;          /// bit 56 to 63: zeroed
+    };                             ///
+  };                               ///
+  union {                          ///
+    uint64_t word1 = 0x0;          /// bit  0 to 63: zeroed
+  };                               ///
+  union {                          ///
+    uint64_t word2 = 0x0;          ///
+    struct {                       ///
+      uint32_t triggerOrbit;       /// bit 0 to 31: trigger orbit
+      uint32_t heartbeatOrbit;     /// bit 32 to 63: trigger orbit
+    };                             ///
+  };                               ///
+  union {                          ///
+    uint64_t word3 = 0x0;          /// bit  0 to 63: zeroed
+  };                               ///
+  union {                          ///
+    uint64_t word4 = 0x0;          ///
+    struct {                       ///
+      uint64_t triggerType : 32;   /// bit  0 to 31: trigger type
+      uint64_t triggerBC : 12;     /// bit 32 to 43: trigger BC ID
+      uint64_t zero41 : 4;         /// bit 44 to 47: zeroed
+      uint64_t heartbeatBC : 12;   /// bit 48 to 59: heartbeat BC ID
+      uint64_t zero42 : 4;         /// bit 60 to 63: zeroed
+    };                             ///
+  };                               ///
+  union {                          ///
+    uint64_t word5 = 0x0;          /// bit  0 to 63: zeroed
+  };                               ///
+  union {                          ///
+    uint64_t word6 = 0x0;          ///
+    struct {                       ///
+      uint64_t stop : 8;           /// bit  0 to  7: stop code
+      uint64_t pageCnt : 16;       /// bit  8 to 23: pages counter
+      uint64_t zero6 : 8;          /// bit 24 to 31: zeroed
+      uint64_t detectorField : 16; /// bit 32 to 47: detector field
+      uint64_t par : 16;           /// bit 48 to 63: par
+    };
+  };
+  union {
+    uint64_t word7 = 0x0; /// bit  0 to 63: zeroed
+  };
+};
+
+/// RDH v2
+/// this is the version 2 definition which probably has not been adapted by any FEE
+/// https://docs.google.com/document/d/1FLcBrPaF3Bg1Pnm17nwaxNlenKtEk3ocizEAiGP58J8
+///
 ///       63     56      48      40      32      24      16       8       0
 ///       |---------------|---------------|---------------|---------------|
 ///
@@ -51,7 +164,7 @@ namespace header {
 /// - heartbeat and trigger orbit/BC: LHC clock parameters, still under
 ///                 discussion whether separate fields for HB and trigger
 ///                 information needed
-/// - trigger type: bit fiels fir the trigger type yet to be decided
+/// - trigger type: bit fiels for the trigger type yet to be decided
 /// - page count:   incremented if data is bigger than the page size, pages are
 ///                 incremented starting from 0
 /// - stop:         bit 0 of the stop field is set if this is the last page
@@ -103,8 +216,7 @@ struct RAWDataHeaderV2
   };
 };
 
-using RAWDataHeader = RAWDataHeaderV2;
-
+using RAWDataHeader = RAWDataHeaderV3;
 }
 }
 

--- a/DataFormats/Headers/test/test_RAWDataHeader.cxx
+++ b/DataFormats/Headers/test/test_RAWDataHeader.cxx
@@ -19,64 +19,79 @@ using RDH = o2::header::RAWDataHeader;
 
 BOOST_AUTO_TEST_CASE(test_rdh)
 {
-  static_assert(sizeof(RDH) == 32, "the RAWDataHeader is supposed to be 256 bit");
+  static_assert(sizeof(RDH) == 64, "the RAWDataHeader is supposed to be 512 bit");
 
   // check the defaults
   RDH defaultRDH;
-  BOOST_CHECK(defaultRDH.version == 2);
+  BOOST_CHECK(defaultRDH.version == 3);
   BOOST_CHECK(defaultRDH.blockLength == 0);
   BOOST_CHECK(defaultRDH.feeId == 0xffff);
-  BOOST_CHECK(defaultRDH.linkId == 0xff);
-  BOOST_CHECK(defaultRDH.headerSize == 4); // header size in 64 bit words
+  //BOOST_CHECK(defaultRDH.linkId == 0xff);
+  BOOST_CHECK(defaultRDH.headerSize == 8); // header size in 64 bit words
 
   using byte = unsigned char;
   std::array<byte, sizeof(RDH)> buffer;
   buffer.fill(0);
 
-  buffer[0] = 0x2; // set version 2
-  buffer[1] = 0x6;
-  buffer[2] = 0x1;
-  buffer[3] = 0xad;
-  buffer[4] = 0xde;
-  buffer[5] = 0xaf;
-  buffer[6] = 0x04;
+  buffer[0] = 0x3;  // set version 3
+  buffer[1] = 0x08; // header size 8 64 bit words
+  buffer[2] = 0x6;
+  buffer[3] = 0x1;
+  buffer[4] = 0xad;
+  buffer[5] = 0xde;
+  buffer[6] = 0;
   buffer[7] = 0;
 
-  buffer[16] = 0x23;
-  buffer[17] = 0x71;
-  buffer[18] = 0x98;
-  buffer[19] = 0xba;
-  buffer[20] = 0xdc;
-  buffer[21] = 0x3e;
-  buffer[22] = 0x12;
-  buffer[23] = 0;
+  // do not set anything in words 1,2, and 3
 
-  buffer[24] = 0x0f;
-  buffer[25] = 0xd0;
-  buffer[26] = 0;
-  buffer[27] = 0xad;
-  buffer[28] = 0xde;
-  buffer[29] = 0;
+  buffer[32] = 0x23;
+  buffer[33] = 0x71;
+  buffer[34] = 0x98;
+  buffer[35] = 0xba;
+  buffer[36] = 0xdc;
+  buffer[37] = 0x0e;
+  buffer[38] = 0x12;
+  buffer[39] = 0x0a;
+
+  // do not set anything in word 5
+
+  buffer[48] = 0x00;
+  buffer[49] = 0x0f;
+  buffer[50] = 0xd0;
+  buffer[51] = 0x00;
+  buffer[52] = 0xad;
+  buffer[53] = 0xde;
+  buffer[54] = 0;
+  buffer[55] = 0;
+
+  // do not set anything in word 7
 
   auto rdh = reinterpret_cast<RDH*>(buffer.data());
 
   // if the tests fail, we are probbaly on a big endian architecture or
   // there are alignment issues
-  BOOST_CHECK(rdh->version == 2);
+  BOOST_CHECK(rdh->version == 3);
   BOOST_CHECK(rdh->blockLength == 262);
   BOOST_CHECK(rdh->feeId == 0xdead);
-  BOOST_CHECK(rdh->linkId == 0xaf);
-  BOOST_CHECK(rdh->headerSize == 4);
+  //BOOST_CHECK(rdh->linkId == 0xaf);
+  BOOST_CHECK(rdh->headerSize == 8);
+  BOOST_CHECK(rdh->priority == 0);
   BOOST_CHECK(rdh->zero0 == 0);
+  BOOST_CHECK(rdh->word1 == 0);
+  BOOST_CHECK(rdh->word2 == 0);
+  BOOST_CHECK(rdh->word3 == 0);
   BOOST_CHECK(rdh->triggerOrbit == 0);
   BOOST_CHECK(rdh->heartbeatOrbit == 0);
-  BOOST_CHECK(rdh->triggerBC == 0x123);
-  BOOST_CHECK(rdh->triggerType == 0xedcba987);
-  BOOST_CHECK(rdh->heartbeatBC == 0x123);
-  BOOST_CHECK(rdh->zero2 == 0);
+  BOOST_CHECK(rdh->triggerType == 0xba987123);
+  BOOST_CHECK(rdh->triggerBC == 0xedc);
+  BOOST_CHECK(rdh->heartbeatBC == 0xa12);
+  BOOST_CHECK(rdh->zero41 == 0);
+  BOOST_CHECK(rdh->zero42 == 0);
+  BOOST_CHECK(rdh->word5 == 0);
   BOOST_CHECK(rdh->pageCnt == 0xd00f);
   BOOST_CHECK(rdh->stop == 0);
   BOOST_CHECK(rdh->detectorField == 0xdead);
   BOOST_CHECK(rdh->par == 0);
-  BOOST_CHECK(rdh->zero3 == 0);
+  BOOST_CHECK(rdh->zero6 == 0);
+  BOOST_CHECK(rdh->word7 == 0);
 }


### PR DESCRIPTION
RDH v3 consists of 4 64 bit words, each of the words is extended to 128 bits by the CRU
https://docs.google.com/document/d/1otkSDYasqpVBDnxplBI7dWNxaZohctA-bvhyrzvtLoQ
accessed on Sep 12 2018, a pdf version is available under this link
https://alice-o2-project.web.cern.ch/_webdav/files/pdf/RDH%20V3_2.pdf