### PR TITLE
DPL: add Idle & ClockTick callbacks

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -203,6 +203,7 @@ set(TEST_SRCS
       test/test_AlgorithmSpec.cxx
       test/test_BoostOptionsRetriever.cxx
       test/test_CallbackRegistry.cxx
+      test/test_CallbackService.cxx
       test/test_ChannelSpecHelpers.cxx
       test/test_CompletionPolicy.cxx
       test/test_DanglingInputs.cxx

--- a/Framework/Core/README.md
+++ b/Framework/Core/README.md
@@ -360,6 +360,10 @@ A service that data processors can register callback functions invoked by the fr
 * `CallbackService::Id::Stop`: before exiting the running state.
 * `CallbackService::Id::Reset`: before resetting the device.
 
+Moreover in case you want to process events which are not coming from `FairMQ`, there is a `CallbackService::Id::ClockTick` which is called according to the rate specified for the backing FairMQ device.
+
+Similarly the `CallbackService::Id::Idle` callback is fired whenever there
+was nothing to process.
 
 ## Expressing parallelism
 

--- a/Framework/Core/include/Framework/CallbackService.h
+++ b/Framework/Core/include/Framework/CallbackService.h
@@ -23,8 +23,14 @@ namespace framework
 class CallbackService
 {
  public:
-  // the defined processing steps at which a callback can be invoked
-  enum class Id { Start, Stop, Reset };
+  /// the defined processing steps at which a callback can be invoked
+  enum class Id {
+    Start,    /**< Invoked before the inner loop is started */
+    Stop,     /**< Invoked when the device is about to be stoped */
+    Reset,    /**< Invoked on device rest */
+    Idle,     /**< Invoked when there was no computation scheduled */
+    ClockTick /**< Invoked every iteration of the inner loop */
+  };
 
   template <typename T, T... v>
   class EnumRegistry
@@ -36,11 +42,16 @@ class CallbackService
   using StartCallback = std::function<void()>;
   using StopCallback = std::function<void()>;
   using ResetCallback = std::function<void()>;
-  using Callbacks = CallbackRegistry<Id,                                         //
-                                     RegistryPair<Id, Id::Start, StartCallback>, //
-                                     RegistryPair<Id, Id::Stop, StopCallback>,   //
-                                     RegistryPair<Id, Id::Reset, ResetCallback>  //
-                                     >;                                          //
+  using IdleCallback = std::function<void()>;
+  using ClockTickCallback = std::function<void()>;
+
+  using Callbacks = CallbackRegistry<Id,                                                //
+                                     RegistryPair<Id, Id::Start, StartCallback>,        //
+                                     RegistryPair<Id, Id::Stop, StopCallback>,          //
+                                     RegistryPair<Id, Id::Reset, ResetCallback>,        //
+                                     RegistryPair<Id, Id::Idle, IdleCallback>,          //
+                                     RegistryPair<Id, Id::ClockTick, ClockTickCallback> //
+                                     >;                                                 //
 
   // set callback for specified processing step
   template <typename U>

--- a/Framework/Core/test/test_CallbackService.cxx
+++ b/Framework/Core/test/test_CallbackService.cxx
@@ -1,0 +1,56 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include <iostream>
+#include <boost/algorithm/string.hpp>
+
+#include "Framework/InputSpec.h"
+#include "Framework/CallbackService.h"
+#include "Framework/ControlService.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/ParallelContext.h"
+#include "Framework/runDataProcessing.h"
+#include "Framework/DebugGUI.h"
+#include "DebugGUI/imgui.h"
+
+using namespace o2::framework;
+using DataHeader = o2::header::DataHeader;
+
+WorkflowSpec defineDataProcessing(ConfigContext const&)
+{
+  return WorkflowSpec{
+    { "source",
+      Inputs{},
+      {
+        OutputSpec{ { "test" }, "TST", "A" },
+      },
+      AlgorithmSpec{
+        [](ProcessingContext& ctx) {
+          sleep(1);
+          auto out = ctx.outputs().make<int>(OutputRef{ "test", 0 });
+        } } },
+    { "dest",
+      Inputs{
+        { "test", "TST", "A" } },
+      Outputs{},
+      AlgorithmSpec{
+        [](InitContext& ic) {
+          auto count = std::make_shared<int>(0);
+          auto callback = [count]() {
+            (*count)++;
+          };
+          ic.services().get<CallbackService>().set(CallbackService::Id::ClockTick, callback);
+          return [count](ProcessingContext& ctx) {
+            if (*count > 1000) {
+              ctx.services().get<ControlService>().readyToQuit(true);
+            }
+          };
+        } } }
+  };
+}


### PR DESCRIPTION
This introduces two new kinds of callbacks in the `CallbackService`:

* `ClockTick`: invoked on each iteration of the FairMQ event loop.
* `Idle`: invoked whenever there was no data to be processed.