### PR TITLE
Protection when CUDA headers are loaded

### DIFF
--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/Definitions.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CA/Definitions.h
@@ -79,6 +79,8 @@ typedef cudaStream_t GPUStream;
 #define MATH_MIN std::min
 #define MATH_SQRT std::sqrt
 
+#ifndef __VECTOR_TYPES_H__
+//This will clash if any other header has pulled in CUDA before
 typedef struct _dim3 {
   unsigned int x, y, z;
 } dim3;
@@ -94,6 +96,7 @@ typedef struct _float3 {
 typedef struct _float4 {
   float x, y, z, w;
 } float4;
+#endif
 
 template <typename T, std::size_t Size>
 using GPUArray = std::array<T, Size>;


### PR DESCRIPTION
When CUDA headers are loaded, and the non-CUDA version of ITS tracking is used, these definitions will clash with CUDA. In particular, this automatically fails if ROOT is build against CUDA. This patch is not really perfect, as it only handles the case when the CUDA header is loaded first, but at least it fixes the problem in ROOT, and I do not see a better solution.