### PR TITLE
Fix the case of the class name HandMade3DImpl

### DIFF
--- a/Framework/DebugGUI/CMakeLists.txt
+++ b/Framework/DebugGUI/CMakeLists.txt
@@ -18,7 +18,7 @@ if (GLFW_FOUND)
         src/gl3w.c
         src/Sokol3DUtils.cxx
         src/GL3DUtils.cxx
-        src/HandMade3dImpl.cxx
+        src/HandMade3DImpl.cxx
         src/DebugGUI.cxx
       )
 else()


### PR DESCRIPTION
It would prevent compilation on CC7 with GLFW. Not detected earlier because GLFW is not installed on the build machine.