### PR TITLE
ZDC: Refactor hit processing + optimization

### DIFF
--- a/Detectors/ZDC/simulation/include/ZDCSimulation/Detector.h
+++ b/Detectors/ZDC/simulation/include/ZDCSimulation/Detector.h
@@ -74,7 +74,7 @@ class Detector : public o2::base::DetImpl<Detector>
   void addAlignableVolumes() const override {}
 
   o2::zdc::Hit* addHit(Int_t trackID, Int_t parentID, Int_t sFlag, Float_t primaryEnergy, Int_t detID, Int_t secID,
-                       Vector3D<float> pos, Vector3D<float> mom, Float_t tof, Float_t* xImpact, Double_t energyloss,
+                       Vector3D<float> pos, Vector3D<float> mom, Float_t tof, Vector3D<float> xImpact, Double_t energyloss,
                        Int_t nphePMC, Int_t nphePMQ);
 
  private:
@@ -85,6 +85,10 @@ class Detector : public o2::base::DetImpl<Detector>
   void createCsideBeamLine();
   void createMagnets();
   void createDetectors();
+
+  // determine detector; sector/tower and impact coordinates given volumename and position
+  void getDetIDandSecID(TString const& volname, Vector3D<float> const& x,
+                        Vector3D<float>& xDet, int& detector, int& sector) const;
 
   // Define sensitive volumes
   void defineSensitiveVolumes();
@@ -99,7 +103,7 @@ class Detector : public o2::base::DetImpl<Detector>
   Float_t mTrackEta;
   Bool_t mSecondaryFlag;
   Float_t mPrimaryEnergy;
-  Float_t mXImpact[3];
+  Vector3D<float> mXImpact;
   Float_t mTrackTOF;
   Float_t mTotDepEnergy;
   Float_t mTotLightPMC;

--- a/Detectors/ZDC/simulation/include/ZDCSimulation/Hit.h
+++ b/Detectors/ZDC/simulation/include/ZDCSimulation/Hit.h
@@ -45,7 +45,7 @@ class Hit : public o2::BasicXYZEHit<Float_t, Float_t>
   /// \param nphePMC light output on common PMT
   /// \param nphePMQ light output on sector PMT
   Hit(int trackID, int parent, Bool_t sFlag, Float_t primaryEnergy, Int_t detID, Int_t sectorID,
-      Vector3D<float> pos, Vector3D<float> mom, Float_t tof, Float_t* xImpact, Float_t energyloss, Int_t nphePMC,
+      Vector3D<float> pos, Vector3D<float> mom, Float_t tof, Vector3D<float> xImpact, Float_t energyloss, Int_t nphePMC,
       Int_t nphePMQ);
 
   void setPMCLightYield(float val) { mNphePMC = val; }
@@ -72,7 +72,7 @@ class Hit : public o2::BasicXYZEHit<Float_t, Float_t>
 };
 
 inline Hit::Hit(int trackID, int parent, Bool_t sFlag, Float_t primaryEnergy, Int_t detID, Int_t sectorID,
-                Vector3D<float> pos, Vector3D<float> mom, Float_t tof, Float_t* xImpact, Float_t energyloss,
+                Vector3D<float> pos, Vector3D<float> mom, Float_t tof, Vector3D<float> xImpact, Float_t energyloss,
                 Int_t nphePMC, Int_t nphePMQ)
   : BasicXYZEHit(pos.X(), pos.Y(), pos.Z(), tof, energyloss, trackID, detID),
     mParentID(parent),
@@ -80,7 +80,7 @@ inline Hit::Hit(int trackID, int parent, Bool_t sFlag, Float_t primaryEnergy, In
     mPrimaryEnergy(primaryEnergy),
     mSectorID(sectorID),
     mMomentum(mom.X(), mom.Y(), mom.Z()),
-    mXImpact(xImpact[0], xImpact[1], xImpact[2]),
+    mXImpact(xImpact),
     mNphePMC(nphePMC),
     mNphePMQ(nphePMQ)
 {

--- a/Detectors/ZDC/simulation/src/Detector.cxx
+++ b/Detectors/ZDC/simulation/src/Detector.cxx
@@ -276,16 +276,15 @@ Bool_t Detector::ProcessHits(FairVolume* v)
         charge = TMath::Abs(pdgCode / 10000 - 100000);
       //look into the light tables
       if (mZDCdetectorID == 1 || mZDCdetectorID == 4) {
-        if (iradius > Geometry::ZNFIBREDIAMETER)
-          iradius = Geometry::ZNFIBREDIAMETER;
-        lightoutput = charge * charge * mLightTableZN[ibeta][iangle][iradius];
+        iradius = std::min((int)Geometry::ZNFIBREDIAMETER, iradius);
+        lightoutput = charge * charge * mLightTableZN[ibeta][iradius][iangle];
       } else {
-        if (iradius > Geometry::ZPFIBREDIAMETER)
-          iradius = Geometry::ZPFIBREDIAMETER;
-        lightoutput = charge * charge * mLightTableZP[ibeta][iangle][iradius];
+        iradius = std::min((int)Geometry::ZPFIBREDIAMETER, iradius);
+        lightoutput = charge * charge * mLightTableZP[ibeta][iradius][iangle];
       }
-      if (lightoutput > 0)
+      if (lightoutput > 0) {
         nphe = gRandom->Poisson(lightoutput);
+      }
     }
   }
 


### PR DESCRIPTION
Make hit processing more modular. Here taking out a routine
determining the detector/sector information, making the actual hit creation
logic smaller. Reduce code somewhat and use Vector3D<float> types instead of float* where
possible.

Fix a bug for detection of electromagnetic detector/sector.

Reduce the number of sensitive volumes to absolut necessary (fibres) for digit creation.
This should already be a good optimization as it prevents calling the hit routine
for the passive dominating material ZNST.
(Should one want to track information in passive materials, one may use the MCStepLogger).

Activate previously omitted ZEM as sensitive detector.