### PR TITLE
Fix namespace naming: o2::header::LHCClockParameter

### DIFF
--- a/DataFormats/Headers/include/Headers/TimeStamp.h
+++ b/DataFormats/Headers/include/Headers/TimeStamp.h
@@ -28,7 +28,7 @@ namespace header {
 // https://lhc-machine-outreach.web.cern.ch/lhc-machine-outreach/collisions.htm
 // https://www.lhc-closer.es/taking_a_closer_look_at_lhc/0.buckets_and_bunches
 
-namespace LHCClockParameter {
+namespace lhc_clock_parameter {
   // number of bunches and the 40 MHz clock with 25 ns bunch spacing
   // gives revolution time of 89.1 us and 11.223345 kHz
   // this depends on the assumption that the particles are moving effectively
@@ -73,7 +73,7 @@ namespace LHCClockParameter {
 // - need run start to calculate the epoch
 // - based on revolution frequency and number of bunches
 // TODO: the reference time is probably the start of the fill
-template <typename RefTimePoint, typename Precision = LHCClockParameter::OrbitPrecision>
+template <typename RefTimePoint, typename Precision = lhc_clock_parameter::OrbitPrecision>
 class LHCClock {
 public:
   LHCClock(const RefTimePoint& start) : mReference(start) {}
@@ -83,8 +83,8 @@ public:
   LHCClock(const LHCClock&) = default;
   LHCClock& operator=(const LHCClock&) = default;
 
-  using rep = typename LHCClockParameter::Property<Precision>::rep;
-  using period = typename LHCClockParameter::Property<Precision>::period;
+  using rep = typename lhc_clock_parameter::Property<Precision>::rep;
+  using period = typename lhc_clock_parameter::Property<Precision>::period;
   using duration = std::chrono::duration<rep, period>;
   using time_point = std::chrono::time_point<LHCClock>;
   // this follows the naming convention of std chrono
@@ -104,8 +104,8 @@ private:
 };
 
 // TODO: is it correct to define this types always relative to the system clock?
-using LHCOrbitClock = LHCClock<std::chrono::system_clock::time_point, LHCClockParameter::OrbitPrecision>;
-using LHCBunchClock = LHCClock<std::chrono::system_clock::time_point, LHCClockParameter::BunchPrecision>;
+using LHCOrbitClock = LHCClock<std::chrono::system_clock::time_point, lhc_clock_parameter::OrbitPrecision>;
+using LHCBunchClock = LHCClock<std::chrono::system_clock::time_point, lhc_clock_parameter::BunchPrecision>;
 
 class TimeStamp
 {

--- a/DataFormats/Headers/test/testTimeStamp.cxx
+++ b/DataFormats/Headers/test/testTimeStamp.cxx
@@ -38,7 +38,7 @@ namespace o2 {
 
       // duration comparison
       LHCOrbitClock::duration fourOrbits(4);
-      BOOST_CHECK(fourOrbits == std::chrono::nanoseconds(4 * LHCClockParameter::gOrbitTimeNanoSec));
+      BOOST_CHECK(fourOrbits == std::chrono::nanoseconds(4 * lhc_clock_parameter::gOrbitTimeNanoSec));
     }
 
     BOOST_AUTO_TEST_CASE(TimeStamp_test)
@@ -83,7 +83,7 @@ namespace o2 {
       // check conversion of the us value to LHCClock
       auto timeInOrbitPrecision = timestamp.get<LHCOrbitClock>();
       auto timeInBunchPrecision = timestamp.get<LHCBunchClock>();
-      uint64_t expectedOrbits = tenSeconds * 1000 / (LHCClockParameter::gNumberOfBunches * LHCClockParameter::gBunchSpacingNanoSec);
+      uint64_t expectedOrbits = tenSeconds * 1000 / (lhc_clock_parameter::gNumberOfBunches * lhc_clock_parameter::gBunchSpacingNanoSec);
       BOOST_CHECK(timeInOrbitPrecision.count() == expectedOrbits);
 
       // conversion in orbit precision ignores bunches


### PR DESCRIPTION
Was renamed to `lhc_clock_parameter`, whilst the tool suggests `lhcclock_parameter`.