### PR TITLE
Make global cut and process settings configurable

### DIFF
--- a/Detectors/Passive/src/PassiveLinkDef.h
+++ b/Detectors/Passive/src/PassiveLinkDef.h
@@ -36,8 +36,6 @@
 #pragma link C++ class  o2::passive::FrameStructure+;
 #pragma link C++ class  o2::passive::Shil+;
 #pragma link C++ class  o2::passive::Hall+;
-#pragma link C++ class  o2::conf::ConfigurableParam+;
 #pragma link C++ class  o2::passive::HallSimParam+;
 #pragma link C++ class  o2::conf::ConfigurableParamHelper<o2::passive::HallSimParam>+;
 #endif
-

--- a/Detectors/gconfig/CMakeLists.txt
+++ b/Detectors/gconfig/CMakeLists.txt
@@ -6,10 +6,12 @@ set(SRCS
      src/G3Config.cxx
      src/G4Config.cxx
      src/SimSetup.cxx
+     src/GlobalProcessCutSimParam.cxx
    )
 
 set(HEADERS
     include/${MODULE_NAME}/SimSetup.h
+    include/${MODULE_NAME}/GlobalProcessCutSimParam.h
    )
 
 Set(LINKDEF src/GConfLinkDef.h)

--- a/Detectors/gconfig/SetCuts.h
+++ b/Detectors/gconfig/SetCuts.h
@@ -23,56 +23,55 @@
 
 void SetCuts()
 {
-  cout << "SetCuts Macro: Setting Processes.." <<endl;
-   
+  cout << "SetCuts Macro: Setting Processes.." << endl;
+
   // ------>>>> IMPORTANT!!!!
-  // For a correct comparison between GEANE and MC (pull distributions) 
+  // For a correct comparison between GEANE and MC (pull distributions)
   // or for a simulation without the generation of secondary particles:
   // 1. set LOSS = 2, DRAY = 0, BREM = 1
   // 2. set the following cut values: CUTGAM, CUTELE, CUTNEU, CUTHAD, CUTMUO = 1 MeV or less
   //                                  BCUTE, BCUTM, DCUTE, DCUTM, PPCUTM = 10 TeV
   // (For an explanation of the chosen values, please refer to the GEANT User's Guide
   // or to message #5362 in the PandaRoot Forum >> Monte Carlo Engines >> g3Config.C thread)
-  // 
+  //
   // The default settings refer to a complete simulation which generates and follows also the secondary particles.
 
   // \note All following settings could also be set in Cave since it is always loaded.
   // Use MaterialManager to set processes and cuts
   auto& mgr = MaterialManager::Instance();
+  auto& params = GlobalProcessCutSimParam::Instance();
 
   LOG(INFO) << "Set default settings for processes and cuts.";
-  mgr.DefaultProcesses({ { EProc::kPAIR, 1 },    /** pair production */
-                         { EProc::kCOMP, 1 },    /** Compton scattering */
-                         { EProc::kPHOT, 1 },    /** photo electric effect */
-                         { EProc::kPFIS, 0 },    /** photofission */
-                         { EProc::kDRAY, 0 },    /** delta ray */
-                         { EProc::kANNI, 1 },    /** annihilation */
-                         { EProc::kBREM, 1 },    /** bremsstrahlung */
-                         { EProc::kHADR, 1 },    /** hadronic process */
-                         { EProc::kMUNU, 1 },    /** muon nuclear interaction */
-                         { EProc::kDCAY, 1 },    /** decay */
-                         { EProc::kLOSS, 2 },    /** energy loss */
-                         { EProc::kMULS, 1 },    /** multiple scattering */
-                         { EProc::kCKOV, 1 } }); /** Cherenkov */
+  mgr.DefaultProcesses({ { EProc::kPAIR, params.PAIR },    /** pair production */
+                         { EProc::kCOMP, params.COMP },    /** Compton scattering */
+                         { EProc::kPHOT, params.PHOT },    /** photo electric effect */
+                         { EProc::kPFIS, params.PFIS },    /** photofission */
+                         { EProc::kDRAY, params.DRAY },    /** delta ray */
+                         { EProc::kANNI, params.ANNI },    /** annihilation */
+                         { EProc::kBREM, params.BREM },    /** bremsstrahlung */
+                         { EProc::kHADR, params.HADR },    /** hadronic process */
+                         { EProc::kMUNU, params.MUNU },    /** muon nuclear interaction */
+                         { EProc::kDCAY, params.DCAY },    /** decay */
+                         { EProc::kLOSS, params.LOSS },    /** energy loss */
+                         { EProc::kMULS, params.MULS },    /** multiple scattering */
+                         { EProc::kCKOV, params.CKOV } }); /** Cherenkov */
 
-  const Double_t cut1 = 1.0E-3; // GeV --> 1 MeV
-  //Double_t cutb = 1.0E4;          // GeV --> 10 TeV
-  const Double_t cutTofmax = 1.E10; // seconds
-
-  mgr.DefaultCuts({ { ECut::kCUTGAM, cut1 },         /** gammas */
-                    { ECut::kCUTELE, cut1 },         /** electrons */
-                    { ECut::kCUTNEU, cut1 },         /** neutral hadrons */
-                    { ECut::kCUTHAD, cut1 },         /** charged hadrons */
-                    { ECut::kCUTMUO, cut1 },         /** muons */
-                    { ECut::kBCUTE, cut1 },          /** electron bremsstrahlung */
-                    { ECut::kBCUTM, cut1 },          /** muon and hadron bremsstrahlung */
-                    { ECut::kDCUTE, cut1 },          /** delta-rays by electrons */
-                    { ECut::kDCUTM, cut1 },          /** delta-rays by muons */
-                    { ECut::kPPCUTM, cut1 },         /** direct pair production by muons */
-                    { ECut::kTOFMAX, cutTofmax } }); /** time of flight */
+  mgr.DefaultCuts({ { ECut::kCUTGAM, params.CUTGAM },    /** gammas */
+                    { ECut::kCUTELE, params.CUTELE },    /** electrons */
+                    { ECut::kCUTNEU, params.CUTNEU },    /** neutral hadrons */
+                    { ECut::kCUTHAD, params.CUTHAD },    /** charged hadrons */
+                    { ECut::kCUTMUO, params.CUTMUO },    /** muons */
+                    { ECut::kBCUTE, params.BCUTE },      /** electron bremsstrahlung */
+                    { ECut::kBCUTM, params.BCUTM },      /** muon and hadron bremsstrahlung */
+                    { ECut::kDCUTE, params.DCUTE },      /** delta-rays by electrons */
+                    { ECut::kDCUTM, params.DCUTM },      /** delta-rays by muons */
+                    { ECut::kPPCUTM, params.PPCUTM },    /** direct pair production by muons */
+                    { ECut::kTOFMAX, params.TOFMAX } }); /** time of flight */
 
   const char* settingProc = mgr.specialProcessesEnabled() ? "enabled" : "disabled";
   const char* settingCut = mgr.specialCutsEnabled() ? "enabled" : "disabled";
   LOG(INFO) << "Special process settings are " << settingProc << ".";
   LOG(INFO) << "Special cut settings are " << settingCut << ".";
+  mgr.printProcesses();
+  mgr.printCuts();
 }

