### PR TITLE
Technical improvements in the ITS reconstruction workflow

### DIFF
--- a/Detectors/ITSMFT/ITS/macros/EVE/DisplayEvents.C
+++ b/Detectors/ITSMFT/ITS/macros/EVE/DisplayEvents.C
@@ -375,7 +375,7 @@ TEveElement* Data::getEveTracks()
     int nc = rec.getNumberOfClusters();
     while (nc--) {
       Int_t idx = rec.getClusterIndex(nc);
-      const Cluster& c = (*mClusterBuffer)[idx];
+      const Cluster& c = mClusters[idx];
       const auto& gloC = c.getXYZGloRot(*gman);
       tpoints->SetNextPoint(gloC.X(), gloC.Y(), gloC.Z());
     }

--- a/Detectors/ITSMFT/ITS/macros/test/CheckTracks.C
+++ b/Detectors/ITSMFT/ITS/macros/test/CheckTracks.C
@@ -68,8 +68,9 @@ void CheckTracks(std::string tracfile = "o2trac_its.root", std::string clusfile 
   o2::dataformats::MCTruthContainer<o2::MCCompLabel>* trkLabArr = nullptr;
   recTree->SetBranchAddress("ITSTrackMCTruth", &trkLabArr);
 
-  Int_t tf = 0, nrec = 0;
-  Int_t lastEventID = -1;
+  Int_t nrec = 0;
+  Int_t lastEventIDcl = -1, cf = 0;
+  Int_t lastEventIDtr = -1, tf = 0;
   Int_t nev = mcTree->GetEntries();
 
   Int_t nb = 100;
@@ -91,19 +92,30 @@ void CheckTracks(std::string tracfile = "o2trac_its.root", std::string clusfile 
     Int_t nmc = mcArr->size();
     Int_t nmcrefs = mcTrackRefs->size();
 
-    while ((n > lastEventID) && (tf < recTree->GetEntries())) { // Cache a new reconstructed TF
-      clusTree->GetEvent(tf);
+    while ((n > lastEventIDtr) && (tf < recTree->GetEntries())) { // Cache a new reconstructed entry
       recTree->GetEvent(tf);
       nrec = recArr->size();
-      for (int i = 0; i < nrec; i++) { // Find the last MC event within this reconstructed TF
+      for (int i = 0; i < nrec; i++) { // Find the last MC event within this reconstructed entry
         auto mclab = (trkLabArr->getLabels(i))[0];
         auto id = mclab.getEventID();
-        if (id > lastEventID)
-          lastEventID = id;
+        if (id > lastEventIDtr)
+          lastEventIDtr = id;
       }
       if (nrec > 0)
-        std::cout << "Caching TF #" << tf << ", with the last event ID=" << lastEventID << std::endl;
+        std::cout << "Caching track entry #" << tf << ", with the last event ID=" << lastEventIDtr << std::endl;
       tf++;
+    }
+    while ((n > lastEventIDcl) && (cf < clusTree->GetEntries())) { // Cache a new reconstructed entry
+      clusTree->GetEvent(cf);
+      for (int i = 0; i < clusArr->size(); i++) { // Find the last MC event within this reconstructed entry
+        auto mclab = (clusLabArr->getLabels(i))[0];
+        auto id = mclab.getEventID();
+        if (id > lastEventIDcl)
+          lastEventIDcl = id;
+      }
+      if (nrec > 0)
+        std::cout << "Caching cluster entry #" << cf << ", with the last event ID=" << lastEventIDcl << std::endl;
+      cf++;
     }
 
     while (nmc--) {

--- a/Detectors/ITSMFT/ITS/macros/test/run_workflows.sh
+++ b/Detectors/ITSMFT/ITS/macros/test/run_workflows.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 o2sim -n 10 -e TGeant3 -g boxgen -m PIPE ITS >& sim.log 
 digitizer-workflow >& digi.log
-#digitizer-workflow --ITStriggered >& digi.log
+#digitizer-workflow --configKeyValues "ITSDigitizerParam.continuous=0" >& digi.log
 its-reco-workflow >& reco.log
 
 # These macros can be run to check the quality of the results 

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTracker.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTracker.h
@@ -112,7 +112,7 @@ class CookedTracker
   const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* mClsLabels = nullptr; /// Cluster MC labels
   o2::dataformats::MCTruthContainer<o2::MCCompLabel>* mTrkLabels = nullptr;       /// Track MC labels
 
-  std::uint32_t mROFrame = 0; ///< last frame processed
+  std::uint32_t mFirstInFrame = 0; ///< Index of the 1st cluster of a frame (within the loaded vector of clusters)
 
   Int_t mNumOfThreads; ///< Number of tracking threads
 

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CookedTracker.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CookedTracker.cxx
@@ -137,7 +137,7 @@ void CookedTracker::setExternalIndices(TrackITS& t) const
   for (Int_t i = 0; i < noc; i++) {
     Int_t index = t.getClusterIndex(i);
     const Cluster* c = getCluster(index);
-    Int_t idx = c - mFirstCluster; // Index of this cluster in event
+    Int_t idx = c - mFirstCluster - mROFrame; // Index of this cluster in event
     t.setExternalClusterIndex(i, idx);
   }
 }
@@ -516,8 +516,6 @@ void CookedTracker::process(const std::vector<Cluster>& clusters, std::vector<Tr
     LOG(INFO) << "Processing time/clusters for single frame : " << diff.count() << " / " << nClFrame << " s" << FairLogger::endl;
 
     start = end;
-
-    mROFrame++; // Increment the RO frame ID and go on, if in continuous mode
   }
 }
 
@@ -557,7 +555,6 @@ void CookedTracker::processFrame(std::vector<TrackITS>& tracks)
         mTrkLabels->addElement(idx, label);
       }
       setExternalIndices(track);
-      track.setROFrame(mROFrame);
       tracks.push_back(track);
     }
   }
