### PR TITLE
Cleanup and update of data compression utilities

### DIFF
--- a/Common/Utils/CMakeLists.txt
+++ b/Common/Utils/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SRCS
   src/TreeStream.cxx
   src/TreeStreamRedirector.cxx
   src/RootChain.cxx
+  src/CompStream.cxx
 )
 
 Set(HEADERS
@@ -24,6 +25,7 @@ O2_GENERATE_LIBRARY()
 set(TEST_SRCS
   test/testTreeStream.cxx
   test/testBoostSerializer.cxx
+  test/testCompStream.cxx
 )
 
 O2_GENERATE_TESTS(

--- a/Common/Utils/include/CommonUtils/CompStream.h
+++ b/Common/Utils/include/CommonUtils/CompStream.h
@@ -1,0 +1,125 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/* Local Variables:  */
+/* mode: c++         */
+/* End:              */
+
+#ifndef COMPSTREAM_H
+#define COMPSTREAM_H
+
+/// @file   CompStream.h
+/// @author Matthias Richter
+/// @since  2018-08-28
+/// @brief  Implementation of iostreams with compression filter
+
+#include <istream>
+#include <fstream>
+#include <ostream>
+#include <string>
+#include <boost/iostreams/filtering_streambuf.hpp>
+
+namespace o2
+{
+namespace io
+{
+
+enum class CompressionMethod {
+  None,
+  Gzip,
+  Zlib,
+  Bzip2,
+  Lzma
+};
+
+/**
+ * @class icomp_stream
+ * An istream variant allowing to add compression filters.
+ *
+ * This stream can be used transparently as std::istream while providing decompression
+ * directly on the backend stream/file.
+ *
+ * Implementation is based on boost::iostreams utilities, the filtered_streambuf
+ * and compression filters. Currently supporting gzip, zlib, bzip2, and lzma algorithms.
+ * The algorithm is specified either by enum or string to the constructor.
+ */
+class icomp_stream : public std::istream
+{
+ public:
+  using streambuffer_t = boost::iostreams::filtering_streambuf<boost::iostreams::input>;
+
+  /// constructor
+  /// @param filename name of the file to read from
+  /// @param method   compression method specified by enum
+  icomp_stream(std::string filename, CompressionMethod method = CompressionMethod::None);
+
+  /// constructor
+  /// @param backend the stream to read data from
+  /// @param method  compression method specified by enum
+  icomp_stream(std::istream& backend, CompressionMethod method = CompressionMethod::None);
+
+  /// constructor
+  /// @param filename name of the file to read from
+  /// @param method   compression method specified by string: gzip, zlib, bzip2, lzma
+  icomp_stream(std::string filename, std::string method);
+
+  /// constructor
+  /// @param backend the stream to read data from
+  /// @param method  compression method specified by string: gzip, zlib, bzip2, lzma
+  icomp_stream(std::istream& backend, std::string method);
+
+ private:
+  streambuffer_t mStreamBuffer;
+  std::ifstream mInputFile;
+};
+
+/**
+ * @class ocomp_stream
+ * An ostream variant allowing to add compression filters.
+ *
+ * This stream can be used transparently as std::ostream while providing compression
+ * directly on the backend stream/file.
+ *
+ * Implementation is based on boost::iostreams utilities, the filtered_streambuf
+ * and compression filters. Currently supporting gzip, zlib, bzip2, and lzma algorithms.
+ * The algorithm is specified either by enum or string to the constructor.
+ */
+class ocomp_stream : public std::ostream
+{
+ public:
+  using streambuffer_t = boost::iostreams::filtering_streambuf<boost::iostreams::output>;
+
+  /// constructor
+  /// @param filename name of the file to read from
+  /// @param method   compression method specified by enum
+  ocomp_stream(std::string filename, CompressionMethod method = CompressionMethod::None);
+
+  /// constructor
+  /// @param backend the stream to read data from
+  /// @param method  compression method specified by enum
+  ocomp_stream(std::ostream& backend, CompressionMethod method = CompressionMethod::None);
+
+  /// constructor
+  /// @param filename name of the file to read from
+  /// @param method   compression method specified by string: gzip, zlib, bzip2, lzma
+  ocomp_stream(std::string filename, std::string method);
+
+  /// constructor
+  /// @param backend the stream to read data from
+  /// @param method  compression method specified by string: gzip, zlib, bzip2, lzma
+  ocomp_stream(std::ostream& backend, std::string method);
+
+ private:
+  streambuffer_t mStreamBuffer;
+};
+
+} // namespace io
+} // namespace o2
+#endif // COMPSTREAM_H

--- a/Common/Utils/src/CompStream.cxx
+++ b/Common/Utils/src/CompStream.cxx
@@ -1,0 +1,154 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   CompStream.cxx
+/// @author Matthias Richter
+/// @since  2018-08-28
+/// @brief  Implementation of iostreams with compression filter
+
+#include "CommonUtils/CompStream.h"
+#include <boost/iostreams/device/file.hpp>
+#include <boost/iostreams/stream.hpp>
+#include <boost/iostreams/copy.hpp>
+#include <boost/iostreams/filter/gzip.hpp>
+#include <boost/iostreams/filter/zlib.hpp>
+#include <boost/iostreams/filter/bzip2.hpp>
+#include <boost/iostreams/filter/lzma.hpp>
+#include <map>
+#include <stdexcept>
+
+namespace o2
+{
+namespace io
+{
+
+namespace CompStreamHelpers
+{
+template <typename T>
+void pushDecompressor(T& stream, CompressionMethod method)
+{
+  switch (method) {
+    case CompressionMethod::Gzip:
+      stream.push(boost::iostreams::gzip_decompressor());
+      break;
+    case CompressionMethod::Zlib:
+      stream.push(boost::iostreams::zlib_decompressor());
+      break;
+    case CompressionMethod::Lzma:
+      stream.push(boost::iostreams::lzma_decompressor());
+      break;
+    case CompressionMethod::Bzip2:
+      stream.push(boost::iostreams::bzip2_decompressor());
+      break;
+    case CompressionMethod::None:
+      break;
+    default:
+      throw std::invalid_argument("missing implementation");
+  }
+}
+
+template <typename T>
+void pushCompressor(T& stream, CompressionMethod method)
+{
+  switch (method) {
+    case CompressionMethod::Gzip:
+      stream.push(boost::iostreams::gzip_compressor());
+      break;
+    case CompressionMethod::Zlib:
+      stream.push(boost::iostreams::zlib_compressor());
+      break;
+    case CompressionMethod::Lzma:
+      stream.push(boost::iostreams::lzma_compressor());
+      break;
+    case CompressionMethod::Bzip2:
+      stream.push(boost::iostreams::bzip2_compressor());
+      break;
+    case CompressionMethod::None:
+      break;
+    default:
+      throw std::invalid_argument("missing implementation");
+  }
+}
+
+const std::map<std::string, CompressionMethod> Mapping = {
+  { "none", CompressionMethod::None },
+  { "gzip", CompressionMethod::Gzip },
+  { "zlib", CompressionMethod::Zlib },
+  { "bzip2", CompressionMethod::Bzip2 },
+  { "lzma", CompressionMethod::Lzma },
+};
+
+auto Method(std::string method)
+{
+  auto const& i = Mapping.find(method);
+  if (i == Mapping.end()) {
+    throw std::invalid_argument("invalid compression method: " + method);
+  }
+  return i->second;
+}
+}
+
+icomp_stream::icomp_stream(std::string filename, CompressionMethod method)
+  : mStreamBuffer(), mInputFile(filename, std::ios_base::in | std::ios_base::binary), std::istream(&mStreamBuffer)
+{
+  CompStreamHelpers::pushDecompressor(mStreamBuffer, method);
+  mStreamBuffer.push(mInputFile);
+}
+
+icomp_stream::icomp_stream(std::istream& backend, CompressionMethod method)
+  : mStreamBuffer(), mInputFile(), std::istream(&mStreamBuffer)
+{
+  CompStreamHelpers::pushDecompressor(mStreamBuffer, method);
+  mStreamBuffer.push(backend);
+}
+
+icomp_stream::icomp_stream(std::string filename, std::string method)
+  : mStreamBuffer(), mInputFile(filename, std::ios_base::in | std::ios_base::binary), std::istream(&mStreamBuffer)
+{
+  CompStreamHelpers::pushDecompressor(mStreamBuffer, CompStreamHelpers::Method(method));
+  mStreamBuffer.push(mInputFile);
+}
+
+icomp_stream::icomp_stream(std::istream& backend, std::string method)
+  : mStreamBuffer(), mInputFile(), std::istream(&mStreamBuffer)
+{
+  CompStreamHelpers::pushDecompressor(mStreamBuffer, CompStreamHelpers::Method(method));
+  mStreamBuffer.push(backend);
+}
+
+ocomp_stream::ocomp_stream(std::string filename, CompressionMethod method)
+  : mStreamBuffer(), std::ostream(&mStreamBuffer)
+{
+  CompStreamHelpers::pushCompressor(mStreamBuffer, method);
+  mStreamBuffer.push(boost::iostreams::file_sink(filename));
+}
+
+ocomp_stream::ocomp_stream(std::ostream& backend, CompressionMethod method)
+  : mStreamBuffer(), std::ostream(&mStreamBuffer)
+{
+  CompStreamHelpers::pushCompressor(mStreamBuffer, method);
+  mStreamBuffer.push(backend);
+}
+
+ocomp_stream::ocomp_stream(std::string filename, std::string method)
+  : mStreamBuffer(), std::ostream(&mStreamBuffer)
+{
+  CompStreamHelpers::pushCompressor(mStreamBuffer, CompStreamHelpers::Method(method));
+  mStreamBuffer.push(boost::iostreams::file_sink(filename));
+}
+
+ocomp_stream::ocomp_stream(std::ostream& backend, std::string method)
+  : mStreamBuffer(), std::ostream(&mStreamBuffer)
+{
+  CompStreamHelpers::pushCompressor(mStreamBuffer, CompStreamHelpers::Method(method));
+  mStreamBuffer.push(backend);
+}
+}
+}

--- a/Common/Utils/test/testCompStream.cxx
+++ b/Common/Utils/test/testCompStream.cxx
@@ -1,0 +1,130 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   testCompStream.cxx
+/// @author Matthias Richter
+/// @since  2018-08-28
+/// @brief  unit tests for iostreams with compression filter
+
+#include "CommonUtils/CompStream.h"
+
+#define BOOST_TEST_MODULE CompStream unit test
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include <boost/filesystem.hpp>
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+
+BOOST_AUTO_TEST_CASE(test_compstream_filesink)
+{
+  const int range = 100;
+  std::stringstream filename;
+  filename << boost::filesystem::temp_directory_path().string() << "/" << boost::filesystem::unique_path().string()
+           << "_testCompStream.gz";
+  {
+    o2::io::ocomp_stream stream(filename.str().c_str(), o2::io::CompressionMethod::Gzip);
+    for (int i = 0; i < range; i++) {
+      stream << i;
+      if (i % 2) {
+        stream << " ";
+      } else {
+        stream << std::endl;
+      }
+    }
+    stream << std::endl;
+    stream.flush();
+  }
+
+  {
+    o2::io::icomp_stream stream(filename.str(), o2::io::CompressionMethod::Gzip);
+    int val;
+    int expected = 0;
+    while (stream >> val) {
+      BOOST_CHECK(val == expected);
+      if (val != expected) {
+        break;
+      }
+      ++expected;
+    }
+    BOOST_CHECK(expected == range);
+  }
+
+  boost::filesystem::remove(filename.str());
+}
+
+BOOST_AUTO_TEST_CASE(test_compstream_methods)
+{
+  auto checker = [](o2::io::CompressionMethod method) {
+    std::stringstream pipe;
+    {
+      o2::io::ocomp_stream stream(pipe, method);
+      for (int i = 0; i < 4; i++) {
+        stream << i;
+        stream << " ";
+      }
+      stream << std::endl;
+    }
+
+    {
+      o2::io::icomp_stream stream(pipe, method);
+      int val;
+      int expected = 0;
+      while (stream >> val) {
+        BOOST_CHECK(val == expected);
+        if (val != expected) {
+          return false;
+        }
+        ++expected;
+      }
+    }
+    return true;
+  };
+
+  BOOST_REQUIRE(checker(o2::io::CompressionMethod::Gzip));
+  BOOST_REQUIRE(checker(o2::io::CompressionMethod::Zlib));
+  BOOST_REQUIRE(checker(o2::io::CompressionMethod::Bzip2));
+  BOOST_REQUIRE(checker(o2::io::CompressionMethod::Lzma));
+}
+
+BOOST_AUTO_TEST_CASE(test_compstream_methods_mapper)
+{
+  auto checker = [](o2::io::CompressionMethod outputmethod, std::string inputmethod) {
+    std::stringstream pipe;
+    {
+      o2::io::ocomp_stream stream(pipe, outputmethod);
+      for (int i = 0; i < 4; i++) {
+        stream << i;
+        stream << " ";
+      }
+      stream << std::endl;
+    }
+
+    {
+      o2::io::icomp_stream stream(pipe, inputmethod);
+      int val;
+      int expected = 0;
+      while (stream >> val) {
+        BOOST_CHECK(val == expected);
+        if (val != expected) {
+          return false;
+        }
+        ++expected;
+      }
+    }
+    return true;
+  };
+
+  BOOST_REQUIRE(checker(o2::io::CompressionMethod::Gzip, "gzip"));
+  BOOST_REQUIRE(checker(o2::io::CompressionMethod::Zlib, "zlib"));
+  BOOST_REQUIRE(checker(o2::io::CompressionMethod::Bzip2, "bzip2"));
+  BOOST_REQUIRE(checker(o2::io::CompressionMethod::Lzma, "lzma"));
+}

--- a/Utilities/DataCompression/CMakeLists.txt
+++ b/Utilities/DataCompression/CMakeLists.txt
@@ -10,7 +10,7 @@ set(SRCS
 
 set(LIBRARY_NAME ${MODULE_NAME})
 
-set(BUCKET_NAME common_boost_bucket)
+set(BUCKET_NAME utility_datacompression_bucket)
 
 #O2_GENERATE_LIBRARY()
 

--- a/Utilities/DataCompression/include/DataCompression/CodingModelDispatcher.h
+++ b/Utilities/DataCompression/include/DataCompression/CodingModelDispatcher.h
@@ -31,6 +31,8 @@ using namespace gNeric;
 
 namespace o2
 {
+namespace data_compression
+{
 
 /**
  * @class CodingModelDispatcher Runtime dispatcher interface
@@ -371,6 +373,7 @@ class CodingModelDispatcher
   container_type mContainer;
 };
 
-}; // namespace o2
+} // namespace data_compression
+} // namespace o2
 
 #endif

--- a/Utilities/DataCompression/include/DataCompression/CodingModelDispatcher.h
+++ b/Utilities/DataCompression/include/DataCompression/CodingModelDispatcher.h
@@ -8,26 +8,17 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-//-*- Mode: C++ -*-
+/* Local Variables:  */
+/* mode: c++         */
+/* End:              */
 
 #ifndef CODINGMODELDISPATCHER_H
 #define CODINGMODELDISPATCHER_H
-//****************************************************************************
-//* This file is free software: you can redistribute it and/or modify        *
-//* it under the terms of the GNU General Public License as published by     *
-//* the Free Software Foundation, either version 3 of the License, or        *
-//* (at your option) any later version.                                      *
-//*                                                                          *
-//* Primary Authors: Matthias Richter <richterm@scieq.net>                   *
-//*                                                                          *
-//* The authors make no claims about the suitability of this software for    *
-//* any purpose. It is provided "as is" without express or implied warranty. *
-//****************************************************************************
 
-//  @file   CodingModelDispatcher.h
-//  @author Matthias Richter
-//  @since  2016-09-11
-//  @brief  Runtime dispatcher interface for probability model definitions
+/// @file   CodingModelDispatcher.h
+/// @author Matthias Richter
+/// @since  2016-09-11
+/// @brief  Runtime dispatcher interface for probability model definitions
 
 #include "mpl_tools.h"
 #include "runtime_container.h"

--- a/Utilities/DataCompression/include/DataCompression/DataDeflater.h
+++ b/Utilities/DataCompression/include/DataCompression/DataDeflater.h
@@ -182,7 +182,7 @@ class DataDeflater
   Codec mCodec;
 };
 
-}; // namespace data_compression
-}; // namespace o2
+} // namespace data_compression
+} // namespace o2
 
 #endif

