### PR TITLE
Adding responses for MID simulations

### DIFF
--- a/Detectors/MUON/MID/Base/CMakeLists.txt
+++ b/Detectors/MUON/MID/Base/CMakeLists.txt
@@ -3,6 +3,7 @@ set(MODULE_NAME "MIDBase")
 O2_SETUP(NAME ${MODULE_NAME})
 
 set(SRCS
+  src/ChamberEfficiency.cxx
   src/Constants.cxx
   src/GeometryTransformer.cxx
   src/HitFinder.cxx
@@ -11,6 +12,7 @@ set(SRCS
 )
 
 set(NO_DICT_HEADERS
+  include/${MODULE_NAME}/ChamberEfficiency.h
   include/${MODULE_NAME}/Constants.h
   include/${MODULE_NAME}/GeometryTransformer.h
   include/${MODULE_NAME}/HitFinder.h

--- a/Detectors/MUON/MID/Base/include/MIDBase/ChamberEfficiency.h
+++ b/Detectors/MUON/MID/Base/include/MIDBase/ChamberEfficiency.h
@@ -1,0 +1,50 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDBase/ChamberEfficiency.h
+/// \brief  Measured values of the RPC efficiency
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   03 March 2019
+#ifndef O2_MID_CHAMBEREFFICIENCY_H
+#define O2_MID_CHAMBEREFFICIENCY_H
+
+#include <map>
+#include <array>
+
+namespace o2
+{
+namespace mid
+{
+class ChamberEfficiency
+{
+ public:
+  enum class EffType {
+    BendPlane,
+    NonBendPlane,
+    BothPlanes
+  };
+
+  double getEfficiency(int deId, int columnId, int line, EffType type) const;
+
+  // void setEfficiency(uint32_t nPassed, uint32_t nTotal, int deId, int columnId, int line, EffType type);
+  void addEntry(bool isEfficientBP, bool isEfficientNBP, int deId, int columnId, int line);
+
+ private:
+  int typeToIdx(EffType type) const;
+  int indexToInt(int deId, int columnId, int line) const;
+  std::map<int, std::array<uint32_t, 4>> mCounters; ///< Efficiency counters
+};
+
+ChamberEfficiency createDefaultChamberEfficiency();
+
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_CHAMBEREFFICIENCY_H */

--- a/Detectors/MUON/MID/Base/src/ChamberEfficiency.cxx
+++ b/Detectors/MUON/MID/Base/src/ChamberEfficiency.cxx
@@ -1,0 +1,108 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Base/src/ChamberEfficiency.cxx
+/// \brief  Implementation of the chamber efficiency for the MID RPC
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   01 March 2019
+
+#include "MIDBase/ChamberEfficiency.h"
+
+#include <iostream>
+#include "MIDBase/Constants.h"
+#include "MIDBase/Mapping.h"
+
+namespace o2
+{
+namespace mid
+{
+
+//______________________________________________________________________________
+int ChamberEfficiency::typeToIdx(EffType type) const
+{
+  /// Converts efficiency types to indexes
+  switch (type) {
+    case EffType::BendPlane:
+      return 0;
+    case EffType::NonBendPlane:
+      return 1;
+    case EffType::BothPlanes:
+      return 2;
+  }
+}
+
+//______________________________________________________________________________
+int ChamberEfficiency::indexToInt(int deId, int columnId, int line) const
+{
+  /// Converts indexes to integer for easier map access
+  return line + 10 * columnId + 100 * deId;
+}
+
+//______________________________________________________________________________
+double ChamberEfficiency::getEfficiency(int deId, int columnId, int line, EffType type) const
+{
+  /// Gets the efficiency
+  /// \par deId Detection element ID
+  /// \par columnId Column ID
+  /// \par line line of the local board in the RPC
+  int idx = indexToInt(deId, columnId, line);
+  auto entryTot = mCounters.find(idx);
+  if (entryTot == mCounters.end()) {
+    std::cerr << "Warning: no efficiency found for deId: " << deId << "  column: " << columnId << "  line: " << line << "  type: " << typeToIdx(type) << "\n";
+    return -1.;
+  }
+  return static_cast<double>(entryTot->second[typeToIdx(type)]) / static_cast<double>(entryTot->second[3]);
+}
+
+//______________________________________________________________________________
+void ChamberEfficiency::addEntry(bool isEfficientBP, bool isEfficientNBP, int deId, int columnId, int line)
+{
+  /// Adds an entry
+  /// \par passed Number of efficient events
+  /// \par total Total number of events
+  /// \par deId Detection element ID
+  /// \par columnId Column ID
+  /// \par line line of the local board in the RPC
+  auto& entry = mCounters[indexToInt(deId, columnId, line)];
+  ++entry[3];
+  if (isEfficientBP) {
+    ++entry[0];
+  }
+  if (isEfficientNBP) {
+    ++entry[1];
+  }
+  if (isEfficientBP && isEfficientNBP) {
+    ++entry[2];
+  }
+}
+
+ChamberEfficiency createDefaultChamberEfficiency()
+{
+  /// Creates the default parameters
+  ChamberEfficiency effMap;
+  Mapping mapping;
+  uint32_t nevents = 10000;
+  for (int ide = 0; ide < Constants::sNDetectionElements; ++ide) {
+    for (int icol = mapping.getFirstColumn(ide); icol < 7; ++icol) {
+      for (int iline = mapping.getFirstBoardBP(icol, ide); iline <= mapping.getLastBoardBP(icol, ide); ++iline) {
+        for (uint32_t ievent = 0; ievent < nevents; ++ievent) {
+          effMap.addEntry(true, true, ide, icol, iline);
+          effMap.addEntry(true, true, ide, icol, iline);
+          effMap.addEntry(true, true, ide, icol, iline);
+        }
+      }
+    }
+  }
+
+  return std::move(effMap);
+}
+
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/CMakeLists.txt
+++ b/Detectors/MUON/MID/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_subdirectory(Base)
 add_subdirectory(Clustering)
+add_subdirectory(Simulation)
 add_subdirectory(TestingSimTools)
 add_subdirectory(Tracking)
-add_subdirectory(Simulation)

--- a/Detectors/MUON/MID/Simulation/CMakeLists.txt
+++ b/Detectors/MUON/MID/Simulation/CMakeLists.txt
@@ -3,6 +3,7 @@ set(MODULE_NAME "MIDSimulation")
 O2_SETUP(NAME ${MODULE_NAME})
 
 set(SRCS
+  src/ChamberEfficiencyResponse.cxx
   src/ChamberHV.cxx
   src/ChamberResponse.cxx
   src/ChamberResponseParams.cxx
@@ -14,6 +15,7 @@ set(SRCS
 )
 
 set(HEADERS
+  include/${MODULE_NAME}/ChamberEfficiencyResponse.h
   include/${MODULE_NAME}/ChamberHV.h
   include/${MODULE_NAME}/ChamberResponse.h
   include/${MODULE_NAME}/ChamberResponseParams.h

--- a/Detectors/MUON/MID/Simulation/CMakeLists.txt
+++ b/Detectors/MUON/MID/Simulation/CMakeLists.txt
@@ -4,6 +4,8 @@ O2_SETUP(NAME ${MODULE_NAME})
 
 set(SRCS
   src/ChamberHV.cxx
+  src/ChamberResponse.cxx
+  src/ChamberResponseParams.cxx
   src/Detector.cxx
   src/Geometry.cxx
   src/Hit.cxx
@@ -13,6 +15,8 @@ set(SRCS
 
 set(HEADERS
   include/${MODULE_NAME}/ChamberHV.h
+  include/${MODULE_NAME}/ChamberResponse.h
+  include/${MODULE_NAME}/ChamberResponseParams.h
   include/${MODULE_NAME}/Detector.h
   include/${MODULE_NAME}/Hit.h
   include/${MODULE_NAME}/Stepper.h

--- a/Detectors/MUON/MID/Simulation/CMakeLists.txt
+++ b/Detectors/MUON/MID/Simulation/CMakeLists.txt
@@ -3,6 +3,7 @@ set(MODULE_NAME "MIDSimulation")
 O2_SETUP(NAME ${MODULE_NAME})
 
 set(SRCS
+  src/ChamberHV.cxx
   src/Detector.cxx
   src/Geometry.cxx
   src/Hit.cxx
@@ -11,6 +12,7 @@ set(SRCS
 )
 
 set(HEADERS
+  include/${MODULE_NAME}/ChamberHV.h
   include/${MODULE_NAME}/Detector.h
   include/${MODULE_NAME}/Hit.h
   include/${MODULE_NAME}/Stepper.h

--- a/Detectors/MUON/MID/Simulation/include/MIDSimulation/ChamberEfficiencyResponse.h
+++ b/Detectors/MUON/MID/Simulation/include/MIDSimulation/ChamberEfficiencyResponse.h
@@ -1,0 +1,48 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDSimulation/ChamberEfficiencyResponse.h
+/// \brief  MID RPC effciency response
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   01 March 2019
+
+#ifndef O2_MID_CHAMBEREFFICIENCYRESPONSE_H
+#define O2_MID_CHAMBEREFFICIENCYRESPONSE_H
+
+#include <random>
+#include "MIDBase/ChamberEfficiency.h"
+
+namespace o2
+{
+namespace mid
+{
+class ChamberEfficiencyResponse
+{
+ public:
+  ChamberEfficiencyResponse(const ChamberEfficiency& efficiencyMap);
+  virtual ~ChamberEfficiencyResponse() = default;
+
+  bool isEfficient(int deId, int columnId, int line, bool& isEfficientBP, bool& isEfficientNBP);
+
+  /// Sets the seed
+  void setSeed(unsigned int seed) { mGenerator.seed(seed); }
+
+ private:
+  ChamberEfficiency mEfficiency;                  ///< Measured chamber efficiencies
+  std::default_random_engine mGenerator;          ///< Random numbers generator
+  std::uniform_real_distribution<double> mRandom; ///< Uniform distribution
+};
+
+ChamberEfficiencyResponse createDefaultChamberEfficiencyResponse();
+
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_CHAMBERRESPONSE_H */

--- a/Detectors/MUON/MID/Simulation/include/MIDSimulation/ChamberHV.h
+++ b/Detectors/MUON/MID/Simulation/include/MIDSimulation/ChamberHV.h
@@ -1,0 +1,43 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDSimulation/ChamberHV.h
+/// \brief  HV values for MID RPCs
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   30 April 2018
+#ifndef O2_MID_CHAMBERHV_H
+#define O2_MID_CHAMBERHV_H
+
+#include <array>
+#include "MIDBase/Constants.h"
+
+namespace o2
+{
+namespace mid
+{
+class ChamberHV
+{
+ public:
+  /// Get HV for detection element
+  double getHV(int deId) const { return mHV[deId]; }
+
+  /// sets the HV for detection element
+  void setHV(int deId, double hv) { mHV[deId] = hv; }
+
+ private:
+  std::array<double, Constants::sNDetectionElements> mHV; ///< High voltage values
+};
+
+ChamberHV createDefaultChamberHV();
+
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_CHAMBERHV_H */

--- a/Detectors/MUON/MID/Simulation/include/MIDSimulation/ChamberResponse.h
+++ b/Detectors/MUON/MID/Simulation/include/MIDSimulation/ChamberResponse.h
@@ -1,0 +1,55 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDSimulation/ChamberResponse.h
+/// \brief  MID RPC response
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   30 April 2018
+
+#ifndef O2_MID_CHAMBERRESPONSE_H
+#define O2_MID_CHAMBERRESPONSE_H
+
+#include "MIDSimulation/ChamberResponseParams.h"
+#include "MIDSimulation/ChamberHV.h"
+
+namespace o2
+{
+namespace mid
+{
+class ChamberResponse
+{
+ public:
+  ChamberResponse(const ChamberResponseParams& params, const ChamberHV& hv);
+  virtual ~ChamberResponse() = default;
+
+  inline bool isFired(double prob, double distance, int cathode, int deId, double theta = 0.) const
+  {
+    /// Check if the strip at a certain distance from the impact point is fired
+    /// given a probability prob.
+    return (prob < getFiredProbability(distance, cathode, deId, theta));
+  }
+  double getFiredProbability(double distance, int cathode, int deId, double theta = 0.) const;
+
+  double firedProbabilityFunction(double* var, double* par);
+
+  /// Gets the response parameters
+  ChamberResponseParams getResponseParams() const { return mParams; }
+
+ private:
+  ChamberResponseParams mParams; ///< Chamber response parameters
+  ChamberHV mHV;                 ///< HV values for chambers
+};
+
+ChamberResponse createDefaultChamberResponse();
+
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_CHAMBERRESPONSE_H */

--- a/Detectors/MUON/MID/Simulation/include/MIDSimulation/ChamberResponseParams.h
+++ b/Detectors/MUON/MID/Simulation/include/MIDSimulation/ChamberResponseParams.h
@@ -1,0 +1,52 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDSimulation/ChamberResponseParams.h
+/// \brief  Parameters for MID RPC response
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   26 April 2018
+#ifndef O2_MID_CHAMBERRESPONSEPARAMS_H
+#define O2_MID_CHAMBERRESPONSEPARAMS_H
+
+#include <array>
+
+namespace o2
+{
+namespace mid
+{
+class ChamberResponseParams
+{
+ public:
+  double getParA(double hv) const;
+  double getParB(int cathode, int deId) const;
+  double getParC(double hv) const;
+
+  /// Gets the parameters to compute A
+  const std::array<double, 2> getParametersA() const { return mParA; }
+
+  /// Gets the parameters to compute C
+  const std::array<double, 2> getParametersC() const { return mParC; }
+
+  void setParA(double a0, double a1);
+  void setParC(double c0, double c1);
+  void setParB(int cathode, int deId, double val);
+
+ private:
+  std::array<double, 2> mParA;   ///< Values to compute first parameter
+  std::array<double, 2> mParC;   ///< Values to compute third parameter
+  std::array<double, 144> mParB; ///< Array of second parameter
+};
+
+ChamberResponseParams createDefaultChamberResponseParams();
+
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_CHAMBERRESPONSEPARAMS_H */

--- a/Detectors/MUON/MID/Simulation/src/ChamberEfficiencyResponse.cxx
+++ b/Detectors/MUON/MID/Simulation/src/ChamberEfficiencyResponse.cxx
@@ -1,0 +1,67 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Simulation/src/ChamberEfficiencyResponse.cxx
+/// \brief  Implementation MID RPC efficiency response
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   01 March 2019
+
+#include "MIDSimulation/ChamberEfficiencyResponse.h"
+
+namespace o2
+{
+namespace mid
+{
+//______________________________________________________________________________
+ChamberEfficiencyResponse::ChamberEfficiencyResponse(const ChamberEfficiency& efficiencyMap) : mEfficiency(efficiencyMap)
+{
+  /// Constructor
+}
+
+//______________________________________________________________________________
+bool ChamberEfficiencyResponse::isEfficient(int deId, int columnId, int line, bool& isEfficientBP, bool& isEfficientNBP)
+{
+  /// \par deId Detection element ID
+  /// \par columnId Column ID
+  /// \par line line of the local board in the RPC
+  /// \par isEfficientBP The BP was efficient
+  /// \par isEfficientNBP The NBP was efficient
+  /// Returns true if the chamber is efficient
+
+  // P(B) : probability to fire bending plane
+  double effBP = mEfficiency.getEfficiency(deId, columnId, line, ChamberEfficiency::EffType::BendPlane);
+
+  // P(BN) : probability to fire bending and non-bending plane
+  double effBoth = mEfficiency.getEfficiency(deId, columnId, line, ChamberEfficiency::EffType::BothPlanes);
+
+  isEfficientBP = (mRandom(mGenerator) <= effBP);
+
+  // P(N) : probability to fire non-bending plane
+  double effNBP = 0.;
+  if (isEfficientBP) {
+    // P(N|B) = P(BN) / P(B)
+    effNBP = effBoth / effBP;
+  } else {
+    // P(N|!B) = ( P(N) - P(BN) ) / ( 1 - P(B) )
+    effNBP = (mEfficiency.getEfficiency(deId, columnId, line, ChamberEfficiency::EffType::NonBendPlane) - effBoth) / (1. - effBP);
+  }
+
+  isEfficientNBP = (mRandom(mGenerator) <= effNBP);
+
+  return (isEfficientBP || isEfficientNBP);
+}
+
+ChamberEfficiencyResponse createDefaultChamberEfficiencyResponse()
+{
+  return ChamberEfficiencyResponse(createDefaultChamberEfficiency());
+}
+
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/Simulation/src/ChamberHV.cxx
+++ b/Detectors/MUON/MID/Simulation/src/ChamberHV.cxx
@@ -1,0 +1,34 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Simulation/src/ChamberHV.cxx
+/// \brief  Implementation of the HV for MID RPCs
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   30 April 2018
+
+#include "MIDSimulation/ChamberHV.h"
+
+namespace o2
+{
+namespace mid
+{
+ChamberHV createDefaultChamberHV()
+{
+  /// Creates the default chamber voltages
+  ChamberHV hv;
+  for (int ide = 0; ide < Constants::sNDetectionElements; ++ide) {
+    hv.setHV(ide, 9800.);
+  }
+
+  return std::move(hv);
+}
+
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/Simulation/src/ChamberResponse.cxx
+++ b/Detectors/MUON/MID/Simulation/src/ChamberResponse.cxx
@@ -1,0 +1,91 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Simulation/src/ChamberResponse.cxx
+/// \brief  Implementation MID RPC response
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   30 April 2018
+
+/// This class implements the RPC spatial resolution.
+/// The original functional form is based on this work:
+/// R.~Arnaldi {\it et al.} [ALICE Collaboration],
+/// %``Spatial resolution of RPC in streamer mode,''
+/// Nucl.\ Instrum.\ Meth.\ A {\bf 490} (2002) 51.
+/// doi:10.1016/S0168-9002(02)00917-8
+/// The parameters were further tuned by Massimiliano Marchisone in his PhD thesis:
+/// http://www.theses.fr/2013CLF22406
+
+#include "MIDSimulation/ChamberResponse.h"
+
+#include <cmath>
+
+namespace o2
+{
+namespace mid
+{
+//______________________________________________________________________________
+ChamberResponse::ChamberResponse(const ChamberResponseParams& params, const ChamberHV& hv) : mParams(params), mHV(hv)
+{
+  /// Constructor
+}
+
+//______________________________________________________________________________
+double ChamberResponse::getFiredProbability(double distance, int cathode, int deId, double theta) const
+{
+  /// Get fired probability
+
+  // Need to convert the distance from cm to mm
+  double distMM = distance * 10.;
+  double parA = mParams.getParA(mHV.getHV(deId));
+  double parB = mParams.getParB(cathode, deId);
+  double parC = mParams.getParC(mHV.getHV(deId));
+  double costheta = std::cos(theta);
+  return (parC + parA / (parA + costheta * std::pow(distMM, parB))) / (1 + parC);
+}
+
+//______________________________________________________________________________
+double ChamberResponse::firedProbabilityFunction(double* var, double* par)
+{
+  /// Member function that can be used to tune the parameters
+  /// @param var Variables
+  /// @param par Parameters
+  /// The variables are:
+  /// var[0] -> distance from impact point (in cm)
+  /// The parameters are:
+  /// par[0] -> cathode
+  /// par[1] -> deId
+  /// par[2] -> impact angle (set to 0.)
+  /// par[3] -> parameter B
+  /// par[4] -> parameter A0
+  /// par[5] -> parameter A1
+  /// par[6] -> parameter C0
+  /// par[7] -> parameter C1
+
+  int cathode = (int)par[0];
+  int deId = (int)par[1];
+
+  mParams.setParB(cathode, deId, par[3]);
+  mParams.setParA(par[4], par[5]);
+  mParams.setParC(par[6], par[7]);
+
+  return getFiredProbability(var[0], cathode, deId, par[2]);
+}
+
+//______________________________________________________________________________
+ChamberResponse createDefaultChamberResponse()
+{
+  /// Returns the default chamber response
+  ChamberResponseParams params = createDefaultChamberResponseParams();
+  ChamberHV hv = createDefaultChamberHV();
+  return ChamberResponse(params, hv);
+}
+
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/Simulation/src/ChamberResponseParams.cxx
+++ b/Detectors/MUON/MID/Simulation/src/ChamberResponseParams.cxx
@@ -1,0 +1,256 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Simulation/src/ChamberResponseParams.cxx
+/// \brief  Implementation of the parameters for MID RPC response
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   26 April 2018
+
+/// This class implements the parameters for the parameterization of the RPC spatial resolution.
+/// The parameters were tuned by Massimiliano Marchisone in his PhD thesis:
+/// http://www.theses.fr/2013CLF22406
+/// See ChamberResponse for further details
+
+#include "MIDSimulation/ChamberResponseParams.h"
+
+namespace o2
+{
+namespace mid
+{
+
+//______________________________________________________________________________
+double ChamberResponseParams::getParA(double hv) const
+{
+  /// Gets first parameter
+  /// \par hv RPC HV in volts
+  return mParA[1] * hv + mParA[0];
+}
+
+//______________________________________________________________________________
+double ChamberResponseParams::getParC(double hv) const
+{
+  /// Get third parameter
+  /// \par hv RPC HV in volts
+  return mParC[1] * hv + mParC[0];
+}
+
+//______________________________________________________________________________
+double ChamberResponseParams::getParB(int cathode, int deId) const
+{
+  /// Gets the second parameter
+  /// \par cathode Cathode
+  /// \par deId Detection element ID
+  return mParB[72 * cathode + deId];
+}
+
+//______________________________________________________________________________
+void ChamberResponseParams::setParA(double a0, double a1)
+{
+  /// Sets parameter A
+  mParA[0] = a0;
+  mParA[1] = a1;
+}
+
+//______________________________________________________________________________
+void ChamberResponseParams::setParC(double c0, double c1)
+{
+  /// Sets parameter C
+  mParC[0] = c0;
+  mParC[1] = c1;
+}
+
+//______________________________________________________________________________
+void ChamberResponseParams::setParB(int cathode, int deId, double val)
+{
+  /// Sets parameter B
+  mParB[72 * cathode + deId] = val;
+}
+
+ChamberResponseParams createDefaultChamberResponseParams()
+{
+  /// Creates the default parameters
+  ChamberResponseParams params;
+  params.setParA(-52.70, 6.089 / 1000.);   // par1 in 1/V
+  params.setParC(-0.5e-3, 8.3e-4 / 1000.); // par1 in 1/V
+
+  // if (isStreamer) {
+  //   mParB.fill(2.966);
+  //   return;
+  // }
+
+  // BP
+  // MT11R
+  params.setParB(0, 0, 2.97);
+  params.setParB(0, 1, 2.47);
+  params.setParB(0, 2, 2.47);
+  params.setParB(0, 3, 1.97);
+  params.setParB(0, 4, 1.97);
+  params.setParB(0, 5, 2.47);
+  params.setParB(0, 6, 2.47);
+  params.setParB(0, 7, 2.47);
+  params.setParB(0, 8, 2.97);
+  // MT12R
+  params.setParB(0, 9, 2.97);
+  params.setParB(0, 10, 1.97);
+  params.setParB(0, 11, 1.97);
+  params.setParB(0, 12, 1.97);
+  params.setParB(0, 13, 2.22);
+  params.setParB(0, 14, 2.22);
+  params.setParB(0, 15, 1.97);
+  params.setParB(0, 16, 2.47);
+  params.setParB(0, 17, 2.97);
+  // MT21R
+  params.setParB(0, 18, 2.97);
+  params.setParB(0, 19, 1.97);
+  params.setParB(0, 20, 1.97);
+  params.setParB(0, 21, 1.97);
+  params.setParB(0, 22, 2.22);
+  params.setParB(0, 23, 2.22);
+  params.setParB(0, 24, 2.47);
+  params.setParB(0, 25, 2.47);
+  params.setParB(0, 26, 2.97);
+  // MT22R
+  params.setParB(0, 27, 2.97);
+  params.setParB(0, 28, 1.97);
+  params.setParB(0, 29, 1.97);
+  params.setParB(0, 30, 1.97);
+  params.setParB(0, 31, 1.97);
+  params.setParB(0, 32, 1.97);
+  params.setParB(0, 33, 2.97);
+  params.setParB(0, 34, 2.97);
+  params.setParB(0, 35, 2.97);
+  // MT11L
+  params.setParB(0, 36, 2.97);
+  params.setParB(0, 37, 1.97);
+  params.setParB(0, 38, 2.47);
+  params.setParB(0, 39, 1.97);
+  params.setParB(0, 40, 2.22);
+  params.setParB(0, 41, 1.97);
+  params.setParB(0, 42, 2.47);
+  params.setParB(0, 43, 2.47);
+  params.setParB(0, 44, 2.97);
+  // MT12L
+  params.setParB(0, 45, 2.97);
+  params.setParB(0, 46, 1.97);
+  params.setParB(0, 47, 2.47);
+  params.setParB(0, 48, 1.97);
+  params.setParB(0, 49, 1.97);
+  params.setParB(0, 50, 1.97);
+  params.setParB(0, 51, 2.47);
+  params.setParB(0, 52, 1.97);
+  params.setParB(0, 53, 2.97);
+  // MT21L
+  params.setParB(0, 54, 2.97);
+  params.setParB(0, 55, 1.97);
+  params.setParB(0, 56, 2.47);
+  params.setParB(0, 57, 1.97);
+  params.setParB(0, 58, 1.97);
+  params.setParB(0, 59, 2.22);
+  params.setParB(0, 60, 2.47);
+  params.setParB(0, 61, 2.47);
+  params.setParB(0, 62, 2.97);
+  // MT22L
+  params.setParB(0, 63, 2.97);
+  params.setParB(0, 64, 2.22);
+  params.setParB(0, 65, 2.47);
+  params.setParB(0, 66, 1.72);
+  params.setParB(0, 67, 1.97);
+  params.setParB(0, 68, 1.97);
+  params.setParB(0, 69, 1.97);
+  params.setParB(0, 70, 2.47);
+  params.setParB(0, 71, 2.97);
+
+  // NBP
+  // MT11R
+  params.setParB(1, 0, 2.97);
+  params.setParB(1, 1, 2.97);
+  params.setParB(1, 2, 1.97);
+  params.setParB(1, 3, 1.72);
+  params.setParB(1, 4, 1.97);
+  params.setParB(1, 5, 2.47);
+  params.setParB(1, 6, 2.47);
+  params.setParB(1, 7, 2.97);
+  params.setParB(1, 8, 2.97);
+  // MT12R
+  params.setParB(1, 9, 2.97);
+  params.setParB(1, 10, 2.97);
+  params.setParB(1, 11, 1.97);
+  params.setParB(1, 12, 1.97);
+  params.setParB(1, 13, 2.47);
+  params.setParB(1, 14, 1.97);
+  params.setParB(1, 15, 2.22);
+  params.setParB(1, 16, 2.97);
+  params.setParB(1, 17, 2.97);
+  // MT21R
+  params.setParB(1, 18, 2.97);
+  params.setParB(1, 19, 2.47);
+  params.setParB(1, 20, 1.97);
+  params.setParB(1, 21, 1.97);
+  params.setParB(1, 22, 1.97);
+  params.setParB(1, 23, 2.47);
+  params.setParB(1, 24, 2.47);
+  params.setParB(1, 25, 2.97);
+  params.setParB(1, 26, 2.97);
+  // MT22R
+  params.setParB(1, 27, 2.97);
+  params.setParB(1, 28, 1.97);
+  params.setParB(1, 29, 1.97);
+  params.setParB(1, 30, 1.97);
+  params.setParB(1, 31, 1.72);
+  params.setParB(1, 32, 1.97);
+  params.setParB(1, 33, 2.97);
+  params.setParB(1, 34, 2.97);
+  params.setParB(1, 35, 2.97);
+  // MT11L
+  params.setParB(1, 36, 2.97);
+  params.setParB(1, 37, 2.97);
+  params.setParB(1, 38, 2.47);
+  params.setParB(1, 39, 2.22);
+  params.setParB(1, 40, 1.97);
+  params.setParB(1, 41, 1.97);
+  params.setParB(1, 42, 2.47);
+  params.setParB(1, 43, 2.97);
+  params.setParB(1, 44, 2.97);
+  // MT12L
+  params.setParB(1, 45, 2.97);
+  params.setParB(1, 46, 2.97);
+  params.setParB(1, 47, 2.97);
+  params.setParB(1, 48, 1.97);
+  params.setParB(1, 49, 1.97);
+  params.setParB(1, 50, 1.97);
+  params.setParB(1, 51, 2.97);
+  params.setParB(1, 52, 2.47);
+  params.setParB(1, 53, 2.97);
+  // MT21L
+  params.setParB(1, 54, 2.97);
+  params.setParB(1, 55, 2.97);
+  params.setParB(1, 56, 2.47);
+  params.setParB(1, 57, 2.22);
+  params.setParB(1, 58, 1.97);
+  params.setParB(1, 59, 2.22);
+  params.setParB(1, 60, 2.47);
+  params.setParB(1, 61, 2.97);
+  params.setParB(1, 62, 2.97);
+  // MT22L
+  params.setParB(1, 63, 2.47);
+  params.setParB(1, 64, 2.97);
+  params.setParB(1, 65, 2.47);
+  params.setParB(1, 66, 1.97);
+  params.setParB(1, 67, 2.22);
+  params.setParB(1, 68, 1.72);
+  params.setParB(1, 69, 1.97);
+  params.setParB(1, 70, 2.97);
+  params.setParB(1, 71, 2.97);
+
+  return std::move(params);
+}
+
+} // namespace mid
+} // namespace o2


### PR DESCRIPTION
This is the first of a series of commits to provide the digitization for MID
The commit consists of three parts:
- A class that stores the HV values (needed to determine the probability to fired a strip at a distance d from the impact point)
- The class that uses the HV values and other parameters to determine the probability to fire a strip at a distance d from the impact point)
- The chamber efficiency

The commits are related, but they are indeed atomic and valid on their own: please do not squash this PR