### PR TITLE
Fix: b124-127 of RDH are EndPoint ID, 0 is not guaranteed

### DIFF
--- a/DataFormats/Headers/include/Headers/RAWDataHeader.h
+++ b/DataFormats/Headers/include/Headers/RAWDataHeader.h
@@ -109,7 +109,7 @@ struct RAWDataHeaderV3 {
       uint8_t linkID : 8;          /// bit 96 to 103: link id
       uint8_t packetCounter : 8;   /// bit 104 to 111: packet counter
       uint16_t cruID : 12;         /// bit 112 to 123: CRU ID
-      uint8_t zero1 : 4;           /// bit 124 to 127: zeroed
+      uint8_t endPointID : 4;      /// bit 124 to 127: DATAPATH WRAPPER ID: number used to identify one of the 2 End Points [0/1]
     };                             ///
   };                               ///
   union {                          ///

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ChipMappingMFT.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ChipMappingMFT.h
@@ -52,6 +52,15 @@ class ChipMappingMFT
   ///< get HW id of the RU (software id of the RU)
   uint16_t RUSW2FEEId(uint16_t sw, uint16_t linkID = 0) const { return 0; }
 
+  ///< compose FEEid for given stave (ru) relative to layer and link, see documentation in the constructor
+  uint16_t composeFEEId(uint16_t lr, uint16_t ruOnLr, uint16_t link) const { return 0; }
+
+  ///< decompose FEEid to layer, stave (ru) relative to layer, link, see documentation in the constructor
+  void expandFEEId(uint16_t feeID, uint16_t& lr, uint16_t& ruOnLr, uint16_t& link) const
+  {
+    lr = ruOnLr = link = 0;
+  }
+
   ///< get info on sw RU
   const RUInfo* getRUInfoSW(int ruSW) const { return nullptr; }
 

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelReader.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelReader.h
@@ -48,7 +48,7 @@ constexpr int MaxLinksPerRU = 3;            // max numbet of GBT links per RU
 constexpr int MaxCablesPerRU = 28;          // max numbet of cables RU can readout
 constexpr int MaxChipsPerRU = 196;          // max number of chips the RU can readout
 constexpr int MaxGBTPacketBytes = 8 * 1024; // Max size of GBT packet in bytes (8KB)
-constexpr int NCRUPagesPerSuperpage = 256;  // Max number of CRU pages per superpage
+constexpr int NCRUPagesPerSuperpage = 256;  // Expected max number of CRU pages per superpage
 
 struct RUDecodingStat {
 
@@ -607,24 +607,26 @@ class RawPixelReader : public PixelReader
           break;                    // no data to continue
         }
         ptr = buffer.getPtr();
-	rdh = reinterpret_cast<o2::header::RAWDataHeader*>(ptr);
+        rdh = reinterpret_cast<o2::header::RAWDataHeader*>(ptr);
       }
