### PR TITLE
[ITS/Vertexer] Add DBScan clustering class

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/tracking/CMakeLists.txt
@@ -14,6 +14,7 @@ set(SRC
 set(HEADERS
     include/${MODULE_NAME}/ClusterLines.h
     include/${MODULE_NAME}/Tracklet.h
+    include/${MODULE_NAME}/DBScan.h
 )
 
 Set(LINKDEF src/TrackingLinkDef.h)
@@ -22,6 +23,8 @@ Set(LINKDEF src/TrackingLinkDef.h)
 set(NO_DICT_SRCS # sources not for the dictionary
     src/Cluster.cxx
     src/ROframe.cxx
+    src/Graph.cxx
+    src/DBScan.cxx
     src/IOUtils.cxx
     src/Label.cxx
     src/PrimaryVertexContext.cxx

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/ClusterLines.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/ClusterLines.h
@@ -8,8 +8,8 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifndef O2_ITSMFT_RECONSTRUCTION_CA_LINE_H_
-#define O2_ITSMFT_RECONSTRUCTION_CA_LINE_H_
+#ifndef O2_ITSMFT_TRACKING_LINE_H_
+#define O2_ITSMFT_TRACKING_LINE_H_
 
 #include <array>
 #include <vector>
@@ -107,4 +107,4 @@ class ClusterLines final
 
 } // namespace its
 } // namespace o2
-#endif /* O2_ITSMFT_RECONSTRUCTION_CA_LINE_H_ */
+#endif /* O2_ITSMFT_TRACKING_LINE_H_ */

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/DBScan.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/DBScan.h
@@ -120,7 +120,7 @@ std::vector<std::vector<int>> DBScan<T>::computeClusters()
     if (!usedVertices[cores[core]]) {
       std::vector<unsigned char> clusterFlags = this->getCluster(cores[core]);
       std::transform(usedVertices.begin(), usedVertices.end(), clusterFlags.begin(), usedVertices.begin(), std::logical_or<>());
-      clusters.emplace_back(this->getClusterIndices(clusterFlags));
+      clusters.emplace_back(std::move(this->getClusterIndices(clusterFlags)));
     }
   }
   return clusters;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/DBScan.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/DBScan.h
