### PR TITLE
Exclude test structures named 'A' from doxygen

### DIFF
--- a/DataFormats/MemoryResources/test/test_observer_ptr.cxx
+++ b/DataFormats/MemoryResources/test/test_observer_ptr.cxx
@@ -15,6 +15,10 @@
 #include <functional>
 #include "MemoryResources/observer_ptr.h"
 
+/// exclude from doxygen, TODO: we might want to do this on a higher level
+/// because of doxygen's autolinking of references, all 'A' are displayed as
+/// reference to this struct.
+/// @cond
 struct A {
   int i{ 2 };
   int get() const { return i; }
@@ -126,3 +130,4 @@ BOOST_AUTO_TEST_CASE(observer_ptr_A)
     BOOST_CHECK(std::hash<o2::observer_ptr<int>>()(p) == std::hash<int*>()(p.get()));
   }
 }
+// @endcond

--- a/Framework/Core/test/test_PtrHelpers.cxx
+++ b/Framework/Core/test/test_PtrHelpers.cxx
@@ -16,6 +16,10 @@
 #include "Framework/TypeTraits.h"
 #include <memory>
 
+/// exclude from doxygen, TODO: we might want to do this on a higher level
+/// because of doxygen's autolinking of references, all 'A' are displayed as
+/// reference to this struct.
+/// @cond
 struct Base {
   int v;
 };
@@ -41,3 +45,4 @@ BOOST_AUTO_TEST_CASE(MatchingPtrMaker)
   BOOST_CHECK_EQUAL(static_cast<A*>(s.get())->va, 3);
   BOOST_CHECK_EQUAL(static_cast<B*>(u.get())->vb, 4);
 }
+// @endcond


### PR DESCRIPTION
Because of doxygen's autolinking of references, all 'A' are displayed as
reference to a struct named 'A'.

TODO: we might want to do this on a higher level at some point