### PR TITLE
Optimize CalDet access in digitisation

### DIFF
--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitTime.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitTime.h
@@ -64,6 +64,7 @@ class DigitTime
   /// \param cru CRU ID
   /// \param timeBin Time bin
   /// \param commonMode Common mode value of that specific ROC
+  template <DigitzationMode MODE>
   void fillOutputContainer(std::vector<Digit>* output, dataformats::MCTruthContainer<MCCompLabel>& mcTruth,
                            std::vector<DigitMCMetaData>* debug, const Sector& sector, TimeBin timeBin,
                            float commonMode = 0.f);
@@ -96,6 +97,20 @@ inline float DigitTime::getCommonMode(const CRU& cru) const
   const auto nPads = mapper.getNumberOfPads(gemStack);
   return mCommonMode[gemStack] /
          static_cast<float>(nPads); /// simple case when there is no external capacitance on the ROC;
+}
+
+template <DigitzationMode MODE>
+inline void DigitTime::fillOutputContainer(std::vector<Digit>* output, dataformats::MCTruthContainer<MCCompLabel>& mcTruth,
+                                           std::vector<DigitMCMetaData>* debug, const Sector& sector, TimeBin timeBin,
+                                           float commonMode)
+{
+  static Mapper& mapper = Mapper::instance();
+  GlobalPadNumber globalPad = 0;
+  for (auto& pad : mGlobalPads) {
+    const int cru = mapper.getCRU(sector, globalPad);
+    pad.fillOutputContainer<MODE>(output, mcTruth, debug, cru, timeBin, globalPad, getCommonMode(cru));
+    ++globalPad;
+  }
 }
 }
 }

--- a/Detectors/TPC/simulation/include/TPCSimulation/SAMPAProcessing.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/SAMPAProcessing.h
@@ -66,6 +66,7 @@ class SAMPAProcessing
   /// \param sector Sector number
   /// \param globalPadInSector global pad number in the sector
   /// \return ADC value after application of noise, pedestal and saturation
+  template <DigitzationMode MODE>
   float makeSignal(float ADCcounts, const int sector, const int globalPadInSector, float& pedestal, float& noise);
 
   /// A delta signal is shaped by the FECs and thus spread over several time bins
@@ -140,13 +141,14 @@ inline T SAMPAProcessing::getADCvalue(T nElectrons) const
   return nElectrons * conversion;
 }
 