--- a/Utilities/DataCompression/include/DataCompression/DataDeflater.h
+++ b/Utilities/DataCompression/include/DataCompression/DataDeflater.h
@@ -8,24 +8,17 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+/* Local Variables:  */
+/* mode: c++         */
+/* End:              */
+
 #ifndef DATADEFLATER_H
 #define DATADEFLATER_H
-//****************************************************************************
-//* This file is free software: you can redistribute it and/or modify        *
-//* it under the terms of the GNU General Public License as published by     *
-//* the Free Software Foundation, either version 3 of the License, or        *
-//* (at your option) any later version.                                      *
-//*                                                                          *
-//* Primary Authors: Matthias Richter <richterm@scieq.net>                   *
-//*                                                                          *
-//* The authors make no claims about the suitability of this software for    *
-//* any purpose. It is provided "as is" without express or implied warranty. *
-//****************************************************************************
 
-//  @file   DataDeflater.h
-//  @author Matthias Richter
-//  @since  2016-08-08
-//  @brief  A general data deflater
+/// @file   DataDeflater.h
+/// @author Matthias Richter
+/// @since  2016-08-08
+/// @brief  A general data deflater
 
 #include <cstdint>
 #include <cerrno>

--- a/Utilities/DataCompression/include/DataCompression/HuffmanCodec.h
+++ b/Utilities/DataCompression/include/DataCompression/HuffmanCodec.h
@@ -34,6 +34,8 @@
 
 namespace o2
 {
+namespace data_compression
+{
 
 /**
  * @class HuffmanNode
@@ -602,6 +604,7 @@ class HuffmanModel : public _BASE
   std::multiset<std::shared_ptr<node_type>, isless<std::shared_ptr<node_type>>> mTreeNodes;
 };
 
-}; // namespace o2
+} // namespace data_compression
+} // namespace o2
 
 #endif

--- a/Utilities/DataCompression/include/DataCompression/HuffmanCodec.h
+++ b/Utilities/DataCompression/include/DataCompression/HuffmanCodec.h
@@ -513,12 +513,6 @@ class HuffmanModel : public _BASE
       treeNodeConfiguration(int _index, int _left, int _right) : index(_index), left(_left), right(_right) {}
       int index, left, right;
       bool operator<(const treeNodeConfiguration& other) const { return index < other.index; }
-      struct less {
-        bool operator()(const treeNodeConfiguration& a, const treeNodeConfiguration& b) const
-        {
-          return a.index < b.index;
-        }
-      };
     };
     std::set<treeNodeConfiguration> treeNodeConfigurations;
     char firstChar = 0;
@@ -643,7 +637,7 @@ class HuffmanModel : public _BASE
     const _BASE& model = *this;
     NodeType* left = node->getLeftChild();
     NodeType* right = node->getRightChild();
-    if (left == NULL) {
+    if (left == nullptr) {
       typename _BASE::value_type value = _BASE::alphabet_type::getSymbol(node->getIndex());
       out << nodeIndex << " " << value << " " << model[value] << " " << node->getBinaryCodeLength() << " "
           << node->getBinaryCode() << std::endl;

--- a/Utilities/DataCompression/include/DataCompression/TruncatedPrecisionConverter.h
+++ b/Utilities/DataCompression/include/DataCompression/TruncatedPrecisionConverter.h
@@ -8,25 +8,18 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+/* Local Variables:  */
+/* mode: c++         */
+/* End:              */
+
 #ifndef TRUNCATEDPRECISIONCONVERTER_H
 #define TRUNCATEDPRECISIONCONVERTER_H
-//****************************************************************************
-//* This file is free software: you can redistribute it and/or modify        *
-//* it under the terms of the GNU General Public License as published by     *
-//* the Free Software Foundation, either version 3 of the License, or        *
-//* (at your option) any later version.                                      *
-//*                                                                          *
-//* Primary Authors: Matthias Richter <richterm@scieq.net>                   *
-//*                                                                          *
-//* The authors make no claims about the suitability of this software for    *
-//* any purpose. It is provided "as is" without express or implied warranty. *
-//****************************************************************************
 
-//  @file   TruncatedPrecisionConverter.h
-//  @author Matthias Richter
-//  @since  2016-08-08
-//  @brief  A simple converter producing truncated precision
-//          according to a parameter model
+/// @file   TruncatedPrecisionConverter.h
+/// @author Matthias Richter
+/// @since  2016-08-08
+/// @brief  A simple converter producing truncated precision
+///         according to a parameter model
 
 namespace o2
 {

--- a/Utilities/DataCompression/include/DataCompression/TruncatedPrecisionConverter.h
+++ b/Utilities/DataCompression/include/DataCompression/TruncatedPrecisionConverter.h
@@ -63,6 +63,6 @@ class TruncatedPrecisionConverter
   /// parameter model defines the conversion to the register type for writing bit pattern
   ParameterModelT mParameterModel;
 };
-}; // namespace data_compression
-}; // namespace o2
+} // namespace data_compression
+} // namespace o2
 #endif

