### PR TITLE
Param/INI file and loader for QED e+e- generator

### DIFF
--- a/Common/SimConfig/include/SimConfig/ConfigurableParam.h
+++ b/Common/SimConfig/include/SimConfig/ConfigurableParam.h
@@ -163,9 +163,9 @@ class ConfigurableParam
   static boost::property_tree::ptree readConfigFile(std::string const& filepath);
 
   // writes a human readable JSON file of all parameters
-  static void writeJSON(std::string const& filename);
+  static void writeJSON(std::string const& filename, std::string const& keyOnly = "");
   // writes a human readable INI file of all parameters
-  static void writeINI(std::string const& filename);
+  static void writeINI(std::string const& filename, std::string const& keyOnly = "");
 
   // can be used instead of using API on concrete child classes
   template <typename T>

--- a/Common/SimConfig/src/ConfigurableParam.cxx
+++ b/Common/SimConfig/src/ConfigurableParam.cxx
@@ -191,10 +191,20 @@ int EnumLegalValues::getIntValue(const std::string& value) const
 
 // -----------------------------------------------------------------
 
-void ConfigurableParam::writeINI(std::string const& filename)
+void ConfigurableParam::writeINI(std::string const& filename, std::string const& keyOnly)
 {
   initPropertyTree(); // update the boost tree before writing
-  boost::property_tree::write_ini(filename, *sPtree);
+  if (!keyOnly.empty()) { // write ini for selected key only
+    try {
+      boost::property_tree::ptree kTree;
+      kTree.add_child(keyOnly, sPtree->get_child(keyOnly));
+      boost::property_tree::write_ini(filename, kTree);
+    } catch (const boost::property_tree::ptree_bad_path& err) {
+      LOG(FATAL) << "non-existing key " << keyOnly << " provided to writeINI";
+    }
+  } else {
+    boost::property_tree::write_ini(filename, *sPtree);
+  }
 }
 
 // ------------------------------------------------------------------
