### PR TITLE
Use FairLogger standalone package in Detectors/TOF

### DIFF
--- a/Detectors/TOF/base/src/Geo.cxx
+++ b/Detectors/TOF/base/src/Geo.cxx
@@ -11,7 +11,7 @@
 #include "TOFBase/Geo.h"
 #include "TGeoManager.h"
 #include "TMath.h"
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 #include "DetectorsBase/GeometryManager.h"
 
 ClassImp(o2::tof::Geo);
@@ -30,7 +30,7 @@ Float_t Geo::mRotationMatrixPlateStrip[NPLATES][NMAXNSTRIP][3][3];
 
 void Geo::Init()
 {
-  LOG(INFO) << "tof::Geo: Initialization of TOF rotation parameters";
+  LOG(info) << "tof::Geo: Initialization of TOF rotation parameters";
 
   Double_t rotationAngles[6] =
     { 90., 90. /*+ (isector + 0.5) * PHISEC*/, 0., 0., 90., 0 /* + (isector + 0.5) * PHISEC*/ };
@@ -158,7 +158,7 @@ void Geo::getPos(Int_t* det, Float_t* pos)
   Char_t path[200];
   getVolumePath(det, path);
   if (!gGeoManager) {
-    LOG(ERROR) << " no TGeo! Loading it"
+    LOG(error) << " no TGeo! Loading it"
                << "\n";
     o2::Base::GeometryManager::loadGeometry();
   }
@@ -290,14 +290,16 @@ Int_t Geo::getStripNumberPerSM(Int_t iplate, Int_t istrip)
                   );
 
   if (iplate<0 || iplate>=NPLATES)
-    LOG(ERROR) << "getStripNumberPerSM : " << "Wrong plate number in TOF (" << iplate << ")!\n";
+    LOG(error) << "getStripNumberPerSM : "
+               << "Wrong plate number in TOF (" << iplate << ")!\n";
 
   if (
       (iplate==2 && (istrip<0 || istrip>=NSTRIPA))
       ||
       (iplate!=2 && (istrip<0 || istrip>=NSTRIPC))
       )
-    LOG(ERROR) << "getStripNumberPerSM : " << " Wrong strip number in TOF (strip=" << istrip << " in the plate= " << iplate << ")!\n";
+    LOG(error) << "getStripNumberPerSM : "
+               << " Wrong strip number in TOF (strip=" << istrip << " in the plate= " << iplate << ")!\n";
 
   Int_t stripOffset = 0;
   switch (iplate) {
@@ -327,7 +329,7 @@ Int_t Geo::getStripNumberPerSM(Int_t iplate, Int_t istrip)
 void Geo::fromGlobalToSector(Float_t* pos, Int_t isector)
 {
   if (isector == -1) {
-    //LOG(ERROR) << "Sector Index not valid (-1)\n";
+    //LOG(error) << "Sector Index not valid (-1)\n";
     return;
   }
 

--- a/Detectors/TOF/base/test/testTOFIndex.cxx
+++ b/Detectors/TOF/base/test/testTOFIndex.cxx
@@ -11,7 +11,7 @@
 #define BOOST_TEST_MODULE Test TOFIndex
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
-#include "FairLogger.h" // for FairLogger
+#include <fairlogger/Logger.h> // for FairLogger
 #include "TOFBase/Geo.h"
 #include <TRandom.h>
 #include <TStopwatch.h>
@@ -76,12 +76,12 @@ BOOST_AUTO_TEST_CASE(testTOFIndex) {
                                                          << " --> out:"
                                                          << indextofTest[4]);
             // if (locError && j == 1 && k == 3) {
-            LOG(INFO) << "in:" << indextof[0] << ", " << indextof[1] << ", "
+            LOG(info) << "in:" << indextof[0] << ", " << indextof[1] << ", "
                       << indextof[2] << ", " << indextof[3] << ", "
                       << indextof[4] << " --> out:" << indextofTest[0] << ", "
                       << indextofTest[1] << ", " << indextofTest[2] << ", "
                       << indextofTest[3] << ", " << indextofTest[4]
-                      << " (ch=" << chan << ")" << FairLogger::endl;
+                      << " (ch=" << chan << ")";
             // }
           }
         }

--- a/Detectors/TOF/reconstruction/src/Clusterer.cxx
+++ b/Detectors/TOF/reconstruction/src/Clusterer.cxx
@@ -11,7 +11,7 @@
 /// \file Clusterer.cxx
 /// \brief Implementation of the TOF cluster finder
 #include <algorithm>
-#include "FairLogger.h" // for LOG
+#include <fairlogger/Logger.h> // for LOG
 #include "DataFormatsTOF/Cluster.h"
 #include "TOFReconstruction/Clusterer.h"
 #include "SimulationDataFormat/MCCompLabel.h"
