### PR TITLE
TRD tracker performance optimization

### DIFF
--- a/GPU/GPUTracking/TRDTracking/GPUTRDInterfaces.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDInterfaces.h
@@ -78,6 +78,7 @@ class trackInterface<AliExternalTrackParam> : public AliExternalTrackParam
   float getSigmaY2() const { return GetSigmaY2(); }
   float getSigmaZ2() const { return GetSigmaZ2(); }
 
+  const My_Float* getPar() const { return GetParameter(); }
   const My_Float* getCov() const { return GetCovariance(); }
   bool CheckNumericalQuality() const { return true; }
 
@@ -100,9 +101,18 @@ class propagatorInterface<AliTrackerBase> : public AliTrackerBase
   propagatorInterface<AliTrackerBase>(const propagatorInterface<AliTrackerBase>&) CON_DELETE;
   propagatorInterface<AliTrackerBase>& operator=(const propagatorInterface<AliTrackerBase>&) CON_DELETE;
 
-  bool PropagateToX(float x, float maxSnp, float maxStep) { return PropagateTrackToBxByBz(mParam, x, 0.13957, maxStep, false, maxSnp); }
+  bool propagateToX(float x, float maxSnp, float maxStep) { return PropagateTrackToBxByBz(mParam, x, 0.13957, maxStep, false, maxSnp); }
+  int getPropagatedYZ(My_Float x, My_Float& projY, My_Float& projZ)
+  {
+    Double_t yz[2] = {0.};
+    mParam->GetYZAt(x, GetBz(), yz);
+    projY = yz[0];
+    projZ = yz[1];
+    return 0;
+  }
 
   void setTrack(trackInterface<AliExternalTrackParam>* trk) { mParam = trk; }
+  void setFitInProjections(bool flag) {}
 
   float getAlpha() { return (mParam) ? mParam->GetAlpha() : 99999.f; }
   bool update(const My_Float p[2], const My_Float cov[3]) { return (mParam) ? mParam->update(p, cov) : false; }
@@ -117,7 +127,32 @@ class propagatorInterface<AliTrackerBase> : public AliTrackerBase
 #endif // GPUCA_ALIROOT_LIB
 
 #if defined(GPUCA_O2_LIB) || defined(GPUCA_O2_INTERFACE) // Interface for O2, build only with O2
-// TODO: Implement!
+/*
+#include "ReconstructionDataFormats/Track.h"
+#include "DetectorsBase/Propagator.h"
+
+namespace GPUCA_NAMESPACE
+{
+
+namespace gpu
+{
+// TODO namespace trd??
+
+template <>
+class trackInterface<o2::track::TrackParCov> : public o2::track::TrackParCov
+{
+  typedef o2::track::TrackParCov baseClass;
+};
+
+template <>
+class propagatorInterface<o2::base::Propagator> : public o2::base::Propagator
+{
+
+};
+
+} // namespace gpu
+} // namespace GPUCA_NAMESPACE
+*/
 #endif // GPUCA_O2_LIB || GPUCA_O2_INTERFACE
 
 #include "GPUTPCGMPropagator.h"
@@ -197,6 +232,7 @@ class trackInterface<GPUTPCGMTrackParam> : public GPUTPCGMTrackParam
   GPUd() float getSigmaY2() const { return GetErr2Y(); }
   GPUd() float getSigmaZ2() const { return GetErr2Z(); }
 
+  GPUd() const float* getPar() const { return GetPar(); }
   GPUd() const float* getCov() const { return GetCov(); }
 
   GPUd() void setAlpha(float alpha) { mAlpha = alpha; }
@@ -240,12 +276,14 @@ class propagatorInterface<GPUTPCGMPropagator> : public GPUTPCGMPropagator
     SetTrack(trk, trk->getAlpha());
     mTrack = trk;
   }
-  GPUd() bool PropagateToX(float x, float maxSnp, float maxStep)
+  GPUd() bool propagateToX(float x, float maxSnp, float maxStep)
   {
     bool ok = PropagateToXAlpha(x, GetAlpha(), true) == 0 ? true : false;
     ok = mTrack->CheckNumericalQuality();
     return ok;
   }
+  GPUd() int getPropagatedYZ(float x, float& projY, float& projZ) { return GetPropagatedYZ(x, projY, projZ); }
+  GPUd() void setFitInProjections(bool flag) { SetFitInProjections(flag); }
   GPUd() bool rotate(float alpha)
   {
     if (RotateToAlpha(alpha) == 0) {

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
@@ -80,7 +80,7 @@ void* GPUTRDTracker::SetPointersBase(void* base)
   // Allocate memory for fixed size objects (needs to be done only once)
   //--------------------------------------------------------------------
   mMaxThreads = mRec->GetMaxThreads();
-  computePointerWithAlignment(base, mR, kNLayers);
+  computePointerWithAlignment(base, mR, kNChambers);
   computePointerWithAlignment(base, mNTrackletsInChamber, kNChambers);
   computePointerWithAlignment(base, mTrackletIndexArray, kNChambers);
   computePointerWithAlignment(base, mHypothesis, mNCandidates * mMaxThreads);
@@ -110,7 +110,7 @@ void* GPUTRDTracker::SetPointersTracks(void* base)
 }
 
 GPUTRDTracker::GPUTRDTracker()
-  : mR(nullptr), mIsInitialized(false), mMemoryPermanent(-1), mMemoryTracklets(-1), mMemoryTracks(-1), mNMaxTracks(0), mNMaxSpacePoints(0), mTracks(nullptr), mNCandidates(1), mNTracks(0), mNEvents(0), mTracklets(nullptr), mMaxThreads(100), mNTracklets(0), mNTrackletsInChamber(nullptr), mTrackletIndexArray(nullptr), mHypothesis(nullptr), mCandidates(nullptr), mSpacePoints(nullptr), mTrackletLabels(nullptr), mGeo(nullptr), mDebugOutput(false), mMinPt(0.6f), mMaxEta(0.84f), mMaxChi2(15.0f), mMaxMissingLy(6), mChi2Penalty(12.0f), mZCorrCoefNRC(1.4f), mMCEvent(nullptr), mDebug(new GPUTRDTrackerDebug()), mChainTracking(nullptr)
+  : mR(nullptr), mIsInitialized(false), mMemoryPermanent(-1), mMemoryTracklets(-1), mMemoryTracks(-1), mNMaxTracks(0), mNMaxSpacePoints(0), mTracks(nullptr), mNCandidates(1), mNTracks(0), mNEvents(0), mTracklets(nullptr), mMaxThreads(100), mNTracklets(0), mNTrackletsInChamber(nullptr), mTrackletIndexArray(nullptr), mHypothesis(nullptr), mCandidates(nullptr), mSpacePoints(nullptr), mTrackletLabels(nullptr), mGeo(nullptr), mDebugOutput(false), mRadialOffset(-0.1), mMinPt(0.6f), mMaxEta(0.84f), mExtraRoadY(2.f), mRoadZ(18.f), mMaxChi2(15.0f), mMaxMissingLy(6), mChi2Penalty(12.0f), mZCorrCoefNRC(1.4f), mMCEvent(nullptr), mDebug(new GPUTRDTrackerDebug()), mChainTracking(nullptr)
 {
   //--------------------------------------------------------------------
   // Default constructor
@@ -148,27 +148,19 @@ bool GPUTRDTracker::Init(TRD_GEOMETRY_CONST GPUTRDGeometry* geo)
     mTrackletIndexArray[iDet] = -1;
   }
 
-  // obtain average radius of TRD layers (use default value w/o misalignment if no transformation matrix can be obtained)
-  float x0[kNLayers] = {300.2f, 312.8f, 325.4f, 338.0f, 350.6f, 363.2f};
-  for (int iLy = 0; iLy < kNLayers; iLy++) {
-    mR[iLy] = x0[iLy];
-  }
+  // obtain average radius of TRD chambers
+  float x0[kNLayers] = {300.2f, 312.8f, 325.4f, 338.0f, 350.6f, 363.2f}; // used as default value in case no transformation matrix can be obtained
   auto* matrix = mGeo->GetClusterMatrix(0);
   My_Float loc[3] = {mGeo->AnodePos(), 0.f, 0.f};
   My_Float glb[3] = {0.f, 0.f, 0.f};
-  for (int iLy = 0; iLy < kNLayers; iLy++) {
-    for (int iSec = 0; iSec < kNSectors; iSec++) {
-      matrix = mGeo->GetClusterMatrix(mGeo->GetDetector(iLy, 2, iSec));
-      if (matrix) {
-        break;
-      }
-    }
+  for (int iDet = 0; iDet < kNChambers; ++iDet) {
+    matrix = mGeo->GetClusterMatrix(iDet);
     if (!matrix) {
-      Error("Init", "Could not get transformation matrix for layer %i. Using default x pos instead", iLy);
+      mR[iDet] = x0[mGeo->GetLayer(iDet)];
       continue;
     }
     matrix->LocalToMaster(loc, glb);
-    mR[iLy] = glb[0];
+    mR[iDet] = glb[0];
   }
 
   mDebug->ExpandVectors();
@@ -251,8 +243,13 @@ void GPUTRDTracker::DoTracking()
   }
 
   auto duration = std::chrono::high_resolution_clock::now() - timeStart;
-  // std::cout << "--->  -----> -------> ---------> Time for event " << mNEvents << ": " << std::chrono::duration_cast<std::chrono::milliseconds>(duration).count() << " ms" << std::endl;
-
+  /*
+  std::cout << "--->  -----> -------> ---------> ";
+  std::cout << "Time for event " << mNEvents << ": " << std::chrono::duration_cast<std::chrono::microseconds>(duration).count() << " us ";
+  std::cout << "nTracks: " << mNTracks;
+  std::cout << " nTracklets: " << mNTracklets;
+  std::cout << std::endl;
+  */
   // DumpTracks();
   mNEvents++;
 }
@@ -309,7 +306,7 @@ void GPUTRDTracker::CountMatches(const int trackID, std::vector<int>* matches) c
         if (!mMCEvent) {
           continue;
         }
