### PR TITLE
DPL: add SoA support to TableBuilder.

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -138,6 +138,7 @@ class ColumnIterator
 
 template <typename T, typename INHERIT>
 struct Column {
+  using type = T;
   static constexpr const char* const& label() { return INHERIT::mLabel; }
   ColumnIterator<T> const& getIterator() const
   {
@@ -193,6 +194,7 @@ class Table
 {
  public:
   using iterator = RowView<C...>;
+  using columns = std::tuple<C...>;
 
   Table(std::shared_ptr<arrow::Table> table)
     : mTable(table)

--- a/Framework/Core/test/test_TableBuilder.cxx
+++ b/Framework/Core/test/test_TableBuilder.cxx
@@ -218,3 +218,32 @@ BOOST_AUTO_TEST_CASE(TestCombinedDS)
   //BOOST_CHECK_EQUAL(*unionDF.Define("s5", sum, {"right_x", "left_x"}).Sum("s5"), 56);
   //BOOST_CHECK_EQUAL(*blockDF.Define("s5", sum, {"right_x", "left_x"}).Sum("s5"), 168);
 }
+
+namespace test
+{
+DECLARE_SOA_COLUMN(X, x, uint64_t, "x");
+DECLARE_SOA_COLUMN(Y, y, uint64_t, "y");
+} // namespace test
+
+using TestTable = o2::soa::Table<test::X, test::Y>;
+
+BOOST_AUTO_TEST_CASE(TestSoAIntegration)
+{
+  TableBuilder builder;
+  auto rowWriter = builder.cursor<TestTable>();
+  rowWriter(0, 0, 0);
+  rowWriter(0, 10, 1);
+  rowWriter(0, 20, 2);
+  rowWriter(0, 30, 3);
+  rowWriter(0, 40, 4);
+  rowWriter(0, 50, 5);
+  auto table = builder.finalize();
+  auto readBack = TestTable{ table };
+
+  size_t i = 0;
+  for (auto& row : readBack) {
+    BOOST_CHECK_EQUAL(row.x(), i * 10);
+    BOOST_CHECK_EQUAL(row.y(), i);
+    ++i;
+  }
+}


### PR DESCRIPTION
Previous way of building tables:

     auto rowWriter = builder.persist<int, int, int>("x", "y", "z");

can now be replaced by:

     auto rowWriter = builder.cursor<SimpleVector>();

assuming `SimpleVector` is a `soa::Table` derived class.