### PR TITLE
Subscribing to the DIGTRIGGERS data channel published by TPC digitizer

### DIFF
--- a/Detectors/TPC/workflow/src/ClustererSpec.h
+++ b/Detectors/TPC/workflow/src/ClustererSpec.h
@@ -22,7 +22,7 @@ namespace TPC
 
 /// create a processor spec
 /// read simulated TPC clusters from file and publish
-framework::DataProcessorSpec getClustererSpec(bool sendMC);
+framework::DataProcessorSpec getClustererSpec(bool sendMC, bool haveDigTriggers = false);
 
 } // end namespace TPC
 } // end namespace o2

--- a/Detectors/TPC/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/TPC/workflow/src/RecoWorkflow.cxx
@@ -150,7 +150,7 @@ framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors, std::vec
   //
   //
   if (runClusterer) {
-    parallelProcessors.push_back(o2::TPC::getClustererSpec(propagateMC));
+    parallelProcessors.push_back(o2::TPC::getClustererSpec(propagateMC, inputType == InputType::Digitizer));
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////

--- a/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
+++ b/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
@@ -40,24 +40,27 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 
 using namespace o2::framework;
 
-/// Defines basic workflow for TPC reconstruction
+/// The workflow executable for the stand alone TPC reconstruction workflow
+/// The basic workflow for TPC reconstruction is defined in RecoWorkflow.cxx
+/// and contains the following default processors
 /// - digit reader
 /// - clusterer
-/// - cluster converter
 /// - cluster raw decoder
 /// - CA tracker
 ///
-/// Digit reader and clusterer can be replaced by the cluster reader.
+/// The default workflow can be customized by specifying input and output types
+/// e.g. digits, raw, tracks.
 ///
-/// MC info is always sent by the digit reader and clusterer processes, the
-/// cluster converter process creating the raw format can be configured to forward MC.
+/// MC info is processed by default, disabled by using command line option `--disable-mc`
 ///
-/// This function is required to be implemented to define the workflow specifications
+/// This function hooks up the the workflow specifications into the DPL driver.
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   auto tpcSectors = o2::RangeTokenizer::tokenize<int>(cfgc.options().get<std::string>("tpc-sectors"));
-  return o2::TPC::RecoWorkflow::getWorkflow(tpcSectors,                                    //
-                                            tpcSectors,                                    //
+  // the lane configuration defines the subspecification ids to be distributes
+  // among the lanes.
+  return o2::TPC::RecoWorkflow::getWorkflow(tpcSectors,                                    // sector configuration
+                                            tpcSectors,                                    // lane configuration
                                             not cfgc.options().get<bool>("disable-mc"),    //
                                             cfgc.options().get<int>("tpc-lanes"),          //
                                             cfgc.options().get<std::string>("input-type"), //


### PR DESCRIPTION
The TPC digitizer defines a third output channel, which was left dangling when connecting to the reco workflow. The automatically added file dump however does not signal ready-to-quit, leaving the workflow unterminated.

Need to clarify if the data sent over this channel is needed by the clusterer.