### PR TITLE
Use FairLogger standalone package in Detectors/TPC

### DIFF
--- a/Detectors/TPC/base/include/TPCBase/CalArray.h
+++ b/Detectors/TPC/base/include/TPCBase/CalArray.h
@@ -18,7 +18,7 @@
 #include <type_traits>
 #include <boost/format.hpp>
 
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 
 #include "TPCBase/Mapper.h"
 
@@ -186,8 +186,7 @@ template <class T>
 inline const CalArray<T>& CalArray<T>::operator+= (const CalArray<T>& other)
 {
   if ( !((mPadSubset == other.mPadSubset) && (mPadSubsetNumber == other.mPadSubsetNumber) ) ){
-    LOG(ERROR) << "You are trying to operate on incompatible objects: Pad subset type and number must be the same on both objects"
-               << FairLogger::endl;
+    LOG(error) << "You are trying to operate on incompatible objects: Pad subset type and number must be the same on both objects";
     return *this;
   }
   for (size_t i=0; i<mData.size(); ++i) {
@@ -201,8 +200,7 @@ template <class T>
 inline const CalArray<T>& CalArray<T>::operator-= (const CalArray<T>& other)
 {
   if ( !((mPadSubset == other.mPadSubset) && (mPadSubsetNumber == other.mPadSubsetNumber) ) ){
-    LOG(ERROR) << "You are trying to operate on incompatible objects: Pad subset type and number must be the same on both objects"
-               << FairLogger::endl;
+    LOG(error) << "You are trying to operate on incompatible objects: Pad subset type and number must be the same on both objects";
     return *this;
   }
   for (size_t i=0; i<mData.size(); ++i) {
@@ -216,8 +214,7 @@ template <class T>
 inline const CalArray<T>& CalArray<T>::operator*= (const CalArray<T>& other)
 {
   if ( !((mPadSubset == other.mPadSubset) && (mPadSubsetNumber == other.mPadSubsetNumber) ) ){
-    LOG(ERROR) << "pad subste type of the objects it not compatible" 
-               << FairLogger::endl;
+    LOG(error) << "pad subste type of the objects it not compatible";
     return *this;
   }
   for (size_t i=0; i<mData.size(); ++i) {
@@ -231,8 +228,7 @@ template <class T>
 inline const CalArray<T>& CalArray<T>::operator/= (const CalArray<T>& other)
 {
   if ( !((mPadSubset == other.mPadSubset) && (mPadSubsetNumber == other.mPadSubsetNumber) ) ){
-    LOG(ERROR) << "pad subste type of the objects it not compatible" 
-               << FairLogger::endl;
+    LOG(error) << "pad subste type of the objects it not compatible";
     return *this;
   }
   for (size_t i=0; i<mData.size(); ++i) {

--- a/Detectors/TPC/base/include/TPCBase/CalDet.h
+++ b/Detectors/TPC/base/include/TPCBase/CalDet.h
@@ -17,7 +17,7 @@
 #include <boost/format.hpp>
 #include <boost/range/combine.hpp>
 
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 
 #include "DataFormatsTPC/Defs.h"
 #include "TPCBase/Mapper.h"
@@ -159,7 +159,7 @@ inline const CalDet<T>& CalDet<T>::operator+=(const CalDet& other)
   // make sure the calibration objects have the same substructure
   // TODO: perhaps make it independed of this
   if (mPadSubset != other.mPadSubset) {
-    LOG(ERROR) << "Pad subste type of the objects it not compatible" << FairLogger::endl;
+    LOG(error) << "Pad subste type of the objects it not compatible";
     return *this;
   }
 
@@ -176,7 +176,7 @@ inline const CalDet<T>& CalDet<T>::operator-=(const CalDet& other)
   // make sure the calibration objects have the same substructure
   // TODO: perhaps make it independed of this
   if (mPadSubset != other.mPadSubset) {
-    LOG(ERROR) << "Pad subste type of the objects it not compatible" << FairLogger::endl;
+    LOG(error) << "Pad subste type of the objects it not compatible";
     return *this;
   }
 
@@ -193,7 +193,7 @@ inline const CalDet<T>& CalDet<T>::operator*=(const CalDet& other)
   // make sure the calibration objects have the same substructure
   // TODO: perhaps make it independed of this
   if (mPadSubset != other.mPadSubset) {
-    LOG(ERROR) << "Pad subste type of the objects it not compatible" << FairLogger::endl;
+    LOG(error) << "Pad subste type of the objects it not compatible";
     return *this;
   }
 
@@ -210,7 +210,7 @@ inline const CalDet<T>& CalDet<T>::operator/=(const CalDet& other)
   // make sure the calibration objects have the same substructure
   // TODO: perhaps make it independed of this
   if (mPadSubset != other.mPadSubset) {
-    LOG(ERROR) << "Pad subste type of the objects it not compatible" << FairLogger::endl;
+    LOG(error) << "Pad subste type of the objects it not compatible";
     return *this;
   }
 

--- a/Detectors/TPC/monitor/macro/RunCompareMode3.C
+++ b/Detectors/TPC/monitor/macro/RunCompareMode3.C
@@ -11,7 +11,7 @@
 #if !defined(__CLING__) || defined(__ROOTCLING__)
 #include "TObjString.h"
 #include "TObjArray.h"
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 
 #include "TPCBase/PadPos.h"
 
@@ -36,15 +36,15 @@ RunCompareMode3("GBTx0_Run005:0:0;GBTx1_Run005:1:0")
 //__________________________________________________________________________
 void RunCompareMode3(TString fileInfo)
 {
-  FairLogger *logger = FairLogger::GetLogger();
-  logger->SetLogVerbosityLevel("LOW");
-  logger->SetLogScreenLevel("INFO");
+
+  fair::Logger::SetVerbosity("LOW");
+  fair::Logger::SetConsoleSeverity("INFO");
 
   auto arrData = fileInfo.Tokenize("; ");
   uint64_t checkedAdcValues = 0;
   for (const auto &o : *arrData) {
     const TString& data = static_cast<TObjString*>(o)->String();
-    LOG(INFO) << "Checking file " << data.Data() << FairLogger::endl;
+    LOG(info) << "Checking file " << data.Data();
     // get file info: file name, cru, link
     RawReader rawReaderRaw;
     RawReader rawReaderDec;
@@ -57,7 +57,7 @@ void RunCompareMode3(TString fileInfo)
     auto eventInfoVecDec = rawReaderDec.getEventInfo(rawReaderDec.getFirstEvent());
 
     if (eventInfoVecRaw->begin()->header.dataType != 3) {
-      LOG(ERROR) << "Readout mode was " << (int) eventInfoVecRaw->begin()->header.dataType << " instead of 3." << FairLogger::endl;
+      LOG(error) << "Readout mode was " << (int)eventInfoVecRaw->begin()->header.dataType << " instead of 3.";
       return;
     }
 //    std::cout << eventInfoVecRaw->begin()->path << " "
@@ -84,7 +84,7 @@ void RunCompareMode3(TString fileInfo)
 
     for(uint64_t ev = rawReaderRaw.getFirstEvent(); ev <= rawReaderRaw.getLastEvent(); ++ev) {
       if (rawReaderRaw.loadEvent(ev) != rawReaderDec.loadEvent(ev)) {
-        LOG(ERROR) << "Event " << ev << " can't be decoded by both decoders" << FairLogger::endl;
+        LOG(error) << "Event " << ev << " can't be decoded by both decoders";
         return;
       }
 
@@ -95,35 +95,35 @@ void RunCompareMode3(TString fileInfo)
           for (int i = 0; i < std::min(dataDec->size(),dataRaw->size()); ++i) {
             ++checkedAdcValues;
             if (dataRaw->at(i) - dataDec->at(i+1) != 0) {
-              LOG(ERROR) << "Data is not equal in event " << ev 
-                << " for pad " << (int)padPos.getPad() 
-                << " in row " << (int)padPos.getRow() 
-                << " in timebin " << i
-                << " RawVec size: " << dataRaw->size()
-                << " DecVec size: " << dataDec->size() 
-                << FairLogger:: endl;
-              LOG(ERROR) << "Raw: " << dataRaw->at(i) << " \tDec: " << dataDec->at(i) << FairLogger::endl;
+              LOG(error) << "Data is not equal in event " << ev
+                         << " for pad " << (int)padPos.getPad()
+                         << " in row " << (int)padPos.getRow()
+                         << " in timebin " << i
+                         << " RawVec size: " << dataRaw->size()
+                         << " DecVec size: " << dataDec->size()
+                         << FairLogger::endl;
+              LOG(error) << "Raw: " << dataRaw->at(i) << " \tDec: " << dataDec->at(i);
             }
           }
         } else { 
           for (int i = 0; i < std::min(dataDec->size(),dataRaw->size()); ++i){
             ++checkedAdcValues;
             if (dataRaw->at(i) - dataDec->at(i) != 0) {
-              LOG(ERROR) << "Data is not equal in event " << ev 
-                << " for pad " << (int)padPos.getPad() 
-                << " in row " << (int)padPos.getRow() 
-                << " in timebin " << i
-                << " RawVec size: " << dataRaw->size()
-                << " DecVec size: " << dataDec->size() 
-                << FairLogger:: endl;
-              LOG(ERROR) << "Raw: " << dataRaw->at(i) << " \tDec: " << dataDec->at(i) << FairLogger::endl;
+              LOG(error) << "Data is not equal in event " << ev
+                         << " for pad " << (int)padPos.getPad()
+                         << " in row " << (int)padPos.getRow()
+                         << " in timebin " << i
+                         << " RawVec size: " << dataRaw->size()
+                         << " DecVec size: " << dataDec->size()
+                         << FairLogger::endl;
+              LOG(error) << "Raw: " << dataRaw->at(i) << " \tDec: " << dataDec->at(i);
             }
           }
         }
       }
     }
-    LOG(INFO) << "Compared " << (double)checkedAdcValues/1000000 << "M ADC values in total" << FairLogger::endl;
+    LOG(info) << "Compared " << (double)checkedAdcValues / 1000000 << "M ADC values in total";
   }
-  LOG(INFO) << "Compared " << (double)checkedAdcValues/1000000 << "M ADC values in total" << FairLogger::endl;
+  LOG(info) << "Compared " << (double)checkedAdcValues / 1000000 << "M ADC values in total";
 }
 

--- a/Detectors/TPC/monitor/macro/RunFindAdcError.C
+++ b/Detectors/TPC/monitor/macro/RunFindAdcError.C
@@ -9,7 +9,7 @@
 // or submit itself to any jurisdiction.
 
 #if !defined(__CLING__) || defined(__ROOTCLING__)
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 
 #include "TPCBase/PadPos.h"
 #include "TPCReconstruction/RawReader.h"
@@ -67,17 +67,16 @@ void loopReader(std::shared_ptr<RawReader> reader_ptr, std::vector<Result>& resu
       }
     }
   }
-//  LOG(INFO) << reader->getEventInfo(0)->at(0).path << " done" << FairLogger::endl;
+  //  LOG(info) << reader->getEventInfo(0)->at(0).path << " done";
 }
 
 //__________________________________________________________________________
 void RunFindAdcError(int run_min, int run_max)
 {
   std::string DATADIR = "/local/data/tpc-beam-test-2017";
-  FairLogger *logger = FairLogger::GetLogger();
-  logger->SetLogVerbosityLevel("LOW");
-  logger->SetLogScreenLevel("INFO");
 
+  fair::Logger::SetVerbosity("LOW");
+  fair::Logger::SetConsoleSeverity("INFO");
 
   // ===========================================================================
   // Preparing File Infos
@@ -105,7 +104,7 @@ void RunFindAdcError(int run_min, int run_max)
   // ===========================================================================
   // Preparing the Readers
   // ===========================================================================
-  LOG(INFO) << "Create all Readers..." << FairLogger::endl;
+  LOG(info) << "Create all Readers...";
   std::vector<std::shared_ptr<RawReader>> RawReaders;
   for (const auto &s : fileInfos) {
     auto rawReader = new RawReader;
@@ -117,16 +116,14 @@ void RunFindAdcError(int run_min, int run_max)
     if (rawReader->getEventInfo(0)->at(0).header.dataType != 2)
       RawReaders.push_back(std::shared_ptr<RawReader>(rawReader));
     else
-      LOG(INFO) << "\tDrop Reader of file " << rawReader->getEventInfo(0)->at(0).path << " because of readout mode 2." << FairLogger::endl;
+      LOG(info) << "\tDrop Reader of file " << rawReader->getEventInfo(0)->at(0).path << " because of readout mode 2.";
   }
-  LOG(INFO) << "... done" << FairLogger::endl;
-
-
+  LOG(info) << "... done";
 
   // ===========================================================================
   // Loop through the Readers to find ADC errors
   // ===========================================================================
-  LOG(INFO) << "Loop through Readers..." << FairLogger::endl;
+  LOG(info) << "Loop through Readers...";
   std::vector<std::thread> threads;
   std::vector<std::vector<Result>> results(RawReaders.size());
   int i = 0;
@@ -141,13 +138,12 @@ void RunFindAdcError(int run_min, int run_max)
   for (std::thread& t : threads) {
     t.join();
   }
-  LOG(INFO) << "... done" << FairLogger::endl;
-
+  LOG(info) << "... done";
 
   // ===========================================================================
   // Analyse outcome
   // ===========================================================================
-  logger->SetLogScreenLevel("DEBUG");
+  fair::Logger::SetConsoleSeverity("DEBUG");
   hAdcError = new TH2F("hAdcError","occurrence of ADC errors",36,0,36,20,0,20);
   hAdcError->GetXaxis()->SetTitle("SampaID");
   hAdcError->GetYaxis()->SetTitle("Timebin");

--- a/Detectors/TPC/monitor/macro/RunSimpleEventDisplay.C
+++ b/Detectors/TPC/monitor/macro/RunSimpleEventDisplay.C
@@ -31,7 +31,7 @@
 #include "TPCBase/Mapper.h"
 #include "TPCBase/CalDet.h"
 #include "TPCBase/CalArray.h"
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 #include <iostream>
 #include <fstream>
 #include <memory>
@@ -444,9 +444,9 @@ void Next(int eventNumber=-1)
 //__________________________________________________________________________
 void RunSimpleEventDisplay(TString fileInfo, TString pedestalFile="", Int_t nTimeBinsPerCall=500)
 {
-  FairLogger *logger = FairLogger::GetLogger();
-  logger->SetLogVerbosityLevel("LOW");
-  logger->SetLogScreenLevel("DEBUG");
+
+  fair::Logger::SetVerbosity("LOW");
+  fair::Logger::SetConsoleSeverity("DEBUG");
   if (!pedestalFile.IsNull()) {
     TFile f(pedestalFile);
     if (f.IsOpen()) {

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/AdcClockMonitor.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/AdcClockMonitor.h
@@ -14,7 +14,7 @@
 #ifndef ALICEO2_TPC_ADCCLOCKMONITOR_H_
 #define ALICEO2_TPC_ADCCLOCKMONITOR_H_
 
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 #include <iosfwd>
 #include <iomanip>
 

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/GBTFrameContainer.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/GBTFrameContainer.h
@@ -33,7 +33,7 @@
 #include <iosfwd>
 #include <iomanip>
 
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 
 namespace o2{
 namespace TPC{

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/SyncPatternMonitor.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/SyncPatternMonitor.h
@@ -14,7 +14,7 @@
 #ifndef ALICEO2_TPC_SYNCPATTERNMONITOR_H_
 #define ALICEO2_TPC_SYNCPATTERNMONITOR_H_
 
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 #include <iosfwd>
 #include <iomanip>
 #include <array>
@@ -118,12 +118,12 @@ void SyncPatternMonitor::checkWord(const short hw, const short pos) {
 };
 
 inline
-void SyncPatternMonitor::patternFound(const short hw) { 
-  LOG(DEBUG) << "SAMPA " << mSampa << " (" << ((mLowHigh == 0) ? " low" : "high") << "): "
-     << "SYNC found at Position " << hw << " in checked half word #" << mCheckedWords << FairLogger::endl;
+void SyncPatternMonitor::patternFound(const short hw) {
+  LOG(debug) << "SAMPA " << mSampa << " (" << ((mLowHigh == 0) ? " low" : "high") << "): "
+             << "SYNC found at Position " << hw << " in checked half word #" << mCheckedWords;
   if (mPatternFound) {
-    LOG(WARNING) << "SAMPA " << mSampa << " (" << ((mLowHigh == 0) ? " low" : "high") << "): "
-      << "SYNC was already found" << FairLogger::endl;
+    LOG(warn) << "SAMPA " << mSampa << " (" << ((mLowHigh == 0) ? " low" : "high") << "): "
+              << "SYNC was already found";
   }
   mPatternFound = true; 
   mPosition = SYNC_START; 

--- a/Detectors/TPC/reconstruction/run/readRawData.cxx
+++ b/Detectors/TPC/reconstruction/run/readRawData.cxx
@@ -25,7 +25,7 @@
 #include "TPCReconstruction/RawReader.h"
 #include "TPCReconstruction/RawReaderEventSync.h"
 #include "TPCBase/PadPos.h"
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 
 namespace bpo = boost::program_options;
 using namespace o2::TPC;
@@ -68,10 +68,10 @@ int main(int argc, char *argv[])
   if (infile[0] == "NOFILE") return EXIT_SUCCESS;
 
   // Initialize logger
-  FairLogger *logger = FairLogger::GetLogger();
-  logger->SetLogVerbosityLevel(verbLevel.c_str());
-  logger->SetLogScreenLevel(logLevel.c_str());
-  logger->SetColoredLog(false);
+
+  fair::Logger::SetVerbosity(verbLevel.c_str());
+  fair::Logger::SetConsoleSeverity(logLevel.c_str());
+  fair::Logger::SetConsoleColor(false);
 
   std::vector<RawReader> readers;
   std::shared_ptr<RawReaderEventSync> eventSync = std::make_shared<RawReaderEventSync>();

--- a/Detectors/TPC/reconstruction/src/BoxClusterer.cxx
+++ b/Detectors/TPC/reconstruction/src/BoxClusterer.cxx
@@ -94,7 +94,7 @@
 #include "TPCBase/Digit.h"
 #include "TPCReconstruction/ClusterContainer.h"
 
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 #include "TMath.h"
 #include "TError.h"   // for R__ASSERT()
 
@@ -328,7 +328,7 @@ void BoxClusterer::findLocalMaxima(const Int_t iCRU)
         //      }
         //      std::cout << std::endl;
         //    }
-        ////    LOG(INFO) << *cluster << FairLogger::endl;
+        ////    LOG(info) << *cluster;
       }
     } // end loop over signals
   } // end loop over rows

--- a/Detectors/TPC/reconstruction/src/ClusterContainer.cxx
+++ b/Detectors/TPC/reconstruction/src/ClusterContainer.cxx
@@ -11,7 +11,7 @@
 #include "TPCReconstruction/ClusterContainer.h"
 #include "DataFormatsTPC/Cluster.h"
 
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 #include <cassert>
 
 using namespace o2::TPC;

--- a/Detectors/TPC/reconstruction/src/ClustererTask.cxx
+++ b/Detectors/TPC/reconstruction/src/ClustererTask.cxx
@@ -13,7 +13,7 @@
 
 #include "TPCReconstruction/ClustererTask.h"
 
-#include "FairLogger.h"          // for LOG
+#include <fairlogger/Logger.h>   // for LOG
 #include "FairRootManager.h"     // for FairRootManager
 
 ClassImp(o2::TPC::ClustererTask);
@@ -39,27 +39,27 @@ ClustererTask::ClustererTask(int sectorid)
 /// Inititializes the clusterer and connects input and output container
 InitStatus ClustererTask::Init()
 {
-  LOG(DEBUG) << "Enter Initializer of ClustererTask" << FairLogger::endl;
+  LOG(debug) << "Enter Initializer of ClustererTask";
 
   FairRootManager *mgr = FairRootManager::Instance();
   if( !mgr ) {
-    LOG(ERROR) << "Could not instantiate FairRootManager. Exiting ..." << FairLogger::endl;
+    LOG(error) << "Could not instantiate FairRootManager. Exiting ...";
     return kERROR;
   }
 
   if (mClusterSector < 0 || mClusterSector >= Sector::MAXSECTOR) {
-    LOG(ERROR) << "Sector ID " << mClusterSector << " is not supported. Exiting ..." << FairLogger::endl;
+    LOG(error) << "Sector ID " << mClusterSector << " is not supported. Exiting ...";
     return kERROR;
   }
 
   // Register input container
   std::stringstream sectornamestr;
   sectornamestr << "TPCDigit" << mClusterSector;
-  LOG(INFO) << "FETCHING DIGITS FOR SECTOR " << mClusterSector << "\n";
+  LOG(info) << "FETCHING DIGITS FOR SECTOR " << mClusterSector << "\n";
   mDigitsArray = std::unique_ptr<const std::vector<Digit>>(
     mgr->InitObjectAs<const std::vector<Digit>*>(sectornamestr.str().c_str()));
   if (!mDigitsArray) {
-    LOG(ERROR) << "TPC points not registered in the FairRootManager. Exiting ..." << FairLogger::endl;
+    LOG(error) << "TPC points not registered in the FairRootManager. Exiting ...";
     return kERROR;
   }
   std::stringstream mcsectornamestr;
@@ -67,7 +67,7 @@ InitStatus ClustererTask::Init()
   mDigitMCTruthArray = std::unique_ptr<const MCLabelContainer>(
     mgr->InitObjectAs<const MCLabelContainer*>(mcsectornamestr.str().c_str()));
   if (!mDigitMCTruthArray) {
-    LOG(ERROR) << "TPC MC Truth not registered in the FairRootManager. Exiting ..." << FairLogger::endl;
+    LOG(error) << "TPC MC Truth not registered in the FairRootManager. Exiting ...";
     return kERROR;
   }
 
@@ -97,7 +97,7 @@ InitStatus ClustererTask::Init()
 //_____________________________________________________________________
 void ClustererTask::Exec(Option_t *option)
 {
-  LOG(DEBUG) << "Running clusterization on event " << mEventCount << " with " << mDigitsArray->size() << " digits." << FairLogger::endl;
+  LOG(debug) << "Running clusterization on event " << mEventCount << " with " << mDigitsArray->size() << " digits.";
 
   if (mHwClustersArray)
     mHwClustersArray->clear();
@@ -105,8 +105,7 @@ void ClustererTask::Exec(Option_t *option)
     mHwClustersMCTruthArray->clear();
 
   mHwClusterer->process(*mDigitsArray.get(), mDigitMCTruthArray.get());
-  LOG(DEBUG) << "Hw clusterer delivered " << mHwClustersArray->size() << " cluster container" << FairLogger::endl
-             << FairLogger::endl;
+  LOG(debug) << "Hw clusterer delivered " << mHwClustersArray->size() << " cluster container" << FairLogger::endl;
 
   ++mEventCount;
 }
@@ -114,7 +113,7 @@ void ClustererTask::Exec(Option_t *option)
 //_____________________________________________________________________
 void ClustererTask::FinishTask()
 {
-  LOG(DEBUG) << "Finish clusterization" << FairLogger::endl;
+  LOG(debug) << "Finish clusterization";
 
   if (mHwClustersArray)
     mHwClustersArray->clear();
@@ -122,8 +121,7 @@ void ClustererTask::FinishTask()
     mHwClustersMCTruthArray->clear();
 
   mHwClusterer->finishProcess(*mDigitsArray.get(), mDigitMCTruthArray.get());
-  LOG(DEBUG) << "Hw clusterer delivered " << mHwClustersArray->size() << " cluster container" << FairLogger::endl
-             << FairLogger::endl;
+  LOG(debug) << "Hw clusterer delivered " << mHwClustersArray->size() << " cluster container" << FairLogger::endl;
 
   ++mEventCount;
 }

--- a/Detectors/TPC/reconstruction/src/HalfSAMPAData.cxx
+++ b/Detectors/TPC/reconstruction/src/HalfSAMPAData.cxx
@@ -12,7 +12,7 @@
 /// \author Sebastian Klewin
 
 #include "TPCReconstruction/HalfSAMPAData.h"
-#include "FairLogger.h" 
+#include <fairlogger/Logger.h>
 
 using namespace o2::TPC;
 
@@ -31,8 +31,8 @@ HalfSAMPAData::HalfSAMPAData(int id, bool low, std::array<short,16>& data)
   : mID(id)
   , mLow(low)
 {
-//  if (data.size() != 16)
-//    LOG(ERROR) << "Vector does not contain 16 elements." << FairLogger::endl;
+  //  if (data.size() != 16)
+  //    LOG(error) << "Vector does not contain 16 elements.";
 
   mData = data;
 }

--- a/Detectors/TPC/reconstruction/src/HardwareClusterDecoder.cxx
+++ b/Detectors/TPC/reconstruction/src/HardwareClusterDecoder.cxx
@@ -18,7 +18,7 @@
 #include "TPCBase/Mapper.h"
 #include <algorithm>
 #include <vector>
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 
 #include "SimulationDataFormat/MCTruthContainer.h"
 #include "SimulationDataFormat/MCCompLabel.h"
@@ -46,7 +46,7 @@ int HardwareClusterDecoder::decodeClusters(std::vector<std::pair<const ClusterHa
     {
       if (outMCLabels && inputClusters[i].second > 1)
       {
-        LOG(ERROR) << "Decoding of ClusterHardware to ClusterNative with MC labels is yet only support for single 8kb pages of ClusterHardwareContainer\n";
+        LOG(error) << "Decoding of ClusterHardware to ClusterNative with MC labels is yet only support for single 8kb pages of ClusterHardwareContainer\n";
         return(1);
       }
       for (int j = 0;j < inputClusters[i].second;j++)

--- a/Detectors/TPC/reconstruction/src/HwClusterer.cxx
+++ b/Detectors/TPC/reconstruction/src/HwClusterer.cxx
@@ -18,7 +18,7 @@
 #include "DataFormatsTPC/Cluster.h"
 #include "DataFormatsTPC/ClusterHardware.h"
 
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 
 #include <cassert>
 #include <limits>
@@ -59,7 +59,7 @@ HwClusterer::HwClusterer(
     mClusterArray(clusterOutputContainer),
     mPlainClusterArray(clusterOutputSimple)
 {
-  LOG(DEBUG) << "Enter Initializer of HwClusterer" << FairLogger::endl;
+  LOG(debug) << "Enter Initializer of HwClusterer";
 
   // Given sector ID must be within 0 and 35 for a proper CRU ID calculation
   assert(sectorid >= 0 && sectorid < 36);
@@ -264,7 +264,7 @@ void HwClusterer::process(std::vector<o2::TPC::Digit> const& digits, MCLabelCont
     finishFrame(true);
 
   if (digits.size() != 0)
-    LOG(DEBUG) << "Event ranged from time bin " << digits.front().getTimeStamp() << " to " << digits.back().getTimeStamp() << "." << FairLogger::endl;
+    LOG(debug) << "Event ranged from time bin " << digits.front().getTimeStamp() << " to " << digits.back().getTimeStamp() << ".";
 }
 
 //______________________________________________________________________________

--- a/Detectors/TPC/reconstruction/src/RawReader.cxx
+++ b/Detectors/TPC/reconstruction/src/RawReader.cxx
@@ -22,7 +22,7 @@
 #include "TPCBase/Mapper.h"
 #include "TPCBase/PartitionInfo.h"
 
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 
 using namespace o2::TPC;
 
@@ -61,7 +61,7 @@ bool RawReader::addInputFile(std::string infile) {
   boost::char_separator<char> sep{":"};
   tokenizer tok{infile,sep};
   if (std::distance(tok.begin(), tok.end()) < 3) {
-    LOG(ERROR) << "Not enough arguments" << FairLogger::endl;
+    LOG(error) << "Not enough arguments";
     return false;
   }
 
@@ -74,7 +74,7 @@ bool RawReader::addInputFile(std::string infile) {
     ++it1;
     region = boost::lexical_cast<int>(*it1);
   } catch (boost::bad_lexical_cast) {
-    LOG(ERROR) << "Please enter a region for " << path << FairLogger::endl;
+    LOG(error) << "Please enter a region for " << path;
     return false;
   }
 
@@ -82,18 +82,18 @@ bool RawReader::addInputFile(std::string infile) {
     ++it1;
     link = boost::lexical_cast<int>(*it1);
   } catch (boost::bad_lexical_cast) {
-    LOG(ERROR) << "Please enter a link number for " << path << FairLogger::endl;
+    LOG(error) << "Please enter a link number for " << path;
     return false;
   }
 
   int sampaVersion = -1;
   if (++it1 == tok.end()) {
-    LOG(DEBUG) << "No SAMPA version was entered, assuming latest." << FairLogger::endl;
+    LOG(debug) << "No SAMPA version was entered, assuming latest.";
   } else {
     try {
       sampaVersion = boost::lexical_cast<int>(*it1);
     } catch (boost::bad_lexical_cast) {
-      LOG(ERROR) << "Please enter a valid SAMPA version for " << path << FairLogger::endl;
+      LOG(error) << "Please enter a valid SAMPA version for " << path;
       return false;
     }
   }
@@ -113,28 +113,28 @@ bool RawReader::addInputFile(int region, int link, int sampaVersion, std::string
     mSampaVersion = sampaVersion;
 
   if (run != mRun) {
-    LOG(DEBUG) << "Run of RawReader is " << mRun << " and not " << run << FairLogger::endl;
+    LOG(debug) << "Run of RawReader is " << mRun << " and not " << run;
     return false;
   }
 
   if (region != mRegion) {
-    LOG(DEBUG) << "Region of RawReader is " << mRegion << " and not " << region << FairLogger::endl;
+    LOG(debug) << "Region of RawReader is " << mRegion << " and not " << region;
     return false;
   }
 
   if (link != mLink) {
-    LOG(DEBUG) << "Link of RawReader is " << mLink << " and not " << link << FairLogger::endl;
+    LOG(debug) << "Link of RawReader is " << mLink << " and not " << link;
     return false;
   }
 
   if (sampaVersion != mSampaVersion) {
-    LOG(DEBUG) << "SAMPA Version of RawReader is " << mSampaVersion << " and not " << sampaVersion << FairLogger::endl;
+    LOG(debug) << "SAMPA Version of RawReader is " << mSampaVersion << " and not " << sampaVersion;
     return false;
   }
 
   std::ifstream file(path);
   if (!file.is_open()) {
-    LOG(ERROR) << "Can't read file " << path << FairLogger::endl;
+    LOG(error) << "Can't read file " << path;
     return false;
   }
 
@@ -147,7 +147,7 @@ bool RawReader::addInputFile(int region, int link, int sampaVersion, std::string
   while (pos < length) {
     file.read((char*)&h, sizeof(h));
     if (h.reserved_01 != 0x0F || h.reserved_2() != 0x3fec2fec1fec0fec) {
-      LOG(ERROR) << "Header does not look consistent" << FairLogger::endl;
+      LOG(error) << "Header does not look consistent";
     }
     EventInfo eD;
     eD.path = path;
@@ -159,7 +159,7 @@ bool RawReader::addInputFile(int region, int link, int sampaVersion, std::string
       ins.first->second->push_back(eD);
 
       if (h.eventCount() == 0) {
-        LOG(DEBUG) << "Processing event 0 to find sync pattern for event synchronization" << FairLogger::endl;
+        LOG(debug) << "Processing event 0 to find sync pattern for event synchronization";
         loadEvent(0);   // processing first event to find the SYNC pattern (mode 1) or start of data (mode 2)
         mLastEvent=-1;
       }
@@ -171,7 +171,7 @@ bool RawReader::addInputFile(int region, int link, int sampaVersion, std::string
       file.seekg(pos+(h.nWords*4));
       pos = file.tellg();
     } else {
-      LOG(ERROR) << "Header version " << (int)h.headerVersion << " not implemented." << FairLogger::endl;
+      LOG(error) << "Header version " << (int)h.headerVersion << " not implemented.";
       return false;
     }
   }
@@ -182,14 +182,14 @@ bool RawReader::addInputFile(int region, int link, int sampaVersion, std::string
 bool RawReader::loadEvent(int64_t event) {
   const Mapper& mapper = Mapper::instance();
   const PartitionInfo& partInfo = mapper.getPartitionInfo(mRegion/2);
-  LOG(DEBUG) << "Loading event " << event << " for Link " << (mRegion*partInfo.getNumberOfFECs())+mLink << FairLogger::endl;
+  LOG(debug) << "Loading event " << event << " for Link " << (mRegion * partInfo.getNumberOfFECs()) + mLink;
 
   if (mLastEvent == -1 && event != getFirstEvent() ) {
-    LOG(DEBUG) << "First event was not loaded (maybe important for decoding RAW GBT frames) loading first event." << FairLogger::endl;
+    LOG(debug) << "First event was not loaded (maybe important for decoding RAW GBT frames) loading first event.";
     mSyncPos.fill(-1);
     mTimestampOfFirstData.fill(0);
     loadEvent(getFirstEvent());
-    LOG(DEBUG) << "Continue with event " << event << FairLogger::endl;
+    LOG(debug) << "Continue with event " << event;
   }
   mData.clear();
 
@@ -202,51 +202,53 @@ bool RawReader::loadEvent(int64_t event) {
     switch (eventInfo.header.dataType) {
       case 1: // RAW GBT frames
         {
-          LOG(DEBUG) << "Data of readout mode 1 (RAW GBT frames)" << FairLogger::endl;
-          if (!decodeRawGBTFrames(eventInfo)) return false;
-          break;
+        LOG(debug) << "Data of readout mode 1 (RAW GBT frames)";
+        if (!decodeRawGBTFrames(eventInfo))
+          return false;
+        break;
         }
       case 2: // Decoded data
         {
-          LOG(DEBUG) << "Data of readout mode 2 (decoded data)" << FairLogger::endl;
-          if (!decodePreprocessedData(eventInfo)) return false;
-          break;
+        LOG(debug) << "Data of readout mode 2 (decoded data)";
+        if (!decodePreprocessedData(eventInfo))
+          return false;
+        break;
         }
       case 3: // both, RAW GBT frames and decoded data
         {
           if (mUseRawInMode3) {
-            LOG(DEBUG) << "Data of readout mode 3 (decoding RAW GBT frames)" << FairLogger::endl;
+            LOG(debug) << "Data of readout mode 3 (decoding RAW GBT frames)";
             if (!decodeRawGBTFrames(eventInfo)) return false;
           } else {
-            LOG(DEBUG) << "Data of readout mode 3 (using decoded data)" << FairLogger::endl;
+            LOG(debug) << "Data of readout mode 3 (using decoded data)";
             if (!decodePreprocessedData(eventInfo)) return false;
           }
           break;
         }
       default:
         {
-          LOG(DEBUG) << "Readout mode not known" << FairLogger::endl;
-          break;
+        LOG(debug) << "Readout mode not known";
+        break;
         }
     }
   }
 
   mDataIterator = mData.begin();
-  LOG(DEBUG) << FairLogger::endl;
-  LOG(DEBUG) << FairLogger::endl;
+  LOG(debug);
+  LOG(debug);
   return true;
 }
 
 bool RawReader::decodePreprocessedData(EventInfo eventInfo) {
   std::ifstream file(eventInfo.path);
   if (!file.is_open()) {
-    LOG(ERROR) << "Can't read file " << eventInfo.path << FairLogger::endl;
+    LOG(error) << "Can't read file " << eventInfo.path;
     return false;
   }
 
   int nWords = eventInfo.header.nWords-8;
   uint32_t words[nWords];
-  LOG(DEBUG) << "reading " << nWords << " words from position " << eventInfo.posInFile << " in file " << eventInfo.path << FairLogger::endl;
+  LOG(debug) << "reading " << nWords << " words from position " << eventInfo.posInFile << " in file " << eventInfo.path;
   file.seekg(eventInfo.posInFile);
   file.read((char*)&words, nWords*sizeof(words[0]));
 
@@ -273,17 +275,15 @@ bool RawReader::decodePreprocessedData(EventInfo eventInfo) {
 
   long i_start = 0;
   if (eventInfo.header.eventCount() > 0) {
-    LOG(DEBUG) << "Using offset [" << mTimestampOfFirstData[0] + mEventSynchronizer->getEventOffset(eventInfo.header.eventCount()) << "] "
+    LOG(debug) << "Using offset [" << mTimestampOfFirstData[0] + mEventSynchronizer->getEventOffset(eventInfo.header.eventCount()) << "] "
                << "instead of [" << eventInfo.header.timeStamp() << "] "
-               << " (diff = " << mTimestampOfFirstData[0] + mEventSynchronizer->getEventOffset(eventInfo.header.eventCount()) - eventInfo.header.timeStamp() << ") "
-               << FairLogger::endl;
+               << " (diff = " << mTimestampOfFirstData[0] + mEventSynchronizer->getEventOffset(eventInfo.header.eventCount()) - eventInfo.header.timeStamp() << ") ";
 
     i_start = mTimestampOfFirstData[0] + mEventSynchronizer->getEventOffset(eventInfo.header.eventCount()) - eventInfo.header.timeStamp() -1;
     i_start *= indexStep;
   }
 
-  LOG(DEBUG) << "Start index for Event " << eventInfo.header.eventCount() << " is " << i_start << FairLogger::endl;
-
+  LOG(debug) << "Start index for Event " << eventInfo.header.eventCount() << " is " << i_start;
 
   for (long i=i_start; i<nWords; i=i+indexStep) {
     ids[4] = (words[i+offset] >> 4) & 0xF;
@@ -337,14 +337,14 @@ bool RawReader::decodePreprocessedData(EventInfo eventInfo) {
 bool RawReader::decodeRawGBTFrames(EventInfo eventInfo) {
   std::ifstream file(eventInfo.path);
   if (!file.is_open()) {
-    LOG(ERROR) << "Can't read file " << eventInfo.path << FairLogger::endl;
+    LOG(error) << "Can't read file " << eventInfo.path;
     return false;
   }
 
   int nWords = eventInfo.header.nWords-8;
   uint32_t words[nWords];
-  LOG(DEBUG) << "reading " << nWords << " words from position " << eventInfo.posInFile << " in file " << eventInfo.path << FairLogger::endl;
-  LOG(DEBUG) << "Header time stamp is " << eventInfo.header.timeStamp() << FairLogger::endl;
+  LOG(debug) << "reading " << nWords << " words from position " << eventInfo.posInFile << " in file " << eventInfo.path;
+  LOG(debug) << "Header time stamp is " << eventInfo.header.timeStamp();
   file.seekg(eventInfo.posInFile);
   file.read((char*)&words, nWords*sizeof(words[0]));
 
@@ -380,16 +380,15 @@ bool RawReader::decodeRawGBTFrames(EventInfo eventInfo) {
 
   long i_start = 0;
   if (eventInfo.header.eventCount() > 0) {
-    LOG(DEBUG) << "Using offset [" << mTimestampOfFirstData[0] + mEventSynchronizer->getEventOffset(eventInfo.header.eventCount()) << "] "
+    LOG(debug) << "Using offset [" << mTimestampOfFirstData[0] + mEventSynchronizer->getEventOffset(eventInfo.header.eventCount()) << "] "
                << "instead of [" << eventInfo.header.timeStamp() << "] "
-               << " (diff = " << mTimestampOfFirstData[0] + mEventSynchronizer->getEventOffset(eventInfo.header.eventCount()) - eventInfo.header.timeStamp() << ") "
-               << FairLogger::endl;
+               << " (diff = " << mTimestampOfFirstData[0] + mEventSynchronizer->getEventOffset(eventInfo.header.eventCount()) - eventInfo.header.timeStamp() << ") ";
 
     i_start = mTimestampOfFirstData[0] + mEventSynchronizer->getEventOffset(eventInfo.header.eventCount()) - eventInfo.header.timeStamp() -1;
     i_start *= indexStep;
   }
 
-  LOG(DEBUG) << "Start index for Event " << eventInfo.header.eventCount() << " is " << i_start << FairLogger::endl;
+  LOG(debug) << "Start index for Event " << eventInfo.header.eventCount() << " is " << i_start;
 
   GBTFrame frame;
   if (eventInfo.header.eventCount() > 0) frame.setData(words[i_start-indexStep],words[i_start-indexStep+1],words[i_start-indexStep+2],words[i_start-indexStep+3]);
@@ -418,17 +417,17 @@ bool RawReader::decodeRawGBTFrames(EventInfo eventInfo) {
       if (mSyncPos[4] >= 0) adcClockFound[2] = adcClockFound[2] | !adcCheckErr2;
       if(adcClockFound[0] & adcCheckErr0) {
         adcClockFound[0] = false;
-        LOG(DEBUG) << "ADC clock error of SAMPA " << ((mRegion%2) ? 3 : 0) << " in frame [" << i/indexStep << "]"  << FairLogger::endl;
+        LOG(debug) << "ADC clock error of SAMPA " << ((mRegion % 2) ? 3 : 0) << " in frame [" << i / indexStep << "]";
         mAdcError->emplace_back(std::make_tuple((mRegion%2) ? 3 : 0,i,mSyncPos[0]));
       };
       if(adcClockFound[1] & adcCheckErr1) {
         adcClockFound[1] = false;
-        LOG(DEBUG) << "ADC clock error of SAMPA " << ((mRegion%2) ? 4 : 1) << " in frame [" << i/indexStep << "]"  << FairLogger::endl;
+        LOG(debug) << "ADC clock error of SAMPA " << ((mRegion % 2) ? 4 : 1) << " in frame [" << i / indexStep << "]";
         mAdcError->emplace_back(std::make_tuple((mRegion%2) ? 4 : 1,i,mSyncPos[2]));
       };
       if(adcClockFound[2] & adcCheckErr2) {
         adcClockFound[2] = false;
-        LOG(DEBUG) << "ADC clock error of SAMPA " << 2 << " in frame [" << i/indexStep << "]"  << FairLogger::endl;
+        LOG(debug) << "ADC clock error of SAMPA " << 2 << " in frame [" << i / indexStep << "]";
         mAdcError->emplace_back(std::make_tuple(2,i,mSyncPos[4]));
       };
     }
@@ -437,16 +436,17 @@ bool RawReader::decodeRawGBTFrames(EventInfo eventInfo) {
     short value2;
     for (short iHalfSampa = 0; iHalfSampa < 5; ++iHalfSampa) {
       if (mSyncPos[iHalfSampa] < 0 ) {
-        LOG(DEBUG1) << "Sync pattern for half SAMPA " << iHalfSampa << " not yet found" << FairLogger::endl;
+        LOG(debug1) << "Sync pattern for half SAMPA " << iHalfSampa << " not yet found";
         continue;
       }
       if (lastSyncPos[iHalfSampa] < 0 ) {
-        LOG(DEBUG1) << "Sync pattern for half SAMPA " << iHalfSampa << " not yet found" << FairLogger::endl;
-        LOG(DEBUG1) << lastFrame << FairLogger::endl;
+        LOG(debug1) << "Sync pattern for half SAMPA " << iHalfSampa << " not yet found";
+        LOG(debug1) << lastFrame;
         continue;
       }
       if (mTimestampOfFirstData[iHalfSampa] == 0) {
-        if(iHalfSampa == 0) LOG(DEBUG) << "Setting timestamp of first data to " << eventInfo.header.timeStamp() + 1 + i/indexStep << " for half SAMPA " << iHalfSampa << " (" << 1 + i/indexStep << ")" << FairLogger::endl;
+        if (iHalfSampa == 0)
+          LOG(debug) << "Setting timestamp of first data to " << eventInfo.header.timeStamp() + 1 + i / indexStep << " for half SAMPA " << iHalfSampa << " (" << 1 + i / indexStep << ")";
         mTimestampOfFirstData[iHalfSampa] = eventInfo.header.timeStamp() + 1 + i/indexStep;
       }
 

--- a/Detectors/TPC/reconstruction/src/TPCCATracking.cxx
+++ b/Detectors/TPC/reconstruction/src/TPCCATracking.cxx
@@ -13,7 +13,7 @@
 
 #include "TPCReconstruction/TPCCATracking.h"
 
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 #include "ReconstructionDataFormats/Track.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"

--- a/Detectors/TPC/reconstruction/test/testTPCFastTransform.cxx
+++ b/Detectors/TPC/reconstruction/test/testTPCFastTransform.cxx
@@ -26,7 +26,7 @@
 #include "DataFormatsTPC/Defs.h"
 #include "TPCFastTransform.h"
 #include "Riostream.h"
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 
 #include <vector>
 #include <iostream>

--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitizerTask.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitizerTask.h
@@ -17,7 +17,7 @@
 
 #include <cstdio>
 #include <string>
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 #include "FairTask.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
 #include "TPCBase/Sector.h"
@@ -162,12 +162,12 @@ class DigitizerTask : public FairTask
 
 inline void DigitizerTask::setDebugOutput(TString debugString)
 {
-  LOG(INFO) << "TPC - Debug output enabled for: ";
+  LOG(info) << "TPC - Debug output enabled for: ";
   if (debugString.Contains("DigitMCDebug")) {
-    LOG(INFO) << "DigitMC, ";
+    LOG(info) << "DigitMC, ";
     mDigitDebugOutput = true;
   }
-  LOG(INFO) << "\n";
+  LOG(info) << "\n";
 }
 
 inline void DigitizerTask::setContinuousReadout(bool isContinuous)

--- a/Detectors/TPC/simulation/src/Digitizer.cxx
+++ b/Detectors/TPC/simulation/src/Digitizer.cxx
@@ -26,7 +26,7 @@
 
 #include "TPCBase/Mapper.h"
 
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 
 ClassImp(o2::TPC::Digitizer)
 

--- a/Detectors/TPC/simulation/src/GEMAmplification.cxx
+++ b/Detectors/TPC/simulation/src/GEMAmplification.cxx
@@ -18,7 +18,7 @@
 #include <TFile.h>
 #include "TPCBase/CDBInterface.h"
 #include <fstream>
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 
 using namespace o2::TPC;
 using boost::format;
@@ -46,10 +46,10 @@ GEMAmplification::GEMAmplification()
   TFile* outfile;
   auto cacheexists = fileexists(polyaFileName);
   if (cacheexists) {
-    LOG(INFO) << "TPC GEM SETUP FROM EXISTING CACHE";
+    LOG(info) << "TPC GEM SETUP FROM EXISTING CACHE";
     outfile = TFile::Open(polyaFileName);
   } else {
-    LOG(INFO) << "TPC GEM SETUP : INITIALIZATION FROM SCRATCH";
+    LOG(info) << "TPC GEM SETUP : INITIALIZATION FROM SCRATCH";
     outfile = TFile::Open(polyaFileName, "CREATE");
   }
 
@@ -80,7 +80,7 @@ GEMAmplification::GEMAmplification()
   mRandomGaus.initialize(RandomRing::RandomType::Gaus);
   mRandomFlat.initialize(RandomRing::RandomType::Flat);
   watch.Stop();
-  LOG(INFO) << "TPC GEM SETUP (POLYA-DISTRIBUTION) TOOK " << watch.CpuTime();
+  LOG(info) << "TPC GEM SETUP (POLYA-DISTRIBUTION) TOOK " << watch.CpuTime();
 }
 
 GEMAmplification::~GEMAmplification() = default;

--- a/Detectors/TPC/simulation/src/SAMPAProcessing.cxx
+++ b/Detectors/TPC/simulation/src/SAMPAProcessing.cxx
@@ -19,7 +19,7 @@
 #include <iostream>
 #include <sstream>
 #include <string>
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 
 using namespace o2::TPC;
 

--- a/Detectors/TPC/simulation/test/testTPCSAMPAProcessing.cxx
+++ b/Detectors/TPC/simulation/test/testTPCSAMPAProcessing.cxx
@@ -23,7 +23,7 @@
 #include <iostream>
 #include <sstream>
 #include <string>
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 
 namespace o2
 {


### PR DESCRIPTION
Usage of `FairLogger.h` from FairRoot has been deperecated in favour of
`fairlogger/Logger.h` from the standalone
https://github.com/FairRootGroup/FairLogger package.