### PR TITLE
DPL: Adding TRD digit writer

### DIFF
--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -23,4 +23,8 @@ Digitizer::~Digitizer()
 void Digitizer::process(std::vector<o2::trd::HitType> const& hits, std::vector<o2::trd::Digit>& digits)
 {
   // very basic implementation
+  // for every hit seen, create a digit
+  for (auto& hit : hits) {
+    digits.emplace_back();
+  }
 }

--- a/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
+++ b/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
@@ -50,7 +50,7 @@
 
 // for TRD
 #include "TRDDigitizerSpec.h"
-// #include "TRDDDigitWriterSpec.h"
+#include "TRDDigitWriterSpec.h"
 
 // GRP
 #include "DataFormatsParameters/GRPObject.h"
@@ -349,7 +349,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     // connect the TRD digitization
     specs.emplace_back(o2::trd::getTRDDigitizerSpec(fanoutsize++));
     // connect the TRD digit writer
-    // specs.emplace_back(o2::trd::getTRDDigitWriterSpec());
+    specs.emplace_back(o2::trd::getTRDDigitWriterSpec());
   }
 
   // GRP updater: must come after all detectors since requires their list

--- a/Steer/DigitizerWorkflow/src/TRDDigitWriterSpec.h
+++ b/Steer/DigitizerWorkflow/src/TRDDigitWriterSpec.h
@@ -1,0 +1,43 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef STEER_DIGITIZERWORKFLOW_SRC_TRDDIGITWRITERSPEC_H_
+#define STEER_DIGITIZERWORKFLOW_SRC_TRDDIGITWRITERSPEC_H_
+
+#include "Framework/DataProcessorSpec.h"
+#include "Utils/MakeRootTreeWriterSpec.h"
+#include "Framework/InputSpec.h"
+#include "TRDBase/Digit.h"
+
+namespace o2
+{
+namespace trd
+{
+
+template <typename T>
+using BranchDefinition = framework::MakeRootTreeWriterSpec::BranchDefinition<T>;
+
+o2::framework::DataProcessorSpec getTRDDigitWriterSpec()
+{
+  using InputSpec = framework::InputSpec;
+  using MakeRootTreeWriterSpec = framework::MakeRootTreeWriterSpec;
+  return MakeRootTreeWriterSpec("TRDDigitWriter",
+                                "trddigits.root",
+                                "o2sim",
+                                1,
+                                BranchDefinition<o2::trd::Digit>{ InputSpec{ "input", "TRD", "DIGITS" }, "TRDDigit" }
+                                // add more branch definitions (for example Monte Carlo labels here)
+                                )();
+}
+
+} // end namespace trd
+} // end namespace o2
+
+#endif /* STEER_DIGITIZERWORKFLOW_SRC_TRDDIGITWRITERSPEC_H_ */


### PR DESCRIPTION
Making use of generic MakeRootTreeWriterSpec.
This completes the mockup processing chain
for TRD digits.