### PR TITLE
Update of TPC reco workflow

### DIFF
--- a/DataFormats/Detectors/TPC/CMakeLists.txt
+++ b/DataFormats/Detectors/TPC/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SRCS
    src/Helpers.cxx
    src/TrackTPC.cxx
    src/Cluster.cxx
+   src/TPCSectorHeader.cxx
 )
 
 set(HEADERS
@@ -21,6 +22,7 @@ set(HEADERS
    include/${MODULE_NAME}/Helpers.h
    include/${MODULE_NAME}/TrackTPC.h
    include/${MODULE_NAME}/Cluster.h
+   include/${MODULE_NAME}/TPCSectorHeader.h
    include/${MODULE_NAME}/Constants.h
    include/${MODULE_NAME}/Defs.h
 )

--- a/DataFormats/Detectors/TPC/CMakeLists.txt
+++ b/DataFormats/Detectors/TPC/CMakeLists.txt
@@ -22,7 +22,6 @@ set(HEADERS
    include/${MODULE_NAME}/Helpers.h
    include/${MODULE_NAME}/TrackTPC.h
    include/${MODULE_NAME}/Cluster.h
-   include/${MODULE_NAME}/TPCSectorHeader.h
    include/${MODULE_NAME}/Constants.h
    include/${MODULE_NAME}/Defs.h
 )

--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/TPCSectorHeader.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/TPCSectorHeader.h
@@ -12,12 +12,15 @@
 #define O2_TPCSECTORHEADER_H
 
 #include "Headers/DataHeader.h"
+#include "DataFormatsTPC/Constants.h"
 
 namespace o2
 {
-namespace tpc
+namespace TPC
 {
 
+/// @struct TPCSectorHeader
+/// TPC specific header to be transported on the header stack
 struct TPCSectorHeader : public o2::header::BaseHeader {
   // Required to do the lookup
   static const o2::header::HeaderType sHeaderType;
@@ -28,9 +31,18 @@ struct TPCSectorHeader : public o2::header::BaseHeader {
   {
   }
 
+  static constexpr int NSectors = o2::TPC::Constants::MAXSECTOR;
   int sector;
+  union {
+    uint64_t activeSectorsFlags = 0;
+    struct {
+      uint64_t activeSectors : NSectors;
+      uint64_t unused : 12;
+      uint64_t flags : 16;
+    };
+  };
 };
-} // namespace tpc
+} // namespace TPC
 } // namespace o2
 
 #endif // O2_TPCSECTORHEADER_H

--- a/DataFormats/Detectors/TPC/src/TPCSectorHeader.cxx
+++ b/DataFormats/Detectors/TPC/src/TPCSectorHeader.cxx
@@ -8,6 +8,6 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#include "TPCSectorHeader.h"
+#include "DataFormatsTPC/TPCSectorHeader.h"
 
-constexpr o2::header::HeaderType o2::tpc::TPCSectorHeader::sHeaderType = "TPCSectH";
+constexpr o2::header::HeaderType o2::TPC::TPCSectorHeader::sHeaderType = "TPCSectH";

--- a/Detectors/TPC/workflow/README.md
+++ b/Detectors/TPC/workflow/README.md
@@ -1,0 +1,76 @@
+# DPL workflows for the TPC
+
+## TPC reconstruction workflow
+The TPC reconstruction workflow starts from the TPC digits, the *clusterer* reconstructs clusters. Those are
+*converted* to RAW pages and passed onto the *decoder* providing the decoded (native) cluster format to the
+*tracker*.
+
+The workflow consists of the following DPL processors:
+
+* `digit-reader` -> using tool [o2::framework::RootTreeReader](../../../Framework/Utils/include/Utils/RootTreeReader.h)
+* `clusterer` -> interfaces [o2::TPC::HwClusterer](../reconstruction/include/TPCReconstruction/HwClusterer.h)
+* `converter` -> implements conversions to raw pages, to be moved to a worker class
+* `decoder` -> interfaces [o2::TPC::HardwareClusterDecoder](reconstruction/include/TPCReconstruction/HardwareClusterDecoder.h)
+* `tracker` -> interfaces [o2::TPC::TPCCATracking](reconstruction/include/TPCReconstruction/TPCCATracking.h)
+* `writer` -> implements simple writing to ROOT file
+
+Clusters are created and processed together with the MC labels, however track labels are not yet written
+to output file. This will come soon.
+
+### Input data
+The input can be created by running the simulation (`o2sim`) and the digitizer workflow (`digitizer-workflow`).
+The digitizer workflow produces the file `tpcdigits.root` by default, data is stored in separated branches for
+all sectors.
+
+### Quickstart running the reconstruction workflow
+The workflow is implemented in the `tpc-reco-workflow` executable.
+
+Display all options
+```
+tpc-reco-workflow --help
+```
+
+Important options for the `digit-reader` as initial publisher
+```
+--infile arg                          Name of the input file
+--treename arg (=o2sim)               Name of the input tree
+--digitbranch arg (=TPCDigit)         Digit branch
+--mcbranch arg (=TPCDigitMCTruth)     MC info branch
+--tpc-sectors arg (=0-35)             TPC sector range, e.g. 5-7,8,9
+```
+
+Examples:
+```
+tpc-reco-workflow --infile tpcdigits.root --tpc-sectors 0-15
+```
+
+```
+tpc-reco-workflow --infile tpcdigits.root --tpc-sectors 0-15 --disable-mc 1
+```
+
+### Global workflow options:
+```
+--input-type arg (=digits)            digits, clusters, raw
+--output-type arg (=tracks)           clusters, raw, tracks
+--disable-mc arg (=0)                 disable sending of MC information
+```
+Support for all other output types than `tracks` is going to be implemented soon, multiple outputs
+will be supported in order to keep the data at intermediate steps.
+
+### Current limitations
+* track labels not yet written to file
+* only the full workflow with input type `digits` and output type `tracks` has been tested so far
+* the propagation of MC labels goes together with multiple rearrangements and thus copy
+* only one timeframe is processed, this matches the current working scheme of the digitizer workflow
+* sequential workflow where the TPC sectors are processed individually and the data is buffered in the
+  tracker until complete. We are currently (ab)using DPLs time slice concept to process individual
+  TPC sectors. This is probably anyhow solved sufficiently when the trigger timing is implemented in
+  DPL
+* raw pages are using RawDataHeader version 2 with 4 64bit words, will be converted to version 3 soon
+
+## Open questions
+* how to implement further workflow control with multiple timeframes
+* clarify the buffering of input in the tracker
+* clarify whether or not to call `finishProcessing` of the clusterer
+* the tracker reports about clusters being dropped, can be an indication that some conversion step in
+  the workflow is incorrect.

--- a/Detectors/TPC/workflow/src/CATrackerSpec.cxx
+++ b/Detectors/TPC/workflow/src/CATrackerSpec.cxx
@@ -16,6 +16,7 @@
 #include "CATrackerSpec.h"
 #include "Headers/DataHeader.h"
 #include "Framework/DataRefUtils.h"
+#include "DataFormatsTPC/TPCSectorHeader.h"
 #include "DataFormatsTPC/ClusterNative.h"
 #include "DataFormatsTPC/Helpers.h"
 #include "TPCReconstruction/TPCCATracking.h"
@@ -48,6 +49,10 @@ DataProcessorSpec getCATrackerSpec()
     auto processingFct = [parser, tracker](ProcessingContext& pc) {
       ClusterNativeAccessFullTPC clusterIndex;
       memset(&clusterIndex, 0, sizeof(clusterIndex));
+      auto const* sectorHeader = DataRefUtils::getHeader<o2::TPC::TPCSectorHeader*>(pc.inputs().get("input"));
+      if (sectorHeader) {
+        std::cout << "received data for sector " << sectorHeader->sector << std::endl;
+      }
 
       for (const auto& ref : pc.inputs()) {
         auto size = o2::framework::DataRefUtils::getPayloadSize(ref);

--- a/Detectors/TPC/workflow/src/CATrackerSpec.cxx
+++ b/Detectors/TPC/workflow/src/CATrackerSpec.cxx
@@ -37,7 +37,7 @@ namespace o2
 namespace TPC
 {
 
-DataProcessorSpec getCATrackerSpec()
+DataProcessorSpec getCATrackerSpec(bool processMC)
 {
   constexpr static size_t NSectors = o2::TPC::Sector::MAXSECTOR;
   using ClusterGroupParser = o2::algorithm::ForwardParser<o2::TPC::ClusterGroupHeader>;
@@ -162,8 +162,19 @@ DataProcessorSpec getCATrackerSpec()
     return processingFct;
   };
 
+  auto createInputSpecs = [](bool makeMcInput) {
+    std::vector<InputSpec> inputSpecs{
+      InputSpec{ { "input" }, gDataOriginTPC, "CLUSTERNATIVE", 0, Lifetime::Timeframe },
+    };
+    if (makeMcInput) {
+      constexpr o2::header::DataDescription datadesc("CLNATIVEMCLBL");
+      inputSpecs.emplace_back(InputSpec{ "mclblin", gDataOriginTPC, datadesc, 0, Lifetime::Timeframe });
+    }
+    return std::move(inputSpecs);
+  };
+
   return DataProcessorSpec{ "tracker", // process id
-                            { InputSpec{ "input", "TPC", "CLUSTERNATIVE", 0, Lifetime::Timeframe } },
+                            { createInputSpecs(processMC) },
                             { OutputSpec{ { "output" }, gDataOriginTPC, "TRACKS", 0, Lifetime::Timeframe } },
                             AlgorithmSpec(initFunction) };
 }

--- a/Detectors/TPC/workflow/src/CATrackerSpec.h
+++ b/Detectors/TPC/workflow/src/CATrackerSpec.h
@@ -22,7 +22,7 @@ namespace TPC
 
 /// create a processor spec
 /// read simulated TPC clusters from file and publish
-framework::DataProcessorSpec getCATrackerSpec();
+framework::DataProcessorSpec getCATrackerSpec(bool processMC = false);
 
 } // end namespace TPC
 } // end namespace o2

--- a/Detectors/TPC/workflow/src/ClusterConverterSpec.cxx
+++ b/Detectors/TPC/workflow/src/ClusterConverterSpec.cxx
@@ -201,15 +201,15 @@ DataProcessorSpec getClusterConverterSpec(bool sendMC)
     if (makeMcOutput) {
       OutputLabel label{ "mclblout" };
       // FIXME: define common data type specifiers
-      constexpr o2::header::DataDescription datadesc("CLUSTERMCLBL");
+      constexpr o2::header::DataDescription datadesc("CLUSTERHWMCLBL");
       outputSpecs.emplace_back(label, gDataOriginTPC, datadesc, 0, Lifetime::Timeframe);
     }
     return std::move(outputSpecs);
   };
 
   return DataProcessorSpec{ "converter",
-                            { createInputSpecs(false) },
-                            { createOutputSpecs(false) },
+                            { createInputSpecs(sendMC) },
+                            { createOutputSpecs(sendMC) },
                             AlgorithmSpec(initFunction) };
 }
 } // end namespace TPC

