### PR TITLE
DPL: refactor and extract a TimesliceIndex from DataRelayer

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -233,6 +233,7 @@ set(TEST_SRCS
       test/test_SimpleStringProcessing.cxx
       test/test_SingleDataSource.cxx
       test/test_SuppressionGenerator.cxx
+      test/test_TimesliceIndex.cxx
       test/test_TMessageSerializer.cxx
       test/test_TableBuilder.cxx
       test/test_Task.cxx

--- a/Framework/Core/include/Framework/DataProcessingDevice.h
+++ b/Framework/Core/include/Framework/DataProcessingDevice.h
@@ -66,6 +66,7 @@ class DataProcessingDevice : public FairMQDevice
   ArrowContext mDataFrameContext;
   ContextRegistry mContextRegistry;
   DataAllocator mAllocator;
+  TimesliceIndex mTimesliceIndex;
   DataRelayer mRelayer;
   std::vector<ExpirationHandler> mExpirationHandlers;
 

--- a/Framework/Core/include/Framework/TimesliceIndex.h
+++ b/Framework/Core/include/Framework/TimesliceIndex.h
@@ -1,0 +1,68 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef FRAMEWORK_TIMESLICEINDEX_H
+#define FRAMEWORK_TIMESLICEINDEX_H
+
+#include <vector>
+#include <cstdint>
+
+/// This class holds the information on how to map a given timeslice to a
+/// record row in the cache.  It also holds whether or not a given timeslice is
+/// dirty and can be used to allocate a new timeslice.  This is also exposed as
+/// a service for those who need to create timeslices without data being
+/// associated to it.
+///
+/// In the future this could also come handy to the same timeslice to multiple
+/// entries in the cache.
+
+namespace o2
+{
+namespace framework
+{
+
+struct TimesliceId {
+  static constexpr uint64_t INVALID = -1;
+  size_t value;
+  static bool isValid(TimesliceId const& timeslice);
+};
+
+struct TimesliceSlot {
+  size_t index;
+};
+
+class TimesliceIndex
+{
+ public:
+  inline void resize(size_t s);
+  inline size_t size() const;
+  inline bool isValid(TimesliceSlot const& slot) const;
+  inline bool isDirty(TimesliceSlot const& slot) const;
+  inline bool isObsolete(TimesliceId newTimestamp) const;
+  inline void markAsDirty(TimesliceSlot slot, bool value);
+  inline void markAsObsolete(TimesliceSlot slot);
+  inline void markAsInvalid(TimesliceSlot slot);
+  inline TimesliceSlot bookTimeslice(TimesliceId timestamp);
+  inline TimesliceSlot getSlotForTimeslice(TimesliceId timestamp) const;
+  inline TimesliceId getTimesliceForSlot(TimesliceSlot slot) const;
+
+ private:
+  /// This is the timeslices for all the in flight parts.
+  std::vector<TimesliceId> mTimeslices;
+  /// This keeps track whether or not something was relayed
+  /// since last time we called getReadyToProcess()
+  std::vector<bool> mDirty;
+};
+
+} // namespace framework
+} // namespace o2
+
+#include "TimesliceIndex.inl"
+#endif // FRAMEWORK_TIMESLICEINDEX_H

--- a/Framework/Core/include/Framework/TimesliceIndex.inl
+++ b/Framework/Core/include/Framework/TimesliceIndex.inl
@@ -1,0 +1,83 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+namespace o2
+{
+namespace framework
+{
+
+inline bool TimesliceId::isValid(TimesliceId const& timeslice) { return timeslice.value != INVALID; }
+
+inline void TimesliceIndex::resize(size_t s)
+{
+  mTimeslices.resize(s, { TimesliceId::INVALID });
+  mDirty.resize(s, false);
+}
+
+inline size_t TimesliceIndex::size() const
+{
+  assert(mTimeslices.size() == mDirty.size());
+  return mTimeslices.size();
+}
+
+inline bool TimesliceIndex::isValid(TimesliceSlot const& slot) const
+{
+  return TimesliceId::isValid(mTimeslices[slot.index]);
+}
+
+inline bool TimesliceIndex::isDirty(TimesliceSlot const& slot) const
+{
+  return mDirty[slot.index];
+}
+
+inline bool TimesliceIndex::isObsolete(TimesliceId newTimestamp) const
+{
+  auto slot = getSlotForTimeslice(newTimestamp);
+  auto oldTimestamp = mTimeslices[slot.index];
+  return TimesliceId::isValid(oldTimestamp) && oldTimestamp.value > newTimestamp.value;
+}
+
+inline void TimesliceIndex::markAsDirty(TimesliceSlot slot, bool value)
+{
+  mDirty[slot.index] = value;
+}
+
+inline void TimesliceIndex::markAsObsolete(TimesliceSlot slot)
+{
+  // Invalid slots remain invalid.
+  if (TimesliceId::isValid(mTimeslices[slot.index])) {
+    mTimeslices[slot.index].value += 1;
+  }
+}
+
+inline void TimesliceIndex::markAsInvalid(TimesliceSlot slot)
+{
+  mTimeslices[slot.index] = { TimesliceId::INVALID };
+}
+
+inline TimesliceSlot TimesliceIndex::bookTimeslice(TimesliceId timestamp)
+{
+  auto slot = getSlotForTimeslice(timestamp);
+  mTimeslices[slot.index] = timestamp;
+  mDirty[slot.index] = true;
+  return slot;
+}
+
+inline TimesliceSlot TimesliceIndex::getSlotForTimeslice(TimesliceId timestamp) const
+{
+  return TimesliceSlot{ timestamp.value % mTimeslices.size() };
+}
+
+inline TimesliceId TimesliceIndex::getTimesliceForSlot(TimesliceSlot slot) const
+{
+  return mTimeslices[slot.index];
+}
+
+} // namespace framework
+} // namespace o2

--- a/Framework/Core/src/DataRelayer.cxx
+++ b/Framework/Core/src/DataRelayer.cxx
@@ -15,6 +15,7 @@
 #include "Framework/CompletionPolicy.h"
 #include "Framework/PartRef.h"
 #include "fairmq/FairMQLogger.h"
+#include "Framework/TimesliceIndex.h"
 
 #include <Monitoring/Monitoring.h>
 
@@ -46,9 +47,7 @@ std::vector<size_t> createDistinctRouteIndex(std::vector<InputRoute> const& rout
 }
 }
 
