### PR TITLE
Add CcdApi to dictionary generation

### DIFF
--- a/CCDB/CMakeLists.txt
+++ b/CCDB/CMakeLists.txt
@@ -57,6 +57,7 @@ o2_target_root_dictionary(CCDB
                                   include/CCDB/ObjectHandler.h
                                   include/CCDB/Storage.h
                                   include/CCDB/XmlHandler.h
+				  include/CCDB/CcdbApi.h
                                   include/CCDB/TObjectWrapper.h
                                   test/TestClass.h)
 

--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -199,6 +199,8 @@ class CcdbApi //: public DatabaseInterface
 
   /// Base URL of the CCDB (with port)
   std::string mUrl;
+
+  ClassDef(CcdbApi, 1);
 };
 } // namespace ccdb
 } // namespace o2

--- a/CCDB/src/CCDBLinkDef.h
+++ b/CCDB/src/CCDBLinkDef.h
@@ -33,9 +33,9 @@
 #pragma link C++ class o2::ccdb::GridStorageFactory + ;
 #pragma link C++ class o2::ccdb::GridStorageParameters + ;
 #pragma link C++ class o2::ccdb::XmlHandler + ;
+#pragma link C++ class o2::ccdb::CcdbApi + ;
 /// for the unit test
-#pragma link C++ class TestClass+;
-#pragma link C++ class o2::TObjectWrapper<TestClass>+;
-
+#pragma link C++ class TestClass + ;
+#pragma link C++ class o2::TObjectWrapper < TestClass> + ;
 
 #endif


### PR DESCRIPTION
@costing, @ktf  The ``o2::ccdb::CcdbApi`` had no dictionary generated, while this is needed.

But there is some problem with the dictionary of libO2CCDB (in dev): mentioning any its class on the CLING command line leads to a crash (I am using ubuntu 18.04):

````
root [0] .class o2::ccdb::IdPath
#0  0x00007f4a0fa52687 in __GI___waitpid (pid=24509, stat_loc=stat_loc
entry=0x7ffd06f4e428, options=options
entry=0) at ../sysdeps/unix/sysv/linux/waitpid.c:30
#1  0x00007f4a0f9bd067 in do_system (line=<optimized out>) at ../sysdeps/posix/system.c:149
#2  0x00007f4a106618d4 in TUnixSystem::Exec (shellcmd=<optimized out>, this=0x55c19dd927c0) at /home/shahoian/alice/sw/SOURCES/ROOT/e79be32865/0/core/unix/src/TUnixSystem.cxx:2119
#3  TUnixSystem::StackTrace (this=0x55c19dd927c0) at /home/shahoian/alice/sw/SOURCES/ROOT/e79be32865/0/core/unix/src/TUnixSystem.cxx:2413
#4  0x00007f4a0aeaf7b5 in cling::MultiplexInterpreterCallbacks::PrintStackTrace() () from /home/shahoian/alice/sw/ubuntu1804_x86-64/ROOT/e79be32865-1/lib/libCling.so
#5  0x00007f4a0aeaf20d in cling_runtime_internal_throwIfInvalidPointer () from /home/shahoian/alice/sw/ubuntu1804_x86-64/ROOT/e79be32865-1/lib/libCling.so
#6  0x00007f4a10da4751 in ?? ()
#7  0x00007ffd06f50840 in ?? ()
#8  0x00007f4a10da4858 in ?? ()
#9  0x0000000000000000 in ?? ()
Error in <HandleInterpreterException>: Trying to access a pointer that points to an invalid memory address..
Execution of your code was aborted.
In file included from G__O2CCDB dictionary payload:30:
In file included from /home/shahoian/alice/sw/ubuntu1804_x86-64/FairMQ/v1.4.2-4/include/fairmq/FairMQDevice.h:13:
In file included from /home/shahoian/alice/sw/ubuntu1804_x86-64/FairMQ/v1.4.2-4/include/fairmq/FairMQTransportFactory.h:17:
In file included from /home/shahoian/alice/sw/ubuntu1804_x86-64/FairMQ/v1.4.2-4/include/fairmq/MemoryResources.h:21:
In file included from /home/shahoian/alice/sw/ubuntu1804_x86-64/boost/v1.68.0-6/include/boost/container/flat_map.hpp:29:
In file included from /home/shahoian/alice/sw/ubuntu1804_x86-64/boost/v1.68.0-6/include/boost/container/detail/flat_tree.hpp:29:
/home/shahoian/alice/sw/ubuntu1804_x86-64/boost/v1.68.0-6/include/boost/container/detail/pair.hpp:132:89: warning: invalid memory pointer passed to a callee:
static piecewise_construct_t piecewise_construct = BOOST_CONTAINER_DOC1ST(unspecified, *std_piecewise_construct_holder<>::dummy);
                                                                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/shahoian/alice/sw/ubuntu1804_x86-64/boost/v1.68.0-6/include/boost/container/detail/workaround.hpp:71:46: note: expanded from macro 'BOOST_CONTAINER_DOC1ST'
#define BOOST_CONTAINER_DOC1ST(TYPE1, TYPE2) TYPE2
````
The same happens with just querying the class dictionary, so this is not JIT compilation problem:
````
root [0] .class o2::ccdb::IdPath
#0  0x00007ff101ab4687 in __GI___waitpid (pid=26968, stat_loc=stat_loc
entry=0x7ffede7e6128, options=options
entry=0) at ../sysdeps/unix/sysv/linux/waitpid.c:30
#1  0x00007ff101a1f067 in do_system (line=<optimized out>) at ../sysdeps/posix/system.c:149
#2  0x00007ff1026c38d4 in TUnixSystem::Exec (shellcmd=<optimized out>, this=0x55d8e2b307c0) at /home/shahoian/alice/sw/SOURCES/ROOT/e79be32865/0/core/unix/src/TUnixSystem.cxx:2119
#3  TUnixSystem::StackTrace (this=0x55d8e2b307c0) at /home/shahoian/alice/sw/SOURCES/ROOT/e79be32865/0/core/unix/src/TUnixSystem.cxx:2413
...
````
Should be related to loading of some dependencies, any idea?

Cheers,
 Ruben