### PR TITLE
Safety improvements to the ConfigurableParam concepts

### DIFF
--- a/Common/SimConfig/src/ConfigurableParam.cxx
+++ b/Common/SimConfig/src/ConfigurableParam.cxx
@@ -159,7 +159,7 @@ void ConfigurableParam::updateFromString(std::string configstring)
 
       setValue(extractedkey, extractedvalue);
     } else {
-      LOG(WARN) << "Configuration key " << extractedkey << " not valid ... (ignoring)";
+      LOG(FATAL) << "Configuration key " << extractedkey << " not valid ... (abort)";
       continue;
     }
   }

--- a/Common/SimConfig/src/ConfigurableParam.cxx
+++ b/Common/SimConfig/src/ConfigurableParam.cxx
@@ -140,7 +140,14 @@ void ConfigurableParam::updateFromString(std::string configstring)
     std::string extractedvalue;
     int counter = 0;
     // TODO: make sure format is correct with a regular expression
-    for (const auto& s : keyvaluetokenizer) {
+    for (const auto& ss : keyvaluetokenizer) {
+      auto s = ss;
+      if (s.front() != s.back() || (s.front() != '\'' && s.front() == '\"')) { // not a string
+        s.erase(std::remove(s.begin(), s.end(), ' '), s.end());                // remove all spaces
+      } else {                                                                 // a string
+        s.erase(0, s.find_first_not_of(' '));                                  // remove leading spaces
+        s.erase(s.find_last_not_of(' ') + 1);                                  // remove trailing spaces
+      }
       if (counter == 1) {
         extractedvalue = s;
       }


### PR DESCRIPTION
this PR provides two commits aimed at improving the safety of the use of the ConfigurableParam concept which started with PR #1285.

1. The first commit modifies the current behaviour from WARN to FATAL in case a configuration key is not found and/or is invalid. This will ensure that any attempt to modify not-existing parameters will lead to the crash of the execution.

2. The second commit allows the user to use a potentially more screen-friendly input string and use spaces as he/she wishes. It simply removes the spaces from the configuration string before parsing. Configuration strings such as
`--configKeyValue "HallSim.mCUTGAM = 2, HallSim.mCUTELE = 3"`
are therefore allowed, and will correspond exactly to
`--configKeyValue "HallSim.mCUTGAM=2,HallSim.mCUTELE=3"` in the previous implementation.