-constexpr int64_t INVALID_TIMESLICE = -1;
 constexpr int INVALID_INPUT = -1;
-constexpr DataRelayer::TimesliceId INVALID_TIMESLICE_ID = {INVALID_TIMESLICE};
 
 // 16 is just some reasonable numer
 // The number should really be tuned at runtime for each processor.
@@ -58,9 +57,11 @@ constexpr int DEFAULT_PIPELINE_LENGTH = 16;
 DataRelayer::DataRelayer(const CompletionPolicy& policy,
                          const std::vector<InputRoute>& inputRoutes,
                          const std::vector<ForwardRoute>& forwardRoutes,
-                         monitoring::Monitoring& metrics)
+                         monitoring::Monitoring& metrics,
+                         TimesliceIndex& index)
   : mInputRoutes{ inputRoutes },
     mForwardRoutes{ forwardRoutes },
+    mTimesliceIndex{ index },
     mMetrics{ metrics },
     mCompletionPolicy{ policy },
     mDistinctRoutesIndex{ createDistinctRouteIndex(inputRoutes) }
@@ -74,26 +75,27 @@ DataRelayer::DataRelayer(const CompletionPolicy& policy,
 void DataRelayer::processDanglingInputs(std::vector<ExpirationHandler> const& expirationHandlers,
                                         ServiceRegistry& services)
 {
-  for (size_t ti = 0; ti < mTimeslices.size(); ++ti) {
+  for (size_t ti = 0; ti < mTimesliceIndex.size(); ++ti) {
     // FIXME: for the moment we need to have at least one data input before we
     //        can invoke the dangling inputs helpers.
     //        This is useful for stuff like conditions or histograms, but not
     //        (yet) for timers. For those we would need to have a mechanism
     //        to create valid timeslices.
-    if (mTimeslices[ti].value == INVALID_TIMESLICE) {
+    TimesliceSlot slot{ ti };
+    if (mTimesliceIndex.isValid(slot) == false) {
       continue;
     }
     assert(mDistinctRoutesIndex.empty() == false);
     for (size_t ri = 0; ri < mDistinctRoutesIndex.size(); ++ri) {
       auto& route = mInputRoutes[mDistinctRoutesIndex[ri]];
       auto& expirator = expirationHandlers[mDistinctRoutesIndex[ri]];
-      auto timestamp = mTimeslices[ti].value;
+      auto timestamp = mTimesliceIndex.getTimesliceForSlot(slot);
       auto& part = mCache[ti * mDistinctRoutesIndex.size() + ri];
-      if (part.header == nullptr && part.payload == nullptr && expirator.checker && expirator.checker(mTimeslices[ti].value)) {
+      if (part.header == nullptr && part.payload == nullptr && expirator.checker && expirator.checker(timestamp.value)) {
         assert(ti * mDistinctRoutesIndex.size() + ri < mCache.size());
         assert(expirator.handler);
-        expirator.handler(services, part, timestamp);
-        mDirty[ti] = true;
+        expirator.handler(services, part, timestamp.value);
+        mTimesliceIndex.markAsDirty(slot, true);
         assert(part.header != nullptr);
         assert(part.payload != nullptr);
       }
@@ -130,12 +132,12 @@ DataRelayer::relay(std::unique_ptr<FairMQMessage> &&header,
   // This is the class level state of the relaying. If we start supporting
   // multithreading this will have to be made thread safe before we can invoke
   // relay concurrently.
-  const auto &inputRoutes = mInputRoutes;
-  std::vector<TimesliceId> &timeslices = mTimeslices;
-  auto &cache = mCache;
-  const auto &readonlyCache = mCache;
+  auto const& inputRoutes = mInputRoutes;
+  auto& index = mTimesliceIndex;
+
+  auto& cache = mCache;
+  auto const& readonlyCache = mCache;
   auto& metrics = mMetrics;
-  auto& dirty = mDirty;
   auto numInputTypes = mDistinctRoutesIndex.size();
 
   // IMPLEMENTATION DETAILS
@@ -156,54 +158,40 @@ DataRelayer::relay(std::unique_ptr<FairMQMessage> &&header,
     return inputIdx != INVALID_INPUT;
   };
 
-  // This will check if the timeslice is valid. We hide the details so that in
-  // principle outer code will work regardless of the actual implementation.
-  auto isValidTimeslice = [](int64_t timesliceId) -> bool {
-    return timesliceId != INVALID_TIMESLICE;
-  };
-
   // The timeslice is embedded in the DataProcessingHeader header of the O2
   // header stack. This is an extension to the DataHeader, because apparently
   // we do have data which comes without a timestamp, although I am personally
   // not sure what that would be.
-  auto getTimeslice = [&header, &timeslices]() -> int64_t {
+  const auto getTimeslice = [&header, &index]() -> TimesliceId {
     const DataProcessingHeader* dph = o2::header::get<DataProcessingHeader*>(header->GetData());
     if (dph == nullptr) {
-      return -1;
+      return TimesliceId{ TimesliceId::INVALID };
     }
     size_t timesliceId = dph->startTime;
-    assert(timeslices.size());
-    return timesliceId;
-  };
-
-  // Late arrival means that the incoming timeslice is actually older 
-  // then the one hold in the current cache.
-  auto isInputFromObsolete = [&timeslices](int64_t timeslice) {
-    auto &current = timeslices[timeslice % timeslices.size()];
-    return current.value > timeslice;
+    assert(index.size());
+    return TimesliceId{ timesliceId };
   };
 
   // A cache line is obsolete if the incoming one has a greater timestamp or 
   // if the slot contains an invalid timeslice.
-  auto isCacheEntryObsoleteFor = [&timeslices](int64_t timeslice){
-    auto &current = timeslices[timeslice % timeslices.size()];
-    return current.value == INVALID_TIMESLICE
-           || (current.value < timeslice);
+  const auto isCacheEntryObsoleteFor = [&index](TimesliceId timeslice) {
+    auto current = index.getTimesliceForSlot(index.getSlotForTimeslice(timeslice));
+    return TimesliceId::isValid(current) == false || (current.value < timeslice.value);
   };
 
   // We need to prune the cache from the old stuff, if any. Otherwise we
   // simply store the payload in the cache and we mark relevant bit in the
   // hence the first if.
-  auto pruneCacheSlotFor = [&cache, &numInputTypes, &timeslices, &metrics](int64_t timeslice) {
+  auto pruneCacheSlotFor = [&cache, &numInputTypes, &index, &metrics](TimesliceId timeslice) {
     assert(cache.empty() == false);
-    assert(timeslices.size() * numInputTypes == cache.size());
-    size_t slotIndex = timeslice % timeslices.size();
+    assert(index.size() * numInputTypes == cache.size());
+    auto slot = index.getSlotForTimeslice(timeslice);
     // Prune old stuff from the cache, hopefully deleting it...
     // We set the current slot to the timeslice value, so that old stuff
     // will be ignored.
-    assert(numInputTypes * slotIndex < cache.size());
-    timeslices[slotIndex].value = timeslice;
-    for (size_t ai = slotIndex*numInputTypes, ae = ai + numInputTypes; ai != ae ; ++ai) {
+    assert(numInputTypes * slot.index < cache.size());
+    index.bookTimeslice(timeslice);
+    for (size_t ai = slot.index * numInputTypes, ae = ai + numInputTypes; ai != ae; ++ai) {
       cache[ai].header.reset(nullptr);
       cache[ai].payload.reset(nullptr);
       metrics.send({ 0, std::string("data_relayer/") + std::to_string(ai) });
@@ -214,22 +202,20 @@ DataRelayer::relay(std::unique_ptr<FairMQMessage> &&header,
   // the current timeslice.
   // This should never happen, however given this is dependent on the input
   // we want to protect again malicious / bad upstream source.
-  auto hasCacheInputAlreadyFor = [&cache, &timeslices, &numInputTypes](int64_t timeslice, int input) {
-    size_t slotIndex = timeslice % timeslices.size();
-    PartRef &currentPart = cache[numInputTypes*slotIndex + input];
+  auto hasCacheInputAlreadyFor = [&cache, &index, &numInputTypes](TimesliceId timeslice, int input) {
+    auto slot = index.getSlotForTimeslice(timeslice);
+    PartRef& currentPart = cache[numInputTypes * slot.index + input];
     return (currentPart.payload != nullptr) || (currentPart.header != nullptr);
   };
 
   // Actually save the header / payload in the slot
-  auto saveInSlot = [&header, &payload, &cache, &dirty, &timeslices, &numInputTypes, &metrics](int64_t timeslice, int input) {
-    size_t slotIndex = timeslice % timeslices.size();
-    dirty[slotIndex] = true;
-    auto cacheIdx = numInputTypes * slotIndex + input;
+  auto saveInSlot = [&header, &payload, &cache, &index, &numInputTypes, &metrics](TimesliceId timeslice, int input) {
+    auto slot = index.bookTimeslice(timeslice);
+    auto cacheIdx = numInputTypes * slot.index + input;
     PartRef& currentPart = cache[cacheIdx];
     metrics.send({ 1, std::string("data_relayer/") + std::to_string(cacheIdx) });
     PartRef ref{std::move(header), std::move(payload)};
     currentPart = std::move(ref);
-    timeslices[slotIndex] = {timeslice};
     assert(header.get() == nullptr && payload.get() == nullptr);
   };
 
@@ -245,14 +231,15 @@ DataRelayer::relay(std::unique_ptr<FairMQMessage> &&header,
   }
 
   auto timeslice = getTimeslice();
-  LOG(DEBUG) << "Received timeslice" << timeslice;
-  if (isValidTimeslice(timeslice) == false) {
+  auto slot = index.getSlotForTimeslice(timeslice);
+  LOG(DEBUG) << "Received timeslice" << timeslice.value;
+  if (TimesliceId::isValid(timeslice) == false) {
     LOG(ERROR) << "Could not determine the timeslice for input";
     return WillNotRelay;
   }
 
-  if (isInputFromObsolete(timeslice)) {
-    LOG(ERROR) << "An entry for timeslice " << timeslice << " just arrived but too late to be processed";
+  if (index.isObsolete(timeslice)) {
+    LOG(ERROR) << "An entry for timeslice " << timeslice.value << " just arrived but too late to be processed";
     return WillNotRelay;
   }
 
@@ -290,7 +277,7 @@ DataRelayer::getReadyToProcess() {
   // These two are trivial, but in principle the whole loop could be parallelised
   // or vectorised so "completed" could be a thread local variable which needs
   // merging at the end.
-  auto updateCompletionResults = [&completed](size_t li, CompletionPolicy::CompletionOp op) {
+  auto updateCompletionResults = [&completed](TimesliceSlot li, CompletionPolicy::CompletionOp op) {
     completed.push_back({li, op});
   };
 
@@ -311,9 +298,10 @@ DataRelayer::getReadyToProcess() {
   assert(cacheLines * numInputTypes == cache.size());
 
   for (size_t li = 0; li < cacheLines; ++li) {
-    // We only check the cachelines which have been updated by an incoming 
+    TimesliceSlot slot{ li };
+    // We only check the cachelines which have been updated by an incoming
     // message.
-    if (mDirty[li] == false) {
+    if (mTimesliceIndex.isDirty(slot) == false) {
       continue;
     }
     auto partial = getPartialRecord(li);
@@ -322,30 +310,31 @@ DataRelayer::getReadyToProcess() {
       case CompletionPolicy::CompletionOp::Consume:
       case CompletionPolicy::CompletionOp::Process:
       case CompletionPolicy::CompletionOp::Discard:
-        updateCompletionResults(li, action);
+        updateCompletionResults(slot, action);
         break;
       case CompletionPolicy::CompletionOp::Wait:
         break;
     }
     // Given we have created an action for this cacheline, we need to wait for
     // a new message before we look again into the given cacheline.
-    mDirty[li] = false;
+    mTimesliceIndex.markAsDirty(slot, false);
   }
   return completionResults();
 }
 
 std::vector<std::unique_ptr<FairMQMessage>>
-DataRelayer::getInputsForTimeslice(size_t timeslice) {
+  DataRelayer::getInputsForTimeslice(TimesliceSlot slot)
+{
   const auto numInputTypes = mDistinctRoutesIndex.size();
   // State of the computation
   std::vector<std::unique_ptr<FairMQMessage>> messages;
   messages.reserve(numInputTypes*2);
-  auto &cache = mCache;
-  auto &timeslices = mTimeslices;
+  auto& cache = mCache;
+  auto& index = mTimesliceIndex;
   auto& metrics = mMetrics;
 
   // Nothing to see here, this is just to make the outer loop more understandable.
-  auto jumpToCacheEntryAssociatedWith = [](size_t) {
+  auto jumpToCacheEntryAssociatedWith = [](TimesliceSlot) {
     return;
   };
 
@@ -353,32 +342,32 @@ DataRelayer::getInputsForTimeslice(size_t timeslice) {
   // finished. We bump by one the timeslice for the given cache entry, so that
   // in case we get (for whatever reason) an old input, it will be
   // automatically discarded by the relay method.
-  auto moveHeaderPayloadToOutput = [&messages, &cache, &timeslices, &numInputTypes, &metrics](size_t ti, size_t arg) {
-    auto cacheId = ti * numInputTypes + arg;
+  auto moveHeaderPayloadToOutput = [&messages, &cache, &index, &numInputTypes, &metrics](TimesliceSlot s, size_t arg) {
+    auto cacheId = s.index * numInputTypes + arg;
     metrics.send({ 2, "data_relayer/" + std::to_string(cacheId) });
     messages.emplace_back(std::move(cache[cacheId].header));
     messages.emplace_back(std::move(cache[cacheId].payload));
-    timeslices[ti % timeslices.size()].value += 1;
+    index.markAsObsolete(s);
   };
 
   // An invalid set of arguments is a set of arguments associated to an invalid
   // timeslice, so I can simply do that. I keep the assertion there because in principle
   // we should have dispatched the timeslice already!
   // FIXME: what happens when we have enough timeslices to hit the invalid one?
-  auto invalidateCacheFor = [&numInputTypes, &timeslices, &cache](size_t ti) {
-    for (size_t ai = ti*numInputTypes, ae = ai + numInputTypes; ai != ae; ++ai) {
-       assert(cache[ai].header.get() == nullptr);
-       assert(cache[ai].payload.get() == nullptr);
+  auto invalidateCacheFor = [&numInputTypes, &index, &cache](TimesliceSlot s) {
+    for (size_t ai = s.index * numInputTypes, ae = ai + numInputTypes; ai != ae; ++ai) {
+      assert(cache[ai].header.get() == nullptr);
+      assert(cache[ai].payload.get() == nullptr);
     }
-    timeslices[ti % timeslices.size()] = INVALID_TIMESLICE_ID;
+    index.markAsInvalid(s);
   };
 
   // Outer loop here.
-  jumpToCacheEntryAssociatedWith(timeslice);
+  jumpToCacheEntryAssociatedWith(slot);
   for (size_t ai = 0, ae = numInputTypes; ai != ae;  ++ai) {
-    moveHeaderPayloadToOutput(timeslice, ai);
+    moveHeaderPayloadToOutput(slot, ai);
   }
-  invalidateCacheFor(timeslice);
+  invalidateCacheFor(slot);
 
   return std::move(messages);
 }
@@ -395,13 +384,12 @@ DataRelayer::getParallelTimeslices() const {
 /// the time pipelining.
 void
 DataRelayer::setPipelineLength(size_t s) {
-  mTimeslices.resize(s, INVALID_TIMESLICE_ID);
-  mDirty.resize(mTimeslices.size(), false);
+  mTimesliceIndex.resize(s);
   auto numInputTypes = mDistinctRoutesIndex.size();
   assert(numInputTypes);
-  mCache.resize(numInputTypes * mTimeslices.size());
+  mCache.resize(numInputTypes * mTimesliceIndex.size());
   mMetrics.send({ (int)numInputTypes, "data_relayer/h" });
-  mMetrics.send({ (int)mTimeslices.size(), "data_relayer/w" });
+  mMetrics.send({ (int)mTimesliceIndex.size(), "data_relayer/w" });
 }
 
 }

--- a/Framework/Core/test/test_TimesliceIndex.cxx
+++ b/Framework/Core/test/test_TimesliceIndex.cxx
@@ -1,0 +1,58 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test Framework DataRelayer
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+#include "Framework/TimesliceIndex.h"
+
+BOOST_AUTO_TEST_CASE(TestBasics)
+{
+  using namespace o2::framework;
+  TimesliceIndex index;
+  TimesliceSlot slot;
+
+  BOOST_REQUIRE_EQUAL(index.size(), 0);
+  index.resize(10);
+  BOOST_REQUIRE_EQUAL(index.size(), 10);
+  BOOST_CHECK(index.isValid({ 0 }) == false);
+  BOOST_CHECK(index.isObsolete({ 0 }) == false);
+  BOOST_CHECK(index.isDirty({ 0 }) == false);
+  index.bookTimeslice(TimesliceId{ 0 });
+  BOOST_CHECK(index.isValid(TimesliceSlot{ 0 }));
+  BOOST_CHECK(index.isDirty(TimesliceSlot{ 0 }));
+  BOOST_CHECK(index.isObsolete(TimesliceId{ 0 }) == false);
+  index.bookTimeslice(TimesliceId{ 10 });
+  BOOST_CHECK(index.isValid(TimesliceSlot{ 0 }));
+  BOOST_CHECK_EQUAL(index.getTimesliceForSlot(TimesliceSlot{ 0 }).value, 10);
+  BOOST_CHECK(index.isObsolete(TimesliceId{ 0 }));
+  BOOST_CHECK(index.isObsolete(TimesliceId{ 10 }) == false);
+  BOOST_CHECK(index.isDirty(TimesliceSlot{ 0 }));
+  index.bookTimeslice(TimesliceId{ 1 });
+  BOOST_CHECK_EQUAL(index.getTimesliceForSlot(TimesliceSlot{ 0 }).value, 10);
+  BOOST_CHECK_EQUAL(index.getTimesliceForSlot(TimesliceSlot{ 1 }).value, 1);
+  BOOST_CHECK(index.isObsolete(TimesliceId{ 0 }));
+  BOOST_CHECK(index.isObsolete(TimesliceId{ 1 }) == false);
+  BOOST_CHECK(index.isObsolete(TimesliceId{ 2 }) == false);
+  BOOST_CHECK(index.isValid(TimesliceSlot{ 2 }) == false);
+  BOOST_CHECK(index.isObsolete(TimesliceId{ 10 }) == false);
+  slot = index.getSlotForTimeslice(TimesliceId{ 10 });
+  index.markAsObsolete(slot);
+  BOOST_CHECK(index.isObsolete(TimesliceId{ 10 }));
+  BOOST_CHECK(index.isDirty(slot));
+  slot = index.getSlotForTimeslice(TimesliceId{ 2 });
+  BOOST_CHECK(index.isObsolete(TimesliceId{ 2 }) == false);
+  BOOST_CHECK(index.isValid(slot) == false);
+  index.markAsObsolete(slot);
+  BOOST_CHECK(index.isObsolete(TimesliceId{ 2 }) == false);
+  BOOST_CHECK(index.isValid(slot) == false);
+}


### PR DESCRIPTION
This is done so that TimesliceIndex can be offered as a service to the
ClockTick callback, allowing for new timeslices to be inserted pushed in
the stream without actual data being associated to them. This is a
requirement to get timers and objects from CCDB or any other external
source in the stream.

It also paves the way to a more sophisticated implementation for the
index rather then the current "modulo" one (e.g. it might allow for
multiple entries for the same timeslice as requested by @sawenzel at
some point).