### PR TITLE
DPL: saner rate for rate channel logger

### DIFF
--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -45,10 +45,11 @@ std::string inputChannel2String(const InputChannelSpec& channel)
   char buffer[32];
   auto addressFormat = ChannelSpecHelpers::methodAsUrl(channel.method);
 
-  result += "name=" + channel.name + ",";
-  result += std::string("type=") + ChannelSpecHelpers::typeAsString(channel.type) + ",";
-  result += std::string("method=") + ChannelSpecHelpers::methodAsString(channel.method) + ",";
-  result += std::string("address=") + (snprintf(buffer, 32, addressFormat, channel.port), buffer);
+  result += "name=" + channel.name;
+  result += std::string(",type=") + ChannelSpecHelpers::typeAsString(channel.type);
+  result += std::string(",method=") + ChannelSpecHelpers::methodAsString(channel.method);
+  result += std::string(",address=") + (snprintf(buffer, 32, addressFormat, channel.port), buffer);
+  result += std::string(",rateLogging=60");
 
   return result;
 }
@@ -59,10 +60,11 @@ std::string outputChannel2String(const OutputChannelSpec& channel)
   char buffer[32];
   auto addressFormat = ChannelSpecHelpers::methodAsUrl(channel.method);
 
-  result += "name=" + channel.name + ",";
-  result += std::string("type=") + ChannelSpecHelpers::typeAsString(channel.type) + ",";
-  result += std::string("method=") + ChannelSpecHelpers::methodAsString(channel.method) + ",";
-  result += std::string("address=") + (snprintf(buffer, 32, addressFormat, channel.port), buffer);
+  result += "name=" + channel.name;
+  result += std::string(",type=") + ChannelSpecHelpers::typeAsString(channel.type);
+  result += std::string(",method=") + ChannelSpecHelpers::methodAsString(channel.method);
+  result += std::string(",address=") + (snprintf(buffer, 32, addressFormat, channel.port), buffer);
+  result += std::string(",rateLogging=60");
 
   return result;
 }


### PR DESCRIPTION
Since real people are starting to use DPL, it turns out it is not
particularly user friendly, especially with many devices and without the
GUI, to have so many messages about the performance rate. As a quick fix
I hardcoded a saner value than the current one. This should probably be
made configurable in an easy way.