### PR TITLE
Use FairLogger standalone package in Detectors/MUON

### DIFF
--- a/Detectors/MUON/MID/Base/src/GeometryTransformer.cxx
+++ b/Detectors/MUON/MID/Base/src/GeometryTransformer.cxx
@@ -20,7 +20,7 @@
 #include "TMath.h"
 #include "Math/GenVector/RotationX.h"
 #include "Math/GenVector/RotationY.h"
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 #include "MIDBase/Constants.h"
 
 namespace o2
@@ -63,7 +63,8 @@ void GeometryTransformer::init()
         int deId = Constants::getDEId(isRight, ichamber, irpc);
         ROOT::Math::Translation3D trans(xPos, yPos, zPos);
         mTransformations[deId] = planeTrans * planeRot * trans * rot;
-        LOG(DEBUG) << "DeID " << deId << "\n" << mTransformations[deId];
+        LOG(debug) << "DeID " << deId << "\n"
+                   << mTransformations[deId];
       }
     }
   }

--- a/Detectors/MUON/MID/Clustering/src/Clusterizer.cxx
+++ b/Detectors/MUON/MID/Clustering/src/Clusterizer.cxx
@@ -15,7 +15,7 @@
 #include "MIDClustering/Clusterizer.h"
 #include <cassert>
 
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 
 namespace o2
 {
@@ -144,11 +144,11 @@ void Clusterizer::preClusterizeNBP(PatternStruct& de)
           pc->firstColumn = icolumn;
           pc->area[icolumn] = mMapping.stripByLocation(istrip, 1, 0, icolumn, de.deId);
           limit = pc->area[icolumn].getXmax();
-          LOG(DEBUG) << "New precluster NBP: DE  " << de.deId;
+          LOG(debug) << "New precluster NBP: DE  " << de.deId;
         }
         pc->lastColumn = icolumn;
         pc->area[icolumn].setXmax(limit);
-        LOG(DEBUG) << "  adding col " << icolumn << "  strip " << istrip << "  (" << pc->area[icolumn].getXmin() << ", "
+        LOG(debug) << "  adding col " << icolumn << "  strip " << istrip << "  (" << pc->area[icolumn].getXmin() << ", "
                    << pc->area[icolumn].getXmax() << ") (" << pc->area[icolumn].getYmin() << ", "
                    << pc->area[icolumn].getYmax() << ")";
       } else {
@@ -186,10 +186,10 @@ void Clusterizer::preClusterizeBP(PatternStruct& de)
             pc->lastColumn = icolumn;
             pc->area[icolumn] = mMapping.stripByLocation(istrip, 0, iline, icolumn, de.deId);
             limit = pc->area[icolumn].getYmax();
-            LOG(DEBUG) << "New precluster BP: DE  " << de.deId << "  icolumn " << icolumn;
+            LOG(debug) << "New precluster BP: DE  " << de.deId << "  icolumn " << icolumn;
           }
           pc->area[icolumn].setYmax(limit);
