### PR TITLE
[DPL] Support for resizable DataChunk

### DIFF
--- a/Detectors/TPC/workflow/src/ClusterDecoderRawSpec.cxx
+++ b/Detectors/TPC/workflow/src/ClusterDecoderRawSpec.cxx
@@ -147,7 +147,7 @@ DataProcessorSpec getClusterDecoderRawSpec(bool sendMC)
       // containers are created for clusters and MC labels per (sector,globalPadRow) address
       char* outputBuffer = nullptr;
       auto outputAllocator = [&pc, &fanSpec, &outputBuffer, &rawHeaderStack](size_t size) -> char* {
-        outputBuffer = pc.outputs().newChunk(Output{ gDataOriginTPC, DataDescription("CLUSTERNATIVE"), fanSpec, Lifetime::Timeframe, std::move(rawHeaderStack) }, size).data;
+        outputBuffer = pc.outputs().newChunk(Output{ gDataOriginTPC, DataDescription("CLUSTERNATIVE"), fanSpec, Lifetime::Timeframe, std::move(rawHeaderStack) }, size).data();
         return outputBuffer;
       };
       std::vector<MCLabelContainer> mcoutList;

--- a/Framework/Core/include/Framework/DataAllocator.h
+++ b/Framework/Core/include/Framework/DataAllocator.h
@@ -78,11 +78,11 @@ class DataAllocator
                 ContextRegistry* contextes,
                 const AllowedOutputRoutes& routes);
 
-  DataChunk newChunk(const Output&, size_t);
+  DataChunk& newChunk(const Output&, size_t);
 
-  inline DataChunk newChunk(OutputRef&& ref, size_t size) { return newChunk(getOutputByBind(std::move(ref)), size); }
+  inline DataChunk& newChunk(OutputRef&& ref, size_t size) { return newChunk(getOutputByBind(std::move(ref)), size); }
 
-  DataChunk adoptChunk(const Output&, char*, size_t, fairmq_free_fn*, void*);
+  void adoptChunk(const Output&, char*, size_t, fairmq_free_fn*, void*);
 
   // In case no extra argument is provided and the passed type is trivially
   // copyable and non polymorphic, the most likely wanted behavior is to create
@@ -91,12 +91,12 @@ class DataAllocator
   typename std::enable_if<is_messageable<T>::value == true, T&>::type
     make(const Output& spec)
   {
-    DataChunk chunk = newChunk(spec, sizeof(T));
-    return *reinterpret_cast<T*>(chunk.data);
+    return *reinterpret_cast<T*>(newChunk(spec, sizeof(T)).data());
   }
 
   // In case an extra argument is provided, we consider this an array /
   // collection elements of that type
+  // FIXME: once the vector functionality with polymorphic allocator is fully in place, this might be dropped
   template <typename T>
   typename std::enable_if<is_messageable<T>::value == true, gsl::span<T>&>::type
     make(const Output& spec, size_t nElements)

--- a/Framework/Core/include/Framework/DataChunk.h
+++ b/Framework/Core/include/Framework/DataChunk.h
@@ -10,17 +10,15 @@
 #ifndef FRAMEWORK_DATACHUNK_H
 #define FRAMEWORK_DATACHUNK_H
 
+#include "MemoryResources/MemoryResources.h"
+
 namespace o2
 {
 namespace framework
 {
-
-/// Simple struct to hold a pointer to the actual FairMQMessage.
-/// In principle this could be an iovec...
-struct DataChunk {
-  char *data;
-  size_t size;
-};
+// FIXME: make sure that a DataChunk can not be copied or assigned, because the context returns the
+// object by reference and we have to make sure that the code is using the reference instead of a copy
+using DataChunk = std::vector<char, o2::pmr::polymorphic_allocator<char>>;
 
 } // namespace framework
 } // namespace o2

