### PR TITLE
Modifications to reduce file size of space-charge objects used as input for TPC simulation with constant distortions

### DIFF
--- a/GPU/TPCSpaceChargeBase/AliTPCSpaceCharge3DCalc.cxx
+++ b/GPU/TPCSpaceChargeBase/AliTPCSpaceCharge3DCalc.cxx
@@ -719,8 +719,7 @@ void AliTPCSpaceCharge3DCalc::InitSpaceCharge3DPoissonIntegralDz(
       //(fPoissonSolver->fMgParameters).maxLoop = 6;
 
       w.Start();
-      fPoissonSolver->PoissonSolver3D(matricesV, matricesCharge, nRRow, nZColumn, phiSlice, maxIteration,
-                                      symmetry);
+      fPoissonSolver->PoissonSolver3D(matricesV, matricesCharge, nRRow, nZColumn, phiSlice, maxIteration, symmetry);
       w.Stop();
 
       potentialInterpolator->SetValue(matricesV);
@@ -1729,8 +1728,7 @@ void AliTPCSpaceCharge3DCalc::InitSpaceCharge3DPoisson(Int_t nRRow, Int_t nZColu
           fInterpolationOrder);
 
       Info("AliTPCSpaceCharge3DCalc::InitSpaceCharge3DPoissonIntegralDz", "Step 1: Solving poisson solver");
-      fPoissonSolver->PoissonSolver3D(matricesV, matricesCharge, nRRow, nZColumn, phiSlice, maxIteration,
-                                      symmetry);
+      fPoissonSolver->PoissonSolver3D(matricesV, matricesCharge, nRRow, nZColumn, phiSlice, maxIteration, symmetry);
       Info("AliTPCSpaceCharge3DCalc::InitSpaceCharge3DPoissonIntegralDz", "Step 2: Calculate electric field");
       CalculateEField(
         matricesV,
@@ -2119,10 +2117,8 @@ void AliTPCSpaceCharge3DCalc::LocalDistCorrDz(TMatrixD** matricesEr, TMatrixD** 
 
     for (Int_t j = 0; j < nZColumn - 1; j++) {
       for (Int_t i = 0; i < nRRow; i++) {
-        // localIntErOverEz = (gridSizeZ * 0.5) * ((*eR)(i, j) + (*eR)(i, j + 1)) / (ezField + (*eZ)(i, j));
-        // localIntEPhiOverEz = (gridSizeZ * 0.5) * ((*ePhi)(i, j) + (*ePhi)(i, j + 1)) / (ezField + (*eZ)(i, j));
-        localIntErOverEz = (gridSizeZ * 0.5) * ((*eR)(i, j) + (*eR)(i, j + 1)) / (ezField);
-        localIntEPhiOverEz = (gridSizeZ * 0.5) * ((*ePhi)(i, j) + (*ePhi)(i, j + 1)) / (ezField);
+        localIntErOverEz = (gridSizeZ * 0.5) * ((*eR)(i, j) + (*eR)(i, j + 1)) / (ezField + (*eZ)(i, j));
+        localIntEPhiOverEz = (gridSizeZ * 0.5) * ((*ePhi)(i, j) + (*ePhi)(i, j + 1)) / (ezField + (*eZ)(i, j));
         localIntDeltaEz = (gridSizeZ * 0.5) * ((*eZ)(i, j) + (*eZ)(i, j + 1));
 
         (*distDrDz)(i, j) = fC0 * localIntErOverEz + fC1 * localIntEPhiOverEz;

--- a/GPU/TPCSpaceChargeBase/AliTPCSpaceCharge3DCalc.h
+++ b/GPU/TPCSpaceChargeBase/AliTPCSpaceCharge3DCalc.h
@@ -242,7 +242,6 @@ class AliTPCSpaceCharge3DCalc
   void SetIntegrationStrategy(Int_t integrationStrategy) { fIntegrationStrategy = integrationStrategy; }
 
  private:
-  static const Int_t kNMaxPhi = 360; //!<!
   Profile myProfile;                 //!<!
   Int_t fNRRows = 129;               ///< the maximum on row-slices so far ~ 2cm slicing
   Int_t fNPhiSlices = 180;           ///< the maximum of phi-slices so far = (8 per sector)
@@ -316,28 +315,28 @@ class AliTPCSpaceCharge3DCalc
   TMatrixD** fMatrixPotentialA; //!<! Matrices for storing potential side A
   TMatrixD** fMatrixPotentialC; //!<! Matrices for storing potential side C
 
-  AliTPC3DCylindricalInterpolator* fInterpolatorChargeA = nullptr;        //-> interpolator for charge densities side A
-  AliTPC3DCylindricalInterpolator* fInterpolatorChargeC = nullptr;        //-> interpolator for charge densities side C
-  AliTPC3DCylindricalInterpolator* fInterpolatorPotentialA = nullptr;     //-> interpolator for charge densities side A
-  AliTPC3DCylindricalInterpolator* fInterpolatorPotentialC = nullptr;     //-> interpolator for charge densities side C
-  AliTPC3DCylindricalInterpolator* fInterpolatorInverseChargeA = nullptr; //-> interpolator for inverse charge densities side A
-  AliTPC3DCylindricalInterpolator* fInterpolatorInverseChargeC = nullptr; //-> interpolator for inverse charge densities side C
+  AliTPC3DCylindricalInterpolator* fInterpolatorChargeA = nullptr;        //!<! interpolator for charge densities side A
+  AliTPC3DCylindricalInterpolator* fInterpolatorChargeC = nullptr;        //!<! interpolator for charge densities side C
+  AliTPC3DCylindricalInterpolator* fInterpolatorPotentialA = nullptr;     //!<! interpolator for charge densities side A
+  AliTPC3DCylindricalInterpolator* fInterpolatorPotentialC = nullptr;     //!<! interpolator for charge densities side C
+  AliTPC3DCylindricalInterpolator* fInterpolatorInverseChargeA = nullptr; //!<! interpolator for inverse charge densities side A
+  AliTPC3DCylindricalInterpolator* fInterpolatorInverseChargeC = nullptr; //!<! interpolator for inverse charge densities side C
 
   AliTPCLookUpTable3DInterpolatorD* fLookupIntDistA = nullptr;                   //-> look-up table for global distortion side A
   AliTPCLookUpTable3DInterpolatorD* fLookupIntCorrA = nullptr;                   //-> look-up table for global correction side A
   AliTPCLookUpTable3DInterpolatorD* fLookupIntDistC = nullptr;                   //-> look-up table for global distortion side C
   AliTPCLookUpTable3DInterpolatorD* fLookupIntCorrC = nullptr;                   //-> look-up table for global correction side C
-  AliTPCLookUpTable3DInterpolatorIrregularD* fLookupIntCorrIrregularA = nullptr; //-> look-up table for global correction side A (method irregular)
-  AliTPCLookUpTable3DInterpolatorIrregularD* fLookupIntCorrIrregularC = nullptr; //-> look-up table for global correction side C (method irregular)
-  AliTPCLookUpTable3DInterpolatorD* fLookupIntENoDriftA = nullptr;               //-> look-up table for no drift integration side A
-  AliTPCLookUpTable3DInterpolatorD* fLookupIntENoDriftC = nullptr;               //-> look-up table for no drift integration side C
-  AliTPCLookUpTable3DInterpolatorD* fLookupDistA = nullptr;                      //-> look-up table for local distortion side A
-  AliTPCLookUpTable3DInterpolatorD* fLookupDistC = nullptr;                      //-> look-up table for local distortion side C
-  AliTPCLookUpTable3DInterpolatorD* fLookupInverseDistA = nullptr;               //-> look-up table for local distortion (from inverse) side A
-  AliTPCLookUpTable3DInterpolatorD* fLookupInverseDistC = nullptr;               //-> look-up table for local distortion (from inverse) side C
+  AliTPCLookUpTable3DInterpolatorIrregularD* fLookupIntCorrIrregularA = nullptr; //!<! look-up table for global correction side A (method irregular)
+  AliTPCLookUpTable3DInterpolatorIrregularD* fLookupIntCorrIrregularC = nullptr; //!<! look-up table for global correction side C (method irregular)
+  AliTPCLookUpTable3DInterpolatorD* fLookupIntENoDriftA = nullptr;               //!<! look-up table for no drift integration side A
+  AliTPCLookUpTable3DInterpolatorD* fLookupIntENoDriftC = nullptr;               //!<! look-up table for no drift integration side C
+  AliTPCLookUpTable3DInterpolatorD* fLookupDistA = nullptr;                      //!<! look-up table for local distortion side A
+  AliTPCLookUpTable3DInterpolatorD* fLookupDistC = nullptr;                      //!<! look-up table for local distortion side C
+  AliTPCLookUpTable3DInterpolatorD* fLookupInverseDistA = nullptr;               //!<! look-up table for local distortion (from inverse) side A
+  AliTPCLookUpTable3DInterpolatorD* fLookupInverseDistC = nullptr;               //!<! look-up table for local distortion (from inverse) side C
 
-  AliTPCLookUpTable3DInterpolatorD* fLookupElectricFieldA = nullptr; //-> look-up table for electric field side A
-  AliTPCLookUpTable3DInterpolatorD* fLookupElectricFieldC = nullptr; //-> look-up table for electric field side C
+  AliTPCLookUpTable3DInterpolatorD* fLookupElectricFieldA = nullptr; //!<! look-up table for electric field side A
+  AliTPCLookUpTable3DInterpolatorD* fLookupElectricFieldC = nullptr; //!<! look-up table for electric field side C
 
   TH3* fHistogram3DSpaceCharge = nullptr;  //!<! Histogram with the input space charge histogram - used as an optional input
   TH3* fHistogram3DSpaceChargeA = nullptr; //!<! Histogram with the input space charge histogram - used as an optional input side A
@@ -358,7 +357,7 @@ class AliTPCSpaceCharge3DCalc
   TFormula* fFormulaEr = nullptr;   //!<! er Er(r,rho,z) electric field (r) function
   TFormula* fFormulaEz = nullptr;   //!<! ez Ez(r,rho,z) electric field (z) function
 
-  AliTPCPoissonSolver* fPoissonSolver = nullptr; //-> Pointer to a poisson solver
+  AliTPCPoissonSolver* fPoissonSolver = nullptr; //!<! Pointer to a poisson solver
 
   void ElectricField(TMatrixD** matricesV, TMatrixD** matricesEr, TMatrixD** matricesEPhi, TMatrixD** matricesEz,
                      const Int_t nRRow, const Int_t nZColumn, const Int_t phiSlices, const Float_t gridSizeR,


### PR DESCRIPTION
**Changes in AliTPCSpaceCharge3DCalc:**
1) Update calculation of local r and rphi distortions by deltaEz (significant for RUN 3 scenarios). 

2) Only stream data members which are relevant for simulation with constant distortions to reduce file size.