### PR TITLE
Catch EMCAL exception

### DIFF
--- a/Steer/DigitizerWorkflow/src/EMCALDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/EMCALDigitizerSpec.cxx
@@ -112,7 +112,13 @@ DataProcessorSpec getEMCALDigitizerSpec(int channel)
         // call actual digitization procedure
         labels->clear();
         digits->clear();
-        digitizer->process(hits, *digits.get());
+        try {
+          digitizer->process(hits, *digits.get());
+        } catch (o2::EMCAL::InvalidPositionException e) {
+          LOG(WARN) << "Exception occurred in EMC digitizer ... ignoring ";
+          LOG(WARN) << "Exception information: " << e.what();
+        }
+
         // copy digits into accumulator
         std::copy(digits->begin(), digits->end(), std::back_inserter(*digitsAccum.get()));
         labelAccum.mergeAtBack(*labels);


### PR DESCRIPTION
We catch a EMCAL exception (known problem), so that
the digitizer workflow does not hang and exits gracefully.

This is related to https://alice.its.cern.ch/jira/projects/O2/issues/O2-447.