### PR TITLE
derive DPL devices using adaptFromTask<T> from framework::core::Task

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/RecoWorkflowSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/RecoWorkflowSpec.cxx
@@ -32,8 +32,7 @@ namespace tof
 {
 
 // use the tasking system of DPL
-// just need to implement 2 special methods init + run (there is no need to inherit from anything)
-class TOFDPLRecoWorkflowTask
+class TOFDPLRecoWorkflowTask : public Task
 {
   using evIdx = o2::dataformats::EvIndex<int, int>;
   using MatchOutputType = std::vector<o2::dataformats::MatchInfoTOF>;
@@ -43,14 +42,14 @@ class TOFDPLRecoWorkflowTask
  public:
   explicit TOFDPLRecoWorkflowTask(bool useMC) : mUseMC(useMC) {}
 
-  void init(framework::InitContext& ic)
+  void init(framework::InitContext& ic) final
   {
     // nothing special to be set up
     o2::base::GeometryManager::loadGeometry("./O2geometry.root", "FAIRGeom");
     o2::base::Propagator::initFieldFromGRP("o2sim_grp.root");
   }
 
-  void run(framework::ProcessingContext& pc)
+  void run(framework::ProcessingContext& pc) final
   {
     static bool finished = false;
     if (finished) {

--- a/Detectors/MUON/MCH/PreClustering/src/DigitSamplerSpec.cxx
+++ b/Detectors/MUON/MCH/PreClustering/src/DigitSamplerSpec.cxx
@@ -38,11 +38,11 @@ using namespace std;
 using namespace o2::framework;
 using namespace o2::mch;
 
-class DigitSamplerTask
+class DigitSamplerTask : public Task
 {
  public:
   //_________________________________________________________________________________________________
-  void init(framework::InitContext& ic)
+  void init(framework::InitContext& ic) final
   {
     /// Get the input file and other options from the context
     LOG(INFO) << "initializing digit sampler";
@@ -64,7 +64,7 @@ class DigitSamplerTask
   }
 
   //_________________________________________________________________________________________________
-  void run(framework::ProcessingContext& pc)
+  void run(framework::ProcessingContext& pc) final
   {
     /// send the digits of the current event
 

--- a/Detectors/MUON/MCH/PreClustering/src/PreClusterFinderSpec.cxx
+++ b/Detectors/MUON/MCH/PreClustering/src/PreClusterFinderSpec.cxx
@@ -40,11 +40,11 @@ namespace mch
 using namespace std;
 using namespace o2::framework;
 
-class PreClusterFinderTask
+class PreClusterFinderTask : public Task
 {
  public:
   //_________________________________________________________________________________________________
-  void init(framework::InitContext& ic)
+  void init(framework::InitContext& ic) final
   {
     /// Prepare the preclusterizer
     LOG(INFO) << "initializing preclusterizer";
@@ -71,7 +71,7 @@ class PreClusterFinderTask
   }
 
   //_________________________________________________________________________________________________
-  void run(framework::ProcessingContext& pc)
+  void run(framework::ProcessingContext& pc) final
   {
     /// read the digits, preclusterize and send the preclusters
 

--- a/Detectors/MUON/MCH/PreClustering/src/PreClusterSinkSpec.cxx
+++ b/Detectors/MUON/MCH/PreClustering/src/PreClusterSinkSpec.cxx
@@ -34,11 +34,11 @@ namespace mch
 using namespace std;
 using namespace o2::framework;
 
-class PreClusterSinkTask
+class PreClusterSinkTask : public Task
 {
  public:
   //_________________________________________________________________________________________________
-  void init(framework::InitContext& ic)
+  void init(framework::InitContext& ic) final
   {
     /// Get the output file from the context
     LOG(INFO) << "initializing precluster sink";
@@ -58,7 +58,7 @@ class PreClusterSinkTask
   }
 
   //_________________________________________________________________________________________________
-  void run(framework::ProcessingContext& pc)
+  void run(framework::ProcessingContext& pc) final
   {
     /// dump the tracks with attached clusters of the current event
     auto msgIn = pc.inputs().get<gsl::span<char>>("preclusters");

--- a/Detectors/MUON/MCH/Tracking/src/ClusterSamplerSpec.cxx
+++ b/Detectors/MUON/MCH/Tracking/src/ClusterSamplerSpec.cxx
@@ -37,11 +37,11 @@ namespace mch
 using namespace std;
 using namespace o2::framework;
 
-class ClusterSamplerTask
+class ClusterSamplerTask : public Task
 {
  public:
   //_________________________________________________________________________________________________
-  void init(framework::InitContext& ic)
+  void init(framework::InitContext& ic) final
   {
     /// Get the input file from the context
     LOG(INFO) << "initializing cluster sampler";
@@ -61,7 +61,7 @@ class ClusterSamplerTask
   }
 
   //_________________________________________________________________________________________________
-  void run(framework::ProcessingContext& pc)
+  void run(framework::ProcessingContext& pc) final
   {
     /// send the clusters of the current event
 

--- a/Detectors/MUON/MCH/Tracking/src/TrackFinderOriginalSpec.cxx
+++ b/Detectors/MUON/MCH/Tracking/src/TrackFinderOriginalSpec.cxx
@@ -41,11 +41,11 @@ namespace mch
 using namespace std;
 using namespace o2::framework;
 
-class TrackFinderTask
+class TrackFinderTask : public Task
 {
  public:
   //_________________________________________________________________________________________________
-  void init(framework::InitContext& ic)
+  void init(framework::InitContext& ic) final
   {
     /// Prepare the track extrapolation tools
 
@@ -68,7 +68,7 @@ class TrackFinderTask
   }
 
   //_________________________________________________________________________________________________
-  void run(framework::ProcessingContext& pc)
+  void run(framework::ProcessingContext& pc) final
   {
     /// read the clusters of the current event, find tracks and send them
 

--- a/Detectors/MUON/MCH/Tracking/src/TrackFitterSpec.cxx
+++ b/Detectors/MUON/MCH/Tracking/src/TrackFitterSpec.cxx
@@ -39,11 +39,11 @@ namespace mch
 using namespace std;
 using namespace o2::framework;
 
-class TrackFitterTask
+class TrackFitterTask : public Task
 {
  public:
   //_________________________________________________________________________________________________
-  void init(framework::InitContext& ic)
+  void init(framework::InitContext& ic) final
   {
     /// Prepare the track extrapolation tools
     LOG(INFO) << "initializing track fitter";
@@ -54,7 +54,7 @@ class TrackFitterTask
   }
 
   //_________________________________________________________________________________________________
-  void run(framework::ProcessingContext& pc)
+  void run(framework::ProcessingContext& pc) final
   {
     /// read the tracks with attached clusters of the current event,
     /// refit them and send the new version

--- a/Detectors/MUON/MCH/Tracking/src/TrackSamplerSpec.cxx
+++ b/Detectors/MUON/MCH/Tracking/src/TrackSamplerSpec.cxx
@@ -35,11 +35,11 @@ namespace mch
 using namespace std;
 using namespace o2::framework;
 
-class TrackSamplerTask
+class TrackSamplerTask : public Task
 {
  public:
   //_________________________________________________________________________________________________
-  void init(framework::InitContext& ic)
+  void init(framework::InitContext& ic) final
   {
     /// Get the input file from the context
     LOG(INFO) << "initializing track sampler";
@@ -59,7 +59,7 @@ class TrackSamplerTask
   }
 
   //_________________________________________________________________________________________________
-  void run(framework::ProcessingContext& pc)
+  void run(framework::ProcessingContext& pc) final
   {
     /// send the tracks with attached clusters of the current event
 

--- a/Detectors/MUON/MCH/Tracking/src/TrackSinkSpec.cxx
+++ b/Detectors/MUON/MCH/Tracking/src/TrackSinkSpec.cxx
@@ -34,11 +34,11 @@ namespace mch
 using namespace std;
 using namespace o2::framework;
 
-class TrackSinkTask
+class TrackSinkTask : public Task
 {
  public:
   //_________________________________________________________________________________________________
-  void init(framework::InitContext& ic)
+  void init(framework::InitContext& ic) final
   {
     /// Get the output file from the context
     LOG(INFO) << "initializing track sink";
@@ -58,7 +58,7 @@ class TrackSinkTask
   }
 
   //_________________________________________________________________________________________________
-  void run(framework::ProcessingContext& pc)
+  void run(framework::ProcessingContext& pc) final
   {
     /// dump the tracks with attached clusters of the current event
     auto msgIn = pc.inputs().get<gsl::span<char>>("tracks");

--- a/Detectors/MUON/MID/Workflow/src/ClusterLabelerSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/ClusterLabelerSpec.cxx
@@ -35,18 +35,17 @@ namespace o2
 namespace mid
 {
 
-class ClusterLabelerDeviceDPL
+class ClusterLabelerDeviceDPL : public o2::framework::Task
 {
  public:
   ClusterLabelerDeviceDPL(const char* inputPreClustersBinding, const char* inputClustersBinding, const char* inputCorrelationBinding, const char* inputLabelsBinding) : mInputPreClustersBinding(inputPreClustersBinding), mInputClustersBinding(inputClustersBinding), mInputCorrelationBinding(inputCorrelationBinding), mInputLabelsBinding(inputLabelsBinding), mPreClusterLabeler(), mClusterLabeler(){};
-  ~ClusterLabelerDeviceDPL() = default;
+  ~ClusterLabelerDeviceDPL() override = default;
 
-  void init(o2::framework::InitContext& ic)
+  void init(o2::framework::InitContext& ic) final
   {
   }
 
-  void
-    run(o2::framework::ProcessingContext& pc)
+  void run(o2::framework::ProcessingContext& pc) final
   {
     auto msgPreClusters = pc.inputs().get(mInputPreClustersBinding.c_str());
     gsl::span<const PreCluster> preClusters = of::DataRefUtils::as<const PreCluster>(msgPreClusters);

--- a/Detectors/MUON/MID/Workflow/src/ClusterizerSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/ClusterizerSpec.cxx
@@ -37,13 +37,13 @@ namespace o2
 namespace mid
 {
 
-class ClusterizerDeviceDPL
+class ClusterizerDeviceDPL : public o2::framework::Task
 {
  public:
   ClusterizerDeviceDPL(const char* inputBinding, bool isMC) : mInputBinding(inputBinding), mIsMC(isMC), mPreClusterizer(), mClusterizer(){};
-  ~ClusterizerDeviceDPL() = default;
+  ~ClusterizerDeviceDPL() override = default;
 
-  void init(o2::framework::InitContext& ic)
+  void init(o2::framework::InitContext& ic) final
   {
     if (!mPreClusterizer.init()) {
       LOG(ERROR) << "Initialization of MID pre-clusterizer device failed";
@@ -61,8 +61,7 @@ class ClusterizerDeviceDPL
     }
   }
 
-  void
-    run(o2::framework::ProcessingContext& pc)
+  void run(o2::framework::ProcessingContext& pc) final
   {
     auto msg = pc.inputs().get(mInputBinding.c_str());
     gsl::span<const ColumnData> patterns = of::DataRefUtils::as<const ColumnData>(msg);

--- a/Detectors/MUON/MID/Workflow/src/DigitReaderSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/DigitReaderSpec.cxx
@@ -36,10 +36,10 @@ namespace o2
 namespace mid
 {
 
-class DigitsReaderDeviceDPL
+class DigitsReaderDeviceDPL : public of::Task
 {
  public:
-  void init(o2::framework::InitContext& ic)
+  void init(o2::framework::InitContext& ic) final
   {
     auto filename = ic.options().get<std::string>("mid-digit-infile");
     mFile = std::make_unique<TFile>(filename.c_str());
@@ -60,7 +60,7 @@ class DigitsReaderDeviceDPL
     mState = 0;
   }
 
-  void run(o2::framework::ProcessingContext& pc)
+  void run(o2::framework::ProcessingContext& pc) final
   {
     if (mState != 0) {
       return;

--- a/Detectors/MUON/MID/Workflow/src/TrackLabelerSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/TrackLabelerSpec.cxx
@@ -30,17 +30,17 @@ namespace o2
 {
 namespace mid
 {
-class TrackLabelerDeviceDPL
+class TrackLabelerDeviceDPL : public of::Task
 {
  public:
   TrackLabelerDeviceDPL(const char* inputClustersBinding, const char* inputTracksBinding, const char* inputLabelsBinding) : mInputClustersBinding(inputClustersBinding), mInputTracksBinding(inputTracksBinding), mInputLabelsBinding(inputLabelsBinding), mTrackLabeler(){};
-  ~TrackLabelerDeviceDPL() = default;
+  ~TrackLabelerDeviceDPL() override = default;
 
-  void init(of::InitContext& ic)
+  void init(of::InitContext& ic) final
   {
   }
 
-  void run(of::ProcessingContext& pc)
+  void run(of::ProcessingContext& pc) final
   {
     auto msgClusters = pc.inputs().get(mInputClustersBinding.c_str());
     gsl::span<const Cluster3D> clusters = of::DataRefUtils::as<const Cluster3D>(msgClusters);

--- a/Detectors/MUON/MID/Workflow/src/TrackerSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/TrackerSpec.cxx
@@ -30,13 +30,13 @@ namespace o2
 {
 namespace mid
 {
-class TrackerDeviceDPL
+class TrackerDeviceDPL : public of::Task
 {
  public:
   explicit TrackerDeviceDPL(const char* inputBinding) : mInputBinding(inputBinding), mTracker(nullptr){};
-  ~TrackerDeviceDPL() = default;
+  ~TrackerDeviceDPL() override = default;
 
-  void init(o2::framework::InitContext& ic)
+  void init(o2::framework::InitContext& ic) final
   {
 
     if (!gGeoManager) {
@@ -50,7 +50,7 @@ class TrackerDeviceDPL
     }
   }
 
-  void run(o2::framework::ProcessingContext& pc)
+  void run(o2::framework::ProcessingContext& pc) final
   {
     auto msg = pc.inputs().get(mInputBinding.c_str());
     gsl::span<const Cluster2D> clusters = of::DataRefUtils::as<const Cluster2D>(msg);

--- a/Detectors/TOF/workflow/src/TOFClusterizerSpec.cxx
+++ b/Detectors/TOF/workflow/src/TOFClusterizerSpec.cxx
@@ -32,19 +32,19 @@ namespace tof
 
 // use the tasking system of DPL
 // just need to implement 2 special methods init + run (there is no need to inherit from anything)
-class TOFDPLClustererTask
+class TOFDPLClustererTask : public Task
 {
   using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
   bool mUseMC = true;
 
  public:
   explicit TOFDPLClustererTask(bool useMC) : mUseMC(useMC) {}
-  void init(framework::InitContext& ic)
+  void init(framework::InitContext& ic) final
   {
     // nothing special to be set up
   }
 
-  void run(framework::ProcessingContext& pc)
+  void run(framework::ProcessingContext& pc) final
   {
     static bool finished = false;
     if (finished) {

--- a/Steer/DigitizerWorkflow/src/FDDDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/FDDDigitizerSpec.cxx
@@ -51,7 +51,7 @@ namespace o2
 namespace fdd
 {
 
-class FDDDPLDigitizerTask
+class FDDDPLDigitizerTask : public Task
 {
  public:
   // FDDDPLDigitizerTask(Digitizer digitizer) : mDigitizer(nullptr)
@@ -59,7 +59,7 @@ class FDDDPLDigitizerTask
   //   /// Ctor
   // }
 
-  void init(framework::InitContext& ic)
+  void init(framework::InitContext& ic) final
   {
     LOG(INFO) << "initializing FDD digitization";
     // setup the input chain for the hits
@@ -82,7 +82,7 @@ class FDDDPLDigitizerTask
     mDigitizer = std::make_unique<Digitizer>(parameters, 0);
   }
 
-  void run(framework::ProcessingContext& pc)
+  void run(framework::ProcessingContext& pc) final
   {
     static bool finished = false;
     if (finished) {

--- a/Steer/DigitizerWorkflow/src/FITDigitWriterSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/FITDigitWriterSpec.cxx
@@ -36,13 +36,13 @@ namespace o2
 namespace fit
 {
 
-class FITDPLDigitWriter
+class FITDPLDigitWriter : public Task
 {
 
   using MCCont = o2::dataformats::MCTruthContainer<o2::ft0::MCLabel>;
 
  public:
-  void init(framework::InitContext& ic)
+  void init(framework::InitContext& ic) final
   {
     std::string detStrL = mID.getName();
     std::transform(detStrL.begin(), detStrL.end(), detStrL.begin(), ::tolower);
@@ -59,7 +59,7 @@ class FITDPLDigitWriter
     mOutTree = std::make_unique<TTree>(treename.c_str(), treename.c_str());
   }
 
-  void run(framework::ProcessingContext& pc)
+  void run(framework::ProcessingContext& pc) final
   {
     if (mFinished) {
       return;

--- a/Steer/DigitizerWorkflow/src/FITDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/FITDigitizerSpec.cxx
@@ -37,15 +37,15 @@ namespace fit
 // helper function which will be offered as a service
 //template <typename T>
 
-class FITDPLDigitizerTask
+class FITDPLDigitizerTask : public Task
 {
 
  public:
   explicit FITDPLDigitizerTask(o2::fit::DigitizationParameters const& parameters)
     : mDigitizer(parameters) {}
-  ~FITDPLDigitizerTask() = default;
+  ~FITDPLDigitizerTask() override = default;
 
-  void init(framework::InitContext& ic)
+  void init(framework::InitContext& ic) final
   {
     // setup the input chain for the hits
     mSimChains.emplace_back(new TChain("o2sim"));
@@ -65,7 +65,7 @@ class FITDPLDigitizerTask
     const bool isContinuous = ic.options().get<int>("pileup");
   }
 
-  void run(framework::ProcessingContext& pc)
+  void run(framework::ProcessingContext& pc) final
   {
 
     static bool finished = false;

--- a/Steer/DigitizerWorkflow/src/GRPUpdaterSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/GRPUpdaterSpec.cxx
@@ -33,17 +33,17 @@ using SubSpecificationType = framework::DataAllocator::SubSpecificationType;
 
 static std::vector<o2::detectors::DetID> sDetList;
 
-class GRPDPLUpdatedTask
+class GRPDPLUpdatedTask : public Task
 {
   using GRP = o2::parameters::GRPObject;
 
  public:
-  void init(framework::InitContext& ic)
+  void init(framework::InitContext& ic) final
   {
     // nothing special to be set up
   }
 
-  void run(framework::ProcessingContext& pc)
+  void run(framework::ProcessingContext& pc) final
   {
     const std::string inputGRP = "o2sim_grp.root";
     const std::string grpName = "GRP";

--- a/Steer/DigitizerWorkflow/src/HMPIDDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/HMPIDDigitizerSpec.cxx
@@ -51,10 +51,10 @@ namespace o2
 namespace hmpid
 {
 
-class HMPIDDPLDigitizerTask
+class HMPIDDPLDigitizerTask : public Task
 {
  public:
-  void init(framework::InitContext& ic)
+  void init(framework::InitContext& ic) final
   {
     LOG(INFO) << "initializing HMPID digitization";
     // setup the input chain for the hits
@@ -75,7 +75,7 @@ class HMPIDDPLDigitizerTask
     }
   }
 
-  void run(framework::ProcessingContext& pc)
+  void run(framework::ProcessingContext& pc) final
   {
     static bool finished = false;
     if (finished) {

--- a/Steer/DigitizerWorkflow/src/ITSMFTDigitWriterSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/ITSMFTDigitWriterSpec.cxx
@@ -36,13 +36,13 @@ namespace o2
 namespace itsmft
 {
 
-class ITSMFTDPLDigitWriter
+class ITSMFTDPLDigitWriter : public Task
 {
 
   using MCCont = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
 
  public:
-  void init(framework::InitContext& ic)
+  void init(framework::InitContext& ic) final
   {
     std::string detStr = mID.getName();
     std::string detStrL = mID.getName();
@@ -69,7 +69,7 @@ class ITSMFTDPLDigitWriter
     mOutTreeMC2ROF = std::make_unique<TTree>(mTreeNameMC2ROF.c_str(), "MC Event to ROF references");
   }
 
-  void run(framework::ProcessingContext& pc)
+  void run(framework::ProcessingContext& pc) final
   {
     if (mFinished) {
       return;

--- a/Steer/DigitizerWorkflow/src/ITSMFTDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/ITSMFTDigitizerSpec.cxx
@@ -39,11 +39,11 @@ namespace o2
 namespace itsmft
 {
 
-class ITSMFTDPLDigitizerTask
+class ITSMFTDPLDigitizerTask : public Task
 {
 
  public:
-  void init(framework::InitContext& ic)
+  void init(framework::InitContext& ic) final
   {
     // setup the input chain for the hits
     mSimChains.emplace_back(new TChain("o2sim"));
@@ -91,7 +91,7 @@ class ITSMFTDPLDigitizerTask
 
   virtual void setDigitizationOptions() = 0;
 
-  void run(framework::ProcessingContext& pc)
+  void run(framework::ProcessingContext& pc) final
   {
     if (mFinished) {
       return;

--- a/Steer/DigitizerWorkflow/src/MCHDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/MCHDigitizerSpec.cxx
@@ -51,10 +51,10 @@ namespace o2
 namespace mch
 {
 
-class MCHDPLDigitizerTask
+class MCHDPLDigitizerTask : public Task
 {
  public:
-  void init(framework::InitContext& ic)
+  void init(framework::InitContext& ic) final
   {
     LOG(DEBUG) << "initializing MCH digitization";
     // setup the input chain for the hits
@@ -75,7 +75,7 @@ class MCHDPLDigitizerTask
     }
   }
 
-  void run(framework::ProcessingContext& pc)
+  void run(framework::ProcessingContext& pc) final
   {
     static bool finished = false;
     if (finished) {

--- a/Steer/DigitizerWorkflow/src/MIDDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/MIDDigitizerSpec.cxx
@@ -52,7 +52,7 @@ namespace o2
 namespace mid
 {
 
-class MIDDPLDigitizerTask
+class MIDDPLDigitizerTask : public Task
 {
  public:
   // MIDDPLDigitizerTask(Digitizer digitizer) : mDigitizer(nullptr)
@@ -60,7 +60,7 @@ class MIDDPLDigitizerTask
   //   /// Ctor
   // }
 
-  void init(framework::InitContext& ic)
+  void init(framework::InitContext& ic) final
   {
     LOG(INFO) << "initializing MID digitization";
     // setup the input chain for the hits
@@ -83,7 +83,7 @@ class MIDDPLDigitizerTask
     mDigitizer = std::make_unique<Digitizer>(createDefaultChamberResponse(), createDefaultChamberEfficiencyResponse(), createTransformationFromManager(gGeoManager));
   }
 
-  void run(framework::ProcessingContext& pc)
+  void run(framework::ProcessingContext& pc) final
   {
     static bool finished = false;
     if (finished) {

--- a/Steer/DigitizerWorkflow/src/TPCDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TPCDigitizerSpec.cxx
@@ -71,7 +71,7 @@ std::string getBranchNameRight(int sector)
   return branchnamestreamright.str();
 }
 
-class TPCDPLDigitizerTask
+class TPCDPLDigitizerTask : public Task
 {
  public:
   TPCDPLDigitizerTask(int channel, bool writeGRP)
@@ -80,7 +80,7 @@ class TPCDPLDigitizerTask
     mWriteGRP = writeGRP;
   };
 
-  void init(framework::InitContext& ic)
+  void init(framework::InitContext& ic) final
   {
     LOG(INFO) << "Initializing TPC digitization";
 
@@ -171,7 +171,7 @@ class TPCDPLDigitizerTask
     }
   }
 
-  void run(framework::ProcessingContext& pc)
+  void run(framework::ProcessingContext& pc) final
   {
     static int callcounter = 0;
     callcounter++;

--- a/Steer/DigitizerWorkflow/src/TRDDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TRDDigitizerSpec.cxx
@@ -51,10 +51,10 @@ namespace o2
 namespace trd
 {
 
-class TRDDPLDigitizerTask
+class TRDDPLDigitizerTask : public Task
 {
  public:
-  void init(framework::InitContext& ic)
+  void init(framework::InitContext& ic) final
   {
     LOG(INFO) << "initializing TRD digitization";
     // setup the input chain for the hits
@@ -75,7 +75,7 @@ class TRDDPLDigitizerTask
     }
   }
 
-  void run(framework::ProcessingContext& pc)
+  void run(framework::ProcessingContext& pc) final
   {
     static bool finished = false;
     if (finished) {

--- a/Steer/DigitizerWorkflow/src/ZDCDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/ZDCDigitizerSpec.cxx
@@ -51,10 +51,10 @@ namespace o2
 namespace zdc
 {
 
-class ZDCDPLDigitizerTask
+class ZDCDPLDigitizerTask : public Task
 {
  public:
-  void init(framework::InitContext& ic)
+  void init(framework::InitContext& ic) final
   {
     LOG(INFO) << "Initializing ZDC digitization";
     // setup the input chain for the hits
@@ -71,7 +71,7 @@ class ZDCDPLDigitizerTask
     }
   }
 
-  void run(framework::ProcessingContext& pc)
+  void run(framework::ProcessingContext& pc) final
   {
     if (mFinished) {
       return;


### PR DESCRIPTION
This is not strictly necessary but the task are expected to provide some set of methods which may evolve with time. Deriving from framework::core::Task allows to inherit default base methods.

@ktf : this is needed to make https://github.com/AliceO2Group/AliceO2/pull/2481 compile.