### PR TITLE
MCCompLabel: Remove implicit conversion operator

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/MCCompLabel.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCCompLabel.h
@@ -66,8 +66,6 @@ class MCCompLabel
     return (tr1 == tr2) ? 1 : ((tr1 = -tr2) ? 0 : -1);
   }
 
-  // conversion operator
-  operator ULong64_t() const { return mLabel; }
   // comparison operator, compares only label, not evential weight info
   bool operator==(const MCCompLabel& other) const { return (mLabel & maskFull) == (other.mLabel & maskFull); }
   // invalidate
@@ -83,6 +81,9 @@ class MCCompLabel
   int getTrackID() const { return static_cast<int>(mLabel & maskTrackID); }
   int getEventID() const { return (mLabel >> nbitsTrackID) & maskEvID; }
   int getSourceID() const { return (mLabel >> (nbitsTrackID + nbitsEvID)) & maskSrcID; }
+
+  ULong64_t getEncodedLabel() const { return mLabel; }
+
   void get(int& trackID, int& evID, int& srcID)
   {
     /// parse label

--- a/DataFormats/simulation/test/testMCCompLabel.cxx
+++ b/DataFormats/simulation/test/testMCCompLabel.cxx
@@ -29,7 +29,7 @@ BOOST_AUTO_TEST_CASE(MCCompLabel_test)
     MCCompLabel lb(tr, ev, src);
     std::cout << "Input:   [" << src << '/' << ev << '/'
               << std::setw(6) << tr << ']' << std::endl;
-    std::cout << "Encoded: " << lb << " (packed: " << ULong_t(lb) << ")" << std::endl;
+    std::cout << "Encoded: " << lb << " (packed: " << lb.getEncodedLabel() << ")" << std::endl;
     int trE, evE, srcE;
     lb.get(trE, evE, srcE);
     std::cout << "Decoded: [" << srcE << '/' << evE << '/'

--- a/Detectors/PHOS/base/include/PHOSBase/Digit.h
+++ b/Detectors/PHOS/base/include/PHOSBase/Digit.h
@@ -99,7 +99,7 @@ class Digit : public DigitBase
   /// \brief Proportion of energy deposited by particle idx
   /// \param idx index in a list of a particles, max length kMaxLabels
   /// \return Proportion of energy from this particle.
-  Label getLabelEProp(Int_t idx) const
+  double getLabelEProp(Int_t idx) const
   {
     if (idx < kMaxLabels)
       return mEProp[idx];

--- a/Detectors/PHOS/reconstruction/src/Cluster.cxx
+++ b/Detectors/PHOS/reconstruction/src/Cluster.cxx
@@ -340,7 +340,7 @@ void Cluster::EvalPrimaries(const std::vector<Digit>* digits)
         }
       }
       if (!found) {
-        mLabelsEProp.push_back(lab);
+        mLabels.push_back(lab);
         mLabelsEProp.push_back(eProp * ((*foundIt).getAmplitude()) / mFullEnergy);
       }
     }


### PR DESCRIPTION
Remove an implicit conversion operator from MCCompLabel since
this is dangerous.

Indeed, this revealed a few problems in PHOS where labels where converted
to float/double numbers.