### PR TITLE
add TPC cluster reject options

### DIFF
--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/ClustererTask.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/ClustererTask.h
@@ -33,7 +33,9 @@ namespace TPC{
 
 class ClustererTask : public FairTask{
 
-  using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
+  using MCLabelContainer    = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
+//  using OutputType          = Cluster;
+  using OutputType          = ClusterHardwareContainer8kb;
 
   public:
    /// Default constructor
@@ -68,8 +70,8 @@ class ClustererTask : public FairTask{
    std::unique_ptr<const MCLabelContainer> mDigitMCTruthArray; ///< Array for MCTruth information associated to digits in mDigitsArrray
 
    // Cluster arrays
-   std::unique_ptr<std::vector<ClusterHardwareContainer8kb>> mHwClustersArray; ///< Array of clusters found by Hw Clusterfinder
-   std::unique_ptr<MCLabelContainer> mHwClustersMCTruthArray;                  ///< Array for MCTruth information associated to cluster in mHwClustersArrays
+   std::unique_ptr<std::vector<OutputType>> mHwClustersArray;   ///< Array of clusters found by Hw Clusterfinder
+   std::unique_ptr<MCLabelContainer> mHwClustersMCTruthArray;   ///< Array for MCTruth information associated to cluster in mHwClustersArrays
 
    ClassDefOverride(ClustererTask, 1)
 };

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/ClustererTask.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/ClustererTask.h
@@ -33,47 +33,47 @@ namespace TPC{
 
 class ClustererTask : public FairTask{
 
-  using MCLabelContainer    = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
-//  using OutputType          = Cluster;
-  using OutputType          = ClusterHardwareContainer8kb;
+  using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
+  //  using OutputType          = Cluster;
+  using OutputType = ClusterHardwareContainer8kb;
 
-  public:
-   /// Default constructor
-   /// \param sectorid Sector to be processed
-   ClustererTask(int sectorid = -1);
+ public:
+  /// Default constructor
+  /// \param sectorid Sector to be processed
+  ClustererTask(int sectorid = -1);
 
-   /// Destructor
-   ~ClustererTask() override = default;
+  /// Destructor
+  ~ClustererTask() override = default;
 
-   /// Initializes the clusterer and connects input and output container
-   InitStatus Init() override;
+  /// Initializes the clusterer and connects input and output container
+  InitStatus Init() override;
 
-   /// Clusterization
-   void Exec(Option_t* option) override;
+  /// Clusterization
+  void Exec(Option_t* option) override;
 
-   /// Complete Clusterization
-   void FinishTask() override;
+  /// Complete Clusterization
+  void FinishTask() override;
 
-   /// Switch for triggered / continuous readout
-   /// \param isContinuous - false for triggered readout, true for continuous readout
-   void setContinuousReadout(bool isContinuous);
+  /// Switch for triggered / continuous readout
+  /// \param isContinuous - false for triggered readout, true for continuous readout
+  void setContinuousReadout(bool isContinuous);
 
-  private:
-   bool mIsContinuousReadout; ///< Switch for continuous readout
-   int mEventCount;           ///< Event counter
-   int mClusterSector;        ///< Sector to be processed
+ private:
+  bool mIsContinuousReadout; ///< Switch for continuous readout
+  int mEventCount;           ///< Event counter
+  int mClusterSector;        ///< Sector to be processed
 
-   std::unique_ptr<HwClusterer> mHwClusterer; ///< Hw Clusterfinder instance
+  std::unique_ptr<HwClusterer> mHwClusterer; ///< Hw Clusterfinder instance
 
-   // Digit arrays
-   std::unique_ptr<const std::vector<Digit>> mDigitsArray;     ///< Array of TPC digits
-   std::unique_ptr<const MCLabelContainer> mDigitMCTruthArray; ///< Array for MCTruth information associated to digits in mDigitsArrray
+  // Digit arrays
+  std::unique_ptr<const std::vector<Digit>> mDigitsArray;     ///< Array of TPC digits
+  std::unique_ptr<const MCLabelContainer> mDigitMCTruthArray; ///< Array for MCTruth information associated to digits in mDigitsArrray
 
-   // Cluster arrays
-   std::unique_ptr<std::vector<OutputType>> mHwClustersArray;   ///< Array of clusters found by Hw Clusterfinder
-   std::unique_ptr<MCLabelContainer> mHwClustersMCTruthArray;   ///< Array for MCTruth information associated to cluster in mHwClustersArrays
+  // Cluster arrays
+  std::unique_ptr<std::vector<OutputType>> mHwClustersArray; ///< Array of clusters found by Hw Clusterfinder
+  std::unique_ptr<MCLabelContainer> mHwClustersMCTruthArray; ///< Array for MCTruth information associated to cluster in mHwClustersArrays
 
-   ClassDefOverride(ClustererTask, 1)
+  ClassDefOverride(ClustererTask, 1)
 };
 
 inline

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/HwClusterer.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/HwClusterer.h
@@ -78,12 +78,14 @@ class HwClusterer : public Clusterer
   /// \param mcDigitTruth MC Digit Truth container
   /// \param clearContainerFirst Clears the outpcontainer for clusters and MC labels first, before processing
   void process(std::vector<o2::TPC::Digit> const& digits, MCLabelContainer const* mcDigitTruth) override;
+  void process(std::vector<o2::TPC::Digit> const& digits, MCLabelContainer const* mcDigitTruth, bool clearContainerFirst);
 
   /// Finish processing digits
   /// \param digits Container with TPC digits
   /// \param mcDigitTruth MC Digit Truth container
   /// \param clearContainerFirst Clears the outpcontainer for clusters and MC labels first, before processing
   void finishProcess(std::vector<o2::TPC::Digit> const& digits, MCLabelContainer const* mcDigitTruth) override;
+  void finishProcess(std::vector<o2::TPC::Digit> const& digits, MCLabelContainer const* mcDigitTruth, bool clearContainerFirst);
 
   /// Switch for triggered / continuous readout
   /// \param isContinuous - false for triggered readout, true for continuous readout
@@ -220,6 +222,16 @@ class HwClusterer : public Clusterer
   std::vector<Cluster>* mPlainClusterArray;                ///< Pointer to output cluster container
   MCLabelContainer* mClusterMcLabelArray;                  ///< Pointer to MC Label container
 };
+
+inline void HwClusterer::process(std::vector<o2::TPC::Digit> const& digits, o2::dataformats::MCTruthContainer<o2::MCCompLabel> const* mcDigitTruth)
+{
+  process(digits, mcDigitTruth, true);
+}
+
+inline void HwClusterer::finishProcess(std::vector<o2::TPC::Digit> const& digits, o2::dataformats::MCTruthContainer<o2::MCCompLabel> const* mcDigitTruth)
+{
+  finishProcess(digits, mcDigitTruth, true);
+}
 
 inline void HwClusterer::setContinuousReadout(bool isContinuous)
 {

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/HwClusterer.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/HwClusterer.h
@@ -76,11 +76,13 @@ class HwClusterer : public Clusterer
   /// Process digits
   /// \param digits Container with TPC digits
   /// \param mcDigitTruth MC Digit Truth container
+  /// \param clearContainerFirst Clears the outpcontainer for clusters and MC labels first, before processing
   void process(std::vector<o2::TPC::Digit> const& digits, MCLabelContainer const* mcDigitTruth) override;
 
   /// Finish processing digits
   /// \param digits Container with TPC digits
   /// \param mcDigitTruth MC Digit Truth container
+  /// \param clearContainerFirst Clears the outpcontainer for clusters and MC labels first, before processing
   void finishProcess(std::vector<o2::TPC::Digit> const& digits, MCLabelContainer const* mcDigitTruth) override;
 
   /// Switch for triggered / continuous readout
@@ -95,6 +97,24 @@ class HwClusterer : public Clusterer
   /// \param charge Threshold which will be used
   void setContributionChargeThreshold(unsigned charge);
 
+  /// Switch to reject single pad clusters
+  /// \param doReject - true to reject clusters with sigmaPad2Pre == 0
+  void setRejectSinglePadClusters(bool doReject);
+
+  /// Switch to reject single time clusters
+  /// \param doReject - true to reject clusters with sigmaTime2Pre == 0
+  void setRejectSingleTimeClusters(bool doReject);
+
+  /// Switch to reject peaks in following timebins
+  /// \param doReject - true to reject peak, false to NOT reject peaks in following bins
+  void setRejectLaterTimebin(bool doReject);
+
+  /// Switch for mode, how the charge should be shared among nearby clusters
+  /// \param mode   0 for no splitting, charge is used for all found peaks,
+  ///               1 for minimum contributes half to all peaks
+  ///               2 for minimum contributes only to left/older peak
+  void setSplittingMode(short mode);
+
  private:
   /*
    * Helper functions
@@ -103,23 +123,23 @@ class HwClusterer : public Clusterer
   /// HW Cluster Processor
   /// \param peakMask       VC-mask with only peaks enabled
   /// \param qMaxIndex      Buffer index of center pad
-  /// \param center_pad     Pad number to be checked for cluster
-  /// \param center_time    Time to be checked for cluster
+  /// \param centerPad     Pad number to be checked for cluster
+  /// \param centerTime    Time to be checked for cluster
   /// \param row            Row number for cluster properties
-  void hwClusterProcessor(Vc::uint_m peakMask, unsigned qMaxIndex, short center_pad, int center_time, unsigned short row);
+  void hwClusterProcessor(Vc::uint_m peakMask, unsigned qMaxIndex, short centerPad, int centerTime, unsigned short row);
 
   /// HW Peak Finder
   /// \param qMaxIndex        Buffer index of central pad
-  /// \param center_pad       Pad number to be checked for cluster
-  /// \param center_time      Time to be checked for cluster
+  /// \param centerPad        Pad number to be checked for cluster
+  /// \param mappedCenterTime Time to be checked for cluster, mapped in available time space
   /// \param row              Row number for cluster properties
-  void hwPeakFinder(unsigned qMaxIndex, short center_pad, int center_time, unsigned short row);
+  void hwPeakFinder(unsigned qMaxIndex, short centerPad, int mappedCenterTime, unsigned short row);
 
   /// Helper function to update cluster properties and MC labels
   /// \param selectionMask  VC-mask with slected pads enabled
   /// \param row            Current row
-  /// \param center_pad     Pad of peak
-  /// \param center_time    Timebin of peak
+  /// \param centerPad     Pad of peak
+  /// \param centerTime    Timebin of peak
   /// \param dp             delta pad
   /// \param dt             delta time
   /// \param qTot           Total charge
@@ -128,7 +148,7 @@ class HwClusterer : public Clusterer
   /// \param sigmaPad2      Weighted sigma pad ^2 parameter
   /// \param sigmaTime2     Weighted sigma time ^2 parameter
   /// \param mcLabel        Vector with MClabel-counter-pairs
-  void updateCluster(const Vc::uint_m selectionMask, int row, short center_pad, int center_time, short dp, short dt, Vc::uint_v& qTot, Vc::int_v& pad, Vc::int_v& time, Vc::int_v& sigmaPad2, Vc::int_v& sigmaTime2, std::vector<std::unique_ptr<std::vector<std::pair<MCCompLabel, unsigned>>>>& mcLabels);
+  void updateCluster(const Vc::uint_m selectionMask, int row, short centerPad, int centerTime, short dp, short dt, Vc::uint_v& qTot, Vc::int_v& pad, Vc::int_v& time, Vc::int_v& sigmaPad2, Vc::int_v& sigmaTime2, std::vector<std::unique_ptr<std::vector<std::pair<MCCompLabel, unsigned>>>>& mcLabels, Vc::uint_m splitMask = Vc::Mask<uint>(false));
 
   /// Writes clusters from temporary storage to cluster output
   /// \param timeOffset   Time offset of cluster container
@@ -146,7 +166,7 @@ class HwClusterer : public Clusterer
   /// \param clear    Clears data buffer afterwards (for not continuous readout)
   void finishFrame(bool clear = false);
 
-  /// Clears the buffer at given timebin TODO: and fills timebin with noise + pedestal
+  /// Clears the buffer at given timebin
   /// \param timebin  Timebin to be cleared
   void clearBuffer(int timebin);
 
@@ -163,22 +183,15 @@ class HwClusterer : public Clusterer
   /// \param value  some value
   Vc::uint_v getFpOfADC(const Vc::uint_v value);
 
-  /// Does the comparison between two pads and sets the bits accordingly
-  /// \param qMaxIndex      Buffer index of central pad
-  /// \param compareIndex   Buffer index of pad to compare with
-  /// \param bitMax         Bit to be set for peak finding
-  /// \param bitMin         Bit to be set for minimum finding
-  /// \param row            Row number
-  void compareForPeak(const unsigned qMaxIndex, const unsigned compareIndex, const unsigned bitMax, const unsigned bitMin, const unsigned short row);
-
   /*
    * class members
    */
-  static const int mTimebinsInBuffer = 5;
+  static const int mTimebinsInBuffer = 6;
 
   unsigned short mNumRows;               ///< Number of rows in this sector
   unsigned short mNumRowSets;            ///< Number of row sets (Number of rows / Vc::Size) in this sector
   short mCurrentMcContainerInBuffer;     ///< Bit field, where to find the current MC container in buffer
+  short mSplittingMode;                  ///< Cluster splitting mode, 0 no splitting, 1 for minimum contributes half to both, 2 for miminum corresponds to left/older cluster
   int mClusterSector;                    ///< Sector to be processed
   int mLastTimebin;                      ///< Last time bin of previous event
   unsigned mLastHB;                      ///< Last HB bin of previous event
@@ -186,6 +199,9 @@ class HwClusterer : public Clusterer
   unsigned mContributionChargeThreshold; ///< Charge threshold for the contributing pads in ADC counts
   unsigned mClusterCounter;              ///< Cluster counter in output container for MC truth matching
   bool mIsContinuousReadout;             ///< Switch for continuous readout
+  bool mRejectSinglePadClusters;         ///< Switch to reject single pad clusters, sigmaPad2Pre == 0
+  bool mRejectSingleTimeClusters;        ///< Switch to reject single time clusters, sigmaTime2Pre == 0
+  bool mRejectLaterTimebin;              ///< Switch to reject peaks in later timebins of the same pad
 
   std::vector<unsigned short> mPadsPerRow;                       ///< Number of pads for given row (offset of 2 pads on both sides is already added)
   std::vector<unsigned short> mPadsPerRowSet;                    ///< Number of pads for given row set (offset of 2 pads on both sides is already added), a row set combines rows for parallel SIMD processing
@@ -220,6 +236,26 @@ inline void HwClusterer::setContributionChargeThreshold(unsigned charge)
   mContributionChargeThreshold = charge;
 }
 
+inline void HwClusterer::setRejectSinglePadClusters(bool doReject)
+{
+  mRejectSinglePadClusters = doReject;
+}
+
+inline void HwClusterer::setRejectSingleTimeClusters(bool doReject)
+{
+  mRejectSingleTimeClusters = doReject;
+}
+
+inline void HwClusterer::setRejectLaterTimebin(bool doReject)
+{
+  mRejectLaterTimebin = doReject;
+}
+
+inline void HwClusterer::setSplittingMode(short mode)
+{
+  mSplittingMode = mode;
+}
+
 inline int HwClusterer::mapTimeInRange(int time)
 {
   return (mTimebinsInBuffer + (time % mTimebinsInBuffer)) % mTimebinsInBuffer;
@@ -239,57 +275,6 @@ inline short HwClusterer::getFirstSetBitOfField()
   return -1;
 }
 
-inline void HwClusterer::compareForPeak(const unsigned qMaxIndex, const unsigned compareIndex, const unsigned bitMax, const unsigned bitMin, const unsigned short row)
-{
-
-  const auto tmpMask = getFpOfADC(mDataBuffer[row][qMaxIndex]) >= getFpOfADC(mDataBuffer[row][compareIndex]);
-
-  // current center could be peak in one direction
-  where(tmpMask) | mDataBuffer[row][qMaxIndex] |= (0x1 << bitMax);
-
-  // other is smaller than center
-  // and if other one was not a peak candidate before (bit is 0), it is a minimum in one direction,
-  // so bitMin has to be set to inverse of bitMax of pad to compare
-  where(tmpMask) | mDataBuffer[row][compareIndex] |= (~mDataBuffer[row][compareIndex] & (0x1 << bitMax)) >> (bitMax - bitMin);
-
-  // other is not peak
-  where(tmpMask) | mDataBuffer[row][compareIndex] &= ~(0x1 << bitMax);
-
-  // other is peak if bit was already set
-  where(!tmpMask) | mDataBuffer[row][compareIndex] |= (mDataBuffer[row][compareIndex] & (0x1 << bitMax));
-}
-
-inline void HwClusterer::updateCluster(
-  const Vc::uint_m selectionMask, int row, short center_pad, int center_time, short dp, short dt,
-  Vc::uint_v& qTot, Vc::int_v& pad, Vc::int_v& time, Vc::int_v& sigmaPad2, Vc::int_v& sigmaTime2,
-  std::vector<std::unique_ptr<std::vector<std::pair<MCCompLabel, unsigned>>>>& mcLabels)
-{
-  const int mappedTime = mapTimeInRange(center_time + dt);
-  const int index = mappedTime * mPadsPerRowSet[row] + center_pad + dp;
-
-  where(selectionMask) | qTot += getFpOfADC(mDataBuffer[row][index]);
-  where(selectionMask) | pad += getFpOfADC(mDataBuffer[row][index]) * dp;
-  where(selectionMask) | time += getFpOfADC(mDataBuffer[row][index]) * dt;
-  where(selectionMask) | sigmaPad2 += getFpOfADC(mDataBuffer[row][index]) * dp * dp;
-  where(selectionMask) | sigmaTime2 += getFpOfADC(mDataBuffer[row][index]) * dt * dt;
-
-  for (int i = 0; i < Vc::uint_v::Size; ++i) {
-    if (selectionMask[i] && mMCtruth[mappedTime] != nullptr) {
-      for (auto& label : mMCtruth[mappedTime]->getLabels(mIndexBuffer[row][index][i])) {
-        bool isKnown = false;
-        for (auto& vecLabel : *mcLabels[i]) {
-          if (label == vecLabel.first) {
-            ++vecLabel.second;
-            isKnown = true;
-          }
-        }
-        if (!isKnown) {
-          mcLabels[i]->emplace_back(label, 1);
-        }
-      }
-    }
-  }
-}
 }
 }
 

--- a/Detectors/TPC/reconstruction/src/ClustererTask.cxx
+++ b/Detectors/TPC/reconstruction/src/ClustererTask.cxx
@@ -72,7 +72,7 @@ InitStatus ClustererTask::Init()
   }
 
   // Register output container
-  mHwClustersArray = std::make_unique<std::vector<ClusterHardwareContainer8kb>>();
+  mHwClustersArray = std::make_unique<std::vector<OutputType>>();
   // a trick to register the unique pointer with FairRootManager
   static auto clusterArrayTmpPtr = mHwClustersArray.get();
   mgr->RegisterAny(Form("TPCClusterHW%i", mClusterSector), clusterArrayTmpPtr, kTRUE);

--- a/Detectors/TPC/reconstruction/src/HwClusterer.cxx
+++ b/Detectors/TPC/reconstruction/src/HwClusterer.cxx
@@ -208,7 +208,7 @@ void HwClusterer::process(std::vector<o2::TPC::Digit> const& digits, MCLabelCont
          *       ---------
          */
         findPeaksForTime(i);
-        computeClusterForTime(i - 2);
+        computeClusterForTime(i - 3);
 
         clearBuffer(i + 1);
 
@@ -582,7 +582,7 @@ void HwClusterer::hwClusterProcessor(const Vc::uint_m peakMask, unsigned qMaxInd
                 (((mDataBuffer[row][rbbIndex] >> 24) & 0x1) == 0x1);
     updateCluster(selectionMask, row, centerPad, centerTime, +1, +2, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
 
-  } 
+  }
 
   selectionMask = peakMask;
   if (mRejectSinglePadClusters) selectionMask &= !(sigmaPad2 == 0);
@@ -853,7 +853,7 @@ void HwClusterer::finishFrame(bool clear)
     }
 
     findPeaksForTime(i);
-    computeClusterForTime(i - 2);
+    computeClusterForTime(i - 3);
     clearBuffer(i + 1);
     mLastHB = HB;
   }

--- a/Detectors/TPC/reconstruction/src/HwClusterer.cxx
+++ b/Detectors/TPC/reconstruction/src/HwClusterer.cxx
@@ -129,16 +129,18 @@ HwClusterer::HwClusterer(
 }
 
 //______________________________________________________________________________
