### PR TITLE
DPL: fix route duplication due to wildcards

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -177,6 +177,7 @@ foreach(t
         PtrHelpers
         Root2ArrowTable
         Services
+        SimpleWildcard
         StringHelpers
         SuppressionGenerator
         TMessageSerializer

--- a/Framework/Core/include/Framework/DataSpecUtils.h
+++ b/Framework/Core/include/Framework/DataSpecUtils.h
@@ -123,6 +123,12 @@ struct DataSpecUtils {
   /// and we can add corner cases as we go.
   static ConcreteDataTypeMatcher asConcreteDataTypeMatcher(InputSpec const& spec);
 
+  /// If possible extract the DataOrigin from an InputSpec.
+  /// This will not always be possible, depending on how complex of
+  /// a query the InputSpec does, however in most cases it should be ok
+  /// and we can add corner cases as we go.
+  static header::DataOrigin asConcreteOrigin(InputSpec const& spec);
+
   /// Create an InputSpec which is able to match all the outputs of the given
   /// OutputSpec
   static InputSpec matchingInput(OutputSpec const& spec);
@@ -135,6 +141,9 @@ struct DataSpecUtils {
 
   /// Build a DataDescriptMatcher which does not care about the subSpec.
   static data_matcher::DataDescriptorMatcher dataDescriptorMatcherFrom(ConcreteDataTypeMatcher const& dataType);
+
+  /// Build a DataDescriptMatcher which does not care about the subSpec and description.
+  static data_matcher::DataDescriptorMatcher dataDescriptorMatcherFrom(header::DataOrigin const& origin);
 };
 
 } // namespace framework

--- a/Framework/Core/include/Framework/InputRoute.h
+++ b/Framework/Core/include/Framework/InputRoute.h
@@ -38,7 +38,11 @@ struct InputRoute {
   using DanglingConfigurator = std::function<ExpirationHandler::Checker(ConfigParamRegistry const&)>;
   using ExpirationConfigurator = std::function<ExpirationHandler::Handler(ConfigParamRegistry const&)>;
 
+  // FIXME: This should really go away and we should make sure that
+  //        whenever we pass the input routes we also have the associated
+  //        input specs available.
   InputSpec matcher;
+  size_t inputSpecIndex;
   std::string sourceChannel;
   size_t timeslice;
   CreationConfigurator creatorConfigurator = nullptr;

--- a/Framework/Core/src/DataRelayer.cxx
+++ b/Framework/Core/src/DataRelayer.cxx
@@ -36,6 +36,8 @@ namespace framework
 
 namespace
 {
+/// Calculate how many input routes there are, doublecounting different
+/// timeslices.
 std::vector<size_t> createDistinctRouteIndex(std::vector<InputRoute> const& routes)
 {
   std::vector<size_t> result;

--- a/Framework/Core/src/DataSpecUtils.cxx
+++ b/Framework/Core/src/DataSpecUtils.cxx
@@ -247,8 +247,7 @@ bool DataSpecUtils::partialMatch(OutputSpec const& output, header::DataOrigin co
 
 bool DataSpecUtils::partialMatch(InputSpec const& input, header::DataOrigin const& origin)
 {
-  auto dataType = DataSpecUtils::asConcreteDataTypeMatcher(input);
-  return dataType.origin == origin;
+  return DataSpecUtils::asConcreteOrigin(input) == origin;
 }
 
 ConcreteDataMatcher DataSpecUtils::asConcreteDataMatcher(InputSpec const& spec)
@@ -373,6 +372,22 @@ ConcreteDataTypeMatcher DataSpecUtils::asConcreteDataTypeMatcher(InputSpec const
                     spec.matcher);
 }
 
+header::DataOrigin DataSpecUtils::asConcreteOrigin(InputSpec const& spec)
+{
+  return std::visit(overloaded{
+                      [](ConcreteDataMatcher const& concrete) {
+                        return concrete.origin;
+                      },
+                      [](DataDescriptorMatcher const& matcher) {
+                        auto state = extractMatcherInfo(matcher);
+                        if (state.hasUniqueOrigin) {
+                          return state.origin;
+                        }
+                        throw std::runtime_error("Could not extract data type from query");
+                      }},
+                    spec.matcher);
+}
+
 DataDescriptorMatcher DataSpecUtils::dataDescriptorMatcherFrom(ConcreteDataTypeMatcher const& dataType)
 {
   auto timeDescriptionMatcher = std::make_unique<DataDescriptorMatcher>(
@@ -383,6 +398,24 @@ DataDescriptorMatcher DataSpecUtils::dataDescriptorMatcherFrom(ConcreteDataTypeM
     DataDescriptorMatcher::Op::And,
     OriginValueMatcher{dataType.origin.as<std::string>()},
     std::move(timeDescriptionMatcher)));
+}
+
+DataDescriptorMatcher DataSpecUtils::dataDescriptorMatcherFrom(header::DataOrigin const& origin)
+{
+  char buf[5] = {0, 0, 0, 0, 0};
+  strncpy(buf, origin.str, 4);
+  DataDescriptorMatcher matchOnlyOrigin{
+    DataDescriptorMatcher::Op::And,
+    OriginValueMatcher{buf},
+    std::make_unique<DataDescriptorMatcher>(
+      DataDescriptorMatcher::Op::And,
+      DescriptionValueMatcher{ContextRef{1}},
+      std::make_unique<DataDescriptorMatcher>(
+        DataDescriptorMatcher::Op::And,
+        SubSpecificationTypeValueMatcher{ContextRef{2}},
+        std::make_unique<DataDescriptorMatcher>(DataDescriptorMatcher::Op::Just,
+                                                StartTimeValueMatcher{ContextRef{0}})))};
+  return std::move(matchOnlyOrigin);
 }
 
 InputSpec DataSpecUtils::matchingInput(OutputSpec const& spec)

--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -517,11 +517,25 @@ void DeviceSpecHelpers::processInEdgeActions(std::vector<DeviceSpec>& devices,
 
     InputRoute route{
       inputSpec,
+      edge.consumerInputIndex,
       sourceChannel,
       edge.producerTimeIndex,
       creationConfigurator,
       danglingConfigurator,
       expirationConfigurator};
+    // In case we have wildcards, we must make sure that some other edge
+    // produced the same route, i.e. has the same matcher.  Without this,
+    // otherwise, we would end up with as many input routes as the outputs that
+    // can be matched by the wildcard.
+    for (size_t iri = 0; iri < consumerDevice.inputs.size(); ++iri) {
+      auto& existingRoute = consumerDevice.inputs[iri];
+      if (existingRoute.timeslice != edge.producerTimeIndex) {
+        continue;
+      }
+      if (existingRoute.inputSpecIndex == edge.consumerInputIndex) {
+        return;
+      }
+    }
 
     consumerDevice.inputs.push_back(route);
   };

--- a/Framework/Core/test/benchmark_DataRelayer.cxx
+++ b/Framework/Core/test/benchmark_DataRelayer.cxx
@@ -31,7 +31,7 @@ static void BM_RelayMessageCreation(benchmark::State& state)
   InputSpec spec{"clusters", "TPC", "CLUSTERS"};
 
   std::vector<InputRoute> inputs = {
-    InputRoute{spec, "Fake", 0}};
+    InputRoute{spec, 0, "Fake", 0}};
 
   std::vector<ForwardRoute> forwards;
   TimesliceIndex index;
@@ -72,7 +72,7 @@ static void BM_RelaySingleSlot(benchmark::State& state)
   InputSpec spec{"clusters", "TPC", "CLUSTERS"};
 
   std::vector<InputRoute> inputs = {
-    InputRoute{spec, "Fake", 0}};
+    InputRoute{spec, 0, "Fake", 0}};
 
   std::vector<ForwardRoute> forwards;
   TimesliceIndex index;
@@ -120,7 +120,7 @@ static void BM_RelayMultipleSlots(benchmark::State& state)
   InputSpec spec{"clusters", "TPC", "CLUSTERS"};
 
   std::vector<InputRoute> inputs = {
-    InputRoute{spec, "Fake", 0}};
+    InputRoute{spec, 0, "Fake", 0}};
 
   std::vector<ForwardRoute> forwards;
   TimesliceIndex index;
@@ -171,8 +171,8 @@ static void BM_RelayMultipleRoutes(benchmark::State& state)
   InputSpec spec2{"tracks", "TPC", "TRACKS"};
 
   std::vector<InputRoute> inputs = {
-    InputRoute{spec1, "Fake1", 0},
-    InputRoute{spec2, "Fake2", 0}};
+    InputRoute{spec1, 0, "Fake1", 0},
+    InputRoute{spec2, 1, "Fake2", 0}};
 
   std::vector<ForwardRoute> forwards;
   TimesliceIndex index;

