### PR TITLE
Fix: protection for sectorID overflow in CookerTracker

### DIFF
--- a/Detectors/ITSMFT/ITS/reconstruction/src/CookedTracker.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CookedTracker.cxx
@@ -702,7 +702,7 @@ void CookedTracker::Layer::init()
     BringTo02Pi(phi);
     mPhi.push_back(phi);
     Int_t s = phi * kNSectors / k2PI;
-    mSectors[s].emplace_back(i, c->getZ());
+    mSectors[s < kNSectors ? s : kNSectors - 1].emplace_back(i, c->getZ());
   }
 
   if (m)


### PR DESCRIPTION
@iouribelikov @mpuccio : this fixes the crash in reconstruction (cluster phi happened to be exactly 2pi).

Yura, note that the CookedTracks is prone to crash in multi-thread mode, since the TGeometry used for material budget query is not thread-safe (navigator changes its state). With 8 threads I get: 
````
#6  TObject::TestBit (f=32768, this=<optimized out>) at /home/shahoian/alice/sw/BUILD/f58b77b61af7bc34412ed1a39b4a5bd4a0b1a428/ROOT/include/TObject.h:172
#7  TGeoNode::IsOffset (this=<optimized out>) at /home/shahoian/alice/sw/BUILD/f58b77b61af7bc34412ed1a39b4a5bd4a0b1a428/ROOT/include/TGeoNode.h:100
...
#17 0x00007f383709b885 in o2::ITS::CookedTracker::makeBackPropParam (this=this
entry=0x7fffba178820, track=...) at /home/shahoian/alice/sw/SOURCES/O2/1.0.0/0/Detectors/ITSMFT/ITS/reconstruction/src/CookedTracker.cxx:600
#18 0x00007f383709ba1e in o2::ITS::CookedTracker::makeBackPropParam (this=this
entry=0x7fffba178820, seeds=std::vector of length 1, capacity 62 = {...}) at /home/shahoian/alice/sw/SOURCES/O2/1.0.0/0/Detectors/ITSMFT/ITS/reconstruction/src/CookedTracker.cxx:579
#19 0x00007f383709fb9c in o2::ITS::CookedTracker::trackInThread (...
````
Cheers,
 Ruben