### PR TITLE
ITS Chip Sensor thickness definition made coherent

### DIFF
--- a/Detectors/ITSMFT/ITS/simulation/src/V3Layer.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/V3Layer.cxx
@@ -17,6 +17,7 @@
 #include "ITSBase/GeometryTGeo.h"
 #include "ITSSimulation/Detector.h"
 #include "ITSMFTSimulation/AlpideChip.h"
+#include "ITSMFTBase/SegmentationAlpide.h"
 
 #include "FairLogger.h" // for LOG
 
@@ -40,13 +41,14 @@ class TGeoMedium;
 
 using namespace TMath;
 using namespace o2::its;
+using namespace o2::itsmft;
 using AlpideChip = o2::itsmft::AlpideChip;
 
 // General Parameters
 const Int_t V3Layer::sNumberOfInnerLayers = 3;
 
-const Double_t V3Layer::sDefaultSensorThick = 18 * sMicron;
-const Double_t V3Layer::sDefaultChipThick = 50 * sMicron;
+const Double_t V3Layer::sDefaultSensorThick = SegmentationAlpide::SensLayerThickness;
+const Double_t V3Layer::sDefaultChipThick = SegmentationAlpide::SensorThickness;
 const Double_t V3Layer::sMetalLayerThick = 15 * sMicron;
 
 // Inner Barrel Parameters

--- a/Detectors/ITSMFT/common/base/include/ITSMFTBase/SegmentationAlpide.h
+++ b/Detectors/ITSMFT/common/base/include/ITSMFTBase/SegmentationAlpide.h
@@ -45,7 +45,7 @@ class SegmentationAlpide
   static constexpr float ActiveMatrixSizeCols = PitchCol*NCols; // Active size along columns
   static constexpr float ActiveMatrixSizeRows = PitchRow*NRows; // Active size along rows
   
-  static constexpr float SensorThickness = 30.e-4;     // effective thickness of sensitive part
+  static constexpr float SensorThickness = 50.e-4;     // full sensor thickness
   static constexpr float SensorSizeCols = ActiveMatrixSizeCols+PassiveEdgeSide+PassiveEdgeSide; // SensorSize along columns
   static constexpr float SensorSizeRows = ActiveMatrixSizeRows+PassiveEdgeTop+PassiveEdgeReadOut; // SensorSize along rows
 

