### PR TITLE
Use FairLogger standalone package in Detectors/PHOS

### DIFF
--- a/Detectors/PHOS/reconstruction/src/Clusterer.cxx
+++ b/Detectors/PHOS/reconstruction/src/Clusterer.cxx
@@ -16,7 +16,7 @@
 #include "PHOSBase/Geometry.h"
 #include "PHOSBase/Digit.h"
 
-#include "FairLogger.h" // for LOG
+#include <fairlogger/Logger.h> // for LOG
 
 using namespace o2::phos;
 
@@ -33,7 +33,7 @@ void Clusterer::process(const std::vector<Digit>* digits, std::vector<Cluster>* 
   // Collect digits to clusters
   MakeClusters(digits, clusters);
 
-  LOG(DEBUG) << "Number of PHOS clusters" << clusters->size() << FairLogger::endl;
+  LOG(debug) << "Number of PHOS clusters" << clusters->size();
 
   // Unfold overlapped clusters
   // TODO:
@@ -41,7 +41,7 @@ void Clusterer::process(const std::vector<Digit>* digits, std::vector<Cluster>* 
 
   // Calculate properties of collected clusters (Local position, energy, disp etc.)
   EvalCluProperties(digits, clusters);
-  LOG(DEBUG) << "PHOS clustrization done" << FairLogger::endl;
+  LOG(debug) << "PHOS clustrization done";
 }
 //____________________________________________________________________________
 void Clusterer::MakeClusters(const std::vector<Digit>* digits, std::vector<Cluster>* clusters)
@@ -117,20 +117,19 @@ void Clusterer::MakeClusters(const std::vector<Digit>* digits, std::vector<Clust
 void Clusterer::EvalCluProperties(const std::vector<Digit>* digits, std::vector<Cluster>* clusters)
 {
   const double kThreshold = 0.020; // TODO: Should be in RecoParams
-  LOG(DEBUG) << "EvalCluProperties: nclu=" << clusters->size() << FairLogger::endl;
+  LOG(debug) << "EvalCluProperties: nclu=" << clusters->size();
 
   for (int i = 0; i < clusters->size(); i++) {
-    LOG(DEBUG) << "   i=" << i << FairLogger::endl;
+    LOG(debug) << "   i=" << i;
 
     Cluster* clu = &(clusters->at(i));
-    LOG(DEBUG) << " clu=" << clu << FairLogger::endl;
+    LOG(debug) << " clu=" << clu;
 
     clu->Purify(kThreshold);
-    //  LOG(DEBUG) << "Purify done" << FairLogger::endl;
+    //  LOG(debug) << "Purify done";
     clu->EvalAll(digits);
     double PosX, PosZ;
     clu->GetLocalPosition(PosX, PosZ);
-    LOG(DEBUG) << "EvalALl done: clu E=" << clu->GetEnergy() << " pos = (" << PosX << "," << PosZ << ")"
-               << FairLogger::endl;
+    LOG(debug) << "EvalALl done: clu E=" << clu->GetEnergy() << " pos = (" << PosX << "," << PosZ << ")";
   }
 }

--- a/Detectors/PHOS/reconstruction/src/ClustererTask.cxx
+++ b/Detectors/PHOS/reconstruction/src/ClustererTask.cxx
@@ -11,7 +11,7 @@
 /// \file  ClustererTask.cxx
 /// \brief Implementation of the PHOS cluster finder task
 
-#include "FairLogger.h"      // for LOG
+#include <fairlogger/Logger.h> // for LOG
 #include "FairRootManager.h" // for FairRootManager
 #include "PHOSReconstruction/ClustererTask.h"
 #include "PHOSReconstruction/Clusterer.h"
@@ -48,13 +48,13 @@ InitStatus ClustererTask::Init()
 {
   FairRootManager* mgr = FairRootManager::Instance();
   if (!mgr) {
-    LOG(ERROR) << "Could not instantiate FairRootManager. Exiting ..." << FairLogger::endl;
+    LOG(error) << "Could not instantiate FairRootManager. Exiting ...";
     return kERROR;
   }
 
   mDigitsArray = mgr->InitObjectAs<const std::vector<o2::phos::Digit>*>("PHSDigit");
   if (!mDigitsArray) {
-    LOG(ERROR) << "PHOS digits not registered in the FairRootManager. Exiting ..." << FairLogger::endl;
+    LOG(error) << "PHOS digits not registered in the FairRootManager. Exiting ...";
     return kERROR;
   }
 
@@ -72,7 +72,7 @@ void ClustererTask::Exec(Option_t* option)
 {
   if (mClustersArray)
     mClustersArray->clear();
-  LOG(DEBUG) << "Running clusterization on new event" << FairLogger::endl;
+  LOG(debug) << "Running clusterization on new event";
 
   mClusterer->process(mDigitsArray, mClustersArray);
 }

--- a/Detectors/PHOS/simulation/src/DigitizerTask.cxx
+++ b/Detectors/PHOS/simulation/src/DigitizerTask.cxx
@@ -14,7 +14,7 @@
 #include "PHOSBase/Hit.h"
 #include "PHOSSimulation/Digitizer.h"
 
-#include "FairLogger.h"      // for LOG
+#include <fairlogger/Logger.h> // for LOG
 #include "FairRootManager.h" // for FairRootManager
 #include "FairTask.h"        // for FairTask, InitStatus
 #include "Rtypes.h"          // for DigitizerTask::Class, ClassDef, etc
@@ -43,13 +43,13 @@ InitStatus DigitizerTask::Init()
 {
   FairRootManager* mgr = FairRootManager::Instance();
   if (!mgr) {
-    LOG(ERROR) << "Could not instantiate FairRootManager. Exiting ..." << FairLogger::endl;
+    LOG(error) << "Could not instantiate FairRootManager. Exiting ...";
     return kERROR;
   }
 
   mHitsArray = mgr->InitObjectAs<const std::vector<o2::phos::Hit>*>("PHSHit");
   if (!mHitsArray) {
-    LOG(ERROR) << "PHOS hits not registered in the FairRootManager. Exiting ..." << FairLogger::endl;
+    LOG(error) << "PHOS hits not registered in the FairRootManager. Exiting ...";
     return kERROR;
   }
 
@@ -72,7 +72,7 @@ void DigitizerTask::Exec(Option_t* option)
     mDigitsArray->clear();
   mDigitizer.setEventTime(mgr->GetEventTime());
 
-  LOG(DEBUG) << "Running digitization on new event " << mEventID << " from source " << mSourceID << FairLogger::endl;
+  LOG(debug) << "Running digitization on new event " << mEventID << " from source " << mSourceID;
   mDigitizer.setCurrSrcID(mSourceID);
   mDigitizer.setCurrEvID(mEventID);
 

--- a/Detectors/PHOS/testsimulation/plot_clu_phos.C
+++ b/Detectors/PHOS/testsimulation/plot_clu_phos.C
@@ -6,7 +6,7 @@
 #include "TH2.h"
 //#include "DataFormatsParameters/GRPObject.h"
 #include "FairFileSource.h"
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 #include "FairRunAna.h"
 //#include "FairRuntimeDb.h"
 #include "FairParRootFileIo.h"

--- a/Detectors/PHOS/testsimulation/plot_dig_phos.C
+++ b/Detectors/PHOS/testsimulation/plot_dig_phos.C
@@ -6,7 +6,7 @@
 #include "TH2.h"
 //#include "DataFormatsParameters/GRPObject.h"
 #include "FairFileSource.h"
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 #include "FairRunAna.h"
 //#include "FairRuntimeDb.h"
 #include "FairParRootFileIo.h"

--- a/Detectors/PHOS/testsimulation/plot_hit_phos.C
+++ b/Detectors/PHOS/testsimulation/plot_hit_phos.C
@@ -6,7 +6,7 @@
 #include "TH2.h"
 //#include "DataFormatsParameters/GRPObject.h"
 #include "FairFileSource.h"
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 #include "FairRunAna.h"
 //#include "FairRuntimeDb.h"
 #include "FairParRootFileIo.h"

--- a/Detectors/PHOS/testsimulation/run_clu_phos.C
+++ b/Detectors/PHOS/testsimulation/run_clu_phos.C
@@ -4,7 +4,7 @@
 #include <TStopwatch.h>
 //#include "DataFormatsParameters/GRPObject.h"
 #include "FairFileSource.h"
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 #include "FairRunAna.h"
 //#include "FairRuntimeDb.h"
 #include "FairParRootFileIo.h"
@@ -17,10 +17,10 @@ void run_clu_phos(std::string outputfile = "o2clu.root", std::string inputfile =
                   std::string paramfile = "AliceO2_TGeant3.phos.params_10.root")
 {
   // Initialize logger
-  FairLogger* logger = FairLogger::GetLogger();
-  logger->SetLogVerbosityLevel("LOW");
-  //  logger->SetLogScreenLevel("INFO");
-  logger->SetLogScreenLevel("DEBUG");
+
+  fair::Logger::SetVerbosity("LOW");
+  //  fair::Logger::SetConsoleSeverity("INFO");
+  fair::Logger::SetConsoleSeverity("DEBUG");
 
   // Setup timer
   TStopwatch timer;

--- a/Detectors/PHOS/testsimulation/run_digi_phos.C
+++ b/Detectors/PHOS/testsimulation/run_digi_phos.C
@@ -4,7 +4,7 @@
 #include <TStopwatch.h>
 //#include "DataFormatsParameters/GRPObject.h"
 #include "FairFileSource.h"
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 #include "FairRunAna.h"
 //#include "FairRuntimeDb.h"
 #include "FairParRootFileIo.h"
@@ -22,10 +22,10 @@ void run_digi_phos(std::string outputfile = "o2dig.root",
   // if rate>0 then continuous simulation for this rate will be performed
 
   // Initialize logger
-  FairLogger* logger = FairLogger::GetLogger();
-  logger->SetLogVerbosityLevel("LOW");
-  //  logger->SetLogScreenLevel("INFO");
-  logger->SetLogScreenLevel("DEBUG");
+
+  fair::Logger::SetVerbosity("LOW");
+  //  fair::Logger::SetConsoleSeverity("INFO");
+  fair::Logger::SetConsoleSeverity("DEBUG");
 
   // Setup timer
   TStopwatch timer;


### PR DESCRIPTION
Usage of `FairLogger.h` from FairRoot has been deperecated in favour of
`fairlogger/Logger.h` from the standalone
https://github.com/FairRootGroup/FairLogger package.