### PR TITLE
[WIP] Resolve ROOT / CUDA / C++17 conflict after CMake migration

### DIFF
--- a/Detectors/GlobalTracking/CMakeLists.txt
+++ b/Detectors/GlobalTracking/CMakeLists.txt
@@ -20,6 +20,8 @@ o2_add_library(GlobalTracking
                                      O2::GPUTracking
                                      O2::TPCBase
                                      O2::TPCReconstruction
+                                     O2::ITSBase
+                                     O2::ITSMFTBase
                                      O2::TOFBase)
 
 o2_target_root_dictionary(GlobalTracking

--- a/Detectors/ITSMFT/ITS/tracking/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/tracking/CMakeLists.txt
@@ -27,10 +27,15 @@ o2_add_library(ITStracking
                PUBLIC_LINK_LIBRARIES O2::GPUCommon
                                      ms_gsl::ms_gsl
                                      O2::CommonConstants
-                                     O2::DataFormatsITSMFT
-                                     O2::SimulationDataFormat
-                                     O2::ITSBase
-                                     O2::DataFormatsITS)
+               PRIVATE_LINK_LIBRARIES O2::DataFormatsITSMFT
+                                      O2::SimulationDataFormat
+                                      O2::ITSBase
+                                      O2::DataFormatsITS
+               PUBLIC_INCLUDE_DIRECTORIES ${ROOT_INCLUDE_DIRS}
+                                          ${CMAKE_SOURCE_DIR}/Detectors/ITSMFT/ITS/tracking/include
+                                          ${CMAKE_SOURCE_DIR}/Detectors/ITSMFT/ITS/base/include
+                                          ${CMAKE_SOURCE_DIR}/Detectors/ITSMFT/common/base/include
+                                          ${CMAKE_SOURCE_DIR}/DataFormats/Detectors/ITSMFT/common/include)
 
 o2_target_root_dictionary(ITStracking
                           HEADERS include/ITStracking/ClusterLines.h

--- a/Examples/Ex3/CMakeLists.txt
+++ b/Examples/Ex3/CMakeLists.txt
@@ -10,7 +10,7 @@
 
 o2_add_library(Ex3
                SOURCES src/A.cxx src/B.cxx
-               PUBLIC_LINK_LIBRARIES FairMQ::FairMQ)
+               PUBLIC_LINK_LIBRARIES FairMQ::FairMQ ROOT::Core)
 
 o2_target_root_dictionary(Ex3 HEADERS include/Ex3/A.h src/B.h)
 

--- a/Examples/Ex4/CMakeLists.txt
+++ b/Examples/Ex4/CMakeLists.txt
@@ -10,7 +10,7 @@
 
 o2_add_library(Ex4
                SOURCES src/A.cxx src/B.cxx
-               PUBLIC_LINK_LIBRARIES FairMQ::FairMQ)
+               PUBLIC_LINK_LIBRARIES FairMQ::FairMQ ROOT::Core)
 
 o2_target_root_dictionary(Ex4 HEADERS include/Ex4/A.h src/B.h)
 

--- a/GPU/Common/CMakeLists.txt
+++ b/GPU/Common/CMakeLists.txt
@@ -29,7 +29,7 @@ set(HDRS_INSTALL
 if(ALIGPU_BUILD_TYPE STREQUAL "O2")
   o2_add_library(${MODULE}
                  TARGETVARNAME targetName
-                 PUBLIC_LINK_LIBRARIES FairLogger::FairLogger ROOT::RIO)
+                 PRIVATE_LINK_LIBRARIES FairLogger::FairLogger ROOT::RIO)
   target_include_directories(${targetName}
                              PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
                                     $<INSTALL_INTERFACE:include/GPU>)

