### PR TITLE
Fix installation of header files of Framework/Logger after CMake migration

### DIFF
--- a/Framework/Logger/CMakeLists.txt
+++ b/Framework/Logger/CMakeLists.txt
@@ -8,9 +8,8 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
-o2_add_library(FrameworkLogger
-               SOURCES src/Logger.cxx
-               PUBLIC_LINK_LIBRARIES fmt::fmt FairLogger::FairLogger)
+o2_add_header_only_library(FrameworkLogger
+               INTERFACE_LINK_LIBRARIES fmt::fmt FairLogger::FairLogger)
 
 # FIXME: the NAME parameter is just there to ease the comparison with previous
 # test names, can be omitted later on

--- a/Framework/Logger/src/Logger.cxx
+++ b/Framework/Logger/src/Logger.cxx
@@ -1,9 +1,0 @@
-// Copyright CERN and copyright holders of ALICE O2. This software is
-// distributed under the terms of the GNU General Public License v3 (GPL
-// Version 3), copied verbatim in the file "COPYING".
-//
-// See http://alice-o2.web.cern.ch/license for full licensing information.
-//
-// In applying this license CERN does not waive the privileges and immunities
-// granted to it by virtue of its status as an Intergovernmental Organization
-// or submit itself to any jurisdiction.

--- a/GPU/Common/GPUCommon.cxx
+++ b/GPU/Common/GPUCommon.cxx
@@ -11,5 +11,4 @@
 /// \file GPUCommon.cxx
 /// \author David Rohr
 
-// Empty file to have at least something in the library for now
-#include "GPUCommonDef.h"
+// Empty file, needed for AliRoot


### PR DESCRIPTION
I guess this is the propper fix for the issue reported by @mconcas in #2244. (See #2236 and #2245 for reference)