### PR TITLE
o2sim: write out sensitive volumes

### DIFF
--- a/Steer/include/Steer/O2MCApplicationBase.h
+++ b/Steer/include/Steer/O2MCApplicationBase.h
@@ -46,6 +46,7 @@ class O2MCApplicationBase : public FairMCApplication
   void BeginEvent() override;
   void FinishEvent() override;
   void ConstructGeometry() override;
+  void InitGeometry() override;
 
   // specific implementation of our hard geometry limits
   double TrackingRmax() const override { return mCutParams.maxRTracking; }
@@ -55,6 +56,8 @@ class O2MCApplicationBase : public FairMCApplication
   o2::conf::SimCutParams const& mCutParams; // reference to parameter system
   unsigned long long mStepCounter{ 0 };
   std::map<int, std::string> mModIdToName{}; // mapping of module id to name
+  std::map<int, std::string> mSensitiveVolumes{}; // collection of all sensitive volumes with
+                                                  // keeping track of volumeIds and volume names
 
   /// some common parts of finishEvent
   void finishEventCommon();

--- a/Steer/src/O2MCApplication.cxx
+++ b/Steer/src/O2MCApplication.cxx
@@ -25,6 +25,7 @@
 #include <SimulationDataFormat/MCEventHeader.h>
 #include <TGeoManager.h>
 #include <fstream>
+#include <FairVolume.h>
 
 namespace o2
 {
@@ -95,6 +96,21 @@ void O2MCApplicationBase::ConstructGeometry()
     auto vol = static_cast<TGeoVolume*>(vollist->At(i));
     auto iter = fModVolMap.find(vol->GetNumber());
     voltomodulefile << vol->GetName() << ":" << mModIdToName[iter->second] << "\n";
+  }
+}
+
+void O2MCApplicationBase::InitGeometry()
+{
+  FairMCApplication::InitGeometry();
+  // now the sensitive volumes are set up in fVolMap and we can query them
+  for (auto e : fVolMap) {
+    // since fVolMap contains multiple entries (if multiple copies), this may
+    // write to the same entry multiple times
+    mSensitiveVolumes[e.first] = e.second->GetName();
+  }
+  std::ofstream sensvolfile("MCStepLoggerSenVol.dat");
+  for (auto e : mSensitiveVolumes) {
+    sensvolfile << e.first << ":" << e.second << "\n";
   }
 }
 


### PR DESCRIPTION
Keep track of which volumes are sensitive.
The main motivation here is that external tools (MCStepLogger)
can use this to categorize steps according to if in sensitive region
or not.