--- a/Framework/Core/include/Framework/DataChunk.h
+++ b/Framework/Core/include/Framework/DataChunk.h
@@ -16,11 +16,32 @@ namespace o2
 {
 namespace framework
 {
-// FIXME: make sure that a DataChunk can not be copied or assigned, because the context returns the
-// object by reference and we have to make sure that the code is using the reference instead of a copy
-using DataChunk = std::vector<char, o2::pmr::polymorphic_allocator<char>>;
+/// @class DataChunk A resizable buffer used with DPL's DataAllocator
+/// DataChunk derives from std::vector with polymorphic allocator and forbids copying, the underlying
+/// buffer is of type char and is through DPL and polymorphic memory resource directly allocated in the
+/// message memory.
+/// Since MessageContext returns the object by reference, the forbidden copy and assignment makes sure that
+/// the code can not accidentally use a copy instead reference.
+class DataChunk : public std::vector<char, o2::pmr::polymorphic_allocator<char>>
+{
+ public:
+  // FIXME: want to have a general forwarding, but then the copy constructor is not deleted any more despite
+  // it's declared deleted
+  //template <typename... Args>
+  //DataChunk(T&& arg, Args&&... args) : std::vector<char, o2::pmr::polymorphic_allocator<char>>(std::forward<Args>(args)...)
+  //{
+  //}
+
+  // DataChunk is special and for the moment it's enough to declare the constructor with size and allocator
+  DataChunk(size_t size, const o2::pmr::polymorphic_allocator<char>& allocator) : std::vector<char, o2::pmr::polymorphic_allocator<char>>(size, allocator)
+  {
+  }
+  DataChunk(const DataChunk&) = delete;
+  DataChunk& operator=(const DataChunk&) = delete;
+  DataChunk(DataChunk&&) = default;
+  DataChunk& operator=(DataChunk&&) = default;
+};
 
 } // namespace framework
 } // namespace o2
-
 #endif // FRAMEWORK_DATACHUNK_H

--- a/Framework/Core/src/DataAllocator.cxx
+++ b/Framework/Core/src/DataAllocator.cxx
@@ -70,7 +70,7 @@ DataChunk& DataAllocator::newChunk(const Output& spec, size_t size)
                                                            o2::header::gSerializationMethodNone, //
                                                            size                                  //
                                                            );
-  auto& co = context->add<MessageContext::VectorObject<DataChunk::value_type>>(std::move(headerMessage), channel, 0, size);
+  auto& co = context->add<MessageContext::ContainerRefObject<DataChunk>>(std::move(headerMessage), channel, 0, size);
   return co;
 }
 

--- a/Framework/Core/src/DataProcessor.cxx
+++ b/Framework/Core/src/DataProcessor.cxx
@@ -34,11 +34,10 @@ namespace framework
 void DataProcessor::doSend(FairMQDevice &device, MessageContext &context) {
   for (auto &message : context) {
     //     monitoringService.send({ message->parts.Size(), "outputs/total" });
-    assert(message->parts.Size() == 2);
-    FairMQParts parts = std::move(message->parts);
-    assert(message->parts.Size() == 0);
+    FairMQParts parts = std::move(message->finalize());
+    assert(message->empty());
     assert(parts.Size() == 2);
-    device.Send(parts, message->channel, 0);
+    device.Send(parts, message->channel(), 0);
     assert(parts.Size() == 2);
   }
 }

--- a/Framework/Core/src/Dispatcher.cxx
+++ b/Framework/Core/src/Dispatcher.cxx
@@ -84,8 +84,8 @@ void Dispatcher::send(DataAllocator& dataAllocator, const DataRef& inputData, co
     dataAllocator.adopt(output, DataRefUtils::as<TObject>(inputData).release());
   } else { // POD
     // todo: do it non-copy, when API is available
-    auto outputMessage = dataAllocator.newChunk(output, inputHeader->payloadSize);
-    memcpy(outputMessage.data, inputData.payload, inputHeader->payloadSize);
+    auto& outputMessage = dataAllocator.newChunk(output, inputHeader->payloadSize);
+    memcpy(outputMessage.data(), inputData.payload, inputHeader->payloadSize);
   }
 }
 

