### PR TITLE
Fix autoloding segfault

### DIFF
--- a/CCDB/CMakeLists.txt
+++ b/CCDB/CMakeLists.txt
@@ -58,6 +58,7 @@ o2_target_root_dictionary(CCDB
                                   include/CCDB/Storage.h
                                   include/CCDB/XmlHandler.h
                                   include/CCDB/TObjectWrapper.h
+                                  include/CCDB/CcdbApi.h
                                   test/TestClass.h)
 
 o2_add_executable(conditions-server

--- a/CCDB/include/CCDB/Backend.h
+++ b/CCDB/include/CCDB/Backend.h
@@ -18,7 +18,9 @@
 #include <string>
 #include <vector>
 
+#if !(defined(__CLING__) || defined(__ROOTCLING__))
 #include <FairMQDevice.h>
+#endif
 
 // Google protocol buffers headers
 #include <google/protobuf/stubs/common.h>
@@ -39,7 +41,9 @@ class Backend
   virtual void Pack(const std::string& path, const std::string& key, std::string*& messageString) = 0;
 
   /// UnPack
+#if !(defined(__CLING__) || defined(__ROOTCLING__))
   virtual Condition* UnPack(std::unique_ptr<FairMQMessage> msg) = 0;
+#endif
 
   /// Serializes a key (and optionally value) to an std::string using Protocol Buffers
   void Serialize(std::string*& messageString, const std::string& key, const std::string& operationType,

--- a/CCDB/include/CCDB/BackendOCDB.h
+++ b/CCDB/include/CCDB/BackendOCDB.h
@@ -37,7 +37,9 @@ class BackendOCDB : public Backend
   void Pack(const std::string& path, const std::string& key, std::string*& messageString) override;
 
   /// Parses an incoming message from the CCDB server and prints the metadata of the included object
+#if !(defined(__CLING__) || defined(__ROOTCLING__))
   Condition* UnPack(std::unique_ptr<FairMQMessage> msg) override;
+#endif
 };
 }
 }

--- a/CCDB/include/CCDB/BackendRiak.h
+++ b/CCDB/include/CCDB/BackendRiak.h
@@ -43,7 +43,9 @@ class BackendRiak : public Backend
   void Pack(const std::string& path, const std::string& key, std::string*& messageString) override;
 
   /// Deserializes and uncompresses an incoming message from the CCDB server
+#if !(defined(__CLING__) || defined(__ROOTCLING__))
   Condition* UnPack(std::unique_ptr<FairMQMessage> msg) override;
+#endif
 };
 }
 }

--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -199,6 +199,8 @@ class CcdbApi //: public DatabaseInterface
 
   /// Base URL of the CCDB (with port)
   std::string mUrl;
+
+  ClassDefNV(CcdbApi, 1);
 };
 } // namespace ccdb
 } // namespace o2

--- a/CCDB/src/CCDBLinkDef.h
+++ b/CCDB/src/CCDBLinkDef.h
@@ -33,6 +33,7 @@
 #pragma link C++ class o2::ccdb::GridStorageFactory + ;
 #pragma link C++ class o2::ccdb::GridStorageParameters + ;
 #pragma link C++ class o2::ccdb::XmlHandler + ;
+#pragma link C++ class o2::ccdb::CcdbApi + ;
 /// for the unit test
 #pragma link C++ class TestClass+;
 #pragma link C++ class o2::TObjectWrapper<TestClass>+;


### PR DESCRIPTION
As discussed in AliceO2Group/AliceO2#2209
loading of the library libO2CCDB fails
with a segfault due to implicit include
of boost/container/detail/pair.hpp via
FairMQ. All instances of FairMQ includes
are hidden from rootcling via include
protections as well as the function
declarations which utilize FairMQ
objects.