### PR TITLE
[EMCAL-575, EMCAL-578, EMCAL-581] Using a timestamp in the range of validity

### DIFF
--- a/Detectors/EMCAL/calib/macros/GainCalibrationFactors_CCDBApiTest.C
+++ b/Detectors/EMCAL/calib/macros/GainCalibrationFactors_CCDBApiTest.C
@@ -88,9 +88,9 @@ void GainCalibrationFactors_CCDBApiTest(const std::string_view ccdbserver = "emc
   ccdbhandler.store(new o2::TObjectWrapper<o2::emcal::GainCalibrationFactors>(gcf), "EMC/GainCalibFactors", metadata, rangestart, rangeend);
 
   // Read gain calibration factors from CCDB, check whether they are the same
-  auto rangetest = create_timestamp(2018, 11, 3, 13, 51, 41); //LHC18q
-  //auto rangetest = create_timestamp(2015, 11, 19, 15, 55, 58); //LHC15
-  std::cout << "Using read timestamp " << rangetest << "(omitted untill function is implemented server side)" << std::endl;
+  auto rangetest = create_timestamp(2018, 11, 16, 20, 55, 3); //LHC18q run 296273
+  //auto rangetest = create_timestamp(2015, 12, 9, 23, 10, 3); //LHC15 run 246583
+  std::cout << "Using read timestamp " << rangetest << std::endl;
   o2::emcal::GainCalibrationFactors* read(nullptr);
   auto res = ccdbhandler.retrieve("EMC/GainCalibFactors", metadata, rangetest);
   if (!res) {

--- a/Detectors/EMCAL/calib/macros/GainCalibrationFactors_CalibDBTest.C
+++ b/Detectors/EMCAL/calib/macros/GainCalibrationFactors_CalibDBTest.C
@@ -86,10 +86,10 @@ void GainCalibrationFactors_CalibDBTest(const std::string_view ccdbserver = "emc
   ccdbhandler.storeGainCalibFactors(gcf, metadata, rangestart, rangeend);
 
   // Read gain calibration factors from CCDB, check whether they are the same
-  auto rangetest = create_timestamp(2018, 11, 3, 13, 51, 41); //LHC18q
-  //auto rangetest = create_timestamp(2015, 11, 19, 15, 55, 58); //LHC15
+  auto rangetest = create_timestamp(2018, 11, 16, 20, 55, 3); //LHC18q run 296273
+  //auto rangetest = create_timestamp(2015, 12, 9, 23, 10, 3); //LHC15 run 246583
 
-  std::cout << "Using read timestamp " << rangetest << "(omitted untill function is implemented server side)" << std::endl;
+  std::cout << "Using read timestamp " << rangetest << std::endl;
   o2::emcal::GainCalibrationFactors* read(nullptr);
   try {
     read = ccdbhandler.readGainCalibFactors(rangetest, metadata);

--- a/Detectors/EMCAL/calib/macros/TempCalibrationParams_CCDBApiTest.C
+++ b/Detectors/EMCAL/calib/macros/TempCalibrationParams_CCDBApiTest.C
@@ -96,11 +96,11 @@ void TempCalibrationParams_CCDBApiTest(const std::string_view ccdbserver = "emcc
   ccdbhandler.store(new o2::TObjectWrapper<o2::emcal::TempCalibrationParams>(tcp), "EMC/TempCalibParams", metadata, rangestart, rangeend);
 
   // Read temperature calibration coefficients from CCDB, check whether they are the same
-  auto rangetest = create_timestamp(2018, 4, 18, 23, 58, 48); //LHC18
-  //auto rangetest = create_timestamp(2017, 5, 23, 23, 7, 44); //LHC17
-  //auto rangetest = create_timestamp(2016, 4, 23, 0, 58, 40); //LHC16
-  //auto rangetest = create_timestamp(2015, 9, 12, 5, 7, 8); //LHC15
-  std::cout << "Using read timestamp " << rangetest << "(omitted untill function is implemented server side)" << std::endl;
+  auto rangetest = create_timestamp(2018, 4, 27, 1, 5, 52); //LHC18 run 285396
+  //auto rangetest = create_timestamp(2017, 6, 12, 22, 39, 50); //LHC17 run 271777
+  //auto rangetest = create_timestamp(2016, 7, 9, 2, 0, 8); //LHC16 run 257735
+  //auto rangetest = create_timestamp(2015, 12, 9, 23, 10, 3); //LHC15 run 246583
+  std::cout << "Using read timestamp " << rangetest << std::endl;
   o2::emcal::TempCalibrationParams* read(nullptr);
   auto res = ccdbhandler.retrieve("EMC/TempCalibParams", metadata, rangetest);
   if (!res) {

--- a/Detectors/EMCAL/calib/macros/TempCalibrationParams_CalibDBTest.C
+++ b/Detectors/EMCAL/calib/macros/TempCalibrationParams_CalibDBTest.C
@@ -99,7 +99,7 @@ void TempCalibrationParams_CalibDBTest(const std::string_view ccdbserver = "emcc
   //auto rangetest = create_timestamp(2016, 4, 23, 0, 58, 40); //LHC16
   //auto rangetest = create_timestamp(2015, 9, 12, 5, 7, 8); //LHC15
 
-  std::cout << "Using read timestamp " << rangetest << "(omitted untill function is implemented server side)" << std::endl;
+  std::cout << "Using read timestamp " << rangetest << std::endl;
   o2::emcal::TempCalibrationParams* read(nullptr);
   try {
     read = ccdbhandler.readTempCalibParam(rangetest, metadata);

--- a/Detectors/EMCAL/calib/macros/TimeCalibrationParams_CCDBApiTest.C
+++ b/Detectors/EMCAL/calib/macros/TimeCalibrationParams_CCDBApiTest.C
@@ -98,9 +98,9 @@ void TimeCalibrationParams_CCDBApiTest(const std::string_view ccdbserver = "emcc
   ccdbhandler.store(new o2::TObjectWrapper<o2::emcal::TimeCalibrationParams>(tcp), "EMC/TimeCalibParams", metadata, rangestart, rangeend);
 
   // Read time calibration coefficients from CCDB, check whether they are the same
-  auto rangetest = create_timestamp(2018, 4, 18, 23, 58, 48); //LHC18b
-  //auto rangetest = create_timestamp(2017, 5, 28, 9, 6, 42); //LHC17g
-  std::cout << "Using read timestamp " << rangetest << "(omitted untill function is implemented server side)" << std::endl;
+  auto rangetest = create_timestamp(2018, 4, 21, 23, 18, 54); //LHC18b run 285165
+  //auto rangetest = create_timestamp(2017, 6, 5, 5, 25, 28); //LHC17g run 271381
+  std::cout << "Using read timestamp " << rangetest << std::endl;
   o2::emcal::TimeCalibrationParams* read(nullptr);
   auto res = ccdbhandler.retrieve("EMC/TimeCalibParams", metadata, rangetest);
   if (!res) {

--- a/Detectors/EMCAL/calib/macros/TimeCalibrationParams_CalibDBTest.C
+++ b/Detectors/EMCAL/calib/macros/TimeCalibrationParams_CalibDBTest.C
@@ -96,10 +96,10 @@ void TimeCalibrationParams_CalibDBTest(const std::string_view ccdbserver = "emcc
   ccdbhandler.storeTimeCalibParam(tcp, metadata, rangestart, rangeend);
 
   // Read time calibration coefficients from CCDB, check whether they are the same
-  auto rangetest = create_timestamp(2018, 4, 18, 23, 58, 48); //LHC18b
-  //auto rangetest = create_timestamp(2017, 5, 28, 9, 6, 42); //LHC17g
+  auto rangetest = create_timestamp(2018, 4, 21, 23, 18, 54); //LHC18b run 285165
+  //auto rangetest = create_timestamp(2017, 6, 5, 5, 25, 28); //LHC17g run 271381
 
-  std::cout << "Using read timestamp " << rangetest << "(omitted untill function is implemented server side)" << std::endl;
+  std::cout << "Using read timestamp " << rangetest << std::endl;
   o2::emcal::TimeCalibrationParams* read(nullptr);
   try {
     read = ccdbhandler.readTimeCalibParam(rangetest, metadata);


### PR DESCRIPTION
Using a timestamp in the range of validity of the Read/Write operations in the CCDB