### PR TITLE
MC digits for MID

### DIFF
--- a/DataFormats/Detectors/MUON/MID/CMakeLists.txt
+++ b/DataFormats/Detectors/MUON/MID/CMakeLists.txt
@@ -3,16 +3,18 @@ set(MODULE_NAME "DataFormatsMID")
 O2_SETUP(NAME ${MODULE_NAME})
 
 set(SRCS
+  src/ColumnData.cxx
   src/Track.cxx
 )
 
-set(NO_DICT_HEADERS
+set(HEADERS
   include/${MODULE_NAME}/Cluster2D.h
   include/${MODULE_NAME}/Cluster3D.h
   include/${MODULE_NAME}/ColumnData.h
   include/${MODULE_NAME}/Track.h
 )
 
+set(LINKDEF src/DataFormatsMIDLinkDef.h)
 set(LIBRARY_NAME ${MODULE_NAME})
 set(BUCKET_NAME data_format_mid_bucket)
 

--- a/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/ColumnData.h
+++ b/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/ColumnData.h
@@ -16,9 +16,8 @@
 #ifndef O2_MID_COLUMNDATA_H
 #define O2_MID_COLUMNDATA_H
 
-#include <boost/serialization/access.hpp>
-#include <boost/serialization/array.hpp>
 #include <cstdint>
+#include <iostream>
 #include <array>
 
 namespace o2
@@ -27,42 +26,37 @@ namespace mid
 {
 /// Column data structure for MID
 struct ColumnData {
-  uint8_t deId;                     ///< Index of the detection element
-  uint8_t columnId;                 ///< Column in DE
-  std::array<uint16_t, 5> patterns; ///< patterns
+  uint8_t deId = 0;                 ///< Index of the detection element
+  uint8_t columnId = 0;             ///< Column in DE
+  std::array<uint16_t, 5> patterns; ///< Strip patterns
 
-  /// Sets the pattern
-  void setPattern(uint16_t pattern, int cathode, int line) { patterns[(cathode == 1) ? 4 : line] = pattern; }
-  /// Gets the pattern
-  uint16_t getPattern(int cathode, int line) { return patterns[(cathode == 1) ? 4 : line]; }
-  void addStrip(int strip, int cathode, int line) { patterns[(cathode == 1) ? 4 : line] |= (1 << strip); }
-  /// Sets the non-bending plane pattern
-  void setNonBendPattern(uint16_t pattern) { patterns[4] = pattern; }
-  /// Gets the non-bending plane pattern
-  uint16_t getNonBendPattern() { return patterns[4]; }
   /// Sets the bending plane pattern
   void setBendPattern(uint16_t pattern, int line) { patterns[line] = pattern; }
   /// Gets the bending plane pattern
-  uint16_t getBendPattern(int line) { return patterns[line]; }
+  uint16_t getBendPattern(int line) const { return patterns[line]; }
 
-  /// Checks if strip is fired
-  bool isStripFired(int istrip, int cathode, int line) { return patterns[(cathode == 1) ? 4 : line] & (1 << istrip); }
+  /// Sets the non-bending plane pattern
+  void setNonBendPattern(uint16_t pattern) { patterns[4] = pattern; }
+  /// Gets the non-bending plane pattern
+  uint16_t getNonBendPattern() const { return patterns[4]; }
+
+  void setPattern(uint16_t pattern, int cathode, int line);
+  uint16_t getPattern(int cathode, int line) const;
+
+  void addStrip(int strip, int cathode, int line);
+
   /// Checks if strip is fired in the non-bending plane
-  bool isNBPStripFired(int istrip) { return isStripFired(istrip, 1, 0); }
+  bool isNBPStripFired(int istrip) const { return patterns[4] & (1 << istrip); }
   /// Checks if strip is fired in the bending plane
-  bool isBPStripFired(int istrip, uint16_t line) { return isStripFired(istrip, 0, line); }
+  bool isBPStripFired(int istrip, int line) const { return patterns[line] & (1 << istrip); }
 
-  friend class boost::serialization::access;
-
-  /// Serializes the struct
-  template <class Archive>
-  void serialize(Archive& ar, const unsigned int version)
-  {
-    ar& deId;
-    ar& columnId;
-    ar& patterns;
-  }
+  bool isStripFired(int istrip, int cathode, int line) const;
 };
+
+ColumnData operator|(const ColumnData& col1, const ColumnData& col2);
+ColumnData& operator|=(ColumnData& col1, const ColumnData& col2);
+std::ostream& operator<<(std::ostream& os, const ColumnData& col);
+
 } // namespace mid
 } // namespace o2
 

