### PR TITLE
DPL: add support for dangling outputs

### DIFF
--- a/DataFormats/Headers/include/Headers/DataHeader.h
+++ b/DataFormats/Headers/include/Headers/DataHeader.h
@@ -205,6 +205,11 @@ struct DescriptorCompareTraits {
   static bool compare(const T &lh, const T &rh, Length N) {
     return std::memcmp(lh.str, rh.str, N) == 0;
   }
+  template <typename T, typename Length>
+  static bool lessThen(const T& lh, const T& rh, Length N)
+  {
+    return std::memcmp(lh.str, rh.str, N) < 0;
+  }
 };
 template<>
 struct DescriptorCompareTraits<1> {
@@ -212,12 +217,22 @@ struct DescriptorCompareTraits<1> {
   static bool compare(const T &lh, const T &rh, Length) {
     return lh.itg[0] == rh.itg[0];
   }
+  template <typename T, typename Length>
+  static bool lessThen(const T& lh, const T& rh, Length)
+  {
+    return lh.itg[0] < rh.itg[0];
+  }
 };
 template<>
 struct DescriptorCompareTraits<2> {
   template<typename T, typename Length>
   static bool compare(const T &lh, const T &rh, Length) {
     return (lh.itg[0] == rh.itg[0]) && (lh.itg[1] == rh.itg[1]);
+  }
+  template <typename T, typename Length>
+  static bool lessThen(const T& lh, const T& rh, Length)
+  {
+    return std::tie(lh.itg[0], lh.itg[1]) < std::tie(rh.itg[0], rh.itg[1]);
   }
 };
 
@@ -293,6 +308,7 @@ struct Descriptor {
   }
 
   bool operator==(const Descriptor& other) const {return DescriptorCompareTraits<arraySize>::compare(*this,other, N);}
+  bool operator<(const Descriptor& other) const { return DescriptorCompareTraits<arraySize>::lessThen(*this, other, N); }
   bool operator!=(const Descriptor& other) const {return not this->operator==(other);}
 
   // explicitly forbid comparison with e.g. const char* strings

--- a/DataFormats/Headers/test/testDataHeader.cxx
+++ b/DataFormats/Headers/test/testDataHeader.cxx
@@ -132,6 +132,11 @@ namespace o2 {
       BOOST_CHECK(desc.as<std::string>().length() == 6);
       BOOST_CHECK(runtimeDesc.as<std::string>().length() == 16);
       BOOST_CHECK(DataDescription("INVALIDDATA").as<std::string>().length() == 11);
+
+      BOOST_CHECK(DataDescription("A") < DataDescription("B"));
+      BOOST_CHECK(DataDescription("AA") < DataDescription("AB"));
+      BOOST_CHECK(DataDescription("AAA") < DataDescription("AAB"));
+      BOOST_CHECK(DataDescription("AAA") < DataDescription("ABA"));
     }
 
     BOOST_AUTO_TEST_CASE(DataOrigin_test)
@@ -141,12 +146,56 @@ namespace o2 {
       using TestDescriptorT = Descriptor<descriptorSize>;
       BOOST_CHECK(TestDescriptorT::size == descriptorSize);
       BOOST_CHECK(TestDescriptorT::bitcount == descriptorSize * 8);
-      BOOST_CHECK(sizeof(TestDescriptorT::ItgType)*TestDescriptorT::arraySize == descriptorSize);
+      BOOST_CHECK(sizeof(TestDescriptorT::ItgType) * TestDescriptorT::arraySize == descriptorSize);
       BOOST_CHECK(TestDescriptorT::size == sizeof(DataOrigin));
 
       // we want to explicitely have the size of DataOrigin to be 4
       static_assert(sizeof(DataOrigin) == 4,
                     "DataOrigin struct must be of size 4");
+
+      // Check that ordering works.
+      BOOST_CHECK(DataOrigin("A") < DataOrigin("B"));
+      BOOST_CHECK(DataOrigin("AA") < DataOrigin("AB"));
+      BOOST_CHECK(DataOrigin("AAA") < DataOrigin("AAB"));
+      BOOST_CHECK(DataOrigin("AAA") < DataOrigin("ABA"));
+      std::vector<DataOrigin> v1 = { DataOrigin("B"), DataOrigin("C"), DataOrigin("A") };
+      std::sort(v1.begin(), v1.end());
+      BOOST_CHECK_EQUAL(v1[0], DataOrigin("A"));
+      BOOST_CHECK_EQUAL(v1[1], DataOrigin("B"));
+      BOOST_CHECK_EQUAL(v1[2], DataOrigin("C"));
+      std::vector<DataOrigin> v2 = { DataOrigin("A"), DataOrigin("B") };
+      std::sort(v2.begin(), v2.end());
+      BOOST_CHECK_EQUAL(v2[0], DataOrigin("A"));
+      BOOST_CHECK_EQUAL(v2[1], DataOrigin("B"));
+
+      using CustomHeader = std::tuple<DataOrigin, DataDescription>;
+      std::vector<CustomHeader> v3{ CustomHeader{ "TST", "B" }, CustomHeader{ "TST", "A" } };
+      std::sort(v3.begin(), v3.end());
+      auto h0 = CustomHeader{ "TST", "A" };
+      auto h1 = CustomHeader{ "TST", "B" };
+      BOOST_CHECK(v3[0] == h0);
+      BOOST_CHECK(v3[1] == h1);
+
+      using CustomHeader2 = std::tuple<DataOrigin, DataDescription, int>;
+      std::vector<CustomHeader2> v4{ CustomHeader2{ "TST", "A", 1 }, CustomHeader2{ "TST", "A", 0 } };
+      std::sort(v4.begin(), v4.end());
+      auto hh0 = CustomHeader2{ "TST", "A", 0 };
+      auto hh1 = CustomHeader2{ "TST", "A", 1 };
+      BOOST_CHECK(v4[0] == hh0);
+      BOOST_CHECK(v4[1] == hh1);
+
+      struct CustomHeader3 {
+        DataOrigin origin;
+        DataDescription desc;
+        uint64_t subSpec;
+        int isOut;
+      };
+      std::vector<CustomHeader3> v5{ CustomHeader3{ "TST", "A", 0, 1 }, CustomHeader3{ "TST", "A", 0, 0 } };
+      std::sort(v5.begin(), v5.end(), [](CustomHeader3 const& lhs, CustomHeader3 const& rhs) {
+        return std::tie(lhs.origin, lhs.desc, rhs.subSpec, lhs.isOut) < std::tie(rhs.origin, rhs.desc, rhs.subSpec, rhs.isOut);
+      });
+      BOOST_CHECK(v5[0].isOut == 0);
+      BOOST_CHECK(v5[1].isOut == 1);
     }
 
     BOOST_AUTO_TEST_CASE(BaseHeader_test)

--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -208,6 +208,7 @@ set(TEST_SRCS
       test/test_CustomGUI.cxx
       test/test_CompletionPolicy.cxx
       test/test_DanglingInputs.cxx
+      test/test_DanglingOutputs.cxx
       test/test_DataAllocator.cxx
       test/test_DataProcessorSpec.cxx
       test/test_DataRefUtils.cxx

--- a/Framework/Core/include/Framework/InputSpec.h
+++ b/Framework/Core/include/Framework/InputSpec.h
@@ -30,6 +30,12 @@ struct InputSpec {
   header::DataHeader::SubSpecificationType subSpec = 0;
   enum Lifetime lifetime = Lifetime::Timeframe;
 
+  bool operator==(InputSpec const& that) const
+  {
+    return origin == that.origin && description == that.description && subSpec == that.subSpec &&
+           lifetime == that.lifetime;
+  };
+
   friend std::ostream& operator<<(std::ostream& stream, InputSpec const& arg);
 };
 

--- a/Framework/Core/include/Framework/OutputSpec.h
+++ b/Framework/Core/include/Framework/OutputSpec.h
@@ -68,7 +68,7 @@ struct OutputSpec {
   {
   }
 
-  bool operator==(const OutputSpec& that)
+  bool operator==(OutputSpec const& that) const
   {
     return origin == that.origin && description == that.description && subSpec == that.subSpec &&
            lifetime == that.lifetime;

--- a/Framework/Core/src/WorkflowHelpers.h
+++ b/Framework/Core/src/WorkflowHelpers.h
@@ -165,6 +165,11 @@ struct WorkflowHelpers {
   static std::vector<EdgeAction> computeInEdgeActions(
                                  const std::vector<DeviceConnectionEdge> &edges,
                                  const std::vector<size_t> &index);
+
+  /// Given @a workflow it finds the OutputSpec in every module which do not have
+  /// a corresponding InputSpec. I.e. they are dangling.
+  /// @return a vector of InputSpec which would have matched said dangling outputs.
+  static std::vector<InputSpec> computeDanglingOutputs(WorkflowSpec const& workflow);
 };
 
 }

--- a/Framework/Core/test/test_DanglingOutputs.cxx
+++ b/Framework/Core/test/test_DanglingOutputs.cxx
@@ -1,0 +1,51 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/DeviceSpec.h"
+#include <InfoLogger/InfoLogger.hxx>
+#include <vector>
+#include "Framework/runDataProcessing.h"
+#include "Framework/ControlService.h"
+
+using namespace o2::framework;
+
+AlgorithmSpec simplePipe(std::string const& what, int minDelay)
+{
+  return AlgorithmSpec{ [what, minDelay](InitContext& ic) {
+    srand(getpid());
+    return [what, minDelay](ProcessingContext& ctx) {
+      auto bData = ctx.outputs().make<int>(OutputRef{ what }, 1);
+    };
+  } };
+}
+
+// a1 is not actually used by anything, however it might.
+WorkflowSpec defineDataProcessing(ConfigContext const& specs)
+{
+  return WorkflowSpec{
+    { "A",
+      Inputs{},
+      { OutputSpec{ { "a1" }, "TST", "A1" },
+        OutputSpec{ { "a2" }, "TST", "A2" } },
+      AlgorithmSpec{
+        [](ProcessingContext& ctx) {
+          sleep(rand() % 2 + 1);
+          auto aData1 = ctx.outputs().make<int>(OutputRef{ "a1" }, 1);
+          auto aData2 = ctx.outputs().make<int>(Output{ "TST", "A2" }, 1);
+        } } },
+    { "B",
+      { InputSpec{ { "a1" }, "TST", "A1" } },
+      {},
+      AlgorithmSpec{
+        [](ProcessingContext& ctx) {
+          ctx.services().get<ControlService>().readyToQuit(true);
+        } } }
+  };
+}


### PR DESCRIPTION
Sometimes it's handy to leave dangling outputs visible to a data
processor, so that one can reuse a given algorithm in different
scenarious where they might or not be requested.

This changes the previous behavior that was to wipe the output
completely, so that invoking make() on it would have thrown an
exception.

The new behavior will allow the user to invoke make and pass the output
to an internal device that acts as a sink.

Future updates of this feature will allow the user to query if
a given output is dangling or not and provide a callback based API for
make which will invoke the callback only if the output is not dangling.

We could also exploit this feature to have preconfigured actions (e.g. write
to a ROOT file) for dangling outputs, so that the user does not need to
instanciate a writer himself, but can rely on the system to create one
for all the dangling outputs.