### PR TITLE
Possibility to set seed for simulation

### DIFF
--- a/Common/SimConfig/include/SimConfig/SimConfig.h
+++ b/Common/SimConfig/include/SimConfig/SimConfig.h
@@ -39,8 +39,10 @@ struct SimConfigData {
                                              // (can be used to **loosly** change any configuration parameter from
                                              //  command-line)
   int mPrimaryChunkSize;                     // defining max granularity for input primaries of a sim job
-  int mInternalChunkSize;
-  ClassDefNV(SimConfigData, 1);
+  int mInternalChunkSize;                    //
+  int mStartSeed;                            // base for random number seeds
+
+  ClassDefNV(SimConfigData, 2);
 };
 
 // A singleton class which can be used
@@ -97,6 +99,7 @@ class SimConfig
   std::string getKeyValueString() const { return mConfigData.mKeyValueTokens; }
   int getPrimChunkSize() const { return mConfigData.mPrimaryChunkSize; }
   int getInternalChunkSize() const { return mConfigData.mInternalChunkSize; }
+  int getStartSeed() const { return mConfigData.mStartSeed; }
 
  private:
   SimConfigData mConfigData; //!

--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -36,7 +36,9 @@ void SimConfig::initOptions(boost::program_options::options_description& options
     "outPrefix,o", bpo::value<std::string>()->default_value("o2sim"), "prefix of output files")(
     "logseverity", bpo::value<std::string>()->default_value("INFO"), "severity level for FairLogger")(
     "logverbosity", bpo::value<std::string>()->default_value("low"), "level of verbosity for FairLogger (low, medium, high, veryhigh)")(
-    "configKeyValues", bpo::value<std::string>()->default_value(""), "comma separated key=value strings (e.g.: 'TPC.gasDensity=1,...")("chunkSize", bpo::value<unsigned int>()->default_value(10000), "max size of primary chunk (subevent) distributed by server")("chunkSizeI", bpo::value<int>()->default_value(-1), "internalChunkSize");
+    "configKeyValues", bpo::value<std::string>()->default_value(""), "comma separated key=value strings (e.g.: 'TPC.gasDensity=1,...")("chunkSize", bpo::value<unsigned int>()->default_value(10000), "max size of primary chunk (subevent) distributed by server")(
+    "chunkSizeI", bpo::value<int>()->default_value(-1), "internalChunkSize")(
+    "seed", bpo::value<int>()->default_value(-1), "initial seed (default: -1 random)");
 }
 
 bool SimConfig::resetFromParsedMap(boost::program_options::variables_map const& vm)
@@ -82,6 +84,7 @@ bool SimConfig::resetFromParsedMap(boost::program_options::variables_map const& 
   mConfigData.mKeyValueTokens = vm["configKeyValues"].as<std::string>();
   mConfigData.mPrimaryChunkSize = vm["chunkSize"].as<unsigned int>();
   mConfigData.mInternalChunkSize = vm["chunkSizeI"].as<int>();
+  mConfigData.mStartSeed = vm["seed"].as<int>();
   return true;
 }
 


### PR DESCRIPTION
Allow to set the seed for simulation. By default
a random seed will be chosen at each start. If reproducible tests
are needed ... set the seed with the --seed option.

For the moment, change restricted to o2sim_parallel.