### PR TITLE
Correcting compiler warnings in Framework core code

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -57,10 +57,10 @@ class ColumnIterator
  public:
   ColumnIterator(std::shared_ptr<arrow::Column> const& column)
     : mColumn{ column },
-      mCurrentChunk{ 0 },
-      mLastChunk{ mColumn->data()->num_chunks() - 1 },
+      mCurrent{ nullptr },
       mLast{ nullptr },
-      mCurrent{ nullptr }
+      mCurrentChunk{ 0 },
+      mLastChunk{ mColumn->data()->num_chunks() - 1 }
   {
     moveToChunk(mCurrentChunk);
   }

--- a/Framework/Core/include/Framework/ArrowContext.h
+++ b/Framework/Core/include/Framework/ArrowContext.h
@@ -80,10 +80,10 @@ class ArrowContext
     // On send we move the header, but the payload remains
     // there because what's really sent is the copy of the string
     // payload will be cleared by the mMessages.clear()
-    for (auto& m : mMessages) {
-//      assert(m.header.get() == nullptr);
-//      assert(m.payload.get() != nullptr);
-    }
+    // for (auto& m : mMessages) {
+    //   assert(m.header.get() == nullptr);
+    //   assert(m.payload.get() != nullptr);
+    // }
     mMessages.clear();
   }
 

--- a/Framework/Core/include/Framework/CallbackRegistry.h
+++ b/Framework/Core/include/Framework/CallbackRegistry.h
@@ -116,8 +116,6 @@ class CallbackRegistry
     using FunT = typename std::tuple_element<pos - 1, decltype(mStore)>::type::type;
     using ResT = typename FunT::result_type;
     using CheckT = std::function<ResT(TArgs...)>;
-    FunT& fct = std::get<pos - 1>(mStore).callback;
-    auto& storedTypeId = fct.target_type();
     execAt<pos - 1, FunT, CheckT>(std::forward<TArgs>(args)...);
   }
   // termination of the recursive loop

