### PR TITLE
Add TGenerator getter for O2 GeneratorTGenerator

### DIFF
--- a/Generators/include/Generators/GeneratorTGenerator.h
+++ b/Generators/include/Generators/GeneratorTGenerator.h
@@ -39,7 +39,7 @@ class GeneratorTGenerator : public Generator
 
   /** setters **/
   void setTGenerator(TGenerator* val) { mTGenerator = val; };
-
+  const TGenerator* getTGenerator() const { return mTGenerator; }
   /** Initialize the generator if needed **/
   Bool_t Init() override;
 


### PR DESCRIPTION
@preghenella: this is needed to be access calculated X-section of the QED generator wrapped to ``o2::evgen::GeneratorTGenerator``