### PR TITLE
DPL: report data relaying process metrics (QC-139)

### DIFF
--- a/Framework/Core/include/Framework/DataProcessingDevice.h
+++ b/Framework/Core/include/Framework/DataProcessingDevice.h
@@ -73,6 +73,8 @@ class DataProcessingDevice : public FairMQDevice
 
   int mErrorCount;
   int mProcessingCount;
+  uint64_t mLastMetricSentTimestamp = 0; /// The timestamp of the last time we sent non-realtime metrics
+  uint64_t mBeginIterationTimestamp = 0; /// The timestamp of when the current ConditionalRun was started
 };
 
 } // namespace framework

--- a/Framework/Core/include/Framework/DataRelayer.h
+++ b/Framework/Core/include/Framework/DataRelayer.h
@@ -31,6 +31,14 @@ class Monitoring;
 namespace framework
 {
 
+/// Helper struct to hold statistics about the relaying process.
+struct DataRelayerStats {
+  uint64_t malformedInputs = 0;         /// Malformed inputs which the user attempted to process
+  uint64_t droppedComputations = 0;     /// How many computations have been dropped because one of the inputs was late
+  uint64_t droppedIncomingMessages = 0; /// How many messages have been dropped (not relayed) because they were late
+  uint64_t relayedMessages = 0;         /// How many messages have been successfully relayed
+};
+
 class DataRelayer {
 public:
   enum RelayChoice {
@@ -80,6 +88,9 @@ public:
   /// Tune the maximum number of in flight timeslices this can handle.
   void setPipelineLength(size_t s);
 
+  /// @return the current stats about the data relaying process
+  DataRelayerStats const& getStats();
+
  private:
   std::vector<InputRoute> const& mInputRoutes;
   std::vector<ForwardRoute> const& mForwardRoutes;
@@ -104,6 +115,8 @@ public:
   static std::vector<std::string> sMetricsNames;
   static std::vector<std::string> sVariablesMetricsNames;
   static std::vector<std::string> sQueriesMetricsNames;
+
+  DataRelayerStats mStats;
 };
 
 } // namespace framework

--- a/Framework/Core/include/Framework/TimesliceIndex.h
+++ b/Framework/Core/include/Framework/TimesliceIndex.h
@@ -13,8 +13,9 @@
 
 #include "Framework/DataDescriptorMatcher.h"
 
-#include <vector>
 #include <cstdint>
+#include <tuple>
+#include <vector>
 
 namespace o2
 {
@@ -42,6 +43,14 @@ struct TimesliceSlot {
 class TimesliceIndex
 {
  public:
+  /// The outcome for the processing of a given timeslot
+  enum struct ActionTaken {
+    ReplaceUnused,   /// An unused / invalid slot is used to hold the new context
+    ReplaceObsolete, /// An obsolete slot is used to hold the new context and the old one is dropped
+    DropInvalid,     /// An invalid context is not inserted in the index and dropped
+    DropObsolete     /// An obsolete context is not inserted in the index and dropped
+  };
+
   inline void resize(size_t s);
   inline size_t size() const;
   inline bool isValid(TimesliceSlot const& slot) const;
@@ -64,8 +73,10 @@ class TimesliceIndex
   inline data_matcher::VariableContext& getVariablesForSlot(TimesliceSlot slot);
 
   /// Find the LRU entry in the cache and replace it with @a newContext
-  /// @return the slot which was replaced.
-  inline TimesliceSlot replaceLRUWith(data_matcher::VariableContext& newContext);
+  /// @a slot is filled with the slot used to hold the context, if applicable.
+  /// @return the action taken on insertion, which can be used for bookkeeping
+  ///         of the messages.
+  inline std::tuple<ActionTaken, TimesliceSlot> replaceLRUWith(data_matcher::VariableContext& newContext);
 
  private:
   /// @return the oldest slot possible so that we can eventually override it.

--- a/Framework/Core/include/Framework/TimesliceIndex.inc
+++ b/Framework/Core/include/Framework/TimesliceIndex.inc
@@ -104,29 +104,29 @@ inline data_matcher::VariableContext &TimesliceIndex::getVariablesForSlot(Timesl
   return mVariables[slot.index];
 }
 
-inline TimesliceSlot TimesliceIndex::replaceLRUWith(data_matcher::VariableContext& newContext)
+inline std::tuple<TimesliceIndex::ActionTaken, TimesliceSlot> TimesliceIndex::replaceLRUWith(data_matcher::VariableContext& newContext)
 {
   auto oldestSlot = findOldestSlot();
   if (TimesliceIndex::isValid(oldestSlot) == false) {
     mVariables[oldestSlot.index] = newContext;
-    return oldestSlot;
+    return std::make_tuple(ActionTaken::ReplaceUnused, oldestSlot);
   }
   auto oldTimestamp = std::get_if<uint64_t>(&mVariables[oldestSlot.index].get(0));
   if (oldTimestamp == nullptr) {
     mVariables[oldestSlot.index] = newContext;
-    return oldestSlot;
+    return std::make_tuple(ActionTaken::ReplaceUnused, oldestSlot);
   }
 
   auto newTimestamp = std::get_if<uint64_t>(&newContext.get(0));
   if (newTimestamp == nullptr) {
-    return {TimesliceSlot::INVALID};
+    return std::make_tuple(ActionTaken::DropInvalid, TimesliceSlot{TimesliceSlot::INVALID});
   }
 
   if (*newTimestamp > *oldTimestamp) {
     mVariables[oldestSlot.index] = newContext;
-    return oldestSlot;
+    return std::make_tuple(ActionTaken::ReplaceObsolete, oldestSlot);
   }
-  return {TimesliceSlot::INVALID};
+  return std::make_tuple(ActionTaken::DropObsolete, TimesliceSlot{TimesliceSlot::INVALID});
 }
 
 } // namespace framework

--- a/Framework/Core/src/DataRelayer.cxx
+++ b/Framework/Core/src/DataRelayer.cxx
@@ -325,7 +325,8 @@ DataRelayer::relay(std::unique_ptr<FairMQMessage> &&header,
     return WillNotRelay;
   }
 
-  slot = index.replaceLRUWith(pristineContext);
+  TimesliceIndex::ActionTaken action;
+  std::tie(action, slot) = index.replaceLRUWith(pristineContext);
 
   if (TimesliceSlot::isValid(slot) == false) {
     LOG(WARNING) << "Incoming data is already obsolete, not relaying.";

--- a/Framework/Core/src/LifetimeHelpers.cxx
+++ b/Framework/Core/src/LifetimeHelpers.cxx
@@ -92,7 +92,7 @@ ExpirationHandler::Creator LifetimeHelpers::timeDrivenCreation(std::chrono::micr
     // to be created.
     *last = current;
     data_matcher::VariableContext newContext;
-    auto slot = index.replaceLRUWith(newContext);
+    auto [action, slot] = index.replaceLRUWith(newContext);
     index.associate(TimesliceId{ current }, slot);
     return;
   };

--- a/Framework/Core/test/test_TimesliceIndex.cxx
+++ b/Framework/Core/test/test_TimesliceIndex.cxx
@@ -50,33 +50,50 @@ BOOST_AUTO_TEST_CASE(TestBasics)
 BOOST_AUTO_TEST_CASE(TestLRUReplacement)
 {
   using namespace o2::framework;
-  TimesliceSlot slot;
   TimesliceIndex index;
   index.resize(3);
   data_matcher::VariableContext context;
 
-  context.put({ 0, 10 });
-  context.commit();
-  slot = index.replaceLRUWith(context);
-  BOOST_CHECK_EQUAL(slot.index, 0);
-  context.put({ 0, 20 });
-  context.commit();
-  slot = index.replaceLRUWith(context);
-  BOOST_CHECK_EQUAL(slot.index, 1);
-  context.put({ 0, 30 });
-  context.commit();
-  slot = index.replaceLRUWith(context);
-  BOOST_CHECK_EQUAL(slot.index, 2);
-  context.put({ 0, 40 });
-  context.commit();
-  slot = index.replaceLRUWith(context);
-  BOOST_CHECK_EQUAL(slot.index, 0);
-  context.put({ 0, 50 });
-  context.commit();
-  slot = index.replaceLRUWith(context);
-  BOOST_CHECK_EQUAL(slot.index, 1);
-  context.put({ 0, 10 });
-  context.commit();
-  slot = index.replaceLRUWith(context);
-  BOOST_CHECK_EQUAL(slot.index, TimesliceSlot::INVALID);
+  {
+    context.put({ 0, 10 });
+    context.commit();
+    auto [action, slot] = index.replaceLRUWith(context);
+    BOOST_CHECK_EQUAL(slot.index, 0);
+    BOOST_CHECK(action == TimesliceIndex::ActionTaken::ReplaceUnused);
+  }
+  {
+    context.put({ 0, 20 });
+    context.commit();
+    auto [action, slot] = index.replaceLRUWith(context);
+    BOOST_CHECK_EQUAL(slot.index, 1);
+    BOOST_CHECK(action == TimesliceIndex::ActionTaken::ReplaceUnused);
+  }
+  {
+    context.put({ 0, 30 });
+    context.commit();
+    auto [action, slot] = index.replaceLRUWith(context);
+    BOOST_CHECK_EQUAL(slot.index, 2);
+    BOOST_CHECK(action == TimesliceIndex::ActionTaken::ReplaceUnused);
+  }
+  {
+    context.put({ 0, 40 });
+    context.commit();
+    auto [action, slot] = index.replaceLRUWith(context);
+    BOOST_CHECK_EQUAL(slot.index, 0);
+    BOOST_CHECK(action == TimesliceIndex::ActionTaken::ReplaceObsolete);
+  }
+  {
+    context.put({ 0, 50 });
+    context.commit();
+    auto [action, slot] = index.replaceLRUWith(context);
+    BOOST_CHECK_EQUAL(slot.index, 1);
+    BOOST_CHECK(action == TimesliceIndex::ActionTaken::ReplaceObsolete);
+  }
+  {
+    context.put({ 0, 10 });
+    context.commit();
+    auto [action, slot] = index.replaceLRUWith(context);
+    BOOST_CHECK_EQUAL(slot.index, TimesliceSlot::INVALID);
+    BOOST_CHECK(action == TimesliceIndex::ActionTaken::DropObsolete);
+  }
 }


### PR DESCRIPTION
This reports the following metrics via the monitoring interface:

* dpl/relayed_messages: messages which might end up for processing
* dpl/dropped_computations: timeslices dropped because one of the inputs
  did not arrive in time.
* dpl/dropped_incoming_inputs: inputs dropped because they arrived
  too late and their computation was dropped.
* dpl/malformed_messages: messages which were not suitable for DPL
  processing.