### PR TITLE
O2Sim: Fix in determining the default number of workers

### DIFF
--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -14,13 +14,14 @@
 #include <iostream>
 #include <FairLogger.h>
 #include <thread>
+#include <cmath>
 
 using namespace o2::conf;
 namespace bpo = boost::program_options;
 
 void SimConfig::initOptions(boost::program_options::options_description& options)
 {
-  int nsimworkersdefault = std::thread::hardware_concurrency() / 2;
+  int nsimworkersdefault = std::max(1u, std::thread::hardware_concurrency() / 2);
   options.add_options()(
     "mcEngine,e", bpo::value<std::string>()->default_value("TGeant3"), "VMC backend to be used.")(
     "generator,g", bpo::value<std::string>()->default_value("boxgen"), "Event generator to be used.")(

--- a/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
+++ b/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
@@ -98,7 +98,7 @@ void customize(std::vector<o2::framework::CompletionPolicy>& policies)
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   // for the TPC it is useful to take at most half of the available (logical) cores due to memory requirements
-  int defaultlanes = std::thread::hardware_concurrency() / 2;
+  int defaultlanes = std::max(1u, std::thread::hardware_concurrency() / 2);
   std::string laneshelp("Number of tpc processing lanes. A lane is a pipeline of algorithms.");
   workflowOptions.push_back(
     ConfigParamSpec{ "tpc-lanes", VariantType::Int, defaultlanes, { laneshelp } });

--- a/run/O2SimDeviceRunner.cxx
+++ b/run/O2SimDeviceRunner.cxx
@@ -22,6 +22,7 @@
 #include <TStopwatch.h>
 #include <sys/wait.h>
 #include <pthread.h> // to set cpu affinity
+#include <cmath>
 
 namespace bpo = boost::program_options;
 
@@ -188,7 +189,7 @@ int main(int argc, char* argv[])
     }
 
     // should be factored out?
-    int nworkers = std::thread::hardware_concurrency() / 2;
+    int nworkers = std::max(1u, std::thread::hardware_concurrency() / 2);
     auto f = getenv("ALICE_NSIMWORKERS");
     if (f) {
       nworkers = atoi(f);


### PR DESCRIPTION
In case there is only one CPU core and no hyperthreading, the current
mechanism to set the number of workers returned zero.
This commit fixes this problem.