### PR TITLE
Fix: min 0.01 was imposed on TPC cluster err^2 instead of err

### DIFF
--- a/GPU/GPUTracking/Base/GPUParam.cxx
+++ b/GPU/GPUTracking/Base/GPUParam.cxx
@@ -294,8 +294,8 @@ GPUd() float MEM_LG(GPUParam)::GetClusterError2(int yz, int type, float z, float
   MakeType(const float*) c = ParamS0Par[yz][type];
   float v = c[0] + c[1] * z + c[2] * angle2 + c[3] * z * z + c[4] * angle2 * angle2 + c[5] * z * angle2;
   v = CAMath::Abs(v);
-  if (v < 0.01f) {
-    v = 0.01f;
+  if (v < 0.0001f) { // impose at least 100 micron error
+    v = 0.0001f;
   }
   v *= yz ? rec.ClusterError2CorrectionZ : rec.ClusterError2CorrectionY;
   return v;


### PR DESCRIPTION
Hi @sgorbuno @davidrohr 

The TPC cluster error param is copied from aliroot https://github.com/alisw/AliRoot/blob/2d056c378010d88bc5a76303d4bc4541479c28fc/TPC/TPCbase/AliTPCClusterParam.cxx#L937 but there min.val of 0.01 is imposed on the error itself rather than err^2 like in O2. Due to this we were mostly using 1mm errors.