### PR TITLE
Bugfix: need to use unsigned short to represent port range up to 65535

### DIFF
--- a/Framework/Core/src/SimpleResourceManager.h
+++ b/Framework/Core/src/SimpleResourceManager.h
@@ -21,17 +21,18 @@ namespace framework
 /// This is a trivial implementation which can be used to do
 /// laptop deploys.
 class SimpleResourceManager : public ResourceManager {
-public:
+ public:
   /// @a initialPort is the first port which can be used
   ///              by this trivial resource manager.
   /// @a maxPorts is the maximum number of ports starting from
   ///             initialPort that this resource manager can allocate.
-  SimpleResourceManager(short initialPort, short maxPorts = 1000)
-  : mInitialPort{initialPort},
-    mMaxPorts{maxPorts}
+  SimpleResourceManager(unsigned short initialPort, unsigned short maxPorts = 1000)
+    : mInitialPort{ initialPort },
+      mMaxPorts{ maxPorts }
   {}
   std::vector<ComputingResource> getAvailableResources() override;
-private:
+
+ private:
   int mInitialPort;
   int mMaxPorts;
 };


### PR DESCRIPTION
Signed short causes the number to become negative for specified initial
port values > 32767, while range up to 65535 is allowed