### PR TITLE
Implement a second method to reconstruct tracks

### DIFF
--- a/Detectors/MUON/MID/Tracking/include/MIDTracking/Tracker.h
+++ b/Detectors/MUON/MID/Tracking/include/MIDTracking/Tracker.h
@@ -43,7 +43,7 @@ class Tracker
   inline float getSigmaCut() const { return mSigmaCut; }
 
   bool process(gsl::span<const Cluster2D> clusters);
-  bool init();
+  bool init(bool keepAll = false);
 
   /// Gets the array of reconstructes tracks
   const std::vector<Track>& getTracks() { return mTracks; }
@@ -54,7 +54,9 @@ class Tracker
  private:
   bool processSide(bool isRight, bool isInward);
   bool tryAddTrack(const Track& track);
-  bool followTrack(const Track& track, bool isRight, bool isInward);
+  bool followTrackKeepAll(const Track& track, bool isRight, bool isInward);
+  bool followTrackKeepBest(const Track& track, bool isRight, bool isInward);
+  bool findAllClusters(Track& track, int clIdx, bool isRight, bool isInward, int chamber, int irpc);
   bool findNextCluster(const Track& track, bool isRight, bool isInward, int chamber, int firstRPC, int lastRPC, Track& bestTrack) const;
   int getFirstNeighbourRPC(int rpc) const;
   int getLastNeighbourRPC(int rpc) const;
@@ -69,12 +71,15 @@ class Tracker
   float mSigmaCut = 5.;         ///< Number of sigmas cut
   float mMaxChi2 = 1.e6;        ///< Maximum cut on chi2
 
-  std::vector<int> mClusterIndexes[72]; ///< Ordered arrays of clusters indexes
-  std::vector<Cluster3D> mClusters;     ///< 3D clusters
+  std::vector<std::pair<int, bool>> mClusterIndexes[72]; ///< Ordered arrays of clusters indexes
+  std::vector<Cluster3D> mClusters;                      ///< 3D clusters
 
   std::vector<Track> mTracks; ///< Array of tracks
 
   GeometryTransformer mTransformer; ///< Geometry transformer
+
+  typedef bool (Tracker::*TrackerMemFn)(const Track&, bool, bool);
+  TrackerMemFn mFollowTrack{ nullptr }; ///! Choice of the function to follow the track
 };
 } // namespace mid
 } // namespace o2

--- a/Detectors/MUON/MID/Tracking/test/bench_Tracker.cxx
+++ b/Detectors/MUON/MID/Tracking/test/bench_Tracker.cxx
@@ -70,6 +70,7 @@ static void BM_TRACKER(benchmark::State& state)
   o2::mid::Tracker tracker(geoTrans);
 
   int nTracksPerEvent = state.range(0);
+  tracker.init((state.range(1) == 1));
   double num{ 0 };
 
   std::vector<o2::mid::Cluster2D> inputData;
@@ -88,7 +89,9 @@ static void BM_TRACKER(benchmark::State& state)
 static void CustomArguments(benchmark::internal::Benchmark* bench)
 {
   for (int itrack = 1; itrack <= 8; ++itrack) {
-    bench->Arg(itrack);
+    for (int imethod = 0; imethod < 2; ++imethod) {
+      bench->Args({ itrack, imethod });
+    }
   }
 }
 

--- a/Detectors/MUON/MID/Tracking/test/testTracker.cxx
+++ b/Detectors/MUON/MID/Tracking/test/testTracker.cxx
@@ -20,6 +20,7 @@
 #include <boost/test/data/monomorphic/generators/xrange.hpp>
 #include <boost/test/data/test_case.hpp>
 #include <cstdint>
+#include <string>
 #include <sstream>
 #include <vector>
 #include <random>
@@ -43,19 +44,22 @@ struct TrackClusters {
   bool isReconstructible() { return nFiredChambers > 2; }
 };
 
