### PR TITLE
Use FairMQ-shipped forward-declaration for FairMQProgOptions when available

### DIFF
--- a/Framework/Core/include/Framework/FairOptionsRetriever.h
+++ b/Framework/Core/include/Framework/FairOptionsRetriever.h
@@ -18,7 +18,11 @@
 #include <string>
 #include <vector>
 
+#if __has_include(<fairmq/ProgOptionsFwd.h>)
+#include <fairmq/ProgOptionsFwd.h>
+#else
 class FairMQProgOptions;
+#endif
 
 namespace o2
 {


### PR DESCRIPTION
With the next FairMQ stable release (1.4.x) we will rename the `FairMQProgOptions` class to `fair::mq::ProgOptions`.
The old name will still be available as `using FairMQProgOptions = fair::mq::ProgOptions`. However this breaks O2 compilation at the line changed in this PR, because of double definition:
```
DEBUG:O2:O2:0: In file included from ~/dev/alice/sw/SOURCES/O2/1.0.0/0/Framework/Core/src/DataProcessingDevice.cxx:16:
DEBUG:O2:O2:0: ~/dev/alice/sw/SOURCES/O2/1.0.0/0/Framework/Core/include/Framework/FairOptionsRetriever.h:21:7: error: using typedef-name 'using FairMQProgOptions = class fair::mq::ProgOptions' after 'class'
DEBUG:O2:O2:0:  class FairMQProgOptions;
DEBUG:O2:O2:0:        ^~~~~~~~~~~~~~~~~
DEBUG:O2:O2:0: In file included from ~/dev/alice/sw/ubuntu1904_x86-64/FairMQ/config-2-1/include/fairmq/FairMQTransportFactory.h:15,
DEBUG:O2:O2:0:                  from ~/dev/alice/sw/SOURCES/O2/1.0.0/0/DataFormats/MemoryResources/include/MemoryResources/MemoryResources.h:41,
DEBUG:O2:O2:0:                  from ~/dev/alice/sw/SOURCES/O2/1.0.0/0/Framework/Core/include/Framework/TMessageSerializer.h:23,
DEBUG:O2:O2:0:                  from ~/dev/alice/sw/SOURCES/O2/1.0.0/0/Framework/Core/include/Framework/DataRefUtils.h:14,
DEBUG:O2:O2:0:                  from ~/dev/alice/sw/SOURCES/O2/1.0.0/0/Framework/Core/include/Framework/InputRecord.h:14,
DEBUG:O2:O2:0:                  from ~/dev/alice/sw/SOURCES/O2/1.0.0/0/Framework/Core/include/Framework/ProcessingContext.h:13,
DEBUG:O2:O2:0:                  from ~/dev/alice/sw/SOURCES/O2/1.0.0/0/Framework/Core/include/Framework/AlgorithmSpec.h:13,
DEBUG:O2:O2:0:                  from ~/dev/alice/sw/SOURCES/O2/1.0.0/0/Framework/Core/include/Framework/DataProcessingDevice.h:13,
DEBUG:O2:O2:0:                  from ~/dev/alice/sw/SOURCES/O2/1.0.0/0/Framework/Core/src/DataProcessingDevice.cxx:11:
DEBUG:O2:O2:0: ~/dev/alice/sw/ubuntu1904_x86-64/FairMQ/config-2-1/include/fairmq/ProgOptionsFwd.h:20:48: note: 'using FairMQProgOptions = class fair::mq::ProgOptions' has a previous declaration here
DEBUG:O2:O2:0:  using FairMQProgOptions = fair::mq::ProgOptions;
```
This commit changes the forward declaration in O2 to a full include of `<fairmq/options/FairMQProgOptions.h>`. Once you switch to the new release, you can also use the new `<fairmq/ProgOptionsFwd.h>` for the forward declaration (or the full class in `<fairmq/ProgOptions.h>`).

This fix is backwards compatible as we will keep the old header around for a while for backwards-compatibility.

Update: instead use `__has_include()` to detect if the header with our shipped forward declaration is available.