### PR TITLE
Temporarily removing the lzma support from CompStream

### DIFF
--- a/Common/Utils/src/CompStream.cxx
+++ b/Common/Utils/src/CompStream.cxx
@@ -20,7 +20,7 @@
 #include <boost/iostreams/filter/gzip.hpp>
 #include <boost/iostreams/filter/zlib.hpp>
 #include <boost/iostreams/filter/bzip2.hpp>
-#include <boost/iostreams/filter/lzma.hpp>
+//#include <boost/iostreams/filter/lzma.hpp>
 #include <map>
 #include <stdexcept>
 
@@ -42,7 +42,8 @@ void pushDecompressor(T& stream, CompressionMethod method)
       stream.push(boost::iostreams::zlib_decompressor());
       break;
     case CompressionMethod::Lzma:
-      stream.push(boost::iostreams::lzma_decompressor());
+      throw std::runtime_error("lzma support not enabled");
+      //stream.push(boost::iostreams::lzma_decompressor());
       break;
     case CompressionMethod::Bzip2:
       stream.push(boost::iostreams::bzip2_decompressor());
@@ -65,7 +66,8 @@ void pushCompressor(T& stream, CompressionMethod method)
       stream.push(boost::iostreams::zlib_compressor());
       break;
     case CompressionMethod::Lzma:
-      stream.push(boost::iostreams::lzma_compressor());
+      throw std::runtime_error("lzma support not enabled");
+      //stream.push(boost::iostreams::lzma_compressor());
       break;
     case CompressionMethod::Bzip2:
       stream.push(boost::iostreams::bzip2_compressor());

--- a/Common/Utils/test/testCompStream.cxx
+++ b/Common/Utils/test/testCompStream.cxx
@@ -92,7 +92,7 @@ BOOST_AUTO_TEST_CASE(test_compstream_methods)
   BOOST_REQUIRE(checker(o2::io::CompressionMethod::Gzip));
   BOOST_REQUIRE(checker(o2::io::CompressionMethod::Zlib));
   BOOST_REQUIRE(checker(o2::io::CompressionMethod::Bzip2));
-  BOOST_REQUIRE(checker(o2::io::CompressionMethod::Lzma));
+  //BOOST_REQUIRE(checker(o2::io::CompressionMethod::Lzma));
 }
 
 BOOST_AUTO_TEST_CASE(test_compstream_methods_mapper)
@@ -126,5 +126,5 @@ BOOST_AUTO_TEST_CASE(test_compstream_methods_mapper)
   BOOST_REQUIRE(checker(o2::io::CompressionMethod::Gzip, "gzip"));
   BOOST_REQUIRE(checker(o2::io::CompressionMethod::Zlib, "zlib"));
   BOOST_REQUIRE(checker(o2::io::CompressionMethod::Bzip2, "bzip2"));
-  BOOST_REQUIRE(checker(o2::io::CompressionMethod::Lzma, "lzma"));
+  //BOOST_REQUIRE(checker(o2::io::CompressionMethod::Lzma, "lzma"));
 }


### PR DESCRIPTION
Dependencies need to be resolved first. Lzma package is included in the
software stack already today, but not as a requirement for boost. Furthermore,
boost seems to use a different find procedure, as it does not find the package
in a non-system place.