### PR TITLE
DPL: introduce EndOfStream callback

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -44,6 +44,8 @@ o2_add_library(Framework
                        src/DataDescriptorQueryBuilder.cxx
                        src/DataProcessingDevice.cxx
                        src/DataProcessingHeader.cxx
+                       src/DataProcessingHelpers.cxx
+                       src/SourceInfoHeader.cxx
                        src/DataProcessor.cxx
                        src/DataRelayer.cxx
                        src/DataSampling.cxx

--- a/Framework/Core/README.md
+++ b/Framework/Core/README.md
@@ -370,8 +370,9 @@ A service that data processors can register callback functions invoked by the fr
 
 Moreover in case you want to process events which are not coming from `FairMQ`, there is a `CallbackService::Id::ClockTick` which is called according to the rate specified for the backing FairMQ device.
 
-Similarly the `CallbackService::Id::Idle` callback is fired whenever there
-was nothing to process.
+Similarly the `CallbackService::Id::Idle` callback is fired whenever there was nothing to process.
+
+One last callback is `CallbackService::Id::EndOfStream`. This callback will be invoked whenever all the upstream DataProcessingDevice consider that they will not produce any more data, so we can finalize our results and exit.
 
 ## Expressing parallelism
 

--- a/Framework/Core/include/Framework/CallbackService.h
+++ b/Framework/Core/include/Framework/CallbackService.h
@@ -18,6 +18,8 @@ namespace o2
 namespace framework
 {
 
+class EndOfStreamContext;
+
 // A service that data processors can register callback functions invoked by the
 // framework at defined steps in the process flow
 class CallbackService
@@ -25,11 +27,15 @@ class CallbackService
  public:
   /// the defined processing steps at which a callback can be invoked
   enum class Id {
-    Start,    /**< Invoked before the inner loop is started */
-    Stop,     /**< Invoked when the device is about to be stoped */
-    Reset,    /**< Invoked on device rest */
-    Idle,     /**< Invoked when there was no computation scheduled */
-    ClockTick /**< Invoked every iteration of the inner loop */
+    Start,     /**< Invoked before the inner loop is started */
+    Stop,      /**< Invoked when the device is about to be stoped */
+    Reset,     /**< Invoked on device rest */
+    Idle,      /**< Invoked when there was no computation scheduled */
+    ClockTick, /**< Invoked every iteration of the inner loop */
+    /// Invoked when we are notified that no further data will arrive.
+    /// Notice that one could have more "EndOfData" notifications. Because
+    /// we could be signaled by control that the data flow restarted.
+    EndOfStream
   };
 
   template <typename T, T... v>
@@ -44,14 +50,16 @@ class CallbackService
   using ResetCallback = std::function<void()>;
   using IdleCallback = std::function<void()>;
   using ClockTickCallback = std::function<void()>;
+  using EndOfStreamCallback = std::function<void(EndOfStreamContext&)>;
 
-  using Callbacks = CallbackRegistry<Id,                                                //
-                                     RegistryPair<Id, Id::Start, StartCallback>,        //
-                                     RegistryPair<Id, Id::Stop, StopCallback>,          //
-                                     RegistryPair<Id, Id::Reset, ResetCallback>,        //
-                                     RegistryPair<Id, Id::Idle, IdleCallback>,          //
-                                     RegistryPair<Id, Id::ClockTick, ClockTickCallback> //
-                                     >;                                                 //
+  using Callbacks = CallbackRegistry<Id,                                                    //
+                                     RegistryPair<Id, Id::Start, StartCallback>,            //
+                                     RegistryPair<Id, Id::Stop, StopCallback>,              //
+                                     RegistryPair<Id, Id::Reset, ResetCallback>,            //
+                                     RegistryPair<Id, Id::Idle, IdleCallback>,              //
+                                     RegistryPair<Id, Id::ClockTick, ClockTickCallback>,    //
+                                     RegistryPair<Id, Id::EndOfStream, EndOfStreamCallback> //
+                                     >;                                                     //
 
   // set callback for specified processing step
   template <typename U>

--- a/Framework/Core/include/Framework/ChannelInfo.h
+++ b/Framework/Core/include/Framework/ChannelInfo.h
@@ -1,0 +1,38 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef O2_FRAMEWORK_CHANNELINFO_H
+#define O2_FRAMEWORK_CHANNELINFO_H
+
+#include <string>
+
+namespace o2::framework
+{
+
+enum struct InputChannelState {
+  /// The channel is actively receiving data
+  Running,
+  /// The channel was paused
+  Paused,
+  /// The channel was signaled it will not receive any data
+  Completed,
+  /// The channel can be used to retrieve data, but it
+  /// will not send it on its own.
+  Pull
+};
+
+/// This represent the current state of an input channel.  Its values can be
+/// updated by Control or by the by the incoming flow of messages.
+struct InputChannelInfo {
+  InputChannelState state = InputChannelState::Running;
+};
+
+} // namespace o2::framework
+
+#endif // O2_FRAMEWORK_CHANNELSPEC_H

--- a/Framework/Core/include/Framework/ChannelSpec.h
+++ b/Framework/Core/include/Framework/ChannelSpec.h
@@ -34,6 +34,8 @@ enum struct ChannelType {
 
 /// This describes an input channel. Since they are point to
 /// point connections, there is not much to say about them.
+/// Notice that this should be considered read only once it
+/// has been created.
 struct InputChannelSpec {
   std::string name;
   enum ChannelType type;

--- a/Framework/Core/include/Framework/ControlService.h
+++ b/Framework/Core/include/Framework/ControlService.h
@@ -31,6 +31,8 @@ class ControlService
   /// Signal control that we are potentially ready to quit some / all
   /// dataprocessor.
   virtual void readyToQuit(QuitRequest kind) = 0;
+  /// Signal that we are done with the current stream
+  virtual void endOfStream() = 0;
 };
 
 } // namespace o2::framework

--- a/Framework/Core/include/Framework/DataProcessingDevice.h
+++ b/Framework/Core/include/Framework/DataProcessingDevice.h
@@ -33,15 +33,18 @@
 
 #include <memory>
 
-namespace o2
-{
-namespace framework
+namespace o2::framework
 {
 
+struct InputChannelInfo;
+struct DeviceState;
+
+/// A device actually carrying out all the DPL
+/// Data Processing needs.
 class DataProcessingDevice : public FairMQDevice
 {
  public:
-  DataProcessingDevice(const DeviceSpec& spec, ServiceRegistry&);
+  DataProcessingDevice(DeviceSpec const& spec, ServiceRegistry&, DeviceState& state);
   void Init() final;
   void PreRun() final;
   void PostRun() final;
@@ -49,12 +52,15 @@ class DataProcessingDevice : public FairMQDevice
   bool ConditionalRun() final;
 
  protected:
-  bool handleData(FairMQParts&);
+  bool handleData(FairMQParts&, InputChannelInfo&);
   bool tryDispatchComputation();
   void error(const char* msg);
 
  private:
+  /// The specification used to create the initial state of this device
   DeviceSpec const& mSpec;
+  /// The current internal state of this device.
+  DeviceState& mState;
   AlgorithmSpec::InitCallback mInit;
   AlgorithmSpec::ProcessCallback mStatefulProcess;
   AlgorithmSpec::ProcessCallback mStatelessProcess;
@@ -80,6 +86,5 @@ class DataProcessingDevice : public FairMQDevice
   DataProcessingStats mStats;                /// Stats about the actual data processing.
 };
 
-} // namespace framework
-} // namespace o2
+} // namespace o2::framework
 #endif

--- a/Framework/Core/include/Framework/DeviceSpec.h
+++ b/Framework/Core/include/Framework/DeviceSpec.h
@@ -13,6 +13,7 @@
 #include "Framework/WorkflowSpec.h"
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/ChannelSpec.h"
+#include "Framework/ChannelInfo.h"
 #include "Framework/DeviceControl.h"
 #include "Framework/AlgorithmSpec.h"
 #include "Framework/ConfigParamSpec.h"

--- a/Framework/Core/include/Framework/DeviceState.h
+++ b/Framework/Core/include/Framework/DeviceState.h
@@ -1,0 +1,38 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef O2_FRAMEWORK_DEVICESTATE_H_
+#define O2_FRAMEWORK_DEVICESTATE_H_
+
+#include "Framework/ChannelInfo.h"
+#include <vector>
+#include <string>
+#include <map>
+#include <utility>
+
+namespace o2::framework
+{
+
+/// Running state information of a given device
+struct DeviceState {
+  enum struct StreamingState {
+    /// Data is being processed
+    Streaming,
+    /// End of streaming requested, but not notified
+    EndOfStreaming,
+    /// End of streaming notified
+    Idle,
+  };
+  std::vector<InputChannelInfo> inputChannelInfos;
+  StreamingState streaming = StreamingState::Streaming;
+  bool quitRequested = false;
+};
+
+} // namespace o2::framework
+#endif

--- a/Framework/Core/include/Framework/EndOfStreamContext.h
+++ b/Framework/Core/include/Framework/EndOfStreamContext.h
@@ -1,0 +1,38 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef O2_FRAMEWORK_ENDOFSTREAMCONTEXT_H_
+#define O2_FRAMEWORK_ENDOFSTREAMCONTEXT_H_
+
+#include "Framework/InputRecord.h"
+#include "Framework/ServiceRegistry.h"
+#include "Framework/DataAllocator.h"
+
+namespace o2::framework
+{
+
+class EndOfStreamContext
+{
+ public:
+  EndOfStreamContext(ServiceRegistry& services, DataAllocator& allocator)
+    : mServices(services),
+      mAllocator(allocator)
+  {
+  }
+
+  ServiceRegistry& services() { return mServices; }
+  DataAllocator& outputs() { return mAllocator; }
+
+  ServiceRegistry& mServices;
+  DataAllocator& mAllocator;
+};
+
+} // namespace o2::framework
+
+#endif // O2_FRAMEWORK_ENDOFSTREAMCONTEXT_H_

--- a/Framework/Core/include/Framework/SourceInfoHeader.h
+++ b/Framework/Core/include/Framework/SourceInfoHeader.h
@@ -1,0 +1,61 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef FRAMEWORK_SOURCEINFOHEADER_H
+#define FRAMEWORK_SOURCEINFOHEADER_H
+
+#include "Headers/DataHeader.h"
+#include "Framework/ChannelInfo.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <memory>
+#include <cassert>
+
+namespace o2
+{
+namespace framework
+{
+
+//__________________________________________________________________________________________________
+/// @defgroup o2_dataflow_header The SourceInfo Header
+/// @brief A descriptive information for data blocks handled by O2 Data Processing layer
+///
+/// @ingroup aliceo2_dataformat_primitives
+
+//__________________________________________________________________________________________________
+/// @struct SourceInfoHeader
+/// @brief a BaseHeader with state information from the source
+///
+/// This header can be associated to a given O2 message to notify the receiving side
+/// what is the state of the preceding dataprocessor in the dag associated to a given
+/// channel.
+///
+/// @ingroup aliceo2_dataformats_dataheader
+struct SourceInfoHeader : public header::BaseHeader {
+  constexpr static const o2::header::HeaderType sHeaderType = "SrcInfo";
+  static const uint32_t sVersion = 1;
+
+  SourceInfoHeader()
+    : BaseHeader(sizeof(SourceInfoHeader), sHeaderType, header::gSerializationMethodNone, sVersion),
+      state{InputChannelState::Running} {}
+
+  InputChannelState state;
+
+  SourceInfoHeader(const SourceInfoHeader&) = default;
+  static const SourceInfoHeader* Get(const BaseHeader* baseHeader)
+  {
+    return (baseHeader->description == SourceInfoHeader::sHeaderType) ? static_cast<const SourceInfoHeader*>(baseHeader) : nullptr;
+  }
+};
+
+} // namespace framework
+} // namespace o2
+
+#endif // FRAMEWORK_SOURCEINFOHEADER_H

--- a/Framework/Core/include/Framework/TextControlService.h
+++ b/Framework/Core/include/Framework/TextControlService.h
@@ -17,11 +17,15 @@
 namespace o2::framework
 {
 
+class ServiceRegistry;
+class DeviceState;
+
 /// A service that data processors can use to talk to control and ask for
 /// their own state change or others.
 class TextControlService : public ControlService
 {
  public:
+  TextControlService(ServiceRegistry& registry, DeviceState& deviceState);
   /// Tell the control that I am ready to quit. This will be
   /// done by printing (only once)
   ///
@@ -37,8 +41,12 @@ class TextControlService : public ControlService
   /// child.
   void readyToQuit(QuitRequest all = QuitRequest::Me) final;
 
+  void endOfStream() final;
+
  private:
   bool mOnce = false;
+  ServiceRegistry& mRegistry;
+  DeviceState& mDeviceState;
 };
 
 bool parseControl(std::string const& s, std::smatch& match);

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -7,18 +7,23 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#include "DataProcessingStatus.h"
 #include "Framework/DataProcessingDevice.h"
 #include "Framework/ChannelMatching.h"
 #include "Framework/DataProcessingHeader.h"
 #include "Framework/DataProcessor.h"
 #include "Framework/DataSpecUtils.h"
+#include "Framework/DeviceState.h"
+#include "Framework/EndOfStreamContext.h"
 #include "Framework/FairOptionsRetriever.h"
 #include "Framework/FairMQDeviceProxy.h"
 #include "Framework/CallbackService.h"
 #include "Framework/TMessageSerializer.h"
 #include "Framework/InputRecord.h"
 #include "Framework/Signpost.h"
+#include "Framework/SourceInfoHeader.h"
+#include "Framework/Logger.h"
+#include "DataProcessingStatus.h"
+#include "DataProcessingHelpers.h"
 
 #include "ScopedExit.h"
 
@@ -47,8 +52,9 @@ namespace o2
 namespace framework
 {
 
-DataProcessingDevice::DataProcessingDevice(DeviceSpec const& spec, ServiceRegistry& registry)
+DataProcessingDevice::DataProcessingDevice(DeviceSpec const& spec, ServiceRegistry& registry, DeviceState& state)
   : mSpec{spec},
+    mState{state},
     mInit{spec.algorithm.onInit},
     mStatefulProcess{nullptr},
     mStatelessProcess{spec.algorithm.onProcess},
@@ -116,6 +122,18 @@ void DataProcessingDevice::Init()
   if (mInit) {
     InitContext initContext{*mConfigRegistry, mServiceRegistry};
     mStatefulProcess = mInit(initContext);
+  }
+  mState.inputChannelInfos.resize(mSpec.inputChannels.size());
+  /// Internal channels which will never create an actual message
+  /// should be considered as in "Pull" mode, since we do not
+  /// expect them to create any data.
+  for (size_t ci = 0; ci < mSpec.inputChannels.size(); ++ci) {
+    auto& name = mSpec.inputChannels[ci].name;
+    if (name.find("from_internal-dpl-clock") == 0) {
+      mState.inputChannelInfos[ci].state = InputChannelState::Pull;
+    } else if (name.find("from_internal-dpl-ccdb-backend") == 0) {
+      mState.inputChannelInfos[ci].state = InputChannelState::Pull;
+    }
   }
 }
 
@@ -197,12 +215,27 @@ bool DataProcessingDevice::ConditionalRun()
   mBeginIterationTimestamp = (uint64_t)std::chrono::duration<double, std::milli>(now.time_since_epoch()).count();
 
   mServiceRegistry.get<CallbackService>()(CallbackService::Id::ClockTick);
+  // Wether or not we had something to do.
   bool active = false;
-  for (auto& channel : mSpec.inputChannels) {
+  // Notice that in case there are no input channels we should the allDone
+  // state will have to be set explicitly in the code, like we do, for example
+  // for implicit data sources or timers.  This also implies that whatever is
+  // time driven will have to signal EndOfStream itself.
+  bool allDone = mSpec.inputChannels.empty() == false;
+  // Whether or not all the channels are completed
+  for (size_t ci = 0; ci < mSpec.inputChannels.size(); ++ci) {
+    auto& channel = mSpec.inputChannels[ci];
+    auto& info = mState.inputChannelInfos[ci];
+    if (info.state != InputChannelState::Completed) {
+      allDone = false;
+    }
+    if (info.state != InputChannelState::Running) {
+      continue;
+    }
     FairMQParts parts;
     auto result = this->Receive(parts, channel.name, 0, 0);
     if (result > 0) {
-      this->handleData(parts);
+      this->handleData(parts, info);
       active |= this->tryDispatchComputation();
     }
   }
@@ -214,6 +247,42 @@ bool DataProcessingDevice::ConditionalRun()
 
   sendRelayerMetrics();
   flushMetrics();
+
+  // If we got notified that all the sources are done, we call the EndOfStream
+  // callback and return false. Notice that what happens next is actually
+  // dependent on the callback, not something which is controlled by the
+  // framework itself.
+  if (allDone == true && mState.streaming == DeviceState::StreamingState::Streaming) {
+    mState.streaming = DeviceState::StreamingState::EndOfStreaming;
+  }
+
+  if (mState.streaming == DeviceState::StreamingState::EndOfStreaming) {
+    // We keep processing data until we are Idle.
+    // FIXME: not sure this is the correct way to drain the queues, but
+    // I guess we will see.
+    while (this->tryDispatchComputation()) {
+      mRelayer.processDanglingInputs(mExpirationHandlers, mServiceRegistry);
+    }
+    sendRelayerMetrics();
+    flushMetrics();
+    mContextRegistry.get<MessageContext>()->clear();
+    mContextRegistry.get<RootObjectContext>()->clear();
+    mContextRegistry.get<StringContext>()->clear();
+    mContextRegistry.get<ArrowContext>()->clear();
+    mContextRegistry.get<RawBufferContext>()->clear();
+    EndOfStreamContext eosContext{mServiceRegistry, mAllocator};
+    mServiceRegistry.get<CallbackService>()(CallbackService::Id::EndOfStream, eosContext);
+    DataProcessor::doSend(*this, *mContextRegistry.get<MessageContext>());
+    DataProcessor::doSend(*this, *mContextRegistry.get<RootObjectContext>());
+    DataProcessor::doSend(*this, *mContextRegistry.get<StringContext>());
+    DataProcessor::doSend(*this, *mContextRegistry.get<ArrowContext>());
+    DataProcessor::doSend(*this, *mContextRegistry.get<RawBufferContext>());
+    for (auto& channel : mSpec.outputChannels) {
+      DataProcessingHelpers::sendEndOfStream(*this, channel);
+    }
+    mState.streaming = DeviceState::StreamingState::Idle;
+    return true;
+  }
   return true;
 }
 
@@ -221,7 +290,7 @@ bool DataProcessingDevice::ConditionalRun()
 /// is divided in two parts. In the first one we define a set of lambdas
 /// which describe what is actually going to happen, hiding all the state
 /// boilerplate which the user does not need to care about at top level.
-bool DataProcessingDevice::handleData(FairMQParts& parts)
+bool DataProcessingDevice::handleData(FairMQParts& parts, InputChannelInfo& info)
 {
   assert(mSpec.inputChannels.empty() == false);
   assert(parts.Size() > 0);
@@ -239,57 +308,79 @@ bool DataProcessingDevice::handleData(FairMQParts& parts)
     StateMonitoring<DataProcessingStatus>::moveTo(DataProcessingStatus::IN_DPL_OVERHEAD);
   });
 
-  auto& device = *this;
-  auto& errorCount = mErrorCount;
-  auto& relayer = mRelayer;
-  auto& serviceRegistry = mServiceRegistry;
+  enum struct InputType {
+    Invalid,
+    Data,
+    SourceInfo
+  };
 
   // This is how we validate inputs. I.e. we try to enforce the O2 Data model
   // and we do a few stats. We bind parts as a lambda captured variable, rather
   // than an input, because we do not want the outer loop actually be exposed
   // to the implementation details of the messaging layer.
-  auto isValidInput = [& stats = mStats, &parts]() -> bool {
+  auto getInputTypes = [& stats = mStats, &parts, &info]() -> std::optional<std::vector<InputType>> {
     stats.inputParts = parts.Size();
 
     if (parts.Size() % 2) {
-      return false;
+      return std::nullopt;
     }
+    std::vector<InputType> results(parts.Size() / 2, InputType::Invalid);
+
     for (size_t hi = 0; hi < parts.Size() / 2; ++hi) {
       auto pi = hi * 2;
+      auto sih = o2::header::get<SourceInfoHeader*>(parts.At(pi)->GetData());
+      if (sih) {
+        info.state = sih->state;
+        results[hi] = InputType::SourceInfo;
+        continue;
+      }
       auto dh = o2::header::get<DataHeader*>(parts.At(pi)->GetData());
       if (!dh) {
-        LOG(ERROR) << "Header is not a DataHeader?";
-        return false;
+        results[hi] = InputType::Invalid;
+        LOGP(error, "Header is not a DataHeader?");
+        continue;
       }
       if (dh->payloadSize != parts.At(pi + 1)->GetSize()) {
-        LOG(ERROR) << "DataHeader payloadSize mismatch";
-        return false;
+        results[hi] = InputType::Invalid;
+        LOGP(error, "DataHeader payloadSize mismatch");
+        continue;
       }
       auto dph = o2::header::get<DataProcessingHeader*>(parts.At(pi)->GetData());
       if (!dph) {
-        LOG(ERROR) << "Header stack does not contain DataProcessingHeader";
-        return false;
+        results[hi] = InputType::Invalid;
+        LOGP(error, "Header stack does not contain DataProcessingHeader");
+        continue;
       }
+      results[hi] = InputType::Data;
     }
-    return true;
+    return results;
   };
 
-  auto reportError = [&device](const char* message) {
+  auto reportError = [& device = *this](const char* message) {
     device.error(message);
   };
 
-  auto putIncomingMessageIntoCache = [&parts, &relayer, &reportError]() {
+  auto handleValidMessages = [&parts, &relayer = mRelayer, &reportError](std::vector<InputType> const& types) {
     // We relay execution to make sure we have a complete set of parts
     // available.
     for (size_t pi = 0; pi < (parts.Size() / 2); ++pi) {
-      auto headerIndex = 2 * pi;
-      auto payloadIndex = 2 * pi + 1;
-      assert(payloadIndex < parts.Size());
-      auto relayed = relayer.relay(std::move(parts.At(headerIndex)),
-                                   std::move(parts.At(payloadIndex)));
-      if (relayed == DataRelayer::WillNotRelay) {
-        reportError("Unable to relay part.");
-        return;
+      switch (types[pi]) {
+        case InputType::Data: {
+          auto headerIndex = 2 * pi;
+          auto payloadIndex = 2 * pi + 1;
+          assert(payloadIndex < parts.Size());
+          auto relayed = relayer.relay(std::move(parts.At(headerIndex)),
+                                       std::move(parts.At(payloadIndex)));
+          if (relayed == DataRelayer::WillNotRelay) {
+            reportError("Unable to relay part.");
+          }
+        } break;
+        case InputType::SourceInfo: {
+
+        } break;
+        case InputType::Invalid: {
+          reportError("Invalid part found.");
+        } break;
       }
     }
   };
@@ -302,11 +393,12 @@ bool DataProcessingDevice::handleData(FairMQParts& parts)
   // messages). Notice also that we need to act diffently depending on the
   // actual CompletionOp we want to perform. In particular forwarding inputs
   // also gets rid of them from the cache.
-  if (isValidInput() == false) {
+  auto inputTypes = getInputTypes();
+  if (bool(inputTypes) == false) {
     reportError("Parts should come in couples. Dropping it.");
     return true;
   }
-  putIncomingMessageIntoCache();
+  handleValidMessages(*inputTypes);
   return true;
 }
 
@@ -473,6 +565,11 @@ bool DataProcessingDevice::tryDispatchComputation()
       if (input.header == nullptr || input.payload == nullptr) {
         continue;
       }
+      auto sih = o2::header::get<SourceInfoHeader*>(input.header);
+      if (sih) {
+        continue;
+      }
+
       auto dh = o2::header::get<DataHeader*>(input.header);
       if (!dh) {
         reportError("Header is not a DataHeader?");
@@ -569,7 +666,9 @@ bool DataProcessingDevice::tryDispatchComputation()
       mStats.relayerState[cacheId] = state;
     }
     try {
-      dispatchProcessing(action.slot, record);
+      if (mState.quitRequested == false) {
+        dispatchProcessing(action.slot, record);
+      }
     } catch (std::exception& e) {
       errorHandling(e, record);
     }
@@ -592,6 +691,13 @@ bool DataProcessingDevice::tryDispatchComputation()
     } else if (action.op == CompletionPolicy::CompletionOp::Process) {
       cleanTimers(action.slot, record);
     }
+  }
+  // We now broadcast the end of stream if it was requested
+  if (mState.streaming == DeviceState::StreamingState::EndOfStreaming) {
+    for (auto& channel : mSpec.outputChannels) {
+      DataProcessingHelpers::sendEndOfStream(*this, channel);
+    }
+    mState.streaming = DeviceState::StreamingState::Idle;
   }
 
   return true;

--- a/Framework/Core/src/DataProcessingHelpers.cxx
+++ b/Framework/Core/src/DataProcessingHelpers.cxx
@@ -1,0 +1,36 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "DataProcessingHelpers.h"
+#include "Framework/SourceInfoHeader.h"
+#include "Framework/ChannelSpec.h"
+#include "Framework/ChannelInfo.h"
+#include "MemoryResources/MemoryResources.h"
+#include "Headers/DataHeader.h"
+#include "Headers/Stack.h"
+
+#include <FairMQDevice.h>
+
+namespace o2::framework
+{
+void DataProcessingHelpers::sendEndOfStream(FairMQDevice& device, OutputChannelSpec const& channel)
+{
+  FairMQParts parts;
+  FairMQMessagePtr payload(device.NewMessage());
+  SourceInfoHeader sih;
+  sih.state = InputChannelState::Completed;
+  auto channelAlloc = o2::pmr::getTransportAllocator(device.GetChannel(channel.name, 0).Transport());
+  auto header = o2::pmr::getMessage(o2::header::Stack{channelAlloc, sih});
+  // sigh... See if we can avoid having it const by not
+  // exposing it to the user in the first place.
+  parts.AddPart(std::move(header));
+  parts.AddPart(std::move(payload));
+  device.Send(parts, channel.name, 0);
+}
+} // namespace o2::framework

--- a/Framework/Core/src/DataProcessingHelpers.h
+++ b/Framework/Core/src/DataProcessingHelpers.h
@@ -1,0 +1,30 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef O2_FRAMEWORK_DATAPROCESSINGHELPERS_H_
+#define O2_FRAMEWORK_DATAPROCESSINGHELPERS_H_
+
+class FairMQDevice;
+
+namespace o2::framework
+{
+
+struct OutputChannelSpec;
+
+/// Generic helpers for DataProcessing releated functions.
+struct DataProcessingHelpers {
+  /// Send EndOfStream message to a given channel
+  /// @param device the FairMQDevice which needs to send the EndOfStream message
+  /// @param channel the OutputChannelSpec of the channel which needs to be signaled
+  ///        for EndOfStream
+  static void sendEndOfStream(FairMQDevice& device, OutputChannelSpec const& channel);
+};
+
+} // namespace o2::framework
+#endif // O2_FRAMEWORK_DATAPROCESSINGHELPERS_H_

--- a/Framework/Core/src/FrameworkGUIDeviceInspector.cxx
+++ b/Framework/Core/src/FrameworkGUIDeviceInspector.cxx
@@ -54,6 +54,11 @@ void deviceInfoTable(DeviceInfo const& info, DeviceMetricsInfo const& metrics)
     for (size_t i = 0; i < info.queriesViewIndex.indexes.size(); ++i) {
       auto& metric = metrics.metrics[info.queriesViewIndex.indexes[i]];
       ImGui::Text("%zu: %s", i, metrics.stringMetrics[metric.storeIdx][0].data);
+      if (ImGui::IsItemHovered()) {
+        ImGui::BeginTooltip();
+        ImGui::Text("%zu: %s", i, metrics.stringMetrics[metric.storeIdx][0].data);
+        ImGui::EndTooltip();
+      }
     }
   }
 }

--- a/Framework/Core/src/SourceInfoHeader.cxx
+++ b/Framework/Core/src/SourceInfoHeader.cxx
@@ -1,0 +1,19 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/SourceInfoHeader.h"
+#include "Headers/DataHeader.h"
+
+namespace o2::framework
+{
+
+constexpr o2::header::HeaderType SourceInfoHeader::sHeaderType;
+
+} // namespace o2::framework

--- a/Framework/Core/test/test_DataAllocator.cxx
+++ b/Framework/Core/test/test_DataAllocator.cxx
@@ -66,26 +66,6 @@ struct MetaHeader : public o2::header::BaseHeader {
 constexpr o2::header::HeaderType MetaHeader::sHeaderType = "MetaHead";
 } // namespace test
 
-DataProcessorSpec getTimeoutSpec()
-{
-  // a timer process to terminate the workflow after a timeout
-  auto processingFct = [](ProcessingContext& pc) {
-    static int counter = 0;
-    pc.outputs().snapshot(Output{"TEST", "TIMER", 0, Lifetime::Timeframe}, counter);
-
-    // terminate if WaitFor was not interrupted
-    if (pc.services().get<RawDeviceService>().device()->WaitFor(std::chrono::seconds(1)) && (counter++ > 10)) {
-      LOG(ERROR) << "Timeout reached, the workflow seems to be broken";
-      pc.services().get<ControlService>().readyToQuit(QuitRequest::All);
-    }
-  };
-
-  return DataProcessorSpec{"timer",  // name of the processor
-                           Inputs{}, // inputs empty
-                           {OutputSpec{"TEST", "TIMER", 0, Lifetime::Timeframe}},
-                           AlgorithmSpec(processingFct)};
-}
-
 DataProcessorSpec getSourceSpec()
 {
   auto processingFct = [](ProcessingContext& pc) {
@@ -155,7 +135,7 @@ DataProcessorSpec getSourceSpec()
   };
 
   return DataProcessorSpec{"source", // name of the processor
-                           {InputSpec{"timer", "TEST", "TIMER", 0, Lifetime::Timeframe}},
+                           {},
                            {OutputSpec{"TST", "MESSAGEABLE", 0, Lifetime::Timeframe},
                             OutputSpec{{"makesingle"}, "TST", "MAKESINGLE", 0, Lifetime::Timeframe},
                             OutputSpec{{"makespan"}, "TST", "MAKESPAN", 0, Lifetime::Timeframe},
@@ -326,7 +306,6 @@ DataProcessorSpec getSinkSpec()
 WorkflowSpec defineDataProcessing(ConfigContext const&)
 {
   return WorkflowSpec{
-    getTimeoutSpec(),
     getSourceSpec(),
     getSinkSpec()};
 }

--- a/Framework/Core/test/test_DataAllocator.cxx
+++ b/Framework/Core/test/test_DataAllocator.cxx
@@ -132,6 +132,8 @@ DataProcessorSpec getSourceSpec()
     pmrvec.reserve(100);
     pmrvec.emplace_back(o2::test::TriviallyCopyable{1, 2, 3});
     pc.outputs().adoptContainer(pmrOutputSpec, std::move(pmrvec));
+    pc.services().get<ControlService>().endOfStream();
+    pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
   };
 
   return DataProcessorSpec{"source", // name of the processor

--- a/Framework/Utils/test/test_RootTreeWriterWorkflow.cxx
+++ b/Framework/Utils/test/test_RootTreeWriterWorkflow.cxx
@@ -125,6 +125,8 @@ DataProcessorSpec getSourceSpec()
     auto processingFct = [counter](ProcessingContext& pc) {
       if (*counter >= sTreeSize) {
         // don't publish more
+        pc.services().get<ControlService>().endOfStream();
+        pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
         return;
       }
       o2::test::Polymorphic a(*counter);


### PR DESCRIPTION
This allows DataProcessorDevices to signal in the data stream when they are done sending messages and triggers a newly introduced `EndOfStreamCallback` which can then be used to finalise the data processing (and eventually quit). 

Things still to do:

- [x] Make sure the cache is empty when all the channels are in Completed state.
- [x] Make sure we signal the EndOfStream downstream when all the channels are in Completed state.
- [x] Understand why `readyToQuit(false)` does not actually quit.
- [x] Understand why `test_RootTreeWriterWorkflow.cxx` fails.

Possibilities opened by this:
- Introduce a new histogram writing device which collects all the dangling histograms and writes them to file.
- Simplify all the "batch-like" workflows which now do not need to handle quitting themselves.
- Have the timers signal EndOfStream when they are done.
