### PR TITLE
DPL: workaround hanging test

### DIFF
--- a/Framework/Core/test/test_ProcessorOptions.cxx
+++ b/Framework/Core/test/test_ProcessorOptions.cxx
@@ -38,7 +38,6 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
             // there is nothing to do, simply stop the workflow but we have to send at least one message
             // to make sure that the callback of the consumer is called
             ctx.outputs().make<int>(Output{ "TST", "TEST", 0, Lifetime::Timeframe }) = 42;
-            ctx.services().get<ControlService>().readyToQuit(true);
           };
         },
       },


### PR DESCRIPTION
While this should have been gracefully handled by FairMQ, it does not
really make sense to quit when the producer is done, as all the testing
happens in the consumer.