### PR TITLE
Rename CCDB related classes to comply with the Coding Guidelines

### DIFF
--- a/CCDB/CMakeLists.txt
+++ b/CCDB/CMakeLists.txt
@@ -10,9 +10,9 @@
 
 o2_add_library(CCDB
                SOURCES  src/CcdbApi.cxx
-                        src/BasicCCDBManager.cxx
-                        src/CCDBTimeStampUtils.cxx
-        src/IdPath.cxx
+                        src/BasicCcdbManager.cxx
+                        src/CcdbTimeStampUtils.cxx
+                        src/IdPath.cxx
         PUBLIC_LINK_LIBRARIES CURL::libcurl
                                     FairRoot::ParMQ
                                     ROOT::Hist
@@ -22,12 +22,11 @@ o2_add_library(CCDB
                TARGETVARNAME targetName)
 
 o2_target_root_dictionary(CCDB
-                          HEADERS
-                                  include/CCDB/CcdbApi.h
-        include/CCDB/TObjectWrapper.h
-        include/CCDB/IdPath.h
-        include/CCDB/BasicCCDBManager.h
-                                  include/CCDB/CCDBTimeStampUtils.h)
+                          HEADERS include/CCDB/CcdbApi.h
+                                    include/CCDB/TObjectWrapper.h
+                                    include/CCDB/IdPath.h
+                                    include/CCDB/BasicCcdbManager.h
+                                    include/CCDB/CcdbTimeStampUtils.h)
 
 o2_add_test(CcdbApi
             SOURCES test/testCcdbApi.cxx

--- a/CCDB/include/CCDB/BasicCcdbManager.h
+++ b/CCDB/include/CCDB/BasicCcdbManager.h
@@ -1,0 +1,90 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+//
+// Created by Sandro Wenzel on 2019-08-14.
+//
+
+#ifndef O2_BASICCDBMANAGER_H
+#define O2_BASICCDBMANAGER_H
+
+#include "CCDB/CcdbApi.h"
+#include "CCDB/CcdbTimeStampUtils.h"
+#include <string>
+#include <map>
+// #include <FairLogger.h>
+
+namespace o2::ccdb
+{
+
+/// A simple (singleton) class offering simplified access to CCDB (mainly for MC simulation)
+/// The class encapsulates timestamp and URL and is easily usable from detector code.
+class BasicCcdbManager
+{
+ public:
+  static BasicCcdbManager& instance()
+  {
+    const std::string ccdbUrl{"http://ccdb-test.cern.ch:8080"};
+    static BasicCcdbManager inst{ccdbUrl};
+    return inst;
+  }
+
+  /// set a URL to query from
+  void setURL(const std::string& url);
+
+  /// set timestamp cache for all queries
+  void setTimestamp(long t)
+  {
+    if (t >= 0) {
+      mTimestamp = t;
+    }
+  }
+
+  /// query current URL
+  std::string const& getURL() const { return mCcdbAccessor.getURL(); }
+
+  /// query timestamp
+  long getTimestamp() const { return mTimestamp; }
+
+  /// retrieve an object of type T from CCDB as stored under path and timestamp
+  template <typename T>
+  T* getForTimeStamp(std::string const& path, long timestamp) const;
+
+  /// retrieve an object of type T from CCDB as stored under path; will use the timestamp member
+  template <typename T>
+  T* get(std::string const& path) const
+  {
+    // TODO: add some error info/handling when failing
+    return getForTimeStamp<T>(path, mTimestamp);
+  }
+
+  bool isHostReachable() const { return mCcdbAccessor.isHostReachable(); }
+
+ private:
+  BasicCcdbManager(std::string const& path) : mCcdbAccessor{}
+  {
+    mCcdbAccessor.init(path);
+  }
+
+  // we access the CCDB via the CURL based C++ API
+  o2::ccdb::CcdbApi mCcdbAccessor;
+  std::map<std::string, std::string> mMetaData;     // some dummy object needed to talk to CCDB API
+  long mTimestamp{o2::ccdb::getCurrentTimestamp()}; // timestamp to be used for query (by default "now")
+  bool mCanDefault = false;                         // whether default is ok --> useful for testing purposes done standalone/isolation
+};
+
+template <typename T>
+T* BasicCcdbManager::getForTimeStamp(std::string const& path, long timestamp) const
+{
+  return mCcdbAccessor.retrieveFromTFileAny<T>(path, mMetaData, timestamp);
+}
+
+} // namespace o2::ccdb
+
+#endif //O2_BASICCCDBMANAGER_H

--- a/CCDB/include/CCDB/CcdbTimeStampUtils.h
+++ b/CCDB/include/CCDB/CcdbTimeStampUtils.h
@@ -1,0 +1,37 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+//
+// Created by Sandro Wenzel on 2019-08-20.
+//
+
+#ifndef O2_CCDBTIMESTAMPUTILS_H
+#define O2_CCDBTIMESTAMPUTILS_H
+
+/// a couple of static helper functions to create timestamp values for CCDB queries
+
+namespace o2
+{
+namespace ccdb
+{
+
+/// returns the timestamp in long corresponding to "now + secondsInFuture"
+long getFutureTimestamp(int secondsInFuture);
+
+/// returns the timestamp in long corresponding to "now"
+long getCurrentTimestamp();
+
+/// \brief Converting time into numerical time stamp representation
+long createTimestamp(int year, int month, int day, int hour, int minutes, int seconds);
+
+} // namespace ccdb
+} // namespace o2
+
+#endif //O2_CCDBTIMESTAMPUTILS_H

--- a/CCDB/src/BasicCcdbManager.cxx
+++ b/CCDB/src/BasicCcdbManager.cxx
@@ -1,0 +1,28 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+//
+// Created by Sandro Wenzel on 2019-08-14.
+//
+#include "CCDB/BasicCcdbManager.h"
+#include <string>
+
+namespace o2
+{
+namespace ccdb
+{
+
+void BasicCcdbManager::setURL(std::string const& url)
+{
+  mCcdbAccessor.init(url);
+}
+
+} // namespace ccdb
+} // namespace o2

--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -23,14 +23,12 @@
 #include <TSystem.h>
 #include <TStreamerInfo.h>
 #include <TMemFile.h>
-#include <TBufferFile.h>
-#include <TWebFile.h>
 #include <TH1F.h>
 #include <TTree.h>
 #include <FairLogger.h>
 #include <TError.h>
 #include <TClass.h>
-#include <CCDB/CCDBTimeStampUtils.h>
+#include <CCDB/CcdbTimeStampUtils.h>
 #include <algorithm>
 #include <boost/filesystem.hpp>
 

--- a/CCDB/src/CcdbLinkDef.h
+++ b/CCDB/src/CcdbLinkDef.h
@@ -1,0 +1,20 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifdef __CLING__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class o2::ccdb::IdPath + ;
+#pragma link C++ class o2::ccdb::CcdbApi + ;
+#pragma link C++ class o2::ccdb::BasicCcdbManager + ;
+#endif

--- a/CCDB/src/CcdbTimeStampUtils.cxx
+++ b/CCDB/src/CcdbTimeStampUtils.cxx
@@ -1,0 +1,56 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+//
+// Created by Sandro Wenzel on 2019-08-20.
+//
+#include <CCDB/CcdbTimeStampUtils.h>
+#include <chrono>
+#include <ctime>
+
+namespace o2::ccdb
+{
+
+long getFutureTimestamp(int secondsInFuture)
+{
+  std::chrono::seconds sec(secondsInFuture);
+  auto future = std::chrono::system_clock::now() + sec;
+  auto future_ms = std::chrono::time_point_cast<std::chrono::milliseconds>(future);
+  auto epoch = future_ms.time_since_epoch();
+  auto value = std::chrono::duration_cast<std::chrono::milliseconds>(epoch);
+  return value.count();
+}
+
+/// returns the timestamp in long corresponding to "now"
+long getCurrentTimestamp()
+{
+  auto now = std::chrono::system_clock::now();
+  auto now_ms = std::chrono::time_point_cast<std::chrono::milliseconds>(now);
+  auto epoch = now_ms.time_since_epoch();
+  auto value = std::chrono::duration_cast<std::chrono::milliseconds>(epoch);
+  return value.count();
+}
+
+/// \brief Converting time into numerical time stamp representation
+long createTimestamp(int year, int month, int day, int hour, int minutes, int seconds)
+{
+  struct tm timeinfo;
+  timeinfo.tm_year = year;
+  timeinfo.tm_mon = month;
+  timeinfo.tm_mday = day;
+  timeinfo.tm_hour = hour;
+  timeinfo.tm_min = minutes;
+  timeinfo.tm_sec = seconds;
+
+  time_t timeformat = mktime(&timeinfo);
+  return static_cast<long>(timeformat);
+}
+
+} // namespace o2::ccdb

--- a/CCDB/test/testCcdbApi.cxx
+++ b/CCDB/test/testCcdbApi.cxx
@@ -20,24 +20,17 @@
 #include "CCDB/CcdbApi.h"
 #include "CCDB/IdPath.h"    // just as test object
 #include "CommonUtils/RootChain.h" // just as test object
-#include "CCDB/CCDBTimeStampUtils.h"
+#include "CCDB/CcdbTimeStampUtils.h"
 #include <boost/test/unit_test.hpp>
 #include <boost/filesystem.hpp>
-#include <cassert>
 #include <iostream>
-#include <cstdio>
-#include <curl/curl.h>
-#include <sys/stat.h>
-#include <fcntl.h>
 #include <TH1F.h>
 #include <chrono>
 #include <CommonUtils/StringUtils.h>
-#include <TMessage.h>
 #include <TStreamerInfo.h>
 #include <TGraph.h>
 #include <TTree.h>
 #include <TString.h>
-#include <sys/types.h>
 #include <unistd.h>
 
 using namespace std;

--- a/Detectors/TPC/base/include/TPCBase/CDBInterface.h
+++ b/Detectors/TPC/base/include/TPCBase/CDBInterface.h
@@ -18,7 +18,7 @@
 #include <memory>
 
 #include <CCDB/IdPath.h>
-#include <CCDB/BasicCCDBManager.h>
+#include <CCDB/BasicCcdbManager.h>
 #include <TPCBase/CalDet.h>
 
 namespace o2
@@ -167,7 +167,7 @@ class CDBInterface
 template <typename T>
 inline T& CDBInterface::getObjectFromCDB(const o2::ccdb::IdPath& path)
 {
-  static auto cdb = o2::ccdb::BasicCCDBManager::instance();
+  static auto cdb = o2::ccdb::BasicCcdbManager::instance();
   auto* object = cdb.get<T>(path.getPathString().Data());
   return *object;
 }

--- a/EventVisualisation/View/include/EventVisualisationView/EventManager.h
+++ b/EventVisualisation/View/include/EventVisualisationView/EventManager.h
@@ -17,7 +17,7 @@
 #ifndef ALICE_O2_EVENTVISUALISATION_BASE_EVENTMANAGER_H
 #define ALICE_O2_EVENTVISUALISATION_BASE_EVENTMANAGER_H
 
-#include "CCDB/BasicCCDBManager.h"
+#include "CCDB/BasicCcdbManager.h"
 #include "CCDB/CcdbApi.h"
 
 #include <TEveElement.h>


### PR DESCRIPTION
Accronyms should not be all uppercase, but rather use camel-case. It was already the case for CcdbApi and thus we make the naming consistent.

Ok this is not very important and if you disagree I will just drop the PR.