### PR TITLE
Fix clang-tidy again in DebugGUI (and with assertions enabled)

### DIFF
--- a/Framework/DebugGUI/src/HandMadeMath.h
+++ b/Framework/DebugGUI/src/HandMadeMath.h
@@ -221,7 +221,12 @@
 
 #endif /* #ifndef HANDMADE_MATH_NO_SSE */
 
+#ifdef __cplusplus
+#include <cstdint> // This is for types
+#include <cmath>
+#else
 #include <stdint.h> // This is for types
+#endif
 
 #ifdef HANDMADE_MATH__USE_SSE
 #include <xmmintrin.h>
@@ -250,9 +255,11 @@ extern "C"
 #if !defined(HMM_SINF) || !defined(HMM_COSF) || !defined(HMM_TANF) || \
     !defined(HMM_SQRTF) || !defined(HMM_EXPF) || !defined(HMM_LOGF) || \
     !defined(HMM_ACOSF) || !defined(HMM_ATANF)|| !defined(HMM_ATAN2F)
+#ifndef __cplusplus
 #include <math.h>
 #endif
-    
+#endif
+
 #ifndef HMM_SINF
 #define HMM_SINF sinf
 #endif

--- a/Framework/DebugGUI/src/sokol_gfx.h
+++ b/Framework/DebugGUI/src/sokol_gfx.h
@@ -3349,28 +3349,28 @@ _SOKOL_PRIVATE void _sg_create_pass(_sg_pass* pass, _sg_image** att_images, cons
     const sg_attachment_desc* att_desc;
     _sg_attachment* att;
     for (int i = 0; i < SG_MAX_COLOR_ATTACHMENTS; i++) {
-        SOKOL_ASSERT(0 == pass->color_atts[i].image);
-        att_desc = &desc->color_attachments[i];
-        if (att_desc->image.id != SG_INVALID_ID) {
-            pass->num_color_atts++;
-            SOKOL_ASSERT(att_images[i] && (att_images[i]->slot.id == att_desc->image.id));
-            SOKOL_ASSERT(_sg_is_valid_rendertarget_color_format(att_images[i]->pixel_format));
-            att = &pass->color_atts[i];
-            SOKOL_ASSERT((att->image == 0) && (att->image_id.id == SG_INVALID_ID));
-            att->image = att_images[i];
-            att->image_id = att_desc->image;
-            att->mip_level = att_desc->mip_level;
-            att->slice = att_desc->slice;
-        }
+      SOKOL_ASSERT(nullptr == pass->color_atts[i].image);
+      att_desc = &desc->color_attachments[i];
+      if (att_desc->image.id != SG_INVALID_ID) {
+        pass->num_color_atts++;
+        SOKOL_ASSERT(att_images[i] && (att_images[i]->slot.id == att_desc->image.id));
+        SOKOL_ASSERT(_sg_is_valid_rendertarget_color_format(att_images[i]->pixel_format));
+        att = &pass->color_atts[i];
+        SOKOL_ASSERT((att->image == nullptr) && (att->image_id.id == SG_INVALID_ID));
+        att->image = att_images[i];
+        att->image_id = att_desc->image;
+        att->mip_level = att_desc->mip_level;
+        att->slice = att_desc->slice;
+      }
     }
-    SOKOL_ASSERT(0 == pass->ds_att.image);
+    SOKOL_ASSERT(nullptr == pass->ds_att.image);
     att_desc = &desc->depth_stencil_attachment;
     const int ds_img_index = SG_MAX_COLOR_ATTACHMENTS;
     if (att_desc->image.id != SG_INVALID_ID) {
         SOKOL_ASSERT(att_images[ds_img_index] && (att_images[ds_img_index]->slot.id == att_desc->image.id));
         SOKOL_ASSERT(_sg_is_valid_rendertarget_depth_format(att_images[ds_img_index]->pixel_format));
         att = &pass->ds_att;
-        SOKOL_ASSERT((att->image == 0) && (att->image_id.id == SG_INVALID_ID));
+        SOKOL_ASSERT((att->image == nullptr) && (att->image_id.id == SG_INVALID_ID));
         att->image = att_images[ds_img_index];
         att->image_id = att_desc->image;
         att->mip_level = att_desc->mip_level;


### PR DESCRIPTION
@ktf : Your reverted the clang-tidy fixes in #2046, which means that now again everything that includes your DebugGUI headers will fail the CI due to the clang-tidy violations. Right now this affects #2243 .

This PR (hopefully) fixes it properly, keeping the C-stye include for C and moving the C++ include out of the namespace (+ it fixes the sokol header for the case with assertions enabled).

Could you please have a look.