### PR TITLE
Fix missing fmt dependency

### DIFF
--- a/Framework/Logger/CMakeLists.txt
+++ b/Framework/Logger/CMakeLists.txt
@@ -10,10 +10,7 @@
 
 o2_add_library(FrameworkLogger
                SOURCES src/Logger.cxx
-               PUBLIC_LINK_LIBRARIES FairLogger::FairLogger) # FIXME: should be
-                                                             # changed to {fmt}
-                                                             # once we have that
-                                                             # as a dependency
+               PUBLIC_LINK_LIBRARIES fmt::fmt FairLogger::FairLogger)
 
 # FIXME: the NAME parameter is just there to ease the comparison with previous
 # test names, can be omitted later on


### PR DESCRIPTION
@ktf @aphecetche : fmt is now an alidist dependency, and CMake finds fmt, but fmt::fmt was not added to the Logger. Consequently, it was not used, and even breaking systems which have fmt system-wide, because the header is available, but it is not linked.