### PR TITLE
Fix GPUCommon target include directories

### DIFF
--- a/GPU/Common/CMakeLists.txt
+++ b/GPU/Common/CMakeLists.txt
@@ -29,8 +29,10 @@ set(HDRS_INSTALL
 if(ALIGPU_BUILD_TYPE STREQUAL "O2")
   o2_add_library(${MODULE}
                  TARGETVARNAME targetName
-                 PUBLIC_LINK_LIBRARIES FairLogger::FairLogger ROOT::RIO
-                 PUBLIC_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_LIST_DIR})
+                 PUBLIC_LINK_LIBRARIES FairLogger::FairLogger ROOT::RIO)
+  target_include_directories(${targetName}
+                             PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
+                                    $<INSTALL_INTERFACE:include/GPU>)
 
   o2_target_root_dictionary(${MODULE}
                             HEADERS ${HDRS_CINT}


### PR DESCRIPTION
For GPUCommon, include directories are different for the build tree and the install tree