### PR TITLE
Provide generic SetSpecialPhysicsCut implementation

### DIFF
--- a/Detectors/Base/include/DetectorsBase/Detector.h
+++ b/Detectors/Base/include/DetectorsBase/Detector.h
@@ -96,6 +96,10 @@ class Detector : public FairDetector
       return mDensityFactor;
     }
 
+    /// implements interface of FairModule;
+    /// generic implementation for O2 detectors
+    void SetSpecialPhysicsCuts() override;
+
     /// declare alignable volumes of detector
     virtual void addAlignableVolumes() const;
     

--- a/Detectors/Base/src/Detector.cxx
+++ b/Detectors/Base/src/Detector.cxx
@@ -115,6 +115,27 @@ void Detector::defineLayerTurbo(Int_t nlay, Double_t phi0, Double_t r, Int_t nla
 {
 }
 
+void Detector::SetSpecialPhysicsCuts()
+{
+  // default implementation for physics cuts setting (might still be overriden by detectors)
+  // we try to read an external text file supposed to be installed
+  // in a standard directory
+  // ${O2_ROOT}/share/Detectors/DETECTORNAME/simulation/data/simcuts.dat
+  LOG(INFO) << "Setting special cuts for " << GetName();
+  const char* aliceO2env = std::getenv("O2_ROOT");
+  std::string inputFile;
+  if (aliceO2env) {
+    inputFile = std::string(aliceO2env);
+  }
+  inputFile += "/share/Detectors/" + std::string(GetName()) + "/simulation/data/simcuts.dat";
+  auto& matmgr = o2::base::MaterialManager::Instance();
+  matmgr.loadCutsAndProcessesFromFile(GetName(), inputFile.c_str());
+
+  // TODO:
+  // foresee possibility to read from local (non-installed) file or
+  // via command line
+}
+
 void Detector::initFieldTrackingParams(int& integration, float& maxfield)
 {
   // set reasonable default values

--- a/Detectors/Base/src/MaterialManager.cxx
+++ b/Detectors/Base/src/MaterialManager.cxx
@@ -365,7 +365,7 @@ void MaterialManager::loadCutsAndProcessesFromFile(const char* modname, const ch
   std::ifstream cutfile(filename);
 
   if (!cutfile.is_open()) {
-    LOG(ERROR) << "File " << filename << " does not exist; Cannot apply cuts";
+    LOG(WARN) << "File " << filename << " does not exist; Cannot apply cuts";
     return;
   }
 

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
@@ -226,7 +226,6 @@ class Detector : public o2::base::DetImpl<Detector>
   /// \param id volume id
   Int_t chipVolUID(Int_t id) const { return o2::base::GeometryManager::getSensID(o2::detectors::DetID::ITS, id); }
 
-  void SetSpecialPhysicsCuts() override { ; }
   void EndOfEvent() override;
 
   void FinishPrimary() override { ; }

--- a/Detectors/ITSMFT/MFT/simulation/include/MFTSimulation/Detector.h
+++ b/Detectors/ITSMFT/MFT/simulation/include/MFTSimulation/Detector.h
@@ -82,7 +82,6 @@ class Detector : public o2::base::DetImpl<Detector>
   void BeginPrimary() override { ; }
   void PostTrack() override { ; }
   void PreTrack() override { ; }
-  void SetSpecialPhysicsCuts() override { ; }
   void ConstructGeometry() override; // inherited from FairModule
 
   //

--- a/Detectors/TRD/simulation/CMakeLists.txt
+++ b/Detectors/TRD/simulation/CMakeLists.txt
@@ -18,3 +18,5 @@ SET(LIBRARY_NAME ${MODULE_NAME})
 SET(BUCKET_NAME trd_simulation_bucket)
 
 O2_GENERATE_LIBRARY()
+
+INSTALL(DIRECTORY data DESTINATION share/Detectors/TRD/simulation)

--- a/Detectors/TRD/simulation/data/simcuts.dat
+++ b/Detectors/TRD/simulation/data/simcuts.dat
@@ -1,0 +1,9 @@
+* TRD
+* ===
+*
+*    Med GAM   ELEC  NHAD  CHAD  MUON  EBREM MUHAB EDEL  MUDEL MUPA  ANNI  BREM  COMP  DCAY  DRAY  HADR  LOSS  MULS  PAIR  PHOT  RAYL  STRA
+* Mylar
+TRD  27  1e-5  1e-5  1e-3  1e-3  1e-5  1e-5  1e-5  1e-5  1e-5  -1.   1     1     1     1     1     1     3     1     1     1     1     0
+* Gas mixture
+TRD   9  1e-5  1e-5  1e-3  1e-3  1e-5  1e-5  1e-5  1e-5  1e-5  -1.   1     1     1     1     1     1     3     1     1     1     1     1
+*

--- a/Detectors/ZDC/simulation/include/ZDCSimulation/Detector.h
+++ b/Detectors/ZDC/simulation/include/ZDCSimulation/Detector.h
@@ -70,7 +70,6 @@ class Detector : public o2::base::DetImpl<Detector>
   void EndOfEvent() final;
 
   void ConstructGeometry() final;
-  void SetSpecialPhysicsCuts() final;
 
   void createMaterials();
   void addAlignableVolumes() const override {}

--- a/Detectors/ZDC/simulation/src/Detector.cxx
+++ b/Detectors/ZDC/simulation/src/Detector.cxx
@@ -2208,17 +2208,3 @@ void Detector::Reset()
 {
   mHits->clear();
 }
-
-//_____________________________________________________________________________
-void Detector::SetSpecialPhysicsCuts()
-{
-  LOG(INFO) << "Setting special cuts for ZDC";
-  const char* aliceO2env = std::getenv("O2_ROOT");
-  std::string inputFile;
-  if (aliceO2env) {
-    inputFile = std::string(aliceO2env);
-  }
-  inputFile += "/share/Detectors/ZDC/simulation/data/simcuts.dat";
-  auto& matmgr = o2::base::MaterialManager::Instance();
-  matmgr.loadCutsAndProcessesFromFile(GetName(), inputFile.c_str());
-}


### PR DESCRIPTION
(Sensitive) detectors can now simply provide a simcuts.dat
file in order to have cuts applied automatically.

This should make it easy to copy cuts from AliRoot (but a review
of the values is in any case suggested).

Since this is virtual mechanism the default behaviour can still be
overridden (as done by TPC).

Applying generic implementation to ZDC and TRD.