### PR TITLE
DPL: Possibility to snapshot an already serialized object

### DIFF
--- a/Framework/Core/include/Framework/DataAllocator.h
+++ b/Framework/Core/include/Framework/DataAllocator.h
@@ -467,6 +467,10 @@ class DataAllocator
                   "pointer to data type not supported by API. Please pass object by reference");
   }
 
+  /// Take a snapshot of a raw data array which may contain a serialized object.
+  void snapshot(const Output& spec, const char* payload, size_t payloadSize,
+                o2::header::SerializationMethod serializationMethod);
+
   /// make an object of type T and route to output specified by OutputRef
   /// The object is owned by the framework, returned reference can be used to fill the object.
   ///

--- a/Framework/Core/src/DataAllocator.cxx
+++ b/Framework/Core/src/DataAllocator.cxx
@@ -177,6 +177,16 @@ void DataAllocator::adopt(const Output& spec, TableBuilder* tb)
   context->addBuffer(std::move(header), buffer, std::move(finalizer), channel);
 }
 
+void DataAllocator::snapshot(const Output& spec, const char* payload, size_t payloadSize,
+                             o2::header::SerializationMethod serializationMethod)
+{
+  auto proxy = mContextRegistry->get<MessageContext>()->proxy();
+  FairMQMessagePtr payloadMessage(proxy.createMessage(payloadSize));
+  memcpy(payloadMessage->GetData(), payload, payloadSize);
+
+  addPartToContext(std::move(payloadMessage), spec, serializationMethod);
+}
+
 void DataAllocator::create(const Output& spec,
                            std::shared_ptr<arrow::ipc::RecordBatchWriter>* writer,
                            std::shared_ptr<arrow::Schema> schema)


### PR DESCRIPTION
In the Data Sampling's Dispatcher, I would like to be agnostic to what I copy from input to output. This would facilitate supporting all serialization methods and improve its performance (no serialization and de-serialization required anymore).
@ktf @matthiasrichter Are you fine with this modification? I am not forcing it, if there is a way to achieve that with the existing code.