### PR TITLE
More cuts on track merging, should clean up bogus CE-crossing tracks

### DIFF
--- a/Common/MathUtils/include/MathUtils/Utils.h
+++ b/Common/MathUtils/include/MathUtils/Utils.h
@@ -124,7 +124,7 @@ constexpr int bit2Mask(T first, Args... args)
 }
 //--------------------------------------<<<
 
-GPUdi() float FastATan2(float y, float x)
+GPUhdi() float FastATan2(float y, float x)
 {
   // Fast atan2(y,x) for any angle [-Pi,Pi]
   // Average inaccuracy: 0.00048

--- a/GPU/CMakeLists.txt
+++ b/GPU/CMakeLists.txt
@@ -17,9 +17,6 @@
 # HDRS_CINT_O2: Headers for ROOT dictionary (only for O2) HDRS_INSTALL: Headers
 # for installation only
 
-if(NOT ALIGPU_BUILD_TYPE STREQUAL "O2")
-  add_subdirectory(Common) # included at top level due to dependency order
-endif()
 add_subdirectory(Common)
 add_subdirectory(TPCFastTransformation)
 add_subdirectory(GPUTracking)

--- a/GPU/Common/GPUDefConstantsAndSettings.h
+++ b/GPU/Common/GPUDefConstantsAndSettings.h
@@ -34,13 +34,13 @@
 #define GPUCA_GLOBAL_TRACKING_RANGE 45                // Number of rows from the upped/lower limit to search for global track candidates in for
 #define GPUCA_GLOBAL_TRACKING_Y_RANGE_UPPER 0.85      // Inner portion of y-range in slice that is not used in searching for global track candidates
 #define GPUCA_GLOBAL_TRACKING_Y_RANGE_LOWER 0.85
-#define GPUCA_GLOBAL_TRACKING_MIN_ROWS 10 // Min num of rows an additional global track must span over
-#define GPUCA_GLOBAL_TRACKING_MIN_HITS 8  // Min num of hits for an additional global track
+#define GPUCA_GLOBAL_TRACKING_MIN_ROWS 10             // Min num of rows an additional global track must span over
+#define GPUCA_GLOBAL_TRACKING_MIN_HITS 8              // Min num of hits for an additional global track
 
-//#define GPUCA_MERGER_CE_ROWLIMIT 15              //Distance from first / last row in order to attempt merging accross CE
+#define GPUCA_MERGER_CE_ROWLIMIT 5                    //Distance from first / last row in order to attempt merging accross CE
 
-#define GPUCA_MERGER_LOOPER_QPT_LIMIT 4            // Min Q/Pt to run special looper merging procedure
-#define GPUCA_MERGER_HORIZONTAL_DOUBLE_QPT_LIMIT 2 // Min Q/Pt to attempt second horizontal merge between slices after a vertical merge was found
+#define GPUCA_MERGER_LOOPER_QPT_LIMIT 4               // Min Q/Pt to run special looper merging procedure
+#define GPUCA_MERGER_HORIZONTAL_DOUBLE_QPT_LIMIT 2    // Min Q/Pt to attempt second horizontal merge between slices after a vertical merge was found
 
 #define GPUCA_Y_FACTOR 4                              // Weight of y residual vs z residual in tracklet constructor
 #define GPUCA_MAXN 40                                 // Maximum number of neighbor hits to consider in one row in neightbors finder
@@ -50,11 +50,11 @@
 #define GPUCA_MERGER_COV_LIMIT 1000                   // Abort fit when y/z cov exceed the limit
 #define GPUCA_MIN_TRACK_PT_DEFAULT 0.010              // Default setting for minimum track Pt at some places
 
-#define GPUCA_MAX_SLICE_NTRACK (2 << 24) // Maximum number of tracks per slice (limited by track id format)
+#define GPUCA_MAX_SLICE_NTRACK (2 << 24)              // Maximum number of tracks per slice (limited by track id format)
 
 #define GPUCA_TIMING_SUM 1
 
-#define GPUCA_MAX_SIN_PHI_LOW 0.99f // Must be preprocessor define because c++ pre 11 cannot use static constexpr for initializes
+#define GPUCA_MAX_SIN_PHI_LOW 0.99f                   // Must be preprocessor define because c++ pre 11 cannot use static constexpr for initializes
 #define GPUCA_MAX_SIN_PHI 0.999f
 
 #if defined(HAVE_O2HEADERS) && (!defined(__OPENCL__) || defined(__OPENCLCPP__)) && !(defined(ROOT_VERSION_CODE) && ROOT_VERSION_CODE < 393216)
@@ -75,10 +75,10 @@
 //#define GPUCA_MERGER_BY_MC_LABEL
 #define GPUCA_REPRODUCIBLE_CLUSTER_SORTING
 
-//#define GPUCA_FULL_CLUSTERDATA						//Store all cluster information in the cluster data, also those not needed for tracking.
-//#define GPUCA_TPC_RAW_PROPAGATE_PAD_ROW_TIME							//Propagate Pad, Row, Time cluster information to GM
-//#define GPUCA_GM_USE_FULL_FIELD						//Use offline magnetic field during GMPropagator prolongation
-//#define GPUCA_TPC_USE_STAT_ERROR								//Use statistical errors from offline in track fit
+//#define GPUCA_FULL_CLUSTERDATA                      //Store all cluster information in the cluster data, also those not needed for tracking.
+//#define GPUCA_TPC_RAW_PROPAGATE_PAD_ROW_TIME        //Propagate Pad, Row, Time cluster information to GM
+//#define GPUCA_GM_USE_FULL_FIELD                     //Use offline magnetic field during GMPropagator prolongation
+//#define GPUCA_TPC_USE_STAT_ERROR                    //Use statistical errors from offline in track fit
 
 // clang-format on
 

--- a/GPU/GPUTracking/Base/GPUParam.cxx
+++ b/GPU/GPUTracking/Base/GPUParam.cxx
@@ -121,19 +121,21 @@ void GPUParam::SetDefaults(float solenoidBz)
 
 void GPUParam::UpdateEventSettings(const GPUSettingsEvent* e, const GPUSettingsDeviceProcessing* p)
 {
-  AssumeConstantBz = e->constBz;
-  ToyMCEventsFlag = e->homemadeEvents;
-  ContinuousTracking = e->continuousMaxTimeBin != 0;
-  continuousMaxTimeBin = e->continuousMaxTimeBin == -1 ? (0.023 * 5e6) : e->continuousMaxTimeBin;
+  if (e) {
+    AssumeConstantBz = e->constBz;
+    ToyMCEventsFlag = e->homemadeEvents;
+    ContinuousTracking = e->continuousMaxTimeBin != 0;
+    continuousMaxTimeBin = e->continuousMaxTimeBin == -1 ? (0.023 * 5e6) : e->continuousMaxTimeBin;
+    polynomialField.Reset();
+    if (AssumeConstantBz) {
+      GPUTPCGMPolynomialFieldManager::GetPolynomialField(GPUTPCGMPolynomialFieldManager::kUniform, BzkG, polynomialField);
+    } else {
+      GPUTPCGMPolynomialFieldManager::GetPolynomialField(BzkG, polynomialField);
+    }
+  }
   if (p) {
     debugLevel = p->debugLevel;
     resetTimers = p->resetTimers;
-  }
-  polynomialField.Reset();
-  if (AssumeConstantBz) {
-    GPUTPCGMPolynomialFieldManager::GetPolynomialField(GPUTPCGMPolynomialFieldManager::kUniform, BzkG, polynomialField);
-  } else {
-    GPUTPCGMPolynomialFieldManager::GetPolynomialField(BzkG, polynomialField);
   }
 }
 

--- a/GPU/GPUTracking/Base/GPUReconstruction.cxx
+++ b/GPU/GPUTracking/Base/GPUReconstruction.cxx
@@ -428,6 +428,11 @@ void GPUReconstruction::DumpSettings(const char* dir)
   }
 }
 
