### PR TITLE
Possibility to have fast YOKE (compensator) treatment

### DIFF
--- a/Detectors/Base/include/DetectorsBase/MaterialManager.h
+++ b/Detectors/Base/include/DetectorsBase/MaterialManager.h
@@ -39,7 +39,11 @@ enum class EProc { kPAIR = 0,
                    kDCAY,
                    kLOSS,
                    kMULS,
-                   kCKOV };
+                   kCKOV,
+                   kLABS,
+                   kRAYL
+                 };
+
 /// cuts available
 enum class ECut { kCUTGAM = 0,
                   kCUTELE,

--- a/Detectors/Base/include/DetectorsBase/MaterialManager.h
+++ b/Detectors/Base/include/DetectorsBase/MaterialManager.h
@@ -42,7 +42,7 @@ enum class EProc { kPAIR = 0,
                    kCKOV,
                    kLABS,
                    kRAYL
-                 };
+};
 
 /// cuts available
 enum class ECut { kCUTGAM = 0,

--- a/Detectors/Base/src/MaterialManager.cxx
+++ b/Detectors/Base/src/MaterialManager.cxx
@@ -40,7 +40,9 @@ const std::unordered_map<EProc, const char*> MaterialManager::mProcessIDToName =
   { EProc::kDCAY, "DCAY" },
   { EProc::kLOSS, "LOSS" },
   { EProc::kMULS, "MULS" },
-  { EProc::kCKOV, "CKOV" }
+  { EProc::kCKOV, "CKOV" },
+  { EProc::kRAYL, "RAYL" },
+  { EProc::kLABS, "LABS" }
 };
 
 const std::unordered_map<ECut, const char*> MaterialManager::mCutIDToName = {

--- a/Detectors/Passive/include/DetectorsPassive/Compensator.h
+++ b/Detectors/Passive/include/DetectorsPassive/Compensator.h
@@ -37,6 +37,7 @@ class Compensator : public FairModule
   void createMaterials();
   void createCompensator();
   TGeoVolume* createMagnetYoke();
+  void SetSpecialPhysicsCuts() override;
 
   ClassDefOverride(o2::passive::Compensator, 1)
 };

--- a/Detectors/Passive/include/DetectorsPassive/HallSimParam.h
+++ b/Detectors/Passive/include/DetectorsPassive/HallSimParam.h
@@ -26,8 +26,8 @@ struct HallSimParam : public o2::conf::ConfigurableParamHelper<HallSimParam> {
   float mCUTHAD = 1.e-3;
 
   bool fastYoke = false; // if we treat compensator yoke in fast manner
-  float yokeDelta = 2.; // thickness of
-                        // full physics outer layer of compensator yoke (in cm)
+  float yokeDelta = 2.;  // thickness of
+                         // full physics outer layer of compensator yoke (in cm)
 
   // boilerplate stuff + make principal key "HallSim"
   O2ParamDef(HallSimParam, "HallSim");

--- a/Detectors/Passive/include/DetectorsPassive/HallSimParam.h
+++ b/Detectors/Passive/include/DetectorsPassive/HallSimParam.h
@@ -25,6 +25,10 @@ struct HallSimParam : public o2::conf::ConfigurableParamHelper<HallSimParam> {
   float mCUTNEU = 1.e-1;
   float mCUTHAD = 1.e-3;
 
+  bool fastYoke = false; // if we treat compensator yoke in fast manner
+  float yokeDelta = 2.; // thickness of
+                        // full physics outer layer of compensator yoke (in cm)
+
   // boilerplate stuff + make principal key "HallSim"
   O2ParamDef(HallSimParam, "HallSim");
 };

--- a/macro/analyzeHits.C
+++ b/macro/analyzeHits.C
@@ -11,6 +11,8 @@
 #include "HMPIDBase/Hit.h"
 #include "TPCSimulation/Point.h"
 #include "PHOSBase/Hit.h"
+#include "FDDSimulation/Hit.h"
+
 #endif
 
 TString gPrefix("");
@@ -264,6 +266,20 @@ void analyzeMFT(TTree* reftree)
   refresult.print();
 }
 
+void analyzeFDD(TTree* reftree)
+{
+  auto refresult = analyse<o2::fdd::Hit, HitStats<o2::fdd::Hit>>(reftree, "FDDHit");
+  std::cout << gPrefix << " FDD ";
+  refresult.print();
+}
+
+void analyzeV0(TTree* reftree)
+{
+  auto refresult = analyse<o2::v0::Hit, HitStats<o2::v0::Hit>>(reftree, "V0Hit");
+  std::cout << gPrefix << " V0 ";
+  refresult.print();
+}
+
 void analyzeTPC(TTree* reftree)
 {
   // need to loop over sectors
@@ -293,5 +309,7 @@ void analyzeHits(const char* filename = "o2sim.root", const char* prefix = "")
   analyzeTRD(reftree);
   analyzePHS(reftree);
   analyzeT0(reftree);
+  analyzeV0(reftree);
+  analyzeFDD(reftree);
   analyzeHMP(reftree);
 }


### PR DESCRIPTION
Preparing split of YOKE into fast and slow (skin) component.
Can be used for a systematic study of necessary skin depth.

Add missing physics processes to MaterialManager enums.

Update a macro analysing hits.
