### PR TITLE
Adding constant space-charge distortions to TPC simulation

### DIFF
--- a/Detectors/TPC/simulation/CMakeLists.txt
+++ b/Detectors/TPC/simulation/CMakeLists.txt
@@ -26,6 +26,7 @@ set(SRCS
    src/PadResponse.cxx
    src/Point.cxx
    src/SAMPAProcessing.cxx
+   src/SpaceCharge.cxx
 )
 
 set(HEADERS
@@ -42,6 +43,7 @@ set(HEADERS
    include/${MODULE_NAME}/PadResponse.h
    include/${MODULE_NAME}/Point.h
    include/${MODULE_NAME}/SAMPAProcessing.h
+   include/${MODULE_NAME}/SpaceCharge.h
 )
 Set(LINKDEF src/TPCSimulationLinkDef.h)
 Set(LIBRARY_NAME ${MODULE_NAME})

--- a/Detectors/TPC/simulation/include/TPCSimulation/Digitizer.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/Digitizer.h
@@ -18,6 +18,7 @@
 #include "TPCSimulation/DigitContainer.h"
 #include "TPCSimulation/PadResponse.h"
 #include "TPCSimulation/Point.h"
+#include "TPCSimulation/SpaceCharge.h"
 
 #include "TPCBase/Mapper.h"
 #include "Steer/HitProcessingManager.h"
@@ -27,6 +28,7 @@
 using std::vector;
 
 class TTree;
+class TH3;
 
 namespace o2
 {
@@ -92,16 +94,26 @@ class Digitizer
   /// \param isContinuous - false for triggered readout, true for continuous readout
   static void setContinuousReadout(bool isContinuous) { mIsContinuous = isContinuous; }
 
+  /// Enable the use of space-charge distortions
+  /// \param distortionType select the type of space-charge distortions (constant or realistic)
+  /// \param hisInitialSCDensity optional space-charge density histogram to use at the beginning of the simulation
+  /// \param nZSlices number of grid points in z, must be (2**N)+1
+  /// \param nPhiBins number of grid points in phi
+  /// \param nRBins number of grid points in r, must be (2**N)+1
+  void enableSCDistortions(SpaceCharge::SCDistortionType distortionType, TH3* hisInitialSCDensity, int nZSlices, int nPhiBins, int nRBins);
+
  private:
   Digitizer(const Digitizer&);
   Digitizer& operator=(const Digitizer&);
 
-  DigitContainer* mDigitContainer; ///< Container for the Digits
-  static bool mIsContinuous;       ///< Switch for continuous readout
+  DigitContainer* mDigitContainer;                  ///< Container for the Digits
+  std::unique_ptr<SpaceCharge> mSpaceChargeHandler; ///< Handler of space-charge distortions
+  static bool mIsContinuous;                        ///< Switch for continuous readout
+  bool mUseSCDistortions;                           ///< Flag to switch on the use of space-charge distortions
 
   ClassDefNV(Digitizer, 1);
 };
-}
-}
+} // namespace TPC
+} // namespace o2
 
 #endif // ALICEO2_TPC_Digitizer_H_

--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitizerTask.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitizerTask.h
@@ -22,7 +22,10 @@
 #include "SimulationDataFormat/MCTruthContainer.h"
 #include "TPCBase/Sector.h"
 #include "TPCSimulation/Digitizer.h"
+#include "TPCSimulation/SpaceCharge.h"
 #include "Steer/HitProcessingManager.h"
+
+class TH3;
 
 namespace o2
 {
@@ -59,6 +62,14 @@ class DigitizerTask : public FairTask
   /// Switch for triggered / continuous readout
   /// \param isContinuous - false for triggered readout, true for continuous readout
   void setContinuousReadout(bool isContinuous);
+
+  /// Enable the use of space-charge distortions
+  /// \param distortionType select the type of space-charge distortions (constant or realistic)
+  /// \param hisInitialSCDensity optional space-charge density histogram to use at the beginning of the simulation
+  /// \param nZSlices number of grid points in z, must be (2**N)+1; default size 129
+  /// \param nPhiBins number of grid points in phi; default size 180
+  /// \param nRBins number of grid points in r, must be (2**N)+1; default size 129
+  void enableSCDistortions(SpaceCharge::SCDistortionType distortionType, TH3* hisInitialSCDensity = nullptr, int nZSlices = 65, int nPhiBins = 180, int nRBins = 65);
 
   /// Set the maximal number of written out time bins
   /// \param nTimeBinsMax Maximal number of time bins to be written out
@@ -173,7 +184,7 @@ inline void DigitizerTask::setupSector(int s)
     mDigitsDebugArray->clear();
   mHitSector = s;
 }
-}
-}
+} // namespace TPC
+} // namespace o2
 
 #endif // ALICEO2_TPC_DigitizerTask_H_

