### PR TITLE
Applying clang modernize and formatting rules to TPC code

### DIFF
--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/Cluster.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/Cluster.h
@@ -37,7 +37,7 @@ class Cluster : public ClusterTimeStamp
 {
  public:
   /// Default constructor
-  Cluster();
+  Cluster() = default;
 
   /// Constructor, initializing all values
   /// \param cru CRU
@@ -54,7 +54,7 @@ class Cluster : public ClusterTimeStamp
   ~Cluster() = default;
 
   /// Copy Constructor
-  Cluster(const Cluster& other);
+  Cluster(const Cluster& other) = default;
 
   /// Set parameters of cluster
   /// \param cru CRU
@@ -88,17 +88,15 @@ class Cluster : public ClusterTimeStamp
  private:
   friend class boost::serialization::access;
 
-  short mCRU;
-  short mRow;
-  float mQ;
-  float mQmax;
-  float mPadMean;
-  float mPadSigma;
+  short mCRU = -1;
+  short mRow = -1;
+  float mQ = -1;
+  float mQmax = -1;
+  float mPadMean = -1;
+  float mPadSigma = -1;
 
   ClassDefNV(Cluster, 1);
 };
-//________________________________________________________________________
-inline Cluster::Cluster() : Cluster(-1, -1, -1, -1, -1, -1, -1, -1) {}
 
 //________________________________________________________________________
 inline Cluster::Cluster(short cru, short row, float q, float qmax, float padmean, float padsigma, float timemean,
@@ -110,18 +108,6 @@ inline Cluster::Cluster(short cru, short row, float q, float qmax, float padmean
     mQmax(qmax),
     mPadMean(padmean),
     mPadSigma(padsigma)
-{
-}
-
-//________________________________________________________________________
-inline Cluster::Cluster(const Cluster& other)
-  : ClusterTimeStamp(other),
-    mCRU(other.mCRU),
-    mRow(other.mRow),
-    mQ(other.mQ),
-    mQmax(other.mQmax),
-    mPadMean(other.mPadMean),
-    mPadSigma(other.mPadSigma)
 {
 }
 

--- a/Detectors/TPC/base/include/TPCBase/CRU.h
+++ b/Detectors/TPC/base/include/TPCBase/CRU.h
@@ -22,7 +22,7 @@ namespace TPC {
   class CRU {
     public:
       enum { CRUperPartition=2, CRUperIROC=4, CRUperSector=10, MaxCRU=360 };
-      CRU(){}
+      CRU() = default;
       CRU(unsigned short cru):mCRU(cru%MaxCRU) {}
       CRU(const CRU& cru):mCRU(cru.mCRU) {}
       CRU(const Sector& sec, const unsigned char partitionNum) : mCRU(sec.getSector()*CRUperSector+partitionNum) {}

--- a/Detectors/TPC/base/include/TPCBase/Digit.h
+++ b/Detectors/TPC/base/include/TPCBase/Digit.h
@@ -31,7 +31,7 @@ class Digit : public DigitBase
 {
  public:
   /// Default constructor
-  Digit();
+  Digit() = default;
 
   /// Constructor, initializing values for position, charge, time and common mode
   /// \param cru CRU of the Digit
@@ -65,22 +65,13 @@ class Digit : public DigitBase
   int getPad() const { return mPad; }
 
  protected:
-  float mCharge;       ///< ADC value of the Digit
-  unsigned short mCRU; ///< CRU of the Digit
-  unsigned char mRow;  ///< Global pad row of the Digit
-  unsigned char mPad;  ///< Pad of the Digit
+  float mCharge = 0.f;      ///< ADC value of the Digit
+  unsigned short mCRU = -1; ///< CRU of the Digit
+  unsigned char mRow = -1;  ///< Global pad row of the Digit
+  unsigned char mPad = -1;  ///< Pad of the Digit
 
   ClassDefNV(Digit, 1);
 };
-
-inline Digit::Digit()
-  : DigitBase(),
-    mCharge(0.f),
-    mCRU(-1),
-    mRow(-1),
-    mPad(-1)
-{
-}
 
 inline Digit::Digit(int cru, float charge, int row, int pad, int time)
   : DigitBase(time),

--- a/Detectors/TPC/base/include/TPCBase/DigitPos.h
+++ b/Detectors/TPC/base/include/TPCBase/DigitPos.h
@@ -16,32 +16,35 @@
 #include "TPCBase/PadPos.h"
 #include "TPCBase/PadSecPos.h"
 
-namespace o2 {
-namespace TPC {
+namespace o2
+{
+namespace TPC
+{
 
-class DigitPos {
-public:
-  DigitPos() {}
+class DigitPos
+{
+ public:
+  DigitPos() = default;
   DigitPos(CRU c, PadPos pad) : mCRU(c), mPadPos(pad) {}
-  const CRU&  getCRU() const { return mCRU; }
-  CRU& cru()       { return mCRU; }
-  PadPos    getPadPos()       const { return mPadPos; }
-  PadPos    getGlobalPadPos() const;
-  PadSecPos getPadSecPos()    const;
+  const CRU& getCRU() const { return mCRU; }
+  CRU& cru() { return mCRU; }
+  PadPos getPadPos() const { return mPadPos; }
+  PadPos getGlobalPadPos() const;
+  PadSecPos getPadSecPos() const;
 
-  PadPos& padPos()       { return mPadPos; }
+  PadPos& padPos() { return mPadPos; }
 
   bool isValid() const { return mPadPos.isValid(); }
 
-  bool    operator==(const DigitPos& other)  const { return (mCRU==other.mCRU) && (mPadPos==other.mPadPos); }
-  bool    operator!=(const DigitPos& other)  const { return (mCRU!=other.mCRU) || (mPadPos!=other.mPadPos); }
-  bool    operator< (const DigitPos& other)  const { return (mCRU <other.mCRU) && (mPadPos <other.mPadPos); }
+  bool operator==(const DigitPos& other) const { return (mCRU == other.mCRU) && (mPadPos == other.mPadPos); }
+  bool operator!=(const DigitPos& other) const { return (mCRU != other.mCRU) || (mPadPos != other.mPadPos); }
+  bool operator<(const DigitPos& other) const { return (mCRU < other.mCRU) && (mPadPos < other.mPadPos); }
 
-private:
+ private:
   CRU mCRU{};
-  PadPos mPadPos{};          /// Pad position in the local partition coordinates: row starts from 0 for each partition
+  PadPos mPadPos{}; /// Pad position in the local partition coordinates: row starts from 0 for each partition
 };
 
-}
-}
+} // namespace TPC
+} // namespace o2
 #endif

--- a/Detectors/TPC/base/include/TPCBase/FECInfo.h
+++ b/Detectors/TPC/base/include/TPCBase/FECInfo.h
@@ -13,74 +13,85 @@
 
 #include <iosfwd>
 
-namespace o2 {
-namespace TPC {
+namespace o2
+{
+namespace TPC
+{
 
-class FECInfo {
-  public:
-    FECInfo() {}
-    FECInfo(unsigned char index,
-            //unsigned char connector,
-            //unsigned char channel,
-            unsigned char sampaChip,
-            unsigned char sampaChannel)
+class FECInfo
+{
+ public:
+  FECInfo() = default;
+  FECInfo(unsigned char index,
+          //unsigned char connector,
+          //unsigned char channel,
+          unsigned char sampaChip,
+          unsigned char sampaChannel)
     : mIndex(index), /*mConnector(connector), mChannel(channel),*/ mSampaChip(sampaChip), mSampaChannel(sampaChannel)
-    {}
+  {
+  }
 
-    unsigned char getIndex()        const { return mIndex;       }
-    //const unsigned char getConnector()    const { return mConnector;   } // -> can be calculated from mSampaChannel and mSampaChip
-    //const unsigned char getChannel()      const { return mChannel;     } // -> can be calculated from mSampaChannel and mSampaChip
-    unsigned char getSampaChip()    const { return mSampaChip;   }
-    unsigned char getSampaChannel() const { return mSampaChannel;}
+  unsigned char getIndex() const { return mIndex; }
+  //const unsigned char getConnector()    const { return mConnector;   } // -> can be calculated from mSampaChannel and mSampaChip
+  //const unsigned char getChannel()      const { return mChannel;     } // -> can be calculated from mSampaChannel and mSampaChip
+  unsigned char getSampaChip() const { return mSampaChip; }
+  unsigned char getSampaChannel() const { return mSampaChannel; }
 
-    /// equal operator
-    bool operator==(const FECInfo &other) const {
-      return mIndex==other.mIndex &&
-           (mSampaChip==other.mSampaChip && mSampaChannel==other.mSampaChannel) ;
-        //( (mConnector==other.mConnector && mChannel==other.mChannel)
-          //|| (mSampaChip==other.mSampaChip && mSampaChannel==other.mSampaChannel) );
+  /// equal operator
+  bool operator==(const FECInfo& other) const
+  {
+    return mIndex == other.mIndex &&
+           (mSampaChip == other.mSampaChip && mSampaChannel == other.mSampaChannel);
+    //( (mConnector==other.mConnector && mChannel==other.mChannel)
+    //|| (mSampaChip==other.mSampaChip && mSampaChannel==other.mSampaChannel) );
+  }
+
+  static constexpr int globalSAMPAId(const int fecInSector, const int sampaOnFEC, const int channelOnSAMPA)
+  {
+    // channelOnSAMPA 0-31, 5 bits
+    // sampaOnFEC     0- 4, 3 bits
+    // fecInSector    0-90, 7 bits
+    return (fecInSector << 8) + (sampaOnFEC << 5) + channelOnSAMPA;
+  }
+
+  static constexpr int fecInSector(const int globalSAMPAId) { return globalSAMPAId >> 8; }
+  static constexpr int sampaOnFEC(const int globalSAMPAId) { return (globalSAMPAId >> 5) & 7; }
+  static constexpr int channelOnSAMPA(const int globalSAMPAId) { return globalSAMPAId & 31; }
+
+  static void sampaInfo(const int globalSAMPAId, int& fecInSector, int& sampaOnFEC, int& channelOnSAMPA)
+  {
+    fecInSector = (globalSAMPAId >> 8);
+    sampaOnFEC = (globalSAMPAId >> 5) & 7;
+    channelOnSAMPA = (globalSAMPAId & 31);
+  }
+
+  /// smaller operator
+  bool operator<(const FECInfo& other) const
+  {
+    if (mIndex < other.mIndex) {
+      return true;
     }
-
-    static constexpr int globalSAMPAId(const int fecInSector, const int sampaOnFEC, const int channelOnSAMPA)
-    {
-      // channelOnSAMPA 0-31, 5 bits
-      // sampaOnFEC     0- 4, 3 bits
-      // fecInSector    0-90, 7 bits
-      return (fecInSector<<8) + (sampaOnFEC<<5) + channelOnSAMPA;
+    if (mSampaChip < other.mSampaChip) {
+      return true;
     }
-
-    static constexpr int fecInSector   (const int globalSAMPAId) { return globalSAMPAId >> 8; }
-    static constexpr int sampaOnFEC    (const int globalSAMPAId)  { return (globalSAMPAId >> 5) & 7; }
-    static constexpr int channelOnSAMPA(const int globalSAMPAId) { return globalSAMPAId & 31; }
-
-    static void sampaInfo(const int globalSAMPAId, int& fecInSector, int& sampaOnFEC, int& channelOnSAMPA)
-    {
-      fecInSector    = (globalSAMPAId >> 8);
-      sampaOnFEC     = (globalSAMPAId >> 5) & 7;
-      channelOnSAMPA = (globalSAMPAId & 31);
+    if (mSampaChip == other.mSampaChip && mSampaChannel < other.mSampaChannel) {
+      return true;
     }
+    return false;
+  }
 
-    /// smaller operator
-    bool operator<(const FECInfo &other) const
-    {
-      if (mIndex < other.mIndex) { return true; }
-      if (mSampaChip < other.mSampaChip) { return true; }
-      if (mSampaChip==other.mSampaChip && mSampaChannel<other.mSampaChannel) { return true; }
-      return false;
-    }
+ private:
+  std::ostream& print(std::ostream& out) const;
+  friend std::ostream& operator<<(std::ostream& out, const FECInfo& fec);
+  unsigned char mIndex{ 0 };        ///< FEC number in the sector
+  unsigned char mSampaChip{ 0 };    ///< SAMPA chip on the FEC
+  unsigned char mSampaChannel{ 0 }; ///< Cannel on the SAMPA chip
 
-  private:
-   std::ostream& print(std::ostream& out) const;
-   friend std::ostream& operator<<(std::ostream& out, const FECInfo& fec);
-   unsigned char mIndex{ 0 };        ///< FEC number in the sector
-   unsigned char mSampaChip{ 0 };    ///< SAMPA chip on the FEC
-   unsigned char mSampaChannel{ 0 }; ///< Cannel on the SAMPA chip
-
-   // unsigned char mConnector    {0};   ///< Connector on the FEC -> Can be deduced from mSampaChip and mSampaChannel
-   // unsigned char mChannel      {0};   ///< Channel on the FEC -> Can be deduced from mSampaChip and mSampaChannel
+  // unsigned char mConnector    {0};   ///< Connector on the FEC -> Can be deduced from mSampaChip and mSampaChannel
+  // unsigned char mChannel      {0};   ///< Channel on the FEC -> Can be deduced from mSampaChip and mSampaChannel
 };
 
-}
-}
+} // namespace TPC
+} // namespace o2
 
 #endif

--- a/Detectors/TPC/base/include/TPCBase/PadPos.h
+++ b/Detectors/TPC/base/include/TPCBase/PadPos.h
@@ -24,71 +24,77 @@
 #ifndef AliceO2_TPC_PadPos_H
 #define AliceO2_TPC_PadPos_H
 
-namespace o2 {
-namespace TPC {
+namespace o2
+{
+namespace TPC
+{
 class PadPos
 {
-  public:
-    /// default constructor
-    PadPos() {}
+ public:
+  /// default constructor
+  PadPos() = default;
 
-    /// constructor
-    /// @param [in] row pad row
-    /// @param [in] pad pad in a row
-    PadPos(const unsigned char row, const unsigned char pad) : mRow(row), mPad(pad) {}
+  /// constructor
+  /// @param [in] row pad row
+  /// @param [in] pad pad in a row
+  PadPos(const unsigned char row, const unsigned char pad) : mRow(row), mPad(pad) {}
 
-    /// numeric row number
-    /// @return numeric row number
-    unsigned char getRow() const { return mRow; }
+  /// numeric row number
+  /// @return numeric row number
+  unsigned char getRow() const { return mRow; }
 
-    /// numeric pad number
-    /// @return numeric pad number
-    unsigned char getPad() const { return mPad; }
+  /// numeric pad number
+  /// @return numeric pad number
+  unsigned char getPad() const { return mPad; }
 
-    /// setter for row number
-    /// @param [in] row row number
-    void setRow(const unsigned char row) { mRow = row; }
+  /// setter for row number
+  /// @param [in] row row number
+  void setRow(const unsigned char row) { mRow = row; }
 
-    /// setter for pad number
-    /// @param [in] pad pad number
-    void setPad(const unsigned char pad) { mPad = pad; }
+  /// setter for pad number
+  /// @param [in] pad pad number
+  void setPad(const unsigned char pad) { mPad = pad; }
 
-    /// add row offset
-    /// @param [in] rowOffset row offset to add
-    void addRowOffset(const unsigned char rowOffset) { mRow += rowOffset; }
+  /// add row offset
+  /// @param [in] rowOffset row offset to add
+  void addRowOffset(const unsigned char rowOffset) { mRow += rowOffset; }
 
-    /// setter for row and pad number
-    /// @param [in] row row number
-    /// @param [in] pad pad number
-    void set(const unsigned char row, const unsigned char pad)
-    {
-      mRow = row;
-      mPad = pad;
+  /// setter for row and pad number
+  /// @param [in] row row number
+  /// @param [in] pad pad number
+  void set(const unsigned char row, const unsigned char pad)
+  {
+    mRow = row;
+    mPad = pad;
+  }
+
+  /// check if is valid
+  /// @return pad valid
+  bool isValid() const { return !(mRow == 255 && mPad == 255); }
+
+  /// equal operator
+  bool operator==(const PadPos& other) const { return (mRow == other.mRow) && (mPad == other.mPad); }
+
+  /// unequal operator
+  bool operator!=(const PadPos& other) const { return (mRow != other.mRow) || (mPad != other.mPad); }
+
+  /// smaller operator
+  bool operator<(const PadPos& other) const
+  {
+    if (mRow < other.mRow) {
+      return true;
     }
-
-    /// check if is valid
-    /// @return pad valid
-    bool isValid() const { return !(mRow == 255 && mPad == 255); }
-
-    /// equal operator
-    bool operator==(const PadPos &other) const { return (mRow == other.mRow) && (mPad == other.mPad); }
-
-    /// unequal operator
-    bool operator!=(const PadPos &other) const { return (mRow != other.mRow) || (mPad != other.mPad); }
-
-    /// smaller operator
-    bool operator<(const PadPos &other) const
-    {
-      if (mRow < other.mRow) { return true; }
-      if (mRow == other.mRow && mPad < other.mPad) { return true; }
-      return false;
+    if (mRow == other.mRow && mPad < other.mPad) {
+      return true;
     }
+    return false;
+  }
 
-  private:
-    unsigned char mRow{0};  ///< row number
-    unsigned char mPad{0};  ///< pad number in row
+ private:
+  unsigned char mRow{ 0 }; ///< row number
+  unsigned char mPad{ 0 }; ///< pad number in row
 };
-}
-}
+} // namespace TPC
+} // namespace o2
 
 #endif

--- a/Detectors/TPC/base/include/TPCBase/PadRegionInfo.h
+++ b/Detectors/TPC/base/include/TPCBase/PadRegionInfo.h
@@ -31,136 +31,136 @@
 #include "DataFormatsTPC/Defs.h"
 #include "TPCBase/PadPos.h"
 
-namespace o2 {
-namespace TPC {
+namespace o2
+{
+namespace TPC
+{
 
 class PadRegionInfo
 {
-  public:
-    /// default constructor
-    PadRegionInfo() {}
+ public:
+  /// default constructor
+  PadRegionInfo() = default;
 
-    /// constructor
-    /// @param region region number
-    /// @param partition partition number (CRU in sector)
-    /// @param numberOfPadRows number of pad row in this region
-    /// @param padHeight height of the pads in tihs region
-    /// @param padWidth width of the pads in this region
-    /// @param radiusFirstRow radial position of the center of the first row in this region
-    /// @param rowOffset row offset in region with same height
-    /// @param xhelper helper value to calculate pads per row
-    /// @param globalRowOffset global row offset in the sector
-    PadRegionInfo(const unsigned char region,
-                  const unsigned char partition,
-                  const unsigned char numberOfPadRows,
-                  const float padHeight,
-                  const float padWidth,
-                  const float radiusFirstRow,
-                  const unsigned char rowOffset,
-                  const float xhelper,
-                  const unsigned char globalRowOffset
-                 );
+  /// constructor
+  /// @param region region number
+  /// @param partition partition number (CRU in sector)
+  /// @param numberOfPadRows number of pad row in this region
+  /// @param padHeight height of the pads in tihs region
+  /// @param padWidth width of the pads in this region
+  /// @param radiusFirstRow radial position of the center of the first row in this region
+  /// @param rowOffset row offset in region with same height
+  /// @param xhelper helper value to calculate pads per row
+  /// @param globalRowOffset global row offset in the sector
+  PadRegionInfo(const unsigned char region,
+                const unsigned char partition,
+                const unsigned char numberOfPadRows,
+                const float padHeight,
+                const float padWidth,
+                const float radiusFirstRow,
+                const unsigned char rowOffset,
+                const float xhelper,
+                const unsigned char globalRowOffset);
 
-    /// Return the pad region
-    /// \return pad region
-    unsigned char getRegion() const { return mRegion; }
+  /// Return the pad region
+  /// \return pad region
+  unsigned char getRegion() const { return mRegion; }
 
-    /// Return the partition
-    /// \return partition
-    unsigned char getPartition() const { return mPartition; }
+  /// Return the partition
+  /// \return partition
+  unsigned char getPartition() const { return mPartition; }
 
-    /// Return the number of pad rows in this region
-    /// \return number of pad rows in this region
-    unsigned char getNumberOfPadRows() const { return mNumberOfPadRows; }
+  /// Return the number of pad rows in this region
+  /// \return number of pad rows in this region
+  unsigned char getNumberOfPadRows() const { return mNumberOfPadRows; }
 
-    /// Return the total number of pads in this region
-    /// \return total number of pads in this region
-    unsigned short getNumberOfPads() const { return mNumberOfPads; }
+  /// Return the total number of pads in this region
+  /// \return total number of pads in this region
+  unsigned short getNumberOfPads() const { return mNumberOfPads; }
 
-    /// Return the pad height in this region
-    /// \return pad height in this region
-    float getPadHeight() const { return mPadHeight; }
+  /// Return the pad height in this region
+  /// \return pad height in this region
+  float getPadHeight() const { return mPadHeight; }
 
-    /// Return the pad width in this region
-    /// \return pad width in this region
-    float getPadWidth() const { return mPadWidth; }
+  /// Return the pad width in this region
+  /// \return pad width in this region
+  float getPadWidth() const { return mPadWidth; }
 
-    /// Return the radius of the first row in this region
-    /// \return radius of the first row in this region
-    float getRadiusFirstRow() const { return mRadiusFirstRow; }
+  /// Return the radius of the first row in this region
+  /// \return radius of the first row in this region
+  float getRadiusFirstRow() const { return mRadiusFirstRow; }
 
-    /// Return the row offset in the sector
-    /// \return row offset in the sector
-    unsigned char getGlobalRowOffset() const { return mGlobalRowOffset; }
-//   const unsigned char  getRowOffset()        const { return mRowOffset;        }
-//   const float          getXhelper()         const { return mXhelper;         }
+  /// Return the row offset in the sector
+  /// \return row offset in the sector
+  unsigned char getGlobalRowOffset() const { return mGlobalRowOffset; }
+  //   const unsigned char  getRowOffset()        const { return mRowOffset;        }
+  //   const float          getXhelper()         const { return mXhelper;         }
 
-    /// Return the number of pads for the row in `padPos` (row in the sector)
-    /// \param padPos pad position in the sector
-    /// \return number of pads for the row in `padPos` (row in the sector)
-    unsigned char getPadsInRow(const PadPos &padPos) const
-    {
-      return mPadsPerRow[padPos.getRow() - mGlobalRowOffset];
-    }
+  /// Return the number of pads for the row in `padPos` (row in the sector)
+  /// \param padPos pad position in the sector
+  /// \return number of pads for the row in `padPos` (row in the sector)
+  unsigned char getPadsInRow(const PadPos& padPos) const
+  {
+    return mPadsPerRow[padPos.getRow() - mGlobalRowOffset];
+  }
 
-    /// Return the number of pads for the `row` (row in the sector)
-    /// \param padPos row in the sector
-    /// \return number of pads for the row in in the sector
-    unsigned char getPadsInRow(const int row) const { return mPadsPerRow[row - mGlobalRowOffset]; }
+  /// Return the number of pads for the `row` (row in the sector)
+  /// \param padPos row in the sector
+  /// \return number of pads for the row in in the sector
+  unsigned char getPadsInRow(const int row) const { return mPadsPerRow[row - mGlobalRowOffset]; }
 
-    /// Return the number of pads for the `row` (row in the pad region)
-    /// \param padPos row in the pad region
-    /// \return number of pads for the row in in the pad region
-    unsigned char getPadsInRowRegion(const int row) const { return mPadsPerRow[row]; }
+  /// Return the number of pads for the `row` (row in the pad region)
+  /// \param padPos row in the pad region
+  /// \return number of pads for the row in in the pad region
+  unsigned char getPadsInRowRegion(const int row) const { return mPadsPerRow[row]; }
 
-    /// Check if the local X position is in the region
-    /// \param localX local X position
-    /// \param border an optional border width
-    /// \return true if the local X position is in the region
-    /// \todo check function
-    bool isInRegion(float localX, float border = 0.f) const
-    {
-      return localX - mRadiusFirstRow - border > 0.f && localX - mRadiusFirstRow <
-                                                        (mNumberOfPadRows + 1) * mPadHeight + border;
-    }
+  /// Check if the local X position is in the region
+  /// \param localX local X position
+  /// \param border an optional border width
+  /// \return true if the local X position is in the region
+  /// \todo check function
+  bool isInRegion(float localX, float border = 0.f) const
+  {
+    return localX - mRadiusFirstRow - border > 0.f && localX - mRadiusFirstRow < (mNumberOfPadRows + 1) * mPadHeight + border;
+  }
 
-    /// Find the pad and row for a local 3D position
-    /// \param pos 3D position in local coordinates
-    /// \return pad and row for a local 3D position
-    const PadPos findPad(const LocalPosition3D &pos) const;
+  /// Find the pad and row for a local 3D position
+  /// \param pos 3D position in local coordinates
+  /// \return pad and row for a local 3D position
+  const PadPos findPad(const LocalPosition3D& pos) const;
 
-    /// Find the pad and row for a local 2D position and readout side
-    /// \param pos 2D position in local coordinates
-    /// \param side readout side
-    /// \return pad and row for a local 2D position and return side
-    const PadPos findPad(const LocalPosition2D &pos, const Side side = Side::A) const;
+  /// Find the pad and row for a local 2D position and readout side
+  /// \param pos 2D position in local coordinates
+  /// \param side readout side
+  /// \return pad and row for a local 2D position and return side
+  const PadPos findPad(const LocalPosition2D& pos, const Side side = Side::A) const;
 
-    /// Find the pad and row for a local X and Y position and readout side
-    /// \param localX local X position in local coordinates
-    /// \param localY local Y position in local coordinates
-    /// \param side readout side
-    /// \return pad and row for a local X and Y position and readout side
-    const PadPos findPad(const float localX, const float localY, const Side side = Side::A) const;
+  /// Find the pad and row for a local X and Y position and readout side
+  /// \param localX local X position in local coordinates
+  /// \param localY local Y position in local coordinates
+  /// \param side readout side
+  /// \return pad and row for a local X and Y position and readout side
+  const PadPos findPad(const float localX, const float localY, const Side side = Side::A) const;
 
-  private:
-    float mPadHeight{0.f};              ///< pad height in this region
-    float mPadWidth{0.f};               ///< pad width in this region
-    float mRadiusFirstRow{0.f};         ///< radial position of first row
-    float mXhelper{0.f};                ///< helper value to calculate pads per row
-    unsigned short mNumberOfPads{0};    ///< total number of pads in region
-    unsigned char mPartition{0};        ///< partition number
-    unsigned char mRegion{0};           ///< pad region number
-    unsigned char mNumberOfPadRows{0};  ///< number of rows in region
+ private:
+  float mPadHeight{ 0.f };             ///< pad height in this region
+  float mPadWidth{ 0.f };              ///< pad width in this region
+  float mRadiusFirstRow{ 0.f };        ///< radial position of first row
+  float mXhelper{ 0.f };               ///< helper value to calculate pads per row
+  unsigned short mNumberOfPads{ 0 };   ///< total number of pads in region
+  unsigned char mPartition{ 0 };       ///< partition number
+  unsigned char mRegion{ 0 };          ///< pad region number
+  unsigned char mNumberOfPadRows{ 0 }; ///< number of rows in region
 
-    unsigned char mRowOffset{0};        ///< row offset in region with same height
+  unsigned char mRowOffset{ 0 }; ///< row offset in region with same height
 
-    unsigned char mGlobalRowOffset{0};  ///< global pad row offset
+  unsigned char mGlobalRowOffset{ 0 }; ///< global pad row offset
 
-    void init();
+  void init();
 
-    std::vector<unsigned char> mPadsPerRow; ///< number of pad in each row
+  std::vector<unsigned char> mPadsPerRow; ///< number of pad in each row
 };
 
-}
-}
+} // namespace TPC
+} // namespace o2
 #endif

--- a/Detectors/TPC/base/include/TPCBase/PadSecPos.h
+++ b/Detectors/TPC/base/include/TPCBase/PadSecPos.h
@@ -28,28 +28,30 @@
 #include "TPCBase/Sector.h"
 #include "TPCBase/PadPos.h"
 
-namespace o2 {
-namespace TPC {
+namespace o2
+{
+namespace TPC
+{
 class PadSecPos
 {
-  public:
-    PadSecPos() {};
+ public:
+  PadSecPos() = default;
 
-    PadSecPos(const int sector, const int rowInSector, const int padInRow) : mSector(sector), mPadPos(PadPos(rowInSector, padInRow)) {}
-    PadSecPos(const Sector &sec, const PadPos &padPosition) : mSector(sec), mPadPos(padPosition) {}
+  PadSecPos(const int sector, const int rowInSector, const int padInRow) : mSector(sector), mPadPos(PadPos(rowInSector, padInRow)) {}
+  PadSecPos(const Sector& sec, const PadPos& padPosition) : mSector(sec), mPadPos(padPosition) {}
 
-    Sector getSector() const { return mSector; }
+  Sector getSector() const { return mSector; }
 
-    Sector &getSector() { return mSector; }
+  Sector& getSector() { return mSector; }
 
-    const PadPos& getPadPos() const { return mPadPos; }
+  const PadPos& getPadPos() const { return mPadPos; }
 
-    PadPos& getPadPos() { return mPadPos; }
+  PadPos& getPadPos() { return mPadPos; }
 
-  private:
-    Sector mSector{};
-    PadPos mPadPos{};
+ private:
+  Sector mSector{};
+  PadPos mPadPos{};
 };
-}
-}
+} // namespace TPC
+} // namespace o2
 #endif

--- a/Detectors/TPC/base/include/TPCBase/PartitionInfo.h
+++ b/Detectors/TPC/base/include/TPCBase/PartitionInfo.h
@@ -26,35 +26,37 @@
 #ifndef ALICEO2_TPC_PARTITIONINFO_H_
 #define ALICEO2_TPC_PARTITIONINFO_H_
 
-namespace o2 {
-namespace TPC {
+namespace o2
+{
+namespace TPC
+{
 
-class PartitionInfo {
-  public:
-    PartitionInfo() {}
+class PartitionInfo
+{
+ public:
+  PartitionInfo() = default;
 
-    PartitionInfo(const unsigned char  numberOfFECs,
-                  const unsigned char  sectorFECOffset,
-                  const unsigned char  numberOfPadRows,
-                  const unsigned char  globalRowOffset,
-                  const unsigned short numberOfPads
-                 );
+  PartitionInfo(const unsigned char numberOfFECs,
+                const unsigned char sectorFECOffset,
+                const unsigned char numberOfPadRows,
+                const unsigned char globalRowOffset,
+                const unsigned short numberOfPads);
 
-    unsigned char  getNumberOfFECs()    const { return mNumberOfFECs;    }
-    unsigned char  getSectorFECOffset() const { return mSectorFECOffset; }
-    unsigned char  getNumberOfPadRows() const { return mNumberOfPadRows; }
-    unsigned char  getGlobalRowOffset() const { return mGlobalRowOffset; }
-    unsigned short getNumberOfPads()    const { return mNumberOfPads;    }
-  private:
-    unsigned char  mNumberOfFECs   {0};
-    unsigned char  mSectorFECOffset{0};
-    unsigned char  mNumberOfPadRows{0};
-    unsigned char  mGlobalRowOffset{0};
-    unsigned short mNumberOfPads   {0};
+  unsigned char getNumberOfFECs() const { return mNumberOfFECs; }
+  unsigned char getSectorFECOffset() const { return mSectorFECOffset; }
+  unsigned char getNumberOfPadRows() const { return mNumberOfPadRows; }
+  unsigned char getGlobalRowOffset() const { return mGlobalRowOffset; }
+  unsigned short getNumberOfPads() const { return mNumberOfPads; }
 
+ private:
+  unsigned char mNumberOfFECs{ 0 };
+  unsigned char mSectorFECOffset{ 0 };
+  unsigned char mNumberOfPadRows{ 0 };
+  unsigned char mGlobalRowOffset{ 0 };
+  unsigned short mNumberOfPads{ 0 };
 };
 
 } // namespace TPC
-} // namespace AliceO2
+} // namespace o2
 
 #endif // ALICEO2_TPC_PARTITIONINFO_H_

--- a/Detectors/TPC/base/include/TPCBase/RandomRing.h
+++ b/Detectors/TPC/base/include/TPCBase/RandomRing.h
@@ -114,7 +114,7 @@ class RandomRing
 
   RandomType mRandomType;              ///< Type of random numbers used
   std::array<float, N> mRandomNumbers; ///< Ring with random gaus numbers
-  size_t mRingPosition;                ///< presently accessed position in the ring
+  size_t mRingPosition = 0;            ///< presently accessed position in the ring
 
 }; // end class RandomRing
 
@@ -122,8 +122,7 @@ class RandomRing
 template <size_t N>
 inline RandomRing<N>::RandomRing(const RandomType randomType)
   : mRandomType(randomType),
-    mRandomNumbers(),
-    mRingPosition(0)
+    mRandomNumbers()
 
 {
   initialize(randomType);
@@ -133,8 +132,7 @@ inline RandomRing<N>::RandomRing(const RandomType randomType)
 template <size_t N>
 inline RandomRing<N>::RandomRing(TF1& function)
   : mRandomType(RandomType::CustomTF1),
-    mRandomNumbers(),
-    mRingPosition(0)
+    mRandomNumbers()
 {
   initialize(function);
 }

--- a/Detectors/TPC/base/include/TPCBase/Sector.h
+++ b/Detectors/TPC/base/include/TPCBase/Sector.h
@@ -43,7 +43,7 @@ class Sector
   static constexpr int MAXSECTOR = Constants::MAXSECTOR;
 
   /// constructor
-  Sector() {}
+  Sector() = default;
 
   /// construction
   /// @param [in] sec sector number

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/ClustererTask.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/ClustererTask.h
@@ -59,9 +59,9 @@ class ClustererTask : public FairTask{
   void setContinuousReadout(bool isContinuous);
 
  private:
-  bool mIsContinuousReadout; ///< Switch for continuous readout
-  int mEventCount;           ///< Event counter
-  int mClusterSector;        ///< Sector to be processed
+  bool mIsContinuousReadout = true; ///< Switch for continuous readout
+  int mEventCount = 0;              ///< Event counter
+  int mClusterSector = -1;          ///< Sector to be processed
 
   std::unique_ptr<HwClusterer> mHwClusterer; ///< Hw Clusterfinder instance
 

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/TPCCATracking.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/TPCCATracking.h
@@ -34,6 +34,8 @@ class TPCCATracking
 public:
   TPCCATracking();
   ~TPCCATracking();
+  TPCCATracking(const TPCCATracking&) = delete;            // Disable copy
+  TPCCATracking& operator=(const TPCCATracking&) = delete; // Disable assignment
 
   int initialize(const AliGPUCAConfiguration& config);
   int initialize(const char* options = nullptr);
@@ -53,9 +55,6 @@ public:
                                                                   //The tracking code itself is not included in the O2 package, but contained in the CA library.
                                                                   //The TPCCATracking class interfaces this library via this pointer to AliHLTTPCCAO2Interface class.
 
-  TPCCATracking(const TPCCATracking&) = delete;            // Disable copy
-  TPCCATracking& operator=(const TPCCATracking&) = delete; // Disable assignment
-  
   static constexpr float sContinuousTFReferenceLength = 0.023 * 5e6;
   static constexpr float sTrackMCMaxFake = 0.1;
   int mNTracksASide = 0;

--- a/Detectors/TPC/reconstruction/src/ClustererTask.cxx
+++ b/Detectors/TPC/reconstruction/src/ClustererTask.cxx
@@ -23,8 +23,6 @@ using namespace o2::TPC;
 //_____________________________________________________________________
 ClustererTask::ClustererTask(int sectorid)
   : FairTask("TPCClustererTask"),
-    mIsContinuousReadout(true),
-    mEventCount(0),
     mClusterSector(sectorid),
     mHwClusterer(),
     mDigitsArray(),

--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitContainer.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitContainer.h
@@ -75,14 +75,14 @@ class DigitContainer
   void fillOutputContainer(std::vector<Digit>& output, dataformats::MCTruthContainer<MCCompLabel>& mcTruth, const Sector& sector, TimeBin eventTimeBin = 0, bool isContinuous = true, bool finalFlush = false);
 
  private:
-  TimeBin mFirstTimeBin;           ///< First time bin to consider
-  TimeBin mEffectiveTimeBin;       ///< Effective time bin of that digit
-  TimeBin mTmaxTriggered;          ///< Maximum time bin in case of triggered mode (hard cut at average drift speed with additional margin)
-  TimeBin mOffset;                 ///< Size of the container for one event
-  std::deque<DigitTime> mTimeBins; ///< Time bin Container for the ADC value
+  TimeBin mFirstTimeBin = 0;              ///< First time bin to consider
+  TimeBin mEffectiveTimeBin = 0;          ///< Effective time bin of that digit
+  TimeBin mTmaxTriggered = 0;             ///< Maximum time bin in case of triggered mode (hard cut at average drift speed with additional margin)
+  TimeBin mOffset = 600;                  ///< Size of the container for one event
+  std::deque<DigitTime> mTimeBins{ 600 }; ///< Time bin Container for the ADC value
 };
 
-inline DigitContainer::DigitContainer() : mFirstTimeBin(0), mEffectiveTimeBin(0), mTmaxTriggered(0), mOffset(600), mTimeBins(600)
+inline DigitContainer::DigitContainer()
 {
   const static ParameterDetector& detParam = ParameterDetector::defaultInstance();
   mTmaxTriggered = detParam.getMaxTimeBinTriggered();

--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitGlobalPad.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitGlobalPad.h
@@ -46,7 +46,7 @@ class DigitGlobalPad
 {
  public:
   /// Constructor
-  DigitGlobalPad();
+  DigitGlobalPad() = default;
 
   /// Destructor
   ~DigitGlobalPad() = default;
@@ -89,11 +89,9 @@ class DigitGlobalPad
   /// \return true, if trackID, eventID and sourceID are the same
   bool compareMClabels(const MCCompLabel& label1, const MCCompLabel& label2) const;
 
-  float mChargePad;                                  ///< Total accumulated charge on that GlobalPad for a given time bin
+  float mChargePad = 0.;                             ///< Total accumulated charge on that GlobalPad for a given time bin
   int mID = -1;                                      ///< ID of this digit to refer into labels (-1 means not initialized)
 };
-
-inline DigitGlobalPad::DigitGlobalPad() : mChargePad(0.) {}
 
 inline void DigitGlobalPad::addDigit(const MCCompLabel& label, float signal,
                                      o2::dataformats::LabelContainer<std::pair<MCCompLabel, int>, false>& labels)

--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitMCMetaData.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitMCMetaData.h
@@ -17,72 +17,66 @@
 
 #include <Rtypes.h>
 
-namespace o2 {
-namespace TPC {
+namespace o2
+{
+namespace TPC
+{
 
 /// \class DigitMCMetaData
 /// This is the definition of the Meta Data object of the Monte Carlo Digit
 /// It holds auxilliary information relevant for debugging:
 /// ADC value, Common Mode, Pedestal and Noise
 
-class DigitMCMetaData {
-  public:
+class DigitMCMetaData
+{
+ public:
+  /// Default constructor
+  DigitMCMetaData() = default;
 
-    /// Default constructor
-    DigitMCMetaData();
+  /// Constructor, initializing values for position, charge, time and common mode
+  /// \param ADC Raw ADC value of the corresponding DigitMC (before saturation)
+  /// \param commonMode Common mode signal on that ROC in the time bin of the DigitMC
+  /// \param pedestal Raw pedestal value of the corresponding DigitMC (before saturation)
+  /// \param noise Raw noise value of the corresponding DigitMC (before saturation)
+  DigitMCMetaData(float ADC, float commonMode, float pedestal, float noise);
 
-    /// Constructor, initializing values for position, charge, time and common mode
-    /// \param ADC Raw ADC value of the corresponding DigitMC (before saturation)
-    /// \param commonMode Common mode signal on that ROC in the time bin of the DigitMC
-    /// \param pedestal Raw pedestal value of the corresponding DigitMC (before saturation)
-    /// \param noise Raw noise value of the corresponding DigitMC (before saturation)
-    DigitMCMetaData(float ADC, float commonMode, float pedestal, float noise);
+  /// Destructor
+  ~DigitMCMetaData() = default;
 
-    /// Destructor
-    ~DigitMCMetaData() = default;
+  /// Get the raw ADC value
+  /// \return Raw ADC value of the corresponding DigitMC (before saturation)
+  float getRawADC() const { return mADC; }
 
-    /// Get the raw ADC value
-    /// \return Raw ADC value of the corresponding DigitMC (before saturation)
-    float getRawADC() const { return mADC; }
+  /// Get the common mode value
+  /// \return Common mode signal on that ROC in the time bin of the DigitMC
+  float getCommonMode() const { return mCommonMode; }
 
-    /// Get the common mode value
-    /// \return Common mode signal on that ROC in the time bin of the DigitMC
-    float getCommonMode() const { return mCommonMode; }
+  /// Get the raw pedestal value
+  /// \return Raw pedestal value of the corresponding DigitMC (before saturation)
+  float getPedestal() const { return mPedestal; }
 
-    /// Get the raw pedestal value
-    /// \return Raw pedestal value of the corresponding DigitMC (before saturation)
-    float getPedestal() const { return mPedestal; }
+  /// Get the raw noise value
+  /// \return Raw noise value of the corresponding DigitMC (before saturation)
+  float getNoise() const { return mNoise; }
 
-    /// Get the raw noise value
-    /// \return Raw noise value of the corresponding DigitMC (before saturation)
-    float getNoise() const { return mNoise; }
-
-  private:
-    float         mADC;             ///< Raw ADC value of the DigitMCMetaData
-    float         mCommonMode;      ///< Common mode value of the DigitMCMetaData
-    float         mPedestal;        ///< Pedestal value of the DigitMCMetaData
-    float         mNoise;           ///< Noise value of the DigitMCMetaData
+ private:
+  float mADC = 0.f;        ///< Raw ADC value of the DigitMCMetaData
+  float mCommonMode = 0.f; ///< Common mode value of the DigitMCMetaData
+  float mPedestal = 0.f;   ///< Pedestal value of the DigitMCMetaData
+  float mNoise = 0.f;      ///< Noise value of the DigitMCMetaData
 
   ClassDefNV(DigitMCMetaData, 1);
 };
 
-inline
-DigitMCMetaData::DigitMCMetaData()
-  : mADC(0.f),
-    mCommonMode(0.f),
-    mPedestal(0.f),
-    mNoise(0.f)
-  {}
-
-inline
-DigitMCMetaData::DigitMCMetaData(float ADC, float commonMode, float pedestal, float noise)
+inline DigitMCMetaData::DigitMCMetaData(float ADC, float commonMode, float pedestal, float noise)
   : mADC(ADC),
     mCommonMode(commonMode),
     mPedestal(pedestal),
     mNoise(noise)
-{}
+{
+}
 
-}
-}
+} // namespace TPC
+} // namespace o2
 
 #endif // ALICEO2_TPC_DigitMCMetaData_H_

--- a/Detectors/TPC/simulation/include/TPCSimulation/Digitizer.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/Digitizer.h
@@ -54,10 +54,13 @@ class Digitizer
 {
  public:
   /// Default constructor
-  Digitizer();
+  Digitizer() = default;
 
   /// Destructor
   ~Digitizer() = default;
+
+  Digitizer(const Digitizer&) = delete;
+  Digitizer& operator=(const Digitizer&) = delete;
 
   /// Initializer
   void init();
@@ -108,15 +111,13 @@ class Digitizer
   void enableSCDistortions(SpaceCharge::SCDistortionType distortionType, TH3* hisInitialSCDensity, int nZSlices, int nPhiBins, int nRBins);
 
  private:
-  Digitizer(const Digitizer&);
-  Digitizer& operator=(const Digitizer&);
-
   DigitContainer mDigitContainer;                   ///< Container for the Digits
   std::unique_ptr<SpaceCharge> mSpaceChargeHandler; ///< Handler of space-charge distortions
-  Sector mSector;                                   ///< ID of the currently processed sector
-  float mEventTime;                                 ///< Time of the currently processed event
+  Sector mSector = -1;                              ///< ID of the currently processed sector
+  float mEventTime = 0.f;                           ///< Time of the currently processed event
+  // FIXME: whats the reason for hving this static?
   static bool mIsContinuous;                        ///< Switch for continuous readout
-  bool mUseSCDistortions;                           ///< Flag to switch on the use of space-charge distortions
+  bool mUseSCDistortions = false;                   ///< Flag to switch on the use of space-charge distortions
 
   ClassDefNV(Digitizer, 1);
 };

--- a/Detectors/TPC/simulation/src/Digitizer.cxx
+++ b/Detectors/TPC/simulation/src/Digitizer.cxx
@@ -35,15 +35,6 @@ ClassImp(o2::TPC::Digitizer)
 
 bool o2::TPC::Digitizer::mIsContinuous = true;
 
-Digitizer::Digitizer()
-  : mDigitContainer(),
-    mSpaceChargeHandler(nullptr),
-    mSector(-1),
-    mEventTime(0.f),
-    mUseSCDistortions(false)
-{
-}
-
 void Digitizer::init()
 {
   // Calculate distortion lookup tables if initial space-charge density is provided


### PR DESCRIPTION
A first step to get the O2 code checker CI functional again. No functional
changesto the TPC code.

Whitespace changes can be suppressed in the diff by using either option '-b' or '-w'.