### PR TITLE
Skip digitizing electrons with very large times

### DIFF
--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitContainer.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitContainer.h
@@ -75,12 +75,15 @@ class DigitContainer
   /// \param finalFlush Flag whether the whole container is dumped
   void fillOutputContainer(std::vector<Digit>& output, dataformats::MCTruthContainer<MCCompLabel>& mcTruth, const Sector& sector, TimeBin eventTimeBin = 0, bool isContinuous = true, bool finalFlush = false);
 
+  /// Get the size of the container for one event
+  size_t size() const { return mTimeBins.size(); }
+
  private:
   TimeBin mFirstTimeBin = 0;              ///< First time bin to consider
   TimeBin mEffectiveTimeBin = 0;          ///< Effective time bin of that digit
   TimeBin mTmaxTriggered = 0;             ///< Maximum time bin in case of triggered mode (hard cut at average drift speed with additional margin)
-  TimeBin mOffset = 600;                  ///< Size of the container for one event
-  std::deque<DigitTime> mTimeBins{ 600 }; ///< Time bin Container for the ADC value
+  TimeBin mOffset = 700;                  ///< Size of the container for one event
+  std::deque<DigitTime> mTimeBins{ 700 }; ///< Time bin Container for the ADC value
 };
 
 inline DigitContainer::DigitContainer()


### PR DESCRIPTION
@wiechula @a-mathis Digitizing 200 PbPb events I consistently get crash in TPC Digitizer. What happens is that for primary electron with max.drift time coming from hit with very large hit time (28us) the ``DigitContainer::mEffectiveTimeBin`` exceeds the size of mTimeBins container, leading to seg.viol. in addDigit. 
This PR increases the initial size of mTimeBins from 600 to 700 bins, and skips digitization of electrons with ``(drift_time + hit_time)*ZbinWidth + nShapedPoints > DigitContainer::mTimeBins.size()``.
With 700 bins this is equivalent to rejection of hits with time>138 us (e.g. with nominal drift time ~92us 
hitTimes > 44us will be rejected).

This plot shows partile creation times for 200 PbPb event: probability of hitTimes > 30 should be below 10^-7 so we don't lose mush with this protection. 
![trtime](https://user-images.githubusercontent.com/7382029/61571048-23da4e00-aa91-11e9-8211-c34813c841c6.gif)

Alternative brute force ``DigitContainer::reserve`` for every hit would create an overhead. 