### PR TITLE
DPL: refactor DataHeader to not include boost

### DIFF
--- a/Algorithm/test/headerstack.cxx
+++ b/Algorithm/test/headerstack.cxx
@@ -22,6 +22,7 @@
 #include <cstring> // memcmp
 #include "Headers/DataHeader.h" // hexdump
 #include "Headers/NameHeader.h"
+#include "Headers/Stack.h"
 #include "../include/Algorithm/HeaderStack.h"
 
 using DataHeader = o2::header::DataHeader;

--- a/DataFormats/Headers/include/Headers/DataHeader.h
+++ b/DataFormats/Headers/include/Headers/DataHeader.h
@@ -37,7 +37,8 @@
 #include <algorithm> // std::min
 #include <stdexcept>
 #include <string>
-#include "MemoryResources/MemoryResources.h"
+// FIXME: for o2::byte. Use std::byte as soon as we move to C++17..
+#include "MemoryResources/Types.h"
 
 namespace o2 {
 namespace header {
@@ -467,149 +468,6 @@ auto get(const void* buffer, size_t len = 0)
 {
   return get<HeaderType>(reinterpret_cast<const byte *>(buffer), len);
 }
-
-//__________________________________________________________________________________________________
-/// @struct Stack
-/// @brief a move-only header stack with serialized headers
-/// This is the flat buffer where all the headers in a multi-header go.
-/// This guy knows how to move the serialized content to FairMQ
-/// and inform it how to release when all is sent.
-/// methods to construct a multi-header
-/// intended use:
-///   - as a variadic intializer list (as an argument to a function)
-///
-///   One can also use the ctor directly:
-//    Stack::Stack(const T& header1, const T& header2, ...)
-//    - arguments can be headers, or stacks, all will be concatenated in a new Stack
-///   - returns a Stack ready to be shipped.
-struct Stack {
-
- private:
-  static void freefn(void* data, void* hint)
-  {
-    boost::container::pmr::memory_resource* resource = static_cast<boost::container::pmr::memory_resource*>(hint);
-    resource->deallocate(data, 0, 0);
-  }
-
-  struct freeobj {
-    freeobj() {}
-    freeobj(boost::container::pmr::memory_resource* mr) : resource(mr) {}
-
-    boost::container::pmr::memory_resource* resource{ nullptr };
-    void operator()(o2::byte* ptr) { Stack::freefn(ptr, resource); }
-  };
-
- public:
-  using allocator_type = boost::container::pmr::polymorphic_allocator<o2::byte>;
-  using value_type = o2::byte;
-  using BufferType = std::unique_ptr<value_type[], freeobj>;
-
-  Stack() = default;
-  Stack(Stack&&) = default;
-  Stack(Stack&) = delete;
-  Stack& operator=(Stack&) = delete;
-  Stack& operator=(Stack&&) = default;
-
-  value_type* data() const { return buffer.get(); }
-  size_t size() const { return bufferSize; }
-  allocator_type get_allocator() const { return allocator; }
-
-  //
-  boost::container::pmr::memory_resource* getFreefnHint() const noexcept { return allocator.resource(); }
-  static auto getFreefn() noexcept { return &freefn; }
-
-  /// The magic constructors: take arbitrary number of headers and serialize them
-  /// into the buffer buffer allocated by the specified polymorphic allocator. By default
-  /// allocation is done using new_delete_resource.
-  /// In the final stack the first header must be DataHeader.
-  /// all headers must derive from BaseHeader, in addition also other stacks can be passed to ctor.
-  template <typename FirstArgType, typename... Headers,
-            typename std::enable_if_t<
-              !std::is_convertible<FirstArgType, boost::container::pmr::polymorphic_allocator<o2::byte>>::value, int> = 0>
-  Stack(FirstArgType&& firstHeader, Headers&&... headers)
-    : Stack(boost::container::pmr::new_delete_resource(), std::forward<FirstArgType>(firstHeader),
-            std::forward<Headers>(headers)...)
-  {
-  }
-
-  template <typename... Headers>
-  Stack(const allocator_type allocatorArg, Headers&&... headers)
-    : allocator{ allocatorArg },
-      bufferSize{ calculateSize(std::forward<Headers>(headers)...) },
-      buffer{ static_cast<o2::byte*>(allocator.resource()->allocate(bufferSize, alignof(std::max_align_t))),
-              freeobj(getFreefnHint()) }
-  {
-    inject(buffer.get(), std::forward<Headers>(headers)...);
-  }
-
- private:
-  allocator_type allocator{ boost::container::pmr::new_delete_resource() };
-  size_t bufferSize{ 0 };
-  BufferType buffer{ nullptr, freeobj{ getFreefnHint() } };
-
-  template <typename T, typename... Args>
-  static size_t calculateSize(T&& h, Args&&... args) noexcept
-  {
-    return calculateSize(std::forward<T>(h)) + calculateSize(std::forward<Args>(args)...);
-  }
-
-  template <typename T>
-  static size_t calculateSize(T&& h) noexcept
-  {
-    return h.size();
-  }
-
-  //recursion terminator
-  constexpr static size_t calculateSize() { return 0; }
-
-  template <typename T>
-  static o2::byte* inject(o2::byte* here, T&& h) noexcept
-  {
-    using headerType = typename std::remove_cv<typename std::remove_reference<T>::type>::type;
-    static_assert(
-      std::is_base_of<BaseHeader, headerType>::value == true || std::is_same<Stack, headerType>::value == true,
-      "header stack parameters are restricted to stacks and headers derived from BaseHeader");
-    std::copy(h.data(), h.data() + h.size(), here);
-    return here + h.size();
-    // somehow could not trigger copy elision for placed construction, TODO: check out if this is possible here
-    // headerType* placed = new (here) headerType(std::forward<T>(h));
-    // return here + placed->size();
-  }
-
-  template <typename T, typename... Args>
-  static o2::byte* inject(o2::byte* here, T&& h, Args&&... args) noexcept
-  {
-    auto alsohere = inject(here, h);
-    // the type might be a stack itself, loop through headers and set the flag in the last one
-    if (h.size() > 0) {
-      BaseHeader* next = BaseHeader::get(here);
-      while (next->flagsNextHeader) {
-        next = next->next();
-      }
-      next->flagsNextHeader = hasNonEmptyArg(args...);
-    }
-    return inject(alsohere, args...);
-  }
-
-  // helper function to check if there is at least one non-empty header/stack in the argument pack
-  template <typename T, typename... Args>
-  static bool hasNonEmptyArg(const T& h, const Args&... args) noexcept
-  {
-    if (h.size() > 0) {
-      return true;
-    }
-    return hasNonEmptyArg(args...);
-  }
-
-  template <typename T>
-  static bool hasNonEmptyArg(const T& h) noexcept
-  {
-    if (h.size() > 0) {
-      return true;
-    }
-    return false;
-  }
-};
 
 //__________________________________________________________________________________________________
 /// this 128 bit type for a header field describing the payload data type

--- a/DataFormats/Headers/include/Headers/Stack.h
+++ b/DataFormats/Headers/include/Headers/Stack.h
@@ -1,0 +1,166 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef O2_HEADERS_STACK_H
+#define O2_HEADERS_STACK_H
+
+#include "MemoryResources/MemoryResources.h"
+#include "Headers/DataHeader.h"
+
+namespace o2
+{
+namespace header
+{
+//__________________________________________________________________________________________________
+/// @struct Stack
+/// @brief a move-only header stack with serialized headers
+/// This is the flat buffer where all the headers in a multi-header go.
+/// This guy knows how to move the serialized content to FairMQ
+/// and inform it how to release when all is sent.
+/// methods to construct a multi-header
+/// intended use:
+///   - as a variadic intializer list (as an argument to a function)
+///
+///   One can also use the ctor directly:
+//    Stack::Stack(const T& header1, const T& header2, ...)
+//    - arguments can be headers, or stacks, all will be concatenated in a new Stack
+///   - returns a Stack ready to be shipped.
+struct Stack {
+
+ private:
+  static void freefn(void* data, void* hint)
+  {
+    boost::container::pmr::memory_resource* resource = static_cast<boost::container::pmr::memory_resource*>(hint);
+    resource->deallocate(data, 0, 0);
+  }
+
+  struct freeobj {
+    freeobj() {}
+    freeobj(boost::container::pmr::memory_resource* mr) : resource(mr) {}
+
+    boost::container::pmr::memory_resource* resource{ nullptr };
+    void operator()(o2::byte* ptr) { Stack::freefn(ptr, resource); }
+  };
+
+ public:
+  using allocator_type = boost::container::pmr::polymorphic_allocator<o2::byte>;
+  using value_type = o2::byte;
+  using BufferType = std::unique_ptr<value_type[], freeobj>;
+
+  Stack() = default;
+  Stack(Stack&&) = default;
+  Stack(Stack&) = delete;
+  Stack& operator=(Stack&) = delete;
+  Stack& operator=(Stack&&) = default;
+
+  value_type* data() const { return buffer.get(); }
+  size_t size() const { return bufferSize; }
+  allocator_type get_allocator() const { return allocator; }
+
+  //
+  boost::container::pmr::memory_resource* getFreefnHint() const noexcept { return allocator.resource(); }
+  static auto getFreefn() noexcept { return &freefn; }
+
+  /// The magic constructors: take arbitrary number of headers and serialize them
+  /// into the buffer buffer allocated by the specified polymorphic allocator. By default
+  /// allocation is done using new_delete_resource.
+  /// In the final stack the first header must be DataHeader.
+  /// all headers must derive from BaseHeader, in addition also other stacks can be passed to ctor.
+  template <typename FirstArgType, typename... Headers,
+            typename std::enable_if_t<
+              !std::is_convertible<FirstArgType, boost::container::pmr::polymorphic_allocator<o2::byte>>::value, int> = 0>
+  Stack(FirstArgType&& firstHeader, Headers&&... headers)
+    : Stack(boost::container::pmr::new_delete_resource(), std::forward<FirstArgType>(firstHeader),
+            std::forward<Headers>(headers)...)
+  {
+  }
+
+  template <typename... Headers>
+  Stack(const allocator_type allocatorArg, Headers&&... headers)
+    : allocator{ allocatorArg },
+      bufferSize{ calculateSize(std::forward<Headers>(headers)...) },
+      buffer{ static_cast<o2::byte*>(allocator.resource()->allocate(bufferSize, alignof(std::max_align_t))),
+              freeobj(getFreefnHint()) }
+  {
+    inject(buffer.get(), std::forward<Headers>(headers)...);
+  }
+
+ private:
+  allocator_type allocator{ boost::container::pmr::new_delete_resource() };
+  size_t bufferSize{ 0 };
+  BufferType buffer{ nullptr, freeobj{ getFreefnHint() } };
+
+  template <typename T, typename... Args>
+  static size_t calculateSize(T&& h, Args&&... args) noexcept
+  {
+    return calculateSize(std::forward<T>(h)) + calculateSize(std::forward<Args>(args)...);
+  }
+
+  template <typename T>
+  static size_t calculateSize(T&& h) noexcept
+  {
+    return h.size();
+  }
+
+  //recursion terminator
+  constexpr static size_t calculateSize() { return 0; }
+
+  template <typename T>
+  static o2::byte* inject(o2::byte* here, T&& h) noexcept
+  {
+    using headerType = typename std::remove_cv<typename std::remove_reference<T>::type>::type;
+    static_assert(
+      std::is_base_of<BaseHeader, headerType>::value == true || std::is_same<Stack, headerType>::value == true,
+      "header stack parameters are restricted to stacks and headers derived from BaseHeader");
+    std::copy(h.data(), h.data() + h.size(), here);
+    return here + h.size();
+    // somehow could not trigger copy elision for placed construction, TODO: check out if this is possible here
+    // headerType* placed = new (here) headerType(std::forward<T>(h));
+    // return here + placed->size();
+  }
+
+  template <typename T, typename... Args>
+  static o2::byte* inject(o2::byte* here, T&& h, Args&&... args) noexcept
+  {
+    auto alsohere = inject(here, h);
+    // the type might be a stack itself, loop through headers and set the flag in the last one
+    if (h.size() > 0) {
+      BaseHeader* next = BaseHeader::get(here);
+      while (next->flagsNextHeader) {
+        next = next->next();
+      }
+      next->flagsNextHeader = hasNonEmptyArg(args...);
+    }
+    return inject(alsohere, args...);
+  }
+
+  // helper function to check if there is at least one non-empty header/stack in the argument pack
+  template <typename T, typename... Args>
+  static bool hasNonEmptyArg(const T& h, const Args&... args) noexcept
+  {
+    if (h.size() > 0) {
+      return true;
+    }
+    return hasNonEmptyArg(args...);
+  }
+
+  template <typename T>
+  static bool hasNonEmptyArg(const T& h) noexcept
+  {
+    if (h.size() > 0) {
+      return true;
+    }
+    return false;
+  }
+};
+
+} // namespace header
+} // namespace o2
+
+#endif // HEADERS_STACK_H

--- a/DataFormats/Headers/test/testDataHeader.cxx
+++ b/DataFormats/Headers/test/testDataHeader.cxx
@@ -16,6 +16,7 @@
 #include <iomanip>
 #include "Headers/DataHeader.h"
 #include "Headers/NameHeader.h"
+#include "Headers/Stack.h"
 
 #include <chrono>
 

--- a/DataFormats/MemoryResources/include/MemoryResources/Types.h
+++ b/DataFormats/MemoryResources/include/MemoryResources/Types.h
@@ -1,0 +1,19 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_MEMORY_RESOURCES_TYPES_
+#define O2_MEMORY_RESOURCES_TYPES_
+
+namespace o2
+{
+using byte = unsigned char;
+} // namespace o2
+
+#endif

--- a/Framework/Core/include/Framework/DataAllocator.h
+++ b/Framework/Core/include/Framework/DataAllocator.h
@@ -412,21 +412,7 @@ public:
                                            o2::header::SerializationMethod serializationMethod, //
                                            size_t payloadSize);                                 //
 
-  Output getOutputByBind(OutputRef&& ref)
-  {
-    if (ref.label.empty()) {
-      throw std::runtime_error("Invalid (empty) OutputRef provided.");
-    }
-    for (size_t ri = 0, re = mAllowedOutputRoutes.size(); ri != re; ++ri) {
-      if (mAllowedOutputRoutes[ri].matcher.binding.value == ref.label) {
-        auto spec = mAllowedOutputRoutes[ri].matcher;
-        return Output{ spec.origin, spec.description, ref.subSpec, spec.lifetime, std::move(ref.headerStack) };
-      }
-    }
-    throw std::runtime_error("Unable to find OutputSpec with label " + ref.label);
-    assert(false);
-  }
-
+  Output getOutputByBind(OutputRef&& ref);
   void addPartToContext(FairMQMessagePtr&& payload,
                         const Output &spec,
                         o2::header::SerializationMethod serializationMethod);

--- a/Framework/Core/include/Framework/Output.h
+++ b/Framework/Core/include/Framework/Output.h
@@ -12,6 +12,7 @@
 
 #include "Headers/DataHeader.h"
 #include "Framework/Lifetime.h"
+#include "Headers/Stack.h"
 
 namespace o2
 {

--- a/Framework/Core/include/Framework/OutputRef.h
+++ b/Framework/Core/include/Framework/OutputRef.h
@@ -11,6 +11,7 @@
 #define FRAMEWORK_OUTPUTREF_H
 
 #include "Headers/DataHeader.h"
+#include "Headers/Stack.h"
 
 #include <string>
 

--- a/Framework/Core/src/DataSamplingConditionNConsecutive.cxx
+++ b/Framework/Core/src/DataSamplingConditionNConsecutive.cxx
@@ -16,6 +16,7 @@
 #include "Framework/DataSamplingCondition.h"
 #include "Framework/DataSamplingConditionFactory.h"
 #include "Framework/DataProcessingHeader.h"
+#include <fairlogger/Logger.h>
 
 namespace o2
 {

--- a/Framework/Core/src/DataSamplingConditionPayloadSize.cxx
+++ b/Framework/Core/src/DataSamplingConditionPayloadSize.cxx
@@ -16,6 +16,7 @@
 #include "Framework/DataSamplingCondition.h"
 #include "Framework/DataSamplingConditionFactory.h"
 #include "Headers/DataHeader.h"
+#include <fairlogger/Logger.h>
 
 namespace o2
 {

--- a/Framework/Core/src/LifetimeHelpers.cxx
+++ b/Framework/Core/src/LifetimeHelpers.cxx
@@ -13,6 +13,8 @@
 #include "Framework/RawDeviceService.h"
 #include "Framework/InputRoute.h"
 #include "Headers/DataHeader.h"
+#include "Headers/Stack.h"
+#include "MemoryResources/MemoryResources.h"
 #include "Framework/DataProcessingHeader.h"
 #include <fairmq/FairMQDevice.h>
 

--- a/Framework/Core/test/test_DataRelayer.cxx
+++ b/Framework/Core/test/test_DataRelayer.cxx
@@ -14,6 +14,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include "Headers/DataHeader.h"
+#include "Headers/Stack.h"
 #include "Framework/CompletionPolicyHelpers.h"
 #include "Framework/DataRelayer.h"
 #include "Framework/DataProcessingHeader.h"

--- a/Framework/Core/test/test_DataSamplingCondition.cxx
+++ b/Framework/Core/test/test_DataSamplingCondition.cxx
@@ -18,6 +18,7 @@
 #include "Framework/DataRef.h"
 #include "Framework/DataProcessingHeader.h"
 #include "Headers/DataHeader.h"
+#include "Headers/Stack.h"
 
 using namespace o2::framework;
 using namespace o2::header;

--- a/Framework/Core/test/test_InputRecord.cxx
+++ b/Framework/Core/test/test_InputRecord.cxx
@@ -16,6 +16,7 @@
 #include "Framework/InputRecord.h"
 #include "Framework/DataProcessingHeader.h"
 #include "Headers/DataHeader.h"
+#include "Headers/Stack.h"
 
 using namespace o2::framework;
 using DataHeader = o2::header::DataHeader;

--- a/Utilities/O2Device/include/O2Device/Utilities.h
+++ b/Utilities/O2Device/include/O2Device/Utilities.h
@@ -29,6 +29,8 @@
 
 #include "MemoryResources/MemoryResources.h"
 #include "Headers/DataHeader.h"
+#include "Headers/Stack.h"
+
 #include <utility>
 #include <gsl/gsl>
 

--- a/Utilities/aliceHLTwrapper/src/MessageFormat.cxx
+++ b/Utilities/aliceHLTwrapper/src/MessageFormat.cxx
@@ -30,6 +30,7 @@
 #include "aliceHLTwrapper/AliHLTHOMERData.h"
 #include "aliceHLTwrapper/AliHLTHOMERWriter.h"
 #include "aliceHLTwrapper/AliHLTHOMERReader.h"
+#include "Headers/Stack.h"
 
 #include <cstdlib>
 #include <cerrno>

--- a/Utilities/aliceHLTwrapper/test/testMessageFormat.cxx
+++ b/Utilities/aliceHLTwrapper/test/testMessageFormat.cxx
@@ -17,6 +17,7 @@
 #include "aliceHLTwrapper/MessageFormat.h"
 #include "Headers/DataHeader.h"
 #include "Headers/HeartbeatFrame.h"
+#include "Headers/Stack.h"
 
 namespace o2 { 
 namespace alice_hlt {


### PR DESCRIPTION
This separates Stack in its own header so that boost is
not exposed when DataHeader is included. Apart from the discussion
of whether we should include boost in our ROOT_INCLUDE_PATH, this
is in any case a good refactoring which separates the data header
descriptions from their actual manipulation.

Notice we still have Stack being exposed in things which might endup in the workflow, so I am not sure this will completely avoid the boost issue...