### PR TITLE
Track labeler for MID and corresponding tests

### DIFF
--- a/Detectors/MUON/MID/Base/CMakeLists.txt
+++ b/Detectors/MUON/MID/Base/CMakeLists.txt
@@ -6,7 +6,6 @@ set(SRCS
   src/ChamberEfficiency.cxx
   src/Constants.cxx
   src/GeometryTransformer.cxx
-  src/HitFinder.cxx
   src/Mapping.cxx
   src/MpArea.cxx
 )
@@ -15,7 +14,6 @@ set(NO_DICT_HEADERS
   include/${MODULE_NAME}/ChamberEfficiency.h
   include/${MODULE_NAME}/Constants.h
   include/${MODULE_NAME}/GeometryTransformer.h
-  include/${MODULE_NAME}/HitFinder.h
   include/${MODULE_NAME}/Mapping.h
   include/${MODULE_NAME}/MpArea.h
 )

--- a/Detectors/MUON/MID/Simulation/CMakeLists.txt
+++ b/Detectors/MUON/MID/Simulation/CMakeLists.txt
@@ -19,6 +19,7 @@ set(SRCS
   src/MCLabel.cxx
   src/PreClusterLabeler.cxx
   src/Stepper.cxx
+  src/TrackLabeler.cxx
 )
 
 set(HEADERS
@@ -36,6 +37,7 @@ set(HEADERS
   include/${MODULE_NAME}/MCClusterLabel.h
   include/${MODULE_NAME}/MCLabel.h
   include/${MODULE_NAME}/Stepper.h
+  include/${MODULE_NAME}/TrackLabeler.h
 )
 
 set(LINKDEF src/MIDSimulationLinkDef.h)

--- a/Detectors/MUON/MID/Simulation/include/MIDSimulation/MCLabel.h
+++ b/Detectors/MUON/MID/Simulation/include/MIDSimulation/MCLabel.h
@@ -45,6 +45,8 @@ class MCLabel : public o2::MCCompLabel
   MCLabel() = default;
   MCLabel(int trackID, int eventID, int srcID, int deId, int columnId, int cathode, int firstStrip, int lastStrip);
 
+  bool operator==(const MCLabel& other) const;
+
   /// Sets the detection element ID
   void setDEId(int deId) { set(deId, sMaskDE, sOffsetDE); }
   /// Gets the detection element ID

--- a/Detectors/MUON/MID/Simulation/include/MIDSimulation/TrackLabeler.h
+++ b/Detectors/MUON/MID/Simulation/include/MIDSimulation/TrackLabeler.h
@@ -1,0 +1,51 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDSimulation/TrackLabeler.h
+/// \brief  Tracks labeler for MID
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   07 June 2019
+#ifndef O2_MID_TRACKLABELER_H
+#define O2_MID_TRACKLABELER_H
+
+#include <vector>
+#include <gsl/gsl>
+#include "SimulationDataFormat/MCTruthContainer.h"
+#include "SimulationDataFormat/MCCompLabel.h"
+#include "DataFormatsMID/Track.h"
+#include "DataFormatsMID/Cluster3D.h"
+#include "MIDSimulation/MCClusterLabel.h"
+
+namespace o2
+{
+namespace mid
+{
+class TrackLabeler
+{
+ public:
+  void process(gsl::span<const Cluster3D>& clusters, gsl::span<const Track>& tracks, const o2::dataformats::MCTruthContainer<MCClusterLabel>& inMCContainer);
+
+  /// Returns the tracks labels
+  const o2::dataformats::MCTruthContainer<MCCompLabel>& getTracksLabels() { return mMCTracksLabels; }
+
+  /// Returns the cluster labels
+  const o2::dataformats::MCTruthContainer<MCClusterLabel>& getTrackClustersLabels() { return mMCTrackClustersLabels; }
+
+ private:
+  bool areBothSidesFired(const gsl::span<const MCClusterLabel>& labels) const;
+  std::vector<MCCompLabel> findLabels(const Track& track, const o2::dataformats::MCTruthContainer<MCClusterLabel>& inMCContainer) const;
+
+  o2::dataformats::MCTruthContainer<MCCompLabel> mMCTracksLabels;           ///< Track labels
+  o2::dataformats::MCTruthContainer<MCClusterLabel> mMCTrackClustersLabels; ///< Cluster labels
+};
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_TRACKLABELER_H */

--- a/Detectors/MUON/MID/Simulation/src/MCLabel.cxx
+++ b/Detectors/MUON/MID/Simulation/src/MCLabel.cxx
@@ -39,5 +39,13 @@ void MCLabel::set(int value, unsigned int mask, unsigned int offset)
   mStripsInfo |= ((value & mask) << offset);
 }
 
+bool MCLabel::operator==(const MCLabel& other) const
+{
+  if (compare(other) != 1) {
+    return false;
+  }
+  return (mStripsInfo == other.mStripsInfo);
+}
+
 } // namespace mid
 } // namespace o2

