### PR TITLE
Fix namespace naming: o2::Data

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/PrimaryChunk.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/PrimaryChunk.h
@@ -16,7 +16,7 @@
 
 namespace o2
 {
-namespace Data
+namespace data
 {
 
 // structure describing an entity of work

--- a/DataFormats/simulation/include/SimulationDataFormat/Stack.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/Stack.h
@@ -39,7 +39,7 @@ namespace base
 class Detector;
 }
 
-namespace Data
+namespace data
 {
 /// This class handles the particle stack for the transport simulation.
 /// For the stack FILO functunality, it uses the STL stack. To store

--- a/DataFormats/simulation/src/SimulationDataLinkDef.h
+++ b/DataFormats/simulation/src/SimulationDataLinkDef.h
@@ -22,7 +22,7 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
-#pragma link C++ class o2::Data::Stack + ;
+#pragma link C++ class o2::data::Stack + ;
 #pragma link C++ class o2::sim::StackParam+;
 #pragma link C++ class o2::conf::ConfigurableParamHelper<o2::sim::StackParam>+;
 #pragma link C++ class o2::MCTrackT < double > +;
@@ -48,9 +48,9 @@
 #pragma link C++ class std::vector<o2::TrackReference>+;
 #pragma link C++ class o2::dataformats::MCTruthContainer<o2::TrackReference>+;
 
-#pragma link C++ struct o2::Data::SubEventInfo+;
-#pragma link C++ class std::vector<o2::Data::SubEventInfo>+;
-#pragma link C++ struct o2::Data::PrimaryChunk+;
+#pragma link C++ struct o2::data::SubEventInfo+;
+#pragma link C++ class std::vector<o2::data::SubEventInfo>+;
+#pragma link C++ struct o2::data::PrimaryChunk+;
 
 #pragma link C++ class o2::steer::RunContext + ;
 #pragma link C++ class o2::steer::EventPart + ;

--- a/DataFormats/simulation/src/Stack.cxx
+++ b/DataFormats/simulation/src/Stack.cxx
@@ -36,7 +36,7 @@
 using std::cout;
 using std::endl;
 using std::pair;
-using namespace o2::Data;
+using namespace o2::data;
 
 // small helper function to append to vector at arbitrary position
 template <typename T, typename I>
@@ -642,5 +642,5 @@ void Stack::fillParentIDs(std::vector<int>& parentids) const
   } while (mother != -1);
 }
 
-FairGenericStack* Stack::CloneStack() const { return new o2::Data::Stack(*this); }
-ClassImp(o2::Data::Stack)
+FairGenericStack* Stack::CloneStack() const { return new o2::data::Stack(*this); }
+ClassImp(o2::data::Stack)

