### PR TITLE
Catch all std exceptions at the top level of DPL standalone driver

### DIFF
--- a/Framework/Core/include/Framework/ConfigParamRegistry.h
+++ b/Framework/Core/include/Framework/ConfigParamRegistry.h
@@ -63,7 +63,7 @@ class ConfigParamRegistry
     } catch (std::exception& e) {
       throw std::invalid_argument(std::string("missing option: ") + key + " (" + e.what() + ")");
     } catch (...) {
-      throw std::invalid_argument(std::string("missing option: ") + key);
+      throw std::invalid_argument(std::string("error parsing option: ") + key);
     }
   }
 

--- a/Framework/Core/include/Framework/runDataProcessing.h
+++ b/Framework/Core/include/Framework/runDataProcessing.h
@@ -24,6 +24,7 @@
 #include <unistd.h>
 #include <vector>
 #include <cstring>
+#include <exception>
 
 namespace o2
 {
@@ -117,8 +118,8 @@ int main(int argc, char** argv)
     ConfigContext configContext{ workflowOptionsRegistry };
     o2::framework::WorkflowSpec specs = defineDataProcessing(configContext);
     result = doMain(argc, argv, specs, channelPolicies, completionPolicies, workflowOptions, configContext);
-  } catch (std::runtime_error const& error) {
-    LOG(ERROR) << "Runtime exception caught: " << error.what();
+  } catch (std::exception const& error) {
+    LOG(ERROR) << "error while setting up workflow: " << error.what();
   } catch (...) {
     LOG(ERROR) << "Unknown error while setting up workflow.";
   }


### PR DESCRIPTION
This prints a better error message. Workflows simply have terminated
with "Unknown error while setting up workflow" when an option was requested
but not declared.