### PR TITLE
CMD line configurable interaction diamond for vertex spread in simulation

### DIFF
--- a/Generators/CMakeLists.txt
+++ b/Generators/CMakeLists.txt
@@ -9,11 +9,15 @@ set(SRCS
     src/GeneratorFromFile.cxx
     src/Pythia6Generator.cxx
     src/PDG.cxx	
+    src/PrimaryGenerator.cxx
+    src/InteractionDiamondParam.cxx
    )
 set(HEADERS
     include/${MODULE_NAME}/GeneratorFromFile.h
     include/${MODULE_NAME}/Pythia6Generator.h
     include/${MODULE_NAME}/PDG.h
+    include/${MODULE_NAME}/PrimaryGenerator.h
+    include/${MODULE_NAME}/InteractionDiamondParam.h
    )
 if (HAVESIMULATION)
   set(HEADERS ${HEADERS}

--- a/Generators/include/Generators/InteractionDiamondParam.h
+++ b/Generators/include/Generators/InteractionDiamondParam.h
@@ -1,0 +1,39 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author R+Preghenella - October 2018
+
+#ifndef ALICEO2_EVENTGEN_INTERACTIONDIAMONDPARAM_H_
+#define ALICEO2_EVENTGEN_INTERACTIONDIAMONDPARAM_H_
+
+#include "SimConfig/ConfigurableParam.h"
+#include "SimConfig/ConfigurableParamHelper.h"
+
+namespace o2
+{
+namespace eventgen
+{
+
+/**
+ ** a parameter class/struct to keep the settings of
+ ** the interaction diamond (position and width) and 
+ ** allow the user to modify them 
+ **/
+
+struct InteractionDiamondParam : public o2::conf::ConfigurableParamHelper<InteractionDiamondParam> {
+  double position[3] = { 0., 0., 0. };
+  double width[3] = { 0., 0., 0. };
+  O2ParamDef(InteractionDiamondParam, "Diamond");
+};
+
+} // end namespace eventgen
+} // end namespace o2
+
+#endif // ALICEO2_EVENTGEN_INTERACTIONDIAMONDPARAM_H_

--- a/Generators/include/Generators/PrimaryGenerator.h
+++ b/Generators/include/Generators/PrimaryGenerator.h
@@ -1,0 +1,59 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See https://alice-o2.web.cern.ch/ for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author R+Preghenella - June 2017
+
+#ifndef ALICEO2_EVENTGEN_PRIMARYGENERATOR_H_
+#define ALICEO2_EVENTGEN_PRIMARYGENERATOR_H_
+
+#include "FairPrimaryGenerator.h"
+
+namespace o2
+{
+namespace eventgen
+{
+
+/** 
+ ** custom primary generator in order to be able to deal with
+ ** specific O2 matters, like initialisation, generation, ...
+ **/
+
+class PrimaryGenerator : public FairPrimaryGenerator
+{
+
+ public:
+  /** default constructor **/
+  PrimaryGenerator() = default;
+  /** destructor **/
+  virtual ~PrimaryGenerator() = default;
+
+  /** initialize the generator **/
+  virtual Bool_t Init() override;
+
+ protected:
+  /** copy constructor **/
+  PrimaryGenerator(const PrimaryGenerator&) = default;
+  /** operator= **/
+  PrimaryGenerator& operator=(const PrimaryGenerator&) = default;
+
+  /** set interaction diamond position **/
+  void setInteractionDiamond(const Double_t* xyz, const Double_t* sigmaxyz);
+
+  ClassDefOverride(PrimaryGenerator, 1);
+
+}; /** class PrimaryGenerator **/
+
+/*****************************************************************/
+/*****************************************************************/
+
+} /* namespace eventgen */
+} /* namespace o2 */
+
+#endif /* ALICEO2_EVENTGEN_PRIMARYGENERATOR_H_ */

--- a/Generators/src/GeneratorsLinkDef.h
+++ b/Generators/src/GeneratorsLinkDef.h
@@ -31,5 +31,8 @@
 #pragma link C++ class  o2::eventgen::GeneratorFromFile+;
 #pragma link C++ class  o2::eventgen::GeneratorFactory+;
 #pragma link C++ class o2::PDG + ;
+#pragma link C++ class o2::eventgen::PrimaryGenerator + ;
+#pragma link C++ class o2::eventgen::InteractionDiamondParam + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::eventgen::InteractionDiamondParam> + ;
 
 #endif

--- a/Generators/src/InteractionDiamondParam.cxx
+++ b/Generators/src/InteractionDiamondParam.cxx
@@ -1,0 +1,14 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author R+Preghenella - October 2018
+
+#include "Generators/InteractionDiamondParam.h"
+O2ParamImpl(o2::eventgen::InteractionDiamondParam);

--- a/Generators/src/PrimaryGenerator.cxx
+++ b/Generators/src/PrimaryGenerator.cxx
@@ -1,0 +1,60 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author R+Preghenella - June 2017
+
+#include "Generators/PrimaryGenerator.h"
+#include "Generators/InteractionDiamondParam.h"
+#include "FairLogger.h"
+
+namespace o2
+{
+namespace eventgen
+{
+
+/*****************************************************************/
+
+Bool_t PrimaryGenerator::Init()
+{
+  /** init **/
+
+  /** retrieve and set interaction diamond **/
+  auto diamond = InteractionDiamondParam::Instance();
+  setInteractionDiamond(diamond.position, diamond.width);
+
+  /** base class init **/
+  return FairPrimaryGenerator::Init();
+}
+
+/*****************************************************************/
+
+void PrimaryGenerator::setInteractionDiamond(const Double_t* xyz, const Double_t* sigmaxyz)
+{
+  /** set interaction diamond **/
+
+  LOG(INFO) << "Setting interaction diamond: position = {"
+            << xyz[0] << "," << xyz[1] << "," << xyz[2] << "} cm";
+  LOG(INFO) << "Setting interaction diamond: width = {"
+            << sigmaxyz[0] << "," << sigmaxyz[1] << "," << sigmaxyz[2] << "} cm";
+  SetBeam(xyz[0], xyz[1], sigmaxyz[0], sigmaxyz[1]);
+  SetTarget(xyz[2], sigmaxyz[2]);
+  SmearVertexXY(false);
+  SmearVertexZ(false);
+  SmearGausVertexXY(true);
+  SmearGausVertexZ(true);
+}
+
+/*****************************************************************/
+/*****************************************************************/
+
+} /* namespace eventgen */
+} /* namespace o2 */
+
+ClassImp(o2::eventgen::PrimaryGenerator)

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -1173,6 +1173,7 @@ o2_define_bucket(
     INCLUDE_DIRECTORIES
     ${ROOT_INCLUDE_DIR}
     ${FAIRROOT_INCLUDE_DIR}
+    ${CMAKE_SOURCE_DIR}/Common/SimConfig/include
 )
 
 o2_define_bucket(

--- a/macro/o2sim.C
+++ b/macro/o2sim.C
@@ -10,7 +10,7 @@
 
 #include "build_geometry.C"
 #if !defined(__CLING__) || defined(__ROOTCLING__)
-#include <FairPrimaryGenerator.h>
+#include <Generators/PrimaryGenerator.h>
 #include <Generators/GeneratorFactory.h>
 #include <Generators/PDG.h>
 #include <SimConfig/SimConfig.h>
@@ -68,7 +68,7 @@ FairRunSim* o2sim_init(bool asservice)
   build_geometry(run);
 
   // setup generator
-  auto primGen = new FairPrimaryGenerator();
+  auto primGen = new o2::eventgen::PrimaryGenerator();
   if (!asservice) {
     o2::eventgen::GeneratorFactory::setPrimaryGenerator(confref, primGen);
   }


### PR DESCRIPTION
This PR implements a configurable setup for the simulation of the vertex spread in simulation.
A configurable `InteractionDiamondParam` is queried while `Init` the `PrimaryGenerator`, which in turns sets itself up to generate events according to the requested configuration.

The user can configure the xyz values of the position (`position`) and gaussian width (`width`) of the interaction diamond  via `o2sim` command line arguments.

The default xyz values of the position (`position`) and width (`width`) of the interaction diamond are `position[3] = {0., 0., 0.}` and `width[3] = {0., 0., 0.}`. By default, vertices are always generated at `{0., 0., 0.}` with no spread.

For instance, to configure the z-width of the interaction diamond to be 6 cm, add
`--configKeyValue "Diamond.width[2]=6."`
to the `o2sim` line.

Similarly, to configure the y-position of the interaction diamond to be -2mm, add
`--configKeyValue "Diamond.position[1]=-0.2"`
to the `o2sim` line.

To simultaneously configure xyz-position (or width) of the interaction diamond has to be done with (notice no spaces are allowed)
`--configKeyValue "Diamond.position[0]=1.,Diamond.position[1]=1.,Diamond.position[2]=1."`

Future developments in the line of "A concept for configurable parameters" which started with PR #1285 will possibly allow to streamline the setting of xyz values simultaneously in a more compact way.