### PR TITLE
o2sim: propagate MCEventHeader to merger device and output

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/PrimaryChunk.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/PrimaryChunk.h
@@ -12,6 +12,7 @@
 #define ALICEO2_DATA_PRIMARYCHUNK_H_
 
 #include <cstring>
+#include <FairMCEventHeader.h>
 
 namespace o2
 {
@@ -31,6 +32,9 @@ struct SubEventInfo {
   uint32_t index = 0;
   int32_t npersistenttracks = -1; // the number of persistent tracks for this SubEvent (might be set to cache it)
   // might add more fields (such as which process treated this chunk etc)
+
+  FairMCEventHeader mMCEventHeader; // associated FairMC header for vertex information
+
   ClassDefNV(SubEventInfo, 1);
 };
 
@@ -42,8 +46,8 @@ inline bool operator<(SubEventInfo const& a, SubEventInfo const& b)
 // Encapsulating primaries/tracks as well as the event info
 // to be processed by the simulation processors.
 struct PrimaryChunk {
-  std::vector<SubEventInfo> mEventIDs;
-  std::vector<TParticle> mParticles;
+  SubEventInfo mSubEventInfo;
+  std::vector<TParticle> mParticles; // the particles for this chunk
   ClassDefNV(PrimaryChunk, 1);
 };
 }

--- a/run/O2PrimaryServerDevice.h
+++ b/run/O2PrimaryServerDevice.h
@@ -168,7 +168,8 @@ class O2PrimaryServerDevice : public FairMQDevice
     i.nparts = numberofparts;
     i.seed = counter + mInitialSeed;
     i.index = m.mParticles.size();
-    m.mEventIDs.emplace_back(i);
+    i.mMCEventHeader = mEventHeader;
+    m.mSubEventInfo = i;
 
     //auto startoffset = (mPartCounter + 1) * mChunkGranularity;
     //auto endoffset = startindex + mChunkGranularity;

--- a/run/O2SimDevice.h
+++ b/run/O2SimDevice.h
@@ -170,11 +170,11 @@ class O2SimDevice : public FairMQDevice
 
         mVMCApp->setPrimaries(chunk->mParticles);
 
-        auto info = chunk->mEventIDs[0];
+        auto info = chunk->mSubEventInfo;
         mVMCApp->setSubEventInfo(info);
 
         LOG(INFO) << "Processing " << chunk->mParticles.size() << FairLogger::endl;
-        gRandom->SetSeed(chunk->mEventIDs[0].seed);
+        gRandom->SetSeed(chunk->mSubEventInfo.seed);
 
         mVMC->ProcessRun(1);
         FairSystemInfo sysinfo;


### PR DESCRIPTION
The MCEventHeader produced by the event generator is now
propagated to the merger device and put into the output.

Some cleanup operations; code reduction

Relates to https://alice.its.cern.ch/jira/browse/O2-482