### PR TITLE
Split MID digits merger and packer

### DIFF
--- a/Detectors/MUON/MID/Simulation/CMakeLists.txt
+++ b/Detectors/MUON/MID/Simulation/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SRCS
   src/Detector.cxx
   src/Digitizer.cxx
   src/DigitsMerger.cxx
+  src/DigitsPacker.cxx
   src/Geometry.cxx
   src/Hit.cxx
   src/Materials.cxx
@@ -26,6 +27,7 @@ set(HEADERS
   include/${MODULE_NAME}/Detector.h
   include/${MODULE_NAME}/Digitizer.h
   include/${MODULE_NAME}/DigitsMerger.h
+  include/${MODULE_NAME}/DigitsPacker.h
   include/${MODULE_NAME}/Hit.h
   include/${MODULE_NAME}/MCLabel.h
   include/${MODULE_NAME}/Stepper.h

--- a/Detectors/MUON/MID/Simulation/include/MIDSimulation/DigitsMerger.h
+++ b/Detectors/MUON/MID/Simulation/include/MIDSimulation/DigitsMerger.h
@@ -28,7 +28,7 @@ namespace mid
 class DigitsMerger
 {
  public:
-  void process(const std::vector<ColumnDataMC>& inDigitStore, const o2::dataformats::MCTruthContainer<MCLabel>& inMCContainer, std::vector<ColumnData>& outDigitStore, o2::dataformats::MCTruthContainer<MCLabel>& outMCContainer, int timestampdiff = 0);
+  void process(const std::vector<ColumnDataMC>& inDigitStore, const o2::dataformats::MCTruthContainer<MCLabel>& inMCContainer, std::vector<ColumnData>& outDigitStore, o2::dataformats::MCTruthContainer<MCLabel>& outMCContainer);
 
  private:
   std::vector<std::pair<ColumnDataMC, std::vector<size_t>>> mDigitsLabels; //! Temporary digits store
@@ -37,4 +37,4 @@ class DigitsMerger
 } // namespace mid
 } // namespace o2
 
-#endif /* O2_MID_DIGITSMEREGER_H */
+#endif /* O2_MID_DIGITSMERGER_H */