+void GPUReconstruction::UpdateEventSettings(const GPUSettingsEvent* e, const GPUSettingsDeviceProcessing* p)
+{
+  param().UpdateEventSettings(e, p);
+}
+
 void GPUReconstruction::ReadSettings(const char* dir)
 {
   std::string f;

--- a/GPU/GPUTracking/Base/GPUReconstruction.h
+++ b/GPU/GPUTracking/Base/GPUReconstruction.h
@@ -182,6 +182,7 @@ class GPUReconstruction
   void SetSettings(const GPUSettingsEvent* settings, const GPUSettingsRec* rec = nullptr, const GPUSettingsDeviceProcessing* proc = nullptr, const GPURecoStepConfiguration* workflow = nullptr);
   void SetResetTimers(bool reset) { mDeviceProcessingSettings.resetTimers = reset; } // May update also after Init()
   void SetDebugLevelTmp(int level) { mDeviceProcessingSettings.debugLevel = level; } // Temporarily, before calling SetSettings()
+  void UpdateEventSettings(const GPUSettingsEvent* e, const GPUSettingsDeviceProcessing* p = nullptr);
   void SetOutputControl(const GPUOutputControl& v) { mOutputControl = v; }
   void SetOutputControl(void* ptr, size_t size);
   GPUOutputControl& OutputControl() { return mOutputControl; }

--- a/GPU/GPUTracking/Base/GPUReconstructionConvert.cxx
+++ b/GPU/GPUTracking/Base/GPUReconstructionConvert.cxx
@@ -90,3 +90,18 @@ void GPUReconstructionConvert::ConvertRun2RawToNative(o2::tpc::ClusterNativeAcce
   }
 #endif
 }
