### PR TITLE
Fix: real IR of the InteractionSampler was twice of the declared one

### DIFF
--- a/Steer/include/Steer/InteractionSampler.h
+++ b/Steer/include/Steer/InteractionSampler.h
@@ -62,7 +62,7 @@ class InteractionSampler
   float mIntRate = -1.;           ///< total interaction rate in Hz
   float mBCTimeRMS = 0.2;         ///< BC time spread in NANOSECONDS
   float mMuBC = -1.;              ///< interaction probability per BC
-  float mProbNoInteraction = 1.;  ///< probability of BC w/o interaction
+  float mProbInteraction = 1.;    ///< probability of non-0 interactions at per BC
   float mMuBCZTRed = 0;           ///< reduced mu for fast zero-truncated Poisson derivation
 
   o2::BunchFilling mBCFilling;  ///< patter of active BCs

--- a/Steer/test/testInteractionSampler.cxx
+++ b/Steer/test/testInteractionSampler.cxx
@@ -59,6 +59,14 @@ BOOST_AUTO_TEST_CASE(InteractionSampler)
     t = rec.timeNS;
   }
 
+  // make sure the IR corresponds to declared one
+  records.reserve((int)sampler1.getInteractionRate());
+  sampler1.generateCollisionTimes(records);
+  double dt = (records.back().timeNS - records.front().timeNS) * 1.e-9;
+  printf("\nGenerated %d collisions with time span %.3fs at IR=%e\n",
+         (int)records.size(), dt, sampler1.getInteractionRate());
+  BOOST_CHECK(std::abs(dt - 1.) < 0.1);
+
   // reconfigure w/o modifying BC filling but setting per bunch
   // mu (large -> lot of in-bunch pile-up)
   printf("\nResetting/testing sampler with same bunch filling but high mu\n");


### PR DESCRIPTION
Due to the bug, only half of the non-interacting bunches was skipped, leading to ~2 times higher int.rate than expected.
A test added to intercept such behaviour.
@sawenzel: can this be merged quickly, I need it for tests with another branch. 