### PR TITLE
Polymorphic allocators in DPL

### DIFF
--- a/DataFormats/MemoryResources/include/MemoryResources/MemoryResources.h
+++ b/DataFormats/MemoryResources/include/MemoryResources/MemoryResources.h
@@ -41,17 +41,17 @@
 #include <FairMQTransportFactory.h>
 #include <fairmq/MemoryResources.h>
 #include <fairmq/MemoryResourceTools.h>
+#include "Types.h"
 
 namespace o2
 {
 
-using byte = unsigned char;
-
-namespace memory_resource
+namespace pmr
 {
 
 using FairMQMemoryResource = fair::mq::FairMQMemoryResource;
 using ChannelResource = fair::mq::ChannelResource;
+using namespace fair::mq::pmr;
 
 template <typename ContainerT>
 FairMQMessagePtr getMessage(ContainerT&& container, FairMQMemoryResource* targetResource = nullptr)
@@ -209,6 +209,8 @@ class OwningMessageSpectatorAllocator
 
 using ByteSpectatorAllocator = SpectatorAllocator<o2::byte>;
 using BytePmrAllocator = boost::container::pmr::polymorphic_allocator<o2::byte>;
+template <class T>
+using vector = std::vector<T, o2::pmr::polymorphic_allocator<T>>;
 
 //__________________________________________________________________________________________________
 /// Return a std::vector spanned over the contents of the message, takes ownership of the message
@@ -227,7 +229,11 @@ inline static ChannelResource* getTransportAllocator(FairMQTransportFactory* fac
   return factory->GetMemoryResource();
 }
 
-}; //namespace memory_resource
+}; //namespace pmr
+
+template <class T>
+using vector = std::vector<T, o2::pmr::polymorphic_allocator<T>>;
+
 }; //namespace o2
 
 #endif

--- a/DataFormats/MemoryResources/test/testMemoryResources.cxx
+++ b/DataFormats/MemoryResources/test/testMemoryResources.cxx
@@ -19,7 +19,7 @@
 
 namespace o2
 {
-namespace memory_resource
+namespace pmr
 {
 auto factoryZMQ = FairMQTransportFactory::CreateTransportFactory("zeromq");
 auto factorySHM = FairMQTransportFactory::CreateTransportFactory("shmem");
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE(getMessage_test)
     v.emplace_back(2);
     v.emplace_back(3);
     void* vectorBeginPtr = &v[0];
-    message = o2::memory_resource::getMessage(std::move(v));
+    message = o2::pmr::getMessage(std::move(v));
     BOOST_CHECK(message != nullptr);
     BOOST_CHECK(message->GetData() == vectorBeginPtr);
   }
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE(getMessage_test)
     v.emplace_back(5);
     v.emplace_back(6);
     void* vectorBeginPtr = &v[0];
-    message = o2::memory_resource::getMessage(std::move(v), allocSHM);
+    message = o2::pmr::getMessage(std::move(v), allocSHM);
     BOOST_CHECK(message != nullptr);
     BOOST_CHECK(message->GetData() != vectorBeginPtr);
   }
@@ -146,7 +146,7 @@ BOOST_AUTO_TEST_CASE(adoptVector_test)
   BOOST_CHECK(adoptedOwner[1].i == 2);
   BOOST_CHECK(adoptedOwner[2].i == 1);
 
-  auto reclaimedMessage = o2::memory_resource::getMessage(std::move(adoptedOwner));
+  auto reclaimedMessage = o2::pmr::getMessage(std::move(adoptedOwner));
   BOOST_CHECK(reclaimedMessage.get() == messageAddr);
   BOOST_CHECK(adoptedOwner.size() == 0);
 

--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -157,6 +157,7 @@ set(HEADERS
       include/Framework/FairMQResizableBuffer.h
       include/Framework/Metric2DViewIndex.h
       include/Framework/RawBufferContext.h
+      include/Framework/observer_ptr.h
       src/ComputingResource.h
       src/DDSConfigHelpers.h
       src/O2ControlHelpers.h

--- a/Framework/Core/include/Framework/observer_ptr.h
+++ b/Framework/Core/include/Framework/observer_ptr.h
@@ -63,6 +63,12 @@ class observer_ptr
   element_type* mptr{ nullptr };
 };
 
+template <typename W>
+observer_ptr<W> make_observer(W* p) noexcept
+{
+  return observer_ptr(p);
+}
+
 } //namespace o2
 
 #endif

