### PR TITLE
Cooked-matrix tracker working together with the primary-vertex finder

### DIFF
--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTracker.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTracker.h
@@ -25,6 +25,7 @@
 #include "MathUtils/Cartesian3D.h"
 #include "DataFormatsITS/TrackITS.h"
 #include "DataFormatsITSMFT/ROFRecord.h"
+#include "ReconstructionDataFormats/Vertex.h"
 
 namespace o2
 {
@@ -45,6 +46,7 @@ namespace its
 class CookedTracker
 {
   using Cluster = o2::itsmft::Cluster;
+  using Vertex = o2::dataformats::Vertex<o2::dataformats::TimeStamp<int>>;
 
  public:
   CookedTracker(Int_t nThreads = 1);
@@ -52,7 +54,11 @@ class CookedTracker
   CookedTracker& operator=(const CookedTracker& tr) = delete;
   ~CookedTracker() = default;
 
-  void setVertices(std::vector<std::array<Double_t, 3>>& vertices) { mVertices = std::move(vertices); }
+  void setVertices(std::vector<Vertex>& vertices)
+  {
+    mVertices.clear();
+    mVertices = std::move(vertices);
+  }
 
   Double_t getX() const { return mX; }
   Double_t getY() const { return mY; }
@@ -114,7 +120,7 @@ class CookedTracker
 
   Double_t mBz; ///< Effective Z-component of the magnetic field (kG)
 
-  std::vector<std::array<Double_t, 3>> mVertices;
+  std::vector<Vertex> mVertices;
   Double_t mX = 0.; ///< X-coordinate of the primary vertex
   Double_t mY = 0.; ///< Y-coordinate of the primary vertex
   Double_t mZ = 0.; ///< Z-coordinate of the primary vertex

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTracker.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTracker.h
@@ -69,9 +69,7 @@ class CookedTracker
   Int_t getNumberOfThreads() const { return mNumOfThreads; }
 
   // These functions must be implemented
-  void process(const std::vector<Cluster>& clusters, std::vector<TrackITS>& tracks, std::vector<int>& clusIdx,
-               std::vector<o2::itsmft::ROFRecord>& rofs);
-  void processFrame(std::vector<TrackITS>& tracks, std::vector<int>& clusIdx);
+  void process(const std::vector<Cluster>& clusters, std::vector<TrackITS>& tracks, std::vector<int>& clusIdx, o2::itsmft::ROFRecord& rof);
   const Cluster* getCluster(Int_t index) const;
 
   void setGeometry(o2::its::GeometryTGeo* geom);
@@ -94,6 +92,7 @@ class CookedTracker
   void addOutputTrack(const TrackITSExt& t, std::vector<TrackITS>& tracks, std::vector<int>& clusIdx);
   int loadClusters(const std::vector<Cluster>& clusters, const o2::itsmft::ROFRecord& rof);
   void unloadClusters();
+  void processLoadedClusters(std::vector<TrackITS>& tracks, std::vector<int>& clusIdx);
 
   std::vector<TrackITSExt> trackInThread(Int_t first, Int_t last);
   void makeSeeds(std::vector<TrackITSExt>& seeds, Int_t first, Int_t last);

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTracker.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTracker.h
@@ -54,10 +54,9 @@ class CookedTracker
   CookedTracker& operator=(const CookedTracker& tr) = delete;
   ~CookedTracker() = default;
 
-  void setVertices(std::vector<Vertex>& vertices)
+  void setVertices(const std::vector<Vertex>& vertices)
   {
-    mVertices.clear();
-    mVertices = std::move(vertices);
+    mVertices = &vertices;
   }
 
   Double_t getX() const { return mX; }
@@ -120,7 +119,7 @@ class CookedTracker
 
   Double_t mBz; ///< Effective Z-component of the magnetic field (kG)
 
-  std::vector<Vertex> mVertices;
+  const std::vector<Vertex>* mVertices = nullptr;
   Double_t mX = 0.; ///< X-coordinate of the primary vertex
   Double_t mY = 0.; ///< Y-coordinate of the primary vertex
   Double_t mZ = 0.; ///< Z-coordinate of the primary vertex

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CookedTracker.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CookedTracker.cxx
@@ -436,7 +436,7 @@ std::vector<TrackITSExt> CookedTracker::trackInThread(Int_t first, Int_t last)
   std::vector<TrackITSExt> seeds;
   seeds.reserve(last - first + 1);
 
-  for (auto& vtx : mVertices) {
+  for (const auto& vtx : *mVertices) {
     mX = vtx.getX();
     mY = vtx.getY();
     mZ = vtx.getZ();
@@ -458,6 +458,10 @@ void CookedTracker::process(const std::vector<Cluster>& clusters, std::vector<Tr
   //--------------------------------------------------------------------
   // This is the main tracking function
   //--------------------------------------------------------------------
+  if (mVertices == nullptr || mVertices->empty()) {
+    LOG(INFO) << "Not a single primary vertex provided. Skipping...\n";
+    return;
+  }
   LOG(INFO) << "\n CookedTracker::process(), number of threads: " << mNumOfThreads << '\n';
 
   auto start = std::chrono::system_clock::now();

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CookedTracker.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CookedTracker.cxx
@@ -453,19 +453,17 @@ std::vector<TrackITSExt> CookedTracker::trackInThread(Int_t first, Int_t last)
 }
 
 void CookedTracker::process(const std::vector<Cluster>& clusters, std::vector<TrackITS>& tracks,
-                            std::vector<int>& clusIdx, std::vector<o2::itsmft::ROFRecord>& rofs)
+                            std::vector<int>& clusIdx, o2::itsmft::ROFRecord& rof)
 {
   //--------------------------------------------------------------------
   // This is the main tracking function
   //--------------------------------------------------------------------
-  static int entry = 0;
-  LOG(INFO) << "CookedTracker::process() entry " << entry++ << ", number of threads: " << mNumOfThreads;
+  LOG(INFO) << "\n CookedTracker::process(), number of threads: " << mNumOfThreads << '\n';
 
   auto start = std::chrono::system_clock::now();
 
   mFirstCluster = &clusters.front();
 
-  for (auto& rof : rofs) {
     auto nClFrame = loadClusters(clusters, rof);
 
     auto end = std::chrono::system_clock::now();
@@ -476,7 +474,7 @@ void CookedTracker::process(const std::vector<Cluster>& clusters, std::vector<Tr
     start = end;
 
     int first = tracks.size();
-    processFrame(tracks, clusIdx);
+    processLoadedClusters(tracks, clusIdx);
     int number = tracks.size() - first;
     rof.getROFEntry().setIndex(first);
     rof.setNROFEntries(number);
@@ -487,10 +485,9 @@ void CookedTracker::process(const std::vector<Cluster>& clusters, std::vector<Tr
     LOG(INFO) << "Processing time/clusters for single frame : " << diff.count() << " / " << nClFrame << " s" << FairLogger::endl;
 
     start = end;
-  }
 }
 
-void CookedTracker::processFrame(std::vector<TrackITS>& tracks, std::vector<int>& clusIdx)
+void CookedTracker::processLoadedClusters(std::vector<TrackITS>& tracks, std::vector<int>& clusIdx)
 {
   //--------------------------------------------------------------------
   // This is the main tracking function for single frame, it is assumed that only clusters
@@ -529,8 +526,8 @@ void CookedTracker::processFrame(std::vector<TrackITS>& tracks, std::vector<int>
   }
 
   if (nSeeds) {
-    LOG(INFO) << "CookedTracker::process(), good_tracks:/seeds: " << ngood << '/' << nSeeds << "-> "
-              << Float_t(ngood) / nSeeds << FairLogger::endl;
+    LOG(INFO) << "CookedTracker::processLoadedClusters(), good_tracks:/seeds: " << ngood << '/' << nSeeds << "-> "
+              << Float_t(ngood) / nSeeds << '\n';
   }
 }
 

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CookedTracker.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CookedTracker.cxx
@@ -437,9 +437,9 @@ std::vector<TrackITSExt> CookedTracker::trackInThread(Int_t first, Int_t last)
   seeds.reserve(last - first + 1);
 
   for (auto& vtx : mVertices) {
-    mX = vtx[0];
-    mY = vtx[1];
-    mZ = vtx[2];
+    mX = vtx.getX();
+    mY = vtx.getY();
+    mZ = vtx.getZ();
     makeSeeds(seeds, first, last);
   }
 

--- a/Detectors/ITSMFT/ITS/workflow/src/CookedTrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/CookedTrackerSpec.cxx
@@ -95,7 +95,9 @@ void CookedTrackerDPL::run(ProcessingContext& pc)
 
   std::vector<o2::its::TrackITS> tracks;
   std::vector<int> clusIdx;
-  mTracker.process(clusters, tracks, clusIdx, rofs);
+  for (auto& rof : rofs) {
+    mTracker.process(clusters, tracks, clusIdx, rof);
+  }
 
   LOG(INFO) << "ITSCookedTracker pushed " << tracks.size() << " tracks";
   pc.outputs().snapshot(Output{ "ITS", "TRACKS", 0, Lifetime::Timeframe }, tracks);

--- a/macro/run_trac_its.C
+++ b/macro/run_trac_its.C
@@ -27,12 +27,12 @@
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
 #include "ReconstructionDataFormats/Vertex.h"
+#endif
 
 #include "ITStracking/ROframe.h"
 #include "ITStracking/IOUtils.h"
 #include "ITStracking/Vertexer.h"
 #include "ITStracking/VertexerTraits.h"
-#endif
 
 using MCLabCont = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
 using Vertex = o2::dataformats::Vertex<o2::dataformats::TimeStamp<int>>;


### PR DESCRIPTION
Itself, this PR is already functional.  Please try it, and review the code.
However, the reconstruction workflow will not work with the "--disable-mc" flag until the PR #1963 is merged.