### PR TITLE
Use FairLogger standalone package in Detectors/ZDC

### DIFF
--- a/Detectors/ZDC/base/src/Geometry.cxx
+++ b/Detectors/ZDC/base/src/Geometry.cxx
@@ -9,7 +9,7 @@
 // or submit itself to any jurisdiction.
 
 #include "ZDCBase/Geometry.h"
-#include "FairLogger.h"
+#include <fairlogger/Logger.h>
 
 ClassImp(o2::zdc::Geometry);
 


### PR DESCRIPTION
Usage of `FairLogger.h` from FairRoot has been deperecated in favour of
`fairlogger/Logger.h` from the standalone
https://github.com/FairRootGroup/FairLogger package.