### PR TITLE
DPL: improve resource management

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -36,6 +36,7 @@ o2_add_library(Framework
                        src/CommonDataProcessors.cxx
                        src/CompletionPolicy.cxx
                        src/CompletionPolicyHelpers.cxx
+                       src/ComputingResourceHelpers.cxx
                        src/DispatchPolicy.cxx
                        src/ConfigParamsHelper.cxx
                        src/DDSConfigHelpers.cxx

--- a/Framework/Core/include/Framework/ChannelSpec.h
+++ b/Framework/Core/include/Framework/ChannelSpec.h
@@ -40,6 +40,7 @@ struct InputChannelSpec {
   std::string name;
   enum ChannelType type;
   enum ChannelMethod method;
+  std::string hostname;
   unsigned short port;
 };
 
@@ -52,6 +53,7 @@ struct OutputChannelSpec {
   std::string name;
   enum ChannelType type;
   enum ChannelMethod method;
+  std::string hostname;
   unsigned short port;
   size_t listeners;
 };

--- a/Framework/Core/include/Framework/ComputingResource.h
+++ b/Framework/Core/include/Framework/ComputingResource.h
@@ -1,0 +1,49 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef O2_FRAMEWORK_COMPUTINGRESOURCE_H_
+#define O2_FRAMEWORK_COMPUTINGRESOURCE_H_
+
+#include <string>
+
+namespace o2::framework
+{
+
+struct ComputingOffer {
+  float cpu = 0;
+  float memory = 0;
+  std::string hostname = "";
+  unsigned short startPort = 0;
+  unsigned short rangeSize = 0;
+};
+
+/// A computing resource which can be offered to run a device
+struct ComputingResource {
+  ComputingResource() = default;
+  ComputingResource(ComputingOffer const& offer)
+    : cpu(offer.cpu),
+      memory(offer.memory),
+      hostname(offer.hostname),
+      startPort(offer.startPort),
+      lastPort(offer.startPort),
+      usedPorts(0)
+  {
+  }
+
+  float cpu = 0;
+  float memory = 0;
+  std::string hostname = "";
+  unsigned short startPort = 0;
+  unsigned short lastPort = 0;
+  unsigned short usedPorts = 0;
+};
+
+} // namespace o2::framework
+
+#endif // O2_FRAMEWORK_COMPUTINGRESOURCES_H_

--- a/Framework/Core/include/Framework/DeviceSpec.h
+++ b/Framework/Core/include/Framework/DeviceSpec.h
@@ -11,6 +11,7 @@
 #define FRAMEWORK_DEVICESPEC_H
 
 #include "Framework/WorkflowSpec.h"
+#include "Framework/ComputingResource.h"
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/ChannelSpec.h"
 #include "Framework/ChannelInfo.h"
@@ -54,6 +55,7 @@ struct DeviceSpec {
   /// The completion policy to use for this device.
   CompletionPolicy completionPolicy;
   DispatchPolicy dispatchPolicy;
+  ComputingResource resource;
 };
 
 } // namespace framework

--- a/Framework/Core/src/ChannelSpecHelpers.cxx
+++ b/Framework/Core/src/ChannelSpecHelpers.cxx
@@ -8,13 +8,12 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 #include "ChannelSpecHelpers.h"
+#include <fmt/format.h>
 #include <ostream>
 #include <cassert>
 #include <stdexcept>
 
-namespace o2
-{
-namespace framework
+namespace o2::framework
 {
 
 char const* ChannelSpecHelpers::typeAsString(enum ChannelType type)
@@ -43,9 +42,16 @@ char const* ChannelSpecHelpers::methodAsString(enum ChannelMethod method)
   throw std::runtime_error("Unknown ChannelMethod");
 }
 
-char const* ChannelSpecHelpers::methodAsUrl(enum ChannelMethod method)
+std::string ChannelSpecHelpers::channelUrl(OutputChannelSpec const& channel)
 {
-  return (method == ChannelMethod::Bind ? "tcp://*:%d" : "tcp://127.0.0.1:%d");
+  return channel.method == ChannelMethod::Bind ? fmt::format("tcp://*:{}", channel.port)
+                                               : fmt::format("tcp://{}:{}", channel.hostname, channel.port);
+}
+
+std::string ChannelSpecHelpers::channelUrl(InputChannelSpec const& channel)
+{
+  return channel.method == ChannelMethod::Bind ? fmt::format("tcp://*:{}", channel.port)
+                                               : fmt::format("tcp://{}:{}", channel.hostname, channel.port);
 }
 
 /// Stream operators so that we can use ChannelType with Boost.Test
@@ -62,5 +68,4 @@ std::ostream& operator<<(std::ostream& s, ChannelMethod const& method)
   return s;
 }
 
