### PR TITLE
TOFClusterizer: changing log message type from ERROR to WARNING

### DIFF
--- a/Detectors/TOF/base/src/Geo.cxx
+++ b/Detectors/TOF/base/src/Geo.cxx
@@ -158,8 +158,7 @@ void Geo::getPos(Int_t* det, Float_t* pos)
   Char_t path[200];
   getVolumePath(det, path);
   if (!gGeoManager) {
-    LOG(ERROR) << " no TGeo! Loading it"
-               << "\n";
+    LOG(WARNING) << " no TGeo! Loading it";
     o2::Base::GeometryManager::loadGeometry();
   }
   FILE* ciccio = fopen("TOF_geo.txt", "w");


### PR DESCRIPTION
The message should not be of type ERROR because it is handled, changing to WARNING.

The question is if something needs to be initialized earlier.