### PR TITLE
Remove Pause state handler

### DIFF
--- a/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/EventSampler.h
+++ b/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/EventSampler.h
@@ -77,8 +77,6 @@ public:
   void InitTask() override;
   /// inherited from FairMQDevice
   void Run() override;
-  /// inherited from FairMQDevice
-  void Pause() override;
 
   /// sampler loop started in a separate thread
   void samplerLoop();

--- a/Utilities/aliceHLTwrapper/src/EventSampler.cxx
+++ b/Utilities/aliceHLTwrapper/src/EventSampler.cxx
@@ -204,14 +204,6 @@ void EventSampler::Run()
   samplerThread.join();
 }
 
-void EventSampler::Pause()
-{
-  /// inherited from FairMQDevice
-
-  // nothing to do
-  FairMQDevice::Pause();
-}
-
 void EventSampler::samplerLoop()
 {
   /// sampler loop


### PR DESCRIPTION
The FairMQ PAUSED state offers little/no advantage over going from RUN to READY (and back to RUN to unpause). Thus it will be removed and its handler (`FairMQDevice::Pause`) deprecated.

This commit removes the overridden but unused Pause handler from the EventSampler device.