### PR TITLE
Use FairLogger standalone package in Detectors/ITSMFT

### DIFF
--- a/Detectors/ITSMFT/ITS/macros/test/exctracITSMapping.C
+++ b/Detectors/ITSMFT/ITS/macros/test/exctracITSMapping.C
@@ -1,5 +1,5 @@
 #if !defined(__CLING__) || defined(__ROOTCLING__)
-#include <FairLogger.h>
+#include <fairlogger/Logger.h>
 #include <stdio.h>
 #include <vector>
 #include "ITSBase/GeometryTGeo.h"

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CookedTrackerTask.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CookedTrackerTask.cxx
@@ -19,7 +19,7 @@
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
 
-#include "FairLogger.h"      // for LOG
+#include <fairlogger/Logger.h> // for LOG
 #include "FairRootManager.h" // for FairRootManager
 
 ClassImp(o2::ITS::CookedTrackerTask)
@@ -55,13 +55,13 @@ InitStatus CookedTrackerTask::Init()
 {
   FairRootManager* mgr = FairRootManager::Instance();
   if (!mgr) {
-    LOG(ERROR) << "Could not instantiate FairRootManager. Exiting ..." << FairLogger::endl;
+    LOG(error) << "Could not instantiate FairRootManager. Exiting ...";
     return kERROR;
   }
 
   mClustersArray = mgr->InitObjectAs<const std::vector<o2::ITSMFT::Cluster>*>("ITSCluster");
   if (!mClustersArray) {
-    LOG(ERROR) << "ITS clusters not registered in the FairRootManager. Exiting ..." << FairLogger::endl;
+    LOG(error) << "ITS clusters not registered in the FairRootManager. Exiting ...";
     return kERROR;
   }
 
@@ -73,7 +73,7 @@ InitStatus CookedTrackerTask::Init()
     mgr->RegisterAny("ITSTrackMCTruth", mTrkLabels, kTRUE);
     mClsLabels = mgr->InitObjectAs<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>*>("ITSClusterMCTruth");
     if (!mClsLabels) {
-      LOG(ERROR) << "ITS cluster labels not registered in the FairRootManager. Exiting ..." << FairLogger::endl;
+      LOG(error) << "ITS cluster labels not registered in the FairRootManager. Exiting ...";
       return kERROR;
     }
     mVertexer.setMCTruthContainer(mClsLabels);
@@ -95,7 +95,7 @@ void CookedTrackerTask::Exec(Option_t* option)
     mTracksArray->clear();
   if (mTrkLabels)
     mTrkLabels->clear();
-  LOG(DEBUG) << "Running digitization on new event" << FairLogger::endl;
+  LOG(debug) << "Running digitization on new event";
 
   std::vector<std::array<Double_t, 3>> vertices;
   mVertexer.process(*mClustersArray, vertices);

--- a/Detectors/ITSMFT/ITS/reconstruction/src/TrivialClusterer.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/TrivialClusterer.cxx
@@ -18,7 +18,7 @@
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
 
-#include "FairLogger.h"   // for LOG
+#include <fairlogger/Logger.h> // for LOG
 
 using o2::ITSMFT::SegmentationAlpide;
 using namespace o2::ITS;

--- a/Detectors/ITSMFT/ITS/reconstruction/src/TrivialClustererTask.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/TrivialClustererTask.cxx
@@ -19,7 +19,7 @@
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
 
-#include "FairLogger.h"      // for LOG
+#include <fairlogger/Logger.h> // for LOG
 #include "FairRootManager.h" // for FairRootManager
 
 ClassImp(o2::ITS::TrivialClustererTask)
@@ -55,13 +55,13 @@ InitStatus TrivialClustererTask::Init()
 {
   FairRootManager* mgr = FairRootManager::Instance();
   if (!mgr) {
-    LOG(ERROR) << "Could not instantiate FairRootManager. Exiting ..." << FairLogger::endl;
+    LOG(error) << "Could not instantiate FairRootManager. Exiting ...";
     return kERROR;
   }
 
   mDigitsArray = mgr->InitObjectAs<const std::vector<o2::ITSMFT::Digit>*>("ITSDigit");
   if (!mDigitsArray) {
-    LOG(ERROR) << "ITS points not registered in the FairRootManager. Exiting ..." << FairLogger::endl;
+    LOG(error) << "ITS points not registered in the FairRootManager. Exiting ...";
     return kERROR;
   }
 
@@ -88,7 +88,7 @@ void TrivialClustererTask::Exec(Option_t* option)
     mClustersArray->clear();
   if (mClsLabels)
     mClsLabels->clear();
-  LOG(DEBUG) << "Running clusterization on new event" << FairLogger::endl;
+  LOG(debug) << "Running clusterization on new event";
 
   mTrivialClusterer.process(mDigitsArray, mClustersArray);
 }

--- a/Detectors/ITSMFT/ITS/reconstruction/src/TrivialVertexer.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/TrivialVertexer.cxx
@@ -17,7 +17,7 @@
 #include "TTree.h"
 
 #include "FairMCEventHeader.h"
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 
 #include "ITSReconstruction/TrivialVertexer.h"
 #include "DataFormatsITSMFT/Cluster.h"
@@ -45,20 +45,20 @@ Bool_t TrivialVertexer::openInputFile(const Char_t* fname)
 {
   mFile = TFile::Open(fname, "old");
   if (!mFile) {
-    LOG(ERROR) << "TrivialVertexer::openInputFile() : "
-               << "Cannot open the input file !" << FairLogger::endl;
+    LOG(error) << "TrivialVertexer::openInputFile() : "
+               << "Cannot open the input file !";
     return kFALSE;
   }
   mTree = (TTree*)mFile->Get("o2sim");
   if (!mTree) {
-    LOG(ERROR) << "TrivialVertexer::openInputFile() : "
-               << "Cannot get the input tree !" << FairLogger::endl;
+    LOG(error) << "TrivialVertexer::openInputFile() : "
+               << "Cannot get the input tree !";
     return kFALSE;
   }
   Int_t rc = mTree->SetBranchAddress("MCEventHeader.", &mHeader);
   if (rc != 0) {
-    LOG(ERROR) << "TrivialVertexer::openInputFile() : "
-               << "Cannot get the input branch ! rc=" << rc << FairLogger::endl;
+    LOG(error) << "TrivialVertexer::openInputFile() : "
+               << "Cannot get the input branch ! rc=" << rc;
     return kFALSE;
   }
   return kTRUE;
@@ -67,15 +67,15 @@ Bool_t TrivialVertexer::openInputFile(const Char_t* fname)
 void TrivialVertexer::process(const std::vector<Cluster>& clusters, std::vector<std::array<Double_t, 3>>& vertices)
 {
   if (mClsLabels == nullptr) {
-    LOG(INFO) << "TrivialVertexer::process() : "
-              << "No cluster labels available ! Running with a default MC vertex..." << FairLogger::endl;
+    LOG(info) << "TrivialVertexer::process() : "
+              << "No cluster labels available ! Running with a default MC vertex...";
     vertices.emplace_back(std::array<Double_t, 3>{ 0., 0., 0. });
     return;
   }
 
   if (mTree == nullptr) {
-    LOG(INFO) << "TrivialVertexer::process() : "
-              << "No MC information available ! Running with a default MC vertex..." << FairLogger::endl;
+    LOG(info) << "TrivialVertexer::process() : "
+              << "No MC information available ! Running with a default MC vertex...";
     vertices.emplace_back(std::array<Double_t, 3>{ 0., 0., 0. });
     return;
   }
@@ -101,7 +101,7 @@ void TrivialVertexer::process(const std::vector<Cluster>& clusters, std::vector<
     Double_t vy = mHeader->GetY();
     Double_t vz = mHeader->GetZ();
     vertices.emplace_back(std::array<Double_t, 3>{ vx, vy, vz });
-    LOG(INFO) << "TrivialVertexer::process() : "
-              << "MC event #" << mcEv << " with vertex (" << vx << ',' << vy << ',' << vz << ')' << FairLogger::endl;
+    LOG(info) << "TrivialVertexer::process() : "
+              << "MC event #" << mcEv << " with vertex (" << vx << ',' << vy << ',' << vz << ')';
   }
 }

--- a/Detectors/ITSMFT/ITS/simulation/src/DigitizerTask.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/DigitizerTask.cxx
@@ -21,7 +21,7 @@
 #include "ITSMFTSimulation/Hit.h"
 #include "MathUtils/Utils.h"
 
-#include "FairLogger.h"      // for LOG
+#include <fairlogger/Logger.h> // for LOG
 #include "FairRootManager.h" // for FairRootManager
 
 ClassImp(o2::ITS::DigitizerTask);
@@ -45,13 +45,13 @@ InitStatus DigitizerTask::Init()
 {
   FairRootManager* mgr = FairRootManager::Instance();
   if (!mgr) {
-    LOG(ERROR) << "Could not instantiate FairRootManager. Exiting ..." << FairLogger::endl;
+    LOG(error) << "Could not instantiate FairRootManager. Exiting ...";
     return kERROR;
   }
 
   mHitsArray = mgr->InitObjectAs<const std::vector<o2::ITSMFT::Hit>*>("ITSHit");
   if (!mHitsArray) {
-    LOG(ERROR) << "ITS hits not registered in the FairRootManager. Exiting ..." << FairLogger::endl;
+    LOG(error) << "ITS hits not registered in the FairRootManager. Exiting ...";
     return kERROR;
   }
 
@@ -88,7 +88,7 @@ void DigitizerTask::Exec(Option_t* option)
   //
   mDigitizer.setEventTime(tEvent);
   // the type of digitization is steered by the DigiParams object of the Digitizer
-  LOG(DEBUG) << "Running digitization on new event " << mEventID << " from source " << mSourceID << FairLogger::endl;
+  LOG(debug) << "Running digitization on new event " << mEventID << " from source " << mSourceID;
 
   mDigitizer.process(mHitsArray, mEventID, mSourceID);
 
@@ -142,8 +142,8 @@ void DigitizerTask::setQEDInput(TBranch* qed, float timebin, UChar_t srcID)
   // assign the branch containing hits from QED electrons, whith every entry integrating
   // timebin ns of collisions
 
-  LOG(INFO) << "Attaching QED ITS hits as sourceID=" << int(srcID) << ", entry integrates "
-            << timebin << " ns" << FairLogger::endl;
+  LOG(info) << "Attaching QED ITS hits as sourceID=" << int(srcID) << ", entry integrates "
+            << timebin << " ns";
 
   mQEDBranch = qed;
   mQEDEntryTimeBinNS = timebin;

--- a/Detectors/ITSMFT/ITS/simulation/src/V11Geometry.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/V11Geometry.cxx
@@ -14,7 +14,7 @@
 
 #include "ITSSimulation/V11Geometry.h"
 
-#include "FairLogger.h"    // for LOG
+#include <fairlogger/Logger.h> // for LOG
 
 #include <TArc.h>          // for TArc
 #include <TArrow.h>        // for TArrow
@@ -63,7 +63,7 @@ void V11Geometry::intersectLines(Double_t m, Double_t x0, Double_t y0, Double_t 
                                  Double_t y1, Double_t &xi, Double_t &yi) const
 {
   if (TMath::Abs(m - n) < 0.000001) {
-    LOG(ERROR) << "Lines are parallel: m = " << m << " n = " << n << FairLogger::endl;
+    LOG(error) << "Lines are parallel: m = " << m << " n = " << n;
     return;
   }
 

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/Support.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/Support.h
@@ -17,7 +17,7 @@
 
 #include "TNamed.h"
 
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 
 class TGeoVolume;
 class TGeoCompositeShape;

--- a/Detectors/ITSMFT/MFT/base/src/ChipSegmentation.cxx
+++ b/Detectors/ITSMFT/MFT/base/src/ChipSegmentation.cxx
@@ -12,7 +12,7 @@
 /// \brief Description of the virtual segmentation of the chips
 /// \author Raphael Tieulent <raphael.tieulent@cern.ch>
 
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 
 #include "ITSMFTBase/SegmentationAlpide.h"
 #include "MFTBase/ChipSegmentation.h"

--- a/Detectors/ITSMFT/MFT/base/src/Flex.cxx
+++ b/Detectors/ITSMFT/MFT/base/src/Flex.cxx
@@ -22,7 +22,7 @@
 #include "TGeoBoolNode.h"
 #include "TMath.h"
 
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 
 #include "MFTBase/LadderSegmentation.h"
 #include "MFTBase/ChipSegmentation.h"

--- a/Detectors/ITSMFT/MFT/base/src/Geometry.cxx
+++ b/Detectors/ITSMFT/MFT/base/src/Geometry.cxx
@@ -14,7 +14,7 @@
 
 #include "TSystem.h"
 
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 
 #include "MFTBase/Geometry.h"
 #include "MFTBase/GeometryBuilder.h"

--- a/Detectors/ITSMFT/MFT/base/src/HalfDetector.cxx
+++ b/Detectors/ITSMFT/MFT/base/src/HalfDetector.cxx
@@ -14,7 +14,7 @@
 
 #include "TGeoMatrix.h"
 
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 
 #include "MFTBase/HalfDiskSegmentation.h"
 #include "MFTBase/HalfSegmentation.h"
@@ -43,7 +43,7 @@ HalfDetector::HalfDetector(HalfSegmentation* seg) : TNamed(), mHalfVolume(nullpt
 
   SetName(Form("MFT_H_%d", mftGeom->getHalfID(GetUniqueID())));
 
-  LOG(DEBUG) << Form("Creating : %s ", GetName());
+  LOG(debug) << Form("Creating : %s ", GetName());
 
   mHalfVolume = new TGeoVolumeAssembly(GetName());
 
@@ -58,7 +58,7 @@ HalfDetector::~HalfDetector() = default;
 //_____________________________________________________________________________
 void HalfDetector::createHalfDisks()
 {
-  LOG(DEBUG) << "MFT: " << Form("Creating  %d Half-Disk ", mSegmentation->getNHalfDisks());
+  LOG(debug) << "MFT: " << Form("Creating  %d Half-Disk ", mSegmentation->getNHalfDisks());
 
   for (Int_t iDisk = 0; iDisk < mSegmentation->getNHalfDisks(); iDisk++) {
     HalfDiskSegmentation* halfDiskSeg = mSegmentation->getHalfDisk(iDisk);

--- a/Detectors/ITSMFT/MFT/base/src/HalfDisk.cxx
+++ b/Detectors/ITSMFT/MFT/base/src/HalfDisk.cxx
@@ -16,7 +16,7 @@
 #include "TGeoManager.h"
 #include "TGeoBBox.h"
 
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 
 #include "MFTBase/HalfDiskSegmentation.h"
 #include "MFTBase/Ladder.h"
@@ -49,8 +49,7 @@ HalfDisk::HalfDisk(HalfDiskSegmentation* segmentation)
   Geometry* mftGeom = Geometry::instance();
   SetUniqueID(mSegmentation->GetUniqueID());
 
-  LOG(DEBUG1) << "HalfDisk " << Form("creating half-disk: %s Unique ID = %d ", GetName(), mSegmentation->GetUniqueID())
-              << FairLogger::endl;
+  LOG(debug1) << "HalfDisk " << Form("creating half-disk: %s Unique ID = %d ", GetName(), mSegmentation->GetUniqueID());
 
   mHalfDiskVolume = new TGeoVolumeAssembly(GetName());
   /*
@@ -99,7 +98,7 @@ TGeoVolumeAssembly* HalfDisk::createHeatExchanger()
 void HalfDisk::createLadders()
 {
 
-  LOG(DEBUG1) << "CreateLadders: start building ladders" << FairLogger::endl;
+  LOG(debug1) << "CreateLadders: start building ladders";
   for (Int_t iLadder = 0; iLadder < mSegmentation->getNLadders(); iLadder++) {
 
     LadderSegmentation* ladderSeg = mSegmentation->getLadder(iLadder);

--- a/Detectors/ITSMFT/MFT/base/src/HeatExchanger.cxx
+++ b/Detectors/ITSMFT/MFT/base/src/HeatExchanger.cxx
@@ -21,7 +21,7 @@
 #include "TGeoBoolNode.h"
 #include "TGeoBBox.h"
 #include "TGeoVolume.h"
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 #include "MFTBase/Constants.h"
 #include "MFTBase/HeatExchanger.h"
 #include "MFTBase/Geometry.h"

--- a/Detectors/ITSMFT/MFT/base/src/Ladder.cxx
+++ b/Detectors/ITSMFT/MFT/base/src/Ladder.cxx
@@ -19,7 +19,7 @@
 #include "TGeoCompositeShape.h"
 #include "TGeoBoolNode.h"
 
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 
 #include "ITSMFTSimulation/AlpideChip.h"
 #include "ITSMFTBase/SegmentationAlpide.h"
@@ -53,7 +53,7 @@ Ladder::Ladder(LadderSegmentation* segmentation)
   : TNamed(segmentation->GetName(), segmentation->GetName()), mSegmentation(segmentation), mFlex(nullptr)
 {
 
-  LOG(DEBUG1) << "Ladder " << Form("creating : %s", GetName()) << FairLogger::endl;
+  LOG(debug1) << "Ladder " << Form("creating : %s", GetName());
   mLadderVolume = new TGeoVolumeAssembly(GetName());
 }
 
@@ -151,7 +151,7 @@ void Ladder::createSensors()
     masterglue[1] -= shape->GetDY();
     masterglue[2] -= shape->GetDZ();
 
-    LOG(DEBUG1) << "CreateSensors " << Form("adding chip %s_%d ", namePrefixS.Data(), ichip) << FairLogger::endl;
+    LOG(debug1) << "CreateSensors " << Form("adding chip %s_%d ", namePrefixS.Data(), ichip);
     // chipPos->Print();
 
     TGeoTranslation* trans = new TGeoTranslation(master[0], master[1], master[2]);

--- a/Detectors/ITSMFT/MFT/base/src/Segmentation.cxx
+++ b/Detectors/ITSMFT/MFT/base/src/Segmentation.cxx
@@ -12,7 +12,7 @@
 /// \brief Class for the virtual segmentation of the ALICE Muon Forward Tracker
 /// \author Raphael Tieulent <raphael.tieulent@cern.ch>
 
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 
 #include "MFTBase/LadderSegmentation.h"
 #include "MFTBase/HalfDiskSegmentation.h"
@@ -44,7 +44,7 @@ Segmentation::Segmentation(const Char_t* nameGeomFile) : TNamed(), mHalves(nullp
   delete halfBottom;
   delete halfTop;
 
-  LOG(DEBUG1) << "MFT segmentation set!" << FairLogger::endl;
+  LOG(debug1) << "MFT segmentation set!";
 }
 
 //_____________________________________________________________________________
@@ -63,7 +63,7 @@ Segmentation::~Segmentation()
 //_____________________________________________________________________________
 HalfSegmentation* Segmentation::getHalf(Int_t iHalf) const
 {
-  LOG(DEBUG) << Form("Ask for half %d (of %d and %d)", iHalf, Bottom, Top);
+  LOG(debug) << Form("Ask for half %d (of %d and %d)", iHalf, Bottom, Top);
 
   return ((iHalf == Top || iHalf == Bottom) ? ((HalfSegmentation*)mHalves->At(iHalf)) : nullptr);
 }

--- a/Detectors/ITSMFT/MFT/macros/test/extractMFTMapping.C
+++ b/Detectors/ITSMFT/MFT/macros/test/extractMFTMapping.C
@@ -1,5 +1,5 @@
 #if !defined(__CLING__) || defined(__ROOTCLING__)
-#include <FairLogger.h>
+#include <fairlogger/Logger.h>
 #include <stdio.h>
 #include <vector>
 #include "MFTBase/GeometryTGeo.h"

--- a/Detectors/ITSMFT/MFT/simulation/src/DigitizerTask.cxx
+++ b/Detectors/ITSMFT/MFT/simulation/src/DigitizerTask.cxx
@@ -18,7 +18,7 @@
 #include "MFTBase/GeometryTGeo.h"
 #include "MathUtils/Utils.h"
 
-#include "FairLogger.h"      // for LOG
+#include <fairlogger/Logger.h> // for LOG
 #include "FairRootManager.h" // for FairRootManager
 
 ClassImp(o2::MFT::DigitizerTask);
@@ -46,13 +46,13 @@ InitStatus DigitizerTask::Init()
 {
   FairRootManager* mgr = FairRootManager::Instance();
   if (!mgr) {
-    LOG(ERROR) << "Could not instantiate FairRootManager. Exiting ..." << FairLogger::endl;
+    LOG(error) << "Could not instantiate FairRootManager. Exiting ...";
     return kERROR;
   }
 
   mHitsArray = mgr->InitObjectAs<const std::vector<o2::ITSMFT::Hit>*>("MFTHit");
   if (!mHitsArray) {
-    LOG(ERROR) << "MFT hits not registered in the FairRootManager. Exiting ..." << FairLogger::endl;
+    LOG(error) << "MFT hits not registered in the FairRootManager. Exiting ...";
     return kERROR;
   }
 
@@ -89,7 +89,7 @@ void DigitizerTask::Exec(Option_t* option)
   //
   mDigitizer.setEventTime(tEvent);
   // the type of digitization is steered by the DigiParams object of the Digitizer
-  LOG(DEBUG) << "Running digitization on new event " << mEventID << " from source " << mSourceID << FairLogger::endl;
+  LOG(debug) << "Running digitization on new event " << mEventID << " from source " << mSourceID;
 
   mDigitizer.process(mHitsArray, mEventID, mSourceID);
 
@@ -143,8 +143,8 @@ void DigitizerTask::setQEDInput(TBranch* qed, float timebin, UChar_t srcID)
   // assign the branch containing hits from QED electrons, whith every entry integrating
   // timebin ns of collisions
 
-  LOG(INFO) << "Attaching QED ITS hits as sourceID=" << int(srcID) << ", entry integrates "
-            << timebin << " ns" << FairLogger::endl;
+  LOG(info) << "Attaching QED ITS hits as sourceID=" << int(srcID) << ", entry integrates "
+            << timebin << " ns";
 
   mQEDBranch = qed;
   mQEDEntryTimeBinNS = timebin;

--- a/Detectors/ITSMFT/common/base/src/SDigit.cxx
+++ b/Detectors/ITSMFT/common/base/src/SDigit.cxx
@@ -11,7 +11,7 @@
 /// \file SDigit.cxx
 /// \brief Implementation of the ITSMFT summable digit class
 
-#include <FairLogger.h>
+#include <fairlogger/Logger.h>
 #include <TMath.h>
 
 #include "ITSMFTBase/SDigit.h"
@@ -117,7 +117,7 @@ void SDigit::addSignal(Int_t track, Int_t hit, Double_t signal)
   if (TMath::Abs(signal) > 2147483647.0) {
     // PH 2147483647 is the max. integer
     // PH This apparently is a problem which needs investigation
-    LOG(WARNING) << "Too big or too small signal value " << signal << FairLogger::endl;
+    LOG(warn) << "Too big or too small signal value " << signal;
     signal = TMath::Sign((Double_t)2147483647, signal);
   }
   //

--- a/Detectors/ITSMFT/common/reconstruction/src/Clusterer.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/Clusterer.cxx
@@ -11,7 +11,7 @@
 /// \file Clusterer.cxx
 /// \brief Implementation of the ITS cluster finder
 #include <algorithm>
-#include "FairLogger.h" // for LOG
+#include <fairlogger/Logger.h> // for LOG
 
 #include "ITSMFTBase/SegmentationAlpide.h"
 #include "ITSMFTReconstruction/Clusterer.h"
@@ -27,9 +27,9 @@ Clusterer::Clusterer() : mPattIdConverter(), mCurr(mColumn2 + 1), mPrev(mColumn1
   std::fill(std::begin(mColumn2), std::end(mColumn2), -1);
 
 #ifdef _ClusterTopology_
-  LOG(INFO) << "*********************************************************************" << FairLogger::endl;
-  LOG(INFO) << "ATTENTION: YOU ARE RUNNING IN SPECIAL MODE OF STORING CLUSTER PATTERN" << FairLogger::endl;
-  LOG(INFO) << "*********************************************************************" << FairLogger::endl;
+  LOG(info) << "*********************************************************************";
+  LOG(info) << "ATTENTION: YOU ARE RUNNING IN SPECIAL MODE OF STORING CLUSTER PATTERN";
+  LOG(info) << "*********************************************************************";
 #endif //_ClusterTopology_
 
 #ifdef _PERFORM_TIMING_
@@ -54,7 +54,7 @@ void Clusterer::process(PixelReader& reader, std::vector<Cluster>* fullClus,
 
     mCurrROF = mChipData->getROFrame();
     if (prevROF != mCurrROF && prevROF != o2::ITSMFT::PixelData::DummyROF) {
-      LOG(INFO) << "ITS: clusterizing new ROFrame " << mCurrROF << FairLogger::endl;
+      LOG(info) << "ITS: clusterizing new ROFrame " << mCurrROF;
       if (mClusTree) { // if necessary, flush existing data
         flushClusters(fullClus, compClus, labelsCl);
       }
@@ -62,8 +62,8 @@ void Clusterer::process(PixelReader& reader, std::vector<Cluster>* fullClus,
     prevROF = mCurrROF;
 
     mCurrChipID = mChipData->getChipID();
-    // LOG(DEBUG) << "ITSClusterer got Chip " << mCurrChipID << " ROFrame " << mChipData->getROFrame()
-    //            << " Nhits " << mChipData->getData().size() << FairLogger::endl;
+    // LOG(debug) << "ITSClusterer got Chip " << mCurrChipID << " ROFrame " << mChipData->getROFrame()
+    //            << " Nhits " << mChipData->getData().size();
 
     if (mMaskOverflowPixels) { // mask pixels fired from the previous ROF
       if (mChipsOld.size() < mChips.size()) {
@@ -204,7 +204,7 @@ void Clusterer::finishChip(std::vector<Cluster>* fullClus, std::vector<CompClust
         }
         next = pixEntry.first;
       } else {
-        LOG(ERROR) << "Cluster size " << npix + 1 << " exceeds the buffer size" << FairLogger::endl;
+        LOG(error) << "Cluster size " << npix + 1 << " exceeds the buffer size";
       }
     }
     mPreClusterIndices[i1] = -1;
@@ -224,7 +224,7 @@ void Clusterer::finishChip(std::vector<Cluster>* fullClus, std::vector<CompClust
           }
           next = pixEntry.first;
         } else {
-          LOG(ERROR) << "Cluster size " << npix + 1 << " exceeds the buffer size" << FairLogger::endl;
+          LOG(error) << "Cluster size " << npix + 1 << " exceeds the buffer size";
         }
       }
       mPreClusterIndices[i2] = -1;

--- a/Detectors/ITSMFT/common/simulation/src/AlpideChip.cxx
+++ b/Detectors/ITSMFT/common/simulation/src/AlpideChip.cxx
@@ -22,7 +22,7 @@
 #include <TGeoManager.h>      // for gGeoManager, TGeoManager
 #include "TGeoVolume.h"       // for TGeoVolume
 #include "TGeoMatrix.h"       // for TGeoMatrix
-#include "FairLogger.h" // for LOG
+#include <fairlogger/Logger.h> // for LOG
 
 using namespace o2::ITSMFT;
 
@@ -63,9 +63,9 @@ TGeoVolume* AlpideChip::createChip(const Double_t ychip,
   // First create all needed shapes
   ylen = ysens;
   if (ysens > ychip) {
-    LOG(WARNING) << "Sensor half thickness (" << ysens
-                 << ") greater than chip half thickness (" << ychip
-                 << "), setting equal" << FairLogger::endl;
+    LOG(warn) << "Sensor half thickness (" << ysens
+              << ") greater than chip half thickness (" << ychip
+              << "), setting equal";
     ylen = ychip;
   }
 

--- a/Detectors/ITSMFT/common/simulation/src/DigiParams.cxx
+++ b/Detectors/ITSMFT/common/simulation/src/DigiParams.cxx
@@ -11,7 +11,7 @@
 /// \file DigiParams.cxx
 /// \brief Implementation of the ITS digitization steering params
 
-#include "FairLogger.h" // for LOG
+#include <fairlogger/Logger.h> // for LOG
 #include "ITSMFTSimulation/DigiParams.h"
 #include <cassert>
 
@@ -50,9 +50,9 @@ void DigiParams::setChargeThreshold(int v, float frac2Account)
   if (mMinChargeToAccount < 0 || mMinChargeToAccount > mChargeThreshold) {
     mMinChargeToAccount = mChargeThreshold;
   }
-  LOG(INFO) << "Set Alpide charge threshold to " << mChargeThreshold
+  LOG(info) << "Set Alpide charge threshold to " << mChargeThreshold
             << ", single hit will be accounted from " << mMinChargeToAccount
-            << " electrons" << FairLogger::endl;
+            << " electrons";
 }
 
 //______________________________________________

--- a/Detectors/ITSMFT/common/simulation/test/testAlpideSimResponse.cxx
+++ b/Detectors/ITSMFT/common/simulation/test/testAlpideSimResponse.cxx
@@ -14,7 +14,7 @@
 #include <boost/test/unit_test.hpp>
 #include <iostream>
 #include "ITSMFTSimulation/AlpideSimResponse.h"
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 
 using namespace o2::ITSMFT;
 
@@ -24,16 +24,16 @@ BOOST_AUTO_TEST_CASE(AlpideSimResponse_test)
   AlpideSimResponse resp;
   resp.initData();
   float vCol=1.e-4, vRow=1.e-4, vDepth=10.e-4;
-  LOG(INFO) << "Checking response from vRow:" << vCol << " vCol:" << vCol
-            << " Depth:" << vDepth << FairLogger::endl;
+  LOG(info) << "Checking response from vRow:" << vCol << " vCol:" << vCol
+            << " Depth:" << vDepth;
   bool flipCol, flipRow;
   auto respMat = resp.getResponse(vRow,vCol,resp.getDepthMax()-vDepth,flipRow,flipCol);
   BOOST_CHECK( respMat!=nullptr );
   respMat->print(flipRow,flipCol);
   // repsonse at central pixel for electron close to the surface should be >>0
   int pixCen = respMat->getNPix()/2;
-  LOG(INFO) << "Response at central pixel " << pixCen << ":" << pixCen
-            << " is " << respMat->getValue(pixCen,pixCen,flipRow,flipCol) << FairLogger::endl;
+  LOG(info) << "Response at central pixel " << pixCen << ":" << pixCen
+            << " is " << respMat->getValue(pixCen, pixCen, flipRow, flipCol);
   BOOST_CHECK(respMat->getValue(pixCen,pixCen,flipRow,flipCol) > 1e-6);
   //
   // check normalization
@@ -43,6 +43,6 @@ BOOST_AUTO_TEST_CASE(AlpideSimResponse_test)
       norm += respMat->getValue(ir,ic,flipRow,flipCol);
     }
   }
-  LOG(INFO) << "Total response to 1 electron: " << norm << FairLogger::endl;
+  LOG(info) << "Total response to 1 electron: " << norm;
   BOOST_CHECK(norm > 0.1);
 }

--- a/Detectors/ITSMFT/test/HitAnalysis/src/HitAnalysis.cxx
+++ b/Detectors/ITSMFT/test/HitAnalysis/src/HitAnalysis.cxx
@@ -18,7 +18,7 @@
 
 #include "HitAnalysis/HitAnalysis.h"
 
-#include "FairLogger.h" // for LOG
+#include <fairlogger/Logger.h> // for LOG
 
 #include "TH1.h" // for TH1, TH1D, TH1F
 #include "TMath.h"
@@ -69,13 +69,13 @@ InitStatus HitAnalysis::Init()
   // Get the FairRootManager
   FairRootManager* mgr = FairRootManager::Instance();
   if (!mgr) {
-    LOG(ERROR) << "Could not instantiate FairRootManager. Exiting ..." << FairLogger::endl;
+    LOG(error) << "Could not instantiate FairRootManager. Exiting ...";
     return kERROR;
   }
 
   mHits = mgr->InitObjectAs<const std::vector<o2::ITSMFT::Hit>*>("ITSHit");
   if (!mHits) {
-    LOG(ERROR) << "ITS points not registered in the FairRootManager. Exiting ..." << FairLogger::endl;
+    LOG(error) << "ITS points not registered in the FairRootManager. Exiting ...";
     return kERROR;
   }
 


### PR DESCRIPTION
Usage of `FairLogger.h` from FairRoot has been deperecated in favour of
`fairlogger/Logger.h` from the standalone
https://github.com/FairRootGroup/FairLogger package.