--- a/Detectors/gconfig/include/SimSetup/GlobalProcessCutSimParam.h
+++ b/Detectors/gconfig/include/SimSetup/GlobalProcessCutSimParam.h
@@ -1,0 +1,53 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef DETECTORS_GCONFIG_INCLUDE_SIMSETUP_GLOBALPROCESSCUTSIMPARAM_H_
+#define DETECTORS_GCONFIG_INCLUDE_SIMSETUP_GLOBALPROCESSCUTSIMPARAM_H_
+
+#include "SimConfig/ConfigurableParam.h"
+#include "SimConfig/ConfigurableParamHelper.h"
+
+namespace o2
+{
+
+struct GlobalProcessCutSimParam : public o2::conf::ConfigurableParamHelper<GlobalProcessCutSimParam> {
+  int PAIR = 1;
+  int COMP = 1;
+  int PHOT = 1;
+  int PFIS = 0;
+  int DRAY = 0;
+  int ANNI = 1;
+  int BREM = 1;
+  int HADR = 1;
+  int MUNU = 1;
+  int DCAY = 1;
+  int LOSS = 2;
+  int MULS = 1;
+  int CKOV = 1;
+
+  double CUTGAM = 1.0E-3; // GeV --> 1 MeV
+  double CUTELE = 1.0E-3; // GeV --> 1 MeV
+  double CUTNEU = 1.0E-3; // GeV --> 1 MeV
+  double CUTHAD = 1.0E-3; // GeV --> 1 MeV
+  double CUTMUO = 1.0E-3; // GeV --> 1 MeV
+  double BCUTE = 1.0E-3;  // GeV --> 1 MeV
+  double BCUTM = 1.0E-3;  // GeV --> 1 MeV
+  double DCUTE = 1.0E-3;  // GeV --> 1 MeV
+  double DCUTM = 1.0E-3;  // GeV --> 1 MeV
+  double PPCUTM = 1.0E-3; // GeV --> 1 MeV
+  double TOFMAX = 1.E10;  // seconds
+
+  // boilerplate stuff + make principal key "GlobalSimProcs"
+  O2ParamDef(GlobalProcessCutSimParam, "GlobalSimProcs");
+};
+
+} // namespace o2
+
+#endif /* DETECTORS_GCONFIG_INCLUDE_SIMSETUP_GLOBALPROCESSCUTSIMPARAM_H_ */

