### PR TITLE
[ITS][Vertexer-CPU] Separate montecarlo validation and improve debug

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/cuda/include/ITStrackingCUDA/VertexerTraitsGPU.h
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/include/ITStrackingCUDA/VertexerTraitsGPU.h
@@ -10,7 +10,7 @@
 ///
 /// \file VertexerTraitsGPU.h
 /// \brief
-///
+/// \author matteo.concas@cern.ch
 
 #ifndef O2_ITS_TRACKING_VERTEXER_TRAITS_GPU_H_
 #define O2_ITS_TRACKING_VERTEXER_TRAITS_GPU_H_
@@ -38,7 +38,7 @@ class VertexerTraitsGPU : public VertexerTraits
  public:
   VertexerTraitsGPU();
   virtual ~VertexerTraitsGPU();
-  void computeTracklets(const bool useMCLabel = false) override;
+  void computeTracklets() override;
   GPU_DEVICE static const int2 getBinsPhiRectWindow(const Cluster&, float maxdeltaphi);
 
  protected:

--- a/Detectors/ITSMFT/ITS/tracking/cuda/src/VertexerTraitsGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/src/VertexerTraitsGPU.cu
@@ -8,9 +8,9 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 ///
-/// \file TrackerTraitsNV.cu
+/// \file VertexerTraitsGPU.cu.cu
 /// \brief
-///
+/// \author matteo.concas@cern.ch
 
 #include <iostream>
 #include <sstream>
@@ -194,8 +194,9 @@ GPU_GLOBAL void debugSumKernel(const int* arrayToSum, const int size)
 using GPU::Utils::Host::getBlocksGrid;
 using GPU::Utils::Host::getBlockSize;
 