@@ -615,6 +612,8 @@ int CookedTracker::loadClusters(const std::vector<Cluster>& clusters, const o2::
   //--------------------------------------------------------------------
   auto first = rof.getROFEntry().getIndex();
   auto number = rof.getNROFEntries();
+
+  mROFrame = first;
 
   auto clusters_in_frame = gsl::make_span(&clusters[first], number);
   for (const auto& c : clusters_in_frame) {

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CookedTracker.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CookedTracker.cxx
@@ -516,8 +516,7 @@ void CookedTracker::process(const std::vector<Cluster>& clusters, std::vector<Tr
     LOG(INFO) << "Processing time/clusters for single frame : " << diff.count() << " / " << nClFrame << " s" << FairLogger::endl;
 
     start = end;
-    if (!mContinuousMode)
-      break;    // Done, if in triggered mode
+
     mROFrame++; // Increment the RO frame ID and go on, if in continuous mode
   }
 }
@@ -615,12 +614,8 @@ int CookedTracker::loadClusters(const std::vector<Cluster>& clusters, const o2::
   // This function reads the ITSU clusters from the tree,
   // sort them, distribute over the internal tracker arrays, etc
   //--------------------------------------------------------------------
-  int first = 0;
-  int number = clusters.size();
-  if (mContinuousMode) { // Load clusters from this ROFrame only, if in continuous mode
-    first = rof.getROFEntry().getIndex();
-    number = rof.getNROFEntries();
-  }
+  auto first = rof.getROFEntry().getIndex();
+  auto number = rof.getNROFEntries();
 
   auto clusters_in_frame = gsl::make_span(&clusters[first], number);
   for (const auto& c : clusters_in_frame) {

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CookedTracker.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CookedTracker.cxx
@@ -532,7 +532,6 @@ void CookedTracker::processFrame(std::vector<TrackITS>& tracks)
   if (!numOfClusters) {
     return;
   }
-  LOG(INFO) << "CookedTracker::process(), number of threads: " << mNumOfThreads << " for " << numOfClusters << " clusters";
 
   std::vector<std::future<std::vector<TrackITS>>> futures(mNumOfThreads);
   std::vector<std::vector<TrackITS>> seedArray(mNumOfThreads);

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CookedTracker.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CookedTracker.cxx
@@ -137,7 +137,7 @@ void CookedTracker::setExternalIndices(TrackITS& t) const
   for (Int_t i = 0; i < noc; i++) {
     Int_t index = t.getClusterIndex(i);
     const Cluster* c = getCluster(index);
-    Int_t idx = c - mFirstCluster - mROFrame; // Index of this cluster in event
+    Int_t idx = c - mFirstCluster - mFirstInFrame; // Index of this cluster in event
     t.setExternalClusterIndex(i, idx);
   }
 }
@@ -613,7 +613,7 @@ int CookedTracker::loadClusters(const std::vector<Cluster>& clusters, const o2::
   auto first = rof.getROFEntry().getIndex();
   auto number = rof.getNROFEntries();
 
-  mROFrame = first;
+  mFirstInFrame = first;
 
   auto clusters_in_frame = gsl::make_span(&clusters[first], number);
   for (const auto& c : clusters_in_frame) {

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ClusterWriterSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ClusterWriterSpec.h
@@ -28,19 +28,20 @@ namespace ITS
 class ClusterWriter : public Task
 {
  public:
-  ClusterWriter() = default;
+  ClusterWriter(bool useMC) : mUseMC(useMC) {}
   ~ClusterWriter() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
 
  private:
   int mState = 0;
+  bool mUseMC = true;
   std::unique_ptr<TFile> mFile = nullptr;
 };
 
 /// create a processor spec
 /// write ITS clusters a root file
-framework::DataProcessorSpec getClusterWriterSpec();
+framework::DataProcessorSpec getClusterWriterSpec(bool useMC);
 
 } // namespace ITS
 } // namespace o2

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ClustererSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ClustererSpec.h
@@ -30,20 +30,21 @@ namespace ITS
 class ClustererDPL : public Task
 {
  public:
-  ClustererDPL() = default;
+  ClustererDPL(bool useMC) : mUseMC(useMC) {}
   ~ClustererDPL() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
 
  private:
   int mState = 0;
+  bool mUseMC = true;
   std::unique_ptr<std::ifstream> mFile = nullptr;
   std::unique_ptr<o2::itsmft::Clusterer> mClusterer = nullptr;
 };
 
 /// create a processor spec
 /// run ITS cluster finder
-framework::DataProcessorSpec getClustererSpec();
+framework::DataProcessorSpec getClustererSpec(bool useMC);
 
 } // namespace ITS
 } // namespace o2

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/CookedTrackerSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/CookedTrackerSpec.h
@@ -28,20 +28,21 @@ namespace ITS
 class CookedTrackerDPL : public Task
 {
  public:
-  CookedTrackerDPL() = default;
+  CookedTrackerDPL(bool useMC) : mUseMC(useMC) {}
   ~CookedTrackerDPL() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
 
  private:
   int mState = 0;
+  bool mUseMC = true;
   std::unique_ptr<o2::parameters::GRPObject> mGRP = nullptr;
   o2::ITS::CookedTracker mTracker;
 };
 
 /// create a processor spec
 /// run ITS CookedMatrix tracker
