### PR TITLE
Fix missing or malformed copyright notices

### DIFF
--- a/Common/SimConfig/src/SimCutParams.cxx
+++ b/Common/SimConfig/src/SimCutParams.cxx
@@ -1,10 +1,3 @@
-/*
- * SimCutParams.cxx
- *
- *  Created on: Feb 18, 2019
- *      Author: sandro
- */
-
 // Copyright CERN and copyright holders of ALICE O2. This software is
 // distributed under the terms of the GNU General Public License v3 (GPL
 // Version 3), copied verbatim in the file "COPYING".
@@ -14,6 +7,13 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
+
+/*
+ * SimCutParams.cxx
+ *
+ *  Created on: Feb 18, 2019
+ *      Author: sandro
+ */
 
 #include "SimConfig/SimCutParams.h"
 O2ParamImpl(o2::conf::SimCutParams);

--- a/DataFormats/MemoryResources/src/MemoryResources.cxx
+++ b/DataFormats/MemoryResources/src/MemoryResources.cxx
@@ -1,1 +1,11 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 #include "MemoryResources/MemoryResources.h"

--- a/Detectors/ITSMFT/ITS/tracking/cuda/src/dummy.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/src/dummy.cxx
@@ -1,0 +1,9 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/json.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/json.h
@@ -1,3 +1,13 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 /*
     __ _____ _____ _____
  __|  |   __|     |   | |  JSON for Modern C++

--- a/Detectors/TRD/base/include/TRDBase/TRDCalDet.h
+++ b/Detectors/TRD/base/include/TRDBase/TRDCalDet.h
@@ -1,6 +1,3 @@
-#ifndef O2_TRDCALDET_H
-#define O2_TRDCALDET_H
-
 // Copyright CERN and copyright holders of ALICE O2. This software is
 // distributed under the terms of the GNU General Public License v3 (GPL
 // Version 3), copied verbatim in the file "COPYING".
@@ -10,6 +7,8 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
+#ifndef O2_TRDCALDET_H
+#define O2_TRDCALDET_H
 
 /* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
  * See cxx source for full Copyright notice                               */

--- a/Detectors/TRD/base/include/TRDBase/TRDCalROC.h
+++ b/Detectors/TRD/base/include/TRDBase/TRDCalROC.h
@@ -1,3 +1,12 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
 #ifndef O2_TRDCALROC_H
 #define O2_TRDCALROC_H
 /* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *

--- a/Detectors/gconfig/SetCuts.h
+++ b/Detectors/gconfig/SetCuts.h
@@ -1,3 +1,13 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 /********************************************************************************
  *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
  *                                                                              *

--- a/Framework/Core/include/Framework/RCombinedDS.h
+++ b/Framework/Core/include/Framework/RCombinedDS.h
@@ -1,3 +1,12 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
 #ifndef ROOT_RCOMBINEDDS
 #define ROOT_RCOMBINEDDS
 

--- a/Framework/Core/include/Framework/StringContext.h
+++ b/Framework/Core/include/Framework/StringContext.h
@@ -1,4 +1,4 @@
-
+// Copyright CERN and copyright holders of ALICE O2. This software is
 // distributed under the terms of the GNU General Public License v3 (GPL
 // Version 3), copied verbatim in the file "COPYING".
 //

--- a/Framework/Core/src/DataSpecUtils.cxx
+++ b/Framework/Core/src/DataSpecUtils.cxx
@@ -1,3 +1,4 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
 // distributed under the terms of the GNU General Public License v3 (GPL
 // Version 3), copied verbatim in the file "COPYING".
 //

--- a/Framework/Core/src/RCombinedDS.cxx
+++ b/Framework/Core/src/RCombinedDS.cxx
@@ -1,3 +1,13 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 // Author: Giulio Eulisse CERN  2/2018
 
 /*************************************************************************

--- a/Framework/Core/test/benchmark_DataDescriptorMatcher.cxx
+++ b/Framework/Core/test/benchmark_DataDescriptorMatcher.cxx
@@ -1,3 +1,12 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
 #include <benchmark/benchmark.h>
 #include "Headers/DataHeader.h"
 #include "Framework/DataDescriptorMatcher.h"

--- a/Framework/Core/test/benchmark_TableBuilder.cxx
+++ b/Framework/Core/test/benchmark_TableBuilder.cxx
@@ -1,3 +1,5 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
 // Version 3), copied verbatim in the file "COPYING".
 //
 // See http://alice-o2.web.cern.ch/license for full licensing information.

--- a/Framework/Core/test/test_DebugGUIGL.cxx
+++ b/Framework/Core/test/test_DebugGUIGL.cxx
@@ -1,3 +1,12 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
 #include "Framework/DebugGUI.h"
 #include "DebugGUI/GL3DUtils.h"
 

--- a/Framework/Core/test/test_DebugGUISokol.cxx
+++ b/Framework/Core/test/test_DebugGUISokol.cxx
@@ -1,3 +1,12 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
 #include "Framework/DebugGUI.h"
 #include "DebugGUI/Sokol3DUtils.h"
 

--- a/Generators/include/Generators/Generator.h
+++ b/Generators/include/Generators/Generator.h
@@ -2,7 +2,7 @@
 // distributed under the terms of the GNU General Public License v3 (GPL
 // Version 3), copied verbatim in the file "COPYING".
 //
-// See https://alice-o2.web.cern.ch/ for full licensing information.
+// See http://alice-o2.web.cern.ch/license for full licensing information.
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/Generators/include/Generators/GeneratorTGenerator.h
+++ b/Generators/include/Generators/GeneratorTGenerator.h
@@ -2,7 +2,7 @@
 // distributed under the terms of the GNU General Public License v3 (GPL
 // Version 3), copied verbatim in the file "COPYING".
 //
-// See https://alice-o2.web.cern.ch/ for full licensing information.
+// See http://alice-o2.web.cern.ch/license for full licensing information.
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/Generators/include/Generators/PrimaryGenerator.h
+++ b/Generators/include/Generators/PrimaryGenerator.h
@@ -2,7 +2,7 @@
 // distributed under the terms of the GNU General Public License v3 (GPL
 // Version 3), copied verbatim in the file "COPYING".
 //
-// See https://alice-o2.web.cern.ch/ for full licensing information.
+// See http://alice-o2.web.cern.ch/license for full licensing information.
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/Generators/src/Generator.cxx
+++ b/Generators/src/Generator.cxx
@@ -2,7 +2,7 @@
 // distributed under the terms of the GNU General Public License v3 (GPL
 // Version 3), copied verbatim in the file "COPYING".
 //
-// See https://alice-o2.web.cern.ch/ for full licensing information.
+// See http://alice-o2.web.cern.ch/license for full licensing information.
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/Generators/src/GeneratorTGenerator.cxx
+++ b/Generators/src/GeneratorTGenerator.cxx
@@ -2,7 +2,7 @@
 // distributed under the terms of the GNU General Public License v3 (GPL
 // Version 3), copied verbatim in the file "COPYING".
 //
-// See https://alice-o2.web.cern.ch/ for full licensing information.
+// See http://alice-o2.web.cern.ch/license for full licensing information.
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization


### PR DESCRIPTION
Also, `Detectors/gconfig/SetCuts.h` had DOS-style line endings. Had to convert the whole file to not no mix line ending styles.