### PR TITLE
Fix O2-521

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -84,6 +84,7 @@ set(SRCS
     ${GUI_SOURCES}
     test/TestClasses.cxx
     src/Variant.cxx
+    src/MessageContext.cxx
    )
 
 set(HEADERS

--- a/Framework/Core/include/Framework/MessageContext.h
+++ b/Framework/Core/include/Framework/MessageContext.h
@@ -12,12 +12,15 @@
 
 #include "Framework/ContextRegistry.h"
 #include "Framework/FairMQDeviceProxy.h"
+#include "Framework/TypeTraits.h"
 
+#include <fairmq/FairMQMessage.h>
 #include <fairmq/FairMQParts.h>
 
 #include <vector>
 #include <cassert>
 #include <string>
+#include <type_traits>
 
 class FairMQDevice;
 
@@ -27,23 +30,105 @@ namespace framework
 {
 
 class MessageContext {
-public:
- MessageContext(FairMQDeviceProxy proxy)
-   : mProxy{ proxy }
- {
- }
+ public:
+  MessageContext(FairMQDeviceProxy proxy)
+    : mProxy{ proxy }
+  {
+  }
 
- struct MessageRef {
-   FairMQParts parts;
-   std::string channel;
+  // thhis is the virtual interface for context objects
+  class ContextObject
+  {
+   public:
+    ContextObject() = default;
+    ContextObject(FairMQMessagePtr&& headerMsg, FairMQMessagePtr&& payloadMsg, const std::string& bindingChannel)
+      : parts{}, channel{ bindingChannel }
+    {
+      parts.AddPart(std::move(headerMsg));
+      parts.AddPart(std::move(payloadMsg));
+    }
+    virtual ~ContextObject() = default;
+
+    // TODO: we keep this public for the moment to keep the current interface
+    // the send-handler loops over all objects and can acces the message parts
+    // directly, needs to be changed when the context is generalized, then the
+    // information needs to be stored in the derived class
+    FairMQParts parts;
+    std::string channel;
   };
-  using Messages = std::vector<MessageRef>;
 
-  void addPart(FairMQParts &&parts, const std::string &channel) {
-    assert(parts.Size() == 2);
-    mMessages.push_back(std::move(MessageRef{std::move(parts), channel}));
-    assert(parts.Size() == 0);
-    assert(mMessages.back().parts.Size() == 2);
+  /// TrivialObject handles a message object
+  class TrivialObject : public ContextObject
+  {
+   public:
+    /// default contructor forbidden, object always has to control message instances
+    TrivialObject() = delete;
+    /// constructor consuming the header and payload messages for a given channel by move
+    template <typename ContextType>
+    TrivialObject(ContextType*, FairMQMessagePtr&& headerMsg, FairMQMessagePtr&& payloadMsg, const std::string& bindingChannel)
+      : ContextObject(std::forward<FairMQMessagePtr>(headerMsg), std::forward<FairMQMessagePtr>(payloadMsg), bindingChannel)
+    {
+    }
+    /// constructor taking header message by move and creating the paypload message
+    template <typename ContextType, typename... Args>
+    TrivialObject(ContextType* context, FairMQMessagePtr&& headerMsg, const std::string& bindingChannel, int index, Args... args)
+      : ContextObject(std::forward<FairMQMessagePtr>(headerMsg), context->createMessage(bindingChannel, index, std::forward<Args>(args)...), bindingChannel)
+    {
+    }
+    ~TrivialObject() override = default;
+
+    auto* data()
+    {
+      assert(parts.Size() == 2);
+      return parts[1].GetData();
+    }
+  };
+
+  // SpanObject creates a trivial binary object for an array of elements of
+  // type T and holds a span over the elements
+  template <typename T>
+  class SpanObject : public ContextObject
+  {
+   public:
+    static_assert(is_messageable<T>::value == true, "unconsistent type");
+    using value_type = gsl::span<T>;
+    /// default constructor forbidden, object alwasy has to control messages
+    SpanObject() = delete;
+    /// constructor taking header message by move and creating the payload message for the span
+    template <typename ContextType>
+    SpanObject(ContextType* context, FairMQMessagePtr&& headerMsg, const std::string& bindingChannel, int index, size_t nElements)
+    {
+      // create the span object for the memory of the payload message
+      // TODO: we probably also want to check consistency of the header message, i.e. payloadSize member
+      auto payloadMsg = context->createMessage(bindingChannel, index, nElements * sizeof(T));
+      mValue = value_type(reinterpret_cast<T*>(payloadMsg->GetData()), nElements);
+      parts.AddPart(std::move(headerMsg));
+      parts.AddPart(std::move(payloadMsg));
+      channel = bindingChannel;
+    }
+    ~SpanObject() override = default;
+
+    operator value_type&()
+    {
+      return mValue;
+    }
+
+    value_type& get()
+    {
+      return mValue;
+    }
+
+   private:
+    value_type mValue;
+  };
+  using Messages = std::vector<std::unique_ptr<ContextObject>>;
+
+  template <typename T, typename... Args>
+  auto& add(Args&&... args)
+  {
+    static_assert(std::is_base_of<ContextObject, T>::value == true, "type must inherit ContextObject interface");
+    mMessages.push_back(std::move(std::make_unique<T>(this, std::forward<Args>(args)...)));
+    return *dynamic_cast<T*>(mMessages.back().get());
   }
 
   Messages::iterator begin()
@@ -68,7 +153,7 @@ public:
   {
     // Verify that everything has been sent on clear.
     for (auto &m : mMessages) {
-      assert(m.parts.Size() == 0);
+      assert(m->parts.Size() == 0);
     }
     mMessages.clear();
   }
@@ -77,6 +162,13 @@ public:
   {
     return mProxy;
   }
+
+  /// call the proxy to create a message of the specified size
+  /// we don't implement in the header to avoid including the FairMQDevice header here
+  /// that's why the different versions need to be implemented as individual functions
+  // FIXME: can that be const?
+  FairMQMessagePtr createMessage(const std::string& channel, int index, size_t size);
+  FairMQMessagePtr createMessage(const std::string& channel, int index, void* data, size_t size, fairmq_free_fn* ffn, void* hint);
 
  private:
   FairMQDeviceProxy mProxy;

--- a/Framework/Core/src/DataAllocator.cxx
+++ b/Framework/Core/src/DataAllocator.cxx
@@ -64,17 +64,8 @@ DataAllocator::newChunk(const Output& spec, size_t size) {
                                                            o2::header::gSerializationMethodNone, //
                                                            size                                  //
                                                            );
-  FairMQMessagePtr payloadMessage = context->proxy().getDevice()->NewMessageFor(channel, 0, size);
-  auto dataPtr = payloadMessage->GetData();
-  auto dataSize = payloadMessage->GetSize();
-
-  FairMQParts parts;
-  parts.AddPart(std::move(headerMessage));
-  parts.AddPart(std::move(payloadMessage));
-  assert(parts.Size() == 2);
-  context->addPart(std::move(parts), channel);
-  assert(parts.Size() == 0);
-  return DataChunk{reinterpret_cast<char*>(dataPtr), dataSize};
+  auto& co = context->add<MessageContext::TrivialObject>(std::move(headerMessage), channel, 0, size);
+  return DataChunk{ reinterpret_cast<char*>(co.data()), size };
 }
 
 DataChunk
@@ -88,18 +79,10 @@ DataAllocator::adoptChunk(const Output& spec, char *buffer, size_t size, fairmq_
                                                            size                                  //
                                                            );
 
-  FairMQParts parts;
-
   // FIXME: how do we want to use subchannels? time based parallelism?
   auto context = mContextRegistry->get<MessageContext>();
-  FairMQMessagePtr payloadMessage = context->proxy().getDevice()->NewMessageFor(channel, 0, buffer, size, freefn, hint);
-  auto dataPtr = payloadMessage->GetData();
-  LOG(DEBUG) << "New payload at " << payloadMessage->GetData();
-  auto dataSize = payloadMessage->GetSize();
-  parts.AddPart(std::move(headerMessage));
-  parts.AddPart(std::move(payloadMessage));
-  context->addPart(std::move(parts), channel);
-  return DataChunk{reinterpret_cast<char *>(dataPtr), dataSize};
+  auto& co = context->add<MessageContext::TrivialObject>(std::move(headerMessage), channel, 0, buffer, size, freefn, hint);
+  return DataChunk{ reinterpret_cast<char*>(co.data()), size };
 }
 
 FairMQMessagePtr DataAllocator::headerMessageFromOutput(Output const& spec,                     //
@@ -129,16 +112,13 @@ void DataAllocator::addPartToContext(FairMQMessagePtr&& payloadMessage, const Ou
   // RootObjectContext, see DataProcessor::doSend
   auto headerMessage = headerMessageFromOutput(spec, channel, serializationMethod, 0);
 
-  FairMQParts parts;
-
   // FIXME: this is kind of ugly, we know that we can change the content of the
   // header message because we have just created it, but the API declares it const
   const DataHeader* cdh = o2::header::get<DataHeader*>(headerMessage->GetData());
   DataHeader* dh = const_cast<DataHeader*>(cdh);
   dh->payloadSize = payloadMessage->GetSize();
-  parts.AddPart(std::move(headerMessage));
-  parts.AddPart(std::move(payloadMessage));
-  mContextRegistry->get<MessageContext>()->addPart(std::move(parts), channel);
+  auto context = mContextRegistry->get<MessageContext>();
+  context->add<MessageContext::TrivialObject>(std::move(headerMessage), std::move(payloadMessage), channel);
 }
 
 void DataAllocator::adopt(const Output& spec, TObject* ptr)

--- a/Framework/Core/src/DataProcessor.cxx
+++ b/Framework/Core/src/DataProcessor.cxx
@@ -33,12 +33,12 @@ namespace framework
 
 void DataProcessor::doSend(FairMQDevice &device, MessageContext &context) {
   for (auto &message : context) {
-    //     monitoringService.send({ message.parts.Size(), "outputs/total" });
-    assert(message.parts.Size() == 2);
-    FairMQParts parts = std::move(message.parts);
-    assert(message.parts.Size() == 0);
+    //     monitoringService.send({ message->parts.Size(), "outputs/total" });
+    assert(message->parts.Size() == 2);
+    FairMQParts parts = std::move(message->parts);
+    assert(message->parts.Size() == 0);
     assert(parts.Size() == 2);
-    device.Send(parts, message.channel, 0);
+    device.Send(parts, message->channel, 0);
     assert(parts.Size() == 2);
   }
 }

--- a/Framework/Core/src/MessageContext.cxx
+++ b/Framework/Core/src/MessageContext.cxx
@@ -1,0 +1,30 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/MessageContext.h"
+#include "fairmq/FairMQDevice.h"
+
+namespace o2
+{
+namespace framework
+{
+
+FairMQMessagePtr MessageContext::createMessage(const std::string& channel, int index, size_t size)
+{
+  return proxy().getDevice()->NewMessageFor(channel, 0, size);
+}
+
+FairMQMessagePtr MessageContext::createMessage(const std::string& channel, int index, void* data, size_t size, fairmq_free_fn* ffn, void* hint)
+{
+  return proxy().getDevice()->NewMessageFor(channel, 0, data, size, ffn, hint);
+}
+
+} // namespace framework
+} // namespace o2


### PR DESCRIPTION
@ktf, happy to receive your comments.

When I was about to add yet another context I figured out that the registry was not intended for that, so I made it more generic and type safe. In the next step I had to make a context which allows to control different types of `span<T>`, so I ended up making also `MessageContext`  more generic. Apart from cleanup, this should do the job now.

We can consider to move the functionality from the different contexts to specialized context objects in the future if you find the concept appropriate. But that's not urgent, the generic MessageContext would allow this with not to much extension.