### PR TITLE
Remove unused header that nvcc does not like

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
@@ -19,8 +19,6 @@
 #include <climits>
 #include <vector>
 
-#include "json.h"
-
 #include "ITStracking/Constants.h"
 
 namespace o2


### PR DESCRIPTION
This is a minor bugfix that allows (not-so-)old nvcc to compile the ITS CUDA tracker.
Anyway the header was not used and should have been removed in the past...