### PR TITLE
Restore TPC quasi-triggered readout mode for digitization-workflow

### DIFF
--- a/DataFormats/common/CMakeLists.txt
+++ b/DataFormats/common/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SRCS
 Set(HEADERS
   include/${MODULE_NAME}/TimeStamp.h
   include/${MODULE_NAME}/EvIndex.h
+  include/${MODULE_NAME}/RangeReference.h
   include/${MODULE_NAME}/InteractionRecord.h
   include/${MODULE_NAME}/BunchFilling.h  
 )

--- a/DataFormats/common/include/CommonDataFormat/RangeReference.h
+++ b/DataFormats/common/include/CommonDataFormat/RangeReference.h
@@ -1,0 +1,54 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file RangeReference.h
+/// \brief Class to refered to the 1st entry and N elements of some group in the continuous container
+/// \author ruben.shahoyan@cern.ch
+
+#ifndef ALICEO2_RANGEREFERENCE_H
+#define ALICEO2_RANGEREFERENCE_H
+
+#include <Rtypes.h>
+
+namespace o2
+{
+namespace dataformats
+{
+// Composed range reference
+
+template <typename FirstEntry = int, typename NElem = int>
+class RangeReference
+{
+ public:
+  RangeReference(FirstEntry ent, NElem n) { set(ent, n); }
+  RangeReference(const RangeReference<FirstEntry, NElem>& src) = default;
+  RangeReference() = default;
+  ~RangeReference() = default;
+  void set(FirstEntry ent, NElem n)
+  {
+    mFirstEntry = ent;
+    mEntries = n;
+  }
+  FirstEntry getFirstEntry() const { return mFirstEntry; }
+  NElem getEntries() const { return mEntries; }
+  void setFirstEntry(FirstEntry ent) { mFirstEntry = ent; }
+  void setEntries(NElem n) { mEntries = n; }
+  void changeEntriesBy(NElem inc) { mEntries += inc; }
+
+ private:
+  FirstEntry mFirstEntry; ///< 1st entry of the group
+  NElem mEntries = 0;     ///< number of entries
+
+  ClassDefNV(RangeReference, 1);
+};
+} // namespace dataformats
+} // namespace o2
+
+#endif

--- a/DataFormats/common/src/CommonDataFormatLinkDef.h
+++ b/DataFormats/common/src/CommonDataFormatLinkDef.h
@@ -30,6 +30,9 @@
 #pragma link C++ class o2::dataformats::TimeStampWithError < int, int > +;
 
 #pragma link C++ class o2::dataformats::EvIndex < int, int > +;
+#pragma link C++ class o2::dataformats::RangeReference < int, int > +;
+#pragma link C++ class o2::dataformats::RangeReference < o2::dataformats::EvIndex < int, int >, int > +;
+
 #pragma link C++ class o2::InteractionRecord + ;
 #pragma link C++ class o2::BunchFilling + ;
 

--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitizerTask.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitizerTask.h
@@ -63,6 +63,9 @@ class DigitizerTask : public FairTask
   /// \param isContinuous - false for triggered readout, true for continuous readout
   void setContinuousReadout(bool isContinuous);
 
+  /// query if the r/o mode is continuous
+  bool isContinuousReadout() const { return mIsContinuousReadout; }
+
   /// Enable the use of space-charge distortions
   /// \param distortionType select the type of space-charge distortions (constant or realistic)
   /// \param hisInitialSCDensity optional space-charge density histogram to use at the beginning of the simulation

