### PR TITLE
Write output of TPC cluster decoder directly to message memory

### DIFF
--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/ClusterHardware.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/ClusterHardware.h
@@ -147,9 +147,9 @@ struct ClusterHardware { // Draft of hardware clusters in bit-packed format.
 
 struct ClusterHardwareContainer { // Temporary struct to hold a set of hardware clusters, prepended by an RDH, and a
                                   // short header with metadata, to be replace
-  // The total structure is supposed to use up to 8 kb (like a readout block, thus it can hold up to 339 clusters ((8192
-  // - 40) / 24)
-  uint64_t mDH[8];             //< 8 * 64 bit RDH (raw data header)
+  // The total structure is supposed to use up to 8 kb (like a readout block, thus it can hold up to 406 clusters ((8192
+  // - 40) / 20)
+  uint64_t mRDH[8];            //< 8 * 64 bit RDH (raw data header)
   uint32_t timeBinOffset;      //< Time offset in timebins since beginning of the time frame
   uint16_t numberOfClusters;   //< Number of clusters in this 8kb structure
   uint16_t CRU;                //< CRU of the cluster

--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/ClusterNative.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/ClusterNative.h
@@ -101,6 +101,15 @@ struct ClusterNative {
     }
     sigmaPadPacked = tmp;
   }
+
+  bool operator<(const ClusterNative& rhs) const
+  {
+    if (this->getTimePacked() != rhs.getTimePacked()) {
+      return (this->getTimePacked() < rhs.getTimePacked());
+    } else {
+      return (this->padPacked < rhs.padPacked);
+    }
+  }
 };
 
 // This is an index struct to access TPC clusters inside sectors and rows. It shall not own the data, but just point to

