### PR TITLE
DataDescriptorMatcher based time slice extraction

### DIFF
--- a/Framework/Core/include/Framework/DataDescriptorMatcher.h
+++ b/Framework/Core/include/Framework/DataDescriptorMatcher.h
@@ -36,6 +36,8 @@ struct None {
 struct ContextRef {
   size_t index;
 
+  /// Two context refs are the same if they point to the
+  /// same element in the context
   bool operator==(ContextRef const& other) const
   {
     return index == other.index;
@@ -102,6 +104,16 @@ class VariableContext
   void discard()
   {
     mPerformedUpdates = 0;
+  }
+
+  /// Reset the all the variables and updates, without having to
+  /// tear down the context.
+  void reset()
+  {
+    mPerformedUpdates = 0;
+    for (auto& element : mElements) {
+      element.value = None{};
+    }
   }
 
  private:
@@ -379,6 +391,8 @@ class DataDescriptorMatcher
       mLeft = std::move(std::make_unique<DataDescriptorMatcher>(*pval3->get()));
     } else if (auto pval4 = std::get_if<ConstantValueMatcher>(&other.mLeft)) {
       mLeft = *pval4;
+    } else if (auto pval5 = std::get_if<StartTimeValueMatcher>(&other.mLeft)) {
+      mLeft = *pval5;
     }
 
     if (auto pval0 = std::get_if<OriginValueMatcher>(&other.mRight)) {
@@ -391,6 +405,8 @@ class DataDescriptorMatcher
       mRight = std::move(std::make_unique<DataDescriptorMatcher>(*pval3->get()));
     } else if (auto pval4 = std::get_if<ConstantValueMatcher>(&other.mRight)) {
       mRight = *pval4;
+    } else if (auto pval5 = std::get_if<StartTimeValueMatcher>(&other.mRight)) {
+      mRight = *pval5;
     }
   }
 

--- a/Framework/Core/include/Framework/DataRelayer.h
+++ b/Framework/Core/include/Framework/DataRelayer.h
@@ -99,6 +99,7 @@ public:
   CompletionPolicy mCompletionPolicy;
   std::vector<size_t> mDistinctRoutesIndex;
   std::vector<data_matcher::DataDescriptorMatcher> mInputMatchers;
+  std::vector<data_matcher::VariableContext> mVariableContextes;
   static std::vector<std::string> sMetricsNames;
 };
 

--- a/Framework/Core/src/CommonDataProcessors.cxx
+++ b/Framework/Core/src/CommonDataProcessors.cxx
@@ -46,7 +46,7 @@ DataProcessorSpec CommonDataProcessors::getGlobalFileSink(std::vector<InputSpec>
 
     bool hasOutputsToWrite = false;
     auto [variables, outputMatcher] = DataDescriptorQueryBuilder::buildFromKeepConfig(keepString);
-    std::vector<ContextElement> context(variables.size());
+    VariableContext context;
     for (auto& spec : danglingOutputInputs) {
       if (outputMatcher->match(spec, context)) {
         hasOutputsToWrite = true;
@@ -65,8 +65,8 @@ DataProcessorSpec CommonDataProcessors::getGlobalFileSink(std::vector<InputSpec>
       });
     }
     auto output = std::make_shared<std::ofstream>(filename.c_str(), std::ios_base::binary);
-    return std::move([ output, matcher = outputMatcher, contextSize = variables.size() ](ProcessingContext & pc) mutable->void {
-      std::vector<ContextElement> matchingContext(contextSize);
+    return std::move([ output, matcher = outputMatcher ](ProcessingContext & pc) mutable->void {
+      VariableContext matchingContext;
       LOG(INFO) << "processing data set with " << pc.inputs().size() << " entries";
       for (const auto& entry : pc.inputs()) {
         LOG(INFO) << "  " << *(entry.spec);

--- a/Framework/Core/src/DataRelayer.cxx
+++ b/Framework/Core/src/DataRelayer.cxx
@@ -137,7 +137,7 @@ size_t
 {
   /// FIXME: for the moment we have a global context, since we do not support
   ///        yet generic matchers as InputSpec.
-  std::vector<ContextElement> context{};
+  VariableContext context;
 
   for (size_t ri = 0, re = matchers.size(); ri < re; ++ri) {
     auto& matcher = matchers[ri];
@@ -147,8 +147,10 @@ size_t
     }
 
     if (matcher.match(*h, context)) {
+      context.commit();
       return ri;
     }
+    context.discard();
   }
   return matchers.size();
 }

--- a/Framework/Core/test/benchmark_DataDescriptorMatcher.cxx
+++ b/Framework/Core/test/benchmark_DataDescriptorMatcher.cxx
@@ -17,7 +17,7 @@ static void BM_MatchedSingleQuery(benchmark::State& state)
     OriginValueMatcher{ "TRD" }
   };
 
-  std::vector<ContextElement> context;
+  VariableContext context;
 
   for (auto _ : state) {
     matcher.match(header, context);
@@ -45,7 +45,7 @@ static void BM_MatchedFullQuery(benchmark::State& state)
         ConstantValueMatcher{ true }))
   };
 
-  std::vector<ContextElement> context;
+  VariableContext context;
 
   for (auto _ : state) {
     matcher.match(header, context);
@@ -73,7 +73,7 @@ static void BM_UnmatchedSingleQuery(benchmark::State& state)
         ConstantValueMatcher{ true }))
   };
 