--- a/Detectors/TPC/workflow/src/ClusterConverterSpec.h
+++ b/Detectors/TPC/workflow/src/ClusterConverterSpec.h
@@ -22,7 +22,7 @@ namespace TPC
 
 /// create a processor spec
 /// read simulated TPC clusters from file and publish
-framework::DataProcessorSpec getClusterConverterSpec();
+framework::DataProcessorSpec getClusterConverterSpec(bool sendMC);
 
 } // end namespace TPC
 } // end namespace o2

--- a/Detectors/TPC/workflow/src/ClusterDecoderRawSpec.h
+++ b/Detectors/TPC/workflow/src/ClusterDecoderRawSpec.h
@@ -22,7 +22,7 @@ namespace TPC
 
 /// create a processor spec
 /// read simulated TPC clusters from file and publish
-framework::DataProcessorSpec getClusterDecoderRawSpec();
+framework::DataProcessorSpec getClusterDecoderRawSpec(bool sendMC = false);
 
 } // end namespace TPC
 } // end namespace o2

--- a/Detectors/TPC/workflow/src/ClustererSpec.cxx
+++ b/Detectors/TPC/workflow/src/ClustererSpec.cxx
@@ -17,6 +17,8 @@
 #include "Headers/DataHeader.h"
 #include "TPCBase/Digit.h"
 #include "TPCReconstruction/HwClusterer.h"