--- a/Detectors/TPC/simulation/include/TPCSimulation/SpaceCharge.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/SpaceCharge.h
@@ -1,0 +1,182 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file SpaceCharge.h
+/// \brief Definition of the handler for the ALICE TPC space-charge distortions calculations
+/// \author Ernst Hellbär, Goethe-Universität Frankfurt, ernst.hellbar@cern.ch
+
+/*
+ * TODO:
+ *   - fix constants (more precise values, export into TPCBase/Constants)
+ *   - pad granularity in r, rphi?
+ *   - accumulate and add next slice
+ *     - event based: propagate charge(ievent-1), add charge(ievent)
+ *     - time based: mTime0, mEffectiveTime
+ *                   addIons(eventtime, drifttime, r, phi)
+ *                   time in us, 50 kHz = <one event / 20 us>
+ *                   if (ev.time+dr.time-mTime0 < mLengthTimebin) => add2NextSlice
+ *                   if  (mLengthTimebin < ev.time+dr.time-mTime0 < mLengthTimebin+100us) add2NextToNextSlice
+ *                     - apply updated distortions to ions in NextToNextSlice when space charge is propagated; need to store exact positions (e.g. std::vector<std::vector<float>>)!
+ *   - ion transport along the E field -> Jacobi matrices?
+ *   - what about primary ionization?
+ *   - irregular bin sizes in r and rphi
+ *   - timebins or z bins?
+ */
+
+#ifndef ALICEO2_TPC_SPACECHARGE_H
+#define ALICEO2_TPC_SPACECHARGE_H
+
+#include <TMatrixT.h>
+
+#include "AliTPCSpaceCharge3DCalc.h"
+#include "DataFormatsTPC/Defs.h"
+
+class TH3;
+class TMatrixDfwd;
+
+class AliTPCLookUpTable3DInterpolatorD;
+
+namespace o2
+{
+namespace TPC
+{
+
+class SpaceCharge
+{
+ public:
+  /// Enumerator for setting the space-charge distortion mode
+  enum SCDistortionType {
+    SCDistortionsConstant = 0, // space-charge distortions constant over time
+    SCDistortionsRealistic = 1 // realistic evolution of space-charge distortions over time
+  };
+
+  // Constructors
+  /// Default constructor using a grid size of (129 z bins, 180 phi bins, 129 r bins)
+  SpaceCharge();
+  /// Constructor with grid size specified by user
+  /// \param nZSlices number of grid points in z, must be (2**N)+1
+  /// \param nPhiBins number of grid points in phi
+  /// \param nRBins number of grid points in r, must be (2**N)+1
+  SpaceCharge(int nZSlices, int nPhiBins, int nRBins);
+  /// Constructor with grid size and interpolation order specified by user
+  /// \param nZSlices number of grid points in z, must be (2**N)+1
+  /// \param nPhiBins number of grid points in phi
+  /// \param nRBins number of grid points in r, must be (2**N)+1
+  /// \param interpolationOrder order used for interpolation of lookup tables
+  SpaceCharge(int nZSlices, int nPhiBins, int nRBins, int interpolationOrder);
+
+  // Destructor
+  ~SpaceCharge() = default;
+
+  /// Allocate memory for data members
+  void allocateMemory();
+
+  /// Calculate lookup tables if initial space-charge density is provided
+  void init();
+
+  /// Calculate distortion and correction lookup tables using AliTPCSpaceChargeCalc class
+  void calculateLookupTables();
+  /// Update distortion and correction lookup tables by current space-charge density
+  /// \param eventTime time of current event
+  void updateLookupTables(float eventTime);
+
+  /// Set omega*tau and T1, T2 tensor terms in Langevin-equation solution
+  /// \param omegaTau omega*tau
+  /// \param t1 T1 tensor term
+  /// \param t2 T2 tensor term
+  void setOmegaTauT1T2(float omegaTau, float t1, float t2);
+  /// Set an initial space-charge density
+  /// \param hisSCDensity 3D space-charge density histogram, expected format (phi,r,z)
+  void setInitialSpaceChargeDensity(TH3* hisSCDensity);
+  /// Add ions to space-charge density
+  /// \param zPos z position
+  /// \param phiPos phi position
+  /// \param rPos radial position
+  /// \param nIons number of ions
+  void fillSCDensity(float zPos, float phiPos, float rPos, int nIons);
+  /// Propagate space-charge density along electric field by one time slice
+  void propagateSpaceCharge();
+  /// Drift ion along electric field by one time slice
+  /// \param point 3D coordinates of the ion
+  /// \return GlobalPosition3D with coordinates of drifted ion
+  GlobalPosition3D driftIon(GlobalPosition3D& point);
+
+  /// Correct electron position using correction lookup tables
+  /// \param point 3D coordinates of the electron
+  void correctElectron(GlobalPosition3D& point);
+  /// Distort electron position using distortion lookup tables
+  /// \param point 3D coordinates of the electron
+  void distortElectron(GlobalPosition3D& point);
+
+  /// Set the space-charge distortions model
+  /// \param distortionType distortion type (constant or realistic)
+  void setSCDistortionType(SCDistortionType distortionType) { mSCDistortionType = distortionType; }
+  /// Get the space-charge distortions model
+  SCDistortionType getSCDistortionType() const { return mSCDistortionType; }
+
+ private:
+  /// Convert amount of ions into charge density C/m^3
+  /// \param nIons number of ions
+  /// \return space-charge density (C/m^3)
+  float ions2Charge(int nIons);
+
+  static constexpr float DvDEoverv0 = 0.0025; //! v'(E) / v0 = K / (K*E0) for ions, used in dz calculation
+  static const float sEzField;                //! nominal drift field
+
+  static constexpr int MaxZSlices = 200;     //! default number of z slices (1 ms slices)
+  static constexpr int MaxPhiBins = 360;     //! default number of phi bins
+  static constexpr float DriftLength = 250.; //! drift length of the TPC in (cm)
+  // ion mobility K = 3.0769231 cm^2/(Vs) in Ne-CO2 90-10 published by A. Deisting
+  // v_drift = K * E = 3.0769231 cm^2/(Vs) * 400 V/cm = 1230.7692 cm/s
+  // t_drift = 250 cm / v_drift = 203 ms
+  static constexpr float IonDriftTime = 2.03e5; //! drift time of ions for one full drift (us)
+  static constexpr float RadiusInner = 85.;     //! inner radius of the TPC active area
+  static constexpr float RadiusOuter = 245.;    //! outer radius of the TPC active area
+
+  const int mInterpolationOrder; ///< order for interpolation of lookup tables: 2==quadratic, >2==cubic spline
+
+  const int mNZSlices;          ///< number of z slices used in lookup tables
+  const int mNPhiBins;          ///< number of phi bins used in lookup tables
+  const int mNRBins;            ///< number of r bins used in lookup tables
+  const float mLengthZSlice;    ///< length of one z bin (cm)
+  const float mLengthTimeSlice; ///< ion drift time for one z slice (us)
+  const float mWidthPhiBin;     ///< width of one phi bin (radians)
+  const float mLengthRBin;      ///< length of one r bin (cm)
+
+  std::vector<double> mCoordZ;   ///< vector wiht coodinates of the z bins
+  std::vector<double> mCoordPhi; ///< vector wiht coodinates of the phi bins
+  std::vector<double> mCoordR;   ///< vector wiht coodinates of the r bins
+
+  bool mUseInitialSCDensity;          ///< Flag for the use of an initial space-charge density at the beginning of the simulation
+  bool mInitLookUpTables;             ///< Flag to indicate if lookup tables have been calculated
+  float mTimeInit;                    ///< time of last update of lookup tables
+  SCDistortionType mSCDistortionType; ///< Type of space-charge distortions
+
+  AliTPCSpaceCharge3DCalc mLookUpTableCalculator; ///< object to calculate and store correction and distortion lookup tables
+
+  /// TODO: check fastest way to order std::vectors
+  std::vector<std::vector<float>> mSpaceChargeDensityA; ///< space-charge density on the A side, stored in C/m^3 (z)(phi*r), ordering: z=[0,250], ir+iphi*nRBins
+  std::vector<std::vector<float>> mSpaceChargeDensityC; ///< space-charge density on the C side, stored in C/m^3 (z)(phi*r), ordering: z=[0,-250], ir+iphi*nRBins
+
+  /// TODO: Eliminate the need for these matrices as members, they will be owned by AliTPCLookUpTable3DInterpolatorD. AliTPCLookUpTable3DInterpolatorD needs getters for the matrices and the constructor has to be modified.
+  TMatrixD** mMatrixLocalIonDriftDzA;                                      ///< matrix to store local ion drift in z direction along E field on A side
+  TMatrixD** mMatrixLocalIonDriftDzC;                                      ///< matrix to store local ion drift in z direction along E field on A side
+  TMatrixD** mMatrixLocalIonDriftDrphiA;                                   ///< matrix to store local ion drift in rphi direction along E field on A side
+  TMatrixD** mMatrixLocalIonDriftDrphiC;                                   ///< matrix to store local ion drift in rphi direction along E field on A side
+  TMatrixD** mMatrixLocalIonDriftDrA;                                      ///< matrix to store local ion drift in radial direction along E field on A side
+  TMatrixD** mMatrixLocalIonDriftDrC;                                      ///< matrix to store local ion drift in radial direction along E field on C side
+  std::unique_ptr<AliTPCLookUpTable3DInterpolatorD> mLookUpLocalIonDriftA; ///< lookup table for local ion drift along E field on A side
+  std::unique_ptr<AliTPCLookUpTable3DInterpolatorD> mLookUpLocalIonDriftC; ///< lookup table for local ion drift along E field on C side
+};
+
+} // namespace TPC
+} // namespace o2
+
+#endif // ALICEO2_TPC_SPACECHARGE_H

