### PR TITLE
digitizer-workflow: memory reductions part 2

### DIFF
--- a/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
+++ b/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
@@ -51,6 +51,7 @@
 #include <string>
 #include <sstream>
 #include <cmath>
+#include <unistd.h> // for getppid
 
 using namespace o2::framework;
 
@@ -115,7 +116,24 @@ int getNumTPCLanes(std::vector<int> const& sectors, ConfigContext const& configc
 
 void initTPC()
 {
-  LOG(DEBUG) << "Initializing TPC GEMAmplification";
+  // We only want to do this for the DPL master
+  // I am not aware of an easy way to query if "I am DPL master" so
+  // using for the moment a mechanism defining/setting an environment variable
+  // with the parent ID and query inside forks if this environment variable exists
+  // (it assumes fundamentally that the master executes this function first)
+  std::stringstream streamthis;
+  std::stringstream streamparent;
+
+  streamthis << "TPCGEMINIT_PID" << getpid();
+  streamparent << "TPCGEMINIT_PID" << getppid();
+  if (getenv(streamparent.str().c_str())) {
+    LOG(DEBUG) << "GEM ALREADY INITIALIZED ... SKIPPING HERE";
+    return;
+  } else {
+    LOG(DEBUG) << "INITIALIZING TPC GEMAmplification";
+  }
+  setenv(streamthis.str().c_str(), "ON", 1);
+
   auto& cdb = o2::TPC::CDBInterface::instance();
   cdb.setUseDefaults();
   // by invoking this constructor we make sure that a common file will be created


### PR DESCRIPTION
This commit addresses more memory reductions on top of c0ef1d905dd59f.

With this commit, we avoid setting up the TPC GEM initialization in every
DPL processor by restricting it to the master process. Finding out
if we are in the master process is done using environment variables.

(Reminder: This is an objects which needs to be initialized before the TPC
digitizers which have common access to it, and so this is for the moment done
during global workflow setup.)

It is understood that the final solution will use a different mechanism
(OCDB) but given that we gain ~100MB per processor, it is worth improving
on the existing solution NOW.

The commit also now avoids an error message "File not found" during the actual
setup.