### PR TITLE
Updating the definition of RAWDataHeader

### DIFF
--- a/DataFormats/Headers/test/test_RAWDataHeader.cxx
+++ b/DataFormats/Headers/test/test_RAWDataHeader.cxx
@@ -15,15 +15,14 @@
 #include <array>
 #include "Headers/RAWDataHeader.h"
 
-using RDH = o2::header::RAWDataHeader;
-
-BOOST_AUTO_TEST_CASE(test_rdh)
+BOOST_AUTO_TEST_CASE(test_rdh_v4)
 {
-  static_assert(sizeof(RDH) == 64, "the RAWDataHeader is supposed to be 512 bit");
+  using RDH = o2::header::RAWDataHeader;
+  static_assert(sizeof(RDH) == 64, "RAWDataHeader v5 is supposed to be 512 bit");
 
   // check the defaults
   RDH defaultRDH;
-  BOOST_CHECK(defaultRDH.version == 3);
+  BOOST_CHECK(defaultRDH.version == 4);
   BOOST_CHECK(defaultRDH.blockLength == 0);
   BOOST_CHECK(defaultRDH.feeId == 0xffff);
   //BOOST_CHECK(defaultRDH.linkId == 0xff);
@@ -94,4 +93,16 @@ BOOST_AUTO_TEST_CASE(test_rdh)
   BOOST_CHECK(rdh->par == 0);
   BOOST_CHECK(rdh->zero6 == 0);
   BOOST_CHECK(rdh->word7 == 0);
+}
+
+BOOST_AUTO_TEST_CASE(test_rdh_v5)
+{
+  using RDH = o2::header::RAWDataHeaderV5;
+  static_assert(sizeof(RDH) == 64, "RAWDataHeader v5 is supposed to be 512 bit");
+
+  // check the defaults
+  RDH defaultRDH;
+  BOOST_CHECK(defaultRDH.version == 5);
+  BOOST_CHECK(defaultRDH.feeId == 0xffff);
+  BOOST_CHECK(defaultRDH.headerSize == 64); // header size in 64 bytes = 8*64 bit words
 }


### PR DESCRIPTION
The references for RDH v4 and v5 are now in the wp6-doc repo
https://gitlab.cern.ch/AliceO2Group/wp6-doc/blob/master/rdh/RDHV4.md
https://gitlab.cern.ch/AliceO2Group/wp6-doc/blob/master/rdh/RDHV5.md

The previous changes to the RAWDataHeader v3 definition have committed
the update to v4 already, simply renaming the struct. Version 3 and 4
are almost identical, v3 is only missing a few fields which are filled
by the CRU, we keep v3 as a simple alias to v4.

Adding the v5 definition, which contains only one trigger information
set, the length of a few filds has been adjusted, for details see
https://indico.cern.ch/event/818188/#26-cru
https://indico.cern.ch/event/791295/#1-wp6-rdh-v5

Version 5 is not yet implemented in hardware, keeping v4 as default for now.