--- a/Framework/Core/test/benchmark_InputRecord.cxx
+++ b/Framework/Core/test/benchmark_InputRecord.cxx
@@ -31,9 +31,11 @@ static void BM_InputRecordGenericGetters(benchmark::State& state)
   InputSpec spec2{"y", "ITS", "CLUSTERS", 0, Lifetime::Timeframe};
   InputSpec spec3{"z", "TST", "EMPTY", 0, Lifetime::Timeframe};
 
-  auto createRoute = [](const char* source, InputSpec& spec) {
+  size_t i = 0;
+  auto createRoute = [&i](const char* source, InputSpec& spec) {
     return InputRoute{
       spec,
+      i++,
       source};
   };
 

--- a/Framework/Core/test/test_DataRelayer.cxx
+++ b/Framework/Core/test/test_DataRelayer.cxx
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_CASE(TestNoWait)
   InputSpec spec{"clusters", "TPC", "CLUSTERS"};
 
   std::vector<InputRoute> inputs = {
-    InputRoute{spec, "Fake", 0}};
+    InputRoute{spec, 0, "Fake", 0}};
 
   std::vector<ForwardRoute> forwards;
   TimesliceIndex index;
@@ -75,7 +75,7 @@ BOOST_AUTO_TEST_CASE(TestNoWaitMatcher)
   auto specs = o2::framework::select("clusters:TPC/CLUSTERS");
 
   std::vector<InputRoute> inputs = {
-    InputRoute{specs[0], "Fake", 0}};
+    InputRoute{specs[0], 0, "Fake", 0}};
 
   std::vector<ForwardRoute> forwards;
   TimesliceIndex index;