+#include "TPCBase/Sector.h"
+#include "DataFormatsTPC/TPCSectorHeader.h"
 #include "DataFormatsTPC/Cluster.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
 #include "SimulationDataFormat/MCCompLabel.h"
@@ -38,25 +40,63 @@ using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
 /// runs the TPC HwClusterer in a DPL process with digits and mc as input
 DataProcessorSpec getClustererSpec(bool sendMC)
 {
+  constexpr static size_t NSectors = o2::TPC::Sector::MAXSECTOR;
+  struct ProcessAttributes {
+    std::vector<o2::TPC::Cluster> clusterArray;
+    MCLabelContainer mctruthArray;
+    std::array<std::shared_ptr<o2::TPC::HwClusterer>, NSectors> clusterers;
+    int verbosity = 1;
+  };
+
   auto initFunction = [sendMC](InitContext& ic) {
-    auto clusterArray = std::make_shared<std::vector<o2::TPC::Cluster>>();
-    auto mctruthArray = std::make_shared<MCLabelContainer>();
-    // FIXME: correct sector needs to be set!! Do we need a set of clusterers if we want to process
-    // multiple sectors?
-    auto clusterer = std::make_shared<o2::TPC::HwClusterer>(clusterArray.get(), 0, mctruthArray.get());
+    // FIXME: the clusterer needs to be initialized with the sector number, so we need one
+    // per sector. Taking a closer look to the HwClusterer, the sector number is only used
+    // for calculating the CRU id. This could be achieved by passing the current sector as
+    // parameter to the clusterer processing function.
+    auto processAttributes = std::make_shared<ProcessAttributes>();
 
-    auto processingFct = [clusterer, clusterArray, mctruthArray, sendMC](ProcessingContext& pc) {
+    auto processingFct = [processAttributes, sendMC](ProcessingContext& pc) {
+      auto& clusterArray = processAttributes->clusterArray;
+      auto& mctruthArray = processAttributes->mctruthArray;
+      auto& clusterers = processAttributes->clusterers;
+      auto& verbosity = processAttributes->verbosity;
       auto inDigits = pc.inputs().get<const std::vector<o2::TPC::Digit>>("digits");
+      if (verbosity > 0) {
+        LOG(INFO) << "received " << inDigits.size() << " digits";
+      }
       auto inMCLabels = pc.inputs().get<const MCLabelContainer*>("mclabels");
+      auto const* sectorHeader = DataRefUtils::getHeader<o2::TPC::TPCSectorHeader*>(pc.inputs().get("mclabels"));
+      if (sectorHeader == nullptr) {
+        LOG(ERROR) << "sector header missing on header stack";
+        return;
+      }
+      const auto sector = sectorHeader->sector;
+      if (sector < 0) {
+        // FIXME: we need to propagate something
+        return;
+      }
+      if (!clusterers[sector]) {
+        // create the clusterer for this sector, take the same target arrays for all clusterers
+        // as they are not invoked in parallel
+        // the cost of creating the clusterer should be small so we do it in the processing
+        clusterers[sector] = std::make_shared<o2::TPC::HwClusterer>(&clusterArray, sector, &mctruthArray);
+      }
+      auto& clusterer = clusterers[sector];
 
-      LOG(INFO) << "processing " << inDigits.size() << " digit object(s)";
-      clusterArray->clear();
-      mctruthArray->clear();
+      if (verbosity > 0) {
+        LOG(INFO) << "processing " << inDigits.size() << " digit object(s) of sector " << sectorHeader->sector;
+      }
+      clusterArray.clear();
+      mctruthArray.clear();
       clusterer->process(inDigits, inMCLabels.get());
-      LOG(INFO) << "clusterer produced " << clusterArray->size() << " cluster container";
-      pc.outputs().snapshot(OutputRef{ "clusters" }, *clusterArray.get());
+      const std::vector<o2::TPC::Digit> emptyDigits;
+      clusterer->finishProcess(emptyDigits, nullptr);
+      if (verbosity > 0) {
+        LOG(INFO) << "clusterer produced " << clusterArray.size() << " cluster container";
+      }
+      pc.outputs().snapshot(OutputRef{ "clusters", 0, { *sectorHeader } }, clusterArray);
       if (sendMC) {
-        pc.outputs().snapshot(OutputRef{ "clusterlbl" }, *mctruthArray.get());
+        pc.outputs().snapshot(OutputRef{ "clusterlbl", 0, { *sectorHeader } }, mctruthArray);
       }
     };
 

--- a/Detectors/TPC/workflow/src/ClustererSpec.cxx
+++ b/Detectors/TPC/workflow/src/ClustererSpec.cxx
@@ -89,8 +89,11 @@ DataProcessorSpec getClustererSpec(bool sendMC)
       clusterArray.clear();
       mctruthArray.clear();
       clusterer->process(inDigits, inMCLabels.get());
-      const std::vector<o2::TPC::Digit> emptyDigits;
-      clusterer->finishProcess(emptyDigits, nullptr);
+      // FIXME: not clear whether we need to call this and how
+      // currently it makes all clusters being removed in the Tracker
+      // maybe the problem is the empty digit array
+      //const std::vector<o2::TPC::Digit> emptyDigits;
+      //clusterer->finishProcess(emptyDigits, nullptr);
       if (verbosity > 0) {
         LOG(INFO) << "clusterer produced " << clusterArray.size() << " cluster container";
       }

--- a/Detectors/TPC/workflow/src/ClustererSpec.h
+++ b/Detectors/TPC/workflow/src/ClustererSpec.h
@@ -22,7 +22,7 @@ namespace TPC
 
 /// create a processor spec
 /// read simulated TPC clusters from file and publish
-framework::DataProcessorSpec getClustererSpec();
+framework::DataProcessorSpec getClustererSpec(bool sendMC);
 
 } // end namespace TPC
 } // end namespace o2

--- a/Detectors/TPC/workflow/src/DigitReaderSpec.cxx
+++ b/Detectors/TPC/workflow/src/DigitReaderSpec.cxx
@@ -64,7 +64,7 @@ DataProcessorSpec getDigitReaderSpec()
     return processingFct;
   };
 
