### PR TITLE
Implementing parallel processing in the tpc-reco-workflow

### DIFF
--- a/Detectors/TPC/workflow/CMakeLists.txt
+++ b/Detectors/TPC/workflow/CMakeLists.txt
@@ -12,28 +12,30 @@ set(MODULE_NAME "TPCWorkflow")
 set(MODULE_BUCKET_NAME TPC_workflow_bucket)
 
 O2_SETUP(NAME ${MODULE_NAME})
-#set(SRCS
-#   )
+set(SRCS
+   src/RecoWorkflow.cxx
+   src/DigitReaderSpec.cxx
+   src/ClusterReaderSpec.cxx
+   src/ClustererSpec.cxx
+   src/ClusterConverterSpec.cxx
+   src/ClusterDecoderRawSpec.cxx
+   src/CATrackerSpec.cxx
+   src/RootFileWriterSpec.cxx
+   )
 
 ## TODO: feature of macro, it deletes the variables we pass to it, set them again
 ## this has to be fixed in the macro implementation
 set(LIBRARY_NAME ${MODULE_NAME})
 set(BUCKET_NAME ${MODULE_BUCKET_NAME})
 
-#O2_GENERATE_LIBRARY()
+O2_GENERATE_LIBRARY()
 
 O2_GENERATE_EXECUTABLE(
   EXE_NAME tpc-reco-workflow
 
   SOURCES
   src/tpc-reco-workflow.cxx
-  src/DigitReaderSpec.cxx
-  src/ClusterReaderSpec.cxx
-  src/ClustererSpec.cxx
-  src/ClusterConverterSpec.cxx
-  src/ClusterDecoderRawSpec.cxx
-  src/CATrackerSpec.cxx
-  src/RootFileWriterSpec.cxx
 
-  BUCKET_NAME ${MODULE_BUCKET_NAME}
+  MODULE_LIBRARY_NAME ${LIBRARY_NAME}
+  BUCKET_NAME ${BUCKET_NAME}
 )

--- a/Detectors/TPC/workflow/README.md
+++ b/Detectors/TPC/workflow/README.md
@@ -53,9 +53,14 @@ tpc-reco-workflow --infile tpcdigits.root --tpc-sectors 0-15 --disable-mc 1
 --input-type arg (=digits)            digits, clusters, raw
 --output-type arg (=tracks)           clusters, raw, tracks
 --disable-mc arg (=0)                 disable sending of MC information
