### PR TITLE
Fix Segmentation copy bug and split file into .h and .inl.

### DIFF
--- a/Detectors/MUON/MCH/Mapping/Interface/include/MCHMappingInterface/Segmentation.inl
+++ b/Detectors/MUON/MCH/Mapping/Interface/include/MCHMappingInterface/Segmentation.inl
@@ -33,9 +33,7 @@ inline void swap(Segmentation& a, Segmentation& b)
   swap(a.mPadIndexOffset, b.mPadIndexOffset);
 }
 
-inline Segmentation::Segmentation(const Segmentation& seg) : mBending{ seg.mBending }, mNonBending{ seg.mNonBending }, mDetElemId{ seg.mDetElemId }, mPadIndexOffset{ seg.mPadIndexOffset }
-{
-}
+inline Segmentation::Segmentation(const Segmentation& seg) = default;
 
 inline Segmentation::Segmentation(const Segmentation&& seg) : mBending{ std::move(seg.mBending) }, mNonBending{ std::move(seg.mNonBending) }, mDetElemId{ seg.mDetElemId }, mPadIndexOffset{ seg.mPadIndexOffset }
 {

--- a/Detectors/MUON/MCH/Mapping/Interface/include/MCHMappingInterface/Segmentation.inl
+++ b/Detectors/MUON/MCH/Mapping/Interface/include/MCHMappingInterface/Segmentation.inl
@@ -1,0 +1,221 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+namespace o2
+{
+namespace mch
+{
+namespace mapping
+{
+
+inline Segmentation::Segmentation(int deid) : mDetElemId{ deid }, mBending{ CathodeSegmentation(deid, true) }, mNonBending{ CathodeSegmentation(deid, false) }, mPadIndexOffset{ mBending.nofPads() }
+{
+}
+
+inline bool Segmentation::operator==(const Segmentation& rhs) const
+{
+  return mDetElemId == rhs.mDetElemId;
+}
+
+inline bool Segmentation::operator!=(const Segmentation& rhs) const { return !(rhs == *this); }
+
+inline void swap(Segmentation& a, Segmentation& b)
+{
+  using std::swap;
+  swap(a.mDetElemId, b.mDetElemId);
+  swap(a.mPadIndexOffset, b.mPadIndexOffset);
+}
+
+inline Segmentation::Segmentation(const Segmentation& seg) : mBending{ seg.mBending }, mNonBending{ seg.mNonBending }, mDetElemId{ seg.mDetElemId }, mPadIndexOffset{ seg.mPadIndexOffset }
+{
+}
+
+inline Segmentation::Segmentation(const Segmentation&& seg) : mBending{ std::move(seg.mBending) }, mNonBending{ std::move(seg.mNonBending) }, mDetElemId{ seg.mDetElemId }, mPadIndexOffset{ seg.mPadIndexOffset }
+{
+}
+
+inline Segmentation& Segmentation::operator=(Segmentation seg)
+{
+  swap(*this, seg);
+  return *this;
+}
+
+inline int Segmentation::findPadByFEE(int dualSampaId, int dualSampaChannel) const
+{
+  bool isBending = dualSampaId < 1024;
+  int catPadIndex;
+  if (isBending) {
+    catPadIndex = mBending.findPadByFEE(dualSampaId, dualSampaChannel);
+    if (!mBending.isValid(catPadIndex)) {
+      return -1;
+    }
+  } else {
+    catPadIndex = mNonBending.findPadByFEE(dualSampaId, dualSampaChannel);
+    if (!mNonBending.isValid(catPadIndex)) {
+      return -1;
+    }
+  }
+  return padC2DE(catPadIndex, isBending);
+}
+
+inline bool Segmentation::isValid(int dePadIndex) const
+{
+  if (dePadIndex < mPadIndexOffset) {
+    return mBending.isValid(dePadIndex);
+  }
+  return mNonBending.isValid(dePadIndex - mPadIndexOffset);
+}
+
+inline int Segmentation::padC2DE(int catPadIndex, bool isBending) const
+{
+  if (isBending) {
+    return catPadIndex;
+  }
+  return catPadIndex + mPadIndexOffset;
+}
+
+inline void Segmentation::catSegPad(int dePadIndex, const CathodeSegmentation*& catseg, int& padcuid) const
+{
+  if (!isValid(dePadIndex)) {
+    catseg = nullptr;
+    return;
+  }
+  if (dePadIndex < mPadIndexOffset) {
+    catseg = &mBending;
+    padcuid = dePadIndex;
+    return;
+  }
+  catseg = &mNonBending;
+  padcuid = dePadIndex - mPadIndexOffset;
+}
+
+inline bool Segmentation::findPadPairByPosition(double x, double y, int& b, int& nb) const
+{
+  b = mBending.findPadByPosition(x, y);
+  nb = mNonBending.findPadByPosition(x, y);
+  if (!mBending.isValid(b) || !mNonBending.isValid(nb)) {
+    return false;
+  }
+  b = padC2DE(b, true);
+  nb = padC2DE(nb, false);
+  return true;
+}
+
+template <typename CALLABLE>
+void Segmentation::forEachPad(CALLABLE&& func) const
+{
+  mBending.forEachPad(func);
+  int offset{ mPadIndexOffset };
+  mNonBending.forEachPad([&offset, &func](int catPadIndex) {
+    func(catPadIndex + offset);
+  });
+}
+
+template <typename CALLABLE>
+void Segmentation::forEachPadInArea(double xmin, double ymin, double xmax, double ymax, CALLABLE&& func) const
+{
+  mBending.forEachPadInArea(xmin, ymin, xmax, ymax, func);
+  int offset{ mPadIndexOffset };
+  mNonBending.forEachPadInArea(xmin, ymin, xmax, ymax, [&offset, &func](int catPadIndex) {
+    func(catPadIndex + offset);
+  });
+}
+
+template <typename CALLABLE>
+void Segmentation::forEachNeighbouringPad(int dePadIndex, CALLABLE&& func) const
+{
+  const CathodeSegmentation* catSeg{ nullptr };
+  int catPadIndex;
+  catSegPad(dePadIndex, catSeg, catPadIndex);
+
+  int offset{ 0 };
+  if (!isBendingPad(dePadIndex)) {
+    offset = mPadIndexOffset;
+  }
+  catSeg->forEachNeighbouringPad(catPadIndex, [&offset, &func](int cindex) {
+    func(cindex + offset);
+  });
+}
+
+inline std::string Segmentation::padAsString(int dePadIndex) const
+{
+  if (!isValid(dePadIndex)) {
+    return "invalid pad with index=" + std::to_string(dePadIndex);
+  }
+  const CathodeSegmentation* catSeg{ nullptr };
+  int catPadIndex;
+  catSegPad(dePadIndex, catSeg, catPadIndex);
+  auto s = catSeg->padAsString(catPadIndex);
+  if (isBendingPad(dePadIndex)) {
+    s += " (B)";
+  } else {
+    s += " (NB)";
+  }
+  return s;
+}
+
+inline int Segmentation::padDualSampaId(int dePadIndex) const
+{
+  const CathodeSegmentation* catSeg{ nullptr };
+  int catPadIndex;
+  catSegPad(dePadIndex, catSeg, catPadIndex);
+  return catSeg->padDualSampaId(catPadIndex);
+}
+
+inline int Segmentation::padDualSampaChannel(int dePadIndex) const
+{
+  const CathodeSegmentation* catSeg{ nullptr };
+  int catPadIndex;
+  catSegPad(dePadIndex, catSeg, catPadIndex);
+  return catSeg->padDualSampaChannel(catPadIndex);
+}
+
+inline double Segmentation::padPositionX(int dePadIndex) const
+{
+  const CathodeSegmentation* catSeg{ nullptr };
+  int catPadIndex;
+  catSegPad(dePadIndex, catSeg, catPadIndex);
+  return catSeg->padPositionX(catPadIndex);
+}
+
+inline double Segmentation::padPositionY(int dePadIndex) const
+{
+  const CathodeSegmentation* catSeg{ nullptr };
+  int catPadIndex;
+  catSegPad(dePadIndex, catSeg, catPadIndex);
+  return catSeg->padPositionY(catPadIndex);
+}
+
+inline double Segmentation::padSizeX(int dePadIndex) const
+{
+  const CathodeSegmentation* catSeg{ nullptr };
+  int catPadIndex;
+  catSegPad(dePadIndex, catSeg, catPadIndex);
+  return catSeg->padSizeX(catPadIndex);
+}
+
+inline double Segmentation::padSizeY(int dePadIndex) const
+{
+  const CathodeSegmentation* catSeg{ nullptr };
+  int catPadIndex;
+  catSegPad(dePadIndex, catSeg, catPadIndex);
+  return catSeg->padSizeY(catPadIndex);
+}
+
+inline int Segmentation::detElemId() const { return mDetElemId; }
+inline int Segmentation::nofPads() const { return bending().nofPads() + nonBending().nofPads(); }
+inline int Segmentation::nofDualSampas() const { return bending().nofDualSampas() + nonBending().nofDualSampas(); }
+
+inline const CathodeSegmentation& Segmentation::bending() const { return mBending; }
+inline const CathodeSegmentation& Segmentation::nonBending() const { return mNonBending; }
+
+} // namespace mapping
+} // namespace mch
+} // namespace o2

--- a/Detectors/MUON/MCH/Mapping/README.md
+++ b/Detectors/MUON/MCH/Mapping/README.md
@@ -1,21 +1,21 @@
-# MCH Mapping 
+# MCH Mapping
 
 # API
 
-Two APIs are offered to the MCH Mapping : 
-a [C interface](Interface/include/MCHMappingInterface/SegmentationCInterface.h) 
+Two APIs are offered to the MCH Mapping :
+a [C interface](Interface/include/MCHMappingInterface/SegmentationCInterface.h)
 (the core one) and a [C++ interface](Interface/include/MCHMappingInterface/Segmentation.h).
 
-The pattern of this dual interface follows the [Hourglass idea](https://github.com/CppCon/CppCon2014/tree/master/Presentations/Hourglass%20Interfaces%20for%20C%2B%2B%20APIs). 
+The pattern of this dual interface follows the [Hourglass idea](https://github.com/CppCon/CppCon2014/tree/master/Presentations/Hourglass%20Interfaces%20for%20C%2B%2B%20APIs).
 In a nutshell, the core interface is written in C so it can be accessed easily
- from different languages and offers a stable ABI.
- 
-But most users are only exposed to a header-only [C++ interface](Interface/include/MCHMappingInterface/Segmentation.h) which sits on top 
+from different languages and offers a stable ABI.
+
+But most users are only exposed to a header-only [C++ interface](Interface/include/MCHMappingInterface/Segmentation.h) which sits on top
 of this core C interface.
 
-Details are to be found in the interface file or in the doxygen documentation, but 
- the basics of the interface is :
- 
+Details are to be found in the interface file or in the doxygen documentation, but
+the basics of the interface is :
+
 ```c++
 int detElemId{100};
 
@@ -28,29 +28,29 @@ int b, nb;
 book found = seg.findPadPairByPosition(x, y, b, nb);
 
 if (seg.isValid(b)) {
-  std::cout << "There is a bending pad at position " << x << "," << y << "\n"
-            << " which belongs to dualSampa " << seg.padDualSampaId(b)
-            << " and has a x-size of " << seg.padSizeX(b) << " cm\n";
+std::cout << "There is a bending pad at position " << x << "," << y << "\n"
+<< " which belongs to dualSampa " << seg.padDualSampaId(b)
+<< " and has a x-size of " << seg.padSizeX(b) << " cm\n";
 }
 
 assert(b == seg.findPadByFEE(76, 9));
-  
+
 ```
 
-Note that cathode-specific segmentations can be retrieved from `Segmentation` 
-objects (using Bending() and NonBending() methods) or created from scratch
+Note that cathode-specific segmentations can be retrieved from `Segmentation`
+objects (using bending() and nonBending() methods) or created from scratch
 using the `CathodeSegmentation(int detElemId, bool isBendingPlane)` constructor.
 
 # Implementations
 
 Currently [one implementation](Impl3/README.md) is provided. It is faster than the legacy AliRoot one
- (but not by an order of magnitude...). Extensive checks have been made to insure it yields
-  the same results as AliRoot (see the `vsaliroot` directory in the [alo repository](https://github.com/mrrtf/alo) ).
+(but not by an order of magnitude...). Extensive checks have been made to insure it yields
+the same results as AliRoot (see the `vsaliroot` directory in the [alo repository](https://github.com/mrrtf/alo) ).
 
 # Contours
 
 Besides to core API (finding pads by position and by electronic ids), we offer
- [convenience functions](SegContour/README.md) to compute the bounding box and [envelop of the segmentations](SegContour/include/MCHMappingSegContour/SegmentationContours.h).
- 
- A simple executable, `mch-mapping-svg-segmentation3` can be used to produce [SVG](https://developer.mozilla.org/en-US/docs/Web/SVG) plots
- of the segmentations.
+[convenience functions](SegContour/README.md) to compute the bounding box and [envelop of the segmentations](SegContour/include/MCHMappingSegContour/SegmentationContours.h).
+
+A simple executable, `mch-mapping-svg-segmentation3` can be used to produce [SVG](https://developer.mozilla.org/en-US/docs/Web/SVG) plots
+of the segmentations.

--- a/Detectors/MUON/MCH/Mapping/SegContour/src/SegmentationContours.cxx
+++ b/Detectors/MUON/MCH/Mapping/SegContour/src/SegmentationContours.cxx
@@ -31,7 +31,7 @@ Contour<double> getEnvelop(const Segmentation& seg)
 {
   std::vector<Polygon<double>> polygons;
 
-  for (auto& contour : { getEnvelop(seg.NonBending()), getEnvelop(seg.Bending()) }) {
+  for (auto& contour : { getEnvelop(seg.nonBending()), getEnvelop(seg.bending()) }) {
     for (auto& p : contour.getPolygons()) {
       polygons.push_back(p);
     }

--- a/Detectors/MUON/MCH/Simulation/src/Digitizer.cxx
+++ b/Detectors/MUON/MCH/Simulation/src/Digitizer.cxx
@@ -137,8 +137,8 @@ int Digitizer::processHit(const Hit& hit, double event_time)
   std::vector<int> padIDsnon;
 
   //retrieve pads with signal
-  mSeg[indexID].Bending().forEachPadInArea(xMin, yMin, xMax, yMax, [&padIDsbend](int padid) { padIDsbend.emplace_back(padid); });
-  mSeg[indexID].NonBending().forEachPadInArea(xMin, yMin, xMax, yMax, [&padIDsnon](int padid) { padIDsnon.emplace_back(padid); });
+  mSeg[indexID].bending().forEachPadInArea(xMin, yMin, xMax, yMax, [&padIDsbend](int padid) { padIDsbend.emplace_back(padid); });
+  mSeg[indexID].nonBending().forEachPadInArea(xMin, yMin, xMax, yMax, [&padIDsnon](int padid) { padIDsnon.emplace_back(padid); });
 
   //induce signal pad-by-pad: bending
   for (auto& padidbend : padIDsbend) {


### PR DESCRIPTION
The bug (see corresponding new CheckPadOffsetsAfterCopy test) was causing
 an incorrect value returned by Segmentation::isBendingPad(padid) method,
 as long as the segmentation object has been _copied_ before (a freshly
  constructed object was just fine).

The split should make the interface easier to look at, as the .h now contains
only the declarations. The implementation is fully in the .inl file.

Also fix the case of Segmentation Bending and NonBending methods (which should
 start with lower case letters).