### PR TITLE
Extending TPC workflow publisher to read sector data from multiple files

### DIFF
--- a/Detectors/TPC/workflow/src/ClusterDecoderRawSpec.cxx
+++ b/Detectors/TPC/workflow/src/ClusterDecoderRawSpec.cxx
@@ -56,7 +56,7 @@ DataProcessorSpec getClusterDecoderRawSpec(bool sendMC)
     std::unique_ptr<HardwareClusterDecoder> decoder;
     std::set<o2::header::DataHeader::SubSpecificationType> activeInputs;
     bool readyToQuit = false;
-    bool verbosity = 0;
+    int verbosity = 0;
     bool sendMC = false;
   };
 
@@ -109,6 +109,9 @@ DataProcessorSpec getClusterDecoderRawSpec(bool sendMC)
       // FIXME: better description of the raw page
       size_t nPages = size / 8192;
       std::vector<std::pair<const ClusterHardwareContainer*, std::size_t>> inputList;
+      if (verbosity > 0 && labelKey.empty()) {
+        LOG(INFO) << "Decoder input: " << size << ", " << nPages << " pages for sector " << sectorHeader->sector;
+      }
 
       // MC labels are received as one container of labels in the sequence matching clusters
       // in the raw pages
@@ -118,7 +121,7 @@ DataProcessorSpec getClusterDecoderRawSpec(bool sendMC)
         mcin = std::move(pc.inputs().get<MCLabelContainer*>(labelKey.c_str()));
         mcinCopies.resize(nPages);
         if (verbosity > 0) {
-          LOG(INFO) << "Decoder input: " << size << ", " << nPages << " pages, " << mcin->getIndexedSize() << " MC label sets";
+          LOG(INFO) << "Decoder input: " << size << ", " << nPages << " pages, " << mcin->getIndexedSize() << " MC label sets for sector " << sectorHeader->sector;
         }
       }
 
@@ -132,7 +135,7 @@ DataProcessorSpec getClusterDecoderRawSpec(bool sendMC)
       for (size_t page = 0; page < nPages; page++) {
         inputList.emplace_back(reinterpret_cast<const ClusterHardwareContainer*>(ref.payload + page * 8192), 1);
         const ClusterHardwareContainer& container = *(inputList.back().first);
-        if (verbosity > 0) {
+        if (verbosity > 1) {
           LOG(INFO) << "Decoder input in page " << std::setw(2) << page << ": "     //
                     << "CRU " << std::setw(3) << container.CRU << " "               //
                     << std::setw(3) << container.numberOfClusters << " cluster(s)"; //

--- a/Detectors/TPC/workflow/src/ClustererSpec.cxx
+++ b/Detectors/TPC/workflow/src/ClustererSpec.cxx
@@ -94,7 +94,8 @@ DataProcessorSpec getClustererSpec(bool sendMC, bool haveDigTriggers)
       auto inDigits = pc.inputs().get<const std::vector<o2::tpc::Digit>>(inputKey.c_str());
       if (verbosity > 0 && inMCLabels) {
         LOG(INFO) << "received " << inDigits.size() << " digits, "
-                  << inMCLabels->getIndexedSize() << " MC label objects";
+                  << inMCLabels->getIndexedSize() << " MC label objects"
+                  << " input MC label size " << DataRefUtils::getPayloadSize(pc.inputs().get(labelKey.c_str()));
       }
       if (!clusterers[sector]) {
         // create the clusterer for this sector, take the same target arrays for all clusterers
@@ -105,7 +106,8 @@ DataProcessorSpec getClustererSpec(bool sendMC, bool haveDigTriggers)
       auto& clusterer = clusterers[sector];
 
       if (verbosity > 0) {
-        LOG(INFO) << "processing " << inDigits.size() << " digit object(s) of sector " << sectorHeader->sector;
+        LOG(INFO) << "processing " << inDigits.size() << " digit object(s) of sector " << sectorHeader->sector
+                  << " input size " << DataRefUtils::getPayloadSize(pc.inputs().get(inputKey.c_str()));
       }
       // process the digits and MC labels, the bool parameter controls whether to clear all
       // internal data or not. Have to clear it inside the process method as not only the containers
@@ -118,9 +120,11 @@ DataProcessorSpec getClustererSpec(bool sendMC, bool haveDigTriggers)
       if (verbosity > 0) {
         LOG(INFO) << "clusterer produced "
                   << std::accumulate(clusterArray.begin(), clusterArray.end(), size_t(0), [](size_t l, auto const& r) { return l + r.getContainer()->numberOfClusters; })
-                  << " cluster(s)";
+                  << " cluster(s)"
+                  << " for sector " << sectorHeader->sector
+                  << " total size " << sizeof(ClusterHardwareContainer8kb) * clusterArray.size();
         if (!labelKey.empty()) {
-          LOG(INFO) << "clusterer produced " << mctruthArray.getIndexedSize() << " MC label object(s)";
+          LOG(INFO) << "clusterer produced " << mctruthArray.getIndexedSize() << " MC label object(s) for sector " << sectorHeader->sector;
         }
       }
       // FIXME: that should be a case for pmr, want to send the content of the vector as a binary

--- a/Detectors/TPC/workflow/src/PublisherSpec.cxx
+++ b/Detectors/TPC/workflow/src/PublisherSpec.cxx
@@ -94,14 +94,20 @@ DataProcessorSpec getPublisherSpec(PublisherConf const& config, bool propagateMC
           continue;
         }
         o2::header::DataHeader::SubSpecificationType subSpec = *outputId;
+        std::string sectorfile = filename;
+        if (filename.find('%') != std::string::npos) {
+          vector<char> formattedname(filename.length() + 10, 0);
+          snprintf(formattedname.data(), formattedname.size() - 1, filename.c_str(), sector);
+          sectorfile = formattedname.data();
+        }
         std::string clusterbranchname = clbrName + "_" + std::to_string(sector);
         std::string mcbranchname = mcbrName + "_" + std::to_string(sector);
         auto dto = DataSpecUtils::asConcreteDataTypeMatcher(config.dataoutput);
         auto mco = DataSpecUtils::asConcreteDataTypeMatcher(config.mcoutput);
         if (propagateMC) {
-          readers[sector] = std::make_shared<RootTreeReader>(treename.c_str(), // tree name
-                                                             filename.c_str(), // input file name
-                                                             nofEvents,        // number of entries to publish
+          readers[sector] = std::make_shared<RootTreeReader>(treename.c_str(),   // tree name
+                                                             sectorfile.c_str(), // input file name
+                                                             nofEvents,          // number of entries to publish
                                                              publishingMode,
                                                              Output{dto.origin, dto.description, subSpec, persistency},
                                                              clusterbranchname.c_str(), // name of cluster branch
@@ -109,9 +115,9 @@ DataProcessorSpec getPublisherSpec(PublisherConf const& config, bool propagateMC
                                                              mcbranchname.c_str() // name of mc label branch
           );
         } else {
-          readers[sector] = std::make_shared<RootTreeReader>(treename.c_str(), // tree name
-                                                             filename.c_str(), // input file name
-                                                             nofEvents,        // number of entries to publish
+          readers[sector] = std::make_shared<RootTreeReader>(treename.c_str(),   // tree name
+                                                             sectorfile.c_str(), // input file name
+                                                             nofEvents,          // number of entries to publish
                                                              publishingMode,
                                                              Output{dto.origin, dto.description, subSpec, persistency},
                                                              clusterbranchname.c_str() // name of cluster branch


### PR DESCRIPTION
Filename can now contain %d format specifier which will be replaced by formatted
sector number.

Improving log messages