### PR TITLE
Store TPC dEdx Information in trackTPC + some fixes

### DIFF
--- a/DataFormats/Detectors/TPC/CMakeLists.txt
+++ b/DataFormats/Detectors/TPC/CMakeLists.txt
@@ -26,6 +26,7 @@ set(HEADERS
    include/${MODULE_NAME}/Cluster.h
    include/${MODULE_NAME}/Constants.h
    include/${MODULE_NAME}/Defs.h
+   include/${MODULE_NAME}/dEdxInfo.h
 )
 
 set(LINKDEF src/DataFormatsTPCLinkDef.h)

--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/TrackTPC.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/TrackTPC.h
@@ -16,6 +16,7 @@
 #include "DataFormatsTPC/ClusterNative.h"
 #include "DataFormatsTPC/Defs.h"
 #include "DataFormatsTPC/Cluster.h"
+#include "DataFormatsTPC/dEdxInfo.h"
 
 namespace o2
 {
@@ -110,6 +111,8 @@ class TrackTPC : public o2::track::TrackParCov
     uint8_t sectorIndex, rowIndex;
     return (getCluster(nCluster, clusters, sectorIndex, rowIndex));
   }
+  const dEdxInfo& getdEdx() const { return mdEdx; }
+  void setdEdx(const dEdxInfo& v) { mdEdx = v; }
 
  private:
   std::vector<Cluster> mClusterVector;
@@ -122,6 +125,7 @@ class TrackTPC : public o2::track::TrackParCov
   short mFlags = 0;                   ///< various flags, see Flags enum
   float mChi2 = 0.f;                  // Chi2 of the track
   o2::track::TrackParCov mOuterParam; // Track parameters at outer end of TPC.
+  dEdxInfo mdEdx;                     // dEdx Information
 
   // New structure to store cluster references
   std::vector<uint32_t> mClusterReferences;

--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/dEdxInfo.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/dEdxInfo.h
@@ -1,0 +1,47 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file dEdxInfo.h
+/// \author David Rohr
+
+#ifndef DEDXINFO_H
+#define DEDXINFO_H
+
+#include "GPUCommonRtypes.h"
+
+namespace o2
+{
+namespace TPC
+{
+struct dEdxInfo {
+  float dEdxTotIROC;
+  float dEdxTotOROC1;
+  float dEdxTotOROC2;
+  float dEdxTotOROC3;
+  float dEdxTotTPC;
+  float dEdxMaxIROC;
+  float dEdxMaxOROC1;
+  float dEdxMaxOROC2;
+  float dEdxMaxOROC3;
+  float dEdxMaxTPC;
+  unsigned char NHitsIROC;
+  unsigned char NHitsSubThresholdIROC;
+  unsigned char NHitsOROC1;
+  unsigned char NHitsSubThresholdOROC1;
+  unsigned char NHitsOROC2;
+  unsigned char NHitsSubThresholdOROC2;
+  unsigned char NHitsOROC3;
+  unsigned char NHitsSubThresholdOROC3;
+  ClassDefNV(dEdxInfo, 1);
+};
+} // namespace TPC
+} // namespace o2
+
+#endif

--- a/DataFormats/Detectors/TPC/src/DataFormatsTPCLinkDef.h
+++ b/DataFormats/Detectors/TPC/src/DataFormatsTPCLinkDef.h
@@ -34,5 +34,6 @@
 #pragma link C++ class o2::TPC::ClusterNativeHelper::TreeWriter + ;
 #pragma link C++ class o2::TPC::ClusterNativeHelper::TreeWriter::BranchData + ;
 #pragma link C++ class std::vector < o2::TPC::ClusterNativeHelper::TreeWriter::BranchData > +;
+#pragma link C++ class o2::TPC::dEdxInfo + ;
 
 #endif

