### PR TITLE
[WIP] Implementing vector splitting in the RootTreeWriter 

### DIFF
--- a/Framework/Utils/include/DPLUtils/MakeRootTreeWriterSpec.h
+++ b/Framework/Utils/include/DPLUtils/MakeRootTreeWriterSpec.h
@@ -316,6 +316,10 @@ class MakeRootTreeWriterSpec
         auto branchName = ic.options().get<std::string>(branchNameOptions[branchIndex].first.c_str());
         processAttributes->writer->setBranchName(branchIndex, branchName.c_str());
       }
+      auto maxVectorSize = ic.options().get<int>("maxVectorSize");
+      if (maxVectorSize > 0) {
+	processAttributes->writer->setMaxVectorSize(maxVectorSize);
+      }
       processAttributes->writer->init(filename.c_str(), treename.c_str());
 
       // the callback to be set as hook at stop of processing for the framework
@@ -394,6 +398,7 @@ class MakeRootTreeWriterSpec
       {"outfile", VariantType::String, mDefaultFileName.c_str(), {"Name of the output file"}},
       {"treename", VariantType::String, mDefaultTreeName.c_str(), {"Name of tree"}},
       {"nevents", VariantType::Int, mDefaultNofEvents, {"Number of events to execute"}},
+      {"maxVectorSize", VariantType::Int, 0, {"Number of elements written at once for large std vectors"}},
       {"terminate", VariantType::String, mDefaultTerminationPolicy.c_str(), {"Terminate the 'process' or 'workflow'"}},
     };
     for (size_t branchIndex = 0; branchIndex < mBranchNameOptions.size(); branchIndex++) {

--- a/Framework/Utils/include/DPLUtils/RootTreeReader.h
+++ b/Framework/Utils/include/DPLUtils/RootTreeReader.h
@@ -240,6 +240,7 @@ class GenericRootTreeReader
       spec.second->branch->SetAddress(&data);
       spec.second->branch->GetEntry(mReadEntry);
       if (spec.second->sizebranch == nullptr) {
+        LOG(INFO) << "publishing branch " << spec.second->name;
         snapshot(spec.first, std::move(ROOTSerializedByClass(*data, spec.second->classinfo)));
       } else {
         size_t datasize = 0;

--- a/Framework/Utils/test/test_RootTreeWriterWorkflow.cxx
+++ b/Framework/Utils/test/test_RootTreeWriterWorkflow.cxx
@@ -152,6 +152,15 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
   std::string altFileName = fileName + "_alt.root";
   fileName += ".root";
 
+  // clean up before the running the workflow. Somehow this is not possible in the destructor of
+  // the checker
+  if (boost::filesystem::exists(fileName.c_str())) {
+    boost::filesystem::remove(fileName.c_str());
+  }
+  if (boost::filesystem::exists(altFileName.c_str())) {
+    boost::filesystem::remove(altFileName.c_str());
+  }
+
   sChecker.addCheck(fileName, 1);
   sChecker.addCheck(altFileName, sTreeSize);
 


### PR DESCRIPTION
This introduces option `--maxVectorSize` to the `RootTreeWriter` in order to split large vectors into multiple writes.

@shahor02 is this what you have in mind? Can be tested like
```
o2-tpc-reco-workflow --infile tpcdigits.root --tpc-lanes 4 --tpc-tracker '--tracker-options "cont refX=83 bz=-5.0068597793"' --maxVectorSize 100000
```

If this matches your needs, I will implement the reader functionality to merge the data back into one vector.

I think thi is a very tricky functionality, in particular if there are other objects stored in the same tree. I quick test gave me multiplied MC label arrays in the tree viewer, but this can be an artifact of the viewer.