--- a/Detectors/TPC/simulation/include/TPCSimulation/HitDriftFilter.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/HitDriftFilter.h
@@ -82,6 +82,69 @@ void getHits(TChain& chain, const Collection& eventrecords, std::vector<std::vec
 
 inline void getHits(std::vector<TChain*> const& chains, const o2::steer::RunContext& runcontext,
                     std::vector<std::vector<o2::TPC::HitGroup>*>& hitvectors,
+                    std::vector<o2::TPC::TPCHitGroupID>& hitids, const std::string_view branchname,
+                    int collision)
+{
+  // Collect hits of single collision in the run context
+  hitids.clear();
+
+  // helper to fetch right branch
+  auto fetchBranch = [chains, branchname](int source) -> TBranch* {
+    if (!chains[source]) {
+      return nullptr;
+    }
+    auto& chain = *chains[source];
+    auto br = chain.GetBranch(branchname.data());
+    if (!br) {
+      return nullptr;
+    }
+    return br;
+  };
+
+  // number of collision given by runcontext
+  const auto& eventrecords = runcontext.getEventRecords();
+  auto ncollisions = eventrecords.size();
+  if (collision >= ncollisions) {
+    LOG(ERROR) << "runContext contains" << ncollisions << " collisions, " << collision << " is requested";
+    return;
+  }
+  const auto& parts = runcontext.getEventParts();
+  const auto maxpartspercollision = runcontext.getMaxNumberParts();
+
+  const auto& theseparts = parts[collision];
+  for (int p = 0; p < theseparts.size(); ++p) {
+    // compute where to store the hits
+    const auto eventID = theseparts[p].entryID;
+    const auto source = theseparts[p].sourceID;
+    const auto storeentry = eventID * maxpartspercollision + source;
+
+    // retrieve correct branch and fill the vector
+    // This needs to be done only once for any entry per chain
+    // retrieve source
+    if (hitvectors[storeentry] == nullptr) {
+      // TODO: instead of trying to fetch all the time .. do this outside and cache
+      auto br = fetchBranch(source);
+      br->SetAddress(&hitvectors[storeentry]);
+      br->GetEntry(eventID);
+    }
+
+    int groupid = -1;
+    auto groups = hitvectors[storeentry];
+    for (auto& singlegroup : *groups) {
+      if (singlegroup.getSize() == 0) {
+        // there are not hits in this group .. so continue
+        // TODO: figure out why such a group would exist??
+        continue;
+      }
+      groupid++;
+      // need to record index of the group
+      hitids.emplace_back(storeentry, collision, eventID, groupid, source);
+    } // end loop over entries
+  }
+}
+
+inline void getHits(std::vector<TChain*> const& chains, const o2::steer::RunContext& runcontext,
+                    std::vector<std::vector<o2::TPC::HitGroup>*>& hitvectors,
                     std::vector<o2::TPC::TPCHitGroupID>& hitids, const std::string_view branchname, float tmin /*NS*/,
                     float tmax /*NS*/, std::function<float(float, float, float)>&& f)
 {

--- a/Detectors/TPC/simulation/src/Digitizer.cxx
+++ b/Detectors/TPC/simulation/src/Digitizer.cxx
@@ -59,7 +59,6 @@ DigitContainer* Digitizer::Process(const Sector& sector, const std::vector<o2::T
   if (!mIsContinuous) {
     eventTime = 0.f;
   }
-
   /// TODO: if eventtime-lastUpdate>=one space-charge time slice
   ///  1) Propagate current space-charge density
   ///  2) recalculate distortion lookup tables with updated space-charge density
@@ -79,7 +78,8 @@ DigitContainer* Digitizer::Process2(const Sector& sector, const std::vector<std:
     const auto hitvector = hits[id.storeindex];
     auto& group = (*hitvector)[id.groupID];
     auto& MCrecord = interactRecords[id.entry];
-    ProcessHitGroup(group, sector, MCrecord.timeNS * 0.001f, id.entry, id.sourceID);
+    float evTime = mIsContinuous ? MCrecord.timeNS * 0.001f : 0.f;
+    ProcessHitGroup(group, sector, evTime, id.entry, id.sourceID);
   }
 
   return mDigitContainer;

--- a/Steer/DigitizerWorkflow/src/ITSMFTDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/ITSMFTDigitizerSpec.cxx
@@ -339,8 +339,7 @@ DataProcessorSpec getITSDigitizerSpec(int channel)
                               { "simFile", VariantType::String, "o2sim.root", { "Sim (background) input filename" } },
                               { "simFileS", VariantType::String, "", { "Sim (signal) input filename" } },
                               { "simFileQED", VariantType::String, "", { "Sim (QED) input filename" } },
-			      { (detStr + "triggered").c_str(), VariantType::Bool, false,
-			      { "Impose triggered RO mode (default: continuous)" } } } };
+                              { (detStr + "triggered").c_str(), VariantType::Bool, false, { "Impose triggered RO mode (default: continuous)" } } } };
 }
 
 DataProcessorSpec getMFTDigitizerSpec(int channel)
