### PR TITLE
Fix namespace naming: o2::DataFormat

### DIFF
--- a/DataFormats/TimeFrame/include/TimeFrame/TimeFrame.h
+++ b/DataFormats/TimeFrame/include/TimeFrame/TimeFrame.h
@@ -17,7 +17,7 @@
 
 namespace o2
 {
-namespace DataFormat
+namespace dataformats
 {
 
 using PartPosition = int;

--- a/DataFormats/TimeFrame/src/TimeFrameLinkDef.h
+++ b/DataFormats/TimeFrame/src/TimeFrameLinkDef.h
@@ -15,7 +15,7 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
-#pragma link C++ class o2::DataFormat::TimeFrame+;
-#pragma link C++ class o2::DataFormat::MessageSizePair+;
+#pragma link C++ class o2::dataformats::TimeFrame+;
+#pragma link C++ class o2::dataformats::MessageSizePair+;
 
 #endif

--- a/DataFormats/TimeFrame/test/TimeFrameTest.cxx
+++ b/DataFormats/TimeFrame/test/TimeFrameTest.cxx
@@ -21,7 +21,7 @@
 
 namespace o2
 {
-namespace DataFormat
+namespace dataformats
 {
 BOOST_AUTO_TEST_CASE(MessageSizePair_test)
 {

--- a/Utilities/DataFlow/src/EPNReceiverDevice.cxx
+++ b/Utilities/DataFlow/src/EPNReceiverDevice.cxx
@@ -29,7 +29,7 @@ using namespace o2::Devices;
 using SubframeMetadata = o2::data_flow::SubframeMetadata;
 using TPCTestPayload = o2::data_flow::TPCTestPayload;
 using TPCTestCluster = o2::data_flow::TPCTestCluster;
-using IndexElement = o2::DataFormat::IndexElement;
+using IndexElement = o2::dataformats::IndexElement;
 
 void EPNReceiverDevice::InitTask()
 {

--- a/Utilities/DataFlow/src/FakeTimeframeBuilder.cxx
+++ b/Utilities/DataFlow/src/FakeTimeframeBuilder.cxx
@@ -19,7 +19,7 @@
 using DataHeader = o2::header::DataHeader;
 using DataDescription = o2::header::DataDescription;
 using DataOrigin = o2::header::DataOrigin;
-using IndexElement = o2::DataFormat::IndexElement;
+using IndexElement = o2::dataformats::IndexElement;
 
 namespace {
   o2::header::DataDescription lookupDataDescription(const char *key) {

--- a/Utilities/DataFlow/src/TimeframeParser.cxx
+++ b/Utilities/DataFlow/src/TimeframeParser.cxx
@@ -28,7 +28,7 @@
 
 using DataHeader = o2::header::DataHeader;
 using DataDescription = o2::header::DataDescription;
-using IndexElement = o2::DataFormat::IndexElement;
+using IndexElement = o2::dataformats::IndexElement;
 
 namespace o2 { namespace data_flow {
 

--- a/Utilities/DataFlow/src/TimeframeValidatorDevice.cxx
+++ b/Utilities/DataFlow/src/TimeframeValidatorDevice.cxx
@@ -26,7 +26,7 @@
 using DataHeader = o2::header::DataHeader;
 using DataOrigin = o2::header::DataOrigin;
 using DataDescription = o2::header::DataDescription;
-using IndexElement = o2::DataFormat::IndexElement;
+using IndexElement = o2::dataformats::IndexElement;
 
 o2::data_flow::TimeframeValidatorDevice::TimeframeValidatorDevice()
   : O2Device()

--- a/Utilities/DataFlow/src/TimeframeWriterDevice.cxx
+++ b/Utilities/DataFlow/src/TimeframeWriterDevice.cxx
@@ -26,7 +26,7 @@
 
 
 using DataHeader = o2::header::DataHeader;
-using IndexElement = o2::DataFormat::IndexElement;
+using IndexElement = o2::dataformats::IndexElement;
 
 namespace o2 { namespace data_flow {
 


### PR DESCRIPTION
Note that I've renamed it to `dataformats`, not `data_format` as the codechecker would rename, because I suspect http://aliceo2group.github.io/AliceO2/d4/de9/namespaceo2_1_1DataFormat.html and http://aliceo2group.github.io/AliceO2/d1/dea/namespaceo2_1_1dataformats.html are related namespaces.