### PR TITLE
Fix modernize-use-equals-delete

### DIFF
--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/DetMatrixCache.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/DetMatrixCache.h
@@ -148,7 +148,7 @@ class DetMatrixCacheIndirect : private DetMatrixCache
 
  protected:
   // before calling fillMatrixCache, detector implementation should set the size of the matrix cache
-  void setSize(int s) = delete;
+  void setSize(int s) = delete; // NOLINT(modernize-use-equals-delete)
   void setSize(int size, int sizeIndirect);
 
   void setMatrixT2L(const Mat3D& matrix, int sensID) { mT2L.setMatrix(matrix, getCacheHelper(sensID)); }

--- a/EventVisualisation/Base/include/EventVisualisationBase/ConfigurationManager.h
+++ b/EventVisualisation/Base/include/EventVisualisationBase/ConfigurationManager.h
@@ -42,9 +42,9 @@ private:
   /// Default destructor
   ~ConfigurationManager() = default;
   /// Deleted copy constructor
-  ConfigurationManager(ConfigurationManager const&) = delete;
+  ConfigurationManager(ConfigurationManager const&) = delete; // NOLINT(modernize-use-equals-delete)
   /// Deleted assignment operator
-  void operator=(ConfigurationManager const&) = delete;
+  void operator=(ConfigurationManager const&) = delete; // NOLINT(modernize-use-equals-delete)
 };
   
 #endif

--- a/EventVisualisation/Base/include/EventVisualisationBase/EventManager.h
+++ b/EventVisualisation/Base/include/EventVisualisationBase/EventManager.h
@@ -61,9 +61,9 @@ class EventManager : public TEveEventManager, public TQObject
     /// Default destructor
     ~EventManager() final;
     /// Deleted copy constructor
-    EventManager(EventManager const&) = delete;
+    EventManager(EventManager const&) = delete; // NOLINT(modernize-use-equals-delete)
     /// Deleted assignemt operator
-    void operator=(EventManager const&) = delete;
+    void operator=(EventManager const&) = delete; // NOLINT(modernize-use-equals-delete)
 };
 
 }

--- a/EventVisualisation/Base/include/EventVisualisationBase/GeometryManager.h
+++ b/EventVisualisation/Base/include/EventVisualisationBase/GeometryManager.h
@@ -46,9 +46,9 @@ class GeometryManager
     /// Default destructor
     ~GeometryManager() = default;
     /// Deleted copy constructor
-    GeometryManager(GeometryManager const&) = delete;
+    GeometryManager(GeometryManager const&) = delete; // NOLINT(modernize-use-equals-delete)
     /// Deleted assignment operator
-    void operator=(GeometryManager const&)  = delete;
+    void operator=(GeometryManager const&)  = delete; // NOLINT(modernize-use-equals-delete)
 };
   
 }