@@ -361,8 +360,7 @@ DataProcessorSpec getMFTDigitizerSpec(int channel)
                               { "simFile", VariantType::String, "o2sim.root", { "Sim (background) input filename" } },
                               { "simFileS", VariantType::String, "", { "Sim (signal) input filename" } },
                               { "simFileQED", VariantType::String, "", { "Sim (QED) input filename" } },
-                              { (detStr + "triggered").c_str(), VariantType::Bool, false,
-			      { "Impose triggered RO mode (default: continuous)" } } } };
+                              { (detStr + "triggered").c_str(), VariantType::Bool, false, { "Impose triggered RO mode (default: continuous)" } } } };
 }
 
 } // end namespace ITSMFT

--- a/Steer/DigitizerWorkflow/src/ITSMFTDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/ITSMFTDigitizerSpec.cxx
@@ -60,7 +60,7 @@ class ITSMFTDPLDigitizerTask
       LOG(INFO) << "Attach QED Tree: " << mQEDChain.GetEntries() << FairLogger::endl;
     }
     std::string roString = mID.getName();
-    bool triggeredMode = (ic.options().get<int>((roString + "triggered").c_str()));
+    auto triggeredMode = (ic.options().get<bool>((roString + "triggered").c_str()));
     if (!triggeredMode) {
       mROMode = o2::parameters::GRPObject::CONTINUOUS;
     }
@@ -339,7 +339,8 @@ DataProcessorSpec getITSDigitizerSpec(int channel)
                               { "simFile", VariantType::String, "o2sim.root", { "Sim (background) input filename" } },
                               { "simFileS", VariantType::String, "", { "Sim (signal) input filename" } },
                               { "simFileQED", VariantType::String, "", { "Sim (QED) input filename" } },
-                              { (detStr + "triggered").c_str(), VariantType::Int, 0, { "Triggered RO mode (D: continuous)" } } } };
+			      { (detStr + "triggered").c_str(), VariantType::Bool, false,
+			      { "Impose triggered RO mode (default: continuous)" } } } };
 }
 
 DataProcessorSpec getMFTDigitizerSpec(int channel)
@@ -360,7 +361,8 @@ DataProcessorSpec getMFTDigitizerSpec(int channel)
                               { "simFile", VariantType::String, "o2sim.root", { "Sim (background) input filename" } },
                               { "simFileS", VariantType::String, "", { "Sim (signal) input filename" } },
                               { "simFileQED", VariantType::String, "", { "Sim (QED) input filename" } },
-                              { (detStr + "triggered").c_str(), VariantType::Int, 0, { "Triggered RO mode (D: continuous)" } } } };
+                              { (detStr + "triggered").c_str(), VariantType::Bool, false,
+			      { "Impose triggered RO mode (default: continuous)" } } } };
 }
 
 } // end namespace ITSMFT

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -1804,6 +1804,7 @@ o2_define_bucket(
     Steer
     Framework
     DetectorsCommonDataFormats
+    CommonDataFormat
     TPCSimulation
     TPCWorkflow
     DataFormatsTPC


### PR DESCRIPTION
When called with ```--TPCtriggered``` option the digitizer-workflow will go to event based processing mode: the interaction time from the sampler will not be added to the time-bin of the digits.
Still, digits from different events are stored in a single entry of the output tree (need to change this).

This is still not a triggered readout since events which are separated by less than 1 drift time will still be processed separately. Eventually, a proper trigger logics should be introduced. @davidrohr , this should be enough to avoid gap between A and C side clusters, I've checked, the reconstruction works even though the digits from different events are piled up in a single entry. Btw, when reconstructing w/o ```cont``` option, I get some clusters on the wrong side:
```
7649]: [23:56:55][INFO] Removing cluster 3 time: 485.109, abs. z: -0.316422
[7649]: [23:56:55][INFO] Removing cluster 3 time: 489.188, abs. z: -2.42073
[7649]: [23:56:55][INFO] Removing cluster 5 time: 485.453, abs. z: -0.493805
[7649]: [23:56:55][INFO] Removing cluster 10 time: 485.812, abs. z: -0.67923
[7649]: [23:56:55][INFO] Removing cluster 10 time: 485.141, abs. z: -0.33255
```
I don't understand why this should happen when the same vdrift is used for digitization and reconstruction.

Cheers
 Ruben