### PR TITLE
DPL IO API: adding method to query input as gsl::span

### DIFF
--- a/Framework/Core/include/Framework/DataRefUtils.h
+++ b/Framework/Core/include/Framework/DataRefUtils.h
@@ -103,11 +103,13 @@ struct DataRefUtils {
     }
     if (result == nullptr) {
       // did not manage to cast the pointer to result
-      // delete object via the class info, at this point we know that the
-      // class info is there, the object could not have been read otherwise
+      // delete object via the class info if available, not the case for all types,
+      // e.g. for standard containers of ROOT objects apparently this is not always
+      // the case
       auto* delfunc = storedClass->GetDelete();
-      assert(delfunc != nullptr);
-      if (delfunc) (*delfunc)(object);
+      if (delfunc) {
+        (*delfunc)(object);
+      }
 
       std::ostringstream ss;
       ss << "Attempting to extract a "

--- a/Framework/Core/include/Framework/TypeTraits.h
+++ b/Framework/Core/include/Framework/TypeTraits.h
@@ -16,6 +16,7 @@
 
 #include <boost/archive/binary_iarchive.hpp>
 #include <boost/archive/binary_oarchive.hpp>
+#include <gsl/gsl>
 
 namespace o2
 {
@@ -60,6 +61,13 @@ struct is_messageable : std::conditional<std::is_trivially_copyable<T>::value &&
                                            !is_forced_non_messageable<T>::value, //
                                          std::true_type,
                                          std::false_type>::type {
+};
+
+// FIXME: it apears that gsl:span matches the criteria for being messageable, regardless of the
+// underlying type, but our goal is to identify structures that can be sent without serialization.
+// needs investigation
+template <typename T>
+struct is_messageable<gsl::span<T>> : std::false_type {
 };
 
 // Detect a container by checking on the container properties

--- a/Framework/Core/test/test_DataAllocator.cxx
+++ b/Framework/Core/test/test_DataAllocator.cxx
@@ -128,6 +128,9 @@ DataProcessorSpec getSinkSpec()
     // plain, unserialized object in input1 channel
     auto object1 = pc.inputs().get<o2::test::TriviallyCopyable>("input1");
     ASSERT_ERROR(object1 == o2::test::TriviallyCopyable(42, 23, 0xdead));
+    auto object1span = pc.inputs().get<gsl::span<o2::test::TriviallyCopyable>>("input1");
+    ASSERT_ERROR(object1span.size() == 1);
+    ASSERT_ERROR(sizeof(typename decltype(object1span)::value_type) == sizeof(o2::test::TriviallyCopyable));
     // check the additional header on the stack
     auto* metaHeader1 = DataRefUtils::getHeader<test::MetaHeader*>(pc.inputs().get("input1"));
     // check if there are more of the same type

--- a/Framework/Core/test/test_TypeTraits.cxx
+++ b/Framework/Core/test/test_TypeTraits.cxx
@@ -18,6 +18,7 @@
 #include <boost/test/unit_test.hpp>
 #include <vector>
 #include <list>
+#include <gsl/gsl>
 
 using namespace o2::framework;
 
@@ -81,6 +82,8 @@ BOOST_AUTO_TEST_CASE(TestIsMessageable)
   std::vector<int> c;
   o2::test::TriviallyCopyable d;
   o2::test::Polymorphic e;
+  gsl::span<o2::test::TriviallyCopyable> spantriv;
+  gsl::span<o2::test::Polymorphic> spanpoly;
 
   BOOST_REQUIRE_EQUAL(is_messageable<decltype(a)>::value, true);
   BOOST_REQUIRE_EQUAL(is_messageable<decltype(b)>::value, true);
@@ -88,6 +91,8 @@ BOOST_AUTO_TEST_CASE(TestIsMessageable)
   BOOST_REQUIRE_EQUAL(is_messageable<decltype(d)>::value, true);
   BOOST_REQUIRE_EQUAL(is_messageable<decltype(e)>::value, false);
   BOOST_REQUIRE_EQUAL(is_messageable<ROOTSerialized<decltype(e)>>::value, false);
+  BOOST_REQUIRE_EQUAL(is_messageable<decltype(spantriv)>::value, false);
+  BOOST_REQUIRE_EQUAL(is_messageable<decltype(spanpoly)>::value, false);
 }
 
 BOOST_AUTO_TEST_CASE(TestIsStlContainer)


### PR DESCRIPTION
Also fixing two glitches
- explicitely marking gsl::span of some type as non-messageable
  need to investigate why is_messageable type trait is true
- removing an assert for a condition which could not be relied on.
  Not all ROOT serializable objects have a deleter interface function, e.g.
  container of classes not inheriting from TObject. Thi relates to the
  case where a deserialized ROOT object does not comply with the requested
  object type.