### PR TITLE
TrackITS refers on external cluster indices rather than containing array of them

### DIFF
--- a/DataFormats/Detectors/ITSMFT/ITS/include/DataFormatsITS/TrackITS.h
+++ b/DataFormats/Detectors/ITSMFT/ITS/include/DataFormatsITS/TrackITS.h
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "ReconstructionDataFormats/Track.h"
+#include "CommonDataFormat/RangeReference.h"
 
 namespace o2
 {
@@ -28,9 +29,11 @@ class Cluster;
 
 namespace its
 {
+
 class TrackITS : public o2::track::TrackParCov
 {
   using Cluster = o2::itsmft::Cluster;
+  using ClusRefs = o2::dataformats::RangeRefComp<4>;
 
  public:
   using o2::track::TrackParCov::TrackParCov; // inherit base constructors
@@ -38,26 +41,44 @@ class TrackITS : public o2::track::TrackParCov
 
   TrackITS() = default;
   TrackITS(const TrackITS& t) = default;
-  TrackITS(o2::track::TrackParCov&& parcov) : TrackParCov{ parcov } {}
-  TrackITS(o2::track::TrackParCov&& parCov, short ncl, float mass, float chi2, std::uint32_t rof, o2::track::TrackParCov&& outer, std::array<int, MaxClusters> cls) : o2::track::TrackParCov{ parCov }, mNClusters{ ncl }, mMass{ mass }, mChi2{ chi2 }, mROFrame{ rof }, mParamOut{ outer }, mIndex{ cls } {}
+  TrackITS(const o2::track::TrackParCov& parcov) : TrackParCov{ parcov } {}
+  TrackITS(const o2::track::TrackParCov& parCov, float chi2, std::uint32_t rof, const o2::track::TrackParCov& outer)
+    : o2::track::TrackParCov{ parCov }, mChi2{ chi2 }, mROFrame{ rof }, mParamOut{ outer } {}
   TrackITS& operator=(const TrackITS& tr) = default;
   ~TrackITS() = default;
 
   // These functions must be provided
   bool propagate(float alpha, float x, float bz);
-  bool update(const Cluster& c, float chi2, int idx);
+  bool update(const Cluster& c, float chi2);
 
   // Other functions
   float getChi2() const { return mChi2; }
-  int getNumberOfClusters() const { return mNClusters; }
-  int getClusterIndex(int i) const { return mIndex[i]; }
+  int getNumberOfClusters() const { return mClusRef.getEntries(); }
+  int getFirstClusterEntry() const { return mClusRef.getFirstEntry(); }
+  int getClusterEntry(int i) const { return getFirstClusterEntry() + i; }
+  void shiftFirstClusterEntry(int bias)
+  {
+    mClusRef.setFirstEntry(mClusRef.getFirstEntry() + bias);
+  }
+  void setFirstClusterEntry(int offs)
+  {
+    mClusRef.setFirstEntry(offs);
+  }
+  void setNumberOfClusters(int n)
+  {
+    mClusRef.setEntries(n);
+  }
   bool operator<(const TrackITS& o) const;
   void getImpactParams(float x, float y, float z, float bz, float ip[2]) const;
   // bool getPhiZat(float r,float &phi,float &z) const;
 
-  void setClusterIndex(int layer, int index);
-  void setExternalClusterIndex(int layer, int idx, bool newCluster = false);
-  void resetClusters();
+  void setClusterRefs(int firstEntry, int n)
+  {
+    mClusRef.set(firstEntry, n);
+  }
+
+  const ClusRefs& getClusterRefs() const { return mClusRef; }
+  ClusRefs& getClusterRefs() { return mClusRef; }
 
   void setChi2(float chi2) { mChi2 = chi2; }
 
@@ -69,14 +90,49 @@ class TrackITS : public o2::track::TrackParCov
   const o2::track::TrackParCov& getParamOut() const { return mParamOut; }
 
  private:
-  short mNClusters = 0;
-  float mMass = 0.14;                             ///< Assumed mass for this track
+  float mMass = 0.139;                            ///< Assumed mass for this track
   float mChi2 = 0.;                               ///< Chi2 for this track
   std::uint32_t mROFrame = 0;                     ///< RO Frame
-  o2::track::TrackParCov mParamOut;               /// parameter at largest radius
-  std::array<int, MaxClusters> mIndex = { -1 };   ///< Indices of associated clusters
+  o2::track::TrackParCov mParamOut;               ///< parameter at largest radius
+  ClusRefs mClusRef;                              ///< references on clusters
 
-  ClassDefNV(TrackITS, 2)
+  ClassDefNV(TrackITS, 3)
+};
+
+class TrackITSExt : public TrackITS
+{
+  ///< heavy version of TrackITS, with clusters embedded
+ public:
+  static constexpr int MaxClusters = 7;
+  using TrackITS::TrackITS; // inherit base constructors
+
+  TrackITSExt(o2::track::TrackParCov&& parCov, short ncl, float chi2, std::uint32_t rof,
+              o2::track::TrackParCov&& outer, std::array<int, MaxClusters> cls)
+    : TrackITS(parCov, chi2, rof, outer), mIndex{ cls }
+  {
+    setNumberOfClusters(ncl);
+  }
+
+  void setClusterIndex(int l, int i)
+  {
+    int ncl = getNumberOfClusters();
+    mIndex[ncl++] = (l << 28) + i;
+    getClusterRefs().setEntries(ncl);
+  }
+
+  int getClusterIndex(int lr) const { return mIndex[lr]; }
+
+  void setExternalClusterIndex(int layer, int idx, bool newCluster = false)
+  {
+    if (newCluster) {
+      getClusterRefs().setEntries(getNumberOfClusters() + 1);
+    }
+    mIndex[layer] = idx;
+  }
+
+ private:
+  std::array<int, MaxClusters> mIndex = { -1 }; ///< Indices of associated clusters
+  ClassDefNV(TrackITSExt, 1);
 };
 }
 }

