### PR TITLE
[QC-84] Forward all non-framework headers in Dispatcher

### DIFF
--- a/Framework/Core/include/Framework/Dispatcher.h
+++ b/Framework/Core/include/Framework/Dispatcher.h
@@ -49,8 +49,10 @@ class Dispatcher : public Task
 
  private:
   DataSamplingHeader prepareDataSamplingHeader(const DataSamplingPolicy& policy, const DeviceSpec& spec);
+  header::Stack extractAdditionalHeaders(const char* inputHeaderStack) const;
   void send(DataAllocator& dataAllocator, const DataRef& inputData, Output&& output) const;
-  void sendFairMQ(FairMQDevice* device, const DataRef& inputData, const std::string& fairMQChannel, DataSamplingHeader&& dsHeader) const;
+  void sendFairMQ(FairMQDevice* device, const DataRef& inputData, const std::string& fairMQChannel,
+                  header::Stack&& stack) const;
 
   std::string mName;
   std::string mReconfigurationSource;


### PR DESCRIPTION
DataHeader and DataProcessingHeader cannot be forwarded, as they are generated by the framework anyway and we want to avoid having two headers of the same type in the Stack.

@mkrzewic Is there a more efficient and elegant way to do this? I am also not sure if each `std::move` actually helps to elide copying.