### PR TITLE
flpQualification: do not sleep between one message and the other

### DIFF
--- a/Framework/TestWorkflows/src/flpQualification.cxx
+++ b/Framework/TestWorkflows/src/flpQualification.cxx
@@ -58,7 +58,6 @@ DataProcessorSpec templateProcessor()
         size_t index = parallelInfo.index1D();
         LOG(INFO) << reinterpret_cast<DataHeader const*>(values.header)->payloadSize;
         auto aData = outputs.make<int>(Output{ "TST", "P", index }, 1);
-        sleep(rand() % 5);
       });
     } }
   };


### PR DESCRIPTION
Unlike real life, where we struggle to keep up with the lack of
sleep and a good night is fundamental for our proper functioning,
invoking sleep on a computer process drastically reduces its
performance making it unresponsive to external inputs.