### PR TITLE
Add variable y/x and z/x binning options and more

### DIFF
--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/SpacePointsCalibParam.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/SpacePointsCalibParam.h
@@ -33,11 +33,10 @@ static constexpr int NROCTypes = 3;                                  ///< how ma
 static constexpr int NRowsPerROC[NROCTypes] = {63, 64, 32};          ///< number of rows for the different pitches
 static constexpr int NRowsAccumulated[NROCTypes] = {63, 127, 159};   ///< accumulate number of rows (only used as abbreviation)
 static constexpr float ZLimit[2] = {2.49725e2f, 2.49698e2f};         ///< max z-positions for A/C side
-static constexpr float MinX[NROCTypes] = {85.225f, 135.1f, 199.35f}; ///< x-position of first row for each ROC type
 static constexpr float RowDX[NROCTypes] = {.75f, 1.f, 1.5f};         ///< row pitches
-static constexpr float ROCDX[NROCTypes - 1] = {3.375f, 1.25f};       ///< radial distance between the different ROCs
-static constexpr float MaxX = 246.f;                                 ///< max radius for the TPC
-static constexpr float RowX[NPadRows] = {                            ///< x-positions for each pad row
+static constexpr float MinX = 84.85f;                                ///< x-position of inner radius of first pad row ( = RowX[0] - 0.5 * RowDX[0])
+static constexpr float MaxX = 246.f;                                 ///< max radius for the TPC ( = RowX[NPadRows-1] + 0.5 * RowDX[NROCTypes-1] )
+static constexpr float RowX[NPadRows] = {                            ///< x-position for the center of each pad row
   85.225, 85.975, 86.725, 87.475, 88.225, 88.975, 89.725, 90.475, 91.225, 91.975, 92.725, 93.475, 94.225, 94.975, 95.725, 96.475,
   97.225, 97.975, 98.725, 99.475, 100.225, 100.975, 101.725, 102.475, 103.225, 103.975, 104.725, 105.475, 106.225, 106.975, 107.725,
   108.475, 109.225, 109.975, 110.725, 111.475, 112.225, 112.975, 113.725, 114.475, 115.225, 115.975, 116.725, 117.475, 118.225, 118.975,
@@ -56,10 +55,9 @@ static constexpr int NPadRows = o2::tpc::Constants::MAXGLOBALPADROW;
 static constexpr int NROCTypes = 4;
 static constexpr int NRowsPerROC[NROCTypes] = {63, 34, 30, 25};
 static constexpr int NRowsAccumulated[NROCTypes] = {63, 97, 127, 152};
-static constexpr float MinX[NROCTypes] = {85.225f, 135.2f, 171.4f, 209.65f};
 static constexpr float RowDX[NROCTypes] = {.75f, 1.f, 1.2f, 1.5f};
-static constexpr float ROCDX[NROCTypes - 1] = {3.475f, 3.2f, 3.45f};
-static constexpr float MaxX = 247.15f;
+static constexpr float MinX = 84.85f;
+static constexpr float MaxX = 246.4f;
 static constexpr float RowX[NPadRows] = {
   85.225, 85.975, 86.725, 87.475, 88.225, 88.975, 89.725, 90.475, 91.225, 91.975, 92.725, 93.475, 94.225, 94.975, 95.725, 96.475,
   97.225, 97.975, 98.725, 99.475, 100.225, 100.975, 101.725, 102.475, 103.225, 103.975, 104.725, 105.475, 106.225, 106.975, 107.725,

--- a/Detectors/TPC/calibration/SpacePoints/src/SpacePointCalibLinkDef.h
+++ b/Detectors/TPC/calibration/SpacePoints/src/SpacePointCalibLinkDef.h
@@ -19,5 +19,6 @@
 #pragma link C++ class o2::tpc::TrackData + ;
 #pragma link C++ class o2::tpc::TPCClusterResiduals + ;
 #pragma link C++ class o2::tpc::TrackResiduals::LocalResid + ;
+#pragma link C++ class o2::tpc::TrackResiduals::VoxRes + ;
 
 #endif


### PR DESCRIPTION
- Bugfix: insertion sort in roFunc was not working properly
- additional debugging options -> single vector can be dumped to TTree
- fix method to retrieve pad row id from x-position
- fix findVoxelBin method
- remove unnecessary parameters from TPC space point calibration parameters class
- Double precision in LTMUnbinnedSig for AliRoot compatibility
- Make LTMUnbinned method better readable
- Use STL function nth_element instead of selectKthMin
- Make voxel flags the same as in AliRoot version