### PR TITLE
Making the ContextRegistry a dynamic, type-safe registry

### DIFF
--- a/Framework/Core/include/Framework/ArrowContext.h
+++ b/Framework/Core/include/Framework/ArrowContext.h
@@ -10,7 +10,6 @@
 #ifndef FRAMEWORK_ARROWCONTEXT_H
 #define FRAMEWORK_ARROWCONTEXT_H
 
-#include "Framework/ContextRegistry.h"
 #include "Framework/FairMQDeviceProxy.h"
 #include "Framework/TableBuilder.h"
 #include <vector>
@@ -89,22 +88,6 @@ class ArrowContext
   FairMQDeviceProxy mProxy;
   Messages mMessages;
 };
-
-/// Helper to get the context from the registry.
-template <>
-inline ArrowContext*
-  ContextRegistry::get<ArrowContext>()
-{
-  return reinterpret_cast<ArrowContext*>(mContextes[3]);
-}
-
-/// Helper to set the context from the registry.
-template <>
-inline void
-  ContextRegistry::set<ArrowContext>(ArrowContext* context)
-{
-  mContextes[3] = context;
-}
 
 } // namespace framework
 } // namespace o2

--- a/Framework/Core/include/Framework/MessageContext.h
+++ b/Framework/Core/include/Framework/MessageContext.h
@@ -10,7 +10,6 @@
 #ifndef FRAMEWORK_MESSAGECONTEXT_H
 #define FRAMEWORK_MESSAGECONTEXT_H
 
-#include "Framework/ContextRegistry.h"
 #include "Framework/FairMQDeviceProxy.h"
 
 #include <fairmq/FairMQParts.h>
@@ -82,23 +81,6 @@ public:
   FairMQDeviceProxy mProxy;
   Messages mMessages;
 };
-
-/// Helper to get the context from the registry.
-template <>
-inline MessageContext*
-  ContextRegistry::get<MessageContext>()
-{
-  return reinterpret_cast<MessageContext*>(mContextes[0]);
-}
-
-/// Helper to set the context from the registry.
-template <>
-inline void
-  ContextRegistry::set<MessageContext>(MessageContext* context)
-{
-  mContextes[0] = context;
-}
-
 } // namespace framework
 } // namespace o2
 #endif // FRAMEWORK_MESSAGECONTEXT_H

--- a/Framework/Core/include/Framework/RawBufferContext.h
+++ b/Framework/Core/include/Framework/RawBufferContext.h
@@ -16,7 +16,6 @@
 #ifndef FRAMEWORK_RAWBUFFERCONTEXT_H
 #define FRAMEWORK_RAWBUFFERCONTEXT_H
 
-#include "Framework/ContextRegistry.h"
 #include "Framework/FairMQDeviceProxy.h"
 #include "CommonUtils/BoostSerializer.h"
 #include <vector>
@@ -39,6 +38,10 @@ class RawBufferContext
  public:
   RawBufferContext(FairMQDeviceProxy proxy)
     : mProxy{ proxy }
+  {
+  }
+  RawBufferContext(RawBufferContext&& other)
+    : mProxy{ other.mProxy }, mMessages{ std::move(other.mMessages) }
   {
   }
 
@@ -100,22 +103,6 @@ class RawBufferContext
   FairMQDeviceProxy mProxy;
   Messages mMessages;
 };
-
-/// Helper to get the context from the registry.
-template <>
-inline RawBufferContext*
-  ContextRegistry::get<RawBufferContext>()
-{
-  return reinterpret_cast<RawBufferContext*>(mContextes[4]);
-}
-
-/// Helper to set the context from the registry.
-template <>
-inline void
-  ContextRegistry::set<RawBufferContext>(RawBufferContext* context)
-{
-  mContextes[4] = context;
-}
 
 } // namespace framework
 } // namespace o2

--- a/Framework/Core/include/Framework/RootObjectContext.h
+++ b/Framework/Core/include/Framework/RootObjectContext.h
@@ -10,7 +10,6 @@
 #ifndef FRAMEWORK_ROOTOBJETCONTEXT_H
 #define FRAMEWORK_ROOTOBJETCONTEXT_H
 
-#include "Framework/ContextRegistry.h"
 #include "Framework/FairMQDeviceProxy.h"
 #include <vector>
 #include <cassert>
