### PR TITLE
DPL GUI: do not calculate scale at every iteration

### DIFF
--- a/Framework/DebugGUI/src/imgui_extras.cpp
+++ b/Framework/DebugGUI/src/imgui_extras.cpp
@@ -47,7 +47,7 @@ static float binner(BinFunction binFunction,
                     size_t data_idx,
                     size_t values_count,
                     float binStart, float binEnd,
-                    size_t domain_min, size_t domain_max,
+                    size_t domain_min, size_t domain_max, float scale,
                     float (*getterY)(const void* data, int idx),
                     size_t (*getterX)(const void* data, int idx),
                     size_t& cacheXIdx,
@@ -66,7 +66,6 @@ static float binner(BinFunction binFunction,
     default:
       value = 0;
   }
-  float scale = 1.f / (domain_max - domain_min);
   // Accumulate the matching datapoints.
   while (cacheXIdx < values_count) {
     size_t bin = getterX(datas[data_idx], cacheXIdx);
@@ -209,6 +208,7 @@ static void PlotMultiEx(
   std::vector<float> hoveredData(num_datas, 0);
 
   int domain_delta = domain_max - domain_min;
+  float domain_scale = 1.f / (domain_max - domain_min);
   int res_w = ImMin((int)graph_size.x, domain_delta) + ((plot_type == ImGuiPlotType_Lines) ? -1 : 0);
   int item_count = values_count + ((plot_type == ImGuiPlotType_Lines) ? -1 : 0);
 
@@ -253,7 +253,7 @@ static void PlotMultiEx(
     auto [first_valid_index, vx0] = findFirstValidIndexAndValue(datas[data_idx]);
     size_t cacheXIdx = first_valid_index;
     float v0 = getterY(datas[data_idx], (first_valid_index + values_offset) % values_count);
-    float t0 = ImSaturate((vx0 - domain_min) / (domain_max - domain_min));
+    float t0 = ImSaturate((vx0 - domain_min) * domain_scale);
     ImVec2 tp0 = ImVec2(t0, 1.0f - ImSaturate((v0 - scale_min) / (scale_max - scale_min))); // Point in the normalized space of our target rectangle
 
     const ImU32 col_base = colors[data_idx];
@@ -288,7 +288,7 @@ static void PlotMultiEx(
                            data_idx,
                            values_count,
                            binStart, binEnd,
-                           domain_min, domain_max,
+                           domain_min, domain_max, domain_scale,
                            getterY,
                            getterX,
                            cacheXIdx,


### PR DESCRIPTION
Speeds up a bit the rendering when many metrics are involved.