--- a/Framework/Core/include/Framework/ContextRegistry.h
+++ b/Framework/Core/include/Framework/ContextRegistry.h
@@ -45,7 +45,6 @@ class ContextRegistry
   template <typename T>
   T* get() const
   {
-    void* instance = nullptr;
     for (size_t i = 0; i < mRegistryCount; ++i) {
       if (mRegistryKey[i] == typeid(T*).hash_code()) {
         return reinterpret_cast<T*>(mRegistryValue[i]);

--- a/Framework/Core/include/Framework/InputRecord.h
+++ b/Framework/Core/include/Framework/InputRecord.h
@@ -142,7 +142,8 @@ class InputRecord
   int getPos(const char *name) const;
   int getPos(const std::string &name) const;
 
-  DataRef getByPos(int pos) const {
+  DataRef getByPos(unsigned pos) const
+  {
     if (pos * 2 + 1 > mSpan.size() || pos < 0) {
       throw std::runtime_error("Unknown message requested at position " + std::to_string(pos));
     }
@@ -487,11 +488,8 @@ class InputRecord
 
     Iterator() = delete;
 
-  Iterator(ParentType const * parent, size_t position = 0, size_t size = 0)
-      : mParent(parent)
-      , mPosition(position)
-      , mSize(size > position? size : position)
-      , mElement{nullptr, nullptr, nullptr}
+    Iterator(ParentType const* parent, size_t position = 0, size_t size = 0)
+      : mPosition(position), mSize(size > position ? size : position), mParent(parent), mElement{ nullptr, nullptr, nullptr }
     {
       if (mPosition < mSize) {
         mElement = mParent->getByPos(mPosition);

--- a/Framework/Core/include/Framework/MessageContext.h
+++ b/Framework/Core/include/Framework/MessageContext.h
@@ -23,6 +23,7 @@
 #include <string>
 #include <type_traits>
 #include <stdexcept>
+#include <numeric>
 
 class FairMQDevice;
 
@@ -273,9 +274,8 @@ class MessageContext {
   void clear()
   {
     // Verify that everything has been sent on clear.
-    for (auto &m : mMessages) {
-      assert(m->empty());
-    }
+    assert(std::accumulate(mMessages.begin(), mMessages.end(), true, [](bool cond, auto& m) { return cond && m->empty(); }));
+
     mMessages.clear();
   }
 

--- a/Framework/Core/include/Framework/RootObjectContext.h
+++ b/Framework/Core/include/Framework/RootObjectContext.h
@@ -15,6 +15,7 @@
 #include <cassert>
 #include <string>
 #include <memory>
+#include <numeric>
 
 class TObject;
 class FairMQMessage;
@@ -70,10 +71,7 @@ public:
     // On send we move the header, but the payload remains
     // there because what's really sent is the TMessage
     // payload will be cleared by the mMessages.clear()
-    for (auto &m : mMessages) {
-      assert(m.header.get() == nullptr);
-      assert(m.payload.get() != nullptr);
-    }
+    assert(std::accumulate(mMessages.begin(), mMessages.end(), true, [](bool cond, auto& m) { return cond && m.header.get() == nullptr && m.payload.get() != nullptr; }));
     mMessages.clear();
   }
 

--- a/Framework/Core/include/Framework/StringContext.h
+++ b/Framework/Core/include/Framework/StringContext.h
@@ -15,6 +15,7 @@
 #include <cassert>
 #include <string>
 #include <memory>
+#include <numeric>
 
 class FairMQMessage;
 
@@ -71,10 +72,7 @@ class StringContext
     // On send we move the header, but the payload remains
     // there because what's really sent is the copy of the string
     // payload will be cleared by the mMessages.clear()
-    for (auto& m : mMessages) {
-      assert(m.header.get() == nullptr);
-      assert(m.payload.get() != nullptr);
-    }
+    assert(std::accumulate(mMessages.begin(), mMessages.end(), true, [](bool cond, auto& m) { return cond && m.header.get() == nullptr && m.payload.get() != nullptr; }));
     mMessages.clear();
   }
 

--- a/Framework/Core/include/Framework/TableBuilder.h
+++ b/Framework/Core/include/Framework/TableBuilder.h
@@ -241,7 +241,7 @@ class TableBuilder
   }
 
   template <typename... ARGS>
-  auto makeBuilders(std::vector<std::string> const& columnNames, size_t nRows)
+  auto makeBuilders(std::vector<std::string> const& columnNames, int nRows)
   {
     using BuildersTuple = typename std::tuple<std::unique_ptr<typename BuilderTraits<ARGS>::BuilderType>...>;
     mSchema = std::make_shared<arrow::Schema>(TableBuilderHelpers::makeFields<ARGS...>(columnNames));

--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -51,7 +51,7 @@ class FileStream : public arrow::io::InputStream
 
   arrow::Status Read(int64_t nbytes, int64_t* bytes_read, void* out) override
   {
-    auto count = fread(out, nbytes, 1, mStream);
+    [[maybe_unused]] auto count = fread(out, nbytes, 1, mStream);
     if (ferror(mStream) == 0) {
       *bytes_read = nbytes;
       mPos += nbytes;
@@ -157,7 +157,7 @@ AlgorithmSpec AODReaderHelpers::run2ESDConverterCallback()
     }
 
     uint64_t readMask = calculateReadMask(spec.outputs, header::DataOrigin{ "RN2" });
-    auto counter = std::make_shared<int>(0);
+    auto counter = std::make_shared<size_t>(0);
     return adaptStateless([readMask,
                            counter,
                            filenames](DataAllocator& outputs, ControlService& ctrl, RawDeviceService& service) {
@@ -263,7 +263,7 @@ AlgorithmSpec AODReaderHelpers::rootFileReaderCallback()
     }
 
     uint64_t readMask = calculateReadMask(spec.outputs, header::DataOrigin{ "AOD" });
-    auto counter = std::make_shared<int>(0);
+    auto counter = std::make_shared<size_t>(0);
     return adaptStateless([readMask,
                            counter,
                            filenames](DataAllocator& outputs, ControlService& control) {

--- a/Framework/Core/src/CompletionPolicyHelpers.cxx
+++ b/Framework/Core/src/CompletionPolicyHelpers.cxx
@@ -76,8 +76,8 @@ CompletionPolicy CompletionPolicyHelpers::consumeWhenAny() {
 
 CompletionPolicy CompletionPolicyHelpers::processWhenAny() {
   auto matcher = [](DeviceSpec const &) -> bool { return true; };
-  auto callback = [](gsl::span<PartRef const> const &inputs) -> CompletionPolicy::CompletionOp {
-    size_t present = 0;
+  auto callback = [](gsl::span<PartRef const> const& inputs) -> CompletionPolicy::CompletionOp {
+    int present = 0;
     for (auto &input : inputs) {
       if (input.header != nullptr) {
         present++;

--- a/Framework/Core/src/ConfigParamsHelper.cxx
+++ b/Framework/Core/src/ConfigParamsHelper.cxx
@@ -29,12 +29,9 @@ void ConfigParamsHelper::populateBoostProgramOptions(
     const std::vector<ConfigParamSpec> &specs,
     bpo::options_description vetos
   ) {
-  auto proxy = options.add_options();
   for (auto & spec : specs) {
     // skip everything found in the veto definition
     if (vetos.find_nothrow(spec.name, false)) continue;
-    const char *name = spec.name.c_str();
-    const char *help = spec.help.c_str();
 
     switch(spec.type) {
       // FIXME: Should we handle int and size_t diffently?

--- a/Framework/Core/src/DataDescriptorMatcher.cxx
+++ b/Framework/Core/src/DataDescriptorMatcher.cxx
@@ -23,7 +23,7 @@ namespace data_matcher
 ContextElement::Value const& VariableContext::get(size_t pos) const
 {
   // First we check if there is any pending update
-  for (size_t i = 0; i < mPerformedUpdates; ++i) {
+  for (int i = 0; i < mPerformedUpdates; ++i) {
     if (mUpdates[i].position == pos) {
       return mUpdates[i].newValue;
     }
@@ -34,7 +34,7 @@ ContextElement::Value const& VariableContext::get(size_t pos) const
 
 void VariableContext::commit()
 {
-  for (size_t i = 0; i < mPerformedUpdates; ++i) {
+  for (int i = 0; i < mPerformedUpdates; ++i) {
     mElements[mUpdates[i].position].value = mUpdates[i].newValue;
   }
   mPerformedUpdates = 0;

--- a/Framework/Core/src/DataRelayer.cxx
+++ b/Framework/Core/src/DataRelayer.cxx
@@ -99,8 +99,8 @@ DataRelayer::DataRelayer(const CompletionPolicy& policy,
                          TimesliceIndex& index)
   : mInputRoutes{ inputRoutes },
     mForwardRoutes{ forwardRoutes },
-    mTimesliceIndex{ index },
     mMetrics{ metrics },
+    mTimesliceIndex{ index },
     mCompletionPolicy{ policy },
     mDistinctRoutesIndex{ createDistinctRouteIndex(inputRoutes) },
     mInputMatchers{ createInputMatchers(inputRoutes) }
@@ -130,7 +130,7 @@ void DataRelayer::processDanglingInputs(std::vector<ExpirationHandler> const& ex
     }
     assert(mDistinctRoutesIndex.empty() == false);
     for (size_t ri = 0; ri < mDistinctRoutesIndex.size(); ++ri) {
-      auto& route = mInputRoutes[mDistinctRoutesIndex[ri]];
+      //auto& route = mInputRoutes[mDistinctRoutesIndex[ri]];
       auto& expirator = expirationHandlers[mDistinctRoutesIndex[ri]];
       auto timestamp = mTimesliceIndex.getTimesliceForSlot(slot);
       auto& part = mCache[ti * mDistinctRoutesIndex.size() + ri];
@@ -163,9 +163,9 @@ void DataRelayer::processDanglingInputs(std::vector<ExpirationHandler> const& ex
 /// This does the mapping between a route and a InputSpec. The
 /// reason why these might diffent is that when you have timepipelining
 /// you have one route per timeslice, even if the type is the same.
-size_t matchToContext(void* data,
-                      std::vector<DataDescriptorMatcher> const& matchers,
-                      VariableContext& context)
+int matchToContext(void* data,
+                   std::vector<DataDescriptorMatcher> const& matchers,
+                   VariableContext& context)
 {
   for (size_t ri = 0, re = matchers.size(); ri < re; ++ri) {
     auto& matcher = matchers[ri];
@@ -205,11 +205,11 @@ DataRelayer::relay(std::unique_ptr<FairMQMessage> &&header,
   // This is the class level state of the relaying. If we start supporting
   // multithreading this will have to be made thread safe before we can invoke
   // relay concurrently.
-  auto const& inputRoutes = mInputRoutes;
+  //auto const& inputRoutes = mInputRoutes;
   auto& index = mTimesliceIndex;
 
   auto& cache = mCache;
-  auto const& readonlyCache = mCache;
+  //auto const& readonlyCache = mCache;
   auto& metrics = mMetrics;
   auto numInputTypes = mDistinctRoutesIndex.size();
 
@@ -271,10 +271,11 @@ DataRelayer::relay(std::unique_ptr<FairMQMessage> &&header,
   // the current timeslice.
   // This should never happen, however given this is dependent on the input
   // we want to protect again malicious / bad upstream source.
-  auto hasCacheInputAlreadyFor = [&cache, &index, &numInputTypes](TimesliceSlot slot, int input) {
-    PartRef& currentPart = cache[numInputTypes * slot.index + input];
-    return (currentPart.payload != nullptr) || (currentPart.header != nullptr);
-  };
+  // unused for the moment
+  //auto hasCacheInputAlreadyFor = [&cache, &index, &numInputTypes](TimesliceSlot slot, int input) {
+  //  PartRef& currentPart = cache[numInputTypes * slot.index + input];
+  //  return (currentPart.payload != nullptr) || (currentPart.header != nullptr);
+  //};
 
   // Actually save the header / payload in the slot
   auto saveInSlot = [&header,

--- a/Framework/Core/src/DataSamplingConditionRandom.cxx
+++ b/Framework/Core/src/DataSamplingConditionRandom.cxx
@@ -36,8 +36,8 @@ class DataSamplingConditionRandom : public DataSamplingCondition
   DataSamplingConditionRandom() : DataSamplingCondition(),
                                   mThreshold(0),
                                   mGenerator(0),
-                                  mCurrentTimesliceID(0),
-                                  mLastDecision(false){};
+                                  mLastDecision(false),
+                                  mCurrentTimesliceID(0){};
   /// \brief Default destructor
   ~DataSamplingConditionRandom() override = default;
 

--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -17,6 +17,7 @@
 #include <cstring>
 #include <unordered_set>
 #include <vector>
+#include <limits>
 #include "Framework/ChannelConfigurationPolicy.h"
 #include "Framework/ChannelMatching.h"
 #include "Framework/ConfigParamsHelper.h"
@@ -274,7 +275,6 @@ void DeviceSpecHelpers::processOutEdgeActions(std::vector<DeviceSpec>& devices, 
     deviceIndex.emplace_back(DeviceId{ edge.producer, edge.producerTimeIndex, di });
 
     OutputChannelSpec channel = channelFromDeviceEdgeAndPort(device, edge, resources.back().port);
-    const DeviceConnectionId& id = connectionIdFromEdgeAndPort(edge, resources.back().port);
     resources.pop_back();
 
     device.outputChannels.push_back(channel);
@@ -534,10 +534,10 @@ void DeviceSpecHelpers::processInEdgeActions(std::vector<DeviceSpec>& devices,
   // of the sink data processors.
   // New InputChannels need to refer to preexisting OutputChannels we create
   // previously.
-  for (size_t edge : inEdgeIndex) {
+  for (size_t const& edge : inEdgeIndex) {
     auto& action = actions[edge];
 
-    size_t consumerDevice;
+    size_t consumerDevice = std::numeric_limits<size_t>::max();
 
     if (action.requiresNewDevice) {
       if (hasConsumerForEdge(edge)) {
@@ -638,8 +638,8 @@ void DeviceSpecHelpers::prepareArguments(bool defaultQuiet, bool defaultStopped,
     control.quiet = defaultQuiet;
     control.stopped = defaultStopped;
 
-    int argc;
-    char** argv;
+    int argc = 0;
+    char** argv = nullptr;
     std::vector<ConfigParamSpec> workflowOptions;
     /// Lookup the executable name in the metadata associated with the workflow.
     /// If we find it, we rewrite the command line arguments to be processed

--- a/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
+++ b/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
@@ -84,14 +84,13 @@ void broadcastDPLMessage(FairMQDevice& device, FairMQMessagePtr&& headerMessage,
 // FIXME: should I filter out only the output specs which match?
 InjectorFunction o2DataModelAdaptor(OutputSpec const &spec, uint64_t startTime, uint64_t step) {
   auto timesliceId = std::make_shared<size_t>(startTime);
-  return [timesliceId, step](FairMQDevice &device, FairMQParts &parts, int index) {
-    for (size_t i = 0; i < parts.Size()/2; ++i) {
+  return [timesliceId, step](FairMQDevice& device, FairMQParts& parts, int index) {
+    for (int i = 0; i < parts.Size() / 2; ++i) {
       auto dh = o2::header::get<DataHeader*>(parts.At(i * 2)->GetData());
 
       DataProcessingHeader dph{*timesliceId, 0};
       o2::header::Stack headerStack{*dh, dph};
       broadcastMessage(device, std::move(headerStack), std::move(parts.At(i*2+1)), index);
-      auto oldTimesliceId = *timesliceId;
       *timesliceId += 1;
     }
   };
@@ -100,7 +99,7 @@ InjectorFunction o2DataModelAdaptor(OutputSpec const &spec, uint64_t startTime, 
 InjectorFunction dplModelAdaptor(OutputSpec const& spec)
 {
   return [](FairMQDevice& device, FairMQParts& parts, int index) {
-    for (size_t i = 0; i < parts.Size() / 2; ++i) {
+    for (int i = 0; i < parts.Size() / 2; ++i) {
       broadcastDPLMessage(device, std::move(parts.At(i * 2)), std::move(parts.At(i * 2 + 1)), index);
     }
   };
@@ -112,7 +111,7 @@ InjectorFunction incrementalConverter(OutputSpec const &spec, uint64_t startTime
   return [timesliceId, spec, step](FairMQDevice &device, FairMQParts &parts, int index) {
     // We iterate on all the parts and we send them two by two,
     // adding the appropriate O2 header.
-    for (size_t i = 0; i < parts.Size(); ++i) {
+    for (int i = 0; i < parts.Size(); ++i) {
       DataHeader dh;
 
       // FIXME: this only supports fully specified output specs...

--- a/Framework/Core/src/FrameworkGUIDataRelayerUsage.cxx
+++ b/Framework/Core/src/FrameworkGUIDataRelayerUsage.cxx
@@ -137,7 +137,7 @@ void displayDataRelayer(DeviceMetricsInfo const& metrics,
   };
   auto describeCell = [&metrics, &variablesIndex, &queriesIndex](int input, int slot) -> void {
     ImGui::BeginTooltip();
-    for (size_t vi = 0; vi < variablesIndex.w; ++vi) {
+    for (int vi = 0; vi < variablesIndex.w; ++vi) {
       auto idx = (slot * variablesIndex.w) + vi;
       assert(idx < variablesIndex.indexes.size());
       MetricInfo const& metricInfo = metrics.metrics[variablesIndex.indexes[idx]];

--- a/Framework/Core/src/FrameworkGUIDevicesGraph.cxx
+++ b/Framework/Core/src/FrameworkGUIDevicesGraph.cxx
@@ -218,7 +218,7 @@ void showTopologyNodeGraph(WorkspaceGUIState& state,
       char* groupBasename = strrchr(workflow.data(), '/');
       char const* groupName = groupBasename ? groupBasename + 1 : workflow.data();
       bool hasDuplicate = false;
-      for (size_t gi = 0; gi < groupList.Size; ++gi) {
+      for (int gi = 0; gi < groupList.Size; ++gi) {
         if (strncmp(groupName, groupList[gi].name, MAX_GROUP_NAME_SIZE - 1) == 0) {
           hasDuplicate = true;
           break;
@@ -236,7 +236,7 @@ void showTopologyNodeGraph(WorkspaceGUIState& state,
       auto metadatum = std::find_if(metadata.begin(), metadata.end(),
                                     [& name = spec.name](DataProcessorInfo const& info) { return info.name == name; });
 
-      for (size_t gi = 0; gi < groupList.Size; ++gi) {
+      for (int gi = 0; gi < groupList.Size; ++gi) {
         if (metadatum == metadata.end()) {
           break;
         }
@@ -273,7 +273,7 @@ void showTopologyNodeGraph(WorkspaceGUIState& state,
     // definition of the inputs and of the outputs due to the
     // way the forwarding creates hidden dependencies between processes.
     // This should not happen, but apparently it does.
-    for (auto di = 0; di < specs.size(); ++di) {
+    for (size_t di = 0; di < specs.size(); ++di) {
       auto fn = std::find_if(sortedNodes.begin(), sortedNodes.end(), [di](TopoIndexInfo const& info) {
         return di == info.index;
       });
@@ -293,7 +293,7 @@ void showTopologyNodeGraph(WorkspaceGUIState& state,
 
     // FIXME: display nodes using topological sort
     // Update positions
-    for (int si = 0; si < specs.size(); ++si) {
+    for (size_t si = 0; si < specs.size(); ++si) {
       auto& node = sortedNodes[si];
       assert(node.index == si);
       int xpos = 40 + 240 * node.layer;

--- a/Framework/Core/src/FreePortFinder.cxx
+++ b/Framework/Core/src/FreePortFinder.cxx
@@ -21,10 +21,10 @@ namespace framework
 {
 
 FreePortFinder::FreePortFinder(unsigned short initialPort, unsigned short finalPort, unsigned short step)
-  : mInitialPort{ initialPort },
+  : mSocket{ socket(AF_INET, SOCK_STREAM, 0) },
+    mInitialPort{ initialPort },
     mFinalPort{ finalPort },
-    mStep{ step },
-    mSocket{ socket(AF_INET, SOCK_STREAM, 0) }
+    mStep{ step }
 {
 }
 

--- a/Framework/Core/src/InputRecord.cxx
+++ b/Framework/Core/src/InputRecord.cxx
@@ -41,7 +41,7 @@ InputRecord::InputRecord(std::vector<InputRoute> const& inputsSchema,
 
 int
 InputRecord::getPos(const char *binding) const {
-  for (int i = 0; i < mInputsSchema.size(); ++i) {
+  for (size_t i = 0; i < mInputsSchema.size(); ++i) {
     auto &route = mInputsSchema[i];
     if (route.matcher.binding == binding) {
       return i;

--- a/Framework/Core/src/Kernels.cxx
+++ b/Framework/Core/src/Kernels.cxx
@@ -15,6 +15,7 @@
 #include <arrow/type.h>
 #include <arrow/util/variant.h>
 #include <memory>
+#include <limits>
 #include <iostream>
 
 using namespace arrow;
@@ -116,13 +117,13 @@ arrow::Status sliceByColumn(FunctionContext* context, std::string const& key,
   auto countData = std::static_pointer_cast<UInt64Array>(countChunks->chunk(0))->raw_values();
 
   auto table = arrow::util::get<std::shared_ptr<arrow::Table>>(inputTable.value);
-  for (size_t ri = 0; ri < ranges->num_rows(); ++ri) {
+  for (int ri = 0; ri < ranges->num_rows(); ++ri) {
     auto start = startData[ri];
     auto count = countData[ri];
     auto schema = table->schema();
     std::vector<std::shared_ptr<Column>> slicedColumns;
     slicedColumns.reserve(schema->num_fields());
-    for (size_t ci = 0; ci < schema->num_fields(); ++ci) {
+    for (int ci = 0; ci < schema->num_fields(); ++ci) {
       slicedColumns.emplace_back(table->column(ci)->Slice(start, count));
     }
     outputSlices->emplace_back(Datum(arrow::Table::Make(table->schema(), slicedColumns)));

--- a/Framework/Core/src/RCombinedDS.cxx
+++ b/Framework/Core/src/RCombinedDS.cxx
@@ -123,10 +123,10 @@ RCombinedDS::RCombinedDS(std::unique_ptr<RDataSource> inLeft, std::unique_ptr<RD
     // they actually own them.
     fLeft{ inLeft.get() },
     fRight{ inRight.get() },
-    fLeftDF{ std::make_unique<RDataFrame>(std::move(inLeft)) },
-    fRightDF{ std::make_unique<RDataFrame>(std::move(inRight)) },
     fLeftPrefix{ inLeftPrefix },
     fRightPrefix{ inRightPrefix },
+    fLeftDF{ std::make_unique<RDataFrame>(std::move(inLeft)) },
+    fRightDF{ std::make_unique<RDataFrame>(std::move(inRight)) },
     fIndex{ std::move(inIndex) }
 {
   fColumnNames.reserve(fLeft->GetColumnNames().size() + fRight->GetColumnNames().size());

--- a/Framework/Core/src/ReadoutAdapter.cxx
+++ b/Framework/Core/src/ReadoutAdapter.cxx
@@ -27,7 +27,7 @@ InjectorFunction readoutAdapter(OutputSpec const& spec)
   auto counter = std::make_shared<uint64_t>(0);
 
   return [spec, counter](FairMQDevice& device, FairMQParts& parts, int index) {
-    for (size_t i = 0; i < parts.Size(); ++i) {
+    for (int i = 0; i < parts.Size(); ++i) {
       DataHeader dh;
       // FIXME: this will have to change and extract the actual subspec from
       //        the data.

--- a/Framework/Core/src/SimpleResourceManager.cxx
+++ b/Framework/Core/src/SimpleResourceManager.cxx
@@ -27,7 +27,7 @@ std::vector<ComputingResource> SimpleResourceManager::getAvailableResources() {
   }
   // We insert them backwards for compatibility with the previous 
   // way of assigning them.
-  for (size_t i = mInitialPort + mMaxPorts - 1; i >= mInitialPort; --i) {
+  for (int i = mInitialPort + mMaxPorts - 1; i >= mInitialPort; --i) {
     result.push_back(ComputingResource{
       1.0,
       1.0,

--- a/Framework/Core/src/TableBuilder.cxx
+++ b/Framework/Core/src/TableBuilder.cxx
@@ -55,7 +55,7 @@ std::shared_ptr<arrow::Table>
   mFinalizer();
   std::vector<std::shared_ptr<arrow::Column>> columns;
   columns.reserve(mArrays.size());
-  for (size_t i = 0; i < mSchema->num_fields(); ++i) {
+  for (int i = 0; i < mSchema->num_fields(); ++i) {
     auto column = std::make_shared<arrow::Column>(mSchema->field(i), mArrays[i]);
     columns.emplace_back(column);
   }

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -480,7 +480,7 @@ void processChildrenOutput(DriverInfo& driverInfo, DeviceInfos& infos, DeviceSpe
       }
       s.remove_prefix(pos + delimiter.length());
     }
-    size_t oldSize = info.unprinted.size();
+    [[maybe_unused]] size_t oldSize = info.unprinted.size();
     info.unprinted = s;
     O2_SIGNPOST_END(DriverStatus::ID, DriverStatus::BYTES_PROCESSED, oldSize - info.unprinted.size(), 0, 0);
   }
@@ -1134,7 +1134,7 @@ int doMain(int argc, char** argv, o2::framework::WorkflowSpec const& workflow,
            o2::framework::ConfigContext& configContext)
 {
   std::vector<std::string> currentArgs;
-  for (size_t ai = 1; ai < argc; ++ai) {
+  for (int ai = 1; ai < argc; ++ai) {
     currentArgs.push_back(argv[ai]);
   }
 

--- a/Framework/Core/test/benchmark_InputRecord.cxx
+++ b/Framework/Core/test/benchmark_InputRecord.cxx
@@ -83,13 +83,13 @@ static void BM_InputRecordGenericGetters(benchmark::State& state)
 
   for (auto _ : state) {
     // Checking we can get the whole ref by name
-    auto ref00 = record.get("x");
-    auto ref10 = record.get("y");
-    auto ref20 = record.get("z");
+    [[maybe_unused]] auto ref00 = record.get("x");
+    [[maybe_unused]] auto ref10 = record.get("y");
+    [[maybe_unused]] auto ref20 = record.get("z");
 
     // Or we can get it positionally
-    auto ref01 = record.getByPos(0);
-    auto ref11 = record.getByPos(1);
+    [[maybe_unused]] auto ref01 = record.getByPos(0);
+    [[maybe_unused]] auto ref11 = record.getByPos(1);
 
     record.isValid("x");
     record.isValid("y");

--- a/Framework/Core/test/benchmark_TableBuilder.cxx
+++ b/Framework/Core/test/benchmark_TableBuilder.cxx
@@ -34,7 +34,7 @@ static void BM_TableBuilderScalar(benchmark::State& state)
   for (auto _ : state) {
     TableBuilder builder;
     auto rowWriter = builder.persist<float>({ "x" });
-    for (size_t i = 0; i < state.range(0); ++i) {
+    for (int i = 0; i < state.range(0); ++i) {
       rowWriter(0, 0.f);
     }
     auto table = builder.finalize();
@@ -50,7 +50,7 @@ static void BM_TableBuilderScalarPresized(benchmark::State& state)
   for (auto _ : state) {
     TableBuilder builder;
     auto rowWriter = builder.preallocatedPersist<float>({ "x" }, state.range(0));
-    for (size_t i = 0; i < state.range(0); ++i) {
+    for (int i = 0; i < state.range(0); ++i) {
       rowWriter(0, 0.f);
     }
     auto table = builder.finalize();
@@ -68,7 +68,7 @@ static void BM_TableBuilderScalarBulk(benchmark::State& state)
   for (auto _ : state) {
     TableBuilder builder;
     auto bulkWriter = builder.bulkPersist<float>({ "x" }, state.range(0));
-    for (size_t i = 0; i < state.range(0) / chunkSize; ++i) {
+    for (int i = 0; i < state.range(0) / chunkSize; ++i) {
       bulkWriter(0, chunkSize, buffer.data());
     }
     auto table = builder.finalize();
@@ -83,7 +83,7 @@ static void BM_TableBuilderSimple(benchmark::State& state)
   for (auto _ : state) {
     TableBuilder builder;
     auto rowWriter = builder.persist<float, float, float>({ "x", "y", "z" });
-    for (size_t i = 0; i < state.range(0); ++i) {
+    for (int i = 0; i < state.range(0); ++i) {
       rowWriter(0, 0.f, 0.f, 0.f);
     }
     auto table = builder.finalize();
@@ -98,7 +98,7 @@ static void BM_TableBuilderSimple2(benchmark::State& state)
   for (auto _ : state) {
     TableBuilder builder;
     auto rowWriter = builder.persist<float, float, float>({ "x", "y", "z" });
-    for (size_t i = 0; i < state.range(0); ++i) {
+    for (int i = 0; i < state.range(0); ++i) {
       rowWriter(0, 0.f, 0.f, 0.f);
     }
     auto table = builder.finalize();
@@ -122,7 +122,7 @@ static void BM_TableBuilderSoA(benchmark::State& state)
   for (auto _ : state) {
     TableBuilder builder;
     auto rowWriter = builder.cursor<TestVectors>();
-    for (size_t i = 0; i < state.range(0); ++i) {
+    for (int i = 0; i < state.range(0); ++i) {
       rowWriter(0, 0.f, 0.f, 0.f);
     }
     auto table = builder.finalize();
@@ -137,7 +137,7 @@ static void BM_TableBuilderComplex(benchmark::State& state)
   for (auto _ : state) {
     TableBuilder builder;
     auto rowWriter = builder.persist<int, float, std::string, bool>({ "x", "y", "s", "b" });
-    for (size_t i = 0; i < state.range(0); ++i) {
+    for (int i = 0; i < state.range(0); ++i) {
       rowWriter(0, 0, 0., "foo", true);
     }
     auto table = builder.finalize();

--- a/Framework/Core/test/test_BoostSerializedProcessing.cxx
+++ b/Framework/Core/test/test_BoostSerializedProcessing.cxx
@@ -19,6 +19,11 @@
 #include "Framework/SerializationMethods.h"
 #include <boost/serialization/access.hpp>
 
+#define ASSERT_ERROR(condition)                                   \
+  if ((condition) == false) {                                     \
+    LOG(ERROR) << R"(Test condition ")" #condition R"(" failed)"; \
+  }
+
 using namespace o2::framework;
 using DataHeader = o2::header::DataHeader;
 
@@ -40,8 +45,8 @@ class Foo
     fBar4 = "This is FooBar!";
   };
   Foo(int bar1, double bar21, double bar22, std::vector<float>& bar3, std::string& bar4) : fBar1(bar1),
-                                                                                           fBar4(bar4),
-                                                                                           fBar3(bar3)
+                                                                                           fBar3(bar3),
+                                                                                           fBar4(bar4)
   {
     fBar2[0] = bar21;
     fBar2[1] = bar22;
@@ -105,15 +110,15 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
 
           size_t i = 0;
           for (auto const& test : in) {
-            assert((test.fBar1 == check[i].fBar1));       // fBar1 wrong
-            assert((test.fBar2[0] == check[i].fBar2[0])); // fBar2[0] wrong
-            assert((test.fBar2[1] == check[i].fBar2[1])); // fBar2[1] wrong
+            ASSERT_ERROR((test.fBar1 == check[i].fBar1));       // fBar1 wrong
+            ASSERT_ERROR((test.fBar2[0] == check[i].fBar2[0])); // fBar2[0] wrong
+            ASSERT_ERROR((test.fBar2[1] == check[i].fBar2[1])); // fBar2[1] wrong
             size_t j = 0;
             for (auto const& fBar3It : test.fBar3) {
-              assert((fBar3It == check[i].fBar3[j]));     // fBar3[j] wrong
+              ASSERT_ERROR((fBar3It == check[i].fBar3[j])); // fBar3[j] wrong
               j++;
             }
-            assert((test.fBar4 == check[i].fBar4));       // fBar4 wrong
+            ASSERT_ERROR((test.fBar4 == check[i].fBar4)); // fBar4 wrong
             i++;
           }
           ctx.services().get<ControlService>().readyToQuit(true);

--- a/Framework/Core/test/test_CallbackService.cxx
+++ b/Framework/Core/test/test_CallbackService.cxx
@@ -35,7 +35,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
       AlgorithmSpec{
         [](ProcessingContext& ctx) {
           std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-          auto out = ctx.outputs().make<int>(OutputRef{ "test", 0 });
+          ctx.outputs().make<int>(OutputRef{ "test", 0 }) = 0;
         } } },
     { "dest",
       Inputs{

--- a/Framework/Core/test/test_CustomGUIGL.cxx
+++ b/Framework/Core/test/test_CustomGUIGL.cxx
@@ -35,7 +35,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
       AlgorithmSpec{
         adaptStateless([](DataAllocator& outputs) {
           std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-          auto out = outputs.make<int>(OutputRef{ "test", 0 });
+          outputs.make<int>(OutputRef{ "test", 0 }) = 0;
         }) } },
     { "dest",
       Inputs{

--- a/Framework/Core/test/test_CustomGUISokol.cxx
+++ b/Framework/Core/test/test_CustomGUISokol.cxx
@@ -37,7 +37,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
       AlgorithmSpec{
         adaptStateless([](DataAllocator& outputs) {
           std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-          auto out = outputs.make<int>(OutputRef{ "test", 0 });
+          outputs.make<int>(OutputRef{ "test", 0 }) = 0;
         }) } },
     { "dest",
       Inputs{

--- a/Framework/Core/test/test_DataAllocator.cxx
+++ b/Framework/Core/test/test_DataAllocator.cxx
@@ -72,7 +72,6 @@ DataProcessorSpec getTimeoutSpec()
 DataProcessorSpec getSourceSpec()
 {
   auto processingFct = [](ProcessingContext& pc) {
-    static int counter = 0;
     o2::test::TriviallyCopyable a(42, 23, 0xdead);
     o2::test::Polymorphic b(0xbeef);
     std::vector<o2::test::Polymorphic> c{ { 0xaffe }, { 0xd00f } };
@@ -209,7 +208,7 @@ DataProcessorSpec getSinkSpec()
 
     LOG(INFO) << "extracting o2::test::TriviallyCopyable from input7";
     auto object7 = pc.inputs().get<o2::test::TriviallyCopyable>("input7");
-    ASSERT_ERROR(object1 == o2::test::TriviallyCopyable(42, 23, 0xdead));
+    ASSERT_ERROR(object7 == o2::test::TriviallyCopyable(42, 23, 0xdead));
 
     LOG(INFO) << "extracting span of o2::test::TriviallyCopyable from input8";
     auto objectspan8 = DataRefUtils::as<o2::test::TriviallyCopyable>(pc.inputs().get("input8"));

--- a/Framework/Core/test/test_DataRelayer.cxx
+++ b/Framework/Core/test/test_DataRelayer.cxx
@@ -362,19 +362,19 @@ BOOST_AUTO_TEST_CASE(TestPolicies) {
   };
 
   // This fills the cache, and then empties it.
-  auto actions1 = createMessage(dh1, DataProcessingHeader{0,1});
+  createMessage(dh1, DataProcessingHeader{ 0, 1 });
   auto ready1 = relayer.getReadyToProcess();
   BOOST_REQUIRE_EQUAL(ready1.size(), 1);
   BOOST_CHECK_EQUAL(ready1[0].slot.index, 0);
   BOOST_CHECK_EQUAL(ready1[0].op, CompletionPolicy::CompletionOp::Process);
 
-  auto actions2 = createMessage(dh1, DataProcessingHeader{1,1});
+  createMessage(dh1, DataProcessingHeader{ 1, 1 });
   auto ready2 = relayer.getReadyToProcess();
   BOOST_REQUIRE_EQUAL(ready2.size(), 1);
   BOOST_CHECK_EQUAL(ready2[0].slot.index, 1);
   BOOST_CHECK_EQUAL(ready2[0].op, CompletionPolicy::CompletionOp::Process);
 
-  auto actions3 = createMessage(dh2, DataProcessingHeader{1,1});
+  createMessage(dh2, DataProcessingHeader{ 1, 1 });
   auto ready3 = relayer.getReadyToProcess();
   BOOST_REQUIRE_EQUAL(ready3.size(), 1);
   BOOST_CHECK_EQUAL(ready3[0].slot.index, 1);

--- a/Framework/Core/test/test_DeviceSpecHelpers.cxx
+++ b/Framework/Core/test/test_DeviceSpecHelpers.cxx
@@ -67,7 +67,7 @@ void check(const std::vector<std::string>& arguments,
   std::vector<DeviceExecution> deviceExecutions(deviceSpecs.size());
   std::vector<DeviceControl> deviceControls(deviceSpecs.size());
   std::vector<DataProcessorInfo> dataProcessorInfos;
-  for (auto& [name, _] : matrix) {
+  for ([[maybe_unused]] auto& [name, _] : matrix) {
     dataProcessorInfos.push_back(DataProcessorInfo{
       name,
       "executable-name",

--- a/Framework/Core/test/test_FairMQResizableBuffer.cxx
+++ b/Framework/Core/test/test_FairMQResizableBuffer.cxx
@@ -97,7 +97,6 @@ BOOST_AUTO_TEST_CASE(TestContents)
   BOOST_REQUIRE(status.ok());
   BOOST_REQUIRE_EQUAL(buffer.capacity(), 10);
   BOOST_REQUIRE_EQUAL(buffer.size(), 10);
-  auto old_ptr = buffer.data();
 
   strcpy((char *) buffer.mutable_data(), "foo");
 

--- a/Framework/Core/test/test_GUITests.cxx
+++ b/Framework/Core/test/test_GUITests.cxx
@@ -90,9 +90,9 @@ BOOST_AUTO_TEST_CASE(HeatmapTest)
       "[METRIC] data_relayer/0,3 1 1789372894 hostname=test.cern.ch"
     };
     for (auto& metric : dummyHeatmapMetrics) {
-      auto result = DeviceMetricsHelper::parseMetric(metric, match);
+      DeviceMetricsHelper::parseMetric(metric, match);
       // Add the first metric to the store
-      result = DeviceMetricsHelper::processMetric(match, metrics);
+      DeviceMetricsHelper::processMetric(match, metrics);
     }
     gui::displayDataRelayer(metrics, deviceInfo2, size);
 

--- a/Framework/Core/test/test_InputRecord.cxx
+++ b/Framework/Core/test/test_InputRecord.cxx
@@ -98,9 +98,9 @@ BOOST_AUTO_TEST_CASE(TestInputRecord) {
   BOOST_CHECK_EXCEPTION(record.get("err"), std::exception, any_exception);
 
   // Or we can get it positionally
-  BOOST_CHECK_NO_THROW(record.get("x"));
   auto ref01 = record.getByPos(0);
-  auto ref11= record.getByPos(1);
+  auto ref11 = record.getByPos(1);
+  auto ref21 = record.getByPos(2);
   BOOST_CHECK_EXCEPTION(record.getByPos(10), std::exception, any_exception);
 
   // This should be exactly the same pointers
@@ -108,6 +108,8 @@ BOOST_AUTO_TEST_CASE(TestInputRecord) {
   BOOST_CHECK_EQUAL(ref00.payload, ref01.payload);
   BOOST_CHECK_EQUAL(ref10.header, ref11.header);
   BOOST_CHECK_EQUAL(ref10.payload, ref11.payload);
+  BOOST_CHECK_EQUAL(ref20.header, ref21.header);
+  BOOST_CHECK_EQUAL(ref20.payload, ref21.payload);
 
   BOOST_CHECK_EQUAL(record.isValid("x"), true);
   BOOST_CHECK_EQUAL(record.isValid("y"), true);

--- a/Framework/Core/test/test_Parallel.cxx
+++ b/Framework/Core/test/test_Parallel.cxx
@@ -20,6 +20,11 @@
 
 #include <iostream>
 
+#define ASSERT_ERROR(condition)                                   \
+  if ((condition) == false) {                                     \
+    LOG(ERROR) << R"(Test condition ")" #condition R"(" failed)"; \
+  }
+
 using namespace o2::framework;
 
 struct FakeCluster {
@@ -140,6 +145,9 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
         const InputSpec* inputSpec = ctx.inputs().get("dataTPC-sampled").spec;
         auto matcher = DataSpecUtils::asConcreteDataMatcher(*inputSpec);
         LOG(DEBUG) << "qcTask received data with subSpec: " << matcher.subSpec;
+        ASSERT_ERROR(inputDataTpc[0].x < parallelSize);
+        ASSERT_ERROR(inputDataTpc[0].y == 0);
+        ASSERT_ERROR(inputDataTpc[1].y == 1);
       }
     }
   };
@@ -157,6 +165,9 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
       [](ProcessingContext& ctx) {
         const FakeCluster* inputDataTpc = reinterpret_cast<const FakeCluster*>(ctx.inputs().get(
           "dataTPC-proc").payload);
+        ASSERT_ERROR(inputDataTpc[0].x < parallelSize);
+        ASSERT_ERROR(inputDataTpc[0].y == 0);
+        ASSERT_ERROR(inputDataTpc[1].y == 1);
       } }
   };
 

--- a/Framework/Core/test/test_ParallelPipeline.cxx
+++ b/Framework/Core/test/test_ParallelPipeline.cxx
@@ -48,8 +48,8 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
                      << *input.spec << ": " << *((int*)input.payload);
           auto const* dataheader = DataRefUtils::getHeader<o2::header::DataHeader*>(input);
           //auto data& = ctx.outputs().make<int>(OutputRef{"output", dataheader->subSpecification});
-          auto& data = ctx.outputs().make<int>(Output{ "TST", "PREPROC", dataheader->subSpecification, Lifetime::Timeframe });
-          ASSERT_ERROR(ctx.inputs().get<int>(input.spec->binding.c_str()) == parallelContext.index1D());
+          auto& data = ctx.outputs().make<unsigned int>(Output{ "TST", "PREPROC", dataheader->subSpecification, Lifetime::Timeframe });
+          ASSERT_ERROR(ctx.inputs().get<unsigned int>(input.spec->binding.c_str()) == parallelContext.index1D());
           data = parallelContext.index1D();
         }
       } } },
@@ -64,7 +64,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
           auto const& parallelContext = ctx.services().get<ParallelContext>();
           LOG(DEBUG) << "instance " << parallelContext.index1D() << " of " << parallelContext.index1DSize() << ": "
                      << *input.spec << ": " << *((int*)input.payload);
-          ASSERT_ERROR(ctx.inputs().get<int>(input.spec->binding.c_str()) == parallelContext.index1D());
+          ASSERT_ERROR(ctx.inputs().get<unsigned>(input.spec->binding.c_str()) == parallelContext.index1D());
           auto const* dataheader = DataRefUtils::getHeader<o2::header::DataHeader*>(input);
           // TODO: there is a bug in the API for using OutputRef, returns an rvalue which can not be bound to
           // lvalue reference
@@ -102,7 +102,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
     "trigger",
     Inputs{},
     producerOutputs(),
-    AlgorithmSpec{ [subspecs, checkMap, counter = std::make_shared<int>(0)](ProcessingContext& ctx) {
+    AlgorithmSpec{ [subspecs, checkMap, counter = std::make_shared<size_t>(0)](ProcessingContext& ctx) {
       if (*counter < nRolls) {
         size_t multiplicity = subspecs.size() / nPipelines;
         if (subspecs.size() % nPipelines) {

--- a/Framework/Core/test/test_TableBuilder.cxx
+++ b/Framework/Core/test/test_TableBuilder.cxx
@@ -206,9 +206,9 @@ BOOST_AUTO_TEST_CASE(TestCombinedDS)
   //        https://github.com/root-project/root/pull/3277
   //        https://github.com/root-project/root/pull/3428
   //
-  auto sum = [](int lx, int rx) { return lx + rx; };
-  auto left = [](int lx, int) { return lx; };
-  auto right = [](int, int rx) { return rx; };
+  //auto sum = [](int lx, int rx) { return lx + rx; };
+  //auto left = [](int lx, int) { return lx; };
+  //auto right = [](int, int rx) { return rx; };
 
   //BOOST_CHECK_EQUAL(*finalDF.Define("s1", sum, { "left_x", "left_y" }).Sum("s1"), 448);
   //BOOST_CHECK_EQUAL(*finalDF.Define("s4", sum, { "right_x", "left_x" }).Sum("s4"), 448);


### PR DESCRIPTION
Mainly about unused variables in the code, initialisation sequence of class
members and comparison between signed and unsigned.

Also correcting a minor bug in a unit test which was indicated by compiler
warning 'unused variable'.