### PR TITLE
Fix TPC Tracking Buffer Allocation and Overflow Check + some other fixes

### DIFF
--- a/GPU/Common/GPUDefGPUParameters.h
+++ b/GPU/Common/GPUDefGPUParameters.h
@@ -78,7 +78,7 @@
 #define GPUCA_MAX_CLUSTERS (1024 * 1024 * 1024)                        //Maximum number of TPC clusters
 #define GPUCA_MAX_TRACKLETS 65536                                      //Max Number of Tracklets that can be processed by GPU Tracker, Should be divisible by 16 at least
 #define GPUCA_MAX_TRACKS 32768                                         //Max number of Tracks that can be processd by GPU Tracker per sector, must be below 2^24 for track ID format!!!
-#define GPUCA_MAX_ROWSTARTHITS 20000                                   //Maximum number of start hits per row
+#define GPUCA_MAX_ROWSTARTHITS 32768                                   //Maximum number of start hits per row
 
 #define GPUCA_TRACKER_CONSTANT_MEM 65000                               //Amount of Constant Memory to reserve
 
@@ -110,13 +110,13 @@
 
 //Error Codes for GPU Tracker
 #define GPUCA_ERROR_NONE 0
-#define GPUCA_ERROR_ROWBLOCK_TRACKLET_OVERFLOW 1
+#define GPUCA_ERROR_ROWSTARTHIT_OVERFLOW 1
 #define GPUCA_ERROR_TRACKLET_OVERFLOW 2
 #define GPUCA_ERROR_TRACK_OVERFLOW 3
-#define GPUCA_ERROR_SCHEDULE_COLLISION 4
-#define GPUCA_ERROR_WRONG_ROW 5
-#define GPUCA_ERROR_STARTHIT_OVERFLOW 6
-#define GPUCA_ERROR_STRINGS {"GPUCA_ERROR_NONE", "GPUCA_ERROR_ROWBLOCK_TRACKLET_OVERFLOW", "GPUCA_ERROR_TRACKLET_OVERFLOW", "GPUCA_ERROR_TRACK_OVERFLOW", "GPUCA_ERROR_SCHEDULE_COLLISION", "GPUCA_ERROR_WRONG_ROW", "GPUCA_ERROR_STARTHIT_OVERFLOW"}
+#define GPUCA_ERROR_TRACK_HIT_OVERFLOW 4
+#define GPUCA_ERROR_GLOBAL_TRACKING_TRACK_OVERFLOW 5
+#define GPUCA_ERROR_GLOBAL_TRACKING_TRACK_HIT_OVERFLOW 6
+#define GPUCA_ERROR_STRINGS {"GPUCA_ERROR_NONE", "GPUCA_ERROR_ROWSTARTHIT_OVERFLOW", "GPUCA_ERROR_TRACKLET_OVERFLOW", "GPUCA_ERROR_TRACK_OVERFLOW", "GPUCA_ERROR_TRACK_HIT_OVERFLOW", "GPUCA_ERROR_GLOBAL_TRACKING_TRACK_OVERFLOW", "GPUCA_ERROR_GLOBAL_TRACKING_TRACK_HIT_OVERFLOW"}
 
 // clang-format on
 #endif

