### PR TITLE
Reduce ITS Wraper Volume dimensions to avoid fake overlaps with MFT

### DIFF
--- a/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
@@ -115,9 +115,9 @@ static void configITS(Detector* its)
   its->setStaveModelOB(o2::its::Detector::kOBModel2);
 
   const int kNWrapVol = 3;
-  const double wrpRMin[kNWrapVol] = { 2.1, 15.0, 32.0 };
+  const double wrpRMin[kNWrapVol] = { 2.1, 19.3, 32.0 };
   const double wrpRMax[kNWrapVol] = { 14.0, 30.0, 46.0 };
-  const double wrpZSpan[kNWrapVol] = { 70., 95., 200. };
+  const double wrpZSpan[kNWrapVol] = { 70., 93., 160. };
 
   for (int iw = 0; iw < kNWrapVol; iw++) {
     its->defineWrapperVolume(iw, wrpRMin[iw], wrpRMax[iw], wrpZSpan[iw]);


### PR DESCRIPTION
Some elements of the MFT geometry have overlaps with the ITS Wrapper Volumes of Middle and Outer Layers. These cylinders are not real volumes, but simply containers made of air. Their dimensions were reduced to accommodate the MFT elements.