### PR TITLE
DPL: make relayer stats delayed by 1 second

### DIFF
--- a/Framework/Core/include/Framework/DataProcessingStats.h
+++ b/Framework/Core/include/Framework/DataProcessingStats.h
@@ -31,6 +31,7 @@ struct DataProcessingStats {
   int lastElapsedTimeMs;
   int lastTotalProcessedSize;
   InputLatency lastLatency;
+  std::vector<int> relayerState;
 };
 
 } // namespace framework


### PR DESCRIPTION
Given we need to scale to up to 8kHz, there is no way we can use
monitoring to send the data relayer information at that rate. We
therefore send those metrics on a much lower frequency (1Hz) which
should still allow using the GUI for less demanding workflows, but
avoids the bottleneck for high rate ones.