### PR TITLE
Prototype for ITS-TOF trk interpol. for TPC calib

### DIFF
--- a/Detectors/TPC/calibration/SpacePoints/CMakeLists.txt
+++ b/Detectors/TPC/calibration/SpacePoints/CMakeLists.txt
@@ -9,10 +9,19 @@
 # submit itself to any jurisdiction.
 
 o2_add_library(SpacePoints
-               SOURCES src/Param.cxx src/TrackResiduals.cxx
-               PUBLIC_LINK_LIBRARIES O2::DataFormatsTPC)
+               SOURCES src/SpacePointsCalibParam.cxx
+                       src/TrackResiduals.cxx
+                       src/TrackInterpolation.cxx
+               PUBLIC_LINK_LIBRARIES O2::DataFormatsTPC
+                                     O2::TPCBase
+                                     O2::TPCReconstruction
+                                     O2::TPCFastTransformation
+                                     O2::DataFormatsITS
+                                     O2::DataFormatsITSMFT
+                                     O2::DataFormatsTOF)
 
 o2_target_root_dictionary(SpacePoints
-                          HEADERS include/SpacePoints/Param.h
+                          HEADERS include/SpacePoints/SpacePointsCalibParam.h
                                   include/SpacePoints/TrackResiduals.h
+                                  include/SpacePoints/TrackInterpolation.h
                           LINKDEF src/SpacePointCalibLinkDef.h)

--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/SpacePointsCalibParam.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/SpacePointsCalibParam.h
@@ -8,7 +8,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file Param.h
+/// \file SpacePointsCalibParam.h
 /// \brief Parameters used for TPC space point calibration
 ///
 /// \author Ole Schmidt, ole.schmidt@cern.ch
@@ -16,9 +16,9 @@
 #ifndef ALICEO2_TPC_PARAM_H_
 #define ALICEO2_TPC_PARAM_H_
 
-#include "DataFormatsTPC/Constants.h"
-
 #define TPC_RUN2
+
+#include "DataFormatsTPC/Constants.h"
 
 namespace o2
 {
@@ -32,11 +32,12 @@ static constexpr int NPadRows = 159;                                   ///< tota
 static constexpr int NROCTypes = 3;                                    ///< how many different pitches we have between the pad rows
 static constexpr int NRowsPerROC[NROCTypes] = { 63, 64, 32 };          ///< number of rows for the different pitches
 static constexpr int NRowsAccumulated[NROCTypes] = { 63, 127, 159 };   ///< accumulate number of rows (only used as abbreviation)
+static constexpr float ZLimit[2] = { 2.49725e2f, 2.49698e2f };         ///< max z-positions for A/C side
 static constexpr float MinX[NROCTypes] = { 85.225f, 135.1f, 199.35f }; ///< x-position of first row for each ROC type
 static constexpr float RowDX[NROCTypes] = { .75f, 1.f, 1.5f };         ///< row pitches
 static constexpr float ROCDX[NROCTypes - 1] = { 3.375f, 1.25f };       ///< radial distance between the different ROCs
-static constexpr float MaxX = 246.f;                                   ///< maximum radius for the TPC
-static constexpr float RowX[NPadRows] = {
+static constexpr float MaxX = 246.f;                                   ///< max radius for the TPC
+static constexpr float RowX[NPadRows] = {                              ///< x-positions for each pad row
   85.225, 85.975, 86.725, 87.475, 88.225, 88.975, 89.725, 90.475, 91.225, 91.975, 92.725, 93.475, 94.225, 94.975, 95.725, 96.475,
   97.225, 97.975, 98.725, 99.475, 100.225, 100.975, 101.725, 102.475, 103.225, 103.975, 104.725, 105.475, 106.225, 106.975, 107.725,
   108.475, 109.225, 109.975, 110.725, 111.475, 112.225, 112.975, 113.725, 114.475, 115.225, 115.975, 116.725, 117.475, 118.225, 118.975,
@@ -49,6 +50,7 @@ static constexpr float RowX[NPadRows] = {
   212.850, 214.350, 215.850, 217.350, 218.850, 220.350, 221.850, 223.350, 224.850, 226.350, 227.850, 229.350, 230.850, 232.350, 233.850,
   235.350, 236.850, 238.350, 239.850, 241.350, 242.850, 244.350, 245.850
 };
+
 #else  // not defined TPC_RUN2
 /// TPC geometric constants for Run 3+
 static constexpr int NPadRows = o2::tpc::Constants::MAXGLOBALPADROW;
@@ -73,6 +75,39 @@ static constexpr float RowX[NPadRows] = {
   245.650
 };
 #endif // defined TPC_RUN2
+
+// TPC voxel binning
+static constexpr int NY2XBins = 15; ///< number of bins in y/x
+static constexpr int NZ2XBins = 5;  ///< number of bins in z/x
+
+// define ranges for compression to shorts in TPCClusterResiduals
+static constexpr float MaxResid = 20.f; ///< max residual in y and z
+static constexpr float MaxY = 50.f;     ///< max value for y position (sector coordinates)
+static constexpr float MaxZ = 300.f;    ///< max value for z position
+static constexpr float MaxTgSlp = 2.f;  ///< max value for phi and lambda angles
+
+// miscellaneous
+static constexpr float sEps = 1e-6f; ///< small number for float comparisons
+
+// define track cuts for track interpolation
+static constexpr int MinTPCNCls = 70;             ///< min number of TPC clusters
+static constexpr int MinTPCNClsNoOuterPoint = 50; ///< min number of TPC clusters if no hit in TRD or TOF exists
+static constexpr float MaxTPCChi2 = 4.f;          ///< cut on TPC reduced chi2
+static constexpr int MinITSNCls = 4;              ///< min number of ITS clusters
+static constexpr int MinITSNClsNoOuterPoint = 6;  ///< min number of ITS clusters if no hit in TRD or TOF exists
+static constexpr float MaxITSChi2 = 4.f;          ///< cut on ITS reduced chi2
+
+// parameters for conversion of Run 2 residual trees
+static constexpr float InvalidR = 10.f;                 ///< clusters with a radius smaller than this are neglected
+static constexpr float InvalidRes = -900.f;             ///< clusters with a residual smaller than this are neglected
+static constexpr int MinNCl = 30;                       ///< min number of clusters in a track to be used for calibration
+static constexpr float MaxQ2Pt = 3.f;                   ///< max fitted q/pt for a track to be used for calibration
+static constexpr float Bz = -5.0077936f;                ///< hard-coded B-field for the moment to compare with results from AliRoot
+static constexpr float MaxDevHelixY = .3f;              ///< max deviation in Y for clusters wrt helix fit
+static constexpr float MaxDevHelixZ = .3f;              ///< max deviation in Z for clusters wrt helix fit
+static constexpr int MinNumberOfAcceptedResiduals = 30; ///< min number of accepted residuals for
+static constexpr float mMaxStdDevMA = 25.f;             ///< max cluster std. deviation (Y^2 + Z^2) wrt moving average to accept
+
 } // namespace param
 } // namespace tpc
 } // namespace o2

--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackInterpolation.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackInterpolation.h
@@ -1,0 +1,243 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TrackInterpolation.h
+/// \brief Definition of the TrackInterpolation class
+///
+/// \author Ole Schmidt, ole.schmidt@cern.ch
+
+#ifndef ALICEO2_TPC_TRACKINTERPOLATION_H_
+#define ALICEO2_TPC_TRACKINTERPOLATION_H_
+
+#include "CommonDataFormat/EvIndex.h"
+#include "ReconstructionDataFormats/Track.h"
+#include "ReconstructionDataFormats/TrackTPCITS.h"
+#include "ReconstructionDataFormats/MatchInfoTOF.h"
+#include "DataFormatsITSMFT/Cluster.h"
+#include "DataFormatsITS/TrackITS.h"
+#include "DataFormatsTPC/ClusterNativeHelper.h"
+#include "DataFormatsTPC/TrackTPC.h"
+#include "DataFormatsTPC/Constants.h"
+#include "DataFormatsTOF/Cluster.h"
+#include "SpacePoints/SpacePointsCalibParam.h"
+#include "TPCReconstruction/TPCFastTransformHelperO2.h"
+
+class TTree;
+
+namespace o2
+{
+namespace tpc
+{
+
+/// Intermediate structure filled with TPC position information based in ITS-TOF interpolation (per track)
+struct CacheMeanPosInTPC {
+  std::array<std::array<float, 2>, Constants::MAXGLOBALPADROW> posExt{}; ///< y and z coordinate for extrapolated ITS tracks
+  std::array<std::array<float, 3>, Constants::MAXGLOBALPADROW> covExt{}; ///< covarince for extrapolated ITS tracks
+  std::array<std::array<float, 2>, Constants::MAXGLOBALPADROW> posInt{}; ///< y and z coordinate for interpolated TOF/TRD tracks
+  std::array<std::array<float, 3>, Constants::MAXGLOBALPADROW> covInt{}; ///< covarince for interpolated TOF/TRD tracks
+  std::array<std::array<float, 2>, Constants::MAXGLOBALPADROW> pos{};    ///< weighted average of posExt and posInt
+  std::array<std::array<float, 2>, Constants::MAXGLOBALPADROW> clYZ{};   ///< TPC cluster y/z position
+  std::array<float, Constants::MAXGLOBALPADROW> clAngle{};               ///< alpha for TPC cluster
+  std::array<unsigned short, Constants::MAXGLOBALPADROW> clAvailable{};  ///< if a TPC cluster is available in a given row this is set to 1
+  std::array<float, Constants::MAXGLOBALPADROW> phi{};                   ///< track phi (taken from extrapolation)
+  std::array<float, Constants::MAXGLOBALPADROW> tgl{};                   ///< track tgl (taken from extrapolation)
+};
+
+/// Structure used to store the TPC cluster residuals
+struct TPCClusterResiduals {
+  short dy{};           ///< residual in Y
+  short dz{};           ///< residual in Z
+  short y{};            ///< Y position of track
+  short z{};            ///< Z position of track
+  short phi{};          ///< phi angle of track
+  short tgl{};          ///< dip angle of track
+  unsigned char sec{};  ///< sector number 0..17
+  unsigned char dRow{}; ///< distance to previous row in units of pad rows
+  short row{};          ///< TPC pad row (absolute units)
+  void setDY(float val) { dy = fabs(val) < param::MaxResid ? static_cast<short>(val * 0x7fff / param::MaxResid) : static_cast<short>(std::copysign(1., val) * 0x7fff); }
+  void setDZ(float val) { dz = fabs(val) < param::MaxResid ? static_cast<short>(val * 0x7fff / param::MaxResid) : static_cast<short>(std::copysign(1., val) * 0x7fff); }
+  void setY(float val) { y = fabs(val) < param::MaxY ? static_cast<short>(val * 0x7fff / param::MaxY) : static_cast<short>(std::copysign(1., val) * 0x7fff); }
+  void setZ(float val) { z = fabs(val) < param::MaxZ ? static_cast<short>(val * 0x7fff / param::MaxZ) : static_cast<short>(std::copysign(1., val) * 0x7fff); }
+  void setPhi(float val) { phi = fabs(val) < param::MaxTgSlp ? static_cast<short>(val * 0x7fff / param::MaxTgSlp) : static_cast<short>(std::copysign(1., val) * 0x7fff); }
+  void setTgl(float val) { tgl = fabs(val) < param::MaxTgSlp ? static_cast<short>(val * 0x7fff / param::MaxTgSlp) : static_cast<short>(std::copysign(1., val) * 0x7fff); }
+};
+
+/// Structure filled for each track with track quality information and a vector with TPCClusterResiduals
+struct TrackData {
+  int trkId{};              ///< track ID for debugging
+  float eta{};              ///< track dip angle
+  float phi{};              ///< track azimuthal angle
+  float qPt{};              ///< track q/pT
+  float chi2TPC{};          ///< chi2 of TPC track
+  float chi2ITS{};          ///< chi2 of ITS track
+  unsigned short nClsTPC{}; ///< number of attached TPC clusters
+  unsigned short nClsITS{}; ///< number of attached ITS clusters
+  // TODO: Add an additional structure with event information and reference to the tracks for given event?
+  int nTracksInEvent{};               ///< total number of tracks in given event / timeframe ? Used for multiplicity estimate
+  o2::dataformats::EvIndex<> clIdx{}; ///< the event number refers to the first cluster residual of this track, the index to the total number of cluster residuals of this track
+};
+
+/// \class TrackInterpolation
+/// This class is retrieving the TPC space point residuals by interpolating ITS/TRD/TOF tracks.
+/// The residuals are stored in the specified vectors of TPCClusterResiduals
+/// It has been ported from the AliTPCcalibAlignInterpolation class from AliRoot.
+class TrackInterpolation
+{
+ public:
+  /// Default constructor
+  TrackInterpolation() = default;
+
+  /// Initialize everything
+  void init();
+
+  /// Main processing function
+  void process();
+
+  /// Extrapolate ITS-only track through TPC and store residuals to TPC clusters along the way
+  /// \param trkITS ITS only track to be extrapolated
+  /// \param trkTPC TPC track matched to trkITS used for TPC cluster access
+  /// \param trkTime time assigned to TPC track (needed for cluster coordinate transformation)
+  /// \param trkIdTPC TPC track ID
+  /// \return flag if track could successfully be extrapolated to all TPC clusters
+  bool extrapolateTrackITS(const o2::its::TrackITS& trkITS, const TrackTPC& trkTPC, float trkTime, int trkIdTPC);
+
+  /// Interpolate ITS-TPC-TOF tracks in the TPC and store residuals to TPC clusters
+  /// \param matchTOF
+  /// \return flag if track could be processed successfully
+  bool interpolateTrackITSTOF(const std::pair<o2::dataformats::EvIndex<>, o2::dataformats::MatchInfoTOF>& matchTOF);
+
+  /// Check if given ITS-TPC track fullfills quality criteria
+  /// \param matchITSTPC ITS-TPC track to be checked
+  /// \param hasOuterPoint Flag if track has an attached cluster in TRD or TOF
+  /// \return Flag if quality criteria are met
+  bool trackPassesQualityCuts(const o2::dataformats::TrackTPCITS& matchITSTPC, bool hasOuterPoint = true) const;
+
+  /// Load specified entry for all input trees
+  /// \param iEntry number of tree entry
+  void loadEntryForTrees(int iEntry);
+
+  /// Attach all input trees
+  void attachInputTrees();
+
+  /// Add branches to the output trees
+  void prepareOutputTrees();
+
+  /// Reset cache and output vectors
+  void reset();
+
+  // -------------------------------------- settings --------------------------------------------------
+
+  /// Sets the tree/chain containing ITS-TPC matched tracks
+  void setInputTreeITSTPCTracks(TTree* tree) { mTreeITSTPCTracks = tree; }
+  /// Sets the tree/chain containing TPC tracks
+  void setInputTreeTPCTracks(TTree* tree) { mTreeTPCTracks = tree; }
+  ///< Sets the reader for TPC clusters
+  void setInputTPCClustersReader(ClusterNativeHelper::Reader* reader) { mTPCClusterReader = reader; }
+  /// Sets the tree/chain containing ITS tracks
+  void setInputTreeITSTracks(TTree* tree) { mTreeITSTracks = tree; }
+  /// Sets the tree/chain containing ITS clusters
+  void setInputTreeITSClusters(TTree* tree) { mTreeITSClusters = tree; }
+  /// Sets the tree/chain containing TOF matching information
+  void setInputTreeTOFMatches(TTree* tree) { mTreeTOFMatches = tree; }
+  ///< Sets the tree/chain containing TOF clusters
+  void setInputTreeTOFClusters(TTree* tree) { mTreeTOFClusters = tree; }
+
+  /// Sets the output tree for track information
+  void setOutputTreeTracks(TTree* tree) { mTreeOutTrackData = tree; }
+  /// Sets the output tree for TPC cluster residuals
+  void setOutputTreeResiduals(TTree* tree) { mTreeOutClusterRes = tree; }
+
+  /// Sets the maximum phi angle at which track extrapolation is aborted
+  void setMaxSnp(float snp) { mMaxSnp = snp; }
+  /// Sets the maximum step length for track extrapolation
+  void setMaxStep(float step) { mMaxStep = step; }
+  /// Sets the flag if material correction should be applied when extrapolating the tracks
+  void setMatCorr(int matCorr) { mMatCorr = matCorr; }
+  /// Sets whether ITS tracks without match in TRD or TOF should be processed as well
+  void setDoITSOnlyTracks(bool flag) { mDoITSOnlyTracks = flag; }
+
+  /// Setters and Getters for the input branch/file names
+  void setITSTPCTrackBranchName(const std::string& name) { mITSTPCTrackBranchName = name; }
+  void setTPCTrackBranchName(const std::string& name) { mTPCTrackBranchName = name; }
+  void setTPCClusterFileName(const std::string& name) { mTPCClusterFileName = name; }
+  void setITSTrackBranchName(const std::string& name) { mITSTrackBranchName = name; }
+  void setITSClusterBranchName(const std::string& name) { mITSClusterBranchName = name; }
+  void setTOFMatchingBranchName(const std::string& name) { mTOFMatchingBranchName = name; }
+  void setTOFClusterBranchName(const std::string& name) { mTOFClusterBranchName = name; }
+
+  const std::string& getITSTPCTrackBranchName() const { return mITSTPCTrackBranchName; }
+  const std::string& getTPCTrackBranchName() const { return mTPCTrackBranchName; }
+  const std::string& getTPCClusterFileName() const { return mTPCClusterFileName; }
+  const std::string& getITSTrackBranchName() const { return mITSTrackBranchName; }
+  const std::string& getITSClusterBranchName() const { return mITSClusterBranchName; }
+  const std::string& getTOFMatchingBranchName() const { return mTOFMatchingBranchName; }
+  const std::string& getTOFClusterBranchName() const { return mTOFClusterBranchName; }
+
+ private:
+  // names of input files / branches
+  std::string mITSTPCTrackBranchName{ "TPCITS" };                ///< name of branch containing ITS-TPC matched tracks
+  std::string mTPCTrackBranchName{ "Tracks" };                   ///< name of branch containing TPC tracks (needed for TPC cluster access)
+  std::string mTPCClusterFileName{ "tpc-native-clusters.root" }; ///< name of file containing TPC native clusters
+  std::string mITSTrackBranchName{ "ITSTrack" };                 ///< name of branch containing input ITS tracks
+  std::string mITSClusterBranchName{ "ITSCluster" };             ///< name of branch containing input ITS clusters
+  std::string mTOFMatchingBranchName{ "TOFMatchInfo" };          ///< name of branch containing matching info for ITS-TPC-TOF tracks
+  std::string mTOFClusterBranchName{ "TOFCluster" };             ///< name of branch containing TOF clusters
+
+  // parameters
+  float mTPCTimeBinMUS{ .2f }; ///< TPC time bin duration in us
+  float mSigYZ2TOF{ .75f };    ///< for now assume cluster error for TOF equal for all clusters in both Y and Z
+
+  // settings
+  float mMaxSnp{ .85f };          ///< max snp when propagating ITS tracks
+  float mMaxStep{ 2.f };          ///< maximum step for propagation
+  int mMatCorr{ 1 };              ///< if material correction should be done
+  bool mDoITSOnlyTracks{ false }; ///< if ITS only tracks should be processed or not
+
+  // input
+  TTree* mTreeITSTPCTracks{ nullptr };                                                                             ///< input tree for ITS-TPC matched tracks
+  TTree* mTreeTPCTracks{ nullptr };                                                                                ///< input tree for TPC tracks
+  TTree* mTreeITSTracks{ nullptr };                                                                                ///< input tree for ITS tracks
+  TTree* mTreeITSClusters{ nullptr };                                                                              ///< input tree for ITS clusters
+  TTree* mTreeTOFMatches{ nullptr };                                                                               ///< input tree for ITS-TPC-TOF matches
+  TTree* mTreeTOFClusters{ nullptr };                                                                              ///< input tree for TOF clusters
+  std::vector<o2::dataformats::TrackTPCITS>* mITSTPCTrackVecInput{ nullptr };                                      ///< input vector with ITS-TPC matched tracks
+  std::vector<TrackTPC>* mTPCTrackVecInput{ nullptr };                                                             ///< input vector with TPC tracks
+  std::vector<o2::its::TrackITS>* mITSTrackVecInput{ nullptr };                                                    ///< input vector with ITS tracks
+  std::vector<o2::itsmft::Cluster>* mITSClusterVecInput{ nullptr };                                                ///< input vector with ITS clusters
+  ClusterNativeHelper::Reader* mTPCClusterReader = nullptr;                                                        ///< TPC cluster reader
+  std::unique_ptr<ClusterNativeAccess> mTPCClusterIdxStructOwn;                                                    ///< struct holding the TPC cluster indices (for tree-based I/O)
+  std::unique_ptr<ClusterNative[]> mTPCClusterBufferOwn;                                                           ///< buffer for clusters in mTPCClusterIdxStructOwn
+  MCLabelContainer mTPCClusterMCBufferOwn;                                                                         ///< buffer for mc labels
+  std::vector<std::pair<o2::dataformats::EvIndex<>, o2::dataformats::MatchInfoTOF>>* mTOFMatchVecInput{ nullptr }; ///< input vector for ITS-TPC-TOF matching information
+  std::vector<o2::tof::Cluster>* mTOFClusterVecInput{ nullptr };                                                   ///< input vector with TOF clusters
+
+  const ClusterNativeAccess* mTPCClusterIdxStruct = nullptr; ///< struct holding the TPC cluster indices
+
+  // output
+  TTree* mTreeOutTrackData{ nullptr };                    ///< output tree with track quality information
+  std::vector<TrackData> mTrackData{};                    ///< this vector is used to store the track quality information on a per track basis
+  std::vector<TrackData>* mTrackDataPtr{ &mTrackData };   ///< pointer to vector with track data
+  TTree* mTreeOutClusterRes{ nullptr };                   ///< output tree with TPC cluster residuals
+  std::vector<TPCClusterResiduals> mClRes{};              ///< residuals for each available TPC cluster of all tracks
+  std::vector<TPCClusterResiduals>* mClResPtr{ &mClRes }; ///< pointer to vector with residuals
+
+  // cache
+  // TODO a single CacheMeanPosInTPC struct could probably also be put on the stack (ca. 10 kbytes)
+  std::unique_ptr<CacheMeanPosInTPC> mCache{}; ///< store here for each track the mean position + error in the TPC
+
+  // helpers
+  std::unique_ptr<TPCFastTransform> mFastTransform{}; ///< TPC cluster transformation
+};
+
+} // namespace tpc
+
+} // namespace o2
+
+#endif

