### PR TITLE
DPL: refactor OutputSpec and ChannelMatching

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -28,6 +28,7 @@ set(SRCS
     src/ChannelSpecHelpers.cxx
     src/CompletionPolicyHelpers.cxx
     src/ChannelConfigurationPolicy.cxx
+    src/ChannelMatching.cxx
     src/ChannelConfigurationPolicyHelpers.cxx
     src/DataAllocator.cxx
     src/DataDescriptorMatcher.cxx
@@ -51,6 +52,7 @@ set(SRCS
     src/O2ControlHelpers.cxx
     src/DriverControl.cxx
     src/DriverInfo.cxx
+    src/ExternalFairMQDeviceProxy.cxx
     src/FairOptionsRetriever.cxx
     src/FairMQDeviceProxy.cxx
     src/FairMQResizableBuffer.cxx
@@ -58,13 +60,13 @@ set(SRCS
     src/GraphvizHelpers.cxx
     src/InputRecord.cxx
     src/InputSpec.cxx
+    src/OutputSpec.cxx
     src/Kernels.cxx
     src/DataDescriptorQueryBuilder.cxx
     src/LifetimeHelpers.cxx
     src/LocalRootFileService.cxx
     src/LogParsingHelpers.cxx
     src/Metric2DViewIndex.cxx
-    src/ExternalFairMQDeviceProxy.cxx
     src/SimpleResourceManager.cxx
     src/TextControlService.cxx
     src/TableBuilder.cxx

--- a/Framework/Core/include/Framework/ChannelMatching.h
+++ b/Framework/Core/include/Framework/ChannelMatching.h
@@ -7,36 +7,22 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#ifndef FRAMEWORK_CHANNELMATCHING_H
-#define FRAMEWORK_CHANNELMATCHING_H
+#ifndef O2_FRAMEWORK_CHANNELMATCHING_H_
+#define O2_FRAMEWORK_CHANNELMATCHING_H_
 
-#include "Framework/DataProcessorSpec.h"
 #include "Framework/InputSpec.h"
 #include "Framework/OutputSpec.h"
-#include "Framework/DataSpecUtils.h"
 
-#include <vector>
 #include <string>
 
-namespace o2
-{
-namespace framework
+namespace o2::framework
 {
 
 struct LogicalChannelRange {
-  LogicalChannelRange(const OutputSpec& spec)
-  {
-    name = std::string("out_") +
-           spec.origin.as<std::string>() + "_" +
-           spec.description.as<std::string>() + "_" +
-           std::to_string(spec.subSpec);
-  }
+  LogicalChannelRange(OutputSpec const& spec);
 
   std::string name;
-  bool operator<(LogicalChannelRange const& other) const
-  {
-    return this->name < other.name;
-  }
+  bool operator<(LogicalChannelRange const& other) const;
 };
 
 struct DomainId {
@@ -44,46 +30,24 @@ struct DomainId {
 };
 
 struct LogicalChannelDomain {
-  LogicalChannelDomain(const InputSpec& spec)
-  {
-    name.value = std::string("out_") + std::string(DataSpecUtils::label(spec));
-  }
+  LogicalChannelDomain(InputSpec const& spec);
   DomainId name;
-  bool operator<(LogicalChannelDomain const& other) const
-  {
-    return this->name.value < other.name.value;
-  }
+  bool operator<(LogicalChannelDomain const& other) const;
 };
 
 struct PhysicalChannelRange {
-  PhysicalChannelRange(const OutputSpec& spec, int count)
-  {
-    char buffer[16];
-    auto channel = LogicalChannelRange(spec);
-    id = channel.name + (snprintf(buffer, 16, "_%d", count), buffer);
-  }
+  PhysicalChannelRange(OutputSpec const& spec, int count);
 
   std::string id;
-  bool operator<(PhysicalChannelRange const& other) const
-  {
-    return this->id < other.id;
-  }
+  bool operator<(PhysicalChannelRange const& other) const;
 };
 
 struct PhysicalChannelDomain {
-  PhysicalChannelDomain(const InputSpec& spec, int count)
-  {
-    char buffer[16];
-    auto channel = LogicalChannelDomain(spec);
-    id.value = channel.name.value + (snprintf(buffer, 16, "_%d", count), buffer);
-  }
+  PhysicalChannelDomain(InputSpec const& spec, int count);
+
   DomainId id;
-  bool operator<(PhysicalChannelDomain const& other) const
-  {
-    return this->id.value < other.id.value;
-  }
+  bool operator<(PhysicalChannelDomain const& other) const;
 };
 
-} // namespace framework
-} // namespace o2
+} // namespace o2::framework
 #endif // FRAMEWORK_CHANNELMATCHING_H

--- a/Framework/Core/include/Framework/OutputSpec.h
+++ b/Framework/Core/include/Framework/OutputSpec.h
@@ -7,15 +7,13 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#ifndef FRAMEWORK_OUTPUTSPEC_H
-#define FRAMEWORK_OUTPUTSPEC_H
+#ifndef O2_FRAMEWORK_OUTPUTSPEC_H_
+#define O2_FRAMEWORK_OUTPUTSPEC_H_
 
 #include "Headers/DataHeader.h"
 #include "Framework/Lifetime.h"
 
-namespace o2
-{
-namespace framework
+namespace o2::framework
 {
 
 struct OutputLabel {
@@ -33,50 +31,21 @@ struct OutputSpec {
   enum Lifetime lifetime = Lifetime::Timeframe;
 
   OutputSpec(OutputLabel const& inBinding, header::DataOrigin inOrigin, header::DataDescription inDescription,
-             header::DataHeader::SubSpecificationType inSubSpec, enum Lifetime inLifetime = Lifetime::Timeframe)
-    : binding{ inBinding },
-      origin{ inOrigin },
-      description{ inDescription },
-      subSpec{ inSubSpec },
-      lifetime{ inLifetime }
-  {
-  }
+             header::DataHeader::SubSpecificationType inSubSpec, enum Lifetime inLifetime = Lifetime::Timeframe);
 
   OutputSpec(header::DataOrigin inOrigin, header::DataDescription inDescription,
-             header::DataHeader::SubSpecificationType inSubSpec, enum Lifetime inLifetime = Lifetime::Timeframe)
-    : binding{ OutputLabel{ "" } },
-      origin{ inOrigin },
-      description{ inDescription },
-      subSpec{ inSubSpec },
-      lifetime{ inLifetime }
-  {
-  }
+             header::DataHeader::SubSpecificationType inSubSpec, enum Lifetime inLifetime = Lifetime::Timeframe);
 
   OutputSpec(OutputLabel const& inBinding, header::DataOrigin inOrigin, header::DataDescription inDescription,
-             enum Lifetime inLifetime = Lifetime::Timeframe)
-    : binding{ inBinding }, origin{ inOrigin }, description{ inDescription }, subSpec{ 0 }, lifetime{ inLifetime }
-  {
-  }
+             enum Lifetime inLifetime = Lifetime::Timeframe);
 
   OutputSpec(header::DataOrigin inOrigin, header::DataDescription inDescription,
-             enum Lifetime inLifetime = Lifetime::Timeframe)
-    : binding{ OutputLabel{ "" } },
-      origin{ inOrigin },
-      description{ inDescription },
-      subSpec{ 0 },
-      lifetime{ inLifetime }
-  {
-  }
+             enum Lifetime inLifetime = Lifetime::Timeframe);
 
-  bool operator==(OutputSpec const& that) const
-  {
-    return origin == that.origin && description == that.description && subSpec == that.subSpec &&
-           lifetime == that.lifetime;
-  };
+  bool operator==(OutputSpec const& that) const;
 
   friend std::ostream& operator<<(std::ostream& stream, OutputSpec const& arg);
 };
 
-} // namespace framework
-} // namespace o2
+} // namespace o2::framework
 #endif

