### PR TITLE
DPL: fix missing header

### DIFF
--- a/Framework/Core/include/Framework/TableBuilder.h
+++ b/Framework/Core/include/Framework/TableBuilder.h
@@ -15,6 +15,8 @@
 #include <arrow/type_traits.h>
 #include <arrow/table.h>
 #include <arrow/builder.h>
+
+#include <functional>
 #include <vector>
 #include <string>
 #include <memory>


### PR DESCRIPTION
Previously gotten implicitly via arrow, which did a cleanup in 0.12.0.