### PR TITLE
Provide default values for rarely used DataProcessorSpec members

### DIFF
--- a/Framework/Core/include/Framework/DataProcessorSpec.h
+++ b/Framework/Core/include/Framework/DataProcessorSpec.h
@@ -39,16 +39,16 @@ struct DataProcessorSpec {
   Outputs outputs;
   AlgorithmSpec algorithm;
 
-  Options options;
+  Options options = {};
   // FIXME: not used for now...
-  std::vector<std::string> requiredServices;
+  std::vector<std::string> requiredServices = {};
   /// Labels associated to the DataProcessor. These can
   /// be used to group different DataProcessor together
   /// and they can allow to filter different groups, e.g.
   /// use push/pull rather than pub/sub for all the edges
   /// which involve a DataProcessorSpec with a given label.
   /// Examples labels could be "reco", "qc".
-  std::vector<DataProcessorLabel> labels;
+  std::vector<DataProcessorLabel> labels = {};
 
   // FIXME: for the moment I put them here, but it's a hack
   //        since we do not want to expose this to users...


### PR DESCRIPTION
This should suppress the 'missing initializer for member' warnings generated when Options, Services and labels are not explicitly specified. We have this warning enabled in QC.