### PR TITLE
Bring back compile and link flags lost in CMake migration

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/cuda/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/CMakeLists.txt
@@ -8,9 +8,6 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
-find_package(cub)
-set_package_properties(cub PROPERTIES TYPE REQUIRED)
-
 message(STATUS "Building ITS CUDA tracker")
 
 o2_add_library(ITStrackingCUDA

--- a/Framework/DebugGUI/CMakeLists.txt
+++ b/Framework/DebugGUI/CMakeLists.txt
@@ -25,7 +25,10 @@ endif()
 o2_add_library(DebugGUI
                SOURCES src/imgui.cpp src/imgui_draw.cpp src/imgui_extras.cpp
                        ${GUI_BACKEND}
-               PUBLIC_LINK_LIBRARIES O2::FrameworkFoundation ${GUI_TARGET})
+               PUBLIC_LINK_LIBRARIES O2::FrameworkFoundation ${GUI_TARGET}
+               TARGETVARNAME targetName)
+
+target_link_libraries(${targetName} PRIVATE dl)
 
 if(GLFW_FOUND)
   o2_add_executable(imgui

--- a/GPU/GPUTracking/Base/cuda/CMakeLists.txt
+++ b/GPU/GPUTracking/Base/cuda/CMakeLists.txt
@@ -23,7 +23,7 @@ if(ALIGPU_BUILD_TYPE STREQUAL "O2")
       ${CMAKE_SOURCE_DIR}/Detectors/Base/src
       ${CMAKE_SOURCE_DIR}/Detectors/TRD/base/src
       ${CMAKE_SOURCE_DIR}/Detectors/ITSMFT/ITS/tracking/cuda/include
-    PUBLIC_LINK_LIBRARIES O2::GPUTracking
+    PUBLIC_LINK_LIBRARIES O2::GPUTracking O2::ITStrackingCUDA cub::cub
     TARGETVARNAME targetName)
 
   target_compile_definitions(
@@ -61,6 +61,8 @@ if(ALIGPU_BUILD_TYPE STREQUAL "ALIROOT")
   install(TARGETS Ali${MODULE} ARCHIVE DESTINATION lib LIBRARY DESTINATION lib)
 
   install(FILES ${HDRS} DESTINATION include)
+
+  set(targetName Ali${MODULE})
 endif()
 
 if(ALIGPU_BUILD_TYPE STREQUAL "Standalone")
@@ -68,3 +70,6 @@ if(ALIGPU_BUILD_TYPE STREQUAL "Standalone")
   add_library(${MODULE} SHARED ${SRCS})
   install(TARGETS GPUTrackingCUDA)
 endif()
+
+# Since
+target_link_libraries(${targetName} PRIVATE cuda cudart)

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -9,3 +9,4 @@
 # submit itself to any jurisdiction.
 
 include("${CMAKE_CURRENT_LIST_DIR}/O2Dependencies.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/O2CompileFlags.cmake")

--- a/dependencies/FindO2GPU.cmake
+++ b/dependencies/FindO2GPU.cmake
@@ -42,6 +42,8 @@ if(ENABLE_CUDA)
     if(NOT CUDA IN_LIST LANGUAGES)
       message(FATAL_ERROR "CUDA was found but cannot be enabled")
     endif()
+    find_package(cub)
+    set_package_properties(cub PROPERTIES TYPE REQUIRED)
 
     set(CMAKE_CUDA_FLAGS "--expt-relaxed-constexpr")
     set(CMAKE_CUDA_FLAGS_DEBUG "-Xptxas -O0 -Xcompiler -O0")

--- a/dependencies/O2CompileFlags.cmake
+++ b/dependencies/O2CompileFlags.cmake
@@ -1,0 +1,52 @@
+# Copyright CERN and copyright holders of ALICE O2. This software is distributed
+# under the terms of the GNU General Public License v3 (GPL Version 3), copied
+# verbatim in the file "COPYING".
+#
+# See http://alice-o2.web.cern.ch/license for full licensing information.
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization or
+# submit itself to any jurisdiction.
+
+include_guard()
+
+set(CMAKE_CXX_FLAGS_COVERAGE "-g -O2 -fprofile-arcs -ftest-coverage")
+set(CMAKE_C_FLAGS_COVERAGE "${CMAKE_CXX_FLAGS_COVERAGE}")
+set(CMAKE_Fortran_FLAGS_COVERAGE "-g -O2 -fprofile-arcs -ftest-coverage")
+set(CMAKE_LINK_FLAGS_COVERAGE "--coverage -fprofile-arcs  -fPIC")
+
+MARK_AS_ADVANCED(
+    CMAKE_CXX_FLAGS_COVERAGE
+    CMAKE_C_FLAGS_COVERAGE
+    CMAKE_Fortran_FLAGS_COVERAGE
+    CMAKE_LINK_FLAGS_COVERAGE)
+
+#Check the compiler and set the compile and link flags
+IF (NOT CMAKE_BUILD_TYPE)
+  Message(STATUS "Set BuildType to DEBUG")
+  set(CMAKE_BUILD_TYPE Debug)
+ENDIF (NOT CMAKE_BUILD_TYPE)
+
+IF(ENABLE_CASSERT) #For the CI, we want to have <cassert> assertions enabled
+    set(CMAKE_CXX_FLAGS_RELEASE "-O2")
+    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g")
+ELSE()
+    set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
+    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -DNDEBUG")
+ENDIF()
+set(CMAKE_C_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
+set(CMAKE_Fortran_FLAGS_RELEASE "-O2")
+set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+set(CMAKE_Fortran_FLAGS_RELWITHDEBINFO "-O2 -g")
+# make sure Debug build not optimized (does not seem to work without CACHE + FORCE)
+set(CMAKE_CXX_FLAGS_DEBUG "-g -O0" CACHE STRING "Debug mode build flags" FORCE)
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}" CACHE STRING "Debug mode build flags" FORCE)
+set(CMAKE_Fortran_FLAGS_DEBUG "-g -O0" CACHE STRING "Debug mode build flags" FORCE)
+
+if(APPLE)
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-undefined,error") # avoid undefined in our libs
+elseif(UNIX)
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined") # avoid undefined in our libs
+endif()
+
+message(STATUS "Using build type: ${CMAKE_BUILD_TYPE} - CXXFLAGS: ${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE}}")


### PR DESCRIPTION
This brings back Compile and link flags lost during the CMake migration, in particular the -Wl,--no-undefined, which was missing.
Along that, it also fixes some library dependencies that turned out missing indeed.
Not 100% sure this is all modern CMake, 