### PR TITLE
DPL: refactor include statements to ensure atomicity

### DIFF
--- a/Framework/Core/include/Framework/ChannelConfigurationPolicy.h
+++ b/Framework/Core/include/Framework/ChannelConfigurationPolicy.h
@@ -10,10 +10,11 @@
 #ifndef FRAMEWORK_CHANNELCONFIGURATIONPOLICY_H
 #define FRAMEWORK_CHANNELCONFIGURATIONPOLICY_H
 
-#include <functional>
 #include "Framework/ChannelConfigurationPolicyHelpers.h"
 #include "Framework/ChannelSpec.h"
 #include "Framework/DeviceSpec.h"
+
+#include <functional>
 
 namespace o2
 {

--- a/Framework/Core/include/Framework/ConfigParamSpec.h
+++ b/Framework/Core/include/Framework/ConfigParamSpec.h
@@ -10,8 +10,9 @@
 #ifndef FRAMEWORK_CONFIGPARAMSPEC_H
 #define FRAMEWORK_CONFIGPARAMSPEC_H
 
-#include <string>
 #include "Framework/Variant.h"
+
+#include <string>
 
 namespace o2
 {

--- a/Framework/Core/include/Framework/DataAllocator.h
+++ b/Framework/Core/include/Framework/DataAllocator.h
@@ -10,7 +10,6 @@
 #ifndef FRAMEWORK_DATAALLOCATOR_H
 #define FRAMEWORK_DATAALLOCATOR_H
 
-#include "Headers/DataHeader.h"
 #include "Framework/ContextRegistry.h"
 #include "Framework/MessageContext.h"
 #include "Framework/RootObjectContext.h"
@@ -27,15 +26,16 @@
 #include "Framework/SerializationMethods.h"
 #include "Framework/TableBuilder.h"
 
+#include "Headers/DataHeader.h"
+#include <TClass.h>
+#include <gsl/span>
+
 #include <vector>
 #include <map>
 #include <string>
 #include <utility>
 #include <type_traits>
-#include <gsl/span>
 #include <utility>
-
-#include <TClass.h>
 
 // Do not change this for a full inclusion of FairMQDevice.
 class FairMQDevice;

--- a/Framework/Core/include/Framework/DataProcessingDevice.h
+++ b/Framework/Core/include/Framework/DataProcessingDevice.h
@@ -10,9 +10,6 @@
 #ifndef FRAMEWORK_DATAPROCESSING_DEVICE_H
 #define FRAMEWORK_DATAPROCESSING_DEVICE_H
 
-#include <fairmq/FairMQDevice.h>
-#include <fairmq/FairMQParts.h>
-
 #include "Framework/AlgorithmSpec.h"
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/ContextRegistry.h"
@@ -28,6 +25,9 @@
 #include "Framework/InputRoute.h"
 #include "Framework/ForwardRoute.h"
 #include "Framework/TimingInfo.h"
+
+#include <fairmq/FairMQDevice.h>
+#include <fairmq/FairMQParts.h>
 
 #include <memory>
 

--- a/Framework/Core/include/Framework/DataRefUtils.h
+++ b/Framework/Core/include/Framework/DataRefUtils.h
@@ -11,15 +11,18 @@
 #define FRAMEWORK_DATAREFUTILS_H
 
 #include "Framework/DataRef.h"
-#include "Headers/DataHeader.h"
 #include "Framework/TMessageSerializer.h"
 #include "Framework/SerializationMethods.h"
 #include "Framework/TypeTraits.h"
+
+#include "Headers/DataHeader.h"
+
 #include <TClass.h>
+#include <gsl/gsl>
+
 #include <stdexcept>
 #include <sstream>
 #include <type_traits>
-#include <gsl/gsl>
 
 namespace o2
 {

--- a/Framework/Core/include/Framework/DataSamplingConfig.h
+++ b/Framework/Core/include/Framework/DataSamplingConfig.h
@@ -16,12 +16,13 @@
 ///
 /// \author Piotr Konopka, piotr.jan.konopka@cern.ch
 
-#include <vector>
-#include <string>
-
 #include "Framework/InputSpec.h"
 #include "Framework/OutputSpec.h"
+
 #include "Headers/DataHeader.h"
+
+#include <vector>
+#include <string>
 
 namespace o2
 {

--- a/Framework/Core/include/Framework/InputSpec.h
+++ b/Framework/Core/include/Framework/InputSpec.h
@@ -10,10 +10,11 @@
 #ifndef FRAMEWORK_INPUTSPEC_H
 #define FRAMEWORK_INPUTSPEC_H
 
-#include <string>
-#include <ostream>
 #include "Framework/Lifetime.h"
 #include "Headers/DataHeader.h"
+
+#include <string>
+#include <ostream>
 
 namespace o2
 {

--- a/Framework/Core/include/Framework/LifetimeHelpers.h
+++ b/Framework/Core/include/Framework/LifetimeHelpers.h
@@ -10,10 +10,11 @@
 #ifndef FRAMEWORK_LIFETIMEHELPERS_H
 #define FRAMEWORK_LIFETIMEHELPERS_H
 
-#include <functional>
-#include <chrono>
 #include "Framework/ExpirationHandler.h"
 #include "Framework/PartRef.h"
+
+#include <functional>
+#include <chrono>
 
 namespace o2
 {

--- a/Framework/Core/include/Framework/MessageContext.h
+++ b/Framework/Core/include/Framework/MessageContext.h
@@ -10,9 +10,11 @@
 #ifndef FRAMEWORK_MESSAGECONTEXT_H
 #define FRAMEWORK_MESSAGECONTEXT_H
 
-#include <fairmq/FairMQParts.h>
 #include "Framework/ContextRegistry.h"
 #include "Framework/FairMQDeviceProxy.h"
+
+#include <fairmq/FairMQParts.h>
+
 #include <vector>
 #include <cassert>
 #include <string>

--- a/Framework/Core/include/Framework/runDataProcessing.h
+++ b/Framework/Core/include/Framework/runDataProcessing.h
@@ -10,9 +10,6 @@
 #ifndef FRAMEWORK_RUN_DATA_PROCESSING_H
 #define FRAMEWORK_RUN_DATA_PROCESSING_H
 
-#include <unistd.h>
-#include <vector>
-#include <cstring>
 #include "Framework/ChannelConfigurationPolicy.h"
 #include "Framework/CompletionPolicy.h"
 #include "Framework/ConfigParamsHelper.h"
@@ -23,6 +20,10 @@
 
 #include <boost/program_options/options_description.hpp>
 #include <boost/program_options/variables_map.hpp>
+
+#include <unistd.h>
+#include <vector>
+#include <cstring>
 
 namespace o2
 {

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -7,7 +7,6 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#include "FairMQDevice.h"
 #include "Framework/BoostOptionsRetriever.h"
 #include "Framework/ChannelConfigurationPolicy.h"
 #include "Framework/ChannelMatching.h"
@@ -40,13 +39,24 @@
 #include "GraphvizHelpers.h"
 #include "SimpleResourceManager.h"
 
+#include <Monitoring/MonitoringFactory.h>
+#include <InfoLogger/InfoLogger.hxx>
+
+#include "FairMQDevice.h"
+#include <fairmq/DeviceRunner.h>
+#include <fairmq/FairMQLogger.h>
 #include "options/FairMQProgOptions.h"
+
+#include <boost/program_options.hpp>
+#include <boost/program_options/options_description.hpp>
+#include <boost/program_options/variables_map.hpp>
 
 #include <cinttypes>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <csignal>
 #include <iostream>
 #include <map>
 #include <regex>
@@ -54,7 +64,6 @@
 #include <string>
 #include <type_traits>
 #include <chrono>
-
 #include <sys/resource.h>
 #include <sys/select.h>
 #include <sys/socket.h>
@@ -63,19 +72,10 @@
 #include <sys/un.h>
 #include <sys/wait.h>
 #include <unistd.h>
-#include <boost/program_options.hpp>
-#include <boost/program_options/options_description.hpp>
-#include <boost/program_options/variables_map.hpp>
-#include <csignal>
 #include <netinet/ip.h>
 
-#include <fairmq/DeviceRunner.h>
-#include <fairmq/FairMQLogger.h>
-
-#include <Monitoring/MonitoringFactory.h>
 using namespace o2::monitoring;
 
-#include <InfoLogger/InfoLogger.hxx>
 using namespace AliceO2::InfoLogger;
 
 /// Helper class to find a free port.


### PR DESCRIPTION
This refactors a few include statements orders to improve chances
our headers are fully self contained.