### PR TITLE
Add default return value to suppress compiler warning

### DIFF
--- a/Detectors/MUON/MID/Base/src/ChamberEfficiency.cxx
+++ b/Detectors/MUON/MID/Base/src/ChamberEfficiency.cxx
@@ -36,6 +36,9 @@ int ChamberEfficiency::typeToIdx(EffType type) const
     case EffType::BothPlanes:
       return 2;
   }
+
+  // This will never be reached, but it is needed to avoid compiler warnings
+  return -1;
 }
 
 //______________________________________________________________________________


### PR DESCRIPTION
This is a private method used to convert the enum class to int.
All cases are treated, so the correct value is always returned.
However, the absence of a default causes a compiler warning: I am adding a dummy return value whose only aim is to suppress the warning