### PR TITLE
Speedup linking of tpc_monitor

### DIFF
--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -1186,9 +1186,6 @@ o2_define_bucket(
     tpc_monitor_bucket
 
     DEPENDENCIES
-    tpc_calibration_bucket
-    tpc_base_bucket
-    tpc_reconstruction_bucket
     DetectorsBase
     TPCBase
     TPCCalibration
@@ -1198,6 +1195,11 @@ o2_define_bucket(
     ${CMAKE_SOURCE_DIR}/Detectors/TPC/base/include
     ${CMAKE_SOURCE_DIR}/Detectors/TPC/calibration/include
     ${CMAKE_SOURCE_DIR}/Detectors/TPC/reconstruction/include
+    ${CMAKE_SOURCE_DIR}/Common/MathUtils/include
+    ${CMAKE_SOURCE_DIR}/DataFormats/Detectors/TPC/include
+    ${CMAKE_SOURCE_DIR}/DataFormats/common/include
+    ${Vc_INCLUDE_DIR}
+    ${Boost_INCLUDE_DIR}
 )
 
 o2_define_bucket(


### PR DESCRIPTION
This solves an issue in linking tpc_monitor
(on Ubuntu18.04). The problem was that the bucket system
accumulates duplicate libraries for the linker invocation coming
from an overlap of bucket and module dependencies.

The problem is fixed by reducing the bucket dependencies
(at the cost of having to declare more include paths for ROOT
dictionary creation)

We should ideally revise the bucket system and modernize it, but until then
this commit reduces the link time by about a minute.

Fixes https://alice.its.cern.ch/jira/browse/O2-491