### PR TITLE
Small usability improvements to FreePortFinder

### DIFF
--- a/Framework/Core/include/Framework/FreePortFinder.h
+++ b/Framework/Core/include/Framework/FreePortFinder.h
@@ -21,11 +21,15 @@ class FreePortFinder
   FreePortFinder(unsigned short initialPort, unsigned short finalPort, unsigned short step);
   /// Start the scan.
   void scan();
+  /// Test one specific port
+  bool testPort(int port) const;
   ~FreePortFinder();
   /// Get the first port in the selected range
-  unsigned short port();
+  unsigned short port() const;
   /// Get the range size
-  unsigned short range();
+  unsigned short range() const;
+  // set verbose mode
+  void setVerbose(bool b);
 
  private:
   int mSocket;
@@ -33,6 +37,7 @@ class FreePortFinder
   unsigned short mFinalPort;
   unsigned short mStep;
   unsigned short mPort;
+  bool mVerbose = true; // whether scan() reports about progress and final port found
 };
 
 } // namespace framework

--- a/run/o2sim_parallel.cxx
+++ b/run/o2sim_parallel.cxx
@@ -101,6 +101,7 @@ bool updatePorts(std::string configfilename)
   int portend = 50000;
   int step = 2; // we need 2 ports
   o2::framework::FreePortFinder finder(portstart, portend, step);
+  finder.setVerbose(false); // disable verbose output
   finder.scan();
   auto newserverport = finder.port();
   auto newmergerport = newserverport + 1;


### PR DESCRIPTION
Further factorize FreePortFinder

* add function allowing to check a particular port number
* refactor scan() function to use this function
* allow to enable/disable verbose output (sometimes
  it is not wished to be informed about invalid port ranges)
* const correctness fixes
