### PR TITLE
Fixes for Geant4 simulation plus one update:

### DIFF
--- a/DataFormats/simulation/src/Stack.cxx
+++ b/DataFormats/simulation/src/Stack.cxx
@@ -368,7 +368,7 @@ void Stack::UpdateTrackIndex(TRefArray* detList)
       if (o2det) {
         mActiveDetectors.emplace_back(o2det);
       } else {
-        LOG(INFO) << "Found nonconforming detector" << FairLogger::endl;
+        LOG(INFO) << "Found nonconforming detector " << det->GetName() << FairLogger::endl;
       }
     }
   }

--- a/Detectors/FIT/simulation/include/FITSimulation/Detector.h
+++ b/Detectors/FIT/simulation/include/FITSimulation/Detector.h
@@ -81,6 +81,7 @@ class Detector : public o2::Base::DetImpl<Detector>
   /// Base class to create the detector geometry
   void CreateMaterials();
   void ConstructGeometry() override;
+  void ConstructOpGeometry() override;
   void SetOneMCP(TGeoVolume* stl);
 
   // Optical properties reader: e-Energy, abs-AbsorptionLength[cm], n-refractive index

--- a/Detectors/FIT/simulation/src/Detector.cxx
+++ b/Detectors/FIT/simulation/src/Detector.cxx
@@ -42,7 +42,7 @@ Detector::Detector(Bool_t Active)
 }
 
 Detector::Detector(const Detector& rhs)
-  : o2::Base::DetImpl<Detector>(rhs), mIdSens1(rhs.mIdSens1), mPMTeff(nullptr), mHits(new std::vector<o2::fit::HitType>)
+  : o2::Base::DetImpl<Detector>(rhs), mIdSens1(rhs.mIdSens1), mPMTeff(rhs.mPMTeff), mHits(new std::vector<o2::fit::HitType>)
 {
 }
 
@@ -201,6 +201,13 @@ void Detector::ConstructGeometry()
 
   // MCP + 4 x wrapped radiator + 4xphotocathod + MCP + Al top in front of radiators
   SetOneMCP(ins);
+}
+
+void Detector::ConstructOpGeometry()
+{
+  LOG(DEBUG) << "Creating FIT optical geometry properties";
+
+  DefineOpticalProperties();
 }
 
 //_________________________________________
@@ -362,8 +369,6 @@ void Detector::CreateMaterials()
   Medium(16, "OpticalGlass$", 24, 1, isxfld, sxmgmx, 10., .01, .1, .003, .003);
   Medium(19, "OpticalGlassCathode$", 24, 1, isxfld, sxmgmx, 10., .01, .1, .003, .003);
   Medium(22, "SensAir$", 2, 1, isxfld, sxmgmx, 10., .1, 1., .003, .003);
-
-  DefineOpticalProperties();
 }
 
 //-------------------------------------------------------------------

--- a/Detectors/PHOS/simulation/include/PHOSSimulation/Detector.h
+++ b/Detectors/PHOS/simulation/include/PHOSSimulation/Detector.h
@@ -173,6 +173,9 @@ class Detector : public o2::Base::DetImpl<Detector>
   Detector(const Detector& rhs);
   Detector& operator=(const Detector&);
 
+  /// Define the sensitive volumes of the geometry
+  void defineSensitiveVolumes();
+
   // Geometry parameters
   Bool_t mCreateHalfMod;   // Should we create  1/2 filled module
   Bool_t mActiveModule[6]; // list of modules to create

--- a/Detectors/PHOS/simulation/src/Detector.cxx
+++ b/Detectors/PHOS/simulation/src/Detector.cxx
@@ -913,5 +913,3 @@ void Detector::defineSensitiveVolumes()
     }
   }
 }
-
-

--- a/Detectors/PHOS/simulation/src/Detector.cxx
+++ b/Detectors/PHOS/simulation/src/Detector.cxx
@@ -57,6 +57,9 @@ Detector::Detector(const Detector& rhs)
 void Detector::InitializeO2Detector()
 {
   Reset();
+
+  // Define sensitive volumes
+  defineSensitiveVolumes();
 }
 
 void Detector::EndOfEvent()
@@ -283,16 +286,6 @@ void Detector::ConstructGeometry()
   }
 
   gGeoManager->CheckGeometry();
