### PR TITLE
DPL: Drop a bunch of -O0

### DIFF
--- a/Framework/ArrowTests/CMakeLists.txt
+++ b/Framework/ArrowTests/CMakeLists.txt
@@ -29,5 +29,3 @@ O2_GENERATE_TESTS(
   BUCKET_NAME ${BUCKET_NAME}
   TEST_SRCS "test/test_Arrow01.cxx"
 )
-
-target_compile_options(test_ArrowTests_test_Arrow01 PUBLIC -O0 -g -fno-omit-frame-pointer)

--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -220,9 +220,6 @@ O2_GENERATE_EXECUTABLE(
   BUCKET_NAME ${MODULE_BUCKET_NAME}
 )
 
-target_compile_options(Framework PUBLIC -O0 -g -fno-omit-frame-pointer)
-target_compile_options(test_SimpleDataProcessingDevice01 PUBLIC -O0 -g -fno-omit-frame-pointer)
-
 Install(FILES test/test_DataSampling.json DESTINATION share/tests/)
 
 set(TEST_SRCS

--- a/Framework/DebugGUI/CMakeLists.txt
+++ b/Framework/DebugGUI/CMakeLists.txt
@@ -73,5 +73,3 @@ O2_GENERATE_EXECUTABLE(
 add_test(NAME test_DebugGUI_test_ImGUIHeadless COMMAND test_DebugGUI_test_ImGUIHeadless)
 target_link_libraries(test_DebugGUI_test_ImGUIHeadless Boost::unit_test_framework)
 set_tests_properties(test_DebugGUI_test_ImGUIHeadless PROPERTIES TIMEOUT 30)
-
-target_compile_options(DebugGUI PUBLIC -O0 -g -fno-omit-frame-pointer)

--- a/Framework/TestWorkflows/src/o2_sim_its_ALP3.cxx
+++ b/Framework/TestWorkflows/src/o2_sim_its_ALP3.cxx
@@ -43,7 +43,7 @@ DataProcessorSpec sim_its_ALP3() {
   return {
     "sim_its_ALP3",
     Inputs{},
-    {
+    Outputs{
       OutputSpec{"ITS", "HITS"}
     },
     AlgorithmSpec{

--- a/Framework/TestWorkflows/src/o2_sim_tpc.cxx
+++ b/Framework/TestWorkflows/src/o2_sim_tpc.cxx
@@ -27,6 +27,8 @@
 #include "DetectorsPassive/Cave.h"
 #include "Generators/GeneratorFromFile.h"
 #include "TPCSimulation/Detector.h"
+#include "Framework/OutputSpec.h"
+#include <vector>
 
 using namespace o2::framework;
 
@@ -42,9 +44,7 @@ DataProcessorSpec sim_tpc() {
   return {
     "sim_tpc",
     Inputs{},
-    {
-      OutputSpec{"TPC", "GEN"}
-    },
+    Outputs{OutputSpec{"TPC", "GEN"}},
     AlgorithmSpec{
       [](InitContext &setup) {
         int nEvents = setup.options().get<int>("nEvents");


### PR DESCRIPTION
We need to find a way to have debug builds easily, but
we cannot afford to unoptimised builds anymore as we
get closer to production.