### PR TITLE
Fixing code checker errors

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/RecoWorkflowSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/RecoWorkflowSpec.cxx
@@ -106,7 +106,7 @@ class TOFDPLRecoWorkflowTask
     if (mUseMC)
       mMatcher.initWorkflow(tracksRO.get(), clustersRO.get(), &toflab, itslab.get(), tpclab.get());
     else
-      mMatcher.initWorkflow(tracksRO.get(), clustersRO.get(), NULL, NULL, NULL);
+      mMatcher.initWorkflow(tracksRO.get(), clustersRO.get(), nullptr, nullptr, nullptr);
 
     mMatcher.run();
 


### PR DESCRIPTION
Some code checker warnings have been introduced in 6065822182f888769126ccd11e7f5dc1433900ce

```
========== List of errors found ==========
/mnt/mesos/sandbox/sandbox/sw/SOURCES/O2/build_o2checkcode_o2/0/Detectors/GlobalTrackingWorkflow/tofworkflow/src/RecoWorkflowSpec.cxx:109:63: error: use nullptr [modernize-use-nullptr]
/mnt/mesos/sandbox/sandbox/sw/SOURCES/O2/build_o2checkcode_o2/0/Detectors/GlobalTrackingWorkflow/tofworkflow/src/RecoWorkflowSpec.cxx:109:69: error: use nullptr [modernize-use-nullptr]
/mnt/mesos/sandbox/sandbox/sw/SOURCES/O2/build_o2checkcode_o2/0/Detectors/GlobalTrackingWorkflow/tofworkflow/src/RecoWorkflowSpec.cxx:109:75: error: use nullptr [modernize-use-nullptr]
```