### PR TITLE
DPL: add initial facility for complex queries on DataHeader

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -210,6 +210,7 @@ set(TEST_SRCS
       test/test_DanglingInputs.cxx
       test/test_DanglingOutputs.cxx
       test/test_DataAllocator.cxx
+      test/test_DataDescriptorMatcher.cxx
       test/test_DataProcessorSpec.cxx
       test/test_DataRefUtils.cxx
       test/test_DataRelayer.cxx

--- a/Framework/Core/include/Framework/DataDescriptorMatcher.h
+++ b/Framework/Core/include/Framework/DataDescriptorMatcher.h
@@ -1,0 +1,177 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef o2_framework_DataDescriptorMatcher_H_INCLUDED
+#define o2_framework_DataDescriptorMatcher_H_INCLUDED
+
+#include "Headers/DataHeader.h"
+
+#include <cstdint>
+#include <string>
+#include <variant>
+
+namespace o2
+{
+namespace framework
+{
+
+/// Something which can be matched against a header::DataOrigin
+class OriginValueMatcher
+{
+ public:
+  OriginValueMatcher(std::string const& s)
+    : mValue{ s }
+  {
+  }
+
+  bool match(header::DataHeader const& header) const
+  {
+    return strncmp(header.dataOrigin.str, mValue.c_str(), 4) == 0;
+  }
+
+ private:
+  std::string mValue;
+};
+
+/// Something which can be matched against a header::DataDescription
+class DescriptionValueMatcher
+{
+ public:
+  DescriptionValueMatcher(std::string const& s)
+    : mValue{ s }
+  {
+  }
+
+  bool match(header::DataHeader const& header) const
+  {
+    return strncmp(header.dataDescription.str, mValue.c_str(), 8) == 0;
+  }
+
+ private:
+  std::string mValue;
+};
+
+/// Something which can be matched against a header::SubSpecificationType
+class SubSpecificationTypeValueMatcher
+{
+ public:
+  /// The passed string @a s is the expected numerical value for
+  /// the SubSpecification type.
+  SubSpecificationTypeValueMatcher(std::string const& s)
+  {
+    mValue = strtoull(s.c_str(), nullptr, 10);
+  }
+
+  SubSpecificationTypeValueMatcher(uint64_t v)
+  {
+    mValue = v;
+  }
+  bool match(header::DataHeader const& header) const
+  {
+    return header.subSpecification == mValue;
+  }
+
+ private:
+  uint64_t mValue;
+};
+
+/// Something which can be matched against a header::SubSpecificationType
+class ConstantValueMatcher
+{
+ public:
+  /// The passed string @a s is the expected numerical value for
+  /// the SubSpecification type.
+  ConstantValueMatcher(bool value)
+  {
+    mValue = value;
+  }
+  bool match(header::DataHeader const& header) const
+  {
+    return mValue;
+  }
+
+ private:
+  bool mValue;
+};
+
+template <typename DESCRIPTOR>
+struct DescriptorMatcherTrait {
+};
+
+template <>
+struct DescriptorMatcherTrait<header::DataOrigin> {
+  using Matcher = framework::OriginValueMatcher;
+};
+
+template <>
+struct DescriptorMatcherTrait<header::DataDescription> {
+  using Matcher = DescriptionValueMatcher;
+};
+
+template <>
+struct DescriptorMatcherTrait<header::DataHeader::SubSpecificationType> {
+  using Matcher = SubSpecificationTypeValueMatcher;
+};
+
+class DataDescriptorMatcher;
+using Node = std::variant<OriginValueMatcher, DescriptionValueMatcher, SubSpecificationTypeValueMatcher, std::unique_ptr<DataDescriptorMatcher>, ConstantValueMatcher>;
+
+// A matcher for a given O2 Data Model descriptor.  We use a variant to hold
+// the different kind of matchers so that we can have a hierarchy or
+// DataDescriptionMatcher in the future (e.g. to handle OR / AND clauses) or we
+// can apply it to the whole DataHeader.
+class DataDescriptorMatcher
+{
+ public:
+  enum struct Op { Or,
+                   And,
+                   Xor };
+
+  DataDescriptorMatcher(Node&& lhs, Op op, Node&& rhs)
+    : mOp{ op },
+      mLeft{ std::move(lhs) },
+      mRight{ std::move(rhs) }
+  {
+  }
+
+  inline ~DataDescriptorMatcher() = default;
+
+  bool match(header::DataHeader const& d) const
+  {
+    auto eval = [&d](auto&& arg) -> bool {
+      using T = std::decay_t<decltype(arg)>;
+      if constexpr (std::is_same_v<T, std::unique_ptr<DataDescriptorMatcher>>) {
+        return arg->match(d);
+      } else {
+        return arg.match(d);
+      }
+    };
+    auto leftValue = std::visit(eval, mLeft);
+    auto rightValue = std::visit(eval, mRight);
+
+    switch (mOp) {
+      case Op::Or:
+        return leftValue || rightValue;
+      case Op::And:
+        return leftValue && rightValue;
+      case Op::Xor:
+        return leftValue ^ rightValue;
+    }
+  };
+
+ private:
+  Op mOp;
+  Node mLeft;
+  Node mRight;
+};
+
+} // naemspace framework
+} // namespace o2
+
+#endif // o2_framework_DataDescriptorMatcher_H_INCLUDED

--- a/Framework/Core/test/test_DataDescriptorMatcher.cxx
+++ b/Framework/Core/test/test_DataDescriptorMatcher.cxx
@@ -1,0 +1,89 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test Framework DataDescriptorMatcher
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+#include "Framework/DataDescriptorMatcher.h"
+
+using namespace o2::framework;
+using namespace o2::header;
+
+BOOST_AUTO_TEST_CASE(TestSimpleMatching)
+{
+  DataHeader header0;
+  header0.dataOrigin = "TPC";
+  header0.dataDescription = "CLUSTERS";
+  header0.subSpecification = 1;
+
+  DataHeader header1;
+  header1.dataOrigin = "ITS";
+  header1.dataDescription = "TRACKLET";
+  header1.subSpecification = 2;
+
+  DataHeader header2;
+  header2.dataOrigin = "TPC";
+  header2.dataDescription = "TRACKLET";
+  header2.subSpecification = 1;
+
+  DataHeader header3;
+  header3.dataOrigin = "TPC";
+  header3.dataDescription = "CLUSTERS";
+  header3.subSpecification = 0;
+
+  DataHeader header4;
+  header4.dataOrigin = "TRD";
+  header4.dataDescription = "TRACKLET";
+  header4.subSpecification = 0;
+
+  DataDescriptorMatcher matcher{
+    OriginValueMatcher{ "TPC" },
+    DataDescriptorMatcher::Op::And,
+    std::make_unique<DataDescriptorMatcher>(
+      DescriptionValueMatcher{ "CLUSTERS" },
+      DataDescriptorMatcher::Op::And,
+      std::make_unique<DataDescriptorMatcher>(
+        SubSpecificationTypeValueMatcher{ 1 },
+        DataDescriptorMatcher::Op::And,
+        ConstantValueMatcher{ true }))
+  };
+
+  BOOST_CHECK(matcher.match(header0) == true);
+  BOOST_CHECK(matcher.match(header1) == false);
+  BOOST_CHECK(matcher.match(header2) == false);
+  BOOST_CHECK(matcher.match(header3) == false);
+  BOOST_CHECK(matcher.match(header4) == false);
+
+  DataDescriptorMatcher matcher1{
+    OriginValueMatcher{ "TPC" },
+    DataDescriptorMatcher::Op::Or,
+    OriginValueMatcher{ "ITS" }
+  };
+
+  BOOST_CHECK(matcher1.match(header0) == true);
+  BOOST_CHECK(matcher1.match(header1) == true);
+  BOOST_CHECK(matcher1.match(header2) == true);
+  BOOST_CHECK(matcher1.match(header3) == true);
+  BOOST_CHECK(matcher1.match(header4) == false);
+
+  DataDescriptorMatcher matcher2{
+    ConstantValueMatcher{ true },
+    DataDescriptorMatcher::Op::And,
+    DescriptionValueMatcher{ "TRACKLET" }
+  };
+
+  BOOST_CHECK(matcher2.match(header0) == false);
+  BOOST_CHECK(matcher2.match(header1) == true);
+  BOOST_CHECK(matcher2.match(header2) == true);
+  BOOST_CHECK(matcher2.match(header3) == false);
+  BOOST_CHECK(matcher2.match(header4) == true);
+}


### PR DESCRIPTION
This introduces a facility to do complex queries with a given
DataHeader, e.g. leave one of the fields undetermined or pick only
certain combinations. At the moment this is just a helper class,
but it is one of the requirements to have more flexibility in the
`InputSpec` definition and possibly in other ancillary tasks.

The query itself is expressed in terms of a query tree, see the
example test_DataDescriptorMatcher.cxx for more details.