--- a/DataFormats/Detectors/ITSMFT/ITS/src/TrackITS.cxx
+++ b/DataFormats/Detectors/ITSMFT/ITS/src/TrackITS.cxx
@@ -68,34 +68,6 @@ void TrackITS::getImpactParams(Float_t x, Float_t y, Float_t z, Float_t bz, Floa
   ip[1] = getZ() + getTgl() / rp4 * TMath::ASin(f2 * r1 - f1 * r2) - z;
 }
 
-void TrackITS::resetClusters()
-{
-  //------------------------------------------------------------------
-  // Reset the array of attached clusters.
-  //------------------------------------------------------------------
-  mChi2 = -1.;
-  mNClusters = 0;
-}
-
-void TrackITS::setClusterIndex(Int_t l, Int_t i)
-{
-  //--------------------------------------------------------------------
-  // Set the cluster index
-  //--------------------------------------------------------------------
-  Int_t idx = (l << 28) + i;
-  mIndex[mNClusters++] = idx;
-}
-
-void TrackITS::setExternalClusterIndex(Int_t layer, Int_t idx, bool newCluster)
-{
-  //--------------------------------------------------------------------
-  // Set the cluster index within an external cluster array
-  //--------------------------------------------------------------------
-  if (newCluster)
-    mNClusters++;
-  mIndex[layer] = idx;
-}
-
 Bool_t TrackITS::propagate(Float_t alpha, Float_t x, Float_t bz)
 {
   if (rotate(alpha))
@@ -105,53 +77,18 @@ Bool_t TrackITS::propagate(Float_t alpha, Float_t x, Float_t bz)
   return kFALSE;
 }
 
-Bool_t TrackITS::update(const Cluster& c, Float_t chi2, Int_t idx)
+Bool_t TrackITS::update(const Cluster& c, Float_t chi2)
 {
   //--------------------------------------------------------------------
   // Update track params
   //--------------------------------------------------------------------
-  if (!o2::track::TrackParCov::update(static_cast<const o2::BaseCluster<float>&>(c)))
+  if (!o2::track::TrackParCov::update(static_cast<const o2::BaseCluster<float>&>(c))) {
     return kFALSE;
-
+  }
   mChi2 += chi2;
-  mIndex[mNClusters++] = idx;
-
   return kTRUE;
 }
 
