### PR TITLE
Write out the common mode information

### DIFF
--- a/Detectors/TPC/simulation/CMakeLists.txt
+++ b/Detectors/TPC/simulation/CMakeLists.txt
@@ -9,7 +9,8 @@
 # submit itself to any jurisdiction.
 
 o2_add_library(TPCSimulation
-               SOURCES src/Detector.cxx
+               SOURCES src/CommonMode.cxx
+                       src/Detector.cxx
                        src/DigitMCMetaData.cxx
                        src/DigitContainer.cxx
                        src/DigitGlobalPad.cxx
@@ -26,7 +27,8 @@ o2_add_library(TPCSimulation
                                      ROOT::Physics)
 
 o2_target_root_dictionary(TPCSimulation
-                          HEADERS include/TPCSimulation/Detector.h
+                          HEADERS include/TPCSimulation/CommonMode.h
+                                  include/TPCSimulation/Detector.h
                                   include/TPCSimulation/DigitMCMetaData.h
                                   include/TPCSimulation/DigitContainer.h
                                   include/TPCSimulation/DigitGlobalPad.h

--- a/Detectors/TPC/simulation/include/TPCSimulation/CommonMode.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/CommonMode.h
@@ -1,0 +1,75 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file DigitMCMetaData.h
+/// \brief Definition of the Meta Data object of the Monte Carlo Digit
+/// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
+
+#ifndef ALICEO2_TPC_CommonMode_H_
+#define ALICEO2_TPC_CommonMode_H_
+
+#include <Rtypes.h>
+#include "DataFormatsTPC/Defs.h"
+
+namespace o2
+{
+namespace tpc
+{
+
+/// \class CommonMode
+/// This is the definition of a very simple object used to write out
+/// the common mode value in each GEM stack
+
+class CommonMode
+{
+ public:
+  /// Default constructor
+  CommonMode() = default;
+
+  /// Constructor, initializing values for common mode value in GEM stack in a given time bin
+  /// \param commonMode Common mode signal on that GEM stack
+  /// \param timeBin Time bin
+  /// \param gemStack GEm stack
+  CommonMode(float commonMode, TimeBin timeBin, unsigned char gemStack);
+
+  /// Destructor
+  ~CommonMode() = default;
+
+  /// Get the common mode value
+  /// \return Common mode signal
+  float getCommonMode() const { return mCommonMode; }
+
+  /// Get the time bin
+  /// \return Time bin
+  TimeBin getTimeBin() const { return mTimebin; }
+
+  /// Get the GEM stack
+  /// \return GEM stack
+  unsigned char getGEMstack() const { return mGEMstack; }
+
+ private:
+  float mCommonMode = 0.f;      ///< Common mode value
+  TimeBin mTimebin = -1;        ///< Time bin
+  unsigned char mGEMstack = -1; ///< GEM stack
+
+  ClassDefNV(CommonMode, 1);
+};
+
+inline CommonMode::CommonMode(float commonMode, TimeBin timeBin, unsigned char gemStack)
+  : mCommonMode(commonMode),
+    mTimebin(timeBin),
+    mGEMstack(gemStack)
+{
+}
+
+} // namespace tpc
+} // namespace o2
+
+#endif // ALICEO2_TPC_CommonMode_H_

--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitContainer.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitContainer.h
@@ -69,11 +69,12 @@ class DigitContainer
   /// Fill output vector
   /// \param output Output container
   /// \param mcTruth MC Truth container
+  /// \param commonModeOutput Output container for the common mode
   /// \param sector Sector to be processed
   /// \param eventTime time stamp of the event
   /// \param isContinuous Switch for continuous readout
   /// \param finalFlush Flag whether the whole container is dumped
-  void fillOutputContainer(std::vector<Digit>& output, dataformats::MCTruthContainer<MCCompLabel>& mcTruth, const Sector& sector, TimeBin eventTimeBin = 0, bool isContinuous = true, bool finalFlush = false);
+  void fillOutputContainer(std::vector<Digit>& output, dataformats::MCTruthContainer<MCCompLabel>& mcTruth, std::vector<CommonMode>& commonModeOutput, const Sector& sector, TimeBin eventTimeBin = 0, bool isContinuous = true, bool finalFlush = false);
 
   /// Get the size of the container for one event
   size_t size() const { return mTimeBins.size(); }

--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitGlobalPad.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitGlobalPad.h
@@ -142,11 +142,9 @@ inline void DigitGlobalPad::fillOutputContainer(std::vector<Digit>& output,
 
   /// The charge accumulated on that pad is converted into ADC counts, saturation of the SAMPA is applied and a Digit
   /// is created in written out
-  const float totalADC = mChargePad - commonMode; // common mode is subtracted here in order to properly apply noise,
-                                                  // pedestals and saturation of the SAMPA
 
   float noise, pedestal;
-  const float mADC = sampaProcessing.makeSignal<MODE>(totalADC, cru.sector(), globalPad, pedestal, noise);
+  const float mADC = sampaProcessing.makeSignal<MODE>(mChargePad, cru.sector(), globalPad, commonMode, pedestal, noise);
 
   /// only write out the data if there is actually charge on that pad
   if (mADC > 0 && mChargePad > 0) {

--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitTime.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitTime.h
@@ -18,6 +18,7 @@
 #include "TPCBase/Mapper.h"
 #include "TPCSimulation/DigitGlobalPad.h"
 #include "SimulationDataFormat/LabelContainer.h"
+#include "TPCSimulation/CommonMode.h"
 
 namespace o2
 {
@@ -46,9 +47,14 @@ class DigitTime
   void reset();
 
   /// Get common mode for a given GEM stack
-  /// \param CRU CRU of the digit
+  /// \param gemstack GEM stack of the digit
   /// \return Common mode value in that time bin for a given GEM ROC
-  float getCommonMode(const CRU& cru) const;
+  float getCommonMode(const GEMstack& gemstack) const;
+
+  /// Get common mode for a given CRU
+  /// \param CRU CRU of the digit
+  /// \return Common mode value in that time bin for a given CRU
+  float getCommonMode(const CRU& cru) const { return getCommonMode(cru.gemStack()); }
 
   /// Add digit to the row container
   /// \param eventID MC Event ID
@@ -61,12 +67,13 @@ class DigitTime
   /// Fill output vector
   /// \param output Output container
   /// \param mcTruth MC Truth container
+  /// \param commonModeOutput Output container for common mode
   /// \param cru CRU ID
   /// \param timeBin Time bin
   /// \param commonMode Common mode value of that specific ROC
   template <DigitzationMode MODE>
   void fillOutputContainer(std::vector<Digit>& output, dataformats::MCTruthContainer<MCCompLabel>& mcTruth,
-                           const Sector& sector, TimeBin timeBin, float commonMode = 0.f);
+                           std::vector<CommonMode>& commonModeOutput, const Sector& sector, TimeBin timeBin, float commonMode = 0.f);
 
  private:
   std::array<float, GEMSTACKSPERSECTOR> mCommonMode;                 ///< Common mode container - 4 GEM ROCs per sector
@@ -79,7 +86,7 @@ class DigitTime
 
 inline DigitTime::DigitTime() : mCommonMode(), mGlobalPads()
 {
-  mCommonMode.fill(0);
+  mCommonMode.fill(0.f);
   mLabels.reserve(Mapper::getPadsInSector() / 3);
 }
 
@@ -100,28 +107,34 @@ inline void DigitTime::reset()
   for (auto& pad : mGlobalPads) {
     pad.reset();
   }
-  mCommonMode.fill(0);
+  mCommonMode.fill(0.f);
 }
 
-inline float DigitTime::getCommonMode(const CRU& cru) const
+inline float DigitTime::getCommonMode(const GEMstack& gemstack) const
 {
+  /// simple case when there is no external capacitance on the ROC
   static const Mapper& mapper = Mapper::instance();
-  const auto gemStack = static_cast<int>(cru.gemStack());
-  const auto nPads = mapper.getNumberOfPads(gemStack);
-  return mCommonMode[gemStack] /
-         static_cast<float>(nPads); /// simple case when there is no external capacitance on the ROC;
+  const auto nPads = mapper.getNumberOfPads(gemstack);
+  return mCommonMode[gemstack] / static_cast<float>(nPads);
 }
 
 template <DigitzationMode MODE>
 inline void DigitTime::fillOutputContainer(std::vector<Digit>& output, dataformats::MCTruthContainer<MCCompLabel>& mcTruth,
-                                           const Sector& sector, TimeBin timeBin,
+                                           std::vector<CommonMode>& commonModeOutput, const Sector& sector, TimeBin timeBin,
                                            float commonMode)
 {
   static Mapper& mapper = Mapper::instance();
   GlobalPadNumber globalPad = 0;
+  float cm;
+  for (size_t i = 0; i < mCommonMode.size(); ++i) {
+    cm = getCommonMode(GEMstack(i));
+    if (cm > 0.) {
+      commonModeOutput.push_back({cm, timeBin, static_cast<unsigned char>(i)});
+    }
+  }
   for (auto& pad : mGlobalPads) {
     if (pad.getChargePad() > 0.) {
-      const int cru = mapper.getCRU(sector, globalPad);
+      const CRU cru = mapper.getCRU(sector, globalPad);
       pad.fillOutputContainer<MODE>(output, mcTruth, cru, timeBin, globalPad, mLabels, getCommonMode(cru));
     }
     ++globalPad;

--- a/Detectors/TPC/simulation/include/TPCSimulation/Digitizer.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/Digitizer.h
@@ -74,9 +74,11 @@ class Digitizer
   /// Flush the data
   /// \param digits Container for the digits
   /// \param labels Container for the MC labels
+  /// \param commonModeOutput Output container for the common mode
   /// \param finalFlush Flag whether the whole container is dumped
   void flush(std::vector<o2::tpc::Digit>& digits,
-             o2::dataformats::MCTruthContainer<o2::MCCompLabel>& labels, bool finalFlush = false);
+             o2::dataformats::MCTruthContainer<o2::MCCompLabel>& labels,
+             std::vector<o2::tpc::CommonMode>& commonModeOutput, bool finalFlush = false);
 
   /// Set the sector to be processed
   /// \param sec Sector to be processed

--- a/Detectors/TPC/simulation/include/TPCSimulation/SAMPAProcessing.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/SAMPAProcessing.h
@@ -65,9 +65,10 @@ class SAMPAProcessing
   /// \param ADCcounts ADC value of the signal (common mode already subtracted)
   /// \param sector Sector number
   /// \param globalPadInSector global pad number in the sector
+  /// \param commonMode value of the common mode
   /// \return ADC value after application of noise, pedestal and saturation
   template <DigitzationMode MODE>
-  float makeSignal(float ADCcounts, const int sector, const int globalPadInSector, float& pedestal, float& noise);
+  float makeSignal(float ADCcounts, const int sector, const int globalPadInSector, const float commonMode, float& pedestal, float& noise);
 
   /// A delta signal is shaped by the FECs and thus spread over several time bins
   /// This function returns an array with the signal spread into the following time bins
@@ -142,7 +143,7 @@ inline T SAMPAProcessing::getADCvalue(T nElectrons) const
 }
 
 template <DigitzationMode MODE>
-inline float SAMPAProcessing::makeSignal(float ADCcounts, const int sector, const int globalPadInSector,
+inline float SAMPAProcessing::makeSignal(float ADCcounts, const int sector, const int globalPadInSector, const float commonMode,
                                          float& pedestal, float& noise)
 {
   float signal = ADCcounts;
@@ -150,12 +151,14 @@ inline float SAMPAProcessing::makeSignal(float ADCcounts, const int sector, cons
   noise = getNoise(sector, globalPadInSector);
   switch (MODE) {
     case DigitzationMode::FullMode: {
+      signal -= commonMode;
       signal += noise;
       signal += pedestal;
       return getADCSaturation(signal);
       break;
     }
     case DigitzationMode::SubtractPedestal: {
+      signal -= commonMode;
       signal += noise;
       signal += pedestal;
       float signalSubtractPedestal = getADCSaturation(signal) - pedestal;
@@ -163,6 +166,7 @@ inline float SAMPAProcessing::makeSignal(float ADCcounts, const int sector, cons
       break;
     }
     case DigitzationMode::NoSaturation: {
+      signal -= commonMode;
       signal += noise;
       signal += pedestal;
       return signal;

--- a/Detectors/TPC/simulation/src/CommonMode.cxx
+++ b/Detectors/TPC/simulation/src/CommonMode.cxx
@@ -1,0 +1,17 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file CommonMode.cxx
+/// \brief Implementation of the common mode output object
+/// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
+
+#include "TPCSimulation/CommonMode.h"
+
+ClassImp(o2::tpc::CommonMode);

--- a/Detectors/TPC/simulation/src/DigitContainer.cxx
+++ b/Detectors/TPC/simulation/src/DigitContainer.cxx
@@ -21,7 +21,7 @@
 using namespace o2::tpc;
 
 void DigitContainer::fillOutputContainer(std::vector<Digit>& output,
-                                         dataformats::MCTruthContainer<MCCompLabel>& mcTruth, const Sector& sector, TimeBin eventTimeBin, bool isContinuous, bool finalFlush)
+                                         dataformats::MCTruthContainer<MCCompLabel>& mcTruth, std::vector<CommonMode>& commonModeOutput, const Sector& sector, TimeBin eventTimeBin, bool isContinuous, bool finalFlush)
 {
   auto& eleParam = ParameterElectronics::Instance();
   const auto digitizationMode = eleParam.DigiMode;
@@ -38,19 +38,19 @@ void DigitContainer::fillOutputContainer(std::vector<Digit>& output,
 
       switch (digitizationMode) {
         case DigitzationMode::FullMode: {
-          time.fillOutputContainer<DigitzationMode::FullMode>(output, mcTruth, sector, timeBin);
+          time.fillOutputContainer<DigitzationMode::FullMode>(output, mcTruth, commonModeOutput, sector, timeBin);
           break;
         }
         case DigitzationMode::SubtractPedestal: {
-          time.fillOutputContainer<DigitzationMode::SubtractPedestal>(output, mcTruth, sector, timeBin);
+          time.fillOutputContainer<DigitzationMode::SubtractPedestal>(output, mcTruth, commonModeOutput, sector, timeBin);
           break;
         }
         case DigitzationMode::NoSaturation: {
-          time.fillOutputContainer<DigitzationMode::NoSaturation>(output, mcTruth, sector, timeBin);
+          time.fillOutputContainer<DigitzationMode::NoSaturation>(output, mcTruth, commonModeOutput, sector, timeBin);
           break;
         }
         case DigitzationMode::PropagateADC: {
-          time.fillOutputContainer<DigitzationMode::PropagateADC>(output, mcTruth, sector, timeBin);
+          time.fillOutputContainer<DigitzationMode::PropagateADC>(output, mcTruth, commonModeOutput, sector, timeBin);
           break;
         }
       }

--- a/Detectors/TPC/simulation/src/Digitizer.cxx
+++ b/Detectors/TPC/simulation/src/Digitizer.cxx
@@ -156,10 +156,12 @@ void Digitizer::process(const std::vector<o2::tpc::HitGroup>& hits,
 }
 
 void Digitizer::flush(std::vector<o2::tpc::Digit>& digits,
-                      o2::dataformats::MCTruthContainer<o2::MCCompLabel>& labels, bool finalFlush)
+                      o2::dataformats::MCTruthContainer<o2::MCCompLabel>& labels,
+                      std::vector<o2::tpc::CommonMode>& commonModeOutput,
+                      bool finalFlush)
 {
   static SAMPAProcessing& sampaProcessing = SAMPAProcessing::instance();
-  mDigitContainer.fillOutputContainer(digits, labels, mSector, sampaProcessing.getTimeBinFromTime(mEventTime), mIsContinuous, finalFlush);
+  mDigitContainer.fillOutputContainer(digits, labels, commonModeOutput, mSector, sampaProcessing.getTimeBinFromTime(mEventTime), mIsContinuous, finalFlush);
 }
 
 void Digitizer::enableSCDistortions(SpaceCharge::SCDistortionType distortionType, TH3* hisInitialSCDensity, int nZSlices, int nPhiBins, int nRBins)

--- a/Detectors/TPC/simulation/src/TPCSimulationLinkDef.h
+++ b/Detectors/TPC/simulation/src/TPCSimulationLinkDef.h
@@ -18,6 +18,8 @@
 #pragma link C++ class o2::base::DetImpl < o2::tpc::Detector> + ;
 #pragma link C++ class o2::tpc::DigitMCMetaData + ;
 #pragma link C++ class std::vector < o2::tpc::DigitMCMetaData> + ;
+#pragma link C++ class o2::tpc::CommonMode + ;
+#pragma link C++ class std::vector < o2::tpc::CommonMode> + ;
 #pragma link C++ class o2::tpc::DigitContainer + ;
 #pragma link C++ class o2::tpc::DigitGlobalPad + ;
 #pragma link C++ class o2::tpc::Digitizer + ;


### PR DESCRIPTION
- introduces a simple class containing the relevant information
- adds another output branch for the information of each sector to the tpcdigits.root
- information is only written when the common mode value is > 0
- following a request by @wiechula 