### PR TITLE
DPL: make ContextRegistry dynamic

### DIFF
--- a/Framework/Core/include/Framework/ArrowContext.h
+++ b/Framework/Core/include/Framework/ArrowContext.h
@@ -31,11 +31,6 @@ namespace framework
 class ArrowContext
 {
  public:
-  ArrowContext(FairMQDeviceProxy proxy)
-    : mProxy{ proxy }
-  {
-  }
-
   struct MessageRef {
     std::unique_ptr<FairMQMessage> header;
     std::unique_ptr<TableBuilder> payload;
@@ -88,23 +83,9 @@ class ArrowContext
  private:
   FairMQDeviceProxy mProxy;
   Messages mMessages;
+
+  REGISTER_CONTEXT(ArrowContext);
 };
-
-/// Helper to get the context from the registry.
-template <>
-inline ArrowContext*
-  ContextRegistry::get<ArrowContext>()
-{
-  return reinterpret_cast<ArrowContext*>(mContextes[3]);
-}
-
-/// Helper to set the context from the registry.
-template <>
-inline void
-  ContextRegistry::set<ArrowContext>(ArrowContext* context)
-{
-  mContextes[3] = context;
-}
 
 } // namespace framework
 } // namespace o2

--- a/Framework/Core/include/Framework/DataProcessingDevice.h
+++ b/Framework/Core/include/Framework/DataProcessingDevice.h
@@ -61,11 +61,6 @@ class DataProcessingDevice : public FairMQDevice
   std::unique_ptr<ConfigParamRegistry> mConfigRegistry;
   ServiceRegistry& mServiceRegistry;
   TimingInfo mTimingInfo;
-  MessageContext mFairMQContext;
-  RootObjectContext mRootContext;
-  StringContext mStringContext;
-  ArrowContext mDataFrameContext;
-  RawBufferContext mRawBufferContext;
   ContextRegistry mContextRegistry;
   DataAllocator mAllocator;
   DataRelayer mRelayer;

--- a/Framework/Core/include/Framework/FairMQDeviceProxy.h
+++ b/Framework/Core/include/Framework/FairMQDeviceProxy.h
@@ -26,14 +26,16 @@ namespace framework
 class FairMQDeviceProxy
 {
 public:
-  FairMQDeviceProxy(FairMQDevice *device)
-  : mDevice{device}
-  {}
+ void setDevice(FairMQDevice* device)
+ {
+   mDevice = device;
+ }
 
-  /// To be used in DataAllocator.cxx to avoid reimplenting any device
-  /// API.
-  FairMQDevice *getDevice() {
-    return mDevice;
+ /// To be used in DataAllocator.cxx to avoid reimplenting any device
+ /// API.
+ FairMQDevice* getDevice()
+ {
+   return mDevice;
   }
 
   /// Looks like what we really need in the headers is just the transport.
@@ -42,7 +44,7 @@ public:
   std::unique_ptr<FairMQMessage> createMessage() const;
   std::unique_ptr<FairMQMessage> createMessage(const size_t size) const;
 private:
-  FairMQDevice* mDevice;
+ FairMQDevice* mDevice = nullptr;
 };
 
 } // namespace framework

--- a/Framework/Core/include/Framework/MessageContext.h
+++ b/Framework/Core/include/Framework/MessageContext.h
@@ -28,11 +28,6 @@ namespace framework
 
 class MessageContext {
 public:
- MessageContext(FairMQDeviceProxy proxy)
-   : mProxy{ proxy }
- {
- }
-
  struct MessageRef {
    FairMQParts parts;
    std::string channel;
@@ -81,23 +76,9 @@ public:
  private:
   FairMQDeviceProxy mProxy;
   Messages mMessages;
+
+  REGISTER_CONTEXT(MessageContext);
 };
-
-/// Helper to get the context from the registry.
-template <>
-inline MessageContext*
-  ContextRegistry::get<MessageContext>()
-{
-  return reinterpret_cast<MessageContext*>(mContextes[0]);
-}
-
-/// Helper to set the context from the registry.
-template <>
-inline void
-  ContextRegistry::set<MessageContext>(MessageContext* context)
-{
-  mContextes[0] = context;
-}
 
 } // namespace framework
 } // namespace o2

