### PR TITLE
Make framework workflow unit tests running again

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -213,6 +213,7 @@ O2_GENERATE_EXECUTABLE(
   BUCKET_NAME ${MODULE_BUCKET_NAME}
 )
 
+# TODO: is this better a unit test?
 O2_GENERATE_EXECUTABLE(
   EXE_NAME "test_TimePipeline"
   SOURCES "test/test_TimePipeline.cxx"
@@ -239,20 +240,13 @@ Install(FILES test/test_DataSampling.json DESTINATION share/tests/)
 set(TEST_SRCS
       test/test_ASoA.cxx
       test/test_AnalysisTask.cxx
-      test/test_BoostSerializedProcessing.cxx
       test/test_AlgorithmSpec.cxx
       test/test_BoostOptionsRetriever.cxx
       test/test_CallbackRegistry.cxx
-      test/test_CallbackService.cxx
       test/test_ChannelSpecHelpers.cxx
       test/test_ContextRegistry.cxx
       test/test_ConfigParamRegistry.cxx
-      test/test_CustomGUISokol.cxx
-      test/test_CustomGUIGL.cxx
       test/test_CompletionPolicy.cxx
-      test/test_DanglingInputs.cxx
-      test/test_DanglingOutputs.cxx
-      test/test_DataAllocator.cxx
       test/test_DataDescriptorMatcher.cxx
       test/test_DataProcessorSpec.cxx
       test/test_DataRefUtils.cxx
@@ -265,7 +259,6 @@ set(TEST_SRCS
       test/test_DeviceSpec.cxx
       test/test_ExternalFairMQDeviceProxy.cxx
       test/test_FairMQResizableBuffer.cxx
-      test/test_Forwarding.cxx
       test/test_FrameworkDataFlowToDDS.cxx
       test/test_FairMQOptionsRetriever.cxx
       test/test_GUITests.cxx
@@ -274,27 +267,19 @@ set(TEST_SRCS
       test/test_InputRecord.cxx
       test/test_Kernels.cxx
       test/test_LogParsingHelpers.cxx
-      test/test_ParallelProducer.cxx
       test/test_PtrHelpers.cxx
       test/test_Root2ArrowTable.cxx
       test/test_Services.cxx
-      test/test_SimpleRDataFrameProcessing.cxx
-      test/test_SimpleStatefulProcessing01.cxx
-      test/test_SimpleStringProcessing.cxx
-      test/test_SingleDataSource.cxx
-      test/test_SimpleTimer.cxx
       test/test_SuppressionGenerator.cxx
       test/test_TimesliceIndex.cxx
       test/test_TMessageSerializer.cxx
       test/test_TableBuilder.cxx
-      #test/test_Task.cxx
       test/test_TimeParallelPipelining.cxx
       test/test_TypeTraits.cxx
       test/test_Variants.cxx
       test/test_WorkflowHelpers.cxx
       test/test_WorkflowSerialization.cxx
       test/test_DeviceSpecHelpers.cxx
-      test/test_ParallelPipeline.cxx
    )
 
 set(BENCH_SRCS 
@@ -304,6 +289,28 @@ set(BENCH_SRCS
     test/benchmark_DeviceMetricsInfo.cxx
     test/benchmark_InputRecord.cxx
     test/benchmark_TableBuilder.cxx
+    )
+
+set(WORKFLOW_SRCS
+    test/test_CustomGUIGL.cxx
+    test/test_SimpleStatefulProcessing01.cxx
+    #test/test_GenericSource.cxx
+    test/test_CustomGUISokol.cxx
+    #test/test_Task.cxx
+    test/test_Forwarding.cxx
+    test/test_SingleDataSource.cxx
+    test/test_ParallelPipeline.cxx
+    test/test_DataAllocator.cxx
+    test/test_SimpleRDataFrameProcessing.cxx
+    test/test_ParallelProducer.cxx
+    test/test_SimpleTimer.cxx
+    test/test_CallbackService.cxx
+    #test/test_CCDBFetcher.cxx
+    test/test_DanglingOutputs.cxx
+    test/test_BoostSerializedProcessing.cxx
+    test/test_DanglingInputs.cxx
+    test/test_SimpleStringProcessing.cxx
+    test/test_SimpleDataProcessingDevice01.cxx
     )
 
 O2_GENERATE_TESTS(
@@ -319,6 +326,17 @@ O2_GENERATE_TESTS(
   TIMEOUT 30
 )
 
+# Workflows have to be executed with command line option --run
+# The merging functionality would simply dump the configuration on std output because of
+# the connected log pipe
+O2_GENERATE_TESTS(
+  MODULE_LIBRARY_NAME ${LIBRARY_NAME}
+  BUCKET_NAME ${BUCKET_NAME}
+  TEST_SRCS ${WORKFLOW_SRCS}
+  TIMEOUT 30
+  COMMAND_LINE_ARGS --run
+)
+
 # specific tests which needs command line options
 O2_GENERATE_TESTS(
   MODULE_LIBRARY_NAME ${LIBRARY_NAME}
@@ -330,6 +348,7 @@ O2_GENERATE_TESTS(
 
   COMMAND_LINE_ARGS
   --global-config require-me
+  --run
   # Note: the group switch makes process consumer parse only the group arguments
   --consumer "--global-config consumer-config --local-option hello-aliceo2 --a-boolean3 --an-int2 20 --a-double2 22."
 )


### PR DESCRIPTION
Workflows have to be executed with command line option --run
The merging functionality would simply dump the configuration on std output
because of the connected log pipe.