### PR TITLE
 Label allows new Noise state and separate isFake flag 

### DIFF
--- a/DataFormats/Detectors/FIT/T0/include/DataFormatsFITT0/MCLabel.h
+++ b/DataFormats/Detectors/FIT/T0/include/DataFormatsFITT0/MCLabel.h
@@ -27,7 +27,7 @@ class MCLabel : public o2::MCCompLabel
  public:
   MCLabel() = default;
   MCLabel(Int_t trackID, Int_t eventID, Int_t srcID, Int_t chID)
-    : o2::MCCompLabel(trackID, eventID, srcID), mDetID(chID) {}
+    : o2::MCCompLabel(trackID, eventID, srcID, false), mDetID(chID) {}
 
   Int_t getDetID() const { return mDetID; }
 

--- a/DataFormats/simulation/include/SimulationDataFormat/MCCompLabel.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCCompLabel.h
@@ -22,20 +22,22 @@ class MCCompLabel
  private:
   static constexpr ULong64_t ul0x1 = 0x1;
   static constexpr ULong64_t NotSet = 0xffffffffffffffff;
+  static constexpr ULong64_t Noise = 0xfffffffffffffffe;
+  static constexpr ULong64_t Fake = ul0x1 << 63;
+  static constexpr int NReservedBits = 1;
 
   ULong64_t mLabel = NotSet; ///< MC label encoding MCtrack ID and MCevent origin
 
  public:
   // number of bits reserved for MC track ID, DON'T modify this, since the
   // track ID might be negative
-  static constexpr int nbitsTrackID = sizeof(int) * 8;
+  static constexpr int nbitsTrackID = 31; // number of bits reserved for MC track ID
   static constexpr int nbitsEvID = 19; // number of bits reserved for MC event ID
   static constexpr int nbitsSrcID = 8; // number of bits reserved for MC source ID
   // the rest of the bits is reserved at the moment
 
   // check if the fields are defined consistently
-  static_assert(nbitsTrackID == sizeof(int) * 8, "TrackID must have int size");
-  static_assert(nbitsTrackID + nbitsEvID + nbitsSrcID <= sizeof(ULong64_t) * 8,
+  static_assert(nbitsTrackID + nbitsEvID + nbitsSrcID <= sizeof(ULong64_t) * 8 - NReservedBits,
                 "Fields cannot be stored in 64 bits");
 
   // mask to extract MC track ID
@@ -47,18 +49,33 @@ class MCCompLabel
   // mask for all used fields
   static constexpr ULong64_t maskFull = (ul0x1 << (nbitsTrackID + nbitsEvID + nbitsSrcID)) - 1;
 
-  MCCompLabel(int trackID, int evID = 0, int srcID = 0) { set(trackID, evID, srcID); }
-  MCCompLabel() = default;
+  MCCompLabel(int trackID, int evID, int srcID, bool fake) { set(trackID, evID, srcID, fake); }
+  MCCompLabel(bool noise = false)
+  {
+    if (noise) {
+      mLabel = Noise;
+    } else {
+      mLabel = NotSet;
+    }
+  }
   ~MCCompLabel() = default;
 
   // check if label was assigned
   bool isSet() const { return mLabel != NotSet; }
   // check if label was not assigned
   bool isEmpty() const { return mLabel == NotSet; }
-  // check if label was assigned with non-negaive trackID
-  bool isPosTrackID() const { return getTrackID() >= 0; }
-  // return 1 if the tracks are the same and have labels>=0,
-  // 0 if the tracks are the same but at least one of them has label<0
+  // check if label corresponds to real particle
+  bool isNoise() const { return mLabel == Noise; }
+  // check if label was assigned as for correctly identified particle
+  bool isValid() const { return isSet() && !isNoise(); }
+
+  // check if label was assigned as for incorrectly identified particle or not set or noise
+  bool isFake() const { return mLabel & Fake; }
+  // check if label was assigned as for correctly identified particle
+  bool isCorrect() const { return !isFake(); }
+
+  // return 1 if the tracks are the same and correctly identified
+  // 0 if the tracks are the same but at least one of them is fake
   // -1 otherwhise
   int compare(const MCCompLabel& other) const
   {
@@ -66,7 +83,7 @@ class MCCompLabel
       return -1;
     }
     int tr1 = getTrackID(), tr2 = other.getTrackID();
-    return (tr1 == tr2) ? 1 : ((tr1 == -tr2) ? 0 : -1);
+    return (tr1 == tr2) ? ((isCorrect() && other.isCorrect()) ? 1 : 0) : -1;
   }
 
   // conversion operator
