### PR TITLE
Interface to register sensitive volumes and to cache its VMC VolID

### DIFF
--- a/Detectors/Base/include/DetectorsBase/Detector.h
+++ b/Detectors/Base/include/DetectorsBase/Detector.h
@@ -192,6 +192,14 @@ class Detector : public FairDetector
   // ... for things that should be setup in each simulation worker separately)
   virtual void initializeLate() = 0;
 
+  /// helper wrapper function to register a geometry volume given by name with FairRoot
+  /// @returns The MonteCarlo ID for the volume
+  int registerSensitiveVolumeAndGetVolID(std::string const& name);
+
+  /// helper wrapper function to register a geometry volume given by TGeoVolume vol
+  /// @returns The MonteCarlo ID for the volume
+  int registerSensitiveVolumeAndGetVolID(TGeoVolume const* vol);
+
   // The GetCollection interface is made final and deprecated since
   // we no longer support TClonesArrays
   [[deprecated("Use getHits API on concrete detectors!")]] TClonesArray* GetCollection(int iColl) const final;

--- a/Detectors/FIT/FV0/simulation/src/Detector.cxx
+++ b/Detectors/FIT/FV0/simulation/src/Detector.cxx
@@ -65,12 +65,9 @@ Detector::Detector(Bool_t isActive)
 void Detector::InitializeO2Detector()
 {
   LOG(INFO) << "FV0: Initializing O2 detector. Adding sensitive volume.";
-  TGeoVolume* volSensitive = gGeoManager->GetVolume("FV0cell");
-  if (!volSensitive) {
+  const int volid = registerSensitiveVolumeAndGetVolID("FV0cell");
+  if (volid <= 0) {
     LOG(FATAL) << "Can't find FV0 sensitive volume: cell";
-  } else {
-    AddSensitiveVolume(volSensitive);
-    LOG(INFO) << "FV0: Sensitive volume: " << volSensitive->GetName() << "   " << volSensitive->GetNumber();
   }
 }
 

--- a/Detectors/ITSMFT/MFT/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/MFT/simulation/src/Detector.cxx
@@ -449,20 +449,14 @@ void Detector::ConstructGeometry()
 //_____________________________________________________________________________
 void Detector::defineSensitiveVolumes()
 {
-
-  TGeoVolume* vol;
   Geometry* mftGeom = Geometry::instance();
 
-  vol = gGeoManager->GetVolume("MFTSensor");
-  if (!vol) {
-    LOG(FATAL) << "can't find volume MFTSensor";
-  } else {
-    AddSensitiveVolume(vol);
-    if (!mftGeom->getSensorVolumeID()) {
-      mftGeom->setSensorVolumeID(vol->GetNumber());
-    } else if (mftGeom->getSensorVolumeID() != vol->GetNumber()) {
-      LOG(FATAL) << "CreateSensors: different Sensor volume ID !!!!";
-    }
+  auto id = registerSensitiveVolumeAndGetVolID("MFTSensor");
+  if (id <= 0) {
+    LOG(FATAL) << "Can't register volume MFTSensor";
+  }
+  if (!mftGeom->getSensorVolumeID()) {
+    mftGeom->setSensorVolumeID(id);
   }
 }
 


### PR DESCRIPTION
We cannot rely on the TGeoVolume::GetNumber() function to get the volume
id. This seems to work with Geant3 but not for Geant4.
This commit is offering a new API that the developer/user can use to
register a sensitive volume and to query the volume ID from VMC behind
the scenes.

Application to MFT and V0 which where using GetNumber.

Fixes https://alice.its.cern.ch/jira/browse/O2-814
