### PR TITLE
Fix enum introspection problems with ROOT6.18

### DIFF
--- a/Common/SimConfig/src/ConfigurableParam.cxx
+++ b/Common/SimConfig/src/ConfigurableParam.cxx
@@ -20,6 +20,9 @@
 #include <boost/lexical_cast.hpp>
 #include <algorithm>
 #include <array>
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
 #include <cassert>
 #include <iostream>
 #include <string>
@@ -28,6 +31,8 @@
 #include "TDataMember.h"
 #include "TDataType.h"
 #include "TFile.h"
+#include "TEnum.h"
+#include "TEnumConstant.h"
 
 namespace o2
 {
@@ -103,13 +108,28 @@ void EnumRegistry::add(const std::string& key, const TDataMember* dm)
   }
 
   EnumLegalValues legalVals;
-
-  auto opts = dm->GetOptions();
-  for (int i = 0; i < opts->GetSize(); ++i) {
-    auto opt = (TOptionListItem*)opts->At(i);
-    std::pair<std::string, int> val(opt->fOptName, (int)opt->fValue);
-    legalVals.vvalues.push_back(val);
+  auto enumtype = TEnum::GetEnum(dm->GetTypeName());
+  assert(enumtype != nullptr);
+  auto constantlist = enumtype->GetConstants();
+  assert(constantlist != nullptr);
+  if (enumtype) {
+    for (int i = 0; i < constantlist->GetEntries(); ++i) {
+      auto e = (TEnumConstant*)(constantlist->At(i));
+      std::pair<std::string, int> val(e->GetName(), (int)e->GetValue());
+      legalVals.vvalues.push_back(val);
+    }
   }
+
+  // The other method of fetching enum constants from TDataMember->GetOptions
+  // stopped working with ROOT6-18-0:
+
+  // auto opts = dm->GetOptions();
+  // for (int i = 0; i < opts->GetEntries(); ++i) {
+  //   auto opt = (TOptionListItem*)opts->At(i);
+  //   std::pair<std::string, int> val(opt->fOptName, (int)opt->fValue);
+  //   legalVals.vvalues.push_back(val);
+  //   LOG(INFO) << "Adding legal value " << val.first << " " << val.second;
+  // }
 
   auto entry = std::pair<std::string, EnumLegalValues>(key, legalVals);
   this->entries.insert(entry);

--- a/Common/SimConfig/src/SimConfigLinkDef.h
+++ b/Common/SimConfig/src/SimConfigLinkDef.h
@@ -20,7 +20,8 @@
 #pragma link C++ class o2::conf::SimCutParams + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::conf::SimCutParams > +;
 
-#pragma link C++ class o2::conf::G4Params + ;
+#pragma link C++ enum o2::conf::EG4Physics;
+#pragma link C++ struct o2::conf::G4Params + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::conf::G4Params> + ;
 
 #endif

--- a/Detectors/TPC/base/src/TPCBaseLinkDef.h
+++ b/Detectors/TPC/base/src/TPCBaseLinkDef.h
@@ -67,7 +67,9 @@
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::tpc::ParameterElectronics > +;
 #pragma link C++ class o2::tpc::ParameterGas;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::tpc::ParameterGas > +;
-#pragma link C++ class o2::tpc::ParameterGEM;
+#pragma link C++ enum o2::tpc::AmplificationMode;
+#pragma link C++ enum o2::tpc::DigitzationMode;
+#pragma link C++ struct o2::tpc::ParameterGEM;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::tpc::ParameterGEM > +;
 
 #endif


### PR DESCRIPTION
We use introspection features of ROOT to find out
possible constants of enums in the parameter system.

Since ROOT6-18, ROOT has problems providing these constants.
It appears that ROOT, in our situation, is no longer autogenerating/autoloading
the dictionaries for the enum types as it used to do in ROOT6-16.
Also, the TDataMethod::GetOptions is no longer reliably returning the list
of EnumConstants.

This commit addresses these problems, by

a) generating dictionaries for all enum types used in parameters
b) using TEnum::GetEnum() functionality instead of TDataMethod::GetOptions()
   for the introspection part


Fixes https://alice.its.cern.ch/jira/browse/O2-801