### PR TITLE
[O2-778] Rework test_RootTreeWriterWorkflow

### DIFF
--- a/Framework/Utils/CMakeLists.txt
+++ b/Framework/Utils/CMakeLists.txt
@@ -46,9 +46,6 @@ o2_add_test(RootTreeWriterWorkflow
             COMPONENT_NAME DPLUtils
             LABELS dplutils
             COMMAND_LINE_ARGS --run)
-# FIXME: re-enable this when random failures understood
-set_property(TEST Framework/Utils/test/test_RootTreeWriterWorkflow.cxx
-             PROPERTY DISABLED TRUE)
 
 o2_add_test(RootTreeReader
             SOURCES test/test_RootTreeReader.cxx

--- a/Framework/Utils/test/test_RootTreeWriterWorkflow.cxx
+++ b/Framework/Utils/test/test_RootTreeWriterWorkflow.cxx
@@ -10,13 +10,13 @@
 
 #include "Framework/WorkflowSpec.h"
 #include "Framework/DataProcessorSpec.h"
-#include "Framework/runDataProcessing.h"
 #include "Framework/DataAllocator.h"
 #include "Framework/InputRecord.h"
 #include "Framework/InputSpec.h"
 #include "Framework/OutputSpec.h"
 #include "Framework/ControlService.h"
 #include "Framework/CallbackService.h"
+#include "Framework/CustomWorkflowTerminationHook.h"
 #include "DPLUtils/RootTreeWriter.h"
 #include "DPLUtils/MakeRootTreeWriterSpec.h"
 #include "Headers/DataHeader.h"
@@ -43,6 +43,14 @@ class StaticChecker
   // cleanup are expected
   ~StaticChecker() noexcept(false)
   {
+    // the check in the desctructor makes sure that the workflow has been run at all
+    if (mChecks.size() > 0) {
+      throw std::runtime_error("Workflow error: Checks have not been executed");
+    }
+  }
+
+  void runChecks()
+  {
     for (auto const& check : mChecks) {
       TFile* file = TFile::Open(check.first.c_str());
       if (file == nullptr) {
@@ -58,12 +66,9 @@ class StaticChecker
         setError(std::string("can not find tree 'testtree' in file ") + check.first.c_str());
       }
       file->Close();
-      // TODO: keeping this as a note because this is not understood
-      // files should get deleted at this point, but if this line is in, the files are already deleted when entering
-      // the loop. Not clear if there is some out-of-order execution
-      // could not test with std filesystem, because the is first supported in gcc 8
-      //boost::filesystem::remove(check.first.c_str());
+      boost::filesystem::remove(check.first.c_str());
     }
+    mChecks.clear();
     if (mErrorMessage.empty() == false) {
       throw std::runtime_error(mErrorMessage);
     }
@@ -82,11 +87,33 @@ class StaticChecker
     }
   }
 
+  void clear()
+  {
+    mChecks.clear();
+    mErrorMessage.clear();
+  }
+
  private:
   std::vector<std::pair<std::string, int>> mChecks;
   std::string mErrorMessage;
 };
 static StaticChecker sChecker;
+
+void customize(o2::framework::OnWorkflowTerminationHook& hook)
+{
+  hook = [](const char* idstring) {
+    // run the checks in the master driver process, all the individual
+    // processes have the same checker setup, so this needs to be cleared for child
+    // (device) processes.
+    if (idstring == nullptr) {
+      sChecker.runChecks();
+    } else {
+      sChecker.clear();
+    }
+  };
+}
+
+#include "Framework/runDataProcessing.h"
 
 static constexpr int sTreeSize = 10; // elements to send and write
 DataProcessorSpec getSourceSpec()


### PR DESCRIPTION
Checking the file content in the destructor of a static object turned out to
be executed multiple times because every process has the static object. Using
now a custom hook executed at workflow termination to ensure deterministic
execution.

Re-enable RootTreeWriterWorkflow unit test