### PR TITLE
GeneratorHepMC: a HepMC interface to simulation

### DIFF
--- a/Common/SimConfig/include/SimConfig/SimConfig.h
+++ b/Common/SimConfig/include/SimConfig/SimConfig.h
@@ -26,6 +26,7 @@ struct SimConfigData {
   std::string mGenerator;                    // chosen VMC generator
   unsigned int mNEvents;                     // number of events to be simulated
   std::string mExtKinFileName;               // file name of external kinematics file (needed for ext kinematics generator)
+  std::string mHepMCFileName;                // file name of HepMC file
   std::string mExtGenFileName;               // file name containing the external generator configuration
   std::string mExtGenFuncName;               // function call to retrieve the external generator configuration
   std::string mEmbedIntoFileName;            // filename containing the reference events to be used for the embedding
@@ -95,6 +96,7 @@ class SimConfig
   unsigned int getNEvents() const { return mConfigData.mNEvents; }
 
   std::string getExtKinematicsFileName() const { return mConfigData.mExtKinFileName; }
+  std::string getHepMCFileName() const { return mConfigData.mHepMCFileName; }
   std::string getExtGeneratorFileName() const { return mConfigData.mExtGenFileName; }
   std::string getExtGeneratorFuncName() const { return mConfigData.mExtGenFuncName; }
   std::string getEmbedIntoFileName() const { return mConfigData.mEmbedIntoFileName; }

--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -30,6 +30,8 @@ void SimConfig::initOptions(boost::program_options::options_description& options
     "startEvent", bpo::value<unsigned int>()->default_value(0), "index of first event to be used (when applicable)")(
     "extKinFile", bpo::value<std::string>()->default_value("Kinematics.root"),
     "name of kinematics file for event generator from file (when applicable)")(
+    "HepMCFile", bpo::value<std::string>()->default_value("kinematics.hepmc"),
+    "name of HepMC file for event generator from file (when applicable)")(
     "extGenFile", bpo::value<std::string>()->default_value("extgen.C"),
     "name of .C file with definition of external event generator")(
     "extGenFunc", bpo::value<std::string>()->default_value(""),
@@ -85,6 +87,7 @@ bool SimConfig::resetFromParsedMap(boost::program_options::variables_map const& 
   mConfigData.mGenerator = vm["generator"].as<std::string>();
   mConfigData.mNEvents = vm["nEvents"].as<unsigned int>();
   mConfigData.mExtKinFileName = vm["extKinFile"].as<std::string>();
+  mConfigData.mHepMCFileName = vm["HepMCFile"].as<std::string>();
   mConfigData.mExtGenFileName = vm["extGenFile"].as<std::string>();
   mConfigData.mExtGenFuncName = vm["extGenFunc"].as<std::string>();
   mConfigData.mEmbedIntoFileName = vm["embedIntoFile"].as<std::string>();

--- a/Generators/CMakeLists.txt
+++ b/Generators/CMakeLists.txt
@@ -12,6 +12,10 @@ if(pythia_FOUND)
   set(pythiaTarget pythia)
 endif()
 
+if(HepMC_FOUND)
+  set(hepmcTarget HepMC)
+endif()
+
 o2_add_library(Generators
                SOURCES src/Generator.cxx
                        src/GeneratorTGenerator.cxx
@@ -23,13 +27,18 @@ o2_add_library(Generators
                        src/BoxGunParam.cxx
                        src/GeneratorFactory.cxx
                        $<$<BOOL:${pythia_FOUND}>:src/Pythia8Generator.cxx>
+                       $<$<BOOL:${HepMC_FOUND}>:src/GeneratorHepMC.cxx>
                PUBLIC_LINK_LIBRARIES FairRoot::Base O2::SimConfig
-                                     O2::SimulationDataFormat ${pythiaTarget}
+                                     O2::SimulationDataFormat ${pythiaTarget} ${hepmcTarget}
                                      FairRoot::Gen
                TARGETVARNAME targetName)
 
 if(pythia_FOUND)
   target_compile_definitions(${targetName} PUBLIC GENERATORS_WITH_PYTHIA8)
+endif()
+
+if(HepMC_FOUND)
+  target_compile_definitions(${targetName} PUBLIC GENERATORS_WITH_HEPMC3)
 endif()
 
 set(headers
@@ -45,6 +54,10 @@ set(headers
 if(pythia_FOUND)
   list(APPEND headers include/Generators/Pythia8Generator.h
               include/Generators/GeneratorFactory.h)
+endif()
+
+if(HepMC_FOUND)
+  list(APPEND headers include/Generators/GeneratorHepMC.h)
 endif()
 
 o2_target_root_dictionary(Generators HEADERS ${headers})

--- a/Generators/include/Generators/GeneratorHepMC.h
+++ b/Generators/include/Generators/GeneratorHepMC.h
@@ -1,0 +1,83 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author R+Preghenella - August 2017
+
+#ifndef ALICEO2_EVENTGEN_GENERATORHEPMC_H_
+#define ALICEO2_EVENTGEN_GENERATORHEPMC_H_
+
+#include "Generators/Generator.h"
+#include <fstream>
+
+namespace HepMC
+{
+class Reader;
+class GenEvent;
+class FourVector;
+} // namespace HepMC
+
+namespace o2
+{
+namespace eventgen
+{
+
+/*****************************************************************/
+/*****************************************************************/
+
+class GeneratorHepMC : public Generator
+{
+
+ public:
+  /** default constructor **/
+  GeneratorHepMC();
+  /** constructor **/
+  GeneratorHepMC(const Char_t* name, const Char_t* title = "ALICEo2 HepMC Generator");
+  /** destructor **/
+  ~GeneratorHepMC() override;
+
+  /** Initialize the generator if needed **/
+  Bool_t Init() override;
+
+  /** setters **/
+  void setVersion(Int_t val) { mVersion = val; };
+  void setFileName(std::string val) { mFileName = val; };
+
+ protected:
+  /** copy constructor **/
+  GeneratorHepMC(const GeneratorHepMC&);
+  /** operator= **/
+  GeneratorHepMC& operator=(const GeneratorHepMC&);
+
+  /** methods to override **/
+  Bool_t generateEvent() override;
+  Bool_t boostEvent(Double_t boost) override;
+  Bool_t addTracks(FairPrimaryGenerator* primGen) const override;
+
+  /** methods **/
+  const HepMC::FourVector getBoostedVector(const HepMC::FourVector& vector, Double_t boost);
+
+  /** HepMC interface **/
+  std::ifstream mStream; //!
+  std::string mFileName;
+  Int_t mVersion;
+  HepMC::Reader* mReader;  //!
+  HepMC::GenEvent* mEvent; //!
+
+  ClassDefOverride(GeneratorHepMC, 1);
+
+}; /** class GeneratorHepMC **/
+
+/*****************************************************************/
+/*****************************************************************/
+
+} // namespace eventgen
+} // namespace o2
+
+#endif /* ALICEO2_EVENTGEN_GENERATORHEPMC_H_ */

--- a/Generators/src/GeneratorFactory.cxx
+++ b/Generators/src/GeneratorFactory.cxx
@@ -20,6 +20,10 @@
 #ifdef GENERATORS_WITH_PYTHIA8
 #include <Generators/Pythia8Generator.h>
 #endif
+#include <Generators/GeneratorTGenerator.h>
+#ifdef GENERATORS_WITH_HEPMC3
+#include <Generators/GeneratorHepMC.h>
+#endif
 #include <Generators/BoxGunParam.h>
 #include "TROOT.h"
 #include "TSystem.h"
@@ -117,6 +121,14 @@ void GeneratorFactory::setPrimaryGenerator(o2::conf::SimConfig const& conf, Fair
     extGen->SetStartEvent(conf.getStartEvent());
     primGen->AddGenerator(extGen);
     LOG(INFO) << "using external kinematics";
+#ifdef GENERATORS_WITH_HEPMC3
+  } else if (genconfig.compare("hepmc") == 0) {
+    // external HepMC file
+    auto hepmcGen = new o2::eventgen::GeneratorHepMC();
+    hepmcGen->setFileName(conf.getHepMCFileName());
+    hepmcGen->setVersion(2);
+    primGen->AddGenerator(hepmcGen);
+#endif
 #ifdef GENERATORS_WITH_PYTHIA8
   } else if (genconfig.compare("pythia8") == 0) {
     // pythia8 pp

--- a/Generators/src/GeneratorHepMC.cxx
+++ b/Generators/src/GeneratorHepMC.cxx
@@ -1,0 +1,217 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author R+Preghenella - August 2017
+
+#include "Generators/GeneratorHepMC.h"
+#include "HepMC/ReaderAscii.h"
+#include "HepMC/ReaderAsciiHepMC2.h"
+#include "HepMC/GenEvent.h"
+#include "HepMC/GenParticle.h"
+#include "HepMC/GenVertex.h"
+#include "HepMC/FourVector.h"
+
+/** 
+    HepMC/Errors.h of HepMC3 defines DEBUG as a logging macro, and this interferes with FairLogger.
+    Undefining it for the time being, while thinking about a possible solution for this issue.
+**/
+#ifdef DEBUG
+#undef DEBUG
+#endif
+
+#include "FairLogger.h"
+#include "FairPrimaryGenerator.h"
+#include <cmath>
+
+namespace o2
+{
+namespace eventgen
+{
+
+/*****************************************************************/
+/*****************************************************************/
+
+GeneratorHepMC::GeneratorHepMC()
+  : Generator("ALICEo2", "ALICEo2 HepMC Generator"), mStream(), mFileName(), mVersion(3), mReader(nullptr), mEvent(nullptr)
+{
+  /** default constructor **/
+}
+
+/*****************************************************************/
+
+GeneratorHepMC::GeneratorHepMC(const Char_t* name, const Char_t* title)
+  : Generator(name, title), mStream(), mFileName(), mVersion(3), mReader(nullptr), mEvent(nullptr)
+{
+  /** constructor **/
+}
+
+/*****************************************************************/
+
+GeneratorHepMC::~GeneratorHepMC()
+{
+  /** default destructor **/
+
+  if (mStream.is_open())
+    mStream.close();
+  if (mReader) {
+    mReader->close();
+    delete mReader;
+  }
+  if (mEvent)
+    delete mEvent;
+}
+
+/*****************************************************************/
+
+Bool_t GeneratorHepMC::generateEvent()
+{
+  /** generate event **/
+
+  /** clear and read event **/
+  mEvent->clear();
+  mReader->read_event(*mEvent);
+  if (mReader->failed())
+    return kFALSE;
+  /** set units to desired output **/
+  mEvent->set_units(HepMC::Units::GEV, HepMC::Units::CM);
+
+  /** success **/
+  return kTRUE;
+}
+
+/*****************************************************************/
+
+Bool_t GeneratorHepMC::addTracks(FairPrimaryGenerator* primGen) const
+{
+  /** add tracks **/
+
+  /** loop over particles **/
+  auto particles = mEvent->particles();
+  for (auto const& particle : particles) {
+
+    /** get particle information **/
+    auto pdg = particle->pid();
+    auto st = particle->status();
+    auto momentum = particle->momentum();
+    auto vertex = particle->production_vertex()->position();
+    auto parents = particle->parents();   // less efficient than via vertex
+    auto children = particle->children(); // less efficient than via vertex
+
+    /** get momentum information **/
+    auto px = momentum.x();
+    auto py = momentum.y();
+    auto pz = momentum.z();
+    auto et = momentum.t();
+
+    /** get vertex information **/
+    auto vx = vertex.x();
+    auto vy = vertex.y();
+    auto vz = vertex.z();
+    auto vt = vertex.t() * 3.33564095198152022e-11; // [cm -> s]
+
+    /** get mother information **/
+    auto mm = parents.empty() ? -1 : parents.front()->id() - 1;
+
+    /** get weight information [WIP] **/
+    auto ww = 1.;
+
+    /** set want tracking [WIP] **/
+    auto wt = children.empty() && st == 1;
+
+    /* add track */
+    if (wt) {
+      primGen->AddTrack(pdg, px, py, pz, vx, vy, vz, mm, wt, et, vt, ww);
+    }
+
+  } /** end of loop over particles **/
+
+  /** success **/
+  return kTRUE;
+}
+
+/*****************************************************************/
+
+Bool_t GeneratorHepMC::boostEvent(Double_t boost)
+{
+  /** boost **/
+
+  /** loop over particles **/
+  if (std::abs(boost) < 1.e-6)
+    return kTRUE;
+  auto particles = mEvent->particles();
+  for (auto& particle : particles) {
+    auto momentum = getBoostedVector(particle->momentum(), boost);
+    particle->set_momentum(momentum);
+    auto position = getBoostedVector(particle->production_vertex()->position(), boost);
+    particle->production_vertex()->set_position(position);
+  }
+
+  /** success **/
+  return kTRUE;
+}
+
+/*****************************************************************/
+
+const HepMC::FourVector GeneratorHepMC::getBoostedVector(const HepMC::FourVector& vector, Double_t boost)
+{
+  /** boost **/
+
+  auto x = vector.x();
+  auto y = vector.y();
+  auto z = vector.z();
+  auto t = vector.t();
+  auto coshb = std::cosh(boost);
+  auto sinhb = std::sinh(boost);
+  auto xx = x;
+  auto yy = y;
+  auto zz = z * coshb - t * sinhb;
+  auto tt = t * coshb - z * sinhb;
+  return HepMC::FourVector(xx, yy, zz, tt);
+}
+
+/*****************************************************************/
+
+Bool_t GeneratorHepMC::Init()
+{
+  /** init **/
+
+  /** open file **/
+  mStream.open(mFileName);
+  if (!mStream.is_open()) {
+    LOG(FATAL) << "Cannot open input file: " << mFileName << std::endl;
+    return kFALSE;
+  }
+
+  /** create reader according to HepMC version **/
+  switch (mVersion) {
+    case 2:
+      mStream.close();
+      mReader = new HepMC::ReaderAsciiHepMC2(mFileName);
+      break;
+    case 3:
+      mReader = new HepMC::ReaderAscii(mStream);
+      break;
+    default:
+      LOG(FATAL) << "Unsupported HepMC version: " << mVersion << std::endl;
+      return kFALSE;
+  }
+
+  /** create event **/
+  mEvent = new HepMC::GenEvent();
+
+  /** success **/
+  return !mReader->failed();
+}
+
+/*****************************************************************/
+/*****************************************************************/
+
+} /* namespace eventgen */
+} /* namespace o2 */

--- a/Generators/src/GeneratorsLinkDef.h
+++ b/Generators/src/GeneratorsLinkDef.h
@@ -27,6 +27,9 @@
 
 #pragma link C++ class o2::eventgen::Generator + ;
 #pragma link C++ class o2::eventgen::GeneratorTGenerator + ;
+#ifdef GENERATORS_WITH_HEPMC3
+#pragma link C++ class o2::eventgen::GeneratorHepMC + ;
+#endif
 #pragma link C++ class o2::eventgen::Pythia6Generator + ;
 #ifdef GENERATORS_WITH_PYTHIA8
 #pragma link C++ class o2::eventgen::Pythia8Generator + ;

--- a/dependencies/FindHepMC.cmake
+++ b/dependencies/FindHepMC.cmake
@@ -1,0 +1,25 @@
+# Copyright CERN and copyright holders of ALICE O2. This software is distributed
+# under the terms of the GNU General Public License v3 (GPL Version 3), copied
+# verbatim in the file "COPYING".
+#
+# See http://alice-o2.web.cern.ch/license for full licensing information.
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization or
+# submit itself to any jurisdiction.
+
+# use the HepMCConfig.cmake provided by the HepMC3 installation to create a
+# single target HepMC with the include directories and libraries we need
+
+find_package(HepMC NO_MODULE)
+if(NOT HepMC_FOUND)
+  return()
+endif()
+
+add_library(HepMC IMPORTED INTERFACE)
+
+set_target_properties(HepMC
+                      PROPERTIES
+		      INTERFACE_LINK_LIBRARIES "${HEPMC_LIBRARIES}"
+		      INTERFACE_INCLUDE_DIRECTORIES "${HEPMC_INCLUDE_DIR}")
+

--- a/dependencies/O2SimulationDependencies.cmake
+++ b/dependencies/O2SimulationDependencies.cmake
@@ -61,8 +61,11 @@ find_package(Geant4VMC MODULE)
 set_package_properties(Geant4VMC PROPERTIES TYPE ${mcPackageRequirement})
 find_package(VGM CONFIG)
 set_package_properties(VGM PROPERTIES TYPE ${mcPackageRequirement})
-find_package(HepMC CONFIG)
-set_package_properties(HepMC PROPERTIES TYPE ${mcPackageRequirement})
+find_package(HepMC MODULE)
+set_package_properties(HepMC
+		       PROPERTIES
+		       TYPE ${mcPackageRequirement} DESCRIPTION
+		       	    "the HepMC3 event record package")
 
 set(doBuildSimulation OFF)
 


### PR DESCRIPTION
This PR implements an interface to HepMC files to be used within the o2 simulation.
Usage via the `o2-sim` executable is possible 
```o2-sim -g hepmc --HepMCFile thefilename.hepmc```

It is not mandatory to update `alidist` to have this code compiled.
On the other hand, https://github.com/alisw/alidist/pull/1813 solves a ROOT warning (possibly harmless).


