### PR TITLE
[EMCAL-548,EMCAL-612] Integration of digits converter in EMCAL workflow

### DIFF
--- a/Detectors/EMCAL/workflow/CMakeLists.txt
+++ b/Detectors/EMCAL/workflow/CMakeLists.txt
@@ -11,6 +11,7 @@
 o2_add_library(EMCALWorkflow
                SOURCES src/RecoWorkflow.cxx
                        src/PublisherSpec.cxx
+                       src/CellConverterSpec.cxx
                        src/DigitsPrinterSpec.cxx
                PUBLIC_LINK_LIBRARIES O2::Framework O2::DataFormatsEMCAL
                                      O2::DPLUtils O2::EMCALBase O2::Algorithm)

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/CellConverterSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/CellConverterSpec.h
@@ -1,0 +1,81 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <vector>
+
+#include "DataFormatsEMCAL/Cell.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+
+namespace o2
+{
+
+namespace emcal
+{
+
+namespace reco_workflow
+{
+
+/// \class CellConverterSpec
+/// \brief Coverter task for EMCAL digits to EMCAL cells
+/// \author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
+/// \since Sept 24, 2019
+///
+/// Task converting a vector of EMCAL digits to a vector of
+/// EMCAL cells. No selection of digits is done, digits are
+/// copied 1-to-1 to the output. If MC is available and requested,
+/// the MC truth container is ported to the output. Refer to
+/// run for the list of input and output specs.
+class CellConverterSpec : public framework::Task
+{
+ public:
+  /// \brief Constructor
+  /// \param propagateMC If true the MCTruthContainer is propagated to the output
+  CellConverterSpec(bool propagateMC) : framework::Task(), mPropagateMC(propagateMC){};
+
+  /// \brief Destructor
+  ~CellConverterSpec() override = default;
+
+  /// \brief Initializing the CellConverterSpec
+  /// \param ctx Init context
+  void init(framework::InitContext& ctx) final;
+
+  /// \brief Run conversion of digits to cells
+  /// \param ctx Processing context
+  ///
+  /// Converting the input vector of o2::emcal::Digit to
+  /// an output vector of o2::emcal::Cell. Data is copied
+  /// 1-to-1, no additional selection is done. In case
+  /// the task is configured to propagate MC-truth the
+  /// MC truth container is propagated 1-to-1 to the output.
+  ///
+  /// The following branches are linked:
+  /// Input digits: {"EMC", "DIGITS", 0, Lifetime::Timeframe}
+  /// Input MC-truth: {"EMC", "DIGITSMCTR", 0, Lifetime::Timeframe}
+  /// Output cells: {"EMC", "CELLS", 0, Lifetime::Timeframe}
+  /// Output MC-truth: {"EMC", "CELLSMCTR", 0, Lifetime::Timeframe}
+  void run(framework::ProcessingContext& ctx) final;
+
+ private:
+  bool mPropagateMC = false;                 ///< Switch whether to process MC true labels
+  std::vector<o2::emcal::Cell> mOutputCells; ///< Container with output cells
+};
+
+/// \brief Creating DataProcessorSpec for the EMCAL Cell Converter Spec
+/// \param propagateMC If true the MC truth container is propagated to the output
+///
+/// Refer to CellConverterSpec::run for input and output specs
+framework::DataProcessorSpec getCellConverterSpec(bool propagateMC);
+
+} // namespace reco_workflow
+
+} // namespace emcal
+
+} // namespace o2

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/DigitsPrinterSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/DigitsPrinterSpec.h
@@ -9,6 +9,7 @@
 // or submit itself to any jurisdiction.
 
 #include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
 
 namespace o2
 {
@@ -19,8 +20,42 @@ namespace emcal
 namespace reco_workflow
 {
 
+/// \class DigitsPrinterSpec
+/// \brief Example task for EMCAL digits monitoring
+/// \author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
+/// \since July 11, 2019
+///
+/// Example payload for workflows using o2::emcal::Digit as payload.
+/// Printing several digit-related information for each digit. Refer
+/// to run for the list of input spec to be specified.
+class DigitsPrinterSpec : public framework::Task
+{
+ public:
+  /// \brief Constructor
+  DigitsPrinterSpec() = default;
+
+  /// \brief Destructor
+  ~DigitsPrinterSpec() override = default;
+
+  /// \brief Initializing the digits printer task
+  /// \param ctx Init context
+  void init(framework::InitContext& ctx) final;
+
+  /// \brief Printing digit-related information
+  /// \param ctx Processing context
+  ///
+  /// Printing energy and tower ID for each digit.
+  /// Following input branches are linked:
+  /// - digits: {"EMC", "DIGITS", 0, Lifetime::Timeframe}
+  void run(framework::ProcessingContext& ctx) final;
+};
+
+/// \brief Creating digits printer spec
+///
+/// Refer to DigitsPrinterSpec::run for a list of input
+/// specs
 o2::framework::DataProcessorSpec getEmcalDigitsPrinterSpec();
-}
+} // namespace reco_workflow
 } // namespace emcal
 
 } // namespace o2

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/RecoWorkflow.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/RecoWorkflow.h
@@ -25,18 +25,21 @@ namespace reco_workflow
 {
 
 /// define input and output types of the workflow
-enum struct InputType { Digitizer, // directly read digits from channel {TPC:DIGITS}
+enum struct InputType { Digitizer, // directly read digits from channel {TPC:DIGITS)
                         Digits,    // read digits from file
-                        Raw,       // read hardware clusters in raw page format from file
-                        Clusters,  // read native clusters from file
+                        Cells,     // read compressed cells from file
+                        Raw,       // read data in raw page format from file
+                        Clusters   // read native clusters from file
 };
 enum struct OutputType { Digits,
+                         Cells,
                          Raw,
                          Clusters
 };
 
 /// create the workflow for EMCAL reconstruction
 framework::WorkflowSpec getWorkflow(bool propagateMC = true,
+                                    bool enableDigitsPrinter = false,
                                     std::string const& cfgInput = "digits",   //
                                     std::string const& cfgOutput = "clusters" //
 );

--- a/Detectors/EMCAL/workflow/src/CellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/CellConverterSpec.cxx
@@ -1,0 +1,76 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "FairLogger.h"
+
+#include "DataFormatsEMCAL/Digit.h"
+#include "DataFormatsEMCAL/EMCALBlockHeader.h"
+#include "EMCALWorkflow/CellConverterSpec.h"
+#include "Framework/ControlService.h"
+#include "SimulationDataFormat/MCCompLabel.h"
+#include "SimulationDataFormat/MCTruthContainer.h"
+
+using namespace o2::emcal::reco_workflow;
+
+void CellConverterSpec::init(framework::InitContext& ctx)
+{
+  LOG(DEBUG) << "[EMCALCellConverter - init] Initialize converter " << (mPropagateMC ? "with" : "without") << " MC truth container";
+}
+
+void CellConverterSpec::run(framework::ProcessingContext& ctx)
+{
+  LOG(DEBUG) << "[EMCALCellConverter - run] called";
+  auto dataref = ctx.inputs().get("digits");
+  auto const* emcheader = o2::framework::DataRefUtils::getHeader<o2::emcal::EMCALBlockHeader*>(dataref);
+  if (!emcheader->mHasPayload) {
+    LOG(DEBUG) << "[EMCALCellConverter - run] No more digits" << std::endl;
+    ctx.services().get<o2::framework::ControlService>().readyToQuit(false);
+    return;
+  }
+
+  mOutputCells.clear();
+  auto digits = ctx.inputs().get<std::vector<o2::emcal::Digit>>("digits");
+  LOG(DEBUG) << "[EMCALCellConverter - run]  Received " << digits.size() << " digits ...";
+  for (const auto& dig : digits) {
+    ChannelType_t chantype;
+    if (dig.getHighGain())
+      chantype = ChannelType_t::HIGH_GAIN;
+    else if (dig.getLowGain())
+      chantype = ChannelType_t::LOW_GAIN;
+    else if (dig.getTRU())
+      chantype = ChannelType_t::TRU;
+    else if (dig.getLEDMon())
+      chantype = ChannelType_t::LEDMON;
+    mOutputCells.emplace_back(dig.getTower(), dig.getEnergy(), dig.getTimeStamp(), chantype);
+  }
+  LOG(DEBUG) << "[EMCALCellConverter - run] Writing " << mOutputCells.size() << " cells ...";
+  ctx.outputs().snapshot(o2::framework::Output{"EMC", "CELLS", 0, o2::framework::Lifetime::Timeframe}, mOutputCells);
+  if (mPropagateMC) {
+    // copy mc truth container without modification
+    // as indexing doesn't change
+    auto truthcont = ctx.inputs().get<o2::dataformats::MCTruthContainer<o2::MCCompLabel>*>("digitsmctr");
+    ctx.outputs().snapshot(o2::framework::Output{"EMC", "CELLSMCTR", 0, o2::framework::Lifetime::Timeframe}, *truthcont);
+  }
+}
+
+o2::framework::DataProcessorSpec o2::emcal::reco_workflow::getCellConverterSpec(bool propagateMC)
+{
+  std::vector<o2::framework::InputSpec> inputs;
+  std::vector<o2::framework::OutputSpec> outputs;
+  inputs.emplace_back("digits", o2::header::gDataOriginEMC, "DIGITS", 0, o2::framework::Lifetime::Timeframe);
+  outputs.emplace_back("EMC", "CELLS", 0, o2::framework::Lifetime::Timeframe);
+  if (propagateMC) {
+    inputs.emplace_back("digitsmctr", "EMC", "DIGITSMCTR", 0, o2::framework::Lifetime::Timeframe);
+    outputs.emplace_back("EMC", "CELLSMCTR", 0, o2::framework::Lifetime::Timeframe);
+  }
+  return o2::framework::DataProcessorSpec{"EMCALCellConverterSpec",
+                                          inputs,
+                                          outputs,
+                                          o2::framework::adaptFromTask<o2::emcal::reco_workflow::CellConverterSpec>(propagateMC)};
+}

--- a/Detectors/EMCAL/workflow/src/emc-reco-workflow.cxx
+++ b/Detectors/EMCAL/workflow/src/emc-reco-workflow.cxx
@@ -29,6 +29,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   std::vector<o2::framework::ConfigParamSpec> options{
     {"input-type", o2::framework::VariantType::String, "digits", {"digitizer, digits, raw, clusters"}},
     {"output-type", o2::framework::VariantType::String, "digits", {"digits, raw, clusters"}},
+    {"enable-digits-printer", o2::framework::VariantType::Bool, false, {"enable digits printer component"}},
     {"disable-mc", o2::framework::VariantType::Bool, false, {"disable sending of MC information"}},
   };
   std::swap(workflowOptions, options);
@@ -51,8 +52,9 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& cfgc)
 {
   //bla
-  return o2::emcal::reco_workflow::getWorkflow(not cfgc.options().get<bool>("disable-mc"),    //
-                                               cfgc.options().get<std::string>("input-type"), //
-                                               cfgc.options().get<std::string>("output-type") //
+  return o2::emcal::reco_workflow::getWorkflow(not cfgc.options().get<bool>("disable-mc"),        //
+                                               cfgc.options().get<bool>("enable-digits-printer"), //
+                                               cfgc.options().get<std::string>("input-type"),     //
+                                               cfgc.options().get<std::string>("output-type")     //
   );
 }


### PR DESCRIPTION
- Add digits converter spec converting digits to
   cells
- Convert digits printer spec (example payload task)
   to DPL task
- Add writer spec for cells
- Integrate cell converter and cell writer spec in the
   EMCAL reconstruction workflow
-  Make digits printer spec optional (for debugging)