### PR TITLE
Update on TRD Hits (O2-453)

### DIFF
--- a/Detectors/TRD/simulation/include/TRDSimulation/Detector.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Detector.h
@@ -52,15 +52,10 @@ class Detector : public o2::Base::DetImpl<Detector>
 {
  public:
   Detector(Bool_t active = true);
-
   ~Detector() override;
-
   void InitializeO2Detector() override;
-
   bool ProcessHits(FairVolume* v = nullptr) override;
-
   void Register() override;
-
   std::vector<HitType>* getHits(int iColl) const
   {
     if (iColl == 0) {
@@ -68,13 +63,11 @@ class Detector : public o2::Base::DetImpl<Detector>
     }
     return nullptr;
   }
-
+  void FinishEvent() override;
   void Reset() override;
   void EndOfEvent() override;
-
   void createMaterials();
   void ConstructGeometry() override;
-
   /// Add alignable top volumes
   void addAlignableVolumes() const override;
 
@@ -87,7 +80,7 @@ class Detector : public o2::Base::DetImpl<Detector>
 
   // addHit
   template <typename T>
-  void addHit(T x, T y, T z, T time, T energy, int trackId, int detId);
+  void addHit(T x, T y, T z, T tof, int charge, int trackId, int detId);
 
   // Create TR hits
   void createTRhit(int);
@@ -111,9 +104,9 @@ class Detector : public o2::Base::DetImpl<Detector>
 };
 
 template <typename T>
-void Detector::addHit(T x, T y, T z, T time, T energy, int trackId, int detId)
+void Detector::addHit(T x, T y, T z, T tof, int charge, int trackId, int detId)
 {
-  mHits->emplace_back(x, y, z, time, energy, trackId, detId);
+  mHits->emplace_back(x, y, z, tof, charge, trackId, detId);
 }
 
 } // namespace trd

--- a/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
@@ -38,12 +38,9 @@ class Digitizer
   int mEventID = 0;
   int mSrcID = 0;
 
-  float mWion;   //  Ionization potential
   bool mSDigits; // true: convert signals to summable digits, false by default
 
   std::vector<o2::trd::HitType> mHitContainer; // The container of hits in a given detector
-
-  void setWion(float w) { mWion = w; } // Set the Ionization potential
 
   bool getHitContainer(const int, const std::vector<o2::trd::HitType>&, std::vector<o2::trd::HitType>&); // True if there are hits in the detector
   // Digitization chaing methods

--- a/Detectors/TRD/simulation/src/Detector.cxx
+++ b/Detectors/TRD/simulation/src/Detector.cxx
@@ -170,7 +170,7 @@ bool Detector::ProcessHits(FairVolume* v)
   // or store hits of tracks that are entering or exiting
   if (totalChargeDep || trkStat) {
     fMC->TrackPosition(xp, yp, zp);
-    float tof = fMC->TrackTime() * 1e6; // The time of flight in micro-seconds
+    tof = tof * 1e6; // The time of flight in micro-seconds
     const int trackID = stack->GetCurrentTrackNumber();
     addHit(xp, yp, zp, tof, totalChargeDep, trackID, det);
     stack->addHit(GetDetId());

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -25,15 +25,6 @@ Digitizer::Digitizer()
   mGeom = new TRDGeometry();
   mSDigits = false;
 
-  // Get the Ionization energy
-  if (TRDCommonParam::Instance()->IsXenon()) {
-    setWion(23.53); // Ionization energy XeCO2 (85/15)
-  } else if (TRDCommonParam::Instance()->IsArgon()) {
-    setWion(27.21); // Ionization energy ArCO2 (82/18)
-  } else {
-    LOG(FATAL) << "Wrong gas mixture";
-    // add hard exit here!
-  }
 }
 
 Digitizer::~Digitizer() = default;
@@ -190,7 +181,7 @@ bool Digitizer::convertHits(const int det, const std::vector<o2::trd::HitType>& 
     pos[2] = hit.GetZ();
 
     const float eDep = hit.GetEnergyLoss();
-    const int qTotal = (int)eDep / mWion;
+    const int qTotal = (int)eDep; // Small kind of hack, this will be fixed later
 
     gGeoManager->SetCurrentPoint(pos);
     gGeoManager->FindNode();

--- a/Detectors/TRD/simulation/src/TRDSimulationLinkDef.h
+++ b/Detectors/TRD/simulation/src/TRDSimulationLinkDef.h
@@ -17,5 +17,7 @@
 #pragma link C++ class o2::trd::Detector+;
 #pragma link C++ class o2::Base::DetImpl<o2::trd::Detector>+;
 #pragma link C++ class o2::trd::HitType+;
+#pragma link C++ class o2::trd::TRsim+;
+#pragma link C++ class o2::trd::Digitizer+;
 
 #endif


### PR DESCRIPTION
Several short improvements at the level of hit creation (O2-453):

- Update TRD ProcessHits to the same level of AliRoot by keeping track references for the future.
- Hit vector is now ordered by detector number before going into the digitizer.
- Store charge instead of energy deposits (need some work on the future to keep the HitType with the right names).
- Removed Energy to Charge conversion at the Digitizer.
- Included TRsim at Link definitions.