-  std::vector<ContextElement> context;
+  VariableContext context;
 
   for (auto _ : state) {
     matcher.match(header, context);
@@ -102,7 +102,7 @@ static void BM_UnmatchedFullQuery(benchmark::State& state)
         ConstantValueMatcher{ true }))
   };
 
-  std::vector<ContextElement> context;
+  VariableContext context;
 
   for (auto _ : state) {
     matcher.match(header, context);
@@ -130,11 +130,11 @@ static void BM_OneVariableFullMatch(benchmark::State& state)
         ConstantValueMatcher{ true }))
   };
 
-  std::vector<ContextElement> context(1);
+  VariableContext context;
 
   for (auto _ : state) {
-    context[0].value = None{};
     matcher.match(header, context);
+    context.discard();
   }
 }
 // Register the function as a benchmark
@@ -164,12 +164,12 @@ static void BM_OneVariableMatchUnmatch(benchmark::State& state)
         ConstantValueMatcher{ true }))
   };
 
-  std::vector<ContextElement> context(1);
+  VariableContext context;
 
   for (auto _ : state) {
-    context[0].value = None{};
     matcher.match(header0, context);
     matcher.match(header1, context);
+    context.discard();
   }
 }
 // Register the function as a benchmark

--- a/Framework/Core/test/test_DataDescriptorMatcher.cxx
+++ b/Framework/Core/test/test_DataDescriptorMatcher.cxx
@@ -503,6 +503,27 @@ BOOST_AUTO_TEST_CASE(TestVariableContext)
   BOOST_CHECK(v3 != nullptr);
   BOOST_CHECK(*v3 == 77);
 
+  // Let's update again. New values should win.
+  context.put(ContextUpdate{ 0, "SOME MORE" });
+  context.put(ContextUpdate{ 10, 16 });
+  v1 = std::get_if<std::string>(&context.get(0));
+  BOOST_REQUIRE(v1 != nullptr);
+  BOOST_CHECK(*v1 == "SOME MORE");
+  v2 = std::get_if<std::string>(&context.get(1));
+  BOOST_CHECK(v2 == nullptr);
+  v3 = std::get_if<uint64_t>(&context.get(10));
+  BOOST_CHECK(v3 != nullptr);
+  BOOST_CHECK(*v3 == 16);
+
+  // Until we discard again, using reset
+  context.reset();
+  auto n1 = std::get_if<None>(&context.get(0));
+  BOOST_REQUIRE(n1 != nullptr);
+  auto n2 = std::get_if<None>(&context.get(1));
+  BOOST_CHECK(n2 != nullptr);
+  auto n3 = std::get_if<None>(&context.get(10));
+  BOOST_CHECK(n3 != nullptr);
+
   //auto d3 = std::get_if<uint64_t>(&context.get(0));
   //BOOST_CHECK(d1 == nullptr);
   //BOOST_CHECK(d2 == nullptr);

--- a/Framework/Core/test/test_DataDescriptorMatcher.cxx
+++ b/Framework/Core/test/test_DataDescriptorMatcher.cxx
@@ -28,7 +28,7 @@ BOOST_AUTO_TEST_CASE(TestMatcherInvariants)
   header0.dataOrigin = "TPC";
   header0.dataDescription = "CLUSTERS";
   header0.subSpecification = 1;