--- a/DataFormats/simulation/test/MCTrack.cxx
+++ b/DataFormats/simulation/test/MCTrack.cxx
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(MCTrack_test)
 // unit tests on stack
 BOOST_AUTO_TEST_CASE(Stack_test)
 {
-  o2::Data::Stack st;
+  o2::data::Stack st;
   int a;
   TMCProcess proc;
   // add a 2 primary particles
@@ -86,7 +86,7 @@ BOOST_AUTO_TEST_CASE(Stack_test)
   }
 
   {
-    o2::Data::Stack* inst = nullptr;
+    o2::data::Stack* inst = nullptr;
     TFile f("StackOut.root", "OPEN");
     f.GetObject("Stack", inst);
     BOOST_CHECK(inst->getPrimaries().size() == 2);

--- a/Detectors/EMCAL/simulation/src/Detector.cxx
+++ b/Detectors/EMCAL/simulation/src/Detector.cxx
@@ -172,7 +172,7 @@ Bool_t Detector::ProcessHits(FairVolume* v)
     lightyield = CalculateLightYield(eloss, fMC->TrackStep(), fMC->TrackCharge());
   lightyield /= geom->GetSampling();
 
-  auto o2stack = static_cast<o2::Data::Stack*>(fMC->GetStack());
+  auto o2stack = static_cast<o2::data::Stack*>(fMC->GetStack());
   const bool isDaughterOfSeenTrack = o2stack->isTrackDaughterOf(partID, mCurrentTrackID);
   if (!isDaughterOfSeenTrack || detID != mCurrentCellID || !mCurrentHit) {
     // Condition for new hit:

--- a/Detectors/FIT/T0/simulation/src/Detector.cxx
+++ b/Detectors/FIT/T0/simulation/src/Detector.cxx
@@ -312,7 +312,7 @@ Bool_t Detector::ProcessHits(FairVolume* v)
 o2::fit::HitType* Detector::AddHit(float x, float y, float z, float time, float energy, Int_t trackId, Int_t detId)
 {
   mHits->emplace_back(x, y, z, time, energy, trackId, detId);
-  auto stack = (o2::Data::Stack*)fMC->GetStack();
+  auto stack = (o2::data::Stack*)fMC->GetStack();
   stack->addHit(GetDetId());
   return &(mHits->back());
 }

--- a/Detectors/FIT/V0/simulation/src/Detector.cxx
+++ b/Detectors/FIT/V0/simulation/src/Detector.cxx
@@ -147,7 +147,7 @@ o2::v0::Hit* Detector::addHit(Int_t trackId, Int_t cellId, Int_t particleId,
 {
 
   mHits->emplace_back(trackId, cellId, startPos, endPos, startMom, startE, endTime, eLoss, eTot, eDep);
-  auto stack = (o2::Data::Stack*)fMC->GetStack();
+  auto stack = (o2::data::Stack*)fMC->GetStack();
   stack->addHit(GetDetId());
   return &(mHits->back());
 }

--- a/Detectors/HMPID/simulation/src/Detector.cxx
+++ b/Detectors/HMPID/simulation/src/Detector.cxx
@@ -53,7 +53,7 @@ void Detector::InitializeO2Detector()
 bool Detector::ProcessHits(FairVolume* v)
 {
   TString volname = fMC->CurrentVolName();
-  auto stack = (o2::Data::Stack*)fMC->GetStack();
+  auto stack = (o2::data::Stack*)fMC->GetStack();
 
   //Treat photons
   //photon (Ckov or feedback) hits on module PC (Hpad)

--- a/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
@@ -276,7 +276,7 @@ Bool_t Detector::ProcessHits(FairVolume* vol)
     return kFALSE; // RS: can this happen? This method must be called for sensors only?
 
   // Is it needed to keep a track reference when the outer ITS volume is encountered?
-  auto stack = (o2::Data::Stack*)fMC->GetStack();
+  auto stack = (o2::data::Stack*)fMC->GetStack();
   if (fMC->IsTrackExiting() && (lay == 0 || lay == 6)) {
     // Keep the track refs for the innermost and outermost layers only
     o2::TrackReference tr(*fMC, GetDetId());

--- a/Detectors/ITSMFT/MFT/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/MFT/simulation/src/Detector.cxx
@@ -182,7 +182,7 @@ Bool_t Detector::ProcessHits(FairVolume* vol)
                     mTrackData.mMomentumStart.Vect(), mTrackData.mMomentumStart.E(), positionStop.T(),
                     mTrackData.mEnergyLoss, mTrackData.mTrkStatusStart, status);
 
-    o2::Data::Stack* stack = (o2::Data::Stack*)fMC->GetStack();
+    o2::data::Stack* stack = (o2::data::Stack*)fMC->GetStack();
     stack->addHit(GetDetId());
   }
 

--- a/Detectors/MUON/MCH/Simulation/src/Stepper.cxx
+++ b/Detectors/MUON/MCH/Simulation/src/Stepper.cxx
@@ -39,7 +39,7 @@ void Stepper::process(const TVirtualMC& vmc)
   int detElemId;
   vmc.CurrentVolOffID(2, detElemId); // go up 2 levels in the hierarchy to get the DE
 
-  auto stack = static_cast<o2::Data::Stack*>(vmc.GetStack());
+  auto stack = static_cast<o2::data::Stack*>(vmc.GetStack());
 
   if (t.isEntering() || t.isExiting()) {
     // generate a track referenced

--- a/Detectors/MUON/MID/Simulation/src/Stepper.cxx
+++ b/Detectors/MUON/MID/Simulation/src/Stepper.cxx
@@ -34,7 +34,7 @@ bool Stepper::process(const TVirtualMC& vmc)
   int detElemId;
   vmc.CurrentVolOffID(1, detElemId); // go up 1 level in the hierarchy to get the DE
 
-  auto stack = static_cast<o2::Data::Stack*>(vmc.GetStack());
+  auto stack = static_cast<o2::data::Stack*>(vmc.GetStack());
 
   if (ts.isEntering() || ts.isExiting()) {
     // generate a track referenced

--- a/Detectors/TOF/simulation/src/Detector.cxx
+++ b/Detectors/TOF/simulation/src/Detector.cxx
@@ -79,7 +79,7 @@ Bool_t Detector::ProcessHits(FairVolume* v)
   float posx, posy, posz;
   fMC->TrackPosition(posx, posy, posz);
   float time = fMC->TrackTime() * 1.0e09;
-  auto stack = static_cast<o2::Data::Stack*>(fMC->GetStack());
+  auto stack = static_cast<o2::data::Stack*>(fMC->GetStack());
   int trackID = stack->GetCurrentTrackNumber();
   int sensID = v->getMCid();
   Int_t det[5];

--- a/Detectors/TPC/simulation/src/Detector.cxx
+++ b/Detectors/TPC/simulation/src/Detector.cxx
@@ -186,7 +186,7 @@ Bool_t Detector::ProcessHits(FairVolume* vol)
   const float time = fMC->TrackTime() * 1.0e9;
   const int trackID = fMC->GetStack()->GetCurrentTrackNumber();
   const int detID = vol->getMCid();
-  o2::Data::Stack* stack = (o2::Data::Stack*)fMC->GetStack();
+  o2::data::Stack* stack = (o2::data::Stack*)fMC->GetStack();
   if (fMC->IsTrackEntering() || fMC->IsTrackExiting()) {
     stack->addTrackReference(o2::TrackReference(position.X(), position.Y(), position.Z(), momentum.X(), momentum.Y(),
                                                 momentum.Z(), fMC->TrackLength(), time, trackID, GetDetId()));

--- a/Detectors/TRD/simulation/src/Detector.cxx
+++ b/Detectors/TRD/simulation/src/Detector.cxx
@@ -123,7 +123,7 @@ bool Detector::ProcessHits(FairVolume* v)
   // 0: InFlight 1: Entering 2: Exiting
   int trkStat = 0;
 
-  o2::Data::Stack* stack = (o2::Data::Stack*)fMC->GetStack();
+  o2::data::Stack* stack = (o2::data::Stack*)fMC->GetStack();
   float xp, yp, zp;
   float px, py, pz, etot;
   float trackLength = fMC->TrackLength(); // Return the length of the current track from its origin (in cm)
@@ -252,7 +252,7 @@ void Detector::createTRhit(int det)
 
     // Add the hit to the array. TR photon hits are marked by negative energy (and not by charge)
     float tof = fMC->TrackTime() * 1e6; // The time of flight in micro-seconds
-    o2::Data::Stack* stack = (o2::Data::Stack*)fMC->GetStack();
+    o2::data::Stack* stack = (o2::data::Stack*)fMC->GetStack();
     const int trackID = stack->GetCurrentTrackNumber();
     const int totalChargeDep = -1 * (int)(energyeV / mWion); // Negative charge for tagging TR photon hits
     addHit(x, y, z, tof, totalChargeDep, trackID, det);

--- a/Detectors/ZDC/simulation/src/Detector.cxx
+++ b/Detectors/ZDC/simulation/src/Detector.cxx
@@ -256,7 +256,7 @@ Bool_t Detector::ProcessHits(FairVolume* v)
 
   Vector3D<float> xImp(xDet[0], xDet[1], xDet[2]);
 
-  auto stack = (o2::Data::Stack*)fMC->GetStack();
+  auto stack = (o2::data::Stack*)fMC->GetStack();
   int trackn = stack->GetCurrentTrackNumber();
   int trackparent = stack->GetCurrentTrack()->GetMother(0);
   const bool isDaughterOfSeenTrack = stack->isTrackDaughterOf(trackn, mCurrentTrackID);

--- a/Detectors/gconfig/commonConfig.C
+++ b/Detectors/gconfig/commonConfig.C
@@ -10,7 +10,7 @@ template <typename T, typename R>
 void stackSetup(T* vmc, R* run)
 {
   // create the O2 vmc stack instance
-  auto st = new o2::Data::Stack();
+  auto st = new o2::data::Stack();
   st->setMinHits(1);
   auto& stackparam = o2::sim::StackParam::Instance();
   st->StoreSecondaries(stackparam.storeSecondaries);

--- a/Steer/include/Steer/O2MCApplication.h
+++ b/Steer/include/Steer/O2MCApplication.h
@@ -67,7 +67,7 @@ class O2MCApplication : public O2MCApplicationBase
   /** Define actions at the end of run */
   void FinishRun();
 
-  void attachSubEventInfo(FairMQParts&, o2::Data::SubEventInfo const& info) const;
+  void attachSubEventInfo(FairMQParts&, o2::data::SubEventInfo const& info) const;
 
   /** Generate primary particles */
   void GeneratePrimaries() override
@@ -86,7 +86,7 @@ class O2MCApplication : public O2MCApplicationBase
 
     // but here we init the stack from
     // a vector of particles that someone sets externally
-    static_cast<o2::Data::Stack*>(GetStack())->initFromPrimaries(mPrimaries);
+    static_cast<o2::data::Stack*>(GetStack())->initFromPrimaries(mPrimaries);
   }
 
   void setPrimaries(std::vector<TParticle> const& p)
@@ -95,12 +95,12 @@ class O2MCApplication : public O2MCApplicationBase
   }
 
   void setSimDataChannel(FairMQChannel* channel) { mSimDataChannel = channel; }
-  void setSubEventInfo(o2::Data::SubEventInfo& i) { mSubEventInfo = i; }
+  void setSubEventInfo(o2::data::SubEventInfo& i) { mSubEventInfo = i; }
 
   std::vector<TParticle> mPrimaries; //!
 
   FairMQChannel* mSimDataChannel;                      //! generic channel on which to send sim data
-  o2::Data::SubEventInfo mSubEventInfo;                //! what are we currently processing?
+  o2::data::SubEventInfo mSubEventInfo;                //! what are we currently processing?
   std::vector<o2::base::Detector*> mActiveO2Detectors; //! active (data taking) o2 detectors
 
   ClassDefOverride(O2MCApplication, 1) //Interface to MonteCarlo application

--- a/Steer/src/O2MCApplication.cxx
+++ b/Steer/src/O2MCApplication.cxx
@@ -97,7 +97,7 @@ void O2MCApplication::initLate()
   }
 }
 
-void O2MCApplication::attachSubEventInfo(FairMQParts& parts, o2::Data::SubEventInfo const& info) const
+void O2MCApplication::attachSubEventInfo(FairMQParts& parts, o2::data::SubEventInfo const& info) const
 {
   // parts.AddPart(std::move(mSimDataChannel->NewSimpleMessage(info)));
   o2::base::attachTMessage(info, *mSimDataChannel, parts);
@@ -127,7 +127,7 @@ void O2MCApplication::SendData()
 
   // fill these parts ... the receiver has to unpack similary
   // TODO: actually we could just loop over branches in FairRootManager at this moment?
-  mSubEventInfo.npersistenttracks = static_cast<o2::Data::Stack*>(GetStack())->getMCTracks()->size();
+  mSubEventInfo.npersistenttracks = static_cast<o2::data::Stack*>(GetStack())->getMCTracks()->size();
   attachSubEventInfo(simdataparts, mSubEventInfo);
   auto tracks = attachBranch<std::vector<o2::MCTrack>>("MCTrack", *mSimDataChannel, simdataparts);
   attachBranch<std::vector<o2::TrackReference>>("TrackRefs", *mSimDataChannel, simdataparts);

--- a/macro/runCATrackingClusterNative.C
+++ b/macro/runCATrackingClusterNative.C
@@ -34,12 +34,11 @@
 #pragma cling load("libDataFormatsTPC")
 #endif
 
-using namespace o2;
 using namespace o2::TPC;
 using namespace o2::dataformats;
 using namespace std;
 
-using MCLabelContainer = MCTruthContainer<MCCompLabel>;
+using MCLabelContainer = MCTruthContainer<o2::MCCompLabel>;
 
 // This is a prototype of a macro to test running the HLT O2 CA Tracking library on a root input file containg
 // TClonesArray of clusters.

--- a/run/O2HitMerger.h
+++ b/run/O2HitMerger.h
@@ -201,7 +201,7 @@ class O2HitMerger : public FairMQDevice
   // fills a special branch of SubEventInfos in order to keep
   // track of which entry corresponds to which event etc.
   // also creates the MCEventHeader branch expected for physics analysis
-  void fillSubEventInfoEntry(o2::Data::SubEventInfo& info)
+  void fillSubEventInfoEntry(o2::data::SubEventInfo& info)
   {
     auto infoptr = &info;
     fillBranch("SubEventInfo", infoptr);
@@ -215,8 +215,8 @@ class O2HitMerger : public FairMQDevice
     LOG(INFO) << "SIMDATA channel got " << data.Size() << " parts\n";
 
     int index = 0;
-    auto infoptr = o2::base::decodeTMessage<o2::Data::SubEventInfo*>(data, index++);
-    o2::Data::SubEventInfo info = *infoptr;
+    auto infoptr = o2::base::decodeTMessage<o2::data::SubEventInfo*>(data, index++);
+    o2::data::SubEventInfo info = *infoptr;
     auto accum = insertAdd<uint32_t, uint32_t>(mPartsCheckSum, info.eventID, (uint32_t)info.part);
 
     fillSubEventInfoEntry(info);
@@ -333,7 +333,7 @@ class O2HitMerger : public FairMQDevice
     eventheaders.resize(mNExpectedEvents);
 
     // the MC labels (trackID) for hits
-    o2::Data::SubEventInfo* info = nullptr;
+    o2::data::SubEventInfo* info = nullptr;
     infobr->SetAddress(&info);
     for (int i = 0; i < infobr->GetEntries(); ++i) {
       infobr->GetEntry(i);

--- a/run/O2PrimaryServerDevice.h
+++ b/run/O2PrimaryServerDevice.h
@@ -170,8 +170,8 @@ class O2PrimaryServerDevice : public FairMQDevice
     // number of parts should be at least 1 (even if empty)
     numberofparts = std::max(1, numberofparts);
 
-    o2::Data::PrimaryChunk m;
-    o2::Data::SubEventInfo i;
+    o2::data::PrimaryChunk m;
+    o2::data::SubEventInfo i;
     i.eventID = counter;
     i.maxEvents = mMaxEvents;
     i.part = mPartCounter + 1;
@@ -217,7 +217,7 @@ class O2PrimaryServerDevice : public FairMQDevice
     }
 
     TMessage* tmsg = new TMessage(kMESS_OBJECT);
-    tmsg->WriteObjectAny((void*)&m, TClass::GetClass("o2::Data::PrimaryChunk"));
+    tmsg->WriteObjectAny((void*)&m, TClass::GetClass("o2::data::PrimaryChunk"));
 
     auto free_tmessage = [](void* data, void* hint) { delete static_cast<TMessage*>(hint); };
 
@@ -236,7 +236,7 @@ class O2PrimaryServerDevice : public FairMQDevice
   std::string mOutChannelName = "";
   o2::eventgen::PrimaryGenerator mPrimGen;
   o2::dataformats::MCEventHeader mEventHeader;
-  o2::Data::Stack mStack;      // the stack which is filled
+  o2::data::Stack mStack;      // the stack which is filled
   int mChunkGranularity = 500; // how many primaries to send to a worker
   int mLastPosition = 0;       // last position in stack vector
   int mPartCounter = 0;

--- a/run/O2SimDevice.h
+++ b/run/O2SimDevice.h
@@ -166,7 +166,7 @@ class O2SimDevice : public FairMQDevice
 
         // wrap incoming bytes as a TMessageWrapper which offers "adoption" of a buffer
         auto message = new TMessageWrapper(reply->GetData(), reply->GetSize());
-        auto chunk = static_cast<o2::Data::PrimaryChunk*>(message->ReadObjectAny(message->GetClass()));
+        auto chunk = static_cast<o2::data::PrimaryChunk*>(message->ReadObjectAny(message->GetClass()));
 
         mVMCApp->setPrimaries(chunk->mParticles);
 


### PR DESCRIPTION
I've deleted `using namespace o2;` from `macro/runCATrackingClusterNative.C`, because `o2::base` was clashing with `std::base`.