### PR TITLE
MFT: fix a bug in position of disk 4

### DIFF
--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/Constants.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/Constants.h
@@ -28,7 +28,7 @@ constexpr Int_t LayersNumber{ 2 * DisksNumber };
 constexpr Int_t HalvesNumber{ 2 };
 
 /// layer Z position to the middle of the CMOS sensor
-constexpr Double_t LayerZPosition[] = { -45.3, -46.7, -48.6, -50.0, -52.4, -53.8, -68.0, -69.4, -76.1, -77.5 };
+constexpr Double_t LayerZPosition[] = { -45.3, -46.7, -48.6, -50.0, -52.4, -53.8, -67.7, -69.1, -76.1, -77.5 };
 
 /// disk thickness in X0
 constexpr Double_t DiskThicknessInX0[DisksNumber] = { 0.008, 0.008, 0.008, 0.008, 0.008 };


### PR DESCRIPTION
The constants giving the positions of the two faces of the fourth disk were wrong by 3mm
(thanks to Andreas and Alicia for spotting this).