### PR TITLE
O2-738_feature GPU sorting for CUDA using thrust

### DIFF
--- a/GPU/Common/CMakeLists.txt
+++ b/GPU/Common/CMakeLists.txt
@@ -41,6 +41,15 @@ if(ALIGPU_BUILD_TYPE STREQUAL "O2")
 
   target_compile_definitions(${targetName} PRIVATE GPUCA_O2_LIB
                              GPUCA_TPC_GEOMETRY_O2 HAVE_O2HEADERS)
+  
+  # cuda test, only compile if CUDA
+  if(CUDA_ENABLED)                           
+    o2_add_test(${MODULE}
+                PUBLIC_LINK_LIBRARIES O2::${MODULE}
+                SOURCES ctest/testGPUsortCUDA.cu
+                COMPONENT_NAME GPU
+                LABELS gpu)
+  endif()
 
   install(FILES ${HDRS_CINT} ${HDRS_INSTALL} DESTINATION include/GPU)
 endif()

--- a/GPU/Common/GPUCommonAlgorithm.h
+++ b/GPU/Common/GPUCommonAlgorithm.h
@@ -14,7 +14,7 @@
 #ifndef GPUCOMMONALGORITHM_H
 #define GPUCOMMONALGORITHM_H
 
-#include "GPUDef.h"
+#include "GPUCommonDef.h"
 
 #if !defined(GPUCA_GPUCODE_DEVICE)
 #include <algorithm>
@@ -59,7 +59,13 @@ class GPUCommonAlgorithm
   template <class T, class S>
   GPUd() static void Insertionsort(T* left, T* right, const S& comp);
 };
+} // namespace gpu
+} // namespace GPUCA_NAMESPACE
 
+namespace GPUCA_NAMESPACE
+{
+namespace gpu
+{
 template <class T>
 GPUdi() void GPUCommonAlgorithm::SortSwap(GPUgeneric() T* v1, GPUgeneric() T* v2)
 {
@@ -186,6 +192,21 @@ GPUdi() void GPUCommonAlgorithm::Insertionsort(T* left, T* right, const S& comp)
   }
 }
 
+typedef GPUCommonAlgorithm CAAlgo;
+
+} // namespace gpu
+} // namespace GPUCA_NAMESPACE
+
+#ifdef __CUDACC__
+#include "GPUCommonAlgorithmCUDA.cuh"
+
+#else
+
+namespace GPUCA_NAMESPACE
+{
+namespace gpu
+{
+
 template <class T>
 GPUdi() void GPUCommonAlgorithm::sort(T* begin, T* end)
 {
@@ -236,8 +257,9 @@ GPUdi() void GPUCommonAlgorithm::sortInBlock(T* begin, T* end, const S& comp)
 #endif
 }
 
-typedef GPUCommonAlgorithm CAAlgo;
 } // namespace gpu
 } // namespace GPUCA_NAMESPACE
+
+#endif // ifdef __CUDACC__
 
 #endif

