### PR TITLE
Some fixes for GPU TPC Tracking visualization

### DIFF
--- a/Detectors/TPC/workflow/CMakeLists.txt
+++ b/Detectors/TPC/workflow/CMakeLists.txt
@@ -16,6 +16,7 @@ o2_add_library(TPCWorkflow
                        src/ClusterDecoderRawSpec.cxx
                        src/CATrackerSpec.cxx
                        src/TrackReaderSpec.cxx
+               TARGETVARNAME targetName
                PUBLIC_LINK_LIBRARIES O2::Framework O2::DataFormatsTPC
                                      O2::DPLUtils O2::TPCReconstruction)
 
@@ -29,3 +30,9 @@ o2_add_test(workflow
             LABELS tpc workflow
             SOURCES test/test_TPCWorkflow.cxx
             PUBLIC_LINK_LIBRARIES O2::TPCWorkflow)
+
+if(GPUCA_EVENT_DISPLAY OR
+                       (OPENGL_FOUND AND GLFW_FOUND AND GLEW_FOUND AND OPENGL_GLU_FOUND
+                       AND NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin"))
+    target_compile_definitions(${targetName} PRIVATE GPUCA_BUILD_EVENT_DISPLAY)
+endif()

--- a/Detectors/TPC/workflow/src/CATrackerSpec.cxx
+++ b/Detectors/TPC/workflow/src/CATrackerSpec.cxx
@@ -30,7 +30,7 @@
 #include "DetectorsBase/MatLayerCylSet.h"
 #include "GPUO2InterfaceConfiguration.h"
 #include "GPUDisplayBackend.h"
-#ifdef BUILD_EVENT_DISPLAY
+#ifdef GPUCA_BUILD_EVENT_DISPLAY
 #include "GPUDisplayBackendGlfw.h"
 #endif
 #include "DataFormatsParameters/GRPObject.h"
@@ -129,7 +129,7 @@ DataProcessorSpec getCATrackerSpec(bool processMC, std::vector<int> const& input
             dump = true;
             printf("Dumping of input events enabled\n");
           } else if (strncmp(optPtr, "display", optLen) == 0) {
-#ifdef BUILD_EVENT_DISPLAY
+#ifdef GPUCA_BUILD_EVENT_DISPLAY
             processAttributes->displayBackend.reset(new GPUDisplayBackendGlfw);
             display = processAttributes->displayBackend.get();
             printf("Event display enabled\n");

--- a/GPU/GPUTracking/Base/GPUTPCGPURootDump.h
+++ b/GPU/GPUTracking/Base/GPUTPCGPURootDump.h
@@ -14,7 +14,7 @@
 #ifndef GPUTPCGPUROOTDUMP_H
 #define GPUTPCGPUROOTDUMP_H
 
-#if (!defined(GPUCA_STANDALONE) || defined(BUILD_QA)) && !defined(GPUCA_GPUCODE)
+#if (!defined(GPUCA_STANDALONE) || defined(GPUCA_BUILD_QA)) && !defined(GPUCA_GPUCODE)
 #include <TTree.h>
 #include <TFile.h>
 #include <TNtuple.h>

--- a/GPU/GPUTracking/CMakeLists.txt
+++ b/GPU/GPUTracking/CMakeLists.txt
@@ -336,7 +336,7 @@ endif()
 
 if(GPUCA_EVENT_DISPLAY)
   message(STATUS "Building GPU Event Display")
-  target_compile_definitions(${targetName} PRIVATE BUILD_EVENT_DISPLAY)
+  target_compile_definitions(${targetName} PRIVATE GPUCA_BUILD_EVENT_DISPLAY)
   target_link_libraries(${targetName}
                         PUBLIC ${GLEW_LIBRARIES} ${GLFW_LIBRARIES} OpenGL::GL
                                OpenGL::GLU)
@@ -344,7 +344,7 @@ endif()
 
 if(GPUCA_QA)
   message(STATUS "Building GPU QA")
-  target_compile_definitions(${targetName} PRIVATE BUILD_QA)
+  target_compile_definitions(${targetName} PRIVATE GPUCA_BUILD_QA)
 endif()
 
 if(OpenMP_CXX_FOUND)

--- a/GPU/GPUTracking/SliceTracker/GPUTPCClusterErrorStat.h
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCClusterErrorStat.h
@@ -16,7 +16,7 @@
 
 //#define EXTRACT_RESIDUALS
 
-#if (defined(GPUCA_ALIROOT_LIB) || defined(BUILD_QA)) && !defined(GPUCA_GPUCODE) && defined(EXTRACT_RESIDUALS)
+#if (defined(GPUCA_ALIROOT_LIB) || defined(GPUCA_BUILD_QA)) && !defined(GPUCA_GPUCODE) && defined(EXTRACT_RESIDUALS)
 #include "cagpu/GPUTPCGPURootDump.h"
 
 namespace GPUCA_NAMESPACE

--- a/GPU/GPUTracking/Standalone/config_common.mak
+++ b/GPU/GPUTracking/Standalone/config_common.mak
@@ -93,10 +93,10 @@ ifeq ($(BUILD_HIP), 1)
 DEFINES						+= HIP_ENABLED
 endif
 ifeq ($(BUILD_EVENT_DISPLAY), 1)
-DEFINES						+= BUILD_EVENT_DISPLAY
+DEFINES						+= GPUCA_BUILD_EVENT_DISPLAY
 endif
 ifeq ($(BUILD_QA), 1)
-DEFINES						+= BUILD_QA
+DEFINES						+= GPUCA_BUILD_QA
 endif
 
 

--- a/GPU/GPUTracking/Standalone/display/GPUDisplay.cpp
+++ b/GPU/GPUTracking/Standalone/display/GPUDisplay.cpp
@@ -13,7 +13,7 @@
 
 #include "GPUDisplay.h"
 
-#ifdef BUILD_EVENT_DISPLAY
+#ifdef GPUCA_BUILD_EVENT_DISPLAY
 #include "GPUTPCDef.h"
 
 #include <GL/glu.h>

--- a/GPU/GPUTracking/Standalone/display/GPUDisplay.h
+++ b/GPU/GPUTracking/Standalone/display/GPUDisplay.h
@@ -14,7 +14,7 @@
 #ifndef GPUDISPLAY_H
 #define GPUDISPLAY_H
 
-#ifdef BUILD_EVENT_DISPLAY
+#ifdef GPUCA_BUILD_EVENT_DISPLAY
 #ifdef GPUCA_O2_LIB
 //#define GPUCA_DISPLAY_GL3W
 #endif
@@ -32,7 +32,7 @@
 #pragma message "Unsupported OpenGL version < 4.5, disabling standalone event display"
 #else
 #warning Unsupported OpenGL version < 4.5, disabling standalone event display
-#undef BUILD_EVENT_DISPLAY
+#undef GPUCA_BUILD_EVENT_DISPLAY
 #endif
 #endif
 #endif
@@ -49,7 +49,7 @@ class GPUQA;
 } // namespace gpu
 } // namespace GPUCA_NAMESPACE
 
-#ifndef BUILD_EVENT_DISPLAY
+#ifndef GPUCA_BUILD_EVENT_DISPLAY
 
 namespace GPUCA_NAMESPACE
 {

--- a/GPU/GPUTracking/Standalone/display/GPUDisplay.h
+++ b/GPU/GPUTracking/Standalone/display/GPUDisplay.h
@@ -32,8 +32,8 @@
 #pragma message "Unsupported OpenGL version < 4.5, disabling standalone event display"
 #else
 #warning Unsupported OpenGL version < 4.5, disabling standalone event display
-#undef GPUCA_BUILD_EVENT_DISPLAY
 #endif
+#undef GPUCA_BUILD_EVENT_DISPLAY
 #endif
 #endif
 

--- a/GPU/GPUTracking/Standalone/display/GPUDisplayInterpolation.cpp
+++ b/GPU/GPUTracking/Standalone/display/GPUDisplayInterpolation.cpp
@@ -13,7 +13,7 @@
 
 #include <cstdio>
 #include "GPUDisplay.h"
-#ifdef BUILD_EVENT_DISPLAY
+#ifdef GPUCA_BUILD_EVENT_DISPLAY
 
 using namespace GPUCA_NAMESPACE::gpu;
 

--- a/GPU/GPUTracking/Standalone/display/GPUDisplayKeys.cpp
+++ b/GPU/GPUTracking/Standalone/display/GPUDisplayKeys.cpp
@@ -12,7 +12,7 @@
 /// \author David Rohr
 
 #include "GPUDisplay.h"
-#ifdef BUILD_EVENT_DISPLAY
+#ifdef GPUCA_BUILD_EVENT_DISPLAY
 
 using namespace GPUCA_NAMESPACE::gpu;
 

--- a/GPU/GPUTracking/Standalone/display/GPUDisplayQuaternion.cpp
+++ b/GPU/GPUTracking/Standalone/display/GPUDisplayQuaternion.cpp
@@ -12,7 +12,7 @@
 /// \author David Rohr
 
 #include "GPUDisplay.h"
-#ifdef BUILD_EVENT_DISPLAY
+#ifdef GPUCA_BUILD_EVENT_DISPLAY
 
 #include <cmath>
 using namespace GPUCA_NAMESPACE::gpu;

--- a/GPU/GPUTracking/Standalone/qa/GPUQA.h
+++ b/GPU/GPUTracking/Standalone/qa/GPUQA.h
@@ -27,7 +27,7 @@ class TFile;
 class TH1D;
 typedef short int Color_t;
 
-#if !defined(BUILD_QA) || defined(GPUCA_GPUCODE)
+#if !defined(GPUCA_BUILD_QA) || defined(GPUCA_GPUCODE)
 
 namespace GPUCA_NAMESPACE
 {

--- a/GPU/GPUTracking/Standalone/qa/genEvents.h
+++ b/GPU/GPUTracking/Standalone/qa/genEvents.h
@@ -23,7 +23,7 @@ namespace gpu
 class GPUChainTracking;
 struct GPUParam;
 class GPUTPCGMPhysicalTrackModel;
-#if !defined(BUILD_QA) || defined(_WIN32)
+#if !defined(GPUCA_BUILD_QA) || defined(_WIN32)
 class genEvents
 {
  public:

--- a/GPU/GPUTracking/Standalone/standalone.cxx
+++ b/GPU/GPUTracking/Standalone/standalone.cxx
@@ -55,7 +55,7 @@
 #include "GPUChainITS.h"
 #endif
 
-#ifdef BUILD_EVENT_DISPLAY
+#ifdef GPUCA_BUILD_EVENT_DISPLAY
 #ifdef _WIN32
 #include "GPUDisplayBackendWindows.h"
 #else
@@ -152,13 +152,13 @@ int ReadConfiguration(int argc, char** argv)
 #ifndef HAVE_O2HEADERS
   configStandalone.configRec.runTRD = configStandalone.configRec.rundEdx = configStandalone.configRec.runCompression = configStandalone.configRec.runTransformation = 0;
 #endif
-#ifndef BUILD_QA
+#ifndef GPUCA_BUILD_QA
   if (configStandalone.qa || configStandalone.eventGenerator) {
     printf("QA not enabled in build\n");
     return (1);
   }
 #endif
-#ifndef BUILD_EVENT_DISPLAY
+#ifndef GPUCA_BUILD_EVENT_DISPLAY
   if (configStandalone.eventDisplay) {
     printf("EventDisplay not enabled in build\n");
     return (1);
@@ -289,7 +289,7 @@ int SetupReconstruction()
   devProc.runQA = configStandalone.qa;
   devProc.runCompressionStatistics = configStandalone.compressionStat;
   if (configStandalone.eventDisplay) {
-#ifdef BUILD_EVENT_DISPLAY
+#ifdef GPUCA_BUILD_EVENT_DISPLAY
 #ifdef _WIN32
     if (configStandalone.eventDisplay == 1) {
       eventDisplay.reset(new GPUDisplayBackendWindows);


### PR DESCRIPTION
- Don't fail if GLEW is available but OpenGL version to old.
- Propagate availability to TPC workflow.
- Rename defines to make clear this is about GPU Standalone stuff.