### PR TITLE
CMake migration: fix a few glitches

### DIFF
--- a/dependencies/O2Dependencies.cmake
+++ b/dependencies/O2Dependencies.cmake
@@ -41,7 +41,7 @@ set_package_properties(arrow PROPERTIES TYPE REQUIRED)
 find_package(Vc)
 set_package_properties(Vc PROPERTIES TYPE REQUIRED)
 
-find_package(ROOT 6.06.00 MODULE)
+find_package(ROOT 6.16.00 MODULE)
 set_package_properties(ROOT PROPERTIES TYPE REQUIRED)
 
 find_package(fmt)

--- a/dependencies/O2Dependencies.cmake
+++ b/dependencies/O2Dependencies.cmake
@@ -130,11 +130,13 @@ set_package_properties(GLEW PROPERTIES TYPE OPTIONAL)
 find_package(OpenGL)
 set_package_properties(OpenGL PROPERTIES TYPE OPTIONAL)
 
-find_package(Clang)
-set_package_properties(Clang PROPERTIES TYPE OPTIONAL)
-
 find_package(LLVM)
 set_package_properties(LLVM PROPERTIES TYPE OPTIONAL)
+if(LLVM_FOUND)
+find_package(Clang)
+set_package_properties(Clang PROPERTIES TYPE OPTIONAL)
+endif()
+
 
 find_package(O2GPU)
 

--- a/macro/CMakeLists.txt
+++ b/macro/CMakeLists.txt
@@ -123,6 +123,7 @@ o2_add_test_root_macro(
   initSimGeomAndField.C
   PUBLIC_LINK_LIBRARIES O2::DataFormatsParameters O2::Field)
 
+if(Geant4_FOUND)
 o2_add_test_root_macro(o2sim.C
                        PUBLIC_LINK_LIBRARIES O2::Generators
                                              O2::DetectorsPassive
@@ -145,6 +146,7 @@ o2_add_test_root_macro(o2sim.C
                                              O2::CommonTypes
                                              O2::SimSetup
                                              O2::Steer)
+endif()
 
 # FIXME: move to subsystem dir + add includes if one wants to compile it...
 # o2_add_test_root_macro( putCondition.C)


### PR DESCRIPTION
* Clang requires LLVM on some platforms, so if LLVM is not there,
  this will fail.
* We need to protect against usage of simulation packages when
  Geant4 is not there.
* ROOT needs to be at least v6.16.00