### PR TITLE
o2sim: Make logging info more uniform; Do less logging to info

### DIFF
--- a/Common/SimConfig/include/SimConfig/SimConfig.h
+++ b/Common/SimConfig/include/SimConfig/SimConfig.h
@@ -30,6 +30,8 @@ struct SimConfigData {
   float mBMax;                               // maximum for impact parameter sampling
   bool mIsMT;                                // chosen MT mode (Geant4 only)
   std::string mOutputPrefix;                 // prefix to be used for output files
+  std::string mLogSeverity;                  // severity for FairLogger
+  std::string mLogVerbosity;                 // loglevel for FairLogger
   ClassDefNV(SimConfigData, 1);
 };
 
@@ -80,6 +82,8 @@ class SimConfig
   float getBMax() const { return mConfigData.mBMax; }
   bool getIsMT() const { return mConfigData.mIsMT; }
   std::string getOutPrefix() const { return mConfigData.mOutputPrefix; }
+  std::string getLogVerbosity() const { return mConfigData.mLogVerbosity; }
+  std::string getLogSeverity() const { return mConfigData.mLogSeverity; }
 
  private:
   SimConfigData mConfigData; //!

--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -21,15 +21,16 @@ void SimConfig::initOptions(boost::program_options::options_description& options
   options.add_options()(
     "mcEngine,e", bpo::value<std::string>()->default_value("TGeant3"), "VMC backend to be used.")(
     "generator,g", bpo::value<std::string>()->default_value("boxgen"), "Event generator to be used.")(
-    "modules,m", bpo::value<std::vector<std::string>>()->multitoken()->default_value(
-                   std::vector<std::string>({ "all" }), "all modules"),
+    "modules,m", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>({ "all" }), "all modules"),
     "list of detectors")("nEvents,n", bpo::value<unsigned int>()->default_value(1), "number of events")(
     "startEvent", bpo::value<unsigned int>()->default_value(0), "index of first event to be used (when applicable)")(
     "extKinFile", bpo::value<std::string>()->default_value("Kinematics.root"),
     "name of kinematics file for event generator from file (when applicable)")(
     "bMax,b", bpo::value<float>()->default_value(0.), "maximum value for impact parameter sampling (when applicable)")(
     "isMT", bpo::value<bool>()->default_value(false), "multi-threaded mode (Geant4 only")(
-    "outPrefix,o", bpo::value<std::string>()->default_value("o2sim"), "prefix of output files");
+    "outPrefix,o", bpo::value<std::string>()->default_value("o2sim"), "prefix of output files")(
+    "logseverity", bpo::value<std::string>()->default_value("INFO"), "severity level for FairLogger")(
+    "logverbosity", bpo::value<std::string>()->default_value("low"), "level of verbosity for FairLogger (low, medium, high, veryhigh)");
 }
 
 bool SimConfig::resetFromParsedMap(boost::program_options::variables_map const& vm)
@@ -50,6 +51,8 @@ bool SimConfig::resetFromParsedMap(boost::program_options::variables_map const& 
   mConfigData.mBMax = vm["bMax"].as<float>();
   mConfigData.mIsMT = vm["isMT"].as<bool>();
   mConfigData.mOutputPrefix = vm["outPrefix"].as<std::string>();
+  mConfigData.mLogSeverity = vm["logseverity"].as<std::string>();
+  mConfigData.mLogVerbosity = vm["logverbosity"].as<std::string>();
   return true;
 }
 

--- a/Detectors/EMCAL/base/src/Geometry.cxx
+++ b/Detectors/EMCAL/base/src/Geometry.cxx
@@ -157,19 +157,19 @@ Geometry::Geometry(const std::string_view name, const std::string_view mcname, c
 
   memset(SMODULEMATRIX, 0, sizeof(TGeoHMatrix*) * EMCAL_MODULES);
 
-  LOG(INFO) << "Name <<" << name << ">>" << FairLogger::endl;
+  LOG(DEBUG) << "Name <<" << name << ">>";
 }
 
 Geometry& Geometry::operator=(const Geometry& /*rvalue*/)
 {
-  LOG(FATAL) << "assignment operator, not implemented\n";
+  LOG(FATAL) << "assignment operator, not implemented";
   return *this;
 }
 
 Geometry::~Geometry()
 {
   if (this == sGeom) {
-    LOG(ERROR) << "Do not call delete on me\n";
+    LOG(ERROR) << "Do not call delete on me";
     return;
   }
 
@@ -197,8 +197,7 @@ Geometry* Geometry::GetInstance(const std::string_view name, const std::string_v
     return sGeom;
   } else {
     if (sGeom->GetName() != name) {
-      LOG(INFO) << "\n current geometry is " << sGeom->GetName() << " : you should not call " << name
-                << FairLogger::endl;
+      LOG(INFO) << "\n current geometry is " << sGeom->GetName() << " : you should not call " << name;
     } // end
     return sGeom;
   } // end if sGeom
@@ -224,10 +223,10 @@ Geometry* Geometry::GetInstanceFromRunNumber(Int_t runNumber, const std::string_
         LOG(INFO) << "o2::EMCAL::Geometry::GetInstanceFromRunNumber() *** ATTENTION *** \n"
                   << "\t Specified geometry name <<" << geoName << ">> for run " << runNumber
                   << " is not considered! \n"
-                  << "\t In use <<EMCAL_FIRSTYEARV1>>, check run number and year\n";
+                  << "\t In use <<EMCAL_FIRSTYEARV1>>, check run number and year";
       } else {
         LOG(INFO)
-          << "o2::EMCAL::Geometry::GetInstanceFromRunNumber() - Initialized geometry with name <<EMCAL_FIRSTYEARV1>>\n";
+          << "o2::EMCAL::Geometry::GetInstanceFromRunNumber() - Initialized geometry with name <<EMCAL_FIRSTYEARV1>>";
       }
     }
 
@@ -240,10 +239,10 @@ Geometry* Geometry::GetInstanceFromRunNumber(Int_t runNumber, const std::string_
         LOG(INFO) << "o2::EMCAL::Geometry::GetInstanceFromRunNumber() *** ATTENTION *** \n"
                   << "\t Specified geometry name <<" << geoName << ">> for run " << runNumber
                   << " is not considered! \n"
-                  << "\t In use <<EMCAL_COMPLETEV1>>, check run number and year\n";
+                  << "\t In use <<EMCAL_COMPLETEV1>>, check run number and year";
       } else {
         LOG(INFO)
-          << "o2::EMCAL::Geometry::GetInstanceFromRunNumber() - Initialized geometry with name <<EMCAL_COMPLETEV1>>\n";
+          << "o2::EMCAL::Geometry::GetInstanceFromRunNumber() - Initialized geometry with name <<EMCAL_COMPLETEV1>>";
       }
     }
     return Geometry::GetInstance("EMCAL_COMPLETEV1", mcname, mctitle);
@@ -256,10 +255,10 @@ Geometry* Geometry::GetInstanceFromRunNumber(Int_t runNumber, const std::string_
         LOG(INFO) << "o2::EMCAL::Geometry::GetInstanceFromRunNumber() *** ATTENTION *** \n"
                   << "\t Specified geometry name <<" << geoName << " >> for run " << runNumber
                   << " is not considered! \n"
-                  << "\t In use <<EMCAL_COMPLETE12SMV1>>, check run number and year\n";
+                  << "\t In use <<EMCAL_COMPLETE12SMV1>>, check run number and year";
       } else {
         LOG(INFO) << "o2::EMCAL::Geometry::GetInstanceFromRunNumber() - Initialized geometry with name "
-                     "<<EMCAL_COMPLETE12SMV1>>\n";
+                     "<<EMCAL_COMPLETE12SMV1>>";
       }
     }
     return Geometry::GetInstance("EMCAL_COMPLETE12SMV1", mcname, mctitle);
@@ -272,10 +271,10 @@ Geometry* Geometry::GetInstanceFromRunNumber(Int_t runNumber, const std::string_
         LOG(INFO) << "o2::EMCAL::Geometry::GetInstanceFromRunNumber() *** ATTENTION *** \n"
                   << "\t Specified geometry name <<" << geoName << ">> for run " << runNumber
                   << " is not considered! \n"
-                  << "\t In use <<EMCAL_COMPLETE12SMV1_DCAL_8SM>>, check run number and year\n";
+                  << "\t In use <<EMCAL_COMPLETE12SMV1_DCAL_8SM>>, check run number and year";
       } else {
         LOG(INFO) << "o2::EMCAL::Geometry::GetInstanceFromRunNumber() - Initialized geometry with name "
-                     "<<EMCAL_COMPLETE12SMV1_DCAL_8SM>>\n";
+                     "<<EMCAL_COMPLETE12SMV1_DCAL_8SM>>";
       }
     }
     return Geometry::GetInstance("EMCAL_COMPLETE12SMV1_DCAL_8SM", mcname, mctitle);

--- a/Detectors/EMCAL/simulation/src/Detector.cxx
+++ b/Detectors/EMCAL/simulation/src/Detector.cxx
@@ -56,7 +56,7 @@ Detector::Detector(Bool_t active)
 
   Geometry* geo = GetGeometry();
   if (!geo)
-    LOG(FATAL) << "Geometry is nullptr" << std::endl;
+    LOG(FATAL) << "Geometry is nullptr";
   std::string gn = geo->GetName();
   std::transform(gn.begin(), gn.end(), gn.begin(), ::toupper);
 
@@ -95,7 +95,7 @@ void Detector::InitializeO2Detector()
   if (vsense)
     AddSensitiveVolume(vsense);
   else
-    LOG(ERROR) << "EMCAL Sensitive volume SCMX not found ... No hit creation!\n";
+    LOG(ERROR) << "EMCAL Sensitive volume SCMX not found ... No hit creation!";
 }
 
 void Detector::EndOfEvent() { Reset(); }