--- a/Framework/Core/src/ChannelMatching.cxx
+++ b/Framework/Core/src/ChannelMatching.cxx
@@ -1,0 +1,62 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/ChannelMatching.h"
+#include "Framework/DataSpecUtils.h"
+
+namespace o2::framework
+{
+
+LogicalChannelRange::LogicalChannelRange(const OutputSpec& spec)
+{
+  name = std::string("out_") +
+         spec.origin.as<std::string>() + "_" +
+         spec.description.as<std::string>() + "_" +
+         std::to_string(spec.subSpec);
+}
+
+bool LogicalChannelRange::operator<(LogicalChannelRange const& other) const
+{
+  return this->name < other.name;
+}
+
+LogicalChannelDomain::LogicalChannelDomain(const InputSpec& spec)
+{
+  name.value = std::string("out_") + std::string(DataSpecUtils::label(spec));
+}
+
+bool LogicalChannelDomain::operator<(LogicalChannelDomain const& other) const
+{
+  return this->name.value < other.name.value;
+}
+
+PhysicalChannelRange::PhysicalChannelRange(const OutputSpec& spec, int count)
+{
+  char buffer[16];
+  auto channel = LogicalChannelRange(spec);
+  id = channel.name + (snprintf(buffer, 16, "_%d", count), buffer);
+}
+
+bool PhysicalChannelRange::operator<(PhysicalChannelRange const& other) const
+{
+  return this->id < other.id;
+}
+
+PhysicalChannelDomain::PhysicalChannelDomain(const InputSpec& spec, int count)
+{
+  char buffer[16];
+  auto channel = LogicalChannelDomain(spec);
+  id.value = channel.name.value + (snprintf(buffer, 16, "_%d", count), buffer);
+}
+
+bool PhysicalChannelDomain::operator<(PhysicalChannelDomain const& other) const
+{
+  return this->id.value < other.id.value;
+}
+} // namespace o2::framework

