### PR TITLE
Make parallel sim version the default

### DIFF
--- a/Common/SimConfig/include/SimConfig/SimConfig.h
+++ b/Common/SimConfig/include/SimConfig/SimConfig.h
@@ -41,6 +41,7 @@ struct SimConfigData {
   int mPrimaryChunkSize;                     // defining max granularity for input primaries of a sim job
   int mInternalChunkSize;                    //
   int mStartSeed;                            // base for random number seeds
+  int mSimWorkers = 1;                       // number of parallel sim workers (when it applies)
 
   ClassDefNV(SimConfigData, 2);
 };
@@ -100,6 +101,7 @@ class SimConfig
   int getPrimChunkSize() const { return mConfigData.mPrimaryChunkSize; }
   int getInternalChunkSize() const { return mConfigData.mInternalChunkSize; }
   int getStartSeed() const { return mConfigData.mStartSeed; }
+  int getNSimWorkers() const { return mConfigData.mSimWorkers; }
 
  private:
   SimConfigData mConfigData; //!

--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -13,12 +13,14 @@
 #include <boost/program_options.hpp>
 #include <iostream>
 #include <FairLogger.h>
+#include <thread>
 
 using namespace o2::conf;
 namespace bpo = boost::program_options;
 
 void SimConfig::initOptions(boost::program_options::options_description& options)
 {
+  int nsimworkersdefault = std::thread::hardware_concurrency() / 2;
   options.add_options()(
     "mcEngine,e", bpo::value<std::string>()->default_value("TGeant3"), "VMC backend to be used.")(
     "generator,g", bpo::value<std::string>()->default_value("boxgen"), "Event generator to be used.")(
@@ -38,7 +40,8 @@ void SimConfig::initOptions(boost::program_options::options_description& options
     "logverbosity", bpo::value<std::string>()->default_value("low"), "level of verbosity for FairLogger (low, medium, high, veryhigh)")(
     "configKeyValues", bpo::value<std::string>()->default_value(""), "comma separated key=value strings (e.g.: 'TPC.gasDensity=1,...")("chunkSize", bpo::value<unsigned int>()->default_value(10000), "max size of primary chunk (subevent) distributed by server")(
     "chunkSizeI", bpo::value<int>()->default_value(-1), "internalChunkSize")(
-    "seed", bpo::value<int>()->default_value(-1), "initial seed (default: -1 random)");
+    "seed", bpo::value<int>()->default_value(-1), "initial seed (default: -1 random)")(
+    "nworkers,j", bpo::value<int>()->default_value(nsimworkersdefault), "number of parallel simulation workers (only for parallel mode)");
 }
 
 bool SimConfig::resetFromParsedMap(boost::program_options::variables_map const& vm)
@@ -85,6 +88,7 @@ bool SimConfig::resetFromParsedMap(boost::program_options::variables_map const& 
   mConfigData.mPrimaryChunkSize = vm["chunkSize"].as<unsigned int>();
   mConfigData.mInternalChunkSize = vm["chunkSizeI"].as<int>();
   mConfigData.mStartSeed = vm["seed"].as<int>();
+  mConfigData.mSimWorkers = vm["nworkers"].as<int>();
   return true;
 }
 

--- a/Common/Utils/src/ShmManager.cxx
+++ b/Common/Utils/src/ShmManager.cxx
@@ -120,7 +120,7 @@ bool ShmManager::createGlobalSegment(int nsegments)
 
   LOG(INFO) << "CREATING SIM SHARED MEM SEGMENT FOR " << nsegments << " WORKERS";
 #ifdef USESHM
-  LOG(INFO) << "SIZEOF ShmMetaInfo " << sizeof(ShmMetaInfo);
+  // LOG(INFO) << "SIZEOF ShmMetaInfo " << sizeof(ShmMetaInfo);
   const auto totalsize = sizeof(ShmMetaInfo) + SHMPOOLSIZE * nsegments;
   if ((mShmID = shmget(IPC_PRIVATE, totalsize, IPC_CREAT | 0666)) == -1) {
     perror("shmget: shmget failed");
@@ -129,7 +129,7 @@ bool ShmManager::createGlobalSegment(int nsegments)
     // In this case (if it succeeds) we can also share objects with shm pointers
     auto addr = shmat(mShmID, nullptr, 0);
     mSegPtr = addr;
-    LOG(INFO) << "COMMON ADDRESS " << addr << " AS NUMBER " << (unsigned long long)addr;
+    LOG(DEBUG) << "COMMON ADDRESS " << addr << " AS NUMBER " << (unsigned long long)addr;
 
     // initialize the meta information (counter)
     o2::utils::ShmMetaInfo info;
@@ -146,7 +146,7 @@ bool ShmManager::createGlobalSegment(int nsegments)
   }
   LOG(INFO) << "SHARED MEM INITIALIZED AT ID " << mShmID;
   if (mShmID == -1) {
-    LOG(WARN) << "COULD NOT CREATE SHARED MEMORY";
+    LOG(WARN) << "COULD NOT CREATE SHARED MEMORY ... FALLING BACK TO SIMPLE MODE";
     setenv(SHMIDNAME, std::to_string(mShmID).c_str(), 1);
     setenv(SHMADDRNAME, std::to_string(0).c_str(), 1);
   }
