### PR TITLE
Remove outdated test

### DIFF
--- a/CCDB/test/testCcdbApi.cxx
+++ b/CCDB/test/testCcdbApi.cxx
@@ -247,14 +247,6 @@ BOOST_AUTO_TEST_CASE(retrieveTMemFile_test, *utf::precondition(if_reachable()))
   BOOST_CHECK_EQUAL(obj, nullptr);
 }
 
-BOOST_AUTO_TEST_CASE(retrieve_wrong_type, *utf::precondition(if_reachable())) // Test/Detector is not stored as a TFile
-{
-  test_fixture f;
-
-  TObject* obj = f.api.retrieveFromTFile("Test/Detector", f.metadata);
-  BOOST_CHECK_EQUAL(obj, nullptr);
-}
-
 BOOST_AUTO_TEST_CASE(truncate_test, *utf::precondition(if_reachable()))
 {
   test_fixture f;


### PR DESCRIPTION
With the removal of store and retrieve from CcdbApi it is not needed anymore and actually was broken since I cleaned up the ccdb-test.