### PR TITLE
Re-enable the DPL workflow unit tests

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -195,33 +195,33 @@ O2_GENERATE_EXECUTABLE(
   BUCKET_NAME ${MODULE_BUCKET_NAME}
 )
 
-#O2_GENERATE_EXECUTABLE(
-#  EXE_NAME "test_Parallel"
-#  SOURCES "test/test_Parallel.cxx"
-#  MODULE_LIBRARY_NAME ${LIBRARY_NAME}
-#  BUCKET_NAME ${MODULE_BUCKET_NAME}
-#)
+O2_GENERATE_EXECUTABLE(
+  EXE_NAME "test_Parallel"
+  SOURCES "test/test_Parallel.cxx"
+  MODULE_LIBRARY_NAME ${LIBRARY_NAME}
+  BUCKET_NAME ${MODULE_BUCKET_NAME}
+)
 
-#O2_GENERATE_EXECUTABLE(
-#  EXE_NAME "test_TimePipeline"
-#  SOURCES "test/test_TimePipeline.cxx"
-#  MODULE_LIBRARY_NAME ${LIBRARY_NAME}
-#  BUCKET_NAME ${MODULE_BUCKET_NAME}
-#)
+O2_GENERATE_EXECUTABLE(
+  EXE_NAME "test_TimePipeline"
+  SOURCES "test/test_TimePipeline.cxx"
+  MODULE_LIBRARY_NAME ${LIBRARY_NAME}
+  BUCKET_NAME ${MODULE_BUCKET_NAME}
+)
 
-#O2_GENERATE_EXECUTABLE(
-#  EXE_NAME "test_DebugGUISokol"
-#  SOURCES test/test_DebugGUISokol.cxx
-#  MODULE_LIBRARY_NAME ${LIBRARY_NAME}
-#  BUCKET_NAME ${MODULE_BUCKET_NAME}
-#)
+O2_GENERATE_EXECUTABLE(
+  EXE_NAME "test_DebugGUISokol"
+  SOURCES test/test_DebugGUISokol.cxx
+  MODULE_LIBRARY_NAME ${LIBRARY_NAME}
+  BUCKET_NAME ${MODULE_BUCKET_NAME}
+)
 
-#O2_GENERATE_EXECUTABLE(
-#  EXE_NAME "test_DebugGUIGL"
-#  SOURCES test/test_DebugGUIGL.cxx
-#  MODULE_LIBRARY_NAME ${LIBRARY_NAME}
-#  BUCKET_NAME ${MODULE_BUCKET_NAME}
-#)
+O2_GENERATE_EXECUTABLE(
+  EXE_NAME "test_DebugGUIGL"
+  SOURCES test/test_DebugGUIGL.cxx
+  MODULE_LIBRARY_NAME ${LIBRARY_NAME}
+  BUCKET_NAME ${MODULE_BUCKET_NAME}
+)
 
 Install(FILES test/test_DataSampling.json DESTINATION share/tests/)
 
