### PR TITLE
DPL Analysis: add pack_element helper

### DIFF
--- a/Framework/Foundation/CMakeLists.txt
+++ b/Framework/Foundation/CMakeLists.txt
@@ -10,6 +10,11 @@
 
 o2_add_header_only_library(FrameworkFoundation)
 
+o2_add_test(test_FunctionalHelpers NAME test_FrameworkFoundation_test_FunctionalHelpers
+            COMPONENT_NAME FrameworkFoundation
+            SOURCES test/test_FunctionalHelpers.cxx
+            PUBLIC_LINK_LIBRARIES O2::FrameworkFoundation)
+
 o2_add_test(test_Traits NAME test_FrameworkFoundation_test_Traits
             COMPONENT_NAME FrameworkFoundation
             SOURCES test/test_Traits.cxx

--- a/Framework/Foundation/test/test_FunctionalHelpers.cxx
+++ b/Framework/Foundation/test/test_FunctionalHelpers.cxx
@@ -1,0 +1,21 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test Framework Traits
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+#include "Framework/FunctionalHelpers.h"
+
+BOOST_AUTO_TEST_CASE(TestOverride)
+{
+  static_assert(o2::framework::pack_size(o2::framework::pack<int, float>{}) == 2, "Bad size for pack");
+}


### PR DESCRIPTION
This allows retrieving the N-th element of a parameter pack stored
inside a `framework::pack<Args...>`.