--- a/Detectors/TPC/simulation/src/DigitizerTask.cxx
+++ b/Detectors/TPC/simulation/src/DigitizerTask.cxx
@@ -13,6 +13,7 @@
 /// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
 
 #include "TFile.h"
+#include "TH3.h"
 #include "TRandom.h"
 #include "TTree.h"
 
@@ -235,4 +236,21 @@ void DigitizerTask::initBunchTrainStructure(const size_t numberOfEvents)
     } else
       eventTime += bSpacing;
   }
+}
+
+void DigitizerTask::enableSCDistortions(SpaceCharge::SCDistortionType distortionType, TH3* hisInitialSCDensity, int nZSlices, int nPhiBins, int nRBins)
+{
+  if (distortionType == SpaceCharge::SCDistortionType::SCDistortionsConstant) {
+    LOG(INFO) << "Using constant space-charge distortions." << FairLogger::endl;
+    if (hisInitialSCDensity == nullptr) {
+      LOG(FATAL) << "Constant space-charge distortions require an initial space-charge density histogram. Please provide the path to the root file (O2TPCSCDensityHisFilePath) and the histogram name (O2TPCSCDensityHisName) in your environment variables." << FairLogger::endl;
+    }
+  }
+  if (distortionType == SpaceCharge::SCDistortionType::SCDistortionsRealistic) {
+    LOG(INFO) << "Using realistic space-charge distortions." << FairLogger::endl;
+  }
+  if (hisInitialSCDensity) {
+    LOG(INFO) << "Providing initial space-charge density histogram: " << hisInitialSCDensity->GetName() << FairLogger::endl;
+  }
+  mDigitizer->enableSCDistortions(distortionType, hisInitialSCDensity, nZSlices, nPhiBins, nRBins);
 }