-/*
-Bool_t TrackITS::getPhiZat(Float_t r, Float_t &phi, Float_t &z) const
-{
-  //------------------------------------------------------------------
-  // This function returns the global cylindrical (phi,z) of the track
-  // position estimated at the radius r.
-  // The track curvature is neglected.
-  //------------------------------------------------------------------
-  Float_t d=GetD(0., 0., GetBz());
-  if (TMath::Abs(d) > r) {
-    if (r>1e-1) return kFALSE;
-    r = TMath::Abs(d);
-  }
-
-  Float_t rcurr=TMath::Sqrt(GetX()*GetX() + GetY()*GetY());
-  if (TMath::Abs(d) > rcurr) return kFALSE;
-  Float_t globXYZcurr[3]; GetXYZ(globXYZcurr);
-  Float_t phicurr=TMath::ATan2(globXYZcurr[1],globXYZcurr[0]);
-
-  if (GetX()>=0.) {
-    phi=phicurr+TMath::ASin(d/r)-TMath::ASin(d/rcurr);
-  } else {
-    phi=phicurr+TMath::ASin(d/r)+TMath::ASin(d/rcurr)-TMath::Pi();
-  }
-
-  // return a phi in [0,2pi[
-  if (phi<0.) phi+=2.*TMath::Pi();
-  else if (phi>=2.*TMath::Pi()) phi-=2.*TMath::Pi();
-  z=GetZ()+GetTgl()*(TMath::Sqrt((r-d)*(r+d))-TMath::Sqrt((rcurr-d)*(rcurr+d)));
-
-  return kTRUE;
-}
-*/
 
 Bool_t TrackITS::isBetter(const TrackITS& best, Float_t maxChi2) const
 {

--- a/DataFormats/Reconstruction/src/ReconstructionDataFormatsLinkDef.h
+++ b/DataFormats/Reconstruction/src/ReconstructionDataFormatsLinkDef.h
@@ -28,6 +28,7 @@
 
 #pragma link C++ class std::vector < std::pair < float, float >> +;
 #pragma link C++ class std::vector < std::pair < int, float >> +;
+#pragma link C++ class std::vector < int> + ;
 
 #pragma link C++ class o2::dataformats::CalibLHCphaseTOF + ;
 #pragma link C++ class o2::dataformats::CalibTimeSlewingParamTOF + ;

--- a/DataFormats/common/CMakeLists.txt
+++ b/DataFormats/common/CMakeLists.txt
@@ -23,6 +23,7 @@ O2_GENERATE_LIBRARY()
 
 set(TEST_SRCS
   test/testTimeStamp.cxx
+  test/testRangeRef.cxx
 )
 
 O2_GENERATE_TESTS(

--- a/DataFormats/common/src/CommonDataFormatLinkDef.h
+++ b/DataFormats/common/src/CommonDataFormatLinkDef.h
@@ -33,6 +33,8 @@
 #pragma link C++ class o2::dataformats::RangeReference < int, int > +;
 #pragma link C++ class o2::dataformats::RangeReference < o2::dataformats::EvIndex < int, int >, int > +;
 
+#pragma link C++ class o2::dataformats::RangeRefComp < 4> + ; // reference to a set with 15 entries max (ITS clusters)
+
 #pragma link C++ class o2::InteractionRecord + ;
 #pragma link C++ class o2::InteractionTimeRecord + ;
 #pragma link C++ class o2::BunchFilling + ;

--- a/DataFormats/common/test/testRangeRef.cxx
+++ b/DataFormats/common/test/testRangeRef.cxx
@@ -1,0 +1,39 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test TimeRangeRef class
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include "CommonDataFormat/RangeReference.h"
+#include <FairLogger.h>
+
+namespace o2
+{
+
+// basic TimeStamp tests
+BOOST_AUTO_TEST_CASE(RangeRef)
+{
+  int ent = 1000, nent = 5;
+  o2::dataformats::RangeReference<int, int> rangeII(ent, nent);
+  BOOST_CHECK_EQUAL(rangeII.getFirstEntry(), ent);
+  rangeII.changeEntriesBy(nent);
+  BOOST_CHECK_EQUAL(rangeII.getEntries(), 2 * nent);
+
+  o2::dataformats::RangeRefComp<4> range4(ent, nent);
+  BOOST_CHECK_EQUAL(range4.getFirstEntry(), ent);
+  range4.changeEntriesBy(nent);
+  BOOST_CHECK_EQUAL(range4.getEntries(), 2 * nent);
+  LOG(INFO) << "MaxEntryID : " << range4.getMaxFirstEntry() << " MaxEntries: " << range4.getMaxEntries();
+  BOOST_CHECK_EQUAL(range4.getMaxFirstEntry(), (0x1 << (32 - 4)) - 1);
+  BOOST_CHECK_EQUAL(range4.getMaxEntries(), (0x1 << 4) - 1);
+}
+
+} // namespace o2

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
@@ -195,6 +195,20 @@ class MatchTPCITS
     mITSTracksArrayInp = inp;
   }
 
+  ///< set input ITS tracks cluster indices received via DPL
+  void setITSTrackClusIdxInp(const std::vector<int>* inp)
+  {
+    assertDPLIO(true);
+    mITSTrackClusIdxInp = inp;
+  }
+
+  ///< set input ITS tracks cluster indices received via DPL
+  void setITSTrackClusIdxInp(gsl::span<const int> inp)
+  {
+    assertDPLIO(true);
+    mITSTrackClusIdxSPAN = inp;
+  }
+
   ///< set input ITS tracks ROF records received via DPL
   void setITSTrackROFRecInp(const std::vector<o2::itsmft::ROFRecord>* inp)
   {
@@ -536,6 +550,8 @@ class MatchTPCITS
   const std::vector<o2::itsmft::ROFRecord>* mITSTrackROFRec = nullptr;       ///< input ITS tracks ROFRecord
   const std::vector<o2::its::TrackITS>* mITSTracksArrayInp = nullptr;        ///< input ITS tracks
   const std::vector<o2::tpc::TrackTPC>* mTPCTracksArrayInp = nullptr;        ///< input TPC tracks
+  gsl::span<const int> mITSTrackClusIdxSPAN;                                 ///< input ITS track cluster indices span from DPL
+  const std::vector<int>* mITSTrackClusIdxInp = nullptr;                     ///< input ITS track cluster indices
   const std::vector<o2::itsmft::Cluster>* mITSClustersArrayInp = nullptr;    ///< input ITS clusters
   const std::vector<o2::itsmft::ROFRecord>* mITSClusterROFRec = nullptr;     ///< input ITS clusters ROFRecord
   const std::vector<o2::t0::RecPoints>* mFITInfoInp = nullptr;               ///< optional input FIT info
@@ -586,6 +602,7 @@ class MatchTPCITS
   std::vector<o2::MCCompLabel> mOutTPCLabels; ///< TPC label of matched track
 
   std::string mITSTrackBranchName = "ITSTrack";          ///< name of branch containing input ITS tracks
+  std::string mITSTrackClusIdxBranchName = "ITSTrackClusIdx"; ///< name of branch containing input ITS tracks cluster indices
   std::string mITSTrackROFRecBranchName = "ITSTracksROF"; ///< name of branch containing input ITS tracks ROFRecords
   std::string mTPCTrackBranchName = "Tracks";            ///< name of branch containing input TPC tracks
   std::string mITSClusterBranchName = "ITSCluster";      ///< name of branch containing input ITS clusters

--- a/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
@@ -71,10 +71,16 @@ void TPCITSMatchingDPL::run(ProcessingContext& pc)
   }
 
   auto tracksITS = pc.inputs().get<const std::vector<o2::its::TrackITS>>("trackITS");
+  auto trackClIdxITS = pc.inputs().get<gsl::span<int>>("trackClIdx");
   auto tracksITSROF = pc.inputs().get<const std::vector<o2::itsmft::ROFRecord>>("trackITSROF");
   auto clusITS = pc.inputs().get<const std::vector<o2::itsmft::Cluster>>("clusITS");
   auto clusITSROF = pc.inputs().get<const std::vector<o2::itsmft::ROFRecord>>("clusITSROF");
   auto tracksTPC = pc.inputs().get<const std::vector<o2::tpc::TrackTPC>>("trackTPC");
+
+  // TODO: this is very ugly way to transfer the vector to the matcher, we should pass a span
+  std::vector<int> clIdx;
+  clIdx.reserve(trackClIdxITS.size());
+  std::copy(trackClIdxITS.begin(), trackClIdxITS.end(), std::inserter(clIdx, clIdx.end()));
 
   //---------------------------->> TPC Clusters loading >>------------------------------------------
   int operation = 0;
@@ -230,6 +236,7 @@ void TPCITSMatchingDPL::run(ProcessingContext& pc)
   //
   // pass input data to MatchTPCITS object
   mMatching.setITSTracksInp(&tracksITS);
+  mMatching.setITSTrackClusIdxInp(&clIdx);
   mMatching.setITSTrackROFRecInp(&tracksITSROF);
   mMatching.setITSClustersInp(&clusITS);
   mMatching.setITSClusterROFRecInp(&clusITSROF);
@@ -271,6 +278,7 @@ DataProcessorSpec getTPCITSMatchingSpec(bool useMC, bool useFIT, const std::vect
   std::vector<InputSpec> inputs;
   std::vector<OutputSpec> outputs;
   inputs.emplace_back("trackITS", "ITS", "TRACKS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("trackClIdx", "ITS", "TRACKCLSID", 0, Lifetime::Timeframe);
   inputs.emplace_back("trackITSROF", "ITS", "ITSTrackROF", 0, Lifetime::Timeframe);
   inputs.emplace_back("clusITS", "ITS", "CLUSTERS", 0, Lifetime::Timeframe);
   inputs.emplace_back("clusITSROF", "ITS", "ITSClusterROF", 0, Lifetime::Timeframe);

--- a/Detectors/ITSMFT/ITS/macros/EVE/DisplayEvents.C
+++ b/Detectors/ITSMFT/ITS/macros/EVE/DisplayEvents.C
@@ -82,6 +82,7 @@ class Data
   gsl::span<Cluster> mClusters;
   std::vector<o2::itsmft::ROFRecord> mClustersROF;
   std::vector<o2::its::TrackITS>* mTrackBuffer = nullptr;
+  std::vector<int>* mClIdxBuffer = nullptr;
   gsl::span<o2::its::TrackITS> mTracks;
   std::vector<o2::itsmft::ROFRecord> mTracksROF;
   void loadDigits();
@@ -205,6 +206,7 @@ void Data::setTracTree(TTree* tree)
     return;
   }
   tree->SetBranchAddress("ITSTrack", &mTrackBuffer);
+  tree->SetBranchAddress("ITSTrackClusIdx", &mClIdxBuffer);
   mTracTree = tree;
 
   TTree* roft = (TTree*)gFile->Get("ITSTracksROF");
@@ -373,8 +375,9 @@ TEveElement* Data::getEveTracks()
     TEvePointSet* tpoints = new TEvePointSet("tclusters");
     tpoints->SetMarkerColor(kGreen);
     int nc = rec.getNumberOfClusters();
+    int idxRef = rec.getFirstClusterEntry();
     while (nc--) {
-      Int_t idx = rec.getClusterIndex(nc);
+      Int_t idx = (*mClIdxBuffer)[idxRef + nc];
       const Cluster& c = mClusters[idx];
       const auto& gloC = c.getXYZGloRot(*gman);
       tpoints->SetNextPoint(gloC.X(), gloC.Y(), gloC.Z());

--- a/Detectors/ITSMFT/ITS/macros/test/DisplayTrack.C
+++ b/Detectors/ITSMFT/ITS/macros/test/DisplayTrack.C
@@ -175,7 +175,9 @@ found:
   points->SetMarkerColor(kGreen);
 
   std::vector<TrackITS>* trkArr = nullptr;
+  std::vector<int>* clIdx = nullptr;
   tree->SetBranchAddress("ITSTrack", &trkArr);
+  tree->SetBranchAddress("ITSTrackClusIdx", &clIdx);
   // Track MC labels
   o2::dataformats::MCTruthContainer<o2::MCCompLabel>* trkLabArr = nullptr;
   tree->SetBranchAddress("ITSTrackMCTruth", &trkLabArr);
@@ -192,8 +194,9 @@ found:
     if (TMath::Abs(lab.getTrackID()) != track)
       continue;
     Int_t nc = t.getNumberOfClusters();
+    int idxRef = t.getFirstClusterEntry();
     while (n < nc) {
-      Int_t idx = t.getClusterIndex(n);
+      Int_t idx = (*clIdx)[idxRef++];
       Cluster& c = (*clusArr)[idx];
       auto gloC = c.getXYZGloRot(*gman); // convert from tracking to global frame
       points->SetNextPoint(gloC.X(), gloC.Y(), gloC.Z());

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTracker.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTracker.h
@@ -60,8 +60,8 @@ class CookedTracker
   Double_t getSigmaX() const { return mSigmaX; }
   Double_t getSigmaY() const { return mSigmaY; }
   Double_t getSigmaZ() const { return mSigmaZ; }
-  o2::MCCompLabel cookLabel(TrackITS& t, Float_t wrong) const;
-  void setExternalIndices(TrackITS& t) const;
+  o2::MCCompLabel cookLabel(TrackITSExt& t, Float_t wrong) const;
+  void setExternalIndices(TrackITSExt& t) const;
   Double_t getBz() const;
   void setBz(Double_t bz) { mBz = bz; }
 
@@ -69,12 +69,9 @@ class CookedTracker
   Int_t getNumberOfThreads() const { return mNumOfThreads; }
 
   // These functions must be implemented
-  void process(const std::vector<Cluster>& clusters, std::vector<TrackITS>& tracks,
+  void process(const std::vector<Cluster>& clusters, std::vector<TrackITS>& tracks, std::vector<int>& clusIdx,
                std::vector<o2::itsmft::ROFRecord>& rofs);
-  void processFrame(std::vector<TrackITS>& tracks);
-  // Int_t propagateBack(std::vector<TrackITS> *event);
-  // Int_t RefitInward(std::vector<TrackITS> *event);
-  // Bool_t refitAt(Double_t x, TrackITS *seed, const TrackITS *t);
+  void processFrame(std::vector<TrackITS>& tracks, std::vector<int>& clusIdx);
   const Cluster* getCluster(Int_t index) const;
 
   void setGeometry(o2::its::GeometryTGeo* geom);
@@ -94,24 +91,24 @@ class CookedTracker
 
  protected:
   static constexpr int kNLayers = 7;
+  void addOutputTrack(const TrackITSExt& t, std::vector<TrackITS>& tracks, std::vector<int>& clusIdx);
   int loadClusters(const std::vector<Cluster>& clusters, const o2::itsmft::ROFRecord& rof);
   void unloadClusters();
 
-  std::vector<TrackITS> trackInThread(Int_t first, Int_t last);
-  void makeSeeds(std::vector<TrackITS>& seeds, Int_t first, Int_t last);
-  void trackSeeds(std::vector<TrackITS>& seeds);
+  std::vector<TrackITSExt> trackInThread(Int_t first, Int_t last);
+  void makeSeeds(std::vector<TrackITSExt>& seeds, Int_t first, Int_t last);
+  void trackSeeds(std::vector<TrackITSExt>& seeds);
 
-  Bool_t attachCluster(Int_t& volID, Int_t nl, Int_t ci, TrackITS& t, const TrackITS& o) const;
+  Bool_t attachCluster(Int_t& volID, Int_t nl, Int_t ci, TrackITSExt& t, const TrackITSExt& o) const;
 
-  void makeBackPropParam(std::vector<TrackITS>& seeds) const;
-  bool makeBackPropParam(TrackITS& track) const;
+  void makeBackPropParam(std::vector<TrackITSExt>& seeds) const;
+  bool makeBackPropParam(TrackITSExt& track) const;
 
  private:
   bool mContinuousMode = true;                                                    ///< triggered or cont. mode
   const o2::its::GeometryTGeo* mGeom = nullptr;                                   /// interface to geometry
   const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* mClsLabels = nullptr; /// Cluster MC labels
   o2::dataformats::MCTruthContainer<o2::MCCompLabel>* mTrkLabels = nullptr;       /// Track MC labels
-
   std::uint32_t mFirstInFrame = 0; ///< Index of the 1st cluster of a frame (within the loaded vector of clusters)
 
   Int_t mNumOfThreads; ///< Number of tracking threads
@@ -128,7 +125,7 @@ class CookedTracker
   Double_t mSigmaZ = 2.; ///< error of the primary vertex position in Z
 
   static Layer sLayers[kNLayers]; ///< Layers filled with clusters
-  std::vector<TrackITS> mSeeds;   ///< Track seeds
+  std::vector<TrackITSExt> mSeeds; ///< Track seeds
 
   const Cluster* mFirstCluster = nullptr; ///< Pointer to the 1st cluster in event
 

--- a/Detectors/ITSMFT/ITS/tracking/cuda/include/ITStrackingCUDA/TrackerTraitsNV.h
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/include/ITStrackingCUDA/TrackerTraitsNV.h
@@ -34,7 +34,7 @@ class TrackerTraitsNV : public TrackerTraits
 
   void computeLayerCells() final;
   void computeLayerTracklets() final;
-  void refitTracks(const std::array<std::vector<TrackingFrameInfo>, 7>& tf, std::vector<TrackITS>& tracks) final;
+  void refitTracks(const std::array<std::vector<TrackingFrameInfo>, 7>& tf, std::vector<TrackITSExt>& tracks) final;
 };
 
 extern "C" TrackerTraits* createTrackerTraitsNV();

--- a/Detectors/ITSMFT/ITS/tracking/cuda/src/TrackerTraitsNV.cu
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/src/TrackerTraitsNV.cu
@@ -491,7 +491,7 @@ void TrackerTraitsNV::computeLayerCells()
   }
 }
 
-void TrackerTraitsNV::refitTracks(const std::array<std::vector<TrackingFrameInfo>, 7>& tf, std::vector<TrackITS>& tracks)
+void TrackerTraitsNV::refitTracks(const std::array<std::vector<TrackingFrameInfo>, 7>& tf, std::vector<TrackITSExt>& tracks)
 {
   PrimaryVertexContextNV* pvctx = static_cast<PrimaryVertexContextNV*>(mPrimaryVertexContext);
 

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracker.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracker.h
@@ -59,7 +59,7 @@ class Tracker
   void setBz(float bz);
   float getBz() const;
 
-  std::vector<TrackITS>& getTracks();
+  std::vector<TrackITSExt>& getTracks();
   dataformats::MCTruthContainer<MCCompLabel>& getTrackLabels();
 
   void clustersToTracks(const ROframe&, std::ostream& = std::cout);
@@ -78,7 +78,7 @@ class Tracker
   void findCellsNeighbours(int& iteration);
   void findRoads(int& iteration);
   void findTracks(const ROframe& ev);
-  bool fitTrack(const ROframe& event, TrackITS& track, int start, int end, int step);
+  bool fitTrack(const ROframe& event, TrackITSExt& track, int start, int end, int step);
   void traverseCellsTree(const int, const int);
   void computeRoadsMClabels(const ROframe&);
   void computeTracksMClabels(const ROframe&);
@@ -95,7 +95,7 @@ class Tracker
   bool mCUDA = false;
   float mBz = 5.f;
   std::uint32_t mROFrame = 0;
-  std::vector<TrackITS> mTracks;
+  std::vector<TrackITSExt> mTracks;
   dataformats::MCTruthContainer<MCCompLabel> mTrackLabels;
   o2::gpu::GPUChainITS* mRecoChain = nullptr;
 };
@@ -122,7 +122,7 @@ void Tracker::initialisePrimaryVertexContext(T&&... args)
   mPrimaryVertexContext->initialise(std::forward<T>(args)...);
 }
 
-inline std::vector<TrackITS>& Tracker::getTracks()
+inline std::vector<TrackITSExt>& Tracker::getTracks()
 {
   return mTracks;
 }

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackerTraits.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackerTraits.h
@@ -40,8 +40,8 @@ class GPUChainITS;
 namespace its
 {
 
-class TrackITS;
-typedef std::function<int(o2::gpu::GPUChainITS&, std::vector<Road>& roads, std::array<const Cluster*, 7>, std::array<const Cell*, 5>, const std::array<std::vector<TrackingFrameInfo>, 7>&, std::vector<TrackITS>&)> FuncRunITSTrackFit_t;
+class TrackITSExt;
+typedef std::function<int(o2::gpu::GPUChainITS&, std::vector<Road>& roads, std::array<const Cluster*, 7>, std::array<const Cell*, 5>, const std::array<std::vector<TrackingFrameInfo>, 7>&, std::vector<TrackITSExt>&)> FuncRunITSTrackFit_t;
 
 class TrackerTraits
 {
@@ -59,7 +59,7 @@ class TrackerTraits
 
   virtual void computeLayerTracklets(){};
   virtual void computeLayerCells(){};
-  virtual void refitTracks(const std::array<std::vector<TrackingFrameInfo>, 7>&, std::vector<TrackITS>&){};
+  virtual void refitTracks(const std::array<std::vector<TrackingFrameInfo>, 7>&, std::vector<TrackITSExt>&){};
 
   void UpdateTrackingParameters(const TrackingParameters& trkPar);
   PrimaryVertexContext* getPrimaryVertexContext() { return mPrimaryVertexContext; }

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackerTraitsCPU.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackerTraitsCPU.h
@@ -44,7 +44,7 @@ class TrackerTraitsCPU : public TrackerTraits
 
   void computeLayerCells() final;
   void computeLayerTracklets() final;
-  void refitTracks(const std::array<std::vector<TrackingFrameInfo>, 7>& tf, std::vector<TrackITS>& tracks) final;
+  void refitTracks(const std::array<std::vector<TrackingFrameInfo>, 7>& tf, std::vector<TrackITSExt>& tracks) final;
 
  protected:
   std::vector<std::vector<Tracklet>> mTracklets;

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -205,7 +205,7 @@ void Tracker::findRoads(int& iteration)
 void Tracker::findTracks(const ROframe& event)
 {
   mTracks.reserve(mTracks.capacity() + mPrimaryVertexContext->getRoads().size());
-  std::vector<TrackITS> tracks;
+  std::vector<TrackITSExt> tracks;
   tracks.reserve(mPrimaryVertexContext->getRoads().size());
 #ifdef CA_DEBUG
   std::array<int, 4> roadCounters{ 0, 0, 0, 0 };
@@ -256,7 +256,7 @@ void Tracker::findTracks(const ROframe& event)
     const auto& cluster3_tf = event.getTrackingFrameInfoOnLayer(lastCellLevel).at(clusters[lastCellLevel]);
 
     /// FIXME!
-    TrackITS temporaryTrack{ buildTrackSeed(cluster1_glo, cluster2_glo, cluster3_glo, cluster3_tf) };
+    TrackITSExt temporaryTrack{ buildTrackSeed(cluster1_glo, cluster2_glo, cluster3_glo, cluster3_tf) };
     for (size_t iC = 0; iC < clusters.size(); ++iC) {
       temporaryTrack.setExternalClusterIndex(iC, clusters[iC], clusters[iC] != constants::its::UnusedIndex);
     }
@@ -282,7 +282,7 @@ void Tracker::findTracks(const ROframe& event)
   //mTraits->refitTracks(event.getTrackingFrameInfo(), tracks);
 
   std::sort(tracks.begin(), tracks.end(),
-            [](TrackITS& track1, TrackITS& track2) { return track1.isBetter(track2, 1.e6f); });
+            [](TrackITSExt& track1, TrackITSExt& track2) { return track1.isBetter(track2, 1.e6f); });
 
 #ifdef CA_DEBUG
   std::array<int, 26> sharingMatrix{ 0 };
@@ -375,7 +375,7 @@ void Tracker::findTracks(const ROframe& event)
 #endif
 }
 
-bool Tracker::fitTrack(const ROframe& event, TrackITS& track, int start, int end, int step)
+bool Tracker::fitTrack(const ROframe& event, TrackITSExt& track, int start, int end, int step)
 {
   track.setChi2(0);
   for (int iLayer{ start }; iLayer != end; iLayer += step) {
@@ -528,14 +528,14 @@ void Tracker::computeTracksMClabels(const ROframe& event)
 
   int tracksNum{ static_cast<int>(mTracks.size()) };
 
-  for (TrackITS& track : mTracks) {
+  for (auto& track : mTracks) {
 
     MCCompLabel maxOccurrencesValue{ constants::its::UnusedIndex, constants::its::UnusedIndex,
                                      constants::its::UnusedIndex };
     int count{ 0 };
     bool isFakeTrack{ false };
 
-    for (int iCluster = 0; iCluster < TrackITS::MaxClusters; ++iCluster) {
+    for (int iCluster = 0; iCluster < TrackITSExt::MaxClusters; ++iCluster) {
       const int index = track.getClusterIndex(iCluster);
       if (index == constants::its::UnusedIndex) {
         continue;

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackerTraitsCPU.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackerTraitsCPU.cxx
@@ -225,7 +225,7 @@ void TrackerTraitsCPU::computeLayerCells()
   }
 }
 
-void TrackerTraitsCPU::refitTracks(const std::array<std::vector<TrackingFrameInfo>, 7>& tf, std::vector<TrackITS>& tracks)
+void TrackerTraitsCPU::refitTracks(const std::array<std::vector<TrackingFrameInfo>, 7>& tf, std::vector<TrackITSExt>& tracks)
 {
   std::array<const Cell*, 5> cells;
   for (int iLayer = 0; iLayer < 5; iLayer++) {

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/TrackReaderSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/TrackReaderSpec.h
@@ -43,6 +43,7 @@ class TrackReader : public Task
 
   std::vector<o2::itsmft::ROFRecord>*mROFRecInp = nullptr, mROFRecOut;
   std::vector<o2::its::TrackITS>*mTracksInp = nullptr, mTracksOut;
+  std::vector<int>*mClusIndInp = nullptr, mClusIndOut;
   o2::dataformats::MCTruthContainer<o2::MCCompLabel>*mMCTruthInp = nullptr, mMCTruthOut;
 
   o2::header::DataOrigin mOrigin = o2::header::gDataOriginITS;
@@ -54,6 +55,7 @@ class TrackReader : public Task
   std::string mTrackTreeName = "o2sim";
   std::string mROFTreeName = "ITSTracksROF";
   std::string mTrackBranchName = "ITSTrack";
+  std::string mClusIdxBranchName = "ITSTrackClusIdx";
   std::string mTrackMCTruthBranchName = "ITSTrackMCTruth";
 };
 

--- a/Detectors/ITSMFT/ITS/workflow/src/CookedTrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/CookedTrackerSpec.cxx
@@ -94,10 +94,12 @@ void CookedTrackerDPL::run(ProcessingContext& pc)
   mTracker.setVertices(vertices);
 
   std::vector<o2::its::TrackITS> tracks;
-  mTracker.process(clusters, tracks, rofs);
+  std::vector<int> clusIdx;
+  mTracker.process(clusters, tracks, clusIdx, rofs);
 
   LOG(INFO) << "ITSCookedTracker pushed " << tracks.size() << " tracks";
   pc.outputs().snapshot(Output{ "ITS", "TRACKS", 0, Lifetime::Timeframe }, tracks);
+  pc.outputs().snapshot(Output{ "ITS", "TRACKCLSID", 0, Lifetime::Timeframe }, clusIdx);
   pc.outputs().snapshot(Output{ "ITS", "ITSTrackROF", 0, Lifetime::Timeframe }, rofs);
 
   if (mUseMC) {
@@ -118,6 +120,7 @@ DataProcessorSpec getCookedTrackerSpec(bool useMC)
 
   std::vector<OutputSpec> outputs;
   outputs.emplace_back("ITS", "TRACKS", 0, Lifetime::Timeframe);
+  outputs.emplace_back("ITS", "TRACKCLSID", 0, Lifetime::Timeframe);
   outputs.emplace_back("ITS", "ITSTrackROF", 0, Lifetime::Timeframe);
 
   if (useMC) {

--- a/GPU/GPUTracking/Global/GPUChainITS.cxx
+++ b/GPU/GPUTracking/Global/GPUChainITS.cxx
@@ -55,13 +55,13 @@ int GPUChainITS::Finalize() { return 0; }
 
 int GPUChainITS::RunChain() { return 0; }
 
-int GPUChainITS::PrepareAndRunITSTrackFit(std::vector<Road>& roads, std::array<const Cluster*, 7> clusters, std::array<const Cell*, 5> cells, const std::array<std::vector<TrackingFrameInfo>, 7>& tf, std::vector<TrackITS>& tracks)
+int GPUChainITS::PrepareAndRunITSTrackFit(std::vector<Road>& roads, std::array<const Cluster*, 7> clusters, std::array<const Cell*, 5> cells, const std::array<std::vector<TrackingFrameInfo>, 7>& tf, std::vector<TrackITSExt>& tracks)
 {
   mRec->PrepareEvent();
   return RunITSTrackFit(roads, clusters, cells, tf, tracks);
 }
 
-int GPUChainITS::RunITSTrackFit(std::vector<Road>& roads, std::array<const Cluster*, 7> clusters, std::array<const Cell*, 5> cells, const std::array<std::vector<TrackingFrameInfo>, 7>& tf, std::vector<TrackITS>& tracks)
+int GPUChainITS::RunITSTrackFit(std::vector<Road>& roads, std::array<const Cluster*, 7> clusters, std::array<const Cell*, 5> cells, const std::array<std::vector<TrackingFrameInfo>, 7>& tf, std::vector<TrackITSExt>& tracks)
 {
   ActivateThreadContext();
   mRec->SetThreadCounts(RecoStep::ITSTracking);
@@ -93,20 +93,19 @@ int GPUChainITS::RunITSTrackFit(std::vector<Road>& roads, std::array<const Clust
   for (unsigned int i = 0; i < Fitter.NumberOfTracks(); i++) {
     auto& trkin = Fitter.tracks()[i];
 
-    tracks.emplace_back(TrackITS{ { trkin.X(),
-                                    trkin.mAlpha,
-                                    { trkin.Par()[0], trkin.Par()[1], trkin.Par()[2], trkin.Par()[3], trkin.Par()[4] },
-                                    { trkin.Cov()[0], trkin.Cov()[1], trkin.Cov()[2], trkin.Cov()[3], trkin.Cov()[4], trkin.Cov()[5], trkin.Cov()[6], trkin.Cov()[7], trkin.Cov()[8], trkin.Cov()[9], trkin.Cov()[10], trkin.Cov()[11], trkin.Cov()[12], trkin.Cov()[13], trkin.Cov()[14] } },
-                                  (short int)((trkin.NDF() + 5) / 2),
-                                  0.139f,
-                                  trkin.Chi2(),
-                                  0,
-                                  { trkin.mOuterParam.X,
-                                    trkin.mOuterParam.alpha,
-                                    { trkin.mOuterParam.P[0], trkin.mOuterParam.P[1], trkin.mOuterParam.P[2], trkin.mOuterParam.P[3], trkin.mOuterParam.P[4] },
-                                    { trkin.mOuterParam.C[0], trkin.mOuterParam.C[1], trkin.mOuterParam.C[2], trkin.mOuterParam.C[3], trkin.mOuterParam.C[4], trkin.mOuterParam.C[5], trkin.mOuterParam.C[6], trkin.mOuterParam.C[7], trkin.mOuterParam.C[8], trkin.mOuterParam.C[9],
-                                      trkin.mOuterParam.C[10], trkin.mOuterParam.C[11], trkin.mOuterParam.C[12], trkin.mOuterParam.C[13], trkin.mOuterParam.C[14] } },
-                                  { { trkin.mClusters[0], trkin.mClusters[1], trkin.mClusters[2], trkin.mClusters[3], trkin.mClusters[4], trkin.mClusters[5], trkin.mClusters[6] } } });
+    tracks.emplace_back(TrackITSExt{ { trkin.X(),
+                                       trkin.mAlpha,
+                                       { trkin.Par()[0], trkin.Par()[1], trkin.Par()[2], trkin.Par()[3], trkin.Par()[4] },
+                                       { trkin.Cov()[0], trkin.Cov()[1], trkin.Cov()[2], trkin.Cov()[3], trkin.Cov()[4], trkin.Cov()[5], trkin.Cov()[6], trkin.Cov()[7], trkin.Cov()[8], trkin.Cov()[9], trkin.Cov()[10], trkin.Cov()[11], trkin.Cov()[12], trkin.Cov()[13], trkin.Cov()[14] } },
+                                     (short int)((trkin.NDF() + 5) / 2),
+                                     trkin.Chi2(),
+                                     0,
+                                     { trkin.mOuterParam.X,
+                                       trkin.mOuterParam.alpha,
+                                       { trkin.mOuterParam.P[0], trkin.mOuterParam.P[1], trkin.mOuterParam.P[2], trkin.mOuterParam.P[3], trkin.mOuterParam.P[4] },
+                                       { trkin.mOuterParam.C[0], trkin.mOuterParam.C[1], trkin.mOuterParam.C[2], trkin.mOuterParam.C[3], trkin.mOuterParam.C[4], trkin.mOuterParam.C[5], trkin.mOuterParam.C[6], trkin.mOuterParam.C[7], trkin.mOuterParam.C[8], trkin.mOuterParam.C[9],
+                                         trkin.mOuterParam.C[10], trkin.mOuterParam.C[11], trkin.mOuterParam.C[12], trkin.mOuterParam.C[13], trkin.mOuterParam.C[14] } },
+                                     { { trkin.mClusters[0], trkin.mClusters[1], trkin.mClusters[2], trkin.mClusters[3], trkin.mClusters[4], trkin.mClusters[5], trkin.mClusters[6] } } });
   }
 
   ReleaseThreadContext();

--- a/GPU/GPUTracking/Global/GPUChainITS.h
+++ b/GPU/GPUTracking/Global/GPUChainITS.h
@@ -23,7 +23,7 @@ class Cluster;
 class Road;
 class Cell;
 class TrackingFrameInfo;
-class TrackITS;
+class TrackITSExt;
 } // namespace its
 } // namespace o2
 
@@ -45,8 +45,8 @@ class GPUChainITS : public GPUChain
   int RunChain() override;
   void MemorySize(size_t& gpuMem, size_t& pageLockedHostMem) override;
 
-  int PrepareAndRunITSTrackFit(std::vector<o2::its::Road>& roads, std::array<const o2::its::Cluster*, 7> clusters, std::array<const o2::its::Cell*, 5> cells, const std::array<std::vector<o2::its::TrackingFrameInfo>, 7>& tf, std::vector<o2::its::TrackITS>& tracks);
-  int RunITSTrackFit(std::vector<o2::its::Road>& roads, std::array<const o2::its::Cluster*, 7> clusters, std::array<const o2::its::Cell*, 5> cells, const std::array<std::vector<o2::its::TrackingFrameInfo>, 7>& tf, std::vector<o2::its::TrackITS>& tracks);
+  int PrepareAndRunITSTrackFit(std::vector<o2::its::Road>& roads, std::array<const o2::its::Cluster*, 7> clusters, std::array<const o2::its::Cell*, 5> cells, const std::array<std::vector<o2::its::TrackingFrameInfo>, 7>& tf, std::vector<o2::its::TrackITSExt>& tracks);
+  int RunITSTrackFit(std::vector<o2::its::Road>& roads, std::array<const o2::its::Cluster*, 7> clusters, std::array<const o2::its::Cell*, 5> cells, const std::array<std::vector<o2::its::TrackingFrameInfo>, 7>& tf, std::vector<o2::its::TrackITSExt>& tracks);
 
   o2::its::TrackerTraits* GetITSTrackerTraits() { return mITSTrackerTraits.get(); }
   o2::its::VertexerTraits* GetITSVertexerTraits() { return mITSVertexerTraits.get(); }

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -2244,6 +2244,7 @@ o2_define_bucket(
     data_format_its_bucket
 
     DEPENDENCIES
+    data_format_common_bucket
     data_format_reconstruction_bucket
     #
     O2ReconstructionDataFormats

--- a/macro/run_trac_its.C
+++ b/macro/run_trac_its.C
@@ -103,10 +103,12 @@ void run_trac_its(std::string path = "./", std::string outputfile = "o2trac_its.
   // create/attach output tree
   TFile outFile((path + outputfile).data(), "recreate");
   TTree outTree("o2sim", "Cooked ITS Tracks");
-  std::vector<o2::its::TrackITS>* tracksITS = new std::vector<o2::its::TrackITS>;
-  MCLabCont* trackLabels = new MCLabCont();
-  outTree.Branch("ITSTrack", &tracksITS);
-  outTree.Branch("ITSTrackMCTruth", &trackLabels);
+  std::vector<o2::its::TrackITS> tracksITS, *tracksITSPtr = &tracksITS;
+  std::vector<int> trackClIdx, *trackClIdxPtr = &trackClIdx;
+  MCLabCont trackLabels, *trackLabelsPtr = &trackLabels;
+  outTree.Branch("ITSTrack", &tracksITSPtr);
+  outTree.Branch("ITSTrackClusIdx", &trackClIdxPtr);
+  outTree.Branch("ITSTrackMCTruth", &trackLabelsPtr);
 
   TTree treeROF("ITSTracksROF", "ROF records tree");
   treeROF.Branch("ITSTracksROF", &rofs);
@@ -120,7 +122,7 @@ void run_trac_its(std::string path = "./", std::string outputfile = "o2trac_its.
   tracker.setBz(field->solenoidField()); // in kG
   tracker.setGeometry(gman);
   if (mcTruth)
-    tracker.setMCTruthContainers(&allLabels, trackLabels);
+    tracker.setMCTruthContainers(&allLabels, trackLabelsPtr);
   //===========================================
 
   // Load all clusters into a single vector
@@ -150,7 +152,7 @@ void run_trac_its(std::string path = "./", std::string outputfile = "o2trac_its.
   std::vector<std::array<Double_t, 3>> vertices;
   vertices.emplace_back(std::array<Double_t, 3>{ 0., 0., 0. });
   tracker.setVertices(vertices);
-  tracker.process(allClusters, *tracksITS, *rofs);
+  tracker.process(allClusters, tracksITS, trackClIdx, *rofs);
   outTree.Fill();
   treeROF.Fill();
 


### PR DESCRIPTION
@iouribelikov @mpuccio : this PR decouples the TrackITS and indices of contributing clusters. Now the TrackITS just refers to the 1st cluster index in some external array and tells how many clusters to read. 
For the usage in the trackers, where it is convenient to have array of indices local to the track, I've derived TrackITSExt and adapted both CA and CookedTracker to its usage. 
All workflows which before where exchanging the ``vector<TrackITS>``, now also exchange the ``vector<int>`` of cluster indices used by tracks (stored in the same tree as the tracks).