### PR TITLE
Fix Typo in Framework Test

### DIFF
--- a/Framework/Core/test/benchmark_ASoA.cxx
+++ b/Framework/Core/test/benchmark_ASoA.cxx
@@ -397,4 +397,4 @@ static void BM_ASoADynamicColumnPhi(benchmark::State& state)
 }
 BENCHMARK(BM_ASoADynamicColumnPhi)->Range(8, 8 << 17);
 
-BENCHMARK_MAIN()
+BENCHMARK_MAIN();


### PR DESCRIPTION
Missing `;` leads to a compilation syntax error for me. No idea why it passes the CI. Anyhow, this is a typo and should be fixed. @ktf 