### PR TITLE
DPL OutputSpec wildcards

### DIFF
--- a/Framework/Core/include/Framework/DataDescriptorMatcher.h
+++ b/Framework/Core/include/Framework/DataDescriptorMatcher.h
@@ -111,6 +111,12 @@ class ValueHolder
   template <typename V>
   friend std::ostream& operator<<(std::ostream& os, ValueHolder<V> const& holder);
 
+  template <typename VISITOR>
+  decltype(auto) visit(VISITOR visitor) const
+  {
+    return std::visit(visitor, mValue);
+  }
+
  protected:
   std::variant<T, ContextRef> mValue;
 };
@@ -243,6 +249,7 @@ class DataDescriptorMatcher
   /// FIXME: these are not really part of the DataDescriptorMatcher API
   /// and should really be relegated to external helpers...
   bool match(ConcreteDataMatcher const& matcher, VariableContext& context) const;
+  bool match(ConcreteDataTypeMatcher const& matcher, VariableContext& context) const;
   bool match(header::DataHeader const& header, VariableContext& context) const;
   bool match(header::Stack const& stack, VariableContext& context) const;
 

--- a/Framework/Core/include/Framework/DataSpecUtils.h
+++ b/Framework/Core/include/Framework/DataSpecUtils.h
@@ -45,6 +45,12 @@ struct DataSpecUtils {
                     const o2::header::DataDescription& description,
                     const o2::header::DataHeader::SubSpecificationType& subSpec);
 
