### PR TITLE
DPL: move DataRelayer to use a DataDescriptorMatcher for incoming data

### DIFF
--- a/Framework/Core/include/Framework/DataDescriptorMatcher.h
+++ b/Framework/Core/include/Framework/DataDescriptorMatcher.h
@@ -213,6 +213,39 @@ class DataDescriptorMatcher
                    And,
                    Xor };
 
+  /// We treat all the nodes as values, hence we copy the
+  /// contents mLeft and mRight into a new unique_ptr, if
+  /// needed.
+  DataDescriptorMatcher(DataDescriptorMatcher const& other)
+   : mOp{other.mOp},
+     mLeft{ConstantValueMatcher{false}},
+     mRight{ConstantValueMatcher{false}}
+  {
+    if (auto pval0 = std::get_if<OriginValueMatcher>(&other.mLeft)) {
+      mLeft = *pval0;
+    } else if (auto pval1 = std::get_if<DescriptionValueMatcher>(&other.mLeft)) {
+      mLeft = *pval1;
+    } else if (auto pval2 = std::get_if<SubSpecificationTypeValueMatcher>(&other.mLeft)) {
+      mLeft = *pval2;
+    } else if (auto pval3 = std::get_if<std::unique_ptr<DataDescriptorMatcher>>(&other.mLeft)) {
+      mLeft = std::move(std::make_unique<DataDescriptorMatcher>(*pval3->get()));
+    } else if (auto pval4 = std::get_if<ConstantValueMatcher>(&other.mLeft)) {
+      mLeft = *pval4;
+    }
+
+    if (auto pval0 = std::get_if<OriginValueMatcher>(&other.mRight)) {
+      mRight = *pval0;
+    } else if (auto pval1 = std::get_if<DescriptionValueMatcher>(&other.mRight)) {
+      mRight = *pval1;
+    } else if (auto pval2 = std::get_if<SubSpecificationTypeValueMatcher>(&other.mRight)) {
+      mRight = *pval2;
+    } else if (auto pval3 = std::get_if<std::unique_ptr<DataDescriptorMatcher>>(&other.mRight)) {
+      mRight = std::move(std::make_unique<DataDescriptorMatcher>(*pval3->get()));
+    } else if (auto pval4 = std::get_if<ConstantValueMatcher>(&other.mRight)) {
+      mRight = *pval4;
+    }
+  }
+
   /// Unary operator on a node
   DataDescriptorMatcher(Op op, Node&& lhs, Node&& rhs = std::move(ConstantValueMatcher{ false }))
     : mOp{ op },
@@ -312,6 +345,10 @@ class DataDescriptorMatcher
         return leftValue;
     }
   };
+
+  Node const& getLeft() const { return mLeft; };
+  Node const& getRight() const { return mRight; };
+  Op getOp() const { return mOp; };
 
  private:
   Op mOp;

--- a/Framework/Core/include/Framework/DataRelayer.h
+++ b/Framework/Core/include/Framework/DataRelayer.h
@@ -11,6 +11,7 @@
 #define FRAMEWORK_DATARELAYER_H
 
 #include "Framework/InputRoute.h"
+#include "Framework/DataDescriptorMatcher.h"
 #include "Framework/ForwardRoute.h"
 #include "Framework/CompletionPolicy.h"
 #include "Framework/PartRef.h"
@@ -97,6 +98,7 @@ public:
   std::vector<bool> mForwardingMask;
   CompletionPolicy mCompletionPolicy;
   std::vector<size_t> mDistinctRoutesIndex;
+  std::vector<data_matcher::DataDescriptorMatcher> mInputMatchers;
   static std::vector<std::string> sMetricsNames;
 };
 

--- a/Framework/Core/test/test_DataDescriptorMatcher.cxx
+++ b/Framework/Core/test/test_DataDescriptorMatcher.cxx
@@ -21,6 +21,58 @@ using namespace o2::framework;
 using namespace o2::header;
 using namespace o2::framework::data_matcher;
 