--- a/Detectors/MUON/MID/Simulation/include/MIDSimulation/DigitsPacker.h
+++ b/Detectors/MUON/MID/Simulation/include/MIDSimulation/DigitsPacker.h
@@ -1,0 +1,46 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDSimulation/DigitsPacker.h
+/// \brief  Digits sorter for MID
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   05 March 2018
+#ifndef O2_MID_DIGITSPACKER_H
+#define O2_MID_DIGITSPACKER_H
+
+#include <vector>
+#include "SimulationDataFormat/MCTruthContainer.h"
+#include "MIDSimulation/ColumnDataMC.h"
+#include "MIDSimulation/MCLabel.h"
+
+namespace o2
+{
+namespace mid
+{
+class DigitsPacker
+{
+ public:
+  void process(const std::vector<ColumnDataMC>& inDigitStore, const o2::dataformats::MCTruthContainer<MCLabel>& inMCContainer, unsigned int timestampdiff = 0);
+
+  /// Gets the number of groups
+  size_t getNGroups() const { return mTimeGroups.size() - 1; }
+
+  bool getGroup(size_t igroup, std::vector<ColumnDataMC>& digitStore, o2::dataformats::MCTruthContainer<MCLabel>& mcContainer);
+
+ private:
+  std::vector<size_t> mTimeGroups;                                          // Time groups
+  const std::vector<ColumnDataMC>* mDigitStore = nullptr;                   // Digits store (not owner)
+  const o2::dataformats::MCTruthContainer<MCLabel>* mMCContainer = nullptr; // Vector of labels (not owner)
+};
+
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_DIGITSPACKER_H */

--- a/Detectors/MUON/MID/Simulation/src/DigitsMerger.cxx
+++ b/Detectors/MUON/MID/Simulation/src/DigitsMerger.cxx
@@ -18,14 +18,14 @@ namespace o2
 {
 namespace mid
 {
-void DigitsMerger::process(const std::vector<ColumnDataMC>& inDigitStore, const o2::dataformats::MCTruthContainer<MCLabel>& inMCContainer, std::vector<ColumnData>& outDigitStore, o2::dataformats::MCTruthContainer<MCLabel>& outMCContainer, int timestampdiff)
+void DigitsMerger::process(const std::vector<ColumnDataMC>& inDigitStore, const o2::dataformats::MCTruthContainer<MCLabel>& inMCContainer, std::vector<ColumnData>& outDigitStore, o2::dataformats::MCTruthContainer<MCLabel>& outMCContainer)
 {
-  /// Merges the digits which have a timestamp difference smaller than timestamp diff
+  /// Merges the MC digits that are provided per hit
+  /// into the format that we expect from data
   /// \param inDigitStore Vector of input MC digits
   /// \param inMCContainer Container with MC labels for input MC digits
   /// \param outDigitStore Vector with merged digits
   /// \param outMCContainer Container with MC labels for merged digits
-  /// \param timestampdiff Maximum timestamp difference between digits to be merged
   outDigitStore.clear();
   outMCContainer.clear();
   mDigitsLabels.clear();
@@ -35,7 +35,7 @@ void DigitsMerger::process(const std::vector<ColumnDataMC>& inDigitStore, const 
     size_t idx = inIt - inDigitStore.begin();
     for (auto& pair : mDigitsLabels) {
       auto& outCol = pair.first;
-      if (outCol.deId == inIt->deId && outCol.columnId == inIt->columnId && std::abs(inIt->getTimeStamp() - outCol.getTimeStamp()) <= timestampdiff) {
+      if (outCol.deId == inIt->deId && outCol.columnId == inIt->columnId) {
         outCol |= (*inIt);
         pair.second.emplace_back(idx);
         isNew = false;

--- a/Detectors/MUON/MID/Simulation/src/DigitsPacker.cxx
+++ b/Detectors/MUON/MID/Simulation/src/DigitsPacker.cxx
@@ -1,0 +1,65 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Simulation/src/DigitsPacker.cxx
+/// \brief  Implementation of the digits Sorter for MID
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   05 March 2018
+#include "MIDSimulation/DigitsPacker.h"
+
+namespace o2
+{
+namespace mid
+{
+void DigitsPacker::process(const std::vector<ColumnDataMC>& inDigitStore, const o2::dataformats::MCTruthContainer<MCLabel>& inMCContainer, unsigned int timestampdiff)
+{
+  /// Groups the digits which have a timestamp difference smaller than timestamp diff
+  /// \param inDigitStore Vector of input MC digits
+  /// \param inMCContainer Container with MC labels for input MC digits
+  /// \param timestampdiff Maximum timestamp difference between digits to be merged
+  mTimeGroups.clear();
+  mDigitStore = &inDigitStore;
+  mMCContainer = &inMCContainer;
+
+  int ts = -1;
+  for (size_t idx = 0; idx < inDigitStore.size(); ++idx) {
+    if (std::abs(inDigitStore[idx].getTimeStamp() - ts) > timestampdiff) {
+      ts = inDigitStore[idx].getTimeStamp();
+      mTimeGroups.emplace_back(idx);
+    }
+  }
+
+  mTimeGroups.emplace_back(inDigitStore.size());
+}
+
+bool DigitsPacker::getGroup(size_t igroup, std::vector<ColumnDataMC>& digitStore, o2::dataformats::MCTruthContainer<MCLabel>& mcContainer)
+{
+
+  digitStore.clear();
+  mcContainer.clear();
+
+  if (igroup >= getNGroups()) {
+    return false;
+  }
+
+  size_t start = mTimeGroups[igroup];
+  size_t end = mTimeGroups[igroup + 1];
+
+  digitStore.reserve(end - start);
+  std::copy(mDigitStore->begin() + start, mDigitStore->begin() + end, std::back_inserter(digitStore));
+  for (size_t idx = 0; idx < digitStore.size(); ++idx) {
+    mcContainer.addElements(digitStore.size() - 1, mMCContainer->getLabels(start + idx));
+  }
+
+  return true;
+}
+
+} // namespace mid
+} // namespace o2


### PR DESCRIPTION
In the simulation we produce one ColumnData per hit, so that it is easier to associate the corresponding MC label.
However, the ColumnData must then be merged to mimic what happen in real life (sort of digits_to_raw).
The digit merger takes care of it as well as keeping the MC label in synch.

The merged (raw) output can then be packed and sorted according to the timestamp in order to mimic a timeframe. This is done by the sorter.

The two steps where mixed: they are now properly split.