### PR TITLE
Optimizations to the streaming of MCTruthContainer

### DIFF
--- a/DataFormats/simulation/CMakeLists.txt
+++ b/DataFormats/simulation/CMakeLists.txt
@@ -15,6 +15,7 @@ o2_add_library(SimulationDataFormat
                        src/RunContext.cxx
                        src/StackParam.cxx
                        src/MCEventHeader.cxx
+                       src/CustomStreamers.cxx
                PUBLIC_LINK_LIBRARIES ms_gsl::ms_gsl
                                      O2::DetectorsCommonDataFormats
                                      O2::GPUCommon O2::DetectorsBase

--- a/DataFormats/simulation/src/CustomStreamers.cxx
+++ b/DataFormats/simulation/src/CustomStreamers.cxx
@@ -1,0 +1,41 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file CustomStreamers.cxx
+/// \brief Custom streamer implementations for module SimulationDataFormat
+/// \author Matthias Richter (Matthias.Richter@scieq.net)
+/// \since Sep 5 2019
+
+#include "SimulationDataFormat/MCTruthContainer.h"
+#include "SimulationDataFormat/MCCompLabel.h"
+#include "TBuffer.h"
+
+namespace o2
+{
+namespace dataformats
+{
+
+template <>
+void MCTruthContainer<MCCompLabel>::Streamer(TBuffer& R__b)
+{
+  // the custom streamer for MCTruthContainer<MCCompLabel>
+
+  if (R__b.IsReading()) {
+    R__b.ReadClassBuffer(MCTruthContainer<MCCompLabel>::Class(), this);
+    inflate();
+  } else {
+    deflate();
+    R__b.WriteClassBuffer(MCTruthContainer<MCCompLabel>::Class(), this);
+    inflate();
+  }
+}
+
+} // namespace dataformats
+} // namespace o2

--- a/DataFormats/simulation/src/SimulationDataLinkDef.h
+++ b/DataFormats/simulation/src/SimulationDataLinkDef.h
@@ -44,7 +44,7 @@
 #pragma link C++ class o2::BasicXYZQHit < double, double, int> + ;
 #pragma link C++ struct o2::dataformats::MCTruthHeaderElement + ;
 #pragma link C++ class o2::dataformats::MCTruthContainer < long> + ;
-#pragma link C++ class o2::dataformats::MCTruthContainer < o2::MCCompLabel> + ;
+#pragma link C++ class o2::dataformats::MCTruthContainer < o2::MCCompLabel > -;
 #pragma link C++ class std::vector < o2::dataformats::MCTruthContainer < o2::MCCompLabel>> + ;
 #pragma link C++ class std::vector < o2::MCCompLabel> + ;
 #pragma link C++ class std::vector < o2::dataformats::MCTruthHeaderElement> + ;


### PR DESCRIPTION
The MCLabelContainer has two vectors of messageable type which do not need to be root serialized.
For the moment, flattening always requires a copy, but the data can be directly copied
to the message resource. The prototype can be extended later to use multiple parts as allowed by the
DataHeader.

Restore can be done using spectator memory resources for the two regions of the input buffer, but this kind of memory resource needs to be implemented. For the moment we have a copy also here.

The DPL I/O API will be extended to use the custom methods for flatten/restore. In the end its not much different then the BOOST serialization concept, but we have the option to optimize this by using polymorphic memory resources and allocators.

TODO before merging:
- [x] find names for flatten/restore methods -> its good enough
- [x] check the necessary changes in the DPL I/O API (we might want to sort out #1970 before) - DPL IO API has been updated and a custom implementation for MCTruthContainer will be implemented soon
- [x] alternatively check if the two vectors can be sent in individual messages, `o2::pmr::MessageResouce` could be used directly -> flattening can be done directly to buffer with underlying memory resource

This concept can be extended to a generic tool later.

Next developments which will not be part of this PR
- [ ] add benchmark test for MCTruthContainer serialization
- [ ] develop "spectator memory resouces", may be several of this kind working over the memory of of the `o2::pmr::MessageResouce`
