### PR TITLE
O2-592: Increase shared memory buffer for hits

### DIFF
--- a/Common/Utils/include/CommonUtils/ShmManager.h
+++ b/Common/Utils/include/CommonUtils/ShmManager.h
@@ -32,7 +32,7 @@ namespace utils
 {
 
 // the size dedicated to each attached worker/process
-constexpr size_t SHMPOOLSIZE = 1024 * 1024 * 200; // 200MB
+constexpr size_t SHMPOOLSIZE = 1024 * 1024 * 1024; // 1 GB
 
 // some meta info stored at the beginning of the global shared mem segment
 struct ShmMetaInfo {

--- a/run/O2SimDevice.h
+++ b/run/O2SimDevice.h
@@ -90,7 +90,7 @@ class O2SimDevice : public FairMQDevice
     std::unique_ptr<FairMQMessage> reply(channel.NewMessage());
 
     int timeoutinMS = 100000; // wait for 100s max
-    if (channel.Send(request, timeoutinMS) >= 0) {
+    if (channel.Send(request, timeoutinMS) > 0) {
       LOG(INFO) << "Waiting for configuration answer ";
       if (channel.Receive(reply, timeoutinMS) > 0) {
         LOG(INFO) << "Configuration answer received, containing " << reply->GetSize() << " bytes ";
@@ -156,8 +156,8 @@ class O2SimDevice : public FairMQDevice
     mVMCApp->setSimDataChannel(&dataoutchannel);
 
     LOG(INFO) << "Requesting work ";
-    int timeoutinMS = 10000; // wait for 10s max -- we should have a more robust solution
-    if (requestchannel.Send(request, timeoutinMS) >= 0) {
+    int timeoutinMS = 100000; // wait for 100s max -- we should have a more robust solution
+    if (requestchannel.Send(request, timeoutinMS) > 0) {
       LOG(INFO) << "Waiting for answer ";
       // asking for primary generation
 


### PR DESCRIPTION
We need larger memory buffers to the hits when transporting
10K primaries per sub-event. (The alternative would be to decrease
the max sub-event size ... at some moment we need to correlate these numbers).

This should fix O2-592.