-framework::DataProcessorSpec getCookedTrackerSpec();
+framework::DataProcessorSpec getCookedTrackerSpec(bool useMC);
 
 } // namespace ITS
 } // namespace o2

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DigitReaderSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DigitReaderSpec.h
@@ -28,19 +28,20 @@ namespace ITS
 class DigitReader : public Task
 {
  public:
-  DigitReader() = default;
+  DigitReader(bool useMC) : mUseMC(useMC) {}
   ~DigitReader() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
 
  private:
   int mState = 0;
+  bool mUseMC = true;
   std::unique_ptr<TFile> mFile = nullptr;
 };
 
 /// create a processor spec
 /// read simulated ITS digits from a root file
-framework::DataProcessorSpec getDigitReaderSpec();
+framework::DataProcessorSpec getDigitReaderSpec(bool useMC);
 
 } // namespace ITS
 } // namespace o2

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/RecoWorkflow.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/RecoWorkflow.h
@@ -22,7 +22,7 @@ namespace ITS
 
 namespace RecoWorkflow
 {
-framework::WorkflowSpec getWorkflow();
+framework::WorkflowSpec getWorkflow(bool useMC);
 }
 
 } // namespace ITS

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/TrackWriterSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/TrackWriterSpec.h
@@ -28,19 +28,20 @@ namespace ITS
 class TrackWriter : public Task
 {
  public:
-  TrackWriter() = default;
+  TrackWriter(bool useMC) : mUseMC(useMC) {}
   ~TrackWriter() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
 
  private:
   int mState = 0;
+  bool mUseMC = true;
   std::unique_ptr<TFile> mFile = nullptr;
 };
 
 /// create a processor spec
 /// write ITS tracks a root file