+
+int GPUReconstructionConvert::GetMaxTimeBin(const ClusterNativeAccess& native)
+{
+  float retVal = 0;
+  for (unsigned int i = 0; i < NSLICES; i++) {
+    for (unsigned int j = 0; j < GPUCA_ROW_COUNT; j++) {
+      for (unsigned int k = 0; k < native.nClusters[i][j]; k++) {
+        if (native.clusters[i][j][k].getTime() > retVal) {
+          retVal = native.clusters[i][j][k].getTime();
+        }
+      }
+    }
+  }
+  return ceil(retVal);
+}

--- a/GPU/GPUTracking/Base/GPUReconstructionConvert.h
+++ b/GPU/GPUTracking/Base/GPUReconstructionConvert.h
@@ -41,6 +41,7 @@ class GPUReconstructionConvert
   constexpr static unsigned int NSLICES = GPUCA_NSLICES;
   static void ConvertNativeToClusterData(o2::tpc::ClusterNativeAccess* native, std::unique_ptr<GPUTPCClusterData[]>* clusters, unsigned int* nClusters, const TPCFastTransform* transform, int continuousMaxTimeBin = 0);
   static void ConvertRun2RawToNative(o2::tpc::ClusterNativeAccess& native, std::unique_ptr<o2::tpc::ClusterNative[]>& nativeBuffer, const AliHLTTPCRawCluster** rawClusters, unsigned int* nRawClusters);
+  static int GetMaxTimeBin(const o2::tpc::ClusterNativeAccess& native);
 };
 } // namespace gpu
 } // namespace GPUCA_NAMESPACE

--- a/GPU/GPUTracking/Base/hip/GPUReconstructionHIP.hip.cxx
+++ b/GPU/GPUTracking/Base/hip/GPUReconstructionHIP.hip.cxx
@@ -12,7 +12,7 @@
 /// \author David Rohr
 
 #define GPUCA_GPUTYPE_HIP
-#include "hip/hip_runtime.h"
+#include <hip/hip_runtime.h>
 
 #ifdef __CUDACC__
 #define __HIPCC_CUDA__

--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -283,9 +283,14 @@ int GPUChainTracking::PrepareEvent()
   return 0;
 }
 
