### PR TITLE
Reverting PR #2216 because the InputRecord API is not consistent for all cases

### DIFF
--- a/Framework/Core/include/Framework/DataAllocator.h
+++ b/Framework/Core/include/Framework/DataAllocator.h
@@ -143,7 +143,7 @@ class DataAllocator
       } else if constexpr (is_specialization<T, BoostSerialized>::value == false && framework::is_boost_serializable<T>::value == true && std::is_base_of<std::string, T>::value == false) {
         return make_boost<T>(std::move(spec));
       } else {
-        static_assert(always_static_assert_v<T>, ERROR_STRING);
+        static_assert(type_dependent<T>::value, ERROR_STRING);
       }
     } else if constexpr (sizeof...(Args) == 1) {
       using FirstArg = typename std::tuple_element<0, std::tuple<Args...>>::type;
@@ -167,10 +167,10 @@ class DataAllocator
       } else if constexpr (is_specialization<T, BoostSerialized>::value) {
         return make_boost<FirstArg>(std::move(spec));
       } else {
-        static_assert(always_static_assert_v<T>, ERROR_STRING);
+        static_assert(type_dependent<T>::value, ERROR_STRING);
       }
     } else {
-      static_assert(always_static_assert_v<T>, ERROR_STRING);
+      static_assert(type_dependent<T>::value, ERROR_STRING);
     }
   }
 
@@ -232,116 +232,171 @@ class DataAllocator
     mContextRegistry->get<RawBufferContext>()->addRawBuffer(std::move(header), std::move(payload), std::move(channel), std::move(lambdaSerialize), std::move(lambdaDestructor));
   }
 
-  /// Send a snapshot of an object, depending on the object type it is serialized before.
-  /// The method always takes a copy of the data, which will then be sent once the
-  /// computation ends.
+  /// Serialize a snapshot of an object with root dictionary when called,
+  /// will then be sent once the computation ends.
   /// Framework does not take ownership of the @a object. Changes to @a object
   /// after the call will not be sent.
-  ///
-  /// Supported types:
-  /// - messageable types (trivially copyable, non-polymorphic
-  /// - std::vector of messageable types
-  /// - std::vector of pointers of messageable type
-  /// - types with ROOT dictionary and implementing the ROOT ClassDef interface
-  ///
-  /// Note: for many use cases, especially for the messageable types, the `make` interface
-  /// might be better suited as the objects are allocated directly in the underlying
-  /// memory resource and the copy can be avoided.
-  ///
-  /// Note: messageable objects with ROOT dictionary are preferably sent unserialized.
-  /// Use @a ROOTSerialized type wrapper to force ROOT serialization. Same applies to
-  /// types which do not implement the ClassDef interface but have a dictionary.
+  /// Note: also messageable objects can have a dictionary, but serialization
+  /// method can not be deduced automatically. Messageable objects are sent
+  /// unserialized by default. Serialization method needs to be specified
+  /// explicitely otherwise by using ROOTSerialized wrapper type.
   template <typename T>
