### PR TITLE
Fix gpu namespace for ITS tracker (broke the ITS tracking macro)

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracker.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracker.h
@@ -34,10 +34,12 @@
 #include "DataFormatsITS/TrackITS.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 
-class GPUChainITS;
-
 namespace o2
 {
+namespace gpu
+{
+class GPUChainITS;
+}
 namespace ITS
 {
 
@@ -95,7 +97,7 @@ class Tracker
   std::uint32_t mROFrame = 0;
   std::vector<TrackITS> mTracks;
   dataformats::MCTruthContainer<MCCompLabel> mTrackLabels;
-  GPUChainITS* mRecoChain = nullptr;
+  o2::gpu::GPUChainITS* mRecoChain = nullptr;
 };
 
 void Tracker::setParameters(const std::vector<MemoryParameters>& memPars, const std::vector<TrackingParameters>& trkPars)


### PR DESCRIPTION
@mpuccio : The run_track_ca_its.C macro does no longer work (I wantet to check the ITS GPU track fit, now that AliTPCCommon is merged.)
There are two problems in the macro.
- Wrong GPU namespace, which is fixed by this PR.
- The other was introduced by @iouribelikov when he changed loadROFrameData(...). It is not fully clear to me how to fix this, could you have a look?