### PR TITLE
 Adding DPL raw proxy utility

### DIFF
--- a/Framework/Core/include/Framework/DataSpecUtils.h
+++ b/Framework/Core/include/Framework/DataSpecUtils.h
@@ -150,6 +150,14 @@ struct DataSpecUtils {
   /// and we can add corner cases as we go.
   static header::DataOrigin asConcreteOrigin(InputSpec const& spec);
 
+  /// If possible extract either ConcreteTypeDataMatcher or ConcreteDataMatcher
+  /// from an InputSpec and assign it to the matcher of the OutputSpec together
+  /// with binding and lifetime
+  /// If InputSpec holds a ConcreteDataMatcher, this will be used directly, if it
+  /// is a DataDescriptorMatcher, depending on its complexity the ConcreteDataMatcher
+  /// or ConcreteTypeDataMatcher will be created
+  static OutputSpec asOutputSpec(InputSpec const& spec);
+
   /// Create an InputSpec which is able to match all the outputs of the given
   /// OutputSpec
   static InputSpec matchingInput(OutputSpec const& spec);

--- a/Framework/Core/include/Framework/ExternalFairMQDeviceProxy.h
+++ b/Framework/Core/include/Framework/ExternalFairMQDeviceProxy.h
@@ -48,7 +48,8 @@ InjectorFunction o2DataModelAdaptor(OutputSpec const& spec, uint64_t startTime, 
 /// expects it, i.e. with the DataProcessingHeader in the header stack
 /// The list of specs is used as a filter list, all incoming data matching an entry
 /// in the list will be send through the corresponding channel
-InjectorFunction dplModelAdaptor(std::vector<OutputSpec> const& specs = {{header::gDataOriginAny, header::gDataDescriptionAny}});
+InjectorFunction dplModelAdaptor(std::vector<OutputSpec> const& specs = {{header::gDataOriginAny, header::gDataDescriptionAny}},
+                                 bool throwOnUnmatchedInputs = false);
 
 /// The default connection method for the custom source
 static auto gDefaultConverter = incrementalConverter(OutputSpec{"TST", "TEST", 0}, 0, 1);

--- a/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
+++ b/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
@@ -169,9 +169,9 @@ FairMQMessagePtr mergePayloads(FairMQDevice& device, FairMQParts& parts, std::ve
   return message;
 }
 
-InjectorFunction dplModelAdaptor(std::vector<OutputSpec> const& filterSpecs)
+InjectorFunction dplModelAdaptor(std::vector<OutputSpec> const& filterSpecs, bool throwOnUnmatchedInputs)
 {
-  return [filterSpecs = std::move(filterSpecs)](FairMQDevice& device, FairMQParts& parts, ChannelRetriever channelRetriever) {
+  return [filterSpecs = std::move(filterSpecs), throwOnUnmatchedInputs](FairMQDevice& device, FairMQParts& parts, ChannelRetriever channelRetriever) {
     std::unordered_map<std::string, FairMQParts> outputs;
     std::vector<bool> indicesDone(parts.Size() / 2, false);
     for (size_t i = 0; i < parts.Size() / 2; ++i) {
@@ -215,6 +215,8 @@ InjectorFunction dplModelAdaptor(std::vector<OutputSpec> const& filterSpecs)
           }
           indicesDone[i] = true;
           break;
+        } else if (throwOnUnmatchedInputs) {
+          throw std::runtime_error("no matching filter rule for input data " + DataSpecUtils::describe(query));
         }
       }
     }

--- a/Framework/Utils/CMakeLists.txt
+++ b/Framework/Utils/CMakeLists.txt
@@ -18,6 +18,11 @@ o2_add_library(DPLUtils
                        test/DPLOutputTest.cxx
                PUBLIC_LINK_LIBRARIES O2::Framework)
 
+o2_add_executable(raw-proxy
+                  COMPONENT_NAME dpl
+                  SOURCES src/raw-proxy.cxx
+                  PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils)
+
 o2_add_test(DPLBroadcasterMerger
             SOURCES test/test_DPLBroadcasterMerger.cxx src/Utils.cxx
                     test/DPLBroadcasterMerger.cxx src/DPLMerger.cxx

--- a/Framework/Utils/Readme.md
+++ b/Framework/Utils/Readme.md
@@ -1,0 +1,61 @@
+## DPL Utilities
+
+### Raw proxy
+Executable:
+```
+o2-dpl-raw-proxy
+```
+
+A proxy workflow to connect to a channel from DataDistribution. The incoming
+data is supposed to follow the O2 data model with header-payload pair messages.
+The header message must contain `DataHeader` and the internal DPL `DataProcessingHeader`.
+Only data which match the configured outputs will be forwarded.
+
+Since payload can be split into several messages, the proxy will create a new
+message to merge all parts belonging to one payload entity.
+
+#### Usage:
+```
+o2-dpl-raw-proxy --dataspec "0:FLP/RAWDATA" --channel-config "name=readout-proxy,type=pair,method=bind,address=ipc:///tmp/stf-builder-dpl-pipe-0,transport=shmem,rateLogging=1"
+```
+
+Options:
+```
+  --dataspec arg (=A:FLP/RAWDATA;B:FLP/DISTSUBTIMEFRAME/0)
+                                        selection string for the data to be 
+                                        proxied
+  --throwOnUnmatched                    throw if unmatched input data is found
+```
+
+Data is selected by using a configuration string of the format
+`tag1:origin/description/subspec;tag2:...`, the tags are arbitrary and only
+for internal reasons and are ignored.
+Example:
+```
+--dataspec 'A:FLP/RAWDATA;B:FLP/DISTSUBTIMEFRAME/0'
+```
+
+The input channel has name `readout-proxy` and is configured with option `--channel-config`.
+
+By default, data blocks not matching the configured filter/output spec will be silently
+ignored. Use `--throwOnUnmatched` to apply a strict checking in order to indicate unmatched
+data.
+
+#### Connection to workflows
+The proxy workflow only defines the proxy process, workflows can be combined by piping them
+together om the command line
+```
+o2-dpl-raw-proxy --dataspec "0:FLP/RAWDATA" --channel-config "..." | the-subscribing-workflow
+```
+
+#### TODO:
+- stress test with data not following the O2 data model
+- forwarding of shared memory messages
+- vector handling of split payload parts in DPL
+- make the channel config more convenient, do not require the full string and use
+  defaults, e.g. for the name (which can not be changed anyhow)
+- check if the channel config string can be parsed omitting tags, right now this
+  is only possible for the first entry
+
+### ROOT Tree reader and writer
+documentation to be filled

--- a/Framework/Utils/src/raw-proxy.cxx
+++ b/Framework/Utils/src/raw-proxy.cxx
@@ -1,0 +1,57 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/WorkflowSpec.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/DataSpecUtils.h"
+#include "Framework/ControlService.h"
+#include "Framework/Logger.h"
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/ExternalFairMQDeviceProxy.h"
+#include <vector>
+
+using namespace o2::framework;
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  workflowOptions.push_back(
+    ConfigParamSpec{
+      "dataspec", VariantType::String, "A:FLP/RAWDATA;B:FLP/DISTSUBTIMEFRAME/0", {"selection string for the data to be proxied"}});
+
+  workflowOptions.push_back(
+    ConfigParamSpec{
+      "throwOnUnmatched", VariantType::Bool, false, {"throw if unmatched input data is found"}});
+}
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& config)
+{
+  std::string outputconfig = config.options().get<std::string>("dataspec");
+  bool throwOnUnmatched = config.options().get<bool>("throwOnUnmatched");
+  std::vector<InputSpec> matchers = select(outputconfig.c_str());
+  Outputs readoutProxyOutput;
+  for (auto const& matcher : matchers) {
+    readoutProxyOutput.emplace_back(DataSpecUtils::asOutputSpec(matcher));
+  }
+
+  // we use the same specs as filters in the dpl adaptor
+  auto filterSpecs = readoutProxyOutput;
+  DataProcessorSpec readoutProxy = specifyExternalFairMQDeviceProxy(
+    "readout-proxy",
+    std::move(readoutProxyOutput),
+    "type=pair,method=connect,address=ipc:///tmp/readout-pipe-0,rateLogging=1,transport=shmem",
+    dplModelAdaptor(filterSpecs, throwOnUnmatched));
+
+  WorkflowSpec workflow;
+  workflow.emplace_back(readoutProxy);
+  return workflow;
+}


### PR DESCRIPTION
Executable:
    `o2-dpl-raw-proxy`

A proxy workflow to connect to a channel from DataDistribution. The incoming
data is supposed to follow the O2 data model with header-payload pair messages.
The header message must contain `DataHeader` and the internal DPL `DataProcessingHeader`.
Only data which match the configured outputs will be forwarded.

Since payload can be split into several messages, the proxy will create a new
message to merge all parts belonging to one payload entity.