### PR TITLE
DPL driver: increase input parsing performance

### DIFF
--- a/Framework/Core/include/Framework/DeviceMetricsInfo.h
+++ b/Framework/Core/include/Framework/DeviceMetricsInfo.h
@@ -15,6 +15,7 @@
 #include <cstddef>
 #include <functional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace o2
@@ -87,7 +88,7 @@ struct DeviceMetricsHelper {
   using NewMetricCallback = std::function<void(std::string const&, MetricInfo const&, int value, size_t metricIndex)>;
 
   /// Helper function to parse a metric string.
-  static bool parseMetric(const std::string& s, ParsedMetricMatch& results);
+  static bool parseMetric(std::string_view const s, ParsedMetricMatch& results);
 
   /// Processes a parsed metric and stores in the backend store.
   ///

--- a/Framework/Core/include/Framework/LogParsingHelpers.h
+++ b/Framework/Core/include/Framework/LogParsingHelpers.h
@@ -11,6 +11,7 @@
 #define FRAMEWORK_LOGPARSINGHELPERS
 
 #include <string>
+#include <string_view>
 
 namespace o2
 {
@@ -36,7 +37,7 @@ struct LogParsingHelpers {
   /// Token style can then be used for colouring the logs
   /// in the GUI or to exit with error if a sufficient
   /// number of LogLevel::Error is found.
-  static LogLevel parseTokenLevel(const std::string &s);
+  static LogLevel parseTokenLevel(std::string_view const s);
 };
 
 } // namespace framework

--- a/Framework/Core/include/Framework/TextControlService.h
+++ b/Framework/Core/include/Framework/TextControlService.h
@@ -12,6 +12,7 @@
 
 #include "Framework/ControlService.h"
 #include <string>
+#include <string_view>
 #include <regex>
 
 namespace o2
@@ -41,7 +42,7 @@ private:
   bool mOnce = false;
 };
 
-bool parseControl(const std::string &s, std::smatch &match);
+bool parseControl(std::string_view s, std::smatch& match);
 
 } // namespace framework
 } // namespace o2

--- a/Framework/Core/src/DataProcessingStatus.h
+++ b/Framework/Core/src/DataProcessingStatus.h
@@ -33,6 +33,13 @@ enum struct MonitoringStatus : uint32_t {
   FLUSH = 1,
 };
 
+enum struct DriverStatus : uint32_t {
+  ID = 2,
+  BYTES_READ = 0,
+  BYTES_PROCESSED = 1,
+  BUFFER_OVERFLOWS = 2
+};
+
 } // namespace framework
 } // namespace o2
 

--- a/Framework/Core/src/DeviceMetricsInfo.cxx
+++ b/Framework/Core/src/DeviceMetricsInfo.cxx
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <regex>
+#include <string_view>
 #include <tuple>
 #include <iostream>
 
@@ -26,7 +27,7 @@ namespace framework
 // Parses a metric in the form
 //
 // [METRIC] <name>,<type> <value> <timestamp> [<tag>,<tag>]
-bool DeviceMetricsHelper::parseMetric(const std::string& s, ParsedMetricMatch& match)
+bool DeviceMetricsHelper::parseMetric(std::string_view const s, ParsedMetricMatch& match)
 {
   /// Must start with "[METRIC] "
   ///                  012345678

--- a/Framework/Core/src/LogParsingHelpers.cxx
+++ b/Framework/Core/src/LogParsingHelpers.cxx
@@ -16,15 +16,16 @@ namespace framework
 {
 
 char const* const LogParsingHelpers::LOG_LEVELS[(int)LogParsingHelpers::LogLevel::Size] = {
-    "DEBUG",
-    "INFO",
-    "WARNING",
-    "ERROR",
-    "UNKNOWN"
-  };
+  "DEBUG",
+  "INFO",
+  "WARNING",
+  "ERROR",
+  "UNKNOWN"
+};
 using LogLevel = o2::framework::LogParsingHelpers::LogLevel;
 
-LogLevel LogParsingHelpers::parseTokenLevel(const std::string &s) {
+LogLevel LogParsingHelpers::parseTokenLevel(std::string_view const s)
+{
 
   // Example format: [99:99:99][ERROR] (string begins with that, longest is 17 chars)
   constexpr size_t MAXPREFLEN = 17;
@@ -55,6 +56,5 @@ LogLevel LogParsingHelpers::parseTokenLevel(const std::string &s) {
   }
   return LogLevel::Unknown;
 }
-
-}
-}
+} // namespace framework
+} // namespace o2

--- a/Framework/Core/src/TextControlService.cxx
+++ b/Framework/Core/src/TextControlService.cxx
@@ -10,6 +10,7 @@
 #include "Framework/TextControlService.h"
 #include "FairMQLogger.h"
 #include <string>
+#include <string_view>
 #include <regex>
 #include <iostream>
 
@@ -31,13 +32,16 @@ void TextControlService::readyToQuit(bool all) {
   }
 }
 
-bool parseControl(const std::string &s, std::smatch &match) {
+bool parseControl(std::string_view s, std::smatch& match)
+{
   const static std::regex controlRE("READY_TO_(QUIT)_(ME|ALL)", std::regex::optimize);
   auto idx = s.find("CONTROL_ACTION: ");
   if (idx == std::string::npos) {
     return false;
   }
-  return std::regex_search(s.begin() + idx, s.end(), match, controlRE);
+  s.remove_prefix(idx);
+  std::string rs{ s };
+  return std::regex_search(rs, match, controlRE);
 }
 
 } // framework

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -28,10 +28,12 @@
 #include "Framework/ParallelContext.h"
 #include "Framework/RawDeviceService.h"
 #include "Framework/SimpleRawDeviceService.h"