@@ -26,14 +26,14 @@ void Clusterer::process(DataReader& reader, std::vector<Cluster>& clusters, MCLa
   int totNumDigits = 0;
 
   while (reader.getNextStripData(mStripData)) {
-    LOG(DEBUG) << "TOFClusterer got Strip " << mStripData.stripID << " with Ndigits "
+    LOG(debug) << "TOFClusterer got Strip " << mStripData.stripID << " with Ndigits "
                << mStripData.digits.size();
     totNumDigits += mStripData.digits.size();
 
     processStrip(clusters, digitMCTruth);
   }
 
-  LOG(DEBUG) << "We had " << totNumDigits << " digits in this event";
+  LOG(debug) << "We had " << totNumDigits << " digits in this event";
 }
 
 //__________________________________________________
@@ -48,7 +48,7 @@ void Clusterer::processStrip(std::vector<Cluster>& clusters, MCLabelContainer co
   Int_t ieta, ieta2, ieta3; // it is the number of padz-row increasing along the various strips
 
   for (int idig = 0; idig < mStripData.digits.size(); idig++) {
-    //    LOG(DEBUG) << "Checking digit " << idig;
+    //    LOG(debug) << "Checking digit " << idig;
     Digit* dig = &mStripData.digits[idig];
     if (dig->isUsedInCluster())
       continue; // the digit was already used to build a cluster
@@ -56,11 +56,11 @@ void Clusterer::processStrip(std::vector<Cluster>& clusters, MCLabelContainer co
     mNumberOfContributingDigits = 0;
     dig->getPhiAndEtaIndex(iphi, ieta);
     if (mStripData.digits.size() > 1)
-      LOG(DEBUG) << "idig = " << idig;
+      LOG(debug) << "idig = " << idig;
 
     // first we make a cluster out of the digit
     int noc = clusters.size();
-    //    LOG(DEBUG) << "noc = " << noc << "\n";
+    //    LOG(debug) << "noc = " << noc << "\n";
     clusters.emplace_back();
     Cluster& c = clusters[noc];
     addContributingDigit(dig);
@@ -72,14 +72,14 @@ void Clusterer::processStrip(std::vector<Cluster>& clusters, MCLabelContainer co
         continue; // the digit was already used to build a cluster
       // check if the TOF time are close enough to be merged; if not, it means that nothing else will contribute to the cluster (since digits are ordered in time)
       float timeDigNext = digNext->getTDC() * Geo::TDCBIN; // we assume it calibrated (for now); in ps
-      LOG(DEBUG) << "Time difference = " << timeDigNext - timeDig;
+      LOG(debug) << "Time difference = " << timeDigNext - timeDig;
       if (timeDigNext - timeDig > 500 /*in ps*/)
         break;
       digNext->getPhiAndEtaIndex(iphi2, ieta2);
 
       // check if the fired pad are close in space
-      LOG(DEBUG) << "phi difference = " << iphi - iphi2;
-      LOG(DEBUG) << "eta difference = " << ieta - ieta2;
+      LOG(debug) << "phi difference = " << iphi - iphi2;
+      LOG(debug) << "eta difference = " << ieta - ieta2;
       if ((TMath::Abs(iphi - iphi2) > 1) || (TMath::Abs(ieta - ieta2) > 1))
         continue;
 
@@ -99,7 +99,7 @@ void Clusterer::addContributingDigit(Digit* dig)
   // adding a digit to the array that stores the contributing ones
 
   if (mNumberOfContributingDigits == 6) {
-    LOG(ERROR) << "The cluster has already 6 digits associated to it, we cannot add more; returning without doing anything";
+    LOG(error) << "The cluster has already 6 digits associated to it, we cannot add more; returning without doing anything";
   }
   mContributingDigit[mNumberOfContributingDigits] = dig;
   mNumberOfContributingDigits++;
@@ -165,10 +165,10 @@ void Clusterer::buildCluster(Cluster& c, MCLabelContainer const* digitMCTruth)
       } else if (deltaEta == -1) { // the digit is UP wrt the cluster
         mask = Cluster::kUp;
       } else { // impossible!!
-        LOG(DEBUG) << " Check what is going on, the digit you are trying to merge to the cluster must be in a different channels... ";
+        LOG(debug) << " Check what is going on, the digit you are trying to merge to the cluster must be in a different channels... ";
       }
     } else { // impossible!!! We checked above...
-      LOG(DEBUG) << " Check what is going on, the digit you are trying to merge to the cluster is too far from the cluster, you should have not got here... ";
+      LOG(debug) << " Check what is going on, the digit you are trying to merge to the cluster is too far from the cluster, you should have not got here... ";
     }
     c.addBitInContributingChannels(mask);
   }

--- a/Detectors/TOF/reconstruction/src/ClustererTask.cxx
+++ b/Detectors/TOF/reconstruction/src/ClustererTask.cxx
@@ -17,7 +17,7 @@
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
 
-#include "FairLogger.h"      // for LOG
+#include <fairlogger/Logger.h> // for LOG
 #include "FairRootManager.h" // for FairRootManager
 
 ClassImp(o2::tof::ClustererTask);
@@ -50,13 +50,13 @@ InitStatus ClustererTask::Init()
 {
   FairRootManager* mgr = FairRootManager::Instance();
   if (!mgr) {
-    LOG(ERROR) << "Could not instantiate FairRootManager. Exiting ..." << FairLogger::endl;
+    LOG(error) << "Could not instantiate FairRootManager. Exiting ...";
     return kERROR;
   }
 
   const std::vector<o2::tof::Digit>* arr = mgr->InitObjectAs<const std::vector<o2::tof::Digit>*>("TOFDigit");
   if (!arr) {
-    LOG(ERROR) << "TOF digits not registered in the FairRootManager. Exiting ..." << FairLogger::endl;
+    LOG(error) << "TOF digits not registered in the FairRootManager. Exiting ...";
     return kERROR;
   }
   mReader.setDigitArray(arr);
@@ -65,7 +65,7 @@ InitStatus ClustererTask::Init()
     mDigitMCTruth =
       mgr->InitObjectAs<const dataformats::MCTruthContainer<MCCompLabel>*>("TOFDigitMCTruth");
     if (!mDigitMCTruth) {
-      LOG(ERROR) << "TOF MC Truth not registered in the FairRootManager. Exiting ..." << FairLogger::endl;
+      LOG(error) << "TOF MC Truth not registered in the FairRootManager. Exiting ...";
       return kERROR;
     }
   }
@@ -89,7 +89,7 @@ void ClustererTask::Exec(Option_t* option)
     mClustersArray->clear();
   if (mClsLabels)
     mClsLabels->clear();
-  LOG(DEBUG) << "Running clusterization on new event" << FairLogger::endl;
+  LOG(debug) << "Running clusterization on new event";
 
   mClusterer.process(mReader, *mClustersArray, mDigitMCTruth);
 }

