### PR TITLE
[EMCAL-599] Initialize and apply sampling fraction to light yield

### DIFF
--- a/Detectors/EMCAL/base/include/EMCALBase/Geometry.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/Geometry.h
@@ -98,13 +98,11 @@ class Geometry
                                             const std::string_view mcname = "TGeant3",
                                             const std::string_view mctitle = "");
 
-  ///
-  /// Set the value of fSampling used to calibrate the MC hits energy (check)
-  /// Called in AliEMCALv0 and not anymore here in Init() in order to be able to work with Geant4
+  /// Set the value of the Sampling used to calibrate the MC hits energy (check)
+  /// Called in Detector::ConstructGeometry and not anymore here in Init() in order to be able to work with Geant4
   ///
   /// \param mcname: Geant3/4, Flukla, ...
   /// \param mctitle: Geant4 physics list tag name
-  ///
   void DefineSamplingFraction(const std::string_view mcname = "", const std::string_view mctitle = "");
 
   //////////

--- a/Detectors/EMCAL/simulation/src/Detector.cxx
+++ b/Detectors/EMCAL/simulation/src/Detector.cxx
@@ -126,6 +126,8 @@ void Detector::ConstructGeometry()
   LOG(DEBUG2) << "Shish-Kebab geometry : " << GetTitle();
   CreateShiskebabGeometry();
 
+  geom->DefineSamplingFraction(TVirtualMC::GetMC()->GetName(), TVirtualMC::GetMC()->GetTitle());
+
   gGeoManager->CheckGeometry();
 }
 
@@ -170,7 +172,7 @@ Bool_t Detector::ProcessHits(FairVolume* v)
   Double_t lightyield(eloss);
   if (fMC->TrackCharge())
     lightyield = CalculateLightYield(eloss, fMC->TrackStep(), fMC->TrackCharge());
-  lightyield /= geom->GetSampling();
+  lightyield *= geom->GetSampling();
 
   auto o2stack = static_cast<o2::data::Stack*>(fMC->GetStack());
   const bool isDaughterOfSeenTrack = o2stack->isTrackDaughterOf(partID, mCurrentTrackID);


### PR DESCRIPTION
Sampling fraction has been applied previously in the digitization
code. As the sampling fraction depends on the MC engine and the
digitizer has no knowledge about the MC engine it has to be applied
during the hit generation.