### PR TITLE
o2sim: Keep track of secondary production process

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/MCTrack.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCTrack.h
@@ -129,16 +129,22 @@ class MCTrackT
     mProp = prop.i;
   }
   bool getStore() const { return ((PropEncoding)mProp).storage; }
-  // determine if this track has hits
+  /// determine if this track has hits
   bool hasHits() const { return ((PropEncoding)mProp).hitmask != 0; }
-  // set process property
+  /// set process property
   void setProcess(int proc)
   {
     auto prop = ((PropEncoding)mProp);
     prop.process = proc;
     mProp = prop.i;
   }
+
+  /// get the production process (id) of this track
   int getProcess() const { return ((PropEncoding)mProp).process; }
+
+  /// get the string representation of the production process
+  const char* getProdProcessAsString() const;
+
  private:
   /// Momentum components at start vertex [GeV]
   T mStartVertexMomentumX, mStartVertexMomentumY, mStartVertexMomentumZ;
@@ -242,6 +248,8 @@ inline MCTrackT<T>::MCTrackT(const TParticle& part)
     mStartVertexCoordinatesT(part.T() * 1e09),
     mProp(0)
 {
+  // our convention is to communicate the process as (part) of the unique ID
+  setProcess(part.GetUniqueID());
 }
 
 template <typename T>
@@ -275,7 +283,13 @@ inline Double_t MCTrackT<T>::GetRapidity() const
   return y;
 }
 
-using MCTrack = MCTrackT<float>;
+template <typename T>
+inline const char* MCTrackT<T>::getProdProcessAsString() const
+{
+  return TMCProcessName[getProcess()];
 }
+
+using MCTrack = MCTrackT<float>;
+} // end namespace o2
 
 #endif

--- a/DataFormats/simulation/include/SimulationDataFormat/Stack.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/Stack.h
@@ -129,6 +129,9 @@ class Stack : public FairGenericStack
   /// Declared in TVirtualMCStack
   Int_t GetCurrentParentTrackNumber() const override;
 
+  /// Returns the production process of the current track
+  TMCProcess GetProdProcessOfCurrentTrack() const;
+
   /// Fill the MCTrack output array, applying filter criteria
   void FillTrackArray() override;
 
@@ -327,6 +330,12 @@ inline void Stack::setMCEventStats(o2::dataformats::MCEventStats* header)
 {
   mMCEventStats = header;
 }
+
+inline TMCProcess Stack::GetProdProcessOfCurrentTrack() const
+{
+  return (TMCProcess)o2::data::Stack::GetCurrentTrack()->GetUniqueID();
+}
+
 } // namespace data
 } // namespace o2
 


### PR DESCRIPTION
* A new interface to MC stack to query the production
  process of the current track

* Actually store the process ID in our MCTrack class

This fixes https://alice.its.cern.ch/jira/browse/O2-617.

Actually, we already kept track of the process because it was
encoded in the TParticle uniqueID. This commit is just propagating this
information further and offering an actual API to read it out.