-          LOG(DEBUG) << "  adding line " << iline << "  strip " << istrip << "  (" << pc->area[icolumn].getXmin()
+          LOG(debug) << "  adding line " << iline << "  strip " << istrip << "  (" << pc->area[icolumn].getXmin()
                      << ", " << pc->area[icolumn].getXmax() << ") (" << pc->area[icolumn].getYmin() << ", "
                      << pc->area[icolumn].getYmax() << ")";
         } else {
@@ -205,7 +205,7 @@ void Clusterizer::preClusterizeBP(PatternStruct& de)
 void Clusterizer::makeClusters(const int& deIndex)
 {
   /// Makes the clusters and stores it
-  LOG(DEBUG) << "Clusterizing " << deIndex;
+  LOG(debug) << "Clusterizing " << deIndex;
 
   // loop over pre-clusters in the non-bending plane
   for (int inb = 0; inb < mNPreClusters[7]; ++inb) {
@@ -223,7 +223,7 @@ void Clusterizer::makeClusters(const int& deIndex)
       // The NBP pre-cluster spans different columns.
       // The BP contour is therefore a serie of neighbour rectangles
       std::vector<std::vector<PreCluster*>> pcBneighbours;
-      LOG(DEBUG) << "Spanning non-bend: " << icolumn << " -> " << pcNB.lastColumn;
+      LOG(debug) << "Spanning non-bend: " << icolumn << " -> " << pcNB.lastColumn;
       buildListOfNeighbours(icolumn, pcNB.lastColumn, pcBneighbours);
       for (auto& pcBlist : pcBneighbours) {
         makeCluster(pcBlist, deIndex, &pcNB);
@@ -274,7 +274,7 @@ void Clusterizer::makeCluster(PreCluster& clBend, PreCluster& clNonBend, const i
   clBend.paired = 1;
   clNonBend.paired = 1;
 
-  LOG(DEBUG) << "pos: (" << cl.xCoor << ", " << cl.yCoor << ") err2: (" << cl.sigmaX2 << ", " << cl.sigmaY2 << ")";
+  LOG(debug) << "pos: (" << cl.xCoor << ", " << cl.yCoor << ") err2: (" << cl.sigmaX2 << ", " << cl.sigmaY2 << ")";
 }
 
 //______________________________________________________________________________
@@ -313,7 +313,7 @@ void Clusterizer::makeCluster(std::vector<PreCluster*>& pcBlist, const int& deIn
     }
     // area = dx * dy
     sumArea += delta[0] * delta[1];
-    LOG(DEBUG) << "Area += " << delta[0] * delta[1] << " => " << sumArea;
+    LOG(debug) << "Area += " << delta[0] * delta[1] << " => " << sumArea;
     for (int iplane = 0; iplane < 2; ++iplane) {
       for (int ip = 0; ip < 2; ++ip) {
         // second momentum = x_i * x_i * dy
@@ -321,7 +321,7 @@ void Clusterizer::makeCluster(std::vector<PreCluster*>& pcBlist, const int& deIn
         x2[iplane][ip] += currX2;
         // third momentum = x_i * x_i * x_i * dy
         x3[iplane][ip] += currX2 * dim[iplane][ip];
-        LOG(DEBUG) << "x[" << iplane << "][" << ip << "] => val " << dim[iplane][ip] << " delta " << delta[1 - iplane]
+        LOG(debug) << "x[" << iplane << "][" << ip << "] => val " << dim[iplane][ip] << " delta " << delta[1 - iplane]
                    << " => x2 " << x2[iplane][ip] << " x3 " << x3[iplane][ip];
       }
     }
@@ -340,7 +340,7 @@ void Clusterizer::makeCluster(std::vector<PreCluster*>& pcBlist, const int& deIn
   cl.sigmaX2 = (float)sigma2[0];
   cl.sigmaY2 = (float)sigma2[1];
 
-  LOG(DEBUG) << "pos: (" << cl.xCoor << ", " << cl.yCoor << ") err2: (" << cl.sigmaX2 << ", " << cl.sigmaY2 << ")";
+  LOG(debug) << "pos: (" << cl.xCoor << ", " << cl.yCoor << ") err2: (" << cl.sigmaX2 << ", " << cl.sigmaY2 << ")";
 }
 
 //______________________________________________________________________________
@@ -348,22 +348,22 @@ bool Clusterizer::buildListOfNeighbours(int icolumn, int lastColumn, std::vector
                                         bool skipPaired, int currentList)
 {
   /// Build list of neighbours
-  LOG(DEBUG) << "Building list of neighbours in (" << icolumn << ", " << lastColumn << ")";
+  LOG(debug) << "Building list of neighbours in (" << icolumn << ", " << lastColumn << ")";
   for (int jcolumn = icolumn; jcolumn <= lastColumn; ++jcolumn) {
     for (int ib = 0; ib < mNPreClusters[jcolumn]; ++ib) {
       PreCluster* pcB = &mPreClusters[jcolumn][ib];
       if (skipPaired && pcB->paired > 0) {
-        LOG(DEBUG) << "Column " << jcolumn << "  ib " << ib << "  is already paired => skipPaired";
+        LOG(debug) << "Column " << jcolumn << "  ib " << ib << "  is already paired => skipPaired";
         continue;
       }
       if (currentList >= neighbours.size()) {
         // We are starting a new series of neighbour
         // Let's make sure the pre-cluster is not already part of another list
         if (pcB->paired == 2) {
-          LOG(DEBUG) << "Column " << jcolumn << "  ib " << ib << "  is already in a list";
+          LOG(debug) << "Column " << jcolumn << "  ib " << ib << "  is already in a list";
           continue;
         }
-        LOG(DEBUG) << "New list " << currentList;
+        LOG(debug) << "New list " << currentList;
         neighbours.emplace_back(std::vector<PreCluster*>());
       }
       std::vector<PreCluster*>& neighList = neighbours[currentList];
@@ -375,7 +375,7 @@ bool Clusterizer::buildListOfNeighbours(int icolumn, int lastColumn, std::vector
           continue;
       }
       pcB->paired = 2;
-      LOG(DEBUG) << "  adding column " << jcolumn << "  ib " << ib << "  to " << currentList;
+      LOG(debug) << "  adding column " << jcolumn << "  ib " << ib << "  to " << currentList;
       neighList.push_back(pcB);
       buildListOfNeighbours(jcolumn + 1, lastColumn, neighbours, skipPaired, currentList);
       ++currentList;

--- a/Detectors/MUON/MID/Clustering/test/testClusterizer.cxx
+++ b/Detectors/MUON/MID/Clustering/test/testClusterizer.cxx
@@ -27,7 +27,7 @@
 #include <random>
 #include "MIDClustering/Clusterizer.h"
 
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 
 namespace o2
 {

--- a/Detectors/MUON/MID/Tracking/src/Tracker.cxx
+++ b/Detectors/MUON/MID/Tracking/src/Tracker.cxx
@@ -15,7 +15,7 @@
 #include "MIDTracking/Tracker.h"
 
 #include <cmath>
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 #include "MIDBase/Constants.h"
 
 namespace o2
@@ -96,7 +96,7 @@ bool Tracker::loadClusters(const std::vector<Cluster2D>& clusters)
     cl.sigmaX2 = currData.sigmaX2;
     cl.sigmaY2 = currData.sigmaY2;
 
-    LOG(DEBUG) << "deId " << deId << " pos: (" << currData.xCoor << ", " << currData.yCoor << ") err2: ("
+    LOG(debug) << "deId " << deId << " pos: (" << currData.xCoor << ", " << currData.yCoor << ") err2: ("
                << currData.sigmaX2 << ", " << currData.sigmaY2 << ") => (" << cl.position.x() << "," << cl.position.y()
                << "," << cl.position.z() << ")";
   }
@@ -162,9 +162,9 @@ bool Tracker::processSide(bool isRight, bool isInward)
           track.setClusterMatched(secondCh, getClusterId(cl2.id, deId2));
           track.setClusterMatched(3 - firstCh, 0);
           track.setClusterMatched(3 - secondCh, 0);
-          LOG(DEBUG) << deId1 << " - " << deId2;
-          LOG(DEBUG) << "Position: " << track.getPosition();
-          // LOG(DEBUG) << "Covariance: " << track.getCovarianceParameters();
+          LOG(debug) << deId1 << " - " << deId2;
+          LOG(debug) << "Position: " << track.getPosition();
+          // LOG(debug) << "Covariance: " << track.getCovarianceParameters();
           followTrack(track, isRight, isInward);
         } // loop on clusters in second plane
       }   // loop on RPCs in second plane
@@ -186,7 +186,7 @@ bool Tracker::makeTrackSeed(Track& track, const Cluster3D& cl1, const Cluster3D&
   double nonBendingImpactParamErr = std::sqrt(
     (cl1.position.z() * cl1.position.z() * cl2.sigmaX2 + cl2.position.z() * cl2.position.z() * cl1.sigmaX2) / dZ2);
   if ((nonBendingImpactParam - mSigmaCut * nonBendingImpactParamErr) > mImpactParamCut) {
-    LOG(DEBUG) << "NB slope: " << nonBendingSlope << " NB impact param: " << nonBendingImpactParam << " - " << mSigmaCut
+    LOG(debug) << "NB slope: " << nonBendingSlope << " NB impact param: " << nonBendingImpactParam << " - " << mSigmaCut
                << " * " << nonBendingImpactParamErr << " > " << mImpactParamCut;
     return false;
   }
@@ -267,7 +267,7 @@ bool Tracker::findNextCluster(const Track& track, bool isRight, bool isInward, i
         nFiredChambers = depth;
         bestChi2 = sumChi2;
         bestTrack = newTrack;
-        LOG(DEBUG) << "DeId " << deId << "  cluster " << icl << "  nFiredChambers " << nFiredChambers << "  chi2 "
+        LOG(debug) << "DeId " << deId << "  cluster " << icl << "  nFiredChambers " << nFiredChambers << "  chi2 "
                    << bestChi2;
       }
     } // loop on clusters
@@ -299,7 +299,7 @@ double Tracker::tryOneCluster(const Track& track, const Cluster3D& cluster, Trac
     double err2 = covParams[icoor] + dZ2 * covParams[icoor + 2] + 2. * dZ * covParams[icoor + 4] + cerr2[icoor];
     double distMax = mSigmaCut * std::sqrt(2. * err2) + 4.;
     if (std::abs(dist[icoor]) > distMax) {
-      LOG(DEBUG) << "Coordinate " << icoor << "  cl " << cpos[icoor] << " tr " << newPos[icoor] << " err "
+      LOG(debug) << "Coordinate " << icoor << "  cl " << cpos[icoor] << " tr " << newPos[icoor] << " err "
                  << std::sqrt(err2);
       return 2. * mMaxChi2;
     }
@@ -396,7 +396,7 @@ void Tracker::finalizeTrack(Track& track)
   }
   track.setChi2(chi2);
   track.setNDF(ndf);
-  LOG(DEBUG) << track;
+  LOG(debug) << track;
 }
 
 //______________________________________________________________________________
@@ -428,11 +428,11 @@ bool Tracker::addTrack(const Track& track)
       // The new track is compatible with an existing one
       if (chi2OverNDF < checkTrack.getChi2OverNDF()) {
         // The new track is more precise than the old one: replace it!
-        LOG(DEBUG) << "Replacing track " << checkTrack << "\n with " << track;
+        LOG(debug) << "Replacing track " << checkTrack << "\n with " << track;
         checkTrack = track;
         return true;
       } else {
-        LOG(DEBUG) << "Rejecting track " << track << "\n compatible with " << checkTrack;
+        LOG(debug) << "Rejecting track " << track << "\n compatible with " << checkTrack;
         // The new track is less precise than the old one: reject it
         return false;
       }

--- a/Detectors/MUON/MID/Tracking/test/testTracker.cxx
+++ b/Detectors/MUON/MID/Tracking/test/testTracker.cxx
@@ -31,7 +31,7 @@
 #include "MIDTestingSimTools/TrackGenerator.h"
 #include "MIDTracking/Tracker.h"
 
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 
 namespace o2
 {


### PR DESCRIPTION
Usage of `FairLogger.h` from FairRoot has been deperecated in favour of
`fairlogger/Logger.h` from the standalone
https://github.com/FairRootGroup/FairLogger package.