### PR TITLE
DPL extension: adding helpers to duplicate sequence of processors and list of inputs

### DIFF
--- a/Framework/Core/include/Framework/WorkflowSpec.h
+++ b/Framework/Core/include/Framework/WorkflowSpec.h
@@ -30,11 +30,26 @@ WorkflowSpec parallel(DataProcessorSpec original,
                       size_t maxIndex,
                       std::function<void(DataProcessorSpec&, size_t id)> amendCallback);
 
+/// The purpose of this helper is to duplicate a sequence of DataProcessorSpec
+/// as many times as specified in maxIndex and to amend each instance by invoking
+/// amendCallback on them with their own @a id.
+WorkflowSpec parallel(WorkflowSpec specs,
+                      size_t maxIndex,
+                      std::function<void(DataProcessorSpec&, size_t id)> amendCallback);
+
 /// The purpose of this helper is to duplicate an InputSpec @a original
 /// as many times as specified in maxIndex and to amend each instance
 /// by invoking amendCallback on them with their own @a id. This can be
 /// used to programmatically create mergers.
 Inputs mergeInputs(InputSpec original,
+                   size_t maxIndex,
+                   std::function<void(InputSpec&, size_t)> amendCallback);
+
+/// The purpose of this helper is to duplicate a list of InputSpec
+/// as many times as specified in maxIndex and to amend each instance
+/// by invoking amendCallback on them with their own @a id. This can be
+/// used to programmatically create mergers.
+Inputs mergeInputs(Inputs inputs,
                    size_t maxIndex,
                    std::function<void(InputSpec&, size_t)> amendCallback);
 

--- a/Framework/Core/src/WorkflowSpec.cxx
+++ b/Framework/Core/src/WorkflowSpec.cxx
@@ -22,6 +22,7 @@ WorkflowSpec parallel(DataProcessorSpec original,
                       size_t maxIndex,
                       std::function<void(DataProcessorSpec&, size_t)> amendCallback) {
   WorkflowSpec results;
+  results.reserve(maxIndex);
   for (size_t i = 0; i < maxIndex; ++i) {
     results.push_back(original);
     results.back().name = original.name + "_" + std::to_string(i);
@@ -32,10 +33,25 @@ WorkflowSpec parallel(DataProcessorSpec original,
   return results;
 }
 
+WorkflowSpec parallel(WorkflowSpec specs,
+                      size_t maxIndex,
+                      std::function<void(DataProcessorSpec&, size_t)> amendCallback)
+{
+  WorkflowSpec results;
+  results.reserve(specs.size() * maxIndex);
+  for (auto& spec : specs) {
+    auto result = parallel(spec, maxIndex, amendCallback);
+    results.insert(results.end(), result.begin(), result.end());
+  }
+
+  return results;
+}
+
 Inputs mergeInputs(InputSpec original,
                    size_t maxIndex,
                    std::function<void(InputSpec &, size_t)> amendCallback) {
   Inputs results;
+  results.reserve(maxIndex);
   for (size_t i = 0; i < maxIndex; ++i) {
     results.push_back(original);
     amendCallback(results.back(), i);
@@ -43,6 +59,20 @@ Inputs mergeInputs(InputSpec original,
   return results;
 }
 
+Inputs mergeInputs(Inputs inputs,
+                   size_t maxIndex,
+                   std::function<void(InputSpec&, size_t)> amendCallback)
+{
+  Inputs results;
+  results.reserve(inputs.size() * maxIndex);
+  for (size_t i = 0; i < maxIndex; ++i) {
+    for (auto const& original : inputs) {
+      results.push_back(original);
+      amendCallback(results.back(), i);
+    }
+  }
+  return results;
+}
 
 DataProcessorSpec timePipeline(DataProcessorSpec original,
                           size_t count) {


### PR DESCRIPTION
This simplifies the definition of data flow parallelism
- `parallel`-helper: adding variant for a sequence of processors all amended in the
  same way
- `mergeInputs`-helper: adding variant working on a list of inputs