--- a/GPU/Common/GPUCommonAlgorithmCUDA.cuh
+++ b/GPU/Common/GPUCommonAlgorithmCUDA.cuh
@@ -1,0 +1,70 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file GPUCommonAlgorithmCUDA.cuh
+/// \author David Rohr
+
+#ifndef GPUCOMMONALGORITHMCUDA_CUH
+#define GPUCOMMONALGORITHMCUDA_CUH
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
+#include <thrust/sort.h>
+#include <thrust/execution_policy.h>
+#include <thrust/device_ptr.h>
+#pragma GCC diagnostic pop
+
+#include <cuda.h>
+
+namespace GPUCA_NAMESPACE
+{
+namespace gpu
+{
+
+template <class T>
+GPUdi() void GPUCommonAlgorithm::sort(T* begin, T* end)
+{
+  thrust::device_ptr<T> thrustBegin(begin);
+  thrust::device_ptr<T> thrustEnd(end);
+  thrust::sort(thrust::seq, thrustBegin, thrustEnd);
+}
+
+template <class T, class S>
+GPUdi() void GPUCommonAlgorithm::sort(T* begin, T* end, const S& comp)
+{
+  thrust::device_ptr<T> thrustBegin(begin);
+  thrust::device_ptr<T> thrustEnd(end);
+  thrust::sort(thrust::seq, thrustBegin, thrustEnd, comp);
+}
+
+template <class T>
+GPUdi() void GPUCommonAlgorithm::sortInBlock(T* begin, T* end)
+{
+  if (threadIdx.x == 0 && threadIdx.y == 0 && threadIdx.z == 0) {
+    thrust::device_ptr<T> thrustBegin(begin);
+    thrust::device_ptr<T> thrustEnd(end);
+    thrust::sort(thrust::cuda::par, thrustBegin, thrustEnd);
+  }
+}
+
+template <class T, class S>
+GPUdi() void GPUCommonAlgorithm::sortInBlock(T* begin, T* end, const S& comp)
+{
+  if (threadIdx.x == 0 && threadIdx.y == 0 && threadIdx.z == 0) {
+    thrust::device_ptr<T> thrustBegin(begin);
+    thrust::device_ptr<T> thrustEnd(end);
+    thrust::sort(thrust::cuda::par, thrustBegin, thrustEnd, comp);
+  }
+}
+
+} // namespace gpu
+} // namespace GPUCA_NAMESPACE
+
+#endif

