### PR TITLE
Pass TPC native clusters to TPC CA tracking without conversion

### DIFF
--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/TPCCATracking.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/TPCCATracking.h
@@ -19,9 +19,7 @@
 #include "DataFormatsTPC/ClusterNative.h"
 #include "DataFormatsTPC/TrackTPC.h"
 
-class TChain;
 class AliHLTTPCCAO2Interface;
-class AliHLTTPCCAClusterData;
 
 namespace o2 { class MCCompLabel; namespace dataformats { template <class T> class MCTruthContainer; }}
 
@@ -52,8 +50,6 @@ public:
   std::unique_ptr<AliHLTTPCCAO2Interface> mTrackingCAO2Interface; //Pointer to Interface class in HLT O2 CA Tracking library.
                                                                   //The tracking code itself is not included in the O2 package, but contained in the CA library.
                                                                   //The TPCCATracking class interfaces this library via this pointer to AliHLTTPCCAO2Interface class.
-  std::unique_ptr<AliHLTTPCCAClusterData[]> mClusterData_UPTR;
-  AliHLTTPCCAClusterData* mClusterData;
 
   TPCCATracking(const TPCCATracking&) = delete;            // Disable copy
   TPCCATracking& operator=(const TPCCATracking&) = delete; // Disable assignment

--- a/Detectors/TPC/reconstruction/src/TPCCATracking.cxx
+++ b/Detectors/TPC/reconstruction/src/TPCCATracking.cxx
@@ -204,17 +204,21 @@ int TPCCATracking::runTracking(const ClusterNativeAccessFullTPC& clusters, std::
         }
       }
       if (outputTracksMCTruth) {
-        int bestLabelNum = 0, bestLabelCount = 0;
-        for (int j = 0; j < labels.size(); j++) {
-          if (labels[j].second > bestLabelCount) {
-            bestLabelNum = j;
-            bestLabelCount = labels[j].second;
+        if (labels.size() == 0) {
+          outputTracksMCTruth->addElement(iTmp, MCCompLabel()); //default constructor creates NotSet label
+        } else {
+          int bestLabelNum = 0, bestLabelCount = 0;
+          for (int j = 0; j < labels.size(); j++) {
+            if (labels[j].second > bestLabelCount) {
+              bestLabelNum = j;
+              bestLabelCount = labels[j].second;
+            }
           }
+          MCCompLabel& bestLabel = labels[bestLabelNum].first;
+          if (bestLabelCount < (1.f - sTrackMCMaxFake) * tracks[i].NClusters())
+            bestLabel.set(-bestLabel.getTrackID(), bestLabel.getEventID(), bestLabel.getSourceID());
+          outputTracksMCTruth->addElement(iTmp, bestLabel);
         }
-        MCCompLabel& bestLabel = labels[bestLabelNum].first;
-        if (bestLabelCount < (1.f - sTrackMCMaxFake) * tracks[i].NClusters())
-          bestLabel.set(-bestLabel.getTrackID(), bestLabel.getEventID(), bestLabel.getSourceID());
-        outputTracksMCTruth->addElement(iTmp, bestLabel);
       }
       int lastSector = trackClusters[tracks[i].FirstClusterRef() + tracks[i].NClusters() - 1].fNum >> 24;
     }

--- a/Detectors/TRD/base/src/TRDGeometryBase.cxx
+++ b/Detectors/TRD/base/src/TRDGeometryBase.cxx
@@ -13,7 +13,7 @@
 using namespace o2::trd;
 
 //_____________________________________________________________________________
-int TRDGeometryBase::getStack(float z, int layer) const
+GPUd() int TRDGeometryBase::getStack(float z, int layer) const
 {
   //
   // Reconstruct the chamber number from the z position and layer number
@@ -42,7 +42,7 @@ int TRDGeometryBase::getStack(float z, int layer) const
 }
 
 //_____________________________________________________________________________
-bool TRDGeometryBase::isOnBoundary(int det, float y, float z, float eps) const
+GPUd() bool TRDGeometryBase::isOnBoundary(int det, float y, float z, float eps) const
 {
   //
   // Checks whether position is at the boundary of the sensitive volume


### PR DESCRIPTION
- Beforehand, the ClusterNative clusters were converted to AliRoot format. This is no longer necessary. As of AliTPCCommon 2.2, the CA tracking can accept the ClusterNative directly.
- Conversion code is removed, output is exactly the same.
- +2 minor bug fixes for GPU version.

@matthiasrichter : Can you have a look, this does NOT imply changes to the reco workflow.