### PR TITLE
Raw data writer for MID

### DIFF
--- a/Detectors/MUON/MID/Raw/CMakeLists.txt
+++ b/Detectors/MUON/MID/Raw/CMakeLists.txt
@@ -8,10 +8,11 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
-add_subdirectory(Base)
-add_subdirectory(Clustering)
-add_subdirectory(Raw)
-add_subdirectory(Simulation)
-add_subdirectory(TestingSimTools)
-add_subdirectory(Tracking)
-add_subdirectory(Workflow)
+o2_add_library(MIDRaw
+               SOURCES src/Decoder.cxx src/Encoder.cxx
+               PUBLIC_LINK_LIBRARIES ms_gsl::ms_gsl O2::DataFormatsMID
+                                     O2::Headers)
+
+if(BUILD_TESTING)
+  add_subdirectory(test)
+endif()

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/Decoder.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/Decoder.h
@@ -1,0 +1,60 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDRaw/Decoder.h
+/// \brief  Mid raw data decoder
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   30 September 2019
+#ifndef O2_MID_DECODER_H
+#define O2_MID_DECODER_H
+
+#include <cstdint>
+#include <vector>
+#include <gsl/gsl>
+#include "Headers/RAWDataHeader.h"
+#include "DataFormatsMID/ColumnData.h"
+#include "DataFormatsMID/ROFRecord.h"
+#include "MIDRaw/RawUnit.h"
+
+namespace o2
+{
+namespace mid
+{
+class Decoder
+{
+ public:
+  void init();
+  void process(gsl::span<const raw::RawUnit> bytes);
+  /// Gets the vector of data
+  const std::vector<ColumnData>& getData() { return mData; }
+
+  /// Gets the vector of data RO frame records
+  const std::vector<ROFRecord>& getROFRecords() { return mROFRecords; }
+
+ private:
+  gsl::span<const raw::RawUnit> mBytes{};     /// Vector with encoded information
+  size_t mVectorIndex{0};                     /// Index in vector
+  size_t mBitIndex{0};                        /// Index of the current bit
+  size_t mHeaderIndex{0};                     /// Index of the current header
+  size_t mNextHeaderIndex{0};                 /// Index of the next header
+  const header::RAWDataHeader* mRDH{nullptr}; /// Current header (not owner)
+  std::vector<ColumnData> mData{};            /// Vector of output column data
+  std::vector<ROFRecord> mROFRecords{};       ///
+
+  bool nextColumnData();
+  bool isEndOfBuffer() const;
+  int next(unsigned int nBits);
+  bool nextPayload();
+  void reset();
+};
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_DECODER_H */

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/Encoder.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/Encoder.h
@@ -1,0 +1,56 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDRaw/Encoder.h
+/// \brief  MID raw data encoder for MID
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   30 September 2019
+#ifndef O2_MID_ENCODER_H
+#define O2_MID_ENCODER_H
+
+#include <cstdint>
+#include <vector>
+#include <deque>
+#include <gsl/gsl>
+#include "Headers/RAWDataHeader.h"
+#include "DataFormatsMID/ColumnData.h"
+#include "DataFormatsMID/ROFRecord.h"
+#include "MIDRaw/RawUnit.h"
+
+namespace o2
+{
+namespace mid
+{
+class Encoder
+{
+ public:
+  void newHeader(uint32_t bcId, uint32_t orbitId, uint32_t triggerType = 0);
+  void process(gsl::span<const ColumnData> data, const uint16_t localClock, EventType eventType = EventType::Standard);
+  const std::vector<raw::RawUnit>& getBuffer();
+  /// Gets the buffer size in bytes
+  size_t getBufferSize() const { return mBytes.size() * raw::sElementSizeInBytes; }
+  /// Sets the next header offset in bytes
+  void setHeaderOffset(uint16_t headerOffset = 0x2000);
+  void clear();
+
+ private:
+  void add(int value, unsigned int nBits);
+  void completePage(bool stop);
+  header::RAWDataHeader* getRDH() { return reinterpret_cast<header::RAWDataHeader*>(&(mBytes[mHeaderIndex])); }
+
+  std::vector<raw::RawUnit> mBytes{};                      /// Vector with encoded information
+  size_t mBitIndex{0};                                     /// Index of the current bit
+  size_t mHeaderIndex{0};                                  /// Index in the the current header
+  size_t mHeaderOffset{0x2000 / raw::sElementSizeInBytes}; /// Header offset
+};
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_ENCODER_H */

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/RawUnit.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/RawUnit.h
@@ -1,0 +1,43 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDRaw/RawUnit.h
+/// \brief  Raw data format MID
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   30 September 2019
+#ifndef O2_MID_RAWUNIT_H
+#define O2_MID_RAWUNIT_H
+
+#include <cstdint>
+#include <cstddef>
+#include "Headers/RAWDataHeader.h"
+
+namespace o2
+{
+namespace mid
+{
+namespace raw
+{
+typedef uint32_t RawUnit;
+
+// Buffer size
+static constexpr size_t sElementSizeInBytes = sizeof(RawUnit);
+static constexpr size_t sMaxBufferSize = 8192 / sElementSizeInBytes;
+static constexpr size_t sElementSizeInBits = 8 * sElementSizeInBytes;
+
+// Header size
+static constexpr size_t sHeaderSizeInBytes = sizeof(header::RAWDataHeader);
+static constexpr size_t sHeaderSizeInElements = sHeaderSizeInBytes / sElementSizeInBytes;
+
+} // namespace raw
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_RAWUNIT_H */

--- a/Detectors/MUON/MID/Raw/src/Decoder.cxx
+++ b/Detectors/MUON/MID/Raw/src/Decoder.cxx
@@ -1,0 +1,152 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Raw/src/Decoder.cxx
+/// \brief  MID raw data decoder
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   30 September 2019
+
+#include "MIDRaw/Decoder.h"
+#include "RawInfo.h"
+
+#include <map>
+
+namespace o2
+{
+namespace mid
+{
+
+void Decoder::init()
+{
+  mData.reserve(8000);
+  mROFRecords.reserve(2000);
+}
+
+int Decoder::next(unsigned int nBits)
+{
+  /// Get value
+  int value = 0;
+  for (int ibit = 0; ibit < nBits; ++ibit) {
+    if (mBitIndex == raw::sElementSizeInBits) {
+      mBitIndex = 0;
+      ++mVectorIndex;
+      nextPayload();
+    }
+    bool isOn = (mBytes[mVectorIndex] >> mBitIndex) & 0x1;
+    if (isOn) {
+      value |= (1 << ibit);
+    }
+    ++mBitIndex;
+  }
+  return value;
+}
+
+void Decoder::reset()
+{
+  /// Rewind bytes
+  mVectorIndex = 0;
+  mHeaderIndex = 0;
+  mNextHeaderIndex = 0;
+  mBitIndex = 0;
+  mRDH = nullptr;
+  mData.clear();
+  mROFRecords.clear();
+}
+
+void Decoder::process(gsl::span<const raw::RawUnit> bytes)
+{
+  /// Sets the buffer and reset the internal indexes
+  reset();
+  if (bytes.empty()) {
+    return;
+  }
+  mBytes = bytes;
+  while (nextColumnData())
+    ;
+}
+
+bool Decoder::isEndOfBuffer() const
+{
+  /// We are at the end of the buffer
+  return mVectorIndex == mBytes.size();
+}
+
+bool Decoder::nextPayload()
+{
+  /// Go to next payload
+  while (mVectorIndex == mNextHeaderIndex) {
+    mRDH = reinterpret_cast<const header::RAWDataHeader*>(&mBytes[mVectorIndex]);
+    mHeaderIndex = mNextHeaderIndex;
+    mNextHeaderIndex += mRDH->offsetToNext / raw::sElementSizeInBytes;
+    mBitIndex = 0;
+    if (mRDH->memorySize > raw::sHeaderSizeInBytes) {
+      // Payload is not empty: go to end of header
+      mVectorIndex += raw::sHeaderSizeInElements;
+    } else {
+      // Payload is empty: go directly to next header and check it
+      mVectorIndex = mNextHeaderIndex;
+      if (isEndOfBuffer()) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+bool Decoder::nextColumnData()
+{
+  /// Gets the array of column data
+  if (isEndOfBuffer() || !nextPayload()) {
+    return false;
+  }
+
+  EventType eventType = static_cast<EventType>(next(sNBitsEventType));
+  uint16_t localClock = next(sNBitsLocalClock);
+  InteractionRecord intRec(localClock, mRDH->triggerOrbit);
+  auto firstEntry = mData.size();
+  int nFiredRPCs = next(sNBitsNFiredRPCs);
+  ColumnData colData;
+  for (int irpc = 0; irpc < nFiredRPCs; ++irpc) {
+    int rpcId = next(sNBitsRPCId);
+    int nFiredColumns = next(sNBitsNFiredColumns);
+    colData.deId = static_cast<uint8_t>(rpcId);
+    for (int icol = 0; icol < nFiredColumns; ++icol) {
+      colData.columnId = static_cast<uint8_t>(next(sNBitsColumnId));
+      for (int iline = 0; iline < 4; ++iline) {
+        // Reset pattern
+        colData.setBendPattern(0, iline);
+      }
+      int nFiredBoards = next(sNBitsNFiredBoards);
+      for (int iboard = 0; iboard < nFiredBoards; ++iboard) {
+        int boardId = next(sNBitsBoardId);
+        colData.setNonBendPattern(next(sNBitsFiredStrips));
+        colData.setBendPattern(next(sNBitsFiredStrips), boardId);
+      }
+      mData.emplace_back(colData);
+    }
+  }
+
+  mROFRecords.emplace_back(intRec, eventType, firstEntry, mData.size() - firstEntry);
+
+  // The payload bits are contiguous.
+  // However there is an overhead between the last payload byte and the next header.
+  // If we read the full memory size, we
+  // Which means that the size is too small to have another block of data.
+  // When we are close to the new header, we jump directly to the next header
+  if ((mVectorIndex - mHeaderIndex + 1) * raw::sElementSizeInBytes == mRDH->memorySize) {
+    mVectorIndex = mNextHeaderIndex;
+    mBitIndex = 0;
+  }
+
+  return true;
+}
+
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/Raw/src/Encoder.cxx
+++ b/Detectors/MUON/MID/Raw/src/Encoder.cxx
@@ -1,0 +1,145 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Raw/src/Encoder.cxx
+/// \brief  MID raw data fdata encoder
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   30 September 2019
+
+#include "MIDRaw/Encoder.h"
+
+#include <map>
+#include "RawInfo.h"
+
+namespace o2
+{
+namespace mid
+{
+void Encoder::add(int value, unsigned int nBits)
+{
+  /// Add information
+  for (int ibit = 0; ibit < nBits; ++ibit) {
+    if (mBitIndex == raw::sElementSizeInBits) {
+      mBitIndex = 0;
+      if (mBytes.size() == mHeaderIndex + mHeaderOffset) {
+        completePage(false);
+        // Copy previous header
+        std::vector<raw::RawUnit> oldHeader(mBytes.begin() + mHeaderIndex, mBytes.begin() + mHeaderIndex + raw::sHeaderSizeInElements);
+        mHeaderIndex = mBytes.size();
+        std::copy(oldHeader.begin(), oldHeader.end(), std::back_inserter(mBytes));
+        // And increase the page counter
+        ++getRDH()->pageCnt;
+      }
+      mBytes.push_back(0);
+    }
+    bool isOn = (value >> ibit) & 0x1;
+    if (isOn) {
+      mBytes.back() |= (1 << mBitIndex);
+    }
+    ++mBitIndex;
+  }
+}
+
+void Encoder::clear()
+{
+  /// Reset bytes
+  mBytes.clear();
+  mBitIndex = 0;
+  mHeaderIndex = 0;
+}
+
+void Encoder::newHeader(uint32_t bcId, uint32_t orbitId, uint32_t triggerType)
+{
+  /// Add new RDH
+  completePage(true);
+  mHeaderIndex = mBytes.size();
+  for (size_t iel = 0; iel < raw::sHeaderSizeInElements; ++iel) {
+    mBytes.emplace_back(0);
+  }
+  auto rdh = getRDH();
+  *rdh = header::RAWDataHeader();
+  rdh->triggerOrbit = orbitId;
+  rdh->triggerBC = bcId;
+  rdh->triggerType = triggerType;
+  mBitIndex = raw::sElementSizeInBits;
+}
+
+void Encoder::completePage(bool stop)
+{
+  /// Complete the information on the page
+  if (mBytes.empty()) {
+    return;
+  }
+  auto pageSizeInElements = mBytes.size() - mHeaderIndex;
+  if (mHeaderOffset > pageSizeInElements) {
+    // Write zeros up to the end of the page
+    mBytes.resize(mHeaderIndex + mHeaderOffset, 0);
+  }
+
+  auto rdh = getRDH();
+  rdh->memorySize = pageSizeInElements * raw::sElementSizeInBytes;
+  rdh->offsetToNext = (mBytes.size() - mHeaderIndex) * raw::sElementSizeInBytes;
+  rdh->stop = stop;
+}
+
+const std::vector<raw::RawUnit>& Encoder::getBuffer()
+{
+  /// Gets the buffer
+  completePage(true);
+  return mBytes;
+}
+
+void Encoder::setHeaderOffset(uint16_t headerOffset)
+{
+  /// Sets the next header offset in bytes
+  if (headerOffset < raw::sHeaderSizeInBytes) {
+    // The offset must have at least the header size
+    headerOffset = raw::sHeaderSizeInBytes;
+  }
+  mHeaderOffset = headerOffset / raw::sElementSizeInBytes;
+}
+
+void Encoder::process(gsl::span<const ColumnData> data, const uint16_t localClock, EventType eventType)
+{
+  /// Encode data
+  std::map<int, std::vector<int>> dataIndexes;
+  std::vector<std::pair<int, uint16_t>> patterns(4);
+  for (size_t idx = 0; idx < data.size(); ++idx) {
+    dataIndexes[data[idx].deId].emplace_back(idx);
+  }
+  add(static_cast<int>(eventType), sNBitsEventType);
+  add(localClock, sNBitsLocalClock);
+  add(dataIndexes.size(), sNBitsNFiredRPCs);
+  for (auto& item : dataIndexes) {
+    add(item.first, sNBitsRPCId);
+    add(item.second.size(), sNBitsNFiredColumns);
+    for (auto& icol : item.second) {
+      patterns.clear();
+      for (int iline = 0; iline < 4; ++iline) {
+        if (data[icol].getBendPattern(iline) != 0) {
+          patterns.emplace_back(iline, data[icol].getBendPattern(iline));
+        }
+      }
+      if (patterns.empty()) {
+        patterns.emplace_back(0, 0);
+      }
+      add(data[icol].columnId, sNBitsColumnId);
+      add(patterns.size(), sNBitsNFiredBoards);
+      for (auto& pat : patterns) {
+        add(pat.first, sNBitsBoardId);
+        add(data[icol].getNonBendPattern(), sNBitsFiredStrips);
+        add(pat.second, sNBitsFiredStrips);
+      }
+    }
+  }
+}
+
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/Raw/src/RawInfo.h
+++ b/Detectors/MUON/MID/Raw/src/RawInfo.h
@@ -1,0 +1,51 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Raw/src/RawInfo.h
+/// \brief  Raw data format MID
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   30 September 2019
+#ifndef O2_MID_RAWINFO_H
+#define O2_MID_RAWINFO_H
+
+#include <cstdint>
+
+namespace o2
+{
+namespace mid
+{
+
+// Local board patterns
+static constexpr unsigned int sNBitsBoardId = 2;
+static constexpr unsigned int sNBitsFiredStrips = 16;
+
+// Column info
+static constexpr unsigned int sNBitsColumnId = 3;
+static constexpr unsigned int sNBitsNFiredBoards = 3;
+
+// RPC info
+static constexpr unsigned int sNBitsRPCId = 7;
+static constexpr unsigned int sNBitsNFiredColumns = 3;
+
+static constexpr unsigned int sNBitsNFiredRPCs = 7;
+
+// Local clock
+static constexpr unsigned int sNBitsLocalClock = 16;
+
+// Trigger info
+static constexpr unsigned int sNBitsEventType = 2;
+static constexpr unsigned int sStandardEvent = 0;
+static constexpr unsigned int sSoftwareTriggerEvent = 1;
+static constexpr unsigned int sFEEEvent = 2;
+
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_RAWINFO_H */

--- a/Detectors/MUON/MID/Raw/test/CMakeLists.txt
+++ b/Detectors/MUON/MID/Raw/test/CMakeLists.txt
@@ -8,10 +8,16 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
-add_subdirectory(Base)
-add_subdirectory(Clustering)
-add_subdirectory(Raw)
-add_subdirectory(Simulation)
-add_subdirectory(TestingSimTools)
-add_subdirectory(Tracking)
-add_subdirectory(Workflow)
+o2_add_test(Raw
+            SOURCES testRaw.cxx
+            PUBLIC_LINK_LIBRARIES O2::DataFormatsMID O2::MIDRaw
+            COMPONENT_NAME mid
+            LABELS mid muon)
+
+if(benchmark_FOUND)
+  o2_add_executable(raw
+                    COMPONENT_NAME mid
+                    SOURCES bench_Raw.cxx
+                    IS_BENCHMARK
+                    PUBLIC_LINK_LIBRARIES O2::MIDRaw benchmark::benchmark)
+endif()

--- a/Detectors/MUON/MID/Raw/test/bench_Raw.cxx
+++ b/Detectors/MUON/MID/Raw/test/bench_Raw.cxx
@@ -1,0 +1,105 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Tracking/test/bench_Tracker.cxx
+/// \brief  Benchmark tracker device for MID
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   17 March 2018
+
+#include "benchmark/benchmark.h"
+#include <random>
+#include "DataFormatsMID/ROFRecord.h"
+#include "MIDRaw/Encoder.h"
+#include "MIDRaw/Decoder.h"
+#include "MIDRaw/RawUnit.h"
+
+o2::mid::ColumnData getColData(uint8_t deId, uint8_t columnId, uint16_t nbp = 0, uint16_t bp1 = 0, uint16_t bp2 = 0, uint16_t bp3 = 0, uint16_t bp4 = 0)
+{
+  o2::mid::ColumnData col;
+  col.deId = deId;
+  col.columnId = columnId;
+  col.setNonBendPattern(nbp);
+  col.setBendPattern(bp1, 0);
+  col.setBendPattern(bp2, 1);
+  col.setBendPattern(bp3, 2);
+  col.setBendPattern(bp4, 3);
+  return col;
+}
+
+std::vector<o2::mid::raw::RawUnit> generateTestData(size_t nTF, size_t nDataInTF, size_t nColDataInEvent, o2::mid::Encoder& encoder)
+{
+  encoder.clear();
+  std::vector<o2::mid::ColumnData> colData;
+  colData.reserve(nColDataInEvent);
+  int maxNcols = 7;
+  int nDEs = nColDataInEvent / maxNcols;
+  int nColLast = nColDataInEvent % maxNcols;
+  if (nColLast > 0) {
+    ++nDEs;
+  }
+  // Generate data
+  for (int ide = 0; ide < nDEs; ++ide) {
+    int nCol = (ide == nDEs - 1) ? nColLast : maxNcols;
+    for (int icol = 0; icol < nCol; ++icol) {
+      colData.emplace_back(getColData(ide, icol, 0xFF00, 0xFFFF));
+    }
+  }
+  // Fill TF
+  for (size_t itf = 0; itf < nTF; ++itf) {
+    colData.clear();
+    encoder.newHeader(40, itf + 1, 0);
+    for (int ilocal = 0; ilocal < nDataInTF; ++ilocal) {
+      encoder.process(colData, ilocal + 1, o2::mid::EventType::Standard);
+    }
+  }
+
+  return encoder.getBuffer();
+}
+
+static void BM_RAW(benchmark::State& state)
+{
+  o2::mid::Encoder encoder;
+  o2::mid::Decoder decoder;
+
+  int nTF = state.range(0);
+  int nEventPerTF = state.range(1);
+  int nFiredPerEvent = state.range(2);
+  double num{0};
+
+  std::vector<o2::mid::raw::RawUnit> inputData = generateTestData(nTF, nEventPerTF, nFiredPerEvent, encoder);
+
+  for (auto _ : state) {
+    // state.PauseTiming();
+    // inputData = generateTestData(nTF, nFiredPerEvent, encoder);
+    // state.ResumeTiming();
+    decoder.process(inputData);
+    ++num;
+  }
+
+  state.counters["num"] = benchmark::Counter(num, benchmark::Counter::kIsRate);
+}
+
+static void CustomArguments(benchmark::internal::Benchmark* bench)
+{
+  // Empty headers
+  bench->Args({1, 0, 0});
+  bench->Args({10, 0, 0});
+  // One per event
+  bench->Args({1, 1, 1});
+  bench->Args({10, 1, 1});
+  // One large data
+  bench->Args({1, 1, 70 * 4});
+  // Many small data
+  bench->Args({1, 100, 4});
+}
+
+BENCHMARK(BM_RAW)->Apply(CustomArguments)->Unit(benchmark::kNanosecond);
+
+BENCHMARK_MAIN();

--- a/Detectors/MUON/MID/Raw/test/testRaw.cxx
+++ b/Detectors/MUON/MID/Raw/test/testRaw.cxx
@@ -1,0 +1,126 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// @author  Diego Stocco
+
+#define BOOST_TEST_MODULE Test MID raw
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+
+#include <boost/test/data/test_case.hpp>
+#include <iostream>
+#include <vector>
+#include <map>
+#include "DataFormatsMID/ColumnData.h"
+#include "MIDRaw/Encoder.h"
+#include "MIDRaw/Decoder.h"
+#include "MIDRaw/RawUnit.h"
+
+BOOST_AUTO_TEST_SUITE(o2_mid_raw)
+
+o2::mid::ColumnData getColData(uint8_t deId, uint8_t columnId, uint16_t nbp = 0, uint16_t bp1 = 0, uint16_t bp2 = 0, uint16_t bp3 = 0, uint16_t bp4 = 0)
+{
+  o2::mid::ColumnData col;
+  col.deId = deId;
+  col.columnId = columnId;
+  col.setNonBendPattern(nbp);
+  col.setBendPattern(bp1, 0);
+  col.setBendPattern(bp2, 1);
+  col.setBendPattern(bp3, 2);
+  col.setBendPattern(bp4, 3);
+  return col;
+}
+
+void doTest(const o2::mid::EventType& inEventType, const std::map<uint16_t, std::vector<o2::mid::ColumnData>>& inData, const std::vector<o2::mid::ROFRecord>& rofRecords, const std::vector<o2::mid::ColumnData>& data)
+{
+  BOOST_TEST(rofRecords.size() == inData.size());
+  auto inItMap = inData.begin();
+  for (auto rofIt = rofRecords.begin(); rofIt != rofRecords.end(); ++rofIt) {
+    BOOST_TEST(static_cast<int>(rofIt->eventType) == static_cast<int>(inEventType));
+    BOOST_TEST(rofIt->interactionRecord.bc == inItMap->first);
+    BOOST_TEST(rofIt->nEntries == inItMap->second.size());
+    for (size_t icol = rofIt->firstEntry; icol < rofIt->firstEntry + rofIt->nEntries; ++icol) {
+      size_t inCol = icol - rofIt->firstEntry;
+      BOOST_TEST(data[icol].deId == inItMap->second[inCol].deId);
+      BOOST_TEST(data[icol].columnId == inItMap->second[inCol].columnId);
+      BOOST_TEST(data[icol].getNonBendPattern() == inItMap->second[inCol].getNonBendPattern());
+      for (int iline = 0; iline < 4; ++iline) {
+        BOOST_TEST(data[icol].getBendPattern(iline) == inItMap->second[inCol].getBendPattern(iline));
+      }
+    }
+    ++inItMap;
+  }
+}
+
+BOOST_AUTO_TEST_CASE(TestRawSmall)
+{
+  std::map<uint16_t, std::vector<o2::mid::ColumnData>> inData;
+  // Small standard event
+  uint16_t localClock = 100;
+  inData[localClock].emplace_back(getColData(2, 4, 0, 0xFFFF));
+  inData[localClock].emplace_back(getColData(2, 5, 0xFFFF, 0));
+  inData[localClock].emplace_back(getColData(4, 6, 0xFF0F, 0, 0xF0FF, 0xF));
+  localClock = 200;
+  inData[localClock].emplace_back(getColData(34, 3, 0xFF00, 0xFF));
+  o2::mid::EventType inEventType = o2::mid::EventType::Standard;
+  o2::mid::Encoder encoder;
+  o2::mid::Decoder decoder;
+  decoder.init();
+  uint32_t orbit = 20;
+  for (auto& item : inData) {
+    encoder.newHeader(40, ++orbit, 0);
+    encoder.process(item.second, item.first, inEventType);
+  }
+  decoder.process(encoder.getBuffer());
+  doTest(inEventType, inData, decoder.getROFRecords(), decoder.getData());
+}
+
+BOOST_AUTO_TEST_CASE(TestRawBig)
+{
+  std::map<uint16_t, std::vector<o2::mid::ColumnData>> inData;
+  // Big event that should pass the 8kB
+  for (int irepeat = 0; irepeat < 4; ++irepeat) {
+    uint16_t localClock = 100 + irepeat;
+    for (int ide = 0; ide < 72; ++ide) {
+      for (int icol = 0; icol < 7; ++icol) {
+        inData[localClock].emplace_back(getColData(ide, icol, 0xFF00, 0xFFFF));
+      }
+    }
+  }
+  o2::mid::EventType inEventType = o2::mid::EventType::Standard;
+  o2::mid::Encoder encoder;
+  uint32_t orbit = 20;
+  encoder.newHeader(40, ++orbit, 0);
+  for (auto& item : inData) {
+    encoder.process(item.second, item.first, inEventType);
+  }
+  o2::mid::Decoder decoder;
+  decoder.init();
+  decoder.process(encoder.getBuffer());
+  doTest(inEventType, inData, decoder.getROFRecords(), decoder.getData());
+}
+
+BOOST_AUTO_TEST_CASE(TestRawHeaderOnly)
+{
+  o2::mid::Encoder encoder;
+  for (uint32_t iorbit = 1; iorbit < 10; ++iorbit) {
+    encoder.newHeader(40, iorbit, 0);
+  }
+  // End of data
+  encoder.newHeader(0, 0, 1);
+  o2::mid::Decoder decoder;
+  decoder.init();
+  decoder.process(encoder.getBuffer());
+  BOOST_TEST(decoder.getROFRecords().size() == 0);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/Detectors/MUON/MID/Workflow/CMakeLists.txt
+++ b/Detectors/MUON/MID/Workflow/CMakeLists.txt
@@ -30,3 +30,24 @@ o2_add_executable(reco-workflow-mc
 target_include_directories(
   ${exenamerecomc}
   PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>)
+
+o2_add_executable(digits-to-raw-workflow
+                  COMPONENT_NAME mid
+                  SOURCES src/mid-digits-to-raw.cxx
+                          src/DigitReaderSpec.cxx
+                          src/DigitsToRawWorkflow.cxx
+                          src/RawWriterSpec.cxx
+                          TARGETVARNAME
+                          exenameraw
+                  PUBLIC_LINK_LIBRARIES O2::Framework
+                                        O2::SimConfig
+                                        ms_gsl::ms_gsl
+                                        O2::SimulationDataFormat
+                                        O2::DataFormatsMID
+                                        O2::DPLUtils
+                                        O2::MIDSimulation
+                                        O2::MIDRaw)
+
+target_include_directories(
+  ${exenameraw}
+  PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>)

--- a/Detectors/MUON/MID/Workflow/include/MIDWorkflow/DigitsToRawWorkflow.h
+++ b/Detectors/MUON/MID/Workflow/include/MIDWorkflow/DigitsToRawWorkflow.h
@@ -1,0 +1,29 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDWorkflow/DigitsToRawWorkflow.h
+/// \brief  Definition of the reconstruction workflow for MID MC
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   11 April 2019
+
+#ifndef O2_MID_DIGITSTORAWWORKFLOWSPEC_H
+#define O2_MID_DIGITSTORAWWORKFLOWSPEC_H
+
+#include "Framework/WorkflowSpec.h"
+
+namespace o2
+{
+namespace mid
+{
+framework::WorkflowSpec getDigitsToRawWorkflow();
+}
+} // namespace o2
+
+#endif //O2_MID_DIGITSTORAWWORKFLOWSPEC_H

--- a/Detectors/MUON/MID/Workflow/include/MIDWorkflow/RawWriterSpec.h
+++ b/Detectors/MUON/MID/Workflow/include/MIDWorkflow/RawWriterSpec.h
@@ -1,0 +1,29 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDWorkflow/RawWriterSpec.h
+/// \brief  Digits to raw converter spec for MID
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   02 October 2019
+
+#ifndef O2_MID_RAWWRITERSPEC_H
+#define O2_MID_RAWWRITERSPEC_H
+
+#include "Framework/DataProcessorSpec.h"
+
+namespace o2
+{
+namespace mid
+{
+framework::DataProcessorSpec getRawWriterSpec();
+}
+} // namespace o2
+
+#endif //O2_MID_RAWWRITERSPEC_H

--- a/Detectors/MUON/MID/Workflow/src/DigitsToRawWorkflow.cxx
+++ b/Detectors/MUON/MID/Workflow/src/DigitsToRawWorkflow.cxx
@@ -1,0 +1,49 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Workflow/src/DigitsToRawWorkflow.cxx
+/// \brief  Definition of MID reconstruction workflow for MC
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   27 September 2019
+
+#include "MIDWorkflow/DigitsToRawWorkflow.h"
+
+#include "DPLUtils/Utils.h"
+#include "MIDWorkflow/DigitReaderSpec.h"
+#include "MIDWorkflow/RawWriterSpec.h"
+
+namespace of = o2::framework;
+
+namespace o2
+{
+namespace mid
+{
+
+of::WorkflowSpec getDigitsToRawWorkflow()
+{
+
+  auto checkReady = [](o2::framework::DataRef const& ref) {
+    // The default checkReady function is not defined in MakeRootTreeWriterSpec:
+    // this leads to a std::exception in DPL.
+    // While the exception seems harmless (the processing goes on without apparent consequence),
+    // it is quite ugly to see.
+    // So, let us define checkReady here.
+    // FIXME: to be fixed in MakeRootTreeWriterSpec
+    return false;
+  };
+
+  of::WorkflowSpec specs;
+
+  specs.emplace_back(getDigitReaderSpec());
+  specs.emplace_back(getRawWriterSpec());
+  return specs;
+}
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/Workflow/src/RawWriterSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/RawWriterSpec.cxx
@@ -1,0 +1,115 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Workflow/src/RawWriterSpec.cxx
+/// \brief  Digits to raw converter spec for MID
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   02 October 2019
+
+#include "MIDWorkflow/RawWriterSpec.h"
+
+#include <fstream>
+#include <cstdint>
+#include <gsl/gsl>
+#include "Framework/CallbackService.h"
+#include "Framework/DataRefUtils.h"
+#include "Framework/Logger.h"
+#include "Framework/Output.h"
+#include "Framework/Task.h"
+#include "CommonDataFormat/InteractionRecord.h"
+#include "DataFormatsMID/ColumnData.h"
+#include "DataFormatsMID/ROFRecord.h"
+#include "MIDRaw/Encoder.h"
+
+namespace of = o2::framework;
+
+namespace o2
+{
+namespace mid
+{
+class RawWriterDeviceDPL
+{
+ public:
+  RawWriterDeviceDPL(const char* inputBinding, const char* inputROFBinding) : mInputBinding(inputBinding), mInputROFBinding(inputROFBinding), mEncoder(), mFile(), mInteractionRecord(), mState(0){};
+  ~RawWriterDeviceDPL() = default;
+
+  void init(o2::framework::InitContext& ic)
+  {
+    auto filename = ic.options().get<std::string>("mid-raw-outfile");
+    mFile.open(filename.c_str(), std::ios::binary);
+    if (!mFile.is_open()) {
+      LOG(ERROR) << "Cannot open the " << filename << " file !";
+      mState = 1;
+      return;
+    }
+
+    auto headerOffset = ic.options().get<int>("mid-raw-header-offset");
+    mEncoder.setHeaderOffset(headerOffset);
+
+    auto stop = [this]() {
+      /// Close the stream
+      mEncoder.newHeader(mInteractionRecord.bc, mInteractionRecord.orbit, 1);
+      write();
+      mFile.close();
+    };
+    ic.services().get<of::CallbackService>().set(of::CallbackService::Id::Stop, stop);
+    mState = 0;
+  }
+
+  void run(o2::framework::ProcessingContext& pc)
+  {
+    auto msg = pc.inputs().get(mInputBinding.c_str());
+    gsl::span<const ColumnData> data = of::DataRefUtils::as<const ColumnData>(msg);
+
+    auto msgROF = pc.inputs().get(mInputROFBinding.c_str());
+    gsl::span<const ROFRecord> rofRecords = of::DataRefUtils::as<const ROFRecord>(msgROF);
+
+    for (auto& rofRecord : rofRecords) {
+      if (rofRecord.interactionRecord.orbit != mInteractionRecord.orbit) {
+        mEncoder.newHeader(rofRecord.interactionRecord.bc, rofRecord.interactionRecord.orbit, 0);
+        mInteractionRecord = rofRecord.interactionRecord;
+      }
+      auto eventData = data.subspan(rofRecord.firstEntry, rofRecord.nEntries);
+      mEncoder.process(eventData, rofRecord.interactionRecord.bc, rofRecord.eventType);
+    }
+    write();
+  }
+
+ private:
+  void write()
+  {
+    mFile.write(reinterpret_cast<const char*>(mEncoder.getBuffer().data()), mEncoder.getBufferSize());
+    mEncoder.clear();
+  }
+  std::string mInputBinding;
+  std::string mInputROFBinding;
+  Encoder mEncoder{};
+  std::ofstream mFile{};
+  InteractionRecord mInteractionRecord{};
+  int mState{0};
+};
+
+framework::DataProcessorSpec getRawWriterSpec()
+{
+  std::string inputBinding = "mid_data";
+  std::string inputROFBinding = "mid_data_rof";
+  std::vector<of::InputSpec> inputSpecs{of::InputSpec{inputBinding, "MID", "DATA"}, of::InputSpec{inputROFBinding, "MID", "DATAROF"}, of::InputSpec{"mid_data_labels", "MID", "DATALABELS"}};
+
+  return of::DataProcessorSpec{
+    "MIDRawWriter",
+    inputSpecs,
+    of::Outputs{},
+    of::AlgorithmSpec{of::adaptFromTask<o2::mid::RawWriterDeviceDPL>(inputBinding.c_str(), inputROFBinding.c_str())},
+    of::Options{
+      {"mid-raw-outfile", of::VariantType::String, "mid_raw.dat", {"Name of the outputfile"}},
+      {"mid-raw-header-offset", of::VariantType::Int, 0x2000, {"Header offset in bytes"}}}};
+}
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/Workflow/src/mid-digits-to-raw.cxx
+++ b/Detectors/MUON/MID/Workflow/src/mid-digits-to-raw.cxx
@@ -1,0 +1,46 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   mid-digits-to-raw.cxx
+/// \brief  MID raw to digits workflow
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   02 October 2019
+
+#include <string>
+#include <vector>
+#include "Framework/Variant.h"
+#include "SimConfig/ConfigurableParam.h"
+#include "MIDWorkflow/DigitsToRawWorkflow.h"
+
+using namespace o2::framework;
+
+// ------------------------------------------------------------------
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  std::string keyvaluehelp("Semicolon separated key=value strings ...");
+  workflowOptions.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {keyvaluehelp}});
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  // Update the (declared) parameters if changed from the command line
+  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
+  // write the configuration used for the digitizer workflow
+  o2::conf::ConfigurableParam::writeINI("o2mid-recoflow_configuration.ini");
+
+  return std::move(o2::mid::getDigitsToRawWorkflow());
+}


### PR DESCRIPTION
This PR consists of two separate commits: one that introduces the raw data encoder and decoder, and the other that implements the digits-to-raw workflow.
Please do not squeeze them.