### PR TITLE
Introducing SenderPolicy to DPL processors

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -28,6 +28,7 @@ o2_add_library(Framework
                        src/CommonDataProcessors.cxx
                        src/CompletionPolicy.cxx
                        src/CompletionPolicyHelpers.cxx
+                       src/DispatchPolicy.cxx
                        src/ConfigParamsHelper.cxx
                        src/DDSConfigHelpers.cxx
                        src/DataAllocator.cxx

--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -233,6 +233,7 @@ foreach(w
         DanglingInputs
         DanglingOutputs
         DataAllocator
+        StaggeringWorkflow
         Forwarding
         ParallelPipeline
         ParallelProducer

--- a/Framework/Core/include/Framework/DataProcessor.h
+++ b/Framework/Core/include/Framework/DataProcessor.h
@@ -11,6 +11,7 @@
 #define FRAMEWORK_DATAPROCESSOR_H
 
 class FairMQDevice;
+class FairMQParts;
 
 namespace o2
 {
@@ -31,6 +32,7 @@ struct DataProcessor {
   static void doSend(FairMQDevice&, StringContext&);
   static void doSend(FairMQDevice&, ArrowContext&);
   static void doSend(FairMQDevice&, RawBufferContext&);
+  static void doSend(FairMQDevice&, FairMQParts&&, const char*, unsigned int);
 };
 
 } // namespace framework

--- a/Framework/Core/include/Framework/DeviceSpec.h
+++ b/Framework/Core/include/Framework/DeviceSpec.h
@@ -20,6 +20,7 @@
 #include "Framework/InputRoute.h"
 #include "Framework/OutputRoute.h"
 #include "Framework/CompletionPolicy.h"
+#include "Framework/DispatchPolicy.h"
 
 #include <vector>
 #include <string>
@@ -51,6 +52,7 @@ struct DeviceSpec {
   size_t inputTimesliceId;
   /// The completion policy to use for this device.
   CompletionPolicy completionPolicy;
+  DispatchPolicy dispatchPolicy;
 };
 
 } // namespace framework

--- a/Framework/Core/include/Framework/DispatchPolicy.h
+++ b/Framework/Core/include/Framework/DispatchPolicy.h
@@ -1,0 +1,63 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef FRAMEWORK_DISPATCHPOLICY_H
+#define FRAMEWORK_DISPATCHPOLICY_H
+
+#include "Framework/PartRef.h"
+
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace o2
+{
+namespace framework
+{
+
+struct DeviceSpec;
+struct Output;
+
+/// Policy to describe when to dispatch objects
+/// As for now we describe this policy per device, however it can be extended
+/// to match on specific outputs of the device.
+struct DispatchPolicy {
+  /// Action to take whenever an object in the output gets ready:
+  ///
+  enum struct DispatchOp {
+    /// Dispatch objects when the calculation ends, this means the devices will
+    /// send messages from all contextes in one bulk after computation
+    AfterComputation,
+    /// Dispatch the object when it becomes ready, i.e. when it goes out of the
+    /// scope of the user code and no changes to the object are possible
+    WhenReady,
+  };
+
+  using DeviceMatcher = std::function<bool(DeviceSpec const& device)>;
+  // OutputMatcher can be a later extension, but not expected to be of high priority
+  using OutputMatcher = std::function<bool(Output const&)>;
+
+  /// Name of the policy itself.
+  std::string name;
+  /// Callback to be used to understand if the policy should apply
+  /// to the given device.
+  DeviceMatcher deviceMatcher;
+  /// the action to be used for matched devices
+  DispatchOp action = DispatchOp::AfterComputation;
+
+  /// Helper to create the default configuration.
+  static std::vector<DispatchPolicy> createDefaultPolicies();
+};
+
+std::ostream& operator<<(std::ostream& oss, DispatchPolicy::DispatchOp const& val);
+
+} // namespace framework
+} // namespace o2
+
+#endif // FRAMEWORK_DISPATCHPOLICY_H

--- a/Framework/Core/include/Framework/runDataProcessing.h
+++ b/Framework/Core/include/Framework/runDataProcessing.h
@@ -12,6 +12,7 @@
 
 #include "Framework/ChannelConfigurationPolicy.h"
 #include "Framework/CompletionPolicy.h"
+#include "Framework/DispatchPolicy.h"
 #include "Framework/ConfigParamsHelper.h"
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/WorkflowSpec.h"
@@ -68,6 +69,7 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
 void defaultConfiguration(std::vector<o2::framework::ChannelConfigurationPolicy>& channelPolicies) {}
 void defaultConfiguration(std::vector<o2::framework::ConfigParamSpec> &globalWorkflowOptions) {}
 void defaultConfiguration(std::vector<o2::framework::CompletionPolicy> &completionPolicies) {}
+void defaultConfiguration(std::vector<o2::framework::DispatchPolicy>& dispatchPolicies) {}
 void defaultConfiguration(o2::framework::OnWorkflowTerminationHook& hook)
 {
   hook = [](const char*) {};
@@ -91,9 +93,10 @@ struct UserCustomizationsHelper {
 // This comes from the framework itself. This way we avoid code duplication.
 int doMain(int argc, char** argv, o2::framework::WorkflowSpec const& specs,
            std::vector<o2::framework::ChannelConfigurationPolicy> const& channelPolicies,
-           std::vector<o2::framework::CompletionPolicy> const &completionPolicies,
-           std::vector<o2::framework::ConfigParamSpec> const &workflowOptions,
-           o2::framework::ConfigContext &configContext);
+           std::vector<o2::framework::CompletionPolicy> const& completionPolicies,
+           std::vector<o2::framework::DispatchPolicy> const& dispatchPolicies,
+           std::vector<o2::framework::ConfigParamSpec> const& workflowOptions,
+           o2::framework::ConfigContext& configContext);
 
 int main(int argc, char** argv)
 {
@@ -118,11 +121,16 @@ int main(int argc, char** argv)
     auto defaultCompletionPolicies = CompletionPolicy::createDefaultPolicies();
     completionPolicies.insert(std::end(completionPolicies), std::begin(defaultCompletionPolicies), std::end(defaultCompletionPolicies));
 
+    std::vector<DispatchPolicy> dispatchPolicies;
+    UserCustomizationsHelper::userDefinedCustomization(dispatchPolicies, 0);
+    auto defaultDispatchPolicies = DispatchPolicy::createDefaultPolicies();
+    dispatchPolicies.insert(std::end(dispatchPolicies), std::begin(defaultDispatchPolicies), std::end(defaultDispatchPolicies));
+
     std::unique_ptr<ParamRetriever> retriever{ new BoostOptionsRetriever(workflowOptions, true, argc, argv) };
     ConfigParamRegistry workflowOptionsRegistry(std::move(retriever));
     ConfigContext configContext{ workflowOptionsRegistry };
     o2::framework::WorkflowSpec specs = defineDataProcessing(configContext);
-    result = doMain(argc, argv, specs, channelPolicies, completionPolicies, workflowOptions, configContext);
+    result = doMain(argc, argv, specs, channelPolicies, completionPolicies, dispatchPolicies, workflowOptions, configContext);
   } catch (std::exception const& error) {
     LOG(ERROR) << "error while setting up workflow: " << error.what();
   } catch (...) {

--- a/Framework/Core/src/DataAllocator.cxx
+++ b/Framework/Core/src/DataAllocator.cxx
@@ -123,7 +123,10 @@ void DataAllocator::addPartToContext(FairMQMessagePtr&& payloadMessage, const Ou
   DataHeader* dh = const_cast<DataHeader*>(cdh);
   dh->payloadSize = payloadMessage->GetSize();
   auto context = mContextRegistry->get<MessageContext>();
-  context->add<MessageContext::TrivialObject>(std::move(headerMessage), std::move(payloadMessage), channel);
+  // make_scoped creates the context object inside of a scope handler, since it goes out of
+  // scope immediately, the created object is scheduled and can be directly sent if the context
+  // is configured with the dispatcher callback
+  context->make_scoped<MessageContext::TrivialObject>(std::move(headerMessage), std::move(payloadMessage), channel);
 }
 
 void DataAllocator::adopt(const Output& spec, TObject* ptr)

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -67,6 +67,13 @@ DataProcessingDevice::DataProcessingDevice(DeviceSpec const& spec, ServiceRegist
     mProcessingCount{ 0 }
 {
   StateMonitoring<DataProcessingStatus>::start();
+  auto dispatcher = [this](FairMQParts&& parts, std::string const& channel, unsigned int index) {
+    DataProcessor::doSend(*this, std::move(parts), channel.c_str(), index);
+  };
+
+  if (spec.dispatchPolicy.action == DispatchPolicy::DispatchOp::WhenReady) {
+    mFairMQContext.init(dispatcher);
+  }
 }
 
 /// This  takes care  of initialising  the device  from its  specification. In

--- a/Framework/Core/src/DataProcessor.cxx
+++ b/Framework/Core/src/DataProcessor.cxx
@@ -31,6 +31,12 @@ namespace o2
 namespace framework
 {
 
+void DataProcessor::doSend(FairMQDevice& device, FairMQParts&& parts, const char* channel, unsigned int index)
+{
+  assert(parts.Size() == 2);
+  device.Send(parts, channel, index);
+}
+
 void DataProcessor::doSend(FairMQDevice &device, MessageContext &context) {
   for (auto &message : context) {
     //     monitoringService.send({ message->parts.Size(), "outputs/total" });

--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -565,8 +565,9 @@ void DeviceSpecHelpers::processInEdgeActions(std::vector<DeviceSpec>& devices,
 void DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(WorkflowSpec const& workflow,
                                                        std::vector<ChannelConfigurationPolicy> const& channelPolicies,
                                                        std::vector<CompletionPolicy> const& completionPolicies,
+                                                       std::vector<DispatchPolicy> const& dispatchPolicies,
                                                        std::vector<DeviceSpec>& devices,
-                                                       std::vector<ComputingResource> &resources)
+                                                       std::vector<ComputingResource>& resources)
 {
 
   std::vector<LogicalForwardInfo> availableForwardsInfo;
@@ -616,6 +617,12 @@ void DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(WorkflowSpec const& workf
     for (auto &policy : completionPolicies) {
       if (policy.matcher(device) == true) {
         device.completionPolicy = policy;
+        break;
+      }
+    }
+    for (auto& policy : dispatchPolicies) {
+      if (policy.deviceMatcher(device) == true) {
+        device.dispatchPolicy = policy;
         break;
       }
     }

--- a/Framework/Core/src/DeviceSpecHelpers.h
+++ b/Framework/Core/src/DeviceSpecHelpers.h
@@ -15,6 +15,7 @@
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/ChannelSpec.h"
 #include "Framework/CompletionPolicy.h"
+#include "Framework/DispatchPolicy.h"
 #include "Framework/DeviceControl.h"
 #include "Framework/DeviceExecution.h"
 #include "Framework/DeviceSpec.h"
@@ -39,12 +40,23 @@ struct DeviceSpecHelpers {
   /// Helper to convert from an abstract dataflow specification, @a workflow,
   /// to an actual set of devices which will have to run.
   static void dataProcessorSpecs2DeviceSpecs(
-      const WorkflowSpec &workflow,
-      std::vector<ChannelConfigurationPolicy> const &channelPolicies,
-      std::vector<CompletionPolicy> const &completionPolicies,
-      std::vector<DeviceSpec> &devices,
-      std::vector<ComputingResource> &resources
-      );
+    const WorkflowSpec& workflow,
+    std::vector<ChannelConfigurationPolicy> const& channelPolicies,
+    std::vector<CompletionPolicy> const& completionPolicies,
+    std::vector<DispatchPolicy> const& dispatchPolicies,
+    std::vector<DeviceSpec>& devices,
+    std::vector<ComputingResource>& resources);
+
+  static void dataProcessorSpecs2DeviceSpecs(
+    const WorkflowSpec& workflow,
+    std::vector<ChannelConfigurationPolicy> const& channelPolicies,
+    std::vector<CompletionPolicy> const& completionPolicies,
+    std::vector<DeviceSpec>& devices,
+    std::vector<ComputingResource>& resources)
+  {
+    std::vector<DispatchPolicy> dispatchPolicies = DispatchPolicy::createDefaultPolicies();
+    dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, dispatchPolicies, devices, resources);
+  }
 
   /// Helper to prepare the arguments which will be used to 
   /// start the various devices.

--- a/Framework/Core/src/DispatchPolicy.cxx
+++ b/Framework/Core/src/DispatchPolicy.cxx
@@ -1,0 +1,42 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/DispatchPolicy.h"
+#include "Framework/DeviceSpec.h"
+#include <functional>
+#include <iostream>
+
+namespace o2
+{
+namespace framework
+{
+
+/// By default the DispatchPolicy matches any Device and messages are sent
+/// after computation
+std::vector<DispatchPolicy> DispatchPolicy::createDefaultPolicies()
+{
+  return { DispatchPolicy{ "dispatch-all-after-computation", [](DeviceSpec const&) { return true; }, DispatchPolicy::DispatchOp::AfterComputation } };
+}
+
+std::ostream& operator<<(std::ostream& oss, DispatchPolicy::DispatchOp const& val)
+{
+  switch (val) {
+    case DispatchPolicy::DispatchOp::AfterComputation:
+      oss << "after computation";
+      break;
+    case DispatchPolicy::DispatchOp::WhenReady:
+      oss << "when ready";
+      break;
+  };
+  return oss;
+}
+
+} // namespace framework
+} // namespace o2

--- a/Framework/Core/src/DriverInfo.h
+++ b/Framework/Core/src/DriverInfo.h
@@ -98,9 +98,12 @@ struct DriverInfo {
   /// Since they are decided by the toplevel configuration, they belong
   /// to the driver process.
   std::vector<ChannelConfigurationPolicy> channelPolicies;
-  /// These are the policies which can be applied to decide wether or not
+  /// These are the policies which can be applied to decide whether or not
   /// a given record is complete.
   std::vector<CompletionPolicy> completionPolicies;
+  /// These are the policies which can be applied to decide when complete
+  /// objects/messages are sent out
+  std::vector<DispatchPolicy> dispatchPolicies;
   /// The argc with which the driver was started.
   int argc;
   /// The argv with which the driver was started.

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -823,6 +823,7 @@ int runStateMachine(DataProcessorSpecs const& workflow,
           DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow,
                                                             driverInfo.channelPolicies,
                                                             driverInfo.completionPolicies,
+                                                            driverInfo.dispatchPolicies,
                                                             deviceSpecs,
                                                             resources);
           // This should expand nodes so that we can build a consistent DAG.
@@ -1158,6 +1159,7 @@ void initialiseDriverControl(bpo::variables_map const& varmap,
 int doMain(int argc, char** argv, o2::framework::WorkflowSpec const& workflow,
            std::vector<ChannelConfigurationPolicy> const& channelPolicies,
            std::vector<CompletionPolicy> const& completionPolicies,
+           std::vector<DispatchPolicy> const& dispatchPolicies,
            std::vector<ConfigParamSpec> const& currentWorkflowOptions,
            o2::framework::ConfigContext& configContext)
 {
@@ -1285,6 +1287,7 @@ int doMain(int argc, char** argv, o2::framework::WorkflowSpec const& workflow,
   driverInfo.sigchldRequested = false;
   driverInfo.channelPolicies = channelPolicies;
   driverInfo.completionPolicies = completionPolicies;
+  driverInfo.dispatchPolicies = dispatchPolicies;
   driverInfo.argc = argc;
   driverInfo.argv = argv;
   driverInfo.batch = varmap["batch"].as<bool>();

--- a/Framework/Core/test/test_StaggeringWorkflow.cxx
+++ b/Framework/Core/test/test_StaggeringWorkflow.cxx
@@ -1,0 +1,131 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/WorkflowSpec.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/DataSpecUtils.h"
+#include "Framework/DataAllocator.h"
+#include "Framework/InputRecord.h"
+#include "Framework/InputSpec.h"
+#include "Framework/OutputSpec.h"
+#include "Framework/ControlService.h"
+#include "Framework/OutputRoute.h"
+#include "Framework/Logger.h"
+#include "Framework/DispatchPolicy.h"
+#include "Framework/DeviceSpec.h"
+#include <chrono>
+#include <cstring>
+#include <iostream>
+
+void customize(std::vector<o2::framework::DispatchPolicy>& policies)
+{
+  // we customize all devices to dispatch data immediately
+  policies.push_back({ "prompt-for-all", [](auto const&) { return true; }, o2::framework::DispatchPolicy::DispatchOp::WhenReady });
+}
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // we customize the processors to consume data as it comes
+  policies.push_back({ "processor-consume",
+                       [](o2::framework::DeviceSpec const& spec) {
+                         // search for spec names starting with "processor"
+                         return spec.name.find("processor") == 0;
+                       },
+                       [](auto const&) { return o2::framework::CompletionPolicy::CompletionOp::Consume; } });
+}
+
+#include "Framework/runDataProcessing.h"
+
+using namespace o2::framework;
+
+#define ASSERT_ERROR(condition)                                   \
+  if ((condition) == false) {                                     \
+    LOG(ERROR) << R"(Test condition ")" #condition R"(" failed)"; \
+  }
+
+constexpr size_t nPipelines = 3;
+constexpr size_t nChannels = 10;
+
+std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
+{
+  // first fill the subspecifications
+  using MyDataType = o2::header::DataHeader::SubSpecificationType;
+  std::vector<o2::header::DataHeader::SubSpecificationType> subspecs(nChannels);
+  std::generate(subspecs.begin(), subspecs.end(), [counter = std::make_shared<int>(0)]() { return (*counter)++; });
+  std::vector<OutputSpec> producerOutputs;
+  for (auto const& subspec : subspecs) {
+    producerOutputs.emplace_back(OutputSpec{ "PROD", "CHANNEL", subspec, Lifetime::Timeframe });
+  }
+
+  auto producerFct = [subspecs](ProcessingContext& pc) {
+    static bool ready = false;
+    if (ready) {
+      return;
+    }
+    for (auto const& subspec : subspecs) {
+      //pc.outputs().make<MyDataType>(Output{ "PROD", "CHANNEL", subspec, Lifetime::Timeframe }) = subspec;
+      pc.outputs().snapshot(Output{ "PROD", "CHANNEL", subspec, Lifetime::Timeframe }, subspec);
+      std::cout << "publishing channel " << subspec << std::endl;
+      sleep(1);
+    }
+    ready = true;
+    pc.services().get<ControlService>().readyToQuit(false);
+  };
+  auto processorFct = [](ProcessingContext& pc) {
+    int nActiveInputs = 0;
+    for (auto const& input : pc.inputs()) {
+      if (pc.inputs().isValid(input.spec->binding) == false) {
+        // this input slot is empty
+        continue;
+      }
+      auto& data = pc.inputs().get<MyDataType>(input.spec->binding.c_str());
+      std::cout << "processing channel " << data << std::endl;
+      pc.outputs().make<MyDataType>(Output{ "PROC", "CHANNEL", data, Lifetime::Timeframe }) = data;
+      nActiveInputs++;
+    }
+    // since we publish with delays, there should be only one active input at a time
+    ASSERT_ERROR(nActiveInputs == 1);
+  };
+  auto amendSinkInput = [subspecs](InputSpec& input, size_t index) {
+    input.binding += std::to_string(subspecs[index]);
+    DataSpecUtils::updateMatchingSubspec(input, subspecs[index]);
+  };
+  auto sinkFct = [](ProcessingContext& pc) {
+    for (auto const& input : pc.inputs()) {
+      auto& data = pc.inputs().get<MyDataType>(input.spec->binding.c_str());
+      std::cout << "received channel " << data << std::endl;
+    }
+    sleep(2);
+    pc.services().get<ControlService>().readyToQuit(true);
+  };
+
+  std::vector<DataProcessorSpec> workflow = parallelPipeline(
+    std::vector<DataProcessorSpec>{ DataProcessorSpec{
+      "processor",
+      { InputSpec{ "input", "PROD", "CHANNEL", 0, Lifetime::Timeframe } },
+      { OutputSpec{ "PROC", "CHANNEL", 0, Lifetime::Timeframe } },
+      AlgorithmSpec{ processorFct } } },
+    nPipelines,
+    [&subspecs]() { return subspecs.size(); },
+    [&subspecs](size_t index) { return subspecs[index]; });
+
+  workflow.emplace_back(DataProcessorSpec{
+    "producer",
+    Inputs{},
+    producerOutputs,
+    AlgorithmSpec{ producerFct } });
+
+  workflow.emplace_back(DataProcessorSpec{
+    "sink",
+    mergeInputs(InputSpec{ "input", "PROC", "CHANNEL", 0, Lifetime::Timeframe }, nChannels, amendSinkInput),
+    {},
+    AlgorithmSpec{ sinkFct } });
+  return workflow;
+}


### PR DESCRIPTION
`SenderPolicy` describes on per-device basis when completed objects are sent, either at the end of computation - the default and current behavior - or immediately when ready. Depending on the `SenderPolicy` operation, the `DataProcessingDevice` configures the `MessageContext` with a sender callback. The sender policy can be customized in the usual DPL manner.

`MessageContext` has been extended to create context objects embedded into a scope handler. The context object is scheduled, when the handler goes out of scope in the user code. Currently, the `DataAllocator::snapshot` API method uses this feature.

This PR will be the foundation for refactoring the digitizer workflow and to solve the memory problems with large data sets. Enabling the prompt sending also for `DataAllocator::make` remains to be finalized, but the work is nearly finished. Will be done after refactoring the digitizer workflow. The support also has to be implemented to other contexts, though the `RootObjectContext` is already obsolete and `StringContext` can be easily implemented in the same way, including pmr support.

@ktf, not sure if `SenderPolicy` is the appropriate name. I have implemented in parallel to `CompletionPolicy`. I have considered to combine the two, but in the end I thought its two different things.