--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/ClusterNativeHelper.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/ClusterNativeHelper.h
@@ -45,15 +45,6 @@ struct ClusterNativeContainer : public ClusterGroupAttribute {
   using attribute_type = ClusterGroupAttribute;
   using value_type = ClusterNative;
 
-  static bool sortComparison(const ClusterNative& a, const ClusterNative& b)
-  {
-    if (a.getTimePacked() != b.getTimePacked()) {
-      return (a.getTimePacked() < b.getTimePacked());
-    } else {
-      return (a.padPacked < b.padPacked);
-    }
-  }
-
   size_t getFlatSize() const { return sizeof(attribute_type) + clusters.size() * sizeof(value_type); }
 
   const value_type* data() const { return clusters.data(); }
@@ -61,6 +52,27 @@ struct ClusterNativeContainer : public ClusterGroupAttribute {
   value_type* data() { return clusters.data(); }
 
   std::vector<ClusterNative> clusters;
+};
+
+/// @struct ClusterNativeBuffer
+/// Contiguous buffer for a collection of ClusterNative objects
+/// belonging to a row.
+/// The struct inherits the sector, globalPadRow, and nClusters members from the property
+/// ClusterGroupHeader.
+///
+/// Used for messages
+///
+struct ClusterNativeBuffer : public ClusterGroupHeader {
+  using attribute_type = ClusterGroupHeader;
+  using value_type = ClusterNative;
+
+  size_t getFlatSize() const { return sizeof(attribute_type) + nClusters * sizeof(value_type); }
+
+  const value_type* data() const { return clusters; }
+
+  value_type* data() { return clusters; }
+
+  value_type clusters[0];
 };
 
 /// @class ClusterNativeHelper utility class for TPC native clusters

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/HardwareClusterDecoder.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/HardwareClusterDecoder.h
@@ -25,31 +25,70 @@ namespace o2
 namespace TPC
 {
 class ClusterHardwareContainer;
+class MCCompLabel;
+namespace dataformats
+{
+template <typename TruthElement>
+class MCTruthContainer;
 }
-}
 
-namespace o2 { namespace dataformats { template <typename TruthElement> class MCTruthContainer; } class MCCompLabel; }
-
-namespace o2 { namespace TPC {
-
-//Class to convert a list of input buffers containing TPC clusters of type ClusterHardware to type ClusterNative.
+/// @class HardwareClusterDecoder
+/// @brief Class to convert a list of input buffers containing TPC clusters of type ClusterHardware
+/// to type ClusterNative.
+///
+/// This class transforms the hardware cluster raw format to the native cluster format. The output is
+/// organized in blocks per sector-padrow, the sequence of cluster blocks is stored in a flat structure.
+/// Cluster blocks consist of the property header ClusterGroupHeader with members sector, globalPadrow
+/// and nClusters, and the clusters following.
+///
+/// An allocator needs to be provided to allocate a char buffer of specified size from the decoding,
+/// function the cluster blocks are initialized inside the provided binary buffer.
+///
+/// Usage:
+///
+///     HardwareClusterDecoder decoder;
+///     std::vector<char> outputBuffer;
+///     auto outputAllocator = [&outputBuffer](size_t size) -> char* {
+///       outputBuffer.resize(size);
+///       return outputBuffer.data();
+///     }
+///     decoder( {pointer, n}, outputAllocator, &mcIn, &mcOut);
+///
+/// FIXME: The class should be in principle stateless, but right now it has an instance of the
+/// integrator for the digittal currents.
 class HardwareClusterDecoder
 {
 public:
   HardwareClusterDecoder() = default;
   ~HardwareClusterDecoder() = default;
 
+  /// @brief Allocator function object to provide the output buffer
   using OutputAllocator = std::function<char*(size_t)>;
 
+  /// @brief Decode clusters provided in raw pages
+  /// The function uses an allocator object to request a raw char buffer of needed size. Inside this buffer,
+  /// flat structures of type ClusterNativeBuffer are initialized, each block starting with a property header
+  /// containing also the number of clusters immediately following the the property header.
+  ///
+  /// @param inputClusters   list of input pages, each entry a pair of pointer to first page and number of pages
+  /// @param outputAllocator allocator object to provide the output buffer of specified size
+  /// @param inMCLabels      optional pointer to MC label container
+  /// @param outMCLabels     optional pointer to MC output container
   int decodeClusters(std::vector<std::pair<const o2::TPC::ClusterHardwareContainer*, std::size_t>>& inputClusters,
                      OutputAllocator outputAllocator,
                      const std::vector<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>* inMCLabels = nullptr,
                      std::vector<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>* outMCLabels = nullptr);
-  static void sortClustersAndMC(ClusterNative* clusters, size_t nClusters, MCLabelContainer mcTruth);
+
+  /// @brief Sort clusters and MC labels in place
+  /// ClusterNative defines the smaller-than relation used in the sorting, with time being the more significant
+  /// condition in the comparison.
+  static void sortClustersAndMC(ClusterNative* clusters, size_t nClusters,
+                                o2::dataformats::MCTruthContainer<o2::MCCompLabel> mcTruth);
 
  private:
   std::unique_ptr<DigitalCurrentClusterIntegrator> mIntegrator;
 };
 
-}}
+} // namespace TPC
+} // namespace o2
 #endif

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/HardwareClusterDecoder.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/HardwareClusterDecoder.h
@@ -15,6 +15,7 @@
 #define ALICEO2_TPC_HARDWARECLUSTERDECODER_H_
 
 #include <vector>
+#include <functional>
 #include "TPCReconstruction/DigitalCurrentClusterIntegrator.h"
 #include "DataFormatsTPC/ClusterNative.h"
 #include "DataFormatsTPC/ClusterNativeHelper.h"
@@ -38,12 +39,13 @@ public:
   HardwareClusterDecoder() = default;
   ~HardwareClusterDecoder() = default;
 
+  using OutputAllocator = std::function<char*(size_t)>;
+
   int decodeClusters(std::vector<std::pair<const o2::TPC::ClusterHardwareContainer*, std::size_t>>& inputClusters,
-                     std::vector<o2::TPC::ClusterNativeContainer>& outputClusters,
+                     OutputAllocator outputAllocator,
                      const std::vector<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>* inMCLabels = nullptr,
                      std::vector<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>* outMCLabels = nullptr);