@@ -74,27 +91,42 @@ class MCCompLabel
   // allow to retrieve bare label
   ULong64_t getRawValue() const { return mLabel; }
 
-  // comparison operator, compares only label, not evential weight info
+  // comparison operator, compares only label, not evential weight or correctness info
   bool operator==(const MCCompLabel& other) const { return (mLabel & maskFull) == (other.mLabel & maskFull); }
   // invalidate
   void unset() { mLabel = NotSet; }
-  void set(int trackID, int evID, int srcID)
+  void setNoise() { mLabel = Noise; }
+  void setFakeFlag(bool v = true)
+  {
+    if (v) {
+      mLabel |= Fake;
+    } else {
+      mLabel &= ~Fake;
+    }
+  }
+
+  void set(unsigned int trackID, int evID, int srcID, bool fake)
   {
     /// compose label: the track 1st cast to UInt32_t to preserve the sign!
-    mLabel = (maskTrackID & static_cast<ULong64_t>(static_cast<UInt_t>(trackID))) |
+    mLabel = (maskTrackID & static_cast<ULong64_t>(trackID)) |
              (maskEvID & static_cast<ULong64_t>(evID)) << nbitsTrackID |
              (maskSrcID & static_cast<ULong64_t>(srcID)) << (nbitsTrackID + nbitsEvID);
+    if (fake) {
+      setFakeFlag();
+    }
   }
 
   int getTrackID() const { return static_cast<int>(mLabel & maskTrackID); }
+  int getTrackIDSigned() const { return isFake() ? -getTrackID() : getTrackID(); }
   int getEventID() const { return (mLabel >> nbitsTrackID) & maskEvID; }
   int getSourceID() const { return (mLabel >> (nbitsTrackID + nbitsEvID)) & maskSrcID; }
-  void get(int& trackID, int& evID, int& srcID)
+  void get(int& trackID, int& evID, int& srcID, bool& fake)
   {
     /// parse label
     trackID = getTrackID();
     evID = getEventID();
     srcID = getSourceID();
+    fake = isFake();
   }
 
   void print() const;

--- a/DataFormats/simulation/src/MCCompLabel.cxx
+++ b/DataFormats/simulation/src/MCCompLabel.cxx
@@ -29,11 +29,11 @@ void MCCompLabel::print() const
 std::ostream& operator<<(std::ostream& os, const o2::MCCompLabel& c)
 {
   // stream itself
-  if (c.isSet()) {
+  if (c.isValid()) {
     os << '[' << c.getSourceID() << '/' << c.getEventID() << '/'
-       << std::setw(6) << c.getTrackID() << ']';
+       << (c.isFake() ? '-' : '+') << std::setw(6) << c.getTrackID() << ']';
   } else {
-    os << "[unset]";
+    os << (c.isNoise() ? "[noise]" : "[unset]");
   }
   return os;
 }

--- a/Detectors/CPV/base/include/CPVBase/Digit.h
+++ b/Detectors/CPV/base/include/CPVBase/Digit.h
@@ -83,13 +83,13 @@ class Digit : public DigitBase
     if (idx < kMaxLabels) {
       return mLabels[idx];
     } else {
-      return -1;
+      return Label();
     }
   }
   /// \brief Proportion of charge deposited by particle idx
   /// \param idx index in a list of a particles, max length kMaxLabels
   /// \return Proportion of energy from this particle.