-  return DataProcessorSpec{ "producer",
+  return DataProcessorSpec{ "digit-reader",
                             Inputs{}, // no inputs
                             { OutputSpec{ gDataOriginTPC, "DIGIT", 0, Lifetime::Timeframe },
                               OutputSpec{ gDataOriginTPC, "DIGITMCLBL", 0, Lifetime::Timeframe } },

--- a/Detectors/TPC/workflow/src/RangeTokenizer.h
+++ b/Detectors/TPC/workflow/src/RangeTokenizer.h
@@ -1,0 +1,73 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef RANGE_TOKENIZER_H
+#define RANGE_TOKENIZER_H
+
+/// @file   RangeTolenizer.h
+/// @author Matthias Richter
+/// @since  2018-09-18
+/// @brief  Helper function to tokenize sequences and ranges of integral numbers
+
+#include <vector>
+#include <string>
+#include <sstream>
+#include <utility> // std::move
+
+namespace o2
+{
+
+struct RangeTokenizer {
+  /// tokenize a string according to delimiter ',' and extract values of type T
+  template <typename T>
+  static std::vector<T> tokenize(std::string input)
+  {
+    std::istringstream stream(input);
+    std::string token;
+    std::vector<T> res;
+    while (std::getline(stream, token, ',')) {
+      T value;
+      if (std::is_integral<T>::value && token.find('-') != token.npos) {
+        // extract range
+        insertRange(res, token);
+      } else {
+        std::istringstream(token) >> value;
+        res.emplace_back(value);
+      }
+    }
+    return std::move(res);
+  }
+
+  /// extract a range of an integral type from a token string and add to vector
+  template <typename T, typename std::enable_if_t<std::is_integral<T>::value == true, int> = 0>
+  static void insertRange(std::vector<T>& res, std::string token)
+  {
+    std::istringstream tokenstream(token);
+    std::string bound;
+    T lowerBound, upperBound;
+    if (std::getline(tokenstream, bound, '-')) {
+      std::istringstream(bound) >> lowerBound;
+      if (std::getline(tokenstream, bound, '-')) {
+        std::istringstream(bound) >> upperBound;
+        for (T index = lowerBound; index <= upperBound; index++) {
+          res.emplace_back(index);
+        }
+      }
+    }
+  }
+
+  // this is needed to make the compilation work, but never called
+  template <typename T, typename std::enable_if_t<std::is_integral<T>::value == false, int> = 0>
+  static void insertRange(std::vector<T>& res, std::string token)
+  {
+  }
+};
+};
+
+#endif

--- a/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
+++ b/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
@@ -146,7 +146,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     };
   };
 