+int GPUChainTracking::ForceInitQA()
+{
+  return mQA->InitQA();
+}
+
 int GPUChainTracking::Finalize()
 {
-  if (GetDeviceProcessingSettings().runQA && mQAInitialized) {
+  if (GetDeviceProcessingSettings().runQA && mQA->IsInitialized()) {
     mQA->DrawQAHistograms();
   }
   if (GetDeviceProcessingSettings().debugLevel >= 4) {
@@ -1337,7 +1342,7 @@ int GPUChainTracking::RunTRDTracking()
   Tracker.SetMaxData();
   if (GetDeviceProcessingSettings().memoryAllocationStrategy == GPUMemoryResource::ALLOCATION_INDIVIDUAL) {
     AllocateRegisteredMemory(Tracker.MemoryTracks());
-    AllocateRegisteredMemory(Tracker.MemoryTracklets());
+    AllocateRegisteredMemory(Tracker.MemoryTracklets()); // TODO: Is this needed?
   }
 
   for (unsigned int iTracklet = 0; iTracklet < mIOPtrs.nTRDTracklets; ++iTracklet) {
@@ -1394,11 +1399,10 @@ int GPUChainTracking::RunChain()
     mCompressionStatistics.reset(new GPUTPCClusterStatistics);
   }
   const bool needQA = GPUQA::QAAvailable() && (GetDeviceProcessingSettings().runQA || (GetDeviceProcessingSettings().eventDisplay && mIOPtrs.nMCInfosTPC));
-  if (needQA && mQAInitialized == false) {
+  if (needQA && mQA->IsInitialized() == false) {
     if (mQA->InitQA()) {
       return 1;
     }
-    mQAInitialized = true;
   }
   static HighResTimer timerTracking, timerMerger, timerQA, timerTransform, timerCompression;
   static int nCount = 0;

--- a/GPU/GPUTracking/Global/GPUChainTracking.h
+++ b/GPU/GPUTracking/Global/GPUChainTracking.h
@@ -118,6 +118,7 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
   GPUDisplay* GetEventDisplay() { return mEventDisplay.get(); }
   const GPUQA* GetQA() const { return mQA.get(); }
   GPUQA* GetQA() { return mQA.get(); }
+  int ForceInitQA();
 
   // Processing functions
   int RunTPCTrackingSlices();
@@ -184,7 +185,6 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
   bool mDisplayRunning = false;
   std::unique_ptr<GPUQA> mQA;
   std::unique_ptr<GPUTPCClusterStatistics> mCompressionStatistics;
-  bool mQAInitialized = false;
 
   // Ptr to reconstruction detector objects
   std::unique_ptr<o2::tpc::ClusterNativeAccess> mClusterNativeAccess; // Internal memory for clusterNativeAccess

--- a/GPU/GPUTracking/Merger/GPUTPCGMBorderTrack.h
+++ b/GPU/GPUTracking/Merger/GPUTPCGMBorderTrack.h
@@ -82,6 +82,9 @@ class GPUTPCGMBorderTrack
   GPUd() bool CheckChi2QPt(const GPUTPCGMBorderTrack& t, float chi2cut) const
   {
     float d = mP[4] - t.mP[4];
+    if (CAMath::Abs(d) > 0.3f && CAMath::Abs(d) > 0.5f * CAMath::Min(CAMath::Abs(mP[4]), CAMath::Abs(t.mP[4]))) {
+      return false; // Crude cut to avoid some bogus matches, TODO: recheck
+    }
     return (d * d < chi2cut * (mC[4] + t.mC[4]));
   }
 

--- a/GPU/GPUTracking/Merger/GPUTPCGMMerger.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMMerger.cxx
@@ -809,7 +809,6 @@ void GPUTPCGMMerger::MergeCEFill(const GPUTPCGMSliceTrack* track, const GPUTPCGM
   if (cls.row < GPUCA_MERGER_CE_ROWLIMIT || cls.row >= GPUCA_ROW_COUNT - MERGE_CE_ROWLIMIT) {
     return;
   }
-
 #endif
   if (!mCAParam->ContinuousTracking && fabsf(cls.z) > 10) {
     return;

--- a/GPU/GPUTracking/Merger/GPUTPCGMMerger.h
+++ b/GPU/GPUTracking/Merger/GPUTPCGMMerger.h
@@ -120,12 +120,12 @@ class GPUTPCGMMerger : public GPUProcessor
   void Finalize();
 
  private:
-  void MakeBorderTracks(int iSlice, int iBorder, GPUTPCGMBorderTrack B[], int& nB, bool fromOrig = false);
-  void MergeBorderTracks(int iSlice1, GPUTPCGMBorderTrack B1[], int N1, int iSlice2, GPUTPCGMBorderTrack B2[], int N2, int crossCE = 0);
+  void MakeBorderTracks(int iSlice, int iBorder, GPUTPCGMBorderTrack B[], int& nB, bool useOrigTrackParam = false);
+  void MergeBorderTracks(int iSlice1, GPUTPCGMBorderTrack B1[], int N1, int iSlice2, GPUTPCGMBorderTrack B2[], int N2, int mergeMode = 0);
 
   void MergeCEFill(const GPUTPCGMSliceTrack* track, const GPUTPCGMMergedTrackHit& cls, int itr);
-  void ResolveMergeSlices(bool fromOrig, bool mergeAll);
-  void MergeSlicesStep(int border0, int border1, bool fromOrig);
+  void ResolveMergeSlices(bool useOrigTrackParam, bool mergeAll);
+  void MergeSlicesStep(int border0, int border1, bool useOrigTrackParam);
   void ClearTrackLinks(int n);
 
   void PrintMergeGraph(GPUTPCGMSliceTrack* trk);

--- a/GPU/GPUTracking/Standalone/display/GPUDisplayKeys.cxx
+++ b/GPU/GPUTracking/Standalone/display/GPUDisplayKeys.cxx
@@ -52,7 +52,7 @@ const char* HelpText[] = {
   "[e] / [f]                     Rotate",
   "[+] / [-]                     Make points thicker / fainter (Hold SHIFT for lines)",
   "[MOUSE 1]                     Look around",
-  "[MOUSE 2]                     Shift c3amera",
+  "[MOUSE 2]                     Shift camera",
   "[MOUSE 1+2]                   Zoom / Rotate",
   "[SHIFT]                       Slow Zoom / Move / Rotate",
   "[ALT] / [CTRL] / [m]          Focus camera on origin / orient y-axis upwards (combine with [SHIFT] to lock) / Cycle through modes",

--- a/GPU/GPUTracking/Standalone/qa/GPUQA.cxx
+++ b/GPU/GPUTracking/Standalone/qa/GPUQA.cxx
@@ -298,6 +298,9 @@ int GPUQA::GetMCTrackLabel(unsigned int trackId) const { return (trackId >= mTra
 
 int GPUQA::InitQA()
 {
+  if (mQAInitialized) {
+    return 1;
+  }
   char name[2048], fname[1024];
 
   mColorNums = new Color_t[COLORCOUNT];

--- a/GPU/GPUTracking/Standalone/qa/GPUQA.h
+++ b/GPU/GPUTracking/Standalone/qa/GPUQA.h
@@ -53,6 +53,7 @@ class GPUQA
   int GetMCTrackLabel(unsigned int trackId) const { return -1; }
   bool clusterRemovable(int cid, bool prot) const { return false; }
   static bool QAAvailable() { return false; }
+  static bool IsInitialized() { return false; }
 };
 } // namespace gpu
 } // namespace GPUCA_NAMESPACE
@@ -98,6 +99,7 @@ class GPUQA
   int GetMCTrackLabel(unsigned int trackId) const;
   bool clusterRemovable(int cid, bool prot) const;
   static bool QAAvailable() { return true; }
+  bool IsInitialized() { return mQAInitialized; }
 
  private:
   struct additionalMCParameters {

--- a/GPU/GPUTracking/Standalone/qconfigoptions.h
+++ b/GPU/GPUTracking/Standalone/qconfigoptions.h
@@ -140,6 +140,7 @@ AddOption(fifo, bool, false, "fifoScheduler", 0, "Use FIFO realtime scheduler", 
 AddOption(fpe, bool, true, "fpe", 0, "Trap on floating point exceptions")
 AddOption(solenoidBz, float, -1e6f, "solenoidBz", 0, "Field strength of solenoid Bz in kGaus")
 AddOption(constBz, bool, false, "constBz", 0, "Force constand Bz")
+AddOption(overrideMaxTimebin, bool, false, "overrideMaxTimebin", 0, "Override max time bin setting for continuous data with max time bin in time frame")
 AddOption(referenceX, float, 500.f, "referenceX", 0, "Reference X position to transport track to after fit")
 AddOption(rejectMode, char, 5, "rejectMode", 0, "Merger Reject Mode")
 AddOption(allocationStrategy, int, 0, "allocationStrategy", 0, "Memory Allocation Stragegy (0 = auto, 1 = individual allocations, 2 = single global allocation)")

--- a/GPU/GPUTracking/Standalone/standalone.cxx
+++ b/GPU/GPUTracking/Standalone/standalone.cxx
@@ -465,6 +465,7 @@ int main(int argc, char** argv)
 
     for (int j2 = 0; j2 < configStandalone.runs2; j2++) {
       if (configStandalone.configQA.inputHistogramsOnly) {
+        chainTracking->ForceInitQA();
         break;
       }
       if (configStandalone.runs2 > 1) {

--- a/GPU/GPUTracking/Standalone/standalone.cxx
+++ b/GPU/GPUTracking/Standalone/standalone.cxx
@@ -14,6 +14,7 @@
 #include "utils/qconfig.h"
 #include "GPUReconstruction.h"
 #include "GPUReconstructionTimeframe.h"
+#include "GPUReconstructionConvert.h"
 #include "GPUChainTracking.h"
 #include "GPUTPCDef.h"
 #include "GPUQA.h"
@@ -504,6 +505,12 @@ int main(int argc, char** argv)
               break;
             }
           }
+        }
+
+        if (configStandalone.overrideMaxTimebin && chainTracking->mIOPtrs.clustersNative) {
+          GPUSettingsEvent ev = rec->GetEventSettings();
+          ev.continuousMaxTimeBin = GPUReconstructionConvert::GetMaxTimeBin(*chainTracking->mIOPtrs.clustersNative);
+          rec->UpdateEventSettings(&ev);
         }
 
         printf("Loading time: %'d us\n", (int)(1000000 * timerLoad.GetCurrentElapsedTime()));


### PR DESCRIPTION
@shahor02 : That cleans up the outliers, but we also loose some CE crossing tracks in general.
I'll have to check how much one can recover. But actually the track parameters before the merging are not exactly good.
Of course we could refit beforehand, but that would take quite some time. Might be a strategy for asynchronous though, where we might have GPU resources left anyway.
New plot below:
![cetracks](https://user-images.githubusercontent.com/9131638/64443700-cfd40900-d0d2-11e9-958e-bd41add89ccf.png)
