### PR TITLE
DPL: Add ability to persist selected messages

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -72,6 +72,7 @@ set(SRCS
     src/FrameworkGUIDeviceInspector.cxx
     src/FrameworkGUIDataRelayerUsage.cxx
     src/PaletteHelpers.cxx
+    src/CommonDataProcessors.cxx
     ${GUI_SOURCES}
     test/TestClasses.cxx
     src/Variant.cxx

--- a/Framework/Core/include/Framework/CommonDataProcessors.h
+++ b/Framework/Core/include/Framework/CommonDataProcessors.h
@@ -1,0 +1,39 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef o2_framework_CommonDataProcessors_H_INCLUDED
+#define o2_framework_CommonDataProcessors_H_INCLUDED
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/InputSpec.h"
+
+#include <vector>
+
+namespace o2
+{
+namespace framework
+{
+
+/// Helpers to create a few general data processors
+struct CommonDataProcessors {
+  /// Given the list of @a danglingInputs @return a DataProcessor which does
+  /// a binary dump for all the dangling inputs matching the Timeframe
+  /// lifetime. @a unmatched will be filled with all the InputSpecs which are
+  /// not going to be used by the returned DataProcessorSpec.
+  static DataProcessorSpec getGlobalFileSink(std::vector<InputSpec> const& danglingInputs,
+                                             std::vector<InputSpec>& unmatched);
+  /// @return a dummy DataProcessorSpec which requires all the passed @a InputSpec
+  /// and simply discards them.
+  static DataProcessorSpec getDummySink(std::vector<InputSpec> const& danglingInputs);
+};
+
+} // namespace framework
+} // namespace o2
+
+#endif // o2_framework_CommonDataProcessors_H_INCLUDED

--- a/Framework/Core/include/Framework/DataDescriptorMatcher.h
+++ b/Framework/Core/include/Framework/DataDescriptorMatcher.h
@@ -10,6 +10,7 @@
 #ifndef o2_framework_DataDescriptorMatcher_H_INCLUDED
 #define o2_framework_DataDescriptorMatcher_H_INCLUDED
 
+#include "Framework/InputSpec.h"
 #include "Headers/DataHeader.h"
 
 #include <cstdint>
@@ -143,6 +144,18 @@ class DataDescriptorMatcher
   }
 
   inline ~DataDescriptorMatcher() = default;
