### PR TITLE
Improve AOD example

### DIFF
--- a/Framework/Core/include/Framework/AODReaderHelpers.h
+++ b/Framework/Core/include/Framework/AODReaderHelpers.h
@@ -22,8 +22,6 @@ namespace readers
 
 struct AODReaderHelpers {
   static AlgorithmSpec rootFileReaderCallback();
-  /// Just to make sure things work, even without a file...
-  static AlgorithmSpec fakeReaderCallback();
 };
 
 } // namespace readers

--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -11,6 +11,7 @@
 #include "Framework/AODReaderHelpers.h"
 #include "Framework/RootTableBuilderHelpers.h"
 #include "Framework/AlgorithmSpec.h"
+#include "Framework/DeviceSpec.h"
 #include <ROOT/RDataFrame.hxx>
 #include <TFile.h>
 
@@ -19,25 +20,61 @@ namespace o2::framework::readers
 
 AlgorithmSpec AODReaderHelpers::rootFileReaderCallback()
 {
-  auto callback = AlgorithmSpec{ [](InitContext& initCtx) {
-    LOG(INFO) << "This is not a real device, merely a placeholder for external inputs";
-    LOG(INFO) << "To be hidden / removed at some point.";
+  auto callback = AlgorithmSpec{ adaptStateful([](ConfigParamRegistry const& options,
+                                                  DeviceSpec const& spec) {
     std::shared_ptr<TFile> infile;
     try {
-      auto filename = initCtx.options().get<std::string>("aod-file");
+      auto filename = options.get<std::string>("aod-file");
       infile = std::make_shared<TFile>(filename.c_str());
     } catch (...) {
       LOG(ERROR) << "Unable to open file";
     }
-    return [infile](ProcessingContext& ctx) {
+
+    bool readTracks = false;
+    bool readTracksCov = false;
+    bool readTracksExtra = false;
+    bool readCalo = false;
+    bool readMuon = false;
+    bool readVZ = false;
+    // FIXME: bruteforce but effective.
+    for (auto& route : spec.outputs) {
+      if (route.matcher.origin != header::DataOrigin{ "AOD" }) {
+        continue;
+      }
+      auto description = route.matcher.description;
+      if (description == header::DataDescription{ "TRACKPAR" }) {
+        readTracks = true;
+      } else if (description == header::DataDescription{ "TRACKPARCOV" }) {
+        readTracksCov = true;
+      } else if (description == header::DataDescription{ "TRACKEXTRA" }) {
+        readTracksExtra = true;
+      } else if (description == header::DataDescription{ "CALO" }) {
+        readCalo = true;
+      } else if (description == header::DataDescription{ "MUON" }) {
+        readMuon = true;
+      } else if (description == header::DataDescription{ "VZERO" }) {
+        readVZ = true;
+      } else {
+        throw std::runtime_error(std::string("Unknown AOD type: ") + route.matcher.description.str);
+      }
+    }
+
+    return adaptStateless([readTracks,
+                           readTracksCov,
+                           readTracksExtra,
+                           readCalo,
+                           readMuon,
+                           readVZ,
+                           infile](DataAllocator& outputs) {
       if (infile.get() == nullptr || infile->IsOpen() == false) {
         LOG(ERROR) << "File not found: aod.root";
         return;
       }
+
       /// FIXME: Substitute here the actual data you want to convert for the AODReader
-      {
+      if (readTracks) {
         std::unique_ptr<TTreeReader> reader = std::make_unique<TTreeReader>("O2tracks", infile.get());
-        auto& trackParBuilder = ctx.outputs().make<TableBuilder>(Output{ "AOD", "TRACKPAR" });
+        auto& trackParBuilder = outputs.make<TableBuilder>(Output{ "AOD", "TRACKPAR" });
         TTreeReaderValue<int> c0(*reader, "fID4Tracks");
         TTreeReaderValue<float> c1(*reader, "fX");
         TTreeReaderValue<float> c2(*reader, "fAlpha");
@@ -50,7 +87,7 @@ AlgorithmSpec AODReaderHelpers::rootFileReaderCallback()
                                               c0, c1, c2, c3, c4, c5, c6, c7);
       }
 
-      {
+      if (readTracksCov) {
         std::unique_ptr<TTreeReader> covReader = std::make_unique<TTreeReader>("O2tracks", infile.get());
         TTreeReaderValue<float> c0(*covReader, "fCYY");
         TTreeReaderValue<float> c1(*covReader, "fCZY");
@@ -65,11 +102,12 @@ AlgorithmSpec AODReaderHelpers::rootFileReaderCallback()
         TTreeReaderValue<float> c10(*covReader, "fC1PtSnp");
         TTreeReaderValue<float> c11(*covReader, "fC1PtTgl");
         TTreeReaderValue<float> c12(*covReader, "fC1Pt21Pt2");
-        auto& trackParCovBuilder = ctx.outputs().make<TableBuilder>(Output{ "AOD", "TRACKPARCOV" });
+        auto& trackParCovBuilder = outputs.make<TableBuilder>(Output{ "AOD", "TRACKPARCOV" });
         RootTableBuilderHelpers::convertTTree(trackParCovBuilder, *covReader,
                                               c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12);
       }
-      {
+
+      if (readTracksExtra) {
         std::unique_ptr<TTreeReader> extraReader = std::make_unique<TTreeReader>("O2tracks", infile.get());
         TTreeReaderValue<float> c0(*extraReader, "fTPCinnerP");
         TTreeReaderValue<uint64_t> c1(*extraReader, "fFlags");
@@ -84,22 +122,24 @@ AlgorithmSpec AODReaderHelpers::rootFileReaderCallback()
         TTreeReaderValue<float> c10(*extraReader, "fTRDsignal");
         TTreeReaderValue<float> c11(*extraReader, "fTOFsignal");
         TTreeReaderValue<float> c12(*extraReader, "fLength");
-        auto& extraBuilder = ctx.outputs().make<TableBuilder>(Output{ "AOD", "TRACKEXTRA" });
+        auto& extraBuilder = outputs.make<TableBuilder>(Output{ "AOD", "TRACKEXTRA" });
         RootTableBuilderHelpers::convertTTree(extraBuilder, *extraReader,
                                               c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11);
       }
-      {
+
+      if (readCalo) {
         std::unique_ptr<TTreeReader> extraReader = std::make_unique<TTreeReader>("O2calo", infile.get());
         TTreeReaderValue<int> c0(*extraReader, "fID4Calo");
         TTreeReaderValue<short> c1(*extraReader, "fCellNumber");
         TTreeReaderValue<float> c2(*extraReader, "fAmplitude");
         TTreeReaderValue<float> c3(*extraReader, "fTime");
         TTreeReaderValue<int8_t> c4(*extraReader, "fType");
-        auto& extraBuilder = ctx.outputs().make<TableBuilder>(Output{ "AOD", "CALO" });
+        auto& extraBuilder = outputs.make<TableBuilder>(Output{ "AOD", "CALO" });
         RootTableBuilderHelpers::convertTTree(extraBuilder, *extraReader,
                                               c0, c1, c2, c3, c4);
       }
-      {
+
+      if (readMuon) {
         std::unique_ptr<TTreeReader> muReader = std::make_unique<TTreeReader>("O2mu", infile.get());
         TTreeReaderValue<int> c0(*muReader, "fID4mu");
         TTreeReaderValue<float> c1(*muReader, "fInverseBendingMomentum");
@@ -112,71 +152,24 @@ AlgorithmSpec AODReaderHelpers::rootFileReaderCallback()
         TTreeReaderValue<float> c8(*muReader, "fChi2");
         TTreeReaderValue<float> c9(*muReader, "fChi2MatchTrigger");
         TTreeReaderValue<int> c10(*muReader, "fID4vz");
-        auto& muBuilder = ctx.outputs().make<TableBuilder>(Output{ "AOD", "MUON" });
+        auto& muBuilder = outputs.make<TableBuilder>(Output{ "AOD", "MUON" });
         RootTableBuilderHelpers::convertTTree(muBuilder, *muReader,
                                               c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10);
       }
-      {
+
+      if (readVZ) {
         std::unique_ptr<TTreeReader> vzReader = std::make_unique<TTreeReader>("O2vz", infile.get());
         TTreeReaderArray<float> c0(*vzReader, "fAdcVZ"); // FIXME: we do not support arrays for now
         TTreeReaderArray<float> c1(*vzReader, "fTimeVZ");
         TTreeReaderArray<float> c2(*vzReader, "fWidthVZ");
-        auto& vzBuilder = ctx.outputs().make<TableBuilder>(Output{ "AOD", "VZERO" });
+        auto& vzBuilder = outputs.make<TableBuilder>(Output{ "AOD", "VZERO" });
         RootTableBuilderHelpers::convertTTree(vzBuilder, *vzReader,
                                               c0, c1, c2);
       }
-    };
-  } };
+    });
+  }) };
 
   return callback;
-}
-
-AlgorithmSpec AODReaderHelpers::fakeReaderCallback()
-{
-  return AlgorithmSpec{
-    [](InitContext& setup) {
-      return [](ProcessingContext& ctx) {
-        /// We get the table builder for track param.
-        auto& trackParBuilder = ctx.outputs().make<TableBuilder>(Output{ "AOD", "TRACKPAR" });
-        auto& trackParCovBuilder = ctx.outputs().make<TableBuilder>(Output{ "AOD", "TRACKPARCOV" });
-        // We use RDataFrame to create a few columns with 100 rows.
-        // The final action is the one which allows the user to create the
-        // output message.
-        //
-        // FIXME: bloat in the code I'd like to get rid of:
-        //
-        // * I need to specify the types for the columns
-        // * I need to specify the names of the columns twice
-        // * I should use the RDataFrame to read / convert from the ESD...
-        //   Using dummy values for now.
-        ROOT::RDataFrame rdf(100);
-        auto trackParRDF = rdf.Define("mX", "1.f")
-                             .Define("mAlpha", "2.f")
-                             .Define("y", "3.f")
-                             .Define("z", "4.f")
-                             .Define("snp", "5.f")
-                             .Define("tgl", "6.f")
-                             .Define("qpt", "7.f");
-
-        /// FIXME: think of the best way to include the non-diag elements.
-        auto trackParCorRDF = rdf.Define("sigY", "1.f")
-                                .Define("sigZ", "2.f")
-                                .Define("sigSnp", "3.f")
-                                .Define("sigTgl", "4.f")
-                                .Define("sigQpt", "5.f");
-
-        /// FIXME: we need to do some cling magic to hide all of this.
-        trackParRDF.ForeachSlot(trackParBuilder.persist<float, float, float, float, float, float, float>(
-                                  { "mX", "mAlpha", "y", "z", "snp", "tgl", "qpt" }),
-                                { "mX", "mAlpha", "y", "z", "snp", "tgl", "qpt" });
-
-        trackParCorRDF.ForeachSlot(trackParCovBuilder.persist<float, float, float, float, float>(
-                                     { "sigY", "sigZ", "sigSnp", "sigTgl", "sigQpt" }),
-                                   { "sigY", "sigZ", "sigSnp", "sigTgl", "sigQpt" });
-
-      };
-    }
-  };
 }
 
 } // namespace o2::framework::readers

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -702,6 +702,7 @@ int doChild(int argc, char** argv, const o2::framework::DeviceSpec& spec)
       serviceRegistry.registerService<RawDeviceService>(simpleRawDeviceService.get());
       serviceRegistry.registerService<CallbackService>(callbackService.get());
       serviceRegistry.registerService<TimesliceIndex>(timesliceIndex.get());
+      serviceRegistry.registerService<DeviceSpec>(&spec);
 
       // The decltype stuff is to be able to compile with both new and old
       // FairMQ API (one which uses a shared_ptr, the other one a unique_ptr.

--- a/Framework/Core/test/test_Services.cxx
+++ b/Framework/Core/test/test_Services.cxx
@@ -36,18 +36,26 @@ BOOST_AUTO_TEST_CASE(TestServiceRegistry) {
   };
 
   struct InterfaceC {
-    virtual bool method() = 0;
+    virtual bool method() const = 0;
+  };
+
+  struct ConcreteC : InterfaceC {
+    bool method() const final { return false; }
   };
 
   ServiceRegistry registry;
   auto service = std::make_unique<ConcreteA>;
   ConcreteA serviceA;
   ConcreteB serviceB;
+  ConcreteC const serviceC;
   registry.registerService<InterfaceA>(&serviceA);
   registry.registerService<InterfaceB>(&serviceB);
+  registry.registerService<InterfaceC>(&serviceC);
   BOOST_CHECK(registry.get<InterfaceA>().method() == true);
   BOOST_CHECK(registry.get<InterfaceB>().method() == false);
-  BOOST_CHECK_THROW(registry.get<InterfaceC>().method(), std::runtime_error);
+  BOOST_CHECK(registry.get<InterfaceC const>().method() == false);
+  BOOST_CHECK_THROW(registry.get<InterfaceA const>(), std::runtime_error);
+  BOOST_CHECK_THROW(registry.get<InterfaceC>(), std::runtime_error);
 }
 
 BOOST_AUTO_TEST_CASE(TestCallbackService)

--- a/Framework/TestWorkflows/src/o2AODDummy.cxx
+++ b/Framework/TestWorkflows/src/o2AODDummy.cxx
@@ -8,7 +8,6 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 #include "Framework/runDataProcessing.h"
-#include "Framework/AODReaderHelpers.h"
 
 #include <ROOT/RDataFrame.hxx>
 #include <ROOT/RArrowDS.hxx>
@@ -20,32 +19,20 @@ using namespace o2::framework;
 WorkflowSpec defineDataProcessing(ConfigContext const& specs)
 {
   WorkflowSpec workflow{
-    /// FIXME: for the moment we need to have an explicit declaration
-    ///        of the reader and what to produce. In the future this
-    ///        will not be required, as dangling AOD inputs will be mapped automatically
-    ///        to an AOD Source
-    DataProcessorSpec{
-      "dummy-aod-producer",
-      {},
-      {
-        OutputSpec{ { "TrackPar" }, "AOD", "TRACKPAR" },
-        OutputSpec{ { "TrackParCov" }, "AOD", "TRACKPARCOV" },
-        OutputSpec{ { "TrackExtra" }, "AOD", "TRACKEXTRA" },
-        OutputSpec{ { "Muon" }, "AOD", "MUON" },
-        OutputSpec{ { "Calo" }, "AOD", "CALO" },
-        OutputSpec{ { "VZero" }, "AOD", "VZERO" },
-      },
-      o2::framework::readers::AODReaderHelpers::rootFileReaderCallback(),
-      { ConfigParamSpec{ "aod-file", VariantType::String, "aod.root", { "Input AOD file" } } } },
     /// Minimal analysis example
     DataProcessorSpec{
       "dummy-analysis",
       {
+        // Dangling inputs of type AOD will be automatically picked up
+        // by DPL and an extra reader device will be instanciated to
+        // read them.
         InputSpec{ "TrackPar", "AOD", "TRACKPAR" },
         InputSpec{ "TrackParCov", "AOD", "TRACKPARCOV" },
-        InputSpec{ "TrackExtra", "AOD", "TRACKEXTRA" },
-        InputSpec{ "Calo", "AOD", "CALO" },
-        InputSpec{ "Muon", "AOD", "MUON" },
+        // NOTE: Not needed right now. Uncomment if you want to use them
+        //        InputSpec{ "TrackExtra", "AOD", "TRACKEXTRA" },
+        //        InputSpec{ "Calo", "AOD", "CALO" },
+        //        InputSpec{ "Muon", "AOD", "MUON" },
+        //        InputSpec{ "VZero", "AOD", "VZERO" },
       },
       {},
       AlgorithmSpec{


### PR DESCRIPTION
This set of commits is needed so that users who want to write an analysis task do not need to provide a source DataProcessor which reads them from file.

In case the user has dangling inputs of kind "AOD" we create a source for her / him. Notice that it is still possible to write a custom reader for some of the inputs which will have precedence over the default one.