### PR TITLE
MFT: new read-out mapping to work with the latest raw data encoding

### DIFF
--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/GeometryTGeo.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/GeometryTGeo.h
@@ -36,9 +36,9 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
 {
  public:
   typedef o2::Transform3D Mat3D;
-  using DetMatrixCache::getMatrixT2L;
   using DetMatrixCache::getMatrixL2G;
   using DetMatrixCache::getMatrixT2G;
+  using DetMatrixCache::getMatrixT2L;
 
   static GeometryTGeo* Instance()
   {
@@ -60,7 +60,7 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
                /*o2::base::utils::bit2Mask(o2::TransformType::T2L, // default transformations to load
                                            o2::TransformType::T2G,
                                            o2::TransformType::L2G)*/
-               );
+  );
 
   /// Default destructor
   ~GeometryTGeo() override;
@@ -106,6 +106,12 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
     return extractNumberOfSensorsPerLadder(half, disk, ladderID);
   }
 
+  /// Returns the ladder geometry ID from the matrix ID
+  Int_t getLadderID(Int_t disk, Int_t ladder) const
+  {
+    return mLadderIndex2Id[disk][ladder];
+  }
+
  protected:
   /// Determines the number of detector halves in the Geometry
   Int_t extractNumberOfHalves();
@@ -147,6 +153,7 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
 
   /// In a disk start numbering the sensors from zero
   Int_t getFirstSensorIndex(Int_t disk) const { return (disk == 0) ? 0 : mLastSensorIndex[disk - 1] + 1; }
+
  protected:
   static constexpr Int_t MinSensorsPerLadder = 2;
   static constexpr Int_t MaxSensorsPerLadder = 5;
@@ -177,7 +184,7 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
 
   ClassDefOverride(GeometryTGeo, 1); // MFT geometry based on TGeo
 };
-}
-}
+} // namespace mft
+} // namespace o2
 
 #endif

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ChipMappingMFT.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ChipMappingMFT.h
@@ -25,7 +25,9 @@ namespace itsmft
 
 struct MFTChipMappingData {
   UShort_t module = 0;      // global module ID
-  UChar_t chipInModule = 0; // chip within the module
+  UChar_t chipOnModule = 0; // chip within the module
+  UChar_t cable = 0;        // cable in the connector
+  UChar_t chipOnRU = 0;     // chip within the RU (SW)
   ClassDefNV(MFTChipMappingData, 1);
 };
 
@@ -33,87 +35,120 @@ struct MFTModuleMappingData {
   UChar_t layer = 0;        // layer id
   UChar_t nChips = 0;       // number of chips
   UShort_t firstChipID = 0; // global id of 1st chip
+  UChar_t connector = 0;    // cable connector in a zone
+  UChar_t zone = 0;         // read-out zone id
+  UChar_t disk = 0;         // disk id
+  UChar_t half = 0;         // half id
   ClassDefNV(MFTModuleMappingData, 1);
 };
 
 class ChipMappingMFT
 {
  public:
+  ChipMappingMFT();
+  ~ChipMappingMFT() = default;
+
   static constexpr std::string_view getName() { return "MFT"; }
 
   // RS placeholder for methods to implement ----------->
 
   ///< total number of RUs
-  static constexpr int getNRUs() { return 0; }
+  static constexpr Int_t getNRUs() { return NRUs; }
 
   ///< get FEEId of the RU (software id of the RU), read via given link
-  uint8_t FEEId2RUSW(uint16_t hw) const { return 0; }
+  uint8_t FEEId2RUSW(uint16_t hw) const { return mFEEId2RUSW[hw]; }
 
   ///< get HW id of the RU (software id of the RU)
-  uint16_t RUSW2FEEId(uint16_t sw, uint16_t linkID = 0) const { return 0; }
+  uint16_t RUSW2FEEId(uint16_t sw, uint16_t linkID = 0) const { return mRUInfo[sw].idHW; }
 
   ///< compose FEEid for given stave (ru) relative to layer and link, see documentation in the constructor
-  uint16_t composeFEEId(uint16_t lr, uint16_t ruOnLr, uint16_t link) const { return 0; }
+  uint16_t composeFEEId(uint16_t layer, uint16_t ruOnLayer, uint16_t link) const
+  {
+    // only one link is used
+    // ruOnLayer is 0, 1, 2, 3 for half = 0
+    //              4, 5, 6, 7            1
+    auto dhalf = std::div(ruOnLayer, 4);
+    uint16_t half = dhalf.quot;
+    uint16_t zone = dhalf.rem;
+    auto ddisk = std::div(layer, 2);
+    uint16_t disk = ddisk.quot;
+    uint16_t plane = layer % 2;
+    return (half << 6) + (disk << 3) + (plane << 2) + zone;
+  }
 
   ///< decompose FEEid to layer, stave (ru) relative to layer, link, see documentation in the constructor
-  void expandFEEId(uint16_t feeID, uint16_t& lr, uint16_t& ruOnLr, uint16_t& link) const
+  void expandFEEId(uint16_t feeID, uint16_t& layer, uint16_t& ruOnLayer, uint16_t& link) const
   {
-    lr = ruOnLr = link = 0;
+    link = 0;
+    uint16_t half = feeID >> 6;
+    uint16_t disk = (feeID >> 3) & 0x7;
+    uint16_t plane = (feeID >> 2) & 0x1;
+    uint16_t zone = feeID & 0x3;
+    layer = 2 * disk + plane;
+    ruOnLayer = 2 * half + zone;
   }
 
   ///< get info on sw RU
-  const RUInfo* getRUInfoSW(int ruSW) const { return nullptr; }
-
-  ///< get info on sw RU
-  const RUInfo* getRUInfoFEEId(int feeID) const { return nullptr; }
+  const RUInfo* getRUInfoFEEId(Int_t feeID) const { return &mRUInfo[FEEId2RUSW(feeID)]; }
 
   ///< get number of chips served by single cable on given RU type
-  uint8_t getGBTHeaderRUType(int ruType, int cableHW) { return 0; }
+  uint8_t getGBTHeaderRUType(Int_t ruType, Int_t cableHW)
+  {
+    return (cableHW & 0x1f);
+  }
 
   ///< convert HW cable ID to SW ID for give RU type
-  uint8_t cableHW2SW(uint8_t ruType, uint8_t hwid) const { return 0; }
+  uint8_t cableHW2SW(uint8_t ruType, uint8_t hwid) const { return mCableHW2SW[ruType][hwid]; }
 
   ///< get chip global SW ID from chipID on module, cable SW ID and stave (RU) info
-  uint16_t getGlobalChipID(uint16_t chOnModuleHW, int cableHW, const RUInfo& ruInfo) const
+  uint16_t getGlobalChipID(uint16_t chOnModuleHW, Int_t cableHW, const RUInfo& ruInfo) const
   {
-    return 0;
+    return ruInfo.firstChipIDSW + mCableHWFirstChip[ruInfo.ruType][cableHW] + chipModuleIDHW2SW(ruInfo.ruType, chOnModuleHW);
   }
 
-  static constexpr int getNChips() { return NChips; }
-
-  // RS placeholder for methods to implement -----------<
-
-  static constexpr int getNModules() { return NModules; }
-
-  int chipID2Module(int chipID, int& chipInModule) const
+  ///< convert HW id of chip in the module to SW ID (sequential ID on the module)
+  int chipModuleIDHW2SW(int ruType, int hwIDinMod) const
   {
-    chipInModule = ChipMappingData[chipID].chipInModule;
+    return hwIDinMod;
+  }
+
+  ///< convert SW id of chip in the module to HW ID
+  int chipModuleIDSW2HW(int ruType, int swIDinMod) const
+  {
+    return swIDinMod;
+  }
+
+  static constexpr Int_t getNChips() { return NChips; }
+
+  static constexpr Int_t getNModules() { return NModules; }
+
+  Int_t chipID2Module(Int_t chipID, Int_t& chipOnModule) const
+  {
+    chipOnModule = ChipMappingData[chipID].chipOnModule;
     return ChipMappingData[chipID].module;
   }
 
-  int chipID2Module(int chipID) const
+  Int_t chipID2Module(Int_t chipID) const
   {
     return ChipMappingData[chipID].module;
   }
 
-  int getCablesOnRUType(int ruType) const { return 0; }
-
-  int getNChipsInModule(int modID) const
+  Int_t getNChipsInModule(Int_t modID) const
   {
     return ModuleMappingData[modID].nChips;
   }
 
-  int module2ChipID(int modID, int chipInModule) const
+  Int_t module2ChipID(Int_t modID, Int_t chipOnModule) const
   {
-    return ModuleMappingData[modID].firstChipID + chipInModule;
+    return ModuleMappingData[modID].firstChipID + chipOnModule;
   }
 
-  int module2Layer(int modID) const
+  Int_t module2Layer(Int_t modID) const
   {
     return ModuleMappingData[modID].layer;
   }
 
-  int chip2Layer(int chipID) const
+  Int_t chip2Layer(Int_t chipID) const
   {
     return ModuleMappingData[ChipMappingData[chipID].module].layer;
   }
@@ -121,17 +156,119 @@ class ChipMappingMFT
   ///< impose user defined FEEId -> ruSW (staveID) conversion, to be used only for forced decoding of corrupted data
   void imposeFEEId2RUSW(uint16_t, uint16_t) {}
 
+  ///< extract information about the chip with SW ID
+  void getChipInfoSW(Int_t chipSW, ChipInfo& chInfo) const
+  {
+    UShort_t ladder = ChipMappingData[chipSW].module;
+    UChar_t layer = ModuleMappingData[ladder].layer;
+    UChar_t zone = ModuleMappingData[ladder].zone;
+    UChar_t half = ModuleMappingData[ladder].half;
+
+    chInfo.ruType = ZoneRUType[zone][layer / 2];
+
+    // count RU SW per half layers
+    //chInfo.ru = NLayers * (NZonesPerLayer / 2) * half + (NZonesPerLayer / 2) * layer + zone;
+
+    // count RU SW per full layers
+    chInfo.ru = NZonesPerLayer * layer + (NZonesPerLayer / 2) * half + zone;
+
+    chInfo.id = ChipMappingData[chipSW].chipOnRU;
+    chInfo.chOnRU = getChipOnRUInfo(chInfo.ruType, chInfo.id);
+  }
+
+  ///< get number of chips served by RU of given type (i.e. RU type for ITS)
+  Int_t getNChipsOnRUType(Int_t ruType) const { return NChipsOnRUType[ruType]; }
+
+  /// < extract information about the chip properties on the stave of given type for the chip
+  /// < with sequential ID SWID within the stave
+  const ChipOnRUInfo* getChipOnRUInfo(Int_t ruType, Int_t chOnRUSW) const
+  {
+    return &mChipsInfo[mChipInfoEntryRU[ruType] + chOnRUSW];
+  }
+
+  static constexpr std::int16_t getRUDetectorField() { return 0x0; }
+
+  ///< get pattern of lanes on the RU served by a given RU type
+  Int_t getCablesOnRUType(Int_t ruType) const { return (0x1 << NChipsOnRUType[ruType]) - 1; }
+
+  ///< get info on sw RU
+  const RUInfo* getRUInfoSW(int ruSW) const { return &mRUInfo[ruSW]; }
+
+  ///< convert layer ID and RU sequential ID on Layer to absolute RU IDSW
+  int getRUIDSW(int layer, int ruOnLayer) const
+  {
+    int sid = 0;
+    for (int i = 0; i < NLayers; i++) {
+      if (i >= layer)
+        break;
+      sid += NZonesPerLayer;
+    }
+    return sid + ruOnLayer;
+  }
+
  private:
-  int invalid() const;
-  static constexpr int NModules = 280;
-  static constexpr int NChips = 920;
+  Int_t invalid() const;
+  static constexpr Int_t NZonesPerLayer = 2 * 4;
+  static constexpr Int_t NLayers = 10;
+  static constexpr Int_t NRUs = NLayers * NZonesPerLayer;
+  static constexpr Int_t NModules = 280;
+  static constexpr Int_t NChips = 936;
+  static constexpr Int_t NRUTypes = 12;
+  static constexpr Int_t NChipsInfo = 7 + 8 + 9 + 10 + 11 + 12 + 13 + 14 + 16 + 17 + 18 + 19;
+  static constexpr Int_t NChipsPerCable = 1;
+  static constexpr Int_t NLinks = 1;
+  static constexpr Int_t NConnectors = 5;
+  static constexpr Int_t NMaxChipsPerLadder = 5;
+  static constexpr Int_t NRUCables = 25;
+
+  static constexpr Int_t ZoneLadderIDmin[NZonesPerLayer / 2][NLayers]{
+    { 0, 21, 0, 21, 0, 23, 0, 28, 0, 29 },
+    { 3, 18, 3, 18, 3, 20, 4, 24, 5, 25 },
+    { 6, 15, 6, 15, 6, 17, 8, 20, 9, 21 },
+    { 9, 12, 9, 12, 9, 13, 12, 16, 13, 17 }
+  };
+  static constexpr Int_t ZoneLadderIDmax[NZonesPerLayer / 2][NLayers]{
+    { 2, 23, 2, 23, 2, 25, 3, 31, 4, 33 },
+    { 5, 20, 5, 20, 5, 22, 7, 27, 8, 28 },
+    { 8, 17, 8, 17, 8, 19, 11, 23, 12, 24 },
+    { 11, 14, 11, 14, 12, 16, 15, 19, 16, 20 }
+  };
+
+  static constexpr Int_t ZoneRUType[NZonesPerLayer / 2][NLayers / 2]{
+    { 1, 1, 1, 7, 11 },
+    { 2, 2, 4, 8, 9 },
+    { 2, 2, 3, 8, 10 },
+    { 0, 0, 5, 6, 7 }
+  };
+
+  static constexpr Int_t ChipConnectorCable[NConnectors][NMaxChipsPerLadder]{
+    { 5, 6, 7, 24, 23 },
+    { 0, 1, 2, 3, 4 },
+    { 17, 16, 15, 14, 13 },
+    { 22, 21, 20, 19, 18 },
+    { 12, 11, 10, 9, 8 }
+  };
 
   static const std::array<MFTChipMappingData, NChips> ChipMappingData;
   static const std::array<MFTModuleMappingData, NModules> ModuleMappingData;
 
+  ///< number of chips per zone (RU)
+  static constexpr std::array<int, NRUTypes> NChipsOnRUType{ 7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 18, 19 };
+
+  // info on chips info within the zone (RU)
+  std::array<ChipOnRUInfo, NChipsInfo> mChipsInfo;
+  Int_t mChipInfoEntryRU[NRUTypes];
+
+  /// info per zone (RU)
+  std::array<RUInfo, NRUs> mRUInfo;
+  std::vector<uint8_t> mFEEId2RUSW; // HW RU ID -> SW ID conversion
+
+  std::vector<uint8_t> mCableHW2SW[NRUs];       ///< table of cables HW to SW conversion for each RU type
+  std::vector<uint8_t> mCableHWFirstChip[NRUs]; ///< 1st chip of module (relative to the 1st chip of the stave) served by each cable
+
   ClassDefNV(ChipMappingMFT, 1)
 };
-}
-}
+} // namespace itsmft
+} // namespace o2
 
 #endif

--- a/Detectors/ITSMFT/common/reconstruction/src/ChipMappingMFT.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/ChipMappingMFT.cxx
@@ -13,1601 +13,1688 @@
 #include "ITSMFTReconstruction/ChipMappingMFT.h"
 
 using namespace o2::itsmft;
