### PR TITLE
Reordering of loops in TRD hit->signal

### DIFF
--- a/Steer/DigitizerWorkflow/src/TRDDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TRDDigitizerSpec.cxx
@@ -95,6 +95,9 @@ class TRDDPLDigitizerTask
     std::vector<o2::trd::Digit> digitsAccum; // accumulator for digits
     o2::dataformats::MCTruthContainer<o2::trd::MCLabel> labelsAccum;
 
+    TStopwatch timer;
+    timer.Start();
+
     // loop over all composite collisions given from context
     // (aka loop over all the interaction records)
     for (int collID = 0; collID < irecords.size(); ++collID) {
@@ -118,6 +121,9 @@ class TRDDPLDigitizerTask
         labelsAccum.mergeAtBack(labels);
       }
     }
+
+    timer.Stop();
+    LOG(INFO) << "TRD: Digitization took " << timer.CpuTime() << "s";
 
     LOG(INFO) << "TRD: Sending " << digitsAccum.size() << " digits";
     pc.outputs().snapshot(Output{ "TRD", "DIGITS", 0, Lifetime::Timeframe }, digitsAccum);


### PR DESCRIPTION
Exchange the timebin and pad loops. Like this, we
need to access the adcmap a lot less and iteration over timebins
will be more cache friendly.

This commit results in ~2x speedup of the TRD digitization.

Report timing in TRD digitizer.
