### PR TITLE
Basic HMPID digitizer workflow

### DIFF
--- a/Detectors/HMPID/base/CMakeLists.txt
+++ b/Detectors/HMPID/base/CMakeLists.txt
@@ -4,9 +4,11 @@ O2_SETUP(NAME ${MODULE_NAME})
 
 set(SRCS
     src/Param.cxx
+    src/Digit.cxx
     )
 set(HEADERS
     include/${MODULE_NAME}/Param.h
+    include/${MODULE_NAME}/Digit.h
     )
 
 Set(LINKDEF src/HMPIDBaseLinkDef.h)

--- a/Detectors/HMPID/base/include/HMPIDBase/Digit.h
+++ b/Detectors/HMPID/base/include/HMPIDBase/Digit.h
@@ -1,0 +1,110 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef DETECTORS_HMPID_BASE_INCLUDE_HMPIDBASE_DIGIT_H_
+#define DETECTORS_HMPID_BASE_INCLUDE_HMPIDBASE_DIGIT_H_
+
+#include "CommonDataFormat/TimeStamp.h"
+#include "HMPIDBase/Hit.h"   // for hit
+#include "HMPIDBase/Param.h" // for param
+#include "TMath.h"
+
+namespace o2
+{
+namespace hmpid
+{
+
+/// \class Digit
+/// \brief HMPID digit implementation
+using DigitBase = o2::dataformats::TimeStamp<double>;
+class Digit : public DigitBase
+{
+ public:
+  Digit() = default;
+  Digit(float charge) : mQ(charge) {}
+  float getCharge() const { return mQ; }
+  int getPadID() const { return mPad; }
+
+  Digit(HitType const& hit)
+  {
+    int pc, px, py;
+    float localX;
+    float localY;
+
+    // chamber number is in detID
+    const auto chamber = hit.GetDetectorID();
+
+    double tmp[3] = { hit.GetX(), hit.GetY(), hit.GetZ() };
+    Param::Instance()->Mars2Lors(chamber, tmp, localX, localY);
+
+    Param::Lors2Pad(localX, localY, pc, px, py);
+
+    // TODO: check if this digit is valid
+    // mark as invalid otherwise
+
+    // calculate pad id
+    mPad = Param::Abs(chamber, pc, px, py);
+
+    // calculate charge
+    mQ = /*fQHit **/ InMathieson(localX, localY);
+
+    // what about time stamp??
+  }
+
+ private:
+  float mQ = 0.;
+  int mPad = 0.; // -1 indicates invalid digit
+
+  float LorsX() const { return Param::LorsX(Param::A2P(mPad), Param::A2X(mPad)); } //center of the pad x, [cm]
+  float LorsY() const { return Param::LorsY(Param::A2P(mPad), Param::A2Y(mPad)); } //center of the pad y, [cm]
+
+  float IntPartMathiX(float x) const
+  {
+    // Integration of Mathieson.
+    // This is the answer to electrostatic problem of charge distrubution in MWPC described elsewhere. (NIM A370(1988)602-603)
+    // Arguments: x,y- position of the center of Mathieson distribution
+    //  Returns: a charge fraction [0-1] imposed into the pad
+    auto shift1 = -LorsX() + 0.5 * Param::SizePadX();
+    auto shift2 = -LorsX() - 0.5 * Param::SizePadX();
+
+    auto ux1 = Param::SqrtK3x() * TMath::TanH(Param::K2x() * (x + shift1) / Param::PitchAnodeCathode());
+    auto ux2 = Param::SqrtK3x() * TMath::TanH(Param::K2x() * (x + shift2) / o2::hmpid::Param::PitchAnodeCathode());
+
+    return o2::hmpid::Param::K4x() * (TMath::ATan(ux2) - TMath::ATan(ux1));
+  }
+  //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+  Double_t IntPartMathiY(Double_t y) const
+  {
+    // Integration of Mathieson.
+    // This is the answer to electrostatic problem of charge distrubution in MWPC described elsewhere. (NIM A370(1988)602-603)
+    // Arguments: x,y- position of the center of Mathieson distribution
+    //  Returns: a charge fraction [0-1] imposed into the pad
+    Double_t shift1 = -LorsY() + 0.5 * o2::hmpid::Param::SizePadY();
+    Double_t shift2 = -LorsY() - 0.5 * o2::hmpid::Param::SizePadY();
+
+    Double_t uy1 = Param::SqrtK3y() * TMath::TanH(Param::K2y() * (y + shift1) / Param::PitchAnodeCathode());
+    Double_t uy2 = Param::SqrtK3y() * TMath::TanH(Param::K2y() * (y + shift2) / Param::PitchAnodeCathode());
+
+    return Param::K4y() * (TMath::ATan(uy2) - TMath::ATan(uy1));
+  }
+
+  float InMathieson(float localX, float localY) const
+  {
+    return 4. * IntPartMathiX(localX) * IntPartMathiY(localY);
+  }
+
+  ClassDefNV(Digit, 1);
+};
+
+} // namespace hmpid
+} // namespace o2
+
+#endif /* DETECTORS_HMPID_BASE_INCLUDE_HMPIDBASE_DIGIT_H_ */

