### PR TITLE
[ITS] Speed-up CA initialisation + 2 iteration tracking example

### DIFF
--- a/Detectors/ITSMFT/ITS/macros/test/CheckTracks.C
+++ b/Detectors/ITSMFT/ITS/macros/test/CheckTracks.C
@@ -19,10 +19,38 @@
 #include "SimulationDataFormat/MCTruthContainer.h"
 #include "DataFormatsITSMFT/Cluster.h"
 #include "DataFormatsITS/TrackITS.h"
+
 #endif
+
+struct DataFrames {
+  void update(int frame, long index)
+  {
+    if (frame < firstFrame) {
+      firstFrame = frame;
+      firstIndex = index;
+    }
+    if (frame > lastFrame) {
+      lastFrame = frame;
+      lastIndex = index;
+    }
+    if (frame == firstFrame && index < firstIndex) {
+      firstIndex = index;
+    }
+    if (frame == lastFrame && index > lastIndex) {
+      lastIndex = index;
+    }
+  }
+
+  long firstFrame = 10000;
+  int firstIndex = 1;
+  long lastFrame = -10000;
+  int lastIndex = -1;
+};
 
 void CheckTracks(std::string tracfile = "o2trac_its.root", std::string clusfile = "o2clus_its.root", std::string hitfile = "o2sim.root")
 {
+  bool filterMultiROFTracks = 1;
+
   using namespace o2::itsmft;
   using namespace o2::its;
 
@@ -40,21 +68,24 @@ void CheckTracks(std::string tracfile = "o2trac_its.root", std::string clusfile 
   // MC tracks
   TFile* file0 = TFile::Open(hitfile.data());
   TTree* mcTree = (TTree*)gFile->Get("o2sim");
+  mcTree->SetBranchStatus("*", 0); //disable all branches
+  //mcTree->SetBranchStatus("MCEventHeader.*",1);
+  mcTree->SetBranchStatus("MCTrack*", 1);
+
   std::vector<o2::MCTrack>* mcArr = nullptr;
   mcTree->SetBranchAddress("MCTrack", &mcArr);
+
+  /*
   std::vector<o2::TrackReference>* mcTrackRefs = nullptr;
   mcTree->SetBranchAddress("TrackRefs", &mcTrackRefs);
+  */
 
   // Clusters
   TFile::Open(clusfile.data());
   TTree* clusTree = (TTree*)gFile->Get("o2sim");
   std::vector<Cluster>* clusArr = nullptr;
-  auto* branch = clusTree->GetBranch("ITSCluster");
-  if (!branch) {
-    std::cout << "No clusters !" << std::endl;
-    return;
-  }
-  branch->SetAddress(&clusArr);
+  clusTree->SetBranchAddress("ITSCluster", &clusArr);
+
   // Cluster MC labels
   o2::dataformats::MCTruthContainer<o2::MCCompLabel>* clusLabArr = nullptr;
   clusTree->SetBranchAddress("ITSClusterMCTruth", &clusLabArr);
@@ -68,10 +99,8 @@ void CheckTracks(std::string tracfile = "o2trac_its.root", std::string clusfile 
   o2::dataformats::MCTruthContainer<o2::MCCompLabel>* trkLabArr = nullptr;
   recTree->SetBranchAddress("ITSTrackMCTruth", &trkLabArr);
 
-  Int_t nrec = 0;
   Int_t lastEventIDcl = -1, cf = 0;
-  Int_t lastEventIDtr = -1, tf = 0;
-  Int_t nev = mcTree->GetEntries();
+  Int_t nev = mcTree->GetEntriesFast();
 
   Int_t nb = 100;
   Double_t xbins[nb + 1], ptcutl = 0.01, ptcuth = 10.;
@@ -82,90 +111,190 @@ void CheckTracks(std::string tracfile = "o2trac_its.root", std::string clusfile 
   num->Sumw2();
   TH1D* fak = new TH1D("fak", ";#it{p}_{T} (GeV/#it{c});Fak", nb, xbins);
   fak->Sumw2();
+  TH1D* clone = new TH1D("clone", ";#it{p}_{T} (GeV/#it{c});Clone", nb, xbins);
+  clone->Sumw2();
+
   TH1D* den = new TH1D("den", ";#it{p}_{T} (GeV/#it{c});Den", nb, xbins);
   den->Sumw2();
 
-  for (Int_t n = 0; n < 50; n++) {
-    std::cout << "\nMC event " << n << '/' << nev << std::endl;
-    Int_t nGen = 0, nGoo = 0, nFak = 0;
-    mcTree->GetEvent(n);
-    Int_t nmc = mcArr->size();
-    Int_t nmcrefs = mcTrackRefs->size();
+  // search for MC events in frames
 
-    while ((n > lastEventIDtr) && (tf < recTree->GetEntries())) { // Cache a new reconstructed entry
-      recTree->GetEvent(tf);
-      nrec = recArr->size();
-      for (int i = 0; i < nrec; i++) { // Find the last MC event within this reconstructed entry
-        auto mclab = (trkLabArr->getLabels(i))[0];
-        auto id = mclab.getEventID();
-        if (id > lastEventIDtr)
-          lastEventIDtr = id;
-      }
-      if (nrec > 0)
-        std::cout << "Caching track entry #" << tf << ", with the last event ID=" << lastEventIDtr << std::endl;
-      tf++;
+  cout << "Find mc events in cluster frames.. " << endl;
+
+  int loadedEventClust = -1;
+
+  vector<DataFrames> clusterFrames(nev);
+
+  for (int frame = 0; frame < clusTree->GetEntriesFast(); frame++) { // Cluster frames
+    if (!clusTree->GetEvent(frame))
+      continue;
+    loadedEventClust = frame;
+    for (unsigned int i = 0; i < clusArr->size(); i++) { // Find the last MC event within this reconstructed entry
+      auto lab = (clusLabArr->getLabels(i))[0];
+      if (!lab.isValid() || lab.getSourceID() != 0 || lab.getEventID() < 0 || lab.getEventID() >= nev)
+        continue;
+      clusterFrames[lab.getEventID()].update(frame, i);
     }
-    while ((n > lastEventIDcl) && (cf < clusTree->GetEntries())) { // Cache a new reconstructed entry
-      clusTree->GetEvent(cf);
-      for (int i = 0; i < clusArr->size(); i++) { // Find the last MC event within this reconstructed entry
-        auto mclab = (clusLabArr->getLabels(i))[0];
-        auto id = mclab.getEventID();
-        if (id > lastEventIDcl)
-          lastEventIDcl = id;
+  }
+
+  cout << "Find mc events in track frames.. " << endl;
+
+  int loadedEventTracks = -1;
+
+  vector<DataFrames> trackFrames(nev);
+  for (int frame = 0; frame < recTree->GetEntriesFast(); frame++) { // Track frames
+    if (!recTree->GetEvent(frame))
+      continue;
+    int loadedEventTracks = frame;
+    for (unsigned int i = 0; i < recArr->size(); i++) { // Find the last MC event within this reconstructed entry
+      auto lab = (trkLabArr->getLabels(i))[0];
+      if (!lab.isValid()) {
+        const TrackITS& recTrack = (*recArr)[i];
+        fak->Fill(recTrack.getPt());
       }
-      if (nrec > 0)
-        std::cout << "Caching cluster entry #" << cf << ", with the last event ID=" << lastEventIDcl << std::endl;
-      cf++;
+      if (!lab.isValid() || lab.getSourceID() != 0 || lab.getEventID() < 0 || lab.getEventID() >= nev)
+        continue;
+      trackFrames[lab.getEventID()].update(frame, i);
     }
+  }
+
+  cout << "Process mc events.. " << endl;
+
+  Int_t statGen = 0, statGoo = 0, statFak = 0, statClone = 0;
+  int nDataEvents = 0;
+
+  for (Int_t n = 0; n < nev; n++) { // loop over MC events
+
+    std::cout << "\nMC event " << n << '/' << nev << std::endl;
+    DataFrames f = clusterFrames[n];
+    if ((f.firstFrame > f.lastFrame) ||
+        ((f.firstFrame == f.lastFrame) && (f.firstIndex > f.lastIndex)))
+      continue;
+
+    if (!mcTree->GetEvent(n))
+      continue;
+    //cout<<"mc event loaded"<<endl;
+
+    Int_t nmc = mcArr->size();
+    //Int_t nmcrefs = mcTrackRefs->size();
 
     std::vector<int> clusMap(nmc, 0);
-    for (uint i = 0; i < clusArr->size(); i++) {
-      const Cluster& c = (*clusArr)[i];
-      auto lab = (clusLabArr->getLabels(i))[0];
-      if (!lab.isCorrect())
-        continue;
-      if (lab.getEventID() != n)
-        continue;
+    std::vector<int> clusRofMap(nmc, -1);
+    std::vector<int> trackMap(nmc, -1);
+    std::vector<int> mapNFakes(nmc, 0);
+    std::vector<int> mapNClones(nmc, 0);
 
-      if (lab.getTrackID() >= nmc)
-        clusMap.resize(lab.getTrackID());
-      int& ok = clusMap[lab.getTrackID()];
-      auto r = c.getX();
-      if (TMath::Abs(r - 2.2) < 0.5)
-        ok |= 0b1;
-      if (TMath::Abs(r - 3.0) < 0.5)
-        ok |= 0b10;
-      if (TMath::Abs(r - 3.8) < 0.5)
-        ok |= 0b100;
-      if (TMath::Abs(r - 19.5) < 0.5)
-        ok |= 0b1000;
-      if (TMath::Abs(r - 24.5) < 0.5)
-        ok |= 0b10000;
-      if (TMath::Abs(r - 34.5) < 0.5)
-        ok |= 0b100000;
-      if (TMath::Abs(r - 39.5) < 0.5)
-        ok |= 0b1000000;
+    std::vector<TrackITS> trackStore;
+    trackStore.reserve(10000);
+
+    f = trackFrames[n];
+    cout << "track frames: " << f.firstFrame << ", " << f.firstIndex << " <-> " << f.lastFrame << ", " << f.lastIndex << endl;
+
+    for (int frame = f.firstFrame; frame <= f.lastFrame; frame++) {
+      if (frame != loadedEventTracks) {
+        loadedEventTracks = -1;
+        if (!recTree->GetEvent(frame))
+          continue;
+        loadedEventTracks = frame;
+      }
+      long nentr = recArr->size();
+
+      long firstIndex = (frame == f.firstFrame) ? f.firstIndex : 0;
+      long lastIndex = (frame == f.lastFrame) ? f.lastIndex : nentr - 1;
+
+      for (long i = firstIndex; i <= lastIndex; i++) {
+        auto lab = (trkLabArr->getLabels(i))[0];
+        if (!lab.isValid() || lab.getSourceID() != 0 || lab.getEventID() != n)
+          continue;
+        int mcid = lab.getTrackID();
+        if (mcid < 0 || mcid >= nmc) {
+          cout << "track mc label is too big!!!" << endl;
+          continue;
+        }
+        if (lab.isFake()) {
+          mapNFakes[mcid]++;
+        } else if (trackMap[mcid] >= 0) {
+          mapNClones[mcid]++;
+        } else {
+          trackMap[mcid] = trackStore.size();
+          const TrackITS& recTrack = (*recArr)[i];
+          trackStore.emplace_back(recTrack);
+        }
+      }
     }
 
-    std::vector<const TrackITS*> trackMap(clusMap.size(), nullptr);
-    std::vector<o2::MCCompLabel> trackLabelMap;
-    trackLabelMap.resize(clusMap.size());
+    f = clusterFrames[n];
+    cout << "cluster frames: " << f.firstFrame << ", " << f.firstIndex << " <-> " << f.lastFrame << ", " << f.lastIndex << endl;
+    int nClusters = 0;
+    for (int frame = f.firstFrame; frame <= f.lastFrame; frame++) {
+      if (frame != loadedEventClust) {
+        loadedEventClust = -1;
+        if (!clusTree->GetEvent(frame))
+          continue;
+        loadedEventClust = frame;
+      }
+      long nentr = clusArr->size();
 
-    for (Int_t i = 0; i < nrec; i++) {
-      const TrackITS& recTrack = (*recArr)[i];
-      const auto& mclab = (trkLabArr->getLabels(i))[0];
-      auto id = mclab.getEventID();
-      if (!mclab.isValid())
-        continue;
-      if (id != n)
-        continue;
-      int lab = mclab.getTrackID();
-      trackMap[lab] = &recTrack;
-      trackLabelMap[lab] = mclab;
-    }
+      long firstIndex = (frame == f.firstFrame) ? f.firstIndex : 0;
+      long lastIndex = (frame == f.lastFrame) ? f.lastIndex : nentr - 1;
 
-    while (nmc--) {
-      const auto& mcTrack = (*mcArr)[nmc];
+      for (int i = firstIndex; i <= lastIndex; i++) {
+        auto lab = (clusLabArr->getLabels(i))[0];
+        if (!lab.isValid() || lab.getSourceID() != 0 || lab.getEventID() != n)
+          continue;
+
+        int mcid = lab.getTrackID();
+        if (mcid < 0 || mcid >= nmc) {
+          cout << "cluster mc label is too big!!!" << endl;
+          continue;
+        }
+
+        if (!lab.isCorrect())
+          continue;
+
+        const Cluster& c = (*clusArr)[i];
+
+        if (clusRofMap[mcid] < 0) {
+          clusRofMap[mcid] = c.getROFrame();
+        }
+        if (filterMultiROFTracks && (clusRofMap[mcid] != (int)c.getROFrame()))
+          continue;
+
+        nClusters++;
+
+        int& ok = clusMap[mcid];
+        auto r = c.getX();
+        if (TMath::Abs(r - 2.2) < 0.5)
+          ok |= 0b1;
+        if (TMath::Abs(r - 3.0) < 0.5)
+          ok |= 0b10;
+        if (TMath::Abs(r - 3.8) < 0.5)
+          ok |= 0b100;
+        if (TMath::Abs(r - 19.5) < 0.5)
+          ok |= 0b1000;
+        if (TMath::Abs(r - 24.5) < 0.5)
+          ok |= 0b10000;
+        if (TMath::Abs(r - 34.5) < 0.5)
+          ok |= 0b100000;
+        if (TMath::Abs(r - 39.5) < 0.5)
+          ok |= 0b1000000;
+      }
+    } // cluster frames
+
+    if (nClusters > 0)
+      nDataEvents++;
+
+    Int_t nGen = 0, nGoo = 0, nFak = 0, nClone = 0;
+
+    for (int mc = 0; mc < nmc; mc++) {
+
+      const auto& mcTrack = (*mcArr)[mc];
+
+      if (mapNFakes[mc] > 0) { // Fake-track rate calculation
+        nFak += mapNFakes[mc];
+        fak->Fill(mcTrack.GetPt(), mapNFakes[mc]);
+      }
+
       Int_t mID = mcTrack.getMotherTrackId();
       if (mID >= 0)
         continue; // Select primary particles
@@ -173,7 +302,7 @@ void CheckTracks(std::string tracfile = "o2trac_its.root", std::string clusfile 
       if (TMath::Abs(pdg) != 211)
         continue; // Select pions
 
-      if (clusMap[nmc] != 0b1111111)
+      if (clusMap[mc] != 0b1111111)
         continue;
 
       nGen++; // Generated tracks for the efficiency calculation
@@ -193,47 +322,62 @@ void CheckTracks(std::string tracfile = "o2trac_its.root", std::string clusfile 
 
       den->Fill(mcPt);
 
-      const TrackITS* recTrack = trackMap[nmc];
-      if (recTrack == nullptr)
-        continue;
-
-      auto out = recTrack->getParamOut();
-      // recYOut = out.getY();
-      recZOut = out.getZ();
-      recPhiOut = out.getPhi();
-      recThetaOut = out.getTheta();
-
-      std::array<float, 3> p;
-      recTrack->getPxPyPzGlo(p);
-      recPt = recTrack->getPt();
-      recPhi = TMath::ATan2(p[1], p[0]);
-      recLam = TMath::ATan2(p[2], recPt);
-      Float_t vx = 0., vy = 0., vz = 0.; // Assumed primary vertex
-      Float_t bz = 5.;                   // Assumed magnetic field
-      recTrack->getImpactParams(vx, vy, vz, bz, ip);
-
-      auto label = trackLabelMap[nmc];
-      if (label.isCorrect()) {
+      if (trackMap[mc] >= 0) {
         nGoo++; // Good found tracks for the efficiency calculation
         num->Fill(mcPt);
-      } else {
-        nFak++; // Fake-track rate calculation
-        fak->Fill(mcPt);
+
+        const TrackITS& recTrack = trackStore[trackMap[mc]];
+        auto out = recTrack.getParamOut();
+        // recYOut = out.getY();
+        recZOut = out.getZ();
+        recPhiOut = out.getPhi();
+        recThetaOut = out.getTheta();
+        std::array<float, 3> p;
+        recTrack.getPxPyPzGlo(p);
+        recPt = recTrack.getPt();
+        recPhi = TMath::ATan2(p[1], p[0]);
+        recLam = TMath::ATan2(p[2], recPt);
+        Float_t vx = 0., vy = 0., vz = 0.; // Assumed primary vertex
+        Float_t bz = 5.;                   // Assumed magnetic field
+        recTrack.getImpactParams(vx, vy, vz, bz, ip);
+
+        nt->Fill( // mcYOut,recYOut,
+          mcZOut, recZOut, mcPhiOut, recPhiOut, mcThetaOut, recThetaOut, mcPhi, recPhi, mcLam, recLam, mcPt, recPt, ip[0],
+          ip[1], mc);
       }
 
-      nt->Fill( // mcYOut,recYOut,
-        mcZOut, recZOut, mcPhiOut, recPhiOut, mcThetaOut, recThetaOut, mcPhi, recPhi, mcLam, recLam, mcPt, recPt, ip[0],
-        ip[1], label.getTrackIDSigned());
+      if (mapNClones[mc] > 0) { // Clone-track rate calculation
+        nClone += mapNClones[mc];
+        clone->Fill(mcPt, mapNClones[mc]);
+      }
     }
+
+    statGen += nGen;
+    statGoo += nGoo;
+    statFak += nFak;
+    statClone += nClone;
+
     if (nGen > 0) {
       Float_t eff = nGoo / Float_t(nGen);
       Float_t rat = nFak / Float_t(nGen);
-      std::cout << "Good found tracks: " << nGoo << ",  efficiency: " << eff << ",  fake-track rate: " << rat << std::endl;
+      Float_t clonerat = nClone / Float_t(nGen);
+      std::cout << "Good found tracks: " << nGoo << ",  efficiency: " << eff << ",  fake-track rate: " << rat << " clone rate " << clonerat << std::endl;
     }
-  }
+
+  } // mc events
+
+  cout << "\nOverall efficiency: " << endl;
+  if (statGen > 0) {
+    Float_t eff = statGoo / Float_t(statGen);
+    Float_t rat = statFak / Float_t(statGen);
+    Float_t clonerat = statClone / Float_t(statGen);
+    std::cout << "Good found tracks/event: " << statGoo / nDataEvents << ",  efficiency: " << eff << ",  fake-track rate: " << rat << " clone rate " << clonerat << std::endl;
+    }
 
   // "recPt>0" means "found tracks only"
   // "label>0" means "found good tracks only"
+
+    /*
   new TCanvas;
   nt->Draw("ipD", "recPt>0 && label>0");
   new TCanvas;
@@ -246,15 +390,19 @@ void CheckTracks(std::string tracfile = "o2trac_its.root", std::string clusfile 
   nt->Draw("mcPhiOut-recPhiOut", "recPt>0 && label>0");
   new TCanvas;
   nt->Draw("mcThetaOut-recThetaOut", "recPt>0 && label>0");
-  TCanvas* c1 = new TCanvas;
-  c1->SetLogx();
-  c1->SetGridx();
-  c1->SetGridy();
-  num->Divide(num, den, 1, 1, "b");
-  num->Draw("histe");
-  fak->Divide(fak, den, 1, 1, "b");
-  fak->SetLineColor(2);
-  fak->Draw("histesame");
-  f->Write();
-  f->Close();
+  */
+    TCanvas* c1 = new TCanvas;
+    c1->SetLogx();
+    c1->SetGridx();
+    c1->SetGridy();
+    num->Divide(num, den, 1, 1, "b");
+    num->Draw("histe");
+    fak->Divide(fak, den, 1, 1, "b");
+    fak->SetLineColor(2);
+    fak->Draw("histesame");
+    clone->Divide(clone, den, 1, 1, "b");
+    clone->SetLineColor(3);
+    clone->Draw("histesame");
+    f->Write();
+    f->Close();
 }

--- a/Detectors/ITSMFT/ITS/macros/test/CheckTracks.C
+++ b/Detectors/ITSMFT/ITS/macros/test/CheckTracks.C
@@ -372,12 +372,12 @@ void CheckTracks(std::string tracfile = "o2trac_its.root", std::string clusfile 
     Float_t rat = statFak / Float_t(statGen);
     Float_t clonerat = statClone / Float_t(statGen);
     std::cout << "Good found tracks/event: " << statGoo / nDataEvents << ",  efficiency: " << eff << ",  fake-track rate: " << rat << " clone rate " << clonerat << std::endl;
-    }
+  }
 
   // "recPt>0" means "found tracks only"
   // "label>0" means "found good tracks only"
 
-    /*
+  /*
   new TCanvas;
   nt->Draw("ipD", "recPt>0 && label>0");
   new TCanvas;
@@ -391,18 +391,18 @@ void CheckTracks(std::string tracfile = "o2trac_its.root", std::string clusfile 
   new TCanvas;
   nt->Draw("mcThetaOut-recThetaOut", "recPt>0 && label>0");
   */
-    TCanvas* c1 = new TCanvas;
-    c1->SetLogx();
-    c1->SetGridx();
-    c1->SetGridy();
-    num->Divide(num, den, 1, 1, "b");
-    num->Draw("histe");
-    fak->Divide(fak, den, 1, 1, "b");
-    fak->SetLineColor(2);
-    fak->Draw("histesame");
-    clone->Divide(clone, den, 1, 1, "b");
-    clone->SetLineColor(3);
-    clone->Draw("histesame");
-    f->Write();
-    f->Close();
+  TCanvas* c1 = new TCanvas;
+  c1->SetLogx();
+  c1->SetGridx();
+  c1->SetGridy();
+  num->Divide(num, den, 1, 1, "b");
+  num->Draw("histe");
+  fak->Divide(fak, den, 1, 1, "b");
+  fak->SetLineColor(2);
+  fak->Draw("histesame");
+  clone->Divide(clone, den, 1, 1, "b");
+  clone->SetLineColor(3);
+  clone->Draw("histesame");
+  f->Write();
+  f->Close();
 }

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Cluster.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Cluster.h
@@ -29,17 +29,19 @@ namespace its
 {
 
 struct Cluster final {
+  Cluster() = default;
   Cluster(const float x, const float y, const float z, const int idx);
   Cluster(const int, const Cluster&);
   Cluster(const int, const float3&, const Cluster&);
+  void Init(const int, const float3&, const Cluster&);
 
-  float xCoordinate;
-  float yCoordinate;
-  float zCoordinate;
-  float phiCoordinate;
-  float rCoordinate;
-  int clusterId;
-  int indexTableBinIndex;
+  float xCoordinate = -999.f;
+  float yCoordinate = -999.f;
+  float zCoordinate = -999.f;
+  float phiCoordinate = -999.f;
+  float rCoordinate = -999.f;
+  int clusterId = -1;
+  int indexTableBinIndex = -1;
 };
 
 struct TrackingFrameInfo {

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Cluster.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Cluster.h
@@ -29,19 +29,19 @@ namespace its
 {
 
 struct Cluster final {
-  Cluster() = default;
+  Cluster() {} // = default;
   Cluster(const float x, const float y, const float z, const int idx);
   Cluster(const int, const Cluster&);
   Cluster(const int, const float3&, const Cluster&);
   void Init(const int, const float3&, const Cluster&);
 
-  float xCoordinate = -999.f;
-  float yCoordinate = -999.f;
-  float zCoordinate = -999.f;
-  float phiCoordinate = -999.f;
-  float rCoordinate = -999.f;
-  int clusterId = -1;
-  int indexTableBinIndex = -1;
+  float xCoordinate;      // = -999.f;
+  float yCoordinate;      // = -999.f;
+  float zCoordinate;      // = -999.f;
+  float phiCoordinate;    // = -999.f;
+  float rCoordinate;      // = -999.f;
+  int clusterId;          // = -1;
+  int indexTableBinIndex; // = -1;
 };
 
 struct TrackingFrameInfo {

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Cluster.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Cluster.h
@@ -29,7 +29,7 @@ namespace its
 {
 
 struct Cluster final {
-  Cluster() {} // = default;
+  Cluster() = default;
   Cluster(const float x, const float y, const float z, const int idx);
   Cluster(const int, const Cluster&);
   Cluster(const int, const float3&, const Cluster&);

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Constants.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Constants.h
@@ -66,9 +66,11 @@ constexpr int PhiBins{20};
 constexpr float InversePhiBinSize{constants::index_table::PhiBins / constants::math::TwoPi};
 GPU_HOST_DEVICE constexpr GPUArray<float, its::LayersNumber> InverseZBinSize()
 {
-  return GPUArray<float, its::LayersNumber>{{0.5 * ZBins / 16.333f, 0.5 * ZBins / 16.333f, 0.5 * ZBins / 16.333f,
-                                             0.5 * ZBins / 42.140f, 0.5 * ZBins / 42.140f, 0.5 * ZBins / 73.745f,
-                                             0.5 * ZBins / 73.745f}};
+  constexpr auto zSize = its::LayersZCoordinate();
+  constexpr double s = 1.; // safety margin
+  return GPUArray<float, its::LayersNumber>{ { 0.5 * ZBins / (zSize[0] + s), 0.5 * ZBins / (zSize[1] + s), 0.5 * ZBins / (zSize[2] + s),
+                                               0.5 * ZBins / (zSize[3] + s), 0.5 * ZBins / (zSize[4] + s), 0.5 * ZBins / (zSize[5] + s),
+                                               0.5 * ZBins / (zSize[6] + s) } };
 }
 } // namespace index_table
 

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Constants.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Constants.h
@@ -68,9 +68,9 @@ GPU_HOST_DEVICE constexpr GPUArray<float, its::LayersNumber> InverseZBinSize()
 {
   constexpr auto zSize = its::LayersZCoordinate();
   constexpr double s = 1.; // safety margin
-  return GPUArray<float, its::LayersNumber>{ { 0.5 * ZBins / (zSize[0] + s), 0.5 * ZBins / (zSize[1] + s), 0.5 * ZBins / (zSize[2] + s),
-                                               0.5 * ZBins / (zSize[3] + s), 0.5 * ZBins / (zSize[4] + s), 0.5 * ZBins / (zSize[5] + s),
-                                               0.5 * ZBins / (zSize[6] + s) } };
+  return GPUArray<float, its::LayersNumber>{{0.5 * ZBins / (zSize[0] + s), 0.5 * ZBins / (zSize[1] + s), 0.5 * ZBins / (zSize[2] + s),
+                                             0.5 * ZBins / (zSize[3] + s), 0.5 * ZBins / (zSize[4] + s), 0.5 * ZBins / (zSize[5] + s),
+                                             0.5 * ZBins / (zSize[6] + s)}};
 }
 } // namespace index_table
 

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/IndexTableUtils.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/IndexTableUtils.h
@@ -60,7 +60,7 @@ GPU_HOST_DEVICE inline int index_table_utils::getPhiBinIndex(const float current
 GPU_HOST_DEVICE inline int index_table_utils::getBinIndex(const int zIndex, const int phiIndex)
 {
   return gpu::GPUCommonMath::Min(phiIndex * constants::index_table::PhiBins + zIndex,
-                                 constants::index_table::ZBins * constants::index_table::PhiBins);
+                                 constants::index_table::ZBins * constants::index_table::PhiBins - 1);
 }
 
 GPU_HOST_DEVICE inline int index_table_utils::countRowSelectedBins(

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/MathUtils.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/MathUtils.h
@@ -20,6 +20,7 @@
 #include <cmath>
 #endif
 
+#include "MathUtils/Utils.h"
 #include "ITStracking/Constants.h"
 #include "GPUCommonMath.h"
 #include "GPUCommonDef.h"
@@ -40,15 +41,13 @@ GPUhdni() constexpr float3 crossProduct(const float3&, const float3&);
 GPUhdni() float computeCurvature(float x1, float y1, float x2, float y2, float x3, float y3);
 GPUhdni() float computeCurvatureCentreX(float x1, float y1, float x2, float y2, float x3, float y3);
 GPUhdni() float computeTanDipAngle(float x1, float y1, float x2, float y2, float z1, float z2);
-GPUhdni() float fastATan2(float y, float x);
-GPUhdni() float fastATanP(float x);
 
 } // namespace math_utils
 
 GPUhdi() float math_utils::calculatePhiCoordinate(const float xCoordinate, const float yCoordinate)
 {
   //return o2::gpu::CAMath::ATan2(-yCoordinate, -xCoordinate) + constants::math::Pi;
-  return fastATan2(-yCoordinate, -xCoordinate) + constants::math::Pi;
+  return utils::FastATan2(-yCoordinate, -xCoordinate) + constants::math::Pi;
 }
 
 GPUhdi() float math_utils::calculateRCoordinate(const float xCoordinate, const float yCoordinate)
@@ -91,41 +90,6 @@ GPUhdi() float math_utils::computeCurvatureCentreX(float x1, float y1, float x2,
 GPUhdi() float math_utils::computeTanDipAngle(float x1, float y1, float x2, float y2, float z1, float z2)
 {
   return (z1 - z2) / o2::gpu::CAMath::Sqrt((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2));
-}
-
-GPUhdi() float math_utils::fastATan2(float y, float x)
-{
-  constexpr float pi05 = 0.5 * constants::math::Pi;
-
-  float sign = 1.f;
-
-  if (y < 0.f) {
-    y = -y;
-    sign = -1.f;
-  }
-
-  // y >= 0
-
-  float add = 0.f;
-  if (x < 0.f) {
-    add = pi05;
-    float tmp = y;
-    y = -x;
-    x = tmp;
-  }
-
-  // x>=0, y>=0
-  // use atan(t)+atan(1/t)=pi/2 for t>0
-  float atanp = (x > y) ? fastATanP(y / x) : pi05 - fastATanP(x / y);
-  return sign * (atanp + add);
-}
-
-GPUhdi() float math_utils::fastATanP(float x)
-{
-  // x >= 0
-  const float kThresh = 0.315f; // parametrization switch here
-  constexpr float kC0 = 7.85398163397448279e-01f;
-  return x > kThresh ? x * (kC0 + 0.273f * (1.f - x)) : x / (1.f + x * x * 0.2815f);
 }
 
 } // namespace its

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/MathUtils.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/MathUtils.h
@@ -23,6 +23,8 @@
 #include "ITStracking/Constants.h"
 #include "GPUCommonMath.h"
 #include "GPUCommonDef.h"
+#include <cassert>
+#include <iostream>
 
 namespace o2
 {
@@ -38,12 +40,15 @@ GPUhdni() constexpr float3 crossProduct(const float3&, const float3&);
 GPUhdni() float computeCurvature(float x1, float y1, float x2, float y2, float x3, float y3);
 GPUhdni() float computeCurvatureCentreX(float x1, float y1, float x2, float y2, float x3, float y3);
 GPUhdni() float computeTanDipAngle(float x1, float y1, float x2, float y2, float z1, float z2);
+GPUhdni() float fastATan2(float y, float x);
+GPUhdni() float fastATanP(float x);
 
 } // namespace math_utils
 
 GPUhdi() float math_utils::calculatePhiCoordinate(const float xCoordinate, const float yCoordinate)
 {
-  return o2::gpu::CAMath::ATan2(-yCoordinate, -xCoordinate) + constants::math::Pi;
+  //return o2::gpu::CAMath::ATan2(-yCoordinate, -xCoordinate) + constants::math::Pi;
+  return fastATan2(-yCoordinate, -xCoordinate) + constants::math::Pi;
 }
 
 GPUhdi() float math_utils::calculateRCoordinate(const float xCoordinate, const float yCoordinate)
@@ -86,6 +91,41 @@ GPUhdi() float math_utils::computeCurvatureCentreX(float x1, float y1, float x2,
 GPUhdi() float math_utils::computeTanDipAngle(float x1, float y1, float x2, float y2, float z1, float z2)
 {
   return (z1 - z2) / o2::gpu::CAMath::Sqrt((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2));
+}
+
+GPUhdi() float math_utils::fastATan2(float y, float x)
+{
+  constexpr float pi05 = 0.5 * constants::math::Pi;
+
+  float sign = 1.f;
+
+  if (y < 0.f) {
+    y = -y;
+    sign = -1.f;
+  }
+
+  // y >= 0
+
+  float add = 0.f;
+  if (x < 0.f) {
+    add = pi05;
+    float tmp = y;
+    y = -x;
+    x = tmp;
+  }
+
+  // x>=0, y>=0
+  // use atan(t)+atan(1/t)=pi/2 for t>0
+  float atanp = (x > y) ? fastATanP(y / x) : pi05 - fastATanP(x / y);
+  return sign * (atanp + add);
+}
+
+GPUhdi() float math_utils::fastATanP(float x)
+{
+  // x >= 0
+  const float kThresh = 0.315f; // parametrization switch here
+  constexpr float kC0 = 7.85398163397448279e-01f;
+  return x > kThresh ? x * (kC0 + 0.273f * (1.f - x)) : x / (1.f + x * x * 0.2815f);
 }
 
 } // namespace its

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/PrimaryVertexContext.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/PrimaryVertexContext.h
@@ -67,6 +67,7 @@ class PrimaryVertexContext
 
  protected:
   float3 mPrimaryVertex;
+  std::array<std::vector<Cluster>, constants::its::LayersNumber> mUnsortedClusters;
   std::array<std::vector<Cluster>, constants::its::LayersNumber> mClusters;
   std::array<std::vector<bool>, constants::its::LayersNumber> mUsedClusters;
   std::array<std::vector<Cell>, constants::its::CellsPerRoad> mCells;

--- a/Detectors/ITSMFT/ITS/tracking/src/Cluster.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Cluster.cxx
@@ -66,6 +66,19 @@ Cluster::Cluster(const int layerIndex, const float3& primaryVertex, const Cluste
   // Nothing to do
 }
 
+void Cluster::Init(const int layerIndex, const float3& primaryVertex, const Cluster& other)
+{
+  xCoordinate = other.xCoordinate;
+  yCoordinate = other.yCoordinate;
+  zCoordinate = other.zCoordinate;
+  phiCoordinate = getNormalizedPhiCoordinate(
+    calculatePhiCoordinate(xCoordinate - primaryVertex.x, yCoordinate - primaryVertex.y));
+  rCoordinate = calculateRCoordinate(xCoordinate - primaryVertex.x, yCoordinate - primaryVertex.y);
+  clusterId = other.clusterId;
+  indexTableBinIndex = index_table_utils::getBinIndex(index_table_utils::getZBinIndex(layerIndex, zCoordinate),
+                                                     index_table_utils::getPhiBinIndex(phiCoordinate));
+}
+
 TrackingFrameInfo::TrackingFrameInfo(float x, float y, float z, float xTF, float alpha, GPUArray<float, 2>&& posTF,
                                      GPUArray<float, 3>&& covTF)
   : xCoordinate{x}, yCoordinate{y}, zCoordinate{z}, xTrackingFrame{xTF}, alphaTrackingFrame{alpha},

--- a/Detectors/ITSMFT/ITS/tracking/src/Cluster.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Cluster.cxx
@@ -76,7 +76,7 @@ void Cluster::Init(const int layerIndex, const float3& primaryVertex, const Clus
   rCoordinate = calculateRCoordinate(xCoordinate - primaryVertex.x, yCoordinate - primaryVertex.y);
   clusterId = other.clusterId;
   indexTableBinIndex = index_table_utils::getBinIndex(index_table_utils::getZBinIndex(layerIndex, zCoordinate),
-                                                     index_table_utils::getPhiBinIndex(phiCoordinate));
+                                                      index_table_utils::getPhiBinIndex(phiCoordinate));
 }
 
 TrackingFrameInfo::TrackingFrameInfo(float x, float y, float z, float xTF, float alpha, GPUArray<float, 2>&& posTF,

--- a/Detectors/ITSMFT/ITS/tracking/src/PrimaryVertexContext.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/PrimaryVertexContext.cxx
@@ -24,14 +24,25 @@ namespace its
 void PrimaryVertexContext::initialise(const MemoryParameters& memParam, const std::array<std::vector<Cluster>, constants::its::LayersNumber>& cl,
                                       const std::array<float, 3>& pVtx, const int iteration)
 {
-  mPrimaryVertex = {pVtx[0], pVtx[1], pVtx[2]};
 
-  for (int iLayer{0}; iLayer < constants::its::LayersNumber; ++iLayer) {
+  struct ClusterHelper {
+    float phi;
+    float r;
+    int bin;
+    int ind;
+  };
 
-    const auto& currentLayer{cl[iLayer]};
-    const int clustersNum{static_cast<int>(currentLayer.size())};
+  mPrimaryVertex = { pVtx[0], pVtx[1], pVtx[2] };
 
-    if (iteration == 0) {
+  if (iteration == 0) {
+
+    std::vector<ClusterHelper> cHelper;
+
+    for (int iLayer{ 0 }; iLayer < constants::its::LayersNumber; ++iLayer) {
+
+      const auto& currentLayer{ cl[iLayer] };
+      const int clustersNum{ static_cast<int>(currentLayer.size()) };
+
       mClusters[iLayer].clear();
       mClusters[iLayer].resize(clustersNum);
       mUsedClusters[iLayer].clear();
@@ -39,38 +50,57 @@ void PrimaryVertexContext::initialise(const MemoryParameters& memParam, const st
 
       constexpr int _size = constants::index_table::PhiBins * constants::index_table::ZBins;
       std::array<int, _size> clsPerBin;
-      std::array<int, _size> lutPerBin;
       for (int iB{0}; iB < _size; ++iB) {
         clsPerBin[iB] = 0;
-        lutPerBin[iB] = 0;
       }
 
-      std::vector<int> bins(clustersNum);
+      cHelper.clear();
+      cHelper.resize(clustersNum);
+
       for (int iCluster{ 0 }; iCluster < clustersNum; ++iCluster) {
-        const float& x = currentLayer.at(iCluster).xCoordinate;
-        const float& y = currentLayer.at(iCluster).yCoordinate;
-        const float& z = currentLayer.at(iCluster).zCoordinate;
-        const float phi =  math_utils::calculatePhiCoordinate(x - pVtx[0], y - pVtx[1]);
-        int bin = index_table_utils::getBinIndex(index_table_utils::getZBinIndex(iLayer, z),
+        const Cluster& c = currentLayer[iCluster];
+        ClusterHelper& h = cHelper[iCluster];
+        float x = c.xCoordinate - mPrimaryVertex.x;
+        float y = c.yCoordinate - mPrimaryVertex.y;
+        float phi = math_utils::calculatePhiCoordinate(x, y);
+        int bin = index_table_utils::getBinIndex(index_table_utils::getZBinIndex(iLayer, c.zCoordinate),
                                                  index_table_utils::getPhiBinIndex(phi));
-        bins[iCluster] = bin;
-        clsPerBin[bin]++;
+        h.phi = phi;
+        h.r = math_utils::calculateRCoordinate(x, y);
+        h.bin = bin;
+        h.ind = clsPerBin[bin]++;
       }
 
+      std::array<int, _size> lutPerBin;
+      lutPerBin[0] = 0;
       for (int iB{1}; iB < _size; ++iB) {
         lutPerBin[iB] = lutPerBin[iB - 1] + clsPerBin[iB - 1];
       }
 
       for (int iCluster{ 0 }; iCluster < clustersNum; ++iCluster) {
-        const int& bin = bins[iCluster];
-        mClusters[iLayer][lutPerBin[bin]].Init(iLayer, mPrimaryVertex, currentLayer.at(iCluster));
-        lutPerBin[bin]++;
+        ClusterHelper& h = cHelper[iCluster];
+        Cluster& c = mClusters[iLayer][lutPerBin[h.bin] + h.ind];
+        c = currentLayer[iCluster];
+        c.phiCoordinate = h.phi;
+        c.rCoordinate = h.r;
+        c.indexTableBinIndex = h.bin;
       }
 
+      if (iLayer > 0) {
+        for (int iB{ 0 }; iB < _size; ++iB) {
+          mIndexTables[iLayer - 1][iB] = lutPerBin[iB];
+        }
+        for (int iB{ _size }; iB < (int)mIndexTables[iLayer - 1].size(); iB++) {
+          mIndexTables[iLayer - 1][iB] = clustersNum;
+        }
+      }
     }
+  }
 
+  mRoads.clear();
+
+  for (int iLayer{ 0 }; iLayer < constants::its::LayersNumber; ++iLayer) {
     if (iLayer < constants::its::CellsPerRoad) {
-
       mCells[iLayer].clear();
       float cellsMemorySize =
         memParam.MemoryOffset +
@@ -84,7 +114,6 @@ void PrimaryVertexContext::initialise(const MemoryParameters& memParam, const st
     }
 
     if (iLayer < constants::its::CellsPerRoad - 1) {
-
       mCellsLookupTable[iLayer].clear();
       mCellsLookupTable[iLayer].resize(
         std::max(cl[iLayer + 1].size(), cl[iLayer + 2].size()) +
@@ -92,46 +121,13 @@ void PrimaryVertexContext::initialise(const MemoryParameters& memParam, const st
                      cl[iLayer + 1].size()) *
                     cl[iLayer + 2].size()),
         constants::its::UnusedIndex);
-
       mCellsNeighbours[iLayer].clear();
     }
   }
 
-  mRoads.clear();
-
-  for (int iLayer{0}; iLayer < constants::its::LayersNumber; ++iLayer) {
-
-    const int clustersNum = static_cast<int>(mClusters[iLayer].size());
-
-    if (iLayer > 0 && iteration == 0) {
-
-      int previousBinIndex{0};
-      mIndexTables[iLayer - 1][0] = 0;
-
-      for (int iCluster{0}; iCluster < clustersNum; ++iCluster) {
-
-        const int currentBinIndex{mClusters[iLayer][iCluster].indexTableBinIndex};
-
-        if (currentBinIndex > previousBinIndex) {
-
-          for (int iBin{previousBinIndex + 1}; iBin <= currentBinIndex; ++iBin) {
-
-            mIndexTables[iLayer - 1][iBin] = iCluster;
-          }
-
-          previousBinIndex = currentBinIndex;
-        }
-      }
-
-      for (int iBin{previousBinIndex + 1}; iBin < (int)mIndexTables[iLayer - 1].size(); iBin++) {
-        mIndexTables[iLayer - 1][iBin] = clustersNum;
-      }
-    }
-
+  for (int iLayer{ 0 }; iLayer < constants::its::LayersNumber; ++iLayer) {
     if (iLayer < constants::its::TrackletsPerRoad) {
-
       mTracklets[iLayer].clear();
-
       float trackletsMemorySize =
         std::max(cl[iLayer].size(), cl[iLayer + 1].size()) +
         std::ceil((memParam.TrackletsMemoryCoefficients[iLayer] * cl[iLayer].size()) *
@@ -143,7 +139,6 @@ void PrimaryVertexContext::initialise(const MemoryParameters& memParam, const st
     }
 
     if (iLayer < constants::its::CellsPerRoad) {
-
       mTrackletsLookupTable[iLayer].clear();
       mTrackletsLookupTable[iLayer].resize(cl[iLayer + 1].size(), constants::its::UnusedIndex);
     }

--- a/Detectors/ITSMFT/ITS/tracking/src/PrimaryVertexContext.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/PrimaryVertexContext.cxx
@@ -32,16 +32,16 @@ void PrimaryVertexContext::initialise(const MemoryParameters& memParam, const st
     int ind;
   };
 
-  mPrimaryVertex = { pVtx[0], pVtx[1], pVtx[2] };
+  mPrimaryVertex = {pVtx[0], pVtx[1], pVtx[2]};
 
   if (iteration == 0) {
 
     std::vector<ClusterHelper> cHelper;
 
-    for (int iLayer{ 0 }; iLayer < constants::its::LayersNumber; ++iLayer) {
+    for (int iLayer{0}; iLayer < constants::its::LayersNumber; ++iLayer) {
 
-      const auto& currentLayer{ cl[iLayer] };
-      const int clustersNum{ static_cast<int>(currentLayer.size()) };
+      const auto& currentLayer{cl[iLayer]};
+      const int clustersNum{static_cast<int>(currentLayer.size())};
 
       mClusters[iLayer].clear();
       mClusters[iLayer].resize(clustersNum);
@@ -57,7 +57,7 @@ void PrimaryVertexContext::initialise(const MemoryParameters& memParam, const st
       cHelper.clear();
       cHelper.resize(clustersNum);
 
-      for (int iCluster{ 0 }; iCluster < clustersNum; ++iCluster) {
+      for (int iCluster{0}; iCluster < clustersNum; ++iCluster) {
         const Cluster& c = currentLayer[iCluster];
         ClusterHelper& h = cHelper[iCluster];
         float x = c.xCoordinate - mPrimaryVertex.x;
@@ -77,7 +77,7 @@ void PrimaryVertexContext::initialise(const MemoryParameters& memParam, const st
         lutPerBin[iB] = lutPerBin[iB - 1] + clsPerBin[iB - 1];
       }
 
-      for (int iCluster{ 0 }; iCluster < clustersNum; ++iCluster) {
+      for (int iCluster{0}; iCluster < clustersNum; ++iCluster) {
         ClusterHelper& h = cHelper[iCluster];
         Cluster& c = mClusters[iLayer][lutPerBin[h.bin] + h.ind];
         c = currentLayer[iCluster];
@@ -87,10 +87,10 @@ void PrimaryVertexContext::initialise(const MemoryParameters& memParam, const st
       }
 
       if (iLayer > 0) {
-        for (int iB{ 0 }; iB < _size; ++iB) {
+        for (int iB{0}; iB < _size; ++iB) {
           mIndexTables[iLayer - 1][iB] = lutPerBin[iB];
         }
-        for (int iB{ _size }; iB < (int)mIndexTables[iLayer - 1].size(); iB++) {
+        for (int iB{_size}; iB < (int)mIndexTables[iLayer - 1].size(); iB++) {
           mIndexTables[iLayer - 1][iB] = clustersNum;
         }
       }
@@ -99,7 +99,7 @@ void PrimaryVertexContext::initialise(const MemoryParameters& memParam, const st
 
   mRoads.clear();
 
-  for (int iLayer{ 0 }; iLayer < constants::its::LayersNumber; ++iLayer) {
+  for (int iLayer{0}; iLayer < constants::its::LayersNumber; ++iLayer) {
     if (iLayer < constants::its::CellsPerRoad) {
       mCells[iLayer].clear();
       float cellsMemorySize =
@@ -125,7 +125,7 @@ void PrimaryVertexContext::initialise(const MemoryParameters& memParam, const st
     }
   }
 
-  for (int iLayer{ 0 }; iLayer < constants::its::LayersNumber; ++iLayer) {
+  for (int iLayer{0}; iLayer < constants::its::LayersNumber; ++iLayer) {
     if (iLayer < constants::its::TrackletsPerRoad) {
       mTracklets[iLayer].clear();
       float trackletsMemorySize =

--- a/macro/run_trac_ca_its.C
+++ b/macro/run_trac_ca_its.C
@@ -151,12 +151,10 @@ void run_trac_ca_its(bool useITSVertex = false,
   o2::its::VertexerTraits* traits = o2::its::createVertexerTraits();
   o2::its::Vertexer vertexer(traits);
 
-  int roFrameCounter{ 0 };
-
+  int roFrameCounter{0};
 
   std::vector<double> ncls;
   std::vector<double> time;
-
 
   std::vector<TrackingParameters> trackParams(3);
   trackParams[0].TrackletMaxDeltaPhi = 0.05f;
@@ -167,7 +165,7 @@ void run_trac_ca_its(bool useITSVertex = false,
   std::vector<MemoryParameters> memParams(3);
 
   tracker.setParameters(memParams, trackParams);
-  
+
   int currentEvent = -1;
   for (auto& rof : *rofs) {
 
@@ -205,7 +203,7 @@ void run_trac_ca_its(bool useITSVertex = false,
     tracker.clustersToTracks(event);
 
     auto end = std::chrono::high_resolution_clock::now();
-    std::chrono::duration<double, std::milli> diff_t{ end - start };
+    std::chrono::duration<double, std::milli> diff_t{end - start};
 
     ncls.push_back(event.getTotalClusters());
     time.push_back(diff_t.count());
@@ -229,10 +227,9 @@ void run_trac_ca_its(bool useITSVertex = false,
   outTree.Write();
   outFile.Close();
 
-  TGraph* graph = new TGraph(ncls.size(),ncls.data(),time.data());
+  TGraph* graph = new TGraph(ncls.size(), ncls.data(), time.data());
   graph->SetMarkerStyle(20);
   graph->Draw("AP");
-
 }
 
 #endif


### PR DESCRIPTION
I prepared this PR with @sgorbuno who kindly offered help in speeding up some of the routines in the tracking. This time the initialisation was optimised as well as the performance macro (CheckTracks.C) and our own steering macro.
In the new version of the steering macro there is also an example of the 2(n) iterations tracking. I still have to port the full param set of the second iteration from AliRoot, it will come in a second PR.