-framework::DataProcessorSpec getTrackWriterSpec();
+framework::DataProcessorSpec getTrackWriterSpec(bool useMC);
 
 } // namespace ITS
 } // namespace o2

--- a/Detectors/ITSMFT/ITS/workflow/src/ClusterWriterSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ClusterWriterSpec.cxx
@@ -48,20 +48,22 @@ void ClusterWriter::run(ProcessingContext& pc)
 
   auto compClusters = pc.inputs().get<const std::vector<o2::itsmft::CompClusterExt>>("compClusters");
   auto clusters = pc.inputs().get<const std::vector<o2::itsmft::Cluster>>("clusters");
-  auto labels = pc.inputs().get<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>*>("labels");
-  auto plabels = labels.get();
   auto rofs = pc.inputs().get<const std::vector<o2::itsmft::ROFRecord>>("ROframes");
-  auto mc2rofs = pc.inputs().get<const std::vector<o2::itsmft::MC2ROFRecord>>("MC2ROframes");
 
-  LOG(INFO) << "ITSClusterWriter pulled " << clusters.size() << " clusters, "
-            << labels->getIndexedSize() << " MC label objects, in "
-            << rofs.size() << " RO frames and "
-            << mc2rofs.size() << " MC events";
+  std::unique_ptr<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>> labels;
+  const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* plabels = nullptr;
+
+  LOG(INFO) << "ITSClusterWriter pulled " << clusters.size() << " clusters, in "
+            << rofs.size() << " RO frames";
 
   TTree tree("o2sim", "Tree with ITS clusters");
   tree.Branch("ITSClusterComp", &compClusters);
   tree.Branch("ITSCluster", &clusters);
-  tree.Branch("ITSClusterMCTruth", &plabels);
+  if (mUseMC) {
+    labels = pc.inputs().get<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>*>("labels");
+    plabels = labels.get();
+    tree.Branch("ITSClusterMCTruth", &plabels);
+  }
   tree.Fill();
   tree.Write();
 
@@ -72,12 +74,15 @@ void ClusterWriter::run(ProcessingContext& pc)
   treeROF.Fill();
   treeROF.Write();
 
-  // write MC2ROFrecord vector (directly inherited from digits input) to a tree
-  TTree treeMC2ROF("ITSClustersMC2ROF", "MC -> ROF records tree");
-  auto* mc2rofsPtr = &mc2rofs;
-  treeMC2ROF.Branch("ITSClustersMC2ROF", &mc2rofsPtr);
-  treeMC2ROF.Fill();
-  treeMC2ROF.Write();
+  if (mUseMC) {
+    // write MC2ROFrecord vector (directly inherited from digits input) to a tree
+    TTree treeMC2ROF("ITSClustersMC2ROF", "MC -> ROF records tree");
+    auto mc2rofs = pc.inputs().get<const std::vector<o2::itsmft::MC2ROFRecord>>("MC2ROframes");
+    auto* mc2rofsPtr = &mc2rofs;
+    treeMC2ROF.Branch("ITSClustersMC2ROF", &mc2rofsPtr);
+    treeMC2ROF.Fill();
+    treeMC2ROF.Write();
+  }
 
   mFile->Close();
 
@@ -85,18 +90,22 @@ void ClusterWriter::run(ProcessingContext& pc)
   //pc.services().get<ControlService>().readyToQuit(true);
 }
 