--- a/Detectors/HMPID/base/include/HMPIDBase/Hit.h
+++ b/Detectors/HMPID/base/include/HMPIDBase/Hit.h
@@ -8,14 +8,20 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifdef __CLING__
+#ifndef DETECTORS_HMPID_BASE_INCLUDE_HMPIDBASE_HIT_H_
+#define DETECTORS_HMPID_BASE_INCLUDE_HMPIDBASE_HIT_H_
 
-#pragma link off all globals;
-#pragma link off all classes;
-#pragma link off all functions;
+#include "SimulationDataFormat/BaseHits.h"
 
-#pragma link C++ class o2::hmpid::Detector+;
-#pragma link C++ class o2::Base::DetImpl<o2::hmpid::Detector>+;
-#pragma link C++ class o2::hmpid::HMPIDDigitizer + ;
+namespace o2
+{
+namespace hmpid
+{
 
-#endif
+// define HMPID hit type
+using HitType = o2::BasicXYZEHit<float>;
+
+} // namespace hmpid
+} // namespace o2
+
+#endif /* DETECTORS_HMPID_BASE_INCLUDE_HMPIDBASE_HIT_H_ */

--- a/Detectors/HMPID/base/include/HMPIDBase/Param.h
+++ b/Detectors/HMPID/base/include/HMPIDBase/Param.h
@@ -93,7 +93,7 @@ class Param
   //ThMax  (degree) of the camber ch
   float ChThMax(Int_t ch) { return Lors2Mars(ch, LorsX(ch, kMaxPcx) - mX, LorsY(ch, kMaxPcy) - mY).Theta() * r2d(); }
 
-  inline static void Lors2Pad(float x, float y, Int_t& pc, Int_t& px, Int_t& py); //(x,y)->(pc,px,py)
+  static void Lors2Pad(float x, float y, Int_t& pc, Int_t& px, Int_t& py); //(x,y)->(pc,px,py)
 
   //(ch,pc,padx,pady)-> abs pad
   static Int_t Abs(Int_t ch, Int_t pc, Int_t x, Int_t y) { return ch * 100000000 + pc * 1000000 + x * 1000 + y; }

--- a/Detectors/HMPID/base/src/Digit.cxx
+++ b/Detectors/HMPID/base/src/Digit.cxx
@@ -8,14 +8,9 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifdef __CLING__
+#include "HMPIDBase/Digit.h"
+#include <iostream>
 
-#pragma link off all globals;
-#pragma link off all classes;
-#pragma link off all functions;
+using namespace o2::hmpid;
 
-#pragma link C++ class o2::hmpid::Detector+;
-#pragma link C++ class o2::Base::DetImpl<o2::hmpid::Detector>+;
-#pragma link C++ class o2::hmpid::HMPIDDigitizer + ;
-
-#endif
+ClassImp(o2::hmpid::Digit);

--- a/Detectors/HMPID/base/src/HMPIDBaseLinkDef.h
+++ b/Detectors/HMPID/base/src/HMPIDBaseLinkDef.h
@@ -14,6 +14,8 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
-#pragma link C++ class o2::hmpid::Param;
+#pragma link C++ class o2::hmpid::Param + ;
+#pragma link C++ class o2::hmpid::Digit + ;
+#pragma link C++ class vector < o2::hmpid::Digit> + ;
 
 #endif

