### PR TITLE
[WIP] TRD digitizer unordered_map instead of map (O2-734)

### DIFF
--- a/Detectors/TRD/base/include/TRDBase/Digit.h
+++ b/Detectors/TRD/base/include/TRDBase/Digit.h
@@ -14,7 +14,7 @@
 #include <cstdint>
 #include <vector>
 #include <array>
-#include <map>
+#include <unordered_map>
 #include "Rtypes.h" // for ClassDef
 
 namespace o2
@@ -28,10 +28,10 @@ constexpr int kTB = 30;
 constexpr int KEY_MIN = 0;
 constexpr int KEY_MAX = 2211727;
 
-typedef std::uint16_t ADC_t;                         // the ADC value type
-typedef std::array<ADC_t, kTB> ArrayADC_t;           // the array ADC
-typedef std::vector<Digit> DigitContainer_t;         // the digit container type
-typedef std::map<int, ArrayADC_t> SignalContainer_t; // a map container type for signal handling during digitization
+typedef std::uint16_t ADC_t;                                   // the ADC value type
+typedef std::array<ADC_t, kTB> ArrayADC_t;                     // the array ADC
+typedef std::vector<Digit> DigitContainer_t;                   // the digit container type
+typedef std::unordered_map<int, ArrayADC_t> SignalContainer_t; // a map container type for signal handling during digitization
 
 class Digit
 {


### PR DESCRIPTION
https://alice.its.cern.ch/jira/browse/O2-734

@sawenzel, we should try this simple change and see if it outperforms the current version of the digitizer. On the mean time, I am also finalizing the version with flat structures only, but it shouldn't be better than this.