### PR TITLE
TRD MC Labels O2-847

### DIFF
--- a/Detectors/TRD/base/include/TRDBase/Digit.h
+++ b/Detectors/TRD/base/include/TRDBase/Digit.h
@@ -30,7 +30,7 @@ constexpr int KEY_MAX = 2211727;
 
 typedef std::uint16_t ADC_t;                                      // the ADC value type
 typedef std::array<ADC_t, kTB> ArrayADC_t;                        // the array ADC
-typedef std::array<ADC_t, kTB + 1> ArrayADCext_t;                 // the array ADC + digit index
+typedef std::array<ADC_t, kTB + 1> ArrayADCext_t;                 // the array ADC + label index
 typedef std::vector<Digit> DigitContainer_t;                      // the digit container type
 typedef std::unordered_map<int, ArrayADCext_t> SignalContainer_t; // a map container type for signal handling during digitization
 

--- a/Detectors/TRD/base/include/TRDBase/Digit.h
+++ b/Detectors/TRD/base/include/TRDBase/Digit.h
@@ -28,18 +28,19 @@ constexpr int kTB = 30;
 constexpr int KEY_MIN = 0;
 constexpr int KEY_MAX = 2211727;
 
-typedef std::uint16_t ADC_t;                                   // the ADC value type
-typedef std::array<ADC_t, kTB> ArrayADC_t;                     // the array ADC
-typedef std::vector<Digit> DigitContainer_t;                   // the digit container type
-typedef std::unordered_map<int, ArrayADC_t> SignalContainer_t; // a map container type for signal handling during digitization
+typedef std::uint16_t ADC_t;                                      // the ADC value type
+typedef std::array<ADC_t, kTB> ArrayADC_t;                        // the array ADC
+typedef std::array<ADC_t, kTB + 1> ArrayADCext_t;                 // the array ADC + digit index
+typedef std::vector<Digit> DigitContainer_t;                      // the digit container type
+typedef std::unordered_map<int, ArrayADCext_t> SignalContainer_t; // a map container type for signal handling during digitization
 
 class Digit
 {
  public:
   Digit() = default;
   ~Digit() = default;
-  Digit(const int det, const int row, const int pad, const ArrayADC_t adc)
-    : mDetector(det), mRow(row), mPad(pad), mADC(adc) {}
+  Digit(const int det, const int row, const int pad, const ArrayADC_t adc, const size_t idx)
+    : mDetector(det), mRow(row), mPad(pad), mADC(adc), mLabelIdx(idx) {}
   // Copy
   Digit(const Digit&) = default;
   // Assignment
@@ -54,6 +55,7 @@ class Digit
   int getRow() const { return mRow; }
   int getPad() const { return mPad; }
   ArrayADC_t getADC() const { return mADC; }
+  size_t getLabelIndex() const { return mLabelIdx; }
 
   // Set of static helper methods
   static int calculateKey(const int det, const int row, const int col) { return ((det << 12) | (row << 8) | col); }
@@ -69,10 +71,15 @@ class Digit
     digitCont.reserve(adcMapCont.size());
     for (const auto& element : adcMapCont) {
       const int key = element.first;
+      ArrayADC_t adcs{};
+      for (int i = 0; i < kTB; ++i) {
+        adcs[i] = element.second[i];
+      }
+      size_t idx = element.second[kTB];
       digitCont.emplace_back(Digit::getDetectorFromKey(key),
                              Digit::getRowFromKey(key),
                              Digit::getColFromKey(key),
-                             element.second);
+                             adcs, idx);
     }
   }
   static void convertVectorsToMap(const DigitContainer_t& digitCont,
@@ -85,7 +92,11 @@ class Digit
       const int key = calculateKey(element.getDetector(),
                                    element.getRow(),
                                    element.getPad());
-      adcMapCont[key] = element.getADC();
+      ArrayADCext_t adcsext{};
+      for (int i = 0; i < kTB; ++i) {
+        adcsext[i] = element.getADC()[i];
+      }
+      adcMapCont[key] = adcsext;
     }
   }
 
