### PR TITLE
Fix DataSamplingReadoutAdapter's subSpec assignement

### DIFF
--- a/Framework/Core/src/DataSamplingReadoutAdapter.cxx
+++ b/Framework/Core/src/DataSamplingReadoutAdapter.cxx
@@ -31,7 +31,7 @@ InjectorFunction dataSamplingReadoutAdapter(OutputSpec const& spec)
       ConcreteDataTypeMatcher dataType = DataSpecUtils::asConcreteDataTypeMatcher(spec);
       dh.dataOrigin = dataType.origin;
       dh.dataDescription = dataType.description;
-      dh.subSpecification = dbh->linkId;
+      dh.subSpecification = DataSpecUtils::getOptionalSubSpec(spec).value_or(dbh->linkId);
       dh.payloadSize = dbh->dataSize;
       dh.payloadSerializationMethod = o2::header::gSerializationMethodNone;
 


### PR DESCRIPTION
The change introduced in 53e08fef5af6c094cb88c9ea49cefd22491320aa was a bit too soon, since QC is not using wildcards for subSpecs yet. This brings back the previous behaviour (assigning the specified subSpec), while giving the possibility to assign the linkID if wildcards are used.
@vascobarroso