@@ -1,0 +1,141 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+///
+/// \file DBScan.h
+/// \brief
+///
+
+#ifndef O2_ITS_TRACKING_DBSCAN_H_
+#define O2_ITS_TRACKING_DBSCAN_H_
+
+#include <algorithm>
+#include "ITStracking/Graph.h"
+
+namespace o2
+{
+namespace its
+{
+
+typedef std::pair<int, unsigned char> State;
+
+template <typename T>
+class DBScan : Graph<T>
+{
+ public:
+  DBScan() = delete;
+  explicit DBScan(const size_t nThreads);
+  void init(std::vector<T>&, std::function<bool(const T& v1, const T& v2)>);
+  void classifyVertices(const int);
+  void classifyVertices(std::function<unsigned char(std::vector<Edge>&)> classFunction);
+  void classifyVertices(std::function<unsigned char(std::vector<Edge>&)> classFunction, std::function<bool(State&, State&)> sortFunction);
+  std::vector<State> getStates() const { return mStates; }
+  std::vector<int> getCores();
+  std::vector<std::vector<int>> computeClusters();
+
+ private:
+  std::vector<State> mStates;
+  std::function<unsigned char(std::vector<Edge>&)> mClassFunction;
+};
+
+template <typename T>
+DBScan<T>::DBScan(const size_t nThreads) : Graph<T>(nThreads)
+{
+}
+
+template <typename T>
+void DBScan<T>::init(std::vector<T>& vertices, std::function<bool(const T& v1, const T& v2)> discFunction)
+{
+  this->Graph<T>::init(vertices);
+  this->Graph<T>::computeEdges(discFunction);
+}
+
+template <typename T>
+void DBScan<T>::classifyVertices(const int nContributors)
+{
+  classifyVertices([nContributors](std::vector<o2::its::Edge>& edges) { return edges.size() == 0 ? 0 : edges.size() >= static_cast<size_t>(nContributors - 1) ? 2 : 1; },
+                   [](State& s1, State& s2) { return static_cast<int>(s1.second) > static_cast<int>(s2.second); });
+}
+
+template <typename T>
+void DBScan<T>::classifyVertices(std::function<unsigned char(std::vector<Edge>& edges)> classFunction)
+{
+  mClassFunction = classFunction;
+  const size_t size = { this->mVertices->size() };
+  mStates.resize(size);
+
+  if (!this->isMultiThreading()) {
+    for (size_t iVertex{ 0 }; iVertex < size; ++iVertex) {
+      mStates[iVertex] = std::make_pair<int, unsigned char>(iVertex, classFunction(this->getEdges()[iVertex]));
+    }
+  } else {
+    const size_t stride{ static_cast<size_t>(std::ceil(this->mVertices->size() / static_cast<size_t>(this->mExecutors.size()))) };
+    for (size_t iExecutor{ 0 }; iExecutor < this->mExecutors.size(); ++iExecutor) {
+      // We cannot pass a template function to std::thread(), using lambda instead
+      this->mExecutors[iExecutor] = std::thread(
+        [iExecutor, stride, this](const auto& classFunction) {
+          for (size_t iVertex{ iExecutor * stride }; iVertex < stride * (iExecutor + 1) && iVertex < this->mVertices->size(); ++iVertex) {
+            mStates[iVertex] = std::make_pair<int, unsigned char>(iVertex, classFunction(this->getEdges()[iVertex]));
+          }
+        },
+        mClassFunction);
+    }
+  }
+  for (auto&& thread : this->mExecutors) {
+    thread.join();
+  }
+}
+
+template <typename T>
+void DBScan<T>::classifyVertices(std::function<unsigned char(std::vector<Edge>&)> classFunction, std::function<bool(State&, State&)> sortFunction)
+{
+  classifyVertices(classFunction);
+  std::sort(mStates.begin(), mStates.end(), sortFunction);
+}
+
+template <typename T>
+std::vector<int> DBScan<T>::getCores()
+{
+  std::vector<State> cores;
+  std::vector<int> coreIndices;
+  std::copy_if(mStates.begin(), mStates.end(), std::back_inserter(cores), [](const State& state) { return state.second == 2; });
+  std::transform(cores.begin(), cores.end(), std::back_inserter(coreIndices), [](const State& state) -> int { return state.first; });
+  return coreIndices;
+}
+
+template <typename T>
+std::vector<std::vector<int>> DBScan<T>::computeClusters()
+{
+  std::vector<std::vector<int>> clusters;
+  std::vector<int> cores = getCores();
+  std::vector<unsigned char> usedVertices(this->mVertices->size(), false);
+
+  for (size_t core{ 0 }; core < cores.size(); ++core) {
+    if (!usedVertices[cores[core]]) {
+      std::vector<unsigned char> clusterFlags = this->getCluster(cores[core]);
+      std::transform(usedVertices.begin(), usedVertices.end(), clusterFlags.begin(), usedVertices.begin(), std::logical_or<>());
+      clusters.emplace_back(this->getClusterIndices(clusterFlags));
+    }
+  }
+  return clusters;
+}
+
+struct Centroid final {
+  Centroid() = default;
+  Centroid(int* indices, float* position);
+  void init();
+  static float ComputeDistance(const Centroid& c1, const Centroid& c2);
+
+  int mIndices[2];
+  float mPosition[3];
+};
+
+} // namespace its
+} // namespace o2
+#endif

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Graph.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Graph.h
@@ -1,0 +1,232 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+///
+/// \file Graph.h
+/// \brief
+///
+
+#ifndef TRACKINGITSU_INCLUDE_ALGORITHMS_H_
+#define TRACKINGITSU_INCLUDE_ALGORITHMS_H_
+
+#include <array>
+#include <cmath>
+#include <condition_variable>
+#include <functional>
+#include <iostream>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace o2
+{
+namespace its
+{
+
+typedef int Edge;
+
+class Barrier
+{
+ public:
+  explicit Barrier(std::size_t count) : count(count) {}
+  void Wait();
+
+ private:
+  std::mutex mutex;
+  std::condition_variable condition;
+  std::size_t count;
+};
+
+template <typename T>
+class Graph
+{
+ public:
+  Graph() = delete;
+  explicit Graph(const size_t nThreads = 1);
+  void init(std::vector<T>&);
+  std::vector<unsigned char> getCluster(const int);
+  std::vector<int> getClusterIndices(const int);
+  std::vector<int> getClusterIndices(const std::vector<unsigned char> /* , const int*/);
+  void computeEdges(std::function<bool(const T& v1, const T& v2)>);
+  std::vector<std::vector<Edge>> getEdges() const { return mEdges; }
+  char isMultiThreading() const { return mIsMultiThread; }
+
+  std::vector<T>* mVertices = nullptr; // Observer pointer
+  std::vector<std::thread> mExecutors; // Difficult to pass
+
+ private:
+  void findVertexEdges(std::vector<Edge>& localEdges, const T& vertex, const size_t vId, const size_t size);
+
+  // Multithread block
+  size_t mNThreads;
+  char mIsMultiThread;
+
+  // Common data members
+  std::function<bool(const T&, const T&)> mLinkFunction;
+  std::vector<std::vector<Edge>> mEdges;
+  std::vector<unsigned char> mVisited;
+};
+
+template <typename T>
+Graph<T>::Graph(const size_t nThreads) : mNThreads{ nThreads }
+{
+  mIsMultiThread = nThreads > 1 ? true : false;
+}
+
+template <typename T>
+void Graph<T>::init(std::vector<T>& vertices)
+{
+
+  // Graph initialization
+  mVertices = &vertices;
+  if (mIsMultiThread) {
+    mNThreads = std::min(static_cast<const size_t>(std::thread::hardware_concurrency()), mNThreads);
+    mExecutors.resize(mNThreads);
+  }
+
+  mEdges.resize(vertices.size());
+  mVisited.resize(vertices.size(), false);
+}
+
+template <typename T>
+void Graph<T>::computeEdges(std::function<bool(const T& v1, const T& v2)> linkFunction)
+{
+  mLinkFunction = linkFunction;
+  int tot_nedges = 0;
+  const size_t size = { mVertices->size() };
+  if (!mIsMultiThread) {
+    for (size_t iVertex{ 0 }; iVertex < size; ++iVertex) {
+      findVertexEdges(mEdges[iVertex], (*mVertices)[iVertex], iVertex, size);
+      tot_nedges += static_cast<int>(mEdges[iVertex].size());
+    }
+  } else {
+    mNThreads = std::min(static_cast<const size_t>(std::thread::hardware_concurrency()), mNThreads);
+    mExecutors.resize(mNThreads);
+    const size_t stride{ static_cast<size_t>(std::ceil(mVertices->size() / static_cast<size_t>(mExecutors.size()))) };
+    for (size_t iExecutor{ 0 }; iExecutor < mExecutors.size(); ++iExecutor) {
+      // We cannot pass a template function to std::thread(), using lambda instead
+      mExecutors[iExecutor] = std::thread(
+        [iExecutor, stride, this](const auto& linkFunction) {
+          for (size_t iVertex1{ iExecutor * stride }; iVertex1 < stride * (iExecutor + 1) && iVertex1 < mVertices->size(); ++iVertex1) {
+            for (size_t iVertex2{ 0 }; iVertex2 < mVertices->size(); ++iVertex2) {
+              if (iVertex1 != iVertex2 && linkFunction((*mVertices)[iVertex1], (*mVertices)[iVertex2])) {
+                mEdges[iVertex1].emplace_back(iVertex2);
+              }
+            }
+          }
+        },
+        mLinkFunction);
+    }
+  }
+  for (auto&& thread : mExecutors) {
+    thread.join();
+  }
+}
+template <typename T>
+void Graph<T>::findVertexEdges(std::vector<Edge>& localEdges, const T& vertex, const size_t vId, const size_t size)
+{
+  for (size_t iVertex2{ 0 }; iVertex2 < size; ++iVertex2) {
+    if (vId != iVertex2 && mLinkFunction(vertex, (*mVertices)[iVertex2])) {
+      localEdges.emplace_back(iVertex2);
+    }
+  }
+}
+
+template <typename T>
+std::vector<unsigned char> Graph<T>::getCluster(const int vertexId)
+{
+  // This method uses a BFS algorithm to return all the graph
+  // vertex ids belonging to a graph
+  std::vector<int> indices;
+  std::vector<unsigned char> visited(mVertices->size(), false);
+
+  if (!mIsMultiThread) {
+    std::queue<int> idQueue;
+    idQueue.emplace(vertexId);
+    visited[vertexId] = true;
+
+    // Consume the queue
+    while (!idQueue.empty()) {
+      const int id = idQueue.front();
+      idQueue.pop();
+      for (Edge edge : mEdges[id]) {
+        if (!visited[edge]) {
+          idQueue.emplace(edge);
+          indices.emplace_back(edge);
+          visited[edge] = true;
+        }
+      }
+    }
+  } else {
+    const size_t stride{ static_cast<size_t>(std::ceil(static_cast<float>(this->mVertices->size()) / static_cast<size_t>(this->mExecutors.size()))) };
+    std::vector<unsigned char> frontier(mVertices->size(), false);
+    std::vector<unsigned char> flags(mVertices->size(), false);
+
+    frontier[vertexId] = true;
+    int counter{ 0 };
+    while (std::any_of(frontier.begin(), frontier.end(), [](const char t) { return t; })) {
+      flags.resize(mVertices->size(), false);
+      Barrier barrier(mExecutors.size());
+      for (size_t iExecutor{ 0 }; iExecutor < this->mExecutors.size(); ++iExecutor) {
+        mExecutors[iExecutor] = std::thread(
+          [&stride, &frontier, &visited, &barrier, &flags, this](const int executorId) {
+            for (size_t iVertex{ executorId * stride }; iVertex < stride * (executorId + 1) && iVertex < this->mVertices->size(); ++iVertex) {
+              if (frontier[iVertex]) {
+                flags[iVertex] = true;
+                frontier[iVertex] = false;
+                visited[iVertex] = true;
+              }
+            }
+            barrier.Wait();
+            for (size_t iVertex{ executorId * stride }; iVertex < stride * (executorId + 1) && iVertex < this->mVertices->size(); ++iVertex) {
+              if (flags[iVertex]) {
+                for (auto& edge : mEdges[iVertex]) {
+                  if (!visited[edge]) {
+                    frontier[edge] = true;
+                  }
+                }
+              }
+            }
+          },
+          iExecutor);
+      }
+      for (auto&& thread : mExecutors) {
+        thread.join();
+      }
+    }
+  }
+  return visited;
+}
+
+template <typename T>
+std::vector<int> Graph<T>::getClusterIndices(const std::vector<unsigned char> visited)
+{
+  // Return a smaller vector only with the int IDs of the vertices belonging to cluster
+  std::vector<int> indices;
+  for (size_t iVisited{ 0 }; iVisited < visited.size(); ++iVisited) {
+    if (visited[iVisited]) {
+      indices.emplace_back(iVisited);
+    }
+  }
+  return indices;
+}
+
+template <typename T>
+std::vector<int> Graph<T>::getClusterIndices(const int vertexId)
+{
+  std::vector<unsigned char> visited = std::move(getCluster(vertexId));
+  return getClusterIndices(visited);
+}
+
+} // namespace its
+} // namespace o2
+
+#endif

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/ROframe.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/ROframe.h
@@ -12,8 +12,8 @@
 /// \brief
 ///
 