--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackResiduals.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackResiduals.h
@@ -288,12 +288,12 @@ class TrackResiduals
   /// \param ip Bin index in Y/X
   /// \param iz Bin index in Z/X
   /// \return global bin number
-  unsigned short getGlbVoxBin(const int ix, const int ip, const int iz) const;
+  unsigned short getGlbVoxBin(int ix, int ip, int iz) const;
 
   /// Calculates the global bin number
   /// \param bvox Array with the voxels bin indices in X, Y/X and Z/X
   /// \return global bin number
-  unsigned short getGlbVoxBin(const std::array<unsigned char, VoxDim> bvox) const;
+  unsigned short getGlbVoxBin(const std::array<unsigned char, VoxDim>& bvox) const;
 
   /// Calculates the coordinates of the center for a given voxel.
   /// These are not global TPC coordinates, but the coordinates for the given global binning system.
@@ -305,29 +305,29 @@ class TrackResiduals
   /// \param x Coordinate in X
   /// \param p Coordinate in Y/X
   /// \param z Coordinate in Z
-  void getVoxelCoordinates(const int isec, const int ix, const int ip, const int iz, float& x, float& p, float& z) const;
+  void getVoxelCoordinates(int isec, int ix, int ip, int iz, float& x, float& p, float& z) const;
 
   /// Calculates the x-coordinate for given x bin.
   /// \param i Bin index
   /// \return Coordinate in X
-  float getX(const int i) const;
+  float getX(int i) const;
 
   /// Calculates the y/x-coordinate.
   /// \param ix Bin index in X
   /// \param ip Bin index in Y/X
   /// \return Coordinate in Y/X
-  float getY2X(const int ix, const int ip) const;
+  float getY2X(int ix, int ip) const;
 
   /// Calculates the z-coordinate for given z bin
   /// \param i Bin index
   /// \return Coordinate in Z
-  float getZ(const int i) const;
+  float getZ(int i) const;
 
   /// Tests whether a bin in X is set to be ignored.
   /// \param iSec Sector number
   /// \param bin Bin index in X
   /// \return Ignore flag
-  bool getXBinIgnored(const int iSec, const int bin) const { return mXBinsIgnore[iSec].test(bin); }
+  bool getXBinIgnored(int iSec, int bin) const { return mXBinsIgnore[iSec].test(bin); }
 
   /// Calculates the bin indices of the closest voxel.
   /// \param x Coordinate in X
@@ -336,36 +336,36 @@ class TrackResiduals
   /// \param ix Resulting bin index in X
   /// \param ip Resulting bin index in Y/X
   /// \param iz Resulting bin index in Z/X
-  void findVoxel(const float x, const float y2x, const float z2x, int& ix, int& ip, int& iz) const;
+  void findVoxel(float x, float y2x, float z2x, int& ix, int& ip, int& iz) const;
 
   /// Calculates the bin indices for given x, y, z in sector coordinates
-  bool findVoxelBin(const float x, const float y, const float z, std::array<unsigned char, VoxDim>& bvox) const;
+  bool findVoxelBin(float x, float y, float z, std::array<unsigned char, VoxDim>& bvox) const;
 
   /// Transforms X coordinate to bin index
   /// \param x Coordinate in X
   /// \return Bin index in X
-  int getXBin(const float x) const;
+  int getXBin(float x) const;
 
   /// Transforms Y/X coordinate to bin index at given X
   /// \param y2x Coordinate in Y/X
   /// \param ix Bin index in X
   /// \return Bin index in Y/X
-  int getY2XBin(const float y2x, const int ix) const;
+  int getY2XBin(float y2x, int ix) const;
 
   /// Transforms Z coordinate to bin index
   /// \param z2x Coordinate in Z
   /// \return Bin index in Z/X
-  int getZ2XBin(const float z2x) const;
+  int getZ2XBin(float z2x) const;
 
   /// Returns the inverse of the distance between two bins in X
   /// \param ix Bin index in X
   /// \return Inverse of the distance between bins
-  float getDXI(const int ix) const;
+  float getDXI(int ix) const;
 
   /// Returns the inverse of the distance between two bins in Y/X
   /// \param ix Bin index in X
   /// \return Inverse of the distance between bins
-  float getDY2XI(const int ix) const { return mDY2XI[ix]; }
+  float getDY2XI(int ix) const { return mDY2XI[ix]; }
 
   /// Returns the inverse of the distance between two bins in Z/X
   /// \return Inverse of the distance between bins
@@ -537,19 +537,19 @@ class TrackResiduals
 };
 
 //_____________________________________________________
-inline unsigned short TrackResiduals::getGlbVoxBin(const std::array<unsigned char, VoxDim> bvox) const
+inline unsigned short TrackResiduals::getGlbVoxBin(const std::array<unsigned char, VoxDim>& bvox) const
 {
   return bvox[VoxX] + (bvox[VoxF] + bvox[VoxZ] * mNY2XBins) * mNXBins;
 }
 
 //_____________________________________________________
-inline unsigned short TrackResiduals::getGlbVoxBin(const int ix, const int ip, const int iz) const
+inline unsigned short TrackResiduals::getGlbVoxBin(int ix, int ip, int iz) const
 {
   return ix + (ip + iz * mNY2XBins) * mNXBins;
 }
 
 //_____________________________________________________
