### PR TITLE
DPL: prevent InputSpec default constructor

### DIFF
--- a/Framework/Core/include/Framework/InputSpec.h
+++ b/Framework/Core/include/Framework/InputSpec.h
@@ -25,11 +25,22 @@ namespace framework
 /// input or in output. This can be used, for example to match
 /// specific payloads in a timeframe.
 struct InputSpec {
+  /// This is the legacy way to construct things. For the moment we still allow
+  /// accessing directly the members, but this will change as well at some point.
+  InputSpec(std::string binding_, header::DataOrigin origin_, header::DataDescription description_, header::DataHeader::SubSpecificationType subSpec_ = 0, enum Lifetime lifetime_ = Lifetime::Timeframe)
+    : binding{binding_},
+      origin{origin_},
+      description{description_},
+      subSpec{subSpec_},
+      lifetime{lifetime_}
+  {
+  }
+
   std::string binding;
   header::DataOrigin origin;
   header::DataDescription description;
-  header::DataHeader::SubSpecificationType subSpec = 0;
-  enum Lifetime lifetime = Lifetime::Timeframe;
+  header::DataHeader::SubSpecificationType subSpec;
+  enum Lifetime lifetime;
 
   bool operator==(InputSpec const& that) const
   {

--- a/Framework/Core/include/Framework/LifetimeHelpers.h
+++ b/Framework/Core/include/Framework/LifetimeHelpers.h
@@ -13,15 +13,16 @@
 #include "Framework/ExpirationHandler.h"
 #include "Framework/PartRef.h"
 
-#include <functional>
 #include <chrono>
+#include <functional>
+#include <string>
 
 namespace o2
 {
 namespace framework
 {
 
-struct InputRoute;
+struct InputSpec;
 
 /// Lifetime handlers are used to manage the cases in which data is not coming
 /// from the dataflow, but from some other source or trigger, e.g.,
@@ -58,13 +59,13 @@ struct LifetimeHelpers {
   /// FIXME: provide a way to customise the histogram from the configuration.
   static ExpirationHandler::Handler fetchFromObjectRegistry();
 
-  /// Enumerate entries on every invokation.  @a route is the route which the
+  /// Enumerate entries on every invokation.  @a matcher is the InputSpec which the
   /// given enumeration refers to. In particular messages created by the
   /// returned ExpirationHandler will have an header which matches the
   /// dataOrigin, dataDescrition and dataSpecification of the given @a route.
   /// The payload of each message will contain an incremental number for each
   /// message being created.
-  static ExpirationHandler::Handler enumerate(InputRoute const& route);
+  static ExpirationHandler::Handler enumerate(InputSpec const& spec, std::string const& sourceChannel);
 };
 
 } // namespace framework

--- a/Framework/Core/src/DataSampling.cxx
+++ b/Framework/Core/src/DataSampling.cxx
@@ -185,21 +185,24 @@ QcTaskConfigurations DataSampling::readQcTasksConfiguration(const std::string& c
 
     for (auto&& input : taskInputsSplit) {
 
-      InputSpec desiredData;
+      std::string binding;
+      header::DataOrigin origin;
+      header::DataDescription description;
+
       try {
-        desiredData.binding = configFile->get<std::string>(prefixConfigTasks + input + ".inputName");
+        binding = configFile->get<std::string>(prefixConfigTasks + input + ".inputName");
+        std::string originStr = configFile->get<std::string>(prefixConfigTasks + input + ".dataOrigin");
+        std::string descriptionStr = configFile->get<std::string>(prefixConfigTasks + input + ".dataDescription");
 
-        std::string origin = configFile->get<std::string>(prefixConfigTasks + input + ".dataOrigin");
-        origin.copy(desiredData.origin.str, (size_t)desiredData.origin.size);
-
-        std::string description = configFile->get<std::string>(prefixConfigTasks + input + ".dataDescription");
-        description.copy(desiredData.description.str, (size_t)desiredData.description.size);
-
+        originStr.copy(origin.str, (size_t)origin.size);
+        descriptionStr.copy(description.str, (size_t)description.size);
       } catch (...) {
         LOG(ERROR) << "QC Task configuration error. In file " << configurationSource << " input " << input
                    << " has missing values";
         continue;
       }
+
+      InputSpec desiredData{binding, origin, description, 0};
       task.desiredDataSpecs.push_back(desiredData);
 
       // for temporary feature

--- a/Framework/Core/test/test_DataRelayer.cxx
+++ b/Framework/Core/test/test_DataRelayer.cxx
@@ -32,21 +32,12 @@ using Stack = o2::header::Stack;
 // and the subsequent InputRecord is immediately requested.
 BOOST_AUTO_TEST_CASE(TestNoWait) {
   Monitoring metrics;
-  InputSpec spec;
-  spec.binding = "clusters";
-  spec.description = "CLUSTERS";
-  spec.origin = "TPC";
-  spec.subSpec = 0;
-  spec.lifetime = Lifetime::Timeframe;
-
-  InputRoute route;
-  route.sourceChannel = "Fake";
-  route.matcher = spec;
-  route.timeslice = 0;
+  InputSpec spec{ "clusters", "TPC", "CLUSTERS" };
 
   std::vector<InputRoute> inputs = {
-    route
+    InputRoute{ spec, "Fake", 0 }
   };
+
   std::vector<ForwardRoute> forwards;
   TimesliceIndex index;
 
@@ -81,31 +72,22 @@ BOOST_AUTO_TEST_CASE(TestNoWait) {
 // correctly relayed before being processed.
 BOOST_AUTO_TEST_CASE(TestRelay) {
   Monitoring metrics;
-  InputSpec spec1;
-  spec1.binding = "clusters";
-  spec1.description = "CLUSTERS";
-  spec1.origin = "TPC";
-  spec1.subSpec = 0;
-  spec1.lifetime = Lifetime::Timeframe;
+  InputSpec spec1{
+    "clusters",
+    "TPC",
+    "CLUSTERS",
+  };
+  InputSpec spec2{
+    "clusters_its",
+    "ITS",
+    "CLUSTERS",
+  };
 
-  InputSpec spec2;
-  spec2.binding = "clusters_its";
-  spec2.description = "CLUSTERS";
-  spec2.origin = "ITS";
-  spec2.subSpec = 0;
-  spec2.lifetime = Lifetime::Timeframe;
+  std::vector<InputRoute> inputs = {
+    InputRoute{ spec1, "Fake1", 0 },
+    InputRoute{ spec2, "Fake2", 0 }
+  };
 
-  InputRoute route1;
-  route1.sourceChannel = "Fake";
-  route1.matcher = spec1;
-  route1.timeslice = 0;
-
-  InputRoute route2;
-  route2.sourceChannel = "Fake";
-  route2.matcher = spec2;
-  route2.timeslice = 0;
-
-  std::vector<InputRoute> inputs = { route1, route2 };
   std::vector<ForwardRoute> forwards;
 
   TimesliceIndex index;
@@ -157,20 +139,10 @@ BOOST_AUTO_TEST_CASE(TestRelay) {
 // the cache.
 BOOST_AUTO_TEST_CASE(TestCache) {
   Monitoring metrics;
-  InputSpec spec;
-  spec.binding = "clusters";
-  spec.description = "CLUSTERS";
-  spec.origin = "TPC";
-  spec.subSpec = 0;
-  spec.lifetime = Lifetime::Timeframe;
-
-  InputRoute route;
-  route.sourceChannel = "Fake";
-  route.matcher = spec;
-  route.timeslice = 0;
+  InputSpec spec{ "clusters", "TPC", "CLUSTERS" };
 
   std::vector<InputRoute> inputs = {
-    route
+    InputRoute{ spec, "Fake", 0 }
   };
   std::vector<ForwardRoute> forwards;
 
@@ -231,34 +203,14 @@ BOOST_AUTO_TEST_CASE(TestCache) {
 // it will run immediately.
 BOOST_AUTO_TEST_CASE(TestPolicies) {
   Monitoring metrics;
-  InputSpec spec1;
-  spec1.binding = "clusters";
-  spec1.description = "CLUSTERS";
-  spec1.origin = "TPC";
-  spec1.subSpec = 0;
-  spec1.lifetime = Lifetime::Timeframe;
-
-  InputSpec spec2;
-  spec2.binding = "tracks";
-  spec2.description = "TRACKS";
-  spec2.origin = "TPC";
-  spec2.subSpec = 0;
-  spec2.lifetime = Lifetime::Timeframe;
-
-  InputRoute route1;
-  route1.sourceChannel = "Fake";
-  route1.matcher = spec1;
-  route1.timeslice = 0;
-
-  InputRoute route2;
-  route2.sourceChannel = "Fake2";
-  route2.matcher = spec2;
-  route2.timeslice = 0;
+  InputSpec spec1{ "clusters", "TPC", "CLUSTERS" };
+  InputSpec spec2{ "tracks", "TPC", "TRACKS" };
 
   std::vector<InputRoute> inputs = {
-    route1,
-    route2
+    InputRoute{ spec1, "Fake1", 0 },
+    InputRoute{ spec2, "Fake2", 0 },
   };
+
   std::vector<ForwardRoute> forwards;
   TimesliceIndex index;
 

--- a/Framework/Core/test/test_InputRecord.cxx
+++ b/Framework/Core/test/test_InputRecord.cxx
@@ -26,32 +26,15 @@ bool any_exception( std::exception const& ex ) { return true; }
 
 BOOST_AUTO_TEST_CASE(TestInputRecord) {
   // Create the routes we want for the InputRecord
-  InputSpec spec1;
-  spec1.binding = "x";
-  spec1.description = "CLUSTERS";
-  spec1.origin = "TPC";
-  spec1.subSpec = 0;
-  spec1.lifetime = Lifetime::Timeframe;
+  InputSpec spec1{ "x", "TPC", "CLUSTERS", 0, Lifetime::Timeframe };
+  InputSpec spec2{ "y", "ITS", "CLUSTERS", 0, Lifetime::Timeframe };
+  InputSpec spec3{ "z", "TST", "EMPTY", 0, Lifetime::Timeframe };
 
-  InputSpec spec2;
-  spec2.binding = "y";
-  spec2.description = "CLUSTERS";
-  spec2.origin = "ITS";
-  spec2.subSpec = 0;
-  spec2.lifetime = Lifetime::Timeframe;
-
-  InputSpec spec3;
-  spec3.binding = "z";
-  spec3.description = "EMPTY";
-  spec3.origin = "TST";
-  spec3.subSpec = 0;
-  spec3.lifetime = Lifetime::Timeframe;
-
-  auto createRoute = [](const char *source, InputSpec &spec) {
-    InputRoute route;
-    route.sourceChannel = source;
-    route.matcher = spec;
-    return route;
+  auto createRoute = [](const char* source, InputSpec& spec) {
+    return InputRoute{
+      spec,
+      source
+    };
   };
 
   std::vector<InputRoute> schema = {
@@ -143,5 +126,3 @@ BOOST_AUTO_TEST_CASE(TestInputRecord) {
   BOOST_CHECK_EQUAL(record.get<int>("x"), 1);
   BOOST_CHECK_EQUAL(record.get<int>("x"), 1);
 }
-
-

--- a/Framework/Core/test/test_WorkflowHelpers.cxx
+++ b/Framework/Core/test/test_WorkflowHelpers.cxx
@@ -40,11 +40,11 @@ BOOST_AUTO_TEST_CASE(TestVerifyWorkflow)
 
   // A non fully specified input is an error, given the result is ambiguous.
   // Completely ambiguous.
-  checkIncompleteInput(WorkflowSpec{ { "A", { InputSpec{} } } });
+  checkIncompleteInput(WorkflowSpec{ { "A", { InputSpec{ "", "", "" } } } });
   // missing origin and description
-  checkIncompleteInput(WorkflowSpec{ { "A", { InputSpec{ "x" } } } });
+  checkIncompleteInput(WorkflowSpec{ { "A", { InputSpec{ "x", "", "" } } } });
   // missing description
-  checkIncompleteInput(WorkflowSpec{ { "A", { InputSpec{ "x", "TST" } } } });
+  checkIncompleteInput(WorkflowSpec{ { "A", { InputSpec{ "x", "TST", "" } } } });
   // This is fine, since by default both subSpec == 0 and
   // Timeframe are assumed.
   checkOk(WorkflowSpec{ { "A", { InputSpec{ "x", "TST", "A" } } } });


### PR DESCRIPTION
As we move closer to have InputSpec as a veritable "matcher" object
rather than a set of variables to be equal compared, I need to tight
the access to the member variables. The first adiabatic step in such a
direction is to make sure an InputSpec is built all at once, and not
incrementally, as that ability will be lost once we move to use
a DataDescriptorMatcher to describe the InputSpec internal State.