+#include "Framework/Signpost.h"
 #include "Framework/TextControlService.h"
 #include "Framework/CallbackService.h"
 #include "Framework/WorkflowSpec.h"
 
+#include "DataProcessingStatus.h"
 #include "DDSConfigHelpers.h"
 #include "O2ControlHelpers.h"
 #include "DeviceSpecHelpers.h"
@@ -131,12 +133,13 @@ std::ostream& operator<<(std::ostream& out, const enum TerminationPolicy& policy
 // FIXME: We should really print full lines.
 bool getChildData(int infd, DeviceInfo& outinfo)
 {
-  char buffer[1024];
+  char buffer[1024 * 16];
   int bytes_read;
   // NOTE: do not quite understand read ends up blocking if I read more than
   //        once. Oh well... Good enough for now.
+  O2_SIGNPOST_START(DriverStatus::ID, DriverStatus::BYTES_READ, outinfo.pid, infd, 0);
   // do {
-  bytes_read = read(infd, buffer, 1024);
+  bytes_read = read(infd, buffer, 1024 * 16);
   if (bytes_read == 0) {
     return false;
   }
@@ -150,7 +153,8 @@ bool getChildData(int infd, DeviceInfo& outinfo)
   }
   assert(bytes_read > 0);
   outinfo.unprinted += std::string(buffer, bytes_read);
-  //  } while (bytes_read != 0);
+  // } while (bytes_read != 0);
+  O2_SIGNPOST_END(DriverStatus::ID, DriverStatus::BYTES_READ, bytes_read, 0, 0);
   return true;
 }
 
@@ -372,7 +376,6 @@ void processChildrenOutput(DriverInfo& driverInfo, DeviceInfos& infos, DeviceSpe
   assert(infos.size() == controls.size());
   std::smatch match;
   ParsedMetricMatch metricMatch;
-  std::string token;
   const std::string delimiter("\n");
   bool hasNewMetric = false;
   for (size_t di = 0, de = infos.size(); di < de; ++di) {
@@ -384,7 +387,9 @@ void processChildrenOutput(DriverInfo& driverInfo, DeviceInfos& infos, DeviceSpe
       continue;
     }
 
-    auto s = info.unprinted;
+    O2_SIGNPOST_START(DriverStatus::ID, DriverStatus::BYTES_PROCESSED, info.pid, 0, 0);
+
+    std::string_view s = info.unprinted;
     size_t pos = 0;
     info.history.resize(info.historySize);
     info.historyLevel.resize(info.historySize);
@@ -400,7 +405,7 @@ void processChildrenOutput(DriverInfo& driverInfo, DeviceInfos& infos, DeviceSpe
     };
 
     while ((pos = s.find(delimiter)) != std::string::npos) {
-      token = s.substr(0, pos);
+      std::string token{ s.substr(0, pos) };
       auto logLevel = LogParsingHelpers::parseTokenLevel(token);
 
       // Check if the token is a metric from SimpleMetricsService
@@ -431,7 +436,7 @@ void processChildrenOutput(DriverInfo& driverInfo, DeviceInfos& infos, DeviceSpe
             }
           }
         }
-      } else if (!control.quiet && (strstr(token.c_str(), control.logFilter) != nullptr) &&
+      } else if (!control.quiet && (token.find(control.logFilter) != std::string::npos) &&
                  logLevel >= control.logLevel) {
         assert(info.historyPos >= 0);
         assert(info.historyPos < info.history.size());
@@ -449,9 +454,11 @@ void processChildrenOutput(DriverInfo& driverInfo, DeviceInfos& infos, DeviceSpe
       if (logLevel == LogParsingHelpers::LogLevel::Error) {
         info.lastError = token;
       }
-      s.erase(0, pos + delimiter.length());
+      s.remove_prefix(pos + delimiter.length());
     }
+    size_t oldSize = info.unprinted.size();
     info.unprinted = s;
+    O2_SIGNPOST_END(DriverStatus::ID, DriverStatus::BYTES_PROCESSED, oldSize - info.unprinted.size(), 0, 0);
   }
   if (hasNewMetric) {
     hasNewMetric = false;

--- a/Framework/Core/test/test_DeviceMetricsInfo.cxx
+++ b/Framework/Core/test/test_DeviceMetricsInfo.cxx
@@ -15,17 +15,19 @@
 #include <boost/test/unit_test.hpp>
 #include <iostream>
 #include <regex>
-
+#include <string_view>
 
 BOOST_AUTO_TEST_CASE(TestDeviceMetricsInfo) {
   using namespace o2::framework;
-  std::string metric;
+  std::string metricString;
   ParsedMetricMatch match;
   bool result;
   DeviceMetricsInfo info;
 
   // Parse a simple metric
-  metric = "[METRIC] bkey,0 12 1789372894 hostname=test.cern.ch";
+  metricString = "foo[METRIC] bkey,0 12 1789372894 hostname=test.cern.chbar";
+  std::string_view metric{ metricString.data() + 3, metricString.size() - 6 };
+  BOOST_REQUIRE_EQUAL(metric, std::string("[METRIC] bkey,0 12 1789372894 hostname=test.cern.ch"));
   result = DeviceMetricsHelper::parseMetric(metric, match);
   BOOST_REQUIRE_EQUAL(result, true);
   BOOST_CHECK(strncmp(match.beginKey, "bkey", 4) == 0);


### PR DESCRIPTION
Remove a bit of technical debt when processing the inputs from the
children dataprocessors. In particular:

* Most of parsing / processing now uses a string_view so that the
  unparsed buffers are not copied around multiple times.
* Read buffer is now 16kB (was 1kB) which seems to avoid having
  to split the processing in multiple iterations.
* Add tracing information for data being read from children and
  for data processed by the driver.