-  static void sortClustersAndMC(std::vector<o2::TPC::ClusterNative> clusters,
-                                o2::dataformats::MCTruthContainer<o2::MCCompLabel> mcTruth);
+  static void sortClustersAndMC(ClusterNative* clusters, size_t nClusters, MCLabelContainer mcTruth);
 
  private:
   std::unique_ptr<DigitalCurrentClusterIntegrator> mIntegrator;

--- a/Detectors/TPC/reconstruction/src/HardwareClusterDecoder.cxx
+++ b/Detectors/TPC/reconstruction/src/HardwareClusterDecoder.cxx
@@ -19,6 +19,7 @@
 #include "TPCBase/Mapper.h"
 #include <algorithm>
 #include <vector>
+#include <numeric> // std::iota
 #include "FairLogger.h"
 
 #include "SimulationDataFormat/MCTruthContainer.h"
@@ -31,16 +32,18 @@ using namespace o2::TPC;
 using namespace o2;
 using namespace o2::dataformats;
 
-int HardwareClusterDecoder::decodeClusters(std::vector<std::pair<const ClusterHardwareContainer*, std::size_t>>& inputClusters, std::vector<ClusterNativeContainer>& outputClusters, const std::vector<MCLabelContainer>* inMCLabels, std::vector<MCLabelContainer>* outMCLabels)
+int HardwareClusterDecoder::decodeClusters(std::vector<std::pair<const ClusterHardwareContainer*, std::size_t>>& inputClusters, HardwareClusterDecoder::OutputAllocator outputAllocator, const std::vector<MCLabelContainer>* inMCLabels, std::vector<MCLabelContainer>* outMCLabels)
 {
   if (mIntegrator == nullptr) mIntegrator.reset(new DigitalCurrentClusterIntegrator);
   if (!inMCLabels) outMCLabels = nullptr;
+  std::vector<ClusterNativeBuffer*> outputBufferMap;
   int nRowClusters[Constants::MAXSECTOR][Constants::MAXGLOBALPADROW] = {0};
   int containerRowCluster[Constants::MAXSECTOR][Constants::MAXGLOBALPADROW] =  {0};
   Mapper& mapper = Mapper::instance();
   int numberOfOutputContainers = 0;
   for (int loop = 0;loop < 2;loop++)
   {
+    int nTotalClusters = 0;
     for (int i = 0;i < inputClusters.size();i++)
     {
       if (outMCLabels && inputClusters[i].second > 1)
@@ -66,7 +69,7 @@ int HardwareClusterDecoder::decodeClusters(std::vector<std::pair<const ClusterHa
           {
             //Fill cluster in the respective output buffer
             const ClusterHardware& cIn = cont.clusters[k];
-            ClusterNative& cOut = outputClusters[containerRowCluster[sector][padRowGlobal]].clusters[nCls];
+            ClusterNative& cOut = outputBufferMap[containerRowCluster[sector][padRowGlobal]]->clusters[nCls];
             float pad = cIn.getPad();
             cOut.setPad(pad);
             cOut.setTimeFlags(cIn.getTimeLocal() + cont.timeBinOffset, cIn.getFlags());
@@ -89,58 +92,69 @@ int HardwareClusterDecoder::decodeClusters(std::vector<std::pair<const ClusterHa
             if (nCls == 0) numberOfOutputContainers++;
           }
           nCls++;
+          nTotalClusters++;
         }
       }
     }
     if (loop == 1)
     {
       //We are done with filling the buffers, sort all output buffers
-      for (int i = 0;i < outputClusters.size();i++)
-      {
+      for (int i = 0; i < outputBufferMap.size(); i++) {
         if (outMCLabels) {
-          sortClustersAndMC(outputClusters[i].clusters, (*outMCLabels)[i]);
+          sortClustersAndMC(outputBufferMap[i]->clusters, outputBufferMap[i]->nClusters, (*outMCLabels)[i]);
         } else {
-          auto& cl = outputClusters[i].clusters;
-          std::sort(cl.data(), cl.data() + cl.size(), ClusterNativeContainer::sortComparison);
+          auto* cl = outputBufferMap[i]->clusters;
+          std::sort(cl, cl + outputBufferMap[i]->nClusters);
         }
       }
     }
     else
     {
       //Now we know the size of all output buffers, allocate them
-      outputClusters.resize(numberOfOutputContainers);
       if (outMCLabels) outMCLabels->resize(numberOfOutputContainers);
+      size_t rawOutputBufferSize = numberOfOutputContainers * sizeof(ClusterNativeBuffer) + nTotalClusters * sizeof(ClusterNative);
+      char* rawOutputBuffer = outputAllocator(rawOutputBufferSize);
+      char* rawOutputBufferIterator = rawOutputBuffer;
       numberOfOutputContainers = 0;
       for (int i = 0;i < Constants::MAXSECTOR;i++)
       {
         for (int j = 0;j < Constants::MAXGLOBALPADROW;j++)
         {
           if (nRowClusters[i][j] == 0) continue;
-          outputClusters[numberOfOutputContainers].clusters.resize(nRowClusters[i][j]);
-          outputClusters[numberOfOutputContainers].sector = i;
-          outputClusters[numberOfOutputContainers].globalPadRow = j;
+          outputBufferMap.push_back(reinterpret_cast<ClusterNativeBuffer*>(rawOutputBufferIterator));
+          ClusterNativeBuffer& container = *outputBufferMap.back();
+          container.sector = i;
+          container.globalPadRow = j;
+          container.nClusters = nRowClusters[i][j];
           containerRowCluster[i][j] = numberOfOutputContainers++;
+          rawOutputBufferIterator += container.getFlatSize();
           mIntegrator->initRow(i, j);
         }
       }
+      assert(rawOutputBufferIterator == rawOutputBuffer + rawOutputBufferSize);
       memset(nRowClusters, 0, sizeof(nRowClusters));
     }
   }
   return(0);
 }
 
-void HardwareClusterDecoder::sortClustersAndMC(std::vector<ClusterNative> clusters, MCLabelContainer mcTruth)
+void HardwareClusterDecoder::sortClustersAndMC(ClusterNative* clusters, size_t nClusters, MCLabelContainer mcTruth)
 {
-  std::vector<unsigned int> indizes(clusters.size());
-  for (int i = 0;i < indizes.size();i++) indizes[i] = i;
-  std::sort(indizes.data(), indizes.data() + indizes.size(), [&clusters](const auto a, const auto b) {
-    return ClusterNativeContainer::sortComparison(clusters[a], clusters[b]);
+  std::vector<unsigned int> indizes(nClusters);
+  std::iota(indizes.begin(), indizes.end(), 0);
+  std::sort(indizes.begin(), indizes.end(), [&clusters](const auto a, const auto b) {
+    return clusters[a] < clusters[b];
   });
-  std::vector<ClusterNative> tmpCl = std::move(clusters);
+  std::vector<unsigned int> actual = indizes;
   MCLabelContainer tmpMC = std::move(mcTruth);
-  for (int i = 0;i < clusters.size();i++)
-  {
-    clusters[i] = tmpCl[indizes[i]];
+  assert(mcTruth.getIndexedSize() == 0);
+  for (int i = 0; i < nClusters; i++) {
+    ClusterNative backup = clusters[i];
+    clusters[i] = clusters[actual[indizes[i]]];
+    clusters[actual[indizes[i]]] = backup;
+    auto tmp = actual[i];
+    actual[i] = actual[indizes[i]];
+    actual[indizes[i]] = tmp;
     gsl::span<const MCCompLabel> mcArray = tmpMC.getLabels(indizes[i]);
     for (int k = 0;k < mcArray.size();k++)
     {

--- a/Detectors/TPC/workflow/src/ClusterDecoderRawSpec.cxx
+++ b/Detectors/TPC/workflow/src/ClusterDecoderRawSpec.cxx
@@ -145,35 +145,21 @@ DataProcessorSpec getClusterDecoderRawSpec(bool sendMC)
       }
       // output of the decoder is sorted in (sector,globalPadRow) coordinates, individual
       // containers are created for clusters and MC labels per (sector,globalPadRow) address
-      std::vector<ClusterNativeContainer> cont;
+      char* outputBuffer = nullptr;
+      auto outputAllocator = [&pc, &fanSpec, &outputBuffer, &rawHeaderStack](size_t size) -> char* {
+        outputBuffer = pc.outputs().newChunk(Output{ gDataOriginTPC, DataDescription("CLUSTERNATIVE"), fanSpec, Lifetime::Timeframe, std::move(rawHeaderStack) }, size).data;
+        return outputBuffer;
+      };
       std::vector<MCLabelContainer> mcoutList;
-      decoder->decodeClusters(inputList, cont, (mcin ? &mcinCopies : nullptr), &mcoutList);
+      decoder->decodeClusters(inputList, outputAllocator, (mcin ? &mcinCopies : nullptr), &mcoutList);
 
-      // The output of clusters involves a copy to flatten the list of buffers and extend the
-      // ClusterGroupAttribute struct containing sector and globalPadRow by the size of the collection.
-      // FIXME: provide allocator to decoder to do the allocation in place, create ClusterGroupHeader
-      //        directly
-      // The vector of MC label containers is simply serialized
-      size_t totalSize = 0;
-      for (const auto& coll : cont) {
-        const auto& groupAttribute = static_cast<const ClusterGroupAttribute>(coll);
-        totalSize += coll.getFlatSize() + sizeof(ClusterGroupHeader) - sizeof(ClusterGroupAttribute);
-      }
+      // TODO: reestablish the logging messages on the raw buffer
+      // if (verbosity > 1) {
+      //   LOG(INFO) << "decoder " << std::setw(2) << sectorHeader->sector                             //
+      //             << ": decoded " << std::setw(4) << coll.clusters.size() << " clusters on sector " //
+      //             << std::setw(2) << (int)coll.sector << "[" << (int)coll.globalPadRow << "]";      //
+      // }
 
-      auto* target = pc.outputs().newChunk(Output{ gDataOriginTPC, DataDescription("CLUSTERNATIVE"), fanSpec, Lifetime::Timeframe, std::move(rawHeaderStack) }, totalSize).data;
-
-      for (const auto& coll : cont) {
-        if (verbosity > 1) {
-          LOG(INFO) << "decoder " << std::setw(2) << sectorHeader->sector                             //
-                    << ": decoded " << std::setw(4) << coll.clusters.size() << " clusters on sector " //
-                    << std::setw(2) << (int)coll.sector << "[" << (int)coll.globalPadRow << "]";      //
-        }
-        ClusterGroupHeader groupHeader(coll, coll.clusters.size());
-        memcpy(target, &groupHeader, sizeof(groupHeader));
-        target += sizeof(groupHeader);
-        memcpy(target, coll.data(), coll.getFlatSize() - sizeof(ClusterGroupAttribute));
-        target += coll.getFlatSize() - sizeof(ClusterGroupAttribute);
-      }
       if (!labelKey.empty()) {
         if (verbosity > 0) {
           LOG(INFO) << "sending " << mcoutList.size() << " MC label container(s) with in total "
@@ -198,6 +184,9 @@ DataProcessorSpec getClusterDecoderRawSpec(bool sendMC)
       };
       std::map<o2::header::DataHeader::SubSpecificationType, SectorInputDesc> inputs;
       for (auto const& inputRef : pc.inputs()) {
+        // loop over all inputs and associate data and mc channels by the subspecification. DPL makes sure that
+        // each origin/description/subspecification identifier is only once in the inputs, no other overwrite
+        // protection in the list of keys.
         auto const* dataHeader = DataRefUtils::getHeader<o2::header::DataHeader*>(inputRef);
         assert(dataHeader);
         if (dataHeader->dataOrigin == gDataOriginTPC && dataHeader->dataDescription == DataDescription("CLUSTERHW")) {


### PR DESCRIPTION
Defining also a helper struct to represent ClusterNative objects preceded by
a descriptive header struct in a flat buffer.

This changes the output of the cluster decoder to a flat buffer structure, the memory is allocated directly in the output message, or can be allocated by the custom allocator.