### PR TITLE
o2sim: correctly register hit creation; remove duplicate bucket

### DIFF
--- a/Detectors/CPV/simulation/src/Detector.cxx
+++ b/Detectors/CPV/simulation/src/Detector.cxx
@@ -351,6 +351,8 @@ void Detector::AddHit(int trackID, int detID, const Point3D<float>& pos, double 
   LOG(DEBUG4) << "Adding hit for track " << trackID << " in a pad " << detID << " with position (" << pos.X() << ", "
               << pos.Y() << ", " << pos.Z() << "), time" << time << ", qdep =" << qdep << std::endl;
   mHits->emplace_back(trackID, detID, pos, time, qdep);
+  // register hit creation with MCStack
+  static_cast<o2::data::Stack*>(fMC->GetStack())->addHit(GetDetId());
 }
 
 void Detector::ConstructGeometry()

--- a/Detectors/MUON/MCH/Simulation/src/Detector.cxx
+++ b/Detectors/MUON/MCH/Simulation/src/Detector.cxx
@@ -10,6 +10,7 @@
 
 #include "MCHSimulation/Detector.h"
 #include "MCHSimulation/Geometry.h"
+#include "SimulationDataFormat/Stack.h"
 #include "Stepper.h"
 #include "TGeoManager.h"
 #include <sstream>
@@ -63,6 +64,7 @@ void Detector::ConstructGeometry()
 Bool_t Detector::ProcessHits(FairVolume* v)
 {
   mStepper->process(*fMC);
+  (static_cast<o2::data::Stack*>(fMC->GetStack()))->addHit(GetDetId());
   return kTRUE;
 }
 

--- a/Detectors/MUON/MID/Simulation/src/Detector.cxx
+++ b/Detectors/MUON/MID/Simulation/src/Detector.cxx
@@ -10,6 +10,7 @@
 
 #include "MIDSimulation/Detector.h"
 #include "MIDSimulation/Geometry.h"
+#include "SimulationDataFormat/Stack.h"
 #include <TGeoManager.h>
 #include <TGeoVolume.h>
 #include "FairVolume.h"
@@ -40,7 +41,11 @@ void Detector::InitializeO2Detector()
 
 bool Detector::ProcessHits(FairVolume* vol)
 {
-  return mStepper.process(*fMC);
+  auto hit = mStepper.process(*fMC);
+  if (hit) {
+    (static_cast<o2::data::Stack*>(fMC->GetStack()))->addHit(GetDetId());
+  }
+  return hit;
 }
 
 std::vector<Hit>* Detector::getHits(int iColl)

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -2341,23 +2341,6 @@ o2_define_bucket(
     MIDClustering
 )
 
-o2_define_bucket(
-    NAME
-    mid_simulation_bucket
-
-    DEPENDENCIES
-    mid_base_bucket
-    root_base_bucket
-    fairroot_base_bucket
-    DetectorsBase
-    detectors_base_bucket
-    SimulationDataFormat
-    MIDBase
-
-    INCLUDE_DIRECTORIES
-    ${CMAKE_SOURCE_DIR}/Detectors/Base/include
-    ${CMAKE_SOURCE_DIR}/DataFormats/simulation/include
-)
 
 o2_define_bucket(
     NAME
@@ -2454,6 +2437,7 @@ o2_define_bucket(
     root_base_bucket
     mid_base_bucket
     MIDBase
+    SimulationDataFormat
 )
 
 o2_define_bucket(


### PR DESCRIPTION
add calls to stack->addHit since we need to register tracks that
create a hit (important for Kinematics pruning)
  * done for CVP, MCH, MID

remove a duplicate bucket for mid_simulation