@@ -94,6 +105,7 @@ class Digit
   std::uint8_t mRow{0};       // pad row, 0-15
   std::uint8_t mPad{0};       // pad within pad row, 0-143
   ArrayADC_t mADC{};          // ADC vector (30 time-bins)
+  size_t mLabelIdx{0};        // index for mc label
 
   ClassDefNV(Digit, 1);
 };

--- a/Detectors/TRD/base/include/TRDBase/MCLabel.h
+++ b/Detectors/TRD/base/include/TRDBase/MCLabel.h
@@ -24,12 +24,14 @@ class MCLabel : public o2::MCCompLabel
 {
  private:
   bool mIsDigit{false};
+  int mNumberOfDigits{0};
 
  public:
   MCLabel() = default;
-  MCLabel(int trackID, int eventID, int srcID, int isDigit)
-    : o2::MCCompLabel(trackID, eventID, srcID, false), mIsDigit(isDigit) {}
+  MCLabel(int trackID, int eventID, int srcID, bool isDigit, int nDigits)
+    : o2::MCCompLabel(trackID, eventID, srcID, false), mIsDigit(isDigit), mNumberOfDigits(nDigits) {}
   int isDigit() const { return mIsDigit; }
+  int numberOfDigits() const { return mNumberOfDigits; }
 
   ClassDefNV(MCLabel, 1);
 };

--- a/Detectors/TRD/base/include/TRDBase/MCLabel.h
+++ b/Detectors/TRD/base/include/TRDBase/MCLabel.h
@@ -22,16 +22,10 @@ namespace trd
 
 class MCLabel : public o2::MCCompLabel
 {
- private:
-  bool mIsDigit{false};
-  int mNumberOfDigits{0};
-
  public:
   MCLabel() = default;
-  MCLabel(int trackID, int eventID, int srcID, bool isDigit, int nDigits)
-    : o2::MCCompLabel(trackID, eventID, srcID, false), mIsDigit(isDigit), mNumberOfDigits(nDigits) {}
-  int isDigit() const { return mIsDigit; }
-  int numberOfDigits() const { return mNumberOfDigits; }
+  MCLabel(int trackID, int eventID, int srcID)
+    : o2::MCCompLabel(trackID, eventID, srcID, false) {}
 
   ClassDefNV(MCLabel, 1);
 };

--- a/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
@@ -55,10 +55,10 @@ class Digitizer
 
   void getHitContainerPerDetector(const std::vector<HitType>&, std::array<std::vector<HitType>, kNdet>&);
   // Digitization chaing methods
-  bool convertHits(const int, const std::vector<HitType>&, SignalContainer_t&); // True if hit-to-signal conversion is successful
-  bool convertSignalsToDigits(const int, SignalContainer_t&);                   // True if signal-to-digit conversion is successful
-  bool convertSignalsToSDigits(const int, SignalContainer_t&);                  // True if signal-to-sdigit conversion is successful
-  bool convertSignalsToADC(const int, SignalContainer_t&);                      // True if signal-to-ADC conversion is successful
+  bool convertHits(const int, const std::vector<HitType>&, SignalContainer_t&, o2::dataformats::MCTruthContainer<MCLabel>&); // True if hit-to-signal conversion is successful
+  bool convertSignalsToDigits(const int, SignalContainer_t&);                                                                // True if signal-to-digit conversion is successful
+  bool convertSignalsToSDigits(const int, SignalContainer_t&);                                                               // True if signal-to-sdigit conversion is successful
+  bool convertSignalsToADC(const int, SignalContainer_t&);                                                                   // True if signal-to-ADC conversion is successful
 
   bool diffusion(float, double, double, double, double, double, double&, double&, double&); // True if diffusion is applied successfully
 };

