### PR TITLE
fix wrong passing by value instead of reference

### DIFF
--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/HardwareClusterDecoder.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/HardwareClusterDecoder.h
@@ -83,7 +83,7 @@ class HardwareClusterDecoder
   /// ClusterNative defines the smaller-than relation used in the sorting, with time being the more significant
   /// condition in the comparison.
   static void sortClustersAndMC(ClusterNative* clusters, size_t nClusters,
-                                o2::dataformats::MCTruthContainer<o2::MCCompLabel> mcTruth);
+                                o2::dataformats::MCTruthContainer<o2::MCCompLabel>& mcTruth);
 
  private:
   std::unique_ptr<DigitalCurrentClusterIntegrator> mIntegrator;

--- a/Detectors/TPC/reconstruction/src/HardwareClusterDecoder.cxx
+++ b/Detectors/TPC/reconstruction/src/HardwareClusterDecoder.cxx
@@ -133,7 +133,7 @@ int HardwareClusterDecoder::decodeClusters(std::vector<std::pair<const ClusterHa
 }
 
 void HardwareClusterDecoder::sortClustersAndMC(ClusterNative* clusters, size_t nClusters,
-                                               o2::dataformats::MCTruthContainer<o2::MCCompLabel> mcTruth)
+                                               o2::dataformats::MCTruthContainer<o2::MCCompLabel>& mcTruth)
 {
   std::vector<unsigned int> indizes(nClusters);
   std::iota(indizes.begin(), indizes.end(), 0);


### PR DESCRIPTION
This caused the problem in the wrong MC labels associated to clusters,
resulting in quite many fake track flags.