-
-  // Define sensitive volume
-  if (fActive) {
-    TGeoVolume* vsense = gGeoManager->GetVolume("PXTL");
-    if (vsense) {
-      AddSensitiveVolume(vsense);
-    } else {
-      LOG(ERROR) << "PHOS Sensitive volume PXTL not found ... No hit creation!\n";
-    }
-  }
 }
 //-----------------------------------------
 void Detector::CreateMaterials()
@@ -907,3 +900,18 @@ void Detector::ConstructSupportGeometry()
     }
   }
 }
+
+//-----------------------------------------
+void Detector::defineSensitiveVolumes()
+{
+  if (fActive) {
+    TGeoVolume* vsense = gGeoManager->GetVolume("PXTL");
+    if (vsense) {
+      AddSensitiveVolume(vsense);
+    } else {
+      LOG(ERROR) << "PHOS Sensitive volume PXTL not found ... No hit creation!\n";
+    }
+  }
+}
+
+

--- a/Detectors/ZDC/simulation/src/Detector.cxx
+++ b/Detectors/ZDC/simulation/src/Detector.cxx
@@ -455,7 +455,7 @@ void Detector::createMaterials()
   // ******** MATERIAL DEFINITION ********
   Mixture(0, "Walloy$", aW, zW, dW, 3, wW);
   Mixture(1, "CuZn$", aCuZn, zCuZn, dCuZn, 2, wCuZn);
-  Mixture(2, "SiO2$", aq, zq, dq, 2, wq);
+  Mixture(2, "SiO2$", aq, zq, dq, -2, wq);
   Material(3, "Pb $", aPb, zPb, dPb, radPb, absPb);
   Material(4, "Cu $", aCu, zCu, dCu, radCu, absCu);
   Material(5, "Fe $", aFe, zFe, dFe, radFe, absFe);
@@ -1479,7 +1479,7 @@ void Detector::createCsideBeamLine()
   // Inner trousers
   TGeoCompositeShape* pIntTrousersC = new TGeoCompositeShape("intTrousersC", "QCLint:ZDCC_c1+QCLint:ZDCC_c2");
   // Volume: QCLint
-  TGeoMedium* medZDCvoid = gGeoManager->GetMedium("ZDC_VoidNoField");
+  TGeoMedium* medZDCvoid = gGeoManager->GetMedium("ZDC_VoidNoField$");
   TGeoVolume* pQCLint = new TGeoVolume("QCLint", pIntTrousersC, medZDCvoid);
   pQCLint->SetLineColor(kTeal);
   pQCLint->SetVisLeaves(kTRUE);

--- a/Detectors/gconfig/g4Config.C
+++ b/Detectors/gconfig/g4Config.C
@@ -69,5 +69,8 @@ void Config()
   /// (verbose level, global range cut, ..)
   geant4->ProcessGeantMacro(configm1.Data());
 
+  // Enter in Geant4 Interactive mode
+  // geant4->StartGeantUI();
+
   cout << "g4Config.C finished" << endl;
 }

--- a/Detectors/gconfig/g4config.in
+++ b/Detectors/gconfig/g4config.in
@@ -5,9 +5,11 @@
 /mcVerbose/geometryManager 1
 /mcVerbose/opGeometryManager 1
 /mcTracking/loopVerbose 1
-/mcPhysics/rangeCuts 0.01 mm
-
 /mcVerbose/composedPhysicsList 2
+#/tracking/verbose 1
+#//control/cout/ignoreThreadsExcept 0
+
+/mcPhysics/rangeCuts 0.01 mm
 /mcTracking/skipNeutrino true
 /mcDet/setIsMaxStepInLowDensityMaterials true
 /mcDet/setMaxStepInLowDensityMaterials 10 m
@@ -33,5 +35,5 @@
 #
 # Geant4 VMC >= v3.2
 /mcPhysics/emModel/setEmModel  SpecialUrbanMsc
-/mcPhysics/emModel/setRegions  EMCAL_Lead$ EMCAL_Scintillator$
+/mcPhysics/emModel/setRegions  EMC_Lead$ EMC_Scintillator$
 /mcPhysics/emModel/setParticles  e- e+


### PR DESCRIPTION
- in fit::Detector - moved definition of optical properties in ConstructOpGeometry(); fixed copy ctor
- in zdc::Detector - fixed materials definitions
- in phos::Detector - moved defition of sensitive volumes to InitO2Detector()
- in g4config.in - fixed the media names for setting SpecialUrbanMsc model
- in g4Config.C - added commented lines for entering in Geant4 UI (useful for debugging)
- in Data::Stack - added more info in printing about a nonconform detector