### PR TITLE
O2-843 Sorting out dependencies for DataFormats/Detectors/Common

### DIFF
--- a/DataFormats/Detectors/Common/CMakeLists.txt
+++ b/DataFormats/Detectors/Common/CMakeLists.txt
@@ -10,7 +10,11 @@
 
 o2_add_library(DetectorsCommonDataFormats
                SOURCES src/DetID.cxx src/AlignParam.cxx src/DetMatrixCache.cxx
-               PUBLIC_LINK_LIBRARIES ROOT::Core ROOT::Geom O2::MathUtils)
+               PUBLIC_LINK_LIBRARIES
+               ROOT::Core
+               ROOT::Geom
+               O2::GPUCommon
+               O2::MathUtils)
 
 o2_target_root_dictionary(
   DetectorsCommonDataFormats


### PR DESCRIPTION
Need to add direct dependency to `O2::GPUCommon` so that other targets using
`O2::DetectorsCommonDataFormats` can use correct dependencies