### PR TITLE
Add Readout frame records for MID

### DIFF
--- a/DataFormats/Detectors/MUON/MID/CMakeLists.txt
+++ b/DataFormats/Detectors/MUON/MID/CMakeLists.txt
@@ -10,10 +10,12 @@
 
 o2_add_library(DataFormatsMID
                SOURCES src/ColumnData.cxx src/Track.cxx
-               PUBLIC_LINK_LIBRARIES Boost::serialization O2::MathUtils)
+               PUBLIC_LINK_LIBRARIES Boost::serialization O2::MathUtils
+                                     O2::ReconstructionDataFormats)
 
 o2_target_root_dictionary(DataFormatsMID
                           HEADERS include/DataFormatsMID/Cluster2D.h
                                   include/DataFormatsMID/Cluster3D.h
                                   include/DataFormatsMID/ColumnData.h
+                                  include/DataFormatsMID/ROFRecord.h
                                   include/DataFormatsMID/Track.h)

--- a/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/ROFRecord.h
+++ b/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/ROFRecord.h
@@ -1,0 +1,50 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   DataFormatsMID/ROFRecord.h
+/// \brief  Definition of the MID event record
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   13 October 2019
+
+#ifndef ALICEO2_MID_ROFRECORD_H
+#define ALICEO2_MID_ROFRECORD_H
+
+#include "CommonDataFormat/InteractionRecord.h"
+
+namespace o2
+{
+namespace mid
+{
+
+enum class EventType {
+  Standard = 0,
+  Noise = 1,
+  Dead = 2
+};
+
+/// ROFRecord class encodes the trigger interaction record of given ROF and
+/// the reference on the 1st object (digit, cluster etc) of this ROF in the data tree
+struct ROFRecord {
+  o2::InteractionRecord interactionRecord{}; //< Interaction record
+  EventType eventType{EventType::Standard};  //< Event type
+  size_t firstEntry{0};                      //< First associated entry
+  size_t nEntries{0};                        //< Number of associated entries
+
+  ROFRecord() = default;
+  ROFRecord(const o2::InteractionRecord& intRecord, const EventType& evtType, size_t first, size_t nElements) : interactionRecord(intRecord), eventType(evtType), firstEntry(first), nEntries(nElements) {}
+  ROFRecord(const ROFRecord& other, size_t first, size_t nElements) : interactionRecord(other.interactionRecord), eventType(other.eventType), firstEntry(first), nEntries(nElements) {}
+
+  ClassDefNV(ROFRecord, 1);
+};
+
+} // namespace mid
+} // namespace o2
+
+#endif

--- a/DataFormats/Detectors/MUON/MID/src/DataFormatsMIDLinkDef.h
+++ b/DataFormats/Detectors/MUON/MID/src/DataFormatsMIDLinkDef.h
@@ -16,8 +16,10 @@
 
 #pragma link C++ struct o2::mid::Cluster2D + ;
 #pragma link C++ struct o2::mid::Cluster3D + ;
-#pragma link C++ struct o2::mid::ColumnData + ;
-#pragma link C++ class std::vector < o2::mid::ColumnData> + ;
+#pragma link C++ struct o2::mid::ColumnData + ;               // This is needed for the derived classes
+#pragma link C++ class std::vector < o2::mid::ColumnData > +; // This is needed for the derived classes
+#pragma link C++ struct o2::mid::ROFRecord + ;
+#pragma link C++ class std::vector < o2::mid::ROFRecord > +;
 #pragma link C++ struct o2::mid::Track + ;
 
 #endif

--- a/Steer/DigitizerWorkflow/src/MIDDigitWriterSpec.h
+++ b/Steer/DigitizerWorkflow/src/MIDDigitWriterSpec.h
@@ -16,6 +16,7 @@
 #include "DPLUtils/MakeRootTreeWriterSpec.h"
 #include "Framework/InputSpec.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
+#include "DataFormatsMID/ROFRecord.h"
 #include "MIDSimulation/ColumnDataMC.h"
 #include "MIDSimulation/MCLabel.h"
 
@@ -35,10 +36,9 @@ o2::framework::DataProcessorSpec getMIDDigitWriterSpec()
                                 "middigits.root",
                                 "o2sim",
                                 1,
-                                BranchDefinition<std::vector<o2::mid::ColumnDataMC>>{InputSpec{"middigits", "MID", "DIGITS"}, "MIDDigit"},
-                                BranchDefinition<o2::dataformats::MCTruthContainer<o2::mid::MCLabel>>{InputSpec{"middigitlabels", "MID", "DIGITSMC"}, "MIDDigitMCLabels"}
-                                // add more branch definitions (for example Monte Carlo labels here)
-                                )();
+                                BranchDefinition<std::vector<ColumnDataMC>>{InputSpec{"middigits", "MID", "DIGITS"}, "MIDDigit"},
+                                BranchDefinition<std::vector<ROFRecord>>{InputSpec{"midrofrecords", "MID", "DIGITSROF"}, "MIDROFRecords"},
+                                BranchDefinition<o2::dataformats::MCTruthContainer<MCLabel>>{InputSpec{"middigitlabels", "MID", "DIGITLABELS"}, "MIDDigitMCLabels"})();
 }
 
 } // namespace mid


### PR DESCRIPTION
This is the first of a series of PR, whose aim is to allow MID to handle timeframes.
Currently, the MID processors expect objects with the same timestamp within a timeframe as input. This makes it difficult to correctly treat a full timeframe.
The objects with the same timestamp will be therefore referenced with the aim of a ROFRecord.
The following commits are atomic, so please do not squash them.