### PR TITLE
Exclude orbit=0 generation and its ovefrlow by InteractionSampler

### DIFF
--- a/Steer/include/Steer/InteractionSampler.h
+++ b/Steer/include/Steer/InteractionSampler.h
@@ -29,8 +29,8 @@ class InteractionSampler
 {
  public:
   static constexpr float Sec2NanoSec = 1.e9; // s->ns conversion
-
-  o2::InteractionTimeRecord generateCollisionTime();
+  static constexpr int FirstOrbit = 1;       // start from orbit > 0 to avoid problems with negative BCs
+  const o2::InteractionTimeRecord& generateCollisionTime();
   void generateCollisionTimes(std::vector<o2::InteractionTimeRecord>& dest);
 
   void init();
@@ -54,9 +54,8 @@ class InteractionSampler
   void nextCollidingBC();
   void warnOrbitWrapped() const;
 
+  o2::InteractionTimeRecord mIR{{0, FirstOrbit}, 0.};
   int mIntBCCache = 0;         ///< N interactions left for current BC
-  int mBCCurrent = 0;          ///< current BC
-  unsigned int mOrbit = 0;     ///< current orbit
   int mBCMin = 0;              ///< 1st filled BCID
   int mBCMax = -1;             ///< last filled BCID
   float mIntRate = -1.;        ///< total interaction rate in Hz
@@ -88,14 +87,16 @@ inline void InteractionSampler::nextCollidingBC()
 {
   // increment bunch ID till next colliding bunch
   do {
-    if (++mBCCurrent > mBCMax) { // did we exhaust full orbit?
-      mBCCurrent = mBCMin;
-      if (++mOrbit >= o2::constants::lhc::MaxNOrbits) { // wrap orbit (should not happen in run3)
+    if (mIR.bc >= mBCMax) { // did we exhaust full orbit?
+      mIR.bc = mBCMin;
+      if (mIR.orbit == o2::constants::lhc::MaxNOrbits) { // wrap orbit (should not happen in run3)
         warnOrbitWrapped();
-        mOrbit = 0;
       }
+      mIR.orbit++;
+    } else {
+      mIR.bc++;
     }
-  } while (!mBCFilling.testBC(mBCCurrent));
+  } while (!mBCFilling.testBC(mIR.bc));
 }
 
 //_________________________________________________

--- a/Steer/src/InteractionSampler.cxx
+++ b/Steer/src/InteractionSampler.cxx
@@ -53,9 +53,8 @@ void InteractionSampler::init()
   double muexp = TMath::Exp(-mMuBC);
   mProbInteraction = 1. - muexp;
   mMuBCZTRed = mMuBC * muexp / mProbInteraction;
-  mBCCurrent = mBCMin + gRandom->Integer(mBCMax - mBCMin + 1);
   mIntBCCache = 0;
-  mOrbit = 0;
+  mIR.bc = mBCMin;
 }
 
 //_________________________________________________
@@ -67,11 +66,11 @@ void InteractionSampler::print() const
   }
   LOG(INFO) << "InteractionSampler with " << mBCFilling.getNBunches() << " colliding BCs in [" << mBCMin
             << '-' << mBCMax << "], mu(BC)= " << getMuPerBC() << " -> total IR= " << getInteractionRate();
-  LOG(INFO) << "Current BC= " << mBCCurrent << '(' << mIntBCCache << " coll left) at orbit " << mOrbit;
+  LOG(INFO) << "Current " << mIR << '(' << mIntBCCache << " coll left)";
 }
 
 //_________________________________________________
-o2::InteractionTimeRecord InteractionSampler::generateCollisionTime()
+const o2::InteractionTimeRecord& InteractionSampler::generateCollisionTime()
 {
   // generate single interaction record
   if (mIntRate < 0) {
@@ -81,13 +80,11 @@ o2::InteractionTimeRecord InteractionSampler::generateCollisionTime()
   if (mIntBCCache < 1) {                   // do we still have interaction in current BC?
     mIntBCCache = simulateInteractingBC(); // decide which BC interacts and N collisions
   }
-  double timeInt = mTimeInBC.back() + o2::InteractionTimeRecord::bc2ns(mBCCurrent, mOrbit);
+  mIR.timeNS = mTimeInBC.back() + mIR.bc2ns();
   mTimeInBC.pop_back();
   mIntBCCache--;
 
-  o2::InteractionTimeRecord tmp(timeInt);
-
-  return o2::InteractionTimeRecord(timeInt);
+  return mIR;
 }
 
 //_________________________________________________
@@ -119,6 +116,6 @@ int InteractionSampler::simulateInteractingBC()
 void InteractionSampler::warnOrbitWrapped() const
 {
   /// in run3 the orbit is 32 bits and should never wrap
-  LOG(WARN) << "Orbit wraps, current state of InteractionSampler:";
   print();
+  LOG(FATAL) << "Max orbit " << o2::constants::lhc::MaxNOrbits << " overflow";
 }


### PR DESCRIPTION
Some detectors need to inspect BC's before the one being triggered, to exclude negative times we start orbit/bc sampling from orbit 1 instead of unrealistic 0 (in the real running the orbit will be reset
to 0 at the beginning of the each fill).
Produce fatal if orbit exceeds maxOrbit (corresponds to >100 hours) and wraps to 0.

@sawenzel this is needed to avoid lengthy checks/protections in ZDC trigger simulation (perhaps for other detectors also)