### PR TITLE
CcdbApi: new features and sanitizing

### DIFF
--- a/CCDB/CMakeLists.txt
+++ b/CCDB/CMakeLists.txt
@@ -27,6 +27,7 @@ o2_add_library(CCDB
                        src/CcdbApi.cxx
                        src/ConditionsMQServer.cxx
                        src/ConditionsMQClient.cxx
+                       src/CCDBTimeStampUtils.cxx
                        src/request.proto
                PUBLIC_LINK_LIBRARIES FairMQ::FairMQ
                                      protobuf::libprotobuf
@@ -59,6 +60,7 @@ o2_target_root_dictionary(CCDB
                                   include/CCDB/XmlHandler.h
                                   include/CCDB/TObjectWrapper.h
                                   include/CCDB/CcdbApi.h
+                                  include/CCDB/CCDBTimeStampUtils.h
                                   test/TestClass.h)
 
 o2_add_executable(conditions-server
@@ -80,7 +82,7 @@ o2_data_file(COPY config/conditions-server.json config/conditions-client.json
                   example/fill_local_ocdb.C
              DESTINATION config)
 
-if(NOT APPLE)
+#if(NOT APPLE)
   o2_add_test(WriteReadAny
               SOURCES test/testWriteReadAny.cxx
               COMPONENT_NAME ccdb
@@ -92,4 +94,4 @@ if(NOT APPLE)
               COMPONENT_NAME ccdb
               PUBLIC_LINK_LIBRARIES O2::CCDB
               LABELS ccdb)
-endif()
+#endif()

--- a/CCDB/README.md
+++ b/CCDB/README.md
@@ -66,7 +66,7 @@ api.snapshot("FOO", "/tmp/CCDBSnapshot/", 12345);
 
 // read from snapshot by saying
 CcdbApi snapshotapi;
-snaptshotapi.initInSnapshotMode("/tmp/CCDBSnapshot");
+snaptshotapi.init("file:///tmp/CCDBSnapshot");
 
 // reading still works just like this (you have to specify the type)
 auto deadpixelsback = snapshotapi.retrieveFromTFileAny<o2::FOO::DeadPixelMap>("FOO/DeadPixels", metadata);

--- a/CCDB/include/CCDB/CCDBTimeStampUtils.h
+++ b/CCDB/include/CCDB/CCDBTimeStampUtils.h
@@ -1,0 +1,37 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+//
+// Created by Sandro Wenzel on 2019-08-20.
+//
+
+#ifndef O2_CCDBTIMESTAMPUTILS_H
+#define O2_CCDBTIMESTAMPUTILS_H
+
+/// a couple of static helper functions to create timestamp values for CCDB queries
+
+namespace o2
+{
+namespace ccdb
+{
+
+/// returns the timestamp in long corresponding to "now + secondsInFuture"
+long getFutureTimestamp(int secondsInFuture);
+
+/// returns the timestamp in long corresponding to "now"
+long getCurrentTimestamp();
+
+/// \brief Converting time into numerical time stamp representation
+long createTimestamp(int year, int month, int day, int hour, int minutes, int seconds);
+
+} // namespace ccdb
+} // namespace o2
+
+#endif //O2_CCDBTIMESTAMPUTILS_H

--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -50,20 +50,9 @@ class CcdbApi //: public DatabaseInterface
   /**
    * Initialize connection to CCDB
    *
-   * @param host The URL to the CCDB (e.g. "ccdb-test.cern.ch:8080")
+   * @param host The URL to the CCDB (e.g. "ccdb-test.cern.ch:8080" or to a local snapshot "file:///tmp/CCDBSnapshot")
    */
   void init(std::string const& host);
-
-  /**
-   * Initialize in local mode; Objects will be retrieved from snapshot
-   *
-   * @param snapshotpath (e.g. "/path/CCDBSnapshot/")
-   */
-  void initInSnapshotMode(std::string const& snapshotpath)
-  {
-    mSnapshotTopPath = snapshotpath;
-    mInSnapshotMode = true;
-  }
 
   /**
    * Stores an object in the CCDB as a streamed object, not a TFile.
@@ -215,6 +204,17 @@ class CcdbApi //: public DatabaseInterface
   void retrieveBlob(std::string const& path, std::string const& targetdir, std::map<std::string, std::string> const& metadata, long timestamp) const;
 
  private:
+  /**
+   * Initialize in local mode; Objects will be retrieved from snapshot
+   *
+   * @param snapshotpath (e.g. "/path/CCDBSnapshot/")
+   */
+  void initInSnapshotMode(std::string const& snapshotpath)
+  {
+    mSnapshotTopPath = snapshotpath;
+    mInSnapshotMode = true;
+  }
+
   /**
    * Transform and return a string representation of the given timestamp.
    *

--- a/CCDB/src/CCDBTimeStampUtils.cxx
+++ b/CCDB/src/CCDBTimeStampUtils.cxx
@@ -1,0 +1,56 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+//
+// Created by Sandro Wenzel on 2019-08-20.
+//
+#include <CCDB/CCDBTimeStampUtils.h>
+#include <chrono>
+#include <ctime>
+
+namespace o2::ccdb
+{
+
+long getFutureTimestamp(int secondsInFuture)
+{
+  std::chrono::seconds sec(secondsInFuture);
+  auto future = std::chrono::system_clock::now() + sec;
+  auto future_ms = std::chrono::time_point_cast<std::chrono::milliseconds>(future);
+  auto epoch = future_ms.time_since_epoch();
+  auto value = std::chrono::duration_cast<std::chrono::milliseconds>(epoch);
+  return value.count();
+}
+
+/// returns the timestamp in long corresponding to "now"
+long getCurrentTimestamp()
+{
+  auto now = std::chrono::system_clock::now();
+  auto now_ms = std::chrono::time_point_cast<std::chrono::milliseconds>(now);
+  auto epoch = now_ms.time_since_epoch();
+  auto value = std::chrono::duration_cast<std::chrono::milliseconds>(epoch);
+  return value.count();
+}
+
+/// \brief Converting time into numerical time stamp representation
+long createTimestamp(int year, int month, int day, int hour, int minutes, int seconds)
+{
+  struct tm timeinfo;
+  timeinfo.tm_year = year;
+  timeinfo.tm_mon = month;
+  timeinfo.tm_mday = day;
+  timeinfo.tm_hour = hour;
+  timeinfo.tm_min = minutes;
+  timeinfo.tm_sec = seconds;
+
+  time_t timeformat = mktime(&timeinfo);
+  return static_cast<long>(timeformat);
+}
+
+} // namespace o2::ccdb

--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -10,7 +10,7 @@
 
 ///
 /// \file   CcdbApi.cxx
-/// \author Barthelemy von Haller
+/// \author Barthelemy von Haller, Sandro Wenzel
 ///
 
 #include "CCDB/CcdbApi.h"
@@ -29,6 +29,10 @@
 #include <TTree.h>
 #include <FairLogger.h>
 #include <TError.h>
+#include <TClass.h>
+#include <CCDB/CCDBTimeStampUtils.h>
+#include <algorithm>
+#include <boost/filesystem.hpp>
 
 namespace o2
 {
@@ -36,10 +40,6 @@ namespace ccdb
 {
 
 using namespace std;
-
-CcdbApi::CcdbApi() : mUrl("")
-{
-}
 
 CcdbApi::~CcdbApi()
 {
@@ -52,7 +52,7 @@ void CcdbApi::curlInit()
   curl_global_init(CURL_GLOBAL_DEFAULT);
 }
 
-void CcdbApi::init(std::string host)
+void CcdbApi::init(std::string const& host)
 {
   mUrl = host;
   curlInit();
@@ -72,8 +72,8 @@ std::string sanitizeObjectName(const std::string& objectName)
   return tmpObjectName;
 }
 
-void CcdbApi::store(TObject* rootObject, std::string path, std::map<std::string, std::string> metadata,
-                    long startValidityTimestamp, long endValidityTimestamp, bool doStoreStreamerInfo)
+void CcdbApi::store(TObject* rootObject, std::string const& path, std::map<std::string, std::string> const& metadata,
+                    long startValidityTimestamp, long endValidityTimestamp, bool doStoreStreamerInfo) const
 {
   // Serialize the object
   TMessage message(kMESS_OBJECT);
@@ -96,7 +96,7 @@ void CcdbApi::store(TObject* rootObject, std::string path, std::map<std::string,
   string fullUrl = getFullUrlForStorage(sanitizedPath, metadata, sanitizedStartValidityTimestamp, sanitizedEndValidityTimestamp);
 
   // Curl preparation
-  CURL* curl;
+  CURL* curl = nullptr;
   struct curl_httppost* formpost = nullptr;
   struct curl_httppost* lastptr = nullptr;
   struct curl_slist* headerlist = nullptr;
@@ -137,8 +137,97 @@ void CcdbApi::store(TObject* rootObject, std::string path, std::map<std::string,
   }
 }
 
-void CcdbApi::storeAsTFile(TObject* rootObject, std::string path, std::map<std::string, std::string> metadata,
-                           long startValidityTimestamp, long endValidityTimestamp)
+void CcdbApi::storeAsTFile_impl(void* obj, std::type_info const& tinfo, std::string const& path, std::map<std::string, std::string> const& metadata,
+                                long startValidityTimestamp, long endValidityTimestamp) const
+{
+  // We need the TClass for this type; will verify if dictionary exists
+  auto tcl = TClass::GetClass(tinfo);
+  if (!tcl) {
+    std::cerr << "Could not retrieve ROOT dictionary for type " << tinfo.name() << " aborting to write to CCDB";
+    return;
+  }
+
+  // Prepare file name (for now the name corresponds to the name stored by TClass)
+  string objectName = string(tcl->GetName());
+  utils::trim(objectName);
+  string tmpFileName = objectName + "_" + getTimestampString(getCurrentTimestamp()) + ".root";
+#if ROOT_VERSION_CODE < ROOT_VERSION(6, 18, 0)
+  TMemFile memFile(tmpFileName.c_str(), "RECREATE");
+#else
+  size_t memFileBlockSize = 1024; // 1KB
+  TMemFile memFile(tmpFileName.c_str(), "RECREATE", "", ROOT::RCompressionSetting::EDefaults::kUseGeneralPurpose,
+                   memFileBlockSize);
+#endif
+  if (memFile.IsZombie()) {
+    cerr << "Error opening file " << tmpFileName << ", we can't store object " << objectName << endl;
+    memFile.Close();
+    return;
+  }
+  memFile.WriteObjectAny(obj, tcl, objectName.c_str());
+  memFile.Close();
+
+  // Prepare Buffer
+  void* buffer = malloc(memFile.GetSize());
+  memFile.CopyTo(buffer, memFile.GetSize());
+
+  // Prepare URL
+  long sanitizedStartValidityTimestamp = startValidityTimestamp;
+  if (startValidityTimestamp == -1) {
+    cout << "Start of Validity not set, current timestamp used." << endl;
+    sanitizedStartValidityTimestamp = getCurrentTimestamp();
+  }
+  long sanitizedEndValidityTimestamp = endValidityTimestamp;
+  if (endValidityTimestamp == -1) {
+    cout << "End of Validity not set, start of validity plus 1 year used." << endl;
+    sanitizedEndValidityTimestamp = getFutureTimestamp(60 * 60 * 24 * 365);
+  }
+  string fullUrl = getFullUrlForStorage(path, metadata, sanitizedStartValidityTimestamp, sanitizedEndValidityTimestamp);
+  std::cout << "FULL URL " << fullUrl << "\n";
+
+  // Curl preparation
+  CURL* curl = nullptr;
+  struct curl_httppost* formpost = nullptr;
+  struct curl_httppost* lastptr = nullptr;
+  struct curl_slist* headerlist = nullptr;
+  static const char buf[] = "Expect:";
+  curl_formadd(&formpost,
+               &lastptr,
+               CURLFORM_COPYNAME, "send",
+               CURLFORM_BUFFER, tmpFileName.c_str(),
+               CURLFORM_BUFFERPTR, buffer, //.Buffer(),
+               CURLFORM_BUFFERLENGTH, memFile.GetSize(),
+               CURLFORM_END);
+
+  curl = curl_easy_init();
+  headerlist = curl_slist_append(headerlist, buf);
+  if (curl != nullptr) {
+    /* what URL that receives this POST */
+    curl_easy_setopt(curl, CURLOPT_URL, fullUrl.c_str());
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headerlist);
+    curl_easy_setopt(curl, CURLOPT_HTTPPOST, formpost);
+
+    /* Perform the request, res will get the return code */
+    CURLcode res = curl_easy_perform(curl);
+    /* Check for errors */
+    if (res != CURLE_OK) {
+      fprintf(stderr, "curl_easy_perform() failed: %s\n",
+              curl_easy_strerror(res));
+    }
+
+    /* always cleanup */
+    curl_easy_cleanup(curl);
+
+    /* then cleanup the formpost chain */
+    curl_formfree(formpost);
+    /* free slist */
+    curl_slist_free_all(headerlist);
+  } else {
+    cerr << "curl initialization failure" << endl;
+  }
+}
+
+void CcdbApi::storeAsTFile(TObject* rootObject, std::string const& path, std::map<std::string, std::string> const& metadata,
+                           long startValidityTimestamp, long endValidityTimestamp) const
 {
   // Prepare file
   string objectName = string(rootObject->GetName());
@@ -219,7 +308,7 @@ void CcdbApi::storeAsTFile(TObject* rootObject, std::string path, std::map<std::
 }
 
 string CcdbApi::getFullUrlForStorage(const string& path, const map<string, string>& metadata,
-                                     long startValidityTimestamp, long endValidityTimestamp)
+                                     long startValidityTimestamp, long endValidityTimestamp) const
 {
   // Prepare timestamps
   string startValidityString = getTimestampString(startValidityTimestamp < 0 ? getCurrentTimestamp() : startValidityTimestamp);
@@ -234,8 +323,13 @@ string CcdbApi::getFullUrlForStorage(const string& path, const map<string, strin
 }
 
 // todo make a single method of the one above and below
-string CcdbApi::getFullUrlForRetrieval(const string& path, const map<string, string>& metadata, long timestamp)
+string CcdbApi::getFullUrlForRetrieval(const string& path, const map<string, string>& metadata, long timestamp) const
 {
+  if (mInSnapshotMode) {
+    string snapshotPath = mSnapshotTopPath + "/" + path + "/snapshot.root";
+    return snapshotPath;
+  }
+
   // Prepare timestamps
   string validityString = getTimestampString(timestamp < 0 ? getCurrentTimestamp() : timestamp);
   // Build URL
@@ -282,8 +376,23 @@ static size_t WriteMemoryCallback(void* contents, size_t size, size_t nmemb, voi
   return realsize;
 }
 
-TObject* CcdbApi::retrieve(std::string path, std::map<std::string, std::string> metadata,
-                           long timestamp)
+/**
+ * Callback used by CURL to store the data received from the CCDB
+ * directly into a binary file
+ * @param contents
+ * @param size
+ * @param nmemb
+ * @param userp a MemoryStruct where data is stored.
+ * @return the size of the data we received and stored at userp.
+ */
+static size_t WriteToFileCallback(void* ptr, size_t size, size_t nmemb, FILE* stream)
+{
+  size_t written = fwrite(ptr, size, nmemb, stream);
+  return written;
+}
+
+TObject* CcdbApi::retrieve(std::string const& path, std::map<std::string, std::string> const& metadata,
+                           long timestamp) const
 {
   // Note : based on https://curl.haxx.se/libcurl/c/getinmemory.html
   // Thus it does not comply to our coding guidelines as it is a copy paste.
@@ -365,7 +474,7 @@ TObject* CcdbApi::retrieve(std::string path, std::map<std::string, std::string> 
   return result;
 }
 
-TObject* CcdbApi::retrieveFromTFile(std::string path, std::map<std::string, std::string> metadata, long timestamp)
+TObject* CcdbApi::retrieveFromTFile(std::string const& path, std::map<std::string, std::string> const& metadata, long timestamp) const
 {
   // Note : based on https://curl.haxx.se/libcurl/c/getinmemory.html
   // Thus it does not comply to our coding guidelines as it is a copy paste.
@@ -411,27 +520,207 @@ TObject* CcdbApi::retrieveFromTFile(std::string path, std::map<std::string, std:
       TMemFile memFile("name", chunk.memory, chunk.size, "READ");
       gErrorIgnoreLevel = previousErrorLevel;
       if (!memFile.IsZombie()) {
-        void* object = memFile.GetObjectChecked("ccdb_object", "TObject");
-        if (object != nullptr) {
-          // Copy object in memory and make sure we detach it from the file
-          result = ((TObject*)(object))->Clone(); // the buffer will be discarded so we have to copy
-          // because objects of these classes will belong to the current directory, ie. the file, we ahve to explicitly unset the directory
-          if (result->InheritsFrom("TTree")) {
-            auto* tree = dynamic_cast<TTree*>(result);
-            tree->SetDirectory(nullptr);
-          } else if (result->InheritsFrom("TH1")) {
-            auto* h = dynamic_cast<TH1*>(result);
-            h->SetDirectory(nullptr);
-          }
-        } else {
-          LOG(ERROR) << "Couldn't retrieve the object " << path << endl;
+        result = (TObject*)extractFromTFile(memFile, "ccdb_object", TClass::GetClass("TObject"));
+        if (result == nullptr) {
+          LOG(ERROR) << "Couldn't retrieve the object " << path;
         }
         memFile.Close();
       } else {
-        LOG(DEBUG) << "Object " << path << " is not stored in a TMemFile" << endl;
+        LOG(DEBUG) << "Object " << path << " is not stored in a TMemFile";
       }
     } else {
-      LOG(ERROR) << "Invalid URL : " << fullUrl << endl;
+      LOG(ERROR) << "Invalid URL : " << fullUrl;
+    }
+  } else {
+    fprintf(stderr, "curl_easy_perform() failed: %s\n", curl_easy_strerror(res));
+  }
+
+  curl_easy_cleanup(curl_handle);
+  free(chunk.memory);
+  return result;
+}
+
+void CcdbApi::retrieveBlob(std::string const& path, std::string const& targetdir, std::map<std::string, std::string> const& metadata, long timestamp) const
+{
+  string fullUrl = getFullUrlForRetrieval(path, metadata, timestamp);
+
+  // we setup the target path for this blob
+  std::string fulltargetdir = targetdir + '/' + path;
+
+  if (!boost::filesystem::exists(fulltargetdir)) {
+    if (!boost::filesystem::create_directories(fulltargetdir)) {
+      std::cerr << "Could not create target directory " << fulltargetdir << "\n";
+    }
+  }
+
+  std::string targetpath = fulltargetdir + "/snapshot.root";
+  FILE* fp = fopen(targetpath.c_str(), "w");
+  if (!fp) {
+    std::cerr << " Could not open/create target file " << targetpath << "\n";
+    return;
+  }
+
+  // Prepare CURL
+  CURL* curl_handle;
+  CURLcode res;
+
+  /* init the curl session */
+  curl_handle = curl_easy_init();
+
+  /* specify URL to get */
+  curl_easy_setopt(curl_handle, CURLOPT_URL, fullUrl.c_str());
+
+  /* send all data to this function  */
+  curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, WriteToFileCallback);
+
+  /* we pass our file handle to the callback function */
+  curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, (void*)fp);
+
+  /* some servers don't like requests that are made without a user-agent
+         field, so we provide one */
+  curl_easy_setopt(curl_handle, CURLOPT_USERAGENT, "libcurl-agent/1.0");
+
+  /* if redirected , we tell libcurl to follow redirection */
+  curl_easy_setopt(curl_handle, CURLOPT_FOLLOWLOCATION, 1L);
+
+  /* get it! */
+  res = curl_easy_perform(curl_handle);
+
+  void* result = nullptr;
+  if (res == CURLE_OK) {
+    long response_code;
+    res = curl_easy_getinfo(curl_handle, CURLINFO_RESPONSE_CODE, &response_code);
+    if ((res == CURLE_OK) && (response_code != 404)) {
+    } else {
+      LOG(ERROR) << "Invalid URL : " << fullUrl;
+    }
+  } else {
+    fprintf(stderr, "curl_easy_perform() failed: %s\n", curl_easy_strerror(res));
+  }
+
+  if (fp) {
+    fclose(fp);
+  }
+  curl_easy_cleanup(curl_handle);
+}
+
+void CcdbApi::snapshot(std::string const& ccdbrootpath, std::string const& localDir, long timestamp) const
+{
+  // query all subpaths to ccdbrootpath
+  const auto allfolders = getAllFolders(ccdbrootpath);
+  std::map<string, string> metadata;
+  for (auto& folder : allfolders) {
+    retrieveBlob(folder, localDir, metadata, timestamp);
+  }
+}
+
+void* CcdbApi::extractFromTFile(TFile& file, std::string const& objname, TClass const* cl) const
+{
+  if (!cl) {
+    return nullptr;
+  }
+  auto object = file.GetObjectChecked(objname.c_str(), cl);
+  if (!object) {
+    return nullptr;
+  }
+  auto result = object;
+  // We need to handle some specific cases as ROOT ties them deeply
+  // to the file they are contained in
+  if (cl->InheritsFrom("TObject")) {
+    // make a clone
+    auto obj = ((TObject*)object)->Clone();
+    // detach from the file
+    if (auto tree = dynamic_cast<TTree*>(obj)) {
+      tree->SetDirectory(nullptr);
+    } else if (auto h = dynamic_cast<TH1*>(obj)) {
+      h->SetDirectory(nullptr);
+    }
+    result = obj;
+  }
+  return result;
+}
+
+void* CcdbApi::extractFromLocalFile(std::string const& filename, std::string const& objname, TClass const* tcl) const
+{
+  if (!boost::filesystem::exists(filename)) {
+    LOG(INFO) << "Local snapshot " << filename << " not found \n";
+    return nullptr;
+  }
+  TFile f(filename.c_str(), "READ");
+  return extractFromTFile(f, objname, tcl);
+}
+
+void* CcdbApi::retrieveFromTFile(std::type_info const& tinfo, std::string const& path,
+                                 std::map<std::string, std::string> const& metadata, long timestamp) const
+{
+  // We need the TClass for this type; will verify if dictionary exists
+  auto tcl = TClass::GetClass(tinfo);
+  if (!tcl) {
+    std::cerr << "Could not retrieve ROOT dictionary for type " << tinfo.name() << " aborting to read from CCDB";
+    return nullptr;
+  }
+  string objectName = string(tcl->GetName());
+  utils::trim(objectName);
+
+  // Note : based on https://curl.haxx.se/libcurl/c/getinmemory.html
+  // Thus it does not comply to our coding guidelines as it is a copy paste.
+
+  string fullUrl = getFullUrlForRetrieval(path, metadata, timestamp);
+
+  // if we are in snapshot mode we can simply open the file; extract the object and return
+  if (mInSnapshotMode) {
+    return extractFromLocalFile(fullUrl, objectName, tcl);
+  }
+
+  // Prepare CURL
+  CURL* curl_handle;
+  CURLcode res;
+  struct MemoryStruct chunk {
+    (char*)malloc(1) /*memory*/, 0 /*size*/
+  };
+
+  /* init the curl session */
+  curl_handle = curl_easy_init();
+
+  /* specify URL to get */
+  curl_easy_setopt(curl_handle, CURLOPT_URL, fullUrl.c_str());
+
+  /* send all data to this function  */
+  curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, WriteMemoryCallback);
+
+  /* we pass our 'chunk' struct to the callback function */
+  curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, (void*)&chunk);
+
+  /* some servers don't like requests that are made without a user-agent
+         field, so we provide one */
+  curl_easy_setopt(curl_handle, CURLOPT_USERAGENT, "libcurl-agent/1.0");
+
+  /* if redirected , we tell libcurl to follow redirection */
+  curl_easy_setopt(curl_handle, CURLOPT_FOLLOWLOCATION, 1L);
+
+  /* get it! */
+  res = curl_easy_perform(curl_handle);
+
+  void* result = nullptr;
+  if (res == CURLE_OK) {
+    long response_code;
+    res = curl_easy_getinfo(curl_handle, CURLINFO_RESPONSE_CODE, &response_code);
+    if ((res == CURLE_OK) && (response_code != 404)) {
+      Int_t previousErrorLevel = gErrorIgnoreLevel;
+      gErrorIgnoreLevel = kFatal;
+      TMemFile memFile("name", chunk.memory, chunk.size, "READ");
+      gErrorIgnoreLevel = previousErrorLevel;
+      if (!memFile.IsZombie()) {
+        result = extractFromTFile(memFile, objectName.c_str(), tcl);
+        if (!result) {
+          LOG(ERROR) << "Couldn't retrieve the object " << path;
+        }
+        memFile.Close();
+      } else {
+        LOG(DEBUG) << "Object " << path << " is not stored in a TMemFile";
+      }
+    } else {
+      LOG(ERROR) << "Invalid URL : " << fullUrl;
     }
   } else {
     fprintf(stderr, "curl_easy_perform() failed: %s\n", curl_easy_strerror(res));
@@ -449,7 +738,7 @@ size_t CurlWrite_CallbackFunc_StdString2(void* contents, size_t size, size_t nme
   try {
     s->resize(oldLength + newLength);
   } catch (std::bad_alloc& e) {
-    cerr << "memory error when getting data from CCDB" << endl;
+    LOG(ERROR) << "memory error when getting data from CCDB";
     return 0;
   }
 
@@ -457,7 +746,7 @@ size_t CurlWrite_CallbackFunc_StdString2(void* contents, size_t size, size_t nme
   return size * nmemb;
 }
 
-std::string CcdbApi::list(std::string path, bool latestOnly, std::string returnFormat)
+std::string CcdbApi::list(std::string const& path, bool latestOnly, std::string const& returnFormat) const
 {
   CURL* curl;
   CURLcode res;
@@ -490,33 +779,14 @@ std::string CcdbApi::list(std::string path, bool latestOnly, std::string returnF
   return result;
 }
 
-long CcdbApi::getFutureTimestamp(int secondsInFuture)
-{
-  std::chrono::seconds sec(secondsInFuture);
-  auto future = std::chrono::system_clock::now() + sec;
-  auto future_ms = std::chrono::time_point_cast<std::chrono::milliseconds>(future);
-  auto epoch = future_ms.time_since_epoch();
-  auto value = std::chrono::duration_cast<std::chrono::milliseconds>(epoch);
-  return value.count();
-}
-
-long CcdbApi::getCurrentTimestamp()
-{
-  auto now = std::chrono::system_clock::now();
-  auto now_ms = std::chrono::time_point_cast<std::chrono::milliseconds>(now);
-  auto epoch = now_ms.time_since_epoch();
-  auto value = std::chrono::duration_cast<std::chrono::milliseconds>(epoch);
-  return value.count();
-}
-
-std::string CcdbApi::getTimestampString(long timestamp)
+std::string CcdbApi::getTimestampString(long timestamp) const
 {
   stringstream ss;
   ss << timestamp;
   return ss.str();
 }
 
-void CcdbApi::deleteObject(std::string path, long timestamp)
+void CcdbApi::deleteObject(std::string const& path, long timestamp) const
 {
   CURL* curl;
   CURLcode res;
@@ -539,7 +809,7 @@ void CcdbApi::deleteObject(std::string path, long timestamp)
   }
 }
 
-void CcdbApi::truncate(std::string path)
+void CcdbApi::truncate(std::string const& path) const
 {
   CURL* curl;
   CURLcode res;
@@ -564,7 +834,7 @@ size_t write_data(void* buffer, size_t size, size_t nmemb, void* userp)
   return size * nmemb;
 }
 
-bool CcdbApi::isHostReachable()
+bool CcdbApi::isHostReachable() const
 {
   CURL* curl;
   CURLcode res;
@@ -581,6 +851,59 @@ bool CcdbApi::isHostReachable()
     curl_easy_cleanup(curl);
   }
   return result;
+}
+
+std::vector<std::string> CcdbApi::parseSubFolders(std::string const& reply) const
+{
+  // this needs some text filtering
+  // go through reply line by line until we see "SubFolders:"
+  std::stringstream ss(reply.c_str());
+  std::string line;
+  std::vector<std::string> folders;
+
+  size_t numberoflines = std::count(reply.begin(), reply.end(), '\n');
+  bool inSubFolderSection = false;
+
+  int counter = 0;
+  for (int linenumber = 0; linenumber < numberoflines; ++linenumber) {
+    std::getline(ss, line);
+    if (inSubFolderSection && line.size() > 0) {
+      // remove all white space
+      folders.push_back(sanitizeObjectName(line));
+    }
+
+    if (line.compare("Subfolders:") == 0) {
+      inSubFolderSection = true;
+    }
+  }
+  return folders;
+}
+
+namespace
+{
+void traverseAndFillFolders(CcdbApi const& api, std::string const& top, std::vector<std::string>& folders)
+{
+  // LOG(INFO) << "Querying " << top;
+  auto reply = api.list(top);
+  folders.emplace_back(top);
+  // LOG(INFO) << reply;
+  auto subfolders = api.parseSubFolders(reply);
+  if (subfolders.size() > 0) {
+    // LOG(INFO) << subfolders.size() << " folders in " << top;
+    for (auto& sub : subfolders) {
+      traverseAndFillFolders(api, sub, folders);
+    }
+  } else {
+    // LOG(INFO) << "NO subfolders in " << top;
+  }
+}
+} // namespace
+
+std::vector<std::string> CcdbApi::getAllFolders(std::string const& top) const
+{
+  std::vector<std::string> folders;
+  traverseAndFillFolders(*this, top, folders);
+  return folders;
 }
 
 } // namespace ccdb

