### PR TITLE
Enhancing error message

### DIFF
--- a/Framework/Core/src/DataRelayer.cxx
+++ b/Framework/Core/src/DataRelayer.cxx
@@ -24,6 +24,7 @@
 #include <Monitoring/Monitoring.h>
 
 #include <gsl/span>
+#include <string>
 
 using namespace o2::framework::data_matcher;
 using DataHeader = o2::header::DataHeader;
@@ -360,15 +361,26 @@ DataRelayer::RelayChoice
   VariableContext pristineContext;
   std::tie(input, timeslice) = getInputTimeslice(pristineContext);
 
+  auto DataHeaderInfo = [&header]() {
+    std::string error;
+    const auto* dh = o2::header::get<o2::header::DataHeader*>(header->GetData());
+    if (dh) {
+      error += dh->dataOrigin.as<std::string>() + "/" + dh->dataDescription.as<std::string>() + "/" + dh->subSpecification;
+    } else {
+      error += "invalid header";
+    }
+    return error;
+  };
+
   if (input == INVALID_INPUT) {
-    LOG(ERROR) << "Could not match incoming data to any input";
+    LOG(ERROR) << "Could not match incoming data to any input route: " << DataHeaderInfo();
     mStats.malformedInputs++;
     mStats.droppedIncomingMessages++;
     return WillNotRelay;
   }
 
   if (TimesliceId::isValid(timeslice) == false) {
-    LOG(ERROR) << "Could not determine the timeslice for input";
+    LOG(ERROR) << "Could not determine the timeslice for input: " << DataHeaderInfo();
     mStats.malformedInputs++;
     mStats.droppedIncomingMessages++;
     return WillNotRelay;


### PR DESCRIPTION
The DataHeader info is added to the error message in case the data can
not be relayed.