@@ -103,11 +103,11 @@ void Detector::EndOfEvent() { Reset(); }
 void Detector::ConstructGeometry()
 {
   using boost::algorithm::contains;
-  LOG(DEBUG) << "Creating EMCAL geometry\n";
+  LOG(DEBUG) << "Creating EMCAL geometry";
 
   Geometry* geom = GetGeometry();
   if (!(geom->IsInitialized())) {
-    LOG(ERROR) << "ConstructGeometry: EMCAL Geometry class has not been set up.\n";
+    LOG(ERROR) << "ConstructGeometry: EMCAL Geometry class has not been set up.";
   }
 
   CreateMaterials();
@@ -118,7 +118,7 @@ void Detector::ConstructGeometry()
   CreateEmcalEnvelope();
 
   // COMPACT, TRD1
-  LOG(DEBUG2) << "Shish-Kebab geometry : " << GetTitle() << FairLogger::endl;
+  LOG(DEBUG2) << "Shish-Kebab geometry : " << GetTitle();
   CreateShiskebabGeometry();
 
   gGeoManager->CheckGeometry();
@@ -153,10 +153,10 @@ Bool_t Detector::ProcessHits(FairVolume* v)
     offset = 18;
   }
   LOG(DEBUG3) << "Supermodule copy " << copySmod << ", module copy " << copyMod << ", y-dir " << copyPhi << ", x-dir "
-              << copyEta << ", supermodule ID " << copySmod + offset - 1 << std::endl;
-  LOG(DEBUG3) << "path " << fMC->CurrentVolPath() << std::endl;
+              << copyEta << ", supermodule ID " << copySmod + offset - 1;
+  LOG(DEBUG3) << "path " << fMC->CurrentVolPath();
   LOG(DEBUG3) << "Name of the supermodule type " << fMC->CurrentVolOffName(4) << ", Module name "
-              << fMC->CurrentVolOffName(3) << std::endl;
+              << fMC->CurrentVolOffName(3);
 
   Int_t partID = fMC->GetStack()->GetCurrentTrackNumber(),
         parent = fMC->GetStack()->GetCurrentTrack()->GetMother(0),
@@ -174,7 +174,7 @@ Bool_t Detector::ProcessHits(FairVolume* v)
     // - Processing different track
     // - Inside different cell
     // - First track of the event
-    // std::cout << "New track / cell started\n";
+    // std::cout << "New track / cell started";
     Float_t posX, posY, posZ, momX, momY, momZ, energy;
     fMC->TrackPosition(posX, posY, posZ);
     fMC->TrackMomentum(momX, momY, momZ, energy);
@@ -188,7 +188,7 @@ Bool_t Detector::ProcessHits(FairVolume* v)
     mCurrentCellID = detID;
 
   } else {
-    // std::cout << "Adding energy to the current hit\n";
+    // std::cout << "Adding energy to the current hit";
     mCurrentHit->SetEnergyLoss(mCurrentHit->GetEnergyLoss() + lightyield);
   }
 
@@ -200,7 +200,7 @@ Hit* Detector::AddHit(Int_t trackID, Int_t parentID, Int_t primary, Double_t ini
 {
   LOG(DEBUG4) << "Adding hit for track " << trackID << " (mother " << parentID << ") with position (" << pos.X() << ", "
               << pos.Y() << ", " << pos.Z() << ") and momentum (" << mom.X() << ", " << mom.Y() << ", " << mom.Z()
-              << ")  with energy " << initialEnergy << " loosing " << eLoss << std::endl;
+              << ")  with energy " << initialEnergy << " loosing " << eLoss;
   mHits->emplace_back(primary, trackID, parentID, detID, initialEnergy, pos, mom, time, eLoss);
   return &(mHits->back());
 }
@@ -235,7 +235,7 @@ void Detector::Register()
 
 void Detector::Reset()
 {
-  LOG(DEBUG) << "Cleaning EMCAL hits ...\n";
+  LOG(DEBUG) << "Cleaning EMCAL hits ...";
   mHits->clear();
   mCurrentTrackID = -1;
   mCurrentCellID = -1;
@@ -248,7 +248,7 @@ Geometry* Detector::GetGeometry()
     mGeometry = Geometry::GetInstanceFromRunNumber(223409);
   }
   if (!mGeometry)
-    LOG(ERROR) << "Failure accessing geometry" << std::endl;
+    LOG(ERROR) << "Failure accessing geometry";
   return mGeometry;
 }
 
@@ -295,8 +295,8 @@ void Detector::CreateEmcalEnvelope()
                                 10); // Polygone filled with air
 
     LOG(DEBUG2) << "ConstructGeometry: " << geom->GetNameOfEMCALEnvelope() << " = " << envelopA[5] << ", "
-                << envelopA[6] << FairLogger::endl;
-    LOG(DEBUG2) << "ConstructGeometry: XU0 = " << envelopA[5] << ", " << envelopA[6] << FairLogger::endl;
+                << envelopA[6];
+    LOG(DEBUG2) << "ConstructGeometry: XU0 = " << envelopA[5] << ", " << envelopA[6];
 
     // Position the EMCAL Mother Volume (XEN1) in Alice (ALIC)
     TVirtualMC::GetMC()->Gspos(geom->GetNameOfEMCALEnvelope(), 1, "cave", 0.0, 0.0, 0.0, rotMatrixID, "ONLY");
@@ -318,7 +318,7 @@ void Detector::CreateShiskebabGeometry()
   //  idAL = 1602;
   Double_t par[10], xpos = 0., ypos = 0., zpos = 0.;
 
-  LOG(DEBUG2) << "Name of mother volume: " << g->GetNameOfEMCALEnvelope() << FairLogger::endl;
+  LOG(DEBUG2) << "Name of mother volume: " << g->GetNameOfEMCALEnvelope();
   CreateSupermoduleGeometry(g->GetNameOfEMCALEnvelope());
 
   auto SMTypeList = g->GetEMCSystem();
@@ -340,7 +340,7 @@ void Detector::CreateShiskebabGeometry()
     else if (tmpType == DCAL_EXT)
       CreateEmcalModuleGeometry("DCEXT", "EMOD"); // Mar 13, 2012, DCAL extension SM
     else
-      LOG(ERROR) << "Unkown SM Type!!\n";
+      LOG(ERROR) << "Unkown SM Type!!";
   }
 
   // Sensitive SC  (2x2 tiles)
@@ -367,7 +367,7 @@ void Detector::CreateShiskebabGeometry()
 
   if (g->GetNPHIdiv() == 2 && g->GetNETAdiv() == 2) {
     // Division to tile size - 1-oct-04
-    LOG(DEBUG2) << " Divide SCM0 on y-axis " << g->GetNETAdiv() << FairLogger::endl;
+    LOG(DEBUG2) << " Divide SCM0 on y-axis " << g->GetNETAdiv();
     TVirtualMC::GetMC()->Gsdvn("SCMY", "SCM0", g->GetNETAdiv(), 2); // y-axis
 
     // Trapesoid 2x2
@@ -387,10 +387,10 @@ void Detector::CreateShiskebabGeometry()
     parTRAP[9] = parTRAP[8];      // TL2
     parTRAP[10] = 0.0;            // ALP2
 
-    LOG(DEBUG2) << " ** TRAP ** \n";
+    LOG(DEBUG2) << " ** TRAP ** ";
     for (Int_t i = 0; i < 11; i++)
       LOG(DEBUG3) << " par[" << std::setw(2) << std::setprecision(2) << i << "] " << std::setw(9)
-                  << std::setprecision(4) << parTRAP[i] << FairLogger::endl;
+                  << std::setprecision(4) << parTRAP[i];
 
     TVirtualMC::GetMC()->Gsvolu("SCMX", "TRAP", getMediumID(ID_SC), parTRAP, 11);
     xpos = +(parSCM0[1] + parSCM0[0]) / 4.;
@@ -415,17 +415,17 @@ void Detector::CreateShiskebabGeometry()
       TVirtualMC::GetMC()->Gsvolu("PBTI", "BOX", getMediumID(ID_PB), dummy, 0);
 
       zpos = -mSampleWidth * g->GetNECLayers() / 2. + g->GetECPbRadThick() / 2.;
-      LOG(DEBUG2) << " Pb tiles \n";
+      LOG(DEBUG2) << " Pb tiles ";
 
       for (Int_t iz = 0; iz < g->GetNECLayers(); iz++) {
         par[0] = (parSCM0[0] + tanBetta * mSampleWidth * iz) / 2.;
         xpos = par[0] - xCenterSCMX;
         TVirtualMC::GetMC()->Gsposp("PBTI", ++nr, "SCMX", xpos, ypos, zpos, 0, "ONLY", par, 3);
-        LOG(DEBUG3) << iz + 1 << " xpos " << xpos << " zpos " << zpos << " par[0] " << par[0] << FairLogger::endl;
+        LOG(DEBUG3) << iz + 1 << " xpos " << xpos << " zpos " << zpos << " par[0] " << par[0];
         zpos += mSampleWidth;
       }
 
-      LOG(DEBUG2) << " Number of Pb tiles in SCMX " << nr << FairLogger::endl;
+      LOG(DEBUG2) << " Number of Pb tiles in SCMX " << nr;
     } else {
       // Oct 26, 2010
       // First sheet of paper
@@ -558,7 +558,7 @@ void Detector::CreateSupermoduleGeometry(const std::string_view mother)
 
   //  ===== define Super Module from air - 14x30 module ==== ;
   LOG(DEBUG2) << "\n ## Super Module | fSampleWidth " << std::setw(5) << std::setprecision(3) << mSampleWidth << " ## "
-              << gn << FairLogger::endl;
+              << gn;
   par[0] = g->GetShellThickness() / 2.;               // radial
   par[1] = g->GetPhiModuleSize() * g->GetNPhi() / 2.; // phi
   par[2] = g->GetEtaModuleSize() * g->GetNEta() / 2.; // eta
@@ -569,7 +569,7 @@ void Detector::CreateSupermoduleGeometry(const std::string_view mother)
     dphi = g->GetPhiSuperModule();
     rpos = (g->GetEnvelop(0) + g->GetEnvelop(1)) / 2.;
     LOG(DEBUG2) << " rpos " << std::setw(8) << std::setprecision(2) << rpos << " : dphi " << std::setw(6)
-                << std::setprecision(1) << dphi << " degree \n";
+                << std::setprecision(1) << dphi << " degree ";
   }
 
   if (contains(gn, "WSUC")) {
@@ -582,7 +582,7 @@ void Detector::CreateSupermoduleGeometry(const std::string_view mother)
 
     LOG(DEBUG2) << "SMOD in WSUC : tmed " << getMediumID(ID_AIR) << " | dx " << std::setw(7) << std::setprecision(2)
                 << par[0] << " dy " << std::setw(7) << std::setprecision(2) << par[1] << " dz " << std::setw(7)
-                << std::setprecision(2) << par[2] << " (SMOD, BOX)\n";
+                << std::setprecision(2) << par[2] << " (SMOD, BOX)";
     mSmodPar0 = par[0];
     mSmodPar1 = par[1];
     mSmodPar2 = par[2];
@@ -594,12 +594,12 @@ void Detector::CreateSupermoduleGeometry(const std::string_view mother)
       LOG(DEBUG2) << " fIdRotm " << std::setw(3) << 0 << " phi " << std::setw(7) << std::setprecision(1) << phi << "("
                   << std::setw(5) << std::setprecision(3) << phiRad << ") xpos " << std::setw(7) << std::setprecision(2)
                   << xpos << " ypos " << std::setw(7) << std::setprecision(2) << ypos << " zpos " << std::setw(7)
-                  << std::setprecision(2) << zpos << FairLogger::endl;
+                  << std::setprecision(2) << zpos;
 
       nr++;
     }
   } else { // ALICE
-    LOG(DEBUG2) << " par[0] " << std::setw(7) << std::setprecision(2) << par[0] << " (old) \n";
+    LOG(DEBUG2) << " par[0] " << std::setw(7) << std::setprecision(2) << par[0] << " (old) ";
     for (Int_t i = 0; i < 3; i++)
       par[i] = g->GetSuperModulesPar(i);
     mSmodPar0 = par[0];
@@ -646,13 +646,13 @@ void Detector::CreateSupermoduleGeometry(const std::string_view mother)
         xpos += (2. * par[1] / 3. * TMath::Sin(phiRad));
         ypos -= (2. * par[1] / 3. * TMath::Cos(phiRad));
       } else
