### PR TITLE
Headers: Remove copy constructor declaration of DataIdentifier

### DIFF
--- a/DataFormats/Headers/include/Headers/DataHeader.h
+++ b/DataFormats/Headers/include/Headers/DataHeader.h
@@ -626,7 +626,7 @@ struct DataIdentifier
   DataDescription dataDescription;
   DataOrigin dataOrigin;
   DataIdentifier();
-  DataIdentifier(const DataIdentifier&);
+  DataIdentifier(const DataIdentifier&) = default;
   template<std::size_t N, std::size_t M>
   DataIdentifier(const char (&desc)[N], const char (&origin)[M])
     : dataDescription(desc), dataOrigin(origin)


### PR DESCRIPTION
Missing definition causes link errors. Use the implicitly-defined one.