### PR TITLE
[EMCAL-603] Add exception for invalid supermodule ID

### DIFF
--- a/Detectors/EMCAL/base/include/EMCALBase/Geometry.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/Geometry.h
@@ -235,8 +235,8 @@ class Geometry
   //
   EMCALSMType GetSMType(Int_t nSupMod) const
   {
-    if (nSupMod > mNumberOfSuperModules)
-      return NOT_EXISTENT;
+    if (nSupMod >= mNumberOfSuperModules)
+      throw SupermoduleIndexException(nSupMod, mNumberOfSuperModules);
     return mEMCSMSystem[nSupMod];
   }
 

--- a/Detectors/EMCAL/base/include/EMCALBase/GeometryBase.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/GeometryBase.h
@@ -11,7 +11,6 @@
 #ifndef ALICEO2_EMCAL_GEOMETRYBASE_H
 #define ALICEO2_EMCAL_GEOMETRYBASE_H
 
-#include <sstream>
 #include <string>
 
 namespace o2
@@ -41,10 +40,13 @@ class InvalidModuleException : public std::exception
   /// \brief Constructor
   /// \param nModule Module number raising the exception
   /// \param nMax Maximum amount of modules in setup
-  InvalidModuleException(Int_t nModule, Int_t nMax) : std::exception(), mModule(nModule), mMax(nMax), mMessage()
+  InvalidModuleException(Int_t nModule, Int_t nMax) : std::exception(),
+                                                      mModule(nModule),
+                                                      mMax(nMax),
+                                                      mMessage("Invalid Module [ " + std::to_string(mModule) + "|" + std::to_string(mMax) + "]")
   {
-    mMessage = "Invalid Module [ " + std::to_string(mModule) + "|" + std::to_string(mMax) + "]";
   }
+
   /// \brief Destructor
   ~InvalidModuleException() noexcept final = default;
 
@@ -66,54 +68,122 @@ class InvalidModuleException : public std::exception
   std::string mMessage; ///< Error message
 };
 
+/// \class InvalidPositionException
+/// \brief Exception handling errors due to positions not in the EMCAL area
 class InvalidPositionException : public std::exception
 {
  public:
-  InvalidPositionException(double eta, double phi) : std::exception(), mEta(eta), mPhi(phi)
+  /// \brief Constructor, setting the position raising the exception
+  /// \param eta Eta coordinate of the position
+  /// \param phi Phi coordinate of the position
+  InvalidPositionException(double eta, double phi) : std::exception(),
+                                                     mEta(eta),
+                                                     mPhi(phi),
+                                                     mMessage("Position phi (" + std::to_string(mPhi) + "), eta(" + std::to_string(mEta) + ") not im EMCAL")
   {
-    std::stringstream msgbuilder;
-    msgbuilder << "Position phi (" << mPhi << "), eta(" << mEta << ") not im EMCAL";
-    mMessage = msgbuilder.str();
   }
+
+  /// \brief Destructor
   ~InvalidPositionException() noexcept final = default;
 
-  double GetEta() const noexcept { return mEta; }
-  double GetPhi() const noexcept { return mPhi; }
+  /// \brief Access to eta coordinate raising the exception
+  /// \return Eta coordinate of the position
+  double getEta() const noexcept { return mEta; }
 
-  const char* what() const noexcept final { return mMessage.c_str(); }
+  /// \brief Access to phi corrdinate raising the exception
+  /// \return Phi coordinate of the position
+  double getPhi() const noexcept { return mPhi; }
+
+  /// \brief Access to error message of the exception
+  /// \return Error message
+  const char* what() const noexcept final { return mMessage.data(); }
 
  private:
-  double mEta = 0.;
-  double mPhi = 0.;     ///< Position (eta, phi) raising the exception
+  double mEta = 0.;     ///< Position in eta raising the exception
+  double mPhi = 0.;     ///< Position in phi raising the exception
   std::string mMessage; ///< Error message
 };
 
+/// \class InvalidCellIDException
+/// \brief Exception handling non-existing cell IDs
 class InvalidCellIDException : public std::exception
 {
  public:
-  InvalidCellIDException(Int_t cellID) : std::exception(), mCellID(cellID), mMessage()
+  /// \brief Constructor, setting cell ID raising the exception
+  /// \param cellID Cell ID raising the exception
+  InvalidCellIDException(Int_t cellID) : std::exception(),
+                                         mCellID(cellID),
+                                         mMessage("Cell ID " + std::to_string(mCellID) + " outside limits.")
   {
-    std::stringstream msgbuilder;
-    msgbuilder << "Cell ID " << mCellID << " outside limits.";
-    mMessage = msgbuilder.str();
   }
 
+  /// \brief Destructor
   ~InvalidCellIDException() noexcept final = default;
-  Int_t GetCellID() const noexcept { return mCellID; }
-  const char* what() const noexcept final { return mMessage.c_str(); }
+
+  /// \brief Access to cell ID raising the exception
+  /// \return Cell ID
+  Int_t getCellID() const noexcept { return mCellID; }
+
+  /// \brief Access to error message of the exception
+  /// \return Error message
+  const char* what() const noexcept final { return mMessage.data(); }
 
  private:
   Int_t mCellID;        ///< Cell ID raising the exception
   std::string mMessage; ///< error Message
 };
 
