### PR TITLE
Fix: row/col->local custom shortcut was wrong

### DIFF
--- a/Detectors/ITSMFT/common/base/include/ITSMFTBase/SegmentationAlpide.h
+++ b/Detectors/ITSMFT/common/base/include/ITSMFTBase/SegmentationAlpide.h
@@ -15,6 +15,7 @@
 #define ALICEO2_ITSMFT_SEGMENTATIONALPIDE_H_
 
 #include <Rtypes.h>
+#include "MathUtils/Cartesian3D.h"
 
 namespace o2
 {
@@ -77,8 +78,13 @@ class SegmentationAlpide
   /// If iRow and or iCol is outside of the segmentation range a value of -0.5*Dx()
   /// or -0.5*Dz() is returned.
   static bool detectorToLocal(int iRow, int iCol, float& xRow, float& zCol);
+  static bool detectorToLocal(float row, float col, float& xRow, float& zCol);
+  static bool detectorToLocal(float row, float col, Point3D<float>& loc);
+
   // same but w/o check for row/col range
   static void detectorToLocalUnchecked(int iRow, int iCol, float& xRow, float& zCol);
+  static void detectorToLocalUnchecked(float row, float col, float& xRow, float& zCol);
+  static void detectorToLocalUnchecked(float row, float col, Point3D<float>& loc);
 
   static constexpr float getFirstRowCoordinate() {
     return 0.5 * ((ActiveMatrixSizeRows - PassiveEdgeTop + PassiveEdgeReadOut) - PitchRow);
@@ -125,7 +131,20 @@ inline void SegmentationAlpide::detectorToLocalUnchecked(int iRow, int iCol, flo
   zCol = iCol*PitchCol + getFirstColCoordinate();
 }
 
- //_________________________________________________________________________________________________
+//_________________________________________________________________________________________________
+inline void SegmentationAlpide::detectorToLocalUnchecked(float row, float col, float& xRow, float& zCol)
+{
+  xRow = getFirstRowCoordinate() - row * PitchRow;
+  zCol = col * PitchCol + getFirstColCoordinate();
+}
+
+//_________________________________________________________________________________________________
+inline void SegmentationAlpide::detectorToLocalUnchecked(float row, float col, Point3D<float>& loc)
+{
+  loc.SetCoordinates(getFirstRowCoordinate() - row * PitchRow, 0.f, col * PitchCol + getFirstColCoordinate());
+}
+
+//_________________________________________________________________________________________________
 inline bool SegmentationAlpide::detectorToLocal(int iRow, int iCol, float& xRow, float& zCol)
 {
   if (iRow < 0 || iRow >= NRows || iCol<0 || iCol >= NCols) return false;
@@ -133,7 +152,23 @@ inline bool SegmentationAlpide::detectorToLocal(int iRow, int iCol, float& xRow,
   return true;
 }
 
- 
+//_________________________________________________________________________________________________
+inline bool SegmentationAlpide::detectorToLocal(float row, float col, float& xRow, float& zCol)
+{
+  if (row < 0 || row >= NRows || col < 0 || col >= NCols)
+    return false;
+  detectorToLocalUnchecked(row, col, xRow, zCol);
+  return true;
+}
+
+//_________________________________________________________________________________________________
+inline bool SegmentationAlpide::detectorToLocal(float row, float col, Point3D<float>& loc)
+{
+  if (row < 0 || row >= NRows || col < 0 || col >= NCols)
+    return false;
+  detectorToLocalUnchecked(row, col, loc);
+  return true;
+}
 }
 }
 

--- a/Detectors/ITSMFT/common/reconstruction/src/Clusterer.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/Clusterer.cxx
@@ -270,10 +270,9 @@ void Clusterer::finishChip(std::vector<Cluster>* fullClus, std::vector<CompClust
         x += mPixArrBuff[i].getRowDirect();
         z += mPixArrBuff[i].getCol();
       }
-      Point3D<float> xyzLoc(Segmentation::getFirstRowCoordinate() + x * Segmentation::PitchRow / npix, 0.f,
-                            Segmentation::getFirstColCoordinate() + z * Segmentation::PitchCol / npix);
-      auto xyzTra =
-        mGeometry->getMatrixT2L(mChipData->getChipID()) ^ (xyzLoc); // inverse transform from Local to Tracking frame
+      Point3D<float> xyzLoc;
+      Segmentation::detectorToLocalUnchecked(x / npix, z / npix, xyzLoc);
+      auto xyzTra = mGeometry->getMatrixT2L(mChipData->getChipID()) ^ (xyzLoc); // inverse transform from Local to Tracking frame
       c.setPos(xyzTra);
       c.setErrors(SigmaX2, SigmaY2, 0.f);
     }


### PR DESCRIPTION
Once the Alpide segmentation / matrix orientation were fixed, the shortcut for row/col -> local coordinates
conversion became inconsistent. Add proper shortcut to SegmentationAlpide and use it in the clusterization