### PR TITLE
Update TRD hit type (O2-453)

### DIFF
--- a/Detectors/TRD/simulation/include/TRDSimulation/Detector.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Detector.h
@@ -24,11 +24,55 @@ namespace o2
 {
 namespace trd
 {
-class HitType : public o2::BasicXYZEHit<float>
+class HitType : public o2::BaseHit
 {
+  Point3D<float> mPos; // cartesian position of Hit
+  float mTime;         // time of flight
+  int mCharge;         // energy loss
+  short mDetectorID;   // the detector/sensor id
+
  public:
-  using BasicXYZEHit<float>::BasicXYZEHit;
+  HitType() = default; // for ROOT IO
+  // constructor
+  HitType(float x, float y, float z, float tof, int q, int trackid, short did)
+    : mPos(x, y, z),
+      mTime(tof),
+      mCharge(q),
+      BaseHit(trackid),
+      mDetectorID(did)
+  {
+  }
+
+  // getting the cartesian coordinates
+  float GetX() const { return mPos.X(); }
+  float GetY() const { return mPos.Y(); }
+  float GetZ() const { return mPos.Z(); }
+  Point3D<float> GetPos() const { return mPos; }
+  // getting charge
+  int GetCharge() const { return mCharge; }
+  // getting the time
+  float GetTime() const { return mTime; }
+  // get detector + track information
+  short GetDetectorID() const { return mDetectorID; }
+
+  // modifiers
+  void SetTime(float time) { mTime = time; }
+  void SetCharge(int q) { mCharge = q; }
+  void SetDetectorID(short detID) { mDetectorID = detID; }
+  void SetX(float x) { mPos.SetX(x); }
+  void SetY(float y) { mPos.SetY(y); }
+  void SetZ(float z) { mPos.SetZ(z); }
+  void SetXYZ(float x, float y, float z)
+  {
+    SetX(x);
+    SetY(y);
+    SetZ(z);
+  }
+  void SetPos(Point3D<float> const& p) { mPos = p; }
+
+  ClassDefNV(HitType, 1);
 };
+
 } // namespace trd
 } // namespace o2
 

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -24,7 +24,6 @@ Digitizer::Digitizer()
   // Check if you need more initialization
   mGeom = new TRDGeometry();
   mSDigits = false;
-
 }
 
 Digitizer::~Digitizer() = default;
@@ -180,8 +179,7 @@ bool Digitizer::convertHits(const int det, const std::vector<o2::trd::HitType>& 
     pos[1] = hit.GetY();
     pos[2] = hit.GetZ();
 
-    const float eDep = hit.GetEnergyLoss();
-    const int qTotal = (int)eDep; // Small kind of hack, this will be fixed later
+    const int qTotal = hit.GetCharge();
 
     gGeoManager->SetCurrentPoint(pos);
     gGeoManager->FindNode();


### PR DESCRIPTION
Update of the TRD hit type (O2-453) to keep only deposited charge instead (int) of energy loss (float). This reduces the number of float divisions `Eloss/Wion` and conversion of float to int in several places of the digitizer (which is under development). It also keeps the setting of the ionization energy values only in one place.

We discussed a few days ago that we could create a `BasicXYZHit` from `BaseHit` and then a `BasicXYZEhit` and `BasicXYZQhit`, contained in the data formats. I think it is also ok doing things this way. I let you decide.