+  /// @return true if the InputSpec will match at least the provided @a origin.
+  static bool partialMatch(InputSpec const& spec, o2::header::DataOrigin const& origin);
+
+  /// @return true if the OutputSpec will match at least the provided @a origin.
+  static bool partialMatch(OutputSpec const& spec, o2::header::DataOrigin const& origin);
+
   template <typename T>
   static bool match(const T&spec, const o2::header::DataHeader &header) {
     return DataSpecUtils::match(spec,
@@ -110,12 +116,24 @@ struct DataSpecUtils {
   /// the subSpec.
   static ConcreteDataTypeMatcher asConcreteDataTypeMatcher(OutputSpec const& spec);
 
+  /// If possible extract the ConcreteTypeDataMatcher from an InputSpec.
+  /// This will not always be possible, depending on how complex of
+  /// a query the InputSpec does, however in most cases it should be ok
+  /// and we can add corner cases as we go.
+  static ConcreteDataTypeMatcher asConcreteDataTypeMatcher(InputSpec const& spec);
+
   /// Create an InputSpec which is able to match all the outputs of the given
   /// OutputSpec
   static InputSpec matchingInput(OutputSpec const& spec);
 
-  /// Get the subspec, if available.
+  /// Get the subspec, if available
   static std::optional<header::DataHeader::SubSpecificationType> getOptionalSubSpec(OutputSpec const& spec);
+
+  /// Get the subspec, if available
+  static std::optional<header::DataHeader::SubSpecificationType> getOptionalSubSpec(InputSpec const& spec);
+
+  /// Build a DataDescriptMatcher which does not care about the subSpec.
+  static data_matcher::DataDescriptorMatcher dataDescriptorMatcherFrom(ConcreteDataTypeMatcher const& dataType);
 };
 
 } // namespace framework

--- a/Framework/Core/include/Framework/InputSpec.h
+++ b/Framework/Core/include/Framework/InputSpec.h
@@ -27,9 +27,14 @@ namespace framework
 /// input or in output. This can be used, for example to match
 /// specific payloads in a timeframe.
 struct InputSpec {
-  /// This is the legacy way to construct things. For the moment we still allow
-  /// accessing directly the members, but this will change as well at some point.
-  InputSpec(std::string binding_, header::DataOrigin origin_, header::DataDescription description_, header::DataHeader::SubSpecificationType subSpec_ = 0, enum Lifetime lifetime_ = Lifetime::Timeframe);
+  /// Create a fully qualified InputSpec
+  InputSpec(std::string binding_, header::DataOrigin origin_, header::DataDescription description_, header::DataHeader::SubSpecificationType subSpec_, enum Lifetime lifetime_ = Lifetime::Timeframe);
+  /// Create a fully qualified InputSpec (alternative syntax)
+  InputSpec(std::string binding_, ConcreteDataMatcher const& dataType, enum Lifetime lifetime_ = Lifetime::Timeframe);
+  /// Create a fully qualified InputSpec where the subSpec is 0
+  InputSpec(std::string binding_, header::DataOrigin origin_, header::DataDescription description_, enum Lifetime lifetime_ = Lifetime::Timeframe);
+  /// Create an InputSpec which does not check for the subSpec.
+  InputSpec(std::string binding_, ConcreteDataTypeMatcher const& dataType, enum Lifetime lifetime_ = Lifetime::Timeframe);
   InputSpec(std::string binding, data_matcher::DataDescriptorMatcher &&matcher);
 
   std::string binding;

--- a/Framework/Core/include/Framework/OutputSpec.h
+++ b/Framework/Core/include/Framework/OutputSpec.h
@@ -23,24 +23,38 @@ struct OutputLabel {
   std::string value;
 };
 
-/// A selector for some kind of data being processed, either in
-/// input or in output. This can be used, for example to match
-/// specific payloads in a timeframe.
+/// A criteria which matches data being produced by a given DataProcessorSpec.
+/// This needs to be declared upfront so that we can automatically build the
+/// topology.
 struct OutputSpec {
   OutputLabel binding;
-  std::variant<ConcreteDataMatcher> matcher;
+  std::variant<ConcreteDataMatcher, ConcreteDataTypeMatcher> matcher;
   enum Lifetime lifetime = Lifetime::Timeframe;
 
+  /// Build a fully qualified tuple for the OutputSpec
   OutputSpec(OutputLabel const& inBinding, header::DataOrigin inOrigin, header::DataDescription inDescription,
              header::DataHeader::SubSpecificationType inSubSpec, enum Lifetime inLifetime = Lifetime::Timeframe);
 
+  /// Build a fully qualified tuple for the OutputSpec
   OutputSpec(header::DataOrigin inOrigin, header::DataDescription inDescription,
              header::DataHeader::SubSpecificationType inSubSpec, enum Lifetime inLifetime = Lifetime::Timeframe);
 
+  /// Build an OutputSpec which has 0 as subSpec.
   OutputSpec(OutputLabel const& inBinding, header::DataOrigin inOrigin, header::DataDescription inDescription,
              enum Lifetime inLifetime = Lifetime::Timeframe);
 
+  /// Build an OutputSpec which has 0 as subSpec.
   OutputSpec(header::DataOrigin inOrigin, header::DataDescription inDescription,
+             enum Lifetime inLifetime = Lifetime::Timeframe);
+
+  /// Build an OutputSpec which does not specify which subSpec the output will
+  /// have.
+  OutputSpec(OutputLabel const& inBinding, ConcreteDataTypeMatcher const& dataType,
+             enum Lifetime inLifetime = Lifetime::Timeframe);
+
+  /// Build an OutputSpec which does not specify which subSpec the output will
+  /// have.
+  OutputSpec(ConcreteDataTypeMatcher const& dataType,
              enum Lifetime inLifetime = Lifetime::Timeframe);
 
   bool operator==(OutputSpec const& that) const;

--- a/Framework/Core/src/InputSpec.cxx
+++ b/Framework/Core/src/InputSpec.cxx
@@ -9,6 +9,7 @@
 // or submit itself to any jurisdiction.
 //
 #include "Framework/InputSpec.h"
+#include "Framework/DataSpecUtils.h"
 
 #include <variant>
 
@@ -17,9 +18,30 @@ namespace o2
 namespace framework
 {
 
+InputSpec::InputSpec(std::string binding_, ConcreteDataMatcher const& concrete, enum Lifetime lifetime_)
+  : binding{ binding_ },
+    matcher{ concrete },
+    lifetime{ lifetime_ }
+{
+}
+
 InputSpec::InputSpec(std::string binding_, header::DataOrigin origin_, header::DataDescription description_, header::DataHeader::SubSpecificationType subSpec_, enum Lifetime lifetime_)
   : binding{ binding_ },
     matcher{ ConcreteDataMatcher{ origin_, description_, subSpec_ } },
+    lifetime{ lifetime_ }
+{
+}
+
+InputSpec::InputSpec(std::string binding_, header::DataOrigin origin_, header::DataDescription description_, enum Lifetime lifetime_)
+  : binding{ binding_ },
+    matcher{ ConcreteDataMatcher{ origin_, description_, 0 } },
+    lifetime{ lifetime_ }
+{
+}
+
+InputSpec::InputSpec(std::string binding_, ConcreteDataTypeMatcher const& dataType, enum Lifetime lifetime_)
+  : binding{ binding_ },
+    matcher{ DataSpecUtils::dataDescriptorMatcherFrom(dataType) },
     lifetime{ lifetime_ }
 {
 }

--- a/Framework/Core/src/OutputSpec.cxx
+++ b/Framework/Core/src/OutputSpec.cxx
@@ -45,6 +45,22 @@ OutputSpec::OutputSpec(header::DataOrigin inOrigin, header::DataDescription inDe
 {
 }
 
+OutputSpec::OutputSpec(ConcreteDataTypeMatcher const& dataType,
+                       enum Lifetime inLifetime)
+  : binding{ OutputLabel{ "" } },
+    matcher{ dataType },
+    lifetime{ inLifetime }
+{
+}
+
+OutputSpec::OutputSpec(OutputLabel const& inBinding, ConcreteDataTypeMatcher const& dataType,
+                       enum Lifetime inLifetime)
+  : binding{ inBinding },
+    matcher{ dataType },
+    lifetime{ inLifetime }
+{
+}
+
 bool OutputSpec::operator==(OutputSpec const& that) const
 {
   return this->matcher == that.matcher &&

--- a/Framework/Core/src/WorkflowSerializationHelpers.cxx
+++ b/Framework/Core/src/WorkflowSerializationHelpers.cxx
@@ -212,8 +212,10 @@ struct WorkflowImporter : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
       output.push_back(DataProcessorSpec{});
     } else if (in(State::IN_INPUTS)) {
       push(State::IN_INPUT);
+      inputHasSubSpec = false;
     } else if (in(State::IN_OUTPUTS)) {
       push(State::IN_OUTPUT);
+      outputHasSubSpec = false;
     } else if (in(State::IN_OPTIONS)) {
       push(State::IN_OPTION);
     } else if (in(State::IN_WORKFLOW_OPTIONS)) {
@@ -231,9 +233,19 @@ struct WorkflowImporter : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
   {
     enter("END_OBJECT");
     if (in(State::IN_INPUT)) {
-      output.back().inputs.push_back(InputSpec(binding, origin, description, subspec, lifetime));
+      if (inputHasSubSpec) {
+        output.back().inputs.push_back(InputSpec(binding, origin, description, subspec, lifetime));
+      } else {
+        output.back().inputs.push_back(InputSpec(binding, { origin, description }, lifetime));
+      }
+      inputHasSubSpec = false;
     } else if (in(State::IN_OUTPUT)) {
-      output.back().outputs.push_back(OutputSpec({ binding }, origin, description, subspec, lifetime));
+      if (outputHasSubSpec) {
+        output.back().outputs.push_back(OutputSpec({ binding }, origin, description, subspec, lifetime));
+      } else {
+        output.back().outputs.push_back(OutputSpec({ binding }, { origin, description }, lifetime));
+      }
+      outputHasSubSpec = false;
     } else if (in(State::IN_OPTION)) {
       std::unique_ptr<ConfigParamSpec> opt{ nullptr };
 
@@ -280,8 +292,10 @@ struct WorkflowImporter : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
       push(State::IN_DATAPROCESSORS);
     } else if (in(State::IN_INPUTS)) {
       push(State::IN_INPUT);
+      inputHasSubSpec = false;
     } else if (in(State::IN_OUTPUTS)) {
       push(State::IN_OUTPUT);
+      outputHasSubSpec = false;
     } else if (in(State::IN_OPTIONS)) {
       push(State::IN_OPTION);
     } else if (in(State::IN_WORKFLOW_OPTIONS)) {
@@ -318,6 +332,7 @@ struct WorkflowImporter : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
       push(State::IN_INPUT_DESCRIPTION);
     } else if (in(State::IN_INPUT) && strncmp(str, "subspec", length) == 0) {
       push(State::IN_INPUT_SUBSPEC);
+      inputHasSubSpec = true;
     } else if (in(State::IN_INPUT) && strncmp(str, "lifetime", length) == 0) {
       push(State::IN_INPUT_LIFETIME);
     } else if (in(State::IN_OUTPUT) && strncmp(str, "binding", length) == 0) {
@@ -328,6 +343,7 @@ struct WorkflowImporter : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
       push(State::IN_OUTPUT_DESCRIPTION);
     } else if (in(State::IN_OUTPUT) && strncmp(str, "subspec", length) == 0) {
       push(State::IN_OUTPUT_SUBSPEC);
+      outputHasSubSpec = true;
     } else if (in(State::IN_OUTPUT) && strncmp(str, "lifetime", length) == 0) {
       push(State::IN_OUTPUT_LIFETIME);
     } else if (in(State::IN_DATAPROCESSOR) && strncmp(str, "name", length) == 0) {
@@ -504,6 +520,8 @@ struct WorkflowImporter : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
   VariantType optionType;
   std::string optionDefault;
   std::string optionHelp;
+  bool outputHasSubSpec;
+  bool inputHasSubSpec;
 };
 
 void WorkflowSerializationHelpers::import(std::istream& s,
@@ -556,19 +574,25 @@ void WorkflowSerializationHelpers::dump(std::ostream& out,
     w.Key("inputs");
     w.StartArray();
     for (auto& input : processor.inputs) {
-      auto concrete = DataSpecUtils::asConcreteDataMatcher(input);
-      if (concrete.origin == header::DataOrigin("DPL")) {
+      /// FIXME: this only works for a selected set of InputSpecs...
+      ///        a proper way to fully serialize an InputSpec with
+      ///        a DataDescriptorMatcher is needed.
+      auto dataType = DataSpecUtils::asConcreteDataTypeMatcher(input);
+      if (dataType.origin == header::DataOrigin("DPL")) {
         continue;
       }
       w.StartObject();
       w.Key("binding");
       w.String(input.binding.c_str());
       w.Key("origin");
-      w.String(concrete.origin.str, strnlen(concrete.origin.str, 4));
+      w.String(dataType.origin.str, strnlen(dataType.origin.str, 4));
       w.Key("description");
-      w.String(concrete.description.str, strnlen(concrete.description.str, 16));
-      w.Key("subspec");
-      w.Uint64(concrete.subSpec);
+      w.String(dataType.description.str, strnlen(dataType.description.str, 16));
+      auto subSpec = DataSpecUtils::getOptionalSubSpec(input);
+      if (subSpec.has_value()) {
+        w.Key("subspec");
+        w.Uint64(*subSpec);
+      }
       w.Key("lifetime");
       w.Uint((int)input.lifetime);
       w.EndObject();
@@ -594,7 +618,7 @@ void WorkflowSerializationHelpers::dump(std::ostream& out,
       // FIXME: this will have to change once we introduce wildcards for
       //        OutputSpec
       auto subSpec = DataSpecUtils::getOptionalSubSpec(output);
-      if (subSpec != std::nullopt) {
+      if (subSpec.has_value()) {
         w.Key("subspec");
         w.Uint64(*subSpec);
       }

--- a/Framework/Core/test/test_WorkflowSerialization.cxx
+++ b/Framework/Core/test/test_WorkflowSerialization.cxx
@@ -40,29 +40,33 @@ BOOST_AUTO_TEST_CASE(TestVerifyWorkflow)
                        { OutputSpec{ { "bar" }, "G", "H" } },
                        AlgorithmSpec{ [](ProcessingContext& ctx) {} },
                        {} },
-
+    DataProcessorSpec{ "D",
+                       { InputSpec{ "foo", { "C", "D" } } },
+                       { OutputSpec{ { "bar" }, { "I", "L" } } },
+                       AlgorithmSpec{ [](ProcessingContext& ctx) {} },
+                       {} }
   };
 
   std::vector<DataProcessorInfo> metadataOut{
     { "A", "test_Framework_test_SerializationWorkflow", { "foo" }, { ConfigParamSpec{ "aBool", VariantType::Bool, true, { "A Bool" } } } },
     { "B", "test_Framework_test_SerializationWorkflow", { "b-bar", "bfoof", "fbdbfaso" } },
     { "C", "test_Framework_test_SerializationWorkflow", {} },
+    { "D", "test_Framework_test_SerializationWorkflow", {} },
   };
 
   std::vector<DataProcessorInfo> metadataIn{};
 
-  std::ostringstream os;
-  WorkflowSerializationHelpers::dump(os, w0, metadataOut);
+  std::ostringstream firstDump;
+  WorkflowSerializationHelpers::dump(firstDump, w0, metadataOut);
   std::istringstream is;
-  is.str(os.str());
+  is.str(firstDump.str());
   WorkflowSpec w1;
   WorkflowSerializationHelpers::import(is, w1, metadataIn);
 
-  std::cout << "--" << std::endl;
-  std::ostringstream os2;
-  WorkflowSerializationHelpers::dump(os2, w1, metadataIn);
+  std::ostringstream secondDump;
+  WorkflowSerializationHelpers::dump(secondDump, w1, metadataIn);
 
-  BOOST_REQUIRE_EQUAL(w0.size(), 3);
+  BOOST_REQUIRE_EQUAL(w0.size(), 4);
   BOOST_REQUIRE_EQUAL(w0.size(), w1.size());
-  BOOST_CHECK_EQUAL(os.str(), os2.str());
+  BOOST_CHECK_EQUAL(firstDump.str(), secondDump.str());
 }

--- a/Framework/Core/test/unittest_DataSpecUtils.cxx
+++ b/Framework/Core/test/unittest_DataSpecUtils.cxx
@@ -13,13 +13,15 @@
 #define BOOST_TEST_DYN_LINK
 
 #include "Framework/DataSpecUtils.h"
+#include "Framework/DataDescriptorQueryBuilder.h"
 #include <boost/test/unit_test.hpp>
 
 #include <string>
 
+using namespace o2;
 using namespace o2::framework;
 
-BOOST_AUTO_TEST_CASE(DataSpecUtilsConcreteTest)
+BOOST_AUTO_TEST_CASE(CocreteData)
 {
   OutputSpec spec{
     "TEST",
@@ -27,12 +29,213 @@ BOOST_AUTO_TEST_CASE(DataSpecUtilsConcreteTest)
     1,
     Lifetime::Timeframe
   };
-  ConcreteDataMatcher concrete = DataSpecUtils::asConcreteDataMatcher(spec);
+
+  InputSpec inputSpec{
+    "binding",
+    "TEST",
+    "FOOO",
+    1,
+    Lifetime::Timeframe
+  };
+
+  BOOST_REQUIRE(DataSpecUtils::validate(inputSpec));
+
+  {
+    ConcreteDataMatcher concrete = DataSpecUtils::asConcreteDataMatcher(spec);
+    BOOST_CHECK_EQUAL(std::string(concrete.origin.as<std::string>()), "TEST");
+    BOOST_CHECK_EQUAL(std::string(concrete.description.as<std::string>()), "FOOO");
+    BOOST_CHECK_EQUAL(concrete.subSpec, 1);
+    BOOST_CHECK_EQUAL(DataSpecUtils::describe(spec), "TEST/FOOO/1");
+    BOOST_CHECK_EQUAL(*DataSpecUtils::getOptionalSubSpec(spec), 1);
+
+    ConcreteDataTypeMatcher dataType = DataSpecUtils::asConcreteDataTypeMatcher(spec);
+    BOOST_CHECK_EQUAL(std::string(dataType.origin.as<std::string>()), "TEST");
+    BOOST_CHECK_EQUAL(std::string(dataType.description.as<std::string>()), "FOOO");
+
+    BOOST_CHECK(DataSpecUtils::match(spec, ConcreteDataMatcher{ "TEST", "FOOO", 1 }));
+    BOOST_CHECK(DataSpecUtils::match(spec, ConcreteDataMatcher{ "TEST", "FOOO", 0 }) == false);
+    DataSpecUtils::updateMatchingSubspec(spec, 0);
+    BOOST_CHECK(DataSpecUtils::match(spec, ConcreteDataMatcher{ "TEST", "FOOO", 0 }) == true);
+    BOOST_CHECK(DataSpecUtils::match(inputSpec, ConcreteDataMatcher{ "TEST", "FOOO", 1 }));
+    BOOST_CHECK(DataSpecUtils::match(inputSpec, ConcreteDataMatcher{ "TEST", "FOOO", 0 }) == false);
+    DataSpecUtils::updateMatchingSubspec(inputSpec, 0);
+    BOOST_CHECK(DataSpecUtils::match(inputSpec, ConcreteDataMatcher{ "TEST", "FOOO", 0 }) == true);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(WithWildCards)
+{
+  OutputSpec spec{
+    { "TEST", "FOOO" },
+    Lifetime::Timeframe
+  };
+
+  BOOST_CHECK_THROW(DataSpecUtils::asConcreteDataMatcher(spec), std::bad_variant_access);
+  auto dataType = DataSpecUtils::asConcreteDataTypeMatcher(spec);
+
+  BOOST_CHECK_EQUAL(std::string(dataType.origin.as<std::string>()), "TEST");
+  BOOST_CHECK_EQUAL(std::string(dataType.description.as<std::string>()), "FOOO");
+
+  BOOST_CHECK(DataSpecUtils::match(spec, ConcreteDataMatcher{ "TEST", "FOOO", 1 }));
+  BOOST_CHECK(DataSpecUtils::match(spec, ConcreteDataMatcher{ "TEST", "FOOO", 0 }));
+  BOOST_CHECK_EQUAL(DataSpecUtils::describe(spec), "TEST/FOOO");
+
+  BOOST_CHECK(DataSpecUtils::getOptionalSubSpec(spec) == std::nullopt);
+}
+
+BOOST_AUTO_TEST_CASE(MatchingInputs)
+{
+  OutputSpec fullySpecified{
+    "TEST",
+    "FOOO",
+    1,
+    Lifetime::Timeframe
+  };
+
+  OutputSpec partialMatching{
+    { "TEST", "FOOO" },
+    Lifetime::Timeframe
+  };
+
+  auto matchingInput1 = DataSpecUtils::matchingInput(fullySpecified);
+  ConcreteDataMatcher concrete = DataSpecUtils::asConcreteDataMatcher(matchingInput1);
+
   BOOST_CHECK_EQUAL(std::string(concrete.origin.as<std::string>()), "TEST");
   BOOST_CHECK_EQUAL(std::string(concrete.description.as<std::string>()), "FOOO");
   BOOST_CHECK_EQUAL(concrete.subSpec, 1);
 
-  ConcreteDataTypeMatcher dataType = DataSpecUtils::asConcreteDataTypeMatcher(spec);
-  BOOST_CHECK_EQUAL(std::string(dataType.origin.as<std::string>()), "TEST");
-  BOOST_CHECK_EQUAL(std::string(dataType.description.as<std::string>()), "FOOO");
+  auto matchingInput2 = DataSpecUtils::matchingInput(partialMatching);
+  // BOOST_CHECK_THROW(DataSpecUtils::asConcreteDataMatcher(matchingInput), std::bad_variant_access);
+  // We need a ConcreteDataMatcher to check if the generated input is
+  // correct, because a ConcreteDataTypeMatcher has one extra degree of
+  // freedom.
+  ConcreteDataMatcher concreteExample1{
+    "TEST",
+    "FOOO",
+    0
+  };
+  ConcreteDataMatcher concreteExample2{
+    "TEST",
+    "FOOO",
+    1
+  };
+  ConcreteDataMatcher concreteExample3{
+    "BAR",
+    "FOOO",
+    0
+  };
+  ConcreteDataMatcher concreteExample4{
+    "TEST",
+    "BAR",
+    0
+  };
+  BOOST_CHECK(DataSpecUtils::match(matchingInput2, concreteExample1) == true);
+  BOOST_CHECK(DataSpecUtils::match(matchingInput2, concreteExample2) == true);
+  BOOST_CHECK(DataSpecUtils::match(matchingInput2, concreteExample3) == false);
+  BOOST_CHECK(DataSpecUtils::match(matchingInput2, concreteExample4) == false);
+
+  BOOST_CHECK_THROW(DataSpecUtils::asConcreteDataMatcher(matchingInput2), std::bad_variant_access);
+}
+
+BOOST_AUTO_TEST_CASE(MatchingOutputs)
+{
+  OutputSpec output1{
+    "TST", "A1", 0, Lifetime::Timeframe
+  };
+
+  OutputSpec output2{
+    "TST", "B1", 0, Lifetime::Timeframe
+  };
+
+  OutputSpec output3{
+    { "TST", "A1" }, Lifetime::Timeframe
+  };
+
+  InputSpec input1{
+    "binding", "TST", "A1", 0, Lifetime::Timeframe
+  };
+
+  InputSpec input2{
+    "binding", "TST", "A1", 1, Lifetime::Timeframe
+  };
+
+  InputSpec input3{
+    "binding", "TST", "B1", 0, Lifetime::Timeframe
+  };
+
+  InputSpec input4{
+    "binding", { "TST", "A1" }, Lifetime::Timeframe
+  };
+
+  BOOST_CHECK(DataSpecUtils::match(input1, output1) == true);
+  BOOST_CHECK(DataSpecUtils::match(input1, output2) == false);
+  BOOST_CHECK(DataSpecUtils::match(input1, output3) == false); // Wildcard on output!
+  BOOST_CHECK(DataSpecUtils::match(input2, output1) == false);
+  BOOST_CHECK(DataSpecUtils::match(input2, output2) == false);
+  BOOST_CHECK(DataSpecUtils::match(input2, output3) == false); // Wildcard on output!
+  BOOST_CHECK(DataSpecUtils::match(input3, output1) == false);
+  BOOST_CHECK(DataSpecUtils::match(input3, output2) == true);
+  BOOST_CHECK(DataSpecUtils::match(input3, output3) == false); // Wildcard on output!
+  BOOST_CHECK(DataSpecUtils::match(input4, output1) == true);  // Wildcard in input!
+  BOOST_CHECK(DataSpecUtils::match(input4, output2) == false);
+  BOOST_CHECK(DataSpecUtils::match(input4, output3) == true); // Wildcard on both!
+}
+
+BOOST_AUTO_TEST_CASE(PartialMatching)
+{
+  OutputSpec fullySpecifiedOutput{
+    "TEST",
+    "FOOO",
+    1,
+    Lifetime::Timeframe
+  };
+
+  InputSpec fullySpecifiedInput{
+    "binding",
+    "TSET",
+    "FOOO",
+    1,
+    Lifetime::Timeframe
+  };
+
+  BOOST_CHECK(DataSpecUtils::partialMatch(fullySpecifiedOutput, header::DataOrigin("TEST")));
+  BOOST_CHECK(DataSpecUtils::partialMatch(fullySpecifiedInput, header::DataOrigin("TSET")));
+
+  BOOST_CHECK(DataSpecUtils::partialMatch(fullySpecifiedOutput, header::DataOrigin("FOO")) == false);
+  BOOST_CHECK(DataSpecUtils::partialMatch(fullySpecifiedInput, header::DataOrigin("FOO")) == false);
+}
+
+BOOST_AUTO_TEST_CASE(GetOptionalSubSpecWithMatcher)
+{
+  InputSpec fullInputSpec{
+    "binding",
+    "TSET", "FOOO", 1,
+    Lifetime::Timeframe
+  };
+
+  InputSpec wildcardInputSpec{
+    "binding",
+    { "TSET", "FOOO" },
+    Lifetime::Timeframe
+  };
+
+  auto fromQueryInputSpec = DataDescriptorQueryBuilder::parse("x:TST/A1/77;y:STS/A2;z:FOO/A3");
+
+  BOOST_CHECK(*DataSpecUtils::getOptionalSubSpec(fullInputSpec) == 1);
+  BOOST_CHECK(DataSpecUtils::getOptionalSubSpec(wildcardInputSpec) == std::nullopt);
+  BOOST_REQUIRE_EQUAL(fromQueryInputSpec.size(), 3);
+  BOOST_CHECK(DataSpecUtils::getOptionalSubSpec(fromQueryInputSpec[0]) != std::nullopt);
+  BOOST_CHECK(DataSpecUtils::getOptionalSubSpec(fromQueryInputSpec[0]) == 77);
+  BOOST_CHECK(DataSpecUtils::getOptionalSubSpec(fromQueryInputSpec[1]) == std::nullopt);
+  BOOST_CHECK(DataSpecUtils::getOptionalSubSpec(fromQueryInputSpec[2]) == std::nullopt);
+  DataSpecUtils::updateMatchingSubspec(fromQueryInputSpec[2], 10);
+  BOOST_CHECK(DataSpecUtils::getOptionalSubSpec(fromQueryInputSpec[2]) == 10);
+
+  auto dataType1 = DataSpecUtils::asConcreteDataTypeMatcher(fullInputSpec);
+  BOOST_CHECK_EQUAL(std::string(dataType1.origin.as<std::string>()), "TSET");
+  BOOST_CHECK_EQUAL(std::string(dataType1.description.as<std::string>()), "FOOO");
+
+  auto dataType2 = DataSpecUtils::asConcreteDataTypeMatcher(wildcardInputSpec);
+  BOOST_CHECK_EQUAL(std::string(dataType2.origin.as<std::string>()), "TSET");
+  BOOST_CHECK_EQUAL(std::string(dataType2.description.as<std::string>()), "FOOO");
 }

--- a/Framework/TestWorkflows/CMakeLists.txt
+++ b/Framework/TestWorkflows/CMakeLists.txt
@@ -30,6 +30,11 @@ o2_add_executable(diamond-workflow
                   PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME TestWorkflows)
 
+o2_add_executable(output-wildcard-workflow
+                  SOURCES src/o2OutputWildcardWorkflow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::Framework
+                  COMPONENT_NAME TestWorkflows)
+
 o2_add_executable(parallel-workflow
                   SOURCES src/o2ParallelWorkflow.cxx
                   PUBLIC_LINK_LIBRARIES O2::Framework

--- a/Framework/TestWorkflows/src/o2OutputWildcardWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2OutputWildcardWorkflow.cxx
@@ -1,0 +1,60 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicy.h"
+#include "Framework/DataRefUtils.h"
+#include "Headers/DataHeader.h"
+#include "Framework/DeviceSpec.h"
+#include "Framework/Logger.h"
+
+#include <chrono>
+#include <vector>
+
+#include "Framework/runDataProcessing.h"
+
+using namespace o2::framework;
+
+AlgorithmSpec simplePipe(std::string const& what, int minDelay)
+{
+  return AlgorithmSpec{ adaptStateful([what, minDelay]() {
+    srand(getpid());
+    return adaptStateless([what, minDelay](DataAllocator& outputs) {
+      auto rn = rand() % 5;
+      std::this_thread::sleep_for(std::chrono::seconds(rn + minDelay));
+      auto bData = outputs.make<int>(OutputRef{ what }, rn);
+    });
+  }) };
+}
+
+// This is how you can define your processing in a declarative way
+WorkflowSpec defineDataProcessing(ConfigContext const& specs)
+{
+  return WorkflowSpec{
+    { "A",
+      Inputs{},
+      { OutputSpec{ { "a1" }, { "TST", "A1" } } },
+      AlgorithmSpec{ adaptStateless(
+        [](DataAllocator& outputs) {
+          auto rn = rand() % 5;
+          std::this_thread::sleep_for(std::chrono::seconds(rn));
+          auto& aData = outputs.make<int>(OutputRef{ "a1", static_cast<DataAllocator::SubSpecificationType>(rn) });
+          LOGP(info, "A random subspec:{}", rn);
+        }) } },
+    { "B",
+      { InputSpec{ "x", { "TST", "A1" } } },
+      {},
+      AlgorithmSpec{ adaptStateless(
+        [](InputRecord& inputs) {
+          DataRef ref = inputs.getByPos(0);
+          auto const* header = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
+          LOGP(info, "A random subspec:{}", header->subSpecification);
+        }) } },
+  };
+}


### PR DESCRIPTION
e2e7820 is in principle all is needed to have OutputSpec have a wildcard on the subSpecification. Not tested yet.

Notice this depends on #2057... 