--- a/Utilities/DataCompression/include/DataCompression/dc_primitives.h
+++ b/Utilities/DataCompression/include/DataCompression/dc_primitives.h
@@ -144,18 +144,20 @@ class ExampleAlphabet
   /// get the range of indices aka number of indices
   constexpr unsigned getIndexRange();
 
-  using _iterator_base = std::iterator<std::forward_iterator_tag, T>;
+  template <typename ValueT>
+  using _iterator_base = std::iterator<std::forward_iterator_tag, ValueT>;
 
   /// a forward iterator to access the list of elements
-  class iterator : public _iterator_base
+  template <typename ValueT>
+  class Iterator : public _iterator_base<ValueT>
   {
    public:
-    iterator();
-    ~iterator();
+    Iterator();
+    ~Iterator();
 
-    using self_type = iterator;
-    using reference = typename _iterator_base::reference;
-    using pointer = typename _iterator_base::pointer;
+    using self_type = Iterator;
+    using reference = typename _iterator_base<ValueT>::reference;
+    using pointer = typename _iterator_base<ValueT>::pointer;
 
     // prefix increment
     self_type& operator++();
@@ -173,6 +175,13 @@ class ExampleAlphabet
    private:
   };
 
+  using iterator = Iterator<value_type>;
+  using const_iterator = Iterator<const value_type>;
+
+  /// return forward iterator to begin of element list
+  const_iterator begin() const;
+  /// the end of element list
+  const_iterator end() const;
   /// return forward iterator to begin of element list
   iterator begin();
   /// the end of element list
