### PR TITLE
removing TNamed in PSU

### DIFF
--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/PowerSupplyUnit.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/PowerSupplyUnit.h
@@ -16,7 +16,6 @@
 #ifndef ALICEO2_MFT_POWERSUPPLYUNIT_H_
 #define ALICEO2_MFT_POWERSUPPLYUNIT_H_
 
-#include "TNamed.h"
 #include "TGeoVolume.h"
 #include "TGeoMatrix.h"
 
@@ -25,19 +24,19 @@ namespace o2
 namespace mft
 {
 
-class PowerSupplyUnit : public TNamed
+class PowerSupplyUnit
 {
 
  public:
   PowerSupplyUnit();
   //PowerSupplyUnit(Double_t Rwater, Double_t DRPipe, Double_t PowerSupplyUnitThickness, Double_t CarbonThickness);
 
-  ~PowerSupplyUnit() override = default;
+  ~PowerSupplyUnit() = default;
 
   TGeoVolumeAssembly* create();
 
  private:
-  ClassDefOverride(PowerSupplyUnit, 2);
+ClassDef(PowerSupplyUnit, 2);
 };
 } // namespace mft
 } // namespace o2

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/PowerSupplyUnit.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/PowerSupplyUnit.h
@@ -36,7 +36,7 @@ class PowerSupplyUnit
   TGeoVolumeAssembly* create();
 
  private:
-ClassDef(PowerSupplyUnit, 2);
+  ClassDef(PowerSupplyUnit, 2);
 };
 } // namespace mft
 } // namespace o2

--- a/Detectors/ITSMFT/MFT/base/src/PowerSupplyUnit.cxx
+++ b/Detectors/ITSMFT/MFT/base/src/PowerSupplyUnit.cxx
@@ -31,20 +31,12 @@ using namespace o2::mft;
 ClassImp(o2::mft::PowerSupplyUnit);
 
 //_____________________________________________________________________________
-PowerSupplyUnit::PowerSupplyUnit() : TNamed()
+PowerSupplyUnit::PowerSupplyUnit()
 {
   create();
 }
-/*
 //_____________________________________________________________________________
-PowerSupplyUnit::PowerSupplyUnit(Double_t rWater, Double_t dRPipe, Double_t heatExchangerThickness,
-				 Double_t carbonThickness)
-  : TNamed(),mPSU(nullptr)
-{
-  create(1,1);
-}
-*/
-//_____________________________________________________________________________
+
 TGeoVolumeAssembly* PowerSupplyUnit::create()
 {
 


### PR DESCRIPTION
The TNamed is removed (override as well) in PowerSupplyUnit class