### PR TITLE
Connecting the TPC reco workflow to the digitizer workflow

### DIFF
--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -1805,6 +1805,7 @@ o2_define_bucket(
     Steer
     Framework
     TPCSimulation
+    TPCWorkflow
     DataFormatsTPC
     ITSSimulation
     MFTSimulation


### PR DESCRIPTION

Optionally attaching TPC reco workflow to digitizer workflow
New workflow option `--tpc-reco-type` determines the output of the workflow 
*Note*: at the moment the reco workflo only supports `tracks` as type. 

Some cleanup has been done in the `SimReader` to skip the channel for sector assign as the `TPCSectorHeader` has to be sent anyhow to ensure propagation of the active sectors to the tracker.