### PR TITLE
DPL: speedup DataDescriptorMatcher

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -248,6 +248,14 @@ set(TEST_SRCS
       test/test_WorkflowHelpers.cxx
    )
 
+set(BENCH_SRCS test/benchmark_DataDescriptorMatcher.cxx)
+
+O2_GENERATE_TESTS(
+  MODULE_LIBRARY_NAME ${LIBRARY_NAME}
+  BUCKET_NAME O2FrameworkCore_benchmark_bucket
+  TEST_SRCS ${BENCH_SRCS}
+)
+
 O2_GENERATE_TESTS(
   MODULE_LIBRARY_NAME ${LIBRARY_NAME}
   BUCKET_NAME ${BUCKET_NAME}

--- a/Framework/Core/include/Framework/DataDescriptorMatcher.h
+++ b/Framework/Core/include/Framework/DataDescriptorMatcher.h
@@ -277,6 +277,16 @@ class DataDescriptorMatcher
     } else {
       throw std::runtime_error("Bad parsing tree");
     }
+    // Common speedup.
+    if (mOp == Op::And && leftValue == false) {
+      return false;
+    }
+    if (mOp == Op::Or && leftValue == true) {
+      return true;
+    }
+    if (mOp == Op::Just) {
+      return leftValue;
+    }
 
     if (auto pval0 = std::get_if<OriginValueMatcher>(&mRight)) {
       rightValue = pval0->match(d, context);

--- a/Framework/Core/test/benchmark_DataDescriptorMatcher.cxx
+++ b/Framework/Core/test/benchmark_DataDescriptorMatcher.cxx
@@ -1,0 +1,178 @@
+#include <benchmark/benchmark.h>
+#include "Headers/DataHeader.h"
+#include "Framework/DataDescriptorMatcher.h"
+
+using namespace o2::header;
+using namespace o2::framework::data_matcher;
+
+static void BM_MatchedSingleQuery(benchmark::State& state)
+{
+  DataHeader header;
+  header.dataOrigin = "TRD";
+  header.dataDescription = "TRACKLET";
+  header.subSpecification = 0;
+
+  DataDescriptorMatcher matcher{
+    DataDescriptorMatcher::Op::Just,
+    OriginValueMatcher{ "TRD" }
+  };
+
+  std::vector<ContextElement> context;
+
+  for (auto _ : state) {
+    matcher.match(header, context);
+  }
+}
+
+BENCHMARK(BM_MatchedSingleQuery);
+
+static void BM_MatchedFullQuery(benchmark::State& state)
+{
+  DataHeader header;
+  header.dataOrigin = "TRD";
+  header.dataDescription = "TRACKLET";
+  header.subSpecification = 0;
+
+  DataDescriptorMatcher matcher{
+    DataDescriptorMatcher::Op::And,
+    OriginValueMatcher{ "TRD" },
+    std::make_unique<DataDescriptorMatcher>(
+      DataDescriptorMatcher::Op::And,
+      DescriptionValueMatcher{ "TRACKLET" },
+      std::make_unique<DataDescriptorMatcher>(
+        DataDescriptorMatcher::Op::And,
+        SubSpecificationTypeValueMatcher{ 0 },
+        ConstantValueMatcher{ true }))
+  };
+
+  std::vector<ContextElement> context;
+
+  for (auto _ : state) {
+    matcher.match(header, context);
+  }
+}
+// Register the function as a benchmark
+BENCHMARK(BM_MatchedFullQuery);
+
+static void BM_UnmatchedSingleQuery(benchmark::State& state)
+{
+  DataHeader header;
+  header.dataOrigin = "TRD";
+  header.dataDescription = "TRACKLET";
+  header.subSpecification = 0;
+
+  DataDescriptorMatcher matcher{
+    DataDescriptorMatcher::Op::And,
+    OriginValueMatcher{ "TDR" },
+    std::make_unique<DataDescriptorMatcher>(
+      DataDescriptorMatcher::Op::And,
+      DescriptionValueMatcher{ "TRACKLET" },
+      std::make_unique<DataDescriptorMatcher>(
+        DataDescriptorMatcher::Op::And,
+        SubSpecificationTypeValueMatcher{ 1 },
+        ConstantValueMatcher{ true }))
+  };
+
+  std::vector<ContextElement> context;
+
+  for (auto _ : state) {
+    matcher.match(header, context);
+  }
+}
+
+// Register the function as a benchmark
+BENCHMARK(BM_UnmatchedSingleQuery);
+
+static void BM_UnmatchedFullQuery(benchmark::State& state)
+{
+  DataHeader header;
+  header.dataOrigin = "TRD";
+  header.dataDescription = "TRACKLET";
+  header.subSpecification = 0;
+
+  DataDescriptorMatcher matcher{
+    DataDescriptorMatcher::Op::And,
+    OriginValueMatcher{ "TRD" },
+    std::make_unique<DataDescriptorMatcher>(
+      DataDescriptorMatcher::Op::And,
+      DescriptionValueMatcher{ "TRACKLET" },
+      std::make_unique<DataDescriptorMatcher>(
+        DataDescriptorMatcher::Op::And,
+        SubSpecificationTypeValueMatcher{ 1 },
+        ConstantValueMatcher{ true }))
+  };
+
+  std::vector<ContextElement> context;
+
+  for (auto _ : state) {
+    matcher.match(header, context);
+  }
+}
+// Register the function as a benchmark
+BENCHMARK(BM_UnmatchedFullQuery);
+
+static void BM_OneVariableFullMatch(benchmark::State& state)
+{
+  DataHeader header;
+  header.dataOrigin = "TRD";
+  header.dataDescription = "TRACKLET";
+  header.subSpecification = 0;
+
+  DataDescriptorMatcher matcher{
+    DataDescriptorMatcher::Op::And,
+    OriginValueMatcher{ ContextRef{ 0 } },
+    std::make_unique<DataDescriptorMatcher>(
+      DataDescriptorMatcher::Op::And,
+      DescriptionValueMatcher{ "TRACKLET" },
+      std::make_unique<DataDescriptorMatcher>(
+        DataDescriptorMatcher::Op::And,
+        SubSpecificationTypeValueMatcher{ 1 },
+        ConstantValueMatcher{ true }))
+  };
+
+  std::vector<ContextElement> context(1);
+
+  for (auto _ : state) {
+    context[0].value = None{};
+    matcher.match(header, context);
+  }
+}
+// Register the function as a benchmark
+BENCHMARK(BM_OneVariableFullMatch);
+
+static void BM_OneVariableMatchUnmatch(benchmark::State& state)
+{
+  DataHeader header0;
+  header0.dataOrigin = "TRD";
+  header0.dataDescription = "TRACKLET";
+  header0.subSpecification = 0;
+
+  DataHeader header1;
+  header1.dataOrigin = "TPC";
+  header1.dataDescription = "CLUSTERS";
+  header1.subSpecification = 0;
+
+  DataDescriptorMatcher matcher{
+    DataDescriptorMatcher::Op::And,
+    OriginValueMatcher{ ContextRef{ 0 } },
+    std::make_unique<DataDescriptorMatcher>(
+      DataDescriptorMatcher::Op::And,
+      DescriptionValueMatcher{ "TRACKLET" },
+      std::make_unique<DataDescriptorMatcher>(
+        DataDescriptorMatcher::Op::And,
+        SubSpecificationTypeValueMatcher{ 1 },
+        ConstantValueMatcher{ true }))
+  };
+
+  std::vector<ContextElement> context(1);
+
+  for (auto _ : state) {
+    context[0].value = None{};
+    matcher.match(header0, context);
+    matcher.match(header1, context);
+  }
+}
+// Register the function as a benchmark
+BENCHMARK(BM_OneVariableMatchUnmatch);
+
+BENCHMARK_MAIN();

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -274,6 +274,15 @@ o2_define_bucket(
 
 o2_define_bucket(
     NAME
+    O2FrameworkCore_benchmark_bucket
+
+    DEPENDENCIES
+    O2FrameworkCore_bucket
+    $<IF:$<BOOL:${benchmark_FOUND}>,benchmark::benchmark,$<0:"">>
+)
+
+o2_define_bucket(
+    NAME
     FrameworkApplication_bucket
 
     DEPENDENCIES


### PR DESCRIPTION
Previous results:

```
BM_MatchedSingleQuery              99 ns         99 ns    6865572
BM_MatchedFullQuery               321 ns        320 ns    2206163
BM_UnmatchedSingleQuery           308 ns        308 ns    2270457
BM_UnmatchedFullQuery             313 ns        312 ns    2218307
BM_OneVariableFullMatch           449 ns        448 ns    1552719
BM_OneVariableMatchUnmatch        769 ns        768 ns     889476
```

New results:

```
BM_MatchedSingleQuery              60 ns         60 ns   11614595
BM_MatchedFullQuery               314 ns        314 ns    2242016
BM_UnmatchedSingleQuery            56 ns         56 ns   12320256
BM_UnmatchedFullQuery             272 ns        272 ns    2609243
BM_OneVariableFullMatch           392 ns        392 ns    1783676
BM_OneVariableMatchUnmatch        476 ns        476 ns    1467029
```