### PR TITLE
Add ITS/MFT Digitizer option for Alpide noise setting

### DIFF
--- a/Detectors/ITSMFT/ITS/reconstruction/src/CookedTracker.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CookedTracker.cxx
@@ -515,10 +515,7 @@ void CookedTracker::process(const std::vector<Cluster>& clusters, std::vector<Tr
 
   while (numOfClustersLeft > 0) {
     nClFrame = loadClusters(clusters);
-    if (!nClFrame) {
-      LOG(FATAL) << "Failed to select any cluster out of " << numOfClustersLeft << " check if cont/trig mode is correct"
-                 << FairLogger::endl;
-    }
+
     numOfClustersLeft -= nClFrame;
     auto end = std::chrono::system_clock::now();
     std::chrono::duration<double> diff = end - start;
@@ -545,12 +542,16 @@ void CookedTracker::processFrame(std::vector<TrackITS>& tracks)
   // This is the main tracking function for single frame, it is assumed that only clusters
   // which may contribute to this frame is loaded
   //--------------------------------------------------------------------
-  LOG(INFO) << "CookedTracker::process(), number of threads: " << mNumOfThreads << FairLogger::endl;
+
+  Int_t numOfClusters = sLayers[kSeedingLayer1].getNumberOfClusters();
+  if (!numOfClusters) {
+    return;
+  }
+  LOG(INFO) << "CookedTracker::process(), number of threads: " << mNumOfThreads << " for " << numOfClusters << " clusters";
 
   std::vector<std::future<std::vector<TrackITS>>> futures(mNumOfThreads);
   std::vector<std::vector<TrackITS>> seedArray(mNumOfThreads);
 
-  Int_t numOfClusters = sLayers[kSeedingLayer1].getNumberOfClusters();
   for (Int_t t = 0, first = 0; t < mNumOfThreads; t++) {
     Int_t rem = t < (numOfClusters % mNumOfThreads) ? 1 : 0;
     Int_t last = first + (numOfClusters / mNumOfThreads) + rem;

--- a/Steer/DigitizerWorkflow/src/ITSMFTDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/ITSMFTDigitizerSpec.cxx
@@ -67,6 +67,10 @@ class ITSMFTDPLDigitizerTask
     LOG(INFO) << mID.getName() << " simulated in "
               << ((mROMode == o2::parameters::GRPObject::CONTINUOUS) ? "CONTINUOUS" : "TRIGGERED")
               << " RO mode";
+
+    auto noise = ic.options().get<float>("noise");
+    LOG(INFO) << "Noise generation (per pixel) " << noise;
+
     // make sure that the geometry is loaded (TODO will this be done centrally?)
     if (!gGeoManager) {
       o2::Base::GeometryManager::loadGeometry();
@@ -90,7 +94,7 @@ class ITSMFTDPLDigitizerTask
     // parameters of signal time response: flat-top duration, max rise time and q @ which rise time is 0
     mDigitizer.getParams().getSignalShape().setParameters(7500., 1100., 450.);
     mDigitizer.getParams().setChargeThreshold(150); // charge threshold in electrons
-    mDigitizer.getParams().setNoisePerPixel(1.e-7); // noise level
+    mDigitizer.getParams().setNoisePerPixel(noise); // noise level
     // init digitizer
     mDigitizer.init();
   }
@@ -339,6 +343,7 @@ DataProcessorSpec getITSDigitizerSpec(int channel)
                               { "simFile", VariantType::String, "o2sim.root", { "Sim (background) input filename" } },
                               { "simFileS", VariantType::String, "", { "Sim (signal) input filename" } },
                               { "simFileQED", VariantType::String, "", { "Sim (QED) input filename" } },
+                              { "noise", VariantType::Float, 1.e-7f, { "Noise per pixel" } },
                               { (detStr + "triggered").c_str(), VariantType::Bool, false, { "Impose triggered RO mode (default: continuous)" } } } };
 }
 
@@ -360,6 +365,7 @@ DataProcessorSpec getMFTDigitizerSpec(int channel)
                               { "simFile", VariantType::String, "o2sim.root", { "Sim (background) input filename" } },
                               { "simFileS", VariantType::String, "", { "Sim (signal) input filename" } },
                               { "simFileQED", VariantType::String, "", { "Sim (QED) input filename" } },
+                              { "noise", VariantType::Float, 1.e-7f, { "Noise per pixel" } },
                               { (detStr + "triggered").c_str(), VariantType::Bool, false, { "Impose triggered RO mode (default: continuous)" } } } };
 }
 


### PR DESCRIPTION
Once the Alpide segmentation / matrix orientation were fixed, the shortcut for row/col -> local coordinates
conversion became inconsistent. Add proper shortcut to SegmentationAlpide and use it in the clusterization