### PR TITLE
o2sim: ConditionalRun in hit merger

### DIFF
--- a/run/O2HitMerger.h
+++ b/run/O2HitMerger.h
@@ -209,7 +209,8 @@ class O2HitMerger : public FairMQDevice
     fillBranch("MCEventHeader.", headerptr);
   }
 
-  bool ConditionalRun() override {
+  bool ConditionalRun() override
+  {
     auto& channel = fChannels.at("simdata").at(0);
     FairMQParts request;
     auto bytes = channel.Receive(request);

--- a/run/O2SimDevice.h
+++ b/run/O2SimDevice.h
@@ -174,8 +174,8 @@ class O2SimDevice : public FairMQDevice
         mVMCApp->setSubEventInfo(info);
 
         LOG(INFO) << "Processing " << chunk->mParticles.size() << " primary particles "
-	          << "for event " << info.eventID << "/" << info.maxEvents << " "
-	          << "part " << info.part << "/" << info.nparts;
+                  << "for event " << info.eventID << "/" << info.maxEvents << " "
+                  << "part " << info.part << "/" << info.nparts;
         gRandom->SetSeed(chunk->mSubEventInfo.seed);
 
         mVMC->ProcessRun(1);

--- a/run/O2SimDevice.h
+++ b/run/O2SimDevice.h
@@ -173,7 +173,9 @@ class O2SimDevice : public FairMQDevice
         auto info = chunk->mSubEventInfo;
         mVMCApp->setSubEventInfo(info);
 
-        LOG(INFO) << "Processing " << chunk->mParticles.size() << FairLogger::endl;
+        LOG(INFO) << "Processing " << chunk->mParticles.size() << " primary particles "
+	          << "for event " << info.eventID << "/" << info.maxEvents << " "
+	          << "part " << info.part << "/" << info.nparts;
         gRandom->SetSeed(chunk->mSubEventInfo.seed);
 
         mVMC->ProcessRun(1);

--- a/run/o2sim_parallel.cxx
+++ b/run/o2sim_parallel.cxx
@@ -327,7 +327,7 @@ int main(int argc, char* argv[])
 
     const std::string name("O2HitMergerRunner");
     const std::string path = installpath + "/" + name;
-    execl(path.c_str(), name.c_str(), "--control", "static", "--id", "hitmerger", "--mq-config", localconfig.c_str(),
+    execl(path.c_str(), name.c_str(), "--control", "static", "--catch-signals", "0", "--id", "hitmerger", "--mq-config", localconfig.c_str(),
           (char*)nullptr);
     return 0;
   } else {


### PR DESCRIPTION
Use ConditionalRun in hit merger; Gives more flexibility/controll
for error handling (over OnData).

Smaller changes to terminal output of worker

Overall, this commit makes the system more
reliable and solves a remaining issue in relation
to "Interrupted system call and could not receive on socket".