--- a/Framework/Core/include/Framework/observer_ptr.h
+++ b/Framework/Core/include/Framework/observer_ptr.h
@@ -1,0 +1,68 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef FRAMEWORK_OBSERVER_PTR_H
+#define FRAMEWORK_OBSERVER_PTR_H
+
+#include <cstddef>
+#include <type_traits>
+
+namespace o2
+{
+
+template <typename W>
+class observer_ptr
+{
+ public:
+  using element_type = W;
+
+  constexpr observer_ptr() noexcept = default;
+  constexpr observer_ptr(std::nullptr_t) noexcept {}
+  explicit observer_ptr(element_type* ptr) noexcept : mptr{ ptr } {}
+  template <typename W2, typename std::enable_if<std::is_convertible<element_type*, W2*>::value, int>::type = 1>
+  observer_ptr(observer_ptr<W2> other) noexcept : mptr{ other.get() }
+  {
+  }
+  observer_ptr(const observer_ptr& other) = default;
+  observer_ptr(observer_ptr&& other) = default;
+
+  constexpr element_type* release() noexcept
+  {
+    auto tmp = *this;
+    this->reset();
+    return tmp.get();
+  }
+  constexpr void reset(element_type* p = nullptr) noexcept { *this = p; }
+  constexpr void swap(observer_ptr& other) noexcept
+  {
+    observer_ptr<element_type> tmp(*this);
+    *this = other;
+    other = tmp;
+  };
+  constexpr void swap(std::nullptr_t) noexcept
+  {
+    *this = nullptr;
+  };
+  constexpr element_type* get() const noexcept { return mptr; }
+  constexpr std::add_lvalue_reference_t<element_type> operator*() const { return *get(); }
+  constexpr element_type* operator->() const noexcept { return get(); }
+  constexpr std::add_lvalue_reference_t<observer_ptr<element_type>> operator=(const std::add_lvalue_reference_t<observer_ptr<element_type>> other) { mptr = other.mptr; }
+  constexpr std::add_lvalue_reference_t<observer_ptr<element_type>> operator=(element_type* const other) { mptr = other; }
+
+  constexpr explicit operator element_type*() const noexcept { return get(); }
+  constexpr explicit operator bool() const noexcept { return get() != nullptr; }
+
+ private:
+  element_type* mptr{ nullptr };
+};
+
+} //namespace o2
+
+#endif

