### PR TITLE
ITS vertexer: Add CPU serial transcription of GPU vertexfinder

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/ClusterLines.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/ClusterLines.h
@@ -176,6 +176,7 @@ class ClusterLines final
  public:
   ClusterLines(const int firstLabel, const Line& firstLine, const int secondLabel, const Line& secondLine,
                const bool weight = false);
+  ClusterLines(const Line& firstLine, const Line& secondLine);
   void add(const int& lineLabel, const Line& line, const bool& weight = false);
   void computeClusterCentroid();
   inline std::vector<int>& getLabels() { return mLabels; }

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
@@ -131,9 +131,20 @@ struct VertexerStoreConfigurationGPU {
   int processedTrackletsCapacity = maxTrackletsPerCluster * clustersPerLayerCapacity;
   int maxTrackletCapacity = 2e4;
   int maxCentroidsXYCapacity = std::ceil(maxTrackletCapacity * (maxTrackletCapacity - 1) / 2);
-  int nBinsXYZ[3] = {402, 402, 2002};
-  int binSpanXYZ[3] = {1, 1, 1};
   int nMaxVertices = 10;
+  int nBinsXYZ[3] = {402, 402, 2002};
+  // int nBinsXYZ[3] = {5, 5, 2002};
+  int binSpanXYZ[3] = {1, 1, 1};
+  float lowHistBoundariesXYZ[3] = {-1.98f, -1.98f, -40.f};
+  float highHistBoundariesXYZ[3] = {1.98f, 1.98f, 40.f};
+  float binSizeHistX = (highHistBoundariesXYZ[0] - lowHistBoundariesXYZ[0]) / (nBinsXYZ[0] - 1);
+  float binSizeHistY = (highHistBoundariesXYZ[1] - lowHistBoundariesXYZ[1]) / (nBinsXYZ[1] - 1);
+  float binSizeHistZ = (highHistBoundariesXYZ[2] - lowHistBoundariesXYZ[2]) / (nBinsXYZ[2] - 1);
+};
+
+struct VertexerHistogramsConfiguration {
+  int nBinsXYZ[3] = {402, 402, 2002};
+  int binSpanXYZ[3] = {2, 2, 1};
   float lowHistBoundariesXYZ[3] = {-1.98f, -1.98f, -40.f};
   float highHistBoundariesXYZ[3] = {1.98f, 1.98f, 40.f};
   float binSizeHistX = (highHistBoundariesXYZ[0] - lowHistBoundariesXYZ[0]) / (nBinsXYZ[0] - 1);

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Vertexer.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Vertexer.h
@@ -65,6 +65,7 @@ class Vertexer
 
   void findTrivialMCTracklets();
   void findVertices();
+  void findHistVertices();
 
   template <typename... T>
   void initialiseVertexer(T&&... args);

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
@@ -111,6 +111,7 @@ class VertexerTraits
 #endif
   virtual void computeTrackletsPureMontecarlo();
   virtual void computeVertices();
+  virtual void computeHistVertices();
 
   void updateVertexingParameters(const VertexingParameters& vrtPar);
   VertexingParameters getVertexingParameters() const { return mVrtParams; }

--- a/Detectors/ITSMFT/ITS/tracking/src/ClusterLines.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/ClusterLines.cxx
@@ -173,6 +173,93 @@ ClusterLines::ClusterLines(const int firstLabel, const Line& firstLine, const in
   mAvgDistance2 += (Line::getDistanceFromPoint(secondLine, mVertex) * Line::getDistanceFromPoint(secondLine, mVertex) - mAvgDistance2) / mLabels.size();
 }
 
+ClusterLines::ClusterLines(const Line& firstLine, const Line& secondLine)
+{
+
+  std::array<float, 3> covarianceFirst{1., 1., 1.};
+  std::array<float, 3> covarianceSecond{1., 1., 1.};
+
+  for (int i{0}; i < 6; ++i)
+    mWeightMatrix[i] = firstLine.weightMatrix[i] + secondLine.weightMatrix[i];
+
+  float determinantFirst =
+    firstLine.cosinesDirector[2] * firstLine.cosinesDirector[2] * covarianceFirst[0] * covarianceFirst[1] +
+    firstLine.cosinesDirector[1] * firstLine.cosinesDirector[1] * covarianceFirst[0] * covarianceFirst[2] +
+    firstLine.cosinesDirector[0] * firstLine.cosinesDirector[0] * covarianceFirst[1] * covarianceFirst[2];
+  float determinantSecond =
+    secondLine.cosinesDirector[2] * secondLine.cosinesDirector[2] * covarianceSecond[0] * covarianceSecond[1] +
+    secondLine.cosinesDirector[1] * secondLine.cosinesDirector[1] * covarianceSecond[0] * covarianceSecond[2] +
+    secondLine.cosinesDirector[0] * secondLine.cosinesDirector[0] * covarianceSecond[1] * covarianceSecond[2];
+
+  mAMatrix[0] = (firstLine.cosinesDirector[2] * firstLine.cosinesDirector[2] * covarianceFirst[1] +
+                 firstLine.cosinesDirector[1] * firstLine.cosinesDirector[1] * covarianceFirst[2]) /
+                  determinantFirst +
+                (secondLine.cosinesDirector[2] * secondLine.cosinesDirector[2] * covarianceSecond[1] +
+                 secondLine.cosinesDirector[1] * secondLine.cosinesDirector[1] * covarianceSecond[2]) /
+                  determinantSecond;
+
+  mAMatrix[1] = -firstLine.cosinesDirector[0] * firstLine.cosinesDirector[1] * covarianceFirst[2] / determinantFirst -
+                secondLine.cosinesDirector[0] * secondLine.cosinesDirector[1] * covarianceSecond[2] / determinantSecond;
+
+  mAMatrix[2] = -firstLine.cosinesDirector[0] * firstLine.cosinesDirector[2] * covarianceFirst[1] / determinantFirst -
+                secondLine.cosinesDirector[0] * secondLine.cosinesDirector[2] * covarianceSecond[1] / determinantSecond;
+
+  mAMatrix[3] = (firstLine.cosinesDirector[2] * firstLine.cosinesDirector[2] * covarianceFirst[0] +
+                 firstLine.cosinesDirector[0] * firstLine.cosinesDirector[0] * covarianceFirst[2]) /
+                  determinantFirst +
+                (secondLine.cosinesDirector[2] * secondLine.cosinesDirector[2] * covarianceSecond[0] +
+                 secondLine.cosinesDirector[0] * secondLine.cosinesDirector[0] * covarianceSecond[2]) /
+                  determinantSecond;
+
+  mAMatrix[4] = -firstLine.cosinesDirector[1] * firstLine.cosinesDirector[2] * covarianceFirst[0] / determinantFirst -
+                secondLine.cosinesDirector[1] * secondLine.cosinesDirector[2] * covarianceSecond[0] / determinantSecond;
+
+  mAMatrix[5] = (firstLine.cosinesDirector[1] * firstLine.cosinesDirector[1] * covarianceFirst[0] +
+                 firstLine.cosinesDirector[0] * firstLine.cosinesDirector[0] * covarianceFirst[1]) /
+                  determinantFirst +
+                (secondLine.cosinesDirector[1] * secondLine.cosinesDirector[1] * covarianceSecond[0] +
+                 secondLine.cosinesDirector[0] * secondLine.cosinesDirector[0] * covarianceSecond[1]) /
+                  determinantSecond;
+
+  mBMatrix[0] =
+    (firstLine.cosinesDirector[1] * covarianceFirst[2] * (-firstLine.cosinesDirector[1] * firstLine.originPoint[0] + firstLine.cosinesDirector[0] * firstLine.originPoint[1]) +
+     firstLine.cosinesDirector[2] * covarianceFirst[1] * (-firstLine.cosinesDirector[2] * firstLine.originPoint[0] + firstLine.cosinesDirector[0] * firstLine.originPoint[2])) /
+    determinantFirst;
+
+  mBMatrix[0] +=
+    (secondLine.cosinesDirector[1] * covarianceSecond[2] * (-secondLine.cosinesDirector[1] * secondLine.originPoint[0] + secondLine.cosinesDirector[0] * secondLine.originPoint[1]) +
+     secondLine.cosinesDirector[2] * covarianceSecond[1] *
+       (-secondLine.cosinesDirector[2] * secondLine.originPoint[0] +
+        secondLine.cosinesDirector[0] * secondLine.originPoint[2])) /
+    determinantSecond;
+
+  mBMatrix[1] =
+    (firstLine.cosinesDirector[0] * covarianceFirst[2] * (-firstLine.cosinesDirector[0] * firstLine.originPoint[1] + firstLine.cosinesDirector[1] * firstLine.originPoint[0]) +
+     firstLine.cosinesDirector[2] * covarianceFirst[0] * (-firstLine.cosinesDirector[2] * firstLine.originPoint[1] + firstLine.cosinesDirector[1] * firstLine.originPoint[2])) /
+    determinantFirst;
+
+  mBMatrix[1] +=
+    (secondLine.cosinesDirector[0] * covarianceSecond[2] * (-secondLine.cosinesDirector[0] * secondLine.originPoint[1] + secondLine.cosinesDirector[1] * secondLine.originPoint[0]) +
+     secondLine.cosinesDirector[2] * covarianceSecond[0] *
+       (-secondLine.cosinesDirector[2] * secondLine.originPoint[1] +
+        secondLine.cosinesDirector[1] * secondLine.originPoint[2])) /
+    determinantSecond;
+
+  mBMatrix[2] =
+    (firstLine.cosinesDirector[0] * covarianceFirst[1] * (-firstLine.cosinesDirector[0] * firstLine.originPoint[2] + firstLine.cosinesDirector[2] * firstLine.originPoint[0]) +
+     firstLine.cosinesDirector[1] * covarianceFirst[0] * (-firstLine.cosinesDirector[1] * firstLine.originPoint[2] + firstLine.cosinesDirector[2] * firstLine.originPoint[1])) /
+    determinantFirst;
+
+  mBMatrix[2] +=
+    (secondLine.cosinesDirector[0] * covarianceSecond[1] * (-secondLine.cosinesDirector[0] * secondLine.originPoint[2] + secondLine.cosinesDirector[2] * secondLine.originPoint[0]) +
+     secondLine.cosinesDirector[1] * covarianceSecond[0] *
+       (-secondLine.cosinesDirector[1] * secondLine.originPoint[2] +
+        secondLine.cosinesDirector[2] * secondLine.originPoint[1])) /
+    determinantSecond;
+
+  computeClusterCentroid();
+}
+
 void ClusterLines::add(const int& lineLabel, const Line& line, const bool& weight)
 {
   mLabels.push_back(lineLabel);

--- a/Detectors/ITSMFT/ITS/tracking/src/Vertexer.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Vertexer.cxx
@@ -51,5 +51,10 @@ void Vertexer::findVertices()
   mTraits->computeVertices();
 }
 
+void Vertexer::findHistVertices()
+{
+  mTraits->computeHistVertices();
+}
+
 } // namespace its
 } // namespace o2