-} // namespace framework
-} // namespace o2
+} // namespace o2::framework

--- a/Framework/Core/src/ChannelSpecHelpers.h
+++ b/Framework/Core/src/ChannelSpecHelpers.h
@@ -26,10 +26,10 @@ struct ChannelSpecHelpers {
   static char const* typeAsString(enum ChannelType type);
   /// return a ChannelMethod as a lowercase string
   static char const* methodAsString(enum ChannelMethod method);
-  /// return a ChannelMethod as a connection url
-  /// FIXME: currently it only supports tcp://127.0.0.1 and tcp://*, we should
-  ///        have the actual address customizable.
-  static char const* methodAsUrl(enum ChannelMethod method);
+  /// @return a url associated to an InputChannelSpec
+  static std::string channelUrl(InputChannelSpec const&);
+  /// @return a url associated to an OutputChannelSpec
+  static std::string channelUrl(OutputChannelSpec const&);
 };
 
 /// Stream operators so that we can use ChannelType with Boost.Test

--- a/Framework/Core/src/ComputingResourceHelpers.cxx
+++ b/Framework/Core/src/ComputingResourceHelpers.cxx
@@ -1,0 +1,34 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "ComputingResourceHelpers.h"
+#include <thread>
+#include <unistd.h>
+
+namespace o2::framework
+{
+long getTotalNumberOfBytes()
+{
+  long pages = sysconf(_SC_PHYS_PAGES);
+  long page_size = sysconf(_SC_PAGE_SIZE);
+  return pages * page_size;
+};
+
+ComputingResource ComputingResourceHelpers::getLocalhostResource(unsigned short startPort, unsigned short rangeSize)
+{
+  ComputingResource result;
+  result.cpu = std::thread::hardware_concurrency(),
+  result.memory = getTotalNumberOfBytes();
+  result.hostname = "localhost";
+  result.startPort = startPort;
+  result.lastPort = startPort + rangeSize;
+  result.usedPorts = 0;
+  return result;
+}
+} // namespace o2::framework

--- a/Framework/Core/src/ComputingResourceHelpers.h
+++ b/Framework/Core/src/ComputingResourceHelpers.h
@@ -7,25 +7,17 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#ifndef FRAMEWORK_COMPUTINGRESOURCE_H
-#define FRAMEWORK_COMPUTINGRESOURCE_H
 
-#include <string>
+#ifndef O2_FRAMEWORK_COMPUTINGRESOURCEHELPERS_H_
+#define O2_FRAMEWORK_COMPUTINGRESOURCEHELPERS_H_
 
-namespace o2
+#include "Framework/ComputingResource.h"
+
+namespace o2::framework
 {
-namespace framework
-{
-
-/// A computing resource which can be used to run a device.
-struct ComputingResource {
-  float cpu;
-  float memory;
-  std::string hostname;
-  unsigned short port;
+struct ComputingResourceHelpers {
+  static ComputingResource getLocalhostResource(unsigned short startPort, unsigned short rangeSize);
 };
+} // namespace o2::framework
 
-} // namespace framework
-} // namespace o2
-
-#endif // FRAMEWORK_COMPUTINGRESOURCES_H
+#endif // O2_FRAMEWORK_COMPUTINGRESOURCEHELPERS_H_

--- a/Framework/Core/src/DeviceSpecHelpers.h
+++ b/Framework/Core/src/DeviceSpecHelpers.h
@@ -22,7 +22,7 @@
 #include "Framework/AlgorithmSpec.h"
 #include "Framework/ConfigParamSpec.h"
 #include "Framework/OutputRoute.h"
-#include "ComputingResource.h"
+#include "ResourceManager.h"
 #include "DataProcessorInfo.h"
 #include "WorkflowHelpers.h"
 #include <boost/program_options.hpp>
