### PR TITLE
Use FairLogger standalone package in Detectors/EMCAL

### DIFF
--- a/Detectors/EMCAL/simulation/src/DigitizerTask.cxx
+++ b/Detectors/EMCAL/simulation/src/DigitizerTask.cxx
@@ -14,7 +14,7 @@
 #include "EMCALBase/Hit.h"
 #include "EMCALSimulation/Digitizer.h"
 
-#include "FairLogger.h"      // for LOG
+#include <fairlogger/Logger.h> // for LOG
 #include "FairRootManager.h" // for FairRootManager
 #include "FairTask.h"        // for FairTask, InitStatus
 #include "Rtypes.h"          // for DigitizerTask::Class, ClassDef, etc
@@ -44,13 +44,13 @@ InitStatus DigitizerTask::Init()
 {
   FairRootManager* mgr = FairRootManager::Instance();
   if (!mgr) {
-    LOG(ERROR) << "Could not instantiate FairRootManager. Exiting ..." << FairLogger::endl;
+    LOG(error) << "Could not instantiate FairRootManager. Exiting ...";
     return kERROR;
   }
 
   mHitsArray = mgr->InitObjectAs<const std::vector<o2::EMCAL::Hit>*>("EMCALHit");
   if (!mHitsArray) {
-    LOG(ERROR) << "EMCAL hits not registered in the FairRootManager. Exiting ..." << FairLogger::endl;
+    LOG(error) << "EMCAL hits not registered in the FairRootManager. Exiting ...";
     return kERROR;
   }
 
@@ -76,7 +76,7 @@ void DigitizerTask::Exec(Option_t* option)
     mDigitsArray->clear();
   mDigitizer.setEventTime(mgr->GetEventTime());
 
-  LOG(DEBUG) << "Running digitization on new event " << mEventID << " from source " << mSourceID << FairLogger::endl;
+  LOG(debug) << "Running digitization on new event " << mEventID << " from source " << mSourceID;
 
   mDigitizer.setCurrSrcID(mSourceID);
   mDigitizer.setCurrEvID(mEventID);

--- a/Detectors/EMCAL/testsimulation/PutEmcalInTop.C
+++ b/Detectors/EMCAL/testsimulation/PutEmcalInTop.C
@@ -6,14 +6,14 @@
 #include "DetectorsPassive/Cave.h"
 #include "DetectorsPassive/FrameStructure.h"
 #include "EMCALSimulation/Detector.h"
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 #include "FairRunSim.h"
 #endif
 
 void PutEmcalInTop()
 {
   // minimal macro to test setup of the geometry
-  FairLogger::GetLogger()->SetLogScreenLevel("DEBUG3");
+  fair::Logger::SetConsoleSeverity("DEBUG3");
 
   TString dir = getenv("VMCWORKDIR");
   TString geom_dir = dir + "/Detectors/Geometry/";


### PR DESCRIPTION
Usage of `FairLogger.h` from FairRoot has been deperecated in favour of
`fairlogger/Logger.h` from the standalone
https://github.com/FairRootGroup/FairLogger package.