+BOOST_AUTO_TEST_CASE(TestMatcherInvariants) {
+  DataHeader header0;
+  header0.dataOrigin = "TPC";
+  header0.dataDescription = "CLUSTERS";
+  header0.subSpecification = 1;
+  std::vector<ContextElement> context;
+
+  DataHeader header1;
+  header1.dataOrigin = "ITS";
+  header1.dataDescription = "TRACKLET";
+  header1.subSpecification = 2;
+
+  DataHeader header2;
+  header2.dataOrigin = "TPC";
+  header2.dataDescription = "TRACKLET";
+  header2.subSpecification = 1;
+
+  DataHeader header3;
+  header3.dataOrigin = "TPC";
+  header3.dataDescription = "CLUSTERS";
+  header3.subSpecification = 0;
+
+  DataHeader header4;
+  header4.dataOrigin = "TRD";
+  header4.dataDescription = "TRACKLET";
+  header4.subSpecification = 0;
+
+  DataDescriptorMatcher matcher{
+    DataDescriptorMatcher::Op::And,
+    OriginValueMatcher{ "TPC" },
+    std::make_unique<DataDescriptorMatcher>(
+      DataDescriptorMatcher::Op::And,
+      DescriptionValueMatcher{ "CLUSTERS" },
+      std::make_unique<DataDescriptorMatcher>(
+        DataDescriptorMatcher::Op::And,
+        SubSpecificationTypeValueMatcher{ 1 },
+        ConstantValueMatcher{ true }))
+  };
+  DataDescriptorMatcher matcher2 = matcher;
+  BOOST_CHECK(matcher.match(header0, context) == true);
+  BOOST_CHECK(matcher.match(header1, context) == false);
+  BOOST_CHECK(matcher.match(header2, context) == false);
+  BOOST_CHECK(matcher.match(header3, context) == false);
+  BOOST_CHECK(matcher.match(header4, context) == false);
+  BOOST_CHECK(matcher2.match(header0, context) == true);
+  BOOST_CHECK(matcher2.match(header1, context) == false);
+  BOOST_CHECK(matcher2.match(header2, context) == false);
+  BOOST_CHECK(matcher2.match(header3, context) == false);
+  BOOST_CHECK(matcher2.match(header4, context) == false);
+
+}
+
 BOOST_AUTO_TEST_CASE(TestSimpleMatching)
 {
   DataHeader header0;

--- a/Framework/Core/test/test_DataDescriptorMatcher.cxx
+++ b/Framework/Core/test/test_DataDescriptorMatcher.cxx
@@ -21,7 +21,8 @@ using namespace o2::framework;
 using namespace o2::header;
 using namespace o2::framework::data_matcher;
 
-BOOST_AUTO_TEST_CASE(TestMatcherInvariants) {
+BOOST_AUTO_TEST_CASE(TestMatcherInvariants)
+{
   DataHeader header0;
   header0.dataOrigin = "TPC";
   header0.dataDescription = "CLUSTERS";
@@ -71,6 +72,96 @@ BOOST_AUTO_TEST_CASE(TestMatcherInvariants) {
   BOOST_CHECK(matcher2.match(header3, context) == false);
   BOOST_CHECK(matcher2.match(header4, context) == false);
 
+  BOOST_CHECK(matcher2 == matcher);
+
+  {
+    DataDescriptorMatcher matcherA{
+      DataDescriptorMatcher::Op::Just,
+      OriginValueMatcher{ "TPC" }
+    };
+    DataDescriptorMatcher matcherB{
+      DataDescriptorMatcher::Op::Just,
+      OriginValueMatcher{ "TPC" }
+    };
+    BOOST_CHECK(matcherA == matcherB);
+  }
+
+  {
+    DataDescriptorMatcher matcherA{
+      DataDescriptorMatcher::Op::Just,
+      DescriptionValueMatcher{ "TRACKS" }
+    };
+    DataDescriptorMatcher matcherB{
+      DataDescriptorMatcher::Op::Just,
+      DescriptionValueMatcher{ "TRACKS" }
+    };
+    BOOST_CHECK(matcherA == matcherB);
+  }
+
+  {
+    DataDescriptorMatcher matcherA{
+      DataDescriptorMatcher::Op::Just,
+      SubSpecificationTypeValueMatcher{ 1 }
+    };
+    DataDescriptorMatcher matcherB{
+      DataDescriptorMatcher::Op::Just,
+      SubSpecificationTypeValueMatcher{ 1 }
+    };
+    BOOST_CHECK(matcherA == matcherB);
+  }
+
+  {
+    DataDescriptorMatcher matcherA{
+      DataDescriptorMatcher::Op::Just,
+      ConstantValueMatcher{ 1 }
+    };
+    DataDescriptorMatcher matcherB{
+      DataDescriptorMatcher::Op::Just,
+      ConstantValueMatcher{ 1 }
+    };
+    BOOST_CHECK(matcherA == matcherB);
+  }
+
+  {
+    DataDescriptorMatcher matcherA{
+      DataDescriptorMatcher::Op::And,
+      ConstantValueMatcher{ 1 },
+      DescriptionValueMatcher{ "TPC" }
+    };
+    DataDescriptorMatcher matcherB{
+      DataDescriptorMatcher::Op::Just,
+      ConstantValueMatcher{ 1 },
+      DescriptionValueMatcher{ "TPC" }
+    };
+    BOOST_CHECK(matcherA == matcherB);
+  }
+
+  {
+    DataDescriptorMatcher matcherA{
+      DataDescriptorMatcher::Op::And,
+      OriginValueMatcher{ "TPC" },
+      std::make_unique<DataDescriptorMatcher>(
+        DataDescriptorMatcher::Op::And,
+        DescriptionValueMatcher{ "CLUSTERS" },
+        std::make_unique<DataDescriptorMatcher>(
+          DataDescriptorMatcher::Op::And,
+          SubSpecificationTypeValueMatcher{ 1 },
+          ConstantValueMatcher{ true }))
+    };
+
+    DataDescriptorMatcher matcherB{
+      DataDescriptorMatcher::Op::And,
+      OriginValueMatcher{ "TPC" },
+      std::make_unique<DataDescriptorMatcher>(
+        DataDescriptorMatcher::Op::And,
+        DescriptionValueMatcher{ "CLUSTERS" },
+        std::make_unique<DataDescriptorMatcher>(
+          DataDescriptorMatcher::Op::And,
+          SubSpecificationTypeValueMatcher{ 1 },
+          ConstantValueMatcher{ true }))
+    };
+    BOOST_CHECK(matcherA == matcherB);
+  }
 }
 
 BOOST_AUTO_TEST_CASE(TestSimpleMatching)


### PR DESCRIPTION
This includes the change mentioned in the title plus related refactoring of the `DataDescriptorMatcher` in order to achieve it. Please do not squash as I would like to keep the refactorings separate.

This is all going towards sub-timeframe inputs and wildcards in InputSpec.