@@ -45,14 +45,14 @@ struct DeviceSpecHelpers {
     std::vector<CompletionPolicy> const& completionPolicies,
     std::vector<DispatchPolicy> const& dispatchPolicies,
     std::vector<DeviceSpec>& devices,
-    std::vector<ComputingResource>& resources);
+    ResourceManager& resourceManager);
 
   static void dataProcessorSpecs2DeviceSpecs(
     const WorkflowSpec& workflow,
     std::vector<ChannelConfigurationPolicy> const& channelPolicies,
     std::vector<CompletionPolicy> const& completionPolicies,
     std::vector<DeviceSpec>& devices,
-    std::vector<ComputingResource>& resources)
+    ResourceManager& resources)
   {
     std::vector<DispatchPolicy> dispatchPolicies = DispatchPolicy::createDefaultPolicies();
     dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, dispatchPolicies, devices, resources);
@@ -76,13 +76,14 @@ struct DeviceSpecHelpers {
     std::vector<DeviceSpec>& devices,
     std::vector<DeviceId>& deviceIndex,
     std::vector<DeviceConnectionId>& connections,
-    std::vector<ComputingResource>& resources,
+    ResourceManager& resourceManager,
     const std::vector<size_t>& outEdgeIndex,
     const std::vector<DeviceConnectionEdge>& logicalEdges,
     const std::vector<EdgeAction>& actions,
     const WorkflowSpec& workflow,
     const std::vector<OutputSpec>& outputs,
-    std::vector<ChannelConfigurationPolicy> const& channelPolicies);
+    std::vector<ChannelConfigurationPolicy> const& channelPolicies,
+    ComputingOffer const& defaultOffer);
 
   /// This takes the list of preprocessed edges of a graph
   /// and creates Devices and Channels which are related
@@ -91,14 +92,15 @@ struct DeviceSpecHelpers {
   static void processInEdgeActions(
     std::vector<DeviceSpec>& devices,
     std::vector<DeviceId>& deviceIndex,
-    std::vector<ComputingResource>& resources,
     const std::vector<DeviceConnectionId>& connections,
+    ResourceManager& resourceManager,
     const std::vector<size_t>& inEdgeIndex,
     const std::vector<DeviceConnectionEdge>& logicalEdges,
     const std::vector<EdgeAction>& actions,
     const WorkflowSpec& workflow,
     const std::vector<LogicalForwardInfo>& availableForwardsInfo,
-    std::vector<ChannelConfigurationPolicy> const& channelPolicies);
+    std::vector<ChannelConfigurationPolicy> const& channelPolicies,
+    ComputingOffer const& defaultOffer);
 
   /// return a description of all options to be forwarded to the device
   /// by default

--- a/Framework/Core/src/ResourceManager.h
+++ b/Framework/Core/src/ResourceManager.h
@@ -7,24 +7,22 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#ifndef FRAMEWORK_RESOURCEMANAGER_H
-#define FRAMEWORK_RESOURCEMANAGER_H
+#ifndef O2_FRAMEWORK_RESOURCEMANAGER_H_
+#define O2_FRAMEWORK_RESOURCEMANAGER_H_
 
-#include "ComputingResource.h"
+#include "Framework/ComputingResource.h"
 #include <vector>
 
-namespace o2
-{
-namespace framework
+namespace o2::framework
 {
 
 class ResourceManager
 {
  public:
-  virtual std::vector<ComputingResource> getAvailableResources() = 0;
+  virtual std::vector<ComputingOffer> getAvailableOffers() = 0;
+  virtual void notifyAcceptedOffer(ComputingOffer const&) = 0;
 };
 
-} // namespace framework
-} // namespace o2
+} // namespace o2::framework
 
-#endif // FRAMEWORK_RESOURCEMANAGER_H
+#endif // O2_FRAMEWORK_RESOURCEMANAGER_H_

--- a/Framework/Core/src/SimpleResourceManager.h
+++ b/Framework/Core/src/SimpleResourceManager.h
@@ -7,14 +7,12 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#ifndef FRAMEWORK_SIMPLERESOURCEMANAGER_H
-#define FRAMEWORK_SIMPLERESOURCEMANAGER_H
+#ifndef O2_FRAMEWORK_SIMPLERESOURCEMANAGER_H_
+#define O2_FRAMEWORK_SIMPLERESOURCEMANAGER_H_
 
 #include "ResourceManager.h"
 