-  specs.emplace_back(o2::TPC::getClusterDecoderRawSpec());
+  specs.emplace_back(o2::TPC::getClusterDecoderRawSpec(propagateMC));
 
   auto createInputSpec = []() {
     o2::framework::Inputs inputs;
@@ -164,7 +164,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   };
 
   if (outputType == OutputType::Tracks) {
-    specs.emplace_back(o2::TPC::getCATrackerSpec());
+    specs.emplace_back(o2::TPC::getCATrackerSpec(propagateMC));
     specs.emplace_back(o2::TPC::getRootFileWriterSpec());
   } else if (outputType == OutputType::DecodedClusters) {
     specs.emplace_back(DataProcessorSpec{ "writer",

--- a/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
+++ b/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
@@ -118,10 +118,10 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   if (inputType == InputType::Digits) {
     specs.emplace_back(o2::TPC::getDigitReaderSpec());
     specs.emplace_back(o2::TPC::getClustererSpec(propagateMC));
-    specs.emplace_back(o2::TPC::getClusterConverterSpec(false));
+    specs.emplace_back(o2::TPC::getClusterConverterSpec(propagateMC));
   } else if (inputType == InputType::Clusters) {
     specs.emplace_back(o2::TPC::getClusterReaderSpec(/*propagateMC*/));
-    specs.emplace_back(o2::TPC::getClusterConverterSpec(false));
+    specs.emplace_back(o2::TPC::getClusterConverterSpec(propagateMC));
   } else if (inputType == InputType::Raw) {
     throw std::runtime_error(std::string("input type 'raw' not yet implemented"));
   }

--- a/Steer/DigitizerWorkflow/CMakeLists.txt
+++ b/Steer/DigitizerWorkflow/CMakeLists.txt
@@ -26,7 +26,6 @@ O2_GENERATE_EXECUTABLE(
   src/CollisionTimePrinter.cxx
   src/TPCDriftTimeDigitizerSpec.cxx
   src/TPCDigitRootWriterSpec.cxx
-  src/TPCSectorHeader.cxx
   src/ITSDigitizerSpec.cxx
   src/ITSDigitWriterSpec.cxx
   src/TOFDigitizerSpec.cxx

--- a/Steer/DigitizerWorkflow/src/TPCDigitRootWriterSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TPCDigitRootWriterSpec.cxx
@@ -14,7 +14,7 @@
 /// @brief  Processor spec for a ROOT file writer for TPC digits
 
 #include "TPCDigitRootWriterSpec.h"
-#include "TPCSectorHeader.h"
+#include "DataFormatsTPC/TPCSectorHeader.h"
 #include "Framework/CallbackService.h"
 #include "Framework/ControlService.h"
 #include "TPCBase/Sector.h"
@@ -144,7 +144,7 @@ DataProcessorSpec getTPCDigitRootWriterSpec(int numberofsourcedevices)
 
       // extracts the sector from header of an input
       auto extractSector = [&pc](const char* inputname) {
-        auto sectorHeader = DataRefUtils::getHeader<o2::tpc::TPCSectorHeader*>(pc.inputs().get(inputname));
+        auto sectorHeader = DataRefUtils::getHeader<o2::TPC::TPCSectorHeader*>(pc.inputs().get(inputname));
         if (!sectorHeader) {
           LOG(FATAL) << "Missing sector header in TPC data";
         }

--- a/Steer/DigitizerWorkflow/src/TPCDriftTimeDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TPCDriftTimeDigitizerSpec.cxx
@@ -31,7 +31,7 @@
 #include <sstream>
 #include <algorithm>
 #include "TPCBase/CDBInterface.h"
-#include "TPCSectorHeader.h"
+#include "DataFormatsTPC/TPCSectorHeader.h"
 
 using namespace o2::framework;
 using SubSpecificationType = o2::framework::DataAllocator::SubSpecificationType;
@@ -94,7 +94,7 @@ DataProcessorSpec getTPCDriftTimeDigitizer(int channel, bool cachehits)
 
     // lambda that snapshots digits to be sent out; prepares and attaches header with sector information
     auto snapshotDigits = [sector, &pc, channel](std::vector<o2::TPC::Digit> const& digits) {
-      o2::tpc::TPCSectorHeader header{ sector };
+      o2::TPC::TPCSectorHeader header{ sector };
       // note that snapshoting only works with non-const references (to be fixed?)
       pc.outputs().snapshot(Output{ "TPC", "DIGITS", static_cast<SubSpecificationType>(channel), Lifetime::Timeframe,
                                     header },
@@ -102,7 +102,7 @@ DataProcessorSpec getTPCDriftTimeDigitizer(int channel, bool cachehits)
     };
     // lambda that snapshots labels to be sent out; prepares and attaches header with sector information
     auto snapshotLabels = [&sector, &pc, &channel](o2::dataformats::MCTruthContainer<o2::MCCompLabel> const& labels) {
-      o2::tpc::TPCSectorHeader header{ sector };
+      o2::TPC::TPCSectorHeader header{ sector };
       pc.outputs().snapshot(Output{ "TPC", "DIGITSMCTR", static_cast<SubSpecificationType>(channel),
                                     Lifetime::Timeframe, header },
                             const_cast<o2::dataformats::MCTruthContainer<o2::MCCompLabel>&>(labels));

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -328,8 +328,10 @@ o2_define_bucket(
     data_format_TPC_bucket
 
     DEPENDENCIES
+    data_format_headers_bucket
     data_format_reconstruction_bucket
     ReconstructionDataFormats
+    Headers
 
     INCLUDE_DIRECTORIES
     ${CMAKE_SOURCE_DIR}/DataFormats/simulation/include
@@ -1754,6 +1756,7 @@ o2_define_bucket(
     Steer
     Framework
     TPCSimulation
+    DataFormatsTPC
     ITSSimulation
     ITSMFTBase
     TOFSimulation


### PR DESCRIPTION
This implements the processing of TPC digits in individual sectors, the collection in the tracker process and running tracking when the input is complete.

Command line:
```
tpc-reco-workflow --infile tpcdigits.root --disable-mc 1
```
The input can be created by running the simulation (`o2sim`) and the digitizer workflow.

Blockers:
- [x] sorting of labels in the cluster converter
it turns out that the cluster output from the clusterer is not sorted in CRU, so the converter needs to do some sorting into pages, labels also need to be sorted
- [x] splitting of labels in the decoder
the decoder expects an array of single raw pages and a corresponding array of labels which need to be create from the single input block of labels, see https://alice.its.cern.ch/jira/browse/O2-394 for reason of splitting the MC container
- [x] configurable sector range
- [x] MC processing in the tracker

To be done in the next iteration
- [x] README and instructions
- [ ] adopt the RootTreeWriter tool for writing the output and passing track labels to writer
- [ ] configurable outputs at different stages
- [ ] parallel workflow
- [ ] clarify the buffering of input in the tracker
- [ ] clarify whether or not to call `finishProcessing` of the clusterer
