### PR TITLE
Fixes for TRDBase dictionary generation:

### DIFF
--- a/Detectors/TRD/base/include/TRDBase/TRDCalPadStatus.h
+++ b/Detectors/TRD/base/include/TRDBase/TRDCalPadStatus.h
@@ -45,7 +45,7 @@ class TRDCalPadStatus
   TRDCalPadStatus();
   TRDCalPadStatus(const Text_t* name, const Text_t* title);
   TRDCalPadStatus(const TRDCalPadStatus& c);
-  virtual ~TRDCalPadStatus();
+  ~TRDCalPadStatus();
   TRDCalPadStatus& operator=(const TRDCalPadStatus& c);
 
   void Copy(TRDCalPadStatus& c) const;

--- a/Detectors/TRD/base/include/TRDBase/TRDCalSingleChamberStatus.h
+++ b/Detectors/TRD/base/include/TRDBase/TRDCalSingleChamberStatus.h
@@ -37,7 +37,7 @@ class TRDCalSingleChamberStatus
   TRDCalSingleChamberStatus();
   TRDCalSingleChamberStatus(Int_t p, Int_t c, Int_t cols);
   TRDCalSingleChamberStatus(const TRDCalSingleChamberStatus& c);
-  virtual ~TRDCalSingleChamberStatus();
+  ~TRDCalSingleChamberStatus();
   TRDCalSingleChamberStatus& operator=(const TRDCalSingleChamberStatus& c);
   void Copy(TRDCalSingleChamberStatus& c) const;
 


### PR DESCRIPTION
Hi @jolopezl 
This PR fixes the compilation warnings
````
Warning: Unused class rule: o2::dataformats::MCTruthContainer < o2::trd::MCLabel>
Warning: Unused class rule: o2::trd::TRDCalPadStatus
Warning: Unused class rule: o2::trd::TRDCalSingleChamberStatus
````
leading to error in the digitization:
````
[31009:TRDDigitizer]: IncrementalExecutor::executeFunction: symbol '_ZN2o211dataformats16MCTruthContainerINS_3trd7MCLabelEE5ClassEv' unresolved while linking [cling interfac
e function]!
[31009:TRDDigitizer]: You are probably missing the definition of o2::dataformats::MCTruthContainer<o2::trd::MCLabel>::Class()
[31009:TRDDigitizer]: Maybe you need to load the corresponding shared library?
````

1) dictionary generation for o2::dataformats::MCTruthContainer<o2::trd::MCLabel> was ignored since neither of sources included SimulationDataFormat/MCTruthContainer.h. Added to MCLabel.h
2) dictionary generation for TRDCalPadStatus and TRDCalSingleChamberStatus was ignored since they had virtual destructors but used ClassDefNV. I've removed the virtuality; unless you are going to derive from these classes and use polymorphic pointers, it is not needed.

One more point: the ``o2::trd::MCLabel`` just adds to ``o2::MCCompLabel`` an extra ``bool mIsDigit`` but this changes the size of the class from 8 to 16 bytes due to the alignment. From the ``Digitzer.cxx`` I did not understand why is it needed, could you explain?
In any case, if this flag is needed, we have a few bits currently unused in the MCCompLabel, if needed, I can reserve it for user flag. 