### PR TITLE
Filter out optimization flags from the global build flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,10 @@ MARK_AS_ADVANCED(
     CMAKE_Fortran_FLAGS_COVERAGE
     CMAKE_LINK_FLAGS_COVERAGE)
 
+# filter out optimization flags from the global build flags, this is a feature of the build system
+# the flags will be set by cmake according to corresponding build type flags
+string(REGEX REPLACE "[-]O[0-9]" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+string(REGEX REPLACE "[-]O[0-9]" "" CMAKE_C_FLAGS ${CMAKE_C_FLAGS})
 
 #Check the compiler and set the compile and link flags
 IF (NOT CMAKE_BUILD_TYPE)


### PR DESCRIPTION
This avoids building with -O2 optimization in build type DEBUG, this is a feature of the
build system, the configuration sets -O2 globally to make sure that also packages not using
cmake or cmake with incorrect build type configuration are built with optimization.

The flags will be set by cmake according to corresponding build type flags, so there is no
practical change for O2 build except that the DEBUG build is as one expects.