### PR TITLE
Generator-level implementation of embedding into background

### DIFF
--- a/Common/SimConfig/include/SimConfig/SimConfig.h
+++ b/Common/SimConfig/include/SimConfig/SimConfig.h
@@ -28,6 +28,7 @@ struct SimConfigData {
   std::string mExtKinFileName;               // file name of external kinematics file (needed for ext kinematics generator)
   std::string mExtGenFileName;               // file name containing the external generator configuration
   std::string mExtGenFuncName;               // function call to retrieve the external generator configuration
+  std::string mEmbedIntoFileName;            // filename containing the reference events to be used for the embedding
   unsigned int mStartEvent;                  // index of first event to be taken
   float mBMax;                               // maximum for impact parameter sampling
   bool mIsMT;                                // chosen MT mode (Geant4 only)
@@ -91,6 +92,7 @@ class SimConfig
   std::string getExtKinematicsFileName() const { return mConfigData.mExtKinFileName; }
   std::string getExtGeneratorFileName() const { return mConfigData.mExtGenFileName; }
   std::string getExtGeneratorFuncName() const { return mConfigData.mExtGenFuncName; }
+  std::string getEmbedIntoFileName() const { return mConfigData.mEmbedIntoFileName; }
   unsigned int getStartEvent() const { return mConfigData.mStartEvent; }
   float getBMax() const { return mConfigData.mBMax; }
   bool getIsMT() const { return mConfigData.mIsMT; }

--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -33,6 +33,8 @@ void SimConfig::initOptions(boost::program_options::options_description& options
     "name of .C file with definition of external event generator")(
     "extGenFunc", bpo::value<std::string>()->default_value(""),
     "function call to load the definition of external event generator")(
+    "embedIntoFile", bpo::value<std::string>()->default_value(""),
+    "filename containing the reference events to be used for the embedding")(
     "bMax,b", bpo::value<float>()->default_value(0.), "maximum value for impact parameter sampling (when applicable)")(
     "isMT", bpo::value<bool>()->default_value(false), "multi-threaded mode (Geant4 only")(
     "outPrefix,o", bpo::value<std::string>()->default_value("o2sim"), "prefix of output files")(
@@ -78,6 +80,7 @@ bool SimConfig::resetFromParsedMap(boost::program_options::variables_map const& 
   mConfigData.mExtKinFileName = vm["extKinFile"].as<std::string>();
   mConfigData.mExtGenFileName = vm["extGenFile"].as<std::string>();
   mConfigData.mExtGenFuncName = vm["extGenFunc"].as<std::string>();
+  mConfigData.mEmbedIntoFileName = vm["embedIntoFile"].as<std::string>();
   mConfigData.mStartEvent = vm["startEvent"].as<unsigned int>();
   mConfigData.mBMax = vm["bMax"].as<float>();
   mConfigData.mIsMT = vm["isMT"].as<bool>();

--- a/DataFormats/simulation/CMakeLists.txt
+++ b/DataFormats/simulation/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SRCS
   src/MCCompLabel.cxx
   src/RunContext.cxx
   src/StackParam.cxx
+  src/MCEventHeader.cxx
 )
 
 Set(HEADERS
@@ -21,6 +22,7 @@ Set(HEADERS
     include/${MODULE_NAME}/PrimaryChunk.h
     include/${MODULE_NAME}/RunContext.h
     include/${MODULE_NAME}/LabelContainer.h
+    include/${MODULE_NAME}/MCEventHeader.h
 )
 
 Set(LINKDEF src/SimulationDataLinkDef.h)

--- a/DataFormats/simulation/include/SimulationDataFormat/MCEventHeader.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCEventHeader.h
@@ -1,0 +1,59 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author R+Preghenella - August 2017
+
+#ifndef ALICEO2_DATAFORMATS_MCEVENTHEADER_H_
+#define ALICEO2_DATAFORMATS_MCEVENTHEADER_H_
+
+#include "FairMCEventHeader.h"
+#include <string>
+
+namespace o2
+{
+namespace dataformats
+{
+
+class GeneratorHeader;
+
+/*****************************************************************/
+/*****************************************************************/
+
+class MCEventHeader : public FairMCEventHeader
+{
+
+ public:
+  MCEventHeader() = default;
+  MCEventHeader(const MCEventHeader& rhs) = default;
+  MCEventHeader& operator=(const MCEventHeader& rhs) = default;
+  ~MCEventHeader() = default;
+
+  /** setters **/
+  void setEmbeddingFileName(std::string value) { mEmbeddingFileName = value; };
+  void setEmbeddingEventIndex(Int_t value) { mEmbeddingEventIndex = value; };
+
+  /** methods **/
+  virtual void Reset();
+
+ protected:
+  std::string mEmbeddingFileName;
+  Int_t mEmbeddingEventIndex = 0;
+
+  ClassDefOverride(MCEventHeader, 1);
+
+}; /** class MCEventHeader **/
+
+/*****************************************************************/
+/*****************************************************************/
+
+} /* namespace dataformats */
+} /* namespace o2 */
+
+#endif /* ALICEO2_DATAFORMATS_MCEVENTHEADER_H_ */

--- a/DataFormats/simulation/include/SimulationDataFormat/PrimaryChunk.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/PrimaryChunk.h
@@ -12,7 +12,7 @@
 #define ALICEO2_DATA_PRIMARYCHUNK_H_
 
 #include <cstring>
-#include <FairMCEventHeader.h>
+#include <SimulationDataFormat/MCEventHeader.h>
 
 namespace o2
 {
@@ -33,7 +33,7 @@ struct SubEventInfo {
   int32_t npersistenttracks = -1; // the number of persistent tracks for this SubEvent (might be set to cache it)
   // might add more fields (such as which process treated this chunk etc)
 
-  FairMCEventHeader mMCEventHeader; // associated FairMC header for vertex information
+  o2::dataformats::MCEventHeader mMCEventHeader; // associated FairMC header for vertex information
 
   ClassDefNV(SubEventInfo, 1);
 };

--- a/DataFormats/simulation/src/MCEventHeader.cxx
+++ b/DataFormats/simulation/src/MCEventHeader.cxx
@@ -1,0 +1,39 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author R+Preghenella - August 2017
+
+#include "SimulationDataFormat/MCEventHeader.h"
+#include "FairRootManager.h"
+
+namespace o2
+{
+namespace dataformats
+{
+
+/*****************************************************************/
+/*****************************************************************/
+
+void MCEventHeader::Reset()
+{
+  /** reset **/
+
+  mEmbeddingFileName.clear();
+  mEmbeddingEventIndex = 0;
+  FairMCEventHeader::Reset();
+}
+
+/*****************************************************************/
+/*****************************************************************/
+
+} /* namespace dataformats */
+} /* namespace o2 */
+
+ClassImp(o2::dataformats::MCEventHeader)

--- a/DataFormats/simulation/src/SimulationDataLinkDef.h
+++ b/DataFormats/simulation/src/SimulationDataLinkDef.h
@@ -57,4 +57,6 @@
 #pragma link C++ class vector < o2::steer::EventPart > +;
 #pragma link C++ class vector < vector < o2::steer::EventPart >> +;
 
+#pragma link C++ class o2::dataformats::MCEventHeader + ;
+
 #endif

--- a/Generators/include/Generators/PrimaryGenerator.h
+++ b/Generators/include/Generators/PrimaryGenerator.h
@@ -15,6 +15,11 @@
 
 #include "FairPrimaryGenerator.h"
 
+class TFile;
+class TTree;
+class TString;
+class FairMCEventHeader;
+
 namespace o2
 {
 namespace eventgen
@@ -32,10 +37,22 @@ class PrimaryGenerator : public FairPrimaryGenerator
   /** default constructor **/
   PrimaryGenerator() = default;
   /** destructor **/
-  virtual ~PrimaryGenerator() = default;
+  virtual ~PrimaryGenerator();
+
+  /** Public method GenerateEvent
+      To be called at the beginning of each event from FairMCApplication.
+      Generates an event vertex and calls the ReadEvent methods from the
+      registered generators.
+      *@param pStack The particle stack
+      *@return kTRUE if successful, kFALSE if not
+      **/
+  Bool_t GenerateEvent(FairGenericStack* pStack) override;
 
   /** initialize the generator **/
   virtual Bool_t Init() override;
+
+  /** Public embedding methods **/
+  Bool_t embedInto(TString fname);
 
  protected:
   /** copy constructor **/
@@ -46,7 +63,17 @@ class PrimaryGenerator : public FairPrimaryGenerator
   /** set interaction diamond position **/
   void setInteractionDiamond(const Double_t* xyz, const Double_t* sigmaxyz);
 
-  ClassDefOverride(PrimaryGenerator, 1);
+  /** set interaction vertex position **/
+  void setInteractionVertex(const FairMCEventHeader* event);
+
+  /** embedding members **/
+  TFile* mEmbedFile = nullptr;
+  TTree* mEmbedTree = nullptr;
+  Int_t mEmbedEntries = 0;
+  Int_t mEmbedCounter = 0;
+  FairMCEventHeader* mEmbedEvent = nullptr;
+
+  ClassDefOverride(PrimaryGenerator, 2);
 
 }; /** class PrimaryGenerator **/
 

--- a/Generators/include/Generators/PrimaryGenerator.h
+++ b/Generators/include/Generators/PrimaryGenerator.h
@@ -18,7 +18,14 @@
 class TFile;
 class TTree;
 class TString;
-class FairMCEventHeader;
+
+namespace o2
+{
+namespace dataformats
+{
+class MCEventHeader;
+}
+} // namespace o2
 
 namespace o2
 {
@@ -64,14 +71,14 @@ class PrimaryGenerator : public FairPrimaryGenerator
   void setInteractionDiamond(const Double_t* xyz, const Double_t* sigmaxyz);
 
   /** set interaction vertex position **/
-  void setInteractionVertex(const FairMCEventHeader* event);
+  void setInteractionVertex(const o2::dataformats::MCEventHeader* event);
 
   /** embedding members **/
   TFile* mEmbedFile = nullptr;
   TTree* mEmbedTree = nullptr;
   Int_t mEmbedEntries = 0;
-  Int_t mEmbedCounter = 0;
-  FairMCEventHeader* mEmbedEvent = nullptr;
+  Int_t mEmbedIndex = 0;
+  o2::dataformats::MCEventHeader* mEmbedEvent = nullptr;
 
   ClassDefOverride(PrimaryGenerator, 2);
 

--- a/Generators/src/PrimaryGenerator.cxx
+++ b/Generators/src/PrimaryGenerator.cxx
@@ -12,12 +12,14 @@
 
 #include "Generators/PrimaryGenerator.h"
 #include "Generators/InteractionDiamondParam.h"
+#include "SimulationDataFormat/MCEventHeader.h"
 #include "FairLogger.h"
 
 #include "FairGenericStack.h"
-#include "FairMCEventHeader.h"
 #include "TFile.h"
 #include "TTree.h"
+
+using o2::dataformats::MCEventHeader;
 
 namespace o2
 {
@@ -76,7 +78,7 @@ Bool_t PrimaryGenerator::GenerateEvent(FairGenericStack* pStack)
   /** this is for embedding **/
 
   /** setup interaction vertex **/
-  mEmbedTree->GetEntry(mEmbedCounter);
+  mEmbedTree->GetEntry(mEmbedIndex);
   setInteractionVertex(mEmbedEvent);
 
   /** generate event **/
@@ -84,15 +86,15 @@ Bool_t PrimaryGenerator::GenerateEvent(FairGenericStack* pStack)
     return kFALSE;
 
   /** add embedding info to event header **/
-  //  auto o2event = dynamic_cast<MCEventHeader*>(fEvent);
-  //  if (o2event) {
-  //    o2event->setEmbeddingFileName(mEmbedFile->GetName());
-  //    o2event->setEmbeddingEventCounter(mEmbedCounter);
-  //  }
+  auto o2event = dynamic_cast<MCEventHeader*>(fEvent);
+  if (o2event) {
+    o2event->setEmbeddingFileName(mEmbedFile->GetName());
+    o2event->setEmbeddingEventIndex(mEmbedIndex);
+  }
 
   /** increment embedding counter **/
-  mEmbedCounter++;
-  mEmbedCounter %= mEmbedEntries;
+  mEmbedIndex++;
+  mEmbedIndex %= mEmbedEntries;
 
   /** success **/
   return kTRUE;
@@ -118,7 +120,7 @@ void PrimaryGenerator::setInteractionDiamond(const Double_t* xyz, const Double_t
 
 /*****************************************************************/
 
-void PrimaryGenerator::setInteractionVertex(const FairMCEventHeader* event)
+void PrimaryGenerator::setInteractionVertex(const MCEventHeader* event)
 {
   /** set interaction vertex **/
 
@@ -165,7 +167,7 @@ Bool_t PrimaryGenerator::embedInto(TString fname)
   }
 
   /** connect MC event header **/
-  mEmbedEvent = new FairMCEventHeader;
+  mEmbedEvent = new MCEventHeader;
   mEmbedTree->SetBranchAddress("MCEventHeader.", &mEmbedEvent);
 
   /** success **/

--- a/Steer/src/O2MCApplication.cxx
+++ b/Steer/src/O2MCApplication.cxx
@@ -22,7 +22,7 @@
 #include <DetectorsBase/Detector.h>
 #include <CommonUtils/ShmManager.h>
 #include <cassert>
-#include <FairMCEventHeader.h>
+#include <SimulationDataFormat/MCEventHeader.h>
 
 namespace o2
 {

--- a/doc/DetectorSimulation.md
+++ b/doc/DetectorSimulation.md
@@ -80,7 +80,18 @@ Use the **`-g extkin`** command line option:
 o2sim -g extkin --extKinFile Kinematics.root ...
 ```
 
-#### 4. **How can I obtained detailed stepping information?**
+#### 4. **How can I generate events (signal) using the vertex position of already-generated (background) events?**
+
+This process might be called embedding, where one wants to merge two events generated independenly. For that to be physically correct, both events have to originate from the same interaction vertex.
+Assuming that your already-generated (background) events are stored in the `o2sim.background.root` file, you can force the interaction vertex for the generation of a new set of events to be the same as the one in the background with the following command line option:
+
+```
+o2sim --embedIntoFile o2sim.background.root
+```
+
+Background events are sampled one-by-one until all events have been used. At that point the events start to be reused.
+
+#### 5. **How can I obtained detailed stepping information?**
 Run the simulation (best in version `o2sim_serial`) with a preloaded library:
 ```
 MCSTEPLOG_TTREE=1 LD_PRELOAD=$O2_ROOT/lib/libMCStepLogger.so o2sim_serial -j 1 -n 10

--- a/macro/o2sim.C
+++ b/macro/o2sim.C
@@ -72,7 +72,11 @@ FairRunSim* o2sim_init(bool asservice)
   build_geometry(run);
 
   // setup generator
+  auto embedinto_filename = confref.getEmbedIntoFileName();
   auto primGen = new o2::eventgen::PrimaryGenerator();
+  if (!embedinto_filename.empty()) {
+    primGen->embedInto(embedinto_filename);
+  }
   if (!asservice) {
     o2::eventgen::GeneratorFactory::setPrimaryGenerator(confref, primGen);
   }

--- a/macro/o2sim.C
+++ b/macro/o2sim.C
@@ -13,6 +13,7 @@
 #include <Generators/PrimaryGenerator.h>
 #include <Generators/GeneratorFactory.h>
 #include <Generators/PDG.h>
+#include "SimulationDataFormat/MCEventHeader.h"
 #include <SimConfig/SimConfig.h>
 #include <SimConfig/ConfigurableParam.h>
 #include <CommonUtils/RngHelper.h>
@@ -67,6 +68,10 @@ FairRunSim* o2sim_init(bool asservice)
   run->SetOutputFile(outputfilename.c_str());  // Output file
   run->SetName(confref.getMCEngine().c_str()); // Transport engine
   run->SetIsMT(confref.getIsMT());             // MT mode
+
+  /** set event header **/
+  auto header = new o2::dataformats::MCEventHeader();
+  run->SetMCEventHeader(header);
 
   // construct geometry / including magnetic field
   build_geometry(run);

--- a/run/O2HitMerger.h
+++ b/run/O2HitMerger.h
@@ -17,7 +17,7 @@
 #include "FairMQMessage.h"
 #include <FairMQDevice.h>
 #include <FairLogger.h>
-#include <FairMCEventHeader.h>
+#include <SimulationDataFormat/MCEventHeader.h>
 #include <SimulationDataFormat/Stack.h>
 #include <SimulationDataFormat/PrimaryChunk.h>
 #include <DetectorsCommonDataFormats/DetID.h>
@@ -328,7 +328,7 @@ class O2HitMerger : public FairMQDevice
     std::map<int, std::vector<int>> entrygroups;  // collecting all entries belonging to an event
     std::map<int, std::vector<int>> trackoffsets; // collecting trackoffsets to be applied to correct
 
-    std::vector<FairMCEventHeader> eventheaders; // collecting the event headers
+    std::vector<o2::dataformats::MCEventHeader> eventheaders; // collecting the event headers
     eventheaders.resize(mNExpectedEvents);
 
     // the MC labels (trackID) for hits
@@ -370,7 +370,7 @@ class O2HitMerger : public FairMQDevice
     mergedOutTree->SetEntries(entrygroups.size());
 
     // put the event headers into the new TTree
-    FairMCEventHeader header;
+    o2::dataformats::MCEventHeader header;
     auto headerbr = o2::Base::getOrMakeBranch(*mergedOutTree, "MCEventHeader.", &header);
     for (int i = 0; i < info->maxEvents; i++) {
       header = eventheaders[i];

--- a/run/O2PrimaryServerDevice.h
+++ b/run/O2PrimaryServerDevice.h
@@ -18,7 +18,7 @@
 #include <Generators/GeneratorFactory.h>
 #include <FairMQMessage.h>
 #include <SimulationDataFormat/Stack.h>
-#include <FairMCEventHeader.h>
+#include <SimulationDataFormat/MCEventHeader.h>
 #include <TMessage.h>
 #include <TClass.h>
 #include <SimulationDataFormat/PrimaryChunk.h>
@@ -235,7 +235,7 @@ class O2PrimaryServerDevice : public FairMQDevice
  private:
   std::string mOutChannelName = "";
   o2::eventgen::PrimaryGenerator mPrimGen;
-  FairMCEventHeader mEventHeader;
+  o2::dataformats::MCEventHeader mEventHeader;
   o2::Data::Stack mStack;      // the stack which is filled
   int mChunkGranularity = 500; // how many primaries to send to a worker
   int mLastPosition = 0;       // last position in stack vector

--- a/run/O2PrimaryServerDevice.h
+++ b/run/O2PrimaryServerDevice.h
@@ -56,6 +56,11 @@ class O2PrimaryServerDevice : public FairMQDevice
     o2::conf::ConfigurableParam::updateFromString(conf.getKeyValueString());
     o2::eventgen::GeneratorFactory::setPrimaryGenerator(conf, &mPrimGen);
     mPrimGen.SetEvent(&mEventHeader);
+
+    auto embedinto_filename = conf.getEmbedIntoFileName();
+    if (!embedinto_filename.empty()) {
+      mPrimGen.embedInto(embedinto_filename);
+    }
     mPrimGen.Init();
   }
 


### PR DESCRIPTION
This commit implements a basic mechanism to allow embedding
of signal events on pre-generated background events.

The currently-supported background source is file based,
namely the user needs to specify the filename (o2sim.root)
that contains the background events. The primary generator
of the signal events will force the primary interaction
vertex to be the same as the one of the background event.
Background events are sampled one-by-one until all events
have been used. At that point the events start to be reused.

User can select the embedding mode via o2sim command-line:
o2sim --embedIntoFile o2sim.bkg.root