### PR TITLE
o2sim: Make event server less blocking

### DIFF
--- a/run/O2PrimaryServerDevice.h
+++ b/run/O2PrimaryServerDevice.h
@@ -30,6 +30,7 @@
 #include <typeinfo>
 #include <thread>
 #include <TROOT.h>
+#include <TStopwatch.h>
 
 namespace o2
 {
@@ -47,7 +48,12 @@ class O2PrimaryServerDevice : public FairMQDevice
   }
 
   /// Default destructor
-  ~O2PrimaryServerDevice() final = default;
+  ~O2PrimaryServerDevice() final
+  {
+    if (mGeneratorThread.joinable()) {
+      mGeneratorThread.join();
+    }
+  }
 
  protected:
   void initGenerator()
@@ -62,6 +68,18 @@ class O2PrimaryServerDevice : public FairMQDevice
       mPrimGen.embedInto(embedinto_filename);
     }
     mPrimGen.Init();
+    generateEvent(); // generate a first event
+  }
+
+  // function generating one event
+  void generateEvent()
+  {
+    TStopwatch timer;
+    timer.Start();
+    mStack.Reset();
+    mPrimGen.GenerateEvent(&mStack);
+    timer.Stop();
+    LOG(INFO) << "Event generation took " << timer.CpuTime() << "s";
   }
 
   void InitTask() final
@@ -95,7 +113,7 @@ class O2PrimaryServerDevice : public FairMQDevice
     // lunch initialization of particle generator asynchronously
     // so that we reach the RUNNING state of the server quickly
     // and do not block here
-    mGeneratorInitThread = std::thread(&O2PrimaryServerDevice::initGenerator, this);
+    mGeneratorThread = std::thread(&O2PrimaryServerDevice::initGenerator, this);
 
     // init pipe
     auto pipeenv = getenv("ALICE_O2SIMSERVERTODRIVER_PIPE");
@@ -124,7 +142,7 @@ class O2PrimaryServerDevice : public FairMQDevice
       fTransportFactory->CreateMessage(tmsg->Buffer(), tmsg->BufferSize(), free_tmessage, tmsg));
 
     // send answer
-    if (Send(message, "primary-get") > 0) {
+    if (Send(message, "primary-get", 0) > 0) {
       LOG(INFO) << "config reply send ";
       return true;
     }
@@ -146,11 +164,6 @@ class O2PrimaryServerDevice : public FairMQDevice
       return true;
     }
 
-    // we only need the initialized generator at this moment
-    if (mGeneratorInitThread.joinable()) {
-      mGeneratorInitThread.join();
-    }
-
     static int counter = 0;
     if (counter >= mMaxEvents && mNeedNewEvent) {
       return false;
@@ -158,8 +171,10 @@ class O2PrimaryServerDevice : public FairMQDevice
 
     LOG(INFO) << "Received request for work ";
     if (mNeedNewEvent) {
-      mStack.Reset();
-      mPrimGen.GenerateEvent(&mStack);
+      // we need a newly generated event now
+      if (mGeneratorThread.joinable()) {
+        mGeneratorThread.join();
+      }
       mNeedNewEvent = false;
       mPartCounter = 0;
       counter++;
@@ -181,13 +196,6 @@ class O2PrimaryServerDevice : public FairMQDevice
     i.mMCEventHeader = mEventHeader;
     m.mSubEventInfo = i;
 
-    //auto startoffset = (mPartCounter + 1) * mChunkGranularity;
-    //auto endoffset = startindex + mChunkGranularity;
-    //auto startiter = prims.begin() + mPartCounter * mChunkGranularity;
-    //auto enditer = endindex < prims.size() ? startiter + mChunkGranularity : prims.end();
-    //auto startiter = startoffset < prims.size() ? prims.rbegin() - startoffset : prims.begin();
-    //auto remaining = prims.size() - (mPartCounter + 1) * mChunkGranularity;
-    //auto enditer = startiter + (remaining > mChunkGranularity)? mChunkGranularity : remaining;
     int endindex = prims.size() - mPartCounter * mChunkGranularity;
     int startindex = prims.size() - (mPartCounter + 1) * mChunkGranularity;
     if (startindex < 0) {
@@ -197,13 +205,12 @@ class O2PrimaryServerDevice : public FairMQDevice
       endindex = 0;
     }
 
-    // std::copy(startiter, enditer, std::back_inserter(m.mParticles));
     for (int index = startindex; index < endindex; ++index) {
       m.mParticles.emplace_back(prims[index]);
     }
 
-    LOG(WARNING) << "Sending " << m.mParticles.size() << " particles\n";
-    LOG(WARNING) << "treating ev " << counter << " part " << i.part << " out of " << i.nparts << "\n";
+    LOG(INFO) << "Sending " << m.mParticles.size() << " particles\n";
+    LOG(INFO) << "treating ev " << counter << " part " << i.part << " out of " << i.nparts << "\n";
 
     // feedback to driver if new event started
     if (mPipeToDriver != -1 && i.part == 1) {
@@ -214,6 +221,8 @@ class O2PrimaryServerDevice : public FairMQDevice
     mPartCounter++;
     if (mPartCounter == numberofparts) {
       mNeedNewEvent = true;
+      // start generation of a new event
+      mGeneratorThread = std::thread(&O2PrimaryServerDevice::generateEvent, this);
     }
 
     TMessage* tmsg = new TMessage(kMESS_OBJECT);
@@ -225,7 +234,7 @@ class O2PrimaryServerDevice : public FairMQDevice
       fTransportFactory->CreateMessage(tmsg->Buffer(), tmsg->BufferSize(), free_tmessage, tmsg));
 
     // send answer
-    if (Send(message, "primary-get") > 0) {
+    if (Send(message, "primary-get", 0) > 0) {
       LOG(INFO) << "reply send";
       return true;
     }
@@ -245,7 +254,8 @@ class O2PrimaryServerDevice : public FairMQDevice
   int mInitialSeed = -1;
   int mPipeToDriver = -1; // handle for direct piper to driver (to communicate meta info)
 
-  std::thread mGeneratorInitThread; //! a thread used to concurrently init the particle generator
+  std::thread mGeneratorThread; //! a thread used to concurrently init the particle generator
+                                //  or to generate events
 };
 
 } // namespace devices


### PR DESCRIPTION
* generate events concurrently in a thread
* use asynchronous mode for sending back

This should lead to a more responsive event server.
Other steps (such as asynchronous creation of the ROOT message) might follow.