### PR TITLE
Temporarily disable test_MID_GeometryTransformer

### DIFF
--- a/Detectors/MUON/MID/Base/CMakeLists.txt
+++ b/Detectors/MUON/MID/Base/CMakeLists.txt
@@ -38,8 +38,9 @@ O2_GENERATE_TESTS(
   TEST_SRCS test/testDEconversion.cxx
 )
 
-O2_GENERATE_TESTS(
-  MODULE_LIBRARY_NAME ${LIBRARY_NAME}
-  BUCKET_NAME ${BUCKET_NAME}
-  TEST_SRCS test/testGeometryTransformer.cxx
-)
+# SW: This test takes very very long
+#O2_GENERATE_TESTS(
+#  MODULE_LIBRARY_NAME ${LIBRARY_NAME}
+#  BUCKET_NAME ${BUCKET_NAME}
+#  TEST_SRCS test/testGeometryTransformer.cxx
+#)


### PR DESCRIPTION
The testGeometryTransformer for MID takes very long to complete.
This is probably due to its "sampling" nature.

Disabling it momentarily to speed up CI. Please revise the test before re-enabling.