### PR TITLE
DPL GUI: add headless test for ImGUI

### DIFF
--- a/Framework/DebugGUI/CMakeLists.txt
+++ b/Framework/DebugGUI/CMakeLists.txt
@@ -59,4 +59,15 @@ O2_GENERATE_EXECUTABLE(
 )
 endif()
 
+O2_GENERATE_EXECUTABLE(
+  EXE_NAME "test_DebugGUI_test_ImGUIHeadless"
+  SOURCES test/test_ImGUIHeadless.cpp test/imgui_demo.cpp
+
+  MODULE_LIBRARY_NAME ${LIBRARY_NAME}
+  BUCKET_NAME ${MODULE_BUCKET_NAME}
+)
+add_test(NAME test_DebugGUI_test_ImGUIHeadless COMMAND test_DebugGUI_test_ImGUIHeadless)
+target_link_libraries(test_DebugGUI_test_ImGUIHeadless Boost::unit_test_framework)
+set_tests_properties(test_DebugGUI_test_ImGUIHeadless PROPERTIES TIMEOUT 30)
+
 target_compile_options(DebugGUI PUBLIC -O0 -g -fno-omit-frame-pointer)

--- a/Framework/DebugGUI/include/DebugGUI/imgui.h
+++ b/Framework/DebugGUI/include/DebugGUI/imgui.h
@@ -161,7 +161,7 @@ namespace ImGui
     IMGUI_API void          EndFrame();                                 // ends the ImGui frame. automatically called by Render(), so most likely don't need to ever call that yourself directly. If you don't need to render you may call EndFrame() but you'll have wasted CPU already. If you don't need to render, better to not create any imgui windows instead!
 
     // Demo, Debug, Information
-    IMGUI_API void          ShowDemoWindow(bool* p_open = NULL);        // create demo/test window (previously called ShowTestWindow). demonstrate most ImGui features. call this to learn about the library! try to make it always available in your application!
+    IMGUI_API void          ShowDemoWindow(bool* p_open = NULL, bool def_open = false);        // create demo/test window (previously called ShowTestWindow). demonstrate most ImGui features. call this to learn about the library! try to make it always available in your application!
     IMGUI_API void          ShowMetricsWindow(bool* p_open = NULL);     // create metrics window. display ImGui internals: draw commands (with individual draw calls and vertices), window list, basic internal state, etc.
     IMGUI_API void          ShowStyleEditor(ImGuiStyle* ref = NULL);    // add style editor block (not a window). you can pass in a reference ImGuiStyle structure to compare to, revert to and save to (else it uses the default style)
     IMGUI_API bool          ShowStyleSelector(const char* label);       // add style selector block (not a window), essentially a combo listing the default styles.

--- a/Framework/DebugGUI/test/imgui.h
+++ b/Framework/DebugGUI/test/imgui.h
@@ -161,7 +161,7 @@ namespace ImGui
     IMGUI_API void          EndFrame();                                 // ends the ImGui frame. automatically called by Render(), so most likely don't need to ever call that yourself directly. If you don't need to render you may call EndFrame() but you'll have wasted CPU already. If you don't need to render, better to not create any imgui windows instead!
 
     // Demo, Debug, Information
-    IMGUI_API void          ShowDemoWindow(bool* p_open = NULL);        // create demo/test window (previously called ShowTestWindow). demonstrate most ImGui features. call this to learn about the library! try to make it always available in your application!
+    IMGUI_API void          ShowDemoWindow(bool* p_open = NULL, bool def_open = false);        // create demo/test window (previously called ShowTestWindow). demonstrate most ImGui features. call this to learn about the library! try to make it always available in your application!
     IMGUI_API void          ShowMetricsWindow(bool* p_open = NULL);     // create metrics window. display ImGui internals: draw commands (with individual draw calls and vertices), window list, basic internal state, etc.
     IMGUI_API void          ShowStyleEditor(ImGuiStyle* ref = NULL);    // add style editor block (not a window). you can pass in a reference ImGuiStyle structure to compare to, revert to and save to (else it uses the default style)
     IMGUI_API bool          ShowStyleSelector(const char* label);       // add style selector block (not a window), essentially a combo listing the default styles.

--- a/Framework/DebugGUI/test/imgui_demo.cpp
+++ b/Framework/DebugGUI/test/imgui_demo.cpp
@@ -125,24 +125,24 @@ void ImGui::ShowUserGuide()
 }
 
 // Demonstrate most ImGui features (big function!)
