### PR TITLE
flpQualification: connect to readout

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -80,6 +80,7 @@ set(SRCS
     src/PaletteHelpers.cxx
     src/CommonDataProcessors.cxx
     src/RCombinedDS.cxx
+    src/ReadoutAdapter.cxx
     ${GUI_SOURCES}
     test/TestClasses.cxx
     src/Variant.cxx

--- a/Framework/Core/include/Framework/ReadoutAdapter.h
+++ b/Framework/Core/include/Framework/ReadoutAdapter.h
@@ -1,0 +1,30 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef o2_framework_ReadoutAdapter_H_DEFINED
+#define o2_framework_ReadoutAdapter_H_DEFINED
+
+#include "ExternalFairMQDeviceProxy.h"
+
+namespace o2
+{
+namespace framework
+{
+
+/// An adapter function for data sent by Readout.  It gets the raw pages as
+/// provided by Readout and wraps them in a multipart message where the
+/// DataHeader is specified by the OutputSpec, while the DataProcessing header
+/// is an enumeration of the pages received.
+InjectorFunction readoutAdapter(OutputSpec const& spec);
+
+} // namespace framework
+} // namespace o2
+
+#endif // o2_framework_ReadoutAdapter_H_DEFINED

--- a/Framework/Core/src/ReadoutAdapter.cxx
+++ b/Framework/Core/src/ReadoutAdapter.cxx
@@ -1,0 +1,46 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/ReadoutAdapter.h"
+#include "Framework/DataProcessingHeader.h"
+#include "Headers/DataHeader.h"
+
+#include <Common/DataBlock.h>
+
+namespace o2
+{
+namespace framework
+{
+
+using DataHeader = o2::header::DataHeader;
+
+InjectorFunction readoutAdapter(OutputSpec const& spec)
+{
+  auto counter = std::make_shared<uint64_t>(0);
+
+  return [spec, counter](FairMQDevice& device, FairMQParts& parts, int index) {
+    for (size_t i = 0; i < parts.Size(); ++i) {
+      DataHeader dh;
+      dh.dataOrigin = spec.origin;
+      dh.dataDescription = spec.description;
+      dh.subSpecification = spec.subSpec;
+      dh.payloadSize = parts.At(i)->GetSize();
+      dh.payloadSerializationMethod = o2::header::gSerializationMethodNone;
+
+      DataProcessingHeader dph{ *counter, 0 };
+      (*counter) += 1UL;
+      o2::header::Stack headerStack{ dh, dph };
+      broadcastMessage(device, std::move(headerStack), std::move(parts.At(i)), index);
+    }
+  };
+}
+
+} // namespace framework
+} // namespace o2

--- a/Framework/TestWorkflows/README
+++ b/Framework/TestWorkflows/README
@@ -16,8 +16,18 @@ for the two layers can be controlled via the command line options.
 The connections to Readout and DataDistribution are not actually there
 yet, but they come next.
 
-Synopsis: flpQualification
+Synopsis: flpQualification [options]
 
 Relevant options:
-* --2-layer-jobs <n>
-* --3-layer-pipelining <m>
+
+* --2-layer-jobs <n> : number of data parallel workers in the first processing
+  layer
+* --3-layer-pipelining <m> : numer of time pipelined workers in the second processing
+  layer.
+
+Readout proxy channel configuration can be done by passing the option as it
+follows:
+
+   --readout-proxy '--channel-config "name=readout-proxy,type=pair,method=connect,address=ipc:///tmp/readout-pipe-0,rateLogging=1"'
+
+These must match appropriately the configuration of `readout.exe`.


### PR DESCRIPTION
This introduces preliminary ability to connect to a Readout device. For
the moment no interpretation of the input is done and the timestamp for
the DataProcessingHeader is a simple enumeration of the messages.