### PR TITLE
Merging of split payload data, matching to output channel

### DIFF
--- a/Framework/Core/src/DataSamplingReadoutAdapter.cxx
+++ b/Framework/Core/src/DataSamplingReadoutAdapter.cxx
@@ -21,7 +21,7 @@ using DataHeader = o2::header::DataHeader;
 
 InjectorFunction dataSamplingReadoutAdapter(OutputSpec const& spec)
 {
-  return [spec](FairMQDevice& device, FairMQParts& parts, ChannelRetreiver channelRetreiver) {
+  return [spec](FairMQDevice& device, FairMQParts& parts, ChannelRetriever channelRetriever) {
     for (size_t i = 0; i < parts.Size() / 2; ++i) {
 
       auto dbh = reinterpret_cast<DataBlockHeaderBase*>(parts.At(2 * i)->GetData());
@@ -37,7 +37,7 @@ InjectorFunction dataSamplingReadoutAdapter(OutputSpec const& spec)
 
       DataProcessingHeader dph{dbh->blockId, 0};
       o2::header::Stack headerStack{dh, dph};
-      sendOnChannel(device, std::move(headerStack), std::move(parts.At(2 * i + 1)), spec, channelRetreiver);
+      sendOnChannel(device, std::move(headerStack), std::move(parts.At(2 * i + 1)), spec, channelRetriever);
     }
   };
 }

--- a/Framework/Core/src/ReadoutAdapter.cxx
+++ b/Framework/Core/src/ReadoutAdapter.cxx
@@ -26,7 +26,7 @@ InjectorFunction readoutAdapter(OutputSpec const& spec)
 {
   auto counter = std::make_shared<uint64_t>(0);
 
-  return [spec, counter](FairMQDevice& device, FairMQParts& parts, ChannelRetreiver channelRetreiver) {
+  return [spec, counter](FairMQDevice& device, FairMQParts& parts, ChannelRetriever channelRetriever) {
     for (size_t i = 0; i < parts.Size(); ++i) {
       DataHeader dh;
       // FIXME: this will have to change and extract the actual subspec from
@@ -41,7 +41,7 @@ InjectorFunction readoutAdapter(OutputSpec const& spec)
       DataProcessingHeader dph{*counter, 0};
       (*counter) += 1UL;
       o2::header::Stack headerStack{dh, dph};
-      sendOnChannel(device, std::move(headerStack), std::move(parts.At(i)), spec, channelRetreiver);
+      sendOnChannel(device, std::move(headerStack), std::move(parts.At(i)), spec, channelRetriever);
     }
   };
 }

--- a/Framework/TestWorkflows/src/flpQualification.cxx
+++ b/Framework/TestWorkflows/src/flpQualification.cxx
@@ -95,7 +95,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
     "readout-proxy",
     Outputs{{"ITS", "RAWDATA"}},
     "type=pair,method=connect,address=ipc:///tmp/readout-pipe-0,rateLogging=1,transport=shmem",
-    inputType == "readout" ? readoutAdapter({"ITS", "RAWDATA"}) : dplModelAdaptor({"ITS", "RAWDATA"}));
+    inputType == "readout" ? readoutAdapter({"ITS", "RAWDATA"}) : dplModelAdaptor({{"ITS", "RAWDATA"}}));
 
   // This is an example of how we can parallelize by subSpec.
   // templatedProcessor will be instanciated N times and the lambda function


### PR DESCRIPTION
Several changes to the ExternalFairMQDeviceProxy
- using OutputSpec as filter list in dplModelAdaptor
- matching the output channel to the actual data header
- Implementing merging of split payload data and association to correct output channel

- [ ] would like to have a unit test for the integrity of the merged data