### PR TITLE
Test to ensure we stick to the executable naming convention

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,3 +337,12 @@ configure_file("${CMAKE_SOURCE_DIR}/cmake/tests-wrapper.sh.in"
 file(COPY "${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/tests-wrapper.sh"
     DESTINATION "${CMAKE_BINARY_DIR}"
     FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+
+# Create test for executable naming convention
+configure_file("${CMAKE_SOURCE_DIR}/cmake/ensure-executable-naming-convention.sh.in"
+               "${CMAKE_BINARY_DIR}/ensure-executable-naming-convention.sh"
+               @ONLY
+               NEWLINE_STYLE UNIX)
+
+add_test(NAME "ensure-executable-naming-convention" 
+        COMMAND "ensure-executable-naming-convention.sh")

--- a/Detectors/FIT/workflow/CMakeLists.txt
+++ b/Detectors/FIT/workflow/CMakeLists.txt
@@ -27,7 +27,7 @@ set(BUCKET_NAME ${MODULE_BUCKET_NAME})
 O2_GENERATE_LIBRARY()
 
 O2_GENERATE_EXECUTABLE(
-  EXE_NAME "fit-reco-workflow"
+  EXE_NAME "o2-fit-reco-workflow"
 
   SOURCES
   src/fit-reco-workflow.cxx

--- a/Detectors/GlobalTrackingWorkflow/CMakeLists.txt
+++ b/Detectors/GlobalTrackingWorkflow/CMakeLists.txt
@@ -25,7 +25,7 @@ set(BUCKET_NAME ${MODULE_BUCKET_NAME})
 O2_GENERATE_LIBRARY()
 
 O2_GENERATE_EXECUTABLE(
-  EXE_NAME tpcits-match-workflow
+  EXE_NAME o2-tpcits-match-workflow
   
   SOURCES
   src/tpcits-match-workflow.cxx

--- a/cmake/ensure-executable-naming-convention.sh.in
+++ b/cmake/ensure-executable-naming-convention.sh.in
@@ -1,0 +1,54 @@
+#
+# Ensure (part of) our executable naming convention
+# (see https://github.com/AliceO2Group/CodingGuidelines)
+#
+# what we test here is that all the names of the executables
+# in @CMAKE_INSTALL_PREFIX@/bin/ :
+# - are all lowercases
+# - contain no special character other than "-"
+# - start with o2- (or test)
+# - (unless it's a test) is of the form o2-xxx
+# where xxx is in a list of known sub-systems for the AliceO2 repository
+#
+
+rc=0
+
+error_msg() {
+        echo "ERROR: executable name $1 does not follow naming convention : $2"
+        rc=1
+}
+
+warning_unknown_subsystem() {
+        echo "WARNING: in $1 the subsystem $2 is not in the list of know subsystem"
+}
+
+re_is_test="^test"
+re_start_with_o2_or_test="^o2-"
+re_only_lower_case_or_dash="^([a-z,0-9]|-)+$"
+re_subsystem="(o2)-([a-z,0-9]+)+" # o2-subsystem
+
+known_groups="alicehlt \
+analysis aod d0 simple \
+data datapublisher datasampling \
+ccdb \
+sim \
+eve \
+fake dummy diamond parallel \
+fit its mch mid tpc \
+tpcits \
+flp heartbeat message epn \
+mergers \
+subframebuilder sync timeframe"
+
+for f in $(ls @CMAKE_INSTALL_PREFIX@/bin); do
+        [[ -x $f ]] && continue
+        [[ $f =~ $re_is_test ]] && continue # convention for tests is yet to come
+        [[ ! $f =~ $re_start_with_o2_or_test ]] && error_msg $f "does not start with o2-"
+        [[ ! $f =~ $re_only_lower_case_or_dash ]] && error_msg $f "should only contains lowercase letters, numbers, or dashes"
+        [[ $f =~ $re_subsystem ]] && subsystem=${BASH_REMATCH[2]}
+        [[ ! " $known_groups " =~  .*\ $subsystem\ .* ]] && warning_unknown_subsystem $f $subsystem
+done
+
+exit $rc
+
+

--- a/cmake/ensure-executable-naming-convention.sh.in
+++ b/cmake/ensure-executable-naming-convention.sh.in
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # Ensure (part of) our executable naming convention
 # (see https://github.com/AliceO2Group/CodingGuidelines)
@@ -11,23 +12,23 @@
 # where xxx is in a list of known sub-systems for the AliceO2 repository
 #
 
-rc=0
+RC=0
 
 error_msg() {
-        echo "ERROR: executable name $1 does not follow naming convention : $2"
-        rc=1
+  echo "ERROR: executable name $1 does not follow naming convention : $2" >&2
+  RC=1
 }
 
 warning_unknown_subsystem() {
-        echo "WARNING: in $1 the subsystem $2 is not in the list of know subsystem"
+  echo "WARNING: in $1 the subsystem $2 is not in the list of know subsystem"
 }
 
-re_is_test="^test"
-re_start_with_o2_or_test="^o2-"
-re_only_lower_case_or_dash="^([a-z,0-9]|-)+$"
-re_subsystem="(o2)-([a-z,0-9]+)+" # o2-subsystem
+RE_IS_TEST="^test"
+RE_START_WITH_O2_OR_TEST="^o2-"
+RE_ONLY_LOWER_CASE_OR_DASH="^[a-z0-9]([a-z0-9]+|-)+[a-z0-9]$"
+RE_SUBSYSTEM="(o2)-([a-z,0-9]+)+" # o2-subsystem
 
-known_groups="alicehlt \
+KNOWN_GROUPS="alicehlt \
 analysis aod d0 simple \
 data datapublisher datasampling \
 ccdb \
@@ -40,15 +41,14 @@ flp heartbeat message epn \
 mergers \
 subframebuilder sync timeframe"
 
-for f in $(ls @CMAKE_INSTALL_PREFIX@/bin); do
-        [[ -x $f ]] && continue
-        [[ $f =~ $re_is_test ]] && continue # convention for tests is yet to come
-        [[ ! $f =~ $re_start_with_o2_or_test ]] && error_msg $f "does not start with o2-"
-        [[ ! $f =~ $re_only_lower_case_or_dash ]] && error_msg $f "should only contains lowercase letters, numbers, or dashes"
-        [[ $f =~ $re_subsystem ]] && subsystem=${BASH_REMATCH[2]}
-        [[ ! " $known_groups " =~  .*\ $subsystem\ .* ]] && warning_unknown_subsystem $f $subsystem
+for F in @CMAKE_INSTALL_PREFIX@/bin/*; do
+  [[ -x $F ]] && continue
+  [[ $F =~ $RE_IS_TEST ]] && continue # convention for tests is yet to come
+  [[ ! $F =~ $RE_START_WITH_O2_OR_TEST ]] && error_msg $F "does not start with o2-"
+  [[ ! $F =~ $RE_ONLY_LOWER_CASE_OR_DASH ]] && error_msg $F "should only contains lowercase letters, numbers, or dashes"
+  [[ $F =~ $RE_SUBSYSTEM ]] && SUBSYSTEM=${BASH_REMATCH[2]}
+  [[ ! " $KNOWN_GROUPS " =~  .*\ $SUBSYSTEM\ .* ]] && warning_unknown_subsystem $F $SUBSYSTEM
 done
 
-exit $rc
-
+exit $RC
 


### PR DESCRIPTION
Plus two fixes already for executables not following it.

Opened for discussion probably is how to properly deal with the "subsystem" part of the name (o2-subsystem{-whatever-else}) in the script `cmake/ensure-executable-naming-convention.sh.in`

In order not to change any more for the moment, I just listed the existing "subsystems" we currently have in our executable names. Might have to revisit this if we want to categorize a bit our executables. Or do nothing if we don't. In any case the script issue a warning, not an error, for unknown "subsystem" names.

