### PR TITLE
Use tower ID from Hit

### DIFF
--- a/Detectors/EMCAL/simulation/src/Digitizer.cxx
+++ b/Detectors/EMCAL/simulation/src/Digitizer.cxx
@@ -73,8 +73,7 @@ void Digitizer::process(const std::vector<Hit>& hits, std::vector<Digit>& digits
 //_______________________________________________________________________
 o2::EMCAL::Digit Digitizer::hitToDigit(const Hit& hit)
 {
-  Point3D<double> pos(hit.GetX(), hit.GetY(), hit.GetZ());
-  Int_t tower = mGeometry->GetAbsCellIdFromEtaPhi(pos.Eta(), pos.Phi());
+  Int_t tower = hit.GetDetectorID();
   Double_t amplitude = hit.GetEnergyLoss();
   Digit digit(tower, amplitude, mEventTime);
   return digit;


### PR DESCRIPTION
Do not determine tower ID again for digit from
eta/phi cuts since the method is imprecise and
at the sector boundaries digits are assigned
to incorrect towers or not matched to towers
at all (A. Knospe).