### PR TITLE
Improved basic hit class

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/BaseHits.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/BaseHits.h
@@ -25,7 +25,7 @@ class BaseHit
 {
  public:
   BaseHit() = default;
-  BaseHit(int id) : mTrackID{id} {}
+  BaseHit(int id) : mTrackID{ id } {}
   int GetTrackID() const { return mTrackID; }
   void SetTrackID(int id) { mTrackID = id; }
 
@@ -38,21 +38,21 @@ class BaseHit
 // these are meant to be an alternative to FairMCPoint
 // which always includes the momentum and is purely based on double values
 
-// T is basic type for position, E is basic type for time and energy loss
-template <typename T, typename E=float>
-class BasicXYZEHit : public BaseHit
+// T is basic type for position, E is basic type for time and hit value
+template <typename T, typename E, typename V = float>
+class BasicXYZVHit : public BaseHit
 {
-  Point3D<T> mPos; // cartesian position of Hit
-  E mTime;         // time of flight
-  E mELoss;        // energy loss
+  Point3D<T> mPos;   // cartesian position of Hit
+  E mTime;           // time of flight
+  V mHitValue;       // hit value
   short mDetectorID; // the detector/sensor id
 
  public:
-  BasicXYZEHit() = default; // for ROOT IO
+  BasicXYZVHit() = default; // for ROOT IO
 
   // constructor
-  BasicXYZEHit(T x, T y, T z, E time, E e, int trackid, short did)
-    :  mPos(x, y, z), mTime(time), mELoss(e), BaseHit(trackid), mDetectorID(did)
+  BasicXYZVHit(T x, T y, T z, E time, V val, int trackid, short did)
+    : mPos(x, y, z), mTime(time), mHitValue(val), BaseHit(trackid), mDetectorID(did)
   {
   }
 
@@ -61,8 +61,8 @@ class BasicXYZEHit : public BaseHit
   T GetY() const { return mPos.Y(); }
   T GetZ() const { return mPos.Z(); }
   Point3D<T> GetPos() const { return mPos; }
-  // getting energy loss
-  E GetEnergyLoss() const { return mELoss; }
+  // getting hit value
+  V GetHitValue() const { return mHitValue; }
   // getting the time
   E GetTime() const { return mTime; }
   // get detector + track information
@@ -70,7 +70,7 @@ class BasicXYZEHit : public BaseHit
 
   // modifiers
   void SetTime(E time) { mTime = time; }
-  void SetEnergyLoss(E eLoss) { mELoss = eLoss; }
+  void SetHitValue(V val) { mHitValue = val; }
   void SetDetectorID(short detID) { mDetectorID = detID; }
   void SetX(T x) { mPos.SetX(x); }
   void SetY(T y) { mPos.SetY(y); }
@@ -81,10 +81,22 @@ class BasicXYZEHit : public BaseHit
     SetY(y);
     SetZ(z);
   }
-  void SetPos(Point3D<T> const &p) { mPos = p; }
+  void SetPos(Point3D<T> const& p) { mPos = p; }
+
+  ClassDefNV(BasicXYZVHit, 1);
+};
+
+template <typename T, typename E = float, typename V = float>
+class BasicXYZEHit : public BasicXYZVHit<T, E, V>
+{
+ public:
+  using BasicXYZVHit<T, E, V>::BasicXYZVHit;
+
+  V GetEnergyLoss() const { return BasicXYZVHit<T, E, V>::GetHitValue(); }
+  void SetEnergyLoss(V val) { BasicXYZVHit<T, E, V>::SetHitValue(val); }
 
   ClassDefNV(BasicXYZEHit, 1);
 };
 
-} // end namespace AliceO2
+} // namespace o2
 #endif

--- a/DataFormats/simulation/include/SimulationDataFormat/BaseHits.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/BaseHits.h
@@ -38,7 +38,10 @@ class BaseHit
 // these are meant to be an alternative to FairMCPoint
 // which always includes the momentum and is purely based on double values
 
