### PR TITLE
Fixing the list of headers for libO2Mergers.rootmap

### DIFF
--- a/Utilities/Mergers/CMakeLists.txt
+++ b/Utilities/Mergers/CMakeLists.txt
@@ -17,13 +17,8 @@ o2_add_library(Mergers
 
 o2_target_root_dictionary(
   Mergers
-  HEADERS include/Mergers/Merger.h
-          include/Mergers/MergerConfig.h
-          include/Mergers/MergeInterface.h
+  HEADERS include/Mergers/MergeInterface.h
           include/Mergers/MergeInterfaceOverrideExample.h
-          include/Mergers/MergerInfrastructureBuilder.h
-          include/Mergers/MergerBuilder.h
-          include/Mergers/MergerCache.h
   LINKDEF include/Mergers/LinkDef.h)
 
 o2_add_executable(topology-example


### PR DESCRIPTION
There has been an occasional problem with the generation of libO2Mergers.rootmap
rootcling_wrapper.sh returned with non-zero value without any further error message.
It turned out that more header files in cmake configuration and LLinkDef  have been
inconsistent already in the original commit 7e233ec388d2b29cb05bdb3f53fd1d21b9e9c801