### PR TITLE
Fix in TPC HWCF: always call finishFrame in the end of process

### DIFF
--- a/Detectors/TPC/reconstruction/src/HwClusterer.cxx
+++ b/Detectors/TPC/reconstruction/src/HwClusterer.cxx
@@ -253,8 +253,7 @@ void HwClusterer::process(std::vector<o2::TPC::Digit> const& digits, MCLabelCont
     mLastTimebin = digit.getTimeStamp();
   }
 
-  if (!mIsContinuousReadout)
-    finishFrame(true);
+  finishFrame(!mIsContinuousReadout); // clear buffers for triggered readout
 
   if (digits.size() != 0)
     LOG(DEBUG) << "Event ranged from time bin " << digits.front().getTimeStamp() << " to " << digits.back().getTimeStamp() << "." << FairLogger::endl;


### PR DESCRIPTION
In the continuous mode (but see PS below) the clusterizer does not produce the clusters for the digits of the very last HB, i.e. timebin >  (maxTimeBinSeen/447 - 1)*447, with 447 being some conventional HB length in the HwClusterer. This leads to a hole of in small eta tracks in the end of the TF.
This PR enforces ```finishFrame``` call in the end of the ```HwClusterer::process```, with the ```clean=true``` option for triggered mode and w/o clean in continuous one.

As far as I understand, this also addresses the concern of @matthiasrichter at https://github.com/AliceO2Group/AliceO2/blob/8abb483029a057e272d5ac0c5287f4c6e73f1264/Detectors/TPC/workflow/src/ClustererSpec.cxx#L109. @KlewinS , could you please review this PR.

Below are the tracks eta distribution and timebins of clusters (those attached to tracks) vs digits before and after the fix (just 1 PbPb event in continuous mode):
![trceta_old_new](https://user-images.githubusercontent.com/7382029/47046922-9894fa80-d196-11e8-9012-e664c4a30e4a.gif)
![cltime_old_new](https://user-images.githubusercontent.com/7382029/47046923-9894fa80-d196-11e8-8896-02ea2db33f89.gif)

@wiechula, @sawenzel, in continuous mode it seems there are distinct steps in digits timbin distribution every 500 timebins...  

Cheers, 
Ruben

PS: In fact, the last portion of clusters is not sent to the output also in the triggered mode, since the  HwClusterer::setContinuousReadout(...) is not called by the ClustererSpec, so that the HwClusterer is always in cont. mode and the ```if (!mIsContinuousReadout) finishFrame(true);``` is not called in the ```HwClusterer::process```. This should be addressed by https://alice.its.cern.ch/jira/browse/O2-405