@@ -230,14 +230,14 @@ set(TEST_SRCS
       test/test_AlgorithmSpec.cxx
       test/test_BoostOptionsRetriever.cxx
       test/test_CallbackRegistry.cxx
-      #test/test_CallbackService.cxx
+      test/test_CallbackService.cxx
       test/test_ChannelSpecHelpers.cxx
-      #test/test_CustomGUISokol.cxx
-      #test/test_CustomGUIGL.cxx
+      test/test_CustomGUISokol.cxx
+      test/test_CustomGUIGL.cxx
       test/test_CompletionPolicy.cxx
-      #test/test_DanglingInputs.cxx
-      #test/test_DanglingOutputs.cxx
-      #test/test_DataAllocator.cxx
+      test/test_DanglingInputs.cxx
+      test/test_DanglingOutputs.cxx
+      test/test_DataAllocator.cxx
       test/test_DataDescriptorMatcher.cxx
       test/test_DataProcessorSpec.cxx
       test/test_DataRefUtils.cxx
@@ -249,23 +249,23 @@ set(TEST_SRCS
       test/test_DeviceSpec.cxx
       test/test_ExternalFairMQDeviceProxy.cxx
       test/test_FairMQResizableBuffer.cxx
-      #test/test_Forwarding.cxx
-      #test/test_FrameworkDataFlowToDDS.cxx
+      test/test_Forwarding.cxx
+      test/test_FrameworkDataFlowToDDS.cxx
       test/test_FairMQOptionsRetriever.cxx
       test/test_GUITests.cxx
       test/test_Graphviz.cxx
       test/test_InfoLogger.cxx
       test/test_InputRecord.cxx
       test/test_LogParsingHelpers.cxx
-      #test/test_ParallelProducer.cxx
+      test/test_ParallelProducer.cxx
       test/test_PtrHelpers.cxx
       test/test_Root2ArrowTable.cxx
       test/test_Services.cxx
       test/test_SimpleRDataFrameProcessing.cxx
       test/test_SimpleStatefulProcessing01.cxx
       test/test_SimpleStringProcessing.cxx
-      #test/test_SingleDataSource.cxx
-      #test/test_SimpleTimer.cxx
+      test/test_SingleDataSource.cxx
+      test/test_SimpleTimer.cxx
       test/test_SuppressionGenerator.cxx
       test/test_TimesliceIndex.cxx
       test/test_TMessageSerializer.cxx
@@ -301,16 +301,16 @@ O2_GENERATE_TESTS(
 )
 
 # specific tests which needs command line options
-#O2_GENERATE_TESTS(
-#  MODULE_LIBRARY_NAME ${LIBRARY_NAME}
-#  BUCKET_NAME ${BUCKET_NAME}
-#  TIMEOUT 300
-#
-#  TEST_SRCS
-#  test/test_ProcessorOptions.cxx
-#
-#  COMMAND_LINE_ARGS
-#  --global-config require-me
-#  # Note: the group switch makes process consumer parse only the group arguments
-#  --consumer "--global-config consumer-config --local-option hello-aliceo2 --a-boolean3 --an-int2 20 --a-double2 22."
-#)
+O2_GENERATE_TESTS(
+  MODULE_LIBRARY_NAME ${LIBRARY_NAME}
+  BUCKET_NAME ${BUCKET_NAME}
+  TIMEOUT 60
+
+  TEST_SRCS
+  test/test_ProcessorOptions.cxx
+
+  COMMAND_LINE_ARGS
+  --global-config require-me
+  # Note: the group switch makes process consumer parse only the group arguments
+  --consumer "--global-config consumer-config --local-option hello-aliceo2 --a-boolean3 --an-int2 20 --a-double2 22."
+)

--- a/Framework/Core/test/test_DataAllocator.cxx
+++ b/Framework/Core/test/test_DataAllocator.cxx
@@ -16,11 +16,14 @@
 #include "Framework/InputSpec.h"
 #include "Framework/OutputSpec.h"
 #include "Framework/ControlService.h"
+#include "Framework/RawDeviceService.h"
 #include "Framework/SerializationMethods.h"
 #include "Headers/DataHeader.h"
 #include "TestClasses.h"
 #include "FairMQLogger.h"
+#include <fairmq/FairMQDevice.h>
 #include <vector>
+#include <chrono>
 
 using namespace o2::framework;
 
@@ -53,8 +56,8 @@ DataProcessorSpec getTimeoutSpec()
     static int counter = 0;
     pc.outputs().snapshot(Output{ "TEST", "TIMER", 0, Lifetime::Timeframe }, counter);
 
-    sleep(1);
-    if (counter++ > 10) {
+    // terminate if WaitFor was not interrupted
+    if (pc.services().get<RawDeviceService>().device()->WaitFor(std::chrono::seconds(1)) && (counter++ > 10)) {
       LOG(ERROR) << "Timeout reached, the workflow seems to be broken";
       pc.services().get<ControlService>().readyToQuit(true);
     }


### PR DESCRIPTION
Revert "DPL: disable tests which timeout due to a FairMQ regression"
This reverts commit defa237caa5e47e567bfb8145e431a098d9287ae.

Tests are run with `--dont-fail-on-timeout` since 310e8f2129, real
issues will lead to other error codes and are not masked.