### PR TITLE
Updating the coupling of TPC reconstruction workflow to digitizer workflow

### DIFF
--- a/Steer/DigitizerWorkflow/src/SimReaderSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/SimReaderSpec.cxx
@@ -33,7 +33,7 @@ namespace o2
 {
 namespace steer
 {
-DataProcessorSpec getSimReaderSpec(int fanoutsize, std::shared_ptr<std::vector<int>> tpcsectors,
+DataProcessorSpec getSimReaderSpec(int fanoutsize, const std::vector<int>& tpcsectors,
                                    std::shared_ptr<std::vector<int>> tpcsubchannels)
 {
   // this container will contain the TPC sector assignment per subchannel per invocation
@@ -43,7 +43,7 @@ DataProcessorSpec getSimReaderSpec(int fanoutsize, std::shared_ptr<std::vector<i
   tpcsectormessages->resize(tpcsubchannels->size());
   int tpcchannelcounter = 0;
   uint64_t activeSectors = 0;
-  for (const auto& tpcsector : *tpcsectors.get()) {
+  for (const auto& tpcsector : tpcsectors) {
     activeSectors |= (uint64_t)0x1 << tpcsector;
     auto actualchannel = (*tpcsubchannels.get())[tpcchannelcounter % tpcsubchannels->size()];
     LOG(DEBUG) << " WILL ASSIGN SECTOR " << tpcsector << " to subchannel " << actualchannel;

--- a/Steer/DigitizerWorkflow/src/SimReaderSpec.h
+++ b/Steer/DigitizerWorkflow/src/SimReaderSpec.h
@@ -17,7 +17,7 @@ namespace o2
 {
 namespace steer
 {
-o2::framework::DataProcessorSpec getSimReaderSpec(int fanoutsize, std::shared_ptr<std::vector<int>> tpcsectors,
+o2::framework::DataProcessorSpec getSimReaderSpec(int fanoutsize, const std::vector<int>& tpcsectors,
                                                   std::shared_ptr<std::vector<int>> tpcsubchannels);
 }
 }


### PR DESCRIPTION
- using [RangeTokenizer](https://github.com/AliceO2Group/AliceO2/blob/dev/Algorithm/include/Algorithm/RangeTokenizer.h) to extract list of TPC sectors, sequences of ranges
  can now be specified, e.g. 0-3,5,16-20
- propagating the tpc sector configuration to the reco workflow, this allows
  to run all the different output modes of the TPC reconstruction workflow:
  raw, decoded-clusters, tracks
- minor cleanup of internal variable, no need to make it shared_ptr