### PR TITLE
[ITS] Improve MC test by comparing evtID

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/cuda/src/VertexerTraitsGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/src/VertexerTraitsGPU.cu
@@ -329,10 +329,12 @@ void VertexerTraitsGPU::computeTracklets(const bool useMCLabel)
       for (int k{ 0 }; k < foundTracklets01_h[i]; ++k) {
         assert(comb01[stride + k].secondClusterIndex == comb12[stride + j].firstClusterIndex);
         const float deltaTanLambda{ gpu::GPUCommonMath::Abs(comb01[stride + k].tanLambda - comb12[stride + j].tanLambda) };
-        mDeltaTanlambdas.push_back(std::array<float, 7>{ deltaTanLambda,
-                                                         mClusters[0][comb01[stride + k].firstClusterIndex].zCoordinate, mClusters[0][comb01[stride + k].firstClusterIndex].rCoordinate,
-                                                         mClusters[1][comb01[stride + k].secondClusterIndex].zCoordinate, mClusters[1][comb01[stride + k].secondClusterIndex].rCoordinate,
-                                                         mClusters[2][comb12[stride + j].secondClusterIndex].zCoordinate, mClusters[2][comb12[stride + j].secondClusterIndex].rCoordinate });
+        mTrackletInfo.push_back(std::array<float, 9>{ deltaTanLambda,
+                                                      mClusters[0][comb01[stride + k].firstClusterIndex].zCoordinate, mClusters[0][comb01[stride + k].firstClusterIndex].rCoordinate,
+                                                      mClusters[1][comb01[stride + k].secondClusterIndex].zCoordinate, mClusters[1][comb01[stride + k].secondClusterIndex].rCoordinate,
+                                                      mClusters[2][comb12[stride + j].secondClusterIndex].zCoordinate, mClusters[2][comb12[stride + j].secondClusterIndex].rCoordinate,
+                                                      42.f, /* dummy */
+                                                      true /* dummy */ });
       }
     }
   }

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Vertexer.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Vertexer.h
@@ -77,7 +77,7 @@ class Vertexer
   std::vector<Tracklet> getTracklets01() const;
   std::vector<Tracklet> getTracklets12() const;
   std::array<std::vector<Cluster>, 3> getClusters() const;
-  std::vector<std::array<float, 7>> getDeltaTanLambdas() const;
+  std::vector<std::array<float, 9>> getDeltaTanLambdas() const;
   std::vector<std::array<float, 4>> getCentroids() const;
   std::vector<std::array<float, 6>> getLinesData() const;
   void processLines();
@@ -177,9 +177,9 @@ inline std::array<std::vector<Cluster>, 3> Vertexer::getClusters() const
   return mTraits->mClusters;
 }
 
-inline std::vector<std::array<float, 7>> Vertexer::getDeltaTanLambdas() const
+inline std::vector<std::array<float, 9>> Vertexer::getDeltaTanLambdas() const
 {
-  return mTraits->mDeltaTanlambdas;
+  return mTraits->mTrackletInfo;
 }
 
 inline std::vector<std::array<float, 4>> Vertexer::getCentroids() const

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
@@ -86,7 +86,7 @@ class VertexerTraits
   std::vector<Tracklet> mComb01;
   std::vector<Tracklet> mComb12;
   std::array<std::vector<Cluster>, constants::its::LayersNumberVertexer> mClusters;
-  std::vector<std::array<float, 7>> mDeltaTanlambdas;
+  std::vector<std::array<float, 9>> mTrackletInfo;
   std::vector<std::array<float, 6>> mLinesData;
   std::vector<std::array<float, 4>> mCentroids;
   void processLines();


### PR DESCRIPTION
This is just an addendum to last one. The `compare` function helps also to be sure to match id only on the same eventID.
Three small questions for @shahor02:
1. is `MCCompLabel::compare` suitable for checking ITS clusters on different layers are generated by the same track in the same event? 
2. in the `MCCompLabel::compare` function there is a check on the `isFake` flag. What does it mean?
3. I also separately ask for `isValid` to be true. Is it redundant in the case of ITS clusters, after having already passed the compare test?

Thanks