### PR TITLE
DPL: add variables to DataDescriptorMatcher

### DIFF
--- a/Framework/Core/include/Framework/DataDescriptorQueryBuilder.h
+++ b/Framework/Core/include/Framework/DataDescriptorQueryBuilder.h
@@ -19,7 +19,22 @@ namespace o2
 namespace framework
 {
 
+namespace data_matcher
+{
 class DataDescriptorMatcher;
+}
+
+/// Struct describing a query.
+/// @a variableNames is filled with the variables which are
+/// referenced in the matcher string. We return it as part of the query so that it can
+/// be eventually passed to a different query builder which wants to use the
+/// same variable names.  Alternatively we could simply build the query in
+/// one go and return the number of
+/// variables required by the context. Not sure what's the best approach.
+struct DataDescriptorQuery {
+  std::vector<std::string> variableNames;
+  std::shared_ptr<data_matcher::DataDescriptorMatcher> matcher;
+};
 
 /// Various utilities to manipulate InputSpecs
 struct DataDescriptorQueryBuilder {
@@ -34,7 +49,7 @@ struct DataDescriptorQueryBuilder {
   /// config := spec;spec;...
   ///
   /// Example for config: TPC/CLUSTER/0;ITS/TRACKS/1
-  static std::shared_ptr<DataDescriptorMatcher> buildFromKeepConfig(std::string const& config);
+  static DataDescriptorQuery buildFromKeepConfig(std::string const& config);
 };
 
 } // namespace framework

--- a/Framework/Core/src/DataDescriptorQueryBuilder.cxx
+++ b/Framework/Core/src/DataDescriptorQueryBuilder.cxx
@@ -16,12 +16,14 @@
 #include <string>
 #include <vector>
 
+using namespace o2::framework::data_matcher;
+
 namespace o2
 {
 namespace framework
 {
 
-std::shared_ptr<DataDescriptorMatcher> DataDescriptorQueryBuilder::buildFromKeepConfig(std::string const& config)
+DataDescriptorQuery DataDescriptorQueryBuilder::buildFromKeepConfig(std::string const& config)
 {
   static const std::regex specTokenRE(R"re((\w{1,4})/(\w{1,16})/(\d*))re");
   static const std::regex delimiter(",");
@@ -55,7 +57,8 @@ std::shared_ptr<DataDescriptorMatcher> DataDescriptorQueryBuilder::buildFromKeep
       result = std::move(next);
     }
   }
-  return std::move(result);
+
+  return std::move(DataDescriptorQuery{ {}, std::move(result) });
 }
 
 } // namespace framework


### PR DESCRIPTION
This introduces the ability to build matchers that refer to some
variable in a context. The context itself can either be prefilled,
or filled on the fly on first match.