### PR TITLE
Adapt TPC Standalone QA to process O2 MC labels + general QA/Display improvements

### DIFF
--- a/Detectors/TPC/workflow/src/CATrackerSpec.cxx
+++ b/Detectors/TPC/workflow/src/CATrackerSpec.cxx
@@ -91,15 +91,16 @@ DataProcessorSpec getCATrackerSpec(bool processMC, std::vector<int> const& input
       // This should go away eventually.
 
       // Default Settings
-      float solenoidBz = 5.00668;  // B-field
-      float refX = 83.;            // transport tracks to this x after tracking, >500 for disabling
-      bool continuous = false;     // time frame data v.s. triggered events
-      int nThreads = 1;            // number of threads if we run on the CPU, 1 = default, 0 = auto-detect
-      bool useGPU = false;         // use a GPU for processing, if false uses GPU
-      int debugLevel = 0;          // Enable additional debug output
-      bool dump = false;           // create memory dump of processed events for standalone runs
-      char gpuType[1024] = "CUDA"; // Type of GPU device, if useGPU is set to true
-      GPUDisplayBackend* display = nullptr;
+      float solenoidBz = 5.00668;           // B-field
+      float refX = 83.;                     // transport tracks to this x after tracking, >500 for disabling
+      bool continuous = false;              // time frame data v.s. triggered events
+      int nThreads = 1;                     // number of threads if we run on the CPU, 1 = default, 0 = auto-detect
+      bool useGPU = false;                  // use a GPU for processing, if false uses GPU
+      int debugLevel = 0;                   // Enable additional debug output
+      bool dump = false;                    // create memory dump of processed events for standalone runs
+      char gpuType[1024] = "CUDA";          // Type of GPU device, if useGPU is set to true
+      GPUDisplayBackend* display = nullptr; // Ptr to display backend (enables event display)
+      bool qa = false;                      // Run the QA after tracking
 
       const auto grp = o2::parameters::GRPObject::loadFrom("o2sim_grp.root");
       if (grp) {
@@ -136,6 +137,9 @@ DataProcessorSpec getCATrackerSpec(bool processMC, std::vector<int> const& input
 #else
             printf("Standalone Event Display not enabled at build time!\n");
 #endif
+          } else if (strncmp(optPtr, "qa", optLen) == 0) {
+            qa = true;
+            printf("Enabling TPC Standalone QA\n");
           } else if (optLen > 3 && strncmp(optPtr, "bz=", 3) == 0) {
             sscanf(optPtr + 3, "%f", &solenoidBz);
             printf("Using solenoid field %f\n", solenoidBz);
@@ -172,7 +176,7 @@ DataProcessorSpec getCATrackerSpec(bool processMC, std::vector<int> const& input
       config.configProcessing.forceDeviceType = true; // If we request a GPU, we force that it is available - no CPU fallback
 
       config.configDeviceProcessing.nThreads = nThreads;
-      config.configDeviceProcessing.runQA = false;          // Run QA after tracking
+      config.configDeviceProcessing.runQA = qa;             // Run QA after tracking
       config.configDeviceProcessing.eventDisplay = display; // Ptr to event display backend, for running standalone OpenGL event display
                                                             // config.configDeviceProcessing.eventDisplay = new GPUDisplayBackendX11;
 

--- a/GPU/GPUTracking/Base/GPUDataTypes.h
+++ b/GPU/GPUTracking/Base/GPUDataTypes.h
@@ -51,7 +51,7 @@ namespace gpu
 #endif
 
 #ifdef __OPENCL__
-MEM_CLASS_PRE()
+MEM_CLASS_PRE() // Macro with some template magic for OpenCL 1.2
 #endif
 class GPUTPCTrack;
 class GPUTPCHitId;

--- a/GPU/GPUTracking/DataCompression/GPUTPCCompressionKernels.h
+++ b/GPU/GPUTracking/DataCompression/GPUTPCCompressionKernels.h
@@ -21,7 +21,7 @@ namespace o2
 namespace tpc
 {
 struct ClusterNative;
-} // namespace tpc
+}
 } // namespace o2
 
 namespace GPUCA_NAMESPACE

--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -281,6 +281,9 @@ int GPUChainTracking::PrepareEvent()
 
 int GPUChainTracking::Finalize()
 {
+  if (GetDeviceProcessingSettings().runQA && mQAInitialized) {
+    mQA->DrawQAHistograms();
+  }
   if (GetDeviceProcessingSettings().debugLevel >= 4) {
     mDebugFile.close();
   }

--- a/GPU/GPUTracking/Merger/GPUTPCGMMerger.h
+++ b/GPU/GPUTracking/Merger/GPUTPCGMMerger.h
@@ -95,7 +95,6 @@ class GPUTPCGMMerger : public GPUProcessor
   }
   GPUhd() const GPUTPCTracker* SliceTrackers() const { return (mSliceTrackers); }
   GPUhd() GPUAtomic(unsigned int) * ClusterAttachment() const { return (mClusterAttachment); }
-  GPUhd() int MaxId() const { return (mMaxID); }
   GPUhd() unsigned int* TrackOrder() const { return (mTrackOrder); }
 
   enum attachTypes { attachAttached = 0x40000000,

--- a/GPU/GPUTracking/Standalone/display/GPUDisplay.h
+++ b/GPU/GPUTracking/Standalone/display/GPUDisplay.h
@@ -348,7 +348,8 @@ class GPUDisplay
   int mHideRejectedClusters = 1;
   int mHideUnmatchedClusters = 0;
   int mHideRejectedTracks = 1;
-  int markAdjacentClusters = 0;
+  int mMarkAdjacentClusters = 0;
+  int mMarkFakeClusters = 0;
 
   vecpod<std::array<int, 37>> mCollisionClusters;
   int mNCollissions = 1;

--- a/GPU/GPUTracking/Standalone/display/GPUDisplayKeys.cpp
+++ b/GPU/GPUTracking/Standalone/display/GPUDisplayKeys.cpp
@@ -30,6 +30,7 @@ const char* HelpText[] = {
   "[x]                           Exclude Clusters used in the tracking steps enabled for visualization ([1]-[8])",
   "[.]                           Exclude rejected tracks",
   "[c]                           Mark flagged clusters (splitPad = 0x1, splitTime = 0x2, edge = 0x4, singlePad = 0x8, rejectDistance = 0x10, rejectErr = 0x20",
+  "[z]                           Mark fake attached clusters",
   "[B]                           Mark clusters attached as adjacent",
   "[L] / [K]                     Draw single collisions (next / previous)",
   "[C]                           Colorcode clusters of different collisions",
@@ -57,7 +58,7 @@ const char* HelpText[] = {
   "[ALT] / [CTRL] / [m]          Focus camera on origin / orient y-axis upwards (combine with [SHIFT] to lock) / Cycle through modes",
   "[1] ... [8] / [N]             Enable display of clusters, preseeds, seeds, starthits, tracklets, tracks, global tracks, merged tracks / Show assigned clusters in colors"
   "[F1] / [F2]                   Enable / disable drawing of TPC / TRD"
-  // FREE: u z
+  // FREE: u
 };
 
 void GPUDisplay::PrintHelp()
@@ -169,23 +170,27 @@ void GPUDisplay::HandleKeyRelease(unsigned char key)
     SetInfo("Cluster flag highlight mask set to %d (%s)", mMarkClusters,
             mMarkClusters == 0 ? "off" : mMarkClusters == 1 ? "split pad" : mMarkClusters == 2 ? "split time" : mMarkClusters == 4 ? "edge" : mMarkClusters == 8 ? "singlePad" : mMarkClusters == 0x10 ? "reject distance" : "reject error");
     mUpdateDLList = true;
+  } else if (key == 'z') {
+    mMarkFakeClusters ^= 1;
+    SetInfo("Marking fake clusters: %s", mMarkFakeClusters ? "on" : "off");
+    mUpdateDLList = true;
   } else if (key == 'B') {
-    markAdjacentClusters++;
-    if (markAdjacentClusters == 5) {
-      markAdjacentClusters = 7;
+    mMarkAdjacentClusters++;
+    if (mMarkAdjacentClusters == 5) {
+      mMarkAdjacentClusters = 7;
     }
-    if (markAdjacentClusters == 9) {
-      markAdjacentClusters = 15;
+    if (mMarkAdjacentClusters == 9) {
+      mMarkAdjacentClusters = 15;
     }
-    if (markAdjacentClusters == 18) {
-      markAdjacentClusters = 0;
+    if (mMarkAdjacentClusters == 18) {
+      mMarkAdjacentClusters = 0;
     }
-    if (markAdjacentClusters == 17) {
-      SetInfo("Marking protected clusters (%d)", markAdjacentClusters);
-    } else if (markAdjacentClusters == 16) {
-      SetInfo("Marking removable clusters (%d)", markAdjacentClusters);
+    if (mMarkAdjacentClusters == 17) {
+      SetInfo("Marking protected clusters (%d)", mMarkAdjacentClusters);
+    } else if (mMarkAdjacentClusters == 16) {
+      SetInfo("Marking removable clusters (%d)", mMarkAdjacentClusters);
     } else {
-      SetInfo("Marking adjacent clusters (%d): rejected %s, tube %s, looper leg %s, low Pt %s", markAdjacentClusters, (markAdjacentClusters & 1) ? "yes" : " no", (markAdjacentClusters & 2) ? "yes" : " no", (markAdjacentClusters & 4) ? "yes" : " no", (markAdjacentClusters & 8) ? "yes" : " no");
+      SetInfo("Marking adjacent clusters (%d): rejected %s, tube %s, looper leg %s, low Pt %s", mMarkAdjacentClusters, (mMarkAdjacentClusters & 1) ? "yes" : " no", (mMarkAdjacentClusters & 2) ? "yes" : " no", (mMarkAdjacentClusters & 4) ? "yes" : " no", (mMarkAdjacentClusters & 8) ? "yes" : " no");
     }
     mUpdateDLList = true;
   } else if (key == 'C') {

--- a/GPU/GPUTracking/Standalone/standalone.cxx
+++ b/GPU/GPUTracking/Standalone/standalone.cxx
@@ -560,19 +560,11 @@ int main(int argc, char** argv)
   }
 breakrun:
 
-  if (configStandalone.qa) {
 #ifndef _WIN32
-    if (configStandalone.fpe) {
-      fedisableexcept(FE_INVALID | FE_DIVBYZERO | FE_OVERFLOW);
-    }
-
-#endif
-    if (chainTracking->GetQA() == nullptr) {
-      printf("QA Unavailable\n");
-      return 1;
-    }
-    chainTracking->GetQA()->DrawQAHistograms();
+  if (configStandalone.qa && configStandalone.fpe) {
+    fedisableexcept(FE_INVALID | FE_DIVBYZERO | FE_OVERFLOW);
   }
+#endif
 
   rec->Finalize();
   rec->Exit();


### PR DESCRIPTION
First version of TPC resolution and efficiency QA.
- Supports imported Run 2 Raw / MC data and Run 3 MCTruthContainer and o2sim.log MC trees.
- So far runs only with the tracking, next PR should add standalone capabilities to run on std::vector<trackTPC>
- Some features still disabled for O2, but needs more other work first.