### PR TITLE
Fix multiple library linking

### DIFF
--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -1186,9 +1186,7 @@ o2_define_bucket(
     tpc_monitor_bucket
 
     DEPENDENCIES
-    tpc_calibration_bucket
-    tpc_base_bucket
-    tpc_reconstruction_bucket
+    common_vc_bucket
     DetectorsBase
     TPCBase
     TPCCalibration
@@ -1198,6 +1196,8 @@ o2_define_bucket(
     ${CMAKE_SOURCE_DIR}/Detectors/TPC/base/include
     ${CMAKE_SOURCE_DIR}/Detectors/TPC/calibration/include
     ${CMAKE_SOURCE_DIR}/Detectors/TPC/reconstruction/include
+    ${CMAKE_SOURCE_DIR}/DataFormats/Detectors/TPC/include
+    ${CMAKE_SOURCE_DIR}/Common/MathUtils/include
 )
 
 o2_define_bucket(


### PR DESCRIPTION
Due to bucket inclusions, many libraries appeared multiple times in the
linking phase. On some distributions this causes the linker to take very
long.
This fix removes the bucket inclusions.