--- a/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/AliHLTHOMERData.h
+++ b/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/AliHLTHOMERData.h
@@ -210,6 +210,10 @@ const homer_uint8 kHOMERBigEndianByteOrder    = 2;
 class AliHLTHOMERBlockDescriptor
     {
     public:
+      /** copy constructor prohibited */
+      AliHLTHOMERBlockDescriptor(const AliHLTHOMERBlockDescriptor&) = delete;
+      /** assignment operator prohibited */
+      AliHLTHOMERBlockDescriptor& operator=(const AliHLTHOMERBlockDescriptor&) = delete;
 
 	static unsigned GetHOMERBlockDescriptorSize()
 		{
@@ -377,10 +381,6 @@ class AliHLTHOMERBlockDescriptor
       void* fHeader; //! transient
 	
     private:
-      /** copy constructor prohibited */
-      AliHLTHOMERBlockDescriptor(const AliHLTHOMERBlockDescriptor&);
-      /** assignment operator prohibited */
-      AliHLTHOMERBlockDescriptor& operator=(const AliHLTHOMERBlockDescriptor&);
     };
 
 // the HOMERBlockDescriptor is used in the code

--- a/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/Component.h
+++ b/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/Component.h
@@ -78,6 +78,10 @@ public:
   Component();
   /// destructor
   ~Component();
+  // copy constructor prohibited
+  Component(const Component&) = delete;
+  // assignment operator prohibited
+  Component& operator=(const Component&) = delete;
 
   /// get description of options
   static bpo::options_description GetOptionsDescription();
@@ -130,11 +134,6 @@ public:
 protected:
 
 private:
-  // copy constructor prohibited
-  Component(const Component&);
-  // assignment operator prohibited
-  Component& operator=(const Component&);
-
   /// output buffer to receive the data produced by component
   std::vector<uint8_t> mOutputBuffer;
 

--- a/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/EventSampler.h
+++ b/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/EventSampler.h
@@ -48,6 +48,10 @@ public:
   EventSampler(int verbosity=0);
   /// destructor
   ~EventSampler() override;
+  // copy constructor prohibited
+  EventSampler(const EventSampler&) = delete;
+  // assignment operator prohibited
+  EventSampler& operator=(const EventSampler&) = delete;
 
   /// get description of options
   static bpo::options_description GetOptionsDescription();
@@ -84,11 +88,6 @@ public:
 protected:
 
 private:
-  // copy constructor prohibited
-  EventSampler(const EventSampler&);
-  // assignment operator prohibited
-  EventSampler& operator=(const EventSampler&);
-
   int mEventPeriod;          // event rate in us
   int mInitialDelay;         // initial delay in ms before sending first event
   int mNEvents;              // number of generated events

--- a/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/HOMERFactory.h
+++ b/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/HOMERFactory.h
@@ -84,6 +84,10 @@ class HOMERFactory {
   HOMERFactory();
   /** destructor */
   virtual ~HOMERFactory();
+  /** copy constructor prohibited */
+  HOMERFactory(const HOMERFactory&) = delete;
+  /** assignment operator prohibited */
+  HOMERFactory& operator=(const HOMERFactory&) = delete;
 
   /**
    * Open a homer reader working on a TCP port.
@@ -140,11 +144,6 @@ class HOMERFactory {
  protected:
 
  private:
-  /** copy constructor prohibited */
-  HOMERFactory(const HOMERFactory&);
-  /** assignment operator prohibited */
-  HOMERFactory& operator=(const HOMERFactory&);
-
   /**
    * Load the HOMER library.
    */

--- a/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/MessageFormat.h
+++ b/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/MessageFormat.h
@@ -92,6 +92,10 @@ public:
   MessageFormat();
   /// destructor
   ~MessageFormat();
+  // copy constructor prohibited
+  MessageFormat(const MessageFormat&) = delete;
+  // assignment operator prohibited
+  MessageFormat& operator=(const MessageFormat&) = delete;
 
   using DataHeader = o2::header::DataHeader;
   using HeartbeatFrameEnvelope = o2::header::HeartbeatFrameEnvelope;
@@ -186,11 +190,6 @@ public:
 protected:
 
 private:
-  // copy constructor prohibited
-  MessageFormat(const MessageFormat&);
-  // assignment operator prohibited
-  MessageFormat& operator=(const MessageFormat&);
-
   // single point to provide a target pointer, either by using a
   // provided callback function or in the internal buffer, which has
   // to be allocated completely in advance in order to ensure validity

--- a/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/WrapperDevice.h
+++ b/Utilities/aliceHLTwrapper/include/aliceHLTwrapper/WrapperDevice.h
@@ -52,6 +52,10 @@ public:
   WrapperDevice(int verbosity = 0);
   /// destructor
   ~WrapperDevice() override;
+  // copy constructor prohibited
+  WrapperDevice(const WrapperDevice&) = delete;
+  // assignment operator prohibited
+  WrapperDevice& operator=(const WrapperDevice&) = delete;
 
   /// get description of options
   static bpo::options_description GetOptionsDescription();
@@ -79,11 +83,6 @@ public:
 protected:
 
 private:
-  // copy constructor prohibited
-  WrapperDevice(const WrapperDevice&);
-  // assignment operator prohibited
-  WrapperDevice& operator=(const WrapperDevice&);
-
   /// create a new message with data buffer of specified size
   unsigned char* createMessageBuffer(unsigned size);
 


### PR DESCRIPTION
I've decided that it would be right not to make deleted special member functions of singletons public for consistency and marked them with `// NOLINT(modernize-use-equals-delete)`. The same is for `setSize`.