### PR TITLE
[AliRoot-8326] Preparation work for the removal of the O2RecipeAdapter.

### DIFF
--- a/dependencies/FindFairRoot.cmake
+++ b/dependencies/FindFairRoot.cmake
@@ -12,11 +12,9 @@
 
 find_path(FairRoot_INC FairDetector.h
           PATH_SUFFIXES FairRoot/include
-          PATHS ${FAIRROOTPATH}/include)
-
-# if(NOT EXISTS ${FairRoot_INC}) set(FairRoot_FOUND FALSE)
-# if(FairRoot_FIND_REQUIRED) message(FATAL_ERROR "Could not find FairRoot")
-# endif() return() endif()
+          PATHS ${FAIRROOTPATH}/include
+          ${FAIRROOT_ROOT}/include
+          $ENV{FAIRROOT_ROOT}/include)
 
 get_filename_component(FairRoot_TOPDIR "${FairRoot_INC}/.." ABSOLUTE)
 

--- a/dependencies/Findms_gsl.cmake
+++ b/dependencies/Findms_gsl.cmake
@@ -8,7 +8,8 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
-find_path(MS_GSL_INCLUDE_DIR gsl/gsl PATH_SUFFIXES ms_gsl/include)
+find_path(MS_GSL_INCLUDE_DIR gsl/gsl PATH_SUFFIXES ms_gsl/include include
+        PATHS $ENV{MS_GSL_ROOT})
 
 if(NOT MS_GSL_INCLUDE_DIR)
   set(MS_GSL_FOUND FALSE)

--- a/dependencies/Findpythia.cmake
+++ b/dependencies/Findpythia.cmake
@@ -8,36 +8,39 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
-find_path(${CMAKE_FIND_PACKAGE_NAME}_INCLUDE_DIR
+set(PKGNAME ${CMAKE_FIND_PACKAGE_NAME})
+string(TOUPPER ${PKGNAME} PKGENVNAME)
+
+find_path(${PKGNAME}_INCLUDE_DIR
           NAMES Pythia.h
-          PATH_SUFFIXES Pythia8)
+          PATH_SUFFIXES Pythia8
+          PATHS $ENV{${PKGENVNAME}_ROOT}/include)
 
-find_library(${CMAKE_FIND_PACKAGE_NAME}_LIBRARY_SHARED
-             NAMES libpythia8.so libpythia8.dylib)
+find_library(${PKGNAME}_LIBRARY_SHARED NAMES libpythia8.so libpythia8.dylib
+          PATHS $ENV{${PKGENVNAME}_ROOT}/lib)
 
-find_path(${CMAKE_FIND_PACKAGE_NAME}_DATA
+find_path(${PKGNAME}_DATA
           NAMES MainProgramSettings.xml
-          PATHS ${${CMAKE_FIND_PACKAGE_NAME}_ROOT}/share/Pythia8/xmldoc)
+          PATHS ${${PKGNAME}_ROOT}/share/Pythia8/xmldoc
+                $ENV{${PKGENVNAME}_ROOT}/share/Pythia8/xmldoc)
 
-if(${CMAKE_FIND_PACKAGE_NAME}_INCLUDE_DIR
-   AND ${CMAKE_FIND_PACKAGE_NAME}_LIBRARY_SHARED
-   AND ${CMAKE_FIND_PACKAGE_NAME}_DATA)
+if(${PKGNAME}_INCLUDE_DIR AND ${PKGNAME}_LIBRARY_SHARED AND ${PKGNAME}_DATA)
   add_library(pythia SHARED IMPORTED)
-  get_filename_component(incdir ${${CMAKE_FIND_PACKAGE_NAME}_INCLUDE_DIR}/..
-                         ABSOLUTE)
+  get_filename_component(incdir ${${PKGNAME}_INCLUDE_DIR}/.. ABSOLUTE)
   set_target_properties(pythia
                         PROPERTIES IMPORTED_LOCATION
-                                   ${${CMAKE_FIND_PACKAGE_NAME}_LIBRARY_SHARED}
+                                   ${${PKGNAME}_LIBRARY_SHARED}
                                    INTERFACE_INCLUDE_DIRECTORIES ${incdir})
 endif()
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(
-  ${CMAKE_FIND_PACKAGE_NAME}
-  REQUIRED_VARS ${CMAKE_FIND_PACKAGE_NAME}_INCLUDE_DIR
-                ${CMAKE_FIND_PACKAGE_NAME}_LIBRARY_SHARED
-                ${CMAKE_FIND_PACKAGE_NAME}_DATA)
+find_package_handle_standard_args(${PKGNAME}
+                                  REQUIRED_VARS ${PKGNAME}_INCLUDE_DIR
+                                                ${PKGNAME}_LIBRARY_SHARED
+                                                ${PKGNAME}_DATA)
 