-        // continue; //FIXME uncomment to count only exact matches
+        //continue; //FIXME uncomment to count only exact matches
         AliMCParticle* mcPart = (AliMCParticle*)mMCEvent->GetTrack(lb);
         while (mcPart) {
           lb = mcPart->GetMother();
@@ -335,8 +332,8 @@ GPUd() void GPUTRDTracker::CheckTrackRefs(const int trackID, bool* findableMC) c
 #ifdef ENABLE_GPUMC
   //--------------------------------------------------------------------
   // loop over all track references for the input trackID and set
-  // findableMC to true for each layer in which a track hit exiting
-  // the TRD chamber exists
+  // findableMC to true for each layer in which a track hit  both
+  // entering and exiting the TRD chamber exists
   // (in debug mode)
   //--------------------------------------------------------------------
   TParticle* particle;
@@ -346,6 +343,7 @@ GPUd() void GPUTRDTracker::CheckTrackRefs(const int trackID, bool* findableMC) c
   if (nHits < 1) {
     return;
   }
+  bool isFindable[2 * kNLayers] = {false};
   int nHitsTrd = 0;
   for (int iHit = 0; iHit < nHits; ++iHit) {
     AliTrackReference* trackReference = static_cast<AliTrackReference*>(trackRefs->UncheckedAt(iHit));
@@ -378,7 +376,19 @@ GPUd() void GPUTRDTracker::CheckTrackRefs(const int trackID, bool* findableMC) c
       GPUError("x=%f, y=%f, z=%f, layer=%i", xLoc, trackReference->LocalY(), trackReference->Z(), layer);
       continue;
     }
-    findableMC[layer] = true;
+    if (trackReference->TestBits(0x1 << 18)) {
+      isFindable[layer * 2] = true;
+    }
+    if (trackReference->TestBits(0x1 << 17)) {
+      isFindable[layer * 2 + 1] = true;
+    }
+  }
+  for (int iLayer = 0; iLayer < kNLayers; ++iLayer) {
+    if (isFindable[iLayer * 2] && isFindable[iLayer * 2 + 1]) {
+      findableMC[iLayer] = true;
+    } else {
+      findableMC[iLayer] = false;
+    }
   }
 #endif
 }
@@ -422,8 +432,10 @@ GPUd() void GPUTRDTracker::DoTrackingThread(int iTrk, int threadId)
   // perform the tracking for one track (must be threadsafe)
   //--------------------------------------------------------------------
   GPUTRDPropagator prop(&Param().polynomialField);
-  prop.setTrack(&(mTracks[iTrk]));
-  FollowProlongation(&prop, &(mTracks[iTrk]), threadId);
+  GPUTRDTrack trkCopy = mTracks[iTrk];
+  prop.setTrack(&trkCopy);
+  prop.setFitInProjections(true);
+  FollowProlongation(&prop, &trkCopy, threadId);
 }
 
 GPUd() bool GPUTRDTracker::CalculateSpacePoints()
@@ -460,7 +472,7 @@ GPUd() bool GPUTRDTracker::CalculateSpacePoints()
       float sz2 = pp->GetRowSize(trkltZbin) * pp->GetRowSize(trkltZbin) / 12.f; // sigma_z = l_pad/sqrt(12) TODO try a larger z error
       My_Float xTrkltDet[3] = {0.f};                                            // trklt position in chamber coordinates
       My_Float xTrkltSec[3] = {0.f};                                            // trklt position in sector coordinates
-      xTrkltDet[0] = mGeo->AnodePos();
+      xTrkltDet[0] = mGeo->AnodePos() + mRadialOffset;
       xTrkltDet[1] = mTracklets[trkltIdx].GetY();
       xTrkltDet[2] = pp->GetRowPos(trkltZbin) - pp->GetRowSize(trkltZbin) / 2.f - pp->GetRowPos(pp->GetNrows() / 2);
       matrix->LocalToMaster(xTrkltDet, xTrkltSec);
