### PR TITLE
Fix CMake migration issues

### DIFF
--- a/Framework/Logger/CMakeLists.txt
+++ b/Framework/Logger/CMakeLists.txt
@@ -18,3 +18,6 @@ o2_add_test(Logger NAME test_FrameworkLogger_unittest_Logger
             SOURCES test/unittest_Logger.cxx
             COMPONENT_NAME framework
             PUBLIC_LINK_LIBRARIES O2::FrameworkLogger)
+
+install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/${baseTargetName}
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/Framework/Logger/CMakeLists.txt
+++ b/Framework/Logger/CMakeLists.txt
@@ -19,5 +19,5 @@ o2_add_test(Logger NAME test_FrameworkLogger_unittest_Logger
             COMPONENT_NAME framework
             PUBLIC_LINK_LIBRARIES O2::FrameworkLogger)
 
-install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/${baseTargetName}
+install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/Framework
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})


### PR DESCRIPTION
Apparently one needs to handle by hand the fact that a top-level:

```
add_directory(Framework/Logger)
```

suddenly has its headers copied to "include/FrameworkLogger", rather than "include/Framework" as before. Notice this is not the case for `e.g. Framework/Foundation` because that's included as part of

```
add_directory(Framework)
``` 
