### PR TITLE
Extend the external generator (extgen) concept to any FairGenerator

### DIFF
--- a/Generators/share/external/extgen.C
+++ b/Generators/share/external/extgen.C
@@ -1,34 +1,30 @@
 /** 
-    It is mandatory that the function returns a TGenerator* 
+    It is mandatory that the function returns a FairGenerator* 
     whereas there are no restrictions on the function name
     and the arguments to the function prototype.
 
-    TGenerator *extgen(double energy = 2760.);
+    FairGenerator *extgen(Int_t aPDG = 211.);
     
-    It is mandatory to define the units used by the
-    concerned generator to allow for the proper
-    conversion to the units used by the simulation.
-    The above is done by defining the following
-    variable mandatory global variables 
-
-    double momentumUnit; // [GeV/c]
-    double energyUnit;   // [GeV/c]
-    double positionUnit; // [cm]
-    double timeUnit;     // [s]
-
-    and assign the proper values, either initialising them
-    or withing the function to be called
 **/
 
-double momentumUnit = 1.;
-double energyUnit = 1.;
-double positionUnit = 1.;
-double timeUnit = 1.;
-
-TGenerator*
-  extgen()
+class MyGenerator : public FairGenerator
 {
-  std::cout << "This is a template function for an external generator" << std::endl;
-  auto gen = new TGenerator;
+ public:
+  MyGenerator(Int_t aPDG) : FairGenerator("MyGenerator"), mPDG(aPDG){};
+  Bool_t ReadEvent(FairPrimaryGenerator* primGen) override
+  {
+    primGen->AddTrack(mPDG, 0.5, 0.5, 0., 0., 0., 0.);
+    return kTRUE;
+  };
+
+ private:
+  Int_t mPDG;
+};
+
+FairGenerator*
+  extgen(Int_t aPDG = 211)
+{
+  std::cout << "This is a template function for an custom generator" << std::endl;
+  auto gen = new MyGenerator(aPDG);
   return gen;
 }

--- a/Generators/share/external/hijing.C
+++ b/Generators/share/external/hijing.C
@@ -4,16 +4,12 @@
 
 /// \author R+Preghenella - October 2018
 
-double momentumUnit = 1.;        // [GeV/c]
-double energyUnit = 1.;          // [GeV/c]
-double positionUnit = 0.1;       // [cm]
-double timeUnit = 3.3356410e-12; // [s]
-
 R__LOAD_LIBRARY(libTHijing)
 
-TGenerator*
+FairGenerator*
   hijing(double energy = 5020., double bMin = 0., double bMax = 20.)
 {
+  // instance and configure Hijing
   auto hij = new AliGenHijing(-1);
   hij->SetEnergyCMS(energy);
   hij->SetImpactParameterRange(bMin, bMax);
@@ -28,5 +24,13 @@ TGenerator*
   hij->SetSelectAll(0);
   hij->SetPtHardMin(2.3);
   hij->Init();
-  return hij->GetMC();
+
+  // instance and configure TGenerator interface
+  auto tgen = new o2::eventgen::GeneratorTGenerator();
+  tgen->setMomentumUnit(1.);        // [GeV/c]
+  tgen->setEnergyUnit(1.);          // [GeV/c]
+  tgen->setPositionUnit(0.1);       // [cm]
+  tgen->setTimeUnit(3.3356410e-12); // [s]
+  tgen->setTGenerator(hij);
+  return tgen;
 }

--- a/Generators/share/external/pythia6.C
+++ b/Generators/share/external/pythia6.C
@@ -4,23 +4,27 @@
 
 /// \author R+Preghenella - October 2018
 
-double momentumUnit = 1.;        // [GeV/c]
-double energyUnit = 1.;          // [GeV/c]
-double positionUnit = 0.1;       // [cm]
-double timeUnit = 3.3356410e-12; // [s]
-
 R__LOAD_LIBRARY(libpythia6)
 
 void configure(TPythia6* py6, const char* params);
 
-TGenerator*
+FairGenerator*
   pythia6(double energy = 14000., const char* params = nullptr)
 {
+  // instance and configure Pythia6
   auto py6 = TPythia6::Instance();
   if (params)
     configure(py6, params);
   py6->Initialize("CMS", "p", "p", energy);
-  return py6;
+
+  // instance and configure TGenerator interface
+  auto tgen = new o2::eventgen::GeneratorTGenerator();
+  tgen->setMomentumUnit(1.);        // [GeV/c]
+  tgen->setEnergyUnit(1.);          // [GeV/c]
+  tgen->setPositionUnit(0.1);       // [cm]
+  tgen->setTimeUnit(3.3356410e-12); // [s]
+  tgen->setTGenerator(py6);
+  return tgen;
 }
 
 void configure(TPythia6* py6, const char* params)

--- a/Generators/share/external/tgenerator.C
+++ b/Generators/share/external/tgenerator.C
@@ -1,0 +1,19 @@
+// template macro to configure a generic TGenerator interface
+
+/// \author R+Preghenella - March 2019
+
+FairGenerator*
+  tgenerator()
+{
+  // instance and configure an external TGenerator
+  auto gen = new TGenerator;
+
+  // instance and configure TGenerator interface
+  auto tgen = new o2::eventgen::GeneratorTGenerator();
+  tgen->setMomentumUnit(1.);        // [GeV/c]
+  tgen->setEnergyUnit(1.);          // [GeV/c]
+  tgen->setPositionUnit(0.1);       // [cm]
+  tgen->setTimeUnit(3.3356410e-12); // [s]
+  tgen->setTGenerator(gen);
+  return tgen;
+}