-// T is basic type for position, E is basic type for time and hit value
+// Generic class to keep position, time and hit value
+// T is basic type for position,
+// E is basic type for time,
+// V is basic type for hit value.
 template <typename T, typename E, typename V = float>
 class BasicXYZVHit : public BaseHit
 {
@@ -86,6 +89,10 @@ class BasicXYZVHit : public BaseHit
   ClassDefNV(BasicXYZVHit, 1);
 };
 
+// Class for a hit containing energy loss as hit value
+// T is basic type for position,
+// E is basic type for time (float as default),
+// V is basic type for hit value (float as default).
 template <typename T, typename E = float, typename V = float>
 class BasicXYZEHit : public BasicXYZVHit<T, E, V>
 {
@@ -96,6 +103,22 @@ class BasicXYZEHit : public BasicXYZVHit<T, E, V>
   void SetEnergyLoss(V val) { BasicXYZVHit<T, E, V>::SetHitValue(val); }
 
   ClassDefNV(BasicXYZEHit, 1);
+};
+
+// Class for a hit containing charge as hit value
+// T is basic type for position,
+// E is basic type for time (float as default),
+// V is basic type for hit value (int as default).
+template <typename T, typename E = float, typename V = int>
+class BasicXYZQHit : public BasicXYZVHit<T, E, V>
+{
+ public:
+  using BasicXYZVHit<T, E, V>::BasicXYZVHit;
+
+  V GetCharge() const { return BasicXYZVHit<T, E, V>::GetHitValue(); }
+  void SetCharge(V val) { BasicXYZVHit<T, E, V>::SetHitValue(val); }
+
+  ClassDefNV(BasicXYZQHit, 1);
 };
 
 } // namespace o2

--- a/DataFormats/simulation/src/SimulationDataLinkDef.h
+++ b/DataFormats/simulation/src/SimulationDataLinkDef.h
@@ -34,8 +34,12 @@
 #pragma link C++ class o2::MCCompLabel + ;
 
 #pragma link C++ class o2::BaseHit + ;
-#pragma link C++ class o2::BasicXYZEHit < float, float > +;
-#pragma link C++ class o2::BasicXYZEHit < double, double > +;
+#pragma link C++ class o2::BasicXYZVHit < float, float, int > +;
+#pragma link C++ class o2::BasicXYZVHit < float, float, float > +;
+#pragma link C++ class o2::BasicXYZVHit < double, double, int > +;
+#pragma link C++ class o2::BasicXYZVHit < double, double, double > +;
+#pragma link C++ class o2::BasicXYZEHit < float, float, float > +;
+#pragma link C++ class o2::BasicXYZEHit < double, double, double > +;
 #pragma link C++ struct o2::dataformats::MCTruthHeaderElement + ;
 #pragma link C++ class o2::dataformats::MCTruthContainer < long > +;
 #pragma link C++ class o2::dataformats::MCTruthContainer < o2::MCCompLabel > +;

--- a/DataFormats/simulation/src/SimulationDataLinkDef.h
+++ b/DataFormats/simulation/src/SimulationDataLinkDef.h
@@ -34,12 +34,14 @@
 #pragma link C++ class o2::MCCompLabel + ;
 
 #pragma link C++ class o2::BaseHit + ;
-#pragma link C++ class o2::BasicXYZVHit < float, float, int > +;
 #pragma link C++ class o2::BasicXYZVHit < float, float, float > +;
-#pragma link C++ class o2::BasicXYZVHit < double, double, int > +;
 #pragma link C++ class o2::BasicXYZVHit < double, double, double > +;
+#pragma link C++ class o2::BasicXYZVHit < float, float, int > +;
+#pragma link C++ class o2::BasicXYZVHit < double, double, int > +;
 #pragma link C++ class o2::BasicXYZEHit < float, float, float > +;
 #pragma link C++ class o2::BasicXYZEHit < double, double, double > +;
