### PR TITLE
Revert "Implementing std::hash specialization for MCCompLabel"

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/MCCompLabel.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCCompLabel.h
@@ -25,6 +25,8 @@ class MCCompLabel
 
   ULong64_t mLabel = NotSet; ///< MC label encoding MCtrack ID and MCevent origin
 
+  void checkFieldConsistensy();
+
  public:
   // number of bits reserved for MC track ID, DON'T modify this, since the
   // track ID might be negative
@@ -32,11 +34,6 @@ class MCCompLabel
   static constexpr int nbitsEvID = 19; // number of bits reserved for MC event ID
   static constexpr int nbitsSrcID = 8; // number of bits reserved for MC source ID
   // the rest of the bits is reserved at the moment
-
-  // check if the fields are defined consistently
-  static_assert(nbitsTrackID == sizeof(int) * 8, "TrackID must have int size");
-  static_assert(nbitsTrackID + nbitsEvID + nbitsSrcID <= sizeof(ULong64_t) * 8,
-                "Fields cannot be stored in 64 bits");
 
   // mask to extract MC track ID
   static constexpr ULong64_t maskTrackID = (ul0x1 << nbitsTrackID) - 1;
@@ -104,18 +101,5 @@ class MCCompLabel
 }
 
 std::ostream& operator<<(std::ostream& os, const o2::MCCompLabel& c);
-
-namespace std
-{
-// defining std::hash for MCCompLabel in order to be used with unordered_maps
-template <>
-struct hash<o2::MCCompLabel> {
- public:
-  size_t operator()(o2::MCCompLabel const& label) const
-  {
-    return static_cast<uint64_t>(label);
-  }
-};
-} // namespace std
 
 #endif

--- a/DataFormats/simulation/src/MCCompLabel.cxx
+++ b/DataFormats/simulation/src/MCCompLabel.cxx
@@ -37,3 +37,12 @@ std::ostream& operator<<(std::ostream& os, const o2::MCCompLabel& c)
   }
   return os;
 }
+
+ //_____________________________________________
+void MCCompLabel::checkFieldConsistensy()
+{
+  // check if the fields are defined consistently
+  static_assert(nbitsTrackID==sizeof(int)*8, "TrackID must have int size");
+  static_assert(nbitsTrackID+nbitsEvID+nbitsSrcID<=sizeof(ULong64_t)*8,
+                "Fields cannot be stored in 64 bits");
+}

--- a/DataFormats/simulation/test/testMCCompLabel.cxx
+++ b/DataFormats/simulation/test/testMCCompLabel.cxx
@@ -25,22 +25,16 @@ BOOST_AUTO_TEST_CASE(MCCompLabel_test)
   BOOST_CHECK(!lbUndef.isSet()); // test invalid label status
 
   int ev = 200, src = 10;
-  std::unordered_map<MCCompLabel, int> labelMap;
   for (int tr=-100;tr<200;tr+=150) {
     MCCompLabel lb(tr, ev, src);
     std::cout << "Input:   [" << src << '/' << ev << '/'
               << std::setw(6) << tr << ']' << std::endl;
     std::cout << "Encoded: " << lb << " (packed: " << ULong_t(lb) << ")" << std::endl;
-    labelMap[lb] = tr;
     int trE, evE, srcE;
     lb.get(trE, evE, srcE);
     std::cout << "Decoded: [" << srcE << '/' << evE << '/'
               << std::setw(6) << trE << ']' << std::endl;
 
     BOOST_CHECK(tr == trE && ev == evE && src == srcE);
-  }
-
-  for (auto& [key, value] : labelMap) {
-    BOOST_CHECK(key.getTrackID() == value);
   }
 }


### PR DESCRIPTION
This reverts commit b8470f8bde8d283fa0cec33da9aa24e91ed3e142.
It breaks compilation on MacOS which needs to fixed first.