@@ -235,19 +244,22 @@ class ContiguousAlphabet
   /// name is part of the type definition, defined as a boost mpl string
   constexpr const char* getName() const { return boost::mpl::c_str<NameT>::value; }
 
-  using _iterator_base = std::iterator<std::forward_iterator_tag, T>;
+  template <typename ValueT>
+  using _iterator_base = std::iterator<std::forward_iterator_tag, ValueT>;
 
   /// a forward iterator to access the list of elements
-  class iterator : public _iterator_base
+  template <typename ValueT>
+  class Iterator : public _iterator_base<ValueT>
   {
    public:
-    iterator() : mValue(_max), mIsEnd(true) {}
-    iterator(T value, bool isEnd) : mValue(value), mIsEnd(isEnd) {}
-    ~iterator() {}
+    Iterator() : mValue(_max), mIsEnd(true) {}
+    Iterator(T value, bool isEnd) : mValue(value), mIsEnd(isEnd) {}
+    ~Iterator() {}
 
-    using self_type = iterator;
-    using reference = typename _iterator_base::reference;
-    using pointer = typename _iterator_base::pointer;
+    using self_type = Iterator;
+    using value_type = typename _iterator_base<ValueT>::value_type;
+    using reference = typename _iterator_base<ValueT>::reference;
+    using pointer = typename _iterator_base<ValueT>::pointer;
 
     // prefix increment
     self_type& operator++()
@@ -291,9 +303,18 @@ class ContiguousAlphabet
     bool operator!=(const self_type& other) { return not(*this == other); }
 
    private:
-    T mValue;
+    value_type mValue;
     bool mIsEnd;
   };
