### PR TITLE
ConfigurableParam: Support for std::string parameter values

### DIFF
--- a/Common/SimConfig/doc/ConfigurableParam.md
+++ b/Common/SimConfig/doc/ConfigurableParam.md
@@ -86,7 +86,7 @@ Thereafter, the parameter `ParamA` is automatically registered in a parameter re
 
 * Parameter classes may only contain simple members! Currently the following types are supported
     * simple pods (for example `double x; char y;`)
-    * simple char strings (`char *`)
+    * std::string
     * fixed size arrays of pods using the ROOT way to serialize:
        ```c++
        static constexpr int N=3; //!

--- a/Common/SimConfig/include/SimConfig/ConfigurableParam.h
+++ b/Common/SimConfig/include/SimConfig/ConfigurableParam.h
@@ -105,9 +105,9 @@ class ConfigurableParam
   static void printAllKeyValuePairs();
 
   // writes a human readable JSON file of all parameters
-  static void writeJSON(std::string filename);
+  static void writeJSON(std::string const& filename);
   // writes a human readable INI file of all parameters
-  static void writeINI(std::string filename);
+  static void writeINI(std::string const& filename);
 
   // can be used instead of using API on concrete child classes
   template <typename T>
@@ -120,7 +120,7 @@ class ConfigurableParam
   }
 
   template <typename T>
-  static void setValue(std::string mainkey, std::string subkey, T x)
+  static void setValue(std::string const& mainkey, std::string const& subkey, T x)
   {
     auto key = mainkey + "." + subkey;
     if (sPtree->get_optional<std::string>(key).is_initialized()) {
@@ -134,7 +134,7 @@ class ConfigurableParam
 
   // specialized for std::string
   // which means that the type will be converted internally
-  static void setValue(std::string key, std::string valuestring)
+  static void setValue(std::string const& key, std::string const& valuestring)
   {
     if (sPtree->get_optional<std::string>(key).is_initialized()) {
       sPtree->put(key, valuestring);
@@ -157,7 +157,7 @@ class ConfigurableParam
   // (certain) key-values
   // propagates changes down to each registered configuration
   // might be useful to get stuff from the command line
-  static void updateFromString(std::string);
+  static void updateFromString(std::string const&);
 
  protected:
   // constructor is doing nothing else but
@@ -166,7 +166,7 @@ class ConfigurableParam
 
   static void initPropertyTree();
   static bool updateThroughStorageMap(std::string, std::string, std::type_info const&, void*);
-  static bool updateThroughStorageMapWithConversion(std::string, std::string);
+  static bool updateThroughStorageMapWithConversion(std::string const&, std::string const&);
 
   virtual ~ConfigurableParam() = default;
 
@@ -177,7 +177,7 @@ class ConfigurableParam
 
   // static map keeping, for each configuration key, its memory location and type
   // (internal use to easily sync updates, this is ok since parameter classes are singletons)
-  static std::map<std::string, std::pair<int, void*>>* sKeyToStorageMap;
+  static std::map<std::string, std::pair<std::type_info const&, void*>>* sKeyToStorageMap;
 
   // keep track of provenance of parameters and values
   static std::map<std::string, ConfigurableParam::EParamProvenance>* sValueProvenanceMap;

--- a/Common/SimConfig/include/SimConfig/ConfigurableParamHelper.h
+++ b/Common/SimConfig/include/SimConfig/ConfigurableParamHelper.h
@@ -33,7 +33,7 @@ class _ParamHelper
                                   std::map<std::string, ConfigurableParam::EParamProvenance> const* provmap);
 
   static void fillKeyValuesImpl(std::string mainkey, TClass* cl, void*, boost::property_tree::ptree*,
-                                std::map<std::string, std::pair<int, void*>>*);
+                                std::map<std::string, std::pair<std::type_info const&, void*>>*);
 
   static void printWarning(std::type_info const&);
 


### PR DESCRIPTION
This commit enables support for std::string members in parameter classes:
```
struct Param : ConfigurableParamHelper<Param> {
  std::string name = "defaultString";
};
```
will now work and be modifyable through the offered APIs.

std::string is the only way to represent strings. char* will not work.