--- a/Framework/Core/test/test_DataAllocator.cxx
+++ b/Framework/Core/test/test_DataAllocator.cxx
@@ -107,6 +107,14 @@ DataProcessorSpec getSourceSpec()
     auto freefct = [](void* data, void* hint) {}; // simply ignore the cleanup for the test
     static std::string teststring = "adoptchunk";
     pc.outputs().adoptChunk(Output{ "TST", "ADOPTCHUNK", 0, Lifetime::Timeframe }, teststring.data(), teststring.length(), freefct, nullptr);
+    // test resizable data chunk, initial size 0 and grow
+    auto& growchunk = pc.outputs().newChunk(OutputRef{ "growchunk", 0 }, 0);
+    growchunk.resize(sizeof(o2::test::TriviallyCopyable));
+    memcpy(growchunk.data(), &a, sizeof(o2::test::TriviallyCopyable));
+    // test resizable data chunk, large initial size and shrink
+    auto& shrinkchunk = pc.outputs().newChunk(OutputRef{ "shrinkchunk", 0 }, 1000000);
+    shrinkchunk.resize(sizeof(o2::test::TriviallyCopyable));
+    memcpy(shrinkchunk.data(), &a, sizeof(o2::test::TriviallyCopyable));
   };
 
   return DataProcessorSpec{ "source", // name of the processor
@@ -114,6 +122,8 @@ DataProcessorSpec getSourceSpec()
                             { OutputSpec{ "TST", "MESSAGEABLE", 0, Lifetime::Timeframe },
                               OutputSpec{ { "makesingle" }, "TST", "MAKESINGLE", 0, Lifetime::Timeframe },
                               OutputSpec{ { "makespan" }, "TST", "MAKESPAN", 0, Lifetime::Timeframe },
+                              OutputSpec{ { "growchunk" }, "TST", "GROWCHUNK", 0, Lifetime::Timeframe },
+                              OutputSpec{ { "shrinkchunk" }, "TST", "SHRINKCHUNK", 0, Lifetime::Timeframe },
                               OutputSpec{ "TST", "ADOPTCHUNK", 0, Lifetime::Timeframe },
                               OutputSpec{ "TST", "MSGBLEROOTSRLZ", 0, Lifetime::Timeframe },
                               OutputSpec{ "TST", "ROOTNONTOBJECT", 0, Lifetime::Timeframe },
@@ -143,8 +153,10 @@ DataProcessorSpec getSinkSpec()
       dumpStack(dh);
     }
     // plain, unserialized object in input1 channel
+    LOG(INFO) << "extracting o2::test::TriviallyCopyable from input1";
     auto object1 = pc.inputs().get<o2::test::TriviallyCopyable>("input1");
     ASSERT_ERROR(object1 == o2::test::TriviallyCopyable(42, 23, 0xdead));
+    LOG(INFO) << "extracting span of o2::test::TriviallyCopyable from input1";
     auto object1span = pc.inputs().get<gsl::span<o2::test::TriviallyCopyable>>("input1");
     ASSERT_ERROR(object1span.size() == 1);
     ASSERT_ERROR(sizeof(typename decltype(object1span)::value_type) == sizeof(o2::test::TriviallyCopyable));
@@ -157,49 +169,66 @@ DataProcessorSpec getSinkSpec()
     ASSERT_ERROR(metaHeader2 != nullptr && metaHeader2->secret == 23);
 
     // ROOT-serialized messageable object in input2 channel
+    LOG(INFO) << "extracting o2::test::TriviallyCopyable pointer from input2";
     auto object2 = pc.inputs().get<o2::test::TriviallyCopyable*>("input2");
     ASSERT_ERROR(object2 != nullptr);
     ASSERT_ERROR(*object2 == o2::test::TriviallyCopyable(42, 23, 0xdead));
 
     // ROOT-serialized, non-messageable object in input3 channel
+    LOG(INFO) << "extracting o2::test::Polymorphic pointer from input3";
     auto object3 = pc.inputs().get<o2::test::Polymorphic*>("input3");
     ASSERT_ERROR(object3 != nullptr);
     ASSERT_ERROR(*object3 == o2::test::Polymorphic(0xbeef));
 
     // container of objects
+    LOG(INFO) << "extracting vector of o2::test::Polymorphic from input4";
     auto object4 = pc.inputs().get<std::vector<o2::test::Polymorphic>>("input4");
     ASSERT_ERROR(object4.size() == 2);
     ASSERT_ERROR(object4[0] == o2::test::Polymorphic(0xaffe));
     ASSERT_ERROR(object4[1] == o2::test::Polymorphic(0xd00f));
 
     // container of objects
+    LOG(INFO) << "extracting vector of o2::test::Polymorphic from input5";
     auto object5 = pc.inputs().get<std::vector<o2::test::Polymorphic>>("input5");
     ASSERT_ERROR(object5.size() == 2);
     ASSERT_ERROR(object5[0] == o2::test::Polymorphic(0xaffe));
     ASSERT_ERROR(object5[1] == o2::test::Polymorphic(0xd00f));
 
     // container of objects
+    LOG(INFO) << "extracting vector of o2::test::Polymorphic from input6";
     auto object6 = pc.inputs().get<std::vector<o2::test::Polymorphic>>("input6");
     ASSERT_ERROR(object6.size() == 2);
     ASSERT_ERROR(object6[0] == o2::test::Polymorphic(0xaffe));
     ASSERT_ERROR(object6[1] == o2::test::Polymorphic(0xd00f));
 
     // checking retrieving buffer as raw char*, and checking content by cast
+    LOG(INFO) << "extracting raw char* from input1";
     auto rawchar = pc.inputs().get<const char*>("input1");
     const auto& data1 = *reinterpret_cast<const o2::test::TriviallyCopyable*>(rawchar);
     ASSERT_ERROR(data1 == o2::test::TriviallyCopyable(42, 23, 0xdead));
 
+    LOG(INFO) << "extracting o2::test::TriviallyCopyable from input7";
     auto object7 = pc.inputs().get<o2::test::TriviallyCopyable>("input7");
     ASSERT_ERROR(object1 == o2::test::TriviallyCopyable(42, 23, 0xdead));
 
+    LOG(INFO) << "extracting span of o2::test::TriviallyCopyable from input8";
     auto objectspan8 = DataRefUtils::as<o2::test::TriviallyCopyable>(pc.inputs().get("input8"));
     ASSERT_ERROR(objectspan8.size() == 3);
     for (auto const& object8 : objectspan8) {
       ASSERT_ERROR(object8 == o2::test::TriviallyCopyable(42, 23, 0xdead));
     }
 
+    LOG(INFO) << "extracting std::string from input9";
     auto object9 = pc.inputs().get<std::string>("input9");
     ASSERT_ERROR(object9 == "adoptchunk");
+
+    LOG(INFO) << "extracting o2::test::TriviallyCopyable from input10";
+    auto object10 = pc.inputs().get<o2::test::TriviallyCopyable>("input10");
+    ASSERT_ERROR(object10 == o2::test::TriviallyCopyable(42, 23, 0xdead));
+
+    LOG(INFO) << "extracting o2::test::TriviallyCopyable from input11";
+    auto object11 = pc.inputs().get<o2::test::TriviallyCopyable>("input11");
+    ASSERT_ERROR(object11 == o2::test::TriviallyCopyable(42, 23, 0xdead));
 
     pc.services().get<ControlService>().readyToQuit(true);
   };
