### PR TITLE
bug fix in interaction sampler for event time jitter

### DIFF
--- a/Steer/src/InteractionSampler.cxx
+++ b/Steer/src/InteractionSampler.cxx
@@ -107,7 +107,7 @@ int InteractionSampler::simulateInteractingBC()
   for (int i = ncoll; i--;) {
     double tInBC = 0; // tInBC should be in the vicinity of the BC
     do {
-      tInBC = gRandom->Gaus(0,mBCTimeRMS);
+      tInBC = gRandom->Gaus(0.,mBCTimeRMS);
     } while (std::abs(tInBC) > o2::constants::lhc::LHCBunchSpacingNS / 2.1);
     mTimeInBC.push_back(tInBC);
   }

--- a/Steer/src/InteractionSampler.cxx
+++ b/Steer/src/InteractionSampler.cxx
@@ -107,7 +107,7 @@ int InteractionSampler::simulateInteractingBC()
   for (int i = ncoll; i--;) {
     double tInBC = 0; // tInBC should be in the vicinity of the BC
     do {
-      tInBC = gRandom->Gaus(mBCTimeRMS);
+      tInBC = gRandom->Gaus(0,mBCTimeRMS);
     } while (std::abs(tInBC) > o2::constants::lhc::LHCBunchSpacingNS / 2.1);
     mTimeInBC.push_back(tInBC);
   }


### PR DESCRIPTION
gRandom->Gaus(mTimeBCRMS) invoked in the wrong way (1 argument has to be the mean and not the RMS). RMS moved as second argument