--- a/GPU/Common/ctest/testGPUsortCUDA.cu
+++ b/GPU/Common/ctest/testGPUsortCUDA.cu
@@ -1,0 +1,142 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file testGPUsortCUDA.cu
+/// \author ...
+
+#define GPUCA_GPUTYPE_PASCAL
+
+#define BOOST_TEST_MODULE Test GPUCommonAlgorithm Sorting CUDA
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include <iostream>
+#include <cstring>
+#include <boost/test/unit_test.hpp>
+#include "GPUCommonAlgorithm.h"
+
+///////////////////////////////////////////////////////////////
+// Test setup and tear down
+///////////////////////////////////////////////////////////////
+
+static constexpr float TOLERANCE = 10 * std::numeric_limits<float>::epsilon();
+
+cudaError_t cudaCheckError(cudaError_t cudaErrorCode)
+{
+  if (cudaErrorCode != cudaSuccess) {
+    std::cerr << "ErrorCode " << cudaErrorCode << " " << cudaGetErrorName(cudaErrorCode) << ": " << cudaGetErrorString(cudaErrorCode) << std::endl;
+    exit(-1);
+  }
+  return cudaErrorCode;
+}
+
+struct TestEnvironment {
+  TestEnvironment() : size(101), data(nullptr), sorted(size)
+  {
+    cudaCheckError(cudaMallocManaged(&data, size * sizeof(float)));
+
+    // create an array of unordered floats with negative and positive values
+    for (size_t i = 0; i < size; i++) {
+      data[i] = size / 2 - i;
+    }
+    // create copy
+    std::memcpy(sorted.data(), data, size * sizeof(float));
+    // sort
+    std::sort(sorted.begin(), sorted.end());
+  }
+
+  ~TestEnvironment()
+  {
+    cudaFree(data);
+  };
+
+  const size_t size;
+  float* data;
+  std::vector<float> sorted;
+};
+
+template <typename T>
+void testAlmostEqualArray(T* correct, T* testing, size_t size)
+{
+  for (size_t i = 0; i < size; i++) {
+    if (std::fabs(correct[i]) < TOLERANCE) {
+      BOOST_CHECK_SMALL(testing[i], TOLERANCE);
+    } else {
+      BOOST_CHECK_CLOSE(correct[i], testing[i], 1.0 / TOLERANCE);
+    }
+  }
+}
+
+///////////////////////////////////////////////////////////////
+
+__global__ void sortInThread(float* data, size_t dataLength)
+{
+  // make sure only one thread is working on this.
+  if (blockIdx.x == 0 && blockIdx.y == 0 && blockIdx.z == 0 && threadIdx.x == 0 && threadIdx.y == 0 && threadIdx.z == 0) {
+    o2::gpu::CAAlgo::sort(data, data + dataLength);
+  }
+}
+
+__global__ void sortInThreadWithOperator(float* data, size_t dataLength)
+{
+  // make sure only one thread is working on this.
+  if (blockIdx.x == 0 && blockIdx.y == 0 && blockIdx.z == 0 && threadIdx.x == 0 && threadIdx.y == 0 && threadIdx.z == 0) {
+    o2::gpu::CAAlgo::sort(data, data + dataLength, [](float a, float b) { return a < b; });
+  }
+}
+
+///////////////////////////////////////////////////////////////
+
+__global__ void sortInBlock(float* data, size_t dataLength)
+{
+  o2::gpu::CAAlgo::sortInBlock<float>(data, data + dataLength);
+}
+
+__global__ void sortInBlockWithOperator(float* data, size_t dataLength)
+{
+  o2::gpu::CAAlgo::sortInBlock(data, data + dataLength, [](float a, float b) { return a < b; });
+}
+///////////////////////////////////////////////////////////////
+
+BOOST_AUTO_TEST_SUITE(TestsortInThread)
+
+BOOST_FIXTURE_TEST_CASE(GPUsortThreadCUDA, TestEnvironment)
+{
+  sortInThread<<<1, 1>>>(data, size);
+  BOOST_CHECK_EQUAL(cudaCheckError(cudaDeviceSynchronize()), CUDA_SUCCESS);
+  testAlmostEqualArray(sorted.data(), data, size);
+}
+
+BOOST_FIXTURE_TEST_CASE(GPUsortThreadOperatorCUDA, TestEnvironment)
+{
+  sortInThreadWithOperator<<<1, 1>>>(data, size);
+  BOOST_CHECK_EQUAL(cudaCheckError(cudaDeviceSynchronize()), CUDA_SUCCESS);
+  testAlmostEqualArray(sorted.data(), data, size);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(TestsortInBlock)
+
+BOOST_FIXTURE_TEST_CASE(GPUsortBlockCUDA, TestEnvironment)
+{
+  sortInBlock<<<1, 128>>>(data, size);
+  BOOST_CHECK_EQUAL(cudaCheckError(cudaDeviceSynchronize()), CUDA_SUCCESS);
+  testAlmostEqualArray(sorted.data(), data, size);
+}
+
+BOOST_FIXTURE_TEST_CASE(GPUsortBlockOperatorCUDA, TestEnvironment)
+{
+  sortInBlockWithOperator<<<1, 128>>>(data, size);
+  BOOST_CHECK_EQUAL(cudaCheckError(cudaDeviceSynchronize()), CUDA_SUCCESS);
+  testAlmostEqualArray(sorted.data(), data, size);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/GPU/GPUTracking/DataCompression/GPUTPCCompressionKernels.h
+++ b/GPU/GPUTracking/DataCompression/GPUTPCCompressionKernels.h
@@ -47,7 +47,7 @@ class GPUTPCCompressionKernels : public GPUKernelTemplate
   GPUd() static void Thread(int nBlocks, int nThreads, int iBlock, int iThread, GPUsharedref() GPUTPCSharedMemory& smem, processorType& processors);
 #endif
 
- protected:
+ public:
   template <int I>
   class GPUTPCCompressionKernels_Compare
   {


### PR DESCRIPTION
First PR concerning feature request [O2-738_feature](https://alice.its.cern.ch/jira/browse/O2-738). 

Includes CUDA specific per thread and per threadblock sorting using thrust libraries and adds tests.