-        LOG(ERROR) << "Unkown SM Type!!\n";
+        LOG(ERROR) << "Unkown SM Type!!";
 
       if (SMOrder == 1) { // first time, create the SM
         TVirtualMC::GetMC()->Gsvolu(smName.Data(), "BOX", getMediumID(ID_AIR), parC, 3);
 
         LOG(DEBUG2) << R"( Super module with name \")" << smName << R"(\" was created in \"box\" with: par[0] = )"
-                    << parC[0] << ", par[1] = " << parC[1] << ", par[2] = " << parC[2] << FairLogger::endl;
+                    << parC[0] << ", par[1] = " << parC[1] << ", par[2] = " << parC[2];
       }
 
       if (smodnum % 2 == 1) {
@@ -671,11 +671,11 @@ void Detector::CreateSupermoduleGeometry(const std::string_view mother)
                   << " phi " << std::setw(6) << std::setprecision(1) << phi << "(" << std::setw(5)
                   << std::setprecision(3) << phiRad << ") xpos " << std::setw(7) << std::setprecision(2) << xpos
                   << " ypos " << std::setw(7) << std::setprecision(2) << ypos << " zpos " << std::setw(7)
-                  << std::setprecision(2) << zpos << " : i " << smodnum << FairLogger::endl;
+                  << std::setprecision(2) << zpos << " : i " << smodnum;
     }
   }
 
-  LOG(DEBUG2) << " Number of Super Modules " << nSMod << FairLogger::endl;
+  LOG(DEBUG2) << " Number of Super Modules " << nSMod;
 
   // Steel plate
   if (g->GetSteelFrontThickness() > 0.0) { // 28-mar-05
@@ -684,7 +684,7 @@ void Detector::CreateSupermoduleGeometry(const std::string_view mother)
 
     LOG(DEBUG1) << "tmed " << getMediumID(ID_STEEL) << " | dx " << std::setw(7) << std::setprecision(2) << par[0]
                 << " dy " << std::setw(7) << std::setprecision(2) << par[1] << " dz " << std::setw(7)
-                << std::setprecision(2) << par[2] << " (STPL) \n";
+                << std::setprecision(2) << par[2] << " (STPL) ";
 
     xpos = -(g->GetShellThickness() - g->GetSteelFrontThickness()) / 2.;
     TVirtualMC::GetMC()->Gspos("STPL", 1, "SMOD", xpos, 0.0, 0.0, 0, "ONLY");
@@ -726,7 +726,7 @@ void Detector::CreateEmcalModuleGeometry(const std::string_view mother, const st
       LOG(DEBUG4) << std::setw(2) << iz + 1 << " | angle | " << std::setw(6) << std::setprecision(3) << angle << " - "
                   << std::setw(6) << std::setprecision(3) << phiOK << " = " << std::setw(6) << std::setprecision(3)
                   << angle - phiOK << "(eta " << std::setw(5) << std::setprecision(3) << mod.GetEtaOfCenterOfModule()
-                  << ")\n";
+                  << ")";
       xpos = mod.GetPosXfromR() + g->GetSteelFrontThickness() - mSmodPar0;
       zpos = mod.GetPosZ() - mSmodPar2;
 
@@ -742,7 +742,7 @@ void Detector::CreateEmcalModuleGeometry(const std::string_view mother, const st
           continue; //!!!DCSM from 8th to 23th
         zpos = mod.GetPosZ() - mSmodPar2 - g->GetDCALInnerEdge() / 2.;
       } else if (mother.compare("SMOD"))
-        LOG(ERROR) << "Unknown super module Type!!\n";
+        LOG(ERROR) << "Unknown super module Type!!";
 
       for (auto iy : boost::irange(0, iyMax)) { // flat in phi
         ypos = g->GetPhiModuleSize() * (2 * iy + 1 - iyMax) / 2.;
@@ -750,7 +750,7 @@ void Detector::CreateEmcalModuleGeometry(const std::string_view mother, const st
 
         // printf(" %2i xpos %7.2f ypos %7.2f zpos %7.2f fIdRotm %i\n", nr, xpos, ypos, zpos, fIdRotm);
         LOG(DEBUG3) << std::setw(3) << std::setprecision(3) << nr << "(" << std::setw(2) << std::setprecision(2)
-                    << iy + 1 << "," << std::setw(2) << std::setprecision(2) << iz + 1 << ")\n";
+                    << iy + 1 << "," << std::setw(2) << std::setprecision(2) << iz + 1 << ")";
       }
       // PH          printf("\n");
     } else { // WSUC
@@ -764,7 +764,7 @@ void Detector::CreateEmcalModuleGeometry(const std::string_view mother, const st
       LOG(DEBUG4) << std::setw(2) << iz + 1 << " | angle -phiOK | " << std::setw(6) << std::setprecision(3) << angle
                   << " - " << std::setw(6) << std::setprecision(3) << phiOK << " = " << std::setw(6)
                   << std::setprecision(3) << angle - phiOK << "(eta " << std::setw(5) << std::setprecision(3)
-                  << mod.GetEtaOfCenterOfModule() << ")\n";
+                  << mod.GetEtaOfCenterOfModule() << ")";
 
       zpos = mod.GetPosZ() - mSmodPar2;
       ypos = mod.GetPosXfromR() - mSmodPar1;
@@ -776,11 +776,11 @@ void Detector::CreateEmcalModuleGeometry(const std::string_view mother, const st
         TVirtualMC::GetMC()->Gspos(child.data(), ++nr, mother.data(), xpos, ypos, zpos, rotMatrixID, "ONLY");
         // printf(" %7.2f ", xpos);
       }
-      // printf("\n");
+      // printf("");
     }
   }
 
-  LOG(DEBUG2) << " Number of modules in Super Module(" << mother << ") " << nr << FairLogger::endl;
+  LOG(DEBUG2) << " Number of modules in Super Module(" << mother << ") " << nr;
 }
 
 void Detector::CreateAlFrontPlate(const std::string_view mother, const std::string_view child)

--- a/Detectors/FIT/simulation/src/Detector.cxx
+++ b/Detectors/FIT/simulation/src/Detector.cxx
@@ -51,7 +51,7 @@ void Detector::InitializeO2Detector()
   // FIXME: we need to register the sensitive volumes with FairRoot
   TGeoVolume* v = gGeoManager->GetVolume("0REG");
   if (v == nullptr)
-    printf("@@@@ Sensitive volume 0REG not found!!!!!!!!");
+    LOG(WARN) << "@@@@ Sensitive volume 0REG not found!!!!!!!!";
   else {
     AddSensitiveVolume(v);
   }
@@ -59,7 +59,7 @@ void Detector::InitializeO2Detector()
 
 void Detector::ConstructGeometry()
 {
-  LOG(DEBUG) << "Creating FIT geometry\n";
+  LOG(DEBUG) << "Creating FIT geometry";
   CreateMaterials();
 
   Float_t zdetA = 333;
@@ -74,11 +74,10 @@ void Detector::ConstructGeometry()
 
   int nCellsA = Geometry::NCellsA;
   int nCellsC = Geometry::NCellsC;
-  //std::cout<<"@@@@ mGeometry->NCells "<<nCellsA<<" "<<nCellsC<<std::endl;
 
   Geometry geometry;
   TVector3 centerMCP = geometry.centerMCP(2);
-  std::cout << "@@@@ mGeometry->centerMCP " << nCellsA << " " << nCellsC << centerMCP.X() << std::endl;
+  LOG(DEBUG) << "@@@@ mGeometry->centerMCP " << nCellsA << " " << nCellsC << centerMCP.X();
 
   Matrix(idrotm[901], 90., 0., 90., 90., 180., 0.);
 
@@ -164,7 +163,7 @@ void Detector::ConstructGeometry()
     nameTr = Form("0TR%i", itr + 1);
     z = -pstartA[2] + pinstart[2];
     tr[itr] = new TGeoTranslation(nameTr.Data(), xa[itr], ya[itr], z);
-    printf(" itr %i A %f %f %f \n", itr, xa[itr], ya[itr], z + zdetA);
+    LOG(DEBUG) << Form(" FIT: itr %i A %f %f %f \n", itr, xa[itr], ya[itr], z + zdetA);
     tr[itr]->RegisterYourself();
     stlinA->AddNode(ins, itr, tr[itr]);
   }
@@ -241,13 +240,13 @@ void Detector::SetOneMCP(TGeoVolume* ins)
   topref->AddNode(top, 1, new TGeoTranslation(0, 0, 0));
   xinv = -ptop[0] - prfv[0];
   topref->AddNode(rfv, 1, new TGeoTranslation(xinv, 0, 0));
-  printf(" GEOGEO  refv %f ,  0,0 \n", xinv);
+  LOG(DEBUG) << Form(" GEOGEO  refv %f ,  0,0 \n", xinv);
   xinv = ptop[0] + prfv[0];
   topref->AddNode(rfv, 2, new TGeoTranslation(xinv, 0, 0));
-  printf(" GEOGEO  refv %f ,  0,0 \n", xinv);
+  LOG(DEBUG) << Form(" GEOGEO  refv %f ,  0,0 \n", xinv);
   yinv = -ptop[1] - prfh[1];
   topref->AddNode(rfh, 1, new TGeoTranslation(0, yinv, 0));
-  printf(" GEOGEO  refh  ,  0, %f, 0 \n", yinv);
+  LOG(DEBUG) << Form(" GEOGEO  refh  ,  0, %f, 0 \n", yinv);
   yinv = ptop[1] + prfh[1];
   topref->AddNode(rfh, 2, new TGeoTranslation(0, yinv, 0));
 
@@ -259,11 +258,11 @@ void Detector::SetOneMCP(TGeoVolume* ins)
       yin = -pinstart[1] + 0.3 + (iy + 0.5) * 2 * ptopref[1];
       ntops++;
       ins->AddNode(topref, ntops, new TGeoTranslation(xin, yin, z));
-      printf(" 0TOP  full %i x %f y %f z %f \n", ntops, xin, yin, z);
+      LOG(DEBUG) << Form(" 0TOP  full %i x %f y %f z %f \n", ntops, xin, yin, z);
       z = -pinstart[2] + 2 * pal[2] + 2 * ptopref[2] + preg[2];
       ins->AddNode(cat, ntops, new TGeoTranslation(xin, yin, z));
       // cat->Print();
-      printf(" GEOGEO  CATHOD x=%f , y= %f z= %f num  %i\n", xin, yin, z, ntops);
+      LOG(DEBUG) << Form(" GEOGEO  CATHOD x=%f , y= %f z= %f num  %i\n", xin, yin, z, ntops);
     }
   }
   // Al top
