### PR TITLE
Fix missing GPU vector ptr initialization in ITS tracker

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/cuda/include/ITStrackingCUDA/Vector.h
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/include/ITStrackingCUDA/Vector.h
@@ -70,8 +70,8 @@ class Vector final
  private:
   GPU_HOST_DEVICE Vector(const Vector&, const bool);
 
-  T* mArrayPointer;
-  int* mDeviceSize;
+  T* mArrayPointer = nullptr;
+  int* mDeviceSize = nullptr;
   int mCapacity;
   bool mIsWeak;
 };


### PR DESCRIPTION
@mpuccio @mconcas : I have been observing some undefined behavior and crashes in the ITS tracker traits destructors when I enabled the GPU. It seems to be (at least partially) related to uninitialized ptrs in the ITS GPU vector.

This PR fixes the issue for me for now, but it was not really reproducible, so I am not sure if it is fixed to 100%.

Also, you actually have constructors that should initialize it to nullptr already, but apparently, this is not working in all cases. I didn't manage to fully understand it and then gave up... Anyhow, the initialization in this way should not hurt in any case.

Do you want to check what goes wrong with the initialization, or shell we just merge commit?

Below is a valgrind stacktrace before one of the crashes I had, in case you want to investigate further.

==20508==    at 0xA80886C: o2::its::GPU::Vector<o2::its::Cell>::destroy() (Vector.h:245)
==20508==    by 0xA8060C2: o2::its::GPU::Vector<o2::its::Cell>::~Vector() (Vector.h:140)
==20508==    by 0xA805440: std::array<o2::its::GPU::Vector<o2::its::Cell>, 4ul>::~array() (array:94)
==20508==    by 0xA80CA8B: o2::its::PrimaryVertexContextNV::~PrimaryVertexContextNV() (PrimaryVertexContextNV.h:39)
==20508==    by 0xA80CAFB: o2::its::PrimaryVertexContextNV::~PrimaryVertexContextNV() (PrimaryVertexContextNV.h:39)
==20508==    by 0xA7FA9DB: o2::its::TrackerTraitsNV::~TrackerTraitsNV() (TrackerTraitsNV.cu:295)
==20508==    by 0xA7FAA03: o2::its::TrackerTraitsNV::~TrackerTraitsNV() (TrackerTraitsNV.cu:296)
==20508==    by 0x49EB5D1: std::default_delete<o2::its::TrackerTraits>::operator()(o2::its::TrackerTraits*) const (unique_ptr.h:81)
