### PR TITLE
Improving handling of objects and structs and supporting binary branches

### DIFF
--- a/Framework/Utils/include/Utils/MakeRootTreeWriterSpec.h
+++ b/Framework/Utils/include/Utils/MakeRootTreeWriterSpec.h
@@ -42,6 +42,12 @@ namespace framework
 /// A branch definition is always bound to a data type, the advanced version supports
 /// multiple branches for the same data type. See further down.
 ///
+/// While the generic writer is primarily intended for ROOT serializable objects, a special
+/// case is the writing of binary data when const char* is used as type. Data is written
+/// as a std::vector<char>, this ensures separation on event basis as well as having binary
+/// data in parallel to ROOT objects in the same file, e.g. a binary data format from the
+/// reconstruction in parallel to MC labels.
+///
 /// The processor spec is generated with the following options:
 ///   --outfile
 ///   --treename

--- a/Framework/Utils/test/test_RootTreeWriter.cxx
+++ b/Framework/Utils/test/test_RootTreeWriter.cxx
@@ -102,9 +102,10 @@ BOOST_AUTO_TEST_CASE(test_RootTreeWriter)
                             return dataHeader->subSpecification;
                           },
                           // the branch names are simply built by adding the index
-                          [](std::string base, size_t i) { return base + "_" + std::to_string(i); } });
+                          [](std::string base, size_t i) { return base + "_" + std::to_string(i); } },
+                        RootTreeWriter::BranchDef<const char*>{ "input4", "binarybranch" });
 
-  BOOST_CHECK(writer.getStoreSize() == 2);
+  BOOST_CHECK(writer.getStoreSize() == 3);
 
   // need to mimic a context to actually call the processing
   auto transport = FairMQTransportFactory::CreateTransportFactory("zeromq");
@@ -143,6 +144,7 @@ BOOST_AUTO_TEST_CASE(test_RootTreeWriter)
   createPlainMessage(o2::header::DataHeader{ "INT", "TST", 0 }, a);
   createSerializedMessage(o2::header::DataHeader{ "CONTAINER", "TST", 0 }, b);
   createSerializedMessage(o2::header::DataHeader{ "CONTAINER", "TST", 1 }, c);
+  createPlainMessage(o2::header::DataHeader{ "BINARY", "TST", 0 }, a);
 
   // Note: InputRecord works on references to the schema and the message vector
   // so we can not specify the schema definition directly in the definition of
@@ -153,7 +155,8 @@ BOOST_AUTO_TEST_CASE(test_RootTreeWriter)
   std::vector<InputRoute> schema = {
     { InputSpec{ "input1", "TST", "INT" }, "input1", 0 },       //
     { InputSpec{ "input2", "TST", "CONTAINER" }, "input2", 0 }, //
-    { InputSpec{ "input3", "TST", "CONTAINER" }, "input3", 1 }  //
+    { InputSpec{ "input3", "TST", "CONTAINER" }, "input3", 1 }, //
+    { InputSpec{ "input4", "TST", "BINARY" }, "input4", 0 },    //
   };
 
   auto getter = [&store](size_t i) -> char const* { return static_cast<char const*>(store[i]->GetData()); };


### PR DESCRIPTION
Correctly using address of struct object for simple objects and address of pointer
to object for ROOT objects as branch address. This avoids also the copying of the
deserialized data for ROOT objects.

Supporting binary branches. By specifying const char* as store type, the data from
the input will be written to a binary branch, vector of char is used as format. An
additional branch with the size is added.

The RootTreeReader is updated accordingly to publish the binary chunk.