### PR TITLE
Bugfix tpc reco workflow: clear the output containers for the TPC HwClusterer consistently

### DIFF
--- a/Detectors/TPC/workflow/src/ClusterConverterSpec.cxx
+++ b/Detectors/TPC/workflow/src/ClusterConverterSpec.cxx
@@ -88,15 +88,17 @@ DataProcessorSpec getClusterConverterSpec(bool sendMC, int fanNumber)
       // this will return a span of TPC clusters
       auto inClusters = pc.inputs().get<std::vector<o2::TPC::Cluster>>("clusterin");
       int nClusters = inClusters.size();
-      LOG(INFO) << "got clusters from input: " << nClusters;
 
       // MC labels are received as one container of labels in the sequence matching clusters
       // in the input
       std::unique_ptr<const MCLabelContainer> mcin;
       MCLabelContainer mcout;
+      std::string mcMesssage;
       if (sendMC) {
         mcin = std::move(pc.inputs().get<MCLabelContainer*>("mclblin"));
+        mcMesssage = ", " + std::to_string(mcin->getIndexedSize()) + " MC label objects";
       }
+      LOG(INFO) << "got " << nClusters << " cluster(s) from input" << mcMesssage;
 
       // clusters need to be sorted to write clusters of one CRU to raw pages
       struct ClusterMapper {


### PR DESCRIPTION
Have to clear the output containers inside the process method as not only the
containers are cleared but also the cluster counter. Clearing the containers
externally leaves the cluster counter unchanged and leads to an inconsistency
between cluster container and MC label container (the latter just grows with
every call). This is probably a bug of the TPC HwClusterer.

Also implementing:
- some minor changes on the logging output.
- boundary check for MC label object processing in the decoder