### PR TITLE
Defining another OutputSpec constructors and adding some notes

### DIFF
--- a/Framework/Core/include/Framework/ConcreteDataMatcher.h
+++ b/Framework/Core/include/Framework/ConcreteDataMatcher.h
@@ -37,6 +37,10 @@ struct ConcreteDataTypeMatcher {
   {
     return origin == that.origin && description == that.description;
   }
+  bool operator!=(ConcreteDataTypeMatcher const& that) const
+  {
+    return not operator==(that);
+  }
 };
 
 /// This fully qualifies data geometry.
@@ -69,6 +73,10 @@ struct ConcreteDataMatcher {
   bool operator==(ConcreteDataMatcher const& that) const
   {
     return origin == that.origin && description == that.description && subSpec == that.subSpec;
+  }
+  bool operator!=(ConcreteDataMatcher const& that) const
+  {
+    return not operator==(that);
   }
 };
 

--- a/Framework/Core/include/Framework/OutputSpec.h
+++ b/Framework/Core/include/Framework/OutputSpec.h
@@ -51,6 +51,10 @@ struct OutputSpec {
   OutputSpec(OutputLabel const& inBinding, ConcreteDataMatcher const& concrete,
              enum Lifetime inLifetime = Lifetime::Timeframe);
 
+  /// Build an OutputSpec from a ConcreteDataMatcher
+  OutputSpec(ConcreteDataMatcher const& concrete,
+             enum Lifetime inLifetime = Lifetime::Timeframe);
+
   /// Build an OutputSpec which does not specify which subSpec the output will
   /// have.
   OutputSpec(OutputLabel const& inBinding, ConcreteDataTypeMatcher const& dataType,

--- a/Framework/Core/src/OutputSpec.cxx
+++ b/Framework/Core/src/OutputSpec.cxx
@@ -32,6 +32,8 @@ OutputSpec::OutputSpec(header::DataOrigin inOrigin, header::DataDescription inDe
 OutputSpec::OutputSpec(OutputLabel const& inBinding, header::DataOrigin inOrigin, header::DataDescription inDescription,
                        enum Lifetime inLifetime)
   : binding{inBinding},
+    // Note: using 0 as subspec is specifically intended default behavior, a matcher ignoring
+    // the subspec can be passed using the specific constructor with ConcreteDataTypeMatcher
     matcher{ConcreteDataMatcher{inOrigin, inDescription, 0}},
     lifetime{inLifetime}
 {
@@ -40,7 +42,16 @@ OutputSpec::OutputSpec(OutputLabel const& inBinding, header::DataOrigin inOrigin
 OutputSpec::OutputSpec(header::DataOrigin inOrigin, header::DataDescription inDescription,
                        enum Lifetime inLifetime)
   : binding{OutputLabel{""}},
+    // Note: using 0 as subspec is specifically intended default behavior, a matcher ignoring
+    // the subspec can be passed using the specific constructor with ConcreteDataTypeMatcher
     matcher{ConcreteDataMatcher{inOrigin, inDescription, 0}},
+    lifetime{inLifetime}
+{
+}
+
+OutputSpec::OutputSpec(ConcreteDataMatcher const& concrete, enum Lifetime inLifetime)
+  : binding{""},
+    matcher{concrete},
     lifetime{inLifetime}
 {
 }


### PR DESCRIPTION
If the subspec was not specified we can not simply create `ConcreteDataMatchers`
with subspec 0.

This is relevant when searching for a matching output for a DataHeader in the list of output routes. Using e.g. `OutputSpec{"TST", "Data"}` without any supspec, every DataHeader with this origin and description should match ignoring the subspec, however only with subspec 0 is matched.

The following unit tests are failing, need to look in more detail.
	 45 - test_Framework_test_WorkflowHelpers (Failed)
	 63 - test_Framework_test_DanglingOutputs (Failed)
	 69 - test_Framework_test_SimpleDataProcessingDevice01 (Failed)

@ktf do you think?