### PR TITLE
Update of TRD Geometry

### DIFF
--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/DetMatrixCache.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/DetMatrixCache.h
@@ -126,7 +126,7 @@ class DetMatrixCacheIndirect : private DetMatrixCache
  public:
   typedef o2::Transform3D Mat3D;
   typedef o2::Rotation2D Rot2D;
-     
+
   DetMatrixCacheIndirect() = default;
   DetMatrixCacheIndirect(const o2::detectors::DetID& id) : DetMatrixCache(id) {}
   virtual ~DetMatrixCacheIndirect() override = default;
@@ -138,13 +138,13 @@ class DetMatrixCacheIndirect : private DetMatrixCache
   const Mat3D& getMatrixT2G(int sensID) const { return mT2G.getMatrix(mIndirection[sensID]); }
   const Mat3D& getMatrixL2G(int sensID) const { return mL2G.getMatrix(mIndirection[sensID]); }
   const Rot2D& getMatrixT2GRot(int sensID) const { return mT2GRot.getMatrix(mIndirection[sensID]); }
-  
+
   bool isBuilt() const { return DetMatrixCache::isBuilt(); }
   int getSize() const { return DetMatrixCache::getSize(); }
   int getIndirectSize() const { return mIndirectSize; }
   bool isMatrixAvailable(int sensID) const { return mIndirection[sensID] >= 0; }
 
-protected:
+ protected:
   // before calling fillMatrixCache, detector implementation should set the size of the matrix cache
   void setSize(int s) = delete;
   void setSize(int size, int sizeIndirect);
@@ -164,10 +164,12 @@ protected:
     if (sensID >= mIndirectSize) {
       LOG(FATAL) << "SendID " << sensID << " exceeds indirect cache size of " << mIndirectSize;
     }
-    if (mIndirection[sensID] >= 0) return mIndirection[sensID];
+    if (mIndirection[sensID] >= 0) {
+      return mIndirection[sensID];
+    }
     return (mIndirection[sensID] = mNextEntry++);
   }
-    
+
   int mIndirectSize = 0;           ///< prebooked number of indirect sensors
   int mNextEntry = 0;              ///< next free entry in actual cache
   std::vector<short> mIndirection; ///< indirection table

--- a/DataFormats/Detectors/Common/src/DetMatrixCache.cxx
+++ b/DataFormats/Detectors/Common/src/DetMatrixCache.cxx
@@ -35,8 +35,7 @@ void DetMatrixCacheIndirect::setSize(int size, int sizeIndirect)
   if (mSize != 0 || mIndirectSize != 0) {
     LOG(FATAL) << "Cache size (N sensors) was already set to " << mSize << " / " << mIndirectSize;
   }
-  if (mIndirectSize >= 32768)
-  {
+  if (mIndirectSize >= 32768) {
     LOG(FATAL) << "Indirect cache size exceeds maximum size of 32768 (signed short)\n";
   }
   DetMatrixCache::setSize(size);

--- a/DataFormats/Detectors/Common/src/DetMatrixCache.cxx
+++ b/DataFormats/Detectors/Common/src/DetMatrixCache.cxx
@@ -24,7 +24,21 @@ void DetMatrixCache::setSize(int s)
 {
   // set the size of the matrix cache, can be done only once
   if (mSize != 0) {
-    LOG(FATAL) << "Cache size (N sensors) was already set to " << mSize << FairLogger::endl;
+    LOG(FATAL) << "Cache size (N sensors) was already set to " << mSize;
   }
   mSize = s;
+}
+
+void DetMatrixCacheIndirect::setSize(int size, int sizeIndirect)
+{
+  // set the size of the matrix cache, can be done only once
+  if (mSize != 0 || mIndirectSize != 0) {
+    LOG(FATAL) << "Cache size (N sensors) was already set to " << mSize << " / " << mIndirectSize;
+  }
+  if (mIndirectSize >= 32768)
+  {
+    LOG(FATAL) << "Indirect cache size exceeds maximum size of 32768 (signed short)\n";
+  }
+  DetMatrixCache::setSize(size);
+  mIndirection.resize(mIndirectSize = sizeIndirect, -1);
 }

--- a/DataFormats/Detectors/Common/src/DetectorsCommonDataFormatsLinkDef.h
+++ b/DataFormats/Detectors/Common/src/DetectorsCommonDataFormatsLinkDef.h
@@ -19,5 +19,6 @@
 #pragma link C++ class o2::detectors::MatrixCache < o2::Transform3D > +;
 #pragma link C++ class o2::detectors::MatrixCache < o2::Rotation2D > +;
 #pragma link C++ class o2::detectors::DetMatrixCache + ;
+#pragma link C++ class o2::detectors::DetMatrixCacheIndirect + ;
 
 #endif

--- a/Detectors/TRD/base/CMakeLists.txt
+++ b/Detectors/TRD/base/CMakeLists.txt
@@ -4,6 +4,7 @@ O2_SETUP(NAME ${MODULE_NAME})
 
 SET(SRCS
   src/TRDPadPlane.cxx
+  src/TRDGeometryBase.cxx
   src/TRDGeometry.cxx
   src/TRDCommonParam.cxx
   src/TRDSimParam.cxx
@@ -11,6 +12,7 @@ SET(SRCS
 
 SET(HEADERS
   include/${MODULE_NAME}/TRDPadPlane.h
+  include/${MODULE_NAME}/TRDGeometryBase.h
   include/${MODULE_NAME}/TRDGeometry.h
   include/${MODULE_NAME}/TRDSimParam.h
   include/${MODULE_NAME}/TRDCommonParam.h

--- a/Detectors/TRD/base/include/TRDBase/TRDCommonParam.h
+++ b/Detectors/TRD/base/include/TRDBase/TRDCommonParam.h
@@ -13,17 +13,17 @@
 
 #include "TRDBase/TRDSimParam.h"
 
-class TRDPadPlane;
-
 namespace o2
 {
 namespace trd
 {
+
+class TRDPadPlane;
+constexpr int kNlayer = 6, kNstack = 5, kNsector = 18, kNdet = 540;
+
 class TRDCommonParam
 {
  public:
-  enum { kNlayer = 6, kNstack = 5, kNsector = 18, kNdet = 540 };
-
   enum { kXenon = 0, kArgon = 1 };
 
   TRDCommonParam(const TRDCommonParam& p);

--- a/Detectors/TRD/base/include/TRDBase/TRDGeometry.h
+++ b/Detectors/TRD/base/include/TRDBase/TRDGeometry.h
@@ -12,6 +12,7 @@
 #define O2_TRDGEOMETRY_H
 
 #include "TRDBase/TRDGeometryBase.h"
+#include "DetectorsCommonDataFormats/DetMatrixCache.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 
 #include <string>
@@ -20,13 +21,15 @@
 
 class TGeoHMatrix;
 
+using namespace o2::trd;
+
 namespace o2
 {
 namespace trd
 {
 class TRDPadPlane;
 
-class TRDGeometry : public TRDGeometryBase
+class TRDGeometry : public TRDGeometryBase, public o2::detectors::DetMatrixCacheIndirect
 {
  public:
   TRDGeometry();
@@ -40,10 +43,15 @@ class TRDGeometry : public TRDGeometryBase
   void CreateFrame(std::vector<int> const& idtmed);
   void CreateServices(std::vector<int> const& idtmed);
   bool RotateBack(int det, const double* const loc, double* glb) const;
+  
+  bool ChamberInGeometry(int det);
+  const Mat3D* GetClusterMatrix(int det);
 
   std::vector<std::string> const& getSensitiveTRDVolumes() const { return mSensitiveVolumeNames; }
 
  protected:
+  virtual void fillMatrixCache(int mask) override;
+
   static TObjArray* fgClusterMatrixArray; //! Transformation matrices loc. cluster to tracking cs
   static std::unique_ptr<TRDPadPlane[]> fgPadPlaneArray;
 
@@ -54,7 +62,7 @@ class TRDGeometry : public TRDGeometryBase
   // helper function to create volumes and registering them automatically
   void createVolume(const char* name, const char* shape, int nmed, float* upar, int np);
 
-  ClassDefNV(TRDGeometry, 1) //  TRD geometry class
+  ClassDefOverride(TRDGeometry, 1) //  TRD geometry class
 };
 } // end namespace trd
 } // end namespace o2

--- a/Detectors/TRD/base/include/TRDBase/TRDGeometry.h
+++ b/Detectors/TRD/base/include/TRDBase/TRDGeometry.h
@@ -19,31 +19,24 @@
 #include <vector>
 #include <memory>
 
-class TGeoHMatrix;
-
 using namespace o2::trd;
 
 namespace o2
 {
 namespace trd
 {
-class TRDPadPlane;
 
 class TRDGeometry : public TRDGeometryBase, public o2::detectors::DetMatrixCacheIndirect
 {
  public:
   TRDGeometry();
-  ~TRDGeometry();
+  virtual ~TRDGeometry() override = default;
 
   void CreateGeometry(std::vector<int> const& idtmed);
-  void CreateVolumes(std::vector<int> const& idtmed);
-  static void CreatePadPlaneArray();
-  static void CreatePadPlane(int ilayer, int istack, TRDPadPlane& plane);
-  void AssembleChamber(int ilayer, int istack);
-  void CreateFrame(std::vector<int> const& idtmed);
-  void CreateServices(std::vector<int> const& idtmed);
+  void addAlignableVolumes() const;
+  bool createClusterMatrixArray();
+
   bool RotateBack(int det, const double* const loc, double* glb) const;
-  
   bool ChamberInGeometry(int det);
   const Mat3D* GetClusterMatrix(int det);
 
@@ -52,10 +45,16 @@ class TRDGeometry : public TRDGeometryBase, public o2::detectors::DetMatrixCache
  protected:
   virtual void fillMatrixCache(int mask) override;
 
-  static TObjArray* fgClusterMatrixArray; //! Transformation matrices loc. cluster to tracking cs
   static std::unique_ptr<TRDPadPlane[]> fgPadPlaneArray;
 
  private:
+  void CreateVolumes(std::vector<int> const& idtmed);
+  void AssembleChamber(int ilayer, int istack);
+  void CreateFrame(std::vector<int> const& idtmed);
+  void CreateServices(std::vector<int> const& idtmed);
+  static void CreatePadPlaneArray();
+  static void CreatePadPlane(int ilayer, int istack);
+
   std::vector<std::string> mSensitiveVolumeNames; //!< vector keeping track of sensitive TRD volumes
   static const o2::detectors::DetID sDetID;
 

--- a/Detectors/TRD/base/include/TRDBase/TRDGeometry.h
+++ b/Detectors/TRD/base/include/TRDBase/TRDGeometry.h
@@ -11,8 +11,11 @@
 #ifndef O2_TRDGEOMETRY_H
 #define O2_TRDGEOMETRY_H
 
+#include "TRDBase/TRDGeometryBase.h"
+
 #include <string>
 #include <vector>
+#include <memory>
 
 class TGeoHMatrix;
 
@@ -22,184 +25,26 @@ namespace trd
 {
 class TRDPadPlane;
 
-class TRDGeometry
+class TRDGeometry : public TRDGeometryBase
 {
  public:
-  enum { kNlayer = 6, kNstack = 5, kNsector = 18, kNdet = 540, kNdets = 30 };
-
   TRDGeometry();
   ~TRDGeometry();
 
   void CreateGeometry(std::vector<int> const& idtmed);
-  int IsVersion() { return 1; }
-  bool IsHole(int la, int st, int se) const;
-  bool IsOnBoundary(int det, float y, float z, float eps = 0.5) const;
-  bool RotateBack(int det, const double* const loc, double* glb) const;
-
-  // bool           ChamberInGeometry(int det);
-
+  void CreateVolumes(std::vector<int> const& idtmed);
+  static void CreatePadPlaneArray();
+  static void CreatePadPlane(int ilayer, int istack, TRDPadPlane& plane);
   void AssembleChamber(int ilayer, int istack);
   void CreateFrame(std::vector<int> const& idtmed);
   void CreateServices(std::vector<int> const& idtmed);
+  bool RotateBack(int det, const double* const loc, double* glb) const;
 
-  //  static  bool           CreateClusterMatrixArray();
-  // static  TGeoHMatrix     *GetClusterMatrix(int det);
-
-  void SetSMstatus(int sm, char status) { fgSMstatus[sm] = status; }
-  static int GetDetectorSec(int layer, int stack);
-  static int GetDetector(int layer, int stack, int sector);
-  static int GetLayer(int det);
-  static int GetStack(int det);
-  int GetStack(double z, int layer);
-  static int GetSector(int det);
-
-  static void CreatePadPlaneArray();
-  static TRDPadPlane* CreatePadPlane(int layer, int stack);
-  static TRDPadPlane* GetPadPlane(int layer, int stack);
-  static TRDPadPlane* GetPadPlane(int det) { return GetPadPlane(GetLayer(det), GetStack(det)); }
-  static int GetRowMax(int layer, int stack, int /*sector*/);
-  static int GetColMax(int layer);
-  static double GetRow0(int layer, int stack, int /*sector*/);
-  static double GetCol0(int layer);
-
-  static float GetTime0(int layer) { return fgkTime0[layer]; }
-  static double GetXtrdBeg() { return fgkXtrdBeg; }
-  static double GetXtrdEnd() { return fgkXtrdEnd; }
-  char GetSMstatus(int sm) const { return fgSMstatus[sm]; }
-  static float GetChamberWidth(int layer) { return fgkCwidth[layer]; }
-  static float GetChamberLength(int layer, int stack) { return fgkClength[layer][stack]; }
-  static double GetAlpha() { return 2.0 * 3.14159265358979324 / fgkNsector; }
-  static int Nsector() { return fgkNsector; }
-  static int Nlayer() { return fgkNlayer; }
-  static int Nstack() { return fgkNstack; }
-  static int Ndet() { return fgkNdet; }
-  static float Cheight() { return fgkCH; }
-  static float CheightSV() { return fgkCHsv; }
-  static float Cspace() { return fgkVspace; }
-  static float CraHght() { return fgkCraH; }
-  static float CdrHght() { return fgkCdrH; }
-  static float CamHght() { return fgkCamH; }
-  static float CroHght() { return fgkCroH; }
-  static float CsvHght() { return fgkCsvH; }
-  static float CroWid() { return fgkCroW; }
-  static float AnodePos() { return fgkAnodePos; }
-  static float MyThick() { return fgkRMyThick; }
-  static float DrThick() { return fgkDrThick; }
-  static float AmThick() { return fgkAmThick; }
-  static float DrZpos() { return fgkDrZpos; }
-  static float RpadW() { return fgkRpadW; }
-  static float CpadW() { return fgkCpadW; }
-  static float Cwidcha() { return (fgkSwidth2 - fgkSwidth1) / fgkSheight * (fgkCH + fgkVspace); }
-  static int MCMmax() { return fgkMCMmax; }
-  static int MCMrow() { return fgkMCMrow; }
-  static int ROBmaxC0() { return fgkROBmaxC0; }
-  static int ROBmaxC1() { return fgkROBmaxC1; }
-  static int ADCmax() { return fgkADCmax; }
-  static int TBmax() { return fgkTBmax; }
-  static int Padmax() { return fgkPadmax; }
-  static int Colmax() { return fgkColmax; }
-  static int RowmaxC0() { return fgkRowmaxC0; }
-  static int RowmaxC1() { return fgkRowmaxC1; }
   std::vector<std::string> const& getSensitiveTRDVolumes() const { return mSensitiveVolumeNames; }
+
  protected:
-  static const int fgkNsector; //  Number of sectors in the full detector (18)
-  static const int fgkNlayer;  //  Number of layers of the TRD (6)
-  static const int fgkNstack;  //  Number of stacks in z-direction (5)
-  static const int fgkNdet;    //  Total number of detectors (18 * 6 * 5 = 540)
-
-  static const float fgkTlength; //  Length of the TRD-volume in spaceframe (BTRD)
-
-  static const float fgkSheight; //  Height of the supermodule
-  static const float fgkSwidth1; //  Lower width of the supermodule
-  static const float fgkSwidth2; //  Upper width of the supermodule
-  static const float fgkSlength; //  Length of the supermodule
-
-  static const float fgkFlength; //  Length of the service space in front of a supermodule
-
-  static const float fgkSMpltT; //  Thickness of the super module side plates
-
-  static const float fgkCraH; //  Height of the radiator part of the chambers
-  static const float fgkCdrH; //  Height of the drift region of the chambers
-  static const float fgkCamH; //  Height of the amplification region of the chambers
-  static const float fgkCroH; //  Height of the readout of the chambers
-  static const float fgkCsvH; //  Height of the services on top of the chambers
-  static const float fgkCH;   //  Total height of the chambers (w/o services)
-  static const float fgkCHsv; //  Total height of the chambers (with services)
-
-  static const float fgkAnodePos; //  Distance of anode wire plane relative to alignabl volume
-
-  static const float fgkVspace; //  Vertical spacing of the chambers
-  static const float fgkHspace; //  Horizontal spacing of the chambers
-  static const float fgkVrocsm; //  Radial distance of the first ROC to the outer SM plates
-
-  static const float fgkCalT;    //  Thickness of the lower aluminum frame
-  static const float fgkCalW;    //  Width of additional aluminum ledge on lower frame
-  static const float fgkCalH;    //  Height of additional aluminum ledge on lower frame
-  static const float fgkCalWmod; //  Width of additional aluminum ledge on lower frame
-  static const float fgkCalHmod; //  Height of additional aluminum ledge on lower frame
-  static const float fgkCwsW;    //  Width of additional wacosit ledge on lower frame
-  static const float fgkCwsH;    //  Height of additional wacosit ledge on lower frame
-  static const float fgkCclsT;   //  Thickness of the lower Wacosit frame sides
-  static const float fgkCclfT;   //  Thickness of the lower Wacosit frame front
-  static const float fgkCglT;    //  Thichness of the glue around the radiator
-  static const float fgkCcuTa;   //  Thickness of the upper Wacosit frame around amp. region
-  static const float fgkCcuTb;   //  Thickness of the upper Wacosit frame around amp. region
-  static const float fgkCauT;    //  Thickness of the aluminum frame of the back panel
-  static const float fgkCroW;    //  Additional width of the readout chamber frames
-
-  static const float fgkCpadW; //  Difference of outer chamber width and pad plane width
-  static const float fgkRpadW; //  Difference of outer chamber width and pad plane width
-
-  static const float fgkXeThick; //  Thickness of the gas volume
-  static const float fgkDrThick; //  Thickness of the drift region
-  static const float fgkAmThick; //  Thickness of the amplification region
-  static const float fgkWrThick; //  Thickness of the wire planes
-
-  static const float fgkPPdThick; //  Thickness of copper of the pad plane
-  static const float fgkPPpThick; //  Thickness of PCB board of the pad plane
-  static const float fgkPGlThick; //  Thickness of the glue layer
-  static const float fgkPCbThick; //  Thickness of the carbon layers
-  static const float fgkPHcThick; //  Thickness of the honeycomb support structure
-  static const float fgkPPcThick; //  Thickness of the PCB readout boards
-  static const float fgkPRbThick; //  Thickness of the PCB copper layers
-  static const float fgkPElThick; //  Thickness of all other electronics components (caps, etc.)
-
-  static const float fgkRFbThick; //  Thickness of the fiber layers in the radiator
-  static const float fgkRRhThick; //  Thickness of the rohacell layers in the radiator
-  static const float fgkRGlThick; //  Thickness of the glue layers in the radiator
-  static const float fgkRCbThick; //  Thickness of the carbon layers in the radiator
-  static const float fgkRMyThick; //  Thickness of the mylar layers in the radiator
-
-  static const float fgkDrZpos;  //  Position of the drift region
-  static const float fgkAmZpos;  //  Position of the amplification region
-  static const float fgkWrZposA; //  Position of the wire planes
-  static const float fgkWrZposB; //  Position of the wire planes
-  static const float fgkCalZpos; //  Position of the additional aluminum ledges
-
-  static const int fgkMCMmax;   //  Maximum number of MCMs per ROB
-  static const int fgkMCMrow;   //  Maximum number of MCMs per ROB Row
-  static const int fgkROBmaxC0; //  Maximum number of ROBs per C0 chamber
-  static const int fgkROBmaxC1; //  Maximum number of ROBs per C1 chamber
-  static const int fgkADCmax;   //  Maximum number of ADC channels per MCM
-  static const int fgkTBmax;    //  Maximum number of Time bins
-  static const int fgkPadmax;   //  Maximum number of pads per MCM
-  static const int fgkColmax;   //  Maximum number of pads per padplane row
-  static const int fgkRowmaxC0; //  Maximum number of Rows per C0 chamber
-  static const int fgkRowmaxC1; //  Maximum number of Rows per C1 chamber
-
-  static const float fgkCwidth[kNlayer];           //  Outer widths of the chambers
-  static const float fgkClength[kNlayer][kNstack]; //  Outer lengths of the chambers
-
-  static const double fgkTime0Base;     //  Base value for calculation of Time-position of pad 0
-  static const float fgkTime0[kNlayer]; //  Time-position of pad 0
-
-  static const double fgkXtrdBeg; //  X-coordinate in tracking system of begin of TRD mother volume
-  static const double fgkXtrdEnd; //  X-coordinate in tracking system of end of TRD mother volume
-
   static TObjArray* fgClusterMatrixArray; //! Transformation matrices loc. cluster to tracking cs
-  static std::vector<TRDPadPlane*>* fgPadPlaneArray;
-
-  static char fgSMstatus[kNsector]; //  Super module status byte
+  static std::unique_ptr<TRDPadPlane[]> fgPadPlaneArray;
 
  private:
   std::vector<std::string> mSensitiveVolumeNames; //!< vector keeping track of sensitive TRD volumes

--- a/Detectors/TRD/base/include/TRDBase/TRDGeometry.h
+++ b/Detectors/TRD/base/include/TRDBase/TRDGeometry.h
@@ -32,28 +32,28 @@ class TRDGeometry : public TRDGeometryBase, public o2::detectors::DetMatrixCache
   TRDGeometry();
   virtual ~TRDGeometry() override = default;
 
-  void CreateGeometry(std::vector<int> const& idtmed);
+  void createGeometry(std::vector<int> const& idtmed);
   void addAlignableVolumes() const;
   bool createClusterMatrixArray();
 
-  bool RotateBack(int det, const double* const loc, double* glb) const;
-  bool ChamberInGeometry(int det);
-  const Mat3D* GetClusterMatrix(int det);
+  bool rotateBack(int det, const float* const loc, float* glb) const;
+  bool chamberInGeometry(int det);
+  const Mat3D* getClusterMatrix(int det);
 
   std::vector<std::string> const& getSensitiveTRDVolumes() const { return mSensitiveVolumeNames; }
 
  protected:
   virtual void fillMatrixCache(int mask) override;
 
-  static std::unique_ptr<TRDPadPlane[]> fgPadPlaneArray;
+  std::unique_ptr<TRDPadPlane[]> fgPadPlaneArray;
 
  private:
-  void CreateVolumes(std::vector<int> const& idtmed);
-  void AssembleChamber(int ilayer, int istack);
-  void CreateFrame(std::vector<int> const& idtmed);
-  void CreateServices(std::vector<int> const& idtmed);
-  static void CreatePadPlaneArray();
-  static void CreatePadPlane(int ilayer, int istack);
+  void createVolumes(std::vector<int> const& idtmed);
+  void assembleChamber(int ilayer, int istack);
+  void createFrame(std::vector<int> const& idtmed);
+  void createServices(std::vector<int> const& idtmed);
+  void createPadPlaneArray();
+  void createPadPlane(int ilayer, int istack);
 
   std::vector<std::string> mSensitiveVolumeNames; //!< vector keeping track of sensitive TRD volumes
   static const o2::detectors::DetID sDetID;

--- a/Detectors/TRD/base/include/TRDBase/TRDGeometry.h
+++ b/Detectors/TRD/base/include/TRDBase/TRDGeometry.h
@@ -12,6 +12,7 @@
 #define O2_TRDGEOMETRY_H
 
 #include "TRDBase/TRDGeometryBase.h"
+#include "DetectorsCommonDataFormats/DetID.h"
 
 #include <string>
 #include <vector>
@@ -48,6 +49,7 @@ class TRDGeometry : public TRDGeometryBase
 
  private:
   std::vector<std::string> mSensitiveVolumeNames; //!< vector keeping track of sensitive TRD volumes
+  static const o2::detectors::DetID sDetID;
 
   // helper function to create volumes and registering them automatically
   void createVolume(const char* name, const char* shape, int nmed, float* upar, int np);

--- a/Detectors/TRD/base/include/TRDBase/TRDGeometryBase.h
+++ b/Detectors/TRD/base/include/TRDBase/TRDGeometryBase.h
@@ -22,11 +22,13 @@ class TRDPadPlane;
 class TRDGeometryBase
 {
  public:
-  int IsVersion() { return 1; }
-  bool IsHole(int la, int st, int se) const;
-  bool IsOnBoundary(int det, float y, float z, float eps = 0.5) const;
+  ~TRDGeometryBase() = default;
 
-  void SetSMstatus(int sm, bool status) {
+  int isVersion() { return 1; }
+  bool isHole(int la, int st, int se) const;
+  bool isOnBoundary(int det, float y, float z, float eps = 0.5) const;
+
+  void setSMstatus(int sm, bool status) {
     if (status) {
       mSMStatus |= 0x3ffff&(0x1<<sm);
     }
@@ -34,146 +36,168 @@ class TRDGeometryBase
       mSMStatus &= ~(0x3ffff&(0x1<<sm));
     }
   }
-  bool GetSMstatus(int sm) const { return (mSMStatus&(0x1<<sm))!=0; }
-  static int GetDetectorSec(int layer, int stack);
-  static int GetDetector(int layer, int stack, int sector);
-  static int GetLayer(int det);
-  int GetStack(int det) const;
-  int GetStack(double z, int layer) const;
-  static int GetSector(int det) {return (det / (kNlayer * kNstack));}
+  bool getSMstatus(int sm) const { return (mSMStatus&(0x1<<sm))!=0; }
+  int getDetectorSec(int layer, int stack) const;
+  int getDetector(int layer, int stack, int sector) const;
+  int getLayer(int det) const;
+  int getStack(int det) const;
+  int getStack(float z, int layer) const;
 
-  TRDPadPlane* GetPadPlane(int layer, int stack) const;
-  TRDPadPlane* GetPadPlane(int det) const { return GetPadPlane(GetLayer(det), GetStack(det)); }
-  int GetRowMax(int layer, int stack, int /*sector*/) const;
-  int GetColMax(int layer) const;
-  double GetRow0(int layer, int stack, int /*sector*/) const;
-  double GetCol0(int layer) const;
+  TRDPadPlane* getPadPlane(int layer, int stack) const;
+  TRDPadPlane* getPadPlane(int det) const { return getPadPlane(getLayer(det), getStack(det)); }
+  int getRowMax(int layer, int stack, int /*sector*/) const;
+  int getColMax(int layer) const;
+  float getRow0(int layer, int stack, int /*sector*/) const;
+  float getCol0(int layer) const;
 
-  static float GetTime0(int layer) { return fgkTime0[layer]; }
-  static double GetXtrdBeg() { return fgkXtrdBeg; }
-  static double GetXtrdEnd() { return fgkXtrdEnd; }
-  static float GetChamberWidth(int layer) { return fgkCwidth[layer]; }
-  static float GetChamberLength(int layer, int stack) { return fgkClength[layer][stack]; }
-  static double GetAlpha() { return 2.0 * 3.14159265358979324 / kNsector; }
-  static float Cheight() { return fgkCH; }
-  static float CheightSV() { return fgkCHsv; }
-  static float Cspace() { return fgkVspace; }
-  static float CraHght() { return fgkCraH; }
-  static float CdrHght() { return fgkCdrH; }
-  static float CamHght() { return fgkCamH; }
-  static float CroHght() { return fgkCroH; }
-  static float CsvHght() { return fgkCsvH; }
-  static float CroWid() { return fgkCroW; }
-  static float AnodePos() { return fgkAnodePos; }
-  static float MyThick() { return fgkRMyThick; }
-  static float DrThick() { return fgkDrThick; }
-  static float AmThick() { return fgkAmThick; }
-  static float DrZpos() { return fgkDrZpos; }
-  static float RpadW() { return fgkRpadW; }
-  static float CpadW() { return fgkCpadW; }
-  static float Cwidcha() { return (fgkSwidth2 - fgkSwidth1) / fgkSheight * (fgkCH + fgkVspace); }
-  static int MCMmax() { return fgkMCMmax; }
-  static int MCMrow() { return fgkMCMrow; }
-  static int ROBmaxC0() { return fgkROBmaxC0; }
-  static int ROBmaxC1() { return fgkROBmaxC1; }
-  static int ADCmax() { return fgkADCmax; }
-  static int TBmax() { return fgkTBmax; }
-  static int Padmax() { return fgkPadmax; }
-  static int Colmax() { return fgkColmax; }
-  static int RowmaxC0() { return fgkRowmaxC0; }
-  static int RowmaxC1() { return fgkRowmaxC1; }
+  static constexpr int getSector(int det) {return (det / (kNlayer * kNstack));}
+  static constexpr float getTime0(int layer) { return fgkTime0[layer]; }
+  static constexpr float getXtrdBeg() { return fgkXtrdBeg; }
+  static constexpr float getXtrdEnd() { return fgkXtrdEnd; }
+  static constexpr float getChamberWidth(int layer) { return fgkCwidth[layer]; }
+  static constexpr float getChamberLength(int layer, int stack) { return fgkClength[layer][stack]; }
+  static constexpr float getAlpha() { return 2.0 * 3.14159265358979324 / kNsector; }
+  static constexpr float cheight() { return fgkCH; }
+  static constexpr float cheightSV() { return fgkCHsv; }
+  static constexpr float cspace() { return fgkVspace; }
+  static constexpr float craHght() { return fgkCraH; }
+  static constexpr float cdrHght() { return fgkCdrH; }
+  static constexpr float camHght() { return fgkCamH; }
+  static constexpr float croHght() { return fgkCroH; }
+  static constexpr float csvHght() { return fgkCsvH; }
+  static constexpr float croWid() { return fgkCroW; }
+  static constexpr float anodePos() { return fgkAnodePos; }
+  static constexpr float myThick() { return fgkRMyThick; }
+  static constexpr float drThick() { return fgkDrThick; }
+  static constexpr float amThick() { return fgkAmThick; }
+  static constexpr float drZpos() { return fgkDrZpos; }
+  static constexpr float rpadW() { return fgkRpadW; }
+  static constexpr float cpadW() { return fgkCpadW; }
+  static constexpr float cwidcha() { return (fgkSwidth2 - fgkSwidth1) / fgkSheight * (fgkCH + fgkVspace); }
+  static constexpr int MCMmax() { return fgkMCMmax; }
+  static constexpr int MCMrow() { return fgkMCMrow; }
+  static constexpr int ROBmaxC0() { return fgkROBmaxC0; }
+  static constexpr int ROBmaxC1() { return fgkROBmaxC1; }
+  static constexpr int ADCmax() { return fgkADCmax; }
+  static constexpr int TBmax() { return fgkTBmax; }
+  static constexpr int padmax() { return fgkPadmax; }
+  static constexpr int colmax() { return fgkColmax; }
+  static constexpr int rowmaxC0() { return fgkRowmaxC0; }
+  static constexpr int rowmaxC1() { return fgkRowmaxC1; }
  protected:
-  TRDGeometryBase();
-  ~TRDGeometryBase() = default;
-     
-  static const float fgkTlength; //  Length of the TRD-volume in spaceframe (BTRD)
+  TRDGeometryBase() = default;
+  
+  static constexpr float fgkTlength = 751.0; ///< Total length of the TRD mother volume
 
-  static const float fgkSheight; //  Height of the supermodule
-  static const float fgkSwidth1; //  Lower width of the supermodule
-  static const float fgkSwidth2; //  Upper width of the supermodule
-  static const float fgkSlength; //  Length of the supermodule
+  // Parameter of the super module mother volumes
+  static constexpr float fgkSheight = 77.9;    ///<  Height of the supermodule
+  static constexpr float fgkSwidth1 = 94.881;  ///< Lower width of the supermodule
+  static constexpr float fgkSwidth2 = 122.353; ///< Upper width of the supermodule
+  static constexpr float fgkSlength = 702.0;   ///< Length of the supermodule
 
-  static const float fgkFlength; //  Length of the service space in front of a supermodule
+  // Length of the additional space in front of the supermodule used for services
+  static constexpr float fgkFlength = (fgkTlength - fgkSlength) / 2.0;
 
-  static const float fgkSMpltT; //  Thickness of the super module side plates
+  static constexpr float fgkSMpltT = 0.2;   ///< Thickness of the super module side plates
 
-  static const float fgkCraH; //  Height of the radiator part of the chambers
-  static const float fgkCdrH; //  Height of the drift region of the chambers
-  static const float fgkCamH; //  Height of the amplification region of the chambers
-  static const float fgkCroH; //  Height of the readout of the chambers
-  static const float fgkCsvH; //  Height of the services on top of the chambers
-  static const float fgkCH;   //  Total height of the chambers (w/o services)
-  static const float fgkCHsv; //  Total height of the chambers (with services)
+  static constexpr float fgkVspace = 1.784; ///< Vertical spacing of the chambers
+  static constexpr float fgkHspace = 2.0;   ///< Horizontal spacing of the chambers
+  static constexpr float fgkVrocsm = 1.2;   ///< Radial distance of the first ROC to the outer plates of the SM
 
-  static const float fgkAnodePos; //  Distance of anode wire plane relative to alignabl volume
+  static constexpr float fgkCraH = 4.8;     ///<  Height of the radiator part of the chambers
+  static constexpr float fgkCdrH = 3.0;     ///<  Height of the drift region of the chambers
+  static constexpr float fgkCamH = 0.7;     ///<  Height of the amplification region of the chambers
+  static constexpr float fgkCroH = 2.316;   ///<  Height of the readout of the chambers
+  static constexpr float fgkCroW = 0.9;     ///< Additional width of the readout chamber frames
+  static constexpr float fgkCsvH = fgkVspace - 0.742; ///< Height of the services on top of the chambers
+  static constexpr float fgkCH = fgkCraH + fgkCdrH + fgkCamH + fgkCroH; ///< Total height of the chambers (w/o services)
+  static constexpr float fgkCHsv = fgkCH + fgkCsvH; ///< Total height of the chambers (with services)
 
-  static const float fgkVspace; //  Vertical spacing of the chambers
-  static const float fgkHspace; //  Horizontal spacing of the chambers
-  static const float fgkVrocsm; //  Radial distance of the first ROC to the outer SM plates
+  // Distance of anode wire plane relative to middle of alignable volume
+  static constexpr float fgkAnodePos = fgkCraH + fgkCdrH + fgkCamH / 2.0 - fgkCHsv / 2.0;
 
-  static const float fgkCalT;    //  Thickness of the lower aluminum frame
-  static const float fgkCalW;    //  Width of additional aluminum ledge on lower frame
-  static const float fgkCalH;    //  Height of additional aluminum ledge on lower frame
-  static const float fgkCalWmod; //  Width of additional aluminum ledge on lower frame
-  static const float fgkCalHmod; //  Height of additional aluminum ledge on lower frame
-  static const float fgkCwsW;    //  Width of additional wacosit ledge on lower frame
-  static const float fgkCwsH;    //  Height of additional wacosit ledge on lower frame
-  static const float fgkCclsT;   //  Thickness of the lower Wacosit frame sides
-  static const float fgkCclfT;   //  Thickness of the lower Wacosit frame front
-  static const float fgkCglT;    //  Thichness of the glue around the radiator
-  static const float fgkCcuTa;   //  Thickness of the upper Wacosit frame around amp. region
-  static const float fgkCcuTb;   //  Thickness of the upper Wacosit frame around amp. region
-  static const float fgkCauT;    //  Thickness of the aluminum frame of the back panel
-  static const float fgkCroW;    //  Additional width of the readout chamber frames
+  static constexpr float fgkCalT = 0.4;    ///< Thicknesses of different parts of the chamber frame Lower aluminum frame
+  static constexpr float fgkCclsT = 0.21;  ///< Thickness of the lower Wacosit frame sides
+  static constexpr float fgkCclfT = 1.0;   ///< Thickness of the lower Wacosit frame front
+  static constexpr float fgkCglT = 0.25;   ///< Thichness of the glue around the radiator
+  static constexpr float fgkCcuTa = 1.0;   ///< Upper Wacosit frame around amplification region
+  static constexpr float fgkCcuTb = 0.8;   ///< Thickness of the upper Wacosit frame around amp. region
+  static constexpr float fgkCauT = 1.5;    ///< Al frame of back panel
+  static constexpr float fgkCalW = 2.5;    ///< Width of additional aluminum ledge on lower frame
+  static constexpr float fgkCalH = 0.4;    ///< Height of additional aluminum ledge on lower frame
+  static constexpr float fgkCalWmod = 0.4; ///< Width of additional aluminum ledge on lower frame
+  static constexpr float fgkCalHmod = 2.5; ///< Height of additional aluminum ledge on lower frame
+  static constexpr float fgkCwsW = 1.2;    ///< Width of additional wacosit ledge on lower frame
+  static constexpr float fgkCwsH = 0.3;    ///< Height of additional wacosit ledge on lower frame
 
-  static const float fgkCpadW; //  Difference of outer chamber width and pad plane width
-  static const float fgkRpadW; //  Difference of outer chamber width and pad plane width
+  static constexpr float fgkCpadW = 0.0;   ///>Difference of outer chamber width and pad plane width
+  static constexpr float fgkRpadW = 1.0;   ///<Difference of outer chamber width and pad plane width
 
-  static const float fgkXeThick; //  Thickness of the gas volume
-  static const float fgkDrThick; //  Thickness of the drift region
-  static const float fgkAmThick; //  Thickness of the amplification region
-  static const float fgkWrThick; //  Thickness of the wire planes
+  //
+  // Thickness of the the material layers
+  //
+  static constexpr float fgkDrThick = fgkCdrH; ///< Thickness of the drift region
+  static constexpr float fgkAmThick = fgkCamH; ///< Thickness of the amplification region
+  static constexpr float fgkXeThick = fgkDrThick + fgkAmThick; ///< Thickness of the gas volume
+  static constexpr float fgkWrThick = 0.00011; ///< Thickness of the wire planes
 
-  static const float fgkPPdThick; //  Thickness of copper of the pad plane
-  static const float fgkPPpThick; //  Thickness of PCB board of the pad plane
-  static const float fgkPGlThick; //  Thickness of the glue layer
-  static const float fgkPCbThick; //  Thickness of the carbon layers
-  static const float fgkPHcThick; //  Thickness of the honeycomb support structure
-  static const float fgkPPcThick; //  Thickness of the PCB readout boards
-  static const float fgkPRbThick; //  Thickness of the PCB copper layers
-  static const float fgkPElThick; //  Thickness of all other electronics components (caps, etc.)
+  static constexpr float fgkRMyThick = 0.0015; ///< Thickness of the mylar layers in the radiator
+  static constexpr float fgkRCbThick = 0.0055; ///< Thickness of the carbon layers in the radiator
+  static constexpr float fgkRGlThick = 0.0065; ///< Thickness of the glue layers in the radiator
+  static constexpr float fgkRRhThick = 0.8;    ///< Thickness of the rohacell layers in the radiator
+  static constexpr float fgkRFbThick = fgkCraH - 2.0 * (fgkRMyThick + fgkRCbThick + fgkRRhThick); ///< Thickness of the fiber layers in the radiator
 
-  static const float fgkRFbThick; //  Thickness of the fiber layers in the radiator
-  static const float fgkRRhThick; //  Thickness of the rohacell layers in the radiator
-  static const float fgkRGlThick; //  Thickness of the glue layers in the radiator
-  static const float fgkRCbThick; //  Thickness of the carbon layers in the radiator
-  static const float fgkRMyThick; //  Thickness of the mylar layers in the radiator
+  static constexpr float fgkPPdThick = 0.0025; ///< Thickness of copper of the pad plane
+  static constexpr float fgkPPpThick = 0.0356; ///< Thickness of PCB board of the pad plane
+  static constexpr float fgkPGlThick = 0.1428; ///< Thickness of the glue layer
+  static constexpr float fgkPCbThick = 0.019;  ///< Thickness of the carbon layers
+  static constexpr float fgkPPcThick = 0.0486; ///< Thickness of the PCB readout boards
+  static constexpr float fgkPRbThick = 0.0057; ///< Thickness of the PCB copper layers
+  static constexpr float fgkPElThick = 0.0029; ///< Thickness of all other electronics components (caps, etc.)
+  static constexpr float fgkPHcThick =
+    fgkCroH - fgkPPdThick - fgkPPpThick - fgkPGlThick - fgkPCbThick * 2.0 - fgkPPcThick - fgkPRbThick - fgkPElThick; ///< Thickness of the honeycomb support structure
 
-  static const float fgkDrZpos;  //  Position of the drift region
-  static const float fgkAmZpos;  //  Position of the amplification region
-  static const float fgkWrZposA; //  Position of the wire planes
-  static const float fgkWrZposB; //  Position of the wire planes
-  static const float fgkCalZpos; //  Position of the additional aluminum ledges
+  //
+  // Position of the material layers
+  //
+  static constexpr float fgkDrZpos = 2.4;  ///< Position of the drift region
+  static constexpr float fgkAmZpos = 0.0;  ///< Position of the amplification region
+  static constexpr float fgkWrZposA = 0.0; ///< Position of the wire planes
+  static constexpr float fgkWrZposB = -fgkAmThick / 2.0 + 0.001; ///< Position of the wire planes
+  static constexpr float fgkCalZpos = 0.3; ///< Position of the additional aluminum ledges
 
-  static const int fgkMCMmax;   //  Maximum number of MCMs per ROB
-  static const int fgkMCMrow;   //  Maximum number of MCMs per ROB Row
-  static const int fgkROBmaxC0; //  Maximum number of ROBs per C0 chamber
-  static const int fgkROBmaxC1; //  Maximum number of ROBs per C1 chamber
-  static const int fgkADCmax;   //  Maximum number of ADC channels per MCM
-  static const int fgkTBmax;    //  Maximum number of Time bins
-  static const int fgkPadmax;   //  Maximum number of pads per MCM
-  static const int fgkColmax;   //  Maximum number of pads per padplane row
-  static const int fgkRowmaxC0; //  Maximum number of Rows per C0 chamber
-  static const int fgkRowmaxC1; //  Maximum number of Rows per C1 chamber
+  static constexpr int fgkMCMmax = 16;     ///< Maximum number of MCMs per ROB
+  static constexpr int fgkMCMrow = 4;      ///< Maximum number of MCMs per ROB Row
+  static constexpr int fgkROBmaxC0 = 6;    ///< Maximum number of ROBs per C0 chamber
+  static constexpr int fgkROBmaxC1 = 8;    ///< Maximum number of ROBs per C1 chamber
+  static constexpr int fgkADCmax = 21;     ///< Maximum number of ADC channels per MCM
+  static constexpr int fgkTBmax = 60;      ///< Maximum number of Time bins
+  static constexpr int fgkPadmax = 18;     ///< Maximum number of pads per MCM
+  static constexpr int fgkColmax = 144;    ///< Maximum number of pads per padplane row
+  static constexpr int fgkRowmaxC0 = 12;   ///< Maximum number of Rows per C0 chamber
+  static constexpr int fgkRowmaxC1 = 16;   ///< Maximum number of Rows per C1 chamber
 
-  static const float fgkCwidth[kNlayer];           //  Outer widths of the chambers
-  static const float fgkClength[kNlayer][kNstack]; //  Outer lengths of the chambers
+  static constexpr float fgkTime0Base = 300.65; ///< Base value for calculation of Time-position of pad 0
+  // Time-position of pad 0
+  static constexpr float fgkTime0[6] = { fgkTime0Base + 0 * (fgkCH + fgkVspace),
+                                           fgkTime0Base + 1 * (fgkCH + fgkVspace),
+                                           fgkTime0Base + 2 * (fgkCH + fgkVspace),
+                                           fgkTime0Base + 3 * (fgkCH + fgkVspace),
+                                           fgkTime0Base + 4 * (fgkCH + fgkVspace),
+                                           fgkTime0Base + 5 * (fgkCH + fgkVspace) };
 
-  static const double fgkTime0Base;     //  Base value for calculation of Time-position of pad 0
-  static const float fgkTime0[kNlayer]; //  Time-position of pad 0
+  static constexpr float fgkXtrdBeg = 288.43; ///< X-coordinate in tracking system of begin of TRD mother volume
+  static constexpr float fgkXtrdEnd = 366.33; ///< X-coordinate in tracking system of end of TRD mother volume
 
-  static const double fgkXtrdBeg; //  X-coordinate in tracking system of begin of TRD mother volume
-  static const double fgkXtrdEnd; //  X-coordinate in tracking system of end of TRD mother volume
+  // The outer width of the chambers
+  static constexpr float fgkCwidth[kNlayer] = { 90.4, 94.8, 99.3, 103.7, 108.1, 112.6 };
+
+  // The outer lengths of the chambers
+  // Includes the spacings between the chambers!
+  static constexpr float fgkClength[kNlayer][kNstack] = {
+    { 124.0, 124.0, 110.0, 124.0, 124.0 }, { 124.0, 124.0, 110.0, 124.0, 124.0 }, { 131.0, 131.0, 110.0, 131.0, 131.0 },
+    { 138.0, 138.0, 110.0, 138.0, 138.0 }, { 145.0, 145.0, 110.0, 145.0, 145.0 }, { 147.0, 147.0, 110.0, 147.0, 147.0 }
+  };
 
   int mSMStatus = 0x3ffff;
   

--- a/Detectors/TRD/base/include/TRDBase/TRDGeometryBase.h
+++ b/Detectors/TRD/base/include/TRDBase/TRDGeometryBase.h
@@ -26,18 +26,13 @@ class TRDGeometryBase
   bool IsHole(int la, int st, int se) const;
   bool IsOnBoundary(int det, float y, float z, float eps = 0.5) const;
 
-  // bool           ChamberInGeometry(int det);
-
-  //  static  bool           CreateClusterMatrixArray();
-  // static  TGeoHMatrix     *GetClusterMatrix(int det);
-
   void SetSMstatus(int sm, char status) { fgSMstatus[sm] = status; }
   static int GetDetectorSec(int layer, int stack);
   static int GetDetector(int layer, int stack, int sector);
   static int GetLayer(int det);
   int GetStack(int det) const;
   int GetStack(double z, int layer) const;
-  static int GetSector(int det);
+  static int GetSector(int det) {return (det / (kNlayer * kNstack));}
 
   TRDPadPlane* GetPadPlane(int layer, int stack) const;
   TRDPadPlane* GetPadPlane(int det) const { return GetPadPlane(GetLayer(det), GetStack(det)); }

--- a/Detectors/TRD/base/include/TRDBase/TRDGeometryBase.h
+++ b/Detectors/TRD/base/include/TRDBase/TRDGeometryBase.h
@@ -28,15 +28,15 @@ class TRDGeometryBase
   bool isHole(int la, int st, int se) const;
   bool isOnBoundary(int det, float y, float z, float eps = 0.5) const;
 
-  void setSMstatus(int sm, bool status) {
+  void setSMstatus(int sm, bool status)
+  {
     if (status) {
-      mSMStatus |= 0x3ffff&(0x1<<sm);
-    }
-    else {
-      mSMStatus &= ~(0x3ffff&(0x1<<sm));
+      mSMStatus |= 0x3ffff & (0x1 << sm);
+    } else {
+      mSMStatus &= ~(0x3ffff & (0x1 << sm));
     }
   }
-  bool getSMstatus(int sm) const { return (mSMStatus&(0x1<<sm))!=0; }
+  bool getSMstatus(int sm) const { return (mSMStatus & (0x1 << sm)) != 0; }
   int getDetectorSec(int layer, int stack) const;
   int getDetector(int layer, int stack, int sector) const;
   int getLayer(int det) const;
@@ -50,157 +50,160 @@ class TRDGeometryBase
   float getRow0(int layer, int stack, int /*sector*/) const;
   float getCol0(int layer) const;
 
-  static constexpr int getSector(int det) {return (det / (kNlayer * kNstack));}
-  static constexpr float getTime0(int layer) { return fgkTime0[layer]; }
-  static constexpr float getXtrdBeg() { return fgkXtrdBeg; }
-  static constexpr float getXtrdEnd() { return fgkXtrdEnd; }
-  static constexpr float getChamberWidth(int layer) { return fgkCwidth[layer]; }
-  static constexpr float getChamberLength(int layer, int stack) { return fgkClength[layer][stack]; }
+  static constexpr int getSector(int det) { return (det / (kNlayer * kNstack)); }
+  static constexpr float getTime0(int layer) { return TIME0[layer]; }
+  static constexpr float getXtrdBeg() { return XTRDBEG; }
+  static constexpr float getXtrdEnd() { return XTRDEND; }
+  static constexpr float getChamberWidth(int layer) { return CWIDTH[layer]; }
+  static constexpr float getChamberLength(int layer, int stack) { return CLENGTH[layer][stack]; }
   static constexpr float getAlpha() { return 2.0 * 3.14159265358979324 / kNsector; }
-  static constexpr float cheight() { return fgkCH; }
-  static constexpr float cheightSV() { return fgkCHsv; }
-  static constexpr float cspace() { return fgkVspace; }
-  static constexpr float craHght() { return fgkCraH; }
-  static constexpr float cdrHght() { return fgkCdrH; }
-  static constexpr float camHght() { return fgkCamH; }
-  static constexpr float croHght() { return fgkCroH; }
-  static constexpr float csvHght() { return fgkCsvH; }
-  static constexpr float croWid() { return fgkCroW; }
-  static constexpr float anodePos() { return fgkAnodePos; }
-  static constexpr float myThick() { return fgkRMyThick; }
-  static constexpr float drThick() { return fgkDrThick; }
-  static constexpr float amThick() { return fgkAmThick; }
-  static constexpr float drZpos() { return fgkDrZpos; }
-  static constexpr float rpadW() { return fgkRpadW; }
-  static constexpr float cpadW() { return fgkCpadW; }
-  static constexpr float cwidcha() { return (fgkSwidth2 - fgkSwidth1) / fgkSheight * (fgkCH + fgkVspace); }
-  static constexpr int MCMmax() { return fgkMCMmax; }
-  static constexpr int MCMrow() { return fgkMCMrow; }
-  static constexpr int ROBmaxC0() { return fgkROBmaxC0; }
-  static constexpr int ROBmaxC1() { return fgkROBmaxC1; }
-  static constexpr int ADCmax() { return fgkADCmax; }
-  static constexpr int TBmax() { return fgkTBmax; }
-  static constexpr int padmax() { return fgkPadmax; }
-  static constexpr int colmax() { return fgkColmax; }
-  static constexpr int rowmaxC0() { return fgkRowmaxC0; }
-  static constexpr int rowmaxC1() { return fgkRowmaxC1; }
+  static constexpr float cheight() { return CH; }
+  static constexpr float cheightSV() { return CHSV; }
+  static constexpr float cspace() { return VSPACE; }
+  static constexpr float craHght() { return CRAH; }
+  static constexpr float cdrHght() { return CDRH; }
+  static constexpr float camHght() { return CAMH; }
+  static constexpr float croHght() { return CROH; }
+  static constexpr float csvHght() { return CSVH; }
+  static constexpr float croWid() { return CROW; }
+  static constexpr float anodePos() { return ANODEPOS; }
+  static constexpr float myThick() { return RMYTHICK; }
+  static constexpr float drThick() { return DRTHICK; }
+  static constexpr float amThick() { return AMTHICK; }
+  static constexpr float drZpos() { return DRZPOS; }
+  static constexpr float rpadW() { return RPADW; }
+  static constexpr float cpadW() { return CPADW; }
+  static constexpr float cwidcha() { return (SWIDTH2 - SWIDTH1) / SHEIGHT * (CH + VSPACE); }
+  static constexpr int MCMmax() { return MCMMAX; }
+  static constexpr int MCMrow() { return MCMROW; }
+  static constexpr int ROBmaxC0() { return ROBMAXC0; }
+  static constexpr int ROBmaxC1() { return ROBMAXC1; }
+  static constexpr int ADCmax() { return ADCMAX; }
+  static constexpr int TBmax() { return TBMAX; }
+  static constexpr int padmax() { return PADMAX; }
+  static constexpr int colmax() { return COLMAX; }
+  static constexpr int rowmaxC0() { return ROWMAXC0; }
+  static constexpr int rowmaxC1() { return ROWMAXC1; }
  protected:
   TRDGeometryBase() = default;
-  
-  static constexpr float fgkTlength = 751.0; ///< Total length of the TRD mother volume
+
+  static constexpr float TLENGTH = 751.0; ///< Total length of the TRD mother volume
 
   // Parameter of the super module mother volumes
-  static constexpr float fgkSheight = 77.9;    ///<  Height of the supermodule
-  static constexpr float fgkSwidth1 = 94.881;  ///< Lower width of the supermodule
-  static constexpr float fgkSwidth2 = 122.353; ///< Upper width of the supermodule
-  static constexpr float fgkSlength = 702.0;   ///< Length of the supermodule
+  static constexpr float SHEIGHT = 77.9;    ///<  Height of the supermodule
+  static constexpr float SWIDTH1 = 94.881;  ///< Lower width of the supermodule
+  static constexpr float SWIDTH2 = 122.353; ///< Upper width of the supermodule
+  static constexpr float SLENGTH = 702.0;   ///< Length of the supermodule
 
   // Length of the additional space in front of the supermodule used for services
-  static constexpr float fgkFlength = (fgkTlength - fgkSlength) / 2.0;
+  static constexpr float FLENGTH = (TLENGTH - SLENGTH) / 2.0;
 
-  static constexpr float fgkSMpltT = 0.2;   ///< Thickness of the super module side plates
+  static constexpr float SMPLTT = 0.2; ///< Thickness of the super module side plates
 
-  static constexpr float fgkVspace = 1.784; ///< Vertical spacing of the chambers
-  static constexpr float fgkHspace = 2.0;   ///< Horizontal spacing of the chambers
-  static constexpr float fgkVrocsm = 1.2;   ///< Radial distance of the first ROC to the outer plates of the SM
+  static constexpr float VSPACE = 1.784; ///< Vertical spacing of the chambers
+  static constexpr float HSPACE = 2.0;   ///< Horizontal spacing of the chambers
+  static constexpr float VROCSM = 1.2;   ///< Radial distance of the first ROC to the outer plates of the SM
 
-  static constexpr float fgkCraH = 4.8;     ///<  Height of the radiator part of the chambers
-  static constexpr float fgkCdrH = 3.0;     ///<  Height of the drift region of the chambers
-  static constexpr float fgkCamH = 0.7;     ///<  Height of the amplification region of the chambers
-  static constexpr float fgkCroH = 2.316;   ///<  Height of the readout of the chambers
-  static constexpr float fgkCroW = 0.9;     ///< Additional width of the readout chamber frames
-  static constexpr float fgkCsvH = fgkVspace - 0.742; ///< Height of the services on top of the chambers
-  static constexpr float fgkCH = fgkCraH + fgkCdrH + fgkCamH + fgkCroH; ///< Total height of the chambers (w/o services)
-  static constexpr float fgkCHsv = fgkCH + fgkCsvH; ///< Total height of the chambers (with services)
+  static constexpr float CRAH = 4.8;                     ///<  Height of the radiator part of the chambers
+  static constexpr float CDRH = 3.0;                     ///<  Height of the drift region of the chambers
+  static constexpr float CAMH = 0.7;                     ///<  Height of the amplification region of the chambers
+  static constexpr float CROH = 2.316;                   ///<  Height of the readout of the chambers
+  static constexpr float CROW = 0.9;                     ///< Additional width of the readout chamber frames
+  static constexpr float CSVH = VSPACE - 0.742;          ///< Height of the services on top of the chambers
+  static constexpr float CH = CRAH + CDRH + CAMH + CROH; ///< Total height of the chambers (w/o services)
+  static constexpr float CHSV = CH + CSVH;               ///< Total height of the chambers (with services)
 
   // Distance of anode wire plane relative to middle of alignable volume
-  static constexpr float fgkAnodePos = fgkCraH + fgkCdrH + fgkCamH / 2.0 - fgkCHsv / 2.0;
+  static constexpr float ANODEPOS = CRAH + CDRH + CAMH / 2.0 - CHSV / 2.0;
 
-  static constexpr float fgkCalT = 0.4;    ///< Thicknesses of different parts of the chamber frame Lower aluminum frame
-  static constexpr float fgkCclsT = 0.21;  ///< Thickness of the lower Wacosit frame sides
-  static constexpr float fgkCclfT = 1.0;   ///< Thickness of the lower Wacosit frame front
-  static constexpr float fgkCglT = 0.25;   ///< Thichness of the glue around the radiator
-  static constexpr float fgkCcuTa = 1.0;   ///< Upper Wacosit frame around amplification region
-  static constexpr float fgkCcuTb = 0.8;   ///< Thickness of the upper Wacosit frame around amp. region
-  static constexpr float fgkCauT = 1.5;    ///< Al frame of back panel
-  static constexpr float fgkCalW = 2.5;    ///< Width of additional aluminum ledge on lower frame
-  static constexpr float fgkCalH = 0.4;    ///< Height of additional aluminum ledge on lower frame
-  static constexpr float fgkCalWmod = 0.4; ///< Width of additional aluminum ledge on lower frame
-  static constexpr float fgkCalHmod = 2.5; ///< Height of additional aluminum ledge on lower frame
-  static constexpr float fgkCwsW = 1.2;    ///< Width of additional wacosit ledge on lower frame
-  static constexpr float fgkCwsH = 0.3;    ///< Height of additional wacosit ledge on lower frame
+  static constexpr float CALT = 0.4;    ///< Thicknesses of different parts of the chamber frame Lower aluminum frame
+  static constexpr float CCLST = 0.21;  ///< Thickness of the lower Wacosit frame sides
+  static constexpr float CCLFT = 1.0;   ///< Thickness of the lower Wacosit frame front
+  static constexpr float CGLT = 0.25;   ///< Thichness of the glue around the radiator
+  static constexpr float CCUTA = 1.0;   ///< Upper Wacosit frame around amplification region
+  static constexpr float CCUTB = 0.8;   ///< Thickness of the upper Wacosit frame around amp. region
+  static constexpr float CAUT = 1.5;    ///< Al frame of back panel
+  static constexpr float CALW = 2.5;    ///< Width of additional aluminum ledge on lower frame
+  static constexpr float CALH = 0.4;    ///< Height of additional aluminum ledge on lower frame
+  static constexpr float CALWMOD = 0.4; ///< Width of additional aluminum ledge on lower frame
+  static constexpr float CALHMOD = 2.5; ///< Height of additional aluminum ledge on lower frame
+  static constexpr float CWSW = 1.2;    ///< Width of additional wacosit ledge on lower frame
+  static constexpr float CWSH = 0.3;    ///< Height of additional wacosit ledge on lower frame
 
-  static constexpr float fgkCpadW = 0.0;   ///>Difference of outer chamber width and pad plane width
-  static constexpr float fgkRpadW = 1.0;   ///<Difference of outer chamber width and pad plane width
+  static constexpr float CPADW = 0.0; ///>Difference of outer chamber width and pad plane width
+  static constexpr float RPADW = 1.0; ///<Difference of outer chamber width and pad plane width
 
   //
   // Thickness of the the material layers
   //
-  static constexpr float fgkDrThick = fgkCdrH; ///< Thickness of the drift region
-  static constexpr float fgkAmThick = fgkCamH; ///< Thickness of the amplification region
-  static constexpr float fgkXeThick = fgkDrThick + fgkAmThick; ///< Thickness of the gas volume
-  static constexpr float fgkWrThick = 0.00011; ///< Thickness of the wire planes
+  static constexpr float DRTHICK = CDRH;              ///< Thickness of the drift region
+  static constexpr float AMTHICK = CAMH;              ///< Thickness of the amplification region
+  static constexpr float XETHICK = DRTHICK + AMTHICK; ///< Thickness of the gas volume
+  static constexpr float WRTHICK = 0.00011;           ///< Thickness of the wire planes
 
-  static constexpr float fgkRMyThick = 0.0015; ///< Thickness of the mylar layers in the radiator
-  static constexpr float fgkRCbThick = 0.0055; ///< Thickness of the carbon layers in the radiator
-  static constexpr float fgkRGlThick = 0.0065; ///< Thickness of the glue layers in the radiator
-  static constexpr float fgkRRhThick = 0.8;    ///< Thickness of the rohacell layers in the radiator
-  static constexpr float fgkRFbThick = fgkCraH - 2.0 * (fgkRMyThick + fgkRCbThick + fgkRRhThick); ///< Thickness of the fiber layers in the radiator
+  static constexpr float RMYTHICK = 0.0015;                                        ///< Thickness of the mylar layers in the radiator
+  static constexpr float RCBTHICK = 0.0055;                                        ///< Thickness of the carbon layers in the radiator
+  static constexpr float RGLTHICK = 0.0065;                                        ///< Thickness of the glue layers in the radiator
+  static constexpr float RRHTHICK = 0.8;                                           ///< Thickness of the rohacell layers in the radiator
+  static constexpr float RFBTHICK = CRAH - 2.0 * (RMYTHICK + RCBTHICK + RRHTHICK); ///< Thickness of the fiber layers in the radiator
 
-  static constexpr float fgkPPdThick = 0.0025; ///< Thickness of copper of the pad plane
-  static constexpr float fgkPPpThick = 0.0356; ///< Thickness of PCB board of the pad plane
-  static constexpr float fgkPGlThick = 0.1428; ///< Thickness of the glue layer
-  static constexpr float fgkPCbThick = 0.019;  ///< Thickness of the carbon layers
-  static constexpr float fgkPPcThick = 0.0486; ///< Thickness of the PCB readout boards
-  static constexpr float fgkPRbThick = 0.0057; ///< Thickness of the PCB copper layers
-  static constexpr float fgkPElThick = 0.0029; ///< Thickness of all other electronics components (caps, etc.)
-  static constexpr float fgkPHcThick =
-    fgkCroH - fgkPPdThick - fgkPPpThick - fgkPGlThick - fgkPCbThick * 2.0 - fgkPPcThick - fgkPRbThick - fgkPElThick; ///< Thickness of the honeycomb support structure
+  static constexpr float PPDTHICK = 0.0025;                                                                                  ///< Thickness of copper of the pad plane
+  static constexpr float PPPTHICK = 0.0356;                                                                                  ///< Thickness of PCB board of the pad plane
+  static constexpr float PGLTHICK = 0.1428;                                                                                  ///< Thickness of the glue layer
+  static constexpr float PCBTHICK = 0.019;                                                                                   ///< Thickness of the carbon layers
+  static constexpr float PPCTHICK = 0.0486;                                                                                  ///< Thickness of the PCB readout boards
+  static constexpr float PRBTHICK = 0.0057;                                                                                  ///< Thickness of the PCB copper layers
+  static constexpr float PELTHICK = 0.0029;                                                                                  ///< Thickness of all other electronics components (caps, etc.)
+  static constexpr float PHCTHICK = CROH - PPDTHICK - PPPTHICK - PGLTHICK - PCBTHICK * 2.0 - PPCTHICK - PRBTHICK - PELTHICK; ///< Thickness of the honeycomb support structure
 
   //
   // Position of the material layers
   //
-  static constexpr float fgkDrZpos = 2.4;  ///< Position of the drift region
-  static constexpr float fgkAmZpos = 0.0;  ///< Position of the amplification region
-  static constexpr float fgkWrZposA = 0.0; ///< Position of the wire planes
-  static constexpr float fgkWrZposB = -fgkAmThick / 2.0 + 0.001; ///< Position of the wire planes
-  static constexpr float fgkCalZpos = 0.3; ///< Position of the additional aluminum ledges
+  static constexpr float DRZPOS = 2.4;                     ///< Position of the drift region
+  static constexpr float AMZPOS = 0.0;                     ///< Position of the amplification region
+  static constexpr float WRZPOSA = 0.0;                    ///< Position of the wire planes
+  static constexpr float WRZPOSB = -AMTHICK / 2.0 + 0.001; ///< Position of the wire planes
+  static constexpr float CALZPOS = 0.3;                    ///< Position of the additional aluminum ledges
 
-  static constexpr int fgkMCMmax = 16;     ///< Maximum number of MCMs per ROB
-  static constexpr int fgkMCMrow = 4;      ///< Maximum number of MCMs per ROB Row
-  static constexpr int fgkROBmaxC0 = 6;    ///< Maximum number of ROBs per C0 chamber
-  static constexpr int fgkROBmaxC1 = 8;    ///< Maximum number of ROBs per C1 chamber
-  static constexpr int fgkADCmax = 21;     ///< Maximum number of ADC channels per MCM
-  static constexpr int fgkTBmax = 60;      ///< Maximum number of Time bins
-  static constexpr int fgkPadmax = 18;     ///< Maximum number of pads per MCM
-  static constexpr int fgkColmax = 144;    ///< Maximum number of pads per padplane row
-  static constexpr int fgkRowmaxC0 = 12;   ///< Maximum number of Rows per C0 chamber
-  static constexpr int fgkRowmaxC1 = 16;   ///< Maximum number of Rows per C1 chamber
+  static constexpr int MCMMAX = 16;   ///< Maximum number of MCMs per ROB
+  static constexpr int MCMROW = 4;    ///< Maximum number of MCMs per ROB Row
+  static constexpr int ROBMAXC0 = 6;  ///< Maximum number of ROBs per C0 chamber
+  static constexpr int ROBMAXC1 = 8;  ///< Maximum number of ROBs per C1 chamber
+  static constexpr int ADCMAX = 21;   ///< Maximum number of ADC channels per MCM
+  static constexpr int TBMAX = 60;    ///< Maximum number of Time bins
+  static constexpr int PADMAX = 18;   ///< Maximum number of pads per MCM
+  static constexpr int COLMAX = 144;  ///< Maximum number of pads per padplane row
+  static constexpr int ROWMAXC0 = 12; ///< Maximum number of Rows per C0 chamber
+  static constexpr int ROWMAXC1 = 16; ///< Maximum number of Rows per C1 chamber
 
-  static constexpr float fgkTime0Base = 300.65; ///< Base value for calculation of Time-position of pad 0
+  static constexpr float TIME0BASE = 300.65; ///< Base value for calculation of Time-position of pad 0
   // Time-position of pad 0
-  static constexpr float fgkTime0[6] = { fgkTime0Base + 0 * (fgkCH + fgkVspace),
-                                           fgkTime0Base + 1 * (fgkCH + fgkVspace),
-                                           fgkTime0Base + 2 * (fgkCH + fgkVspace),
-                                           fgkTime0Base + 3 * (fgkCH + fgkVspace),
-                                           fgkTime0Base + 4 * (fgkCH + fgkVspace),
-                                           fgkTime0Base + 5 * (fgkCH + fgkVspace) };
+  static constexpr float TIME0[6] = { TIME0BASE + 0 * (CH + VSPACE),
+                                      TIME0BASE + 1 * (CH + VSPACE),
+                                      TIME0BASE + 2 * (CH + VSPACE),
+                                      TIME0BASE + 3 * (CH + VSPACE),
+                                      TIME0BASE + 4 * (CH + VSPACE),
+                                      TIME0BASE + 5 * (CH + VSPACE) };
 
-  static constexpr float fgkXtrdBeg = 288.43; ///< X-coordinate in tracking system of begin of TRD mother volume
-  static constexpr float fgkXtrdEnd = 366.33; ///< X-coordinate in tracking system of end of TRD mother volume
+  static constexpr float XTRDBEG = 288.43; ///< X-coordinate in tracking system of begin of TRD mother volume
+  static constexpr float XTRDEND = 366.33; ///< X-coordinate in tracking system of end of TRD mother volume
 
   // The outer width of the chambers
-  static constexpr float fgkCwidth[kNlayer] = { 90.4, 94.8, 99.3, 103.7, 108.1, 112.6 };
+  static constexpr float CWIDTH[kNlayer] = { 90.4, 94.8, 99.3, 103.7, 108.1, 112.6 };
 
   // The outer lengths of the chambers
   // Includes the spacings between the chambers!
-  static constexpr float fgkClength[kNlayer][kNstack] = {
-    { 124.0, 124.0, 110.0, 124.0, 124.0 }, { 124.0, 124.0, 110.0, 124.0, 124.0 }, { 131.0, 131.0, 110.0, 131.0, 131.0 },
-    { 138.0, 138.0, 110.0, 138.0, 138.0 }, { 145.0, 145.0, 110.0, 145.0, 145.0 }, { 147.0, 147.0, 110.0, 147.0, 147.0 }
+  static constexpr float CLENGTH[kNlayer][kNstack] = {
+    { 124.0, 124.0, 110.0, 124.0, 124.0 },
+    { 124.0, 124.0, 110.0, 124.0, 124.0 },
+    { 131.0, 131.0, 110.0, 131.0, 131.0 },
+    { 138.0, 138.0, 110.0, 138.0, 138.0 },
+    { 145.0, 145.0, 110.0, 145.0, 145.0 },
+    { 147.0, 147.0, 110.0, 147.0, 147.0 }
   };
 
   int mSMStatus = 0x3ffff;
-  
+
   TRDPadPlane* mPadPlaneArray = nullptr;
 
  private:

--- a/Detectors/TRD/base/include/TRDBase/TRDGeometryBase.h
+++ b/Detectors/TRD/base/include/TRDBase/TRDGeometryBase.h
@@ -52,11 +52,7 @@ class TRDGeometryBase
   char GetSMstatus(int sm) const { return fgSMstatus[sm]; }
   static float GetChamberWidth(int layer) { return fgkCwidth[layer]; }
   static float GetChamberLength(int layer, int stack) { return fgkClength[layer][stack]; }
-  static double GetAlpha() { return 2.0 * 3.14159265358979324 / fgkNsector; }
-  static int Nsector() { return fgkNsector; }
-  static int Nlayer() { return fgkNlayer; }
-  static int Nstack() { return fgkNstack; }
-  static int Ndet() { return fgkNdet; }
+  static double GetAlpha() { return 2.0 * 3.14159265358979324 / kNsector; }
   static float Cheight() { return fgkCH; }
   static float CheightSV() { return fgkCHsv; }
   static float Cspace() { return fgkVspace; }
@@ -88,11 +84,6 @@ class TRDGeometryBase
   TRDGeometryBase();
   ~TRDGeometryBase();
      
-  static const int fgkNsector; //  Number of sectors in the full detector (18)
-  static const int fgkNlayer;  //  Number of layers of the TRD (6)
-  static const int fgkNstack;  //  Number of stacks in z-direction (5)
-  static const int fgkNdet;    //  Total number of detectors (18 * 6 * 5 = 540)
-
   static const float fgkTlength; //  Length of the TRD-volume in spaceframe (BTRD)
 
   static const float fgkSheight; //  Height of the supermodule

--- a/Detectors/TRD/base/include/TRDBase/TRDGeometryBase.h
+++ b/Detectors/TRD/base/include/TRDBase/TRDGeometryBase.h
@@ -11,6 +11,8 @@
 #ifndef O2_TRDGEOMETRYBASE_H
 #define O2_TRDGEOMETRYBASE_H
 
+#include "TRDBase/TRDCommonParam.h"
+
 namespace o2
 {
 namespace trd
@@ -20,13 +22,19 @@ class TRDPadPlane;
 class TRDGeometryBase
 {
  public:
-  enum { kNlayer = 6, kNstack = 5, kNsector = 18, kNdet = 540, kNdets = 30 };
-
   int IsVersion() { return 1; }
   bool IsHole(int la, int st, int se) const;
   bool IsOnBoundary(int det, float y, float z, float eps = 0.5) const;
 
-  void SetSMstatus(int sm, char status) { fgSMstatus[sm] = status; }
+  void SetSMstatus(int sm, bool status) {
+    if (status) {
+      mSMStatus |= 0x3ffff&(0x1<<sm);
+    }
+    else {
+      mSMStatus &= ~(0x3ffff&(0x1<<sm));
+    }
+  }
+  bool GetSMstatus(int sm) const { return (mSMStatus&(0x1<<sm))!=0; }
   static int GetDetectorSec(int layer, int stack);
   static int GetDetector(int layer, int stack, int sector);
   static int GetLayer(int det);
@@ -44,7 +52,6 @@ class TRDGeometryBase
   static float GetTime0(int layer) { return fgkTime0[layer]; }
   static double GetXtrdBeg() { return fgkXtrdBeg; }
   static double GetXtrdEnd() { return fgkXtrdEnd; }
-  char GetSMstatus(int sm) const { return fgSMstatus[sm]; }
   static float GetChamberWidth(int layer) { return fgkCwidth[layer]; }
   static float GetChamberLength(int layer, int stack) { return fgkClength[layer][stack]; }
   static double GetAlpha() { return 2.0 * 3.14159265358979324 / kNsector; }
@@ -77,7 +84,7 @@ class TRDGeometryBase
   static int RowmaxC1() { return fgkRowmaxC1; }
  protected:
   TRDGeometryBase();
-  ~TRDGeometryBase();
+  ~TRDGeometryBase() = default;
      
   static const float fgkTlength; //  Length of the TRD-volume in spaceframe (BTRD)
 
@@ -168,7 +175,7 @@ class TRDGeometryBase
   static const double fgkXtrdBeg; //  X-coordinate in tracking system of begin of TRD mother volume
   static const double fgkXtrdEnd; //  X-coordinate in tracking system of end of TRD mother volume
 
-  static char fgSMstatus[kNsector]; //  Super module status byte
+  int mSMStatus = 0x3ffff;
   
   TRDPadPlane* mPadPlaneArray = nullptr;
 

--- a/Detectors/TRD/base/include/TRDBase/TRDGeometryBase.h
+++ b/Detectors/TRD/base/include/TRDBase/TRDGeometryBase.h
@@ -1,0 +1,194 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TRDGEOMETRYBASE_H
+#define O2_TRDGEOMETRYBASE_H
+
+namespace o2
+{
+namespace trd
+{
+class TRDPadPlane;
+
+class TRDGeometryBase
+{
+ public:
+  enum { kNlayer = 6, kNstack = 5, kNsector = 18, kNdet = 540, kNdets = 30 };
+
+  int IsVersion() { return 1; }
+  bool IsHole(int la, int st, int se) const;
+  bool IsOnBoundary(int det, float y, float z, float eps = 0.5) const;
+
+  // bool           ChamberInGeometry(int det);
+
+  //  static  bool           CreateClusterMatrixArray();
+  // static  TGeoHMatrix     *GetClusterMatrix(int det);
+
+  void SetSMstatus(int sm, char status) { fgSMstatus[sm] = status; }
+  static int GetDetectorSec(int layer, int stack);
+  static int GetDetector(int layer, int stack, int sector);
+  static int GetLayer(int det);
+  int GetStack(int det) const;
+  int GetStack(double z, int layer) const;
+  static int GetSector(int det);
+
+  TRDPadPlane* GetPadPlane(int layer, int stack) const;
+  TRDPadPlane* GetPadPlane(int det) const { return GetPadPlane(GetLayer(det), GetStack(det)); }
+  int GetRowMax(int layer, int stack, int /*sector*/) const;
+  int GetColMax(int layer) const;
+  double GetRow0(int layer, int stack, int /*sector*/) const;
+  double GetCol0(int layer) const;
+
+  static float GetTime0(int layer) { return fgkTime0[layer]; }
+  static double GetXtrdBeg() { return fgkXtrdBeg; }
+  static double GetXtrdEnd() { return fgkXtrdEnd; }
+  char GetSMstatus(int sm) const { return fgSMstatus[sm]; }
+  static float GetChamberWidth(int layer) { return fgkCwidth[layer]; }
+  static float GetChamberLength(int layer, int stack) { return fgkClength[layer][stack]; }
+  static double GetAlpha() { return 2.0 * 3.14159265358979324 / fgkNsector; }
+  static int Nsector() { return fgkNsector; }
+  static int Nlayer() { return fgkNlayer; }
+  static int Nstack() { return fgkNstack; }
+  static int Ndet() { return fgkNdet; }
+  static float Cheight() { return fgkCH; }
+  static float CheightSV() { return fgkCHsv; }
+  static float Cspace() { return fgkVspace; }
+  static float CraHght() { return fgkCraH; }
+  static float CdrHght() { return fgkCdrH; }
+  static float CamHght() { return fgkCamH; }
+  static float CroHght() { return fgkCroH; }
+  static float CsvHght() { return fgkCsvH; }
+  static float CroWid() { return fgkCroW; }
+  static float AnodePos() { return fgkAnodePos; }
+  static float MyThick() { return fgkRMyThick; }
+  static float DrThick() { return fgkDrThick; }
+  static float AmThick() { return fgkAmThick; }
+  static float DrZpos() { return fgkDrZpos; }
+  static float RpadW() { return fgkRpadW; }
+  static float CpadW() { return fgkCpadW; }
+  static float Cwidcha() { return (fgkSwidth2 - fgkSwidth1) / fgkSheight * (fgkCH + fgkVspace); }
+  static int MCMmax() { return fgkMCMmax; }
+  static int MCMrow() { return fgkMCMrow; }
+  static int ROBmaxC0() { return fgkROBmaxC0; }
+  static int ROBmaxC1() { return fgkROBmaxC1; }
+  static int ADCmax() { return fgkADCmax; }
+  static int TBmax() { return fgkTBmax; }
+  static int Padmax() { return fgkPadmax; }
+  static int Colmax() { return fgkColmax; }
+  static int RowmaxC0() { return fgkRowmaxC0; }
+  static int RowmaxC1() { return fgkRowmaxC1; }
+ protected:
+  TRDGeometryBase();
+  ~TRDGeometryBase();
+     
+  static const int fgkNsector; //  Number of sectors in the full detector (18)
+  static const int fgkNlayer;  //  Number of layers of the TRD (6)
+  static const int fgkNstack;  //  Number of stacks in z-direction (5)
+  static const int fgkNdet;    //  Total number of detectors (18 * 6 * 5 = 540)
+
+  static const float fgkTlength; //  Length of the TRD-volume in spaceframe (BTRD)
+
+  static const float fgkSheight; //  Height of the supermodule
+  static const float fgkSwidth1; //  Lower width of the supermodule
+  static const float fgkSwidth2; //  Upper width of the supermodule
+  static const float fgkSlength; //  Length of the supermodule
+
+  static const float fgkFlength; //  Length of the service space in front of a supermodule
+
+  static const float fgkSMpltT; //  Thickness of the super module side plates
+
+  static const float fgkCraH; //  Height of the radiator part of the chambers
+  static const float fgkCdrH; //  Height of the drift region of the chambers
+  static const float fgkCamH; //  Height of the amplification region of the chambers
+  static const float fgkCroH; //  Height of the readout of the chambers
+  static const float fgkCsvH; //  Height of the services on top of the chambers
+  static const float fgkCH;   //  Total height of the chambers (w/o services)
+  static const float fgkCHsv; //  Total height of the chambers (with services)
+
+  static const float fgkAnodePos; //  Distance of anode wire plane relative to alignabl volume
+
+  static const float fgkVspace; //  Vertical spacing of the chambers
+  static const float fgkHspace; //  Horizontal spacing of the chambers
+  static const float fgkVrocsm; //  Radial distance of the first ROC to the outer SM plates
+
+  static const float fgkCalT;    //  Thickness of the lower aluminum frame
+  static const float fgkCalW;    //  Width of additional aluminum ledge on lower frame
+  static const float fgkCalH;    //  Height of additional aluminum ledge on lower frame
+  static const float fgkCalWmod; //  Width of additional aluminum ledge on lower frame
+  static const float fgkCalHmod; //  Height of additional aluminum ledge on lower frame
+  static const float fgkCwsW;    //  Width of additional wacosit ledge on lower frame
+  static const float fgkCwsH;    //  Height of additional wacosit ledge on lower frame
+  static const float fgkCclsT;   //  Thickness of the lower Wacosit frame sides
+  static const float fgkCclfT;   //  Thickness of the lower Wacosit frame front
+  static const float fgkCglT;    //  Thichness of the glue around the radiator
+  static const float fgkCcuTa;   //  Thickness of the upper Wacosit frame around amp. region
+  static const float fgkCcuTb;   //  Thickness of the upper Wacosit frame around amp. region
+  static const float fgkCauT;    //  Thickness of the aluminum frame of the back panel
+  static const float fgkCroW;    //  Additional width of the readout chamber frames
+
+  static const float fgkCpadW; //  Difference of outer chamber width and pad plane width
+  static const float fgkRpadW; //  Difference of outer chamber width and pad plane width
+
+  static const float fgkXeThick; //  Thickness of the gas volume
+  static const float fgkDrThick; //  Thickness of the drift region
+  static const float fgkAmThick; //  Thickness of the amplification region
+  static const float fgkWrThick; //  Thickness of the wire planes
+
+  static const float fgkPPdThick; //  Thickness of copper of the pad plane
+  static const float fgkPPpThick; //  Thickness of PCB board of the pad plane
+  static const float fgkPGlThick; //  Thickness of the glue layer
+  static const float fgkPCbThick; //  Thickness of the carbon layers
+  static const float fgkPHcThick; //  Thickness of the honeycomb support structure
+  static const float fgkPPcThick; //  Thickness of the PCB readout boards
+  static const float fgkPRbThick; //  Thickness of the PCB copper layers
+  static const float fgkPElThick; //  Thickness of all other electronics components (caps, etc.)
+
+  static const float fgkRFbThick; //  Thickness of the fiber layers in the radiator
+  static const float fgkRRhThick; //  Thickness of the rohacell layers in the radiator
+  static const float fgkRGlThick; //  Thickness of the glue layers in the radiator
+  static const float fgkRCbThick; //  Thickness of the carbon layers in the radiator
+  static const float fgkRMyThick; //  Thickness of the mylar layers in the radiator
+
+  static const float fgkDrZpos;  //  Position of the drift region
+  static const float fgkAmZpos;  //  Position of the amplification region
+  static const float fgkWrZposA; //  Position of the wire planes
+  static const float fgkWrZposB; //  Position of the wire planes
+  static const float fgkCalZpos; //  Position of the additional aluminum ledges
+
+  static const int fgkMCMmax;   //  Maximum number of MCMs per ROB
+  static const int fgkMCMrow;   //  Maximum number of MCMs per ROB Row
+  static const int fgkROBmaxC0; //  Maximum number of ROBs per C0 chamber
+  static const int fgkROBmaxC1; //  Maximum number of ROBs per C1 chamber
+  static const int fgkADCmax;   //  Maximum number of ADC channels per MCM
+  static const int fgkTBmax;    //  Maximum number of Time bins
+  static const int fgkPadmax;   //  Maximum number of pads per MCM
+  static const int fgkColmax;   //  Maximum number of pads per padplane row
+  static const int fgkRowmaxC0; //  Maximum number of Rows per C0 chamber
+  static const int fgkRowmaxC1; //  Maximum number of Rows per C1 chamber
+
+  static const float fgkCwidth[kNlayer];           //  Outer widths of the chambers
+  static const float fgkClength[kNlayer][kNstack]; //  Outer lengths of the chambers
+
+  static const double fgkTime0Base;     //  Base value for calculation of Time-position of pad 0
+  static const float fgkTime0[kNlayer]; //  Time-position of pad 0
+
+  static const double fgkXtrdBeg; //  X-coordinate in tracking system of begin of TRD mother volume
+  static const double fgkXtrdEnd; //  X-coordinate in tracking system of end of TRD mother volume
+
+  static char fgSMstatus[kNsector]; //  Super module status byte
+  
+  TRDPadPlane* mPadPlaneArray = nullptr;
+
+ private:
+  ClassDefNV(TRDGeometryBase, 1) //  TRD geometry class
+};
+} // end namespace trd
+} // end namespace o2
+#endif

--- a/Detectors/TRD/base/include/TRDBase/TRDPadPlane.h
+++ b/Detectors/TRD/base/include/TRDBase/TRDPadPlane.h
@@ -37,59 +37,59 @@ class TRDPadPlane
   ~TRDPadPlane();
   // virtual void       Copy(TObject &p) const;
 
-  void SetLayer(int l) { mLayer = l; };
-  void SetStack(int s) { mStack = s; };
-  void SetRowSpacing(double s) { mRowSpacing = s; };
-  void SetColSpacing(double s) { mColSpacing = s; };
-  void SetLengthRim(double l) { mLengthRim = l; };
-  void SetWidthRim(double w) { mWidthRim = w; };
-  void SetNcols(int n)
+  void setLayer(int l) { mLayer = l; };
+  void setStack(int s) { mStack = s; };
+  void setRowSpacing(double s) { mRowSpacing = s; };
+  void setColSpacing(double s) { mColSpacing = s; };
+  void setLengthRim(double l) { mLengthRim = l; };
+  void setWidthRim(double w) { mWidthRim = w; };
+  void setNcols(int n)
   {
     mNcols = n;
     if (mPadCol)
       delete[] mPadCol;
     mPadCol = new double[mNcols];
   };
-  void SetNrows(int n)
+  void setNrows(int n)
   {
     mNrows = n;
     if (mPadRow)
       delete[] mPadRow;
     mPadRow = new double[mNrows];
   };
-  void SetPadCol(int ic, double c)
+  void setPadCol(int ic, double c)
   {
     if (ic < mNcols)
       mPadCol[ic] = c;
   };
-  void SetPadRow(int ir, double r)
+  void setPadRow(int ir, double r)
   {
     if (ir < mNrows)
       mPadRow[ir] = r;
   };
-  void SetLength(double l) { mLength = l; };
-  void SetWidth(double w) { mWidth = w; };
-  void SetLengthOPad(double l) { mLengthOPad = l; };
-  void SetWidthOPad(double w) { mWidthOPad = w; };
-  void SetLengthIPad(double l) { mLengthIPad = l; };
-  void SetWidthIPad(double w) { mWidthIPad = w; };
-  void SetPadRowSMOffset(double o) { mPadRowSMOffset = o; };
-  void SetAnodeWireOffset(float o) { mAnodeWireOffset = o; };
-  void SetTiltingAngle(double t);
+  void setLength(double l) { mLength = l; };
+  void setWidth(double w) { mWidth = w; };
+  void setLengthOPad(double l) { mLengthOPad = l; };
+  void setWidthOPad(double w) { mWidthOPad = w; };
+  void setLengthIPad(double l) { mLengthIPad = l; };
+  void setWidthIPad(double w) { mWidthIPad = w; };
+  void setPadRowSMOffset(double o) { mPadRowSMOffset = o; };
+  void setAnodeWireOffset(float o) { mAnodeWireOffset = o; };
+  void setTiltingAngle(double t);
 
-  int GetPadRowNumber(double z) const;
-  int GetPadRowNumberROC(double z) const;
-  int GetPadColNumber(double rphi) const;
+  int getPadRowNumber(double z) const;
+  int getPadRowNumberROC(double z) const;
+  int getPadColNumber(double rphi) const;
 
-  double GetTiltOffset(double rowOffset) const { return mTiltingTan * (rowOffset - 0.5 * mLengthIPad); };
-  double GetPadRowOffset(int row, double z) const
+  double getTiltOffset(double rowOffset) const { return mTiltingTan * (rowOffset - 0.5 * mLengthIPad); };
+  double getPadRowOffset(int row, double z) const
   {
     if ((row < 0) || (row >= mNrows))
       return -1.0;
     else
       return mPadRow[row] + mPadRowSMOffset - z;
   };
-  double GetPadRowOffsetROC(int row, double z) const
+  double getPadRowOffsetROC(int row, double z) const
   {
     if ((row < 0) || (row >= mNrows))
       return -1.0;
@@ -97,7 +97,7 @@ class TRDPadPlane
       return mPadRow[row] - z;
   };
 
-  double GetPadColOffset(int col, double rphi) const
+  double getPadColOffset(int col, double rphi) const
   {
     if ((col < 0) || (col >= mNcols))
       return -1.0;
@@ -105,26 +105,26 @@ class TRDPadPlane
       return rphi - mPadCol[col];
   };
 
-  double GetTiltingAngle() const { return mTiltingAngle; };
-  int GetNrows() const { return mNrows; };
-  int GetNcols() const { return mNcols; };
-  double GetRow0() const { return mPadRow[0] + mPadRowSMOffset; };
-  double GetRow0ROC() const { return mPadRow[0]; };
-  double GetCol0() const { return mPadCol[0]; };
-  double GetRowEnd() const { return mPadRow[mNrows - 1] - mLengthOPad + mPadRowSMOffset; };
-  double GetRowEndROC() const { return mPadRow[mNrows - 1] - mLengthOPad; };
-  double GetColEnd() const { return mPadCol[mNcols - 1] + mWidthOPad; };
-  double GetRowPos(int row) const { return mPadRow[row] + mPadRowSMOffset; };
-  double GetRowPosROC(int row) const { return mPadRow[row]; };
-  double GetColPos(int col) const { return mPadCol[col]; };
-  double GetRowSize(int row) const
+  double getTiltingAngle() const { return mTiltingAngle; };
+  int getNrows() const { return mNrows; };
+  int getNcols() const { return mNcols; };
+  double getRow0() const { return mPadRow[0] + mPadRowSMOffset; };
+  double getRow0ROC() const { return mPadRow[0]; };
+  double getCol0() const { return mPadCol[0]; };
+  double getRowEnd() const { return mPadRow[mNrows - 1] - mLengthOPad + mPadRowSMOffset; };
+  double getRowEndROC() const { return mPadRow[mNrows - 1] - mLengthOPad; };
+  double getColEnd() const { return mPadCol[mNcols - 1] + mWidthOPad; };
+  double getRowPos(int row) const { return mPadRow[row] + mPadRowSMOffset; };
+  double getRowPosROC(int row) const { return mPadRow[row]; };
+  double getColPos(int col) const { return mPadCol[col]; };
+  double getRowSize(int row) const
   {
     if ((row == 0) || (row == mNrows - 1))
       return mLengthOPad;
     else
       return mLengthIPad;
   };
-  double GetColSize(int col) const
+  double getColSize(int col) const
   {
     if ((col == 0) || (col == mNcols - 1))
       return mWidthOPad;
@@ -132,15 +132,15 @@ class TRDPadPlane
       return mWidthIPad;
   };
 
-  double GetLengthRim() const { return mLengthRim; };
-  double GetWidthRim() const { return mWidthRim; };
-  double GetRowSpacing() const { return mRowSpacing; };
-  double GetColSpacing() const { return mColSpacing; };
-  double GetLengthOPad() const { return mLengthOPad; };
-  double GetLengthIPad() const { return mLengthIPad; };
-  double GetWidthOPad() const { return mWidthOPad; };
-  double GetWidthIPad() const { return mWidthIPad; };
-  double GetAnodeWireOffset() const { return mAnodeWireOffset; };
+  double getLengthRim() const { return mLengthRim; };
+  double getWidthRim() const { return mWidthRim; };
+  double getRowSpacing() const { return mRowSpacing; };
+  double getColSpacing() const { return mColSpacing; };
+  double getLengthOPad() const { return mLengthOPad; };
+  double getLengthIPad() const { return mLengthIPad; };
+  double getWidthOPad() const { return mWidthOPad; };
+  double getWidthIPad() const { return mWidthIPad; };
+  double getAnodeWireOffset() const { return mAnodeWireOffset; };
  protected:
   int mLayer; //  Layer number
   int mStack; //  Stack number

--- a/Detectors/TRD/base/include/TRDBase/TRDPadPlane.h
+++ b/Detectors/TRD/base/include/TRDBase/TRDPadPlane.h
@@ -32,6 +32,8 @@ class TRDPadPlane
  public:
   TRDPadPlane();
   TRDPadPlane(int layer, int stack);
+  TRDPadPlane(const TRDPadPlane& p) = delete;
+  TRDPadPlane& operator=(const TRDPadPlane& p) = delete;
   ~TRDPadPlane();
   // virtual void       Copy(TObject &p) const;
 
@@ -172,9 +174,6 @@ class TRDPadPlane
   double mAnodeWireOffset; //  Distance of first anode wire from pad edge
 
  private:
-  TRDPadPlane(const TRDPadPlane& p);
-  TRDPadPlane& operator=(const TRDPadPlane& p);
-
   ClassDefNV(TRDPadPlane, 1) //  TRD ROC pad plane
 };
 }

--- a/Detectors/TRD/base/src/TRDBaseLinkDef.h
+++ b/Detectors/TRD/base/src/TRDBaseLinkDef.h
@@ -16,6 +16,7 @@
 
 #pragma link C++ class o2::trd::TRDPadPlane + ;
 #pragma link C++ class o2::trd::TRDGeometry + ;
+#pragma link C++ class o2::trd::TRDGeometryBase + ;
 #pragma link C++ class o2::trd::TRDCommonParam + ;
 #pragma link C++ class o2::trd::TRDSimParam + ;
 

--- a/Detectors/TRD/base/src/TRDCommonParam.cxx
+++ b/Detectors/TRD/base/src/TRDCommonParam.cxx
@@ -308,7 +308,7 @@ double TRDCommonParam::TimeStruct(float vdrift, double dist, double z)
 
   // Dist now is the drift distance to the anode wires (negative if electrons are
   // between anode wire plane and cathode pad plane)
-  dist -= TRDGeometry::AmThick() / 2.0;
+  dist -= TRDGeometry::amThick() / 2.0;
 
   // Interpolation in z-directions, lower drift time map
   const float ktdrift1 =

--- a/Detectors/TRD/base/src/TRDGeometry.cxx
+++ b/Detectors/TRD/base/src/TRDGeometry.cxx
@@ -215,7 +215,7 @@ void TRDGeometry::createPadPlane(int ilayer, int istack)
   //
   // Row direction
   //
-  float row = fgkClength[ilayer][istack] / 2.0 - fgkRpadW - padPlane.getLengthRim();
+  float row = CLENGTH[ilayer][istack] / 2.0 - RPADW - padPlane.getLengthRim();
   for (int ir = 0; ir < padPlane.getNrows(); ir++) {
     padPlane.setPadRow(ir, row);
     row -= padPlane.getRowSpacing();
@@ -228,7 +228,7 @@ void TRDGeometry::createPadPlane(int ilayer, int istack)
   //
   // Column direction
   //
-  float col = -fgkCwidth[ilayer] / 2.0 - fgkCroW + padPlane.getWidthRim();
+  float col = -CWIDTH[ilayer] / 2.0 - CROW + padPlane.getWidthRim();
   for (int ic = 0; ic < padPlane.getNcols(); ic++) {
     padPlane.setPadCol(ic, col);
     col += padPlane.getColSpacing();
@@ -240,11 +240,11 @@ void TRDGeometry::createPadPlane(int ilayer, int istack)
   }
   // Calculate the offset to translate from the local ROC system into
   // the local supermodule system, which is used for clusters
-  float rowTmp = fgkClength[ilayer][0] + fgkClength[ilayer][1] + fgkClength[ilayer][2] / 2.0;
+  float rowTmp = CLENGTH[ilayer][0] + CLENGTH[ilayer][1] + CLENGTH[ilayer][2] / 2.0;
   for (int jstack = 0; jstack < istack; jstack++) {
-    rowTmp -= fgkClength[ilayer][jstack];
+    rowTmp -= CLENGTH[ilayer][jstack];
   }
-  padPlane.setPadRowSMOffset(rowTmp - fgkClength[ilayer][istack] / 2.0);
+  padPlane.setPadRowSMOffset(rowTmp - CLENGTH[ilayer][istack] / 2.0);
 }
 
 void TRDGeometry::createVolume(const char* name, const char* shape, int nmed, float* upar, int np)
@@ -263,12 +263,12 @@ void TRDGeometry::createGeometry(std::vector<int> const& idtmed)
 {
   //
   // Create the TRD geometry
-  
+
   if (!gGeoManager) {
     // RSTODO: in future there will be a method to load matrices from the CDB
-    LOG(FATAL) << "Geometry is not loaded" << FairLogger::endl;
+    LOG(FATAL) << "Geometry is not loaded";
   }
-  
+
   createPadPlaneArray();
   mPadPlaneArray = fgPadPlaneArray.get();
   createVolumes(idtmed);
@@ -342,29 +342,29 @@ void TRDGeometry::createVolumes(std::vector<int> const& idtmed)
   //
   // The mother volume for one sector (Air), full length in z-direction
   // Provides material for side plates of super module
-  parTrd[0] = fgkSwidth1 / 2.0;
-  parTrd[1] = fgkSwidth2 / 2.0;
-  parTrd[2] = fgkSlength / 2.0;
-  parTrd[3] = fgkSheight / 2.0;
+  parTrd[0] = SWIDTH1 / 2.0;
+  parTrd[1] = SWIDTH2 / 2.0;
+  parTrd[2] = SLENGTH / 2.0;
+  parTrd[3] = SHEIGHT / 2.0;
   createVolume("UTR1", "TRD1", idtmed[2], parTrd, kNparTrd);
   createVolume("UTR2", "TRD1", idtmed[2], parTrd, kNparTrd);
   createVolume("UTR3", "TRD1", idtmed[2], parTrd, kNparTrd);
   createVolume("UTR4", "TRD1", idtmed[2], parTrd, kNparTrd);
   // The outer aluminum plates of the super module (Al)
-  parTrd[0] = fgkSwidth1 / 2.0;
-  parTrd[1] = fgkSwidth2 / 2.0;
-  parTrd[2] = fgkSlength / 2.0;
-  parTrd[3] = fgkSheight / 2.0;
+  parTrd[0] = SWIDTH1 / 2.0;
+  parTrd[1] = SWIDTH2 / 2.0;
+  parTrd[2] = SLENGTH / 2.0;
+  parTrd[3] = SHEIGHT / 2.0;
   createVolume("UTS1", "TRD1", idtmed[1], parTrd, kNparTrd);
   createVolume("UTS2", "TRD1", idtmed[1], parTrd, kNparTrd);
   createVolume("UTS3", "TRD1", idtmed[1], parTrd, kNparTrd);
   createVolume("UTS4", "TRD1", idtmed[1], parTrd, kNparTrd);
   // The inner part of the TRD mother volume for one sector (Air),
   // full length in z-direction
-  parTrd[0] = fgkSwidth1 / 2.0 - fgkSMpltT;
-  parTrd[1] = fgkSwidth2 / 2.0 - fgkSMpltT;
-  parTrd[2] = fgkSlength / 2.0;
-  parTrd[3] = fgkSheight / 2.0 - fgkSMpltT;
+  parTrd[0] = SWIDTH1 / 2.0 - SMPLTT;
+  parTrd[1] = SWIDTH2 / 2.0 - SMPLTT;
+  parTrd[2] = SLENGTH / 2.0;
+  parTrd[3] = SHEIGHT / 2.0 - SMPLTT;
   createVolume("UTI1", "TRD1", idtmed[2], parTrd, kNparTrd);
   createVolume("UTI2", "TRD1", idtmed[2], parTrd, kNparTrd);
   createVolume("UTI3", "TRD1", idtmed[2], parTrd, kNparTrd);
@@ -372,10 +372,10 @@ void TRDGeometry::createVolumes(std::vector<int> const& idtmed)
 
   // The inner part of the TRD mother volume for services in front
   // of the supermodules  (Air),
-  parTrd[0] = fgkSwidth1 / 2.0;
-  parTrd[1] = fgkSwidth2 / 2.0;
-  parTrd[2] = fgkFlength / 2.0;
-  parTrd[3] = fgkSheight / 2.0;
+  parTrd[0] = SWIDTH1 / 2.0;
+  parTrd[1] = SWIDTH2 / 2.0;
+  parTrd[2] = FLENGTH / 2.0;
+  parTrd[3] = SHEIGHT / 2.0;
   createVolume("UTF1", "TRD1", idtmed[2], parTrd, kNparTrd);
   createVolume("UTF2", "TRD1", idtmed[2], parTrd, kNparTrd);
 
@@ -386,69 +386,69 @@ void TRDGeometry::createVolumes(std::vector<int> const& idtmed)
       // The lower part of the readout chambers (drift volume + radiator)
       // The aluminum frames
       snprintf(cTagV, kTag, "UA%02d", iDet);
-      parCha[0] = fgkCwidth[ilayer] / 2.0;
-      parCha[1] = fgkClength[ilayer][istack] / 2.0 - fgkHspace / 2.0;
-      parCha[2] = fgkCraH / 2.0 + fgkCdrH / 2.0;
+      parCha[0] = CWIDTH[ilayer] / 2.0;
+      parCha[1] = CLENGTH[ilayer][istack] / 2.0 - HSPACE / 2.0;
+      parCha[2] = CRAH / 2.0 + CDRH / 2.0;
       createVolume(cTagV, "BOX ", idtmed[1], parCha, kNparCha);
       // The additional aluminum on the frames
       // This part has not the correct shape but is just supposed to
       // represent the missing material. The correct form of the L-shaped
       // profile would not fit into the alignable volume.
       snprintf(cTagV, kTag, "UZ%02d", iDet);
-      parCha[0] = fgkCalWmod / 2.0;
-      parCha[1] = fgkClength[ilayer][istack] / 2.0 - fgkHspace / 2.0;
-      parCha[2] = fgkCalHmod / 2.0;
+      parCha[0] = CALWMOD / 2.0;
+      parCha[1] = CLENGTH[ilayer][istack] / 2.0 - HSPACE / 2.0;
+      parCha[2] = CALHMOD / 2.0;
       createVolume(cTagV, "BOX ", idtmed[1], parCha, kNparCha);
       // The additional Wacosit on the frames
       snprintf(cTagV, kTag, "UP%02d", iDet);
-      parCha[0] = fgkCwsW / 2.0;
-      parCha[1] = fgkClength[ilayer][istack] / 2.0 - fgkHspace / 2.0;
-      parCha[2] = fgkCwsH / 2.0;
+      parCha[0] = CWSW / 2.0;
+      parCha[1] = CLENGTH[ilayer][istack] / 2.0 - HSPACE / 2.0;
+      parCha[2] = CWSH / 2.0;
       createVolume(cTagV, "BOX ", idtmed[7], parCha, kNparCha);
       // The Wacosit frames
       snprintf(cTagV, kTag, "UB%02d", iDet);
-      parCha[0] = fgkCwidth[ilayer] / 2.0 - fgkCalT;
+      parCha[0] = CWIDTH[ilayer] / 2.0 - CALT;
       parCha[1] = -1.0;
       parCha[2] = -1.0;
       createVolume(cTagV, "BOX ", idtmed[7], parCha, kNparCha);
       // The glue around the radiator
       snprintf(cTagV, kTag, "UX%02d", iDet);
-      parCha[0] = fgkCwidth[ilayer] / 2.0 - fgkCalT - fgkCclsT;
-      parCha[1] = fgkClength[ilayer][istack] / 2.0 - fgkHspace / 2.0 - fgkCclfT;
-      parCha[2] = fgkCraH / 2.0;
+      parCha[0] = CWIDTH[ilayer] / 2.0 - CALT - CCLST;
+      parCha[1] = CLENGTH[ilayer][istack] / 2.0 - HSPACE / 2.0 - CCLFT;
+      parCha[2] = CRAH / 2.0;
       createVolume(cTagV, "BOX ", idtmed[11], parCha, kNparCha);
       // The inner part of radiator (air)
       snprintf(cTagV, kTag, "UC%02d", iDet);
-      parCha[0] = fgkCwidth[ilayer] / 2.0 - fgkCalT - fgkCclsT - fgkCglT;
-      parCha[1] = fgkClength[ilayer][istack] / 2.0 - fgkHspace / 2.0 - fgkCclfT - fgkCglT;
+      parCha[0] = CWIDTH[ilayer] / 2.0 - CALT - CCLST - CGLT;
+      parCha[1] = CLENGTH[ilayer][istack] / 2.0 - HSPACE / 2.0 - CCLFT - CGLT;
       parCha[2] = -1.0;
       createVolume(cTagV, "BOX ", idtmed[2], parCha, kNparCha);
 
       // The upper part of the readout chambers (amplification volume)
       // The Wacosit frames
       snprintf(cTagV, kTag, "UD%02d", iDet);
-      parCha[0] = fgkCwidth[ilayer] / 2.0 + fgkCroW;
-      parCha[1] = fgkClength[ilayer][istack] / 2.0 - fgkHspace / 2.0;
-      parCha[2] = fgkCamH / 2.0;
+      parCha[0] = CWIDTH[ilayer] / 2.0 + CROW;
+      parCha[1] = CLENGTH[ilayer][istack] / 2.0 - HSPACE / 2.0;
+      parCha[2] = CAMH / 2.0;
       createVolume(cTagV, "BOX ", idtmed[7], parCha, kNparCha);
       // The inner part of the Wacosit frame (air)
       snprintf(cTagV, kTag, "UE%02d", iDet);
-      parCha[0] = fgkCwidth[ilayer] / 2.0 + fgkCroW - fgkCcuTb;
-      parCha[1] = fgkClength[ilayer][istack] / 2.0 - fgkHspace / 2.0 - fgkCcuTa;
+      parCha[0] = CWIDTH[ilayer] / 2.0 + CROW - CCUTB;
+      parCha[1] = CLENGTH[ilayer][istack] / 2.0 - HSPACE / 2.0 - CCUTA;
       parCha[2] = -1.;
       createVolume(cTagV, "BOX ", idtmed[2], parCha, kNparCha);
 
       // The back panel, including pad plane and readout boards
       // The aluminum frames
       snprintf(cTagV, kTag, "UF%02d", iDet);
-      parCha[0] = fgkCwidth[ilayer] / 2.0 + fgkCroW;
-      parCha[1] = fgkClength[ilayer][istack] / 2.0 - fgkHspace / 2.0;
-      parCha[2] = fgkCroH / 2.0;
+      parCha[0] = CWIDTH[ilayer] / 2.0 + CROW;
+      parCha[1] = CLENGTH[ilayer][istack] / 2.0 - HSPACE / 2.0;
+      parCha[2] = CROH / 2.0;
       createVolume(cTagV, "BOX ", idtmed[1], parCha, kNparCha);
       // The inner part of the aluminum frames
       snprintf(cTagV, kTag, "UG%02d", iDet);
-      parCha[0] = fgkCwidth[ilayer] / 2.0 + fgkCroW - fgkCauT;
-      parCha[1] = fgkClength[ilayer][istack] / 2.0 - fgkHspace / 2.0 - fgkCauT;
+      parCha[0] = CWIDTH[ilayer] / 2.0 + CROW - CAUT;
+      parCha[1] = CLENGTH[ilayer][istack] / 2.0 - HSPACE / 2.0 - CAUT;
       parCha[2] = -1.0;
       createVolume(cTagV, "BOX ", idtmed[2], parCha, kNparCha);
 
@@ -459,100 +459,100 @@ void TRDGeometry::createVolumes(std::vector<int> const& idtmed)
       // Mylar layer (radiator)
       parCha[0] = -1.0;
       parCha[1] = -1.0;
-      parCha[2] = fgkRMyThick / 2.0;
+      parCha[2] = RMYTHICK / 2.0;
       snprintf(cTagV, kTag, "URMY%02d", iDet);
       createVolume(cTagV, "BOX ", idtmed[27], parCha, kNparCha);
       // Carbon layer (radiator)
       parCha[0] = -1.0;
       parCha[1] = -1.0;
-      parCha[2] = fgkRCbThick / 2.0;
+      parCha[2] = RCBTHICK / 2.0;
       snprintf(cTagV, kTag, "URCB%02d", iDet);
       createVolume(cTagV, "BOX ", idtmed[26], parCha, kNparCha);
       // Araldite layer (radiator)
       parCha[0] = -1.0;
       parCha[1] = -1.0;
-      parCha[2] = fgkRGlThick / 2.0;
+      parCha[2] = RGLTHICK / 2.0;
       snprintf(cTagV, kTag, "URGL%02d", iDet);
       createVolume(cTagV, "BOX ", idtmed[11], parCha, kNparCha);
       // Rohacell layer (radiator)
       parCha[0] = -1.0;
       parCha[1] = -1.0;
-      parCha[2] = fgkRRhThick / 2.0;
+      parCha[2] = RRHTHICK / 2.0;
       snprintf(cTagV, kTag, "URRH%02d", iDet);
       createVolume(cTagV, "BOX ", idtmed[15], parCha, kNparCha);
       // Fiber layer (radiator)
       parCha[0] = -1.0;
       parCha[1] = -1.0;
-      parCha[2] = fgkRFbThick / 2.0;
+      parCha[2] = RFBTHICK / 2.0;
       snprintf(cTagV, kTag, "URFB%02d", iDet);
       createVolume(cTagV, "BOX ", idtmed[28], parCha, kNparCha);
 
       // Xe/Isobutane layer (drift volume)
-      parCha[0] = fgkCwidth[ilayer] / 2.0 - fgkCalT - fgkCclsT;
-      parCha[1] = fgkClength[ilayer][istack] / 2.0 - fgkHspace / 2.0 - fgkCclfT;
-      parCha[2] = fgkDrThick / 2.0;
+      parCha[0] = CWIDTH[ilayer] / 2.0 - CALT - CCLST;
+      parCha[1] = CLENGTH[ilayer][istack] / 2.0 - HSPACE / 2.0 - CCLFT;
+      parCha[2] = DRTHICK / 2.0;
       snprintf(cTagV, kTag, "UJ%02d", iDet);
       createVolume(cTagV, "BOX ", idtmed[9], parCha, kNparCha);
 
       // Xe/Isobutane layer (amplification volume)
       parCha[0] = -1.0;
       parCha[1] = -1.0;
-      parCha[2] = fgkAmThick / 2.0;
+      parCha[2] = AMTHICK / 2.0;
       snprintf(cTagV, kTag, "UK%02d", iDet);
       createVolume(cTagV, "BOX ", idtmed[9], parCha, kNparCha);
       // Cu layer (wire plane)
       parCha[0] = -1.0;
       parCha[1] = -1.0;
-      parCha[2] = fgkWrThick / 2.0;
+      parCha[2] = WRTHICK / 2.0;
       snprintf(cTagV, kTag, "UW%02d", iDet);
       createVolume(cTagV, "BOX ", idtmed[3], parCha, kNparCha);
 
       // Cu layer (pad plane)
       parCha[0] = -1.0;
       parCha[1] = -1.0;
-      parCha[2] = fgkPPdThick / 2.0;
+      parCha[2] = PPDTHICK / 2.0;
       snprintf(cTagV, kTag, "UPPD%02d", iDet);
       createVolume(cTagV, "BOX ", idtmed[5], parCha, kNparCha);
       // G10 layer (pad plane)
       parCha[0] = -1.0;
       parCha[1] = -1.0;
-      parCha[2] = fgkPPpThick / 2.0;
+      parCha[2] = PPPTHICK / 2.0;
       snprintf(cTagV, kTag, "UPPP%02d", iDet);
       createVolume(cTagV, "BOX ", idtmed[13], parCha, kNparCha);
       // Araldite layer (glue)
       parCha[0] = -1.0;
       parCha[1] = -1.0;
-      parCha[2] = fgkPGlThick / 2.0;
+      parCha[2] = PGLTHICK / 2.0;
       snprintf(cTagV, kTag, "UPGL%02d", iDet);
       createVolume(cTagV, "BOX ", idtmed[11], parCha, kNparCha);
       // Carbon layer (carbon fiber mats)
       parCha[0] = -1.0;
       parCha[1] = -1.0;
-      parCha[2] = fgkPCbThick / 2.0;
+      parCha[2] = PCBTHICK / 2.0;
       snprintf(cTagV, kTag, "UPCB%02d", iDet);
       createVolume(cTagV, "BOX ", idtmed[26], parCha, kNparCha);
       // Aramide layer (honeycomb)
       parCha[0] = -1.0;
       parCha[1] = -1.0;
-      parCha[2] = fgkPHcThick / 2.0;
+      parCha[2] = PHCTHICK / 2.0;
       snprintf(cTagV, kTag, "UPHC%02d", iDet);
       createVolume(cTagV, "BOX ", idtmed[10], parCha, kNparCha);
       // G10 layer (PCB readout board)
       parCha[0] = -1.0;
       parCha[1] = -1.0;
-      parCha[2] = fgkPPcThick / 2;
+      parCha[2] = PPCTHICK / 2;
       snprintf(cTagV, kTag, "UPPC%02d", iDet);
       createVolume(cTagV, "BOX ", idtmed[13], parCha, kNparCha);
       // Cu layer (traces in readout board)
       parCha[0] = -1.0;
       parCha[1] = -1.0;
-      parCha[2] = fgkPRbThick / 2.0;
+      parCha[2] = PRBTHICK / 2.0;
       snprintf(cTagV, kTag, "UPRB%02d", iDet);
       createVolume(cTagV, "BOX ", idtmed[6], parCha, kNparCha);
       // Cu layer (other material on in readout board, incl. screws)
       parCha[0] = -1.0;
       parCha[1] = -1.0;
-      parCha[2] = fgkPElThick / 2.0;
+      parCha[2] = PELTHICK / 2.0;
       snprintf(cTagV, kTag, "UPEL%02d", iDet);
       createVolume(cTagV, "BOX ", idtmed[4], parCha, kNparCha);
 
@@ -564,38 +564,38 @@ void TRDGeometry::createVolumes(std::vector<int> const& idtmed)
 
       // Lower part
       // Mylar layers (radiator)
-      zpos = fgkRMyThick / 2.0 - fgkCraH / 2.0;
+      zpos = RMYTHICK / 2.0 - CRAH / 2.0;
       snprintf(cTagV, kTag, "URMY%02d", iDet);
       snprintf(cTagM, kTag, "UC%02d", iDet);
       TVirtualMC::GetMC()->Gspos(cTagV, 1, cTagM, xpos, ypos, zpos, 0, "ONLY");
-      zpos = -fgkRMyThick / 2.0 + fgkCraH / 2.0;
+      zpos = -RMYTHICK / 2.0 + CRAH / 2.0;
       snprintf(cTagV, kTag, "URMY%02d", iDet);
       snprintf(cTagM, kTag, "UC%02d", iDet);
       TVirtualMC::GetMC()->Gspos(cTagV, 2, cTagM, xpos, ypos, zpos, 0, "ONLY");
       // Carbon layers (radiator)
-      zpos = fgkRCbThick / 2.0 + fgkRMyThick - fgkCraH / 2.0;
+      zpos = RCBTHICK / 2.0 + RMYTHICK - CRAH / 2.0;
       snprintf(cTagV, kTag, "URCB%02d", iDet);
       snprintf(cTagM, kTag, "UC%02d", iDet);
       TVirtualMC::GetMC()->Gspos(cTagV, 1, cTagM, xpos, ypos, zpos, 0, "ONLY");
-      zpos = -fgkRCbThick / 2.0 - fgkRMyThick + fgkCraH / 2.0;
+      zpos = -RCBTHICK / 2.0 - RMYTHICK + CRAH / 2.0;
       snprintf(cTagV, kTag, "URCB%02d", iDet);
       snprintf(cTagM, kTag, "UC%02d", iDet);
       TVirtualMC::GetMC()->Gspos(cTagV, 2, cTagM, xpos, ypos, zpos, 0, "ONLY");
       // Carbon layers (radiator)
-      zpos = fgkRGlThick / 2.0 + fgkRCbThick + fgkRMyThick - fgkCraH / 2.0;
+      zpos = RGLTHICK / 2.0 + RCBTHICK + RMYTHICK - CRAH / 2.0;
       snprintf(cTagV, kTag, "URGL%02d", iDet);
       snprintf(cTagM, kTag, "UC%02d", iDet);
       TVirtualMC::GetMC()->Gspos(cTagV, 1, cTagM, xpos, ypos, zpos, 0, "ONLY");
-      zpos = -fgkRGlThick / 2.0 - fgkRCbThick - fgkRMyThick + fgkCraH / 2.0;
+      zpos = -RGLTHICK / 2.0 - RCBTHICK - RMYTHICK + CRAH / 2.0;
       snprintf(cTagV, kTag, "URGL%02d", iDet);
       snprintf(cTagM, kTag, "UC%02d", iDet);
       TVirtualMC::GetMC()->Gspos(cTagV, 2, cTagM, xpos, ypos, zpos, 0, "ONLY");
       // Rohacell layers (radiator)
-      zpos = fgkRRhThick / 2.0 + fgkRGlThick + fgkRCbThick + fgkRMyThick - fgkCraH / 2.0;
+      zpos = RRHTHICK / 2.0 + RGLTHICK + RCBTHICK + RMYTHICK - CRAH / 2.0;
       snprintf(cTagV, kTag, "URRH%02d", iDet);
       snprintf(cTagM, kTag, "UC%02d", iDet);
       TVirtualMC::GetMC()->Gspos(cTagV, 1, cTagM, xpos, ypos, zpos, 0, "ONLY");
-      zpos = -fgkRRhThick / 2.0 - fgkRGlThick - fgkRCbThick - fgkRMyThick + fgkCraH / 2.0;
+      zpos = -RRHTHICK / 2.0 - RGLTHICK - RCBTHICK - RMYTHICK + CRAH / 2.0;
       snprintf(cTagV, kTag, "URRH%02d", iDet);
       snprintf(cTagM, kTag, "UC%02d", iDet);
       TVirtualMC::GetMC()->Gspos(cTagV, 2, cTagM, xpos, ypos, zpos, 0, "ONLY");
@@ -606,69 +606,69 @@ void TRDGeometry::createVolumes(std::vector<int> const& idtmed)
       TVirtualMC::GetMC()->Gspos(cTagV, 1, cTagM, xpos, ypos, zpos, 0, "ONLY");
 
       // Xe/Isobutane layer (drift volume)
-      zpos = fgkDrZpos;
+      zpos = DRZPOS;
       snprintf(cTagV, kTag, "UJ%02d", iDet);
       snprintf(cTagM, kTag, "UB%02d", iDet);
       TVirtualMC::GetMC()->Gspos(cTagV, 1, cTagM, xpos, ypos, zpos, 0, "ONLY");
 
       // Upper part
       // Xe/Isobutane layer (amplification volume)
-      zpos = fgkAmZpos;
+      zpos = AMZPOS;
       snprintf(cTagV, kTag, "UK%02d", iDet);
       snprintf(cTagM, kTag, "UE%02d", iDet);
       TVirtualMC::GetMC()->Gspos(cTagV, 1, cTagM, xpos, ypos, zpos, 0, "ONLY");
       // Cu layer (wire planes inside amplification volume)
-      zpos = fgkWrZposA;
+      zpos = WRZPOSA;
       snprintf(cTagV, kTag, "UW%02d", iDet);
       snprintf(cTagM, kTag, "UK%02d", iDet);
       TVirtualMC::GetMC()->Gspos(cTagV, 1, cTagM, xpos, ypos, zpos, 0, "ONLY");
-      zpos = fgkWrZposB;
+      zpos = WRZPOSB;
       snprintf(cTagV, kTag, "UW%02d", iDet);
       snprintf(cTagM, kTag, "UK%02d", iDet);
       TVirtualMC::GetMC()->Gspos(cTagV, 2, cTagM, xpos, ypos, zpos, 0, "ONLY");
 
       // Back panel + pad plane + readout part
       // Cu layer (pad plane)
-      zpos = fgkPPdThick / 2.0 - fgkCroH / 2.0;
+      zpos = PPDTHICK / 2.0 - CROH / 2.0;
       snprintf(cTagV, kTag, "UPPD%02d", iDet);
       snprintf(cTagM, kTag, "UG%02d", iDet);
       TVirtualMC::GetMC()->Gspos(cTagV, 1, cTagM, xpos, ypos, zpos, 0, "ONLY");
       // G10  layer (pad plane)
-      zpos = fgkPPpThick / 2.0 + fgkPPdThick - fgkCroH / 2.0;
+      zpos = PPPTHICK / 2.0 + PPDTHICK - CROH / 2.0;
       snprintf(cTagV, kTag, "UPPP%02d", iDet);
       snprintf(cTagM, kTag, "UG%02d", iDet);
       TVirtualMC::GetMC()->Gspos(cTagV, 1, cTagM, xpos, ypos, zpos, 0, "ONLY");
       // Araldite layer (glue)
-      zpos = fgkPGlThick / 2.0 + fgkPPpThick + fgkPPdThick - fgkCroH / 2.0;
+      zpos = PGLTHICK / 2.0 + PPPTHICK + PPDTHICK - CROH / 2.0;
       snprintf(cTagV, kTag, "UPGL%02d", iDet);
       snprintf(cTagM, kTag, "UG%02d", iDet);
       TVirtualMC::GetMC()->Gspos(cTagV, 1, cTagM, xpos, ypos, zpos, 0, "ONLY");
       // Carbon layers (carbon fiber mats)
-      zpos = fgkPCbThick / 2.0 + fgkPGlThick + fgkPPpThick + fgkPPdThick - fgkCroH / 2.0;
+      zpos = PCBTHICK / 2.0 + PGLTHICK + PPPTHICK + PPDTHICK - CROH / 2.0;
       snprintf(cTagV, kTag, "UPCB%02d", iDet);
       snprintf(cTagM, kTag, "UG%02d", iDet);
       TVirtualMC::GetMC()->Gspos(cTagV, 1, cTagM, xpos, ypos, zpos, 0, "ONLY");
-      zpos = -fgkPCbThick / 2.0 - fgkPPcThick - fgkPRbThick - fgkPElThick + fgkCroH / 2.0;
+      zpos = -PCBTHICK / 2.0 - PPCTHICK - PRBTHICK - PELTHICK + CROH / 2.0;
       snprintf(cTagV, kTag, "UPCB%02d", iDet);
       snprintf(cTagM, kTag, "UG%02d", iDet);
       TVirtualMC::GetMC()->Gspos(cTagV, 2, cTagM, xpos, ypos, zpos, 0, "ONLY");
       // Aramide layer (honeycomb)
-      zpos = fgkPHcThick / 2.0 + fgkPCbThick + fgkPGlThick + fgkPPpThick + fgkPPdThick - fgkCroH / 2.0;
+      zpos = PHCTHICK / 2.0 + PCBTHICK + PGLTHICK + PPPTHICK + PPDTHICK - CROH / 2.0;
       snprintf(cTagV, kTag, "UPHC%02d", iDet);
       snprintf(cTagM, kTag, "UG%02d", iDet);
       TVirtualMC::GetMC()->Gspos(cTagV, 1, cTagM, xpos, ypos, zpos, 0, "ONLY");
       // G10 layer (PCB readout board)
-      zpos = -fgkPPcThick / 2.0 - fgkPRbThick - fgkPElThick + fgkCroH / 2.0;
+      zpos = -PPCTHICK / 2.0 - PRBTHICK - PELTHICK + CROH / 2.0;
       snprintf(cTagV, kTag, "UPPC%02d", iDet);
       snprintf(cTagM, kTag, "UG%02d", iDet);
       TVirtualMC::GetMC()->Gspos(cTagV, 1, cTagM, xpos, ypos, zpos, 0, "ONLY");
       // Cu layer (traces in readout board)
-      zpos = -fgkPRbThick / 2.0 - fgkPElThick + fgkCroH / 2.0;
+      zpos = -PRBTHICK / 2.0 - PELTHICK + CROH / 2.0;
       snprintf(cTagV, kTag, "UPRB%02d", iDet);
       snprintf(cTagM, kTag, "UG%02d", iDet);
       TVirtualMC::GetMC()->Gspos(cTagV, 1, cTagM, xpos, ypos, zpos, 0, "ONLY");
       // Cu layer (other materials on readout board, incl. screws)
-      zpos = -fgkPElThick / 2.0 + fgkCroH / 2.0;
+      zpos = -PELTHICK / 2.0 + CROH / 2.0;
       snprintf(cTagV, kTag, "UPEL%02d", iDet);
       snprintf(cTagM, kTag, "UG%02d", iDet);
       TVirtualMC::GetMC()->Gspos(cTagV, 1, cTagM, xpos, ypos, zpos, 0, "ONLY");
@@ -683,7 +683,7 @@ void TRDGeometry::createVolumes(std::vector<int> const& idtmed)
       snprintf(cTagM, kTag, "UX%02d", iDet);
       TVirtualMC::GetMC()->Gspos(cTagV, 1, cTagM, xpos, ypos, zpos, 0, "ONLY");
       // The glue around the radiator
-      zpos = fgkCraH / 2.0 - fgkCdrH / 2.0 - fgkCraH / 2.0;
+      zpos = CRAH / 2.0 - CDRH / 2.0 - CRAH / 2.0;
       snprintf(cTagV, kTag, "UX%02d", iDet);
       snprintf(cTagM, kTag, "UB%02d", iDet);
       TVirtualMC::GetMC()->Gspos(cTagV, 1, cTagM, xpos, ypos, zpos, 0, "ONLY");
@@ -769,7 +769,7 @@ void TRDGeometry::createVolumes(std::vector<int> const& idtmed)
   // Put the TRD volumes into the space frame mother volumes
   // if enabled via status flag
   xpos = 0.0;
-  ypos = 0.5 * fgkSlength + 0.5 * fgkFlength;
+  ypos = 0.5 * SLENGTH + 0.5 * FLENGTH;
   zpos = 0.0;
   for (int isector = 0; isector < kNsector; isector++) {
     if (getSMstatus(isector)) {
@@ -844,10 +844,10 @@ void TRDGeometry::createFrame(std::vector<int> const& idtmed)
   // Bottom 1 (all sectors)
   parCrb[0] = 77.49 / 2.0;
   parCrb[1] = 104.60 / 2.0;
-  parCrb[2] = fgkSMpltT / 2.0;
+  parCrb[2] = SMPLTT / 2.0;
   xpos = 0.0;
   ypos = 0.0;
-  zpos = fgkSMpltT / 2.0 - fgkSheight / 2.0;
+  zpos = SMPLTT / 2.0 - SHEIGHT / 2.0;
   TVirtualMC::GetMC()->Gsposp("USCR", 1, "UTS1", xpos, ypos, zpos, 0, "ONLY", parCrb, kNparCrb);
   TVirtualMC::GetMC()->Gsposp("USCR", 2, "UTS2", xpos, ypos, zpos, 0, "ONLY", parCrb, kNparCrb);
   TVirtualMC::GetMC()->Gsposp("USCR", 3, "UTS3", xpos, ypos, zpos, 0, "ONLY", parCrb, kNparCrb);
@@ -855,10 +855,10 @@ void TRDGeometry::createFrame(std::vector<int> const& idtmed)
   // Bottom 2 (all sectors)
   parCrb[0] = 77.49 / 2.0;
   parCrb[1] = 55.80 / 2.0;
-  parCrb[2] = fgkSMpltT / 2.0;
+  parCrb[2] = SMPLTT / 2.0;
   xpos = 0.0;
   ypos = 85.6;
-  zpos = fgkSMpltT / 2.0 - fgkSheight / 2.0;
+  zpos = SMPLTT / 2.0 - SHEIGHT / 2.0;
   TVirtualMC::GetMC()->Gsposp("USCR", 5, "UTS1", xpos, ypos, zpos, 0, "ONLY", parCrb, kNparCrb);
   TVirtualMC::GetMC()->Gsposp("USCR", 6, "UTS2", xpos, ypos, zpos, 0, "ONLY", parCrb, kNparCrb);
   TVirtualMC::GetMC()->Gsposp("USCR", 7, "UTS3", xpos, ypos, zpos, 0, "ONLY", parCrb, kNparCrb);
@@ -870,10 +870,10 @@ void TRDGeometry::createFrame(std::vector<int> const& idtmed)
   // Bottom 3 (all sectors)
   parCrb[0] = 77.49 / 2.0;
   parCrb[1] = 56.00 / 2.0;
-  parCrb[2] = fgkSMpltT / 2.0;
+  parCrb[2] = SMPLTT / 2.0;
   xpos = 0.0;
   ypos = 148.5;
-  zpos = fgkSMpltT / 2.0 - fgkSheight / 2.0;
+  zpos = SMPLTT / 2.0 - SHEIGHT / 2.0;
   TVirtualMC::GetMC()->Gsposp("USCR", 13, "UTS1", xpos, ypos, zpos, 0, "ONLY", parCrb, kNparCrb);
   TVirtualMC::GetMC()->Gsposp("USCR", 14, "UTS2", xpos, ypos, zpos, 0, "ONLY", parCrb, kNparCrb);
   TVirtualMC::GetMC()->Gsposp("USCR", 15, "UTS3", xpos, ypos, zpos, 0, "ONLY", parCrb, kNparCrb);
@@ -885,10 +885,10 @@ void TRDGeometry::createFrame(std::vector<int> const& idtmed)
   // Bottom 4 (all sectors)
   parCrb[0] = 77.49 / 2.0;
   parCrb[1] = 118.00 / 2.0;
-  parCrb[2] = fgkSMpltT / 2.0;
+  parCrb[2] = SMPLTT / 2.0;
   xpos = 0.0;
   ypos = 240.5;
-  zpos = fgkSMpltT / 2.0 - fgkSheight / 2.0;
+  zpos = SMPLTT / 2.0 - SHEIGHT / 2.0;
   TVirtualMC::GetMC()->Gsposp("USCR", 21, "UTS1", xpos, ypos, zpos, 0, "ONLY", parCrb, kNparCrb);
   TVirtualMC::GetMC()->Gsposp("USCR", 22, "UTS2", xpos, ypos, zpos, 0, "ONLY", parCrb, kNparCrb);
   TVirtualMC::GetMC()->Gsposp("USCR", 23, "UTS3", xpos, ypos, zpos, 0, "ONLY", parCrb, kNparCrb);
@@ -900,19 +900,19 @@ void TRDGeometry::createFrame(std::vector<int> const& idtmed)
   // Top 1 (only in front of PHOS)
   parCrb[0] = 111.48 / 2.0;
   parCrb[1] = 105.00 / 2.0;
-  parCrb[2] = fgkSMpltT / 2.0;
+  parCrb[2] = SMPLTT / 2.0;
   xpos = 0.0;
   ypos = 0.0;
-  zpos = fgkSMpltT / 2.0 - fgkSheight / 2.0;
+  zpos = SMPLTT / 2.0 - SHEIGHT / 2.0;
   TVirtualMC::GetMC()->Gsposp("USCR", 29, "UTS2", xpos, ypos, -zpos, 0, "ONLY", parCrb, kNparCrb);
   TVirtualMC::GetMC()->Gsposp("USCR", 30, "UTS3", xpos, ypos, -zpos, 0, "ONLY", parCrb, kNparCrb);
   // Top 2 (only in front of PHOS)
   parCrb[0] = 111.48 / 2.0;
   parCrb[1] = 56.00 / 2.0;
-  parCrb[2] = fgkSMpltT / 2.0;
+  parCrb[2] = SMPLTT / 2.0;
   xpos = 0.0;
   ypos = 85.5;
-  zpos = fgkSMpltT / 2.0 - fgkSheight / 2.0;
+  zpos = SMPLTT / 2.0 - SHEIGHT / 2.0;
   TVirtualMC::GetMC()->Gsposp("USCR", 31, "UTS2", xpos, ypos, -zpos, 0, "ONLY", parCrb, kNparCrb);
   TVirtualMC::GetMC()->Gsposp("USCR", 32, "UTS3", xpos, ypos, -zpos, 0, "ONLY", parCrb, kNparCrb);
   TVirtualMC::GetMC()->Gsposp("USCR", 33, "UTS2", xpos, -ypos, -zpos, 0, "ONLY", parCrb, kNparCrb);
@@ -929,7 +929,7 @@ void TRDGeometry::createFrame(std::vector<int> const& idtmed)
   const int kNparSRL = 11;
   float parSRL[kNparSRL];
   // Trapezoidal shape
-  parSRL[0] = fgkSlength / 2.0;
+  parSRL[0] = SLENGTH / 2.0;
   parSRL[1] = 0.0;
   parSRL[2] = 0.0;
   parSRL[3] = kSRLhgt / 2.0;
@@ -946,10 +946,10 @@ void TRDGeometry::createFrame(std::vector<int> const& idtmed)
   ypos = 0.0;
   zpos = 0.0;
   for (ilayer = 1; ilayer < kNlayer; ilayer++) {
-    xpos = fgkCwidth[ilayer] / 2.0 + kSRLwidA / 2.0 + kSRLdst;
+    xpos = CWIDTH[ilayer] / 2.0 + kSRLwidA / 2.0 + kSRLdst;
     ypos = 0.0;
-    zpos = fgkVrocsm + fgkSMpltT - fgkCalZpos - fgkSheight / 2.0 + fgkCraH + fgkCdrH - fgkCalH - kSRLhgt / 2.0 +
-           ilayer * (fgkCH + fgkVspace);
+    zpos = VROCSM + SMPLTT - CALZPOS - SHEIGHT / 2.0 + CRAH + CDRH - CALH - kSRLhgt / 2.0 +
+           ilayer * (CH + VSPACE);
     TVirtualMC::GetMC()->Gspos("USRL", ilayer + 1, "UTI1", xpos, ypos, zpos, matrix[2], "ONLY");
     TVirtualMC::GetMC()->Gspos("USRL", ilayer + 1 + kNlayer, "UTI1", -xpos, ypos, zpos, matrix[3], "ONLY");
     TVirtualMC::GetMC()->Gspos("USRL", ilayer + 1 + 2 * kNlayer, "UTI2", xpos, ypos, zpos, matrix[2], "ONLY");
@@ -971,7 +971,7 @@ void TRDGeometry::createFrame(std::vector<int> const& idtmed)
   const int kNparSCB = 3;
   float parSCB[kNparSCB];
   parSCB[1] = kSCBwid / 2.0;
-  parSCB[2] = fgkCH / 2.0 + fgkVspace / 2.0 - kSCHhgt;
+  parSCB[2] = CH / 2.0 + VSPACE / 2.0 - kSCHhgt;
 
   const int kNparSCI = 3;
   float parSCI[kNparSCI];
@@ -982,7 +982,7 @@ void TRDGeometry::createFrame(std::vector<int> const& idtmed)
   zpos = 0.0;
   for (ilayer = 0; ilayer < kNlayer; ilayer++) {
     // The aluminum of the cross bars
-    parSCB[0] = fgkCwidth[ilayer] / 2.0 + kSRLdst / 2.0;
+    parSCB[0] = CWIDTH[ilayer] / 2.0 + kSRLdst / 2.0;
     snprintf(cTagV, kTag, "USF%01d", ilayer);
     createVolume(cTagV, "BOX ", idtmed[1], parSCB, kNparSCB);
 
@@ -1011,15 +1011,15 @@ void TRDGeometry::createFrame(std::vector<int> const& idtmed)
 
     snprintf(cTagV, kTag, "USF%01d", ilayer);
     xpos = 0.0;
-    zpos = fgkVrocsm + fgkSMpltT + parSCB[2] - fgkSheight / 2.0 + ilayer * (fgkCH + fgkVspace);
+    zpos = VROCSM + SMPLTT + parSCB[2] - SHEIGHT / 2.0 + ilayer * (CH + VSPACE);
 
-    ypos = fgkClength[ilayer][2] / 2.0 + fgkClength[ilayer][1];
+    ypos = CLENGTH[ilayer][2] / 2.0 + CLENGTH[ilayer][1];
     TVirtualMC::GetMC()->Gspos(cTagV, 1, "UTI1", xpos, ypos, zpos, 0, "ONLY");
     TVirtualMC::GetMC()->Gspos(cTagV, 3, "UTI2", xpos, ypos, zpos, 0, "ONLY");
     TVirtualMC::GetMC()->Gspos(cTagV, 5, "UTI3", xpos, ypos, zpos, 0, "ONLY");
     TVirtualMC::GetMC()->Gspos(cTagV, 7, "UTI4", xpos, ypos, zpos, 0, "ONLY");
 
-    ypos = -fgkClength[ilayer][2] / 2.0 - fgkClength[ilayer][1];
+    ypos = -CLENGTH[ilayer][2] / 2.0 - CLENGTH[ilayer][1];
     TVirtualMC::GetMC()->Gspos(cTagV, 2, "UTI1", xpos, ypos, zpos, 0, "ONLY");
     TVirtualMC::GetMC()->Gspos(cTagV, 4, "UTI2", xpos, ypos, zpos, 0, "ONLY");
     TVirtualMC::GetMC()->Gspos(cTagV, 6, "UTI3", xpos, ypos, zpos, 0, "ONLY");
@@ -1034,17 +1034,17 @@ void TRDGeometry::createFrame(std::vector<int> const& idtmed)
   float parSCH[kNparSCH];
 
   for (ilayer = 1; ilayer < kNlayer - 1; ilayer++) {
-    parSCH[0] = fgkCwidth[ilayer] / 2.0;
-    parSCH[1] = (fgkClength[ilayer + 1][2] / 2.0 + fgkClength[ilayer + 1][1] - fgkClength[ilayer][2] / 2.0 -
-                 fgkClength[ilayer][1]) /
+    parSCH[0] = CWIDTH[ilayer] / 2.0;
+    parSCH[1] = (CLENGTH[ilayer + 1][2] / 2.0 + CLENGTH[ilayer + 1][1] - CLENGTH[ilayer][2] / 2.0 -
+                 CLENGTH[ilayer][1]) /
                 2.0;
     parSCH[2] = kSCHhgt / 2.0;
 
     snprintf(cTagV, kTag, "USH%01d", ilayer);
     createVolume(cTagV, "BOX ", idtmed[1], parSCH, kNparSCH);
     xpos = 0.0;
-    ypos = fgkClength[ilayer][2] / 2.0 + fgkClength[ilayer][1] + parSCH[1];
-    zpos = fgkVrocsm + fgkSMpltT - kSCHhgt / 2.0 - fgkSheight / 2.0 + (ilayer + 1) * (fgkCH + fgkVspace);
+    ypos = CLENGTH[ilayer][2] / 2.0 + CLENGTH[ilayer][1] + parSCH[1];
+    zpos = VROCSM + SMPLTT - kSCHhgt / 2.0 - SHEIGHT / 2.0 + (ilayer + 1) * (CH + VSPACE);
     TVirtualMC::GetMC()->Gspos(cTagV, 1, "UTI1", xpos, ypos, zpos, 0, "ONLY");
     TVirtualMC::GetMC()->Gspos(cTagV, 3, "UTI2", xpos, ypos, zpos, 0, "ONLY");
     TVirtualMC::GetMC()->Gspos(cTagV, 5, "UTI3", xpos, ypos, zpos, 0, "ONLY");
@@ -1161,7 +1161,7 @@ void TRDGeometry::createFrame(std::vector<int> const& idtmed)
   zpos = 0.4;
   TVirtualMC::GetMC()->Gspos("USD6", 1, "USDB", xpos, ypos, zpos, matrix[2], "ONLY");
   xpos = 0.0;
-  ypos = fgkClength[5][2] / 2.0;
+  ypos = CLENGTH[5][2] / 2.0;
   zpos = 0.04;
   TVirtualMC::GetMC()->Gspos("USDB", 1, "UTI1", xpos, ypos, zpos, 0, "ONLY");
   TVirtualMC::GetMC()->Gspos("USDB", 2, "UTI1", xpos, -ypos, zpos, 0, "ONLY");
@@ -1177,8 +1177,8 @@ void TRDGeometry::createFrame(std::vector<int> const& idtmed)
   parBOX[2] = 3.00 / 2.0;
   createVolume("USD7", "BOX ", idtmed[1], parBOX, kNparBOX);
   xpos = 0.0;
-  ypos = fgkClength[5][2] / 2.0;
-  zpos = fgkSheight / 2.0 - fgkSMpltT - 3.00 / 2.0;
+  ypos = CLENGTH[5][2] / 2.0;
+  zpos = SHEIGHT / 2.0 - SMPLTT - 3.00 / 2.0;
   TVirtualMC::GetMC()->Gspos("USD7", 1, "UTI1", xpos, ypos, zpos, 0, "ONLY");
   TVirtualMC::GetMC()->Gspos("USD7", 2, "UTI1", xpos, -ypos, zpos, 0, "ONLY");
   TVirtualMC::GetMC()->Gspos("USD7", 3, "UTI2", xpos, ypos, zpos, 0, "ONLY");
@@ -1193,8 +1193,8 @@ void TRDGeometry::createFrame(std::vector<int> const& idtmed)
   parBOX[2] = 1.74 / 2.0;
   createVolume("USD8", "BOX ", idtmed[1], parBOX, kNparBOX);
   xpos = 0.0;
-  ypos = fgkClength[5][2] / 2.0 - 0.1;
-  zpos = -fgkSheight / 2.0 + fgkSMpltT + 2.27;
+  ypos = CLENGTH[5][2] / 2.0 - 0.1;
+  zpos = -SHEIGHT / 2.0 + SMPLTT + 2.27;
   TVirtualMC::GetMC()->Gspos("USD8", 1, "UTI1", xpos, ypos, zpos, 0, "ONLY");
   TVirtualMC::GetMC()->Gspos("USD8", 2, "UTI1", xpos, -ypos, zpos, 0, "ONLY");
   TVirtualMC::GetMC()->Gspos("USD8", 3, "UTI2", xpos, ypos, zpos, 0, "ONLY");
@@ -1209,8 +1209,8 @@ void TRDGeometry::createFrame(std::vector<int> const& idtmed)
   parBOX[2] = 1.40 / 2.0;
   createVolume("USD9", "BOX ", idtmed[1], parBOX, kNparBOX);
   xpos = 0.0;
-  ypos = fgkClength[5][2] / 2.0;
-  zpos = -fgkSheight / 2.0 + fgkSMpltT + 1.40 / 2.0;
+  ypos = CLENGTH[5][2] / 2.0;
+  zpos = -SHEIGHT / 2.0 + SMPLTT + 1.40 / 2.0;
   TVirtualMC::GetMC()->Gspos("USD9", 1, "UTI1", xpos, ypos, zpos, 0, "ONLY");
   TVirtualMC::GetMC()->Gspos("USD9", 2, "UTI1", xpos, -ypos, zpos, 0, "ONLY");
   TVirtualMC::GetMC()->Gspos("USD9", 3, "UTI2", xpos, ypos, zpos, 0, "ONLY");
@@ -1233,7 +1233,7 @@ void TRDGeometry::createFrame(std::vector<int> const& idtmed)
   parTRP[10] = -5.0;
   createVolume("USDF", "TRAP", idtmed[2], parTRP, kNparTRP);
   xpos = -32.0;
-  ypos = fgkClength[5][2] / 2.0 + 1.20 / 2.0 + 0.10 / 2.0;
+  ypos = CLENGTH[5][2] / 2.0 + 1.20 / 2.0 + 0.10 / 2.0;
   zpos = 0.0;
   TVirtualMC::GetMC()->Gspos("USDF", 1, "UTI1", xpos, ypos, zpos, matrix[2], "ONLY");
   TVirtualMC::GetMC()->Gspos("USDF", 2, "UTI1", xpos, -ypos, zpos, matrix[2], "ONLY");
@@ -1293,7 +1293,7 @@ void TRDGeometry::createFrame(std::vector<int> const& idtmed)
   TVirtualMC::GetMC()->Gspos("USC3", 1, "USCB", xpos, ypos, zpos, matrix[4], "ONLY");
   TVirtualMC::GetMC()->Gspos("USC3", 2, "USCB", -xpos, ypos, zpos, matrix[5], "ONLY");
   xpos = 0.0;
-  ypos = fgkClength[5][2] / 2.0 + fgkClength[5][1] + fgkClength[5][0];
+  ypos = CLENGTH[5][2] / 2.0 + CLENGTH[5][1] + CLENGTH[5][0];
   zpos = 0.0;
   TVirtualMC::GetMC()->Gspos("USCB", 1, "UTI1", xpos, ypos, zpos, 0, "ONLY");
   TVirtualMC::GetMC()->Gspos("USCB", 2, "UTI1", xpos, -ypos, zpos, 0, "ONLY");
@@ -1309,8 +1309,8 @@ void TRDGeometry::createFrame(std::vector<int> const& idtmed)
   parBOX[2] = 3.00 / 2.0;
   createVolume("USC4", "BOX ", idtmed[1], parBOX, kNparBOX);
   xpos = 0.0;
-  ypos = fgkClength[5][2] / 2.0 + fgkClength[5][1] + fgkClength[5][0];
-  zpos = fgkSheight / 2.0 - fgkSMpltT - 3.00 / 2.0;
+  ypos = CLENGTH[5][2] / 2.0 + CLENGTH[5][1] + CLENGTH[5][0];
+  zpos = SHEIGHT / 2.0 - SMPLTT - 3.00 / 2.0;
   TVirtualMC::GetMC()->Gspos("USC4", 1, "UTI1", xpos, ypos, zpos, 0, "ONLY");
   TVirtualMC::GetMC()->Gspos("USC4", 2, "UTI1", xpos, -ypos, zpos, 0, "ONLY");
   TVirtualMC::GetMC()->Gspos("USC4", 3, "UTI2", xpos, ypos, zpos, 0, "ONLY");
@@ -1325,8 +1325,8 @@ void TRDGeometry::createFrame(std::vector<int> const& idtmed)
   parBOX[2] = 2.00 / 2.0;
   createVolume("USC5", "BOX ", idtmed[1], parBOX, kNparBOX);
   xpos = 0.0;
-  ypos = fgkClength[5][2] / 2.0 + fgkClength[5][1] + fgkClength[5][0];
-  zpos = -fgkSheight / 2.0 + fgkSMpltT + 2.60;
+  ypos = CLENGTH[5][2] / 2.0 + CLENGTH[5][1] + CLENGTH[5][0];
+  zpos = -SHEIGHT / 2.0 + SMPLTT + 2.60;
   TVirtualMC::GetMC()->Gspos("USC5", 1, "UTI1", xpos, ypos, zpos, 0, "ONLY");
   TVirtualMC::GetMC()->Gspos("USC5", 2, "UTI1", xpos, -ypos, zpos, 0, "ONLY");
   TVirtualMC::GetMC()->Gspos("USC5", 3, "UTI2", xpos, ypos, zpos, 0, "ONLY");
@@ -1341,8 +1341,8 @@ void TRDGeometry::createFrame(std::vector<int> const& idtmed)
   parBOX[2] = 1.60 / 2.0;
   createVolume("USC6", "BOX ", idtmed[1], parBOX, kNparBOX);
   xpos = 0.0;
-  ypos = fgkClength[5][2] / 2.0 + fgkClength[5][1] + fgkClength[5][0];
-  zpos = -fgkSheight / 2.0 + fgkSMpltT + 1.60 / 2.0;
+  ypos = CLENGTH[5][2] / 2.0 + CLENGTH[5][1] + CLENGTH[5][0];
+  zpos = -SHEIGHT / 2.0 + SMPLTT + 1.60 / 2.0;
   TVirtualMC::GetMC()->Gspos("USC6", 1, "UTI1", xpos, ypos, zpos, 0, "ONLY");
   TVirtualMC::GetMC()->Gspos("USC6", 2, "UTI1", xpos, -ypos, zpos, 0, "ONLY");
   TVirtualMC::GetMC()->Gspos("USC6", 3, "UTI2", xpos, ypos, zpos, 0, "ONLY");
@@ -1375,12 +1375,12 @@ void TRDGeometry::createFrame(std::vector<int> const& idtmed)
   const float kSCLposzUb = 0.3;
   // Vertical
   parSCL[0] = kSCLthkUa / 2.0;
-  parSCL[1] = fgkSlength / 2.0;
+  parSCL[1] = SLENGTH / 2.0;
   parSCL[2] = kSCLwidUa / 2.0;
   createVolume("USL1", "BOX ", idtmed[1], parSCL, kNparSCL);
-  xpos = fgkSwidth2 / 2.0 - fgkSMpltT - kSCLposxUa;
+  xpos = SWIDTH2 / 2.0 - SMPLTT - kSCLposxUa;
   ypos = 0.0;
-  zpos = fgkSheight / 2.0 - fgkSMpltT - kSCLposzUa;
+  zpos = SHEIGHT / 2.0 - SMPLTT - kSCLposzUa;
   TVirtualMC::GetMC()->Gspos("USL1", 1, "UTI1", xpos, ypos, zpos, matrix[0], "ONLY");
   TVirtualMC::GetMC()->Gspos("USL1", 3, "UTI4", xpos, ypos, zpos, matrix[0], "ONLY");
   xpos = -xpos;
@@ -1388,12 +1388,12 @@ void TRDGeometry::createFrame(std::vector<int> const& idtmed)
   TVirtualMC::GetMC()->Gspos("USL1", 4, "UTI4", xpos, ypos, zpos, matrix[1], "ONLY");
   // Horizontal
   parSCL[0] = kSCLwidUb / 2.0;
-  parSCL[1] = fgkSlength / 2.0;
+  parSCL[1] = SLENGTH / 2.0;
   parSCL[2] = kSCLthkUb / 2.0;
   createVolume("USL2", "BOX ", idtmed[1], parSCL, kNparSCL);
-  xpos = fgkSwidth2 / 2.0 - fgkSMpltT - kSCLposxUb;
+  xpos = SWIDTH2 / 2.0 - SMPLTT - kSCLposxUb;
   ypos = 0.0;
-  zpos = fgkSheight / 2.0 - fgkSMpltT - kSCLposzUb;
+  zpos = SHEIGHT / 2.0 - SMPLTT - kSCLposzUb;
   TVirtualMC::GetMC()->Gspos("USL2", 1, "UTI1", xpos, ypos, zpos, 0, "ONLY");
   TVirtualMC::GetMC()->Gspos("USL2", 3, "UTI2", xpos, ypos, zpos, 0, "ONLY");
   TVirtualMC::GetMC()->Gspos("USL2", 5, "UTI3", xpos, ypos, zpos, 0, "ONLY");
@@ -1418,7 +1418,7 @@ void TRDGeometry::createFrame(std::vector<int> const& idtmed)
   const float kSCLposzLb = kSCLthkLb / 2.0;
   // Vertical
   // Trapezoidal shape
-  parSCLb[0] = fgkSlength / 2.0;
+  parSCLb[0] = SLENGTH / 2.0;
   parSCLb[1] = 0.0;
   parSCLb[2] = 0.0;
   parSCLb[3] = kSCLwidLa / 2.0;
@@ -1430,9 +1430,9 @@ void TRDGeometry::createFrame(std::vector<int> const& idtmed)
   parSCLb[9] = kSCLthkLa / 2.0;
   parSCLb[10] = 5.0;
   createVolume("USL3", "TRAP", idtmed[1], parSCLb, kNparSCLb);
-  xpos = fgkSwidth1 / 2.0 - fgkSMpltT - kSCLposxLa;
+  xpos = SWIDTH1 / 2.0 - SMPLTT - kSCLposxLa;
   ypos = 0.0;
-  zpos = -fgkSheight / 2.0 + fgkSMpltT + kSCLposzLa;
+  zpos = -SHEIGHT / 2.0 + SMPLTT + kSCLposzLa;
   TVirtualMC::GetMC()->Gspos("USL3", 1, "UTI1", xpos, ypos, zpos, matrix[2], "ONLY");
   TVirtualMC::GetMC()->Gspos("USL3", 3, "UTI2", xpos, ypos, zpos, matrix[2], "ONLY");
   TVirtualMC::GetMC()->Gspos("USL3", 5, "UTI3", xpos, ypos, zpos, matrix[2], "ONLY");
@@ -1444,12 +1444,12 @@ void TRDGeometry::createFrame(std::vector<int> const& idtmed)
   TVirtualMC::GetMC()->Gspos("USL3", 8, "UTI4", xpos, ypos, zpos, matrix[3], "ONLY");
   // Horizontal part
   parSCL[0] = kSCLwidLb / 2.0;
-  parSCL[1] = fgkSlength / 2.0;
+  parSCL[1] = SLENGTH / 2.0;
   parSCL[2] = kSCLthkLb / 2.0;
   createVolume("USL4", "BOX ", idtmed[1], parSCL, kNparSCL);
-  xpos = fgkSwidth1 / 2.0 - fgkSMpltT - kSCLposxLb;
+  xpos = SWIDTH1 / 2.0 - SMPLTT - kSCLposxLb;
   ypos = 0.0;
-  zpos = -fgkSheight / 2.0 + fgkSMpltT + kSCLposzLb;
+  zpos = -SHEIGHT / 2.0 + SMPLTT + kSCLposzLb;
   TVirtualMC::GetMC()->Gspos("USL4", 1, "UTI1", xpos, ypos, zpos, 0, "ONLY");
   TVirtualMC::GetMC()->Gspos("USL4", 3, "UTI2", xpos, ypos, zpos, 0, "ONLY");
   TVirtualMC::GetMC()->Gspos("USL4", 5, "UTI3", xpos, ypos, zpos, 0, "ONLY");
@@ -1466,13 +1466,13 @@ void TRDGeometry::createFrame(std::vector<int> const& idtmed)
 
   const int kNparTrd = 4;
   float parTrd[kNparTrd];
-  parTrd[0] = fgkSwidth1 / 2.0 - 2.5;
-  parTrd[1] = fgkSwidth2 / 2.0 - 2.5;
-  parTrd[2] = fgkSMpltT / 2.0;
-  parTrd[3] = fgkSheight / 2.0 - 1.0;
+  parTrd[0] = SWIDTH1 / 2.0 - 2.5;
+  parTrd[1] = SWIDTH2 / 2.0 - 2.5;
+  parTrd[2] = SMPLTT / 2.0;
+  parTrd[3] = SHEIGHT / 2.0 - 1.0;
   createVolume("UTA1", "TRD1", idtmed[1], parTrd, kNparTrd);
   xpos = 0.0;
-  ypos = fgkSMpltT / 2.0 - fgkFlength / 2.0;
+  ypos = SMPLTT / 2.0 - FLENGTH / 2.0;
   zpos = -0.5;
   TVirtualMC::GetMC()->Gspos("UTA1", 1, "UTF1", xpos, ypos, zpos, 0, "ONLY");
   TVirtualMC::GetMC()->Gspos("UTA1", 2, "UTF2", xpos, -ypos, zpos, 0, "ONLY");
@@ -1485,17 +1485,17 @@ void TRDGeometry::createFrame(std::vector<int> const& idtmed)
   createVolume("UTA2", "BOX ", idtmed[1], parPlt, 0);
   xpos = 0.0;
   ypos = 0.0;
-  zpos = fgkSheight / 2.0 - fgkSMpltT / 2.0;
-  parPlt[0] = fgkSwidth2 / 2.0 - 0.2;
-  parPlt[1] = fgkFlength / 2.0;
-  parPlt[2] = fgkSMpltT / 2.0;
+  zpos = SHEIGHT / 2.0 - SMPLTT / 2.0;
+  parPlt[0] = SWIDTH2 / 2.0 - 0.2;
+  parPlt[1] = FLENGTH / 2.0;
+  parPlt[2] = SMPLTT / 2.0;
   TVirtualMC::GetMC()->Gsposp("UTA2", 1, "UTF2", xpos, ypos, zpos, 0, "ONLY", parPlt, kNparPlt);
-  xpos = (fgkSwidth1 + fgkSwidth2) / 4.0 - fgkSMpltT / 2.0 - 0.0016;
+  xpos = (SWIDTH1 + SWIDTH2) / 4.0 - SMPLTT / 2.0 - 0.0016;
   ypos = 0.0;
   zpos = 0.0;
-  parPlt[0] = fgkSMpltT / 2.0;
-  parPlt[1] = fgkFlength / 2.0;
-  parPlt[2] = fgkSheight / 2.0;
+  parPlt[0] = SMPLTT / 2.0;
+  parPlt[1] = FLENGTH / 2.0;
+  parPlt[2] = SHEIGHT / 2.0;
   TVirtualMC::GetMC()->Gsposp("UTA2", 2, "UTF2", xpos, ypos, zpos, matrix[0], "ONLY", parPlt, kNparPlt);
   TVirtualMC::GetMC()->Gsposp("UTA2", 3, "UTF2", -xpos, ypos, zpos, matrix[1], "ONLY", parPlt, kNparPlt);
 
@@ -1505,8 +1505,8 @@ void TRDGeometry::createFrame(std::vector<int> const& idtmed)
   parBOX[2] = 10.0 / 2.0;
   createVolume("UTA3", "BOX ", idtmed[1], parBOX, kNparBOX);
   xpos = 0.0;
-  ypos = 1.0 / 2.0 + fgkSMpltT - fgkFlength / 2.0;
-  zpos = fgkSheight / 2.0 - 1.5 - 10.0 / 2.0;
+  ypos = 1.0 / 2.0 + SMPLTT - FLENGTH / 2.0;
+  zpos = SHEIGHT / 2.0 - 1.5 - 10.0 / 2.0;
   TVirtualMC::GetMC()->Gspos("UTA3", 1, "UTF1", xpos, ypos, zpos, 0, "ONLY");
   TVirtualMC::GetMC()->Gspos("UTA3", 2, "UTF2", xpos, -ypos, zpos, 0, "ONLY");
 }
@@ -1603,12 +1603,12 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
 
   for (ilayer = 1; ilayer < kNlayer; ilayer++) {
     // Along the chambers
-    xpos = fgkCwidth[ilayer] / 2.0 + kCOLwid / 2.0 + kCOLposx;
+    xpos = CWIDTH[ilayer] / 2.0 + kCOLwid / 2.0 + kCOLposx;
     ypos = 0.0;
     zpos =
-      fgkVrocsm + fgkSMpltT - fgkCalZpos + kCOLhgt / 2.0 - fgkSheight / 2.0 + kCOLposz + ilayer * (fgkCH + fgkVspace);
+      VROCSM + SMPLTT - CALZPOS + kCOLhgt / 2.0 - SHEIGHT / 2.0 + kCOLposz + ilayer * (CH + VSPACE);
     parCOL[0] = kCOLwid / 2.0;
-    parCOL[1] = fgkSlength / 2.0;
+    parCOL[1] = SLENGTH / 2.0;
     parCOL[2] = kCOLhgt / 2.0;
     TVirtualMC::GetMC()->Gsposp("UTC1", ilayer, "UTI1", xpos, ypos, zpos, matrix[0], "ONLY", parCOL, kNparCOL);
     TVirtualMC::GetMC()->Gsposp("UTC1", ilayer + kNlayer, "UTI1", -xpos, ypos, zpos, matrix[1], "ONLY", parCOL,
@@ -1627,12 +1627,12 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
                                 kNparCOL);
 
     // Front of supermodules
-    xpos = fgkCwidth[ilayer] / 2.0 + kCOLwid / 2.0 + kCOLposx;
+    xpos = CWIDTH[ilayer] / 2.0 + kCOLwid / 2.0 + kCOLposx;
     ypos = 0.0;
     zpos =
-      fgkVrocsm + fgkSMpltT - fgkCalZpos + kCOLhgt / 2.0 - fgkSheight / 2.0 + kCOLposz + ilayer * (fgkCH + fgkVspace);
+      VROCSM + SMPLTT - CALZPOS + kCOLhgt / 2.0 - SHEIGHT / 2.0 + kCOLposz + ilayer * (CH + VSPACE);
     parCOL[0] = kCOLwid / 2.0;
-    parCOL[1] = fgkFlength / 2.0;
+    parCOL[1] = FLENGTH / 2.0;
     parCOL[2] = kCOLhgt / 2.0;
     TVirtualMC::GetMC()->Gsposp("UTC3", ilayer + 2 * kNlayer, "UTF1", xpos, ypos, zpos, matrix[0], "ONLY", parCOL,
                                 kNparCOL);
@@ -1646,10 +1646,10 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
 
   for (ilayer = 1; ilayer < kNlayer; ilayer++) {
     // In baby frame
-    xpos = fgkCwidth[ilayer] / 2.0 + kCOLwid / 2.0 + kCOLposx - 2.5;
+    xpos = CWIDTH[ilayer] / 2.0 + kCOLwid / 2.0 + kCOLposx - 2.5;
     ypos = kBBSdz / 2.0 - kBBMdz / 2.0;
     zpos =
-      fgkVrocsm + fgkSMpltT - fgkCalZpos + kCOLhgt / 2.0 - fgkSheight / 2.0 + kCOLposz + ilayer * (fgkCH + fgkVspace);
+      VROCSM + SMPLTT - CALZPOS + kCOLhgt / 2.0 - SHEIGHT / 2.0 + kCOLposz + ilayer * (CH + VSPACE);
     parCOL[0] = kCOLwid / 2.0;
     parCOL[1] = kBBSdz / 2.0;
     parCOL[2] = kCOLhgt / 2.0;
@@ -1661,10 +1661,10 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
 
   for (ilayer = 1; ilayer < kNlayer; ilayer++) {
     // In back frame
-    xpos = fgkCwidth[ilayer] / 2.0 + kCOLwid / 2.0 + kCOLposx - 0.3;
+    xpos = CWIDTH[ilayer] / 2.0 + kCOLwid / 2.0 + kCOLposx - 0.3;
     ypos = -kBFSdz / 2.0 + kBFMdz / 2.0;
     zpos =
-      fgkVrocsm + fgkSMpltT - fgkCalZpos + kCOLhgt / 2.0 - fgkSheight / 2.0 + kCOLposz + ilayer * (fgkCH + fgkVspace);
+      VROCSM + SMPLTT - CALZPOS + kCOLhgt / 2.0 - SHEIGHT / 2.0 + kCOLposz + ilayer * (CH + VSPACE);
     parCOL[0] = kCOLwid / 2.0;
     parCOL[1] = kBFSdz / 2.0;
     parCOL[2] = kCOLhgt / 2.0;
@@ -1676,11 +1676,11 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
 
   // The upper most layer
   // Along the chambers
-  xpos = fgkCwidth[5] / 2.0 - kCOLhgt / 2.0 - 1.3;
+  xpos = CWIDTH[5] / 2.0 - kCOLhgt / 2.0 - 1.3;
   ypos = 0.0;
-  zpos = fgkSheight / 2.0 - fgkSMpltT - 0.4 - kCOLwid / 2.0;
+  zpos = SHEIGHT / 2.0 - SMPLTT - 0.4 - kCOLwid / 2.0;
   parCOL[0] = kCOLwid / 2.0;
-  parCOL[1] = fgkSlength / 2.0;
+  parCOL[1] = SLENGTH / 2.0;
   parCOL[2] = kCOLhgt / 2.0;
   TVirtualMC::GetMC()->Gsposp("UTC1", 6, "UTI1", xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
   TVirtualMC::GetMC()->Gsposp("UTC1", 6 + kNlayer, "UTI1", -xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
@@ -1691,29 +1691,29 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
   TVirtualMC::GetMC()->Gsposp("UTC1", 6 + 10 * kNlayer, "UTI4", xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
   TVirtualMC::GetMC()->Gsposp("UTC1", 6 + 11 * kNlayer, "UTI4", -xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
   // Front of supermodules
-  xpos = fgkCwidth[5] / 2.0 - kCOLhgt / 2.0 - 1.3;
+  xpos = CWIDTH[5] / 2.0 - kCOLhgt / 2.0 - 1.3;
   ypos = 0.0;
-  zpos = fgkSheight / 2.0 - fgkSMpltT - 0.4 - kCOLwid / 2.0;
+  zpos = SHEIGHT / 2.0 - SMPLTT - 0.4 - kCOLwid / 2.0;
   parCOL[0] = kCOLwid / 2.0;
-  parCOL[1] = fgkFlength / 2.0;
+  parCOL[1] = FLENGTH / 2.0;
   parCOL[2] = kCOLhgt / 2.0;
   TVirtualMC::GetMC()->Gsposp("UTC3", 6 + 2 * kNlayer, "UTF1", xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
   TVirtualMC::GetMC()->Gsposp("UTC3", 6 + 3 * kNlayer, "UTF1", -xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
   TVirtualMC::GetMC()->Gsposp("UTC3", 6 + 4 * kNlayer, "UTF2", xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
   TVirtualMC::GetMC()->Gsposp("UTC3", 6 + 5 * kNlayer, "UTF2", -xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
   // In baby frame
-  xpos = fgkCwidth[5] / 2.0 - kCOLhgt / 2.0 - 3.1;
+  xpos = CWIDTH[5] / 2.0 - kCOLhgt / 2.0 - 3.1;
   ypos = kBBSdz / 2.0 - kBBMdz / 2.0;
-  zpos = fgkSheight / 2.0 - fgkSMpltT - 0.4 - kCOLwid / 2.0;
+  zpos = SHEIGHT / 2.0 - SMPLTT - 0.4 - kCOLwid / 2.0;
   parCOL[0] = kCOLwid / 2.0;
   parCOL[1] = kBBSdz / 2.0;
   parCOL[2] = kCOLhgt / 2.0;
   TVirtualMC::GetMC()->Gsposp("UTC3", 6 + 6 * kNlayer, "BBTRD", xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
   TVirtualMC::GetMC()->Gsposp("UTC3", 6 + 7 * kNlayer, "BBTRD", -xpos, ypos, zpos, matrix[3], "ONLY", parCOL, kNparCOL);
   // In back frame
-  xpos = fgkCwidth[5] / 2.0 - kCOLhgt / 2.0 - 1.3;
+  xpos = CWIDTH[5] / 2.0 - kCOLhgt / 2.0 - 1.3;
   ypos = -kBFSdz / 2.0 + kBFMdz / 2.0;
-  zpos = fgkSheight / 2.0 - fgkSMpltT - 0.4 - kCOLwid / 2.0;
+  zpos = SHEIGHT / 2.0 - SMPLTT - 0.4 - kCOLwid / 2.0;
   parCOL[0] = kCOLwid / 2.0;
   parCOL[1] = kBFSdz / 2.0;
   parCOL[2] = kCOLhgt / 2.0;
@@ -1741,12 +1741,12 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
 
   for (ilayer = 1; ilayer < kNlayer; ilayer++) {
     // Along the chambers
-    xpos = fgkCwidth[ilayer] / 2.0 + kPWRwid / 2.0 + kPWRposx;
+    xpos = CWIDTH[ilayer] / 2.0 + kPWRwid / 2.0 + kPWRposx;
     ypos = 0.0;
     zpos =
-      fgkVrocsm + fgkSMpltT - fgkCalZpos + kPWRhgtA / 2.0 - fgkSheight / 2.0 + kPWRposz + ilayer * (fgkCH + fgkVspace);
+      VROCSM + SMPLTT - CALZPOS + kPWRhgtA / 2.0 - SHEIGHT / 2.0 + kPWRposz + ilayer * (CH + VSPACE);
     parPWR[0] = kPWRwid / 2.0;
-    parPWR[1] = fgkSlength / 2.0;
+    parPWR[1] = SLENGTH / 2.0;
     parPWR[2] = kPWRhgtA / 2.0;
     TVirtualMC::GetMC()->Gsposp("UTP1", ilayer, "UTI1", xpos, ypos, zpos, matrix[0], "ONLY", parPWR, kNparPWR);
     TVirtualMC::GetMC()->Gsposp("UTP1", ilayer + kNlayer, "UTI1", -xpos, ypos, zpos, matrix[1], "ONLY", parPWR,
@@ -1765,12 +1765,12 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
                                 kNparPWR);
 
     // Front of supermodule
-    xpos = fgkCwidth[ilayer] / 2.0 + kPWRwid / 2.0 + kPWRposx;
+    xpos = CWIDTH[ilayer] / 2.0 + kPWRwid / 2.0 + kPWRposx;
     ypos = 0.0;
     zpos =
-      fgkVrocsm + fgkSMpltT - fgkCalZpos + kPWRhgtA / 2.0 - fgkSheight / 2.0 + kPWRposz + ilayer * (fgkCH + fgkVspace);
+      VROCSM + SMPLTT - CALZPOS + kPWRhgtA / 2.0 - SHEIGHT / 2.0 + kPWRposz + ilayer * (CH + VSPACE);
     parPWR[0] = kPWRwid / 2.0;
-    parPWR[1] = fgkFlength / 2.0;
+    parPWR[1] = FLENGTH / 2.0;
     parPWR[2] = kPWRhgtA / 2.0;
     TVirtualMC::GetMC()->Gsposp("UTP3", ilayer + 2 * kNlayer, "UTF1", xpos, ypos, zpos, matrix[0], "ONLY", parPWR,
                                 kNparPWR);
@@ -1784,10 +1784,10 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
 
   for (ilayer = 1; ilayer < kNlayer; ilayer++) {
     // In baby frame
-    xpos = fgkCwidth[ilayer] / 2.0 + kPWRwid / 2.0 + kPWRposx - 2.5;
+    xpos = CWIDTH[ilayer] / 2.0 + kPWRwid / 2.0 + kPWRposx - 2.5;
     ypos = kBBSdz / 2.0 - kBBMdz / 2.0;
     zpos =
-      fgkVrocsm + fgkSMpltT - fgkCalZpos + kPWRhgtB / 2.0 - fgkSheight / 2.0 + kPWRposz + ilayer * (fgkCH + fgkVspace);
+      VROCSM + SMPLTT - CALZPOS + kPWRhgtB / 2.0 - SHEIGHT / 2.0 + kPWRposz + ilayer * (CH + VSPACE);
     parPWR[0] = kPWRwid / 2.0;
     parPWR[1] = kBBSdz / 2.0;
     parPWR[2] = kPWRhgtB / 2.0;
@@ -1799,10 +1799,10 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
 
   for (ilayer = 1; ilayer < kNlayer; ilayer++) {
     // In back frame
-    xpos = fgkCwidth[ilayer] / 2.0 + kPWRwid / 2.0 + kPWRposx - 0.3;
+    xpos = CWIDTH[ilayer] / 2.0 + kPWRwid / 2.0 + kPWRposx - 0.3;
     ypos = -kBFSdz / 2.0 + kBFMdz / 2.0;
     zpos =
-      fgkVrocsm + fgkSMpltT - fgkCalZpos + kPWRhgtB / 2.0 - fgkSheight / 2.0 + kPWRposz + ilayer * (fgkCH + fgkVspace);
+      VROCSM + SMPLTT - CALZPOS + kPWRhgtB / 2.0 - SHEIGHT / 2.0 + kPWRposz + ilayer * (CH + VSPACE);
     parPWR[0] = kPWRwid / 2.0;
     parPWR[1] = kBFSdz / 2.0;
     parPWR[2] = kPWRhgtB / 2.0;
@@ -1814,11 +1814,11 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
 
   // The upper most layer
   // Along the chambers
-  xpos = fgkCwidth[5] / 2.0 + kPWRhgtB / 2.0 - 1.3;
+  xpos = CWIDTH[5] / 2.0 + kPWRhgtB / 2.0 - 1.3;
   ypos = 0.0;
-  zpos = fgkSheight / 2.0 - fgkSMpltT - 0.6 - kPWRwid / 2.0;
+  zpos = SHEIGHT / 2.0 - SMPLTT - 0.6 - kPWRwid / 2.0;
   parPWR[0] = kPWRwid / 2.0;
-  parPWR[1] = fgkSlength / 2.0;
+  parPWR[1] = SLENGTH / 2.0;
   parPWR[2] = kPWRhgtB / 2.0;
   TVirtualMC::GetMC()->Gsposp("UTP1", 6, "UTI1", xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
   TVirtualMC::GetMC()->Gsposp("UTP1", 6 + kNlayer, "UTI1", -xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
@@ -1829,29 +1829,29 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
   TVirtualMC::GetMC()->Gsposp("UTP1", 6 + 10 * kNlayer, "UTI4", xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
   TVirtualMC::GetMC()->Gsposp("UTP1", 6 + 11 * kNlayer, "UTI4", -xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
   // Front of supermodules
-  xpos = fgkCwidth[5] / 2.0 + kPWRhgtB / 2.0 - 1.3;
+  xpos = CWIDTH[5] / 2.0 + kPWRhgtB / 2.0 - 1.3;
   ypos = 0.0;
-  zpos = fgkSheight / 2.0 - fgkSMpltT - 0.6 - kPWRwid / 2.0;
+  zpos = SHEIGHT / 2.0 - SMPLTT - 0.6 - kPWRwid / 2.0;
   parPWR[0] = kPWRwid / 2.0;
-  parPWR[1] = fgkFlength / 2.0;
+  parPWR[1] = FLENGTH / 2.0;
   parPWR[2] = kPWRhgtB / 2.0;
   TVirtualMC::GetMC()->Gsposp("UTP3", 6 + 2 * kNlayer, "UTF1", xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
   TVirtualMC::GetMC()->Gsposp("UTP3", 6 + 3 * kNlayer, "UTF1", -xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
   TVirtualMC::GetMC()->Gsposp("UTP3", 6 + 4 * kNlayer, "UTF2", xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
   TVirtualMC::GetMC()->Gsposp("UTP3", 6 + 5 * kNlayer, "UTF2", -xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
   // In baby frame
-  xpos = fgkCwidth[5] / 2.0 + kPWRhgtB / 2.0 - 3.0;
+  xpos = CWIDTH[5] / 2.0 + kPWRhgtB / 2.0 - 3.0;
   ypos = kBBSdz / 2.0 - kBBMdz / 2.0;
-  zpos = fgkSheight / 2.0 - fgkSMpltT - 0.6 - kPWRwid / 2.0;
+  zpos = SHEIGHT / 2.0 - SMPLTT - 0.6 - kPWRwid / 2.0;
   parPWR[0] = kPWRwid / 2.0;
   parPWR[1] = kBBSdz / 2.0;
   parPWR[2] = kPWRhgtB / 2.0;
   TVirtualMC::GetMC()->Gsposp("UTP3", 6 + 6 * kNlayer, "BBTRD", xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
   TVirtualMC::GetMC()->Gsposp("UTP3", 6 + 7 * kNlayer, "BBTRD", -xpos, ypos, zpos, matrix[3], "ONLY", parPWR, kNparPWR);
   // In back frame
-  xpos = fgkCwidth[5] / 2.0 + kPWRhgtB / 2.0 - 1.3;
+  xpos = CWIDTH[5] / 2.0 + kPWRhgtB / 2.0 - 1.3;
   ypos = -kBFSdz / 2.0 + kBFMdz / 2.0;
-  zpos = fgkSheight / 2.0 - fgkSMpltT - 0.6 - kPWRwid / 2.0;
+  zpos = SHEIGHT / 2.0 - SMPLTT - 0.6 - kPWRwid / 2.0;
   parPWR[0] = kPWRwid / 2.0;
   parPWR[1] = kBFSdz / 2.0;
   parPWR[2] = kPWRhgtB / 2.0;
@@ -1866,39 +1866,39 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
   // PHOS holes
   parTube[0] = 0.0;
   parTube[1] = 2.2 / 2.0;
-  parTube[2] = fgkClength[5][2] / 2.0 - fgkHspace / 2.0;
+  parTube[2] = CLENGTH[5][2] / 2.0 - HSPACE / 2.0;
   createVolume("UTG1", "TUBE", idtmed[8], parTube, kNparTube);
   parTube[0] = 0.0;
   parTube[1] = 2.1 / 2.0;
-  parTube[2] = fgkClength[5][2] / 2.0 - fgkHspace / 2.0;
+  parTube[2] = CLENGTH[5][2] / 2.0 - HSPACE / 2.0;
   createVolume("UTG2", "TUBE", idtmed[9], parTube, kNparTube);
   xpos = 0.0;
   ypos = 0.0;
   zpos = 0.0;
   TVirtualMC::GetMC()->Gspos("UTG2", 1, "UTG1", xpos, ypos, zpos, 0, "ONLY");
   for (ilayer = 0; ilayer < kNlayer; ilayer++) {
-    xpos = fgkCwidth[ilayer] / 2.0 + kCOLwid / 2.0 - 1.5;
+    xpos = CWIDTH[ilayer] / 2.0 + kCOLwid / 2.0 - 1.5;
     ypos = 0.0;
-    zpos = fgkVrocsm + fgkSMpltT + kCOLhgt / 2.0 - fgkSheight / 2.0 + 5.0 + ilayer * (fgkCH + fgkVspace);
+    zpos = VROCSM + SMPLTT + kCOLhgt / 2.0 - SHEIGHT / 2.0 + 5.0 + ilayer * (CH + VSPACE);
     TVirtualMC::GetMC()->Gspos("UTG1", 1 + ilayer, "UTI3", xpos, ypos, zpos, matrix[4], "ONLY");
     TVirtualMC::GetMC()->Gspos("UTG1", 7 + ilayer, "UTI3", -xpos, ypos, zpos, matrix[4], "ONLY");
   }
   // Missing L4S4 chamber in sector 17
   parTube[0] = 0.0;
   parTube[1] = 2.2 / 2.0;
-  parTube[2] = fgkClength[4][4] / 2.0 - fgkHspace / 2.0;
+  parTube[2] = CLENGTH[4][4] / 2.0 - HSPACE / 2.0;
   createVolume("UTG3", "TUBE", idtmed[8], parTube, kNparTube);
   parTube[0] = 0.0;
   parTube[1] = 2.1 / 2.0;
-  parTube[2] = fgkClength[4][4] / 2.0 - fgkHspace / 2.0;
+  parTube[2] = CLENGTH[4][4] / 2.0 - HSPACE / 2.0;
   createVolume("UTG4", "TUBE", idtmed[9], parTube, kNparTube);
   xpos = 0.0;
   ypos = 0.0;
   zpos = 0.0;
   TVirtualMC::GetMC()->Gspos("UTG4", 1, "UTG3", xpos, ypos, zpos, 0, "ONLY");
-  xpos = fgkCwidth[4] / 2.0 + kCOLwid / 2.0 - 1.5;
-  ypos = -fgkClength[4][0] / 2.0 - fgkClength[4][1] - fgkClength[4][2] / 2.0;
-  zpos = fgkVrocsm + fgkSMpltT + kCOLhgt / 2.0 - fgkSheight / 2.0 + 5.0 + 4 * (fgkCH + fgkVspace);
+  xpos = CWIDTH[4] / 2.0 + kCOLwid / 2.0 - 1.5;
+  ypos = -CLENGTH[4][0] / 2.0 - CLENGTH[4][1] - CLENGTH[4][2] / 2.0;
+  zpos = VROCSM + SMPLTT + kCOLhgt / 2.0 - SHEIGHT / 2.0 + 5.0 + 4 * (CH + VSPACE);
   TVirtualMC::GetMC()->Gspos("UTG3", 1, "UTI4", xpos, ypos, zpos, matrix[4], "ONLY");
   TVirtualMC::GetMC()->Gspos("UTG4", 2, "UTI4", -xpos, ypos, zpos, matrix[4], "ONLY");
 
@@ -1914,9 +1914,9 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
       int iDet = getDetectorSec(ilayer, istack);
 
       snprintf(cTagV, kTag, "UU%02d", iDet);
-      parServ[0] = fgkCwidth[ilayer] / 2.0;
-      parServ[1] = fgkClength[ilayer][istack] / 2.0 - fgkHspace / 2.0;
-      parServ[2] = fgkCsvH / 2.0;
+      parServ[0] = CWIDTH[ilayer] / 2.0;
+      parServ[1] = CLENGTH[ilayer][istack] / 2.0 - HSPACE / 2.0;
+      parServ[2] = CSVH / 2.0;
       createVolume(cTagV, "BOX", idtmed[2], parServ, kNparServ);
     }
   }
@@ -1947,16 +1947,16 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
       int iDet = getDetectorSec(ilayer, istack);
       int iCopy = getDetector(ilayer, istack, 0) * 100;
       int nMCMrow = getRowMax(ilayer, istack, 0);
-      float ySize = (getChamberLength(ilayer, istack) - 2.0 * fgkRpadW) / ((float)nMCMrow);
+      float ySize = (getChamberLength(ilayer, istack) - 2.0 * RPADW) / ((float)nMCMrow);
       snprintf(cTagV, kTag, "UU%02d", iDet);
       for (int iMCMrow = 0; iMCMrow < nMCMrow; iMCMrow++) {
         xpos = 0.0;
-        ypos = (0.5 + iMCMrow) * ySize - fgkClength[ilayer][istack] / 2.0 + fgkHspace / 2.0;
+        ypos = (0.5 + iMCMrow) * ySize - CLENGTH[ilayer][istack] / 2.0 + HSPACE / 2.0;
         zpos = 0.0 + 0.742 / 2.0;
         // The cooling pipes
         parTube[0] = 0.0;
         parTube[1] = 0.3 / 2.0; // Thickness of the cooling pipes
-        parTube[2] = fgkCwidth[ilayer] / 2.0;
+        parTube[2] = CWIDTH[ilayer] / 2.0;
         TVirtualMC::GetMC()->Gsposp("UTCP", iCopy + iMCMrow, cTagV, xpos, ypos, zpos, matrix[2], "ONLY", parTube,
                                     kNparTube);
       }
@@ -1979,15 +1979,15 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
       int iDet = getDetectorSec(ilayer, istack);
       int iCopy = getDetector(ilayer, istack, 0) * 100;
       int nMCMrow = getRowMax(ilayer, istack, 0);
-      float ySize = (getChamberLength(ilayer, istack) - 2.0 * fgkRpadW) / ((float)nMCMrow);
+      float ySize = (getChamberLength(ilayer, istack) - 2.0 * RPADW) / ((float)nMCMrow);
       snprintf(cTagV, kTag, "UU%02d", iDet);
       for (int iMCMrow = 0; iMCMrow < nMCMrow; iMCMrow++) {
         xpos = 0.0;
-        ypos = (0.5 + iMCMrow) * ySize - 1.0 - fgkClength[ilayer][istack] / 2.0 + fgkHspace / 2.0;
+        ypos = (0.5 + iMCMrow) * ySize - 1.0 - CLENGTH[ilayer][istack] / 2.0 + HSPACE / 2.0;
         zpos = -0.4 + 0.742 / 2.0;
         parTube[0] = 0.0;
         parTube[1] = 0.2 / 2.0; // Thickness of the power lines
-        parTube[2] = fgkCwidth[ilayer] / 2.0;
+        parTube[2] = CWIDTH[ilayer] / 2.0;
         TVirtualMC::GetMC()->Gsposp("UTPL", iCopy + iMCMrow, cTagV, xpos, ypos, zpos, matrix[2], "ONLY", parTube,
                                     kNparTube);
       }
@@ -2054,21 +2054,21 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
       int iDet = getDetectorSec(ilayer, istack);
       int iCopy = getDetector(ilayer, istack, 0) * 1000;
       int nMCMrow = getRowMax(ilayer, istack, 0);
-      float ySize = (getChamberLength(ilayer, istack) - 2.0 * fgkRpadW) / ((float)nMCMrow);
+      float ySize = (getChamberLength(ilayer, istack) - 2.0 * RPADW) / ((float)nMCMrow);
       int nMCMcol = 8;
-      float xSize = (getChamberWidth(ilayer) - 2.0 * fgkCpadW) / ((float)nMCMcol + 6); // Introduce 6 gaps
+      float xSize = (getChamberWidth(ilayer) - 2.0 * CPADW) / ((float)nMCMcol + 6);    // Introduce 6 gaps
       int iMCM[8] = { 1, 2, 3, 5, 8, 9, 10, 12 };                                      // 0..7 MCM + 6 gap structure
       snprintf(cTagV, kTag, "UU%02d", iDet);
       for (int iMCMrow = 0; iMCMrow < nMCMrow; iMCMrow++) {
         for (int iMCMcol = 0; iMCMcol < nMCMcol; iMCMcol++) {
-          xpos = (0.5 + iMCM[iMCMcol]) * xSize + 1.0 - fgkCwidth[ilayer] / 2.0;
-          ypos = (0.5 + iMCMrow) * ySize + 1.0 - fgkClength[ilayer][istack] / 2.0 + fgkHspace / 2.0;
+          xpos = (0.5 + iMCM[iMCMcol]) * xSize + 1.0 - CWIDTH[ilayer] / 2.0;
+          ypos = (0.5 + iMCMrow) * ySize + 1.0 - CLENGTH[ilayer][istack] / 2.0 + HSPACE / 2.0;
           zpos = -0.4 + 0.742 / 2.0;
           TVirtualMC::GetMC()->Gspos("UMCM", iCopy + iMCMrow * 10 + iMCMcol, cTagV, xpos, ypos, zpos, 0, "ONLY");
           // Add two additional smaller cooling pipes on top of the MCMs
           // to mimic the meandering structure
-          xpos = (0.5 + iMCM[iMCMcol]) * xSize + 1.0 - fgkCwidth[ilayer] / 2.0;
-          ypos = (0.5 + iMCMrow) * ySize - fgkClength[ilayer][istack] / 2.0 + fgkHspace / 2.0;
+          xpos = (0.5 + iMCM[iMCMcol]) * xSize + 1.0 - CWIDTH[ilayer] / 2.0;
+          ypos = (0.5 + iMCMrow) * ySize - CLENGTH[ilayer][istack] / 2.0 + HSPACE / 2.0;
           zpos = 0.0 + 0.742 / 2.0;
           parTube[0] = 0.0;
           parTube[1] = 0.3 / 2.0; // Thickness of the cooling pipes
@@ -2133,10 +2133,10 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
     for (ilayer = 0; ilayer < kNlayer; ilayer++) {
       int iDet = getDetectorSec(ilayer, istack);
       int iCopy = iDet + 1;
-      xpos = fgkCwidth[ilayer] / 2.0 -
-             1.9 * (getChamberLength(ilayer, istack) - 2.0 * fgkRpadW) / ((float)getRowMax(ilayer, istack, 0));
-      ypos = 0.05 * fgkClength[ilayer][istack];
-      zpos = kDCSz / 2.0 - fgkCsvH / 2.0;
+      xpos = CWIDTH[ilayer] / 2.0 -
+             1.9 * (getChamberLength(ilayer, istack) - 2.0 * RPADW) / ((float)getRowMax(ilayer, istack, 0));
+      ypos = 0.05 * CLENGTH[ilayer][istack];
+      zpos = kDCSz / 2.0 - CSVH / 2.0;
       snprintf(cTagV, kTag, "UU%02d", iDet);
       TVirtualMC::GetMC()->Gspos("UDCS", iCopy, cTagV, xpos, ypos, zpos, 0, "ONLY");
     }
@@ -2193,16 +2193,16 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
     for (ilayer = 0; ilayer < kNlayer; ilayer++) {
       int iDet = getDetectorSec(ilayer, istack);
       int iCopy = iDet + 1;
-      xpos = fgkCwidth[ilayer] / 2.0 -
-             1.92 * (getChamberLength(ilayer, istack) - 2.0 * fgkRpadW) / ((float)getRowMax(ilayer, istack, 0));
+      xpos = CWIDTH[ilayer] / 2.0 -
+             1.92 * (getChamberLength(ilayer, istack) - 2.0 * RPADW) / ((float)getRowMax(ilayer, istack, 0));
       ypos = -16.0;
-      zpos = kORIz / 2.0 - fgkCsvH / 2.0;
+      zpos = kORIz / 2.0 - CSVH / 2.0;
       snprintf(cTagV, kTag, "UU%02d", iDet);
       TVirtualMC::GetMC()->Gspos("UORI", iCopy, cTagV, xpos, ypos, zpos, 0, "ONLY");
-      xpos = -fgkCwidth[ilayer] / 2.0 +
-             3.8 * (getChamberLength(ilayer, istack) - 2.0 * fgkRpadW) / ((float)getRowMax(ilayer, istack, 0));
+      xpos = -CWIDTH[ilayer] / 2.0 +
+             3.8 * (getChamberLength(ilayer, istack) - 2.0 * RPADW) / ((float)getRowMax(ilayer, istack, 0));
       ypos = -16.0;
-      zpos = kORIz / 2.0 - fgkCsvH / 2.0;
+      zpos = kORIz / 2.0 - CSVH / 2.0;
       snprintf(cTagV, kTag, "UU%02d", iDet);
       TVirtualMC::GetMC()->Gspos("UORI", iCopy + kNdet, cTagV, xpos, ypos, zpos, 0, "ONLY");
     }
@@ -2228,11 +2228,11 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
   TVirtualMC::GetMC()->Gspos("UTG4", 1, "UTG3", xpos, ypos, zpos, 0, "ONLY");
   for (ilayer = 0; ilayer < kNlayer - 1; ilayer++) {
     xpos = 0.0;
-    ypos = fgkClength[ilayer][2] / 2.0 + fgkClength[ilayer][1] + fgkClength[ilayer][0];
-    zpos = 9.0 - fgkSheight / 2.0 + ilayer * (fgkCH + fgkVspace);
+    ypos = CLENGTH[ilayer][2] / 2.0 + CLENGTH[ilayer][1] + CLENGTH[ilayer][0];
+    zpos = 9.0 - SHEIGHT / 2.0 + ilayer * (CH + VSPACE);
     parTube[0] = 0.0;
     parTube[1] = 1.5 / 2.0;
-    parTube[2] = fgkCwidth[ilayer] / 2.0 - 2.5;
+    parTube[2] = CWIDTH[ilayer] / 2.0 - 2.5;
     TVirtualMC::GetMC()->Gsposp("UTG3", ilayer + 1, "UTI1", xpos, ypos, zpos, matrix[2], "ONLY", parTube, kNparTube);
     TVirtualMC::GetMC()->Gsposp("UTG3", ilayer + 1 + 1 * kNlayer, "UTI1", xpos, -ypos, zpos, matrix[2], "ONLY", parTube,
                                 kNparTube);
@@ -2342,7 +2342,7 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
   TVirtualMC::GetMC()->Gspos("UTCO", 8, "UTCM", xpos, ypos, zpos, matrix[4], "ONLY");
 
   xpos = 40.0;
-  ypos = fgkFlength / 2.0 - 23.0 / 2.0;
+  ypos = FLENGTH / 2.0 - 23.0 / 2.0;
   zpos = 0.0;
   TVirtualMC::GetMC()->Gspos("UTCM", 1, "UTF1", xpos, ypos, zpos, matrix[0], "ONLY");
   TVirtualMC::GetMC()->Gspos("UTCM", 2, "UTF1", -xpos, ypos, zpos, matrix[1], "ONLY");
@@ -2355,15 +2355,15 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
   parBox[2] = 7.0 / 2.0;
   createVolume("UTPC", "BOX ", idtmed[25], parBox, kNparBox);
   for (ilayer = 0; ilayer < kNlayer - 1; ilayer++) {
-    xpos = fgkCwidth[ilayer] / 2.0 + kPWRwid / 2.0;
+    xpos = CWIDTH[ilayer] / 2.0 + kPWRwid / 2.0;
     ypos = 0.0;
-    zpos = fgkVrocsm + fgkSMpltT + kPWRhgtA / 2.0 - fgkSheight / 2.0 + kPWRposz + (ilayer + 1) * (fgkCH + fgkVspace);
+    zpos = VROCSM + SMPLTT + kPWRhgtA / 2.0 - SHEIGHT / 2.0 + kPWRposz + (ilayer + 1) * (CH + VSPACE);
     TVirtualMC::GetMC()->Gspos("UTPC", ilayer, "UTF1", xpos, ypos, zpos, matrix[0], "ONLY");
     TVirtualMC::GetMC()->Gspos("UTPC", ilayer + kNlayer, "UTF1", -xpos, ypos, zpos, matrix[1], "ONLY");
   }
-  xpos = fgkCwidth[5] / 2.0 + kPWRhgtA / 2.0 - 2.0;
+  xpos = CWIDTH[5] / 2.0 + kPWRhgtA / 2.0 - 2.0;
   ypos = 0.0;
-  zpos = fgkSheight / 2.0 - fgkSMpltT - 2.0;
+  zpos = SHEIGHT / 2.0 - SMPLTT - 2.0;
   TVirtualMC::GetMC()->Gspos("UTPC", 5, "UTF1", xpos, ypos, zpos, matrix[3], "ONLY");
   TVirtualMC::GetMC()->Gspos("UTPC", 5 + kNlayer, "UTF1", -xpos, ypos, zpos, matrix[3], "ONLY");
 
@@ -2396,8 +2396,8 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
   zpos = 0.0;
   TVirtualMC::GetMC()->Gspos("UTE2", 1, "UTE1", xpos, ypos, zpos, 0, "ONLY");
   xpos = 0.0;
-  ypos = fgkSlength / 2.0 - 10.0 / 2.0 - 3.0;
-  zpos = -fgkSheight / 2.0 + 6.0 / 2.0 + 1.0;
+  ypos = SLENGTH / 2.0 - 10.0 / 2.0 - 3.0;
+  zpos = -SHEIGHT / 2.0 + 6.0 / 2.0 + 1.0;
   TVirtualMC::GetMC()->Gspos("UTE1", 1, "UTI1", xpos, ypos, zpos, 0, "ONLY");
   TVirtualMC::GetMC()->Gspos("UTE1", 2, "UTI2", xpos, ypos, zpos, 0, "ONLY");
   TVirtualMC::GetMC()->Gspos("UTE1", 3, "UTI3", xpos, ypos, zpos, 0, "ONLY");
@@ -2418,8 +2418,8 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
   zpos = 0.0;
   TVirtualMC::GetMC()->Gspos("UTE4", 1, "UTE3", xpos, ypos, zpos, 0, "ONLY");
   xpos = 0.0;
-  ypos = -fgkSlength / 2.0 + 15.0 / 2.0 + 3.0;
-  zpos = -fgkSheight / 2.0 + 20.0 / 2.0 + 1.0;
+  ypos = -SLENGTH / 2.0 + 15.0 / 2.0 + 3.0;
+  zpos = -SHEIGHT / 2.0 + 20.0 / 2.0 + 1.0;
   TVirtualMC::GetMC()->Gspos("UTE3", 1, "UTI1", xpos, ypos, zpos, 0, "ONLY");
   TVirtualMC::GetMC()->Gspos("UTE3", 2, "UTI2", xpos, ypos, zpos, 0, "ONLY");
   TVirtualMC::GetMC()->Gspos("UTE3", 3, "UTI3", xpos, ypos, zpos, 0, "ONLY");
@@ -2440,7 +2440,7 @@ void TRDGeometry::createServices(std::vector<int> const& idtmed)
   zpos = 0.0;
   TVirtualMC::GetMC()->Gspos("UTE6", 1, "UTE5", xpos, ypos, zpos, 0, "ONLY");
   xpos = 20.0;
-  ypos = -fgkSlength / 2.0 + 7.0 / 2.0 + 3.0;
+  ypos = -SLENGTH / 2.0 + 7.0 / 2.0 + 3.0;
   zpos = 0.0;
   TVirtualMC::GetMC()->Gspos("UTE5", 1, "UTI1", xpos, ypos, zpos, 0, "ONLY");
   TVirtualMC::GetMC()->Gspos("UTE5", 2, "UTI2", xpos, ypos, zpos, 0, "ONLY");
@@ -2479,24 +2479,24 @@ void TRDGeometry::assembleChamber(int ilayer, int istack)
   // including radiator and drift region
   xpos = 0.0;
   ypos = 0.0;
-  zpos = fgkCraH / 2.0 + fgkCdrH / 2.0 - fgkCHsv / 2.0;
+  zpos = CRAH / 2.0 + CDRH / 2.0 - CHSV / 2.0;
   snprintf(cTagV, kTag, "UA%02d", idet);
   TGeoVolume* rocA = gGeoManager->GetVolume(cTagV);
   roc->AddNode(rocA, 1, new TGeoTranslation(xpos, ypos, zpos));
 
   // Add the additional aluminum ledges
-  xpos = fgkCwidth[ilayer] / 2.0 + fgkCalWmod / 2.0;
+  xpos = CWIDTH[ilayer] / 2.0 + CALWMOD / 2.0;
   ypos = 0.0;
-  zpos = fgkCraH + fgkCdrH - fgkCalZpos - fgkCalHmod / 2.0 - fgkCHsv / 2.0;
+  zpos = CRAH + CDRH - CALZPOS - CALHMOD / 2.0 - CHSV / 2.0;
   snprintf(cTagV, kTag, "UZ%02d", idet);
   TGeoVolume* rocZ = gGeoManager->GetVolume(cTagV);
   roc->AddNode(rocZ, 1, new TGeoTranslation(xpos, ypos, zpos));
   roc->AddNode(rocZ, 2, new TGeoTranslation(-xpos, ypos, zpos));
 
   // Add the additional wacosit ledges
-  xpos = fgkCwidth[ilayer] / 2.0 + fgkCwsW / 2.0;
+  xpos = CWIDTH[ilayer] / 2.0 + CWSW / 2.0;
   ypos = 0.0;
-  zpos = fgkCraH + fgkCdrH - fgkCwsH / 2.0 - fgkCHsv / 2.0;
+  zpos = CRAH + CDRH - CWSH / 2.0 - CHSV / 2.0;
   snprintf(cTagV, kTag, "UP%02d", idet);
   TGeoVolume* rocP = gGeoManager->GetVolume(cTagV);
   roc->AddNode(rocP, 1, new TGeoTranslation(xpos, ypos, zpos));
@@ -2506,7 +2506,7 @@ void TRDGeometry::assembleChamber(int ilayer, int istack)
   // including amplification region
   xpos = 0.0;
   ypos = 0.0;
-  zpos = fgkCamH / 2.0 + fgkCraH + fgkCdrH - fgkCHsv / 2.0;
+  zpos = CAMH / 2.0 + CRAH + CDRH - CHSV / 2.0;
   snprintf(cTagV, kTag, "UD%02d", idet);
   TGeoVolume* rocD = gGeoManager->GetVolume(cTagV);
   roc->AddNode(rocD, 1, new TGeoTranslation(xpos, ypos, zpos));
@@ -2515,7 +2515,7 @@ void TRDGeometry::assembleChamber(int ilayer, int istack)
   // including back panel and FEE
   xpos = 0.0;
   ypos = 0.0;
-  zpos = fgkCroH / 2.0 + fgkCamH + fgkCraH + fgkCdrH - fgkCHsv / 2.0;
+  zpos = CROH / 2.0 + CAMH + CRAH + CDRH - CHSV / 2.0;
   snprintf(cTagV, kTag, "UF%02d", idet);
   TGeoVolume* rocF = gGeoManager->GetVolume(cTagV);
   roc->AddNode(rocF, 1, new TGeoTranslation(xpos, ypos, zpos));
@@ -2523,7 +2523,7 @@ void TRDGeometry::assembleChamber(int ilayer, int istack)
   // Add the volume with services on top of the back panel
   xpos = 0.0;
   ypos = 0.0;
-  zpos = fgkCsvH / 2.0 + fgkCroH + fgkCamH + fgkCraH + fgkCdrH - fgkCHsv / 2.0;
+  zpos = CSVH / 2.0 + CROH + CAMH + CRAH + CDRH - CHSV / 2.0;
   snprintf(cTagV, kTag, "UU%02d", idet);
   TGeoVolume* rocU = gGeoManager->GetVolume(cTagV);
   roc->AddNode(rocU, 1, new TGeoTranslation(xpos, ypos, zpos));
@@ -2531,12 +2531,12 @@ void TRDGeometry::assembleChamber(int ilayer, int istack)
   // Place the ROC assembly into the super modules
   xpos = 0.0;
   ypos = 0.0;
-  ypos = fgkClength[ilayer][0] + fgkClength[ilayer][1] + fgkClength[ilayer][2] / 2.0;
+  ypos = CLENGTH[ilayer][0] + CLENGTH[ilayer][1] + CLENGTH[ilayer][2] / 2.0;
   for (int ic = 0; ic < istack; ic++) {
-    ypos -= fgkClength[ilayer][ic];
+    ypos -= CLENGTH[ilayer][ic];
   }
-  ypos -= fgkClength[ilayer][istack] / 2.0;
-  zpos = fgkVrocsm + fgkSMpltT + fgkCHsv / 2.0 - fgkSheight / 2.0 + ilayer * (fgkCH + fgkVspace);
+  ypos -= CLENGTH[ilayer][istack] / 2.0;
+  zpos = VROCSM + SMPLTT + CHSV / 2.0 - SHEIGHT / 2.0 + ilayer * (CH + VSPACE);
   TGeoVolume* sm1 = gGeoManager->GetVolume("UTI1");
   TGeoVolume* sm2 = gGeoManager->GetVolume("UTI2");
   TGeoVolume* sm3 = gGeoManager->GetVolume("UTI3");
@@ -2558,50 +2558,50 @@ void TRDGeometry::fillMatrixCache(int mask)
   if (mask != o2::utils::bit2Mask(o2::TransformType::T2L)) {
     LOG(FATAL) << "Unsupported transform matrix mask" << FairLogger::endl;
   }
-  
+
   useT2LCache();
 
   std::string volPath;
-  const std::string vpStr { "ALIC_1/B077_1/BSEGMO" };
-  const std::string vpApp1 {"_1/BTRD" };
-  const std::string vpApp2  { "_1" };
-  const std::string vpApp3a { "/UTR1_1/UTS1_1/UTI1_1" };
-  const std::string vpApp3b { "/UTR2_1/UTS2_1/UTI2_1" };
-  const std::string vpApp3c { "/UTR3_1/UTS3_1/UTI3_1" };
-  const std::string vpApp3d { "/UTR4_1/UTS4_1/UTI4_1" };
+  const std::string vpStr{ "ALIC_1/B077_1/BSEGMO" };
+  const std::string vpApp1{ "_1/BTRD" };
+  const std::string vpApp2{ "_1" };
+  const std::string vpApp3a{ "/UTR1_1/UTS1_1/UTI1_1" };
+  const std::string vpApp3b{ "/UTR2_1/UTS2_1/UTI2_1" };
+  const std::string vpApp3c{ "/UTR3_1/UTS3_1/UTI3_1" };
+  const std::string vpApp3d{ "/UTR4_1/UTS4_1/UTI4_1" };
 
   for (int ilayer = 0; ilayer < kNlayer; ilayer++) {
-    for (int isector = 0; isector < kNsector; isector++ ) {
+    for (int isector = 0; isector < kNsector; isector++) {
       for (int istack = 0; istack < kNstack; istack++) {
-        Int_t lid = getDetector(ilayer,istack,isector);
+        Int_t lid = getDetector(ilayer, istack, isector);
         // Check for disabled supermodules
-        volPath  = vpStr;
+        volPath = vpStr;
         volPath += std::to_string(isector);
         volPath += vpApp1;
         volPath += std::to_string(isector);
         volPath += vpApp2;
         switch (isector) {
-        case 17:
-          if ((istack == 4) && (ilayer == 4)) {
-            continue;
-          }
-          volPath += vpApp3d;
-          break;
-        case 13:
-        case 14:
-        case 15:
-          // Check for holes in from of PHOS
-          if (istack == 2) {
-            continue;
-          }
-          volPath += vpApp3c;
-          break;
-        case 11:
-        case 12:
-          volPath += vpApp3b;
-          break;
-        default:
-          volPath += vpApp3a;
+          case 17:
+            if ((istack == 4) && (ilayer == 4)) {
+              continue;
+            }
+            volPath += vpApp3d;
+            break;
+          case 13:
+          case 14:
+          case 15:
+            // Check for holes in from of PHOS
+            if (istack == 2) {
+              continue;
+            }
+            volPath += vpApp3c;
+            break;
+          case 11:
+          case 12:
+            volPath += vpApp3b;
+            break;
+          default:
+            volPath += vpApp3a;
         };
         if (!gGeoManager->CheckPath(volPath.c_str())) {
           continue;
@@ -2613,10 +2613,10 @@ void TRDGeometry::fillMatrixCache(int mask)
         //
         // Cluster transformation matrix
         //
-        TGeoHMatrix  rotMatrix(mchange.Inverse());
+        TGeoHMatrix rotMatrix(mchange.Inverse());
         rotMatrix.MultiplyLeft(m);
         Double_t sectorAngle = 20.0 * (isector % 18) + 10.0;
-        TGeoHMatrix  rotSector;
+        TGeoHMatrix rotSector;
         rotSector.RotateZ(sectorAngle);
         const auto& inv = rotSector.Inverse();
         rotMatrix.MultiplyLeft(&inv);
@@ -2635,91 +2635,91 @@ void TRDGeometry::addAlignableVolumes() const
   if (!gGeoManager) {
     LOG(FATAL) << "Geometry is not loaded";
   }
-  
+
   std::string volPath;
-  std::string vpStr { "ALIC_1/B077_1/BSEGMO" };
-  const std::string vpApp1 {"_1/BTRD" };
-  const std::string vpApp2  { "_1" };
-  const std::string vpApp3a { "/UTR1_1/UTS1_1/UTI1_1" };
-  const std::string vpApp3b { "/UTR2_1/UTS2_1/UTI2_1" };
-  const std::string vpApp3c { "/UTR3_1/UTS3_1/UTI3_1" };
-  const std::string vpApp3d { "/UTR4_1/UTS4_1/UTI4_1" };
+  std::string vpStr{ "ALIC_1/B077_1/BSEGMO" };
+  const std::string vpApp1{ "_1/BTRD" };
+  const std::string vpApp2{ "_1" };
+  const std::string vpApp3a{ "/UTR1_1/UTS1_1/UTI1_1" };
+  const std::string vpApp3b{ "/UTR2_1/UTS2_1/UTI2_1" };
+  const std::string vpApp3c{ "/UTR3_1/UTS3_1/UTI3_1" };
+  const std::string vpApp3d{ "/UTR4_1/UTS4_1/UTI4_1" };
   std::string symName;
-  
+
   // in opposite to AliGeomManager, we use consecutive numbering of modules through whole TRD
   int volid = -1;
 
   // The super modules
   // The symbolic names are: TRD/sm00 ... TRD/sm17
-  for (int isector = 0; isector < kNsector; isector++ ) {
-    volPath  = vpStr;
+  for (int isector = 0; isector < kNsector; isector++) {
+    volPath = vpStr;
     volPath += std::to_string(isector);
     volPath += vpApp1;
     volPath += std::to_string(isector);
     volPath += vpApp2;
-    symName = Form("TRD/sm%02d",isector);
-    gGeoManager->SetAlignableEntry(symName.c_str(),volPath.c_str());
+    symName = Form("TRD/sm%02d", isector);
+    gGeoManager->SetAlignableEntry(symName.c_str(), volPath.c_str());
   }
-  
+
   // The readout chambers
   // The symbolic names are: TRD/sm00/st0/pl0 ... TRD/sm17/st4/pl5
-  
-  for (int isector = 0; isector < kNsector; isector++ ) {
-    if (!getSMstatus(isector)) continue;
+
+  for (int isector = 0; isector < kNsector; isector++) {
+    if (!getSMstatus(isector))
+      continue;
     for (int ilayer = 0; ilayer < kNlayer; ilayer++) {
       for (int istack = 0; istack < kNstack; istack++) {
-        Int_t lid = getDetector(ilayer,istack,isector);
+        Int_t lid = getDetector(ilayer, istack, isector);
         int idet = getDetectorSec(ilayer, istack);
 
         // Check for disabled supermodules
-        volPath  = vpStr;
+        volPath = vpStr;
         volPath += std::to_string(isector);
         volPath += vpApp1;
         volPath += std::to_string(isector);
         volPath += vpApp2;
         switch (isector) {
-        case 17:
-          if ((istack == 4) && (ilayer == 4)) {
-            continue;
-          }
-          volPath += vpApp3d;
-          break;
-        case 13:
-        case 14:
-        case 15:
-          // Check for holes in from of PHOS
-          if (istack == 2) {
-            continue;
-          }
-          volPath += vpApp3c;
-          break;
-        case 11:
-        case 12:
-          volPath += vpApp3b;
-          break;
-        default:
-          volPath += vpApp3a;
+          case 17:
+            if ((istack == 4) && (ilayer == 4)) {
+              continue;
+            }
+            volPath += vpApp3d;
+            break;
+          case 13:
+          case 14:
+          case 15:
+            // Check for holes in from of PHOS
+            if (istack == 2) {
+              continue;
+            }
+            volPath += vpApp3c;
+            break;
+          case 11:
+          case 12:
+            volPath += vpApp3b;
+            break;
+          default:
+            volPath += vpApp3a;
         };
-        volPath += Form("/UT%02d_1",idet);
+        volPath += Form("/UT%02d_1", idet);
 
-        symName  = Form("TRD/sm%02d/st%d/pl%d",isector,istack,ilayer);
+        symName = Form("TRD/sm%02d/st%d/pl%d", isector, istack, ilayer);
         int modID = o2::Base::GeometryManager::getSensID(o2::detectors::DetID::TRD, lid);
 
-        TGeoPNEntry *alignableEntry = gGeoManager->SetAlignableEntry(symName.c_str(),volPath.c_str(),modID);
+        TGeoPNEntry* alignableEntry = gGeoManager->SetAlignableEntry(symName.c_str(), volPath.c_str(), modID);
 
         // Add the tracking to local matrix
         if (alignableEntry) {
-          TGeoHMatrix *globMatrix = alignableEntry->GetGlobalOrig();
+          TGeoHMatrix* globMatrix = alignableEntry->GetGlobalOrig();
           Double_t sectorAngle = 20.0 * (isector % 18) + 10.0;
-          TGeoHMatrix *t2lMatrix  = new TGeoHMatrix();
+          TGeoHMatrix* t2lMatrix = new TGeoHMatrix();
           t2lMatrix->RotateZ(sectorAngle);
           const TGeoHMatrix& globmatrixi = globMatrix->Inverse();
           t2lMatrix->MultiplyLeft(&globmatrixi);
           alignableEntry->SetMatrix(t2lMatrix);
-        }
-        else {
+        } else {
           LOG(ERROR) << "Alignable entry is not valid: ModID:" << modID << " Sector:" << isector << " Lr:" << ilayer
-              << " Stack: " << istack << " name: " << symName.c_str() << " vol: " << volPath.c_str();
+                     << " Stack: " << istack << " name: " << symName.c_str() << " vol: " << volPath.c_str();
         }
       }
     }
@@ -2734,7 +2734,7 @@ bool TRDGeometry::createClusterMatrixArray()
     return false;
   }
   if (isBuilt()) {
-    LOG(WARNING) << "Already built" << FairLogger::endl;
+    LOG(WARNING) << "Already built";
     return true; // already initialized
   }
 
@@ -2749,7 +2749,9 @@ const TRDGeometry::Mat3D* TRDGeometry::getClusterMatrix(int det)
   //
   // Returns the cluster transformation matrix for a given detector
   //
-  if (!isMatrixAvailable(det)) return nullptr;
+  if (!isMatrixAvailable(det)) {
+    return nullptr;
+  }
   return &getMatrixT2L(det);
 }
 

--- a/Detectors/TRD/base/src/TRDGeometry.cxx
+++ b/Detectors/TRD/base/src/TRDGeometry.cxx
@@ -23,7 +23,6 @@ using namespace o2::trd;
 
 //_____________________________________________________________________________
 
-TObjArray* TRDGeometry::fgClusterMatrixArray = nullptr;
 std::unique_ptr<TRDPadPlane[]> TRDGeometry::fgPadPlaneArray;
 const o2::detectors::DetID TRDGeometry::sDetID(o2::detectors::DetID::TRD);
 
@@ -32,14 +31,6 @@ TRDGeometry::TRDGeometry() : TRDGeometryBase(), o2::detectors::DetMatrixCacheInd
 {
   //
   // TRDGeometry default constructor
-  //
-}
-
-//_____________________________________________________________________________
-TRDGeometry::~TRDGeometry()
-{
-  //
-  // TRDGeometry destructor
   //
 }
 
@@ -74,33 +65,32 @@ void TRDGeometry::CreatePadPlaneArray()
   fgPadPlaneArray.reset(new TRDPadPlane[kNlayer * kNstack]);
   for (int ilayer = 0; ilayer < kNlayer; ilayer++) {
     for (int istack = 0; istack < kNstack; istack++) {
-      int ipp = GetDetectorSec(ilayer, istack);
-      CreatePadPlane(ilayer, istack, fgPadPlaneArray.get()[ipp]);
+      CreatePadPlane(ilayer, istack);
     }
   }
 }
 
 //_____________________________________________________________________________
-void TRDGeometry::CreatePadPlane(int ilayer, int istack, TRDPadPlane& plane)
+void TRDGeometry::CreatePadPlane(int ilayer, int istack)
 {
   //
   // Creates an TRDPadPlane object
   //
+  int ipp = GetDetectorSec(ilayer, istack);
+  auto& padPlane = fgPadPlaneArray.get()[ipp];
 
-  TRDPadPlane* padPlane = &plane;
+  padPlane.SetLayer(ilayer);
+  padPlane.SetStack(istack);
 
-  padPlane->SetLayer(ilayer);
-  padPlane->SetStack(istack);
+  padPlane.SetRowSpacing(0.0);
+  padPlane.SetColSpacing(0.0);
 
-  padPlane->SetRowSpacing(0.0);
-  padPlane->SetColSpacing(0.0);
+  padPlane.SetLengthRim(1.0);
+  padPlane.SetWidthRim(0.5);
 
-  padPlane->SetLengthRim(1.0);
-  padPlane->SetWidthRim(0.5);
+  padPlane.SetNcols(144);
 
-  padPlane->SetNcols(144);
-
-  padPlane->SetAnodeWireOffset(0.25);
+  padPlane.SetAnodeWireOffset(0.25);
 
   //
   // The pad plane parameter
@@ -110,114 +100,114 @@ void TRDGeometry::CreatePadPlane(int ilayer, int istack, TRDPadPlane& plane)
     case 0:
       if (istack == 2) {
         // L0C0 type
-        padPlane->SetNrows(12);
-        padPlane->SetLength(108.0);
-        padPlane->SetLengthOPad(8.0);
-        padPlane->SetLengthIPad(9.0);
+        padPlane.SetNrows(12);
+        padPlane.SetLength(108.0);
+        padPlane.SetLengthOPad(8.0);
+        padPlane.SetLengthIPad(9.0);
       } else {
         // L0C1 type
-        padPlane->SetNrows(16);
-        padPlane->SetLength(122.0);
-        padPlane->SetLengthOPad(7.5);
-        padPlane->SetLengthIPad(7.5);
+        padPlane.SetNrows(16);
+        padPlane.SetLength(122.0);
+        padPlane.SetLengthOPad(7.5);
+        padPlane.SetLengthIPad(7.5);
       }
-      padPlane->SetWidth(92.2);
-      padPlane->SetWidthOPad(0.515);
-      padPlane->SetWidthIPad(0.635);
-      padPlane->SetTiltingAngle(-kTiltAngle);
+      padPlane.SetWidth(92.2);
+      padPlane.SetWidthOPad(0.515);
+      padPlane.SetWidthIPad(0.635);
+      padPlane.SetTiltingAngle(-kTiltAngle);
       break;
     case 1:
       if (istack == 2) {
         // L1C0 type
-        padPlane->SetNrows(12);
-        padPlane->SetLength(108.0);
-        padPlane->SetLengthOPad(8.0);
-        padPlane->SetLengthIPad(9.0);
+        padPlane.SetNrows(12);
+        padPlane.SetLength(108.0);
+        padPlane.SetLengthOPad(8.0);
+        padPlane.SetLengthIPad(9.0);
       } else {
         // L1C1 type
-        padPlane->SetNrows(16);
-        padPlane->SetLength(122.0);
-        padPlane->SetLengthOPad(7.5);
-        padPlane->SetLengthIPad(7.5);
+        padPlane.SetNrows(16);
+        padPlane.SetLength(122.0);
+        padPlane.SetLengthOPad(7.5);
+        padPlane.SetLengthIPad(7.5);
       }
-      padPlane->SetWidth(96.6);
-      padPlane->SetWidthOPad(0.585);
-      padPlane->SetWidthIPad(0.665);
-      padPlane->SetTiltingAngle(kTiltAngle);
+      padPlane.SetWidth(96.6);
+      padPlane.SetWidthOPad(0.585);
+      padPlane.SetWidthIPad(0.665);
+      padPlane.SetTiltingAngle(kTiltAngle);
       break;
     case 2:
       if (istack == 2) {
         // L2C0 type
-        padPlane->SetNrows(12);
-        padPlane->SetLength(108.0);
-        padPlane->SetLengthOPad(8.0);
-        padPlane->SetLengthIPad(9.0);
+        padPlane.SetNrows(12);
+        padPlane.SetLength(108.0);
+        padPlane.SetLengthOPad(8.0);
+        padPlane.SetLengthIPad(9.0);
       } else {
         // L2C1 type
-        padPlane->SetNrows(16);
-        padPlane->SetLength(129.0);
-        padPlane->SetLengthOPad(7.5);
-        padPlane->SetLengthIPad(8.0);
+        padPlane.SetNrows(16);
+        padPlane.SetLength(129.0);
+        padPlane.SetLengthOPad(7.5);
+        padPlane.SetLengthIPad(8.0);
       }
-      padPlane->SetWidth(101.1);
-      padPlane->SetWidthOPad(0.705);
-      padPlane->SetWidthIPad(0.695);
-      padPlane->SetTiltingAngle(-kTiltAngle);
+      padPlane.SetWidth(101.1);
+      padPlane.SetWidthOPad(0.705);
+      padPlane.SetWidthIPad(0.695);
+      padPlane.SetTiltingAngle(-kTiltAngle);
       break;
     case 3:
       if (istack == 2) {
         // L3C0 type
-        padPlane->SetNrows(12);
-        padPlane->SetLength(108.0);
-        padPlane->SetLengthOPad(8.0);
-        padPlane->SetLengthIPad(9.0);
+        padPlane.SetNrows(12);
+        padPlane.SetLength(108.0);
+        padPlane.SetLengthOPad(8.0);
+        padPlane.SetLengthIPad(9.0);
       } else {
         // L3C1 type
-        padPlane->SetNrows(16);
-        padPlane->SetLength(136.0);
-        padPlane->SetLengthOPad(7.5);
-        padPlane->SetLengthIPad(8.5);
+        padPlane.SetNrows(16);
+        padPlane.SetLength(136.0);
+        padPlane.SetLengthOPad(7.5);
+        padPlane.SetLengthIPad(8.5);
       }
-      padPlane->SetWidth(105.5);
-      padPlane->SetWidthOPad(0.775);
-      padPlane->SetWidthIPad(0.725);
-      padPlane->SetTiltingAngle(kTiltAngle);
+      padPlane.SetWidth(105.5);
+      padPlane.SetWidthOPad(0.775);
+      padPlane.SetWidthIPad(0.725);
+      padPlane.SetTiltingAngle(kTiltAngle);
       break;
     case 4:
       if (istack == 2) {
         // L4C0 type
-        padPlane->SetNrows(12);
-        padPlane->SetLength(108.0);
-        padPlane->SetLengthOPad(8.0);
+        padPlane.SetNrows(12);
+        padPlane.SetLength(108.0);
+        padPlane.SetLengthOPad(8.0);
       } else {
         // L4C1 type
-        padPlane->SetNrows(16);
-        padPlane->SetLength(143.0);
-        padPlane->SetLengthOPad(7.5);
+        padPlane.SetNrows(16);
+        padPlane.SetLength(143.0);
+        padPlane.SetLengthOPad(7.5);
       }
-      padPlane->SetWidth(109.9);
-      padPlane->SetWidthOPad(0.845);
-      padPlane->SetLengthIPad(9.0);
-      padPlane->SetWidthIPad(0.755);
-      padPlane->SetTiltingAngle(-kTiltAngle);
+      padPlane.SetWidth(109.9);
+      padPlane.SetWidthOPad(0.845);
+      padPlane.SetLengthIPad(9.0);
+      padPlane.SetWidthIPad(0.755);
+      padPlane.SetTiltingAngle(-kTiltAngle);
       break;
     case 5:
       if (istack == 2) {
         // L5C0 type
-        padPlane->SetNrows(12);
-        padPlane->SetLength(108.0);
-        padPlane->SetLengthOPad(8.0);
+        padPlane.SetNrows(12);
+        padPlane.SetLength(108.0);
+        padPlane.SetLengthOPad(8.0);
       } else {
         // L5C1 type
-        padPlane->SetNrows(16);
-        padPlane->SetLength(145.0);
-        padPlane->SetLengthOPad(8.5);
+        padPlane.SetNrows(16);
+        padPlane.SetLength(145.0);
+        padPlane.SetLengthOPad(8.5);
       }
-      padPlane->SetWidth(114.4);
-      padPlane->SetWidthOPad(0.965);
-      padPlane->SetLengthIPad(9.0);
-      padPlane->SetWidthIPad(0.785);
-      padPlane->SetTiltingAngle(kTiltAngle);
+      padPlane.SetWidth(114.4);
+      padPlane.SetWidthOPad(0.965);
+      padPlane.SetLengthIPad(9.0);
+      padPlane.SetWidthIPad(0.785);
+      padPlane.SetTiltingAngle(kTiltAngle);
       break;
   };
 
@@ -226,27 +216,27 @@ void TRDGeometry::CreatePadPlane(int ilayer, int istack, TRDPadPlane& plane)
   //
   // Row direction
   //
-  double row = fgkClength[ilayer][istack] / 2.0 - fgkRpadW - padPlane->GetLengthRim();
-  for (int ir = 0; ir < padPlane->GetNrows(); ir++) {
-    padPlane->SetPadRow(ir, row);
-    row -= padPlane->GetRowSpacing();
+  double row = fgkClength[ilayer][istack] / 2.0 - fgkRpadW - padPlane.GetLengthRim();
+  for (int ir = 0; ir < padPlane.GetNrows(); ir++) {
+    padPlane.SetPadRow(ir, row);
+    row -= padPlane.GetRowSpacing();
     if (ir == 0) {
-      row -= padPlane->GetLengthOPad();
+      row -= padPlane.GetLengthOPad();
     } else {
-      row -= padPlane->GetLengthIPad();
+      row -= padPlane.GetLengthIPad();
     }
   }
   //
   // Column direction
   //
-  double col = -fgkCwidth[ilayer] / 2.0 - fgkCroW + padPlane->GetWidthRim();
-  for (int ic = 0; ic < padPlane->GetNcols(); ic++) {
-    padPlane->SetPadCol(ic, col);
-    col += padPlane->GetColSpacing();
+  double col = -fgkCwidth[ilayer] / 2.0 - fgkCroW + padPlane.GetWidthRim();
+  for (int ic = 0; ic < padPlane.GetNcols(); ic++) {
+    padPlane.SetPadCol(ic, col);
+    col += padPlane.GetColSpacing();
     if (ic == 0) {
-      col += padPlane->GetWidthOPad();
+      col += padPlane.GetWidthOPad();
     } else {
-      col += padPlane->GetWidthIPad();
+      col += padPlane.GetWidthIPad();
     }
   }
   // Calculate the offset to translate from the local ROC system into
@@ -255,7 +245,7 @@ void TRDGeometry::CreatePadPlane(int ilayer, int istack, TRDPadPlane& plane)
   for (int jstack = 0; jstack < istack; jstack++) {
     rowTmp -= fgkClength[ilayer][jstack];
   }
-  padPlane->SetPadRowSMOffset(rowTmp - fgkClength[ilayer][istack] / 2.0);
+  padPlane.SetPadRowSMOffset(rowTmp - fgkClength[ilayer][istack] / 2.0);
 }
 
 void TRDGeometry::createVolume(const char* name, const char* shape, int nmed, float* upar, int np)
@@ -275,22 +265,14 @@ void TRDGeometry::CreateGeometry(std::vector<int> const& idtmed)
   //
   // Create the TRD geometry
   
-  if (isBuilt()) {
-    LOG(WARNING) << "Already built" << FairLogger::endl;
-    return; // already initialized
-  }
-
   if (!gGeoManager) {
     // RSTODO: in future there will be a method to load matrices from the CDB
     LOG(FATAL) << "Geometry is not loaded" << FairLogger::endl;
   }
-
+  
   CreatePadPlaneArray();
   mPadPlaneArray = fgPadPlaneArray.get();
   CreateVolumes(idtmed);
-  
-  setSize(kNdet, kNdet);
-  fillMatrixCache(o2::utils::bit2Mask(o2::TransformType::T2L));
 }
 
 void TRDGeometry::CreateVolumes(std::vector<int> const& idtmed)
@@ -2581,30 +2563,23 @@ void TRDGeometry::fillMatrixCache(int mask)
   useT2LCache();
 
   std::string volPath;
-  const std::string vpStr   = "ALIC_1/B077_1/BSEGMO";
-  const std::string vpApp1  = "_1/BTRD";
-  const std::string vpApp2  = "_1";
-  const std::string vpApp3a = "/UTR1_1/UTS1_1/UTI1_1";
-  const std::string vpApp3b = "/UTR2_1/UTS2_1/UTI2_1";
-  const std::string vpApp3c = "/UTR3_1/UTS3_1/UTI3_1";
-  const std::string vpApp3d = "/UTR4_1/UTS4_1/UTI4_1";
+  const std::string vpStr { "ALIC_1/B077_1/BSEGMO" };
+  const std::string vpApp1 {"_1/BTRD" };
+  const std::string vpApp2  { "_1" };
+  const std::string vpApp3a { "/UTR1_1/UTS1_1/UTI1_1" };
+  const std::string vpApp3b { "/UTR2_1/UTS2_1/UTI2_1" };
+  const std::string vpApp3c { "/UTR3_1/UTS3_1/UTI3_1" };
+  const std::string vpApp3d { "/UTR4_1/UTS4_1/UTI4_1" };
 
-  fgClusterMatrixArray = new TObjArray(kNdet);
-
-  // in opposite to AliGeomManager, we use consecutive numbering of modules through whole TRD
-  int volid = -1;
-  
   for (int ilayer = 0; ilayer < kNlayer; ilayer++) {
     for (int isector = 0; isector < kNsector; isector++ ) {
       for (int istack = 0; istack < kNstack; istack++) {
         Int_t lid = GetDetector(ilayer,istack,isector);
-
-        volid++;
         // Check for disabled supermodules
         volPath  = vpStr;
-        volPath += isector;
+        volPath += std::to_string(isector);
         volPath += vpApp1;
-        volPath += isector;
+        volPath += std::to_string(isector);
         volPath += vpApp2;
         switch (isector) {
         case 17:
@@ -2630,28 +2605,143 @@ void TRDGeometry::fillMatrixCache(int mask)
           volPath += vpApp3a;
         };
         if (!gGeoManager->CheckPath(volPath.c_str())) {
-          //AliInfo(Form("Path not found in geometry: %s",volPath.Data()));
           continue;
         }
-        TGeoHMatrix *m = o2::Base::GeometryManager::getMatrix(sDetID, volid);
+        const auto m = o2::Base::GeometryManager::getMatrix(o2::detectors::DetID::TRD, lid);
         TGeoRotation mchange;
         mchange.RotateY(90);
         mchange.RotateX(90);
-
         //
         // Cluster transformation matrix
         //
-        std::unique_ptr<TGeoHMatrix> rotMatrix = std::make_unique<TGeoHMatrix>(mchange.Inverse());
-        rotMatrix->MultiplyLeft(m);
-        float sectorAngle = 20.0 * (isector % 18) + 10.0;
+        TGeoHMatrix  rotMatrix(mchange.Inverse());
+        rotMatrix.MultiplyLeft(m);
+        Double_t sectorAngle = 20.0 * (isector % 18) + 10.0;
         TGeoHMatrix  rotSector;
         rotSector.RotateZ(sectorAngle);
         const auto& inv = rotSector.Inverse();
-        rotMatrix->MultiplyLeft(&inv);
-        setMatrixT2L(Mat3D(*rotMatrix), lid);
+        rotMatrix.MultiplyLeft(&inv);
+        setMatrixT2L(Mat3D(rotMatrix), lid);
       }
     }
   }
+}
+
+//_____________________________________________________________________________
+void TRDGeometry::addAlignableVolumes() const
+{
+  //
+  // define alignable volumes of the TRD
+  //
+  if (!gGeoManager) {
+    LOG(FATAL) << "Geometry is not loaded";
+  }
+  
+  std::string volPath;
+  std::string vpStr { "ALIC_1/B077_1/BSEGMO" };
+  const std::string vpApp1 {"_1/BTRD" };
+  const std::string vpApp2  { "_1" };
+  const std::string vpApp3a { "/UTR1_1/UTS1_1/UTI1_1" };
+  const std::string vpApp3b { "/UTR2_1/UTS2_1/UTI2_1" };
+  const std::string vpApp3c { "/UTR3_1/UTS3_1/UTI3_1" };
+  const std::string vpApp3d { "/UTR4_1/UTS4_1/UTI4_1" };
+  std::string symName;
+  
+  // in opposite to AliGeomManager, we use consecutive numbering of modules through whole TRD
+  int volid = -1;
+
+  // The super modules
+  // The symbolic names are: TRD/sm00 ... TRD/sm17
+  for (int isector = 0; isector < kNsector; isector++ ) {
+    volPath  = vpStr;
+    volPath += std::to_string(isector);
+    volPath += vpApp1;
+    volPath += std::to_string(isector);
+    volPath += vpApp2;
+    symName = Form("TRD/sm%02d",isector);
+    gGeoManager->SetAlignableEntry(symName.c_str(),volPath.c_str());
+  }
+  
+  // The readout chambers
+  // The symbolic names are: TRD/sm00/st0/pl0 ... TRD/sm17/st4/pl5
+  
+  for (int isector = 0; isector < kNsector; isector++ ) {
+    if (!GetSMstatus(isector)) continue;
+    for (int ilayer = 0; ilayer < kNlayer; ilayer++) {
+      for (int istack = 0; istack < kNstack; istack++) {
+        Int_t lid = GetDetector(ilayer,istack,isector);
+        int idet = GetDetectorSec(ilayer, istack);
+
+        // Check for disabled supermodules
+        volPath  = vpStr;
+        volPath += std::to_string(isector);
+        volPath += vpApp1;
+        volPath += std::to_string(isector);
+        volPath += vpApp2;
+        switch (isector) {
+        case 17:
+          if ((istack == 4) && (ilayer == 4)) {
+            continue;
+          }
+          volPath += vpApp3d;
+          break;
+        case 13:
+        case 14:
+        case 15:
+          // Check for holes in from of PHOS
+          if (istack == 2) {
+            continue;
+          }
+          volPath += vpApp3c;
+          break;
+        case 11:
+        case 12:
+          volPath += vpApp3b;
+          break;
+        default:
+          volPath += vpApp3a;
+        };
+        volPath += Form("/UT%02d_1",idet);
+
+        symName  = Form("TRD/sm%02d/st%d/pl%d",isector,istack,ilayer);
+        int modID = o2::Base::GeometryManager::getSensID(o2::detectors::DetID::TRD, lid);
+
+        TGeoPNEntry *alignableEntry = gGeoManager->SetAlignableEntry(symName.c_str(),volPath.c_str(),modID);
+
+        // Add the tracking to local matrix
+        if (alignableEntry) {
+          TGeoHMatrix *globMatrix = alignableEntry->GetGlobalOrig();
+          Double_t sectorAngle = 20.0 * (isector % 18) + 10.0;
+          TGeoHMatrix *t2lMatrix  = new TGeoHMatrix();
+          t2lMatrix->RotateZ(sectorAngle);
+          const TGeoHMatrix& globmatrixi = globMatrix->Inverse();
+          t2lMatrix->MultiplyLeft(&globmatrixi);
+          alignableEntry->SetMatrix(t2lMatrix);
+        }
+        else {
+          LOG(ERROR) << "Alignable entry is not valid: ModID:" << modID << " Sector:" << isector << " Lr:" << ilayer
+              << " Stack: " << istack << " name: " << symName.c_str() << " vol: " << volPath.c_str();
+        }
+      }
+    }
+  }
+}
+
+//_____________________________________________________________________________
+bool TRDGeometry::createClusterMatrixArray()
+{
+  if (!gGeoManager) {
+    LOG(ERROR) << "Geometry is not loaded yet";
+    return false;
+  }
+  if (isBuilt()) {
+    LOG(WARNING) << "Already built" << FairLogger::endl;
+    return true; // already initialized
+  }
+
+  setSize(521, kNdet); //Only 521 of kNdet matrices are filled
+  fillMatrixCache(o2::utils::bit2Mask(o2::TransformType::T2L));
+  return true;
 }
 
 //_____________________________________________________________________________
@@ -2677,5 +2767,3 @@ bool TRDGeometry::ChamberInGeometry(int det)
     return true;
   }
 }
-
-ClassImp(TRDGeometry)

--- a/Detectors/TRD/base/src/TRDGeometry.cxx
+++ b/Detectors/TRD/base/src/TRDGeometry.cxx
@@ -23,169 +23,11 @@ using namespace o2::trd;
 
 //_____________________________________________________________________________
 
-//
-// The geometry constants
-//
-const int TRDGeometry::fgkNsector = kNsector;
-const int TRDGeometry::fgkNlayer = kNlayer;
-const int TRDGeometry::fgkNstack = kNstack;
-const int TRDGeometry::fgkNdet = kNdet;
-
-//
-// Dimensions of the detector
-//
-
-// Total length of the TRD mother volume
-const float TRDGeometry::fgkTlength = 751.0;
-
-// Parameter of the super module mother volumes
-const float TRDGeometry::fgkSheight = 77.9;
-const float TRDGeometry::fgkSwidth1 = 94.881;
-const float TRDGeometry::fgkSwidth2 = 122.353;
-const float TRDGeometry::fgkSlength = 702.0;
-
-// Length of the additional space in front of the supermodule
-// used for services
-const float TRDGeometry::fgkFlength = (TRDGeometry::fgkTlength - TRDGeometry::fgkSlength) / 2.0;
-
-// The super module side plates
-const float TRDGeometry::fgkSMpltT = 0.2;
-
-// Vertical spacing of the chambers
-const float TRDGeometry::fgkVspace = 1.784;
-// Horizontal spacing of the chambers
-const float TRDGeometry::fgkHspace = 2.0;
-// Radial distance of the first ROC to the outer plates of the SM
-const float TRDGeometry::fgkVrocsm = 1.2;
-
-// Height of different chamber parts
-// Radiator
-const float TRDGeometry::fgkCraH = 4.8;
-// Drift region
-const float TRDGeometry::fgkCdrH = 3.0;
-// Amplification region
-const float TRDGeometry::fgkCamH = 0.7;
-// Readout
-const float TRDGeometry::fgkCroH = 2.316;
-// Additional width of the readout chamber frames
-const float TRDGeometry::fgkCroW = 0.9;
-// Services on top of ROC
-const float TRDGeometry::fgkCsvH = TRDGeometry::fgkVspace - 0.742;
-// Total height (w/o services)
-const float TRDGeometry::fgkCH =
-  TRDGeometry::fgkCraH + TRDGeometry::fgkCdrH + TRDGeometry::fgkCamH + TRDGeometry::fgkCroH;
-// Total height (with services)
-
-const float TRDGeometry::fgkCHsv = TRDGeometry::fgkCH + TRDGeometry::fgkCsvH;
-
-// Distance of anode wire plane relative to middle of alignable volume
-const float TRDGeometry::fgkAnodePos =
-  TRDGeometry::fgkCraH + TRDGeometry::fgkCdrH + TRDGeometry::fgkCamH / 2.0 - TRDGeometry::fgkCHsv / 2.0;
-
-// Thicknesses of different parts of the chamber frame
-// Lower aluminum frame
-const float TRDGeometry::fgkCalT = 0.4;
-// Lower Wacosit frame sides
-const float TRDGeometry::fgkCclsT = 0.21;
-// Lower Wacosit frame front
-const float TRDGeometry::fgkCclfT = 1.0;
-// Thickness of glue around radiator
-const float TRDGeometry::fgkCglT = 0.25;
-// Upper Wacosit frame around amplification region
-const float TRDGeometry::fgkCcuTa = 1.0;
-const float TRDGeometry::fgkCcuTb = 0.8;
-// Al frame of back panel
-const float TRDGeometry::fgkCauT = 1.5;
-// Additional Al ledge at the lower chamber frame
-// Actually the dimensions are not realistic, but
-// modified in order to allow to mis-alignment.
-// The amount of material is, however, correct
-const float TRDGeometry::fgkCalW = 2.5;
-const float TRDGeometry::fgkCalH = 0.4;
-const float TRDGeometry::fgkCalWmod = 0.4;
-const float TRDGeometry::fgkCalHmod = 2.5;
-// Additional Wacosit ledge at the lower chamber frame
-const float TRDGeometry::fgkCwsW = 1.2;
-const float TRDGeometry::fgkCwsH = 0.3;
-
-// Difference of outer chamber width and pad plane width
-const float TRDGeometry::fgkCpadW = 0.0;
-const float TRDGeometry::fgkRpadW = 1.0;
-
-//
-// Thickness of the the material layers
-//
-const float TRDGeometry::fgkDrThick = TRDGeometry::fgkCdrH;
-const float TRDGeometry::fgkAmThick = TRDGeometry::fgkCamH;
-const float TRDGeometry::fgkXeThick = TRDGeometry::fgkDrThick + TRDGeometry::fgkAmThick;
-const float TRDGeometry::fgkWrThick = 0.00011;
-
-const float TRDGeometry::fgkRMyThick = 0.0015;
-const float TRDGeometry::fgkRCbThick = 0.0055;
-const float TRDGeometry::fgkRGlThick = 0.0065;
-const float TRDGeometry::fgkRRhThick = 0.8;
-const float TRDGeometry::fgkRFbThick = fgkCraH - 2.0 * (fgkRMyThick + fgkRCbThick + fgkRRhThick);
-
-const float TRDGeometry::fgkPPdThick = 0.0025;
-const float TRDGeometry::fgkPPpThick = 0.0356;
-const float TRDGeometry::fgkPGlThick = 0.1428;
-const float TRDGeometry::fgkPCbThick = 0.019;
-const float TRDGeometry::fgkPPcThick = 0.0486;
-const float TRDGeometry::fgkPRbThick = 0.0057;
-const float TRDGeometry::fgkPElThick = 0.0029;
-const float TRDGeometry::fgkPHcThick =
-  fgkCroH - fgkPPdThick - fgkPPpThick - fgkPGlThick - fgkPCbThick * 2.0 - fgkPPcThick - fgkPRbThick - fgkPElThick;
-
-//
-// Position of the material layers
-//
-const float TRDGeometry::fgkDrZpos = 2.4;
-const float TRDGeometry::fgkAmZpos = 0.0;
-const float TRDGeometry::fgkWrZposA = 0.0;
-const float TRDGeometry::fgkWrZposB = -fgkAmThick / 2.0 + 0.001;
-const float TRDGeometry::fgkCalZpos = 0.3;
-
-const int TRDGeometry::fgkMCMmax = 16;
-const int TRDGeometry::fgkMCMrow = 4;
-const int TRDGeometry::fgkROBmaxC0 = 6;
-const int TRDGeometry::fgkROBmaxC1 = 8;
-const int TRDGeometry::fgkADCmax = 21;
-const int TRDGeometry::fgkTBmax = 60;
-const int TRDGeometry::fgkPadmax = 18;
-const int TRDGeometry::fgkColmax = 144;
-const int TRDGeometry::fgkRowmaxC0 = 12;
-const int TRDGeometry::fgkRowmaxC1 = 16;
-
-const double TRDGeometry::fgkTime0Base = 300.65;
-const float TRDGeometry::fgkTime0[6] = { static_cast<float>(fgkTime0Base + 0 * (Cheight() + Cspace())),
-                                         static_cast<float>(fgkTime0Base + 1 * (Cheight() + Cspace())),
-                                         static_cast<float>(fgkTime0Base + 2 * (Cheight() + Cspace())),
-                                         static_cast<float>(fgkTime0Base + 3 * (Cheight() + Cspace())),
-                                         static_cast<float>(fgkTime0Base + 4 * (Cheight() + Cspace())),
-                                         static_cast<float>(fgkTime0Base + 5 * (Cheight() + Cspace())) };
-
-const double TRDGeometry::fgkXtrdBeg = 288.43; // Values depend on position of TRD
-const double TRDGeometry::fgkXtrdEnd = 366.33; // mother volume inside space frame !!!
-
-// The outer width of the chambers
-const float TRDGeometry::fgkCwidth[kNlayer] = { 90.4, 94.8, 99.3, 103.7, 108.1, 112.6 };
-
-// The outer lengths of the chambers
-// Includes the spacings between the chambers!
-const float TRDGeometry::fgkClength[kNlayer][kNstack] = {
-  { 124.0, 124.0, 110.0, 124.0, 124.0 }, { 124.0, 124.0, 110.0, 124.0, 124.0 }, { 131.0, 131.0, 110.0, 131.0, 131.0 },
-  { 138.0, 138.0, 110.0, 138.0, 138.0 }, { 145.0, 145.0, 110.0, 145.0, 145.0 }, { 147.0, 147.0, 110.0, 147.0, 147.0 }
-};
-
-char TRDGeometry::fgSMstatus[kNsector] = { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 };
-
 TObjArray* TRDGeometry::fgClusterMatrixArray = nullptr;
-
-// TObjArray* TRDGeometry::fgPadPlaneArray = NULL;
-std::vector<TRDPadPlane*>* TRDGeometry::fgPadPlaneArray;
+std::unique_ptr<TRDPadPlane[]> TRDGeometry::fgPadPlaneArray;
 
 //_____________________________________________________________________________
-TRDGeometry::TRDGeometry()
+TRDGeometry::TRDGeometry() : TRDGeometryBase()
 {
   //
   // TRDGeometry default constructor
@@ -201,37 +43,50 @@ TRDGeometry::~TRDGeometry()
 }
 
 //_____________________________________________________________________________
+bool TRDGeometry::RotateBack(int det, const double* const loc, double* glb) const
+{
+  //
+  // Rotates a chambers to transform the corresponding local frame
+  // coordinates <loc> into the coordinates of the ALICE restframe <glb>.
+  //
+
+  int sector = GetSector(det);
+  float phi = 2.0 * TMath::Pi() / (float)fgkNsector * ((float)sector + 0.5);
+
+  glb[0] = loc[0] * TMath::Cos(phi) - loc[1] * TMath::Sin(phi);
+  glb[1] = loc[0] * TMath::Sin(phi) + loc[1] * TMath::Cos(phi);
+  glb[2] = loc[2];
+
+  return true;
+}
+
+//_____________________________________________________________________________
 void TRDGeometry::CreatePadPlaneArray()
 {
   //
   // Creates the array of TRDPadPlane objects
   //
 
-  if (fgPadPlaneArray)
+  if (fgPadPlaneArray != nullptr)
     return;
 
-  //  static TObjArray padPlaneArray(fgkNlayer * fgkNstack);
-  // padPlaneArray.SetOwner(true);
-
-  fgPadPlaneArray = new std::vector<TRDPadPlane*>;
-  fgPadPlaneArray->resize(fgkNlayer * fgkNstack);
+  fgPadPlaneArray.reset(new TRDPadPlane[fgkNlayer * fgkNstack]);
   for (int ilayer = 0; ilayer < fgkNlayer; ilayer++) {
     for (int istack = 0; istack < fgkNstack; istack++) {
       int ipp = GetDetectorSec(ilayer, istack);
-      // fgPadPlaneArray->AddAt(CreatePadPlane(ilayer,istack),ipp);
-      (*fgPadPlaneArray)[ipp] = CreatePadPlane(ilayer, istack);
+      CreatePadPlane(ilayer, istack, fgPadPlaneArray.get()[ipp]);
     }
   }
 }
 
 //_____________________________________________________________________________
-TRDPadPlane* TRDGeometry::CreatePadPlane(int ilayer, int istack)
+void TRDGeometry::CreatePadPlane(int ilayer, int istack, TRDPadPlane& plane)
 {
   //
   // Creates an TRDPadPlane object
   //
 
-  TRDPadPlane* padPlane = new TRDPadPlane();
+  TRDPadPlane* padPlane = &plane;
 
   padPlane->SetLayer(ilayer);
   padPlane->SetStack(istack);
@@ -400,8 +255,6 @@ TRDPadPlane* TRDGeometry::CreatePadPlane(int ilayer, int istack)
     rowTmp -= fgkClength[ilayer][jstack];
   }
   padPlane->SetPadRowSMOffset(rowTmp - fgkClength[ilayer][istack] / 2.0);
-
-  return padPlane;
 }
 
 void TRDGeometry::createVolume(const char* name, const char* shape, int nmed, float* upar, int np)
@@ -420,6 +273,16 @@ void TRDGeometry::CreateGeometry(std::vector<int> const& idtmed)
 {
   //
   // Create the TRD geometry
+  CreatePadPlaneArray();
+  mPadPlaneArray = fgPadPlaneArray.get();
+  CreateVolumes(idtmed);
+  CreatePadPlaneArray();
+}
+
+void TRDGeometry::CreateVolumes(std::vector<int> const& idtmed)
+{
+  //
+  // Create the TRD geometry volumes
   //
   //
   // Names of the TRD volumina (xx = detector number):
@@ -1199,7 +1062,7 @@ void TRDGeometry::CreateFrame(std::vector<int> const& idtmed)
   }
 
   //
-  // The aymmetric flat frame in the middle
+  // The asymmetric flat frame in the middle
   //
 
   // The envelope volume (aluminum)
@@ -2695,158 +2558,6 @@ void TRDGeometry::AssembleChamber(int ilayer, int istack)
   }
 }
 
-//_____________________________________________________________________________
-bool TRDGeometry::RotateBack(int det, const double* const loc, double* glb) const
-{
-  //
-  // Rotates a chambers to transform the corresponding local frame
-  // coordinates <loc> into the coordinates of the ALICE restframe <glb>.
-  //
-
-  int sector = GetSector(det);
-  float phi = 2.0 * TMath::Pi() / (float)fgkNsector * ((float)sector + 0.5);
-
-  glb[0] = loc[0] * TMath::Cos(phi) - loc[1] * TMath::Sin(phi);
-  glb[1] = loc[0] * TMath::Sin(phi) + loc[1] * TMath::Cos(phi);
-  glb[2] = loc[2];
-
-  return true;
-}
-
-//_____________________________________________________________________________
-int TRDGeometry::GetDetectorSec(int layer, int stack)
-{
-  //
-  // Convert plane / stack into detector number for one single sector
-  //
-
-  return (layer + stack * fgkNlayer);
-}
-
-//_____________________________________________________________________________
-int TRDGeometry::GetDetector(int layer, int stack, int sector)
-{
-  //
-  // Convert layer / stack / sector into detector number
-  //
-
-  return (layer + stack * fgkNlayer + sector * fgkNlayer * fgkNstack);
-}
-
-//_____________________________________________________________________________
-int TRDGeometry::GetLayer(int det)
-{
-  //
-  // Reconstruct the layer number from the detector number
-  //
-
-  return ((int)(det % fgkNlayer));
-}
-
-//_____________________________________________________________________________
-int TRDGeometry::GetStack(int det)
-{
-  //
-  // Reconstruct the stack number from the detector number
-  //
-
-  return ((int)(det % (fgkNlayer * fgkNstack)) / fgkNlayer);
-}
-
-//_____________________________________________________________________________
-int TRDGeometry::GetStack(double z, int layer)
-{
-  //
-  // Reconstruct the chamber number from the z position and layer number
-  //
-  // The return function has to be protected for positiveness !!
-  //
-
-  if ((layer < 0) || (layer >= fgkNlayer))
-    return -1;
-
-  int istck = fgkNstack;
-  double zmin = 0.0;
-  double zmax = 0.0;
-
-  do {
-    istck--;
-    if (istck < 0)
-      break;
-    TRDPadPlane* pp = GetPadPlane(layer, istck);
-    zmax = pp->GetRow0();
-    int nrows = pp->GetNrows();
-    zmin = zmax - 2 * pp->GetLengthOPad() - (nrows - 2) * pp->GetLengthIPad() - (nrows - 1) * pp->GetRowSpacing();
-  } while ((z < zmin) || (z > zmax));
-
-  return istck;
-}
-
-//_____________________________________________________________________________
-int TRDGeometry::GetSector(int det)
-{
-  //
-  // Reconstruct the sector number from the detector number
-  //
-
-  return ((int)(det / (fgkNlayer * fgkNstack)));
-}
-
-//_____________________________________________________________________________
-TRDPadPlane* TRDGeometry::GetPadPlane(int layer, int stack)
-{
-  //
-  // Returns the pad plane for a given plane <pl> and stack <st> number
-  //
-
-  if (!fgPadPlaneArray) {
-    CreatePadPlaneArray();
-  }
-
-  int ipp = GetDetectorSec(layer, stack);
-  return (*fgPadPlaneArray)[ipp];
-}
-
-//_____________________________________________________________________________
-int TRDGeometry::GetRowMax(int layer, int stack, int /*sector*/)
-{
-  //
-  // Returns the number of rows on the pad plane
-  //
-
-  return GetPadPlane(layer, stack)->GetNrows();
-}
-
-//_____________________________________________________________________________
-int TRDGeometry::GetColMax(int layer)
-{
-  //
-  // Returns the number of rows on the pad plane
-  //
-
-  return GetPadPlane(layer, 0)->GetNcols();
-}
-
-//_____________________________________________________________________________
-double TRDGeometry::GetRow0(int layer, int stack, int /*sector*/)
-{
-  //
-  // Returns the position of the border of the first pad in a row
-  //
-
-  return GetPadPlane(layer, stack)->GetRow0();
-}
-
-//_____________________________________________________________________________
-double TRDGeometry::GetCol0(int layer)
-{
-  //
-  // Returns the position of the border of the first pad in a column
-  //
-
-  return GetPadPlane(layer, 0)->GetCol0();
-}
-
 /*
 //_____________________________________________________________________________
 bool TRDGeometry::CreateClusterMatrixArray()
@@ -2995,56 +2706,5 @@ bool TRDGeometry::ChamberInGeometry(int det)
 
 }
 */
-
-//_____________________________________________________________________________
-bool TRDGeometry::IsHole(int /*la*/, int st, int se) const
-{
-  //
-  // Checks for holes in front of PHOS
-  //
-
-  if (((se == 13) || (se == 14) || (se == 15)) && (st == 2)) {
-    return true;
-  }
-
-  return false;
-}
-
-//_____________________________________________________________________________
-bool TRDGeometry::IsOnBoundary(int det, float y, float z, float eps) const
-{
-  //
-  // Checks whether position is at the boundary of the sensitive volume
-  //
-
-  int ly = GetLayer(det);
-  if ((ly < 0) || (ly >= fgkNlayer))
-    return true;
-
-  int stk = GetStack(det);
-  if ((stk < 0) || (stk >= fgkNstack))
-    return true;
-
-  TRDPadPlane* pp = (*fgPadPlaneArray)[GetDetectorSec(ly, stk)];
-  if (!pp)
-    return true;
-
-  double max = pp->GetRow0();
-  int n = pp->GetNrows();
-  double min = max - 2 * pp->GetLengthOPad() - (n - 2) * pp->GetLengthIPad() - (n - 1) * pp->GetRowSpacing();
-  if (z < min + eps || z > max - eps) {
-    // printf("z : min[%7.2f (%7.2f)] %7.2f max[(%7.2f) %7.2f]\n", min, min+eps, z, max-eps, max);
-    return true;
-  }
-  min = pp->GetCol0();
-  n = pp->GetNcols();
-  max = min + 2 * pp->GetWidthOPad() + (n - 2) * pp->GetWidthIPad() + (n - 1) * pp->GetColSpacing();
-  if (y < min + eps || y > max - eps) {
-    // printf("y : min[%7.2f (%7.2f)] %7.2f max[(%7.2f) %7.2f]\n", min, min+eps, y, max-eps, max);
-    return true;
-  }
-
-  return false;
-}
 
 ClassImp(TRDGeometry)

--- a/Detectors/TRD/base/src/TRDGeometry.cxx
+++ b/Detectors/TRD/base/src/TRDGeometry.cxx
@@ -23,7 +23,6 @@ using namespace o2::trd;
 
 //_____________________________________________________________________________
 
-std::unique_ptr<TRDPadPlane[]> TRDGeometry::fgPadPlaneArray;
 const o2::detectors::DetID TRDGeometry::sDetID(o2::detectors::DetID::TRD);
 
 //_____________________________________________________________________________
@@ -35,14 +34,14 @@ TRDGeometry::TRDGeometry() : TRDGeometryBase(), o2::detectors::DetMatrixCacheInd
 }
 
 //_____________________________________________________________________________
-bool TRDGeometry::RotateBack(int det, const double* const loc, double* glb) const
+bool TRDGeometry::rotateBack(int det, const float* const loc, float* glb) const
 {
   //
   // Rotates a chambers to transform the corresponding local frame
   // coordinates <loc> into the coordinates of the ALICE restframe <glb>.
   //
 
-  int sector = GetSector(det);
+  int sector = getSector(det);
   float phi = 2.0 * TMath::Pi() / (float)kNsector * ((float)sector + 0.5);
 
   glb[0] = loc[0] * TMath::Cos(phi) - loc[1] * TMath::Sin(phi);
@@ -53,7 +52,7 @@ bool TRDGeometry::RotateBack(int det, const double* const loc, double* glb) cons
 }
 
 //_____________________________________________________________________________
-void TRDGeometry::CreatePadPlaneArray()
+void TRDGeometry::createPadPlaneArray()
 {
   //
   // Creates the array of TRDPadPlane objects
@@ -65,32 +64,32 @@ void TRDGeometry::CreatePadPlaneArray()
   fgPadPlaneArray.reset(new TRDPadPlane[kNlayer * kNstack]);
   for (int ilayer = 0; ilayer < kNlayer; ilayer++) {
     for (int istack = 0; istack < kNstack; istack++) {
-      CreatePadPlane(ilayer, istack);
+      createPadPlane(ilayer, istack);
     }
   }
 }
 
 //_____________________________________________________________________________
-void TRDGeometry::CreatePadPlane(int ilayer, int istack)
+void TRDGeometry::createPadPlane(int ilayer, int istack)
 {
   //
   // Creates an TRDPadPlane object
   //
-  int ipp = GetDetectorSec(ilayer, istack);
+  int ipp = getDetectorSec(ilayer, istack);
   auto& padPlane = fgPadPlaneArray.get()[ipp];
 
-  padPlane.SetLayer(ilayer);
-  padPlane.SetStack(istack);
+  padPlane.setLayer(ilayer);
+  padPlane.setStack(istack);
 
-  padPlane.SetRowSpacing(0.0);
-  padPlane.SetColSpacing(0.0);
+  padPlane.setRowSpacing(0.0);
+  padPlane.setColSpacing(0.0);
 
-  padPlane.SetLengthRim(1.0);
-  padPlane.SetWidthRim(0.5);
+  padPlane.setLengthRim(1.0);
+  padPlane.setWidthRim(0.5);
 
-  padPlane.SetNcols(144);
+  padPlane.setNcols(144);
 
-  padPlane.SetAnodeWireOffset(0.25);
+  padPlane.setAnodeWireOffset(0.25);
 
   //
   // The pad plane parameter
@@ -100,114 +99,114 @@ void TRDGeometry::CreatePadPlane(int ilayer, int istack)
     case 0:
       if (istack == 2) {
         // L0C0 type
-        padPlane.SetNrows(12);
-        padPlane.SetLength(108.0);
-        padPlane.SetLengthOPad(8.0);
-        padPlane.SetLengthIPad(9.0);
+        padPlane.setNrows(12);
+        padPlane.setLength(108.0);
+        padPlane.setLengthOPad(8.0);
+        padPlane.setLengthIPad(9.0);
       } else {
         // L0C1 type
-        padPlane.SetNrows(16);
-        padPlane.SetLength(122.0);
-        padPlane.SetLengthOPad(7.5);
-        padPlane.SetLengthIPad(7.5);
+        padPlane.setNrows(16);
+        padPlane.setLength(122.0);
+        padPlane.setLengthOPad(7.5);
+        padPlane.setLengthIPad(7.5);
       }
-      padPlane.SetWidth(92.2);
-      padPlane.SetWidthOPad(0.515);
-      padPlane.SetWidthIPad(0.635);
-      padPlane.SetTiltingAngle(-kTiltAngle);
+      padPlane.setWidth(92.2);
+      padPlane.setWidthOPad(0.515);
+      padPlane.setWidthIPad(0.635);
+      padPlane.setTiltingAngle(-kTiltAngle);
       break;
     case 1:
       if (istack == 2) {
         // L1C0 type
-        padPlane.SetNrows(12);
-        padPlane.SetLength(108.0);
-        padPlane.SetLengthOPad(8.0);
-        padPlane.SetLengthIPad(9.0);
+        padPlane.setNrows(12);
+        padPlane.setLength(108.0);
+        padPlane.setLengthOPad(8.0);
+        padPlane.setLengthIPad(9.0);
       } else {
         // L1C1 type
-        padPlane.SetNrows(16);
-        padPlane.SetLength(122.0);
-        padPlane.SetLengthOPad(7.5);
-        padPlane.SetLengthIPad(7.5);
+        padPlane.setNrows(16);
+        padPlane.setLength(122.0);
+        padPlane.setLengthOPad(7.5);
+        padPlane.setLengthIPad(7.5);
       }
-      padPlane.SetWidth(96.6);
-      padPlane.SetWidthOPad(0.585);
-      padPlane.SetWidthIPad(0.665);
-      padPlane.SetTiltingAngle(kTiltAngle);
+      padPlane.setWidth(96.6);
+      padPlane.setWidthOPad(0.585);
+      padPlane.setWidthIPad(0.665);
+      padPlane.setTiltingAngle(kTiltAngle);
       break;
     case 2:
       if (istack == 2) {
         // L2C0 type
-        padPlane.SetNrows(12);
-        padPlane.SetLength(108.0);
-        padPlane.SetLengthOPad(8.0);
-        padPlane.SetLengthIPad(9.0);
+        padPlane.setNrows(12);
+        padPlane.setLength(108.0);
+        padPlane.setLengthOPad(8.0);
+        padPlane.setLengthIPad(9.0);
       } else {
         // L2C1 type
-        padPlane.SetNrows(16);
-        padPlane.SetLength(129.0);
-        padPlane.SetLengthOPad(7.5);
-        padPlane.SetLengthIPad(8.0);
+        padPlane.setNrows(16);
+        padPlane.setLength(129.0);
+        padPlane.setLengthOPad(7.5);
+        padPlane.setLengthIPad(8.0);
       }
-      padPlane.SetWidth(101.1);
-      padPlane.SetWidthOPad(0.705);
-      padPlane.SetWidthIPad(0.695);
-      padPlane.SetTiltingAngle(-kTiltAngle);
+      padPlane.setWidth(101.1);
+      padPlane.setWidthOPad(0.705);
+      padPlane.setWidthIPad(0.695);
+      padPlane.setTiltingAngle(-kTiltAngle);
       break;
     case 3:
       if (istack == 2) {
         // L3C0 type
-        padPlane.SetNrows(12);
-        padPlane.SetLength(108.0);
-        padPlane.SetLengthOPad(8.0);
-        padPlane.SetLengthIPad(9.0);
+        padPlane.setNrows(12);
+        padPlane.setLength(108.0);
+        padPlane.setLengthOPad(8.0);
+        padPlane.setLengthIPad(9.0);
       } else {
         // L3C1 type
-        padPlane.SetNrows(16);
-        padPlane.SetLength(136.0);
-        padPlane.SetLengthOPad(7.5);
-        padPlane.SetLengthIPad(8.5);
+        padPlane.setNrows(16);
+        padPlane.setLength(136.0);
+        padPlane.setLengthOPad(7.5);
+        padPlane.setLengthIPad(8.5);
       }
-      padPlane.SetWidth(105.5);
-      padPlane.SetWidthOPad(0.775);
-      padPlane.SetWidthIPad(0.725);
-      padPlane.SetTiltingAngle(kTiltAngle);
+      padPlane.setWidth(105.5);
+      padPlane.setWidthOPad(0.775);
+      padPlane.setWidthIPad(0.725);
+      padPlane.setTiltingAngle(kTiltAngle);
       break;
     case 4:
       if (istack == 2) {
         // L4C0 type
-        padPlane.SetNrows(12);
-        padPlane.SetLength(108.0);
-        padPlane.SetLengthOPad(8.0);
+        padPlane.setNrows(12);
+        padPlane.setLength(108.0);
+        padPlane.setLengthOPad(8.0);
       } else {
         // L4C1 type
-        padPlane.SetNrows(16);
-        padPlane.SetLength(143.0);
-        padPlane.SetLengthOPad(7.5);
+        padPlane.setNrows(16);
+        padPlane.setLength(143.0);
+        padPlane.setLengthOPad(7.5);
       }
-      padPlane.SetWidth(109.9);
-      padPlane.SetWidthOPad(0.845);
-      padPlane.SetLengthIPad(9.0);
-      padPlane.SetWidthIPad(0.755);
-      padPlane.SetTiltingAngle(-kTiltAngle);
+      padPlane.setWidth(109.9);
+      padPlane.setWidthOPad(0.845);
+      padPlane.setLengthIPad(9.0);
+      padPlane.setWidthIPad(0.755);
+      padPlane.setTiltingAngle(-kTiltAngle);
       break;
     case 5:
       if (istack == 2) {
         // L5C0 type
-        padPlane.SetNrows(12);
-        padPlane.SetLength(108.0);
-        padPlane.SetLengthOPad(8.0);
+        padPlane.setNrows(12);
+        padPlane.setLength(108.0);
+        padPlane.setLengthOPad(8.0);
       } else {
         // L5C1 type
-        padPlane.SetNrows(16);
-        padPlane.SetLength(145.0);
-        padPlane.SetLengthOPad(8.5);
+        padPlane.setNrows(16);
+        padPlane.setLength(145.0);
+        padPlane.setLengthOPad(8.5);
       }
-      padPlane.SetWidth(114.4);
-      padPlane.SetWidthOPad(0.965);
-      padPlane.SetLengthIPad(9.0);
-      padPlane.SetWidthIPad(0.785);
-      padPlane.SetTiltingAngle(kTiltAngle);
+      padPlane.setWidth(114.4);
+      padPlane.setWidthOPad(0.965);
+      padPlane.setLengthIPad(9.0);
+      padPlane.setWidthIPad(0.785);
+      padPlane.setTiltingAngle(kTiltAngle);
       break;
   };
 
@@ -216,36 +215,36 @@ void TRDGeometry::CreatePadPlane(int ilayer, int istack)
   //
   // Row direction
   //
-  double row = fgkClength[ilayer][istack] / 2.0 - fgkRpadW - padPlane.GetLengthRim();
-  for (int ir = 0; ir < padPlane.GetNrows(); ir++) {
-    padPlane.SetPadRow(ir, row);
-    row -= padPlane.GetRowSpacing();
+  float row = fgkClength[ilayer][istack] / 2.0 - fgkRpadW - padPlane.getLengthRim();
+  for (int ir = 0; ir < padPlane.getNrows(); ir++) {
+    padPlane.setPadRow(ir, row);
+    row -= padPlane.getRowSpacing();
     if (ir == 0) {
-      row -= padPlane.GetLengthOPad();
+      row -= padPlane.getLengthOPad();
     } else {
-      row -= padPlane.GetLengthIPad();
+      row -= padPlane.getLengthIPad();
     }
   }
   //
   // Column direction
   //
-  double col = -fgkCwidth[ilayer] / 2.0 - fgkCroW + padPlane.GetWidthRim();
-  for (int ic = 0; ic < padPlane.GetNcols(); ic++) {
-    padPlane.SetPadCol(ic, col);
-    col += padPlane.GetColSpacing();
+  float col = -fgkCwidth[ilayer] / 2.0 - fgkCroW + padPlane.getWidthRim();
+  for (int ic = 0; ic < padPlane.getNcols(); ic++) {
+    padPlane.setPadCol(ic, col);
+    col += padPlane.getColSpacing();
     if (ic == 0) {
-      col += padPlane.GetWidthOPad();
+      col += padPlane.getWidthOPad();
     } else {
-      col += padPlane.GetWidthIPad();
+      col += padPlane.getWidthIPad();
     }
   }
   // Calculate the offset to translate from the local ROC system into
   // the local supermodule system, which is used for clusters
-  double rowTmp = fgkClength[ilayer][0] + fgkClength[ilayer][1] + fgkClength[ilayer][2] / 2.0;
+  float rowTmp = fgkClength[ilayer][0] + fgkClength[ilayer][1] + fgkClength[ilayer][2] / 2.0;
   for (int jstack = 0; jstack < istack; jstack++) {
     rowTmp -= fgkClength[ilayer][jstack];
   }
-  padPlane.SetPadRowSMOffset(rowTmp - fgkClength[ilayer][istack] / 2.0);
+  padPlane.setPadRowSMOffset(rowTmp - fgkClength[ilayer][istack] / 2.0);
 }
 
 void TRDGeometry::createVolume(const char* name, const char* shape, int nmed, float* upar, int np)
@@ -260,7 +259,7 @@ void TRDGeometry::createVolume(const char* name, const char* shape, int nmed, fl
 }
 
 //_____________________________________________________________________________
-void TRDGeometry::CreateGeometry(std::vector<int> const& idtmed)
+void TRDGeometry::createGeometry(std::vector<int> const& idtmed)
 {
   //
   // Create the TRD geometry
@@ -270,12 +269,12 @@ void TRDGeometry::CreateGeometry(std::vector<int> const& idtmed)
     LOG(FATAL) << "Geometry is not loaded" << FairLogger::endl;
   }
   
-  CreatePadPlaneArray();
+  createPadPlaneArray();
   mPadPlaneArray = fgPadPlaneArray.get();
-  CreateVolumes(idtmed);
+  createVolumes(idtmed);
 }
 
-void TRDGeometry::CreateVolumes(std::vector<int> const& idtmed)
+void TRDGeometry::createVolumes(std::vector<int> const& idtmed)
 {
   //
   // Create the TRD geometry volumes
@@ -382,7 +381,7 @@ void TRDGeometry::CreateVolumes(std::vector<int> const& idtmed)
 
   for (int istack = 0; istack < kNstack; istack++) {
     for (int ilayer = 0; ilayer < kNlayer; ilayer++) {
-      int iDet = GetDetectorSec(ilayer, istack);
+      int iDet = getDetectorSec(ilayer, istack);
 
       // The lower part of the readout chambers (drift volume + radiator)
       // The aluminum frames
@@ -709,14 +708,14 @@ void TRDGeometry::CreateVolumes(std::vector<int> const& idtmed)
   }
 
   // Create the volumes of the super module frame
-  CreateFrame(idtmed);
+  createFrame(idtmed);
 
   // Create the volumes of the services
-  CreateServices(idtmed);
+  createServices(idtmed);
 
   for (int istack = 0; istack < kNstack; istack++) {
     for (int ilayer = 0; ilayer < kNlayer; ilayer++) {
-      AssembleChamber(ilayer, istack);
+      assembleChamber(ilayer, istack);
     }
   }
 
@@ -742,7 +741,7 @@ void TRDGeometry::CreateVolumes(std::vector<int> const& idtmed)
   ypos = 0.0;
   zpos = 0.0;
   for (int isector = 0; isector < kNsector; isector++) {
-    if (GetSMstatus(isector)) {
+    if (getSMstatus(isector)) {
       snprintf(cTagV, kTag, "BTRD%d", isector);
       switch (isector) {
         case 17:
@@ -773,7 +772,7 @@ void TRDGeometry::CreateVolumes(std::vector<int> const& idtmed)
   ypos = 0.5 * fgkSlength + 0.5 * fgkFlength;
   zpos = 0.0;
   for (int isector = 0; isector < kNsector; isector++) {
-    if (GetSMstatus(isector)) {
+    if (getSMstatus(isector)) {
       snprintf(cTagV, kTag, "BTRD%d", isector);
       TVirtualMC::GetMC()->Gspos("UTF1", 1, cTagV, xpos, ypos, zpos, 0, "ONLY");
       TVirtualMC::GetMC()->Gspos("UTF2", 1, cTagV, xpos, -ypos, zpos, 0, "ONLY");
@@ -791,7 +790,7 @@ void TRDGeometry::CreateVolumes(std::vector<int> const& idtmed)
 }
 
 //_____________________________________________________________________________
-void TRDGeometry::CreateFrame(std::vector<int> const& idtmed)
+void TRDGeometry::createFrame(std::vector<int> const& idtmed)
 {
   //
   // Create the geometry of the frame of the supermodule
@@ -1513,7 +1512,7 @@ void TRDGeometry::CreateFrame(std::vector<int> const& idtmed)
 }
 
 //_____________________________________________________________________________
-void TRDGeometry::CreateServices(std::vector<int> const& idtmed)
+void TRDGeometry::createServices(std::vector<int> const& idtmed)
 {
   //
   // Create the geometry of the services
@@ -1912,7 +1911,7 @@ void TRDGeometry::CreateServices(std::vector<int> const& idtmed)
 
   for (istack = 0; istack < kNstack; istack++) {
     for (ilayer = 0; ilayer < kNlayer; ilayer++) {
-      int iDet = GetDetectorSec(ilayer, istack);
+      int iDet = getDetectorSec(ilayer, istack);
 
       snprintf(cTagV, kTag, "UU%02d", iDet);
       parServ[0] = fgkCwidth[ilayer] / 2.0;
@@ -1945,10 +1944,10 @@ void TRDGeometry::CreateServices(std::vector<int> const& idtmed)
   // Position the cooling pipes in the mother volume
   for (istack = 0; istack < kNstack; istack++) {
     for (ilayer = 0; ilayer < kNlayer; ilayer++) {
-      int iDet = GetDetectorSec(ilayer, istack);
-      int iCopy = GetDetector(ilayer, istack, 0) * 100;
-      int nMCMrow = GetRowMax(ilayer, istack, 0);
-      float ySize = (GetChamberLength(ilayer, istack) - 2.0 * fgkRpadW) / ((float)nMCMrow);
+      int iDet = getDetectorSec(ilayer, istack);
+      int iCopy = getDetector(ilayer, istack, 0) * 100;
+      int nMCMrow = getRowMax(ilayer, istack, 0);
+      float ySize = (getChamberLength(ilayer, istack) - 2.0 * fgkRpadW) / ((float)nMCMrow);
       snprintf(cTagV, kTag, "UU%02d", iDet);
       for (int iMCMrow = 0; iMCMrow < nMCMrow; iMCMrow++) {
         xpos = 0.0;
@@ -1977,10 +1976,10 @@ void TRDGeometry::CreateServices(std::vector<int> const& idtmed)
   // Position the power lines in the mother volume
   for (istack = 0; istack < kNstack; istack++) {
     for (ilayer = 0; ilayer < kNlayer; ilayer++) {
-      int iDet = GetDetectorSec(ilayer, istack);
-      int iCopy = GetDetector(ilayer, istack, 0) * 100;
-      int nMCMrow = GetRowMax(ilayer, istack, 0);
-      float ySize = (GetChamberLength(ilayer, istack) - 2.0 * fgkRpadW) / ((float)nMCMrow);
+      int iDet = getDetectorSec(ilayer, istack);
+      int iCopy = getDetector(ilayer, istack, 0) * 100;
+      int nMCMrow = getRowMax(ilayer, istack, 0);
+      float ySize = (getChamberLength(ilayer, istack) - 2.0 * fgkRpadW) / ((float)nMCMrow);
       snprintf(cTagV, kTag, "UU%02d", iDet);
       for (int iMCMrow = 0; iMCMrow < nMCMrow; iMCMrow++) {
         xpos = 0.0;
@@ -2052,12 +2051,12 @@ void TRDGeometry::CreateServices(std::vector<int> const& idtmed)
   // Position the MCMs in the mother volume
   for (istack = 0; istack < kNstack; istack++) {
     for (ilayer = 0; ilayer < kNlayer; ilayer++) {
-      int iDet = GetDetectorSec(ilayer, istack);
-      int iCopy = GetDetector(ilayer, istack, 0) * 1000;
-      int nMCMrow = GetRowMax(ilayer, istack, 0);
-      float ySize = (GetChamberLength(ilayer, istack) - 2.0 * fgkRpadW) / ((float)nMCMrow);
+      int iDet = getDetectorSec(ilayer, istack);
+      int iCopy = getDetector(ilayer, istack, 0) * 1000;
+      int nMCMrow = getRowMax(ilayer, istack, 0);
+      float ySize = (getChamberLength(ilayer, istack) - 2.0 * fgkRpadW) / ((float)nMCMrow);
       int nMCMcol = 8;
-      float xSize = (GetChamberWidth(ilayer) - 2.0 * fgkCpadW) / ((float)nMCMcol + 6); // Introduce 6 gaps
+      float xSize = (getChamberWidth(ilayer) - 2.0 * fgkCpadW) / ((float)nMCMcol + 6); // Introduce 6 gaps
       int iMCM[8] = { 1, 2, 3, 5, 8, 9, 10, 12 };                                      // 0..7 MCM + 6 gap structure
       snprintf(cTagV, kTag, "UU%02d", iDet);
       for (int iMCMrow = 0; iMCMrow < nMCMrow; iMCMrow++) {
@@ -2132,10 +2131,10 @@ void TRDGeometry::CreateServices(std::vector<int> const& idtmed)
   // Put the DCS board in the chamber services mother volume
   for (istack = 0; istack < kNstack; istack++) {
     for (ilayer = 0; ilayer < kNlayer; ilayer++) {
-      int iDet = GetDetectorSec(ilayer, istack);
+      int iDet = getDetectorSec(ilayer, istack);
       int iCopy = iDet + 1;
       xpos = fgkCwidth[ilayer] / 2.0 -
-             1.9 * (GetChamberLength(ilayer, istack) - 2.0 * fgkRpadW) / ((float)GetRowMax(ilayer, istack, 0));
+             1.9 * (getChamberLength(ilayer, istack) - 2.0 * fgkRpadW) / ((float)getRowMax(ilayer, istack, 0));
       ypos = 0.05 * fgkClength[ilayer][istack];
       zpos = kDCSz / 2.0 - fgkCsvH / 2.0;
       snprintf(cTagV, kTag, "UU%02d", iDet);
@@ -2192,16 +2191,16 @@ void TRDGeometry::CreateServices(std::vector<int> const& idtmed)
   // Put the ORI board in the chamber services mother volume
   for (istack = 0; istack < kNstack; istack++) {
     for (ilayer = 0; ilayer < kNlayer; ilayer++) {
-      int iDet = GetDetectorSec(ilayer, istack);
+      int iDet = getDetectorSec(ilayer, istack);
       int iCopy = iDet + 1;
       xpos = fgkCwidth[ilayer] / 2.0 -
-             1.92 * (GetChamberLength(ilayer, istack) - 2.0 * fgkRpadW) / ((float)GetRowMax(ilayer, istack, 0));
+             1.92 * (getChamberLength(ilayer, istack) - 2.0 * fgkRpadW) / ((float)getRowMax(ilayer, istack, 0));
       ypos = -16.0;
       zpos = kORIz / 2.0 - fgkCsvH / 2.0;
       snprintf(cTagV, kTag, "UU%02d", iDet);
       TVirtualMC::GetMC()->Gspos("UORI", iCopy, cTagV, xpos, ypos, zpos, 0, "ONLY");
       xpos = -fgkCwidth[ilayer] / 2.0 +
-             3.8 * (GetChamberLength(ilayer, istack) - 2.0 * fgkRpadW) / ((float)GetRowMax(ilayer, istack, 0));
+             3.8 * (getChamberLength(ilayer, istack) - 2.0 * fgkRpadW) / ((float)getRowMax(ilayer, istack, 0));
       ypos = -16.0;
       zpos = kORIz / 2.0 - fgkCsvH / 2.0;
       snprintf(cTagV, kTag, "UU%02d", iDet);
@@ -2455,7 +2454,7 @@ void TRDGeometry::CreateServices(std::vector<int> const& idtmed)
 }
 
 //_____________________________________________________________________________
-void TRDGeometry::AssembleChamber(int ilayer, int istack)
+void TRDGeometry::assembleChamber(int ilayer, int istack)
 {
   //
   // Group volumes UA, UD, UF, UU into an assembly that defines the
@@ -2470,7 +2469,7 @@ void TRDGeometry::AssembleChamber(int ilayer, int istack)
   double ypos = 0.0;
   double zpos = 0.0;
 
-  int idet = GetDetectorSec(ilayer, istack);
+  int idet = getDetectorSec(ilayer, istack);
 
   // Create the assembly for a given ROC
   snprintf(cTagM, kTag, "UT%02d", idet);
@@ -2574,7 +2573,7 @@ void TRDGeometry::fillMatrixCache(int mask)
   for (int ilayer = 0; ilayer < kNlayer; ilayer++) {
     for (int isector = 0; isector < kNsector; isector++ ) {
       for (int istack = 0; istack < kNstack; istack++) {
-        Int_t lid = GetDetector(ilayer,istack,isector);
+        Int_t lid = getDetector(ilayer,istack,isector);
         // Check for disabled supermodules
         volPath  = vpStr;
         volPath += std::to_string(isector);
@@ -2666,11 +2665,11 @@ void TRDGeometry::addAlignableVolumes() const
   // The symbolic names are: TRD/sm00/st0/pl0 ... TRD/sm17/st4/pl5
   
   for (int isector = 0; isector < kNsector; isector++ ) {
-    if (!GetSMstatus(isector)) continue;
+    if (!getSMstatus(isector)) continue;
     for (int ilayer = 0; ilayer < kNlayer; ilayer++) {
       for (int istack = 0; istack < kNstack; istack++) {
-        Int_t lid = GetDetector(ilayer,istack,isector);
-        int idet = GetDetectorSec(ilayer, istack);
+        Int_t lid = getDetector(ilayer,istack,isector);
+        int idet = getDetectorSec(ilayer, istack);
 
         // Check for disabled supermodules
         volPath  = vpStr;
@@ -2745,7 +2744,7 @@ bool TRDGeometry::createClusterMatrixArray()
 }
 
 //_____________________________________________________________________________
-const TRDGeometry::Mat3D* TRDGeometry::GetClusterMatrix(int det)
+const TRDGeometry::Mat3D* TRDGeometry::getClusterMatrix(int det)
 {
   //
   // Returns the cluster transformation matrix for a given detector
@@ -2755,7 +2754,7 @@ const TRDGeometry::Mat3D* TRDGeometry::GetClusterMatrix(int det)
 }
 
 //_____________________________________________________________________________
-bool TRDGeometry::ChamberInGeometry(int det)
+bool TRDGeometry::chamberInGeometry(int det)
 {
   //
   // Checks whether the given detector is part of the current geometry

--- a/Detectors/TRD/base/src/TRDGeometryBase.cxx
+++ b/Detectors/TRD/base/src/TRDGeometryBase.cxx
@@ -16,163 +16,7 @@
 using namespace o2::trd;
 
 //_____________________________________________________________________________
-
-//
-// Dimensions of the detector
-//
-
-// Total length of the TRD mother volume
-const float TRDGeometryBase::fgkTlength = 751.0;
-
-// Parameter of the super module mother volumes
-const float TRDGeometryBase::fgkSheight = 77.9;
-const float TRDGeometryBase::fgkSwidth1 = 94.881;
-const float TRDGeometryBase::fgkSwidth2 = 122.353;
-const float TRDGeometryBase::fgkSlength = 702.0;
-
-// Length of the additional space in front of the supermodule
-// used for services
-const float TRDGeometryBase::fgkFlength = (TRDGeometryBase::fgkTlength - TRDGeometryBase::fgkSlength) / 2.0;
-
-// The super module side plates
-const float TRDGeometryBase::fgkSMpltT = 0.2;
-
-// Vertical spacing of the chambers
-const float TRDGeometryBase::fgkVspace = 1.784;
-// Horizontal spacing of the chambers
-const float TRDGeometryBase::fgkHspace = 2.0;
-// Radial distance of the first ROC to the outer plates of the SM
-const float TRDGeometryBase::fgkVrocsm = 1.2;
-
-// Height of different chamber parts
-// Radiator
-const float TRDGeometryBase::fgkCraH = 4.8;
-// Drift region
-const float TRDGeometryBase::fgkCdrH = 3.0;
-// Amplification region
-const float TRDGeometryBase::fgkCamH = 0.7;
-// Readout
-const float TRDGeometryBase::fgkCroH = 2.316;
-// Additional width of the readout chamber frames
-const float TRDGeometryBase::fgkCroW = 0.9;
-// Services on top of ROC
-const float TRDGeometryBase::fgkCsvH = TRDGeometryBase::fgkVspace - 0.742;
-// Total height (w/o services)
-const float TRDGeometryBase::fgkCH =
-  TRDGeometryBase::fgkCraH + TRDGeometryBase::fgkCdrH + TRDGeometryBase::fgkCamH + TRDGeometryBase::fgkCroH;
-// Total height (with services)
-
-const float TRDGeometryBase::fgkCHsv = TRDGeometryBase::fgkCH + TRDGeometryBase::fgkCsvH;
-
-// Distance of anode wire plane relative to middle of alignable volume
-const float TRDGeometryBase::fgkAnodePos =
-  TRDGeometryBase::fgkCraH + TRDGeometryBase::fgkCdrH + TRDGeometryBase::fgkCamH / 2.0 - TRDGeometryBase::fgkCHsv / 2.0;
-
-// Thicknesses of different parts of the chamber frame
-// Lower aluminum frame
-const float TRDGeometryBase::fgkCalT = 0.4;
-// Lower Wacosit frame sides
-const float TRDGeometryBase::fgkCclsT = 0.21;
-// Lower Wacosit frame front
-const float TRDGeometryBase::fgkCclfT = 1.0;
-// Thickness of glue around radiator
-const float TRDGeometryBase::fgkCglT = 0.25;
-// Upper Wacosit frame around amplification region
-const float TRDGeometryBase::fgkCcuTa = 1.0;
-const float TRDGeometryBase::fgkCcuTb = 0.8;
-// Al frame of back panel
-const float TRDGeometryBase::fgkCauT = 1.5;
-// Additional Al ledge at the lower chamber frame
-// Actually the dimensions are not realistic, but
-// modified in order to allow to mis-alignment.
-// The amount of material is, however, correct
-const float TRDGeometryBase::fgkCalW = 2.5;
-const float TRDGeometryBase::fgkCalH = 0.4;
-const float TRDGeometryBase::fgkCalWmod = 0.4;
-const float TRDGeometryBase::fgkCalHmod = 2.5;
-// Additional Wacosit ledge at the lower chamber frame
-const float TRDGeometryBase::fgkCwsW = 1.2;
-const float TRDGeometryBase::fgkCwsH = 0.3;
-
-// Difference of outer chamber width and pad plane width
-const float TRDGeometryBase::fgkCpadW = 0.0;
-const float TRDGeometryBase::fgkRpadW = 1.0;
-
-//
-// Thickness of the the material layers
-//
-const float TRDGeometryBase::fgkDrThick = TRDGeometryBase::fgkCdrH;
-const float TRDGeometryBase::fgkAmThick = TRDGeometryBase::fgkCamH;
-const float TRDGeometryBase::fgkXeThick = TRDGeometryBase::fgkDrThick + TRDGeometryBase::fgkAmThick;
-const float TRDGeometryBase::fgkWrThick = 0.00011;
-
-const float TRDGeometryBase::fgkRMyThick = 0.0015;
-const float TRDGeometryBase::fgkRCbThick = 0.0055;
-const float TRDGeometryBase::fgkRGlThick = 0.0065;
-const float TRDGeometryBase::fgkRRhThick = 0.8;
-const float TRDGeometryBase::fgkRFbThick = fgkCraH - 2.0 * (fgkRMyThick + fgkRCbThick + fgkRRhThick);
-
-const float TRDGeometryBase::fgkPPdThick = 0.0025;
-const float TRDGeometryBase::fgkPPpThick = 0.0356;
-const float TRDGeometryBase::fgkPGlThick = 0.1428;
-const float TRDGeometryBase::fgkPCbThick = 0.019;
-const float TRDGeometryBase::fgkPPcThick = 0.0486;
-const float TRDGeometryBase::fgkPRbThick = 0.0057;
-const float TRDGeometryBase::fgkPElThick = 0.0029;
-const float TRDGeometryBase::fgkPHcThick =
-  fgkCroH - fgkPPdThick - fgkPPpThick - fgkPGlThick - fgkPCbThick * 2.0 - fgkPPcThick - fgkPRbThick - fgkPElThick;
-
-//
-// Position of the material layers
-//
-const float TRDGeometryBase::fgkDrZpos = 2.4;
-const float TRDGeometryBase::fgkAmZpos = 0.0;
-const float TRDGeometryBase::fgkWrZposA = 0.0;
-const float TRDGeometryBase::fgkWrZposB = -fgkAmThick / 2.0 + 0.001;
-const float TRDGeometryBase::fgkCalZpos = 0.3;
-
-const int TRDGeometryBase::fgkMCMmax = 16;
-const int TRDGeometryBase::fgkMCMrow = 4;
-const int TRDGeometryBase::fgkROBmaxC0 = 6;
-const int TRDGeometryBase::fgkROBmaxC1 = 8;
-const int TRDGeometryBase::fgkADCmax = 21;
-const int TRDGeometryBase::fgkTBmax = 60;
-const int TRDGeometryBase::fgkPadmax = 18;
-const int TRDGeometryBase::fgkColmax = 144;
-const int TRDGeometryBase::fgkRowmaxC0 = 12;
-const int TRDGeometryBase::fgkRowmaxC1 = 16;
-
-const double TRDGeometryBase::fgkTime0Base = 300.65;
-const float TRDGeometryBase::fgkTime0[6] = { static_cast<float>(fgkTime0Base + 0 * (Cheight() + Cspace())),
-                                         static_cast<float>(fgkTime0Base + 1 * (Cheight() + Cspace())),
-                                         static_cast<float>(fgkTime0Base + 2 * (Cheight() + Cspace())),
-                                         static_cast<float>(fgkTime0Base + 3 * (Cheight() + Cspace())),
-                                         static_cast<float>(fgkTime0Base + 4 * (Cheight() + Cspace())),
-                                         static_cast<float>(fgkTime0Base + 5 * (Cheight() + Cspace())) };
-
-const double TRDGeometryBase::fgkXtrdBeg = 288.43; // Values depend on position of TRD
-const double TRDGeometryBase::fgkXtrdEnd = 366.33; // mother volume inside space frame !!!
-
-// The outer width of the chambers
-const float TRDGeometryBase::fgkCwidth[kNlayer] = { 90.4, 94.8, 99.3, 103.7, 108.1, 112.6 };
-
-// The outer lengths of the chambers
-// Includes the spacings between the chambers!
-const float TRDGeometryBase::fgkClength[kNlayer][kNstack] = {
-  { 124.0, 124.0, 110.0, 124.0, 124.0 }, { 124.0, 124.0, 110.0, 124.0, 124.0 }, { 131.0, 131.0, 110.0, 131.0, 131.0 },
-  { 138.0, 138.0, 110.0, 138.0, 138.0 }, { 145.0, 145.0, 110.0, 145.0, 145.0 }, { 147.0, 147.0, 110.0, 147.0, 147.0 }
-};
-
-//_____________________________________________________________________________
-TRDGeometryBase::TRDGeometryBase()
-{
-  //
-  // TRDGeometry default constructor
-  //
-}
-
-//_____________________________________________________________________________
-int TRDGeometryBase::GetDetectorSec(int layer, int stack)
+int TRDGeometryBase::getDetectorSec(int layer, int stack) const
 {
   //
   // Convert plane / stack into detector number for one single sector
@@ -182,7 +26,7 @@ int TRDGeometryBase::GetDetectorSec(int layer, int stack)
 }
 
 //_____________________________________________________________________________
-int TRDGeometryBase::GetDetector(int layer, int stack, int sector)
+int TRDGeometryBase::getDetector(int layer, int stack, int sector) const
 {
   //
   // Convert layer / stack / sector into detector number
@@ -192,7 +36,7 @@ int TRDGeometryBase::GetDetector(int layer, int stack, int sector)
 }
 
 //_____________________________________________________________________________
-int TRDGeometryBase::GetLayer(int det)
+int TRDGeometryBase::getLayer(int det) const
 {
   //
   // Reconstruct the layer number from the detector number
@@ -202,7 +46,7 @@ int TRDGeometryBase::GetLayer(int det)
 }
 
 //_____________________________________________________________________________
-int TRDGeometryBase::GetStack(int det) const
+int TRDGeometryBase::getStack(int det) const
 {
   //
   // Reconstruct the stack number from the detector number
@@ -212,7 +56,7 @@ int TRDGeometryBase::GetStack(int det) const
 }
 
 //_____________________________________________________________________________
-int TRDGeometryBase::GetStack(double z, int layer) const
+int TRDGeometryBase::getStack(float z, int layer) const
 {
   //
   // Reconstruct the chamber number from the z position and layer number
@@ -224,75 +68,75 @@ int TRDGeometryBase::GetStack(double z, int layer) const
     return -1;
 
   int istck = kNstack;
-  double zmin = 0.0;
-  double zmax = 0.0;
+  float zmin = 0.0;
+  float zmax = 0.0;
 
   do {
     istck--;
     if (istck < 0)
       break;
-    TRDPadPlane* pp = GetPadPlane(layer, istck);
-    zmax = pp->GetRow0();
-    int nrows = pp->GetNrows();
-    zmin = zmax - 2 * pp->GetLengthOPad() - (nrows - 2) * pp->GetLengthIPad() - (nrows - 1) * pp->GetRowSpacing();
+    TRDPadPlane* pp = getPadPlane(layer, istck);
+    zmax = pp->getRow0();
+    int nrows = pp->getNrows();
+    zmin = zmax - 2 * pp->getLengthOPad() - (nrows - 2) * pp->getLengthIPad() - (nrows - 1) * pp->getRowSpacing();
   } while ((z < zmin) || (z > zmax));
 
   return istck;
 }
 
 //_____________________________________________________________________________
-TRDPadPlane* TRDGeometryBase::GetPadPlane(int layer, int stack) const
+TRDPadPlane* TRDGeometryBase::getPadPlane(int layer, int stack) const
 {
   //
   // Returns the pad plane for a given plane <pl> and stack <st> number
   //
 
-  int ipp = GetDetectorSec(layer, stack);
+  int ipp = getDetectorSec(layer, stack);
   return &mPadPlaneArray[ipp];
 }
 
 //_____________________________________________________________________________
-int TRDGeometryBase::GetRowMax(int layer, int stack, int /*sector*/) const
+int TRDGeometryBase::getRowMax(int layer, int stack, int /*sector*/) const
 {
   //
   // Returns the number of rows on the pad plane
   //
 
-  return GetPadPlane(layer, stack)->GetNrows();
+  return getPadPlane(layer, stack)->getNrows();
 }
 
 //_____________________________________________________________________________
-int TRDGeometryBase::GetColMax(int layer) const
+int TRDGeometryBase::getColMax(int layer) const
 {
   //
   // Returns the number of rows on the pad plane
   //
 
-  return GetPadPlane(layer, 0)->GetNcols();
+  return getPadPlane(layer, 0)->getNcols();
 }
 
 //_____________________________________________________________________________
-double TRDGeometryBase::GetRow0(int layer, int stack, int /*sector*/) const
+float TRDGeometryBase::getRow0(int layer, int stack, int /*sector*/) const
 {
   //
   // Returns the position of the border of the first pad in a row
   //
 
-  return GetPadPlane(layer, stack)->GetRow0();
+  return getPadPlane(layer, stack)->getRow0();
 }
 
 //_____________________________________________________________________________
-double TRDGeometryBase::GetCol0(int layer) const
+float TRDGeometryBase::getCol0(int layer) const
 {
   //
   // Returns the position of the border of the first pad in a column
   //
 
-  return GetPadPlane(layer, 0)->GetCol0();
+  return getPadPlane(layer, 0)->getCol0();
 }
 
 //_____________________________________________________________________________
-bool TRDGeometryBase::IsHole(int /*la*/, int st, int se) const
+bool TRDGeometryBase::isHole(int /*la*/, int st, int se) const
 {
   //
   // Checks for holes in front of PHOS
@@ -306,34 +150,34 @@ bool TRDGeometryBase::IsHole(int /*la*/, int st, int se) const
 }
 
 //_____________________________________________________________________________
-bool TRDGeometryBase::IsOnBoundary(int det, float y, float z, float eps) const
+bool TRDGeometryBase::isOnBoundary(int det, float y, float z, float eps) const
 {
   //
   // Checks whether position is at the boundary of the sensitive volume
   //
 
-  int ly = GetLayer(det);
+  int ly = getLayer(det);
   if ((ly < 0) || (ly >= kNlayer))
     return true;
 
-  int stk = GetStack(det);
+  int stk = getStack(det);
   if ((stk < 0) || (stk >= kNstack))
     return true;
 
-  TRDPadPlane* pp = &mPadPlaneArray[GetDetectorSec(ly, stk)];
+  TRDPadPlane* pp = &mPadPlaneArray[getDetectorSec(ly, stk)];
   if (!pp)
     return true;
 
-  double max = pp->GetRow0();
-  int n = pp->GetNrows();
-  double min = max - 2 * pp->GetLengthOPad() - (n - 2) * pp->GetLengthIPad() - (n - 1) * pp->GetRowSpacing();
+  float max = pp->getRow0();
+  int n = pp->getNrows();
+  float min = max - 2 * pp->getLengthOPad() - (n - 2) * pp->getLengthIPad() - (n - 1) * pp->getRowSpacing();
   if (z < min + eps || z > max - eps) {
     // printf("z : min[%7.2f (%7.2f)] %7.2f max[(%7.2f) %7.2f]\n", min, min+eps, z, max-eps, max);
     return true;
   }
-  min = pp->GetCol0();
-  n = pp->GetNcols();
-  max = min + 2 * pp->GetWidthOPad() + (n - 2) * pp->GetWidthIPad() + (n - 1) * pp->GetColSpacing();
+  min = pp->getCol0();
+  n = pp->getNcols();
+  max = min + 2 * pp->getWidthOPad() + (n - 2) * pp->getWidthIPad() + (n - 1) * pp->getColSpacing();
   if (y < min + eps || y > max - eps) {
     // printf("y : min[%7.2f (%7.2f)] %7.2f max[(%7.2f) %7.2f]\n", min, min+eps, y, max-eps, max);
     return true;

--- a/Detectors/TRD/base/src/TRDGeometryBase.cxx
+++ b/Detectors/TRD/base/src/TRDGeometryBase.cxx
@@ -18,14 +18,6 @@ using namespace o2::trd;
 //_____________________________________________________________________________
 
 //
-// The geometry constants
-//
-const int TRDGeometryBase::fgkNsector = kNsector;
-const int TRDGeometryBase::fgkNlayer = kNlayer;
-const int TRDGeometryBase::fgkNstack = kNstack;
-const int TRDGeometryBase::fgkNdet = kNdet;
-
-//
 // Dimensions of the detector
 //
 
@@ -196,7 +188,7 @@ int TRDGeometryBase::GetDetectorSec(int layer, int stack)
   // Convert plane / stack into detector number for one single sector
   //
 
-  return (layer + stack * fgkNlayer);
+  return (layer + stack * kNlayer);
 }
 
 //_____________________________________________________________________________
@@ -206,7 +198,7 @@ int TRDGeometryBase::GetDetector(int layer, int stack, int sector)
   // Convert layer / stack / sector into detector number
   //
 
-  return (layer + stack * fgkNlayer + sector * fgkNlayer * fgkNstack);
+  return (layer + stack * kNlayer + sector * kNlayer * kNstack);
 }
 
 //_____________________________________________________________________________
@@ -216,7 +208,7 @@ int TRDGeometryBase::GetLayer(int det)
   // Reconstruct the layer number from the detector number
   //
 
-  return ((int)(det % fgkNlayer));
+  return ((int)(det % kNlayer));
 }
 
 //_____________________________________________________________________________
@@ -226,7 +218,7 @@ int TRDGeometryBase::GetStack(int det) const
   // Reconstruct the stack number from the detector number
   //
 
-  return ((int)(det % (fgkNlayer * fgkNstack)) / fgkNlayer);
+  return ((int)(det % (kNlayer * kNstack)) / kNlayer);
 }
 
 //_____________________________________________________________________________
@@ -238,10 +230,10 @@ int TRDGeometryBase::GetStack(double z, int layer) const
   // The return function has to be protected for positiveness !!
   //
 
-  if ((layer < 0) || (layer >= fgkNlayer))
+  if ((layer < 0) || (layer >= kNlayer))
     return -1;
 
-  int istck = fgkNstack;
+  int istck = kNstack;
   double zmin = 0.0;
   double zmax = 0.0;
 
@@ -341,11 +333,11 @@ bool TRDGeometryBase::IsOnBoundary(int det, float y, float z, float eps) const
   //
 
   int ly = GetLayer(det);
-  if ((ly < 0) || (ly >= fgkNlayer))
+  if ((ly < 0) || (ly >= kNlayer))
     return true;
 
   int stk = GetStack(det);
-  if ((stk < 0) || (stk >= fgkNstack))
+  if ((stk < 0) || (stk >= kNstack))
     return true;
 
   TRDPadPlane* pp = &mPadPlaneArray[GetDetectorSec(ly, stk)];

--- a/Detectors/TRD/base/src/TRDGeometryBase.cxx
+++ b/Detectors/TRD/base/src/TRDGeometryBase.cxx
@@ -251,16 +251,6 @@ int TRDGeometryBase::GetStack(double z, int layer) const
 }
 
 //_____________________________________________________________________________
-int TRDGeometryBase::GetSector(int det)
-{
-  //
-  // Reconstruct the sector number from the detector number
-  //
-
-  return ((int)(det / (fgkNlayer * fgkNstack)));
-}
-
-//_____________________________________________________________________________
 TRDPadPlane* TRDGeometryBase::GetPadPlane(int layer, int stack) const
 {
   //

--- a/Detectors/TRD/base/src/TRDGeometryBase.cxx
+++ b/Detectors/TRD/base/src/TRDGeometryBase.cxx
@@ -163,21 +163,11 @@ const float TRDGeometryBase::fgkClength[kNlayer][kNstack] = {
   { 138.0, 138.0, 110.0, 138.0, 138.0 }, { 145.0, 145.0, 110.0, 145.0, 145.0 }, { 147.0, 147.0, 110.0, 147.0, 147.0 }
 };
 
-char TRDGeometryBase::fgSMstatus[kNsector] = { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 };
-
 //_____________________________________________________________________________
 TRDGeometryBase::TRDGeometryBase()
 {
   //
   // TRDGeometry default constructor
-  //
-}
-
-//_____________________________________________________________________________
-TRDGeometryBase::~TRDGeometryBase()
-{
-  //
-  // TRDGeometry destructor
   //
 }
 
@@ -351,5 +341,3 @@ bool TRDGeometryBase::IsOnBoundary(int det, float y, float z, float eps) const
 
   return false;
 }
-
-ClassImp(TRDGeometryBase)

--- a/Detectors/TRD/base/src/TRDGeometryBase.cxx
+++ b/Detectors/TRD/base/src/TRDGeometryBase.cxx
@@ -1,0 +1,373 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <FairLogger.h>
+
+#include "TRDBase/TRDGeometryBase.h"
+#include "TRDBase/TRDPadPlane.h"
+
+using namespace o2::trd;
+
+//_____________________________________________________________________________
+
+//
+// The geometry constants
+//
+const int TRDGeometryBase::fgkNsector = kNsector;
+const int TRDGeometryBase::fgkNlayer = kNlayer;
+const int TRDGeometryBase::fgkNstack = kNstack;
+const int TRDGeometryBase::fgkNdet = kNdet;
+
+//
+// Dimensions of the detector
+//
+
+// Total length of the TRD mother volume
+const float TRDGeometryBase::fgkTlength = 751.0;
+
+// Parameter of the super module mother volumes
+const float TRDGeometryBase::fgkSheight = 77.9;
+const float TRDGeometryBase::fgkSwidth1 = 94.881;
+const float TRDGeometryBase::fgkSwidth2 = 122.353;
+const float TRDGeometryBase::fgkSlength = 702.0;
+
+// Length of the additional space in front of the supermodule
+// used for services
+const float TRDGeometryBase::fgkFlength = (TRDGeometryBase::fgkTlength - TRDGeometryBase::fgkSlength) / 2.0;
+
+// The super module side plates
+const float TRDGeometryBase::fgkSMpltT = 0.2;
+
+// Vertical spacing of the chambers
+const float TRDGeometryBase::fgkVspace = 1.784;
+// Horizontal spacing of the chambers
+const float TRDGeometryBase::fgkHspace = 2.0;
+// Radial distance of the first ROC to the outer plates of the SM
+const float TRDGeometryBase::fgkVrocsm = 1.2;
+
+// Height of different chamber parts
+// Radiator
+const float TRDGeometryBase::fgkCraH = 4.8;
+// Drift region
+const float TRDGeometryBase::fgkCdrH = 3.0;
+// Amplification region
+const float TRDGeometryBase::fgkCamH = 0.7;
+// Readout
+const float TRDGeometryBase::fgkCroH = 2.316;
+// Additional width of the readout chamber frames
+const float TRDGeometryBase::fgkCroW = 0.9;
+// Services on top of ROC
+const float TRDGeometryBase::fgkCsvH = TRDGeometryBase::fgkVspace - 0.742;
+// Total height (w/o services)
+const float TRDGeometryBase::fgkCH =
+  TRDGeometryBase::fgkCraH + TRDGeometryBase::fgkCdrH + TRDGeometryBase::fgkCamH + TRDGeometryBase::fgkCroH;
+// Total height (with services)
+
+const float TRDGeometryBase::fgkCHsv = TRDGeometryBase::fgkCH + TRDGeometryBase::fgkCsvH;
+
+// Distance of anode wire plane relative to middle of alignable volume
+const float TRDGeometryBase::fgkAnodePos =
+  TRDGeometryBase::fgkCraH + TRDGeometryBase::fgkCdrH + TRDGeometryBase::fgkCamH / 2.0 - TRDGeometryBase::fgkCHsv / 2.0;
+
+// Thicknesses of different parts of the chamber frame
+// Lower aluminum frame
+const float TRDGeometryBase::fgkCalT = 0.4;
+// Lower Wacosit frame sides
+const float TRDGeometryBase::fgkCclsT = 0.21;
+// Lower Wacosit frame front
+const float TRDGeometryBase::fgkCclfT = 1.0;
+// Thickness of glue around radiator
+const float TRDGeometryBase::fgkCglT = 0.25;
+// Upper Wacosit frame around amplification region
+const float TRDGeometryBase::fgkCcuTa = 1.0;
+const float TRDGeometryBase::fgkCcuTb = 0.8;
+// Al frame of back panel
+const float TRDGeometryBase::fgkCauT = 1.5;
+// Additional Al ledge at the lower chamber frame
+// Actually the dimensions are not realistic, but
+// modified in order to allow to mis-alignment.
+// The amount of material is, however, correct
+const float TRDGeometryBase::fgkCalW = 2.5;
+const float TRDGeometryBase::fgkCalH = 0.4;
+const float TRDGeometryBase::fgkCalWmod = 0.4;
+const float TRDGeometryBase::fgkCalHmod = 2.5;
+// Additional Wacosit ledge at the lower chamber frame
+const float TRDGeometryBase::fgkCwsW = 1.2;
+const float TRDGeometryBase::fgkCwsH = 0.3;
+
+// Difference of outer chamber width and pad plane width
+const float TRDGeometryBase::fgkCpadW = 0.0;
+const float TRDGeometryBase::fgkRpadW = 1.0;
+
+//
+// Thickness of the the material layers
+//
+const float TRDGeometryBase::fgkDrThick = TRDGeometryBase::fgkCdrH;
+const float TRDGeometryBase::fgkAmThick = TRDGeometryBase::fgkCamH;
+const float TRDGeometryBase::fgkXeThick = TRDGeometryBase::fgkDrThick + TRDGeometryBase::fgkAmThick;
+const float TRDGeometryBase::fgkWrThick = 0.00011;
+
+const float TRDGeometryBase::fgkRMyThick = 0.0015;
+const float TRDGeometryBase::fgkRCbThick = 0.0055;
+const float TRDGeometryBase::fgkRGlThick = 0.0065;
+const float TRDGeometryBase::fgkRRhThick = 0.8;
+const float TRDGeometryBase::fgkRFbThick = fgkCraH - 2.0 * (fgkRMyThick + fgkRCbThick + fgkRRhThick);
+
+const float TRDGeometryBase::fgkPPdThick = 0.0025;
+const float TRDGeometryBase::fgkPPpThick = 0.0356;
+const float TRDGeometryBase::fgkPGlThick = 0.1428;
+const float TRDGeometryBase::fgkPCbThick = 0.019;
+const float TRDGeometryBase::fgkPPcThick = 0.0486;
+const float TRDGeometryBase::fgkPRbThick = 0.0057;
+const float TRDGeometryBase::fgkPElThick = 0.0029;
+const float TRDGeometryBase::fgkPHcThick =
+  fgkCroH - fgkPPdThick - fgkPPpThick - fgkPGlThick - fgkPCbThick * 2.0 - fgkPPcThick - fgkPRbThick - fgkPElThick;
+
+//
+// Position of the material layers
+//
+const float TRDGeometryBase::fgkDrZpos = 2.4;
+const float TRDGeometryBase::fgkAmZpos = 0.0;
+const float TRDGeometryBase::fgkWrZposA = 0.0;
+const float TRDGeometryBase::fgkWrZposB = -fgkAmThick / 2.0 + 0.001;
+const float TRDGeometryBase::fgkCalZpos = 0.3;
+
+const int TRDGeometryBase::fgkMCMmax = 16;
+const int TRDGeometryBase::fgkMCMrow = 4;
+const int TRDGeometryBase::fgkROBmaxC0 = 6;
+const int TRDGeometryBase::fgkROBmaxC1 = 8;
+const int TRDGeometryBase::fgkADCmax = 21;
+const int TRDGeometryBase::fgkTBmax = 60;
+const int TRDGeometryBase::fgkPadmax = 18;
+const int TRDGeometryBase::fgkColmax = 144;
+const int TRDGeometryBase::fgkRowmaxC0 = 12;
+const int TRDGeometryBase::fgkRowmaxC1 = 16;
+
+const double TRDGeometryBase::fgkTime0Base = 300.65;
+const float TRDGeometryBase::fgkTime0[6] = { static_cast<float>(fgkTime0Base + 0 * (Cheight() + Cspace())),
+                                         static_cast<float>(fgkTime0Base + 1 * (Cheight() + Cspace())),
+                                         static_cast<float>(fgkTime0Base + 2 * (Cheight() + Cspace())),
+                                         static_cast<float>(fgkTime0Base + 3 * (Cheight() + Cspace())),
+                                         static_cast<float>(fgkTime0Base + 4 * (Cheight() + Cspace())),
+                                         static_cast<float>(fgkTime0Base + 5 * (Cheight() + Cspace())) };
+
+const double TRDGeometryBase::fgkXtrdBeg = 288.43; // Values depend on position of TRD
+const double TRDGeometryBase::fgkXtrdEnd = 366.33; // mother volume inside space frame !!!
+
+// The outer width of the chambers
+const float TRDGeometryBase::fgkCwidth[kNlayer] = { 90.4, 94.8, 99.3, 103.7, 108.1, 112.6 };
+
+// The outer lengths of the chambers
+// Includes the spacings between the chambers!
+const float TRDGeometryBase::fgkClength[kNlayer][kNstack] = {
+  { 124.0, 124.0, 110.0, 124.0, 124.0 }, { 124.0, 124.0, 110.0, 124.0, 124.0 }, { 131.0, 131.0, 110.0, 131.0, 131.0 },
+  { 138.0, 138.0, 110.0, 138.0, 138.0 }, { 145.0, 145.0, 110.0, 145.0, 145.0 }, { 147.0, 147.0, 110.0, 147.0, 147.0 }
+};
+
+char TRDGeometryBase::fgSMstatus[kNsector] = { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 };
+
+//_____________________________________________________________________________
+TRDGeometryBase::TRDGeometryBase()
+{
+  //
+  // TRDGeometry default constructor
+  //
+}
+
+//_____________________________________________________________________________
+TRDGeometryBase::~TRDGeometryBase()
+{
+  //
+  // TRDGeometry destructor
+  //
+}
+
+//_____________________________________________________________________________
+int TRDGeometryBase::GetDetectorSec(int layer, int stack)
+{
+  //
+  // Convert plane / stack into detector number for one single sector
+  //
+
+  return (layer + stack * fgkNlayer);
+}
+
+//_____________________________________________________________________________
+int TRDGeometryBase::GetDetector(int layer, int stack, int sector)
+{
+  //
+  // Convert layer / stack / sector into detector number
+  //
+
+  return (layer + stack * fgkNlayer + sector * fgkNlayer * fgkNstack);
+}
+
+//_____________________________________________________________________________
+int TRDGeometryBase::GetLayer(int det)
+{
+  //
+  // Reconstruct the layer number from the detector number
+  //
+
+  return ((int)(det % fgkNlayer));
+}
+
+//_____________________________________________________________________________
+int TRDGeometryBase::GetStack(int det) const
+{
+  //
+  // Reconstruct the stack number from the detector number
+  //
+
+  return ((int)(det % (fgkNlayer * fgkNstack)) / fgkNlayer);
+}
+
+//_____________________________________________________________________________
+int TRDGeometryBase::GetStack(double z, int layer) const
+{
+  //
+  // Reconstruct the chamber number from the z position and layer number
+  //
+  // The return function has to be protected for positiveness !!
+  //
+
+  if ((layer < 0) || (layer >= fgkNlayer))
+    return -1;
+
+  int istck = fgkNstack;
+  double zmin = 0.0;
+  double zmax = 0.0;
+
+  do {
+    istck--;
+    if (istck < 0)
+      break;
+    TRDPadPlane* pp = GetPadPlane(layer, istck);
+    zmax = pp->GetRow0();
+    int nrows = pp->GetNrows();
+    zmin = zmax - 2 * pp->GetLengthOPad() - (nrows - 2) * pp->GetLengthIPad() - (nrows - 1) * pp->GetRowSpacing();
+  } while ((z < zmin) || (z > zmax));
+
+  return istck;
+}
+
+//_____________________________________________________________________________
+int TRDGeometryBase::GetSector(int det)
+{
+  //
+  // Reconstruct the sector number from the detector number
+  //
+
+  return ((int)(det / (fgkNlayer * fgkNstack)));
+}
+
+//_____________________________________________________________________________
+TRDPadPlane* TRDGeometryBase::GetPadPlane(int layer, int stack) const
+{
+  //
+  // Returns the pad plane for a given plane <pl> and stack <st> number
+  //
+
+  int ipp = GetDetectorSec(layer, stack);
+  return &mPadPlaneArray[ipp];
+}
+
+//_____________________________________________________________________________
+int TRDGeometryBase::GetRowMax(int layer, int stack, int /*sector*/) const
+{
+  //
+  // Returns the number of rows on the pad plane
+  //
+
+  return GetPadPlane(layer, stack)->GetNrows();
+}
+
+//_____________________________________________________________________________
+int TRDGeometryBase::GetColMax(int layer) const
+{
+  //
+  // Returns the number of rows on the pad plane
+  //
+
+  return GetPadPlane(layer, 0)->GetNcols();
+}
+
+//_____________________________________________________________________________
+double TRDGeometryBase::GetRow0(int layer, int stack, int /*sector*/) const
+{
+  //
+  // Returns the position of the border of the first pad in a row
+  //
+
+  return GetPadPlane(layer, stack)->GetRow0();
+}
+
+//_____________________________________________________________________________
+double TRDGeometryBase::GetCol0(int layer) const
+{
+  //
+  // Returns the position of the border of the first pad in a column
+  //
+
+  return GetPadPlane(layer, 0)->GetCol0();
+}
+
+//_____________________________________________________________________________
+bool TRDGeometryBase::IsHole(int /*la*/, int st, int se) const
+{
+  //
+  // Checks for holes in front of PHOS
+  //
+
+  if (((se == 13) || (se == 14) || (se == 15)) && (st == 2)) {
+    return true;
+  }
+
+  return false;
+}
+
+//_____________________________________________________________________________
+bool TRDGeometryBase::IsOnBoundary(int det, float y, float z, float eps) const
+{
+  //
+  // Checks whether position is at the boundary of the sensitive volume
+  //
+
+  int ly = GetLayer(det);
+  if ((ly < 0) || (ly >= fgkNlayer))
+    return true;
+
+  int stk = GetStack(det);
+  if ((stk < 0) || (stk >= fgkNstack))
+    return true;
+
+  TRDPadPlane* pp = &mPadPlaneArray[GetDetectorSec(ly, stk)];
+  if (!pp)
+    return true;
+
+  double max = pp->GetRow0();
+  int n = pp->GetNrows();
+  double min = max - 2 * pp->GetLengthOPad() - (n - 2) * pp->GetLengthIPad() - (n - 1) * pp->GetRowSpacing();
+  if (z < min + eps || z > max - eps) {
+    // printf("z : min[%7.2f (%7.2f)] %7.2f max[(%7.2f) %7.2f]\n", min, min+eps, z, max-eps, max);
+    return true;
+  }
+  min = pp->GetCol0();
+  n = pp->GetNcols();
+  max = min + 2 * pp->GetWidthOPad() + (n - 2) * pp->GetWidthIPad() + (n - 1) * pp->GetColSpacing();
+  if (y < min + eps || y > max - eps) {
+    // printf("y : min[%7.2f (%7.2f)] %7.2f max[(%7.2f) %7.2f]\n", min, min+eps, y, max-eps, max);
+    return true;
+  }
+
+  return false;
+}
+
+ClassImp(TRDGeometryBase)

--- a/Detectors/TRD/base/src/TRDPadPlane.cxx
+++ b/Detectors/TRD/base/src/TRDPadPlane.cxx
@@ -101,7 +101,7 @@ TRDPadPlane::~TRDPadPlane()
 }
 
 //_____________________________________________________________________________
-void TRDPadPlane::SetTiltingAngle(double t)
+void TRDPadPlane::setTiltingAngle(double t)
 {
   //
   // Set the tilting angle of the pads
@@ -112,7 +112,7 @@ void TRDPadPlane::SetTiltingAngle(double t)
 }
 
 //_____________________________________________________________________________
-int TRDPadPlane::GetPadRowNumber(double z) const
+int TRDPadPlane::getPadRowNumber(double z) const
 {
   //
   // Finds the pad row number for a given z-position in local supermodule system
@@ -123,7 +123,7 @@ int TRDPadPlane::GetPadRowNumber(double z) const
   int nbelow = 0;
   int middle = 0;
 
-  if ((z > GetRow0()) || (z < GetRowEnd())) {
+  if ((z > getRow0()) || (z < getRowEnd())) {
     row = -1;
 
   } else {
@@ -147,7 +147,7 @@ int TRDPadPlane::GetPadRowNumber(double z) const
 }
 
 //_____________________________________________________________________________
-int TRDPadPlane::GetPadRowNumberROC(double z) const
+int TRDPadPlane::getPadRowNumberROC(double z) const
 {
   //
   // Finds the pad row number for a given z-position in local ROC system
@@ -158,7 +158,7 @@ int TRDPadPlane::GetPadRowNumberROC(double z) const
   int nbelow = 0;
   int middle = 0;
 
-  if ((z > GetRow0ROC()) || (z < GetRowEndROC())) {
+  if ((z > getRow0ROC()) || (z < getRowEndROC())) {
     row = -1;
 
   } else {
@@ -182,7 +182,7 @@ int TRDPadPlane::GetPadRowNumberROC(double z) const
 }
 
 //_____________________________________________________________________________
-int TRDPadPlane::GetPadColNumber(double rphi) const
+int TRDPadPlane::getPadColNumber(double rphi) const
 {
   //
   // Finds the pad column number for a given rphi-position
@@ -193,7 +193,7 @@ int TRDPadPlane::GetPadColNumber(double rphi) const
   int nbelow = 0;
   int middle = 0;
 
-  if ((rphi < GetCol0()) || (rphi > GetColEnd())) {
+  if ((rphi < getCol0()) || (rphi > getColEnd())) {
     col = -1;
 
   } else {

--- a/Detectors/TRD/base/src/TRDPadPlane.cxx
+++ b/Detectors/TRD/base/src/TRDPadPlane.cxx
@@ -100,61 +100,6 @@ TRDPadPlane::~TRDPadPlane()
   }
 }
 
-/*
-//_____________________________________________________________________________
-void TRDPadPlane::Copy(TObject &p) const
-{
-  //
-  // Copy function
-  //
-
-  int iBin = 0;
-
-  ((TRDPadPlane &) p).fLayer           = fLayer;
-  ((TRDPadPlane &) p).fStack           = fStack;
-
-  ((TRDPadPlane &) p).fLength          = fLength;
-  ((TRDPadPlane &) p).fWidth           = fWidth;
-  ((TRDPadPlane &) p).fLengthRim       = fLengthRim;
-  ((TRDPadPlane &) p).fWidthRim        = fWidthRim;
-  ((TRDPadPlane &) p).fLengthOPad      = fLengthOPad;
-  ((TRDPadPlane &) p).fWidthOPad       = fWidthOPad;
-  ((TRDPadPlane &) p).fLengthIPad      = fLengthIPad;
-  ((TRDPadPlane &) p).fWidthIPad       = fWidthIPad;
-
-  ((TRDPadPlane &) p).fRowSpacing      = fRowSpacing;
-  ((TRDPadPlane &) p).fColSpacing      = fColSpacing;
-
-  ((TRDPadPlane &) p).fNrows           = fNrows;
-  ((TRDPadPlane &) p).fNcols           = fNcols;
-
-  ((TRDPadPlane &) p).fTiltingAngle    = fTiltingAngle;
-  ((TRDPadPlane &) p).fTiltingTan      = fTiltingTan;
-
-  ((TRDPadPlane &) p).fPadRowSMOffset  = fPadRowSMOffset;
-  ((TRDPadPlane &) p).fAnodeWireOffset = fAnodeWireOffset;
-
-  if (((TRDPadPlane &) p).fPadRow) {
-    delete [] ((TRDPadPlane &) p).fPadRow;
-  }
-  ((TRDPadPlane &) p).fPadRow = new double[fNrows];
-  for (iBin = 0; iBin < fNrows; iBin++) {
-    ((TRDPadPlane &) p).fPadRow[iBin] = fPadRow[iBin];
-  }
-
-  if (((TRDPadPlane &) p).fPadCol) {
-    delete [] ((TRDPadPlane &) p).fPadCol;
-  }
-  ((TRDPadPlane &) p).fPadCol = new double[fNrows];
-  for (iBin = 0; iBin < fNrows; iBin++) {
-    ((TRDPadPlane &) p).fPadCol[iBin] = fPadCol[iBin];
-  }
-
-  TObject::Copy(p);
-
-}
-*/
-
 //_____________________________________________________________________________
 void TRDPadPlane::SetTiltingAngle(double t)
 {

--- a/Detectors/TRD/simulation/include/TRDSimulation/Detector.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Detector.h
@@ -72,7 +72,7 @@ class Detector : public o2::Base::DetImpl<Detector>
 
   void createMaterials();
   void ConstructGeometry() override;
-  
+
   /// Add alignable top volumes
   void addAlignableVolumes() const override;
 

--- a/Detectors/TRD/simulation/include/TRDSimulation/Detector.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Detector.h
@@ -72,6 +72,9 @@ class Detector : public o2::Base::DetImpl<Detector>
 
   void createMaterials();
   void ConstructGeometry() override;
+  
+  /// Add alignable top volumes
+  void addAlignableVolumes() const override;
 
  private:
   /// copy constructor (used in MT)

--- a/Detectors/TRD/simulation/src/Detector.cxx
+++ b/Detectors/TRD/simulation/src/Detector.cxx
@@ -302,7 +302,7 @@ void Detector::ConstructGeometry()
   getMediumIDMappingAsVector(medmapping);
 
   mGeom = new TRDGeometry();
-  mGeom->CreateGeometry(medmapping);
+  mGeom->createGeometry(medmapping);
 }
 
 void Detector::defineSensitiveVolumes()

--- a/Detectors/TRD/simulation/src/Detector.cxx
+++ b/Detectors/TRD/simulation/src/Detector.cxx
@@ -318,4 +318,9 @@ void Detector::defineSensitiveVolumes()
   }
 }
 
+void Detector::addAlignableVolumes() const
+{
+  mGeom->addAlignableVolumes();
+}
+
 ClassImp(Detector);

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -1369,6 +1369,8 @@ o2_define_bucket(
     Geom
     SimulationDataFormat
     CommonDataFormat
+    data_format_detectors_common_bucket
+    DetectorsCommonDataFormats
 
     INCLUDE_DIRECTORIES
     ${FAIRROOT_INCLUDE_DIR}

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -1376,6 +1376,7 @@ o2_define_bucket(
     ${FAIRROOT_INCLUDE_DIR}
     ${CMAKE_SOURCE_DIR}/DataFormats/simulation/include
     ${CMAKE_SOURCE_DIR}/DataFormats/common/include
+    ${CMAKE_SOURCE_DIR}/Detectors/Base/include
     ${CMAKE_SOURCE_DIR}/Common/MathUtils/include
 )
 


### PR DESCRIPTION
This PR collects several changes needed for the TRD Geometry.
The purpose is to get the full Geometry with Transformation Matrices working and create a version of it that is runable on GPUs.

This PR contains:
- Splits TRD geometry in two parts, a base version that shall run on GPU eventually, and a full version for the host with all the CreateGeometry and related functions.
- Merge recent changes by Ruben to fix creation of Geometry Matrices.
- Adopt DetMatrixCache for TRDGeometry
- Make all constants constexpr
- The class was a semi-singleton with many statics, all statics removed.

The next PR, which requires alisw/alidist#1405, will bring on top:
- Create TRDGeometryGPU version of the class, that derrives from TRDGeometry and FlatObject.
- GPU Version of simplified DetMatrixCache