-void HwClusterer::process(std::vector<o2::TPC::Digit> const& digits, MCLabelContainer const* mcDigitTruth)
+void HwClusterer::process(std::vector<o2::TPC::Digit> const& digits, MCLabelContainer const* mcDigitTruth, bool clearContainerFirst)
 {
-  if (mClusterArray)
-    mClusterArray->clear();
-  if (mPlainClusterArray)
-    mPlainClusterArray->clear();
+  if (clearContainerFirst) {
+    if (mClusterArray)
+      mClusterArray->clear();
+    if (mPlainClusterArray)
+      mPlainClusterArray->clear();
 
-  if (mClusterMcLabelArray)
-    mClusterMcLabelArray->clear();
-  mClusterCounter = 0;
+    if (mClusterMcLabelArray)
+      mClusterMcLabelArray->clear();
+    mClusterCounter = 0;
+  }
 
   int digitIndex = 0;
   int index;
@@ -266,10 +268,10 @@ void HwClusterer::process(std::vector<o2::TPC::Digit> const& digits, MCLabelCont
 }
 
 //______________________________________________________________________________
-void HwClusterer::finishProcess(std::vector<o2::TPC::Digit> const& digits, MCLabelContainer const* mcDigitTruth)
+void HwClusterer::finishProcess(std::vector<o2::TPC::Digit> const& digits, MCLabelContainer const* mcDigitTruth, bool clearContainerFirst)
 {
   // Process the last digits (if there are any)
-  process(digits, mcDigitTruth);
+  process(digits, mcDigitTruth, clearContainerFirst);
 
   // Search in last remaining timebins
   finishFrame(false);

--- a/Detectors/TPC/reconstruction/src/HwClusterer.cxx
+++ b/Detectors/TPC/reconstruction/src/HwClusterer.cxx
@@ -398,21 +398,21 @@ void HwClusterer::hwClusterProcessor(const Vc::uint_m peakMask, unsigned qMaxInd
     // but only half the charge if (i) is minimum
 
     // center
-    updateCluster(peakMask, row, centerPad, centerTime,  0,  0, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
+    updateCluster(peakMask, row, centerPad, centerTime, 0, 0, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
 
     // horizontal, look for minimum in pad direction
     auto splitMask = (((mDataBuffer[row][lIndex] >> 26) & 0x1) == 0x1);
-    updateCluster(peakMask, row, centerPad, centerTime, -1,  0, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
+    updateCluster(peakMask, row, centerPad, centerTime, -1, 0, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
 
     splitMask = (((mDataBuffer[row][rIndex] >> 26) & 0x1) == 0x1);
-    updateCluster(peakMask, row, centerPad, centerTime, +1,  0, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
+    updateCluster(peakMask, row, centerPad, centerTime, +1, 0, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
 
     // vertical look for minimum in time direction
     splitMask = (((mDataBuffer[row][tIndex] >> 25) & 0x1) == 0x1);
-    updateCluster(peakMask, row, centerPad, centerTime,  0, -1, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
+    updateCluster(peakMask, row, centerPad, centerTime, 0, -1, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
 
     splitMask = (((mDataBuffer[row][bIndex] >> 25) & 0x1) == 0x1);
-    updateCluster(peakMask, row, centerPad, centerTime,  0, +1, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
+    updateCluster(peakMask, row, centerPad, centerTime, 0, +1, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
 
     // diagonal tl/br, look for minimum in 1. diagonal + vertical + horizontal direction
     splitMask = (((mDataBuffer[row][ltIndex] >> 24) & 0x1) == 0x1) |
@@ -485,9 +485,9 @@ void HwClusterer::hwClusterProcessor(const Vc::uint_m peakMask, unsigned qMaxInd
                     (((mDataBuffer[row][ltIndex] >> 24) & 0x1) != 0x1) &                            // AND (i) is not minimum in corresponding directions
                     (((mDataBuffer[row][ltIndex] >> 25) & 0x1) != 0x1) &
                     (((mDataBuffer[row][ltIndex] >> 26) & 0x1) != 0x1) &
-                    (((mDataBuffer[row][lltIndex] >> 25) & 0x1) != 0x1) &                           // AND other (o) is not minimum in corresponding direction
-                    (((mDataBuffer[row][lttIndex] >> 26) & 0x1) != 0x1);                            // AND other (o) is not minimum in corresponding direction
-    splitMask = (((mDataBuffer[row][llttIndex] >> 24) & 0x1) == 0x1) |                              // split (o) if it is miminum in corresponding direction
+                    (((mDataBuffer[row][lltIndex] >> 25) & 0x1) != 0x1) & // AND other (o) is not minimum in corresponding direction
+                    (((mDataBuffer[row][lttIndex] >> 26) & 0x1) != 0x1);  // AND other (o) is not minimum in corresponding direction
+    splitMask = (((mDataBuffer[row][llttIndex] >> 24) & 0x1) == 0x1) |    // split (o) if it is miminum in corresponding direction
                 (((mDataBuffer[row][llttIndex] >> 25) & 0x1) == 0x1) |
                 (((mDataBuffer[row][llttIndex] >> 26) & 0x1) == 0x1);
     updateCluster(selectionMask, row, centerPad, centerTime, -2, -2, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
@@ -498,8 +498,6 @@ void HwClusterer::hwClusterProcessor(const Vc::uint_m peakMask, unsigned qMaxInd
     splitMask = (((mDataBuffer[row][lttIndex] >> 25) & 0x1) == 0x1) |
                 (((mDataBuffer[row][lttIndex] >> 24) & 0x1) == 0x1);
     updateCluster(selectionMask, row, centerPad, centerTime, -1, -2, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
-
-
 
     selectionMask = peakMask &
                     (getFpOfADC(mDataBuffer[row][lbIndex]) > (mContributionChargeThreshold << 4)) &
@@ -527,8 +525,6 @@ void HwClusterer::hwClusterProcessor(const Vc::uint_m peakMask, unsigned qMaxInd
                 (((mDataBuffer[row][lbbIndex] >> 23) & 0x1) == 0x1);
     updateCluster(selectionMask, row, centerPad, centerTime, -1, +2, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
 
-
-
     selectionMask = peakMask &
                     (getFpOfADC(mDataBuffer[row][rtIndex]) > (mContributionChargeThreshold << 4)) &
                     (((mDataBuffer[row][rtIndex] >> 26) & 0x1) != 0x1);
@@ -555,9 +551,6 @@ void HwClusterer::hwClusterProcessor(const Vc::uint_m peakMask, unsigned qMaxInd
                 (((mDataBuffer[row][rttIndex] >> 23) & 0x1) == 0x1);
     updateCluster(selectionMask, row, centerPad, centerTime, +1, -2, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
 
-
-
-
     selectionMask = peakMask &
                     (getFpOfADC(mDataBuffer[row][rbIndex]) > (mContributionChargeThreshold << 4)) &
                     (((mDataBuffer[row][rbIndex] >> 26) & 0x1) != 0x1);
@@ -583,12 +576,13 @@ void HwClusterer::hwClusterProcessor(const Vc::uint_m peakMask, unsigned qMaxInd
     splitMask = (((mDataBuffer[row][rbbIndex] >> 25) & 0x1) == 0x1) |
                 (((mDataBuffer[row][rbbIndex] >> 24) & 0x1) == 0x1);
     updateCluster(selectionMask, row, centerPad, centerTime, +1, +2, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
-
   }
 
   selectionMask = peakMask;
-  if (mRejectSinglePadClusters) selectionMask &= !(sigmaPad2 == 0);
-  if (mRejectSingleTimeClusters) selectionMask &= !(sigmaTime2 == 0);
+  if (mRejectSinglePadClusters)
+    selectionMask &= !(sigmaPad2 == 0);
+  if (mRejectSingleTimeClusters)
+    selectionMask &= !(sigmaTime2 == 0);
 
   ClusterHardware tmpCluster;
   for (int i = 0; i < Vc::uint_v::Size; ++i) {
@@ -685,7 +679,6 @@ void HwClusterer::hwPeakFinder(unsigned qMaxIndex, short centerPad, int mappedCe
   //  - other is peak if maxBit was already set before
   Vc::where(!tmpMask) | mDataBuffer[row][qMaxIndex] |= (0x1 << 26);
   Vc::where(!tmpMask) | mDataBuffer[row][compareIndex0] &= ~(0x1 << 26);
-
 
   //////////////////////////////////////
   // Comparison in time direction
@@ -807,7 +800,7 @@ void HwClusterer::computeClusterForTime(int timebin)
 
   const unsigned timeBinWrapped = mapTimeInRange(timebin);
   if (mRejectLaterTimebin) {
-    const unsigned previousTimeBinWrapped = mapTimeInRange(timebin-2);
+    const unsigned previousTimeBinWrapped = mapTimeInRange(timebin - 2);
     for (unsigned short row = 0; row < mNumRowSets; ++row) {
       const unsigned padOffset = timeBinWrapped * mPadsPerRowSet[row];
       const unsigned previousPadOffset = previousTimeBinWrapped * mPadsPerRowSet[row];
@@ -817,9 +810,9 @@ void HwClusterer::computeClusterForTime(int timebin)
         const unsigned qMaxPreviousIndex = previousPadOffset + pad;
 
         // TODO: define needed difference
-        const auto peakMask = ((mDataBuffer[row][qMaxIndex] >> 27) == 0x1F) &   //  True if current pad is peak AND
-          (getFpOfADC(mDataBuffer[row][qMaxIndex]) > getFpOfADC(mDataBuffer[row][qMaxPreviousIndex]) | // previous has smaller charge
-          !((mDataBuffer[row][qMaxPreviousIndex] >> 27) == 0x1F));              //  or previous one was not a peak
+        const auto peakMask = ((mDataBuffer[row][qMaxIndex] >> 27) == 0x1F) &                                              //  True if current pad is peak AND
+                              (getFpOfADC(mDataBuffer[row][qMaxIndex]) > getFpOfADC(mDataBuffer[row][qMaxPreviousIndex]) | // previous has smaller charge
+                               !((mDataBuffer[row][qMaxPreviousIndex] >> 27) == 0x1F));                                    //  or previous one was not a peak
         if (peakMask.isEmpty())
           continue;
 
@@ -886,13 +879,13 @@ void HwClusterer::clearBuffer(int timebin)
 void HwClusterer::updateCluster(
   const Vc::uint_m selectionMask, int row, short centerPad, int centerTime, short dp, short dt,
   Vc::uint_v& qTot, Vc::int_v& pad, Vc::int_v& time, Vc::int_v& sigmaPad2, Vc::int_v& sigmaTime2,
-  std::vector<std::unique_ptr<std::vector<std::pair<MCCompLabel, unsigned>>>>& mcLabels, const Vc::uint_m splitMask )
+  std::vector<std::unique_ptr<std::vector<std::pair<MCCompLabel, unsigned>>>>& mcLabels, const Vc::uint_m splitMask)
 {
-  if (selectionMask.isEmpty()) return;
+  if (selectionMask.isEmpty())
+    return;
 
   const int mappedTime = mapTimeInRange(centerTime + dt);
   const int index = mappedTime * mPadsPerRowSet[row] + centerPad + dp;
-
 
   // If the charge should be split, only half of the charge is used
   Vc::where(selectionMask & splitMask) | qTot += (getFpOfADC(mDataBuffer[row][index]) >> 1);
@@ -925,4 +918,3 @@ void HwClusterer::updateCluster(
     }
   }
 }
-

--- a/Detectors/TPC/reconstruction/src/HwClusterer.cxx
+++ b/Detectors/TPC/reconstruction/src/HwClusterer.cxx
@@ -34,6 +34,7 @@ HwClusterer::HwClusterer(
     mNumRows(0),
     mNumRowSets(0),
     mCurrentMcContainerInBuffer(0),
+    mSplittingMode(0),
     mClusterSector(sectorid),
     mLastTimebin(-1),
     mLastHB(0),
@@ -41,6 +42,9 @@ HwClusterer::HwClusterer(
     mContributionChargeThreshold(0),
     mClusterCounter(0),
     mIsContinuousReadout(true),
+    mRejectSinglePadClusters(false),
+    mRejectSingleTimeClusters(false),
+    mRejectLaterTimebin(false),
     mPadsPerRowSet(),
     mGlobalRowToRegion(),
     mGlobalRowToLocalRow(),
@@ -230,6 +234,7 @@ void HwClusterer::process(std::vector<o2::TPC::Digit> const& digits, MCLabelCont
     index = mapTimeInRange(digit.getTimeStamp()) * mPadsPerRowSet[mGlobalRowToRowSet[digit.getRow()]] + (digit.getPad() + 2);
     // offset of digit pad because of 2 empty pads on both sides
 
+    // TODO: fill noise here as well if necessary
     if (mPedestalObject) {
       /*
        * If a pedestal object was registered, check if charge of pad is greater
@@ -239,11 +244,11 @@ void HwClusterer::process(std::vector<o2::TPC::Digit> const& digits, MCLabelCont
       if (digit.getChargeFloat() < mPedestalObject->getValue(CRU(digit.getCRU()), digit.getRow(), digit.getPad())) {
         mDataBuffer[mGlobalRowToRowSet[digit.getRow()]][index][mGlobalRowToVcIndex[digit.getRow()]] = 0;
       } else {
-        mDataBuffer[mGlobalRowToRowSet[digit.getRow()]][index][mGlobalRowToVcIndex[digit.getRow()]] += static_cast<unsigned>(
+        mDataBuffer[mGlobalRowToRowSet[digit.getRow()]][index][mGlobalRowToVcIndex[digit.getRow()]] = static_cast<unsigned>(
           (digit.getChargeFloat() - mPedestalObject->getValue(CRU(digit.getCRU()), digit.getRow(), digit.getPad())) * (1 << 4));
       }
     } else {
-      mDataBuffer[mGlobalRowToRowSet[digit.getRow()]][index][mGlobalRowToVcIndex[digit.getRow()]] += static_cast<unsigned>(digit.getChargeFloat() * (1 << 4));
+      mDataBuffer[mGlobalRowToRowSet[digit.getRow()]][index][mGlobalRowToVcIndex[digit.getRow()]] = static_cast<unsigned>(digit.getChargeFloat() * (1 << 4));
     }
     if (mDataBuffer[mGlobalRowToRowSet[digit.getRow()]][index][mGlobalRowToVcIndex[digit.getRow()]] > 0x3FFF)
       mDataBuffer[mGlobalRowToRowSet[digit.getRow()]][index][mGlobalRowToVcIndex[digit.getRow()]] = 0x3FFF; // set only 14 LSBs
@@ -271,7 +276,7 @@ void HwClusterer::finishProcess(std::vector<o2::TPC::Digit> const& digits, MCLab
 }
 
 //______________________________________________________________________________
-void HwClusterer::hwClusterProcessor(const Vc::uint_m peakMask, unsigned qMaxIndex, short center_pad, int center_time, unsigned short row)
+void HwClusterer::hwClusterProcessor(const Vc::uint_m peakMask, unsigned qMaxIndex, short centerPad, int centerTime, unsigned short row)
 {
   Vc::uint_v qTot = 0;
   Vc::int_v pad = 0;
@@ -286,74 +291,311 @@ void HwClusterer::hwClusterProcessor(const Vc::uint_m peakMask, unsigned qMaxInd
     mcLabels[i] = std::make_unique<std::vector<labelPair>>();
   }
 
-  // Cluster:
-  //
-  // o  o   o   o   o
-  // o  i   i   i   o
-  // o  i   C   i   o
-  // o  i   i   i   o
-  // o  o   o   o   o
+  const unsigned llttIndex = mapTimeInRange(centerTime - 2) * mPadsPerRowSet[row] + centerPad - 2;
+  const unsigned lltIndex = mapTimeInRange(centerTime - 1) * mPadsPerRowSet[row] + centerPad - 2;
+  const unsigned llIndex = mapTimeInRange(centerTime + 0) * mPadsPerRowSet[row] + centerPad - 2;
+  const unsigned llbIndex = mapTimeInRange(centerTime + 1) * mPadsPerRowSet[row] + centerPad - 2;
+  const unsigned llbbIndex = mapTimeInRange(centerTime + 2) * mPadsPerRowSet[row] + centerPad - 2;
 
-  // Use always inner 3x3 matrix
-  //    i   i   i
-  //    i   C   i
-  //    i   i   i
-  //
-  for (short dt = -1; dt <= 1; ++dt) {
-    for (short dp = -1; dp <= 1; ++dp) {
-      updateCluster(peakMask, row, center_pad, center_time, dp, dt, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
+  const unsigned lttIndex = llttIndex + 1;
+  const unsigned ltIndex = lltIndex + 1;
+  const unsigned lIndex = llIndex + 1;
+  const unsigned lbIndex = llbIndex + 1;
+  const unsigned lbbIndex = llbbIndex + 1;
+
+  const unsigned ttIndex = lttIndex + 1;
+  const unsigned tIndex = ltIndex + 1;
+  const unsigned bIndex = lbIndex + 1;
+  const unsigned bbIndex = lbbIndex + 1;
+
+  const unsigned rttIndex = ttIndex + 1;
+  const unsigned rtIndex = tIndex + 1;
+  const unsigned rIndex = lIndex + 2;
+  const unsigned rbIndex = bIndex + 1;
+  const unsigned rbbIndex = bbIndex + 1;
+
+  const unsigned rrttIndex = rttIndex + 1;
+  const unsigned rrtIndex = rtIndex + 1;
+  const unsigned rrIndex = rIndex + 1;
+  const unsigned rrbIndex = rbIndex + 1;
+  const unsigned rrbbIndex = rbbIndex + 1;
+
+  Vc::uint_m selectionMask;
+  if (mSplittingMode == 0) {
+    // Charge is not splitted between nearby peaks, every peak uses all charges
+
+    // Cluster:
+    //
+    // o  o   o   o   o
+    // o  i   i   i   o
+    // o  i   C   i   o
+    // o  i   i   i   o
+    // o  o   o   o   o
+
+    // Use always inner 3x3 matrix
+    //    i   i   i
+    //    i   C   i
+    //    i   i   i
+    for (short dt = -1; dt <= 1; ++dt) {
+      for (short dp = -1; dp <= 1; ++dp) {
+        updateCluster(peakMask, row, centerPad, centerTime, dp, dt, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
+      }
     }
-  }
 
-  // Use outer pads (o) only, if corresponding inner pad (i) is above contribution threshold
-  //        o
-  //        i
-  // o  i   C   i   o
-  //        i
-  //        o
-  auto selectionMask = (getFpOfADC(mDataBuffer[row][mapTimeInRange(center_time) * mPadsPerRowSet[row] + center_pad - 1]) > (mContributionChargeThreshold << 4)) & peakMask;
-  updateCluster(selectionMask, row, center_pad, center_time, -2, 0, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
+    // Use outer pads (o) only, if corresponding inner pad (i) is above contribution threshold
+    //        o
+    //        i
+    // o  i   C   i   o
+    //        i
+    //        o
+    selectionMask = peakMask & (getFpOfADC(mDataBuffer[row][lIndex]) > (mContributionChargeThreshold << 4));
+    updateCluster(selectionMask, row, centerPad, centerTime, -2, 0, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
 
-  selectionMask = (getFpOfADC(mDataBuffer[row][mapTimeInRange(center_time) * mPadsPerRowSet[row] + center_pad + 1]) > (mContributionChargeThreshold << 4)) & peakMask;
-  updateCluster(selectionMask, row, center_pad, center_time, +2, 0, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
+    selectionMask = peakMask & (getFpOfADC(mDataBuffer[row][rIndex]) > (mContributionChargeThreshold << 4));
+    updateCluster(selectionMask, row, centerPad, centerTime, +2, 0, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
 
-  selectionMask = (getFpOfADC(mDataBuffer[row][mapTimeInRange(center_time - 1) * mPadsPerRowSet[row] + center_pad]) > (mContributionChargeThreshold << 4)) & peakMask;
-  updateCluster(selectionMask, row, center_pad, center_time, 0, -2, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
+    selectionMask = peakMask & (getFpOfADC(mDataBuffer[row][tIndex]) > (mContributionChargeThreshold << 4));
+    updateCluster(selectionMask, row, centerPad, centerTime, 0, -2, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
 
-  selectionMask = (getFpOfADC(mDataBuffer[row][mapTimeInRange(center_time + 1) * mPadsPerRowSet[row] + center_pad]) > (mContributionChargeThreshold << 4)) & peakMask;
-  updateCluster(selectionMask, row, center_pad, center_time, 0, +2, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
+    selectionMask = peakMask & (getFpOfADC(mDataBuffer[row][bIndex]) > (mContributionChargeThreshold << 4));
+    updateCluster(selectionMask, row, centerPad, centerTime, 0, +2, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
 
-  // o  o       o   o
-  // o  i       i   o
-  //        C
-  // o  i       i   o
-  // o  o       o   o
-  selectionMask = (getFpOfADC(mDataBuffer[row][mapTimeInRange(center_time - 1) * mPadsPerRowSet[row] + center_pad - 1]) > (mContributionChargeThreshold << 4)) & peakMask;
-  updateCluster(selectionMask, row, center_pad, center_time, -2, -1, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
-  updateCluster(selectionMask, row, center_pad, center_time, -2, -2, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
-  updateCluster(selectionMask, row, center_pad, center_time, -1, -2, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
+    // o  o       o   o
+    // o  i       i   o
+    //        C
+    // o  i       i   o
+    // o  o       o   o
+    selectionMask = peakMask & (getFpOfADC(mDataBuffer[row][ltIndex]) > (mContributionChargeThreshold << 4));
+    updateCluster(selectionMask, row, centerPad, centerTime, -2, -1, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
+    updateCluster(selectionMask, row, centerPad, centerTime, -2, -2, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
+    updateCluster(selectionMask, row, centerPad, centerTime, -1, -2, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
 
-  selectionMask = (getFpOfADC(mDataBuffer[row][mapTimeInRange(center_time + 1) * mPadsPerRowSet[row] + center_pad - 1]) > (mContributionChargeThreshold << 4)) & peakMask;
-  updateCluster(selectionMask, row, center_pad, center_time, -2, +1, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
-  updateCluster(selectionMask, row, center_pad, center_time, -2, +2, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
-  updateCluster(selectionMask, row, center_pad, center_time, -1, +2, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
+    selectionMask = peakMask & (getFpOfADC(mDataBuffer[row][lbIndex]) > (mContributionChargeThreshold << 4));
+    updateCluster(selectionMask, row, centerPad, centerTime, -2, +1, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
+    updateCluster(selectionMask, row, centerPad, centerTime, -2, +2, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
+    updateCluster(selectionMask, row, centerPad, centerTime, -1, +2, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
 
-  selectionMask = (getFpOfADC(mDataBuffer[row][mapTimeInRange(center_time - 1) * mPadsPerRowSet[row] + center_pad + 1]) > (mContributionChargeThreshold << 4)) & peakMask;
-  updateCluster(selectionMask, row, center_pad, center_time, +2, -1, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
-  updateCluster(selectionMask, row, center_pad, center_time, +2, -2, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
-  updateCluster(selectionMask, row, center_pad, center_time, +1, -2, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
+    selectionMask = peakMask & (getFpOfADC(mDataBuffer[row][rtIndex]) > (mContributionChargeThreshold << 4));
+    updateCluster(selectionMask, row, centerPad, centerTime, +2, -1, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
+    updateCluster(selectionMask, row, centerPad, centerTime, +2, -2, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
+    updateCluster(selectionMask, row, centerPad, centerTime, +1, -2, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
 
-  selectionMask = (getFpOfADC(mDataBuffer[row][mapTimeInRange(center_time + 1) * mPadsPerRowSet[row] + center_pad + 1]) > (mContributionChargeThreshold << 4)) & peakMask;
-  updateCluster(selectionMask, row, center_pad, center_time, +2, +1, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
-  updateCluster(selectionMask, row, center_pad, center_time, +2, +2, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
-  updateCluster(selectionMask, row, center_pad, center_time, +1, +2, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
+    selectionMask = peakMask & (getFpOfADC(mDataBuffer[row][rbIndex]) > (mContributionChargeThreshold << 4));
+    updateCluster(selectionMask, row, centerPad, centerTime, +2, +1, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
+    updateCluster(selectionMask, row, centerPad, centerTime, +2, +2, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
+    updateCluster(selectionMask, row, centerPad, centerTime, +1, +2, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
 
+  } else if (mSplittingMode == 1) {
+    // Charge is split at minimum, the minimum itself contributes half too all
+    // adjacent peaks (even if there are 3).
+
+    // Use always inner 3x3 matrix
+    //    i   i   i
+    //    i   C   i
+    //    i   i   i
+    // but only half the charge if (i) is minimum
+
+    // center
+    updateCluster(peakMask, row, centerPad, centerTime,  0,  0, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels);
+
+    // horizontal, look for minimum in pad direction
+    auto splitMask = (((mDataBuffer[row][lIndex] >> 26) & 0x1) == 0x1);
+    updateCluster(peakMask, row, centerPad, centerTime, -1,  0, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
+
+    splitMask = (((mDataBuffer[row][rIndex] >> 26) & 0x1) == 0x1);
+    updateCluster(peakMask, row, centerPad, centerTime, +1,  0, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
+
+    // vertical look for minimum in time direction
+    splitMask = (((mDataBuffer[row][tIndex] >> 25) & 0x1) == 0x1);
+    updateCluster(peakMask, row, centerPad, centerTime,  0, -1, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
+
+    splitMask = (((mDataBuffer[row][bIndex] >> 25) & 0x1) == 0x1);
+    updateCluster(peakMask, row, centerPad, centerTime,  0, +1, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
+
+    // diagonal tl/br, look for minimum in 1. diagonal + vertical + horizontal direction
+    splitMask = (((mDataBuffer[row][ltIndex] >> 24) & 0x1) == 0x1) |
+                (((mDataBuffer[row][ltIndex] >> 25) & 0x1) == 0x1) |
+                (((mDataBuffer[row][ltIndex] >> 26) & 0x1) == 0x1);
+    updateCluster(peakMask, row, centerPad, centerTime, -1, -1, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
+
+    splitMask = (((mDataBuffer[row][rbIndex] >> 24) & 0x1) == 0x1) |
+                (((mDataBuffer[row][rbIndex] >> 25) & 0x1) == 0x1) |
+                (((mDataBuffer[row][rbIndex] >> 26) & 0x1) == 0x1);
+    updateCluster(peakMask, row, centerPad, centerTime, +1, +1, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
+
+    // diagonal tr/bl, look for minimum in 2. diagonal + vertical + horizontal direction
+    splitMask = (((mDataBuffer[row][rtIndex] >> 23) & 0x1) == 0x1) |
+                (((mDataBuffer[row][rtIndex] >> 25) & 0x1) == 0x1) |
+                (((mDataBuffer[row][rtIndex] >> 26) & 0x1) == 0x1);
+    updateCluster(peakMask, row, centerPad, centerTime, +1, -1, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
+
+    splitMask = (((mDataBuffer[row][lbIndex] >> 23) & 0x1) == 0x1) |
+                (((mDataBuffer[row][lbIndex] >> 25) & 0x1) == 0x1) |
+                (((mDataBuffer[row][lbIndex] >> 26) & 0x1) == 0x1);
+    updateCluster(peakMask, row, centerPad, centerTime, -1, +1, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
+
+    // Use outer pads (o) only, if corresponding inner pad (i) is above contribution threshold
+    //        o
+    //        i
+    // o  i   C   i   o
+    //        i
+    //        o
+    // and only if inner pad (i) is not a minimum (in corresponding direction).
+    // Split charge, if (o) is a minimum.
+    selectionMask = peakMask &                                                                     // using (o) (if we have a peak in the center)
+                    (getFpOfADC(mDataBuffer[row][lIndex]) > (mContributionChargeThreshold << 4)) & // AND (i) is above threshold
+                    (((mDataBuffer[row][lIndex] >> 26) & 0x1) != 0x1);                             // AND (i) is not minimum in corresponding direction
+    splitMask = (((mDataBuffer[row][llIndex] >> 26) & 0x1) == 0x1);                                // split (o) if it is miminum in corresponding direction
+    updateCluster(selectionMask, row, centerPad, centerTime, -2, 0, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
+
+    selectionMask = peakMask &
+                    (getFpOfADC(mDataBuffer[row][rIndex]) > (mContributionChargeThreshold << 4)) &
+                    (((mDataBuffer[row][rIndex] >> 26) & 0x1) != 0x1);
+    splitMask = (((mDataBuffer[row][rrIndex] >> 26) & 0x1) == 0x1);
+    updateCluster(selectionMask, row, centerPad, centerTime, +2, 0, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
+
+    selectionMask = peakMask &
+                    (getFpOfADC(mDataBuffer[row][tIndex]) > (mContributionChargeThreshold << 4)) &
+                    (((mDataBuffer[row][tIndex] >> 25) & 0x1) != 0x1);
+    splitMask = (((mDataBuffer[row][ttIndex] >> 26) & 0x1) == 0x1);
+    updateCluster(selectionMask, row, centerPad, centerTime, 0, -2, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
+
+    selectionMask = peakMask &
+                    (getFpOfADC(mDataBuffer[row][bIndex]) > (mContributionChargeThreshold << 4)) &
+                    (((mDataBuffer[row][bIndex] >> 25) & 0x1) != 0x1);
+    splitMask = (((mDataBuffer[row][bbIndex] >> 26) & 0x1) == 0x1);
+    updateCluster(selectionMask, row, centerPad, centerTime, 0, +2, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
+
+    // o  o       o   o
+    // o  i       i   o
+    //        C
+    // o  i       i   o
+    // o  o       o   o
+    selectionMask = peakMask &                                                                      // using (o) (if we have a peak in the center)
+                    (getFpOfADC(mDataBuffer[row][ltIndex]) > (mContributionChargeThreshold << 4)) & // AND (i) is above threshold
+                    (((mDataBuffer[row][ltIndex] >> 26) & 0x1) != 0x1);                             // AND (i) is not minimum in corresponding direction
+    splitMask = (((mDataBuffer[row][lltIndex] >> 26) & 0x1) == 0x1) |                               // split (o) if it is miminum in corresponding directions
+                (((mDataBuffer[row][lltIndex] >> 24) & 0x1) == 0x1);
+    updateCluster(selectionMask, row, centerPad, centerTime, -2, -1, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
+
+    selectionMask = peakMask &                                                                      // using (o) (if we have a peak in the center)
+                    (getFpOfADC(mDataBuffer[row][ltIndex]) > (mContributionChargeThreshold << 4)) & // AND (i) is above threshold
+                    (((mDataBuffer[row][ltIndex] >> 24) & 0x1) != 0x1) &                            // AND (i) is not minimum in corresponding directions
+                    (((mDataBuffer[row][ltIndex] >> 25) & 0x1) != 0x1) &
+                    (((mDataBuffer[row][ltIndex] >> 26) & 0x1) != 0x1) &
+                    (((mDataBuffer[row][lltIndex] >> 25) & 0x1) != 0x1) &                           // AND other (o) is not minimum in corresponding direction
+                    (((mDataBuffer[row][lttIndex] >> 26) & 0x1) != 0x1);                            // AND other (o) is not minimum in corresponding direction
+    splitMask = (((mDataBuffer[row][llttIndex] >> 24) & 0x1) == 0x1) |                              // split (o) if it is miminum in corresponding direction
+                (((mDataBuffer[row][llttIndex] >> 25) & 0x1) == 0x1) |
+                (((mDataBuffer[row][llttIndex] >> 26) & 0x1) == 0x1);
+    updateCluster(selectionMask, row, centerPad, centerTime, -2, -2, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
+
+    selectionMask = peakMask &
+                    (getFpOfADC(mDataBuffer[row][ltIndex]) > (mContributionChargeThreshold << 4)) &
+                    (((mDataBuffer[row][ltIndex] >> 25) & 0x1) != 0x1);
+    splitMask = (((mDataBuffer[row][lttIndex] >> 25) & 0x1) == 0x1) |
+                (((mDataBuffer[row][lttIndex] >> 24) & 0x1) == 0x1);
+    updateCluster(selectionMask, row, centerPad, centerTime, -1, -2, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
+
+
+
+    selectionMask = peakMask &
+                    (getFpOfADC(mDataBuffer[row][lbIndex]) > (mContributionChargeThreshold << 4)) &
+                    (((mDataBuffer[row][lbIndex] >> 26) & 0x1) != 0x1);
+    splitMask = (((mDataBuffer[row][llbIndex] >> 26) & 0x1) == 0x1) |
+                (((mDataBuffer[row][llbIndex] >> 23) & 0x1) == 0x1);
+    updateCluster(selectionMask, row, centerPad, centerTime, -2, +1, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
+
+    selectionMask = peakMask &
+                    (getFpOfADC(mDataBuffer[row][lbIndex]) > (mContributionChargeThreshold << 4)) &
+                    (((mDataBuffer[row][lbIndex] >> 23) & 0x1) != 0x1) &
+                    (((mDataBuffer[row][lbIndex] >> 25) & 0x1) != 0x1) &
+                    (((mDataBuffer[row][lbIndex] >> 26) & 0x1) != 0x1) &
+                    (((mDataBuffer[row][llbIndex] >> 25) & 0x1) != 0x1) &
+                    (((mDataBuffer[row][lbbIndex] >> 26) & 0x1) != 0x1);
+    splitMask = (((mDataBuffer[row][llbbIndex] >> 23) & 0x1) == 0x1) |
+                (((mDataBuffer[row][llbbIndex] >> 25) & 0x1) == 0x1) |
+                (((mDataBuffer[row][llbbIndex] >> 26) & 0x1) == 0x1);
+    updateCluster(selectionMask, row, centerPad, centerTime, -2, +2, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
+
+    selectionMask = peakMask &
+                    (getFpOfADC(mDataBuffer[row][lbIndex]) > (mContributionChargeThreshold << 4)) &
+                    (((mDataBuffer[row][lbIndex] >> 25) & 0x1) != 0x1);
+    splitMask = (((mDataBuffer[row][lbbIndex] >> 25) & 0x1) == 0x1) |
+                (((mDataBuffer[row][lbbIndex] >> 23) & 0x1) == 0x1);
+    updateCluster(selectionMask, row, centerPad, centerTime, -1, +2, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
+
+
+
+    selectionMask = peakMask &
+                    (getFpOfADC(mDataBuffer[row][rtIndex]) > (mContributionChargeThreshold << 4)) &
+                    (((mDataBuffer[row][rtIndex] >> 26) & 0x1) != 0x1);
+    splitMask = (((mDataBuffer[row][rrtIndex] >> 26) & 0x1) == 0x1) |
+                (((mDataBuffer[row][rrtIndex] >> 23) & 0x1) == 0x1);
+    updateCluster(selectionMask, row, centerPad, centerTime, +2, -1, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
+
+    selectionMask = peakMask &
+                    (getFpOfADC(mDataBuffer[row][rtIndex]) > (mContributionChargeThreshold << 4)) &
+                    (((mDataBuffer[row][rtIndex] >> 23) & 0x1) != 0x1) &
+                    (((mDataBuffer[row][rtIndex] >> 25) & 0x1) != 0x1) &
+                    (((mDataBuffer[row][rtIndex] >> 26) & 0x1) != 0x1) &
+                    (((mDataBuffer[row][rrtIndex] >> 25) & 0x1) != 0x1) &
+                    (((mDataBuffer[row][rttIndex] >> 26) & 0x1) != 0x1);
+    splitMask = (((mDataBuffer[row][rrttIndex] >> 23) & 0x1) == 0x1) |
+                (((mDataBuffer[row][rrttIndex] >> 25) & 0x1) == 0x1) |
+                (((mDataBuffer[row][rrttIndex] >> 26) & 0x1) == 0x1);
+    updateCluster(selectionMask, row, centerPad, centerTime, +2, -2, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
+
+    selectionMask = peakMask &
+                    (getFpOfADC(mDataBuffer[row][rtIndex]) > (mContributionChargeThreshold << 4)) &
+                    (((mDataBuffer[row][rtIndex] >> 25) & 0x1) != 0x1);
+    splitMask = (((mDataBuffer[row][rttIndex] >> 25) & 0x1) == 0x1) |
+                (((mDataBuffer[row][rttIndex] >> 23) & 0x1) == 0x1);
+    updateCluster(selectionMask, row, centerPad, centerTime, +1, -2, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
+
+
+
+
+    selectionMask = peakMask &
+                    (getFpOfADC(mDataBuffer[row][rbIndex]) > (mContributionChargeThreshold << 4)) &
+                    (((mDataBuffer[row][rbIndex] >> 26) & 0x1) != 0x1);
+    splitMask = (((mDataBuffer[row][rrbIndex] >> 26) & 0x1) == 0x1) |
+                (((mDataBuffer[row][rrbIndex] >> 24) & 0x1) == 0x1);
+    updateCluster(selectionMask, row, centerPad, centerTime, +2, +1, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
+
+    selectionMask = peakMask &
+                    (getFpOfADC(mDataBuffer[row][rbIndex]) > (mContributionChargeThreshold << 4)) &
+                    (((mDataBuffer[row][rbIndex] >> 24) & 0x1) != 0x1) &
+                    (((mDataBuffer[row][rbIndex] >> 25) & 0x1) != 0x1) &
+                    (((mDataBuffer[row][rbIndex] >> 26) & 0x1) != 0x1) &
+                    (((mDataBuffer[row][rrbIndex] >> 25) & 0x1) != 0x1) &
+                    (((mDataBuffer[row][rbbIndex] >> 26) & 0x1) != 0x1);
+    splitMask = (((mDataBuffer[row][rrbbIndex] >> 24) & 0x1) == 0x1) |
+                (((mDataBuffer[row][rrbbIndex] >> 25) & 0x1) == 0x1) |
+                (((mDataBuffer[row][rrbbIndex] >> 26) & 0x1) == 0x1);
+    updateCluster(selectionMask, row, centerPad, centerTime, +2, +2, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
+
+    selectionMask = peakMask &
+                    (getFpOfADC(mDataBuffer[row][rbIndex]) > (mContributionChargeThreshold << 4)) &
+                    (((mDataBuffer[row][rbIndex] >> 25) & 0x1) != 0x1);
+    splitMask = (((mDataBuffer[row][rbbIndex] >> 25) & 0x1) == 0x1) |
+                (((mDataBuffer[row][rbbIndex] >> 24) & 0x1) == 0x1);
+    updateCluster(selectionMask, row, centerPad, centerTime, +1, +2, qTot, pad, time, sigmaPad2, sigmaTime2, mcLabels, splitMask);
+
+  } 
+
+  selectionMask = peakMask;
+  if (mRejectSinglePadClusters) selectionMask &= !(sigmaPad2 == 0);
+  if (mRejectSingleTimeClusters) selectionMask &= !(sigmaTime2 == 0);
+
+  ClusterHardware tmpCluster;
   for (int i = 0; i < Vc::uint_v::Size; ++i) {
-    if (peakMask[i]) {
+    if (selectionMask[i]) {
+
       mTmpClusterArray[mGlobalRowToRegion[row * Vc::uint_v::Size + i]]->emplace_back();
       mTmpClusterArray[mGlobalRowToRegion[row * Vc::uint_v::Size + i]]->back().setCluster(
-        center_pad - 2,    // we have two artificial empty pads "on the left" which needs to be subtracted
-        center_time % 447, // the time within a HB
+        centerPad - 2,    // we have two artificial empty pads "on the left" which needs to be subtracted
+        centerTime % 447, // the time within a HB
         pad[i], time[i],
         sigmaPad2[i], sigmaTime2[i],
         (getFpOfADC(mDataBuffer[row][qMaxIndex])[i] >> 3), // keep only 1 fixed point precision bit
@@ -368,24 +610,24 @@ void HwClusterer::hwClusterProcessor(const Vc::uint_m peakMask, unsigned qMaxInd
 }
 
 //______________________________________________________________________________
-void HwClusterer::hwPeakFinder(unsigned qMaxIndex, short center_pad, int center_time, unsigned short row)
+void HwClusterer::hwPeakFinder(unsigned qMaxIndex, short centerPad, int mappedCenterTime, unsigned short row)
 {
 
   // Always the center pad is compared with a fixed other pad. The first
-  // comparison is in pad direction. That bin (p+2,t+1) is a peak in pad
-  // direction, it has to be >= then (p+1,t+1) and in the next iteration, where
-  // the next pad is the center, the comparison of (the new center with the new
-  // left one) must be false, so that (p+3,t+1) > (p+2,t+1). Afterwards, this
-  // is also done in time direction and both diagonal directions. With those 4
-  // comparisons, all 8 neighboring pads are checked iteratively.
+  // comparison is in pad direction. That bin (p,t) is a peak in pad direction,
+  // it has to be >= then (p-1,t) and in the next iteration, where the next pad
+  // is the center, the comparison of (the new center with the new left one)
+  // must be false, so that (p+1,t) > (p,t). Afterwards, this is also done in
+  // time direction and both diagonal directions. With those 4 comparisons, all
+  // 8 neighboring pads are checked iteratively.
   //
   // Example in pad direction:
-  //     p+0 p+1 p+2 p+3 p+4                  p+1 p+2 p+3 p+4 p+5
-  // t+0  o   o   o   o   o                    o   o   o   o   o
-  // t+1  o   i   i   i   o   next iteration   o   i   i   i   o
-  // t+2  o   I<->C   i   o  --------------->  O   I<->c   i   o
-  // t+3  o   i   i   i   o                    o   i   i   i   o
-  // t+4  o   o   o   o   o                    o   o   o   o   o
+  //     p-2 p-1  p  p+1 p+2                  p-1  p  p+1 p+2 p+3
+  // t-2  o   o   o   o   o                    o   o   o   o   o
+  // t-1  o   i   i   i   o   next iteration   o   i   i   i   o
+  // t    o   I<->C   i   o  --------------->  O   I<->c   i   o
+  // t+1  o   i   i   i   o                    o   i   i   i   o
+  // t+2  o   o   o   o   o                    o   o   o   o   o
   //
   //
   // Meaning of the set bit:
@@ -399,23 +641,73 @@ void HwClusterer::hwPeakFinder(unsigned qMaxIndex, short center_pad, int center_
   //  26 | minimum in pad direction
   //  25 | minimum in time direction
   //  24 | minimum in 1. diagonal direction
-  //  23 | minimum in 1. diagonal direction
+  //  23 | minimum in 2. diagonal direction
+
+  const int compareIndex0 = mappedCenterTime * mPadsPerRowSet[row] + centerPad - 1;
+  const int compareIndex1 = mapTimeInRange(mappedCenterTime - 1) * mPadsPerRowSet[row] + centerPad;
+  const int compareIndex2 = compareIndex1 - 1;
+  const int compareIndex3 = compareIndex1 + 1;
+  const auto adcMask = (getFpOfADC(mDataBuffer[row][qMaxIndex]) == 0) &
+                       (getFpOfADC(mDataBuffer[row][compareIndex0]) == 0) &
+                       (getFpOfADC(mDataBuffer[row][compareIndex1]) == 0) &
+                       (getFpOfADC(mDataBuffer[row][compareIndex2]) == 0) &
+                       (getFpOfADC(mDataBuffer[row][compareIndex3]) == 0);
+  if (adcMask.isFull()) {
+    // if all 0, we can skip the following part and directly set the bits where
+    // the comparisons were true, TODO: still possible if difference is applied?
+    mDataBuffer[row][qMaxIndex] |= (0x1 << 31);
+    mDataBuffer[row][compareIndex0] &= ~(0x1 << 31);
+    mDataBuffer[row][qMaxIndex] |= (0x1 << 30);
+    mDataBuffer[row][compareIndex1] &= ~(0x1 << 30);
+    mDataBuffer[row][qMaxIndex] |= (0x1 << 29);
+    mDataBuffer[row][compareIndex2] &= ~(0x1 << 29);
+    mDataBuffer[row][qMaxIndex] |= (0x1 << 28);
+    mDataBuffer[row][compareIndex3] &= ~(0x1 << 28);
+    return;
+  }
 
   //////////////////////////////////////
   // Comparison in pad direction
-  compareForPeak(qMaxIndex, mapTimeInRange(center_time) * mPadsPerRowSet[row] + center_pad - 1, 31, 26, row);
+  // TODO: define needed difference
+  auto tmpMask = getFpOfADC(mDataBuffer[row][qMaxIndex]) >= getFpOfADC(mDataBuffer[row][compareIndex0]);
+  // if true:
+  //  - current center could be peak
+  //  - cleare possible maxBit of other
+  //  - other is minimum if minBit was already set before
+  Vc::where(tmpMask) | mDataBuffer[row][qMaxIndex] |= (0x1 << 31);
+  Vc::where(tmpMask) | mDataBuffer[row][compareIndex0] &= ~(0x1 << 31);
+
+  // if false:
+  //  - current center could be minimum
+  //  - cleare possible minBit of other
+  //  - other is peak if maxBit was already set before
+  Vc::where(!tmpMask) | mDataBuffer[row][qMaxIndex] |= (0x1 << 26);
+  Vc::where(!tmpMask) | mDataBuffer[row][compareIndex0] &= ~(0x1 << 26);
+
 
   //////////////////////////////////////
   // Comparison in time direction
-  compareForPeak(qMaxIndex, mapTimeInRange(center_time - 1) * mPadsPerRowSet[row] + center_pad, 30, 25, row);
+  tmpMask = getFpOfADC(mDataBuffer[row][qMaxIndex]) >= getFpOfADC(mDataBuffer[row][compareIndex1]);
+  Vc::where(tmpMask) | mDataBuffer[row][qMaxIndex] |= (0x1 << 30);
+  Vc::where(tmpMask) | mDataBuffer[row][compareIndex1] &= ~(0x1 << 30);
+  Vc::where(!tmpMask) | mDataBuffer[row][qMaxIndex] |= (0x1 << 25);
+  Vc::where(!tmpMask) | mDataBuffer[row][compareIndex1] &= ~(0x1 << 25);
 
   //////////////////////////////////////
   // Comparison in 1. diagonal direction
-  compareForPeak(qMaxIndex, mapTimeInRange(center_time - 1) * mPadsPerRowSet[row] + center_pad - 1, 29, 24, row);
+  tmpMask = getFpOfADC(mDataBuffer[row][qMaxIndex]) >= getFpOfADC(mDataBuffer[row][compareIndex2]);
+  Vc::where(tmpMask) | mDataBuffer[row][qMaxIndex] |= (0x1 << 29);
+  Vc::where(tmpMask) | mDataBuffer[row][compareIndex2] &= ~(0x1 << 29);
+  Vc::where(!tmpMask) | mDataBuffer[row][qMaxIndex] |= (0x1 << 24);
+  Vc::where(!tmpMask) | mDataBuffer[row][compareIndex2] &= ~(0x1 << 24);
 
   //////////////////////////////////////
   // Comparison in 2. diagonal direction
-  compareForPeak(qMaxIndex, mapTimeInRange(center_time - 1) * mPadsPerRowSet[row] + center_pad + 1, 28, 23, row);
+  tmpMask = getFpOfADC(mDataBuffer[row][qMaxIndex]) >= getFpOfADC(mDataBuffer[row][compareIndex3]);
+  Vc::where(tmpMask) | mDataBuffer[row][qMaxIndex] |= (0x1 << 28);
+  Vc::where(tmpMask) | mDataBuffer[row][compareIndex3] &= ~(0x1 << 28);
+  Vc::where(!tmpMask) | mDataBuffer[row][qMaxIndex] |= (0x1 << 23);
+  Vc::where(!tmpMask) | mDataBuffer[row][compareIndex3] &= ~(0x1 << 23);
 
   //////////////////////////////////////
   // Comparison peak threshold
@@ -498,9 +790,9 @@ void HwClusterer::findPeaksForTime(int timebin)
     const unsigned padOffset = timeBinWrapped * mPadsPerRowSet[row];
     // two empty pads on the left and right without a cluster peak, check one
     // beyond rightmost pad for remaining relations
-    for (short pad = 2; pad < mPadsPerRowSet[row] - 1; ++pad) {
+    for (short pad = 1; pad < mPadsPerRowSet[row] - 1; ++pad) {
       const unsigned qMaxIndex = padOffset + pad;
-      hwPeakFinder(qMaxIndex, pad, timebin, row);
+      hwPeakFinder(qMaxIndex, pad, timeBinWrapped, row);
     }
   }
 }
@@ -512,17 +804,39 @@ void HwClusterer::computeClusterForTime(int timebin)
     return;
 
   const unsigned timeBinWrapped = mapTimeInRange(timebin);
-  for (unsigned short row = 0; row < mNumRowSets; ++row) {
-    const unsigned padOffset = timeBinWrapped * mPadsPerRowSet[row];
-    // two empty pads on the left and right without a cluster peak
-    for (short pad = 2; pad < mPadsPerRowSet[row] - 2; ++pad) {
-      const unsigned qMaxIndex = padOffset + pad;
+  if (mRejectLaterTimebin) {
+    const unsigned previousTimeBinWrapped = mapTimeInRange(timebin-2);
+    for (unsigned short row = 0; row < mNumRowSets; ++row) {
+      const unsigned padOffset = timeBinWrapped * mPadsPerRowSet[row];
+      const unsigned previousPadOffset = previousTimeBinWrapped * mPadsPerRowSet[row];
+      // two empty pads on the left and right without a cluster peak
+      for (short pad = 2; pad < mPadsPerRowSet[row] - 2; ++pad) {
+        const unsigned qMaxIndex = padOffset + pad;
+        const unsigned qMaxPreviousIndex = previousPadOffset + pad;
 
-      const auto peakMask = ((mDataBuffer[row][qMaxIndex] >> 27) == 0x1F);
-      if (peakMask.isEmpty())
-        continue;
+        // TODO: define needed difference
+        const auto peakMask = ((mDataBuffer[row][qMaxIndex] >> 27) == 0x1F) &   //  True if current pad is peak AND
+          (getFpOfADC(mDataBuffer[row][qMaxIndex]) > getFpOfADC(mDataBuffer[row][qMaxPreviousIndex]) | // previous has smaller charge
+          !((mDataBuffer[row][qMaxPreviousIndex] >> 27) == 0x1F));              //  or previous one was not a peak
+        if (peakMask.isEmpty())
+          continue;
 
-      hwClusterProcessor(peakMask, qMaxIndex, pad, timebin, row);
+        hwClusterProcessor(peakMask, qMaxIndex, pad, timebin, row);
+      }
+    }
+  } else {
+    for (unsigned short row = 0; row < mNumRowSets; ++row) {
+      const unsigned padOffset = timeBinWrapped * mPadsPerRowSet[row];
+      // two empty pads on the left and right without a cluster peak
+      for (short pad = 2; pad < mPadsPerRowSet[row] - 2; ++pad) {
+        const unsigned qMaxIndex = padOffset + pad;
+
+        const auto peakMask = ((mDataBuffer[row][qMaxIndex] >> 27) == 0x1F);
+        if (peakMask.isEmpty())
+          continue;
+
+        hwClusterProcessor(peakMask, qMaxIndex, pad, timebin, row);
+      }
     }
   }
 }
@@ -559,10 +873,54 @@ void HwClusterer::clearBuffer(int timebin)
   mCurrentMcContainerInBuffer &= ~(0x1 << wrappedTime); // clear bit
   for (unsigned short row = 0; row < mNumRowSets; ++row) {
     // reset timebin which is not needed anymore
-    // TODO: for simulation fill with pedestal/noise instead of 0
     std::fill(mDataBuffer[row].begin() + wrappedTime * mPadsPerRowSet[row],
-              mDataBuffer[row].begin() + wrappedTime * mPadsPerRowSet[row] + mPadsPerRowSet[row] - 1, 0);
+              mDataBuffer[row].begin() + wrappedTime * mPadsPerRowSet[row] + mPadsPerRowSet[row], 0);
     std::fill(mIndexBuffer[row].begin() + wrappedTime * mPadsPerRowSet[row],
-              mIndexBuffer[row].begin() + wrappedTime * mPadsPerRowSet[row] + mPadsPerRowSet[row] - 1, -1);
+              mIndexBuffer[row].begin() + wrappedTime * mPadsPerRowSet[row] + mPadsPerRowSet[row], -1);
   }
 }
+
+//______________________________________________________________________________
+void HwClusterer::updateCluster(
+  const Vc::uint_m selectionMask, int row, short centerPad, int centerTime, short dp, short dt,
+  Vc::uint_v& qTot, Vc::int_v& pad, Vc::int_v& time, Vc::int_v& sigmaPad2, Vc::int_v& sigmaTime2,
+  std::vector<std::unique_ptr<std::vector<std::pair<MCCompLabel, unsigned>>>>& mcLabels, const Vc::uint_m splitMask )
+{
+  if (selectionMask.isEmpty()) return;
+
+  const int mappedTime = mapTimeInRange(centerTime + dt);
+  const int index = mappedTime * mPadsPerRowSet[row] + centerPad + dp;
+
+
+  // If the charge should be split, only half of the charge is used
+  Vc::where(selectionMask & splitMask) | qTot += (getFpOfADC(mDataBuffer[row][index]) >> 1);
+  Vc::where(selectionMask & splitMask) | pad += (getFpOfADC(mDataBuffer[row][index]) >> 1) * dp;
+  Vc::where(selectionMask & splitMask) | time += (getFpOfADC(mDataBuffer[row][index]) >> 1) * dt;
+  Vc::where(selectionMask & splitMask) | sigmaPad2 += (getFpOfADC(mDataBuffer[row][index]) >> 1) * dp * dp;
+  Vc::where(selectionMask & splitMask) | sigmaTime2 += (getFpOfADC(mDataBuffer[row][index]) >> 1) * dt * dt;
+
+  // Otherwise the full charge
+  Vc::where(selectionMask & (!splitMask)) | qTot += getFpOfADC(mDataBuffer[row][index]);
+  Vc::where(selectionMask & (!splitMask)) | pad += getFpOfADC(mDataBuffer[row][index]) * dp;
+  Vc::where(selectionMask & (!splitMask)) | time += getFpOfADC(mDataBuffer[row][index]) * dt;
+  Vc::where(selectionMask & (!splitMask)) | sigmaPad2 += getFpOfADC(mDataBuffer[row][index]) * dp * dp;
+  Vc::where(selectionMask & (!splitMask)) | sigmaTime2 += getFpOfADC(mDataBuffer[row][index]) * dt * dt;
+
+  for (int i = 0; i < Vc::uint_v::Size; ++i) {
+    if (selectionMask[i] && mMCtruth[mappedTime] != nullptr) {
+      for (auto& label : mMCtruth[mappedTime]->getLabels(mIndexBuffer[row][index][i])) {
+        bool isKnown = false;
+        for (auto& vecLabel : *mcLabels[i]) {
+          if (label == vecLabel.first) {
+            ++vecLabel.second;
+            isKnown = true;
+          }
+        }
+        if (!isKnown) {
+          mcLabels[i]->emplace_back(label, 1);
+        }
+      }
+    }
+  }
+}
+

--- a/Detectors/TPC/reconstruction/test/testTPCHwClusterer.cxx
+++ b/Detectors/TPC/reconstruction/test/testTPCHwClusterer.cxx
@@ -84,13 +84,57 @@ float sigma_t_pre(std::array<int, 25>& data)
   return ret;
 };
 
+float p_pre_fp(std::array<float, 25>& data)
+{
+  int ret = 0;
+  ret += -2 * (data[0] * 16) - (data[1] * 16) + 0 * (data[3] * 16 ) + (data[3] * 16 ) + 2 * (data[4] * 16 );
+  ret += -2 * (data[5] * 16) - (data[6] * 16) + 0 * (data[8] * 16 ) + (data[8] * 16 ) + 2 * (data[9] * 16 );
+  ret += -2 * (data[10] * 16) - (data[11] * 16 ) + 0 * (data[13] * 16 ) + (data[13] * 16 ) + 2 * (data[14] * 16 );
+  ret += -2 * (data[15] * 16) - (data[16] * 16 ) + 0 * (data[18] * 16 ) + (data[18] * 16 ) + 2 * (data[19] * 16 );
+  ret += -2 * (data[20] * 16) - (data[21] * 16 ) + 0 * (data[23] * 16 ) + (data[23] * 16 ) + 2 * (data[24] * 16 );
+  return ret;
+};
+
+float sigma_p_pre_fp(std::array<float, 25>& data)
+{
+  int ret = 0;
+  ret += 4 * (data[0] * 16 ) + (data[1] * 16 ) + 0 * (data[3] * 16 ) + (data[3] * 16 ) + 4 * (data[4] * 16 );
+  ret += 4 * (data[5] * 16 ) + (data[6] * 16 ) + 0 * (data[8] * 16 ) + (data[8] * 16 ) + 4 * (data[9] * 16 );
+  ret += 4 * (data[10] * 16 ) + (data[11] * 16 ) + 0 * (data[13] * 16 ) + (data[13] * 16 ) + 4 * (data[14] * 16 );
+  ret += 4 * (data[15] * 16 ) + (data[16] * 16 ) + 0 * (data[18] * 16 ) + (data[18] * 16 ) + 4 * (data[19] * 16 );
+  ret += 4 * (data[20] * 16 ) + (data[21] * 16 ) + 0 * (data[23] * 16 ) + (data[23] * 16 ) + 4 * (data[24] * 16 );
+  return ret;
+};
+
+float t_pre_fp(std::array<float, 25>& data)
+{
+  int ret = 0;
+  ret += -2 * (data[0] * 16 ) - 2 * (data[1] * 16 ) - 2 * (data[2] * 16 ) - 2 * (data[3] * 16 ) - 2 * (data[4] * 16 );
+  ret += -1 * (data[5] * 16 ) - 1 * (data[6] * 16 ) - 1 * (data[7] * 16 ) - 1 * (data[8] * 16 ) - 1 * (data[9] * 16 );
+  ret += 0 * (data[10] * 16 ) + 0 * (data[11] * 16 ) + 0 * (data[12] * 16 ) + 0 * (data[13] * 16 ) + 0 * (data[14] * 16 );
+  ret += 1 * (data[15] * 16 ) + 1 * (data[16] * 16 ) + 1 * (data[17] * 16 ) + 1 * (data[18] * 16 ) + 1 * (data[19] * 16 );
+  ret += 2 * (data[20] * 16 ) + 2 * (data[21] * 16 ) + 2 * (data[22] * 16 ) + 2 * (data[23] * 16 ) + 2 * (data[24] * 16 );
+  return ret;
+};
+
+float sigma_t_pre_fp(std::array<float, 25>& data)
+{
+  int ret = 0;
+  ret += 4 * (data[0] * 16 ) + 4 * (data[1] * 16 ) + 4 * (data[2] * 16 ) + 4 * (data[3] * 16 ) + 4 * (data[4] * 16 );
+  ret += 1 * (data[5] * 16 ) + 1 * (data[6] * 16 ) + 1 * (data[7] * 16 ) + 1 * (data[8] * 16 ) + 1 * (data[9] * 16 );
+  ret += 0 * (data[10] * 16 ) + 0 * (data[11] * 16 ) + 0 * (data[12] * 16 ) + 0 * (data[13] * 16 ) + 0 * (data[14] * 16 );
+  ret += 1 * (data[15] * 16 ) + 1 * (data[16] * 16 ) + 1 * (data[17] * 16 ) + 1 * (data[18] * 16 ) + 1 * (data[19] * 16 );
+  ret += 4 * (data[20] * 16 ) + 4 * (data[21] * 16 ) + 4 * (data[22] * 16 ) + 4 * (data[23] * 16 ) + 4 * (data[24] * 16 );
+  return ret;
+};
+
+
+
 /// @brief Test 1 basic class tests
 BOOST_AUTO_TEST_CASE(HwClusterer_test1)
 {
   std::cout << "##" << std::endl;
   std::cout << "## Starting test 1, basic class tests." << std::endl;
-  std::cout << "##" << std::endl
-            << std::endl;
   using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
   auto clusterArray = std::make_unique<std::vector<ClusterHardwareContainer8kb>>();
   auto labelArray = std::make_unique<MCLabelContainer>();
@@ -134,8 +178,6 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test1)
   BOOST_CHECK_EQUAL(labelArray->getLabels(1).size(), 1); // second cluster got one MC label
   BOOST_CHECK_EQUAL(labelArray->getLabels(1)[0].getTrackID(), 3);
 
-  std::cout << std::endl;
-  std::cout << "##" << std::endl;
   std::cout << "## Test 1 done." << std::endl;
   std::cout << "##" << std::endl
             << std::endl;
@@ -146,8 +188,6 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test2)
 {
   std::cout << "##" << std::endl;
   std::cout << "## Starting test 2, finding single pad clusters." << std::endl;
-  std::cout << "##" << std::endl
-            << std::endl;
   using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
   auto clusterArray = std::make_unique<std::vector<o2::TPC::ClusterHardwareContainer8kb>>();
   auto labelArray = std::make_unique<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>();
@@ -212,8 +252,6 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test2)
       BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getSigmaTime2(), 0);
     }
   }
-  std::cout << std::endl;
-  std::cout << "##" << std::endl;
   std::cout << "## Test 2 done." << std::endl;
   std::cout << "##" << std::endl
             << std::endl;
@@ -224,8 +262,6 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test3)
 {
   std::cout << "##" << std::endl;
   std::cout << "## Starting test 3, computing cluster properties." << std::endl;
-  std::cout << "##" << std::endl
-            << std::endl;
   using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
   auto clusterArray = std::make_unique<std::vector<o2::TPC::ClusterHardwareContainer8kb>>();
   auto labelArray = std::make_unique<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>();
@@ -319,11 +355,673 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test3)
       0.0001);
   }
 
-  std::cout << std::endl;
-  std::cout << "##" << std::endl;
   std::cout << "## Test 3 done." << std::endl;
   std::cout << "##" << std::endl
             << std::endl;
 }
+
+
+/// @brief Test 4 Reject single pad clusters
+BOOST_AUTO_TEST_CASE(HwClusterer_test4)
+{
+  std::cout << "##" << std::endl;
+  std::cout << "## Starting test 4, rejecting single pad clusters." << std::endl;
+  using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
+  auto clusterArray = std::make_unique<std::vector<o2::TPC::ClusterHardwareContainer8kb>>();
+  auto labelArray = std::make_unique<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>();
+
+  o2::TPC::HwClusterer clusterer(clusterArray.get(), 0, labelArray.get());
+  // If continuous readout is false, all clusters are written directly to the output
+  clusterer.setContinuousReadout(false);
+
+  auto digits = std::make_unique<std::vector<o2::TPC::Digit>>();
+  // Digit(int cru, float charge, int row, int pad, int time)
+  // single pad and time cluster
+  std::array<std::array<int, 25>, 4> clusters;
+  clusters[0] = { { 0,  0,  0,  0,  0,
+                    0,  0,  0,  0,  0,
+                    0,  0, 67,  0,  0,
+                    0,  0,  0,  0,  0,
+                    0,  0,  0,  0,  0 } };
+
+  // single time cluster, but enlarged in pad direction
+  clusters[1] = { { 0,  0,  0,  0,  0,
+                    0,  0,  0,  0,  0,
+                    0, 12, 72, 24,  0,
+                    0,  0,  0,  0,  0,
+                    0,  0,  0,  0,  0 } };
+
+  // single pad cluster, but enlarged in tim direction
+  clusters[2] = { { 0,  0,  0,  0,  0,
+                    0,  0, 33,  0,  0,
+                    0,  0, 57,  0,  0,
+                    0,  0, 12,  0,  0,
+                    0,  0,  0,  0,  0 } };
+
+  // wide cluster in both direction
+  clusters[3] = { { 0,  0,  0,  0,  0,
+                    0, 46, 71, 32,  0,
+                    0, 32,129, 16,  0,
+                    0, 19, 53, 23,  0,
+                    0,  0,  0,  0,  0 } };
+
+
+  for (int dp = 0; dp < 5; ++dp) {
+    for (int dt = 0; dt < 5; ++dt) {
+      for (int cl = 0; cl < clusters.size(); ++cl) {
+        digits->emplace_back(0, clusters[cl][dt * 5 + dp], cl, cl + dp, cl * 10 + dt);
+      }
+    }
+  }
+
+
+  std::sort(digits->begin(), digits->end(), sortTime());
+
+  // Search clusters without thresholds, all 4 clusters shoud be found
+  std::cout << "testing without thresholds..." << std::endl;
+  clusterer.setRejectSinglePadClusters(false);
+  clusterer.setRejectSingleTimeClusters(false);
+  clusterer.process(*digits.get(), nullptr);
+  BOOST_CHECK_EQUAL(clusterArray->size(),1);
+  auto clusterContainer = (*clusterArray)[0].getContainer();
+  BOOST_CHECK_EQUAL(clusterContainer->numberOfClusters,4);
+  for (int clIndex = 0; clIndex < clusterContainer->numberOfClusters; ++clIndex) {
+    float qtot = std::accumulate(clusters[clIndex].begin(), clusters[clIndex].end(), 0);
+    // Check QTot
+    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getQTot(), std::accumulate(clusters[clIndex].begin(), clusters[clIndex].end(), 0));
+    // Check QMax
+    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getQMax(), clusters[clIndex][12]);
+    // Check row
+    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getRow(), clIndex);
+    // Check Flags
+    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getFlags(), 0);
+    // Check pad
+    BOOST_CHECK_CLOSE(
+      clusterContainer->clusters[clIndex].getPad(),
+      p_pre(clusters[clIndex]) / qtot + clIndex + 2,
+      0.0001);
+    // Check time
+    BOOST_CHECK_CLOSE(
+      clusterContainer->clusters[clIndex].getTimeLocal() + clusterContainer->timeBinOffset,
+      t_pre(clusters[clIndex]) / qtot + clIndex * 10 + 2,
+      0.0001);
+    // Check pad sigma
+    BOOST_CHECK_CLOSE(
+      clusterContainer->clusters[clIndex].getSigmaPad2(),
+      (sigma_p_pre(clusters[clIndex]) / qtot) - ((p_pre(clusters[clIndex]) * p_pre(clusters[clIndex])) / (qtot * qtot)),
+      0.0001);
+    // Check time sigma
+    BOOST_CHECK_CLOSE(
+      clusterContainer->clusters[clIndex].getSigmaTime2(),
+      (sigma_t_pre(clusters[clIndex]) / qtot) - ((t_pre(clusters[clIndex]) * t_pre(clusters[clIndex])) / (qtot * qtot)),
+      0.0001);
+  }
+
+
+  // Search clusters with threshold in pad direction, only clusters 1 and 3 should be found
+  std::cout << "testing with pad threshold..." << std::endl;
+  clusterer.setRejectSinglePadClusters(true);
+  clusterer.setRejectSingleTimeClusters(false);
+  clusterer.process(*digits.get(), nullptr);
+  BOOST_CHECK_EQUAL(clusterArray->size(),1);
+  clusterContainer = (*clusterArray)[0].getContainer();
+  BOOST_CHECK_EQUAL(clusterContainer->numberOfClusters,2);
+  for (int clIndex = 0; clIndex < clusterContainer->numberOfClusters; ++clIndex) {
+    float qtot = std::accumulate(clusters[clIndex*2+1].begin(), clusters[clIndex*2+1].end(), 0);
+    // Check QTot
+    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getQTot(), std::accumulate(clusters[clIndex*2+1].begin(), clusters[clIndex*2+1].end(), 0));
+    // Check QMax
+    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getQMax(), clusters[clIndex*2+1][12]);
+    // Check row
+    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getRow(), clIndex*2+1);
+    // Check Flags
+    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getFlags(), 0);
+    // Check pad
+    BOOST_CHECK_CLOSE(
+      clusterContainer->clusters[clIndex].getPad(),
+      p_pre(clusters[clIndex*2+1]) / qtot + (clIndex*2+1) + 2,
+      0.0001);
+    // Check time
+    BOOST_CHECK_CLOSE(
+      clusterContainer->clusters[clIndex].getTimeLocal() + clusterContainer->timeBinOffset,
+      t_pre(clusters[clIndex*2+1]) / qtot + (clIndex*2+1) * 10 + 2,
+      0.0001);
+    // Check pad sigma
+    BOOST_CHECK_CLOSE(
+      clusterContainer->clusters[clIndex].getSigmaPad2(),
+      (sigma_p_pre(clusters[clIndex*2+1]) / qtot) - ((p_pre(clusters[clIndex*2+1]) * p_pre(clusters[clIndex*2+1])) / (qtot * qtot)),
+      0.0001);
+    // Check time sigma
+    BOOST_CHECK_CLOSE(
+      clusterContainer->clusters[clIndex].getSigmaTime2(),
+      (sigma_t_pre(clusters[clIndex*2+1]) / qtot) - ((t_pre(clusters[clIndex*2+1]) * t_pre(clusters[clIndex*2+1])) / (qtot * qtot)),
+      0.0001);
+  }
+
+  // Search clusters with threshold in time direction, only clusters 2 and 3 should be found
+  std::cout << "testing with time threshold..." << std::endl;
+  clusterer.setRejectSinglePadClusters(false);
+  clusterer.setRejectSingleTimeClusters(true);
+  clusterer.process(*digits.get(), nullptr);
+  BOOST_CHECK_EQUAL(clusterArray->size(),1);
+  clusterContainer = (*clusterArray)[0].getContainer();
+  BOOST_CHECK_EQUAL(clusterContainer->numberOfClusters,2);
+  for (int clIndex = 0; clIndex < clusterContainer->numberOfClusters; ++clIndex) {
+    float qtot = std::accumulate(clusters[clIndex+2].begin(), clusters[clIndex+2].end(), 0);
+    // Check QTot
+    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getQTot(), std::accumulate(clusters[clIndex+2].begin(), clusters[clIndex+2].end(), 0));
+    // Check QMax
+    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getQMax(), clusters[clIndex+2][12]);
+    // Check row
+    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getRow(), clIndex+2);
+    // Check Flags
+    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getFlags(), 0);
+    // Check pad
+    BOOST_CHECK_CLOSE(
+      clusterContainer->clusters[clIndex].getPad(),
+      p_pre(clusters[clIndex+2]) / qtot + (clIndex+2) + 2,
+      0.0001);
+    // Check time
+    BOOST_CHECK_CLOSE(
+      clusterContainer->clusters[clIndex].getTimeLocal() + clusterContainer->timeBinOffset,
+      t_pre(clusters[clIndex+2]) / qtot + (clIndex+2) * 10 + 2,
+      0.0001);
+    // Check pad sigma
+    BOOST_CHECK_CLOSE(
+      clusterContainer->clusters[clIndex].getSigmaPad2(),
+      (sigma_p_pre(clusters[clIndex+2]) / qtot) - ((p_pre(clusters[clIndex+2]) * p_pre(clusters[clIndex+2])) / (qtot * qtot)),
+      0.0001);
+    // Check time sigma
+    BOOST_CHECK_CLOSE(
+      clusterContainer->clusters[clIndex].getSigmaTime2(),
+      (sigma_t_pre(clusters[clIndex+2]) / qtot) - ((t_pre(clusters[clIndex+2]) * t_pre(clusters[clIndex+2])) / (qtot * qtot)),
+      0.0001);
+  }
+
+  // Search clusters with both thresholds, only cluster 3 should be found
+  std::cout << "testing both thresholds..." << std::endl;
+  clusterer.setRejectSinglePadClusters(true);
+  clusterer.setRejectSingleTimeClusters(true);
+  clusterer.process(*digits.get(), nullptr);
+  BOOST_CHECK_EQUAL(clusterArray->size(),1);
+  clusterContainer = (*clusterArray)[0].getContainer();
+  BOOST_CHECK_EQUAL(clusterContainer->numberOfClusters,1);
+  for (int clIndex = 0; clIndex < clusterContainer->numberOfClusters; ++clIndex) {
+    float qtot = std::accumulate(clusters[clIndex+3].begin(), clusters[clIndex+3].end(), 0);
+    // Check QTot
+    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getQTot(), std::accumulate(clusters[clIndex+3].begin(), clusters[clIndex+3].end(), 0));
+    // Check QMax
+    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getQMax(), clusters[clIndex+3][12]);
+    // Check row
+    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getRow(), clIndex+3);
+    // Check Flags
+    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getFlags(), 0);
+    // Check pad
+    BOOST_CHECK_CLOSE(
+      clusterContainer->clusters[clIndex].getPad(),
+      p_pre(clusters[clIndex+3]) / qtot + (clIndex+3) + 2,
+      0.0001);
+    // Check time
+    BOOST_CHECK_CLOSE(
+      clusterContainer->clusters[clIndex].getTimeLocal() + clusterContainer->timeBinOffset,
+      t_pre(clusters[clIndex+3]) / qtot + (clIndex+3) * 10 + 2,
+      0.0001);
+    // Check pad sigma
+    BOOST_CHECK_CLOSE(
+      clusterContainer->clusters[clIndex].getSigmaPad2(),
+      (sigma_p_pre(clusters[clIndex+3]) / qtot) - ((p_pre(clusters[clIndex+3]) * p_pre(clusters[clIndex+3])) / (qtot * qtot)),
+      0.0001);
+    // Check time sigma
+    BOOST_CHECK_CLOSE(
+      clusterContainer->clusters[clIndex].getSigmaTime2(),
+      (sigma_t_pre(clusters[clIndex+3]) / qtot) - ((t_pre(clusters[clIndex+3]) * t_pre(clusters[clIndex+3])) / (qtot * qtot)),
+      0.0001);
+  }
+
+
+  std::cout << "## Test 4 done." << std::endl;
+  std::cout << "##" << std::endl
+            << std::endl;
+}
+
+
+/// @brief Test 5 Reject peaks in subsequent timebins
+BOOST_AUTO_TEST_CASE(HwClusterer_test5)
+{
+  std::cout << "##" << std::endl;
+  std::cout << "## Starting test 5, rejecting peaks in subsequent." << std::endl;
+  using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
+  auto clusterArray = std::make_unique<std::vector<o2::TPC::ClusterHardwareContainer8kb>>();
+  auto labelArray = std::make_unique<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>();
+
+  o2::TPC::HwClusterer clusterer(clusterArray.get(), 0, labelArray.get());
+  // If continuous readout is false, all clusters are written directly to the output
+  clusterer.setContinuousReadout(false);
+
+  auto digits = std::make_unique<std::vector<o2::TPC::Digit>>();
+  // Digit(int cru, float charge, int row, int pad, int time)
+  // two peaks, with the greater one afterwards
+  std::array<std::array<int, 25>, 2> clusters;
+  clusters[0] = { { 0,  0,  6,  0,  0,
+                    0,  0, 23,  0,  0,
+                    0,  0,  7,  0,  0,
+                    0,  0, 77,  0,  0,
+                    0,  0,  5,  0,  0 } };
+
+  // two peaks, with the greater one first
+  clusters[1] = { { 0,  0,  6,  0,  0,
+                    0,  0, 67,  0,  0,
+                    0,  0,  7,  0,  0,
+                    0,  0, 13,  0,  0,
+                    0,  0,  5,  0,  0 } };
+
+  for (int dp = 0; dp < 5; ++dp) {
+    for (int dt = 0; dt < 5; ++dt) {
+      for (int cl = 0; cl < clusters.size(); ++cl) {
+        digits->emplace_back(0, clusters[cl][dt * 5 + dp], cl, cl + dp, cl * 10 + dt);
+      }
+    }
+  }
+
+
+  std::sort(digits->begin(), digits->end(), sortTime());
+
+  // Search clusters without rejection, all 4 clusters shoud be found
+  std::cout << "testing without rejection..." << std::endl;
+  clusterer.setRejectLaterTimebin(false);
+  clusterer.process(*digits.get(), nullptr);
+  BOOST_CHECK_EQUAL(clusterArray->size(),1);
+  auto clusterContainer = (*clusterArray)[0].getContainer();
+  BOOST_CHECK_EQUAL(clusterContainer->numberOfClusters,4);
+  BOOST_CHECK_EQUAL(clusterContainer->clusters[0].getQMax(), clusters[0][7]);
+  BOOST_CHECK_EQUAL(clusterContainer->clusters[1].getQMax(), clusters[0][17]);
+  BOOST_CHECK_EQUAL(clusterContainer->clusters[2].getQMax(), clusters[1][7]);
+  BOOST_CHECK_EQUAL(clusterContainer->clusters[3].getQMax(), clusters[1][17]);
+
+  // Search clusters with rejection, cluster with peak charge 13 should be surpressed
+  std::cout << "testing with with rejection..." << std::endl;
+  clusterer.setRejectLaterTimebin(true);
+  clusterer.process(*digits.get(), nullptr);
+  BOOST_CHECK_EQUAL(clusterArray->size(),1);
+  clusterContainer = (*clusterArray)[0].getContainer();
+  BOOST_CHECK_EQUAL(clusterContainer->numberOfClusters,3);
+  BOOST_CHECK_EQUAL(clusterContainer->clusters[0].getQMax(), clusters[0][7]);
+  BOOST_CHECK_EQUAL(clusterContainer->clusters[1].getQMax(), clusters[0][17]);
+  BOOST_CHECK_EQUAL(clusterContainer->clusters[2].getQMax(), clusters[1][7]);
+
+  std::cout << "## Test 5 done." << std::endl;
+  std::cout << "##" << std::endl
+            << std::endl;
+}
+
+
+/// @brief Test 6 Split charge among nearby clusters
+BOOST_AUTO_TEST_CASE(HwClusterer_test6)
+{
+  std::cout << "##" << std::endl;
+  std::cout << "## Starting test 6, split charge among nearby clusters." << std::endl;
+  using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
+  auto clusterArray = std::make_unique<std::vector<o2::TPC::ClusterHardwareContainer8kb>>();
+  auto labelArray = std::make_unique<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>();
+
+  o2::TPC::HwClusterer clusterer(clusterArray.get(), 0, labelArray.get());
+  // If continuous readout is false, all clusters are written directly to the output
+  clusterer.setContinuousReadout(false);
+
+  auto digits = std::make_unique<std::vector<o2::TPC::Digit>>();
+  // Digit(int cru, float charge, int row, int pad, int time)
+  std::array<std::array<int, 100>, 6> clusters;
+  // Just a single cluster
+  clusters[0] = { { 0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
+                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
+                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
+                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
+                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
+
+                    4,  9, 12,  6,  1,    0,  0,  0,  0,  0,
+                    8, 17, 25, 18,  5,    0,  0,  0,  0,  0,
+                   13, 22, 50, 28, 14,    0,  0,  0,  0,  0,
+                    9, 16, 27, 19,  7,    0,  0,  0,  0,  0,
+                    2,  7, 11,  6,  3,    0,  0,  0,  0,  0 } };
+
+  // Two clusters next to each other in pad direction, peaks well separated
+  clusters[1] = { { 0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
+                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
+                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
+                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
+                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
+
+                    4,  9, 12,  6,  1,    4,  9, 12,  6,  1,
+                    8, 17, 25, 18,  5,    8, 17, 25, 18,  5,
+                   13, 22, 51, 28, 14,   13, 22, 52, 28, 15,
+                    9, 16, 27, 19,  7,    9, 16, 27, 19,  7,
+                    2,  7, 11,  6,  3,    2,  7, 11,  6,  3} };
+
+  // Two clusters next to each other in pad direction, peaks 4 pads appart
+  clusters[2] = { { 0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
+                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
+                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
+                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
+                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
+
+                    4,  9, 12,  6,  1,    9, 12,  6,  1,  0,
+                    8, 17, 25, 18,  5,   17, 25, 18,  5,  0,
+                   13, 22, 53, 28, 14,   22, 54, 28, 15,  0,
+                    9, 16, 27, 19,  7,   16, 27, 19,  7,  0,
+                    2,  7, 11,  6,  3,    7, 11,  6,  3,  0} };
+
+  // Two clusters next to each other in pad direction, peaks 3 pads appartd
+  clusters[3] = { { 0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
+                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
+                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
+                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
+                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
+
+                    0,  4,  9, 12,  6,    9, 12,  6,  1,  0,
+                    0,  8, 17, 25, 18,   17, 25, 18,  5,  0,
+                    0, 13, 22, 55, 28,   22, 56, 28, 15,  0,
+                    0,  9, 16, 27, 19,   16, 27, 19,  7,  0,
+                    0,  2,  7, 11,  6,    7, 11,  6,  3,  0} };
+
+  // Two clusters next to each other in pad direction, peaks 2 pads appartd
+  clusters[4] = { { 0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
+                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
+                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
+                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
+                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
+
+                    0,  4,  9, 12,  6,   12,  6,  1,  0,  0,
+                    0,  8, 17, 25, 18,   25, 18,  5,  0,  0,
+                    0, 13, 22, 57, 28,   58, 28, 15,  0,  0,
+                    0,  9, 16, 27, 19,   27, 19,  7,  0,  0,
+                    0,  2,  7, 11,  6,   11,  6,  3,  0,  0} };
+
+  // Two clusters next to each other in diagonal direction
+  clusters[5] = { { 0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
+                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
+                    0,  0,  0,  0,  4,    9, 12,  6,  1,  0,
+                    0,  0,  0,  0,  8,   17, 25, 18,  5,  0,
+                    0,  0,  0,  0, 13,   22, 59, 28, 15,  0,
+
+                    4,  9, 12,  6,  9,   16, 27, 19,  7,  0,
+                    8, 17, 25, 18,  2,    7, 11,  6,  3,  0,
+                   13, 22, 60, 28, 14,    0,  0,  0,  0,  0,
+                    9, 16, 27, 19,  7,    0,  0,  0,  0,  0,
+                    2,  7, 11,  6,  3,    0,  0,  0,  0,  0} };
+
+
+
+  std::array<std::array<float, 25>, 11> clustersMode0;
+  clustersMode0[0] = { { 4,  9, 12,  6,  1,
+                         8, 17, 25, 18,  5,
+                        13, 22, 50, 28, 14,
+                         9, 16, 27, 19,  7,
+                         2,  7, 11,  6,  3} };
+
+  clustersMode0[1] = { { 4,  9, 12,  6,  1,
+                         8, 17, 25, 18,  5,
+                        13, 22, 51, 28, 14,
+                         9, 16, 27, 19,  7,
+                         2,  7, 11,  6,  3} };
+
+  clustersMode0[2] = { { 4,  9, 12,  6,  1,
+                         8, 17, 25, 18,  5,
+                        13, 22, 52, 28, 15,
+                         9, 16, 27, 19,  7,
+                         2,  7, 11,  6,  3} };
+
+  clustersMode0[3] = { { 4,  9, 12,  6,  1,
+                         8, 17, 25, 18,  5,
+                        13, 22, 53, 28, 14,
+                         9, 16, 27, 19,  7,
+                         2,  7, 11,  6,  3} };
+
+  clustersMode0[4] = { { 1,  9, 12,  6,  1,
+                         5, 17, 25, 18,  5,
+                        14, 22, 54, 28, 15,
+                         7, 16, 27, 19,  7,
+                         3,  7, 11,  6,  3} };
+
+  clustersMode0[5] = { { 4,  9, 12,  6,  9,
+                         8, 17, 25, 18, 17,
+                        13, 22, 55, 28, 22,
+                         9, 16, 27, 19, 16,
+                         2,  7, 11,  6,  7} };
+
+  clustersMode0[6] = { { 6,  9, 12,  6,  1,
+                        18, 17, 25, 18,  5,
+                        28, 22, 56, 28, 15,
+                        19, 16, 27, 19,  7,
+                         6,  7, 11,  6,  3} };
+
+  clustersMode0[7] = { { 4,  9, 12,  6, 12,
+                         8, 17, 25, 18, 25,
+                        13, 22, 57, 28, 58,
+                         9, 16, 27, 19, 27,
+                         2,  7, 11,  6, 11} };
+
+  clustersMode0[8] = { {12,  6, 12,  6,  1,
+                        25, 18, 25, 18,  5,
+                        57, 28, 58, 28, 15,
+                        27, 19, 27, 19,  7,
+                        11,  6, 11,  6,  3} };
+
+  clustersMode0[9] = { { 4,  9, 12,  6,  1,
+                         8, 17, 25, 18,  5,
+                        13, 22, 59, 28, 15,
+                         9, 16, 27, 19,  7,
+                         2,  7, 11,  6,  3} };
+
+
+  clustersMode0[10] = { { 4,  9, 12,  6,  9,
+                          8, 17, 25, 18,  2,
+                         13, 22, 60, 28, 14,
+                          9, 16, 27, 19,  7,
+                          2,  7, 11,  6,  3} };
+
+  std::array<std::array<float, 25>, 11> clustersMode1;
+  clustersMode1[0] = { { 4,  9, 12,  6,  1,
+                         8, 17, 25, 18,  5,
+                        13, 22, 50, 28, 14,
+                         9, 16, 27, 19,  7,
+                         2,  7, 11,  6,  3} };
+
+  clustersMode1[1] = { { 4,  9, 12,  6,  0.5,
+                         8, 17, 25, 18,  2.5,
+                        13, 22, 51, 28, 14,
+                         9, 16, 27, 19,  3.5,
+                         2,  7, 11,  6,  3} };
+
+  clustersMode1[2] = { { 4,  9, 12,  6,  1,
+                         8, 17, 25, 18,  5,
+                        6.5, 22, 52, 28, 15,
+                         9, 16, 27, 19,  7,
+                         1,  7, 11,  6,  3} };
+
+  clustersMode1[3] = { { 4,  9, 12,  6,  0.5,
+                         8, 17, 25, 18,  2.5,
+                        13, 22, 53, 28,  7,
+                         9, 16, 27, 19,  3.5,
+                         2,  7, 11,  6,  1.5} };
+
+  clustersMode1[4] = { { 0.5,  9, 12,  6,  1,
+                         2.5, 17, 25, 18,  5,
+                         7  , 22, 54, 28, 15,
+                         3.5, 16, 27, 19,  7,
+                         1.5,  7, 11,  6,  3} };
+
+  clustersMode1[5] = { { 4,  9, 12,  6,  0,
+                         8, 17, 25, 18,8.5,
+                        13, 22, 55, 28, 11,
+                         9, 16, 27, 19,  8,
+                         2,  7, 11,  6,  0} };
+
+  clustersMode1[6] = { {  0,  9, 12,  6,  1,
+                          0,8.5, 25, 18,  5,
+                          0, 11, 56, 28, 15,
+                          0,  8, 27, 19,  7,
+                          0,  7, 11,  6,  3} };
+
+  clustersMode1[7] = { { 4,  9, 12,  6,  0,
+                         8, 17, 25,  9,  0,
+                        13, 22, 57, 14,  0,
+                         9, 16, 27,9.5,  0,
+                         2,  7, 11,  6,  0} };
+
+  clustersMode1[8] = { { 0,  6, 12,  6,  1,
+                         0,  9, 25, 18,  5,
+                         0, 14, 58, 28, 15,
+                         0,9.5, 27, 19,  7,
+                         0,  6, 11,  6,  3} };
+
+  clustersMode1[9] = { { 4,  9, 12,  6,  1,
+                         8, 17, 25, 18,  5,
+                        13, 22, 59, 28, 15,
+                       4.5, 16, 27, 19,  7,
+                         1,3.5, 11,  6,  3} };
+
+  clustersMode1[10] = { { 4,  9, 12,  3,  0,
+                          8, 17, 25, 18,  1,
+                         13, 22, 60, 28, 14,
+                          9, 16, 27, 19,  7,
+                          2,  7, 11,  6,  3} };
+
+
+  for (int cl = 0; cl < clusters.size(); ++cl) {
+    for (int dt = 0; dt < 10; ++dt) {
+      for (int dp = 0; dp < 10; ++dp) {
+        // Digit(int cru, float charge, int row, int pad, int time)
+        digits->emplace_back(0, clusters[cl][dt * 10 + dp], cl, dp, dt+20*cl);
+      }
+    }
+  }
+
+
+  std::sort(digits->begin(), digits->end(), sortTime());
+
+  std::cout << "testing without splitting..." << std::endl;
+
+  std::vector<ClusterHardware> clustersToCompare;
+  clustersToCompare.emplace_back();
+  clustersToCompare.back().setCluster(2,7, p_pre_fp(clustersMode0[0]), t_pre_fp(clustersMode0[0]), sigma_p_pre_fp(clustersMode0[0]), sigma_t_pre_fp(clustersMode0[0]), (clustersMode0[0][12]*2), (std::accumulate(clustersMode0[0].begin(), clustersMode0[0].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.emplace_back();
+  clustersToCompare.back().setCluster(2,7+20, p_pre_fp(clustersMode0[1]), t_pre_fp(clustersMode0[1]), sigma_p_pre_fp(clustersMode0[1]), sigma_t_pre_fp(clustersMode0[1]), (clustersMode0[1][12]*2), (std::accumulate(clustersMode0[1].begin(), clustersMode0[1].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.emplace_back();
+  clustersToCompare.back().setCluster(2+5,7+20, p_pre_fp(clustersMode0[2]), t_pre_fp(clustersMode0[2]), sigma_p_pre_fp(clustersMode0[2]), sigma_t_pre_fp(clustersMode0[2]), (clustersMode0[2][12]*2), (std::accumulate(clustersMode0[2].begin(), clustersMode0[2].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.emplace_back();
+  clustersToCompare.back().setCluster(2,7+40, p_pre_fp(clustersMode0[3]), t_pre_fp(clustersMode0[3]), sigma_p_pre_fp(clustersMode0[3]), sigma_t_pre_fp(clustersMode0[3]), (clustersMode0[3][12]*2), (std::accumulate(clustersMode0[3].begin(), clustersMode0[3].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.emplace_back();
+  clustersToCompare.back().setCluster(2+4,7+40, p_pre_fp(clustersMode0[4]), t_pre_fp(clustersMode0[4]), sigma_p_pre_fp(clustersMode0[4]), sigma_t_pre_fp(clustersMode0[4]), (clustersMode0[4][12]*2), (std::accumulate(clustersMode0[4].begin(), clustersMode0[4].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.emplace_back();
+  clustersToCompare.back().setCluster(2+1,7+60, p_pre_fp(clustersMode0[5]), t_pre_fp(clustersMode0[5]), sigma_p_pre_fp(clustersMode0[5]), sigma_t_pre_fp(clustersMode0[5]), (clustersMode0[5][12]*2), (std::accumulate(clustersMode0[5].begin(), clustersMode0[5].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.emplace_back();
+  clustersToCompare.back().setCluster(2+4,7+60, p_pre_fp(clustersMode0[6]), t_pre_fp(clustersMode0[6]), sigma_p_pre_fp(clustersMode0[6]), sigma_t_pre_fp(clustersMode0[6]), (clustersMode0[6][12]*2), (std::accumulate(clustersMode0[6].begin(), clustersMode0[6].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.emplace_back();
+  clustersToCompare.back().setCluster(2+1,7+80, p_pre_fp(clustersMode0[7]), t_pre_fp(clustersMode0[7]), sigma_p_pre_fp(clustersMode0[7]), sigma_t_pre_fp(clustersMode0[7]), (clustersMode0[7][12]*2), (std::accumulate(clustersMode0[7].begin(), clustersMode0[7].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.emplace_back();
+  clustersToCompare.back().setCluster(2+3,7+80, p_pre_fp(clustersMode0[8]), t_pre_fp(clustersMode0[8]), sigma_p_pre_fp(clustersMode0[8]), sigma_t_pre_fp(clustersMode0[8]), (clustersMode0[8][12]*2), (std::accumulate(clustersMode0[8].begin(), clustersMode0[8].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.emplace_back();
+  clustersToCompare.back().setCluster(2+4,7+97, p_pre_fp(clustersMode0[9]), t_pre_fp(clustersMode0[9]), sigma_p_pre_fp(clustersMode0[9]), sigma_t_pre_fp(clustersMode0[9]), (clustersMode0[9][12]*2), (std::accumulate(clustersMode0[9].begin(), clustersMode0[9].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.emplace_back();
+  clustersToCompare.back().setCluster(2,7+100, p_pre_fp(clustersMode0[10]), t_pre_fp(clustersMode0[10]), sigma_p_pre_fp(clustersMode0[10]), sigma_t_pre_fp(clustersMode0[10]), (clustersMode0[10][12]*2), (std::accumulate(clustersMode0[10].begin(), clustersMode0[10].end(), 0.0) * 16), 0, 0);
+  clusterer.setSplittingMode(0);
+  clusterer.process(*digits.get(), nullptr);
+  BOOST_CHECK_EQUAL(clusterArray->size(),1);
+  auto clusterContainer = (*clusterArray)[0].getContainer();
+  BOOST_CHECK_EQUAL(clusterContainer->numberOfClusters, 11);
+  for (int clIndex = 0; clIndex < clusterContainer->numberOfClusters; ++clIndex) {
+    std::cout << "Testing cluster " << clIndex << std::endl;
+    // Checking row and flags are not relevant for this test
+    // Check QTot
+    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getQTot(), clustersToCompare[clIndex].getQTot());
+    // Check QMax
+    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getQMax(), clustersToCompare[clIndex].getQMax());
+    // Check pad
+    BOOST_CHECK_CLOSE(
+      clusterContainer->clusters[clIndex].getPad(),
+      clustersToCompare[clIndex].getPad(),
+      0.0001);
+    // Check time
+    BOOST_CHECK_CLOSE(
+      clusterContainer->clusters[clIndex].getTimeLocal() + clusterContainer->timeBinOffset,
+      clustersToCompare[clIndex].getTimeLocal(),
+      0.0001);
+    // Check pad sigma
+    BOOST_CHECK_CLOSE(
+      clusterContainer->clusters[clIndex].getSigmaPad2(),
+      clustersToCompare[clIndex].getSigmaPad2(),
+      0.0001);
+    // Check time sigma
+    BOOST_CHECK_CLOSE(
+      clusterContainer->clusters[clIndex].getSigmaTime2(),
+      clustersToCompare[clIndex].getSigmaTime2(),
+      0.0001);
+  }
+
+
+  std::cout << "testing splitting mode 1..." << std::endl;
+  clustersToCompare.clear();
+  clustersToCompare.emplace_back();
+  clustersToCompare.back().setCluster(2,7, p_pre_fp(clustersMode1[0]), t_pre_fp(clustersMode1[0]), sigma_p_pre_fp(clustersMode1[0]), sigma_t_pre_fp(clustersMode1[0]), (clustersMode1[0][12]*2), (std::accumulate(clustersMode1[0].begin(), clustersMode1[0].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.emplace_back();
+  clustersToCompare.back().setCluster(2,7+20, p_pre_fp(clustersMode1[1]), t_pre_fp(clustersMode1[1]), sigma_p_pre_fp(clustersMode1[1]), sigma_t_pre_fp(clustersMode1[1]), (clustersMode1[1][12]*2), (std::accumulate(clustersMode1[1].begin(), clustersMode1[1].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.emplace_back();
+  clustersToCompare.back().setCluster(2+5,7+20, p_pre_fp(clustersMode1[2]), t_pre_fp(clustersMode1[2]), sigma_p_pre_fp(clustersMode1[2]), sigma_t_pre_fp(clustersMode1[2]), (clustersMode1[2][12]*2), (std::accumulate(clustersMode1[2].begin(), clustersMode1[2].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.emplace_back();
+  clustersToCompare.back().setCluster(2,7+40, p_pre_fp(clustersMode1[3]), t_pre_fp(clustersMode1[3]), sigma_p_pre_fp(clustersMode1[3]), sigma_t_pre_fp(clustersMode1[3]), (clustersMode1[3][12]*2), (std::accumulate(clustersMode1[3].begin(), clustersMode1[3].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.emplace_back();
+  clustersToCompare.back().setCluster(2+4,7+40, p_pre_fp(clustersMode1[4]), t_pre_fp(clustersMode1[4]), sigma_p_pre_fp(clustersMode1[4]), sigma_t_pre_fp(clustersMode1[4]), (clustersMode1[4][12]*2), (std::accumulate(clustersMode1[4].begin(), clustersMode1[4].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.emplace_back();
+  clustersToCompare.back().setCluster(2+1,7+60, p_pre_fp(clustersMode1[5]), t_pre_fp(clustersMode1[5]), sigma_p_pre_fp(clustersMode1[5]), sigma_t_pre_fp(clustersMode1[5]), (clustersMode1[5][12]*2), (std::accumulate(clustersMode1[5].begin(), clustersMode1[5].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.emplace_back();
+  clustersToCompare.back().setCluster(2+4,7+60, p_pre_fp(clustersMode1[6]), t_pre_fp(clustersMode1[6]), sigma_p_pre_fp(clustersMode1[6]), sigma_t_pre_fp(clustersMode1[6]), (clustersMode1[6][12]*2), (std::accumulate(clustersMode1[6].begin(), clustersMode1[6].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.emplace_back();
+  clustersToCompare.back().setCluster(2+1,7+80, p_pre_fp(clustersMode1[7]), t_pre_fp(clustersMode1[7]), sigma_p_pre_fp(clustersMode1[7]), sigma_t_pre_fp(clustersMode1[7]), (clustersMode1[7][12]*2), (std::accumulate(clustersMode1[7].begin(), clustersMode1[7].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.emplace_back();
+  clustersToCompare.back().setCluster(2+3,7+80, p_pre_fp(clustersMode1[8]), t_pre_fp(clustersMode1[8]), sigma_p_pre_fp(clustersMode1[8]), sigma_t_pre_fp(clustersMode1[8]), (clustersMode1[8][12]*2), (std::accumulate(clustersMode1[8].begin(), clustersMode1[8].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.emplace_back();
+  clustersToCompare.back().setCluster(2+4,7+97, p_pre_fp(clustersMode1[9]), t_pre_fp(clustersMode1[9]), sigma_p_pre_fp(clustersMode1[9]), sigma_t_pre_fp(clustersMode1[9]), (clustersMode1[9][12]*2), (std::accumulate(clustersMode1[9].begin(), clustersMode1[9].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.emplace_back();
+  clustersToCompare.back().setCluster(2,7+100, p_pre_fp(clustersMode1[10]), t_pre_fp(clustersMode1[10]), sigma_p_pre_fp(clustersMode1[10]), sigma_t_pre_fp(clustersMode1[10]), (clustersMode1[10][12]*2), (std::accumulate(clustersMode1[10].begin(), clustersMode1[10].end(), 0.0) * 16), 0, 0);
+  clusterer.setSplittingMode(1);
+  clusterer.process(*digits.get(), nullptr);
+  BOOST_CHECK_EQUAL(clusterArray->size(),1);
+  clusterContainer = (*clusterArray)[0].getContainer();
+  BOOST_CHECK_EQUAL(clusterContainer->numberOfClusters, 11);
+  for (int clIndex = 0; clIndex < clusterContainer->numberOfClusters; ++clIndex) {
+    std::cout << "Testing cluster " << clIndex << std::endl;
+    // Checking row and flags are not relevant for this test
+    // Check QTot
+    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getQTot(), clustersToCompare[clIndex].getQTot());
+    // Check QMax
+    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getQMax(), clustersToCompare[clIndex].getQMax());
+    // Check pad
+    BOOST_CHECK_CLOSE(
+      clusterContainer->clusters[clIndex].getPad(),
+      clustersToCompare[clIndex].getPad(),
+      0.0001);
+    // Check time
+    BOOST_CHECK_CLOSE(
+      clusterContainer->clusters[clIndex].getTimeLocal() + clusterContainer->timeBinOffset,
+      clustersToCompare[clIndex].getTimeLocal(),
+      0.0001);
+    // Check pad sigma
+    BOOST_CHECK_CLOSE(
+      clusterContainer->clusters[clIndex].getSigmaPad2(),
+      clustersToCompare[clIndex].getSigmaPad2(),
+      0.0001);
+    // Check time sigma
+    BOOST_CHECK_CLOSE(
+      clusterContainer->clusters[clIndex].getSigmaTime2(),
+      clustersToCompare[clIndex].getSigmaTime2(),
+      0.0001);
+  }
+
+  std::cout << "## Test 6 done." << std::endl;
+  std::cout << "##" << std::endl
+            << std::endl;
+}
+
+
 }
 }

--- a/Detectors/TPC/reconstruction/test/testTPCHwClusterer.cxx
+++ b/Detectors/TPC/reconstruction/test/testTPCHwClusterer.cxx
@@ -87,48 +87,46 @@ float sigma_t_pre(std::array<int, 25>& data)
 float p_pre_fp(std::array<float, 25>& data)
 {
   int ret = 0;
-  ret += -2 * (data[0] * 16) - (data[1] * 16) + 0 * (data[3] * 16 ) + (data[3] * 16 ) + 2 * (data[4] * 16 );
-  ret += -2 * (data[5] * 16) - (data[6] * 16) + 0 * (data[8] * 16 ) + (data[8] * 16 ) + 2 * (data[9] * 16 );
-  ret += -2 * (data[10] * 16) - (data[11] * 16 ) + 0 * (data[13] * 16 ) + (data[13] * 16 ) + 2 * (data[14] * 16 );
-  ret += -2 * (data[15] * 16) - (data[16] * 16 ) + 0 * (data[18] * 16 ) + (data[18] * 16 ) + 2 * (data[19] * 16 );
-  ret += -2 * (data[20] * 16) - (data[21] * 16 ) + 0 * (data[23] * 16 ) + (data[23] * 16 ) + 2 * (data[24] * 16 );
+  ret += -2 * (data[0] * 16) - (data[1] * 16) + 0 * (data[3] * 16) + (data[3] * 16) + 2 * (data[4] * 16);
+  ret += -2 * (data[5] * 16) - (data[6] * 16) + 0 * (data[8] * 16) + (data[8] * 16) + 2 * (data[9] * 16);
+  ret += -2 * (data[10] * 16) - (data[11] * 16) + 0 * (data[13] * 16) + (data[13] * 16) + 2 * (data[14] * 16);
+  ret += -2 * (data[15] * 16) - (data[16] * 16) + 0 * (data[18] * 16) + (data[18] * 16) + 2 * (data[19] * 16);
+  ret += -2 * (data[20] * 16) - (data[21] * 16) + 0 * (data[23] * 16) + (data[23] * 16) + 2 * (data[24] * 16);
   return ret;
 };
 
 float sigma_p_pre_fp(std::array<float, 25>& data)
 {
   int ret = 0;
-  ret += 4 * (data[0] * 16 ) + (data[1] * 16 ) + 0 * (data[3] * 16 ) + (data[3] * 16 ) + 4 * (data[4] * 16 );
-  ret += 4 * (data[5] * 16 ) + (data[6] * 16 ) + 0 * (data[8] * 16 ) + (data[8] * 16 ) + 4 * (data[9] * 16 );
-  ret += 4 * (data[10] * 16 ) + (data[11] * 16 ) + 0 * (data[13] * 16 ) + (data[13] * 16 ) + 4 * (data[14] * 16 );
-  ret += 4 * (data[15] * 16 ) + (data[16] * 16 ) + 0 * (data[18] * 16 ) + (data[18] * 16 ) + 4 * (data[19] * 16 );
-  ret += 4 * (data[20] * 16 ) + (data[21] * 16 ) + 0 * (data[23] * 16 ) + (data[23] * 16 ) + 4 * (data[24] * 16 );
+  ret += 4 * (data[0] * 16) + (data[1] * 16) + 0 * (data[3] * 16) + (data[3] * 16) + 4 * (data[4] * 16);
+  ret += 4 * (data[5] * 16) + (data[6] * 16) + 0 * (data[8] * 16) + (data[8] * 16) + 4 * (data[9] * 16);
+  ret += 4 * (data[10] * 16) + (data[11] * 16) + 0 * (data[13] * 16) + (data[13] * 16) + 4 * (data[14] * 16);
+  ret += 4 * (data[15] * 16) + (data[16] * 16) + 0 * (data[18] * 16) + (data[18] * 16) + 4 * (data[19] * 16);
+  ret += 4 * (data[20] * 16) + (data[21] * 16) + 0 * (data[23] * 16) + (data[23] * 16) + 4 * (data[24] * 16);
   return ret;
 };
 
 float t_pre_fp(std::array<float, 25>& data)
 {
   int ret = 0;
-  ret += -2 * (data[0] * 16 ) - 2 * (data[1] * 16 ) - 2 * (data[2] * 16 ) - 2 * (data[3] * 16 ) - 2 * (data[4] * 16 );
-  ret += -1 * (data[5] * 16 ) - 1 * (data[6] * 16 ) - 1 * (data[7] * 16 ) - 1 * (data[8] * 16 ) - 1 * (data[9] * 16 );
-  ret += 0 * (data[10] * 16 ) + 0 * (data[11] * 16 ) + 0 * (data[12] * 16 ) + 0 * (data[13] * 16 ) + 0 * (data[14] * 16 );
-  ret += 1 * (data[15] * 16 ) + 1 * (data[16] * 16 ) + 1 * (data[17] * 16 ) + 1 * (data[18] * 16 ) + 1 * (data[19] * 16 );
-  ret += 2 * (data[20] * 16 ) + 2 * (data[21] * 16 ) + 2 * (data[22] * 16 ) + 2 * (data[23] * 16 ) + 2 * (data[24] * 16 );
+  ret += -2 * (data[0] * 16) - 2 * (data[1] * 16) - 2 * (data[2] * 16) - 2 * (data[3] * 16) - 2 * (data[4] * 16);
+  ret += -1 * (data[5] * 16) - 1 * (data[6] * 16) - 1 * (data[7] * 16) - 1 * (data[8] * 16) - 1 * (data[9] * 16);
+  ret += 0 * (data[10] * 16) + 0 * (data[11] * 16) + 0 * (data[12] * 16) + 0 * (data[13] * 16) + 0 * (data[14] * 16);
+  ret += 1 * (data[15] * 16) + 1 * (data[16] * 16) + 1 * (data[17] * 16) + 1 * (data[18] * 16) + 1 * (data[19] * 16);
+  ret += 2 * (data[20] * 16) + 2 * (data[21] * 16) + 2 * (data[22] * 16) + 2 * (data[23] * 16) + 2 * (data[24] * 16);
   return ret;
 };
 
 float sigma_t_pre_fp(std::array<float, 25>& data)
 {
   int ret = 0;
-  ret += 4 * (data[0] * 16 ) + 4 * (data[1] * 16 ) + 4 * (data[2] * 16 ) + 4 * (data[3] * 16 ) + 4 * (data[4] * 16 );
-  ret += 1 * (data[5] * 16 ) + 1 * (data[6] * 16 ) + 1 * (data[7] * 16 ) + 1 * (data[8] * 16 ) + 1 * (data[9] * 16 );
-  ret += 0 * (data[10] * 16 ) + 0 * (data[11] * 16 ) + 0 * (data[12] * 16 ) + 0 * (data[13] * 16 ) + 0 * (data[14] * 16 );
-  ret += 1 * (data[15] * 16 ) + 1 * (data[16] * 16 ) + 1 * (data[17] * 16 ) + 1 * (data[18] * 16 ) + 1 * (data[19] * 16 );
-  ret += 4 * (data[20] * 16 ) + 4 * (data[21] * 16 ) + 4 * (data[22] * 16 ) + 4 * (data[23] * 16 ) + 4 * (data[24] * 16 );
+  ret += 4 * (data[0] * 16) + 4 * (data[1] * 16) + 4 * (data[2] * 16) + 4 * (data[3] * 16) + 4 * (data[4] * 16);
+  ret += 1 * (data[5] * 16) + 1 * (data[6] * 16) + 1 * (data[7] * 16) + 1 * (data[8] * 16) + 1 * (data[9] * 16);
+  ret += 0 * (data[10] * 16) + 0 * (data[11] * 16) + 0 * (data[12] * 16) + 0 * (data[13] * 16) + 0 * (data[14] * 16);
+  ret += 1 * (data[15] * 16) + 1 * (data[16] * 16) + 1 * (data[17] * 16) + 1 * (data[18] * 16) + 1 * (data[19] * 16);
+  ret += 4 * (data[20] * 16) + 4 * (data[21] * 16) + 4 * (data[22] * 16) + 4 * (data[23] * 16) + 4 * (data[24] * 16);
   return ret;
 };
-
-
 
 /// @brief Test 1 basic class tests
 BOOST_AUTO_TEST_CASE(HwClusterer_test1)
@@ -360,7 +358,6 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test3)
             << std::endl;
 }
 
-
 /// @brief Test 4 Reject single pad clusters
 BOOST_AUTO_TEST_CASE(HwClusterer_test4)
 {
@@ -378,33 +375,32 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test4)
   // Digit(int cru, float charge, int row, int pad, int time)
   // single pad and time cluster
   std::array<std::array<int, 25>, 4> clusters;
-  clusters[0] = { { 0,  0,  0,  0,  0,
-                    0,  0,  0,  0,  0,
-                    0,  0, 67,  0,  0,
-                    0,  0,  0,  0,  0,
-                    0,  0,  0,  0,  0 } };
+  clusters[0] = { { 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0,
+                    0, 0, 67, 0, 0,
+                    0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0 } };
 
   // single time cluster, but enlarged in pad direction
-  clusters[1] = { { 0,  0,  0,  0,  0,
-                    0,  0,  0,  0,  0,
-                    0, 12, 72, 24,  0,
-                    0,  0,  0,  0,  0,
-                    0,  0,  0,  0,  0 } };
+  clusters[1] = { { 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0,
+                    0, 12, 72, 24, 0,
+                    0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0 } };
 
   // single pad cluster, but enlarged in tim direction
-  clusters[2] = { { 0,  0,  0,  0,  0,
-                    0,  0, 33,  0,  0,
-                    0,  0, 57,  0,  0,
-                    0,  0, 12,  0,  0,
-                    0,  0,  0,  0,  0 } };
+  clusters[2] = { { 0, 0, 0, 0, 0,
+                    0, 0, 33, 0, 0,
+                    0, 0, 57, 0, 0,
+                    0, 0, 12, 0, 0,
+                    0, 0, 0, 0, 0 } };
 
   // wide cluster in both direction
-  clusters[3] = { { 0,  0,  0,  0,  0,
-                    0, 46, 71, 32,  0,
-                    0, 32,129, 16,  0,
-                    0, 19, 53, 23,  0,
-                    0,  0,  0,  0,  0 } };
-
+  clusters[3] = { { 0, 0, 0, 0, 0,
+                    0, 46, 71, 32, 0,
+                    0, 32, 129, 16, 0,
+                    0, 19, 53, 23, 0,
+                    0, 0, 0, 0, 0 } };
 
   for (int dp = 0; dp < 5; ++dp) {
     for (int dt = 0; dt < 5; ++dt) {
@@ -414,7 +410,6 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test4)
     }
   }
 
-
   std::sort(digits->begin(), digits->end(), sortTime());
 
   // Search clusters without thresholds, all 4 clusters shoud be found
@@ -422,9 +417,9 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test4)
   clusterer.setRejectSinglePadClusters(false);
   clusterer.setRejectSingleTimeClusters(false);
   clusterer.process(*digits.get(), nullptr);
-  BOOST_CHECK_EQUAL(clusterArray->size(),1);
+  BOOST_CHECK_EQUAL(clusterArray->size(), 1);
   auto clusterContainer = (*clusterArray)[0].getContainer();
-  BOOST_CHECK_EQUAL(clusterContainer->numberOfClusters,4);
+  BOOST_CHECK_EQUAL(clusterContainer->numberOfClusters, 4);
   for (int clIndex = 0; clIndex < clusterContainer->numberOfClusters; ++clIndex) {
     float qtot = std::accumulate(clusters[clIndex].begin(), clusters[clIndex].end(), 0);
     // Check QTot
@@ -457,44 +452,43 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test4)
       0.0001);
   }
 
-
   // Search clusters with threshold in pad direction, only clusters 1 and 3 should be found
   std::cout << "testing with pad threshold..." << std::endl;
   clusterer.setRejectSinglePadClusters(true);
   clusterer.setRejectSingleTimeClusters(false);
   clusterer.process(*digits.get(), nullptr);
-  BOOST_CHECK_EQUAL(clusterArray->size(),1);
+  BOOST_CHECK_EQUAL(clusterArray->size(), 1);
   clusterContainer = (*clusterArray)[0].getContainer();
-  BOOST_CHECK_EQUAL(clusterContainer->numberOfClusters,2);
+  BOOST_CHECK_EQUAL(clusterContainer->numberOfClusters, 2);
   for (int clIndex = 0; clIndex < clusterContainer->numberOfClusters; ++clIndex) {
-    float qtot = std::accumulate(clusters[clIndex*2+1].begin(), clusters[clIndex*2+1].end(), 0);
+    float qtot = std::accumulate(clusters[clIndex * 2 + 1].begin(), clusters[clIndex * 2 + 1].end(), 0);
     // Check QTot
-    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getQTot(), std::accumulate(clusters[clIndex*2+1].begin(), clusters[clIndex*2+1].end(), 0));
+    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getQTot(), std::accumulate(clusters[clIndex * 2 + 1].begin(), clusters[clIndex * 2 + 1].end(), 0));
     // Check QMax
-    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getQMax(), clusters[clIndex*2+1][12]);
+    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getQMax(), clusters[clIndex * 2 + 1][12]);
     // Check row
-    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getRow(), clIndex*2+1);
+    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getRow(), clIndex * 2 + 1);
     // Check Flags
     BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getFlags(), 0);
     // Check pad
     BOOST_CHECK_CLOSE(
       clusterContainer->clusters[clIndex].getPad(),
-      p_pre(clusters[clIndex*2+1]) / qtot + (clIndex*2+1) + 2,
+      p_pre(clusters[clIndex * 2 + 1]) / qtot + (clIndex * 2 + 1) + 2,
       0.0001);
     // Check time
     BOOST_CHECK_CLOSE(
       clusterContainer->clusters[clIndex].getTimeLocal() + clusterContainer->timeBinOffset,
-      t_pre(clusters[clIndex*2+1]) / qtot + (clIndex*2+1) * 10 + 2,
+      t_pre(clusters[clIndex * 2 + 1]) / qtot + (clIndex * 2 + 1) * 10 + 2,
       0.0001);
     // Check pad sigma
     BOOST_CHECK_CLOSE(
       clusterContainer->clusters[clIndex].getSigmaPad2(),
-      (sigma_p_pre(clusters[clIndex*2+1]) / qtot) - ((p_pre(clusters[clIndex*2+1]) * p_pre(clusters[clIndex*2+1])) / (qtot * qtot)),
+      (sigma_p_pre(clusters[clIndex * 2 + 1]) / qtot) - ((p_pre(clusters[clIndex * 2 + 1]) * p_pre(clusters[clIndex * 2 + 1])) / (qtot * qtot)),
       0.0001);
     // Check time sigma
     BOOST_CHECK_CLOSE(
       clusterContainer->clusters[clIndex].getSigmaTime2(),
-      (sigma_t_pre(clusters[clIndex*2+1]) / qtot) - ((t_pre(clusters[clIndex*2+1]) * t_pre(clusters[clIndex*2+1])) / (qtot * qtot)),
+      (sigma_t_pre(clusters[clIndex * 2 + 1]) / qtot) - ((t_pre(clusters[clIndex * 2 + 1]) * t_pre(clusters[clIndex * 2 + 1])) / (qtot * qtot)),
       0.0001);
   }
 
@@ -503,38 +497,38 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test4)
   clusterer.setRejectSinglePadClusters(false);
   clusterer.setRejectSingleTimeClusters(true);
   clusterer.process(*digits.get(), nullptr);
-  BOOST_CHECK_EQUAL(clusterArray->size(),1);
+  BOOST_CHECK_EQUAL(clusterArray->size(), 1);
   clusterContainer = (*clusterArray)[0].getContainer();
-  BOOST_CHECK_EQUAL(clusterContainer->numberOfClusters,2);
+  BOOST_CHECK_EQUAL(clusterContainer->numberOfClusters, 2);
   for (int clIndex = 0; clIndex < clusterContainer->numberOfClusters; ++clIndex) {
-    float qtot = std::accumulate(clusters[clIndex+2].begin(), clusters[clIndex+2].end(), 0);
+    float qtot = std::accumulate(clusters[clIndex + 2].begin(), clusters[clIndex + 2].end(), 0);
     // Check QTot
-    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getQTot(), std::accumulate(clusters[clIndex+2].begin(), clusters[clIndex+2].end(), 0));
+    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getQTot(), std::accumulate(clusters[clIndex + 2].begin(), clusters[clIndex + 2].end(), 0));
     // Check QMax
-    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getQMax(), clusters[clIndex+2][12]);
+    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getQMax(), clusters[clIndex + 2][12]);
     // Check row
-    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getRow(), clIndex+2);
+    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getRow(), clIndex + 2);
     // Check Flags
     BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getFlags(), 0);
     // Check pad
     BOOST_CHECK_CLOSE(
       clusterContainer->clusters[clIndex].getPad(),
-      p_pre(clusters[clIndex+2]) / qtot + (clIndex+2) + 2,
+      p_pre(clusters[clIndex + 2]) / qtot + (clIndex + 2) + 2,
       0.0001);
     // Check time
     BOOST_CHECK_CLOSE(
       clusterContainer->clusters[clIndex].getTimeLocal() + clusterContainer->timeBinOffset,
-      t_pre(clusters[clIndex+2]) / qtot + (clIndex+2) * 10 + 2,
+      t_pre(clusters[clIndex + 2]) / qtot + (clIndex + 2) * 10 + 2,
       0.0001);
     // Check pad sigma
     BOOST_CHECK_CLOSE(
       clusterContainer->clusters[clIndex].getSigmaPad2(),
-      (sigma_p_pre(clusters[clIndex+2]) / qtot) - ((p_pre(clusters[clIndex+2]) * p_pre(clusters[clIndex+2])) / (qtot * qtot)),
+      (sigma_p_pre(clusters[clIndex + 2]) / qtot) - ((p_pre(clusters[clIndex + 2]) * p_pre(clusters[clIndex + 2])) / (qtot * qtot)),
       0.0001);
     // Check time sigma
     BOOST_CHECK_CLOSE(
       clusterContainer->clusters[clIndex].getSigmaTime2(),
-      (sigma_t_pre(clusters[clIndex+2]) / qtot) - ((t_pre(clusters[clIndex+2]) * t_pre(clusters[clIndex+2])) / (qtot * qtot)),
+      (sigma_t_pre(clusters[clIndex + 2]) / qtot) - ((t_pre(clusters[clIndex + 2]) * t_pre(clusters[clIndex + 2])) / (qtot * qtot)),
       0.0001);
   }
 
@@ -543,47 +537,45 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test4)
   clusterer.setRejectSinglePadClusters(true);
   clusterer.setRejectSingleTimeClusters(true);
   clusterer.process(*digits.get(), nullptr);
-  BOOST_CHECK_EQUAL(clusterArray->size(),1);
+  BOOST_CHECK_EQUAL(clusterArray->size(), 1);
   clusterContainer = (*clusterArray)[0].getContainer();
-  BOOST_CHECK_EQUAL(clusterContainer->numberOfClusters,1);
+  BOOST_CHECK_EQUAL(clusterContainer->numberOfClusters, 1);
   for (int clIndex = 0; clIndex < clusterContainer->numberOfClusters; ++clIndex) {
-    float qtot = std::accumulate(clusters[clIndex+3].begin(), clusters[clIndex+3].end(), 0);
+    float qtot = std::accumulate(clusters[clIndex + 3].begin(), clusters[clIndex + 3].end(), 0);
     // Check QTot
-    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getQTot(), std::accumulate(clusters[clIndex+3].begin(), clusters[clIndex+3].end(), 0));
+    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getQTot(), std::accumulate(clusters[clIndex + 3].begin(), clusters[clIndex + 3].end(), 0));
     // Check QMax
-    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getQMax(), clusters[clIndex+3][12]);
+    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getQMax(), clusters[clIndex + 3][12]);
     // Check row
-    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getRow(), clIndex+3);
+    BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getRow(), clIndex + 3);
     // Check Flags
     BOOST_CHECK_EQUAL(clusterContainer->clusters[clIndex].getFlags(), 0);
     // Check pad
     BOOST_CHECK_CLOSE(
       clusterContainer->clusters[clIndex].getPad(),
-      p_pre(clusters[clIndex+3]) / qtot + (clIndex+3) + 2,
+      p_pre(clusters[clIndex + 3]) / qtot + (clIndex + 3) + 2,
       0.0001);
     // Check time
     BOOST_CHECK_CLOSE(
       clusterContainer->clusters[clIndex].getTimeLocal() + clusterContainer->timeBinOffset,
-      t_pre(clusters[clIndex+3]) / qtot + (clIndex+3) * 10 + 2,
+      t_pre(clusters[clIndex + 3]) / qtot + (clIndex + 3) * 10 + 2,
       0.0001);
     // Check pad sigma
     BOOST_CHECK_CLOSE(
       clusterContainer->clusters[clIndex].getSigmaPad2(),
-      (sigma_p_pre(clusters[clIndex+3]) / qtot) - ((p_pre(clusters[clIndex+3]) * p_pre(clusters[clIndex+3])) / (qtot * qtot)),
+      (sigma_p_pre(clusters[clIndex + 3]) / qtot) - ((p_pre(clusters[clIndex + 3]) * p_pre(clusters[clIndex + 3])) / (qtot * qtot)),
       0.0001);
     // Check time sigma
     BOOST_CHECK_CLOSE(
       clusterContainer->clusters[clIndex].getSigmaTime2(),
-      (sigma_t_pre(clusters[clIndex+3]) / qtot) - ((t_pre(clusters[clIndex+3]) * t_pre(clusters[clIndex+3])) / (qtot * qtot)),
+      (sigma_t_pre(clusters[clIndex + 3]) / qtot) - ((t_pre(clusters[clIndex + 3]) * t_pre(clusters[clIndex + 3])) / (qtot * qtot)),
       0.0001);
   }
-
 
   std::cout << "## Test 4 done." << std::endl;
   std::cout << "##" << std::endl
             << std::endl;
 }
-
 
 /// @brief Test 5 Reject peaks in subsequent timebins
 BOOST_AUTO_TEST_CASE(HwClusterer_test5)
@@ -602,18 +594,18 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test5)
   // Digit(int cru, float charge, int row, int pad, int time)
   // two peaks, with the greater one afterwards
   std::array<std::array<int, 25>, 2> clusters;
-  clusters[0] = { { 0,  0,  6,  0,  0,
-                    0,  0, 23,  0,  0,
-                    0,  0,  7,  0,  0,
-                    0,  0, 77,  0,  0,
-                    0,  0,  5,  0,  0 } };
+  clusters[0] = { { 0, 0, 6, 0, 0,
+                    0, 0, 23, 0, 0,
+                    0, 0, 7, 0, 0,
+                    0, 0, 77, 0, 0,
+                    0, 0, 5, 0, 0 } };
 
   // two peaks, with the greater one first
-  clusters[1] = { { 0,  0,  6,  0,  0,
-                    0,  0, 67,  0,  0,
-                    0,  0,  7,  0,  0,
-                    0,  0, 13,  0,  0,
-                    0,  0,  5,  0,  0 } };
+  clusters[1] = { { 0, 0, 6, 0, 0,
+                    0, 0, 67, 0, 0,
+                    0, 0, 7, 0, 0,
+                    0, 0, 13, 0, 0,
+                    0, 0, 5, 0, 0 } };
 
   for (int dp = 0; dp < 5; ++dp) {
     for (int dt = 0; dt < 5; ++dt) {
@@ -623,16 +615,15 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test5)
     }
   }
 
-
   std::sort(digits->begin(), digits->end(), sortTime());
 
   // Search clusters without rejection, all 4 clusters shoud be found
   std::cout << "testing without rejection..." << std::endl;
   clusterer.setRejectLaterTimebin(false);
   clusterer.process(*digits.get(), nullptr);
-  BOOST_CHECK_EQUAL(clusterArray->size(),1);
+  BOOST_CHECK_EQUAL(clusterArray->size(), 1);
   auto clusterContainer = (*clusterArray)[0].getContainer();
-  BOOST_CHECK_EQUAL(clusterContainer->numberOfClusters,4);
+  BOOST_CHECK_EQUAL(clusterContainer->numberOfClusters, 4);
   BOOST_CHECK_EQUAL(clusterContainer->clusters[0].getQMax(), clusters[0][7]);
   BOOST_CHECK_EQUAL(clusterContainer->clusters[1].getQMax(), clusters[0][17]);
   BOOST_CHECK_EQUAL(clusterContainer->clusters[2].getQMax(), clusters[1][7]);
@@ -642,9 +633,9 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test5)
   std::cout << "testing with with rejection..." << std::endl;
   clusterer.setRejectLaterTimebin(true);
   clusterer.process(*digits.get(), nullptr);
-  BOOST_CHECK_EQUAL(clusterArray->size(),1);
+  BOOST_CHECK_EQUAL(clusterArray->size(), 1);
   clusterContainer = (*clusterArray)[0].getContainer();
-  BOOST_CHECK_EQUAL(clusterContainer->numberOfClusters,3);
+  BOOST_CHECK_EQUAL(clusterContainer->numberOfClusters, 3);
   BOOST_CHECK_EQUAL(clusterContainer->clusters[0].getQMax(), clusters[0][7]);
   BOOST_CHECK_EQUAL(clusterContainer->clusters[1].getQMax(), clusters[0][17]);
   BOOST_CHECK_EQUAL(clusterContainer->clusters[2].getQMax(), clusters[1][7]);
@@ -653,7 +644,6 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test5)
   std::cout << "##" << std::endl
             << std::endl;
 }
-
 
 /// @brief Test 6 Split charge among nearby clusters
 BOOST_AUTO_TEST_CASE(HwClusterer_test6)
@@ -672,230 +662,219 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test6)
   // Digit(int cru, float charge, int row, int pad, int time)
   std::array<std::array<int, 100>, 6> clusters;
   // Just a single cluster
-  clusters[0] = { { 0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
-                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
-                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
-                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
-                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
-
-                    4,  9, 12,  6,  1,    0,  0,  0,  0,  0,
-                    8, 17, 25, 18,  5,    0,  0,  0,  0,  0,
-                   13, 22, 50, 28, 14,    0,  0,  0,  0,  0,
-                    9, 16, 27, 19,  7,    0,  0,  0,  0,  0,
-                    2,  7, 11,  6,  3,    0,  0,  0,  0,  0 } };
+  clusters[0] = { { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    4, 9, 12, 6, 1, 0, 0, 0, 0, 0,
+                    8, 17, 25, 18, 5, 0, 0, 0, 0, 0,
+                    13, 22, 50, 28, 14, 0, 0, 0, 0, 0,
+                    9, 16, 27, 19, 7, 0, 0, 0, 0, 0,
+                    2, 7, 11, 6, 3, 0, 0, 0, 0, 0 } };
 
   // Two clusters next to each other in pad direction, peaks well separated
-  clusters[1] = { { 0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
-                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
-                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
-                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
-                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
-
-                    4,  9, 12,  6,  1,    4,  9, 12,  6,  1,
-                    8, 17, 25, 18,  5,    8, 17, 25, 18,  5,
-                   13, 22, 51, 28, 14,   13, 22, 52, 28, 15,
-                    9, 16, 27, 19,  7,    9, 16, 27, 19,  7,
-                    2,  7, 11,  6,  3,    2,  7, 11,  6,  3} };
+  clusters[1] = { { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    4, 9, 12, 6, 1, 4, 9, 12, 6, 1,
+                    8, 17, 25, 18, 5, 8, 17, 25, 18, 5,
+                    13, 22, 51, 28, 14, 13, 22, 52, 28, 15,
+                    9, 16, 27, 19, 7, 9, 16, 27, 19, 7,
+                    2, 7, 11, 6, 3, 2, 7, 11, 6, 3 } };
 
   // Two clusters next to each other in pad direction, peaks 4 pads appart
-  clusters[2] = { { 0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
-                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
-                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
-                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
-                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
-
-                    4,  9, 12,  6,  1,    9, 12,  6,  1,  0,
-                    8, 17, 25, 18,  5,   17, 25, 18,  5,  0,
-                   13, 22, 53, 28, 14,   22, 54, 28, 15,  0,
-                    9, 16, 27, 19,  7,   16, 27, 19,  7,  0,
-                    2,  7, 11,  6,  3,    7, 11,  6,  3,  0} };
+  clusters[2] = { { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    4, 9, 12, 6, 1, 9, 12, 6, 1, 0,
+                    8, 17, 25, 18, 5, 17, 25, 18, 5, 0,
+                    13, 22, 53, 28, 14, 22, 54, 28, 15, 0,
+                    9, 16, 27, 19, 7, 16, 27, 19, 7, 0,
+                    2, 7, 11, 6, 3, 7, 11, 6, 3, 0 } };
 
   // Two clusters next to each other in pad direction, peaks 3 pads appartd
-  clusters[3] = { { 0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
-                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
-                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
-                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
-                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
-
-                    0,  4,  9, 12,  6,    9, 12,  6,  1,  0,
-                    0,  8, 17, 25, 18,   17, 25, 18,  5,  0,
-                    0, 13, 22, 55, 28,   22, 56, 28, 15,  0,
-                    0,  9, 16, 27, 19,   16, 27, 19,  7,  0,
-                    0,  2,  7, 11,  6,    7, 11,  6,  3,  0} };
+  clusters[3] = { { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 4, 9, 12, 6, 9, 12, 6, 1, 0,
+                    0, 8, 17, 25, 18, 17, 25, 18, 5, 0,
+                    0, 13, 22, 55, 28, 22, 56, 28, 15, 0,
+                    0, 9, 16, 27, 19, 16, 27, 19, 7, 0,
+                    0, 2, 7, 11, 6, 7, 11, 6, 3, 0 } };
 
   // Two clusters next to each other in pad direction, peaks 2 pads appartd
-  clusters[4] = { { 0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
-                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
-                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
-                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
-                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
-
-                    0,  4,  9, 12,  6,   12,  6,  1,  0,  0,
-                    0,  8, 17, 25, 18,   25, 18,  5,  0,  0,
-                    0, 13, 22, 57, 28,   58, 28, 15,  0,  0,
-                    0,  9, 16, 27, 19,   27, 19,  7,  0,  0,
-                    0,  2,  7, 11,  6,   11,  6,  3,  0,  0} };
+  clusters[4] = { { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 4, 9, 12, 6, 12, 6, 1, 0, 0,
+                    0, 8, 17, 25, 18, 25, 18, 5, 0, 0,
+                    0, 13, 22, 57, 28, 58, 28, 15, 0, 0,
+                    0, 9, 16, 27, 19, 27, 19, 7, 0, 0,
+                    0, 2, 7, 11, 6, 11, 6, 3, 0, 0 } };
 
   // Two clusters next to each other in diagonal direction
-  clusters[5] = { { 0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
-                    0,  0,  0,  0,  0,    0,  0,  0,  0,  0,
-                    0,  0,  0,  0,  4,    9, 12,  6,  1,  0,
-                    0,  0,  0,  0,  8,   17, 25, 18,  5,  0,
-                    0,  0,  0,  0, 13,   22, 59, 28, 15,  0,
-
-                    4,  9, 12,  6,  9,   16, 27, 19,  7,  0,
-                    8, 17, 25, 18,  2,    7, 11,  6,  3,  0,
-                   13, 22, 60, 28, 14,    0,  0,  0,  0,  0,
-                    9, 16, 27, 19,  7,    0,  0,  0,  0,  0,
-                    2,  7, 11,  6,  3,    0,  0,  0,  0,  0} };
-
-
+  clusters[5] = { { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 4, 9, 12, 6, 1, 0,
+                    0, 0, 0, 0, 8, 17, 25, 18, 5, 0,
+                    0, 0, 0, 0, 13, 22, 59, 28, 15, 0,
+                    4, 9, 12, 6, 9, 16, 27, 19, 7, 0,
+                    8, 17, 25, 18, 2, 7, 11, 6, 3, 0,
+                    13, 22, 60, 28, 14, 0, 0, 0, 0, 0,
+                    9, 16, 27, 19, 7, 0, 0, 0, 0, 0,
+                    2, 7, 11, 6, 3, 0, 0, 0, 0, 0 } };
 
   std::array<std::array<float, 25>, 11> clustersMode0;
-  clustersMode0[0] = { { 4,  9, 12,  6,  1,
-                         8, 17, 25, 18,  5,
-                        13, 22, 50, 28, 14,
-                         9, 16, 27, 19,  7,
-                         2,  7, 11,  6,  3} };
+  clustersMode0[0] = { { 4, 9, 12, 6, 1,
+                         8, 17, 25, 18, 5,
+                         13, 22, 50, 28, 14,
+                         9, 16, 27, 19, 7,
+                         2, 7, 11, 6, 3 } };
 
-  clustersMode0[1] = { { 4,  9, 12,  6,  1,
-                         8, 17, 25, 18,  5,
-                        13, 22, 51, 28, 14,
-                         9, 16, 27, 19,  7,
-                         2,  7, 11,  6,  3} };
+  clustersMode0[1] = { { 4, 9, 12, 6, 1,
+                         8, 17, 25, 18, 5,
+                         13, 22, 51, 28, 14,
+                         9, 16, 27, 19, 7,
+                         2, 7, 11, 6, 3 } };
 
-  clustersMode0[2] = { { 4,  9, 12,  6,  1,
-                         8, 17, 25, 18,  5,
-                        13, 22, 52, 28, 15,
-                         9, 16, 27, 19,  7,
-                         2,  7, 11,  6,  3} };
+  clustersMode0[2] = { { 4, 9, 12, 6, 1,
+                         8, 17, 25, 18, 5,
+                         13, 22, 52, 28, 15,
+                         9, 16, 27, 19, 7,
+                         2, 7, 11, 6, 3 } };
 
-  clustersMode0[3] = { { 4,  9, 12,  6,  1,
-                         8, 17, 25, 18,  5,
-                        13, 22, 53, 28, 14,
-                         9, 16, 27, 19,  7,
-                         2,  7, 11,  6,  3} };
+  clustersMode0[3] = { { 4, 9, 12, 6, 1,
+                         8, 17, 25, 18, 5,
+                         13, 22, 53, 28, 14,
+                         9, 16, 27, 19, 7,
+                         2, 7, 11, 6, 3 } };
 
-  clustersMode0[4] = { { 1,  9, 12,  6,  1,
-                         5, 17, 25, 18,  5,
-                        14, 22, 54, 28, 15,
-                         7, 16, 27, 19,  7,
-                         3,  7, 11,  6,  3} };
+  clustersMode0[4] = { { 1, 9, 12, 6, 1,
+                         5, 17, 25, 18, 5,
+                         14, 22, 54, 28, 15,
+                         7, 16, 27, 19, 7,
+                         3, 7, 11, 6, 3 } };
 
-  clustersMode0[5] = { { 4,  9, 12,  6,  9,
+  clustersMode0[5] = { { 4, 9, 12, 6, 9,
                          8, 17, 25, 18, 17,
-                        13, 22, 55, 28, 22,
+                         13, 22, 55, 28, 22,
                          9, 16, 27, 19, 16,
-                         2,  7, 11,  6,  7} };
+                         2, 7, 11, 6, 7 } };
 
-  clustersMode0[6] = { { 6,  9, 12,  6,  1,
-                        18, 17, 25, 18,  5,
-                        28, 22, 56, 28, 15,
-                        19, 16, 27, 19,  7,
-                         6,  7, 11,  6,  3} };
+  clustersMode0[6] = { { 6, 9, 12, 6, 1,
+                         18, 17, 25, 18, 5,
+                         28, 22, 56, 28, 15,
+                         19, 16, 27, 19, 7,
+                         6, 7, 11, 6, 3 } };
 
-  clustersMode0[7] = { { 4,  9, 12,  6, 12,
+  clustersMode0[7] = { { 4, 9, 12, 6, 12,
                          8, 17, 25, 18, 25,
-                        13, 22, 57, 28, 58,
+                         13, 22, 57, 28, 58,
                          9, 16, 27, 19, 27,
-                         2,  7, 11,  6, 11} };
+                         2, 7, 11, 6, 11 } };
 
-  clustersMode0[8] = { {12,  6, 12,  6,  1,
-                        25, 18, 25, 18,  5,
-                        57, 28, 58, 28, 15,
-                        27, 19, 27, 19,  7,
-                        11,  6, 11,  6,  3} };
+  clustersMode0[8] = { { 12, 6, 12, 6, 1,
+                         25, 18, 25, 18, 5,
+                         57, 28, 58, 28, 15,
+                         27, 19, 27, 19, 7,
+                         11, 6, 11, 6, 3 } };
 
-  clustersMode0[9] = { { 4,  9, 12,  6,  1,
-                         8, 17, 25, 18,  5,
-                        13, 22, 59, 28, 15,
-                         9, 16, 27, 19,  7,
-                         2,  7, 11,  6,  3} };
+  clustersMode0[9] = { { 4, 9, 12, 6, 1,
+                         8, 17, 25, 18, 5,
+                         13, 22, 59, 28, 15,
+                         9, 16, 27, 19, 7,
+                         2, 7, 11, 6, 3 } };
 
-
-  clustersMode0[10] = { { 4,  9, 12,  6,  9,
-                          8, 17, 25, 18,  2,
-                         13, 22, 60, 28, 14,
-                          9, 16, 27, 19,  7,
-                          2,  7, 11,  6,  3} };
+  clustersMode0[10] = { { 4, 9, 12, 6, 9,
+                          8, 17, 25, 18, 2,
+                          13, 22, 60, 28, 14,
+                          9, 16, 27, 19, 7,
+                          2, 7, 11, 6, 3 } };
 
   std::array<std::array<float, 25>, 11> clustersMode1;
-  clustersMode1[0] = { { 4,  9, 12,  6,  1,
-                         8, 17, 25, 18,  5,
-                        13, 22, 50, 28, 14,
-                         9, 16, 27, 19,  7,
-                         2,  7, 11,  6,  3} };
+  clustersMode1[0] = { { 4, 9, 12, 6, 1,
+                         8, 17, 25, 18, 5,
+                         13, 22, 50, 28, 14,
+                         9, 16, 27, 19, 7,
+                         2, 7, 11, 6, 3 } };
 
-  clustersMode1[1] = { { 4,  9, 12,  6,  0.5,
-                         8, 17, 25, 18,  2.5,
-                        13, 22, 51, 28, 14,
-                         9, 16, 27, 19,  3.5,
-                         2,  7, 11,  6,  3} };
+  clustersMode1[1] = { { 4, 9, 12, 6, 0.5,
+                         8, 17, 25, 18, 2.5,
+                         13, 22, 51, 28, 14,
+                         9, 16, 27, 19, 3.5,
+                         2, 7, 11, 6, 3 } };
 
-  clustersMode1[2] = { { 4,  9, 12,  6,  1,
-                         8, 17, 25, 18,  5,
-                        6.5, 22, 52, 28, 15,
-                         9, 16, 27, 19,  7,
-                         1,  7, 11,  6,  3} };
+  clustersMode1[2] = { { 4, 9, 12, 6, 1,
+                         8, 17, 25, 18, 5,
+                         6.5, 22, 52, 28, 15,
+                         9, 16, 27, 19, 7,
+                         1, 7, 11, 6, 3 } };
 
-  clustersMode1[3] = { { 4,  9, 12,  6,  0.5,
-                         8, 17, 25, 18,  2.5,
-                        13, 22, 53, 28,  7,
-                         9, 16, 27, 19,  3.5,
-                         2,  7, 11,  6,  1.5} };
+  clustersMode1[3] = { { 4, 9, 12, 6, 0.5,
+                         8, 17, 25, 18, 2.5,
+                         13, 22, 53, 28, 7,
+                         9, 16, 27, 19, 3.5,
+                         2, 7, 11, 6, 1.5 } };
 
-  clustersMode1[4] = { { 0.5,  9, 12,  6,  1,
-                         2.5, 17, 25, 18,  5,
-                         7  , 22, 54, 28, 15,
-                         3.5, 16, 27, 19,  7,
-                         1.5,  7, 11,  6,  3} };
+  clustersMode1[4] = { { 0.5, 9, 12, 6, 1,
+                         2.5, 17, 25, 18, 5,
+                         7, 22, 54, 28, 15,
+                         3.5, 16, 27, 19, 7,
+                         1.5, 7, 11, 6, 3 } };
 
-  clustersMode1[5] = { { 4,  9, 12,  6,  0,
-                         8, 17, 25, 18,8.5,
-                        13, 22, 55, 28, 11,
-                         9, 16, 27, 19,  8,
-                         2,  7, 11,  6,  0} };
+  clustersMode1[5] = { { 4, 9, 12, 6, 0,
+                         8, 17, 25, 18, 8.5,
+                         13, 22, 55, 28, 11,
+                         9, 16, 27, 19, 8,
+                         2, 7, 11, 6, 0 } };
 
-  clustersMode1[6] = { {  0,  9, 12,  6,  1,
-                          0,8.5, 25, 18,  5,
-                          0, 11, 56, 28, 15,
-                          0,  8, 27, 19,  7,
-                          0,  7, 11,  6,  3} };
+  clustersMode1[6] = { { 0, 9, 12, 6, 1,
+                         0, 8.5, 25, 18, 5,
+                         0, 11, 56, 28, 15,
+                         0, 8, 27, 19, 7,
+                         0, 7, 11, 6, 3 } };
 
-  clustersMode1[7] = { { 4,  9, 12,  6,  0,
-                         8, 17, 25,  9,  0,
-                        13, 22, 57, 14,  0,
-                         9, 16, 27,9.5,  0,
-                         2,  7, 11,  6,  0} };
+  clustersMode1[7] = { { 4, 9, 12, 6, 0,
+                         8, 17, 25, 9, 0,
+                         13, 22, 57, 14, 0,
+                         9, 16, 27, 9.5, 0,
+                         2, 7, 11, 6, 0 } };
 
-  clustersMode1[8] = { { 0,  6, 12,  6,  1,
-                         0,  9, 25, 18,  5,
+  clustersMode1[8] = { { 0, 6, 12, 6, 1,
+                         0, 9, 25, 18, 5,
                          0, 14, 58, 28, 15,
-                         0,9.5, 27, 19,  7,
-                         0,  6, 11,  6,  3} };
+                         0, 9.5, 27, 19, 7,
+                         0, 6, 11, 6, 3 } };
 
-  clustersMode1[9] = { { 4,  9, 12,  6,  1,
-                         8, 17, 25, 18,  5,
-                        13, 22, 59, 28, 15,
-                       4.5, 16, 27, 19,  7,
-                         1,3.5, 11,  6,  3} };
+  clustersMode1[9] = { { 4, 9, 12, 6, 1,
+                         8, 17, 25, 18, 5,
+                         13, 22, 59, 28, 15,
+                         4.5, 16, 27, 19, 7,
+                         1, 3.5, 11, 6, 3 } };
 
-  clustersMode1[10] = { { 4,  9, 12,  3,  0,
-                          8, 17, 25, 18,  1,
-                         13, 22, 60, 28, 14,
-                          9, 16, 27, 19,  7,
-                          2,  7, 11,  6,  3} };
-
+  clustersMode1[10] = { { 4, 9, 12, 3, 0,
+                          8, 17, 25, 18, 1,
+                          13, 22, 60, 28, 14,
+                          9, 16, 27, 19, 7,
+                          2, 7, 11, 6, 3 } };
 
   for (int cl = 0; cl < clusters.size(); ++cl) {
     for (int dt = 0; dt < 10; ++dt) {
       for (int dp = 0; dp < 10; ++dp) {
         // Digit(int cru, float charge, int row, int pad, int time)
-        digits->emplace_back(0, clusters[cl][dt * 10 + dp], cl, dp, dt+20*cl);
+        digits->emplace_back(0, clusters[cl][dt * 10 + dp], cl, dp, dt + 20 * cl);
       }
     }
   }
-
 
   std::sort(digits->begin(), digits->end(), sortTime());
 
@@ -903,30 +882,30 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test6)
 
   std::vector<ClusterHardware> clustersToCompare;
   clustersToCompare.emplace_back();
-  clustersToCompare.back().setCluster(2,7, p_pre_fp(clustersMode0[0]), t_pre_fp(clustersMode0[0]), sigma_p_pre_fp(clustersMode0[0]), sigma_t_pre_fp(clustersMode0[0]), (clustersMode0[0][12]*2), (std::accumulate(clustersMode0[0].begin(), clustersMode0[0].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.back().setCluster(2, 7, p_pre_fp(clustersMode0[0]), t_pre_fp(clustersMode0[0]), sigma_p_pre_fp(clustersMode0[0]), sigma_t_pre_fp(clustersMode0[0]), (clustersMode0[0][12] * 2), (std::accumulate(clustersMode0[0].begin(), clustersMode0[0].end(), 0.0) * 16), 0, 0);
   clustersToCompare.emplace_back();
-  clustersToCompare.back().setCluster(2,7+20, p_pre_fp(clustersMode0[1]), t_pre_fp(clustersMode0[1]), sigma_p_pre_fp(clustersMode0[1]), sigma_t_pre_fp(clustersMode0[1]), (clustersMode0[1][12]*2), (std::accumulate(clustersMode0[1].begin(), clustersMode0[1].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.back().setCluster(2, 7 + 20, p_pre_fp(clustersMode0[1]), t_pre_fp(clustersMode0[1]), sigma_p_pre_fp(clustersMode0[1]), sigma_t_pre_fp(clustersMode0[1]), (clustersMode0[1][12] * 2), (std::accumulate(clustersMode0[1].begin(), clustersMode0[1].end(), 0.0) * 16), 0, 0);
   clustersToCompare.emplace_back();
-  clustersToCompare.back().setCluster(2+5,7+20, p_pre_fp(clustersMode0[2]), t_pre_fp(clustersMode0[2]), sigma_p_pre_fp(clustersMode0[2]), sigma_t_pre_fp(clustersMode0[2]), (clustersMode0[2][12]*2), (std::accumulate(clustersMode0[2].begin(), clustersMode0[2].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.back().setCluster(2 + 5, 7 + 20, p_pre_fp(clustersMode0[2]), t_pre_fp(clustersMode0[2]), sigma_p_pre_fp(clustersMode0[2]), sigma_t_pre_fp(clustersMode0[2]), (clustersMode0[2][12] * 2), (std::accumulate(clustersMode0[2].begin(), clustersMode0[2].end(), 0.0) * 16), 0, 0);
   clustersToCompare.emplace_back();
-  clustersToCompare.back().setCluster(2,7+40, p_pre_fp(clustersMode0[3]), t_pre_fp(clustersMode0[3]), sigma_p_pre_fp(clustersMode0[3]), sigma_t_pre_fp(clustersMode0[3]), (clustersMode0[3][12]*2), (std::accumulate(clustersMode0[3].begin(), clustersMode0[3].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.back().setCluster(2, 7 + 40, p_pre_fp(clustersMode0[3]), t_pre_fp(clustersMode0[3]), sigma_p_pre_fp(clustersMode0[3]), sigma_t_pre_fp(clustersMode0[3]), (clustersMode0[3][12] * 2), (std::accumulate(clustersMode0[3].begin(), clustersMode0[3].end(), 0.0) * 16), 0, 0);
   clustersToCompare.emplace_back();
-  clustersToCompare.back().setCluster(2+4,7+40, p_pre_fp(clustersMode0[4]), t_pre_fp(clustersMode0[4]), sigma_p_pre_fp(clustersMode0[4]), sigma_t_pre_fp(clustersMode0[4]), (clustersMode0[4][12]*2), (std::accumulate(clustersMode0[4].begin(), clustersMode0[4].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.back().setCluster(2 + 4, 7 + 40, p_pre_fp(clustersMode0[4]), t_pre_fp(clustersMode0[4]), sigma_p_pre_fp(clustersMode0[4]), sigma_t_pre_fp(clustersMode0[4]), (clustersMode0[4][12] * 2), (std::accumulate(clustersMode0[4].begin(), clustersMode0[4].end(), 0.0) * 16), 0, 0);
   clustersToCompare.emplace_back();
-  clustersToCompare.back().setCluster(2+1,7+60, p_pre_fp(clustersMode0[5]), t_pre_fp(clustersMode0[5]), sigma_p_pre_fp(clustersMode0[5]), sigma_t_pre_fp(clustersMode0[5]), (clustersMode0[5][12]*2), (std::accumulate(clustersMode0[5].begin(), clustersMode0[5].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.back().setCluster(2 + 1, 7 + 60, p_pre_fp(clustersMode0[5]), t_pre_fp(clustersMode0[5]), sigma_p_pre_fp(clustersMode0[5]), sigma_t_pre_fp(clustersMode0[5]), (clustersMode0[5][12] * 2), (std::accumulate(clustersMode0[5].begin(), clustersMode0[5].end(), 0.0) * 16), 0, 0);
   clustersToCompare.emplace_back();
-  clustersToCompare.back().setCluster(2+4,7+60, p_pre_fp(clustersMode0[6]), t_pre_fp(clustersMode0[6]), sigma_p_pre_fp(clustersMode0[6]), sigma_t_pre_fp(clustersMode0[6]), (clustersMode0[6][12]*2), (std::accumulate(clustersMode0[6].begin(), clustersMode0[6].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.back().setCluster(2 + 4, 7 + 60, p_pre_fp(clustersMode0[6]), t_pre_fp(clustersMode0[6]), sigma_p_pre_fp(clustersMode0[6]), sigma_t_pre_fp(clustersMode0[6]), (clustersMode0[6][12] * 2), (std::accumulate(clustersMode0[6].begin(), clustersMode0[6].end(), 0.0) * 16), 0, 0);
   clustersToCompare.emplace_back();
-  clustersToCompare.back().setCluster(2+1,7+80, p_pre_fp(clustersMode0[7]), t_pre_fp(clustersMode0[7]), sigma_p_pre_fp(clustersMode0[7]), sigma_t_pre_fp(clustersMode0[7]), (clustersMode0[7][12]*2), (std::accumulate(clustersMode0[7].begin(), clustersMode0[7].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.back().setCluster(2 + 1, 7 + 80, p_pre_fp(clustersMode0[7]), t_pre_fp(clustersMode0[7]), sigma_p_pre_fp(clustersMode0[7]), sigma_t_pre_fp(clustersMode0[7]), (clustersMode0[7][12] * 2), (std::accumulate(clustersMode0[7].begin(), clustersMode0[7].end(), 0.0) * 16), 0, 0);
   clustersToCompare.emplace_back();
-  clustersToCompare.back().setCluster(2+3,7+80, p_pre_fp(clustersMode0[8]), t_pre_fp(clustersMode0[8]), sigma_p_pre_fp(clustersMode0[8]), sigma_t_pre_fp(clustersMode0[8]), (clustersMode0[8][12]*2), (std::accumulate(clustersMode0[8].begin(), clustersMode0[8].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.back().setCluster(2 + 3, 7 + 80, p_pre_fp(clustersMode0[8]), t_pre_fp(clustersMode0[8]), sigma_p_pre_fp(clustersMode0[8]), sigma_t_pre_fp(clustersMode0[8]), (clustersMode0[8][12] * 2), (std::accumulate(clustersMode0[8].begin(), clustersMode0[8].end(), 0.0) * 16), 0, 0);
   clustersToCompare.emplace_back();
-  clustersToCompare.back().setCluster(2+4,7+97, p_pre_fp(clustersMode0[9]), t_pre_fp(clustersMode0[9]), sigma_p_pre_fp(clustersMode0[9]), sigma_t_pre_fp(clustersMode0[9]), (clustersMode0[9][12]*2), (std::accumulate(clustersMode0[9].begin(), clustersMode0[9].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.back().setCluster(2 + 4, 7 + 97, p_pre_fp(clustersMode0[9]), t_pre_fp(clustersMode0[9]), sigma_p_pre_fp(clustersMode0[9]), sigma_t_pre_fp(clustersMode0[9]), (clustersMode0[9][12] * 2), (std::accumulate(clustersMode0[9].begin(), clustersMode0[9].end(), 0.0) * 16), 0, 0);
   clustersToCompare.emplace_back();
-  clustersToCompare.back().setCluster(2,7+100, p_pre_fp(clustersMode0[10]), t_pre_fp(clustersMode0[10]), sigma_p_pre_fp(clustersMode0[10]), sigma_t_pre_fp(clustersMode0[10]), (clustersMode0[10][12]*2), (std::accumulate(clustersMode0[10].begin(), clustersMode0[10].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.back().setCluster(2, 7 + 100, p_pre_fp(clustersMode0[10]), t_pre_fp(clustersMode0[10]), sigma_p_pre_fp(clustersMode0[10]), sigma_t_pre_fp(clustersMode0[10]), (clustersMode0[10][12] * 2), (std::accumulate(clustersMode0[10].begin(), clustersMode0[10].end(), 0.0) * 16), 0, 0);
   clusterer.setSplittingMode(0);
   clusterer.process(*digits.get(), nullptr);
-  BOOST_CHECK_EQUAL(clusterArray->size(),1);
+  BOOST_CHECK_EQUAL(clusterArray->size(), 1);
   auto clusterContainer = (*clusterArray)[0].getContainer();
   BOOST_CHECK_EQUAL(clusterContainer->numberOfClusters, 11);
   for (int clIndex = 0; clIndex < clusterContainer->numberOfClusters; ++clIndex) {
@@ -958,34 +937,33 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test6)
       0.0001);
   }
 
-
   std::cout << "testing splitting mode 1..." << std::endl;
   clustersToCompare.clear();
   clustersToCompare.emplace_back();
-  clustersToCompare.back().setCluster(2,7, p_pre_fp(clustersMode1[0]), t_pre_fp(clustersMode1[0]), sigma_p_pre_fp(clustersMode1[0]), sigma_t_pre_fp(clustersMode1[0]), (clustersMode1[0][12]*2), (std::accumulate(clustersMode1[0].begin(), clustersMode1[0].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.back().setCluster(2, 7, p_pre_fp(clustersMode1[0]), t_pre_fp(clustersMode1[0]), sigma_p_pre_fp(clustersMode1[0]), sigma_t_pre_fp(clustersMode1[0]), (clustersMode1[0][12] * 2), (std::accumulate(clustersMode1[0].begin(), clustersMode1[0].end(), 0.0) * 16), 0, 0);
   clustersToCompare.emplace_back();
-  clustersToCompare.back().setCluster(2,7+20, p_pre_fp(clustersMode1[1]), t_pre_fp(clustersMode1[1]), sigma_p_pre_fp(clustersMode1[1]), sigma_t_pre_fp(clustersMode1[1]), (clustersMode1[1][12]*2), (std::accumulate(clustersMode1[1].begin(), clustersMode1[1].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.back().setCluster(2, 7 + 20, p_pre_fp(clustersMode1[1]), t_pre_fp(clustersMode1[1]), sigma_p_pre_fp(clustersMode1[1]), sigma_t_pre_fp(clustersMode1[1]), (clustersMode1[1][12] * 2), (std::accumulate(clustersMode1[1].begin(), clustersMode1[1].end(), 0.0) * 16), 0, 0);
   clustersToCompare.emplace_back();
-  clustersToCompare.back().setCluster(2+5,7+20, p_pre_fp(clustersMode1[2]), t_pre_fp(clustersMode1[2]), sigma_p_pre_fp(clustersMode1[2]), sigma_t_pre_fp(clustersMode1[2]), (clustersMode1[2][12]*2), (std::accumulate(clustersMode1[2].begin(), clustersMode1[2].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.back().setCluster(2 + 5, 7 + 20, p_pre_fp(clustersMode1[2]), t_pre_fp(clustersMode1[2]), sigma_p_pre_fp(clustersMode1[2]), sigma_t_pre_fp(clustersMode1[2]), (clustersMode1[2][12] * 2), (std::accumulate(clustersMode1[2].begin(), clustersMode1[2].end(), 0.0) * 16), 0, 0);
   clustersToCompare.emplace_back();
-  clustersToCompare.back().setCluster(2,7+40, p_pre_fp(clustersMode1[3]), t_pre_fp(clustersMode1[3]), sigma_p_pre_fp(clustersMode1[3]), sigma_t_pre_fp(clustersMode1[3]), (clustersMode1[3][12]*2), (std::accumulate(clustersMode1[3].begin(), clustersMode1[3].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.back().setCluster(2, 7 + 40, p_pre_fp(clustersMode1[3]), t_pre_fp(clustersMode1[3]), sigma_p_pre_fp(clustersMode1[3]), sigma_t_pre_fp(clustersMode1[3]), (clustersMode1[3][12] * 2), (std::accumulate(clustersMode1[3].begin(), clustersMode1[3].end(), 0.0) * 16), 0, 0);
   clustersToCompare.emplace_back();
-  clustersToCompare.back().setCluster(2+4,7+40, p_pre_fp(clustersMode1[4]), t_pre_fp(clustersMode1[4]), sigma_p_pre_fp(clustersMode1[4]), sigma_t_pre_fp(clustersMode1[4]), (clustersMode1[4][12]*2), (std::accumulate(clustersMode1[4].begin(), clustersMode1[4].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.back().setCluster(2 + 4, 7 + 40, p_pre_fp(clustersMode1[4]), t_pre_fp(clustersMode1[4]), sigma_p_pre_fp(clustersMode1[4]), sigma_t_pre_fp(clustersMode1[4]), (clustersMode1[4][12] * 2), (std::accumulate(clustersMode1[4].begin(), clustersMode1[4].end(), 0.0) * 16), 0, 0);
   clustersToCompare.emplace_back();
-  clustersToCompare.back().setCluster(2+1,7+60, p_pre_fp(clustersMode1[5]), t_pre_fp(clustersMode1[5]), sigma_p_pre_fp(clustersMode1[5]), sigma_t_pre_fp(clustersMode1[5]), (clustersMode1[5][12]*2), (std::accumulate(clustersMode1[5].begin(), clustersMode1[5].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.back().setCluster(2 + 1, 7 + 60, p_pre_fp(clustersMode1[5]), t_pre_fp(clustersMode1[5]), sigma_p_pre_fp(clustersMode1[5]), sigma_t_pre_fp(clustersMode1[5]), (clustersMode1[5][12] * 2), (std::accumulate(clustersMode1[5].begin(), clustersMode1[5].end(), 0.0) * 16), 0, 0);
   clustersToCompare.emplace_back();
-  clustersToCompare.back().setCluster(2+4,7+60, p_pre_fp(clustersMode1[6]), t_pre_fp(clustersMode1[6]), sigma_p_pre_fp(clustersMode1[6]), sigma_t_pre_fp(clustersMode1[6]), (clustersMode1[6][12]*2), (std::accumulate(clustersMode1[6].begin(), clustersMode1[6].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.back().setCluster(2 + 4, 7 + 60, p_pre_fp(clustersMode1[6]), t_pre_fp(clustersMode1[6]), sigma_p_pre_fp(clustersMode1[6]), sigma_t_pre_fp(clustersMode1[6]), (clustersMode1[6][12] * 2), (std::accumulate(clustersMode1[6].begin(), clustersMode1[6].end(), 0.0) * 16), 0, 0);
   clustersToCompare.emplace_back();
-  clustersToCompare.back().setCluster(2+1,7+80, p_pre_fp(clustersMode1[7]), t_pre_fp(clustersMode1[7]), sigma_p_pre_fp(clustersMode1[7]), sigma_t_pre_fp(clustersMode1[7]), (clustersMode1[7][12]*2), (std::accumulate(clustersMode1[7].begin(), clustersMode1[7].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.back().setCluster(2 + 1, 7 + 80, p_pre_fp(clustersMode1[7]), t_pre_fp(clustersMode1[7]), sigma_p_pre_fp(clustersMode1[7]), sigma_t_pre_fp(clustersMode1[7]), (clustersMode1[7][12] * 2), (std::accumulate(clustersMode1[7].begin(), clustersMode1[7].end(), 0.0) * 16), 0, 0);
   clustersToCompare.emplace_back();
-  clustersToCompare.back().setCluster(2+3,7+80, p_pre_fp(clustersMode1[8]), t_pre_fp(clustersMode1[8]), sigma_p_pre_fp(clustersMode1[8]), sigma_t_pre_fp(clustersMode1[8]), (clustersMode1[8][12]*2), (std::accumulate(clustersMode1[8].begin(), clustersMode1[8].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.back().setCluster(2 + 3, 7 + 80, p_pre_fp(clustersMode1[8]), t_pre_fp(clustersMode1[8]), sigma_p_pre_fp(clustersMode1[8]), sigma_t_pre_fp(clustersMode1[8]), (clustersMode1[8][12] * 2), (std::accumulate(clustersMode1[8].begin(), clustersMode1[8].end(), 0.0) * 16), 0, 0);
   clustersToCompare.emplace_back();
-  clustersToCompare.back().setCluster(2+4,7+97, p_pre_fp(clustersMode1[9]), t_pre_fp(clustersMode1[9]), sigma_p_pre_fp(clustersMode1[9]), sigma_t_pre_fp(clustersMode1[9]), (clustersMode1[9][12]*2), (std::accumulate(clustersMode1[9].begin(), clustersMode1[9].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.back().setCluster(2 + 4, 7 + 97, p_pre_fp(clustersMode1[9]), t_pre_fp(clustersMode1[9]), sigma_p_pre_fp(clustersMode1[9]), sigma_t_pre_fp(clustersMode1[9]), (clustersMode1[9][12] * 2), (std::accumulate(clustersMode1[9].begin(), clustersMode1[9].end(), 0.0) * 16), 0, 0);
   clustersToCompare.emplace_back();
-  clustersToCompare.back().setCluster(2,7+100, p_pre_fp(clustersMode1[10]), t_pre_fp(clustersMode1[10]), sigma_p_pre_fp(clustersMode1[10]), sigma_t_pre_fp(clustersMode1[10]), (clustersMode1[10][12]*2), (std::accumulate(clustersMode1[10].begin(), clustersMode1[10].end(), 0.0) * 16), 0, 0);
+  clustersToCompare.back().setCluster(2, 7 + 100, p_pre_fp(clustersMode1[10]), t_pre_fp(clustersMode1[10]), sigma_p_pre_fp(clustersMode1[10]), sigma_t_pre_fp(clustersMode1[10]), (clustersMode1[10][12] * 2), (std::accumulate(clustersMode1[10].begin(), clustersMode1[10].end(), 0.0) * 16), 0, 0);
   clusterer.setSplittingMode(1);
   clusterer.process(*digits.get(), nullptr);
-  BOOST_CHECK_EQUAL(clusterArray->size(),1);
+  BOOST_CHECK_EQUAL(clusterArray->size(), 1);
   clusterContainer = (*clusterArray)[0].getContainer();
   BOOST_CHECK_EQUAL(clusterContainer->numberOfClusters, 11);
   for (int clIndex = 0; clIndex < clusterContainer->numberOfClusters; ++clIndex) {
@@ -1021,7 +999,5 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test6)
   std::cout << "##" << std::endl
             << std::endl;
 }
-
-
 }
 }

--- a/Detectors/TPC/workflow/src/ClustererSpec.cxx
+++ b/Detectors/TPC/workflow/src/ClustererSpec.cxx
@@ -103,14 +103,11 @@ DataProcessorSpec getClustererSpec(bool sendMC, int fanNumber)
       if (verbosity > 0) {
         LOG(INFO) << "processing " << inDigits.size() << " digit object(s) of sector " << sectorHeader->sector;
       }
-      clusterArray.clear();
-      mctruthArray.clear();
-      clusterer->process(inDigits, inMCLabels.get());
-      // FIXME: not clear whether we need to call this and how
-      // currently it makes all clusters being removed in the Tracker
-      // maybe the problem is the empty digit array
-      //const std::vector<o2::TPC::Digit> emptyDigits;
-      //clusterer->finishProcess(emptyDigits, nullptr);
+      clusterArray.clear(); // this would also be done in the HwClusterer if the clearContainerFirst of process() would be set to true instead of false
+      mctruthArray.clear(); // this would also be done in the HwClusterer if the clearContainerFirst of process() would be set to true instead of false
+      clusterer->process(inDigits, inMCLabels.get(), false);
+      const std::vector<o2::TPC::Digit> emptyDigits;
+      clusterer->finishProcess(emptyDigits, nullptr, false); // keep here the falso, otherwise the clusters are lost of they are not stored in the meantime
       if (verbosity > 0) {
         LOG(INFO) << "clusterer produced " << clusterArray.size() << " cluster container";
       }

--- a/Detectors/TPC/workflow/src/ClustererSpec.cxx
+++ b/Detectors/TPC/workflow/src/ClustererSpec.cxx
@@ -107,7 +107,7 @@ DataProcessorSpec getClustererSpec(bool sendMC, int fanNumber)
       mctruthArray.clear(); // this would also be done in the HwClusterer if the clearContainerFirst of process() would be set to true instead of false
       clusterer->process(inDigits, inMCLabels.get(), false);
       const std::vector<o2::TPC::Digit> emptyDigits;
-      clusterer->finishProcess(emptyDigits, nullptr, false); // keep here the falso, otherwise the clusters are lost of they are not stored in the meantime
+      clusterer->finishProcess(emptyDigits, nullptr, false); // keep here the false, otherwise the clusters are lost of they are not stored in the meantime
       if (verbosity > 0) {
         LOG(INFO) << "clusterer produced " << clusterArray.size() << " cluster container";
       }


### PR DESCRIPTION
- added the option to reject clusters:
  - single pad clusters
  - single time clusters
  - peak in the same pad but later timebin

- added first "charge sharing" option, clusters are split at the minimum, the minimum itself contributes half to all clusters.

- added option to **NOT** clear output containers by calling process/finishProcess functions (@matthiasrichter maybe this helps with the reco-workflow, could you please test it)