-namespace o2
-{
-namespace framework
+namespace o2::framework
 {
 
 /// A resource manager with infinite resources at its disposal.
@@ -23,23 +21,22 @@ namespace framework
 class SimpleResourceManager : public ResourceManager
 {
  public:
-  /// @a initialPort is the first port which can be used
-  ///              by this trivial resource manager.
-  /// @a maxPorts is the maximum number of ports starting from
-  ///             initialPort that this resource manager can allocate.
-  SimpleResourceManager(unsigned short initialPort, unsigned short maxPorts = 1000)
-    : mInitialPort{initialPort},
-      mMaxPorts{maxPorts}
+  /// @a initialResources the precomputed list of available resources
+  SimpleResourceManager(std::vector<ComputingResource> intialResources)
+    : mResources{intialResources}
   {
   }
-  std::vector<ComputingResource> getAvailableResources() override;
+  /// Get the available resources for a device to run on
+  std::vector<ComputingOffer> getAvailableOffers() override;
+
+  /// Notify that we have accepted a given resource and that it
+  /// should not be reoffered
+  void notifyAcceptedOffer(ComputingOffer const& accepted) override;
 
  private:
-  int mInitialPort;
-  int mMaxPorts;
+  std::vector<ComputingResource> mResources;
 };
 
-} // namespace framework
-} // namespace o2
+} // namespace o2::framework
 
-#endif // FRAMEWORK_SIMPLERESOURCEMANAGER_H
+#endif // O2_FRAMEWORK_SIMPLERESOURCEMANAGER_H_

--- a/Framework/Core/test/test_ChannelSpecHelpers.cxx
+++ b/Framework/Core/test/test_ChannelSpecHelpers.cxx
@@ -25,12 +25,6 @@ BOOST_AUTO_TEST_CASE(TestChannelMethod)
 
   BOOST_REQUIRE_EQUAL(oss.str(), "bindconnect");
   std::ostringstream oss2;
-
-  oss2 << ChannelSpecHelpers::methodAsUrl(ChannelMethod::Bind)
-       << "\n"
-       << ChannelSpecHelpers::methodAsUrl(ChannelMethod::Connect);
-
-  BOOST_REQUIRE_EQUAL(oss2.str(), "tcp://*:%d\ntcp://127.0.0.1:%d");
 }
 
 BOOST_AUTO_TEST_CASE(TestChannelType)

--- a/Framework/Core/test/test_DeviceSpec.cxx
+++ b/Framework/Core/test/test_DeviceSpec.cxx
@@ -20,6 +20,7 @@
 #include "Framework/WorkflowSpec.h"
 #include "Framework/DataSpecUtils.h"
 #include "../src/SimpleResourceManager.h"
+#include "../src/ComputingResourceHelpers.h"
 #include "test_HelperMacros.h"
 
 using namespace o2::framework;
@@ -44,10 +45,18 @@ BOOST_AUTO_TEST_CASE(TestDeviceSpec1)
   BOOST_REQUIRE_EQUAL(channelPolicies.empty(), false);
   BOOST_REQUIRE_EQUAL(completionPolicies.empty(), false);
   std::vector<DeviceSpec> devices;
-  SimpleResourceManager rm(22000, 1000);
-  auto resources = rm.getAvailableResources();
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, resources);
-  BOOST_CHECK_EQUAL(devices.size(), 2);
+
+  std::vector<ComputingResource> resources{ComputingResourceHelpers::getLocalhostResource(22000, 1000)};
+  BOOST_REQUIRE_EQUAL(resources.size(), 1);
+  BOOST_CHECK_EQUAL(resources[0].startPort, 22000);
+  SimpleResourceManager rm(resources);
+  auto offers = rm.getAvailableOffers();
+  BOOST_REQUIRE_EQUAL(offers.size(), 1);
+  BOOST_CHECK_EQUAL(offers[0].startPort, 22000);
+  BOOST_CHECK_EQUAL(offers[0].rangeSize, 1000);
+
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, rm);
+  BOOST_REQUIRE_EQUAL(devices.size(), 2);
   BOOST_CHECK_EQUAL(devices[0].outputChannels.size(), 1);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, ChannelMethod::Bind);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].type, ChannelType::Push);