--- a/Detectors/ITSMFT/common/base/include/ITSMFTBase/SegmentationAlpide.h
+++ b/Detectors/ITSMFT/common/base/include/ITSMFTBase/SegmentationAlpide.h
@@ -22,7 +22,6 @@ namespace o2
 namespace itsmft
 {
 
-  
 /// Segmentation and response for pixels in ITSMFT upgrade
 /// Questions to solve: are guardrings needed and do they belong to the sensor or to the chip in
 /// TGeo. At the moment assume that the local coord syst. is located at bottom left corner
@@ -32,22 +31,21 @@ namespace itsmft
 class SegmentationAlpide
 {
  public:
-
-  static constexpr int   NCols = 1024;
-  static constexpr int   NRows = 512;
-  static constexpr int   NPixels = NRows*NCols;
+  static constexpr int NCols = 1024;
+  static constexpr int NRows = 512;
+  static constexpr int NPixels = NRows * NCols;
   static constexpr float PitchCol = 29.24e-4;
   static constexpr float PitchRow = 26.88e-4;
-  static constexpr float SensLayerThickness = 22.e-4; // effective thickness of sensitive layer, https://alice.its.cern.ch/jira/browse/AOC-46
-  static constexpr float PassiveEdgeReadOut = 0.12f;  // width of the readout edge (Passive bottom)
-  static constexpr float PassiveEdgeTop = 37.44e-4;   // Passive area on top
-  static constexpr float PassiveEdgeSide = 29.12e-4;  // width of Passive area on left/right of the sensor
-  static constexpr float ActiveMatrixSizeCols = PitchCol*NCols; // Active size along columns
-  static constexpr float ActiveMatrixSizeRows = PitchRow*NRows; // Active size along rows
-  
-  static constexpr float SensorThickness = 50.e-4;     // full sensor thickness
-  static constexpr float SensorSizeCols = ActiveMatrixSizeCols+PassiveEdgeSide+PassiveEdgeSide; // SensorSize along columns
-  static constexpr float SensorSizeRows = ActiveMatrixSizeRows+PassiveEdgeTop+PassiveEdgeReadOut; // SensorSize along rows
+  static constexpr float SensLayerThickness = 22.e-4;             // effective thickness of sensitive layer, https://alice.its.cern.ch/jira/browse/AOC-46
+  static constexpr float PassiveEdgeReadOut = 0.12f;              // width of the readout edge (Passive bottom)
+  static constexpr float PassiveEdgeTop = 37.44e-4;               // Passive area on top
+  static constexpr float PassiveEdgeSide = 29.12e-4;              // width of Passive area on left/right of the sensor
+  static constexpr float ActiveMatrixSizeCols = PitchCol * NCols; // Active size along columns
+  static constexpr float ActiveMatrixSizeRows = PitchRow * NRows; // Active size along rows
+
+  static constexpr float SensorThickness = 50.e-4;                                                    // full sensor thickness
+  static constexpr float SensorSizeCols = ActiveMatrixSizeCols + PassiveEdgeSide + PassiveEdgeSide;   // SensorSize along columns
+  static constexpr float SensorSizeRows = ActiveMatrixSizeRows + PassiveEdgeTop + PassiveEdgeReadOut; // SensorSize along rows
 
   SegmentationAlpide() = default;
   ~SegmentationAlpide() = default;
@@ -86,16 +84,16 @@ class SegmentationAlpide
   static void detectorToLocalUnchecked(float row, float col, float& xRow, float& zCol);
   static void detectorToLocalUnchecked(float row, float col, Point3D<float>& loc);
 
-  static constexpr float getFirstRowCoordinate() {
+  static constexpr float getFirstRowCoordinate()
+  {
     return 0.5 * ((ActiveMatrixSizeRows - PassiveEdgeTop + PassiveEdgeReadOut) - PitchRow);
   }
   static constexpr float getFirstColCoordinate() { return 0.5 * (PitchCol - ActiveMatrixSizeCols); }
-  
+
   static void print();
-  
+
   ClassDefNV(SegmentationAlpide, 1) // Segmentation class upgrade pixels
 };
-
 
 //_________________________________________________________________________________________________
 inline void SegmentationAlpide::localToDetectorUnchecked(float xRow, float zCol, int& iRow, int& iCol)
@@ -105,8 +103,10 @@ inline void SegmentationAlpide::localToDetectorUnchecked(float xRow, float zCol,
   zCol += 0.5 * ActiveMatrixSizeCols;                                               // coordinate wrt left edge of Active matrix
   iRow = int(xRow / PitchRow);
   iCol = int(zCol / PitchCol);
-  if (xRow<0) iRow -= 1;
-  if (zCol<0) iCol -= 1;
+  if (xRow < 0)
+    iRow -= 1;
+  if (zCol < 0)
+    iCol -= 1;
 }
 
 //_________________________________________________________________________________________________
@@ -114,8 +114,8 @@ inline bool SegmentationAlpide::localToDetector(float xRow, float zCol, int& iRo
 {
   // convert to row/col
   xRow = 0.5 * (ActiveMatrixSizeRows - PassiveEdgeTop + PassiveEdgeReadOut) - xRow; // coordinate wrt left edge of Active matrix
-  zCol += 0.5 * ActiveMatrixSizeCols; // coordinate wrt bottom edge of Active matrix
-  if (xRow<0 || xRow>=ActiveMatrixSizeRows || zCol<0 || zCol>=ActiveMatrixSizeCols) {
+  zCol += 0.5 * ActiveMatrixSizeCols;                                               // coordinate wrt bottom edge of Active matrix
+  if (xRow < 0 || xRow >= ActiveMatrixSizeRows || zCol < 0 || zCol >= ActiveMatrixSizeCols) {
     iRow = iCol = -1;
     return false;
   }
@@ -128,7 +128,7 @@ inline bool SegmentationAlpide::localToDetector(float xRow, float zCol, int& iRo
 inline void SegmentationAlpide::detectorToLocalUnchecked(int iRow, int iCol, float& xRow, float& zCol)
 {
   xRow = getFirstRowCoordinate() - iRow * PitchRow;
-  zCol = iCol*PitchCol + getFirstColCoordinate();
+  zCol = iCol * PitchCol + getFirstColCoordinate();
 }
 
 //_________________________________________________________________________________________________
@@ -147,8 +147,9 @@ inline void SegmentationAlpide::detectorToLocalUnchecked(float row, float col, P
 //_________________________________________________________________________________________________
 inline bool SegmentationAlpide::detectorToLocal(int iRow, int iCol, float& xRow, float& zCol)
 {
-  if (iRow < 0 || iRow >= NRows || iCol<0 || iCol >= NCols) return false;
-  detectorToLocalUnchecked(iRow,iCol,xRow,zCol);
+  if (iRow < 0 || iRow >= NRows || iCol < 0 || iCol >= NCols)
+    return false;
+  detectorToLocalUnchecked(iRow, iCol, xRow, zCol);
   return true;
 }
 


### PR DESCRIPTION
The definition of the chip thickness was made coherent in order to use the same definition in simulaiotn and reconstruction (via V3Layer and GeometryTGeo).