### PR TITLE
o2sim: stability fix for 0 events

### DIFF
--- a/run/o2sim_parallel.cxx
+++ b/run/o2sim_parallel.cxx
@@ -240,7 +240,6 @@ int main(int argc, char* argv[])
   int pipe_mergerdriver_fd[2];
   pipe(pipe_mergerdriver_fd);
 
-  int status, cpid;
   pid = fork();
   if (pid == 0) {
     int fd = open(mergerlogname, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
@@ -266,6 +265,7 @@ int main(int argc, char* argv[])
   // wait on merger (which when exiting completes the workflow)
   auto mergerpid = childpids.back();
 
+  int status, cpid;
   // wait just blocks and waits until any child returns; but we make sure to wait until merger is here
   while ((cpid = wait(&status)) != mergerpid) {
     if (WIFSIGNALED(status)) {


### PR DESCRIPTION
There was a problem when the user asked for 0 events
to be simulated, since in this case the data merger device never
received any data and would hang.
This problem is now fixed by letting the merger know how many
events to expect (from analysing the configuration). This probably makes sense
but leads to a tighter coupling. To be reviewed.

Note that the 0 event case is useful since we want to expect
the geometry created during initialization etc.