### PR TITLE
Fix to generate doc with v1.8.16

### DIFF
--- a/doc/doxyfile.in
+++ b/doc/doxyfile.in
@@ -100,7 +100,7 @@ WARN_LOGFILE           =
 #---------------------------------------------------------------------------
 INPUT                  = "@CMAKE_SOURCE_DIR@"
 INPUT_ENCODING         = UTF-8
-FILE_PATTERNS          =
+FILE_PATTERNS          = *.cxx *.h *.inl *.md
 RECURSIVE              = YES
 EXCLUDE                = .git/ \
                          build/ \
@@ -131,8 +131,6 @@ REFERENCES_LINK_SOURCE = YES
 SOURCE_TOOLTIPS        = YES
 USE_HTAGS              = NO
 VERBATIM_HEADERS       = YES
-CLANG_ASSISTED_PARSING = NO
-CLANG_OPTIONS          =
 #---------------------------------------------------------------------------
 # Configuration options related to the alphabetical class index
 #---------------------------------------------------------------------------
@@ -276,12 +274,10 @@ GENERATE_TAGFILE       =
 ALLEXTERNALS           = NO
 EXTERNAL_GROUPS        = YES
 EXTERNAL_PAGES         = YES
-PERL_PATH              = /usr/bin/perl
 #---------------------------------------------------------------------------
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------
 CLASS_DIAGRAMS         = YES
-MSCGEN_PATH            =
 DIA_PATH               =
 HIDE_UNDOC_RELATIONS   = NO
 HAVE_DOT               = YES


### PR DESCRIPTION
An empty documentation is built when using doxygen v1.8.16.
The reason seems to be that when FILE_PATTERNS is left blank the default patterns are not used anymore and no file is matched.
If the desired file patterns are explicitely specified, everything seems to work fine again.
Also, doxygen prints some warning about some obsolete variables that are therefore removed