--- a/Detectors/TPC/reconstruction/src/TPCCATracking.cxx
+++ b/Detectors/TPC/reconstruction/src/TPCCATracking.cxx
@@ -174,6 +174,7 @@ int TPCCATracking::runTracking(const ClusterNativeAccessFullTPC& clusters, std::
 
       oTrack.setChi2(tracks[i].GetParam().GetChi2());
       auto& outerPar = tracks[i].OuterParam();
+      oTrack.setdEdx(tracks[i].dEdxInfo());
       oTrack.setOuterParam(o2::track::TrackParCov(
         outerPar.X, outerPar.alpha,
         { outerPar.P[0], outerPar.P[1], outerPar.P[2], outerPar.P[3], outerPar.P[4] },

--- a/GPU/Common/GPUDefGPUParameters.h
+++ b/GPU/Common/GPUDefGPUParameters.h
@@ -86,6 +86,8 @@
 #define GPUCA_MEMORY_SIZE            ((size_t)  4096 * 1024 * 1024)    //Size of memory allocated on Device
 #define GPUCA_HOST_MEMORY_SIZE       ((size_t)  4096 * 1024 * 1024)    //Size of memory allocated on Host
 
+#define GPUCA_GPU_STACK_SIZE 8192                                      //Stack size per GPU thread
+
 //Make sure options do not interfere
 
 #ifndef GPUCA_GPUCODE

--- a/GPU/GPUTracking/Base/cuda/GPUReconstructionCUDA.cu
+++ b/GPU/GPUTracking/Base/cuda/GPUReconstructionCUDA.cu
@@ -308,7 +308,7 @@ int GPUReconstructionCUDABackend::InitDevice_Runtime()
   }
 
   ReleaseThreadContext();
-  GPUInfo("CUDA Initialisation successfull (Device %d: %s, Thread %d, %lld/%lld bytes used)", mDeviceId, cudaDeviceProp.name, mThreadId, (long long int)mHostMemorySize, (long long int)mDeviceMemorySize);
+  GPUInfo("CUDA Initialisation successfull (Device %d: %s (Frequency %d, Cores %d), %'lld / %'lld bytes host / global memory, Stack frame %'d, Constant memory %'lld)", mDeviceId, cudaDeviceProp.name, cudaDeviceProp.clockRate, cudaDeviceProp.multiProcessorCount, (long long int)mHostMemorySize, (long long int)mDeviceMemorySize, GPUCA_GPU_STACK_SIZE, (long long int)sizeof(GPUConstantMem));
 
   return (0);
 }

--- a/GPU/GPUTracking/Base/cuda/GPUReconstructionCUDA.cu
+++ b/GPU/GPUTracking/Base/cuda/GPUReconstructionCUDA.cu
@@ -239,6 +239,13 @@ int GPUReconstructionCUDABackend::InitDevice_Runtime()
     return (1);
   }
 
+  if (GPUFailedMsgI(cudaThreadSetLimit(cudaLimitStackSize, GPUCA_GPU_STACK_SIZE)))
+  {
+    GPUError("Error setting CUDA stack size");
+    GPUFailedMsgI(cudaDeviceReset());
+    return (1);
+  }
+
   if (mDeviceMemorySize > cudaDeviceProp.totalGlobalMem || GPUFailedMsgI(cudaMalloc(&mDeviceMemoryBase, mDeviceMemorySize))) {
     GPUError("CUDA Memory Allocation Error");
     GPUFailedMsgI(cudaDeviceReset());

--- a/GPU/GPUTracking/Base/cuda/GPUReconstructionCUDA.cu
+++ b/GPU/GPUTracking/Base/cuda/GPUReconstructionCUDA.cu
@@ -239,8 +239,7 @@ int GPUReconstructionCUDABackend::InitDevice_Runtime()
     return (1);
   }
 
-  if (GPUFailedMsgI(cudaThreadSetLimit(cudaLimitStackSize, GPUCA_GPU_STACK_SIZE)))
-  {
+  if (GPUFailedMsgI(cudaThreadSetLimit(cudaLimitStackSize, GPUCA_GPU_STACK_SIZE))) {
     GPUError("Error setting CUDA stack size");
     GPUFailedMsgI(cudaDeviceReset());
     return (1);

--- a/GPU/GPUTracking/Base/hip/GPUReconstructionHIP.hip.cpp
+++ b/GPU/GPUTracking/Base/hip/GPUReconstructionHIP.hip.cpp
@@ -197,6 +197,13 @@ int GPUReconstructionHIPBackend::InitDevice_Runtime()
 
   mNStreams = std::max(mDeviceProcessingSettings.nStreams, 3);
 
+  /*if (GPUFailedMsgI(hipThreadSetLimit(hipLimitStackSize, GPUCA_GPU_STACK_SIZE)))
+     {
+      GPUError("Error setting HIP stack size");
+      GPUFailedMsgI(hipDeviceReset());
+      return(1);
+     }*/
+
   if (mDeviceMemorySize > hipDeviceProp_t.totalGlobalMem || GPUFailedMsgI(hipMalloc(&mDeviceMemoryBase, mDeviceMemorySize))) {
     GPUError("HIP Memory Allocation Error");
     GPUFailedMsgI(hipDeviceReset());
@@ -259,7 +266,8 @@ int GPUReconstructionHIPBackend::InitDevice_Runtime()
   }
 
   ReleaseThreadContext();
-  GPUInfo("HIP Initialisation successfull (Device %d: %s, Thread %d, %lld/%lld bytes used)", mDeviceId, hipDeviceProp_t.name, mThreadId, (long long int)mHostMemorySize, (long long int)mDeviceMemorySize);
+  GPUInfo("HIP Initialisation successfull (Device %d: %s (Frequency %d, Cores %d), %'lld / %'lld bytes host / global memory, Stack frame %'d, Constant memory %'lld)", mDeviceId, hipDeviceProp_t.name, hipDeviceProp_t.clockRate, hipDeviceProp_t.multiProcessorCount, (long long int)mHostMemorySize,
+          (long long int)mDeviceMemorySize, GPUCA_GPU_STACK_SIZE, (long long int)sizeof(GPUConstantMem));
 
   return (0);
 }

--- a/GPU/GPUTracking/Base/opencl/GPUReconstructionOCL.cxx
+++ b/GPU/GPUTracking/Base/opencl/GPUReconstructionOCL.cxx
@@ -406,7 +406,7 @@ int GPUReconstructionOCLBackend::InitDevice_Runtime()
     memset(mHostMemoryBase, 0, mHostMemorySize);
   }
 
