### PR TITLE
Re-enable PR #2345 "Simplifying InputRecord API"

### DIFF
--- a/Framework/Core/include/Framework/InputRecord.h
+++ b/Framework/Core/include/Framework/InputRecord.h
@@ -16,6 +16,9 @@
 #include "Framework/TypeTraits.h"
 #include "Framework/InputSpan.h"
 #include "Framework/TableConsumer.h"
+#include "Framework/Traits.h"
+#include "MemoryResources/MemoryResources.h"
+#include "Headers/DataHeader.h"
 
 #include "CommonUtils/BoostSerializer.h"
 
@@ -41,29 +44,47 @@ struct InputSpec;
 
 /// @class InputRecord
 /// @brief The input API of the Data Processing Layer
-/// This class holds the inputs which  are being processed by the system while
-/// they are  being processed.  The user can  get an instance  for it  via the
-/// ProcessingContext and can use it to retrieve the inputs, either by name or
-/// by index.  A few utility  methods are  provided to automatically  cast the
-/// inputs to  known types. The user is also allowed to  override the `get`
-/// template and provide his own serialization mechanism.
+/// This class holds the inputs which are valid for processing. The user can get an
+/// instance for it via the ProcessingContext and can use it to retrieve the inputs,
+/// either by name or by index. A few utility methods are provided to automatically
+/// cast the (deserialized) inputs to  known types.
 ///
-/// The @ref get<T>(binding) method is implemeted for the following types:
-/// - (a) const char*
-/// - (b) std::string
-/// - (c) messageable type T
-/// - (d) pointer type T* for types with ROOT dictionary or messageable types
-/// - (e) std container of type T with ROOT dictionary
-/// - (f) DataRef holding header and payload information, this is also the default
+/// \par The @ref get<T>(binding) method is implemeted for the following types:
+/// - (a) @ref DataRef holding header and payload information, this is also the default
 ///       get method without template parameter
+/// - (b) std::string
+/// - (c) const char*
+///       this is meant for C-style strings which are 0 terminated, there is no length
+///       information
+/// - (d) @ref TableConsumer
+/// - (e) boost serializable types
+/// - (f) span over messageable type T
+/// - (g) std::vector of messageable type or type with ROOT dictionary
+/// - (h) messageable type T
+/// - (i) pointer type T* for types with ROOT dictionary or messageable types
 ///
-/// The return type of get<T>(binding) is:
-/// - (a) const char* to payload content
+/// \par The return type of get<T>(binding) is:
+/// - (a) @ref DataRef object
 /// - (b) std::string copy of the payload
-/// - (c) const ref for messageable types T, the payload content casted to the type
-/// - (d) object with pointer-like behavior (unique_ptr) if T* specified
-/// - (e) std::container object returned by std::move
-/// - (f) DataRef object returned by copy
+/// - (c) const char* to payload content
+/// - (d) unique_ptr of TableConsumer
+/// - (e) object by move
+/// - (f) span object over original payload
+/// - (g) vector by move
+/// - (h) reference to object
+/// - (i) object with pointer-like behavior (unique_ptr)
+///
+/// \par Examples
+/// <pre>
+///    auto& v1 = get<int>("input1");
+///    auto v2 = get<vector<int>>("input2");
+///    auto v3 = get<TList*>("input3");
+///    auto v4 = get<vector<TParticle>>("input4");
+/// </pre>
+///
+/// \par Validity of inputs
+/// Not all input slots are always valid if a custom completion policy is chosen. Validity
+/// can be checked using method @ref isValid.
 ///
 /// Iterator functionality is implemented to iterate over the list of DataRef objects,
 /// including begin() and end() methods.
@@ -75,6 +96,8 @@ struct InputSpec;
 class InputRecord
 {
  public:
+  using DataHeader = o2::header::DataHeader;
+
   InputRecord(std::vector<InputRoute> const& inputs,
               InputSpan&& span);
 
@@ -159,166 +182,14 @@ class InputRecord
     }
   }
 
