### PR TITLE
o2sim: Fix bug for shared memory readout [O2-689]

### DIFF
--- a/Detectors/Base/include/DetectorsBase/Detector.h
+++ b/Detectors/Base/include/DetectorsBase/Detector.h
@@ -408,6 +408,7 @@ class DetImpl : public o2::base::Detector
   void fillHitBranch(TTree& tr, FairMQParts& parts, int& index) override
   {
     int probe = 0;
+    bool* busy = nullptr;
     using Hit_t = decltype(static_cast<Det*>(this)->Det::getHits(probe));
     std::string name = static_cast<Det*>(this)->getHitBranchNames(probe++);
     while (name.size() > 0) {
@@ -425,20 +426,20 @@ class DetImpl : public o2::base::Detector
         }
       } else {
         // for each branch name we extract/decode hits from the message parts ...
-        bool* busy;
         auto hitsptr = decodeShmMessage<Hit_t>(parts, index++, busy);
-        LOG(DEBUG2) << "GOT " << hitsptr->size() << " HITS ";
         // ... and fill the tree branch
         auto br = getOrMakeBranch(tr, name.c_str(), hitsptr);
         br->SetAddress(static_cast<void*>(&hitsptr));
         br->Fill();
         br->ResetAddress();
-
-        // he we are done so unset the busy flag
-        *busy = false;
       }
       // next name
       name = static_cast<Det*>(this)->getHitBranchNames(probe++);
+    }
+    // there is only one busy flag per detector so we need to clear it only
+    // at the end (after all branches have been treated)
+    if (busy) {
+      *busy = false;
     }
   }
 

--- a/Detectors/Base/src/Detector.cxx
+++ b/Detectors/Base/src/Detector.cxx
@@ -192,7 +192,6 @@ void* decodeShmCore(FairMQParts& dataparts, int index, bool*& busy)
   };
 
   shmcontext* info = (shmcontext*)rawmessage->GetData();
-  LOG(DEBUG) << " GOT SHMID " << info->id;
 
   busy = info->busy_ptr;
   return info->object_ptr;


### PR DESCRIPTION
The shared memory readout for hits uses a "busy"
flag to indicate that a buffer is still being processed.
This flag was unset to early, in particular for the TPC where we
have multiple hit branches.

Fixes https://alice.its.cern.ch/jira/browse/O2-689