--- a/GPU/GPUTracking/CMakeLists.txt
+++ b/GPU/GPUTracking/CMakeLists.txt
@@ -195,11 +195,11 @@ if(ALIGPU_BUILD_TYPE STREQUAL "O2")
   o2_add_library(${MODULE}
                  TARGETVARNAME targetName
                  PUBLIC_LINK_LIBRARIES O2::GPUCommon
-                                       O2::DataFormatsTPC
-                                       O2::TRDBase
-                                       O2::ITStracking
                                        O2::TPCFastTransformation
-                                       O2::DebugGUI
+                 PRIVATE_LINK_LIBRARIES O2::DataFormatsTPC
+                                        O2::TRDBase
+                                        O2::ITStracking
+                                        O2::DebugGUI
                  PUBLIC_INCLUDE_DIRECTORIES SliceTracker
                                             Base
                                             TPCConvert
@@ -214,6 +214,21 @@ if(ALIGPU_BUILD_TYPE STREQUAL "O2")
                                             Interface
                                             Merger
                                             DataCompression
+                                            ${ROOT_INCLUDE_DIRS}
+                                            ${CMAKE_SOURCE_DIR}/Common/Constants/include
+                                            ${CMAKE_SOURCE_DIR}/Common/MathUtils/include
+                                            ${CMAKE_SOURCE_DIR}/DataFormats/common/include
+                                            ${CMAKE_SOURCE_DIR}/Detectors/TPC/base/include
+                                            ${CMAKE_SOURCE_DIR}/DataFormats/Detectors/TPC/include
+                                            ${CMAKE_SOURCE_DIR}/DataFormats/common/include
+                                            ${CMAKE_SOURCE_DIR}/Detectors/TRD/base/include
+                                            ${CMAKE_SOURCE_DIR}/Detectors/ITSMFT/ITS/tracking/include
+                                            ${CMAKE_SOURCE_DIR}/Detectors/ITSMFT/ITS/base/include
+                                            ${CMAKE_SOURCE_DIR}/DataFormats/Detectors/ITSMFT/ITS/include
+                                            ${CMAKE_SOURCE_DIR}/DataFormats/Reconstruction/include
+                                            ${CMAKE_SOURCE_DIR}/DataFormats/simulation/include
+                                            ${CMAKE_SOURCE_DIR}/Detectors/Base/include
+                                            ${CMAKE_SOURCE_DIR}/DataFormats/Detectors/Common/include
                  TARGETVARNAME targetName
                  SOURCES ${SRCS} ${SRCS_NO_CINT} ${SRCS_NO_H})
 

--- a/GPU/TPCFastTransformation/CMakeLists.txt
+++ b/GPU/TPCFastTransformation/CMakeLists.txt
@@ -27,7 +27,8 @@ if(${ALIGPU_BUILD_TYPE} STREQUAL "O2")
                  TARGETVARNAME targetName
                  SOURCES ${SRCS}
                  PUBLIC_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_LIST_DIR}
