### PR TITLE
DPL GUI: refactor 2D Metrics index

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -56,6 +56,7 @@ set(SRCS
     src/LifetimeHelpers.cxx
     src/LocalRootFileService.cxx
     src/LogParsingHelpers.cxx
+    src/Metric2DViewIndex.cxx
     src/ExternalFairMQDeviceProxy.cxx
     src/SimpleResourceManager.cxx
     src/TextControlService.cxx
@@ -149,6 +150,7 @@ set(HEADERS
       include/Framework/DPLBoostSerializer.h
       include/Framework/TableBuilder.h
       include/Framework/FairMQResizableBuffer.h
+      include/Framework/Metric2DViewIndex.h
       src/ComputingResource.h
       src/DDSConfigHelpers.h
       src/DeviceSpecHelpers.h

--- a/Framework/Core/include/Framework/DeviceInfo.h
+++ b/Framework/Core/include/Framework/DeviceInfo.h
@@ -11,6 +11,7 @@
 #define FRAMEWORK_DEVICEINFO_H
 
 #include "Framework/LogParsingHelpers.h"
+#include "Framework/Metric2DViewIndex.h"
 #include "Framework/Variant.h"
 
 #include <cstddef>
@@ -24,16 +25,6 @@ namespace o2
 {
 namespace framework
 {
-
-/// Index of what metrics have to be picked up
-/// for the DataRelayer view of a given device.
-struct DataRelayerViewIndex {
-  int w = 0;
-  int h = 0;
-  std::vector<size_t> indexes = {};
-  /// Whether or not the view is ready to be used.
-  bool isComplete() const { return (w * h) != 0; }
-};
 
 struct DeviceInfo {
   /// The pid of the device associated to this device
@@ -57,8 +48,8 @@ struct DeviceInfo {
   bool active;
   /// Whether the device is ready to quit.
   bool readyToQuit;
-  /// Index for a particular release.
-  DataRelayerViewIndex dataRelayerViewIndex;
+  /// Index for a particular relayer.
+  Metric2DViewIndex dataRelayerViewIndex;
 };
 
 } // namespace framework

--- a/Framework/Core/include/Framework/Metric2DViewIndex.h
+++ b/Framework/Core/include/Framework/Metric2DViewIndex.h
@@ -1,0 +1,46 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef o2_framework_Metric2DViewInfo_H_INCLUDED
+#define o2_framework_Metric2DViewInfo_H_INCLUDED
+
+#include <functional>
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace o2
+{
+namespace framework
+{
+
+struct MetricInfo;
+
+/// This allows keeping track of the metrics which should be grouped together
+/// in some sort of 2D representation.
+struct Metric2DViewIndex {
+  using Updater = std::function<void(std::string const&, MetricInfo const&, int)>;
+  /// The prefix in the metrics store to be used for the view
+  std::string prefix;
+  /// The size in X of the metrics
+  int w = 0;
+  /// The size in Y of the metrics
+  int h = 0;
+  /// The row major list of indices for the metrics which compose the 2D view
+  std::vector<std::size_t> indexes = {};
+  /// Whether or not the view is ready to be used.
+  bool isComplete() const { return (w * h) != 0; }
+
+  static Updater getUpdater(Metric2DViewIndex& view);
+};
+
+} // namespace framework
+} // namespace o2
+
+#endif // o2_framework_Metric2DViewInfo_H_INCLUDED

--- a/Framework/Core/src/Metric2DViewIndex.cxx
+++ b/Framework/Core/src/Metric2DViewIndex.cxx
@@ -1,0 +1,66 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/Metric2DViewIndex.h"
+
+#include "Framework/DeviceMetricsInfo.h"
+
+#include <fairmq/FairMQLogger.h>
+
+#include <algorithm>
+#include <functional>
+
+namespace o2
+{
+namespace framework
+{
+
+Metric2DViewIndex::Updater Metric2DViewIndex::getUpdater(Metric2DViewIndex& view)
+{
+  return [&view](std::string const& name, MetricInfo const& metric, int value) -> void {
+    if (view.prefix.size() > name.size()) {
+      return;
+    }
+    if (std::mismatch(view.prefix.begin(), view.prefix.end(), name.begin()).first != view.prefix.end()) {
+      return;
+    }
+
+    auto extra = name;
+
+    // +1 is to remove the /
+    extra.erase(0, view.prefix.size() + 1);
+    if (extra == "w") {
+      view.w = value;
+      view.indexes.resize(view.w * view.h);
+      return;
+    } else if (extra == "h") {
+      view.h = value;
+      view.indexes.resize(view.w * view.h);
+      return;
+    }
+    int idx = -1;
+    try {
+      idx = std::stoi(extra, nullptr, 10);
+    } catch (...) {
+      LOG(ERROR) << "Badly formatted metric";
+    }
+    if (idx < 0) {
+      LOG(ERROR) << "Negative metric";
+      return;
+    }
+    if (view.indexes.size() <= idx) {
+      view.indexes.resize(std::max(idx + 1, view.w * view.h));
+    }
+    view.indexes[idx] = metric.storeIdx;
+  };
+}
+
+} // namespace framework
+} // namespace o2

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -288,14 +288,6 @@ static void handle_sigint(int) { graceful_exit = true; }
 
 static void handle_sigchld(int) { sigchld_requested = true; }
 
-bool startsWith(std::string mainStr, std::string toMatch)
-{
-  if (mainStr.find(toMatch) == 0) {
-    return true;
-  } else {
-    return false;
-  }
-}
 
 /// This will start a new device by forking and executing a
 /// new child
@@ -354,7 +346,7 @@ void spawnDevice(DeviceSpec const& spec, std::map<int, size_t>& socket2DeviceInf
   info.historySize = 1000;
   info.historyPos = 0;
   info.maxLogLevel = LogParsingHelpers::LogLevel::Debug;
-  info.dataRelayerViewIndex = DataRelayerViewIndex{ 0, 0, {} };
+  info.dataRelayerViewIndex = Metric2DViewIndex{ "data_relayer", 0, 0, {} };
 
   socket2DeviceInfo.insert(std::make_pair(childstdout[0], deviceInfos.size()));
   socket2DeviceInfo.insert(std::make_pair(childstderr[0], deviceInfos.size()));
@@ -371,8 +363,6 @@ void spawnDevice(DeviceSpec const& spec, std::map<int, size_t>& socket2DeviceInf
 void processChildrenOutput(DriverInfo& driverInfo, DeviceInfos& infos, DeviceSpecs const& specs,
                            DeviceControls& controls, std::vector<DeviceMetricsInfo>& metricsInfos)
 {
-  static const char* DATA_RELAYER_METRIC_PREFIX = "data_relayer";
-  static const size_t DATA_RELAYER_METRIC_PREFIX_SIZE = std::strlen(DATA_RELAYER_METRIC_PREFIX);
   // Wait for children to say something. When they do
   // print it.
   fd_set fdset;
@@ -426,39 +416,7 @@ void processChildrenOutput(DriverInfo& driverInfo, DeviceInfos& infos, DeviceSpe
     info.history.resize(info.historySize);
     info.historyLevel.resize(info.historySize);
 
-    auto& view = info.dataRelayerViewIndex;
-    auto updateDataRelayerViewIndex = [&view](std::string const& name, MetricInfo const& metric, int value) {
-      if (startsWith(name, DATA_RELAYER_METRIC_PREFIX) == false) {
-        return;
-      }
-      auto extra = name;
-
-      // +1 is to remove the /
-      extra.erase(0, DATA_RELAYER_METRIC_PREFIX_SIZE + 1);
-      if (extra == "w") {
-        view.w = value;
-        view.indexes.resize(view.w * view.h);
-        return;
-      } else if (extra == "h") {
-        view.h = value;
-        view.indexes.resize(view.w * view.h);
-        return;
-      }
-      int idx = -1;
-      try {
-        idx = std::stoi(extra, nullptr, 10);
-      } catch (...) {
-        LOG(ERROR) << "Badly formatted metric" << std::endl;
-      }
-      if (idx < 0) {
-        LOG(ERROR) << "Negative metric" << std::endl;
-        return;
-      }
-      if (view.indexes.size() <= idx) {
-        view.indexes.resize(std::max(idx + 1, view.w * view.h));
-      }
-      view.indexes[idx] = metric.storeIdx;
-    };
+    auto updateDataRelayerViewIndex = Metric2DViewIndex::getUpdater(info.dataRelayerViewIndex);
 
     while ((pos = s.find(delimiter)) != std::string::npos) {
       token = s.substr(0, pos);

--- a/Framework/Core/test/test_GUITests.cxx
+++ b/Framework/Core/test/test_GUITests.cxx
@@ -66,6 +66,7 @@ BOOST_AUTO_TEST_CASE(HeatmapTest)
   DeviceInfo deviceInfo;
   DeviceInfo deviceInfo2;
   deviceInfo2.dataRelayerViewIndex = {
+    "data_relayer",
     1,
     1,
     { 0 }
@@ -174,7 +175,7 @@ BOOST_AUTO_TEST_CASE(DevicesGraph)
       {},
       true,
       false,
-      0 });
+      Metric2DViewIndex{}});
 
   std::vector<DeviceControl> controls;
   controls.push_back(


### PR DESCRIPTION
This makes the old DataRelayerViewIndex a generic component for metrics
which should really grouped in a 2D display. To be used by the soon to
be introduced DataDescriptorMatcher debug view.