### PR TITLE
Add observer_ptr ( a la C++20 TSv2)

### DIFF
--- a/DataFormats/MemoryResources/CMakeLists.txt
+++ b/DataFormats/MemoryResources/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SRCS
 
 set(HEADERS
   include/${MODULE_NAME}/MemoryResources.h
+  include/${MODULE_NAME}/observer_ptr.h
 )
 
 set(LIBRARY_NAME ${MODULE_NAME})
@@ -20,6 +21,7 @@ O2_GENERATE_LIBRARY()
 
 set(TEST_SRCS
   test/testMemoryResources.cxx
+  test/test_observer_ptr.cxx
 )
 
 O2_GENERATE_TESTS(

--- a/DataFormats/MemoryResources/include/MemoryResources/observer_ptr.h
+++ b/DataFormats/MemoryResources/include/MemoryResources/observer_ptr.h
@@ -1,0 +1,158 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef FRAMEWORK_OBSERVER_PTR_H
+#define FRAMEWORK_OBSERVER_PTR_H
+
+#include <cstddef>
+#include <type_traits>
+
+namespace o2
+{
+
+template <typename W>
+class observer_ptr
+{
+ public:
+  using element_type = W;
+
+  constexpr observer_ptr() noexcept = default;
+  constexpr observer_ptr(std::nullptr_t) noexcept {}
+  explicit observer_ptr(element_type* ptr) noexcept : mptr{ ptr } {}
+  template <typename W2, typename std::enable_if<std::is_convertible<W2*, element_type*>::value, int>::type = 1>
+  observer_ptr(observer_ptr<W2> other) noexcept : mptr{ other.get() }
+  {
+  }
+  observer_ptr(const observer_ptr& other) = default;
+  observer_ptr(observer_ptr&& other) = default;
+
+  constexpr element_type* release() noexcept
+  {
+    auto tmp = *this;
+    this->reset();
+    return tmp.get();
+  }
+  constexpr void reset(element_type* p = nullptr) noexcept { *this = p; }
+  constexpr void swap(observer_ptr& other) noexcept
+  {
+    observer_ptr<element_type> tmp(*this);
+    *this = other;
+    other = tmp;
+  };
+  constexpr void swap(std::nullptr_t) noexcept
+  {
+    *this = nullptr;
+  };
+  constexpr element_type* get() const noexcept { return mptr; }
+  constexpr std::add_lvalue_reference_t<element_type> operator*() const { return *get(); }
+  constexpr element_type* operator->() const noexcept { return get(); }
+  constexpr std::add_lvalue_reference_t<observer_ptr<element_type>> operator=(const std::add_lvalue_reference_t<observer_ptr<element_type>> other)
+  {
+    mptr = other.mptr;
+    return *this;
+  }
+  constexpr std::add_lvalue_reference_t<observer_ptr<element_type>> operator=(element_type* const other)
+  {
+    mptr = other;
+    return *this;
+  }
+
+  constexpr explicit operator element_type*() const noexcept { return get(); }
+  constexpr explicit operator bool() const noexcept { return get() != nullptr; }
+
+ private:
+  element_type* mptr{ nullptr };
+};
+
+template <typename W>
+observer_ptr<W> make_observer(W* p) noexcept
+{
+  return observer_ptr(p);
+}
+
+template <class W1, class W2>
+bool operator==(const observer_ptr<W1>& p1, const observer_ptr<W2>& p2)
+{
+  return p1.get() == p2.get();
+}
+
+template <class W1, class W2>
+bool operator!=(const observer_ptr<W1>& p1, const observer_ptr<W2>& p2)
+{
+  return !(p1 == p2);
+}
+
+template <class W>
+bool operator==(const observer_ptr<W>& p, std::nullptr_t) noexcept
+{
+  return !p;
+}
+
+template <class W>
+bool operator==(std::nullptr_t, const observer_ptr<W>& p) noexcept
+{
+  return !p;
+}
+
+template <class W>
+bool operator!=(const observer_ptr<W>& p, std::nullptr_t) noexcept
+{
+  return static_cast<bool>(p);
+}
+
+template <class W>
+bool operator!=(std::nullptr_t, const observer_ptr<W>& p) noexcept
+{
+  return static_cast<bool>(p);
+}
+
+template <class W1, class W2>
+bool operator<(const observer_ptr<W1>& p1, const observer_ptr<W2>& p2)
+{
+  return p1.get() < p2.get();
+}
+
+template <class W1, class W2>
+bool operator>(const observer_ptr<W1>& p1, const observer_ptr<W2>& p2)
+{
+  return p1.get() > p2.get();
+}
+
+template <class W1, class W2>
+bool operator<=(const observer_ptr<W1>& p1, const observer_ptr<W2>& p2)
+{
+  return p1.get() <= p2.get();
+}
+
+template <class W1, class W2>
+bool operator>=(const observer_ptr<W1>& p1, const observer_ptr<W2>& p2)
+{
+  return p1.get() >= p2.get();
+}
+
+} //namespace o2
+
+namespace std
+{
+template <class W>
+void swap(o2::observer_ptr<W>& lhs, o2::observer_ptr<W>& rhs) noexcept
+{
+  lhs.swap(rhs);
+}
+template <class T>
+struct hash<o2::observer_ptr<T>> {
+  std::size_t operator()(const o2::observer_ptr<T>& in) const noexcept
+  {
+    return std::hash<T*>()(in.get());
+  };
+};
+} //namespace std
+
+#endif

--- a/DataFormats/MemoryResources/test/test_observer_ptr.cxx
+++ b/DataFormats/MemoryResources/test/test_observer_ptr.cxx
@@ -1,0 +1,128 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test observer_ptr
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include <functional>
+#include "MemoryResources/observer_ptr.h"
+
+struct A {
+  int i{ 2 };
+  int get() const { return i; }
+};
+
+BOOST_AUTO_TEST_CASE(observer_ptr_A)
+{
+  using namespace o2;
+  A t;
+  int i{ 1 };
+
+  {
+    observer_ptr<int> p{ nullptr };
+    BOOST_CHECK(p == nullptr);
+  }
+
+  {
+    observer_ptr<int> p;
+    BOOST_CHECK(p == nullptr);
+  }
+
+  {
+    observer_ptr<int> b{ &i };
+    observer_ptr<void> a(b);
+    BOOST_CHECK(a == b);
+  }
+
+  {
+    observer_ptr<int> b{ &i };
+    observer_ptr<int> a(b);
+    BOOST_CHECK(a == b);
+  }
+
+  {
+    const observer_ptr<int> b{ &i };
+    observer_ptr<int> a(b);
+    BOOST_CHECK(a == b);
+  }
+
+  {
+    observer_ptr<A> pt{ &t };
+    A* ptt = pt.release();
+    BOOST_CHECK(ptt == &t);
+    BOOST_CHECK(pt == nullptr);
+  }
+
+  {
+    observer_ptr<A> p{ &t };
+    p.reset();
+    BOOST_CHECK(p == nullptr);
+    p.reset(&t);
+    BOOST_CHECK(p.get() == &t);
+  }
+
+  {
+    A tt{ 4 };
+    observer_ptr<A> pp{ &tt };
+    observer_ptr<A> p{ &t };
+    p.swap(pp);
+    BOOST_CHECK(p->get() == 4 && pp->get() == 2);
+    p.swap(nullptr);
+    BOOST_CHECK(p == nullptr);
+    std::swap(p, pp);
+    BOOST_CHECK(pp == nullptr);
+    BOOST_CHECK(p->get() == 2);
+  }
+
+  {
+    observer_ptr<A> p{ &t };
+    BOOST_CHECK(p.get() == &t);
+  }
+
+  {
+    observer_ptr<A> p{ &t };
+    BOOST_CHECK((*p).i == 2);
+  }
+
+  {
+    observer_ptr<A> p;
+    p = &t;
+    BOOST_CHECK(p.get() == &t);
+    observer_ptr<A> pp;
+    pp = p;
+    BOOST_CHECK(pp.get() == &t);
+  }
+
+  //comparisons
+  {
+    A tt{ 4 };
+    observer_ptr<A> pp{ &tt };
+    observer_ptr<A> p{ &t };
+    observer_ptr<A> p_{ &t };
+    observer_ptr<A> n{ nullptr };
+    BOOST_CHECK(p != pp);
+    BOOST_CHECK(p == p_);
+    BOOST_CHECK(p != nullptr);
+    BOOST_CHECK(n == nullptr);
+    BOOST_CHECK((&tt > &t) ? pp > p : p > pp);
+    BOOST_CHECK((&tt < &t) ? pp < p : p < pp);
+    BOOST_CHECK((&tt >= &t) ? pp >= p : p >= pp);
+    BOOST_CHECK((&tt <= &t) ? pp <= p : p <= pp);
+    BOOST_CHECK((&t >= &t) ? p >= p : p >= p);
+    BOOST_CHECK((&t <= &t) ? p <= p : p <= p);
+  }
+
+  //hash
+  {
+    observer_ptr<int> p{ &i };
+    BOOST_CHECK(std::hash<o2::observer_ptr<int>>()(p) == std::hash<int*>()(p.get()));
+  }
+}


### PR DESCRIPTION
was discussed few times, so here it is. I have not put it in the Framework directly since it should be available also to lower level stuff that is a DPL dependency. Could not find a clear candidate for a location, so for now I propose to have it in MemoryResources, since this is pulled in by everybody via e.g. Headers. I'm sure at some point a better spot will present itself.