### PR TITLE
Getting rid of broadcast method for external FairMQ DPL proxies

### DIFF
--- a/Framework/Core/include/Framework/DataSpecUtils.h
+++ b/Framework/Core/include/Framework/DataSpecUtils.h
@@ -29,7 +29,12 @@ struct DataSpecUtils {
   /// @return true if a given InputSpec @a spec matches with a @a target ConcreteDataTypeMatcher
   static bool match(InputSpec const& spec, ConcreteDataTypeMatcher const& target);
 
-  /// @return true if a given InputSpec @a spec matches with a @a target ConcreteDataMatcher
+  /// @return true if matchers of the two specs match on all three levels if both
+  /// matchers are of type ConcreteDataMatcher, on the level of origin and description
+  /// otherwise
+  static bool match(OutputSpec const& left, OutputSpec const& right);
+
+  /// @return true if a given OutputSpec @a spec matches with a @a target ConcreteDataMatcher
   static bool match(OutputSpec const& spec, ConcreteDataMatcher const& target);
 
   /// @return true if a given InputSpec @a input  matches the @a output outputspec

--- a/Framework/Core/include/Framework/ExternalFairMQDeviceProxy.h
+++ b/Framework/Core/include/Framework/ExternalFairMQDeviceProxy.h
@@ -21,9 +21,10 @@ namespace o2
 {
 namespace framework
 {
-void broadcastMessage(FairMQDevice& device, o2::header::Stack&& headerStack, FairMQMessagePtr&& payloadMessage, int index);
+using ChannelRetreiver = std::function<std::string(OutputSpec const&)>;
+using InjectorFunction = std::function<void(FairMQDevice& device, FairMQParts& inputs, ChannelRetreiver)>;
 
-using InjectorFunction = std::function<void(FairMQDevice& device, FairMQParts& inputs, int index)>;
+void sendOnChannel(FairMQDevice& device, o2::header::Stack&& headerStack, FairMQMessagePtr&& payloadMessage, OutputSpec const& spec, ChannelRetreiver& channelRetreiver);
 
 /// Helper function which takes a set of inputs coming from a device,
 /// massages them so that they are valid DPL messages using @param spec as header

--- a/Framework/Core/include/Framework/RawDeviceService.h
+++ b/Framework/Core/include/Framework/RawDeviceService.h
@@ -10,20 +10,17 @@
 #ifndef FRAMEWORK_RAWDEVICESERVICE_H
 #define FRAMEWORK_RAWDEVICESERVICE_H
 
-#include <map>
-#include <string>
-#include <vector>
-
 class FairMQDevice;
 
 namespace o2
 {
 namespace framework
 {
+class DeviceSpec;
 
 /// This service provides a hook into the actual fairmq device running the
-/// computation, and allows and advanced user to modify its behavior in
-/// from with a workflow class. This should be used to implement special
+/// computation, and allows an advanced user to modify its behavior
+/// from within a workflow class. This should be used to implement special
 /// `DataProcessors` like one that acts as a gateway to standard FairMQ
 /// devices.
 class RawDeviceService
@@ -31,6 +28,7 @@ class RawDeviceService
  public:
   virtual FairMQDevice* device() = 0;
   virtual void setDevice(FairMQDevice* device) = 0;
+  virtual DeviceSpec const& spec() = 0;
 };
 
 } // namespace framework

--- a/Framework/Core/include/Framework/SimpleRawDeviceService.h
+++ b/Framework/Core/include/Framework/SimpleRawDeviceService.h
@@ -11,19 +11,20 @@
 #define FRAMEWORK_SIMPLERAWDEVICESERVICE_H
 
 #include "Framework/RawDeviceService.h"
+#include "Framework/DeviceSpec.h"
 
 namespace o2
 {
 namespace framework
 {
 
-/// Fairly unsophisticated service which simply stores and return the
-/// requested FairMQDevice
+/// Fairly unsophisticated service which simply stores and returns the
+/// requested FairMQDevice and DeviceSpec
 class SimpleRawDeviceService : public RawDeviceService
 {
  public:
-  SimpleRawDeviceService(FairMQDevice* device)
-    : mDevice(device)
+  SimpleRawDeviceService(FairMQDevice* device, DeviceSpec const& spec)
+    : mDevice(device), mSpec(spec)
   {
   }
 
@@ -37,8 +38,14 @@ class SimpleRawDeviceService : public RawDeviceService
     mDevice = device;
   }
 
+  DeviceSpec const& spec() final
+  {
+    return mSpec;
+  }
+
  private:
   FairMQDevice* mDevice;
+  DeviceSpec const& mSpec;
 };
 
 } // namespace framework

--- a/Framework/Core/src/DataSamplingReadoutAdapter.cxx
+++ b/Framework/Core/src/DataSamplingReadoutAdapter.cxx
@@ -21,7 +21,7 @@ using DataHeader = o2::header::DataHeader;
 
 InjectorFunction dataSamplingReadoutAdapter(OutputSpec const& spec)
 {
-  return [spec](FairMQDevice& device, FairMQParts& parts, int index) {
+  return [spec](FairMQDevice& device, FairMQParts& parts, ChannelRetreiver channelRetreiver) {
     for (size_t i = 0; i < parts.Size() / 2; ++i) {
 
       auto dbh = reinterpret_cast<DataBlockHeaderBase*>(parts.At(2 * i)->GetData());
@@ -37,7 +37,7 @@ InjectorFunction dataSamplingReadoutAdapter(OutputSpec const& spec)
 
       DataProcessingHeader dph{dbh->blockId, 0};
       o2::header::Stack headerStack{dh, dph};
-      broadcastMessage(device, std::move(headerStack), std::move(parts.At(2 * i + 1)), index);
+      sendOnChannel(device, std::move(headerStack), std::move(parts.At(2 * i + 1)), spec, channelRetreiver);
     }
   };
 }

--- a/Framework/Core/src/DataSpecUtils.cxx
+++ b/Framework/Core/src/DataSpecUtils.cxx
@@ -231,6 +231,20 @@ bool DataSpecUtils::match(OutputSpec const& spec, ConcreteDataMatcher const& tar
                     spec.matcher);
 }
 
+bool DataSpecUtils::match(OutputSpec const& left, OutputSpec const& right)
+{
+  if (auto leftConcrete = std::get_if<ConcreteDataMatcher>(&left.matcher)) {
+    return match(right, *leftConcrete);
+  } else if (auto rightConcrete = std::get_if<ConcreteDataMatcher>(&right.matcher)) {
+    return match(left, *rightConcrete);
+  } else {
+    // both sides are ConcreteDataTypeMatcher without subspecification, we simply specify 0
+    // this is ignored in the mathing since also left hand object is ConcreteDataTypeMatcher
+    ConcreteDataTypeMatcher dataType = DataSpecUtils::asConcreteDataTypeMatcher(right);
+    return match(left, dataType.origin, dataType.description, 0);
+  }
+}
+
 bool DataSpecUtils::match(InputSpec const& input, OutputSpec const& output)
 {
   return std::visit([&input](auto const& concrete) -> bool {

--- a/Framework/Core/src/ReadoutAdapter.cxx
+++ b/Framework/Core/src/ReadoutAdapter.cxx
@@ -26,7 +26,7 @@ InjectorFunction readoutAdapter(OutputSpec const& spec)
 {
   auto counter = std::make_shared<uint64_t>(0);
 
-  return [spec, counter](FairMQDevice& device, FairMQParts& parts, int index) {
+  return [spec, counter](FairMQDevice& device, FairMQParts& parts, ChannelRetreiver channelRetreiver) {
     for (size_t i = 0; i < parts.Size(); ++i) {
       DataHeader dh;
       // FIXME: this will have to change and extract the actual subspec from
@@ -41,7 +41,7 @@ InjectorFunction readoutAdapter(OutputSpec const& spec)
       DataProcessingHeader dph{*counter, 0};
       (*counter) += 1UL;
       o2::header::Stack headerStack{dh, dph};
-      broadcastMessage(device, std::move(headerStack), std::move(parts.At(i)), index);
+      sendOnChannel(device, std::move(headerStack), std::move(parts.At(i)), spec, channelRetreiver);
     }
   };
 }

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -643,7 +643,7 @@ int doChild(int argc, char** argv, const o2::framework::DeviceSpec& spec)
       deviceState = std::make_unique<DeviceState>();
       textControlService = std::make_unique<TextControlService>(serviceRegistry, *deviceState.get());
       parallelContext = std::make_unique<ParallelContext>(spec.rank, spec.nSlots);
-      simpleRawDeviceService = std::make_unique<SimpleRawDeviceService>(nullptr);
+      simpleRawDeviceService = std::make_unique<SimpleRawDeviceService>(nullptr, spec);
       callbackService = std::make_unique<CallbackService>();
       monitoringService = MonitoringFactory::Get(r.fConfig.GetStringValue("monitoring-backend"));
       auto infoLoggerMode = r.fConfig.GetStringValue("infologger-mode");

--- a/Framework/Core/test/unittest_DataSpecUtils.cxx
+++ b/Framework/Core/test/unittest_DataSpecUtils.cxx
@@ -151,6 +151,7 @@ BOOST_AUTO_TEST_CASE(MatchingOutputs)
   InputSpec input4{
     "binding", {"TST", "A1"}, Lifetime::Timeframe};
 
+  // matching inputs to outputs
   BOOST_CHECK(DataSpecUtils::match(input1, output1) == true);
   BOOST_CHECK(DataSpecUtils::match(input1, output2) == false);
   BOOST_CHECK(DataSpecUtils::match(input1, output3) == false); // Wildcard on output!
@@ -163,6 +164,21 @@ BOOST_AUTO_TEST_CASE(MatchingOutputs)
   BOOST_CHECK(DataSpecUtils::match(input4, output1) == true);  // Wildcard in input!
   BOOST_CHECK(DataSpecUtils::match(input4, output2) == false);
   BOOST_CHECK(DataSpecUtils::match(input4, output3) == true); // Wildcard on both!
+
+  // matching outputs to output definitions
+  // ConcreteDataMatcher on both sides
+  BOOST_CHECK(DataSpecUtils::match(output1, OutputSpec{"TST", "A1", 0}) == true);
+  BOOST_CHECK(DataSpecUtils::match(output1, OutputSpec{"TST", "A1", 1}) == false);
+
+  // ConcreteDataMatcher left, ConcreteDataTypeMatcher right (subspec ignored)
+  BOOST_CHECK(DataSpecUtils::match(output1, OutputSpec{"TST", "A1"}) == true);
+
+  // ConcreteDataTypeMatcher left (subspec ignored), ConcreteDataMatcher right
+  BOOST_CHECK(DataSpecUtils::match(output3, OutputSpec{"TST", "A1", 0}) == true);
+  BOOST_CHECK(DataSpecUtils::match(output3, OutputSpec{"TST", "A1", 1}) == true);
+
+  // ConcreteDataTypeMatcher on both sides
+  BOOST_CHECK(DataSpecUtils::match(output3, OutputSpec{"TST", "A1"}) == true);
 }
 
 BOOST_AUTO_TEST_CASE(PartialMatching)


### PR DESCRIPTION
The bradcast message has been used to forward the incoming messages from
an out-of-bound device on all relevant output channels. There was a bug,
as this can only work for the first channel, messages are unique pointers
which will be empty after first send.

Messages are now sent only on the concrete channel according to the OutputSpec
of the adapter function.

The relevant information is retreived via the RawDeviceContext and for this
purpose, the DeviceSpec has been added to RawDeviceContext.

The index of FairMQ channels has been removed as we use only one channel per
channel name.