### PR TITLE
Logger: distinguish between LOGF and LOGP

### DIFF
--- a/Framework/Core/README.md
+++ b/Framework/Core/README.md
@@ -333,7 +333,8 @@ FairLogger.
 ...
 
 LOG(INFO) << "some message";      // streamer based API
-LOGF(INFO, "{}", "some message"); // fmt based API
+LOGF(INFO, "%s", "some message"); // printf based API
+LOGP(INFO, "{}", "some message"); // python / fmt based API
 O2INFO("{}", "some message);      // same but with less typing.
 ```
 

--- a/Framework/Logger/include/Framework/Logger.h
+++ b/Framework/Logger/include/Framework/Logger.h
@@ -17,10 +17,44 @@
 #include <fairlogger/Logger.h>
 #if __has_include(<fmt/format.h>)
 #include <fmt/format.h>
-#define LOGF(level, ...) LOG(level) << fmt::format(__VA_ARGS__)
+#include <fmt/printf.h>
+FMT_BEGIN_NAMESPACE
+template <typename S, typename Char = FMT_CHAR(S)>
+inline int vfprintf(fair::Logger& logger,
+                    const S& format,
+                    basic_format_args<typename basic_printf_context_t<
+                      internal::basic_buffer<Char>>::type>
+                      args)
+{
+  basic_memory_buffer<Char> buffer;
+  printf(buffer, to_string_view(format), args);
+  logger << std::string_view(buffer.data(), buffer.size());
+  return static_cast<int>(buffer.size());
+}
+
+template <typename S, typename... Args>
+inline FMT_ENABLE_IF_T(internal::is_string<S>::value, int)
+  fprintf(fair::Logger& logger,
+          const S& format_str, const Args&... args)
+{
+  internal::check_format_string<Args...>(format_str);
+  typedef internal::basic_buffer<FMT_CHAR(S)> buffer;
+  typedef typename basic_printf_context_t<buffer>::type context;
+  format_arg_store<context, Args...> as{ args... };
+  return vfprintf(logger, to_string_view(format_str),
+                  basic_format_args<context>(as));
+}
+
+FMT_END_NAMESPACE
+
+#define LOGF(severity, ...)                                                                                                                                        \
+  for (bool fairLOggerunLikelyvariable = false; fair::Logger::Logging(fair::Severity::severity) && !fairLOggerunLikelyvariable; fairLOggerunLikelyvariable = true) \
+  fmt::fprintf(fair::Logger(fair::Severity::severity, __FILE__, CONVERTTOSTRING(__LINE__), __FUNCTION__).Log(), __VA_ARGS__)
+#define LOGP(level, ...) LOG(level) << fmt::format(__VA_ARGS__)
 #else
 #define O2_FIRST_ARG(N, ...) N
 #define LOGF(level, ...) LOG(level) << O2_FIRST_ARG(__VA_ARGS__)
+#define LOGP(level, ...) LOG(level) << O2_FIRST_ARG(__VA_ARGS__)
 #endif
 #define O2DEBUG(...) LOGF(debug, __VA_ARGS__)
 #define O2INFO(...) LOGF(info, __VA_ARGS__)
@@ -28,6 +62,7 @@
 #elif __has_include(<fmt/format.h>)
 #include <fmt/format.h>
 #define LOGF(level, ...) fmt::printf(__VA_ARGS__)
+#define LOGP(level, ...) fmt::print(__VA_ARGS__)
 #define O2DEBUG(...) LOGF("dummy", __VA_ARGS__)
 #define O2INFO(...) LOGF("dummy", __VA_ARGS__)
 #define O2ERROR(...) LOGF("dummy", __VA_ARGS__)

--- a/Framework/Logger/test/unittest_Logger.cxx
+++ b/Framework/Logger/test/unittest_Logger.cxx
@@ -17,10 +17,13 @@
 
 BOOST_AUTO_TEST_CASE(TestLogF)
 {
-  LOGF(error, "{}", "Hello world");
-  LOGF(info, "{}", "Hello world");
-  LOGF(error, "{:03.2f}", 1000.30343f);
-  LOGF(error, "{1} {0}", "world", "Hello");
+  LOGF(error, "%s", "Hello world");
+  LOGF(info, "%s", "Hello world");
+  LOGF(error, "%.2f", 1000.30343f);
+  LOGP(error, "{}", "Hello world");
+  LOGP(info, "{}", "Hello world");
+  LOGP(error, "{:03.2f}", 1000.30343f);
+  LOGP(error, "{1} {0}", "world", "Hello");
   O2ERROR("{}", "Hello world");
   O2INFO("{}", "Hello world");
 }


### PR DESCRIPTION
The former now has printf-like syntax, the latter uses the native
python / fmt syntax.