### PR TITLE
Fix namespace naming: o2::its::...

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/cuda/include/ITStrackingCUDA/DeviceStoreNV.h
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/include/ITStrackingCUDA/DeviceStoreNV.h
@@ -44,7 +44,7 @@ class DeviceStoreNV final
                                           const std::array<std::vector<int>, constants::its::CellsPerRoad - 1>&);
   GPU_DEVICE const float3& getPrimaryVertex();
   GPU_HOST_DEVICE Array<Vector<Cluster>, constants::its::LayersNumber>& getClusters();
-  GPU_DEVICE Array<Array<int, constants::IndexTable::ZBins * constants::IndexTable::PhiBins + 1>,
+  GPU_DEVICE Array<Array<int, constants::index_table::ZBins * constants::index_table::PhiBins + 1>,
                    constants::its::TrackletsPerRoad>&
     getIndexTables();
   GPU_HOST_DEVICE Array<Vector<Tracklet>, constants::its::TrackletsPerRoad>& getTracklets();
@@ -58,7 +58,7 @@ class DeviceStoreNV final
  private:
   UniquePointer<float3> mPrimaryVertex;
   Array<Vector<Cluster>, constants::its::LayersNumber> mClusters;
-  Array<Array<int, constants::IndexTable::ZBins * constants::IndexTable::PhiBins + 1>, constants::its::TrackletsPerRoad>
+  Array<Array<int, constants::index_table::ZBins * constants::index_table::PhiBins + 1>, constants::its::TrackletsPerRoad>
     mIndexTables;
   Array<Vector<Tracklet>, constants::its::TrackletsPerRoad> mTracklets;
   Array<Vector<int>, constants::its::CellsPerRoad> mTrackletsLookupTable;
@@ -75,7 +75,7 @@ GPU_HOST_DEVICE inline Array<Vector<Cluster>, constants::its::LayersNumber>& Dev
   return mClusters;
 }
 
