### PR TITLE
Fix duplicated name in merger example topology

### DIFF
--- a/Utilities/Mergers/src/mergersTopologyExample.cxx
+++ b/Utilities/Mergers/src/mergersTopologyExample.cxx
@@ -225,7 +225,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
     mergersBuilder.generateInfrastructure(specs);
 
     DataProcessorSpec printer{
-      "printer-bins",
+      "printer-custom",
       Inputs{
         { "custom", "TST", "CUSTOM", 0 }
       },


### PR DESCRIPTION
This duplicated name prevented from running the topology.