### PR TITLE
DPL: Initialize things in the init function and not elsewhere

### DIFF
--- a/Steer/DigitizerWorkflow/src/TPCDriftTimeDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TPCDriftTimeDigitizerSpec.cxx
@@ -65,14 +65,10 @@ DataProcessorSpec getTPCDriftTimeDigitizer(int channel, bool cachehits)
   //
   auto simChains = std::make_shared<std::vector<TChain*>>();
   auto digitizertask = std::make_shared<o2::TPC::DigitizerTask>();
-  digitizertask->Init2();
 
   auto digitArray = std::make_shared<std::vector<o2::TPC::Digit>>();
 
   auto mcTruthArray = std::make_shared<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>();
-  // the task takes the ownership of digit array + mc truth array
-  // TODO: make this clear in the API
-  digitizertask->setOutputData(digitArray.get(), mcTruthArray.get());
 
   auto doit = [simChain, simChains, digitizertask, digitArray, mcTruthArray, channel](ProcessingContext& pc) {
     static int callcounter = 0;
@@ -223,9 +219,13 @@ DataProcessorSpec getTPCDriftTimeDigitizer(int channel, bool cachehits)
   };
 
   // init function return a lambda taking a ProcessingContext
-  auto initIt = [simChain, simChains, doit](InitContext& ctx) {
-    // setup the input chain
+  auto initIt = [digitizertask, digitArray, mcTruthArray, simChain, simChains, doit](InitContext& ctx) {
+    digitizertask->Init2();
+    // the task takes the ownership of digit array + mc truth array
+    // TODO: make this clear in the API
+    digitizertask->setOutputData(digitArray.get(), mcTruthArray.get());
 
+    // setup the input chain
     simChains->emplace_back(new TChain("o2sim"));
     // add the background chain
     simChains->back()->AddFile(ctx.options().get<std::string>("simFile").c_str());


### PR DESCRIPTION
Solving a memory problem in the digitizer workflow by moving the initialization
of the TPC digitizer into the actual init lambda.

Before it was done in the "getDataProcessorSpec" function. This is not a good place
since in fact every single DPL processor/process with evaluate this function (if it needs it
or not) upon topology creation.
In this case, every single DPL processor was instantiating pixels of a TPC readout chamber...
even though it was not actually doing TPC stuff.

We need to be careful about that. Some other data structures such as shared_ptrs need to be revised
in different places.

On the other hand, I think there is no need that every single processor evaluates the whole topology
at startup. This should really be done by a single master processor which communicates the topology
to the forks. This would also avoid such problems.