-void VertexerTraitsGPU::computeTracklets(const bool useMCLabel)
+void VertexerTraitsGPU::computeTracklets()
 {
+  const unsigned char useMCLabel = false;
   if (useMCLabel)
     std::cout << "info: running trackleter in Montecarlo check mode." << std::endl;
   const GPU::DeviceProperties& deviceProperties = GPU::Context::getInstance().getDeviceProperties();
@@ -329,12 +330,12 @@ void VertexerTraitsGPU::computeTracklets(const bool useMCLabel)
       for (int k{0}; k < foundTracklets01_h[i]; ++k) {
         assert(comb01[stride + k].secondClusterIndex == comb12[stride + j].firstClusterIndex);
         const float deltaTanLambda{gpu::GPUCommonMath::Abs(comb01[stride + k].tanLambda - comb12[stride + j].tanLambda)};
-        mTrackletInfo.push_back(std::array<float, 9>{deltaTanLambda,
-                                                     mClusters[0][comb01[stride + k].firstClusterIndex].zCoordinate, mClusters[0][comb01[stride + k].firstClusterIndex].rCoordinate,
-                                                     mClusters[1][comb01[stride + k].secondClusterIndex].zCoordinate, mClusters[1][comb01[stride + k].secondClusterIndex].rCoordinate,
-                                                     mClusters[2][comb12[stride + j].secondClusterIndex].zCoordinate, mClusters[2][comb12[stride + j].secondClusterIndex].rCoordinate,
-                                                     42.f, /* dummy */
-                                                     true /* dummy */});
+        // mTrackletInfo.push_back(std::array<float, 9>{deltaTanLambda,
+        //                                              mClusters[0][comb01[stride + k].firstClusterIndex].zCoordinate, mClusters[0][comb01[stride + k].firstClusterIndex].rCoordinate,
+        //                                              mClusters[1][comb01[stride + k].secondClusterIndex].zCoordinate, mClusters[1][comb01[stride + k].secondClusterIndex].rCoordinate,
+        //                                              mClusters[2][comb12[stride + j].secondClusterIndex].zCoordinate, mClusters[2][comb12[stride + j].secondClusterIndex].rCoordinate,
+        //                                              42.f, /* dummy */
+        //                                              true /* dummy */});
       }
     }
   }

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
@@ -134,7 +134,7 @@ inline MemoryParameters& MemoryParameters::operator=(const MemoryParameters& t)
 
 struct VertexingParameters {
   float zCut = 0.002f;   //0.002f
-  float phiCut = 0.005f; //0.005f
+  float phiCut = 0.002f; //0.005f
   float pairCut = 0.04f;
   float clusterCut = 0.8f;
   float tanLambdaCut = 0.025f;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracklet.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracklet.h
@@ -29,10 +29,10 @@ struct Tracklet final {
   GPU_DEVICE Tracklet(const int, const int, const Cluster&, const Cluster&);
   void dump();
 
-  const int firstClusterIndex;
-  const int secondClusterIndex;
-  const float tanLambda;
-  const float phiCoordinate;
+  int firstClusterIndex;
+  int secondClusterIndex;
+  float tanLambda;
+  float phiCoordinate;
 };
 
 inline Tracklet::Tracklet() : firstClusterIndex{0}, secondClusterIndex{0}, tanLambda{0.0f}, phiCoordinate{0.0f}

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
@@ -56,6 +56,13 @@ struct lightVertex {
   int mTimeStamp;
 };
 
+struct ClusterMCLabelInfo {
+  int TrackId;
+  int MotherId;
+  int EventId;
+  float Pt;
+};
+
 enum class VertexerDebug : unsigned int {
   TrackletTreeAll = 0x1 << 1,
   LineTreeAll = 0x1 << 2,
@@ -71,7 +78,13 @@ class VertexerTraits
 {
  public:
   VertexerTraits();
+
+#ifdef _ALLOW_DEBUG_TREES_ITS_
   virtual ~VertexerTraits();
+#else
+  virtual ~VertexerTraits() = default;
+#endif
+
   GPU_HOST_DEVICE static constexpr int4 getEmptyBinsRect() { return int4{0, 0, 0, 0}; }
   GPU_HOST_DEVICE static const int4 getBinsRect(const Cluster&, const int, const float, float maxdeltaz, float maxdeltaphi);
   GPU_HOST_DEVICE static const int2 getPhiBins(float phi, float deltaPhi);

--- a/Detectors/ITSMFT/ITS/tracking/src/Vertexer.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Vertexer.cxx
@@ -34,7 +34,11 @@ float Vertexer::clustersToVertices(ROframe& event, const bool useMc, std::ostrea
   ROframe* eventptr = &event;
   float total{0.f};
   total += evaluateTask(&Vertexer::initialiseVertexer, "Vertexer initialisation", timeBenchmarkOutputStream, eventptr);
-  total += evaluateTask(&Vertexer::findTracklets, "Tracklet finding", timeBenchmarkOutputStream, useMc);
+  total += evaluateTask(&Vertexer::findTracklets, "Tracklet finding", timeBenchmarkOutputStream);
+  if (useMc) {
+    total += evaluateTask(&Vertexer::filterMCTracklets, "MC tracklets filtering", timeBenchmarkOutputStream);
+  }
+  total += evaluateTask(&Vertexer::validateTracklets, "Adjacent tracklets validation", timeBenchmarkOutputStream);
   total += evaluateTask(&Vertexer::findVertices, "Vertex finding", timeBenchmarkOutputStream);
 
   return total;

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -140,13 +140,13 @@ VertexerTraits::VertexerTraits() : mAverageClustersRadii{std::array<float, 3>{0.
   setIsGPU(false);
 }
 
+#ifdef _ALLOW_DEBUG_TREES_ITS_
 VertexerTraits::~VertexerTraits()
 {
-#ifdef _ALLOW_DEBUG_TREES_ITS_
   assert(mEvent != nullptr);
   delete mTreeStream;
-#endif
 }
+#endif
 
 void VertexerTraits::reset()
 {
@@ -247,7 +247,7 @@ void VertexerTraits::computeTrackletsPureMontecarlo()
       const Cluster& nextCluster{mClusters[1][iNextLayerClusterIndex]};
       const auto& lblNext = mEvent->getClusterLabels(1, nextCluster.clusterId);
       const auto& lblCurr = mEvent->getClusterLabels(0, currentCluster.clusterId);
-      if (lblNext.compare(lblCurr) == 1) {
+      if (lblNext.compare(lblCurr) == 1 && lblCurr.getSourceID() == 0) {
         mComb01.emplace_back(iCurrentLayerClusterIndex, iNextLayerClusterIndex, currentCluster, nextCluster);
       }
     }
@@ -259,7 +259,7 @@ void VertexerTraits::computeTrackletsPureMontecarlo()
       const Cluster& nextCluster{mClusters[1][iNextLayerClusterIndex]};
       const auto& lblNext = mEvent->getClusterLabels(1, nextCluster.clusterId);
       const auto& lblCurr = mEvent->getClusterLabels(2, currentCluster.clusterId);
-      if (lblNext.compare(lblCurr) == 1) {
+      if (lblNext.compare(lblCurr) == 1 && lblCurr.getSourceID() == 0) {
         mComb12.emplace_back(iNextLayerClusterIndex, iCurrentLayerClusterIndex, nextCluster, currentCluster);
       }
     }
@@ -348,7 +348,7 @@ void VertexerTraits::computeMCFiltering()
   for (size_t iTracklet{0}; iTracklet < mComb01.size(); ++iTracklet) {
     const auto& lbl0 = mEvent->getClusterLabels(0, mClusters[0][mComb01[iTracklet].firstClusterIndex].clusterId);
     const auto& lbl1 = mEvent->getClusterLabels(1, mClusters[1][mComb01[iTracklet].secondClusterIndex].clusterId);
-    if (!lbl0.compare(lbl1) == 1) { // evtId && trackId && isValid
+    if (!(lbl0.compare(lbl1) == 1 && lbl0.getSourceID() == 0)) { // evtId && trackId && isValid
       mComb01.erase(mComb01.begin() + iTracklet);
       --iTracklet; // vector size has been decreased
     }
@@ -357,7 +357,7 @@ void VertexerTraits::computeMCFiltering()
   for (size_t iTracklet{0}; iTracklet < mComb12.size(); ++iTracklet) {
     const auto& lbl1 = mEvent->getClusterLabels(1, mClusters[1][mComb12[iTracklet].firstClusterIndex].clusterId);
     const auto& lbl2 = mEvent->getClusterLabels(2, mClusters[2][mComb12[iTracklet].secondClusterIndex].clusterId);
-    if (!lbl1.compare(lbl2) == 1) { // evtId && trackId && isValid
+    if (!(lbl1.compare(lbl2) == 1 && lbl1.getSourceID() == 0)) { // evtId && trackId && isValid
       mComb12.erase(mComb12.begin() + iTracklet);
       --iTracklet; // vector size has been decreased
     }

--- a/macro/run_primary_vertexer_ITS.C
+++ b/macro/run_primary_vertexer_ITS.C
@@ -1,5 +1,7 @@
 #if !defined(__CLING__) || defined(__ROOTCLING__)
 
+#include <memory>
+
 #include <TChain.h>
 #include <TFile.h>
 #include <TSystem.h>
@@ -14,12 +16,7 @@
 #include "ITSBase/GeometryTGeo.h"
 #include "ITStracking/IOUtils.h"
 #include "ITStracking/Vertexer.h"
-// DEBUG
-#include "ITStracking/ClusterLines.h"
-#include "ITStracking/Tracklet.h"
-#include "ITStracking/Cluster.h"
 
-// #define __VERTEXER_ITS_DEBUG
 #if defined(__VERTEXER_ITS_GPU)
 #include "GPUO2Interface.h"
 #include "GPUReconstruction.h"
@@ -93,7 +90,7 @@ int run_primary_vertexer_ITS(const bool useGPU = false,
   itsClustersROF.SetBranchAddress("ITSClustersROF", &rofs);
   itsClustersROF.GetEntry(0);
 
-  //get labels
+  // get labels
   o2::dataformats::MCTruthContainer<o2::MCCompLabel>* labels = nullptr;
   itsClusters.SetBranchAddress("ITSClusterMCTruth", &labels);
 
@@ -104,23 +101,10 @@ int run_primary_vertexer_ITS(const bool useGPU = false,
     new std::vector<o2::dataformats::Vertex<o2::dataformats::TimeStamp<int>>>;
   outTree.Branch("ITSVertices", &verticesITS);
 
-  // DEBUG
-#if defined(__VERTEXER_ITS_DEBUG)
-  TNtuple tracklets("Tracklets", "Tracklets", "oX:oY:oZ:c1:c2:c3:DCAvtx:DCAz");
-  TNtuple comb01("comb01", "comb01", "tanLambda:phi");
-  TNtuple comb12("comb12", "comb12", "tanLambda:phi");
-  TNtuple clusPhi01("clus_phi01", "clus_phi01", "phi0:phi1");
-  TNtuple clusPhi12("clus_phi12", "clus_phi12", "phi1:phi2");
-  TNtuple trackdeltaTanLambdas("dtl", "dtl", "deltatanlambda:c0z:c0r:c1z:c1r:c2z:c2r:evtId:valid");
-  TNtuple centroids("centroids", "centroids", "id:x:y:z:dca");
-  TNtuple linesData("ld", "linesdata", "x:xy:xz:y:yz:z");
-  const o2::its::Line zAxis{std::array<float, 3>{0.f, 0.f, -1.f}, std::array<float, 3>{0.f, 0.f, 1.f}};
-#endif
-
-  // Benchmarks
-  TNtuple foundVerticesBenchmark("foundVerticesBenchmark", "Found vertices benchmark", "frameId:foundVertices:nTracklets");
-  TNtuple timeBenchmark("timeBenchmark", "Time benchmarks", "init:trackletFinder:vertexFinder");
-  // \Benchmarks
+  // benchmarks
+  TNtuple foundVerticesBenchmark("foundVerticesBenchmark", "Found vertices benchmark", "frameId:foundVertices");
+  TNtuple timeBenchmark("timeBenchmark", "Time benchmarks", "init:trackletFinder:trackletMatcher:vertexFinder:total");
+  // \benchmarks
 
   std::uint32_t roFrame = 0;
 
@@ -132,9 +116,7 @@ int run_primary_vertexer_ITS(const bool useGPU = false,
   const int stopAt = (inspEvt == -1) ? rofs->size() : inspEvt + numEvents;
   const int startAt = (inspEvt == -1) ? 0 : inspEvt;
 
-  o2::its::ROframe frame(-123);
-
-  o2::its::VertexerTraits* traits = nullptr;
+  std::unique_ptr<o2::its::VertexerTraits> traits;
 
 #if defined(__VERTEXER_ITS_GPU)
   if (useGPU) {
@@ -142,88 +124,53 @@ int run_primary_vertexer_ITS(const bool useGPU = false,
   }
 #else
   if (!useGPU) {
-    traits = o2::its::createVertexerTraits();
+    traits = std::make_unique<o2::its::VertexerTraits>();
   }
 #endif
 
-  o2::its::Vertexer vertexer(traits);
+  o2::its::Vertexer vertexer(traits.get());
   vertexer.setParameters(parameters);
-
+  itsClusters.GetEntry(0);
+  mcHeaderTree.GetEntry(0);
   for (size_t iROfCount{static_cast<size_t>(startAt)}; iROfCount < static_cast<size_t>(stopAt); ++iROfCount) {
     auto& rof = (*rofs)[iROfCount];
+    o2::its::ROframe frame(iROfCount); // to get meaningful roframeId
     std::cout << "ROframe: " << iROfCount << std::endl;
-    itsClusters.GetEntry(rof.getROFEntry().getEvent());
-    mcHeaderTree.GetEntry(rof.getROFEntry().getEvent());
     int nclUsed = o2::its::ioutils::loadROFrameData(rof, frame, clusters, labels);
 
     std::array<float, 3> total{0.f, 0.f, 0.f};
     o2::its::ROframe* eventptr = &frame;
 
-    total[0] = vertexer.evaluateTask(&o2::its::Vertexer::initialiseVertexer, "Vertexer initialisation", std::cout, eventptr);
-    total[1] = vertexer.evaluateTask(&o2::its::Vertexer::findTracklets, "Tracklet finding", std::cout, useMCcheck);
-    // total[1] = vertexer.evaluateTask(&o2::its::Vertexer::findTrivialMCTracklets, "Trivial Tracklet finding", std::cout);
-    total[2] = vertexer.evaluateTask(&o2::its::Vertexer::findVertices, "Vertex finding", std::cout);
-    // vertexer.findVerticesDBS();
+    // debug
+    vertexer.setDebugTrackletSelection();
+    vertexer.setDebugLines(); // Handle with care, takes very long
+    vertexer.setDebugCombinatorics();
+    vertexer.setDebugSummaryLines();
+    // \debug
 
-#if defined(__VERTEXER_ITS_DEBUG)
-    // vertexer.processLines();
-    vertexer.dumpTraits();
-    std::vector<std::array<float, 6>> linesdata = vertexer.getLinesData();
-    std::vector<std::array<float, 4>> centroidsData = vertexer.getCentroids();
-    std::vector<o2::its::Line> lines = vertexer.getLines();
-    std::vector<o2::its::Tracklet> c01 = vertexer.getTracklets01();
-    std::vector<o2::its::Tracklet> c12 = vertexer.getTracklets12();
-    std::array<std::vector<o2::its::Cluster>, 3> clusters = vertexer.getClusters();
-    std::vector<std::array<float, 9>> dtlambdas = vertexer.getDeltaTanLambdas();
-    for (auto& line : lines)
-      tracklets.Fill(line.originPoint[0], line.originPoint[1], line.originPoint[2], line.cosinesDirector[0], line.cosinesDirector[1], line.cosinesDirector[2],
-                     o2::its::Line::getDistanceFromPoint(line, std::array<float, 3>{0.f, 0.f, 0.f}), o2::its::Line::getDCA(line, zAxis));
-    for (int i{0}; i < static_cast<int>(c01.size()); ++i) {
-      comb01.Fill(c01[i].tanLambda, c01[i].phiCoordinate);
-      clusPhi01.Fill(clusters[0][c01[i].firstClusterIndex].phiCoordinate, clusters[1][c01[i].secondClusterIndex].phiCoordinate);
+    total[0] = vertexer.evaluateTask(&o2::its::Vertexer::initialiseVertexer, "Vertexer initialisation", std::cout, eventptr);
+    // total[1] = vertexer.evaluateTask(&o2::its::Vertexer::findTrivialMCTracklets, "Trivial Tracklet finding", std::cout); // If enable this, comment out the validateTracklets
+    total[1] = vertexer.evaluateTask(&o2::its::Vertexer::findTracklets, "Tracklet finding", std::cout);
+    if (useMCcheck) {
+      vertexer.evaluateTask(&o2::its::Vertexer::filterMCTracklets, "MC tracklets filtering", std::cout);
     }
-    for (int i{0}; i < static_cast<int>(c12.size()); ++i) {
-      comb12.Fill(c12[i].tanLambda, c12[i].phiCoordinate);
-      clusPhi12.Fill(clusters[1][c12[i].firstClusterIndex].phiCoordinate, clusters[2][c12[i].secondClusterIndex].phiCoordinate);
-    }
-    for (auto& delta : dtlambdas) {
-      trackdeltaTanLambdas.Fill(delta.data());
-    }
-    for (auto& centroid : centroidsData) {
-      auto cdata = centroid.data();
-      centroids.Fill(roFrame, cdata[0], cdata[1], cdata[2], cdata[3]);
-    }
-    for (auto& linedata : linesdata) {
-      linesData.Fill(linedata.data());
-    }
-#endif
+    total[2] = vertexer.evaluateTask(&o2::its::Vertexer::validateTracklets, "Adjacent tracklets validation", std::cout);
+    total[3] = vertexer.evaluateTask(&o2::its::Vertexer::findVertices, "Vertex finding", std::cout);
 
     std::vector<Vertex> vertITS = vertexer.exportVertices();
     const size_t numVert = vertITS.size();
-    foundVerticesBenchmark.Fill(static_cast<float>(iROfCount), static_cast<float>(numVert) /* , static_cast<float>(linesdata.size())*/);
+    foundVerticesBenchmark.Fill(static_cast<float>(iROfCount), static_cast<float>(numVert));
     verticesITS->swap(vertITS);
     // TODO: get vertexer postion form MC truth
 
-    if (numVert > 0) {
-      timeBenchmark.Fill(total[0], total[1], total[2]);
-    }
+    timeBenchmark.Fill(total[0], total[1], total[2], total[3], total[0] + total[1] + total[2] + total[3]);
     outTree.Fill();
   }
-
+  traits.reset();
+  outputfile->cd();
   outTree.Write();
   foundVerticesBenchmark.Write();
   timeBenchmark.Write();
-
-#if defined(__VERTEXER_ITS_DEBUG)
-  tracklets.Write();
-  comb01.Write();
-  comb12.Write();
-  clusPhi01.Write();
-  clusPhi12.Write();
-  trackdeltaTanLambdas.Write();
-  centroids.Write();
-  linesData.Write();
-#endif
 
   outputfile->Close();
   return 0;

--- a/macro/run_trac_ca_its.C
+++ b/macro/run_trac_ca_its.C
@@ -147,7 +147,7 @@ void run_trac_ca_its(bool useITSVertex = false,
     mcHeaderTree.GetEntry(rof.getROFEntry().getEvent());
     o2::its::ioutils::loadROFrameData(rof, event, clusters, labels);
     if (useITSVertex) {
-    
+
       vertexer.initialiseVertexer(&event);
       vertexer.findTracklets();
       // vertexer.filterMCTracklets(); // to use MC check

--- a/macro/run_trac_ca_its.C
+++ b/macro/run_trac_ca_its.C
@@ -147,10 +147,11 @@ void run_trac_ca_its(bool useITSVertex = false,
     mcHeaderTree.GetEntry(rof.getROFEntry().getEvent());
     o2::its::ioutils::loadROFrameData(rof, event, clusters, labels);
     if (useITSVertex) {
+    
       vertexer.initialiseVertexer(&event);
-
-      // set to true to use MC check
-      vertexer.findTracklets(false);
+      vertexer.findTracklets();
+      // vertexer.filterMCTracklets(); // to use MC check
+      vertexer.validateTracklets();
       vertexer.findVertices();
       std::vector<Vertex> vertITS = vertexer.exportVertices();
       if (!vertITS.empty()) {


### PR DESCRIPTION
These changes are mainly focused on the CPU version, but in general will made debug/mc validation easier and seamlessly portable to GPU version, which as told before will have a refresh too.
More specifically:
 - Tracklets are now MC-validated in dedicated function -> no more mention of MC truth in combinatorial code. My plan is to keep the mc-validation on CPU also for GPU vertexer
 - Debug boilerplate has been completely dismissed in favour of few utilities heavily relying on the `TreeStreamRedirector` class, as @shahor02 once suggested me to do (thanks!).

Not sure about the formatting, will update and remove the WIP tag upon green light from travis