+/// \class InvalidSupermoduleTypeException
+/// \brief Exception handling improper or uninitialized supermodule types
 class InvalidSupermoduleTypeException : public std::exception
 {
  public:
+  /// \brief constructor
   InvalidSupermoduleTypeException() = default;
+
+  /// \brief Destructor
   ~InvalidSupermoduleTypeException() noexcept final = default;
+
+  /// \brief Access to error message of the exception
   const char* what() const noexcept final { return "Uknown SuperModule Type !!"; }
 };
+
+/// \class SupermoduleIndexException
+/// \brief Handling error due to invalid supermodule
+class SupermoduleIndexException : public std::exception
+{
+ public:
+  /// \brief Constructor, initializing the exception
+  /// \param supermodule Supermodule ID raising the exception
+  /// \param maxSupermodules Max. number of supermodules in the geometry setup
+  SupermoduleIndexException(int supermodule, int maxSupermodules) : std::exception(),
+                                                                    mSupermoduleIndex(supermodule),
+                                                                    mMaxSupermodules(maxSupermodules)
+  {
+    mMessage = "Invalid supermodule ID " + std::to_string(mSupermoduleIndex) + ", max " + std::to_string(mMaxSupermodules);
+  }
+
+  /// \brief Destructor
+  ~SupermoduleIndexException() noexcept final = default;
+
+  /// \brief Access to supermodule index raising the exception
+  /// \return Supermodule index
+  int getSupermodule() const noexcept { return mSupermoduleIndex; }
+
+  /// \brief Access to maximum number of supermodules
+  /// \return Max. number of supermodules
+  int getMaxSupermodule() const noexcept { return mMaxSupermodules; }
+
+  /// \brief Access to error message of the exception
+  /// \return Error message
+  const char* what() const noexcept final { return mMessage.data(); }
+
+ private:
+  int mSupermoduleIndex; ///< Supermodule index raising the exception
+  int mMaxSupermodules;  ///< Max. number of supermodules
+  std::string mMessage;  ///< Error message
+};
+
 } // namespace emcal
 } // namespace o2
 

