### PR TITLE
DPL: add DataSpecUtils::getOptionalSubSpec API

### DIFF
--- a/Framework/Core/include/Framework/DataSpecUtils.h
+++ b/Framework/Core/include/Framework/DataSpecUtils.h
@@ -15,6 +15,8 @@
 #include "Headers/DataHeader.h"
 #include "Framework/Output.h"
 
+#include <optional>
+
 namespace o2
 {
 namespace framework
@@ -85,6 +87,9 @@ struct DataSpecUtils {
   /// For the moment this is trivial as the OutputSpec does not allow
   /// for wildcards.
   static ConcreteDataMatcher asConcreteDataMatcher(OutputSpec const& spec);
+
+  /// Get the subspec, if available.
+  static std::optional<header::DataHeader::SubSpecificationType> getOptionalSubSpec(OutputSpec const& spec);
 };
 
 } // namespace framework

--- a/Framework/Core/src/DataSpecUtils.cxx
+++ b/Framework/Core/src/DataSpecUtils.cxx
@@ -12,10 +12,9 @@
 #include <cstring>
 #include <cinttypes>
 
-namespace o2
+namespace o2::framework
 {
-namespace framework
-{
+
 namespace
 {
 std::string join(ConcreteDataMatcher const& matcher, std::string const sep = "_")
@@ -147,5 +146,10 @@ ConcreteDataMatcher DataSpecUtils::asConcreteDataMatcher(OutputSpec const& spec)
   return ConcreteDataMatcher{spec.origin, spec.description, spec.subSpec};
 }
 
-} // namespace framework
-} // namespace o2
+std::optional<header::DataHeader::SubSpecificationType> DataSpecUtils::getOptionalSubSpec(OutputSpec const& spec)
+{
+  ConcreteDataMatcher concrete = DataSpecUtils::asConcreteDataMatcher(spec);
+  return concrete.subSpec;
+}
+
+} // namespace o2::framework


### PR DESCRIPTION
This will become more meaningful once we migrate to the new OutputSpec, but for
now it should allow QC to migrate away from accessing OutputSpec details.