### PR TITLE
Bugfix: Default geometry not handled for empty name

### DIFF
--- a/Detectors/EMCAL/base/src/Geometry.cxx
+++ b/Detectors/EMCAL/base/src/Geometry.cxx
@@ -189,7 +189,7 @@ Geometry* Geometry::GetInstance(const std::string_view name, const std::string_v
                                 const std::string_view mctitle)
 {
   if (!sGeom) {
-    if (name != std::string("")) { // get default geometry
+    if (!name.length()) { // get default geometry
       sGeom = new Geometry(DEFAULT_GEOMETRY, mcname, mctitle);
     } else {
       sGeom = new Geometry(name, mcname, mctitle);


### PR DESCRIPTION
Default and named geometry were mixed up.