### PR TITLE
FindParticle problem in Geant4/HMPID/Pythia8HI

### DIFF
--- a/Generators/include/Generators/PrimaryGenerator.h
+++ b/Generators/include/Generators/PrimaryGenerator.h
@@ -2,7 +2,7 @@
 // distributed under the terms of the GNU General Public License v3 (GPL
 // Version 3), copied verbatim in the file "COPYING".
 //
-// See https://alice-o2.web.cern.ch/ for full licensing information.
+// See http://alice-o2.web.cern.ch/license for full licensing information.
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
@@ -54,6 +54,19 @@ class PrimaryGenerator : public FairPrimaryGenerator
       *@return kTRUE if successful, kFALSE if not
       **/
   Bool_t GenerateEvent(FairGenericStack* pStack) override;
+
+  /** Public method AddTrack
+      Adding a track to the MC stack. To be called within the ReadEvent
+      methods of the registered generators.
+      *@param pdgid Particle ID (PDG code)
+      *@param px,py,pz Momentum coordinates [GeV]
+      *@param vx,vy,vz Track origin relative to event vertex
+      **/
+  void AddTrack(Int_t pdgid, Double_t px, Double_t py, Double_t pz,
+                Double_t vx, Double_t vy, Double_t vz,
+                Int_t parent = -1, Bool_t wanttracking = true,
+                Double_t e = -9e9, Double_t tof = 0.,
+                Double_t weight = 0., TMCProcess proc = kPPrimary) override;
 
   /** initialize the generator **/
   virtual Bool_t Init() override;

--- a/Generators/src/GeneratorFactory.cxx
+++ b/Generators/src/GeneratorFactory.cxx
@@ -108,6 +108,18 @@ void GeneratorFactory::setPrimaryGenerator(o2::conf::SimConfig const& conf, Fair
     py8Gen->SetParameters("ParticleDecays:tau0Max 0.001");
     py8Gen->SetParameters("ParticleDecays:limitTau0 on");
     primGen->AddGenerator(py8Gen);
+  } else if (genconfig.compare("pythia8hf") == 0) {
+    // pythia8 pp (HF production)
+    // configures pythia for HF production in pp collisions at 14 TeV
+    // TODO: make this configurable
+    auto py8Gen = new o2::eventgen::Pythia8Generator();
+    py8Gen->SetParameters("Beams:idA 2212");   // p
+    py8Gen->SetParameters("Beams:idB 2212");   // p
+    py8Gen->SetParameters("Beams:eCM 14000."); // [GeV]
+    py8Gen->SetParameters("HardQCD:hardccbar on");
+    py8Gen->SetParameters("HardQCD:hardbbbar on");
+    py8Gen->SetParameters("ParticleDecays:tau0Max 0.001");
+    py8Gen->SetParameters("ParticleDecays:limitTau0 on");
     primGen->AddGenerator(py8Gen);
   } else if (genconfig.compare("pythia8hi") == 0) {
     // pythia8 heavy-ion

--- a/Generators/src/GeneratorFactory.cxx
+++ b/Generators/src/GeneratorFactory.cxx
@@ -105,9 +105,9 @@ void GeneratorFactory::setPrimaryGenerator(o2::conf::SimConfig const& conf, Fair
     py8Gen->SetParameters("Beams:idB 2212");       // p
     py8Gen->SetParameters("Beams:eCM 14000.");     // [GeV]
     py8Gen->SetParameters("SoftQCD:inelastic on"); // all inelastic processes
-    py8Gen->SetParameters("ParticleDecays:xyMax 0.1");
-    py8Gen->SetParameters("ParticleDecays:zMax 1.");
-    py8Gen->SetParameters("ParticleDecays:limitCylinder on");
+    py8Gen->SetParameters("ParticleDecays:tau0Max 0.001");
+    py8Gen->SetParameters("ParticleDecays:limitTau0 on");
+    primGen->AddGenerator(py8Gen);
     primGen->AddGenerator(py8Gen);
   } else if (genconfig.compare("pythia8hi") == 0) {
     // pythia8 heavy-ion
@@ -122,9 +122,8 @@ void GeneratorFactory::setPrimaryGenerator(o2::conf::SimConfig const& conf, Fair
     py8Gen->SetParameters("HeavyIon:SigFitDefPar 14.82,1.82,0.25,0.0,0.0,0.0,0.0,0.0"); // valid for Pb-Pb 5520 only
     py8Gen->SetParameters(
       ("HeavyIon:bWidth " + std::to_string(conf.getBMax())).c_str()); // impact parameter from 0-x [fm]
-    py8Gen->SetParameters("ParticleDecays:xyMax 0.1");
-    py8Gen->SetParameters("ParticleDecays:zMax 1.");
-    py8Gen->SetParameters("ParticleDecays:limitCylinder on");
+    py8Gen->SetParameters("ParticleDecays:tau0Max 0.001");
+    py8Gen->SetParameters("ParticleDecays:limitTau0 on");
     primGen->AddGenerator(py8Gen);
   } else if (genconfig.compare("extgen") == 0) {
     // external generator via TGenerator interface

--- a/Generators/src/PrimaryGenerator.cxx
+++ b/Generators/src/PrimaryGenerator.cxx
@@ -19,6 +19,9 @@
 #include "TFile.h"
 #include "TTree.h"
 
+#include "TDatabasePDG.h"
+#include "TVirtualMC.h"
+
 using o2::dataformats::MCEventHeader;
 
 namespace o2
@@ -98,6 +101,26 @@ Bool_t PrimaryGenerator::GenerateEvent(FairGenericStack* pStack)
 
   /** success **/
   return kTRUE;
+}
+
+/*****************************************************************/
+
+void PrimaryGenerator::AddTrack(Int_t pdgid, Double_t px, Double_t py, Double_t pz,
+                                Double_t vx, Double_t vy, Double_t vz,
+                                Int_t parent, Bool_t wanttracking,
+                                Double_t e, Double_t tof,
+                                Double_t weight, TMCProcess proc)
+{
+  /** add track **/
+
+  /** check if particle exists in PDG database **/
+  if (!TDatabasePDG::Instance()->GetParticle(pdgid)) {
+    LOG(WARN) << "Skipping particle undefined in PDG: pdg = " << pdgid;
+    return;
+  }
+
+  /** success **/
+  FairPrimaryGenerator::AddTrack(pdgid, px, py, pz, vx, vy, vz, parent, wanttracking, e, tof, weight, proc);
 }
 
 /*****************************************************************/


### PR DESCRIPTION
This PR fixes the issue reported in JIRA [02-496].

A first commit adds a protection at the PrimaryGenerator level to avoid injecting in the stack particles which are unknown to the PDG table. They are discarded and a warning is issued.

A second commit fixes an unexpected behaviour in the particle decays with Pythia8 which caused excited hadronic states (like D* and B*) to be injected in the stack (unknown particles to G3/G4) instead of being decayed. For some reason, this behaviour appears to only happen when running the heavy-ion machinery. The commit changes the strategy and now the decays are configured based on the intrinsic lifetime of the particle (decay if cTau < 1 um).

A third commit adds another Pythia8 generator configuration to force the production of heavy flavours via the selection of c-cbar and b-bbar hard production processes.