-  std::vector<ContextElement> context;
+  VariableContext context;
 
   DataHeader header1;
   header1.dataOrigin = "ITS";
@@ -204,7 +204,7 @@ BOOST_AUTO_TEST_CASE(TestSimpleMatching)
         ConstantValueMatcher{ true }))
   };
 
-  std::vector<ContextElement> context;
+  VariableContext context;
   BOOST_CHECK(matcher.match(header0, context) == true);
   BOOST_CHECK(matcher.match(header1, context) == false);
   BOOST_CHECK(matcher.match(header2, context) == false);
@@ -263,7 +263,7 @@ BOOST_AUTO_TEST_CASE(TestQueryBuilder)
   header4.subSpecification = 0;
 
   /// In this test the context is empty, since we do not use any variables.
-  std::vector<ContextElement> context;
+  VariableContext context;
 
   auto matcher1 = DataDescriptorQueryBuilder::buildFromKeepConfig("TPC/CLUSTERS/1");
   BOOST_CHECK(matcher1.matcher->match(header0, context) == true);
@@ -297,7 +297,7 @@ BOOST_AUTO_TEST_CASE(TestQueryBuilder)
 // This checks matching using variables
 BOOST_AUTO_TEST_CASE(TestMatchingVariables)
 {
-  std::vector<ContextElement> context(2);
+  VariableContext context;
 
   DataDescriptorMatcher matcher{
     DataDescriptorMatcher::Op::And,
@@ -317,10 +317,10 @@ BOOST_AUTO_TEST_CASE(TestMatchingVariables)
   header0.subSpecification = 1;
 
   BOOST_CHECK(matcher.match(header0, context) == true);
-  auto s = std::get_if<std::string>(&context[0].value);
+  auto s = std::get_if<std::string>(&context.get(0));
   BOOST_CHECK(s != nullptr);
   BOOST_CHECK(*s == "TPC");
-  auto v = std::get_if<uint64_t>(&context[1].value);
+  auto v = std::get_if<uint64_t>(&context.get(1));
   BOOST_CHECK(v != nullptr);
   BOOST_CHECK(*v == 1);
 
@@ -332,7 +332,7 @@ BOOST_AUTO_TEST_CASE(TestMatchingVariables)
   header1.subSpecification = 1;
 
   BOOST_CHECK(matcher.match(header1, context) == false);
-  auto s1 = std::get_if<std::string>(&context[0].value);
+  auto s1 = std::get_if<std::string>(&context.get(0));
   BOOST_CHECK(s1 != nullptr);
   BOOST_CHECK(*s1 == "TPC");
 }
@@ -357,7 +357,7 @@ BOOST_AUTO_TEST_CASE(TestInputSpecMatching)
         ConstantValueMatcher{ true }))
   };
 
-  std::vector<ContextElement> context;
+  VariableContext context;
 
   BOOST_CHECK(matcher.match(spec0, context) == true);
   BOOST_CHECK(matcher.match(spec1, context) == false);