+template <DigitzationMode MODE>
 inline float SAMPAProcessing::makeSignal(float ADCcounts, const int sector, const int globalPadInSector,
                                          float& pedestal, float& noise)
 {
   float signal = ADCcounts;
   pedestal = getPedestal(sector, globalPadInSector);
   noise = getNoise(sector, globalPadInSector);
-  switch (mEleParam->getDigitizationMode()) {
+  switch (MODE) {
     case DigitzationMode::FullMode: {
       signal += noise;
       signal += pedestal;

--- a/Detectors/TPC/simulation/include/TPCSimulation/SAMPAProcessing.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/SAMPAProcessing.h
@@ -63,10 +63,10 @@ class SAMPAProcessing
 
   /// Make the full signal including noise and pedestals from the OCDB
   /// \param ADCcounts ADC value of the signal (common mode already subtracted)
-  /// \param cru CRU of the signal
-  /// \param padPos PadPos of the signal
+  /// \param sector Sector number
+  /// \param globalPadInSector global pad number in the sector
   /// \return ADC value after application of noise, pedestal and saturation
-  float makeSignal(float ADCcounts, const CRU& cru, const PadPos& pos, float& pedestal, float& noise);
+  float makeSignal(float ADCcounts, const int sector, const int globalPadInSector, float& pedestal, float& noise);
 
   /// A delta signal is shaped by the FECs and thus spread over several time bins
   /// This function returns an array with the signal spread into the following time bins
@@ -113,13 +113,13 @@ class SAMPAProcessing
   /// \param cru CRU of the channel of interest
   /// \param padPos PadPos of the channel of interest
   /// \return Noise on the channel of interest
-  float getNoise(const CRU& cru, const PadPos& pos);
+  float getNoise(const int sector, const int globalPadInSector);
 
   /// Get the pedestal for a given channel
   /// \param cru CRU of the channel of interest
   /// \param padPos PadPos of the channel of interest
   /// \return Pedestal on the channel of interest
-  float getPedestal(const CRU& cru, const PadPos& pos) const;
+  float getPedestal(const int sector, const int globalPadInSector) const;
 
  private:
   SAMPAProcessing();
@@ -140,12 +140,12 @@ inline T SAMPAProcessing::getADCvalue(T nElectrons) const
   return nElectrons * conversion;
 }
 
-inline float SAMPAProcessing::makeSignal(float ADCcounts, const CRU& cru, const PadPos& pos,
+inline float SAMPAProcessing::makeSignal(float ADCcounts, const int sector, const int globalPadInSector,
                                          float& pedestal, float& noise)
 {
   float signal = ADCcounts;
-  pedestal = getPedestal(cru, pos);
-  noise = getNoise(cru, pos);
+  pedestal = getPedestal(sector, globalPadInSector);
+  noise = getNoise(sector, globalPadInSector);
   switch (mEleParam->getDigitizationMode()) {
     case DigitzationMode::FullMode: {
       signal += noise;
@@ -223,14 +223,14 @@ inline float SAMPAProcessing::getTimeBinTime(float time) const
   return getTimeFromBin(timeBin);
 }
 
-inline float SAMPAProcessing::getNoise(const CRU& cru, const PadPos& pos)
+inline float SAMPAProcessing::getNoise(const int sector, const int globalPadInSector)
 {
-  return mRandomNoiseRing.getNextValue() * mNoiseMap->getValue(cru, pos.getRow(), pos.getPad());
+  return mRandomNoiseRing.getNextValue() * mNoiseMap->getValue(sector, globalPadInSector);
 }
 
-inline float SAMPAProcessing::getPedestal(const CRU& cru, const PadPos& pos) const
+inline float SAMPAProcessing::getPedestal(const int sector, const int globalPadInSector) const
 {
-  return mPedestalMap->getValue(cru, pos.getRow(), pos.getPad());
+  return mPedestalMap->getValue(sector, globalPadInSector);
 }
 }
 }

--- a/Detectors/TPC/simulation/src/DigitContainer.cxx
+++ b/Detectors/TPC/simulation/src/DigitContainer.cxx
@@ -15,6 +15,8 @@
 #include "TPCSimulation/DigitContainer.h"
 #include "FairLogger.h"
 #include "TPCBase/Mapper.h"
+#include "TPCBase/CDBInterface.h"
+#include "TPCBase/ParameterElectronics.h"
 
 using namespace o2::TPC;
 
@@ -51,7 +53,28 @@ void DigitContainer::fillOutputContainer(std::vector<Digit>* output,
       if (!isContinuous && timeBin > mTmaxTriggered)
         continue;
       ++nProcessedTimeBins;
-      time.fillOutputContainer(output, mcTruth, debug, mSector, timeBin);
+      auto& cdb = CDBInterface::instance();
+      auto& eleParam = cdb.getParameterElectronics();
+      const auto digitizationMode = eleParam.getDigitizationMode();
+
+      switch (digitizationMode) {
+        case DigitzationMode::FullMode: {
+          time.fillOutputContainer<DigitzationMode::FullMode>(output, mcTruth, debug, mSector, timeBin);
+          break;
+        }
+        case DigitzationMode::SubtractPedestal: {
+          time.fillOutputContainer<DigitzationMode::SubtractPedestal>(output, mcTruth, debug, mSector, timeBin);
+          break;
+        }
+        case DigitzationMode::NoSaturation: {
+          time.fillOutputContainer<DigitzationMode::NoSaturation>(output, mcTruth, debug, mSector, timeBin);
+          break;
+        }
+        case DigitzationMode::PropagateADC: {
+          time.fillOutputContainer<DigitzationMode::PropagateADC>(output, mcTruth, debug, mSector, timeBin);
+          break;
+        }
+      }
     } else {
       break;
     }

--- a/Detectors/TPC/simulation/src/DigitGlobalPad.cxx
+++ b/Detectors/TPC/simulation/src/DigitGlobalPad.cxx
@@ -38,7 +38,7 @@ void DigitGlobalPad::fillOutputContainer(std::vector<Digit>* output,
                                                   // pedestals and saturation of the SAMPA
 
   float noise, pedestal;
-  const float mADC = sampaProcessing.makeSignal(totalADC, cru, pad, pedestal, noise);
+  const float mADC = sampaProcessing.makeSignal(totalADC, cru.sector(), globalPad, pedestal, noise);
 
   /// only write out the data if there is actually charge on that pad
   if (mADC > 0 && mChargePad > 0) {

--- a/Detectors/TPC/simulation/src/DigitTime.cxx
+++ b/Detectors/TPC/simulation/src/DigitTime.cxx
@@ -13,19 +13,5 @@
 /// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
 
 #include "TPCSimulation/DigitTime.h"
-#include "TPCBase/Mapper.h"
 
 using namespace o2::TPC;
-
-void DigitTime::fillOutputContainer(std::vector<Digit>* output, dataformats::MCTruthContainer<MCCompLabel>& mcTruth,
-                                    std::vector<DigitMCMetaData>* debug, const Sector& sector, TimeBin timeBin,
-                                    float commonMode)
-{
-  static Mapper& mapper = Mapper::instance();
-  GlobalPadNumber globalPad = 0;
-  for (auto& pad : mGlobalPads) {
-    const int cru = mapper.getCRU(sector, globalPad);
-    pad.fillOutputContainer(output, mcTruth, debug, cru, timeBin, globalPad, getCommonMode(cru));
-    ++globalPad;
-  }
-}


### PR DESCRIPTION
This is a simplification in the calibration object access. It significantly reduces function calls to the mapper, assuming a specific topology of the calibration object.
For the future, the CalDet and CalArray objects should be optimized.