### PR TITLE
[WIP] Implementing support for option lists and retrieval by vector

### DIFF
--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -311,6 +311,7 @@ o2_define_bucket(
 
     SYSTEMINCLUDE_DIRECTORIES
     ${CMAKE_SOURCE_DIR}/Utilities/PCG/include
+    ${CMAKE_SOURCE_DIR}/Algorithm/include
 )
 
 o2_define_bucket(


### PR DESCRIPTION
That is a possibility for supporting vectorized options, i.e. options with multiple parameters, here separated by comma. Maybe it is not the best place for the implementation, so it can be moved somewhere else (though the specialization overload for get<vector<>> needs to be there). Also the handling of the default value in the ConfigParamSpec is bound to string in order to specify a list or range. The actual retrieval to a vector of some type is independent from that.

- adding support for getting vector<T> from ConfigRegistry
- adding support for comma-separated option lists
- support ranges for integral types

Example:
  --some-option 1,2,3,5-9,11

can be retrieved as vector of ints.

Note: in order to specify a default option list, the parameter has to be
defined with type string to handle the default list as a string. Extraction
to the actual type is independent of this.