### PR TITLE
Adding missing option '--tracker-options' to tracker spec

### DIFF
--- a/Detectors/TPC/workflow/README.md
+++ b/Detectors/TPC/workflow/README.md
@@ -57,6 +57,14 @@ tpc-reco-workflow --infile tpcdigits.root --tpc-sectors 0-15 --disable-mc 1
 Support for all other output types than `tracks` is going to be implemented soon, multiple outputs
 will be supported in order to keep the data at intermediate steps.
 
+### Processor options
+
+#### TPC CA tracker
+The [tracker spec](src/CATrackerSpec.cxx) interfaces the [o2::TPC::TPCCATracking](reconstruction/include/TPCReconstruction/TPCCATracking.h) worker class which can be initialized using an option string. The processor spec defines the option `--tracker-option`, e.g.
+```
+--tracker-option ""refX=83""
+```
+
 ### Current limitations
 * track labels not yet written to file
 * only the full workflow with input type `digits` and output type `tracks` has been tested so far

--- a/Detectors/TPC/workflow/src/CATrackerSpec.cxx
+++ b/Detectors/TPC/workflow/src/CATrackerSpec.cxx
@@ -255,7 +255,10 @@ DataProcessorSpec getCATrackerSpec(bool processMC)
   return DataProcessorSpec{ "tracker", // process id
                             { createInputSpecs(processMC) },
                             { createOutputSpecs(false /*create onece writer process has been changed*/) },
-                            AlgorithmSpec(initFunction) };
+                            AlgorithmSpec(initFunction),
+                            Options{
+                              { "tracker-options", VariantType::String, "", { "Option string passed to tracker" } },
+                            } };
 }
 
 } // namespace TPC


### PR DESCRIPTION
This has actually been forgotten to be added to the options definition while
it was already queried. Have to check why the error message slipped through.

The TPCCATracking worker class can be initialized with a string of options,
e.g. now one can specify --tracker-options "refX=83"