### PR TITLE
Make sure geometry file is available in standard way

### DIFF
--- a/macro/o2sim.C
+++ b/macro/o2sim.C
@@ -92,7 +92,9 @@ FairRunSim* o2sim_init(bool asservice)
   }
   geomss << ".root";
   gGeoManager->Export(geomss.str().c_str());
-
+  if (asservice) {
+    symlink(geomss.str().c_str(), "O2geometry.root");
+  }
   std::time_t runStart = std::time(nullptr);
 
   // runtime database


### PR DESCRIPTION
Little fix for parallel simulation, where each worker
creates a geometry file + a PID identifier in order to avoid that they all
write to the same file.
We now make sure that the standard file (or a link) O2geometry.root
is created or symlinked, since this is expected by the processing chain further up.

With this, we can now run o2sim_parallel + digitizer-workflow.
Thanks to @davidrohr.