@@ -213,7 +242,9 @@ DataProcessorSpec getSinkSpec()
                               InputSpec{ "input6", "TST", "ROOTSERLZDVEC2", 0, Lifetime::Timeframe },
                               InputSpec{ "input7", "TST", "MAKESINGLE", 0, Lifetime::Timeframe },
                               InputSpec{ "input8", "TST", "MAKESPAN", 0, Lifetime::Timeframe },
-                              InputSpec{ "input9", "TST", "ADOPTCHUNK", 0, Lifetime::Timeframe } },
+                              InputSpec{ "input9", "TST", "ADOPTCHUNK", 0, Lifetime::Timeframe },
+                              InputSpec{ "input10", "TST", "GROWCHUNK", 0, Lifetime::Timeframe },
+                              InputSpec{ "input11", "TST", "SHRINKCHUNK", 0, Lifetime::Timeframe } },
                             Outputs{},
                             AlgorithmSpec(processingFct) };
 }

--- a/Framework/Core/test/test_SimpleStatefulProcessing01.cxx
+++ b/Framework/Core/test/test_SimpleStatefulProcessing01.cxx
@@ -52,8 +52,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const&) {
             callbacks.set(CallbackService::Id::Stop, stopcb);
             callbacks.set(CallbackService::Id::Reset, resetcb);
             return adaptStateless([](DataAllocator& outputs) {
-              auto out = outputs.newChunk({ "TES", "STATEFUL", 0 }, sizeof(int));
-              auto outI = reinterpret_cast<int*>(out.data);
+              auto& out = outputs.newChunk({ "TES", "STATEFUL", 0 }, sizeof(int));
+              auto outI = reinterpret_cast<int*>(out.data());
               outI[0] = foo++;
             });
           }) //

