### PR TITLE
Don't set GPUCA_O2_LIB etc for TPCFastTransform, it's only for GPUTracking

### DIFF
--- a/GPU/TPCFastTransformation/CMakeLists.txt
+++ b/GPU/TPCFastTransformation/CMakeLists.txt
@@ -33,9 +33,6 @@ if(${ALIGPU_BUILD_TYPE} STREQUAL "O2")
                             HEADERS ${HDRS_CINT_O2}
                             LINKDEF TPCFastTransformationLinkDef_O2.h)
 
-  target_compile_definitions(${targetName} PRIVATE GPUCA_O2_LIB
-                             GPUCA_TPC_GEOMETRY_O2 HAVE_O2HEADERS)
-
   install(FILES ${HDRS_CINT_O2} DESTINATION include/GPU)
   file(COPY ${HDRS_CINT_O2} DESTINATION ${CMAKE_BINARY_DIR}/stage/include/GPU)
 


### PR DESCRIPTION
Some defines were copied to TPCFastTransform to steer the namespace name, which was added to avoid symbol collisions between O2 and AliRoot when O2 is built v.s. AliRoot. Unfortunately, this breaks the ROOT dictionary for the TPC Fast Transform object.

This is a first simple attempt to fix it, not to be merged yet, must be double-checked.
@sgorbuno : Could you have a look if this works for you?