### PR TITLE
[EMCAL-551] Fix typo in DataFormatsEMCAL LinkDef

### DIFF
--- a/DataFormats/Detectors/EMCAL/src/DataFormatsEMCALLinkDef.h
+++ b/DataFormats/Detectors/EMCAL/src/DataFormatsEMCALLinkDef.h
@@ -14,8 +14,8 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
-#pragma link C++ class o2::emcal:Cell+;
-#pragma link C++ class o2::emcal:Digit+;
+#pragma link C++ class o2::emcal::Cell + ;
+#pragma link C++ class o2::emcal::Digit + ;
 
 #pragma link C++ class std::vector < o2::emcal::Cell > +;
 #pragma link C++ class std::vector < o2::emcal::Digit > +;


### PR DESCRIPTION
Missing colon in pragma declaration for digit
and cell class creating problems with dictionary
generation.