### PR TITLE
Set O2 compile flags in CMakeList and remove check_compiler macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,6 @@ include(O2Dependencies)
 include(FairMacros)
 include(WriteConfigFile)
 include(CTest)
-include(CheckCompiler)
 #include(CheckFortran)
 
 # check if we have a simulation environment
@@ -80,13 +79,24 @@ IF (NOT CMAKE_BUILD_TYPE)
   Message(STATUS "Set BuildType DEBUG")
   set(CMAKE_BUILD_TYPE Debug)
 ENDIF (NOT CMAKE_BUILD_TYPE)
-Check_Compiler()
 
+IF(ENABLE_CASSERT) #For the CI, we want to have <cassert> assertions enabled
+    set(CMAKE_CXX_FLAGS_RELEASE "-O2")
+    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g")
+ELSE()
+    set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
+    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -DNDEBUG")
+ENDIF()
+set(CMAKE_C_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
+set(CMAKE_Fortran_FLAGS_RELEASE "-O2")
+set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+set(CMAKE_Fortran_FLAGS_RELWITHDEBINFO "-O2 -g")
 # make sure Debug build not optimized (does not seem to work without CACHE + FORCE)
 set(CMAKE_CXX_FLAGS_DEBUG "-g -O0" CACHE STRING "Debug mode build flags" FORCE)
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}" CACHE STRING "Debug mode build flags" FORCE)
 set(CMAKE_Fortran_FLAGS_DEBUG "-g -O0" CACHE STRING "Debug mode build flags" FORCE)
 
+message(STATUS "Using build type: ${CMAKE_BUILD_TYPE} - CXXFLAGS: ${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE}}")
 
 set(LIBRARY_OUTPUT_PATH "${CMAKE_BINARY_DIR}/lib")
 set(EXECUTABLE_OUTPUT_PATH "${CMAKE_BINARY_DIR}/bin")

--- a/Framework/Core/src/FrameworkGUIDeviceInspector.cxx
+++ b/Framework/Core/src/FrameworkGUIDeviceInspector.cxx
@@ -120,7 +120,8 @@ void displayDeviceInspector(DeviceSpec const& spec, DeviceInfo const& info, Devi
 #else
     setenv("O2DPLDEBUG", "xterm -hold -e gdb attach $O2DEBUGGEDPID", 0);
 #endif
-    system(getenv("O2DPLDEBUG"));
+    int retVal = system(getenv("O2DPLDEBUG"));
+    (void)retVal;
   }
 
   deviceInfoTable(info, metrics);

--- a/Framework/Core/src/RCombinedDS.cxx
+++ b/Framework/Core/src/RCombinedDS.cxx
@@ -32,6 +32,7 @@ double loop on the entries of the two RDataSources.
 
 #define protected public
 #include "Framework/RCombinedDS.h"
+#include "Framework/CompilerBuiltins.h"
 
 #if __has_include(<ROOT/RDF/Utils.hxx>)
 #include <ROOT/RDF/Utils.hxx>
@@ -214,6 +215,7 @@ std::vector<void*> RCombinedDS::GetColumnReadersImpl(std::string_view colName, c
     return fRight->GetColumnReadersImpl(colName, info);
   }
   assert(false);
+  O2_BUILTIN_UNREACHABLE();
 }
 
 void RCombinedDS::Initialise()


### PR DESCRIPTION
As discussed last week, sets the O2 compile flags in our cmake instead of pulling in fairroot @pzhristov  @sawenzel @dberzano  @matthiasrichter 

@ktf : You seem to use assert(false) to silence "no return value" compiler warnings in several places, which does not work if we set the -DNDEBUG compile flag. However, I think it is correct to set this in debug mode, so I added some dummy returns.