### PR TITLE
Remove unneeded dependency (fixes GPU CI)

### DIFF
--- a/CCDB/CMakeLists.txt
+++ b/CCDB/CMakeLists.txt
@@ -16,7 +16,6 @@ o2_add_library(CCDB
         PUBLIC_LINK_LIBRARIES CURL::libcurl
                                     FairRoot::ParMQ
                                     ROOT::Hist
-                                    O2::Device
                                     O2::CommonUtils
                                     FairMQ::FairMQ
                TARGETVARNAME targetName)
@@ -34,4 +33,3 @@ o2_add_test(CcdbApi
             COMPONENT_NAME ccdb
             PUBLIC_LINK_LIBRARIES O2::CCDB
             LABELS ccdb)
-


### PR DESCRIPTION
@sawenzel @mconcas :
The problem is the same as we fixed in ROOT here: alisw/alidist#1733
We have the same problem with Control/Monitoring/Readout. This PR just removed the (unnecessary) dependency from O2::Device and thus from O2::Monitoring.

I think it will be quite inconvenient to patch all our dependencies like I did with ROOT. There was already a related discussion in an issue of the CMake git, so I added our case there: https://gitlab.kitware.com/cmake/cmake/issues/19123
With some luck, they fix that in a future version.