-GPU_DEVICE inline Array<Array<int, constants::IndexTable::ZBins * constants::IndexTable::PhiBins + 1>,
+GPU_DEVICE inline Array<Array<int, constants::index_table::ZBins * constants::index_table::PhiBins + 1>,
                         constants::its::TrackletsPerRoad>&
   DeviceStoreNV::getIndexTables()
 {

--- a/Detectors/ITSMFT/ITS/tracking/cuda/include/ITStrackingCUDA/VertexerTraitsGPU.h
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/include/ITStrackingCUDA/VertexerTraitsGPU.h
@@ -31,7 +31,7 @@ namespace its
 {
 class ROframe;
 
-using constants::IndexTable::InversePhiBinSize;
+using constants::index_table::InversePhiBinSize;
 
 class VertexerTraitsGPU : public VertexerTraits
 {
@@ -65,8 +65,8 @@ class VertexerTraitsGPU : public VertexerTraits
 inline GPU_DEVICE const int2 VertexerTraitsGPU::getBinsPhiRectWindow(const Cluster& currentCluster, float phiCut)
 {
   // This function returns the lowest PhiBin and the number of phi bins to be spanned, In the form int2{phiBinLow, PhiBinSpan}
-  const int phiBinMin{ IndexTableUtils::getPhiBinIndex(
-    MathUtils::getNormalizedPhiCoordinate(currentCluster.phiCoordinate - phiCut)) };
+  const int phiBinMin{ index_table_utils::getPhiBinIndex(
+    math_utils::getNormalizedPhiCoordinate(currentCluster.phiCoordinate - phiCut)) };
   const int phiBinSpan{ static_cast<int>(MATH_CEIL(phiCut * InversePhiBinSize)) };
   return int2{ phiBinMin, phiBinSpan };
 }

--- a/Detectors/ITSMFT/ITS/tracking/cuda/src/DeviceStoreNV.cu
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/src/DeviceStoreNV.cu
@@ -56,7 +56,7 @@ __device__ void fillIndexTables(GPU::DeviceStoreNV &primaryVertexContext, const 
 
     if (currentClusterIndex == nextLayerClustersNum - 1) {
 
-      for (int iBin{ currentBinIndex + 1 }; iBin <= o2::its::constants::IndexTable::ZBins * o2::its::constants::IndexTable::PhiBins;
+      for (int iBin{ currentBinIndex + 1 }; iBin <= o2::its::constants::index_table::ZBins * o2::its::constants::index_table::PhiBins;
            iBin++) {
 
         primaryVertexContext.getIndexTables()[layerIndex][iBin] = nextLayerClustersNum;

--- a/Detectors/ITSMFT/ITS/tracking/cuda/src/TrackerTraitsNV.cu
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/src/TrackerTraitsNV.cu
@@ -71,13 +71,13 @@ __device__ void computeLayerTracklets(DeviceStoreNV& devStore, const int layerIn
 
       if (phiBinsNum < 0) {
 
-        phiBinsNum += constants::IndexTable::PhiBins;
+        phiBinsNum += constants::index_table::PhiBins;
       }
 
       for (int iPhiBin{ selectedBinsRect.y }, iPhiCount{ 0 }; iPhiCount < phiBinsNum;
-           iPhiBin = ++iPhiBin == constants::IndexTable::PhiBins ? 0 : iPhiBin, iPhiCount++) {
+           iPhiBin = ++iPhiBin == constants::index_table::PhiBins ? 0 : iPhiBin, iPhiCount++) {
 
-        const int firstBinIndex { IndexTableUtils::getBinIndex(selectedBinsRect.x, iPhiBin) };
+        const int firstBinIndex{ index_table_utils::getBinIndex(selectedBinsRect.x, iPhiBin) };
         const int firstRowClusterIndex = devStore.getIndexTables()[layerIndex][firstBinIndex];
         const int maxRowClusterIndex = devStore.getIndexTables()[layerIndex][ { firstBinIndex
             + selectedBinsRect.z - selectedBinsRect.x + 1 }];
@@ -91,7 +91,7 @@ __device__ void computeLayerTracklets(DeviceStoreNV& devStore, const int layerIn
             tanLambda * (nextCluster.rCoordinate - currentCluster.rCoordinate) + currentCluster.zCoordinate - nextCluster.zCoordinate) };
           const float deltaPhi{ gpu::GPUCommonMath::Abs(currentCluster.phiCoordinate - nextCluster.phiCoordinate) };
 
-          if (deltaZ < kTrkPar.TrackletMaxDeltaZ[layerIndex] && (deltaPhi < kTrkPar.TrackletMaxDeltaPhi || gpu::GPUCommonMath::Abs(deltaPhi - constants::Math::TwoPi) < kTrkPar.TrackletMaxDeltaPhi)) {
+          if (deltaZ < kTrkPar.TrackletMaxDeltaZ[layerIndex] && (deltaPhi < kTrkPar.TrackletMaxDeltaPhi || gpu::GPUCommonMath::Abs(deltaPhi - constants::math::TwoPi) < kTrkPar.TrackletMaxDeltaPhi)) {
 
             cooperative_groups::coalesced_group threadGroup = cooperative_groups::coalesced_threads();
             int currentIndex{};
@@ -154,7 +154,7 @@ __device__ void computeLayerCells(DeviceStoreNV& devStore, const int layerIndex,
         const float deltaTanLambda{ gpu::GPUCommonMath::Abs(currentTracklet.tanLambda - nextTracklet.tanLambda) };
         const float deltaPhi{ gpu::GPUCommonMath::Abs(currentTracklet.phiCoordinate - nextTracklet.phiCoordinate) };
 
-        if (deltaTanLambda < kTrkPar.CellMaxDeltaTanLambda && (deltaPhi < kTrkPar.CellMaxDeltaPhi || gpu::GPUCommonMath::Abs(deltaPhi - constants::Math::TwoPi) < kTrkPar.CellMaxDeltaPhi)) {
+        if (deltaTanLambda < kTrkPar.CellMaxDeltaTanLambda && (deltaPhi < kTrkPar.CellMaxDeltaPhi || gpu::GPUCommonMath::Abs(deltaPhi - constants::math::TwoPi) < kTrkPar.CellMaxDeltaPhi)) {
 
           const float averageTanLambda { 0.5f * (currentTracklet.tanLambda + nextTracklet.tanLambda) };
           const float directionZIntersection { -averageTanLambda * firstCellCluster.rCoordinate
@@ -173,12 +173,12 @@ __device__ void computeLayerCells(DeviceStoreNV& devStore, const int layerIndex,
                 thirdCellCluster.yCoordinate - firstCellCluster.yCoordinate, thirdCellClusterQuadraticRCoordinate
                     - firstCellClusterQuadraticRCoordinate };
 
-            float3 cellPlaneNormalVector { MathUtils::crossProduct(firstDeltaVector, secondDeltaVector) };
+            float3 cellPlaneNormalVector{ math_utils::crossProduct(firstDeltaVector, secondDeltaVector) };
 
             const float vectorNorm{ gpu::GPUCommonMath::Sqrt(
               cellPlaneNormalVector.x * cellPlaneNormalVector.x + cellPlaneNormalVector.y * cellPlaneNormalVector.y + cellPlaneNormalVector.z * cellPlaneNormalVector.z) };
 
-            if (!(vectorNorm < constants::Math::FloatMinThreshold || gpu::GPUCommonMath::Abs(cellPlaneNormalVector.z) < constants::Math::FloatMinThreshold)) {
+            if (!(vectorNorm < constants::math::FloatMinThreshold || gpu::GPUCommonMath::Abs(cellPlaneNormalVector.z) < constants::math::FloatMinThreshold)) {
 
               const float inverseVectorNorm { 1.0f / vectorNorm };
               const float3 normalizedPlaneVector { cellPlaneNormalVector.x * inverseVectorNorm, cellPlaneNormalVector.y

--- a/Detectors/ITSMFT/ITS/tracking/cuda/src/VertexerTraitsGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/src/VertexerTraitsGPU.cu
@@ -37,14 +37,14 @@ namespace o2
 namespace its
 {
 
-using constants::IndexTable::PhiBins;
-using constants::IndexTable::ZBins;
+using constants::index_table::PhiBins;
+using constants::index_table::ZBins;
 using constants::its::LayersRCoordinate;
 using constants::its::LayersZCoordinate;
-using constants::Math::TwoPi;
-using IndexTableUtils::getPhiBinIndex;
-using IndexTableUtils::getZBinIndex;
-using MathUtils::getNormalizedPhiCoordinate;
+using constants::math::TwoPi;
+using index_table_utils::getPhiBinIndex;
+using index_table_utils::getZBinIndex;
+using math_utils::getNormalizedPhiCoordinate;
 
 VertexerTraitsGPU::VertexerTraitsGPU()
 {
@@ -116,7 +116,7 @@ GPU_GLOBAL void trackleterKernel(
           phiBinsNum += PhiBins;
         }
         for (int iPhiBin{ selectedBinsRect.y }, iPhiCount{ 0 }; iPhiCount < phiBinsNum; iPhiBin = ++iPhiBin == PhiBins ? 0 : iPhiBin, iPhiCount++) {
-          const int firstBinIndex{ IndexTableUtils::getBinIndex(selectedBinsRect.x, iPhiBin) };
+          const int firstBinIndex{ index_table_utils::getBinIndex(selectedBinsRect.x, iPhiBin) };
           const int firstRowClusterIndex{ indexTableNext[firstBinIndex] };
           const int maxRowClusterIndex{ indexTableNext[firstBinIndex + selectedBinsRect.z - selectedBinsRect.x + 1] };
           for (int iNextLayerCluster{ firstRowClusterIndex }; iNextLayerCluster <= maxRowClusterIndex && iNextLayerCluster < GPUclusterSizeNext; ++iNextLayerCluster) {

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
@@ -77,7 +77,7 @@ struct IndexTableParameters {
   void ComputeInverseBinSizes();
   int ZBins = 20;
   int PhiBins = 20;
-  float InversePhiBinSize = 20 / constants::Math::TwoPi;
+  float InversePhiBinSize = 20 / constants::math::TwoPi;
   std::array<float, constants::its::LayersNumber> InverseZBinSize;
 };
 
@@ -93,7 +93,7 @@ inline IndexTableParameters::IndexTableParameters()
 
 inline void IndexTableParameters::ComputeInverseBinSizes()
 {
-  InversePhiBinSize = PhiBins / constants::Math::TwoPi;
+  InversePhiBinSize = PhiBins / constants::math::TwoPi;
   for (int iL = 0; iL < constants::its::LayersNumber; ++iL) {
     InverseZBinSize[iL] = 0.5f * ZBins / constants::its::LayersZCoordinate()[iL];
   }

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Constants.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Constants.h
@@ -32,7 +32,7 @@ namespace constants
 
 constexpr bool DoTimeBenchmarks = true;
 
-namespace Math
+namespace math
 {
 constexpr float Pi{ 3.14159265359f };
 constexpr float TwoPi{ 2.0f * Pi };
@@ -59,11 +59,11 @@ GPU_HOST_DEVICE constexpr GPUArray<float, LayersNumber> LayersRCoordinate()
 }
 } // namespace its
 
-namespace IndexTable
+namespace index_table
 {
 constexpr int ZBins{ 20 };
 constexpr int PhiBins{ 20 };
-constexpr float InversePhiBinSize{ constants::IndexTable::PhiBins / constants::Math::TwoPi };
+constexpr float InversePhiBinSize{ constants::index_table::PhiBins / constants::math::TwoPi };
 GPU_HOST_DEVICE constexpr GPUArray<float, its::LayersNumber> InverseZBinSize()
 {
   return GPUArray<float, its::LayersNumber>{ { 0.5 * ZBins / 16.333f, 0.5 * ZBins / 16.333f, 0.5 * ZBins / 16.333f,
@@ -72,7 +72,7 @@ GPU_HOST_DEVICE constexpr GPUArray<float, its::LayersNumber> InverseZBinSize()
 }
 } // namespace IndexTable
 
-namespace PDGCodes
+namespace pdgcodes
 {
 constexpr int PionCode{ 211 };
 }

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/IOUtils.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/IOUtils.h
@@ -53,7 +53,7 @@ void from_json(const nlohmann::json& j, MemoryParameters& par);
 void to_json(nlohmann::json& j, const IndexTableParameters& par);
 void from_json(const nlohmann::json& j, IndexTableParameters& par);
 
-namespace IOUtils
+namespace ioutils
 {
 void loadConfigurations(const std::string&);
 std::vector<ROframe> loadEventData(const std::string&);

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/IndexTableUtils.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/IndexTableUtils.h
@@ -30,41 +30,41 @@ namespace o2
 namespace its
 {
 
-namespace IndexTableUtils
+namespace index_table_utils
 {
 float getInverseZBinSize(const int);
 GPU_HOST_DEVICE int getZBinIndex(const int, const float);
 GPU_HOST_DEVICE int getPhiBinIndex(const float);
 GPU_HOST_DEVICE int getBinIndex(const int, const int);
 GPU_HOST_DEVICE int countRowSelectedBins(
-  const GPUArray<int, constants::IndexTable::ZBins * constants::IndexTable::PhiBins + 1>&, const int, const int,
+  const GPUArray<int, constants::index_table::ZBins * constants::index_table::PhiBins + 1>&, const int, const int,
   const int);
 } // namespace IndexTableUtils
 
 inline float getInverseZCoordinate(const int layerIndex)
 {
-  return 0.5f * constants::IndexTable::ZBins / constants::its::LayersZCoordinate()[layerIndex];
+  return 0.5f * constants::index_table::ZBins / constants::its::LayersZCoordinate()[layerIndex];
 }
 
-GPU_HOST_DEVICE inline int IndexTableUtils::getZBinIndex(const int layerIndex, const float zCoordinate)
+GPU_HOST_DEVICE inline int index_table_utils::getZBinIndex(const int layerIndex, const float zCoordinate)
 {
   return (zCoordinate + constants::its::LayersZCoordinate()[layerIndex]) *
-         constants::IndexTable::InverseZBinSize()[layerIndex];
+         constants::index_table::InverseZBinSize()[layerIndex];
 }
 
-GPU_HOST_DEVICE inline int IndexTableUtils::getPhiBinIndex(const float currentPhi)
+GPU_HOST_DEVICE inline int index_table_utils::getPhiBinIndex(const float currentPhi)
 {
-  return (currentPhi * constants::IndexTable::InversePhiBinSize);
+  return (currentPhi * constants::index_table::InversePhiBinSize);
 }
 
-GPU_HOST_DEVICE inline int IndexTableUtils::getBinIndex(const int zIndex, const int phiIndex)
+GPU_HOST_DEVICE inline int index_table_utils::getBinIndex(const int zIndex, const int phiIndex)
 {
-  return gpu::GPUCommonMath::Min(phiIndex * constants::IndexTable::PhiBins + zIndex,
-                                 constants::IndexTable::ZBins * constants::IndexTable::PhiBins);
+  return gpu::GPUCommonMath::Min(phiIndex * constants::index_table::PhiBins + zIndex,
+                                 constants::index_table::ZBins * constants::index_table::PhiBins);
 }
 
-GPU_HOST_DEVICE inline int IndexTableUtils::countRowSelectedBins(
-  const GPUArray<int, constants::IndexTable::ZBins * constants::IndexTable::PhiBins + 1>& indexTable,
+GPU_HOST_DEVICE inline int index_table_utils::countRowSelectedBins(
+  const GPUArray<int, constants::index_table::ZBins * constants::index_table::PhiBins + 1>& indexTable,
   const int phiBinIndex, const int minZBinIndex, const int maxZBinIndex)
 {
   const int firstBinIndex{ getBinIndex(minZBinIndex, phiBinIndex) };

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/MathUtils.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/MathUtils.h
@@ -29,7 +29,7 @@ namespace o2
 namespace its
 {
 
-namespace MathUtils
+namespace math_utils
 {
 GPUhdni() float calculatePhiCoordinate(const float, const float);
 GPUhdni() float calculateRCoordinate(const float, const float);
@@ -41,24 +41,24 @@ GPUhdni() float computeTanDipAngle(float x1, float y1, float x2, float y2, float
 
 } // namespace MathUtils
 
-GPUhdi() float MathUtils::calculatePhiCoordinate(const float xCoordinate, const float yCoordinate)
+GPUhdi() float math_utils::calculatePhiCoordinate(const float xCoordinate, const float yCoordinate)
 {
-  return o2::gpu::CAMath::ATan2(-yCoordinate, -xCoordinate) + constants::Math::Pi;
+  return o2::gpu::CAMath::ATan2(-yCoordinate, -xCoordinate) + constants::math::Pi;
 }
 
-GPUhdi() float MathUtils::calculateRCoordinate(const float xCoordinate, const float yCoordinate)
+GPUhdi() float math_utils::calculateRCoordinate(const float xCoordinate, const float yCoordinate)
 {
   return o2::gpu::CAMath::Sqrt(xCoordinate * xCoordinate + yCoordinate * yCoordinate);
 }
 
-GPUhdi() constexpr float MathUtils::getNormalizedPhiCoordinate(const float phiCoordinate)
+GPUhdi() constexpr float math_utils::getNormalizedPhiCoordinate(const float phiCoordinate)
 {
   return (phiCoordinate < 0)
-           ? phiCoordinate + constants::Math::TwoPi
-           : (phiCoordinate > constants::Math::TwoPi) ? phiCoordinate - constants::Math::TwoPi : phiCoordinate;
+           ? phiCoordinate + constants::math::TwoPi
+           : (phiCoordinate > constants::math::TwoPi) ? phiCoordinate - constants::math::TwoPi : phiCoordinate;
 }
 
-GPUhdi() constexpr float3 MathUtils::crossProduct(const float3& firstVector, const float3& secondVector)
+GPUhdi() constexpr float3 math_utils::crossProduct(const float3& firstVector, const float3& secondVector)
 {
 
   return float3{ (firstVector.y * secondVector.z) - (firstVector.z * secondVector.y),
@@ -66,7 +66,7 @@ GPUhdi() constexpr float3 MathUtils::crossProduct(const float3& firstVector, con
                  (firstVector.x * secondVector.y) - (firstVector.y * secondVector.x) };
 }
 
-GPUhdi() float MathUtils::computeCurvature(float x1, float y1, float x2, float y2, float x3, float y3)
+GPUhdi() float math_utils::computeCurvature(float x1, float y1, float x2, float y2, float x3, float y3)
 {
   const float d = (x2 - x1) * (y3 - y2) - (x3 - x2) * (y2 - y1);
   const float a =
@@ -77,13 +77,13 @@ GPUhdi() float MathUtils::computeCurvature(float x1, float y1, float x2, float y
   return -1.f * d / o2::gpu::CAMath::Sqrt((d * x1 - a) * (d * x1 - a) + (d * y1 - b) * (d * y1 - b));
 }
 
-GPUhdi() float MathUtils::computeCurvatureCentreX(float x1, float y1, float x2, float y2, float x3, float y3)
+GPUhdi() float math_utils::computeCurvatureCentreX(float x1, float y1, float x2, float y2, float x3, float y3)
 {
   const float k1 = (y2 - y1) / (x2 - x1), k2 = (y3 - y2) / (x3 - x2);
   return 0.5f * (k1 * k2 * (y1 - y3) + k2 * (x1 + x2) - k1 * (x2 + x3)) / (k2 - k1);
 }
 
-GPUhdi() float MathUtils::computeTanDipAngle(float x1, float y1, float x2, float y2, float z1, float z2)
+GPUhdi() float math_utils::computeTanDipAngle(float x1, float y1, float x2, float y2, float z1, float z2)
 {
   return (z1 - z2) / o2::gpu::CAMath::Sqrt((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2));
 }

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/PrimaryVertexContext.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/PrimaryVertexContext.h
@@ -54,7 +54,7 @@ class PrimaryVertexContext
   bool isClusterUsed(int layer, int clusterId) const;
   void markUsedCluster(int layer, int clusterId);
 
-  std::array<std::array<int, constants::IndexTable::ZBins * constants::IndexTable::PhiBins + 1>,
+  std::array<std::array<int, constants::index_table::ZBins * constants::index_table::PhiBins + 1>,
              constants::its::TrackletsPerRoad>&
     getIndexTables();
   std::array<std::vector<Tracklet>, constants::its::TrackletsPerRoad>& getTracklets();
@@ -69,7 +69,7 @@ class PrimaryVertexContext
   std::array<std::vector<std::vector<int>>, constants::its::CellsPerRoad - 1> mCellsNeighbours;
   std::vector<Road> mRoads;
 
-  std::array<std::array<int, constants::IndexTable::ZBins * constants::IndexTable::PhiBins + 1>,
+  std::array<std::array<int, constants::index_table::ZBins * constants::index_table::PhiBins + 1>,
              constants::its::TrackletsPerRoad>
     mIndexTables;
   std::array<std::vector<Tracklet>, constants::its::TrackletsPerRoad> mTracklets;
@@ -105,7 +105,7 @@ inline bool PrimaryVertexContext::isClusterUsed(int layer, int clusterId) const
 
 inline void PrimaryVertexContext::markUsedCluster(int layer, int clusterId) { mUsedClusters[layer][clusterId] = true; }
 
-inline std::array<std::array<int, constants::IndexTable::ZBins * constants::IndexTable::PhiBins + 1>,
+inline std::array<std::array<int, constants::index_table::ZBins * constants::index_table::PhiBins + 1>,
                   constants::its::TrackletsPerRoad>&
   PrimaryVertexContext::getIndexTables()
 {

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackerTraits.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackerTraits.h
@@ -91,10 +91,10 @@ inline GPU_DEVICE const int4 TrackerTraits::getBinsRect(const Cluster& currentCl
     return getEmptyBinsRect();
   }
 
-  return int4{ gpu::GPUCommonMath::Max(0, IndexTableUtils::getZBinIndex(layerIndex + 1, zRangeMin)),
-               IndexTableUtils::getPhiBinIndex(MathUtils::getNormalizedPhiCoordinate(phiRangeMin)),
-               gpu::GPUCommonMath::Min(constants::IndexTable::ZBins - 1, IndexTableUtils::getZBinIndex(layerIndex + 1, zRangeMax)),
-               IndexTableUtils::getPhiBinIndex(MathUtils::getNormalizedPhiCoordinate(phiRangeMax)) };
+  return int4{ gpu::GPUCommonMath::Max(0, index_table_utils::getZBinIndex(layerIndex + 1, zRangeMin)),
+               index_table_utils::getPhiBinIndex(math_utils::getNormalizedPhiCoordinate(phiRangeMin)),
+               gpu::GPUCommonMath::Min(constants::index_table::ZBins - 1, index_table_utils::getZBinIndex(layerIndex + 1, zRangeMax)),
+               index_table_utils::getPhiBinIndex(math_utils::getNormalizedPhiCoordinate(phiRangeMax)) };
 }
 }
 }

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
@@ -34,8 +34,8 @@ namespace its
 
 class ROframe;
 
-using constants::IndexTable::PhiBins;
-using constants::IndexTable::ZBins;
+using constants::index_table::PhiBins;
+using constants::index_table::ZBins;
 using constants::its::LayersNumberVertexer;
 
 struct lightVertex {
@@ -143,16 +143,16 @@ inline GPU_DEVICE const int4 VertexerTraits::getBinsRect(const Cluster& currentC
     return getEmptyBinsRect();
   }
 
-  return int4{ gpu::GPUCommonMath::Max(0, IndexTableUtils::getZBinIndex(layerIndex + 1, zRangeMin)),
-               IndexTableUtils::getPhiBinIndex(MathUtils::getNormalizedPhiCoordinate(phiRangeMin)),
-               gpu::GPUCommonMath::Min(constants::IndexTable::ZBins - 1, IndexTableUtils::getZBinIndex(layerIndex + 1, zRangeMax)),
-               IndexTableUtils::getPhiBinIndex(MathUtils::getNormalizedPhiCoordinate(phiRangeMax)) };
+  return int4{ gpu::GPUCommonMath::Max(0, index_table_utils::getZBinIndex(layerIndex + 1, zRangeMin)),
+               index_table_utils::getPhiBinIndex(math_utils::getNormalizedPhiCoordinate(phiRangeMin)),
+               gpu::GPUCommonMath::Min(constants::index_table::ZBins - 1, index_table_utils::getZBinIndex(layerIndex + 1, zRangeMax)),
+               index_table_utils::getPhiBinIndex(math_utils::getNormalizedPhiCoordinate(phiRangeMax)) };
 }
 
 inline GPU_HOST_DEVICE const int2 VertexerTraits::getPhiBins(const int layerIndex, float phi, float dPhi)
 {
-  return int2{ IndexTableUtils::getPhiBinIndex(MathUtils::getNormalizedPhiCoordinate(phi - dPhi)),
-               IndexTableUtils::getPhiBinIndex(MathUtils::getNormalizedPhiCoordinate(phi + dPhi)) };
+  return int2{ index_table_utils::getPhiBinIndex(math_utils::getNormalizedPhiCoordinate(phi - dPhi)),
+               index_table_utils::getPhiBinIndex(math_utils::getNormalizedPhiCoordinate(phi + dPhi)) };
 }
 
 inline GPU_HOST_DEVICE const int4 VertexerTraits::getBinsRect2(const Cluster& currentCluster, const int layerIndex,
@@ -169,10 +169,10 @@ inline GPU_HOST_DEVICE const int4 VertexerTraits::getBinsRect2(const Cluster& cu
     return getEmptyBinsRect();
   }
 
-  return int4{ gpu::GPUCommonMath::Max(0, IndexTableUtils::getZBinIndex(layerIndex + 1, zRangeMin)),
-               IndexTableUtils::getPhiBinIndex(MathUtils::getNormalizedPhiCoordinate(phiRangeMin)),
-               gpu::GPUCommonMath::Min(constants::IndexTable::ZBins - 1, IndexTableUtils::getZBinIndex(layerIndex + 1, zRangeMax)),
-               IndexTableUtils::getPhiBinIndex(MathUtils::getNormalizedPhiCoordinate(phiRangeMax)) };
+  return int4{ gpu::GPUCommonMath::Max(0, index_table_utils::getZBinIndex(layerIndex + 1, zRangeMin)),
+               index_table_utils::getPhiBinIndex(math_utils::getNormalizedPhiCoordinate(phiRangeMin)),
+               gpu::GPUCommonMath::Min(constants::index_table::ZBins - 1, index_table_utils::getZBinIndex(layerIndex + 1, zRangeMax)),
+               index_table_utils::getPhiBinIndex(math_utils::getNormalizedPhiCoordinate(phiRangeMax)) };
 }
 extern "C" VertexerTraits* createVertexerTraits();
 

--- a/Detectors/ITSMFT/ITS/tracking/src/Cluster.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Cluster.cxx
@@ -22,9 +22,9 @@ namespace o2
 namespace its
 {
 
-using MathUtils::calculatePhiCoordinate;
-using MathUtils::calculateRCoordinate;
-using MathUtils::getNormalizedPhiCoordinate;
+using math_utils::calculatePhiCoordinate;
+using math_utils::calculateRCoordinate;
+using math_utils::getNormalizedPhiCoordinate;
 
 Cluster::Cluster(const float x, const float y, const float z, const int index)
   : xCoordinate{ x },
@@ -45,8 +45,8 @@ Cluster::Cluster(const int layerIndex, const Cluster& other)
     phiCoordinate{ getNormalizedPhiCoordinate(calculatePhiCoordinate(other.xCoordinate, other.yCoordinate)) },
     rCoordinate{ calculateRCoordinate(other.xCoordinate, other.yCoordinate) },
     clusterId{ other.clusterId },
-    indexTableBinIndex{ IndexTableUtils::getBinIndex(IndexTableUtils::getZBinIndex(layerIndex, zCoordinate),
-                                                     IndexTableUtils::getPhiBinIndex(phiCoordinate)) }
+    indexTableBinIndex{ index_table_utils::getBinIndex(index_table_utils::getZBinIndex(layerIndex, zCoordinate),
+                                                       index_table_utils::getPhiBinIndex(phiCoordinate)) }
 //, montecarloId{ other.montecarloId }
 {
   // Nothing to do
@@ -60,8 +60,8 @@ Cluster::Cluster(const int layerIndex, const float3& primaryVertex, const Cluste
       calculatePhiCoordinate(xCoordinate - primaryVertex.x, yCoordinate - primaryVertex.y)) },
     rCoordinate{ calculateRCoordinate(xCoordinate - primaryVertex.x, yCoordinate - primaryVertex.y) },
     clusterId{ other.clusterId },
-    indexTableBinIndex{ IndexTableUtils::getBinIndex(IndexTableUtils::getZBinIndex(layerIndex, zCoordinate),
-                                                     IndexTableUtils::getPhiBinIndex(phiCoordinate)) }
+    indexTableBinIndex{ index_table_utils::getBinIndex(index_table_utils::getZBinIndex(layerIndex, zCoordinate),
+                                                       index_table_utils::getPhiBinIndex(phiCoordinate)) }
 {
   // Nothing to do
 }

--- a/Detectors/ITSMFT/ITS/tracking/src/IOUtils.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/IOUtils.cxx
@@ -40,7 +40,7 @@ namespace o2
 namespace its
 {
 
-void IOUtils::loadConfigurations(const std::string& fileName)
+void ioutils::loadConfigurations(const std::string& fileName)
 {
   if (!fileName.empty()) {
     std::ifstream inputStream;
@@ -52,7 +52,7 @@ void IOUtils::loadConfigurations(const std::string& fileName)
   }
 }
 
-std::vector<ROframe> IOUtils::loadEventData(const std::string& fileName)
+std::vector<ROframe> ioutils::loadEventData(const std::string& fileName)
 {
   std::vector<ROframe> events{};
   std::ifstream inputStream{};
@@ -102,7 +102,7 @@ std::vector<ROframe> IOUtils::loadEventData(const std::string& fileName)
   return events;
 }
 
-void IOUtils::loadEventData(ROframe& event, const std::vector<itsmft::Cluster>* clusters,
+void ioutils::loadEventData(ROframe& event, const std::vector<itsmft::Cluster>* clusters,
                             const dataformats::MCTruthContainer<MCCompLabel>* mcLabels)
 {
   if (!clusters) {
@@ -133,7 +133,7 @@ void IOUtils::loadEventData(ROframe& event, const std::vector<itsmft::Cluster>* 
   }
 }
 
-int IOUtils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& event, const std::vector<itsmft::Cluster>* clusters,
+int ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& event, const std::vector<itsmft::Cluster>* clusters,
                              const dataformats::MCTruthContainer<MCCompLabel>* mcLabels)
 {
   if (!clusters) {
@@ -168,7 +168,7 @@ int IOUtils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& event, c
   return number;
 }
 
-std::vector<std::unordered_map<int, Label>> IOUtils::loadLabels(const int eventsNum, const std::string& fileName)
+std::vector<std::unordered_map<int, Label>> ioutils::loadLabels(const int eventsNum, const std::string& fileName)
 {
   std::vector<std::unordered_map<int, Label>> labelsMap{};
   std::unordered_map<int, Label> currentEventLabelsMap{};
@@ -197,7 +197,7 @@ std::vector<std::unordered_map<int, Label>> IOUtils::loadLabels(const int events
 
         if (inputStringStream >> transverseMomentum >> phiCoordinate >> pseudorapidity >> pdgCode >> numberOfClusters) {
 
-          if (std::abs(pdgCode) == constants::PDGCodes::PionCode && numberOfClusters == 7) {
+          if (std::abs(pdgCode) == constants::pdgcodes::PionCode && numberOfClusters == 7) {
 
             currentEventLabelsMap.emplace(std::piecewise_construct, std::forward_as_tuple(monteCarloId),
                                           std::forward_as_tuple(monteCarloId, transverseMomentum, phiCoordinate,
@@ -213,7 +213,7 @@ std::vector<std::unordered_map<int, Label>> IOUtils::loadLabels(const int events
   return labelsMap;
 }
 
-void IOUtils::writeRoadsReport(std::ofstream& correctRoadsOutputStream, std::ofstream& duplicateRoadsOutputStream,
+void ioutils::writeRoadsReport(std::ofstream& correctRoadsOutputStream, std::ofstream& duplicateRoadsOutputStream,
                                std::ofstream& fakeRoadsOutputStream, const std::vector<std::vector<Road>>& roads,
                                const std::unordered_map<int, Label>& labelsMap)
 {

--- a/Detectors/ITSMFT/ITS/tracking/src/IndexTableUtils.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/IndexTableUtils.cxx
@@ -19,8 +19,8 @@ namespace o2
 namespace its
 {
 
-const std::vector<std::pair<int, int>> IndexTableUtils::selectClusters(
-  const std::array<int, constants::IndexTable::ZBins * constants::IndexTable::PhiBins + 1>& indexTable,
+const std::vector<std::pair<int, int>> index_table_utils::selectClusters(
+  const std::array<int, constants::index_table::ZBins * constants::index_table::PhiBins + 1>& indexTable,
   const std::array<int, 4>& selectedBinsRect)
 {
   std::vector<std::pair<int, int>> filteredBins{};
@@ -28,15 +28,15 @@ const std::vector<std::pair<int, int>> IndexTableUtils::selectClusters(
   int phiBinsNum{ selectedBinsRect[3] - selectedBinsRect[1] + 1 };
 
   if (phiBinsNum < 0) {
-    phiBinsNum += constants::IndexTable::PhiBins;
+    phiBinsNum += constants::index_table::PhiBins;
   }
 
   filteredBins.reserve(phiBinsNum);
 
   for (int iPhiBin{ selectedBinsRect[1] }, iPhiCount{ 0 }; iPhiCount < phiBinsNum;
-       iPhiBin = ++iPhiBin == constants::IndexTable::PhiBins ? 0 : iPhiBin, iPhiCount++) {
+       iPhiBin = ++iPhiBin == constants::index_table::PhiBins ? 0 : iPhiBin, iPhiCount++) {
 
-    const int firstBinIndex{ IndexTableUtils::getBinIndex(selectedBinsRect[0], iPhiBin) };
+    const int firstBinIndex{ index_table_utils::getBinIndex(selectedBinsRect[0], iPhiBin) };
 
     filteredBins.emplace_back(indexTable[firstBinIndex],
                               countRowSelectedBins(indexTable, iPhiBin, selectedBinsRect[0], selectedBinsRect[2]));

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -583,14 +583,14 @@ track::TrackParCov Tracker::buildTrackSeed(const Cluster& cluster1, const Cluste
   const float y3 = tf3.positionTrackingFrame[0];
   const float z3 = tf3.positionTrackingFrame[1];
 
-  const float crv = MathUtils::computeCurvature(x1, y1, x2, y2, x3, y3);
-  const float x0 = MathUtils::computeCurvatureCentreX(x1, y1, x2, y2, x3, y3);
-  const float tgl12 = MathUtils::computeTanDipAngle(x1, y1, x2, y2, z1, z2);
-  const float tgl23 = MathUtils::computeTanDipAngle(x2, y2, x3, y3, z2, z3);
+  const float crv = math_utils::computeCurvature(x1, y1, x2, y2, x3, y3);
+  const float x0 = math_utils::computeCurvatureCentreX(x1, y1, x2, y2, x3, y3);
+  const float tgl12 = math_utils::computeTanDipAngle(x1, y1, x2, y2, z1, z2);
+  const float tgl23 = math_utils::computeTanDipAngle(x2, y2, x3, y3, z2, z3);
 
   const float fy = 1. / (cluster2.rCoordinate - cluster3.rCoordinate);
   const float& tz = fy;
-  const float cy = (MathUtils::computeCurvature(x1, y1, x2, y2 + constants::its::Resolution, x3, y3) - crv) /
+  const float cy = (math_utils::computeCurvature(x1, y1, x2, y2 + constants::its::Resolution, x3, y3) - crv) /
                    (constants::its::Resolution * getBz() * o2::constants::math::B2C) *
                    20.f; // FIXME: MS contribution to the cov[14] (*20 added)
   constexpr float s2 = constants::its::Resolution * constants::its::Resolution;

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackerTraitsCPU.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackerTraitsCPU.cxx
@@ -60,13 +60,13 @@ void TrackerTraitsCPU::computeLayerTracklets()
       int phiBinsNum{ selectedBinsRect.w - selectedBinsRect.y + 1 };
 
       if (phiBinsNum < 0) {
-        phiBinsNum += constants::IndexTable::PhiBins;
+        phiBinsNum += constants::index_table::PhiBins;
       }
 
       for (int iPhiBin{ selectedBinsRect.y }, iPhiCount{ 0 }; iPhiCount < phiBinsNum;
-           iPhiBin = ++iPhiBin == constants::IndexTable::PhiBins ? 0 : iPhiBin, iPhiCount++) {
+           iPhiBin = ++iPhiBin == constants::index_table::PhiBins ? 0 : iPhiBin, iPhiCount++) {
 
-        const int firstBinIndex{ IndexTableUtils::getBinIndex(selectedBinsRect.x, iPhiBin) };
+        const int firstBinIndex{ index_table_utils::getBinIndex(selectedBinsRect.x, iPhiBin) };
         const int maxBinIndex{ firstBinIndex + selectedBinsRect.z - selectedBinsRect.x + 1 };
         const int firstRowClusterIndex = primaryVertexContext->getIndexTables()[iLayer][firstBinIndex];
         const int maxRowClusterIndex = primaryVertexContext->getIndexTables()[iLayer][maxBinIndex];
@@ -85,7 +85,7 @@ void TrackerTraitsCPU::computeLayerTracklets()
 
           if (deltaZ < mTrkParams.TrackletMaxDeltaZ[iLayer] &&
               (deltaPhi < mTrkParams.TrackletMaxDeltaPhi ||
-               gpu::GPUCommonMath::Abs(deltaPhi - constants::Math::TwoPi) < mTrkParams.TrackletMaxDeltaPhi)) {
+               gpu::GPUCommonMath::Abs(deltaPhi - constants::math::TwoPi) < mTrkParams.TrackletMaxDeltaPhi)) {
 
             if (iLayer > 0 &&
                 primaryVertexContext->getTrackletsLookupTable()[iLayer - 1][iCluster] == constants::its::UnusedIndex) {
@@ -154,7 +154,7 @@ void TrackerTraitsCPU::computeLayerCells()
 
         if (deltaTanLambda < mTrkParams.CellMaxDeltaTanLambda &&
             (deltaPhi < mTrkParams.CellMaxDeltaPhi ||
-             std::abs(deltaPhi - constants::Math::TwoPi) < mTrkParams.CellMaxDeltaPhi)) {
+             std::abs(deltaPhi - constants::math::TwoPi) < mTrkParams.CellMaxDeltaPhi)) {
 
           const float averageTanLambda{ 0.5f * (currentTracklet.tanLambda + nextTracklet.tanLambda) };
           const float directionZIntersection{ -averageTanLambda * firstCellCluster.rCoordinate +
@@ -175,14 +175,14 @@ void TrackerTraitsCPU::computeLayerCells()
                                             thirdCellClusterQuadraticRCoordinate -
                                               firstCellClusterQuadraticRCoordinate };
 
-            float3 cellPlaneNormalVector{ MathUtils::crossProduct(firstDeltaVector, secondDeltaVector) };
+            float3 cellPlaneNormalVector{ math_utils::crossProduct(firstDeltaVector, secondDeltaVector) };
 
             const float vectorNorm{ std::sqrt(cellPlaneNormalVector.x * cellPlaneNormalVector.x +
                                               cellPlaneNormalVector.y * cellPlaneNormalVector.y +
                                               cellPlaneNormalVector.z * cellPlaneNormalVector.z) };
 
-            if (vectorNorm < constants::Math::FloatMinThreshold ||
-                std::abs(cellPlaneNormalVector.z) < constants::Math::FloatMinThreshold) {
+            if (vectorNorm < constants::math::FloatMinThreshold ||
+                std::abs(cellPlaneNormalVector.z) < constants::math::FloatMinThreshold) {
 
               continue;
             }

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -26,12 +26,12 @@ namespace o2
 namespace its
 {
 
-using constants::IndexTable::PhiBins;
-using constants::IndexTable::ZBins;
+using constants::index_table::PhiBins;
+using constants::index_table::ZBins;
 using constants::its::LayersRCoordinate;
 using constants::its::LayersZCoordinate;
-using constants::Math::TwoPi;
-using IndexTableUtils::getZBinIndex;
+using constants::math::TwoPi;
+using index_table_utils::getZBinIndex;
 
 void trackleterKernelSerial(
   const std::vector<Cluster>& clustersNextLayer,    // 0 2
@@ -60,7 +60,7 @@ void trackleterKernelSerial(
       }
       // loop on phi bins next layer
       for (int iPhiBin{ selectedBinsRect.y }, iPhiCount{ 0 }; iPhiCount < phiBinsNum; iPhiBin = ++iPhiBin == PhiBins ? 0 : iPhiBin, iPhiCount++) {
-        const int firstBinIndex{ IndexTableUtils::getBinIndex(selectedBinsRect.x, iPhiBin) };
+        const int firstBinIndex{ index_table_utils::getBinIndex(selectedBinsRect.x, iPhiBin) };
         const int firstRowClusterIndex{ indexTableNext[firstBinIndex] };
         const int maxRowClusterIndex{ indexTableNext[firstBinIndex + selectedBinsRect.z - selectedBinsRect.x + 1] };
         // loop on clusters next layer
@@ -129,9 +129,9 @@ VertexerTraits::VertexerTraits() : mAverageClustersRadii{ std::array<float, 3>{ 
                                    mMaxDirectorCosine3{ 0.f }
 {
   // CUDA does not allow for dynamic initialization -> no constructor for VertexingParams
-  mVrtParams.phiSpan = static_cast<int>(std::ceil(constants::IndexTable::PhiBins * mVrtParams.phiCut /
-                                                  constants::Math::TwoPi));
-  mVrtParams.zSpan = static_cast<int>(std::ceil(mVrtParams.zCut * constants::IndexTable::InverseZBinSize()[0]));
+  mVrtParams.phiSpan = static_cast<int>(std::ceil(constants::index_table::PhiBins * mVrtParams.phiCut /
+                                                  constants::math::TwoPi));
+  mVrtParams.zSpan = static_cast<int>(std::ceil(mVrtParams.zCut * constants::index_table::InverseZBinSize()[0]));
   setIsGPU(false);
 }
 
@@ -211,10 +211,10 @@ const std::vector<std::pair<int, int>> VertexerTraits::selectClusters(const std:
   filteredBins.reserve(phiBinsNum);
   for (int iPhiBin{ selectedBinsRect[1] }, iPhiCount{ 0 }; iPhiCount < phiBinsNum;
        iPhiBin = ++iPhiBin == PhiBins ? 0 : iPhiBin, iPhiCount++) {
-    const int firstBinIndex{ IndexTableUtils::getBinIndex(selectedBinsRect[0], iPhiBin) };
+    const int firstBinIndex{ index_table_utils::getBinIndex(selectedBinsRect[0], iPhiBin) };
     filteredBins.emplace_back(
       indexTable[firstBinIndex],
-      IndexTableUtils::countRowSelectedBins(indexTable, iPhiBin, selectedBinsRect[0], selectedBinsRect[2]));
+      index_table_utils::countRowSelectedBins(indexTable, iPhiBin, selectedBinsRect[0], selectedBinsRect[2]));
   }
   return filteredBins;
 }

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/RecoWorkflow.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/RecoWorkflow.h
@@ -20,7 +20,7 @@ namespace o2
 namespace its
 {
 
-namespace RecoWorkflow
+namespace reco_workflow
 {
 framework::WorkflowSpec getWorkflow(bool useMC);
 }

--- a/Detectors/ITSMFT/ITS/workflow/src/CookedTrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/CookedTrackerSpec.cxx
@@ -101,7 +101,7 @@ void CookedTrackerDPL::run(ProcessingContext& pc)
   std::vector<o2::its::TrackITS> tracks;
   std::vector<int> clusIdx;
   for (auto& rof : rofs) {
-    o2::its::IOUtils::loadROFrameData(rof, event, &clusters, labels.get());
+    o2::its::ioutils::loadROFrameData(rof, event, &clusters, labels.get());
     vertexer.clustersToVertices(event);
     auto vertices = vertexer.exportVertices();
     if (vertices.empty()) {

--- a/Detectors/ITSMFT/ITS/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/RecoWorkflow.cxx
@@ -24,7 +24,7 @@ namespace o2
 namespace its
 {
 
-namespace RecoWorkflow
+namespace reco_workflow
 {
 
 framework::WorkflowSpec getWorkflow(bool useMC)

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -107,7 +107,7 @@ void TrackerDPL::run(ProcessingContext& pc)
 
   if (continuous) {
     for (const auto& rof : rofs) {
-      int nclUsed = IOUtils::loadROFrameData(rof, event, &clusters, labels);
+      int nclUsed = ioutils::loadROFrameData(rof, event, &clusters, labels);
       if (nclUsed) {
         LOG(INFO) << "ROframe: " << roFrame << ", clusters loaded : " << nclUsed;
         mVertexer->clustersToVertices(event);
@@ -128,7 +128,7 @@ void TrackerDPL::run(ProcessingContext& pc)
       roFrame++;
     }
   } else {
-    IOUtils::loadEventData(event, &clusters, labels);
+    ioutils::loadEventData(event, &clusters, labels);
     event.addPrimaryVertex(0.f, 0.f, 0.f); //FIXME :  run an actual vertex finder !
     mTracker->clustersToTracks(event);
     tracks.swap(mTracker->getTracks());

--- a/Detectors/ITSMFT/ITS/workflow/src/its-reco-workflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/its-reco-workflow.cxx
@@ -40,5 +40,5 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 
   auto useMC = !configcontext.options().get<bool>("disable-mc");
 
-  return std::move(o2::its::RecoWorkflow::getWorkflow(useMC));
+  return std::move(o2::its::reco_workflow::getWorkflow(useMC));
 }

--- a/GPU/GPUTracking/ITS/GPUITSFitterKernels.cxx
+++ b/GPU/GPUTracking/ITS/GPUITSFitterKernels.cxx
@@ -122,16 +122,16 @@ GPUd() void GPUITSFitterKernel::Thread<0>(int nBlocks, int nThreads, int iBlock,
       const float y3 = cluster3.positionTrackingFrame[0];
       const float z3 = cluster3.positionTrackingFrame[1];
 
-      const float crv = MathUtils::computeCurvature(x1, y1, x2, y2, x3, y3);
-      const float x0 = MathUtils::computeCurvatureCentreX(x1, y1, x2, y2, x3, y3);
-      const float tgl12 = MathUtils::computeTanDipAngle(x1, y1, x2, y2, z1, z2);
-      const float tgl23 = MathUtils::computeTanDipAngle(x2, y2, x3, y3, z2, z3);
+      const float crv = math_utils::computeCurvature(x1, y1, x2, y2, x3, y3);
+      const float x0 = math_utils::computeCurvatureCentreX(x1, y1, x2, y2, x3, y3);
+      const float tgl12 = math_utils::computeTanDipAngle(x1, y1, x2, y2, z1, z2);
+      const float tgl23 = math_utils::computeTanDipAngle(x2, y2, x3, y3, z2, z3);
 
       const float r2 = CAMath::Sqrt(cluster2.xCoordinate * cluster2.xCoordinate + cluster2.yCoordinate * cluster2.yCoordinate);
       const float r3 = CAMath::Sqrt(cluster3.xCoordinate * cluster3.xCoordinate + cluster3.yCoordinate * cluster3.yCoordinate);
       const float fy = 1. / (r2 - r3);
       const float& tz = fy;
-      const float cy = (MathUtils::computeCurvature(x1, y1, x2, y2 + o2::its::constants::its::Resolution, x3, y3) - crv) / (o2::its::constants::its::Resolution * bz * constants::math::B2C) * 20.f; // FIXME: MS contribution to the cov[14] (*20 added)
+      const float cy = (math_utils::computeCurvature(x1, y1, x2, y2 + o2::its::constants::its::Resolution, x3, y3) - crv) / (o2::its::constants::its::Resolution * bz * constants::math::B2C) * 20.f; // FIXME: MS contribution to the cov[14] (*20 added)
       constexpr float s2 = o2::its::constants::its::Resolution * o2::its::constants::its::Resolution;
 
       temporaryTrack.X() = cluster3.xTrackingFrame;

--- a/macro/run_primary_vertexer_ITS.C
+++ b/macro/run_primary_vertexer_ITS.C
@@ -116,7 +116,7 @@ int run_primary_vertexer_ITS(const bool useGPU = false,
   for (auto& rof : *rofs) {
     itsClusters.GetEntry(rof.getROFEntry().getEvent());
     mcHeaderTree.GetEntry(rof.getROFEntry().getEvent());
-    int nclUsed = o2::its::IOUtils::loadROFrameData(rof, frame, clusters, labels);
+    int nclUsed = o2::its::ioutils::loadROFrameData(rof, frame, clusters, labels);
     // float total = vertexer.clustersToVertices(frame, true);
     vertexer.initialiseVertexer(&frame);
     vertexer.findTracklets(useMCcheck);

--- a/macro/run_trac_ca_its.C
+++ b/macro/run_trac_ca_its.C
@@ -146,7 +146,7 @@ void run_trac_ca_its(bool useITSVertex = false,
   for (auto& rof : *rofs) {
     itsClusters.GetEntry(rof.getROFEntry().getEvent());
     mcHeaderTree.GetEntry(rof.getROFEntry().getEvent());
-    o2::its::IOUtils::loadROFrameData(rof, event, clusters, labels);
+    o2::its::ioutils::loadROFrameData(rof, event, clusters, labels);
     if (useITSVertex) {
       vertexer.initialiseVertexer(&event);
 

--- a/macro/run_trac_its.C
+++ b/macro/run_trac_its.C
@@ -161,7 +161,7 @@ void run_trac_its(std::string path = "./", std::string outputfile = "o2trac_its.
   o2::its::ROframe event(0);
 
   for (auto& rof : *rofs) {
-    o2::its::IOUtils::loadROFrameData(rof, event, &allClusters, &allLabels);
+    o2::its::ioutils::loadROFrameData(rof, event, &allClusters, &allLabels);
     vertexer.clustersToVertices(event);
     auto vertices = vertexer.exportVertices();
     if (vertices.empty()) {


### PR DESCRIPTION
 - o2::its::IOUtils
 - o2::its::IndexTableUtils
 - o2::its::MathUtils
 - o2::its::RecoWorkflow
 - o2::its::constants::IndexTable
 - o2::its::constants::Math
 - o2::its::constants::PDGCodes