### PR TITLE
Supporting multiple branch clones in one branch definition

### DIFF
--- a/Framework/Utils/test/test_RootTreeWriter.cxx
+++ b/Framework/Utils/test/test_RootTreeWriter.cxx
@@ -19,28 +19,94 @@
 #include <fairmq/FairMQTransportFactory.h>
 #include "Framework/DataProcessingHeader.h"
 #include "Framework/InputRecord.h"
+#include "Framework/DataRef.h"
+#include "Framework/DataRefUtils.h"
 #include "Utils/RootTreeWriter.h"
 #include "Utils/MakeRootTreeWriterSpec.h"
 #include "../../Core/test/TestClasses.h"
 #include <vector>
 #include <memory>
+#include <type_traits> // std::is_fundamental
 #include <TClass.h>
+#include <TFile.h>
+#include <TTree.h>
+#include <TBranch.h>
+#include <TSystem.h>
 
 using namespace o2::framework;
 using DataHeader = o2::header::DataHeader;
 
+template <typename T>
+struct BranchContent {
+  using ref_type = T;
+  const char* branchName;
+  ref_type reference;
+};
+
+template <typename T>
+bool checkBranch(TTree& tree, BranchContent<T>&& content)
+{
+  TBranch* branch = tree.GetBranch(content.branchName);
+  BOOST_REQUIRE(branch != nullptr);
+  T store;
+  T* pointer = &store;
+  // in general, pointer to pointer has to be used for setting the branch
+  // address to a store object, however this does not work for fundamental
+  // types, there the address to the variable has to be used in order
+  // to read back the value. Why? no clue.
+  if (std::is_fundamental<T>::value) {
+    branch->SetAddress(&store);
+  } else {
+    branch->SetAddress(&pointer);
+  }
+  branch->GetEntry(0);
+  BOOST_CHECK_MESSAGE(store == content.reference, "mismatch for branch " << content.branchName);
+  return store == content.reference;
+}
+
+template <typename T, typename... Args>
+bool checkBranch(TTree& tree, BranchContent<T>&& content, Args&&... args)
+{
+  return checkBranch(tree, std::forward<BranchContent<T>>(content)) && checkBranch(tree, std::forward<Args>(args)...);
+}
+
+template <typename... Args>
+bool checkTree(const char* filename, const char* treename, Args&&... args)
+{
+  TFile* file = TFile::Open(filename);
+  BOOST_REQUIRE(file != nullptr);
+  TTree* tree = reinterpret_cast<TTree*>(file->GetObjectChecked(treename, "TTree"));
+  BOOST_REQUIRE(tree != nullptr);
+  return checkBranch(*tree, std::forward<Args>(args)...);
+}
+
 BOOST_AUTO_TEST_CASE(test_RootTreeWriter)
 {
-  // need to mimic a context to actually call the processing
-  // for now just test the besic compilation and setup
+  std::string filename = "test_RootTreeWriter.root";
+  const char* treename = "testtree";
+
   using Container = std::vector<o2::test::Polymorphic>;
-  RootTreeWriter writer("test.root", "testtree",                                            // file and tree name
-                        RootTreeWriter::BranchDef<int>{ "input1", "intbranch" },            // branch definition
-                        RootTreeWriter::BranchDef<Container>{ "input2", "containerbranch" } // branch definition
-                        );
+  // setting up the writer with two branch definitions
+  // first definition is for a single input and simple type written to one branch
+  // second branch handles two inputs of the same data type, the mapping of the
+  // input data to the target branch is taken from the sub specification
+  RootTreeWriter writer(filename.c_str(), treename, // file and tree name
+                        RootTreeWriter::BranchDef<int>{ "input1", "intbranch" },
+                        RootTreeWriter::BranchDef<Container>{
+                          std::vector<std::string>({ "input2", "input3" }), "containerbranch",
+                          // define two target branches (this matches the input list)
+                          2,
+                          // the callback extracts the sub specification from the DataHeader as index
+                          [](o2::framework::DataRef const& ref) {
+                            auto const* dataHeader = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
+                            return dataHeader->subSpecification;
+                          },
+                          // the branch names are simply built by adding the index
+                          [](std::string base, size_t i) { return base + "_" + std::to_string(i); } });
 
   BOOST_CHECK(writer.getStoreSize() == 2);
 
+  // need to mimic a context to actually call the processing
   auto transport = FairMQTransportFactory::CreateTransportFactory("zeromq");
   std::vector<FairMQMessagePtr> store;
 
@@ -73,8 +139,10 @@ BOOST_AUTO_TEST_CASE(test_RootTreeWriter)
 
   int a = 23;
   Container b{ { 0 } };
+  Container c{ { 21 } };
   createPlainMessage(o2::header::DataHeader{ "INT", "TST", 0 }, a);
   createSerializedMessage(o2::header::DataHeader{ "CONTAINER", "TST", 0 }, b);
+  createSerializedMessage(o2::header::DataHeader{ "CONTAINER", "TST", 1 }, c);
 
   // Note: InputRecord works on references to the schema and the message vector
   // so we can not specify the schema definition directly in the definition of
@@ -83,8 +151,9 @@ BOOST_AUTO_TEST_CASE(test_RootTreeWriter)
   // temporary argument is still in memory
   // FIXME: check why the compiler does not detect this
   std::vector<InputRoute> schema = {
-    { InputSpec{ "input1", "TST", "INT" }, "input1", 0 },      //
-    { InputSpec{ "input2", "TST", "CONTAINER" }, "input2", 0 } //
+    { InputSpec{ "input1", "TST", "INT" }, "input1", 0 },       //
+    { InputSpec{ "input2", "TST", "CONTAINER" }, "input2", 0 }, //
+    { InputSpec{ "input3", "TST", "CONTAINER" }, "input3", 1 }  //
   };
 
   auto getter = [&store](size_t i) -> char const* { return static_cast<char const*>(store[i]->GetData()); };
@@ -96,6 +165,11 @@ BOOST_AUTO_TEST_CASE(test_RootTreeWriter)
 
   writer(inputs);
   writer.close();
+
+  checkTree(filename.c_str(), treename,
+            BranchContent<int>{ "intbranch", a },
+            BranchContent<Container>{ "containerbranch_0", b },
+            BranchContent<Container>{ "containerbranch_1", c });
 }
 
 template <typename T>


### PR DESCRIPTION
Adding optional branch clones with respect to two dimensions:
1) the input key is now a list of inputs and one branch spec execution
   will loop over the complete list
2) multiple branch clones can be selected based on the header message

To activate branch clones, the branch definition needs to be configured with:
- cloning multiplicity
- a getter callback to return the branch index based on the DataRef
- a getter callback to create a branch name from base name and index
The branch name is used as a base name.