@@ -249,10 +259,20 @@ boost::property_tree::ptree ConfigurableParam::readJSON(std::string const& filep
 
 // ------------------------------------------------------------------
 
-void ConfigurableParam::writeJSON(std::string const& filename)
+void ConfigurableParam::writeJSON(std::string const& filename, std::string const& keyOnly)
 {
   initPropertyTree(); // update the boost tree before writing
-  boost::property_tree::write_json(filename, *sPtree);
+  if (!keyOnly.empty()) { // write ini for selected key only
+    try {
+      boost::property_tree::ptree kTree;
+      kTree.add_child(keyOnly, sPtree->get_child(keyOnly));
+      boost::property_tree::write_json(filename, kTree);
+    } catch (const boost::property_tree::ptree_bad_path& err) {
+      LOG(FATAL) << "non-existing key " << keyOnly << " provided to writeJSON";
+    }
+  } else {
+    boost::property_tree::write_json(filename, *sPtree);
+  }
 }
 
 // ------------------------------------------------------------------

--- a/Generators/CMakeLists.txt
+++ b/Generators/CMakeLists.txt
@@ -25,6 +25,7 @@ o2_add_library(Generators
                        src/PrimaryGenerator.cxx
                        src/InteractionDiamondParam.cxx
                        src/BoxGunParam.cxx
+		       src/QEDGenParam.cxx
                        src/GeneratorFactory.cxx
                        $<$<BOOL:${pythia_FOUND}>:src/Pythia8Generator.cxx>
                        $<$<BOOL:${HepMC_FOUND}>:src/GeneratorHepMC.cxx>
@@ -49,7 +50,8 @@ set(headers
     include/Generators/PDG.h
     include/Generators/PrimaryGenerator.h
     include/Generators/InteractionDiamondParam.h
-    include/Generators/BoxGunParam.h)
+    include/Generators/BoxGunParam.h
+    include/Generators/QEDGenParam.h)
 
 if(pythia_FOUND)
   list(APPEND headers include/Generators/Pythia8Generator.h
@@ -70,10 +72,20 @@ if(pythia6_FOUND)
                          PUBLIC_LINK_LIBRARIES O2::Generators MC::Pythia6
                          LABELS generators)
 endif()
+
+if(doBuildSimulation)
+  o2_add_test_root_macro(share/external/QEDLoader.C
+                         PUBLIC_LINK_LIBRARIES O2::Generators
+                                               O2::SimConfig
+                                               LABELS generators
+			                       LOAD_ONLY)
+endif()
+
 o2_add_test_root_macro(share/external/tgenerator.C
                        PUBLIC_LINK_LIBRARIES O2::Generators
                        LABELS generators)
 
+		     
 install(FILES share/external/extgen.C share/external/pythia6.C
-              share/external/tgenerator.C
+              share/external/tgenerator.C share/external/QEDLoader.C share/external/QEDepem.C
         DESTINATION share/Generators/external/)

--- a/Generators/include/Generators/QEDGenParam.h
+++ b/Generators/include/Generators/QEDGenParam.h
@@ -1,0 +1,42 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_QEDGENINFO_H
+#define ALICEO2_QEDGENINFO_H
+
+#include "SimConfig/ConfigurableParam.h"
+#include "SimConfig/ConfigurableParamHelper.h"
+
+//  @file   QEDGenInfo.h
+//  @author ruben.shahoyan@cern.ch
+//  @brief  Summary of QED generation: cuts and estimated x-section
+
+namespace o2
+{
+namespace eventgen
+{
+struct QEDGenParam : public o2::conf::ConfigurableParamHelper<QEDGenParam> {
+
+  float yMin = -6.f;    ///< min Y
+  float yMax = 6.f;     ///< max Y
+  float ptMin = 0.4e-3; ///< min pT
+  float ptMax = 10.f;   ///< min pT
+  //
+  float xSectionQED = -1; ///< estimated QED x-section in barns
+  float xSectionHad = 8.; ///< reference hadronic x-section for the same system
+
+  // boilerplate stuff + make principal key
+  O2ParamDef(QEDGenParam, "QEDGenParam");
+};
+
+} // namespace eventgen
+} // namespace o2
+
+#endif

--- a/Generators/share/external/QEDLoader.C
+++ b/Generators/share/external/QEDLoader.C
@@ -1,0 +1,32 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+//< Loader macro to run QED background generator from QEDepem.C macro, use it as e.g.
+//< o2-sim -n10000 -m PIPE ITS T0 MFT  --noemptyevents -g extgen --extGenFile QEDloader.C
+#include <FairLogger.h>
+
+FairGenerator* fg = nullptr;
+
+FairGenerator* QEDLoader()
+{
+  const TString macroName = "QEDepem";
+  gSystem->Load("libTEPEMGEN.so");
+
+  // the path of the macro to load depends on where it was installed, we assume that its installation
+  // directory is the same as of the loader macro
+  std::ostringstream mstr;
+  mstr << __FILE__;
+  TString macroFullName = Form("%s/%s.C", gSystem->DirName(mstr.str().c_str()), macroName.Data());
+  LOG(INFO) << "\nLoading " << macroFullName.Data() << "\n";
+
+  gROOT->LoadMacro(macroFullName.Data());
+  gInterpreter->ProcessLine(Form("%s()", macroName.Data()));
+  return fg;
+}

--- a/Generators/share/external/QEDepem.C
+++ b/Generators/share/external/QEDepem.C
@@ -1,0 +1,53 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+//< Macro to run QED background generator, us it as e.g.
+//< o2-sim -n10000 -m PIPE ITS T0 MFT  --noemptyevents -g extgen --extGenFile QEDloader.C
+
+R__LOAD_LIBRARY(libTEPEMGEN.so)
+
+o2::eventgen::GeneratorTGenerator* QEDepem()
+{
+  auto& qedParam = o2::eventgen::QEDGenParam::Instance();
+  auto& diamond = o2::eventgen::InteractionDiamondParam::Instance();
+  if (qedParam.yMin >= qedParam.yMax) {
+    LOG(FATAL) << "QEDGenParam.yMin(" << qedParam.yMin << ") >= QEDGenParam.yMax(" << qedParam.yMax << ")";
+  }
+  if (qedParam.ptMin >= qedParam.ptMax) {
+    LOG(FATAL) << "QEDGenParam.ptMin(" << qedParam.ptMin << ") >= QEDGenParam.ptMax(" << qedParam.ptMax << ")";
+  }
+
+  auto genBg = new TGenEpEmv1();
+  genBg->SetYRange(qedParam.yMin, qedParam.yMax);                                  // Set Y limits
+  genBg->SetPtRange(qedParam.ptMin, qedParam.ptMax);                               // Set pt limits (GeV) for e+-: 1MeV corresponds to max R=13.3mm at 5kGaus
+  genBg->SetOrigin(diamond.position[0], diamond.position[1], diamond.position[2]); // vertex position in space
+  genBg->SetSigma(diamond.width[0], diamond.width[1], diamond.width[2]);           // vertex sigma
+  genBg->SetTimeOrigin(0.);                                                        // vertex position in time
+  genBg->Init();
+
+  // calculate and store X-section
+  std::ostringstream xstr;
+  xstr << "QEDGenParam.xSectionQED=" << genBg->GetXSection();
+  qedParam.updateFromString(xstr.str());
+  const std::string qedIniFileName = "qedgenparam.ini";
+  qedParam.writeINI(qedIniFileName, "QEDGenParam");
+  qedParam.printKeyValues(true);
+  LOG(INFO) << "Info: QED background generation parameters stored to " << qedIniFileName;
+
+  // instance and configure TGenerator interface
+  auto tgen = new o2::eventgen::GeneratorTGenerator();
+  tgen->setMomentumUnit(1.); // [GeV/c]
+  tgen->setEnergyUnit(1.);   // [GeV/c]
+  tgen->setPositionUnit(1.); // [cm]
+  tgen->setTimeUnit(1.);     // [s]
+  tgen->setTGenerator(genBg);
+  fg = tgen;
+  return tgen;
+}

--- a/Generators/share/external/README.md
+++ b/Generators/share/external/README.md
@@ -1,0 +1,16 @@
+# External generators
+
+
+------------
+
+
+## qedbkg.C
+
+-  Invokes TGenEpEmv1 generator from [AEGIS](https://github.com/AliceO2Group/AEGIS) package for Pb-Pb &rarr;  e+e- generation.
+	+	optional parameters are rapidity and pT ranges to generate, can be provided as key/value option, e.g.
+``
+o2-sim -n 1000 -m PIPE ITS -g extgen --extGenFile $O2_ROOT/share/Generators/external/QEDLoader.C  --configKeyValues 'QEDGenParam.yMin=-3;QEDGenParam.ptMin=0.001'
+``
+The x-section of the process depends on the applied cuts, it is calculated on the fly and stored in the ``qedgenparam.ini`` file.
+
+------------

--- a/Generators/src/GeneratorsLinkDef.h
+++ b/Generators/src/GeneratorsLinkDef.h
@@ -42,5 +42,7 @@
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::eventgen::InteractionDiamondParam> + ;
 #pragma link C++ class o2::eventgen::BoxGunParam + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::eventgen::BoxGunParam> + ;
+#pragma link C++ class o2::eventgen::QEDGenParam + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::eventgen::QEDGenParam> + ;
 
 #endif

--- a/Generators/src/QEDGenParam.cxx
+++ b/Generators/src/QEDGenParam.cxx
@@ -1,0 +1,15 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Generators/QEDGenParam.h"
+
+using namespace o2::eventgen;
+
+O2ParamImpl(o2::eventgen::QEDGenParam);

--- a/cmake/O2RootMacroExclusionList.cmake
+++ b/cmake/O2RootMacroExclusionList.cmake
@@ -37,6 +37,7 @@ list(APPEND O2_ROOT_MACRO_EXCLUSION_LIST
             GPU/TPCFastTransformation/macro/loadlibs.C # Special macro
             GPU/TPCFastTransformation/macro/moveTPCFastTransform.C # Relies on initTPCcalibration.C
             Generators/share/external/hijing.C
+	    Generators/share/external/QEDepem.C
             macro/SetIncludePath.C
             macro/loadExtDepLib.C
             macro/load_all_libs.C

--- a/dependencies/O2SimulationDependencies.cmake
+++ b/dependencies/O2SimulationDependencies.cmake
@@ -66,7 +66,6 @@ set_package_properties(HepMC
 		       PROPERTIES
 		       TYPE ${mcPackageRequirement} DESCRIPTION
 		       	    "the HepMC3 event record package")
-
 set(doBuildSimulation OFF)
 
 if(pythia_FOUND


### PR DESCRIPTION
QED generator can be invoked as o2-sim -g extgen --extGenFile $O2_ROOT/share/Generators/external/QEDLoader.C with additional options provided via QEDGenParam key/value wrapper class. 

On execution qedgenparam.ini file will be written with used options + estimated x-section of the process, to be used for QED weighting wrt. the hadronic process during digitization

@sawenzel the 1st commit adds to the ConfigurableParam.writeINI and writeJSON an option to write only a particular top object key (by default all objects are dumped, as before). 