### PR TITLE
Removing TNamed and override

### DIFF
--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/Flex.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/Flex.h
@@ -15,8 +15,6 @@
 #ifndef ALICEO2_MFT_FLEX_H_
 #define ALICEO2_MFT_FLEX_H_
 
-#include "TNamed.h"
-
 class TGeoVolume;
 class TGeoVolumeAssembly;
 
@@ -25,13 +23,13 @@ namespace o2
 namespace mft
 {
 
-class Flex : public TNamed
+class Flex
 {
 
  public:
   Flex();
   Flex(LadderSegmentation* ladder);
-  ~Flex() override;
+  ~Flex();
   TGeoVolumeAssembly* makeFlex(Int_t nbsensors, Double_t length);
   void makeElectricComponents(TGeoVolumeAssembly* flex, Int_t nbsensors, Double_t length, Double_t zvarnish);
 
@@ -45,9 +43,9 @@ class Flex : public TNamed
   Double_t* mFlexOrigin;
   LadderSegmentation* mLadderSeg;
 
-  ClassDefOverride(Flex, 1)
+  ClassDef(Flex, 1)
 };
-}
-}
+} // namespace mft
+} // namespace o2
 
 #endif

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/GeometryBuilder.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/GeometryBuilder.h
@@ -16,26 +16,24 @@
 #ifndef ALICEO2_MFT_GEOMETRYBUILDER_H_
 #define ALICEO2_MFT_GEOMETRYBUILDER_H_
 
-#include "TNamed.h"
-
 namespace o2
 {
 namespace mft
 {
 
-class GeometryBuilder : public TNamed
+class GeometryBuilder
 {
 
  public:
-  GeometryBuilder();
-  ~GeometryBuilder() override;
+  GeometryBuilder() = default;
+  ~GeometryBuilder() = default;
 
   void buildGeometry();
 
  private:
-  ClassDefOverride(GeometryBuilder, 1)
+  ClassDef(GeometryBuilder, 1)
 };
-}
-}
+} // namespace mft
+} // namespace o2
 
 #endif

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/HalfCone.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/HalfCone.h
@@ -16,8 +16,6 @@
 #ifndef ALICEO2_MFT_HALFCONE_H_
 #define ALICEO2_MFT_HALFCONE_H_
 
-#include "TNamed.h"
-
 class TGeoVolumeAssembly;
 
 namespace o2
@@ -25,13 +23,13 @@ namespace o2
 namespace mft
 {
 
-class HalfCone : public TNamed
+class HalfCone
 {
 
  public:
   HalfCone();
 
-  ~HalfCone() override;
+  ~HalfCone();
 
   TGeoVolumeAssembly* createHalfCone(Int_t half);
 
@@ -39,9 +37,9 @@ class HalfCone : public TNamed
   TGeoVolumeAssembly* mHalfCone;
 
  private:
-  ClassDefOverride(HalfCone, 1)
+  ClassDef(HalfCone, 1)
 };
-}
-}
+} // namespace mft
+} // namespace o2
 
 #endif

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/HalfDiskSegmentation.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/HalfDiskSegmentation.h
@@ -76,7 +76,7 @@ class HalfDiskSegmentation : public VSegmentation
 
   ClassDefOverride(HalfDiskSegmentation, 1);
 };
-}
-}
+} // namespace mft
+} // namespace o2
 
 #endif

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/HalfSegmentation.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/HalfSegmentation.h
@@ -28,7 +28,7 @@ namespace mft
 {
 class HalfDiskSegmentation;
 }
-}
+} // namespace o2
 
 namespace o2
 {
@@ -46,7 +46,7 @@ class HalfSegmentation : public VSegmentation
   ~HalfSegmentation() override;
   void Clear(const Option_t* /*opt*/) override;
 
-  Bool_t getID() const { return (GetUniqueID() >> 12); };
+  // Bool_t getID() const { return (GetUniqueID() >> 12); };
 
   Int_t getNHalfDisks() const { return mHalfDisks->GetEntries(); }
 
@@ -66,7 +66,7 @@ class HalfSegmentation : public VSegmentation
 
   ClassDefOverride(HalfSegmentation, 1);
 };
