### PR TITLE
Defining default move constructor and assignment operator for MCTruthContainer

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/MCTruthContainer.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCTruthContainer.h
@@ -64,10 +64,14 @@ class MCTruthContainer
   ~MCTruthContainer() = default;
   // copy constructor
   MCTruthContainer(const MCTruthContainer& other) = default;
+  // move constructor
+  MCTruthContainer(MCTruthContainer&& other) = default;
   // assignment operator
   MCTruthContainer& operator=(const MCTruthContainer &other) = default;
+  // move assignment operator
+  MCTruthContainer& operator=(MCTruthContainer&& other) = default;
 
-    // access
+  // access
   MCTruthHeaderElement getMCTruthHeader(uint dataindex) const { return mHeaderArray[dataindex]; }
   // access the element directly (can be encapsulated better away)... needs proper element index
   // which can be obtained from the MCTruthHeader startposition and size

--- a/DataFormats/simulation/test/testMCTruthContainer.cxx
+++ b/DataFormats/simulation/test/testMCTruthContainer.cxx
@@ -243,4 +243,25 @@ BOOST_AUTO_TEST_CASE(LabelContainer_noncont)
   BOOST_CHECK(cont2.getLabels(100).size() == 0);
 }
 
+BOOST_AUTO_TEST_CASE(MCTruthContainer_move)
+{
+  using TruthElement = long;
+  using Container = dataformats::MCTruthContainer<TruthElement>;
+  Container container;
+  container.addElement(0, TruthElement(1));
+  container.addElement(0, TruthElement(2));
+  container.addElement(1, TruthElement(1));
+  container.addElement(2, TruthElement(10));
+
+  Container container2 = std::move(container);
+  BOOST_CHECK(container.getIndexedSize() == 0);
+  BOOST_CHECK(container.getNElements() == 0);
+
+  std::swap(container, container2);
+  BOOST_CHECK(container2.getIndexedSize() == 0);
+  BOOST_CHECK(container2.getNElements() == 0);
+  BOOST_CHECK(container.getIndexedSize() == 3);
+  BOOST_CHECK(container.getNElements() == 4);
+}
+
 } // end namespace


### PR DESCRIPTION
Have been running into problems with some existing code because the content of
the container was not really moved to the target instance. By explicitly defining
the move constructor and assignment operator as default, the compiler does the
correct thing with the member vectors.

There was probably a bug in the TPC HardwareClusterDecoder where std::move(container)
has been used with the intention to make the original container empty.