--- a/Detectors/TPC/simulation/src/SpaceCharge.cxx
+++ b/Detectors/TPC/simulation/src/SpaceCharge.cxx
@@ -1,0 +1,336 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file SpaceCharge.cxx
+/// \brief Implementation of the interface for the ALICE TPC space-charge distortions calculations
+/// \author Ernst Hellbär, Goethe-Universität Frankfurt, ernst.hellbar@cern.ch
+
+#include "TGeoGlobalMagField.h"
+#include "TH3.h"
+#include "TMath.h"
+#include "TMatrixD.h"
+
+#include "AliTPCPoissonSolver.h"
+
+#include "CommonConstants/MathConstants.h"
+#include "DataFormatsTPC/Constants.h"
+#include "DataFormatsTPC/Defs.h"
+#include "Field/MagneticField.h"
+#include "MathUtils/Utils.h"
+#include "TPCBase/ParameterGas.h"
+#include "TPCSimulation/SpaceCharge.h"
+
+using namespace o2::TPC;
+
+const float o2::TPC::SpaceCharge::sEzField = (AliTPCPoissonSolver::fgkCathodeV - AliTPCPoissonSolver::fgkGG) / AliTPCPoissonSolver::fgkTPCZ0;
+
+SpaceCharge::SpaceCharge()
+  : mNZSlices(MaxZSlices),
+    mNPhiBins(MaxPhiBins),
+    mNRBins(Constants::MAXGLOBALPADROW),
+    mLengthZSlice(DriftLength / MaxZSlices),
+    mLengthTimeSlice(IonDriftTime / MaxZSlices),
+    mWidthPhiBin(o2::constants::math::TwoPI / MaxPhiBins),
+    mLengthRBin((RadiusOuter - RadiusInner) / Constants::MAXGLOBALPADROW),
+    mCoordZ(MaxZSlices),
+    mCoordPhi(MaxPhiBins),
+    mCoordR(Constants::MAXGLOBALPADROW),
+    mInterpolationOrder(2),
+    mUseInitialSCDensity(false),
+    mInitLookUpTables(false),
+    mTimeInit(-1),
+    mSCDistortionType(SpaceCharge::SCDistortionType::SCDistortionsRealistic),
+    mLookUpTableCalculator(Constants::MAXGLOBALPADROW, MaxZSlices, MaxPhiBins, 2, 3, 0),
+    mSpaceChargeDensityA(MaxZSlices),
+    mSpaceChargeDensityC(MaxZSlices)
+{
+  allocateMemory();
+}
+
+SpaceCharge::SpaceCharge(int nZSlices, int nPhiBins, int nRBins)
+  : mNZSlices(nZSlices),
+    mNPhiBins(nPhiBins),
+    mNRBins(nRBins),
+    mLengthZSlice(DriftLength / nZSlices),
+    mLengthTimeSlice(IonDriftTime / nZSlices),
+    mWidthPhiBin(o2::constants::math::TwoPI / nPhiBins),
+    mLengthRBin((RadiusOuter - RadiusInner) / nRBins),
+    mCoordZ(nZSlices),
+    mCoordPhi(nPhiBins),
+    mCoordR(nRBins),
+    mInterpolationOrder(2),
+    mUseInitialSCDensity(false),
+    mInitLookUpTables(false),
+    mTimeInit(-1),
+    mSCDistortionType(SpaceCharge::SCDistortionType::SCDistortionsRealistic),
+    mLookUpTableCalculator(nRBins, nZSlices, nPhiBins, 2, 3, 0),
+    mSpaceChargeDensityA(nZSlices),
+    mSpaceChargeDensityC(nZSlices)
+{
+  allocateMemory();
+}
+
+SpaceCharge::SpaceCharge(int nZSlices, int nPhiBins, int nRBins, int interpolationOrder)
+  : mNZSlices(nZSlices),
+    mNPhiBins(nPhiBins),
+    mNRBins(nRBins),
+    mLengthZSlice(DriftLength / nZSlices),
+    mLengthTimeSlice(IonDriftTime / nZSlices),
+    mWidthPhiBin(o2::constants::math::TwoPI / nPhiBins),
+    mLengthRBin((RadiusOuter - RadiusInner) / nRBins),
+    mCoordZ(nZSlices),
+    mCoordPhi(nPhiBins),
+    mCoordR(nRBins),
+    mInterpolationOrder(interpolationOrder),
+    mUseInitialSCDensity(false),
+    mInitLookUpTables(false),
+    mTimeInit(-1),
+    mSCDistortionType(SpaceCharge::SCDistortionType::SCDistortionsRealistic),
+    mLookUpTableCalculator(nRBins, nZSlices, nPhiBins, interpolationOrder, 3, 0),
+    mSpaceChargeDensityA(nZSlices),
+    mSpaceChargeDensityC(nZSlices)
+{
+  allocateMemory();
+}
+
+void SpaceCharge::allocateMemory()
+{
+  for (auto i = 0; i < mNZSlices; ++i) {
+    mSpaceChargeDensityA[i].resize(mNPhiBins * mNRBins);
+    mSpaceChargeDensityC[i].resize(mNPhiBins * mNRBins);
+  }
+
+  for (int iz = 0; iz < mNZSlices; ++iz)
+    mCoordZ[iz] = (iz + 1) * mLengthZSlice;
+  for (int iphi = 0; iphi < mNPhiBins; ++iphi)
+    mCoordPhi[iphi] = (iphi + 1) * mWidthPhiBin;
+  for (int ir = 0; ir < mNRBins; ++ir)
+    mCoordR[ir] = (ir + 1) * mLengthRBin;
+
+  mMatrixLocalIonDriftDzA = new TMatrixD*[mNPhiBins];
+  mMatrixLocalIonDriftDrphiA = new TMatrixD*[mNPhiBins];
+  mMatrixLocalIonDriftDrA = new TMatrixD*[mNPhiBins];
+  mMatrixLocalIonDriftDzC = new TMatrixD*[mNPhiBins];
+  mMatrixLocalIonDriftDrphiC = new TMatrixD*[mNPhiBins];
+  mMatrixLocalIonDriftDrC = new TMatrixD*[mNPhiBins];
+  for (int iphi = 0; iphi < mNPhiBins; ++iphi) {
+    mMatrixLocalIonDriftDzA[iphi] = new TMatrixD(mNRBins, mNZSlices);
+    mMatrixLocalIonDriftDrphiA[iphi] = new TMatrixD(mNRBins, mNZSlices);
+    mMatrixLocalIonDriftDrA[iphi] = new TMatrixD(mNRBins, mNZSlices);
+    mMatrixLocalIonDriftDzC[iphi] = new TMatrixD(mNRBins, mNZSlices);
+    mMatrixLocalIonDriftDrphiC[iphi] = new TMatrixD(mNRBins, mNZSlices);
+    mMatrixLocalIonDriftDrC[iphi] = new TMatrixD(mNRBins, mNZSlices);
+  }
+  mLookUpLocalIonDriftA = std::make_unique<AliTPCLookUpTable3DInterpolatorD>(mNRBins, mMatrixLocalIonDriftDrA, mCoordR.data(), mNPhiBins, mMatrixLocalIonDriftDrphiA, mCoordPhi.data(), mNZSlices, mMatrixLocalIonDriftDzA, mCoordZ.data(), mInterpolationOrder);
+  mLookUpLocalIonDriftC = std::make_unique<AliTPCLookUpTable3DInterpolatorD>(mNRBins, mMatrixLocalIonDriftDrC, mCoordR.data(), mNPhiBins, mMatrixLocalIonDriftDrphiC, mCoordPhi.data(), mNZSlices, mMatrixLocalIonDriftDzC, mCoordZ.data(), mInterpolationOrder);
+}
+
+void SpaceCharge::init()
+{
+  auto o2field = static_cast<o2::field::MagneticField*>(TGeoGlobalMagField::Instance()->GetField());
+  float bzField = o2field->solenoidField(); // magnetic field in kGauss
+  /// TODO is there a faster way to get the drift velocity
+  const static ParameterGas& gasParam = ParameterGas::defaultInstance();
+  float vDrift = gasParam.getVdrift(); // drift velocity in cm/us
+  /// TODO fix hard coded values (ezField, t1, t2): export to Constants.h or get from somewhere?
+  float t1 = 1.;
+  float t2 = 1.;
+  /// TODO use this parameterization or fixed value(s) from Magboltz calculations?
+  float omegaTau = -10. * bzField * vDrift / TMath::Abs(sEzField);
+  setOmegaTauT1T2(omegaTau, t1, t2);
+  if (mUseInitialSCDensity) {
+    calculateLookupTables();
+  }
+}
+
+void SpaceCharge::calculateLookupTables()
+{
+  // Potential, E field and electron distortion and correction lookup tables
+  mLookUpTableCalculator.ForceInitSpaceCharge3DPoissonIntegralDz(mNRBins, mNZSlices, mNPhiBins, 300, 1e-8);
+
+  // Lookup tables for local ion drift along E field
+  if (mSCDistortionType == SCDistortionType::SCDistortionsRealistic) {
+    for (int iphi = 0; iphi < mNPhiBins; ++iphi) {
+      float phi = mCoordPhi[iphi];
+      TMatrixD& matrixDzA = *mMatrixLocalIonDriftDzA[iphi];
+      TMatrixD& matrixDzC = *mMatrixLocalIonDriftDzC[iphi];
+      TMatrixD& matrixDrphiA = *mMatrixLocalIonDriftDrphiA[iphi];
+      TMatrixD& matrixDrphiC = *mMatrixLocalIonDriftDrphiC[iphi];
+      TMatrixD& matrixDrA = *mMatrixLocalIonDriftDrA[iphi];
+      TMatrixD& matrixDrC = *mMatrixLocalIonDriftDrC[iphi];
+      int roc = o2::utils::Angle2Sector(phi);
+      for (int ir = 0; ir < mNRBins; ++ir) {
+        float radius = mCoordR[ir];
+        for (int iz = 0; iz < mNZSlices; ++iz) {
+          // A side
+          float z = mCoordZ[iz];
+          float x0[3] = { radius, phi, z };
+          float x1[3] = { radius, phi, z - mLengthZSlice };
+          double eVector0[3] = { 0.f, 0.f, 0.f };
+          double eVector1[3] = { 0.f, 0.f, 0.f };
+          mLookUpTableCalculator.GetElectricFieldCyl(x0, roc, eVector0);
+          mLookUpTableCalculator.GetElectricFieldCyl(x1, roc, eVector1);
+          matrixDzA(ir, iz) = DvDEoverv0 * (mLengthZSlice / 2.f) * (eVector0[2] + eVector1[2]);
+          matrixDrphiA(ir, iz) = (mLengthZSlice / 2.f) * (eVector0[1] + eVector1[1]) / sEzField;
+          matrixDrA(ir, iz) = (mLengthZSlice / 2.f) * (eVector0[0] + eVector1[0]) / sEzField;
+          // C side
+          x0[2] *= -1;
+          x1[2] *= -1;
+          mLookUpTableCalculator.GetElectricFieldCyl(x0, roc + 18, eVector0);
+          mLookUpTableCalculator.GetElectricFieldCyl(x1, roc + 18, eVector1);
+          matrixDzC(ir, iz) = DvDEoverv0 * (mLengthZSlice / 2.f) * (eVector0[2] + eVector1[2]);
+          matrixDrphiC(ir, iz) = (mLengthZSlice / 2.f) * (eVector0[1] + eVector1[1]) / sEzField;
+          matrixDrC(ir, iz) = (mLengthZSlice / 2.f) * (eVector0[0] + eVector1[0]) / sEzField;
+        }
+      }
+    }
+    mLookUpLocalIonDriftA->CopyFromMatricesToInterpolator();
+    mLookUpLocalIonDriftC->CopyFromMatricesToInterpolator();
+
+    /// TODO: Propagate current SC density along E field by one time bin for next update
+  }
+
+  mInitLookUpTables = true;
+}
+
+void SpaceCharge::updateLookupTables(float eventTime)
+{
+  if (mTimeInit < 0.) {
+    mTimeInit = eventTime; // set the time of first initialization
+  }
+  if (TMath::Abs(eventTime - mTimeInit) < mLengthTimeSlice) {
+    return; // update only after one time bin has passed
+  }
+
+  std::unique_ptr<std::unique_ptr<TMatrixD>[]> spaceChargeA = std::make_unique<std::unique_ptr<TMatrixD>[]>(mNPhiBins);
+  std::unique_ptr<std::unique_ptr<TMatrixD>[]> spaceChargeC = std::make_unique<std::unique_ptr<TMatrixD>[]>(mNPhiBins);
+  for (int iphi = 0; iphi < mNPhiBins; ++iphi) {
+    spaceChargeA[iphi] = std::make_unique<TMatrixD>(mNRBins, mNZSlices);
+    spaceChargeC[iphi] = std::make_unique<TMatrixD>(mNRBins, mNZSlices);
+  }
+  for (int iside = 0; iside < 2; ++iside) {
+    for (int iphi = 0; iphi < mNPhiBins; ++iphi) {
+      TMatrixD& chargeDensity = iside == 0 ? *spaceChargeA[iphi] : *spaceChargeC[iphi];
+      for (int ir = 0; ir < mNRBins; ++ir) {
+        for (int iz = 0; iz < mNZSlices; ++iz) {
+          if (iside == 0) {
+            chargeDensity(ir, iz) = mSpaceChargeDensityA[iz][ir + iphi * mNRBins];
+          } else {
+            chargeDensity(ir, iz) = mSpaceChargeDensityC[iz][ir + iphi * mNRBins];
+          }
+        }
+      }
+    }
+  }
+  mLookUpTableCalculator.SetInputSpaceChargeA((TMatrixD**)spaceChargeA.get());
+  mLookUpTableCalculator.SetInputSpaceChargeC((TMatrixD**)spaceChargeC.get());
+  calculateLookupTables();
+}
+
+void SpaceCharge::setOmegaTauT1T2(float omegaTau, float t1, float t2)
+{
+  mLookUpTableCalculator.SetOmegaTauT1T2(omegaTau, t1, t2);
+}
+
+void SpaceCharge::setInitialSpaceChargeDensity(TH3* hisSCDensity)
+{
+  std::unique_ptr<std::unique_ptr<TMatrixD>[]> spaceChargeA = std::make_unique<std::unique_ptr<TMatrixD>[]>(mNPhiBins);
+  std::unique_ptr<std::unique_ptr<TMatrixD>[]> spaceChargeC = std::make_unique<std::unique_ptr<TMatrixD>[]>(mNPhiBins);
+  for (int iphi = 0; iphi < mNPhiBins; ++iphi) {
+    spaceChargeA[iphi] = std::make_unique<TMatrixD>(mNRBins, mNZSlices);
+    spaceChargeC[iphi] = std::make_unique<TMatrixD>(mNRBins, mNZSlices);
+  }
+  mLookUpTableCalculator.GetChargeDensity((TMatrixD**)spaceChargeA.get(), (TMatrixD**)spaceChargeC.get(), hisSCDensity, mNRBins, mNZSlices, mNPhiBins);
+  for (int iside = 0; iside < 2; ++iside) {
+    for (int iphi = 0; iphi < mNPhiBins; ++iphi) {
+      TMatrixD& chargeDensity = iside == 0 ? *spaceChargeA[iphi] : *spaceChargeC[iphi];
+      for (int ir = 0; ir < mNRBins; ++ir) {
+        for (int iz = 0; iz < mNZSlices; ++iz) {
+          if (iside == 0) {
+            mSpaceChargeDensityA[iz][ir + iphi * mNRBins] = chargeDensity(ir, iz);
+          } else {
+            mSpaceChargeDensityC[iz][ir + iphi * mNRBins] = chargeDensity(ir, iz);
+          }
+        }
+      }
+    }
+  }
+  mLookUpTableCalculator.SetInputSpaceChargeA((TMatrixD**)spaceChargeA.get());
+  mLookUpTableCalculator.SetInputSpaceChargeC((TMatrixD**)spaceChargeC.get());
+  mUseInitialSCDensity = true;
+}
+
+void SpaceCharge::fillSCDensity(float zPos, float phiPos, float rPos, int nIons)
+{
+  const int zBin = TMath::Abs(zPos) / mLengthZSlice;
+  const int phiBin = phiPos / mWidthPhiBin;
+  const int rBin = rPos / mLengthRBin;
+  if (zPos > 0) {
+    mSpaceChargeDensityA[zBin][rBin + phiBin * mNRBins] += ions2Charge(nIons);
+  } else {
+    mSpaceChargeDensityC[zBin][rBin + phiBin * mNRBins] += ions2Charge(nIons);
+  }
+}
+
+/// TODO
+// void SpaceCharge::propagateSpaceCharge()
+// {
+//
+// }
+
+// GlobalPosition3D SpaceCharge::driftIon(GlobalPosition3D &point);
+// {
+//   GlobalPosition3D posIonDistorted(point.X(),point.Y(),point.Z());
+//   if (!mInitLookUpTables) return posIonDistorted;
+//
+// }
+
+void SpaceCharge::correctElectron(GlobalPosition3D& point)
+{
+  if (!mInitLookUpTables) {
+    return;
+  }
+  const float x[3] = { point.X(), point.Y(), point.Z() };
+  float dx[3] = { 0.f, 0.f, 0.f };
+  float phi = TMath::ATan2(x[1], x[0]);
+  if (phi < 0) {
+    phi += TMath::TwoPi();
+  }
+  int roc = phi / TMath::Pi() * 9;
+  if (x[2] < 0) {
+    roc += 18;
+  }
+  mLookUpTableCalculator.GetCorrection(x, roc, dx);
+  point = GlobalPosition3D(x[0] + dx[0], x[1] + dx[1], x[2] + dx[2]);
+}
+
+void SpaceCharge::distortElectron(GlobalPosition3D& point)
+{
+  if (!mInitLookUpTables) {
+    return;
+  }
+  const float x[3] = { point.X(), point.Y(), point.Z() };
+  float dx[3] = { 0.f, 0.f, 0.f };
+  float phi = TMath::ATan2(x[1], x[0]);
+  if (phi < 0) {
+    phi += TMath::TwoPi();
+  }
+  int roc = phi / TMath::Pi() * 9;
+  if (x[2] < 0) {
+    roc += 18;
+  }
+  mLookUpTableCalculator.GetDistortion(x, roc, dx);
+  point = GlobalPosition3D(x[0] + dx[0], x[1] + dx[1], x[2] + dx[2]);
+}
+
+float SpaceCharge::ions2Charge(int nIons)
+{
+  return 1.e6f * nIons * TMath::Qe() / (mLengthZSlice * (mWidthPhiBin * mLengthRBin) * mLengthRBin);
+}