--- a/Detectors/TOF/reconstruction/src/DataReader.cxx
+++ b/Detectors/TOF/reconstruction/src/DataReader.cxx
@@ -14,7 +14,7 @@
 #include "TOFReconstruction/DataReader.h"
 #include "TOFBase/Geo.h"
 #include <algorithm>
-#include "FairLogger.h" // for LOG
+#include <fairlogger/Logger.h> // for LOG
 
 using namespace o2::tof;
 using o2::tof::Digit;

--- a/Detectors/TOF/simulation/src/Detector.cxx
+++ b/Detectors/TOF/simulation/src/Detector.cxx
@@ -12,7 +12,7 @@
 #include "TMath.h"
 #include "TString.h"
 
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 #include "FairVolume.h"
 #include "FairRootManager.h"
 
@@ -69,7 +69,7 @@ Bool_t Detector::ProcessHits(FairVolume* v)
   float pos2x, pos2y, pos2z;
   fMC->TrackPosition(pos2x, pos2y, pos2z);
   Float_t radius = std::sqrt(pos2x * pos2x + pos2y * pos2y);
-  LOG(DEBUG) << "Process hit in TOF volume ar R=" << radius << " - Z=" << pos2z;
+  LOG(debug) << "Process hit in TOF volume ar R=" << radius << " - Z=" << pos2z;
 
   Float_t enDep = fMC->Edep();
   if (enDep < 1E-8)
@@ -93,7 +93,7 @@ Bool_t Detector::ProcessHits(FairVolume* v)
     stack->addHit(GetDetId());
   } else {
     mHits->back().SetEnergyLoss(mHits->back().GetEnergyLoss() + newhit.GetEnergyLoss());
-    // LOG(INFO)<<"Merging hit "<<"\n";
+    // LOG(info)<<"Merging hit "<<"\n";
     //  <<mHits->back().GetId()<<"with new hit "<<newhit.GetId()<<"\n";
   }
   mLastChannelID = channel;
@@ -302,7 +302,7 @@ void Detector::ConstructGeometry()
   Float_t xTof = Geo::STRIPLENGTH + 2.5, yTof = Geo::RMAX - Geo::RMIN, zTof = Geo::ZLENA;
   DefineGeometry(xTof, yTof, zTof);
 
-  LOG(INFO) << "Loaded TOF geometry";
+  LOG(info) << "Loaded TOF geometry";
 }
 
 void Detector::EndOfEvent() { Reset(); }