-  GPUInfo("OPENCL Initialisation successfull (%d: %s %s (Frequency %d, Shaders %d) Thread %d, %lld bytes used)", bestDevice, device_vendor, device_name, (int)freq, (int)shaders, mThreadId, (long long int)mDeviceMemorySize);
+  GPUInfo("OPENCL Initialisation successfull (%d: %s %s (Frequency %d, Shaders %d), %'lld / %'lld bytes host / global memory, Stack frame %'d, Constant memory %'lld)", bestDevice, device_vendor, device_name, (int)freq, (int)shaders, (long long int)mDeviceMemorySize, (long long int)mHostMemorySize, -1, (long long int)sizeof(GPUConstantMem));
 
   return (0);
 }

--- a/GPU/GPUTracking/Merger/GPUTPCGMMergedTrack.h
+++ b/GPU/GPUTracking/Merger/GPUTPCGMMergedTrack.h
@@ -16,18 +16,7 @@
 
 #include "GPUTPCGMTrackParam.h"
 #include "GPUTPCGMMergedTrackHit.h"
-#ifdef GPUCA_ALIROOT_LIB
-namespace GPUCA_NAMESPACE
-{
-namespace gpu
-{
-struct GPUdEdxInfo {
-};
-} // namespace gpu
-} // namespace GPUCA_NAMESPACE
-#else
 #include "GPUdEdxInfo.h"