--- a/Framework/Utils/src/DPLBroadcaster.cxx
+++ b/Framework/Utils/src/DPLBroadcaster.cxx
@@ -47,8 +47,8 @@ o2f::DataProcessorSpec defineBroadcaster(std::string devName, o2f::InputSpec usr
                auto msgSize = (*funcPtr)(inputMsg);
                // Iterating over the OutputSpecs to push the input message to all the output destinations
                for (const auto& itOutputs : (*outputsPtr)) {
-                 auto fwdMsg = ctx.outputs().newChunk(itOutputs, msgSize);
-                 std::memcpy(fwdMsg.data, inputMsg.payload, msgSize);
+                 auto& fwdMsg = ctx.outputs().newChunk(itOutputs, msgSize);
+                 std::memcpy(fwdMsg.data(), inputMsg.payload, msgSize);
                }
              };
            } } };

--- a/Framework/Utils/src/DPLGatherer.cxx
+++ b/Framework/Utils/src/DPLGatherer.cxx
@@ -42,9 +42,9 @@ o2f::DataProcessorSpec defineGatherer(std::string devName, o2f::Inputs usrInputs
                  // Retrieving message size from API
                  auto msgSize = (o2::header::get<o2::header::DataHeader*>(itInputs.header))->payloadSize;
                  // Allocating new chunk
-                 auto fwdMsg = ctx.outputs().newChunk((*outputPtr), msgSize);
+                 auto& fwdMsg = ctx.outputs().newChunk((*outputPtr), msgSize);
                  // Moving the input to the output chunk
-                 std::memmove(fwdMsg.data, itInputs.payload, msgSize);
+                 std::memmove(fwdMsg.data(), itInputs.payload, msgSize);
                }
              };
            } } };

--- a/Framework/Utils/src/DPLRouter.cxx
+++ b/Framework/Utils/src/DPLRouter.cxx
@@ -42,8 +42,8 @@ o2f::DataProcessorSpec defineRouter(std::string devName, o2f::Inputs usrInput, o
                auto msgSize = (o2::header::get<o2::header::DataHeader*>(inputMsg.header))->payloadSize;
                auto& outputCh = (*outputsPtr)[(*mappingFuncPtr)(inputMsg)];
 
-               auto fwdMsg = ctx.outputs().newChunk(outputCh, msgSize);
-               std::memcpy(fwdMsg.data, inputMsg.payload, msgSize);
+               auto& fwdMsg = ctx.outputs().newChunk(outputCh, msgSize);
+               std::memcpy(fwdMsg.data(), inputMsg.payload, msgSize);
              };
            } } };
 }

--- a/Framework/Utils/test/DPLBroadcasterMerger.cxx
+++ b/Framework/Utils/test/DPLBroadcasterMerger.cxx
@@ -49,12 +49,12 @@ o2f::DataProcessorSpec defineGenerator(o2f::OutputSpec usrOutput)
 
                LOG(INFO) << ">>> Preparing MSG:" << msgIndex;
 
