### PR TITLE
method to extract topology as a walk from reference col/row

### DIFF
--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/Cluster.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/Cluster.h
@@ -143,6 +143,8 @@ class Cluster : public o2::BaseCluster<float>
     mPattern[nbits >> 3] &= (0xff ^ (0x1 << (nbits % 8)));
   }
 
+  void getDiffPattern(std::vector<std::pair<short, short>>& diffv, short colRef, short rowRef) const;
+
 #endif
   //
  protected:

--- a/DataFormats/Detectors/ITSMFT/common/src/Cluster.cxx
+++ b/DataFormats/Detectors/ITSMFT/common/src/Cluster.cxx
@@ -90,3 +90,31 @@ void Cluster::print() const
   }
 #endif
 }
+
+#ifdef _ClusterTopology_
+//______________________________________________________________________________
+void Cluster::getDiffPattern(std::vector<std::pair<short, short>>& diffv, short colRef, short rowRef) const
+{
+  // fill vector with incremental differences starting from colRed / rowRef
+  int nr = getPatternRowSpan();
+  int nc = getPatternColSpan();
+  diffv.clear();
+  for (short ir = 0; ir < nr; ir++) {
+    for (short ic0 = 0; ic0 < nc; ic0++) {
+      short ic = (ir & 0x1) ? nc - ic0 - 1 : ic0; // left-to-right for even rows, right-to-left for odd columns
+      if (testPixel(ir, ic)) {
+        short row = ir + mPatternRowMin, col = ic + mPatternColMin;
+        short drow = row - rowRef, dcol = col - colRef;
+        if (!dcol && !drow) {
+          continue;
+        }
+        diffv.emplace_back(dcol, drow);
+        colRef = col;
+        rowRef = row;
+      }
+    }
+  }
+  // flag end of the pattern
+  diffv.emplace_back(0, 0);
+}
+#endif

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/LookUp.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/LookUp.h
@@ -39,6 +39,7 @@ class LookUp
   int getTopologiesOverThreshold() { return mTopologiesOverThreshold; }
   void loadDictionary(std::string fileName);
   bool IsGroup(int id) const;
+  int size() const { return mDictionary.GetSize(); }
 
  private:
   TopologyDictionary mDictionary;


### PR DESCRIPTION
Method to fill provided vector std::vector<std::pair<short,short>> with increments <d_column,d_row> to traverse all fired pixels of the topology starting from the provided column and row. Used for the study of an additional stream of full hitmaps in ITS compressed data (for  lossless compression)