--- a/GPU/GPUTracking/Base/GPUReconstructionCPU.cxx
+++ b/GPU/GPUTracking/Base/GPUReconstructionCPU.cxx
@@ -158,8 +158,9 @@ int GPUReconstructionCPU::RunChains()
   }
 
   for (unsigned int i = 0; i < mChains.size(); i++) {
-    if (mChains[i]->RunChain()) {
-      return 1;
+    int retVal = mChains[i]->RunChain();
+    if (retVal) {
+      return retVal;
     }
   }
 

--- a/GPU/GPUTracking/Base/GPUReconstructionTimeframe.cxx
+++ b/GPU/GPUTracking/Base/GPUReconstructionTimeframe.cxx
@@ -18,7 +18,9 @@
 #include "AliHLTTPCClusterMCData.h"
 #include "GPUTPCMCInfo.h"
 #include "GPUTPCClusterData.h"
+#include "AliHLTTPCRawCluster.h"
 #include "ClusterNativeAccessExt.h"
+#include "TPCFastTransform.h"
 
 #include <cstdio>
 #include <exception>
@@ -33,18 +35,22 @@ static auto& config = configStandalone.configTF;
 
 GPUReconstructionTimeframe::GPUReconstructionTimeframe(GPUChainTracking* chain, int (*read)(int), int nEvents) : mChain(chain), mReadEvent(read), mNEventsInDirectory(nEvents), mDisUniReal(0., 1.), mRndGen1(configStandalone.seed), mRndGen2(mDisUniInt(mRndGen1))
 {
-  mMaxBunchesFull = mTimeOrbit / configStandalone.configTF.bunchSpacing;
-  mMaxBunches = (mTimeOrbit - configStandalone.configTF.abortGapTime) / configStandalone.configTF.bunchSpacing;
+  mMaxBunchesFull = TIME_ORBIT / config.bunchSpacing;
+  mMaxBunches = (TIME_ORBIT - config.abortGapTime) / config.bunchSpacing;
 
-  if (configStandalone.configTF.bunchSim) {
-    if (configStandalone.configTF.bunchCount * configStandalone.configTF.bunchTrainCount > mMaxBunches) {
+  if (config.overlayRaw && chain->GetTPCTransform() == nullptr) {
+    printf("Overlay Raw Events requires TPC Fast Transform\n");
+    throw std::exception();
+  }
+  if (config.bunchSim) {
+    if (config.bunchCount * config.bunchTrainCount > mMaxBunches) {
       printf("Invalid timeframe settings: too many colliding bunches requested!\n");
       throw std::exception();
     }
-    mTrainDist = mMaxBunches / configStandalone.configTF.bunchTrainCount;
-    mCollisionProbability = (float)configStandalone.configTF.interactionRate * (float)(mMaxBunchesFull * configStandalone.configTF.bunchSpacing / 1e9f) / (float)(configStandalone.configTF.bunchCount * configStandalone.configTF.bunchTrainCount);
-    printf("Timeframe settings: %d trains of %d bunches, bunch spacing: %d, train spacing: %dx%d, filled bunches %d / %d (%d), collision probability %f, mixing %d events\n", configStandalone.configTF.bunchTrainCount, configStandalone.configTF.bunchCount, configStandalone.configTF.bunchSpacing,
-           mTrainDist, configStandalone.configTF.bunchSpacing, configStandalone.configTF.bunchCount * configStandalone.configTF.bunchTrainCount, mMaxBunches, mMaxBunchesFull, mCollisionProbability, mNEventsInDirectory);
+    mTrainDist = mMaxBunches / config.bunchTrainCount;
+    mCollisionProbability = (float)config.interactionRate * (float)(mMaxBunchesFull * config.bunchSpacing / 1e9f) / (float)(config.bunchCount * config.bunchTrainCount);
+    printf("Timeframe settings: %d trains of %d bunches, bunch spacing: %d, train spacing: %dx%d, filled bunches %d / %d (%d), collision probability %f, mixing %d events\n", config.bunchTrainCount, config.bunchCount, config.bunchSpacing,
+           mTrainDist, config.bunchSpacing, config.bunchCount * config.bunchTrainCount, mMaxBunches, mMaxBunchesFull, mCollisionProbability, mNEventsInDirectory);
   }
 
   mEventStride = configStandalone.seed;
@@ -55,20 +61,28 @@ GPUReconstructionTimeframe::GPUReconstructionTimeframe(GPUChainTracking* chain, 
   }
 }
 
-int GPUReconstructionTimeframe::ReadEventShifted(int iEvent, float shift, float minZ, float maxZ, bool silent)
+int GPUReconstructionTimeframe::ReadEventShifted(int iEvent, float shiftZ, float minZ, float maxZ, bool silent)
 {
   mReadEvent(iEvent);
-
-  if (shift != 0.) {
+  if (config.overlayRaw) {
+    float shiftTTotal = (((double)config.timeFrameLen - DRIFT_TIME) * ((double)TPCZ / (double)DRIFT_TIME) - shiftZ) / mChain->GetTPCTransform()->getVDrift();
+    for (unsigned int iSlice = 0; iSlice < NSLICES; iSlice++) {
+      for (unsigned int j = 0; j < mChain->mIOPtrs.nRawClusters[iSlice]; j++) {
+        auto& tmp = mChain->mIOMem.rawClusters[iSlice][j];
+        tmp.fTime += shiftTTotal;
+      }
+    }
+  }
+  if (shiftZ != 0.) {
     for (unsigned int iSlice = 0; iSlice < NSLICES; iSlice++) {
       for (unsigned int j = 0; j < mChain->mIOPtrs.nClusterData[iSlice]; j++) {
         auto& tmp = mChain->mIOMem.clusterData[iSlice][j];
-        tmp.z += iSlice < NSLICES / 2 ? shift : -shift;
+        tmp.z += iSlice < NSLICES / 2 ? shiftZ : -shiftZ;
       }
     }
     for (unsigned int i = 0; i < mChain->mIOPtrs.nMCInfosTPC; i++) {
       auto& tmp = mChain->mIOMem.mcInfosTPC[i];
-      tmp.z += i < NSLICES / 2 ? shift : -shift;
+      tmp.z += i < NSLICES / 2 ? shiftZ : -shiftZ;
     }
   }
 
@@ -79,11 +93,15 @@ int GPUReconstructionTimeframe::ReadEventShifted(int iEvent, float shift, float 
     unsigned int currentClusterTotal = 0;
     for (unsigned int iSlice = 0; iSlice < NSLICES; iSlice++) {
       unsigned int currentClusterSlice = 0;
+      bool doRaw = config.overlayRaw && mChain->mIOPtrs.nClusterData[iSlice] == mChain->mIOPtrs.nRawClusters[iSlice];
       for (unsigned int i = 0; i < mChain->mIOPtrs.nClusterData[iSlice]; i++) {
         float sign = iSlice < NSLICES / 2 ? 1 : -1;
         if (sign * mChain->mIOMem.clusterData[iSlice][i].z >= minZ && sign * mChain->mIOMem.clusterData[iSlice][i].z <= maxZ) {
           if (currentClusterSlice != i) {
             mChain->mIOMem.clusterData[iSlice][currentClusterSlice] = mChain->mIOMem.clusterData[iSlice][i];
+            if (doRaw) {
+              mChain->mIOMem.rawClusters[iSlice][currentClusterSlice] = mChain->mIOMem.rawClusters[iSlice][i];
+            }
           }
           if (mChain->mIOPtrs.nMCLabelsTPC > currentClusterTotal && nClusters != currentClusterTotal) {
             mChain->mIOMem.mcLabelsTPC[nClusters] = mChain->mIOMem.mcLabelsTPC[currentClusterTotal];
@@ -98,8 +116,13 @@ int GPUReconstructionTimeframe::ReadEventShifted(int iEvent, float shift, float 
         currentClusterTotal++;
       }
       mChain->mIOPtrs.nClusterData[iSlice] = currentClusterSlice;
+      if (doRaw) {
+        mChain->mIOPtrs.nRawClusters[iSlice] = currentClusterSlice;
+      }
     }
-    mChain->mIOPtrs.nMCLabelsTPC = nClusters;
+    if (mChain->mIOPtrs.nMCLabelsTPC) {
+      mChain->mIOPtrs.nMCLabelsTPC = nClusters;
+    }
   } else {
     for (unsigned int i = 0; i < NSLICES; i++) {
       nClusters += mChain->mIOPtrs.nClusterData[i];
@@ -124,19 +147,32 @@ void GPUReconstructionTimeframe::MergeShiftedEvents()
     auto& ptr = std::get<0>(mShiftedEvents[i]);
     for (unsigned int j = 0; j < NSLICES; j++) {
       mChain->mIOPtrs.nClusterData[j] += ptr.nClusterData[j];
+      if (config.overlayRaw) {
+        mChain->mIOPtrs.nRawClusters[j] += ptr.nRawClusters[j];
+      }
     }
     mChain->mIOPtrs.nMCLabelsTPC += ptr.nMCLabelsTPC;
     mChain->mIOPtrs.nMCInfosTPC += ptr.nMCInfosTPC;
     SetDisplayInformation(i);
   }
   unsigned int nClustersTotal = 0;
+  unsigned int nClustersTotalRaw = 0;
   unsigned int nClustersSliceOffset[NSLICES] = { 0 };
   for (unsigned int i = 0; i < NSLICES; i++) {
     nClustersSliceOffset[i] = nClustersTotal;
     nClustersTotal += mChain->mIOPtrs.nClusterData[i];
+    nClustersTotalRaw += mChain->mIOPtrs.nRawClusters[i];
   }
-  const bool doLabels = nClustersTotal == mChain->mIOPtrs.nMCLabelsTPC;
+  if (nClustersTotalRaw && nClustersTotalRaw != nClustersTotal) {
+    printf("Inconsitency between raw clusters and cluster data\n");
+    throw std::exception();
+  }
+  if (mChain->mIOPtrs.nMCLabelsTPC && nClustersTotal != mChain->mIOPtrs.nMCLabelsTPC) {
+    printf("Inconsitency between TPC clusters and MC labels\n");
+    throw std::exception();
+  }
   mChain->AllocateIOMemory();
+  mChain->mIOPtrs.clustersNative = nullptr;
 
   unsigned int nTrackOffset = 0;
   unsigned int nClustersEventOffset[NSLICES] = { 0 };
@@ -145,12 +181,15 @@ void GPUReconstructionTimeframe::MergeShiftedEvents()
     unsigned int inEventOffset = 0;
     for (unsigned int j = 0; j < NSLICES; j++) {
       memcpy((void*)&mChain->mIOMem.clusterData[j][nClustersEventOffset[j]], (void*)ptr.clusterData[j], ptr.nClusterData[j] * sizeof(ptr.clusterData[j][0]));
-      if (doLabels) {
+      if (nClustersTotalRaw) {
+        memcpy((void*)&mChain->mIOMem.rawClusters[j][nClustersEventOffset[j]], (void*)ptr.rawClusters[j], ptr.nRawClusters[j] * sizeof(ptr.rawClusters[j][0]));
+      }
+      if (mChain->mIOPtrs.nMCLabelsTPC) {
         memcpy((void*)&mChain->mIOMem.mcLabelsTPC[nClustersSliceOffset[j] + nClustersEventOffset[j]], (void*)&ptr.mcLabelsTPC[inEventOffset], ptr.nClusterData[j] * sizeof(ptr.mcLabelsTPC[0]));
       }
       for (unsigned int k = 0; k < ptr.nClusterData[j]; k++) {
         mChain->mIOMem.clusterData[j][nClustersEventOffset[j] + k].id = nClustersSliceOffset[j] + nClustersEventOffset[j] + k;
-        if (doLabels) {
+        if (mChain->mIOPtrs.nMCLabelsTPC) {
           for (int l = 0; l < 3; l++) {
             auto& label = mChain->mIOMem.mcLabelsTPC[nClustersSliceOffset[j] + nClustersEventOffset[j] + k].fClusterID[l];
             if (label.fMCID >= 0) {
@@ -168,18 +207,20 @@ void GPUReconstructionTimeframe::MergeShiftedEvents()
     nTrackOffset += ptr.nMCInfosTPC;
   }
 
+  printf("Merged %d events, %u clusters total\n", (int)mShiftedEvents.size(), nClustersTotal);
+
   mShiftedEvents.clear();
 }
 
 int GPUReconstructionTimeframe::LoadCreateTimeFrame(int iEvent)
 {
-  if (configStandalone.configTF.nTotalInTFEvents && mNTotalCollisions >= configStandalone.configTF.nTotalInTFEvents) {
+  if (config.nTotalInTFEvents && mNTotalCollisions >= config.nTotalInTFEvents) {
     return (2);
   }
 
-  long long int nBunch = -mDriftTime / config.bunchSpacing;
+  long long int nBunch = -DRIFT_TIME / config.bunchSpacing;
   long long int lastBunch = config.timeFrameLen / config.bunchSpacing;
-  long long int lastTFBunch = lastBunch - mDriftTime / config.bunchSpacing;
+  long long int lastTFBunch = lastBunch - DRIFT_TIME / config.bunchSpacing;
   int nCollisions = 0, nBorderCollisions = 0, nTrainCollissions = 0, nMultipleCollisions = 0, nTrainMultipleCollisions = 0;
   int nTrain = 0;
   int mcMin = -1, mcMax = -1;
@@ -227,8 +268,8 @@ int GPUReconstructionTimeframe::LoadCreateTimeFrame(int iEvent)
             mSimBunchNoRepeatEvent++;
           }
           mEventUsed[useEvent] = 1;
-          double shift = (double)nBunch * (double)config.bunchSpacing * (double)mTPCZ / (double)mDriftTime;
-          int nClusters = ReadEventShifted(useEvent, shift, 0, (double)config.timeFrameLen * mTPCZ / mDriftTime, true);
+          double shift = (double)nBunch * (double)config.bunchSpacing * (double)TPCZ / (double)DRIFT_TIME;
+          int nClusters = ReadEventShifted(useEvent, shift, 0, (double)config.timeFrameLen * (double)TPCZ / (double)DRIFT_TIME, true);
           if (nClusters < 0) {
             printf("Unexpected error\n");
             return (1);
@@ -261,12 +302,12 @@ int GPUReconstructionTimeframe::LoadCreateTimeFrame(int iEvent)
     nBunch += mMaxBunchesFull - mTrainDist * config.bunchTrainCount;
   }
   mNTotalCollisions += nCollisions;
-  printf("Timeframe statistics: collisions: %d+%d in %d trains (inside / outside), average rate %f (pile up: in bunch %d, in train %d)\n", nCollisions, nBorderCollisions, nTrainCollissions, (float)nCollisions / (float)(config.timeFrameLen - mDriftTime) * 1e9, nMultipleCollisions,
+  printf("Timeframe statistics: collisions: %d+%d in %d trains (inside / outside), average rate %f (pile up: in bunch %d, in train %d)\n", nCollisions, nBorderCollisions, nTrainCollissions, (float)nCollisions / (float)(config.timeFrameLen - DRIFT_TIME) * 1e9, nMultipleCollisions,
          nTrainMultipleCollisions);
   MergeShiftedEvents();
   printf("\tTotal clusters: %u, MC Labels %d, MC Infos %d\n", nTotalClusters, (int)mChain->mIOPtrs.nMCLabelsTPC, (int)mChain->mIOPtrs.nMCInfosTPC);
 
-  if (!config.noBorder) {
+  if (!config.noBorder && mChain->GetQA()) {
     mChain->GetQA()->SetMCTrackRange(mcMin, mcMax);
   }
   return (0);
@@ -280,11 +321,7 @@ int GPUReconstructionTimeframe::LoadMergedEvents(int iEvent)
       if (config.randomizeDistance) {
         shift = mDisUniReal(mRndGen2);
         if (config.shiftFirstEvent) {
-          if (iEventInTimeframe == 0) {
-            shift = shift * config.averageDistance;
-          } else {
-            shift = (iEventInTimeframe + shift) * config.averageDistance;
-          }
+          shift = (iEventInTimeframe + shift) * config.averageDistance;
         } else {
           if (iEventInTimeframe == 0) {
             shift = 0;

--- a/GPU/GPUTracking/Base/GPUReconstructionTimeframe.h
+++ b/GPU/GPUTracking/Base/GPUReconstructionTimeframe.h
@@ -40,8 +40,13 @@ class GPUReconstructionTimeframe
   GPUReconstructionTimeframe(GPUChainTracking* rec, int (*read)(int), int nEvents);
   int LoadCreateTimeFrame(int iEvent);
   int LoadMergedEvents(int iEvent);
-  int ReadEventShifted(int i, float shift, float minZ = -1e6, float maxZ = -1e6, bool silent = false);
+  int ReadEventShifted(int i, float shiftZ, float minZ = -1e6, float maxZ = -1e6, bool silent = false);
   void MergeShiftedEvents();
+
+  static constexpr int ORBIT_RATE = 11245;
+  static constexpr int DRIFT_TIME = 93000;
+  static constexpr int TPCZ = 250;
+  static constexpr int TIME_ORBIT = 1000000000 / ORBIT_RATE;
 
  private:
   constexpr static unsigned int NSLICES = GPUReconstruction::NSLICES;
@@ -59,10 +64,6 @@ class GPUReconstructionTimeframe
 
   int mTrainDist = 0;
   float mCollisionProbability = 0.;
-  const int mOrbitRate = 11245;
-  const int mDriftTime = 93000;
-  const int mTPCZ = 250;
-  const int mTimeOrbit = 1000000000 / mOrbitRate;
   int mMaxBunchesFull;
   int mMaxBunches;
 

--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -277,6 +277,7 @@ int GPUChainTracking::PrepareEvent()
       offset += mIOPtrs.nClusterData[iSlice];
     }
   }
+  printf("Event has %d TPC Clusters\n", offset);
   processors()->tpcCompressor.mMaxClusters = offset;
 
   if (mRec->IsGPU()) {
@@ -570,6 +571,9 @@ void GPUChainTracking::ConvertRun2RawToNative()
     mIOPtrs.rawClusters[i] = nullptr;
     mIOPtrs.nRawClusters[i] = 0;
     mIOMem.rawClusters[i].reset(nullptr);
+    mIOPtrs.clusterData[i] = nullptr;
+    mIOPtrs.nClusterData[i] = 0;
+    mIOMem.clusterData[i].reset(nullptr);
   }
   mIOPtrs.clustersNative = mClusterNativeAccess.get();
 }

--- a/GPU/GPUTracking/Merger/GPUTPCGMMerger.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMMerger.cxx
@@ -1234,13 +1234,7 @@ void GPUTPCGMMerger::CollectMergedTracks()
 void GPUTPCGMMerger::PrepareClustersForFit()
 {
   unsigned int maxId = 0;
-  if (mCAParam->rec.NonConsecutiveIDs) {
-    maxId = mNOutputTrackClusters;
-  } else {
-    for (int i = 0; i < NSLICES; i++) {
-      maxId += mSliceTrackers[i].NHitsTotal();
-    }
-  }
+  maxId = mCAParam->rec.NonConsecutiveIDs ? mNOutputTrackClusters : mNMaxClusters;
   if (maxId > mNMaxClusters) {
     throw std::runtime_error("mNMaxClusters too small");
   }

--- a/GPU/GPUTracking/Merger/GPUTPCGMTrackParam.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMTrackParam.cxx
@@ -613,6 +613,9 @@ GPUd() void GPUTPCGMTrackParam::AttachClustersMirror(const GPUTPCGMMerger* Merge
   float b = prop.GetBz(prop.GetAlpha(), mX, mP[0], mP[1]);
 
   int count = CAMath::Abs((toX - X) / 0.5f) + 0.5f;
+  if (count == 0) {
+    return;
+  }
   float dx = (toX - X) / count;
   const float myRowX = Merger->Param().tpcGeometry.Row2X(iRow);
   // printf("AttachMirror\n");

--- a/GPU/GPUTracking/SliceTracker/GPUTPCTracker.h
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCTracker.h
@@ -54,7 +54,6 @@ class GPUTPCTracker : public GPUProcessor
 
   struct StructGPUParameters {
     GPUAtomic(unsigned int) nextTracklet; // Next Tracklet to process
-    int gpuError;                         // Signalizes error on GPU during GPU Reconstruction, kind of return value
   };
 
   MEM_CLASS_PRE2()
@@ -69,6 +68,7 @@ class GPUTPCTracker : public GPUProcessor
     int nLocalTracks;                   // number of reconstructed tracks before global tracking
     GPUAtomic(unsigned int) nTrackHits; // number of track hits
     int nLocalTrackHits;                // see above
+    int kernelError;                    // Error code during kernel execution
     StructGPUParameters gpuParameters;  // GPU parameters
   };
 
@@ -101,10 +101,11 @@ class GPUTPCTracker : public GPUProcessor
   GPUh() MakeType(const MEM_LG(GPUTPCRow) &) Row(const GPUTPCHitId& HitId) const { return mData.Row(HitId.RowIndex()); }
 
   GPUhd() GPUTPCSliceOutput* Output() const { return mOutput; }
-
-  GPUh() GPUglobalref() commonMemoryStruct* CommonMemory() const { return (mCommonMem); }
-
 #endif
+  GPUhdni() GPUglobalref() commonMemoryStruct* CommonMemory() const
+  {
+    return (mCommonMem);
+  }
 
   MEM_CLASS_PRE2()
   GPUd() void GetErrors2(int iRow, const MEM_LG2(GPUTPCTrackParam) & t, float& ErrY2, float& ErrZ2) const
@@ -150,8 +151,11 @@ class GPUTPCTracker : public GPUProcessor
 
   GPUhd() GPUglobalref() const MEM_GLOBAL(GPUTPCRow) & Row(int rowIndex) const { return mData.Row(rowIndex); }
 
-  GPUhd() int NHitsTotal() const { return mData.NumberOfHits(); }
-  GPUhd() int NMaxTracks() const { return mNMaxTracks; }
+  GPUhd() unsigned int NHitsTotal() const { return mData.NumberOfHits(); }
+  GPUhd() unsigned int NMaxTracklets() const { return mNMaxTracklets; }
+  GPUhd() unsigned int NMaxTracks() const { return mNMaxTracks; }
+  GPUhd() unsigned int NMaxTrackHits() const { return mNMaxTrackHits; }
+  GPUhd() unsigned int NMaxStartHits() const { return mNMaxStartHits; }
 
   MEM_TEMPLATE()
   GPUd() void SetHitLinkUpData(const MEM_TYPE(GPUTPCRow) & row, int hitIndex, calink v) { mData.SetHitLinkUpData(row, hitIndex, v); }
@@ -240,7 +244,7 @@ class GPUTPCTracker : public GPUProcessor
     float fSortVal; // Value to sort for
   };
 
-  void PerformGlobalTracking(GPUTPCTracker& sliceLeft, GPUTPCTracker& sliceRight, unsigned int MaxTracksLeft, unsigned int MaxTracksRight);
+  void PerformGlobalTracking(GPUTPCTracker& sliceLeft, GPUTPCTracker& sliceRight);
 
   void* LinkTmpMemory() { return mLinkTmpMemory; }
 
@@ -261,10 +265,10 @@ class GPUTPCTracker : public GPUProcessor
   MEM_LG(GPUTPCSliceData)
   mData; // The SliceData object. It is used to encapsulate the storage in memory from the access
 
-  int mNMaxStartHits;
-  int mNMaxTracklets;
-  int mNMaxTracks;
-  int mNMaxTrackHits;
+  unsigned int mNMaxStartHits;
+  unsigned int mNMaxTracklets;
+  unsigned int mNMaxTracks;
+  unsigned int mNMaxTrackHits;
   short mMemoryResLinksScratch;
   short mMemoryResScratch;
   short mMemoryResScratchHost;

--- a/GPU/GPUTracking/SliceTracker/GPUTPCTrackerDump.cxx
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCTrackerDump.cxx
@@ -151,9 +151,6 @@ void GPUTPCTracker::DumpTrackletHits(std::ostream& out)
   if (nTracklets < 0) {
     nTracklets = 0;
   }
-  if (nTracklets > GPUCA_MAX_TRACKLETS) {
-    nTracklets = GPUCA_MAX_TRACKLETS;
-  }
   out << "Tracklets: (Slice" << mISlice << ") (" << nTracklets << ")" << std::endl;
   if (mRec->GetDeviceProcessingSettings().comparableDebutOutput) {
     GPUTPCHitId* tmpIds = new GPUTPCHitId[nTracklets];
@@ -173,7 +170,7 @@ void GPUTPCTracker::DumpTrackletHits(std::ostream& out)
           if (tmpTracklets[i].NHits()) {
             for (int k = tmpTracklets[i].FirstRow(); k <= tmpTracklets[i].LastRow(); k++) {
               const int pos = k * nTracklets + j;
-              if (pos < 0 || pos >= GPUCA_MAX_TRACKLETS * GPUCA_ROW_COUNT) {
+              if (pos < 0 || pos >= (int)mNMaxTracklets * GPUCA_ROW_COUNT) {
                 printf("internal error: invalid tracklet position k=%d j=%d pos=%d\n", k, j, pos);
               } else {
                 mTrackletRowHits[pos] = tmpHits[k * nTracklets + i];

--- a/GPU/GPUTracking/SliceTracker/GPUTPCTracklet.h
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCTracklet.h
@@ -44,11 +44,11 @@ class GPUTPCTracklet
   GPUhd() int HitWeight() const { return mHitWeight; }
   GPUhd() MakeType(const MEM_LG(GPUTPCBaseTrackParam) &) Param() const { return mParam; }
 #ifndef GPUCA_EXTERN_ROW_HITS
-  GPUhd() int RowHit(int i) const
+  GPUhd() calink RowHit(int i) const
   {
     return mRowHits[i];
   }
-  GPUhd() const int* RowHits() const { return (mRowHits); }
+  GPUhd() const calink* RowHits() const { return (mRowHits); }
   GPUhd() void SetRowHit(int irow, int ih) { mRowHits[irow] = ih; }
 #endif // GPUCA_EXTERN_ROW_HITS
 

--- a/GPU/GPUTracking/Standalone/qconfigoptions.h
+++ b/GPU/GPUTracking/Standalone/qconfigoptions.h
@@ -19,7 +19,7 @@ EndConfig()
 
 BeginSubConfig(structConfigTF, configTF, configStandalone, "TF", 't', "Timeframe settings")
 AddOption(nMerge, int, 0, "merge", 0, "Merge n events in a timeframe", min(0))
-AddOption(averageDistance, float, 50., "mergeDist", 0, "Average distance of events merged into timeframe", min(0.f))
+AddOption(averageDistance, float, 50., "mergeDist", 0, "Average distance in cm of events merged into timeframe", min(0.f))
 AddOption(randomizeDistance, bool, true, "mergeRand", 0, "Randomize distance around average distance of merged events")
 AddOption(shiftFirstEvent, bool, true, "mergeFirst", 0, "Also shift the first event in z when merging events to a timeframe")
 AddOption(bunchSim, bool, false, "simBunches", 0, "Simulate correct bunch interactions instead of placing only the average number of events, ignores the merge parameters")
@@ -33,6 +33,7 @@ AddOption(noBorder, bool, false, "noBorder", 0, "Do not simulate border effects 
 AddOption(noEventRepeat, int, 0, "noEventRepeat", 0, "0: Place random events, 1: Place events in timeframe one after another, 2: Place random events but do not repat", def(1))
 AddOption(nTotalInTFEvents, int, 0, "nTotal", 0, "Total number of collisions to be placed in the interior of all time frames (excluding borders)")
 AddOption(eventStride, int, 0, "eventStride", 0, "Do not select random event, but walk over array of events in stride steps")
+AddOption(overlayRaw, bool, false, "overlayRaw", 0, "Overlay raw TPC data instead of spatial clusters")
 AddHelp("help", 'h')
 EndConfig()
 

--- a/GPU/GPUTracking/Standalone/standalone.cxx
+++ b/GPU/GPUTracking/Standalone/standalone.cxx
@@ -512,15 +512,15 @@ int main(int argc, char** argv)
               nClustersTotal += nClusters;
               nEventsProcessed++;
             }
-          }
 
-          if (chainTracking->GetRecoSteps() & GPUReconstruction::RecoStep::TRDTracking) {
-            int nTracklets = 0;
-            for (int k = 0; k < chainTracking->GetTRDTracker()->NTracks(); k++) {
-              auto& trk = chainTracking->GetTRDTracker()->Tracks()[k];
-              nTracklets += trk.GetNtracklets();
+            if (chainTracking->GetRecoSteps() & GPUReconstruction::RecoStep::TRDTracking) {
+              int nTracklets = 0;
+              for (int k = 0; k < chainTracking->GetTRDTracker()->NTracks(); k++) {
+                auto& trk = chainTracking->GetTRDTracker()->Tracks()[k];
+                nTracklets += trk.GetNtracklets();
+              }
+              printf("TRD Tracker reconstructed %d tracks (%d tracklets)\n", chainTracking->GetTRDTracker()->NTracks(), nTracklets);
             }
-            printf("TRD Tracker reconstructed %d tracks (%d tracklets)\n", chainTracking->GetTRDTracker()->NTracks(), nTracklets);
           }
 
           if (tmpRetVal == 2) {

--- a/GPU/GPUTracking/Standalone/standalone.cxx
+++ b/GPU/GPUTracking/Standalone/standalone.cxx
@@ -469,7 +469,7 @@ int main(int argc, char** argv)
 
           int tmpRetVal = rec->RunChains();
 
-          if (tmpRetVal == 0) {
+          if (tmpRetVal == 0 || tmpRetVal == 2) {
             int nTracks = 0, nClusters = 0, nAttachedClusters = 0, nAttachedClustersFitted = 0;
             for (int k = 0; k < chainTracking->GetTPCMerger().NOutputTracks(); k++) {
               if (chainTracking->GetTPCMerger().OutputTracks()[k].OK()) {

--- a/GPU/GPUTracking/Standalone/tools/testCL.sh
+++ b/GPU/GPUTracking/Standalone/tools/testCL.sh
@@ -9,7 +9,7 @@ LLVM_SPIRV=llvm-spirv
 #COMPILER=/home/qon/llvm/install/bin/clang++
 #LLVM_SPIRV=/home/qon/llvm/build-spirv/tools/llvm-spirv/llvm-spirv
 
-INCLUDES="-I ../. -I ../Base -I ../SliceTracker -I ../Common -I ../Merger -I ../TRDTracking -I../ITS -I../dEdx -I../TPCConvert -I../TPCFastTransformation -I../DataCompression -I$HOME/alice/O2/DataFormats/Detectors/TPC/include -I$HOME/alice/O2/Detectors/Base/include -I$HOME/alice/O2/Detectors/Base/src -I$HOME/alice/O2/Common/MathUtils/include -I$HOME/alice/O2/Detectors/TRD/base/include -I$HOME/alice/O2/Detectors/TRD/base/src -I$HOME/alice/O2/Detectors/ITSMFT/ITS/tracking/include -I$HOME/alice/O2/Common/Constants/include"
+INCLUDES="-I ../. -I ../Base -I ../SliceTracker -I ../Common -I ../Merger -I ../TRDTracking -I../ITS -I../dEdx -I../TPCConvert -I../TPCFastTransformation -I../DataCompression -I$HOME/alice/O2/DataFormats/Detectors/TPC/include -I$HOME/alice/O2/Detectors/Base/include -I$HOME/alice/O2/Detectors/Base/src -I$HOME/alice/O2/Common/MathUtils/include -I$HOME/alice/O2/Detectors/TRD/base/include -I$HOME/alice/O2/Detectors/TRD/base/src -I$HOME/alice/O2/Detectors/ITSMFT/ITS/tracking/include -I$HOME/alice/O2/Detectors/ITSMFT/ITS/tracking/cuda/include -I$HOME/alice/O2/Common/Constants/include"
 DEFINES="-DGPUCA_STANDALONE -DGPUCA_ENABLE_GPU_TRACKER -DGPUCA_GPULIBRARY=OCL -DNDEBUG -D__OPENCLCPP__ -DHAVE_O2HEADERS"
 
 echo Test1 - Preprocess

--- a/GPU/GPUTracking/Standalone/utils/qconfig.h
+++ b/GPU/GPUTracking/Standalone/utils/qconfig.h
@@ -143,7 +143,8 @@
   if (subConfig == nullptr || strcmp(subConfig, followSub == 2 ? qon_mxstr(name) : preoptname) == 0) {                                                                                                    \
     constexpr const char* preopt = preoptname;                                                                                                                                                            \
     constexpr const char preoptshort = preoptnameshort;                                                                                                                                                   \
-    printf("\n  %s: (--%s%s%c)\n", descr, preoptname, preoptnameshort == 0 ? "" : " or -", (int)preoptnameshort);
+    char argBuffer[2] = { preoptnameshort, 0 };                                                                                                                                                           \
+    printf("\n  %s: (--%s%s%s)\n", descr, preoptname, preoptnameshort == 0 ? "" : " or -", argBuffer);
 #define EndConfig() }
 #define AddHelp(cmd, cmdshort) qConfigType<void*>::qConfigHelpOption("help", "help", nullptr, cmd, cmdshort, preopt, preoptshort, 3, "Show usage information");
 #define AddHelpAll(cmd, cmdshort) qConfigType<void*>::qConfigHelpOption("help all", "help all", nullptr, cmd, cmdshort, preopt, preoptshort, 3, "Show usage info including all subparameters");

--- a/GPU/TPCFastTransformation/TPCFastTransform.h
+++ b/GPU/TPCFastTransformation/TPCFastTransform.h
@@ -186,6 +186,9 @@ class TPCFastTransform : public FlatObject
   /// Gives Z length of the TPC, side C
   GPUd() float getTPCzLengthC() const { return mTPCzLengthC; }
 
+  /// Return mVDrift in cm / time bin
+  GPUd() float getVDrift() const { return mVdrift; }
+
   /// Print method
   void Print() const;
 


### PR DESCRIPTION
- Should never segfault when a buffer is exceeded, but always return with an error.
- Memory allocation on the CPU is no longer limited by the constants (will just allocate more if insufficient). (@shahor02 : Should be able to process arbitrary length time frames now, as long as nCl < 2 billion, and if there is enough memory. No need to change the constants any more).
- Overlaying TPC events into time frames now also works with cluster in native TPC coordinates (needed for running tpc conversion and compression).
- Fix a possible FPE (this wasn't seen within O2, so I guess we don't have a check for FPE there yet?)