@@ -237,7 +237,7 @@ void ShmManager::release()
 {
 #ifdef USESHM
   if (mIsMaster) {
-    LOG(INFO) << "REMOVING SHARED MEM SEGMENT ID " << mShmID;
+    LOG(DEBUG) << "REMOVING SHARED MEM SEGMENT ID " << mShmID;
     if (mShmID != -1) {
       shmctl(mShmID, IPC_RMID, nullptr);
       mShmID = -1;

--- a/run/CMakeLists.txt
+++ b/run/CMakeLists.txt
@@ -1,11 +1,11 @@
 
 Set(Exe_Names
-  o2sim
+  o2sim_serial
   runTPC
   O2SimDeviceRunner
   O2PrimaryServerDeviceRunner
   O2HitMergerRunner
-  o2sim_parallel
+  o2sim
 )
 
 Set(Exe_Source
@@ -14,7 +14,7 @@ Set(Exe_Source
   O2SimDeviceRunner.cxx
   O2PrimaryServerDeviceRunner.cxx
   O2HitMergerRunner.cxx
-  o2sim_parallel
+  o2sim_parallel.cxx
 )
 
 set(BUCKET_NAME "run_bucket")
@@ -42,13 +42,14 @@ if (HAVESIMULATION)
   if(NOT APPLE) # THESE TESTS HAVE PROBLEMS ON OUR CI MACHINE
   add_test(NAME o2sim_G4
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-    COMMAND ${CMAKE_BINARY_DIR}/bin/o2sim -n 2 -m PIPE ITS TPC TRD TOF EMC PHS -e TGeant4 -o o2simG4)
-  set_tests_properties(o2sim_G4 PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished succesfully"
+    COMMAND ${CMAKE_BINARY_DIR}/bin/o2sim -n 2 -j 2 -m PIPE ITS TPC TRD TOF EMC PHS -e TGeant4 -o o2simG4)
+  set_tests_properties(o2sim_G4 PROPERTIES PASS_REGULAR_EXPRESSION "SIMULATION RETURNED SUCCESFULLY"
                                            ENVIRONMENT VMCWORKDIR=${CMAKE_SOURCE_DIR} FIXTURES_SETUP G4) 
-                                           
+
+  # note that the MT is currently only supported in the non FairMQ version					 
   add_test(NAME o2sim_G4_mt 
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-    COMMAND ${CMAKE_BINARY_DIR}/bin/o2sim -n 10 -m PIPE ITS TPC TRD TOF EMC PHS -e TGeant4 --isMT on -o o2simG4MT)
+    COMMAND ${CMAKE_BINARY_DIR}/bin/o2sim_serial -n 10 -m PIPE ITS TPC TRD TOF EMC PHS -e TGeant4 --isMT on -o o2simG4MT)
   set_tests_properties(o2sim_G4_mt PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished succesfully"
                                               ENVIRONMENT VMCWORKDIR=${CMAKE_SOURCE_DIR})
   
@@ -60,8 +61,8 @@ if (HAVESIMULATION)
   endif()
   add_test(NAME o2sim_G3
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-    COMMAND ${CMAKE_BINARY_DIR}/bin/o2sim -n 2 -m PIPE ITS TPC MCH TOF EMC PHS -e TGeant3 -o o2simG3)
-  set_tests_properties(o2sim_G3 PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished succesfully"
+    COMMAND ${CMAKE_BINARY_DIR}/bin/o2sim -n 2 -j 2 -m PIPE ITS TPC MCH TOF EMC PHS -e TGeant3 -o o2simG3)
+  set_tests_properties(o2sim_G3 PROPERTIES PASS_REGULAR_EXPRESSION "SIMULATION RETURNED SUCCESFULLY"
                                            ENVIRONMENT VMCWORKDIR=${CMAKE_SOURCE_DIR} FIXTURES_SETUP G3) 
   
   add_test(NAME checksimkinematics_G3

--- a/run/O2SimDeviceRunner.cxx
+++ b/run/O2SimDeviceRunner.cxx
@@ -184,8 +184,7 @@ int main(int argc, char* argv[])
     if (f) {
       nworkers = atoi(f);
     }
-    LOG(INFO) << "Running with " << nworkers << " sim workers "
-              << "(customize using the ALICE_NSIMWORKERS environment variable)\n";
+    LOG(INFO) << "Running with " << nworkers << " sim workers ";
 
     // then we fork and create a device in each fork
     for (int i = 0; i < nworkers; ++i) {


### PR DESCRIPTION
This commit makes the parallel version of the simulation
the default one. I believe it is stable enough to give this a try.
With this the user will automatically use
all its cores to do simulation without any chance in the
command line interface.

Please report any problem found.

The former default will be available as o2sim_serial.