### PR TITLE
Bugfix RootTreeReader argument parsing

### DIFF
--- a/Framework/Utils/test/test_RootTreeReader.cxx
+++ b/Framework/Utils/test/test_RootTreeReader.cxx
@@ -64,8 +64,8 @@ DataProcessorSpec getSourceSpec()
     auto reader = std::make_shared<RootTreeReader>("testtree",       // tree name
                                                    fileName.c_str(), // input file name
                                                    Output{ "TST", "ARRAYOFDATA", 0, persistency },
-                                                   "dataarray" // name of cluster branch
-                                                   );
+                                                   "dataarray", // name of cluster branch
+                                                   RootTreeReader::PublishingMode::Single);
 
     auto processingFct = [reader](ProcessingContext& pc) {
       if (reader->getCount() == 0) {


### PR DESCRIPTION
After commit 70c6e7b8c78b605665b90794a05caeb60ae8cfd0 it was not possible
to have a single argument like the publishing mode at the end of the argument pack.