@@ -124,8 +124,8 @@ BOOST_AUTO_TEST_CASE(TestRelay)
   };
 
   std::vector<InputRoute> inputs = {
-    InputRoute{spec1, "Fake1", 0},
-    InputRoute{spec2, "Fake2", 0}};
+    InputRoute{spec1, 0, "Fake1", 0},
+    InputRoute{spec2, 1, "Fake2", 0}};
 
   std::vector<ForwardRoute> forwards;
 
@@ -191,8 +191,8 @@ BOOST_AUTO_TEST_CASE(TestRelayBug)
   };
 
   std::vector<InputRoute> inputs = {
-    InputRoute{spec1, "Fake1", 0},
-    InputRoute{spec2, "Fake2", 0}};
+    InputRoute{spec1, 0, "Fake1", 0},
+    InputRoute{spec2, 1, "Fake2", 0}};
 
   std::vector<ForwardRoute> forwards;
 
@@ -261,7 +261,7 @@ BOOST_AUTO_TEST_CASE(TestCache)
   InputSpec spec{"clusters", "TPC", "CLUSTERS"};
 
   std::vector<InputRoute> inputs = {
-    InputRoute{spec, "Fake", 0}};
+    InputRoute{spec, 0, "Fake", 0}};
   std::vector<ForwardRoute> forwards;
 
   auto policy = CompletionPolicyHelpers::consumeWhenAll();
@@ -325,8 +325,8 @@ BOOST_AUTO_TEST_CASE(TestPolicies)
   InputSpec spec2{"tracks", "TPC", "TRACKS"};
 
   std::vector<InputRoute> inputs = {
-    InputRoute{spec1, "Fake1", 0},
-    InputRoute{spec2, "Fake2", 0},
+    InputRoute{spec1, 0, "Fake1", 0},
+    InputRoute{spec2, 1, "Fake2", 0},
   };
 
   std::vector<ForwardRoute> forwards;

