### PR TITLE
[EMCAL-551, EMCAL-572] Fix precision in energy bits

### DIFF
--- a/DataFormats/Detectors/EMCAL/CMakeLists.txt
+++ b/DataFormats/Detectors/EMCAL/CMakeLists.txt
@@ -27,3 +27,9 @@ o2_target_root_dictionary(DataFormatsEMCAL
                                   include/DataFormatsEMCAL/Cell.h
                                   include/DataFormatsEMCAL/Digit.h
                                   include/DataFormatsEMCAL/Cluster.h)
+
+o2_add_test(Cell
+            SOURCES test/testCell.cxx
+            COMPONENT_NAME DataFormats-EMCAL
+            PUBLIC_LINK_LIBRARIES O2::DataFormatsEMCAL
+            LABELS emcal dataformats)

--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Cell.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Cell.h
@@ -13,6 +13,7 @@
 
 #include <bitset>
 #include "Rtypes.h"
+#include "DataFormatsEMCAL/Constants.h"
 
 // Structure:
 // Bits 38-39: Cell type: 00=Low Gain, 01=High Gain, 10=LED mon, 11=TRU

--- a/DataFormats/Detectors/EMCAL/src/Cell.cxx
+++ b/DataFormats/Detectors/EMCAL/src/Cell.cxx
@@ -86,22 +86,17 @@ Short_t Cell::getEnergyBits() const
 
 void Cell::setEnergy(Double_t energy)
 {
-  ULong_t a = 0;
-  if (energy > 0x3fff * (constants::EMCAL_ADCENERGY / 16.0))
-    a = 0x3fff;
-  else if (energy < 0)
-    a = 0;
-  else
-    a = (ULong_t)((energy / (constants::EMCAL_ADCENERGY)*16.0) + 0.5);
+  ULong_t a = static_cast<ULong_t>(energy / 0.0153);
+  a = a & 0x3FFF;
 
   a <<= 24;
-  ULong_t b = getLong() & 0xc00ffffff; // 1100000000000000111111111111111111111111
+  ULong_t b = getLong() & 0xc000ffffff; // 1100000000000000111111111111111111111111
   mBits = b + a;
 }
 
 Double_t Cell::getEnergy() const
 {
-  return getEnergyBits() * (constants::EMCAL_ADCENERGY) / 16.0;
+  return double(getEnergyBits() * 0.0153);
 }
 
 void Cell::setType(ChannelType_t ctype)

--- a/DataFormats/Detectors/EMCAL/test/testCell.cxx
+++ b/DataFormats/Detectors/EMCAL/test/testCell.cxx
@@ -49,13 +49,13 @@ BOOST_AUTO_TEST_CASE(Cell_test)
   }
 
   c.setTimeStamp(0);
-  std::vector<double> energies = {0.5, 1, 2, 5, 10, 20};
+  std::vector<double> energies = {0.5, 1, 2, 5, 10, 20, 40, 60, 100, 150, 200};
 
   for (auto e : energies) {
     c.setEnergy(e);
     BOOST_CHECK_EQUAL(c.getTower(), 0);
     BOOST_CHECK_EQUAL(c.getTimeStamp(), 0);
-    BOOST_CHECK_SMALL(e - c.getEnergy(), 0.1);
+    BOOST_CHECK_SMALL(e - c.getEnergy(), 0.02); // Require 20 MeV resolution
     BOOST_CHECK_EQUAL(c.getLowGain(), true);
   }
 

