### PR TITLE
Implementing std::hash specialization for MCCompLabel

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/MCCompLabel.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCCompLabel.h
@@ -25,8 +25,6 @@ class MCCompLabel
 
   ULong64_t mLabel = NotSet; ///< MC label encoding MCtrack ID and MCevent origin
 
-  void checkFieldConsistensy();
-
  public:
   // number of bits reserved for MC track ID, DON'T modify this, since the
   // track ID might be negative
@@ -34,6 +32,11 @@ class MCCompLabel
   static constexpr int nbitsEvID = 19; // number of bits reserved for MC event ID
   static constexpr int nbitsSrcID = 8; // number of bits reserved for MC source ID
   // the rest of the bits is reserved at the moment
+
+  // check if the fields are defined consistently
+  static_assert(nbitsTrackID == sizeof(int) * 8, "TrackID must have int size");
+  static_assert(nbitsTrackID + nbitsEvID + nbitsSrcID <= sizeof(ULong64_t) * 8,
+                "Fields cannot be stored in 64 bits");
 
   // mask to extract MC track ID
   static constexpr ULong64_t maskTrackID = (ul0x1 << nbitsTrackID) - 1;
@@ -104,5 +107,18 @@ class MCCompLabel
 }
 
 std::ostream& operator<<(std::ostream& os, const o2::MCCompLabel& c);
+
+namespace std
+{
+// defining std::hash for MCCompLabel in order to be used with unordered_maps
+template <>
+struct hash<o2::MCCompLabel> {
+ public:
+  size_t operator()(o2::MCCompLabel const& label) const
+  {
+    return static_cast<uint64_t>(label);
+  }
+};
+} // namespace std
 
 #endif

--- a/DataFormats/simulation/src/MCCompLabel.cxx
+++ b/DataFormats/simulation/src/MCCompLabel.cxx
@@ -37,12 +37,3 @@ std::ostream& operator<<(std::ostream& os, const o2::MCCompLabel& c)
   }
   return os;
 }
-
- //_____________________________________________
-void MCCompLabel::checkFieldConsistensy()
-{
-  // check if the fields are defined consistently
-  static_assert(nbitsTrackID==sizeof(int)*8, "TrackID must have int size");
-  static_assert(nbitsTrackID+nbitsEvID+nbitsSrcID<=sizeof(ULong64_t)*8,
-                "Fields cannot be stored in 64 bits");
-}

--- a/DataFormats/simulation/test/testMCCompLabel.cxx
+++ b/DataFormats/simulation/test/testMCCompLabel.cxx
@@ -15,6 +15,7 @@
 #include <iomanip>
 #include <ios>
 #include <iostream>
+#include <unordered_map>
 #include "SimulationDataFormat/MCCompLabel.h"
 
 using namespace o2;
@@ -25,16 +26,22 @@ BOOST_AUTO_TEST_CASE(MCCompLabel_test)
   BOOST_CHECK(!lbUndef.isSet()); // test invalid label status
 
   int ev = 200, src = 10;
+  std::unordered_map<MCCompLabel, int> labelMap;
   for (int tr=-100;tr<200;tr+=150) {
     MCCompLabel lb(tr, ev, src);
     std::cout << "Input:   [" << src << '/' << ev << '/'
               << std::setw(6) << tr << ']' << std::endl;
     std::cout << "Encoded: " << lb << " (packed: " << ULong_t(lb) << ")" << std::endl;
+    labelMap[lb] = tr;
     int trE, evE, srcE;
     lb.get(trE, evE, srcE);
     std::cout << "Decoded: [" << srcE << '/' << evE << '/'
               << std::setw(6) << trE << ']' << std::endl;
 
     BOOST_CHECK(tr == trE && ev == evE && src == srcE);
+  }
+
+  for (auto& [key, value] : labelMap) {
+    BOOST_CHECK(key.getTrackID() == value);
   }
 }


### PR DESCRIPTION
Restore PR #1645 after resolving compilation issue. Previous implementation
in commit b8470f8bde8d283fa0cec33da9aa24e91ed3e142 has been reverted in
commit 9497df2fe71655ed4a2519dfd54e8ff74de6fb39.

Compilation error on macos was simply caused by missing header <unordered_map>.