### PR TITLE
Introduce config parameters for sim stack; Option to prune kinematics

### DIFF
--- a/DataFormats/simulation/CMakeLists.txt
+++ b/DataFormats/simulation/CMakeLists.txt
@@ -7,10 +7,12 @@ set(SRCS
   src/MCTrack.cxx
   src/MCCompLabel.cxx
   src/RunContext.cxx
+  src/StackParam.cxx
 )
 
 Set(HEADERS
     include/${MODULE_NAME}/Stack.h
+    include/${MODULE_NAME}/StackParam.h
     include/${MODULE_NAME}/MCTrack.h
     include/${MODULE_NAME}/BaseHits.h
     include/${MODULE_NAME}/MCTruthContainer.h

--- a/DataFormats/simulation/include/SimulationDataFormat/Stack.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/Stack.h
@@ -154,6 +154,7 @@ class Stack : public FairGenericStack
 
   /// Modifiers
   void StoreSecondaries(Bool_t choice = kTRUE) { mStoreSecondaries = choice; }
+  void pruneKinematics(bool choice = true) { mPruneKinematics = choice; }
   void setMinHits(Int_t min) { mMinHits = min; }
   void SetEnergyCut(Double_t eMin) { mEnergyCut = eMin; }
   void StoreMothers(Bool_t choice = kTRUE) { mStoreMothers = choice; }
@@ -246,6 +247,7 @@ class Stack : public FairGenericStack
   /// Variables defining the criteria for output selection
   Bool_t mStoreMothers;
   Bool_t mStoreSecondaries;
+  bool mPruneKinematics = false; // whether or not we filter the output kinematics
   Int_t mMinHits;
   Double32_t mEnergyCut;
 

--- a/DataFormats/simulation/include/SimulationDataFormat/StackParam.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/StackParam.h
@@ -1,0 +1,34 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_SIMDATAFORMAT_STACKPARAM_H_
+#define ALICEO2_SIMDATAFORMAT_STACKPARAM_H_
+
+#include "SimConfig/ConfigurableParam.h"
+#include "SimConfig/ConfigurableParamHelper.h"
+
+namespace o2
+{
+namespace sim
+{
+
+// configuration parameters for simulation Stack
+struct StackParam : public o2::conf::ConfigurableParamHelper<StackParam> {
+  bool storeSecondaries = true;
+  bool pruneKine = true;
+
+  // boilerplate stuff + make principal key "Stack"
+  O2ParamDef(StackParam, "Stack");
+};
+
+} // namespace sim
+} // namespace o2
+
+#endif // ALICEO2_SIMDATAFORMAT_STACKPARAM_H_

--- a/DataFormats/simulation/src/SimulationDataLinkDef.h
+++ b/DataFormats/simulation/src/SimulationDataLinkDef.h
@@ -23,6 +23,8 @@
 #pragma link off all functions;
 
 #pragma link C++ class o2::Data::Stack + ;
+#pragma link C++ class o2::sim::StackParam+;
+#pragma link C++ class o2::conf::ConfigurableParamHelper<o2::sim::StackParam>+;
 #pragma link C++ class o2::MCTrackT < double > +;
 #pragma link C++ class o2::MCTrackT < float > +;
 #pragma link C++ class o2::MCTrack + ;

--- a/DataFormats/simulation/src/Stack.cxx
+++ b/DataFormats/simulation/src/Stack.cxx
@@ -316,7 +316,7 @@ void Stack::finishCurrentPrimary()
   int neglected = 0;
   std::vector<int> indicesKept;
   for (const auto& particle : mParticles) {
-    if (particle.getStore()) {
+    if (particle.getStore() || !mPruneKinematics) {
       // map the global track index to the new persistent index
       // FIXME: only fill the map for non-trivial mappings in which mTransportedIDs[index]!=mTracks->size();
       mIndexMap[mTransportedIDs[index]] = mTracks->size();

--- a/DataFormats/simulation/src/StackParam.cxx
+++ b/DataFormats/simulation/src/StackParam.cxx
@@ -1,0 +1,12 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "SimulationDataFormat/StackParam.h"
+O2ParamImpl(o2::sim::StackParam);

--- a/Detectors/gconfig/commonConfig.C
+++ b/Detectors/gconfig/commonConfig.C
@@ -1,15 +1,17 @@
-
 // common piece of code to setup stack and register
 // with VMC instances
 template <typename T, typename R>
-void stackSetup(T* vmc, R* run) {
+void stackSetup(T* vmc, R* run)
+{
   // create the O2 vmc stack instance
   auto st = new o2::Data::Stack();
   st->setMinHits(1);
-  st->StoreSecondaries(kTRUE);
+  auto& stackparam = o2::sim::StackParam::Instance();
+  st->StoreSecondaries(stackparam.storeSecondaries);
+  st->pruneKinematics(stackparam.pruneKine);
   vmc->SetStack(st);
 
-/*
+  /*
   // register the stack as an observer on FinishPrimary events (managed by Cave)
   bool foundCave = false;
   auto modules = run->GetListOfModules();

--- a/Detectors/gconfig/src/G3Config.cxx
+++ b/Detectors/gconfig/src/G3Config.cxx
@@ -12,6 +12,7 @@
 #include "TGeant3.h"
 #include "TGeant3TGeo.h"
 #include "SimulationDataFormat/Stack.h"
+#include "SimulationDataFormat/StackParam.h"
 #include <iostream>
 #include "FairLogger.h"
 #include "FairModule.h"

--- a/Detectors/gconfig/src/G4Config.cxx
+++ b/Detectors/gconfig/src/G4Config.cxx
@@ -10,6 +10,7 @@
 
 #include "FairRunSim.h"
 #include "SimulationDataFormat/Stack.h"
+#include "SimulationDataFormat/StackParam.h"
 #include <iostream>
 #include "FairLogger.h"
 #include "TGeant4.h"

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -610,12 +610,15 @@ o2_define_bucket(
     detectors_base_bucket
     DetectorsBase
     RIO
+    SimConfig
 
     INCLUDE_DIRECTORIES
     ${CMAKE_SOURCE_DIR}/Common/MathUtils/include
     ${CMAKE_SOURCE_DIR}/DataFormats/Detectors/Common/include
     ${CMAKE_SOURCE_DIR}/DataFormats/simulation/include
     ${CMAKE_SOURCE_DIR}/Detectors/Base/include/
+    ${CMAKE_SOURCE_DIR}/Common/SimConfig/include/
+
     ${MS_GSL_INCLUDE_DIR}
 )
 


### PR DESCRIPTION
We can now switch off/on pruning of kinematics via a simple configuration change

o2sim --configKeyValues "Stack.pruneKine=0"

The default is to prune.

This commit serves as another example how to add components to the simulation
configuration.