@@ -55,13 +64,13 @@ BOOST_AUTO_TEST_CASE(TestDeviceSpec1)
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].port, 22000);
   BOOST_CHECK_EQUAL(devices[0].outputs.size(), 1);
 
-  BOOST_CHECK_EQUAL(devices[1].inputChannels.size(), 1);
+  BOOST_REQUIRE_EQUAL(devices[1].inputChannels.size(), 1);
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].method, ChannelMethod::Connect);
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].type, ChannelType::Pull);
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].name, "from_A_to_B");
   BOOST_CHECK_EQUAL(devices[1].inputChannels[0].port, 22000);
 
-  BOOST_CHECK_EQUAL(devices[1].inputs.size(), 1);
+  BOOST_REQUIRE_EQUAL(devices[1].inputs.size(), 1);
   BOOST_CHECK_EQUAL(devices[1].inputs[0].sourceChannel, "from_A_to_B");
 }
 
@@ -79,9 +88,9 @@ BOOST_AUTO_TEST_CASE(TestDeviceSpec1PushPull)
 
   BOOST_REQUIRE_EQUAL(channelPolicies.empty(), false);
   std::vector<DeviceSpec> devices;
-  SimpleResourceManager rm(22000, 1000);
-  auto resources = rm.getAvailableResources();
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, resources);
+  std::vector<ComputingResource> resources{ComputingResourceHelpers::getLocalhostResource(22000, 1000)};
+  SimpleResourceManager rm(resources);
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, rm);
   BOOST_CHECK_EQUAL(devices.size(), 2);
   BOOST_CHECK_EQUAL(devices[0].outputChannels.size(), 1);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, ChannelMethod::Bind);
@@ -123,9 +132,9 @@ BOOST_AUTO_TEST_CASE(TestDeviceSpec2)
   auto completionPolicies = CompletionPolicy::createDefaultPolicies();
   std::vector<DeviceSpec> devices;
 
-  SimpleResourceManager rm(22000, 1000);
-  auto resources = rm.getAvailableResources();
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, resources);
+  std::vector<ComputingResource> resources{ComputingResourceHelpers::getLocalhostResource(22000, 1000)};
+  SimpleResourceManager rm(resources);
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, rm);
   BOOST_CHECK_EQUAL(devices.size(), 2);
   BOOST_CHECK_EQUAL(devices[0].outputChannels.size(), 1);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, ChannelMethod::Bind);
@@ -165,9 +174,9 @@ BOOST_AUTO_TEST_CASE(TestDeviceSpec3)
   auto completionPolicies = CompletionPolicy::createDefaultPolicies();
   std::vector<DeviceSpec> devices;
 
-  SimpleResourceManager rm(22000, 1000);
-  auto resources = rm.getAvailableResources();
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, resources);
+  std::vector<ComputingResource> resources{ComputingResourceHelpers::getLocalhostResource(22000, 1000)};
+  SimpleResourceManager rm(resources);
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, rm);
   BOOST_CHECK_EQUAL(devices.size(), 3);
   BOOST_CHECK_EQUAL(devices[0].outputChannels.size(), 2);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, ChannelMethod::Bind);
@@ -212,10 +221,10 @@ BOOST_AUTO_TEST_CASE(TestDeviceSpec4)
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
   auto completionPolicies = CompletionPolicy::createDefaultPolicies();
   std::vector<DeviceSpec> devices;
-  SimpleResourceManager rm(22000, 1000);
-  auto resources = rm.getAvailableResources();
+  std::vector<ComputingResource> resources{ComputingResourceHelpers::getLocalhostResource(22000, 1000)};
+  SimpleResourceManager rm(resources);
 
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, resources);
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, rm);
   BOOST_CHECK_EQUAL(devices.size(), 4);
   BOOST_CHECK_EQUAL(devices[0].outputChannels.size(), 2);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, ChannelMethod::Bind);
@@ -282,9 +291,9 @@ BOOST_AUTO_TEST_CASE(TestTopologyForwarding)
   auto completionPolicies = CompletionPolicy::createDefaultPolicies();
   std::vector<DeviceSpec> devices;
 
-  SimpleResourceManager rm(22000, 1000);
-  auto resources = rm.getAvailableResources();
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, resources);
+  std::vector<ComputingResource> resources{ComputingResourceHelpers::getLocalhostResource(22000, 1000)};
+  SimpleResourceManager rm(resources);
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, rm);
   BOOST_CHECK_EQUAL(devices.size(), 3);
   BOOST_CHECK_EQUAL(devices[0].outputChannels.size(), 1);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, ChannelMethod::Bind);
