### PR TITLE
Removing the default for the number of events to run in the TRDDigitWriter

### DIFF
--- a/Steer/DigitizerWorkflow/src/TRDDigitWriterSpec.h
+++ b/Steer/DigitizerWorkflow/src/TRDDigitWriterSpec.h
@@ -31,7 +31,6 @@ o2::framework::DataProcessorSpec getTRDDigitWriterSpec()
   return MakeRootTreeWriterSpec("TRDDigitWriter",
                                 "trddigits.root",
                                 "o2sim",
-                                1,
                                 BranchDefinition<o2::trd::Digit>{ InputSpec{ "input", "TRD", "DIGITS" }, "TRDDigit" }
                                 // add more branch definitions (for example Monte Carlo labels here)
                                 )();


### PR DESCRIPTION
The RootTreeWriter is currently configured to terminate the complete workflow
after the specified number of events. If it is configured with a default of
1, it will force the complete workflow to terminate.

This feature of the RootTreeWriter is going to be changed. Also, a reliable
termination functionality in DPL is under discussion.