### PR TITLE
Bump DigitizationMode to subtract the pedestals by default

### DIFF
--- a/Detectors/TPC/base/src/ParameterElectronics.cxx
+++ b/Detectors/TPC/base/src/ParameterElectronics.cxx
@@ -24,6 +24,6 @@ ParameterElectronics::ParameterElectronics()
     mADCsaturation(1024.f),
     mZbinWidth(0.2f),
     mElectronCharge(1.602e-19f),
-    mDigitizationMode(DigitzationMode::FullMode)
+    mDigitizationMode(DigitzationMode::SubtractPedestal)
 {
 }


### PR DESCRIPTION
o Otherwise the clusterizer finds also clusters in the tails of the digits
o Hence, more than one track per particle is found