-}
-}
+} // namespace mft
+} // namespace o2
 
 #endif

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/HeatExchanger.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/HeatExchanger.h
@@ -25,14 +25,14 @@ namespace o2
 namespace mft
 {
 
-class HeatExchanger : public TNamed
+class HeatExchanger
 {
 
  public:
   HeatExchanger();
   HeatExchanger(Double_t Rwater, Double_t DRPipe, Double_t HeatExchangerThickness, Double_t CarbonThickness);
 
-  ~HeatExchanger() override = default;
+  ~HeatExchanger() = default;
 
   TGeoVolumeAssembly* create(Int_t kHalf, Int_t disk);
 
@@ -136,9 +136,9 @@ class HeatExchanger : public TNamed
   Double_t mAngle4fifth[4];  // angle of torus for fifth pipe of disk 4
   Double_t mRadius4fifth[4]; // radius of torus for fifth pipe of disk 4
 
-  ClassDefOverride(HeatExchanger, 2);
+  ClassDef(HeatExchanger, 2);
 };
-}
-}
+} // namespace mft
+} // namespace o2
 
 #endif

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/LadderSegmentation.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/LadderSegmentation.h
@@ -68,7 +68,7 @@ class LadderSegmentation : public VSegmentation
 
   ClassDefOverride(LadderSegmentation, 1);
 };
-}
-}
+} // namespace mft
+} // namespace o2
 
 #endif

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/Segmentation.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/Segmentation.h
@@ -25,24 +25,25 @@ namespace mft
 {
 class HalfSegmentation;
 }
-}
+} // namespace o2
 
 namespace o2
 {
 namespace mft
 {
 
-class Segmentation : public TNamed
+class Segmentation
 {
 
  public:
-  enum { Bottom, Top };
+  enum { Bottom,
+         Top };
 
   Segmentation();
   Segmentation(const Char_t* nameGeomFile);
 
-  ~Segmentation() override;
-  void Clear(const Option_t* /*opt*/) override;
+  ~Segmentation();
+  void Clear(const Option_t* /*opt*/);
 
   /// \brief Returns pointer to the segmentation of the half-MFT
   /// \param iHalf Integer : 0 = Bottom; 1 = Top
@@ -59,9 +60,9 @@ class Segmentation : public TNamed
  private:
   TClonesArray* mHalves; ///< \brief Array of pointer to HalfSegmentation
 
-  ClassDefOverride(Segmentation, 1);
+  ClassDef(Segmentation, 1);
 };
-}
-}
+} // namespace mft
+} // namespace o2
 
 #endif

--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/Support.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/Support.h
@@ -15,8 +15,6 @@
 #ifndef ALICEO2_MFT_SUPPORT_H_
 #define ALICEO2_MFT_SUPPORT_H_
 
-#include "TNamed.h"
-
 #include "FairLogger.h"
 
 class TGeoVolume;
@@ -27,13 +25,13 @@ namespace o2
 namespace mft
 {
 
-class Support : public TNamed
+class Support
 {
 
  public:
   Support();
 
-  ~Support() override;
+  ~Support();
 
   TGeoVolumeAssembly* createVolume(Int_t half, Int_t disk);
   TGeoVolumeAssembly* createPCBs(Int_t half, Int_t disk);
@@ -65,9 +63,9 @@ class Support : public TNamed
   Double_t mPCBThickness;
 
  private:
-  ClassDefOverride(Support, 1)
+  ClassDef(Support, 1)
 };
-}
-}
+} // namespace mft
+} // namespace o2
 
 #endif

--- a/Detectors/ITSMFT/MFT/base/src/Flex.cxx
+++ b/Detectors/ITSMFT/MFT/base/src/Flex.cxx
@@ -37,7 +37,7 @@ using namespace o2::itsmft;
 ClassImp(o2::mft::Flex);
 
 //_____________________________________________________________________________
-Flex::Flex() : TNamed(), mFlexOrigin(), mLadderSeg(nullptr)
+Flex::Flex() : mFlexOrigin(), mLadderSeg(nullptr)
 {
   // Constructor
 }
@@ -46,7 +46,7 @@ Flex::Flex() : TNamed(), mFlexOrigin(), mLadderSeg(nullptr)
 Flex::~Flex() = default;
 
 //_____________________________________________________________________________
-Flex::Flex(LadderSegmentation* ladder) : TNamed(), mFlexOrigin(), mLadderSeg(ladder)
+Flex::Flex(LadderSegmentation* ladder) : mFlexOrigin(), mLadderSeg(ladder)
 {
   // Constructor
 }

--- a/Detectors/ITSMFT/MFT/base/src/GeometryBuilder.cxx
+++ b/Detectors/ITSMFT/MFT/base/src/GeometryBuilder.cxx
@@ -30,15 +30,6 @@ using namespace o2::mft;
 ClassImp(o2::mft::GeometryBuilder);
 
 //_____________________________________________________________________________