-  /// Generic function to extract a messageable type by reference
-  /// Cast content of payload bound by @a binding to known type.
-  /// Will not be used for types needing extra serialization
-  /// Note: is_messagable also checks that T is not a pointer
-  /// @return const ref to specified type
-  template <typename T>
-  typename std::enable_if<is_messageable<T>::value && std::is_same<T, DataRef>::value == false && framework::is_boost_serializable<T>::value == false, //
-                          T>::type const&
-    get(char const* binding) const
+  template <typename T = DataRef, typename std::enable_if_t<std::is_same<T, DataRef>::value == true, int> = 0>
+  decltype(auto) get(char const* binding) const
   {
-    // we need to check the serialization type, the cast makes only sense for
-    // unserialized objects
-    // FIXME: add specialization for move assignable types
-    using DataHeader = o2::header::DataHeader;
-
-    auto ref = this->get(binding);
-    auto header = o2::header::get<const DataHeader*>(ref.header);
-    auto method = header->payloadSerializationMethod;
-    if (method != o2::header::gSerializationMethodNone) {
-      // FIXME: we could in principle support serialized content here as well if we
-      // store all extracted objects internally and provide cleanup
-      throw std::runtime_error("Can not extract a plain object from serialized message");
-    }
-    return *reinterpret_cast<T const*>(get<DataRef>(binding).payload);
-  }
-
-  /// Generic function to extract a messageable type by pointer
-  /// @return unique_ptr to message content with custom deleter
-  template <class PtrT>
-  typename std::enable_if<                                                                     //
-    std::is_pointer<PtrT>::value == true && std::is_same<PtrT, const char*>::value == false && //
-      is_messageable<typename std::remove_pointer<PtrT>::type>::value == true &&               //
-      has_root_dictionary<typename std::remove_pointer<PtrT>::type>::value == false,           //
-    std::unique_ptr<typename std::remove_pointer<PtrT>::type const,                            //
-                    Deleter<typename std::remove_pointer<PtrT>::type const>>>::type            //
-    get(char const* binding) const
-  {
-    using T = typename std::remove_pointer<PtrT>::type;
-    auto const& data = get<T>(binding);
-    // return type with non-owning Deleter instance
-    std::unique_ptr<T const, Deleter<T const>> result(&data, Deleter<T const>(false));
-    return std::move(result);
-  }
-
-  /// substitution for const char*
-  /// If we ask for a char const *, we simply point to the payload. Notice this
-  /// is meant for C-style strings. If you want to actually get hold of the buffer,
-  /// use get<DataRef> (or simply get) as that will give you the size as well.
-  /// FIXME: check that the string is null terminated.
-  /// @return pointer to payload content
-  template <typename T>
-  typename std::enable_if<std::is_same<T, char const*>::value, T>::type
-    get(char const* binding) const
-  {
-    return reinterpret_cast<char const*>(get<DataRef>(binding).payload);
-  }
-
-  /// substitution for span of messageable objects
-  /// Note: there is no check for serialization type for the moment, which means that the method
-  /// can be used to get the raw buffer by simply querying gsl::span<unsigned char>.
-  /// FIXME: there will be std::span in C++20
-  template <typename T>
-  typename std::enable_if<std::is_same<T, gsl::span<typename T::value_type>>::value == true,
-                          gsl::span<typename T::value_type const>>::type
-    get(char const* binding) const
-  {
-    auto&& ref = get<DataRef>(binding);
-    auto header = header::get<const header::DataHeader*>(ref.header);
-    assert(header);
-    using ValueT = typename T::value_type;
-    if (header->payloadSize % sizeof(ValueT)) {
-      throw std::runtime_error("Inconsistent type and payload size at " + std::string(binding) +
-                               ": type size " + std::to_string(sizeof(ValueT)) +
-                               "  payload size " + std::to_string(header->payloadSize));
-    }
-    return gsl::span<ValueT const>(reinterpret_cast<ValueT const*>(ref.payload), header->payloadSize / sizeof(ValueT));
-  }
-
-  /// substitution for std::string
-  /// If we ask for a string, we need to duplicate it because we do not want
-  /// the buffer to be deleted when it goes out of scope.
-  /// FIXME: check that the string is null terminated.
-  /// @return std::string object
-  template <typename T>
-  typename std::enable_if<std::is_same<T, std::string>::value, T>::type
-    get(char const* binding) const
-  {
-    auto&& ref = get<DataRef>(binding);
-    auto header = header::get<const header::DataHeader*>(ref.header);
-    assert(header);
-    return std::move(std::string(ref.payload, header->payloadSize));
-  }
-
-  /// substitution for TableConsumer
-  /// For the moment this is dummy, as it requires proper support to
-  /// create the RDataSource from the arrow buffer.
-  template <typename T>
-  typename std::enable_if<std::is_same<T, TableConsumer>::value, std::unique_ptr<TableConsumer>>::type
-    get(char const* binding) const
-  {
-
-    auto&& ref = get<DataRef>(binding);
-    auto header = header::get<const header::DataHeader*>(ref.header);
-    assert(header);
-    auto data = reinterpret_cast<uint8_t const*>(ref.payload);
-    return std::move(std::make_unique<TableConsumer>(data, header->payloadSize));
-  }
-
-  /// substitution for boost-serialized entities
-  /// We have to deserialize the ostringstream.
-  /// FIXME: check that the string is null terminated.
-  /// @return deserialized copy of payload
-  template <typename T>
-  typename std::enable_if<framework::is_boost_serializable<T>::value == true //
-                            && std::is_same<T, std::string>::value == false  //
-                            && has_root_dictionary<T>::value == false,
-                          T>::type
-    get(char const* binding) const
-  {
-    auto&& ref = get<DataRef>(binding);
-    auto header = header::get<const header::DataHeader*>(ref.header);
-    assert(header);
-    auto str = std::string(ref.payload, header->payloadSize);
-    assert(header->payloadSize == sizeof(T));
-    auto desData = o2::utils::BoostDeserialize<T>(str);
-    return std::move(desData);
-  }
-
-  template <typename T, typename WT = typename T::wrapped_type>
-  typename std::enable_if<is_specialization<T, BoostSerialized>::value == true, WT>::type
-    get(char const* binding) const
-  {
-    auto&& ref = get<DataRef>(binding);
-    auto header = header::get<const header::DataHeader*>(ref.header);
-    assert(header);
-    auto str = std::string(ref.payload, header->payloadSize);
-    auto desData = o2::utils::BoostDeserialize<WT>(str);
-    return std::move(desData);
-  }
-
-  template <typename T>
-  T get_boost(char const* binding) const
-  {
-    auto&& ref = get<DataRef>(binding);
-    auto header = header::get<const header::DataHeader*>(ref.header);
-    assert(header);
-    auto str = std::string(ref.payload, header->payloadSize);
-    auto desData = o2::utils::BoostDeserialize<T>(str);
-    return std::move(desData);
-  }
-
-  /// substitution for DataRef
-  /// DataRef is special. Since there is no point in storing one in a payload,
-  /// what it actually does is to return the DataRef used to hold the
-  /// (header, payload) pair.
-  /// @return DataRef object
-  template <typename T = DataRef>
-  typename std::enable_if<std::is_same<T, DataRef>::value, T>::type
-    get(const char* binding) const
-  {
+    // implementation (a)
+    // DataRef is special. Since there is no point in storing one in a payload,
+    // what it actually does is to return the DataRef used to hold the
+    // (header, payload) pair.
+    // returns DataRef object
     try {
       auto pos = getPos(binding);
       if (pos < 0) {
@@ -331,137 +202,222 @@ class InputRecord
     }
   }
 
-  /// substitution for DataRef
-  /// DataRef is special. Since there is no point in storing one in a payload,
-  /// what it actually does is to return the DataRef used to hold the
-  /// (header, payload) pair.
-  /// @return DataRef object
-  template <class T = DataRef>
-  typename std::enable_if<std::is_same<T, DataRef>::value, T>::type
-    get(std::string const& binding) const
+  /// get object of the specified type from input
+  /// The actual operation and cast dependd on the target data type and the serialization type of the
+  /// incoming data. See @ref Inputrecord class description for supported types.
+  /// @param binding   the input to extract the data from
+  template <typename T, typename std::enable_if_t<std::is_same<T, DataRef>::value == false, int> = 0>
+  decltype(auto) get(char const* binding) const
   {
-    try {
-      auto pos = getPos(binding);
-      if (pos < 0) {
-        throw std::invalid_argument("no matching route found for " + binding);
+    // make sure the selection is working
+    static_assert(std::is_same<T, DataRef>::value == false);
+    if constexpr (std::is_same<T, std::string>::value) {
+      // substitution for std::string
+      // If we ask for a string, we need to duplicate it because we do not want
+      // the buffer to be deleted when it goes out of scope. The string is built
+      // from the data and its lengh, null-termination is not necessary.
+      // return std::string object
+      DataRef ref = get<DataRef>(binding);
+      auto header = header::get<const header::DataHeader*>(ref.header);
+      assert(header);
+      return std::string(ref.payload, header->payloadSize);
+
+      // implementation (c)
+    } else if constexpr (std::is_same<T, char const*>::value) {
+      // substitution for const char*
+      // If we ask for a char const *, we simply point to the payload. Notice this
+      // is meant for C-style strings which are expected to be null terminated.
+      // If you want to actually get hold of the buffer, use gsl::span<char> as that will
+      // give you the size as well.
+      // return pointer to payload content
+      return reinterpret_cast<char const*>(get<DataRef>(binding).payload);
+
+      // implementation (d)
+    } else if constexpr (std::is_same<T, TableConsumer>::value) {
+      // substitution for TableConsumer
+      // For the moment this is dummy, as it requires proper support to
+      // create the RDataSource from the arrow buffer.
+      DataRef ref = get<DataRef>(binding);
+      auto header = header::get<const header::DataHeader*>(ref.header);
+      assert(header);
+      auto data = reinterpret_cast<uint8_t const*>(ref.payload);
+      return std::make_unique<TableConsumer>(data, header->payloadSize);
+
+      // implementation (e)
+    } else if constexpr (framework::is_boost_serializable<T>::value || is_specialization<T, BoostSerialized>::value) {
+      // substitution for boost-serialized entities
+      // We have to deserialize the ostringstream.
+      // FIXME: check that the string is null terminated.
+      // @return deserialized copy of payload
+      DataRef ref = get<DataRef>(binding);
+      auto header = header::get<const header::DataHeader*>(ref.header);
+      assert(header);
+      auto str = std::string(ref.payload, header->payloadSize);
+      assert(header->payloadSize == sizeof(T));
+      if constexpr (is_specialization<T, BoostSerialized>::value) {
+        return o2::utils::BoostDeserialize<typename T::wrapped_type>(str);
+      } else {
+        return o2::utils::BoostDeserialize<T>(str);
       }
-      return getByPos(pos);
-    } catch (const std::exception& e) {
-      throw std::runtime_error("Unknown argument requested " + std::string(binding) +
-                               " - " + e.what());
-    }
-  }
 
-  /// substitution for pointer to non-messageable objects with ROOT dictionary
-  /// Template parameter is a pointer
-  /// This supports the common case of retrieving a root object and getting pointer.
-  /// Notice that this will return a copy of the actual contents of the buffer, because
-  /// the buffer is actually serialised, for this reason we return a unique_ptr<T>.
-  /// FIXME: does it make more sense to keep ownership of all the deserialised
-  /// objects in a single place so that we can avoid duplicate deserializations?
-  /// @return unique_ptr to deserialized content
-  template <class PtrT>
-  typename std::enable_if<                                                            //
-    std::is_pointer<PtrT>::value == true &&                                           //
-      has_root_dictionary<typename std::remove_pointer<PtrT>::type>::value == true && //
-      is_messageable<typename std::remove_pointer<PtrT>::type>::value == false,       //
-    std::unique_ptr<typename std::remove_pointer<PtrT>::type const>>::type            //
-    get(char const* binding) const
-  {
-    using T = typename std::remove_pointer<PtrT>::type;
-    auto ref = this->get(binding);
-    return std::move(DataRefUtils::as<T>(ref));
-  }
+      // implementation (f)
+    } else if constexpr (is_span<T>::value) {
+      // substitution for span of messageable objects
+      // Note: there is no check for serialization type for the moment, which means that the method
+      // can be used to get the raw buffer by simply querying gsl::span<unsigned char>.
+      // FIXME: there will be std::span in C++20
+      static_assert(has_messageable_value_type<T>::value, "span can only be created for messageable types");
+      DataRef ref = get<DataRef>(binding);
+      auto header = header::get<const header::DataHeader*>(ref.header);
+      assert(header);
+      using ValueT = typename T::value_type;
+      if (header->payloadSize % sizeof(ValueT)) {
+        throw std::runtime_error("Inconsistent type and payload size at " + std::string(binding) +
+                                 ": type size " + std::to_string(sizeof(ValueT)) +
+                                 "  payload size " + std::to_string(header->payloadSize));
+      }
+      return gsl::span<ValueT const>(reinterpret_cast<ValueT const*>(ref.payload), header->payloadSize / sizeof(ValueT));
 
-  /// substitution for container of non-messageable objects with ROOT dictionary
-  /// Notice that this will return a copy of the actual contents of the buffer, because
-  /// the buffer is actually serialised. The extracted container is swaped to local,
-  /// container, C++11 and beyond will implicitly apply return value optimization.
-  /// @return std container object
-  template <class T>
-  typename std::enable_if<is_container<T>::value == true &&          //
-                            has_root_dictionary<T>::value == true && //
-                            is_messageable<T>::value == false,       //
-                          T>::type                                   //
-    get(char const* binding) const
-  {
-    using NonConstT = typename std::remove_const<T>::type;
-    auto ref = this->get(binding);
-    // we expect the unique_ptr to hold an object, exception should have been thrown
-    // otherwise
-    auto object = DataRefUtils::as<NonConstT>(ref);
-    // need to swap the content of the deserialized container to a local variable to force return
-    // value optimization
-    NonConstT container;
-    std::swap(container, *object);
-    return container;
-  }
+      // implementation (g)
+    } else if constexpr (is_container<T>::value) {
+      // currently implemented only for vectors
+      if constexpr (is_specialization<typename std::remove_const<T>::type, std::vector>::value) {
+        DataRef ref = get<DataRef>(binding);
+        auto header = o2::header::get<const DataHeader*>(ref.header);
+        auto method = header->payloadSerializationMethod;
+        if (method == o2::header::gSerializationMethodNone) {
+          // TODO: construct a vector spectator
+          // this is a quick solution now which makes a copy of the plain vector data
+          auto* start = reinterpret_cast<typename T::value_type const*>(ref.payload);
+          auto* end = start + header->payloadSize / sizeof(typename T::value_type);
+          T result(start, end);
+          return result;
+        } else if (method == o2::header::gSerializationMethodROOT) {
+          /// substitution for container of non-messageable objects with ROOT dictionary
+          /// Notice that this will return a copy of the actual contents of the buffer, because
+          /// the buffer is actually serialised. The extracted container is swaped to local,
+          /// container, C++11 and beyond will implicitly apply return value optimization.
+          /// @return std container object
+          using NonConstT = typename std::remove_const<T>::type;
+          // we expect the unique_ptr to hold an object, exception should have been thrown
+          // otherwise
+          auto object = DataRefUtils::as<NonConstT>(ref);
+          // need to swap the content of the deserialized container to a local variable to force return
+          // value optimization
+          T container;
+          std::swap(const_cast<NonConstT&>(container), *object);
+          return container;
+        } else {
+          throw std::runtime_error("Attempt to extract object from message with unsupported serialization type");
+        }
+      } else {
+        static_assert(always_static_assert_v<T>, "unsupported code path");
+      }
 
-  /// substitution for pointer to messageable objects with ROOT dictionary
-  /// the operation depends on the transmitted serialization method
-  /// @return unique_ptr to deserialized content
-  template <typename PtrT>
-  typename std::enable_if<std::is_pointer<PtrT>::value == true &&                                           //
-                            has_root_dictionary<typename std::remove_pointer<PtrT>::type>::value == true && //
-                            is_messageable<typename std::remove_pointer<PtrT>::type>::value == true,        //
-                          std::unique_ptr<typename std::remove_pointer<PtrT>::type const,
-                                          Deleter<typename std::remove_pointer<PtrT>::type const>>>::type
-    get(char const* binding) const
-  {
-    using DataHeader = o2::header::DataHeader;
-    using T = typename std::remove_pointer<PtrT>::type;
+      // implementation (h)
+    } else if constexpr (is_messageable<T>::value) {
+      // extract a messageable type by reference
+      // Cast content of payload bound by @a binding to known type.
+      // we need to check the serialization type, the cast makes only sense for
+      // unserialized objects
+      using DataHeader = o2::header::DataHeader;
 
-    auto ref = this->get(binding);
-    auto header = o2::header::get<const DataHeader*>(ref.header);
-    auto method = header->payloadSerializationMethod;
-    if (method == o2::header::gSerializationMethodNone) {
-      auto const* ptr = reinterpret_cast<T const*>(ref.payload);
-      // return type with non-owning Deleter instance
-      std::unique_ptr<T const, Deleter<T const>> result(ptr, Deleter<T const>(false));
-      return std::move(result);
-    } else if (method == o2::header::gSerializationMethodROOT) {
-      // explicitely specify serialization method to ROOT-serialized because type T
-      // is messageable and a different method would be deduced in DataRefUtils
-      // return type with owning Deleter instance, forwarding to default_deleter
-      std::unique_ptr<T const, Deleter<T const>> result(DataRefUtils::as<ROOTSerialized<T>>(ref).release());
-      return std::move(result);
+      DataRef ref = get<DataRef>(binding);
+      auto header = o2::header::get<const DataHeader*>(ref.header);
+      auto method = header->payloadSerializationMethod;
+      if (method != o2::header::gSerializationMethodNone) {
+        // FIXME: we could in principle support serialized content here as well if we
+        // store all extracted objects internally and provide cleanup
+        throw std::runtime_error("Can not extract a plain object from serialized message");
+      }
+      return *reinterpret_cast<T const*>(ref.payload);
+
+      // implementation (i)
+    } else if constexpr (std::is_pointer<T>::value &&
+                         (is_messageable<typename std::remove_pointer<T>::type>::value || has_root_dictionary<typename std::remove_pointer<T>::type>::value)) {
+      // extract a messageable type or object with ROOT dictionary by pointer
+      // return unique_ptr to message content with custom deleter
+      using DataHeader = o2::header::DataHeader;
+      using ValueT = typename std::remove_pointer<T>::type;
+
+      DataRef ref = get<DataRef>(binding);
+      auto header = o2::header::get<const DataHeader*>(ref.header);
+      auto method = header->payloadSerializationMethod;
+      if (method == o2::header::gSerializationMethodNone) {
+        if constexpr (is_messageable<ValueT>::value) {
+          auto const* ptr = reinterpret_cast<ValueT const*>(ref.payload);
+          // return type with non-owning Deleter instance
+          std::unique_ptr<ValueT const, Deleter<ValueT const>> result(ptr, Deleter<ValueT const>(false));
+          return result;
+        } else if constexpr (is_specialization<ValueT, std::vector>::value && has_messageable_value_type<ValueT>::value) {
+          // TODO: construct a vector spectator
+          // this is a quick solution now which makes a copy of the plain vector data
+          auto* start = reinterpret_cast<typename ValueT::value_type const*>(ref.payload);
+          auto* end = start + header->payloadSize / sizeof(typename ValueT::value_type);
+          auto container = std::make_unique<ValueT>(start, end);
+          std::unique_ptr<ValueT const, Deleter<ValueT const>> result(container.release(), Deleter<ValueT const>(true));
+          return result;
+        }
+        throw std::runtime_error("unsupported code path");
+      } else if (method == o2::header::gSerializationMethodROOT) {
+        // This supports the common case of retrieving a root object and getting pointer.
+        // Notice that this will return a copy of the actual contents of the buffer, because
+        // the buffer is actually serialised, for this reason we return a unique_ptr<T>.
+        // FIXME: does it make more sense to keep ownership of all the deserialised
+        // objects in a single place so that we can avoid duplicate deserializations?
+        // explicitely specify serialization method to ROOT-serialized because type T
+        // is messageable and a different method would be deduced in DataRefUtils
+        // return type with owning Deleter instance, forwarding to default_deleter
+        std::unique_ptr<ValueT const, Deleter<ValueT const>> result(DataRefUtils::as<ROOTSerialized<ValueT>>(ref).release());
+        return result;
+      } else {
+        throw std::runtime_error("Attempt to extract object from message with unsupported serialization type");
+      }
+    } else if constexpr (has_root_dictionary<T>::value) {
+      // retrieving ROOT objects follows the pointer approach, i.e. T* has to be specified
+      // as template parameter and a unique_ptr will be returned, std vectors of ROOT serializable
+      // objects can be retrieved by move, this is handled above in the "container" code branch
+      static_assert(always_static_assert_v<T>, "ROOT objects need to be retrieved by pointer");
     } else {
-      throw std::runtime_error("Attempt to extract object from message with unsupported serialization type");
+      // non-messageable objects for which serialization method can not be derived by type,
+      // the operation depends on the transmitted serialization method
+      using DataHeader = o2::header::DataHeader;
+
+      DataRef ref = get<DataRef>(binding);
+      auto header = o2::header::get<const DataHeader*>(ref.header);
+      auto method = header->payloadSerializationMethod;
+      if (method == o2::header::gSerializationMethodNone) {
+        // this code path is only selected if the type is non-messageable
+        throw std::runtime_error(
+          "Type mismatch: attempt to extract a non-messagable object "
+          "from message with unserialized data");
+      } else if (method == o2::header::gSerializationMethodROOT) {
+        // explicitely specify serialization method to ROOT-serialized because type T
+        // is messageable and a different method would be deduced in DataRefUtils
+        // return type with owning Deleter instance, forwarding to default_deleter
+        std::unique_ptr<T const, Deleter<T const>> result(DataRefUtils::as<ROOTSerialized<T>>(ref).release());
+        return result;
+      } else {
+        throw std::runtime_error("Attempt to extract object from message with unsupported serialization type");
+      }
     }
   }
 
-  // substitution for non-messageable objects for which serialization method can not
-  // be derived by type, the operation depends on the transmitted serialization method
-  // FIXME: some of the substitutions can for sure be combined when the return types
-  // will be unified in a later refactoring
-  // FIXME: request a pointer where you get a pointer
+  template <typename T = DataRef>
+  decltype(auto) get(std::string const& binding) const
+  {
+    return get<T>(binding.c_str());
+  }
+
   template <typename T>
-  typename std::enable_if_t<is_messageable<T>::value == false                         //
-                              && std::is_pointer<T>::value == false                   //
-                              && std::is_same<T, DataRef>::value == false             //
-                              && std::is_same<T, std::string>::value == false         //
-                              && has_root_dictionary<T>::value == false               //
-                              && framework::is_boost_serializable<T>::value == false, //
-                            std::unique_ptr<T const, Deleter<T const>>>::type
-    get(char const* binding) const
+  T get_boost(char const* binding) const
   {
-    using DataHeader = o2::header::DataHeader;
-
-    auto ref = this->get(binding);
-    auto header = o2::header::get<const DataHeader*>(ref.header);
-    auto method = header->payloadSerializationMethod;
-    if (method == o2::header::gSerializationMethodNone) {
-      throw std::runtime_error(
-        "Type mismatch: attempt to extract a non-messagable object from message with unserialized data");
-    } else if (method == o2::header::gSerializationMethodROOT) {
-      // explicitely specify serialization method to ROOT-serialized because type T
-      // is messageable and a different method would be deduced in DataRefUtils
-      // return type with owning Deleter instance, forwarding to default_deleter
-      std::unique_ptr<T const, Deleter<T const>> result(DataRefUtils::as<ROOTSerialized<T>>(ref).release());
-      return std::move(result);
-    } else {
-      throw std::runtime_error("Attempt to extract object from message with unsupported serialization type");
-    }
+    DataRef ref = get<DataRef>(binding);
+    auto header = header::get<const header::DataHeader*>(ref.header);
+    assert(header);
+    auto str = std::string(ref.payload, header->payloadSize);
+    auto desData = o2::utils::BoostDeserialize<T>(str);
+    return std::move(desData);
   }
 
   /// Helper method to be used to check if a given part of the InputRecord is present.

--- a/Framework/Core/test/test_InputRecord.cxx
+++ b/Framework/Core/test/test_InputRecord.cxx
@@ -125,3 +125,9 @@ BOOST_AUTO_TEST_CASE(TestInputRecord)
   BOOST_CHECK_EQUAL(record.get<int>("x"), 1);
   BOOST_CHECK_EQUAL(record.get<int>("x"), 1);
 }
+
+// TODO:
+// - test all `get` implementations
+// - create a list of supported types and check that the API compiles
+// - test return value optimization for vectors, unique_ptr
+// - check objects which work directly on the payload for zero-copy


### PR DESCRIPTION
Compilation problem on macos is fixed. Aparently clang could not handle the
recursive call, split into two functions, selected via SFINAE idiom.