### PR TITLE
Fix: account for diff.spans of response and sensor depths

### DIFF
--- a/Detectors/ITSMFT/common/simulation/src/Digitizer.cxx
+++ b/Detectors/ITSMFT/common/simulation/src/Digitizer.cxx
@@ -206,6 +206,7 @@ void Digitizer::processHit(const o2::itsmft::Hit& hit, UInt_t& maxFr, int evID, 
   const auto& matrix = mGeometry->getMatrixL2G(hit.GetDetectorID());
   Vector3D<float> xyzLocS(matrix ^ (hit.GetPosStart())); // start position in sensor frame
   Vector3D<float> xyzLocE(matrix ^ (hit.GetPos()));      // end position in sensor frame
+
   Vector3D<float> step(xyzLocE);
   step -= xyzLocS;
   step *= nStepsInv; // position increment at each step
@@ -268,8 +269,11 @@ void Digitizer::processHit(const o2::itsmft::Hit& hit, UInt_t& maxFr, int evID, 
 
   const o2::itsmft::AlpideSimResponse* resp = mParams.getAlpSimResponse();
 
-  // take into account that the AlpideSimResponse has min/max thickness non-symmetric around 0
-  xyzLocS.SetY(xyzLocS.Y() + resp->getDepthShift());
+  // take into account that the AlpideSimResponse depth defintion has different min/max boundaries
+  // although the max should coincide with the surface of the epitaxial layer, which in the chip
+  // local coordinates has Y = +SensorLayerThicknessEff/2
+
+  xyzLocS.SetY(xyzLocS.Y() + resp->getDepthMax() - Segmentation::SensorLayerThicknessEff / 2.);
 
   // collect charge in evey pixel which might be affected by the hit
   for (int iStep = nSteps; iStep--;) {


### PR DESCRIPTION
Hi @iouribelikov 

This PR mostly fixes the problem w/o any fudge factors (thanks for the hint). The top/bottom plot is dz vs Z/R for Lr0 before/after the fix: 
![cmp_lr0dzvstgl](https://user-images.githubusercontent.com/7382029/64300835-bae66100-cf7e-11e9-94f1-5785fbe51027.gif)
(the asymmetry in z/r is because I was using 19 events with random vertex, also, z/r in this case does not really give the tg(lambda)). 

![cmp_lr0dz](https://user-images.githubusercontent.com/7382029/64300836-bae66100-cf7e-11e9-92b1-233bc3bc8ca2.gif)

The remaining diagonal bands after the correction are due to the single pixel clusters.

The reason of the bias was in different boundaries of the sensor (+11:-19 \mum) and response object (+25:-20 \mum) depth dimensions. Note there is still an internal inconsistency: Miko's object has non-0 response over the whole depth while the transport by the construction of 30\um sensors produces hit start/stop positions in these +11:-19 range. Now I "align" the coordinate of the sensor surface with the surface slice of the response object, but effectively we don't see account electrons from the least efficient 10\um (if the response is correct). Another inconsistency is COG of charge collection along the thickness: we define it in the middle of the "epitaxial layer", i.e. 11 um from the surface, while Miko's response COG seems to be little bit shifted (I guess this is the reason of remaining bias vs Z/R).

I see that the cluster size increases after the fix:
![cmp_clsize](https://user-images.githubusercontent.com/7382029/64300834-bae66100-cf7e-11e9-8033-70075770be15.gif)

