### PR TITLE
Extra features in Alpide cluster patterns dictionary generation

### DIFF
--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/ClusterTopology.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/ClusterTopology.h
@@ -50,6 +50,8 @@ class ClusterTopology
   unsigned long getHash() const { return mHash; }
   /// Prints the topology
   friend std::ostream& operator<<(std::ostream& os, const ClusterTopology& top);
+  /// Prints to the stdout
+  void print() const { std::cout << (*this) << "\n"; }
   /// MurMur2 hash fucntion
   static unsigned int hashFunction(const void* key, int len);
   /// Compute the complete hash as defined for mHash

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TopologyDictionary.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TopologyDictionary.h
@@ -53,6 +53,7 @@ struct GroupStruct {
   ClusterPattern mPattern; ///< Bitmask of pixels. For groups the biggest bounding box for the group is taken, with all
                            ///the bits set to 1.
   double mFrequency;       ///< Frequency of the topology
+  ClassDefNV(GroupStruct, 1);
 };
 
 class TopologyDictionary

--- a/DataFormats/Detectors/ITSMFT/common/src/ITSMFTDataFormatsLinkDef.h
+++ b/DataFormats/Detectors/ITSMFT/common/src/ITSMFTDataFormatsLinkDef.h
@@ -27,5 +27,6 @@
 #pragma link C++ class o2::ITSMFT::ClusterPattern + ;
 #pragma link C++ class o2::ITSMFT::ClusterTopology + ;
 #pragma link C++ class o2::ITSMFT::TopologyDictionary + ;
+#pragma link C++ class o2::ITSMFT::GroupStruct + ;
 
 #endif

