### PR TITLE
[EMCAL-609] Port setters/getters for cell type to Digits

### DIFF
--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Cell.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Cell.h
@@ -25,18 +25,11 @@ namespace o2
 namespace emcal
 {
 
-enum CellType {
-  kLowGain,
-  kHighGain,
-  kLEDMon,
-  kTRU
-};
-
 class Cell
 {
  public:
   Cell() = default;
-  Cell(Short_t tower, Double_t energy, Double_t time, CellType ctype = CellType::kLowGain);
+  Cell(Short_t tower, Double_t energy, Double_t time, ChannelType_t ctype = ChannelType_t::LOW_GAIN);
   ~Cell() = default; // override
 
   void setTower(Short_t tower);
@@ -51,8 +44,8 @@ class Cell
   void setEnergy(Double_t energy);
   Double_t getEnergy() const;
 
-  void setType(CellType ctype);
-  UInt_t getType() const;
+  void setType(ChannelType_t ctype);
+  ChannelType_t getType() const;
 
   void setLowGain();
   Bool_t getLowGain() const;

--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Constants.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Constants.h
@@ -13,6 +13,7 @@
 #include <Rtypes.h>
 #include <iosfwd>
 #include <exception>
+#include <cstdint>
 
 namespace o2
 {
@@ -28,7 +29,7 @@ enum {
 
 /// \enum ChannelType_t
 /// \brief Type of a raw data channel
-enum class ChannelType_t {
+enum ChannelType_t {
   HIGH_GAIN, ///< High gain channel
   LOW_GAIN,  ///< Low gain channel
   TRU,       ///< TRU channel

--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Digit.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Digit.h
@@ -58,13 +58,29 @@ class Digit : public DigitBase
   void setEnergy(Double_t energy) { mEnergy = energy; }
   Double_t getEnergy() const { return mEnergy; }
 
+  void setType(ChannelType_t ctype) { mChannelType = ctype; }
+  ChannelType_t getType() const { return mChannelType; }
+
+  void setLowGain() { mChannelType = ChannelType_t::LOW_GAIN; }
+  Bool_t getLowGain() const { return mChannelType == ChannelType_t::LOW_GAIN; }
+
+  void setHighGain() { mChannelType = ChannelType_t::HIGH_GAIN; }
+  Bool_t getHighGain() const { return mChannelType == ChannelType_t::HIGH_GAIN; }
+
+  void setLEDMon() { mChannelType = ChannelType_t::LEDMON; }
+  Bool_t getLEDMon() const { return mChannelType == ChannelType_t::LEDMON; }
+
+  void setTRU() { mChannelType = ChannelType_t::TRU; }
+  Bool_t getTRU() const { return mChannelType == ChannelType_t::TRU; }
+
   void PrintStream(std::ostream& stream) const;
 
  private:
   friend class boost::serialization::access;
 
-  Double_t mEnergy; ///< Energy (GeV/c^2)
-  Short_t mTower;   ///< Tower index (absolute cell ID)
+  Double_t mEnergy = 0.;                                 ///< Energy (GeV/c^2)
+  Short_t mTower = -1;                                   ///< Tower index (absolute cell ID)
+  ChannelType_t mChannelType = ChannelType_t::HIGH_GAIN; ///< Channel type (high gain, low gain, TRU, LEDMON)
 
   ClassDefNV(Digit, 1);
 };

--- a/DataFormats/Detectors/EMCAL/src/Cell.cxx
+++ b/DataFormats/Detectors/EMCAL/src/Cell.cxx
@@ -15,7 +15,7 @@
 
 using namespace o2::emcal;
 
-Cell::Cell(Short_t tower, Double_t energy, Double_t time, CellType ctype)
+Cell::Cell(Short_t tower, Double_t energy, Double_t time, ChannelType_t ctype)
 {
   setTower(tower);
   setTimeStamp(time);
@@ -104,27 +104,33 @@ Double_t Cell::getEnergy() const
   return getEnergyBits() * (constants::EMCAL_ADCENERGY) / 16.0;
 }
 
-void Cell::setType(CellType ctype)
+void Cell::setType(ChannelType_t ctype)
 {
-  if (ctype == CellType::kHighGain)
-    setHighGain();
-  else if (ctype == CellType::kLEDMon)
-    setLEDMon();
-  else if (ctype == CellType::kTRU)
-    setTRU();
-  else
-    setLowGain();
+  switch (ctype) {
+    case ChannelType_t::HIGH_GAIN:
+      setHighGain();
+      break;
+    case ChannelType_t::LOW_GAIN:
+      setLowGain();
+      break;
+    case ChannelType_t::TRU:
+      setTRU();
+      break;
+    case ChannelType_t::LEDMON:
+      setHighGain();
+      break;
+  };
 }
 
-UInt_t Cell::getType() const
+ChannelType_t Cell::getType() const
 {
   if (getHighGain())
-    return CellType::kHighGain;
+    return ChannelType_t::HIGH_GAIN;
   else if (getLEDMon())
-    return CellType::kLEDMon;
+    return ChannelType_t::LEDMON;
   else if (getTRU())
-    return CellType::kTRU;
-  return CellType::kLowGain;
+    return ChannelType_t::TRU;
+  return ChannelType_t::LOW_GAIN;
 }
 
 void Cell::setLowGain()

--- a/DataFormats/Detectors/EMCAL/src/DataFormatsEMCALLinkDef.h
+++ b/DataFormats/Detectors/EMCAL/src/DataFormatsEMCALLinkDef.h
@@ -23,6 +23,6 @@
 #pragma link C++ class std::vector < o2::emcal::Cluster > +;
 
 // For channel type in digits and cells
-#pragma link C++ enum class o2::emcal::ChannelType_t + ;
+#pragma link C++ enum o2::emcal::ChannelType_t + ;
 
 #endif

--- a/DataFormats/Detectors/EMCAL/src/DataFormatsEMCALLinkDef.h
+++ b/DataFormats/Detectors/EMCAL/src/DataFormatsEMCALLinkDef.h
@@ -22,4 +22,7 @@
 #pragma link C++ class std::vector < o2::emcal::Digit > +;
 #pragma link C++ class std::vector < o2::emcal::Cluster > +;
 
+// For channel type in digits and cells
+#pragma link C++ enum class o2::emcal::ChannelType_t + ;
+
 #endif

--- a/DataFormats/Detectors/EMCAL/src/Digit.cxx
+++ b/DataFormats/Detectors/EMCAL/src/Digit.cxx
@@ -28,7 +28,7 @@ Digit& Digit::operator+=(const Digit& other)
 
 void Digit::PrintStream(std::ostream& stream) const
 {
-  stream << "EMCAL Digit: Tower " << mTower << ", Time " << getTimeStamp() << ", Energy " << mEnergy;
+  stream << "EMCAL Digit: Tower " << mTower << ", Time " << getTimeStamp() << ", Energy " << mEnergy << ", type " << mChannelType;
 }
 
 std::ostream& operator<<(std::ostream& stream, const Digit& digi)


### PR DESCRIPTION
Adding getters and setters for cell type to
digits so that the interface between the
two objects is compatible. This is of
relevance for components forseen to work
with both object types.

In addition: Use o2::emcal::ChannelType_t for
channel type information.