@@ -1857,7 +1857,7 @@ void Detector::addAlignableVolumes() const
   for (Int_t isect = 0; isect < Geo::NSECTORS; isect++) {
     for (Int_t istr = 1; istr <= Geo::NSTRIPXSECTOR; istr++) {
       modUID = o2::Base::GeometryManager::getSensID(idTOF, modnum++);
-      LOG(DEBUG) << "modUID: " << modUID;
+      LOG(debug) << "modUID: " << modUID;
 
       if (mTOFSectors[isect] == -1)
         continue;
@@ -1890,24 +1890,24 @@ void Detector::addAlignableVolumes() const
       symName += snSTRIP;
       symName += Form("%02d", istr);
 
-      LOG(DEBUG) << "--------------------------------------------"
+      LOG(debug) << "--------------------------------------------"
                  << "\n";
-      LOG(DEBUG) << "Alignable object" << imod << "\n";
-      LOG(DEBUG) << "volPath=" << volPath << "\n";
-      LOG(DEBUG) << "symName=" << symName << "\n";
-      LOG(DEBUG) << "--------------------------------------------"
+      LOG(debug) << "Alignable object" << imod << "\n";
+      LOG(debug) << "volPath=" << volPath << "\n";
+      LOG(debug) << "symName=" << symName << "\n";
+      LOG(debug) << "--------------------------------------------"
                  << "\n";
 
-      LOG(DEBUG) << "Check for alignable entry: " << symName;
+      LOG(debug) << "Check for alignable entry: " << symName;
 
       if (!gGeoManager->SetAlignableEntry(symName.Data(), volPath.Data(), modUID)) {
-        LOG(ERROR) << "Alignable entry " << symName << " NOT set";
+        LOG(error) << "Alignable entry " << symName << " NOT set";
       }
-      LOG(DEBUG) << "Alignable entry " << symName << " set";
+      LOG(debug) << "Alignable entry " << symName << " set";
 
       // T2L matrices for alignment
       TGeoPNEntry* e = gGeoManager->GetAlignableEntryByUID(modUID);
-      LOG(DEBUG) << "Got TGeoPNEntry " << e;
+      LOG(debug) << "Got TGeoPNEntry " << e;
 
       if (e) {
         TGeoHMatrix* globMatrix = e->GetGlobalOrig();

--- a/Detectors/TOF/simulation/src/DigitizerTask.cxx
+++ b/Detectors/TOF/simulation/src/DigitizerTask.cxx
@@ -14,7 +14,7 @@
 #include "TOFSimulation/DigitizerTask.h"
 #include "MathUtils/Utils.h"
 
-#include "FairLogger.h"      // for LOG
+#include <fairlogger/Logger.h> // for LOG
 #include "FairRootManager.h" // for FairRootManager
 
 ClassImp(o2::tof::DigitizerTask);
@@ -35,13 +35,13 @@ InitStatus DigitizerTask::Init()
 {
   FairRootManager* mgr = FairRootManager::Instance();
   if (!mgr) {
-    LOG(ERROR) << "Could not instantiate FairRootManager. Exiting ..." << FairLogger::endl;
+    LOG(error) << "Could not instantiate FairRootManager. Exiting ...";
     return kERROR;
   }
 
   mHitsArray = mgr->InitObjectAs<const std::vector<o2::tof::HitType>*>("TOFHit");
   if (!mHitsArray) {
-    LOG(ERROR) << "TOF hits not registered in the FairRootManager. Exiting ..." << FairLogger::endl;
+    LOG(error) << "TOF hits not registered in the FairRootManager. Exiting ...";
     return kERROR;
   }
 
@@ -78,14 +78,14 @@ void DigitizerTask::Exec(Option_t* option)
   mDigitizer.setMCTruthContainer(mMCTruthArray);
 
   // the type of digitization is steered by the DigiParams object of the Digitizer
-  LOG(DEBUG) << "Running digitization on new event " << mEventID << " from source " << mSourceID << FairLogger::endl;
+  LOG(debug) << "Running digitization on new event " << mEventID << " from source " << mSourceID;
 
   /// RS: ATTENTION: this is just a trick until we clarify how the hits from different source are
   /// provided and identified.
   mDigitizer.setSrcID(mSourceID);
   mDigitizer.setEventID(mEventID);
 
-  LOG(INFO) << "Digitizing " << mHitsArray->size() << " hits \n";
+  LOG(info) << "Digitizing " << mHitsArray->size() << " hits \n";
   mDigitizer.process(mHitsArray, mDigitsArray);
 
   mEventID++;


### PR DESCRIPTION
Usage of `FairLogger.h` from FairRoot has been deperecated in favour of
`fairlogger/Logger.h` from the standalone
https://github.com/FairRootGroup/FairLogger package.