### PR TITLE
TRD presorted hit array per detector O2-455

### DIFF
--- a/Detectors/TRD/base/include/TRDBase/TRDCommonParam.h
+++ b/Detectors/TRD/base/include/TRDBase/TRDCommonParam.h
@@ -20,6 +20,7 @@ namespace trd
 
 class TRDPadPlane;
 constexpr int kNlayer = 6, kNstack = 5, kNsector = 18, kNdet = 540;
+constexpr int kTimeBins = 30;
 
 class TRDCommonParam
 {

--- a/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
@@ -54,7 +54,7 @@ class Digitizer
 
   std::vector<HitType> mHitContainer; // The container of hits in a given detector
 
-  bool getHitContainer(const int, const std::vector<HitType>&, std::vector<HitType>&); // True if there are hits in the detector
+  void getHitContainerPerDetector(const std::vector<HitType>&, std::array<std::vector<HitType>, 540> &);
   // Digitization chaing methods
   bool convertHits(const int, const std::vector<HitType>&, TRDArraySignal&); // True if hit-to-signal conversion is successful
   bool convertSignalsToDigits(const int, int&);                              // True if signal-to-digit conversion is successful

--- a/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
@@ -13,6 +13,7 @@
 
 #include "TRDSimulation/Detector.h"
 #include "TRDBase/Digit.h"
+#include "TRDBase/TRDCommonParam.h"
 
 namespace o2
 {
@@ -20,7 +21,6 @@ namespace trd
 {
 
 class TRDGeometry;
-class TRDCommonParam;
 class TRDSimParam;
 class TRDPadPlane;
 class TRDArraySignal;
@@ -29,9 +29,6 @@ class PadResponse;
 class Digitizer
 {
  public:
-  enum { kTimeBins = 30,
-         kNdet = 540 };
-  //
   Digitizer();
   ~Digitizer() = default;
   void process(std::vector<HitType> const&, std::vector<Digit>&);

--- a/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
@@ -29,7 +29,8 @@ class PadResponse;
 class Digitizer
 {
  public:
-  enum { kTimeBins = 30 };
+  enum { kTimeBins = 30,
+         kNdet = 540 };
   //
   Digitizer();
   ~Digitizer() = default;
@@ -54,7 +55,7 @@ class Digitizer
 
   std::vector<HitType> mHitContainer; // The container of hits in a given detector
 
-  void getHitContainerPerDetector(const std::vector<HitType>&, std::array<std::vector<HitType>, 540>&);
+  void getHitContainerPerDetector(const std::vector<HitType>&, std::array<std::vector<HitType>, kNdet>&);
   // Digitization chaing methods
   bool convertHits(const int, const std::vector<HitType>&, TRDArraySignal&); // True if hit-to-signal conversion is successful
   bool convertSignalsToDigits(const int, int&);                              // True if signal-to-digit conversion is successful

--- a/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
@@ -54,7 +54,7 @@ class Digitizer
 
   std::vector<HitType> mHitContainer; // The container of hits in a given detector
 
-  void getHitContainerPerDetector(const std::vector<HitType>&, std::array<std::vector<HitType>, 540> &);
+  void getHitContainerPerDetector(const std::vector<HitType>&, std::array<std::vector<HitType>, 540>&);
   // Digitization chaing methods
   bool convertHits(const int, const std::vector<HitType>&, TRDArraySignal&); // True if hit-to-signal conversion is successful
   bool convertSignalsToDigits(const int, int&);                              // True if signal-to-digit conversion is successful

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -15,7 +15,6 @@
 #include "DetectorsBase/GeometryManager.h"
 
 #include "TRDBase/TRDGeometry.h"
-#include "TRDBase/TRDCommonParam.h" // For kNdet & el. diffusion
 #include "TRDBase/TRDSimParam.h"
 #include "TRDBase/TRDPadPlane.h"
 #include "TRDBase/TRDArraySignal.h"

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -65,7 +65,7 @@ void Digitizer::process(std::vector<HitType> const& hits, std::vector<Digit>& di
   int totalNumberOfProcessedHits = 0;
   // LOG(INFO) << "Start of processing " << hits.size() << " hits";
 
-  std::array<std::vector<HitType>, 540> hitsPerDetector;
+  std::array<std::vector<HitType>, kNdet> hitsPerDetector;
   getHitContainerPerDetector(hits, hitsPerDetector);
 
   for (int det = 0; det < kNdet; ++det) {
@@ -98,10 +98,10 @@ void Digitizer::process(std::vector<HitType> const& hits, std::vector<Digit>& di
   // LOG(INFO) << "End of processing " << totalNumberOfProcessedHits << " hits";
 }
 
-void Digitizer::getHitContainerPerDetector(const std::vector<HitType>& hits, std::array<std::vector<HitType>, 540>& hitsPerDetector)
+void Digitizer::getHitContainerPerDetector(const std::vector<HitType>& hits, std::array<std::vector<HitType>, kNdet>& hitsPerDetector)
 {
   //
-  // Fill an array of size 540
+  // Fill an array of size kNdet (540)
   // The i-element of the array contains the hit collection for the i-detector
   // To be called once, before doing the loop over all detectors and process the hits
   //

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -106,10 +106,8 @@ void Digitizer::getHitContainerPerDetector(const std::vector<HitType>& hits, std
   // The i-element of the array contains the hit collection for the i-detector
   // To be called once, before doing the loop over all detectors and process the hits
   //
-  short det = 0; // 0 - 539
   for (const auto& hit : hits) {
-    det = hit.GetDetectorID();
-    hitsPerDetector[det].push_back(hit);
+    hitsPerDetector[hit.GetDetectorID()].push_back(hit);
   }
 }
 


### PR DESCRIPTION
A more efficient way of passing the hits per detector at the cost of using some extra memory:

- Create an array of size 540 to contain the hit containers per detector
- Each element of the array contains the hit collection for a given detector
- Requieres only one loop per event over the full hit container: previously we had Nevents * HitsContainerSize loops.
- The array<vector> data structure was proposed to be created at the processHits level, but rejected since it was inefficient at the DPL. So, here it is used as a helper only.