### PR TITLE
Introduce BasicCCDBManager as convenience access to CCDB

### DIFF
--- a/CCDB/CMakeLists.txt
+++ b/CCDB/CMakeLists.txt
@@ -27,6 +27,7 @@ o2_add_library(CCDB
                        src/CcdbApi.cxx
                        src/ConditionsMQServer.cxx
                        src/ConditionsMQClient.cxx
+                       src/BasicCCDBManager.cxx
                        src/CCDBTimeStampUtils.cxx
                        src/request.proto
                PUBLIC_LINK_LIBRARIES FairMQ::FairMQ
@@ -60,6 +61,7 @@ o2_target_root_dictionary(CCDB
                                   include/CCDB/XmlHandler.h
                                   include/CCDB/TObjectWrapper.h
                                   include/CCDB/CcdbApi.h
+                                  include/CCDB/BasicCCDBManager.h
                                   include/CCDB/CCDBTimeStampUtils.h
                                   test/TestClass.h)
 

--- a/CCDB/README.md
+++ b/CCDB/README.md
@@ -72,9 +72,38 @@ snaptshotapi.init("file:///tmp/CCDBSnapshot");
 auto deadpixelsback = snapshotapi.retrieveFromTFileAny<o2::FOO::DeadPixelMap>("FOO/DeadPixels", metadata);
 ```
 
-# Future ideas:
+## Future ideas :
 
 - [ ] offer API without need to pass metadata object
 - [ ] deprecate TMessage based API
 - [ ] code reduction or delegation between various storeAsTFile APIs
 - [ ] eventually just call the functions store/retrieve once TMessage is disabled
+
+
+# BasicCCDBManager
+
+A basic higher level class `BasicCCDBManager` is offered for convenient access to the CCDB from
+user code. This class
+* Encapsulates the timestamp.
+* Offers a more convenient `get` function to retrieve objects.
+* Is a singleton which is initialized once and can be used from any detector code.
+
+The class was written for the use-case of transport MC simulation. Typical usage should be like
+
+```c++
+// setup manager once (at start of processing) 
+auto& mgr = o2::ccdb::BasicCCDBManager::instance();
+mgr.setURL("http://ourccdbserverver.cern.ch");
+mgr.setTimestamp(timestamp_which_we_want_to_anchor_to);
+
+
+// in some FOO detector code (detector initialization)
+auto& mgr = o2::ccdb::BasicCCDBManager::instance();
+// just give the correct path and you will be served the object
+auto alignment = mgr.get<o2::FOO::GeomAlignment>("/FOO/Alignment");
+```
+
+## Future ideas / todo:
+
+- [ ] offer improved error handling / exceptions
+- [ ] do we need a store method?

--- a/CCDB/include/CCDB/BasicCCDBManager.h
+++ b/CCDB/include/CCDB/BasicCCDBManager.h
@@ -1,0 +1,90 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+//
+// Created by Sandro Wenzel on 2019-08-14.
+//
+
+#ifndef O2_BASICCDBMANAGER_H
+#define O2_BASICCDBMANAGER_H
+
+#include "CCDB/CcdbApi.h"
+#include "CCDB/CCDBTimeStampUtils.h"
+#include <string>
+#include <map>
+// #include <FairLogger.h>
+
+namespace o2::ccdb
+{
+
+/// A simple (singleton) class offering simplified access to CCDB (mainly for MC simulation)
+/// The class encapsulates timestamp and URL and is easily usable from detector code.
+class BasicCCDBManager
+{
+ public:
+  static BasicCCDBManager& instance()
+  {
+    const std::string ccdbUrl{"http://ccdb-test.cern.ch:8080"};
+    static BasicCCDBManager inst{ccdbUrl};
+    return inst;
+  }
+
+  /// set a URL to query from
+  void setURL(const std::string& url);
+
+  /// set timestamp cache for all queries
+  void setTimestamp(long t)
+  {
+    if (t >= 0) {
+      mTimestamp = t;
+    }
+  }
+
+  /// query current URL
+  std::string const& getURL() const { return mCCDBAccessor.getURL(); }
+
+  /// query timestamp
+  long getTimestamp() const { return mTimestamp; }
+
+  /// retrieve an object of type T from CCDB as stored under path and timestamp
+  template <typename T>
+  T* getForTimeStamp(std::string const& path, long timestamp) const;
+
+  /// retrieve an object of type T from CCDB as stored under path; will use the timestamp member
+  template <typename T>
+  T* get(std::string const& path) const
+  {
+    // TODO: add some error info/handling when failing
+    return getForTimeStamp<T>(path, mTimestamp);
+  }
+
+  bool isHostReachable() const { return mCCDBAccessor.isHostReachable(); }
+
+ private:
+  BasicCCDBManager(std::string const& path) : mCCDBAccessor{}
+  {
+    mCCDBAccessor.init(path);
+  }
+
+  // we access the CCDB via the CURL based C++ API
+  o2::ccdb::CcdbApi mCCDBAccessor;
+  std::map<std::string, std::string> mMetaData;     // some dummy object needed to talk to CCDB API
+  long mTimestamp{o2::ccdb::getCurrentTimestamp()}; // timestamp to be used for query (by default "now")
+  bool mCanDefault = false;                         // whether default is ok --> useful for testing purposes done standalone/isolation
+};
+
+template <typename T>
+T* BasicCCDBManager::getForTimeStamp(std::string const& path, long timestamp) const
+{
+  return mCCDBAccessor.retrieveFromTFileAny<T>(path, mMetaData, timestamp);
+}
+
+} // namespace o2::ccdb
+
+#endif //O2_BASICCCDBMANAGER_H

--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -55,6 +55,12 @@ class CcdbApi //: public DatabaseInterface
   void init(std::string const& host);
 
   /**
+   * Query current URL
+   *
+   */
+  std::string const& getURL() const { return mUrl; }
+
+  /**
    * Stores an object in the CCDB as a streamed object, not a TFile.
    *
    * @param rootObject Raw pointer to the object to store.

--- a/CCDB/src/BasicCCDBManager.cxx
+++ b/CCDB/src/BasicCCDBManager.cxx
@@ -1,0 +1,28 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+//
+// Created by Sandro Wenzel on 2019-08-14.
+//
+#include "CCDB/BasicCCDBManager.h"
+#include <string>
+
+namespace o2
+{
+namespace ccdb
+{
+
+void BasicCCDBManager::setURL(std::string const& url)
+{
+  mCCDBAccessor.init(url);
+}
+
+} // namespace ccdb
+} // namespace o2

--- a/CCDB/src/CCDBLinkDef.h
+++ b/CCDB/src/CCDBLinkDef.h
@@ -34,6 +34,8 @@
 #pragma link C++ class o2::ccdb::GridStorageParameters + ;
 #pragma link C++ class o2::ccdb::XmlHandler + ;
 #pragma link C++ class o2::ccdb::CcdbApi + ;
+#pragma link C++ class o2::ccdb::BasicCCDBManager + ;
+
 /// for the unit test
 #pragma link C++ class TestClass + ;
 #pragma link C++ class o2::TObjectWrapper < TestClass> + ;

--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -57,13 +57,13 @@ void CcdbApi::init(std::string const& host)
   // if host is prefixed with "file://" this is a local snapshot
   // in this case we init the API in snapshot (readonly) mode
   constexpr const char* SNAPSHOTPREFIX = "file://";
+  mUrl = host;
 
   if (host.substr(0, 7).compare(SNAPSHOTPREFIX) == 0) {
     auto path = host.substr(7);
     LOG(INFO) << "Initializing CcdbApi in snapshot readonly mode ... reading snapshot from path " << path;
     initInSnapshotMode(path);
   } else {
-    mUrl = host;
     curlInit();
   }
 }

--- a/Common/SimConfig/include/SimConfig/SimConfig.h
+++ b/Common/SimConfig/include/SimConfig/SimConfig.h
@@ -46,6 +46,8 @@ struct SimConfigData {
   int mStartSeed;                            // base for random number seeds
   int mSimWorkers = 1;                       // number of parallel sim workers (when it applies)
   bool mFilterNoHitEvents = false;           // whether to filter out events not leaving any response
+  std::string mCCDBUrl;                      // the URL where to find CCDB
+  long mTimestamp;                           // timestamp to anchor transport simulation to
 
   ClassDefNV(SimConfigData, 2);
 };

--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -47,7 +47,9 @@ void SimConfig::initOptions(boost::program_options::options_description& options
     "chunkSizeI", bpo::value<int>()->default_value(-1), "internalChunkSize")(
     "seed", bpo::value<int>()->default_value(-1), "initial seed (default: -1 random)")(
     "nworkers,j", bpo::value<int>()->default_value(nsimworkersdefault), "number of parallel simulation workers (only for parallel mode)")(
-    "noemptyevents", "only writes events with at least one hit");
+    "noemptyevents", "only writes events with at least one hit")(
+    "CCDBUrl", bpo::value<std::string>()->default_value("ccdb-test.cern.ch:8080"), "URL for CCDB to be used.")(
+    "timestamp", bpo::value<long>()->default_value(-1), "global timestamp value (for anchoring) - default is now");
 }
 
 bool SimConfig::resetFromParsedMap(boost::program_options::variables_map const& vm)
@@ -98,6 +100,8 @@ bool SimConfig::resetFromParsedMap(boost::program_options::variables_map const& 
   mConfigData.mInternalChunkSize = vm["chunkSizeI"].as<int>();
   mConfigData.mStartSeed = vm["seed"].as<int>();
   mConfigData.mSimWorkers = vm["nworkers"].as<int>();
+  mConfigData.mTimestamp = vm["timestamp"].as<long>();
+  mConfigData.mCCDBUrl = vm["CCDBUrl"].as<std::string>();
   if (vm.count("noemptyevents")) {
     mConfigData.mFilterNoHitEvents = true;
   }


### PR DESCRIPTION
 Introduce BasicCCDBManager as convenience access to CCDB
    
    * minimalistic singleton accessor to CCDB (having transport MC in mind)
      - for the moment read-only
    
    * make o2-sim configurable to use a specific timestamp (for anchoring) and
      to set a specific CCDB URL
    
    This then provides a significant step foward. Henceforth, detectors
    can query the CCDB easily to setup the transport simulation according
    to the conditions at the achoring time.