-const std::array<MFTChipMappingData, ChipMappingMFT::NChips> ChipMappingMFT::ChipMappingData{ { // chip:   0 (2), ladder:  0, layer: 0, disk: 0, half: 0
-                                                                                                { 0, 0 },
-                                                                                                { 0, 1 },
-                                                                                                // chip:   2 (2), ladder:  1, layer: 0, disk: 0, half: 0
-                                                                                                { 1, 0 },
-                                                                                                { 1, 1 },
-                                                                                                // chip:   4 (2), ladder:  2, layer: 0, disk: 0, half: 0
-                                                                                                { 2, 0 },
-                                                                                                { 2, 1 },
-                                                                                                // chip:   6 (2), ladder:  3, layer: 1, disk: 0, half: 0
-                                                                                                { 3, 0 },
-                                                                                                { 3, 1 },
-                                                                                                // chip:   8 (2), ladder:  4, layer: 1, disk: 0, half: 0
-                                                                                                { 4, 0 },
-                                                                                                { 4, 1 },
-                                                                                                // chip:  10 (2), ladder:  5, layer: 1, disk: 0, half: 0
-                                                                                                { 5, 0 },
-                                                                                                { 5, 1 },
-                                                                                                // chip:  12 (3), ladder:  6, layer: 0, disk: 0, half: 0
-                                                                                                { 6, 0 },
-                                                                                                { 6, 1 },
-                                                                                                { 6, 2 },
-                                                                                                // chip:  15 (3), ladder:  7, layer: 0, disk: 0, half: 0
-                                                                                                { 7, 0 },
-                                                                                                { 7, 1 },
-                                                                                                { 7, 2 },
-                                                                                                // chip:  18 (3), ladder:  8, layer: 0, disk: 0, half: 0
-                                                                                                { 8, 0 },
-                                                                                                { 8, 1 },
-                                                                                                { 8, 2 },
-                                                                                                // chip:  21 (3), ladder:  9, layer: 0, disk: 0, half: 0
-                                                                                                { 9, 0 },
-                                                                                                { 9, 1 },
-                                                                                                { 9, 2 },
-                                                                                                // chip:  24 (3), ladder: 10, layer: 0, disk: 0, half: 0
-                                                                                                { 10, 0 },
-                                                                                                { 10, 1 },
-                                                                                                { 10, 2 },
-                                                                                                // chip:  27 (3), ladder: 11, layer: 0, disk: 0, half: 0
-                                                                                                { 11, 0 },
-                                                                                                { 11, 1 },
-                                                                                                { 11, 2 },
-                                                                                                // chip:  30 (3), ladder: 12, layer: 0, disk: 0, half: 0
-                                                                                                { 12, 0 },
-                                                                                                { 12, 1 },
-                                                                                                { 12, 2 },
-                                                                                                // chip:  33 (3), ladder: 13, layer: 0, disk: 0, half: 0
-                                                                                                { 13, 0 },
-                                                                                                { 13, 1 },
-                                                                                                { 13, 2 },
-                                                                                                // chip:  36 (3), ladder: 14, layer: 0, disk: 0, half: 0
-                                                                                                { 14, 0 },
-                                                                                                { 14, 1 },
-                                                                                                { 14, 2 },
-                                                                                                // chip:  39 (3), ladder: 15, layer: 1, disk: 0, half: 0
-                                                                                                { 15, 0 },
-                                                                                                { 15, 1 },
-                                                                                                { 15, 2 },
-                                                                                                // chip:  42 (3), ladder: 16, layer: 1, disk: 0, half: 0
-                                                                                                { 16, 0 },
-                                                                                                { 16, 1 },
-                                                                                                { 16, 2 },
-                                                                                                // chip:  45 (3), ladder: 17, layer: 1, disk: 0, half: 0
-                                                                                                { 17, 0 },
-                                                                                                { 17, 1 },
-                                                                                                { 17, 2 },
-                                                                                                // chip:  48 (3), ladder: 18, layer: 1, disk: 0, half: 0
-                                                                                                { 18, 0 },
-                                                                                                { 18, 1 },
-                                                                                                { 18, 2 },
-                                                                                                // chip:  51 (3), ladder: 19, layer: 1, disk: 0, half: 0
-                                                                                                { 19, 0 },
-                                                                                                { 19, 1 },
-                                                                                                { 19, 2 },
-                                                                                                // chip:  54 (3), ladder: 20, layer: 1, disk: 0, half: 0
-                                                                                                { 20, 0 },
-                                                                                                { 20, 1 },
-                                                                                                { 20, 2 },
-                                                                                                // chip:  57 (3), ladder: 21, layer: 1, disk: 0, half: 0
-                                                                                                { 21, 0 },
-                                                                                                { 21, 1 },
-                                                                                                { 21, 2 },
-                                                                                                // chip:  60 (3), ladder: 22, layer: 1, disk: 0, half: 0
-                                                                                                { 22, 0 },
-                                                                                                { 22, 1 },
-                                                                                                { 22, 2 },
-                                                                                                // chip:  63 (3), ladder: 23, layer: 1, disk: 0, half: 0
-                                                                                                { 23, 0 },
-                                                                                                { 23, 1 },
-                                                                                                { 23, 2 },
-                                                                                                // chip:  66 (2), ladder:  0, layer: 2, disk: 1, half: 0
-                                                                                                { 24, 0 },
-                                                                                                { 24, 1 },
-                                                                                                // chip:  68 (2), ladder:  1, layer: 2, disk: 1, half: 0
-                                                                                                { 25, 0 },
-                                                                                                { 25, 1 },
-                                                                                                // chip:  70 (2), ladder:  2, layer: 2, disk: 1, half: 0
-                                                                                                { 26, 0 },
-                                                                                                { 26, 1 },
-                                                                                                // chip:  72 (2), ladder:  3, layer: 3, disk: 1, half: 0
-                                                                                                { 27, 0 },
-                                                                                                { 27, 1 },
-                                                                                                // chip:  74 (2), ladder:  4, layer: 3, disk: 1, half: 0
-                                                                                                { 28, 0 },
-                                                                                                { 28, 1 },
-                                                                                                // chip:  76 (2), ladder:  5, layer: 3, disk: 1, half: 0
-                                                                                                { 29, 0 },
-                                                                                                { 29, 1 },
-                                                                                                // chip:  78 (3), ladder:  6, layer: 2, disk: 1, half: 0
-                                                                                                { 30, 0 },
-                                                                                                { 30, 1 },
-                                                                                                { 30, 2 },
-                                                                                                // chip:  81 (3), ladder:  7, layer: 2, disk: 1, half: 0
-                                                                                                { 31, 0 },
-                                                                                                { 31, 1 },
-                                                                                                { 31, 2 },
-                                                                                                // chip:  84 (3), ladder:  8, layer: 2, disk: 1, half: 0
-                                                                                                { 32, 0 },
-                                                                                                { 32, 1 },
-                                                                                                { 32, 2 },
-                                                                                                // chip:  87 (3), ladder:  9, layer: 2, disk: 1, half: 0
-                                                                                                { 33, 0 },
-                                                                                                { 33, 1 },
-                                                                                                { 33, 2 },
-                                                                                                // chip:  90 (3), ladder: 10, layer: 2, disk: 1, half: 0
-                                                                                                { 34, 0 },
-                                                                                                { 34, 1 },
-                                                                                                { 34, 2 },
-                                                                                                // chip:  93 (3), ladder: 11, layer: 2, disk: 1, half: 0
-                                                                                                { 35, 0 },
-                                                                                                { 35, 1 },
-                                                                                                { 35, 2 },
-                                                                                                // chip:  96 (3), ladder: 12, layer: 2, disk: 1, half: 0
-                                                                                                { 36, 0 },
-                                                                                                { 36, 1 },
-                                                                                                { 36, 2 },
-                                                                                                // chip:  99 (3), ladder: 13, layer: 2, disk: 1, half: 0
-                                                                                                { 37, 0 },
-                                                                                                { 37, 1 },
-                                                                                                { 37, 2 },
-                                                                                                // chip: 102 (3), ladder: 14, layer: 2, disk: 1, half: 0
-                                                                                                { 38, 0 },
-                                                                                                { 38, 1 },
-                                                                                                { 38, 2 },
-                                                                                                // chip: 105 (3), ladder: 15, layer: 3, disk: 1, half: 0
-                                                                                                { 39, 0 },
-                                                                                                { 39, 1 },
-                                                                                                { 39, 2 },
-                                                                                                // chip: 108 (3), ladder: 16, layer: 3, disk: 1, half: 0
-                                                                                                { 40, 0 },
-                                                                                                { 40, 1 },
-                                                                                                { 40, 2 },
-                                                                                                // chip: 111 (3), ladder: 17, layer: 3, disk: 1, half: 0
-                                                                                                { 41, 0 },
-                                                                                                { 41, 1 },
-                                                                                                { 41, 2 },
-                                                                                                // chip: 114 (3), ladder: 18, layer: 3, disk: 1, half: 0
-                                                                                                { 42, 0 },
-                                                                                                { 42, 1 },
-                                                                                                { 42, 2 },
-                                                                                                // chip: 117 (3), ladder: 19, layer: 3, disk: 1, half: 0
-                                                                                                { 43, 0 },
-                                                                                                { 43, 1 },
-                                                                                                { 43, 2 },
-                                                                                                // chip: 120 (3), ladder: 20, layer: 3, disk: 1, half: 0
-                                                                                                { 44, 0 },
-                                                                                                { 44, 1 },
-                                                                                                { 44, 2 },
-                                                                                                // chip: 123 (3), ladder: 21, layer: 3, disk: 1, half: 0
-                                                                                                { 45, 0 },
-                                                                                                { 45, 1 },
-                                                                                                { 45, 2 },
-                                                                                                // chip: 126 (3), ladder: 22, layer: 3, disk: 1, half: 0
-                                                                                                { 46, 0 },
-                                                                                                { 46, 1 },
-                                                                                                { 46, 2 },
-                                                                                                // chip: 129 (3), ladder: 23, layer: 3, disk: 1, half: 0
-                                                                                                { 47, 0 },
-                                                                                                { 47, 1 },
-                                                                                                { 47, 2 },
-                                                                                                // chip: 132 (2), ladder:  0, layer: 4, disk: 2, half: 0
-                                                                                                { 48, 0 },
-                                                                                                { 48, 1 },
-                                                                                                // chip: 134 (2), ladder:  1, layer: 4, disk: 2, half: 0
-                                                                                                { 49, 0 },
-                                                                                                { 49, 1 },
-                                                                                                // chip: 136 (2), ladder:  2, layer: 5, disk: 2, half: 0
-                                                                                                { 50, 0 },
-                                                                                                { 50, 1 },
-                                                                                                // chip: 138 (2), ladder:  3, layer: 5, disk: 2, half: 0
-                                                                                                { 51, 0 },
-                                                                                                { 51, 1 },
-                                                                                                // chip: 140 (3), ladder:  4, layer: 4, disk: 2, half: 0
-                                                                                                { 52, 0 },
-                                                                                                { 52, 1 },
-                                                                                                { 52, 2 },
-                                                                                                // chip: 143 (3), ladder:  5, layer: 4, disk: 2, half: 0
-                                                                                                { 53, 0 },
-                                                                                                { 53, 1 },
-                                                                                                { 53, 2 },
-                                                                                                // chip: 146 (3), ladder:  6, layer: 4, disk: 2, half: 0
-                                                                                                { 54, 0 },
-                                                                                                { 54, 1 },
-                                                                                                { 54, 2 },
-                                                                                                // chip: 149 (3), ladder:  7, layer: 4, disk: 2, half: 0
-                                                                                                { 55, 0 },
-                                                                                                { 55, 1 },
-                                                                                                { 55, 2 },
-                                                                                                // chip: 152 (3), ladder:  8, layer: 4, disk: 2, half: 0
-                                                                                                { 56, 0 },
-                                                                                                { 56, 1 },
-                                                                                                { 56, 2 },
-                                                                                                // chip: 155 (3), ladder:  9, layer: 4, disk: 2, half: 0
-                                                                                                { 57, 0 },
-                                                                                                { 57, 1 },
-                                                                                                { 57, 2 },
-                                                                                                // chip: 158 (3), ladder: 10, layer: 4, disk: 2, half: 0
-                                                                                                { 58, 0 },
-                                                                                                { 58, 1 },
-                                                                                                { 58, 2 },
-                                                                                                // chip: 161 (3), ladder: 11, layer: 5, disk: 2, half: 0
-                                                                                                { 59, 0 },
-                                                                                                { 59, 1 },
-                                                                                                { 59, 2 },
-                                                                                                // chip: 164 (3), ladder: 12, layer: 5, disk: 2, half: 0
-                                                                                                { 60, 0 },
-                                                                                                { 60, 1 },
-                                                                                                { 60, 2 },
-                                                                                                // chip: 167 (3), ladder: 13, layer: 5, disk: 2, half: 0
-                                                                                                { 61, 0 },
-                                                                                                { 61, 1 },
-                                                                                                { 61, 2 },
-                                                                                                // chip: 170 (3), ladder: 14, layer: 5, disk: 2, half: 0
-                                                                                                { 62, 0 },
-                                                                                                { 62, 1 },
-                                                                                                { 62, 2 },
-                                                                                                // chip: 173 (3), ladder: 15, layer: 5, disk: 2, half: 0
-                                                                                                { 63, 0 },
-                                                                                                { 63, 1 },
-                                                                                                { 63, 2 },
-                                                                                                // chip: 176 (3), ladder: 16, layer: 5, disk: 2, half: 0
-                                                                                                { 64, 0 },
-                                                                                                { 64, 1 },
-                                                                                                { 64, 2 },
-                                                                                                // chip: 179 (3), ladder: 17, layer: 5, disk: 2, half: 0
-                                                                                                { 65, 0 },
-                                                                                                { 65, 1 },
-                                                                                                { 65, 2 },
-                                                                                                // chip: 182 (4), ladder: 18, layer: 4, disk: 2, half: 0
-                                                                                                { 66, 0 },
-                                                                                                { 66, 1 },
-                                                                                                { 66, 2 },
-                                                                                                { 66, 3 },
-                                                                                                // chip: 186 (4), ladder: 19, layer: 4, disk: 2, half: 0
-                                                                                                { 67, 0 },
-                                                                                                { 67, 1 },
-                                                                                                { 67, 2 },
-                                                                                                { 67, 3 },
-                                                                                                // chip: 190 (4), ladder: 20, layer: 4, disk: 2, half: 0
-                                                                                                { 68, 0 },
-                                                                                                { 68, 1 },
-                                                                                                { 68, 2 },
-                                                                                                { 68, 3 },
-                                                                                                // chip: 194 (4), ladder: 21, layer: 4, disk: 2, half: 0
-                                                                                                { 69, 0 },
-                                                                                                { 69, 1 },
-                                                                                                { 69, 2 },
-                                                                                                { 69, 3 },
-                                                                                                // chip: 198 (4), ladder: 22, layer: 5, disk: 2, half: 0
-                                                                                                { 70, 0 },
-                                                                                                { 70, 1 },
-                                                                                                { 70, 2 },
-                                                                                                { 70, 3 },
-                                                                                                // chip: 202 (4), ladder: 23, layer: 5, disk: 2, half: 0
-                                                                                                { 71, 0 },
-                                                                                                { 71, 1 },
-                                                                                                { 71, 2 },
-                                                                                                { 71, 3 },
-                                                                                                // chip: 206 (4), ladder: 24, layer: 5, disk: 2, half: 0
-                                                                                                { 72, 0 },
-                                                                                                { 72, 1 },
-                                                                                                { 72, 2 },
-                                                                                                { 72, 3 },
-                                                                                                // chip: 210 (4), ladder: 25, layer: 5, disk: 2, half: 0
-                                                                                                { 73, 0 },
-                                                                                                { 73, 1 },
-                                                                                                { 73, 2 },
-                                                                                                { 73, 3 },
-                                                                                                // chip: 214 (2), ladder:  0, layer: 6, disk: 3, half: 0
-                                                                                                { 74, 0 },
-                                                                                                { 74, 1 },
-                                                                                                // chip: 216 (2), ladder:  1, layer: 6, disk: 3, half: 0
-                                                                                                { 75, 0 },
-                                                                                                { 75, 1 },
-                                                                                                // chip: 218 (2), ladder:  2, layer: 7, disk: 3, half: 0
-                                                                                                { 76, 0 },
-                                                                                                { 76, 1 },
-                                                                                                // chip: 220 (2), ladder:  3, layer: 7, disk: 3, half: 0
-                                                                                                { 77, 0 },
-                                                                                                { 77, 1 },
-                                                                                                // chip: 222 (3), ladder:  4, layer: 6, disk: 3, half: 0
-                                                                                                { 78, 0 },
-                                                                                                { 78, 1 },
-                                                                                                { 78, 2 },
-                                                                                                // chip: 225 (3), ladder:  5, layer: 6, disk: 3, half: 0
-                                                                                                { 79, 0 },
-                                                                                                { 79, 1 },
-                                                                                                { 79, 2 },
-                                                                                                // chip: 228 (3), ladder:  6, layer: 6, disk: 3, half: 0
-                                                                                                { 80, 0 },
-                                                                                                { 80, 1 },
-                                                                                                { 80, 2 },
-                                                                                                // chip: 231 (3), ladder:  7, layer: 7, disk: 3, half: 0
-                                                                                                { 81, 0 },
-                                                                                                { 81, 1 },
-                                                                                                { 81, 2 },
-                                                                                                // chip: 234 (3), ladder:  8, layer: 7, disk: 3, half: 0
-                                                                                                { 82, 0 },
-                                                                                                { 82, 1 },
-                                                                                                { 82, 2 },
-                                                                                                // chip: 237 (3), ladder:  9, layer: 7, disk: 3, half: 0
-                                                                                                { 83, 0 },
-                                                                                                { 83, 1 },
-                                                                                                { 83, 2 },
-                                                                                                // chip: 240 (4), ladder: 10, layer: 6, disk: 3, half: 0
-                                                                                                { 84, 0 },
-                                                                                                { 84, 1 },
-                                                                                                { 84, 2 },
-                                                                                                { 84, 3 },
-                                                                                                // chip: 244 (4), ladder: 11, layer: 6, disk: 3, half: 0
-                                                                                                { 85, 0 },
-                                                                                                { 85, 1 },
-                                                                                                { 85, 2 },
-                                                                                                { 85, 3 },
-                                                                                                // chip: 248 (4), ladder: 12, layer: 6, disk: 3, half: 0
-                                                                                                { 86, 0 },
-                                                                                                { 86, 1 },
-                                                                                                { 86, 2 },
-                                                                                                { 86, 3 },
-                                                                                                // chip: 252 (4), ladder: 13, layer: 6, disk: 3, half: 0
-                                                                                                { 87, 0 },
-                                                                                                { 87, 1 },
-                                                                                                { 87, 2 },
-                                                                                                { 87, 3 },
-                                                                                                // chip: 256 (4), ladder: 14, layer: 6, disk: 3, half: 0
-                                                                                                { 88, 0 },
-                                                                                                { 88, 1 },
-                                                                                                { 88, 2 },
-                                                                                                { 88, 3 },
-                                                                                                // chip: 260 (4), ladder: 15, layer: 6, disk: 3, half: 0
-                                                                                                { 89, 0 },
-                                                                                                { 89, 1 },
-                                                                                                { 89, 2 },
-                                                                                                { 89, 3 },
-                                                                                                // chip: 264 (4), ladder: 16, layer: 6, disk: 3, half: 0
-                                                                                                { 90, 0 },
-                                                                                                { 90, 1 },
-                                                                                                { 90, 2 },
-                                                                                                { 90, 3 },
-                                                                                                // chip: 268 (4), ladder: 17, layer: 6, disk: 3, half: 0
-                                                                                                { 91, 0 },
-                                                                                                { 91, 1 },
-                                                                                                { 91, 2 },
-                                                                                                { 91, 3 },
-                                                                                                // chip: 272 (4), ladder: 18, layer: 6, disk: 3, half: 0
-                                                                                                { 92, 0 },
-                                                                                                { 92, 1 },
-                                                                                                { 92, 2 },
-                                                                                                { 92, 3 },
-                                                                                                // chip: 276 (4), ladder: 19, layer: 6, disk: 3, half: 0
-                                                                                                { 93, 0 },
-                                                                                                { 93, 1 },
-                                                                                                { 93, 2 },
-                                                                                                { 93, 3 },
-                                                                                                // chip: 280 (4), ladder: 20, layer: 6, disk: 3, half: 0
-                                                                                                { 94, 0 },
-                                                                                                { 94, 1 },
-                                                                                                { 94, 2 },
-                                                                                                { 94, 3 },
-                                                                                                // chip: 284 (4), ladder: 21, layer: 7, disk: 3, half: 0
-                                                                                                { 95, 0 },
-                                                                                                { 95, 1 },
-                                                                                                { 95, 2 },
-                                                                                                { 95, 3 },
-                                                                                                // chip: 288 (4), ladder: 22, layer: 7, disk: 3, half: 0
-                                                                                                { 96, 0 },
-                                                                                                { 96, 1 },
-                                                                                                { 96, 2 },
-                                                                                                { 96, 3 },
-                                                                                                // chip: 292 (4), ladder: 23, layer: 7, disk: 3, half: 0
-                                                                                                { 97, 0 },
-                                                                                                { 97, 1 },
-                                                                                                { 97, 2 },
-                                                                                                { 97, 3 },
-                                                                                                // chip: 296 (4), ladder: 24, layer: 7, disk: 3, half: 0
-                                                                                                { 98, 0 },
-                                                                                                { 98, 1 },
-                                                                                                { 98, 2 },
-                                                                                                { 98, 3 },
-                                                                                                // chip: 300 (4), ladder: 25, layer: 7, disk: 3, half: 0
-                                                                                                { 99, 0 },
-                                                                                                { 99, 1 },
-                                                                                                { 99, 2 },
-                                                                                                { 99, 3 },
-                                                                                                // chip: 304 (4), ladder: 26, layer: 7, disk: 3, half: 0
-                                                                                                { 100, 0 },
-                                                                                                { 100, 1 },
-                                                                                                { 100, 2 },
-                                                                                                { 100, 3 },
-                                                                                                // chip: 308 (4), ladder: 27, layer: 7, disk: 3, half: 0
-                                                                                                { 101, 0 },
-                                                                                                { 101, 1 },
-                                                                                                { 101, 2 },
-                                                                                                { 101, 3 },
-                                                                                                // chip: 312 (4), ladder: 28, layer: 7, disk: 3, half: 0
-                                                                                                { 102, 0 },
-                                                                                                { 102, 1 },
-                                                                                                { 102, 2 },
-                                                                                                { 102, 3 },
-                                                                                                // chip: 316 (4), ladder: 29, layer: 7, disk: 3, half: 0
-                                                                                                { 103, 0 },
-                                                                                                { 103, 1 },
-                                                                                                { 103, 2 },
-                                                                                                { 103, 3 },
-                                                                                                // chip: 320 (4), ladder: 30, layer: 7, disk: 3, half: 0
-                                                                                                { 104, 0 },
-                                                                                                { 104, 1 },
-                                                                                                { 104, 2 },
-                                                                                                { 104, 3 },
-                                                                                                // chip: 324 (4), ladder: 31, layer: 7, disk: 3, half: 0
-                                                                                                { 105, 0 },
-                                                                                                { 105, 1 },
-                                                                                                { 105, 2 },
-                                                                                                { 105, 3 },
-                                                                                                // chip: 328 (2), ladder:  0, layer: 8, disk: 4, half: 0
-                                                                                                { 106, 0 },
-                                                                                                { 106, 1 },
-                                                                                                // chip: 330 (2), ladder:  1, layer: 8, disk: 4, half: 0
-                                                                                                { 107, 0 },
-                                                                                                { 107, 1 },
-                                                                                                // chip: 332 (2), ladder:  2, layer: 9, disk: 4, half: 0
-                                                                                                { 108, 0 },
-                                                                                                { 108, 1 },
-                                                                                                // chip: 334 (2), ladder:  3, layer: 9, disk: 4, half: 0
-                                                                                                { 109, 0 },
-                                                                                                { 109, 1 },
-                                                                                                // chip: 336 (3), ladder:  4, layer: 8, disk: 4, half: 0
-                                                                                                { 110, 0 },
-                                                                                                { 110, 1 },
-                                                                                                { 110, 2 },
-                                                                                                // chip: 339 (3), ladder:  5, layer: 8, disk: 4, half: 0
-                                                                                                { 111, 0 },
-                                                                                                { 111, 1 },
-                                                                                                { 111, 2 },
-                                                                                                // chip: 342 (3), ladder:  6, layer: 9, disk: 4, half: 0
-                                                                                                { 112, 0 },
-                                                                                                { 112, 1 },
-                                                                                                { 112, 2 },
-                                                                                                // chip: 345 (3), ladder:  7, layer: 9, disk: 4, half: 0
-                                                                                                { 113, 0 },
-                                                                                                { 113, 1 },
-                                                                                                { 113, 2 },
-                                                                                                // chip: 348 (4), ladder:  8, layer: 8, disk: 4, half: 0
-                                                                                                { 114, 0 },
-                                                                                                { 114, 1 },
-                                                                                                { 114, 2 },
-                                                                                                { 114, 3 },
-                                                                                                // chip: 352 (4), ladder:  9, layer: 8, disk: 4, half: 0
-                                                                                                { 115, 0 },
-                                                                                                { 115, 1 },
-                                                                                                { 115, 2 },
-                                                                                                { 115, 3 },
-                                                                                                // chip: 356 (4), ladder: 10, layer: 8, disk: 4, half: 0
-                                                                                                { 116, 0 },
-                                                                                                { 116, 1 },
-                                                                                                { 116, 2 },
-                                                                                                { 116, 3 },
-                                                                                                // chip: 360 (4), ladder: 11, layer: 8, disk: 4, half: 0
-                                                                                                { 117, 0 },
-                                                                                                { 117, 1 },
-                                                                                                { 117, 2 },
-                                                                                                { 117, 3 },
-                                                                                                // chip: 364 (4), ladder: 12, layer: 8, disk: 4, half: 0
-                                                                                                { 118, 0 },
-                                                                                                { 118, 1 },
-                                                                                                { 118, 2 },
-                                                                                                { 118, 3 },
-                                                                                                // chip: 368 (4), ladder: 13, layer: 8, disk: 4, half: 0
-                                                                                                { 119, 0 },
-                                                                                                { 119, 1 },
-                                                                                                { 119, 2 },
-                                                                                                { 119, 3 },
-                                                                                                // chip: 372 (4), ladder: 14, layer: 8, disk: 4, half: 0
-                                                                                                { 120, 0 },
-                                                                                                { 120, 1 },
-                                                                                                { 120, 2 },
-                                                                                                { 120, 3 },
-                                                                                                // chip: 376 (4), ladder: 15, layer: 8, disk: 4, half: 0
-                                                                                                { 121, 0 },
-                                                                                                { 121, 1 },
-                                                                                                { 121, 2 },
-                                                                                                { 121, 3 },
-                                                                                                // chip: 380 (4), ladder: 16, layer: 8, disk: 4, half: 0
-                                                                                                { 122, 0 },
-                                                                                                { 122, 1 },
-                                                                                                { 122, 2 },
-                                                                                                { 122, 3 },
-                                                                                                // chip: 384 (4), ladder: 17, layer: 9, disk: 4, half: 0
-                                                                                                { 123, 0 },
-                                                                                                { 123, 1 },
-                                                                                                { 123, 2 },
-                                                                                                { 123, 3 },
-                                                                                                // chip: 388 (4), ladder: 18, layer: 9, disk: 4, half: 0
-                                                                                                { 124, 0 },
-                                                                                                { 124, 1 },
-                                                                                                { 124, 2 },
-                                                                                                { 124, 3 },
-                                                                                                // chip: 392 (4), ladder: 19, layer: 9, disk: 4, half: 0
-                                                                                                { 125, 0 },
-                                                                                                { 125, 1 },
-                                                                                                { 125, 2 },
-                                                                                                { 125, 3 },
-                                                                                                // chip: 396 (4), ladder: 20, layer: 9, disk: 4, half: 0
-                                                                                                { 126, 0 },
-                                                                                                { 126, 1 },
-                                                                                                { 126, 2 },
-                                                                                                { 126, 3 },
-                                                                                                // chip: 400 (4), ladder: 21, layer: 9, disk: 4, half: 0
-                                                                                                { 127, 0 },
-                                                                                                { 127, 1 },
-                                                                                                { 127, 2 },
-                                                                                                { 127, 3 },
-                                                                                                // chip: 404 (4), ladder: 22, layer: 9, disk: 4, half: 0
-                                                                                                { 128, 0 },
-                                                                                                { 128, 1 },
-                                                                                                { 128, 2 },
-                                                                                                { 128, 3 },
-                                                                                                // chip: 408 (4), ladder: 23, layer: 9, disk: 4, half: 0
-                                                                                                { 129, 0 },
-                                                                                                { 129, 1 },
-                                                                                                { 129, 2 },
-                                                                                                { 129, 3 },
-                                                                                                // chip: 412 (4), ladder: 24, layer: 9, disk: 4, half: 0
-                                                                                                { 130, 0 },
-                                                                                                { 130, 1 },
-                                                                                                { 130, 2 },
-                                                                                                { 130, 3 },
-                                                                                                // chip: 416 (4), ladder: 25, layer: 9, disk: 4, half: 0
-                                                                                                { 131, 0 },
-                                                                                                { 131, 1 },
-                                                                                                { 131, 2 },
-                                                                                                { 131, 3 },
-                                                                                                // chip: 420 (5), ladder: 26, layer: 8, disk: 4, half: 0
-                                                                                                { 132, 0 },
-                                                                                                { 132, 1 },
-                                                                                                { 132, 2 },
-                                                                                                { 132, 3 },
-                                                                                                { 132, 4 },
-                                                                                                // chip: 425 (5), ladder: 27, layer: 8, disk: 4, half: 0
-                                                                                                { 133, 0 },
-                                                                                                { 133, 1 },
-                                                                                                { 133, 2 },
-                                                                                                { 133, 3 },
-                                                                                                { 133, 4 },
-                                                                                                // chip: 430 (5), ladder: 28, layer: 8, disk: 4, half: 0
-                                                                                                { 134, 0 },
-                                                                                                { 134, 1 },
-                                                                                                { 134, 2 },
-                                                                                                { 134, 3 },
-                                                                                                { 134, 4 },
-                                                                                                // chip: 435 (5), ladder: 29, layer: 8, disk: 4, half: 0
-                                                                                                { 135, 0 },
-                                                                                                { 135, 1 },
-                                                                                                { 135, 2 },
-                                                                                                { 135, 3 },
-                                                                                                { 135, 4 },
-                                                                                                // chip: 440 (5), ladder: 30, layer: 9, disk: 4, half: 0
-                                                                                                { 136, 0 },
-                                                                                                { 136, 1 },
-                                                                                                { 136, 2 },
-                                                                                                { 136, 3 },
-                                                                                                { 136, 4 },
-                                                                                                // chip: 445 (5), ladder: 31, layer: 9, disk: 4, half: 0
-                                                                                                { 137, 0 },
-                                                                                                { 137, 1 },
-                                                                                                { 137, 2 },
-                                                                                                { 137, 3 },
-                                                                                                { 137, 4 },
-                                                                                                // chip: 450 (5), ladder: 32, layer: 9, disk: 4, half: 0
-                                                                                                { 138, 0 },
-                                                                                                { 138, 1 },
-                                                                                                { 138, 2 },
-                                                                                                { 138, 3 },
-                                                                                                { 138, 4 },
-                                                                                                // chip: 455 (5), ladder: 33, layer: 9, disk: 4, half: 0
-                                                                                                { 139, 0 },
-                                                                                                { 139, 1 },
-                                                                                                { 139, 2 },
-                                                                                                { 139, 3 },
-                                                                                                { 139, 4 },
-                                                                                                // chip: 460 (2), ladder:  0, layer: 0, disk: 0, half: 1
-                                                                                                { 140, 0 },
-                                                                                                { 140, 1 },
-                                                                                                // chip: 462 (2), ladder:  1, layer: 0, disk: 0, half: 1
-                                                                                                { 141, 0 },
-                                                                                                { 141, 1 },
-                                                                                                // chip: 464 (2), ladder:  2, layer: 0, disk: 0, half: 1
-                                                                                                { 142, 0 },
-                                                                                                { 142, 1 },
-                                                                                                // chip: 466 (2), ladder:  3, layer: 1, disk: 0, half: 1
-                                                                                                { 143, 0 },
-                                                                                                { 143, 1 },
-                                                                                                // chip: 468 (2), ladder:  4, layer: 1, disk: 0, half: 1
-                                                                                                { 144, 0 },
-                                                                                                { 144, 1 },
-                                                                                                // chip: 470 (2), ladder:  5, layer: 1, disk: 0, half: 1
-                                                                                                { 145, 0 },
-                                                                                                { 145, 1 },
-                                                                                                // chip: 472 (3), ladder:  6, layer: 0, disk: 0, half: 1
-                                                                                                { 146, 0 },
-                                                                                                { 146, 1 },
-                                                                                                { 146, 2 },
-                                                                                                // chip: 475 (3), ladder:  7, layer: 0, disk: 0, half: 1
-                                                                                                { 147, 0 },
-                                                                                                { 147, 1 },
-                                                                                                { 147, 2 },
-                                                                                                // chip: 478 (3), ladder:  8, layer: 0, disk: 0, half: 1
-                                                                                                { 148, 0 },
-                                                                                                { 148, 1 },
-                                                                                                { 148, 2 },
-                                                                                                // chip: 481 (3), ladder:  9, layer: 0, disk: 0, half: 1
-                                                                                                { 149, 0 },
-                                                                                                { 149, 1 },
-                                                                                                { 149, 2 },
-                                                                                                // chip: 484 (3), ladder: 10, layer: 0, disk: 0, half: 1
-                                                                                                { 150, 0 },
-                                                                                                { 150, 1 },
-                                                                                                { 150, 2 },
-                                                                                                // chip: 487 (3), ladder: 11, layer: 0, disk: 0, half: 1
-                                                                                                { 151, 0 },
-                                                                                                { 151, 1 },
-                                                                                                { 151, 2 },
-                                                                                                // chip: 490 (3), ladder: 12, layer: 0, disk: 0, half: 1
-                                                                                                { 152, 0 },
-                                                                                                { 152, 1 },
-                                                                                                { 152, 2 },
-                                                                                                // chip: 493 (3), ladder: 13, layer: 0, disk: 0, half: 1
-                                                                                                { 153, 0 },
-                                                                                                { 153, 1 },
-                                                                                                { 153, 2 },
-                                                                                                // chip: 496 (3), ladder: 14, layer: 0, disk: 0, half: 1
-                                                                                                { 154, 0 },
-                                                                                                { 154, 1 },
-                                                                                                { 154, 2 },
-                                                                                                // chip: 499 (3), ladder: 15, layer: 1, disk: 0, half: 1
-                                                                                                { 155, 0 },
-                                                                                                { 155, 1 },
-                                                                                                { 155, 2 },
-                                                                                                // chip: 502 (3), ladder: 16, layer: 1, disk: 0, half: 1
-                                                                                                { 156, 0 },
-                                                                                                { 156, 1 },
-                                                                                                { 156, 2 },
-                                                                                                // chip: 505 (3), ladder: 17, layer: 1, disk: 0, half: 1
-                                                                                                { 157, 0 },
-                                                                                                { 157, 1 },
-                                                                                                { 157, 2 },
-                                                                                                // chip: 508 (3), ladder: 18, layer: 1, disk: 0, half: 1
-                                                                                                { 158, 0 },
-                                                                                                { 158, 1 },
-                                                                                                { 158, 2 },
-                                                                                                // chip: 511 (3), ladder: 19, layer: 1, disk: 0, half: 1
-                                                                                                { 159, 0 },
-                                                                                                { 159, 1 },
-                                                                                                { 159, 2 },
-                                                                                                // chip: 514 (3), ladder: 20, layer: 1, disk: 0, half: 1
-                                                                                                { 160, 0 },
-                                                                                                { 160, 1 },
-                                                                                                { 160, 2 },
-                                                                                                // chip: 517 (3), ladder: 21, layer: 1, disk: 0, half: 1
-                                                                                                { 161, 0 },
-                                                                                                { 161, 1 },
-                                                                                                { 161, 2 },
-                                                                                                // chip: 520 (3), ladder: 22, layer: 1, disk: 0, half: 1
-                                                                                                { 162, 0 },
-                                                                                                { 162, 1 },
-                                                                                                { 162, 2 },
-                                                                                                // chip: 523 (3), ladder: 23, layer: 1, disk: 0, half: 1
-                                                                                                { 163, 0 },
-                                                                                                { 163, 1 },
-                                                                                                { 163, 2 },
-                                                                                                // chip: 526 (2), ladder:  0, layer: 2, disk: 1, half: 1
-                                                                                                { 164, 0 },
-                                                                                                { 164, 1 },
-                                                                                                // chip: 528 (2), ladder:  1, layer: 2, disk: 1, half: 1
-                                                                                                { 165, 0 },
-                                                                                                { 165, 1 },
-                                                                                                // chip: 530 (2), ladder:  2, layer: 2, disk: 1, half: 1
-                                                                                                { 166, 0 },
-                                                                                                { 166, 1 },
-                                                                                                // chip: 532 (2), ladder:  3, layer: 3, disk: 1, half: 1
-                                                                                                { 167, 0 },
-                                                                                                { 167, 1 },
-                                                                                                // chip: 534 (2), ladder:  4, layer: 3, disk: 1, half: 1
-                                                                                                { 168, 0 },
-                                                                                                { 168, 1 },
-                                                                                                // chip: 536 (2), ladder:  5, layer: 3, disk: 1, half: 1
-                                                                                                { 169, 0 },
-                                                                                                { 169, 1 },
-                                                                                                // chip: 538 (3), ladder:  6, layer: 2, disk: 1, half: 1
-                                                                                                { 170, 0 },
-                                                                                                { 170, 1 },
-                                                                                                { 170, 2 },
-                                                                                                // chip: 541 (3), ladder:  7, layer: 2, disk: 1, half: 1
-                                                                                                { 171, 0 },
-                                                                                                { 171, 1 },
-                                                                                                { 171, 2 },
-                                                                                                // chip: 544 (3), ladder:  8, layer: 2, disk: 1, half: 1
-                                                                                                { 172, 0 },
-                                                                                                { 172, 1 },
-                                                                                                { 172, 2 },
-                                                                                                // chip: 547 (3), ladder:  9, layer: 2, disk: 1, half: 1
-                                                                                                { 173, 0 },
-                                                                                                { 173, 1 },
-                                                                                                { 173, 2 },
-                                                                                                // chip: 550 (3), ladder: 10, layer: 2, disk: 1, half: 1
-                                                                                                { 174, 0 },
-                                                                                                { 174, 1 },
-                                                                                                { 174, 2 },
-                                                                                                // chip: 553 (3), ladder: 11, layer: 2, disk: 1, half: 1
-                                                                                                { 175, 0 },
-                                                                                                { 175, 1 },
-                                                                                                { 175, 2 },
-                                                                                                // chip: 556 (3), ladder: 12, layer: 2, disk: 1, half: 1
-                                                                                                { 176, 0 },
-                                                                                                { 176, 1 },
-                                                                                                { 176, 2 },
-                                                                                                // chip: 559 (3), ladder: 13, layer: 2, disk: 1, half: 1
-                                                                                                { 177, 0 },
-                                                                                                { 177, 1 },
-                                                                                                { 177, 2 },
-                                                                                                // chip: 562 (3), ladder: 14, layer: 2, disk: 1, half: 1
-                                                                                                { 178, 0 },
-                                                                                                { 178, 1 },
-                                                                                                { 178, 2 },
-                                                                                                // chip: 565 (3), ladder: 15, layer: 3, disk: 1, half: 1
-                                                                                                { 179, 0 },
-                                                                                                { 179, 1 },
-                                                                                                { 179, 2 },
-                                                                                                // chip: 568 (3), ladder: 16, layer: 3, disk: 1, half: 1
-                                                                                                { 180, 0 },
-                                                                                                { 180, 1 },
-                                                                                                { 180, 2 },
-                                                                                                // chip: 571 (3), ladder: 17, layer: 3, disk: 1, half: 1
-                                                                                                { 181, 0 },
-                                                                                                { 181, 1 },
-                                                                                                { 181, 2 },
-                                                                                                // chip: 574 (3), ladder: 18, layer: 3, disk: 1, half: 1
-                                                                                                { 182, 0 },
-                                                                                                { 182, 1 },
-                                                                                                { 182, 2 },
-                                                                                                // chip: 577 (3), ladder: 19, layer: 3, disk: 1, half: 1
-                                                                                                { 183, 0 },
-                                                                                                { 183, 1 },
-                                                                                                { 183, 2 },
-                                                                                                // chip: 580 (3), ladder: 20, layer: 3, disk: 1, half: 1
-                                                                                                { 184, 0 },
-                                                                                                { 184, 1 },
-                                                                                                { 184, 2 },
-                                                                                                // chip: 583 (3), ladder: 21, layer: 3, disk: 1, half: 1
-                                                                                                { 185, 0 },
-                                                                                                { 185, 1 },
-                                                                                                { 185, 2 },
-                                                                                                // chip: 586 (3), ladder: 22, layer: 3, disk: 1, half: 1
-                                                                                                { 186, 0 },
-                                                                                                { 186, 1 },
-                                                                                                { 186, 2 },
-                                                                                                // chip: 589 (3), ladder: 23, layer: 3, disk: 1, half: 1
-                                                                                                { 187, 0 },
-                                                                                                { 187, 1 },
-                                                                                                { 187, 2 },
-                                                                                                // chip: 592 (2), ladder:  0, layer: 4, disk: 2, half: 1
-                                                                                                { 188, 0 },
-                                                                                                { 188, 1 },
-                                                                                                // chip: 594 (2), ladder:  1, layer: 4, disk: 2, half: 1
-                                                                                                { 189, 0 },
-                                                                                                { 189, 1 },
-                                                                                                // chip: 596 (2), ladder:  2, layer: 5, disk: 2, half: 1
-                                                                                                { 190, 0 },
-                                                                                                { 190, 1 },
-                                                                                                // chip: 598 (2), ladder:  3, layer: 5, disk: 2, half: 1
-                                                                                                { 191, 0 },
-                                                                                                { 191, 1 },
-                                                                                                // chip: 600 (3), ladder:  4, layer: 4, disk: 2, half: 1
-                                                                                                { 192, 0 },
-                                                                                                { 192, 1 },
-                                                                                                { 192, 2 },
-                                                                                                // chip: 603 (3), ladder:  5, layer: 4, disk: 2, half: 1
-                                                                                                { 193, 0 },
-                                                                                                { 193, 1 },
-                                                                                                { 193, 2 },
-                                                                                                // chip: 606 (3), ladder:  6, layer: 4, disk: 2, half: 1
-                                                                                                { 194, 0 },
-                                                                                                { 194, 1 },
-                                                                                                { 194, 2 },
-                                                                                                // chip: 609 (3), ladder:  7, layer: 4, disk: 2, half: 1
-                                                                                                { 195, 0 },
-                                                                                                { 195, 1 },
-                                                                                                { 195, 2 },
-                                                                                                // chip: 612 (3), ladder:  8, layer: 4, disk: 2, half: 1
-                                                                                                { 196, 0 },
-                                                                                                { 196, 1 },
-                                                                                                { 196, 2 },
-                                                                                                // chip: 615 (3), ladder:  9, layer: 4, disk: 2, half: 1
-                                                                                                { 197, 0 },
-                                                                                                { 197, 1 },
-                                                                                                { 197, 2 },
-                                                                                                // chip: 618 (3), ladder: 10, layer: 4, disk: 2, half: 1
-                                                                                                { 198, 0 },
-                                                                                                { 198, 1 },
-                                                                                                { 198, 2 },
-                                                                                                // chip: 621 (3), ladder: 11, layer: 5, disk: 2, half: 1
-                                                                                                { 199, 0 },
-                                                                                                { 199, 1 },
-                                                                                                { 199, 2 },
-                                                                                                // chip: 624 (3), ladder: 12, layer: 5, disk: 2, half: 1
-                                                                                                { 200, 0 },
-                                                                                                { 200, 1 },
-                                                                                                { 200, 2 },
-                                                                                                // chip: 627 (3), ladder: 13, layer: 5, disk: 2, half: 1
-                                                                                                { 201, 0 },
-                                                                                                { 201, 1 },
-                                                                                                { 201, 2 },
-                                                                                                // chip: 630 (3), ladder: 14, layer: 5, disk: 2, half: 1
-                                                                                                { 202, 0 },
-                                                                                                { 202, 1 },
-                                                                                                { 202, 2 },
-                                                                                                // chip: 633 (3), ladder: 15, layer: 5, disk: 2, half: 1
-                                                                                                { 203, 0 },
-                                                                                                { 203, 1 },
-                                                                                                { 203, 2 },
-                                                                                                // chip: 636 (3), ladder: 16, layer: 5, disk: 2, half: 1
-                                                                                                { 204, 0 },
-                                                                                                { 204, 1 },
-                                                                                                { 204, 2 },
-                                                                                                // chip: 639 (3), ladder: 17, layer: 5, disk: 2, half: 1
-                                                                                                { 205, 0 },
-                                                                                                { 205, 1 },
-                                                                                                { 205, 2 },
-                                                                                                // chip: 642 (4), ladder: 18, layer: 4, disk: 2, half: 1
-                                                                                                { 206, 0 },
-                                                                                                { 206, 1 },
-                                                                                                { 206, 2 },
-                                                                                                { 206, 3 },
-                                                                                                // chip: 646 (4), ladder: 19, layer: 4, disk: 2, half: 1
-                                                                                                { 207, 0 },
-                                                                                                { 207, 1 },
-                                                                                                { 207, 2 },
-                                                                                                { 207, 3 },
-                                                                                                // chip: 650 (4), ladder: 20, layer: 4, disk: 2, half: 1
-                                                                                                { 208, 0 },
-                                                                                                { 208, 1 },
-                                                                                                { 208, 2 },
-                                                                                                { 208, 3 },
-                                                                                                // chip: 654 (4), ladder: 21, layer: 4, disk: 2, half: 1
-                                                                                                { 209, 0 },
-                                                                                                { 209, 1 },
-                                                                                                { 209, 2 },
-                                                                                                { 209, 3 },
-                                                                                                // chip: 658 (4), ladder: 22, layer: 5, disk: 2, half: 1
-                                                                                                { 210, 0 },
-                                                                                                { 210, 1 },
-                                                                                                { 210, 2 },
-                                                                                                { 210, 3 },
-                                                                                                // chip: 662 (4), ladder: 23, layer: 5, disk: 2, half: 1
-                                                                                                { 211, 0 },
-                                                                                                { 211, 1 },
-                                                                                                { 211, 2 },
-                                                                                                { 211, 3 },
-                                                                                                // chip: 666 (4), ladder: 24, layer: 5, disk: 2, half: 1
-                                                                                                { 212, 0 },
-                                                                                                { 212, 1 },
-                                                                                                { 212, 2 },
-                                                                                                { 212, 3 },
-                                                                                                // chip: 670 (4), ladder: 25, layer: 5, disk: 2, half: 1
-                                                                                                { 213, 0 },
-                                                                                                { 213, 1 },
-                                                                                                { 213, 2 },
-                                                                                                { 213, 3 },
-                                                                                                // chip: 674 (2), ladder:  0, layer: 6, disk: 3, half: 1
-                                                                                                { 214, 0 },
-                                                                                                { 214, 1 },
-                                                                                                // chip: 676 (2), ladder:  1, layer: 6, disk: 3, half: 1
-                                                                                                { 215, 0 },
-                                                                                                { 215, 1 },
-                                                                                                // chip: 678 (2), ladder:  2, layer: 7, disk: 3, half: 1
-                                                                                                { 216, 0 },
-                                                                                                { 216, 1 },
-                                                                                                // chip: 680 (2), ladder:  3, layer: 7, disk: 3, half: 1
-                                                                                                { 217, 0 },
-                                                                                                { 217, 1 },
-                                                                                                // chip: 682 (3), ladder:  4, layer: 6, disk: 3, half: 1
-                                                                                                { 218, 0 },
-                                                                                                { 218, 1 },
-                                                                                                { 218, 2 },
-                                                                                                // chip: 685 (3), ladder:  5, layer: 6, disk: 3, half: 1
-                                                                                                { 219, 0 },
-                                                                                                { 219, 1 },
-                                                                                                { 219, 2 },
-                                                                                                // chip: 688 (3), ladder:  6, layer: 6, disk: 3, half: 1
-                                                                                                { 220, 0 },
-                                                                                                { 220, 1 },
-                                                                                                { 220, 2 },
-                                                                                                // chip: 691 (3), ladder:  7, layer: 7, disk: 3, half: 1
-                                                                                                { 221, 0 },
-                                                                                                { 221, 1 },
-                                                                                                { 221, 2 },
-                                                                                                // chip: 694 (3), ladder:  8, layer: 7, disk: 3, half: 1
-                                                                                                { 222, 0 },
-                                                                                                { 222, 1 },
-                                                                                                { 222, 2 },
-                                                                                                // chip: 697 (3), ladder:  9, layer: 7, disk: 3, half: 1
-                                                                                                { 223, 0 },
-                                                                                                { 223, 1 },
-                                                                                                { 223, 2 },
-                                                                                                // chip: 700 (4), ladder: 10, layer: 6, disk: 3, half: 1
-                                                                                                { 224, 0 },
-                                                                                                { 224, 1 },
-                                                                                                { 224, 2 },
-                                                                                                { 224, 3 },
-                                                                                                // chip: 704 (4), ladder: 11, layer: 6, disk: 3, half: 1
-                                                                                                { 225, 0 },
-                                                                                                { 225, 1 },
-                                                                                                { 225, 2 },
-                                                                                                { 225, 3 },
-                                                                                                // chip: 708 (4), ladder: 12, layer: 6, disk: 3, half: 1
-                                                                                                { 226, 0 },
-                                                                                                { 226, 1 },
-                                                                                                { 226, 2 },
-                                                                                                { 226, 3 },
-                                                                                                // chip: 712 (4), ladder: 13, layer: 6, disk: 3, half: 1
-                                                                                                { 227, 0 },
-                                                                                                { 227, 1 },
-                                                                                                { 227, 2 },
-                                                                                                { 227, 3 },
-                                                                                                // chip: 716 (4), ladder: 14, layer: 6, disk: 3, half: 1
-                                                                                                { 228, 0 },
-                                                                                                { 228, 1 },
-                                                                                                { 228, 2 },
-                                                                                                { 228, 3 },
-                                                                                                // chip: 720 (4), ladder: 15, layer: 6, disk: 3, half: 1
-                                                                                                { 229, 0 },
-                                                                                                { 229, 1 },
-                                                                                                { 229, 2 },
-                                                                                                { 229, 3 },
-                                                                                                // chip: 724 (4), ladder: 16, layer: 6, disk: 3, half: 1
-                                                                                                { 230, 0 },
-                                                                                                { 230, 1 },
-                                                                                                { 230, 2 },
-                                                                                                { 230, 3 },
-                                                                                                // chip: 728 (4), ladder: 17, layer: 6, disk: 3, half: 1
-                                                                                                { 231, 0 },
-                                                                                                { 231, 1 },
-                                                                                                { 231, 2 },
-                                                                                                { 231, 3 },
-                                                                                                // chip: 732 (4), ladder: 18, layer: 6, disk: 3, half: 1
-                                                                                                { 232, 0 },
-                                                                                                { 232, 1 },
-                                                                                                { 232, 2 },
-                                                                                                { 232, 3 },
-                                                                                                // chip: 736 (4), ladder: 19, layer: 6, disk: 3, half: 1
-                                                                                                { 233, 0 },
-                                                                                                { 233, 1 },
-                                                                                                { 233, 2 },
-                                                                                                { 233, 3 },
-                                                                                                // chip: 740 (4), ladder: 20, layer: 6, disk: 3, half: 1
-                                                                                                { 234, 0 },
-                                                                                                { 234, 1 },
-                                                                                                { 234, 2 },
-                                                                                                { 234, 3 },
-                                                                                                // chip: 744 (4), ladder: 21, layer: 7, disk: 3, half: 1
-                                                                                                { 235, 0 },
-                                                                                                { 235, 1 },
-                                                                                                { 235, 2 },
-                                                                                                { 235, 3 },
-                                                                                                // chip: 748 (4), ladder: 22, layer: 7, disk: 3, half: 1
-                                                                                                { 236, 0 },
-                                                                                                { 236, 1 },
-                                                                                                { 236, 2 },
-                                                                                                { 236, 3 },
-                                                                                                // chip: 752 (4), ladder: 23, layer: 7, disk: 3, half: 1
-                                                                                                { 237, 0 },
-                                                                                                { 237, 1 },
-                                                                                                { 237, 2 },
-                                                                                                { 237, 3 },
-                                                                                                // chip: 756 (4), ladder: 24, layer: 7, disk: 3, half: 1
-                                                                                                { 238, 0 },
-                                                                                                { 238, 1 },
-                                                                                                { 238, 2 },
-                                                                                                { 238, 3 },
-                                                                                                // chip: 760 (4), ladder: 25, layer: 7, disk: 3, half: 1
-                                                                                                { 239, 0 },
-                                                                                                { 239, 1 },
-                                                                                                { 239, 2 },
-                                                                                                { 239, 3 },
-                                                                                                // chip: 764 (4), ladder: 26, layer: 7, disk: 3, half: 1
-                                                                                                { 240, 0 },
-                                                                                                { 240, 1 },
-                                                                                                { 240, 2 },
-                                                                                                { 240, 3 },
-                                                                                                // chip: 768 (4), ladder: 27, layer: 7, disk: 3, half: 1
-                                                                                                { 241, 0 },
-                                                                                                { 241, 1 },
-                                                                                                { 241, 2 },
-                                                                                                { 241, 3 },
-                                                                                                // chip: 772 (4), ladder: 28, layer: 7, disk: 3, half: 1
-                                                                                                { 242, 0 },
-                                                                                                { 242, 1 },
-                                                                                                { 242, 2 },
-                                                                                                { 242, 3 },
-                                                                                                // chip: 776 (4), ladder: 29, layer: 7, disk: 3, half: 1
-                                                                                                { 243, 0 },
-                                                                                                { 243, 1 },
-                                                                                                { 243, 2 },
-                                                                                                { 243, 3 },
-                                                                                                // chip: 780 (4), ladder: 30, layer: 7, disk: 3, half: 1
-                                                                                                { 244, 0 },
-                                                                                                { 244, 1 },
-                                                                                                { 244, 2 },
-                                                                                                { 244, 3 },
-                                                                                                // chip: 784 (4), ladder: 31, layer: 7, disk: 3, half: 1
-                                                                                                { 245, 0 },
-                                                                                                { 245, 1 },
-                                                                                                { 245, 2 },
-                                                                                                { 245, 3 },
-                                                                                                // chip: 788 (2), ladder:  0, layer: 8, disk: 4, half: 1
-                                                                                                { 246, 0 },
-                                                                                                { 246, 1 },
-                                                                                                // chip: 790 (2), ladder:  1, layer: 8, disk: 4, half: 1
-                                                                                                { 247, 0 },
-                                                                                                { 247, 1 },
-                                                                                                // chip: 792 (2), ladder:  2, layer: 9, disk: 4, half: 1
-                                                                                                { 248, 0 },
-                                                                                                { 248, 1 },
-                                                                                                // chip: 794 (2), ladder:  3, layer: 9, disk: 4, half: 1
-                                                                                                { 249, 0 },
-                                                                                                { 249, 1 },
-                                                                                                // chip: 796 (3), ladder:  4, layer: 8, disk: 4, half: 1
-                                                                                                { 250, 0 },
-                                                                                                { 250, 1 },
-                                                                                                { 250, 2 },
-                                                                                                // chip: 799 (3), ladder:  5, layer: 8, disk: 4, half: 1
-                                                                                                { 251, 0 },
-                                                                                                { 251, 1 },
-                                                                                                { 251, 2 },
-                                                                                                // chip: 802 (3), ladder:  6, layer: 9, disk: 4, half: 1
-                                                                                                { 252, 0 },
-                                                                                                { 252, 1 },
-                                                                                                { 252, 2 },
-                                                                                                // chip: 805 (3), ladder:  7, layer: 9, disk: 4, half: 1
-                                                                                                { 253, 0 },
-                                                                                                { 253, 1 },
-                                                                                                { 253, 2 },
-                                                                                                // chip: 808 (4), ladder:  8, layer: 8, disk: 4, half: 1
-                                                                                                { 254, 0 },
-                                                                                                { 254, 1 },
-                                                                                                { 254, 2 },
-                                                                                                { 254, 3 },
-                                                                                                // chip: 812 (4), ladder:  9, layer: 8, disk: 4, half: 1
-                                                                                                { 255, 0 },
-                                                                                                { 255, 1 },
-                                                                                                { 255, 2 },
-                                                                                                { 255, 3 },
-                                                                                                // chip: 816 (4), ladder: 10, layer: 8, disk: 4, half: 1
-                                                                                                { 256, 0 },
-                                                                                                { 256, 1 },
-                                                                                                { 256, 2 },
-                                                                                                { 256, 3 },
-                                                                                                // chip: 820 (4), ladder: 11, layer: 8, disk: 4, half: 1
-                                                                                                { 257, 0 },
-                                                                                                { 257, 1 },
-                                                                                                { 257, 2 },
-                                                                                                { 257, 3 },
-                                                                                                // chip: 824 (4), ladder: 12, layer: 8, disk: 4, half: 1
-                                                                                                { 258, 0 },
-                                                                                                { 258, 1 },
-                                                                                                { 258, 2 },
-                                                                                                { 258, 3 },
-                                                                                                // chip: 828 (4), ladder: 13, layer: 8, disk: 4, half: 1
-                                                                                                { 259, 0 },
-                                                                                                { 259, 1 },
-                                                                                                { 259, 2 },
-                                                                                                { 259, 3 },
-                                                                                                // chip: 832 (4), ladder: 14, layer: 8, disk: 4, half: 1
-                                                                                                { 260, 0 },
-                                                                                                { 260, 1 },
-                                                                                                { 260, 2 },
-                                                                                                { 260, 3 },
-                                                                                                // chip: 836 (4), ladder: 15, layer: 8, disk: 4, half: 1
-                                                                                                { 261, 0 },
-                                                                                                { 261, 1 },
-                                                                                                { 261, 2 },
-                                                                                                { 261, 3 },
-                                                                                                // chip: 840 (4), ladder: 16, layer: 8, disk: 4, half: 1
-                                                                                                { 262, 0 },
-                                                                                                { 262, 1 },
-                                                                                                { 262, 2 },
-                                                                                                { 262, 3 },
-                                                                                                // chip: 844 (4), ladder: 17, layer: 9, disk: 4, half: 1
-                                                                                                { 263, 0 },
-                                                                                                { 263, 1 },
-                                                                                                { 263, 2 },
-                                                                                                { 263, 3 },
-                                                                                                // chip: 848 (4), ladder: 18, layer: 9, disk: 4, half: 1
-                                                                                                { 264, 0 },
-                                                                                                { 264, 1 },
-                                                                                                { 264, 2 },
-                                                                                                { 264, 3 },
-                                                                                                // chip: 852 (4), ladder: 19, layer: 9, disk: 4, half: 1
-                                                                                                { 265, 0 },
-                                                                                                { 265, 1 },
-                                                                                                { 265, 2 },
-                                                                                                { 265, 3 },
-                                                                                                // chip: 856 (4), ladder: 20, layer: 9, disk: 4, half: 1
-                                                                                                { 266, 0 },
-                                                                                                { 266, 1 },
-                                                                                                { 266, 2 },
-                                                                                                { 266, 3 },
-                                                                                                // chip: 860 (4), ladder: 21, layer: 9, disk: 4, half: 1
-                                                                                                { 267, 0 },
-                                                                                                { 267, 1 },
-                                                                                                { 267, 2 },
-                                                                                                { 267, 3 },
-                                                                                                // chip: 864 (4), ladder: 22, layer: 9, disk: 4, half: 1
-                                                                                                { 268, 0 },
-                                                                                                { 268, 1 },
-                                                                                                { 268, 2 },
-                                                                                                { 268, 3 },
-                                                                                                // chip: 868 (4), ladder: 23, layer: 9, disk: 4, half: 1
-                                                                                                { 269, 0 },
-                                                                                                { 269, 1 },
-                                                                                                { 269, 2 },
-                                                                                                { 269, 3 },
-                                                                                                // chip: 872 (4), ladder: 24, layer: 9, disk: 4, half: 1
-                                                                                                { 270, 0 },
-                                                                                                { 270, 1 },
-                                                                                                { 270, 2 },
-                                                                                                { 270, 3 },
-                                                                                                // chip: 876 (4), ladder: 25, layer: 9, disk: 4, half: 1
-                                                                                                { 271, 0 },
-                                                                                                { 271, 1 },
-                                                                                                { 271, 2 },
-                                                                                                { 271, 3 },
-                                                                                                // chip: 880 (5), ladder: 26, layer: 8, disk: 4, half: 1
-                                                                                                { 272, 0 },
-                                                                                                { 272, 1 },
-                                                                                                { 272, 2 },
-                                                                                                { 272, 3 },
-                                                                                                { 272, 4 },
-                                                                                                // chip: 885 (5), ladder: 27, layer: 8, disk: 4, half: 1
-                                                                                                { 273, 0 },
-                                                                                                { 273, 1 },
-                                                                                                { 273, 2 },
-                                                                                                { 273, 3 },
-                                                                                                { 273, 4 },
-                                                                                                // chip: 890 (5), ladder: 28, layer: 8, disk: 4, half: 1
-                                                                                                { 274, 0 },
-                                                                                                { 274, 1 },
-                                                                                                { 274, 2 },
-                                                                                                { 274, 3 },
-                                                                                                { 274, 4 },
-                                                                                                // chip: 895 (5), ladder: 29, layer: 8, disk: 4, half: 1
-                                                                                                { 275, 0 },
-                                                                                                { 275, 1 },
-                                                                                                { 275, 2 },
-                                                                                                { 275, 3 },
-                                                                                                { 275, 4 },
-                                                                                                // chip: 900 (5), ladder: 30, layer: 9, disk: 4, half: 1
-                                                                                                { 276, 0 },
-                                                                                                { 276, 1 },
-                                                                                                { 276, 2 },
-                                                                                                { 276, 3 },
-                                                                                                { 276, 4 },
-                                                                                                // chip: 905 (5), ladder: 31, layer: 9, disk: 4, half: 1
-                                                                                                { 277, 0 },
-                                                                                                { 277, 1 },
-                                                                                                { 277, 2 },
-                                                                                                { 277, 3 },
-                                                                                                { 277, 4 },
-                                                                                                // chip: 910 (5), ladder: 32, layer: 9, disk: 4, half: 1
-                                                                                                { 278, 0 },
-                                                                                                { 278, 1 },
-                                                                                                { 278, 2 },
-                                                                                                { 278, 3 },
-                                                                                                { 278, 4 },
-                                                                                                // chip: 915 (5), ladder: 33, layer: 9, disk: 4, half: 1
-                                                                                                { 279, 0 },
-                                                                                                { 279, 1 },
-                                                                                                { 279, 2 },
-                                                                                                { 279, 3 },
-                                                                                                { 279, 4 }
+const std::array<MFTChipMappingData, ChipMappingMFT::NChips> ChipMappingMFT::ChipMappingData{ {
+
+  // { module, chipOnModule, cable, chipOnRU }
+
+  // chip:   0 (2), ladder:  0 ( 0), layer: 0, disk: 0, half: 0, zone: 0
+  { 0, 0, 5, 0 },
+  { 0, 1, 6, 1 },
+  // chip:   2 (2), ladder:  1 (10), layer: 0, disk: 0, half: 0, zone: 3
+  { 1, 0, 0, 0 },
+  { 1, 1, 1, 1 },
+  // chip:   4 (2), ladder:  2 (11), layer: 0, disk: 0, half: 0, zone: 3
+  { 2, 0, 17, 2 },
+  { 2, 1, 16, 3 },
+  // chip:   6 (2), ladder:  3 (12), layer: 1, disk: 0, half: 0, zone: 3
+  { 3, 0, 17, 2 },
+  { 3, 1, 16, 3 },
+  // chip:   8 (2), ladder:  4 (13), layer: 1, disk: 0, half: 0, zone: 3
+  { 4, 0, 0, 0 },
+  { 4, 1, 1, 1 },
+  // chip:  10 (2), ladder:  5 (23), layer: 1, disk: 0, half: 0, zone: 0
+  { 5, 0, 5, 0 },
+  { 5, 1, 6, 1 },
+  // chip:  12 (3), ladder:  6 ( 1), layer: 0, disk: 0, half: 0, zone: 0
+  { 6, 0, 0, 2 },
+  { 6, 1, 1, 3 },
+  { 6, 2, 2, 4 },
+  // chip:  15 (3), ladder:  7 ( 2), layer: 0, disk: 0, half: 0, zone: 0
+  { 7, 0, 17, 5 },
+  { 7, 1, 16, 6 },
+  { 7, 2, 15, 7 },
+  // chip:  18 (3), ladder:  8 ( 3), layer: 0, disk: 0, half: 0, zone: 1
+  { 8, 0, 5, 0 },
+  { 8, 1, 6, 1 },
+  { 8, 2, 7, 2 },
+  // chip:  21 (3), ladder:  9 ( 4), layer: 0, disk: 0, half: 0, zone: 1
+  { 9, 0, 0, 3 },
+  { 9, 1, 1, 4 },
+  { 9, 2, 2, 5 },
+  // chip:  24 (3), ladder: 10 ( 5), layer: 0, disk: 0, half: 0, zone: 1
+  { 10, 0, 17, 6 },
+  { 10, 1, 16, 7 },
+  { 10, 2, 15, 8 },
+  // chip:  27 (3), ladder: 11 ( 6), layer: 0, disk: 0, half: 0, zone: 2
+  { 11, 0, 5, 0 },
+  { 11, 1, 6, 1 },
+  { 11, 2, 7, 2 },
+  // chip:  30 (3), ladder: 12 ( 7), layer: 0, disk: 0, half: 0, zone: 2
+  { 12, 0, 0, 3 },
+  { 12, 1, 1, 4 },
+  { 12, 2, 2, 5 },
+  // chip:  33 (3), ladder: 13 ( 8), layer: 0, disk: 0, half: 0, zone: 2
+  { 13, 0, 17, 6 },
+  { 13, 1, 16, 7 },
+  { 13, 2, 15, 8 },
+  // chip:  36 (3), ladder: 14 ( 9), layer: 0, disk: 0, half: 0, zone: 3
+  { 14, 0, 5, 4 },
+  { 14, 1, 6, 5 },
+  { 14, 2, 7, 6 },
+  // chip:  39 (3), ladder: 15 (14), layer: 1, disk: 0, half: 0, zone: 3
+  { 15, 0, 5, 4 },
+  { 15, 1, 6, 5 },
+  { 15, 2, 7, 6 },
+  // chip:  42 (3), ladder: 16 (15), layer: 1, disk: 0, half: 0, zone: 2
+  { 16, 0, 17, 6 },
+  { 16, 1, 16, 7 },
+  { 16, 2, 15, 8 },
+  // chip:  45 (3), ladder: 17 (16), layer: 1, disk: 0, half: 0, zone: 2
+  { 17, 0, 0, 3 },
+  { 17, 1, 1, 4 },
+  { 17, 2, 2, 5 },
+  // chip:  48 (3), ladder: 18 (17), layer: 1, disk: 0, half: 0, zone: 2
+  { 18, 0, 5, 0 },
+  { 18, 1, 6, 1 },
+  { 18, 2, 7, 2 },
+  // chip:  51 (3), ladder: 19 (18), layer: 1, disk: 0, half: 0, zone: 1
+  { 19, 0, 17, 6 },
+  { 19, 1, 16, 7 },
+  { 19, 2, 15, 8 },
+  // chip:  54 (3), ladder: 20 (19), layer: 1, disk: 0, half: 0, zone: 1
+  { 20, 0, 0, 3 },
+  { 20, 1, 1, 4 },
+  { 20, 2, 2, 5 },
+  // chip:  57 (3), ladder: 21 (20), layer: 1, disk: 0, half: 0, zone: 1
+  { 21, 0, 5, 0 },
+  { 21, 1, 6, 1 },
+  { 21, 2, 7, 2 },
+  // chip:  60 (3), ladder: 22 (21), layer: 1, disk: 0, half: 0, zone: 0
+  { 22, 0, 17, 5 },
+  { 22, 1, 16, 6 },
+  { 22, 2, 15, 7 },
+  // chip:  63 (3), ladder: 23 (22), layer: 1, disk: 0, half: 0, zone: 0
+  { 23, 0, 0, 2 },
+  { 23, 1, 1, 3 },
+  { 23, 2, 2, 4 },
+  // chip:  66 (2), ladder:  0 ( 0), layer: 2, disk: 1, half: 0, zone: 0
+  { 24, 0, 5, 0 },
+  { 24, 1, 6, 1 },
+  // chip:  68 (2), ladder:  1 (10), layer: 2, disk: 1, half: 0, zone: 3
+  { 25, 0, 0, 0 },
+  { 25, 1, 1, 1 },
+  // chip:  70 (2), ladder:  2 (11), layer: 2, disk: 1, half: 0, zone: 3
+  { 26, 0, 17, 2 },
+  { 26, 1, 16, 3 },
+  // chip:  72 (2), ladder:  3 (12), layer: 3, disk: 1, half: 0, zone: 3
+  { 27, 0, 17, 2 },
+  { 27, 1, 16, 3 },
+  // chip:  74 (2), ladder:  4 (13), layer: 3, disk: 1, half: 0, zone: 3
+  { 28, 0, 0, 0 },
+  { 28, 1, 1, 1 },
+  // chip:  76 (2), ladder:  5 (23), layer: 3, disk: 1, half: 0, zone: 0
+  { 29, 0, 5, 0 },
+  { 29, 1, 6, 1 },
+  // chip:  78 (3), ladder:  6 ( 1), layer: 2, disk: 1, half: 0, zone: 0
+  { 30, 0, 0, 2 },
+  { 30, 1, 1, 3 },
+  { 30, 2, 2, 4 },
+  // chip:  81 (3), ladder:  7 ( 2), layer: 2, disk: 1, half: 0, zone: 0
+  { 31, 0, 17, 5 },
+  { 31, 1, 16, 6 },
+  { 31, 2, 15, 7 },
+  // chip:  84 (3), ladder:  8 ( 3), layer: 2, disk: 1, half: 0, zone: 1
+  { 32, 0, 5, 0 },
+  { 32, 1, 6, 1 },
+  { 32, 2, 7, 2 },
+  // chip:  87 (3), ladder:  9 ( 4), layer: 2, disk: 1, half: 0, zone: 1
+  { 33, 0, 0, 3 },
+  { 33, 1, 1, 4 },
+  { 33, 2, 2, 5 },
+  // chip:  90 (3), ladder: 10 ( 5), layer: 2, disk: 1, half: 0, zone: 1
+  { 34, 0, 17, 6 },
+  { 34, 1, 16, 7 },
+  { 34, 2, 15, 8 },
+  // chip:  93 (3), ladder: 11 ( 6), layer: 2, disk: 1, half: 0, zone: 2
+  { 35, 0, 5, 0 },
+  { 35, 1, 6, 1 },
+  { 35, 2, 7, 2 },
+  // chip:  96 (3), ladder: 12 ( 7), layer: 2, disk: 1, half: 0, zone: 2
+  { 36, 0, 0, 3 },
+  { 36, 1, 1, 4 },
+  { 36, 2, 2, 5 },
+  // chip:  99 (3), ladder: 13 ( 8), layer: 2, disk: 1, half: 0, zone: 2
+  { 37, 0, 17, 6 },
+  { 37, 1, 16, 7 },
+  { 37, 2, 15, 8 },
+  // chip: 102 (3), ladder: 14 ( 9), layer: 2, disk: 1, half: 0, zone: 3
+  { 38, 0, 5, 4 },
+  { 38, 1, 6, 5 },
+  { 38, 2, 7, 6 },
+  // chip: 105 (3), ladder: 15 (14), layer: 3, disk: 1, half: 0, zone: 3
+  { 39, 0, 5, 4 },
+  { 39, 1, 6, 5 },
+  { 39, 2, 7, 6 },
+  // chip: 108 (3), ladder: 16 (15), layer: 3, disk: 1, half: 0, zone: 2
+  { 40, 0, 17, 6 },
+  { 40, 1, 16, 7 },
+  { 40, 2, 15, 8 },
+  // chip: 111 (3), ladder: 17 (16), layer: 3, disk: 1, half: 0, zone: 2
+  { 41, 0, 0, 3 },
+  { 41, 1, 1, 4 },
+  { 41, 2, 2, 5 },
+  // chip: 114 (3), ladder: 18 (17), layer: 3, disk: 1, half: 0, zone: 2
+  { 42, 0, 5, 0 },
+  { 42, 1, 6, 1 },
+  { 42, 2, 7, 2 },
+  // chip: 117 (3), ladder: 19 (18), layer: 3, disk: 1, half: 0, zone: 1
+  { 43, 0, 17, 6 },
+  { 43, 1, 16, 7 },
+  { 43, 2, 15, 8 },
+  // chip: 120 (3), ladder: 20 (19), layer: 3, disk: 1, half: 0, zone: 1
+  { 44, 0, 0, 3 },
+  { 44, 1, 1, 4 },
+  { 44, 2, 2, 5 },
+  // chip: 123 (3), ladder: 21 (20), layer: 3, disk: 1, half: 0, zone: 1
+  { 45, 0, 5, 0 },
+  { 45, 1, 6, 1 },
+  { 45, 2, 7, 2 },
+  // chip: 126 (3), ladder: 22 (21), layer: 3, disk: 1, half: 0, zone: 0
+  { 46, 0, 17, 5 },
+  { 46, 1, 16, 6 },
+  { 46, 2, 15, 7 },
+  // chip: 129 (3), ladder: 23 (22), layer: 3, disk: 1, half: 0, zone: 0
+  { 47, 0, 0, 2 },
+  { 47, 1, 1, 3 },
+  { 47, 2, 2, 4 },
+  // chip: 132 (2), ladder:  0 ( 0), layer: 4, disk: 2, half: 0, zone: 0
+  { 48, 0, 5, 0 },
+  { 48, 1, 6, 1 },
+  // chip: 134 (2), ladder:  1 (12), layer: 4, disk: 2, half: 0, zone: 3
+  { 49, 0, 22, 0 },
+  { 49, 1, 21, 1 },
+  // chip: 136 (2), ladder:  2 (13), layer: 5, disk: 2, half: 0, zone: 3
+  { 50, 0, 22, 0 },
+  { 50, 1, 21, 1 },
+  // chip: 138 (2), ladder:  3 (25), layer: 5, disk: 2, half: 0, zone: 0
+  { 51, 0, 5, 0 },
+  { 51, 1, 6, 1 },
+  // chip: 140 (3), ladder:  4 ( 1), layer: 4, disk: 2, half: 0, zone: 0
+  { 52, 0, 0, 2 },
+  { 52, 1, 1, 3 },
+  { 52, 2, 2, 4 },
+  // chip: 143 (3), ladder:  5 ( 2), layer: 4, disk: 2, half: 0, zone: 0
+  { 53, 0, 17, 5 },
+  { 53, 1, 16, 6 },
+  { 53, 2, 15, 7 },
+  // chip: 146 (3), ladder:  6 ( 5), layer: 4, disk: 2, half: 0, zone: 1
+  { 54, 0, 17, 0 },
+  { 54, 1, 16, 1 },
+  { 54, 2, 15, 2 },
+  // chip: 149 (3), ladder:  7 ( 6), layer: 4, disk: 2, half: 0, zone: 2
+  { 55, 0, 5, 0 },
+  { 55, 1, 6, 1 },
+  { 55, 2, 7, 2 },
+  // chip: 152 (3), ladder:  8 ( 7), layer: 4, disk: 2, half: 0, zone: 2
+  { 56, 0, 0, 3 },
+  { 56, 1, 1, 4 },
+  { 56, 2, 2, 5 },
+  // chip: 155 (3), ladder:  9 (10), layer: 4, disk: 2, half: 0, zone: 3
+  { 57, 0, 0, 2 },
+  { 57, 1, 1, 3 },
+  { 57, 2, 2, 4 },
+  // chip: 158 (3), ladder: 10 (11), layer: 4, disk: 2, half: 0, zone: 3
+  { 58, 0, 17, 5 },
+  { 58, 1, 16, 6 },
+  { 58, 2, 15, 7 },
+  // chip: 161 (3), ladder: 11 (14), layer: 5, disk: 2, half: 0, zone: 3
+  { 59, 0, 17, 5 },
+  { 59, 1, 16, 6 },
+  { 59, 2, 15, 7 },
+  // chip: 164 (3), ladder: 12 (15), layer: 5, disk: 2, half: 0, zone: 3
+  { 60, 0, 0, 2 },
+  { 60, 1, 1, 3 },
+  { 60, 2, 2, 4 },
+  // chip: 167 (3), ladder: 13 (18), layer: 5, disk: 2, half: 0, zone: 2
+  { 61, 0, 0, 3 },
+  { 61, 1, 1, 4 },
+  { 61, 2, 2, 5 },
+  // chip: 170 (3), ladder: 14 (19), layer: 5, disk: 2, half: 0, zone: 2
+  { 62, 0, 5, 0 },
+  { 62, 1, 6, 1 },
+  { 62, 2, 7, 2 },
+  // chip: 173 (3), ladder: 15 (20), layer: 5, disk: 2, half: 0, zone: 1
+  { 63, 0, 17, 0 },
+  { 63, 1, 16, 1 },
+  { 63, 2, 15, 2 },
+  // chip: 176 (3), ladder: 16 (23), layer: 5, disk: 2, half: 0, zone: 0
+  { 64, 0, 17, 5 },
+  { 64, 1, 16, 6 },
+  { 64, 2, 15, 7 },
+  // chip: 179 (3), ladder: 17 (24), layer: 5, disk: 2, half: 0, zone: 0
+  { 65, 0, 0, 2 },
+  { 65, 1, 1, 3 },
+  { 65, 2, 2, 4 },
+  // chip: 182 (4), ladder: 18 ( 3), layer: 4, disk: 2, half: 0, zone: 1
+  { 66, 0, 5, 3 },
+  { 66, 1, 6, 4 },
+  { 66, 2, 7, 5 },
+  { 66, 3, 24, 6 },
+  // chip: 186 (4), ladder: 19 ( 4), layer: 4, disk: 2, half: 0, zone: 1
+  { 67, 0, 0, 7 },
+  { 67, 1, 1, 8 },
+  { 67, 2, 2, 9 },
+  { 67, 3, 3, 10 },
+  // chip: 190 (4), ladder: 20 ( 8), layer: 4, disk: 2, half: 0, zone: 2
+  { 68, 0, 17, 6 },
+  { 68, 1, 16, 7 },
+  { 68, 2, 15, 8 },
+  { 68, 3, 14, 9 },
+  // chip: 194 (4), ladder: 21 ( 9), layer: 4, disk: 2, half: 0, zone: 3
+  { 69, 0, 5, 8 },
+  { 69, 1, 6, 9 },
+  { 69, 2, 7, 10 },
+  { 69, 3, 24, 11 },
+  // chip: 198 (4), ladder: 22 (16), layer: 5, disk: 2, half: 0, zone: 3
+  { 70, 0, 5, 8 },
+  { 70, 1, 6, 9 },
+  { 70, 2, 7, 10 },
+  { 70, 3, 24, 11 },
+  // chip: 202 (4), ladder: 23 (17), layer: 5, disk: 2, half: 0, zone: 2
+  { 71, 0, 17, 6 },
+  { 71, 1, 16, 7 },
+  { 71, 2, 15, 8 },
+  { 71, 3, 14, 9 },
+  // chip: 206 (4), ladder: 24 (21), layer: 5, disk: 2, half: 0, zone: 1
+  { 72, 0, 0, 7 },
+  { 72, 1, 1, 8 },
+  { 72, 2, 2, 9 },
+  { 72, 3, 3, 10 },
+  // chip: 210 (4), ladder: 25 (22), layer: 5, disk: 2, half: 0, zone: 1
+  { 73, 0, 5, 3 },
+  { 73, 1, 6, 4 },
+  { 73, 2, 7, 5 },
+  { 73, 3, 24, 6 },
+  // chip: 214 (3), ladder:  0 ( 0), layer: 6, disk: 3, half: 0, zone: 0
+  { 74, 0, 5, 0 },
+  { 74, 1, 6, 1 },
+  { 74, 2, 7, 2 },
+  // chip: 217 (3), ladder:  1 ( 1), layer: 6, disk: 3, half: 0, zone: 0
+  { 75, 0, 0, 3 },
+  { 75, 1, 1, 4 },
+  { 75, 2, 2, 5 },
+  // chip: 220 (3), ladder:  2 (13), layer: 6, disk: 3, half: 0, zone: 3
+  { 76, 0, 0, 0 },
+  { 76, 1, 1, 1 },
+  { 76, 2, 2, 2 },
+  // chip: 223 (3), ladder:  3 (14), layer: 6, disk: 3, half: 0, zone: 3
+  { 77, 0, 17, 3 },
+  { 77, 1, 16, 4 },
+  { 77, 2, 15, 5 },
+  // chip: 226 (3), ladder:  4 (15), layer: 6, disk: 3, half: 0, zone: 3
+  { 78, 0, 22, 6 },
+  { 78, 1, 21, 7 },
+  { 78, 2, 20, 8 },
+  // chip: 229 (3), ladder:  5 (16), layer: 7, disk: 3, half: 0, zone: 3
+  { 79, 0, 22, 6 },
+  { 79, 1, 21, 7 },
+  { 79, 2, 20, 8 },
+  // chip: 232 (3), ladder:  6 (17), layer: 7, disk: 3, half: 0, zone: 3
+  { 80, 0, 17, 3 },
+  { 80, 1, 16, 4 },
+  { 80, 2, 15, 5 },
+  // chip: 235 (3), ladder:  7 (18), layer: 7, disk: 3, half: 0, zone: 3
+  { 81, 0, 0, 0 },
+  { 81, 1, 1, 1 },
+  { 81, 2, 2, 2 },
+  // chip: 238 (3), ladder:  8 (30), layer: 7, disk: 3, half: 0, zone: 0
+  { 82, 0, 0, 3 },
+  { 82, 1, 1, 4 },
+  { 82, 2, 2, 5 },
+  // chip: 241 (3), ladder:  9 (31), layer: 7, disk: 3, half: 0, zone: 0
+  { 83, 0, 5, 0 },
+  { 83, 1, 6, 1 },
+  { 83, 2, 7, 2 },
+  // chip: 244 (4), ladder: 10 ( 2), layer: 6, disk: 3, half: 0, zone: 0
+  { 84, 0, 17, 6 },
+  { 84, 1, 16, 7 },
+  { 84, 2, 15, 8 },
+  { 84, 3, 14, 9 },
+  // chip: 248 (4), ladder: 11 ( 3), layer: 6, disk: 3, half: 0, zone: 0
+  { 85, 0, 22, 10 },
+  { 85, 1, 21, 11 },
+  { 85, 2, 20, 12 },
+  { 85, 3, 19, 13 },
+  // chip: 252 (4), ladder: 12 ( 4), layer: 6, disk: 3, half: 0, zone: 1
+  { 86, 0, 5, 0 },
+  { 86, 1, 6, 1 },
+  { 86, 2, 7, 2 },
+  { 86, 3, 24, 3 },
+  // chip: 256 (4), ladder: 13 ( 5), layer: 6, disk: 3, half: 0, zone: 1
+  { 87, 0, 0, 4 },
+  { 87, 1, 1, 5 },
+  { 87, 2, 2, 6 },
+  { 87, 3, 3, 7 },
+  // chip: 260 (4), ladder: 14 ( 6), layer: 6, disk: 3, half: 0, zone: 1
+  { 88, 0, 17, 8 },
+  { 88, 1, 16, 9 },
+  { 88, 2, 15, 10 },
+  { 88, 3, 14, 11 },
+  // chip: 264 (4), ladder: 15 ( 7), layer: 6, disk: 3, half: 0, zone: 1
+  { 89, 0, 22, 12 },
+  { 89, 1, 21, 13 },
+  { 89, 2, 20, 14 },
+  { 89, 3, 19, 15 },
+  // chip: 268 (4), ladder: 16 ( 8), layer: 6, disk: 3, half: 0, zone: 2
+  { 90, 0, 5, 0 },
+  { 90, 1, 6, 1 },
+  { 90, 2, 7, 2 },
+  { 90, 3, 24, 3 },
+  // chip: 272 (4), ladder: 17 ( 9), layer: 6, disk: 3, half: 0, zone: 2
+  { 91, 0, 0, 4 },
+  { 91, 1, 1, 5 },
+  { 91, 2, 2, 6 },
+  { 91, 3, 3, 7 },
+  // chip: 276 (4), ladder: 18 (10), layer: 6, disk: 3, half: 0, zone: 2
+  { 92, 0, 17, 8 },
+  { 92, 1, 16, 9 },
+  { 92, 2, 15, 10 },
+  { 92, 3, 14, 11 },
+  // chip: 280 (4), ladder: 19 (11), layer: 6, disk: 3, half: 0, zone: 2
+  { 93, 0, 22, 12 },
+  { 93, 1, 21, 13 },
+  { 93, 2, 20, 14 },
+  { 93, 3, 19, 15 },
+  // chip: 284 (4), ladder: 20 (12), layer: 6, disk: 3, half: 0, zone: 3
+  { 94, 0, 5, 9 },
+  { 94, 1, 6, 10 },
+  { 94, 2, 7, 11 },
+  { 94, 3, 24, 12 },
+  // chip: 288 (4), ladder: 21 (19), layer: 7, disk: 3, half: 0, zone: 3
+  { 95, 0, 5, 9 },
+  { 95, 1, 6, 10 },
+  { 95, 2, 7, 11 },
+  { 95, 3, 24, 12 },
+  // chip: 292 (4), ladder: 22 (20), layer: 7, disk: 3, half: 0, zone: 2
+  { 96, 0, 22, 12 },
+  { 96, 1, 21, 13 },
+  { 96, 2, 20, 14 },
+  { 96, 3, 19, 15 },
+  // chip: 296 (4), ladder: 23 (21), layer: 7, disk: 3, half: 0, zone: 2
+  { 97, 0, 17, 8 },
+  { 97, 1, 16, 9 },
+  { 97, 2, 15, 10 },
+  { 97, 3, 14, 11 },
+  // chip: 300 (4), ladder: 24 (22), layer: 7, disk: 3, half: 0, zone: 2
+  { 98, 0, 0, 4 },
+  { 98, 1, 1, 5 },
+  { 98, 2, 2, 6 },
+  { 98, 3, 3, 7 },
+  // chip: 304 (4), ladder: 25 (23), layer: 7, disk: 3, half: 0, zone: 2
+  { 99, 0, 5, 0 },
+  { 99, 1, 6, 1 },
+  { 99, 2, 7, 2 },
+  { 99, 3, 24, 3 },
+  // chip: 308 (4), ladder: 26 (24), layer: 7, disk: 3, half: 0, zone: 1
+  { 100, 0, 22, 12 },
+  { 100, 1, 21, 13 },
+  { 100, 2, 20, 14 },
+  { 100, 3, 19, 15 },
+  // chip: 312 (4), ladder: 27 (25), layer: 7, disk: 3, half: 0, zone: 1
+  { 101, 0, 17, 8 },
+  { 101, 1, 16, 9 },
+  { 101, 2, 15, 10 },
+  { 101, 3, 14, 11 },
+  // chip: 316 (4), ladder: 28 (26), layer: 7, disk: 3, half: 0, zone: 1
+  { 102, 0, 0, 4 },
+  { 102, 1, 1, 5 },
+  { 102, 2, 2, 6 },
+  { 102, 3, 3, 7 },
+  // chip: 320 (4), ladder: 29 (27), layer: 7, disk: 3, half: 0, zone: 1
+  { 103, 0, 5, 0 },
+  { 103, 1, 6, 1 },
+  { 103, 2, 7, 2 },
+  { 103, 3, 24, 3 },
+  // chip: 324 (4), ladder: 30 (28), layer: 7, disk: 3, half: 0, zone: 0
+  { 104, 0, 22, 10 },
+  { 104, 1, 21, 11 },
+  { 104, 2, 20, 12 },
+  { 104, 3, 19, 13 },
+  // chip: 328 (4), ladder: 31 (29), layer: 7, disk: 3, half: 0, zone: 0
+  { 105, 0, 17, 6 },
+  { 105, 1, 16, 7 },
+  { 105, 2, 15, 8 },
+  { 105, 3, 14, 9 },
+  // chip: 332 (3), ladder:  0 ( 0), layer: 8, disk: 4, half: 0, zone: 0
+  { 106, 0, 5, 0 },
+  { 106, 1, 6, 1 },
+  { 106, 2, 7, 2 },
+  // chip: 335 (3), ladder:  1 ( 1), layer: 8, disk: 4, half: 0, zone: 0
+  { 107, 0, 0, 3 },
+  { 107, 1, 1, 4 },
+  { 107, 2, 2, 5 },
+  // chip: 338 (3), ladder:  2 (15), layer: 8, disk: 4, half: 0, zone: 3
+  { 108, 0, 17, 3 },
+  { 108, 1, 16, 4 },
+  { 108, 2, 15, 5 },
+  // chip: 341 (3), ladder:  3 (16), layer: 8, disk: 4, half: 0, zone: 3
+  { 109, 0, 22, 0 },
+  { 109, 1, 21, 1 },
+  { 109, 2, 20, 2 },
+  // chip: 344 (3), ladder:  4 (17), layer: 9, disk: 4, half: 0, zone: 3
+  { 110, 0, 22, 0 },
+  { 110, 1, 21, 1 },
+  { 110, 2, 20, 2 },
+  // chip: 347 (3), ladder:  5 (18), layer: 9, disk: 4, half: 0, zone: 3
+  { 111, 0, 17, 3 },
+  { 111, 1, 16, 4 },
+  { 111, 2, 15, 5 },
+  // chip: 350 (3), ladder:  6 (32), layer: 9, disk: 4, half: 0, zone: 0
+  { 112, 0, 0, 3 },
+  { 112, 1, 1, 4 },
+  { 112, 2, 2, 5 },
+  // chip: 353 (3), ladder:  7 (33), layer: 9, disk: 4, half: 0, zone: 0
+  { 113, 0, 5, 0 },
+  { 113, 1, 6, 1 },
+  { 113, 2, 7, 2 },
+  // chip: 356 (4), ladder:  8 ( 2), layer: 8, disk: 4, half: 0, zone: 0
+  { 114, 0, 17, 6 },
+  { 114, 1, 16, 7 },
+  { 114, 2, 15, 8 },
+  { 114, 3, 14, 9 },
+  // chip: 360 (4), ladder:  9 ( 3), layer: 8, disk: 4, half: 0, zone: 0
+  { 115, 0, 22, 10 },
+  { 115, 1, 21, 11 },
+  { 115, 2, 20, 12 },
+  { 115, 3, 19, 13 },
+  // chip: 364 (4), ladder: 10 ( 6), layer: 8, disk: 4, half: 0, zone: 1
+  { 116, 0, 0, 0 },
+  { 116, 1, 1, 1 },
+  { 116, 2, 2, 2 },
+  { 116, 3, 3, 3 },
+  // chip: 368 (4), ladder: 11 ( 7), layer: 8, disk: 4, half: 0, zone: 1
+  { 117, 0, 17, 4 },
+  { 117, 1, 16, 5 },
+  { 117, 2, 15, 6 },
+  { 117, 3, 14, 7 },
+  // chip: 372 (4), ladder: 12 ( 8), layer: 8, disk: 4, half: 0, zone: 1
+  { 118, 0, 22, 8 },
+  { 118, 1, 21, 9 },
+  { 118, 2, 20, 10 },
+  { 118, 3, 19, 11 },
+  // chip: 376 (4), ladder: 13 ( 9), layer: 8, disk: 4, half: 0, zone: 2
+  { 119, 0, 5, 0 },
+  { 119, 1, 6, 1 },
+  { 119, 2, 7, 2 },
+  { 119, 3, 24, 3 },
+  // chip: 380 (4), ladder: 14 (10), layer: 8, disk: 4, half: 0, zone: 2
+  { 120, 0, 0, 4 },
+  { 120, 1, 1, 5 },
+  { 120, 2, 2, 6 },
+  { 120, 3, 3, 7 },
+  // chip: 384 (4), ladder: 15 (13), layer: 8, disk: 4, half: 0, zone: 3
+  { 121, 0, 5, 10 },
+  { 121, 1, 6, 11 },
+  { 121, 2, 7, 12 },
+  { 121, 3, 24, 13 },
+  // chip: 388 (4), ladder: 16 (14), layer: 8, disk: 4, half: 0, zone: 3
+  { 122, 0, 0, 6 },
+  { 122, 1, 1, 7 },
+  { 122, 2, 2, 8 },
+  { 122, 3, 3, 9 },
+  // chip: 392 (4), ladder: 17 (19), layer: 9, disk: 4, half: 0, zone: 3
+  { 123, 0, 0, 6 },
+  { 123, 1, 1, 7 },
+  { 123, 2, 2, 8 },
+  { 123, 3, 3, 9 },
+  // chip: 396 (4), ladder: 18 (20), layer: 9, disk: 4, half: 0, zone: 3
+  { 124, 0, 5, 10 },
+  { 124, 1, 6, 11 },
+  { 124, 2, 7, 12 },
+  { 124, 3, 24, 13 },
+  // chip: 400 (4), ladder: 19 (23), layer: 9, disk: 4, half: 0, zone: 2
+  { 125, 0, 0, 4 },
+  { 125, 1, 1, 5 },
+  { 125, 2, 2, 6 },
+  { 125, 3, 3, 7 },
+  // chip: 404 (4), ladder: 20 (24), layer: 9, disk: 4, half: 0, zone: 2
+  { 126, 0, 5, 0 },
+  { 126, 1, 6, 1 },
+  { 126, 2, 7, 2 },
+  { 126, 3, 24, 3 },
+  // chip: 408 (4), ladder: 21 (25), layer: 9, disk: 4, half: 0, zone: 1
+  { 127, 0, 22, 8 },
+  { 127, 1, 21, 9 },
+  { 127, 2, 20, 10 },
+  { 127, 3, 19, 11 },
+  // chip: 412 (4), ladder: 22 (26), layer: 9, disk: 4, half: 0, zone: 1
+  { 128, 0, 17, 4 },
+  { 128, 1, 16, 5 },
+  { 128, 2, 15, 6 },
+  { 128, 3, 14, 7 },
+  // chip: 416 (4), ladder: 23 (27), layer: 9, disk: 4, half: 0, zone: 1
+  { 129, 0, 0, 0 },
+  { 129, 1, 1, 1 },
+  { 129, 2, 2, 2 },
+  { 129, 3, 3, 3 },
+  // chip: 420 (4), ladder: 24 (30), layer: 9, disk: 4, half: 0, zone: 0
+  { 130, 0, 22, 10 },
+  { 130, 1, 21, 11 },
+  { 130, 2, 20, 12 },
+  { 130, 3, 19, 13 },
+  // chip: 424 (4), ladder: 25 (31), layer: 9, disk: 4, half: 0, zone: 0
+  { 131, 0, 17, 6 },
+  { 131, 1, 16, 7 },
+  { 131, 2, 15, 8 },
+  { 131, 3, 14, 9 },
+  // chip: 428 (5), ladder: 26 ( 4), layer: 8, disk: 4, half: 0, zone: 0
+  { 132, 0, 12, 14 },
+  { 132, 1, 11, 15 },
+  { 132, 2, 10, 16 },
+  { 132, 3, 9, 17 },
+  { 132, 4, 8, 18 },
+  // chip: 433 (5), ladder: 27 ( 5), layer: 8, disk: 4, half: 0, zone: 1
+  { 133, 0, 5, 12 },
+  { 133, 1, 6, 13 },
+  { 133, 2, 7, 14 },
+  { 133, 3, 24, 15 },
+  { 133, 4, 23, 16 },
+  // chip: 438 (5), ladder: 28 (11), layer: 8, disk: 4, half: 0, zone: 2
+  { 134, 0, 17, 8 },
+  { 134, 1, 16, 9 },
+  { 134, 2, 15, 10 },
+  { 134, 3, 14, 11 },
+  { 134, 4, 13, 12 },
+  // chip: 443 (5), ladder: 29 (12), layer: 8, disk: 4, half: 0, zone: 2
+  { 135, 0, 22, 13 },
+  { 135, 1, 21, 14 },
+  { 135, 2, 20, 15 },
+  { 135, 3, 19, 16 },
+  { 135, 4, 18, 17 },
+  // chip: 448 (5), ladder: 30 (21), layer: 9, disk: 4, half: 0, zone: 2
+  { 136, 0, 22, 13 },
+  { 136, 1, 21, 14 },
+  { 136, 2, 20, 15 },
+  { 136, 3, 19, 16 },
+  { 136, 4, 18, 17 },
+  // chip: 453 (5), ladder: 31 (22), layer: 9, disk: 4, half: 0, zone: 2
+  { 137, 0, 17, 8 },
+  { 137, 1, 16, 9 },
+  { 137, 2, 15, 10 },
+  { 137, 3, 14, 11 },
+  { 137, 4, 13, 12 },
+  // chip: 458 (5), ladder: 32 (28), layer: 9, disk: 4, half: 0, zone: 1
+  { 138, 0, 5, 12 },
+  { 138, 1, 6, 13 },
+  { 138, 2, 7, 14 },
+  { 138, 3, 24, 15 },
+  { 138, 4, 23, 16 },
+  // chip: 463 (5), ladder: 33 (29), layer: 9, disk: 4, half: 0, zone: 0
+  { 139, 0, 12, 14 },
+  { 139, 1, 11, 15 },
+  { 139, 2, 10, 16 },
+  { 139, 3, 9, 17 },
+  { 139, 4, 8, 18 },
+  // chip: 468 (2), ladder:  0 ( 0), layer: 0, disk: 0, half: 1, zone: 0
+  { 140, 0, 5, 0 },
+  { 140, 1, 6, 1 },
+  // chip: 470 (2), ladder:  1 (10), layer: 0, disk: 0, half: 1, zone: 3
+  { 141, 0, 0, 0 },
+  { 141, 1, 1, 1 },
+  // chip: 472 (2), ladder:  2 (11), layer: 0, disk: 0, half: 1, zone: 3
+  { 142, 0, 17, 2 },
+  { 142, 1, 16, 3 },
+  // chip: 474 (2), ladder:  3 (12), layer: 1, disk: 0, half: 1, zone: 3
+  { 143, 0, 17, 2 },
+  { 143, 1, 16, 3 },
+  // chip: 476 (2), ladder:  4 (13), layer: 1, disk: 0, half: 1, zone: 3
+  { 144, 0, 0, 0 },
+  { 144, 1, 1, 1 },
+  // chip: 478 (2), ladder:  5 (23), layer: 1, disk: 0, half: 1, zone: 0
+  { 145, 0, 5, 0 },
+  { 145, 1, 6, 1 },
+  // chip: 480 (3), ladder:  6 ( 1), layer: 0, disk: 0, half: 1, zone: 0
+  { 146, 0, 0, 2 },
+  { 146, 1, 1, 3 },
+  { 146, 2, 2, 4 },
+  // chip: 483 (3), ladder:  7 ( 2), layer: 0, disk: 0, half: 1, zone: 0
+  { 147, 0, 17, 5 },
+  { 147, 1, 16, 6 },
+  { 147, 2, 15, 7 },
+  // chip: 486 (3), ladder:  8 ( 3), layer: 0, disk: 0, half: 1, zone: 1
+  { 148, 0, 5, 0 },
+  { 148, 1, 6, 1 },
+  { 148, 2, 7, 2 },
+  // chip: 489 (3), ladder:  9 ( 4), layer: 0, disk: 0, half: 1, zone: 1
+  { 149, 0, 0, 3 },
+  { 149, 1, 1, 4 },
+  { 149, 2, 2, 5 },
+  // chip: 492 (3), ladder: 10 ( 5), layer: 0, disk: 0, half: 1, zone: 1
+  { 150, 0, 17, 6 },
+  { 150, 1, 16, 7 },
+  { 150, 2, 15, 8 },
+  // chip: 495 (3), ladder: 11 ( 6), layer: 0, disk: 0, half: 1, zone: 2
+  { 151, 0, 5, 0 },
+  { 151, 1, 6, 1 },
+  { 151, 2, 7, 2 },
+  // chip: 498 (3), ladder: 12 ( 7), layer: 0, disk: 0, half: 1, zone: 2
+  { 152, 0, 0, 3 },
+  { 152, 1, 1, 4 },
+  { 152, 2, 2, 5 },
+  // chip: 501 (3), ladder: 13 ( 8), layer: 0, disk: 0, half: 1, zone: 2
+  { 153, 0, 17, 6 },
+  { 153, 1, 16, 7 },
+  { 153, 2, 15, 8 },
+  // chip: 504 (3), ladder: 14 ( 9), layer: 0, disk: 0, half: 1, zone: 3
+  { 154, 0, 5, 4 },
+  { 154, 1, 6, 5 },
+  { 154, 2, 7, 6 },
+  // chip: 507 (3), ladder: 15 (14), layer: 1, disk: 0, half: 1, zone: 3
+  { 155, 0, 5, 4 },
+  { 155, 1, 6, 5 },
+  { 155, 2, 7, 6 },
+  // chip: 510 (3), ladder: 16 (15), layer: 1, disk: 0, half: 1, zone: 2
+  { 156, 0, 17, 6 },
+  { 156, 1, 16, 7 },
+  { 156, 2, 15, 8 },
+  // chip: 513 (3), ladder: 17 (16), layer: 1, disk: 0, half: 1, zone: 2
+  { 157, 0, 0, 3 },
+  { 157, 1, 1, 4 },
+  { 157, 2, 2, 5 },
+  // chip: 516 (3), ladder: 18 (17), layer: 1, disk: 0, half: 1, zone: 2
+  { 158, 0, 5, 0 },
+  { 158, 1, 6, 1 },
+  { 158, 2, 7, 2 },
+  // chip: 519 (3), ladder: 19 (18), layer: 1, disk: 0, half: 1, zone: 1
+  { 159, 0, 17, 6 },
+  { 159, 1, 16, 7 },
+  { 159, 2, 15, 8 },
+  // chip: 522 (3), ladder: 20 (19), layer: 1, disk: 0, half: 1, zone: 1
+  { 160, 0, 0, 3 },
+  { 160, 1, 1, 4 },
+  { 160, 2, 2, 5 },
+  // chip: 525 (3), ladder: 21 (20), layer: 1, disk: 0, half: 1, zone: 1
+  { 161, 0, 5, 0 },
+  { 161, 1, 6, 1 },
+  { 161, 2, 7, 2 },
+  // chip: 528 (3), ladder: 22 (21), layer: 1, disk: 0, half: 1, zone: 0
+  { 162, 0, 17, 5 },
+  { 162, 1, 16, 6 },
+  { 162, 2, 15, 7 },
+  // chip: 531 (3), ladder: 23 (22), layer: 1, disk: 0, half: 1, zone: 0
+  { 163, 0, 0, 2 },
+  { 163, 1, 1, 3 },
+  { 163, 2, 2, 4 },
+  // chip: 534 (2), ladder:  0 ( 0), layer: 2, disk: 1, half: 1, zone: 0
+  { 164, 0, 5, 0 },
+  { 164, 1, 6, 1 },
+  // chip: 536 (2), ladder:  1 (10), layer: 2, disk: 1, half: 1, zone: 3
+  { 165, 0, 0, 0 },
+  { 165, 1, 1, 1 },
+  // chip: 538 (2), ladder:  2 (11), layer: 2, disk: 1, half: 1, zone: 3
+  { 166, 0, 17, 2 },
+  { 166, 1, 16, 3 },
+  // chip: 540 (2), ladder:  3 (12), layer: 3, disk: 1, half: 1, zone: 3
+  { 167, 0, 17, 2 },
+  { 167, 1, 16, 3 },
+  // chip: 542 (2), ladder:  4 (13), layer: 3, disk: 1, half: 1, zone: 3
+  { 168, 0, 0, 0 },
+  { 168, 1, 1, 1 },
+  // chip: 544 (2), ladder:  5 (23), layer: 3, disk: 1, half: 1, zone: 0
+  { 169, 0, 5, 0 },
+  { 169, 1, 6, 1 },
+  // chip: 546 (3), ladder:  6 ( 1), layer: 2, disk: 1, half: 1, zone: 0
+  { 170, 0, 0, 2 },
+  { 170, 1, 1, 3 },
+  { 170, 2, 2, 4 },
+  // chip: 549 (3), ladder:  7 ( 2), layer: 2, disk: 1, half: 1, zone: 0
+  { 171, 0, 17, 5 },
+  { 171, 1, 16, 6 },
+  { 171, 2, 15, 7 },
+  // chip: 552 (3), ladder:  8 ( 3), layer: 2, disk: 1, half: 1, zone: 1
+  { 172, 0, 5, 0 },
+  { 172, 1, 6, 1 },
+  { 172, 2, 7, 2 },
+  // chip: 555 (3), ladder:  9 ( 4), layer: 2, disk: 1, half: 1, zone: 1
+  { 173, 0, 0, 3 },
+  { 173, 1, 1, 4 },
+  { 173, 2, 2, 5 },
+  // chip: 558 (3), ladder: 10 ( 5), layer: 2, disk: 1, half: 1, zone: 1
+  { 174, 0, 17, 6 },
+  { 174, 1, 16, 7 },
+  { 174, 2, 15, 8 },
+  // chip: 561 (3), ladder: 11 ( 6), layer: 2, disk: 1, half: 1, zone: 2
+  { 175, 0, 5, 0 },
+  { 175, 1, 6, 1 },
+  { 175, 2, 7, 2 },
+  // chip: 564 (3), ladder: 12 ( 7), layer: 2, disk: 1, half: 1, zone: 2
+  { 176, 0, 0, 3 },
+  { 176, 1, 1, 4 },
+  { 176, 2, 2, 5 },
+  // chip: 567 (3), ladder: 13 ( 8), layer: 2, disk: 1, half: 1, zone: 2
+  { 177, 0, 17, 6 },
+  { 177, 1, 16, 7 },
+  { 177, 2, 15, 8 },
+  // chip: 570 (3), ladder: 14 ( 9), layer: 2, disk: 1, half: 1, zone: 3
+  { 178, 0, 5, 4 },
+  { 178, 1, 6, 5 },
+  { 178, 2, 7, 6 },
+  // chip: 573 (3), ladder: 15 (14), layer: 3, disk: 1, half: 1, zone: 3
+  { 179, 0, 5, 4 },
+  { 179, 1, 6, 5 },
+  { 179, 2, 7, 6 },
+  // chip: 576 (3), ladder: 16 (15), layer: 3, disk: 1, half: 1, zone: 2
+  { 180, 0, 17, 6 },
+  { 180, 1, 16, 7 },
+  { 180, 2, 15, 8 },
+  // chip: 579 (3), ladder: 17 (16), layer: 3, disk: 1, half: 1, zone: 2
+  { 181, 0, 0, 3 },
+  { 181, 1, 1, 4 },
+  { 181, 2, 2, 5 },
+  // chip: 582 (3), ladder: 18 (17), layer: 3, disk: 1, half: 1, zone: 2
+  { 182, 0, 5, 0 },
+  { 182, 1, 6, 1 },
+  { 182, 2, 7, 2 },
+  // chip: 585 (3), ladder: 19 (18), layer: 3, disk: 1, half: 1, zone: 1
+  { 183, 0, 17, 6 },
+  { 183, 1, 16, 7 },
+  { 183, 2, 15, 8 },
+  // chip: 588 (3), ladder: 20 (19), layer: 3, disk: 1, half: 1, zone: 1
+  { 184, 0, 0, 3 },
+  { 184, 1, 1, 4 },
+  { 184, 2, 2, 5 },
+  // chip: 591 (3), ladder: 21 (20), layer: 3, disk: 1, half: 1, zone: 1
+  { 185, 0, 5, 0 },
+  { 185, 1, 6, 1 },
+  { 185, 2, 7, 2 },
+  // chip: 594 (3), ladder: 22 (21), layer: 3, disk: 1, half: 1, zone: 0
+  { 186, 0, 17, 5 },
+  { 186, 1, 16, 6 },
+  { 186, 2, 15, 7 },
+  // chip: 597 (3), ladder: 23 (22), layer: 3, disk: 1, half: 1, zone: 0
+  { 187, 0, 0, 2 },
+  { 187, 1, 1, 3 },
+  { 187, 2, 2, 4 },
+  // chip: 600 (2), ladder:  0 ( 0), layer: 4, disk: 2, half: 1, zone: 0
+  { 188, 0, 5, 0 },
+  { 188, 1, 6, 1 },
+  // chip: 602 (2), ladder:  1 (12), layer: 4, disk: 2, half: 1, zone: 3
+  { 189, 0, 22, 0 },
+  { 189, 1, 21, 1 },
+  // chip: 604 (2), ladder:  2 (13), layer: 5, disk: 2, half: 1, zone: 3
+  { 190, 0, 22, 0 },
+  { 190, 1, 21, 1 },
+  // chip: 606 (2), ladder:  3 (25), layer: 5, disk: 2, half: 1, zone: 0
+  { 191, 0, 5, 0 },
+  { 191, 1, 6, 1 },
+  // chip: 608 (3), ladder:  4 ( 1), layer: 4, disk: 2, half: 1, zone: 0
+  { 192, 0, 0, 2 },
+  { 192, 1, 1, 3 },
+  { 192, 2, 2, 4 },
+  // chip: 611 (3), ladder:  5 ( 2), layer: 4, disk: 2, half: 1, zone: 0
+  { 193, 0, 17, 5 },
+  { 193, 1, 16, 6 },
+  { 193, 2, 15, 7 },
+  // chip: 614 (3), ladder:  6 ( 5), layer: 4, disk: 2, half: 1, zone: 1
+  { 194, 0, 17, 0 },
+  { 194, 1, 16, 1 },
+  { 194, 2, 15, 2 },
+  // chip: 617 (3), ladder:  7 ( 6), layer: 4, disk: 2, half: 1, zone: 2
+  { 195, 0, 5, 0 },
+  { 195, 1, 6, 1 },
+  { 195, 2, 7, 2 },
+  // chip: 620 (3), ladder:  8 ( 7), layer: 4, disk: 2, half: 1, zone: 2
+  { 196, 0, 0, 3 },
+  { 196, 1, 1, 4 },
+  { 196, 2, 2, 5 },
+  // chip: 623 (3), ladder:  9 (10), layer: 4, disk: 2, half: 1, zone: 3
+  { 197, 0, 0, 2 },
+  { 197, 1, 1, 3 },
+  { 197, 2, 2, 4 },
+  // chip: 626 (3), ladder: 10 (11), layer: 4, disk: 2, half: 1, zone: 3
+  { 198, 0, 17, 5 },
+  { 198, 1, 16, 6 },
+  { 198, 2, 15, 7 },
+  // chip: 629 (3), ladder: 11 (14), layer: 5, disk: 2, half: 1, zone: 3
+  { 199, 0, 17, 5 },
+  { 199, 1, 16, 6 },
+  { 199, 2, 15, 7 },
+  // chip: 632 (3), ladder: 12 (15), layer: 5, disk: 2, half: 1, zone: 3
+  { 200, 0, 0, 2 },
+  { 200, 1, 1, 3 },
+  { 200, 2, 2, 4 },
+  // chip: 635 (3), ladder: 13 (18), layer: 5, disk: 2, half: 1, zone: 2
+  { 201, 0, 0, 3 },
+  { 201, 1, 1, 4 },
+  { 201, 2, 2, 5 },
+  // chip: 638 (3), ladder: 14 (19), layer: 5, disk: 2, half: 1, zone: 2
+  { 202, 0, 5, 0 },
+  { 202, 1, 6, 1 },
+  { 202, 2, 7, 2 },
+  // chip: 641 (3), ladder: 15 (20), layer: 5, disk: 2, half: 1, zone: 1
+  { 203, 0, 17, 0 },
+  { 203, 1, 16, 1 },
+  { 203, 2, 15, 2 },
+  // chip: 644 (3), ladder: 16 (23), layer: 5, disk: 2, half: 1, zone: 0
+  { 204, 0, 17, 5 },
+  { 204, 1, 16, 6 },
+  { 204, 2, 15, 7 },
+  // chip: 647 (3), ladder: 17 (24), layer: 5, disk: 2, half: 1, zone: 0
+  { 205, 0, 0, 2 },
+  { 205, 1, 1, 3 },
+  { 205, 2, 2, 4 },
+  // chip: 650 (4), ladder: 18 ( 3), layer: 4, disk: 2, half: 1, zone: 1
+  { 206, 0, 5, 3 },
+  { 206, 1, 6, 4 },
+  { 206, 2, 7, 5 },
+  { 206, 3, 24, 6 },
+  // chip: 654 (4), ladder: 19 ( 4), layer: 4, disk: 2, half: 1, zone: 1
+  { 207, 0, 0, 7 },
+  { 207, 1, 1, 8 },
+  { 207, 2, 2, 9 },
+  { 207, 3, 3, 10 },
+  // chip: 658 (4), ladder: 20 ( 8), layer: 4, disk: 2, half: 1, zone: 2
+  { 208, 0, 17, 6 },
+  { 208, 1, 16, 7 },
+  { 208, 2, 15, 8 },
+  { 208, 3, 14, 9 },
+  // chip: 662 (4), ladder: 21 ( 9), layer: 4, disk: 2, half: 1, zone: 3
+  { 209, 0, 5, 8 },
+  { 209, 1, 6, 9 },
+  { 209, 2, 7, 10 },
+  { 209, 3, 24, 11 },
+  // chip: 666 (4), ladder: 22 (16), layer: 5, disk: 2, half: 1, zone: 3
+  { 210, 0, 5, 8 },
+  { 210, 1, 6, 9 },
+  { 210, 2, 7, 10 },
+  { 210, 3, 24, 11 },
+  // chip: 670 (4), ladder: 23 (17), layer: 5, disk: 2, half: 1, zone: 2
+  { 211, 0, 17, 6 },
+  { 211, 1, 16, 7 },
+  { 211, 2, 15, 8 },
+  { 211, 3, 14, 9 },
+  // chip: 674 (4), ladder: 24 (21), layer: 5, disk: 2, half: 1, zone: 1
+  { 212, 0, 0, 7 },
+  { 212, 1, 1, 8 },
+  { 212, 2, 2, 9 },
+  { 212, 3, 3, 10 },
+  // chip: 678 (4), ladder: 25 (22), layer: 5, disk: 2, half: 1, zone: 1
+  { 213, 0, 5, 3 },
+  { 213, 1, 6, 4 },
+  { 213, 2, 7, 5 },
+  { 213, 3, 24, 6 },
+  // chip: 682 (3), ladder:  0 ( 0), layer: 6, disk: 3, half: 1, zone: 0
+  { 214, 0, 5, 0 },
+  { 214, 1, 6, 1 },
+  { 214, 2, 7, 2 },
+  // chip: 685 (3), ladder:  1 ( 1), layer: 6, disk: 3, half: 1, zone: 0
+  { 215, 0, 0, 3 },
+  { 215, 1, 1, 4 },
+  { 215, 2, 2, 5 },
+  // chip: 688 (3), ladder:  2 (13), layer: 6, disk: 3, half: 1, zone: 3
+  { 216, 0, 0, 0 },
+  { 216, 1, 1, 1 },
+  { 216, 2, 2, 2 },
+  // chip: 691 (3), ladder:  3 (14), layer: 6, disk: 3, half: 1, zone: 3
+  { 217, 0, 17, 3 },
+  { 217, 1, 16, 4 },
+  { 217, 2, 15, 5 },
+  // chip: 694 (3), ladder:  4 (15), layer: 6, disk: 3, half: 1, zone: 3
+  { 218, 0, 22, 6 },
+  { 218, 1, 21, 7 },
+  { 218, 2, 20, 8 },
+  // chip: 697 (3), ladder:  5 (16), layer: 7, disk: 3, half: 1, zone: 3
+  { 219, 0, 22, 6 },
+  { 219, 1, 21, 7 },
+  { 219, 2, 20, 8 },
+  // chip: 700 (3), ladder:  6 (17), layer: 7, disk: 3, half: 1, zone: 3
+  { 220, 0, 17, 3 },
+  { 220, 1, 16, 4 },
+  { 220, 2, 15, 5 },
+  // chip: 703 (3), ladder:  7 (18), layer: 7, disk: 3, half: 1, zone: 3
+  { 221, 0, 0, 0 },
+  { 221, 1, 1, 1 },
+  { 221, 2, 2, 2 },
+  // chip: 706 (3), ladder:  8 (30), layer: 7, disk: 3, half: 1, zone: 0
+  { 222, 0, 0, 3 },
+  { 222, 1, 1, 4 },
+  { 222, 2, 2, 5 },
+  // chip: 709 (3), ladder:  9 (31), layer: 7, disk: 3, half: 1, zone: 0
+  { 223, 0, 5, 0 },
+  { 223, 1, 6, 1 },
+  { 223, 2, 7, 2 },
+  // chip: 712 (4), ladder: 10 ( 2), layer: 6, disk: 3, half: 1, zone: 0
+  { 224, 0, 17, 6 },
+  { 224, 1, 16, 7 },
+  { 224, 2, 15, 8 },
+  { 224, 3, 14, 9 },
+  // chip: 716 (4), ladder: 11 ( 3), layer: 6, disk: 3, half: 1, zone: 0
+  { 225, 0, 22, 10 },
+  { 225, 1, 21, 11 },
+  { 225, 2, 20, 12 },
+  { 225, 3, 19, 13 },
+  // chip: 720 (4), ladder: 12 ( 4), layer: 6, disk: 3, half: 1, zone: 1
+  { 226, 0, 5, 0 },
+  { 226, 1, 6, 1 },
+  { 226, 2, 7, 2 },
+  { 226, 3, 24, 3 },
+  // chip: 724 (4), ladder: 13 ( 5), layer: 6, disk: 3, half: 1, zone: 1
+  { 227, 0, 0, 4 },
+  { 227, 1, 1, 5 },
+  { 227, 2, 2, 6 },
+  { 227, 3, 3, 7 },
+  // chip: 728 (4), ladder: 14 ( 6), layer: 6, disk: 3, half: 1, zone: 1
+  { 228, 0, 17, 8 },
+  { 228, 1, 16, 9 },
+  { 228, 2, 15, 10 },
+  { 228, 3, 14, 11 },
+  // chip: 732 (4), ladder: 15 ( 7), layer: 6, disk: 3, half: 1, zone: 1
+  { 229, 0, 22, 12 },
+  { 229, 1, 21, 13 },
+  { 229, 2, 20, 14 },
+  { 229, 3, 19, 15 },
+  // chip: 736 (4), ladder: 16 ( 8), layer: 6, disk: 3, half: 1, zone: 2
+  { 230, 0, 5, 0 },
+  { 230, 1, 6, 1 },
+  { 230, 2, 7, 2 },
+  { 230, 3, 24, 3 },
+  // chip: 740 (4), ladder: 17 ( 9), layer: 6, disk: 3, half: 1, zone: 2
+  { 231, 0, 0, 4 },
+  { 231, 1, 1, 5 },
+  { 231, 2, 2, 6 },
+  { 231, 3, 3, 7 },
+  // chip: 744 (4), ladder: 18 (10), layer: 6, disk: 3, half: 1, zone: 2
+  { 232, 0, 17, 8 },
+  { 232, 1, 16, 9 },
+  { 232, 2, 15, 10 },
+  { 232, 3, 14, 11 },
+  // chip: 748 (4), ladder: 19 (11), layer: 6, disk: 3, half: 1, zone: 2
+  { 233, 0, 22, 12 },
+  { 233, 1, 21, 13 },
+  { 233, 2, 20, 14 },
+  { 233, 3, 19, 15 },
+  // chip: 752 (4), ladder: 20 (12), layer: 6, disk: 3, half: 1, zone: 3
+  { 234, 0, 5, 9 },
+  { 234, 1, 6, 10 },
+  { 234, 2, 7, 11 },
+  { 234, 3, 24, 12 },
+  // chip: 756 (4), ladder: 21 (19), layer: 7, disk: 3, half: 1, zone: 3
+  { 235, 0, 5, 9 },
+  { 235, 1, 6, 10 },
+  { 235, 2, 7, 11 },
+  { 235, 3, 24, 12 },
+  // chip: 760 (4), ladder: 22 (20), layer: 7, disk: 3, half: 1, zone: 2
+  { 236, 0, 22, 12 },
+  { 236, 1, 21, 13 },
+  { 236, 2, 20, 14 },
+  { 236, 3, 19, 15 },
+  // chip: 764 (4), ladder: 23 (21), layer: 7, disk: 3, half: 1, zone: 2
+  { 237, 0, 17, 8 },
+  { 237, 1, 16, 9 },
+  { 237, 2, 15, 10 },
+  { 237, 3, 14, 11 },
+  // chip: 768 (4), ladder: 24 (22), layer: 7, disk: 3, half: 1, zone: 2
+  { 238, 0, 0, 4 },
+  { 238, 1, 1, 5 },
+  { 238, 2, 2, 6 },
+  { 238, 3, 3, 7 },
+  // chip: 772 (4), ladder: 25 (23), layer: 7, disk: 3, half: 1, zone: 2
+  { 239, 0, 5, 0 },
+  { 239, 1, 6, 1 },
+  { 239, 2, 7, 2 },
+  { 239, 3, 24, 3 },
+  // chip: 776 (4), ladder: 26 (24), layer: 7, disk: 3, half: 1, zone: 1
+  { 240, 0, 22, 12 },
+  { 240, 1, 21, 13 },
+  { 240, 2, 20, 14 },
+  { 240, 3, 19, 15 },
+  // chip: 780 (4), ladder: 27 (25), layer: 7, disk: 3, half: 1, zone: 1
+  { 241, 0, 17, 8 },
+  { 241, 1, 16, 9 },
+  { 241, 2, 15, 10 },
+  { 241, 3, 14, 11 },
+  // chip: 784 (4), ladder: 28 (26), layer: 7, disk: 3, half: 1, zone: 1
+  { 242, 0, 0, 4 },
+  { 242, 1, 1, 5 },
+  { 242, 2, 2, 6 },
+  { 242, 3, 3, 7 },
+  // chip: 788 (4), ladder: 29 (27), layer: 7, disk: 3, half: 1, zone: 1
+  { 243, 0, 5, 0 },
+  { 243, 1, 6, 1 },
+  { 243, 2, 7, 2 },
+  { 243, 3, 24, 3 },
+  // chip: 792 (4), ladder: 30 (28), layer: 7, disk: 3, half: 1, zone: 0
+  { 244, 0, 22, 10 },
+  { 244, 1, 21, 11 },
+  { 244, 2, 20, 12 },
+  { 244, 3, 19, 13 },
+  // chip: 796 (4), ladder: 31 (29), layer: 7, disk: 3, half: 1, zone: 0
+  { 245, 0, 17, 6 },
+  { 245, 1, 16, 7 },
+  { 245, 2, 15, 8 },
+  { 245, 3, 14, 9 },
+  // chip: 800 (3), ladder:  0 ( 0), layer: 8, disk: 4, half: 1, zone: 0
+  { 246, 0, 5, 0 },
+  { 246, 1, 6, 1 },
+  { 246, 2, 7, 2 },
+  // chip: 803 (3), ladder:  1 ( 1), layer: 8, disk: 4, half: 1, zone: 0
+  { 247, 0, 0, 3 },
+  { 247, 1, 1, 4 },
+  { 247, 2, 2, 5 },
+  // chip: 806 (3), ladder:  2 (15), layer: 8, disk: 4, half: 1, zone: 3
+  { 248, 0, 17, 3 },
+  { 248, 1, 16, 4 },
+  { 248, 2, 15, 5 },
+  // chip: 809 (3), ladder:  3 (16), layer: 8, disk: 4, half: 1, zone: 3
+  { 249, 0, 22, 0 },
+  { 249, 1, 21, 1 },
+  { 249, 2, 20, 2 },
+  // chip: 812 (3), ladder:  4 (17), layer: 9, disk: 4, half: 1, zone: 3
+  { 250, 0, 22, 0 },
+  { 250, 1, 21, 1 },
+  { 250, 2, 20, 2 },
+  // chip: 815 (3), ladder:  5 (18), layer: 9, disk: 4, half: 1, zone: 3
+  { 251, 0, 17, 3 },
+  { 251, 1, 16, 4 },
+  { 251, 2, 15, 5 },
+  // chip: 818 (3), ladder:  6 (32), layer: 9, disk: 4, half: 1, zone: 0
+  { 252, 0, 0, 3 },
+  { 252, 1, 1, 4 },
+  { 252, 2, 2, 5 },
+  // chip: 821 (3), ladder:  7 (33), layer: 9, disk: 4, half: 1, zone: 0
+  { 253, 0, 5, 0 },
+  { 253, 1, 6, 1 },
+  { 253, 2, 7, 2 },
+  // chip: 824 (4), ladder:  8 ( 2), layer: 8, disk: 4, half: 1, zone: 0
+  { 254, 0, 17, 6 },
+  { 254, 1, 16, 7 },
+  { 254, 2, 15, 8 },
+  { 254, 3, 14, 9 },
+  // chip: 828 (4), ladder:  9 ( 3), layer: 8, disk: 4, half: 1, zone: 0
+  { 255, 0, 22, 10 },
+  { 255, 1, 21, 11 },
+  { 255, 2, 20, 12 },
+  { 255, 3, 19, 13 },
+  // chip: 832 (4), ladder: 10 ( 6), layer: 8, disk: 4, half: 1, zone: 1
+  { 256, 0, 0, 0 },
+  { 256, 1, 1, 1 },
+  { 256, 2, 2, 2 },
+  { 256, 3, 3, 3 },
+  // chip: 836 (4), ladder: 11 ( 7), layer: 8, disk: 4, half: 1, zone: 1
+  { 257, 0, 17, 4 },
+  { 257, 1, 16, 5 },
+  { 257, 2, 15, 6 },
+  { 257, 3, 14, 7 },
+  // chip: 840 (4), ladder: 12 ( 8), layer: 8, disk: 4, half: 1, zone: 1
+  { 258, 0, 22, 8 },
+  { 258, 1, 21, 9 },
+  { 258, 2, 20, 10 },
+  { 258, 3, 19, 11 },
+  // chip: 844 (4), ladder: 13 ( 9), layer: 8, disk: 4, half: 1, zone: 2
+  { 259, 0, 5, 0 },
+  { 259, 1, 6, 1 },
+  { 259, 2, 7, 2 },
+  { 259, 3, 24, 3 },
+  // chip: 848 (4), ladder: 14 (10), layer: 8, disk: 4, half: 1, zone: 2
+  { 260, 0, 0, 4 },
+  { 260, 1, 1, 5 },
+  { 260, 2, 2, 6 },
+  { 260, 3, 3, 7 },
+  // chip: 852 (4), ladder: 15 (13), layer: 8, disk: 4, half: 1, zone: 3
+  { 261, 0, 5, 10 },
+  { 261, 1, 6, 11 },
+  { 261, 2, 7, 12 },
+  { 261, 3, 24, 13 },
+  // chip: 856 (4), ladder: 16 (14), layer: 8, disk: 4, half: 1, zone: 3
+  { 262, 0, 0, 6 },
+  { 262, 1, 1, 7 },
+  { 262, 2, 2, 8 },
+  { 262, 3, 3, 9 },
+  // chip: 860 (4), ladder: 17 (19), layer: 9, disk: 4, half: 1, zone: 3
+  { 263, 0, 0, 6 },
+  { 263, 1, 1, 7 },
+  { 263, 2, 2, 8 },
+  { 263, 3, 3, 9 },
+  // chip: 864 (4), ladder: 18 (20), layer: 9, disk: 4, half: 1, zone: 3
+  { 264, 0, 5, 10 },
+  { 264, 1, 6, 11 },
+  { 264, 2, 7, 12 },
+  { 264, 3, 24, 13 },
+  // chip: 868 (4), ladder: 19 (23), layer: 9, disk: 4, half: 1, zone: 2
+  { 265, 0, 0, 4 },
+  { 265, 1, 1, 5 },
+  { 265, 2, 2, 6 },
+  { 265, 3, 3, 7 },
+  // chip: 872 (4), ladder: 20 (24), layer: 9, disk: 4, half: 1, zone: 2
+  { 266, 0, 5, 0 },
+  { 266, 1, 6, 1 },
+  { 266, 2, 7, 2 },
+  { 266, 3, 24, 3 },
+  // chip: 876 (4), ladder: 21 (25), layer: 9, disk: 4, half: 1, zone: 1
+  { 267, 0, 22, 8 },
+  { 267, 1, 21, 9 },
+  { 267, 2, 20, 10 },
+  { 267, 3, 19, 11 },
+  // chip: 880 (4), ladder: 22 (26), layer: 9, disk: 4, half: 1, zone: 1
+  { 268, 0, 17, 4 },
+  { 268, 1, 16, 5 },
+  { 268, 2, 15, 6 },
+  { 268, 3, 14, 7 },
+  // chip: 884 (4), ladder: 23 (27), layer: 9, disk: 4, half: 1, zone: 1
+  { 269, 0, 0, 0 },
+  { 269, 1, 1, 1 },
+  { 269, 2, 2, 2 },
+  { 269, 3, 3, 3 },
+  // chip: 888 (4), ladder: 24 (30), layer: 9, disk: 4, half: 1, zone: 0
+  { 270, 0, 22, 10 },
+  { 270, 1, 21, 11 },
+  { 270, 2, 20, 12 },
+  { 270, 3, 19, 13 },
+  // chip: 892 (4), ladder: 25 (31), layer: 9, disk: 4, half: 1, zone: 0
+  { 271, 0, 17, 6 },
+  { 271, 1, 16, 7 },
+  { 271, 2, 15, 8 },
+  { 271, 3, 14, 9 },
+  // chip: 896 (5), ladder: 26 ( 4), layer: 8, disk: 4, half: 1, zone: 0
+  { 272, 0, 12, 14 },
+  { 272, 1, 11, 15 },
+  { 272, 2, 10, 16 },
+  { 272, 3, 9, 17 },
+  { 272, 4, 8, 18 },
+  // chip: 901 (5), ladder: 27 ( 5), layer: 8, disk: 4, half: 1, zone: 1
+  { 273, 0, 5, 12 },
+  { 273, 1, 6, 13 },
+  { 273, 2, 7, 14 },
+  { 273, 3, 24, 15 },
+  { 273, 4, 23, 16 },
+  // chip: 906 (5), ladder: 28 (11), layer: 8, disk: 4, half: 1, zone: 2
+  { 274, 0, 17, 8 },
+  { 274, 1, 16, 9 },
+  { 274, 2, 15, 10 },
+  { 274, 3, 14, 11 },
+  { 274, 4, 13, 12 },
+  // chip: 911 (5), ladder: 29 (12), layer: 8, disk: 4, half: 1, zone: 2
+  { 275, 0, 22, 13 },
+  { 275, 1, 21, 14 },
+  { 275, 2, 20, 15 },
+  { 275, 3, 19, 16 },
+  { 275, 4, 18, 17 },
+  // chip: 916 (5), ladder: 30 (21), layer: 9, disk: 4, half: 1, zone: 2
+  { 276, 0, 22, 13 },
+  { 276, 1, 21, 14 },
+  { 276, 2, 20, 15 },
+  { 276, 3, 19, 16 },
+  { 276, 4, 18, 17 },
+  // chip: 921 (5), ladder: 31 (22), layer: 9, disk: 4, half: 1, zone: 2
+  { 277, 0, 17, 8 },
+  { 277, 1, 16, 9 },
+  { 277, 2, 15, 10 },
+  { 277, 3, 14, 11 },
+  { 277, 4, 13, 12 },
+  // chip: 926 (5), ladder: 32 (28), layer: 9, disk: 4, half: 1, zone: 1
+  { 278, 0, 5, 12 },
+  { 278, 1, 6, 13 },
+  { 278, 2, 7, 14 },
+  { 278, 3, 24, 15 },
+  { 278, 4, 23, 16 },
+  // chip: 931 (5), ladder: 33 (29), layer: 9, disk: 4, half: 1, zone: 0
+  { 279, 0, 12, 14 },
+  { 279, 1, 11, 15 },
+  { 279, 2, 10, 16 },
+  { 279, 3, 9, 17 },
+  { 279, 4, 8, 18 }
 
 } };
 
 const std::array<MFTModuleMappingData, ChipMappingMFT::NModules> ChipMappingMFT::ModuleMappingData{ {
 
-  // layer: 0
-  { 0, 2, 0 },
-  { 0, 2, 2 },
-  { 0, 2, 4 },
-
-  // layer: 1
-  { 1, 2, 6 },
-  { 1, 2, 8 },
-  { 1, 2, 10 },
+  // { layer, nChips, firstChipID, connector, zone, disk, half }
 
   // layer: 0
-  { 0, 3, 12 },
-  { 0, 3, 15 },
-  { 0, 3, 18 },
-  { 0, 3, 21 },
-  { 0, 3, 24 },
-  { 0, 3, 27 },
-  { 0, 3, 30 },
-  { 0, 3, 33 },
-  { 0, 3, 36 },
+  { 0, 2, 0, 0, 0, 0, 0 },
+  { 0, 2, 2, 1, 3, 0, 0 },
+  { 0, 2, 4, 2, 3, 0, 0 },
 
   // layer: 1
-  { 1, 3, 39 },
-  { 1, 3, 42 },
-  { 1, 3, 45 },
-  { 1, 3, 48 },
-  { 1, 3, 51 },
-  { 1, 3, 54 },
-  { 1, 3, 57 },
-  { 1, 3, 60 },
-  { 1, 3, 63 },
-
-  // layer: 2
-  { 2, 2, 66 },
-  { 2, 2, 68 },
-  { 2, 2, 70 },
-
-  // layer: 3
-  { 3, 2, 72 },
-  { 3, 2, 74 },
-  { 3, 2, 76 },
-
-  // layer: 2
-  { 2, 3, 78 },
-  { 2, 3, 81 },
-  { 2, 3, 84 },
-  { 2, 3, 87 },
-  { 2, 3, 90 },
-  { 2, 3, 93 },
-  { 2, 3, 96 },
-  { 2, 3, 99 },
-  { 2, 3, 102 },
-
-  // layer: 3
-  { 3, 3, 105 },
-  { 3, 3, 108 },
-  { 3, 3, 111 },
-  { 3, 3, 114 },
-  { 3, 3, 117 },
-  { 3, 3, 120 },
-  { 3, 3, 123 },
-  { 3, 3, 126 },
-  { 3, 3, 129 },
-
-  // layer: 4
-  { 4, 2, 132 },
-  { 4, 2, 134 },
-
-  // layer: 5
-  { 5, 2, 136 },
-  { 5, 2, 138 },
-
-  // layer: 4
-  { 4, 3, 140 },
-  { 4, 3, 143 },
-  { 4, 3, 146 },
-  { 4, 3, 149 },
-  { 4, 3, 152 },
-  { 4, 3, 155 },
-  { 4, 3, 158 },
-
-  // layer: 5
-  { 5, 3, 161 },
-  { 5, 3, 164 },
-  { 5, 3, 167 },
-  { 5, 3, 170 },
-  { 5, 3, 173 },
-  { 5, 3, 176 },
-  { 5, 3, 179 },
-
-  // layer: 4
-  { 4, 4, 182 },
-  { 4, 4, 186 },
-  { 4, 4, 190 },
-  { 4, 4, 194 },
-
-  // layer: 5
-  { 5, 4, 198 },
-  { 5, 4, 202 },
-  { 5, 4, 206 },
-  { 5, 4, 210 },
-
-  // layer: 6
-  { 6, 2, 214 },
-  { 6, 2, 216 },
-
-  // layer: 7
-  { 7, 2, 218 },
-  { 7, 2, 220 },
-
-  // layer: 6
-  { 6, 3, 222 },
-  { 6, 3, 225 },
-  { 6, 3, 228 },
-
-  // layer: 7
-  { 7, 3, 231 },
-  { 7, 3, 234 },
-  { 7, 3, 237 },
-
-  // layer: 6
-  { 6, 4, 240 },
-  { 6, 4, 244 },
-  { 6, 4, 248 },
-  { 6, 4, 252 },
-  { 6, 4, 256 },
-  { 6, 4, 260 },
-  { 6, 4, 264 },
-  { 6, 4, 268 },
-  { 6, 4, 272 },
-  { 6, 4, 276 },
-  { 6, 4, 280 },
-
-  // layer: 7
-  { 7, 4, 284 },
-  { 7, 4, 288 },
-  { 7, 4, 292 },
-  { 7, 4, 296 },
-  { 7, 4, 300 },
-  { 7, 4, 304 },
-  { 7, 4, 308 },
-  { 7, 4, 312 },
-  { 7, 4, 316 },
-  { 7, 4, 320 },
-  { 7, 4, 324 },
-
-  // layer: 8
-  { 8, 2, 328 },
-  { 8, 2, 330 },
-
-  // layer: 9
-  { 9, 2, 332 },
-  { 9, 2, 334 },
-
-  // layer: 8
-  { 8, 3, 336 },
-  { 8, 3, 339 },
-
-  // layer: 9
-  { 9, 3, 342 },
-  { 9, 3, 345 },
-
-  // layer: 8
-  { 8, 4, 348 },
-  { 8, 4, 352 },
-  { 8, 4, 356 },
-  { 8, 4, 360 },
-  { 8, 4, 364 },
-  { 8, 4, 368 },
-  { 8, 4, 372 },
-  { 8, 4, 376 },
-  { 8, 4, 380 },
-
-  // layer: 9
-  { 9, 4, 384 },
-  { 9, 4, 388 },
-  { 9, 4, 392 },
-  { 9, 4, 396 },
-  { 9, 4, 400 },
-  { 9, 4, 404 },
-  { 9, 4, 408 },
-  { 9, 4, 412 },
-  { 9, 4, 416 },
-
-  // layer: 8
-  { 8, 5, 420 },
-  { 8, 5, 425 },
-  { 8, 5, 430 },
-  { 8, 5, 435 },
-
-  // layer: 9
-  { 9, 5, 440 },
-  { 9, 5, 445 },
-  { 9, 5, 450 },
-  { 9, 5, 455 },
+  { 1, 2, 6, 2, 3, 0, 0 },
+  { 1, 2, 8, 1, 3, 0, 0 },
+  { 1, 2, 10, 0, 0, 0, 0 },
 
   // layer: 0
-  { 0, 2, 460 },
-  { 0, 2, 462 },
-  { 0, 2, 464 },
+  { 0, 3, 12, 1, 0, 0, 0 },
+  { 0, 3, 15, 2, 0, 0, 0 },
+  { 0, 3, 18, 0, 1, 0, 0 },
+  { 0, 3, 21, 1, 1, 0, 0 },
+  { 0, 3, 24, 2, 1, 0, 0 },
+  { 0, 3, 27, 0, 2, 0, 0 },
+  { 0, 3, 30, 1, 2, 0, 0 },
+  { 0, 3, 33, 2, 2, 0, 0 },
+  { 0, 3, 36, 0, 3, 0, 0 },
 
   // layer: 1
-  { 1, 2, 466 },
-  { 1, 2, 468 },
-  { 1, 2, 470 },
+  { 1, 3, 39, 0, 3, 0, 0 },
+  { 1, 3, 42, 2, 2, 0, 0 },
+  { 1, 3, 45, 1, 2, 0, 0 },
+  { 1, 3, 48, 0, 2, 0, 0 },
+  { 1, 3, 51, 2, 1, 0, 0 },
+  { 1, 3, 54, 1, 1, 0, 0 },
+  { 1, 3, 57, 0, 1, 0, 0 },
+  { 1, 3, 60, 2, 0, 0, 0 },
+  { 1, 3, 63, 1, 0, 0, 0 },
+
+  // layer: 2
+  { 2, 2, 66, 0, 0, 1, 0 },
+  { 2, 2, 68, 1, 3, 1, 0 },
+  { 2, 2, 70, 2, 3, 1, 0 },
+
+  // layer: 3
+  { 3, 2, 72, 2, 3, 1, 0 },
+  { 3, 2, 74, 1, 3, 1, 0 },
+  { 3, 2, 76, 0, 0, 1, 0 },
+
+  // layer: 2
+  { 2, 3, 78, 1, 0, 1, 0 },
+  { 2, 3, 81, 2, 0, 1, 0 },
+  { 2, 3, 84, 0, 1, 1, 0 },
+  { 2, 3, 87, 1, 1, 1, 0 },
+  { 2, 3, 90, 2, 1, 1, 0 },
+  { 2, 3, 93, 0, 2, 1, 0 },
+  { 2, 3, 96, 1, 2, 1, 0 },
+  { 2, 3, 99, 2, 2, 1, 0 },
+  { 2, 3, 102, 0, 3, 1, 0 },
+
+  // layer: 3
+  { 3, 3, 105, 0, 3, 1, 0 },
+  { 3, 3, 108, 2, 2, 1, 0 },
+  { 3, 3, 111, 1, 2, 1, 0 },
+  { 3, 3, 114, 0, 2, 1, 0 },
+  { 3, 3, 117, 2, 1, 1, 0 },
+  { 3, 3, 120, 1, 1, 1, 0 },
+  { 3, 3, 123, 0, 1, 1, 0 },
+  { 3, 3, 126, 2, 0, 1, 0 },
+  { 3, 3, 129, 1, 0, 1, 0 },
+
+  // layer: 4
+  { 4, 2, 132, 0, 0, 2, 0 },
+  { 4, 2, 134, 3, 3, 2, 0 },
+
+  // layer: 5
+  { 5, 2, 136, 3, 3, 2, 0 },
+  { 5, 2, 138, 0, 0, 2, 0 },
+
+  // layer: 4
+  { 4, 3, 140, 1, 0, 2, 0 },
+  { 4, 3, 143, 2, 0, 2, 0 },
+  { 4, 3, 146, 2, 1, 2, 0 },
+  { 4, 3, 149, 0, 2, 2, 0 },
+  { 4, 3, 152, 1, 2, 2, 0 },
+  { 4, 3, 155, 1, 3, 2, 0 },
+  { 4, 3, 158, 2, 3, 2, 0 },
+
+  // layer: 5
+  { 5, 3, 161, 2, 3, 2, 0 },
+  { 5, 3, 164, 1, 3, 2, 0 },
+  { 5, 3, 167, 1, 2, 2, 0 },
+  { 5, 3, 170, 0, 2, 2, 0 },
+  { 5, 3, 173, 2, 1, 2, 0 },
+  { 5, 3, 176, 2, 0, 2, 0 },
+  { 5, 3, 179, 1, 0, 2, 0 },
+
+  // layer: 4
+  { 4, 4, 182, 0, 1, 2, 0 },
+  { 4, 4, 186, 1, 1, 2, 0 },
+  { 4, 4, 190, 2, 2, 2, 0 },
+  { 4, 4, 194, 0, 3, 2, 0 },
+
+  // layer: 5
+  { 5, 4, 198, 0, 3, 2, 0 },
+  { 5, 4, 202, 2, 2, 2, 0 },
+  { 5, 4, 206, 1, 1, 2, 0 },
+  { 5, 4, 210, 0, 1, 2, 0 },
+
+  // layer: 6
+  { 6, 3, 214, 0, 0, 3, 0 },
+  { 6, 3, 217, 1, 0, 3, 0 },
+  { 6, 3, 220, 1, 3, 3, 0 },
+  { 6, 3, 223, 2, 3, 3, 0 },
+  { 6, 3, 226, 3, 3, 3, 0 },
+
+  // layer: 7
+  { 7, 3, 229, 3, 3, 3, 0 },
+  { 7, 3, 232, 2, 3, 3, 0 },
+  { 7, 3, 235, 1, 3, 3, 0 },
+  { 7, 3, 238, 1, 0, 3, 0 },
+  { 7, 3, 241, 0, 0, 3, 0 },
+
+  // layer: 6
+  { 6, 4, 244, 2, 0, 3, 0 },
+  { 6, 4, 248, 3, 0, 3, 0 },
+  { 6, 4, 252, 0, 1, 3, 0 },
+  { 6, 4, 256, 1, 1, 3, 0 },
+  { 6, 4, 260, 2, 1, 3, 0 },
+  { 6, 4, 264, 3, 1, 3, 0 },
+  { 6, 4, 268, 0, 2, 3, 0 },
+  { 6, 4, 272, 1, 2, 3, 0 },
+  { 6, 4, 276, 2, 2, 3, 0 },
+  { 6, 4, 280, 3, 2, 3, 0 },
+  { 6, 4, 284, 0, 3, 3, 0 },
+
+  // layer: 7
+  { 7, 4, 288, 0, 3, 3, 0 },
+  { 7, 4, 292, 3, 2, 3, 0 },
+  { 7, 4, 296, 2, 2, 3, 0 },
+  { 7, 4, 300, 1, 2, 3, 0 },
+  { 7, 4, 304, 0, 2, 3, 0 },
+  { 7, 4, 308, 3, 1, 3, 0 },
+  { 7, 4, 312, 2, 1, 3, 0 },
+  { 7, 4, 316, 1, 1, 3, 0 },
+  { 7, 4, 320, 0, 1, 3, 0 },
+  { 7, 4, 324, 3, 0, 3, 0 },
+  { 7, 4, 328, 2, 0, 3, 0 },
+
+  // layer: 8
+  { 8, 3, 332, 0, 0, 4, 0 },
+  { 8, 3, 335, 1, 0, 4, 0 },
+  { 8, 3, 338, 2, 3, 4, 0 },
+  { 8, 3, 341, 3, 3, 4, 0 },
+
+  // layer: 9
+  { 9, 3, 344, 3, 3, 4, 0 },
+  { 9, 3, 347, 2, 3, 4, 0 },
+  { 9, 3, 350, 1, 0, 4, 0 },
+  { 9, 3, 353, 0, 0, 4, 0 },
+
+  // layer: 8
+  { 8, 4, 356, 2, 0, 4, 0 },
+  { 8, 4, 360, 3, 0, 4, 0 },
+  { 8, 4, 364, 1, 1, 4, 0 },
+  { 8, 4, 368, 2, 1, 4, 0 },
+  { 8, 4, 372, 3, 1, 4, 0 },
+  { 8, 4, 376, 0, 2, 4, 0 },
+  { 8, 4, 380, 1, 2, 4, 0 },
+  { 8, 4, 384, 0, 3, 4, 0 },
+  { 8, 4, 388, 1, 3, 4, 0 },
+
+  // layer: 9
+  { 9, 4, 392, 1, 3, 4, 0 },
+  { 9, 4, 396, 0, 3, 4, 0 },
+  { 9, 4, 400, 1, 2, 4, 0 },
+  { 9, 4, 404, 0, 2, 4, 0 },
+  { 9, 4, 408, 3, 1, 4, 0 },
+  { 9, 4, 412, 2, 1, 4, 0 },
+  { 9, 4, 416, 1, 1, 4, 0 },
+  { 9, 4, 420, 3, 0, 4, 0 },
+  { 9, 4, 424, 2, 0, 4, 0 },
+
+  // layer: 8
+  { 8, 5, 428, 4, 0, 4, 0 },
+  { 8, 5, 433, 0, 1, 4, 0 },
+  { 8, 5, 438, 2, 2, 4, 0 },
+  { 8, 5, 443, 3, 2, 4, 0 },
+
+  // layer: 9
+  { 9, 5, 448, 3, 2, 4, 0 },
+  { 9, 5, 453, 2, 2, 4, 0 },
+  { 9, 5, 458, 0, 1, 4, 0 },
+  { 9, 5, 463, 4, 0, 4, 0 },
 
   // layer: 0
-  { 0, 3, 472 },
-  { 0, 3, 475 },
-  { 0, 3, 478 },
-  { 0, 3, 481 },
-  { 0, 3, 484 },
-  { 0, 3, 487 },
-  { 0, 3, 490 },
-  { 0, 3, 493 },
-  { 0, 3, 496 },
+  { 0, 2, 468, 0, 0, 0, 1 },
+  { 0, 2, 470, 1, 3, 0, 1 },
+  { 0, 2, 472, 2, 3, 0, 1 },
 
   // layer: 1
-  { 1, 3, 499 },
-  { 1, 3, 502 },
-  { 1, 3, 505 },
-  { 1, 3, 508 },
-  { 1, 3, 511 },
-  { 1, 3, 514 },
-  { 1, 3, 517 },
-  { 1, 3, 520 },
-  { 1, 3, 523 },
+  { 1, 2, 474, 2, 3, 0, 1 },
+  { 1, 2, 476, 1, 3, 0, 1 },
+  { 1, 2, 478, 0, 0, 0, 1 },
+
+  // layer: 0
+  { 0, 3, 480, 1, 0, 0, 1 },
+  { 0, 3, 483, 2, 0, 0, 1 },
+  { 0, 3, 486, 0, 1, 0, 1 },
+  { 0, 3, 489, 1, 1, 0, 1 },
+  { 0, 3, 492, 2, 1, 0, 1 },
+  { 0, 3, 495, 0, 2, 0, 1 },
+  { 0, 3, 498, 1, 2, 0, 1 },
+  { 0, 3, 501, 2, 2, 0, 1 },
+  { 0, 3, 504, 0, 3, 0, 1 },
+
+  // layer: 1
+  { 1, 3, 507, 0, 3, 0, 1 },
+  { 1, 3, 510, 2, 2, 0, 1 },
+  { 1, 3, 513, 1, 2, 0, 1 },
+  { 1, 3, 516, 0, 2, 0, 1 },
+  { 1, 3, 519, 2, 1, 0, 1 },
+  { 1, 3, 522, 1, 1, 0, 1 },
+  { 1, 3, 525, 0, 1, 0, 1 },
+  { 1, 3, 528, 2, 0, 0, 1 },
+  { 1, 3, 531, 1, 0, 0, 1 },
 
   // layer: 2
-  { 2, 2, 526 },
-  { 2, 2, 528 },
-  { 2, 2, 530 },
+  { 2, 2, 534, 0, 0, 1, 1 },
+  { 2, 2, 536, 1, 3, 1, 1 },
+  { 2, 2, 538, 2, 3, 1, 1 },
 
   // layer: 3
-  { 3, 2, 532 },
-  { 3, 2, 534 },
-  { 3, 2, 536 },
+  { 3, 2, 540, 2, 3, 1, 1 },
+  { 3, 2, 542, 1, 3, 1, 1 },
+  { 3, 2, 544, 0, 0, 1, 1 },
 
   // layer: 2
-  { 2, 3, 538 },
-  { 2, 3, 541 },
-  { 2, 3, 544 },
-  { 2, 3, 547 },
-  { 2, 3, 550 },
-  { 2, 3, 553 },
-  { 2, 3, 556 },
-  { 2, 3, 559 },
-  { 2, 3, 562 },
+  { 2, 3, 546, 1, 0, 1, 1 },
+  { 2, 3, 549, 2, 0, 1, 1 },
+  { 2, 3, 552, 0, 1, 1, 1 },
+  { 2, 3, 555, 1, 1, 1, 1 },
+  { 2, 3, 558, 2, 1, 1, 1 },
+  { 2, 3, 561, 0, 2, 1, 1 },
+  { 2, 3, 564, 1, 2, 1, 1 },
+  { 2, 3, 567, 2, 2, 1, 1 },
+  { 2, 3, 570, 0, 3, 1, 1 },
 
   // layer: 3
-  { 3, 3, 565 },
-  { 3, 3, 568 },
-  { 3, 3, 571 },
-  { 3, 3, 574 },
-  { 3, 3, 577 },
-  { 3, 3, 580 },
-  { 3, 3, 583 },
-  { 3, 3, 586 },
-  { 3, 3, 589 },
+  { 3, 3, 573, 0, 3, 1, 1 },
+  { 3, 3, 576, 2, 2, 1, 1 },
+  { 3, 3, 579, 1, 2, 1, 1 },
+  { 3, 3, 582, 0, 2, 1, 1 },
+  { 3, 3, 585, 2, 1, 1, 1 },
+  { 3, 3, 588, 1, 1, 1, 1 },
+  { 3, 3, 591, 0, 1, 1, 1 },
+  { 3, 3, 594, 2, 0, 1, 1 },
+  { 3, 3, 597, 1, 0, 1, 1 },
 
   // layer: 4
-  { 4, 2, 592 },
-  { 4, 2, 594 },
+  { 4, 2, 600, 0, 0, 2, 1 },
+  { 4, 2, 602, 3, 3, 2, 1 },
 
   // layer: 5
-  { 5, 2, 596 },
-  { 5, 2, 598 },
+  { 5, 2, 604, 3, 3, 2, 1 },
+  { 5, 2, 606, 0, 0, 2, 1 },
 
   // layer: 4
-  { 4, 3, 600 },
-  { 4, 3, 603 },
-  { 4, 3, 606 },
-  { 4, 3, 609 },
-  { 4, 3, 612 },
-  { 4, 3, 615 },
-  { 4, 3, 618 },
+  { 4, 3, 608, 1, 0, 2, 1 },
+  { 4, 3, 611, 2, 0, 2, 1 },
+  { 4, 3, 614, 2, 1, 2, 1 },
+  { 4, 3, 617, 0, 2, 2, 1 },
+  { 4, 3, 620, 1, 2, 2, 1 },
+  { 4, 3, 623, 1, 3, 2, 1 },
+  { 4, 3, 626, 2, 3, 2, 1 },
 
   // layer: 5
-  { 5, 3, 621 },
-  { 5, 3, 624 },
-  { 5, 3, 627 },
-  { 5, 3, 630 },
-  { 5, 3, 633 },
-  { 5, 3, 636 },
-  { 5, 3, 639 },
+  { 5, 3, 629, 2, 3, 2, 1 },
+  { 5, 3, 632, 1, 3, 2, 1 },
+  { 5, 3, 635, 1, 2, 2, 1 },
+  { 5, 3, 638, 0, 2, 2, 1 },
+  { 5, 3, 641, 2, 1, 2, 1 },
+  { 5, 3, 644, 2, 0, 2, 1 },
+  { 5, 3, 647, 1, 0, 2, 1 },
 
   // layer: 4
-  { 4, 4, 642 },
-  { 4, 4, 646 },
-  { 4, 4, 650 },
-  { 4, 4, 654 },
+  { 4, 4, 650, 0, 1, 2, 1 },
+  { 4, 4, 654, 1, 1, 2, 1 },
+  { 4, 4, 658, 2, 2, 2, 1 },
+  { 4, 4, 662, 0, 3, 2, 1 },
 
   // layer: 5
-  { 5, 4, 658 },
-  { 5, 4, 662 },
-  { 5, 4, 666 },
-  { 5, 4, 670 },
+  { 5, 4, 666, 0, 3, 2, 1 },
+  { 5, 4, 670, 2, 2, 2, 1 },
+  { 5, 4, 674, 1, 1, 2, 1 },
+  { 5, 4, 678, 0, 1, 2, 1 },
 
   // layer: 6
-  { 6, 2, 674 },
-  { 6, 2, 676 },
+  { 6, 3, 682, 0, 0, 3, 1 },
+  { 6, 3, 685, 1, 0, 3, 1 },
+  { 6, 3, 688, 1, 3, 3, 1 },
+  { 6, 3, 691, 2, 3, 3, 1 },
+  { 6, 3, 694, 3, 3, 3, 1 },
 
   // layer: 7
-  { 7, 2, 678 },
-  { 7, 2, 680 },
+  { 7, 3, 697, 3, 3, 3, 1 },
+  { 7, 3, 700, 2, 3, 3, 1 },
+  { 7, 3, 703, 1, 3, 3, 1 },
+  { 7, 3, 706, 1, 0, 3, 1 },
+  { 7, 3, 709, 0, 0, 3, 1 },
 
   // layer: 6
-  { 6, 3, 682 },
-  { 6, 3, 685 },
-  { 6, 3, 688 },
+  { 6, 4, 712, 2, 0, 3, 1 },
+  { 6, 4, 716, 3, 0, 3, 1 },
+  { 6, 4, 720, 0, 1, 3, 1 },
+  { 6, 4, 724, 1, 1, 3, 1 },
+  { 6, 4, 728, 2, 1, 3, 1 },
+  { 6, 4, 732, 3, 1, 3, 1 },
+  { 6, 4, 736, 0, 2, 3, 1 },
+  { 6, 4, 740, 1, 2, 3, 1 },
+  { 6, 4, 744, 2, 2, 3, 1 },
+  { 6, 4, 748, 3, 2, 3, 1 },
+  { 6, 4, 752, 0, 3, 3, 1 },
 
   // layer: 7
-  { 7, 3, 691 },
-  { 7, 3, 694 },
-  { 7, 3, 697 },
-
-  // layer: 6
-  { 6, 4, 700 },
-  { 6, 4, 704 },
-  { 6, 4, 708 },
-  { 6, 4, 712 },
-  { 6, 4, 716 },
-  { 6, 4, 720 },
-  { 6, 4, 724 },
-  { 6, 4, 728 },
-  { 6, 4, 732 },
-  { 6, 4, 736 },
-  { 6, 4, 740 },
-
-  // layer: 7
-  { 7, 4, 744 },
-  { 7, 4, 748 },
-  { 7, 4, 752 },
-  { 7, 4, 756 },
-  { 7, 4, 760 },
-  { 7, 4, 764 },
-  { 7, 4, 768 },
-  { 7, 4, 772 },
-  { 7, 4, 776 },
-  { 7, 4, 780 },
-  { 7, 4, 784 },
+  { 7, 4, 756, 0, 3, 3, 1 },
+  { 7, 4, 760, 3, 2, 3, 1 },
+  { 7, 4, 764, 2, 2, 3, 1 },
+  { 7, 4, 768, 1, 2, 3, 1 },
+  { 7, 4, 772, 0, 2, 3, 1 },
+  { 7, 4, 776, 3, 1, 3, 1 },
+  { 7, 4, 780, 2, 1, 3, 1 },
+  { 7, 4, 784, 1, 1, 3, 1 },
+  { 7, 4, 788, 0, 1, 3, 1 },
+  { 7, 4, 792, 3, 0, 3, 1 },
+  { 7, 4, 796, 2, 0, 3, 1 },
 
   // layer: 8
-  { 8, 2, 788 },
-  { 8, 2, 790 },
+  { 8, 3, 800, 0, 0, 4, 1 },
+  { 8, 3, 803, 1, 0, 4, 1 },
+  { 8, 3, 806, 2, 3, 4, 1 },
+  { 8, 3, 809, 3, 3, 4, 1 },
 
   // layer: 9
-  { 9, 2, 792 },
-  { 9, 2, 794 },
+  { 9, 3, 812, 3, 3, 4, 1 },
+  { 9, 3, 815, 2, 3, 4, 1 },
+  { 9, 3, 818, 1, 0, 4, 1 },
+  { 9, 3, 821, 0, 0, 4, 1 },
 
   // layer: 8
-  { 8, 3, 796 },
-  { 8, 3, 799 },
+  { 8, 4, 824, 2, 0, 4, 1 },
+  { 8, 4, 828, 3, 0, 4, 1 },
+  { 8, 4, 832, 1, 1, 4, 1 },
+  { 8, 4, 836, 2, 1, 4, 1 },
+  { 8, 4, 840, 3, 1, 4, 1 },
+  { 8, 4, 844, 0, 2, 4, 1 },
+  { 8, 4, 848, 1, 2, 4, 1 },
+  { 8, 4, 852, 0, 3, 4, 1 },
+  { 8, 4, 856, 1, 3, 4, 1 },
 
   // layer: 9
-  { 9, 3, 802 },
-  { 9, 3, 805 },
+  { 9, 4, 860, 1, 3, 4, 1 },
+  { 9, 4, 864, 0, 3, 4, 1 },
+  { 9, 4, 868, 1, 2, 4, 1 },
+  { 9, 4, 872, 0, 2, 4, 1 },
+  { 9, 4, 876, 3, 1, 4, 1 },
+  { 9, 4, 880, 2, 1, 4, 1 },
+  { 9, 4, 884, 1, 1, 4, 1 },
+  { 9, 4, 888, 3, 0, 4, 1 },
+  { 9, 4, 892, 2, 0, 4, 1 },
 
   // layer: 8
-  { 8, 4, 808 },
-  { 8, 4, 812 },
-  { 8, 4, 816 },
-  { 8, 4, 820 },
-  { 8, 4, 824 },
-  { 8, 4, 828 },
-  { 8, 4, 832 },
-  { 8, 4, 836 },
-  { 8, 4, 840 },
+  { 8, 5, 896, 4, 0, 4, 1 },
+  { 8, 5, 901, 0, 1, 4, 1 },
+  { 8, 5, 906, 2, 2, 4, 1 },
+  { 8, 5, 911, 3, 2, 4, 1 },
 
   // layer: 9
-  { 9, 4, 844 },
-  { 9, 4, 848 },
-  { 9, 4, 852 },
-  { 9, 4, 856 },
-  { 9, 4, 860 },
-  { 9, 4, 864 },
-  { 9, 4, 868 },
-  { 9, 4, 872 },
-  { 9, 4, 876 },
-
-  // layer: 8
-  { 8, 5, 880 },
-  { 8, 5, 885 },
-  { 8, 5, 890 },
-  { 8, 5, 895 },
-
-  // layer: 9
-  { 9, 5, 900 },
-  { 9, 5, 905 },
-  { 9, 5, 910 },
-  { 9, 5, 915 }
+  { 9, 5, 916, 3, 2, 4, 1 },
+  { 9, 5, 921, 2, 2, 4, 1 },
+  { 9, 5, 926, 0, 1, 4, 1 },
+  { 9, 5, 931, 4, 0, 4, 1 }
 
 } };
+
+//_____________________________________________________________________________
+ChipMappingMFT::ChipMappingMFT()
+{
+  // init chips info
+
+  uint32_t maxRUHW = composeFEEId(NLayers - 1, NZonesPerLayer - 1, NLinks - 1); // Max possible FEE ID
+  mFEEId2RUSW.resize(maxRUHW + 1, 0xff);
+
+  int curLayer = -1, curZone = -1, curHalf = -1;
+  int chipsOnRUType[NRUTypes]{ 0 };
+  int ctrChip = 0;
+  for (int iRU = 0; iRU < NRUTypes; ++iRU) {
+    for (int iChip = 0; iChip < NChips; ++iChip) {
+
+      auto module = ChipMappingData[iChip].module;
+      auto layer = ModuleMappingData[module].layer;
+      auto zone = ModuleMappingData[module].zone;
+      auto half = ModuleMappingData[module].half;
+      auto ruType = ZoneRUType[zone][layer / 2];
+
+      if (ruType != iRU || chipsOnRUType[iRU] == NChipsOnRUType[iRU]) {
+        continue;
+      }
+
+      if (chipsOnRUType[iRU] == 0) {
+        curLayer = layer;
+        curZone = zone;
+        curHalf = half;
+        mChipInfoEntryRU[iRU] = ctrChip;
+        mCableHW2SW[iRU].resize(NRUCables, 0xff);
+        mCableHWFirstChip[iRU].resize(NRUCables, 0xff);
+      } else {
+        if ((layer != curLayer) || (zone != curZone) || (half != curHalf)) {
+          continue;
+        }
+      }
+
+      auto& chInfo = mChipsInfo[ctrChip++];
+
+      // this is the same as ChipMappingData[iChip].chipOnRU
+      chInfo.id = chipsOnRUType[iRU];
+
+      chInfo.moduleHW = ModuleMappingData[module].connector;
+      chInfo.moduleSW = ChipMappingData[iChip].module;
+
+      chInfo.chipOnModuleSW = ChipMappingData[iChip].chipOnModule;
+      chInfo.chipOnModuleHW = chInfo.chipOnModuleSW;
+
+      chInfo.cableHW = ChipConnectorCable[chInfo.moduleHW][chInfo.chipOnModuleHW];
+      chInfo.cableSW = ChipMappingData[iChip].chipOnRU;
+
+      chInfo.chipOnCable = 0;
+
+      mCableHW2SW[iRU][chInfo.cableHW] = chInfo.cableSW;
+      mCableHWFirstChip[iRU][chInfo.cableHW] = 0;
+
+      //printf("BV===== ChipMappingMFT: RU %2d layer %d zone %d module %3d mChipsInfo[%2d] , chInfo.id %2d (%2d) chipID %3d connector %1d cable %2d \n", iRU, layer, zone, module, ctrChip - 1, chInfo.id, ChipMappingData[iChip].chipOnRU, iChip, chInfo.moduleHW, chInfo.cableHW);
+
+      ++chipsOnRUType[iRU];
+    }
+  }
+
+  int ctrRU = 0;
+  uint16_t chipCount = 0;
+  for (int iLayer = 0; iLayer < NLayers; ++iLayer) {
+    for (int iZone = 0; iZone < NZonesPerLayer; ++iZone) {
+      auto& ruInfo = mRUInfo[ctrRU];
+      ruInfo.idSW = ctrRU++;
+
+      // map FEEIds (RU read out by at most 3 GBT links) to SW ID
+      ruInfo.idHW = composeFEEId(iLayer, iZone, 0); // FEEId for link 0
+      mFEEId2RUSW[ruInfo.idHW] = ruInfo.idSW;
+      ruInfo.layer = iLayer;
+      ruInfo.ruType = ZoneRUType[iZone % 4][iLayer / 2];
+      ruInfo.nCables = NChipsOnRUType[ruInfo.ruType];
+      ruInfo.firstChipIDSW = chipCount;
+      chipCount += NChipsOnRUType[ruInfo.ruType];
+    }
+  }
+}


### PR DESCRIPTION
This is the MFT mapping connecting the sensor geometry used in the simulations with the read-out cabling and GBT formatting of the raw data. It is working with the template RawPixelReader in the same way as the ITS equivalent mapping. Because the sensor numbers of the MFT do not follow a regular pattern as in the case of ITS, a lot of them are pre-calculated and filled in arrays. The macro used to do this will come in a future commit. This mapping was checked with a simulation, coding digits to raw and decoding raw to digits, which are compared to the original ones.