-struct MyFixture {
-  static GeometryTransformer geoTrans;
-  static HitFinder hitFinder;
-  static TrackGenerator trackGen;
-  static Tracker tracker;
-  static Mapping mapping;
+struct Helper {
+  Mapping mapping;
+  GeometryTransformer geoTrans;
+  HitFinder hitFinder;
+  TrackGenerator trackGen;
+  Tracker tracker;
+  Tracker trackerAll;
+
+  Helper() : mapping(), geoTrans(createDefaultTransformer()), hitFinder(geoTrans), trackGen(), tracker(geoTrans), trackerAll(geoTrans)
+  {
+    tracker.init();
+    trackerAll.init(true);
+  }
 };
 
-GeometryTransformer MyFixture::geoTrans = createDefaultTransformer();
-HitFinder MyFixture::hitFinder(geoTrans);
-TrackGenerator MyFixture::trackGen;
-Tracker MyFixture::tracker(geoTrans);
-Mapping MyFixture::mapping;
+static Helper helper;
 
 TrackClusters getTrackClusters(const Track& track)
 {
@@ -66,23 +70,23 @@ TrackClusters getTrackClusters(const Track& track)
   MpArea area;
   Cluster2D cl;
   for (int ich = 0; ich < 4; ++ich) {
-    std::vector<std::pair<int, Point3D<float>>> pairs = MyFixture::hitFinder.getLocalPositions(track, ich);
+    std::vector<std::pair<int, Point3D<float>>> pairs = helper.hitFinder.getLocalPositions(track, ich);
     bool isFired = false;
     for (auto& pair : pairs) {
       int deId = pair.first;
       float xPos = pair.second.x();
       float yPos = pair.second.y();
-      stripIndex = MyFixture::mapping.stripByPosition(xPos, yPos, 0, deId, false);
+      stripIndex = helper.mapping.stripByPosition(xPos, yPos, 0, deId, false);
       if (!stripIndex.isValid()) {
         continue;
       }
       cl.deId = deId;
-      area = MyFixture::mapping.stripByLocation(stripIndex.strip, 0, stripIndex.line, stripIndex.column, deId);
+      area = helper.mapping.stripByLocation(stripIndex.strip, 0, stripIndex.line, stripIndex.column, deId);
       cl.yCoor = area.getCenterY();
       float halfSize = area.getHalfSizeY();
       cl.sigmaY2 = halfSize * halfSize / 3.;
-      stripIndex = MyFixture::mapping.stripByPosition(xPos, yPos, 1, deId, false);
-      area = MyFixture::mapping.stripByLocation(stripIndex.strip, 1, stripIndex.line, stripIndex.column, deId);
+      stripIndex = helper.mapping.stripByPosition(xPos, yPos, 1, deId, false);
+      area = helper.mapping.stripByLocation(stripIndex.strip, 1, stripIndex.line, stripIndex.column, deId);
       cl.xCoor = area.getCenterX();
       halfSize = area.getHalfSizeX();
       cl.sigmaX2 = halfSize * halfSize / 3.;
@@ -99,16 +103,26 @@ TrackClusters getTrackClusters(const Track& track)
 std::vector<TrackClusters> getTrackClusters(int nTracks)
 {
   std::vector<TrackClusters> trackClusters;
-  std::vector<Track> tracks = MyFixture::trackGen.generate(nTracks);
+  std::vector<Track> tracks = helper.trackGen.generate(nTracks);
   for (auto& track : tracks) {
     trackClusters.push_back(getTrackClusters(track));
   }
   return trackClusters;
 }
 
-BOOST_DATA_TEST_CASE_F(MyFixture, TestMultipleTracks, boost::unit_test::data::xrange(1, 9), nTracksPerEvent)
+std::string getTrackInfo(const Track& track)
 {
-  float chi2Cut = tracker.getSigmaCut() * tracker.getSigmaCut();
+  std::stringstream ss;
+  ss << track << "  clusters: ";
+  for (int ich = 0; ich < 4; ++ich) {
+    ss << " " << track.getClusterMatched(ich);
+  }
+  return ss.str();
+}
+
+BOOST_DATA_TEST_CASE(TestMultipleTracks, boost::unit_test::data::xrange(1, 9), nTracksPerEvent)
+{
+  float chi2Cut = helper.tracker.getSigmaCut() * helper.tracker.getSigmaCut();
   int nTotFakes = 0, nTotReconstructible = 0;
   for (int ievt = 0; ievt < 1000; ++ievt) {
     std::vector<TrackClusters> trackClusters = getTrackClusters(nTracksPerEvent);
@@ -129,12 +143,12 @@ BOOST_DATA_TEST_CASE_F(MyFixture, TestMultipleTracks, boost::unit_test::data::xr
     }
 
     // Run tracker algorithm
-    tracker.process(clusters);
+    helper.tracker.process(clusters);
 
     // Further strings for debugging
     ss << "  Reconstructed tracks:\n";
-    for (size_t ireco = 0; ireco < tracker.getTracks().size(); ++ireco) {
-      ss << "  " << tracker.getTracks()[ireco] << "\n";
+    for (size_t ireco = 0; ireco < helper.tracker.getTracks().size(); ++ireco) {
+      ss << "  " << helper.tracker.getTracks()[ireco] << "\n";
     }
 
     // Check that all reconstructible tracks are reconstructed
@@ -143,8 +157,8 @@ BOOST_DATA_TEST_CASE_F(MyFixture, TestMultipleTracks, boost::unit_test::data::xr
     for (auto& trCl : trackClusters) {
       ++itr;
       bool isReco = false;
-      for (size_t ireco = 0; ireco < tracker.getTracks().size(); ++ireco) {
-        if (tracker.getTracks()[ireco].isCompatible(trCl.track, chi2Cut)) {
+      for (size_t ireco = 0; ireco < helper.tracker.getTracks().size(); ++ireco) {
+        if (helper.tracker.getTracks()[ireco].isCompatible(trCl.track, chi2Cut)) {
           isReco = true;
           break;
         }
@@ -165,13 +179,49 @@ BOOST_DATA_TEST_CASE_F(MyFixture, TestMultipleTracks, boost::unit_test::data::xr
       }
     } // loop on input tracks
     nTotReconstructible += nReconstructible;
-    int nFakes = tracker.getTracks().size() - nReconstructible;
+    int nFakes = helper.tracker.getTracks().size() - nReconstructible;
     if (nFakes > 0) {
       ++nTotFakes;
     }
   } // loop on events
   // To show the following message, run the test with: --log_level=message
   BOOST_TEST_MESSAGE("Fraction of fake tracks: " << (double)nTotFakes / (double)nTotReconstructible);
+}
+
+BOOST_DATA_TEST_CASE(TestAlgorithms, boost::unit_test::data::xrange(2, 3), nTracksPerEvent)
+{
+  float chi2Cut = helper.tracker.getSigmaCut() * helper.tracker.getSigmaCut();
+  int nTotFakes = 0, nTotReconstructible = 0;
+  for (int ievt = 0; ievt < 1000; ++ievt) {
+    std::vector<TrackClusters> trackClusters = getTrackClusters(nTracksPerEvent);
+    std::vector<Cluster2D> clusters;
+    for (auto& trCl : trackClusters) {
+      for (auto& cl : trCl.clusters) {
+        clusters.push_back(cl);
+      }
+    }
+
+    // Run tracker algorithm
+    helper.tracker.process(clusters);
+    helper.trackerAll.process(clusters);
+
+    BOOST_TEST(helper.tracker.getTracks().size() <= helper.trackerAll.getTracks().size());
+
+    for (auto& track : helper.tracker.getTracks()) {
+      bool isCompatible = false;
+      std::stringstream ss;
+      ss << "\n"
+         << getTrackInfo(track) << "  has no match in:\n";
+      for (auto& trackAll : helper.trackerAll.getTracks()) {
+        ss << getTrackInfo(trackAll) << "\n";
+        if (trackAll.isCompatible(track, chi2Cut)) {
+          isCompatible = true;
+          break;
+        }
+      }
+      BOOST_TEST(isCompatible, ss.str());
+    }
+  }
 }
 
 } // namespace mid


### PR DESCRIPTION
This method keeps all tracks instead of just the best one.
The method has a higher efficiency in events with large track multiplicity
(but it is slower and provides a larger number of fakes)