### PR TITLE
AnalysisTask improvements

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -58,6 +58,7 @@ set(SRCS
     src/GraphvizHelpers.cxx
     src/InputRecord.cxx
     src/InputSpec.cxx
+    src/Kernels.cxx
     src/DataDescriptorQueryBuilder.cxx
     src/LifetimeHelpers.cxx
     src/LocalRootFileService.cxx
@@ -163,6 +164,7 @@ set(HEADERS
       include/Framework/FairMQResizableBuffer.h
       include/Framework/Metric2DViewIndex.h
       include/Framework/RawBufferContext.h
+      include/Framework/Kernels.h
       src/ComputingResource.h
       src/DDSConfigHelpers.h
       src/O2ControlHelpers.h
@@ -229,6 +231,7 @@ O2_GENERATE_EXECUTABLE(
 Install(FILES test/test_DataSampling.json DESTINATION share/tests/)
 
 set(TEST_SRCS
+      test/test_ASoA.cxx
       test/test_AnalysisTask.cxx
       test/test_BoostSerializedProcessing.cxx
       test/test_AlgorithmSpec.cxx
@@ -262,6 +265,7 @@ set(TEST_SRCS
       test/test_Graphviz.cxx
       test/test_InfoLogger.cxx
       test/test_InputRecord.cxx
+      test/test_Kernels.cxx
       test/test_LogParsingHelpers.cxx
       test/test_ParallelProducer.cxx
       test/test_PtrHelpers.cxx

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1,0 +1,232 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_FRAMEWORK_ASOA_H_
+#define O2_FRAMEWORK_ASOA_H_
+
+#include <arrow/table.h>
+#include <arrow/array.h>
+#include <cassert>
+
+namespace o2
+{
+namespace soa
+{
+
+template <typename T>
+struct arrow_array_for {
+};
+template <>
+struct arrow_array_for<int32_t> {
+  using type = arrow::Int32Array;
+};
+template <>
+struct arrow_array_for<int64_t> {
+  using type = arrow::Int64Array;
+};
+template <>
+struct arrow_array_for<uint32_t> {
+  using type = arrow::UInt32Array;
+};
+template <>
+struct arrow_array_for<uint64_t> {
+  using type = arrow::UInt64Array;
+};
+template <>
+struct arrow_array_for<float> {
+  using type = arrow::FloatArray;
+};
+template <>
+struct arrow_array_for<double> {
+  using type = arrow::DoubleArray;
+};
+
+template <typename T>
+using arrow_array_for_t = typename arrow_array_for<T>::type;
+
+template <typename T>
+class ColumnIterator
+{
+ public:
+  ColumnIterator(std::shared_ptr<arrow::Column> const& column)
+    : mColumn{ column },
+      mCurrentChunk{ 0 },
+      mLastChunk{ mColumn->data()->num_chunks() - 1 },
+      mLast{ nullptr },
+      mCurrent{ nullptr }
+  {
+    moveToChunk(mCurrentChunk);
+  }
+
+  void moveToChunk(int chunk)
+  {
+    assert(mColumn.get());
+    assert(mColumn->data());
+    mCurrentChunk = chunk;
+    auto chunks = mColumn->data();
+    auto array = std::static_pointer_cast<arrow_array_for_t<T>>(chunks->chunk(chunk));
+    assert(array.get());
+    mCurrent = array->raw_values();
+    mLast = mCurrent + array->length();
+  }
+
+  void moveToEnd()
+  {
+    mCurrentChunk = mLastChunk;
+    auto chunks = mColumn->data();
+    auto array = std::static_pointer_cast<arrow_array_for_t<T>>(chunks->chunk(mCurrentChunk));
+    assert(array.get());
+    mLast = array->raw_values() + array->length();
+    mCurrent = mLast;
+  }
+
+  T const& operator*() const
+  {
+    return *mCurrent;
+  }
+
+  bool operator==(ColumnIterator<T> const& other) const
+  {
+    return mCurrent == other.mCurrent;
+  }
+
+  bool operator!=(ColumnIterator<T> const& other) const
+  {
+    return mCurrent != other.mCurrent;
+  }
+
+  bool operator<(ColumnIterator<T> const& other) const
+  {
+    if (mCurrentChunk < other.mCurrentChunk) {
+      return true;
+    }
+    return mCurrent < other.mCurrent;
+  }
+
+  ColumnIterator<T>& operator++()
+  {
+    // Notice how end is actually mLast of the last chunk
+    if (mCurrent + 1 == mLast && mCurrentChunk < mLastChunk) {
+      mCurrentChunk += 1;
+      moveToChunk(mCurrentChunk);
+    } else {
+      mCurrent++;
+    }
+    return *this;
+  }
+
+  ColumnIterator<T> operator++(int)
+  {
+    ColumnIterator<T> old = *this;
+    operator++();
+    return old;
+  }
+
+  std::shared_ptr<arrow::Column> mColumn;
+  T const* mCurrent;
+  T const* mLast;
+  int mCurrentChunk;
+  int mLastChunk;
+};
+
+template <typename T, typename INHERIT>
+struct Column {
+  static constexpr const char* const& label() { return INHERIT::mLabel; }
+  ColumnIterator<T> const& getIterator() const
+  {
+    return mColumnIterator;
+  }
+  ColumnIterator<T> mColumnIterator;
+};
+
+template <typename... C>
+struct RowView : public C... {
+ public:
+  RowView(std::shared_ptr<arrow::Table> const& table)
+    : C{ ColumnIterator<typename C::type>(table->column(table->schema()->GetFieldIndex(C::label()))) }...
+  {
+  }
+
+  RowView<C...>& operator++()
+  {
+    (C::mColumnIterator.operator++(), ...);
+    return *this;
+  }
+
+  RowView<C...> operator++(int)
+  {
+    RowView<C...> copy = *this;
+    operator++();
+    return copy;
+  }
+
+  RowView<C...> const& operator*()
+  {
+    return *this;
+  }
+
+  bool operator!=(RowView<C...> const& other) const
+  {
+    return (static_cast<C const&>(*this).mColumnIterator.operator!=(static_cast<C const&>(other).mColumnIterator) || ...);
+  }
+
+  bool operator==(RowView<C...> const& other) const
+  {
+    return (static_cast<C const&>(*this).mColumnIterator.operator==(static_cast<C const&>(other).mColumnIterator) || ...);
+  }
+
+  void moveToEnd()
+  {
+    (C::mColumnIterator.moveToEnd(), ...);
+  }
+};
+
+template <typename... C>
+class Table
+{
+ public:
+  using iterator = RowView<C...>;
+
+  Table(std::shared_ptr<arrow::Table> table)
+    : mTable(table)
+  {
+  }
+
+  RowView<C...> begin() const
+  {
+    return RowView<C...>(mTable);
+  }
+
+  RowView<C...> end() const
+  {
+    RowView<C...> end(mTable);
+    end.moveToEnd();
+    return end;
+  }
+
+ private:
+  std::shared_ptr<arrow::Table> mTable;
+};
+
+} // namespace soa
+} // namespace o2
+
+#define DECLARE_SOA_COLUMN(_Name_, _Getter_, _Type_, _Label_) \
+  struct _Name_ : o2::soa::Column<_Type_, _Name_> {           \
+    static constexpr const char* mLabel = _Label_;            \
+    using type = _Type_;                                      \
+                                                              \
+    _Type_ const _Getter_() const                             \
+    {                                                         \
+      return *mColumnIterator;                                \
+    }                                                         \
+  };
+
+#endif // O2_FRAMEWORK_ASOA_H_

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -12,6 +12,12 @@
 
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/AlgorithmSpec.h"
+#include "Framework/Traits.h"
+#include "Framework/Kernels.h"
+#include "Framework/ASoA.h"
+
+#include <arrow/compute/context.h>
+#include <arrow/compute/kernel.h>
 #include <arrow/table.h>
 #include <type_traits>
 #include <utility>
@@ -19,6 +25,45 @@
 
 namespace o2
 {
+
+namespace aod
+{
+
+namespace track
+{
+DECLARE_SOA_COLUMN(CollisionId, collisionId, int, "fID4Tracks");
+DECLARE_SOA_COLUMN(X, x, float, "fX");
+DECLARE_SOA_COLUMN(Alpha, alpha, float, "fAlpha");
+DECLARE_SOA_COLUMN(Y, y, float, "fY");
+DECLARE_SOA_COLUMN(Z, z, float, "fZ");
+DECLARE_SOA_COLUMN(Snp, snp, float, "fSnp");
+DECLARE_SOA_COLUMN(Tgl, tgl, float, "fTgl");
+DECLARE_SOA_COLUMN(Signed1Pt, signed1Pt, float, "fSigned1Pt");
+} // namespace track
+
+using Tracks = soa::Table<track::CollisionId, track::X, track::Alpha,
+                          track::Y, track::Z, track::Snp, track::Tgl,
+                          track::Signed1Pt>;
+using Track = Tracks::iterator;
+
+namespace collision
+{
+DECLARE_SOA_COLUMN(Centrality, centrality, float, "centrality");
+} // namespace collision
+
+using Collisions = soa::Table<collision::Centrality>;
+using Collision = Collisions::iterator;
+
+namespace timeframe
+{
+DECLARE_SOA_COLUMN(Timestamp, timestamp, uint64_t, "timestamp");
+} // namespace timeframe
+
+using Timeframes = soa::Table<timeframe::Timestamp>;
+using Timeframe = Timeframes::iterator;
+
+} // namespace aod
+
 namespace framework
 {
 
@@ -43,9 +88,14 @@ class AnalysisTask
   /// be complete.
   virtual void run(ProcessingContext& context) = 0;
 
-  /// This will be invoked and passed the tracks table for
-  /// each message.
-  virtual void processTracks(std::shared_ptr<arrow::Table> tracks) {}
+  /// Override this to subscribe to each track. No guarantees on the order.
+  virtual void processTrack(aod::Track const& tracks) {}
+  /// Override this to subscribe to all the tracks and including their associated collision.
+  virtual void processCollisionTrack(aod::Collision const& collision, aod::Track const& track) {}
+  /// Override this to subscribe to all the tracks of the given timeframe.
+  virtual void processTimeframeTracks(aod::Timeframe const& timeframe, aod::Tracks const& tracks) {}
+  /// Override this to subscribe to all the tracks associated to a given collision.
+  virtual void processCollisionTracks(aod::Collision const& collision, aod::Tracks const& tracks) {}
 };
 
 /// Adaptor to make an AlgorithmSpec from a o2::framework::Task
@@ -53,21 +103,83 @@ class AnalysisTask
 template <typename T, typename... Args>
 DataProcessorSpec adaptAnalysisTask(std::string name, Args&&... args)
 {
+  constexpr bool hasProcessTrack = is_overriding<decltype(&T::processTrack),
+                                                 decltype(&AnalysisTask::processTrack)>::value;
+  constexpr bool hasProcessCollisionTrack = is_overriding<decltype(&T::processCollisionTrack),
+                                                          decltype(&AnalysisTask::processCollisionTrack)>::value;
+  constexpr bool hasProcessTimeframeTracks = is_overriding<decltype(&T::processTimeframeTracks),
+                                                           decltype(&AnalysisTask::processTimeframeTracks)>::value;
+  constexpr bool hasProcessCollisionTracks = is_overriding<decltype(&T::processCollisionTracks),
+                                                           decltype(&AnalysisTask::processCollisionTracks)>::value;
+
   auto task = std::make_shared<T>(std::forward<Args>(args)...);
   auto algo = AlgorithmSpec::InitCallback{ [task](InitContext& ic) {
     task->init(ic);
     return [task](ProcessingContext& pc) {
       task->run(pc);
-      if constexpr (std::is_member_function_pointer<decltype(&T::processTracks)>::value) {
+      if constexpr (hasProcessTrack) {
         auto tracks = pc.inputs().get<TableConsumer>("tracks");
-        task->processTracks(tracks->asArrowTable());
+        for (auto& track : aod::Tracks(tracks->asArrowTable())) {
+          task->processTrack(track);
+        }
+      }
+      if constexpr (hasProcessCollisionTrack) {
+        auto tracks = pc.inputs().get<TableConsumer>("tracks");
+        auto collisions = pc.inputs().get<TableConsumer>("collisions");
+        size_t currentCollision = 0;
+        aod::Collision collision(collisions->asArrowTable());
+        for (auto& track : aod::Tracks(tracks->asArrowTable())) {
+          auto collisionIndex = track.collisionId();
+          // We find the associated collision, assuming they are sorted.
+          while (collisionIndex > currentCollision) {
+            ++currentCollision;
+            ++collision;
+          }
+          task->processTrack(collision, track);
+        }
+      }
+      if constexpr (hasProcessTimeframeTracks) {
+        auto tracks = pc.inputs().get<TableConsumer>("tracks");
+        auto timeframes = pc.inputs().get<TableConsumer>("timeframe");
+        // FIXME: For the moment we assume we have a single timeframe...
+        aod::Timeframe timeframe(timeframes->asArrowTable());
+        task->processTimeframeTracks(timeframe, aod::Tracks(tracks->asArrowTable()));
+      }
+      if constexpr (hasProcessCollisionTracks) {
+        auto collisions = pc.inputs().get<TableConsumer>("collisions");
+        auto allTracks = pc.inputs().get<TableConsumer>("tracks");
+        arrow::compute::FunctionContext ctx;
+        std::vector<arrow::compute::Datum> eventTracksCollection;
+        auto result = o2::framework::sliceByColumn(&ctx, "fID4Tracks", allTracks->asArrowTable(), &eventTracksCollection);
+        if (result.ok() == false) {
+          LOG(ERROR) << "Error while splitting the tracks per events";
+          return;
+        }
+        size_t currentCollision = 0;
+        aod::Collision collision(collisions->asArrowTable());
+        for (auto& eventTracks : eventTracksCollection) {
+          // FIXME: We find the associated collision, assuming they are sorted.
+          aod::Tracks tracks(arrow::util::get<std::shared_ptr<arrow::Table>>(eventTracks.value));
+          auto collisionIndex = tracks.begin().collisionId();
+          while (collisionIndex > currentCollision) {
+            ++currentCollision;
+            ++collision;
+          }
+          task->processCollisionTracks(collision, tracks);
+        }
       }
     };
   } };
   std::vector<InputSpec> inputs;
 
-  if constexpr (std::is_member_function_pointer<decltype(&T::processTracks)>::value) {
+  if constexpr (hasProcessTrack || hasProcessCollisionTrack || hasProcessTimeframeTracks || hasProcessCollisionTracks) {
     inputs.emplace_back(InputSpec{ "tracks", "AOD", "TRACKPAR" });
+  }
+  if constexpr (hasProcessCollisionTrack || hasProcessCollisionTracks) {
+    inputs.emplace_back(InputSpec{ "collisions", "AOD", "COLLISIONS" });
+  }
+  if constexpr (hasProcessTimeframeTracks) {
+    inputs.emplace_back(InputSpec{ "timeframe", "AOD", "TIMEFRAME" });
   }
 
   DataProcessorSpec spec{

--- a/Framework/Core/include/Framework/Kernels.h
+++ b/Framework/Core/include/Framework/Kernels.h
@@ -1,0 +1,88 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_FRAMEWORK_KERNELS_H_
+#define O2_FRAMEWORK_KERNELS_H_
+
+#include "arrow/compute/kernel.h"
+#include "arrow/status.h"
+#include "arrow/util/visibility.h"
+#include <arrow/util/variant.h>
+
+#include <string>
+
+namespace arrow
+{
+class Array;
+class DataType;
+
+namespace compute
+{
+class FunctionContext;
+} // namespace compute
+} // namespace arrow
+
+namespace o2
+{
+namespace framework
+{
+
+struct ARROW_EXPORT HashByColumnOptions {
+  std::string columnName;
+};
+
+/// A kernel which provides a unique hash based on the contents of a given
+/// column
+/// * The input datum has to be a table like object.
+/// * The output datum will be a column of integers which define the
+///   category.
+class ARROW_EXPORT HashByColumnKernel : public arrow::compute::UnaryKernel
+{
+ public:
+  HashByColumnKernel(HashByColumnOptions options = {});
+  virtual arrow::Status Call(arrow::compute::FunctionContext* ctx,
+                             arrow::compute::Datum const& table,
+                             arrow::compute::Datum* hashes) override;
+
+ private:
+  HashByColumnOptions mOptions;
+};
+
+struct ARROW_EXPORT GroupByOptions {
+  std::string columnName;
+};
+
+/// Build ranges
+class ARROW_EXPORT SortedGroupByKernel : public arrow::compute::UnaryKernel
+{
+ public:
+  explicit SortedGroupByKernel(GroupByOptions options = {});
+  virtual arrow::Status Call(arrow::compute::FunctionContext* ctx,
+                             arrow::compute::Datum const& table,
+                             arrow::compute::Datum* outputRanges) override;
+  //virtual std::shared_ptr<arrow::DataType> out_type() const override {
+  //  return mType;
+  //}
+
+ private:
+  std::shared_ptr<arrow::DataType> mType;
+  GroupByOptions mOptions;
+};
+
+/// Slice a given table is a vector of tables each containing a slice.
+arrow::Status sliceByColumn(arrow::compute::FunctionContext* context,
+                            std::string const& key,
+                            arrow::compute::Datum const& inputTable,
+                            std::vector<arrow::compute::Datum>* outputSlices);
+
+} // namespace framework
+} // namespace o2
+
+#endif // O2_FRAMEWORK_KERNELS_H_

--- a/Framework/Core/src/Kernels.cxx
+++ b/Framework/Core/src/Kernels.cxx
@@ -1,0 +1,119 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/Kernels.h"
+#include "Framework/TableBuilder.h"
+
+#include <arrow/builder.h>
+#include <arrow/status.h>
+#include <arrow/type.h>
+#include <arrow/util/variant.h>
+#include <memory>
+#include <iostream>
+
+using namespace arrow;
+using namespace arrow::compute;
+
+namespace o2
+{
+namespace framework
+{
+
+HashByColumnKernel::HashByColumnKernel(HashByColumnOptions options)
+  : mOptions{ options }
+{
+}
+
+Status HashByColumnKernel::Call(FunctionContext* ctx, Datum const& inputTable, Datum* hashes)
+{
+  if (inputTable.kind() == Datum::TABLE) {
+    auto table = arrow::util::get<std::shared_ptr<arrow::Table>>(inputTable.value);
+    auto columnIndex = table->schema()->GetFieldIndex(mOptions.columnName);
+    auto chunkedArray = table->column(columnIndex)->data();
+    *hashes = std::move(chunkedArray);
+    return arrow::Status::OK();
+  }
+  return Status::Invalid("Input Datum was not a table");
+}
+
+SortedGroupByKernel::SortedGroupByKernel(GroupByOptions options)
+  : mOptions(options)
+{
+}
+
+Status SortedGroupByKernel::Call(FunctionContext* ctx, Datum const& inputTable, Datum* outputRanges)
+{
+  if (inputTable.kind() == Datum::TABLE) {
+    auto table = arrow::util::get<std::shared_ptr<arrow::Table>>(inputTable.value);
+    auto columnIndex = table->schema()->GetFieldIndex(mOptions.columnName);
+    auto chunkedArray = table->column(columnIndex)->data();
+    TableBuilder builder;
+    auto writer = builder.persist<uint64_t, uint64_t>({ "start", "count" });
+    uint64_t currentIndex = std::static_pointer_cast<arrow::UInt64Array>(chunkedArray->chunk(0))->raw_values()[0];
+    uint64_t currentCount = 0;
+    for (size_t ci = 0; ci < chunkedArray->num_chunks(); ++ci) {
+      auto chunk = chunkedArray->chunk(ci);
+      uint64_t const* data = std::static_pointer_cast<arrow::UInt64Array>(chunk)->raw_values();
+      for (size_t ai = 0; ai < chunk->length(); ++ai) {
+        if (currentIndex == data[ai]) {
+          currentCount++;
+        } else if (currentIndex != -1) {
+          writer(0, currentIndex, currentCount);
+          currentIndex = data[ai];
+          currentCount = 1;
+        }
+      }
+    }
+    writer(0, currentIndex, currentCount);
+    *outputRanges = std::move(builder.finalize());
+    return arrow::Status::OK();
+  }
+  return arrow::Status::OK();
+}
+
+/// Slice a given table is a vector of tables each containing a slice.
+arrow::Status sliceByColumn(FunctionContext* context, std::string const& key,
+                            Datum const& inputTable, std::vector<Datum>* outputSlices)
+{
+  if (inputTable.kind() != Datum::TABLE) {
+    return Status::Invalid("Input Datum was not a table");
+  }
+
+  // build all the ranges on the fly.
+  Datum outRanges;
+  SortedGroupByKernel groupBy({ GroupByOptions{ key } });
+  ARROW_RETURN_NOT_OK(groupBy.Call(context, inputTable, &outRanges));
+  auto ranges = util::get<std::shared_ptr<arrow::Table>>(outRanges.value);
+  outputSlices->reserve(ranges->num_rows());
+
+  auto startChunks = ranges->column(0)->data();
+  assert(startChunks->num_chunks() == 1);
+  auto countChunks = ranges->column(1)->data();
+  assert(countChunks->num_chunks() == 1);
+  auto startData = std::static_pointer_cast<UInt64Array>(startChunks->chunk(0))->raw_values();
+  auto countData = std::static_pointer_cast<UInt64Array>(countChunks->chunk(0))->raw_values();
+
+  auto table = arrow::util::get<std::shared_ptr<arrow::Table>>(inputTable.value);
+  for (size_t ri = 0; ri < ranges->num_rows(); ++ri) {
+    auto start = startData[ri];
+    auto count = countData[ri];
+    auto schema = table->schema();
+    std::vector<std::shared_ptr<Column>> slicedColumns;
+    slicedColumns.reserve(schema->num_fields());
+    for (size_t ci = 0; ci < schema->num_fields(); ++ci) {
+      slicedColumns.emplace_back(table->column(ci)->Slice(start, count));
+    }
+    outputSlices->emplace_back(Datum(arrow::Table::Make(table->schema(), slicedColumns)));
+  }
+  Datum out;
+  return arrow::Status::OK();
+}
+
+} // namespace framework
+} // namespace o2

--- a/Framework/Core/test/test_ASoA.cxx
+++ b/Framework/Core/test/test_ASoA.cxx
@@ -1,0 +1,81 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test Framework ASoA
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include "Framework/ASoA.h"
+#include "Framework/TableBuilder.h"
+#include <boost/test/unit_test.hpp>
+
+using namespace o2::framework;
+using namespace arrow;
+using namespace o2::soa;
+
+namespace test
+{
+DECLARE_SOA_COLUMN(X, x, uint64_t, "x");
+DECLARE_SOA_COLUMN(Y, y, uint64_t, "y");
+} // namespace test
+
+BOOST_AUTO_TEST_CASE(TestTableIteration)
+{
+  TableBuilder builder;
+  auto rowWriter = builder.persist<uint64_t, uint64_t>({ "x", "y" });
+  rowWriter(0, 0, 0);
+  rowWriter(0, 0, 1);
+  rowWriter(0, 0, 2);
+  rowWriter(0, 0, 3);
+  rowWriter(0, 1, 4);
+  rowWriter(0, 1, 5);
+  rowWriter(0, 1, 6);
+  rowWriter(0, 1, 7);
+  auto table = builder.finalize();
+
+  auto i = ColumnIterator<uint64_t>(table->column(0));
+  BOOST_CHECK_EQUAL(*i++, 0);
+  BOOST_CHECK_EQUAL(*i++, 0);
+  BOOST_CHECK_EQUAL(*i++, 0);
+  BOOST_CHECK_EQUAL(*i++, 0);
+  BOOST_CHECK_EQUAL(*i++, 1);
+  BOOST_CHECK_EQUAL(*i++, 1);
+  BOOST_CHECK_EQUAL(*i++, 1);
+  BOOST_CHECK_EQUAL(*i++, 1);
+
+  RowView<test::X, test::Y> tests(table);
+  BOOST_CHECK_EQUAL(tests.x(), 0);
+  BOOST_CHECK_EQUAL(tests.y(), 0);
+  ++tests;
+  BOOST_CHECK_EQUAL(tests.x(), 0);
+  BOOST_CHECK_EQUAL(tests.y(), 1);
+  using Test = o2::soa::Table<test::X, test::Y>;
+  Test tests2{ table };
+  size_t value = 0;
+  auto b = tests2.begin();
+  auto e = tests2.end();
+  BOOST_CHECK(b != e);
+  b++;
+  b++;
+  b++;
+  b++;
+  b++;
+  b++;
+  b++;
+  b++;
+  BOOST_CHECK(b == e);
+
+  for (auto t : tests2) {
+    BOOST_CHECK_EQUAL(t.x(), value / 4);
+    BOOST_CHECK_EQUAL(t.y(), value);
+    BOOST_REQUIRE(value < 8);
+    value++;
+  }
+}

--- a/Framework/Core/test/test_Kernels.cxx
+++ b/Framework/Core/test/test_Kernels.cxx
@@ -1,0 +1,64 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test Framework AlgorithmSpec
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include "Framework/Kernels.h"
+#include "Framework/TableBuilder.h"
+#include <arrow/compute/context.h>
+#include <arrow/compute/kernels/hash.h>
+#include <boost/test/unit_test.hpp>
+
+using namespace o2::framework;
+using namespace arrow;
+using namespace arrow::compute;
+
+BOOST_AUTO_TEST_CASE(TestHashByColumnKernel)
+{
+  TableBuilder builder;
+  auto rowWriter = builder.persist<uint64_t, uint64_t>({ "x", "y" });
+  rowWriter(0, 0, 0);
+  rowWriter(0, 0, 1);
+  rowWriter(0, 0, 2);
+  rowWriter(0, 0, 3);
+  rowWriter(0, 1, 4);
+  rowWriter(0, 1, 5);
+  rowWriter(0, 1, 6);
+  rowWriter(0, 1, 7);
+  auto table = builder.finalize();
+
+  arrow::compute::FunctionContext ctx;
+  HashByColumnKernel kernel{ { "x" } };
+  std::shared_ptr<arrow::Array> out;
+  auto outDatum = arrow::compute::Datum(out);
+  BOOST_CHECK_EQUAL(kernel.Call(&ctx, arrow::compute::Datum(table), &outDatum).ok(), true);
+  auto indices = arrow::util::get<std::shared_ptr<arrow::ChunkedArray>>(outDatum.value);
+  BOOST_CHECK_EQUAL(indices->length(), table->num_rows());
+
+  std::shared_ptr<arrow::Array> uniqueValues;
+  BOOST_CHECK_EQUAL(Unique(&ctx, arrow::compute::Datum(indices), &uniqueValues).ok(), true);
+  BOOST_REQUIRE(uniqueValues.get() != nullptr);
+  BOOST_CHECK_EQUAL(uniqueValues->length(), 2);
+
+  arrow::compute::Datum outRanges;
+  SortedGroupByKernel groupBy{ { "x" } };
+  BOOST_CHECK_EQUAL(groupBy.Call(&ctx, arrow::compute::Datum(table), &outRanges).ok(), true);
+  auto result = arrow::util::get<std::shared_ptr<arrow::Table>>(outRanges.value);
+  BOOST_REQUIRE(result.get() != nullptr);
+  BOOST_CHECK_EQUAL(result->num_rows(), 2);
+
+  std::vector<Datum> splitted;
+  BOOST_CHECK_EQUAL(sliceByColumn(&ctx, "x", arrow::compute::Datum(table), &splitted).ok(), true);
+  BOOST_REQUIRE_EQUAL(splitted.size(), 2);
+  BOOST_CHECK_EQUAL(util::get<std::shared_ptr<Table>>(splitted[0].value)->num_rows(), 4);
+  BOOST_CHECK_EQUAL(util::get<std::shared_ptr<Table>>(splitted[1].value)->num_rows(), 4);
+}

--- a/Framework/Foundation/CMakeLists.txt
+++ b/Framework/Foundation/CMakeLists.txt
@@ -12,3 +12,8 @@ set(MODULE_NAME "FrameworkFoundation")
 
 set(MODULE_BUCKET_NAME O2FrameworkFoundation_bucket)
 
+O2_GENERATE_TESTS(
+  MODULE_LIBRARY_NAME ${LIBRARY_NAME}
+  BUCKET_NAME O2FrameworkFoundation_bucket
+  TEST_SRCS test/test_Traits.cxx
+)

--- a/Framework/Foundation/include/Framework/Traits.h
+++ b/Framework/Foundation/include/Framework/Traits.h
@@ -1,0 +1,27 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_FRAMEWORK_TRAITS_H_
+#define O2_FRAMEWORK_TRAITS_H_
+
+#include <type_traits>
+
+namespace o2
+{
+namespace framework
+{
+
+template <typename A, typename B>
+struct is_overriding : public std::bool_constant<std::is_same_v<A, B> == false && std::is_member_function_pointer_v<A> && std::is_member_function_pointer_v<B>> {
+};
+} // namespace framework
+} // namespace o2
+
+#endif // O2_FRAMEWORK_TRAITS_H_

--- a/Framework/Foundation/test/test_Traits.cxx
+++ b/Framework/Foundation/test/test_Traits.cxx
@@ -1,0 +1,35 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test Framework Traits
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+#include "Framework/Traits.h"
+
+struct Foo {
+  virtual void a() {}
+};
+
+struct Bar : public Foo {
+  virtual void a() {}
+};
+
+struct FooBar : public Foo {
+};
+
+BOOST_AUTO_TEST_CASE(TestOverride)
+{
+  bool check1 = o2::framework::is_overriding<decltype(&Bar::a), decltype(&Foo::a)>::value;
+  BOOST_CHECK_EQUAL(check1, true);
+  bool check2 = o2::framework::is_overriding<decltype(&FooBar::a), decltype(&Foo::a)>::value;
+  BOOST_CHECK_EQUAL(check2, false);
+}

--- a/Framework/TestWorkflows/src/o2AnalysisTaskExample.cxx
+++ b/Framework/TestWorkflows/src/o2AnalysisTaskExample.cxx
@@ -10,6 +10,7 @@
 #include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
 
+using namespace o2;
 using namespace o2::framework;
 
 // This is a stateful task, where we send the state downstream.
@@ -27,7 +28,7 @@ class ATask : public AnalysisTask
   {
   }
 
-  void processTracks(std::shared_ptr<arrow::Table> tracks)
+  virtual void processTimeframeTracks(aod::Timeframe const&, aod::Tracks const& tracks) override
   {
   }
 


### PR DESCRIPTION
This PR serves four purposes:

* It introduces an helper which allows static dispatching of virtual methods of a given base class (AnalysisTask, in this case) so that DPL will request the data needed and perform a given operation only when the hooks are effectively overriden by the AnalysisTask implementor.
* It introduces a few kernels for splitting a large table of tracks in it's "per-event" sub-tables. Actual data is zero-copied thanks to Arrow Table slicing facilities. It also serves as an example of how to create Arrow compute Kernels.
* It introduces a few new analysis hooks, as discussed, to process various combinations of Collisions, Timeframe and Tracks.
* It introduces a new SoA layer which sits on top of Arrow Tables and allows to iterate over via a user friendly, physics oriented C++ API.