### PR TITLE
DPL: use ptr + size based API

### DIFF
--- a/Framework/Core/include/Framework/TableBuilder.h
+++ b/Framework/Core/include/Framework/TableBuilder.h
@@ -79,7 +79,7 @@ struct BuilderUtils {
     // FIXME: for the moment we do not fill things.
     auto status = builder->Append();
     auto valueBuilder = reinterpret_cast<ValueBuilderType*>(builder->value_builder());
-    return status & valueBuilder->AppendValues(ip.first, ip.second);
+    return status & valueBuilder->AppendValues(&*ip.first, std::distance(ip.first, ip.second));
   }
 };
 


### PR DESCRIPTION
Old iterator based API seems to be missing from 0.12.0. This should
work with both 0.12.0 and 0.11.0.