### PR TITLE
o2sim: added cmd line parameters to setup interaction diamond position and width

### DIFF
--- a/Common/SimConfig/include/SimConfig/SimConfig.h
+++ b/Common/SimConfig/include/SimConfig/SimConfig.h
@@ -28,6 +28,8 @@ struct SimConfigData {
   std::string mExtKinFileName;               // file name of external kinematics file (needed for ext kinematics generator)
   unsigned int mStartEvent;                  // index of first event to be taken
   float mBMax;                               // maximum for impact parameter sampling
+  std::vector<float> mOrigin;                // position of the interaction diamond
+  std::vector<float> mSigmaO;                // width of the interaction diamond
   bool mIsMT;                                // chosen MT mode (Geant4 only)
   std::string mOutputPrefix;                 // prefix to be used for output files
   ClassDefNV(SimConfigData, 1);
@@ -78,6 +80,8 @@ class SimConfig
   std::string getExtKinematicsFileName() const { return mConfigData.mExtKinFileName; }
   unsigned int getStartEvent() const { return mConfigData.mStartEvent; }
   float getBMax() const { return mConfigData.mBMax; }
+  std::vector<float> getOrigin() const { return mConfigData.mOrigin; }
+  std::vector<float> getSigmaO() const { return mConfigData.mSigmaO; }
   bool getIsMT() const { return mConfigData.mIsMT; }
   std::string getOutPrefix() const { return mConfigData.mOutputPrefix; }
 

--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -28,6 +28,8 @@ void SimConfig::initOptions(boost::program_options::options_description& options
     "extKinFile", bpo::value<std::string>()->default_value("Kinematics.root"),
     "name of kinematics file for event generator from file (when applicable)")(
     "bMax,b", bpo::value<float>()->default_value(0.), "maximum value for impact parameter sampling (when applicable)")(
+    "origin", bpo::value<std::vector<float>>()->multitoken()->default_value(std::vector<float>({0., 0., 0.}), "0 0 0"), "position of the interaction diamond: x y z (cm)")(
+    "sigmaO", bpo::value<std::vector<float>>()->multitoken()->default_value(std::vector<float>({0.001, 0.001, 6.}), "0.001 0.001 6"), "width of the interaction diamond: x y z (cm)")(
     "isMT", bpo::value<bool>()->default_value(false), "multi-threaded mode (Geant4 only")(
     "outPrefix,o", bpo::value<std::string>()->default_value("o2sim"), "prefix of output files");
 }
@@ -48,6 +50,8 @@ bool SimConfig::resetFromParsedMap(boost::program_options::variables_map const& 
   mConfigData.mExtKinFileName = vm["extKinFile"].as<std::string>();
   mConfigData.mStartEvent = vm["startEvent"].as<unsigned int>();
   mConfigData.mBMax = vm["bMax"].as<float>();
+  mConfigData.mOrigin = vm["origin"].as<std::vector<float>>();
+  mConfigData.mSigmaO = vm["sigmaO"].as<std::vector<float>>();
   mConfigData.mIsMT = vm["isMT"].as<bool>();
   mConfigData.mOutputPrefix = vm["outPrefix"].as<std::string>();
   return true;

--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -68,7 +68,8 @@ bool SimConfig::resetFromArguments(int argc, char* argv[])
   initOptions(desc);
 
   try {
-    bpo::store(parse_command_line(argc, argv, desc), vm);
+    bpo::store(parse_command_line(argc, argv, desc, bpo::command_line_style::unix_style ^ bpo::command_line_style::allow_short), vm);
+    //    bpo::store(parse_command_line(argc, argv, desc), vm);
     bpo::notify(vm);
   } catch (const std::exception& ex) {
     std::cerr << "exception caught\n";

--- a/macro/o2sim.C
+++ b/macro/o2sim.C
@@ -57,6 +57,23 @@ FairRunSim* o2sim_init(bool asservice)
 
   // setup generator
   auto primGen = new FairPrimaryGenerator();
+  // interaction diamond
+  auto origin = confref.getOrigin();
+  auto sigmaO = confref.getSigmaO();
+  if (origin.size() != 3)
+    LOG(FATAL) << "Exactly 3 values accepted for interaction diamond position, " << origin.size() << " provided" << FairLogger::endl;
+  if (sigmaO.size() != 3)
+    LOG(FATAL) << "Exactly 3 values accepted for interaction diamond width, " << sigmaO.size() << " provided" << FairLogger::endl;
+  LOG(INFO) << "Setting interaction diamond: position / width = {"
+	    << origin[0] << "," << origin[1] << "," << origin[2] << "} / {"
+	    << sigmaO[0] << "," << sigmaO[1] << "," << sigmaO[2] << "} cm"
+	    << FairLogger::endl;
+  primGen->SetBeam(origin[0], origin[1], sigmaO[0], sigmaO[1]);
+  primGen->SetTarget(origin[2], sigmaO[2]);
+  primGen->SmearVertexXY(false);
+  primGen->SmearVertexZ(false);
+  primGen->SmearGausVertexXY(true);
+  primGen->SmearGausVertexZ(true);
   if (!asservice) {
     o2::eventgen::GeneratorFactory::setPrimaryGenerator(confref, primGen);
   }


### PR DESCRIPTION
This PR allows the `o2sim` executable to accept parameters that will setup the position and width of the interaction diamond for the simulation.

`o2sim -g pythia8 --origin 0.5 0.5 0.1 --sigmaO 1.e-3 1.e-3 5.5`

On the other hand, this needs a second commit to instruct `boost::program_options` to accept negative numbers. This would require (as far as I know) to drop the possibility to use the short version of commands which cannot be correctly interpreted anymore.

Currently

`o2sim -g pythia8 --origin 0.5 -0.5 0.1 --sigmaO 1.e-3 1.e-3 5.5`

causes an error, and there is apparently no way to prevent it (by using quotes for instance, boost strips them apparently).

With the second commit (that will come)

`o2sim -g pythia8 --origin 0.5 -0.5 0.1 --sigmaO 1.e-3 1.e-3 5.5`

will work fine for the negative number, although the `-g pythia8` is not understood anymore.
The correct command would need to be

`o2sim --generator pythia8 --origin 0.5 -0.5 0.1 --sigmaO 1.e-3 1.e-3 5.5`

@sawenzel , thanks for comments.

Cheers,
Roberto