### PR TITLE
Revert "Comment out failing test until problem resolved"

### DIFF
--- a/Framework/Utils/CMakeLists.txt
+++ b/Framework/Utils/CMakeLists.txt
@@ -49,7 +49,7 @@ O2_FRAMEWORK_WORKFLOW(
 set(TEST_SRCS
     #  test/test_RootTreeReader.cxx
       test/test_RootTreeWriter.cxx
-    # test/test_RootTreeWriterWorkflow.cxx
+      test/test_RootTreeWriterWorkflow.cxx
    )
 
 O2_GENERATE_TESTS(


### PR DESCRIPTION
This reverts commit 854daf2b7d690ceda239ecf3fa3ad6dfc50ae29c.
Should no longer be a problem with the new testing mechanism.