--- a/macro/run_primary_vertexer_ITS.C
+++ b/macro/run_primary_vertexer_ITS.C
@@ -147,6 +147,8 @@ int run_primary_vertexer_ITS(const bool useGPU = false,
     }
 #endif
     total[2] = vertexer.evaluateTask(&o2::its::Vertexer::validateTracklets, "Adjacent tracklets validation", std::cout);
+    // In case willing to use the histogram-based vertexer
+    // total[3] = vertexer.evaluateTask(&o2::its::Vertexer::findHistVertices, "Vertex finding with histograms", std::cout);
     total[3] = vertexer.evaluateTask(&o2::its::Vertexer::findVertices, "Vertex finding", std::cout);
 
     std::vector<Vertex> vertITS = vertexer.exportVertices();


### PR DESCRIPTION
@iouribelikov  @shahor02 
Here there is the equivalent on CPU of the algorithm used for vertex finding on GPU
Notably:
 - Found a major bug in histogram filling for GPU: fixed (nice to have a comparison on CPU already)
 - It's based on `boost::histogram`s, which are nice but not perfect. Best performances will be likely achieved as if we are going to bump our O2 boost version to 1.71.x. At the moment no `std::max_element(boost::histogram::indexed(myHistogram))` is available due to input iterator vs forward iterator implementation on boost side. (see https://github.com/boostorg/histogram/issues/198) so I had to implement my "find max" logic.

A part form that it is consistent with the GPU implementation. Cross-tests, tuning/improvements and benchmarks of this algorithm are yet to come. 
Then we will decide which algorithm is going to survive on CPU.