### PR TITLE
Fix sensitiveVolume function in TPC

### DIFF
--- a/Detectors/TPC/simulation/include/TPCSimulation/Detector.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/Detector.h
@@ -163,7 +163,7 @@ class Detector: public o2::Base::DetImpl<Detector> {
     void ConstructTPCGeometry();
 
     /** Define the sensitive volumes of the geometry */
-    void DefineSensitiveVolumes() override;
+    void defineSensitiveVolumes();
 
     /** container for produced hits */
     std::vector<HitGroup>*  mHitsPerSectorCollection[Sector::MAXSECTOR]; //! container that keeps track-grouped hits per sector

--- a/Detectors/TPC/simulation/src/Detector.cxx
+++ b/Detectors/TPC/simulation/src/Detector.cxx
@@ -95,7 +95,7 @@ Detector::~Detector()
 void Detector::InitializeO2Detector()
 {
   // Define the list of sensitive volumes
-  DefineSensitiveVolumes();
+  defineSensitiveVolumes();
 }
 
 void Detector::SetSpecialPhysicsCuts()
@@ -3027,7 +3027,7 @@ void Detector::LoadGeometryFromFile()
   alice->AddNode(tpcVolume, 1);
 }
 
-void Detector::DefineSensitiveVolumes()
+void Detector::defineSensitiveVolumes()
 {
   TGeoManager* geoManager = gGeoManager;
   TGeoVolume* v = nullptr;


### PR DESCRIPTION
This aligns/uniformizes the definition of TPC sensitive
volumes with how its done for other detectors.
In fact TPC was the only one overriding a FairRoot interface
for this which is now going to be deprecated.

This commit fixes a compile error for defaults-fairroot-dev.