--- a/Framework/Core/src/OutputSpec.cxx
+++ b/Framework/Core/src/OutputSpec.cxx
@@ -1,0 +1,58 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/OutputSpec.h"
+#include "Framework/Lifetime.h"
+
+namespace o2::framework
+{
+OutputSpec::OutputSpec(OutputLabel const& inBinding, header::DataOrigin inOrigin, header::DataDescription inDescription,
+                       header::DataHeader::SubSpecificationType inSubSpec, enum Lifetime inLifetime)
+  : binding{ inBinding },
+    origin{ inOrigin },
+    description{ inDescription },
+    subSpec{ inSubSpec },
+    lifetime{ inLifetime }
+{
+}
+
+OutputSpec::OutputSpec(header::DataOrigin inOrigin, header::DataDescription inDescription,
+                       header::DataHeader::SubSpecificationType inSubSpec, enum Lifetime inLifetime)
+  : binding{ OutputLabel{ "" } },
+    origin{ inOrigin },
+    description{ inDescription },
+    subSpec{ inSubSpec },
+    lifetime{ inLifetime }
+{
+}
+
+OutputSpec::OutputSpec(OutputLabel const& inBinding, header::DataOrigin inOrigin, header::DataDescription inDescription,
+                       enum Lifetime inLifetime)
+  : binding{ inBinding }, origin{ inOrigin }, description{ inDescription }, subSpec{ 0 }, lifetime{ inLifetime }
+{
+}
+
+OutputSpec::OutputSpec(header::DataOrigin inOrigin, header::DataDescription inDescription,
+                       enum Lifetime inLifetime)
+  : binding{ OutputLabel{ "" } },
+    origin{ inOrigin },
+    description{ inDescription },
+    subSpec{ 0 },
+    lifetime{ inLifetime }
+{
+}
+
+bool OutputSpec::operator==(OutputSpec const& that) const
+{
+  return origin == that.origin && description == that.description && subSpec == that.subSpec &&
+         lifetime == that.lifetime;
+};
+
+} // namespace o2::framework


### PR DESCRIPTION
Moving the implementation to the .cxx file as preliminary work
to make the OutputSpec support wildcards.