### PR TITLE
Fix systematic drift bug in TRD digitization

### DIFF
--- a/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
@@ -59,7 +59,8 @@ class Digitizer
   bool convertSignalsToDigits(const int, SignalContainer_t&);                   // True if signal-to-digit conversion is successful
   bool convertSignalsToSDigits(const int, SignalContainer_t&);                  // True if signal-to-sdigit conversion is successful
   bool convertSignalsToADC(const int, SignalContainer_t&);                      // True if signal-to-ADC conversion is successful
-  bool diffusion(float, double, double, double&, double&, double&);             // True if diffusion is applied successfully
+
+  bool diffusion(float, double, double, double, double, double, double&, double&, double&); // True if diffusion is applied successfully
 };
 } // namespace trd
 } // namespace o2


### PR DESCRIPTION
I noticed that we were systematically loosing electrons
in the signal generation. The reason is that the locC position
is smeared by diffusion and that each electrons applied also
a linear shift.
Further, the diffusion was not independent for each electron as the locC
was merely reused in its last state.

This commit fixes this problem by making the diffusion process start always from
the original hit coordinates. The final coordinates are now
specific/local to each electrion.