--- a/Detectors/EMCAL/base/src/Geometry.cxx
+++ b/Detectors/EMCAL/base/src/Geometry.cxx
@@ -212,70 +212,60 @@ Geometry* Geometry::GetInstanceFromRunNumber(Int_t runNumber, const std::string_
 
   // printf("AliEMCALGeometry::GetInstanceFromRunNumber() - run %d, geoName <<%s>> \n",runNumber,geoName.Data());
 
-  bool showInfo = !(getenv("HLT_ONLINE_MODE") && strcmp(getenv("HLT_ONLINE_MODE"), "on") == 0);
-
   if (runNumber >= 104064 && runNumber < 140000) {
     // 2009-2010 runs
     // First year geometry, 4 SM.
 
-    if (showInfo) {
-      if (contains(geoName, "FIRSTYEARV1") && geoName != std::string("")) {
-        LOG(INFO) << "o2::emcal::Geometry::GetInstanceFromRunNumber() *** ATTENTION *** \n"
-                  << "\t Specified geometry name <<" << geoName << ">> for run " << runNumber
-                  << " is not considered! \n"
-                  << "\t In use <<EMCAL_FIRSTYEARV1>>, check run number and year";
-      } else {
-        LOG(INFO)
-          << "o2::emcal::Geometry::GetInstanceFromRunNumber() - Initialized geometry with name <<EMCAL_FIRSTYEARV1>>";
-      }
+    if (contains(geoName, "FIRSTYEARV1") && geoName != std::string("")) {
+      LOG(INFO) << "o2::emcal::Geometry::GetInstanceFromRunNumber() *** ATTENTION *** \n"
+                << "\t Specified geometry name <<" << geoName << ">> for run " << runNumber
+                << " is not considered! \n"
+                << "\t In use <<EMCAL_FIRSTYEARV1>>, check run number and year";
+    } else {
+      LOG(INFO)
+        << "o2::emcal::Geometry::GetInstanceFromRunNumber() - Initialized geometry with name <<EMCAL_FIRSTYEARV1>>";
     }
 
     return Geometry::GetInstance("EMCAL_FIRSTYEARV1", mcname, mctitle);
   } else if (runNumber >= 140000 && runNumber <= 170593) {
     // Almost complete EMCAL geometry, 10 SM. Year 2011 configuration
 
-    if (showInfo) {
-      if (contains(geoName, "COMPLETEV1") && geoName != std::string("")) {
-        LOG(INFO) << "o2::emcal::Geometry::GetInstanceFromRunNumber() *** ATTENTION *** \n"
-                  << "\t Specified geometry name <<" << geoName << ">> for run " << runNumber
-                  << " is not considered! \n"
-                  << "\t In use <<EMCAL_COMPLETEV1>>, check run number and year";
-      } else {
-        LOG(INFO)
-          << "o2::emcal::Geometry::GetInstanceFromRunNumber() - Initialized geometry with name <<EMCAL_COMPLETEV1>>";
-      }
+    if (contains(geoName, "COMPLETEV1") && geoName != std::string("")) {
+      LOG(INFO) << "o2::emcal::Geometry::GetInstanceFromRunNumber() *** ATTENTION *** \n"
+                << "\t Specified geometry name <<" << geoName << ">> for run " << runNumber
+                << " is not considered! \n"
+                << "\t In use <<EMCAL_COMPLETEV1>>, check run number and year";
+    } else {
+      LOG(INFO)
+        << "o2::emcal::Geometry::GetInstanceFromRunNumber() - Initialized geometry with name <<EMCAL_COMPLETEV1>>";
     }
     return Geometry::GetInstance("EMCAL_COMPLETEV1", mcname, mctitle);
   } else if (runNumber > 176000 && runNumber <= 197692) {
     // Complete EMCAL geometry, 12 SM. Year 2012 and on
     // The last 2 SM were not active, anyway they were there.
 
-    if (showInfo) {
-      if (contains(geoName, "COMPLETE12SMV1") && geoName != std::string("")) {
-        LOG(INFO) << "o2::emcal::Geometry::GetInstanceFromRunNumber() *** ATTENTION *** \n"
-                  << "\t Specified geometry name <<" << geoName << " >> for run " << runNumber
-                  << " is not considered! \n"
-                  << "\t In use <<EMCAL_COMPLETE12SMV1>>, check run number and year";
-      } else {
-        LOG(INFO) << "o2::emcal::Geometry::GetInstanceFromRunNumber() - Initialized geometry with name "
-                     "<<EMCAL_COMPLETE12SMV1>>";
-      }
+    if (contains(geoName, "COMPLETE12SMV1") && geoName != std::string("")) {
+      LOG(INFO) << "o2::emcal::Geometry::GetInstanceFromRunNumber() *** ATTENTION *** \n"
+                << "\t Specified geometry name <<" << geoName << " >> for run " << runNumber
+                << " is not considered! \n"
+                << "\t In use <<EMCAL_COMPLETE12SMV1>>, check run number and year";
+    } else {
+      LOG(INFO) << "o2::emcal::Geometry::GetInstanceFromRunNumber() - Initialized geometry with name "
+                   "<<EMCAL_COMPLETE12SMV1>>";
     }
     return Geometry::GetInstance("EMCAL_COMPLETE12SMV1", mcname, mctitle);
   } else // Run 2
   {
     // EMCAL + DCAL geometry, 20 SM. Year 2015 and on
 
-    if (showInfo) {
-      if (contains(geoName, "DCAL_8SM") && geoName != std::string("")) {
-        LOG(INFO) << "o2::emcal::Geometry::GetInstanceFromRunNumber() *** ATTENTION *** \n"
-                  << "\t Specified geometry name <<" << geoName << ">> for run " << runNumber
-                  << " is not considered! \n"
-                  << "\t In use <<EMCAL_COMPLETE12SMV1_DCAL_8SM>>, check run number and year";
-      } else {
-        LOG(INFO) << "o2::emcal::Geometry::GetInstanceFromRunNumber() - Initialized geometry with name "
-                     "<<EMCAL_COMPLETE12SMV1_DCAL_8SM>>";
-      }
+    if (contains(geoName, "DCAL_8SM") && geoName != std::string("")) {
+      LOG(INFO) << "o2::emcal::Geometry::GetInstanceFromRunNumber() *** ATTENTION *** \n"
+                << "\t Specified geometry name <<" << geoName << ">> for run " << runNumber
+                << " is not considered! \n"
+                << "\t In use <<EMCAL_COMPLETE12SMV1_DCAL_8SM>>, check run number and year";
+    } else {
+      LOG(INFO) << "o2::emcal::Geometry::GetInstanceFromRunNumber() - Initialized geometry with name "
+                   "<<EMCAL_COMPLETE12SMV1_DCAL_8SM>>";
     }
     return Geometry::GetInstance("EMCAL_COMPLETE12SMV1_DCAL_8SM", mcname, mctitle);
   }


### PR DESCRIPTION
Add handling for invalid supermodule ID. Used in
Geometry::GetSMType(int supermodule), but could
also be used elsewhere.

In addition:
- Documentation of existing exception in GeometryBase
- Minor cleanup in Geometry