--- a/Framework/Core/test/test_InputRecord.cxx
+++ b/Framework/Core/test/test_InputRecord.cxx
@@ -31,12 +31,15 @@ BOOST_AUTO_TEST_CASE(TestInputRecord)
   InputSpec spec2{"y", "ITS", "CLUSTERS", 0, Lifetime::Timeframe};
   InputSpec spec3{"z", "TST", "EMPTY", 0, Lifetime::Timeframe};
 
-  auto createRoute = [](const char* source, InputSpec& spec) {
+  size_t i = 0;
+  auto createRoute = [&i](const char* source, InputSpec& spec) {
     return InputRoute{
       spec,
+      i++,
       source};
   };
 
+  /// FIXME: keep it simple and simply use the constructor...
   std::vector<InputRoute> schema = {
     createRoute("x_source", spec1),
     createRoute("y_source", spec2),

--- a/Framework/Core/test/test_SimpleWildcard.cxx
+++ b/Framework/Core/test/test_SimpleWildcard.cxx
@@ -1,0 +1,55 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/CallbackService.h"
+#include "Framework/ControlService.h"
+#include "Framework/EndOfStreamContext.h"
+#include <iostream>
+#include <algorithm>
+#include <memory>
+#include <unordered_map>
+
+using namespace o2::framework;
+
+WorkflowSpec defineDataProcessing(ConfigContext const&)
+{
+  return {{"A1",
+           Inputs{},
+           Outputs{
+             OutputSpec{{"out"}, "TST", "OUT", 0}},
+           AlgorithmSpec{
+             [](ProcessingContext& ctx) {
+               ctx.outputs().make<TObjString>(OutputRef{"out", 0}, "abc");
+               ctx.services().get<ControlService>().endOfStream();
+               ctx.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+             }}},
+          {"A2",
+           Inputs{},
+           Outputs{
+             OutputSpec{{"out"}, "TST", "OUT", 1}},
+           AlgorithmSpec{
+             [](ProcessingContext& ctx) {
+               ctx.outputs().make<TObjString>(OutputRef{"out", 1}, "def");
+               ctx.services().get<ControlService>().endOfStream();
+               ctx.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+             }}},
+          {"B",
+           Inputs{InputSpec{"in", {"TST", "OUT"}}},
+           Outputs{},
+           AlgorithmSpec{adaptStateful([](CallbackService& callbacks) {
+             callbacks.set(CallbackService::Id::EndOfStream, [](EndOfStreamContext& context) {
+               context.services().get<ControlService>().readyToQuit(QuitRequest::All);
+             });
+             return adaptStateless([](InputRecord& inputs) {
+               auto s = inputs.get<TObjString*>("in");
+               LOG(INFO) << "String is " << s->GetString().Data();
+             }); })}}};
+}

--- a/Framework/Utils/test/test_RootTreeWriter.cxx
+++ b/Framework/Utils/test/test_RootTreeWriter.cxx
@@ -153,10 +153,10 @@ BOOST_AUTO_TEST_CASE(test_RootTreeWriter)
   // temporary argument is still in memory
   // FIXME: check why the compiler does not detect this
   std::vector<InputRoute> schema = {
-    {InputSpec{"input1", "TST", "INT"}, "input1", 0},       //
-    {InputSpec{"input2", "TST", "CONTAINER"}, "input2", 0}, //
-    {InputSpec{"input3", "TST", "CONTAINER"}, "input3", 1}, //
-    {InputSpec{"input4", "TST", "BINARY"}, "input4", 0},    //
+    {InputSpec{"input1", "TST", "INT"}, 0, "input1", 0},       //
+    {InputSpec{"input2", "TST", "CONTAINER"}, 1, "input2", 0}, //
+    {InputSpec{"input3", "TST", "CONTAINER"}, 2, "input3", 1}, //
+    {InputSpec{"input4", "TST", "BINARY"}, 3, "input4", 0},    //
   };
 
   auto getter = [&store](size_t i) -> char const* { return static_cast<char const*>(store[i]->GetData()); };


### PR DESCRIPTION
There are cases in which using a wildcard matcher in a consumer
would result in duplicated input routes, while the wanted behavior
is to have a single input route processing one matching message after
the other. This makes sure that there is no duplication in such case.
For example consider producer PRODUCER producing A/1 and A/2, and
CONSUMER matching on A/*, this will now invoke the processing callback
when either A/1 or A/2 is received.