--- a/Detectors/gconfig/src/G3Config.cxx
+++ b/Detectors/gconfig/src/G3Config.cxx
@@ -18,9 +18,11 @@
 #include "FairModule.h"
 #include <DetectorsPassive/Cave.h>
 #include "DetectorsBase/MaterialManager.h"
+#include "SimSetup/GlobalProcessCutSimParam.h"
 
 //using declarations here since SetCuts.C and g3Config.C are included within namespace
 // these are needed for SetCuts.C inclusion
+using o2::GlobalProcessCutSimParam;
 using o2::Base::ECut;
 using o2::Base::EProc;
 using o2::Base::MaterialManager;
@@ -42,5 +44,5 @@ void G3Config()
   Config();
   SetCuts();
 }
-}
-}
+} // namespace g3config
+} // namespace o2

--- a/Detectors/gconfig/src/G4Config.cxx
+++ b/Detectors/gconfig/src/G4Config.cxx
@@ -19,9 +19,11 @@
 #include "FairModule.h"
 #include <DetectorsPassive/Cave.h>
 #include "DetectorsBase/MaterialManager.h"
+#include "SimSetup/GlobalProcessCutSimParam.h"
 
 //using declarations here since SetCuts.C and g4Config.C are included within namespace
 // these are needed for SetCuts.C inclusion
+using o2::GlobalProcessCutSimParam;
 using o2::Base::ECut;
 using o2::Base::EProc;
 using o2::Base::MaterialManager;
@@ -42,5 +44,5 @@ void G4Config()
   Config();
   SetCuts();
 }
-}
-}
+} // namespace g4config
+} // namespace o2

--- a/Detectors/gconfig/src/GlobalProcessCutSimParam.cxx
+++ b/Detectors/gconfig/src/GlobalProcessCutSimParam.cxx
@@ -8,16 +8,5 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-
-#ifdef __CLING__
-
-#pragma link off all globals;
-#pragma link off all classes;
-#pragma link off all functions;
-#pragma link C++ class o2::SimSetup+;
-
-#pragma link C++ class  o2::conf::ConfigurableParam+;
-#pragma link C++ class  o2::GlobalProcessCutSimParam+;
-#pragma link C++ class  o2::conf::ConfigurableParamHelper<o2::GlobalProcessCutSimParam>+;
-
-#endif
+#include "SimSetup/GlobalProcessCutSimParam.h"
+O2ParamImpl(o2::GlobalProcessCutSimParam);

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -2408,6 +2408,7 @@ o2_define_bucket(
     ${Geant3_INCLUDE_DIRS}
     ${FAIRROOT_INCLUDE_DIR}
     ${ROOT_INCLUDE_DIR}
+    ${CMAKE_SOURCE_DIR}/Common/SimConfig/include
 )
 
 o2_define_bucket(


### PR DESCRIPTION
The global process and cut settings for particle transport have been
made configurable making use of the O2 ConfigurableParam concept.
Modifying parameters can be done via the key 'GlobalSim'. Hence, they
can be set also in the command line

$> o2sim --configKeyValues 'GlobalSim.mPAIR=0'

which in this case turns off pair production.