### PR TITLE
[O2-379] Using run2/3 geometry in digitizer workflow

### DIFF
--- a/Steer/DigitizerWorkflow/src/EMCALDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/EMCALDigitizerSpec.cxx
@@ -154,7 +154,9 @@ DataProcessorSpec getEMCALDigitizerSpec(int channel)
     if (!gGeoManager) {
       o2::Base::GeometryManager::loadGeometry();
     }
-    auto geom = o2::EMCAL::Geometry::GetInstance("EMCAL_COMPLETE", "Geant4", "EMV-EMCAL");
+    // run 3 geometry == run 2 geometry for EMCAL
+    // to be adapted with run numbers at a later stage
+    auto geom = o2::EMCAL::Geometry::GetInstance("EMCAL_COMPLETE12SMV1_DCAL_8SM", "Geant4", "EMV-EMCAL");
     // init digitizer
     digitizer->setGeometry(geom);
     digitizer->init();


### PR DESCRIPTION
The digitizer workflow was using by mistake the run1
geometry with 10 supermodules (without DCAL) while
the simulation was using the run2/3 geometry. For
the moment it is hard coded - to be changed when
it is clear how to dynamically handle this according
to the run numbers.