--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -54,8 +54,18 @@ void CcdbApi::curlInit()
 
 void CcdbApi::init(std::string const& host)
 {
-  mUrl = host;
-  curlInit();
+  // if host is prefixed with "file://" this is a local snapshot
+  // in this case we init the API in snapshot (readonly) mode
+  constexpr const char* SNAPSHOTPREFIX = "file://";
+
+  if (host.substr(0, 7).compare(SNAPSHOTPREFIX) == 0) {
+    auto path = host.substr(7);
+    LOG(INFO) << "Initializing CcdbApi in snapshot readonly mode ... reading snapshot from path " << path;
+    initInSnapshotMode(path);
+  } else {
+    mUrl = host;
+    curlInit();
+  }
 }
 
 /**

--- a/CCDB/test/testCcdbApi.cxx
+++ b/CCDB/test/testCcdbApi.cxx
@@ -157,7 +157,7 @@ BOOST_AUTO_TEST_CASE(store_retrieve_TMemFile_templated_test, *utf::precondition(
 
   // b) init a new instance from the snapshot and query something from it
   o2::ccdb::CcdbApi snapshot;
-  snapshot.initInSnapshotMode(ph.string());
+  snapshot.init("file://" + ph.string());
 
   // c) query from the snapshot
   BOOST_CHECK(snapshot.retrieveFromTFileAny<o2::ccdb::IdPath>("Test/CCDBPath", f.metadata) != nullptr);

--- a/CCDB/test/testCcdbApi.cxx
+++ b/CCDB/test/testCcdbApi.cxx
@@ -18,7 +18,11 @@
 #define BOOST_TEST_DYN_LINK
 
 #include "CCDB/CcdbApi.h"
+#include "CCDB/IdPath.h"    // just as test object
+#include "CCDB/Condition.h" // just as test object
+#include "CCDB/CCDBTimeStampUtils.h"
 #include <boost/test/unit_test.hpp>
+#include <boost/filesystem.hpp>
 #include <cassert>
 #include <iostream>
 #include <cstdio>
@@ -32,6 +36,7 @@
 #include <TStreamerInfo.h>
 #include <TGraph.h>
 #include <TTree.h>
+#include <TString.h>
 
 using namespace std;
 using namespace o2::ccdb;
@@ -81,25 +86,6 @@ struct test_fixture {
   map<string, string> metadata;
 };
 
-long getFutureTimestamp(int secondsInFuture)
-{
-  std::chrono::seconds sec(secondsInFuture);
-  auto future = std::chrono::system_clock::now() + sec;
-  auto future_ms = std::chrono::time_point_cast<std::chrono::milliseconds>(future);
-  auto epoch = future_ms.time_since_epoch();
-  auto value = std::chrono::duration_cast<std::chrono::milliseconds>(epoch);
-  return value.count();
-}
-
-long getCurrentTimestamp()
-{
-  auto now = std::chrono::system_clock::now();
-  auto now_ms = std::chrono::time_point_cast<std::chrono::milliseconds>(now);
-  auto epoch = now_ms.time_since_epoch();
-  auto value = std::chrono::duration_cast<std::chrono::milliseconds>(epoch);
-  return value.count();
-}
-
 BOOST_AUTO_TEST_CASE(storeTMemFile_test, *utf::precondition(if_reachable()))
 {
   test_fixture f;
@@ -118,6 +104,105 @@ BOOST_AUTO_TEST_CASE(storeTMemFile_test, *utf::precondition(if_reachable()))
   tree->Branch("det", &a, "a/I");
   tree->Fill();
   f.api.storeAsTFile(tree, "Test/tree", f.metadata);
+}
+
+BOOST_AUTO_TEST_CASE(store_retrieve_TMemFile_templated_test, *utf::precondition(if_reachable()))
+{
+  test_fixture f;
+
+  // try to store a user defined class
+  // since we don't depend on anything, we are putting an object known to CCDB
+  o2::ccdb::IdPath path;
+  path.setPath("HelloWorld");
+
+  f.api.storeAsTFileAny(&path, "Test/CCDBPath", f.metadata);
+
+  // try to retrieve strongly typed user defined class
+  // since we don't depend on anything, we are using an object known to CCDB
+  o2::ccdb::IdPath* path2 = nullptr;
+
+  path2 = f.api.retrieveFromTFileAny<o2::ccdb::IdPath>("Test/CCDBPath", f.metadata);
+  BOOST_CHECK_NE(path2, nullptr);
+
+  // check some non-trivial data content
+  BOOST_CHECK(path2 && path2->getPathString().CompareTo("HelloWorld") == 0);
+
+  // try to query with different type and verify that we get nullptr
+  BOOST_CHECK(f.api.retrieveFromTFileAny<o2::ccdb::Condition>("Test/CCDBPath", f.metadata) == nullptr);
+
+  //-----------------------------------------------------------------------------------------------
+  // test if writing/reading complicated objects like TTree works (because of particular ownership)
+  // ----------------------------------------------------------------------------------------------
+  auto tree = new TTree("tree123", "tree123");
+  int a = 4;
+  tree->Branch("det", &a, "a/I");
+  tree->Fill();
+  f.api.storeAsTFileAny(tree, "Test/tree2", f.metadata);
+  delete tree;
+
+  // read back
+  tree = f.api.retrieveFromTFileAny<TTree>("/Test/tree2", f.metadata);
+  BOOST_CHECK(tree != nullptr);
+  BOOST_CHECK(tree != nullptr && std::strcmp(tree->GetName(), "tree123") == 0);
+  BOOST_CHECK(tree != nullptr && tree->GetEntries() == 1);
+
+  // ---------------------------
+  // test the snapshot mechanism
+  // ---------------------------
+  // a) create a local snapshot of the Test folder
+  auto ph = boost::filesystem::unique_path();
+  boost::filesystem::create_directories(ph);
+  f.api.snapshot("/Test", ph.string(), o2::ccdb::getCurrentTimestamp());
+  std::cout << "Creating snapshot at " << ph.string() << "\n";
+
+  // b) init a new instance from the snapshot and query something from it
+  o2::ccdb::CcdbApi snapshot;
+  snapshot.initInSnapshotMode(ph.string());
+
+  // c) query from the snapshot
+  BOOST_CHECK(snapshot.retrieveFromTFileAny<o2::ccdb::IdPath>("Test/CCDBPath", f.metadata) != nullptr);
+
+  {
+    auto tree = snapshot.retrieveFromTFileAny<TTree>("/Test/tree2", f.metadata);
+    BOOST_CHECK(tree != nullptr);
+    BOOST_CHECK(tree != nullptr && std::strcmp(tree->GetName(), "tree123") == 0);
+    BOOST_CHECK(tree != nullptr && tree->GetEntries() == 1);
+  }
+}
+
+/// A test verifying that the DB responds the correct result for given timestamps
+BOOST_AUTO_TEST_CASE(timestamptest, *utf::precondition(if_reachable()))
+{
+  test_fixture f;
+
+  // try to store a user defined class
+  // since we don't depend on anything, we are putting an object known to CCDB
+  o2::ccdb::IdPath path;
+  path.setPath("HelloWorld");
+
+  const long timestamp = 1000;             // inclusive start of validity
+  const long endvalidity = timestamp + 10; // exclusive end of validitiy
+  f.api.storeAsTFileAny(&path, "Test/CCDBPathUnitTest", f.metadata, timestamp, endvalidity);
+
+  // try to retrieve strongly typed user defined class
+  // since we don't depend on anything, we are using an object known to CCDB
+  o2::ccdb::IdPath* path2 = nullptr;
+
+  path2 = f.api.retrieveFromTFileAny<o2::ccdb::IdPath>("Test/CCDBPathUnitTest", f.metadata, timestamp);
+  BOOST_CHECK_NE(path2, nullptr);
+
+  // check that we get something for the whole time range
+  for (int t = timestamp; t < endvalidity; ++t) {
+    auto p = f.api.retrieveFromTFileAny<o2::ccdb::IdPath>("Test/CCDBPathUnitTest", f.metadata, t);
+    BOOST_CHECK_NE(p, nullptr);
+  }
+
+  // check that answer is null for anything outside
+  auto plower = f.api.retrieveFromTFileAny<o2::ccdb::IdPath>("Test/CCDBPathUnitTest", f.metadata, timestamp - 1);
+  BOOST_CHECK(plower == nullptr);
+
+  auto pupper = f.api.retrieveFromTFileAny<o2::ccdb::IdPath>("Test/CCDBPathUnitTest", f.metadata, endvalidity);
+  BOOST_CHECK(pupper == nullptr);
 }
 
 BOOST_AUTO_TEST_CASE(retrieveTMemFile_test, *utf::precondition(if_reachable()))
@@ -212,8 +297,8 @@ BOOST_AUTO_TEST_CASE(delete_test, *utf::precondition(if_reachable()))
   test_fixture f;
 
   auto h1 = new TH1F("object1", "object1", 100, 0, 99);
-  long from = getCurrentTimestamp();
-  long to = getFutureTimestamp(60 * 60 * 24 * 365 * 10);
+  long from = o2::ccdb::getCurrentTimestamp();
+  long to = o2::ccdb::getFutureTimestamp(60 * 60 * 24 * 365 * 10);
   f.api.store(h1, "Test/Detector", f.metadata, from, to); // test with explicit dates
   auto h2 = f.api.retrieve("Test/Detector", f.metadata);
   BOOST_CHECK(h2 != nullptr);


### PR DESCRIPTION
 CcdbApi: new features and sanitizing
    
    This commit adds the following (sometime prototypic) new functionality to CcdbApi:
    
    * ability to write/retrieve any arbitrary class T (having a ROOT
      dictionary) to the CCDB (via the TMemFile) mechanism
      - the function is offered next to existing API for the moment
      - a unit test checking this functionality was added
    
    * ability parse and return the recursive subfolder structure inside the CCDB
    
    * ability to generate a local snapshot of the CCDB (given some top level path and timestamp)
      - checked in unit test
    
    * ability to init the CCDB from the snapshot in order to serve cases when there
      is no network connection
      - works only with the new template<T> API for the moment
    
    In addition, this commit sanitizes existing code a bit:
    
    * apply const correctness
    
    * pass values by reference not by value
    
    * separate some timestamp utility functions and reduce code duplication
    
    * make object extraction from TFile standalone according to DRY principle
    
    * extend unit test to make sure any timestamp in a given interval works correctly


TODO:

- [x] update documentation
- [x]  extend unit tests
- [x] make snapshotting based on URL