### PR TITLE
Adding vectors with EMCAL Hit/Digit to the linkdef

### DIFF
--- a/Detectors/EMCAL/base/src/EMCALBaseLinkDef.h
+++ b/Detectors/EMCAL/base/src/EMCALBaseLinkDef.h
@@ -18,4 +18,7 @@
 #pragma link C++ class o2::EMCAL::Hit+;
 #pragma link C++ class o2::EMCAL::Geometry+;
 
+#pragma link C++ class std::vector < o2::EMCAL::Hit > +;
+#pragma link C++ class std::vector < o2::EMCAL::Digit > +;
+
 #endif


### PR DESCRIPTION
This is needed in order to read the containers from the
simtree (i.e. in macros)