### PR TITLE
Make sure to print out the errors from root cling

### DIFF
--- a/cmake/O2DefineOptions.cmake
+++ b/cmake/O2DefineOptions.cmake
@@ -19,6 +19,8 @@ function(o2_define_options)
   option(BUILD_TEST_ROOT_MACROS
          "Build the tests toload and compile the Root macros" ON)
 
+  option(ENABLE_CASSERT "Enable asserts" OFF)
+
   option(
     BUILD_SIMULATION_DEFAULT
     "Default behavior for simulation (disregarded if BUILD_SIMULATION is defined)"

--- a/cmake/rootcling_wrapper.sh.in
+++ b/cmake/rootcling_wrapper.sh.in
@@ -77,7 +77,7 @@ LOGFILE=${DICTIONARY_FILE}.log
   -rml ${ROOTMAP_LIBRARY_NAME} \
   ${INCLUDE_DIRS//;/ } \
   ${COMPILE_DEFINITIONS//;/ } \
-  ${HEADERS//;/ } >${LOGFILE} 2>&1
+  ${HEADERS//;/ } > ${LOGFILE} 2>&1 || cat ${LOGFILE} >&2
 
 MSG="Warning: Unused class rule"
 if [[ -s ${LOGFILE} ]]; then


### PR DESCRIPTION
The root cling wrapper dumps all output to a log file, but the errors should
also appear in the build log, especially important to have the complete log for
running the CI.

Also making ENABLE_CASSERT a cmake option, default OFF