### PR TITLE
Add first example for TPC QC analysis

### DIFF
--- a/Detectors/TPC/qc/CMakeLists.txt
+++ b/Detectors/TPC/qc/CMakeLists.txt
@@ -8,10 +8,17 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
-add_subdirectory(base)
-add_subdirectory(reconstruction)
-add_subdirectory(calibration)
-add_subdirectory(simulation)
-add_subdirectory(monitor)
-add_subdirectory(workflow)
-add_subdirectory(qc)
+o2_add_library(TPCQC
+               SOURCES src/PID.cxx
+               PUBLIC_LINK_LIBRARIES O2::TPCBase)
+
+
+
+o2_target_root_dictionary(TPCQC
+                          HEADERS include/TPCQC/PID.h)
+
+o2_add_test(PID
+            COMPONENT_NAME tpc
+            PUBLIC_LINK_LIBRARIES O2::TPCQC
+            SOURCES test/test_PID.cxx
+            LABELS tpc)

--- a/Detectors/TPC/qc/include/TPCQC/PID.h
+++ b/Detectors/TPC/qc/include/TPCQC/PID.h
@@ -1,0 +1,62 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// @file   PID.h
+/// @author Jens Wiechula, Jens.Wiechula@ikf.uni-frankfurt.de
+///
+
+#ifndef AliceO2_TPC_ROC_H
+#define AliceO2_TPC_ROC_H
+
+//root includes
+#include "TH1F.h"
+//o2 includes
+#include "DataFormatsTPC/Defs.h"
+#include "DataFormatsTPC/TrackTPC.h"
+#include "TPCBase/Sector.h"
+
+namespace o2
+{
+namespace tpc
+{
+namespace qc
+{
+
+/// Keep QC information for PID related observables
+///
+/// This is just a dummy implementation to get started with QC
+/// @author Jens Wiechula, Jens.Wiechula@ikf.uni-frankfurt.de
+class PID
+{
+ public:
+  PID();
+
+  bool processTrack(o2::tpc::TrackTPC const& track);
+
+  /// Initialize all histograms
+  void initializeHistograms();
+
+  /// Reset all histograms
+  void resetHistograms();
+
+  std::vector<TH1F>& getHistograms1D() { return mHist1D; }
+  const std::vector<TH1F>& getHistograms1D() const { return mHist1D; }
+
+ private:
+  std::vector<TH1F> mHist1D;
+
+  ClassDefNV(PID, 1)
+};
+} // namespace qc
+} // namespace tpc
+} // namespace o2
+
+#endif

--- a/Detectors/TPC/qc/src/PID.cxx
+++ b/Detectors/TPC/qc/src/PID.cxx
@@ -1,0 +1,57 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <cmath>
+
+#include "DataFormatsTPC/dEdxInfo.h"
+
+#include "TPCQC/PID.h"
+
+ClassImp(o2::tpc::qc::PID);
+
+using namespace o2::tpc::qc;
+
+PID::PID() : mHist1D{}
+{
+}
+
+void PID::initializeHistograms()
+{
+  mHist1D.emplace_back("hMIP", "MIP position;MIP (ADC counts)", 100, 0, 100);
+}
+
+void PID::resetHistograms()
+{
+  for (auto& hist : mHist1D) {
+    hist.Reset();
+  }
+}
+
+bool PID::processTrack(o2::tpc::TrackTPC const& track)
+{
+  // ===| variables required for cutting and filling |===
+  const auto p = track.getP();
+  const auto dEdx = track.getdEdx().dEdxTotTPC;
+
+  // ===| cuts |===
+  // hard coded cuts. Should be more configural in future
+  if (std::abs(p - 0.5) > 0.05) {
+    return false;
+  }
+
+  if (dEdx > 70) {
+    return false;
+  }
+
+  // ===| histogram filling |===
+  mHist1D[0].Fill(dEdx);
+
+  return true;
+}

--- a/Detectors/TPC/qc/src/TPCQCLinkDef.h
+++ b/Detectors/TPC/qc/src/TPCQCLinkDef.h
@@ -1,0 +1,19 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifdef __CLING__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class o2::tpc::qc::PID+;
+
+#endif

--- a/Detectors/TPC/qc/test/test_PID.cxx
+++ b/Detectors/TPC/qc/test/test_PID.cxx
@@ -1,0 +1,22 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test TPC QC
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include "DataFormatsTPC/Defs.h"
+#include "TPCQC/PID.h"
+#include <cmath>
+
+BOOST_AUTO_TEST_CASE(ReadWriteROOTFile)
+{
+  o2::tpc::qc::PID pid;
+}


### PR DESCRIPTION
The idea is to seprate the logic of the QC analysis from the processing.
The logical part of the analysis, histogram filling, cuts etc. should
stay in O2. Those classes will then be used in the QC tasks.