--- a/DataFormats/Detectors/MUON/MID/src/ColumnData.cxx
+++ b/DataFormats/Detectors/MUON/MID/src/ColumnData.cxx
@@ -1,0 +1,86 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/src/ColumnData.cxx
+/// \brief  Strip pattern (aka digits)
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   19 February 2018
+
+#include "DataFormatsMID/ColumnData.h"
+
+#include <bitset>
+
+namespace o2
+{
+namespace mid
+{
+
+void ColumnData::setPattern(uint16_t pattern, int cathode, int line)
+{
+  /// Sets the pattern
+  if (cathode == 0)
+    setBendPattern(pattern, line);
+  else
+    setNonBendPattern(pattern);
+}
+
+uint16_t ColumnData::getPattern(int cathode, int line) const
+{
+  /// Gets the pattern
+  return (cathode == 0) ? getBendPattern(line) : getNonBendPattern();
+}
+
+void ColumnData::addStrip(int strip, int cathode, int line)
+{
+  /// Adds a strip to the pattern
+  int ipat = (cathode == 1) ? 4 : line;
+  patterns[ipat] |= (1 << strip);
+}
+
+bool ColumnData::isStripFired(int istrip, int cathode, int line) const
+{
+  /// Checks if the strip is fired
+  return (cathode == 0) ? isBPStripFired(istrip, line) : isNBPStripFired(istrip);
+}
+
+ColumnData& operator|=(ColumnData& col1, const ColumnData& col2)
+{
+  /// Merge operator for ColumnData
+  if (col1.deId != col2.deId || col1.columnId != col2.columnId) {
+    throw std::runtime_error("Cannot merge ColumnData");
+  }
+  for (size_t ipat = 0; ipat < col1.patterns.size(); ++ipat) {
+    col1.patterns[ipat] |= col2.patterns[ipat];
+  }
+  return col1;
+}
+
+ColumnData operator|(const ColumnData& col1, const ColumnData& col2)
+{
+  /// Merge operator for ColumnData
+  ColumnData out = col1;
+  out |= col2;
+  return out;
+}
+
+std::ostream& operator<<(std::ostream& os, const ColumnData& col)
+{
+  /// Output streamer for ColumnData
+  os << "deId: " << static_cast<int>(col.deId) << "  col: " << static_cast<int>(col.columnId);
+  os << "  NBP: " << std::bitset<16>(col.getNonBendPattern());
+  os << "  BP: ";
+  for (int iline = 0; iline < 4; ++iline) {
+    os << " " << std::bitset<16>(col.getBendPattern(iline));
+  }
+  return os;
+}
+
+} // namespace mid
+} // namespace o2

--- a/DataFormats/Detectors/MUON/MID/src/DataFormatsMIDLinkDef.h
+++ b/DataFormats/Detectors/MUON/MID/src/DataFormatsMIDLinkDef.h
@@ -1,0 +1,23 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifdef __CLING__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ struct o2::mid::Cluster2D + ;
+#pragma link C++ struct o2::mid::Cluster3D + ;
+#pragma link C++ struct o2::mid::ColumnData + ;
+#pragma link C++ class std::vector < o2::mid::ColumnData > +;
+#pragma link C++ struct o2::mid::Track + ;
+
+#endif

--- a/Detectors/MUON/MID/Clustering/test/testClusterizer.cxx
+++ b/Detectors/MUON/MID/Clustering/test/testClusterizer.cxx
@@ -247,8 +247,7 @@ std::vector<ColumnData> getFiredStrips(float xPos, float yPos, int deId, Mapping
         columnStruct->deId = deId;
         columnStruct->columnId = neigh.column;
       }
-      int line = (cathode == 1) ? 4 : neigh.line;
-      columnStruct->patterns[line] |= (1 << neigh.strip);
+      columnStruct->addStrip(neigh.strip, cathode, neigh.line);
     }
   }
   return columns;

--- a/Detectors/MUON/MID/Simulation/CMakeLists.txt
+++ b/Detectors/MUON/MID/Simulation/CMakeLists.txt
@@ -19,6 +19,7 @@ set(HEADERS
   include/${MODULE_NAME}/ChamberHV.h
   include/${MODULE_NAME}/ChamberResponse.h
   include/${MODULE_NAME}/ChamberResponseParams.h
+  include/${MODULE_NAME}/ColumnDataMC.h
   include/${MODULE_NAME}/Detector.h
   include/${MODULE_NAME}/Hit.h
   include/${MODULE_NAME}/Stepper.h

--- a/Detectors/MUON/MID/Simulation/include/MIDSimulation/ColumnDataMC.h
+++ b/Detectors/MUON/MID/Simulation/include/MIDSimulation/ColumnDataMC.h
@@ -1,0 +1,35 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDSimulation/ColumnDataMC.h
+/// \brief  Strip pattern (aka digits) for simulations
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   05 March 2019
+
+#ifndef O2_MID_COLUMNDATAMC_H
+#define O2_MID_COLUMNDATAMC_H
+
+#include "CommonDataFormat/TimeStamp.h"
+#include "DataFormatsMID/ColumnData.h"
+
+namespace o2
+{
+namespace mid
+{
+/// Column data structure for MID simulations
+class ColumnDataMC : public ColumnData, public o2::dataformats::TimeStamp<int>
+{
+  ClassDefNV(ColumnDataMC, 1);
+};
+
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_COLUMNDATAMC_H */

--- a/Detectors/MUON/MID/Simulation/src/MIDSimulationLinkDef.h
+++ b/Detectors/MUON/MID/Simulation/src/MIDSimulationLinkDef.h
@@ -21,5 +21,7 @@
 #pragma link C++ class o2::Base::DetImpl < o2::mid::Detector > +;
 #pragma link C++ class o2::mid::Hit + ;
 #pragma link C++ class std::vector < o2::mid::Hit > +;
+#pragma link C++ class o2::mid::ColumnDataMC + ;
+#pragma link C++ class std::vector < o2::mid::ColumnDataMC > +;
 
 #endif


### PR DESCRIPTION
This is the second of a series of commit to introduces the MID digitization. In this commit I introduce the data format.
For MID, the MC digits and real digits coincide. They need to be streamed to a root file in the simulation, while we do not necessarily need to be dependent on ROOT during reconstruction.
Actually, we want the real digits format to be as simple as possible, independent of the serialization method.
In order to do so, the real digits (ColumnData) were simplified: they are now just a plain struct with some setters/getters. Any serialization-specific method was stripped off.
On the other hand, we introduced the MC digits (ColumnDataMC), which derive from both ColumnData and dataformats::TimeStamp. They implement a dictionary and a ClassDef, so that they can be streamed to file and they derive from TimeStamp since it seems to be the standard for MC digits.
The commits are related to each others, but they are atomic, so they should not be squashed.