### PR TITLE
Correct the return value in o2::compatibility::FairMQ13::IsRunning()

### DIFF
--- a/Utilities/O2Device/include/O2Device/Compatibility.h
+++ b/Utilities/O2Device/include/O2Device/Compatibility.h
@@ -30,7 +30,7 @@ class FairMQ13
   static bool IsRunning(T* device)
   {
     if constexpr (std::is_same_v<decltype(test<T>(nullptr)), std::true_type>) {
-      return device->NewStatePending();
+      return !device->NewStatePending();
     } else if constexpr (std::is_same_v<decltype(test<T>(nullptr)), std::false_type>) {
       return device->CheckCurrentState(T::RUNNING);
     }


### PR DESCRIPTION
You want to stop running when there is a new state pending.

Thanks Taku Gunji for reporting the issue with this.