### PR TITLE
Introduce Segmentation class spanning the two cathodes.

### DIFF
--- a/Detectors/MUON/MCH/Mapping/Impl3/src/CathodeSegmentationCImpl3.cxx
+++ b/Detectors/MUON/MCH/Mapping/Impl3/src/CathodeSegmentationCImpl3.cxx
@@ -78,7 +78,7 @@ void mchCathodeSegmentationForEachDualSampa(MchCathodeSegmentationHandle segHand
 }
 
 MCHMAPPINGIMPL3_EXPORT
-void mchCathodeSegmentationForOneDetectionElementOfEachCathodeSegmentationType(MchDetectionElementHandler handler, void* clientData)
+void mchCathodeSegmentationForOneDetectionElementOfEachSegmentationType(MchDetectionElementHandler handler, void* clientData)
 {
   for (auto detElemId :
        { 100, 300, 500, 501, 502, 503, 504, 600, 601, 602, 700, 701, 702, 703, 704, 705, 706, 902, 903, 904, 905 }) {
@@ -87,70 +87,70 @@ void mchCathodeSegmentationForOneDetectionElementOfEachCathodeSegmentationType(M
 }
 
 MCHMAPPINGIMPL3_EXPORT
-int mchCathodeSegmentationIsPadValid(MchCathodeSegmentationHandle segHandle, int paduid)
+int mchCathodeSegmentationIsPadValid(MchCathodeSegmentationHandle segHandle, int catPadIndex)
 {
-  return paduid != segHandle->impl->InvalidPadUid;
+  return catPadIndex != segHandle->impl->InvalidCatPadIndex;
 }
 
 MCHMAPPINGIMPL3_EXPORT
 void mchCathodeSegmentationForEachPadInDualSampa(MchCathodeSegmentationHandle segHandle, int dualSampaId, MchPadHandler handler,
                                                  void* clientData)
 {
-  for (auto p : segHandle->impl->getPadUids(dualSampaId)) {
+  for (auto p : segHandle->impl->getCatPadIndexs(dualSampaId)) {
     handler(clientData, p);
   }
 }
 
 MCHMAPPINGIMPL3_EXPORT
-double mchCathodeSegmentationPadPositionX(MchCathodeSegmentationHandle segHandle, int paduid)
+double mchCathodeSegmentationPadPositionX(MchCathodeSegmentationHandle segHandle, int catPadIndex)
 {
-  return segHandle->impl->padPositionX(paduid);
+  return segHandle->impl->padPositionX(catPadIndex);
 }
 
 MCHMAPPINGIMPL3_EXPORT
-double mchCathodeSegmentationPadPositionY(MchCathodeSegmentationHandle segHandle, int paduid)
+double mchCathodeSegmentationPadPositionY(MchCathodeSegmentationHandle segHandle, int catPadIndex)
 {
-  return segHandle->impl->padPositionY(paduid);
+  return segHandle->impl->padPositionY(catPadIndex);
 }
 
 MCHMAPPINGIMPL3_EXPORT
-double mchCathodeSegmentationPadSizeX(MchCathodeSegmentationHandle segHandle, int paduid)
+double mchCathodeSegmentationPadSizeX(MchCathodeSegmentationHandle segHandle, int catPadIndex)
 {
-  return segHandle->impl->padSizeX(paduid);
+  return segHandle->impl->padSizeX(catPadIndex);
 }
 
 MCHMAPPINGIMPL3_EXPORT
-double mchCathodeSegmentationPadSizeY(MchCathodeSegmentationHandle segHandle, int paduid)
+double mchCathodeSegmentationPadSizeY(MchCathodeSegmentationHandle segHandle, int catPadIndex)
 {
-  return segHandle->impl->padSizeY(paduid);
+  return segHandle->impl->padSizeY(catPadIndex);
 }
 
 MCHMAPPINGIMPL3_EXPORT
-int mchCathodeSegmentationPadDualSampaId(MchCathodeSegmentationHandle segHandle, int paduid)
+int mchCathodeSegmentationPadDualSampaId(MchCathodeSegmentationHandle segHandle, int catPadIndex)
 {
-  return segHandle->impl->padDualSampaId(paduid);
+  return segHandle->impl->padDualSampaId(catPadIndex);
 }
 
 MCHMAPPINGIMPL3_EXPORT
-int mchCathodeSegmentationPadDualSampaChannel(MchCathodeSegmentationHandle segHandle, int paduid)
+int mchCathodeSegmentationPadDualSampaChannel(MchCathodeSegmentationHandle segHandle, int catPadIndex)
 {
-  return segHandle->impl->padDualSampaChannel(paduid);
+  return segHandle->impl->padDualSampaChannel(catPadIndex);
 }
 
 MCHMAPPINGIMPL3_EXPORT
 void mchCathodeSegmentationForEachPadInArea(MchCathodeSegmentationHandle segHandle, double xmin, double ymin, double xmax,
                                             double ymax, MchPadHandler handler, void* clientData)
 {
-  for (auto p : segHandle->impl->getPadUids(xmin, ymin, xmax, ymax)) {
+  for (auto p : segHandle->impl->getCatPadIndexs(xmin, ymin, xmax, ymax)) {
     handler(clientData, p);
   }
 }
 
 MCHMAPPINGIMPL3_EXPORT
-void mchCathodeSegmentationForEachNeighbouringPad(MchCathodeSegmentationHandle segHandle, int paduid, MchPadHandler handler,
+void mchCathodeSegmentationForEachNeighbouringPad(MchCathodeSegmentationHandle segHandle, int catPadIndex, MchPadHandler handler,
                                                   void* userData)
 {
-  for (auto p : segHandle->impl->getNeighbouringPadUids(paduid)) {
+  for (auto p : segHandle->impl->getNeighbouringCatPadIndexs(catPadIndex)) {
     handler(userData, p);
   }
 }

--- a/Detectors/MUON/MCH/Mapping/Impl3/src/CathodeSegmentationImpl3.h
+++ b/Detectors/MUON/MCH/Mapping/Impl3/src/CathodeSegmentationImpl3.h
@@ -33,7 +33,7 @@ namespace impl3
 class CathodeSegmentation
 {
  public:
-  static constexpr int InvalidPadUid{ -1 };
+  static constexpr int InvalidCatPadIndex{ -1 };
 
   using Point = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>;
   using Box = boost::geometry::model::box<Point>;
@@ -42,14 +42,14 @@ class CathodeSegmentation
   CathodeSegmentation(int segType, bool isBendingPlane, std::vector<PadGroup> padGroups,
                       std::vector<PadGroupType> padGroupTypes, std::vector<std::pair<float, float>> padSizes);
 
-  /// Return the list of paduids for the pads of the given dual sampa.
-  std::vector<int> getPadUids(int dualSampaIds) const;
+  /// Return the list of catPadIndexs for the pads of the given dual sampa.
+  std::vector<int> getCatPadIndexs(int dualSampaIds) const;
 
-  /// Return the list of paduids for the pads contained in the box {xmin,ymin,xmax,ymax}.
-  std::vector<int> getPadUids(double xmin, double ymin, double xmax, double ymax) const;
+  /// Return the list of catPadIndexs for the pads contained in the box {xmin,ymin,xmax,ymax}.
+  std::vector<int> getCatPadIndexs(double xmin, double ymin, double xmax, double ymax) const;
 
-  /// Return the list of paduids of the pads which are neighbours to paduid
-  std::vector<int> getNeighbouringPadUids(int paduid) const;
+  /// Return the list of catPadIndexs of the pads which are neighbours to catPadIndex
+  std::vector<int> getNeighbouringCatPadIndexs(int catPadIndex) const;
 
   std::set<int> dualSampaIds() const { return mDualSampaIds; }
 
@@ -57,26 +57,26 @@ class CathodeSegmentation
 
   int findPadByFEE(int dualSampaId, int dualSampaChannel) const;
 
-  bool hasPadByPosition(double x, double y) const { return findPadByPosition(x, y) != InvalidPadUid; }
+  bool hasPadByPosition(double x, double y) const { return findPadByPosition(x, y) != InvalidCatPadIndex; }
 
   bool hasPadByFEE(int dualSampaId, int dualSampaChannel) const
   {
-    return findPadByFEE(dualSampaId, dualSampaChannel) != InvalidPadUid;
+    return findPadByFEE(dualSampaId, dualSampaChannel) != InvalidCatPadIndex;
   }
 
   friend std::ostream& operator<<(std::ostream& os, const CathodeSegmentation& seg);
 
-  double padPositionX(int paduid) const;
+  double padPositionX(int catPadIndex) const;
 
-  double padPositionY(int paduid) const;
+  double padPositionY(int catPadIndex) const;
 
-  double padSizeX(int paduid) const;
+  double padSizeX(int catPadIndex) const;
 
-  double padSizeY(int paduid) const;
+  double padSizeY(int catPadIndex) const;
 
-  int padDualSampaId(int paduid) const;
+  int padDualSampaId(int catPadIndex) const;
 
-  int padDualSampaChannel(int paduid) const;
+  int padDualSampaChannel(int catPadIndex) const;
 
  private:
   int dualSampaIndex(int dualSampaId) const;
@@ -85,11 +85,11 @@ class CathodeSegmentation
 
   std::ostream& showPad(std::ostream& out, int index) const;
 
-  const PadGroup& padGroup(int paduid) const;
+  const PadGroup& padGroup(int catPadIndex) const;
 
-  const PadGroupType& padGroupType(int paduid) const;
+  const PadGroupType& padGroupType(int catPadIndex) const;
 
-  double squaredDistance(int paduid, double x, double y) const;
+  double squaredDistance(int catPadIndex, double x, double y) const;
 
  private:
   int mSegType;
@@ -99,9 +99,9 @@ class CathodeSegmentation
   std::vector<PadGroupType> mPadGroupTypes;
   std::vector<std::pair<float, float>> mPadSizes;
   boost::geometry::index::rtree<Value, boost::geometry::index::quadratic<8>> mRtree;
-  std::vector<int> mPadUid2PadGroupIndex;
-  std::vector<int> mPadUid2PadGroupTypeFastIndex;
-  std::vector<int> mPadGroupIndex2PadUidIndex;
+  std::vector<int> mCatPadIndex2PadGroupIndex;
+  std::vector<int> mCatPadIndex2PadGroupTypeFastIndex;
+  std::vector<int> mPadGroupIndex2CatPadIndexIndex;
 };
 
 CathodeSegmentation* createCathodeSegmentation(int detElemId, bool isBendingPlane);

--- a/Detectors/MUON/MCH/Mapping/Interface/include/MCHMappingInterface/CathodeSegmentation.h
+++ b/Detectors/MUON/MCH/Mapping/Interface/include/MCHMappingInterface/CathodeSegmentation.h
@@ -33,12 +33,18 @@ namespace mapping
 /// @brief A CathodeSegmentation lets you _find_ pads on a given plane (cathode) of a detection element
 /// and then _inspect_ those pads.
 ///
+/// Note that instead of CathodeSegmentation most users will prefer to use
+/// the Segmentation class which handles both cathodes of a detection element
+/// at once.
+///
 /// Pads can be found by :
 /// - their position (x,y) in the plane
 /// - their front-end electronics characteristics (which DualSampa chip, which chip channel)
 ///
 /// What you get back from the find methods are not pad objects directly but a reference (integer)
 /// that can then be used to query the segmentation object about that pad.
+/// That reference integer (catPadIndex) is an index between 0 and nofPads()-1.
+/// The exact ordering of this index is implementation dependent though.
 ///
 /// Pad information that can be retrieved :
 /// - position in x and y directions
@@ -73,6 +79,11 @@ class CathodeSegmentation
     };
     mchCathodeSegmentationForEachDualSampa(mImpl, callback, &addDualSampaId);
     mDualSampaIds = dpid;
+    int n{ 0 };
+    for (auto i = 0; i < nofDualSampas(); ++i) {
+      forEachPadInDualSampa(dualSampaId(i), [&n](int /*catPadIndex*/) { ++n; });
+    }
+    mNofPads = n;
   }
 
   bool operator==(const CathodeSegmentation& rhs) const
@@ -90,6 +101,7 @@ class CathodeSegmentation
     swap(a.mDualSampaIds, b.mDualSampaIds);
     swap(a.mDetElemId, b.mDetElemId);
     swap(a.mIsBendingPlane, b.mIsBendingPlane);
+    swap(a.mNofPads, b.mNofPads);
   }
 
   CathodeSegmentation(const CathodeSegmentation& seg)
@@ -98,6 +110,7 @@ class CathodeSegmentation
     mIsBendingPlane = seg.mIsBendingPlane;
     mImpl = mchCathodeSegmentationConstruct(mDetElemId, mIsBendingPlane);
     mDualSampaIds = seg.mDualSampaIds;
+    mNofPads = seg.mNofPads;
   }
 
   CathodeSegmentation& operator=(CathodeSegmentation seg)
@@ -109,21 +122,21 @@ class CathodeSegmentation
   ~CathodeSegmentation() { mchCathodeSegmentationDestruct(mImpl); }
 
   /** @name Pad Unique Identifier
-   * Pads are identified by a unique integer, paduid.
-   * @warning This paduid is only valid within the realm of this CathodeSegmentation object
+   * Pads are identified by a unique integer, catPadIndex.
+   * @warning This catPadIndex is only valid within the realm of this CathodeSegmentation object
    * (to use the query methods padPosition, padSize, etc...).
    * So do _not_ rely on any given value it might take (as it might change
    * between e.g. library version or underlying implementation)
    */
-  ///@{ Not every integer is a valid paduid. This method will tell if paduid is a valid one.
-  bool isValid(int paduid) const { return mchCathodeSegmentationIsPadValid(mImpl, paduid) > 0; }
+  ///@{ Not every integer is a valid catPadIndex. This method will tell if catPadIndex is a valid one.
+  bool isValid(int catPadIndex) const { return mchCathodeSegmentationIsPadValid(mImpl, catPadIndex) > 0; }
   ///@}
 
   /** @name Pad finding.
    * Methods to find a pad.
    * In each case the returned integer
-   * represents either a paduid if a pad is found or
-   * an integer representing an invalid paduid otherwise.
+   * represents either a catPadIndex if a pad is found or
+   * an integer representing an invalid catPadIndex otherwise.
    * Validity of the returned value can be tested using isValid()
    */
   ///@{
@@ -141,38 +154,23 @@ class CathodeSegmentation
   ///@}
 
   /// @name Pad information retrieval.
-  /// Given a _valid_ paduid those methods return information
+  /// Given a _valid_ catPadIndex those methods return information
   /// (position, size, fee) about that pad.
   /// @{
-  double padPositionX(int paduid) const { return mchCathodeSegmentationPadPositionX(mImpl, paduid); }
-
-  double padPositionY(int paduid) const { return mchCathodeSegmentationPadPositionY(mImpl, paduid); }
-
-  double padSizeX(int paduid) const { return mchCathodeSegmentationPadSizeX(mImpl, paduid); }
-
-  double padSizeY(int paduid) const { return mchCathodeSegmentationPadSizeY(mImpl, paduid); }
-
-  int padDualSampaId(int paduid) const { return mchCathodeSegmentationPadDualSampaId(mImpl, paduid); }
-
-  int padDualSampaChannel(int paduid) const { return mchCathodeSegmentationPadDualSampaChannel(mImpl, paduid); }
-
+  double padPositionX(int catPadIndex) const { return mchCathodeSegmentationPadPositionX(mImpl, catPadIndex); }
+  double padPositionY(int catPadIndex) const { return mchCathodeSegmentationPadPositionY(mImpl, catPadIndex); }
+  double padSizeX(int catPadIndex) const { return mchCathodeSegmentationPadSizeX(mImpl, catPadIndex); }
+  double padSizeY(int catPadIndex) const { return mchCathodeSegmentationPadSizeY(mImpl, catPadIndex); }
+  int padDualSampaId(int catPadIndex) const { return mchCathodeSegmentationPadDualSampaId(mImpl, catPadIndex); }
+  int padDualSampaChannel(int catPadIndex) const { return mchCathodeSegmentationPadDualSampaChannel(mImpl, catPadIndex); }
+  std::string padAsString(int catPadIndex) const;
   /// @}
 
   /** @name Some general characteristics of this segmentation. */
   ///@{
   bool isBendingPlane() const { return mIsBendingPlane; }
-
   int nofDualSampas() const { return mDualSampaIds.size(); }
-
-  int nofPads() const
-  {
-    int n{ 0 };
-    for (auto i = 0; i < nofDualSampas(); ++i) {
-      forEachPadInDualSampa(dualSampaId(i), [&n](int /*paduid*/) { ++n; });
-    }
-    return n;
-  }
-
+  int nofPads() const { return mNofPads; }
   /// \param dualSampaIndex must be in the range 0..nofDualSampas()-1
   /// \return the DualSampa chip id for a given index
   int dualSampaId(int dualSampaIndex) const { return mDualSampaIds[dualSampaIndex]; }
@@ -190,21 +188,25 @@ class CathodeSegmentation
   void forEachPadInArea(double xmin, double ymin, double xmax, double ymax, CALLABLE&& func) const;
 
   template <typename CALLABLE>
-  void forEachNeighbouringPad(int paduid, CALLABLE&& func) const;
+  void forEachPad(CALLABLE&& func) const;
+
+  template <typename CALLABLE>
+  void forEachNeighbouringPad(int catPadIndex, CALLABLE&& func) const;
   ///@}
  private:
   MchCathodeSegmentationHandle mImpl;
   std::vector<int> mDualSampaIds;
   int mDetElemId;
   bool mIsBendingPlane;
+  int mNofPads = 0;
 };
 
 template <typename CALLABLE>
 void CathodeSegmentation::forEachPadInDualSampa(int dualSampaId, CALLABLE&& func) const
 {
-  auto callback = [](void* data, int paduid) {
+  auto callback = [](void* data, int catPadIndex) {
     auto fn = static_cast<decltype(&func)>(data);
-    (*fn)(paduid);
+    (*fn)(catPadIndex);
   };
   mchCathodeSegmentationForEachPadInDualSampa(mImpl, dualSampaId, callback, &func);
 }
@@ -212,21 +214,29 @@ void CathodeSegmentation::forEachPadInDualSampa(int dualSampaId, CALLABLE&& func
 template <typename CALLABLE>
 void CathodeSegmentation::forEachPadInArea(double xmin, double ymin, double xmax, double ymax, CALLABLE&& func) const
 {
-  auto callback = [](void* data, int paduid) {
+  auto callback = [](void* data, int catPadIndex) {
     auto fn = static_cast<decltype(&func)>(data);
-    (*fn)(paduid);
+    (*fn)(catPadIndex);
   };
   mchCathodeSegmentationForEachPadInArea(mImpl, xmin, ymin, xmax, ymax, callback, &func);
 }
 
 template <typename CALLABLE>
-void CathodeSegmentation::forEachNeighbouringPad(int paduid, CALLABLE&& func) const
+void CathodeSegmentation::forEachPad(CALLABLE&& func) const
+{
+  for (auto i = 0; i < nofPads(); i++) {
+    func(i);
+  }
+}
+
+template <typename CALLABLE>
+void CathodeSegmentation::forEachNeighbouringPad(int catPadIndex, CALLABLE&& func) const
 {
   auto callback = [](void* data, int puid) {
     auto fn = static_cast<decltype(&func)>(data);
     (*fn)(puid);
   };
-  mchCathodeSegmentationForEachNeighbouringPad(mImpl, paduid, callback, &func);
+  mchCathodeSegmentationForEachNeighbouringPad(mImpl, catPadIndex, callback, &func);
 }
 
 /** Convenience method to loop over detection elements. */
@@ -242,25 +252,24 @@ void forEachDetectionElement(CALLABLE&& func)
 
 /** Convenience method to loop over all segmentation types. */
 template <typename CALLABLE>
-void forOneDetectionElementOfEachCathodeSegmentationType(CALLABLE&& func)
+void forOneDetectionElementOfEachSegmentationType(CALLABLE&& func)
 {
   auto callback = [](void* data, int detElemId) {
     auto fn = static_cast<decltype(&func)>(data);
     (*fn)(detElemId);
   };
-  mchCathodeSegmentationForOneDetectionElementOfEachCathodeSegmentationType(callback, &func);
+  mchCathodeSegmentationForOneDetectionElementOfEachSegmentationType(callback, &func);
 }
 
 /** Convenience method to get a string representation of a pad. */
-inline std::string padAsString(const CathodeSegmentation& seg, int paduid)
+inline std::string CathodeSegmentation::padAsString(int catPadIndex) const
 {
-  if (seg.isValid(paduid)) {
-    return boost::str(boost::format("Pad %10d FEC %4d CH %2d X %7.3f Y %7.3f SX %7.3f SY %7.3f") % paduid %
-                      seg.padDualSampaId(paduid) % seg.padDualSampaChannel(paduid) % seg.padPositionX(paduid) %
-                      seg.padPositionY(paduid) % seg.padSizeX(paduid) % seg.padSizeY(paduid));
-  } else {
-    return "invalid pad with uid=" + std::to_string(paduid);
+  if (!isValid(catPadIndex)) {
+    return "invalid pad with uid=" + std::to_string(catPadIndex);
   }
+  return boost::str(boost::format("FEC %4d CH %2d X %7.3f Y %7.3f SX %7.3f SY %7.3f") %
+                    padDualSampaId(catPadIndex) % padDualSampaChannel(catPadIndex) % padPositionX(catPadIndex) %
+                    padPositionY(catPadIndex) % padSizeX(catPadIndex) % padSizeY(catPadIndex));
 }
 
 } // namespace mapping

--- a/Detectors/MUON/MCH/Mapping/Interface/include/MCHMappingInterface/CathodeSegmentationCInterface.h
+++ b/Detectors/MUON/MCH/Mapping/Interface/include/MCHMappingInterface/CathodeSegmentationCInterface.h
@@ -36,7 +36,7 @@ typedef void (*MchDetectionElementHandler)(void* clientData, int detElemId);
 
 typedef void (*MchDualSampaHandler)(void* clientData, int dualSampaId);
 
-typedef void (*MchPadHandler)(void* clientData, int paduid);
+typedef void (*MchPadHandler)(void* clientData, int catPadIndex);
 
 /** @name Creation and destruction of the segmentation handle.
  *
@@ -52,23 +52,23 @@ void mchCathodeSegmentationDestruct(MchCathodeSegmentationHandle segHandle);
 ///@}
 
 /** @name Pad Unique Identifier
- * Pads are identified by a unique integer, paduid.
- * @warning This paduid is only valid within the functions of this library
+ * Pads are identified by a unique integer, catPadIndex.
+ * @warning This catPadIndex is only valid within the functions of this library
  * (to use the query methods padPosition, padSize, etc...).
  * So do _not_ rely on any given value it might take (as it might change
  * between e.g. library versions)
  */
 ///@{
 
-/// Return > 0 if paduid is a valid one or <= 1 if not
-int mchCathodeSegmentationIsPadValid(MchCathodeSegmentationHandle segHandle, int paduid);
+/// Return > 0 if catPadIndex is a valid one or <= 1 if not
+int mchCathodeSegmentationIsPadValid(MchCathodeSegmentationHandle segHandle, int catPadIndex);
 ///@}
 
 /** @name Pad finding.
  * Functions to find a pad.
  * In each case the returned integer
- * represents either a paduid if a pad is found or
- * an integer representing an invalid paduid otherwise.
+ * represents either a catPadIndex if a pad is found or
+ * an integer representing an invalid catPadIndex otherwise.
  * Validity of the returned value can be tested using mchCathodeSegmentationIsPadValid()
  */
 ///@{
@@ -81,25 +81,25 @@ int mchCathodeSegmentationFindPadByFEE(MchCathodeSegmentationHandle segHandle, i
 ///@}
 
 /** @name Pad information retrieval.
- * Given a _valid_ paduid those methods return information
+ * Given a _valid_ catPadIndex those methods return information
  * (position, size, front-end electronics) about that pad.
  *
  * Positions and sizes are in centimetres.
  *
- * If paduid is invalid, you are on your own.
+ * If catPadIndex is invalid, you are on your own.
  */
 /// @{
-double mchCathodeSegmentationPadPositionX(MchCathodeSegmentationHandle segHandle, int paduid);
+double mchCathodeSegmentationPadPositionX(MchCathodeSegmentationHandle segHandle, int catPadIndex);
 
-double mchCathodeSegmentationPadPositionY(MchCathodeSegmentationHandle segHandle, int paduid);
+double mchCathodeSegmentationPadPositionY(MchCathodeSegmentationHandle segHandle, int catPadIndex);
 
-double mchCathodeSegmentationPadSizeX(MchCathodeSegmentationHandle segHandle, int paduid);
+double mchCathodeSegmentationPadSizeX(MchCathodeSegmentationHandle segHandle, int catPadIndex);
 
-double mchCathodeSegmentationPadSizeY(MchCathodeSegmentationHandle segHandle, int paduid);
+double mchCathodeSegmentationPadSizeY(MchCathodeSegmentationHandle segHandle, int catPadIndex);
 
-int mchCathodeSegmentationPadDualSampaId(MchCathodeSegmentationHandle segHandle, int paduid);
+int mchCathodeSegmentationPadDualSampaId(MchCathodeSegmentationHandle segHandle, int catPadIndex);
 
-int mchCathodeSegmentationPadDualSampaChannel(MchCathodeSegmentationHandle segHandle, int paduid);
+int mchCathodeSegmentationPadDualSampaChannel(MchCathodeSegmentationHandle segHandle, int catPadIndex);
 ///@}
 
 /** @name ForEach methods.
@@ -108,7 +108,7 @@ int mchCathodeSegmentationPadDualSampaChannel(MchCathodeSegmentationHandle segHa
 ///@{
 void mchCathodeSegmentationForEachDetectionElement(MchDetectionElementHandler handler, void* clientData);
 
-void mchCathodeSegmentationForOneDetectionElementOfEachCathodeSegmentationType(MchDetectionElementHandler handler, void* clientData);
+void mchCathodeSegmentationForOneDetectionElementOfEachSegmentationType(MchDetectionElementHandler handler, void* clientData);
 
 void mchCathodeSegmentationForEachDualSampa(MchCathodeSegmentationHandle segHandle, MchDualSampaHandler handler, void* clientData);
 
@@ -118,7 +118,9 @@ void mchCathodeSegmentationForEachPadInDualSampa(MchCathodeSegmentationHandle se
 void mchCathodeSegmentationForEachPadInArea(MchCathodeSegmentationHandle segHandle, double xmin, double ymin, double xmax,
                                             double ymax, MchPadHandler handler, void* clientData);
 
-void mchCathodeSegmentationForEachNeighbouringPad(MchCathodeSegmentationHandle segHandle, int paduid, MchPadHandler handler,
+void mchCathodeSegmentationForEachPad(MchCathodeSegmentationHandle segHandle, MchPadHandler handler, void* clientData);
+
+void mchCathodeSegmentationForEachNeighbouringPad(MchCathodeSegmentationHandle segHandle, int catPadIndex, MchPadHandler handler,
                                                   void* userData);
 ///@}
 

--- a/Detectors/MUON/MCH/Mapping/Interface/include/MCHMappingInterface/Segmentation.h
+++ b/Detectors/MUON/MCH/Mapping/Interface/include/MCHMappingInterface/Segmentation.h
@@ -258,8 +258,8 @@ void Segmentation::forEachNeighbouringPad(int dePadIndex, CALLABLE&& func) const
   if (!isBendingPad(dePadIndex)) {
     offset = mPadIndexOffset;
   }
-  catSeg->forEachNeighbouringPad(catPadIndex, [&offset, &func](int catPadIndex) {
-    func(catPadIndex + offset);
+  catSeg->forEachNeighbouringPad(catPadIndex, [&offset, &func](int cindex) {
+    func(cindex + offset);
   });
 }
 

--- a/Detectors/MUON/MCH/Mapping/Interface/include/MCHMappingInterface/Segmentation.h
+++ b/Detectors/MUON/MCH/Mapping/Interface/include/MCHMappingInterface/Segmentation.h
@@ -1,0 +1,329 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/** @file CathodeSegmentation.h
+ * C++ Interface to the Muon MCH mapping.
+ * @author  Laurent Aphecetche
+ */
+
+#ifndef O2_MCH_MAPPING_SEGMENTATION_H
+#define O2_MCH_MAPPING_SEGMENTATION_H
+
+#include "MCHMappingInterface/CathodeSegmentation.h"
+
+namespace o2
+{
+namespace mch
+{
+namespace mapping
+{
+
+/// @brief A Segmentation lets you _find_ pads of a detection element
+/// and then _inspect_ those pads.
+///
+/// Note that this class is closely related to the CathodeSegmentation one which
+/// only deals with one of the two cathodes of a detection element.
+///
+/// Pads can be found by :
+/// - their position (x,y)
+/// - their front-end electronics characteristics (which DualSampa chip, which chip channel)
+///
+/// What you get back from the find methods are not pad objects directly but a reference (integer)
+/// that can then be used to query the segmentation object about that pad.
+/// @warning This integer reference (dePadIndex) is only valid within the realm
+/// of this Segmentation object (to use the query methods padPosition, padSize, etc...).
+/// So do _not_ rely on any given value it might take (as it might change
+/// between e.g. library version or underlying implementation)
+///
+/// By convention, the pad references are contiguous (ranging from 0 to number
+/// of pads in the detection element), and the bending pads come first.
+///
+/// Pad information that can be retrieved :
+/// - position in x and y directions
+/// - size in x and y directions
+/// - dual sampa id
+/// - dual sampa channel
+///
+/// In addition, you can _apply_ some function to a group of pads using one of the the forEach methods :
+/// - all the pads belonging to a given dual sampa
+/// - all the pads within a given area (box)
+/// - all the pads that are neighbours of a given pad
+
+class Segmentation
+{
+ public:
+  /// This ctor throws if deid is invalid
+  Segmentation(int deid) : mDetElemId{ deid }, mBending{ CathodeSegmentation(deid, true) }, mNonBending{ CathodeSegmentation(deid, false) }, mPadIndexOffset{ mBending.nofPads() } {}
+
+  bool operator==(const Segmentation& rhs) const
+  {
+    return mDetElemId == rhs.mDetElemId;
+  }
+
+  bool operator!=(const Segmentation& rhs) const { return !(rhs == *this); }
+
+  friend void swap(Segmentation& a, Segmentation& b)
+  {
+    using std::swap;
+    swap(a.mDetElemId, b.mDetElemId);
+  }
+
+  Segmentation(const Segmentation& seg) : mBending{ seg.mBending }, mNonBending{ seg.mNonBending }
+  {
+    mDetElemId = seg.mDetElemId;
+  }
+
+  Segmentation(const Segmentation&& seg) : mBending{ std::move(seg.mBending) }, mNonBending{ std::move(seg.mNonBending) }
+  {
+    mDetElemId = seg.mDetElemId;
+  }
+  Segmentation& operator=(Segmentation seg)
+  {
+    swap(*this, seg);
+    return *this;
+  }
+
+  /** @name Some general characteristics of this segmentation. */
+  ///@{
+  int detElemId() const { return mDetElemId; }
+  int nofPads() const { return mBending.nofPads() + mNonBending.nofPads(); }
+  int nofDualSampas() const { return mBending.nofDualSampas() + mNonBending.nofDualSampas(); }
+  ///@}
+
+  /** @name Access to individual cathode segmentations. 
+    * Not needed in most cases.
+    */
+  ///@{
+  const CathodeSegmentation& Bending() const { return mBending; }
+  const CathodeSegmentation& NonBending() const { return mNonBending; }
+  ///@}
+
+  /** @name Pad finding.
+   * Methods to find a pad.
+   * In each case the returned integer(s)
+   * represents either a dePadIndex if a pad is found or
+   * an integer representing an invalid dePadIndex otherwise.
+   * Validity of the returned value can be tested using isValid()
+   */
+  ///@{
+  /** Find the pads at position (x,y) (in cm). 
+    Returns true is the bpad and nbpad has been filled with a valid dePadIndex,
+    false otherwise (if position is outside the segmentation area).
+    @param bpad the dePadIndex of the bending pad at position (x,y)
+    @param nbpad the dePadIndex of the non-bending pad at position (x,y)
+  */
+  bool findPadPairByPosition(double x, double y, int& bpad, int& nbpad) const;
+
+  /** Find the pad connected to the given channel of the given dual sampa. */
+  int findPadByFEE(int dualSampaId, int dualSampaChannel) const;
+  ///@}
+
+  /// @name Pad information retrieval.
+  /// Given a _valid_ dePadIndex those methods return information
+  /// (position, size, fee, etc...) about that pad.
+  /// @{
+  double padPositionX(int dePadIndex) const;
+  double padPositionY(int dePadIndex) const;
+  double padSizeX(int dePadIndex) const;
+  double padSizeY(int dePadIndex) const;
+  int padDualSampaId(int dePadIndex) const;
+  int padDualSampaChannel(int dePadIndex) const;
+  bool isValid(int dePadIndex) const;
+  bool isBendingPad(int dePadIndex) const { return dePadIndex < mPadIndexOffset; }
+  std::string padAsString(int dePadIndex) const;
+  /// @}
+
+  /** @name ForEach methods.
+   * Those methods let you execute a function on each of the pads belonging to
+   * some group.
+   */
+  ///@{
+  template <typename CALLABLE>
+  void forEachPad(CALLABLE&& func) const;
+
+  template <typename CALLABLE>
+  void forEachNeighbouringPad(int dePadIndex, CALLABLE&& func) const;
+
+  template <typename CALLABLE>
+  void forEachPadInArea(double xmin, double ymin, double xmax, double ymax, CALLABLE&& func) const;
+  ///@}
+
+ private:
+  int padC2DE(int catPadIndex, bool isBending) const;
+  void catSegPad(int dePadIndex, const CathodeSegmentation*& catseg, int& padcuid) const;
+
+ private:
+  int mDetElemId;
+  CathodeSegmentation mBending;
+  CathodeSegmentation mNonBending;
+  int mPadIndexOffset = 0;
+};
+
+inline int Segmentation::findPadByFEE(int dualSampaId, int dualSampaChannel) const
+{
+  bool isBending = dualSampaId < 1024;
+  int catPadIndex;
+  if (isBending) {
+    catPadIndex = mBending.findPadByFEE(dualSampaId, dualSampaChannel);
+    if (!mBending.isValid(catPadIndex)) {
+      return -1;
+    }
+  } else {
+    catPadIndex = mNonBending.findPadByFEE(dualSampaId, dualSampaChannel);
+    if (!mNonBending.isValid(catPadIndex)) {
+      return -1;
+    }
+  }
+  return padC2DE(catPadIndex, isBending);
+}
+
+inline bool Segmentation::isValid(int dePadIndex) const
+{
+  if (dePadIndex < mPadIndexOffset) {
+    return mBending.isValid(dePadIndex);
+  }
+  return mNonBending.isValid(dePadIndex - mPadIndexOffset);
+}
+
+inline int Segmentation::padC2DE(int catPadIndex, bool isBending) const
+{
+  if (isBending) {
+    return catPadIndex;
+  }
+  return catPadIndex + mPadIndexOffset;
+}
+
+inline void Segmentation::catSegPad(int dePadIndex, const CathodeSegmentation*& catseg, int& padcuid) const
+{
+  if (!isValid(dePadIndex)) {
+    catseg = nullptr;
+    return;
+  }
+  if (dePadIndex < mPadIndexOffset) {
+    catseg = &mBending;
+    padcuid = dePadIndex;
+    return;
+  }
+  catseg = &mNonBending;
+  padcuid = dePadIndex - mPadIndexOffset;
+}
+
+inline bool Segmentation::findPadPairByPosition(double x, double y, int& b, int& nb) const
+{
+  b = mBending.findPadByPosition(x, y);
+  nb = mNonBending.findPadByPosition(x, y);
+  if (!mBending.isValid(b) || !mNonBending.isValid(nb)) {
+    return false;
+  }
+  b = padC2DE(b, true);
+  nb = padC2DE(nb, false);
+  return true;
+}
+
+template <typename CALLABLE>
+void Segmentation::forEachPad(CALLABLE&& func) const
+{
+  mBending.forEachPad(func);
+  int offset{ mPadIndexOffset };
+  mNonBending.forEachPad([&offset, &func](int catPadIndex) {
+    func(catPadIndex + offset);
+  });
+}
+
+template <typename CALLABLE>
+void Segmentation::forEachPadInArea(double xmin, double ymin, double xmax, double ymax, CALLABLE&& func) const
+{
+  mBending.forEachPadInArea(xmin, ymin, xmax, ymax, func);
+  int offset{ mPadIndexOffset };
+  mNonBending.forEachPadInArea(xmin, ymin, xmax, ymax, [&offset, &func](int catPadIndex) {
+    func(catPadIndex + offset);
+  });
+}
+
+template <typename CALLABLE>
+void Segmentation::forEachNeighbouringPad(int dePadIndex, CALLABLE&& func) const
+{
+  const CathodeSegmentation* catSeg{ nullptr };
+  int catPadIndex;
+  catSegPad(dePadIndex, catSeg, catPadIndex);
+
+  int offset{ 0 };
+  if (!isBendingPad(dePadIndex)) {
+    offset = mPadIndexOffset;
+  }
+  catSeg->forEachNeighbouringPad(catPadIndex, [&offset, &func](int catPadIndex) {
+    func(catPadIndex + offset);
+  });
+}
+
+inline std::string Segmentation::padAsString(int dePadIndex) const
+{
+  if (!isValid(dePadIndex)) {
+    return "invalid pad with index=" + std::to_string(dePadIndex);
+  }
+  const CathodeSegmentation* catSeg{ nullptr };
+  int catPadIndex;
+  catSegPad(dePadIndex, catSeg, catPadIndex);
+  return catSeg->padAsString(catPadIndex);
+}
+
+inline int Segmentation::padDualSampaId(int dePadIndex) const
+{
+  const CathodeSegmentation* catSeg{ nullptr };
+  int catPadIndex;
+  catSegPad(dePadIndex, catSeg, catPadIndex);
+  return catSeg->padDualSampaId(catPadIndex);
+}
+
+inline int Segmentation::padDualSampaChannel(int dePadIndex) const
+{
+  const CathodeSegmentation* catSeg{ nullptr };
+  int catPadIndex;
+  catSegPad(dePadIndex, catSeg, catPadIndex);
+  return catSeg->padDualSampaChannel(catPadIndex);
+}
+
+inline double Segmentation::padPositionX(int dePadIndex) const
+{
+  const CathodeSegmentation* catSeg{ nullptr };
+  int catPadIndex;
+  catSegPad(dePadIndex, catSeg, catPadIndex);
+  return catSeg->padPositionX(catPadIndex);
+}
+
+inline double Segmentation::padPositionY(int dePadIndex) const
+{
+  const CathodeSegmentation* catSeg{ nullptr };
+  int catPadIndex;
+  catSegPad(dePadIndex, catSeg, catPadIndex);
+  return catSeg->padPositionY(catPadIndex);
+}
+
+inline double Segmentation::padSizeX(int dePadIndex) const
+{
+  const CathodeSegmentation* catSeg{ nullptr };
+  int catPadIndex;
+  catSegPad(dePadIndex, catSeg, catPadIndex);
+  return catSeg->padSizeX(catPadIndex);
+}
+
+inline double Segmentation::padSizeY(int dePadIndex) const
+{
+  const CathodeSegmentation* catSeg{ nullptr };
+  int catPadIndex;
+  catSegPad(dePadIndex, catSeg, catPadIndex);
+  return catSeg->padSizeY(catPadIndex);
+}
+
+} // namespace mapping
+} // namespace mch
+} // namespace o2
+
+#endif

--- a/Detectors/MUON/MCH/Mapping/README.md
+++ b/Detectors/MUON/MCH/Mapping/README.md
@@ -18,24 +18,28 @@ Details are to be found in the interface file or in the doxygen documentation, b
  
 ```c++
 int detElemId{100};
-bool isBendingPlane{true};
 
-o2::mch::mapping::Segmentation seg{detElemId, isBendingPlane};
+o2::mch::mapping::Segmentation seg{detElemId};
 
 double x{1.5};
 double y{18.6};
 
-int paduid = seg.findPadByPosition(x, y);
+int b, nb;
+book found = seg.findPadPairByPosition(x, y, b, nb);
 
-if (seg.isValid(paduid)) {
-  std::cout << "There is a pad at position " << x << "," << y << "\n"
-            << " which belongs to dualSampa " << seg.padDualSampaId(paduid)
-            << " and has a x-size of " << seg.padSizeX(paduid) << " cm\n";
+if (seg.isValid(b)) {
+  std::cout << "There is a bending pad at position " << x << "," << y << "\n"
+            << " which belongs to dualSampa " << seg.padDualSampaId(b)
+            << " and has a x-size of " << seg.padSizeX(b) << " cm\n";
 }
 
-assert(paduid == seg.findPadByFEE(76, 9));
+assert(b == seg.findPadByFEE(76, 9));
   
 ```
+
+Note that cathode-specific segmentations can be retrieved from `Segmentation` 
+objects (using Bending() and NonBending() methods) or created from scratch
+using the `CathodeSegmentation(int detElemId, bool isBendingPlane)` constructor.
 
 # Implementations
 

--- a/Detectors/MUON/MCH/Mapping/SegContour/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Mapping/SegContour/CMakeLists.txt
@@ -3,7 +3,8 @@ set(BUCKET_NAME mch_mapping_segcontour_bucket)
 
 set(SRCS
         src/CathodeSegmentationContours.cxx
-        src/CathodeSegmentationSVGWriter.cxx)
+        src/CathodeSegmentationSVGWriter.cxx
+        src/SegmentationContours.cxx)
 
 set(LIBRARY_NAME MCHMappingSegContour3)
 

--- a/Detectors/MUON/MCH/Mapping/SegContour/src/CathodeSegmentationContours.cxx
+++ b/Detectors/MUON/MCH/Mapping/SegContour/src/CathodeSegmentationContours.cxx
@@ -44,13 +44,13 @@ std::vector<std::vector<int>> getPadChannels(const CathodeSegmentation& seg)
 
   for (auto i = 0; i < seg.nofDualSampas(); ++i) {
     std::vector<int> pads;
-    seg.forEachPadInDualSampa(seg.dualSampaId(i), [&pads, &seg](int paduid) {
-      double x = seg.padPositionX(paduid);
-      double y = seg.padPositionY(paduid);
-      double dx = seg.padSizeX(paduid) / 2.0;
-      double dy = seg.padSizeY(paduid) / 2.0;
+    seg.forEachPadInDualSampa(seg.dualSampaId(i), [&pads, &seg](int catPadIndex) {
+      double x = seg.padPositionX(catPadIndex);
+      double y = seg.padPositionY(catPadIndex);
+      double dx = seg.padSizeX(catPadIndex) / 2.0;
+      double dy = seg.padSizeY(catPadIndex) / 2.0;
 
-      pads.emplace_back(seg.padDualSampaChannel(paduid));
+      pads.emplace_back(seg.padDualSampaChannel(catPadIndex));
     });
     dualSampaPads.push_back(pads);
   }
@@ -61,11 +61,11 @@ std::vector<std::vector<int>> getPadChannels(const CathodeSegmentation& seg)
 std::vector<Polygon<double>> getPadPolygons(const CathodeSegmentation& seg, int dualSampaId)
 {
   std::vector<Polygon<double>> pads;
-  seg.forEachPadInDualSampa(dualSampaId, [&pads, &seg](int paduid) {
-    double x = seg.padPositionX(paduid);
-    double y = seg.padPositionY(paduid);
-    double dx = seg.padSizeX(paduid) / 2.0;
-    double dy = seg.padSizeY(paduid) / 2.0;
+  seg.forEachPadInDualSampa(dualSampaId, [&pads, &seg](int catPadIndex) {
+    double x = seg.padPositionX(catPadIndex);
+    double y = seg.padPositionY(catPadIndex);
+    double dx = seg.padSizeX(catPadIndex) / 2.0;
+    double dy = seg.padSizeY(catPadIndex) / 2.0;
 
     pads.emplace_back(Polygon<double>{
       { x - dx, y - dy }, { x + dx, y - dy }, { x + dx, y + dy }, { x - dx, y + dy }, { x - dx, y - dy } });

--- a/Detectors/MUON/MCH/Mapping/SegContour/src/CathodeSegmentationSVGWriter.cxx
+++ b/Detectors/MUON/MCH/Mapping/SegContour/src/CathodeSegmentationSVGWriter.cxx
@@ -9,7 +9,7 @@
 // or submit itself to any jurisdiction.
 
 ///
-/// @author  Laurent Apaduidecetche
+/// @author  Laurent Aphecetche
 
 #include "MCHMappingSegContour/CathodeSegmentationSVGWriter.h"
 #include "MCHMappingInterface/CathodeSegmentation.h"

--- a/Detectors/MUON/MCH/Mapping/SegContour/src/SVGSegmentation.cxx
+++ b/Detectors/MUON/MCH/Mapping/SegContour/src/SVGSegmentation.cxx
@@ -67,7 +67,7 @@ int main(int argc, char* argv[])
   }
 
   if (vm.count("all")) {
-    o2::mch::mapping::forOneDetectionElementOfEachCathodeSegmentationType(
+    o2::mch::mapping::forOneDetectionElementOfEachSegmentationType(
       [&detElemIds](int detElemId) { detElemIds.push_back(detElemId); });
   }
 

--- a/Detectors/MUON/MCH/Mapping/SegContour/src/SegmentationContours.cxx
+++ b/Detectors/MUON/MCH/Mapping/SegContour/src/SegmentationContours.cxx
@@ -11,13 +11,12 @@
 ///
 /// @author  Laurent Aphecetche
 
-#ifndef O2_MCH_MAPPING_SEGMENTATIONCONTOURS_H
-#define O2_MCH_MAPPING_SEGMENTATIONCONTOURS_H
+#include "MCHMappingSegContour/SegmentationContours.h"
+#include "MCHMappingSegContour/CathodeSegmentationContours.h"
+#include "MCHContour/ContourCreator.h"
+#include <iostream>
 
-#include <vector>
-#include "MCHContour/Contour.h"
-#include "MCHContour/BBox.h"
-#include "MCHMappingInterface/Segmentation.h"
+using namespace o2::mch::contour;
 
 namespace o2
 {
@@ -26,11 +25,20 @@ namespace mch
 namespace mapping
 {
 
-o2::mch::contour::Contour<double> getEnvelop(const Segmentation& seg);
+BBox<double> getBBox(const Segmentation& seg) { return getBBox(getEnvelop(seg)); }
 
-o2::mch::contour::BBox<double> getBBox(const Segmentation& seg);
+Contour<double> getEnvelop(const Segmentation& seg)
+{
+  std::vector<Polygon<double>> polygons;
+
+  for (auto& contour : { getEnvelop(seg.NonBending()), getEnvelop(seg.Bending()) }) {
+    for (auto& p : contour.getPolygons()) {
+      polygons.push_back(p);
+    }
+  }
+  return o2::mch::contour::createContour(polygons);
+}
+
 } // namespace mapping
 } // namespace mch
 } // namespace o2
-
-#endif

--- a/Detectors/MUON/MCH/Mapping/SegContour/src/SegmentationSVGWriter.cxx
+++ b/Detectors/MUON/MCH/Mapping/SegContour/src/SegmentationSVGWriter.cxx
@@ -9,7 +9,7 @@
 // or submit itself to any jurisdiction.
 
 ///
-/// @author  Laurent Apaduidecetche
+/// @author  Laurent Aphecetche
 
 #include "MCHMappingSegContour/CathodeSegmentationSVGWriter.h"
 #include "MCHMappingInterface/CathodeSegmentation.h"

--- a/Detectors/MUON/MCH/Mapping/test/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Mapping/test/CMakeLists.txt
@@ -1,22 +1,30 @@
-O2_SETUP(NAME MCHMappingTest)
+o2_setup(NAME MCHMappingTest)
 set(BUCKET_NAME mch_mapping_test_bucket)
 
 # trying to get only one test exe for this module
-O2_GENERATE_EXECUTABLE(
-        EXE_NAME test_MCHMappingTest
-        SOURCES src/CathodeSegmentation.cxx src/CathodeSegmentationLong.cxx 
-        BUCKET_NAME mch_mapping_test_bucket
-)
+o2_generate_executable(EXE_NAME
+                       test_MCHMappingTest
+                       SOURCES
+                       src/CathodeSegmentation.cxx
+                       src/CathodeSegmentationLong.cxx
+                       src/Segmentation.cxx
+                       BUCKET_NAME
+                       mch_mapping_test_bucket)
 
 target_link_libraries(test_MCHMappingTest Boost::unit_test_framework)
 add_test(NAME test_MCHMappingTest COMMAND test_MCHMappingTest)
 
-if (benchmark_FOUND)
-    O2_GENERATE_EXECUTABLE(
-            EXE_NAME mch-mapping-bench-segmentation3
-            SOURCES src/BenchCathodeSegmentation.cxx 
-            BUCKET_NAME mch_mapping_test_bucket)
-endif ()
+if(benchmark_FOUND)
+  o2_generate_executable(EXE_NAME
+                         mch-mapping-bench-segmentation3
+                         SOURCES
+                         src/BenchCathodeSegmentation.cxx
+                         src/BenchSegmentation.cxx
+                         BUCKET_NAME
+                         mch_mapping_test_bucket)
+endif()
 
-file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/data/test_random_pos.json
-DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+file(COPY
+     ${CMAKE_CURRENT_SOURCE_DIR}/data/test_random_pos.json
+     DESTINATION
+     ${CMAKE_CURRENT_BINARY_DIR})

--- a/Detectors/MUON/MCH/Mapping/test/src/BenchCathodeSegmentation.cxx
+++ b/Detectors/MUON/MCH/Mapping/test/src/BenchCathodeSegmentation.cxx
@@ -39,7 +39,7 @@ std::vector<TestPoint> generateUniformTestPoints(int n, double xmin, double ymin
 
 static void segmentationList(benchmark::internal::Benchmark* b)
 {
-  o2::mch::mapping::forOneDetectionElementOfEachCathodeSegmentationType([&b](int detElemId) {
+  o2::mch::mapping::forOneDetectionElementOfEachSegmentationType([&b](int detElemId) {
     for (auto bending : { true, false }) {
       {
         b->Args({ detElemId, bending });
@@ -66,7 +66,7 @@ BENCHMARK_DEFINE_F(BenchO2, ctor)
 std::vector<int> getDetElemIds()
 {
   std::vector<int> deids;
-  o2::mch::mapping::forOneDetectionElementOfEachCathodeSegmentationType(
+  o2::mch::mapping::forOneDetectionElementOfEachSegmentationType(
     [&deids](int detElemId) { deids.push_back(detElemId); });
   return deids;
 }

--- a/Detectors/MUON/MCH/Mapping/test/src/BenchSegmentation.cxx
+++ b/Detectors/MUON/MCH/Mapping/test/src/BenchSegmentation.cxx
@@ -1,0 +1,89 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// @author  Laurent Aphecetche
+
+#include <algorithm>
+#include <random>
+#include "benchmark/benchmark.h"
+#include "MCHMappingInterface/Segmentation.h"
+
+static void segmentationList(benchmark::internal::Benchmark* b)
+{
+  o2::mch::mapping::forOneDetectionElementOfEachSegmentationType([&b](int detElemId) {
+    b->Args({ detElemId });
+  });
+}
+
+class BenchSegO2 : public benchmark::Fixture
+{
+};
+
+BENCHMARK_DEFINE_F(BenchSegO2, ctor)
+(benchmark::State& state)
+{
+  int detElemId = state.range(0);
+
+  for (auto _ : state) {
+    o2::mch::mapping::Segmentation seg{ detElemId };
+  }
+}
+
+namespace
+{
+std::vector<int> getDetElemIds()
+{
+  std::vector<int> deids;
+  o2::mch::mapping::forEachDetectionElement(
+    [&deids](int detElemId) { deids.push_back(detElemId); });
+  return deids;
+}
+} // namespace
+
+static void benchSegmentationCtorAll(benchmark::State& state)
+{
+  std::vector<int> deids = getDetElemIds();
+  for (auto _ : state) {
+    for (auto detElemId : deids) {
+      o2::mch::mapping::Segmentation seg{ detElemId };
+    }
+  }
+}
+
+static void benchSegmentationCtorMap(benchmark::State& state)
+{
+  std::vector<int> deids = getDetElemIds();
+  std::map<int, o2::mch::mapping::Segmentation> cache;
+
+  for (auto _ : state) {
+    for (auto detElemId : deids) {
+      cache.emplace(detElemId, o2::mch::mapping::Segmentation(detElemId));
+    }
+  }
+}
+
+static void benchSegmentationCtorMapPtr(benchmark::State& state)
+{
+  std::vector<int> deids = getDetElemIds();
+  std::map<int, o2::mch::mapping::Segmentation*> cache;
+
+  for (auto _ : state) {
+    for (auto detElemId : deids) {
+      cache.emplace(detElemId, new o2::mch::mapping::Segmentation(detElemId));
+    }
+  }
+}
+BENCHMARK(benchSegmentationCtorAll)->Unit(benchmark::kMillisecond);
+BENCHMARK(benchSegmentationCtorMap)->Unit(benchmark::kMillisecond);
+BENCHMARK(benchSegmentationCtorMapPtr)->Unit(benchmark::kMillisecond);
+
+BENCHMARK_REGISTER_F(BenchSegO2, ctor)->Apply(segmentationList)->Unit(benchmark::kMicrosecond);
+

--- a/Detectors/MUON/MCH/Mapping/test/src/BenchSegmentation.cxx
+++ b/Detectors/MUON/MCH/Mapping/test/src/BenchSegmentation.cxx
@@ -86,4 +86,3 @@ BENCHMARK(benchSegmentationCtorMap)->Unit(benchmark::kMillisecond);
 BENCHMARK(benchSegmentationCtorMapPtr)->Unit(benchmark::kMillisecond);
 
 BENCHMARK_REGISTER_F(BenchSegO2, ctor)->Apply(segmentationList)->Unit(benchmark::kMicrosecond);
-

--- a/Detectors/MUON/MCH/Mapping/test/src/CathodeSegmentation.cxx
+++ b/Detectors/MUON/MCH/Mapping/test/src/CathodeSegmentation.cxx
@@ -25,6 +25,7 @@
 #include <boost/test/data/monomorphic.hpp>
 #include <boost/test/data/monomorphic/generators/xrange.hpp>
 #include <boost/test/data/test_case.hpp>
+#include <limits>
 #include <fstream>
 #include <iostream>
 
@@ -32,7 +33,7 @@ using namespace o2::mch::mapping;
 namespace bdata = boost::unit_test::data;
 
 BOOST_AUTO_TEST_SUITE(o2_mch_mapping)
-BOOST_AUTO_TEST_SUITE(segmentation)
+BOOST_AUTO_TEST_SUITE(cathode_segmentation)
 
 BOOST_AUTO_TEST_CASE(NumberOfDetectionElementsIs156)
 {
@@ -43,7 +44,7 @@ BOOST_AUTO_TEST_CASE(NumberOfDetectionElementsIs156)
 
 BOOST_AUTO_TEST_CASE(GetCathodeSegmentationMustNotThrowIfDetElemIdIsValid)
 {
-  forOneDetectionElementOfEachCathodeSegmentationType([](int detElemId) {
+  forOneDetectionElementOfEachSegmentationType([](int detElemId) {
     BOOST_CHECK_NO_THROW(CathodeSegmentation(detElemId, true));
     BOOST_CHECK_NO_THROW(CathodeSegmentation(detElemId, false));
   });
@@ -113,7 +114,7 @@ BOOST_AUTO_TEST_CASE(TotalNofBendingFECInSegTypes)
 {
   int nb{ 0 };
   int nnb{ 0 };
-  forOneDetectionElementOfEachCathodeSegmentationType([&](int detElemId) {
+  forOneDetectionElementOfEachSegmentationType([&](int detElemId) {
     nb += CathodeSegmentation(detElemId, true).nofDualSampas();
     nnb += CathodeSegmentation(detElemId, false).nofDualSampas();
   });
@@ -224,7 +225,7 @@ BOOST_AUTO_TEST_CASE(NofNonBendingFEC)
 BOOST_AUTO_TEST_CASE(CountPadsInCathodeSegmentations)
 {
   int n{ 0 };
-  forOneDetectionElementOfEachCathodeSegmentationType([&n](int detElemId) {
+  forOneDetectionElementOfEachSegmentationType([&n](int detElemId) {
     for (auto plane : { true, false }) {
       CathodeSegmentation seg{ detElemId, plane };
       n += seg.nofPads();
@@ -236,7 +237,7 @@ BOOST_AUTO_TEST_CASE(CountPadsInCathodeSegmentations)
 BOOST_AUTO_TEST_CASE(LoopOnCathodeSegmentations)
 {
   int n{ 0 };
-  forOneDetectionElementOfEachCathodeSegmentationType([&n](int detElemId) {
+  forOneDetectionElementOfEachSegmentationType([&n](int detElemId) {
     n += 2; // two planes (bending, non-bending)
   });
   BOOST_CHECK_EQUAL(n, 42);
@@ -245,12 +246,12 @@ BOOST_AUTO_TEST_CASE(LoopOnCathodeSegmentations)
 BOOST_AUTO_TEST_CASE(DualSampasWithLessThan64Pads)
 {
   std::map<int, int> non64;
-  forOneDetectionElementOfEachCathodeSegmentationType([&non64](int detElemId) {
+  forOneDetectionElementOfEachSegmentationType([&non64](int detElemId) {
     for (auto plane : { true, false }) {
       CathodeSegmentation seg{ detElemId, plane };
       for (int i = 0; i < seg.nofDualSampas(); ++i) {
         int n{ 0 };
-        seg.forEachPadInDualSampa(seg.dualSampaId(i), [&n](int /*paduid*/) { ++n; });
+        seg.forEachPadInDualSampa(seg.dualSampaId(i), [&n](int /*catPadIndex*/) { ++n; });
         if (n != 64) {
           non64[n]++;
         }
@@ -297,14 +298,20 @@ BOOST_AUTO_TEST_CASE(ThrowsIfDualSampaChannelIsNotBetween0And63)
   BOOST_CHECK_THROW(seg.findPadByFEE(102, 64), std::out_of_range);
 }
 
-BOOST_AUTO_TEST_CASE(ReturnsTrueIfPadIsConnected) { BOOST_CHECK_EQUAL(seg.isValid(seg.findPadByFEE(102, 3)), true); }
+BOOST_AUTO_TEST_CASE(ReturnsTrueIfPadIsConnected)
+{
+  BOOST_CHECK_EQUAL(seg.isValid(seg.findPadByFEE(102, 3)), true);
+}
 
 BOOST_AUTO_TEST_CASE(ReturnsFalseIfPadIsNotConnected)
 {
   BOOST_CHECK_EQUAL(seg.isValid(seg.findPadByFEE(214, 14)), false);
 }
 
-BOOST_AUTO_TEST_CASE(HasPadByPosition) { BOOST_CHECK_EQUAL(seg.isValid(seg.findPadByPosition(40.0, 30.0)), true); }
+BOOST_AUTO_TEST_CASE(HasPadByPosition)
+{
+  BOOST_CHECK_EQUAL(seg.isValid(seg.findPadByPosition(40.0, 30.0)), true);
+}
 
 BOOST_AUTO_TEST_CASE(CheckPositionOfOnePadInDE100Bending)
 {

--- a/Detectors/MUON/MCH/Mapping/test/src/CathodeSegmentationLong.cxx
+++ b/Detectors/MUON/MCH/Mapping/test/src/CathodeSegmentationLong.cxx
@@ -98,7 +98,7 @@ std::vector<Point> checkGaps(const CathodeSegmentation& seg, double xstep = 1.0,
         std::sqrt(o2::mch::contour::squaredDistancePointToPolygon(o2::mch::contour::Vertex<double>{ x, y }, env[0]));
       bool withinEnveloppe = env.contains(x, y) && (distanceToEnveloppe > 1E-5);
       if (withinEnveloppe && !seg.isValid(seg.findPadByPosition(x, y))) {
-        gaps.push_back(std::make_pair(x, y));
+        gaps.emplace_back(x, y);
       }
     }
   }

--- a/Detectors/MUON/MCH/Mapping/test/src/Segmentation.cxx
+++ b/Detectors/MUON/MCH/Mapping/test/src/Segmentation.cxx
@@ -36,8 +36,8 @@ const Segmentation& SegCache(int detElemId)
   if (cache.empty()) {
     auto start = std::chrono::high_resolution_clock::now();
     std::vector<int> deids;
-    forEachDetectionElement([&deids](int detElemId) {
-      deids.push_back(detElemId);
+    forEachDetectionElement([&deids](int deid) {
+      deids.push_back(deid);
     });
     for (auto deid : deids) {
       cache.emplace(deid, new Segmentation(deid));

--- a/Detectors/MUON/MCH/Mapping/test/src/Segmentation.cxx
+++ b/Detectors/MUON/MCH/Mapping/test/src/Segmentation.cxx
@@ -1,0 +1,396 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// @author  Laurent Aphecetche
+
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+
+#include "boost/format.hpp"
+#include "MCHMappingInterface/Segmentation.h"
+#include "MCHMappingSegContour/SegmentationContours.h"
+#include <boost/test/data/monomorphic.hpp>
+#include <boost/test/data/monomorphic/generators/xrange.hpp>
+#include <boost/test/data/test_case.hpp>
+#include <fstream>
+#include <iostream>
+#include <chrono>
+
+using namespace o2::mch::mapping;
+namespace bdata = boost::unit_test::data;
+
+// The SegCache is not stricly needed here
+// but it helps speeding up the tests.
+const Segmentation& SegCache(int detElemId)
+{
+  static std::map<int, Segmentation*> cache;
+  if (cache.empty()) {
+    auto start = std::chrono::high_resolution_clock::now();
+    std::vector<int> deids;
+    forEachDetectionElement([&deids](int detElemId) {
+      deids.push_back(detElemId);
+    });
+    for (auto deid : deids) {
+      cache.emplace(deid, new Segmentation(deid));
+    }
+    auto end = std::chrono::high_resolution_clock::now();
+    auto elapsedTime =
+      std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+  }
+  auto f = cache.find(detElemId);
+  return *(f->second);
+}
+
+BOOST_AUTO_TEST_SUITE(o2_mch_mapping)
+BOOST_AUTO_TEST_SUITE(segmentation)
+
+BOOST_AUTO_TEST_CASE(GetSegmentationMustNotThrowIfDetElemIdIsValid)
+{
+  // do not use the SegCache here as we want to test the object
+  // construction (which is used also by the SegCache...)
+  forOneDetectionElementOfEachSegmentationType([](int detElemId) {
+    BOOST_CHECK_NO_THROW(Segmentation{ detElemId });
+  });
+}
+
+BOOST_AUTO_TEST_CASE(GetSegmentationThrowsIfDetElemIdIsNotValid)
+{
+  // do not use the SegCache here as we want to test the object
+  // construction (which is used also by the SegCache...)
+  BOOST_CHECK_THROW(Segmentation(-1), std::runtime_error);
+  BOOST_CHECK_THROW(Segmentation(121), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(CheckNofPads)
+{
+  // Explicitly don't make a loop to more clearly document the number of pads
+  // per detection element.
+  //
+  // Sorted by decreasing number of pads.
+  BOOST_CHECK_EQUAL(SegCache(100).nofPads(), 28672);
+  BOOST_CHECK_EQUAL(SegCache(300).nofPads(), 27933);
+  BOOST_CHECK_EQUAL(SegCache(902).nofPads(), 7616);
+  BOOST_CHECK_EQUAL(SegCache(702).nofPads(), 7072);
+  BOOST_CHECK_EQUAL(SegCache(701).nofPads(), 6976);
+  BOOST_CHECK_EQUAL(SegCache(601).nofPads(), 6208);
+  BOOST_CHECK_EQUAL(SegCache(501).nofPads(), 6064);
+  BOOST_CHECK_EQUAL(SegCache(602).nofPads(), 5440);
+  BOOST_CHECK_EQUAL(SegCache(700).nofPads(), 5440);
+  BOOST_CHECK_EQUAL(SegCache(502).nofPads(), 5296);
+  BOOST_CHECK_EQUAL(SegCache(600).nofPads(), 5120);
+  BOOST_CHECK_EQUAL(SegCache(500).nofPads(), 4976);
+  BOOST_CHECK_EQUAL(SegCache(903).nofPads(), 4896);
+  BOOST_CHECK_EQUAL(SegCache(703).nofPads(), 4352);
+  BOOST_CHECK_EQUAL(SegCache(904).nofPads(), 3808);
+  BOOST_CHECK_EQUAL(SegCache(503).nofPads(), 3264);
+  BOOST_CHECK_EQUAL(SegCache(704).nofPads(), 3264);
+  BOOST_CHECK_EQUAL(SegCache(504).nofPads(), 2176);
+  BOOST_CHECK_EQUAL(SegCache(905).nofPads(), 2176);
+  BOOST_CHECK_EQUAL(SegCache(705).nofPads(), 1632);
+  BOOST_CHECK_EQUAL(SegCache(706).nofPads(), 1088);
+}
+
+BOOST_AUTO_TEST_CASE(TotalNofFECInSegTypesIs2265)
+{
+  int n{ 0 };
+  forOneDetectionElementOfEachSegmentationType([&](int detElemId) {
+    n += SegCache(detElemId).nofDualSampas();
+  });
+  BOOST_CHECK_EQUAL(n, 2265);
+}
+
+BOOST_AUTO_TEST_CASE(CheckBoundingBoxesAreAsExpected)
+{
+  // BOOST_CHECK_EQUAL(getBBox(Segmentation(300)), o2::mch::contour::BBox<double>(-1, -0.75, 116, 117.25));
+  //   BOOST_CHECK_EQUAL(getBBox(Segmentation(500)), o2::mch::contour::BBox<double>(-75, -20, 57.5, 20));
+  BOOST_CHECK_EQUAL(getBBox(SegCache(501)), o2::mch::contour::BBox<double>(-75, -20, 80, 20));
+  BOOST_CHECK_EQUAL(getBBox(SegCache(502)), o2::mch::contour::BBox<double>(-80, -20, 75, 20));
+  BOOST_CHECK_EQUAL(getBBox(SegCache(503)), o2::mch::contour::BBox<double>(-60, -20, 60, 20));
+  BOOST_CHECK_EQUAL(getBBox(SegCache(504)), o2::mch::contour::BBox<double>(-40, -20, 40, 20));
+  //   BOOST_CHECK_EQUAL(getBBox(Segmentation(600)), o2::mch::contour::BBox<double>(-80, -20, 57.5, 20));
+  BOOST_CHECK_EQUAL(getBBox(SegCache(601)), o2::mch::contour::BBox<double>(-80, -20, 80, 20));
+  BOOST_CHECK_EQUAL(getBBox(SegCache(602)), o2::mch::contour::BBox<double>(-80, -20, 80, 20));
+  BOOST_CHECK_EQUAL(getBBox(SegCache(700)), o2::mch::contour::BBox<double>(-100, -20, 100, 20));
+  BOOST_CHECK_EQUAL(getBBox(SegCache(701)), o2::mch::contour::BBox<double>(-120, -20, 120, 20));
+  BOOST_CHECK_EQUAL(getBBox(SegCache(702)), o2::mch::contour::BBox<double>(-100, -20, 100, 20));
+  BOOST_CHECK_EQUAL(getBBox(SegCache(703)), o2::mch::contour::BBox<double>(-100, -20, 100, 20));
+  BOOST_CHECK_EQUAL(getBBox(SegCache(704)), o2::mch::contour::BBox<double>(-80, -20, 80, 20));
+  BOOST_CHECK_EQUAL(getBBox(SegCache(705)), o2::mch::contour::BBox<double>(-60, -20, 60, 20));
+  BOOST_CHECK_EQUAL(getBBox(SegCache(706)), o2::mch::contour::BBox<double>(-40, -20, 40, 20));
+  BOOST_CHECK_EQUAL(getBBox(SegCache(902)), o2::mch::contour::BBox<double>(-120, -20, 120, 20));
+  BOOST_CHECK_EQUAL(getBBox(SegCache(903)), o2::mch::contour::BBox<double>(-120, -20, 120, 20));
+  BOOST_CHECK_EQUAL(getBBox(SegCache(904)), o2::mch::contour::BBox<double>(-100, -20, 100, 20));
+  BOOST_CHECK_EQUAL(getBBox(SegCache(905)), o2::mch::contour::BBox<double>(-80, -20, 80, 20));
+}
+
+BOOST_AUTO_TEST_CASE(CheckNofBendingFEC)
+{
+  BOOST_CHECK_EQUAL(SegCache(100).nofDualSampas(), 451);
+  BOOST_CHECK_EQUAL(SegCache(300).nofDualSampas(), 443);
+  BOOST_CHECK_EQUAL(SegCache(902).nofDualSampas(), 120);
+  BOOST_CHECK_EQUAL(SegCache(702).nofDualSampas(), 111);
+  BOOST_CHECK_EQUAL(SegCache(701).nofDualSampas(), 110);
+  BOOST_CHECK_EQUAL(SegCache(601).nofDualSampas(), 97);
+  BOOST_CHECK_EQUAL(SegCache(501).nofDualSampas(), 95);
+  BOOST_CHECK_EQUAL(SegCache(602).nofDualSampas(), 85);
+  BOOST_CHECK_EQUAL(SegCache(700).nofDualSampas(), 86);
+  BOOST_CHECK_EQUAL(SegCache(502).nofDualSampas(), 83);
+  BOOST_CHECK_EQUAL(SegCache(600).nofDualSampas(), 80);
+  BOOST_CHECK_EQUAL(SegCache(500).nofDualSampas(), 78);
+  BOOST_CHECK_EQUAL(SegCache(903).nofDualSampas(), 78);
+  BOOST_CHECK_EQUAL(SegCache(703).nofDualSampas(), 69);
+  BOOST_CHECK_EQUAL(SegCache(904).nofDualSampas(), 61);
+  BOOST_CHECK_EQUAL(SegCache(503).nofDualSampas(), 51);
+  BOOST_CHECK_EQUAL(SegCache(704).nofDualSampas(), 52);
+  BOOST_CHECK_EQUAL(SegCache(504).nofDualSampas(), 34);
+  BOOST_CHECK_EQUAL(SegCache(905).nofDualSampas(), 36);
+  BOOST_CHECK_EQUAL(SegCache(705).nofDualSampas(), 27);
+  BOOST_CHECK_EQUAL(SegCache(706).nofDualSampas(), 18);
+}
+
+BOOST_AUTO_TEST_CASE(PadCountInSegmentationTypesMustBe143469)
+{
+  int n{ 0 };
+  forOneDetectionElementOfEachSegmentationType([&n](int detElemId) {
+    n += SegCache(detElemId).nofPads();
+  });
+  BOOST_CHECK_EQUAL(n, 143469);
+}
+
+BOOST_AUTO_TEST_CASE(PadCountInAllSegmentationsMustBe1064008)
+{
+  int n{ 0 };
+  forEachDetectionElement([&n](int detElemId) {
+    n += SegCache(detElemId).nofPads();
+  });
+  BOOST_CHECK_EQUAL(n, 1064008);
+}
+
+BOOST_AUTO_TEST_CASE(NumberOfSegmentationsMustBe21)
+{
+  int n{ 0 };
+  forOneDetectionElementOfEachSegmentationType([&n](int detElemId) {
+    n++;
+  });
+  BOOST_CHECK_EQUAL(n, 21);
+}
+
+struct SEG {
+  Segmentation seg{ 100 };
+};
+
+BOOST_AUTO_TEST_CASE(TestForEachPadAndPadIndexRange)
+{
+  int npads = 0;
+  forOneDetectionElementOfEachSegmentationType([&npads](int detElemId) {
+    int n = 0;
+    int pmin = std::numeric_limits<int>::max();
+    int pmax = 0;
+    Segmentation seg{ detElemId };
+    seg.forEachPad([&n, &pmin, &pmax, &npads](int dePadIndex) {
+      npads++;
+      n++;
+      pmin = std::min(pmin, dePadIndex);
+      pmax = std::max(pmax, dePadIndex);
+    });
+    BOOST_CHECK_EQUAL(n, seg.nofPads());
+    BOOST_CHECK_EQUAL(pmin, 0);
+    BOOST_CHECK_EQUAL(pmax, seg.nofPads() - 1);
+  });
+}
+
+// All the remaining tests of this file are using seg (DE100).
+
+BOOST_FIXTURE_TEST_SUITE(DE100, SEG)
+
+BOOST_TEST_DECORATOR(*boost::unit_test::tolerance(1E-3))
+BOOST_AUTO_TEST_CASE(CheckOnePosition)
+{
+  int b, nb;
+  bool ok = seg.findPadPairByPosition(24.2, 23.70, b, nb);
+  BOOST_CHECK_EQUAL(ok, true);
+  BOOST_TEST(seg.padPositionX(b) == 24.255);
+  BOOST_TEST(seg.padPositionY(b) == 23.73);
+  BOOST_TEST(seg.padSizeX(b) == 0.63);
+  BOOST_TEST(seg.padSizeY(b) == 0.42);
+}
+
+bool checkSameCathode(const Segmentation& seg, int depadindex, const std::vector<int>& padindices)
+{
+  bool isBending = seg.isBendingPad(depadindex);
+  for (auto n : padindices) {
+    if (seg.isBendingPad(n) != isBending) {
+      return false;
+    }
+  }
+  return true;
+}
+
+struct PadInfo {
+  int fec, ch;
+  double x, y, sx, sy;
+};
+
+// areEqual returns true if the two values are within 1 micron.
+bool areEqual(double a, double b)
+{
+  return std::fabs(a - b) < 1E-4; // 1 micron expressed in centimeters
+}
+
+// testNeighbours returns true if the neighbours of dePadIndex, as
+// returned by the Segmentation::forEachNeighbouringPad, are the same
+// as the elements of expected vector.
+bool testNeighbours(const Segmentation& seg, int dePadIndex, std::vector<PadInfo>& expected)
+{
+  std::vector<int> nei;
+  seg.forEachNeighbouringPad(dePadIndex, [&nei](int depadindex) {
+    nei.push_back(depadindex);
+  });
+
+  if (nei.size() != expected.size()) {
+    return false;
+  }
+  auto notFound = nei.size();
+  for (auto n : nei) {
+    for (auto e : expected) {
+      if (seg.padDualSampaId(n) == e.fec &&
+          seg.padDualSampaChannel(n) == e.ch &&
+          areEqual(seg.padPositionX(n), e.x) &&
+          areEqual(seg.padPositionY(n), e.y) &&
+          areEqual(seg.padSizeX(n), e.sx) &&
+          areEqual(seg.padSizeY(n), e.sy)) {
+        notFound--;
+      }
+    }
+  }
+  return notFound == 0;
+}
+
+BOOST_AUTO_TEST_CASE(CheckOnePadNeighbours)
+{
+  // Below are the neighbouring pads of the pad(s) @ (24.0, 24.0)cm
+  // for DE 100.
+  // What is tested below is not the PAD (index might depend on
+  // the underlying implementation) but the rest of the information :
+  // (FEC,CH), (X,Y), (SX,SY)
+  //
+  // PAD       5208 FEC   95 CH  0 X  23.625 Y  23.730 SX   0.630 SY   0.420
+  // PAD       5209 FEC   95 CH  3 X  23.625 Y  24.150 SX   0.630 SY   0.420
+  // PAD       5210 FEC   95 CH  4 X  23.625 Y  24.570 SX   0.630 SY   0.420
+  // PAD       5226 FEC   95 CH 42 X  24.255 Y  24.570 SX   0.630 SY   0.420
+  // PAD       5242 FEC   95 CH 43 X  24.885 Y  24.570 SX   0.630 SY   0.420
+  // PAD       5241 FEC   95 CH  2 X  24.885 Y  24.150 SX   0.630 SY   0.420
+  // PAD       5240 FEC   95 CH 46 X  24.885 Y  23.730 SX   0.630 SY   0.420
+  // PAD       5224 FEC   95 CH 31 X  24.255 Y  23.730 SX   0.630 SY   0.420
+  // PAD      19567 FEC 1119 CH 48 X  23.310 Y  23.520 SX   0.630 SY   0.420
+  // PAD      19568 FEC 1119 CH 46 X  23.310 Y  23.940 SX   0.630 SY   0.420
+  // PAD      19569 FEC 1119 CH  0 X  23.310 Y  24.360 SX   0.630 SY   0.420
+  // PAD      19585 FEC 1119 CH 42 X  23.940 Y  24.360 SX   0.630 SY   0.420
+  // PAD      19601 FEC 1119 CH  1 X  24.570 Y  24.360 SX   0.630 SY   0.420
+  // PAD      19600 FEC 1119 CH 44 X  24.570 Y  23.940 SX   0.630 SY   0.420
+  // PAD      19599 FEC 1119 CH 30 X  24.570 Y  23.520 SX   0.630 SY   0.420
+  // PAD      19583 FEC 1119 CH 29 X  23.940 Y  23.520 SX   0.630 SY   0.420
+
+  std::vector<PadInfo> bendingNeighbours{
+    { 95, 0, 23.625, 23.730, 0.630, 0.420 },
+    { 95, 3, 23.625, 24.150, 0.630, 0.420 },
+    { 95, 4, 23.625, 24.570, 0.630, 0.420 },
+    { 95, 42, 24.255, 24.570, 0.630, 0.420 },
+    { 95, 43, 24.885, 24.570, 0.630, 0.420 },
+    { 95, 2, 24.885, 24.150, 0.630, 0.420 },
+    { 95, 46, 24.885, 23.730, 0.630, 0.420 },
+    { 95, 31, 24.255, 23.730, 0.630, 0.420 }
+  };
+
+  std::vector<PadInfo> nonBendingNeighbours{
+    { 1119, 48, 23.310, 23.520, 0.630, 0.420 },
+    { 1119, 46, 23.310, 23.940, 0.630, 0.420 },
+    { 1119, 0, 23.310, 24.360, 0.630, 0.420 },
+    { 1119, 42, 23.940, 24.360, 0.630, 0.420 },
+    { 1119, 1, 24.570, 24.360, 0.630, 0.420 },
+    { 1119, 44, 24.570, 23.940, 0.630, 0.420 },
+    { 1119, 30, 24.570, 23.520, 0.630, 0.420 },
+    { 1119, 29, 23.940, 23.520, 0.630, 0.420 }
+  };
+
+  int pb, pnb;
+  bool ok = seg.findPadPairByPosition(24.0, 24.0, pb, pnb);
+  BOOST_CHECK_EQUAL(ok, true);
+  BOOST_CHECK_EQUAL(testNeighbours(seg, pb, bendingNeighbours), true);
+  BOOST_CHECK_EQUAL(testNeighbours(seg, pnb, nonBendingNeighbours), true);
+}
+
+BOOST_AUTO_TEST_CASE(CircularTest)
+{
+  std::vector<std::pair<int, int>> tp{
+    { 95, 45 },
+    { 1119, 45 } // both pads @pos 24.0, 24.0cm
+  };
+
+  for (auto p : tp) {
+    auto dsid = p.first;
+    auto dsch = p.second;
+    auto dePadIndex = seg.findPadByFEE(dsid, dsch);
+    BOOST_CHECK_EQUAL(seg.padDualSampaId(dePadIndex), dsid);
+    BOOST_CHECK_EQUAL(seg.padDualSampaChannel(dePadIndex), dsch);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(ThrowsIfDualSampaChannelIsNotBetween0And63)
+{
+  BOOST_CHECK_THROW(seg.findPadByFEE(102, -1), std::out_of_range);
+  BOOST_CHECK_THROW(seg.findPadByFEE(102, 64), std::out_of_range);
+}
+
+BOOST_AUTO_TEST_CASE(ReturnsTrueIfPadIsConnected) { BOOST_CHECK_EQUAL(seg.isValid(seg.findPadByFEE(102, 3)), true); }
+
+BOOST_AUTO_TEST_CASE(ReturnsFalseIfPadIsNotConnected)
+{
+  BOOST_CHECK_EQUAL(seg.isValid(seg.findPadByFEE(214, 14)), false);
+}
+
+BOOST_AUTO_TEST_CASE(HasPadByPosition)
+{
+  int b, nb;
+  bool ok = seg.findPadPairByPosition(40.0, 30.0, b, nb);
+  BOOST_CHECK_EQUAL(ok, true);
+}
+
+BOOST_AUTO_TEST_CASE(CheckOnePadPositionPresentOnOnlyBendingPlane)
+{
+  double x = 1.575;
+  double y = 18.69;
+  int b, nb;
+  bool ok = seg.findPadPairByPosition(x, y, b, nb);
+  BOOST_CHECK_EQUAL(ok, false);
+  BOOST_CHECK_EQUAL(seg.findPadByFEE(76, 9), b);
+  BOOST_CHECK_EQUAL(seg.isValid(nb), false);
+}
+
+BOOST_AUTO_TEST_CASE(CheckCopy)
+{
+  Segmentation copy{ seg };
+  BOOST_TEST((copy == seg));
+  BOOST_TEST(copy.nofPads() == seg.nofPads());
+}
+
+BOOST_AUTO_TEST_CASE(CheckAssignment)
+{
+  Segmentation copy{ 200 };
+  copy = seg;
+  BOOST_TEST((copy == seg));
+  BOOST_TEST(copy.nofPads() == seg.nofPads());
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Some more renaming, but more important is the new « most probable entry point » for the mapping : the Segmentation class which encompasses two cathodes of one detection element, and its numerous associated tests.

One other important change is to acknowledge the fact that padcid / paduid (names from the Go implementation, btw) are in fact not UIDs but really indices : first one local to a cathode, second one local the detection element. As such, we : 
- renamed them to catPadIndex and dePadIndex respectively
- added some tests to check that they are actually indices ranging from 0 to nofPads-1
 
(The Go impl will have to follow this new naming eventually).

