### PR TITLE
Adapt LUT class for GPU

### DIFF
--- a/Common/MathUtils/include/MathUtils/Utils.h
+++ b/Common/MathUtils/include/MathUtils/Utils.h
@@ -20,6 +20,7 @@
 #include <cmath>
 #endif
 #include "GPUCommonDef.h"
+#include "GPUCommonMath.h"
 #include "CommonConstants/MathConstants.h"
 
 namespace o2
@@ -69,8 +70,8 @@ inline void BringToPMPiGen(float& phi)
 inline void sincosf(float ang, float& s, float& c)
 {
   // consider speedup for simultaneus calculation
-  s = sinf(ang);
-  c = cosf(ang);
+  s = o2::gpu::CAMath::Sin(ang);
+  c = o2::gpu::CAMath::Cos(ang);
 }
 
 #ifndef __OPENCL__

--- a/Common/MathUtils/include/MathUtils/Utils.h
+++ b/Common/MathUtils/include/MathUtils/Utils.h
@@ -15,8 +15,11 @@
 #ifndef ALICEO2_COMMON_MATH_UTILS_
 #define ALICEO2_COMMON_MATH_UTILS_
 
+#ifndef __OPENCL__
 #include <array>
 #include <cmath>
+#endif
+#include "GPUCommonDef.h"
 #include "CommonConstants/MathConstants.h"
 
 namespace o2