--- a/Detectors/HMPID/simulation/CMakeLists.txt
+++ b/Detectors/HMPID/simulation/CMakeLists.txt
@@ -4,9 +4,11 @@ O2_SETUP(NAME ${MODULE_NAME})
 
 set(SRCS
     src/Detector.cxx
+    src/HMPIDDigitizer.cxx
     )
 set(HEADERS
     include/${MODULE_NAME}/Detector.h
+    include/${MODULE_NAME}/HMPIDDigitizer.h
     )
 
 Set(LINKDEF src/HMPIDSimulationLinkDef.h)

--- a/Detectors/HMPID/simulation/include/HMPIDSimulation/Detector.h
+++ b/Detectors/HMPID/simulation/include/HMPIDSimulation/Detector.h
@@ -13,7 +13,7 @@
 
 #include <vector>
 #include "DetectorsBase/Detector.h"
-#include "SimulationDataFormat/BaseHits.h"
+#include "HMPIDBase/Hit.h"
 
 class TGeoVolume;
 class TGeoHMatrix;
@@ -22,10 +22,6 @@ namespace o2
 {
 namespace hmpid
 {
-
-// define HMPID hit type
-using HitType = o2::BasicXYZEHit<float>;
-
 class Detector : public o2::Base::DetImpl<Detector>
 {
  public:

--- a/Detectors/HMPID/simulation/include/HMPIDSimulation/HMPIDDigitizer.h
+++ b/Detectors/HMPID/simulation/include/HMPIDSimulation/HMPIDDigitizer.h
@@ -1,0 +1,49 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef DETECTORS_HMPID_SIMULATION_INCLUDE_HMPIDSIMULATION_HMPIDDIGITIZER_H_
+#define DETECTORS_HMPID_SIMULATION_INCLUDE_HMPIDSIMULATION_HMPIDDIGITIZER_H_
+
+#include "HMPIDBase/Digit.h"
+#include "HMPIDSimulation/Detector.h" // for the hit
+#include <vector>
+
+namespace o2
+{
+namespace hmpid
+{
+
+class HMPIDDigitizer
+{
+ public:
+  void setEventTime(double timeNS) { mTime = timeNS; }
+  void setEventID(int eventID) { mEventID = eventID; }
+  void setSrcID(int sID) { mSrcID = sID; }
+
+  // this will process hits and fill the digit vector with digits which are finalized
+  void process(std::vector<o2::hmpid::HitType> const&, std::vector<o2::hmpid::Digit>& digit);
+
+ private:
+  double mTime = 0.;
+  int mEventID = 0;
+  int mSrcID = 0;
+
+  // internal buffers for digits
+  std::vector<o2::hmpid::Digit> mSummable;
+  std::vector<o2::hmpid::Digit> mFinal;
+
+  // other stuff needed for digitizaton
+
+  ClassDefNV(HMPIDDigitizer, 1);
+};
+} // namespace hmpid
+} // namespace o2
+
+#endif /* DETECTORS_HMPID_SIMULATION_INCLUDE_HMPIDSIMULATION_HMPIDDIGITIZER_H_ */

--- a/Detectors/HMPID/simulation/src/HMPIDDigitizer.cxx
+++ b/Detectors/HMPID/simulation/src/HMPIDDigitizer.cxx
@@ -1,0 +1,27 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "HMPIDSimulation/HMPIDDigitizer.h"
+#include "HMPIDBase/Digit.h"
+
+using namespace o2::hmpid;
+
+ClassImp(HMPIDDigitizer);
+
+// this will process hits and fill the digit vector with digits which are finalized
+void HMPIDDigitizer::process(std::vector<o2::hmpid::HitType> const& hits, std::vector<o2::hmpid::Digit>& digits)
+{
+  // this is a very simple variant that creates one digit from one hit
+  // conversion is done in the digit constructor
+  // TODO: introduce cross-talk, pile-up, etc.
+  for (auto& hit : hits) {
+    digits.emplace_back(hit);
+  }
+}

--- a/Steer/DigitizerWorkflow/CMakeLists.txt
+++ b/Steer/DigitizerWorkflow/CMakeLists.txt
@@ -36,6 +36,8 @@ O2_GENERATE_EXECUTABLE(
   src/FITDigitWriterSpec.cxx
   src/EMCALDigitizerSpec.cxx
   src/EMCALDigitWriterSpec.cxx
+  src/HMPIDDigitizerSpec.cxx
+  src/HMPIDDigitWriterSpec.cxx
   src/GRPUpdaterSpec.cxx
 
   BUCKET_NAME ${MODULE_BUCKET_NAME}

--- a/Steer/DigitizerWorkflow/src/HMPIDDigitWriterSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/HMPIDDigitWriterSpec.cxx
@@ -1,0 +1,73 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "HMPIDDigitWriterSpec.h"
+#include "Framework/ControlService.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/DataRefUtils.h"
+#include "Framework/Lifetime.h"
+#include "Framework/Task.h"
+#include "HMPIDBase/Digit.h"
+
+using namespace o2::framework;
+using SubSpecificationType = o2::framework::DataAllocator::SubSpecificationType;
+
+namespace o2
+{
+namespace hmpid
+{
+
+class HMPIDDPLDigitWriterTask
+{
+ public:
+  void init(framework::InitContext& ic)
+  {
+    LOG(INFO) << "initializing HMPID digit writer";
+  }
+
+  void run(framework::ProcessingContext& pc)
+  {
+    static bool finished = false;
+    if (finished) {
+      return;
+    }
+
+    LOG(INFO) << "Doing HMPID digit IO";
+    auto digits = pc.inputs().get<std::vector<o2::hmpid::Digit>*>("hmpiddigits");
+    LOG(INFO) << "HMPID received " << digits->size() << " digits";
+    for (auto& digit : *digits) {
+      LOG(INFO) << "Have digit with charge " << digit.getCharge();
+    }
+
+    // we should be only called once; tell DPL that this process is ready to exit
+    pc.services().get<ControlService>().readyToQuit(false);
+    finished = true;
+  }
+};
+
+o2::framework::DataProcessorSpec getHMPIDDigitWriterSpec()
+{
+  // create the full data processor spec using
+  //  a name identifier
+  //  input description
+  //  algorithmic description (here a lambda getting called once to setup the actual processing function)
+  //  options that can be used for this processor (here: input file names where to take the hits)
+  return DataProcessorSpec{
+    "HMPIDDigitWriternn",
+    Inputs{ InputSpec{ "hmpiddigits", "HMP", "DIGITS", 0, Lifetime::Timeframe } },
+    {},
+    AlgorithmSpec{ adaptFromTask<HMPIDDPLDigitWriterTask>() },
+    Options{
+      { "digitFile", VariantType::String, "hmpiddigits.root", { "filename for HMPID digits" } } }
+  };
+}
+
+} // end namespace hmpid
+} // end namespace o2

--- a/Steer/DigitizerWorkflow/src/HMPIDDigitWriterSpec.h
+++ b/Steer/DigitizerWorkflow/src/HMPIDDigitWriterSpec.h
@@ -8,14 +8,19 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifdef __CLING__
+#ifndef STEER_DIGITIZERWORKFLOW_SRC_HMPIDDIGITWRITERSPEC_H_
+#define STEER_DIGITIZERWORKFLOW_SRC_HMPIDDIGITWRITERSPEC_H_
 
-#pragma link off all globals;
-#pragma link off all classes;
-#pragma link off all functions;
+#include "Framework/DataProcessorSpec.h"
 
-#pragma link C++ class o2::hmpid::Detector+;
-#pragma link C++ class o2::Base::DetImpl<o2::hmpid::Detector>+;
-#pragma link C++ class o2::hmpid::HMPIDDigitizer + ;
+namespace o2
+{
+namespace hmpid
+{
 
-#endif
+o2::framework::DataProcessorSpec getHMPIDDigitWriterSpec();
+
+} // end namespace hmpid
+} // end namespace o2
+
+#endif /* STEER_DIGITIZERWORKFLOW_SRC_HMPIDDIGITWRITERSPEC_H_ */

--- a/Steer/DigitizerWorkflow/src/HMPIDDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/HMPIDDigitizerSpec.cxx
@@ -1,0 +1,163 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "HMPIDDigitizerSpec.h"
+#include "Framework/ControlService.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/DataRefUtils.h"
+#include "Framework/Lifetime.h"
+#include "Headers/DataHeader.h"
+#include "TStopwatch.h"
+#include "Steer/HitProcessingManager.h" // for RunContext
+#include "TChain.h"
+#include <SimulationDataFormat/MCCompLabel.h>
+#include <SimulationDataFormat/MCTruthContainer.h>
+#include "Framework/Task.h"
+#include "DataFormatsParameters/GRPObject.h"
+#include "HMPIDBase/Digit.h"
+#include "HMPIDSimulation/HMPIDDigitizer.h"
+#include "HMPIDSimulation/Detector.h"
+#include "DetectorsBase/GeometryManager.h"
+
+using namespace o2::framework;
+using SubSpecificationType = o2::framework::DataAllocator::SubSpecificationType;
+
+// helper function which will be offered as a service
+template <typename T>
+void retrieveHits(std::vector<TChain*> const& chains,
+                  const char* brname,
+                  int sourceID,
+                  int entryID,
+                  std::vector<T>* hits)
+{
+  auto br = chains[sourceID]->GetBranch(brname);
+  if (!br) {
+    LOG(ERROR) << "No branch found";
+    return;
+  }
+  br->SetAddress(&hits);
+  br->GetEntry(entryID);
+}
+
+namespace o2
+{
+namespace hmpid
+{
+
+class HMPIDDPLDigitizerTask
+{
+ public:
+  void init(framework::InitContext& ic)
+  {
+    LOG(INFO) << "initializing HMPID digitization";
+    // setup the input chain for the hits
+    mSimChains.emplace_back(new TChain("o2sim"));
+
+    // add the main (background) file
+    mSimChains.back()->AddFile(ic.options().get<std::string>("simFile").c_str());
+
+    // maybe add a particular signal file
+    auto signalfilename = ic.options().get<std::string>("simFileS");
+    if (signalfilename.size() > 0) {
+      mSimChains.emplace_back(new TChain("o2sim"));
+      mSimChains.back()->AddFile(signalfilename.c_str());
+    }
+
+    if (!gGeoManager) {
+      o2::Base::GeometryManager::loadGeometry();
+    }
+  }
+
+  void run(framework::ProcessingContext& pc)
+  {
+    static bool finished = false;
+    if (finished) {
+      return;
+    }
+    LOG(INFO) << "Doing HMPID digitization";
+
+    // read collision context from input
+    auto context = pc.inputs().get<o2::steer::RunContext*>("collisioncontext");
+    auto& irecords = context->getEventRecords();
+
+    for (auto& record : irecords) {
+      LOG(INFO) << "HMPID TIME RECEIVED " << record.timeNS;
+    }
+
+    auto& eventParts = context->getEventParts();
+    std::vector<o2::hmpid::Digit> digitsAccum; // accumulator for digits
+
+    // loop over all composite collisions given from context
+    // (aka loop over all the interaction records)
+    for (int collID = 0; collID < irecords.size(); ++collID) {
+      mDigitizer.setEventTime(irecords[collID].timeNS);
+
+      // for each collision, loop over the constituents event and source IDs
+      // (background signal merging is basically taking place here)
+      for (auto& part : eventParts[collID]) {
+        mDigitizer.setEventID(part.entryID);
+        mDigitizer.setSrcID(part.sourceID);
+
+        // get the hits for this event and this source
+        std::vector<o2::hmpid::HitType> hits;
+        retrieveHits(mSimChains, "HMPHit", part.sourceID, part.entryID, &hits);
+        LOG(INFO) << "For collision " << collID << " eventID " << part.entryID << " found HMP " << hits.size() << " hits ";
+
+        std::vector<o2::hmpid::Digit> digits; // digits which get filled
+
+        mDigitizer.process(hits, digits);
+        LOG(INFO) << "HMPID obtained " << digits.size() << " digits ";
+        for (auto& d : digits) {
+          LOG(INFO) << "CHARGE " << d.getCharge();
+          LOG(INFO) << "PAD " << d.getPadID();
+        }
+        std::copy(digits.begin(), digits.end(), std::back_inserter(digitsAccum));
+      }
+    }
+    pc.outputs().snapshot(Output{ "HMP", "DIGITS", 0, Lifetime::Timeframe }, digitsAccum);
+
+    LOG(INFO) << "HMP: Sending ROMode= " << mROMode << " to GRPUpdater";
+    pc.outputs().snapshot(Output{ "HMP", "ROMode", 0, Lifetime::Timeframe }, mROMode);
+
+    // we should be only called once; tell DPL that this process is ready to exit
+    pc.services().get<ControlService>().readyToQuit(false);
+    finished = true;
+  }
+
+ private:
+  HMPIDDigitizer mDigitizer;
+  std::vector<TChain*> mSimChains;
+  // RS: at the moment using hardcoded flag for continuos readout
+  o2::parameters::GRPObject::ROMode mROMode = o2::parameters::GRPObject::CONTINUOUS; // readout mode
+};
+
+o2::framework::DataProcessorSpec getHMPIDDigitizerSpec(int channel)
+{
+  // create the full data processor spec using
+  //  a name identifier
+  //  input description
+  //  algorithmic description (here a lambda getting called once to setup the actual processing function)
+  //  options that can be used for this processor (here: input file names where to take the hits)
+  return DataProcessorSpec{
+    "HMPIDDigitizer",
+    Inputs{ InputSpec{ "collisioncontext", "SIM", "COLLISIONCONTEXT", static_cast<SubSpecificationType>(channel), Lifetime::Timeframe } },
+
+    Outputs{ OutputSpec{ "HMP", "DIGITS", 0, Lifetime::Timeframe },
+             OutputSpec{ "HMP", "ROMode", 0, Lifetime::Timeframe } },
+
+    AlgorithmSpec{ adaptFromTask<HMPIDDPLDigitizerTask>() },
+
+    Options{ { "simFile", VariantType::String, "o2sim.root", { "Sim (background) input filename" } },
+             { "simFileS", VariantType::String, "", { "Sim (signal) input filename" } } }
+  };
+}
+
+} // end namespace hmpid
+} // end namespace o2

--- a/Steer/DigitizerWorkflow/src/HMPIDDigitizerSpec.h
+++ b/Steer/DigitizerWorkflow/src/HMPIDDigitizerSpec.h
@@ -8,14 +8,19 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifdef __CLING__
+#ifndef STEER_DIGITIZERWORKFLOW_SRC_HMPIDDIGITIZERSPEC_H_
+#define STEER_DIGITIZERWORKFLOW_SRC_HMPIDDIGITIZERSPEC_H_
 
-#pragma link off all globals;
-#pragma link off all classes;
-#pragma link off all functions;
+#include "Framework/DataProcessorSpec.h"
 
-#pragma link C++ class o2::hmpid::Detector+;
-#pragma link C++ class o2::Base::DetImpl<o2::hmpid::Detector>+;
-#pragma link C++ class o2::hmpid::HMPIDDigitizer + ;
+namespace o2
+{
+namespace hmpid
+{
 
-#endif
+o2::framework::DataProcessorSpec getHMPIDDigitizerSpec(int channel);
+
+} // end namespace hmpid
+} // end namespace o2
+
+#endif /* STEER_DIGITIZERWORKFLOW_SRC_HMPIDDIGITIZERSPEC_H_ */

--- a/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
+++ b/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
@@ -44,6 +44,10 @@
 #include "EMCALDigitizerSpec.h"
 #include "EMCALDigitWriterSpec.h"
 
+// for HMPID
+#include "HMPIDDigitizerSpec.h"
+#include "HMPIDDigitWriterSpec.h"
+
 // GRP
 #include "DataFormatsParameters/GRPObject.h"
 #include "GRPUpdaterSpec.h"
@@ -324,6 +328,15 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     specs.emplace_back(o2::emcal::getEMCALDigitizerSpec(fanoutsize++));
     // connect the EMCal digit writer
     specs.emplace_back(o2::emcal::getEMCALDigitWriterSpec());
+  }
+
+  // add HMPID
+  if (isEnabled(o2::detectors::DetID::HMP)) {
+    detList.emplace_back(o2::detectors::DetID::HMP);
+    // connect the HMP digitization
+    specs.emplace_back(o2::hmpid::getHMPIDDigitizerSpec(fanoutsize++));
+    // connect the HMP digit writer
+    specs.emplace_back(o2::hmpid::getHMPIDDigitWriterSpec());
   }
 
   // GRP updater: must come after all detectors since requires their list

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -1883,6 +1883,8 @@ o2_define_bucket(
     TOFReconstruction
     FITSimulation
     EMCALSimulation
+    HMPIDBase
+    HMPIDSimulation
 )
 
 o2_define_bucket(


### PR DESCRIPTION
This commit provides a basic DPL digitizer workflow
for HMPID.

It achieves:
  - rudimentary digits and first conversion from hits
  - a Digitizer class
  - DPL components for digitization

With this, everything is there to have the workflow running.

The following steps need to be done next:
  - correct hit -> digits conversion
  - consider cross talk (hit influencing multiple pads)
  - implement digit pileup + zero suppression
  - finish IO of digits
  - add treatment of MC labels

This commit relates to https://alice.its.cern.ch/jira/browse/O2-384

Authors: @gvolpe79, @sawenzel