### PR TITLE
Ability to filter out empty events

### DIFF
--- a/Common/SimConfig/include/SimConfig/SimConfig.h
+++ b/Common/SimConfig/include/SimConfig/SimConfig.h
@@ -43,6 +43,7 @@ struct SimConfigData {
   int mInternalChunkSize;                    //
   int mStartSeed;                            // base for random number seeds
   int mSimWorkers = 1;                       // number of parallel sim workers (when it applies)
+  bool mFilterNoHitEvents = false;           // whether to filter out events not leaving any response
 
   ClassDefNV(SimConfigData, 2);
 };
@@ -104,6 +105,7 @@ class SimConfig
   int getInternalChunkSize() const { return mConfigData.mInternalChunkSize; }
   int getStartSeed() const { return mConfigData.mStartSeed; }
   int getNSimWorkers() const { return mConfigData.mSimWorkers; }
+  bool isFilterOutNoHitEvents() const { return mConfigData.mFilterNoHitEvents; }
 
  private:
   SimConfigData mConfigData; //!

--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -44,7 +44,8 @@ void SimConfig::initOptions(boost::program_options::options_description& options
     "configKeyValues", bpo::value<std::string>()->default_value(""), "semicolon separated key=value strings (e.g.: 'TPC.gasDensity=1;...")("chunkSize", bpo::value<unsigned int>()->default_value(5000), "max size of primary chunk (subevent) distributed by server")(
     "chunkSizeI", bpo::value<int>()->default_value(-1), "internalChunkSize")(
     "seed", bpo::value<int>()->default_value(-1), "initial seed (default: -1 random)")(
-    "nworkers,j", bpo::value<int>()->default_value(nsimworkersdefault), "number of parallel simulation workers (only for parallel mode)");
+    "nworkers,j", bpo::value<int>()->default_value(nsimworkersdefault), "number of parallel simulation workers (only for parallel mode)")(
+    "noemptyevents", "only writes events with at least one hit");
 }
 
 bool SimConfig::resetFromParsedMap(boost::program_options::variables_map const& vm)
@@ -93,6 +94,9 @@ bool SimConfig::resetFromParsedMap(boost::program_options::variables_map const& 
   mConfigData.mInternalChunkSize = vm["chunkSizeI"].as<int>();
   mConfigData.mStartSeed = vm["seed"].as<int>();
   mConfigData.mSimWorkers = vm["nworkers"].as<int>();
+  if (vm.count("noemptyevents")) {
+    mConfigData.mFilterNoHitEvents = true;
+  }
   return true;
 }
 

--- a/DataFormats/simulation/CMakeLists.txt
+++ b/DataFormats/simulation/CMakeLists.txt
@@ -23,6 +23,7 @@ Set(HEADERS
     include/${MODULE_NAME}/RunContext.h
     include/${MODULE_NAME}/LabelContainer.h
     include/${MODULE_NAME}/MCEventHeader.h
+    include/${MODULE_NAME}/MCEventStats.h
 )
 
 Set(LINKDEF src/SimulationDataLinkDef.h)

--- a/DataFormats/simulation/include/SimulationDataFormat/MCEventHeader.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCEventHeader.h
@@ -14,6 +14,7 @@
 #define ALICEO2_DATAFORMATS_MCEVENTHEADER_H_
 
 #include "FairMCEventHeader.h"
+#include "SimulationDataFormat/MCEventStats.h"
 #include <string>
 
 namespace o2
@@ -26,6 +27,7 @@ class GeneratorHeader;
 /*****************************************************************/
 /*****************************************************************/
 
