### PR TITLE
DPL Analysis: rework OutputAppender API

### DIFF
--- a/Framework/AnalysisTutorial/CMakeLists.txt
+++ b/Framework/AnalysisTutorial/CMakeLists.txt
@@ -39,3 +39,8 @@ o2_add_executable(dynamic-columns
                   SOURCES src/dynamicColumns.cxx
                   PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME AnalysisTutorial)
+
+o2_add_executable(histograms
+                  SOURCES src/histograms.cxx
+                  PUBLIC_LINK_LIBRARIES O2::Framework
+                  COMPONENT_NAME AnalysisTutorial)

--- a/Framework/AnalysisTutorial/src/histograms.cxx
+++ b/Framework/AnalysisTutorial/src/histograms.cxx
@@ -1,0 +1,48 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/HistogramRegistry.h"
+#include <TH1.h>
+
+using namespace o2;
+using namespace o2::framework;
+
+// This is a very simple example showing how to create an histogram
+// FIXME: this should really inherit from AnalysisTask but
+//        we need GCC 7.4+ for that
+struct ATask {
+  HistogramRegistry registry{
+    "MyAnalysisHistos",
+    true,
+    {{"Test1", "SomethingElse1", {"TH1F", 100, 0, 2 * M_PI}},
+     {"Test2", "SomethingElse2", {"TH1F", 100, 0, 2 * M_PI}},
+     {"Test3", "SomethingElse3", {"TH1F", 100, 0, 2 * M_PI}},
+     {"Test4", "SomethingElse4", {"TH1F", 100, 0, 2 * M_PI}},
+     {"Test5", "SomethingElse5", {"TH1F", 100, 0, 2 * M_PI}},
+     {"Test6", "SomethingElse6", {"TH1F", 100, 0, 2 * M_PI}},
+     {"Test7", "SomethingElse7", {"TH1F", 100, 0, 2 * M_PI}}}};
+
+  void process(aod::Tracks const& tracks)
+  {
+    for (auto& track : tracks) {
+      auto phi = asin(track.snp()) + track.alpha() + M_PI;
+
+      registry.get("SomethingElse")->Fill(phi);
+    }
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const&)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<ATask>("fill-etaphi-histogram")};
+}

--- a/Framework/Core/include/Framework/HistogramRegistry.h
+++ b/Framework/Core/include/Framework/HistogramRegistry.h
@@ -12,8 +12,10 @@
 #define FRAMEWORK_HISTOGRAMREGISTRY_H_
 
 #include "Framework/ASoA.h"
-#include "Framework/Logger.h"
 #include "Framework/FunctionalHelpers.h"
+#include "Framework/Logger.h"
+#include "Framework/OutputRef.h"
+#include "Framework/OutputSpec.h"
 #include "Framework/StringHelpers.h"
 #include "Framework/TableBuilder.h"
 
@@ -116,6 +118,19 @@ class HistogramRegistry
     throw std::runtime_error("No match found!");
   }
 
+  // @return the associated OutputSpec
+  OutputSpec const spec()
+  {
+    ConcreteDataMatcher matcher{"HIST", "\0", 0};
+    strncpy(matcher.description.str, this->name.data(), 16);
+    return OutputSpec{OutputLabel{this->name}, matcher};
+  }
+
+  OutputRef ref()
+  {
+    return OutputRef{this->name, 0};
+  }
+
   /// lookup distance counter for benchmarking
   mutable uint32_t lookup = 0;
 
@@ -138,7 +153,7 @@ class HistogramRegistry
   {
     return i & mask;
   }
-  char const* const name;
+  std::string name;
   bool enabled;
 
   /// The maximum number of histograms in buffer is currently set to 512

--- a/Framework/Core/include/Framework/OutputSpec.h
+++ b/Framework/Core/include/Framework/OutputSpec.h
@@ -47,6 +47,10 @@ struct OutputSpec {
   OutputSpec(header::DataOrigin inOrigin, header::DataDescription inDescription,
              enum Lifetime inLifetime = Lifetime::Timeframe);
 
+  /// Build an OutputSpec from a ConcreteDataMatcher
+  OutputSpec(OutputLabel const& inBinding, ConcreteDataMatcher const& concrete,
+             enum Lifetime inLifetime = Lifetime::Timeframe);
+
   /// Build an OutputSpec which does not specify which subSpec the output will
   /// have.
   OutputSpec(OutputLabel const& inBinding, ConcreteDataTypeMatcher const& dataType,

--- a/Framework/Core/src/OutputSpec.cxx
+++ b/Framework/Core/src/OutputSpec.cxx
@@ -45,6 +45,13 @@ OutputSpec::OutputSpec(header::DataOrigin inOrigin, header::DataDescription inDe
 {
 }
 
+OutputSpec::OutputSpec(OutputLabel const& inBinding, ConcreteDataMatcher const& concrete, enum Lifetime inLifetime)
+  : binding{inBinding},
+    matcher{concrete},
+    lifetime{inLifetime}
+{
+}
+
 OutputSpec::OutputSpec(ConcreteDataTypeMatcher const& dataType,
                        enum Lifetime inLifetime)
   : binding{OutputLabel{""}},


### PR DESCRIPTION
* Rename to OutputManager since we will use it also for histograms.
* Add hook to finalize objects.
* Provide initial implementation for histograms.