@@ -87,23 +86,6 @@ public:
   FairMQDeviceProxy mProxy;
   Messages mMessages;
 };
-
-/// Helper to get the context from the registry.
-template <>
-inline RootObjectContext*
-  ContextRegistry::get<RootObjectContext>()
-{
-  return reinterpret_cast<RootObjectContext*>(mContextes[1]);
-}
-
-/// Helper to set the context from the registry.
-template <>
-inline void
-  ContextRegistry::set<RootObjectContext>(RootObjectContext* context)
-{
-  mContextes[1] = context;
-}
-
 } // namespace framework
 } // namespace o2
 #endif // FRAMEWORK_ROOTOBJECTCONTEXT_H

--- a/Framework/Core/include/Framework/StringContext.h
+++ b/Framework/Core/include/Framework/StringContext.h
@@ -10,7 +10,6 @@
 #ifndef FRAMEWORK_STRINGCONTEXT_H
 #define FRAMEWORK_STRINGCONTEXT_H
 
-#include "Framework/ContextRegistry.h"
 #include "Framework/FairMQDeviceProxy.h"
 #include <vector>
 #include <cassert>
@@ -88,22 +87,6 @@ class StringContext
   FairMQDeviceProxy mProxy;
   Messages mMessages;
 };
-
-/// Helper to get the context from the registry.
-template <>
-inline StringContext*
-  ContextRegistry::get<StringContext>()
-{
-  return reinterpret_cast<StringContext*>(mContextes[2]);
-}
-
-/// Helper to set the context from the registry.
-template <>
-inline void
-  ContextRegistry::set<StringContext>(StringContext* context)
-{
-  mContextes[2] = context;
-}
 
 } // namespace framework
 } // namespace o2

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -74,7 +74,7 @@ DataProcessingDevice::DataProcessingDevice(DeviceSpec const& spec, ServiceRegist
     mStringContext{ FairMQDeviceProxy{ this } },
     mDataFrameContext{ FairMQDeviceProxy{ this } },
     mRawBufferContext{ FairMQDeviceProxy{ this } },
-    mContextRegistry{ { &mFairMQContext, &mRootContext, &mStringContext, &mDataFrameContext, &mRawBufferContext } },
+    mContextRegistry{ &mFairMQContext, &mRootContext, &mStringContext, &mDataFrameContext, &mRawBufferContext },
     mAllocator{ &mTimingInfo, &mContextRegistry, spec.outputs },
     mRelayer{ spec.completionPolicy, spec.inputs, spec.forwards, registry.get<Monitoring>(), registry.get<TimesliceIndex>() },
     mServiceRegistry{ registry },
@@ -288,23 +288,23 @@ bool DataProcessingDevice::tryDispatchComputation()
   std::vector<std::unique_ptr<FairMQMessage>> currentSetOfInputs;
 
   auto& allocator = mAllocator;
-  auto& context = mFairMQContext;
+  auto& context = *mContextRegistry.get<MessageContext>();
   auto& device = *this;
   auto& errorCallback = mError;
   auto& errorCount = mErrorCount;
   auto& forwards = mSpec.forwards;
   auto& inputsSchema = mSpec.inputs;
   auto& processingCount = mProcessingCount;
-  auto& rdfContext = mDataFrameContext;
+  auto& rdfContext = *mContextRegistry.get<ArrowContext>();
   auto& relayer = mRelayer;
-  auto& rootContext = mRootContext;
+  auto& rootContext = *mContextRegistry.get<RootObjectContext>();
   auto& serviceRegistry = mServiceRegistry;
   auto& statefulProcess = mStatefulProcess;
   auto& statelessProcess = mStatelessProcess;
-  auto& stringContext = mStringContext;
+  auto& stringContext = *mContextRegistry.get<StringContext>();
   auto& timingInfo = mTimingInfo;
   auto& timesliceIndex = mServiceRegistry.get<TimesliceIndex>();
-  auto& rawContext = mRawBufferContext;
+  auto& rawContext = *mContextRegistry.get<RawBufferContext>();
 
   // These duplicate references are created so that each function
   // does not need to know about the whole class state, but I can


### PR DESCRIPTION
This is only a first step avoiding the array with fixed positions with minimal
changes to the other code. Further cleanup ahead.