### PR TITLE
Disabling failing ccdb_api_test on MacOS

### DIFF
--- a/CCDB/CMakeLists.txt
+++ b/CCDB/CMakeLists.txt
@@ -151,15 +151,17 @@ install(
     DESTINATION bin/config
 )
 
-set(TEST_SRCS
-   test/testWriteReadAny.cxx
-   test/testCcdbApi.cxx
-) 
+if (NOT APPLE)
+  set(TEST_SRCS
+     test/testWriteReadAny.cxx
+     test/testCcdbApi.cxx
+  ) 
 
-O2_GENERATE_TESTS(
-  BUCKET_NAME ${BUCKET_NAME}
-  MODULE_LIBRARY_NAME ${MODULE_NAME}
-  TEST_SRCS ${TEST_SRCS}
-)
+  O2_GENERATE_TESTS(
+    BUCKET_NAME ${BUCKET_NAME}
+    MODULE_LIBRARY_NAME ${MODULE_NAME}
+    TEST_SRCS ${TEST_SRCS}
+  )
+endif()
 
 


### PR DESCRIPTION
not to be merged