### PR TITLE
DPL: reduce verbosity to use stateless Algorithms

### DIFF
--- a/Framework/Core/test/test_AlgorithmSpec.cxx
+++ b/Framework/Core/test/test_AlgorithmSpec.cxx
@@ -46,4 +46,8 @@ BOOST_AUTO_TEST_CASE(TestAlgorithmSpec) {
     }},
     AlgorithmSpec::emptyErrorCallback()
   };
+
+  AlgorithmSpec spec7{ adaptStateless([](InputRecord&, DataAllocator&) {}) };
+  int i = 0;
+  AlgorithmSpec spec8{ adaptStateless([&i](InputRecord&, DataAllocator&) {}) };
 }

--- a/Framework/Core/test/test_SimpleStatefulProcessing01.cxx
+++ b/Framework/Core/test/test_SimpleStatefulProcessing01.cxx
@@ -32,52 +32,54 @@ WorkflowSpec defineDataProcessing(ConfigContext const&) {
       // particular case, but a Singleton or a captured new object would
       // work as well.
       AlgorithmSpec{
-        [](InitContext& setup) {
-          static int foo = 0;
-          static int step = 0; // incremented in registered callbacks
-          auto startcb = []() {
-            ++step;
-            LOG(INFO) << "start " << step;
-          };
-          auto stopcb = []() {
-            ++step;
-            LOG(INFO) << "stop " << step;
-          };
-          auto resetcb = []() {
-            ++step;
-            LOG(INFO) << "reset " << step;
-          };
-          setup.services().get<CallbackService>().set(CallbackService::Id::Start, startcb);
-          setup.services().get<CallbackService>().set(CallbackService::Id::Stop, stopcb);
-          setup.services().get<CallbackService>().set(CallbackService::Id::Reset, resetcb);
-          return [](ProcessingContext& ctx) {
-            sleep(1);
-            auto out = ctx.outputs().newChunk({ "TES", "STATEFUL", 0 }, sizeof(int));
-            auto outI = reinterpret_cast<int*>(out.data);
-            outI[0] = foo++;
-          };
-        } //
-      }   //
-    },    //
+        adaptStateful(
+          [](CallbackService& callbacks) {
+            static int foo = 0;
+            static int step = 0; // incremented in registered callbacks
+            auto startcb = []() {
+              ++step;
+              LOG(INFO) << "start " << step;
+            };
+            auto stopcb = []() {
+              ++step;
+              LOG(INFO) << "stop " << step;
+            };
+            auto resetcb = []() {
+              ++step;
+              LOG(INFO) << "reset " << step;
+            };
+            callbacks.set(CallbackService::Id::Start, startcb);
+            callbacks.set(CallbackService::Id::Stop, stopcb);
+            callbacks.set(CallbackService::Id::Reset, resetcb);
+            return adaptStateless([](DataAllocator& outputs) {
+              sleep(1);
+              auto out = outputs.newChunk({ "TES", "STATEFUL", 0 }, sizeof(int));
+              auto outI = reinterpret_cast<int*>(out.data);
+              outI[0] = foo++;
+            });
+          }) //
+      }      //
+    },       //
     DataProcessorSpec{
       "consumer",                                                         //
       { InputSpec{ "test", "TES", "STATEFUL", 0, Lifetime::Timeframe } }, //
       Outputs{},                                                          //
       AlgorithmSpec{
-        [](InitContext&) {
-          static int expected = 0;
-          return [](ProcessingContext& ctx) {
-            const int* in = reinterpret_cast<const int*>(ctx.inputs().get("test").payload);
+        adaptStateful(
+          []() {
+            static int expected = 0;
+            return adaptStateless([](InputRecord& inputs, ControlService& control) {
+              const int* in = reinterpret_cast<const int*>(inputs.get("test").payload);
 
-            if (*in != expected++) {
-              LOG(ERROR) << "Expecting " << expected << " found " << *in;
-            } else {
-              LOG(INFO) << "Everything OK for " << expected << std::endl;
-              ctx.services().get<ControlService>().readyToQuit(true);
-            }
-          };
-        } //
-      }   //
-    }     //
+              if (*in != expected++) {
+                LOG(ERROR) << "Expecting " << expected << " found " << *in;
+              } else {
+                LOG(INFO) << "Everything OK for " << expected << std::endl;
+                control.readyToQuit(true);
+              }
+            });
+          }) //
+      }      //
+    }        //
   };
 }


### PR DESCRIPTION
This introduces an helper which greatly reduces the typing
required to implement a stateless algorithm, i.e. one which
purely transforms the input into an output.

As you can read in the documentation with this the user simply needs
to pass a lambda where he specifies as inputs any of InputRecord,
DataAllocator, ConfigParamService, or any of the services hanging
from the ServiceRegistry, e.g. Monitoring. The actual extraction
of those classes happens via the template magic, leaving the user with
just:

```C++
  AlgorithmSpec{
    adaptStateless([](InputRecord &inputs, DataAllocator& output){
    ...
  })}
```
In the future we might extend this to non stateless callbacks, capturing
lambdas and actually embed it directly into the AlgorithmSpec
constructor, without the need of an helper.