@@ -397,11 +406,14 @@ BOOST_AUTO_TEST_CASE(TestOutEdgeProcessingHelpers)
   WorkflowSpec workflow = defineDataProcessing7();
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
 
-  SimpleResourceManager rm(22000, 1000);
-  auto resources = rm.getAvailableResources();
+  std::vector<ComputingResource> resources{ComputingResourceHelpers::getLocalhostResource(22000, 1000)};
+  SimpleResourceManager rm(resources);
+  ComputingOffer defaultOffer;
+  defaultOffer.cpu = 0.01;
+  defaultOffer.memory = 0.01;
 
-  DeviceSpecHelpers::processOutEdgeActions(devices, deviceIndex, connections, resources, edgeOutIndex, logicalEdges,
-                                           actions, workflow, globalOutputs, channelPolicies);
+  DeviceSpecHelpers::processOutEdgeActions(devices, deviceIndex, connections, rm, edgeOutIndex, logicalEdges,
+                                           actions, workflow, globalOutputs, channelPolicies, defaultOffer);
 
   std::vector<DeviceId> expectedDeviceIndex = {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {1, 0, 1}, {1, 0, 1}, {1, 1, 2}, {1, 1, 2}, {1, 2, 3}, {1, 2, 3}};
   BOOST_REQUIRE_EQUAL(devices.size(), 4); // For producers
@@ -427,8 +439,9 @@ BOOST_AUTO_TEST_CASE(TestOutEdgeProcessingHelpers)
   BOOST_REQUIRE_EQUAL(devices[2].outputs.size(), 2);
   BOOST_REQUIRE_EQUAL(devices[3].outputs.size(), 2);
 
-  // FIXME: check we have the right connections as well..
-  BOOST_CHECK_EQUAL(resources.back().port, 22009);
+  auto offers = rm.getAvailableOffers();
+  BOOST_REQUIRE_EQUAL(offers.size(), 1);
+  BOOST_CHECK_EQUAL(offers[0].startPort, 22009);
 
   // Not sure this is correct, but lets assume that's the case..
   std::vector<size_t> edgeInIndex{0, 1, 2, 3, 4, 5, 6, 7, 8};
@@ -447,8 +460,8 @@ BOOST_AUTO_TEST_CASE(TestOutEdgeProcessingHelpers)
 
   std::sort(connections.begin(), connections.end());
 
-  DeviceSpecHelpers::processInEdgeActions(devices, deviceIndex, resources, connections, edgeInIndex, logicalEdges,
-                                          inActions, workflow, availableForwardsInfo, channelPolicies);
+  DeviceSpecHelpers::processInEdgeActions(devices, deviceIndex, connections, rm, edgeInIndex, logicalEdges,
+                                          inActions, workflow, availableForwardsInfo, channelPolicies, defaultOffer);
   //
   std::vector<DeviceId> expectedDeviceIndexFinal = {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {1, 0, 1}, {1, 0, 1}, {1, 1, 2}, {1, 1, 2}, {1, 2, 3}, {1, 2, 3}, {2, 0, 4}, {2, 1, 5}};
   BOOST_REQUIRE_EQUAL(expectedDeviceIndexFinal.size(), deviceIndex.size());
@@ -555,9 +568,9 @@ BOOST_AUTO_TEST_CASE(TestTopologyLayeredTimePipeline)
   std::vector<DeviceSpec> devices;
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
   auto completionPolicies = CompletionPolicy::createDefaultPolicies();
-  SimpleResourceManager rm(22000, 1000);
-  auto resources = rm.getAvailableResources();
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, resources);
+  std::vector<ComputingResource> resources{ComputingResourceHelpers::getLocalhostResource(22000, 1000)};
+  SimpleResourceManager rm(resources);
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, rm);
   BOOST_CHECK_EQUAL(devices.size(), 6);
   BOOST_CHECK_EQUAL(devices[0].id, "A");
   BOOST_CHECK_EQUAL(devices[1].id, "B_t0");