--- a/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
@@ -51,7 +51,6 @@ class Digitizer
 
   bool mSDigits{false};               // true: convert signals to summable digits, false by defaults
   std::vector<HitType> mHitContainer; // the container of hits in a given detector
-  std::vector<MCLabel> mLabels;       // the container of labels
 
   void getHitContainerPerDetector(const std::vector<HitType>&, std::array<std::vector<HitType>, kNdet>&);
   // Digitization chaing methods

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -165,7 +165,6 @@ bool Digitizer::convertHits(const int det, const std::vector<HitType>& hits, Sig
   // Loop over hits
   for (const auto& hit : hits) {
     bool isDigit = false;
-    int nHitsConvertedToDigits = 0; // total number of hits converted to digits
     size_t labelIndex = labels.getIndexedSize();
     const int qTotal = hit.GetCharge();
     /*
@@ -338,7 +337,6 @@ bool Digitizer::convertHits(const int det, const std::vector<HitType>& hits, Sig
         // Get the old signal
         auto& currentSignal = adcMapCont[key];
         isDigit = true;
-        nHitsConvertedToDigits++;
         currentSignal[kTB] = labelIndex; // store the label index in this extra timebin to pass it to the digit structure
         for (int iTimeBin = firstTimeBin; iTimeBin < lastTimeBin; ++iTimeBin) {
           // Apply the time response
@@ -354,7 +352,6 @@ bool Digitizer::convertHits(const int det, const std::vector<HitType>& hits, Sig
           signalOld[0] = 0;
           signalOld[1] = 0;
           signalOld[2] = 0;
-
           signalOld[iPad] = currentSignal[iTimeBin];
           if (colPos != colE) {
             // Cross talk added to non-central pads
@@ -365,11 +362,14 @@ bool Digitizer::convertHits(const int det, const std::vector<HitType>& hits, Sig
           }
           // Update the final signal
           currentSignal[iTimeBin] = signalOld[iPad];
-        }                                                                                                        // Loop: time bins
-      }                                                                                                          // Loop: pads
-    }                                                                                                            // end of loop over electrons
-    labels.addElement(labelIndex, MCLabel(hit.GetTrackID(), mEventID, mSrcID, isDigit, nHitsConvertedToDigits)); // add one mc label per hit
-  }                                                                                                              // end of loop over hits
+        } // Loop: time bins
+      }   // Loop: pads
+    }     // end of loop over electrons
+    if (isDigit) {
+      MCLabel label(hit.GetTrackID(), mEventID, mSrcID); // add one label is the at least one digit is created
+      labels.addElement(labelIndex, label);
+    }
+  } // end of loop over hits
   return true;
 }
 

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -60,7 +60,6 @@ void Digitizer::process(std::vector<HitType> const& hits, DigitContainer_t& digi
   // const int nTimeBins = mCalib->GetNumberOfTimeBinsDCS(); PLEASE FIX ME when CCDB is ready
 
   SignalContainer_t adcMapCont;
-  mLabels.clear();
 
   // Get the a hit container for all the hits in a given detector then call convertHits for a given detector (0 - 539)
   std::array<std::vector<HitType>, kNdet> hitsPerDetector;
@@ -83,7 +82,7 @@ void Digitizer::process(std::vector<HitType> const& hits, DigitContainer_t& digi
       continue;
     }
 
-    if (!convertHits(det, hitsPerDetector[det], adcMapCont)) {
+    if (!convertHits(det, hitsPerDetector[det], adcMapCont, labels)) {
       LOG(WARN) << "TRD conversion of hits failed for detector " << det;
       continue; // go to the next chamber
     }
@@ -101,11 +100,6 @@ void Digitizer::process(std::vector<HitType> const& hits, DigitContainer_t& digi
 
   // Finalize
   Digit::convertMapToVectors(adcMapCont, digitCont);
-
-  // MC labels
-  for (int i = 0; i < mLabels.size(); ++i) {
-    labels.addElement(i, mLabels[i]);
-  }
 }
 
 void Digitizer::getHitContainerPerDetector(const std::vector<HitType>& hits, std::array<std::vector<HitType>, kNdet>& hitsPerDetector)
@@ -120,7 +114,7 @@ void Digitizer::getHitContainerPerDetector(const std::vector<HitType>& hits, std
   }
 }
 
-bool Digitizer::convertHits(const int det, const std::vector<HitType>& hits, SignalContainer_t& adcMapCont)
+bool Digitizer::convertHits(const int det, const std::vector<HitType>& hits, SignalContainer_t& adcMapCont, o2::dataformats::MCTruthContainer<MCLabel>& labels)
 {
   //
   // Convert the detector-wise sorted hits to detector signals
@@ -171,6 +165,8 @@ bool Digitizer::convertHits(const int det, const std::vector<HitType>& hits, Sig
   // Loop over hits
   for (const auto& hit : hits) {
     bool isDigit = false;
+    int nHitsConvertedToDigits = 0; // total number of hits converted to digits
+    size_t labelIndex = labels.getIndexedSize();
     const int qTotal = hit.GetCharge();
     /*
       Now the real local coordinate system of the ROC
@@ -341,6 +337,9 @@ bool Digitizer::convertHits(const int det, const std::vector<HitType>& hits, Sig
         // Add the signals
         // Get the old signal
         auto& currentSignal = adcMapCont[key];
+        isDigit = true;
+        nHitsConvertedToDigits++;
+        currentSignal[kTB] = labelIndex; // store the label index in this extra timebin to pass it to the digit structure
         for (int iTimeBin = firstTimeBin; iTimeBin < lastTimeBin; ++iTimeBin) {
           // Apply the time response
           double timeResponse = 1;
@@ -366,12 +365,11 @@ bool Digitizer::convertHits(const int det, const std::vector<HitType>& hits, Sig
           }
           // Update the final signal
           currentSignal[iTimeBin] = signalOld[iPad];
-          isDigit = true;
-        } // Loop: time bins
-      }   // Loop: pads
-    }     // end of loop over electrons
-    mLabels.emplace_back(hit.GetTrackID(), mEventID, mSrcID, isDigit);
-  } // end of loop over hits
+        }                                                                                                        // Loop: time bins
+      }                                                                                                          // Loop: pads
+    }                                                                                                            // end of loop over electrons
+    labels.addElement(labelIndex, MCLabel(hit.GetTrackID(), mEventID, mSrcID, isDigit, nHitsConvertedToDigits)); // add one mc label per hit
+  }                                                                                                              // end of loop over hits
   return true;
 }
 
@@ -461,7 +459,10 @@ bool Digitizer::convertSignalsToADC(const int det, SignalContainer_t& adcMapCont
     }
     // loop over time bins
     // for (int tb = 0; tb < nTimeTotal; tb++) {
+    int tb = 0;
     for (auto& adcArrayVal : adcMapIter.second) {
+      if (++tb > kTimeBins) // avoid accessing the mc label index
+        break;
       float signalAmp = (float)adcArrayVal; // The signal amplitude
       signalAmp *= coupling;                // Pad and time coupling
       signalAmp *= padgain;                 // Gain factors


### PR DESCRIPTION
Labels are implemented for the TRD. This PR proposes using one label per hit, each label contains the usual MC label info + if the hit generated a digit or not and how many digits. In parallel, each digit now contains a short that corresponds to the label index to track down multiple digits originated from the same hit.

To keep the label index during the processing of hits an augmented arrayadc is used temporarily. Here, the last array value contains the label index (as an extra time bin, not used for an adc value, but for the label index). The ArrayADC sent in the digit container remains the same, and the label index is new member in the digit class too.

https://alice.its.cern.ch/jira/browse/O2-847.