-void ImGui::ShowDemoWindow(bool* p_open)
+void ImGui::ShowDemoWindow(bool* p_open, bool def_open)
 {
     // Examples apps
-    static bool show_app_main_menu_bar = false;
-    static bool show_app_console = false;
-    static bool show_app_log = false;
-    static bool show_app_layout = false;
-    static bool show_app_property_editor = false;
-    static bool show_app_long_text = false;
-    static bool show_app_auto_resize = false;
-    static bool show_app_constrained_resize = false;
-    static bool show_app_simple_overlay = false;
-    static bool show_app_window_titles = false;
-    static bool show_app_custom_rendering = false;
-    static bool show_app_style_editor = false;
+    static bool show_app_main_menu_bar = def_open;
+    static bool show_app_console = def_open;
+    static bool show_app_log = def_open;
+    static bool show_app_layout = def_open;
+    static bool show_app_property_editor = def_open;
+    static bool show_app_long_text = def_open;
+    static bool show_app_auto_resize = def_open;
+    static bool show_app_constrained_resize = def_open;
+    static bool show_app_simple_overlay = def_open;
+    static bool show_app_window_titles = def_open;
+    static bool show_app_custom_rendering = def_open;
+    static bool show_app_style_editor = def_open;
 
-    static bool show_app_metrics = false;
-    static bool show_app_about = false;
+    static bool show_app_metrics = def_open;
+    static bool show_app_about = def_open;
 
     if (show_app_main_menu_bar)       ShowExampleAppMainMenuBar();
     if (show_app_console)             ShowExampleAppConsole(&show_app_console);

--- a/Framework/DebugGUI/test/test_ImGUIHeadless.cpp
+++ b/Framework/DebugGUI/test/test_ImGUIHeadless.cpp
@@ -1,0 +1,54 @@
+#include "DebugGUI/imgui.h"
+#include <stdio.h>
+
+static void error_callback(int error, const char* description)
+{
+    fprintf(stderr, "Error %d: %s\n", error, description);
+}
+
+int main(int, char**)
+{
+  IMGUI_CHECKVERSION();
+  ImGui::CreateContext();
+  ImGuiIO& io = ImGui::GetIO();
+
+  // Build atlas
+  unsigned char* tex_pixels = nullptr;
+  int tex_w, tex_h;
+  io.Fonts->GetTexDataAsRGBA32(&tex_pixels, &tex_w, &tex_h);
+
+  bool show_test_window = true;
+  bool show_another_window = true;
+  ImVec4 clear_color = ImColor(114, 144, 154);
+
+  for (int n = 0; n < 50; n++) {
+    io.DisplaySize = ImVec2(1920, 1080);
+    io.DeltaTime = 1.0f / 60.0f;
+    ImGui::NewFrame();
+
+    // 1. Show a simple window
+    // Tip: if we don't call ImGui::Begin()/ImGui::End() the widgets appears in a window automatically called "Debug"
+    static float f = 0.0f;
+    ImGui::Text("Hello, world!");
+    ImGui::SliderFloat("float", &f, 0.0f, 1.0f);
+    ImGui::ColorEdit3("clear color", (float*)&clear_color);
+    if (ImGui::Button("Test Window")) show_test_window ^= 1;
+    if (ImGui::Button("Another Window")) show_another_window ^= 1;
+    ImGui::Text("Application average %.3f ms/frame (%.1f FPS)", 1000.0f / ImGui::GetIO().Framerate, ImGui::GetIO().Framerate);
+
+    // 2. Show another simple window, this time using an explicit Begin/End pair
+    ImGui::SetNextWindowSize(ImVec2(200,100), ImGuiSetCond_FirstUseEver);
+    ImGui::Begin("Another Window", &show_another_window);
+    ImGui::Text("Hello");
+    ImGui::End();
+
+    ImGui::SetNextWindowPos(ImVec2(650, 20), ImGuiSetCond_FirstUseEver);
+    ImGui::ShowDemoWindow(nullptr, true);
+
+    ImGui::Render();
+  }
+
+  ImGui::DestroyContext();
+
+  return 0;
+}


### PR DESCRIPTION
Framework/DebugGUI package is a red-herring in terms of coverage, due to
the imported imgui. While the proper solution would be to manage to
compile imgui outside AliceO2, this should increase a bit the actual
coverage.