-  void snapshot(const Output& spec, T const& object)
+  typename std::enable_if<has_root_dictionary<T>::value == true && is_messageable<T>::value == false, void>::type
+    snapshot(const Output& spec, T& object)
+  {
+    auto proxy = mContextRegistry->get<RootObjectContext>()->proxy();
+    FairMQMessagePtr payloadMessage(proxy.createMessage());
+    auto* cl = TClass::GetClass(typeid(T));
+    TMessageSerializer().Serialize(*payloadMessage, &object, cl);
+
+    addPartToContext(std::move(payloadMessage), spec, o2::header::gSerializationMethodROOT);
+  }
+
+  /// Explicitely ROOT serialize a snapshot of @a object when called,
+  /// will then be sent once the computation ends. The @a object is wrapped
+  /// into type ROOTSerialized to explicitely mark this serialization method,
+  /// and is expected to have a ROOT dictionary. Availability can not be checked
+  /// at compile time for all cases.
+  /// Framework does not take ownership of the @a object. Changes to @a object
+  /// after the call will not be sent.
+  template <typename W>
+  typename std::enable_if<is_specialization<W, ROOTSerialized>::value == true, void>::type
+    snapshot(const Output& spec, W wrapper)
+  {
+    using T = typename W::wrapped_type;
+    static_assert(std::is_same<typename W::hint_type, const char>::value || //
+                    std::is_same<typename W::hint_type, TClass>::value ||   //
+                    std::is_void<typename W::hint_type>::value,             //
+                  "class hint must be of type TClass or const char");
+
+    auto proxy = mContextRegistry->get<RootObjectContext>()->proxy();
+    FairMQMessagePtr payloadMessage(proxy.createMessage());
+    const TClass* cl = nullptr;
+    if (wrapper.getHint() == nullptr) {
+      // get TClass info by wrapped type
+      cl = TClass::GetClass(typeid(T));
+    } else if (std::is_same<typename W::hint_type, TClass>::value) {
+      // the class info has been passed directly
+      cl = reinterpret_cast<const TClass*>(wrapper.getHint());
+    } else if (std::is_same<typename W::hint_type, const char>::value) {
+      // get TClass info by optional name
+      cl = TClass::GetClass(reinterpret_cast<const char*>(wrapper.getHint()));
+    }
+    if (has_root_dictionary<T>::value == false && cl == nullptr) {
+      std::string msg("ROOT serialization not supported, dictionary not found for type ");
+      if (std::is_same<typename W::hint_type, const char>::value) {
+        msg += reinterpret_cast<const char*>(wrapper.getHint());
+      } else {
+        msg += typeid(T).name();
+      }
+      throw std::runtime_error(msg);
+    }
+    TMessageSerializer().Serialize(*payloadMessage, &wrapper(), cl);
+    addPartToContext(std::move(payloadMessage), spec, o2::header::gSerializationMethodROOT);
+  }
+
+  /// Serialize a snapshot of a trivially copyable, non-polymorphic @a object,
+  /// referred to be 'messageable, will then be sent once the computation ends.
+  /// Framework does not take ownership of @param object. Changes to @param object
+  /// after the call will not be sent.
+  /// Note: also messageable objects with ROOT dictionary are preferably sent
+  /// unserialized. Use @a ROOTSerialized type wrapper to force ROOT serialization.
+  template <typename T>
+  typename std::enable_if<is_messageable<T>::value == true, void>::type
+    snapshot(const Output& spec, T const& object)
   {
     auto proxy = mContextRegistry->get<MessageContext>()->proxy();
-    FairMQMessagePtr payloadMessage;
-    auto serializationType = o2::header::gSerializationMethodNone;
-    if constexpr (is_messageable<T>::value == true) {
-      // Serialize a snapshot of a trivially copyable, non-polymorphic object,
-      payloadMessage = proxy.createMessage(sizeof(T));
-      memcpy(payloadMessage->GetData(), &object, sizeof(T));
+    FairMQMessagePtr payloadMessage(proxy.createMessage(sizeof(T)));
+    memcpy(payloadMessage->GetData(), &object, sizeof(T));
 
-      serializationType = o2::header::gSerializationMethodNone;
-    } else if constexpr (is_specialization<T, std::vector>::value == true) {
-      using ElementType = typename std::remove_pointer<typename T::value_type>::type;
-      if constexpr (is_messageable<ElementType>::value) {
-        // Serialize a snapshot of a std::vector of trivially copyable, non-polymorphic elements
-        // Note: in most cases it is better to use the `make` function und work with the provided
-        // reference object
-        constexpr auto elementSizeInBytes = sizeof(ElementType);
-        auto sizeInBytes = elementSizeInBytes * object.size();
-        payloadMessage = proxy.createMessage(sizeInBytes);
+    addPartToContext(std::move(payloadMessage), spec, o2::header::gSerializationMethodNone);
+  }
 
-        if constexpr (std::is_pointer<typename T::value_type>::value == false) {
-          // vector of elements
-          memcpy(payloadMessage->GetData(), object.data(), sizeInBytes);
-        } else {
-          // serialize vector of pointers to elements
-          auto target = reinterpret_cast<unsigned char*>(payloadMessage->GetData());
-          for (auto const& pointer : object) {
-            memcpy(target, pointer, elementSizeInBytes);
-            target += elementSizeInBytes;
-          }
-        }
+  /// Serialize a snapshot of a std::vector of trivially copyable, non-polymorphic
+  /// elements, which will then be sent once the computation ends.
+  /// Framework does not take ownership of @param object. Changes to @param object
+  /// after the call will not be sent.
+  template <typename C>
+  typename std::enable_if<is_specialization<C, std::vector>::value == true &&
+                          std::is_pointer<typename C::value_type>::value == false &&
+                          is_messageable<typename C::value_type>::value == true>::type
+    snapshot(const Output& spec, C const& v)
+  {
+    auto proxy = mContextRegistry->get<MessageContext>()->proxy();
+    auto sizeInBytes = sizeof(typename C::value_type) * v.size();
+    FairMQMessagePtr payloadMessage(proxy.createMessage(sizeInBytes));
 
-        serializationType = o2::header::gSerializationMethodNone;
-      } else if constexpr (has_root_dictionary<ElementType>::value) {
-        return snapshot(spec, ROOTSerialized<T const>(object));
-      } else {
-        static_assert(always_static_assert_v<T>,
-                      "value type of std::vector not supported by API, supported types:"
-                      "\n - messageable tyeps (trivially copyable, non-polymorphic structures)"
-                      "\n - pointers to those"
-                      "\n - types with ROOT dictionary and implementing ROOT ClassDef interface");
-      }
-    } else if constexpr (has_root_dictionary<T>::value == true || is_specialization<T, ROOTSerialized>::value == true) {
-      // Serialize a snapshot of an object with root dictionary
-      payloadMessage = proxy.createMessage();
-      if constexpr (is_specialization<T, ROOTSerialized>::value == true) {
-        // Explicitely ROOT serialize a snapshot of object.
-        // An object wrapped into type `ROOTSerialized` is explicitely marked to be ROOT serialized
-        // and is expected to have a ROOT dictionary. Availability can not be checked at compile time
-        // for all cases.
-        using WrappedType = typename T::wrapped_type;
-        static_assert(std::is_same<typename T::hint_type, const char>::value ||
-                        std::is_same<typename T::hint_type, TClass>::value ||
-                        std::is_void<typename T::hint_type>::value,
-                      "class hint must be of type TClass or const char");
+    typename C::value_type* tmp = const_cast<typename C::value_type*>(v.data());
+    memcpy(payloadMessage->GetData(), reinterpret_cast<void*>(tmp), sizeInBytes);
 
-        const TClass* cl = nullptr;
-        if (object.getHint() == nullptr) {
-          // get TClass info by wrapped type
-          cl = TClass::GetClass(typeid(WrappedType));
-        } else if (std::is_same<typename T::hint_type, TClass>::value) {
-          // the class info has been passed directly
-          cl = reinterpret_cast<const TClass*>(object.getHint());
-        } else if (std::is_same<typename T::hint_type, const char>::value) {
-          // get TClass info by optional name
-          cl = TClass::GetClass(reinterpret_cast<const char*>(object.getHint()));
-        }
-        if (has_root_dictionary<WrappedType>::value == false && cl == nullptr) {
-          std::string msg("ROOT serialization not supported, dictionary not found for type ");
-          if (std::is_same<typename T::hint_type, const char>::value) {
-            msg += reinterpret_cast<const char*>(object.getHint());
-          } else {
-            msg += typeid(WrappedType).name();
-          }
-          throw std::runtime_error(msg);
-        }
-        TMessageSerializer().Serialize(*payloadMessage, &object(), cl);
-      } else {
-        TMessageSerializer().Serialize(*payloadMessage, &object, TClass::GetClass(typeid(T)));
-      }
-      serializationType = o2::header::gSerializationMethodROOT;
-    } else {
-      static_assert(always_static_assert_v<T>,
-                    "data type T not supported by API, \n specializations available for"
-                    "\n - trivially copyable, non-polymorphic structures"
-                    "\n - std::vector of messageable structures or pointers to those"
-                    "\n - types with ROOT dictionary and implementing ROOT ClassDef interface");
+    addPartToContext(std::move(payloadMessage), spec, o2::header::gSerializationMethodNone);
+  }
+
+  /// Serialize a snapshot of a std::vector of pointers to trivially copyable,
+  /// non-polymorphic elements, which will then be sent once the computation ends.
+  /// Framework does not take ownership of @param object. Changes to @param object
+  /// after the call will not be sent.
+  template <typename C>
+  typename std::enable_if<
+    is_specialization<C, std::vector>::value == true &&
+    std::is_pointer<typename C::value_type>::value == true &&
+    is_messageable<typename std::remove_pointer<typename C::value_type>::type>::value == true>::type
+    snapshot(const Output& spec, C const& v)
+  {
+    using ElementType = typename std::remove_pointer<typename C::value_type>::type;
+    constexpr auto elementSizeInBytes = sizeof(ElementType);
+    auto sizeInBytes = elementSizeInBytes * v.size();
+    auto proxy = mContextRegistry->get<MessageContext>()->proxy();
+    FairMQMessagePtr payloadMessage(proxy.createMessage(sizeInBytes));
+
+    auto target = reinterpret_cast<unsigned char*>(payloadMessage->GetData());
+    for (auto const& pointer : v) {
+      memcpy(target, pointer, elementSizeInBytes);
+      target += elementSizeInBytes;
     }
-    addPartToContext(std::move(payloadMessage), spec, serializationType);
+
+    addPartToContext(std::move(payloadMessage), spec, o2::header::gSerializationMethodNone);
+  }
+
+  /// specialization to catch unsupported types and throw a detailed compiler error
+  template <typename T>
+  typename std::enable_if<has_root_dictionary<T>::value == false &&                //
+                          is_specialization<T, ROOTSerialized>::value == false &&  //
+                          is_messageable<T>::value == false &&                     //
+                          std::is_pointer<T>::value == false &&                    //
+                          is_specialization<T, std::vector>::value == false>::type //
+    snapshot(const Output& spec, T const&)
+  {
+    static_assert(always_static_assert_v<T>,
+                  "data type T not supported by API, \n specializations available for"
+                  "\n - trivially copyable, non-polymorphic structures"
+                  "\n - std::vector of messageable structures or pointers to those"
+                  "\n - object with dictionary by reference");
+  }
+
+  /// specialization to catch unsupported types, check value_type of std::vector
+  /// and throw a detailed compiler error
+  template <typename T>
+  typename std::enable_if<
+    is_specialization<T, std::vector>::value == true &&
+    is_messageable<
+      typename std::remove_pointer<typename T::value_type>::type>::value == false>::type
+    snapshot(const Output& spec, T const&)
+  {
+    static_assert(always_static_assert_v<T>,
+                  "data type T not supported by API, \n specializations available for"
+                  "\n - trivially copyable, non-polymorphic structures"
+                  "\n - std::vector of messageable structures or pointers to those"
+                  "\n - object with dictionary by reference");
+  }
+
+  /// specialization to catch the case where a pointer to an object has been
+  /// accidentally given as parameter
+  template <typename T>
+  typename std::enable_if<std::is_pointer<T>::value>::type snapshot(const Output& spec, T const&)
+  {
+    static_assert(always_static_assert_v<T>,
+                  "pointer to data type not supported by API. Please pass object by reference");
   }
 
   /// Take a snapshot of a raw data array which can be either POD or may contain a serialized


### PR DESCRIPTION
Obviously there was a glitch which I did not expect when refactoring `DataAllocator::snapshot`. And it seems,
objects have been unnecessarily ROOT serialized all the time, so at least we found this. 

PR #2216 with Commit 68f6b4df267201cbf5e2d6b2732ed822ce1599d6 changed the precedence
order of serialization methods for types which are both messageable and ROOT serializable,
now the unserialized transmission is preferred.

This is a temporary messure until InputRecord has been adapted.