@@ -675,8 +688,8 @@ WorkflowSpec defineDataProcessing8()
 BOOST_AUTO_TEST_CASE(TestSimpleWildcard)
 {
   auto workflow = defineDataProcessing8();
-  SimpleResourceManager rm(22000, 1000);
-  auto resources = rm.getAvailableResources();
+  std::vector<ComputingResource> resources{ComputingResourceHelpers::getLocalhostResource(22000, 1000)};
+  SimpleResourceManager rm(resources);
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
 
   std::vector<DeviceSpec> devices;
@@ -711,8 +724,12 @@ BOOST_AUTO_TEST_CASE(TestSimpleWildcard)
     EdgeAction{false, false},
   };
 
-  DeviceSpecHelpers::processOutEdgeActions(devices, deviceIndex, connections, resources, edgeOutIndex, logicalEdges,
-                                           outActions, workflow, globalOutputs, channelPolicies);
+  ComputingOffer defaultOffer;
+  defaultOffer.cpu = 0.01;
+  defaultOffer.memory = 0.01;
+
+  DeviceSpecHelpers::processOutEdgeActions(devices, deviceIndex, connections, rm, edgeOutIndex, logicalEdges,
+                                           outActions, workflow, globalOutputs, channelPolicies, defaultOffer);
 
   BOOST_REQUIRE_EQUAL(devices.size(), 2); // Two devices have outputs: A and Timer
   BOOST_CHECK_EQUAL(devices[0].name, "A");
@@ -727,8 +744,8 @@ BOOST_AUTO_TEST_CASE(TestSimpleWildcard)
 
   std::sort(connections.begin(), connections.end());
 
-  DeviceSpecHelpers::processInEdgeActions(devices, deviceIndex, resources, connections, edgeInIndex, logicalEdges,
-                                          inActions, workflow, availableForwardsInfo, channelPolicies);
+  DeviceSpecHelpers::processInEdgeActions(devices, deviceIndex, connections, rm, edgeInIndex, logicalEdges,
+                                          inActions, workflow, availableForwardsInfo, channelPolicies, defaultOffer);
 
   BOOST_REQUIRE_EQUAL(devices.size(), 3); // Now we also have B
   BOOST_CHECK_EQUAL(devices[0].name, "A");

--- a/Framework/Core/test/test_DeviceSpecHelpers.cxx
+++ b/Framework/Core/test/test_DeviceSpecHelpers.cxx
@@ -23,6 +23,7 @@
 #include <vector>
 #include <map>
 #include "../src/SimpleResourceManager.h"
+#include "../src/ComputingResourceHelpers.h"
 
 namespace o2
 {
@@ -131,14 +132,14 @@ BOOST_AUTO_TEST_CASE(test_prepareArguments)
 
   std::vector<DeviceSpec> deviceSpecs;
 
-  auto resourceManager = std::make_unique<SimpleResourceManager>(42000, 100);
-  auto resources = resourceManager->getAvailableResources();
+  std::vector<ComputingResource> resources = {ComputingResourceHelpers::getLocalhostResource(22000, 1000)};
+  auto rm = std::make_unique<SimpleResourceManager>(resources);
 
   DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow,
                                                     ChannelConfigurationPolicy::createDefaultPolicies(),
                                                     CompletionPolicy::createDefaultPolicies(),
                                                     deviceSpecs,
-                                                    resources);
+                                                    *rm);
 
   // Now doing the test cases
   CheckMatrix matrix;

--- a/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
+++ b/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
@@ -15,6 +15,7 @@
 #include "../src/DDSConfigHelpers.h"
 #include "../src/DeviceSpecHelpers.h"
 #include "../src/SimpleResourceManager.h"
+#include "../src/ComputingResourceHelpers.h"
 #include "Framework/DataAllocator.h"
 #include "Framework/DeviceControl.h"
 #include "Framework/DeviceSpec.h"
@@ -69,10 +70,10 @@ BOOST_AUTO_TEST_CASE(TestGraphviz)
   std::ostringstream ss{""};
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
   std::vector<DeviceSpec> devices;
-  SimpleResourceManager rm(22000, 1000);
-  auto resources = rm.getAvailableResources();
+  std::vector<ComputingResource> resources{ComputingResourceHelpers::getLocalhostResource(22000, 1000)};
+  SimpleResourceManager rm(resources);
   auto completionPolicies = CompletionPolicy::createDefaultPolicies();
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, resources);
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, rm);
   std::vector<DeviceControl> controls;
   std::vector<DeviceExecution> executions;
   controls.resize(devices.size());