+
+  using iterator = Iterator<value_type>;
+  using const_iterator = Iterator<const value_type>;
+
+  /// return forward iterator to begin of element list
+  const_iterator begin() const { return iterator(_min, false); }
+
+  /// the end of element list
+  const_iterator end() const { return iterator(_max, true); }
 
   /// return forward iterator to begin of element list
   iterator begin() { return iterator(_min, false); }
@@ -396,6 +417,10 @@ class ProbabilityModel
     static WeightType dummy = _default0;
     return dummy;
   }
+
+  typename TableType::const_iterator begin() const { return mProbabilityTable.begin(); }
+
+  typename TableType::const_iterator end() const { return mProbabilityTable.end(); }
 
   typename TableType::iterator begin() { return mProbabilityTable.begin(); }
 

--- a/Utilities/DataCompression/include/DataCompression/dc_primitives.h
+++ b/Utilities/DataCompression/include/DataCompression/dc_primitives.h
@@ -34,6 +34,11 @@
 #include <boost/mpl/range_c.hpp>
 #include <boost/mpl/string.hpp>
 
+namespace o2
+{
+namespace data_compression
+{
+
 //////////////////////////////////////////////////////////////////////////////
 //
 // General meta programming tools
@@ -403,4 +408,6 @@ class ProbabilityModel
   WeightType mTotalWeight;
 };
 
+} // namespace data_compression
+} // namespace o2
 #endif

--- a/Utilities/DataCompression/include/DataCompression/dc_primitives.h
+++ b/Utilities/DataCompression/include/DataCompression/dc_primitives.h
@@ -8,26 +8,17 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-//-*- Mode: C++ -*-
+/* Local Variables:  */
+/* mode: c++         */
+/* End:              */
 
 #ifndef DC_PRIMITIVES_H
 #define DC_PRIMITIVES_H
-//****************************************************************************
-//* This file is free software: you can redistribute it and/or modify        *
-//* it under the terms of the GNU General Public License as published by     *
-//* the Free Software Foundation, either version 3 of the License, or        *
-//* (at your option) any later version.                                      *
-//*                                                                          *
-//* Primary Authors: Matthias Richter <richterm@scieq.net>                   *
-//*                                                                          *
-//* The authors make no claims about the suitability of this software for    *
-//* any purpose. It is provided "as is" without express or implied warranty. *
-//****************************************************************************
 