@@ -25,7 +28,7 @@ namespace o2
 //{
 namespace utils
 {
-inline void BringTo02Pi(float& phi)
+GPUdi() void BringTo02Pi(float& phi)
 {
   // ensure angle in [0:2pi] for the input in [-pi:pi] or [0:pi]
   if (phi < 0.f) {
@@ -70,6 +73,7 @@ inline void sincosf(float ang, float& s, float& c)
   c = cosf(ang);
 }
 
+#ifndef __OPENCL__
 inline void RotateZ(std::array<float, 3>& xy, float alpha)
 {
   // transforms vector in tracking frame alpha to global frame
@@ -78,6 +82,7 @@ inline void RotateZ(std::array<float, 3>& xy, float alpha)
   xy[0] = x * cs - xy[1] * sn;
   xy[1] = x * sn + xy[1] * cs;
 }
+#endif
 
 inline int Angle2Sector(float phi)
 {

--- a/Detectors/Base/include/DetectorsBase/MatCell.h
+++ b/Detectors/Base/include/DetectorsBase/MatCell.h
@@ -29,10 +29,10 @@ struct MatCell {
   float meanRho;                    ///< mean density, g/cm^3
   float meanX2X0;                   ///< fraction of radiaton lenght
 
-  MatCell() : meanRho(0.f), meanX2X0(0.f) {}
-  MatCell(const MatCell& src) CON_DEFAULT;
+  GPUd() MatCell() : meanRho(0.f), meanX2X0(0.f) {}
+  GPUdDefault() MatCell(const MatCell& src) CON_DEFAULT;
 
-  void scale(float scale)
+  GPUd() void scale(float scale)
   {
     meanRho *= scale;
     meanX2X0 *= scale;
@@ -47,10 +47,10 @@ struct MatBudget : MatCell {
   static constexpr int NParams = 3; // number of material parameters described
   float length;                     ///< length in material
 
-  MatBudget() : length(0.f) {}
-  MatBudget(const MatBudget& src) CON_DEFAULT;
+  GPUd() MatBudget() : length(0.f) {}
+  GPUdDefault() MatBudget(const MatBudget& src) CON_DEFAULT;
 
-  void scale(float scale)
+  GPUd() void scale(float scale)
   {
     MatCell::scale(scale);
     length *= scale;

--- a/Detectors/Base/include/DetectorsBase/MatLayerCyl.h
+++ b/Detectors/Base/include/DetectorsBase/MatLayerCyl.h
@@ -21,6 +21,7 @@
 #include "GPUCommonDef.h"
 #include "FlatObject.h"
 #include "GPUCommonRtypes.h"
+#include "GPUCommonMath.h"
 #include "DetectorsBase/MatCell.h"
 
 namespace o2
@@ -68,9 +69,9 @@ class MatLayerCyl : public o2::gpu::FlatObject
 
   GPUd() float getRMin() const
   {
-    return std::sqrt(getRMin2());
+    return o2::gpu::CAMath::Sqrt(getRMin2());
   }
-  GPUd() float getRMax() const { return std::sqrt(getRMax2()); }
+  GPUd() float getRMax() const { return o2::gpu::CAMath::Sqrt(getRMax2()); }
   GPUd() float getZMin() const { return -mZHalf; }
   GPUd() float getZMax() const { return mZHalf; }
 

--- a/Detectors/Base/include/DetectorsBase/MatLayerCylSet.h
+++ b/Detectors/Base/include/DetectorsBase/MatLayerCylSet.h
@@ -14,13 +14,14 @@
 #ifndef ALICEO2_MATLAYERCYLSET_H
 #define ALICEO2_MATLAYERCYLSET_H
 
+#include "GPUCommonDef.h"
 #include "DetectorsBase/MatLayerCyl.h"
 #include "DetectorsBase/Ray.h"
 #include "FlatObject.h"
 
-#ifndef GPUCA_GPUCODE // this part is unvisible on GPU version
+#ifndef GPUCA_ALIGPUCODE // this part is unvisible on GPU version
 #include "MathUtils/Cartesian3D.h"
-#endif // !GPUCA_GPUCODE
+#endif // !GPUCA_ALIGPUCODE
 
 /**********************************************************************
  *                                                                    *
@@ -53,20 +54,20 @@ class MatLayerCylSet : public o2::gpu::FlatObject
   ~MatLayerCylSet() CON_DEFAULT;
   MatLayerCylSet(const MatLayerCylSet& src) CON_DELETE;
 
-  const MatLayerCylSetLayout* get() const { return reinterpret_cast<const MatLayerCylSetLayout*>(mFlatBufferPtr); }
-  MatLayerCylSetLayout* get() { return reinterpret_cast<MatLayerCylSetLayout*>(mFlatBufferPtr); }
+  GPUd() const MatLayerCylSetLayout* get() const { return reinterpret_cast<const MatLayerCylSetLayout*>(mFlatBufferPtr); }
+  GPUd() MatLayerCylSetLayout* get() { return reinterpret_cast<MatLayerCylSetLayout*>(mFlatBufferPtr); }
 
-  int getNLayers() const { return get() ? get()->mNLayers : 0; }
-  const MatLayerCyl& getLayer(int i) const { return get()->mLayers[i]; }
+  GPUd() int getNLayers() const { return get() ? get()->mNLayers : 0; }
+  GPUd() const MatLayerCyl& getLayer(int i) const { return get()->mLayers[i]; }
 
-  bool getLayersRange(const Ray& ray, short& lmin, short& lmax) const;
-  float getRMin() const { return get()->mRMin; }
-  float getRMax() const { return get()->mRMax; }
-  float getZMax() const { return get()->mZMax; }
-  float getRMin2() const { return get()->mRMin2; }
-  float getRMax2() const { return get()->mRMax2; }
+  GPUd() bool getLayersRange(const Ray& ray, short& lmin, short& lmax) const;
+  GPUd() float getRMin() const { return get()->mRMin; }
+  GPUd() float getRMax() const { return get()->mRMax; }
+  GPUd() float getZMax() const { return get()->mZMax; }
+  GPUd() float getRMin2() const { return get()->mRMin2; }
+  GPUd() float getRMax2() const { return get()->mRMax2; }
 
-#ifndef GPUCA_GPUCODE // this part is unvisible on GPU version
+#ifndef GPUCA_ALIGPUCODE // this part is unvisible on GPU version
 
   void print(bool data = false) const;
   void addLayer(float rmin, float rmax, float zmax, float dz, float drphi);
@@ -78,22 +79,22 @@ class MatLayerCylSet : public o2::gpu::FlatObject
   static MatLayerCylSet* loadFromFile(std::string inpFName = "matbud.root", std::string name = "MatBud");
   void flatten();
 
-#endif // !GPUCA_GPUCODE
+#endif // !GPUCA_ALIGPUCODE
 
-  std::size_t estimateFlatBufferSize() const;
-
-#ifndef GPUCA_GPUCODE // this part is unvisible on GPU version
+#ifndef GPUCA_ALIGPUCODE // this part is unvisible on GPU version
   MatBudget getMatBudget(const Point3D<float>& point0, const Point3D<float>& point1) const
   {
     // get material budget traversed on the line between point0 and point1
     return getMatBudget(point0.X(), point0.Y(), point0.Z(), point1.X(), point1.Y(), point1.Z());
   }
-#endif // !GPUCA_GPUCODE
-  MatBudget getMatBudget(float x0, float y0, float z0, float x1, float y1, float z1) const;
+#endif // !GPUCA_ALIGPUCODE
+  GPUd() MatBudget getMatBudget(float x0, float y0, float z0, float x1, float y1, float z1) const;
 
-  int searchSegment(float val, int low = -1, int high = -1) const;
+  GPUd() int searchSegment(float val, int low = -1, int high = -1) const;
 
+#ifndef GPUCA_GPUCODE
   //-----------------------------------------------------------
+  std::size_t estimateFlatBufferSize() const;
   void moveBufferTo(char* newFlatBufferPtr);
 
   void setActualBufferAddress(char* actualFlatBufferPtr);
@@ -109,6 +110,7 @@ class MatLayerCylSet : public o2::gpu::FlatObject
   static constexpr size_t getClassAlignmentBytes() { return 8; }
   /// Gives minimal alignment in bytes required for the flat buffer
   static constexpr size_t getBufferAlignmentBytes() { return 8; }
+#endif // !GPUCA_GPUCODE
 
   ClassDefNV(MatLayerCylSet, 1);
 };

--- a/Detectors/Base/include/DetectorsBase/Ray.h
+++ b/Detectors/Base/include/DetectorsBase/Ray.h
@@ -39,13 +39,12 @@ class Ray
 {
 
  public:
-  using CrossPar = std::pair<float, float>;
   using vecF3 = float[3];
 
   static constexpr float InvalidT = -1e9;
   static constexpr float Tiny = 1e-9;
 
-  GPUd() Ray() : mP{ 0.f }, mD{ 0.f }, mDistXY2(0.f), mDistXY2i(0.f), mDistXYZ(0.f), mXDxPlusYDy(0.f), mXDxPlusYDyRed(0.f), mXDxPlusYDy2(0.f), mR02(0.f), mR12(0.f), mCrossParams()
+  GPUd() Ray() : mP{ 0.f }, mD{ 0.f }, mDistXY2(0.f), mDistXY2i(0.f), mDistXYZ(0.f), mXDxPlusYDy(0.f), mXDxPlusYDyRed(0.f), mXDxPlusYDy2(0.f), mR02(0.f), mR12(0.f)
   {
   }
   GPUd() ~Ray() CON_DEFAULT;
@@ -56,13 +55,17 @@ class Ray
   GPUd() Ray(float x0, float y0, float z0, float x1, float y1, float z1);
 
   GPUd() int crossLayer(const MatLayerCyl& lr);
-  GPUd() bool crossCircleR(float r2, CrossPar& cross) const;
+  GPUd() bool crossCircleR(float r2, float& cross1, float& cross2) const;
 
   GPUd() float crossRadial(const MatLayerCyl& lr, int sliceID) const;
   GPUd() float crossRadial(float cs, float sn) const;
   GPUd() float crossZ(float z) const;
 
-  GPUd() const CrossPar& getCrossParams(int i) const { return mCrossParams[i]; }
+  GPUd() void getCrossParams(int i, float& par1, float& par2) const
+  {
+    par1 = mCrossParams1[i];
+    par2 = mCrossParams2[i];
+  }
 
   GPUd() void getMinMaxR2(float& rmin2, float& rmax2) const;
 
@@ -81,7 +84,7 @@ class Ray
 
   GPUd() float getZ(float t) const { return mP[2] + t * mD[2]; }
 
-  GPUd() bool validateZRange(CrossPar& cpar, const MatLayerCyl& lr) const;
+  GPUd() bool validateZRange(float& cpar1, float& cpar2, const MatLayerCyl& lr) const;
 
  private:
   vecF3 mP;                             ///< entrance point
@@ -94,7 +97,8 @@ class Ray
   float mXDxPlusYDy2;                   ///< aux (x0*DX+y0*DY)^2
   float mR02;                           ///< radius^2 of mP
   float mR12;                           ///< radius^2 of mP1
-  std::array<CrossPar, 2> mCrossParams; ///< parameters of crossing the layer
+  float mCrossParams1[2];               ///< parameters of crossing the layer (first parameter)
+  float mCrossParams2[2];               ///< parameters of crossing the layer (second parameter)
 
   ClassDefNV(Ray, 1);
 };
@@ -142,7 +146,7 @@ GPUdi() float Ray::crossRadial(float cs, float sn) const
 }
 
 //______________________________________________________
-GPUdi() bool Ray::crossCircleR(float r2, CrossPar& cross) const
+GPUdi() bool Ray::crossCircleR(float r2, float& cross1, float& cross2) const
 {
   // calculate parameters t of intersection with circle of radius r^2
   // calculated as solution of equation
@@ -152,8 +156,8 @@ GPUdi() bool Ray::crossCircleR(float r2, CrossPar& cross) const
   if (det < 0)
     return false; // no intersection
   float detRed = std::sqrt(det) * mDistXY2i;
-  cross.first = mXDxPlusYDyRed + detRed;  // (-mXDxPlusYDy + det)*mDistXY2i;
-  cross.second = mXDxPlusYDyRed - detRed; // (-mXDxPlusYDy - det)*mDistXY2i;
+  cross1 = mXDxPlusYDyRed + detRed; // (-mXDxPlusYDy + det)*mDistXY2i;
+  cross2 = mXDxPlusYDyRed - detRed; // (-mXDxPlusYDy - det)*mDistXY2i;
   return true;
 }
 
@@ -172,20 +176,20 @@ GPUdi() float Ray::crossZ(float z) const
 }
 
 //______________________________________________________
-GPUdi() bool Ray::validateZRange(CrossPar& cpar, const MatLayerCyl& lr) const
+GPUdi() bool Ray::validateZRange(float& cpar1, float& cpar2, const MatLayerCyl& lr) const
 {
   // make sure that estimated crossing parameters are compatible
   // with Z coverage of the layer
-  MatLayerCyl::RangeStatus zout0 = lr.isZOutside(getZ(cpar.first)), zout1 = lr.isZOutside(getZ(cpar.second));
+  MatLayerCyl::RangeStatus zout0 = lr.isZOutside(getZ(cpar1)), zout1 = lr.isZOutside(getZ(cpar2));
   if (zout0 == zout1) { // either both points outside w/o crossing or boht inside
     return zout0 == MatLayerCyl::Within ? true : false;
   }
   // at least 1 point is outside, but there is a crossing
   if (zout0 != MatLayerCyl::Within) {
-    cpar.first = crossZ(zout0 == MatLayerCyl::Below ? lr.getZMin() : lr.getZMax());
+    cpar1 = crossZ(zout0 == MatLayerCyl::Below ? lr.getZMin() : lr.getZMax());
   }
   if (zout1 != MatLayerCyl::Within) {
-    cpar.second = crossZ(zout1 == MatLayerCyl::Below ? lr.getZMin() : lr.getZMax());
+    cpar2 = crossZ(zout1 == MatLayerCyl::Below ? lr.getZMin() : lr.getZMax());
   }
   return true;
 }

--- a/Detectors/Base/include/DetectorsBase/Ray.h
+++ b/Detectors/Base/include/DetectorsBase/Ray.h
@@ -16,6 +16,7 @@
 
 #include "GPUCommonRtypes.h"
 #include "GPUCommonDef.h"
+#include "GPUCommonMath.h"
 #include "DetectorsBase/MatLayerCyl.h"
 #include "MathUtils/Utils.h"
 
@@ -77,7 +78,7 @@ class Ray
 
   GPUd() float getPhi(float t) const
   {
-    float p = std::atan2(mP[1] + t * mD[1], mP[0] + t * mD[0]);
+    float p = o2::gpu::CAMath::ATan2(mP[1] + t * mD[1], mP[0] + t * mD[0]);
     o2::utils::BringTo02Pi(p);
     return p;
   }
@@ -111,7 +112,7 @@ inline Ray::Ray(const Point3D<float> point0, const Point3D<float> point1)
 {
   mDistXY2 = mD[0] * mD[0] + mD[1] * mD[1];
   mDistXY2i = mDistXY2 > 0 ? 1.f / mDistXY2 : 0.f;
-  mDistXYZ = std::sqrt(mDistXY2 + mD[2] * mD[2]);
+  mDistXYZ = o2::gpu::CAMath::Sqrt(mDistXY2 + mD[2] * mD[2]);
   mXDxPlusYDy = point0.X() * mD[0] + point0.Y() * mD[1];
   mXDxPlusYDyRed = -mXDxPlusYDy * mDistXY2i;
   mXDxPlusYDy2 = mXDxPlusYDy * mXDxPlusYDy;
@@ -126,7 +127,7 @@ GPUdi() Ray::Ray(float x0, float y0, float z0, float x1, float y1, float z1)
 {
   mDistXY2 = mD[0] * mD[0] + mD[1] * mD[1];
   mDistXY2i = mDistXY2 > 0 ? 1.f / mDistXY2 : 0.f;
-  mDistXYZ = std::sqrt(mDistXY2 + mD[2] * mD[2]);
+  mDistXYZ = o2::gpu::CAMath::Sqrt(mDistXY2 + mD[2] * mD[2]);
   mXDxPlusYDy = x0 * mD[0] + y0 * mD[1];
   mXDxPlusYDyRed = -mXDxPlusYDy * mDistXY2i;
   mXDxPlusYDy2 = mXDxPlusYDy * mXDxPlusYDy;
@@ -139,7 +140,7 @@ GPUdi() float Ray::crossRadial(float cs, float sn) const
 {
   // calculate t of crossing with radial line with inclination cosine and sine
   float den = mD[0] * sn - mD[1] * cs;
-  if (std::abs(den) < Tiny) {
+  if (o2::gpu::CAMath::Abs(den) < Tiny) {
     return InvalidT;
   }
   return (mP[1] * cs - mP[0] * sn) / den;
@@ -155,7 +156,7 @@ GPUdi() bool Ray::crossCircleR(float r2, float& cross1, float& cross2) const
   float det = mXDxPlusYDy2 - mDistXY2 * (mR02 - r2);
   if (det < 0)
     return false; // no intersection
-  float detRed = std::sqrt(det) * mDistXY2i;
+  float detRed = o2::gpu::CAMath::Sqrt(det) * mDistXY2i;
   cross1 = mXDxPlusYDyRed + detRed; // (-mXDxPlusYDy + det)*mDistXY2i;
   cross2 = mXDxPlusYDyRed - detRed; // (-mXDxPlusYDy - det)*mDistXY2i;
   return true;
@@ -172,7 +173,7 @@ GPUdi() float Ray::crossRadial(const MatLayerCyl& lr, int sliceID) const
 GPUdi() float Ray::crossZ(float z) const
 {
   // calculate t of crossing XY plane at Z
-  return std::abs(mD[2]) > Tiny ? (z - mP[2]) / mD[2] : InvalidT;
+  return o2::gpu::CAMath::Abs(mD[2]) > Tiny ? (z - mP[2]) / mD[2] : InvalidT;
 }
 
 //______________________________________________________

--- a/Detectors/Base/src/MatLayerCyl.cxx
+++ b/Detectors/Base/src/MatLayerCyl.cxx
@@ -14,19 +14,20 @@
 #include "DetectorsBase/MatLayerCyl.h"
 #include "MathUtils/Utils.h"
 #include "CommonConstants/MathConstants.h"
+#ifndef GPUCA_ALIGPUCODE // this part is unvisible on GPU version
 #include "DetectorsBase/GeometryManager.h"
-
-#include <FairLogger.h>
+#include "GPUCommonFairLogger.h"
+#endif
 
 using namespace o2::base;
 using flatObject = o2::gpu::FlatObject;
 
 //________________________________________________________________________________
-MatLayerCyl::MatLayerCyl() : mZHalf(0.f), mNZBins(0), mNPhiBins(0), mNPhiSlices(0), mRMin2(0.f), mRMax2(0.f), mDZ(0.f), mDZInv(0.f), mDPhi(0.f), mDPhiInv(0.f), mPhiBin2Slice(nullptr), mSliceCos(nullptr), mSliceSin(nullptr), mCells(nullptr)
+MatLayerCyl::MatLayerCyl() : mNZBins(0), mNPhiBins(0), mNPhiSlices(0), mZHalf(0.f), mRMin2(0.f), mRMax2(0.f), mDZ(0.f), mDZInv(0.f), mDPhi(0.f), mDPhiInv(0.f), mPhiBin2Slice(nullptr), mSliceCos(nullptr), mSliceSin(nullptr), mCells(nullptr)
 {
 }
 
-#ifndef GPUCA_GPUCODE // this part is unvisible on GPU version
+#ifndef GPUCA_ALIGPUCODE // this part is unvisible on GPU version
 //________________________________________________________________________________
 MatLayerCyl::MatLayerCyl(float rMin, float rMax, float zHalfSpan, float dzMin, float drphiMin)
 {
@@ -305,8 +306,9 @@ void MatLayerCyl::flatten(char* newPtr)
   mConstructionMask = Constructed;
 }
 
-#endif // ! GPUCA_GPUCODE
+#endif // ! GPUCA_ALIGPUCODE
 
+#ifndef GPUCA_GPUCODE
 //________________________________________________________________________________
 void MatLayerCyl::fixPointers(char* oldPtr, char* newPtr)
 {
@@ -316,9 +318,10 @@ void MatLayerCyl::fixPointers(char* oldPtr, char* newPtr)
   mSliceSin = flatObject::relocatePointer(oldPtr, newPtr, mSliceSin);
   mCells = flatObject::relocatePointer(oldPtr, newPtr, mCells);
 }
+#endif // ! GPUCA_GPUCODE
 
 //________________________________________________________________________________
-int MatLayerCyl::getNPhiBinsInSlice(int iSlice, int& binMin, int& binMax) const
+GPUd() int MatLayerCyl::getNPhiBinsInSlice(int iSlice, int& binMin, int& binMax) const
 {
   // slow method to get number of phi bins for given phi slice
   int nb = 0;

--- a/Detectors/Base/src/MatLayerCylSet.cxx
+++ b/Detectors/Base/src/MatLayerCylSet.cxx
@@ -13,21 +13,21 @@
 
 #include "DetectorsBase/MatLayerCylSet.h"
 #include "CommonConstants/MathConstants.h"
-#include <FairLogger.h>
 
-#ifndef GPUCA_GPUCODE // this part is unvisible on GPU version
+#ifndef GPUCA_ALIGPUCODE // this part is unvisible on GPU version
 
+#include "GPUCommonFairLogger.h"
 #include <TFile.h>
 #include "CommonUtils/TreeStreamRedirector.h"
 #define _DBG_LOC_ // for local debugging only
 
-#endif // !GPUCA_GPUCODE
+#endif // !GPUCA_ALIGPUCODE
 
 using namespace o2::base;
 
-#ifndef GPUCA_GPUCODE // this part is unvisible on GPU version
-
 using flatObject = o2::gpu::FlatObject;
+
+#ifndef GPUCA_ALIGPUCODE // this part is unvisible on GPU version
 
 //________________________________________________________________________________
 void MatLayerCylSet::addLayer(float rmin, float rmax, float zmax, float dz, float drphi)
@@ -215,8 +215,9 @@ void MatLayerCylSet::print(bool data) const
          float(getFlatBufferSize()) / 1024 / 1024);
 }
 
-#endif //!GPUCA_GPUCODE
+#endif //!GPUCA_ALIGPUCODE
 
+#ifndef GPUCA_GPUCODE
 //________________________________________________________________________________
 std::size_t MatLayerCylSet::estimateFlatBufferSize() const
 {
@@ -231,9 +232,10 @@ std::size_t MatLayerCylSet::estimateFlatBufferSize() const
   }
   return sz;
 }
+#endif // ! GPUCA_GPUCODE
 
 //_________________________________________________________________________________________________
-MatBudget MatLayerCylSet::getMatBudget(float x0, float y0, float z0, float x1, float y1, float z1) const
+GPUd() MatBudget MatLayerCylSet::getMatBudget(float x0, float y0, float z0, float x1, float y1, float z1) const
 {
   // get material budget traversed on the line between point0 and point1
   MatBudget rval;
@@ -347,7 +349,7 @@ MatBudget MatLayerCylSet::getMatBudget(float x0, float y0, float z0, float x1, f
 }
 
 //_________________________________________________________________________________________________
-bool MatLayerCylSet::getLayersRange(const Ray& ray, short& lmin, short& lmax) const
+GPUd() bool MatLayerCylSet::getLayersRange(const Ray& ray, short& lmin, short& lmax) const
 {
   // get range of layers corresponding to rmin/rmax
   //
@@ -374,7 +376,7 @@ bool MatLayerCylSet::getLayersRange(const Ray& ray, short& lmin, short& lmax) co
   return lmin <= lmax; // valid if both are not in the same gap
 }
 
-int MatLayerCylSet::searchSegment(float val, int low, int high) const
+GPUd() int MatLayerCylSet::searchSegment(float val, int low, int high) const
 {
   ///< search segment val belongs to. The val MUST be within the boundaries
   if (low < 0) {
@@ -396,7 +398,7 @@ int MatLayerCylSet::searchSegment(float val, int low, int high) const
   return mid;
 }
 
-#ifndef GPUCA_GPUCODE // this part is unvisible on GPU version
+#ifndef GPUCA_ALIGPUCODE // this part is unvisible on GPU version
 
 void MatLayerCylSet::flatten()
 {
@@ -438,8 +440,9 @@ void MatLayerCylSet::moveBufferTo(char* newFlatBufferPtr)
   flatObject::moveBufferTo(newFlatBufferPtr);
   setActualBufferAddress(mFlatBufferPtr);
 }
-#endif // !GPUCA_GPUCODE
+#endif // !GPUCA_ALIGPUCODE
 
+#ifndef GPUCA_GPUCODE
 //______________________________________________
 void MatLayerCylSet::setFutureBufferAddress(char* futureFlatBufferPtr)
 {
@@ -456,7 +459,6 @@ void MatLayerCylSet::setActualBufferAddress(char* actualFlatBufferPtr)
   ///
   fixPointers(actualFlatBufferPtr);
 }
-#ifndef GPUCA_GPUCODE // code invisible on GPU
 //______________________________________________
 void MatLayerCylSet::cloneFromObject(const MatLayerCylSet& obj, char* newFlatBufferPtr)
 {
@@ -464,7 +466,6 @@ void MatLayerCylSet::cloneFromObject(const MatLayerCylSet& obj, char* newFlatBuf
   flatObject::cloneFromObject(obj, newFlatBufferPtr);
   fixPointers(mFlatBufferPtr);
 }
-#endif
 
 //______________________________________________
 void MatLayerCylSet::fixPointers(char* newBasePtr)
@@ -494,3 +495,4 @@ void MatLayerCylSet::fixPointers(char* oldPtr, char* newPtr)
     get()->mLayers[i].fixPointers(oldPtr, newPtr);
   }
 }
+#endif // !GPUCA_GPUCODE

--- a/Detectors/Base/src/MatLayerCylSet.cxx
+++ b/Detectors/Base/src/MatLayerCylSet.cxx
@@ -249,8 +249,9 @@ GPUd() MatBudget MatLayerCylSet::getMatBudget(float x0, float y0, float z0, floa
     const auto& lr = getLayer(lrID);
     int nc = ray.crossLayer(lr);
     for (int ic = nc; ic--;) {
-      auto& cross = ray.getCrossParams(ic); // tmax,tmin of crossing the layer
-      auto phi0 = ray.getPhi(cross.first), phi1 = ray.getPhi(cross.second), dPhi = phi0 - phi1;
+      float cross1, cross2;
+      ray.getCrossParams(ic, cross1, cross2); // tmax,tmin of crossing the layer
+      auto phi0 = ray.getPhi(cross1), phi1 = ray.getPhi(cross2), dPhi = phi0 - phi1;
       auto phiID = lr.getPhiSliceID(phi0), phiIDLast = lr.getPhiSliceID(phi1);
       // account for eventual wrapping around 0
       if (dPhi > 0.f) {
@@ -264,11 +265,11 @@ GPUd() MatBudget MatLayerCylSet::getMatBudget(float x0, float y0, float z0, floa
       }
       int stepPhiID = phiID > phiIDLast ? -1 : 1;
       bool checkMorePhi = true;
-      auto tStartPhi = cross.first, tEndPhi = 0.f;
+      auto tStartPhi = cross1, tEndPhi = 0.f;
       do {
         // get the path in the current phi slice
         if (phiID == phiIDLast) {
-          tEndPhi = cross.second;
+          tEndPhi = cross2;
           checkMorePhi = false;
         } else { // last phi slice still not reached
           tEndPhi = ray.crossRadial(lr, (stepPhiID > 0 ? phiID + 1 : phiID) % lr.getNPhiSlices());

--- a/Detectors/Base/src/Ray.cxx
+++ b/Detectors/Base/src/Ray.cxx
@@ -12,8 +12,10 @@
 /// \brief Implementation of ray between start-end points for material budget estimate
 
 #include "DetectorsBase/Ray.h"
+#include "GPUCommonMath.h"
 
 using namespace o2::base;
+using namespace o2::gpu;
 
 //______________________________________________________
 GPUd() int Ray::crossLayer(const MatLayerCyl& lr)
@@ -26,7 +28,7 @@ GPUd() int Ray::crossLayer(const MatLayerCyl& lr)
   float detMax = mXDxPlusYDy2 - mDistXY2 * (mR02 - lr.getRMax2());
   if (detMax < 0)
     return 0; // does not reach outer R, hence inner also
-  float detMaxRed = std::sqrt(detMax) * mDistXY2i;
+  float detMaxRed = CAMath::Sqrt(detMax) * mDistXY2i;
   float tCross0Max = mXDxPlusYDyRed + detMaxRed; // largest possible t
 
   if (tCross0Max < 0) { // max t is outside of the limiting point -> other t's also
@@ -44,7 +46,7 @@ GPUd() int Ray::crossLayer(const MatLayerCyl& lr)
     return validateZRange(mCrossParams1[0], mCrossParams2[0], lr);
   }
   int nCross = 0;
-  float detMinRed = std::sqrt(detMin) * mDistXY2i;
+  float detMinRed = CAMath::Sqrt(detMin) * mDistXY2i;
   float tCross1Max = mXDxPlusYDyRed + detMinRed;
   float tCross1Min = mXDxPlusYDyRed - detMinRed;
 

--- a/Detectors/Base/src/Ray.cxx
+++ b/Detectors/Base/src/Ray.cxx
@@ -16,12 +16,7 @@
 using namespace o2::base;
 
 //______________________________________________________
-Ray::Ray() : mP{ 0.f }, mD{ 0.f }, mDistXY2(0.f), mDistXY2i(0.f), mDistXYZ(0.f), mXDxPlusYDy(0.f), mXDxPlusYDyRed(0.f), mXDxPlusYDy2(0.f), mR02(0.f), mR12(0.f), mCrossParams()
-{
-}
-
-//______________________________________________________
-int Ray::crossLayer(const MatLayerCyl& lr)
+GPUd() int Ray::crossLayer(const MatLayerCyl& lr)
 {
   // Calculate parameters t of intersection with cyl.layer
   // Calculated as solution of equation for ray crossing with circles of r (rmin and rmax)

--- a/Detectors/Base/src/Ray.cxx
+++ b/Detectors/Base/src/Ray.cxx
@@ -39,9 +39,9 @@ GPUd() int Ray::crossLayer(const MatLayerCyl& lr)
   }
   float detMin = mXDxPlusYDy2 - mDistXY2 * (mR02 - lr.getRMin2());
   if (detMin < 0) { // does not reach inner R -> just 1 tangential crossing
-    mCrossParams[0].first = tCross0Min > 0.f ? tCross0Min : 0.f;
-    mCrossParams[0].second = tCross0Max < 1.f ? tCross0Max : 1.f;
-    return validateZRange(mCrossParams[0], lr);
+    mCrossParams1[0] = tCross0Min > 0.f ? tCross0Min : 0.f;
+    mCrossParams2[0] = tCross0Max < 1.f ? tCross0Max : 1.f;
+    return validateZRange(mCrossParams1[0], mCrossParams2[0], lr);
   }
   int nCross = 0;
   float detMinRed = std::sqrt(detMin) * mDistXY2i;
@@ -49,17 +49,17 @@ GPUd() int Ray::crossLayer(const MatLayerCyl& lr)
   float tCross1Min = mXDxPlusYDyRed - detMinRed;
 
   if (tCross1Max < 1.f) {
-    mCrossParams[0].first = tCross0Max < 1.f ? tCross0Max : 1.f;
-    mCrossParams[0].second = tCross1Max > 0.f ? tCross1Max : 0.f;
-    if (validateZRange(mCrossParams[nCross], lr)) {
+    mCrossParams1[0] = tCross0Max < 1.f ? tCross0Max : 1.f;
+    mCrossParams2[0] = tCross1Max > 0.f ? tCross1Max : 0.f;
+    if (validateZRange(mCrossParams1[nCross], mCrossParams2[nCross], lr)) {
       nCross++;
     }
   }
 
   if (tCross1Min > -0.f) {
-    mCrossParams[nCross].first = tCross1Min < 1.f ? tCross1Min : 1.f;
-    mCrossParams[nCross].second = tCross0Min > 0.f ? tCross0Min : 0.f;
-    if (validateZRange(mCrossParams[nCross], lr)) {
+    mCrossParams1[nCross] = tCross1Min < 1.f ? tCross1Min : 1.f;
+    mCrossParams1[nCross] = tCross0Min > 0.f ? tCross0Min : 0.f;
+    if (validateZRange(mCrossParams1[nCross], mCrossParams2[nCross], lr)) {
       nCross++;
     }
   }

--- a/Detectors/Base/test/buildMatBudLUT.C
+++ b/Detectors/Base/test/buildMatBudLUT.C
@@ -19,7 +19,7 @@
 #include <TSystem.h>
 #endif
 
-#ifndef GPUCA_GPUCODE // this part is unvisible on GPU version
+#ifndef GPUCA_ALIGPUCODE // this part is unvisible on GPU version
 
 o2::base::MatLayerCylSet mbLUT;
 

--- a/Detectors/Base/test/testMatBudLUT.cxx
+++ b/Detectors/Base/test/testMatBudLUT.cxx
@@ -19,11 +19,11 @@ namespace o2
 {
 BOOST_AUTO_TEST_CASE(MatBudLUT)
 {
-#ifndef GPUCA_GPUCODE // this part is unvisible on GPU version
+#ifndef GPUCA_ALIGPUCODE // this part is unvisible on GPU version
 
   BOOST_CHECK(buildMatBudLUT(2, 20)); // generate LUT
   BOOST_CHECK(testMBLUT());           // test LUT manipulations
 
-#endif //!GPUCA_GPUCODE
+#endif //!GPUCA_ALIGPUCODE
 }
 } // namespace o2

--- a/GPU/GPUTracking/Base/GPUReconstructionIncludesDevice.h
+++ b/GPU/GPUTracking/Base/GPUReconstructionIncludesDevice.h
@@ -47,6 +47,11 @@ using namespace GPUCA_NAMESPACE::gpu;
 #include "GPUTPCGMTrackParam.cxx"
 #include "GPUTPCGMPhysicalTrackModel.cxx"
 #include "GPUTPCGMPropagator.cxx"
+#ifdef HAVE_O2HEADERS
+#include "MatLayerCylSet.cxx"
+#include "MatLayerCyl.cxx"
+#include "Ray.cxx"
+#endif
 #endif
 
 #ifdef GPUCA_BUILD_DEDX

--- a/GPU/GPUTracking/Base/cuda/CMakeLists.txt
+++ b/GPU/GPUTracking/Base/cuda/CMakeLists.txt
@@ -70,6 +70,7 @@ else() #if we do not build for AliRoot, for the time being we still need some du
 endif()
 if(ALIGPU_BUILD_TYPE STREQUAL "O2") #We need to add src dirs of O2 to include cxx files for CUDA compilation
     include_directories(${CMAKE_SOURCE_DIR}/Detectors/TRD/base/src)
+    include_directories(${CMAKE_SOURCE_DIR}/Detectors/Base/src)
 endif()
 
 # Sources in alphabetical order

--- a/GPU/GPUTracking/Base/hip/CMakeLists.txt
+++ b/GPU/GPUTracking/Base/hip/CMakeLists.txt
@@ -65,6 +65,7 @@ else() #if we do not build for AliRoot, for the time being we still need some du
 endif()
 if(ALIGPU_BUILD_TYPE STREQUAL "O2") #We need to add src dirs of O2 to include cxx files for HIP compilation
     include_directories(${CMAKE_SOURCE_DIR}/Detectors/TRD/base/src)
+    include_directories(${CMAKE_SOURCE_DIR}/Detectors/Base/src)
 endif()
 
 # Sources in alphabetical order

--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -39,6 +39,7 @@ using namespace GPUCA_NAMESPACE::gpu;
 
 #ifdef HAVE_O2HEADERS
 #include "TRDBase/TRDGeometryFlat.h"
+#include "DetectorsBase/MatLayerCylSet.h"
 #else
 namespace o2
 {

--- a/GPU/GPUTracking/Merger/GPUTPCGMPropagator.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMPropagator.cxx
@@ -16,6 +16,10 @@
 #include "GPUParam.h"
 #include "GPUTPCGMMergedTrackHit.h"
 
+#ifdef HAVE_O2HEADERS
+#include "DetectorsBase/MatLayerCylSet.h"
+#endif
+
 #ifndef __OPENCL__
 #include <cmath>
 #endif
@@ -490,7 +494,6 @@ GPUd() int GPUTPCGMPropagator::PropagateToXAlpha(float posX, float posAlpha, boo
     mC43 += dLabs * mMaterial.k43;
     mC44 += dLabs * mMaterial.k44;
   }
-
   return 0;
 }
 
@@ -1078,4 +1081,13 @@ GPUd() void GPUTPCGMPropagator::Mirror(bool inFlyDirection)
   } else {
     // std::cout<<"MIRROR: DONT APPLY ENERGY LOSS!!!"<<std::endl;
   }
+}
+
+GPUd() o2::base::MatBudget GPUTPCGMPropagator::getMatBudget(float* p1, float* p2)
+{
+#ifdef HAVE_O2HEADERS
+  return mMatLUT->getMatBudget(p1[0], p1[1], p1[2], p2[0], p2[1], p2[2]);
+#else
+  return o2::base::MatBudget();
+#endif
 }

--- a/GPU/GPUTracking/Merger/GPUTPCGMPropagator.h
+++ b/GPU/GPUTracking/Merger/GPUTPCGMPropagator.h
@@ -20,6 +20,19 @@
 #include "GPUTPCGMPolynomialField.h"
 #include "GPUCommonMath.h"
 
+namespace o2
+{
+namespace base
+{
+struct MatBudget;
+class MatLayerCylSet;
+#ifndef HAVE_O2HEADERS
+struct MatBudget {
+};
+#endif
+} // namespace base
+} // namespace o2
+
 namespace GPUCA_NAMESPACE
 {
 namespace gpu
@@ -50,6 +63,7 @@ class GPUTPCGMPropagator
   };
 
   GPUd() void SetMaterial(float radLen, float rho);
+  GPUd() o2::base::MatBudget getMatBudget(float* p1, float* p2);
 
   GPUd() void SetPolynomialField(const GPUTPCGMPolynomialField* field) { mField = field; }
 
@@ -134,6 +148,7 @@ class GPUTPCGMPropagator
   float mMaxSinPhi = GPUCA_MAX_SIN_PHI;
 
   GPUTPCGMOfflineStatisticalErrors mStatErrors;
+  const o2::base::MatLayerCylSet* mMatLUT = nullptr;
 };
 
 GPUd() inline void GPUTPCGMPropagator::SetMaterial(float radLen, float rho)

--- a/GPU/GPUTracking/Merger/GPUTPCGMTrackParam.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMTrackParam.cxx
@@ -24,12 +24,14 @@
 #include "GPUTPCGMMerger.h"
 #include "GPUTPCTracker.h"
 #include "GPUTPCClusterData.h"
-#ifdef GPUCA_ALIROOT_LIB
-#include "AliExternalTrackParam.h"
-#endif
 #include "GPUdEdx.h"
 #include "GPUParam.h"
 #include "GPUTPCClusterErrorStat.h"
+
+#ifdef GPUCA_ALIROOT_LIB
+#include "AliExternalTrackParam.h"
+#endif
+
 #ifdef GPUCA_CADEBUG_ENABLED
 #include "../utils/qconfig.h"
 #include "GPUChainTracking.h"

--- a/GPU/GPUTracking/Standalone/config_common.mak
+++ b/GPU/GPUTracking/Standalone/config_common.mak
@@ -75,7 +75,9 @@ INCLUDEPATHS					+= O2Headers \
 								${CONFIG_O2DIR}/DataFormats/Detectors/Common/include \
 								${CONFIG_O2DIR}/DataFormats/Detectors/TPC/include \
 								${CONFIG_O2DIR}/DataFormats/simulation/include \
-								${CONFIG_O2DIR}/DataFormats/Detectors/ITSMFT/ITS/include
+								${CONFIG_O2DIR}/DataFormats/Detectors/ITSMFT/ITS/include \
+								${CONFIG_O2DIR}/Detectors/Base/src \
+								${CONFIG_O2DIR}/Detectors/Base/include
 endif
 
 ifeq ($(CONFIG_O2), 1)

--- a/GPU/GPUTracking/Standalone/config_libGPUTracking.mak
+++ b/GPU/GPUTracking/Standalone/config_libGPUTracking.mak
@@ -105,5 +105,8 @@ CXXFILES					+= ${CONFIG_O2DIR}/DataFormats/simulation/src/MCCompLabel.cxx \
 								${CONFIG_O2DIR}/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx \
 								${CONFIG_O2DIR}/Detectors/ITSMFT/ITS/tracking/src/ROframe.cxx \
 								${CONFIG_O2DIR}/Detectors/ITSMFT/ITS/tracking/src/Road.cxx \
-								${CONFIG_O2DIR}/Detectors/TRD/base/src/TRDGeometryBase.cxx
+								${CONFIG_O2DIR}/Detectors/TRD/base/src/TRDGeometryBase.cxx \
+								${CONFIG_O2DIR}/Detectors/Base/src/MatLayerCylSet.cxx \
+								${CONFIG_O2DIR}/Detectors/Base/src/MatLayerCyl.cxx \
+								${CONFIG_O2DIR}/Detectors/Base/src/Ray.cxx
 endif

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -2617,6 +2617,7 @@ o2_define_bucket(
     ${CMAKE_SOURCE_DIR}/GPU/GPUTracking/Standalone/display
     ${CMAKE_SOURCE_DIR}/GPU/GPUTracking/Standalone/qa
     ${CMAKE_SOURCE_DIR}/Framework/Core/include
+    ${CMAKE_SOURCE_DIR}/Detectors/Base/include
     ${CMAKE_SOURCE_DIR}/Detectors/ITSMFT/ITS/tracking/include
     ${CMAKE_SOURCE_DIR}/Detectors/TRD/base/include
 )


### PR DESCRIPTION
@shahor02 : This adapts the LUT class for GPU. There is one issue left with CUDA. Ray.h uses std::array<CrossPar, 2> mCrossParams;, but CUDA right now does not work with std::array and std::pair.
If that is fine with you, I'd just replace this by two C arrays.

The rest is just adding GPU...() macros and minor modifications.

FYI:
GPUd() is the default macro, GPUdi() will add an inline keyword for host code. You must not write "GPUd() inline" but use GPUdi() instead.

For masking there is different levels:
GPUCA_ALIGPUCODE (everything from AliGPU)
GPUCA_GPUCODE (passed to CUDA / OpenCL / HIP compiler, device or host runtime)
GPUCA_GPUCODE_DEVICE (only compiled for device)
I modified some of the masking levels you already inserted, and added some more for incompatible functions.

We might also have to replace some std::sqrt etc. by CAMath::Sqrt, which is just a forward to the std::... routines in the CPU case.