### PR TITLE
DPL: add metrics for inputs latencies

### DIFF
--- a/Framework/Core/include/Framework/DataProcessingHeader.h
+++ b/Framework/Core/include/Framework/DataProcessingHeader.h
@@ -44,12 +44,14 @@ namespace framework
 struct DataProcessingHeader : public header::BaseHeader
 {
   // Required to do the lookup
+  static uint64_t getCreationTime();
   constexpr static const o2::header::HeaderType sHeaderType = "DataFlow";
   static const uint32_t sVersion = 1;
 
   // allows DataHeader::SubSpecificationType to be used as generic type in the code
   using StartTime = uint64_t;
   using Duration = uint64_t;
+  using CreationTime = uint64_t;
 
   ///
   /// data start time
@@ -60,6 +62,8 @@ struct DataProcessingHeader : public header::BaseHeader
   /// data duration
   ///
   Duration duration;
+
+  CreationTime creation;
 
   //___NEVER MODIFY THE ABOVE
   //___NEW STUFF GOES BELOW
@@ -76,9 +80,10 @@ struct DataProcessingHeader : public header::BaseHeader
   }
 
   DataProcessingHeader(StartTime s, Duration d)
-  : BaseHeader(sizeof(DataProcessingHeader), sHeaderType, header::gSerializationMethodNone,sVersion),
-    startTime(s),
-    duration(d)
+    : BaseHeader(sizeof(DataProcessingHeader), sHeaderType, header::gSerializationMethodNone, sVersion),
+      startTime(s),
+      duration(d),
+      creation(getCreationTime())
   {
   }
 

--- a/Framework/Core/src/DataProcessingHeader.cxx
+++ b/Framework/Core/src/DataProcessingHeader.cxx
@@ -11,10 +11,19 @@
 #include "Framework/DataProcessingHeader.h"
 #include "Headers/DataHeader.h"
 
+#include <cstdint>
+#include <chrono>
+
 namespace o2
 {
 namespace framework
 {
+
+uint64_t DataProcessingHeader::getCreationTime()
+{
+  auto now = std::chrono::steady_clock::now();
+  return std::chrono::duration<double, std::milli>(now.time_since_epoch()).count();
+}
 
 constexpr o2::header::HeaderType DataProcessingHeader::sHeaderType;
 


### PR DESCRIPTION
This adds an extra field to the DataProcessing header to account for the
message creation time, which is then used on the backend to compute the
minimum and maximum latencies for the parts composing the inputs to
start being processed. Since we also know how much data the input is
this gives us the rate at which data is being created, injested and
started to be consumed.

As a bonus, metrics are now documented in code for what they do.