-                 PUBLIC_LINK_LIBRARIES O2::GPUCommon Vc::Vc ROOT::Core)
+                 PUBLIC_LINK_LIBRARIES O2::GPUCommon Vc::Vc
+                 PRIVATE_LINK_LIBRARIES ROOT::Core)
 
   o2_target_root_dictionary(${MODULE}
                             HEADERS ${HDRS_CINT_O2}

--- a/cmake/AddRootDictionary.cmake
+++ b/cmake/AddRootDictionary.cmake
@@ -137,9 +137,9 @@ function(add_root_dictionary target)
       -rmf ${rootmapFile}
       -rml $<TARGET_FILE_NAME:${target}>
       $<GENEX_EVAL:-I$<JOIN:$<TARGET_PROPERTY:${target},INCLUDE_DIRECTORIES>,\;-I>>
-      # the generator expression above gets the list of all include 
-      # directories that might be required using the transitive dependencies 
-      # of the target ${target} and prepend each item of that list with -I 
+      # the generator expression above gets the list of all include
+      # directories that might be required using the transitive dependencies
+      # of the target ${target} and prepend each item of that list with -I
       "${defs}"
       ${incdirs} ${headers}
     COMMAND
@@ -155,7 +155,7 @@ function(add_root_dictionary target)
   if(NOT ROOT::RIO IN_LIST libs)
     # add ROOT::IO if not already there as a target that has a Root dictionary
     # has to depend on ... Root
-    target_link_libraries(${target} PUBLIC ROOT::RIO)
+    target_link_libraries(${target} PRIVATE ROOT::RIO)
   endif()
 
   # Get the list of include directories that will be required to compile the

--- a/cmake/O2AddLibrary.cmake
+++ b/cmake/O2AddLibrary.cmake
@@ -31,6 +31,9 @@ include(O2NameTarget)
 #   to use the fully qualified target name (i.e. including the namespace part)
 #   even for internal (O2) targets.
 #
+# * PRIVATE_LINK_LIBRARIES (needed in most cases) : as PUBLIC_LINK_LIBRARIES,
+#   but dependencies are not forwarded to the consumers.
+#
 # * PUBLIC_INCLUDE_DIRECTORIES (not needed in most cases) : the list of include
 #   directories where to find the include files needed to compile this library
 #   and that will be needed as well by the consumers of that library. By default
@@ -54,7 +57,7 @@ function(o2_add_library baseTargetName)
     A
     ""
     "TARGETVARNAME"
-    "SOURCES;PUBLIC_INCLUDE_DIRECTORIES;PUBLIC_LINK_LIBRARIES;PRIVATE_INCLUDE_DIRECTORIES"
+    "SOURCES;PUBLIC_INCLUDE_DIRECTORIES;PUBLIC_LINK_LIBRARIES;PRIVATE_INCLUDE_DIRECTORIES;PRIVATE_LINK_LIBRARIES"
     )
 
   if(A_UNPARSED_ARGUMENTS)
@@ -89,6 +92,17 @@ function(o2_add_library baseTargetName)
           FATAL_ERROR "Trying to add a dependency on non-existing target ${L}")
       endif()
       target_link_libraries(${target} PUBLIC ${L})
+    endforeach()
+  endif()
+
+  # Private dependencies
+  if(A_PRIVATE_LINK_LIBRARIES)
+    foreach(L IN LISTS A_PRIVATE_LINK_LIBRARIES)
+      if(NOT TARGET ${L})
+        message(
+          FATAL_ERROR "Trying to add a dependency on non-existing target ${L}")
+      endif()
+      target_link_libraries(${target} PRIVATE ${L})
     endforeach()
   endif()
 

--- a/macro/CMakeLists.txt
+++ b/macro/CMakeLists.txt
@@ -334,6 +334,7 @@ o2_add_test_root_macro(run_sim_tpc.C
 # FIXME: move to subsystem dir + check how to deal with GPU dependencies
 o2_add_test_root_macro(run_trac_ca_its.C
                        PUBLIC_LINK_LIBRARIES O2::GPUTracking
+                                             O2::ITStracking
                        LABELS its COMPILE_ONLY)
 
 # FIXME: move to subsystem dir


### PR DESCRIPTION
This solves a problem if linking to both a ROOT and a CUDA target when C++ std is C++17.
The cause is that ROOT sets `INTERFACE_COMPILE_FEATURES "cxx_std_17"` to its targets (as of ROOT 6.18.00 to all targets). This propagates to all dependent libraries. If any of these libraries involves a CUDA file, CMake throws a Fatal error since it knows the CUDA compiler cannot compile C++17 code.

Since I did not find a way to remove the propagation of the COMPILE_FEATURES, and since this is actually not a ROOT or CMAKE bug, but just a problem with how we use CUDA (Have C++17 code but limit ourselves to C++14 for CUDA), this is the least intrusive way to solve it.

What this PR does:
 - There are only 2 libraries compiling .cu files, and these link only to GPUTracking and ITStracking targets.
 - The PR strips all PUBLIC dependencies that involve ROOT from GPUTracking and ITStracking, and instead sets PUBLIC include paths to ROOT, and the stipped O2 dependencies.
- Dependencies are instead added as PRIVATE link dependencies, so the problematic compile feature is not forwarded to the CUDA libraries.

If anyone has a better idea, I'd be very glad to have a cleaner solution.

@mpuccio : FYI: If you want to compile with CUDA after the CMake migration, you might have to pull this patch in depending on your ROOT version.