-  Label getLabelEProp(int idx) const
+  double getLabelEProp(int idx) const
   {
     if (idx < kMaxLabels) {
       return mEProp[idx];

--- a/Detectors/EMCAL/simulation/src/Digitizer.cxx
+++ b/Detectors/EMCAL/simulation/src/Digitizer.cxx
@@ -72,7 +72,7 @@ void Digitizer::process(const std::vector<Hit>& hits, std::vector<Digit>& digits
         mDigits[id].push_front(digit);
       }
 
-      o2::MCCompLabel label(hit.GetTrackID(), mCurrEvID, mCurrSrcID);
+      o2::MCCompLabel label(hit.GetTrackID(), mCurrEvID, mCurrSrcID, false);
       mMCTruthContainer.addElementRandomAccess(LabelIndex, label);
     } catch (InvalidPositionException& e) {
       LOG(ERROR) << "Error in creating the digit: " << e.what() << FairLogger::endl;

--- a/Detectors/GlobalTracking/src/MatchTOF.cxx
+++ b/Detectors/GlobalTracking/src/MatchTOF.cxx
@@ -738,9 +738,7 @@ void MatchTOF::selectBestMatches()
     }
     if (!labelOk) {
       // we have not found the track label among those associated to the TOF cluster --> fake match! We will associate the label of the main channel, but negative
-      o2::MCCompLabel fakeTOFlabel;
-      fakeTOFlabel.set(-labelsTOF[0].getTrackID(), labelsTOF[0].getEventID(), labelsTOF[0].getSourceID());
-      mOutTOFLabels.push_back(fakeTOFlabel);
+      mOutTOFLabels.emplace_back(labelsTOF[0].getTrackID(), labelsTOF[0].getEventID(), labelsTOF[0].getSourceID(), true);
     }
     mOutTPCLabels.push_back(labelTPC);
     mOutITSLabels.push_back(labelITS);

--- a/Detectors/HMPID/simulation/src/HMPIDDigitizer.cxx
+++ b/Detectors/HMPID/simulation/src/HMPIDDigitizer.cxx
@@ -94,7 +94,7 @@ void HMPIDDigitizer::process(std::vector<o2::hmpid::HitType> const& hits, std::v
 
         if (mRegisteredLabelContainer) {
           auto labels = mTmpLabelContainer.getLabels(index);
-          o2::MCCompLabel newlabel(hit.GetTrackID(), mEventID, mSrcID);
+          o2::MCCompLabel newlabel(hit.GetTrackID(), mEventID, mSrcID, false);
           bool newlabelneeded = true;
           for (auto& l : labels) {
             if (l == newlabel) {
@@ -114,7 +114,7 @@ void HMPIDDigitizer::process(std::vector<o2::hmpid::HitType> const& hits, std::v
 
         if (mRegisteredLabelContainer) {
           // add label for this digit
-          mTmpLabelContainer.addElement(mDigits.size() - 1, o2::MCCompLabel(hit.GetTrackID(), mEventID, mSrcID));
+          mTmpLabelContainer.addElement(mDigits.size() - 1, o2::MCCompLabel(hit.GetTrackID(), mEventID, mSrcID, false));
         }
       }
     }

--- a/Detectors/ITSMFT/ITS/macros/test/CheckClusters.C
+++ b/Detectors/ITSMFT/ITS/macros/test/CheckClusters.C
@@ -70,9 +70,10 @@ void CheckClusters(std::string clusfile = "o2clus_its.root", std::string hitfile
 
       float dx = 0, dz = 0;
       int trID = lab.getTrackID();
+      bool isOK = lab.isValid();
       int ievH = lab.getEventID();
       Point3D<float> locH, locHsta;
-      if (trID >= 0) { // is this cluster from hit or noise ?
+      if (isOK) { // is this cluster from hit or noise ?
         Hit* p = nullptr;
         if (lastReadHitEv != ievH) {
           hitTree->GetEvent(ievH);

--- a/Detectors/ITSMFT/ITS/macros/test/CheckDigits.C
+++ b/Detectors/ITSMFT/ITS/macros/test/CheckDigits.C
@@ -75,7 +75,7 @@ void CheckDigits(std::string digifile = "itsdigits.root", std::string hitfile = 
       int trID = labs[0].getTrackID();
       int ievH = labs[0].getEventID();
 
-      if (trID >= 0) { // not a noise
+      if (labs[0].isValid()) { // not a noise
         ndr++;
         const auto gloD = gman->getMatrixL2G(chipID)(locD); // convert to global
         float dx = 0., dz = 0.;

--- a/Detectors/ITSMFT/ITS/macros/test/CheckTopologies.C
+++ b/Detectors/ITSMFT/ITS/macros/test/CheckTopologies.C
@@ -93,7 +93,7 @@ void CheckTopologies(std::string clusfile = "o2clus_its.root", std::string hitfi
       int trID = lab.getTrackID();
       int ievH = lab.getEventID();
       Point3D<float> locH, locHsta;
-      if (trID >= 0) { // is this cluster from hit or noise ?
+      if (lab.isValid()) { // is this cluster from hit or noise ?
         Hit* p = nullptr;
         if (lastReadHitEv != ievH) {
           hitTree->GetEvent(ievH);

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CookedTracker.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CookedTracker.cxx
@@ -120,7 +120,7 @@ Label CookedTracker::cookLabel(TrackITSExt& t, Float_t wrong) const
 
   if ((1. - Float_t(maxL) / noc) > wrong) {
     // change the track ID to negative
-    lab.set(-lab.getTrackID(), lab.getEventID(), lab.getSourceID());
+    lab.setFakeFlag();
   }
   // t.SetFakeRatio((1.- Float_t(maxL)/noc));
   return lab;

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -531,7 +531,7 @@ void Tracker::computeTracksMClabels(const ROframe& event)
   for (auto& track : mTracks) {
 
     MCCompLabel maxOccurrencesValue{ constants::its::UnusedIndex, constants::its::UnusedIndex,
-                                     constants::its::UnusedIndex };
+                                     constants::its::UnusedIndex, false };
     int count{ 0 };
     bool isFakeTrack{ false };
 
@@ -558,9 +558,9 @@ void Tracker::computeTracksMClabels(const ROframe& event)
       track.setExternalClusterIndex(iCluster, event.getClusterExternalIndex(iCluster, index));
     }
 
-    if (isFakeTrack)
-      maxOccurrencesValue.set(-maxOccurrencesValue.getTrackID(), maxOccurrencesValue.getEventID(),
-                              maxOccurrencesValue.getSourceID());
+    if (isFakeTrack) {
+      maxOccurrencesValue.setFakeFlag();
+    }
     mTrackLabels.addElement(mTrackLabels.getIndexedSize(), maxOccurrencesValue);
   }
 }

--- a/Detectors/ITSMFT/common/simulation/src/ChipDigitsContainer.cxx
+++ b/Detectors/ITSMFT/common/simulation/src/ChipDigitsContainer.cxx
@@ -42,7 +42,7 @@ void ChipDigitsContainer::addNoise(UInt_t rofMin, UInt_t rofMax, const o2::itsmf
       // RS TODO: why the noise was added with 0 charge? It should be above the threshold!
       auto key = getOrderingKey(rof, row, col);
       if (!findDigit(key)) {
-        addDigit(key, rof, row, col, nel, o2::MCCompLabel(-1, 0, 0));
+        addDigit(key, rof, row, col, nel, o2::MCCompLabel(true));
       }
     }
   }

--- a/Detectors/ITSMFT/common/simulation/src/Digitizer.cxx
+++ b/Detectors/ITSMFT/common/simulation/src/Digitizer.cxx
@@ -307,7 +307,7 @@ void Digitizer::processHit(const o2::itsmft::Hit& hit, UInt_t& maxFr, int evID, 
   }
 
   // fire the pixels assuming Poisson(n_response_electrons)
-  o2::MCCompLabel lbl(hit.GetTrackID(), evID, srcID);
+  o2::MCCompLabel lbl(hit.GetTrackID(), evID, srcID, false);
   auto& chip = mChips[hit.GetDetectorID()];
 
   for (int irow = rowSpan; irow--;) {

--- a/Detectors/MUON/MCH/Simulation/src/Digitizer.cxx
+++ b/Detectors/MUON/MCH/Simulation/src/Digitizer.cxx
@@ -91,7 +91,7 @@ void Digitizer::process(const std::vector<Hit> hits, std::vector<Digit>& digits)
   for (auto& hit : hits) {
     int detID = hit.GetDetectorID();
     int ndigits = processHit(hit, detID, mEventTime);
-    MCCompLabel label(hit.GetTrackID(), mEventID, mSrcID);
+    MCCompLabel label(hit.GetTrackID(), mEventID, mSrcID, false);
     for (int i = 0; i < ndigits; ++i) {
       int digitIndex = mDigits.size() - ndigits + i;
       mTrackLabels.emplace(mTrackLabels.begin() + digitIndex, label);
@@ -200,7 +200,7 @@ void Digitizer::mergeDigits(const std::vector<Digit> digits, const std::vector<o
       adc += sortedDigits(k).getADC();
     }
     mDigits.emplace_back(sortedDigits(i).getTimeStamp(), sortedDigits(i).getDetID(), sortedDigits(i).getPadID(), adc);
-    mTrackLabels.emplace_back(sortedLabels(i).getTrackID(), sortedLabels(i).getEventID(), sortedLabels(i).getSourceID());
+    mTrackLabels.emplace_back(sortedLabels(i).getTrackID(), sortedLabels(i).getEventID(), sortedLabels(i).getSourceID(), false);
     i = j;
     ++count;
   }

--- a/Detectors/MUON/MCH/Simulation/test/DigitMerging.cxx
+++ b/Detectors/MUON/MCH/Simulation/test/DigitMerging.cxx
@@ -60,7 +60,7 @@ std::vector<Digit> mergeDigits_sortnosizeadjust(const std::vector<Digit>& inputD
       adc += sortedDigits(k).getADC();
     }
     digits.emplace_back(sortedDigits(i).getTimeStamp(), sortedDigits(i).getDetID(), sortedDigits(i).getPadID(), adc);
-    labels.emplace_back(sortedLabels(i).getTrackID(), sortedLabels(i).getEventID(), sortedLabels(i).getSourceID());
+    labels.emplace_back(sortedLabels(i).getTrackID(), sortedLabels(i).getEventID(), sortedLabels(i).getSourceID(), false);
     i = j;
   }
   return digits;
@@ -100,7 +100,7 @@ std::vector<Digit> mergeDigits_sortsizeadjust(const std::vector<Digit>& inputDig
       adc += sortedDigits(k).getADC();
     }
     digits.emplace_back(sortedDigits(i).getTimeStamp(), sortedDigits(i).getDetID(), sortedDigits(i).getPadID(), adc);
-    labels.emplace_back(sortedLabels(i).getTrackID(), sortedLabels(i).getEventID(), sortedLabels(i).getSourceID());
+    labels.emplace_back(sortedLabels(i).getTrackID(), sortedLabels(i).getEventID(), sortedLabels(i).getSourceID(), false);
     i = j;
   }
   digits.resize(digits.size());

--- a/Detectors/MUON/MCH/Simulation/test/benchDigitMerging.cxx
+++ b/Detectors/MUON/MCH/Simulation/test/benchDigitMerging.cxx
@@ -43,7 +43,7 @@ std::vector<o2::MCCompLabel> createLabels(int N)
 
   for (auto i = 0; i < N; i++) {
     int randomTrackID = std::rand() * N;
-    labels.emplace_back(randomTrackID, dummyEventID, dummysrcID);
+    labels.emplace_back(randomTrackID, dummyEventID, dummysrcID, false);
   }
 
   return labels;

--- a/Detectors/MUON/MCH/Simulation/test/testDigitMerging.cxx
+++ b/Detectors/MUON/MCH/Simulation/test/testDigitMerging.cxx
@@ -38,10 +38,10 @@ std::vector<Digit> createNonOverlappingDigits()
 std::vector<o2::MCCompLabel> createLabelsNonOverlappingDigits()
 {
   return std::vector<o2::MCCompLabel>{
-    { 0, 0, 10 },
-    { 0, 0, 10 },
-    { 10, 0, 10 },
-    { 11, 0, 10 }
+    { 0, 0, 10, false },
+    { 0, 0, 10, false },
+    { 10, 0, 10, false },
+    { 11, 0, 10, false }
   };
 }
 
@@ -62,15 +62,15 @@ std::vector<Digit> createOverlappingDigits()
 std::vector<o2::MCCompLabel> createLabelsOverlappingDigits()
 {
   return std::vector<o2::MCCompLabel>{
-    { 0, 0, 10 },
-    { 0, 0, 10 },
-    { 10, 0, 10 },
-    { 11, 0, 10 },
-    { 10, 0, 10 },
-    { 2, 0, 10 },
-    { 4, 0, 10 },
-    { 5, 0, 10 },
-    { 6, 0, 10 }
+    { 0, 0, 10, false },
+    { 0, 0, 10, false },
+    { 10, 0, 10, false },
+    { 11, 0, 10, false },
+    { 10, 0, 10, false },
+    { 2, 0, 10, false },
+    { 4, 0, 10, false },
+    { 5, 0, 10, false },
+    { 6, 0, 10, false }
   };
 }
 
@@ -87,10 +87,10 @@ std::vector<Digit> expected()
 std::vector<o2::MCCompLabel> labelexpected()
 {
   return std::vector<o2::MCCompLabel>{
-    { 0, 0, 10 },
-    { 0, 0, 10 },
-    { 10, 0, 10 },
-    { 11, 0, 10 }
+    { 0, 0, 10, false },
+    { 0, 0, 10, false },
+    { 10, 0, 10, false },
+    { 11, 0, 10, false }
   };
 }
 

--- a/Detectors/MUON/MCH/Simulation/test/testDigitization.cxx
+++ b/Detectors/MUON/MCH/Simulation/test/testDigitization.cxx
@@ -167,11 +167,11 @@ BOOST_AUTO_TEST_CASE(mergingDigitizer)
 
   for (int i = 0; i < rep1; i++) {
     digits.emplace_back(digits.at(0).getTimeStamp(), digits.at(0).getDetID(), digits.at(0).getPadID(), digits.at(0).getADC());
-    labels.emplace_back(labels.at(0).getTrackID(), labels.at(0).getEventID(), labels.at(0).getSourceID());
+    labels.emplace_back(labels.at(0).getTrackID(), labels.at(0).getEventID(), labels.at(0).getSourceID(), false);
   }
   for (int i = 0; i < rep2; i++) {
     digits.emplace_back(digits.at(1).getTimeStamp(), digits.at(0).getDetID(), digits.at(1).getPadID(), digits.at(1).getADC());
-    labels.emplace_back(labels.at(1).getTrackID(), labels.at(1).getEventID(), labels.at(1).getSourceID());
+    labels.emplace_back(labels.at(1).getTrackID(), labels.at(1).getEventID(), labels.at(1).getSourceID(), false);
   }
 
   digitizer.mergeDigits(digits, labels);

--- a/Detectors/MUON/MID/Simulation/src/MCClusterLabel.cxx
+++ b/Detectors/MUON/MID/Simulation/src/MCClusterLabel.cxx
@@ -22,7 +22,7 @@ namespace o2
 namespace mid
 {
 
-MCClusterLabel::MCClusterLabel(int trackID, int eventID, int srcID, bool isFiredBP, bool isFiredNBP) : o2::MCCompLabel(trackID, eventID, srcID)
+MCClusterLabel::MCClusterLabel(int trackID, int eventID, int srcID, bool isFiredBP, bool isFiredNBP) : o2::MCCompLabel(trackID, eventID, srcID, false)
 {
   /// Constructor
   setIsFiredBP(isFiredBP);

--- a/Detectors/MUON/MID/Simulation/src/MCLabel.cxx
+++ b/Detectors/MUON/MID/Simulation/src/MCLabel.cxx
@@ -22,7 +22,7 @@ namespace o2
 namespace mid
 {
 
-MCLabel::MCLabel(int trackID, int eventID, int srcID, int deId, int columnId, int cathode, int firstStrip, int lastStrip) : o2::MCCompLabel(trackID, eventID, srcID)
+MCLabel::MCLabel(int trackID, int eventID, int srcID, int deId, int columnId, int cathode, int firstStrip, int lastStrip) : o2::MCCompLabel(trackID, eventID, srcID, false)
 {
   /// Constructor
   setDEId(deId);

--- a/Detectors/MUON/MID/Simulation/src/PreClusterLabeler.cxx
+++ b/Detectors/MUON/MID/Simulation/src/PreClusterLabeler.cxx
@@ -71,7 +71,7 @@ bool PreClusterLabeler::addLabel(size_t idx, const MCLabel& label)
   if (isDuplicated(idx, label)) {
     return false;
   }
-  MCCompLabel lb(label.getTrackID(), label.getEventID(), label.getSourceID());
+  MCCompLabel lb(label.getTrackID(), label.getEventID(), label.getSourceID(), label.isFake());
   mMCContainer.addElement(idx, lb);
   return true;
 }

--- a/Detectors/PHOS/base/include/PHOSBase/Digit.h
+++ b/Detectors/PHOS/base/include/PHOSBase/Digit.h
@@ -94,12 +94,12 @@ class Digit : public DigitBase
     if (idx < kMaxLabels)
       return mLabels[idx];
     else
-      return -1;
+      return Label();
   }
   /// \brief Proportion of energy deposited by particle idx
   /// \param idx index in a list of a particles, max length kMaxLabels
   /// \return Proportion of energy from this particle.
-  Label getLabelEProp(Int_t idx) const
+  double getLabelEProp(Int_t idx) const
   {
     if (idx < kMaxLabels)
       return mEProp[idx];

--- a/Detectors/TOF/simulation/include/TOFSimulation/MCLabel.h
+++ b/Detectors/TOF/simulation/include/TOFSimulation/MCLabel.h
@@ -27,7 +27,7 @@ class MCLabel : public o2::MCCompLabel
 
  public:
   MCLabel() = default;
-  MCLabel(Int_t trackID, Int_t eventID, Int_t srcID, Int_t tdc) : o2::MCCompLabel(trackID, eventID, srcID), mTDC(tdc) {}
+  MCLabel(Int_t trackID, Int_t eventID, Int_t srcID, Int_t tdc) : o2::MCCompLabel(trackID, eventID, srcID, false), mTDC(tdc) {}
   Int_t getTDC() const { return mTDC; }
 };
 }

--- a/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
+++ b/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
@@ -235,7 +235,7 @@ int GPUCATracking::runTracking(GPUO2InterfaceIOPtrs* data)
         }
         MCCompLabel& bestLabel = labels[bestLabelNum].first;
         if (bestLabelCount < (1.f - sTrackMCMaxFake) * nOutCl) {
-          bestLabel.set(-bestLabel.getTrackID(), bestLabel.getEventID(), bestLabel.getSourceID());
+          bestLabel.setFakeFlag();
         }
         outputTracksMCTruth->addElement(iTmp, bestLabel);
       }

--- a/Detectors/TPC/reconstruction/test/testTPCHwClusterer.cxx
+++ b/Detectors/TPC/reconstruction/test/testTPCHwClusterer.cxx
@@ -150,9 +150,9 @@ BOOST_AUTO_TEST_CASE(HwClusterer_test1)
   digitVec.emplace_back(0, 12, 13, 5, 2);
   digitVec.emplace_back(0, 321, 7, 10, 10);
 
-  labelContainer.addElement(0, 1);
-  labelContainer.addElement(1, 2);
-  labelContainer.addElement(2, 3);
+  labelContainer.addElement(0, { 1, 0, 0, false });
+  labelContainer.addElement(1, { 2, 0, 0, false });
+  labelContainer.addElement(2, { 3, 0, 0, false });
 
   auto digits = std::make_unique<const std::vector<Digit>>(digitVec);
   auto mcDigitTruth = std::make_unique<const MCLabelContainer>(labelContainer);

--- a/Detectors/TPC/simulation/src/Digitizer.cxx
+++ b/Detectors/TPC/simulation/src/Digitizer.cxx
@@ -133,7 +133,7 @@ void Digitizer::process(const std::vector<o2::tpc::HitGroup>& hits,
 
         const GlobalPadNumber globalPad = mapper.globalPadNumber(digiPadPos.getGlobalPadPos());
         const float ADCsignal = sampaProcessing.getADCvalue(static_cast<float>(nElectronsGEM));
-        const MCCompLabel label(MCTrackID, eventID, sourceID);
+        const MCCompLabel label(MCTrackID, eventID, sourceID, false);
         sampaProcessing.getShapedSignal(ADCsignal, absoluteTime, signalArray);
         for (float i = 0; i < nShapedPoints; ++i) {
           const float time = absoluteTime + i * eleParam.ZbinWidth;

--- a/Detectors/TPC/simulation/test/testTPCDigitContainer.cxx
+++ b/Detectors/TPC/simulation/test/testTPCDigitContainer.cxx
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(DigitContainer_test1)
 
   for (int i = 0; i < cru.size(); ++i) {
     const GlobalPadNumber globalPad = mapper.getPadNumberInROC(PadROCPos(CRU(cru[i]).roc(), PadPos(Row[i], Pad[i])));
-    digitContainer.addDigit(MCCompLabel(MCtrack[i], MCevent[i], 0), cru[i], Time[i], globalPad, nEle[i]);
+    digitContainer.addDigit(MCCompLabel(MCtrack[i], MCevent[i], 0, false), cru[i], Time[i], globalPad, nEle[i]);
   }
 
   /// here the raw pointer is needed owed to the internal handling of the TClonesArrays in FairRoot
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE(DigitContainer_test2)
 
     // add labels to each voxel, sum up the charge MCevent.size() times
     for (int j = 0; j < MCevent.size(); ++j) {
-      digitContainer.addDigit(MCCompLabel(MCtrack[j], MCevent[j], 0), cru[i], Time[i], globalPad, nEle[i]);
+      digitContainer.addDigit(MCCompLabel(MCtrack[j], MCevent[j], 0, false), cru[i], Time[i], globalPad, nEle[i]);
     }
   }
 

--- a/Detectors/TRD/base/include/TRDBase/MCLabel.h
+++ b/Detectors/TRD/base/include/TRDBase/MCLabel.h
@@ -8,7 +8,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-// Declaration of a transient MC label class for ZDC
+// Declaration of a transient MC label class for TRD
 
 #ifndef ALICEO2_TRD_MCLABEL_H_
 #define ALICEO2_TRD_MCLABEL_H_
@@ -28,7 +28,7 @@ class MCLabel : public o2::MCCompLabel
  public:
   MCLabel() = default;
   MCLabel(int trackID, int eventID, int srcID, int isDigit)
-    : o2::MCCompLabel(trackID, eventID, srcID), mIsDigit(isDigit) {}
+    : o2::MCCompLabel(trackID, eventID, srcID, false), mIsDigit(isDigit) {}
   int isDigit() const { return mIsDigit; }
 
   ClassDefNV(MCLabel, 1);

--- a/Detectors/ZDC/simulation/include/ZDCSimulation/MCLabel.h
+++ b/Detectors/ZDC/simulation/include/ZDCSimulation/MCLabel.h
@@ -27,7 +27,7 @@ class MCLabel : public o2::MCCompLabel
  public:
   MCLabel() = default;
   MCLabel(Int_t trackID, Int_t eventID, Int_t srcID, Int_t chID)
-    : o2::MCCompLabel(trackID, eventID, srcID), mChannel(chID) {}
+    : o2::MCCompLabel(trackID, eventID, srcID, false), mChannel(chID) {}
 
   Int_t getChannel() const { return mChannel; }
 


### PR DESCRIPTION
To avoid ambiguity for track0, the track ID is stored is a non-negative number and fake/correct flag is stored as a separate bit.
Now ``getTrackID()`` will return the track ID >=0 (be it fake or correct) and one can check separately the status via ``isFake``.
The method ``getTrackIDSigned()`` will return ``trackID*(fake ? -1:1)`` in old convention.
The noise can be flagged either by calling ``setNoise()`` on the existing label or via construction of new label by ``MCCompLabel(bool noise)`` (default invalid=false will create a label in ``isEmpty()`` state as before), ``MCCompLabel(true)`` with create initialized Noise label. Both Noise and Empty labels return isFake() true.

@davidrohr , please check if it is ok for you.