### PR TITLE
add option to set the field in o2-sim

### DIFF
--- a/Common/SimConfig/include/SimConfig/SimConfig.h
+++ b/Common/SimConfig/include/SimConfig/SimConfig.h
@@ -49,8 +49,9 @@ struct SimConfigData {
   bool mFilterNoHitEvents = false;           // whether to filter out events not leaving any response
   std::string mCCDBUrl;                      // the URL where to find CCDB
   long mTimestamp;                           // timestamp to anchor transport simulation to
+  int mField;                                // L3 field setting in kGauss: +-2,+-5 and 0
 
-  ClassDefNV(SimConfigData, 2);
+  ClassDefNV(SimConfigData, 3);
 };
 
 // A singleton class which can be used

--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -48,6 +48,7 @@ void SimConfig::initOptions(boost::program_options::options_description& options
     "chunkSize", bpo::value<unsigned int>()->default_value(5000), "max size of primary chunk (subevent) distributed by server")(
     "chunkSizeI", bpo::value<int>()->default_value(-1), "internalChunkSize")(
     "seed", bpo::value<int>()->default_value(-1), "initial seed (default: -1 random)")(
+    "field", bpo::value<int>()->default_value(-5), "L3 field rounded to kGauss, allowed values +-2,+-5 and 0")(
     "nworkers,j", bpo::value<int>()->default_value(nsimworkersdefault), "number of parallel simulation workers (only for parallel mode)")(
     "noemptyevents", "only writes events with at least one hit")(
     "CCDBUrl", bpo::value<std::string>()->default_value("ccdb-test.cern.ch:8080"), "URL for CCDB to be used.")(
@@ -108,6 +109,7 @@ bool SimConfig::resetFromParsedMap(boost::program_options::variables_map const& 
   if (vm.count("noemptyevents")) {
     mConfigData.mFilterNoHitEvents = true;
   }
+  mConfigData.mField = vm["field"].as<int>();
   return true;
 }
 


### PR DESCRIPTION
@strogolo : with this PR you can set the field during the simulation, particularly, for 0 field use
``o2-sim --field 0``, for reduced 2 kGauss: `` --field 2`` etc. Defualt is ``-5`` corresponding to -30kA in the L3.