--- a/Framework/Core/src/DataAllocator.cxx
+++ b/Framework/Core/src/DataAllocator.cxx
@@ -117,8 +117,8 @@ FairMQMessagePtr DataAllocator::headerMessageFromOutput(Output const& spec,     
   DataProcessingHeader dph{mTimingInfo->timeslice, 1};
   auto context = mContextRegistry->get<MessageContext>();
 
-  auto channelAlloc = o2::memory_resource::getTransportAllocator(context->proxy().getTransport(channel, 0));
-  return o2::memory_resource::getMessage(o2::header::Stack{ channelAlloc, dh, dph, spec.metaHeader });
+  auto channelAlloc = o2::pmr::getTransportAllocator(context->proxy().getTransport(channel, 0));
+  return o2::pmr::getMessage(o2::header::Stack{ channelAlloc, dh, dph, spec.metaHeader });
 }
 
 void DataAllocator::addPartToContext(FairMQMessagePtr&& payloadMessage, const Output& spec,

--- a/Framework/Core/src/Dispatcher.cxx
+++ b/Framework/Core/src/Dispatcher.cxx
@@ -104,8 +104,8 @@ void Dispatcher::sendFairMQ(FairMQDevice* device, const DataRef& inputData, cons
   DataProcessingHeader dphout{ dph->startTime, dph->duration };
   o2::header::Stack headerStack{ dhout, dphout };
 
-  auto channelAlloc = o2::memory_resource::getTransportAllocator(device->Transport());
-  FairMQMessagePtr msgHeaderStack = o2::memory_resource::getMessage(std::move(headerStack), channelAlloc);
+  auto channelAlloc = o2::pmr::getTransportAllocator(device->Transport());
+  FairMQMessagePtr msgHeaderStack = o2::pmr::getMessage(std::move(headerStack), channelAlloc);
 
   char* payloadCopy = new char[dh->payloadSize];
   memcpy(payloadCopy, inputData.payload, dh->payloadSize);

--- a/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
+++ b/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
@@ -40,8 +40,8 @@ void broadcastMessage(FairMQDevice &device, o2::header::Stack &&headerStack, Fai
 
     // FIXME: this assumes there is only one output from here... This should
     //        really do the matchmaking between inputs and output channels.
-    auto channelAlloc = o2::memory_resource::getTransportAllocator(channelInfo.second[index].Transport());
-    FairMQMessagePtr headerMessage = o2::memory_resource::getMessage(std::move(headerStack), channelAlloc);
+    auto channelAlloc = o2::pmr::getTransportAllocator(channelInfo.second[index].Transport());
+    FairMQMessagePtr headerMessage = o2::pmr::getMessage(std::move(headerStack), channelAlloc);
 
     FairMQParts out;
     out.AddPart(std::move(headerMessage));

--- a/Framework/Core/src/LifetimeHelpers.cxx
+++ b/Framework/Core/src/LifetimeHelpers.cxx
@@ -126,8 +126,8 @@ ExpirationHandler::Handler LifetimeHelpers::enumerate(ConcreteDataMatcher const&
     DataProcessingHeader dph{ timestamp, 1 };
 
     auto&& transport = rawDeviceService.device()->GetChannel(sourceChannel, 0).Transport();
-    auto channelAlloc = o2::memory_resource::getTransportAllocator(transport);
-    auto header = o2::memory_resource::getMessage(o2::header::Stack{ channelAlloc, dh, dph });
+    auto channelAlloc = o2::pmr::getTransportAllocator(transport);
+    auto header = o2::pmr::getMessage(o2::header::Stack{ channelAlloc, dh, dph });
     ref.header = std::move(header);
 
     auto payload = rawDeviceService.device()->NewMessage(*counter);

--- a/Framework/Utils/include/Utils/Utils.h
+++ b/Framework/Utils/include/Utils/Utils.h
@@ -18,6 +18,7 @@
 
 #include "Framework/DataProcessorSpec.h"
 #include <functional>
+#include "MemoryResources/MemoryResources.h"
 
 namespace o2f = o2::framework;
 
@@ -36,7 +37,7 @@ o2f::DataProcessorSpec defineBroadcaster(std::string devName, o2f::InputSpec usr
                                          size_t fixMsgSize);
 o2f::DataProcessorSpec defineBroadcaster(std::string devName, o2f::InputSpec usrInput, o2f::Outputs usrOutputs);
 
-using OutputBuffer = std::vector<char>;
+using OutputBuffer = o2::vector<char>;
 // Merger implementations
 o2f::DataProcessorSpec defineMerger(std::string devName, o2f::Inputs usrInputs, o2f::OutputSpec usrOutput,
                                     std::function<void(OutputBuffer, const o2f::DataRef)> const mergerFunc);

--- a/Framework/Utils/src/DPLMerger.cxx
+++ b/Framework/Utils/src/DPLMerger.cxx
@@ -40,14 +40,13 @@ o2f::DataProcessorSpec defineMerger(std::string devName, o2f::Inputs usrInputs, 
 
              // Defining the ProcessCallback as returned object of InitCallback
              return [outputPtr, mergerFuncPtr](o2f::ProcessingContext& ctx) {
-               OutputBuffer outputBuffer;
+               OutputBuffer outputBuffer = ctx.outputs().makeVector<char>(*outputPtr);
                // Iterating over the InputSpecs to aggregate msgs from the connected devices
                for (const auto& itInputs : ctx.inputs()) {
                  (*mergerFuncPtr)(outputBuffer, itInputs);
                }
                // Adopting the buffer as new chunk
-               ctx.outputs().adoptChunk((*outputPtr), &outputBuffer[0], outputBuffer.size(), header::Stack::getFreefn(),
-                                        nullptr);
+               ctx.outputs().adoptContainer((*outputPtr), std::move(outputBuffer));
              };
            } } };
 }

--- a/Utilities/O2Device/README.md
+++ b/Utilities/O2Device/README.md
@@ -23,7 +23,7 @@ addDataBlock(O2Message& message, o2::header::Stack&& headerStack, T data);
 - data:
   - ```FairMQMessagePtr``` (```std::unique_ptr<FairMQMessage>```)
   - STL-like container that uses a ```pmr::polymorphic_allocator``` as allocator. Note: this is only efficient if
-    the memory resource used to construct the allocator is ```o2::memory_resource::ChannelResource```, otherwise an implicit copy occurs.
+    the memory resource used to construct the allocator is ```o2::pmr::ChannelResource```, otherwise an implicit copy occurs.
 
 ### forEach()
 Executes a function on each data block within the message.
@@ -39,11 +39,11 @@ the function is a callable object (lambda, functor, std::function) and needs to 
 #### basic example, inside a FairMQDevice:
 ```C++
 // make sure we have the allocator associated with the transport appropriate for the selected channel:
-auto outputChannelAllocator = o2::memory_resource::getTransportAllocator(GetChannel("dataOut").Transport());
+auto outputChannelAllocator = o2::pmr::getTransportAllocator(GetChannel("dataOut").Transport());
 
 //the data
 using namespace boost::container::pmr;
-std::vector<int, polymorphic_allocator<int>> dataVector(polymorphic_allocator<int>{outputChannelAllocator});
+o2::pmr::vector<int> dataVector(outputChannelAllocator);
 dataVector.reserve(10);
 dataVector.push_back(1);
 dataVector.push_back(2);

--- a/Utilities/O2Device/include/O2Device/Utilities.h
+++ b/Utilities/O2Device/include/O2Device/Utilities.h
@@ -44,7 +44,7 @@ using O2Message = FairMQParts;
 //__________________________________________________________________________________________________
 // addDataBlock for generic (compatible) containers, that is contiguous containers using the pmr allocator
 template <typename ContainerT, typename std::enable_if<!std::is_same<ContainerT, FairMQMessagePtr>::value, int>::type = 0>
-bool addDataBlock(O2Message& parts, o2::header::Stack&& inputStack, ContainerT&& inputData, o2::memory_resource::FairMQMemoryResource* targetResource = nullptr)
+bool addDataBlock(O2Message& parts, o2::header::Stack&& inputStack, ContainerT&& inputData, o2::pmr::FairMQMemoryResource* targetResource = nullptr)
 {
   using std::move;
   using std::forward;
@@ -62,7 +62,7 @@ bool addDataBlock(O2Message& parts, o2::header::Stack&& inputStack, ContainerT&&
 // addDataBlock for data already wrapped in FairMQMessagePtr
 // note: since we cannot partially specialize function templates, use SFINAE here instead
 template <typename ContainerT, typename std::enable_if<std::is_same<ContainerT, FairMQMessagePtr>::value, int>::type = 0>
-bool addDataBlock(O2Message& parts, o2::header::Stack&& inputStack, ContainerT&& dataMessage, o2::memory_resource::FairMQMemoryResource* targetResource = nullptr)
+bool addDataBlock(O2Message& parts, o2::header::Stack&& inputStack, ContainerT&& dataMessage, o2::pmr::FairMQMemoryResource* targetResource = nullptr)
 {
   using std::move;
 

--- a/Utilities/O2Device/test/test_O2Device.cxx
+++ b/Utilities/O2Device/test/test_O2Device.cxx
@@ -20,7 +20,7 @@
 
 using namespace o2::Base;
 using namespace o2::header;
-using namespace o2::memory_resource;
+using namespace o2::pmr;
 
 auto factoryZMQ = FairMQTransportFactory::CreateTransportFactory("zeromq");
 auto factorySHM = FairMQTransportFactory::CreateTransportFactory("shmem");
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE(getMessage_Stack)
     Stack s1{ DataHeader{ gDataDescriptionInvalid, gDataOriginInvalid, DataHeader::SubSpecificationType{ 0 } },
               NameHeader<9>{ "somename" } };
 
-    auto message = o2::memory_resource::getMessage(std::move(s1), allocZMQ);
+    auto message = o2::pmr::getMessage(std::move(s1), allocZMQ);
 
     BOOST_REQUIRE(s1.data() == nullptr);
     BOOST_REQUIRE(message != nullptr);
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(getMessage_Stack)
               NameHeader<9>{ "somename" } };
     BOOST_TEST(allocZMQ->getNumberOfMessages() == 1);
 
-    auto message = o2::memory_resource::getMessage(std::move(s1), allocSHM);
+    auto message = o2::pmr::getMessage(std::move(s1), allocSHM);
 
     BOOST_TEST(allocZMQ->getNumberOfMessages() == 0);
     BOOST_TEST(allocSHM->getNumberOfMessages() == 0);

--- a/Utilities/O2MessageMonitor/src/O2MessageMonitor.cxx
+++ b/Utilities/O2MessageMonitor/src/O2MessageMonitor.cxx
@@ -58,7 +58,7 @@ void O2MessageMonitor::Run()
     type = subChannels[0].GetType();
   }
 
-  auto dataResource = o2::memory_resource::getTransportAllocator(subChannels[0].Transport());
+  auto dataResource = o2::pmr::getTransportAllocator(subChannels[0].Transport());
 
   while (CheckCurrentState(RUNNING) && (--mIterations) != 0) {
     this_thread::sleep_for(chrono::milliseconds(mDelay));

--- a/Utilities/aliceHLTwrapper/src/MessageFormat.cxx
+++ b/Utilities/aliceHLTwrapper/src/MessageFormat.cxx
@@ -134,7 +134,7 @@ int MessageFormat::addMessage(uint8_t* buffer, unsigned size)
   return mBlockDescriptors.size() - count;
 }
 
-int MessageFormat::addMessages(const vector<BufferDesc_t>& list)
+int MessageFormat::addMessages(const std::vector<BufferDesc_t>& list)
 {
   // add list of messages
   int totalCount = 0;
@@ -163,13 +163,13 @@ int MessageFormat::addMessages(const vector<BufferDesc_t>& list)
 }
 
 int MessageFormat::readBlockSequence(uint8_t* buffer, unsigned size,
-                                     vector<BlockDescriptor>& descriptorList) const
+                                     std::vector<BlockDescriptor>& descriptorList) const
 {
   // read a sequence of blocks consisting of AliHLTComponentBlockData followed by payload
   // from a buffer
   if (buffer == nullptr) return 0;
   unsigned position = 0;
-  vector<BlockDescriptor> input;
+  std::vector<BlockDescriptor> input;
   while (position + sizeof(AliHLTComponentBlockData) < size) {
     AliHLTComponentBlockData* p = reinterpret_cast<AliHLTComponentBlockData*>(buffer + position);
     if (p->fStructSize == 0 ||                         // no valid header
@@ -199,7 +199,7 @@ int MessageFormat::readBlockSequence(uint8_t* buffer, unsigned size,
 }
 
 int MessageFormat::readHOMERFormat(uint8_t* buffer, unsigned size,
-                                   vector<BlockDescriptor>& descriptorList) const
+                                   std::vector<BlockDescriptor>& descriptorList) const
 {
   // read message payload in HOMER format
   if (mpFactory == nullptr) const_cast<MessageFormat*>(this)->mpFactory = new o2::alice_hlt::HOMERFactory;
@@ -224,7 +224,7 @@ int MessageFormat::readHOMERFormat(uint8_t* buffer, unsigned size,
   return nofBlocks;
 }
 
-int MessageFormat::readO2Format(const vector<BufferDesc_t>& list, std::vector<BlockDescriptor>& descriptorList, HeartbeatHeader& hbh, HeartbeatTrailer& hbt) const
+int MessageFormat::readO2Format(const std::vector<BufferDesc_t>& list, std::vector<BlockDescriptor>& descriptorList, HeartbeatHeader& hbh, HeartbeatTrailer& hbt) const
 {
   int partNumber = 0;
   const o2::header::DataHeader* dh = nullptr;
@@ -278,10 +278,10 @@ int MessageFormat::readO2Format(const vector<BufferDesc_t>& list, std::vector<Bl
   return list.size()/2;
 }
 
-vector<MessageFormat::BufferDesc_t> MessageFormat::createMessages(const AliHLTComponentBlockData* blocks,
-                                                                  unsigned count, unsigned totalPayloadSize,
-                                                                  const AliHLTComponentEventData* evtData,
-                                                                  boost::signals2::signal<unsigned char* (unsigned int)> *cbAllocate)
+std::vector<MessageFormat::BufferDesc_t> MessageFormat::createMessages(const AliHLTComponentBlockData* blocks,
+                                                                       unsigned count, unsigned totalPayloadSize,
+                                                                       const AliHLTComponentEventData* evtData,
+                                                                       boost::signals2::signal<unsigned char*(unsigned int)>* cbAllocate)
 {
   // O2 output mode does not support event info struct
   // for the moment simply ignore it, not sure if this is the best


### PR DESCRIPTION
marked as WIP since this is a proposal on how interfaces in DPL to handle STL containers with polymorphic allocators could look like. A proposed use case is in DPLmerger.cxx - it also finally got rid of the last instance of the use of the header:Stack freefn public API. Good riddance.

The use of pmr containers with appropriate allocators is meant to achieve zero copy data exchange in all cases supported by fairmq (including shmem and ofi) in a transparent standards compliant way.