### PR TITLE
Remove fatal debug message left from CMake migration

### DIFF
--- a/dependencies/Findcub.cmake
+++ b/dependencies/Findcub.cmake
@@ -12,7 +12,6 @@ find_path(CUB_INCLUDE_DIR cub/cub.cuh PATHS ${cub_ROOT} ${CMAKE_CUDA_TOOLKIT_INC
 
 if(NOT CUB_INCLUDE_DIR)
   set(CUB_FOUND FALSE)
-  message(FATAL_ERROR "CUB not found")
   return()
 endif()
 


### PR DESCRIPTION
@ktf : I think it is just this bogus fatal message. When CUB_FOUND is set to false, we should not bail out with a FATAL. Don't know where it came from, I guess it was added for debugging during the CMake migration.