-//  @file   dc_primitives.h
-//  @author Matthias Richter
-//  @since  2016-08-15
-//  @brief  Primitives for data compression
+/// @file   dc_primitives.h
+/// @author Matthias Richter
+/// @since  2016-08-15
+/// @brief  Primitives for data compression
 
 /**
  * The following template classes are defined

--- a/Utilities/DataCompression/test/DataGenerator.h
+++ b/Utilities/DataCompression/test/DataGenerator.h
@@ -10,22 +10,10 @@
 
 #ifndef DATAGENERATOR_H
 #define DATAGENERATOR_H
-//****************************************************************************
-//* This file is free software: you can redistribute it and/or modify        *
-//* it under the terms of the GNU General Public License as published by     *
-//* the Free Software Foundation, either version 3 of the License, or        *
-//* (at your option) any later version.                                      *
-//*                                                                          *
-//* Primary Authors: Matthias Richter <richterm@scieq.net>                   *
-//*                                                                          *
-//* The authors make no claims about the suitability of this software for    *
-//* any purpose. It is provided "as is" without express or implied warranty. *
-//****************************************************************************
-
-//  @file   DataGenerator.h
-//  @author Matthias Richter
-//  @since  2016-12-06
-//  @brief  A simple data generator
+/// @file   DataGenerator.h
+/// @author Matthias Richter
+/// @since  2016-12-06
+/// @brief  A simple data generator
 
 #include <stdexcept> // exeptions, range_error
 #include <utility>   // std::forward

--- a/Utilities/DataCompression/test/Fifo.h
+++ b/Utilities/DataCompression/test/Fifo.h
@@ -24,10 +24,10 @@
 //* any purpose. It is provided "as is" without express or implied warranty. *
 //****************************************************************************
 
-//  @file   Fifo.h
-//  @author Matthias Richter
-//  @since  2016-12-07
-//  @brief  Thread safe FIFO
+/// @file   Fifo.h
+/// @author Matthias Richter
+/// @since  2016-12-07
+/// @brief  Thread safe FIFO
 
 #include <queue>
 #include <mutex>

--- a/Utilities/DataCompression/test/test_DataGenerator.cxx
+++ b/Utilities/DataCompression/test/test_DataGenerator.cxx
@@ -8,22 +8,10 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-//****************************************************************************
-//* This file is free software: you can redistribute it and/or modify        *
-//* it under the terms of the GNU General Public License as published by     *
-//* the Free Software Foundation, either version 3 of the License, or        *
-//* (at your option) any later version.                                      *
-//*                                                                          *
-//* Primary Authors: Matthias Richter <richterm@scieq.net>                   *
-//*                                                                          *
-//* The authors make no claims about the suitability of this software for    *
-//* any purpose. It is provided "as is" without express or implied warranty. *
-//****************************************************************************
-
-//  @file   test_DataGenerator.cxx
-//  @author Matthias Richter
-//  @since  2016-12-06
-//  @brief  Test program for simple data generator
+/// @file   test_DataGenerator.cxx
+/// @author Matthias Richter
+/// @since  2016-12-06
+/// @brief  Test program for simple data generator
 
 #define BOOST_TEST_MODULE Utility test
 #define BOOST_TEST_MAIN

--- a/Utilities/DataCompression/test/test_Fifo.cxx
+++ b/Utilities/DataCompression/test/test_Fifo.cxx
@@ -8,22 +8,10 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-//****************************************************************************
-//* This file is free software: you can redistribute it and/or modify        *
-//* it under the terms of the GNU General Public License as published by     *
-//* the Free Software Foundation, either version 3 of the License, or        *
-//* (at your option) any later version.                                      *
-//*                                                                          *
-//* Primary Authors: Matthias Richter <richterm@scieq.net>                   *
-//*                                                                          *
-//* The authors make no claims about the suitability of this software for    *
-//* any purpose. It is provided "as is" without express or implied warranty. *
-//****************************************************************************
-
-//  @file   test_Fifo.cxx
-//  @author Matthias Richter
-//  @since  2016-12-06
-//  @brief  Test program for thread safe FIFO
+/// @file   test_Fifo.cxx
+/// @author Matthias Richter
+/// @since  2016-12-06
+/// @brief  Test program for thread safe FIFO
 
 #define BOOST_TEST_MODULE Utility test
 #define BOOST_TEST_MAIN

--- a/Utilities/DataCompression/test/test_HuffmanCodec.cxx
+++ b/Utilities/DataCompression/test/test_HuffmanCodec.cxx
@@ -28,6 +28,11 @@
 #include "DataGenerator.h"
 #include "Fifo.h"
 
+namespace o2
+{
+namespace data_compression
+{
+
 // a decoder process working on the FIFO of encoded data and comparing to
 // original data from the corresponding FIFO
 template <class RandvalStreamT, class EncodedStreamT, class CodecT>
@@ -53,6 +58,8 @@ void decoderProcess(RandvalStreamT& fifoRandvals, EncodedStreamT& fifoEncoded, C
   }));
 }
 
+using namespace o2::data_compression;
+
 BOOST_AUTO_TEST_CASE(test_HuffmanCodec)
 {
   // defining a contiguous alphabet of integral 16 bit unsigned numbers
@@ -73,7 +80,7 @@ BOOST_AUTO_TEST_CASE(test_HuffmanCodec)
   // third template parameter determines whether code has to be decoded
   // MSB to LSB (true) or LSB to MSB (false)
   using HuffmanModel_t =
-    o2::HuffmanModel<ProbabilityModel<SimpleRangeAlphabet_t>, std::bitset<32>, true>;
+    HuffmanModel<ProbabilityModel<SimpleRangeAlphabet_t>, std::bitset<32>, true>;
   HuffmanModel_t huffmanmodel;
 
   std::cout << std::endl << "Huffman probability model after initialization: " << std::endl;
@@ -101,7 +108,7 @@ BOOST_AUTO_TEST_CASE(test_HuffmanCodec)
   std::cout << std::endl << "Generating binary tree and Huffman codes" << std::endl;
   huffmanmodel.GenerateHuffmanTree();
   huffmanmodel.print();
-  using Codec_t = o2::HuffmanCodec<HuffmanModel_t>;
+  using Codec_t = HuffmanCodec<HuffmanModel_t>;
   Codec_t codec(huffmanmodel);
 
   ////////////////////////////////////////////////////////////////////////////
@@ -165,3 +172,6 @@ BOOST_AUTO_TEST_CASE(test_HuffmanCodec)
   decoderThread.join();
   std::cout << "... done" << std::endl;
 }
+
+} // namespace data_compression
+} // namespace o2

--- a/Utilities/DataCompression/test/test_HuffmanCodec.cxx
+++ b/Utilities/DataCompression/test/test_HuffmanCodec.cxx
@@ -8,24 +8,12 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-//****************************************************************************
-//* This file is free software: you can redistribute it and/or modify        *
-//* it under the terms of the GNU General Public License as published by     *
-//* the Free Software Foundation, either version 3 of the License, or        *
-//* (at your option) any later version.                                      *
-//*                                                                          *
-//* Primary Authors: Matthias Richter <richterm@scieq.net>                   *
-//*                                                                          *
-//* The authors make no claims about the suitability of this software for    *
-//* any purpose. It is provided "as is" without express or implied warranty. *
-//****************************************************************************
+/// @file   test_HuffmanCodec.cxx
+/// @author Matthias Richter
+/// @since  2016-08-11
+/// @brief  Test program for Huffman codec template class
 
-//  @file   test_HuffmanCodec.cxx
-//  @author Matthias Richter
-//  @since  2016-08-11
-//  @brief  Test program for Huffman codec template class
-
-#define BOOST_TEST_MODULE Utility test
+#define BOOST_TEST_MODULE HuffmanCodec unit test
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
@@ -40,6 +28,8 @@
 #include "DataGenerator.h"
 #include "Fifo.h"
 
+// a decoder process working on the FIFO of encoded data and comparing to
+// original data from the corresponding FIFO
 template <class RandvalStreamT, class EncodedStreamT, class CodecT>
 void decoderProcess(RandvalStreamT& fifoRandvals, EncodedStreamT& fifoEncoded, CodecT& codec)
 {
@@ -83,7 +73,7 @@ BOOST_AUTO_TEST_CASE(test_HuffmanCodec)
   // third template parameter determines whether code has to be decoded
   // MSB to LSB (true) or LSB to MSB (false)
   using HuffmanModel_t =
-    o2::HuffmanModel<ProbabilityModel<SimpleRangeAlphabet_t>, o2::HuffmanNode<std::bitset<32>>, true>;
+    o2::HuffmanModel<ProbabilityModel<SimpleRangeAlphabet_t>, std::bitset<32>, true>;
   HuffmanModel_t huffmanmodel;
 
   std::cout << std::endl << "Huffman probability model after initialization: " << std::endl;

--- a/Utilities/DataCompression/test/test_HuffmanCodec.cxx
+++ b/Utilities/DataCompression/test/test_HuffmanCodec.cxx
@@ -17,8 +17,10 @@
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
+#include <boost/filesystem.hpp>
 #include <iostream>
 #include <iomanip>
+#include <sstream>
 #include <vector>
 #include <bitset>
 #include <thread>
@@ -58,9 +60,49 @@ void decoderProcess(RandvalStreamT& fifoRandvals, EncodedStreamT& fifoEncoded, C
   }));
 }
 
-using namespace o2::data_compression;
+template <typename CodecT, typename GeneratorT>
+void checkRandom(CodecT& codec, GeneratorT& generator, int nRolls = 1000000)
+{
+  using ValueT = typename CodecT::value_type;
+  using CodeT = typename CodecT::code_type;
+  auto const& huffmanmodel = codec.getCodingModel();
 
-BOOST_AUTO_TEST_CASE(test_HuffmanCodec)
+  ////////////////////////////////////////////////////////////////////////////
+  // test loop for random values
+  //
+
+  // FIFO for the random numbers
+  o2::test::Fifo<ValueT> fifoRandvals;
+
+  // FIFO for encoded values
+  using FifoBuffer_t = o2::test::Fifo<uint32_t>;
+  FifoBuffer_t fifoEncoded;
+
+  int n = nRolls;
+  std::cout << std::endl
+            << "Testing encoding-decoding with " << nRolls << " random value(s) ..." << std::endl;
+
+  std::thread decoderThread([&]() { decoderProcess(fifoRandvals, fifoEncoded, codec); });
+
+  while (n-- > 0) {
+    uint16_t codeLen = 0;
+    CodeT code;
+    ValueT value = generator();
+    codec.Encode(value, code, codeLen);
+    fifoRandvals.push(value);
+    if (huffmanmodel.OrderMSB) {
+      code <<= (code.size() - codeLen);
+    }
+    fifoEncoded.push(code.to_ulong(), n == 0);
+    // std::cout << "encoded: " << std::setw(4) << value << " code: " << code << std::endl;
+  }
+
+  decoderThread.join();
+
+  std::cout << "... done" << std::endl;
+}
+
+auto setupCodec(int verbosity = 0)
 {
   // defining a contiguous alphabet of integral 16 bit unsigned numbers
   // in the range [-7, 10] including the upper bound
@@ -83,10 +125,13 @@ BOOST_AUTO_TEST_CASE(test_HuffmanCodec)
     HuffmanModel<ProbabilityModel<SimpleRangeAlphabet_t>, std::bitset<32>, true>;
   HuffmanModel_t huffmanmodel;
 
-  std::cout << std::endl << "Huffman probability model after initialization: " << std::endl;
   huffmanmodel.init(0.);
-  for (auto s : alphabet) {
-    std::cout << "val = " << std::setw(2) << s << " --> weight = " << huffmanmodel[s] << std::endl;
+  if (verbosity > 0) {
+    std::cout << std::endl
+              << "Huffman probability model after initialization: " << std::endl;
+    for (auto s : alphabet) {
+      std::cout << "val = " << std::setw(2) << s << " --> weight = " << huffmanmodel[s] << std::endl;
+    }
   }
 
   // add probabilities from data generator as weights for every symbol
@@ -96,81 +141,88 @@ BOOST_AUTO_TEST_CASE(test_HuffmanCodec)
 
   // normalizing the weight to the total weight thus having the probability
   // for every symbol
-  std::cout << std::endl << "Probabilities from DataGenerator:" << std::endl;
   huffmanmodel.normalize();
-  for (auto i : huffmanmodel) {
-    std::cout << "val = " << std::setw(2) << i.first << " --> weight = " << i.second << std::endl;
+  if (verbosity > 0) {
+    std::cout << std::endl
+              << "Probabilities from DataGenerator:" << std::endl;
+    for (auto i : huffmanmodel) {
+      std::cout << "val = " << std::setw(2) << i.first << " --> weight = " << i.second << std::endl;
+    }
   }
 
   ////////////////////////////////////////////////////////////////////////////
   // generate the Huffman tree in the Huffman model and create a Huffman
   // codec operating on the probability table
-  std::cout << std::endl << "Generating binary tree and Huffman codes" << std::endl;
   huffmanmodel.GenerateHuffmanTree();
-  huffmanmodel.print();
-  using Codec_t = HuffmanCodec<HuffmanModel_t>;
-  Codec_t codec(huffmanmodel);
+  if (verbosity > 0) {
+    std::cout << std::endl
+              << "Generating binary tree and Huffman codes" << std::endl;
+    huffmanmodel.print();
+  }
+  return std::pair<HuffmanCodec<HuffmanModel_t>, DataGenerator_t>(huffmanmodel, dg);
+}
+
+BOOST_AUTO_TEST_CASE(test_HuffmanCodec_basic)
+{
+  auto setup = setupCodec();
+  auto& codec = setup.first;
+  auto& dg = setup.second;
+  auto const& huffmanmodel = codec.getCodingModel();
+  using ValueT = decltype(setup.first)::value_type;
+  using CodeT = decltype(setup.first)::code_type;
 
   ////////////////////////////////////////////////////////////////////////////
   // print Huffman code summary and perform an encoding-decoding check for
   // every symbol
   std::cout << std::endl
-            << "Huffman code summary: " << (HuffmanModel_t::orderMSB ? "MSB to LSB" : "LSB to MSB") << std::endl;
-  for (auto i : huffmanmodel) {
+            << "Huffman code summary: " << (huffmanmodel.OrderMSB ? "MSB to LSB" : "LSB to MSB") << std::endl;
+  for (auto const& i : huffmanmodel) {
     uint16_t codeLen = 0;
-    HuffmanModel_t::code_type code;
+    CodeT code;
     codec.Encode(i.first, code, codeLen);
     std::cout << "value: " << std::setw(4) << i.first << "   code length: " << std::setw(3) << codeLen << "   code: ";
-    if (not HuffmanModel_t::orderMSB) {
+    if (not huffmanmodel.OrderMSB) {
       std::cout << std::setw(code.size() - codeLen);
     }
     for (int k = 0; k < codeLen; k++) {
       std::cout << code[codeLen - 1 - k];
     }
     std::cout << std::endl;
-    if (HuffmanModel_t::orderMSB) {
+    if (huffmanmodel.OrderMSB) {
       code <<= (code.size() - codeLen);
     }
     uint16_t decodedLen = 0;
-    HuffmanModel_t::value_type value;
+    ValueT value;
     codec.Decode(value, code, decodedLen);
     if (codeLen != decodedLen || value != i.first) {
       std::cout << "mismatch in decoded value: " << value << "(" << decodedLen << ")" << std::endl;
     }
   }
 
-  ////////////////////////////////////////////////////////////////////////////
-  // test loop for random values
-  //
+  checkRandom(codec, dg);
+}
 
-  // FIFO for the random numbers
-  o2::test::Fifo<DataGenerator_t::value_type> fifoRandvals;
+BOOST_AUTO_TEST_CASE(test_HuffmanCodec_configuration)
+{
+  auto setup = setupCodec();
+  auto& codec = setup.first;
+  auto& dg = setup.second;
+  auto const& huffmanmodel = codec.getCodingModel();
+  using ValueT = decltype(setup.first)::value_type;
+  using CodeT = decltype(setup.first)::code_type;
 
-  // FIFO for encoded values
-  using FifoBuffer_t = o2::test::Fifo<uint32_t>;
-  FifoBuffer_t fifoEncoded;
+  // check writing and reading of the huffman configuration
+  std::stringstream filename;
+  filename << boost::filesystem::temp_directory_path().string() << "/" << boost::filesystem::unique_path().string()
+           << "_testHuffmanCodec.zlib";
 
-  const int nRolls = 1000000;
-  int n = nRolls;
-  std::cout << std::endl << "Testing encoding-decoding with " << nRolls << " random value(s) ..." << std::endl;
+  auto nNodes = codec.writeConfiguration(filename.str().c_str(), "zlib");
+  BOOST_CHECK(nNodes > 0);
+  auto result = codec.loadConfiguration(filename.str().c_str(), "zlib");
+  BOOST_CHECK(result == 0);
+  boost::filesystem::remove(filename.str());
 
-  std::thread decoderThread([&]() { decoderProcess(fifoRandvals, fifoEncoded, codec); });
-
-  while (n-- > 0) {
-    uint16_t codeLen = 0;
-    HuffmanModel_t::code_type code;
-    DataGenerator_t::value_type value = dg();
-    codec.Encode(value, code, codeLen);
-    fifoRandvals.push(value);
-    if (HuffmanModel_t::orderMSB) {
-      code <<= (code.size() - codeLen);
-    }
-    fifoEncoded.push(code.to_ulong(), n == 0);
-    // std::cout << "encoded: " << std::setw(4) << value << " code: " << code << std::endl;
-  }
-
-  decoderThread.join();
-  std::cout << "... done" << std::endl;
+  checkRandom(codec, dg);
 }
 
 } // namespace data_compression

--- a/Utilities/DataCompression/test/test_dc_primitives.cxx
+++ b/Utilities/DataCompression/test/test_dc_primitives.cxx
@@ -8,6 +8,11 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+/// @file   test_dc_primitives.cxx
+/// @author Matthias Richter
+/// @since  2016-08-31
+/// @brief  Test program for dc_primitives tools
+
 #define BOOST_TEST_MODULE Utility test
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK

--- a/Utilities/DataCompression/test/test_dc_primitives.cxx
+++ b/Utilities/DataCompression/test/test_dc_primitives.cxx
@@ -28,6 +28,11 @@
 #include <iomanip>
 #include <vector>
 
+namespace o2
+{
+namespace data_compression
+{
+
 /**
  * TODO: would like to have a general Tester for different kinds
  * of meta programs, but did not succeed so far to define a templated
@@ -104,3 +109,6 @@ BOOST_AUTO_TEST_CASE(test_dc_primitives)
   using ParameterSet = boost::mpl::vector<TestAlphabet, TenBitAlphabet>;
   boost::mpl::for_each<ParameterSet>(AlphabetTester<std::vector<int16_t>>(values));
 }
+
+} // namespace data_compression
+} // namespace o2

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -49,7 +49,7 @@ find_package(HEPMC)
 # disable package for the moment
 #find_package(IWYU)
 
-find_package(Boost 1.59 COMPONENTS container thread system timer program_options random filesystem chrono exception regex serialization log log_setup unit_test_framework date_time signals REQUIRED)
+find_package(Boost 1.59 COMPONENTS container thread system timer program_options random filesystem chrono exception regex serialization log log_setup unit_test_framework date_time signals iostreams REQUIRED)
 # for the guideline support library
 include_directories(${MS_GSL_INCLUDE_DIR})
 
@@ -1733,6 +1733,7 @@ o2_define_bucket(
   Core Tree
   ReconstructionDataFormats # for test dependency only
   common_boost_bucket
+  Boost::iostreams
   DataFormatsMID
 
   INCLUDE_DIRECTORIES

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -2074,3 +2074,14 @@ o2_define_bucket(
     ${FAIRROOT_INCLUDE_DIR}
     ${ROOT_INCLUDE_DIR}
 )
+
+o2_define_bucket(
+    NAME
+    utility_datacompression_bucket
+
+    DEPENDENCIES
+    CommonUtils
+    common_boost_bucket
+
+    INCLUDE_DIRECTORIES
+)


### PR DESCRIPTION
Adding a stream interface for iostreams with compression filters based on boost::iostreams.

Small incremental update otherwise:
* cleanup license information
* cleanup namespaces and coding convention adjustments
* writing the Huffman configuration in compressed format