@@ -391,7 +391,7 @@ BOOST_AUTO_TEST_CASE(TestInputSpecMatching)
 
 BOOST_AUTO_TEST_CASE(TestStartTimeMatching)
 {
-  std::vector<ContextElement> context(1);
+  VariableContext context;
 
   DataDescriptorMatcher matcher{
     DataDescriptorMatcher::Op::Just,
@@ -411,7 +411,100 @@ BOOST_AUTO_TEST_CASE(TestStartTimeMatching)
   BOOST_CHECK(s2dph != nullptr);
   BOOST_CHECK_EQUAL(s2dph->startTime, 123);
   BOOST_CHECK(matcher.match(s, context) == true);
-  auto vPtr = std::get_if<uint64_t>(&context[0].value);
+  auto vPtr = std::get_if<uint64_t>(&context.get(0));
   BOOST_REQUIRE(vPtr != nullptr);
   BOOST_CHECK_EQUAL(*vPtr, 123);
+}
+
+/// If a query matches only partially, we do not want
+/// to pollute the context with partial results.
+BOOST_AUTO_TEST_CASE(TestAtomicUpdatesOfContext)
+{
+  VariableContext context;
+
+  DataDescriptorMatcher matcher{
+    DataDescriptorMatcher::Op::And,
+    OriginValueMatcher{ ContextRef{ 0 } },
+    std::make_unique<DataDescriptorMatcher>(
+      DataDescriptorMatcher::Op::And,
+      DescriptionValueMatcher{ "CLUSTERS" },
+      std::make_unique<DataDescriptorMatcher>(
+        DataDescriptorMatcher::Op::Just,
+        SubSpecificationTypeValueMatcher{ ContextRef{ 1 } }))
+  };
+
+  /// This will match TPC, but not TRACKS, so the context should
+  /// be left pristine.
+  DataHeader dh;
+  dh.dataOrigin = "TPC";
+  dh.dataDescription = "TRACKS";
+  dh.subSpecification = 1;
+
+  auto vPtr0 = std::get_if<None>(&context.get(0));
+  auto vPtr1 = std::get_if<None>(&context.get(1));
+  BOOST_CHECK(vPtr0 != nullptr);
+  BOOST_CHECK(vPtr1 != nullptr);
+  BOOST_REQUIRE_EQUAL(matcher.match(dh, context), false);
+  // We discard the updates, because there was no match
+  context.discard();
+  vPtr0 = std::get_if<None>(&context.get(0));
+  vPtr1 = std::get_if<None>(&context.get(1));
+  BOOST_CHECK(vPtr0 != nullptr);
+  BOOST_CHECK(vPtr1 != nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(TestVariableContext)
+{
+  VariableContext context;
+  // Put some updates, but do not commit them
+  // we should still be able to retrieve them
+  // (just slower).
+  context.put(ContextUpdate{ 0, "A TEST" });
+  context.put(ContextUpdate{ 10, 77 });
+  auto v1 = std::get_if<std::string>(&context.get(0));
+  BOOST_REQUIRE(v1 != nullptr);
+  BOOST_CHECK(*v1 == "A TEST");
+  auto v2 = std::get_if<std::string>(&context.get(1));
+  BOOST_CHECK(v2 == nullptr);
+  auto v3 = std::get_if<uint64_t>(&context.get(10));
+  BOOST_CHECK(v3 != nullptr);
+  BOOST_CHECK(*v3 == 77);
+  context.commit();
+  // After commits everything is the same
+  v1 = std::get_if<std::string>(&context.get(0));
+  BOOST_REQUIRE(v1 != nullptr);
+  BOOST_CHECK(*v1 == "A TEST");
+  v2 = std::get_if<std::string>(&context.get(1));
+  BOOST_CHECK(v2 == nullptr);
+  v3 = std::get_if<uint64_t>(&context.get(10));
+  BOOST_CHECK(v3 != nullptr);
+  BOOST_CHECK(*v3 == 77);
+
+  // Let's update again. New values should win.
+  context.put(ContextUpdate{ 0, "SOME MORE" });
+  context.put(ContextUpdate{ 10, 16 });
+  v1 = std::get_if<std::string>(&context.get(0));
+  BOOST_REQUIRE(v1 != nullptr);
+  BOOST_CHECK(*v1 == "SOME MORE");
+  v2 = std::get_if<std::string>(&context.get(1));
+  BOOST_CHECK(v2 == nullptr);
+  v3 = std::get_if<uint64_t>(&context.get(10));
+  BOOST_CHECK(v3 != nullptr);
+  BOOST_CHECK(*v3 == 16);
+
+  // Until we discard
+  context.discard();
+  v1 = std::get_if<std::string>(&context.get(0));
+  BOOST_REQUIRE(v1 != nullptr);
+  BOOST_CHECK(*v1 == "A TEST");
+  auto n = std::get_if<None>(&context.get(1));
+  BOOST_CHECK(n != nullptr);
+  v3 = std::get_if<uint64_t>(&context.get(10));
+  BOOST_CHECK(v3 != nullptr);
+  BOOST_CHECK(*v3 == 77);
+
+  //auto d3 = std::get_if<uint64_t>(&context.get(0));
+  //BOOST_CHECK(d1 == nullptr);
+  //BOOST_CHECK(d2 == nullptr);
+  //BOOST_CHECK(d3 == nullptr);
 }


### PR DESCRIPTION
This refactors the logic in `DataRelayer` to use a `DataDescriptorMatcher` query to extract the timeslice information, rather than an hardcoded lookup in `DataProcessingHeader->startTime`.
While the actual query mechanism is still hardcoded, this will be soon extended to be able to do the following:

* Allow generic queries to match the inputs, including wildcard matching.
* Allow a definition of time which is different between various inputs, e.g. allowing merging multiple timeslices together.