--- a/Detectors/MUON/MID/Simulation/src/TrackLabeler.cxx
+++ b/Detectors/MUON/MID/Simulation/src/TrackLabeler.cxx
@@ -1,0 +1,110 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Simulation/src/TrackLabeler.cxx
+/// \brief  Implementation of the TrackLabeler for MID
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   01 March 2018
+#include "MIDSimulation/TrackLabeler.h"
+
+namespace o2
+{
+namespace mid
+{
+
+bool TrackLabeler::areBothSidesFired(const gsl::span<const MCClusterLabel>& labels) const
+{
+  /// Check if the BP and NBP were fired by some track
+  bool isFiredBP = false, isFiredNBP = false;
+  for (auto& label : labels) {
+    if (label.isFiredBP()) {
+      isFiredBP = true;
+    }
+    if (label.isFiredNBP()) {
+      isFiredNBP = true;
+    }
+  }
+  return isFiredBP && isFiredNBP;
+}
+
+std::vector<MCCompLabel> TrackLabeler::findLabels(const Track& track, const o2::dataformats::MCTruthContainer<MCClusterLabel>& inMCContainer) const
+{
+  /// Finds the track label from its associated clusters labels
+  std::vector<MCCompLabel> allLabels;
+  std::vector<int> counts;
+  for (int ich = 0; ich < 4; ++ich) {
+    auto icl = track.getClusterMatched(ich);
+    if (icl < 0) {
+      continue;
+    }
+
+    // First check if the BP and NBP were ever fired by a track
+    // If they are, it means that the chamber was efficient
+    bool bothFired = areBothSidesFired(inMCContainer.getLabels(icl));
+
+    for (auto& label : inMCContainer.getLabels(icl)) {
+      // This track fired only one cathode
+      bool oneFired = (!label.isFiredBP() || !label.isFiredNBP());
+      if (bothFired && oneFired) {
+        // This condition means that the cluster was made from
+        // a track in the BP and a different track in the NBP.
+        // This happens when we have two tracks in the same column.
+        // This means that the cluster is a fake one, so we discard it
+        continue;
+      }
+      bool isNew = true;
+      for (size_t idx = 0; idx < allLabels.size(); ++idx) {
+        if (allLabels[idx] == label) {
+          ++counts[idx];
+          isNew = false;
+          break;
+        }
+      }
+      if (isNew) {
+        allLabels.emplace_back(label);
+        counts.emplace_back(1);
+      }
+    }
+  }
+
+  std::vector<MCCompLabel> labels;
+
+  for (size_t idx = 0; idx < allLabels.size(); ++idx) {
+    if (counts[idx] >= 3) {
+      labels.emplace_back(allLabels[idx]);
+    }
+  }
+
+  return std::move(labels);
+}
+
+void TrackLabeler::process(gsl::span<const Cluster3D>& clusters, gsl::span<const Track>& tracks, const o2::dataformats::MCTruthContainer<MCClusterLabel>& inMCContainer)
+{
+  /// Applies labels to the tracks
+  mMCTracksLabels.clear();
+
+  for (auto& track : tracks) {
+    auto idx = &track - &tracks[0];
+    auto labels = findLabels(track, inMCContainer);
+    if (labels.empty()) {
+      labels.emplace_back(MCCompLabel());
+    }
+    for (auto& label : labels) {
+      mMCTracksLabels.addElement(idx, label);
+    }
+  }
+
+  // For the moment we store all clusters
+  // This can change if we decide to store only associated clusters
+  mMCTrackClustersLabels.clear();
+  mMCTrackClustersLabels = inMCContainer;
+}
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/Simulation/test/testSimulation.cxx
+++ b/Detectors/MUON/MID/Simulation/test/testSimulation.cxx
@@ -12,49 +12,103 @@
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
 
-#include <boost/test/data/monomorphic.hpp>
-#include <boost/test/data/monomorphic/generators/xrange.hpp>
 #include <boost/test/data/test_case.hpp>
-#include <iostream>
 #include <sstream>
 #include "MathUtils/Cartesian3D.h"
+#include "DataFormatsMID/Cluster2D.h"
+#include "DataFormatsMID/Cluster3D.h"
+#include "DataFormatsMID/ColumnData.h"
+#include "DataFormatsMID/Track.h"
 #include "MIDBase/Mapping.h"
 #include "MIDBase/GeometryTransformer.h"
+#include "MIDSimulation/ChamberResponseParams.h"
+#include "MIDSimulation/ClusterLabeler.h"
 #include "MIDSimulation/ColumnDataMC.h"
 #include "MIDSimulation/Digitizer.h"
 #include "MIDSimulation/DigitsMerger.h"
-#include "MIDSimulation/ChamberResponseParams.h"
+#include "MIDSimulation/DigitsPacker.h"
 #include "MIDSimulation/Hit.h"
-#include "MIDClustering/PreClusterizer.h"
+#include "MIDSimulation/PreClusterLabeler.h"
+#include "MIDSimulation/TrackLabeler.h"
 #include "MIDClustering/Clusterizer.h"
+#include "MIDClustering/PreClusterHelper.h"
+#include "MIDClustering/PreClusterizer.h"
+#include "MIDTracking/Tracker.h"
+#include "MIDTestingSimTools/TrackGenerator.h"
+#include "MIDTestingSimTools/HitFinder.h"
 
 namespace o2
 {
 namespace mid
 {
 
-struct SIMUL {
-  static Mapping mapping;
-  static ChamberResponseParams params;
-  static GeometryTransformer geoTrans;
-  static Digitizer digitizer;
-  static DigitsMerger digitsMerger;
-  static PreClusterizer preClusterizer;
-  static Clusterizer clusterizer;
+Digitizer createDigitizerNoClusterSize()
+{
+  /// Returns the default chamber response
+  ChamberResponseParams params = createDefaultChamberResponseParams();
+  params.setParA(0., 0.);
+  params.setParC(0., 0.);
+  ChamberHV hv = createDefaultChamberHV();
 
-  void setup()
+  return Digitizer(ChamberResponse(params, hv), createDefaultChamberEfficiencyResponse(), createDefaultTransformer());
+}
+
+struct SimBase {
+  Mapping mapping;
+  GeometryTransformer geoTrans;
+  SimBase() : mapping(), geoTrans(createDefaultTransformer()) {}
+};
+
+static SimBase simBase;
+
+struct SimDigitizer {
+  ChamberResponseParams params;
+  Digitizer digitizer;
+  Digitizer digitizerNoClusterSize;
+  DigitsMerger digitsMerger;
+  DigitsPacker digitsPacker;
+  SimDigitizer() : params(createDefaultChamberResponseParams()), digitizer(createDefaultDigitizer()), digitizerNoClusterSize(createDigitizerNoClusterSize()), digitsMerger(), digitsPacker() {}
+};
+
+static SimDigitizer simDigitizer;
+
+struct SimClustering {
+  std::vector<std::array<size_t, 2>> correlation;
+  PreClusterizer preClusterizer;
+  Clusterizer clusterizer;
+  PreClusterHelper preClusterHelper;
+  PreClusterLabeler preClusterLabeler;
+  ClusterLabeler clusterLabeler;
+  SimClustering() : correlation(), preClusterizer(), clusterizer(), preClusterHelper(), preClusterLabeler(), clusterLabeler()
   {
-    clusterizer.init();
+    correlation.clear();
+    preClusterizer.init();
+    clusterizer.init([&](size_t baseIndex, size_t relatedIndex) { correlation.push_back({ baseIndex, relatedIndex }); });
   }
 };
 
-Mapping SIMUL::mapping;
-ChamberResponseParams SIMUL::params = createDefaultChamberResponseParams();
-GeometryTransformer SIMUL::geoTrans = createDefaultTransformer();
-Digitizer SIMUL::digitizer = createDefaultDigitizer();
-DigitsMerger SIMUL::digitsMerger;
-PreClusterizer SIMUL::preClusterizer;
-Clusterizer SIMUL::clusterizer;
+static SimClustering simClustering;
+
+struct SimTracking {
+  Tracker tracker;
+  TrackGenerator trackGen;
+  HitFinder hitFinder;
+  TrackLabeler trackLabeler;
+  SimTracking() : tracker(simBase.geoTrans), trackGen(), hitFinder(simBase.geoTrans), trackLabeler()
+  {
+    trackGen.setSeed(123456789);
+    tracker.init(true);
+  }
+};
+
+static SimTracking simTracking;
+
+struct GenTrack {
+  Track track;
+  std::vector<Hit> hits;
+  int nFiredChambers{ 0 };
+  bool isReconstructible() { return nFiredChambers > 2; }
+};
 
 std::vector<Hit> generateHits(size_t nHits, int deId, const Mapping& mapping, const GeometryTransformer geoTrans)
 {
@@ -68,10 +122,40 @@ std::vector<Hit> generateHits(size_t nHits, int deId, const Mapping& mapping, co
     if (!mapping.stripByPosition(point.x(), point.y(), 0, deId, false).isValid()) {
       continue;
     }
-    Point3D<float> globalPoint = SIMUL::geoTrans.localToGlobal(deId, point);
+    Point3D<float> globalPoint = geoTrans.localToGlobal(deId, point);
     hits.emplace_back(hits.size(), deId, globalPoint, globalPoint);
   }
   return hits;
+}
+
+std::vector<GenTrack> generateTracks(int nTracks)
+{
+  Mapping::MpStripIndex stripIndex;
+  auto tracks = simTracking.trackGen.generate(nTracks);
+  std::vector<GenTrack> genTracks;
+  for (auto& track : tracks) {
+    int trackId = &track - &tracks[0];
+    GenTrack genTrack;
+    genTrack.track = track;
+    for (int ich = 0; ich < 4; ++ich) {
+      auto pairs = simTracking.hitFinder.getLocalPositions(track, ich);
+      bool isFired = false;
+      for (auto pair : pairs) {
+        stripIndex = simBase.mapping.stripByPosition(pair.second.x(), pair.second.y(), 0, pair.first, false);
+        if (!stripIndex.isValid()) {
+          continue;
+        }
+        auto pos = simBase.geoTrans.localToGlobal(pair.first, pair.second.x(), pair.second.y());
+        genTrack.hits.emplace_back(trackId, pair.first, pos, pos);
+        isFired = true;
+      }
+      if (isFired) {
+        ++genTrack.nFiredChambers;
+      }
+    }
+    genTracks.emplace_back(genTrack);
+  }
+  return genTracks;
 }
 
 bool checkLabel(const ColumnData& digit, MCLabel& label, std::string& errorMessage)
@@ -106,6 +190,93 @@ bool checkLabel(const ColumnData& digit, MCLabel& label, std::string& errorMessa
   return isOk;
 }
 
+std::vector<PreCluster> getRelatedPreClusters(const Hit& hit, int cathode, const std::vector<PreCluster>& preClusters, const o2::dataformats::MCTruthContainer<MCCompLabel>& labels)
+{
+  std::vector<PreCluster> sortedPC;
+  for (size_t ipc = 0; ipc < preClusters.size(); ++ipc) {
+    for (auto& label : labels.getLabels(ipc)) {
+      if (label.getTrackID() == hit.GetTrackID() && preClusters[ipc].cathode == cathode) {
+        sortedPC.emplace_back(preClusters[ipc]);
+      }
+    }
+  }
+  std::sort(sortedPC.begin(), sortedPC.end(), [](const PreCluster& pc1, const PreCluster& pc2) { return (pc1.firstColumn <= pc2.firstColumn); });
+  return std::move(sortedPC);
+}
+
+bool isContiguous(const std::vector<PreCluster>& sortedPC)
+{
+  int lastColumn = sortedPC.front().firstColumn;
+  for (auto it = sortedPC.begin() + 1; it != sortedPC.end(); ++it) {
+    if (it->firstColumn - (it - 1)->firstColumn != 1) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool isInside(double localX, double localY, const std::vector<PreCluster>& sortedPC, std::string& errorMsg)
+{
+  std::stringstream ss;
+  ss << "Point: (" << localX << ", " << localY << ")  outside PC:";
+  for (auto& pc : sortedPC) {
+    MpArea area = simClustering.preClusterHelper.getArea(pc);
+    ss << "  PC: " << pc;
+    ss << "  area: x (" << area.getXmin() << ", " << area.getXmax() << ")";
+    ss << " y (" << area.getYmin() << ", " << area.getYmax() << ")";
+    if (localX >= area.getXmin() && localX <= area.getXmax() &&
+        localY >= area.getYmin() && localY <= area.getYmax()) {
+      return true;
+    }
+  }
+  errorMsg = ss.str();
+  return false;
+}
+
+std::string getDebugInfo(const std::vector<GenTrack>& genTracks, Tracker& tracker, TrackLabeler& trackLabeler)
+{
+  std::stringstream debug;
+  for (size_t igen = 0; igen < genTracks.size(); ++igen) {
+    debug << "Gen: " << genTracks[igen].track << "\n  hits:\n";
+    for (auto& hit : genTracks[igen].hits) {
+      debug << "    " << hit << "\n";
+    }
+    debug << "  clusters:\n";
+    for (size_t icl = 0; icl < tracker.getClusters().size(); ++icl) {
+      bool matches = false;
+      for (auto& label : trackLabeler.getTrackClustersLabels().getLabels(icl)) {
+        if (label.getTrackID() == igen) {
+          matches = true;
+          break;
+        }
+      }
+      if (matches) {
+        debug << "    icl: " << icl << "  " << tracker.getClusters()[icl] << "\n";
+      }
+    }
+  }
+
+  for (size_t itrack = 0; itrack < tracker.getTracks().size(); ++itrack) {
+    debug << "reco: " << tracker.getTracks()[itrack] << "  matches:";
+    for (auto& label : trackLabeler.getTracksLabels().getLabels(itrack)) {
+      debug << "  " << label.getTrackID();
+    }
+    debug << "  clusters:\n";
+    for (int ich = 0; ich < 4; ++ich) {
+      int icl = tracker.getTracks()[itrack].getClusterMatched(ich);
+      debug << "    icl: " << icl;
+      if (icl >= 0) {
+        debug << "    " << tracker.getClusters()[icl];
+        for (auto& label : trackLabeler.getTrackClustersLabels().getLabels(icl)) {
+          debug << "  ID: " << label.getTrackID() << "  fires: [" << label.isFiredBP() << ", " << label.isFiredNBP() << "]";
+        }
+        debug << "\n";
+      }
+    }
+  }
+  return debug.str();
+}
+
 std::vector<int> getDEList()
 {
   // The algorithm should work in the same way on all detection elements.
@@ -117,65 +288,15 @@ std::vector<int> getDEList()
   return deList;
 }
 
-BOOST_TEST_GLOBAL_FIXTURE(SIMUL);
-
 BOOST_AUTO_TEST_SUITE(o2_mid_simulation)
-// BOOST_FIXTURE_TEST_SUITE(sim, SIMUL)
-
-BOOST_DATA_TEST_CASE(MID_SimulChain, boost::unit_test::data::make(getDEList()), deId)
-{
-  // In this test, we generate a cluster from one impact point and we reconstruct it.
-  // If the impact point is in the RPC, the digitizer will return a list of strips,
-  // that are close to each other by construction.
-  // We will therefore have exactly one reconstructed cluster.
-  // It is worth noting, however, that the clustering algorithm is designed to
-  // produce two clusters if the BP and NBP do not overlap.
-  // The digitizer produces superposed BP and NBP strips only if the response parameters
-  // are the same for both.
-  // Otherwise we can have from 1 to 3 clusters produced.
-
-  std::vector<ColumnDataMC> digitStoreMC;
-  o2::dataformats::MCTruthContainer<MCLabel> digitLabelsMC;
-  std::vector<ColumnData> digitStore;
-  o2::dataformats::MCTruthContainer<MCLabel> digitLabels;
-
-  for (int ievent = 0; ievent < 100; ++ievent) {
-    auto hits = generateHits(1, deId, SIMUL::mapping, SIMUL::geoTrans);
-    std::stringstream ss;
-    int nGenClusters = 1, nRecoClusters = 0;
-    SIMUL::digitizer.process(hits, digitStoreMC, digitLabelsMC);
-    SIMUL::digitsMerger.process(digitStoreMC, digitLabelsMC, digitStore, digitLabels);
-    SIMUL::preClusterizer.process(digitStore);
-    gsl::span<const PreCluster> preClusters(SIMUL::preClusterizer.getPreClusters().data(), SIMUL::preClusterizer.getPreClusters().size());
-    SIMUL::clusterizer.process(preClusters);
-    nRecoClusters = SIMUL::clusterizer.getClusters().size();
-    ss << "nRecoClusters: " << nRecoClusters << "  nGenClusters: " << nGenClusters << "\n";
-    for (auto& col : digitStore) {
-      ss << col << "\n";
-    }
-    ss << "\n  Clusters:\n";
-    for (auto it = SIMUL::clusterizer.getClusters().begin(); it < SIMUL::clusterizer.getClusters().begin() + nRecoClusters; ++it) {
-      ss << "pos: (" << it->xCoor << ", " << it->yCoor << ")  sigma2: (" << it->sigmaX2 << ", " << it->sigmaY2 << ")\n";
-    }
-
-    int nColumns = digitStore.size();
-
-    if (SIMUL::params.getParB(0, deId) == SIMUL::params.getParB(1, deId) && nColumns <= 2) {
-      BOOST_TEST((nRecoClusters == nGenClusters), ss.str());
-    } else {
-      BOOST_TEST((nRecoClusters >= nGenClusters && nRecoClusters <= nColumns), ss.str());
-    }
-  }
-}
 
 BOOST_DATA_TEST_CASE(MID_Digitizer, boost::unit_test::data::make(getDEList()), deId)
 {
-  // In this test we generate 100 hits
-  // We then tests that the MC labels are correctly assigned
-  auto hits = generateHits(100, deId, SIMUL::mapping, SIMUL::geoTrans);
+  // In this test we generate hits, digitize them and test that the MC labels are correctly assigned
+  auto hits = generateHits(10, deId, simBase.mapping, simBase.geoTrans);
   std::vector<ColumnDataMC> digitStoreMC;
   o2::dataformats::MCTruthContainer<MCLabel> digitLabelsMC;
-  SIMUL::digitizer.process(hits, digitStoreMC, digitLabelsMC);
+  simDigitizer.digitizer.process(hits, digitStoreMC, digitLabelsMC);
   // We check that we have as many sets of labels as digits
   BOOST_TEST(digitStoreMC.size() == digitLabelsMC.getIndexedSize());
   for (size_t idig = 0; idig < digitLabelsMC.getIndexedSize(); ++idig) {
@@ -188,10 +309,10 @@ BOOST_DATA_TEST_CASE(MID_Digitizer, boost::unit_test::data::make(getDEList()), d
     }
   }
 
-  // We then test the merging of the 100 hits
+  // We then test the merging of the hits
   std::vector<ColumnData> digitStore;
   o2::dataformats::MCTruthContainer<MCLabel> digitLabels;
-  SIMUL::digitsMerger.process(digitStoreMC, digitLabelsMC, digitStore, digitLabels);
+  simDigitizer.digitsMerger.process(digitStoreMC, digitLabelsMC, digitStore, digitLabels);
   // The number of merged digits should be smaller than the number of input digits
   BOOST_TEST(digitStore.size() <= digitStoreMC.size());
   // We check that we have as many sets of labels as digits
@@ -216,7 +337,276 @@ BOOST_DATA_TEST_CASE(MID_Digitizer, boost::unit_test::data::make(getDEList()), d
   }
 }
 
-// BOOST_AUTO_TEST_SUITE_END()
+BOOST_DATA_TEST_CASE(MID_DigitReader, boost::unit_test::data::make(getDEList()), deId)
+{
+  // Testing of the packing of digits
+
+  size_t nEvents = 20;
+  std::vector<std::vector<ColumnDataMC>> digitsCollection;
+  std::vector<ColumnDataMC> digits, packedDigits;
+  std::vector<o2::dataformats::MCTruthContainer<MCLabel>> mcContainerCollection;
+  o2::dataformats::MCTruthContainer<MCLabel> mcContainer, packedMCContainer;
+  for (size_t ievent = 0; ievent < nEvents; ++ievent) {
+    // Generate digits per event. Each event has a different timestamp
+    auto hits = generateHits(5, deId, simBase.mapping, simBase.geoTrans);
+    digitsCollection.push_back({});
+    mcContainerCollection.push_back({});
+    simDigitizer.digitizer.setEventTime(10 * ievent);
+    simDigitizer.digitizer.process(hits, digitsCollection.back(), mcContainerCollection.back());
+    std::copy(digitsCollection.back().begin(), digitsCollection.back().end(), std::back_inserter(digits));
+    mcContainer.mergeAtBack(mcContainerCollection.back());
+  }
+  // This should pack again the digits per event
+  simDigitizer.digitsPacker.process(digits, mcContainer, 0);
+  BOOST_TEST(simDigitizer.digitsPacker.getNGroups() == nEvents);
+  for (size_t igroup = 0; igroup < simDigitizer.digitsPacker.getNGroups(); ++igroup) {
+    simDigitizer.digitsPacker.getGroup(igroup, packedDigits, packedMCContainer);
+    // Check that the number of digits per event is equal to the input one
+    BOOST_TEST(packedDigits.size() == digitsCollection[igroup].size());
+    for (size_t idigit = 0; idigit < packedDigits.size(); ++idigit) {
+      // Check that we have the same digits as the input ones
+      BOOST_TEST(packedDigits[idigit].getNonBendPattern() == digitsCollection[igroup][idigit].getNonBendPattern());
+      // Check that we have the same labels as the input ones
+      size_t nLabels = packedMCContainer.getLabels(idigit).size();
+      BOOST_TEST(nLabels == mcContainerCollection[igroup].getLabels(idigit).size());
+      for (size_t ilabel = 0; ilabel < nLabels; ++ilabel) {
+        BOOST_TEST(packedMCContainer.getLabels(idigit)[ilabel] == mcContainerCollection[igroup].getLabels(idigit)[ilabel]);
+      }
+    }
+  }
+}
+
+BOOST_DATA_TEST_CASE(MID_SingleCluster, boost::unit_test::data::make(getDEList()), deId)
+{
+  // In this test, we generate reconstruct one single hit.
+  // If the hit is in the RPC, the digitizer will return a list of strips,
+  // that are close to each other by construction.
+  // We will therefore have exactly one reconstructed cluster.
+  // It is worth noting, however, that the clustering algorithm is designed to
+  // produce two clusters if the BP and NBP do not overlap.
+  // The digitizer produces superposed BP and NBP strips only if the response parameters
+  // are the same for both.
+  // Otherwise we can have from 1 to 3 clusters produced.
+
+  std::vector<ColumnDataMC> digitStoreMC;
+  o2::dataformats::MCTruthContainer<MCLabel> digitLabelsMC;
+  std::vector<ColumnData> digitStore;
+  o2::dataformats::MCTruthContainer<MCLabel> digitLabels;
+
+  for (int ievent = 0; ievent < 100; ++ievent) {
+    auto hits = generateHits(1, deId, simBase.mapping, simBase.geoTrans);
+    std::stringstream ss;
+    int nGenClusters = 1, nRecoClusters = 0;
+    simDigitizer.digitizer.process(hits, digitStoreMC, digitLabelsMC);
+    simDigitizer.digitsMerger.process(digitStoreMC, digitLabelsMC, digitStore, digitLabels);
+    simClustering.preClusterizer.process(digitStore);
+    gsl::span<const PreCluster> preClusters(simClustering.preClusterizer.getPreClusters().data(), simClustering.preClusterizer.getPreClusters().size());
+    simClustering.clusterizer.process(preClusters);
+    nRecoClusters = simClustering.clusterizer.getClusters().size();
+    ss << "nRecoClusters: " << nRecoClusters << "  nGenClusters: " << nGenClusters << "\n";
+    for (auto& col : digitStore) {
+      ss << col << "\n";
+    }
+    ss << "\n  Clusters:\n";
+    for (auto& cl : simClustering.clusterizer.getClusters()) {
+      ss << cl << "\n";
+    }
+
+    int nColumns = digitStore.size();
+
+    if (simDigitizer.params.getParB(0, deId) == simDigitizer.params.getParB(1, deId) && nColumns <= 2) {
+      BOOST_TEST((nRecoClusters == nGenClusters), ss.str());
+    } else {
+      BOOST_TEST((nRecoClusters >= nGenClusters && nRecoClusters <= nColumns), ss.str());
+    }
+  }
+}
+
+BOOST_DATA_TEST_CASE(MID_SimClusters, boost::unit_test::data::make(getDEList()), deId)
+{
+  // In this test, we generate few hits, reconstruct the clusters
+  // and verify that the MC labels are correctly assigned to the clusters
+
+  std::vector<ColumnDataMC> digitStoreMC;
+  o2::dataformats::MCTruthContainer<MCLabel> digitLabelsMC;
+  std::vector<ColumnData> digitStore;
+  o2::dataformats::MCTruthContainer<MCLabel> digitLabels;
+
+  for (int ievent = 0; ievent < 100; ++ievent) {
+    auto hits = generateHits(10, deId, simBase.mapping, simBase.geoTrans);
+    std::stringstream ss;
+    int nGenClusters = 1, nRecoClusters = 0;
+    simDigitizer.digitizer.process(hits, digitStoreMC, digitLabelsMC);
+    simDigitizer.digitsMerger.process(digitStoreMC, digitLabelsMC, digitStore, digitLabels);
+    simClustering.preClusterizer.process(digitStore);
+    gsl::span<const PreCluster> preClusters(simClustering.preClusterizer.getPreClusters().data(), simClustering.preClusterizer.getPreClusters().size());
+    simClustering.correlation.clear();
+    simClustering.clusterizer.process(preClusters);
+    simClustering.preClusterLabeler.process(preClusters, digitLabels);
+    // Check that all pre-clusters have a label
+    BOOST_TEST(preClusters.size() == simClustering.preClusterLabeler.getContainer().getIndexedSize());
+    // Check that the pre-clusters contain the hits from which they were generated
+    for (auto& hit : hits) {
+      auto pt = simBase.geoTrans.globalToLocal(hit.GetDetectorID(), hit.middlePoint());
+      for (int icath = 0; icath < 2; ++icath) {
+        auto sortedPC = getRelatedPreClusters(hit, 1, simClustering.preClusterizer.getPreClusters(), simClustering.preClusterLabeler.getContainer());
+        if (icath == 1) {
+          // Check that there is only 1 pre-cluster in the NBP
+          // CAVEAT: this is valid as far as we do not have masked strips
+          BOOST_TEST(sortedPC.size() == 1);
+        }
+        std::string errorMsg;
+        BOOST_TEST(isInside(pt.x(), pt.y(), sortedPC, errorMsg), errorMsg.c_str());
+      }
+    }
+
+    gsl::span<const Cluster2D> clusters(simClustering.clusterizer.getClusters().data(), simClustering.clusterizer.getClusters().size());
+    gsl::span<const std::array<size_t, 2>> correlation(simClustering.correlation.data(), simClustering.correlation.size());
+    simClustering.clusterLabeler.process(preClusters, simClustering.preClusterLabeler.getContainer(), clusters, correlation);
+    // Check that all clusters have a label
+    BOOST_TEST(clusters.size() == simClustering.clusterLabeler.getContainer().getIndexedSize());
+
+    for (auto pair : simClustering.correlation) {
+      // std::string errorMsg;
+      // const auto& cl(clusters[pair.first]);
+      // std::vector<PreCluster> sortedPC{ preClusters[pair.second] };
+      // Test that the cluster is inside the associated pre-cluster
+      // BOOST_TEST(isInside(cl.xCoor, cl.yCoor, sortedPC, errorMsg), errorMsg.c_str());
+      // Test that the cluster has all pre-clusters labels
+      for (auto& pcLabel : simClustering.preClusterLabeler.getContainer().getLabels(pair[1])) {
+        bool isInLabels = false;
+        for (auto& label : simClustering.clusterLabeler.getContainer().getLabels(pair[0])) {
+          if (label.compare(pcLabel) == 1) {
+            isInLabels = true;
+            bool isFired = (preClusters[pair[1]].cathode == 0) ? label.isFiredBP() : label.isFiredNBP();
+            // Test that the fired flag is correctly set
+            BOOST_TEST(isFired);
+            break;
+          }
+        }
+        BOOST_TEST(isInLabels);
+      }
+    }
+  }
+}
+
+BOOST_DATA_TEST_CASE(MID_SimTracks, boost::unit_test::data::make({ 1, 2, 3, 4, 5, 6, 7, 8, 9 }), nTracks)
+{
+  // In this test, we generate tracks and we reconstruct them.
+  // It is worth noting that in this case we do not use the default digitizer
+  // But rather a digitizer with a cluster size of 0.
+  // The reason is that, with the current implementation of the digitizer,
+  // which has to be further fine-tuned,
+  // we can have very large clusters, of few local-boards/columns.
+  // In this case the resolution is rather bad, and this impacts the tracking performance,
+  // even when the tracking algorithm has no bugs.
+  // The aim of this test is to check that the algorithms work.
+  // The tracking performance and tuning of the MC will be done in the future via dedicated studies.
+
+  std::vector<ColumnDataMC> digitStoreMC;
+  o2::dataformats::MCTruthContainer<MCLabel> digitLabelsMC;
+  std::vector<ColumnData> digitStore;
+  o2::dataformats::MCTruthContainer<MCLabel> digitLabels;
+
+  // In the tracking algorithm, if we have two tracks that are compatible within uncertainties
+  // we keep only one of the two. This is done to avoid duplicated tracks.
+  // In this test we can have many tracks in the same event.
+  // If two tracks are close, they can give two reconstucted tracks compatible among each others,
+  // within their uncertainties. One of the two is therefore rejected.
+  // However, the track might not be compatible with the (rejected) generated track that has no uncertainty.
+  // To avoid this, compare adding a factor 2 in the sigma cut.
+  float chi2Cut = simTracking.tracker.getSigmaCut() * simTracking.tracker.getSigmaCut();
+
+  unsigned long int nReco = 0, nGood = 0, nUntagged = 0, nTaggedNonCompatible = 0, nReconstructible = 0;
+
+  for (int ievent = 0; ievent < 100; ++ievent) {
+    auto genTracks = generateTracks(nTracks);
+    std::vector<Hit> hits;
+    for (auto& genTrack : genTracks) {
+      std::copy(genTrack.hits.begin(), genTrack.hits.end(), std::back_inserter(hits));
+      if (genTrack.isReconstructible()) {
+        ++nReconstructible;
+      }
+    }
+
+    simDigitizer.digitizerNoClusterSize.process(hits, digitStoreMC, digitLabelsMC);
+    simDigitizer.digitsMerger.process(digitStoreMC, digitLabelsMC, digitStore, digitLabels);
+    simClustering.preClusterizer.process(digitStore);
+    gsl::span<const PreCluster> preClusters(simClustering.preClusterizer.getPreClusters().data(), simClustering.preClusterizer.getPreClusters().size());
+    simClustering.correlation.clear();
+    simClustering.clusterizer.process(preClusters);
+    simClustering.preClusterLabeler.process(preClusters, digitLabels);
+    gsl::span<const Cluster2D> clusters(simClustering.clusterizer.getClusters().data(), simClustering.clusterizer.getClusters().size());
+    gsl::span<const std::array<size_t, 2>> correlation(simClustering.correlation.data(), simClustering.correlation.size());
+    simClustering.clusterLabeler.process(preClusters, simClustering.preClusterLabeler.getContainer(), clusters, correlation);
+    simTracking.tracker.process(clusters);
+    gsl::span<const Track> tracks(simTracking.tracker.getTracks().data(), simTracking.tracker.getTracks().size());
+    gsl::span<const Cluster3D> trClusters(simTracking.tracker.getClusters().data(), simTracking.tracker.getClusters().size());
+    simTracking.trackLabeler.process(trClusters, tracks, simClustering.clusterLabeler.getContainer());
+
+    // For the moment we save all clusters
+    BOOST_TEST(trClusters.size() == clusters.size());
+    BOOST_TEST(tracks.size() == simTracking.trackLabeler.getTracksLabels().getIndexedSize());
+    BOOST_TEST(trClusters.size() == simTracking.trackLabeler.getTrackClustersLabels().getIndexedSize());
+
+    std::string debugInfo = "";
+    // Test that all reconstructible tracks are reconstructed
+    for (size_t igen = 0; igen < genTracks.size(); ++igen) {
+      bool isReco = false;
+      for (size_t itrack = 0; itrack < tracks.size(); ++itrack) {
+        for (auto& label : simTracking.trackLabeler.getTracksLabels().getLabels(itrack)) {
+          if (label.getTrackID() == igen) {
+            if (tracks[itrack].isCompatible(genTracks[igen].track, chi2Cut)) {
+              isReco = true;
+            }
+          }
+        }
+      }
+      std::stringstream ss;
+      ss << "Gen ID: " << igen << "  isReconstructible: " << genTracks[igen].isReconstructible() << " != isReco " << isReco;
+      if (debugInfo.empty()) {
+        debugInfo = getDebugInfo(genTracks, simTracking.tracker, simTracking.trackLabeler);
+      }
+      ss << "\n"
+         << debugInfo;
+      BOOST_TEST(isReco == genTracks[igen].isReconstructible(), ss.str().c_str());
+    }
+
+    // Perform some statistics
+    for (size_t itrack = 0; itrack < tracks.size(); ++itrack) {
+      for (auto& label : simTracking.trackLabeler.getTracksLabels().getLabels(itrack)) {
+        if (label.isEmpty()) {
+          ++nUntagged;
+          continue;
+        }
+        const Track& matchedGenTrack(genTracks[label.getTrackID()].track);
+        if (tracks[itrack].isCompatible(matchedGenTrack, chi2Cut)) {
+          ++nGood;
+        } else {
+          ++nTaggedNonCompatible;
+        }
+        int nMatched = 0;
+        for (int ich = 0; ich < 4; ++ich) {
+          int trClusIdx = tracks[itrack].getClusterMatched(ich);
+          if (trClusIdx < 0) {
+            continue;
+          }
+          for (auto& trClusterLabel : simTracking.trackLabeler.getTrackClustersLabels().getLabels(trClusIdx)) {
+            if (trClusterLabel.getTrackID() == label.getTrackID()) {
+              ++nMatched;
+            }
+          }
+        }
+        BOOST_TEST(nMatched >= 3);
+      }
+    }
+  }
+  std::stringstream outMsg;
+  outMsg << "Tracks per event: " << nTracks << "  fraction of good: " << static_cast<double>(nGood) / static_cast<double>(nReconstructible) << "  untagged: " << static_cast<double>(nUntagged) / static_cast<double>(nReconstructible) << "  tagged but not compatible: " << static_cast<double>(nTaggedNonCompatible) / static_cast<double>(nReconstructible);
+
+  BOOST_TEST_MESSAGE(outMsg.str().c_str());
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 } // namespace mid

--- a/Detectors/MUON/MID/TestingSimTools/CMakeLists.txt
+++ b/Detectors/MUON/MID/TestingSimTools/CMakeLists.txt
@@ -3,10 +3,12 @@ set(MODULE_NAME "MIDTestingSimTools")
 O2_SETUP(NAME ${MODULE_NAME})
 
 set(SRCS
+   src/HitFinder.cxx
    src/TrackGenerator.cxx
 )
 
 set(HEADERS
+   include/${MODULE_NAME}/HitFinder.h
    include/${MODULE_NAME}/TrackGenerator.h
 )
 

--- a/Detectors/MUON/MID/TestingSimTools/include/MIDTestingSimTools/HitFinder.h
+++ b/Detectors/MUON/MID/TestingSimTools/include/MIDTestingSimTools/HitFinder.h
@@ -8,7 +8,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file   MIDBase/HitFinder.h
+/// \file   MIDTestingSimTools/HitFinder.h
 /// \brief  Hit finder for MID
 /// \author Diego Stocco <Diego.Stocco at cern.ch>
 /// \date   14 March 2018
@@ -19,7 +19,6 @@
 #include "MathUtils/Cartesian3D.h"
 #include "DataFormatsMID/Track.h"
 #include "MIDBase/GeometryTransformer.h"
-#include "MIDBase/Constants.h"
 
 namespace o2
 {

--- a/Detectors/MUON/MID/TestingSimTools/include/MIDTestingSimTools/TrackGenerator.h
+++ b/Detectors/MUON/MID/TestingSimTools/include/MIDTestingSimTools/TrackGenerator.h
@@ -29,16 +29,11 @@ namespace mid
 class TrackGenerator
 {
  public:
-  TrackGenerator();
-  virtual ~TrackGenerator() = default;
-
-  TrackGenerator(const TrackGenerator&) = delete;
-  TrackGenerator& operator=(const TrackGenerator&) = delete;
-  TrackGenerator(TrackGenerator&&) = delete;
-  TrackGenerator& operator=(TrackGenerator&&) = delete;
-
   std::vector<Track> generate();
   std::vector<Track> generate(int nTracks);
+
+  /// Sets the seed
+  inline void setSeed(unsigned int seed) { mGenerator.seed(seed); }
 
   /// Sets the mean number of track per events
   void setMeanTracksPerEvent(int meanTracksPerEvent) { mMeanTracksPerEvent = meanTracksPerEvent; }
@@ -56,10 +51,10 @@ class TrackGenerator
  private:
   std::array<float, 4> getLimitsForAcceptance(std::array<float, 3> pos);
 
-  int mMeanTracksPerEvent;               ///< Mean tracks per event
-  std::array<float, 4> mSlopeLimits;     ///< Limits for track slope
-  std::array<float, 6> mPositionLimits;  ///< x,y,z position limits
-  std::default_random_engine mGenerator; ///< Random numbers generator
+  int mMeanTracksPerEvent = 1;                                           ///< Mean tracks per event
+  std::array<float, 4> mSlopeLimits{ { -0.2, 0.2, -0.5, 0.5 } };         ///< Limits for track slope
+  std::array<float, 6> mPositionLimits{ { -2., 2, -2., 2., -5., 5. } };  ///< x,y,z position limits
+  std::default_random_engine mGenerator{ std::default_random_engine() }; ///< Random numbers generator
 };
 } // namespace mid
 } // namespace o2

--- a/Detectors/MUON/MID/TestingSimTools/src/HitFinder.cxx
+++ b/Detectors/MUON/MID/TestingSimTools/src/HitFinder.cxx
@@ -8,16 +8,15 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file   MID/Base/src/HitFinder.cxx
+/// \file   MID/TestingSimTools/src/HitFinder.cxx
 /// \brief  Implementation of the hit finder for MID
 /// \author Diego Stocco <Diego.Stocco at cern.ch>
 /// \date   14 March 2018
 
-#include "MIDBase/HitFinder.h"
+#include "MIDTestingSimTools/HitFinder.h"
 
 #include <cmath>
 #include "MIDBase/Constants.h"
-#include "MathUtils/Cartesian3D.h"
 
 namespace o2
 {

--- a/Detectors/MUON/MID/TestingSimTools/src/TrackGenerator.cxx
+++ b/Detectors/MUON/MID/TestingSimTools/src/TrackGenerator.cxx
@@ -19,15 +19,6 @@ namespace o2
 {
 namespace mid
 {
-//______________________________________________________________________________
-TrackGenerator::TrackGenerator()
-  : mMeanTracksPerEvent(1),
-    mSlopeLimits{ { -0.2, 0.2, -0.5, 0.5 } },
-    mPositionLimits{ { -2., 2, -2., 2., -5., 5. } },
-    mGenerator(std::default_random_engine())
-{
-  /// Default constructor
-}
 
 //______________________________________________________________________________
 std::vector<Track> TrackGenerator::generate()

--- a/Detectors/MUON/MID/Tracking/test/bench_Tracker.cxx
+++ b/Detectors/MUON/MID/Tracking/test/bench_Tracker.cxx
@@ -14,13 +14,12 @@
 /// \date   17 March 2018
 
 #include "benchmark/benchmark.h"
-#include <iostream>
 #include <random>
 #include "DataFormatsMID/Cluster2D.h"
 #include "DataFormatsMID/Track.h"
 #include "MIDBase/Mapping.h"
 #include "MIDBase/MpArea.h"
-#include "MIDBase/HitFinder.h"
+#include "MIDTestingSimTools/HitFinder.h"
 #include "MIDTestingSimTools/TrackGenerator.h"
 #include "MIDTracking/Tracker.h"
 

--- a/Detectors/MUON/MID/Tracking/test/testTracker.cxx
+++ b/Detectors/MUON/MID/Tracking/test/testTracker.cxx
@@ -23,12 +23,11 @@
 #include <string>
 #include <sstream>
 #include <vector>
-#include <random>
 #include "DataFormatsMID/Cluster2D.h"
 #include "DataFormatsMID/Track.h"
 #include "MIDBase/Mapping.h"
 #include "MIDBase/MpArea.h"
-#include "MIDBase/HitFinder.h"
+#include "MIDTestingSimTools/HitFinder.h"
 #include "MIDTestingSimTools/TrackGenerator.h"
 #include "MIDTracking/Tracker.h"
 

--- a/cmake/O2Dependencies.cmake
+++ b/cmake/O2Dependencies.cmake
@@ -2490,6 +2490,8 @@ o2_define_bucket(
     O2MIDBase
     O2MIDSimulation
     O2MIDClustering
+    O2MIDTracking
+    O2MIDTestingSimTools
 
     INCLUDE_DIRECTORIES
     ${CMAKE_SOURCE_DIR}/Detectors/MUON/MID/Simulation/src


### PR DESCRIPTION
This PR consists of 5 separate but closely related commits:
- the first one adds the track labeler
- the second to fourth are needed for the tests
- the last commit adds the tests for both the track labeler and the cluster labeler
The tests are meant to check the correct label propagation throughout the full simulation/reconstruction chain.
They are in between unit_tests and integration tests.

Please do not squash the 5 commits.