### PR TITLE
Add DPL_TESTS_BATCH_MODE cmake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,11 @@ o2_define_rpath()
 # External dependencies
 include(dependencies/CMakeLists.txt)
 
+# This is needed because CI might not have X11 or Cocoa available
+if (DPL_TESTS_BATCH_MODE)
+  set(DPL_WORKFLOW_TESTS_EXTRA_OPTIONS -b)
+endif()
+
 # include macros and functions that are used in the following subdirectories'
 # CMakeLists.txt
 include(O2AddExecutable)

--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -272,7 +272,7 @@ foreach(w
               PUBLIC_LINK_LIBRARIES O2::Framework
               TIMEOUT 30
               NO_BOOST_TEST
-              COMMAND_LINE_ARGS --run)
+              COMMAND_LINE_ARGS ${DPL_WORKFLOW_TESTS_EXTRA_OPTIONS} --run)
 endforeach()
 
 # TODO: DanglingInput test not working for the moment [ERROR] Unable to relay
@@ -300,7 +300,7 @@ o2_add_test(
   PUBLIC_LINK_LIBRARIES O2::Framework
   NO_BOOST_TEST
   COMMAND_LINE_ARGS
-    --global-config require-me --run
+    --global-config require-me --run ${DPL_WORKFLOW_TESTS_EXTRA_OPTIONS}
     # Note: the group switch makes process consumer parse only the group
     arguments --consumer
     "--global-config consumer-config --local-option hello-aliceo2 --a-boolean3 --an-int2 20 --a-double2 22."

--- a/Framework/Utils/CMakeLists.txt
+++ b/Framework/Utils/CMakeLists.txt
@@ -45,11 +45,11 @@ o2_add_test(RootTreeWriterWorkflow
             PUBLIC_LINK_LIBRARIES O2::DPLUtils
             COMPONENT_NAME DPLUtils
             LABELS dplutils
-            COMMAND_LINE_ARGS --run)
+            COMMAND_LINE_ARGS ${DPL_WORKFLOW_TESTS_EXTRA_OPTIONS} --run)
 
 o2_add_test(RootTreeReader
             SOURCES test/test_RootTreeReader.cxx
             PUBLIC_LINK_LIBRARIES O2::DPLUtils
             COMPONENT_NAME DPLUtils
             LABELS dplutils
-            COMMAND_LINE_ARGS --run)
+            COMMAND_LINE_ARGS ${DPL_WORKFLOW_TESTS_EXTRA_OPTIONS} --run)


### PR DESCRIPTION
Used to turn off GUI when running tests non-interactively (e.g. in CI).