### PR TITLE
DPL: allow on-the-fly creation of AOD by a DPL dataprocessor

### DIFF
--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -602,10 +602,10 @@ std::vector<InputSpec> WorkflowHelpers::computeDanglingOutputs(WorkflowSpec cons
     }
 
     if (matched == false) {
-      auto &outputSpec = workflow[output.workflowId].outputs[output.id];
+      auto& outputSpec = workflow[output.workflowId].outputs[output.id];
       char buf[64];
-      results.push_back(InputSpec{ (snprintf(buf, 64, "dangling_%zu_%zu", output.workflowId, output.id), buf), outputSpec.origin,
-                                   outputSpec.description, outputSpec.subSpec });
+      results.emplace_back(InputSpec{ (snprintf(buf, 64, "dangling_%zu_%zu", output.workflowId, output.id), buf), outputSpec.origin,
+                                      outputSpec.description, outputSpec.subSpec });
     }
   }
 


### PR DESCRIPTION
Previously messages with AOD origin were only meant to be provided by
the internal AOD reader. With this, in case one of the data processor
claims it is able to produce some AOD (e.g.  quantities which are not
persisted), it can do so without the system being confused about it.