+// AliceO2 specialization of EventHeader class
 class MCEventHeader : public FairMCEventHeader
 {
 
@@ -42,11 +44,17 @@ class MCEventHeader : public FairMCEventHeader
   /** methods **/
   virtual void Reset();
 
+  MCEventStats& getMCEventStats() { return mEventStats; }
+
  protected:
   std::string mEmbeddingFileName;
   Int_t mEmbeddingEventIndex = 0;
 
-  ClassDefOverride(MCEventHeader, 1);
+  // store a view global properties that this event
+  // had in the current simulation (which can be used quick filtering/searching)
+  MCEventStats mEventStats{};
+
+  ClassDefOverride(MCEventHeader, 2);
 
 }; /** class MCEventHeader **/
 

--- a/DataFormats/simulation/include/SimulationDataFormat/MCEventStats.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCEventStats.h
@@ -1,0 +1,65 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author S Wenzel - April 2019
+
+#ifndef ALICEO2_DATAFORMATS_MCEVENTSTATS_H_
+#define ALICEO2_DATAFORMATS_MCEVENTSTATS_H_
+
+#include "Rtypes.h" // to get ClassDef?
+
+namespace o2
+{
+namespace dataformats
+{
+
+/// A simple class collecting summary counters about
+/// the MC transport of a single event/chunk
+class MCEventStats
+{
+ public:
+  void setNHits(int n) { mNOfHits = n; }
+  int getNHits() const { return mNOfHits; }
+  void setNTransportedTracks(int n) { mNOfTransportedTracks = n; }
+  int getNTransportedTracks() const { return mNOfTransportedTracks; }
+  void setNKeptTracks(int n) { mNOfKeptTracks = n; }
+  int getNKeptTracks() const { return mNOfKeptTracks; }
+  void setNSteps(int n) { mNOfSteps = n; }
+  int getNSteps() const { return mNOfSteps; }
+
+  /// merge from another object
+  void add(MCEventStats const& other)
+  {
+    mNOfHits += other.mNOfHits;
+    mNOfTransportedTracks += other.mNOfTransportedTracks;
+    mNOfKeptTracks += other.mNOfKeptTracks;
+    mNOfSteps += other.mNOfSteps;
+  }
+
+ private:
+  // store a view global properties that this event
+  // had in the current simulation (which can be used quick filtering/searching)
+
+  int mNOfHits = 0;              // number of hits produced
+  int mNOfTransportedTracks = 0; // number of tracks transported
+  int mNOfKeptTracks = 0;        // number of tracks stored/kept in output
+  int mNOfSteps = 0;             // number of MC steps done
+
+  ClassDefNV(MCEventStats, 1);
+
+}; /** class MCEventStats **/
+
+/*****************************************************************/
+/*****************************************************************/
+
+} /* namespace dataformats */
+} /* namespace o2 */
+
+#endif /* ALICEO2_DATAFORMATS_MCEVENTSTATS_H_ */

--- a/DataFormats/simulation/include/SimulationDataFormat/Stack.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/Stack.h
@@ -20,6 +20,7 @@
 #include "SimulationDataFormat/MCTrack.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
 #include "SimulationDataFormat/TrackReference.h"
+#include "SimulationDataFormat/MCEventStats.h"
 
 #include "Rtypes.h"
 #include "TParticle.h"
@@ -207,6 +208,14 @@ class Stack : public FairGenericStack
   // The resulting ids will be in strictly monotonously decreasing order
   void fillParentIDs(std::vector<int>& ids) const;
 
+  /// set MCEventStats (for current event)
+  /// used by MCApplication to inject here so that
+  /// stack can set some information
+  void setMCEventStats(o2::dataformats::MCEventStats* header);
+
+  /// update values in the current event header
+  void updateEventStats();
+
  private:
   /// STL stack (FILO) used to handle the TParticles for tracking
   /// stack entries refer to
@@ -249,6 +258,7 @@ class Stack : public FairGenericStack
   Bool_t mStoreSecondaries;
   bool mPruneKinematics = false; // whether or not we filter the output kinematics
   Int_t mMinHits;
+  Int_t mHitCounter = 0; //! counts hits communicated via addHit
   Double32_t mEnergyCut;
 
   // variables for the cleanup / filtering procedure