-#endif
 
 namespace GPUCA_NAMESPACE
 {

--- a/GPU/GPUTracking/Merger/GPUTPCGMTrackParam.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMTrackParam.cxx
@@ -171,7 +171,7 @@ GPUd() bool GPUTPCGMTrackParam::Fit(const GPUTPCGMMerger* merger, int iTrk, GPUT
           continue;
         }
       } else if (allowModification && lastRow != 255 && CAMath::Abs(clusters[ihit].row - lastRow) > 1) {
-        if (dEdxOut && iWay == nWays - 1 && clusters[ihit].row == lastRow - 2 && clusters[ihit].leg == clusters[maxN].leg) {
+        if (dEdxOut && iWay == nWays - 1 && clusters[ihit].row == lastRow - 2 && clusters[ihit].leg == clusters[maxN - 1].leg) {
           dEdx.fillSubThreshold(lastRow - 1, param);
         }
         AttachClustersPropagate(merger, clusters[ihit].slice, lastRow, clusters[ihit].row, iTrk, clusters[ihit].leg == clusters[maxN - 1].leg, prop, inFlyDirection);
@@ -270,7 +270,7 @@ GPUd() bool GPUTPCGMTrackParam::Fit(const GPUTPCGMMerger* merger, int iTrk, GPUT
           CADEBUG(printf("Reinit linearization\n"));
           prop.SetTrack(this, prop.GetAlpha());
         }
-        if (dEdxOut && iWay == nWays - 1 && clusters[ihit].leg == clusters[maxN].leg) {
+        if (dEdxOut && iWay == nWays - 1 && clusters[ihit].leg == clusters[maxN - 1].leg) {
           dEdx.fillCluster(clusters[ihit].amp, clusters[ihit].amp, clusters[ihit].row, mP[2], mP[3], param);
         }
       } else if (retVal == 2) { // cluster far away form the track

--- a/GPU/GPUTracking/Merger/GPUTPCGMTrackParam.h
+++ b/GPU/GPUTracking/Merger/GPUTPCGMTrackParam.h
@@ -17,6 +17,7 @@
 #include "GPUTPCDef.h"
 #include "GPUTPCGMMergedTrackHit.h"
 #include "GPUCommonMath.h"
+#include "GPUdEdxInfo.h"
 
 #ifndef __OPENCL__
 #include <cstddef>
@@ -35,7 +36,6 @@ class GPUTPCGMPhysicalTrackModel;
 class GPUTPCGMPolynomialField;
 class GPUTPCGMMergedTrack;
 class GPUTPCGMPropagator;
-struct GPUdEdxInfo;
 
 /**
  * @class GPUTPCGMTrackParam

--- a/GPU/GPUTracking/Standalone/tools/switchToAliRootLicense.sh
+++ b/GPU/GPUTracking/Standalone/tools/switchToAliRootLicense.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+cd ../../../
+if [ $(ls | grep GPUTracking | wc -l) != "1" ]; then
+    echo Incorrect directory
+    exit 1
+fi
+
+git grep -l "^// Copyright CERN and copyright holders of ALICE O2. This software is" | \
+    grep "^Common/\|^GPUTracking/\|TPCFastTransformation" | \
+    xargs -r -n 1 \
+    sed -i -e '/Copyright CERN and copyright holders of ALICE O2. This software is/,/or submit itself to any jurisdiction/c\
+//**************************************************************************\
+//* This file is property of and copyright by the ALICE Project            *\
+//* ALICE Experiment at CERN, All rights reserved.                         *\
+//*                                                                        *\
+//* Primary Authors: Matthias Richter <Matthias.Richter@ift.uib.no>        *\
+//*                  for The ALICE HLT Project.                            *\
+//*                                                                        *\
+//* Permission to use, copy, modify and distribute this software and its   *\
+//* documentation strictly for non-commercial purposes is hereby granted   *\
+//* without fee, provided that the above copyright notice appears in all   *\
+//* copies and that both the copyright notice and this permission notice   *\
+//* appear in the supporting documentation. The authors make no claims     *\
+//* about the suitability of this software for any purpose. It is          *\
+//* provided "as is" without express or implied warranty.                  *\
+//**************************************************************************\'

--- a/GPU/GPUTracking/dEdx/GPUdEdx.h
+++ b/GPU/GPUTracking/dEdx/GPUdEdx.h
@@ -89,7 +89,11 @@ GPUdi() void GPUdEdx::fillCluster(float qtot, float qmax, int padRow, float trac
   }
   const int roc = param.tpcGeometry.GetROC(padRow);
   checkSubThresh(roc);
-  float factor = CAMath::Sqrt((1 - trackSnp * trackSnp) / (1 + trackTgl * trackTgl));
+  float snp2 = trackSnp * trackSnp;
+  if (snp2 > GPUCA_MAX_SIN_PHI_LOW) {
+    snp2 = GPUCA_MAX_SIN_PHI_LOW;
+  }
+  float factor = CAMath::Sqrt((1 - snp2) / (1 + trackTgl * trackTgl));
   factor /= param.tpcGeometry.PadHeight(padRow);
   qtot *= factor;
   qmax *= factor / param.tpcGeometry.PadWidth(padRow);

--- a/GPU/GPUTracking/dEdx/GPUdEdx.h
+++ b/GPU/GPUTracking/dEdx/GPUdEdx.h
@@ -18,13 +18,12 @@
 #include "GPUTPCGeometry.h"
 #include "GPUCommonMath.h"
 #include "GPUParam.h"
+#include "GPUdEdxInfo.h"
 
 namespace GPUCA_NAMESPACE
 {
 namespace gpu
 {
-struct GPUdEdxInfo;
-
 #ifdef GPUCA_ALIROOT_LIB
 
 class GPUdEdx

--- a/GPU/GPUTracking/dEdx/GPUdEdxInfo.h
+++ b/GPU/GPUTracking/dEdx/GPUdEdxInfo.h
@@ -14,32 +14,20 @@
 #ifndef GPUDEDXINFO_H
 #define GPUDEDXINFO_H
 
-#include "GPUDef.h"
+#ifdef HAVE_O2HEADERS
+#include "DataFormatsTPC/dEdxInfo.h"
+#endif
 
 namespace GPUCA_NAMESPACE
 {
 namespace gpu
 {
+#ifdef HAVE_O2HEADERS
+using GPUdEdxInfo = o2::TPC::dEdxInfo;
+#else
 struct GPUdEdxInfo {
-  float dEdxTotIROC;
-  float dEdxTotOROC1;
-  float dEdxTotOROC2;
-  float dEdxTotOROC3;
-  float dEdxTotTPC;
-  float dEdxMaxIROC;
-  float dEdxMaxOROC1;
-  float dEdxMaxOROC2;
-  float dEdxMaxOROC3;
-  float dEdxMaxTPC;
-  unsigned char NHitsIROC;
-  unsigned char NHitsSubThresholdIROC;
-  unsigned char NHitsOROC1;
-  unsigned char NHitsSubThresholdOROC1;
-  unsigned char NHitsOROC2;
-  unsigned char NHitsSubThresholdOROC2;
-  unsigned char NHitsOROC3;
-  unsigned char NHitsSubThresholdOROC3;
 };
+#endif
 } // namespace gpu
 } // namespace GPUCA_NAMESPACE
 


### PR DESCRIPTION
@wiechula : As we discussed today, this PR moves the dEdx information to TPCDataFormats and stores it in the trackTPC after tracking.