### PR TITLE
DPL Driver: speedup metric handling

### DIFF
--- a/Framework/Core/include/Framework/FrameworkGUIState.h
+++ b/Framework/Core/include/Framework/FrameworkGUIState.h
@@ -30,7 +30,6 @@ struct WorkspaceGUIState {
   int selectedMetric;
   size_t metricMinRange;
   size_t metricMaxRange;
-  std::vector<std::string> availableMetrics;
   std::vector<DeviceGUIState> devices;
   float leftPaneSize;
   float rightPaneSize;

--- a/Framework/Core/src/DriverInfo.h
+++ b/Framework/Core/src/DriverInfo.h
@@ -120,6 +120,9 @@ struct DriverInfo {
   std::vector<ConfigParamSpec> workflowOptions;
   /// The config context. We use a bare pointer because std::observer_ptr is not a thing, yet.
   ConfigContext const* configContext;
+  /// The names for all the metrics which have been collected by this driver.
+  /// Should always be sorted alphabetically to ease insertion.
+  std::vector<std::string> availableMetrics;
 };
 
 } // namespace framework


### PR DESCRIPTION
Old code was recalculating the metrics to display for every iteration,
rather than doing it only when a new metric was added like now. While
this worked well for a few metrics, as we increase the number of them,
this becomes an obvious performance bottleneck.

While in production (i.e. when running on O2 Control / DDS) this part of
the code should not be exercised, several people use the DPL driver code
as convenience way to develop / debug issues and this was affecting
performance there in a significant way.