-GeometryBuilder::GeometryBuilder() : TNamed()
-{
-  // default constructor
-}
-
-//_____________________________________________________________________________
-GeometryBuilder::~GeometryBuilder() = default;
-
-//_____________________________________________________________________________
 /// \brief Build the MFT Geometry
 void GeometryBuilder::buildGeometry()
 {

--- a/Detectors/ITSMFT/MFT/base/src/HalfCone.cxx
+++ b/Detectors/ITSMFT/MFT/base/src/HalfCone.cxx
@@ -35,7 +35,7 @@ using namespace o2::mft;
 ClassImp(o2::mft::HalfCone);
 
 //_____________________________________________________________________________
-HalfCone::HalfCone() : TNamed(), mHalfCone(nullptr)
+HalfCone::HalfCone() : mHalfCone(nullptr)
 {
 
   // default constructor

--- a/Detectors/ITSMFT/MFT/base/src/HeatExchanger.cxx
+++ b/Detectors/ITSMFT/MFT/base/src/HeatExchanger.cxx
@@ -32,8 +32,7 @@ ClassImp(o2::mft::HeatExchanger);
 
 //_____________________________________________________________________________
 HeatExchanger::HeatExchanger()
-  : TNamed(),
-    mHalfDisk(nullptr),
+  : mHalfDisk(nullptr),
     mHalfDiskRotation(nullptr),
     mHalfDiskTransformation(nullptr),
     mRWater(0.),
@@ -94,8 +93,7 @@ HeatExchanger::HeatExchanger()
 //_____________________________________________________________________________
 HeatExchanger::HeatExchanger(Double_t rWater, Double_t dRPipe, Double_t heatExchangerThickness,
                              Double_t carbonThickness)
-  : TNamed(),
-    mHalfDisk(nullptr),
+  : mHalfDisk(nullptr),
     mHalfDiskRotation(nullptr),
     mHalfDiskTransformation(nullptr),
     mRWater(rWater),

--- a/Detectors/ITSMFT/MFT/base/src/Segmentation.cxx
+++ b/Detectors/ITSMFT/MFT/base/src/Segmentation.cxx
@@ -24,10 +24,10 @@ using namespace o2::mft;
 ClassImp(o2::mft::Segmentation);
 
 //_____________________________________________________________________________
-Segmentation::Segmentation() : TNamed(), mHalves(nullptr) {}
+Segmentation::Segmentation() : mHalves(nullptr) {}
 
 //_____________________________________________________________________________
-Segmentation::Segmentation(const Char_t* nameGeomFile) : TNamed(), mHalves(nullptr)
+Segmentation::Segmentation(const Char_t* nameGeomFile) : mHalves(nullptr)
 {
 
   // constructor

--- a/Detectors/ITSMFT/MFT/base/src/Support.cxx
+++ b/Detectors/ITSMFT/MFT/base/src/Support.cxx
@@ -27,8 +27,7 @@ ClassImp(o2::mft::Support);
 
 //_____________________________________________________________________________
 Support::Support()
-  : TNamed(),
-    mSupportVolume(nullptr),
+  : mSupportVolume(nullptr),
     mSupportThickness(0.7), // cm    instead of 0.8, fm
     mPCBThickness(0.1)      // cm
 {
@@ -43,7 +42,7 @@ Support::~Support() { delete mSupportVolume; }
 TGeoVolumeAssembly* Support::createVolume(Int_t half, Int_t disk)
 {
 
-  Info("CreateVolume", Form("Creating support and PCB for half %d and disk %d)", half, disk), 0, 0);
+  //Info("CreateVolume", Form("Creating support and PCB for half %d and disk %d)", half, disk), 0, 0);
 
   mSupportVolume = new TGeoVolumeAssembly(Form("SupportPCB_%d_%d", half, disk));
 
@@ -66,7 +65,7 @@ TGeoVolumeAssembly* Support::createVolume(Int_t half, Int_t disk)
 TGeoVolumeAssembly* Support::createPCBs(Int_t half, Int_t disk)
 {
 
-  Info("CreatePCBs", Form("Creating PCB for half %d and disk %d ", half, disk), 0, 0);
+  //Info("CreatePCBs", Form("Creating PCB for half %d and disk %d ", half, disk), 0, 0);
 
   TGeoVolumeAssembly* pcbVolume;
 
@@ -1493,7 +1492,7 @@ TGeoVolumeAssembly* Support::createPCB_PSU(Int_t half, Int_t disk)
 TGeoVolume* Support::createSupport(Int_t half, Int_t disk)
 {
 
-  Info("CreateSupport", Form("Creating PCB for half %d and disk %d ", half, disk), 0, 0);
+  //Info("CreateSupport", Form("Creating PCB for half %d and disk %d ", half, disk), 0, 0);
 
   // Get Mediums
   TGeoMedium* medPeek = gGeoManager->GetMedium("MFT_PEEK$");


### PR DESCRIPTION
The unnecessary TNamed and override are removed in some MFT classes