### PR TITLE
Make box particle gun configurable

### DIFF
--- a/Generators/CMakeLists.txt
+++ b/Generators/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SRCS
     src/PDG.cxx	
     src/PrimaryGenerator.cxx
     src/InteractionDiamondParam.cxx
+    src/BoxGunParam.cxx
    )
 set(HEADERS
     include/${MODULE_NAME}/Generator.h
@@ -26,7 +27,8 @@ set(HEADERS
     include/${MODULE_NAME}/PDG.h
     include/${MODULE_NAME}/PrimaryGenerator.h
     include/${MODULE_NAME}/InteractionDiamondParam.h
-   )
+    include/${MODULE_NAME}/BoxGunParam.h
+       )
 if (HAVESIMULATION)
   set(HEADERS ${HEADERS}
       include/${MODULE_NAME}/GeneratorFactory.h

--- a/Generators/include/Generators/BoxGunParam.h
+++ b/Generators/include/Generators/BoxGunParam.h
@@ -1,0 +1,42 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author S+Wenzel - May 2019
+
+#ifndef ALICEO2_EVENTGEN_GUNPARAM_H_
+#define ALICEO2_EVENTGEN_GUNPARAM_H_
+
+#include "SimConfig/ConfigurableParam.h"
+#include "SimConfig/ConfigurableParamHelper.h"
+
+namespace o2
+{
+namespace eventgen
+{
+
+/**
+ ** A parameter class/struct holding values for
+ ** the box/gun generator. Allows for quick runtime configurability
+ ** of particle type, energy, direction, etc.
+ **/
+struct BoxGunParam : public o2::conf::ConfigurableParamHelper<BoxGunParam> {
+  int pdg = 13;                      // which particle (default proton?); could make this an enum
+  int number = 10;                   // how many particles
+  double eta[2] = { -1, 1 };         // eta range
+  double prange[2] = { 0.1, 5 };     // energy range min, max in GeV
+  double phirange[2] = { 0., 360. }; // phi range
+  bool debug = false;                // whether to print out produced particles
+  O2ParamDef(BoxGunParam, "BoxGun");
+};
+
+} // end namespace eventgen
+} // end namespace o2
+
+#endif // ALICEO2_EVENTGEN_INTERACTIONDIAMONDPARAM_H_

--- a/Generators/src/BoxGunParam.cxx
+++ b/Generators/src/BoxGunParam.cxx
@@ -1,0 +1,12 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Generators/BoxGunParam.h"
+O2ParamImpl(o2::eventgen::BoxGunParam);

--- a/Generators/src/GeneratorFactory.cxx
+++ b/Generators/src/GeneratorFactory.cxx
@@ -18,6 +18,7 @@
 #include <SimConfig/SimConfig.h>
 #include <Generators/GeneratorFromFile.h>
 #include <Generators/Pythia8Generator.h>
+#include <Generators/BoxGunParam.h>
 #include "TROOT.h"
 #include "TSystem.h"
 #include "TGlobal.h"
@@ -38,13 +39,16 @@ void GeneratorFactory::setPrimaryGenerator(o2::conf::SimConfig const& conf, Fair
   }
   auto genconfig = conf.getGenerator();
   if (genconfig.compare("boxgen") == 0) {
-    // a simple "box" generator
-    LOG(INFO) << "Init box generator";
-    auto boxGen = new FairBoxGenerator(211, 10); /*protons*/
-    boxGen->SetEtaRange(-0.9, 0.9);
-    boxGen->SetPRange(0.1, 5);
-    boxGen->SetPhiRange(0., 360.);
-    boxGen->SetDebug(kTRUE);
+    // a simple "box" generator configurable via BoxGunparam
+    auto& boxparam = BoxGunParam::Instance();
+    LOG(INFO) << "Init box generator with following parameters";
+    LOG(INFO) << boxparam;
+    auto boxGen = new FairBoxGenerator(boxparam.pdg, boxparam.number);
+    boxGen->SetEtaRange(boxparam.eta[0], boxparam.eta[1]);
+    boxGen->SetPRange(boxparam.prange[0], boxparam.prange[1]);
+    boxGen->SetPhiRange(boxparam.phirange[0], boxparam.phirange[1]);
+    boxGen->SetDebug(boxparam.debug);
+
     primGen->AddGenerator(boxGen);
   } else if (genconfig.compare("fwmugen") == 0) {
     // a simple "box" generator for forward muons

--- a/Generators/src/GeneratorsLinkDef.h
+++ b/Generators/src/GeneratorsLinkDef.h
@@ -36,5 +36,7 @@
 #pragma link C++ class o2::eventgen::PrimaryGenerator + ;
 #pragma link C++ class o2::eventgen::InteractionDiamondParam + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::eventgen::InteractionDiamondParam> + ;
+#pragma link C++ class o2::eventgen::BoxGunParam + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::eventgen::BoxGunParam> + ;
 
 #endif


### PR DESCRIPTION
The box event generator is now configurable which is convenient
for testing/scanning simulation with various particle types and energies.