### PR TITLE
DPL: Fix timers

### DIFF
--- a/Framework/Core/include/Framework/ExpirationHandler.h
+++ b/Framework/Core/include/Framework/ExpirationHandler.h
@@ -23,9 +23,10 @@ namespace framework
 struct PartRef;
 struct ServiceRegistry;
 struct TimesliceIndex;
+struct TimesliceSlot;
 
 struct ExpirationHandler {
-  using Creator = std::function<void(TimesliceIndex&)>;
+  using Creator = std::function<TimesliceSlot(TimesliceIndex&)>;
   using Checker = std::function<bool(uint64_t timestamp)>;
   using Handler = std::function<void(ServiceRegistry&, PartRef& expiredInput, uint64_t timestamp)>;
 

--- a/Framework/Core/src/DataRelayer.cxx
+++ b/Framework/Core/src/DataRelayer.cxx
@@ -116,8 +116,9 @@ void DataRelayer::processDanglingInputs(std::vector<ExpirationHandler> const& ex
                                         ServiceRegistry& services)
 {
   // Create any slot for the time based fields
+  std::vector<TimesliceSlot> slotsCreatedByHandlers(expirationHandlers.size());
   for (size_t hi = 0; hi < expirationHandlers.size(); ++hi) {
-    expirationHandlers[hi].creator(mTimesliceIndex);
+    slotsCreatedByHandlers[hi] = expirationHandlers[hi].creator(mTimesliceIndex);
   }
   // Expire the records as needed.
   for (size_t ti = 0; ti < mTimesliceIndex.size(); ++ti) {
@@ -138,6 +139,9 @@ void DataRelayer::processDanglingInputs(std::vector<ExpirationHandler> const& ex
         continue;
       }
       if (!expirator.checker) {
+        continue;
+      }
+      if (slotsCreatedByHandlers[mDistinctRoutesIndex[ri]].index != slot.index) {
         continue;
       }
       if (expirator.checker(timestamp.value) == false) {

--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -113,9 +113,7 @@ struct ExpirationHandlerHelpers {
   static InputRoute::DanglingConfigurator danglingTimerConfigurator(InputSpec const& matcher)
   {
     return [matcher](ConfigParamRegistry const& options) {
-      std::string rateName = std::string{ "period-" } + matcher.binding;
-      auto period = options.get<int>(rateName.c_str());
-      return LifetimeHelpers::expireTimed(std::chrono::microseconds(period));
+      return LifetimeHelpers::expireAlways();
     };
   }
 

--- a/Framework/Core/src/LifetimeHelpers.cxx
+++ b/Framework/Core/src/LifetimeHelpers.cxx
@@ -73,7 +73,6 @@ ExpirationHandler::Creator LifetimeHelpers::timeDrivenCreation(std::chrono::micr
   auto last = std::make_shared<decltype(start)>(start);
   // FIXME: should create timeslices when period expires....
   return [last, period](TimesliceIndex& index) -> TimesliceSlot {
-
     // Nothing to do if the time has not expired yet.
     auto current = getCurrentTime();
     auto delta = current - *last;


### PR DESCRIPTION
This PR contains two fixes which make my timer use-case work. The problems and solutions are described in the commit messages.

I think that `test_DanglingInputs` will fail now, because timer messages will be created in slots which were booked by the timer mechanism, so we won't get any cache line completed, which is necessary to invoke the `ProcessCallback` there. Apparently, the test used to pass thanks to a bug ;)

@ktf What do you think? I am not advocating too much for this specific fixes if you have a better idea how to solve that.