### PR TITLE
Fix in access to TPC clusters MC info + cleanup of LinkDef 

### DIFF
--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/ClusterNativeHelper.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/ClusterNativeHelper.h
@@ -196,11 +196,13 @@ class ClusterNativeHelper
     /// tree
     TTree* mTree = nullptr;
     /// the array of raw buffers
-    std::array<std::vector<char>*, NSectors> mSectorRaw;
+    std::array<std::vector<char>*, NSectors> mSectorRaw = { nullptr };
     /// the array of raw buffers
-    std::array<size_t, NSectors> mSectorRawSize;
+    std::array<size_t, NSectors> mSectorRawSize = { 0 };
     /// the array of MC label containers
     std::array<std::vector<MCLabelContainer>, NSectors> mSectorMC;
+    /// pointers on the elements of array of MC label containers
+    std::array<std::vector<MCLabelContainer>*, NSectors> mSectorMCPtr = { nullptr };
   };
 
   /// @class TreeWriter

--- a/DataFormats/Detectors/TPC/src/ClusterNativeHelper.cxx
+++ b/DataFormats/Detectors/TPC/src/ClusterNativeHelper.cxx
@@ -112,7 +112,8 @@ void ClusterNativeHelper::Reader::init(const char* filename, const char* treenam
     branchname = mMCBranchName + "_" + std::to_string(sector);
     branch = mTree->GetBranch(branchname.c_str());
     if (branch) {
-      branch->SetAddress(&mSectorMC);
+      mSectorMCPtr[sector] = &mSectorMC[sector];
+      branch->SetAddress(&mSectorMCPtr[sector]);
       ++nofMCBranches;
     }
   }
@@ -156,6 +157,7 @@ int ClusterNativeHelper::Reader::parseSector(const char* buffer, size_t size, st
   if (!buffer || size == 0) {
     return 0;
   }
+
   auto mcIterator = mcinput.begin();
   using ClusterGroupParser = o2::algorithm::ForwardParser<o2::TPC::ClusterGroupHeader>;
   ClusterGroupParser parser;

--- a/DataFormats/Detectors/TPC/src/DataFormatsTPCLinkDef.h
+++ b/DataFormats/Detectors/TPC/src/DataFormatsTPCLinkDef.h
@@ -25,7 +25,6 @@
 #pragma link C++ class std::vector < o2::TPC::ClusterHardware > +;
 #pragma link C++ class std::vector < o2::TPC::ClusterHardwareContainerFixedSize < 8192 >> +;
 #pragma link C++ class std::vector < o2::TPC::ClusterHardwareContainer8kb > +;
-#pragma link C++ class o2::TPC::TPCClusterFormatHelper + ;
 #pragma link C++ class o2::TPC::TrackTPC + ;
 #pragma link C++ class o2::TPC::Cluster + ;
 #pragma link C++ class std::vector < o2::TPC::Cluster > +;


### PR DESCRIPTION
The access to clusters MC truth (or simply destructing the ClusterNativeHelper::Reader) was leading to segm.viol. since the addresses of MC branches were not correctly set. 
With this fix attached macro dumps correctly the cluster info (runs over the output of  
````tpc-reco-workflow  --tpc-digit-reader "--infile tpcdigits.root" --input-type digits --output-type clusters,tracks --tracker-options "cont refX=83 bz=-5.0068597793" --tpc-track-writer "--treename events --track-branch-name Tracks --trackmc-branch-name TracksMCTruth"````). @martenole, you can extract the lines for access to tracks/clusters from it.

[tpcclAcc.C.gz](https://github.com/AliceO2Group/AliceO2/files/3061201/tpcclAcc.C.gz)

