### PR TITLE
Updates to wrapper volumes and containers for hosting the OB Support Wheels

### DIFF
--- a/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
@@ -32,6 +32,7 @@
 
 #include "TGeoManager.h"     // for TGeoManager, gGeoManager
 #include "TGeoTube.h"        // for TGeoTube
+#include "TGeoPcon.h"        // for TGeoPcon
 #include "TGeoVolume.h"      // for TGeoVolume, TGeoVolumeAssembly
 #include "TString.h"         // for TString, operator+
 #include "TVirtualMC.h"      // for gMC, TVirtualMC
@@ -117,7 +118,7 @@ static void configITS(Detector* its)
   const int kNWrapVol = 3;
   const double wrpRMin[kNWrapVol] = {2.1, 19.3, 32.0};
   const double wrpRMax[kNWrapVol] = {14.0, 30.0, 46.0};
-  const double wrpZSpan[kNWrapVol] = {70., 93., 160.};
+  const double wrpZSpan[kNWrapVol] = {70., 93., 165.8};
 
   for (int iw = 0; iw < kNWrapVol; iw++) {
     its->defineWrapperVolume(iw, wrpRMin[iw], wrpRMax[iw], wrpZSpan[iw]);
@@ -686,13 +687,35 @@ void Detector::getLayerParameters(Int_t nlay, Double_t& phi0, Double_t& r, Int_t
 TGeoVolume* Detector::createWrapperVolume(Int_t id)
 {
   // Creates an air-filled wrapper cylindrical volume
+  // For OB a Pcon is needed to host the support rings
+  // while avoiding overlaps with MFT structures
+
+  const Double_t suppRingAZlen = 4.;
+  const Double_t suppRingCZlen[2] = {4.8, 4.0};
+  const Double_t suppRingsRmin[2] = {23.35, 20.05};
 
   if (mWrapperMinRadius[id] < 0 || mWrapperMaxRadius[id] < 0 || mWrapperZSpan[id] < 0) {
     LOG(FATAL) << "Wrapper volume " << id << " was requested but not defined";
   }
 
   // Now create the actual shape and volume
-  auto* tube = new TGeoTube(mWrapperMinRadius[id], mWrapperMaxRadius[id], mWrapperZSpan[id] / 2.);
+  TGeoShape* tube;
+  if (id == 1) {
+    TGeoPcon* wrap = new TGeoPcon(0, 360, 6);
+    Double_t zlen = mWrapperZSpan[id] / 2 + suppRingCZlen[0];
+    wrap->DefineSection(0, -zlen, suppRingsRmin[0], mWrapperMaxRadius[id]);
+    zlen = mWrapperZSpan[id] / 2 + suppRingCZlen[1];
+    wrap->DefineSection(1, -zlen, suppRingsRmin[0], mWrapperMaxRadius[id]);
+    wrap->DefineSection(2, -zlen, suppRingsRmin[1], mWrapperMaxRadius[id]);
+    wrap->DefineSection(3, -mWrapperZSpan[id] / 2., suppRingsRmin[1], mWrapperMaxRadius[id]);
+    wrap->DefineSection(4, -mWrapperZSpan[id] / 2., mWrapperMinRadius[id], mWrapperMaxRadius[id]);
+    zlen = mWrapperZSpan[id] / 2 + suppRingAZlen;
+    wrap->DefineSection(5, zlen, mWrapperMinRadius[id], mWrapperMaxRadius[id]);
+    tube = (TGeoShape*)wrap;
+  } else {
+    TGeoTube* wrap = new TGeoTube(mWrapperMinRadius[id], mWrapperMaxRadius[id], mWrapperZSpan[id] / 2.);
+    tube = (TGeoShape*)wrap;
+  }
 
   TGeoMedium* medAir = gGeoManager->GetMedium("ITS_AIR$");
 
@@ -1082,13 +1105,13 @@ Hit* Detector::addHit(int trackID, int detID, const TVector3& startPos, const TV
 
 void Detector::Print(std::ostream* os) const
 {
-  // Standard output format for this class.
-  // Inputs:
-  //   ostream *os   The output stream
-  // Outputs:
-  //   none.
-  // Return:
-  //   none.
+// Standard output format for this class.
+// Inputs:
+//   ostream *os   The output stream
+// Outputs:
+//   none.
+// Return:
+//   none.
 
 #if defined __GNUC__
 #if __GNUC__ > 2

--- a/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
@@ -1105,13 +1105,13 @@ Hit* Detector::addHit(int trackID, int detID, const TVector3& startPos, const TV
 
 void Detector::Print(std::ostream* os) const
 {
-// Standard output format for this class.
-// Inputs:
-//   ostream *os   The output stream
-// Outputs:
-//   none.
-// Return:
-//   none.
+  // Standard output format for this class.
+  // Inputs:
+  //   ostream *os   The output stream
+  // Outputs:
+  //   none.
+  // Return:
+  //   none.
 
 #if defined __GNUC__
 #if __GNUC__ > 2


### PR DESCRIPTION
In view of the implementation of the MB/OB Support Wheels, some changes were needed to host them and avoid fake overlaps or extrusions with the air containers. Namely:
- the OB Wrapper Volume was extended in Z
- the MB Wrapper Volume was extended in Z and its shape changed from a simple Tube to a properly crafted Pcon to avoid fake overlaps with the MFT elements
- the top vertices of the Space Frame were reduced to their actual length (they were erroneously too long)
- the air volume containing the end part of the Space Frame was differently shaped to avoid fake overlaps with the support wheels

The actual wheels are not included in this PR: they will be part of a separate PR.