### PR TITLE
Fix InputSpecs generation in Data Sampling

### DIFF
--- a/Framework/Core/src/DataSampling.cxx
+++ b/Framework/Core/src/DataSampling.cxx
@@ -138,8 +138,8 @@ std::vector<InputSpec> DataSampling::InputSpecsForPolicy(ConfigurationInterface*
             path.second.subSpec,
             path.second.lifetime });
       }
+      break;
     }
-    break;
   }
   return inputs;
 }


### PR DESCRIPTION
Just a misplaced 'break' which caused jumping out of the loop too soon.