### PR TITLE
Fix Findms_gsl.cmake

### DIFF
--- a/dependencies/Findms_gsl.cmake
+++ b/dependencies/Findms_gsl.cmake
@@ -13,7 +13,7 @@ find_path(MS_GSL_INCLUDE_DIR gsl/gsl PATH_SUFFIXES ms_gsl/include include
 
 if(NOT MS_GSL_INCLUDE_DIR)
   set(MS_GSL_FOUND FALSE)
-  message(FATAL_ERROR "MS_GSL not found")
+  message(ERROR "MS_GSL not found")
   return()
 endif()
 

--- a/dependencies/Findms_gsl.cmake
+++ b/dependencies/Findms_gsl.cmake
@@ -13,7 +13,7 @@ find_path(MS_GSL_INCLUDE_DIR gsl/gsl PATH_SUFFIXES ms_gsl/include include
 
 if(NOT MS_GSL_INCLUDE_DIR)
   set(MS_GSL_FOUND FALSE)
-  message(ERROR "MS_GSL not found")
+  message(WARNING "MS_GSL not found")
   return()
 endif()
 


### PR DESCRIPTION
No need to have a fatal if it is not found and it is not required. If it is required, the call to find_package should indicate it.