### PR TITLE
ConfigurableParam: Fix issue with operator<<; Some code style changes

### DIFF
--- a/Common/SimConfig/include/SimConfig/ConfigurableParamHelper.h
+++ b/Common/SimConfig/include/SimConfig/ConfigurableParamHelper.h
@@ -28,9 +28,9 @@ namespace conf
 
 // Utility structure for passing around ConfigurableParam data member info
 // (where value is the string representation)
-struct paramDataMember {
+struct ParamDataMember {
   std::string name;
-  const char* value;
+  std::string value;
   std::string provenance;
 
   std::string toString(bool showProv) const;
@@ -43,7 +43,7 @@ struct paramDataMember {
 class _ParamHelper
 {
  private:
-  static std::vector<paramDataMember>* getDataMembersImpl(std::string mainkey, TClass* cl, void*,
+  static std::vector<ParamDataMember>* getDataMembersImpl(std::string mainkey, TClass* cl, void*,
                                                           std::map<std::string, ConfigurableParam::EParamProvenance> const* provmap);
 
   static void fillKeyValuesImpl(std::string mainkey, TClass* cl, void*, boost::property_tree::ptree*,
@@ -54,8 +54,8 @@ class _ParamHelper
   static void assignmentImpl(std::string mainkey, TClass* cl, void* to, void* from,
                              std::map<std::string, ConfigurableParam::EParamProvenance>* provmap);
 
-  static void outputMembersImpl(std::ostream& out, std::vector<paramDataMember>* members, bool showProv);
-  static void printMembersImpl(std::vector<paramDataMember>* members, bool showProv);
+  static void outputMembersImpl(std::ostream& out, std::vector<ParamDataMember> const* members, bool showProv);
+  static void printMembersImpl(std::vector<ParamDataMember> const* members, bool showProv);
 
   template <typename P>
   friend class ConfigurableParamHelper;
@@ -102,7 +102,7 @@ class ConfigurableParamHelper : virtual public ConfigurableParam
 
   // Grab the list of ConfigurableParam data members
   // Returns a nullptr if the TClass of the P template class cannot be created.
-  std::vector<paramDataMember>* getDataMembers() const
+  std::vector<ParamDataMember>* getDataMembers() const
   {
     // just a helper line to make sure P::sInstance is looked-up
     // and that compiler complains about missing static sInstance of type P

--- a/Common/SimConfig/src/ConfigurableParamHelper.cxx
+++ b/Common/SimConfig/src/ConfigurableParamHelper.cxx
@@ -27,16 +27,15 @@ using namespace o2::conf;
 
 // ----------------------------------------------------------------------
 
-std::string paramDataMember::toString(bool showProv) const
+std::string ParamDataMember::toString(bool showProv) const
 {
   std::string nil = "<null>";
-  std::string val = ((value == nullptr) ? nil : std::string(value));
 
   std::ostringstream out;
-  out << name << " : " << val;
+  out << name << " : " << value;
 
   if (showProv) {
-    std::string prov = (provenance == "" ? nil : provenance);
+    std::string prov = (provenance.compare("") == 0 ? nil : provenance);
     out << "\t\t[ " + prov + " ]";
   }
 
@@ -44,7 +43,7 @@ std::string paramDataMember::toString(bool showProv) const
   return out.str();
 }
 
-std::ostream& operator<<(std::ostream& out, const paramDataMember& pdm)
+std::ostream& operator<<(std::ostream& out, const ParamDataMember& pdm)
 {
   out << pdm.toString(false);
   return out;
@@ -132,10 +131,10 @@ const char* asString(TDataMember const& dm, char* pointer)
 
 // ----------------------------------------------------------------------
 
-std::vector<paramDataMember>* _ParamHelper::getDataMembersImpl(std::string mainkey, TClass* cl, void* obj,
+std::vector<ParamDataMember>* _ParamHelper::getDataMembersImpl(std::string mainkey, TClass* cl, void* obj,
                                                                std::map<std::string, ConfigurableParam::EParamProvenance> const* provmap)
 {
-  std::vector<paramDataMember>* members = new std::vector<paramDataMember>;
+  std::vector<ParamDataMember>* members = new std::vector<ParamDataMember>;
 
   auto toDataMember = [&members, obj, mainkey, provmap](const TDataMember* dm, int index, int size) {
     auto dt = dm->GetDataType();
@@ -149,8 +148,7 @@ std::vector<paramDataMember>* _ParamHelper::getDataMembersImpl(std::string maink
     if (iter != provmap->end()) {
       prov = ConfigurableParam::toString(iter->second);
     }
-
-    paramDataMember member = { name, value, prov };
+    ParamDataMember member{ name, value, prov };
     members->push_back(member);
   };
 
@@ -247,15 +245,16 @@ void _ParamHelper::fillKeyValuesImpl(std::string mainkey, TClass* cl, void* obj,
 
 // ----------------------------------------------------------------------
 
-void _ParamHelper::printMembersImpl(std::vector<paramDataMember>* members, bool showProv)
+void _ParamHelper::printMembersImpl(std::vector<ParamDataMember> const* members, bool showProv)
 {
   _ParamHelper::outputMembersImpl(std::cout, members, showProv);
 }
 
-void _ParamHelper::outputMembersImpl(std::ostream& out, std::vector<paramDataMember>* members, bool showProv)
+void _ParamHelper::outputMembersImpl(std::ostream& out, std::vector<ParamDataMember> const* members, bool showProv)
 {
-  if (members == nullptr)
+  if (members == nullptr) {
     return;
+  }
 
   for (auto& member : *members) {
     out << member.toString(showProv);


### PR DESCRIPTION
* fix issue with operator<< which was not printing correct values
  (probably due to problem with copying pointer values)

* rename paramDataMember to ParamDataMember (since a type)

* some const-correctness fixes