@@ -265,6 +275,9 @@ class Stack : public FairGenericStack
   std::vector<o2::TrackReference>* mTrackRefs = nullptr; //!
 
   o2::dataformats::MCTruthContainer<o2::TrackReference>* mIndexedTrackRefs = nullptr; //!
+
+  /// a pointer to the current MCEventStats object
+  o2::dataformats::MCEventStats* mMCEventStats = nullptr; //!
 
   /// Mark tracks for output using selection criteria
   /// returns true if all available tracks are selected
@@ -309,7 +322,12 @@ inline bool Stack::isCurrentTrackDaughterOf(int parentid) const
   // otherwise ...
   return isTrackDaughterOf(mIndexOfCurrentTrack, parentid);
 }
+
+inline void Stack::setMCEventStats(o2::dataformats::MCEventStats* header)
+{
+  mMCEventStats = header;
 }
-}
+} // namespace data
+} // namespace o2
 
 #endif

--- a/DataFormats/simulation/src/SimulationDataLinkDef.h
+++ b/DataFormats/simulation/src/SimulationDataLinkDef.h
@@ -63,6 +63,7 @@
 #pragma link C++ class vector < o2::steer::EventPart > +;
 #pragma link C++ class vector < vector < o2::steer::EventPart >> +;
 
+#pragma link C++ class o2::dataformats::MCEventStats + ;
 #pragma link C++ class o2::dataformats::MCEventHeader + ;
 
 #endif

--- a/DataFormats/simulation/src/Stack.cxx
+++ b/DataFormats/simulation/src/Stack.cxx
@@ -330,6 +330,15 @@ TParticle* Stack::PopPrimaryForTracking(Int_t iPrim)
   return &mPrimaryParticles[iPrim];
 }
 
+void Stack::updateEventStats()
+{
+  if (mMCEventStats) {
+    mMCEventStats->setNHits(mHitCounter);
+    mMCEventStats->setNTransportedTracks(mNumberOfEntriesInParticles);
+    mMCEventStats->setNKeptTracks(mTracks->size());
+  }
+}
+
 void Stack::FillTrackArray()
 {
   /// This interface is not implemented since we are filtering/filling the output array
@@ -490,6 +499,7 @@ void Stack::Reset()
   mTrackRefs->clear();
   mIndexedTrackRefs->clear();
   mTrackIDtoParticlesEntry.clear();
+  mHitCounter = 0;
 }
 
 void Stack::Register()
@@ -522,6 +532,7 @@ void Stack::Print(Option_t* option) const
 void Stack::addHit(int iDet) { addHit(iDet, mParticles.size() - 1); }
 void Stack::addHit(int iDet, Int_t iTrack)
 {
+  mHitCounter++;
   auto& part = mParticles[iTrack];
   part.setHit(iDet);
 }

--- a/Detectors/Base/include/DetectorsBase/Detector.h
+++ b/Detectors/Base/include/DetectorsBase/Detector.h
@@ -427,7 +427,7 @@ class DetImpl : public o2::base::Detector
         // for each branch name we extract/decode hits from the message parts ...
         bool* busy;
         auto hitsptr = decodeShmMessage<Hit_t>(parts, index++, busy);
-        LOG(INFO) << "GOT " << hitsptr->size() << " HITS ";
+        LOG(DEBUG2) << "GOT " << hitsptr->size() << " HITS ";
         // ... and fill the tree branch
         auto br = getOrMakeBranch(tr, name.c_str(), hitsptr);
         br->SetAddress(static_cast<void*>(&hitsptr));
@@ -461,6 +461,9 @@ class DetImpl : public o2::base::Detector
     }
   }
 
