### PR TITLE
Add a function to generate simple clusters and fix fake pileup

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
@@ -137,6 +137,7 @@ struct VertexingParameters {
   float phiCut = 0.005f; //0.005f
   float pairCut = 0.04f;
   float clusterCut = 0.8f;
+  float tanLambdaCut = 0.025f;
   int clusterContributorsCut = 16;
   int phiSpan = -1;
   int zSpan = -1;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/IOUtils.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/IOUtils.h
@@ -63,7 +63,6 @@ int loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& events, const std
                     const dataformats::MCTruthContainer<MCCompLabel>* mClsLabels = nullptr);
 void generateSimpleData(ROframe& event, const int phiDivs, const int zDivs);
 
-
 std::vector<std::unordered_map<int, Label>> loadLabels(const int, const std::string&);
 void writeRoadsReport(std::ofstream&, std::ofstream&, std::ofstream&, const std::vector<std::vector<Road>>&,
                       const std::unordered_map<int, Label>&);

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/IOUtils.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/IOUtils.h
@@ -61,6 +61,8 @@ void loadEventData(ROframe& events, const std::vector<itsmft::Cluster>* mCluster
                    const dataformats::MCTruthContainer<MCCompLabel>* mClsLabels = nullptr);
 int loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& events, const std::vector<itsmft::Cluster>* mClustersArray,
                     const dataformats::MCTruthContainer<MCCompLabel>* mClsLabels = nullptr);
+void generateSimpleData(ROframe& event, const int phiDivs, const int zDivs);
+
 
 std::vector<std::unordered_map<int, Label>> loadLabels(const int, const std::string&);
 void writeRoadsReport(std::ofstream&, std::ofstream&, std::ofstream&, const std::vector<std::vector<Road>>&,

--- a/Detectors/ITSMFT/ITS/tracking/src/IOUtils.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/IOUtils.cxx
@@ -171,31 +171,18 @@ int ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& event, c
   return number;
 }
 
