### PR TITLE
DPL support for resizable vector  through make<std::vector<messageable_type>> 

### DIFF
--- a/Framework/Core/include/Framework/TypeTraits.h
+++ b/Framework/Core/include/Framework/TypeTraits.h
@@ -104,6 +104,14 @@ struct is_container<
     void>> : public std::true_type {
 };
 
+// Detect whether a container class has a type definition `value_type` of messageable type
+template <typename T, typename _ = void>
+struct has_messageable_value_type : std::false_type {
+};
+template <typename T>
+struct has_messageable_value_type<T, std::conditional_t<false, typename T::value_type, void>> : is_messageable<typename T::value_type> {
+};
+
 // Detect whether a class has a ROOT dictionary
 // This member detector idiom is implemented using SFINAE idiom to look for
 // a 'Class()' method.

--- a/Framework/Core/test/test_TypeTraits.cxx
+++ b/Framework/Core/test/test_TypeTraits.cxx
@@ -106,6 +106,10 @@ BOOST_AUTO_TEST_CASE(TestIsStlContainer)
   BOOST_REQUIRE_EQUAL(is_container<decltype(b)>::value, false);
   BOOST_REQUIRE_EQUAL(is_container<decltype(c)>::value, true);
   BOOST_REQUIRE_EQUAL(is_container<decltype(d)>::value, true);
+
+  BOOST_REQUIRE_EQUAL(has_messageable_value_type<decltype(b)>::value, false);
+  BOOST_REQUIRE_EQUAL(has_messageable_value_type<std::vector<int>>::value, true);
+  BOOST_REQUIRE_EQUAL(has_messageable_value_type<decltype(c)>::value, false);
 }
 
 BOOST_AUTO_TEST_CASE(TestHasRootStreamer)


### PR DESCRIPTION
@ktf, this implements the basic support for sending vectors of messageable type through the `DataAllocator::make` API

Only to be merged after #1970

TODO:
- [x] merge #1970
- [x] check `value_type` to be messageable
- [x] arbitrary constructor arguments


In a separate PR the InputRecord API can be adapted, for the moment `span` needs to be used to extract the array of elements.