--- a/Framework/Core/include/Framework/RawBufferContext.h
+++ b/Framework/Core/include/Framework/RawBufferContext.h
@@ -37,11 +37,6 @@ namespace framework
 class RawBufferContext
 {
  public:
-  RawBufferContext(FairMQDeviceProxy proxy)
-    : mProxy{ proxy }
-  {
-  }
-
   struct MessageRef {
     std::unique_ptr<FairMQMessage> header;
     char* payload;
@@ -99,23 +94,8 @@ class RawBufferContext
  private:
   FairMQDeviceProxy mProxy;
   Messages mMessages;
+  REGISTER_CONTEXT(RawBufferContext);
 };
-
-/// Helper to get the context from the registry.
-template <>
-inline RawBufferContext*
-  ContextRegistry::get<RawBufferContext>()
-{
-  return reinterpret_cast<RawBufferContext*>(mContextes[4]);
-}
-
-/// Helper to set the context from the registry.
-template <>
-inline void
-  ContextRegistry::set<RawBufferContext>(RawBufferContext* context)
-{
-  mContextes[4] = context;
-}
 
 } // namespace framework
 } // namespace o2

--- a/Framework/Core/include/Framework/RootObjectContext.h
+++ b/Framework/Core/include/Framework/RootObjectContext.h
@@ -29,11 +29,6 @@ namespace framework
 /// computation.
 class RootObjectContext {
 public:
- RootObjectContext(FairMQDeviceProxy proxy)
-   : mProxy{ proxy }
- {
- }
-
  struct MessageRef {
    std::unique_ptr<FairMQMessage> header;
    std::unique_ptr<TObject> payload;
@@ -86,23 +81,8 @@ public:
  private:
   FairMQDeviceProxy mProxy;
   Messages mMessages;
+  REGISTER_CONTEXT(RootObjectContext);
 };
-
-/// Helper to get the context from the registry.
-template <>
-inline RootObjectContext*
-  ContextRegistry::get<RootObjectContext>()
-{
-  return reinterpret_cast<RootObjectContext*>(mContextes[1]);
-}
-
-/// Helper to set the context from the registry.
-template <>
-inline void
-  ContextRegistry::set<RootObjectContext>(RootObjectContext* context)
-{
-  mContextes[1] = context;
-}
 
 } // namespace framework
 } // namespace o2

--- a/Framework/Core/include/Framework/StringContext.h
+++ b/Framework/Core/include/Framework/StringContext.h
@@ -30,11 +30,6 @@ namespace framework
 class StringContext
 {
  public:
-  StringContext(FairMQDeviceProxy proxy)
-    : mProxy{ proxy }
-  {
-  }
-
   struct MessageRef {
     std::unique_ptr<FairMQMessage> header;
     std::unique_ptr<std::string> payload;
@@ -87,23 +82,8 @@ class StringContext
  private:
   FairMQDeviceProxy mProxy;
   Messages mMessages;
+  REGISTER_CONTEXT(StringContext);
 };
-
-/// Helper to get the context from the registry.
-template <>
-inline StringContext*
-  ContextRegistry::get<StringContext>()
-{
-  return reinterpret_cast<StringContext*>(mContextes[2]);
-}
-
-/// Helper to set the context from the registry.
-template <>
-inline void
-  ContextRegistry::set<StringContext>(StringContext* context)
-{
-  mContextes[2] = context;
-}
 
 } // namespace framework
 } // namespace o2

--- a/Framework/Core/src/FairMQDeviceProxy.cxx
+++ b/Framework/Core/src/FairMQDeviceProxy.cxx
@@ -17,6 +17,7 @@ namespace o2
 {
 namespace framework
 {
+
 FairMQTransportFactory* FairMQDeviceProxy::getTransport()
 {
   return mDevice->Transport();


### PR DESCRIPTION
Contextes can con register themselves at initialization time,
without need to have an hardcoded ID. Besides removing a bunch
of code duplication, this also allows having a central place
which knows about all the available contextes and paves the way
to optimized executables where only some of the backends are
included. E.g. it could be used to load ROOT serialisation only
on those workflows which actually need it.