+
+  /// @return true if the (sub-)query associated to this matcher will
+  /// match the provided @a spec, false otherwise.
+  bool match(InputSpec const& spec) const
+  {
+    header::DataHeader dh;
+    dh.dataOrigin = spec.origin;
+    dh.dataDescription = spec.description;
+    dh.subSpecification = spec.subSpec;
+
+    return this->match(dh);
+  }
 
   bool match(header::DataHeader const& d) const
   {

--- a/Framework/Core/src/CommonDataProcessors.cxx
+++ b/Framework/Core/src/CommonDataProcessors.cxx
@@ -1,0 +1,118 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/CommonDataProcessors.h"
+
+#include "Framework/AlgorithmSpec.h"
+#include "Framework/DataProcessingHeader.h"
+#include "Framework/DataDescriptorQueryBuilder.h"
+#include "Framework/DataDescriptorMatcher.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/InitContext.h"
+#include "Framework/InitContext.h"
+#include "Framework/InputSpec.h"
+#include "Framework/OutputSpec.h"
+#include "Framework/Variant.h"
+
+#include <exception>
+#include <fstream>
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace o2
+{
+namespace framework
+{
+
+DataProcessorSpec CommonDataProcessors::getGlobalFileSink(std::vector<InputSpec> const& danglingOutputInputs,
+                                                          std::vector<InputSpec>& unmatched)
+{
+  auto writerFunction = [danglingOutputInputs](InitContext& ic) -> std::function<void(ProcessingContext&)> {
+    auto filename = ic.options().get<std::string>("outfile");
+    auto keepString = ic.options().get<std::string>("keep");
+
+    if (filename.empty()) {
+      throw std::runtime_error("output file missing");
+    }
+
+    bool hasOutputsToWrite = false;
+    auto outputMatcher = DataDescriptorQueryBuilder::buildFromKeepConfig(keepString);
+    for (auto& spec : danglingOutputInputs) {
+      if (outputMatcher->match(spec)) {
+        hasOutputsToWrite = true;
+      }
+    }
+    if (hasOutputsToWrite == false) {
+      return std::move([](ProcessingContext& pc) mutable -> void {
+        static bool once = false;
+        /// We do it like this until we can use the interruptible sleep
+        /// provided by recent FairMQ releases.
+        if (!once) {
+          LOG(INFO) << "No dangling output to be dumped.";
+          once = true;
+        }
+        sleep(1);
+      });
+    }
+    auto output = std::make_shared<std::ofstream>(filename.c_str(), std::ios_base::binary);
+    return std::move([ output, matcher = outputMatcher ](ProcessingContext & pc) mutable->void {
+      LOG(INFO) << "processing data set with " << pc.inputs().size() << " entries";
+      for (const auto& entry : pc.inputs()) {
+        LOG(INFO) << "  " << *(entry.spec);
+        auto header = DataRefUtils::getHeader<header::DataHeader*>(entry);
+        auto dataProcessingHeader = DataRefUtils::getHeader<DataProcessingHeader*>(entry);
+        if (matcher->match(*header) == false) {
+          continue;
+        }
+        output->write(reinterpret_cast<char const*>(header), sizeof(header::DataHeader));
+        output->write(reinterpret_cast<char const*>(dataProcessingHeader), sizeof(DataProcessingHeader));
+        output->write(entry.payload, o2::framework::DataRefUtils::getPayloadSize(entry));
+        LOG(INFO) << "wrote data, size " << o2::framework::DataRefUtils::getPayloadSize(entry);
+      }
+    });
+  };
+
+  std::vector<InputSpec> validBinaryInputs;
+  auto onlyTimeframe = [](InputSpec const& input) {
+    return input.lifetime == Lifetime::Timeframe;
+  };
+
+  auto noTimeframe = [](InputSpec const& input) {
+    return input.lifetime != Lifetime::Timeframe;
+  };
+
+  std::copy_if(danglingOutputInputs.begin(), danglingOutputInputs.end(),
+               std::back_inserter(validBinaryInputs), onlyTimeframe);
+  std::copy_if(danglingOutputInputs.begin(), danglingOutputInputs.end(),
+               std::back_inserter(unmatched), noTimeframe);
+
+  DataProcessorSpec spec{
+    "dpl-global-binary-file-sink",
+    validBinaryInputs,
+    Outputs{},
+    AlgorithmSpec(writerFunction),
+    { { "outfile", VariantType::String, "dpl-out.bin", { "Name of the output file" } },
+      { "keep", VariantType::String, "", { "Comma separated list of ORIGIN/DESCRIPTION/SUBSPECIFICATION to save in outfile" } } }
+  };
+
+  return spec;
+}
+
+DataProcessorSpec CommonDataProcessors::getDummySink(std::vector<InputSpec> const& danglingOutputInputs)
+{
+  return DataProcessorSpec{
+    "dpl-dummy-sink",
+    danglingOutputInputs,
+    Outputs{},
+  };
+}
+
+} // namespace framework
+} // namespace o2


### PR DESCRIPTION
This shows how it's possible to have automatic persistency of messages (to file in this particular case) in DPL. While the logic is quite trivial at the moment (drop everything by default, unless specified with the `--keep` option) it can be easily extended. In particular I was thinking about:

* Pushing (selected) dangling `Lifetime::QA` histograms to a ROOT file or CCDB.
* Pushing (selected)  dangling `Lifetime::Condition` objects to CCDB.
* Pushing (selected) dangling Arrow tables to root or Parquet.
* Pushing (selected) dangling `Lifetime::Timeframe` messages to a binary dump (e.g. to debug).
* Allow selecting any intermediate message (dangling or not) and push it to file.

The syntax could be extended to specify the actual output or to support wildcards, e.g.:

```
--keep "TPC/CLUSTERS/*,*/TRACKS/*>cluster.dump"
```

or 

```
--keep "TPC/QA/*>file.root:branch/branch"
```

To be discussed on Friday.