+  // default implementation for setting hits
+  // always returns false indicating that there is no other
+  // component to assign to apart from i == 0
   template <typename Hit_t>
   bool setHits(int i, std::vector<Hit_t>* ptr)
   {

--- a/Steer/include/Steer/O2MCApplication.h
+++ b/Steer/include/Steer/O2MCApplication.h
@@ -51,6 +51,8 @@ class O2MCApplication : public O2MCApplicationBase
     fStack->FillTrackArray();
     fStack->UpdateTrackIndex(fActiveDetectors);
 
+    finishEventCommon();
+
     // This special finish event version does not fill the output tree of FairRootManager
     // but forwards the data to the HitMerger
     SendData();
@@ -95,12 +97,12 @@ class O2MCApplication : public O2MCApplicationBase
   }
 
   void setSimDataChannel(FairMQChannel* channel) { mSimDataChannel = channel; }
-  void setSubEventInfo(o2::data::SubEventInfo& i) { mSubEventInfo = i; }
+  void setSubEventInfo(o2::data::SubEventInfo* i);
 
   std::vector<TParticle> mPrimaries; //!
 
   FairMQChannel* mSimDataChannel;                      //! generic channel on which to send sim data
-  o2::data::SubEventInfo mSubEventInfo;                //! what are we currently processing?
+  o2::data::SubEventInfo* mSubEventInfo = nullptr;     //! what are we currently processing?
   std::vector<o2::base::Detector*> mActiveO2Detectors; //! active (data taking) o2 detectors
 
   ClassDefOverride(O2MCApplication, 1) //Interface to MonteCarlo application

--- a/Steer/include/Steer/O2MCApplicationBase.h
+++ b/Steer/include/Steer/O2MCApplicationBase.h
@@ -54,6 +54,9 @@ class O2MCApplicationBase : public FairMCApplication
   o2::conf::SimCutParams const& mCutParams; // reference to parameter system
   unsigned long long mStepCounter{ 0 };
 
+  /// some common parts of finishEvent
+  void finishEventCommon();
+
   ClassDefOverride(O2MCApplicationBase, 1)
 };
 

--- a/Steer/src/O2MCApplication.cxx
+++ b/Steer/src/O2MCApplication.cxx
@@ -88,7 +88,9 @@ void O2MCApplicationBase::FinishEvent()
   finishEventCommon();
 
   auto header = static_cast<o2::dataformats::MCEventHeader*>(fMCEventHeader);
-  if (header->getMCEventStats().getNHits() == 0) {
+  auto& confref = o2::conf::SimConfig::Instance();
+
+  if (confref.isFilterOutNoHitEvents() && header->getMCEventStats().getNHits() == 0) {
     LOG(INFO) << "Discarding current event due to no hits";
     SetSaveCurrentEvent(false);
   }

--- a/run/O2SimDevice.h
+++ b/run/O2SimDevice.h
@@ -173,7 +173,7 @@ class O2SimDevice : public FairMQDevice
         mVMCApp->setPrimaries(chunk->mParticles);
 
         auto info = chunk->mSubEventInfo;
-        mVMCApp->setSubEventInfo(info);
+        mVMCApp->setSubEventInfo(&info);
 
         LOG(INFO) << "Processing " << chunk->mParticles.size() << " primary particles "
                   << "for event " << info.eventID << "/" << info.maxEvents << " "

--- a/run/o2sim_parallel.cxx
+++ b/run/o2sim_parallel.cxx
@@ -77,7 +77,9 @@ int checkresult()
   if (!tr) {
     errors++;
   } else {
-    errors += tr->GetEntries() != conf.getNEvents();
+    if (!conf.isFilterOutNoHitEvents()) {
+      errors += tr->GetEntries() != conf.getNEvents();
+    }
   }
 
   // add more simple checks


### PR DESCRIPTION
* Introduction of MCEventStats class to collect
  some global properties (number of hits, tracks, etc) done
  for one event. Such objects are attached to the MCEventHeader and can
  quickly be accessed for filtering MC events.

* First prototype of filtering out events which did not leave any
  detector response (hit)

* some reduction of verbosity (INFO -> DEBUG)

Implements most of https://alice.its.cern.ch/jira/browse/O2-604