--- a/Framework/Core/test/test_Graphviz.cxx
+++ b/Framework/Core/test/test_Graphviz.cxx
@@ -11,6 +11,7 @@
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
 
+#include "../src/ComputingResourceHelpers.h"
 #include "../src/DeviceSpecHelpers.h"
 #include "../src/GraphvizHelpers.h"
 #include "../src/SimpleResourceManager.h"
@@ -96,9 +97,9 @@ BOOST_AUTO_TEST_CASE(TestGraphviz)
   }
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
   auto completionPolicies = CompletionPolicy::createDefaultPolicies();
-  SimpleResourceManager rm(22000, 1000);
-  auto resources = rm.getAvailableResources();
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, resources);
+  std::vector<ComputingResource> resources = {ComputingResourceHelpers::getLocalhostResource(22000, 1000)};
+  SimpleResourceManager rm(resources);
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, rm);
   str.str("");
   GraphvizHelpers::dumpDeviceSpec2Graphviz(str, devices);
   lineByLineComparision(str.str(), R"EXPECTED(digraph structs {
@@ -134,9 +135,9 @@ BOOST_AUTO_TEST_CASE(TestGraphvizWithPipeline)
   }
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
   auto completionPolicies = CompletionPolicy::createDefaultPolicies();
-  SimpleResourceManager rm(22000, 1000);
-  auto resources = rm.getAvailableResources();
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, resources);
+  std::vector<ComputingResource> resources = {ComputingResourceHelpers::getLocalhostResource(22000, 1000)};
+  SimpleResourceManager rm(resources);
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, rm);
   str.str("");
   GraphvizHelpers::dumpDeviceSpec2Graphviz(str, devices);
   lineByLineComparision(str.str(), R"EXPECTED(digraph structs {

--- a/Framework/Core/test/test_TimeParallelPipelining.cxx
+++ b/Framework/Core/test/test_TimeParallelPipelining.cxx
@@ -14,6 +14,7 @@
 #include <boost/test/unit_test.hpp>
 #include "../src/DeviceSpecHelpers.h"
 #include "../src/SimpleResourceManager.h"
+#include "../src/ComputingResourceHelpers.h"
 #include "Framework/DeviceControl.h"
 #include "Framework/DeviceSpec.h"
 #include "Framework/WorkflowSpec.h"
@@ -53,9 +54,9 @@ BOOST_AUTO_TEST_CASE(TimePipeliningSimple)
   std::vector<DeviceSpec> devices;
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
   auto completionPolicies = CompletionPolicy::createDefaultPolicies();
-  SimpleResourceManager rm(22000, 1000);
-  auto resources = rm.getAvailableResources();
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, resources);
+  std::vector<ComputingResource> resources = {ComputingResourceHelpers::getLocalhostResource(22000, 1000)};
+  SimpleResourceManager rm(resources);
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, rm);
   BOOST_REQUIRE_EQUAL(devices.size(), 4);
   auto& producer = devices[0];
   auto& layer0Consumer0 = devices[1];
@@ -105,9 +106,9 @@ BOOST_AUTO_TEST_CASE(TimePipeliningFull)
   std::vector<DeviceSpec> devices;
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies();
   auto completionPolicies = CompletionPolicy::createDefaultPolicies();
-  SimpleResourceManager rm(22000, 1000);
-  auto resources = rm.getAvailableResources();
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, resources);
+  std::vector<ComputingResource> resources = {ComputingResourceHelpers::getLocalhostResource(22000, 1000)};
+  SimpleResourceManager rm(resources);
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, rm);
   BOOST_REQUIRE_EQUAL(devices.size(), 7);
   auto& producer = devices[0];
   auto& layer0Consumer0 = devices[1];


### PR DESCRIPTION
Rework the way DPL assign resources to devices. This is a first
step in moving away from the hardcoded 127.0.0.1 ip address and
allows DPL workflows to run distributed without a third party
configuring the channels. 


A further optimization will also allow DPL to configure ipc / shared memory when two devices happen to be assigned to the same machine.

- [ ] Allow setting the available resources from the command line.
- [ ] Only spawn devices which have a resource assigned which match the local hostname.
- [ ] If two devices are known to be on the same host, use ipc rather than tcp.