### PR TITLE
DPL: remove debug printouts

### DIFF
--- a/Framework/Core/src/DataProcessingStatus.h
+++ b/Framework/Core/src/DataProcessingStatus.h
@@ -13,6 +13,9 @@
 #include "Framework/Signpost.h"
 #include <cstdint>
 
+/// probes to be used by the DPL
+#define O2_PROBE_DATARELAYER 3
+
 namespace o2
 {
 namespace framework
@@ -38,7 +41,6 @@ enum struct DriverStatus : uint32_t {
   BYTES_READ = 0,
   BYTES_PROCESSED = 1,
   BUFFER_OVERFLOWS = 2
-
 };
 
 } // namespace framework

--- a/Framework/Core/src/DataRelayer.cxx
+++ b/Framework/Core/src/DataRelayer.cxx
@@ -17,6 +17,8 @@
 #include "Framework/CompletionPolicy.h"
 #include "Framework/PartRef.h"
 #include "Framework/TimesliceIndex.h"
+#include "DataProcessingStatus.h"
+#include "Framework/Signpost.h"
 
 #include <Monitoring/Monitoring.h>
 
@@ -348,7 +350,7 @@ DataRelayer::relay(std::unique_ptr<FairMQMessage> &&header,
 
   /// If we get a valid result, we can store the message in cache.
   if (input != INVALID_INPUT && TimesliceId::isValid(timeslice) && TimesliceSlot::isValid(slot)) {
-    LOG(DEBUG) << "Received timeslice " << timeslice.value;
+    O2_SIGNPOST(O2_PROBE_DATARELAYER, timeslice.value, 0, 0, 0);
     saveInSlot(timeslice, input, slot);
     index.publishSlot(slot);
     index.markAsDirty(slot, true);

--- a/Framework/Core/test/test_ParallelPipeline.cxx
+++ b/Framework/Core/test/test_ParallelPipeline.cxx
@@ -44,8 +44,8 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
       AlgorithmSpec{ [](ProcessingContext& ctx) {
         for (auto const& input : ctx.inputs()) {
           auto const& parallelContext = ctx.services().get<ParallelContext>();
-          std::cout << "instance " << parallelContext.index1D() << " of " << parallelContext.index1DSize() << ": "
-                    << *input.spec << ": " << *((int*)input.payload) << std::endl;
+          LOG(DEBUG) << "instance " << parallelContext.index1D() << " of " << parallelContext.index1DSize() << ": "
+                     << *input.spec << ": " << *((int*)input.payload);
           auto const* dataheader = DataRefUtils::getHeader<o2::header::DataHeader*>(input);
           //auto data& = ctx.outputs().make<int>(OutputRef{"output", dataheader->subSpecification});
           auto& data = ctx.outputs().make<int>(Output{ "TST", "PREPROC", dataheader->subSpecification, Lifetime::Timeframe });
@@ -62,8 +62,8 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
       AlgorithmSpec{ [](ProcessingContext& ctx) {
         for (auto const& input : ctx.inputs()) {
           auto const& parallelContext = ctx.services().get<ParallelContext>();
-          std::cout << "instance " << parallelContext.index1D() << " of " << parallelContext.index1DSize() << ": "
-                    << *input.spec << ": " << *((int*)input.payload) << std::endl;
+          LOG(DEBUG) << "instance " << parallelContext.index1D() << " of " << parallelContext.index1DSize() << ": "
+                     << *input.spec << ": " << *((int*)input.payload);
           ASSERT_ERROR(ctx.inputs().get<int>(input.spec->binding.c_str()) == parallelContext.index1D());
           auto const* dataheader = DataRefUtils::getHeader<o2::header::DataHeader*>(input);
           // TODO: there is a bug in the API for using OutputRef, returns an rvalue which can not be bound to
@@ -140,7 +140,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
     Outputs(),
     AlgorithmSpec{ [checkMap](ProcessingContext& ctx) {
       for (auto const& input : ctx.inputs()) {
-        std::cout << "consuming : " << *input.spec << ": " << *((int*)input.payload) << std::endl;
+        LOG(DEBUG) << "consuming : " << *input.spec << ": " << *((int*)input.payload);
         auto const* dataheader = DataRefUtils::getHeader<o2::header::DataHeader*>(input);
         if (input.spec->binding.compare(0, 6, "datain") == 0) {
           ASSERT_ERROR((*checkMap)[dataheader->subSpecification] == ctx.inputs().get<int>(input.spec->binding.c_str()));


### PR DESCRIPTION
Substitute them with LOG(DEBUG) or O2_SIGNPOST where it makes sense.