@@ -290,7 +289,6 @@ Bool_t Detector::ProcessHits(FairVolume* v)
     float etot = fMC->Etot();
     int iPart = fMC->TrackPid();
     float enDep = fMC->Edep();
-    //  if (iPart != 50000050) printf("@@@@@  %f %f %f %i %i %i\n",x,y,z,detID,mcp,quadrant );
     if (iPart == 50000050) // If particles is photon then ...
     {
       if (RegisterPhotoE(etot)) {

--- a/Detectors/HMPID/simulation/src/Detector.cxx
+++ b/Detectors/HMPID/simulation/src/Detector.cxx
@@ -45,7 +45,7 @@ Detector::Detector(const Detector& other) : mSensitiveVolumes(other.mSensitiveVo
 void Detector::InitializeO2Detector()
 {
   for (auto sensitiveHpad : mSensitiveVolumes) {
-    LOG(INFO) << "HMPID: registering sensitive " << sensitiveHpad->GetName();
+    LOG(DEBUG) << "HMPID: registering sensitive " << sensitiveHpad->GetName();
     AddSensitiveVolume(sensitiveHpad);
   }
 }

--- a/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
@@ -540,8 +540,7 @@ void Detector::defineWrapperVolume(Int_t id, Double_t rmin, Double_t rmax, Doubl
 {
   // set parameters of id-th wrapper volume
   if (id >= sNumberOfWrapperVolumes || id < 0) {
-    LOG(FATAL) << "id " << id << " of wrapper volume is not in 0-" << sNumberOfWrapperVolumes - 1 << " range"
-               << FairLogger::endl;
+    LOG(FATAL) << "id " << id << " of wrapper volume is not in 0-" << sNumberOfWrapperVolumes - 1 << " range";
   }
 
   mWrapperMinRadius[id] = rmin;
@@ -570,11 +569,10 @@ void Detector::defineLayer(Int_t nlay, double phi0, Double_t r, Int_t nstav, Int
   //   none.
 
   LOG(INFO) << "L# " << nlay << " Phi:" << phi0 << " R:" << r << " Nst:" << nstav << " Nunit:" << nunit
-            << " Lthick:" << lthick << " Dthick:" << dthick << " DetID:" << dettypeID << " B:" << buildLevel
-            << FairLogger::endl;
+            << " Lthick:" << lthick << " Dthick:" << dthick << " DetID:" << dettypeID << " B:" << buildLevel;
 
   if (nlay >= sNumberLayers || nlay < 0) {
-    LOG(ERROR) << "Wrong layer number " << nlay << FairLogger::endl;
+    LOG(ERROR) << "Wrong layer number " << nlay;
     return;
   }
 
@@ -614,10 +612,10 @@ void Detector::defineLayerTurbo(Int_t nlay, Double_t phi0, Double_t r, Int_t nst
 
   LOG(INFO) << "L# " << nlay << " Phi:" << phi0 << " R:" << r << " Nst:" << nstav << " Nunit:" << nunit
             << " W:" << width << " Tilt:" << tilt << " Lthick:" << lthick << " Dthick:" << dthick
-            << " DetID:" << dettypeID << " B:" << buildLevel << FairLogger::endl;
+            << " DetID:" << dettypeID << " B:" << buildLevel;
 
   if (nlay >= sNumberLayers || nlay < 0) {
-    LOG(ERROR) << "Wrong layer number " << nlay << FairLogger::endl;
+    LOG(ERROR) << "Wrong layer number " << nlay;
     return;
   }
 
@@ -655,7 +653,7 @@ void Detector::getLayerParameters(Int_t nlay, Double_t& phi0, Double_t& r, Int_t
   //   none.
 
   if (nlay >= sNumberLayers || nlay < 0) {
-    LOG(ERROR) << "Wrong layer number " << nlay << FairLogger::endl;
+    LOG(ERROR) << "Wrong layer number " << nlay;
     return;
   }
 
@@ -708,7 +706,7 @@ void Detector::constructDetectorGeometry()
   TGeoVolume* vALIC = geoManager->GetVolume("cave");
 
   if (!vALIC) {
-    LOG(FATAL) << "Could not find the top volume" << FairLogger::endl;
+    LOG(FATAL) << "Could not find the top volume";
   }
 
   new TGeoVolumeAssembly(GeometryTGeo::getITSVolPattern());
@@ -722,36 +720,36 @@ void Detector::constructDetectorGeometry()
   // Check that we have all needed parameters
   for (Int_t j = 0; j < sNumberLayers; j++) {
     if (mLayerRadii[j] <= 0) {
-      LOG(FATAL) << "Wrong layer radius for layer " << j << "(" << mLayerRadii[j] << ")" << FairLogger::endl;
+      LOG(FATAL) << "Wrong layer radius for layer " << j << "(" << mLayerRadii[j] << ")";
     }
     if (mStavePerLayer[j] <= 0) {
-      LOG(FATAL) << "Wrong number of staves for layer " << j << "(" << mStavePerLayer[j] << ")" << FairLogger::endl;
+      LOG(FATAL) << "Wrong number of staves for layer " << j << "(" << mStavePerLayer[j] << ")";
     }
     if (mUnitPerStave[j] <= 0) {
-      LOG(FATAL) << "Wrong number of chips for layer " << j << "(" << mUnitPerStave[j] << ")" << FairLogger::endl;
+      LOG(FATAL) << "Wrong number of chips for layer " << j << "(" << mUnitPerStave[j] << ")";
     }
     if (mChipThickness[j] < 0) {
-      LOG(FATAL) << "Wrong chip thickness for layer " << j << "(" << mChipThickness[j] << ")" << FairLogger::endl;
+      LOG(FATAL) << "Wrong chip thickness for layer " << j << "(" << mChipThickness[j] << ")";
     }
     if (mTurboLayer[j] && mStaveWidth[j] <= 0) {
-      LOG(FATAL) << "Wrong stave width for layer " << j << "(" << mStaveWidth[j] << ")" << FairLogger::endl;
+      LOG(FATAL) << "Wrong stave width for layer " << j << "(" << mStaveWidth[j] << ")";
     }
     if (mDetectorThickness[j] < 0) {
-      LOG(FATAL) << "Wrong Sensor thickness for layer " << j << "(" << mDetectorThickness[j] << ")" << FairLogger::endl;
+      LOG(FATAL) << "Wrong Sensor thickness for layer " << j << "(" << mDetectorThickness[j] << ")";
     }
 
     if (j > 0) {
       if (mLayerRadii[j] <= mLayerRadii[j - 1]) {
         LOG(FATAL) << "Layer " << j << " radius (" << mLayerRadii[j] << ") is smaller than layer " << j - 1
-                   << " radius (" << mLayerRadii[j - 1] << ")" << FairLogger::endl;
+                   << " radius (" << mLayerRadii[j - 1] << ")";
       }
     }
 
     if (mChipThickness[j] == 0) {
-      LOG(INFO) << "Chip thickness for layer " << j << " not set, using default" << FairLogger::endl;
+      LOG(INFO) << "Chip thickness for layer " << j << " not set, using default";
     }
     if (mDetectorThickness[j] == 0) {
-      LOG(INFO) << "Sensor thickness for layer " << j << " not set, using default" << FairLogger::endl;
+      LOG(INFO) << "Sensor thickness for layer " << j << " not set, using default";
     }
   }
 
@@ -792,7 +790,7 @@ void Detector::constructDetectorGeometry()
       mGeometry[j]->setStaveModel(mStaveModelOuterBarrel);
     }
 
-    LOG(DEBUG1) << "mBuildLevel: " << mBuildLevel[j] << FairLogger::endl;
+    LOG(DEBUG1) << "mBuildLevel: " << mBuildLevel[j];
 
     if (mChipThickness[j] != 0) {
       mGeometry[j]->setChipThick(mChipThickness[j]);
@@ -803,7 +801,7 @@ void Detector::constructDetectorGeometry()
 
     for (int iw = 0; iw < sNumberOfWrapperVolumes; iw++) {
       if (mLayerRadii[j] > mWrapperMinRadius[iw] && mLayerRadii[j] < mWrapperMaxRadius[iw]) {
-        LOG(INFO) << "Will embed layer " << j << " in wrapper volume " << iw << FairLogger::endl;
+        LOG(DEBUG) << "Will embed layer " << j << " in wrapper volume " << iw;
 
         dest = wrapVols[iw];
         mWrapperLayerId[j] = iw;
@@ -863,20 +861,20 @@ void Detector::addAlignableVolumes() const
   // Created:      06 Mar 2018  Mario Sitta First version (mainly ported from AliRoot)
   //
 
-  LOG(INFO) << "Add ITS alignable volumes" << FairLogger::endl;
+  LOG(INFO) << "Add ITS alignable volumes";
 
   if (!gGeoManager) {
-    LOG(FATAL) << "TGeoManager doesn't exist !" << FairLogger::endl;
+    LOG(FATAL) << "TGeoManager doesn't exist !";
     return;
   }
 
   TString path = Form("/cave_1/%s_2", GeometryTGeo::getITSVolPattern());
   TString sname = GeometryTGeo::composeSymNameITS();
 
-  LOG(DEBUG) << sname << " <-> " << path << FairLogger::endl;
+  LOG(DEBUG) << sname << " <-> " << path;
 
   if (!gGeoManager->SetAlignableEntry(sname.Data(), path.Data()))
-    LOG(FATAL) << "Unable to set alignable entry ! " << sname << " : " << path << FairLogger::endl;
+    LOG(FATAL) << "Unable to set alignable entry ! " << sname << " : " << path;
 
   Int_t lastUID = 0;
   for (Int_t lr = 0; lr < sNumberLayers; lr++)
@@ -898,10 +896,10 @@ void Detector::addAlignableVolumesLayer(int lr, TString& parent, Int_t& lastUID)
   TString path = Form("%s/%s/%s%d_1", parent.Data(), wrpV.Data(), GeometryTGeo::getITSLayerPattern(), lr);
   TString sname = GeometryTGeo::composeSymNameLayer(lr);
 
-  LOG(DEBUG) << "Add " << sname << " <-> " << path << FairLogger::endl;
+  LOG(DEBUG) << "Add " << sname << " <-> " << path;
 
   if (!gGeoManager->SetAlignableEntry(sname.Data(), path.Data()))
-    LOG(FATAL) << "Unable to set alignable entry ! " << sname << " : " << path << FairLogger::endl;
+    LOG(FATAL) << "Unable to set alignable entry ! " << sname << " : " << path;
 
   const V3Layer* lrobj = mGeometry[lr];
   Int_t nstaves = lrobj->getNumberOfStavesPerParent();
@@ -922,10 +920,10 @@ void Detector::addAlignableVolumesStave(Int_t lr, Int_t st, TString& parent, Int
   TString path = Form("%s/%s%d_%d", parent.Data(), GeometryTGeo::getITSStavePattern(), lr, st);
   TString sname = GeometryTGeo::composeSymNameStave(lr, st);
 
-  LOG(DEBUG) << "Add " << sname << " <-> " << path << FairLogger::endl;
+  LOG(DEBUG) << "Add " << sname << " <-> " << path;
 
   if (!gGeoManager->SetAlignableEntry(sname.Data(), path.Data()))
-    LOG(FATAL) << "Unable to set alignable entry ! " << sname << " : " << path << FairLogger::endl;
+    LOG(FATAL) << "Unable to set alignable entry ! " << sname << " : " << path;
 
   const V3Layer* lrobj = mGeometry[lr];
   Int_t nhstave = lrobj->getNumberOfHalfStavesPerParent();
@@ -949,10 +947,10 @@ void Detector::addAlignableVolumesHalfStave(Int_t lr, Int_t st, Int_t hst, TStri
     path = Form("%s/%s%d_%d", parent.Data(), GeometryTGeo::getITSHalfStavePattern(), lr, hst);
     TString sname = GeometryTGeo::composeSymNameHalfStave(lr, st, hst);
 
-    LOG(DEBUG) << "Add " << sname << " <-> " << path << FairLogger::endl;
+    LOG(DEBUG) << "Add " << sname << " <-> " << path;
 
     if (!gGeoManager->SetAlignableEntry(sname.Data(), path.Data()))
-      LOG(FATAL) << "Unable to set alignable entry ! " << sname << " : " << path << FairLogger::endl;
+      LOG(FATAL) << "Unable to set alignable entry ! " << sname << " : " << path;
   }
 
   const V3Layer* lrobj = mGeometry[lr];
@@ -977,10 +975,10 @@ void Detector::addAlignableVolumesModule(Int_t lr, Int_t st, Int_t hst, Int_t md
     path = Form("%s/%s%d_%d", parent.Data(), GeometryTGeo::getITSModulePattern(), lr, md);
     TString sname = GeometryTGeo::composeSymNameModule(lr, st, hst, md);
 
-    LOG(DEBUG) << "Add " << sname << " <-> " << path << FairLogger::endl;
+    LOG(DEBUG) << "Add " << sname << " <-> " << path;
 
     if (!gGeoManager->SetAlignableEntry(sname.Data(), path.Data()))
-      LOG(FATAL) << "Unable to set alignable entry ! " << sname << " : " << path << FairLogger::endl;
+      LOG(FATAL) << "Unable to set alignable entry ! " << sname << " : " << path;
   }
 
   const V3Layer* lrobj = mGeometry[lr];
@@ -1004,10 +1002,10 @@ void Detector::addAlignableVolumesChip(Int_t lr, Int_t st, Int_t hst, Int_t md, 
   TString sname = GeometryTGeo::composeSymNameChip(lr, st, hst, md, ch);
   Int_t modUID = chipVolUID(lastUID++);
 
-  LOG(DEBUG) << "Add " << sname << " <-> " << path << FairLogger::endl;
+  LOG(DEBUG) << "Add " << sname << " <-> " << path;
 
   if (!gGeoManager->SetAlignableEntry(sname, path.Data(), modUID))
-    LOG(FATAL) << "Unable to set alignable entry ! " << sname << " : " << path << FairLogger::endl;
+    LOG(FATAL) << "Unable to set alignable entry ! " << sname << " : " << path;
 
   return;
 }

--- a/Detectors/ITSMFT/MFT/base/src/GeometryBuilder.cxx
+++ b/Detectors/ITSMFT/MFT/base/src/GeometryBuilder.cxx
@@ -50,15 +50,15 @@ void GeometryBuilder::buildGeometry()
 
   TGeoVolume* volMFT = new TGeoVolumeAssembly(GeometryTGeo::getMFTVolPattern());
 
-  LOG(INFO) << "GeometryBuilder::buildGeometry volume name = " << GeometryTGeo::getMFTVolPattern() << FairLogger::endl;
+  LOG(INFO) << "GeometryBuilder::buildGeometry volume name = " << GeometryTGeo::getMFTVolPattern();
 
   TGeoVolume* vALIC = gGeoManager->GetVolume("cave");
   if (!vALIC) {
-    LOG(FATAL) << "Could not find the top volume" << FairLogger::endl;
+    LOG(FATAL) << "Could not find the top volume";
   }
 
-  Info("buildGeometry", Form("gGeoManager name is %s title is %s \n", gGeoManager->GetName(), gGeoManager->GetTitle()),
-       0, 0);
+  LOG(DEBUG) << "buildGeometry: "
+             << Form("gGeoManager name is %s title is %s", gGeoManager->GetName(), gGeoManager->GetTitle());
 
   Segmentation* seg = mftGeo->getSegmentation();
 

--- a/Detectors/ITSMFT/MFT/base/src/GeometryTGeo.cxx
+++ b/Detectors/ITSMFT/MFT/base/src/GeometryTGeo.cxx
@@ -64,7 +64,7 @@ GeometryTGeo::GeometryTGeo(Bool_t build, Int_t loadTrans) : o2::ITSMFT::Geometry
   // default c-tor, if build is true, the structures will be filled and the transform matrices
   // will be cached
   if (sInstance) {
-    LOG(FATAL) << "Invalid use of public constructor: o2::MFT::GeometryTGeo instance exists" << FairLogger::endl;
+    LOG(FATAL) << "Invalid use of public constructor: o2::MFT::GeometryTGeo instance exists";
     // throw std::runtime_error("Invalid use of public constructor: o2::MFT::GeometryTGeo instance exists");
   }
 
@@ -78,13 +78,13 @@ GeometryTGeo::GeometryTGeo(Bool_t build, Int_t loadTrans) : o2::ITSMFT::Geometry
 void GeometryTGeo::Build(Int_t loadTrans)
 {
   if (isBuilt()) {
-    LOG(WARNING) << "Already built" << FairLogger::endl;
+    LOG(WARNING) << "Already built";
     return; // already initialized
   }
 
   if (!gGeoManager) {
     // RSTODO: in future there will be a method to load matrices from the CDB
-    LOG(FATAL) << "Geometry is not loaded" << FairLogger::endl;
+    LOG(FATAL) << "Geometry is not loaded";
   }
 
   mNumberOfHalves = extractNumberOfHalves();
@@ -92,13 +92,13 @@ void GeometryTGeo::Build(Int_t loadTrans)
     return;
   }
 
-  // LOG(INFO) << "Number of halves " << mNumberOfHalves << FairLogger::endl;
+  // LOG(INFO) << "Number of halves " << mNumberOfHalves;
   mNumberOfDisks.resize(mNumberOfHalves);
 
   mTotalNumberOfSensors = 0;
   for (Int_t i = 0; i < mNumberOfHalves; i++) {
     mNumberOfDisks[i] = extractNumberOfDisks(i);
-    // LOG(INFO) << "Number of disks " << mNumberOfDisks[i] << " in half " << i << FairLogger::endl;
+    // LOG(INFO) << "Number of disks " << mNumberOfDisks[i] << " in half " << i;
 
     // use one half only
     if (i == 0) {
@@ -116,7 +116,7 @@ void GeometryTGeo::Build(Int_t loadTrans)
         for (Int_t nSensor = MinSensorsPerLadder; nSensor <= MaxSensorsPerLadder; nSensor++) {
           mNumberOfLadders[j][nSensor] = extractNumberOfLadders(i, j, nSensor);
           // LOG(INFO) << "Number of ladders with " << nSensor << " sensors is " << mNumberOfLadders[j][nSensor] << " in
-          // disk " << j << FairLogger::endl;
+          // disk " << j;
 
           numberOfLadders += mNumberOfLadders[j][nSensor];
           mTotalNumberOfSensors += mNumberOfLadders[j][nSensor] * nSensor;
@@ -135,7 +135,7 @@ void GeometryTGeo::Build(Int_t loadTrans)
           Int_t n = extractNumberOfLadders(i, j, nSensor, nL);
         } // nSensor
 
-        LOG(INFO) << "Disk " << j << " has " << mNumberOfSensorsPerDisk[j] << " sensors " << FairLogger::endl;
+        LOG(DEBUG) << "MFT: Disk " << j << " has " << mNumberOfSensorsPerDisk[j] << " sensors ";
 
       } // disk
 
@@ -144,8 +144,7 @@ void GeometryTGeo::Build(Int_t loadTrans)
   } // halves
 
   mTotalNumberOfSensors *= mNumberOfHalves;
-  LOG(INFO) << "Total number of sensors " << mTotalNumberOfSensors << " in " << mNumberOfHalves << " detector halves"
-            << FairLogger::endl;
+  LOG(DEBUG) << "MFT: Total number of sensors " << mTotalNumberOfSensors << " in " << mNumberOfHalves << " detector halves";
 
   mSensorIndexToLayer.resize(mTotalNumberOfSensors);
   mLayerMedianZ.resize(mNumberOfDisks[0]);
@@ -163,7 +162,7 @@ void GeometryTGeo::Build(Int_t loadTrans)
   }
   for (Int_t j = 0; j < mNumberOfDisks[0]; j++) {
     mLayerMedianZ[j] = 0.5 * (zLay0[j] + zLay1[j]);
-    // LOG(INFO) << "Disk " << j << " has median z " << mLayerMedianZ[j] << FairLogger::endl;
+    // LOG(INFO) << "Disk " << j << " has median z " << mLayerMedianZ[j];
   }
   for (Int_t i = 0; i < mTotalNumberOfSensors; i++) {
     TGeoHMatrix* hm = extractMatrixSensor(i);
@@ -185,7 +184,7 @@ void GeometryTGeo::Build(Int_t loadTrans)
     Int_t half = getHalf(i);
     Int_t ladderID = mLadderIndex2Id[disk][ladder];
     LOG(INFO) << "Index " << i << " half " << half << " disk " << disk << " ladder " << ladder << " geomap " << ladderID
-  << FairLogger::endl;
+;
   }
   */
   setSize(mTotalNumberOfSensors);
@@ -202,7 +201,7 @@ void GeometryTGeo::Build(Int_t loadTrans)
         for (Int_t iS = 0; iS < nS; iS++) {
           index = getSensorIndex(iH,iD,iL,iS);
           LOG(INFO) << "Half " << iH << " disk " << iD << " ladder " << ladder << " ladderID " << iL << " sensor " << iS
-  << " index " << index << FairLogger::endl;
+  << " index " << index;
         } // sensor
       } // ladder
     } // disk
@@ -218,13 +217,13 @@ Int_t GeometryTGeo::extractNumberOfSensorsPerLadder(Int_t half, Int_t disk, Int_
   snprintf(laddername, 30, "%s_%d_%d_%d", getMFTLadderPattern(), half, disk, ladder);
   TGeoVolume* volLadder = gGeoManager->GetVolume(laddername);
   if (!volLadder) {
-    LOG(FATAL) << "can't find volume " << laddername << FairLogger::endl;
+    LOG(FATAL) << "can't find volume " << laddername;
   }
   // Loop on all ladder nodes, count sensor volumes by checking names
   Int_t nNodes = volLadder->GetNodes()->GetEntries();
   for (int j = 0; j < nNodes; j++) {
     // LOG(INFO) << "GeometryTGeo::extractNumberOfSensorsPerLadder " << half << " " << disk << " " << ladder << " " <<
-    // volLadder->GetNodes()->At(j)->GetName() << FairLogger::endl;
+    // volLadder->GetNodes()->At(j)->GetName();
     if (strstr(volLadder->GetNodes()->At(j)->GetName(), getMFTChipPattern())) {
       numberOfSensors++;
     }
@@ -241,7 +240,7 @@ Int_t GeometryTGeo::extractNumberOfLadders(Int_t half, Int_t disk, Int_t nsensor
   snprintf(diskname, 30, "%s_%d_%d", getMFTDiskPattern(), half, disk);
   TGeoVolume* volDisk = gGeoManager->GetVolume(diskname);
   if (!volDisk) {
-    LOG(FATAL) << "can't find volume " << diskname << FairLogger::endl;
+    LOG(FATAL) << "can't find volume " << diskname;
   }
   // Loop on all disk nodes, count ladder volumes by checking names
   TObjArray* nodes = volDisk->GetNodes();
@@ -269,7 +268,7 @@ Int_t GeometryTGeo::extractNumberOfLadders(Int_t half, Int_t disk, Int_t nsensor
   snprintf(diskname, 30, "%s_%d_%d", getMFTDiskPattern(), half, disk);
   TGeoVolume* volDisk = gGeoManager->GetVolume(diskname);
   if (!volDisk) {
-    LOG(FATAL) << "can't find volume " << diskname << FairLogger::endl;
+    LOG(FATAL) << "can't find volume " << diskname;
   }
   // Loop on all disk nodes, count ladder volumes by checking names
   TObjArray* nodes = volDisk->GetNodes();
@@ -285,7 +284,7 @@ Int_t GeometryTGeo::extractNumberOfLadders(Int_t half, Int_t disk, Int_t nsensor
         mLadderIndex2Id[disk][nL] = ladderID;
         mLadderId2Index[disk][ladderID] = nL;
         // LOG(INFO) << "In disk " << disk << " ladder with " << nsensor << " sensors has matrix index " << nL << " and
-        // geometry index " << mLadderIndex2Id[disk][nL] << FairLogger::endl;
+        // geometry index " << mLadderIndex2Id[disk][nL];
         nL++;
         //
         numberOfLadders++;
@@ -304,7 +303,7 @@ Int_t GeometryTGeo::extractNumberOfDisks(Int_t half) const
   snprintf(halfname, 30, "%s_%d", getMFTHalfPattern(), half);
   TGeoVolume* volHalf = gGeoManager->GetVolume(halfname);
   if (!volHalf) {
-    LOG(FATAL) << "can't find " << halfname << " volume" << FairLogger::endl;
+    LOG(FATAL) << "can't find " << halfname << " volume";
     return -1;
   }
 
@@ -326,7 +325,7 @@ Int_t GeometryTGeo::extractNumberOfHalves()
 
   TGeoVolume* volMFT = gGeoManager->GetVolume(getMFTVolPattern());
   if (!volMFT) {
-    LOG(FATAL) << "MFT volume " << getMFTVolPattern() << " is not in the geometry" << FairLogger::endl;
+    LOG(FATAL) << "MFT volume " << getMFTVolPattern() << " is not in the geometry";
   }
 
   // Loop on all MFT nodes and count half detector volumes by checking names
@@ -341,7 +340,7 @@ Int_t GeometryTGeo::extractNumberOfHalves()
     if (strstr(name, getMFTHalfPattern())) {
       numberOfHalves++;
       if ((halfID = extractVolumeCopy(name, getMFTHalfPattern())) < 0) {
-        LOG(FATAL) << "Failed to extract half ID from the " << name << FairLogger::endl;
+        LOG(FATAL) << "Failed to extract half ID from the " << name;
         exit(1);
       }
     }
@@ -372,20 +371,20 @@ TGeoHMatrix* GeometryTGeo::extractMatrixSensor(Int_t index) const
   getSensorID(index, half, disk, ladder, sensor);
   ladderID = mLadderIndex2Id[disk][ladder];
   // LOG(INFO) << "extractMatrixSensor index " << index << " half " << half << " disk " << disk << " ladder " << ladder
-  // << " ladderID " << ladderID << FairLogger::endl;
+  // << " ladderID " << ladderID;
 
   TString path = Form("/cave_1/%s_0/", getMFTVolPattern());
   path += Form("%s_%d_%d/%s_%d_%d_%d/%s_%d_%d_%d_%d/%s_%d_%d_%d_%d/%s_1", getMFTHalfPattern(), half, half,
                getMFTDiskPattern(), half, disk, disk, getMFTLadderPattern(), half, disk, ladderID, ladderID,
                getMFTChipPattern(), half, disk, ladderID, sensor, getMFTSensorPattern());
-  // LOG(INFO) << "Volume path is " << path.Data() << FairLogger::endl;
+  // LOG(INFO) << "Volume path is " << path.Data();
 
   static TGeoHMatrix matTmp;
   gGeoManager->PushPath();
 
   if (!gGeoManager->cd(path.Data())) {
     gGeoManager->PopPath();
-    LOG(ERROR) << "Error in cd-ing to " << path.Data() << FairLogger::endl;
+    LOG(ERROR) << "Error in cd-ing to " << path.Data();
     return nullptr;
   } // end if !gGeoManager
 
@@ -409,7 +408,7 @@ void GeometryTGeo::fillMatrixCache(Int_t mask)
   // populate matrix cache for requested transformations
   //
   if (mSize < 1) {
-    LOG(WARNING) << "The method Build was not called yet" << FairLogger::endl;
+    LOG(WARNING) << "The method Build was not called yet";
     Build(mask);
     return;
   }
@@ -417,7 +416,7 @@ void GeometryTGeo::fillMatrixCache(Int_t mask)
   // FairLogger::endl;
   // build matrices
   if ((mask & o2::utils::bit2Mask(o2::TransformType::L2G)) && !getCacheL2G().isFilled()) {
-    LOG(INFO) << "Loading MFT L2G matrices from TGeo" << FairLogger::endl;
+    LOG(INFO) << "Loading MFT L2G matrices from TGeo";
     auto& cacheL2G = getCacheL2G();
     cacheL2G.setSize(mSize);
     for (Int_t i = 0; i < mSize; i++) {
@@ -428,7 +427,7 @@ void GeometryTGeo::fillMatrixCache(Int_t mask)
 
   if ((mask & o2::utils::bit2Mask(o2::TransformType::T2L)) && !getCacheT2L().isFilled()) {
     // matrices for Tracking to Local frame transformation
-    LOG(INFO) << "Loading MFT T2L matrices from TGeo" << FairLogger::endl;
+    LOG(INFO) << "Loading MFT T2L matrices from TGeo";
     auto& cacheT2L = getCacheT2L();
     cacheT2L.setSize(mSize);
     for (int i = 0; i < mSize; i++) {
@@ -439,7 +438,7 @@ void GeometryTGeo::fillMatrixCache(Int_t mask)
 
   if ((mask & o2::utils::bit2Mask(o2::TransformType::T2G)) && !getCacheT2G().isFilled()) {
     // matrices for Tracking to Global frame transformation
-    LOG(INFO) << "Loading MFT T2G matrices from TGeo" << FairLogger::endl;
+    LOG(INFO) << "Loading MFT T2G matrices from TGeo";
     auto& cacheT2G = getCacheT2G();
     cacheT2G.setSize(mSize);
     for (int i = 0; i < mSize; i++) {

--- a/Detectors/ITSMFT/MFT/base/src/HalfDetector.cxx
+++ b/Detectors/ITSMFT/MFT/base/src/HalfDetector.cxx
@@ -43,7 +43,7 @@ HalfDetector::HalfDetector(HalfSegmentation* seg) : TNamed(), mHalfVolume(nullpt
 
   SetName(Form("MFT_H_%d", mftGeom->getHalfID(GetUniqueID())));
 
-  Info("HalfDetector", Form("Creating : %s ", GetName()), 0, 0);
+  LOG(DEBUG) << Form("Creating : %s ", GetName());
 
   mHalfVolume = new TGeoVolumeAssembly(GetName());
 
@@ -58,8 +58,7 @@ HalfDetector::~HalfDetector() = default;
 //_____________________________________________________________________________
 void HalfDetector::createHalfDisks()
 {
-
-  Info("CreateHalfDisks", Form("Creating  %d Half-Disk ", mSegmentation->getNHalfDisks()), 0, 0);
+  LOG(DEBUG) << "MFT: " << Form("Creating  %d Half-Disk ", mSegmentation->getNHalfDisks());
 
   for (Int_t iDisk = 0; iDisk < mSegmentation->getNHalfDisks(); iDisk++) {
     HalfDiskSegmentation* halfDiskSeg = mSegmentation->getHalfDisk(iDisk);

--- a/Detectors/ITSMFT/MFT/base/src/HeatExchanger.cxx
+++ b/Detectors/ITSMFT/MFT/base/src/HeatExchanger.cxx
@@ -125,8 +125,7 @@ HeatExchanger::HeatExchanger(Double_t rWater, Double_t dRPipe, Double_t heatExch
 //_____________________________________________________________________________
 TGeoVolumeAssembly* HeatExchanger::create(Int_t half, Int_t disk)
 {
-
-  Info("Create", Form("Creating HeatExchanger_%d_%d", disk, half), 0, 0);
+  LOG(DEBUG) << "Create" << Form("Creating HeatExchanger_%d_%d", disk, half);
 
   mHalfDisk = new TGeoVolumeAssembly(Form("HeatExchanger_%d_%d", disk, half));
   switch (disk) {
@@ -147,7 +146,7 @@ TGeoVolumeAssembly* HeatExchanger::create(Int_t half, Int_t disk)
       break;
   }
 
-  Info("Create", Form("... done HeatExchanger_%d_%d", disk, half), 0, 0);
+  LOG(DEBUG) << "Create", Form("... done HeatExchanger_%d_%d", disk, half);
 
   return mHalfDisk;
 }
@@ -207,12 +206,13 @@ void HeatExchanger::createHalfDisk0(Int_t half)
 
   Int_t disk = 0;
 
-  if (half == Top)
-    printf("Creating MFT heat exchanger for disk0 top\n");
-  else if (half == Bottom)
-    printf("Creating MFT heat exchanger for disk0 bottom\n");
-  else
-    printf("No valid option for MFT heat exchanger on disk0\n");
+  if (half == Top) {
+    LOG(DEBUG) << "Creating MFT heat exchanger for disk0 top";
+  } else if (half == Bottom) {
+    LOG(DEBUG) << "Creating MFT heat exchanger for disk0 bottom";
+  } else {
+    LOG(DEBUG) << "No valid option for MFT heat exchanger on disk0";
+  }
 
   // mCarbon   = gGeoManager->GetMedium("MFT_Carbon$");
   mCarbon = gGeoManager->GetMedium("MFT_CarbonFiber$");
@@ -677,12 +677,13 @@ void HeatExchanger::createHalfDisk1(Int_t half)
 
   Int_t disk = 1;
 
-  if (half == Top)
-    printf("Creating MFT heat exchanger for disk1 top\n");
-  else if (half == Bottom)
-    printf("Creating MFT heat exchanger for disk1 bottom\n");
-  else
-    printf("No valid option for MFT heat exchanger on disk1\n");
+  if (half == Top) {
+    LOG(DEBUG) << "Creating MFT heat exchanger for disk1 top";
+  } else if (half == Bottom) {
+    LOG(DEBUG) << "Creating MFT heat exchanger for disk1 bottom";
+  } else {
+    LOG(DEBUG) << "No valid option for MFT heat exchanger on disk1";
+  }
 
   // mCarbon   = gGeoManager->GetMedium("MFT_Carbon$");
   mCarbon = gGeoManager->GetMedium("MFT_CarbonFiber$");
@@ -1142,12 +1143,13 @@ void HeatExchanger::createHalfDisk2(Int_t half)
 
   Int_t disk = 2;
 
-  if (half == Top)
-    printf("Creating MFT heat exchanger for disk2 top\n");
-  else if (half == Bottom)
-    printf("Creating MFT heat exchanger for disk2 bottom\n");
-  else
-    printf("No valid option for MFT heat exchanger on disk2\n");
+  if (half == Top) {
+    LOG(DEBUG) << "Creating MFT heat exchanger for disk2 top";
+  } else if (half == Bottom) {
+    LOG(DEBUG) << "Creating MFT heat exchanger for disk2 bottom";
+  } else {
+    LOG(DEBUG) << "No valid option for MFT heat exchanger on disk2";
+  }
 
   // mCarbon   = gGeoManager->GetMedium("MFT_Carbon$");
   mCarbon = gGeoManager->GetMedium("MFT_CarbonFiber$");
@@ -1609,12 +1611,13 @@ void HeatExchanger::createHalfDisk3(Int_t half)
 
   Int_t disk = 3;
 
-  if (half == Top)
-    printf("Creating MFT heat exchanger for disk3 top\n");
-  else if (half == Bottom)
-    printf("Creating MFT heat exchanger for disk3 bottom\n");
-  else
-    printf("No valid option for MFT heat exchanger on disk3\n");
+  if (half == Top) {
+    LOG(DEBUG) << "Creating MFT heat exchanger for disk3 top";
+  } else if (half == Bottom) {
+    LOG(DEBUG) << "Creating MFT heat exchanger for disk3 bottom";
+  } else {
+    LOG(DEBUG) << "No valid option for MFT heat exchanger on disk3";
+  }
 
   // mCarbon   = gGeoManager->GetMedium("MFT_Carbon$");
   mCarbon = gGeoManager->GetMedium("MFT_CarbonFiber$");
@@ -2108,12 +2111,13 @@ void HeatExchanger::createHalfDisk4(Int_t half)
 
   Int_t disk = 4;
 
-  if (half == Top)
-    printf("Creating MFT heat exchanger for disk4 top\n");
-  else if (half == Bottom)
-    printf("Creating MFT heat exchanger for disk4 bottom\n");
-  else
-    printf("No valid option for MFT heat exchanger on disk4\n");
+  if (half == Top) {
+    LOG(DEBUG) << "Creating MFT heat exchanger for disk4 top";
+  } else if (half == Bottom) {
+    LOG(DEBUG) << "Creating MFT heat exchanger for disk4 bottom";
+  } else {
+    LOG(DEBUG) << "No valid option for MFT heat exchanger on disk4";
+  }
 
   // mCarbon   = gGeoManager->GetMedium("MFT_Carbon$");
   mCarbon = gGeoManager->GetMedium("MFT_CarbonFiber$");

--- a/Detectors/ITSMFT/MFT/base/src/Segmentation.cxx
+++ b/Detectors/ITSMFT/MFT/base/src/Segmentation.cxx
@@ -63,8 +63,7 @@ Segmentation::~Segmentation()
 //_____________________________________________________________________________
 HalfSegmentation* Segmentation::getHalf(Int_t iHalf) const
 {
-
-  Info("GetHalf", Form("Ask for half %d (of %d and %d)", iHalf, Bottom, Top), 0, 0);
+  LOG(DEBUG) << Form("Ask for half %d (of %d and %d)", iHalf, Bottom, Top);
 
   return ((iHalf == Top || iHalf == Bottom) ? ((HalfSegmentation*)mHalves->At(iHalf)) : nullptr);
 }
@@ -74,11 +73,11 @@ HalfSegmentation* Segmentation::getHalf(Int_t iHalf) const
 //_____________________________________________________________________________
 void Segmentation::Clear(const Option_t* /*opt*/)
 {
-
-  if (mHalves)
+  if (mHalves) {
     mHalves->Delete();
-  delete mHalves;
-  mHalves = nullptr;
+    delete mHalves;
+    mHalves = nullptr;
+  }
 }
 
 /// Returns the local ID of the sensor on the entire disk specified

--- a/Detectors/ITSMFT/MFT/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/MFT/simulation/src/Detector.cxx
@@ -124,7 +124,7 @@ Bool_t Detector::ProcessHits(FairVolume* vol)
   Int_t sensorIndex = mGeometryTGeo->getSensorIndex(halfID, diskID, ladderID, sensorID);
 
   // LOG(INFO) << "Found hit into half = " << halfID << "; disk = " << diskID << "; ladder = " << ladderID << "; sensor
-  // = " << sensorID << FairLogger::endl;
+  // = " << sensorID ;
 
   bool startHit = false, stopHit = false;
   unsigned char status = 0;
@@ -329,7 +329,7 @@ void Detector::createMaterials()
   Float_t maxField;
   o2::Base::Detector::initFieldTrackingParams(fieldType, maxField);
 
-  LOG(INFO) << "Detector::createMaterials >>>>> fieldType " << fieldType << " maxField " << maxField << "\n";
+  LOG(DEBUG) << "Detector::createMaterials >>>>> fieldType " << fieldType << " maxField " << maxField;
 
   o2::Base::Detector::Mixture(++matId, "Air$", aAir, zAir, dAir, nAir, wAir);
   o2::Base::Detector::Medium(Air, "Air$", matId, unsens, fieldType, maxField, tmaxfd, stemax, deemax, epsil, stmin);
@@ -426,7 +426,7 @@ void Detector::createMaterials()
   o2::Base::Detector::Medium(CarbonFleece, "CarbonFleece$", matId, unsens, itgfld, maxfld, tmaxfd, stemax, deemax,
                              epsil, stmin);
 
-  LOG(INFO) << "Detector::createMaterials -----> matId = " << matId << "\n";
+  LOG(DEBUG) << "Detector::createMaterials -----> matId = " << matId;
 }
 
 //_____________________________________________________________________________
@@ -454,13 +454,13 @@ void Detector::defineSensitiveVolumes()
 
   vol = gGeoManager->GetVolume("MFTSensor");
   if (!vol) {
-    LOG(FATAL) << "can't find volume MFTSensor" << FairLogger::endl;
+    LOG(FATAL) << "can't find volume MFTSensor";
   } else {
     AddSensitiveVolume(vol);
     if (!mftGeom->getSensorVolumeID()) {
       mftGeom->setSensorVolumeID(vol->GetNumber());
     } else if (mftGeom->getSensorVolumeID() != vol->GetNumber()) {
-      LOG(FATAL) << "CreateSensors: different Sensor volume ID !!!!" << FairLogger::endl;
+      LOG(FATAL) << "CreateSensors: different Sensor volume ID !!!!";
     }
   }
 }

--- a/Detectors/TOF/simulation/src/Detector.cxx
+++ b/Detectors/TOF/simulation/src/Detector.cxx
@@ -293,7 +293,7 @@ void Detector::ConstructGeometry()
   Float_t xTof = Geo::STRIPLENGTH + 2.5, yTof = Geo::RMAX - Geo::RMIN, zTof = Geo::ZLENA;
   DefineGeometry(xTof, yTof, zTof);
 
-  LOG(INFO) << "Loaded TOF geometry" << FairLogger::endl;
+  LOG(INFO) << "Loaded TOF geometry";
 }
 
 void Detector::EndOfEvent() { Reset(); }
@@ -1848,7 +1848,7 @@ void Detector::addAlignableVolumes() const
   for (Int_t isect = 0; isect < Geo::NSECTORS; isect++) {
     for (Int_t istr = 1; istr <= Geo::NSTRIPXSECTOR; istr++) {
       modUID = o2::Base::GeometryManager::getSensID(idTOF, modnum++);
-      LOG(INFO) << "modUID: " << modUID << "\n";
+      LOG(DEBUG) << "modUID: " << modUID;
 
       if (mTOFSectors[isect] == -1)
         continue;
@@ -1889,15 +1889,16 @@ void Detector::addAlignableVolumes() const
       LOG(DEBUG) << "--------------------------------------------"
                  << "\n";
 
-      LOG(INFO) << "Check for alignable entry: " << symName << "\n";
+      LOG(DEBUG) << "Check for alignable entry: " << symName;
 
-      if (!gGeoManager->SetAlignableEntry(symName.Data(), volPath.Data(), modUID))
-        LOG(ERROR) << "Alignable entry " << symName << " NOT set\n";
-      LOG(INFO) << "Alignable entry " << symName << " set\n";
+      if (!gGeoManager->SetAlignableEntry(symName.Data(), volPath.Data(), modUID)) {
+        LOG(ERROR) << "Alignable entry " << symName << " NOT set";
+      }
+      LOG(DEBUG) << "Alignable entry " << symName << " set";
 
       // T2L matrices for alignment
       TGeoPNEntry* e = gGeoManager->GetAlignableEntryByUID(modUID);
-      LOG(INFO) << "Got TGeoPNEntry " << e << "\n";
+      LOG(DEBUG) << "Got TGeoPNEntry " << e;
 
       if (e) {
         TGeoHMatrix* globMatrix = e->GetGlobalOrig();

--- a/Generators/src/GeneratorFactory.cxx
+++ b/Generators/src/GeneratorFactory.cxx
@@ -35,7 +35,7 @@ void GeneratorFactory::setPrimaryGenerator(o2::conf::SimConfig const& conf, Fair
   auto genconfig = conf.getGenerator();
   if (genconfig.compare("boxgen") == 0) {
     // a simple "box" generator
-    std::cout << "Init box generator\n";
+    LOG(INFO) << "Init box generator";
     auto boxGen = new FairBoxGenerator(211, 10); /*protons*/
     boxGen->SetEtaRange(-0.9, 0.9);
     boxGen->SetPRange(0.1, 5);
@@ -44,7 +44,7 @@ void GeneratorFactory::setPrimaryGenerator(o2::conf::SimConfig const& conf, Fair
     primGen->AddGenerator(boxGen);
   } else if (genconfig.compare("fwmugen") == 0) {
     // a simple "box" generator for forward muons
-    std::cout << "Init box forward muons generator\n";
+    LOG(INFO) << "Init box forward muons generator";
     auto boxGen = new FairBoxGenerator(13, 1); /* mu- */
     boxGen->SetEtaRange(-2.5, -4.0);
     boxGen->SetPRange(100.0, 100.0);
@@ -52,7 +52,7 @@ void GeneratorFactory::setPrimaryGenerator(o2::conf::SimConfig const& conf, Fair
     primGen->AddGenerator(boxGen);
   } else if (genconfig.compare("fwpigen") == 0) {
     // a simple "box" generator for forward pions
-    std::cout << "Init box forward muons generator\n";
+    LOG(INFO) << "Init box forward muons generator";
     auto boxGen = new FairBoxGenerator(-211, 1); /* pi- */
     boxGen->SetEtaRange(-2.5, -4.0);
     boxGen->SetPRange(7.0, 7.0);
@@ -60,7 +60,7 @@ void GeneratorFactory::setPrimaryGenerator(o2::conf::SimConfig const& conf, Fair
     primGen->AddGenerator(boxGen);
   } else if (genconfig.compare("fwrootino") == 0) {
     // a simple "box" generator for forward rootinos
-    std::cout << "Init box forward rootinos generator\n";
+    LOG(INFO) << "Init box forward rootinos generator";
     auto boxGen = new FairBoxGenerator(0, 1); /* mu- */
     boxGen->SetEtaRange(-2.5, -4.0);
     boxGen->SetPRange(1, 5);
@@ -73,7 +73,7 @@ void GeneratorFactory::setPrimaryGenerator(o2::conf::SimConfig const& conf, Fair
     auto extGen = new o2::eventgen::GeneratorFromFile(conf.getExtKinematicsFileName().c_str());
     extGen->SetStartEvent(conf.getStartEvent());
     primGen->AddGenerator(extGen);
-    std::cout << "using external kinematics\n";
+    LOG(INFO) << "using external kinematics";
   } else if (genconfig.compare("pythia8") == 0) {
     // pythia8 pp
     // configures pythia for min.bias pp collisions at 14 TeV
@@ -105,7 +105,7 @@ void GeneratorFactory::setPrimaryGenerator(o2::conf::SimConfig const& conf, Fair
     py8Gen->SetParameters("ParticleDecays:limitCylinder on");
     primGen->AddGenerator(py8Gen);
   } else {
-    LOG(FATAL) << "Invalid generator" << FairLogger::endl;
+    LOG(FATAL) << "Invalid generator";
   }
 }
 

--- a/macro/build_geometry.C
+++ b/macro/build_geometry.C
@@ -47,7 +47,7 @@ bool isActivated(std::string s)
   auto& modulelist = o2::conf::SimConfig::Instance().getActiveDetectors();
   auto active = std::find(modulelist.begin(), modulelist.end(), s) != modulelist.end();
   if (active) {
-    std::cout << "Activating " << s << " module \n";
+    LOG(INFO) << "Activating " << s << " module";
   }
   return active;
 }

--- a/run/o2sim.cxx
+++ b/run/o2sim.cxx
@@ -22,6 +22,10 @@ int main(int argc, char* argv[])
     return 1;
   }
 
+  // customize the level of output
+  FairLogger::GetLogger()->SetLogScreenLevel(conf.getLogSeverity().c_str());
+  FairLogger::GetLogger()->SetLogVerbosityLevel(conf.getLogVerbosity().c_str());
+
   // call o2sim "macro"
   o2sim(false);
 


### PR DESCRIPTION
This commit is doing some cleanup and uniformization on the logging
printouts.

Do
* less logging to INFO since this leads to very large unreadable printouts
  at each simulations start
* remove unnecessary endl and "\n"
* favour LOG(INFO) over Info(...) from ROOT

This also introduces a configurability of the logseverity and logverbosity
from the command line. We can now say

```
o2sim --logverbosity veryhigh --logseverity DEBUG3 ...
```

to see everything up to DEBUG3 level with veryhigh verbosity
(see FairLogger for more info).