### PR TITLE
Fix namespace naming: o2::its::Constants

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
@@ -53,23 +53,23 @@ struct TrackingParameters {
   int MinTrackLength = 7;
   /// Trackleting cuts
   float TrackletMaxDeltaPhi = 0.3f;
-  float TrackletMaxDeltaZ[Constants::its::TrackletsPerRoad] = { 0.1f, 0.1f, 0.3f, 0.3f, 0.3f, 0.3f };
+  float TrackletMaxDeltaZ[constants::its::TrackletsPerRoad] = { 0.1f, 0.1f, 0.3f, 0.3f, 0.3f, 0.3f };
   /// Cell finding cuts
   float CellMaxDeltaTanLambda = 0.025f;
-  float CellMaxDCA[Constants::its::CellsPerRoad] = { 0.05f, 0.04f, 0.05f, 0.2f, 0.4f };
+  float CellMaxDCA[constants::its::CellsPerRoad] = { 0.05f, 0.04f, 0.05f, 0.2f, 0.4f };
   float CellMaxDeltaPhi = 0.14f;
-  float CellMaxDeltaZ[Constants::its::CellsPerRoad] = { 0.2f, 0.4f, 0.5f, 0.6f, 3.0f };
+  float CellMaxDeltaZ[constants::its::CellsPerRoad] = { 0.2f, 0.4f, 0.5f, 0.6f, 3.0f };
   /// Neighbour finding cuts
-  float NeighbourMaxDeltaCurvature[Constants::its::CellsPerRoad - 1] = { 0.008f, 0.0025f, 0.003f, 0.0035f };
-  float NeighbourMaxDeltaN[Constants::its::CellsPerRoad - 1] = { 0.002f, 0.0090f, 0.002f, 0.005f };
+  float NeighbourMaxDeltaCurvature[constants::its::CellsPerRoad - 1] = { 0.008f, 0.0025f, 0.003f, 0.0035f };
+  float NeighbourMaxDeltaN[constants::its::CellsPerRoad - 1] = { 0.002f, 0.0090f, 0.002f, 0.005f };
 };
 
 struct MemoryParameters {
   /// Memory coefficients
   MemoryParameters& operator=(const MemoryParameters& t);
   int MemoryOffset = 256;
-  float CellsMemoryCoefficients[Constants::its::CellsPerRoad] = { 2.3208e-08f, 2.104e-08f, 1.6432e-08f, 1.2412e-08f, 1.3543e-08f };
-  float TrackletsMemoryCoefficients[Constants::its::TrackletsPerRoad] = { 0.0016353f, 0.0013627f, 0.000984f, 0.00078135f, 0.00057934f, 0.00052217f };
+  float CellsMemoryCoefficients[constants::its::CellsPerRoad] = { 2.3208e-08f, 2.104e-08f, 1.6432e-08f, 1.2412e-08f, 1.3543e-08f };
+  float TrackletsMemoryCoefficients[constants::its::TrackletsPerRoad] = { 0.0016353f, 0.0013627f, 0.000984f, 0.00078135f, 0.00057934f, 0.00052217f };
 };
 
 struct IndexTableParameters {
@@ -77,13 +77,13 @@ struct IndexTableParameters {
   void ComputeInverseBinSizes();
   int ZBins = 20;
   int PhiBins = 20;
-  float InversePhiBinSize = 20 / Constants::Math::TwoPi;
-  std::array<float, Constants::its::LayersNumber> InverseZBinSize;
+  float InversePhiBinSize = 20 / constants::Math::TwoPi;
+  std::array<float, constants::its::LayersNumber> InverseZBinSize;
 };
 
 inline int TrackingParameters::CellMinimumLevel()
 {
-  return MinTrackLength - Constants::its::ClustersPerCell + 1;
+  return MinTrackLength - constants::its::ClustersPerCell + 1;
 }
 
 inline IndexTableParameters::IndexTableParameters()
@@ -93,9 +93,9 @@ inline IndexTableParameters::IndexTableParameters()
 
 inline void IndexTableParameters::ComputeInverseBinSizes()
 {
-  InversePhiBinSize = PhiBins / Constants::Math::TwoPi;
-  for (int iL = 0; iL < Constants::its::LayersNumber; ++iL) {
-    InverseZBinSize[iL] = 0.5f * ZBins / Constants::its::LayersZCoordinate()[iL];
+  InversePhiBinSize = PhiBins / constants::Math::TwoPi;
+  for (int iL = 0; iL < constants::its::LayersNumber; ++iL) {
+    InverseZBinSize[iL] = 0.5f * ZBins / constants::its::LayersZCoordinate()[iL];
   }
 }
 
@@ -105,17 +105,17 @@ inline TrackingParameters& TrackingParameters::operator=(const TrackingParameter
   this->MinTrackLength = t.MinTrackLength;
   /// Trackleting cuts
   this->TrackletMaxDeltaPhi = t.TrackletMaxDeltaPhi;
-  for (int iT = 0; iT < Constants::its::TrackletsPerRoad; ++iT)
+  for (int iT = 0; iT < constants::its::TrackletsPerRoad; ++iT)
     this->TrackletMaxDeltaZ[iT] = t.TrackletMaxDeltaZ[iT];
   /// Cell finding cuts
   this->CellMaxDeltaTanLambda = t.CellMaxDeltaTanLambda;
   this->CellMaxDeltaPhi = t.CellMaxDeltaPhi;
-  for (int iC = 0; iC < Constants::its::CellsPerRoad; ++iC) {
+  for (int iC = 0; iC < constants::its::CellsPerRoad; ++iC) {
     this->CellMaxDCA[iC] = t.CellMaxDCA[iC];
     this->CellMaxDeltaZ[iC] = t.CellMaxDeltaZ[iC];
   }
   /// Neighbour finding cuts
-  for (int iC = 0; iC < Constants::its::CellsPerRoad - 1; ++iC) {
+  for (int iC = 0; iC < constants::its::CellsPerRoad - 1; ++iC) {
     this->NeighbourMaxDeltaCurvature[iC] = t.NeighbourMaxDeltaCurvature[iC];
     this->NeighbourMaxDeltaN[iC] = t.NeighbourMaxDeltaN[iC];
   }
@@ -125,9 +125,9 @@ inline TrackingParameters& TrackingParameters::operator=(const TrackingParameter
 inline MemoryParameters& MemoryParameters::operator=(const MemoryParameters& t)
 {
   this->MemoryOffset = t.MemoryOffset;
-  for (int iC = 0; iC < Constants::its::CellsPerRoad; ++iC)
+  for (int iC = 0; iC < constants::its::CellsPerRoad; ++iC)
     this->CellsMemoryCoefficients[iC] = t.CellsMemoryCoefficients[iC];
-  for (int iT = 0; iT < Constants::its::TrackletsPerRoad; ++iT)
+  for (int iT = 0; iT < constants::its::TrackletsPerRoad; ++iT)
     this->TrackletsMemoryCoefficients[iT] = t.TrackletsMemoryCoefficients[iT];
   return *this;
 }

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Constants.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Constants.h
@@ -27,7 +27,7 @@ namespace o2
 namespace its
 {
 
-namespace Constants
+namespace constants
 {
 
 constexpr bool DoTimeBenchmarks = true;
@@ -63,7 +63,7 @@ namespace IndexTable
 {
 constexpr int ZBins{ 20 };
 constexpr int PhiBins{ 20 };
-constexpr float InversePhiBinSize{ Constants::IndexTable::PhiBins / Constants::Math::TwoPi };
+constexpr float InversePhiBinSize{ constants::IndexTable::PhiBins / constants::Math::TwoPi };
 GPU_HOST_DEVICE constexpr GPUArray<float, its::LayersNumber> InverseZBinSize()
 {
   return GPUArray<float, its::LayersNumber>{ { 0.5 * ZBins / 16.333f, 0.5 * ZBins / 16.333f, 0.5 * ZBins / 16.333f,

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/IndexTableUtils.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/IndexTableUtils.h
@@ -36,34 +36,34 @@ GPU_HOST_DEVICE int getZBinIndex(const int, const float);
 GPU_HOST_DEVICE int getPhiBinIndex(const float);
 GPU_HOST_DEVICE int getBinIndex(const int, const int);
 GPU_HOST_DEVICE int countRowSelectedBins(
-  const GPUArray<int, Constants::IndexTable::ZBins * Constants::IndexTable::PhiBins + 1>&, const int, const int,
+  const GPUArray<int, constants::IndexTable::ZBins * constants::IndexTable::PhiBins + 1>&, const int, const int,
   const int);
 } // namespace IndexTableUtils
 
 inline float getInverseZCoordinate(const int layerIndex)
 {
-  return 0.5f * Constants::IndexTable::ZBins / Constants::its::LayersZCoordinate()[layerIndex];
+  return 0.5f * constants::IndexTable::ZBins / constants::its::LayersZCoordinate()[layerIndex];
 }
 
 GPU_HOST_DEVICE inline int IndexTableUtils::getZBinIndex(const int layerIndex, const float zCoordinate)
 {
-  return (zCoordinate + Constants::its::LayersZCoordinate()[layerIndex]) *
-         Constants::IndexTable::InverseZBinSize()[layerIndex];
+  return (zCoordinate + constants::its::LayersZCoordinate()[layerIndex]) *
+         constants::IndexTable::InverseZBinSize()[layerIndex];
 }
 
 GPU_HOST_DEVICE inline int IndexTableUtils::getPhiBinIndex(const float currentPhi)
 {
-  return (currentPhi * Constants::IndexTable::InversePhiBinSize);
+  return (currentPhi * constants::IndexTable::InversePhiBinSize);
 }
 
 GPU_HOST_DEVICE inline int IndexTableUtils::getBinIndex(const int zIndex, const int phiIndex)
 {
-  return MATH_MIN(phiIndex * Constants::IndexTable::PhiBins + zIndex,
-                  Constants::IndexTable::ZBins * Constants::IndexTable::PhiBins);
+  return MATH_MIN(phiIndex * constants::IndexTable::PhiBins + zIndex,
+                  constants::IndexTable::ZBins * constants::IndexTable::PhiBins);
 }
 
 GPU_HOST_DEVICE inline int IndexTableUtils::countRowSelectedBins(
-  const GPUArray<int, Constants::IndexTable::ZBins * Constants::IndexTable::PhiBins + 1>& indexTable,
+  const GPUArray<int, constants::IndexTable::ZBins * constants::IndexTable::PhiBins + 1>& indexTable,
   const int phiBinIndex, const int minZBinIndex, const int maxZBinIndex)
 {
   const int firstBinIndex{ getBinIndex(minZBinIndex, phiBinIndex) };

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/MathUtils.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/MathUtils.h
@@ -43,7 +43,7 @@ GPUhdni() float computeTanDipAngle(float x1, float y1, float x2, float y2, float
 
 GPUhdi() float MathUtils::calculatePhiCoordinate(const float xCoordinate, const float yCoordinate)
 {
-  return o2::gpu::CAMath::ATan2(-yCoordinate, -xCoordinate) + Constants::Math::Pi;
+  return o2::gpu::CAMath::ATan2(-yCoordinate, -xCoordinate) + constants::Math::Pi;
 }
 
 GPUhdi() float MathUtils::calculateRCoordinate(const float xCoordinate, const float yCoordinate)
@@ -54,8 +54,8 @@ GPUhdi() float MathUtils::calculateRCoordinate(const float xCoordinate, const fl
 GPUhdi() constexpr float MathUtils::getNormalizedPhiCoordinate(const float phiCoordinate)
 {
   return (phiCoordinate < 0)
-           ? phiCoordinate + Constants::Math::TwoPi
-           : (phiCoordinate > Constants::Math::TwoPi) ? phiCoordinate - Constants::Math::TwoPi : phiCoordinate;
+           ? phiCoordinate + constants::Math::TwoPi
+           : (phiCoordinate > constants::Math::TwoPi) ? phiCoordinate - constants::Math::TwoPi : phiCoordinate;
 }
 
 GPUhdi() constexpr float3 MathUtils::crossProduct(const float3& firstVector, const float3& secondVector)

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/PrimaryVertexContext.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/PrimaryVertexContext.h
@@ -42,55 +42,55 @@ class PrimaryVertexContext
   PrimaryVertexContext(const PrimaryVertexContext&) = delete;
   PrimaryVertexContext& operator=(const PrimaryVertexContext&) = delete;
 
-  virtual void initialise(const MemoryParameters& memParam, const std::array<std::vector<Cluster>, Constants::its::LayersNumber>& cl,
+  virtual void initialise(const MemoryParameters& memParam, const std::array<std::vector<Cluster>, constants::its::LayersNumber>& cl,
                           const std::array<float, 3>& pv, const int iteration);
   const float3& getPrimaryVertex() const;
-  std::array<std::vector<Cluster>, Constants::its::LayersNumber>& getClusters();
-  std::array<std::vector<Cell>, Constants::its::CellsPerRoad>& getCells();
-  std::array<std::vector<int>, Constants::its::CellsPerRoad - 1>& getCellsLookupTable();
-  std::array<std::vector<std::vector<int>>, Constants::its::CellsPerRoad - 1>& getCellsNeighbours();
+  std::array<std::vector<Cluster>, constants::its::LayersNumber>& getClusters();
+  std::array<std::vector<Cell>, constants::its::CellsPerRoad>& getCells();
+  std::array<std::vector<int>, constants::its::CellsPerRoad - 1>& getCellsLookupTable();
+  std::array<std::vector<std::vector<int>>, constants::its::CellsPerRoad - 1>& getCellsNeighbours();
   std::vector<Road>& getRoads();
 
   bool isClusterUsed(int layer, int clusterId) const;
   void markUsedCluster(int layer, int clusterId);
 
-  std::array<std::array<int, Constants::IndexTable::ZBins * Constants::IndexTable::PhiBins + 1>,
-             Constants::its::TrackletsPerRoad>&
+  std::array<std::array<int, constants::IndexTable::ZBins * constants::IndexTable::PhiBins + 1>,
+             constants::its::TrackletsPerRoad>&
     getIndexTables();
-  std::array<std::vector<Tracklet>, Constants::its::TrackletsPerRoad>& getTracklets();
-  std::array<std::vector<int>, Constants::its::CellsPerRoad>& getTrackletsLookupTable();
+  std::array<std::vector<Tracklet>, constants::its::TrackletsPerRoad>& getTracklets();
+  std::array<std::vector<int>, constants::its::CellsPerRoad>& getTrackletsLookupTable();
 
  protected:
   float3 mPrimaryVertex;
-  std::array<std::vector<Cluster>, Constants::its::LayersNumber> mClusters;
-  std::array<std::vector<bool>, Constants::its::LayersNumber> mUsedClusters;
-  std::array<std::vector<Cell>, Constants::its::CellsPerRoad> mCells;
-  std::array<std::vector<int>, Constants::its::CellsPerRoad - 1> mCellsLookupTable;
-  std::array<std::vector<std::vector<int>>, Constants::its::CellsPerRoad - 1> mCellsNeighbours;
+  std::array<std::vector<Cluster>, constants::its::LayersNumber> mClusters;
+  std::array<std::vector<bool>, constants::its::LayersNumber> mUsedClusters;
+  std::array<std::vector<Cell>, constants::its::CellsPerRoad> mCells;
+  std::array<std::vector<int>, constants::its::CellsPerRoad - 1> mCellsLookupTable;
+  std::array<std::vector<std::vector<int>>, constants::its::CellsPerRoad - 1> mCellsNeighbours;
   std::vector<Road> mRoads;
 
-  std::array<std::array<int, Constants::IndexTable::ZBins * Constants::IndexTable::PhiBins + 1>,
-             Constants::its::TrackletsPerRoad>
+  std::array<std::array<int, constants::IndexTable::ZBins * constants::IndexTable::PhiBins + 1>,
+             constants::its::TrackletsPerRoad>
     mIndexTables;
-  std::array<std::vector<Tracklet>, Constants::its::TrackletsPerRoad> mTracklets;
-  std::array<std::vector<int>, Constants::its::CellsPerRoad> mTrackletsLookupTable;
+  std::array<std::vector<Tracklet>, constants::its::TrackletsPerRoad> mTracklets;
+  std::array<std::vector<int>, constants::its::CellsPerRoad> mTrackletsLookupTable;
 };
 
 inline const float3& PrimaryVertexContext::getPrimaryVertex() const { return mPrimaryVertex; }
 
-inline std::array<std::vector<Cluster>, Constants::its::LayersNumber>& PrimaryVertexContext::getClusters()
+inline std::array<std::vector<Cluster>, constants::its::LayersNumber>& PrimaryVertexContext::getClusters()
 {
   return mClusters;
 }
 
-inline std::array<std::vector<Cell>, Constants::its::CellsPerRoad>& PrimaryVertexContext::getCells() { return mCells; }
+inline std::array<std::vector<Cell>, constants::its::CellsPerRoad>& PrimaryVertexContext::getCells() { return mCells; }
 
-inline std::array<std::vector<int>, Constants::its::CellsPerRoad - 1>& PrimaryVertexContext::getCellsLookupTable()
+inline std::array<std::vector<int>, constants::its::CellsPerRoad - 1>& PrimaryVertexContext::getCellsLookupTable()
 {
   return mCellsLookupTable;
 }
 
-inline std::array<std::vector<std::vector<int>>, Constants::its::CellsPerRoad - 1>&
+inline std::array<std::vector<std::vector<int>>, constants::its::CellsPerRoad - 1>&
   PrimaryVertexContext::getCellsNeighbours()
 {
   return mCellsNeighbours;
@@ -105,19 +105,19 @@ inline bool PrimaryVertexContext::isClusterUsed(int layer, int clusterId) const
 
 inline void PrimaryVertexContext::markUsedCluster(int layer, int clusterId) { mUsedClusters[layer][clusterId] = true; }
 
-inline std::array<std::array<int, Constants::IndexTable::ZBins * Constants::IndexTable::PhiBins + 1>,
-                  Constants::its::TrackletsPerRoad>&
+inline std::array<std::array<int, constants::IndexTable::ZBins * constants::IndexTable::PhiBins + 1>,
+                  constants::its::TrackletsPerRoad>&
   PrimaryVertexContext::getIndexTables()
 {
   return mIndexTables;
 }
 
-inline std::array<std::vector<Tracklet>, Constants::its::TrackletsPerRoad>& PrimaryVertexContext::getTracklets()
+inline std::array<std::vector<Tracklet>, constants::its::TrackletsPerRoad>& PrimaryVertexContext::getTracklets()
 {
   return mTracklets;
 }
 
-inline std::array<std::vector<int>, Constants::its::CellsPerRoad>& PrimaryVertexContext::getTrackletsLookupTable()
+inline std::array<std::vector<int>, constants::its::CellsPerRoad>& PrimaryVertexContext::getTrackletsLookupTable()
 {
   return mTrackletsLookupTable;
 }

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/ROframe.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/ROframe.h
@@ -48,10 +48,10 @@ class ROframe final
   void printPrimaryVertices() const;
   int getTotalClusters() const;
 
-  const std::array<std::vector<Cluster>, Constants::its::LayersNumber>& getClusters() const;
+  const std::array<std::vector<Cluster>, constants::its::LayersNumber>& getClusters() const;
   const std::vector<Cluster>& getClustersOnLayer(int layerId) const;
   const std::vector<TrackingFrameInfo>& getTrackingFrameInfoOnLayer(int layerId) const;
-  const std::array<std::vector<TrackingFrameInfo>, Constants::its::LayersNumber>& getTrackingFrameInfo() const;
+  const std::array<std::vector<TrackingFrameInfo>, constants::its::LayersNumber>& getTrackingFrameInfo() const;
 
   const TrackingFrameInfo& getClusterTrackingFrameInfo(int layerId, const Cluster& cl) const;
   const MCCompLabel& getClusterLabels(int layerId, const Cluster& cl) const;
@@ -71,10 +71,10 @@ class ROframe final
  private:
   const int mROframeId;
   std::vector<float3> mPrimaryVertices;
-  std::array<std::vector<Cluster>, Constants::its::LayersNumber> mClusters;
-  std::array<std::vector<TrackingFrameInfo>, Constants::its::LayersNumber> mTrackingFrameInfo;
-  std::array<std::vector<MCCompLabel>, Constants::its::LayersNumber> mClusterLabels;
-  std::array<std::vector<int>, Constants::its::LayersNumber> mClusterExternalIndices;
+  std::array<std::vector<Cluster>, constants::its::LayersNumber> mClusters;
+  std::array<std::vector<TrackingFrameInfo>, constants::its::LayersNumber> mTrackingFrameInfo;
+  std::array<std::vector<MCCompLabel>, constants::its::LayersNumber> mClusterLabels;
+  std::array<std::vector<int>, constants::its::LayersNumber> mClusterExternalIndices;
 };
 
 inline int ROframe::getROFrameId() const { return mROframeId; }
@@ -83,7 +83,7 @@ inline const float3& ROframe::getPrimaryVertex(const int vertexIndex) const { re
 
 inline int ROframe::getPrimaryVerticesNum() const { return mPrimaryVertices.size(); }
 
-inline const std::array<std::vector<Cluster>, Constants::its::LayersNumber>& ROframe::getClusters() const
+inline const std::array<std::vector<Cluster>, constants::its::LayersNumber>& ROframe::getClusters() const
 {
   return mClusters;
 }
@@ -98,7 +98,7 @@ inline const std::vector<TrackingFrameInfo>& ROframe::getTrackingFrameInfoOnLaye
   return mTrackingFrameInfo[layerId];
 }
 
-inline const std::array<std::vector<TrackingFrameInfo>, Constants::its::LayersNumber>& ROframe::getTrackingFrameInfo() const
+inline const std::array<std::vector<TrackingFrameInfo>, constants::its::LayersNumber>& ROframe::getTrackingFrameInfo() const
 {
   return mTrackingFrameInfo;
 }
@@ -153,7 +153,7 @@ inline void ROframe::addClusterExternalIndexToLayer(int layer, const int idx)
 
 inline void ROframe::clear()
 {
-  for (int iL = 0; iL < Constants::its::LayersNumber; ++iL) {
+  for (int iL = 0; iL < constants::its::LayersNumber; ++iL) {
     mClusters[iL].clear();
     mTrackingFrameInfo[iL].clear();
     mClusterLabels[iL].clear();

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Road.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Road.h
@@ -44,7 +44,7 @@ class Road final
   void addCell(int, int);
 
  private:
-  int mCellIds[Constants::its::CellsPerRoad];
+  int mCellIds[constants::its::CellsPerRoad];
   int mRoadSize;
   int mLabel;
   bool mIsFakeRoad;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracker.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracker.h
@@ -138,7 +138,7 @@ float Tracker::evaluateTask(void (Tracker::*task)(T...), const char* taskName, s
 {
   float diff{ 0.f };
 
-  if (Constants::DoTimeBenchmarks) {
+  if (constants::DoTimeBenchmarks) {
     auto start = std::chrono::high_resolution_clock::now();
     (this->*task)(std::forward<T>(args)...);
     auto end = std::chrono::high_resolution_clock::now();

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackerTraits.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackerTraits.h
@@ -85,15 +85,15 @@ inline GPU_DEVICE const int4 TrackerTraits::getBinsRect(const Cluster& currentCl
   const float zRangeMax = directionZIntersection + 2 * maxdeltaz;
   const float phiRangeMax = currentCluster.phiCoordinate + maxdeltaphi;
 
-  if (zRangeMax < -Constants::its::LayersZCoordinate()[layerIndex + 1] ||
-      zRangeMin > Constants::its::LayersZCoordinate()[layerIndex + 1] || zRangeMin > zRangeMax) {
+  if (zRangeMax < -constants::its::LayersZCoordinate()[layerIndex + 1] ||
+      zRangeMin > constants::its::LayersZCoordinate()[layerIndex + 1] || zRangeMin > zRangeMax) {
 
     return getEmptyBinsRect();
   }
 
   return int4{ MATH_MAX(0, IndexTableUtils::getZBinIndex(layerIndex + 1, zRangeMin)),
                IndexTableUtils::getPhiBinIndex(MathUtils::getNormalizedPhiCoordinate(phiRangeMin)),
-               MATH_MIN(Constants::IndexTable::ZBins - 1, IndexTableUtils::getZBinIndex(layerIndex + 1, zRangeMax)),
+               MATH_MIN(constants::IndexTable::ZBins - 1, IndexTableUtils::getZBinIndex(layerIndex + 1, zRangeMax)),
                IndexTableUtils::getPhiBinIndex(MathUtils::getNormalizedPhiCoordinate(phiRangeMax)) };
 }
 }

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Vertexer.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Vertexer.h
@@ -127,7 +127,7 @@ float Vertexer::evaluateTask(void (Vertexer::*task)(T...), const char* taskName,
 {
   float diff{ 0.f };
 
-  if (Constants::DoTimeBenchmarks) {
+  if (constants::DoTimeBenchmarks) {
     auto start = std::chrono::high_resolution_clock::now();
     (this->*task)(std::forward<T>(args)...);
     auto end = std::chrono::high_resolution_clock::now();

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
@@ -32,9 +32,9 @@ namespace its
 
 class ROframe;
 
-using Constants::IndexTable::PhiBins;
-using Constants::IndexTable::ZBins;
-using Constants::its::LayersNumberVertexer;
+using constants::IndexTable::PhiBins;
+using constants::IndexTable::ZBins;
+using constants::its::LayersNumberVertexer;
 
 struct lightVertex {
   lightVertex(float x, float y, float z, std::array<float, 6> rms2, int cont, float avgdis2, int stamp);
@@ -83,7 +83,7 @@ class VertexerTraits
   std::vector<Line> mTracklets;
   std::vector<Tracklet> mComb01;
   std::vector<Tracklet> mComb12;
-  std::array<std::vector<Cluster>, Constants::its::LayersNumberVertexer> mClusters;
+  std::array<std::vector<Cluster>, constants::its::LayersNumberVertexer> mClusters;
   std::vector<std::array<float, 7>> mDeltaTanlambdas;
   std::vector<std::array<float, 6>> mLinesData;
   std::vector<std::array<float, 4>> mCentroids;
@@ -135,15 +135,15 @@ inline GPU_DEVICE const int4 VertexerTraits::getBinsRect(const Cluster& currentC
   const float zRangeMax = directionZIntersection + maxdeltaz;
   const float phiRangeMax = currentCluster.phiCoordinate + maxdeltaphi;
 
-  if (zRangeMax < -Constants::its::LayersZCoordinate()[layerIndex + 1] ||
-      zRangeMin > Constants::its::LayersZCoordinate()[layerIndex + 1] || zRangeMin > zRangeMax) {
+  if (zRangeMax < -constants::its::LayersZCoordinate()[layerIndex + 1] ||
+      zRangeMin > constants::its::LayersZCoordinate()[layerIndex + 1] || zRangeMin > zRangeMax) {
 
     return getEmptyBinsRect();
   }
 
   return int4{ MATH_MAX(0, IndexTableUtils::getZBinIndex(layerIndex + 1, zRangeMin)),
                IndexTableUtils::getPhiBinIndex(MathUtils::getNormalizedPhiCoordinate(phiRangeMin)),
-               MATH_MIN(Constants::IndexTable::ZBins - 1, IndexTableUtils::getZBinIndex(layerIndex + 1, zRangeMax)),
+               MATH_MIN(constants::IndexTable::ZBins - 1, IndexTableUtils::getZBinIndex(layerIndex + 1, zRangeMax)),
                IndexTableUtils::getPhiBinIndex(MathUtils::getNormalizedPhiCoordinate(phiRangeMax)) };
 }
 
@@ -161,15 +161,15 @@ inline GPU_HOST_DEVICE const int4 VertexerTraits::getBinsRect2(const Cluster& cu
   const float zRangeMax = directionZIntersection + 2 * maxdeltaz;
   const float phiRangeMax = currentCluster.phiCoordinate + maxdeltaphi;
 
-  if (zRangeMax < -Constants::its::LayersZCoordinate()[layerIndex + 1] ||
-      zRangeMin > Constants::its::LayersZCoordinate()[layerIndex + 1] || zRangeMin > zRangeMax) {
+  if (zRangeMax < -constants::its::LayersZCoordinate()[layerIndex + 1] ||
+      zRangeMin > constants::its::LayersZCoordinate()[layerIndex + 1] || zRangeMin > zRangeMax) {
 
     return getEmptyBinsRect();
   }
 
   return int4{ MATH_MAX(0, IndexTableUtils::getZBinIndex(layerIndex + 1, zRangeMin)),
                IndexTableUtils::getPhiBinIndex(MathUtils::getNormalizedPhiCoordinate(phiRangeMin)),
-               MATH_MIN(Constants::IndexTable::ZBins - 1, IndexTableUtils::getZBinIndex(layerIndex + 1, zRangeMax)),
+               MATH_MIN(constants::IndexTable::ZBins - 1, IndexTableUtils::getZBinIndex(layerIndex + 1, zRangeMax)),
                IndexTableUtils::getPhiBinIndex(MathUtils::getNormalizedPhiCoordinate(phiRangeMax)) };
 }
 extern "C" VertexerTraits* createVertexerTraits();

--- a/Detectors/ITSMFT/ITS/tracking/src/IOUtils.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/IOUtils.cxx
@@ -193,7 +193,7 @@ std::vector<std::unordered_map<int, Label>> IOUtils::loadLabels(const int events
 
         if (inputStringStream >> transverseMomentum >> phiCoordinate >> pseudorapidity >> pdgCode >> numberOfClusters) {
 
-          if (std::abs(pdgCode) == Constants::PDGCodes::PionCode && numberOfClusters == 7) {
+          if (std::abs(pdgCode) == constants::PDGCodes::PionCode && numberOfClusters == 7) {
 
             currentEventLabelsMap.emplace(std::piecewise_construct, std::forward_as_tuple(monteCarloId),
                                           std::forward_as_tuple(monteCarloId, transverseMomentum, phiCoordinate,
@@ -258,15 +258,15 @@ void IOUtils::writeRoadsReport(std::ofstream& correctRoadsOutputStream, std::ofs
 
 void to_json(nlohmann::json& j, const TrackingParameters& par)
 {
-  std::array<float, Constants::its::TrackletsPerRoad> tmpTrackletMaxDeltaZ;
+  std::array<float, constants::its::TrackletsPerRoad> tmpTrackletMaxDeltaZ;
   std::copy(par.TrackletMaxDeltaZ, par.TrackletMaxDeltaZ + tmpTrackletMaxDeltaZ.size(), tmpTrackletMaxDeltaZ.begin());
-  std::array<float, Constants::its::CellsPerRoad> tmpCellMaxDCA;
+  std::array<float, constants::its::CellsPerRoad> tmpCellMaxDCA;
   std::copy(par.CellMaxDCA, par.CellMaxDCA + tmpCellMaxDCA.size(), tmpCellMaxDCA.begin());
-  std::array<float, Constants::its::CellsPerRoad> tmpCellMaxDeltaZ;
+  std::array<float, constants::its::CellsPerRoad> tmpCellMaxDeltaZ;
   std::copy(par.CellMaxDeltaZ, par.CellMaxDeltaZ + tmpCellMaxDeltaZ.size(), tmpCellMaxDeltaZ.begin());
-  std::array<float, Constants::its::CellsPerRoad - 1> tmpNeighbourMaxDeltaCurvature;
+  std::array<float, constants::its::CellsPerRoad - 1> tmpNeighbourMaxDeltaCurvature;
   std::copy(par.NeighbourMaxDeltaCurvature, par.NeighbourMaxDeltaCurvature + tmpNeighbourMaxDeltaCurvature.size(), tmpNeighbourMaxDeltaCurvature.begin());
-  std::array<float, Constants::its::CellsPerRoad - 1> tmpNeighbourMaxDeltaN;
+  std::array<float, constants::its::CellsPerRoad - 1> tmpNeighbourMaxDeltaN;
   std::copy(par.NeighbourMaxDeltaN, par.NeighbourMaxDeltaN + tmpNeighbourMaxDeltaN.size(), tmpNeighbourMaxDeltaN.begin());
   j = nlohmann::json{
     { "ClusterSharing", par.ClusterSharing },
@@ -289,23 +289,23 @@ void from_json(const nlohmann::json& j, TrackingParameters& par)
   par.TrackletMaxDeltaPhi = j.at("TrackletMaxDeltaPhi").get<float>();
   par.CellMaxDeltaTanLambda = j.at("CellMaxDeltaTanLambda").get<float>();
   par.CellMaxDeltaPhi = j.at("CellMaxDeltaPhi").get<float>();
-  auto tmpTrackletMaxDeltaZ = j.at("TrackletMaxDeltaZ").get<std::array<float, Constants::its::TrackletsPerRoad>>();
+  auto tmpTrackletMaxDeltaZ = j.at("TrackletMaxDeltaZ").get<std::array<float, constants::its::TrackletsPerRoad>>();
   std::copy(tmpTrackletMaxDeltaZ.begin(), tmpTrackletMaxDeltaZ.end(), par.TrackletMaxDeltaZ);
-  auto tmpCellMaxDCA = j.at("CellMaxDCA").get<std::array<float, Constants::its::CellsPerRoad>>();
+  auto tmpCellMaxDCA = j.at("CellMaxDCA").get<std::array<float, constants::its::CellsPerRoad>>();
   std::copy(tmpCellMaxDCA.begin(), tmpCellMaxDCA.end(), par.CellMaxDCA);
-  auto tmpCellMaxDeltaZ = j.at("CellMaxDeltaZ").get<std::array<float, Constants::its::CellsPerRoad>>();
+  auto tmpCellMaxDeltaZ = j.at("CellMaxDeltaZ").get<std::array<float, constants::its::CellsPerRoad>>();
   std::copy(tmpCellMaxDCA.begin(), tmpCellMaxDeltaZ.end(), par.CellMaxDeltaZ);
-  auto tmpNeighbourMaxDeltaCurvature = j.at("NeighbourMaxDeltaCurvature").get<std::array<float, Constants::its::CellsPerRoad - 1>>();
+  auto tmpNeighbourMaxDeltaCurvature = j.at("NeighbourMaxDeltaCurvature").get<std::array<float, constants::its::CellsPerRoad - 1>>();
   std::copy(tmpNeighbourMaxDeltaCurvature.begin(), tmpNeighbourMaxDeltaCurvature.end(), par.NeighbourMaxDeltaCurvature);
-  auto tmpNeighbourMaxDeltaN = j.at("NeighbourMaxDeltaN").get<std::array<float, Constants::its::CellsPerRoad - 1>>();
+  auto tmpNeighbourMaxDeltaN = j.at("NeighbourMaxDeltaN").get<std::array<float, constants::its::CellsPerRoad - 1>>();
   std::copy(tmpNeighbourMaxDeltaN.begin(), tmpNeighbourMaxDeltaN.end(), par.NeighbourMaxDeltaN);
 }
 
 void to_json(nlohmann::json& j, const MemoryParameters& par)
 {
-  std::array<float, Constants::its::CellsPerRoad> tmpCellsMemoryCoefficients;
+  std::array<float, constants::its::CellsPerRoad> tmpCellsMemoryCoefficients;
   std::copy(par.CellsMemoryCoefficients, par.CellsMemoryCoefficients + tmpCellsMemoryCoefficients.size(), tmpCellsMemoryCoefficients.begin());
-  std::array<float, Constants::its::TrackletsPerRoad> tmpTrackletsMemoryCoefficients;
+  std::array<float, constants::its::TrackletsPerRoad> tmpTrackletsMemoryCoefficients;
   std::copy(par.TrackletsMemoryCoefficients, par.TrackletsMemoryCoefficients + tmpTrackletsMemoryCoefficients.size(), tmpTrackletsMemoryCoefficients.begin());
   j = nlohmann::json{
     { "MemoryOffset", par.MemoryOffset },
@@ -317,9 +317,9 @@ void to_json(nlohmann::json& j, const MemoryParameters& par)
 void from_json(const nlohmann::json& j, MemoryParameters& par)
 {
   par.MemoryOffset = j.at("MemoryOffset").get<int>();
-  auto tmpCellsMemoryCoefficients = j.at("CellsMemoryCoefficients").get<std::array<float, Constants::its::CellsPerRoad>>();
+  auto tmpCellsMemoryCoefficients = j.at("CellsMemoryCoefficients").get<std::array<float, constants::its::CellsPerRoad>>();
   std::copy(tmpCellsMemoryCoefficients.begin(), tmpCellsMemoryCoefficients.end(), par.CellsMemoryCoefficients);
-  auto tmpTrackletsMemoryCoefficients = j.at("TrackletsMemoryCoefficients").get<std::array<float, Constants::its::TrackletsPerRoad>>();
+  auto tmpTrackletsMemoryCoefficients = j.at("TrackletsMemoryCoefficients").get<std::array<float, constants::its::TrackletsPerRoad>>();
   std::copy(tmpTrackletsMemoryCoefficients.begin(), tmpTrackletsMemoryCoefficients.end(), par.TrackletsMemoryCoefficients);
 }
 

--- a/Detectors/ITSMFT/ITS/tracking/src/PrimaryVertexContext.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/PrimaryVertexContext.cxx
@@ -21,12 +21,12 @@ namespace o2
 namespace its
 {
 
-void PrimaryVertexContext::initialise(const MemoryParameters& memParam, const std::array<std::vector<Cluster>, Constants::its::LayersNumber>& cl,
+void PrimaryVertexContext::initialise(const MemoryParameters& memParam, const std::array<std::vector<Cluster>, constants::its::LayersNumber>& cl,
                                       const std::array<float, 3>& pVtx, const int iteration)
 {
   mPrimaryVertex = { pVtx[0], pVtx[1], pVtx[2] };
 
-  for (int iLayer{ 0 }; iLayer < Constants::its::LayersNumber; ++iLayer) {
+  for (int iLayer{ 0 }; iLayer < constants::its::LayersNumber; ++iLayer) {
 
     const auto& currentLayer{ cl[iLayer] };
     const int clustersNum{ static_cast<int>(currentLayer.size()) };
@@ -48,7 +48,7 @@ void PrimaryVertexContext::initialise(const MemoryParameters& memParam, const st
       });
     }
 
-    if (iLayer < Constants::its::CellsPerRoad) {
+    if (iLayer < constants::its::CellsPerRoad) {
 
       mCells[iLayer].clear();
       float cellsMemorySize =
@@ -62,7 +62,7 @@ void PrimaryVertexContext::initialise(const MemoryParameters& memParam, const st
       }
     }
 
-    if (iLayer < Constants::its::CellsPerRoad - 1) {
+    if (iLayer < constants::its::CellsPerRoad - 1) {
 
       mCellsLookupTable[iLayer].clear();
       mCellsLookupTable[iLayer].resize(
@@ -70,7 +70,7 @@ void PrimaryVertexContext::initialise(const MemoryParameters& memParam, const st
           std::ceil((memParam.TrackletsMemoryCoefficients[iLayer + 1] *
                      cl[iLayer + 1].size()) *
                     cl[iLayer + 2].size()),
-        Constants::its::UnusedIndex);
+        constants::its::UnusedIndex);
 
       mCellsNeighbours[iLayer].clear();
     }
@@ -78,7 +78,7 @@ void PrimaryVertexContext::initialise(const MemoryParameters& memParam, const st
 
   mRoads.clear();
 
-  for (int iLayer{ 0 }; iLayer < Constants::its::LayersNumber; ++iLayer) {
+  for (int iLayer{ 0 }; iLayer < constants::its::LayersNumber; ++iLayer) {
 
     const int clustersNum = static_cast<int>(mClusters[iLayer].size());
 
@@ -107,7 +107,7 @@ void PrimaryVertexContext::initialise(const MemoryParameters& memParam, const st
       }
     }
 
-    if (iLayer < Constants::its::TrackletsPerRoad) {
+    if (iLayer < constants::its::TrackletsPerRoad) {
 
       mTracklets[iLayer].clear();
 
@@ -121,10 +121,10 @@ void PrimaryVertexContext::initialise(const MemoryParameters& memParam, const st
       }
     }
 
-    if (iLayer < Constants::its::CellsPerRoad) {
+    if (iLayer < constants::its::CellsPerRoad) {
 
       mTrackletsLookupTable[iLayer].clear();
-      mTrackletsLookupTable[iLayer].resize(cl[iLayer + 1].size(), Constants::its::UnusedIndex);
+      mTrackletsLookupTable[iLayer].resize(cl[iLayer + 1].size(), constants::its::UnusedIndex);
     }
   }
 }

--- a/Detectors/ITSMFT/ITS/tracking/src/Road.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Road.cxx
@@ -25,15 +25,15 @@ Road::Road(int cellLayer, int cellId) : Road() { addCell(cellLayer, cellId); }
 
 void Road::resetRoad()
 {
-  for (int i = 0; i < Constants::its::CellsPerRoad; i++) {
-    mCellIds[i] = Constants::its::UnusedIndex;
+  for (int i = 0; i < constants::its::CellsPerRoad; i++) {
+    mCellIds[i] = constants::its::UnusedIndex;
   }
   mRoadSize = 0;
 }
 
 void Road::addCell(int cellLayer, int cellId)
 {
-  if (mCellIds[cellLayer] == Constants::its::UnusedIndex) {
+  if (mCellIds[cellLayer] == constants::its::UnusedIndex) {
     ++mRoadSize;
   }
 

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -69,7 +69,7 @@ void Tracker::clustersToTracks(const ROframe& event, std::ostream& timeBenchmark
       total += evaluateTask(&Tracker::findTracks, "Track finding", timeBenchmarkOutputStream, event);
     }
 
-    if (Constants::DoTimeBenchmarks)
+    if (constants::DoTimeBenchmarks)
       timeBenchmarkOutputStream << std::setw(2) << " - "
                                 << "Vertex processing completed in: " << total << "ms" << std::endl;
   }
@@ -88,7 +88,7 @@ void Tracker::computeCells()
 
 void Tracker::findCellsNeighbours(int& iteration)
 {
-  for (int iLayer{ 0 }; iLayer < Constants::its::CellsPerRoad - 1; ++iLayer) {
+  for (int iLayer{ 0 }; iLayer < constants::its::CellsPerRoad - 1; ++iLayer) {
 
     if (mPrimaryVertexContext->getCells()[iLayer + 1].empty() ||
         mPrimaryVertexContext->getCellsLookupTable()[iLayer].empty()) {
@@ -102,7 +102,7 @@ void Tracker::findCellsNeighbours(int& iteration)
       const Cell& currentCell{ mPrimaryVertexContext->getCells()[iLayer][iCell] };
       const int nextLayerTrackletIndex{ currentCell.getSecondTrackletIndex() };
       const int nextLayerFirstCellIndex{ mPrimaryVertexContext->getCellsLookupTable()[iLayer][nextLayerTrackletIndex] };
-      if (nextLayerFirstCellIndex != Constants::its::UnusedIndex &&
+      if (nextLayerFirstCellIndex != constants::its::UnusedIndex &&
           mPrimaryVertexContext->getCells()[iLayer + 1][nextLayerFirstCellIndex].getFirstTrackletIndex() ==
             nextLayerTrackletIndex) {
 
@@ -147,11 +147,11 @@ void Tracker::findCellsNeighbours(int& iteration)
 
 void Tracker::findRoads(int& iteration)
 {
-  for (int iLevel{ Constants::its::CellsPerRoad }; iLevel >= mTrkParams[iteration].CellMinimumLevel(); --iLevel) {
+  for (int iLevel{ constants::its::CellsPerRoad }; iLevel >= mTrkParams[iteration].CellMinimumLevel(); --iLevel) {
     CA_DEBUGGER(int nRoads = -mPrimaryVertexContext->getRoads().size());
     const int minimumLevel{ iLevel - 1 };
 
-    for (int iLayer{ Constants::its::CellsPerRoad - 1 }; iLayer >= minimumLevel; --iLayer) {
+    for (int iLayer{ constants::its::CellsPerRoad - 1 }; iLayer >= minimumLevel; --iLayer) {
 
       const int levelCellsNum{ static_cast<int>(mPrimaryVertexContext->getCells()[iLayer].size()) };
 
@@ -216,13 +216,13 @@ void Tracker::findTracks(const ROframe& event)
 #endif
 
   for (auto& road : mPrimaryVertexContext->getRoads()) {
-    std::array<int, 7> clusters{ Constants::its::UnusedIndex, Constants::its::UnusedIndex, Constants::its::UnusedIndex, Constants::its::UnusedIndex, Constants::its::UnusedIndex, Constants::its::UnusedIndex, Constants::its::UnusedIndex };
-    int lastCellLevel = Constants::its::UnusedIndex;
+    std::array<int, 7> clusters{ constants::its::UnusedIndex, constants::its::UnusedIndex, constants::its::UnusedIndex, constants::its::UnusedIndex, constants::its::UnusedIndex, constants::its::UnusedIndex, constants::its::UnusedIndex };
+    int lastCellLevel = constants::its::UnusedIndex;
     CA_DEBUGGER(int nClusters = 2);
 
-    for (int iCell{ 0 }; iCell < Constants::its::CellsPerRoad; ++iCell) {
+    for (int iCell{ 0 }; iCell < constants::its::CellsPerRoad; ++iCell) {
       const int cellIndex = road[iCell];
-      if (cellIndex == Constants::its::UnusedIndex) {
+      if (cellIndex == constants::its::UnusedIndex) {
         continue;
       } else {
         clusters[iCell] = mPrimaryVertexContext->getCells()[iCell][cellIndex].getFirstClusterIndex();
@@ -239,12 +239,12 @@ void Tracker::findTracks(const ROframe& event)
     assert(nClusters >= mTrkParams[0].MinTrackLength);
     CA_DEBUGGER(roadCounters[nClusters - 4]++);
 
-    if (lastCellLevel == Constants::its::UnusedIndex)
+    if (lastCellLevel == constants::its::UnusedIndex)
       continue;
 
     /// From primary vertex context index to event index (== the one used as input of the tracking code)
     for (int iC{ 0 }; iC < clusters.size(); iC++) {
-      if (clusters[iC] != Constants::its::UnusedIndex) {
+      if (clusters[iC] != constants::its::UnusedIndex) {
         clusters[iC] = mPrimaryVertexContext->getClusters()[iC][clusters[iC]].clusterId;
       }
     }
@@ -258,20 +258,20 @@ void Tracker::findTracks(const ROframe& event)
     /// FIXME!
     TrackITS temporaryTrack{ buildTrackSeed(cluster1_glo, cluster2_glo, cluster3_glo, cluster3_tf) };
     for (size_t iC = 0; iC < clusters.size(); ++iC) {
-      temporaryTrack.setExternalClusterIndex(iC, clusters[iC], clusters[iC] != Constants::its::UnusedIndex);
+      temporaryTrack.setExternalClusterIndex(iC, clusters[iC], clusters[iC] != constants::its::UnusedIndex);
     }
-    bool fitSuccess = fitTrack(event, temporaryTrack, Constants::its::LayersNumber - 4, -1, -1);
+    bool fitSuccess = fitTrack(event, temporaryTrack, constants::its::LayersNumber - 4, -1, -1);
     if (!fitSuccess)
       continue;
     CA_DEBUGGER(fitCounters[nClusters - 4]++);
     temporaryTrack.resetCovariance();
-    fitSuccess = fitTrack(event, temporaryTrack, 0, Constants::its::LayersNumber, 1);
+    fitSuccess = fitTrack(event, temporaryTrack, 0, constants::its::LayersNumber, 1);
     if (!fitSuccess)
       continue;
     CA_DEBUGGER(backpropagatedCounters[nClusters - 4]++);
     temporaryTrack.getParamOut() = temporaryTrack;
     temporaryTrack.resetCovariance();
-    fitSuccess = fitTrack(event, temporaryTrack, Constants::its::LayersNumber - 1, -1, -1);
+    fitSuccess = fitTrack(event, temporaryTrack, constants::its::LayersNumber - 1, -1, -1);
     if (!fitSuccess)
       continue;
     CA_DEBUGGER(refitCounters[nClusters - 4]++);
@@ -297,8 +297,8 @@ void Tracker::findTracks(const ROframe& event)
   for (auto& track : tracks) {
     CA_DEBUGGER(int nClusters = 0);
     int nShared = 0;
-    for (int iLayer{ 0 }; iLayer < Constants::its::LayersNumber; ++iLayer) {
-      if (track.getClusterIndex(iLayer) == Constants::its::UnusedIndex) {
+    for (int iLayer{ 0 }; iLayer < constants::its::LayersNumber; ++iLayer) {
+      if (track.getClusterIndex(iLayer) == constants::its::UnusedIndex) {
         continue;
       }
       nShared += int(mPrimaryVertexContext->isClusterUsed(iLayer, track.getClusterIndex(iLayer)));
@@ -322,8 +322,8 @@ void Tracker::findTracks(const ROframe& event)
     prevNclusters = nClusters;
 #endif
 
-    for (int iLayer{ 0 }; iLayer < Constants::its::LayersNumber; ++iLayer) {
-      if (track.getClusterIndex(iLayer) == Constants::its::UnusedIndex) {
+    for (int iLayer{ 0 }; iLayer < constants::its::LayersNumber; ++iLayer) {
+      if (track.getClusterIndex(iLayer) == constants::its::UnusedIndex) {
         continue;
       }
       mPrimaryVertexContext->markUsedCluster(iLayer, track.getClusterIndex(iLayer));
@@ -379,7 +379,7 @@ bool Tracker::fitTrack(const ROframe& event, TrackITS& track, int start, int end
 {
   track.setChi2(0);
   for (int iLayer{ start }; iLayer != end; iLayer += step) {
-    if (track.getClusterIndex(iLayer) == Constants::its::UnusedIndex) {
+    if (track.getClusterIndex(iLayer) == constants::its::UnusedIndex) {
       continue;
     }
     const TrackingFrameInfo& trackingHit = event.getTrackingFrameInfoOnLayer(iLayer).at(track.getClusterIndex(iLayer));
@@ -450,15 +450,15 @@ void Tracker::computeRoadsMClabels(const ROframe& event)
   for (int iRoad{ 0 }; iRoad < roadsNum; ++iRoad) {
 
     Road& currentRoad{ mPrimaryVertexContext->getRoads()[iRoad] };
-    int maxOccurrencesValue{ Constants::its::UnusedIndex };
+    int maxOccurrencesValue{ constants::its::UnusedIndex };
     int count{ 0 };
     bool isFakeRoad{ false };
     bool isFirstRoadCell{ true };
 
-    for (int iCell{ 0 }; iCell < Constants::its::CellsPerRoad; ++iCell) {
+    for (int iCell{ 0 }; iCell < constants::its::CellsPerRoad; ++iCell) {
       const int currentCellIndex{ currentRoad[iCell] };
 
-      if (currentCellIndex == Constants::its::UnusedIndex) {
+      if (currentCellIndex == constants::its::UnusedIndex) {
         if (isFirstRoadCell) {
           continue;
         } else {
@@ -524,14 +524,14 @@ void Tracker::computeTracksMClabels(const ROframe& event)
 
   for (TrackITS& track : mTracks) {
 
-    MCCompLabel maxOccurrencesValue{ Constants::its::UnusedIndex, Constants::its::UnusedIndex,
-                                     Constants::its::UnusedIndex };
+    MCCompLabel maxOccurrencesValue{ constants::its::UnusedIndex, constants::its::UnusedIndex,
+                                     constants::its::UnusedIndex };
     int count{ 0 };
     bool isFakeTrack{ false };
 
     for (int iCluster = 0; iCluster < TrackITS::MaxClusters; ++iCluster) {
       const int index = track.getClusterIndex(iCluster);
-      if (index == Constants::its::UnusedIndex) {
+      if (index == constants::its::UnusedIndex) {
         continue;
       }
 
@@ -584,15 +584,15 @@ track::TrackParCov Tracker::buildTrackSeed(const Cluster& cluster1, const Cluste
 
   const float fy = 1. / (cluster2.rCoordinate - cluster3.rCoordinate);
   const float& tz = fy;
-  const float cy = (MathUtils::computeCurvature(x1, y1, x2, y2 + Constants::its::Resolution, x3, y3) - crv) /
-                   (Constants::its::Resolution * getBz() * constants::math::B2C) *
+  const float cy = (MathUtils::computeCurvature(x1, y1, x2, y2 + constants::its::Resolution, x3, y3) - crv) /
+                   (constants::its::Resolution * getBz() * o2::constants::math::B2C) *
                    20.f; // FIXME: MS contribution to the cov[14] (*20 added)
-  constexpr float s2 = Constants::its::Resolution * Constants::its::Resolution;
+  constexpr float s2 = constants::its::Resolution * constants::its::Resolution;
 
   return track::TrackParCov(tf3.xTrackingFrame, tf3.alphaTrackingFrame,
                             { y3, z3, crv * (x3 - x0), 0.5f * (tgl12 + tgl23),
-                              std::abs(getBz()) < constants::math::Almost0 ? constants::math::Almost0
-                                                                           : crv / (getBz() * constants::math::B2C) },
+                              std::abs(getBz()) < o2::constants::math::Almost0 ? o2::constants::math::Almost0
+                                                                           : crv / (getBz() * o2::constants::math::B2C) },
                             { s2, 0.f, s2, s2 * fy, 0.f, s2 * fy * fy, 0.f, s2 * tz, 0.f, s2 * tz * tz, s2 * cy, 0.f,
                               s2 * fy * cy, 0.f, s2 * cy * cy });
 }

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackerTraitsCPU.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackerTraitsCPU.cxx
@@ -32,7 +32,7 @@ namespace its
 void TrackerTraitsCPU::computeLayerTracklets()
 {
   PrimaryVertexContext* primaryVertexContext = mPrimaryVertexContext;
-  for (int iLayer{ 0 }; iLayer < Constants::its::TrackletsPerRoad; ++iLayer) {
+  for (int iLayer{ 0 }; iLayer < constants::its::TrackletsPerRoad; ++iLayer) {
     if (primaryVertexContext->getClusters()[iLayer].empty() || primaryVertexContext->getClusters()[iLayer + 1].empty()) {
       return;
     }
@@ -44,7 +44,7 @@ void TrackerTraitsCPU::computeLayerTracklets()
       const Cluster& currentCluster{ primaryVertexContext->getClusters()[iLayer][iCluster] };
 
       const float tanLambda{ (currentCluster.zCoordinate - primaryVertex.z) / currentCluster.rCoordinate };
-      const float directionZIntersection{ tanLambda * (Constants::its::LayersRCoordinate()[iLayer + 1] -
+      const float directionZIntersection{ tanLambda * (constants::its::LayersRCoordinate()[iLayer + 1] -
                                                        currentCluster.rCoordinate) +
                                           currentCluster.zCoordinate };
 
@@ -58,11 +58,11 @@ void TrackerTraitsCPU::computeLayerTracklets()
       int phiBinsNum{ selectedBinsRect.w - selectedBinsRect.y + 1 };
 
       if (phiBinsNum < 0) {
-        phiBinsNum += Constants::IndexTable::PhiBins;
+        phiBinsNum += constants::IndexTable::PhiBins;
       }
 
       for (int iPhiBin{ selectedBinsRect.y }, iPhiCount{ 0 }; iPhiCount < phiBinsNum;
-           iPhiBin = ++iPhiBin == Constants::IndexTable::PhiBins ? 0 : iPhiBin, iPhiCount++) {
+           iPhiBin = ++iPhiBin == constants::IndexTable::PhiBins ? 0 : iPhiBin, iPhiCount++) {
 
         const int firstBinIndex{ IndexTableUtils::getBinIndex(selectedBinsRect.x, iPhiBin) };
         const int maxBinIndex{ firstBinIndex + selectedBinsRect.z - selectedBinsRect.x + 1 };
@@ -83,10 +83,10 @@ void TrackerTraitsCPU::computeLayerTracklets()
 
           if (deltaZ < mTrkParams.TrackletMaxDeltaZ[iLayer] &&
               (deltaPhi < mTrkParams.TrackletMaxDeltaPhi ||
-               MATH_ABS(deltaPhi - Constants::Math::TwoPi) < mTrkParams.TrackletMaxDeltaPhi)) {
+               MATH_ABS(deltaPhi - constants::Math::TwoPi) < mTrkParams.TrackletMaxDeltaPhi)) {
 
             if (iLayer > 0 &&
-                primaryVertexContext->getTrackletsLookupTable()[iLayer - 1][iCluster] == Constants::its::UnusedIndex) {
+                primaryVertexContext->getTrackletsLookupTable()[iLayer - 1][iCluster] == constants::its::UnusedIndex) {
 
               primaryVertexContext->getTrackletsLookupTable()[iLayer - 1][iCluster] =
                 primaryVertexContext->getTracklets()[iLayer].size();
@@ -104,7 +104,7 @@ void TrackerTraitsCPU::computeLayerTracklets()
 void TrackerTraitsCPU::computeLayerCells()
 {
   PrimaryVertexContext* primaryVertexContext = mPrimaryVertexContext;
-  for (int iLayer{ 0 }; iLayer < Constants::its::CellsPerRoad; ++iLayer) {
+  for (int iLayer{ 0 }; iLayer < constants::its::CellsPerRoad; ++iLayer) {
 
     if (primaryVertexContext->getTracklets()[iLayer + 1].empty() ||
         primaryVertexContext->getTracklets()[iLayer].empty()) {
@@ -123,7 +123,7 @@ void TrackerTraitsCPU::computeLayerCells()
         primaryVertexContext->getTrackletsLookupTable()[iLayer][nextLayerClusterIndex]
       };
 
-      if (nextLayerFirstTrackletIndex == Constants::its::UnusedIndex) {
+      if (nextLayerFirstTrackletIndex == constants::its::UnusedIndex) {
 
         continue;
       }
@@ -152,7 +152,7 @@ void TrackerTraitsCPU::computeLayerCells()
 
         if (deltaTanLambda < mTrkParams.CellMaxDeltaTanLambda &&
             (deltaPhi < mTrkParams.CellMaxDeltaPhi ||
-             std::abs(deltaPhi - Constants::Math::TwoPi) < mTrkParams.CellMaxDeltaPhi)) {
+             std::abs(deltaPhi - constants::Math::TwoPi) < mTrkParams.CellMaxDeltaPhi)) {
 
           const float averageTanLambda{ 0.5f * (currentTracklet.tanLambda + nextTracklet.tanLambda) };
           const float directionZIntersection{ -averageTanLambda * firstCellCluster.rCoordinate +
@@ -179,8 +179,8 @@ void TrackerTraitsCPU::computeLayerCells()
                                               cellPlaneNormalVector.y * cellPlaneNormalVector.y +
                                               cellPlaneNormalVector.z * cellPlaneNormalVector.z) };
 
-            if (vectorNorm < Constants::Math::FloatMinThreshold ||
-                std::abs(cellPlaneNormalVector.z) < Constants::Math::FloatMinThreshold) {
+            if (vectorNorm < constants::Math::FloatMinThreshold ||
+                std::abs(cellPlaneNormalVector.z) < constants::Math::FloatMinThreshold) {
 
               continue;
             }
@@ -209,7 +209,7 @@ void TrackerTraitsCPU::computeLayerCells()
 
             const float cellTrajectoryCurvature{ 1.0f / cellTrajectoryRadius };
             if (iLayer > 0 &&
-                primaryVertexContext->getCellsLookupTable()[iLayer - 1][iTracklet] == Constants::its::UnusedIndex) {
+                primaryVertexContext->getCellsLookupTable()[iLayer - 1][iTracklet] == constants::its::UnusedIndex) {
 
               primaryVertexContext->getCellsLookupTable()[iLayer - 1][iTracklet] =
                 primaryVertexContext->getCells()[iLayer].size();

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -26,11 +26,11 @@ namespace o2
 namespace its
 {
 
-using Constants::IndexTable::PhiBins;
-using Constants::IndexTable::ZBins;
-using Constants::its::LayersRCoordinate;
-using Constants::its::LayersZCoordinate;
-using Constants::Math::TwoPi;
+using constants::IndexTable::PhiBins;
+using constants::IndexTable::ZBins;
+using constants::its::LayersRCoordinate;
+using constants::its::LayersZCoordinate;
+using constants::Math::TwoPi;
 using IndexTableUtils::getZBinIndex;
 
 void trackleterKernelSerial(
@@ -129,15 +129,15 @@ VertexerTraits::VertexerTraits() : mAverageClustersRadii{ std::array<float, 3>{ 
                                    mMaxDirectorCosine3{ 0.f }
 {
   // CUDA does not allow for dynamic initialization -> no constructor for VertexingParams
-  mVrtParams.phiSpan = static_cast<int>(std::ceil(Constants::IndexTable::PhiBins * mVrtParams.phiCut /
-                                                  Constants::Math::TwoPi));
-  mVrtParams.zSpan = static_cast<int>(std::ceil(mVrtParams.zCut * Constants::IndexTable::InverseZBinSize()[0]));
+  mVrtParams.phiSpan = static_cast<int>(std::ceil(constants::IndexTable::PhiBins * mVrtParams.phiCut /
+                                                  constants::Math::TwoPi));
+  mVrtParams.zSpan = static_cast<int>(std::ceil(mVrtParams.zCut * constants::IndexTable::InverseZBinSize()[0]));
   setIsGPU(false);
 }
 
 void VertexerTraits::reset()
 {
-  for (int iLayer{ 0 }; iLayer < Constants::its::LayersNumberVertexer; ++iLayer) {
+  for (int iLayer{ 0 }; iLayer < constants::its::LayersNumberVertexer; ++iLayer) {
     mClusters[iLayer].clear();
     mIndexTables[iLayer].fill(0);
   }
@@ -162,7 +162,7 @@ std::vector<int> VertexerTraits::getMClabelsLayer(const int layer) const
 void VertexerTraits::arrangeClusters(ROframe* event)
 {
   mEvent = event;
-  for (int iLayer{ 0 }; iLayer < Constants::its::LayersNumberVertexer; ++iLayer) {
+  for (int iLayer{ 0 }; iLayer < constants::its::LayersNumberVertexer; ++iLayer) {
     const auto& currentLayer{ event->getClustersOnLayer(iLayer) };
     const size_t clustersNum{ currentLayer.size() };
     if (clustersNum > 0) {

--- a/GPU/GPUTracking/ITS/GPUITSFitterKernels.cxx
+++ b/GPU/GPUTracking/ITS/GPUITSFitterKernels.cxx
@@ -22,13 +22,14 @@
 #include "CommonConstants/MathConstants.h"
 
 using namespace GPUCA_NAMESPACE::gpu;
+using namespace o2::its::constants::its;
 using namespace o2::its;
 using namespace o2;
 
 GPUd() bool GPUITSFitterKernel::fitTrack(GPUITSFitter& Fitter, GPUTPCGMPropagator& prop, GPUITSTrack& track, int start, int end, int step)
 {
   for (int iLayer{ start }; iLayer != end; iLayer += step) {
-    if (track.mClusters[iLayer] == Constants::its::UnusedIndex) {
+    if (track.mClusters[iLayer] == UnusedIndex) {
       continue;
     }
     const TrackingFrameInfo& trackingHit = Fitter.trackingFrame()[iLayer][track.mClusters[iLayer]];
@@ -65,13 +66,13 @@ GPUd() void GPUITSFitterKernel::Thread<0>(int nBlocks, int nThreads, int iBlock,
 
   for (int iRoad = get_global_id(0); iRoad < Fitter.NumberOfRoads(); iRoad += get_global_size(0)) {
     Road& road = Fitter.roads()[iRoad];
-    int clusters[7] = { Constants::its::UnusedIndex, Constants::its::UnusedIndex, Constants::its::UnusedIndex, Constants::its::UnusedIndex, Constants::its::UnusedIndex, Constants::its::UnusedIndex, Constants::its::UnusedIndex };
-    int lastCellLevel = Constants::its::UnusedIndex;
+    int clusters[7] = { UnusedIndex, UnusedIndex, UnusedIndex, UnusedIndex, UnusedIndex, UnusedIndex, UnusedIndex };
+    int lastCellLevel = UnusedIndex;
     CA_DEBUGGER(int nClusters = 2);
 
-    for (int iCell{ 0 }; iCell < Constants::its::CellsPerRoad; ++iCell) {
+    for (int iCell{ 0 }; iCell < CellsPerRoad; ++iCell) {
       const int cellIndex = road[iCell];
-      if (cellIndex == Constants::its::UnusedIndex) {
+      if (cellIndex == UnusedIndex) {
         continue;
       } else {
         clusters[iCell] = Fitter.cells()[iCell][cellIndex].getFirstClusterIndex();
@@ -84,13 +85,13 @@ GPUd() void GPUITSFitterKernel::Thread<0>(int nBlocks, int nThreads, int iBlock,
 
     CA_DEBUGGER(roadCounters[nClusters - 4]++);
 
-    if (lastCellLevel == Constants::its::UnusedIndex) {
+    if (lastCellLevel == UnusedIndex) {
       continue;
     }
 
     /// From primary vertex context index to event index (== the one used as input of the tracking code)
     for (int iC{ 0 }; iC < 7; iC++) {
-      if (clusters[iC] != Constants::its::UnusedIndex) {
+      if (clusters[iC] != UnusedIndex) {
         clusters[iC] = Fitter.clusters()[iC][clusters[iC]].clusterId;
       }
     }
@@ -121,8 +122,8 @@ GPUd() void GPUITSFitterKernel::Thread<0>(int nBlocks, int nThreads, int iBlock,
       const float r3 = CAMath::Sqrt(cluster3.xCoordinate * cluster3.xCoordinate + cluster3.yCoordinate * cluster3.yCoordinate);
       const float fy = 1. / (r2 - r3);
       const float& tz = fy;
-      const float cy = (MathUtils::computeCurvature(x1, y1, x2, y2 + Constants::its::Resolution, x3, y3) - crv) / (Constants::its::Resolution * bz * constants::math::B2C) * 20.f; // FIXME: MS contribution to the cov[14] (*20 added)
-      constexpr float s2 = Constants::its::Resolution * Constants::its::Resolution;
+      const float cy = (MathUtils::computeCurvature(x1, y1, x2, y2 + Resolution, x3, y3) - crv) / (Resolution * bz * constants::math::B2C) * 20.f; // FIXME: MS contribution to the cov[14] (*20 added)
+      constexpr float s2 = Resolution * Resolution;
 
       temporaryTrack.X() = cluster3.xTrackingFrame;
       temporaryTrack.Y() = y3;
@@ -155,13 +156,13 @@ GPUd() void GPUITSFitterKernel::Thread<0>(int nBlocks, int nThreads, int iBlock,
     for (size_t iC = 0; iC < 7; ++iC) {
       temporaryTrack.mClusters[iC] = clusters[iC];
     }
-    bool fitSuccess = fitTrack(Fitter, prop, temporaryTrack, Constants::its::LayersNumber - 4, -1, -1);
+    bool fitSuccess = fitTrack(Fitter, prop, temporaryTrack, LayersNumber - 4, -1, -1);
     if (!fitSuccess) {
       continue;
     }
     CA_DEBUGGER(fitCounters[nClusters - 4]++);
     temporaryTrack.ResetCovariance();
-    fitSuccess = fitTrack(Fitter, prop, temporaryTrack, 0, Constants::its::LayersNumber, 1);
+    fitSuccess = fitTrack(Fitter, prop, temporaryTrack, 0, LayersNumber, 1);
     if (!fitSuccess) {
       continue;
     }
@@ -175,7 +176,7 @@ GPUd() void GPUITSFitterKernel::Thread<0>(int nBlocks, int nThreads, int iBlock,
     temporaryTrack.mOuterParam.X = temporaryTrack.X();
     temporaryTrack.mOuterParam.alpha = prop.GetAlpha();
     temporaryTrack.ResetCovariance();
-    fitSuccess = fitTrack(Fitter, prop, temporaryTrack, Constants::its::LayersNumber - 1, -1, -1);
+    fitSuccess = fitTrack(Fitter, prop, temporaryTrack, LayersNumber - 1, -1, -1);
     if (!fitSuccess) {
       continue;
     }


### PR DESCRIPTION
`GPU/GPUTracking/ITS/GPUITSFitterKernels.cxx` file required manual intervention, because it was using  `constants::its::UnusedIndex` etc. and the name `constants`, after the fix, became resolving as `o2::constants`, not `o2::its::constants`, which caused compilation errors, because there is no `o2::constants::its`. Make sure you agree with the way this was fixed.