-inline void TrackResiduals::getVoxelCoordinates(const int isec, const int ix, const int ip, const int iz, float& x, float& p, float& z) const
+inline void TrackResiduals::getVoxelCoordinates(int isec, int ix, int ip, int iz, float& x, float& p, float& z) const
 {
   x = getX(ix);
   p = getY2X(ix, ip);
@@ -560,7 +560,7 @@ inline void TrackResiduals::getVoxelCoordinates(const int isec, const int ix, co
 }
 
 //_____________________________________________________
-inline float TrackResiduals::getDXI(const int ix) const
+inline float TrackResiduals::getDXI(int ix) const
 {
   if (mUniformBins[VoxX]) {
     return mDXI;
@@ -590,26 +590,26 @@ inline float TrackResiduals::getDXI(const int ix) const
 }
 
 //_____________________________________________________
-inline float TrackResiduals::getX(const int i) const
+inline float TrackResiduals::getX(int i) const
 {
   return mUniformBins[VoxX] ? param::MinX[0] + (i + 0.5) * mDX : param::RowX[i];
 }
 
 //_____________________________________________________
-inline float TrackResiduals::getY2X(const int ix, const int ip) const
+inline float TrackResiduals::getY2X(int ix, int ip) const
 {
   return (0.5f + ip) * mDY2X[ix] - mMaxY2X[ix];
 }
 
 //_____________________________________________________
-inline float TrackResiduals::getZ(const int i) const
+inline float TrackResiduals::getZ(int i) const
 {
   // always positive
   return (0.5f + i) * mDZ;
 }
 
 //_____________________________________________________
-inline void TrackResiduals::findVoxel(const float x, const float y2x, const float z2x, int& ix, int& ip, int& iz) const
+inline void TrackResiduals::findVoxel(float x, float y2x, float z2x, int& ix, int& ip, int& iz) const
 {
   ix = getXBin(x);
   ip = getY2XBin(y2x, ix);
@@ -617,7 +617,7 @@ inline void TrackResiduals::findVoxel(const float x, const float y2x, const floa
 }
 
 //_____________________________________________________
-inline int TrackResiduals::getY2XBin(const float y2x, const int ix) const
+inline int TrackResiduals::getY2XBin(float y2x, int ix) const
 {
   int bp = (y2x + mMaxY2X[ix]) * mDY2XI[ix];
   if (bp < 0) {
@@ -627,7 +627,7 @@ inline int TrackResiduals::getY2XBin(const float y2x, const int ix) const
 }
 
 //_____________________________________________________
-inline int TrackResiduals::getZ2XBin(const float z2x) const
+inline int TrackResiduals::getZ2XBin(float z2x) const
 {
   int bz = z2x * mDZI;
   if (bz < 0) {

--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackResiduals.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackResiduals.h
@@ -21,15 +21,19 @@
 
 #include <memory>
 #include <vector>
+#include <array>
 #include <bitset>
 #include <string>
 #include <Rtypes.h>
 
 #include "DataFormatsTPC/Defs.h"
-#include "SpacePoints/Param.h"
+#include "SpacePoints/SpacePointsCalibParam.h"
+#include "SpacePoints/TrackInterpolation.h"
 
 #include "TTree.h"
 #include "TFile.h"
+#include "TChain.h"
+#include "TVectorT.h"
 
 namespace o2
 {
@@ -71,8 +75,8 @@ class TrackResiduals
   enum class KernelType { Epanechnikov,
                           Gaussian };
 
-  /// Structure which gets filled with the results
-  struct bres_t {
+  /// Structure which gets filled with the results for each voxel
+  struct VoxRes {
     std::array<float, ResDim> D{};            ///< values of extracted distortions
     std::array<float, ResDim> E{};            ///< their errors
     std::array<float, ResDim> DS{};           ///< smoothed residual
@@ -81,9 +85,34 @@ class TrackResiduals
     float dYSigMAD{ 0.f };                    ///< MAD estimator of dY sigma (dispersion after slope removal)
     float dZSigLTM{ 0.f };                    ///< Z sigma from unbinned LTM estimator
     std::array<float, VoxHDim> stat{};        ///< statistics: averages of each voxel dimension + entries
-    std::array<unsigned char, VoxDim> bvox{}; ///< voxel identifier, here the bvox[0] shows number of Q bins used for Y
+    std::array<unsigned char, VoxDim> bvox{}; ///< voxel identifier: VoxZ, VoxF, VoxX
     unsigned char bsec{ 0 };                  ///< sector ID (0-35)
     unsigned char flags{ 0 };                 ///< status flag
+  };
+
+  /// Structure for local residuals (y/z position, dip angle, voxel identifier)
+  struct LocalResid {
+    short dy;                                 ///< residual in y, ranges from -param::sMaxResid to +param::sMaxResid
+    short dz;                                 ///< residual in z, ranges from -param::sMaxResid to +param::sMaxResid
+    short tgSlp;                              ///< track dip angle, ranges from -param::sMaxAngle to +param::sMaxAngle
+    std::array<unsigned char, VoxDim> bvox{}; ///< voxel identifier: VoxZ, VoxF, VoxX
+  };
+
+  /// Helper structure to organize acess to delta trees from Run2 (legacy method)
+  /// All parameters are on a per-track basis
+  struct DeltaStruct {
+    TVectorF* vecR{ nullptr };     ///< cluster radius
+    TVectorF* vecSec{ nullptr };   ///< cluster sector (0..71) A/C side, IROC/OROC
+    TVectorF* vecPhi{ nullptr };   ///< azimuthal angle of cluster frame (-pi..pi)
+    TVectorF* vecZ{ nullptr };     ///< cluster z position
+    TVectorF* vecDYits{ nullptr }; ///< cluster y residual wrt ITS track
+    TVectorF* vecDZits{ nullptr }; ///< cluster z residual wrt ITS track
+    TVectorF* vecDYtrd{ nullptr }; ///< cluster y residual wrt ITS-TRD track
+    TVectorF* vecDZtrd{ nullptr }; ///< cluster z residual wrt ITS-TRD track
+    Double32_t param[5] = { 0.f }; ///< track parameters at inner wall of TPC
+    Char_t trdOK{ 0 };             ///< track had matched points in TRD
+    Char_t itsOK{ 0 };             ///< track had matched points in ITS
+    UShort_t npValid{ 0 };         ///< number of valid TPC clusters
   };
 
   // -------------------------------------- initialization --------------------------------------------------
@@ -102,7 +131,7 @@ class TrackResiduals
   /// Sets a flag to print the memory usage at certain points in the program for performance studies.
   void setPrintMemoryUsage() { mPrintMem = true; }
   /// Sets the kernel type used for smoothing.
-  /// \param type Kernel type (Epanechnikov / Gaussian)
+  /// \param kernel Kernel type (Epanechnikov / Gaussian)
   /// \param bwX Bin width in X
   /// \param bwP Bin width in Y/X
   /// \param bwZ Bin width in Z
@@ -112,6 +141,24 @@ class TrackResiduals
   void setKernelType(KernelType kernel = KernelType::Epanechnikov, float bwX = 2.1f, float bwP = 2.1f, float bwZ = 1.7f, float scX = 1.f, float scP = 1.f, float scZ = 1.f);
 
   // -------------------------------------- steering functions --------------------------------------------------
+
+  /// Build local residual trees from Run 2 legacy data in the same way as in AliRoot
+  void buildLocalResidualTreesFromRun2Data();
+
+  /// Fill the tree with local residuals with input from the buffer arrays
+  void fillLocalResidualsTrees();
+
+  /// Activate necessary branches from Run 2 delta trees
+  void prepareDeltaTreeBranches();
+
+  /// Create output files for each sector with trees for local residuals
+  void prepareLocalResidualTrees();
+
+  /// Write trees with local residuals to file
+  void writeLocalResidualTreesToFile();
+
+  /// Loads residual data from track interpolation and fills voxel data structures local residuals
+  void convertToLocalResiduals();
 
   /// Steers the processing of the residuals for all sectors.
   void processResiduals();
@@ -125,13 +172,13 @@ class TrackResiduals
   /// \param dz Vector with residuals in z
   /// \param tg Vector with tan(phi) of the tracks
   /// \param resVox Voxel results structure
-  void processVoxelResiduals(std::vector<float>& dy, std::vector<float>& dz, std::vector<float>& tg, bres_t& resVox);
+  void processVoxelResiduals(std::vector<float>& dy, std::vector<float>& dz, std::vector<float>& tg, VoxRes& resVox);
 
   /// Estimates dispersion for given voxel
   /// \param tg Vector with tan(phi) of the tracks
   /// \param dy Vector with residuals in y
   /// \param resVox Voxel results structure
-  void processVoxelDispersions(std::vector<float>& tg, std::vector<float>& dy, bres_t& resVox);
+  void processVoxelDispersions(std::vector<float>& tg, std::vector<float>& dy, VoxRes& resVox);
 
   /// Applies voxel validation cuts.
   /// Bad X bins are stored in mXBinsIgnore bitset
@@ -208,53 +255,79 @@ class TrackResiduals
   /// \return Kernel weight
   double getKernelWeight(std::array<double, 3> u2vec) const;
 
+  /// Calculates the differences in Y and Z for a given set of clusters to a fitted helix.
+  /// First a circular fit in the azimuthal plane is performed and subsequently a linear fit in the transversal plane
+  bool compareToHelix(std::array<float, param::NPadRows>& residHelixY, std::array<float, param::NPadRows>& residHelixZ);
+
+  /// Fits a circle to a given set of points in x and y. Kasa algorithm is used.
+  /// \param nCl number of used points
+  /// \param x array with values for x
+  /// \param y array with values for y
+  /// \param xc fit result for circle center position in x is stored here
+  /// \param yc fit result for circle center position in y is stored here
+  /// \param r fit result for circle radius is stored here
+  /// \param residHelixY residuals in y from fitted circle to given points is stored here
+  void fitCircle(int nCl, std::array<float, param::NPadRows>& x, std::array<float, param::NPadRows>& y, float& xc, float& yc, float& r, std::array<float, param::NPadRows>& residHelixY);
+
+  /// Fits a straight line to a given set of points, w/o taking into account measurement errors or different weights for the points
+  /// Straight line is given by y = a * x + b
+  /// \param res[0] contains the slope (a)
+  /// \param res[1] contains the offset (b)
+  bool fitPoly1(int nCl, std::array<float, param::NPadRows>& x, std::array<float, param::NPadRows>& y, std::array<float, 2>& res);
+
+  /// For a given set of points, calculate the differences from each point to the fitted lines from all other points in their neighbourhoods (+- mNMALong points)
+  void diffToLocLine(int np, int idxOffset, const std::array<float, param::NPadRows>& x, const std::array<float, param::NPadRows>& y, std::array<float, param::NPadRows>& diffY);
+
+  /// For a given set of points, calculate their deviation from the moving average (build from the neighbourhood +- mNMALong points)
+  void diffToMA(int np, const std::array<float, param::NPadRows>& y, std::array<float, param::NPadRows>& diffMA);
+
   // -------------------------------------- binning / geometry --------------------------------------------------
 
   /// Calculates the global bin number
   /// \param ix Bin index in X
   /// \param ip Bin index in Y/X
-  /// \param iz Bin index in Z
+  /// \param iz Bin index in Z/X
   /// \return global bin number
-  unsigned short getGlbVoxBin(int ix, int ip, int iz) const;
+  unsigned short getGlbVoxBin(const int ix, const int ip, const int iz) const;
 
   /// Calculates the global bin number
-  /// \param bvox Array with the voxels bin indices in X, Y/X and Z
+  /// \param bvox Array with the voxels bin indices in X, Y/X and Z/X
   /// \return global bin number
-  unsigned short getGlbVoxBin(std::array<unsigned char, VoxDim> bvox) const;
+  unsigned short getGlbVoxBin(const std::array<unsigned char, VoxDim> bvox) const;
 
   /// Calculates the coordinates of the center for a given voxel.
   /// These are not global TPC coordinates, but the coordinates for the given global binning system.
   /// E.g. z ranges from -1 to 1.
-  /// \param iSec The sector in which we are
+  /// \param isec The sector in which we are
   /// \param ix Bin index in X
   /// \param ip Bin index in Y/X
   /// \param iz Bin index in Z
   /// \param x Coordinate in X
   /// \param p Coordinate in Y/X
   /// \param z Coordinate in Z
-  void getVoxelCoordinates(int isec, int ix, int ip, int iz, float& x, float& p, float& z) const;
+  void getVoxelCoordinates(const int isec, const int ix, const int ip, const int iz, float& x, float& p, float& z) const;
 
   /// Calculates the x-coordinate for given x bin.
   /// \param i Bin index
   /// \return Coordinate in X
-  float getX(int i) const;
+  float getX(const int i) const;
 
   /// Calculates the y/x-coordinate.
   /// \param ix Bin index in X
   /// \param ip Bin index in Y/X
   /// \return Coordinate in Y/X
-  float getY2X(int ix, int ip) const;
+  float getY2X(const int ix, const int ip) const;
 
   /// Calculates the z-coordinate for given z bin
   /// \param i Bin index
   /// \return Coordinate in Z
-  float getZ(int i) const;
+  float getZ(const int i) const;
 
   /// Tests whether a bin in X is set to be ignored.
   /// \param iSec Sector number
   /// \param bin Bin index in X
   /// \return Ignore flag
-  bool getXBinIgnored(int iSec, int bin) const { return mXBinsIgnore[iSec].test(bin); }
+  bool getXBinIgnored(const int iSec, const int bin) const { return mXBinsIgnore[iSec].test(bin); }
 
   /// Calculates the bin indices of the closest voxel.
   /// \param x Coordinate in X
@@ -262,45 +335,49 @@ class TrackResiduals
   /// \param z2x Coordinate in Z
   /// \param ix Resulting bin index in X
   /// \param ip Resulting bin index in Y/X
-  /// \param iz Resulting bin index in Z
-  void findVoxel(float x, float y2x, float z2x, int& ix, int& ip, int& iz) const;
+  /// \param iz Resulting bin index in Z/X
+  void findVoxel(const float x, const float y2x, const float z2x, int& ix, int& ip, int& iz) const;
+
+  /// Calculates the bin indices for given x, y, z in sector coordinates
+  bool findVoxelBin(const float x, const float y, const float z, std::array<unsigned char, VoxDim>& bvox) const;
 
   /// Transforms X coordinate to bin index
   /// \param x Coordinate in X
   /// \return Bin index in X
-  int getXBin(float x) const;
+  int getXBin(const float x) const;
 
   /// Transforms Y/X coordinate to bin index at given X
   /// \param y2x Coordinate in Y/X
   /// \param ix Bin index in X
   /// \return Bin index in Y/X
-  int getY2XBin(float y2x, int ix) const;
+  int getY2XBin(const float y2x, const int ix) const;
 
   /// Transforms Z coordinate to bin index
   /// \param z2x Coordinate in Z
-  /// \return Bin index in Z
-  int getZ2XBin(float z2x) const;
+  /// \return Bin index in Z/X
+  int getZ2XBin(const float z2x) const;
 
   /// Returns the inverse of the distance between two bins in X
-  /// \parma ix Bin index in X
+  /// \param ix Bin index in X
   /// \return Inverse of the distance between bins
-  float getDXI(int ix) const;
+  float getDXI(const int ix) const;
 
   /// Returns the inverse of the distance between two bins in Y/X
-  /// \parma ix Bin index in X
+  /// \param ix Bin index in X
   /// \return Inverse of the distance between bins
-  float getDY2XI(int ix) const { return mDY2XI[ix]; }
+  float getDY2XI(const int ix) const { return mDY2XI[ix]; }
 
-  /// Returns the inverse of the distance between two bins in Z
+  /// Returns the inverse of the distance between two bins in Z/X
   /// \return Inverse of the distance between bins
   float getDZ2XI() const { return mDZI; }
 
   // -------------------------------------- settings --------------------------------------------------
 
   void setLocalResFileName(std::string fName) { mLocalResFileName = fName; }
+  void setLocalResTreeName(std::string tName) { mLocalResTreeName = tName; }
+  void setLocalResBranchName(std::string bName) { mLocalResBranchName = bName; }
   void setMaxPointsPerSector(int nPoints) { mMaxPointsPerSector = nPoints; }
   void setMinEntriesPerVoxel(int nEntries) { mMinEntriesPerVoxel = nEntries; }
-  void setMaxTgSlp(float maxTgSlp) { mMaxTgSlp = maxTgSlp; }
   void setLTMCut(float ltmCut) { mLTMCut = ltmCut; }
   void setMinFracLTM(float ltmCut) { mMinFracLTM = ltmCut; }
   void setMinValidVoxFracDrift(float frac) { mMinValidVoxFracDrift = frac; }
@@ -315,9 +392,10 @@ class TrackResiduals
   void setMaxGaussStdDev(float sigmas) { mMaxGaussStdDev = sigmas; }
 
   std::string getLocalResFileName() const { return mLocalResFileName; }
+  std::string getLocalResTreeName() const { return mLocalResTreeName; }
+  std::string getLocalResBranchName() const { return mLocalResBranchName; }
   int getMaxPointsPerSector() const { return mMaxPointsPerSector; }
   int getMinEntriesPerVoxel() const { return mMinEntriesPerVoxel; }
-  float getMaxTgSlp() const { return mMaxTgSlp; }
   float getLTMCut() const { return mLTMCut; }
   float getMinFracLTM() const { return mMinFracLTM; }
   float getMinValidVoxFracDrift() const { return mMinValidVoxFracDrift; }
@@ -330,6 +408,13 @@ class TrackResiduals
   float getMaxSigY() const { return mMaxSigY; }
   float getMaxSigZ() const { return mMaxSigZ; }
   float getMaxGaussStdDev() const { return mMaxGaussStdDev; }
+
+  // ------------------------- conversion of delta trees -> compact trees ------------------------------
+  /// For use with Run 2 data, outlier filtering
+  bool validateTrack(std::array<int, 3>& counterTrkValidation);
+
+  /// For use with Run 2 data, outlier filtering
+  int checkResiduals(std::bitset<param::NPadRows>& rejCl, float& rmsLong);
 
   // -------------------------------------- debugging --------------------------------------------------
 
@@ -352,24 +437,33 @@ class TrackResiduals
   void closeOutputFile();
 
  private:
+  // names of input files / trees
+  std::string mInputFileNameResiduals{ "residuals_tpc.root" }; ///< name of file with track residuals
   // some constants
   static constexpr float sFloatEps{ 1.e-7f }; ///< float epsilon for robust linear fitting
   static constexpr float sDeadZone{ 1.5f };   ///< dead zone for TPC in between sectors
   static constexpr float sMaxZ2X{ 1.f };      ///< max value for Z2X
-  static constexpr float sMaxResid{ 20.f };   ///< maximum residual in y and z
   static constexpr int sSmtLinDim{ 4 };       ///< max matrix size for smoothing (pol1)
   static constexpr int sMaxSmtDim{ 7 };       ///< max matrix size for smoothing (pol2)
 
   // input data
+  std::unique_ptr<TFile> mFileIn{};                       ///< input file with residuals data
+  TTree* mTreeInTracks{ nullptr };                        ///< tree with input track information
+  std::vector<TrackData> mTrackData{};                    ///< vector with input track information
+  std::vector<TrackData>* mTrackDataPtr{ &mTrackData };   ///< pointer to mTrackData
+  TTree* mTreeInClRes{ nullptr };                         ///< tree with TPC cluster residuals
+  std::vector<TPCClusterResiduals> mClRes{};              ///< vector with TPC cluster residuals
+  std::vector<TPCClusterResiduals>* mClResPtr{ &mClRes }; ///< pointer to mClRes
+  // output data
   std::unique_ptr<TFile> mFileOut{}; ///< output debug file
   std::unique_ptr<TTree> mTreeOut{}; ///< tree holding debug output
   // status flags
   bool mIsInitialized{}; ///< initialize only once
   bool mPrintMem{};      ///< turn on to print memory usage at certain points
   // binning
-  int mNXBins{};                           ///< number of bins in radial direction
-  int mNY2XBins{ 15 };                     ///< number of y/x bins per sector
-  int mNZ2XBins{ 5 };                      ///< number of z/x bins per sector
+  int mNXBins{ param::NPadRows };          ///< number of bins in radial direction
+  int mNY2XBins{ param::NY2XBins };        ///< number of y/x bins per sector
+  int mNZ2XBins{ param::NZ2XBins };        ///< number of z/x bins per sector
   int mNVoxPerSector{};                    ///< number of voxels per sector
   float mDX{};                             ///< x bin size
   float mDXI{};                            ///< inverse of x bin size
@@ -379,11 +473,17 @@ class TrackResiduals
   float mDZ{};                             ///< bin size in z
   float mDZI{};                            ///< inverse of bin size in z
   std::array<bool, VoxDim> mUniformBins{}; ///< if binning is uniform for each dimension
+  // local residual data, extracted from track interpolation
+  std::array<std::unique_ptr<TFile>, SECTORSPERSIDE * SIDES> mTmpFile{}; ///< I/O file
+  std::array<std::unique_ptr<TTree>, SECTORSPERSIDE * SIDES> mTmpTree{}; ///< I/O tree per sector
+  LocalResid mLocalResid{};                                              ///< data exchange structure for filling mTmpTree
+  LocalResid* mLocalResidPtr{ &mLocalResid };                            ///< pointer to mLocalResid
   // settings
-  std::string mLocalResFileName{ "data/tmpDeltaSect" }; ///< filename for local residuals input
+  std::string mLocalResFileName{ "deltasSect" };        ///< filename for local residuals input
+  std::string mLocalResTreeName{ "treeSec" };           ///< name for tree with local residuals
+  std::string mLocalResBranchName{ "localResid" };      ///< branch with LocalResid objects
   int mMaxPointsPerSector{ 30'000'000 };                ///< maximum number of accepted points per sector
   int mMinEntriesPerVoxel{ 15 };                        ///< minimum number of points in voxel for processing
-  float mMaxTgSlp{ 2.f };                               ///< maximum tan(phi) of tracks to be considered
   float mLTMCut{ .75f };                                ///< fraction op points to keep when trimming input data
   float mMinFracLTM{ .5f };                             ///< minimum fraction of points to keep when trimming data to fit expected sigma
   float mMinValidVoxFracDrift{ .5f };                   ///< if more than this fraction of bins are bad for one pad row the bad row is declared bad
@@ -408,23 +508,48 @@ class TrackResiduals
   // (intermediate) results
   std::array<std::bitset<param::NPadRows>, SECTORSPERSIDE * SIDES> mXBinsIgnore{};          ///< flags which X bins to ignore
   std::array<std::array<float, param::NPadRows>, SECTORSPERSIDE * SIDES> mValidFracXBins{}; ///< for each sector for each X-bin the fraction of validated voxels
-  std::array<std::vector<bres_t>, SECTORSPERSIDE * SIDES> mVoxelResults{};                  ///< results per sector and per voxel for 3-D distortions
+  std::array<std::vector<VoxRes>, SECTORSPERSIDE * SIDES> mVoxelResults{};                  ///< results per sector and per voxel for 3-D distortions
+  // conversion of Run 2 data to local residuals
+  std::string mPathToResidualFiles{ "~/tmp/" };
+  std::string mResidualDataFileName{ "ResidualTrees.root" };
+  std::string mResidualDataTreeName{ "delta" };
+  DeltaStruct mDeltaStruct;
+  std::unique_ptr<TChain> mRun2DeltaTree{};
+  bool mFilterOutliers = true;
+  int mNMALong{ 15 }; ///< number of points to be used for moving average (long range)
+  float mMaxRejFrac{ .15f };
+  float mMaxRMSLong{ .8f };
+  // buffer arrays as in AliTPCDcalibRes
+  std::array<float, param::NPadRows> mArrX;
+  std::array<float, param::NPadRows> mArrR;
+  std::array<float, param::NPadRows> mArrYTr;
+  std::array<float, param::NPadRows> mArrZTr;
+  std::array<float, param::NPadRows> mArrYCl;
+  std::array<float, param::NPadRows> mArrZCl;
+  std::array<float, param::NPadRows> mArrDZ;
+  std::array<float, param::NPadRows> mArrDY;
+  std::array<float, param::NPadRows> mArrPhi;
+  std::array<float, param::NPadRows> mArrTgSlp;
+  std::array<int, param::NPadRows> mArrSecId;
+  float mQpt{ 0.f };
+  float mTgl{ 0.f };
+  int mNCl{ 0 };
 };
 
 //_____________________________________________________
-inline unsigned short TrackResiduals::getGlbVoxBin(std::array<unsigned char, VoxDim> bvox) const
+inline unsigned short TrackResiduals::getGlbVoxBin(const std::array<unsigned char, VoxDim> bvox) const
 {
   return bvox[VoxX] + (bvox[VoxF] + bvox[VoxZ] * mNY2XBins) * mNXBins;
 }
 
 //_____________________________________________________
-inline unsigned short TrackResiduals::getGlbVoxBin(int ix, int ip, int iz) const
+inline unsigned short TrackResiduals::getGlbVoxBin(const int ix, const int ip, const int iz) const
 {
   return ix + (ip + iz * mNY2XBins) * mNXBins;
 }
 
 //_____________________________________________________
-inline void TrackResiduals::getVoxelCoordinates(int isec, int ix, int ip, int iz, float& x, float& p, float& z) const
+inline void TrackResiduals::getVoxelCoordinates(const int isec, const int ix, const int ip, const int iz, float& x, float& p, float& z) const
 {
   x = getX(ix);
   p = getY2X(ix, ip);
@@ -435,7 +560,7 @@ inline void TrackResiduals::getVoxelCoordinates(int isec, int ix, int ip, int iz
 }
 
 //_____________________________________________________
-inline float TrackResiduals::getDXI(int ix) const
+inline float TrackResiduals::getDXI(const int ix) const
 {
   if (mUniformBins[VoxX]) {
     return mDXI;
@@ -465,26 +590,26 @@ inline float TrackResiduals::getDXI(int ix) const
 }
 
 //_____________________________________________________
-inline float TrackResiduals::getX(int i) const
+inline float TrackResiduals::getX(const int i) const
 {
   return mUniformBins[VoxX] ? param::MinX[0] + (i + 0.5) * mDX : param::RowX[i];
 }
 
 //_____________________________________________________
-inline float TrackResiduals::getY2X(int ix, int ip) const
+inline float TrackResiduals::getY2X(const int ix, const int ip) const
 {
   return (0.5f + ip) * mDY2X[ix] - mMaxY2X[ix];
 }
 
 //_____________________________________________________
-inline float TrackResiduals::getZ(int i) const
+inline float TrackResiduals::getZ(const int i) const
 {
   // always positive
   return (0.5f + i) * mDZ;
 }
 
 //_____________________________________________________
-inline void TrackResiduals::findVoxel(float x, float y2x, float z2x, int& ix, int& ip, int& iz) const
+inline void TrackResiduals::findVoxel(const float x, const float y2x, const float z2x, int& ix, int& ip, int& iz) const
 {
   ix = getXBin(x);
   ip = getY2XBin(y2x, ix);
@@ -492,7 +617,7 @@ inline void TrackResiduals::findVoxel(float x, float y2x, float z2x, int& ix, in
 }
 
 //_____________________________________________________
-inline int TrackResiduals::getY2XBin(float y2x, int ix) const
+inline int TrackResiduals::getY2XBin(const float y2x, const int ix) const
 {
   int bp = (y2x + mMaxY2X[ix]) * mDY2XI[ix];
   if (bp < 0) {
@@ -502,11 +627,12 @@ inline int TrackResiduals::getY2XBin(float y2x, int ix) const
 }
 
 //_____________________________________________________
-inline int TrackResiduals::getZ2XBin(float z2x) const
+inline int TrackResiduals::getZ2XBin(const float z2x) const
 {
   int bz = z2x * mDZI;
   if (bz < 0) {
     // accounting for clusters which were moved to the wrong side
+    // TODO: how can this happen?
     bz = 0;
   }
   return (bz < mNZ2XBins) ? bz : mNZ2XBins - 1;

--- a/Detectors/TPC/calibration/SpacePoints/src/SpacePointCalibLinkDef.h
+++ b/Detectors/TPC/calibration/SpacePoints/src/SpacePointCalibLinkDef.h
@@ -14,6 +14,10 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
+#pragma link C++ class o2::tpc::TrackInterpolation + ;
 #pragma link C++ class o2::tpc::TrackResiduals + ;
+#pragma link C++ class o2::tpc::TrackData + ;
+#pragma link C++ class o2::tpc::TPCClusterResiduals + ;
+#pragma link C++ class o2::tpc::TrackResiduals::LocalResid + ;
 
 #endif

--- a/Detectors/TPC/calibration/SpacePoints/src/SpacePointsCalibParam.cxx
+++ b/Detectors/TPC/calibration/SpacePoints/src/SpacePointsCalibParam.cxx
@@ -8,9 +8,9 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file Param.cxx
+/// \file SpacePointsCalibParam.cxx
 /// \brief Implementation file for parameters to make code checker happy
 ///
 /// \author Ole Schmidt, ole.schmidt@cern.ch
 
-#include "SpacePoints/Param.h"
+#include "SpacePoints/SpacePointsCalibParam.h"

--- a/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
+++ b/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
@@ -1,0 +1,427 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TrackInterpolation.cxx
+/// \brief Implementation of the TrackInterpolation class
+///
+/// \author Ole Schmidt, ole.schmidt@cern.ch
+///
+
+#include "SpacePoints/TrackInterpolation.h"
+#include "TPCBase/ParameterElectronics.h"
+#include "DataFormatsTPC/TrackTPC.h"
+#include "DetectorsBase/Propagator.h"
+
+#include <fairlogger/Logger.h>
+
+using namespace o2::tpc;
+
+void TrackInterpolation::init()
+{
+  // perform initialization
+  attachInputTrees();
+
+  const auto& elParam = ParameterElectronics::Instance();
+  mTPCTimeBinMUS = elParam.ZbinWidth;
+
+  std::unique_ptr<TPCFastTransform> fastTransform = (TPCFastTransformHelperO2::instance()->create(0));
+  mFastTransform = std::move(fastTransform);
+
+  mCache = std::make_unique<CacheMeanPosInTPC>();
+
+  if (mTreeOutTrackData && mTreeOutClusterRes) {
+    prepareOutputTrees();
+  }
+}
+
+void TrackInterpolation::process()
+{
+  // main processing function
+  loadEntryForTrees(0); // TODO for now all input data is stored in trees with a single entry
+
+  std::set<unsigned int> tracksDone; // to store indices of ITS-TPC matched tracks that have been processed
+
+  LOG(info) << "Processing " << mTOFMatchVecInput->size() << " ITS-TPC-TOF matched tracks out of "
+            << mITSTPCTrackVecInput->size() << " ITS-TPC matched tracks";
+
+  // TODO reserve only a fraction of the needed space for all tracks? How many tracks pass on average the quality cuts with how many TPC clusters?
+  mTrackData.reserve(mTOFMatchVecInput->size());
+  mClRes.reserve(mTOFMatchVecInput->size() * param::NPadRows);
+
+  int nTracksTPC = mTPCTrackVecInput->size();
+
+  for (const auto& trkTOF : *mTOFMatchVecInput) {
+    // process ITS-TPC-TOF matched tracks
+    if (!trackPassesQualityCuts(mITSTPCTrackVecInput->at(trkTOF.first.getIndex()))) {
+      continue;
+    }
+    mTrackData.emplace_back();
+    if (!interpolateTrackITSTOF(trkTOF)) {
+      mTrackData.pop_back();
+      continue;
+    }
+    mTrackData.back().nTracksInEvent = nTracksTPC;
+    tracksDone.insert(trkTOF.first.getIndex());
+  }
+
+  LOG(info) << "Could process " << tracksDone.size() << " ITS-TPC-TOF matched tracks successfully";
+
+  if (mDoITSOnlyTracks) {
+    size_t nTracksDoneITS = 0;
+    size_t nTracksSkipped = 0;
+    for (std::size_t iTrk = 0; iTrk < mITSTPCTrackVecInput->size(); ++iTrk) {
+      // process ITS-TPC matched tracks that were not matched to TOF
+      if (tracksDone.find(iTrk) != tracksDone.end()) {
+        // track also has a matching cluster in TOF and has already been processed
+        ++nTracksSkipped;
+        continue;
+      }
+      const auto& trk = mITSTPCTrackVecInput->at(iTrk);
+      if (!trackPassesQualityCuts(trk, false)) {
+        continue;
+      }
+      mTrackData.emplace_back();
+      const auto& trkIdTPC = trk.getRefTPC().getIndex();
+      const auto& trkTPC = mTPCTrackVecInput->at(trkIdTPC);
+      const auto& trkITS = mITSTrackVecInput->at(trk.getRefITS().getIndex());
+      if (!extrapolateTrackITS(trkITS, trkTPC, trk.getTimeMUS().getTimeStamp(), trkIdTPC)) {
+        mTrackData.pop_back();
+        continue;
+      }
+      mTrackData.back().nTracksInEvent = nTracksTPC;
+      ++nTracksDoneITS;
+    }
+    LOG(info) << "Could process " << nTracksDoneITS << " ITS-TPC matched tracks successfully";
+    LOG(info) << "Skipped " << nTracksSkipped << " tracks, as they were successfully propagated to TOF";
+  }
+
+  if (mTreeOutTrackData) {
+    mTreeOutTrackData->Fill();
+  }
+  if (mTreeOutClusterRes) {
+    mTreeOutClusterRes->Fill();
+  }
+}
+
+bool TrackInterpolation::trackPassesQualityCuts(const o2::dataformats::TrackTPCITS& matchITSTPC, bool hasOuterPoint) const
+{
+  // apply track quality cuts (assume different settings for track with and without points in TRD or TOF)
+  const auto& trkTPC = mTPCTrackVecInput->at(matchITSTPC.getRefTPC().getIndex());
+  const auto& trkITS = mITSTrackVecInput->at(matchITSTPC.getRefITS().getIndex());
+  if (hasOuterPoint) {
+    // track has a match in TRD or TOF
+    if (trkTPC.getNClusterReferences() < param::MinTPCNCls ||
+        trkITS.getNumberOfClusters() < param::MinITSNCls) {
+      return false;
+    }
+    if (trkTPC.getChi2() / trkTPC.getNClusterReferences() > param::MaxTPCChi2 ||
+        trkITS.getChi2() / trkITS.getNumberOfClusters() > param::MaxITSChi2) {
+      return false;
+    }
+  } else {
+    // ITS-TPC only track
+    if (trkTPC.getNClusterReferences() < param::MinTPCNClsNoOuterPoint ||
+        trkITS.getNumberOfClusters() < param::MinITSNClsNoOuterPoint) {
+      return false;
+    }
+    if (trkTPC.getChi2() / trkTPC.getNClusterReferences() > param::MaxTPCChi2 ||
+        trkITS.getChi2() / trkITS.getNumberOfClusters() > param::MaxITSChi2) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool TrackInterpolation::interpolateTrackITSTOF(const std::pair<o2::dataformats::EvIndex<>, o2::dataformats::MatchInfoTOF>& matchTOF)
+{
+  // get TPC cluster residuals to ITS-TOF only tracks
+  size_t trkIdx = mTrackData.size() - 1;
+  auto propagator = o2::base::Propagator::Instance();
+  const auto& matchITSTPC = mITSTPCTrackVecInput->at(matchTOF.first.getIndex());
+  const auto& clTOF = mTOFClusterVecInput->at(matchTOF.second.getTOFClIndex());
+  //const int clTOFSec = (TMath::ATan2(-clTOF.getY(), -clTOF.getX()) + o2::constants::math::PI) * o2::constants::math::Rad2Deg * 0.05; // taken from TOF cluster class as there is no const getter for the sector
+  const int clTOFSec = clTOF.getCount();
+  const float clTOFAlpha = o2::utils::Sector2Angle(clTOFSec);
+  const auto& trkTPC = mTPCTrackVecInput->at(matchITSTPC.getRefTPC().getIndex());
+  const auto& trkITS = mITSTrackVecInput->at(matchITSTPC.getRefITS().getIndex());
+  auto trkWork = trkITS.getParamOut();
+  *mCache = {};                                     // reset the cache
+  mTrackData[trkIdx].clIdx.setEvent(mClRes.size()); // reference the first cluster residual belonging to this track
+  //printf("=== New Track with pt = %.3f, nClsTPC = %i ===\n", trkWork.getQ2Pt(), trkTPC.getNClusterReferences());
+
+  // store the TPC cluster positions in the cache
+  float clusterTimeBinOffset = matchITSTPC.getTimeMUS().getTimeStamp() / mTPCTimeBinMUS;
+  for (int iCl = trkTPC.getNClusterReferences(); iCl--;) {
+    uint8_t sector, row;
+    uint32_t clusterIndexInRow;
+    trkTPC.getClusterReference(iCl, sector, row, clusterIndexInRow);
+    const auto& clTPC = trkTPC.getCluster(iCl, *mTPCClusterIdxStruct, sector, row);
+    float clTPCX;
+    std::array<float, 2> clTPCYZ;
+    mFastTransform->Transform(sector, row, clTPC.getPad(), clTPC.getTime() - clusterTimeBinOffset, clTPCX, clTPCYZ[0], clTPCYZ[1]);
+    sector %= SECTORSPERSIDE;
+    mCache->clAvailable[row] = 1;
+    mCache->clYZ[row][0] = clTPCYZ[0];
+    mCache->clYZ[row][1] = clTPCYZ[1];
+    mCache->clAngle[row] = o2::utils::Sector2Angle(sector);
+  }
+
+  // first extrapolate through TPC and store track position at each pad row
+  for (int iRow = 0; iRow < param::NPadRows; ++iRow) {
+    if (!mCache->clAvailable[iRow]) {
+      continue;
+    }
+    if (!trkWork.rotate(mCache->clAngle[iRow])) {
+      LOG(debug) << "Failed to rotate track during first extrapolation";
+      return false;
+    }
+    if (!propagator->PropagateToXBxByBz(trkWork, param::RowX[iRow], o2::constants::physics::MassPionCharged, mMaxSnp, mMaxStep, mMatCorr)) {
+      LOG(debug) << "Failed on first extrapolation";
+      return false;
+    }
+    mCache->posExt[iRow][0] = trkWork.getY();
+    mCache->posExt[iRow][1] = trkWork.getZ();
+    mCache->covExt[iRow][0] = trkWork.getSigmaY2();
+    mCache->covExt[iRow][1] = trkWork.getSigmaZY();
+    mCache->covExt[iRow][2] = trkWork.getSigmaZ2();
+    mCache->phi[iRow] = trkWork.getSnp();
+    mCache->tgl[iRow] = trkWork.getTgl();
+    //printf("Track alpha at row %i: %.2f, Y(%.2f), Z(%.2f)\n", iRow, trkWork.getAlpha(), trkWork.getY(), trkWork.getZ());
+  }
+
+  // now continue to TOF and update track with TOF cluster
+  if (!trkWork.rotate(clTOFAlpha)) {
+    LOG(debug) << "Failed to rotate into TOF cluster sector frame";
+    return false;
+  }
+  //float ca, sa;
+  //o2::utils::sincosf(clTOFAlpha, sa, ca);
+  //float clTOFX = clTOF.getX() * ca + clTOF.getY() * sa;                                 // cluster x in sector coordinate frame
+  //std::array<float, 2> clTOFYZ{ -clTOF.getX() * sa + clTOF.getY() * ca, clTOF.getZ() }; // cluster y and z in sector coordinate frame
+  float clTOFX = clTOF.getX();
+  std::array<float, 2> clTOFYZ{ clTOF.getY(), clTOF.getZ() };
+  std::array<float, 3> clTOFCov{ mSigYZ2TOF, 0.f, mSigYZ2TOF }; // assume no correlation between y and z and equal cluster error sigma^2 = (3cm)^2 / 12
+  if (!propagator->PropagateToXBxByBz(trkWork, clTOFX, o2::constants::physics::MassPionCharged, mMaxSnp, mMaxStep, mMatCorr)) {
+    LOG(debug) << "Failed final propagation to TOF radius";
+    return false;
+  }
+  if (!trkWork.update(clTOFYZ, clTOFCov)) {
+    LOG(debug) << "Failed to update extrapolated ITS track with TOF cluster";
+    return false;
+  }
+
+  // go back through the TPC and store updated track positions
+  for (int iRow = param::NPadRows; iRow--;) {
+    if (!mCache->clAvailable[iRow]) {
+      continue;
+    }
+    if (!trkWork.rotate(mCache->clAngle[iRow])) {
+      LOG(debug) << "Failed to rotate track during back propagation";
+      return false;
+    }
+    if (!propagator->PropagateToXBxByBz(trkWork, param::RowX[iRow], o2::constants::physics::MassPionCharged, mMaxSnp, mMaxStep, mMatCorr)) {
+      LOG(debug) << "Failed on back propagation";
+      //printf("trkX(%.2f), clX(%.2f), clY(%.2f), clZ(%.2f), alphaTOF(%.2f)\n", trkWork.getX(), param::RowX[iRow], clTOFYZ[0], clTOFYZ[1], clTOFAlpha);
+      return false;
+    }
+    mCache->posInt[iRow][0] = trkWork.getY();
+    mCache->posInt[iRow][1] = trkWork.getZ();
+    mCache->covInt[iRow][0] = trkWork.getSigmaY2();
+    mCache->covInt[iRow][1] = trkWork.getSigmaZY();
+    mCache->covInt[iRow][2] = trkWork.getSigmaZ2();
+  }
+
+  // calculate weighted mean at each pad row (assume for now y and z are uncorrelated) and store residuals to TPC clusters
+  unsigned short deltaRow = 0;
+  unsigned short nMeasurements = 0;
+  for (int iRow = 0; iRow < param::NPadRows; ++iRow) {
+    if (!mCache->clAvailable[iRow]) {
+      ++deltaRow;
+      continue;
+    }
+    float wTotY = 1.f / mCache->covExt[iRow][0] + 1.f / mCache->covInt[iRow][0];
+    float wTotZ = 1.f / mCache->covExt[iRow][2] + 1.f / mCache->covInt[iRow][2];
+    mCache->pos[iRow][0] = (mCache->posExt[iRow][0] / mCache->covExt[iRow][0] + mCache->posInt[iRow][0] / mCache->covInt[iRow][0]) / wTotY;
+    mCache->pos[iRow][1] = (mCache->posExt[iRow][1] / mCache->covExt[iRow][2] + mCache->posInt[iRow][1] / mCache->covInt[iRow][2]) / wTotZ;
+
+    TPCClusterResiduals res;
+    res.setDY(mCache->clYZ[iRow][0] - mCache->pos[iRow][0]);
+    res.setDZ(mCache->clYZ[iRow][1] - mCache->pos[iRow][1]);
+    res.setY(mCache->pos[iRow][0]);
+    res.setZ(mCache->pos[iRow][1]);
+    res.setPhi(mCache->phi[iRow]);
+    res.setTgl(mCache->tgl[iRow]);
+    res.sec = o2::utils::Angle2Sector(mCache->clAngle[iRow]);
+    res.dRow = deltaRow;
+    res.row = iRow;
+    mClRes.push_back(std::move(res));
+    ++nMeasurements;
+    deltaRow = 1;
+  }
+
+  mTrackData[trkIdx].trkId = matchITSTPC.getRefTPC().getIndex();
+  mTrackData[trkIdx].eta = trkTPC.getEta();
+  mTrackData[trkIdx].phi = trkTPC.getSnp();
+  mTrackData[trkIdx].qPt = trkTPC.getQ2Pt();
+  mTrackData[trkIdx].chi2TPC = trkTPC.getChi2();
+  mTrackData[trkIdx].chi2ITS = trkITS.getChi2();
+  mTrackData[trkIdx].nClsTPC = trkTPC.getNClusterReferences();
+  mTrackData[trkIdx].nClsITS = trkITS.getNumberOfClusters();
+  mTrackData[trkIdx].clIdx.setIndex(nMeasurements);
+
+  return true;
+}
+
+bool TrackInterpolation::extrapolateTrackITS(const o2::its::TrackITS& trkITS, const TrackTPC& trkTPC, float trkTime, int trkIdTPC)
+{
+  // extrapolate ITS-only track through TPC and store residuals to TPC clusters in the output vectors
+  size_t trkIdx = mTrackData.size() - 1;
+  mTrackData[trkIdx].clIdx.setEvent(mClRes.size());
+  auto trk = trkITS.getParamOut();
+  float clusterTimeBinOffset = trkTime / mTPCTimeBinMUS;
+  auto propagator = o2::base::Propagator::Instance();
+  unsigned short rowPrev = 0;
+  unsigned short nMeasurements = 0;
+  for (int iCl = trkTPC.getNClusterReferences(); iCl--;) {
+    uint8_t sector, row;
+    uint32_t clusterIndexInRow;
+    trkTPC.getClusterReference(iCl, sector, row, clusterIndexInRow);
+    const auto& cl = trkTPC.getCluster(iCl, *mTPCClusterIdxStruct, sector, row);
+    float x = 0, y = 0, z = 0;
+    mFastTransform->Transform(sector, row, cl.getPad(), cl.getTime() - clusterTimeBinOffset, x, y, z);
+    if (!trk.rotate(o2::utils::Sector2Angle(sector))) {
+      return false;
+    }
+    if (!propagator->PropagateToXBxByBz(trk, x, o2::constants::physics::MassPionCharged, mMaxSnp, mMaxStep, mMatCorr)) {
+      return false;
+    }
+    TPCClusterResiduals res;
+    res.setDY(y - trk.getY());
+    res.setDY(z - trk.getZ());
+    res.setY(trk.getY());
+    res.setZ(trk.getZ());
+    res.setPhi(trk.getSnp());
+    res.setTgl(trk.getTgl());
+    res.sec = o2::utils::Angle2Sector(trk.getAlpha());
+    res.dRow = row - rowPrev;
+    res.row = row;
+    rowPrev = row;
+    mClRes.push_back(std::move(res));
+    ++nMeasurements;
+  }
+  mTrackData[trkIdx].trkId = trkIdTPC;
+  mTrackData[trkIdx].eta = trkTPC.getEta();
+  mTrackData[trkIdx].phi = trkTPC.getSnp();
+  mTrackData[trkIdx].qPt = trkTPC.getQ2Pt();
+  mTrackData[trkIdx].chi2TPC = trkTPC.getChi2();
+  mTrackData[trkIdx].chi2ITS = trkITS.getChi2();
+  mTrackData[trkIdx].nClsTPC = trkTPC.getNClusterReferences();
+  mTrackData[trkIdx].nClsITS = trkITS.getNumberOfClusters();
+  mTrackData[trkIdx].clIdx.setIndex(nMeasurements);
+
+  return true;
+}
+
+void TrackInterpolation::loadEntryForTrees(int iEntry)
+{
+  mTreeITSTPCTracks->GetEntry(iEntry);
+  mTreeTPCTracks->GetEntry(iEntry);
+  mTreeITSTracks->GetEntry(iEntry);
+  mTreeITSClusters->GetEntry(iEntry);
+  mTreeTOFMatches->GetEntry(iEntry);
+  mTreeTOFClusters->GetEntry(iEntry);
+  mTPCClusterReader->read(iEntry);
+  mTPCClusterReader->fillIndex(*mTPCClusterIdxStructOwn.get(), mTPCClusterBufferOwn, mTPCClusterMCBufferOwn);
+  mTPCClusterIdxStruct = mTPCClusterIdxStructOwn.get();
+}
+
+void TrackInterpolation::attachInputTrees()
+{
+  // access input for ITS-TPC matched tracks (needed for the references to ITS/TPC tracks)
+  if (!mTreeITSTPCTracks) {
+    LOG(fatal) << "The input tree for ITS-TPC matched tracks is not set!";
+  }
+  if (!mTreeITSTPCTracks->GetBranch(mITSTPCTrackBranchName.data())) {
+    LOG(fatal) << "Did not find ITS-TPC matched tracks branch " << mITSTPCTrackBranchName << " in the input tree";
+  }
+  mTreeITSTPCTracks->SetBranchAddress(mITSTPCTrackBranchName.data(), &mITSTPCTrackVecInput);
+  LOG(info) << "Attached ITS-TPC tracks " << mITSTPCTrackBranchName << " branch with "
+            << mTreeITSTPCTracks->GetEntries() << " entries";
+  // access input for TPC tracks (only used for cluster access)
+  if (!mTreeTPCTracks) {
+    LOG(fatal) << "The input tree for TPC tracks is not set!";
+  }
+  if (!mTreeTPCTracks->GetBranch(mTPCTrackBranchName.data())) {
+    LOG(fatal) << "Did not find TPC tracks branch " << mTPCTrackBranchName << " in the input tree";
+  }
+  mTreeTPCTracks->SetBranchAddress(mTPCTrackBranchName.data(), &mTPCTrackVecInput);
+  LOG(info) << "Attached TPC tracks " << mTPCTrackBranchName << " branch with "
+            << mTreeTPCTracks->GetEntries() << " entries";
+  // access input for TPC clusters
+  if (!mTPCClusterReader) {
+    LOG(fatal) << "TPC clusters reader is not set";
+  }
+  LOG(info) << "Attached TPC clusters reader with " << mTPCClusterReader->getTreeSize() << "entries";
+  mTPCClusterIdxStructOwn = std::make_unique<ClusterNativeAccess>();
+  // access input for ITS tracks
+  if (!mTreeITSTracks) {
+    LOG(fatal) << "The input tree for ITS tracks is not set!";
+  }
+  if (!mTreeITSTracks->GetBranch(mITSTrackBranchName.data())) {
+    LOG(fatal) << "Did not find ITS tracks branch " << mITSTrackBranchName << " in the input tree";
+  }
+  mTreeITSTracks->SetBranchAddress(mITSTrackBranchName.data(), &mITSTrackVecInput);
+  LOG(info) << "Attached ITS tracks " << mITSTrackBranchName << " branch with "
+            << mTreeITSTracks->GetEntries() << " entries";
+  // access input for ITS clusters
+  if (!mTreeITSClusters) {
+    LOG(fatal) << "The input tree for ITS clusters is not set!";
+  }
+  if (!mTreeITSClusters->GetBranch(mITSClusterBranchName.data())) {
+    LOG(fatal) << "Did not find ITS clusters branch " << mITSClusterBranchName << " in the input tree";
+  }
+  mTreeITSClusters->SetBranchAddress(mITSClusterBranchName.data(), &mITSClusterVecInput);
+  LOG(info) << "Attached ITS clusters " << mITSClusterBranchName << " branch with "
+            << mTreeITSClusters->GetEntries() << " entries";
+  // access input for TPC-TOF matching information
+  if (!mTreeTOFMatches) {
+    LOG(fatal) << "The input tree for with TOF matching information is not set!";
+  }
+  if (!mTreeTOFMatches->GetBranch(mTOFMatchingBranchName.data())) {
+    LOG(fatal) << "Did not find TOF matches branch " << mTOFMatchingBranchName << " in the input tree";
+  }
+  mTreeTOFMatches->SetBranchAddress(mTOFMatchingBranchName.data(), &mTOFMatchVecInput);
+  LOG(info) << "Attached TOF matches " << mTOFMatchingBranchName << " branch with "
+            << mTreeTOFMatches->GetEntries() << " entries";
+  // access input for TOF clusters
+  if (!mTreeTOFClusters) {
+    LOG(fatal) << "The input tree for with TOF clusters is not set!";
+  }
+  if (!mTreeTOFClusters->GetBranch(mTOFClusterBranchName.data())) {
+    LOG(fatal) << "Did not find TOF clusters branch " << mTOFClusterBranchName << " in the input tree";
+  }
+  mTreeTOFClusters->SetBranchAddress(mTOFClusterBranchName.data(), &mTOFClusterVecInput);
+  LOG(info) << "Attached TOF clusters " << mTOFClusterBranchName << " branch with "
+            << mTreeTOFClusters->GetEntries() << " entries";
+
+  // TODO: add MC information
+}
+
+void TrackInterpolation::prepareOutputTrees()
+{
+  mTreeOutTrackData->Branch("tracks", &mTrackDataPtr);
+  mTreeOutClusterRes->Branch("residuals", &mClResPtr);
+}
+
+void TrackInterpolation::reset()
+{
+  mTrackData.clear();
+  mClRes.clear();
+}

--- a/Detectors/TPC/calibration/SpacePoints/src/TrackResiduals.cxx
+++ b/Detectors/TPC/calibration/SpacePoints/src/TrackResiduals.cxx
@@ -38,7 +38,14 @@
 
 #include <fairlogger/Logger.h>
 
-#define TPC_RUN2
+#define TPC_RUN2 // if defined, use run 2 geometry for TPC
+
+#define LOCAL_RESIDUAL_FORMAT_OLD // if defined, data in compact trees is stored as Double32_t, otherwise as short
+#ifdef LOCAL_RESIDUAL_FORMAT_OLD
+using LocResStruct = AliTPCDcalibRes::dts_t;
+#else
+using LocResStruct = o2::tpc::TrackResiduals::LocalResid;
+#endif
 
 using namespace o2::tpc;
 
@@ -112,7 +119,7 @@ void TrackResiduals::initResultsContainer(int iSec)
     for (int ip = 0; ip < mNY2XBins; ++ip) {
       for (int iz = 0; iz < mNZ2XBins; ++iz) {
         int binGlb = getGlbVoxBin(ix, ip, iz);
-        bres_t& resVox = mVoxelResults[iSec][binGlb];
+        VoxRes& resVox = mVoxelResults[iSec][binGlb];
         resVox.bvox[VoxX] = ix;
         resVox.bvox[VoxF] = ip;
         resVox.bvox[VoxZ] = iz;
@@ -131,13 +138,13 @@ void TrackResiduals::reset()
 {
   for (int iSec = 0; iSec < SECTORSPERSIDE * SIDES; ++iSec) {
     mXBinsIgnore[iSec].reset();
-    std::fill(mVoxelResults[iSec].begin(), mVoxelResults[iSec].end(), bres_t());
+    std::fill(mVoxelResults[iSec].begin(), mVoxelResults[iSec].end(), VoxRes());
     std::fill(mValidFracXBins[iSec].begin(), mValidFracXBins[iSec].end(), 0);
   }
 }
 
 //______________________________________________________________________________
-int TrackResiduals::getXBin(float x) const
+int TrackResiduals::getXBin(const float x) const
 {
   // convert x to bin ID, following pad row widths
   if (mUniformBins[VoxX]) {
@@ -175,6 +182,18 @@ int TrackResiduals::getXBin(float x) const
     }
 #endif
   }
+}
+
+bool TrackResiduals::findVoxelBin(float x, float y, float z, std::array<unsigned char, VoxDim>& bvox) const
+{
+  if (fabs(z / x) > sMaxZ2X) {
+    //printf("z/x (%.2f) out of range, z=%.2f, x=%.2f\n", z / x, z, x);
+    return false;
+  }
+  bvox[VoxZ] = getZ2XBin(fabs(z / x));
+  bvox[VoxX] = getXBin(x);
+  bvox[VoxF] = getY2XBin(y / x, bvox[VoxX]);
+  return true;
 }
 
 void TrackResiduals::setKernelType(KernelType kernel, float bwX, float bwP, float bwZ, float scX, float scP, float scZ)
@@ -216,6 +235,417 @@ void TrackResiduals::setKernelType(KernelType kernel, float bwX, float bwP, floa
 ///
 ///////////////////////////////////////////////////////////////////////////////
 
+void TrackResiduals::buildLocalResidualTreesFromRun2Data()
+{
+  // prepare trees for storage of local residuals
+  prepareLocalResidualTrees();
+  // access delta trees created by AliTPCcalibAlignInterpolation::Process();
+  mRun2DeltaTree = std::make_unique<TChain>(mResidualDataTreeName.data());
+  mRun2DeltaTree->AddFile((mPathToResidualFiles + mResidualDataFileName).data());
+  prepareDeltaTreeBranches();
+  std::array<float, param::NPadRows> residHelixY;
+  std::array<float, param::NPadRows> residHelixZ;
+  auto* brTRDOK = mRun2DeltaTree->GetBranch("trdOK");
+  auto* brITSOK = mRun2DeltaTree->GetBranch("itsOK");
+  auto nTracks = mRun2DeltaTree->GetEntries();
+  int nTracksSelected = 0;
+  int nTracksSelectedWithOutliers = 0;
+  std::array<int, 3> counterTrkValidation{ 0 };
+  int nRejCl = 0, nRejHelix = 0, nRejQpt = 0, nRejValidation = 0;
+  LOG(info) << "Building local residual trees from " << nTracks << " tracks.";
+  for (int iTrk = 0; iTrk < nTracks; ++iTrk) {
+    /*
+    printf("Checking track %i\n", iTrk);
+    if (iTrk > 2) {
+      break;
+    }
+    */
+    brTRDOK->GetEntry(iTrk);
+    brITSOK->GetEntry(iTrk);
+    if (!mDeltaStruct.trdOK || !mDeltaStruct.itsOK) {
+      //printf("Track %i trd or its not OK\n", iTrk);
+      continue;
+    }
+    mRun2DeltaTree->GetEntry(iTrk);
+    const Float_t* vSec = mDeltaStruct.vecSec->GetMatrixArray();
+    const Float_t* vPhi = mDeltaStruct.vecPhi->GetMatrixArray();
+    const Float_t* vR = mDeltaStruct.vecR->GetMatrixArray();
+    const Float_t* vZ = mDeltaStruct.vecZ->GetMatrixArray();
+    const Float_t* vDY = mDeltaStruct.vecDYtrd->GetMatrixArray();
+    const Float_t* vDZ = mDeltaStruct.vecDZtrd->GetMatrixArray();
+    const Float_t* vDYits = mDeltaStruct.vecDYits->GetMatrixArray();
+    const Float_t* vDZits = mDeltaStruct.vecDZits->GetMatrixArray();
+    mQpt = mDeltaStruct.param[4];
+    mTgl = mDeltaStruct.param[3];
+    mNCl = 0;
+
+    //printf("qpt(%.2f), tgl(%.2f), nPoints(%03i), current mNCl(%03i)\n", mQpt, mTgl, mDeltaStruct.npValid, mNCl);
+
+    // load all points into buffer
+    for (int iCl = 0; iCl < mDeltaStruct.npValid; ++iCl) {
+      //printf("checking point %03i, mNCl(%03i), nPadRows(%i)\n", iCl, mNCl, param::NPadRows);
+      // check if point is OK
+      if (vR[iCl] < param::InvalidR || vDY[iCl] < param::InvalidRes || vDYits[iCl] < param::InvalidRes) {
+        //printf("point %03i not OK: vR(%.2f), vDY(%.2f), vDTits(%.2f)\n", iCl, vR[iCl], vDY[iCl], vDYits[iCl]);
+        continue;
+      }
+      // then fill buffer arrays
+      mArrX[mNCl] = -1;
+      mArrR[mNCl] = vR[iCl];
+      mArrZTr[mNCl] = vZ[iCl] + vDZ[iCl] - vDZits[iCl];
+      mArrDY[mNCl] = vDY[iCl];
+      mArrDZ[mNCl] = vDZ[iCl];
+      mArrPhi[mNCl] = vPhi[iCl];
+      if (mArrPhi[mNCl] < 0) {
+        mArrPhi[mNCl] += o2::constants::math::TwoPI;
+      }
+      mArrSecId[mNCl] = static_cast<int>(nearbyint(vSec[iCl])) % (SECTORSPERSIDE * SIDES); // 0..35 for sectors from A0 to C17
+      ++mNCl;
+    }
+    if (mNCl < param::MinNCl) {
+      //printf("Not enough points: %i \n", mNCl);
+      ++nRejCl;
+      continue;
+    }
+    ++nTracksSelectedWithOutliers;
+    //printf("Checking track %i\n", iTrk);
+    bool resHelix = compareToHelix(residHelixY, residHelixZ);
+    /*
+    printf("Printing helix residuals for track %i\n", iTrk);
+    for (int i = 0; i < param::NPadRows; ++i) {
+      printf("residHelixY[%03i]=% .4f \t \t residHelixZ[%03i]=% .4f\n", i, residHelixY[i], i, residHelixZ[i]);
+    }
+    */
+    if (mFilterOutliers && !resHelix) {
+      // too strong deviation to helix -> discard track
+      ++nRejHelix;
+      continue;
+    }
+    if (fabsf(mQpt) > param::MaxQ2Pt) {
+      // discard low pt tracks now that a more precise q/pt estimate is available
+      ++nRejQpt;
+      continue;
+    }
+
+    // now everything needs to be converted to the sector frame
+    int nClTmp = mNCl;
+    mNCl = 0;
+    for (int iCl = 0; iCl < nClTmp; ++iCl) {
+      int side = mArrSecId[iCl] / SECTORSPERSIDE; // TODO check if side is always correct!
+      float cs = cos(mArrPhi[iCl] - (.5f + mArrSecId[iCl] % SECTORSPERSIDE) * o2::constants::math::SectorSpanRad);
+      float sn = std::sqrt((1.f + cs) * (1.f - cs)); // sin^2 + cos^2 = 1 => sin = sqrt(1-cos^2)
+
+      // by using propagation in the cluster frame in AliTPCcalibAlignInterpolation::Process(),
+      // the x of the track is evaluated not at the pad-row x = r * cs, but at x = r * cs - dy * sn
+      float xRow = mArrR[iCl] * cs;
+      float dx = mArrDY[iCl] * sn;
+      float yCl = mArrR[iCl] * sn;         // cluster y in sector frame
+      float yTrk = yCl + mArrDY[iCl] * cs; // track Y in sector frame at x = xTrk = xRow - dx
+      float zTrk = mArrZTr[iCl];           // track Z at x = xTrk = xRow - dx
+      float zCl = zTrk - mArrDZ[iCl];      // cluster z is zTrk - deltaZ
+      // use linear approximation to take the track to the real pad-row x
+      float tgSlp = mArrTgSlp[iCl];
+      if (fabsf(tgSlp) > param::MaxTgSlp) {
+        continue;
+      }
+      yTrk += dx * tgSlp;
+      float csXtrkInv = std::sqrt(1.f + tgSlp * tgSlp); // invers cosine of track angle
+      zTrk += dx * mTgl * csXtrkInv;
+
+      // assign recalculated residuals to arrays
+      mArrX[mNCl] = xRow;
+      mArrYTr[mNCl] = yTrk;
+      mArrZTr[mNCl] = zTrk;
+      mArrYCl[mNCl] = yCl;
+      mArrZCl[mNCl] = zCl;
+      mArrDY[mNCl] = yTrk - yCl;
+      mArrDZ[mNCl] = zTrk - zCl;
+      // prevent under-/overflows
+      if (fabsf(mArrDY[mNCl]) > param::MaxResid - param::sEps) {
+        continue;
+      }
+      if (fabsf(mArrDZ[mNCl]) > param::MaxResid - param::sEps) {
+        continue;
+      }
+      if (mArrX[mNCl] < param::MinX[0] || mArrX[mNCl] > param::MaxX) {
+        continue;
+      }
+      if (fabsf(mArrZCl[mNCl]) > param::ZLimit[side]) {
+        continue;
+      }
+      // done converting everything to sector frame
+      ++mNCl;
+    }
+    if (mFilterOutliers && !validateTrack(counterTrkValidation)) {
+      ++nRejValidation;
+      continue;
+    }
+    ++nTracksSelected;
+
+    fillLocalResidualsTrees();
+  }
+  LOG(info) << "Accepted " << nTracksSelected << " tracks. With outliers it would be " << nTracksSelectedWithOutliers;
+  writeLocalResidualTreesToFile();
+  //printf("Rejected due to Nclusters(%i), HelixFit(%i), qpt(%i), validation(%i)\n", nRejCl, nRejHelix, nRejQpt, nRejValidation);
+  //printf("validation failed %i times because of fraction of rej. cls and %i times because of rms and %i rest\n", counterTrkValidation[1], counterTrkValidation[2], counterTrkValidation[0]);
+}
+
+void TrackResiduals::fillLocalResidualsTrees()
+{
+  for (int iCl = mNCl; iCl--;) {
+    if (mArrX[iCl] < param::InvalidR) {
+      // this cluster was marked as outlier
+      continue;
+    }
+    int secId = mArrSecId[iCl]; // 0..35 numbering (A00 to C17)
+    if (!findVoxelBin(mArrX[iCl], mArrYCl[iCl], mArrZCl[iCl], mLocalResid.bvox)) {
+      continue;
+    }
+    mLocalResid.dy = static_cast<short>(mArrDY[iCl] * 0x7fff / param::MaxResid);
+    mLocalResid.dz = static_cast<short>(mArrDZ[iCl] * 0x7fff / param::MaxResid);
+    mLocalResid.tgSlp = static_cast<short>(mArrTgSlp[iCl] * 0x7fff / param::MaxTgSlp);
+    // fill tree
+    mTmpTree[secId]->Fill();
+    // TODO: fill statistics distribution within the voxel
+  }
+}
+
+bool TrackResiduals::validateTrack(std::array<int, 3>& counterTrkValidation)
+{
+  if (mNCl < mNMALong) {
+    ++counterTrkValidation[0];
+    return false;
+  }
+  std::bitset<param::NPadRows> rejCl{};
+  float rmsLong = 0.f;
+  int nRej = checkResiduals(rejCl, rmsLong);
+  if (static_cast<float>(nRej) / mNCl > mMaxRejFrac) {
+    ++counterTrkValidation[1];
+    return false;
+  }
+  if (rmsLong > mMaxRMSLong) {
+    ++counterTrkValidation[2];
+    return false;
+  }
+  for (int iCl = mNCl; iCl--;) {
+    // mark rejected clusters
+    if (rejCl.test(iCl)) {
+      mArrR[iCl] = -1.f;
+      mArrX[iCl] = -1.f;
+    }
+  }
+  return true;
+}
+
+int TrackResiduals::checkResiduals(std::bitset<param::NPadRows>& rejCl, float& rmsLong)
+{
+  int secStart = mArrSecId[0];
+  int iClFirst = 0;
+  int iClLast = mNCl - 1;
+
+  // arrays with differences / abs(differences) of points to their neighbourhood, initialized to zero
+  std::array<float, param::NPadRows> yDiffLL{};
+  std::array<float, param::NPadRows> zDiffLL{};
+  std::array<float, param::NPadRows> absDevY{};
+  std::array<float, param::NPadRows> absDevZ{};
+
+  for (int iCl = 0; iCl < mNCl; ++iCl) {
+    if (iCl < iClLast && mArrSecId[iCl] == secStart) {
+      continue;
+    }
+    // sector changed or last cluster reached
+    // now run estimators for all points in the same sector
+    int nClSec = iCl - iClFirst;
+    if (iCl == iClLast) {
+      ++nClSec;
+    }
+    diffToLocLine(nClSec, iClFirst, mArrX, mArrDY, yDiffLL);
+    diffToLocLine(nClSec, iClFirst, mArrX, mArrDZ, zDiffLL);
+    iClFirst = iCl;
+    secStart = mArrSecId[iCl];
+  }
+  // store abs deviations
+  int nAccY = 0;
+  int nAccZ = 0;
+  for (int iCl = mNCl; iCl--;) {
+    if (fabsf(yDiffLL[iCl]) > param::sEps) {
+      absDevY[nAccY++] = fabsf(yDiffLL[iCl]);
+    }
+    if (fabsf(zDiffLL[iCl]) > param::sEps) {
+      absDevZ[nAccZ++] = fabsf(zDiffLL[iCl]);
+    }
+  }
+  if (nAccY < param::MinNumberOfAcceptedResiduals || nAccZ < param::MinNumberOfAcceptedResiduals) {
+    // mask all clusters
+    rejCl.set();
+    return mNCl;
+  }
+  // estimate rms on 90% of the smallest deviations
+  int nKeepY = static_cast<int>(.9 * nAccY);
+  int nKeepZ = static_cast<int>(.9 * nAccZ);
+  std::nth_element(absDevY.begin(), absDevY.begin() + nKeepY, absDevY.begin() + nAccY);
+  std::nth_element(absDevZ.begin(), absDevZ.begin() + nKeepZ, absDevZ.begin() + nAccZ);
+  float rmsYkeep = 0.f;
+  float rmsZkeep = 0.f;
+  for (int i = nKeepY; i--;) {
+    rmsYkeep += absDevY[i] * absDevY[i];
+  }
+  for (int i = nKeepZ; i--;) {
+    rmsZkeep += absDevZ[i] * absDevZ[i];
+  }
+  rmsYkeep = std::sqrt(rmsYkeep / nKeepY);
+  rmsZkeep = std::sqrt(rmsZkeep / nKeepZ);
+  if (rmsYkeep < param::sEps || rmsZkeep < param::sEps) {
+    LOG(warning) << "Too small RMS: " << rmsYkeep << "(y), " << rmsZkeep << "(z).";
+    rejCl.set();
+    return mNCl;
+  }
+  float rmsYkeepI = 1.f / rmsYkeep;
+  float rmsZkeepI = 1.f / rmsZkeep;
+  int nAcc = 0;
+  std::array<float, param::NPadRows> yAcc;
+  std::array<float, param::NPadRows> yDiffLong;
+  for (int iCl = 0; iCl < mNCl; ++iCl) {
+    yDiffLL[iCl] *= rmsYkeepI;
+    zDiffLL[iCl] *= rmsZkeepI;
+    if (yDiffLL[iCl] * yDiffLL[iCl] + zDiffLL[iCl] * zDiffLL[iCl] > param::mMaxStdDevMA) {
+      rejCl.set(iCl);
+    } else {
+      yAcc[nAcc++] = mArrDY[iCl];
+    }
+  }
+  if (nAcc > mNMALong) {
+    diffToMA(nAcc, yAcc, yDiffLong);
+    float average = 0.f;
+    float rms = 0.f;
+    for (int i = 0; i < nAcc; ++i) {
+      // what about points without enough neighbours?? don't they distort the average?
+      average += yDiffLong[i];
+      rms += yDiffLong[i] * yDiffLong[i];
+    }
+    average /= nAcc;
+    rmsLong = rms / nAcc - average * average;
+    rmsLong = (rmsLong > 0) ? std::sqrt(rmsLong) : 0.f;
+  }
+  return rejCl.count();
+}
+
+void TrackResiduals::prepareDeltaTreeBranches()
+{
+  mRun2DeltaTree->SetMakeClass(1);
+  mRun2DeltaTree->SetBranchStatus("*", 0);
+
+  mRun2DeltaTree->SetBranchStatus("trdOK", 1);
+  mRun2DeltaTree->SetBranchStatus("trd0.", 1);
+  mRun2DeltaTree->SetBranchStatus("trd1.", 1);
+  mRun2DeltaTree->SetBranchStatus("vecSec.", 1);
+  mRun2DeltaTree->SetBranchStatus("vecPhi.", 1);
+  mRun2DeltaTree->SetBranchStatus("vecR.", 1);
+  mRun2DeltaTree->SetBranchStatus("vecZ.", 1);
+  mRun2DeltaTree->SetBranchStatus("npValid", 1);
+  mRun2DeltaTree->SetBranchStatus("itsOK", 1);
+  mRun2DeltaTree->SetBranchStatus("its0.", 1);
+  mRun2DeltaTree->SetBranchStatus("its1.", 1);
+  mRun2DeltaTree->SetBranchStatus("track.fP[5]", 1);
+
+  mRun2DeltaTree->SetBranchAddress("trdOK", &mDeltaStruct.trdOK);
+  mRun2DeltaTree->SetBranchAddress("trd0.", &mDeltaStruct.vecDYtrd);
+  mRun2DeltaTree->SetBranchAddress("trd1.", &mDeltaStruct.vecDZtrd);
+  mRun2DeltaTree->SetBranchAddress("vecSec.", &mDeltaStruct.vecSec);
+  mRun2DeltaTree->SetBranchAddress("vecPhi.", &mDeltaStruct.vecPhi);
+  mRun2DeltaTree->SetBranchAddress("vecR.", &mDeltaStruct.vecR);
+  mRun2DeltaTree->SetBranchAddress("vecZ.", &mDeltaStruct.vecZ);
+  mRun2DeltaTree->SetBranchAddress("npValid", &mDeltaStruct.npValid);
+  mRun2DeltaTree->SetBranchAddress("itsOK", &mDeltaStruct.itsOK);
+  mRun2DeltaTree->SetBranchAddress("its0.", &mDeltaStruct.vecDYits);
+  mRun2DeltaTree->SetBranchAddress("its1.", &mDeltaStruct.vecDZits);
+  mRun2DeltaTree->SetBranchAddress("track.fP[5]", mDeltaStruct.param);
+}
+
+void TrackResiduals::prepareLocalResidualTrees()
+{
+  // prepare tree structure
+  for (int iSec = 0; iSec < SECTORSPERSIDE * SIDES; ++iSec) {
+    mTmpFile[iSec] = std::make_unique<TFile>(Form("%s%d.root", mLocalResFileName.c_str(), iSec), "recreate");
+    mTmpTree[iSec] = std::make_unique<TTree>(Form("%s%d", mLocalResTreeName.c_str(), iSec), "TPC local residuals");
+    mTmpTree[iSec]->Branch(mLocalResBranchName.c_str(), &mLocalResidPtr);
+  }
+}
+
+void TrackResiduals::writeLocalResidualTreesToFile()
+{
+  // write trees with local residuals to file
+  for (int iSec = 0; iSec < SECTORSPERSIDE * SIDES; ++iSec) {
+    if (!mTmpFile[iSec]) {
+      continue;
+    }
+    mTmpFile[iSec]->cd();
+    mTmpTree[iSec]->Write();
+    mTmpTree[iSec].reset();
+    mTmpFile[iSec]->Close();
+    mTmpFile[iSec].reset();
+  }
+}
+
+void TrackResiduals::convertToLocalResiduals()
+{
+  // When using data generated with o2 without distortions the residuals can easily be converted
+  // without the need of outlier filtering (is this really true?).
+  // Probably a lot of the functionality from buildLocalResidualTreesFromRun2Data() have to be
+  // added here as well.
+  if (!mIsInitialized) {
+    init();
+  }
+  // open input file and access track data
+  mFileIn = std::make_unique<TFile>(mInputFileNameResiduals.data(), "open");
+  if (!mFileIn) {
+    LOG(error) << "input file could not be opened";
+    return;
+  }
+  mTreeInTracks = static_cast<TTree*>(mFileIn->Get("tracks"));
+  if (!mTreeInTracks) {
+    LOG(error) << "tree with track information not available in input file";
+    return;
+  }
+  mTreeInTracks->SetBranchAddress("tracks", &mTrackDataPtr);
+  mTreeInTracks->GetEntry(0);
+  // and access also cluster residuals
+  mTreeInClRes = static_cast<TTree*>(mFileIn->Get("residuals"));
+  if (!mTreeInClRes) {
+    LOG(error) << "tree with TPC cluster residuals not available in input file";
+    return;
+  }
+  mTreeInClRes->SetBranchAddress("residuals", &mClResPtr);
+  mTreeInClRes->GetEntry(0);
+
+  prepareLocalResidualTrees();
+
+  // loop over tracks
+  for (const auto& trk : mTrackData) {
+    int iRow = 0;
+    for (int iCl = 0; iCl < trk.clIdx.getIndex(); ++iCl) {
+      int clIdx = trk.clIdx.getEvent() + iCl;
+      std::array<unsigned char, VoxDim> bvox;
+      iRow += mClRes[clIdx].dRow;
+      float xPos = param::RowX[iRow];
+      if (!findVoxelBin(xPos, mClRes[clIdx].y * param::MaxY / 0x7fff, mClRes[clIdx].z * param::MaxZ / 0x7fff, bvox)) {
+        continue;
+      }
+      mLocalResid.dy = mClRes[clIdx].dy;
+      mLocalResid.dz = mClRes[clIdx].dz;
+      mLocalResid.tgSlp = mClRes[clIdx].phi;
+      mLocalResid.bvox = bvox;
+      // sector numbering 0..35 a.k.a. A0..C17
+      int sec = mClRes[clIdx].z < 0 ? mClRes[clIdx].sec : mClRes[clIdx].sec + SECTORSPERSIDE;
+      mTmpTree[sec]->Fill();
+      // TODO calculate mean position of clusters in each voxel (can be updated each time a new measurement is found inside voxel)
+    }
+  }
+
+  // write to file for debugging
+  writeLocalResidualTreesToFile();
+}
+
 //______________________________________________________________________________
 void TrackResiduals::processResiduals()
 {
@@ -245,15 +675,16 @@ void TrackResiduals::processSectorResiduals(int iSec)
     LOG(error) << "failed to open " << filename.c_str();
     return;
   }
-  std::string treename = "ts" + std::to_string(iSec);
+  std::string treename = mLocalResTreeName + std::to_string(iSec);
   std::unique_ptr<TTree> tree((TTree*)flin->Get(treename.c_str()));
   if (!tree) {
     LOG(error) << "did not find the data tree " << treename.c_str();
     return;
   }
-  AliTPCDcalibRes::dts_t trkRes;
+  // read compact delte trees created with AliRoot or o2
+  LocResStruct trkRes;
   auto* pTrkRes = &trkRes;
-  tree->SetBranchAddress("dts", &pTrkRes);
+  tree->SetBranchAddress(mLocalResBranchName.c_str(), &pTrkRes);
   auto nPoints = tree->GetEntries();
   if (!nPoints) {
     LOG(warning) << "no entries found for sector " << iSec;
@@ -268,7 +699,7 @@ void TrackResiduals::processSectorResiduals(int iSec)
 
   LOG(info) << "extracted " << nPoints << " of unbinned data";
 
-  std::vector<bres_t>& secData = mVoxelResults[iSec];
+  std::vector<VoxRes>& secData = mVoxelResults[iSec];
 
   unsigned int nAccepted = 0;
 
@@ -284,12 +715,21 @@ void TrackResiduals::processSectorResiduals(int iSec)
   // read input data into internal vectors
   for (int i = 0; i < nPoints; ++i) {
     tree->GetEntry(i);
-    if (fabs(trkRes.tgSlp) >= mMaxTgSlp) {
+#ifdef LOCAL_RESIDUAL_FORMAT_OLD
+    if (fabs(trkRes.tgSlp) >= param::MaxTgSlp) {
       continue;
     }
     dyData[nAccepted] = trkRes.dy;
     dzData[nAccepted] = trkRes.dz;
     tgSlpData[nAccepted] = trkRes.tgSlp;
+#else
+    if (fabs(trkRes.tgSlp * param::MaxTgSlp / 0x7fff) >= param::MaxTgSlp) {
+      continue;
+    }
+    dyData[nAccepted] = trkRes.dy * param::MaxResid / 0x7fff;
+    dzData[nAccepted] = trkRes.dz * param::MaxResid / 0x7fff;
+    tgSlpData[nAccepted] = trkRes.tgSlp * param::MaxTgSlp / 0x7fff;
+#endif
     binData[nAccepted] = getGlbVoxBin(trkRes.bvox[VoxX], trkRes.bvox[VoxF], trkRes.bvox[VoxZ]);
     nAccepted++;
   }
@@ -310,19 +750,21 @@ void TrackResiduals::processSectorResiduals(int iSec)
   tgSlpData.resize(nAccepted);
   binData.resize(nAccepted);
 
+#ifdef LOCAL_RESIDUAL_FORMAT_OLD
   // convert to short and back to float to be compatible with AliRoot version
   std::vector<short> dyDataShort(nAccepted);
   std::vector<short> dzDataShort(nAccepted);
   std::vector<short> tgSlpDataShort(nAccepted);
   for (unsigned int i = 0; i < nAccepted; ++i) {
-    dyDataShort[i] = short(dyData[i] * 0x7fff / sMaxResid);
-    dzDataShort[i] = short(dzData[i] * 0x7fff / sMaxResid);
-    tgSlpDataShort[i] = short(tgSlpData[i] * 0x7fff / mMaxTgSlp);
+    dyDataShort[i] = short(dyData[i] * 0x7fff / param::MaxResid);
+    dzDataShort[i] = short(dzData[i] * 0x7fff / param::MaxResid);
+    tgSlpDataShort[i] = short(tgSlpData[i] * 0x7fff / param::MaxTgSlp);
 
-    dyData[i] = dyDataShort[i] * sMaxResid / 0x7fff;
-    dzData[i] = dzDataShort[i] * sMaxResid / 0x7fff;
-    tgSlpData[i] = tgSlpDataShort[i] * mMaxTgSlp / 0x7fff;
+    dyData[i] = dyDataShort[i] * param::MaxResid / 0x7fff;
+    dzData[i] = dzDataShort[i] * param::MaxResid / 0x7fff;
+    tgSlpData[i] = tgSlpDataShort[i] * param::MaxTgSlp / 0x7fff;
   }
+#endif
 
   // sort in voxel increasing order
   o2::math_utils::math_base::SortData(binData, binIndices);
@@ -346,7 +788,7 @@ void TrackResiduals::processSectorResiduals(int iSec)
     int idx = binIndices[nProcessed];
     if (currVoxBin != binData[idx]) {
       if (nPointsInVox) {
-        bres_t& resVox = secData[currVoxBin];
+        VoxRes& resVox = secData[currVoxBin];
         processVoxelResiduals(dyVec, dzVec, tgVec, resVox);
       }
       currVoxBin = binData[idx];
@@ -363,7 +805,7 @@ void TrackResiduals::processSectorResiduals(int iSec)
   }
   if (nPointsInVox) {
     // process last voxel
-    bres_t& resVox = secData[currVoxBin];
+    VoxRes& resVox = secData[currVoxBin];
     processVoxelResiduals(dyVec, dzVec, tgVec, resVox);
   }
   LOG(info) << "extracted residuals for sector " << iSec;
@@ -387,7 +829,7 @@ void TrackResiduals::processSectorResiduals(int iSec)
     int idx = binIndices[nProcessed];
     if (currVoxBin != binData[idx]) {
       if (nPointsInVox) {
-        bres_t& resVox = secData[currVoxBin];
+        VoxRes& resVox = secData[currVoxBin];
         if (!getXBinIgnored(iSec, resVox.bvox[VoxX])) {
           processVoxelDispersions(tgVec, dyVec, resVox);
         }
@@ -404,7 +846,7 @@ void TrackResiduals::processSectorResiduals(int iSec)
   }
   if (nPointsInVox) {
     // process last voxel
-    bres_t& resVox = secData[currVoxBin];
+    VoxRes& resVox = secData[currVoxBin];
     if (!getXBinIgnored(iSec, resVox.bvox[VoxX])) {
       processVoxelDispersions(tgVec, dyVec, resVox);
     }
@@ -417,16 +859,17 @@ void TrackResiduals::processSectorResiduals(int iSec)
     for (int iz = 0; iz < mNZ2XBins; ++iz) {
       for (int ip = 0; ip < mNY2XBins; ++ip) {
         int voxBin = getGlbVoxBin(ix, ip, iz);
-        bres_t& resVox = secData[voxBin];
+        VoxRes& resVox = secData[voxBin];
         getSmoothEstimate(iSec, resVox.stat[VoxX], resVox.stat[VoxF], resVox.stat[VoxZ], resVox.DS, 0x1 << VoxV);
       }
     }
   }
+  LOG(info) << "Done processing residuals for sector " << iSec;
   dumpResults(iSec);
 }
 
 //______________________________________________________________________________
-void TrackResiduals::processVoxelResiduals(std::vector<float>& dy, std::vector<float>& dz, std::vector<float>& tg, bres_t& resVox)
+void TrackResiduals::processVoxelResiduals(std::vector<float>& dy, std::vector<float>& dz, std::vector<float>& tg, VoxRes& resVox)
 {
   size_t nPoints = dy.size();
   //LOG(debug) << "processing voxel residuals for vox " << getGlbVoxBin(resVox.bvox) << " with " << nPoints << " points";
@@ -469,7 +912,7 @@ void TrackResiduals::processVoxelResiduals(std::vector<float>& dy, std::vector<f
   return;
 }
 
-void TrackResiduals::processVoxelDispersions(std::vector<float>& tg, std::vector<float>& dy, bres_t& resVox)
+void TrackResiduals::processVoxelDispersions(std::vector<float>& tg, std::vector<float>& dy, VoxRes& resVox)
 {
   size_t nPoints = tg.size();
   LOG(debug) << "processing voxel dispersions for vox " << getGlbVoxBin(resVox.bvox) << " with " << nPoints << " points";
@@ -492,7 +935,7 @@ int TrackResiduals::validateVoxels(int iSec)
   int cntMasked = 0;  // number of voxels masked due to fit error and / or distribution sigmas
   int cntInvalid = 0; // number of voxels which were invalid before + masked ones
   mXBinsIgnore[iSec].reset();
-  std::vector<bres_t>& secData = mVoxelResults[iSec];
+  std::vector<VoxRes>& secData = mVoxelResults[iSec];
 
   int cntMaskedFit = 0;
   int cntMaskedSigma = 0;
@@ -503,7 +946,7 @@ int TrackResiduals::validateVoxels(int iSec)
     for (int ip = 0; ip < mNY2XBins; ++ip) {
       for (int iz = 0; iz < mNZ2XBins; ++iz) {
         int binGlb = getGlbVoxBin(ix, ip, iz);
-        bres_t& resVox = secData[binGlb];
+        VoxRes& resVox = secData[binGlb];
         bool voxelOK = (resVox.flags & DistDone) && !(resVox.flags & Masked);
         if (voxelOK) {
           // check fit errors
@@ -613,7 +1056,7 @@ int TrackResiduals::validateVoxels(int iSec)
 
 void TrackResiduals::smooth(int iSec)
 {
-  std::vector<bres_t>& secData = mVoxelResults[iSec];
+  std::vector<VoxRes>& secData = mVoxelResults[iSec];
   for (int ix = 0; ix < mNXBins; ++ix) {
     if (getXBinIgnored(iSec, ix)) {
       continue;
@@ -621,7 +1064,7 @@ void TrackResiduals::smooth(int iSec)
     for (int ip = 0; ip < mNY2XBins; ++ip) {
       for (int iz = 0; iz < mNZ2XBins; ++iz) {
         int voxBin = getGlbVoxBin(ix, ip, iz);
-        bres_t& resVox = secData[voxBin];
+        VoxRes& resVox = secData[voxBin];
         resVox.flags &= ~SmoothDone;
         bool res = getSmoothEstimate(resVox.bsec, resVox.stat[VoxX], resVox.stat[VoxF], resVox.stat[VoxZ], resVox.DS, (0x1 << VoxX | 0x1 << VoxF | 0x1 << VoxZ));
         if (!res) {
@@ -640,7 +1083,7 @@ void TrackResiduals::smooth(int iSec)
     for (int ip = 0; ip < mNY2XBins; ++ip) {
       for (int iz = 0; iz < mNZ2XBins; ++iz) {
         int voxBin = getGlbVoxBin(ix, ip, iz);
-        bres_t& resVox = secData[voxBin];
+        VoxRes& resVox = secData[voxBin];
         if (!(resVox.flags & SmoothDone)) {
           continue;
         }
@@ -677,16 +1120,16 @@ bool TrackResiduals::getSmoothEstimate(int iSec, float x, float p, float z, std:
 
   int ix0, ip0, iz0;
   findVoxel(x, p, iSec < SECTORSPERSIDE ? z : -z, ix0, ip0, iz0); // find nearest voxel
-  std::vector<bres_t>& secData = mVoxelResults[iSec];
+  std::vector<VoxRes>& secData = mVoxelResults[iSec];
   int binCenter = getGlbVoxBin(ix0, ip0, iz0); // global bin of nearest voxel
-  bres_t& voxCenter = secData[binCenter];      // nearest voxel
+  VoxRes& voxCenter = secData[binCenter];      // nearest voxel
   LOG(debug) << "getting smooth estimate around voxel " << binCenter;
 
   // cache
   // \todo maybe a 1-D cache would be more efficient?
   std::array<std::array<double, sMaxSmtDim*(sMaxSmtDim + 1) / 2>, ResDim> cmat;
   int maxNeighb = 10 * 10 * 10;
-  std::vector<bres_t*> currVox;
+  std::vector<VoxRes*> currVox;
   currVox.reserve(maxNeighb);
   std::vector<float> currCache;
   currCache.reserve(maxNeighb * VoxHDim);
@@ -778,7 +1221,7 @@ bool TrackResiduals::getSmoothEstimate(int iSec, float x, float p, float z, std:
       for (int ip = ipMin; ip <= ipMax; ++ip) {
         for (int iz = izMin; iz <= izMax; ++iz) {
           int binNb = getGlbVoxBin(ix, ip, iz);
-          bres_t& voxNb = secData[binNb];
+          VoxRes& voxNb = secData[binNb];
           if (!(voxNb.flags & DistDone) ||
               (voxNb.flags & Masked) ||
               getXBinIgnored(iSec, ix)) {
@@ -873,7 +1316,7 @@ bool TrackResiduals::getSmoothEstimate(int iSec, float x, float p, float z, std:
       double dxi2 = dxi * dxi;
       double dfi2 = dfi * dfi;
       double dzi2 = dzi * dzi;
-      const bres_t* voxNb = currVox[iNb];
+      const VoxRes* voxNb = currVox[iNb];
       for (int iDim = 0; iDim < ResDim; ++iDim) {
         if (!doDim[iDim]) {
           continue;
@@ -1040,6 +1483,94 @@ double TrackResiduals::getKernelWeight(std::array<double, 3> u2vec) const
 /// fitting + statistics helper functions
 ///
 ///////////////////////////////////////////////////////////////////////////////
+
+void TrackResiduals::diffToMA(int np, const std::array<float, param::NPadRows>& y, std::array<float, param::NPadRows>& diffMA)
+{
+  // Calculate
+  float sumArr[np + 1];
+  float* sum = sumArr + 1;
+  sum[-1] = 0.f;
+  for (int i = 0; i < np; ++i) {
+    sum[i] = sum[i - 1] + y[i];
+  }
+  for (int i = 0; i < np; ++i) {
+    diffMA[i] = 0;
+    int iLeft = i - mNMALong;
+    int iRight = i + mNMALong;
+    if (iLeft < 0) {
+      iLeft = 0;
+    }
+    if (iRight >= np) {
+      iRight = np - 1;
+    }
+    int nPoints = iRight - iLeft;
+    if (nPoints < mNMALong) {
+      continue;
+    }
+    float movingAverage = (sum[iRight] - sum[iLeft - 1] - (sum[i] - sum[i - 1])) / nPoints;
+    diffMA[i] = y[i] - movingAverage;
+  }
+}
+
+void TrackResiduals::diffToLocLine(int np, int idxOffset, const std::array<float, param::NPadRows>& x, const std::array<float, param::NPadRows>& y, std::array<float, param::NPadRows>& diffY)
+{
+  // Calculate the difference between the points and the linear extrapolations from the neighbourhood.
+  // Nothing more than multiple 1-d fits at once. Instead of building 4 sums (x, x^2, y, xy), 4 * nPoints sums are calculated at once
+  // compare to TrackResiduals::fitPoly1() method
+
+  // adding one entry to the arrays saves an additional if statement when calculating the cumulants
+  float sumX1arr[np + 1];
+  float sumX2arr[np + 1];
+  float sumY1arr[np + 1];
+  float sumXYarr[np + 1];
+  float* sumX1 = sumX1arr + 1;
+  float* sumX2 = sumX2arr + 1;
+  float* sumY1 = sumY1arr + 1;
+  float* sumXY = sumXYarr + 1;
+  sumX1[-1] = 0.f;
+  sumX2[-1] = 0.f;
+  sumY1[-1] = 0.f;
+  sumXY[-1] = 0.f;
+
+  // accumulate sums for all points
+  for (int iCl = 0; iCl < np; ++iCl) {
+    int idx = iCl + idxOffset;
+    sumX1[iCl] = sumX1[iCl - 1] + x[idx];
+    sumX2[iCl] = sumX2[iCl - 1] + x[idx] * x[idx];
+    sumY1[iCl] = sumY1[iCl - 1] + y[idx];
+    sumXY[iCl] = sumXY[iCl - 1] + x[idx] * y[idx];
+  }
+
+  for (int iCl = 0; iCl < np; ++iCl) {
+    int iClLeft = iCl - mNMALong;
+    int iClRight = iCl + mNMALong;
+    if (iClLeft < 0) {
+      iClLeft = 0;
+    }
+    if (iClRight >= np) {
+      iClRight = np - 1;
+    }
+    int nPoints = iClRight - iClLeft;
+    if (nPoints < mNMALong) {
+      continue;
+    }
+    float nPointsInv = 1.f / nPoints;
+    int iClLeftP = iClLeft - 1;
+    int iClCurrP = iCl - 1;
+    // extract sum from iClLeft to iClRight from cumulants, excluding iCl from the fit
+    float sX1 = sumX1[iClRight] - sumX1[iClLeftP] - (sumX1[iCl] - sumX1[iClCurrP]);
+    float sX2 = sumX2[iClRight] - sumX2[iClLeftP] - (sumX2[iCl] - sumX2[iClCurrP]);
+    float sY1 = sumY1[iClRight] - sumY1[iClLeftP] - (sumY1[iCl] - sumY1[iClCurrP]);
+    float sXY = sumXY[iClRight] - sumXY[iClLeftP] - (sumXY[iCl] - sumXY[iClCurrP]);
+    float det = sX2 - nPointsInv * sX1 * sX1;
+    if (fabsf(det) < 1e-12f) {
+      continue;
+    }
+    float slope = (sXY - nPointsInv * sX1 * sY1) / det;
+    float offset = nPointsInv * sY1 - nPointsInv * slope * sX1;
+    diffY[iCl + idxOffset] = y[iCl + idxOffset] - slope * x[iCl + idxOffset] - offset;
+  }
+}
 
 float TrackResiduals::fitPoly1Robust(std::vector<float>& x, std::vector<float>& y, std::array<float, 2>& res, std::array<float, 3>& err, float cutLTM) const
 {
@@ -1219,6 +1750,7 @@ float TrackResiduals::selectKthMin(const int k, std::vector<float>& data)
   // to have this value in location data[k] , with all smaller elements moved before it
   // (in arbitrary order) and all larger elements after (also in arbitrary order).
   // From Numerical Recipes in C++ (paragraph 8.5)
+  // Probably it is not needed anymore, since std::nth_element() can also be used
 
   int i, ir, j, l, mid, n = data.size();
   float a;    // partitioning element
@@ -1316,6 +1848,193 @@ float TrackResiduals::getMAD2Sigma(std::vector<float> data) const
 
   float k = 1.4826f; // scale factor for normally distributed data
   return k * medianOfAbsDeviations;
+}
+
+bool TrackResiduals::compareToHelix(std::array<float, param::NPadRows>& residHelixY, std::array<float, param::NPadRows>& residHelixZ)
+{
+  //printf("-----------------compare to helix -------------\n");
+  std::array<float, param::NPadRows> xLab;
+  std::array<float, param::NPadRows> yLab;
+  std::array<float, param::NPadRows> sPath;
+
+  float curvature = fabsf(mQpt * param::Bz * o2::constants::physics::LightSpeedCm2S * 1e-14f);
+  int secCurr = mArrSecId[0];
+  float phiSect = (secCurr + .5f) * o2::constants::math::SectorSpanRad;
+  float snPhi = sin(phiSect);
+  float csPhi = cos(phiSect);
+  sPath[0] = 0.f;
+
+  for (int iP = 0; iP < mNCl; ++iP) {
+    //printf("idx%03i: phi(%.2f), r(%.2f), dy(%.2f), sect0(%02i), z(%.2f)\n", iP, mArrPhi[iP], mArrR[iP], mArrDY[iP], secCurr, mArrZTr[iP]);
+    float cs = cos(mArrPhi[iP] - phiSect);
+    float sn = sin(mArrPhi[iP] - phiSect);
+    // we are still in the cluster frame - radius and x are the same in this case
+    // now we rotate into the frame of the sector with the first cluster of the track
+    xLab[iP] = mArrR[iP] * cs - mArrDY[iP] * sn;
+    yLab[iP] = mArrDY[iP] * cs + mArrR[iP] * sn;
+    if (iP > 0) {
+      float dx = xLab[iP] - xLab[iP - 1];
+      float dy = yLab[iP] - yLab[iP - 1];
+      float ds2 = dx * dx + dy * dy;
+      float ds = sqrt(ds2); // circular path (linear approximation)
+      // if the curvature of the track or the (approximated) chord length is too large the more exact formula is used:
+      // chord length = 2r * asin(ds/(2r))
+      // using the first two terms of the tailer expansion for asin(x) ~ x + x^3 / 6
+      if (ds * curvature > 0.05) {
+        ds *= (1.f + ds2 * curvature * curvature / 24.f);
+      }
+      sPath[iP] = sPath[iP - 1] + ds;
+    }
+  }
+  float xcSec = 0.f;
+  float ycSec = 0.f;
+  float r = 0.f;
+  fitCircle(mNCl, xLab, yLab, xcSec, ycSec, r, residHelixY);
+  // determine curvature
+  float phiI = TMath::ATan2(yLab[0], xLab[0]);
+  float phiF = TMath::ATan2(yLab[mNCl - 1], xLab[mNCl - 1]);
+  if (phiI < 0) {
+    phiI += o2::constants::math::TwoPI;
+  }
+  if (phiF < 0) {
+    phiF += o2::constants::math::TwoPI;
+  }
+  float dPhi = phiF - phiI;
+  float curvSign = 1.f;
+  if (dPhi > 0) {
+    if (dPhi < o2::constants::math::PI) {
+      curvSign = -1.f;
+    }
+  } else if (dPhi < -o2::constants::math::PI) {
+    curvSign = -1.f;
+  }
+  mQpt = std::copysign(1.f / (r * param::Bz * o2::constants::physics::LightSpeedCm2S * 1e-14f), curvSign);
+
+  // calculate circle coordinates in the lab frame
+  float xc = xcSec * csPhi - ycSec * snPhi;
+  float yc = xcSec * snPhi + ycSec * csPhi;
+
+  std::array<float, 2> pol1Z;
+  fitPoly1(mNCl, sPath, mArrZTr, pol1Z);
+
+  mTgl = pol1Z[0];
+
+  // max deviations in both directions from helix fit in y and z
+  float hMinY = 1e9f;
+  float hMaxY = -1e9f;
+  float hMinZ = 1e9f;
+  float hMaxZ = -1e9f;
+  // extract residuals in Z and fill track slopes in sector frame
+  for (int iCl = 0; iCl < mNCl; ++iCl) {
+    float resZ = mArrZTr[iCl] - (pol1Z[1] + sPath[iCl] * pol1Z[0]);
+    residHelixZ[iCl] = resZ;
+    if (resZ < hMinZ) {
+      hMinZ = resZ;
+    }
+    if (resZ > hMaxZ) {
+      hMaxZ = resZ;
+    }
+    if (residHelixY[iCl] < hMinY) {
+      hMinY = residHelixY[iCl];
+    }
+    if (residHelixY[iCl] > hMaxY) {
+      hMaxY = residHelixY[iCl];
+    }
+    int sec = mArrSecId[iCl];
+    if (sec != secCurr) {
+      secCurr = sec;
+      phiSect = (.5f + sec) * o2::constants::math::SectorSpanRad;
+      snPhi = sin(phiSect);
+      csPhi = cos(phiSect);
+      xcSec = xc * csPhi + yc * snPhi; // recalculate circle center in the sector frame
+    }
+
+    float cs = cos(mArrPhi[iCl] - phiSect);
+    float xRow = mArrR[iCl] * cs; // pad row x in sector frame
+    float sinPhi = (xRow - xcSec) / r;
+    // TODO add track inclination angle at pad-row
+    mArrTgSlp[iCl] = tan(asin(sinPhi));
+    // In B+ the slope of q- should increase with x. Just look on q * B
+    if (mQpt * param::Bz > 0) {
+      mArrTgSlp[iCl] *= -1.f;
+    }
+  }
+  return fabsf(hMaxY - hMinY) < param::MaxDevHelixY && fabsf(hMaxZ - hMinZ) < param::MaxDevHelixZ;
+}
+
+void TrackResiduals::fitCircle(int nCl, std::array<float, param::NPadRows>& x, std::array<float, param::NPadRows>& y, float& xc, float& yc, float& r, std::array<float, param::NPadRows>& residHelixY)
+{
+  float xMean = 0.f;
+  float yMean = 0.f;
+
+  for (int i = nCl; i--;) {
+    xMean += x[i];
+    yMean += y[i];
+  }
+  xMean /= nCl;
+  yMean /= nCl;
+  // define sums needed for circular fit
+  float su2 = 0.f, sv2 = 0.f, suv = 0.f, su3 = 0.f, sv3 = 0.f, su2v = 0.f, suv2 = 0.f;
+  for (int i = nCl; i--;) {
+    float ui = x[i] - xMean;
+    float vi = y[i] - yMean;
+    float ui2 = ui * ui;
+    float vi2 = vi * vi;
+    suv += ui * vi;
+    su2 += ui2;
+    sv2 += vi2;
+    su3 += ui2 * ui;
+    sv3 += vi2 * vi;
+    su2v += ui2 * vi;
+    suv2 += ui * vi2;
+  }
+  float rhsU = .5f * (su3 + suv2);
+  float rhsV = .5f * (sv3 + su2v);
+  float det = su2 * sv2 - suv * suv;
+  float uc = (rhsU * sv2 - rhsV * suv) / det;
+  float vc = (su2 * rhsV - suv * rhsU) / det;
+  float r2 = uc * uc + vc * vc + (su2 + sv2) / nCl;
+  xc = uc + xMean;
+  yc = vc + yMean;
+  r = sqrt(r2);
+  // write residuals to residHelixY
+  for (int i = nCl; i--;) {
+    float dx = x[i] - xc;
+    float dxr = r2 - dx * dx;
+    float ys = dxr > 0 ? sqrt(dxr) : 0.f; // distance of point in y from the circle center (using fit results for r and xc)
+    float dy = y[i] - yc;                 // distance of point in y from the circle center (using fit result for yc)
+    float dysp = dy - ys;
+    float dysm = dy + ys;
+    residHelixY[i] = fabsf(dysp) < fabsf(dysm) ? dysp : dysm;
+  }
+  //printf("Circle fit results: pT = %.2f => r should be roughly %f\n", 1.f/mQpt, 1.f/(mQpt * 0.3f * 0.5f));
+  //printf("r = %.4f m, xc = %.4f, yc = %.4f\n", r/100.f, xc, yc);
+}
+
+bool TrackResiduals::fitPoly1(int nCl, std::array<float, param::NPadRows>& x, std::array<float, param::NPadRows>& y, std::array<float, 2>& res)
+{
+  // fit a straight line y = ax + b to a given set of points (x,y)
+  // no measurement errors assumed, no fit errors calculated
+  // res[0] = a (slope)
+  // res[1] = b (offset)
+  if (nCl < 2) {
+    // not enough points
+    return false;
+  }
+  float sumX = 0.f, sumY = 0.f, sumXY = 0.f, sumX2 = 0.f, nInv = 1.f / nCl;
+  for (int i = nCl; i--;) {
+    sumX += x[i];
+    sumY += y[i];
+    sumXY += x[i] * y[i];
+    sumX2 += x[i] * x[i];
+  }
+  float det = sumX2 - nInv * sumX * sumX;
+  if (fabsf(det) < 1e-12f) {
+    return false;
+  }
+  res[0] = (sumXY - nInv * sumX * sumY) / det;
+  res[1] = nInv * sumY - nInv * res[0] * sumX;
+  return true;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/Detectors/TPC/calibration/SpacePoints/src/TrackResiduals.cxx
+++ b/Detectors/TPC/calibration/SpacePoints/src/TrackResiduals.cxx
@@ -144,7 +144,7 @@ void TrackResiduals::reset()
 }
 
 //______________________________________________________________________________
-int TrackResiduals::getXBin(const float x) const
+int TrackResiduals::getXBin(float x) const
 {
   // convert x to bin ID, following pad row widths
   if (mUniformBins[VoxX]) {
@@ -384,10 +384,10 @@ void TrackResiduals::buildLocalResidualTreesFromRun2Data()
 
     fillLocalResidualsTrees();
   }
+  printf("Rejected due to Nclusters(%i), HelixFit(%i), qpt(%i), validation(%i)\n", nRejCl, nRejHelix, nRejQpt, nRejValidation);
+  printf("validation failed %i times because of fraction of rej. cls and %i times because of rms and %i rest\n", counterTrkValidation[1], counterTrkValidation[2], counterTrkValidation[0]);
   LOG(info) << "Accepted " << nTracksSelected << " tracks. With outliers it would be " << nTracksSelectedWithOutliers;
   writeLocalResidualTreesToFile();
-  //printf("Rejected due to Nclusters(%i), HelixFit(%i), qpt(%i), validation(%i)\n", nRejCl, nRejHelix, nRejQpt, nRejValidation);
-  //printf("validation failed %i times because of fraction of rej. cls and %i times because of rms and %i rest\n", counterTrkValidation[1], counterTrkValidation[2], counterTrkValidation[0]);
 }
 
 void TrackResiduals::fillLocalResidualsTrees()
@@ -623,8 +623,8 @@ void TrackResiduals::convertToLocalResiduals()
   // loop over tracks
   for (const auto& trk : mTrackData) {
     int iRow = 0;
-    for (int iCl = 0; iCl < trk.clIdx.getIndex(); ++iCl) {
-      int clIdx = trk.clIdx.getEvent() + iCl;
+    for (int iCl = 0; iCl < trk.clIdx.getEntries(); ++iCl) {
+      int clIdx = trk.clIdx.getFirstEntry() + iCl;
       std::array<unsigned char, VoxDim> bvox;
       iRow += mClRes[clIdx].dRow;
       float xPos = param::RowX[iRow];


### PR DESCRIPTION
- ITS-TPC-TOF tracks are refitted w/o TPC information and the TPC cluster residuals w.r.t. the refitted tracks are stored in a specified data structure
- ITS-TPC tracks can also be used, in this case an extrapolation of the ITS only tracks is performed
- Some track quality cuts have been added, but these are still to be tuned
- The output of the TrackInterpolation class needs to be converted before it can be used as input for TrackResiduals
- This is work in progress!