### PR TITLE
Fix adoptVector

### DIFF
--- a/DataFormats/MemoryResources/include/MemoryResources/MemoryResources.h
+++ b/DataFormats/MemoryResources/include/MemoryResources/MemoryResources.h
@@ -215,6 +215,7 @@ using BytePmrAllocator = boost::container::pmr::polymorphic_allocator<o2::byte>;
 template <typename ElemT>
 auto adoptVector(size_t nelem, FairMQMessagePtr message)
 {
+  static_assert(std::is_trivially_destructible<ElemT>::value);
   return std::vector<const ElemT, OwningMessageSpectatorAllocator<const ElemT>>(
     nelem, OwningMessageSpectatorAllocator<const ElemT>(MessageResource{ std::move(message) }));
 };

--- a/DataFormats/MemoryResources/include/MemoryResources/MemoryResources.h
+++ b/DataFormats/MemoryResources/include/MemoryResources/MemoryResources.h
@@ -61,53 +61,6 @@ FairMQMessagePtr getMessage(ContainerT&& container, FairMQMemoryResource* target
 
 //__________________________________________________________________________________________________
 /// This memory resource only watches, does not allocate/deallocate anything.
-/// In combination with the ByteSpectatorAllocator this is an alternative to using span, as raw memory
-/// (e.g. an existing buffer message) will be accessible with appropriate container.
-class SpectatorMessageResource : public FairMQMemoryResource
-{
-
- public:
-  SpectatorMessageResource() = default;
-  SpectatorMessageResource(const FairMQMessage* _message) : message(_message){};
-  FairMQMessagePtr getMessage(void* p) override { return nullptr; }
-  FairMQTransportFactory* getTransportFactory() noexcept override { return nullptr; }
-  size_t getNumberOfMessages() const noexcept override { return 0; }
-  void* setMessage(FairMQMessagePtr) override { return nullptr; }
-
- protected:
-  const FairMQMessage* message;
-
-  void* do_allocate(std::size_t bytes, std::size_t alignment) override
-  {
-    if (message) {
-      if (bytes > message->GetSize()) {
-        throw std::bad_alloc();
-      }
-      return message->GetData();
-    } else {
-      return nullptr;
-    }
-  };
-  void do_deallocate(void* p, std::size_t bytes, std::size_t alignment) override
-  {
-    message = nullptr;
-    return;
-  };
-  bool do_is_equal(const memory_resource& other) const noexcept override
-  {
-    const SpectatorMessageResource* that = dynamic_cast<const SpectatorMessageResource*>(&other);
-    if (!that) {
-      return false;
-    }
-    if (that->message == message) {
-      return true;
-    }
-    return false;
-  };
-};
-
-//__________________________________________________________________________________________________
-/// This memory resource only watches, does not allocate/deallocate anything.
 /// Ownership of hte message is taken. Meant to be used for transparent data adoption in containers.
 /// In combination with the SpectatorAllocator this is an alternative to using span, as raw memory
 /// (e.g. an existing buffer message) will be accessible with appropriate container.
@@ -120,8 +73,8 @@ class MessageResource : public FairMQMemoryResource
   MessageResource(MessageResource&&) noexcept = default;
   MessageResource& operator=(const MessageResource&) = default;
   MessageResource& operator=(MessageResource&&) = default;
-  MessageResource(FairMQMessagePtr message, FairMQMemoryResource* upstream)
-    : mUpstream{ upstream },
+  MessageResource(FairMQMessagePtr message)
+    : mUpstream{ message->GetTransport()->GetMemoryResource() },
       mMessageSize{ message->GetSize() },
       mMessageData{ mUpstream ? mUpstream->setMessage(std::move(message))
                               : throw std::runtime_error("MessageResource::MessageResource upstream is nullptr") }
@@ -136,13 +89,19 @@ class MessageResource : public FairMQMemoryResource
   FairMQMemoryResource* mUpstream{ nullptr };
   size_t mMessageSize{ 0 };
   void* mMessageData{ nullptr };
+  bool initialImport{true};
 
   void* do_allocate(std::size_t bytes, std::size_t alignment) override
   {
+    if (initialImport) {
     if (bytes > mMessageSize) {
       throw std::bad_alloc();
     }
+    initialImport=false;
     return mMessageData;
+    } else {
+      return mUpstream->allocate(bytes, alignment);
+    }
   }
   void do_deallocate(void* p, std::size_t bytes, std::size_t alignment) override
   {
@@ -252,37 +211,13 @@ using ByteSpectatorAllocator = SpectatorAllocator<o2::byte>;
 using BytePmrAllocator = boost::container::pmr::polymorphic_allocator<o2::byte>;
 
 //__________________________________________________________________________________________________
-/// Return a vector of const ElemT, takes ownership of the message, needs an upstream global ChannelResource to register
-/// the message.
+/// Return a std::vector spanned over the contents of the message, takes ownership of the message
 template <typename ElemT>
-auto adoptVector(size_t nelem, ChannelResource* upstream, FairMQMessagePtr message)
+auto adoptVector(size_t nelem, FairMQMessagePtr message)
 {
   return std::vector<const ElemT, OwningMessageSpectatorAllocator<const ElemT>>(
-    nelem, OwningMessageSpectatorAllocator<const ElemT>(MessageResource{ std::move(message), upstream }));
+    nelem, OwningMessageSpectatorAllocator<const ElemT>(MessageResource{ std::move(message) }));
 };
-
-//__________________________________________________________________________________________________
-// This returns a unique_ptr of const vector, does not allow modifications at the cost of pointer
-// semantics for access.
-// use auto or decltype to catch the return value (or use span)
-template <typename ElemT>
-auto adoptVector(size_t nelem, FairMQMessage* message)
-{
-  using DataType = std::vector<ElemT, ByteSpectatorAllocator>;
-
-  struct doubleDeleter {
-    // kids: don't do this at home! (but here it's OK)
-    // this stateful deleter allows a single unique_ptr to manage 2 resources at the same time.
-    std::unique_ptr<SpectatorMessageResource> extra;
-    void operator()(const DataType* ptr) { delete ptr; }
-  };
-
-  using OutputType = std::unique_ptr<const DataType, doubleDeleter>;
-
-  auto resource = std::make_unique<SpectatorMessageResource>(message);
-  auto output = new DataType(nelem, ByteSpectatorAllocator{ resource.get() });
-  return OutputType(output, doubleDeleter{ std::move(resource) });
-}
 
 //__________________________________________________________________________________________________
 /// Get the allocator associated to a transport factory

--- a/DataFormats/MemoryResources/include/MemoryResources/MemoryResources.h
+++ b/DataFormats/MemoryResources/include/MemoryResources/MemoryResources.h
@@ -89,16 +89,16 @@ class MessageResource : public FairMQMemoryResource
   FairMQMemoryResource* mUpstream{ nullptr };
   size_t mMessageSize{ 0 };
   void* mMessageData{ nullptr };
-  bool initialImport{true};
+  bool initialImport{ true };
 
   void* do_allocate(std::size_t bytes, std::size_t alignment) override
   {
     if (initialImport) {
-    if (bytes > mMessageSize) {
-      throw std::bad_alloc();
-    }
-    initialImport=false;
-    return mMessageData;
+      if (bytes > mMessageSize) {
+        throw std::bad_alloc();
+      }
+      initialImport = false;
+      return mMessageData;
     } else {
       return mUpstream->allocate(bytes, alignment);
     }

--- a/DataFormats/MemoryResources/include/MemoryResources/MemoryResources.h
+++ b/DataFormats/MemoryResources/include/MemoryResources/MemoryResources.h
@@ -216,8 +216,8 @@ template <typename ElemT>
 auto adoptVector(size_t nelem, FairMQMessagePtr message)
 {
   static_assert(std::is_trivially_destructible<ElemT>::value);
-  return std::vector<const ElemT, OwningMessageSpectatorAllocator<const ElemT>>(
-    nelem, OwningMessageSpectatorAllocator<const ElemT>(MessageResource{ std::move(message) }));
+  return std::vector<ElemT, OwningMessageSpectatorAllocator<ElemT>>(
+    nelem, OwningMessageSpectatorAllocator<ElemT>(MessageResource{ std::move(message) }));
 };
 
 //__________________________________________________________________________________________________

--- a/DataFormats/MemoryResources/include/MemoryResources/MemoryResources.h
+++ b/DataFormats/MemoryResources/include/MemoryResources/MemoryResources.h
@@ -105,7 +105,7 @@ class MessageResource : public FairMQMemoryResource
   }
   void do_deallocate(void* p, std::size_t bytes, std::size_t alignment) override
   {
-    getMessage(mMessageData); //let the message die.
+    mUpstream->deallocate(p, bytes, alignment);
     return;
   }
   bool do_is_equal(const memory_resource& other) const noexcept override

--- a/DataFormats/MemoryResources/test/testMemoryResources.cxx
+++ b/DataFormats/MemoryResources/test/testMemoryResources.cxx
@@ -26,39 +26,39 @@ auto factorySHM = FairMQTransportFactory::CreateTransportFactory("shmem");
 
 struct testData {
   int i{ 1 };
-  static int nallocated;
-  static int nallocations;
-  static int ndeallocations;
+  static int nconstructed;
+  static int nconstructions;
+  static int ndestructions;
   testData()
   {
-    ++nallocated;
-    ++nallocations;
+    ++nconstructed;
+    ++nconstructions;
   }
   testData(const testData& in) : i{ in.i }
   {
-    ++nallocated;
-    ++nallocations;
+    ++nconstructed;
+    ++nconstructions;
   }
   testData(const testData&& in) : i{ in.i }
   {
-    ++nallocated;
-    ++nallocations;
+    ++nconstructed;
+    ++nconstructions;
   }
   testData(int in) : i{ in }
   {
-    ++nallocated;
-    ++nallocations;
+    ++nconstructed;
+    ++nconstructions;
   }
   ~testData()
   {
-    --nallocated;
-    ++ndeallocations;
+    --nconstructed;
+    ++ndestructions;
   }
 };
 
-int testData::nallocated = 0;
-int testData::nallocations = 0;
-int testData::ndeallocations = 0;
+int testData::nconstructed = 0;
+int testData::nconstructions = 0;
+int testData::ndestructions = 0;
 
 auto allocZMQ = getTransportAllocator(factoryZMQ.get());
 auto allocSHM = getTransportAllocator(factorySHM.get());
@@ -74,8 +74,8 @@ using namespace boost::container::pmr;
 
 BOOST_AUTO_TEST_CASE(allocator_test)
 {
-  testData::nallocations = 0;
-  testData::ndeallocations = 0;
+  testData::nconstructions = 0;
+  testData::ndestructions = 0;
 
   {
     std::vector<testData, polymorphic_allocator<testData>> v(polymorphic_allocator<testData>{ allocZMQ });
@@ -86,13 +86,13 @@ BOOST_AUTO_TEST_CASE(allocator_test)
     v.emplace_back(2);
     v.emplace_back(3);
     BOOST_CHECK((byte*)&(*v.end()) - (byte*)&(*v.begin()) == 3 * sizeof(testData));
-    BOOST_CHECK(testData::nallocated == 3);
+    BOOST_CHECK(testData::nconstructed == 3);
   }
-  BOOST_CHECK(testData::nallocated == 0);
-  BOOST_CHECK(testData::nallocations == testData::ndeallocations);
+  BOOST_CHECK(testData::nconstructed == 0);
+  BOOST_CHECK(testData::nconstructions == testData::ndestructions);
 
-  testData::nallocations = 0;
-  testData::ndeallocations = 0;
+  testData::nconstructions = 0;
+  testData::ndestructions = 0;
   {
     std::vector<testData, SpectatorAllocator<testData>> v(SpectatorAllocator<testData>{ allocZMQ });
     v.reserve(3);
@@ -100,16 +100,16 @@ BOOST_AUTO_TEST_CASE(allocator_test)
     v.emplace_back(1);
     v.emplace_back(2);
     v.emplace_back(3);
-    BOOST_CHECK(testData::nallocated == 3);
+    BOOST_CHECK(testData::nconstructed == 3);
   }
-  BOOST_CHECK(testData::nallocated == 3); //ByteSpectatorAllocator does not call dtors so nallocated remains at 3;
+  BOOST_CHECK(testData::nconstructed == 3); //ByteSpectatorAllocator does not call dtors so nconstructed remains at 3;
   BOOST_CHECK(allocZMQ->getNumberOfMessages() == 0);
 }
 
 BOOST_AUTO_TEST_CASE(getMessage_test)
 {
-  testData::nallocations = 0;
-  testData::ndeallocations = 0;
+  testData::nconstructions = 0;
+  testData::ndestructions = 0;
 
   FairMQMessagePtr message{ nullptr };
 
@@ -152,13 +152,17 @@ BOOST_AUTO_TEST_CASE(getMessage_test)
 
 BOOST_AUTO_TEST_CASE(adoptVector_test)
 {
+  testData::nconstructed = 0;
+  testData::nconstructions = 0;
+  testData::ndestructions = 0;
+
   //Create a bogus message
   auto message = factoryZMQ->CreateMessage(3 * sizeof(testData));
   auto messageAddr = message.get();
   testData tmpBuf[3] = { 3, 2, 1 };
   std::memcpy(message->GetData(), tmpBuf, 3 * sizeof(testData));
 
-  auto adoptedOwner = adoptVector<testData>(3, getTransportAllocator(factoryZMQ.get()), std::move(message));
+  auto adoptedOwner = adoptVector<testData>(3, std::move(message));
   BOOST_CHECK(adoptedOwner[0].i == 3);
   BOOST_CHECK(adoptedOwner[1].i == 2);
   BOOST_CHECK(adoptedOwner[2].i == 1);
@@ -166,6 +170,17 @@ BOOST_AUTO_TEST_CASE(adoptVector_test)
   auto reclaimedMessage = o2::memory_resource::getMessage(std::move(adoptedOwner));
   BOOST_CHECK(reclaimedMessage.get() == messageAddr);
   BOOST_CHECK(adoptedOwner.size() == 0);
+
+  auto modified = adoptVector<testData>(3, std::move(reclaimedMessage));
+  modified.emplace_back(9);
+  BOOST_CHECK(modified[3].i == 9);
+  BOOST_CHECK(modified.size() == 4);
+  BOOST_CHECK(testData::nconstructed == 7);
+  BOOST_CHECK(testData::nconstructions == 7);
+  BOOST_CHECK(testData::ndestructions == 0); //we don't call the dtor, just drop the store
+  auto modifiedMessage = getMessage(std::move(modified));
+  BOOST_CHECK(modifiedMessage != nullptr);
+  BOOST_CHECK(modifiedMessage.get() != messageAddr);
 }
 };
 };


### PR DESCRIPTION
makes it more standards compliant - standard does not allow ```vector<const ElemT>``` - gcc8 starts enforcing that. Also - returned vector inow actually
behaves like a vector with full functionality. Constness needs to be enforced by a framework or the user, depending on the use case.