-mark_as_advanced(${CMAKE_FIND_PACKAGE_NAME}_INCLUDE_DIR
-                 ${CMAKE_FIND_PACKAGE_NAME}_LIBRARY_SHARED
-                 ${CMAKE_FIND_PACKAGE_NAME}_DATA)
+mark_as_advanced(${PKGNAME}_INCLUDE_DIR ${PKGNAME}_LIBRARY_SHARED
+                 ${PKGNAME}_DATA)
+
+unset(PKGNAME)
+unset(PKGENVNAME)

--- a/dependencies/Findpythia6.cmake
+++ b/dependencies/Findpythia6.cmake
@@ -8,19 +8,26 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
-find_library(${CMAKE_FIND_PACKAGE_NAME}_LIBRARY_SHARED
-             NAMES libpythia6.so libpythia6.dylib)
+set(PKGNAME ${CMAKE_FIND_PACKAGE_NAME})
+string(TOUPPER ${PKGNAME} PKGENVNAME)
 
-if(${CMAKE_FIND_PACKAGE_NAME}_LIBRARY_SHARED)
+find_library(${PKGNAME}_LIBRARY_SHARED
+             NAMES libpythia6.so libpythia6.dylib
+             PATHS $ENV{${PKGENVNAME}_ROOT}/lib)
+
+if(${PKGNAME}_LIBRARY_SHARED)
   add_library(pythia6 SHARED IMPORTED)
   set_target_properties(pythia6
                         PROPERTIES IMPORTED_LOCATION
-                                   ${${CMAKE_FIND_PACKAGE_NAME}_LIBRARY_SHARED})
+                                   ${${PKGNAME}_LIBRARY_SHARED})
 endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
-  ${CMAKE_FIND_PACKAGE_NAME}
-  REQUIRED_VARS ${CMAKE_FIND_PACKAGE_NAME}_LIBRARY_SHARED)
+  ${PKGNAME}
+  REQUIRED_VARS ${PKGNAME}_LIBRARY_SHARED)
 
-mark_as_advanced(${CMAKE_FIND_PACKAGE_NAME}_LIBRARY_SHARED)
+mark_as_advanced(${PKGNAME}_LIBRARY_SHARED)
+
+unset(PKGNAME)
+unset(PKGENVNAME)

--- a/dependencies/O2Dependencies.cmake
+++ b/dependencies/O2Dependencies.cmake
@@ -11,6 +11,7 @@
 include_guard()
 
 include("${CMAKE_CURRENT_LIST_DIR}/O2RecipeAdapter.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/O2TestsAdapter.cmake")
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR} ${CMAKE_MODULE_PATH})
 

--- a/dependencies/O2RecipeAdapter.cmake
+++ b/dependencies/O2RecipeAdapter.cmake
@@ -11,20 +11,9 @@
 # FIXME: this part should disappear when we merge all this new cmake stuff and
 # we change the o2.sh recipe accordingly.
 #
-# We "adapt" two things here :
-#
-# 1. we unset most of the -D variables that were passed to cmake so our auto-
-#   detection has a chance to work. Should not be needed in the long run if we
-#   use the correct -D set from the beginning
-#
-# 1. we patch those tests that require some environment (most notably the O2_ROOT
-#   variable) to convert from O2_ROOT pointing to build tree to O2_ROOT pointing
-#   to install tree. Should not be needed in the long run if we consider (as we
-#   should, I would argue) that tests are running off the build tree, before
-#   installation (and are not installed, as there's probably no point in doing
-#   so) Should not be needed in the long run if we consider (as we should, I
-#   would argue) that tests are running off the build tree, before installation
-#   (and are not installed, as there's probably no point in doing so)
+# we unset most of the -D variables that were passed to cmake so our auto-
+# detection has a chance to work. Should not be needed in the long run if we use
+# the correct -D set from the beginning
 #
 
 function(o2_show_env var)
