### PR TITLE
Devices set readyToQuit(false) after 1st TF to unblock flow completion

### DIFF
--- a/Detectors/FIT/workflow/src/T0RecPointWriterSpec.cxx
+++ b/Detectors/FIT/workflow/src/T0RecPointWriterSpec.cxx
@@ -49,7 +49,7 @@ void T0RecPointWriter::run(ProcessingContext& pc)
   tree.Write();
 
   mFinished = true;
-  pc.services().get<ControlService>().readyToQuit(true);
+  pc.services().get<ControlService>().readyToQuit(false);
 }
 
 DataProcessorSpec getT0RecPointWriterSpec(bool useMC)

--- a/Detectors/GlobalTrackingWorkflow/src/TrackWriterTPCITSSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TrackWriterTPCITSSpec.cxx
@@ -62,7 +62,7 @@ void TrackWriterTPCITS::run(ProcessingContext& pc)
   tree.SetEntries(1);
   tree.Write();
   mFinished = true;
-  pc.services().get<ControlService>().readyToQuit(true);
+  pc.services().get<ControlService>().readyToQuit(false);
 }
 
 DataProcessorSpec getTrackWriterTPCITSSpec(bool useMC)

--- a/Detectors/ITSMFT/ITS/workflow/src/ClusterWriterSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ClusterWriterSpec.cxx
@@ -87,7 +87,7 @@ void ClusterWriter::run(ProcessingContext& pc)
   mFile->Close();
 
   mState = 2;
-  //pc.services().get<ControlService>().readyToQuit(true);
+  pc.services().get<ControlService>().readyToQuit(false);
 }
 
 DataProcessorSpec getClusterWriterSpec(bool useMC)

--- a/Detectors/ITSMFT/ITS/workflow/src/ClustererSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ClustererSpec.cxx
@@ -126,7 +126,7 @@ void ClustererDPL::run(ProcessingContext& pc)
   }
 
   mState = 2;
-  //pc.services().get<ControlService>().readyToQuit(true);
+  pc.services().get<ControlService>().readyToQuit(false);
 }
 
 DataProcessorSpec getClustererSpec(bool useMC)

--- a/Detectors/ITSMFT/ITS/workflow/src/CookedTrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/CookedTrackerSpec.cxx
@@ -106,7 +106,7 @@ void CookedTrackerDPL::run(ProcessingContext& pc)
   }
 
   mState = 2;
-  //pc.services().get<ControlService>().readyToQuit(true);
+  pc.services().get<ControlService>().readyToQuit(false);
 }
 
 DataProcessorSpec getCookedTrackerSpec(bool useMC)

--- a/Detectors/ITSMFT/ITS/workflow/src/DigitReaderSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/DigitReaderSpec.cxx
@@ -110,7 +110,7 @@ void DigitReader::run(ProcessingContext& pc)
     return;
   }
   mState = 2;
-  //pc.services().get<ControlService>().readyToQuit(true);
+  pc.services().get<ControlService>().readyToQuit(false);
 }
 
 DataProcessorSpec getDigitReaderSpec(bool useMC)

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackWriterSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackWriterSpec.cxx
@@ -84,7 +84,7 @@ void TrackWriter::run(ProcessingContext& pc)
   mFile->Close();
 
   mState = 2;
-  pc.services().get<ControlService>().readyToQuit(true);
+  pc.services().get<ControlService>().readyToQuit(false);
 }
 
 DataProcessorSpec getTrackWriterSpec(bool useMC)

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -149,7 +149,7 @@ void TrackerDPL::run(ProcessingContext& pc)
   pc.outputs().snapshot(Output{ "ITS", "ITSTrackMC2ROF", 0, Lifetime::Timeframe }, mc2rofs);
 
   mState = 2;
-  //pc.services().get<ControlService>().readyToQuit(true);
+  pc.services().get<ControlService>().readyToQuit(false);
 }
 
 DataProcessorSpec getTrackerSpec()


### PR DESCRIPTION
In absence of the flow forced termination by its last device setting  ``readyToQuit(true)`` (which creates problems with flows merging, see https://github.com/AliceO2Group/AliceO2/pull/1888#issuecomment-494816380) all devices should terminate themselves by   ``pc.services().get<ControlService>().readyToQuit(false)`` in order to complete the flow.