--- a/Detectors/TPC/simulation/src/TPCSimulationLinkDef.h
+++ b/Detectors/TPC/simulation/src/TPCSimulationLinkDef.h
@@ -32,6 +32,7 @@
 #pragma link C++ class std::vector < o2::TPC::ElementalHit > +;
 #pragma link C++ class o2::TPC::HitGroup + ;
 #pragma link C++ class o2::TPC::SAMPAProcessing + ;
+#pragma link C++ class o2::TPC::SpaceCharge+;
 
 #pragma link C++ class std::vector < o2::TPC::HitGroup > +;
 

--- a/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
+++ b/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
@@ -8,6 +8,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#include "DetectorsBase/Propagator.h"
 #include "Framework/WorkflowSpec.h"
 #include "Framework/ConfigParamSpec.h"
 #include "Framework/CompletionPolicy.h"
@@ -178,6 +179,9 @@ bool wantCollisionTimePrinter()
 
 std::shared_ptr<o2::parameters::GRPObject> readGRP(std::string inputGRP = "o2sim_grp.root")
 {
+  // init magnetic field
+  o2::Base::Propagator::initFieldFromGRP(inputGRP);
+
   auto grp = o2::parameters::GRPObject::loadFrom(inputGRP);
   if (!grp) {
     LOG(ERROR) << "This workflow needs a valid GRP file to start";

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -966,13 +966,14 @@ o2_define_bucket(
     tpc_base_bucket
     data_format_TPC_bucket
     detectors_base_bucket
+    TPCSpaceChargeBase_bucket
     Field
     DetectorsBase
     Generators
     TPCBase
     SimulationDataFormat
     DataFormatsTPC
-    TPCSpaceChargeBase_bucket
+    O2TPCSpaceChargeBase
     Geom
     MathCore
     MathUtils


### PR DESCRIPTION
Adding first version of constant space-charge distortions to TPC simulation. New options to enable distortions in digitizer-workflow.

Usage in digitizer-workflow:
--distortionType 2 (enable constant distortions)
--gridSize 33,180,33 (comma separated list of z,phi,r bin of lookup tables, default value 33,180,33)
--initialSpaceChargeDensity (path to root file with TH3 used as initial space-charge density and name of TH3 (comma separated))