-DataProcessorSpec getClusterWriterSpec()
+DataProcessorSpec getClusterWriterSpec(bool useMC)
 {
+  std::vector<InputSpec> inputs;
+  inputs.emplace_back("compClusters", "ITS", "COMPCLUSTERS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("clusters", "ITS", "CLUSTERS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("ROframes", "ITS", "ITSClusterROF", 0, Lifetime::Timeframe);
+  if (useMC) {
+    inputs.emplace_back("labels", "ITS", "CLUSTERSMCTR", 0, Lifetime::Timeframe);
+    inputs.emplace_back("MC2ROframes", "ITS", "ITSClusterMC2ROF", 0, Lifetime::Timeframe);
+  }
+
   return DataProcessorSpec{
     "its-cluster-writer",
-    Inputs{
-      InputSpec{ "compClusters", "ITS", "COMPCLUSTERS", 0, Lifetime::Timeframe },
-      InputSpec{ "clusters", "ITS", "CLUSTERS", 0, Lifetime::Timeframe },
-      InputSpec{ "labels", "ITS", "CLUSTERSMCTR", 0, Lifetime::Timeframe },
-      InputSpec{ "ROframes", "ITS", "ITSClusterROF", 0, Lifetime::Timeframe },
-      InputSpec{ "MC2ROframes", "ITS", "ITSClusterMC2ROF", 0, Lifetime::Timeframe } },
+    inputs,
     Outputs{},
-    AlgorithmSpec{ adaptFromTask<ClusterWriter>() },
+    AlgorithmSpec{ adaptFromTask<ClusterWriter>(useMC) },
     Options{
       { "its-cluster-outfile", VariantType::String, "o2clus_its.root", { "Name of the output file" } } }
   };

--- a/Detectors/ITSMFT/ITS/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/RecoWorkflow.cxx
@@ -27,16 +27,16 @@ namespace ITS
 namespace RecoWorkflow
 {
 
-framework::WorkflowSpec getWorkflow()
+framework::WorkflowSpec getWorkflow(bool useMC)
 {
   framework::WorkflowSpec specs;
 
-  specs.emplace_back(o2::ITS::getDigitReaderSpec());
-  specs.emplace_back(o2::ITS::getClustererSpec());
-  specs.emplace_back(o2::ITS::getClusterWriterSpec());
+  specs.emplace_back(o2::ITS::getDigitReaderSpec(useMC));
+  specs.emplace_back(o2::ITS::getClustererSpec(useMC));
+  specs.emplace_back(o2::ITS::getClusterWriterSpec(useMC));
   //specs.emplace_back(o2::ITS::getTrackerSpec());
-  specs.emplace_back(o2::ITS::getCookedTrackerSpec());
-  specs.emplace_back(o2::ITS::getTrackWriterSpec());
+  specs.emplace_back(o2::ITS::getCookedTrackerSpec(useMC));
+  specs.emplace_back(o2::ITS::getTrackWriterSpec(useMC));
 
   return specs;
 }

--- a/Detectors/ITSMFT/ITS/workflow/src/its-reco-workflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/its-reco-workflow.cxx
@@ -19,7 +19,11 @@ using namespace o2::framework;
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   // option allowing to set parameters
+  workflowOptions.push_back(ConfigParamSpec{
+    "disable-mc", o2::framework::VariantType::Bool, false, { "disable MC propagation even if available" } });
+
   std::string keyvaluehelp("Semicolon separated key=value strings (e.g.: 'ITSDigitizerParam.roFrameLength=6000.;...')");
+
   workflowOptions.push_back(ConfigParamSpec{ "configKeyValues", VariantType::String, "", { keyvaluehelp } });
 }
 
@@ -34,5 +38,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   // write the configuration used for the digitizer workflow
   o2::conf::ConfigurableParam::writeINI("o2itsrecoflow_configuration.ini");
 
-  return std::move(o2::ITS::RecoWorkflow::getWorkflow());
+  auto useMC = !configcontext.options().get<bool>("disable-mc");
+
+  return std::move(o2::ITS::RecoWorkflow::getWorkflow(useMC));
 }

--- a/macro/run_trac_its.C
+++ b/macro/run_trac_its.C
@@ -78,6 +78,7 @@ void run_trac_its(std::string path = "./", std::string outputfile = "o2trac_its.
   }
   std::vector<o2::itsmft::Cluster>* clusters = nullptr;
   itsClusters.SetBranchAddress("ITSCluster", &clusters);
+  std::vector<o2::itsmft::Cluster> allClusters;
 
   MCLabCont* labels = nullptr;
   if (!itsClusters.GetBranch("ITSClusterMCTruth")) {
@@ -85,6 +86,7 @@ void run_trac_its(std::string path = "./", std::string outputfile = "o2trac_its.
   } else {
     itsClusters.SetBranchAddress("ITSClusterMCTruth", &labels);
   }
+  MCLabCont allLabels;
 
   TChain itsClustersROF("ITSClustersROF");
   itsClustersROF.AddFile((path + inputClustersITS).data());
@@ -105,6 +107,9 @@ void run_trac_its(std::string path = "./", std::string outputfile = "o2trac_its.
   MCLabCont* trackLabels = new MCLabCont();
   outTree.Branch("ITSTrack", &tracksITS);
   outTree.Branch("ITSTrackMCTruth", &trackLabels);
+
+  TTree treeROF("ITSTracksROF", "ROF records tree");
+  treeROF.Branch("ITSTracksROF", &rofs);
   //<<<--------- create/attach output -------------<<<
 
   //=================== INIT ==================
@@ -115,24 +120,43 @@ void run_trac_its(std::string path = "./", std::string outputfile = "o2trac_its.
   tracker.setBz(field->solenoidField()); // in kG
   tracker.setGeometry(gman);
   if (mcTruth)
-    tracker.setMCTruthContainers(labels, trackLabels);
+    tracker.setMCTruthContainers(&allLabels, trackLabels);
   //===========================================
 
-  //-------------------- settings -----------//
-  for (int iEvent = 0; iEvent < itsClusters.GetEntries(); ++iEvent) {
+  // Load all clusters into a single vector
+  int prevEntry = -1;
+  int offset = 0;
+  for (auto& rof : *rofs) {
+    int entry = rof.getROFEntry().getEvent();
+    if (entry > prevEntry) { // In principal, there should be just one entry...
+      if (itsClusters.GetEntry(entry) <= 0) {
+        LOG(ERROR) << "ITSDigitReader: empty digit entry, or read error !";
+        return;
+      }
+      prevEntry = entry;
+      offset = allClusters.size();
 
-    std::vector<std::array<Double_t, 3>> vertices;
-    vertices.emplace_back(std::array<Double_t, 3>{ 0., 0., 0. });
+      std::copy(clusters->begin(), clusters->end(), std::back_inserter(allClusters));
+      allLabels.mergeAtBack(*labels);
+    }
 
-    itsClusters.GetEntry(iEvent);
-    tracker.setVertices(vertices);
-    tracker.process(*clusters, *tracksITS, *rofs);
-    outTree.Fill();
-    tracksITS->clear();
-    trackLabels->clear();
+    rof.getROFEntry().setEvent(0);
+    int index = rof.getROFEntry().getIndex();
+    rof.getROFEntry().setIndex(index + offset);
+
+    std::cout << "entry nclusters offset " << entry << ' ' << clusters->size() << ' ' << offset << '\n';
   }
+
+  std::vector<std::array<Double_t, 3>> vertices;
+  vertices.emplace_back(std::array<Double_t, 3>{ 0., 0., 0. });
+  tracker.setVertices(vertices);
+  tracker.process(allClusters, *tracksITS, *rofs);
+  outTree.Fill();
+  treeROF.Fill();
+
   outFile.cd();
   outTree.Write();
+  treeROF.Write();
   outFile.Close();
 
   timer.Stop();


### PR DESCRIPTION
With this PR we will be able to
1) run the ITS reconstruction workflow in "triggered" RO mode,
2) run both ITS tests (the macro-driven and the DPL based) in continuous and "triggered" RO modes,
3) process digits and clusters stored in both single or multiple tree entries,
4) suppress the propagation of MC labels through the RAM by means of the "--disable-mc" command-line argument passed to the reconstruction workflow.  