+#pragma link C++ class o2::BasicXYZQHit < float, float, int > +;
+#pragma link C++ class o2::BasicXYZQHit < double, double, int > +;
 #pragma link C++ struct o2::dataformats::MCTruthHeaderElement + ;
 #pragma link C++ class o2::dataformats::MCTruthContainer < long > +;
 #pragma link C++ class o2::dataformats::MCTruthContainer < o2::MCCompLabel > +;

--- a/Detectors/TRD/simulation/include/TRDSimulation/Detector.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Detector.h
@@ -24,10 +24,10 @@ namespace o2
 {
 namespace trd
 {
-class HitType : public o2::BasicXYZEHit<float>
+class HitType : public o2::BasicXYZQHit<float>
 {
  public:
-  using BasicXYZEHit<float>::BasicXYZEHit;
+  using BasicXYZQHit<float>::BasicXYZQHit;
 };
 } // namespace trd
 } // namespace o2

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -180,8 +180,7 @@ bool Digitizer::convertHits(const int det, const std::vector<o2::trd::HitType>& 
     pos[1] = hit.GetY();
     pos[2] = hit.GetZ();
 
-    const float eDep = hit.GetEnergyLoss();
-    const int qTotal = (int)eDep; // Small kind of hack, this will be fixed later
+    const int qTotal = hit.GetCharge();
 
     gGeoManager->SetCurrentPoint(pos);
     gGeoManager->FindNode();

--- a/macro/analyzeHits.C
+++ b/macro/analyzeHits.C
@@ -82,7 +82,6 @@ struct HitStatsBase {
 
 template <typename T>
 struct HitStats : public HitStatsBase {
-
   // adds a hit to the statistics
   void addHit(T const& hit)
   {
@@ -97,6 +96,29 @@ struct HitStats : public HitStatsBase {
     ZAvg += z;
     Z2Avg += z * z;
     auto e = hit.GetEnergyLoss();
+    EAvg += e;
+    E2Avg += e * e;
+    auto t = hit.GetTime();
+    TAvg += t;
+    T2Avg += t * t;
+  }
+};
+
+struct TRDHitStats : public HitStatsBase {
+  // adds a hit to the statistics
+  void addHit(o2::trd::HitType const& hit)
+  {
+    NHits++;
+    auto x = hit.GetX();
+    XAvg += x;
+    X2Avg += x * x;
+    auto y = hit.GetY();
+    YAvg += y;
+    Y2Avg += y * y;
+    auto z = hit.GetZ();
+    ZAvg += z;
+    Z2Avg += z * z;
+    auto e = hit.GetCharge();
     EAvg += e;
     E2Avg += e * e;
     auto t = hit.GetTime();
@@ -205,9 +227,10 @@ void analyzeEMC(TTree* reftree)
 }
 
 // do comparison for TRD
+// need a different version of TRDHitStats to retrieve the hit value
 void analyzeTRD(TTree* reftree)
 {
-  auto refresult = analyse<o2::trd::HitType, HitStats<o2::trd::HitType>>(reftree, "TRDHit");
+  auto refresult = analyse<o2::trd::HitType, TRDHitStats>(reftree, "TRDHit");
   std::cout << gPrefix << " TRD ";
   refresult.print();
 }


### PR DESCRIPTION
This PR adds a more flexible hit type class (`BasicXYZVHit`) and two specialized classes (`BasicXYZEHit` and `BasicXYZQHit`). These classes have different types for the hit value (`double` or `float`, and `int`). Therefore, they can store energy loss or deposited charge as the hit value using the right type.

The motivation is the TRD hit value, which keeps deposited charge (`int`) instead of energy loss (`float` or `double`). In the hit file `o2sim.root` the hits were visualized as energy loss (`mELoss`), while they actually store deposited charge. The wrong variable name could cause mistakes in the future (short discussion in O2-453).

As a solution, `mELoss`  is now `mHitValue`. Two new specialized classes contain the hit value getter methods `GetEnergyLoss()` and `GetCharge()`, both returning the right types and keeping clarity in the code.