+--tpc-lanes arg (=1)                  number of parallel lanes up to the tracker
 ```
 Support for all other output types than `tracks` is going to be implemented soon, multiple outputs
 will be supported in order to keep the data at intermediate steps.
+
+#### Parallel processing
+Parallel processing is controlled by the option `--tpc-lanes n`. The digit reader will fan out to n processing
+lanes, each with clusterer, converter and decoder. The tracker will fan in from the parallel lanes.
 
 ### Processor options
 

--- a/Detectors/TPC/workflow/include/TPCWorkflow/RecoWorkflow.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/RecoWorkflow.h
@@ -1,0 +1,45 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TPC_RECOWORKFLOW_H
+#define O2_TPC_RECOWORKFLOW_H
+/// @file   RecoWorkflow.h
+/// @author Matthias Richter
+/// @since  2018-09-26
+/// @brief  Workflow definition for the TPC reconstruction
+
+#include "Framework/WorkflowSpec.h"
+#include <string>
+namespace o2
+{
+namespace TPC
+{
+
+namespace RecoWorkflow
+{
+/// define input and output types of the workflow
+enum struct InputType { Digitizer, // directly read digits from  {TPC:DIGITS}
+                        Digits,    // read digits from file
+                        Clusters,  // read clusters from file
+                        Raw };
+enum struct OutputType { Clusters,
+                         Raw,
+                         DecodedClusters,
+                         Tracks };
+
+/// create the workflow for TPC reconstruction
+framework::WorkflowSpec getWorkflow(bool propagateMC = true, int nLanes = 1,                               //
+                                    std::string inputType = "digitizer", std::string outputType = "tracks" //
+                                    );
+
+} // end namespace RecoWorkflow
+} // end namespace TPC
+} // end namespace o2
+#endif //O2_TPC_RECOWORKFLOW_H

--- a/Detectors/TPC/workflow/src/CATrackerSpec.h
+++ b/Detectors/TPC/workflow/src/CATrackerSpec.h
@@ -22,7 +22,7 @@ namespace TPC
 
 /// create a processor spec
 /// read simulated TPC clusters from file and publish
-framework::DataProcessorSpec getCATrackerSpec(bool processMC = false);
+framework::DataProcessorSpec getCATrackerSpec(bool processMC = false, size_t fanIn = 1);
 
 } // end namespace TPC
 } // end namespace o2

--- a/Detectors/TPC/workflow/src/ClusterConverterSpec.h
+++ b/Detectors/TPC/workflow/src/ClusterConverterSpec.h
@@ -22,7 +22,7 @@ namespace TPC
 
 /// create a processor spec
 /// read simulated TPC clusters from file and publish
-framework::DataProcessorSpec getClusterConverterSpec(bool sendMC);
+framework::DataProcessorSpec getClusterConverterSpec(bool sendMC, int fanNumber = -1);
 
 } // end namespace TPC
 } // end namespace o2

--- a/Detectors/TPC/workflow/src/ClusterDecoderRawSpec.h
+++ b/Detectors/TPC/workflow/src/ClusterDecoderRawSpec.h
@@ -22,7 +22,7 @@ namespace TPC
 
 /// create a processor spec
 /// read simulated TPC clusters from file and publish
-framework::DataProcessorSpec getClusterDecoderRawSpec(bool sendMC = false);
+framework::DataProcessorSpec getClusterDecoderRawSpec(bool sendMC = false, int fanNumber = -1);
 
 } // end namespace TPC
 } // end namespace o2

--- a/Detectors/TPC/workflow/src/ClustererSpec.cxx
+++ b/Detectors/TPC/workflow/src/ClustererSpec.cxx
@@ -38,8 +38,19 @@ using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
 
 /// create a processor spec
 /// runs the TPC HwClusterer in a DPL process with digits and mc as input
-DataProcessorSpec getClustererSpec(bool sendMC)
+DataProcessorSpec getClustererSpec(bool sendMC, int fanNumber)
 {
+  std::string processorName = "tpc-clusterer";
+  o2::header::DataHeader::SubSpecificationType fanSpec = 0;
+  if (fanNumber < 0) {
+    // only one instance; set to 0, it is used as subspecification
+    fanNumber = 0;
+  } else {
+    // multiple instances, add number to name
+    processorName += std::to_string(fanNumber);
+    fanSpec = fanNumber;
+  }
+
   constexpr static size_t NSectors = o2::TPC::Sector::MAXSECTOR;
   struct ProcessAttributes {
     std::vector<o2::TPC::Cluster> clusterArray;
@@ -48,32 +59,38 @@ DataProcessorSpec getClustererSpec(bool sendMC)
     int verbosity = 1;
   };
 
-  auto initFunction = [sendMC](InitContext& ic) {
+  auto initFunction = [sendMC, fanSpec](InitContext& ic) {
     // FIXME: the clusterer needs to be initialized with the sector number, so we need one
     // per sector. Taking a closer look to the HwClusterer, the sector number is only used
     // for calculating the CRU id. This could be achieved by passing the current sector as
     // parameter to the clusterer processing function.
     auto processAttributes = std::make_shared<ProcessAttributes>();
 
-    auto processingFct = [processAttributes, sendMC](ProcessingContext& pc) {
+    auto processingFct = [processAttributes, sendMC, fanSpec](ProcessingContext& pc) {
       auto& clusterArray = processAttributes->clusterArray;
       auto& mctruthArray = processAttributes->mctruthArray;
       auto& clusterers = processAttributes->clusterers;
       auto& verbosity = processAttributes->verbosity;
-      auto inDigits = pc.inputs().get<const std::vector<o2::TPC::Digit>>("digits");
-      if (verbosity > 0) {
-        LOG(INFO) << "received " << inDigits.size() << " digits";
-      }
-      auto inMCLabels = pc.inputs().get<const MCLabelContainer*>("mclabels");
-      auto const* sectorHeader = DataRefUtils::getHeader<o2::TPC::TPCSectorHeader*>(pc.inputs().get("mclabels"));
+      auto const* sectorHeader = DataRefUtils::getHeader<o2::TPC::TPCSectorHeader*>(pc.inputs().get("digits"));
       if (sectorHeader == nullptr) {
         LOG(ERROR) << "sector header missing on header stack";
         return;
       }
       const auto sector = sectorHeader->sector;
       if (sector < 0) {
-        // FIXME: we need to propagate something
+        // forward the control information
+        // FIXME define and use flags in TPCSectorHeader
+        o2::TPC::TPCSectorHeader header{ sector };
+        pc.outputs().snapshot(OutputRef{ "clusters", fanSpec, { header } }, fanSpec);
+        if (sendMC) {
+          pc.outputs().snapshot(OutputRef{ "clusterlbl", fanSpec, { header } }, fanSpec);
+        }
         return;
+      }
+      auto inMCLabels = pc.inputs().get<const MCLabelContainer*>("mclabels");
+      auto inDigits = pc.inputs().get<const std::vector<o2::TPC::Digit>>("digits");
+      if (verbosity > 0) {
+        LOG(INFO) << "received " << inDigits.size() << " digits";
       }
       if (!clusterers[sector]) {
         // create the clusterer for this sector, take the same target arrays for all clusterers
@@ -97,31 +114,31 @@ DataProcessorSpec getClustererSpec(bool sendMC)
       if (verbosity > 0) {
         LOG(INFO) << "clusterer produced " << clusterArray.size() << " cluster container";
       }
-      pc.outputs().snapshot(OutputRef{ "clusters", 0, { *sectorHeader } }, clusterArray);
+      pc.outputs().snapshot(OutputRef{ "clusters", fanSpec, { *sectorHeader } }, clusterArray);
       if (sendMC) {
-        pc.outputs().snapshot(OutputRef{ "clusterlbl", 0, { *sectorHeader } }, mctruthArray);
+        pc.outputs().snapshot(OutputRef{ "clusterlbl", fanSpec, { *sectorHeader } }, mctruthArray);
       }
     };
 
     return processingFct;
   };
 
-  auto createOutputSpecs = [](bool makeMcOutput) {
+  auto createOutputSpecs = [fanSpec](bool makeMcOutput) {
     std::vector<OutputSpec> outputSpecs{
-      OutputSpec{ { "clusters" }, gDataOriginTPC, "CLUSTERSIM", 0, Lifetime::Timeframe },
+      OutputSpec{ { "clusters" }, gDataOriginTPC, "CLUSTERSIM", fanSpec, Lifetime::Timeframe },
     };
     if (makeMcOutput) {
       OutputLabel label{ "clusterlbl" };
       // FIXME: define common data type specifiers
       constexpr o2::header::DataDescription datadesc("CLUSTERMCLBL");
-      outputSpecs.emplace_back(label, gDataOriginTPC, datadesc, 0, Lifetime::Timeframe);
+      outputSpecs.emplace_back(label, gDataOriginTPC, datadesc, fanSpec, Lifetime::Timeframe);
     }
     return std::move(outputSpecs);
   };
 
-  return DataProcessorSpec{ "tpc-clusterer",
-                            { InputSpec{ "digits", gDataOriginTPC, "DIGIT", 0, Lifetime::Timeframe },
-                              InputSpec{ "mclabels", gDataOriginTPC, "DIGITMCLBL", 0, Lifetime::Timeframe } },
+  return DataProcessorSpec{ processorName,
+                            { InputSpec{ "digits", gDataOriginTPC, "DIGITS", fanSpec, Lifetime::Timeframe },
+                              InputSpec{ "mclabels", gDataOriginTPC, "DIGITSMCTR", fanSpec, Lifetime::Timeframe } },
                             { createOutputSpecs(sendMC) },
                             AlgorithmSpec(initFunction) };
 }

--- a/Detectors/TPC/workflow/src/ClustererSpec.h
+++ b/Detectors/TPC/workflow/src/ClustererSpec.h
@@ -22,7 +22,7 @@ namespace TPC
 
 /// create a processor spec
 /// read simulated TPC clusters from file and publish
-framework::DataProcessorSpec getClustererSpec(bool sendMC);
+framework::DataProcessorSpec getClustererSpec(bool sendMC, int fanNumber = -1);
 
 } // end namespace TPC
 } // end namespace o2

--- a/Detectors/TPC/workflow/src/DigitReaderSpec.h
+++ b/Detectors/TPC/workflow/src/DigitReaderSpec.h
@@ -22,7 +22,7 @@ namespace TPC
 
 /// create a processor spec
 /// read simulated TPC clusters from file and publish
-framework::DataProcessorSpec getDigitReaderSpec();
+framework::DataProcessorSpec getDigitReaderSpec(size_t parallel = 1);
 
 } // end namespace TPC
 } // end namespace o2

--- a/Detectors/TPC/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/TPC/workflow/src/RecoWorkflow.cxx
@@ -1,0 +1,162 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   RecoWorkflow.cxx
+/// @author Matthias Richter
+/// @since  2018-09-26
+/// @brief  Workflow definition for the TPC reconstruction
+
+#include "Framework/WorkflowSpec.h"
+
+#include "TPCWorkflow/RecoWorkflow.h"
+#include "DigitReaderSpec.h"
+#include "ClusterReaderSpec.h"
+#include "ClustererSpec.h"
+#include "ClusterConverterSpec.h"
+#include "ClusterDecoderRawSpec.h"
+#include "CATrackerSpec.h"
+#include "RootFileWriterSpec.h"
+#include "DataFormatsTPC/Constants.h"
+#include "DataFormatsTPC/ClusterGroupAttribute.h"
+
+#include "FairMQLogger.h"
+#include <string>
+#include <stdexcept>
+#include <fstream>
+#include <sstream>
+#include <iomanip>
+#include <unordered_map>
+#include <stdexcept>
+
+namespace o2
+{
+namespace TPC
+{
+namespace RecoWorkflow
+{
+
+using namespace framework;
+
+const std::unordered_map<std::string, InputType> InputMap{
+  { "digitizer", InputType::Digitizer },
+  { "digits", InputType::Digits },
+  { "clusters", InputType::Clusters },
+  { "raw", InputType::Raw },
+};
+
+const std::unordered_map<std::string, OutputType> OutputMap{
+  { "clusters", OutputType::Clusters },
+  { "raw", OutputType::Raw },
+  { "decoded-clusters", OutputType::DecodedClusters },
+  { "tracks", OutputType::Tracks },
+};
+
+framework::WorkflowSpec getWorkflow(bool propagateMC, int nLanes, std::string cfgInput, std::string cfgOutput)
+{
+  InputType inputType;
+  OutputType outputType;
+  try {
+    inputType = InputMap.at(cfgInput);
+  } catch (std::out_of_range&) {
+    throw std::runtime_error(std::string("invalid input type: ") + cfgInput);
+  }
+  try {
+    outputType = OutputMap.at(cfgOutput);
+  } catch (std::out_of_range&) {
+    throw std::runtime_error(std::string("invalid output type: ") + cfgOutput);
+  }
+
+  WorkflowSpec specs;
+
+  // there is no MC info when starting from raw data
+  // but maybe the warning can be dropped
+  if (propagateMC && outputType == OutputType::Raw) {
+    LOG(WARNING) << "input type 'raw' selected, switch off MC propagation";
+    propagateMC = false;
+  }
+
+  // note: converter does not touch MC, this is routed directly to downstream consumer
+  if (inputType == InputType::Digits) {
+    specs.emplace_back(o2::TPC::getDigitReaderSpec(nLanes));
+    for (int n = 0; n < nLanes; ++n) {
+      specs.emplace_back(o2::TPC::getClustererSpec(propagateMC, (nLanes > 1 ? n : -1)));
+      specs.emplace_back(o2::TPC::getClusterConverterSpec(propagateMC, (nLanes > 1 ? n : -1)));
+    }
+  } else if (inputType == InputType::Digitizer) {
+    for (int n = 0; n < nLanes; ++n) {
+      specs.emplace_back(o2::TPC::getClustererSpec(propagateMC, (nLanes > 1 ? n : -1)));
+      specs.emplace_back(o2::TPC::getClusterConverterSpec(propagateMC, (nLanes > 1 ? n : -1)));
+    }
+  } else if (inputType == InputType::Clusters) {
+    specs.emplace_back(o2::TPC::getClusterReaderSpec(/*propagateMC*/));
+    for (int n = 0; n < nLanes; ++n) {
+      specs.emplace_back(o2::TPC::getClusterConverterSpec(propagateMC, (nLanes > 1 ? n : -1)));
+    }
+  } else if (inputType == InputType::Raw) {
+    throw std::runtime_error(std::string("input type 'raw' not yet implemented"));
+  }
+
+  if (outputType == OutputType::Clusters || outputType == OutputType::Raw) {
+    throw std::runtime_error(std::string("output types 'clusters' and 'raw' not yet implemented"));
+  }
+  // also add a binary writer
+  auto writerFunction = [](InitContext& ic) {
+    auto filename = ic.options().get<std::string>("outfile");
+    if (filename.empty()) {
+      throw std::runtime_error("output file missing");
+    }
+    auto output = std::make_shared<std::ofstream>(filename.c_str(), std::ios_base::binary);
+    return [output](ProcessingContext& pc) {
+      LOG(INFO) << "processing data set with " << pc.inputs().size() << " entries";
+      for (const auto& entry : pc.inputs()) {
+        LOG(INFO) << "  " << *(entry.spec);
+        output->write(entry.payload, o2::framework::DataRefUtils::getPayloadSize(entry));
+        LOG(INFO) << "wrote data, size " << o2::framework::DataRefUtils::getPayloadSize(entry);
+      }
+    };
+  };
+
+  for (int n = 0; n < nLanes; ++n) {
+    specs.emplace_back(o2::TPC::getClusterDecoderRawSpec(propagateMC, (nLanes > 1 ? n : -1)));
+  }
+
+  auto createInputSpec = []() {
+    o2::framework::Inputs inputs;
+    /**
+    for (uint8_t sector = 0; sector < o2::TPC::Constants::MAXSECTOR; sector++) {
+      std::stringstream label;
+      label << "input_" << std::setw(2) << std::setfill('0') << (int)sector;
+      auto subSpec = o2::TPC::ClusterGroupAttribute{sector, 0}.getSubSpecification();
+      inputs.emplace_back(InputSpec{ label.str().c_str(), "TPC", "CLUSTERNATIVE", subSpec, framework::Lifetime::Timeframe });
+    }
+    */
+    inputs.emplace_back(InputSpec{ "input", "TPC", "CLUSTERNATIVE", 0, framework::Lifetime::Timeframe });
+
+    return std::move(inputs);
+  };
+
+  if (outputType == OutputType::Tracks) {
+    specs.emplace_back(o2::TPC::getCATrackerSpec(propagateMC, nLanes));
+    specs.emplace_back(o2::TPC::getRootFileWriterSpec());
+  } else if (outputType == OutputType::DecodedClusters) {
+    specs.emplace_back(DataProcessorSpec{ "writer",
+                                          { createInputSpec() },
+                                          {},
+                                          AlgorithmSpec(writerFunction),
+                                          Options{
+                                            { "outfile", VariantType::String, { "Name of the output file" } },
+                                          } });
+  }
+  return std::move(specs);
+}
+
+} // end namespace RecoWorkflow
+} // end namespace TPC
+} // end namespace o2

--- a/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
+++ b/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
@@ -15,25 +15,11 @@
 
 #include "Framework/WorkflowSpec.h"
 #include "Framework/ConfigParamSpec.h"
+#include "TPCWorkflow/RecoWorkflow.h"
 
-#include "DigitReaderSpec.h"
-#include "ClusterReaderSpec.h"
-#include "ClustererSpec.h"
-#include "ClusterConverterSpec.h"
-#include "ClusterDecoderRawSpec.h"
-#include "CATrackerSpec.h"
-#include "RootFileWriterSpec.h"
-#include "DataFormatsTPC/Constants.h"
-#include "DataFormatsTPC/ClusterGroupAttribute.h"
-
-#include "FairMQLogger.h"
 #include <string>
 #include <stdexcept>
-#include <fstream>
-#include <sstream>
-#include <iomanip>
 #include <unordered_map>
-#include <stdexcept>
 
 // add workflow options, note that customization needs to be declared before
 // including Framework/runDataProcessing
@@ -43,6 +29,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     { "input-type", o2::framework::VariantType::String, "digits", { "digits, clusters, raw" } },
     { "output-type", o2::framework::VariantType::String, "tracks", { "clusters, raw, tracks" } },
     { "disable-mc", o2::framework::VariantType::Bool, false, { "disable sending of MC information" } },
+    { "tpc-lanes", o2::framework::VariantType::Int, 1, { "number of parallel lanes up to the tracker" } },
   };
   std::swap(workflowOptions, options);
 }
@@ -63,117 +50,12 @@ using namespace o2::framework;
 /// MC info is always sent by the digit reader and clusterer processes, the
 /// cluster converter process creating the raw format can be configured to forward MC.
 ///
-/// FIXME:
-/// - add propagation of MC information
-/// - add writing of the CA Tracker output to ROOT file
 /// This function is required to be implemented to define the workflow specifications
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  WorkflowSpec specs;
-
-  /// extract the workflow options and configure workflow
-  enum struct InputType { Digits,
-                          Clusters,
-                          Raw };
-  enum struct OutputType { Clusters,
-                           Raw,
-                           DecodedClusters,
-                           Tracks };
-
-  const std::unordered_map<std::string, InputType> InputMap{
-    { "digits", InputType::Digits },
-    { "clusters", InputType::Clusters },
-    { "raw", InputType::Raw },
-  };
-
-  const std::unordered_map<std::string, OutputType> OutputMap{
-    { "clusters", OutputType::Clusters },
-    { "raw", OutputType::Raw },
-    { "decoded-clusters", OutputType::DecodedClusters },
-    { "tracks", OutputType::Tracks },
-  };
-
-  InputType inputType;
-  OutputType outputType;
-  bool propagateMC = not cfgc.options().get<bool>("disable-mc");
-  try {
-    inputType = InputMap.at(cfgc.options().get<std::string>("input-type"));
-  } catch (std::out_of_range&) {
-    throw std::runtime_error(std::string("invalid input type: ") + cfgc.options().get<std::string>("input-type"));
-  }
-  try {
-    outputType = OutputMap.at(cfgc.options().get<std::string>("output-type"));
-  } catch (std::out_of_range&) {
-    throw std::runtime_error(std::string("invalid output type: ") + cfgc.options().get<std::string>("output-type"));
-  }
-
-  // there is no MC info when starting from raw data
-  // but maybe the warning can be dropped
-  if (propagateMC && outputType == OutputType::Raw) {
-    LOG(WARNING) << "input type 'raw' selected, switch off MC propagation";
-    propagateMC = false;
-  }
-
-  // note: converter does not touch MC, this is routed directly to downstream consumer
-  if (inputType == InputType::Digits) {
-    specs.emplace_back(o2::TPC::getDigitReaderSpec());
-    specs.emplace_back(o2::TPC::getClustererSpec(propagateMC));
-    specs.emplace_back(o2::TPC::getClusterConverterSpec(propagateMC));
-  } else if (inputType == InputType::Clusters) {
-    specs.emplace_back(o2::TPC::getClusterReaderSpec(/*propagateMC*/));
-    specs.emplace_back(o2::TPC::getClusterConverterSpec(propagateMC));
-  } else if (inputType == InputType::Raw) {
-    throw std::runtime_error(std::string("input type 'raw' not yet implemented"));
-  }
-
-  if (outputType == OutputType::Clusters || outputType == OutputType::Raw) {
-    throw std::runtime_error(std::string("output types 'clusters' and 'raw' not yet implemented"));
-  }
-  // also add a binary writer
-  auto writerFunction = [](InitContext& ic) {
-    auto filename = ic.options().get<std::string>("outfile");
-    if (filename.empty()) {
-      throw std::runtime_error("output file missing");
-    }
-    auto output = std::make_shared<std::ofstream>(filename.c_str(), std::ios_base::binary);
-    return [output](ProcessingContext& pc) {
-      LOG(INFO) << "processing data set with " << pc.inputs().size() << " entries";
-      for (const auto& entry : pc.inputs()) {
-        LOG(INFO) << "  " << *(entry.spec);
-        output->write(entry.payload, o2::framework::DataRefUtils::getPayloadSize(entry));
-        LOG(INFO) << "wrote data, size " << o2::framework::DataRefUtils::getPayloadSize(entry);
-      }
-    };
-  };
-
-  specs.emplace_back(o2::TPC::getClusterDecoderRawSpec(propagateMC));
-
-  auto createInputSpec = []() {
-    o2::framework::Inputs inputs;
-    /**
-    for (uint8_t sector = 0; sector < o2::TPC::Constants::MAXSECTOR; sector++) {
-      std::stringstream label;
-      label << "input_" << std::setw(2) << std::setfill('0') << (int)sector;
-      auto subSpec = o2::TPC::ClusterGroupAttribute{sector, 0}.getSubSpecification();
-      inputs.emplace_back(InputSpec{ label.str().c_str(), "TPC", "CLUSTERNATIVE", subSpec, Lifetime::Timeframe });
-    }
-    */
-    inputs.emplace_back(InputSpec{ "input", "TPC", "CLUSTERNATIVE", 0, Lifetime::Timeframe });
-
-    return std::move(inputs);
-  };
-
-  if (outputType == OutputType::Tracks) {
-    specs.emplace_back(o2::TPC::getCATrackerSpec(propagateMC));
-    specs.emplace_back(o2::TPC::getRootFileWriterSpec());
-  } else if (outputType == OutputType::DecodedClusters) {
-    specs.emplace_back(DataProcessorSpec{ "writer",
-                                          { createInputSpec() },
-                                          {},
-                                          AlgorithmSpec(writerFunction),
-                                          Options{
-                                            { "outfile", VariantType::String, { "Name of the output file" } },
-                                          } });
-  }
-  return specs;
+  return std::move(o2::TPC::RecoWorkflow::getWorkflow(not cfgc.options().get<bool>("disable-mc"),    //
+                                                      cfgc.options().get<int>("tpc-lanes"),          //
+                                                      cfgc.options().get<std::string>("input-type"), //
+                                                      cfgc.options().get<std::string>("output-type") //
+                                                      ));
 }


### PR DESCRIPTION
Moving TPC reco workflow definition to separate file and creating library for module
TPCWorkflow with reco workflow and processor specs.

Parallel workflow can be configured using option '--tpc-lanes n'

Added features:
- workflow option --tpc-lanes
- DigitReaderSpec fan out
- CATrackerSpec fan in
- adding input type 'digitizer' to connect directly to the digitizer workflow
- adjusting data descriptions to output of digitizer workflow ('DIGITS', 'DIGITSMCTR').
- forwarding empty data sets at end of processing.
- adjusting processor names: prefix tpc