### PR TITLE
Use FairLogger standalone package in Detectors/FIT

### DIFF
--- a/Detectors/FIT/base/src/Geometry.cxx
+++ b/Detectors/FIT/base/src/Geometry.cxx
@@ -11,7 +11,7 @@
 //#include <TVector3.h>
 #include "FITBase/Geometry.h"
 
-#include <FairLogger.h>
+#include <fairlogger/Logger.h>
 #include <sstream>
 
 ClassImp(o2::fit::Geometry);

--- a/Detectors/FIT/macros/run_digi_fit.C
+++ b/Detectors/FIT/macros/run_digi_fit.C
@@ -3,7 +3,7 @@
 
 #include <TStopwatch.h>
 
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 #include "FairRunAna.h"
 #include "FairFileSource.h"
 #include "FairRuntimeDb.h"
@@ -18,9 +18,9 @@ void run_digi_fit(Int_t nEvents = 10, Float_t rate = 50.e3)
   // if rate>0 then continuous simulation for this rate will be performed
 
   // Initialize logger
-  FairLogger* logger = FairLogger::GetLogger();
-  logger->SetLogVerbosityLevel("LOW");
-  logger->SetLogScreenLevel("DEBUG");
+
+  fair::Logger::SetVerbosity("LOW");
+  fair::Logger::SetConsoleSeverity("DEBUG");
 
   // Input and output file name
   std::stringstream inputfile, outputfile, paramfile;

--- a/Detectors/FIT/reconstruction/src/CollisionTimeRecoTask.cxx
+++ b/Detectors/FIT/reconstruction/src/CollisionTimeRecoTask.cxx
@@ -12,8 +12,7 @@
 /// \brief Implementation of the FIT reconstruction task
 
 #include "FITReconstruction/CollisionTimeRecoTask.h"
-#include "FairLogger.h"      // for LOG
-
+#include <fairlogger/Logger.h> // for LOG
 
 using namespace o2::fit;
 /*
@@ -29,7 +28,7 @@ CollisionTimeRecoTask::CollisionTimeRecoTask()
 void CollisionTimeRecoTask::Process(const Digit& digits,
                                     RecPoints& recPoints) const
 {
-  LOG(INFO) << "Running reconstruction on new event" << FairLogger::endl;
+  LOG(info) << "Running reconstruction on new event";
   recPoints.FillFromDigits(digits);
 }
 //________________________________________________________

--- a/Detectors/FIT/simulation/src/Detector.cxx
+++ b/Detectors/FIT/simulation/src/Detector.cxx
@@ -17,7 +17,7 @@
 #include "TVector3.h"
 
 #include "FairRootManager.h" // for FairRootManager
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 #include "FairVolume.h"
 
 #include "FairRootManager.h"
@@ -57,7 +57,7 @@ void Detector::InitializeO2Detector()
   // FIXME: we need to register the sensitive volumes with FairRoot
   TGeoVolume* v = gGeoManager->GetVolume("0REG");
   if (v == nullptr) {
-    LOG(WARN) << "@@@@ Sensitive volume 0REG not found!!!!!!!!";
+    LOG(warn) << "@@@@ Sensitive volume 0REG not found!!!!!!!!";
   } else {
 
     AddSensitiveVolume(v);
@@ -66,7 +66,7 @@ void Detector::InitializeO2Detector()
 
 void Detector::ConstructGeometry()
 {
-  LOG(DEBUG) << "Creating FIT geometry\n";
+  LOG(debug) << "Creating FIT geometry\n";
   CreateMaterials();
 
   Float_t zdetA = 333;
@@ -209,7 +209,7 @@ void Detector::ConstructGeometry()
 
 void Detector::ConstructOpGeometry()
 {
-  LOG(DEBUG) << "Creating FIT optical geometry properties";
+  LOG(debug) << "Creating FIT optical geometry properties";
 
   DefineOpticalProperties();
 }
@@ -391,7 +391,7 @@ void Detector::DefineOpticalProperties()
 
   if (ReadOptProperties(optPropPath.Data()) < 0) {
     // Error reading file
-    LOG(ERROR) << "Could not read FIT optical properties" << FairLogger::endl;
+    LOG(error) << "Could not read FIT optical properties";
     return;
   }
   Int_t nBins = mPhotonEnergyD.size();

--- a/Detectors/FIT/simulation/src/DigitizerTask.cxx
+++ b/Detectors/FIT/simulation/src/DigitizerTask.cxx
@@ -14,7 +14,7 @@
 #include "FITSimulation/DigitizerTask.h"
 #include "MathUtils/Utils.h"
 
-#include "FairLogger.h"      // for LOG
+#include <fairlogger/Logger.h> // for LOG
 #include "FairRootManager.h" // for FairRootManager
 
 ClassImp(o2::fit::DigitizerTask);
@@ -35,14 +35,14 @@ InitStatus DigitizerTask::Init()
 {
   FairRootManager* mgr = FairRootManager::Instance();
   if (!mgr) {
-    LOG(ERROR) << "Could not instantiate FairRootManager. Exiting ..." << FairLogger::endl;
+    LOG(error) << "Could not instantiate FairRootManager. Exiting ...";
     return kERROR;
   }
 
   mHitsArray = mgr->InitObjectAs<const std::vector<o2::fit::HitType>*>("FITHit");
 
   if (!mHitsArray) {
-    LOG(ERROR) << "FIT hits not registered in the FairRootManager. Exiting ..." << FairLogger::endl;
+    LOG(error) << "FIT hits not registered in the FairRootManager. Exiting ...";
     return kERROR;
   }
 
@@ -66,7 +66,7 @@ void DigitizerTask::Exec(Option_t* option)
   mDigitizer.setEventTime(EventTime);
 
   // the type of digitization is steered by the DigiParams object of the Digitizer
-  LOG(DEBUG) << "Running digitization on new event " << mEventID << " from source " << mSourceID
+  LOG(debug) << "Running digitization on new event " << mEventID << " from source " << mSourceID
              << " Event time " << EventTime;
 
   /// RS: ATTENTION: this is just a trick until we clarify how the hits from different source are


### PR DESCRIPTION
Usage of `FairLogger.h` from FairRoot has been deperecated in favour of
`fairlogger/Logger.h` from the standalone
https://github.com/FairRootGroup/FairLogger package.