### PR TITLE
[EMCAL-571] Use time stamp within time range for read test

### DIFF
--- a/Detectors/EMCAL/calib/macros/BadChannelMap_CCDBApitest.C
+++ b/Detectors/EMCAL/calib/macros/BadChannelMap_CCDBApitest.C
@@ -66,9 +66,9 @@ void BadChannelMap_CCDBApitest(const std::string_view ccdbserver = "emcccdb-test
   // Read bad channel map from CCDB, check whether they are the same
   // using test timestamp from next run (290223)
   auto rangetest = create_timestamp(2018, 7, 30, 12, 13, 20);
-  std::cout << "Using read timestamp " << rangetest << "(omitted untill function is implemented server side)" << std::endl;
+  std::cout << "Using read timestamp " << rangetest << std::endl;
   o2::emcal::BadChannelMap* read(nullptr);
-  auto res = ccdbhandler.retrieve("EMC/BadChannelMap", metadata, rangestart);
+  auto res = ccdbhandler.retrieve("EMC/BadChannelMap", metadata, rangetest);
   if (!res) {
     std::cerr << "Failed retrieving object from CCDB" << std::endl;
     return;

--- a/Detectors/EMCAL/calib/macros/BadChannelMap_CalibDBtest.C
+++ b/Detectors/EMCAL/calib/macros/BadChannelMap_CalibDBtest.C
@@ -64,10 +64,10 @@ void BadChannelMap_CalibDBtest(const std::string_view ccdbserver = "emcccdb-test
   // Read bad channel map from CCDB, check whether they are the same
   // using test timestamp from next run (290223)
   auto rangetest = create_timestamp(2018, 7, 30, 12, 13, 20);
-  std::cout << "Using read timestamp " << rangetest << "(omitted untill function is implemented server side)" << std::endl;
+  std::cout << "Using read timestamp " << rangetest << std::endl;
   o2::emcal::BadChannelMap* read(nullptr);
   try {
-    read = ccdbhandler.readBadChannelMap(rangestart, metadata);
+    read = ccdbhandler.readBadChannelMap(rangetest, metadata);
   } catch (o2::emcal::CalibDB::ObjectNotFoundException& oe) {
     std::cerr << "CCDB error: " << oe.what() << std::endl;
     return;


### PR DESCRIPTION
As the CCDB server now support queries within the
time range the test has been adapted to use a time
stamp within the time range.