### PR TITLE
CCDB: make extractFromTFile helper a static method

### DIFF
--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -265,7 +265,7 @@ class CcdbApi //: public DatabaseInterface
    * @param cl The TClass object describing the serialized type
    * @return raw pointer to created object
    */
-  void* extractFromTFile(TFile& file, std::string const& objname, TClass const* cl) const;
+  static void* extractFromTFile(TFile& file, std::string const& objname, TClass const* cl);
 
   /**
    * Initialization of CURL

--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -559,7 +559,7 @@ void CcdbApi::snapshot(std::string const& ccdbrootpath, std::string const& local
   }
 }
 
-void* CcdbApi::extractFromTFile(TFile& file, std::string const& objname, TClass const* cl) const
+void* CcdbApi::extractFromTFile(TFile& file, std::string const& objname, TClass const* cl)
 {
   if (!cl) {
     return nullptr;


### PR DESCRIPTION
This will simplify reusing the same method for DPL Lifetime::Condition.