-               auto outputMsg =
+               auto& outputMsg =
                  ctx.outputs().newChunk(*usrOutput_shptr, (msgIndex + 1) * sizeof(uint32_t) / sizeof(char));
 
                LOG(INFO) << ">>> Preparing1 MSG:" << msgIndex;
 
-               auto payload = reinterpret_cast<uint32_t*>(outputMsg.data);
+               auto payload = reinterpret_cast<uint32_t*>(outputMsg.data());
 
                payload[0] = msgIndex;
 
@@ -82,8 +82,8 @@ o2f::DataProcessorSpec definePipeline(std::string devName, o2f::InputSpec usrInp
                auto inputMsg = ctx.inputs().getByPos(0);
                auto msgSize = (o2::header::get<o2::header::DataHeader*>(inputMsg.header))->payloadSize;
 
-               auto fwdMsg = ctx.outputs().newChunk((*output_sharedptr), msgSize);
-               std::memcpy(fwdMsg.data, inputMsg.payload, msgSize);
+               auto& fwdMsg = ctx.outputs().newChunk((*output_sharedptr), msgSize);
+               std::memcpy(fwdMsg.data(), inputMsg.payload, msgSize);
              };
            } } };
 }

--- a/Framework/Utils/test/DPLOutputTest.cxx
+++ b/Framework/Utils/test/DPLOutputTest.cxx
@@ -43,12 +43,12 @@ o2f::DataProcessorSpec defineTestGenerator()
 
                LOG(INFO) << ">>> Preparing MSG:" << msgIndex;
 
-               auto outputMsg = ctx.outputs().newChunk({ "TST", "ToSink", 0, o2f::Lifetime::Timeframe },
-                                                       (31 + 1) * sizeof(uint32_t) / sizeof(char));
+               auto& outputMsg = ctx.outputs().newChunk({ "TST", "ToSink", 0, o2f::Lifetime::Timeframe },
+                                                        (31 + 1) * sizeof(uint32_t) / sizeof(char));
 
                LOG(INFO) << ">>> Preparing1 MSG:" << msgIndex;
 
-               auto payload = reinterpret_cast<uint32_t*>(outputMsg.data);
+               auto payload = reinterpret_cast<uint32_t*>(outputMsg.data());
 
                payload[0] = msgIndex;
 


### PR DESCRIPTION
Change `DataChunk` to be `std::vector<char, o2::pmr::polymorphic_allocator>`

Interface changes:
- makeChunk returns reference to vector object
- return value of adoptChunk is dropped, has not been used

This goes in line with the general idea of DataAllocator's `make` methods, where the
object is booked with one single call and is send automatically after processing ends. 
Requires return by reference and to use a reference variable in the code. The disadvantage
is that accidental copy is possible and impossible to detect at compile time.

Details:
Introducing VectorObject to MessageContext, holding an instance of an o2::vector.
The memory is directly allocated in the message memory using the pmr functionality.
In order to avoid that objects go out of scope and the allocated buffer is available
at send, the created vector can not be returned by move, but is kept in the context
and returned by reference. This requires changes in the code to use the reference
instead of a copy.

The return value of adoptChunk must be dropped because a buffer can only be adopted
to a vector object using a special allocator. With this it can not simply be returned
as it is a different type. Using polymorphic_allocator even for trivially default
constructible types still invokes the constructor for the elements, thus changing
the memory of the underlying resource.

TODO:
- [x] adjust payload size in `DataHeader` before sending
- [x] add unit test for resizable chunk
- [x] use `std::vector` with `polymorphic_allocator` in favor of `o2::vector`
- [x] make sure that result of `makeChunk` is not copied to local variable - **not in this PR** requires more effort, see https://github.com/AliceO2Group/AliceO2/pull/1846#issuecomment-480246198
- [x] add specialization of `make` for `o2::vector<T>` - **not in this PR**
