### PR TITLE
Do not use FairLogger::endl

### DIFF
--- a/Detectors/TOF/reconstruction/src/Clusterer.cxx
+++ b/Detectors/TOF/reconstruction/src/Clusterer.cxx
@@ -33,13 +33,13 @@ void Clusterer::process(DataReader& reader, std::vector<Cluster>& clusters, MCLa
 
   while (reader.getNextStripData(mStripData)) {
     LOG(DEBUG) << "TOFClusterer got Strip " << mStripData.stripID << " with Ndigits "
-               << mStripData.digits.size() << FairLogger::endl;
+               << mStripData.digits.size();
     totNumDigits += mStripData.digits.size();
 
     processStrip(clusters, digitMCTruth);
   }
 
-  LOG(DEBUG) << "We had " << totNumDigits << " digits in this event \n";
+  LOG(DEBUG) << "We had " << totNumDigits << " digits in this event";
 }
 
 //__________________________________________________
@@ -54,7 +54,7 @@ void Clusterer::processStrip(std::vector<Cluster>& clusters, MCLabelContainer co
   Int_t ieta, ieta2, ieta3; // it is the number of padz-row increasing along the various strips
 
   for (int idig = 0; idig < mStripData.digits.size(); idig++) {
-    //    LOG(DEBUG) << "Checking digit " << idig << "\n";
+    //    LOG(DEBUG) << "Checking digit " << idig;
     Digit* dig = &mStripData.digits[idig];
     if (dig->isUsedInCluster())
       continue; // the digit was already used to build a cluster
@@ -62,7 +62,7 @@ void Clusterer::processStrip(std::vector<Cluster>& clusters, MCLabelContainer co
     mNumberOfContributingDigits = 0;
     dig->getPhiAndEtaIndex(iphi, ieta);
     if (mStripData.digits.size() > 1)
-      LOG(DEBUG) << "idig = " << idig << "\n";
+      LOG(DEBUG) << "idig = " << idig;
 
     // first we make a cluster out of the digit
     int noc = clusters.size();
@@ -78,14 +78,14 @@ void Clusterer::processStrip(std::vector<Cluster>& clusters, MCLabelContainer co
         continue; // the digit was already used to build a cluster
       // check if the TOF time are close enough to be merged; if not, it means that nothing else will contribute to the cluster (since digits are ordered in time)
       float timeDigNext = digNext->getTDC() * Geo::TDCBIN; // we assume it calibrated (for now); in ps
-      LOG(DEBUG) << "Time difference = " << timeDigNext - timeDig << "\n";
+      LOG(DEBUG) << "Time difference = " << timeDigNext - timeDig;
       if (timeDigNext - timeDig > 500 /*in ps*/)
         break;
       digNext->getPhiAndEtaIndex(iphi2, ieta2);
 
       // check if the fired pad are close in space
-      LOG(DEBUG) << "phi difference = " << iphi - iphi2 << "\n";
-      LOG(DEBUG) << "eta difference = " << ieta - ieta2 << "\n";
+      LOG(DEBUG) << "phi difference = " << iphi - iphi2;
+      LOG(DEBUG) << "eta difference = " << ieta - ieta2;
       if ((TMath::Abs(iphi - iphi2) > 1) || (TMath::Abs(ieta - ieta2) > 1))
         continue;
 
@@ -105,7 +105,7 @@ void Clusterer::addContributingDigit(Digit* dig)
   // adding a digit to the array that stores the contributing ones
 
   if (mNumberOfContributingDigits == 6) {
-    LOG(ERROR) << "The cluster has already 6 digits associated to it, we cannot add more; returning without doing anything" << FairLogger::endl;
+    LOG(ERROR) << "The cluster has already 6 digits associated to it, we cannot add more; returning without doing anything";
   }
   mContributingDigit[mNumberOfContributingDigits] = dig;
   mNumberOfContributingDigits++;
@@ -170,10 +170,10 @@ void Clusterer::buildCluster(Cluster& c, MCLabelContainer const* digitMCTruth)
       } else if (deltaEta == -1) { // the digit is UP wrt the cluster
         mask = Cluster::kUp;
       } else { // impossible!!
-        LOG(DEBUG) << " Check what is going on, the digit you are trying to merge to the cluster must be in a different channels... " << FairLogger::endl;
+        LOG(DEBUG) << " Check what is going on, the digit you are trying to merge to the cluster must be in a different channels... ";
       }
     } else { // impossible!!! We checked above...
-      LOG(DEBUG) << " Check what is going on, the digit you are trying to merge to the cluster is too far from the cluster, you should have not got here... " << FairLogger::endl;
+      LOG(DEBUG) << " Check what is going on, the digit you are trying to merge to the cluster is too far from the cluster, you should have not got here... ";
     }
     c.addBitInContributingChannels(mask);
   }


### PR DESCRIPTION
This commit is removing lots of anwanted empty
lines in the output of TOF digitizer.
Note that with FairLogger it is no longer
necessary to put "\n" nor FairLogger::endl;

Now the text output of the DPL digitizer workflow is
substantially smaller.