### PR TITLE
Fix 3 attempts for all ctests override

### DIFF
--- a/cmake/O2AddTestWrapper.cmake
+++ b/cmake/O2AddTestWrapper.cmake
@@ -106,6 +106,12 @@ function(o2_add_test_wrapper)
   else()
     set(A_NON_FATAL "")
   endif()
+
+  # For now, we enforce 3 max attempts for all tests.
+  # No need to ignore time out, since we have 3 attempts
+  set(A_MAX_ATTEMPTS 3)
+  set(A_DONT_FAIL_ON_TIMEOUT "")
+
   math(EXPR ctestTimeout "(20 + ${A_TIMEOUT}) * ${A_MAX_ATTEMPTS}")
 
   add_test(NAME "${testName}"

--- a/tests/tests-wrapper.sh.in
+++ b/tests/tests-wrapper.sh.in
@@ -63,10 +63,6 @@ function banner() {
   echo "=== $TEST_NAME - $1 ===" >&2
 }
 
-banner "Forcing 3 attempts for all tests, do not ignore timeouts (since we have 3 attempts)"
-DONT_FAIL_ON_TIMEOUT=
-MAX_ATTEMPTS=3
-
 banner "Starting test. Max attempts: $MAX_ATTEMPTS.${TIMEOUT:+" Timeout per attempt: $TIMEOUT."}${DONT_FAIL_ON_TIMEOUT:+" Timeouts are not fatal."}${NON_FATAL:+" Errors are not fatal."}"
 
 for A in "${ARGS[@]}"; do


### PR DESCRIPTION
  The original patch did not compute the hard ctest timeout correctly,
  since the ctest was not aware of the override of the number of
  attempts