### PR TITLE
flpQualification: use shmem for readout transport

### DIFF
--- a/Framework/TestWorkflows/README
+++ b/Framework/TestWorkflows/README
@@ -28,6 +28,6 @@ Relevant options:
 Readout proxy channel configuration can be done by passing the option as it
 follows:
 
-   --readout-proxy '--channel-config "name=readout-proxy,type=pair,method=connect,address=ipc:///tmp/readout-pipe-0,rateLogging=1"'
+   --readout-proxy '--channel-config "name=readout-proxy,type=pair,method=connect,transport=shmem,address=ipc:///tmp/readout-pipe-0,rateLogging=1"'
 
 These must match appropriately the configuration of `readout.exe`.

--- a/Framework/TestWorkflows/src/flpQualification.cxx
+++ b/Framework/TestWorkflows/src/flpQualification.cxx
@@ -88,7 +88,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
   DataProcessorSpec readoutProxy = specifyExternalFairMQDeviceProxy(
     "readout-proxy",
     Outputs{ { "ITS", "RAWDATA" } },
-    "type=pair,method=connect,address=ipc:///tmp/readout-pipe-0,rateLogging=1",
+    "type=pair,method=connect,address=ipc:///tmp/readout-pipe-0,rateLogging=1,transport=shmem",
     readoutAdapter({ "ITS", "RAWDATA" }));
 
   // This is an example of how we can parallelize by subSpec.


### PR DESCRIPTION
This can be changed on the command line as documented.