-      if (mVerbose) {                                                                                                                                                                             
+      if (mVerbose) {
         printRDH(*rdh);
       }
       int ruIDSW = getMapping().FEEId2RUSW(rdh->feeId);
       auto& ruDecode = getCreateRUDecode(ruIDSW);
 
       bool newTrigger = true; // check if we see new trigger
-      auto link = ruDecode.links[rdh->linkID].get();
+      uint16_t lr, ruOnLr, linkIDinRU;
+      getMapping().expandFEEId(rdh->feeId, lr, ruOnLr, linkIDinRU);
+      auto link = ruDecode.links[linkIDinRU].get();
       if (link) {                                                                                                    // was there any data seen on this link before?
         const auto rdhPrev = reinterpret_cast<o2::header::RAWDataHeader*>(link->data.getEnd() - link->lastPageSize); // last stored RDH
         if (isSameRUandTrigger(rdhPrev, rdh)) {
           newTrigger = false;
         }
       } else { // a new link was added
-        ruDecode.links[rdh->linkID] = std::make_unique<RULink>();
-        link = ruDecode.links[rdh->linkID].get();
+        ruDecode.links[linkIDinRU] = std::make_unique<RULink>();
+        link = ruDecode.links[linkIDinRU].get();
         mNLinks++;
       }
       // copy data to the buffer of the link and memorize its RDH pointer
@@ -635,9 +637,9 @@ class RawPixelReader : public PixelReader
 
       if (newTrigger) {
         link->nTriggers++; // acknowledge 1st trigger
-        if (link->nTriggers >= mMinTriggersToCache && !enoughTriggers[ruIDSW][rdh->linkID]) {
+        if (link->nTriggers >= mMinTriggersToCache && !enoughTriggers[ruIDSW][linkIDinRU]) {
           nLEnoughTriggers++;
-          enoughTriggers[ruIDSW][rdh->linkID] = true;
+          enoughTriggers[ruIDSW][linkIDinRU] = true;
         }
       }
 
@@ -771,7 +773,7 @@ class RawPixelReader : public PixelReader
   //_____________________________________
   bool isRDHHeuristic(const o2::header::RAWDataHeader* rdh)
   {
-    /// heuristic check if this is indeed an RDH    
+    /// heuristic check if this is indeed an RDH
     return (!rdh || rdh->headerSize != sizeof(o2::header::RAWDataHeader) || rdh->zero0 != 0 ||
             rdh->zero41 != 0 || rdh->zero42 != 0 || rdh->word5 != 0 || rdh->zero6 != 0)
              ? false

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelReader.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelReader.h
@@ -48,7 +48,7 @@ constexpr int MaxLinksPerRU = 3;            // max numbet of GBT links per RU
 constexpr int MaxCablesPerRU = 28;          // max numbet of cables RU can readout
 constexpr int MaxChipsPerRU = 196;          // max number of chips the RU can readout
 constexpr int MaxGBTPacketBytes = 8 * 1024; // Max size of GBT packet in bytes (8KB)
-constexpr int NCRUPagesPerSuperpage = 256;  // Number of CRU pages per superpage
+constexpr int NCRUPagesPerSuperpage = 256;  // Max number of CRU pages per superpage
 
 struct RUDecodingStat {
 
@@ -590,7 +590,7 @@ class RawPixelReader : public PixelReader
   {
     // distribute data from the single buffer among the links caches
 
-    LOG(INFO) << "Cacheding links data, currently in cache: " << mMinTriggersCached << " triggers";
+    LOG(INFO) << "Caching links data, currently in cache: " << mMinTriggersCached << " triggers";
     auto nRead = loadInput(buffer);
     if (buffer.isEmpty()) {
       return nRead;
@@ -607,8 +607,11 @@ class RawPixelReader : public PixelReader
           break;                    // no data to continue
         }
         ptr = buffer.getPtr();
+	rdh = reinterpret_cast<o2::header::RAWDataHeader*>(ptr);
       }
-
+      if (mVerbose) {                                                                                                                                                                             
+        printRDH(*rdh);
+      }
       int ruIDSW = getMapping().FEEId2RUSW(rdh->feeId);
       auto& ruDecode = getCreateRUDecode(ruIDSW);
 
@@ -768,8 +771,8 @@ class RawPixelReader : public PixelReader
   //_____________________________________
   bool isRDHHeuristic(const o2::header::RAWDataHeader* rdh)
   {
-    /// heuristic check if this is indeed an RDH
-    return (!rdh || rdh->headerSize != sizeof(o2::header::RAWDataHeader) || rdh->zero0 != 0 || rdh->zero1 != 0 ||
+    /// heuristic check if this is indeed an RDH    
+    return (!rdh || rdh->headerSize != sizeof(o2::header::RAWDataHeader) || rdh->zero0 != 0 ||
             rdh->zero41 != 0 || rdh->zero42 != 0 || rdh->word5 != 0 || rdh->zero6 != 0)
              ? false
              : true;

--- a/Detectors/ITSMFT/common/reconstruction/src/ITSMFTReconstructionLinkDef.h
+++ b/Detectors/ITSMFT/common/reconstruction/src/ITSMFTReconstructionLinkDef.h
@@ -33,7 +33,7 @@
 #pragma link C++ class o2::itsmft::GBTData + ;
 #pragma link C++ class o2::itsmft::PayLoadCont + ;
 #pragma link C++ class o2::itsmft::PayLoadSG + ;
-#pragma link C++ class o2::itsmft::RUDecodingStat + ;
+#pragma link C++ class o2::itsmft::GBTLinkDecodingStat + ;
 #pragma link C++ class o2::itsmft::RawDecodingStat + ;
 
 #pragma link C++ class std::map<unsigned long, std::pair<o2::itsmft::ClusterTopology, unsigned long>> + ;

--- a/macro/run_CRUDataSkimming_its.C
+++ b/macro/run_CRUDataSkimming_its.C
@@ -49,14 +49,16 @@ void run_CRUDataSkimming_its(std::string inpName = "rawits.bin",
 
   const auto& MAP = rawReader.getMapping();
   for (int ir = 0; ir < MAP.getNRUs(); ir++) {
-    const auto* ruStat = rawReader.getRUDecodingStatSW(ir);
-    if (ruStat && ruStat->nPackets) {
-      printf("\nStatistics for RU%3d (HWID:0x%4x)\n", ir, MAP.RUSW2FEEId(ir, 0));
-      ruStat->print();
+    for (int il = 0; il < o2::itsmft::MaxLinksPerRU; il++) {
+      const auto ruStat = rawReader.getRUDecodingStatSW(ir, il);
+      if (ruStat && ruStat->nPackets) {
+        printf("\nStatistics for RU%3d (HWID:0x%4x) GBTLink%d\n", ir, MAP.RUSW2FEEId(ir, il), il);
+        ruStat->print();
+      }
     }
   }
-
   rawReader.getDecodingStat().print();
+
   printf("Total time spent on skimming: ");
   sw.Print();
   printf("Time spent on writing output: ");

--- a/macro/run_CRUDataSkimming_its.C
+++ b/macro/run_CRUDataSkimming_its.C
@@ -20,12 +20,14 @@
 
 void run_CRUDataSkimming_its(std::string inpName = "rawits.bin",
                              std::string outName = "rawits_skimmed.bin",
+                             int nTriggersToCache = 1025, // number of triggers per link to cache (> N 8KB CRU pages per superpage)
                              int verbose = 0)
 {
 
   o2::itsmft::RawPixelReader<o2::itsmft::ChipMappingITS> rawReader;
   rawReader.openInput(inpName);
   rawReader.setPadding128(false);
+  rawReader.setMinTriggersToCache(nTriggersToCache);
   rawReader.setVerbosity(verbose);
 
   std::fstream outFile(outName, std::ios::out | std::ios::binary);

--- a/macro/run_digi2raw_its.C
+++ b/macro/run_digi2raw_its.C
@@ -82,14 +82,14 @@ void run_digi2raw_its(std::string outName = "rawits.bin",                       
     uint32_t lanes = mp.getCablesOnRUType(ru.ruInfo->ruType); // lanes patter of this RU
     if (ru.ruInfo->layer < 3) {
       for (int il = 0; il < 3; il++) { // create links
-        ru.links[il] = std::make_unique<o2::itsmft::RULink>();
+        ru.links[il] = std::make_unique<o2::itsmft::GBTLink>();
         ru.links[il]->lanes = lanes & ((0x1 << 3) - 1) << (3 * il); // each link will read 3 lanes==chips
         LOG(INFO) << "RU " << std::setw(3) << ir << " on lr" << int(ru.ruInfo->layer)
                   << " : FEEId 0x" << std::hex << std::setfill('0') << std::setw(6) << mp.RUSW2FEEId(ir, il)
                   << " reads lanes " << std::bitset<9>(ru.links[il]->lanes);
       }
     } else { // note: we are not obliged to do this if only 1 link per RU is used
-      ru.links[0] = std::make_unique<o2::itsmft::RULink>();
+      ru.links[0] = std::make_unique<o2::itsmft::GBTLink>();
       ru.links[0]->lanes = lanes; // single link reads all lanes
       LOG(INFO) << "RU " << std::setw(3) << ir << " on lr" << int(ru.ruInfo->layer)
                 << " : FEEId 0x" << std::hex << std::setfill('0') << std::setw(6) << mp.RUSW2FEEId(ir, 0)

--- a/macro/run_rawdecoding_its.C
+++ b/macro/run_rawdecoding_its.C
@@ -27,6 +27,7 @@ void run_rawdecoding_its(std::string inpName = "rawits.bin", // input binary dat
                          bool outDigPerROF = false,          // in case digits are requested, create separate tree entry for each ROF
                          bool padding = true,                // payload in raw data comes in 128 bit CRU words
                          bool page8kb = true,                // full 8KB CRU pages are provided (no skimming applied)
+                         int nTriggersToCache = 1025,        // number of triggers per link to cache (> N 8KB CRU pages per superpage)
                          int verbose = 0)
 {
 
@@ -34,6 +35,7 @@ void run_rawdecoding_its(std::string inpName = "rawits.bin", // input binary dat
   rawReader.openInput(inpName);
   rawReader.setPadding128(padding); // payload GBT words are padded to 16B
   rawReader.imposeMaxPage(page8kb); // pages are 8kB in size (no skimming)
+  rawReader.setMinTriggersToCache(nTriggersToCache);
   rawReader.setVerbosity(verbose);
 
   o2::itsmft::ChipPixelData chipData;

--- a/macro/run_rawdecoding_its.C
+++ b/macro/run_rawdecoding_its.C
@@ -110,10 +110,12 @@ void run_rawdecoding_its(std::string inpName = "rawits.bin", // input binary dat
 
   const auto& MAP = rawReader.getMapping();
   for (int ir = 0; ir < MAP.getNRUs(); ir++) {
-    const auto ruStat = rawReader.getRUDecodingStatSW(ir);
-    if (ruStat && ruStat->nPackets) {
-      printf("\nStatistics for RU%3d (HWID:0x%4x)\n", ir, MAP.RUSW2FEEId(ir, 0));
-      ruStat->print();
+    for (int il = 0; il < o2::itsmft::MaxLinksPerRU; il++) {
+      const auto ruStat = rawReader.getRUDecodingStatSW(ir, il);
+      if (ruStat && ruStat->nPackets) {
+        printf("\nStatistics for RU%3d (HWID:0x%4x) GBTLink%d\n", ir, MAP.RUSW2FEEId(ir, il), il);
+        ruStat->print();
+      }
     }
   }
   rawReader.getDecodingStat().print();


### PR DESCRIPTION
The bits 124-127 of RDH are for the ``DATAPATH WRAPPER ID: number used to identify one of the 2 End Points [0/1]`` and should not be 0 (as it was assumed in the heuristic detection of the RDH in ITS data decoder).