--- a/Generators/src/GeneratorFactory.cxx
+++ b/Generators/src/GeneratorFactory.cxx
@@ -18,7 +18,6 @@
 #include <SimConfig/SimConfig.h>
 #include <Generators/GeneratorFromFile.h>
 #include <Generators/Pythia8Generator.h>
-#include <Generators/GeneratorTGenerator.h>
 #include "TROOT.h"
 #include "TSystem.h"
 #include "TGlobal.h"
@@ -138,8 +137,7 @@ void GeneratorFactory::setPrimaryGenerator(o2::conf::SimConfig const& conf, Fair
     py8Gen->SetParameters("ParticleDecays:limitTau0 on");
     primGen->AddGenerator(py8Gen);
   } else if (genconfig.compare("extgen") == 0) {
-    // external generator via TGenerator interface
-    auto tgen = new o2::eventgen::GeneratorTGenerator();
+    // external generator via configuration macro
     auto extgen_filename = conf.getExtGeneratorFileName();
     auto extgen_func = conf.getExtGeneratorFuncName();
     if (extgen_func.empty()) {
@@ -154,47 +152,21 @@ void GeneratorFactory::setPrimaryGenerator(o2::conf::SimConfig const& conf, Fair
       LOG(FATAL) << "Cannot find " << extgen_filename << FairLogger::endl;
       return;
     }
-    /** setup convertion units **/
-    if (gROOT->GetGlobal("momentumUnit")) {
-      auto ptr = (double*)gROOT->GetGlobal("momentumUnit")->GetAddress();
-      tgen->setMomentumUnit(*ptr);
-    } else {
-      LOG(FATAL) << "Mandatory global variable 'momentumUnit' not defined";
-    }
-    if (gROOT->GetGlobal("energyUnit")) {
-      auto ptr = (double*)gROOT->GetGlobal("energyUnit")->GetAddress();
-      tgen->setEnergyUnit(*ptr);
-    } else {
-      LOG(FATAL) << "Mandatory global variable 'energyUnit' not defined";
-    }
-    if (gROOT->GetGlobal("positionUnit")) {
-      auto ptr = (double*)gROOT->GetGlobal("positionUnit")->GetAddress();
-      tgen->setPositionUnit(*ptr);
-    } else {
-      LOG(FATAL) << "Mandatory global variable 'positionUnit' not defined";
-    }
-    if (gROOT->GetGlobal("timeUnit")) {
-      auto ptr = (double*)gROOT->GetGlobal("timeUnit")->GetAddress();
-      tgen->setMomentumUnit(*ptr);
-    } else {
-      LOG(FATAL) << "Mandatory global variable 'timeUnit' not defined";
-    }
-    /** retrieve TGenerator **/
+    /** retrieve FairGenerator **/
     auto extgen_gfunc = extgen_func.substr(0, extgen_func.find_first_of('('));
     if (!gROOT->GetGlobalFunction(extgen_gfunc.c_str())) {
       LOG(FATAL) << "Global function '"
                  << extgen_gfunc
                  << "' not defined";
     }
-    if (strcmp(gROOT->GetGlobalFunction(extgen_gfunc.c_str())->GetReturnTypeName(), "TGenerator*")) {
+    if (strcmp(gROOT->GetGlobalFunction(extgen_gfunc.c_str())->GetReturnTypeName(), "FairGenerator*")) {
       LOG(FATAL) << "Global function '"
                  << extgen_gfunc
-                 << "' does not return a 'TGenerator*' type";
+                 << "' does not return a 'FairGenerator*' type";
     }
-    gROOT->ProcessLine(Form("TGenerator *__extgen = dynamic_cast<TGenerator *>(%s);", extgen_func.c_str()));
-    auto extgen_ptr = (TGenerator**)gROOT->GetGlobal("__extgen")->GetAddress();
-    tgen->setTGenerator(*extgen_ptr);
-    primGen->AddGenerator(tgen);
+    gROOT->ProcessLine(Form("FairGenerator *__extgen = dynamic_cast<FairGenerator *>(%s);", extgen_func.c_str()));
+    auto extgen_ptr = (FairGenerator**)gROOT->GetGlobal("__extgen")->GetAddress();
+    primGen->AddGenerator(*extgen_ptr);
   } else if (genconfig.compare("toftest") == 0) { // 1 muon per sector and per module
     LOG(INFO) << "Init tof test generator -> 1 muon per sector and per module";
     for (int i = 0; i < 18; i++) {


### PR DESCRIPTION
Modifies the behaviour of o2sim with the external generator option -g extgen.
It now expects that the external configuration macro defined via --extGenFile returns a FairGenerator* instead of a TGenerator* as it was before.
This allows for a more generic handling of customised external generators.

The TGenerator interface functionality is preserved, as everything can be defined in the configuration macro. Please see for example

share/external/tgenerator.C
share/external/pythia6.C

This change simplifies significantly the code and provides the user with more flexibility.
The user can define its own generator class within the configuration macro. Please see for example

share/external/exgen.C