### PR TITLE
[WIP] Introduce concept of regions

### DIFF
--- a/Detectors/Base/CMakeLists.txt
+++ b/Detectors/Base/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SRCS
   src/GeometryManager.cxx
   src/MaterialManager.cxx
   src/Propagator.cxx
+  src/RegionsManager.cxx
   )
 
 Set(HEADERS
@@ -14,6 +15,7 @@ Set(HEADERS
   include/${MODULE_NAME}/GeometryManager.h
   include/${MODULE_NAME}/MaterialManager.h
   include/${MODULE_NAME}/Propagator.h
+  include/${MODULE_NAME}/RegionsManager.h
   include/${MODULE_NAME}/Triggers.h
 )
 

--- a/Detectors/Base/include/DetectorsBase/Detector.h
+++ b/Detectors/Base/include/DetectorsBase/Detector.h
@@ -98,7 +98,7 @@ class Detector : public FairDetector
 
     /// declare alignable volumes of detector
     virtual void addAlignableVolumes() const;
-    
+
     /// Sets per wrapper volume parameters
     virtual void defineWrapperVolume(Int_t id, Double_t rmin, Double_t rmax, Double_t zspan);
 

--- a/Detectors/Base/include/DetectorsBase/RegionsManager.h
+++ b/Detectors/Base/include/DetectorsBase/RegionsManager.h
@@ -1,0 +1,74 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file RegionsManager.h
+/// \brief Definition of the RegionsManager class
+
+#ifndef ALICEO2_BASE_REGIONSMANAGER_H_
+#define ALICEO2_BASE_REGIONSMANAGER_H_
+
+#include "Rtypes.h"
+#include <string>
+#include <map>
+#include <vector>
+
+namespace o2
+{
+namespace base
+{
+
+// Central class managing creation of volume regions. It adapts the concept of
+// regions as it used in GEANT4. A region is declared via its unique name and
+// the name of the targeted hierachical root volume in order to be independent
+// of geometry/engine implementations at this point.
+class RegionsManager
+{
+ public:
+  static RegionsManager& Instance()
+  {
+    static RegionsManager inst;
+    return inst;
+  }
+
+  // Declare a TGeoVolume to be a root of a region
+  // NOTE Does currently only work with TGeo geometry (as it used by O2)
+  // \param rootVolumeName: name of the volume which should be the root volume of the region.
+  //                        Must be unique! A volume cannot be a root volume of two regions
+  // \param regionName: name of the region, the volume should be added to
+  void addRootVolumeToRegion(const std::string& regionName,const std::string& rootVolumeName);
+
+  // Return the regions with their root volume names
+  const std::map<std::string, std::vector<std::string>>&
+  getRegionVolumesMap() const;
+
+ private:
+   // Check for existing region names and duplications for rootTGeoVolName as being root volume
+   // for multiple regions
+   bool checkRootVolumeExists(const std::string& rootVolumeName) const;
+   // Insert the region - volume pair
+   // TODO This needs to be done recursively
+   void insertRootVolume(const std::string& regionName,const std::string& rootVolumeName);
+
+ private:
+  RegionsManager() = default;
+
+  // lookup structures
+  // map of region name -> name of root volume
+  std::map<std::string, std::vector<std::string>> mRegionVolumesMap;
+  // all root volume names, must be unique, one volume cannot belong to multiple regions
+  std::vector<std::string> mRootVolumeNames;
+
+ public:
+  ClassDefNV(RegionsManager, 0);
+};
+} // namespace base
+} // namespace o2
+
+#endif

--- a/Detectors/Base/src/Detector.cxx
+++ b/Detectors/Base/src/Detector.cxx
@@ -14,6 +14,7 @@
 #include "DetectorsBase/Detector.h"
 #include <TVirtualMC.h> // for TVirtualMC, gMC
 #include "DetectorsBase/MaterialManager.h"
+#include "DetectorsBase/RegionsManager.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 #include "Field/MagneticField.h"
 #include "TString.h" // for TString

--- a/Detectors/Base/src/RegionsManager.cxx
+++ b/Detectors/Base/src/RegionsManager.cxx
@@ -1,0 +1,50 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file RegionsManager.cxx
+/// \brief Implementation of the RegionsManager class
+
+#include <algorithm>
+
+#include "DetectorsBase/RegionsManager.h"
+#include <FairLogger.h>
+
+using namespace o2::base;
+
+void RegionsManager::addRootVolumeToRegion(const std::string& regionName,const std::string& rootVolumeName)
+{
+  if(!checkRootVolumeExists(rootVolumeName)) {
+    LOG(FATAL) << "Volume " << rootVolumeName << " is already a root volume";
+  }
+  insertRootVolume(regionName, rootVolumeName);
+  LOG(INFO) << "Added root volume " << rootVolumeName << " to region " << regionName;
+}
+
+bool RegionsManager::checkRootVolumeExists(const std::string& rootVolumeName) const
+{
+  if(std::find(mRootVolumeNames.begin(), mRootVolumeNames.end(), rootVolumeName) != mRootVolumeNames.end()) {
+    return false;
+  }
+  return true;
+}
+
+void RegionsManager::insertRootVolume(const std::string& regionName,const std::string& rootVolumeName)
+{
+  mRootVolumeNames.push_back(rootVolumeName);
+  mRegionVolumesMap[regionName].push_back(rootVolumeName);
+}
+
+const std::map<std::string, std::vector<std::string>>&
+RegionsManager::getRegionVolumesMap() const
+{
+  return mRegionVolumesMap;
+}
+
+ClassImp(o2::base::RegionsManager)

--- a/Detectors/CMakeLists.txt
+++ b/Detectors/CMakeLists.txt
@@ -30,6 +30,7 @@ add_subdirectory(ZDC)
 add_subdirectory(GlobalTracking)
 IF (HAVESIMULATION)
   add_subdirectory(gconfig)
+  add_subdirectory(FastSim)
 ENDIF (HAVESIMULATION)
 
 if(DEFINED ALITPCCOMMON_DIR)

--- a/Detectors/FastSim/CMakeLists.txt
+++ b/Detectors/FastSim/CMakeLists.txt
@@ -1,0 +1,2 @@
+# Libraries
+add_subdirectory(base)

--- a/Detectors/FastSim/base/CMakeLists.txt
+++ b/Detectors/FastSim/base/CMakeLists.txt
@@ -1,0 +1,19 @@
+SET(MODULE_NAME FastSimBase)
+
+O2_SETUP(NAME ${MODULE_NAME})
+
+set(SRCS
+  src/DirectTransport.cxx
+  src/DirectTransportBuilder.cxx
+)
+
+set(HEADERS
+  include/${MODULE_NAME}/DirectTransport.h
+  include/${MODULE_NAME}/DirectTransportBuilder.h
+)
+
+#SET(LINKDEF src/FastSimBaseLinkDef.h)
+SET(LIBRARY_NAME ${MODULE_NAME})
+SET(BUCKET_NAME fastsim_base_bucket)
+
+O2_GENERATE_LIBRARY()

--- a/Detectors/FastSim/base/include/FastSimBase/DirectTransport.h
+++ b/Detectors/FastSim/base/include/FastSimBase/DirectTransport.h
@@ -1,0 +1,36 @@
+#ifndef ALICEO2_FASTSIM_BASE_DIRECTTRANSPORT_H_
+#define ALICEO2_FASTSIM_BASE_DIRECTTRANSPORT_H_
+
+#include <G4VFastSimulationModel.hh>
+
+namespace o2
+{
+namespace base
+{
+
+/// This fast sim model just pushes a track through a FairModule repspecting
+/// external fields as well
+class DirectTransport : public G4VFastSimulationModel
+{
+  public:
+
+    DirectTransport(const G4String& name);
+    DirectTransport(const G4String& name, G4Region* region);
+
+    G4bool IsApplicable(const G4ParticleDefinition& aParticleType) final;
+    G4bool ModelTrigger(const G4FastTrack& aFastTrack) final;
+    void DoIt(const G4FastTrack& aFastTrack, G4FastStep& aFastStep) final;
+
+  private:
+    DirectTransport(const DirectTransport&);
+    DirectTransport& operator=(const DirectTransport&);
+
+  private:
+    G4bool mDidDirectStep;
+    G4double mLastStep;
+};
+
+} // namespace base
+} // namespace o2
+
+#endif /* ALICEO2_FASTSIM_BASE_DIRECTTRANSPORT_H_ */

--- a/Detectors/FastSim/base/include/FastSimBase/DirectTransportBuilder.h
+++ b/Detectors/FastSim/base/include/FastSimBase/DirectTransportBuilder.h
@@ -1,0 +1,43 @@
+#ifndef ALICEO2_FASTSIM_BASE_DIRECTTRANSPORTBUILDER_H_
+#define ALICEO2_FASTSIM_BASE_DIRECTTRANSPORTBUILDER_H_
+
+#include <G4String.hh>
+
+#include "FastSimBase/DirectTransport.h"
+
+class G4Region;
+
+namespace o2
+{
+namespace base
+{
+
+class DirectTransport;
+
+/// This fast sim model just pushes a track through a FairModule repspecting
+/// external fields as well
+class DirectTransportBuilder
+{
+  public:
+
+    static DirectTransportBuilder& Instance()
+    {
+      static DirectTransportBuilder inst;
+      return inst;
+    }
+
+    DirectTransport* build(G4Region* region) const;
+    DirectTransport* build(const G4String& name) const;
+
+    ~DirectTransportBuilder() = default;
+
+  private:
+    DirectTransportBuilder() = default;
+
+};
+
+
+} // namespace base
+} // namespace o2
+
+#endif /* ALICEO2_FASTSIM_BASE_DIRECTTRANSPORTBUILDER_H_ */

--- a/Detectors/FastSim/base/src/DirectTransport.cxx
+++ b/Detectors/FastSim/base/src/DirectTransport.cxx
@@ -1,0 +1,70 @@
+#include <iostream>
+
+#include <G4Track.hh>
+#include <G4PathFinder.hh>
+#include <G4FieldTrack.hh>
+#include <G4FieldTrackUpdator.hh>
+#include <G4FastTrack.hh>
+#include <G4FastStep.hh>
+#include <G4SystemOfUnits.hh>
+
+#include "FastSimBase/DirectTransport.h"
+
+using namespace o2::base;
+
+DirectTransport::DirectTransport(const G4String& name)
+  : G4VFastSimulationModel(name), mDidDirectStep(false), mLastStep(1.)
+{}
+
+DirectTransport::DirectTransport(const G4String& name, G4Region* region)
+  : G4VFastSimulationModel(name, region), mDidDirectStep(false), mLastStep(1.)
+{}
+
+G4bool DirectTransport::IsApplicable(const G4ParticleDefinition& aParticleType)
+{
+  return true;
+}
+
+G4bool DirectTransport::ModelTrigger(const G4FastTrack &)
+{
+  if(!mDidDirectStep || (mDidDirectStep && mLastStep > 0.01)) {
+    std::cout << "IsApplicable, last step: " << mLastStep << std::endl;
+    return true;
+  }
+  std::cout << "IsApplicable: NO" << std::endl;
+  mDidDirectStep = false;
+  return false;
+}
+
+void DirectTransport::DoIt(const G4FastTrack& aFastTrack, G4FastStep& aFastStep)
+{
+  auto track = *aFastTrack.GetPrimaryTrack();
+
+  std::cout << track.GetPosition() << std::endl;
+
+  auto pathFinder = G4PathFinder::GetInstance();
+  std::cout << "Do direct transport" << std::endl;
+
+  G4FieldTrack aFieldTrack('0');
+  G4FieldTrackUpdator::Update( &aFieldTrack, &track );
+
+  G4double retSafety = -1.0;
+  ELimited retStepLimited;
+  G4FieldTrack endTrack('a');
+  G4double currentMinimumStep = DBL_MAX;
+
+  mLastStep = pathFinder->ComputeStep(aFieldTrack, currentMinimumStep, 0,
+                          aFastTrack.GetPrimaryTrack()->GetCurrentStepNumber(),
+                          retSafety, retStepLimited, endTrack,
+                          aFastTrack.GetPrimaryTrack()->GetVolume());
+
+  //G4ThreeVector addStep(0.001, 0.001, 0.001);
+
+  //addStep += endTrack.GetPosition();
+
+  aFastStep.ProposePrimaryTrackFinalPosition(endTrack.GetPosition());
+
+  std::cout << endTrack.GetPosition() << std::endl;
+  std::cout << mLastStep << std::endl;
+  mDidDirectStep = true;
+}

--- a/Detectors/FastSim/base/src/DirectTransportBuilder.cxx
+++ b/Detectors/FastSim/base/src/DirectTransportBuilder.cxx
@@ -1,0 +1,18 @@
+#include <G4Region.hh>
+
+#include "FastSimBase/DirectTransport.h"
+#include "FastSimBase/DirectTransportBuilder.h"
+
+using namespace o2::base;
+
+DirectTransport* DirectTransportBuilder::build(G4Region* region) const
+{
+  // New direct transport model with the G4Region just extracted.
+  return new DirectTransport(region->GetName() + "_directTransport", region);
+}
+
+DirectTransport* DirectTransportBuilder::build(const G4String& name) const
+{
+  // New direct transport model with the G4Region just extracted.
+  return new DirectTransport(name + "_directTransport");
+}

--- a/Detectors/FastSim/base/src/FastSimBaseLinkDef.h
+++ b/Detectors/FastSim/base/src/FastSimBaseLinkDef.h
@@ -14,12 +14,4 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
-#pragma link C++ class o2::base::Detector + ;
-#pragma link C++ class o2::base::Propagator + ;
-
-#pragma link C++ class o2::base::GeometryManager + ;
-#pragma link C++ class o2::base::GeometryManager::MatBudget + ;
-#pragma link C++ class o2::base::MaterialManager + ;
-#pragma link C++ class o2::base::RegionsManager + ;
-
 #endif

--- a/Detectors/TPC/simulation/src/Detector.cxx
+++ b/Detectors/TPC/simulation/src/Detector.cxx
@@ -12,6 +12,8 @@
 #include "TPCSimulation/Point.h"
 #include "TPCBase/ParameterGas.h"
 
+#include "DetectorsBase/RegionsManager.h"
+
 #include "SimulationDataFormat/Stack.h"
 #include "SimulationDataFormat/TrackReference.h"
 
@@ -1001,6 +1003,7 @@ void Detector::ConstructTPCGeometry()
   //
   TGeoMedium* m1 = gGeoManager->GetMedium("TPC_Air");
   auto* v1 = new TGeoVolume("TPC_M", tpc, m1);
+
   //
   // drift volume - sensitive volume, extended beyond the
   // endcaps, because of the alignment
@@ -1017,6 +1020,8 @@ void Detector::ConstructTPCGeometry()
   //
   TGeoMedium* m5 = gGeoManager->GetMedium("TPC_DriftGas2");
   auto* v9 = new TGeoVolume("TPC_Drift", dvol, m5);
+  // This volume is now defined as root volume of a region
+  //o2::base::RegionsManager::Instance().addRootVolumeToRegion("TPC_DriftGas2", "TPC_M");
   //
   v1->AddNode(v9, 1);
   //

--- a/Detectors/gconfig/CMakeLists.txt
+++ b/Detectors/gconfig/CMakeLists.txt
@@ -7,11 +7,17 @@ set(SRCS
      src/G4Config.cxx
      src/SimSetup.cxx
      src/GlobalProcessCutSimParam.cxx
+     src/O2G4RegionsConstruction.cxx
+     src/O2G4FastSimConstruction.cxx
+     src/O2G4RunConfiguration.cxx
    )
 
 set(HEADERS
     include/${MODULE_NAME}/SimSetup.h
     include/${MODULE_NAME}/GlobalProcessCutSimParam.h
+    include/${MODULE_NAME}/O2G4RegionsConstruction.h
+    include/${MODULE_NAME}/O2G4FastSimConstruction.h
+    include/${MODULE_NAME}/O2G4RunConfiguration.h
    )
 
 Set(LINKDEF src/GConfLinkDef.h)

--- a/Detectors/gconfig/g4Config.C
+++ b/Detectors/gconfig/g4Config.C
@@ -13,7 +13,6 @@
 #include "TPythia6Decayer.h"
 #include "FairRunSim.h"
 #include "TSystem.h"
-#include "TG4RunConfiguration.h"
 #endif
 #include "commonConfig.C"
 
@@ -55,8 +54,9 @@ void Config()
                                  // one and all of its secondaries have been transported
                                  // any other choice is dangerously inconsistent with the FinishPrimary() interface of VMCApp
 
-  auto runConfiguration = new TG4RunConfiguration("geomRoot", "QGSP_FTFP_BERT+optical", "stepLimiter+specialCuts",
-                                                  specialStacking, mtMode);
+  auto runConfiguration = new O2G4RunConfiguration("geomRoot", "QGSP_FTFP_BERT+optical", "stepLimiter+specialCuts",
+                                                   specialStacking, mtMode);
+
 
   /// Create the G4 VMC
   TGeant4* geant4 = new TGeant4("TGeant4", "The Geant4 Monte Carlo", runConfiguration);

--- a/Detectors/gconfig/g4config.in
+++ b/Detectors/gconfig/g4config.in
@@ -1,6 +1,7 @@
 # Geant4 standard configuration based on AliDPG commit 7650a5b
 
 /control/verbose 2
+
 /mcVerbose/all 1
 /mcVerbose/geometryManager 1
 /mcVerbose/opGeometryManager 1

--- a/Detectors/gconfig/include/SimSetup/O2G4FastSimConstruction.h
+++ b/Detectors/gconfig/include/SimSetup/O2G4FastSimConstruction.h
@@ -1,0 +1,58 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file O2G4FastSimConstruction.h
+/// \brief Definition of the FastSims to be created by GEANT4
+
+#ifndef DETECTORS_GCONFIG_INCLUDE_SIMSETUP_O2G4FASTSIMCONSTRUCTION_H_
+#define DETECTORS_GCONFIG_INCLUDE_SIMSETUP_O2G4FASTSIMCONSTRUCTION_H_
+
+#include <string>
+#include <vector>
+
+#include "TG4VUserFastSimulation.h"
+
+namespace o2
+{
+namespace base
+{
+class DirectTransport;
+}
+}
+
+namespace o2
+{
+
+class O2G4FastSimConstruction : public TG4VUserFastSimulation
+{
+  public:
+    O2G4FastSimConstruction(const std::vector<std::string>& directTransportRegions = {});
+    ~O2G4FastSimConstruction() override = default;
+
+    void AddDirectTransportRegion(const std::string& name);
+
+    // Override this final
+    void Construct() final;
+
+  private:
+    /// Not implemented
+    O2G4FastSimConstruction(const O2G4FastSimConstruction& right);
+    /// Not implemented
+    O2G4FastSimConstruction& operator=(const O2G4FastSimConstruction& right);
+
+  private:
+    // names of regions which a DirectTransport will be built for
+    std::vector<std::string> mDirectTransportRegions;
+    std::vector<base::DirectTransport*> mDirectTransportModels;
+};
+
+} // namespace o2
+
+#endif /* DETECTORS_GCONFIG_INCLUDE_SIMSETUP_O2G4FASTSIMCONSTRUCTION_H_ */

--- a/Detectors/gconfig/include/SimSetup/O2G4RegionsConstruction.h
+++ b/Detectors/gconfig/include/SimSetup/O2G4RegionsConstruction.h
@@ -1,0 +1,42 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file G4RegionsConstruction.h
+/// \brief Definition of the Regions to be created by GEANT4 class
+
+#ifndef DETECTORS_GCONFIG_INCLUDE_SIMSETUP_O2G4REGIONSCONSTRUCTION_H_
+#define DETECTORS_GCONFIG_INCLUDE_SIMSETUP_O2G4REGIONSCONSTRUCTION_H_
+
+#include "TG4VUserRegionConstruction.h"
+
+namespace o2
+{
+
+class O2G4RegionsConstruction : public TG4VUserRegionConstruction
+{
+  public:
+    O2G4RegionsConstruction() = default;
+    ~O2G4RegionsConstruction() override = default;
+
+    // Override this final
+    void Construct() final;
+
+  private:
+    /// Not implemented
+    O2G4RegionsConstruction(const O2G4RegionsConstruction& right);
+    /// Not implemented
+    O2G4RegionsConstruction& operator=(const O2G4RegionsConstruction& right);
+
+
+};
+
+} // namespace o2
+
+#endif /* DETECTORS_GCONFIG_INCLUDE_SIMSETUP_G4REGIONSCONSTRUCTION_H_ */

--- a/Detectors/gconfig/include/SimSetup/O2G4RunConfiguration.h
+++ b/Detectors/gconfig/include/SimSetup/O2G4RunConfiguration.h
@@ -1,0 +1,57 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file O2G4RunConfiguration.h
+/// \brief Overriding what is necessary for custom O2 version of TG4RunConfiguration
+
+#ifndef DETECTORS_GCONFIG_INCLUDE_SIMSETUP_O2G4RUNCONFIGURATION_H_
+#define DETECTORS_GCONFIG_INCLUDE_SIMSETUP_O2G4RUNCONFIGURATION_H_
+
+#include <string>
+
+#include "TG4RunConfiguration.h"
+
+class G4VUserPhysicsList;
+class TG4VUserRegionConstruction;
+class TG4VUserFastSimulation;
+
+namespace o2
+{
+
+class O2G4RunConfiguration : public TG4RunConfiguration
+{
+  public:
+    O2G4RunConfiguration(const std::string& userGeometry = "geomRoot",
+                         const std::string& physicsList = "QGSP_FTFP_BERT+optical",
+                         const std::string& specialProcess = "stepLimiter+specialCuts",
+                         bool specialStacking = true,
+                         bool mtApplication = true);
+
+    virtual ~O2G4RunConfiguration() override = default;
+
+    virtual TG4VUserRegionConstruction* CreateUserRegionConstruction() override;
+    virtual TG4VUserFastSimulation* CreateUserFastSimulation() override;
+
+    void SetFastSimConstruction(TG4VUserFastSimulation* fastSimConstruction);
+
+  private:
+    /// Not implemented
+    O2G4RunConfiguration();
+    O2G4RunConfiguration(const O2G4RunConfiguration& right);
+    O2G4RunConfiguration& operator=(const O2G4RunConfiguration& right);
+
+  private:
+    TG4VUserFastSimulation* mFastSimConstruction;
+
+};
+
+} // namespace o2
+
+#endif /* DETECTORS_GCONFIG_INCLUDE_SIMSETUP_O2G4RUNCONFIGURATION_H_ */

--- a/Detectors/gconfig/src/G4Config.cxx
+++ b/Detectors/gconfig/src/G4Config.cxx
@@ -20,6 +20,8 @@
 #include <DetectorsPassive/Cave.h>
 #include "DetectorsBase/MaterialManager.h"
 #include "SimSetup/GlobalProcessCutSimParam.h"
+#include "SimSetup/O2G4RunConfiguration.h"
+#include "SimSetup/O2G4FastSimConstruction.h"
 
 //using declarations here since SetCuts.C and g4Config.C are included within namespace
 // these are needed for SetCuts.C inclusion
@@ -27,6 +29,8 @@ using o2::GlobalProcessCutSimParam;
 using o2::base::ECut;
 using o2::base::EProc;
 using o2::base::MaterialManager;
+using o2::O2G4RunConfiguration;
+using o2::O2G4FastSimConstruction;
 // these are used in g4Config.C
 using std::cout;
 using std::endl;

--- a/Detectors/gconfig/src/O2G4FastSimConstruction.cxx
+++ b/Detectors/gconfig/src/O2G4FastSimConstruction.cxx
@@ -1,0 +1,51 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file G4RegionsConstruction.cxx
+/// \brief Definition of the Regions to be created by GEANT4 class
+
+#include <iostream>
+
+#include <G4Region.hh>
+#include <G4RegionStore.hh>
+
+#include <FairLogger.h>
+
+#include "FastSimBase/DirectTransportBuilder.h"
+#include "FastSimBase/DirectTransport.h"
+
+#include "SimSetup/O2G4FastSimConstruction.h"
+
+using namespace o2;
+
+O2G4FastSimConstruction::O2G4FastSimConstruction(const std::vector<std::string>& directTransportRegions)
+  : TG4VUserFastSimulation()
+{
+  auto& directTransportBuilder = base::DirectTransportBuilder::Instance();
+  for(auto& r : directTransportRegions) {
+    if(std::find(mDirectTransportRegions.begin(), mDirectTransportRegions.end(), r) == mDirectTransportRegions.end()) {
+      mDirectTransportRegions.push_back(r);
+      auto model = directTransportBuilder.build(r);
+      mDirectTransportModels.push_back(model);
+      SetModel(model->GetName());
+      SetModelParticles(model->GetName(), "all");
+      SetModelRegions(model->GetName(), r);
+    }
+  }
+}
+
+void O2G4FastSimConstruction::Construct()
+{
+  std::cout << "Built TGeant4 fast sims" << std::endl;
+  for(auto& model : mDirectTransportModels) {
+    Register(model);
+    LOG(INFO) << "Built direct transport for region " << model->GetName();
+  }
+}

--- a/Detectors/gconfig/src/O2G4RegionsConstruction.cxx
+++ b/Detectors/gconfig/src/O2G4RegionsConstruction.cxx
@@ -1,0 +1,51 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file G4RegionsConstruction.cxx
+/// \brief Definition of the Regions to be created by GEANT4 class
+
+#include <G4LogicalVolume.hh>
+#include <G4Region.hh>
+
+#include <TG4GeometryServices.h>
+
+#include <FairLogger.h>
+
+#include "SimSetup/O2G4RegionsConstruction.h"
+#include "DetectorsBase/RegionsManager.h"
+#include "FastSimBase/DirectTransport.h"
+#include "FastSimBase/DirectTransportBuilder.h"
+
+using namespace o2;
+
+void O2G4RegionsConstruction::Construct()
+{
+  auto regionVolumesMap = base::RegionsManager::Instance().getRegionVolumesMap();
+  auto& directTransportBuilder = base::DirectTransportBuilder::Instance();
+  for(auto& rVols : regionVolumesMap) {
+    if(rVols.second.size() == 0) {
+      continue;
+    }
+    auto region = new G4Region(rVols.first);
+    LOG(INFO) << "Constructed new GEANT4 region " << rVols.first;
+    // Now loop over volumes
+    for(auto& vol : rVols.second) {
+      auto g4LV = TG4GeometryServices::Instance()->FindLogicalVolume(vol.c_str());
+      if(!g4LV) {
+        LOG(FATAL) << "The GEANT4 corresponding volume " << vol << " cannot be found.";
+      }
+      region->AddRootLogicalVolume(g4LV);
+      LOG(INFO) << "Added logical volume " << vol << " to GEANT4 region " << rVols.first;
+    }
+    // Build the direct transport
+    LOG(INFO) << "Build direct transport for GEANT4 region " << rVols.first;
+    directTransportBuilder.build(region);
+  }
+}

--- a/Detectors/gconfig/src/O2G4RunConfiguration.cxx
+++ b/Detectors/gconfig/src/O2G4RunConfiguration.cxx
@@ -1,0 +1,58 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file O2G4RunConfiguration.cxx
+/// \brief Overriding what is necessary for custom O2 version of TG4RunConfiguration
+
+#include <TG4VUserRegionConstruction.h>
+#include <TG4VUserFastSimulation.h>
+
+#include <G4VUserPhysicsList.hh>
+#include <G4FastSimulationPhysics.hh>
+#include <G4VModularPhysicsList.hh>
+
+#include <FairLogger.h>
+
+#include "SimSetup/O2G4RegionsConstruction.h"
+#include "SimSetup/O2G4FastSimConstruction.h"
+#include "SimSetup/O2G4RunConfiguration.h"
+
+using namespace o2;
+
+O2G4RunConfiguration::O2G4RunConfiguration(const std::string& userGeometry,
+                     const std::string& physicsList, const std::string& specialProcess,
+                     bool specialStacking, bool mtApplication)
+  : TG4RunConfiguration(userGeometry.c_str(), physicsList.c_str(), specialProcess.c_str(),
+                        specialStacking, mtApplication), mFastSimConstruction(nullptr)
+{
+  LOG(INFO) << "O2 specific run configuration used";
+}
+
+TG4VUserRegionConstruction* O2G4RunConfiguration::CreateUserRegionConstruction()
+{
+  LOG(INFO) << "Construct regions for TGeant4";
+  return new O2G4RegionsConstruction();
+}
+
+TG4VUserFastSimulation* O2G4RunConfiguration::CreateUserFastSimulation()
+{
+  /// Create the fast sim construction
+  LOG(INFO) << "Create fast simulation construction for TGeant4";
+  // TODO This is for now hard-coded here but will be changed.
+  // TODO Make region extraction base on volume and not on material as it is
+  //      done in GEANT4_VMC
+  return new O2G4FastSimConstruction({"TPC_DriftGas2"});
+}
+
+void O2G4RunConfiguration::SetFastSimConstruction(TG4VUserFastSimulation* fastSimConstruction)
+{
+  LOG(INFO) << "Set fast simulation for TGeant4";
+  mFastSimConstruction = fastSimConstruction;
+}

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -2406,10 +2406,29 @@ o2_define_bucket(
     ${CMAKE_SOURCE_DIR}/Detectors/MUON/MID/TestingSimTools/include
 )
 
+o2_define_bucket(
+    NAME
+    fastsim_base_bucket
+
+    DEPENDENCIES
+    ${Geant4_LIBRARIES}
+    ${Geant4VMC_LIBRARIES}
+    ${FairLogger_DEP}
+
+    INCLUDE_DIRECTORIES
+    ${Geant4VMC_INCLUDE_DIRS}
+    ${Geant4_INCLUDE_DIRS}
+    ${FairLogger_INCDIR}
+    ${CMAKE_SOURCE_DIR}/Detectors/FastSim/base/FastSimBase/include
+)
 
 o2_define_bucket(
     NAME
     simulation_setup_bucket
+
+
+
+
 
     DEPENDENCIES
     ${Geant3_LIBRARIES}
@@ -2419,6 +2438,7 @@ o2_define_bucket(
     fairroot_geom
     SimulationDataFormat
     DetectorsPassive
+    FastSimBase
     pythia6 # this is needed by Geant3 and EGPythia6
     EGPythia6 # this is needed by Geant4 (TPythia6Decayer)
 


### PR DESCRIPTION
It is targeted to introduce the concept of abstract regions as it is
present in GEANT4. This should bring following functionality

-> Define regions during detector construction which might be covered by
   a fast simulation.
-> Will allow for transporting tracks through a region without
   interaction in case a user wants certain particles to skip that
   particular region (e.g. some detecor or passive module).
-> Allows to inter-connect volumes of different detectors/modules.
-> In case of using multiple engines (e.g. mixing GEANT3 with GEANT4) it
   can support the definitions of regions each engine is responsible
   for, see also
   https://github.com/root-project/root/commit/93992b135b37fe8d2592ead5cdbe3b44ef33fea1