@@ -494,20 +506,6 @@ GPUd() bool GPUTRDTracker::FollowProlongation(GPUTRDPropagator* prop, GPUTRDTrac
   //    or track does not fullfill threshold conditions
   //--------------------------------------------------------------------
 
-  if (!t->CheckNumericalQuality()) {
-    return false;
-  }
-
-  // only propagate tracks within TRD acceptance
-  if (CAMath::Abs(t->getEta()) > mMaxEta) {
-    return false;
-  }
-
-  // introduce momentum cut on tracks
-  if (t->getPt() < mMinPt) {
-    return false;
-  }
-
   mDebug->Reset();
   int iTrack = t->GetTPCtrackId();
   t->SetChi2(0.f);
@@ -533,8 +531,12 @@ GPUd() bool GPUTRDTracker::FollowProlongation(GPUTRDPropagator* prop, GPUTRDTrac
   int candidateIdxOffset = threadId * 2 * mNCandidates;
   int hypothesisIdxOffset = threadId * mNCandidates;
 
-  // set input track to first candidate(s)
-  mCandidates[candidateIdxOffset] = *t;
+  GPUTRDTrack* trkWork = t;
+  if (mNCandidates > 1) {
+    // copy input track to first candidate
+    mCandidates[candidateIdxOffset] = *t;
+  }
+
   int nCandidates = 1;
 
   // search window
@@ -562,25 +564,28 @@ GPUd() bool GPUTRDTracker::FollowProlongation(GPUTRDPropagator* prop, GPUTRDTrac
 
       int det[nMaxChambersToSearch] = {-1, -1, -1, -1}; // TRD chambers to be searched for tracklets
 
-      prop->setTrack(&mCandidates[2 * iCandidate + currIdx]);
+      if (mNCandidates > 1) {
+        trkWork = &mCandidates[2 * iCandidate + currIdx];
+        prop->setTrack(trkWork);
+      }
 
-      if (mCandidates[2 * iCandidate + currIdx].GetIsStopped()) {
-        Hypothesis hypo(mCandidates[2 * iCandidate + currIdx].GetNlayers(), iCandidate, -1, mCandidates[2 * iCandidate + currIdx].GetChi2());
+      if (trkWork->GetIsStopped()) {
+        Hypothesis hypo(trkWork->GetNlayers(), iCandidate, -1, trkWork->GetChi2());
         InsertHypothesis(hypo, nCurrHypothesis, hypothesisIdxOffset);
         isOK = true;
         continue;
       }
 
-      // propagate track to average radius of TRD layer iLayer
-      if (!prop->PropagateToX(mR[iLayer], .8f, 2.f)) {
+      // propagate track to average radius of TRD layer iLayer (sector 0, stack 2 is chosen as a reference)
+      if (!prop->propagateToX(mR[2 * kNLayers + iLayer], .8f, 2.f)) {
         if (ENABLE_INFO) {
-          Info("FollowProlongation", "Track propagation failed for track %i candidate %i in layer %i (pt=%f, x=%f, mR[layer]=%f)", iTrack, iCandidate, iLayer, mCandidates[2 * iCandidate + currIdx].getPt(), mCandidates[2 * iCandidate + currIdx].getX(), mR[iLayer]);
+          Info("FollowProlongation", "Track propagation failed for track %i candidate %i in layer %i (pt=%f, x=%f, mR[layer]=%f)", iTrack, iCandidate, iLayer, trkWork->getPt(), trkWork->getX(), mR[2 * kNLayers + iLayer]);
         }
         continue;
       }
 
       // rotate track in new sector in case of sector crossing
-      if (!AdjustSector(prop, &mCandidates[2 * iCandidate + currIdx], iLayer)) {
+      if (!AdjustSector(prop, trkWork, iLayer)) {
         if (ENABLE_INFO) {
           Info("FollowProlongation", "Adjusting sector failed for track %i candidate %i in layer %i", iTrack, iCandidate, iLayer);
         }
@@ -588,27 +593,27 @@ GPUd() bool GPUTRDTracker::FollowProlongation(GPUTRDPropagator* prop, GPUTRDTrac
       }
 
       // check if track is findable
-      if (IsGeoFindable(&mCandidates[2 * iCandidate + currIdx], iLayer, prop->getAlpha())) {
-        mCandidates[2 * iCandidate + currIdx].SetIsFindable(iLayer);
+      if (IsGeoFindable(trkWork, iLayer, prop->getAlpha())) {
+        trkWork->SetIsFindable(iLayer);
       }
 
       // define search window
-      roadY = 7.f * sqrt(mCandidates[2 * iCandidate + currIdx].getSigmaY2() + 0.1f * 0.1f) + 2.f; // add constant to the road for better efficiency
-      // roadZ = 7.f * sqrt(mCandidates[2*iCandidate+currIdx].getSigmaZ2() + 9.f * 9.f / 12.f); // take longest pad length
-      roadZ = 18.f; // simply twice the longest pad length -> efficiency 99.996%
+      roadY = 7.f * CAMath::Sqrt(trkWork->getSigmaY2() + 0.1f * 0.1f) + mExtraRoadY; // add constant to the road to account for uncertainty due to radial deviations (few mm)
+      // roadZ = 7.f * CAMath::Sqrt(trkWork->getSigmaZ2() + 9.f * 9.f / 12.f); // take longest pad length
+      roadZ = mRoadZ; // simply twice the longest pad length -> efficiency 99.996%
       //
-      if (CAMath::Abs(mCandidates[2 * iCandidate + currIdx].getZ()) - roadZ >= zMaxTRD) {
+      if (CAMath::Abs(trkWork->getZ()) - roadZ >= zMaxTRD) {
         if (ENABLE_INFO) {
-          Info("FollowProlongation", "Track out of TRD acceptance with z=%f in layer %i (eta=%f)", mCandidates[2 * iCandidate + currIdx].getZ(), iLayer, mCandidates[2 * iCandidate + currIdx].getEta());
+          Info("FollowProlongation", "Track out of TRD acceptance with z=%f in layer %i (eta=%f)", trkWork->getZ(), iLayer, trkWork->getEta());
         }
         continue;
       }
 
       // determine chamber(s) to be searched for tracklets
-      FindChambersInRoad(&mCandidates[2 * iCandidate + currIdx], roadY, roadZ, iLayer, det, zMaxTRD, prop->getAlpha());
+      FindChambersInRoad(trkWork, roadY, roadZ, iLayer, det, zMaxTRD, prop->getAlpha());
 
       // track debug information to be stored in case no matching tracklet can be found
-      mDebug->SetTrackParameter(mCandidates[2 * iCandidate + currIdx], iLayer);
+      mDebug->SetTrackParameter(*trkWork, iLayer);
 
       // look for tracklets in chamber(s)
       for (int iDet = 0; iDet < nMaxChambersToSearch; iDet++) {
@@ -630,35 +635,42 @@ GPUd() bool GPUTRDTracker::FollowProlongation(GPUTRDPropagator* prop, GPUTRDTrac
           Error("FollowProlongation", "Track is in sector %i and sector %i is searched for tracklets", GetSector(prop->getAlpha()), currSec);
           continue;
         }
+        // propagate track to radius of chamber
+        if (!prop->propagateToX(mR[currDet], .8f, .2f)) {
+          if (ENABLE_WARNING) {
+            Warning("FollowProlongation", "Track parameter for track %i, x=%f at chamber %i x=%f in layer %i cannot be retrieved", iTrack, trkWork->getX(), currDet, mR[currDet], iLayer);
+          }
+        }
         // first propagate track to x of tracklet
         for (int iTrklt = 0; iTrklt < mNTrackletsInChamber[currDet]; ++iTrklt) {
           int trkltIdx = mTrackletIndexArray[currDet] + iTrklt;
-          if (!prop->PropagateToX(mSpacePoints[trkltIdx].mR, .8f, 2.f)) {
-            if (ENABLE_WARNING) {
-              Warning("FollowProlongation", "Track parameter for track %i, x=%f at tracklet %i x=%f in layer %i cannot be retrieved", iTrack, mCandidates[2 * iCandidate + currIdx].getX(), iTrklt, mSpacePoints[trkltIdx].mR, iLayer);
-            }
+          if (CAMath::Abs(trkWork->getY() - mSpacePoints[trkltIdx].mX[0]) > roadY && CAMath::Abs(trkWork->getZ() - mSpacePoints[trkltIdx].mX[1]) > roadZ) {
+            // skip tracklets which are too far away
+            // although the radii of space points and tracks may differ by ~ few mm the roads are large enough to allow no efficiency loss by this cut
             continue;
           }
+          My_Float projY, projZ;
+          prop->getPropagatedYZ(mSpacePoints[trkltIdx].mR, projY, projZ);
           // correction for tilted pads (only applied if deltaZ < l_pad && track z err << l_pad)
-          float tiltCorr = tilt * (mSpacePoints[trkltIdx].mX[1] - mCandidates[2 * iCandidate + currIdx].getZ());
+          float tiltCorr = tilt * (mSpacePoints[trkltIdx].mX[1] - projZ);
           float l_pad = pad->GetRowSize(mTracklets[trkltIdx].GetZbin());
-          if (!((CAMath::Abs(mSpacePoints[trkltIdx].mX[1] - mCandidates[2 * iCandidate + currIdx].getZ()) < l_pad) && (mCandidates[2 * iCandidate + currIdx].getSigmaZ2() < (l_pad * l_pad / 12.f)))) {
+          if (!((CAMath::Abs(mSpacePoints[trkltIdx].mX[1] - projZ) < l_pad) && (trkWork->getSigmaZ2() < (l_pad * l_pad / 12.f)))) {
             tiltCorr = 0.f;
           }
           // correction for mean z position of tracklet (is not the center of the pad if track eta != 0)
-          float zPosCorr = mSpacePoints[trkltIdx].mX[1] + mZCorrCoefNRC * mCandidates[2 * iCandidate + currIdx].getTgl();
+          float zPosCorr = mSpacePoints[trkltIdx].mX[1] + mZCorrCoefNRC * trkWork->getTgl();
           float yPosCorr = mSpacePoints[trkltIdx].mX[0] - tiltCorr;
-          float deltaY = yPosCorr - mCandidates[2 * iCandidate + currIdx].getY();
-          float deltaZ = zPosCorr - mCandidates[2 * iCandidate + currIdx].getZ();
+          float deltaY = yPosCorr - projY;
+          float deltaZ = zPosCorr - projZ;
           My_Float trkltPosTmpYZ[2] = {yPosCorr, zPosCorr};
           My_Float trkltCovTmp[3] = {0.f};
-          if ((CAMath::Abs(deltaY) < roadY) && (CAMath::Abs(deltaZ) < roadZ)) {
+          if ((CAMath::Abs(deltaY) < roadY) && (CAMath::Abs(deltaZ) < roadZ)) { // TODO: check if this is still necessary after the cut before propagation of track
             // tracklet is in windwow: get predicted chi2 for update and store tracklet index if best guess
-            RecalcTrkltCov(tilt, mCandidates[2 * iCandidate + currIdx].getSnp(), pad->GetRowSize(mTracklets[trkltIdx].GetZbin()), trkltCovTmp);
+            RecalcTrkltCov(tilt, trkWork->getSnp(), pad->GetRowSize(mTracklets[trkltIdx].GetZbin()), trkltCovTmp);
             float chi2 = prop->getPredictedChi2(trkltPosTmpYZ, trkltCovTmp);
             // GPUInfo("layer %i: chi2 = %f", iLayer, chi2);
-            if (chi2 < mMaxChi2 && CAMath::Abs(GetAngularPull(mSpacePoints[trkltIdx].mDy, mCandidates[2 * iCandidate + currIdx].getSnp())) < 4) {
-              Hypothesis hypo(mCandidates[2 * iCandidate + currIdx].GetNlayers(), iCandidate, trkltIdx, mCandidates[2 * iCandidate + currIdx].GetChi2() + chi2);
+            if (chi2 < mMaxChi2 && CAMath::Abs(GetAngularPull(mSpacePoints[trkltIdx].mDy, trkWork->getSnp())) < 4) {
+              Hypothesis hypo(trkWork->GetNlayers(), iCandidate, trkltIdx, trkWork->GetChi2() + chi2, GetPredictedChi2(trkltPosTmpYZ, trkltCovTmp, trkWork->getPar(), trkWork->getCov()));
               InsertHypothesis(hypo, nCurrHypothesis, hypothesisIdxOffset);
             } // end tracklet chi2 < mMaxChi2
           }   // end tracklet in window
@@ -666,7 +678,7 @@ GPUd() bool GPUTRDTracker::FollowProlongation(GPUTRDPropagator* prop, GPUTRDTrac
       }       // chamber loop
 
       // add no update to hypothesis list
-      Hypothesis hypoNoUpdate(mCandidates[2 * iCandidate + currIdx].GetNlayers(), iCandidate, -1, mCandidates[2 * iCandidate + currIdx].GetChi2() + mChi2Penalty);
+      Hypothesis hypoNoUpdate(trkWork->GetNlayers(), iCandidate, -1, trkWork->GetChi2() + mChi2Penalty);
       InsertHypothesis(hypoNoUpdate, nCurrHypothesis, hypothesisIdxOffset);
       isOK = true;
     } // end candidate loop
@@ -676,28 +688,27 @@ GPUd() bool GPUTRDTracker::FollowProlongation(GPUTRDPropagator* prop, GPUTRDTrac
     if (matchAvailableAll[iLayer].size() > 0 && mDebugOutput) {
       mDebug->SetNmatchAvail(matchAvailableAll[iLayer].size(), iLayer);
       int realTrkltId = matchAvailableAll[iLayer].at(0);
-      prop->setTrack(&mCandidates[currIdx]);
-      bool flag = prop->PropagateToX(mSpacePoints[realTrkltId].mR, .8f, 2.f);
-      if (flag) {
-        flag = AdjustSector(prop, &mCandidates[currIdx], iLayer);
-      }
-      if (!flag) {
+      int realTrkltDet = mTracklets[realTrkltId].GetDetector();
+      prop->rotate(GetAlphaOfSector(mGeo->GetSector(realTrkltDet)));
+      if (!prop->propagateToX(mSpacePoints[realTrkltId].mR, .8f, 2.f) || GetSector(prop->getAlpha()) != mGeo->GetSector(realTrkltDet)) {
         if (ENABLE_WARNING) {
-          Warning("FollowProlongation", "Track parameter at x=%f for track %i at real tracklet x=%f in layer %i cannot be retrieved (pt=%f)", mCandidates[currIdx].getX(), iTrack, mSpacePoints[realTrkltId].mR, iLayer, mCandidates[currIdx].getPt());
+          Warning("FollowProlongation", "Track parameter at x=%f for track %i at real tracklet x=%f in layer %i cannot be retrieved (pt=%f)", trkWork->getX(), iTrack, mSpacePoints[realTrkltId].mR, iLayer, trkWork->getPt());
         }
       } else {
-        mDebug->SetTrackParameterReal(mCandidates[currIdx], iLayer);
-        float zPosCorrReal = mSpacePoints[realTrkltId].mX[1] + mZCorrCoefNRC * mCandidates[currIdx].getTgl();
-        float deltaZReal = zPosCorrReal - mCandidates[currIdx].getZ();
-        float tiltCorrReal = tilt * (mSpacePoints[realTrkltId].mX[1] - mCandidates[currIdx].getZ());
+        // track could be propagated, rotated and is in the same sector as the MC matching tracklet
+        mDebug->SetTrackParameterReal(*trkWork, iLayer);
+        float zPosCorrReal = mSpacePoints[realTrkltId].mX[1] + mZCorrCoefNRC * trkWork->getTgl();
+        float deltaZReal = zPosCorrReal - trkWork->getZ();
+        float tiltCorrReal = tilt * (mSpacePoints[realTrkltId].mX[1] - trkWork->getZ());
         float l_padReal = pad->GetRowSize(mTracklets[realTrkltId].GetZbin());
-        if ((mCandidates[currIdx].getSigmaZ2() >= (l_padReal * l_padReal / 12.f)) || (CAMath::Abs(mSpacePoints[realTrkltId].mX[1] - mCandidates[currIdx].getZ()) >= l_padReal)) {
+        if ((trkWork->getSigmaZ2() >= (l_padReal * l_padReal / 12.f)) || (CAMath::Abs(mSpacePoints[realTrkltId].mX[1] - trkWork->getZ()) >= l_padReal)) {
           tiltCorrReal = 0;
         }
         My_Float yzPosReal[2] = {mSpacePoints[realTrkltId].mX[0] - tiltCorrReal, zPosCorrReal};
         My_Float covReal[3] = {0.};
-        RecalcTrkltCov(tilt, mCandidates[currIdx].getSnp(), pad->GetRowSize(mTracklets[realTrkltId].GetZbin()), covReal);
+        RecalcTrkltCov(tilt, trkWork->getSnp(), pad->GetRowSize(mTracklets[realTrkltId].GetZbin()), covReal);
         mDebug->SetChi2Real(prop->getPredictedChi2(yzPosReal, covReal), iLayer);
+        mDebug->SetChi2YZPhiReal(GetPredictedChi2(yzPosReal, covReal, trkWork->getPar(), trkWork->getCov()), iLayer);
         mDebug->SetRawTrackletPositionReal(mSpacePoints[realTrkltId].mR, mSpacePoints[realTrkltId].mX, iLayer);
         mDebug->SetCorrectedTrackletPositionReal(yzPosReal, iLayer);
         mDebug->SetTrackletPropertiesReal(mTracklets[realTrkltId].GetDetector(), iLayer);
@@ -706,6 +717,7 @@ GPUd() bool GPUTRDTracker::FollowProlongation(GPUTRDPropagator* prop, GPUTRDTrac
 #endif
     //
     mDebug->SetChi2Update(mHypothesis[0 + hypothesisIdxOffset].mChi2 - t->GetChi2(), iLayer); // only meaningful for ONE candidate!!!
+    mDebug->SetChi2YZPhiUpdate(mHypothesis[0 + hypothesisIdxOffset].mChi2YZPhi, iLayer);      // only meaningful for ONE candidate!!!
     mDebug->SetRoad(roadY, roadZ, iLayer);                                                    // only meaningful for ONE candidate
     bool wasTrackStored = false;
     // --------------------------------------------------------------------------------
@@ -727,71 +739,75 @@ GPUd() bool GPUTRDTracker::FollowProlongation(GPUTRDPropagator* prop, GPUTRDTrac
         break;
       }
       nCandidates = iUpdate + 1;
-      mCandidates[2 * iUpdate + nextIdx] = mCandidates[2 * mHypothesis[iUpdate + hypothesisIdxOffset].mCandidateId + currIdx];
+      if (mNCandidates > 1) {
+        mCandidates[2 * iUpdate + nextIdx] = mCandidates[2 * mHypothesis[iUpdate + hypothesisIdxOffset].mCandidateId + currIdx];
+        trkWork = &mCandidates[2 * iUpdate + nextIdx];
+      }
       if (mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId == -1) {
         // no matching tracklet found
-        if (mCandidates[2 * iUpdate + nextIdx].GetIsFindable(iLayer)) {
-          if (mCandidates[2 * iUpdate + nextIdx].GetNmissingConsecLayers(iLayer) > mMaxMissingLy) {
-            mCandidates[2 * iUpdate + nextIdx].SetIsStopped();
+        if (trkWork->GetIsFindable(iLayer)) {
+          if (trkWork->GetNmissingConsecLayers(iLayer) > mMaxMissingLy) {
+            trkWork->SetIsStopped();
           }
-          mCandidates[2 * iUpdate + nextIdx].SetChi2(mCandidates[2 * iUpdate + nextIdx].GetChi2() + mChi2Penalty);
+          trkWork->SetChi2(trkWork->GetChi2() + mChi2Penalty);
         }
-        if (iUpdate == 0) {
+        if (iUpdate == 0 && mNCandidates > 1) { // TODO: is thie really necessary????? CHECK!
           *t = mCandidates[2 * iUpdate + nextIdx];
         }
         continue;
       }
       // matching tracklet found
-      prop->setTrack(&mCandidates[2 * iUpdate + nextIdx]);
+      if (mNCandidates > 1) {
+        prop->setTrack(trkWork);
+      }
       int trkltSec = mGeo->GetSector(mTracklets[mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId].GetDetector());
       if (trkltSec != GetSector(prop->getAlpha())) {
         // if after a matching tracklet was found another sector was searched for tracklets the track needs to be rotated back
         prop->rotate(GetAlphaOfSector(trkltSec));
       }
-      if (!prop->PropagateToX(mSpacePoints[mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId].mR, .8f, 2.f)) {
+      if (!prop->propagateToX(mSpacePoints[mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId].mR, .8f, 2.f)) {
         if (ENABLE_WARNING) {
           Warning("FollowProlongation", "Final track propagation for track %i update %i in layer %i failed", iTrack, iUpdate, iLayer);
         }
-        mCandidates[2 * iUpdate + nextIdx].SetChi2(mCandidates[2 * iUpdate + nextIdx].GetChi2() + mChi2Penalty);
-        if (mCandidates[2 * iUpdate + nextIdx].GetIsFindable(iLayer)) {
-          if (mCandidates[2 * iUpdate + nextIdx].GetNmissingConsecLayers(iLayer) >= mMaxMissingLy) {
-            mCandidates[2 * iUpdate + nextIdx].SetIsStopped();
+        trkWork->SetChi2(trkWork->GetChi2() + mChi2Penalty);
+        if (trkWork->GetIsFindable(iLayer)) {
+          if (trkWork->GetNmissingConsecLayers(iLayer) >= mMaxMissingLy) {
+            trkWork->SetIsStopped();
           }
         }
-        if (iUpdate == 0) {
+        if (iUpdate == 0 && mNCandidates > 1) {
           *t = mCandidates[2 * iUpdate + nextIdx];
         }
         continue;
       }
 
-      float tiltCorrUp = tilt * (mSpacePoints[mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId].mX[1] - mCandidates[2 * iUpdate + nextIdx].getZ());
-      float zPosCorrUp = mSpacePoints[mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId].mX[1] + mZCorrCoefNRC * mCandidates[2 * iUpdate + nextIdx].getTgl();
+      float tiltCorrUp = tilt * (mSpacePoints[mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId].mX[1] - trkWork->getZ());
+      float zPosCorrUp = mSpacePoints[mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId].mX[1] + mZCorrCoefNRC * trkWork->getTgl();
       float l_padTrklt = pad->GetRowSize(mTracklets[mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId].GetZbin());
-      if (!((mCandidates[2 * iUpdate + nextIdx].getSigmaZ2() < (l_padTrklt * l_padTrklt / 12.f)) && (CAMath::Abs(mSpacePoints[mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId].mX[1] - mCandidates[2 * iUpdate + nextIdx].getZ()) < l_padTrklt))) {
+      if (!((trkWork->getSigmaZ2() < (l_padTrklt * l_padTrklt / 12.f)) && (CAMath::Abs(mSpacePoints[mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId].mX[1] - trkWork->getZ()) < l_padTrklt))) {
         tiltCorrUp = 0.f;
       }
       My_Float trkltPosUp[2] = {mSpacePoints[mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId].mX[0] - tiltCorrUp, zPosCorrUp};
       My_Float trkltCovUp[3] = {0.f};
-      RecalcTrkltCov(tilt, mCandidates[2 * iUpdate + nextIdx].getSnp(), pad->GetRowSize(mTracklets[mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId].GetZbin()), trkltCovUp);
+      RecalcTrkltCov(tilt, trkWork->getSnp(), pad->GetRowSize(mTracklets[mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId].GetZbin()), trkltCovUp);
 
 #ifdef ENABLE_GPUTRDDEBUG
       prop->setTrack(&trackNoUp);
       prop->rotate(GetAlphaOfSector(trkltSec));
-      prop->PropagateToX(mSpacePoints[mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId].mR, .8f, 2.f);
-      prop->PropagateToX(mR[iLayer], .8f, 2.f);
-      prop->setTrack(&mCandidates[2 * iUpdate + nextIdx]);
+      //prop->propagateToX(mSpacePoints[mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId].mR, .8f, 2.f);
+      prop->propagateToX(mR[mTracklets[mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId].GetDetector()], .8f, 2.f);
+      prop->setTrack(trkWork);
 #endif
 
       if (!wasTrackStored) {
 #ifdef ENABLE_GPUTRDDEBUG
         mDebug->SetTrackParameterNoUp(trackNoUp, iLayer);
 #endif
-        mDebug->SetTrackParameter(mCandidates[2 * iUpdate + nextIdx], iLayer);
+        mDebug->SetTrackParameter(*trkWork, iLayer);
         mDebug->SetRawTrackletPosition(mSpacePoints[mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId].mR, mSpacePoints[mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId].mX, iLayer);
         mDebug->SetCorrectedTrackletPosition(trkltPosUp, iLayer);
         mDebug->SetTrackletCovariance(mSpacePoints[mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId].mCov, iLayer);
         mDebug->SetTrackletProperties(mSpacePoints[mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId].mDy, mTracklets[mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId].GetDetector(), iLayer);
-        mDebug->SetRoad(roadY, roadZ, iLayer);
         wasTrackStored = true;
       }
 
@@ -799,27 +815,27 @@ GPUd() bool GPUTRDTracker::FollowProlongation(GPUTRDPropagator* prop, GPUTRDTrac
         if (ENABLE_WARNING) {
           Warning("FollowProlongation", "Failed to update track %i with space point in layer %i", iTrack, iLayer);
         }
-        mCandidates[2 * iUpdate + nextIdx].SetChi2(mCandidates[2 * iUpdate + nextIdx].GetChi2() + mChi2Penalty);
-        if (mCandidates[2 * iUpdate + nextIdx].GetIsFindable(iLayer)) {
-          if (mCandidates[2 * iUpdate + nextIdx].GetNmissingConsecLayers(iLayer) >= mMaxMissingLy) {
-            mCandidates[2 * iUpdate + nextIdx].SetIsStopped();
+        trkWork->SetChi2(trkWork->GetChi2() + mChi2Penalty);
+        if (trkWork->GetIsFindable(iLayer)) {
+          if (trkWork->GetNmissingConsecLayers(iLayer) >= mMaxMissingLy) {
+            trkWork->SetIsStopped();
           }
         }
-        if (iUpdate == 0) {
+        if (iUpdate == 0 && mNCandidates > 1) {
           *t = mCandidates[2 * iUpdate + nextIdx];
         }
         continue;
       }
-      if (!mCandidates[2 * iUpdate + nextIdx].CheckNumericalQuality()) {
+      if (!trkWork->CheckNumericalQuality()) {
         if (ENABLE_WARNING) {
           Info("FollowProlongation", "Track %i has invalid covariance matrix. Aborting track following\n", iTrack);
         }
         return false;
       }
-      mCandidates[2 * iUpdate + nextIdx].AddTracklet(iLayer, mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId);
-      mCandidates[2 * iUpdate + nextIdx].SetChi2(mHypothesis[iUpdate + hypothesisIdxOffset].mChi2);
-      mCandidates[2 * iUpdate + nextIdx].SetIsFindable(iLayer);
-      if (iUpdate == 0) {
+      trkWork->AddTracklet(iLayer, mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId);
+      trkWork->SetChi2(mHypothesis[iUpdate + hypothesisIdxOffset].mChi2);
+      trkWork->SetIsFindable(iLayer);
+      if (iUpdate == 0 && mNCandidates > 1) {
         *t = mCandidates[2 * iUpdate + nextIdx];
       }
     } // end update loop
@@ -911,6 +927,40 @@ GPUd() bool GPUTRDTracker::FollowProlongation(GPUTRDPropagator* prop, GPUTRDTrac
   return true;
 }
 
+GPUd() float GPUTRDTracker::GetPredictedChi2(const My_Float* pTRD, const My_Float* covTRD, const My_Float* pTrk, const My_Float* covTrk) const
+{
+  // FIXME: This function cannot yet be used in production (maybe it is not necessary at all?)
+  // conversion from tracklet deflection to sin(phi) needs to be parametrized
+  // predict chi2 for update of track with pTrk and covTrk with TRD space point with pTRD and covTRD
+  // taking into account y, z and azimuthal angle of the track and tracklet
+  float deltaY = pTrk[0] - pTRD[0];
+  float deltaZ = pTrk[1] - pTRD[1];
+  float deltaS = pTrk[2] - pTRD[2]; // FIXME: pTRD[2] is not defined, needs conversion dy -> sin(phi)
+
+  // add errors for track and space point, assume no correlation in y-sin(phi) and z-sin(phi) for space point
+  float sigmaZ2 = covTrk[2] + covTRD[2];
+  float sigmaS2 = covTrk[5] + GetAngularResolution(pTrk[2]); // FIXME: convert angular resolution from dy to sin(phi) for the TRD space point
+  float sigmaY2 = covTrk[0] + covTRD[0];
+  float sigmaZS = covTrk[4];
+  float sigmaYS = covTrk[3];
+  float sigmaYZ = covTrk[1] + covTRD[1];
+  // inverse of the covariance matrix
+  float c11 = sigmaZ2 * sigmaS2 - sigmaZS * sigmaZS;
+  float c21 = sigmaZS * sigmaYS - sigmaYZ * sigmaS2;
+  float c22 = sigmaY2 * sigmaS2 - sigmaYS * sigmaYS;
+  float c31 = sigmaYZ * sigmaZS - sigmaZ2 * sigmaYS;
+  float c32 = sigmaYZ * sigmaYS - sigmaY2 * sigmaZS;
+  float c33 = sigmaY2 * sigmaZ2 - sigmaYZ * sigmaYZ;
+  // determinant
+  float det = sigmaY2 * sigmaZ2 * sigmaS2 + 2 * sigmaYZ * sigmaZS * sigmaYS - sigmaYS * sigmaYS * sigmaZ2 - sigmaZS * sigmaZS * sigmaY2 - sigmaS2 * sigmaYZ * sigmaYZ;
+  if (CAMath::Abs(det) < 1.e-10f) {
+    printf("Determinant too small: %f\n", det);
+    det = 1.e-10f;
+  }
+  det = 1.f / det;
+  return (c11 * deltaY * deltaY + 2.f * c21 * deltaY * deltaZ + 2.f * c31 * deltaY * deltaS + c22 * deltaZ * deltaZ + 2.f * c32 * deltaZ * deltaS + c33 * deltaS * deltaS) * det;
+}
+
 GPUd() void GPUTRDTracker::InsertHypothesis(Hypothesis hypo, int& nCurrHypothesis, int idxOffset)
 {
   // Insert hypothesis into the array. If the array is full and the reduced chi2 is worse
@@ -998,7 +1048,7 @@ GPUd() bool GPUTRDTracker::AdjustSector(GPUTRDPropagator* prop, GPUTRDTrack* t, 
     if (!prop->rotate(alphaCurr + alpha * sign)) {
       return false;
     }
-    if (!prop->PropagateToX(xTmp, .8f, 2.f)) {
+    if (!prop->propagateToX(xTmp, .8f, 2.f)) {
       return false;
     }
     y = t->getY();
@@ -1050,7 +1100,7 @@ GPUd() float GPUTRDTracker::GetAngularPull(float dYtracklet, float snp) const
   if (dYresolution < 1e-6f) {
     return 999.f;
   }
-  return (dYtracklet - dYtrack) / sqrt(dYresolution);
+  return (dYtracklet - dYtrack) / CAMath::Sqrt(dYresolution);
 }
 
 GPUd() void GPUTRDTracker::FindChambersInRoad(const GPUTRDTrack* t, const float roadY, const float roadZ, const int iLayer, int* det, const float zMax, const float alpha) const

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.h
@@ -16,6 +16,8 @@
 #ifndef GPUTRDTRACKER_H
 #define GPUTRDTRACKER_H
 
+#define POSITIVE_B_FIELD_5KG
+
 #include "GPUCommonDef.h"
 #include "GPUProcessor.h"
 #include "GPUTRDDef.h"
@@ -80,7 +82,7 @@ class GPUTRDTracker : public GPUProcessor
 
   // struct to hold the information on the space points
   struct GPUTRDSpacePointInternal {
-    float mR;                 // x position (7mm above anode wires)
+    float mR;                 // x position (3.5 mm above anode wires) - radial offset due to t0 mis-calibration, measured -1 mm for run 245353
     float mX[2];              // y and z position (sector coordinates)
     My_Float mCov[3];         // sigma_y^2, sigma_yz, sigma_z^2
     float mDy;                // deflection over drift length
@@ -90,14 +92,15 @@ class GPUTRDTracker : public GPUProcessor
   };
 
   struct Hypothesis {
-    int mLayers;
-    int mCandidateId;
-    int mTrackletId;
-    float mChi2;
+    int mLayers;      // number of layers with TRD space point
+    int mCandidateId; // to which track candidate the hypothesis belongs
+    int mTrackletId;  // tracklet index to be used for update
+    float mChi2;      // predicted chi2 for given space point
+    float mChi2YZPhi; // not yet ready (see GetPredictedChi2 method in cxx file)
 
     GPUd() float GetReducedChi2() { return mLayers > 0 ? mChi2 / mLayers : mChi2; }
     GPUd() Hypothesis() : mLayers(0), mCandidateId(-1), mTrackletId(-1), mChi2(9999.f) {}
-    GPUd() Hypothesis(int layers, int candidateId, int trackletId, float chi2) : mLayers(layers), mCandidateId(candidateId), mTrackletId(trackletId), mChi2(chi2) {}
+    GPUd() Hypothesis(int layers, int candidateId, int trackletId, float chi2, float chi2YZPhi = -1.f) : mLayers(layers), mCandidateId(candidateId), mTrackletId(trackletId), mChi2(chi2), mChi2YZPhi(chi2YZPhi) {}
   };
 
   short MemoryPermanent() const { return mMemoryPermanent; }
@@ -116,32 +119,53 @@ class GPUTRDTracker : public GPUProcessor
 #endif
       return (1);
     }
+    if (!trk.CheckNumericalQuality()) {
+      return (0);
+    }
+    if (CAMath::Abs(trk.getEta()) > mMaxEta) {
+      return (0);
+    }
+    if (trk.getPt() < mMinPt) {
+      return (0);
+    }
 #ifdef GPUCA_ALIROOT_LIB
-    new (&mTracks[mNTracks++]) GPUTRDTrack(trk); // We need placement new, since the class is virtual
+    new (&mTracks[mNTracks]) GPUTRDTrack(trk); // We need placement new, since the class is virtual
 #else
-    mTracks[mNTracks++] = trk;
+    mTracks[mNTracks] = trk;
 #endif
+    mTracks[mNTracks].SetTPCtrackId(mNTracks);
     if (label >= 0) {
-      mTracks[mNTracks - 1].SetLabel(label);
+      mTracks[mNTracks].SetLabel(label);
     }
     if (nTrkltsOffline) {
       for (int i = 0; i < 4; ++i) {
-        mTracks[mNTracks - 1].SetNtrackletsOffline(i, nTrkltsOffline[i]); // see GPUTRDTrack.h for information on the index
+        mTracks[mNTracks].SetNtrackletsOffline(i, nTrkltsOffline[i]); // see GPUTRDTrack.h for information on the index
       }
     }
-    mTracks[mNTracks - 1].SetLabelOffline(labelOffline);
+    mTracks[mNTracks].SetLabelOffline(labelOffline);
+    mNTracks++;
     return (0);
   }
   GPUd() void DoTrackingThread(int iTrk, int threadId = 0);
   GPUd() bool CalculateSpacePoints();
   GPUd() bool FollowProlongation(GPUTRDPropagator* prop, GPUTRDTrack* t, int threadId);
+  GPUd() float GetPredictedChi2(const My_Float* pTRD, const My_Float* covTRD, const My_Float* pTrk, const My_Float* covTrk) const;
   GPUd() int GetDetectorNumber(const float zPos, const float alpha, const int layer) const;
   GPUd() bool AdjustSector(GPUTRDPropagator* prop, GPUTRDTrack* t, const int layer) const;
   GPUd() int GetSector(float alpha) const;
   GPUd() float GetAlphaOfSector(const int sec) const;
-  GPUd() float GetRPhiRes(float snp) const { return (0.04f * 0.04f + 0.33f * 0.33f * (snp - 0.126f) * (snp - 0.126f)); } // parametrization obtained from track-tracklet residuals
-  GPUd() float GetAngularResolution(float snp) const { return 0.0415f * 0.0415f + 0.43f * 0.43f * (snp - 0.147f) * (snp - 0.147f); }
-  GPUd() float ConvertAngleToDy(float snp) const { return 0.132f + 2.379f * snp - 0.517f * snp * snp; } // more accurate than sin(phi) = (dy / xDrift) / sqrt(1+(dy/xDrift)^2)
+  // TODO all parametrizations depend on B-field -> need to find correct description.. To be put in CCDB in the future?
+#ifdef POSITIVE_B_FIELD_5KG
+  // B = +5kG for Run 244340 and 245353
+  GPUd() float GetRPhiRes(float snp) const { return (0.04f * 0.04f + 0.31f * 0.31f * (snp - 0.125f) * (snp - 0.125f)); } // parametrization obtained from track-tracklet residuals
+  GPUd() float GetAngularResolution(float snp) const { return 0.041f * 0.041f + 0.43f * 0.43f * (snp - 0.15f) * (snp - 0.15f); }
+  GPUd() float ConvertAngleToDy(float snp) const { return 0.13f + 2.43f * snp - 0.58f * snp * snp; } // more accurate than sin(phi) = (dy / xDrift) / sqrt(1+(dy/xDrift)^2)
+#else
+  // B = -5kG for Run 246390
+  GPUd() float GetRPhiRes(float snp) const { return (0.04f * 0.04f + 0.34f * 0.34f * (snp + 0.14f) * (snp + 0.14f)); }
+  GPUd() float GetAngularResolution(float snp) const { return 0.047f * 0.047f + 0.45f * 0.45f * (snp + 0.15f) * (snp + 0.15f); }
+  GPUd() float ConvertAngleToDy(float snp) const { return -0.15f + 2.34f * snp + 0.56f * snp * snp; } // more accurate than sin(phi) = (dy / xDrift) / sqrt(1+(dy/xDrift)^2)
+#endif
   GPUd() float GetAngularPull(float dYtracklet, float snp) const;
   GPUd() void RecalcTrkltCov(const float tilt, const float snp, const float rowSize, My_Float (&cov)[3]);
   GPUd() void CheckTrackRefs(const int trackID, bool* findableMC) const;
@@ -160,6 +184,8 @@ class GPUTRDTracker : public GPUProcessor
   GPUd() void SetChi2Threshold(float chi2) { mMaxChi2 = chi2; }
   GPUd() void SetChi2Penalty(float chi2) { mChi2Penalty = chi2; }
   GPUd() void SetMaxMissingLayers(int ly) { mMaxMissingLy = ly; }
+  GPUd() void SetExtraRoadY(float extraRoadY) { mExtraRoadY = extraRoadY; }
+  GPUd() void SetRoadZ(float roadZ) { mRoadZ = roadZ; }
 
   GPUd() AliMCEvent* GetMCEvent() const { return mMCEvent; }
   GPUd() bool GetIsDebugOutputOn() const { return mDebugOutput; }
@@ -169,6 +195,8 @@ class GPUTRDTracker : public GPUProcessor
   GPUd() float GetChi2Penalty() const { return mChi2Penalty; }
   GPUd() int GetMaxMissingLayers() const { return mMaxMissingLy; }
   GPUd() int GetNCandidates() const { return mNCandidates; }
+  GPUd() float GetExtraRoadY() const { return mExtraRoadY; }
+  GPUd() float GetRoadZ() const { return mRoadZ; }
 
   // output
   GPUd() int NTracks() const { return mNTracks; }
@@ -179,7 +207,7 @@ class GPUTRDTracker : public GPUProcessor
   GPUd() void DumpTracks();
 
  protected:
-  float* mR;                               // rough radial position of each TRD layer
+  float* mR;                               // radial position of each TRD chamber, alignment taken into account, radial spread within chambers < 7mm
   bool mIsInitialized;                     // flag is set upon initialization
   short mMemoryPermanent;                  // size of permanent memory for the tracker
   short mMemoryTracklets;                  // size of memory for TRD tracklets
@@ -201,8 +229,11 @@ class GPUTRDTracker : public GPUProcessor
   int* mTrackletLabels;                    // array with MC tracklet labels
   TRD_GEOMETRY_CONST GPUTRDGeometry* mGeo; // TRD geometry
   bool mDebugOutput;                       // store debug output
+  float mRadialOffset;                     // due to mis-calibration of t0
   float mMinPt;                            // min pt of TPC tracks for tracking
   float mMaxEta;                           // TPC tracks with higher eta are ignored
+  float mExtraRoadY;                       // addition to search road in r-phi to account for not exact radial match of tracklets and tracks in first iteration
+  float mRoadZ;                            // in z, a constant search road is used
   float mMaxChi2;                          // max chi2 for tracklets
   int mMaxMissingLy;                       // max number of missing layers per track
   float mChi2Penalty;                      // chi2 added to the track for no update

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTrackerDebug.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTrackerDebug.h
@@ -20,6 +20,7 @@
 
 #include "TVectorF.h"
 #include "TTreeStream.h"
+#include "GPULogging.h"
 #include "GPUTRDTrack.h"
 
 namespace GPUCA_NAMESPACE
@@ -93,7 +94,9 @@ class GPUTRDTrackerDebug
     fTrackYReal.ResizeTo(6);
     fTrackZReal.ResizeTo(6);
     fTrackSecReal.ResizeTo(6);
+    fChi2YZPhiUpdate.ResizeTo(6);
     fChi2Update.ResizeTo(6);
+    fChi2YZPhiReal.ResizeTo(6);
     fChi2Real.ResizeTo(6);
     fNmatchesAvail.ResizeTo(6);
     fFindable.ResizeTo(6);
@@ -147,7 +150,9 @@ class GPUTRDTrackerDebug
     fTrackYReal.Zero();
     fTrackZReal.Zero();
     fTrackSecReal.Zero();
+    fChi2YZPhiUpdate.Zero();
     fChi2Update.Zero();
+    fChi2YZPhiReal.Zero();
     fChi2Real.Zero();
     fNmatchesAvail.Zero();
     fFindable.Zero();
@@ -284,6 +289,8 @@ class GPUTRDTrackerDebug
   // update information
   void SetChi2Update(float chi2, int ly) { fChi2Update(ly) = chi2; }
   void SetChi2Real(float chi2, int ly) { fChi2Real(ly) = chi2; }
+  void SetChi2YZPhiUpdate(float chi2, int ly) { fChi2YZPhiUpdate(ly) = chi2; }
+  void SetChi2YZPhiReal(float chi2, int ly) { fChi2YZPhiReal(ly) = chi2; }
 
   // other infos
   void SetRoad(float roadY, float roadZ, int ly)
@@ -362,6 +369,8 @@ class GPUTRDTrackerDebug
       "trackletDetReal.=" << &fTrackletDetReal <<          // detector number for matching or related tracklet if available, otherwise -1
       "chi2Update.=" << &fChi2Update <<                    // chi2 for update
       "chi2Real.=" << &fChi2Real <<                        // chi2 for first tracklet w/ matching MC label
+      "chi2YZPhiUpdate.=" << &fChi2YZPhiUpdate <<          // chi2 for update taking into account full tracklet information (y, z, dY aka sin(phi))
+      "chi2YZPhiReal.=" << &fChi2YZPhiReal <<              // chi2 for first tracklet w/ matching MC label taking into account full tracklet information (y, z, dY aka sin(phi))
       "chi2Total=" << fChi2 <<                             // total chi2 for track
       "nLayers=" << fNlayers <<                            // number of layers in which track was findable
       "nTracklets=" << fNtrklts <<                         // number of attached tracklets
@@ -446,6 +455,8 @@ class GPUTRDTrackerDebug
   TVectorF fTrackletDetReal;
   TVectorF fChi2Update;
   TVectorF fChi2Real;
+  TVectorF fChi2YZPhiUpdate;
+  TVectorF fChi2YZPhiReal;
   TVectorF fRoadY;
   TVectorF fRoadZ;
   TVectorF fFindable;
@@ -497,6 +508,8 @@ class GPUTRDTrackerDebug
   // update information
   GPUd() void SetChi2Update(float chi2, int ly) {}
   GPUd() void SetChi2Real(float chi2, int ly) {}
+  GPUd() void SetChi2YZPhiUpdate(float chi2, int ly) {}
+  GPUd() void SetChi2YZPhiReal(float chi2, int ly) {}
 
   // other infos
   GPUd() void SetRoad(float roadY, float roadZ, int ly) {}

--- a/GPU/GPUTracking/TRDTracking/macros/checkDbgOutput.C
+++ b/GPU/GPUTracking/TRDTracking/macros/checkDbgOutput.C
@@ -42,6 +42,63 @@ TFile* fOut = 0x0; // output file with results
 
 static const Float_t xDrift = 3.f; // drift length in TRD
 
+Float_t mRadiusTRD[540] = {
+  // values obtained from TRD geometry with misalignment from Run 2 data
+  301.1638, 313.6753, 326.2809, 338.9940, 351.6026, 364.0537, 300.1665, 312.7854, 325.2572, 338.0002,
+  350.5855, 363.2468, 299.9399, 312.6280, 325.1296, 337.8112, 350.4096, 362.9868, 300.0480, 312.6387,
+  325.2549, 337.8503, 350.4702, 363.1088, 300.6183, 313.1226, 325.6801, 336.4037, 351.1088, 363.7209,
+  301.0214, 313.5769, 325.9181, 338.8168, 351.3764, 364.0374, 300.4273, 313.0337, 325.5900, 338.2114,
+  350.3062, 363.4128, 300.4677, 312.4737, 325.6458, 338.2561, 350.8812, 363.4771, 300.6205, 313.2002,
+  325.1768, 338.4358, 351.0317, 363.6595, 301.0286, 313.5724, 326.1777, 338.8574, 351.4896, 364.1179,
+  300.9745, 313.4982, 326.1171, 338.7638, 351.3966, 363.9760, 300.3126, 312.8979, 325.4928, 338.0868,
+  350.6675, 363.3101, 300.0797, 312.6622, 325.2723, 337.8378, 350.4357, 363.0448, 300.1662, 312.7673,
+  325.3743, 337.9777, 350.5836, 363.2047, 300.5636, 313.1315, 325.7466, 338.3991, 351.0360, 363.6499,
+  300.0736, 312.5803, 325.2037, 337.8509, 350.4709, 363.0919, 299.4032, 311.9627, 324.5612, 337.1712,
+  349.7448, 362.3622, 299.0729, 311.6657, 324.2644, 336.8565, 349.4228, 362.0316, 299.3591, 311.9435,
+  324.5541, 337.1744, 349.7820, 362.3092, 299.7018, 312.2701, 324.9075, 337.5642, 350.1906, 362.8041,
+  300.2838, 312.7707, 325.4074, 338.0439, 350.6742, 363.2568, 299.4787, 312.0710, 324.6480, 337.2245,
+  349.8300, 362.4292, 299.1346, 311.7354, 324.3476, 336.9353, 349.5186, 362.1122, 299.3472, 311.9391,
+  324.5588, 337.1538, 349.7728, 362.3968, 299.7233, 312.2910, 324.9137, 337.5317, 350.1523, 362.7660,
+  300.8478, 313.3206, 325.9622, 338.6137, 351.2384, 363.7973, 300.4421, 313.0483, 325.6368, 338.2621,
+  350.8496, 363.5216, 300.2939, 312.8903, 325.4760, 338.0599, 350.6551, 363.2704, 300.2710, 312.8796,
+  325.4750, 338.0652, 350.6739, 363.2903, 300.6549, 313.2075, 325.8105, 338.4437, 351.0597, 363.6997,
+  300.3321, 312.8056, 325.4342, 338.0782, 350.7090, 363.2995, 299.7911, 312.3856, 324.9652, 337.5777,
+  350.1493, 362.7679, 299.6359, 312.2484, 324.8446, 337.4233, 350.0143, 362.6087, 299.7957, 312.3872,
+  324.9664, 337.5905, 350.1895, 362.8127, 300.1930, 312.7411, 325.3527, 337.9474, 350.5567, 363.1714,
+  299.8708, 312.4178, 325.0097, 337.6199, 350.2367, 362.8197, 299.1785, 311.7572, 324.3414, 337.3875,
+  349.5200, 362.1488, 299.4955, 312.1514, 324.7430, 337.3484, 349.4956, 362.4435, 300.2071, 313.4209,
+  325.7401, 338.3114, 351.2445, 363.8318, 301.1368, 313.7283, 323.1139, 339.0000, 348.2148, 364.2878,
+  300.2202, 311.5885, 325.3409, 337.9732, 350.6152, 363.1797, 299.4919, 312.0841, 324.6882, 337.2600,
+  349.8945, 362.5386, 299.8091, 312.4409, 325.0175, 337.6343, 350.2683, 362.9218, 300.8080, 313.4294,
+  326.0444, 338.6830, 351.3325, 364.0310, 302.0378, 314.4691, 327.2754, 339.9633, 352.7125, 365.4345,
+  299.9575, 312.4977, 325.0936, 337.7063, 350.2953, 362.9128, 299.5390, 311.1592, 324.7299, 337.3160,
+  349.9368, 362.5510, 299.5108, 312.1093, 324.7206, 337.2922, 349.9214, 362.4301, 299.8687, 312.4665,
+  325.1017, 337.6802, 350.2963, 362.8917, 300.9908, 313.4976, 326.1486, 338.7900, 351.4818, 363.9900,
+  300.6823, 313.2546, 325.9451, 338.5287, 351.1094, 363.7102, 300.0946, 312.6830, 324.9392, 337.8933,
+  350.4915, 363.1127, 299.8324, 312.4263, 325.0230, 337.6105, 350.2232, 362.8239, 299.3513, 311.9513,
+  324.7056, 337.9153, 350.5267, 363.1600, 300.4924, 313.0683, 325.7024, 338.3462, 350.9743, 363.6421,
+  300.7480, 313.3162, 325.9303, 338.5727, 351.1999, 361.9792, 300.3176, 312.9042, 325.4741, 338.1341,
+  350.7175, 363.3588, 300.1988, 312.8076, 325.3764, 337.9723, 350.5598, 363.1935, 300.2925, 312.8776,
+  325.4606, 338.0796, 350.6691, 363.2837, 300.7752, 313.2974, 325.9370, 338.5706, 351.1929, 363.7629,
+  301.4623, 314.0134, 326.6686, 339.3200, 351.9519, 364.5737, 300.6925, 313.2856, 325.9172, 338.5039,
+  351.1359, 363.7670, 300.2042, 312.8122, 325.4005, 337.9800, 350.5984, 363.2198, 300.2045, 312.8112,
+  325.3964, 337.9856, 350.5974, 363.1866, 300.5374, 313.1093, 325.7511, 338.3422, 350.9572, 363.0667,
+  301.8664, 314.4035, 327.0365, 339.7027, 352.3793, 364.9678, 301.2704, 313.8376, 326.4926, 339.1151,
+  351.7640, 364.3762, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 300.4171, 313.0230,
+  325.6084, 338.2077, 350.8230, 363.4106, 300.7245, 313.2963, 325.9065, 338.5176, 351.1591, 363.7482,
+  301.1933, 313.7285, 326.4055, 339.0260, 351.7000, 364.3218, 300.6251, 313.2307, 325.8524, 338.4811,
+  351.0968, 363.7139, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 300.0714, 312.6378,
+  325.2482, 337.8352, 350.4462, 363.0263, 300.4317, 312.9689, 325.5656, 338.2149, 350.8201, 363.4381,
+  301.1367, 313.6926, 326.3340, 338.9482, 351.6006, 364.2099, 300.6340, 313.2314, 325.8670, 338.4652,
+  351.1076, 363.7123, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 299.9679, 312.5547,
+  325.1368, 337.7163, 350.3134, 362.9132, 300.3560, 312.9071, 325.4938, 338.1319, 350.7675, 363.3560,
+  301.6351, 314.1871, 326.8156, 339.4562, 352.0907, 364.7228, 300.8649, 313.4675, 326.0716, 338.7047,
+  350.1673, 363.9594, 300.3626, 312.4153, 325.4608, 338.1805, 350.7680, 363.3876, 300.2386, 312.8433,
+  325.4392, 338.0548, 350.6596, 363.2844, 300.7667, 313.3035, 325.9411, 338.6026, 351.2442, 363.8458,
+  301.1233, 313.6592, 326.2866, 338.9925, 351.5959, 364.2216, 300.4396, 313.0188, 325.6150, 338.2195,
+  350.8347, 363.4567, 300.2179, 312.8220, 325.4206, 337.9880, 350.5974, 363.2124, 300.2803, 312.8911,
+  325.4789, 338.1055, 350.7065, 363.3173, 300.9001, 313.4750, 326.0733, 338.7448, 0.0000, 363.9888};
+
 // branches
 Int_t event = 0x0;
 Int_t nTPCtracks = 0x0;
@@ -231,8 +288,8 @@ void SetAlias(TTree* tree, Bool_t isMC)
   tree->SetAlias("geoFindable", "findable.fElements>0");
   if (isMC) {
     tree->SetAlias("isGold", "nMatching==6");
-    tree->SetAlias("isMatch", "isPresent&&update.fElements<8");
-    tree->SetAlias("isRelated", "update.fElements>3&&update.fElements<8");
+    tree->SetAlias("isMatch", "isPresent&&update.fElements<3.5");
+    tree->SetAlias("isRelated", "update.fElements>3.5&&update.fElements<8");
     tree->SetAlias("isGood", "isMatch||isRelated");
     tree->SetAlias("isFake", "isPresent&&update.fElements>8");
   } else {
@@ -266,6 +323,12 @@ Int_t LoadBranches(Int_t entry)
     lastEntry = entry;
   }
   return 1;
+}
+
+Int_t GetStack(Float_t det)
+{
+  Int_t detInt = TMath::Nint(det);
+  return (detInt % 30) / 6;
 }
 
 // convert azimuthal track angle (sin(phi) = param[3]) to dy of tracklet
@@ -307,6 +370,23 @@ Double_t GetDeltaAngle(Int_t layer)
   Double_t trackletDyLayer = (*trackletDy)[layer];
   Double_t trackletDyF = AngleToDy((*trackPhi)[layer]);
   return (trackletDyLayer - trackletDyF);
+}
+
+Double_t GetEta(Float_t tgl)
+{
+  Double_t theta = TMath::Pi() / 2. - TMath::ATan(tgl);
+  return -TMath::Log(TMath::Tan(theta * .5));
+}
+
+Double_t GetDeltaR(Int_t layer)
+{
+  if (layer < 0 || layer > 5 || (*trackletXreal)[layer] < 10) {
+    return -999;
+  }
+  if (TMath::Abs(GetEta((*trackLambda)[layer])) > 0.05) {
+    return 999;
+  }
+  return (*trackletXreal)[layer] - mRadiusTRD[TMath::Nint((*trackletDetReal)[layer])];
 }
 
 // tracklet residual in rphi, either based on interpolated tracklet position from the surrounding layers
@@ -353,12 +433,13 @@ void FitAngularResolution()
   if (!tree) {
     return;
   }
+  fOut = new TFile("results.root", "update");
   TGraph* gr = TStatToolkit::MakeGraphErrors(tree, "trackletDy.fElements:trackPhi.fElements", "isGold&&LoadBranches(Entry$)", 25, 1, 1, 0, 100000);
   gr->Fit("pol2", "rob=0.9", "", -0.3, 0.3);
   tree->SetAlias("trackletDyFit", TString::Format("(%f)+(%f)*trackPhi.fElements+(%f)*trackPhi.fElements^2", gr->GetFunction("pol2")->GetParameter(0), gr->GetFunction("pol2")->GetParameter(1), gr->GetFunction("pol2")->GetParameter(2)));
   gr->Draw("ap");
   fitTrackletDy->SetParameters(gr->GetFunction("pol2")->GetParameter(0), gr->GetFunction("pol2")->GetParameter(1), gr->GetFunction("pol2")->GetParameter(2));
-  tree->Draw("trackletDy.fElements-trackletDyFit:trackPhi.fElements>>hisDyPhi(20, -0.3, 0.3, 50, -0.3, 0.3)", "isGold", "colz");
+  tree->Draw("trackletDy.fElements-trackletDyFit:trackPhi.fElements>>hisDyPhi(20, -0.25, 0.25, 50, -0.3, 0.3)", "isGold", "colz");
   TH2* hisDyPhi = (TH2*)tree->GetHistogram();
   hisDyPhi->FitSlicesY();
   TH1* hAngularResolution = (TH1*)gROOT->FindObject("hisDyPhi_2");
@@ -366,10 +447,16 @@ void FitAngularResolution()
   hAngularResolution->Fit(fitRMSAngle);
   hAngularResolution->SetTitle("");
   hAngularResolution->GetXaxis()->SetTitle("track #phi");
-  hAngularResolution->GetYaxis()->SetTitle("RMS (tracklet deflection - fit tracklet defl. vs track #phi)");
+  hAngularResolution->GetYaxis()->SetTitle("RMS (tracklet defl. - fit tracklet defl.)");
   gStyle->SetOptStat(0);
   hAngularResolution->Draw();
   fitRMSAngle->Draw("same");
+  hAngularResolution->Write();
+  delete hAngularResolution;
+  fitRMSAngle->Write();
+  delete fitRMSAngle;
+  fOut->Close();
+  delete fOut;
 }
 
 void FitPositionResolution()
@@ -377,10 +464,19 @@ void FitPositionResolution()
   if (!tree) {
     return;
   }
+  fOut = new TFile("results.root", "update");
   tree->Draw("GetDeltaRPhi(layer, 1, 0):trackNoUpPhi.fElements>>hisDeltaRPhi(15, -0.4, 0.4, 50, -0.3, 0.3)", "isGold&&lowMult&&LoadBranches(Entry$)", "colz");
   ((TH2*)tree->GetHistogram())->FitSlicesY();
   ((TH1*)gROOT->FindObject("hisDeltaRPhi_2"))->Fit(fitRMSDelta012);
   gPad->SaveAs("FitPositionResolution.png");
+  TH1* hPositionResolution = (TH1*)gROOT->FindObject("hisDeltaRPhi_2");
+  hPositionResolution->Draw();
+  hPositionResolution->Write();
+  delete hPositionResolution;
+  fitRMSDelta012->Write();
+  delete fitRMSDelta012;
+  fOut->Close();
+  delete fOut;
 }
 
 void FitRPhiVsChamber(Bool_t rawTrkltPosition = kTRUE)
@@ -397,6 +493,41 @@ void FitRPhiVsChamber(Bool_t rawTrkltPosition = kTRUE)
     ((TH2*)tree->GetHistogram())->FitSlicesY();
     ((TH1*)gROOT->FindObject("hisRPhiDet_1"))->Draw();
   }
+}
+
+void CheckRadialOffset()
+{
+  TH2F* hRadialOffset = new TH2F("radialOffset", "", 540, 0, 540, 100, -3, 3);
+  for (Int_t i = 0; i < tree->GetEntriesFast(); ++i) {
+    tree->GetEntry(i);
+    if (trackID < 0) {
+      continue;
+    }
+    if (nMatching != 6) {
+      continue;
+    }
+    //if ((*trackPhi)[0] < 0.15) {
+    //  continue;
+    //}
+    for (Int_t iLy = 0; iLy < 6; iLy++) {
+      Double_t phi = (*trackPhi)[iLy];
+      Double_t deltaRPhi = (*trackletY)[iLy] - (*trackNoUpY)[iLy];
+      Int_t det = (*trackletDet)[iLy];
+      Double_t deltaR = deltaRPhi / TMath::Tan(TMath::ASin(phi));
+      hRadialOffset->Fill(det, deltaR);
+    }
+  }
+  hRadialOffset->Draw("colz");
+}
+
+void FitRadialSpreadTrklts()
+{
+  if (!tree) {
+    return;
+  }
+  tree->Draw("GetDeltaR(layer):trackletDetReal.fElements>>hisRDet(540, -0.5, 539.5, 50, -5, 5)", "LoadBranches(Entry$)", "colz");
+  ((TH2*)tree->GetHistogram())->FitSlicesY();
+  ((TH1*)gROOT->FindObject("hisRDet_2"))->Draw();
 }
 
 void PrintEfficiency(Float_t ptCut = 1.5)
@@ -613,7 +744,7 @@ void MakeLogScale(TH1* hist, Double_t xMin = -1, Double_t xMax = -1)
 
 void TwoTrackletEfficiency(Int_t nEntries = -1)
 {
-  fOut = new TFile("results.root", "recreate");
+  fOut = new TFile("results.root", "update");
   TH1F* hAll = new TH1F("all", "p_{T} spectrum for all tracks;track pT (GeV); counts", 10, 0, 10);
   TH1F* h2Trklts = new TH1F("h2trklts", "p_{T} spectrum for all tracks w/ N_{trklts} >= 2;track pT (GeV); counts", 10, 0, 10);
   TH1F* h2TrkltsNoFakes = new TH1F("h2trkltsNoFakes", "p_{T} spectrum for all tracks w/ N_{trklts} >= 2 and zero fakes;track pT (GeV); counts", 10, 0, 10);
@@ -648,20 +779,20 @@ void TwoTrackletEfficiency(Int_t nEntries = -1)
     if (trackID < 0) {
       continue;
     }
-    if (findable->Sum() < 1) {
+    if (findable->Sum() < 2) {
       continue;
     }
     Double_t pt = trackPtTPC;
     hAll->Fill(pt);
-    if (nTracklets >= 2) {
-      //if (nMatching + nRelated >= 2) {
+    //if (nTracklets >= 2) {
+    if (nMatching + nRelated >= 2) {
       h2Trklts->Fill(pt);
       if (nFake == 0) {
         h2TrkltsNoFakes->Fill(pt);
       }
     }
-    if (nTrackletsOffline >= 2) {
-      //if (nMatchingOffline + nRelatedOffline >= 2) {
+    //if (nTrackletsOffline >= 2) {
+    if (nMatchingOffline + nRelatedOffline >= 2) {
       h2TrkltsRef->Fill(pt);
       if (nFakeOffline == 0) {
         h2TrkltsNoFakesRef->Fill(pt);
@@ -820,20 +951,29 @@ void PlotOnlineTrackletEfficiency(Int_t nEntries = -1)
   // efficiency: fraction of online tracklets with correct track label
   //             if track produced hits within the TRD layer
 
+  fOut = new TFile("results.root", "update");
   if (nEntries < 0) {
     nEntries = tree->GetEntriesFast();
   }
-  TH1F* hAll = new TH1F("all", "tmp histogram;pT (GeV);counts", 10, 0, 5);
-  TH1F* hFrac = new TH1F("frac", "tmp histogram;pT (GeV);counts", 10, 0, 5);
-  TH1F* hEff = new TH1F("eff", "online tracklet efficiency;p_{T} (GeV/#it{c});efficiency", 10, 0, 5);
-  hAll->Sumw2();
-  hFrac->Sumw2();
-  MakeLogScale(hAll, 0.2, 12);
-  MakeLogScale(hFrac, 0.2, 12);
-  MakeLogScale(hEff, 0.2, 12);
+  TH1F* hAllPos = new TH1F("allPos", "tmp histogram;pT (GeV);counts", 10, 0, 5);
+  TH1F* hFracPos = new TH1F("fracPos", "tmp histogram;pT (GeV);counts", 10, 0, 5);
+  TH1F* hEffPos = new TH1F("effPos", "online tracklet efficiency;p_{T} (GeV/#it{c});efficiency", 10, 0, 5);
+  hAllPos->Sumw2();
+  hFracPos->Sumw2();
+  MakeLogScale(hAllPos, 0.2, 12);
+  MakeLogScale(hFracPos, 0.2, 12);
+  MakeLogScale(hEffPos, 0.2, 12);
+  TH1F* hAllNeg = new TH1F("allNeg", "tmp histogram;pT (GeV);counts", 10, 0, 5);
+  TH1F* hFracNeg = new TH1F("fracNeg", "tmp histogram;pT (GeV);counts", 10, 0, 5);
+  TH1F* hEffNeg = new TH1F("effNeg", "online tracklet efficiency;p_{T} (GeV/#it{c});efficiency", 10, 0, 5);
+  hAllNeg->Sumw2();
+  hFracNeg->Sumw2();
+  MakeLogScale(hAllNeg, 0.2, 12);
+  MakeLogScale(hFracNeg, 0.2, 12);
+  MakeLogScale(hEffNeg, 0.2, 12);
   for (Int_t iEntry = 0; iEntry < nEntries; iEntry++) {
     tree->GetEntry(iEntry);
-    if (trackID < 0) {
+    if (trackID < 0 || TMath::Abs(trackPID) != 211) {
       continue;
     }
     for (Int_t iLy = 1; iLy < 6; iLy++) {
@@ -841,24 +981,37 @@ void PlotOnlineTrackletEfficiency(Int_t nEntries = -1)
         continue;
       }
       Double_t trkPt = (*trackPt)[iLy];
-      hAll->Fill(trkPt);
+      //(*trackQPt)[iLy] > 0 ? hAllPos->Fill(trkPt) : hAllNeg->Fill(trkPt);
+      trackPID == 211 ? hAllPos->Fill(trkPt) : hAllNeg->Fill(trkPt);
       if ((*nMatchingTracklets)[iLy] > 0) {
-        hFrac->Fill(trkPt);
+        //(*trackQPt)[iLy] > 0 ? hFracPos->Fill(trkPt) : hFracNeg->Fill(trkPt);
+        trackPID == 211 ? hFracPos->Fill(trkPt) : hFracNeg->Fill(trkPt);
       }
     }
   }
   gStyle->SetOptStat(0);
   gStyle->SetErrorX(0);
-  hEff->Divide(hFrac, hAll, 1, 1, "B");
-  TCanvas* c1 = new TCanvas("c1", "c1");
-  c1->SetGridy();
-  c1->SetGridx();
-  c1->SetLogx();
-  hEff->SetLineWidth(2);
-  hEff->SetMarkerStyle(22);
-  hEff->SetMarkerColor(kBlue);
-  hEff->GetYaxis()->SetRangeUser(0.4, 1.);
-  hEff->Draw("ep");
+  hEffPos->Divide(hFracPos, hAllPos, 1, 1, "B");
+  hEffNeg->Divide(hFracNeg, hAllNeg, 1, 1, "B");
+  //TCanvas* c1 = new TCanvas("c1", "c1");
+  //c1->SetGridy();
+  //c1->SetGridx();
+  //c1->SetLogx();
+  hEffPos->SetLineWidth(2);
+  hEffPos->SetLineColor(kRed);
+  hEffPos->SetMarkerStyle(22);
+  hEffPos->SetMarkerColor(kRed);
+  hEffPos->GetYaxis()->SetRangeUser(0.2, 1.);
+  hEffNeg->SetLineWidth(2);
+  hEffNeg->SetLineColor(kBlack);
+  hEffNeg->SetMarkerStyle(22);
+  hEffNeg->SetMarkerColor(kBlack);
+  //hEff->Draw("ep");
+  hEffPos->Write();
+  delete hEffPos;
+  hEffNeg->Write();
+  delete hEffNeg;
+  fOut->Close();
 }
 
 void MultipleHypothesisCheck(Float_t minPt = 0.7, Int_t nEntries = -1)
@@ -1311,9 +1464,9 @@ void OnlineTrackletEfficiency(Int_t nEntries = -1)
   const Double_t binEndPt = 5.;
 
   const Int_t nBins2D = 50;
-  TH2F* hIsFindableQptY = new TH2F("isFindableQptY", ";#it{y} (cm);#it{q}/#it{p}_{T} (#it{c}/GeV)", nBins2D, -60, 60, nBins2D, -1, 1);
-  TH2F* hIsFoundQptY = new TH2F("isFoundQptY", ";#it{y} (cm);#it{q}/#it{p}_{T} (#it{c}/GeV)", nBins2D, -60, 60, nBins2D, -1, 1);
-  TH2F* hEfficiencyQptY = new TH2F("isEfficiencyQptY", ";#it{y} (cm);#it{q}/#it{p}_{T} (#it{c}/GeV)", nBins2D, -60, 60, nBins2D, -1, 1);
+  TH2F* hIsFindableQptY = new TH2F("isFindableQptY", ";#it{y} (cm);#it{q}/#it{p}_{T} (#it{c}/GeV)", nBins2D, -60, 60, nBins2D, -2, 2);
+  TH2F* hIsFoundQptY = new TH2F("isFoundQptY", ";#it{y} (cm);#it{q}/#it{p}_{T} (#it{c}/GeV)", nBins2D, -60, 60, nBins2D, -2, 2);
+  TH2F* hEfficiencyQptY = new TH2F("isEfficiencyQptY", ";#it{y} (cm);#it{q}/#it{p}_{T} (#it{c}/GeV)", nBins2D, -60, 60, nBins2D, -2, 2);
 
   TH1F* hIsFindablePhi = new TH1F("isFindablePhi", ";track #varphi;counts", nBins, binStartPhi, binEndPhi);
   hIsFindablePhi->Sumw2();
@@ -1374,6 +1527,7 @@ void OnlineTrackletEfficiency(Int_t nEntries = -1)
     for (Int_t iBinY = 0; iBinY < nBins2D; iBinY++) {
       Int_t iBin = hIsFindableQptY->GetBin(iBinX, iBinY);
       if (hIsFindableQptY->GetBinContent(iBin) <= 0) {
+        hEfficiencyQptY->SetBinContent(iBin, 0);
         continue;
       }
       hEfficiencyQptY->SetBinContent(iBin, hIsFoundQptY->GetBinContent(iBin) / hIsFindableQptY->GetBinContent(iBin));
@@ -1423,7 +1577,8 @@ void OnlineTrackletEfficiency(Int_t nEntries = -1)
   legFindable->Draw();
 
   TCanvas* cEfficiencyQptY = new TCanvas("efficiencyQptY", "efficiencyQptY");
-  hEfficiencyQptY->GetZaxis()->SetRangeUser(0.5, 1);
+  hEfficiencyQptY->GetXaxis()->SetRangeUser(-45.0, 45.);
+  hEfficiencyQptY->GetZaxis()->SetRangeUser(0.0, 1);
   hEfficiencyQptY->Draw("colz");
 }
 


### PR DESCRIPTION
Hi @davidrohr 
when I implemented some optimizations for the TRD tracking I did not see a noticeable speedup. With callgrind I saw that most time for the tracking is spent in the propagate function. Currently I propagate the track to each tracklet in the chambers where the track ends up for a comparison. This is needed because of the misalignment of the chambers (the TRD space points are at different radii). If I skip these propagation steps and only propagate once to the middle of the TRD chamber I get a speedup factor of ~18 on a single core!
So I think the greatest potential for a performance optimization is here. I could use `GPUTPCGMPropagator::GetPropagatedYZ` instead of the full propagation, but then the chi2 prediction is not correct. 
Or should I try to implement my own propagate function where only Y, Z and sin(phi) and their errors are calculated such that I can compare those parameters to the TRD space points?
I implemented a function `GetPredictedChi2` which compares tracklet and track, taking into account also the tracklet deflection (see last commit). It is not used yet. I was not sure if that could not be simplified ignoring the correlations sigma_YSinPhi and sigma_ZSinPhi. Since I don't know how to calculate them for the TRD I only use the values of the track for them.
Cheers,
Ole