@@ -43,11 +32,12 @@ macro(o2_unset var)
   unset(${var})
 endmacro()
 
-message(STATUS "!!!")
-message(STATUS "!!! Using O2RecipeAdapter - this should be only temporary")
-message(STATUS "!!!")
-
 if(ALICEO2_MODULAR_BUILD)
+
+  message(STATUS "!!!")
+  message(STATUS "!!! Using O2RecipeAdapter - this should be only temporary")
+  message(STATUS "!!!")
+
   #
   # we use the presence of ALICEO2_MODULAR_BUILD as a signal that we are using
   # the old recipe and we assume Common_O2_ROOT is defined and can be used to
@@ -107,23 +97,3 @@ if(ALICEO2_MODULAR_BUILD)
   o2_show_env(PATH)
 
 endif()
-
-if(DEFINED ENV{ALIBUILD_O2_TESTS} AND PROJECT_NAME STREQUAL "O2")
-  message(STATUS "!!!")
-  message(
-    STATUS
-      "!!! ALIBUILD_O2_TESTS detected. Will patch my tests so they work off the install tree"
-    )
-  configure_file(${CMAKE_SOURCE_DIR}/tests/tmp-patch-tests-environment.sh.in
-                 tmp-patch-tests-environment.sh)
-  install(
-    CODE [[ execute_process(COMMAND bash tmp-patch-tests-environment.sh) ]])
-
-    install(CODE
-            [[ execute_process(COMMAND ldd ${ROOT_rootcling_CMD}) ]])
-
-    install(CODE
-            [[ execute_process(COMMAND otool -L ${ROOT_rootcling_CMD}) ]])
-endif()
-
-message(STATUS "!!!")

--- a/dependencies/O2TestsAdapter.cmake
+++ b/dependencies/O2TestsAdapter.cmake
@@ -1,0 +1,40 @@
+# Copyright CERN and copyright holders of ALICE O2. This software is distributed
+# under the terms of the GNU General Public License v3 (GPL Version 3), copied
+# verbatim in the file "COPYING".
+#
+# See http://alice-o2.web.cern.ch/license for full licensing information.
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization or
+# submit itself to any jurisdiction.
+
+# We patch those tests that require some environment (most notably the O2_ROOT
+# variable) to convert from O2_ROOT pointing to build tree to O2_ROOT pointing
+# to install tree. Should not be needed in the long run if we consider (as we
+# should, I would argue) that tests are running off the build tree, before
+# installation (and are not installed, as there's probably no point in doing so)
+# Should not be needed in the long run if we consider (as we should, I would
+# argue) that tests are running off the build tree, before installation (and are
+# not installed, as there's probably no point in doing so)
+#
+
+include_guard()
+
+if(DEFINED ENV{ALIBUILD_O2_TESTS} AND PROJECT_NAME STREQUAL "O2")
+  message(STATUS "!!!")
+  message(
+    STATUS
+      "!!! ALIBUILD_O2_TESTS detected. Will patch my tests so they work off the install tree"
+    )
+  configure_file(${CMAKE_SOURCE_DIR}/tests/tmp-patch-tests-environment.sh.in
+                 tmp-patch-tests-environment.sh)
+  install(
+    CODE [[ execute_process(COMMAND bash tmp-patch-tests-environment.sh) ]])
+
+    install(CODE
+            [[ execute_process(COMMAND ldd ${ROOT_rootcling_CMD}) ]])
+
+    install(CODE
+            [[ execute_process(COMMAND otool -L ${ROOT_rootcling_CMD}) ]])
+endif()
+


### PR DESCRIPTION
Extract the test adapter (that will stay) from the recipe adapter
(that will go away at some point).

Make a couple of find modules work with the environment version of the
 <PACKAGE>_ROOT cmake variables, so they will work when the
 corresponding variable will be removed from command line used in the
 o2.sh alidist recipe (the numerous -Dxxx_ROOT= lines)