--- a/DataFormats/Detectors/EMCAL/test/testCell.cxx
+++ b/DataFormats/Detectors/EMCAL/test/testCell.cxx
@@ -1,0 +1,103 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test EMCAL Cell
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include "DataFormatsEMCAL/Cell.h"
+
+#include <algorithm>
+
+namespace o2
+{
+
+namespace emcal
+{
+
+/// \brief Standard tests for cell class
+///
+/// - verify that set and get functions return consistent values
+BOOST_AUTO_TEST_CASE(Cell_test)
+{
+  Cell c;
+
+  for (short j = 0; j < 17664; j++) {
+    c.setTower(j);
+    BOOST_CHECK_EQUAL(c.getTower(), j);
+    BOOST_CHECK_EQUAL(c.getTimeStamp(), 0);
+    BOOST_CHECK_EQUAL(c.getEnergy(), 0);
+    BOOST_CHECK_EQUAL(c.getLowGain(), true);
+  }
+
+  c.setTower(0);
+  std::vector<int> times = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 50, 100, 200};
+
+  for (auto t : times) {
+    c.setTimeStamp(t);
+    BOOST_CHECK_EQUAL(c.getTower(), 0);
+    BOOST_CHECK_EQUAL(c.getTimeStamp(), t);
+    BOOST_CHECK_EQUAL(c.getEnergy(), 0);
+    BOOST_CHECK_EQUAL(c.getLowGain(), true);
+  }
+
+  c.setTimeStamp(0);
+  std::vector<double> energies = {0.5, 1, 2, 5, 10, 20};
+
+  for (auto e : energies) {
+    c.setEnergy(e);
+    BOOST_CHECK_EQUAL(c.getTower(), 0);
+    BOOST_CHECK_EQUAL(c.getTimeStamp(), 0);
+    BOOST_CHECK_SMALL(e - c.getEnergy(), 0.1);
+    BOOST_CHECK_EQUAL(c.getLowGain(), true);
+  }
+
+  c.setEnergy(0);
+
+  c.setLowGain();
+  BOOST_CHECK_EQUAL(c.getTower(), 0);
+  BOOST_CHECK_EQUAL(c.getTimeStamp(), 0);
+  BOOST_CHECK_EQUAL(c.getEnergy(), 0);
+  BOOST_CHECK_EQUAL(c.getLowGain(), true);
+  BOOST_CHECK_EQUAL(c.getHighGain(), false);
+  BOOST_CHECK_EQUAL(c.getLEDMon(), false);
+  BOOST_CHECK_EQUAL(c.getTRU(), false);
+
+  c.setHighGain();
+  BOOST_CHECK_EQUAL(c.getTower(), 0);
+  BOOST_CHECK_EQUAL(c.getTimeStamp(), 0);
+  BOOST_CHECK_EQUAL(c.getEnergy(), 0);
+  BOOST_CHECK_EQUAL(c.getLowGain(), false);
+  BOOST_CHECK_EQUAL(c.getHighGain(), true);
+  BOOST_CHECK_EQUAL(c.getLEDMon(), false);
+  BOOST_CHECK_EQUAL(c.getTRU(), false);
+
+  c.setLEDMon();
+  BOOST_CHECK_EQUAL(c.getTower(), 0);
+  BOOST_CHECK_EQUAL(c.getTimeStamp(), 0);
+  BOOST_CHECK_EQUAL(c.getEnergy(), 0);
+  BOOST_CHECK_EQUAL(c.getLowGain(), false);
+  BOOST_CHECK_EQUAL(c.getHighGain(), false);
+  BOOST_CHECK_EQUAL(c.getLEDMon(), true);
+  BOOST_CHECK_EQUAL(c.getTRU(), false);
+
+  c.setTRU();
+  BOOST_CHECK_EQUAL(c.getTower(), 0);
+  BOOST_CHECK_EQUAL(c.getTimeStamp(), 0);
+  BOOST_CHECK_EQUAL(c.getEnergy(), 0);
+  BOOST_CHECK_EQUAL(c.getLowGain(), false);
+  BOOST_CHECK_EQUAL(c.getHighGain(), false);
+  BOOST_CHECK_EQUAL(c.getLEDMon(), false);
+  BOOST_CHECK_EQUAL(c.getTRU(), true);
+}
+
+} // namespace emcal
+
+} // namespace o2


### PR DESCRIPTION
Remove multiplication by 16 which worsened
the precision in energy. Now the precision
is set to 15.3 MeV, reflecting a range
from 0 - 250 GeV coded in 13 bits.

In addition: Unit test for cell class
(EMCAL-572) - A. Knospe.