### PR TITLE
remove #include boost: the class is fwd-declared

### DIFF
--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/Cluster.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/Cluster.h
@@ -15,7 +15,6 @@
 
 #include <Rtypes.h>
 #include <CommonDataFormat/TimeStamp.h>
-#include <boost/serialization/base_object.hpp> // for base_object
 
 namespace boost
 {

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/ClustererTask.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/ClustererTask.h
@@ -41,7 +41,7 @@ class ClustererTask : public FairTask{
    ClustererTask(int sectorid = -1);
 
    /// Destructor
-   ~ClustererTask() = default;
+   ~ClustererTask() override = default;
 
    /// Initializes the clusterer and connects input and output container
    InitStatus Init() override;


### PR DESCRIPTION
Having #include "boost.." in the headers which may end up in the macros makes their compilation impossible unless the ROOT_INCLUDE_PATH is patched.