-void ioutils::generateSimpleData(ROframe& event, const int phiDivs, const int zDivs = 0)
+void ioutils::generateSimpleData(ROframe& event, const int phiDivs, const int zDivs = 1)
 {
   const float angleOffset = constants::math::TwoPi / static_cast<float>(phiDivs);
   // Maximum z allowed on innermost layer should be: ~9,75
-  const float zOffsetFirstLayer = (LayersZCoordinate()[6] * LayersRCoordinate()[0]) / (LayersRCoordinate()[6] * static_cast<float>(zDivs));
+  const float zOffsetFirstLayer = (zDivs == 1) ? 0 : 1.5 * (LayersZCoordinate()[6] * LayersRCoordinate()[0]) / (LayersRCoordinate()[6] * (static_cast<float>(zDivs) - 1));
   std::vector<float> x, y;
   std::array<std::vector<float>, 7> z;
-  const int rZDiv = static_cast<int>(zDivs / 2);
-  for (size_t j{ 0 }; j < rZDiv; ++j) {
+  for (size_t j{ 0 }; j < zDivs; ++j) {
     for (size_t i{ 0 }; i < phiDivs; ++i) {
       x.emplace_back(cos(i * angleOffset + 0.001)); // put an epsilon to move from periods (e.g. 20 clusters vs 20 cells)
       y.emplace_back(sin(i * angleOffset + 0.001));
-      const float zFirstLayer{ 2 * zOffsetFirstLayer * static_cast<float>(j) };
-      z[0].emplace_back(zFirstLayer);
-      for (size_t iLayer{ 1 }; iLayer < constants::its::LayersNumber; ++iLayer) {
-        z[iLayer].emplace_back(zFirstLayer * LayersRCoordinate()[iLayer] / LayersRCoordinate()[0]);
-      }
-    }
-  }
-
-  for (size_t j{ 0 }; j < rZDiv; ++j) {
-    for (size_t i{ 0 }; i < phiDivs; ++i) {
-      x.emplace_back(cos(i * angleOffset + 0.001)); // put an epsilon to move from periods (e.g. 20 clusters vs 20 cells)
-      y.emplace_back(sin(i * angleOffset + 0.001));
-      const float zFirstLayer{ -zOffsetFirstLayer * 2 * static_cast<float>(j) };
+      const float zFirstLayer{ -static_cast<float>((zDivs - 1.) / 2.) * zOffsetFirstLayer + zOffsetFirstLayer * static_cast<float>(j) };
       z[0].emplace_back(zFirstLayer);
       for (size_t iLayer{ 1 }; iLayer < constants::its::LayersNumber; ++iLayer) {
         z[iLayer].emplace_back(zFirstLayer * LayersRCoordinate()[iLayer] / LayersRCoordinate()[0]);
@@ -204,7 +191,7 @@ void ioutils::generateSimpleData(ROframe& event, const int phiDivs, const int zD
   }
 
   for (int iLayer{ 0 }; iLayer < constants::its::LayersNumber; ++iLayer) {
-    for (int i = 0; i < phiDivs * 2 * rZDiv; i++) {
+    for (int i = 0; i < phiDivs * zDivs; i++) {
       o2::MCCompLabel label{ i, 0, 0, false };
       event.addClusterLabelToLayer(iLayer, label);                                                                              //last argument : label, goes into mClustersLabel
       event.addClusterToLayer(iLayer, LayersRCoordinate()[iLayer] * x[i], LayersRCoordinate()[iLayer] * y[i], z[iLayer][i], i); //uses 1st constructor for clusters

--- a/Detectors/ITSMFT/ITS/tracking/src/IOUtils.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/IOUtils.cxx
@@ -178,14 +178,14 @@ void ioutils::generateSimpleData(ROframe& event, const int phiDivs, const int zD
   const float zOffsetFirstLayer = (LayersZCoordinate()[6] * LayersRCoordinate()[0]) / (LayersRCoordinate()[6] * static_cast<float>(zDivs));
   std::vector<float> x, y;
   std::array<std::vector<float>, 7> z;
-  const int rZDiv = static_cast<int>(zDivs/2);
+  const int rZDiv = static_cast<int>(zDivs / 2);
   for (size_t j{ 0 }; j < rZDiv; ++j) {
     for (size_t i{ 0 }; i < phiDivs; ++i) {
       x.emplace_back(cos(i * angleOffset + 0.001)); // put an epsilon to move from periods (e.g. 20 clusters vs 20 cells)
       y.emplace_back(sin(i * angleOffset + 0.001));
       const float zFirstLayer{ 2 * zOffsetFirstLayer * static_cast<float>(j) };
       z[0].emplace_back(zFirstLayer);
-      for( size_t iLayer { 1 }; iLayer < constants::its::LayersNumber; ++iLayer){
+      for (size_t iLayer{ 1 }; iLayer < constants::its::LayersNumber; ++iLayer) {
         z[iLayer].emplace_back(zFirstLayer * LayersRCoordinate()[iLayer] / LayersRCoordinate()[0]);
       }
     }
@@ -197,7 +197,7 @@ void ioutils::generateSimpleData(ROframe& event, const int phiDivs, const int zD
       y.emplace_back(sin(i * angleOffset + 0.001));
       const float zFirstLayer{ -zOffsetFirstLayer * 2 * static_cast<float>(j) };
       z[0].emplace_back(zFirstLayer);
-      for( size_t iLayer { 1 }; iLayer < constants::its::LayersNumber; ++iLayer){
+      for (size_t iLayer{ 1 }; iLayer < constants::its::LayersNumber; ++iLayer) {
         z[iLayer].emplace_back(zFirstLayer * LayersRCoordinate()[iLayer] / LayersRCoordinate()[0]);
       }
     }

--- a/Detectors/ITSMFT/ITS/tracking/src/IOUtils.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/IOUtils.cxx
@@ -35,6 +35,9 @@ constexpr int PrimaryVertexLayerId{ -1 };
 constexpr int EventLabelsSeparator{ -1 };
 } // namespace
 
+using o2::its::constants::its::LayersRCoordinate;
+using o2::its::constants::its::LayersZCoordinate;
+
 namespace o2
 {
 namespace its
@@ -166,6 +169,47 @@ int ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& event, c
     clusterId++;
   }
   return number;
+}
+
+void ioutils::generateSimpleData(ROframe& event, const int phiDivs, const int zDivs = 0)
+{
+  const float angleOffset = constants::math::TwoPi / static_cast<float>(phiDivs);
+  // Maximum z allowed on innermost layer should be: ~9,75
+  const float zOffsetFirstLayer = (LayersZCoordinate()[6] * LayersRCoordinate()[0]) / (LayersRCoordinate()[6] * static_cast<float>(zDivs));
+  std::vector<float> x, y;
+  std::array<std::vector<float>, 7> z;
+  const int rZDiv = static_cast<int>(zDivs/2);
+  for (size_t j{ 0 }; j < rZDiv; ++j) {
+    for (size_t i{ 0 }; i < phiDivs; ++i) {
+      x.emplace_back(cos(i * angleOffset + 0.001)); // put an epsilon to move from periods (e.g. 20 clusters vs 20 cells)
+      y.emplace_back(sin(i * angleOffset + 0.001));
+      const float zFirstLayer{ 2 * zOffsetFirstLayer * static_cast<float>(j) };
+      z[0].emplace_back(zFirstLayer);
+      for( size_t iLayer { 1 }; iLayer < constants::its::LayersNumber; ++iLayer){
+        z[iLayer].emplace_back(zFirstLayer * LayersRCoordinate()[iLayer] / LayersRCoordinate()[0]);
+      }
+    }
+  }
+
+  for (size_t j{ 0 }; j < rZDiv; ++j) {
+    for (size_t i{ 0 }; i < phiDivs; ++i) {
+      x.emplace_back(cos(i * angleOffset + 0.001)); // put an epsilon to move from periods (e.g. 20 clusters vs 20 cells)
+      y.emplace_back(sin(i * angleOffset + 0.001));
+      const float zFirstLayer{ -zOffsetFirstLayer * 2 * static_cast<float>(j) };
+      z[0].emplace_back(zFirstLayer);
+      for( size_t iLayer { 1 }; iLayer < constants::its::LayersNumber; ++iLayer){
+        z[iLayer].emplace_back(zFirstLayer * LayersRCoordinate()[iLayer] / LayersRCoordinate()[0]);
+      }
+    }
+  }
+
+  for (int iLayer{ 0 }; iLayer < constants::its::LayersNumber; ++iLayer) {
+    for (int i = 0; i < phiDivs * 2 * rZDiv; i++) {
+      o2::MCCompLabel label{ i, 0, 0, false };
+      event.addClusterLabelToLayer(iLayer, label);                                                                              //last argument : label, goes into mClustersLabel
+      event.addClusterToLayer(iLayer, LayersRCoordinate()[iLayer] * x[i], LayersRCoordinate()[iLayer] * y[i], z[iLayer][i], i); //uses 1st constructor for clusters
+    }
+  }
 }
 
 std::vector<std::unordered_map<int, Label>> ioutils::loadLabels(const int eventsNum, const std::string& fileName)

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -95,6 +95,7 @@ void trackletSelectionKernelSerial(
   std::vector<Line>& destTracklets,
   std::vector<std::array<float, 7>>& tlv,
   const float tanLambdaCut = 0.025f,
+  const float phiCut = 0.005f,
   const int maxTracklets = static_cast<int>(2e3))
 {
   int offset01{ 0 };
@@ -104,7 +105,8 @@ void trackletSelectionKernelSerial(
     for (int iTracklet12{ offset12 }; iTracklet12 < offset12 + foundTracklets12[iCurrentLayerClusterIndex]; ++iTracklet12) {
       for (int iTracklet01{ offset01 }; iTracklet01 < offset01 + foundTracklets01[iCurrentLayerClusterIndex]; ++iTracklet01) {
         const float deltaTanLambda{ gpu::GPUCommonMath::Abs(tracklets01[iTracklet01].tanLambda - tracklets12[iTracklet12].tanLambda) };
-        if (deltaTanLambda < tanLambdaCut && validTracklets != maxTracklets) {
+        const float deltaPhi{ gpu::GPUCommonMath::Abs(tracklets01[iTracklet01].phiCoordinate - tracklets12[iTracklet12].phiCoordinate) };
+        if (deltaTanLambda < tanLambdaCut && deltaPhi < phiCut && validTracklets != maxTracklets) {
           assert(tracklets01[iTracklet01].secondClusterIndex == tracklets12[iTracklet12].firstClusterIndex);
           // tlv.push_back(std::array<float, 7>{ deltaTanLambda,
           //                                     clustersNextLayer[tracklets01[iTracklet01].firstClusterIndex].zCoordinate, clustersNextLayer[tracklets01[iTracklet01].firstClusterIndex].rCoordinate,
@@ -428,7 +430,9 @@ void VertexerTraits::computeTracklets(const bool useMCLabel)
     foundTracklets01,
     foundTracklets12,
     mTracklets,
-    mDeltaTanlambdas);
+    mDeltaTanlambdas,
+    mVrtParams.phiCut,
+    mVrtParams.tanLambdaCut);
 }
 
 void VertexerTraits::computeVertices()


### PR DESCRIPTION
A function to generate simple clusters corresponding to straight lines starting from the point (0,0,0). Improvements will be added later.