### PR TITLE
Fix to prevent overflow in rdh.memorySize assignment

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelReader.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelReader.h
@@ -485,10 +485,8 @@ class RawPixelReader : public PixelReader
       rdh.linkID = il;
       rdh.pageCnt = 0;
       rdh.stop = 0;
-      rdh.memorySize = rdh.headerSize + (nGBTWordsNeeded + 2) * mGBTWordSize; // update remaining size
-      if (rdh.memorySize > MaxGBTPacketBytes) {
-        rdh.memorySize = MaxGBTPacketBytes;
-      }
+      int loadsize = rdh.headerSize + (nGBTWordsNeeded + 2) * o2::itsmft::GBTPaddedWordLength; // total data to dump
+      rdh.memorySize = loadsize < MaxGBTPacketBytes ? loadsize : MaxGBTPacketBytes;
       rdh.offsetToNext = mImposeMaxPage ? MaxGBTPacketBytes : rdh.memorySize;
 
       link->data.ensureFreeCapacity(MaxGBTPacketBytes);
@@ -543,10 +541,8 @@ class RawPixelReader : public PixelReader
           rdh.stop = nGBTWordsNeeded < maxGBTWordsPerPacket; // flag if this is the last packet of multi-packet
           rdh.blockLength = 0xffff;                          // (nGBTWordsNeeded % maxGBTWordsPerPacket + 2) * mGBTWordSize; // record payload size
           // update remaining size, using padded GBT words (as CRU writes)
-          rdh.memorySize = rdh.headerSize + (nGBTWordsNeeded + 2) * o2::itsmft::GBTPaddedWordLength;
-          if (rdh.memorySize > MaxGBTPacketBytes) {
-            rdh.memorySize = MaxGBTPacketBytes;
-          }
+          loadsize = rdh.headerSize + (nGBTWordsNeeded + 2) * o2::itsmft::GBTPaddedWordLength; // update remaining size
+          rdh.memorySize = loadsize < MaxGBTPacketBytes ? loadsize : MaxGBTPacketBytes;
           rdh.offsetToNext = mImposeMaxPage ? MaxGBTPacketBytes : rdh.memorySize;
           link->data.ensureFreeCapacity(MaxGBTPacketBytes);
           link->data.addFast(reinterpret_cast<uint8_t*>(&rdh), rdh.headerSize); // write RDH for current packet

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelReader.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelReader.h
@@ -578,7 +578,7 @@ class RawPixelReader : public PixelReader
   }
 
   //___________________________________________________________________________________
-  int flushSuperPages(int maxPages, PayLoadCont& sink)
+  int flushSuperPages(int maxPages, PayLoadCont& sink, bool unusedToHead = true)
   {
     // flush superpage (at most maxPages) of each link to the output,
     // return total number of pages flushed
@@ -607,7 +607,9 @@ class RawPixelReader : public PixelReader
           nPages++;
         }
         totPages += nPages;
-        link->data.moveUnusedToHead();
+        if (unusedToHead) {
+          link->data.moveUnusedToHead();
+        }
       } // loop over links
     }   // loop over RUs
     return totPages;

--- a/macro/run_digi2raw_mft.C
+++ b/macro/run_digi2raw_mft.C
@@ -16,13 +16,13 @@
 
 #include "ITSMFTReconstruction/RawPixelReader.h"
 
-void run_digi2raw_mft(std::string outName = "rawmft.bin",                           // name of the output binary file
-                      std::string inpName = "mftdigits.root",                       // name of the input MFT digits
-                      std::string digTreeName = "o2sim",                            // name of the digits tree
-                      std::string digBranchName = "MFTDigit",                       // name of the digits branch
-                      std::string rofRecName = "MFTDigitROF",                       // name of the ROF records tree and its branch
-                      uint8_t ruSWMin = 0, uint8_t ruSWMax = 0xff,                  // seq.ID of 1st and last RU (stave) to convert
-                      uint8_t superPageSize = o2::itsmft::NCRUPagesPerSuperpage / 2 // CRU superpage size, max = 256
+void run_digi2raw_mft(std::string outName = "rawmft.bin",                        // name of the output binary file
+                      std::string inpName = "mftdigits.root",                    // name of the input MFT digits
+                      std::string digTreeName = "o2sim",                         // name of the digits tree
+                      std::string digBranchName = "MFTDigit",                    // name of the digits branch
+                      std::string rofRecName = "MFTDigitROF",                    // name of the ROF records tree and its branch
+                      uint8_t ruSWMin = 0, uint8_t ruSWMax = 0xff,               // seq.ID of 1st and last RU (stave) to convert
+                      uint16_t superPageSize = o2::itsmft::NCRUPagesPerSuperpage // CRU superpage size, max = 256
 )
 {
   TStopwatch swTot;
@@ -104,6 +104,7 @@ void run_digi2raw_mft(std::string outName = "rawmft.bin",                       
       auto rofEntry = rofRec.getROFEntry();
       int nDigROF = rofRec.getNROFEntries();
       LOG(INFO) << "Processing ROF:" << rofRec.getROFrame() << " with " << nDigROF << " entries";
+      rofRec.print();
       if (!nDigROF) {
         LOG(INFO) << "Frame is empty"; // ??
         continue;
@@ -118,7 +119,7 @@ void run_digi2raw_mft(std::string outName = "rawmft.bin",                       
 
       int nPagesCached = rawReader.digits2raw(digiVec, rofEntry.getIndex(), nDigROF, rofRec.getBCData(),
                                               ruSWMin, ruSWMax);
-
+      LOG(INFO) << "Pages chached " << nPagesCached << " superpage: " << int(superPageSize);
       if (nPagesCached >= superPageSize) {
         int nPagesFlushed = rawReader.flushSuperPages(superPageSize, outBuffer);
         fwrite(outBuffer.data(), 1, outBuffer.getSize(), outFl); //write to file
@@ -133,7 +134,7 @@ void run_digi2raw_mft(std::string outName = "rawmft.bin",                       
   // flush the rest
   int flushed = 0;
   do {
-    flushed = rawReader.flushSuperPages(o2::itsmft::NCRUPagesPerSuperpage, outBuffer);
+    flushed = rawReader.flushSuperPages(superPageSize, outBuffer, false);
     fwrite(outBuffer.data(), 1, outBuffer.getSize(), outFl); //write to file
     if (flushed) {
       LOG(INFO) << "Flushed final " << flushed << " CRU pages";


### PR DESCRIPTION
Relevant for digit->raw conversion only