-#ifndef TRACKINGITSU_INCLUDE_ROframe_H_
-#define TRACKINGITSU_INCLUDE_ROframe_H_
+#ifndef TRACKINGITSU_INCLUDE_ROFRAME_H_
+#define TRACKINGITSU_INCLUDE_ROFRAME_H_
 
 #include <array>
 #include <vector>
@@ -179,4 +179,4 @@ inline bool ROframe::hasMCinformation() const
 } // namespace its
 } // namespace o2
 
-#endif /* TRACKINGITSU_INCLUDE_ROframe_H_ */
+#endif /* TRACKINGITSU_INCLUDE_ROFRAME_H_ */

--- a/Detectors/ITSMFT/ITS/tracking/src/DBScan.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/DBScan.cxx
@@ -1,0 +1,41 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+///
+/// \file DBScan.cxx
+/// \brief
+///
+
+#include "ITStracking/DBScan.h"
+#include "ITStracking/Definitions.h"
+#include "GPUCommonMath.h"
+
+namespace o2
+{
+namespace its
+{
+
+Centroid::Centroid(int* indices, float* position)
+{
+  for (int i{ 0 }; i < 2; ++i) {
+    mIndices[i] = indices[i];
+  }
+  for (int i{ 0 }; i < 3; ++i) {
+    mPosition[i] = position[i];
+  }
+}
+
+float Centroid::ComputeDistance(const Centroid& c1, const Centroid& c2)
+{
+  return gpu::GPUCommonMath::Sqrt((c1.mPosition[0] - c2.mPosition[0]) * (c1.mPosition[0] - c2.mPosition[0]) +
+                                  (c1.mPosition[1] - c2.mPosition[1]) * (c1.mPosition[1] - c2.mPosition[1]) +
+                                  (c1.mPosition[2] - c2.mPosition[2]) * (c1.mPosition[2] - c2.mPosition[2]));
+}
+} // namespace its
+} // namespace o2

--- a/Detectors/ITSMFT/ITS/tracking/src/Graph.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Graph.cxx
@@ -7,15 +7,27 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
+///
+/// \file Graph.cxx
+/// \brief
+///
 
-#ifdef __CLING__
+#include "ITStracking/Graph.h"
 
-#pragma link off all globals;
-#pragma link off all classes;
-#pragma link off all functions;
+namespace o2
+{
+namespace its
+{
 
-#pragma link C++ class o2::its::ClusterLines + ;
-#pragma link C++ class o2::its::Tracklet + ;
-#pragma link C++ class o2::its::Centroid + ;
+void Barrier::Wait()
+{
+  std::unique_lock<std::mutex> lock(mutex);
+  if (--count == 0) {
+    condition.notify_all();
+  } else {
+    condition.wait(lock, [this] { return count == 0; });
+  }
+}
 
-#endif
+} // namespace its
+} // namespace o2


### PR DESCRIPTION
This PR introduces:
 - really minor fixes in some ITS classes
 - a working and reusable implementation of a DBScan clustering algorithm, parallel and serial, that I would like to use it into the primary vertex finder in the ITS tracking