### PR TITLE
DPL: workaround issue introduced by the new fake channels [O2-511]

### DIFF
--- a/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
+++ b/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
@@ -37,6 +37,10 @@ void broadcastMessage(FairMQDevice &device, o2::header::Stack &&headerStack, Fai
     if (strncmp(channel.data(), "from_", 5) != 0) {
       continue;
     }
+    /// FIXME: until we find a better way to avoid using fake input channels
+    if (strncmp(channel.data(), "from_internal-dpl-", 18) == 0) {
+      continue;
+    }
 
     // FIXME: this assumes there is only one output from here... This should
     //        really do the matchmaking between inputs and output channels.


### PR DESCRIPTION
This avoids that DPL tries to forward messages from the proxied
component to one of the fake inputs, e.g. the one used for
enumeration. A proper fix should come when the proxied components
will be implemented as fake inputs themselves.