--- a/Detectors/ITSMFT/ITS/macros/test/run_buildTopoDict_its.C
+++ b/Detectors/ITSMFT/ITS/macros/test/run_buildTopoDict_its.C
@@ -1,0 +1,224 @@
+/// \file run_buildTopoDict_its
+/// Macros to generate dictionary of topologies.
+
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include <TAxis.h>
+#include <TCanvas.h>
+#include <TFile.h>
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TNtuple.h>
+#include <TString.h>
+#include <TStyle.h>
+#include <TTree.h>
+#include <TStopwatch.h>
+#include <TSystem.h>
+#include <fstream>
+#include <string>
+
+#include "MathUtils/Utils.h"
+#include "ITSBase/GeometryTGeo.h"
+#include "ITSMFTReconstruction/BuildTopologyDictionary.h"
+#include "DataFormatsITSMFT/Cluster.h"
+#include "DataFormatsITSMFT/ClusterTopology.h"
+#include "DataFormatsITSMFT/ROFRecord.h"
+#include "ITSMFTSimulation/Hit.h"
+#include "MathUtils/Cartesian3D.h"
+#include "SimulationDataFormat/MCCompLabel.h"
+#include "SimulationDataFormat/MCTruthContainer.h"
+#include <unordered_map>
+#endif
+
+/// Build dictionary of topologies from the root file with full clusters
+/// If the hitfile is non-empty, the mean bias between the cluster COG
+/// and mean MC hit position is calculated
+
+void run_buildTopoDict_its(std::string clusfile = "o2clus_its.root",
+                           std::string hitfile = "o2sim.root",
+                           std::string inputGeom = "O2geometry.root")
+{
+  const int QEDSourceID = 99; // Clusters from this MC source correspond to QED electrons
+
+  using namespace o2::Base;
+  using namespace o2::ITS;
+
+  using o2::ITSMFT::BuildTopologyDictionary;
+  using o2::ITSMFT::Cluster;
+  using o2::ITSMFT::ClusterTopology;
+  using o2::ITSMFT::Hit;
+  using ROFRec = o2::ITSMFT::ROFRecord;
+  using MC2ROF = o2::ITSMFT::MC2ROFRecord;
+  using HitVec = std::vector<Hit>;
+  using MC2HITS_map = std::unordered_map<uint64_t, int>; // maps (track_ID<<16 + chip_ID) to entry in the hit vector
+
+  std::vector<HitVec*> hitVecPool;
+  std::vector<MC2HITS_map> mc2hitVec;
+
+  TStopwatch sw;
+  sw.Start();
+
+  // Geometry
+  o2::Base::GeometryManager::loadGeometry(inputGeom);
+  auto gman = o2::ITS::GeometryTGeo::Instance();
+  gman->fillMatrixCache(o2::utils::bit2Mask(o2::TransformType::T2L, o2::TransformType::T2GRot,
+                                            o2::TransformType::L2G)); // request cached transforms
+
+  // Hits if requested
+  TFile* fileH = nullptr;
+  TTree* hitTree = nullptr;
+
+  if (!hitfile.empty() && !gSystem->AccessPathName(hitfile.c_str())) {
+    fileH = TFile::Open(hitfile.data());
+    hitTree = (TTree*)fileH->Get("o2sim");
+    mc2hitVec.resize(hitTree->GetEntries());
+    hitVecPool.resize(hitTree->GetEntries(), nullptr);
+  }
+
+  // Clusters
+  TFile* fileCl = TFile::Open(clusfile.data());
+  TTree* clusTree = (TTree*)fileCl->Get("o2sim");
+  std::vector<Cluster>* clusArr = nullptr;
+  clusTree->SetBranchAddress("ITSCluster", &clusArr);
+
+  // ROFrecords
+  std::vector<ROFRec> rofRecVec, *rofRecVecP = &rofRecVec;
+  TTree* ROFRecTree = (TTree*)fileCl->Get("ITSClustersROF");
+  ROFRecTree->SetBranchAddress("ITSClustersROF", &rofRecVecP);
+
+  // Cluster MC labels
+  o2::dataformats::MCTruthContainer<o2::MCCompLabel>* clusLabArr = nullptr;
+  std::vector<MC2ROF> mc2rofVec, *mc2rofVecP = &mc2rofVec;
+  TTree* MC2ROFRecTree = nullptr;
+  if (hitTree && clusTree->GetBranch("ITSClusterMCTruth")) {
+    clusTree->SetBranchAddress("ITSClusterMCTruth", &clusLabArr);
+    MC2ROFRecTree = (TTree*)fileCl->Get("ITSClustersMC2ROF");
+    MC2ROFRecTree->SetBranchAddress("ITSClustersMC2ROF", &mc2rofVecP);
+  }
+
+  BuildTopologyDictionary dict;
+
+  for (int rofEnt = 0; rofEnt < ROFRecTree->GetEntries(); rofEnt++) {
+    ROFRecTree->GetEntry(rofEnt);
+    int nROFRec = (int)rofRecVec.size();
+    std::vector<int> mcEvMin(nROFRec, hitTree->GetEntries()), mcEvMax(nROFRec, -1);
+
+    if (clusLabArr) { // >> build min and max MC events used by each ROF
+      for (int ent = 0; ent < MC2ROFRecTree->GetEntries(); ent++) {
+        MC2ROFRecTree->GetEntry(ent);
+        for (int imc = mc2rofVec.size(); imc--;) {
+          const auto& mc2rof = mc2rofVec[imc];
+          for (int irfd = mc2rof.maxROF - mc2rof.minROF + 1; irfd--;) {
+            int irof = mc2rof.rofRecordID + irfd;
+            if (mcEvMin[irof] > imc) {
+              mcEvMin[irof] = imc;
+            }
+            if (mcEvMax[irof] < imc) {
+              mcEvMax[irof] = imc;
+            }
+          }
+        }
+      }
+    } // << build min and max MC events used by each ROF
+
+    for (int irof = 0; irof < nROFRec; irof++) {
+      const auto& rofRec = rofRecVec[irof];
+
+      rofRec.print();
+      if (clusTree->GetReadEntry() != rofRec.getROFEntry().getEvent()) { // read the entry containing clusters of given ROF
+        clusTree->GetEntry(rofRec.getROFEntry().getEvent());             // all clusters of the same ROF are in a single entry
+      }
+
+      if (clusLabArr) { // >> read and map MC events contributing to this ROF
+        for (int im = mcEvMin[irof]; im <= mcEvMax[irof]; im++) {
+          if (!hitVecPool[im]) {
+            hitTree->SetBranchAddress("ITSHit", &hitVecPool[im]);
+            hitTree->GetEntry(im);
+            auto& mc2hit = mc2hitVec[im];
+            const auto* hitArray = hitVecPool[im];
+            for (int ih = hitArray->size(); ih--;) {
+              const auto& hit = (*hitArray)[ih];
+              uint64_t key = (uint64_t(hit.GetTrackID()) << 32) + hit.GetDetectorID();
+              mc2hit.emplace(key, ih);
+            }
+          }
+        }
+      } // << cache MC events contributing to this ROF
+
+      for (int icl = 0; icl < rofRec.getNROFEntries(); icl++) {
+        int clEntry = rofRec.getROFEntry().getIndex() + icl; // entry of icl-th cluster of this ROF in the vector of clusters
+        // do we read MC data?
+
+        const auto& cluster = (*clusArr)[clEntry];
+
+        int rowSpan = cluster.getPatternRowSpan();
+        int columnSpan = cluster.getPatternColSpan();
+        int nBytes = (rowSpan * columnSpan) >> 3;
+        if (((rowSpan * columnSpan) % 8) != 0) {
+          nBytes++;
+        }
+        unsigned char patt[Cluster::kMaxPatternBytes];
+        cluster.getPattern(&patt[0], nBytes);
+        ClusterTopology topology(rowSpan, columnSpan, patt);
+        //
+        // do we need to account for the bias of cluster COG wrt MC hit center?
+        float dX = BuildTopologyDictionary::IgnoreVal, dZ = BuildTopologyDictionary::IgnoreVal;
+        if (clusLabArr) {
+          const auto& lab = (clusLabArr->getLabels(clEntry))[0]; // we neglect effect of cluster contributed by multiple hits
+          auto trID = lab.getTrackID();
+          auto srcID = lab.getSourceID();
+          if (srcID != QEDSourceID && trID != -1) { // use MC truth info only for non-QED and non-noise clusters
+            const auto& mc2hit = mc2hitVec[lab.getEventID()];
+            const auto* hitArray = hitVecPool[lab.getEventID()];
+            int chipID = cluster.getSensorID();
+            uint64_t key = (uint64_t(trID) << 32) + chipID;
+            auto hitEntry = mc2hit.find(key);
+            if (hitEntry != mc2hit.end()) {
+              const auto& hit = (*hitArray)[hitEntry->second];
+              auto locH = gman->getMatrixL2G(chipID) ^ (hit.GetPos()); // inverse conversion from global to local
+              auto locHsta = gman->getMatrixL2G(chipID) ^ (hit.GetPosStart());
+              locH.SetXYZ(0.5 * (locH.X() + locHsta.X()), 0.5 * (locH.Y() + locHsta.Y()), 0.5 * (locH.Z() + locHsta.Z()));
+              const auto locC = cluster.getXYZLoc(*gman); // convert from tracking to local frame
+              dX = locH.X() - locC.X();
+              dZ = locH.Z() - locC.Z();
+            } else {
+              printf("Failed to find MC hit entry for Tr:%d chipID:%d\n", trID, chipID);
+            }
+          }
+        }
+        dict.accountTopology(topology, dX, dZ);
+      }
+      // clean MC cache for events which are not needed anymore
+      int irfNext = irof;
+      while ((++irfNext < nROFRec) && mcEvMax[irfNext] < 0) {
+      }                                                                      // find next ROF having MC contribution
+      int limMC = irfNext == nROFRec ? hitVecPool.size() : mcEvMin[irfNext]; // can clean events up to this
+      for (int imc = mcEvMin[irof]; imc < limMC; imc++) {
+        delete hitVecPool[imc];
+        hitVecPool[imc] = nullptr;
+        mc2hitVec[imc].clear();
+      }
+    }
+  }
+
+  dict.setThreshold(0.0001);
+  dict.groupRareTopologies();
+  dict.printDictionaryBinary("dictionary.bin");
+  dict.printDictionary("dictionary.txt");
+  dict.saveDictionaryRoot("dictionary.root");
+
+  TFile histogramOutput("dict_histograms.root", "recreate");
+  TCanvas* cComplete = new TCanvas("cComplete", "Distribution of all the topologies");
+  cComplete->cd();
+  cComplete->SetLogy();
+  TH1F* hComplete = (TH1F*)dict.mHdist.Clone("hDict");
+  hComplete->SetDirectory(0);
+  hComplete->SetTitle("Topology distribution");
+  hComplete->GetXaxis()->SetTitle("Topology ID");
+  hComplete->SetFillColor(kRed);
+  hComplete->SetFillStyle(3005);
+  hComplete->Draw("hist");
+  cComplete->Print("dictHisto.pdf");
+  cComplete->Write();
+  sw.Stop();
+  sw.Print();
+}

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/BuildTopologyDictionary.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/BuildTopologyDictionary.h
@@ -38,17 +38,25 @@ namespace o2
 namespace ITSMFT
 {
 struct TopologyInfo {
-  int mSizeX;
-  int mSizeZ;
-  float mCOGx;
-  float mCOGz;
-  float mXmean;
-  float mXsigma2;
-  float mZmean;
-  float mZsigma2;
-  int mNpixels;
+  int mSizeX = 0;
+  int mSizeZ = 0;
+  float mCOGx = 0.f;
+  float mCOGz = 0.f;
+  float mXmean = 0.f;
+  float mXsigma2 = 0.f;
+  float mZmean = 0.f;
+  float mZsigma2 = 0.f;
+  int mNpixels = 0;
   ClusterPattern mPattern; ///< Bitmask of pixels. For groups the biggest bounding box for the group is taken, with all
                            ///the bits set to 1.
+};
+
+// transient structure to accumulate topology statistics
+struct TopoStat {
+  ClusterTopology topology;
+  unsigned long countsTotal = 0;    // counts for this topology
+  unsigned long countsWithBias = 0; // counts with assigned dX,dY provided
+  TopoStat() = default;
 };
 
 class BuildTopologyDictionary
@@ -59,8 +67,8 @@ class BuildTopologyDictionary
 #endif
 
   BuildTopologyDictionary();
-
-  void accountTopology(const ClusterTopology& cluster, float dX, float dZ);
+  static constexpr float IgnoreVal = 999.;
+  void accountTopology(const ClusterTopology& cluster, float dX = IgnoreVal, float dZ = IgnoreVal);
   void setNGroups(unsigned int ngr); // set number of groups
   void setThreshold(double thr);
   void setThresholdCumulative(double cumulative); // Considering the integral
@@ -76,9 +84,8 @@ class BuildTopologyDictionary
 
  private:
   TopologyDictionary mDictionary; ///< Dictionary of topologies
-  std::map<unsigned long, std::pair<ClusterTopology, unsigned long>>
-    mTopologyMap;                                                         ///< Temporary map of type <hash,<topology,counts>>
-  std::vector<std::pair<unsigned long, unsigned long>> mTopologyFrequency; ///< <freq,hash>, needed to define threshold
+  std::map<unsigned long, TopoStat> mTopologyMap;                          //! Temporary map of type <hash,TopStat>
+  std::vector<std::pair<unsigned long, unsigned long>> mTopologyFrequency; //! <freq,hash>, needed to define threshold
   int mTotClusters;
   int mNumberOfGroups;
   int mNotInGroups;

--- a/Detectors/ITSMFT/common/reconstruction/src/BuildTopologyDictionary.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/BuildTopologyDictionary.cxx
@@ -24,28 +24,29 @@ ClassImp(o2::ITSMFT::BuildTopologyDictionary)
 {
   namespace ITSMFT
   {
+  constexpr float BuildTopologyDictionary::IgnoreVal;
+
   BuildTopologyDictionary::BuildTopologyDictionary() : mTotClusters{ 0 } {}
 
   void BuildTopologyDictionary::accountTopology(const ClusterTopology& cluster, float dX, float dZ)
   {
     mTotClusters++;
+    bool useDf = dX < IgnoreVal / 2; // we may need to account the frequency but to not update the centroid
+    // std::pair<unordered_map<unsigned long, TopoStat>::iterator,bool> ret;
+    //       auto ret = mTopologyMap.insert(std::make_pair(cluster.getHash(), std::make_pair(cluster, 1)));
 
-    // std::pair<unordered_map<unsigned long, std::pair<ClusterTopology,unsigned long>>::iterator,bool> ret;
-    auto ret = mTopologyMap.insert(std::make_pair(cluster.getHash(), std::make_pair(cluster, 1)));
-    if (ret.second == true) {
+    auto& topoStat = mTopologyMap[cluster.getHash()];
+    topoStat.countsTotal++;
+    if (topoStat.countsTotal == 1) { // a new topology is inserted
+      topoStat.topology = cluster;
       //___________________DEFINING_TOPOLOGY_CHARACTERISTICS__________________
       TopologyInfo topInf;
       topInf.mPattern.setPattern(cluster.getPattern().data());
       int& rs = topInf.mSizeX = cluster.getRowSpan();
       int& cs = topInf.mSizeZ = cluster.getColumnSpan();
       //__________________COG_Deterrmination_____________
-      int tempyCOG = 0;
-      int tempzCOG = 0;
-      int tempFiredPixels = 0;
+      int tempyCOG = 0, tempzCOG = 0, tempFiredPixels = 0, s = 0, ic = 0, ir = 0;
       unsigned char tempChar = 0;
-      int s = 0;
-      int ic = 0;
-      int ir = 0;
       for (unsigned int i = 2; i < cluster.getUsedBytes() + 2; i++) {
         tempChar = cluster.getByte(i);
         s = 128; // 0b10000000
@@ -57,45 +58,49 @@ ClassImp(o2::ITSMFT::BuildTopologyDictionary)
           }
           ic++;
           s /= 2;
-          if ((ir + 1) * ic == (rs * cs))
+          if ((ir + 1) * ic == (rs * cs)) {
             break;
+          }
           if (ic == cs) {
             ic = 0;
             ir++;
           }
         }
-        if ((ir + 1) * ic == (rs * cs))
+        if ((ir + 1) * ic == (rs * cs)) {
           break;
+        }
       }
       topInf.mCOGx = 0.5 + (float)tempyCOG / (float)tempFiredPixels;
       topInf.mCOGz = 0.5 + (float)tempzCOG / (float)tempFiredPixels;
       topInf.mNpixels = tempFiredPixels;
-      topInf.mXmean = dX;
-      topInf.mXsigma2 = 0;
-      topInf.mZmean = dZ;
-      topInf.mZsigma2 = 0;
+      if (useDf) {
+        topInf.mXmean = dX;
+        topInf.mZmean = dZ;
+        topoStat.countsWithBias = 1;
+      }
       mMapInfo.insert(std::make_pair(cluster.getHash(), topInf));
+
     } else {
-      int num = (ret.first->second.second++);
-      auto ind = mMapInfo.find(cluster.getHash());
-      float tmpxMean = ind->second.mXmean;
-      float newxMean = ind->second.mXmean = ((tmpxMean)*num + dX) / (num + 1);
-      float tmpxSigma2 = ind->second.mXsigma2;
-      ind->second.mXsigma2 =
-        (num * tmpxSigma2 + (dX - tmpxMean) * (dX - newxMean)) / (num + 1); // online variance algorithm
-      float tmpzMean = ind->second.mZmean;
-      float newzMean = ind->second.mZmean = ((tmpzMean)*num + dZ) / (num + 1);
-      float tmpzSigma2 = ind->second.mZsigma2;
-      ind->second.mZsigma2 =
-        (num * tmpzSigma2 + (dZ - tmpzMean) * (dZ - newzMean)) / (num + 1); // online variance algorithm
+      if (useDf) {
+        auto num = topoStat.countsWithBias++;
+        auto ind = mMapInfo.find(cluster.getHash());
+        float tmpxMean = ind->second.mXmean;
+        float newxMean = ind->second.mXmean = ((tmpxMean)*num + dX) / (num + 1);
+        float tmpxSigma2 = ind->second.mXsigma2;
+        ind->second.mXsigma2 = (num * tmpxSigma2 + (dX - tmpxMean) * (dX - newxMean)) / (num + 1); // online variance algorithm
+        float tmpzMean = ind->second.mZmean;
+        float newzMean = ind->second.mZmean = ((tmpzMean)*num + dZ) / (num + 1);
+        float tmpzSigma2 = ind->second.mZsigma2;
+        ind->second.mZsigma2 = (num * tmpzSigma2 + (dZ - tmpzMean) * (dZ - newzMean)) / (num + 1); // online variance algorithm
+      }
     }
   }
 
   void BuildTopologyDictionary::setThreshold(double thr)
   {
     mTopologyFrequency.clear();
-    for (auto&& p : mTopologyMap) {
-      mTopologyFrequency.emplace_back(std::make_pair(p.second.second, p.first));
+    for (auto&& p : mTopologyMap) { // p is pair<ulong,TopoStat>
+      mTopologyFrequency.emplace_back(std::make_pair(p.second.countsTotal, p.first));
     }
     std::sort(mTopologyFrequency.begin(), mTopologyFrequency.end(),
               [](const std::pair<unsigned long, unsigned long>& couple1,
@@ -116,8 +121,8 @@ ClassImp(o2::ITSMFT::BuildTopologyDictionary)
   void BuildTopologyDictionary::setNGroups(unsigned int ngr)
   {
     mTopologyFrequency.clear();
-    for (auto&& p : mTopologyMap) {
-      mTopologyFrequency.emplace_back(std::make_pair(p.second.second, p.first));
+    for (auto&& p : mTopologyMap) { // p os pair<ulong,TopoStat>
+      mTopologyFrequency.emplace_back(std::make_pair(p.second.countsTotal, p.first));
     }
     std::sort(mTopologyFrequency.begin(), mTopologyFrequency.end(),
               [](const std::pair<unsigned long, unsigned long>& couple1,
@@ -141,8 +146,8 @@ ClassImp(o2::ITSMFT::BuildTopologyDictionary)
     if (cumulative <= 0. || cumulative >= 1.)
       cumulative = 0.99;
     double totFreq = 0.;
-    for (auto&& p : mTopologyMap) {
-      mTopologyFrequency.emplace_back(std::make_pair(p.second.second, p.first));
+    for (auto&& p : mTopologyMap) { // p os pair<ulong,TopoStat>
+      mTopologyFrequency.emplace_back(std::make_pair(p.second.countsTotal, p.first));
     }
     std::sort(mTopologyFrequency.begin(), mTopologyFrequency.end(),
               [](const std::pair<unsigned long, unsigned long>& couple1,
@@ -271,8 +276,8 @@ ClassImp(o2::ITSMFT::BuildTopologyDictionary)
 
     for (unsigned int j = (unsigned int)mNotInGroups; j < mTopologyFrequency.size(); j++) {
       unsigned long hash1 = mTopologyFrequency[j].second;
-      rs = mTopologyMap.find(hash1)->second.first.getRowSpan();
-      cs = mTopologyMap.find(hash1)->second.first.getColumnSpan();
+      rs = mTopologyMap.find(hash1)->second.topology.getRowSpan();
+      cs = mTopologyMap.find(hash1)->second.topology.getColumnSpan();
       index = LookUp::groupFinder(rs, cs);
       groupCounts[index] += mTopologyFrequency[j].first;
     }
@@ -297,10 +302,11 @@ ClassImp(o2::ITSMFT::BuildTopologyDictionary)
     for (int i = 0; i < DB.mNotInGroups; i++) {
       const unsigned long& hash = DB.mTopologyFrequency[i].second;
       os << "Hash: " << hash << std::endl;
-      os << "counts: " << DB.mTopologyMap.find(hash)->second.second << std::endl;
+      os << "counts: " << DB.mTopologyMap.find(hash)->second.countsTotal;
+      os << " (with bias provided: " << DB.mTopologyMap.find(hash)->second.countsWithBias << ")" << std::endl;
       os << "sigmaX: " << std::sqrt(DB.mMapInfo.find(hash)->second.mXsigma2) << std::endl;
       os << "sigmaZ: " << std::sqrt(DB.mMapInfo.find(hash)->second.mZsigma2) << std::endl;
-      os << DB.mTopologyMap.find(hash)->second.first;
+      os << DB.mTopologyMap.find(hash)->second.topology;
     }
     return os;
   }


### PR DESCRIPTION
Hi @lbariogl ,

In order to generate a realistic dictionary I've modified the way pattern info is accounted: now one can account only its frequency w/o affecting the COG bias evaluation. See comment of 1st commit for details.

Also I am adding a macro to generate a dictionary (accounting noise and QED clusters for the entropy only but not for the bias) from the data produced by the DPL flow. I think old CheckTopologies should be eliminated since it will not work with MC containing the QED contribution and the way it accesses the MC hits is super-slow for data with continuous readout.