### PR TITLE
GPU: Add HIP vertexer

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/cuda/include/ITStrackingCUDA/VertexerTraitsGPU.h
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/include/ITStrackingCUDA/VertexerTraitsGPU.h
@@ -62,7 +62,6 @@ class VertexerTraitsGPU : public VertexerTraits
   GPUhd() GPU::DeviceStoreVertexerGPU& getDeviceContext();
 
  protected:
-
   GPU::DeviceStoreVertexerGPU mStoreVertexerGPU;
   GPU::UniquePointer<GPU::DeviceStoreVertexerGPU> mStoreVertexerGPUPtr;
 };

--- a/Detectors/ITSMFT/ITS/tracking/cuda/src/Context.cu
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/src/Context.cu
@@ -125,6 +125,7 @@ Context::Context(bool dumpDevices)
     if (dumpDevices) {
       std::cout << "################ CUDA DEVICE " << iDevice << " ################" << std::endl;
       std::cout << "Name " << mDeviceProperties[iDevice].name << std::endl;
+      std::cout << "minor " << minor << " major " << major << std::endl;
       std::cout << "gpuProcessors " << mDeviceProperties[iDevice].gpuProcessors << std::endl;
       std::cout << "cudaCores " << mDeviceProperties[iDevice].cudaCores << std::endl;
       std::cout << "globalMemorySize " << mDeviceProperties[iDevice].globalMemorySize << std::endl;

--- a/Detectors/ITSMFT/ITS/tracking/cuda/src/VertexerTraitsGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/src/VertexerTraitsGPU.cu
@@ -409,7 +409,7 @@ void VertexerTraitsGPU::computeVertices()
                                                  tmpArrayLow,                                                        // lower_level
                                                  tmpArrayHigh,                                                       // fupper_level
                                                  nCentroids);                                                        // num_row_pixels
-  GPU::printVectorKernel<<<blocksGrid, threadsPerBlock>>>(getDeviceContext(), 0);
+
   cub::DeviceReduce::ArgMax(reinterpret_cast<void*>(mStoreVertexerGPU.getCUBTmpBuffer().get()),
                             bufferSize,
                             histogramXY[0],
@@ -438,7 +438,6 @@ void VertexerTraitsGPU::computeVertices()
                               mStoreVertexerGPU.getHistogramXYZ()[2].get(),
                               mStoreVertexerGPU.getTmpVertexPositionBins().get() + 2,
                               mStoreVertexerGPU.getConfig().nBinsXYZ[2]);
-    // GPU::dumpMaximaKernel<<<blocksGrid, threadsPerBlock>>>(getDeviceContext(), 0);
 #ifdef _ALLOW_DEBUG_TREES_ITS_
     if (isDebugFlag(VertexerDebug::HistCentroids) && !iVertex) {
       mDebugger->fillXYZHistogramTree(std::array<std::vector<int>, 3>{mStoreVertexerGPU.getHistogramXYFromGPU()[0],

--- a/Detectors/ITSMFT/ITS/tracking/cuda/src/dummy.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/src/dummy.cxx
@@ -1,9 +1,0 @@
-// Copyright CERN and copyright holders of ALICE O2. This software is
-// distributed under the terms of the GNU General Public License v3 (GPL
-// Version 3), copied verbatim in the file "COPYING".
-//
-// See http://alice-o2.web.cern.ch/license for full licensing information.
-//
-// In applying this license CERN does not waive the privileges and immunities
-// granted to it by virtue of its status as an Intergovernmental Organization
-// or submit itself to any jurisdiction.

--- a/Detectors/ITSMFT/ITS/tracking/hip/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/tracking/hip/CMakeLists.txt
@@ -18,7 +18,8 @@ endif()
 message(STATUS "Building ITS HIP vertexer")
 set(HDRS ContextHIP.h UtilsHIP.h StreamHIP.h)
 o2_add_library(ITStrackingHIP
-               SOURCES src/DeviceStoreVertexerHIP.hip.cxx
+               SOURCES # src/VertexerTraitsHIP.hip.cxx
+                       src/DeviceStoreVertexerHIP.hip.cxx
                        src/ClusterLinesHIP.hip.cxx
                        src/UtilsHIP.hip.cxx
                        src/ContextHIP.hip.cxx

--- a/Detectors/ITSMFT/ITS/tracking/hip/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/tracking/hip/CMakeLists.txt
@@ -15,10 +15,12 @@ if(DEFINED HIP_AMDGPUTARGET)
   set(TMP_TARGET "(GPU Target ${HIP_AMDGPUTARGET})")
 endif()
 
-message(STATUS "Building ITS HIP tracker")
-
+message(STATUS "Building ITS HIP vertexer")
+set(HDRS ContextHIP.h UtilsHIP.h StreamHIP.h)
 o2_add_library(ITStrackingHIP
-               SOURCES src/UtilsHIP.hip.cxx
+               SOURCES src/DeviceStoreVertexerHIP.hip.cxx
+                       src/ClusterLinesHIP.hip.cxx
+                       src/UtilsHIP.hip.cxx
                        src/ContextHIP.hip.cxx
                PUBLIC_LINK_LIBRARIES O2::ITStracking hip::host hip::device hip::hipcub
                TARGETVARNAME targetName)
@@ -37,4 +39,3 @@ target_compile_options(${targetName}
                               -Wno-invalid-constexpr
                               -Wno-ignored-optimization-argument
                               -Wno-unused-private-field)
-

--- a/Detectors/ITSMFT/ITS/tracking/hip/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/tracking/hip/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 message(STATUS "Building ITS HIP vertexer")
 set(HDRS ContextHIP.h UtilsHIP.h StreamHIP.h)
 o2_add_library(ITStrackingHIP
-               SOURCES # src/VertexerTraitsHIP.hip.cxx
+               SOURCES src/VertexerTraitsHIP.hip.cxx
                        src/DeviceStoreVertexerHIP.hip.cxx
                        src/ClusterLinesHIP.hip.cxx
                        src/UtilsHIP.hip.cxx

--- a/Detectors/ITSMFT/ITS/tracking/hip/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/tracking/hip/CMakeLists.txt
@@ -16,13 +16,15 @@ if(DEFINED HIP_AMDGPUTARGET)
 endif()
 
 message(STATUS "Building ITS HIP vertexer")
-set(HDRS ContextHIP.h UtilsHIP.h StreamHIP.h)
 o2_add_library(ITStrackingHIP
-               SOURCES src/VertexerTraitsHIP.hip.cxx
-                       src/DeviceStoreVertexerHIP.hip.cxx
-                       src/ClusterLinesHIP.hip.cxx
-                       src/UtilsHIP.hip.cxx
+               SOURCES src/ClusterLinesHIP.hip.cxx
                        src/ContextHIP.hip.cxx
+                       # src/DeviceStoreHIP.hip.cxx
+                       src/DeviceStoreVertexerHIP.hip.cxx
+                       src/StreamHIP.hip.cxx
+                       # src/TrackerTraitsHIP.hip.cxx
+                       src/VertexerTraitsHIP.hip.cxx
+                       src/UtilsHIP.hip.cxx                   
                PUBLIC_LINK_LIBRARIES O2::ITStracking hip::host hip::device hip::hipcub
                TARGETVARNAME targetName)
 

--- a/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/ArrayHIP.h
+++ b/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/ArrayHIP.h
@@ -17,7 +17,6 @@
 
 #include <hip/hip_runtime.h>
 
-#include "ITStracking/Definitions.h"
 #include "GPUCommonDef.h"
 
 namespace o2
@@ -30,7 +29,7 @@ namespace GPU
 namespace
 {
 template <typename T, size_t Size>
-struct ArrayTraits final {
+struct ArrayTraitsHIP final {
   typedef T InternalArray[Size];
 
   GPUhd() static constexpr T& getReference(const InternalArray& internalArray, size_t index) noexcept
@@ -46,9 +45,9 @@ struct ArrayTraits final {
 } // namespace
 
 template <typename T, size_t Size>
-struct Array final {
+struct ArrayHIP final {
 
-  void copy(const Array<T, Size>& t)
+  void copy(const ArrayHIP<T, Size>& t)
   {
 #ifdef __OPENCL__
     for (size_t i{0}; i < Size; ++i) {

--- a/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/ArrayHIP.h
+++ b/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/ArrayHIP.h
@@ -8,12 +8,12 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 ///
-/// \file Array.h
+/// \file ArrayHIP.h
 /// \brief
 ///
 
-#ifndef TRAKINGITSU_INCLUDE_GPU_ARRAY_H_
-#define TRAKINGITSU_INCLUDE_GPU_ARRAY_H_
+#ifndef O2_ITS_TRACKING_INCLUDE_ARRAY_HIP_H_
+#define O2_ITS_TRACKING_INCLUDE_ARRAY_HIP_H_
 
 #include <hip/hip_runtime.h>
 
@@ -71,4 +71,4 @@ struct Array final {
 } // namespace its
 } // namespace o2
 
-#endif /* TRAKINGITSU_INCLUDE_GPU_CAGPUVECTOR_H_ */
+#endif /* O2_ITS_TRACKING_INCLUDE_ARRAY_HIP_H_ */

--- a/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/ArrayHIP.h
+++ b/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/ArrayHIP.h
@@ -1,0 +1,74 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+///
+/// \file Array.h
+/// \brief
+///
+
+#ifndef TRAKINGITSU_INCLUDE_GPU_ARRAY_H_
+#define TRAKINGITSU_INCLUDE_GPU_ARRAY_H_
+
+#include <hip/hip_runtime.h>
+
+#include "ITStracking/Definitions.h"
+#include "GPUCommonDef.h"
+
+namespace o2
+{
+namespace its
+{
+namespace GPU
+{
+
+namespace
+{
+template <typename T, size_t Size>
+struct ArrayTraits final {
+  typedef T InternalArray[Size];
+
+  GPUhd() static constexpr T& getReference(const InternalArray& internalArray, size_t index) noexcept
+  {
+    return const_cast<T&>(internalArray[index]);
+  }
+
+  GPUhd() static constexpr T* getPointer(const InternalArray& internalArray) noexcept
+  {
+    return const_cast<T*>(internalArray);
+  }
+};
+} // namespace
+
+template <typename T, size_t Size>
+struct Array final {
+
+  void copy(const Array<T, Size>& t)
+  {
+#ifdef __OPENCL__
+    for (size_t i{0}; i < Size; ++i) {
+      InternalArray[i] = t[i];
+    }
+#else
+    memcpy(InternalArray, t.data(), Size * sizeof(T));
+#endif
+  }
+
+  GPUhd() T* data() noexcept { return const_cast<T*>(InternalArray); }
+  GPUhd() const T* data() const noexcept { return const_cast<T*>(InternalArray); }
+  GPUhd() T& operator[](const int index) noexcept { return const_cast<T&>(InternalArray[index]); }
+  GPUhd() constexpr T& operator[](const int index) const noexcept { return const_cast<T&>(InternalArray[index]); }
+  GPUhd() size_t size() const noexcept { return Size; }
+
+  T InternalArray[Size];
+};
+} // namespace GPU
+} // namespace its
+} // namespace o2
+
+#endif /* TRAKINGITSU_INCLUDE_GPU_CAGPUVECTOR_H_ */

--- a/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/ClusterLinesHIP.h
+++ b/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/ClusterLinesHIP.h
@@ -51,10 +51,10 @@ struct GPUVertex final {
   unsigned char realVertex;
 };
 
-class ClusterLinesGPU final
+class ClusterLinesHIP final
 {
  public:
-  GPUd() ClusterLinesGPU(const Line& firstLine, const Line& secondLine); // poor man solution to calculate duplets' centroid
+  GPUd() ClusterLinesHIP(const Line& firstLine, const Line& secondLine); // poor man solution to calculate duplets' centroid
   GPUd() void computeClusterCentroid();
   GPUd() inline float* getVertex() { return mVertex; }
 

--- a/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/ClusterLinesHIP.h
+++ b/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/ClusterLinesHIP.h
@@ -27,11 +27,11 @@ namespace GPU
 {
 
 struct GPUVertex final {
-  GPUd() GPUVertex() : realVertex{false}
+  GPUhd() GPUVertex() : realVertex{false}
   {
   }
 
-  GPUd() GPUVertex(float x, float y, float z, float eX, float eY, float eZ, int contrib) : xCoord{x},
+  GPUhd() GPUVertex(float x, float y, float z, float eX, float eY, float eZ, int contrib) : xCoord{x},
                                                                                             yCoord{y},
                                                                                             zCoord{z},
                                                                                             errorX{eZ},

--- a/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/ClusterLinesHIP.h
+++ b/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/ClusterLinesHIP.h
@@ -8,12 +8,12 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 ///
-/// \file ClusterLinesGPU.h
+/// \file ClusterLinesHIP.h
 /// \brief GPU-compliant version of ClusterLines, for the moment separated, might create a common traits for ClusterLines + later specifications for each arch, later.
-/// \ autrhor: mconcas@cern.ch
+/// \ author: mconcas@cern.ch
 
-#ifndef ITSTRACKING_INCLUDE_CLUSTERLINES_HIP_H_
-#define ITSTRACKING_INCLUDE_CLUSTERLINES_HIP_H_
+#ifndef O2_ITS_TRACKING_INCLUDE_CLUSTERLINES_HIP_H_
+#define O2_ITS_TRACKING_INCLUDE_CLUSTERLINES_HIP_H_
 
 #include <hip/hip_runtime.h>
 #include "GPUCommonDef.h"
@@ -70,4 +70,4 @@ class ClusterLinesGPU final
 } // namespace GPU
 } // namespace its
 } // namespace o2
-#endif /* ITSTRACKING_INCLUDE_CLUSTERLINES_HIP_H_ */
+#endif /* O2_ITS_TRACKING_INCLUDE_CLUSTERLINES_HIP_H_ */

--- a/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/ClusterLinesHIP.h
+++ b/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/ClusterLinesHIP.h
@@ -1,0 +1,73 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+///
+/// \file ClusterLinesGPU.h
+/// \brief GPU-compliant version of ClusterLines, for the moment separated, might create a common traits for ClusterLines + later specifications for each arch, later.
+/// \ autrhor: mconcas@cern.ch
+
+#ifndef ITSTRACKING_INCLUDE_CLUSTERLINES_HIP_H_
+#define ITSTRACKING_INCLUDE_CLUSTERLINES_HIP_H_
+
+#include <hip/hip_runtime.h>
+#include "GPUCommonDef.h"
+#include "ITStracking/ClusterLines.h"
+
+namespace o2
+{
+namespace its
+{
+namespace GPU
+{
+
+struct GPUVertex final {
+  GPUd() GPUVertex() : realVertex{false}
+  {
+  }
+
+  GPUd() GPUVertex(float x, float y, float z, float eX, float eY, float eZ, int contrib) : xCoord{x},
+                                                                                            yCoord{y},
+                                                                                            zCoord{z},
+                                                                                            errorX{eZ},
+                                                                                            errorY{eY},
+                                                                                            errorZ{eZ},
+                                                                                            contributors{contrib},
+                                                                                            realVertex{true}
+  {
+  }
+  float xCoord;
+  float yCoord;
+  float zCoord;
+  float errorX;
+  float errorY;
+  float errorZ;
+  int contributors;
+  unsigned char realVertex;
+};
+
+class ClusterLinesGPU final
+{
+ public:
+  GPUd() ClusterLinesGPU(const Line& firstLine, const Line& secondLine); // poor man solution to calculate duplets' centroid
+  GPUd() void computeClusterCentroid();
+  GPUd() inline float* getVertex() { return mVertex; }
+
+ private:
+  float mAMatrix[6];         // AX=B
+  float mBMatrix[3];         // AX=B
+  int mLabels[2];            // labels
+  float mVertexCandidate[3]; // vertex candidate
+  float mWeightMatrix[9];    // weight matrix
+  float mVertex[3];          // cluster centroid position
+};
+
+} // namespace GPU
+} // namespace its
+} // namespace o2
+#endif /* ITSTRACKING_INCLUDE_CLUSTERLINES_HIP_H_ */

--- a/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/ContextHIP.h
+++ b/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/ContextHIP.h
@@ -8,12 +8,12 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 ///
-/// \file Context.h
+/// \file ContextHIP.h
 /// \brief
 ///
 
-#ifndef TRACKINGITS_INCLUDE_CONTEXT_HIP_H_
-#define TRACKINGITS_INCLUDE_CONTEXT_HIP_H_
+#ifndef O2_ITS_TRACKING_INCLUDE_CONTEXT_HIP_H_
+#define O2_ITS_TRACKING_INCLUDE_CONTEXT_HIP_H_
 
 #include <string>
 #include <vector>
@@ -68,4 +68,4 @@ class Context final
 } // namespace its
 } // namespace o2
 
-#endif /* TRACKINGITS_INCLUDE_CONTEXT_HIP_H_ */
+#endif /* O2_ITS_TRACKING_INCLUDE_CONTEXT_HIP_H_ */

--- a/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/ContextHIP.h
+++ b/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/ContextHIP.h
@@ -12,8 +12,8 @@
 /// \brief
 ///
 
-#ifndef TRAKINGITSU_INCLUDE_GPU_CONTEXT_H_
-#define TRAKINGITSU_INCLUDE_GPU_CONTEXT_H_
+#ifndef TRACKINGITS_INCLUDE_CONTEXT_HIP_H_
+#define TRACKINGITS_INCLUDE_CONTEXT_HIP_H_
 
 #include <string>
 #include <vector>
@@ -31,7 +31,7 @@ namespace GPU
 struct DeviceProperties final {
   std::string name;
   int gpuProcessors;
-  // int hipCores;
+  int streamProcessors;
   long globalMemorySize;
   long constantMemorySize;
   long sharedMemorySize;
@@ -41,7 +41,7 @@ struct DeviceProperties final {
   long registersPerBlock;
   int warpSize;
   int maxThreadsPerBlock;
-  // int maxBlocksPerSM;
+  int maxBlocksPerSM;
   dim3 maxThreadsDim;
   dim3 maxGridDim;
 };
@@ -68,4 +68,4 @@ class Context final
 } // namespace its
 } // namespace o2
 
-#endif /* TRAKINGITSU_INCLUDE_GPU_CONTEXT_H_ */
+#endif /* TRACKINGITS_INCLUDE_CONTEXT_HIP_H_ */

--- a/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/ContextHIP.h
+++ b/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/ContextHIP.h
@@ -17,9 +17,9 @@
 
 #include <string>
 #include <vector>
-#include "ITStracking/Definitions.h"
-
+// #include "ITStracking/Definitions.h"
 #include <hip/hip_runtime_api.h>
+#include "GPUCommonDef.h"
 
 namespace o2
 {
@@ -46,20 +46,20 @@ struct DeviceProperties final {
   dim3 maxGridDim;
 };
 
-class Context final
+class ContextHIP final
 {
  public:
-  static Context& getInstance();
+  static ContextHIP& getInstance();
 
-  Context(const Context&);
-  Context& operator=(const Context&);
+  ContextHIP(const ContextHIP&);
+  ContextHIP& operator=(const ContextHIP&);
 
   const DeviceProperties& getDeviceProperties();
   const DeviceProperties& getDeviceProperties(const int);
 
  private:
-  Context(bool dumpDevices = true);
-  ~Context() = default;
+  ContextHIP(bool dumpDevices = true);
+  ~ContextHIP() = default;
 
   int mDevicesNum;
   std::vector<DeviceProperties> mDeviceProperties;

--- a/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/DeviceStoreVertexerHIP.h
+++ b/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/DeviceStoreVertexerHIP.h
@@ -48,45 +48,45 @@ enum class VertexerLayerName {
 };
 
 typedef TrackletingLayerOrder Order;
-class DeviceStoreVertexerGPU final
+class DeviceStoreVertexerHIP final
 {
  public:
-  DeviceStoreVertexerGPU();
-  ~DeviceStoreVertexerGPU() = default;
+  DeviceStoreVertexerHIP();
+  ~DeviceStoreVertexerHIP() = default;
 
-  UniquePointer<DeviceStoreVertexerGPU> initialise(const std::array<std::vector<Cluster>, constants::its::LayersNumberVertexer>&,
+  UniquePointer<DeviceStoreVertexerHIP> initialise(const std::array<std::vector<Cluster>, constants::its::LayersNumberVertexer>&,
                                                    const std::array<std::array<int, constants::index_table::ZBins * constants::index_table::PhiBins + 1>,
                                                                     constants::its::LayersNumberVertexer>&);
 
   // RO APIs
-  GPUd() const Array<Vector<Cluster>, constants::its::LayersNumberVertexer>& getClusters()
+  GPUd() const ArrayHIP<VectorHIP<Cluster>, constants::its::LayersNumberVertexer>& getClusters()
   {
     return mClusters;
   }
-  GPUd() const Vector<int>& getIndexTable(const VertexerLayerName);
+  GPUd() const VectorHIP<int>& getIndexTable(const VertexerLayerName);
   GPUhd() VertexerStoreConfigurationGPU& getConfig() { return mGPUConf; }
 
   // Writable APIs
-  GPUd() Vector<Tracklet>& getDuplets01() { return mDuplets01; }
-  GPUd() Vector<Tracklet>& getDuplets12() { return mDuplets12; }
-  GPUd() Vector<Line>& getLines() { return mTracklets; }
-  GPUd() Vector<float>& getBeamPosition() { return mBeamPosition; }
-  GPUhd() Vector<GPUVertex>& getVertices() { return mGPUVertices; }
-  GPUhd() Vector<int>& getNFoundLines() { return mNFoundLines; }
-  GPUhd() Vector<int>& getNExclusiveFoundLines() { return mNExclusiveFoundLines; }
-  GPUhd() Vector<int>& getCUBTmpBuffer() { return mCUBTmpBuffer; }
-  GPUhd() Vector<float>& getXYCentroids() { return mXYCentroids; }
-  GPUhd() Vector<float>& getZCentroids() { return mZCentroids; }
-  GPUhd() Array<Vector<int>, 3>& getHistogramXYZ() { return mHistogramXYZ; }
-  GPUhd() Vector<hipcub::KeyValuePair<int, int>>& getTmpVertexPositionBins() { return mTmpVertexPositionBins; }
+  GPUd() VectorHIP<Tracklet>& getDuplets01() { return mDuplets01; }
+  GPUd() VectorHIP<Tracklet>& getDuplets12() { return mDuplets12; }
+  GPUd() VectorHIP<Line>& getLines() { return mTracklets; }
+  GPUd() VectorHIP<float>& getBeamPosition() { return mBeamPosition; }
+  GPUhd() VectorHIP<GPUVertex>& getVertices() { return mGPUVertices; }
+  GPUhd() VectorHIP<int>& getNFoundLines() { return mNFoundLines; }
+  GPUhd() VectorHIP<int>& getNExclusiveFoundLines() { return mNExclusiveFoundLines; }
+  GPUhd() VectorHIP<int>& getCUBTmpBuffer() { return mCUBTmpBuffer; }
+  GPUhd() VectorHIP<float>& getXYCentroids() { return mXYCentroids; }
+  GPUhd() VectorHIP<float>& getZCentroids() { return mZCentroids; }
+  GPUhd() ArrayHIP<VectorHIP<int>, 3>& getHistogramXYZ() { return mHistogramXYZ; }
+  GPUhd() VectorHIP<hipcub::KeyValuePair<int, int>>& getTmpVertexPositionBins() { return mTmpVertexPositionBins; }
 
 #ifdef _ALLOW_DEBUG_TREES_ITS_
-  GPUd() Array<Vector<int>, 2>& getDupletIndices()
+  GPUd() ArrayHIP<VectorHIP<int>, 2>& getDupletIndices()
   {
     return mDupletIndices;
   }
 #endif
-  GPUhd() Vector<int>& getNFoundTracklets(Order order)
+  GPUhd() VectorHIP<int>& getNFoundTracklets(Order order)
   {
     return mNFoundDuplets[static_cast<int>(order)];
   }
@@ -107,32 +107,32 @@ class DeviceStoreVertexerGPU final
 
  private:
   VertexerStoreConfigurationGPU mGPUConf;
-  Array<Vector<Cluster>, constants::its::LayersNumberVertexer> mClusters;
-  Vector<Line> mTracklets;
-  Array<Vector<int>, 2> mIndexTables;
-  Vector<GPUVertex> mGPUVertices;
+  ArrayHIP<VectorHIP<Cluster>, constants::its::LayersNumberVertexer> mClusters;
+  VectorHIP<Line> mTracklets;
+  ArrayHIP<VectorHIP<int>, 2> mIndexTables;
+  VectorHIP<GPUVertex> mGPUVertices;
 
   // service buffers
-  Vector<int> mNFoundLines;
-  Vector<int> mNExclusiveFoundLines;
-  Vector<Tracklet> mDuplets01;
-  Vector<Tracklet> mDuplets12;
-  Array<Vector<int>, constants::its::LayersNumberVertexer - 1> mNFoundDuplets;
-  Vector<int> mCUBTmpBuffer;
-  Vector<float> mXYCentroids;
-  Vector<float> mZCentroids;
-  Vector<float> mBeamPosition;
-  Array<Vector<int>, 3> mHistogramXYZ;
-  Vector<hipcub::KeyValuePair<int, int>> mTmpVertexPositionBins;
+  VectorHIP<int> mNFoundLines;
+  VectorHIP<int> mNExclusiveFoundLines;
+  VectorHIP<Tracklet> mDuplets01;
+  VectorHIP<Tracklet> mDuplets12;
+  ArrayHIP<VectorHIP<int>, constants::its::LayersNumberVertexer - 1> mNFoundDuplets;
+  VectorHIP<int> mCUBTmpBuffer;
+  VectorHIP<float> mXYCentroids;
+  VectorHIP<float> mZCentroids;
+  VectorHIP<float> mBeamPosition;
+  ArrayHIP<VectorHIP<int>, 3> mHistogramXYZ;
+  VectorHIP<hipcub::KeyValuePair<int, int>> mTmpVertexPositionBins;
 
 #ifdef _ALLOW_DEBUG_TREES_ITS_
-  Array<Vector<int>, 2> mDupletIndices;
-  Vector<int> mSizes;
+  ArrayHIP<VectorHIP<int>, 2> mDupletIndices;
+  VectorHIP<int> mSizes;
 #endif
 };
 
 #ifdef _ALLOW_DEBUG_TREES_ITS_
-inline std::vector<int> DeviceStoreVertexerGPU::getNFoundTrackletsFromGPU(const Order order)
+inline std::vector<int> DeviceStoreVertexerHIP::getNFoundTrackletsFromGPU(const Order order)
 {
   // Careful: this might lead to large allocations, use debug-purpose only
   std::vector<int> sizes;
@@ -150,7 +150,7 @@ inline std::vector<int> DeviceStoreVertexerGPU::getNFoundTrackletsFromGPU(const 
   return nFoundDuplets;
 }
 
-inline std::vector<Tracklet> DeviceStoreVertexerGPU::getRawDupletsFromGPU(const Order order)
+inline std::vector<Tracklet> DeviceStoreVertexerHIP::getRawDupletsFromGPU(const Order order)
 {
   // Careful: this might lead to large allocations, use debug-purpose only
   std::vector<int> sizes;
@@ -172,7 +172,7 @@ inline std::vector<Tracklet> DeviceStoreVertexerGPU::getRawDupletsFromGPU(const 
   return tmpDuplets;
 }
 
-inline std::vector<Tracklet> DeviceStoreVertexerGPU::getDupletsFromGPU(const Order order)
+inline std::vector<Tracklet> DeviceStoreVertexerHIP::getDupletsFromGPU(const Order order)
 {
   // Careful: this might lead to large allocations, use debug-purpose only
   std::vector<int> sizes;
@@ -201,7 +201,7 @@ inline std::vector<Tracklet> DeviceStoreVertexerGPU::getDupletsFromGPU(const Ord
   return shrinkedDuplets;
 }
 
-inline std::vector<std::array<int, 2>> DeviceStoreVertexerGPU::getDupletIndicesFromGPU()
+inline std::vector<std::array<int, 2>> DeviceStoreVertexerHIP::getDupletIndicesFromGPU()
 {
   // Careful: this might lead to large allocations, use debug-purpose only.
   std::array<std::vector<int>, 2> allowedLines;
@@ -219,7 +219,7 @@ inline std::vector<std::array<int, 2>> DeviceStoreVertexerGPU::getDupletIndicesF
   return allowedPairIndices;
 }
 
-inline std::array<std::vector<int>, 2> DeviceStoreVertexerGPU::getHistogramXYFromGPU()
+inline std::array<std::vector<int>, 2> DeviceStoreVertexerHIP::getHistogramXYFromGPU()
 {
   std::array<std::vector<int>, 2> histoXY;
   for (int iHisto{0}; iHisto < 2; ++iHisto) {
@@ -230,7 +230,7 @@ inline std::array<std::vector<int>, 2> DeviceStoreVertexerGPU::getHistogramXYFro
   return histoXY;
 }
 
-inline std::vector<int> DeviceStoreVertexerGPU::getHistogramZFromGPU()
+inline std::vector<int> DeviceStoreVertexerHIP::getHistogramZFromGPU()
 {
   std::vector<int> histoZ;
   histoZ.resize(mGPUConf.nBinsXYZ[2] - 1);
@@ -240,7 +240,7 @@ inline std::vector<int> DeviceStoreVertexerGPU::getHistogramZFromGPU()
   return histoZ;
 }
 
-inline void DeviceStoreVertexerGPU::updateDuplets(const Order order, std::vector<Tracklet>& duplets)
+inline void DeviceStoreVertexerHIP::updateDuplets(const Order order, std::vector<Tracklet>& duplets)
 {
   if (order == GPU::Order::fromInnermostToMiddleLayer) {
     mDuplets01.reset(duplets.data(), static_cast<int>(duplets.size()));
@@ -249,7 +249,7 @@ inline void DeviceStoreVertexerGPU::updateDuplets(const Order order, std::vector
   }
 }
 
-inline void DeviceStoreVertexerGPU::updateFoundDuplets(const Order order, std::vector<int>& nDuplets)
+inline void DeviceStoreVertexerHIP::updateFoundDuplets(const Order order, std::vector<int>& nDuplets)
 {
   if (order == GPU::Order::fromInnermostToMiddleLayer) {
     mNFoundDuplets[0].reset(nDuplets.data(), static_cast<int>(nDuplets.size()));
@@ -258,7 +258,7 @@ inline void DeviceStoreVertexerGPU::updateFoundDuplets(const Order order, std::v
   }
 }
 
-inline std::vector<Line> DeviceStoreVertexerGPU::getRawLinesFromGPU()
+inline std::vector<Line> DeviceStoreVertexerHIP::getRawLinesFromGPU()
 {
   std::vector<Line> lines;
   lines.resize(mGPUConf.processedTrackletsCapacity);
@@ -267,7 +267,7 @@ inline std::vector<Line> DeviceStoreVertexerGPU::getRawLinesFromGPU()
   return lines;
 }
 
-std::vector<int> DeviceStoreVertexerGPU::getNFoundLinesFromGPU()
+std::vector<int> DeviceStoreVertexerHIP::getNFoundLinesFromGPU()
 {
   std::vector<int> nFoundLines;
   nFoundLines.resize(mGPUConf.clustersPerLayerCapacity);
@@ -276,7 +276,7 @@ std::vector<int> DeviceStoreVertexerGPU::getNFoundLinesFromGPU()
   return nFoundLines;
 }
 
-inline std::vector<Line> DeviceStoreVertexerGPU::getLinesFromGPU()
+inline std::vector<Line> DeviceStoreVertexerHIP::getLinesFromGPU()
 {
   std::vector<Line> lines;
   std::vector<Line> tmpLines;

--- a/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/DeviceStoreVertexerHIP.h
+++ b/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/DeviceStoreVertexerHIP.h
@@ -8,13 +8,13 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 ///
-/// \file DeviceStoreVertexer.h
+/// \file DeviceStoreVertexerHIP.h
 /// \brief This class serves as memory interface for GPU vertexer. It will access needed data structures from devicestore apis.
 ///        routines as static as possible.
 /// \author matteo.concas@cern.ch
 
-#ifndef ITSTRACKING_INCLUDE_DEVICESTOREVERTEXER_HIP_H_
-#define ITSTRACKING_INCLUDE_DEVICESTOREVERTEXER_HIP_H_
+#ifndef O2_ITS_TRACKING_INCLUDE_DEVICESTOREVERTEXER_HIP_H_
+#define O2_ITS_TRACKING_INCLUDE_DEVICESTOREVERTEXER_HIP_H_
 
 #include <hipcub/hipcub.hpp>
 
@@ -294,4 +294,4 @@ inline std::vector<Line> DeviceStoreVertexerGPU::getLinesFromGPU()
 } // namespace GPU
 } // namespace its
 } // namespace o2
-#endif //ITSTRACKING_INCLUDE_DEVICESTOREVERTEXER_HIP_H_
+#endif //O2_ITS_TRACKING_INCLUDE_DEVICESTOREVERTEXER_HIP_H_

--- a/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/DeviceStoreVertexerHIP.h
+++ b/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/DeviceStoreVertexerHIP.h
@@ -1,0 +1,297 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+///
+/// \file DeviceStoreVertexer.h
+/// \brief This class serves as memory interface for GPU vertexer. It will access needed data structures from devicestore apis.
+///        routines as static as possible.
+/// \author matteo.concas@cern.ch
+
+#ifndef ITSTRACKING_INCLUDE_DEVICESTOREVERTEXER_HIP_H_
+#define ITSTRACKING_INCLUDE_DEVICESTOREVERTEXER_HIP_H_
+
+#include <hipcub/hipcub.hpp>
+
+#include "ITStracking/Cluster.h"
+#include "ITStracking/Constants.h"
+#include "ITStracking/Configuration.h"
+#include "ITStracking/Tracklet.h"
+#include "ITStracking/ClusterLines.h"
+#include "ITStrackingHIP/ArrayHIP.h"
+#include "ITStrackingHIP/ClusterLinesHIP.h"
+#include "ITStrackingHIP/UniquePointerHIP.h"
+#include "ITStrackingHIP/VectorHIP.h"
+#include "GPUCommonDef.h"
+
+namespace o2
+{
+namespace its
+{
+namespace GPU
+{
+
+enum class TrackletingLayerOrder {
+  fromInnermostToMiddleLayer,
+  fromMiddleToOuterLayer
+};
+
+enum class VertexerLayerName {
+  innermostLayer,
+  middleLayer,
+  outerLayer
+};
+
+typedef TrackletingLayerOrder Order;
+class DeviceStoreVertexerGPU final
+{
+ public:
+  DeviceStoreVertexerGPU();
+  ~DeviceStoreVertexerGPU() = default;
+
+  UniquePointer<DeviceStoreVertexerGPU> initialise(const std::array<std::vector<Cluster>, constants::its::LayersNumberVertexer>&,
+                                                   const std::array<std::array<int, constants::index_table::ZBins * constants::index_table::PhiBins + 1>,
+                                                                    constants::its::LayersNumberVertexer>&);
+
+  // RO APIs
+  GPUd() const Array<Vector<Cluster>, constants::its::LayersNumberVertexer>& getClusters()
+  {
+    return mClusters;
+  }
+  GPUd() const Vector<int>& getIndexTable(const VertexerLayerName);
+  GPUhd() VertexerStoreConfigurationGPU& getConfig() { return mGPUConf; }
+
+  // Writable APIs
+  GPUd() Vector<Tracklet>& getDuplets01() { return mDuplets01; }
+  GPUd() Vector<Tracklet>& getDuplets12() { return mDuplets12; }
+  GPUd() Vector<Line>& getLines() { return mTracklets; }
+  GPUd() Vector<float>& getBeamPosition() { return mBeamPosition; }
+  GPUhd() Vector<GPUVertex>& getVertices() { return mGPUVertices; }
+  GPUhd() Vector<int>& getNFoundLines() { return mNFoundLines; }
+  GPUhd() Vector<int>& getNExclusiveFoundLines() { return mNExclusiveFoundLines; }
+  GPUhd() Vector<int>& getCUBTmpBuffer() { return mCUBTmpBuffer; }
+  GPUhd() Vector<float>& getXYCentroids() { return mXYCentroids; }
+  GPUhd() Vector<float>& getZCentroids() { return mZCentroids; }
+  GPUhd() Array<Vector<int>, 3>& getHistogramXYZ() { return mHistogramXYZ; }
+  GPUhd() Vector<hipcub::KeyValuePair<int, int>>& getTmpVertexPositionBins() { return mTmpVertexPositionBins; }
+
+#ifdef _ALLOW_DEBUG_TREES_ITS_
+  GPUd() Array<Vector<int>, 2>& getDupletIndices()
+  {
+    return mDupletIndices;
+  }
+#endif
+  GPUhd() Vector<int>& getNFoundTracklets(Order order)
+  {
+    return mNFoundDuplets[static_cast<int>(order)];
+  }
+
+#ifdef _ALLOW_DEBUG_TREES_ITS_
+  GPUh() void updateDuplets(const Order, std::vector<Tracklet>&);
+  GPUh() void updateFoundDuplets(const Order, std::vector<int>&);
+  GPUh() std::vector<int> getNFoundTrackletsFromGPU(const Order);
+  GPUh() std::vector<Tracklet> getRawDupletsFromGPU(const Order);
+  GPUh() std::vector<Tracklet> getDupletsFromGPU(const Order);
+  GPUh() std::vector<Line> getRawLinesFromGPU();
+  GPUh() std::vector<std::array<int, 2>> getDupletIndicesFromGPU();
+  GPUh() std::vector<int> getNFoundLinesFromGPU();
+  GPUh() std::array<std::vector<int>, 2> getHistogramXYFromGPU();
+  GPUh() std::vector<int> getHistogramZFromGPU();
+  GPUh() std::vector<Line> getLinesFromGPU();
+#endif
+
+ private:
+  VertexerStoreConfigurationGPU mGPUConf;
+  Array<Vector<Cluster>, constants::its::LayersNumberVertexer> mClusters;
+  Vector<Line> mTracklets;
+  Array<Vector<int>, 2> mIndexTables;
+  Vector<GPUVertex> mGPUVertices;
+
+  // service buffers
+  Vector<int> mNFoundLines;
+  Vector<int> mNExclusiveFoundLines;
+  Vector<Tracklet> mDuplets01;
+  Vector<Tracklet> mDuplets12;
+  Array<Vector<int>, constants::its::LayersNumberVertexer - 1> mNFoundDuplets;
+  Vector<int> mCUBTmpBuffer;
+  Vector<float> mXYCentroids;
+  Vector<float> mZCentroids;
+  Vector<float> mBeamPosition;
+  Array<Vector<int>, 3> mHistogramXYZ;
+  Vector<hipcub::KeyValuePair<int, int>> mTmpVertexPositionBins;
+
+#ifdef _ALLOW_DEBUG_TREES_ITS_
+  Array<Vector<int>, 2> mDupletIndices;
+  Vector<int> mSizes;
+#endif
+};
+
+#ifdef _ALLOW_DEBUG_TREES_ITS_
+inline std::vector<int> DeviceStoreVertexerGPU::getNFoundTrackletsFromGPU(const Order order)
+{
+  // Careful: this might lead to large allocations, use debug-purpose only
+  std::vector<int> sizes;
+  sizes.resize(constants::its::LayersNumberVertexer);
+  mSizes.copyIntoSizedVector(sizes);
+  std::vector<int> nFoundDuplets;
+  nFoundDuplets.resize(sizes[1]);
+
+  if (order == GPU::Order::fromInnermostToMiddleLayer) {
+    mNFoundDuplets[0].copyIntoSizedVector(nFoundDuplets);
+  } else {
+    mNFoundDuplets[1].copyIntoSizedVector(nFoundDuplets);
+  }
+
+  return nFoundDuplets;
+}
+
+inline std::vector<Tracklet> DeviceStoreVertexerGPU::getRawDupletsFromGPU(const Order order)
+{
+  // Careful: this might lead to large allocations, use debug-purpose only
+  std::vector<int> sizes;
+  sizes.resize(constants::its::LayersNumberVertexer);
+  mSizes.copyIntoSizedVector(sizes);
+  std::vector<Tracklet> tmpDuplets;
+  tmpDuplets.resize(static_cast<size_t>(mGPUConf.dupletsCapacity));
+  std::vector<int> nFoundDuplets;
+  nFoundDuplets.resize(sizes[1]);
+
+  if (order == GPU::Order::fromInnermostToMiddleLayer) {
+    mNFoundDuplets[0].copyIntoSizedVector(nFoundDuplets);
+    mDuplets01.copyIntoSizedVector(tmpDuplets);
+  } else {
+    mDuplets12.copyIntoSizedVector(tmpDuplets);
+    mNFoundDuplets[1].copyIntoSizedVector(nFoundDuplets);
+  }
+
+  return tmpDuplets;
+}
+
+inline std::vector<Tracklet> DeviceStoreVertexerGPU::getDupletsFromGPU(const Order order)
+{
+  // Careful: this might lead to large allocations, use debug-purpose only
+  std::vector<int> sizes;
+  sizes.resize(constants::its::LayersNumberVertexer);
+  mSizes.copyIntoSizedVector(sizes);
+  std::vector<Tracklet> tmpDuplets;
+  tmpDuplets.resize(static_cast<size_t>(mGPUConf.dupletsCapacity));
+  std::vector<int> nFoundDuplets;
+  nFoundDuplets.resize(sizes[1]);
+  std::vector<Tracklet> shrinkedDuplets;
+
+  if (order == GPU::Order::fromInnermostToMiddleLayer) {
+    mNFoundDuplets[0].copyIntoSizedVector(nFoundDuplets);
+    mDuplets01.copyIntoSizedVector(tmpDuplets);
+  } else {
+    mDuplets12.copyIntoSizedVector(tmpDuplets);
+    mNFoundDuplets[1].copyIntoSizedVector(nFoundDuplets);
+  }
+
+  for (int iCluster{0}; iCluster < sizes[1]; ++iCluster) {
+    const int stride{iCluster * mGPUConf.maxTrackletsPerCluster};
+    for (int iDuplet{0}; iDuplet < nFoundDuplets[iCluster]; ++iDuplet) {
+      shrinkedDuplets.push_back(tmpDuplets[stride + iDuplet]);
+    }
+  }
+  return shrinkedDuplets;
+}
+
+inline std::vector<std::array<int, 2>> DeviceStoreVertexerGPU::getDupletIndicesFromGPU()
+{
+  // Careful: this might lead to large allocations, use debug-purpose only.
+  std::array<std::vector<int>, 2> allowedLines;
+  std::vector<std::array<int, 2>> allowedPairIndices;
+  int nLines = getNExclusiveFoundLines().getElementFromDevice(mClusters[1].getSizeFromDevice() - 1) + getNFoundLines().getElementFromDevice(mClusters[1].getSizeFromDevice() - 1);
+  allowedPairIndices.reserve(nLines);
+  for (int iAllowed{0}; iAllowed < 2; ++iAllowed) {
+    allowedLines[iAllowed].resize(nLines);
+    mDupletIndices[iAllowed].resize(nLines);
+    mDupletIndices[iAllowed].copyIntoSizedVector(allowedLines[iAllowed]);
+  }
+  for (size_t iPair{0}; iPair < allowedLines[0].size(); ++iPair) {
+    allowedPairIndices.emplace_back(std::array<int, 2>{allowedLines[0][iPair], allowedLines[1][iPair]});
+  }
+  return allowedPairIndices;
+}
+
+inline std::array<std::vector<int>, 2> DeviceStoreVertexerGPU::getHistogramXYFromGPU()
+{
+  std::array<std::vector<int>, 2> histoXY;
+  for (int iHisto{0}; iHisto < 2; ++iHisto) {
+    histoXY[iHisto].resize(mGPUConf.nBinsXYZ[iHisto] - 1);
+    mHistogramXYZ[iHisto].copyIntoSizedVector(histoXY[iHisto]);
+  }
+
+  return histoXY;
+}
+
+inline std::vector<int> DeviceStoreVertexerGPU::getHistogramZFromGPU()
+{
+  std::vector<int> histoZ;
+  histoZ.resize(mGPUConf.nBinsXYZ[2] - 1);
+  std::cout << "Size of dest vector to be refined" << std::endl;
+  mHistogramXYZ[2].copyIntoSizedVector(histoZ);
+
+  return histoZ;
+}
+
+inline void DeviceStoreVertexerGPU::updateDuplets(const Order order, std::vector<Tracklet>& duplets)
+{
+  if (order == GPU::Order::fromInnermostToMiddleLayer) {
+    mDuplets01.reset(duplets.data(), static_cast<int>(duplets.size()));
+  } else {
+    mDuplets12.reset(duplets.data(), static_cast<int>(duplets.size()));
+  }
+}
+
+inline void DeviceStoreVertexerGPU::updateFoundDuplets(const Order order, std::vector<int>& nDuplets)
+{
+  if (order == GPU::Order::fromInnermostToMiddleLayer) {
+    mNFoundDuplets[0].reset(nDuplets.data(), static_cast<int>(nDuplets.size()));
+  } else {
+    mNFoundDuplets[1].reset(nDuplets.data(), static_cast<int>(nDuplets.size()));
+  }
+}
+
+inline std::vector<Line> DeviceStoreVertexerGPU::getRawLinesFromGPU()
+{
+  std::vector<Line> lines;
+  lines.resize(mGPUConf.processedTrackletsCapacity);
+  mTracklets.copyIntoSizedVector(lines);
+
+  return lines;
+}
+
+std::vector<int> DeviceStoreVertexerGPU::getNFoundLinesFromGPU()
+{
+  std::vector<int> nFoundLines;
+  nFoundLines.resize(mGPUConf.clustersPerLayerCapacity);
+  mNFoundLines.copyIntoSizedVector(nFoundLines);
+
+  return nFoundLines;
+}
+
+inline std::vector<Line> DeviceStoreVertexerGPU::getLinesFromGPU()
+{
+  std::vector<Line> lines;
+  std::vector<Line> tmpLines;
+  tmpLines.resize(mGPUConf.processedTrackletsCapacity);
+  mTracklets.copyIntoSizedVector(tmpLines);
+  for (auto& line : tmpLines) {
+    if (line.isEmpty) {
+      break;
+    }
+    lines.push_back(line);
+  }
+  return lines;
+}
+#endif
+} // namespace GPU
+} // namespace its
+} // namespace o2
+#endif //ITSTRACKING_INCLUDE_DEVICESTOREVERTEXER_HIP_H_

--- a/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/StreamHIP.h
+++ b/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/StreamHIP.h
@@ -8,12 +8,12 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 ///
-/// \file Stream.h
+/// \file StreamHIP.h
 /// \brief
 ///
 
-#ifndef TRACKINGITS_INCLUDE_STREAM_HIP_H_
-#define TRACKINGITS_INCLUDE_STREAM_HIP_H_
+#ifndef O2_ITS_TRACKING_INCLUDE_STREAM_HIP_H_
+#define O2_ITS_TRACKING_INCLUDE_STREAM_HIP_H_
 
 #include "ITStracking/Definitions.h"
 
@@ -43,4 +43,4 @@ class Stream final
 } // namespace its
 } // namespace o2
 
-#endif /* TRACKINGITS_INCLUDE_STREAM_HIP_H_ */
+#endif /* O2_ITS_TRACKING_INCLUDE_STREAM_HIP_H_ */

--- a/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/StreamHIP.h
+++ b/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/StreamHIP.h
@@ -12,8 +12,8 @@
 /// \brief
 ///
 
-#ifndef TRAKINGITSU_INCLUDE_GPU_STREAM_H_
-#define TRAKINGITSU_INCLUDE_GPU_STREAM_H_
+#ifndef TRACKINGITS_INCLUDE_STREAM_HIP_H_
+#define TRACKINGITS_INCLUDE_STREAM_HIP_H_
 
 #include "ITStracking/Definitions.h"
 
@@ -43,4 +43,4 @@ class Stream final
 } // namespace its
 } // namespace o2
 
-#endif /* TRAKINGITSU_INCLUDE_GPU_STREAM_H_ */
+#endif /* TRACKINGITS_INCLUDE_STREAM_HIP_H_ */

--- a/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/StreamHIP.h
+++ b/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/StreamHIP.h
@@ -15,7 +15,7 @@
 #ifndef O2_ITS_TRACKING_INCLUDE_STREAM_HIP_H_
 #define O2_ITS_TRACKING_INCLUDE_STREAM_HIP_H_
 
-#include "ITStracking/Definitions.h"
+#include <hip/hip_runtime_api.h>
 
 namespace o2
 {
@@ -24,20 +24,20 @@ namespace its
 namespace GPU
 {
 
-class Stream final
+class StreamHIP final
 {
 
  public:
-  Stream();
-  ~Stream();
+  StreamHIP();
+  ~StreamHIP();
 
-  Stream(const Stream&) = delete;
-  Stream& operator=(const Stream&) = delete;
+  StreamHIP(const StreamHIP&) = delete;
+  StreamHIP& operator=(const StreamHIP&) = delete;
 
-  const GPUStream& get() const;
+  const hipStream_t& get() const;
 
  private:
-  GPUStream mStream;
+  hipStream_t mStream;
 };
 } // namespace GPU
 } // namespace its

--- a/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/UniquePointerHIP.h
+++ b/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/UniquePointerHIP.h
@@ -8,12 +8,12 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 ///
-/// \file UniquePointer.h
+/// \file UniquePointerHIP.h
 /// \brief
 ///
 
-#ifndef TRACKINGITS_INCLUDE_UNIQUEPOINTER_HIP_H_
-#define TRACKINGITS_INCLUDE_UNIQUEPOINTER_HIP_H_
+#ifndef O2_ITS_TRACKING_INCLUDE_UNIQUEPOINTER_HIP_H_
+#define O2_ITS_TRACKING_INCLUDE_UNIQUEPOINTER_HIP_H_
 
 #include "GPUCommonDef.h"
 #include "ITStrackingHIP/UtilsHIP.h"
@@ -150,4 +150,4 @@ GPUhd() const T& UniquePointer<T>::operator*() const noexcept
 } // namespace its
 } // namespace o2
 
-#endif /* TRACKINGITS_INCLUDE_UNIQUEPOINTER_HIP_H_ */
+#endif /* O2_ITS_TRACKING_INCLUDE_UNIQUEPOINTER_HIP_H_ */

--- a/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/UniquePointerHIP.h
+++ b/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/UniquePointerHIP.h
@@ -82,8 +82,8 @@ UniquePointer<T>::UniquePointer(const T& ref)
 {
   try {
 
-    Utils::Host::gpuMalloc(reinterpret_cast<void**>(&mDevicePointer), sizeof(T));
-    Utils::Host::gpuMemcpyHostToDevice(mDevicePointer, &ref, sizeof(T));
+    Utils::HostHIP::gpuMalloc(reinterpret_cast<void**>(&mDevicePointer), sizeof(T));
+    Utils::HostHIP::gpuMemcpyHostToDevice(mDevicePointer, &ref, sizeof(T));
 
   } catch (...) {
 
@@ -119,7 +119,7 @@ void UniquePointer<T>::destroy()
 {
   if (mDevicePointer != nullptr) {
 
-    Utils::Host::gpuFree(mDevicePointer);
+    Utils::HostHIP::gpuFree(mDevicePointer);
   }
 }
 

--- a/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/UniquePointerHIP.h
+++ b/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/UniquePointerHIP.h
@@ -1,0 +1,153 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+///
+/// \file UniquePointer.h
+/// \brief
+///
+
+#ifndef TRACKINGITS_INCLUDE_UNIQUEPOINTER_HIP_H_
+#define TRACKINGITS_INCLUDE_UNIQUEPOINTER_HIP_H_
+
+#include "GPUCommonDef.h"
+#include "ITStrackingHIP/UtilsHIP.h"
+
+namespace o2
+{
+namespace its
+{
+namespace GPU
+{
+
+namespace
+{
+template <typename T>
+struct UniquePointerTraits final {
+  typedef T* InternalPointer;
+
+  GPUhd() static constexpr T& getReference(const InternalPointer& internalPointer) noexcept
+  {
+    return const_cast<T&>(*internalPointer);
+  }
+
+  GPUhd() static constexpr T* getPointer(const InternalPointer& internalPointer) noexcept
+  {
+    return const_cast<T*>(internalPointer);
+  }
+};
+} // namespace
+
+template <typename T>
+class UniquePointer final
+{
+  typedef UniquePointerTraits<T> PointerTraits;
+
+ public:
+  UniquePointer();
+  explicit UniquePointer(const T&);
+  ~UniquePointer();
+
+  UniquePointer(const UniquePointer&) = delete;
+  UniquePointer& operator=(const UniquePointer&) = delete;
+
+  UniquePointer(UniquePointer&&);
+  UniquePointer& operator=(UniquePointer&&);
+
+  GPUhd() T* get() noexcept;
+  GPUhd() const T* get() const noexcept;
+  GPUhd() T& operator*() noexcept;
+  GPUhd() const T& operator*() const noexcept;
+
+ protected:
+  void destroy();
+
+ private:
+  typename PointerTraits::InternalPointer mDevicePointer;
+};
+
+template <typename T>
+UniquePointer<T>::UniquePointer() : mDevicePointer{nullptr}
+{
+  // Nothing to do
+}
+
+template <typename T>
+UniquePointer<T>::UniquePointer(const T& ref)
+{
+  try {
+
+    Utils::Host::gpuMalloc(reinterpret_cast<void**>(&mDevicePointer), sizeof(T));
+    Utils::Host::gpuMemcpyHostToDevice(mDevicePointer, &ref, sizeof(T));
+
+  } catch (...) {
+
+    destroy();
+
+    throw;
+  }
+}
+
+template <typename T>
+UniquePointer<T>::~UniquePointer()
+{
+  destroy();
+}
+
+template <typename T>
+UniquePointer<T>::UniquePointer(UniquePointer<T>&& other) : mDevicePointer{other.mDevicePointer}
+{
+  // Nothing to do
+}
+
+template <typename T>
+UniquePointer<T>& UniquePointer<T>::operator=(UniquePointer<T>&& other)
+{
+  mDevicePointer = other.mDevicePointer;
+  other.mDevicePointer = nullptr;
+
+  return *this;
+}
+
+template <typename T>
+void UniquePointer<T>::destroy()
+{
+  if (mDevicePointer != nullptr) {
+
+    Utils::Host::gpuFree(mDevicePointer);
+  }
+}
+
+template <typename T>
+GPUhd() T* UniquePointer<T>::get() noexcept
+{
+  return PointerTraits::getPointer(mDevicePointer);
+}
+
+template <typename T>
+GPUhd() const T* UniquePointer<T>::get() const noexcept
+{
+  return PointerTraits::getPointer(mDevicePointer);
+}
+
+template <typename T>
+GPUhd() T& UniquePointer<T>::operator*() noexcept
+{
+  return PointerTraits::getReference(mDevicePointer);
+}
+
+template <typename T>
+GPUhd() const T& UniquePointer<T>::operator*() const noexcept
+{
+  return PointerTraits::getReference(mDevicePointer);
+}
+} // namespace GPU
+} // namespace its
+} // namespace o2
+
+#endif /* TRACKINGITS_INCLUDE_UNIQUEPOINTER_HIP_H_ */

--- a/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/UtilsHIP.h
+++ b/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/UtilsHIP.h
@@ -8,12 +8,12 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 ///
-/// \file Utils.h
+/// \file UtilsHIP.h
 /// \brief
 ///
 
-#ifndef TRACKINGITS_INCLUDE_UTILS_HIP_H_
-#define TRACKINGITS_INCLUDE_UTILS_HIP_H_
+#ifndef O2_ITS_TRACKING_INCLUDE_UTILS_HIP_H_
+#define O2_ITS_TRACKING_INCLUDE_UTILS_HIP_H_
 
 #include "GPUCommonDef.h"
 #include "ITStrackingHIP/StreamHIP.h"
@@ -63,4 +63,4 @@ GPUd() int gpuAtomicAdd(int*, const int);
 } // namespace its
 } // namespace o2
 
-#endif /* TRACKINGITS_INCLUDE_UTILS_HIP_H_ */
+#endif /* O2_ITS_TRACKING_INCLUDE_UTILS_HIP_H_ */

--- a/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/UtilsHIP.h
+++ b/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/UtilsHIP.h
@@ -12,8 +12,8 @@
 /// \brief
 ///
 
-#ifndef TRACKINGITS_INCLUDE_GPU_UTILS_HIP_H_
-#define TRACKINGITS_INCLUDE_GPU_UTILS_HIP_H_
+#ifndef TRACKINGITS_INCLUDE_UTILS_HIP_H_
+#define TRACKINGITS_INCLUDE_UTILS_HIP_H_
 
 #include "GPUCommonDef.h"
 #include "ITStrackingHIP/StreamHIP.h"
@@ -36,8 +36,8 @@ namespace Host
 void checkHIPError(const hipError_t error, const char* file, const int line);
 #endif
 
-// dim3 getBlockSize(const int);
-// dim3 getBlockSize(const int, const int);
+dim3 getBlockSize(const int);
+dim3 getBlockSize(const int, const int);
 dim3 getBlockSize(const int, const int, const int);
 dim3 getBlocksGrid(const dim3&, const int);
 dim3 getBlocksGrid(const dim3&, const int, const int);
@@ -63,4 +63,4 @@ GPUd() int gpuAtomicAdd(int*, const int);
 } // namespace its
 } // namespace o2
 
-#endif /* TRACKINGITS_INCLUDE_GPU_UTILS_HIP_H_ */
+#endif /* TRACKINGITS_INCLUDE_UTILS_HIP_H_ */

--- a/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/UtilsHIP.h
+++ b/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/UtilsHIP.h
@@ -29,7 +29,7 @@ namespace GPU
 namespace Utils
 {
 
-namespace Host
+namespace HostHIP
 {
 
 #ifdef __HIPCC__
@@ -52,7 +52,7 @@ void gpuStartProfiler();
 void gpuStopProfiler();
 } // namespace Host
 //
-namespace Device
+namespace DeviceHIP
 {
 GPUd() int getLaneIndex();
 GPUd() int shareToWarp(const int, const int);

--- a/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/VectorHIP.h
+++ b/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/VectorHIP.h
@@ -50,7 +50,7 @@ class VectorHIP final
 
   int getSizeFromDevice() const;
 
-  GPUh() T getElementFromDevice(const int) const;
+  T getElementFromDevice(const int) const;
 
   void resize(const int);
   void reset(const int, const int = 0);
@@ -61,9 +61,9 @@ class VectorHIP final
   GPUhd() T* get() const;
   GPUhd() int capacity() const;
   GPUhd() VectorHIP<T> getWeakCopy() const;
-  GPUd() T& operator[](const int) const;
+  GPUhd() T& operator[](const int) const;
 
-  GPUd() int size() const;
+  GPUhd() int size() const;
   GPUd() int extend(const int) const;
   GPUhd() void dump();
 
@@ -281,13 +281,13 @@ GPUhd() VectorHIP<T> VectorHIP<T>::getWeakCopy() const
 }
 
 template <typename T>
-GPUd() T& VectorHIP<T>::operator[](const int index) const
+GPUhd() T& VectorHIP<T>::operator[](const int index) const
 {
   return mArrayPointer[index];
 }
 
 template <typename T>
-GPUh() T VectorHIP<T>::getElementFromDevice(const int index) const
+T VectorHIP<T>::getElementFromDevice(const int index) const
 {
   T element;
   Utils::HostHIP::gpuMemcpyDeviceToHost(&element, mArrayPointer + index, sizeof(T));
@@ -296,7 +296,7 @@ GPUh() T VectorHIP<T>::getElementFromDevice(const int index) const
 }
 
 template <typename T>
-GPUd() int VectorHIP<T>::size() const
+GPUhd() int VectorHIP<T>::size() const
 {
   return *mDeviceSize;
 }

--- a/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/VectorHIP.h
+++ b/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/VectorHIP.h
@@ -1,0 +1,331 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+///
+/// \file Vector.h
+/// \brief
+///
+
+#ifndef TRACKINGITS_INCLUDE_VECTOR_HIP_H_
+#define TRACKINGITS_INCLUDE_VECTOR_HIP_H_
+
+#include <assert.h>
+#include <new>
+#include <type_traits>
+#include <vector>
+
+#include "GPUCommonDef.h"
+#include "ITStracking/Definitions.h"
+#include "ITStrackingHIP/StreamHIP.h"
+#include "ITStrackingHIP/UtilsHIP.h"
+
+namespace o2
+{
+namespace its
+{
+namespace GPU
+{
+
+template <typename T>
+class Vector final
+{
+  static_assert(std::is_trivially_destructible<T>::value, "Vector only supports trivially destructible objects.");
+
+ public:
+  Vector();
+  explicit Vector(const int, const int = 0);
+  Vector(const T* const, const int, const int = 0);
+  GPUhd() ~Vector();
+
+  Vector(const Vector&) = delete;
+  Vector& operator=(const Vector&) = delete;
+
+  GPUhd() Vector(Vector&&);
+  Vector& operator=(Vector&&);
+
+  int getSizeFromDevice() const;
+
+  T getElementFromDevice(const int) const;
+
+  void resize(const int);
+  void reset(const int, const int = 0);
+  void reset(const T* const, const int, const int = 0);
+  void copyIntoVector(std::vector<T>&, const int);
+  void copyIntoSizedVector(std::vector<T>&);
+
+  GPUhd() T* get() const;
+  GPUhd() int capacity() const;
+  GPUhd() Vector<T> getWeakCopy() const;
+  GPUd() T& operator[](const int) const;
+
+  GPUd() int size() const;
+  GPUd() int extend(const int) const;
+  GPUhd() void dump();
+
+  template <typename... Args>
+  GPUd() void emplace(const int, Args&&...);
+
+ protected:
+  void destroy();
+
+ private:
+  GPUhd() Vector(const Vector&, const bool);
+
+  T* mArrayPointer = nullptr;
+  int* mDeviceSize = nullptr;
+  int mCapacity;
+  bool mIsWeak;
+};
+
+template <typename T>
+Vector<T>::Vector() : Vector{nullptr, 0}
+{
+  // Nothing to do
+}
+
+template <typename T>
+Vector<T>::Vector(const int capacity, const int initialSize) : Vector{nullptr, capacity, initialSize}
+{
+  // Nothing to do
+}
+
+template <typename T>
+Vector<T>::Vector(const T* const source, const int size, const int initialSize) : mCapacity{size}, mIsWeak{false}
+{
+  if (size > 0) {
+    try {
+
+      Utils::Host::gpuMalloc(reinterpret_cast<void**>(&mArrayPointer), size * sizeof(T));
+      Utils::Host::gpuMalloc(reinterpret_cast<void**>(&mDeviceSize), sizeof(int));
+
+      if (source != nullptr) {
+
+        Utils::Host::gpuMemcpyHostToDevice(mArrayPointer, source, size * sizeof(T));
+        Utils::Host::gpuMemcpyHostToDevice(mDeviceSize, &size, sizeof(int));
+
+      } else {
+
+        Utils::Host::gpuMemcpyHostToDevice(mDeviceSize, &initialSize, sizeof(int));
+      }
+
+    } catch (...) {
+
+      destroy();
+
+      throw;
+    }
+  }
+}
+
+template <typename T>
+Vector<T>::Vector(const Vector& other, const bool isWeak)
+  : mArrayPointer{other.mArrayPointer},
+    mDeviceSize{other.mDeviceSize},
+    mCapacity{other.mCapacity},
+    mIsWeak{isWeak}
+{
+  // Nothing to do
+}
+
+template <typename T>
+GPUhd() Vector<T>::~Vector()
+{
+  if (mIsWeak) {
+
+    return;
+
+  } else {
+#if defined(TRACKINGITSU_GPU_DEVICE)
+    assert(0);
+#else
+    destroy();
+#endif
+  }
+}
+
+template <typename T>
+GPUhd() Vector<T>::Vector(Vector<T>&& other)
+  : mArrayPointer{other.mArrayPointer},
+    mDeviceSize{other.mDeviceSize},
+    mCapacity{other.mCapacity},
+    mIsWeak{other.mIsWeak}
+{
+  other.mArrayPointer = nullptr;
+  other.mDeviceSize = nullptr;
+}
+
+template <typename T>
+Vector<T>& Vector<T>::operator=(Vector<T>&& other)
+{
+  destroy();
+
+  mArrayPointer = other.mArrayPointer;
+  mDeviceSize = other.mDeviceSize;
+  mCapacity = other.mCapacity;
+  mIsWeak = other.mIsWeak;
+
+  other.mArrayPointer = nullptr;
+  other.mDeviceSize = nullptr;
+
+  return *this;
+}
+
+template <typename T>
+int Vector<T>::getSizeFromDevice() const
+{
+  int size;
+  Utils::Host::gpuMemcpyDeviceToHost(&size, mDeviceSize, sizeof(int));
+
+  return size;
+}
+
+template <typename T>
+void Vector<T>::resize(const int size)
+{
+  Utils::Host::gpuMemcpyHostToDevice(mDeviceSize, &size, sizeof(int));
+}
+
+template <typename T>
+void Vector<T>::reset(const int capacity, const int initialSize)
+{
+  reset(nullptr, capacity, initialSize);
+}
+
+template <typename T>
+void Vector<T>::reset(const T* const source, const int size, const int initialSize)
+{
+  if (size > mCapacity) {
+    if (mArrayPointer != nullptr) {
+      Utils::Host::gpuFree(mArrayPointer);
+    }
+
+    Utils::Host::gpuMalloc(reinterpret_cast<void**>(&mArrayPointer), size * sizeof(T));
+    mCapacity = size;
+  }
+
+  if (source != nullptr) {
+
+    Utils::Host::gpuMemcpyHostToDevice(mArrayPointer, source, size * sizeof(T));
+    Utils::Host::gpuMemcpyHostToDevice(mDeviceSize, &size, sizeof(int));
+
+  } else {
+    Utils::Host::gpuMemcpyHostToDevice(mDeviceSize, &initialSize, sizeof(int));
+  }
+}
+
+template <typename T>
+void Vector<T>::copyIntoVector(std::vector<T>& destinationVector, const int size)
+{
+
+  T* hostPrimitivePointer = nullptr;
+
+  try {
+
+    hostPrimitivePointer = static_cast<T*>(malloc(size * sizeof(T)));
+    Utils::Host::gpuMemcpyDeviceToHost(hostPrimitivePointer, mArrayPointer, size * sizeof(T));
+
+    destinationVector = std::move(std::vector<T>(hostPrimitivePointer, hostPrimitivePointer + size));
+
+  } catch (...) {
+
+    if (hostPrimitivePointer != nullptr) {
+
+      free(hostPrimitivePointer);
+    }
+
+    throw;
+  }
+}
+
+template <typename T>
+void Vector<T>::copyIntoSizedVector(std::vector<T>& destinationVector)
+{
+  Utils::Host::gpuMemcpyDeviceToHost(destinationVector.data(), mArrayPointer, destinationVector.size() * sizeof(T));
+}
+
+template <typename T>
+inline void Vector<T>::destroy()
+{
+  if (mArrayPointer != nullptr) {
+
+    Utils::Host::gpuFree(mArrayPointer);
+  }
+
+  if (mDeviceSize != nullptr) {
+
+    Utils::Host::gpuFree(mDeviceSize);
+  }
+}
+
+template <typename T>
+GPUhd() T* Vector<T>::get() const
+{
+  return mArrayPointer;
+}
+
+template <typename T>
+GPUhd() int Vector<T>::capacity() const
+{
+  return mCapacity;
+}
+
+template <typename T>
+GPUhd() Vector<T> Vector<T>::getWeakCopy() const
+{
+  return Vector{*this, true};
+}
+
+template <typename T>
+GPUd() T& Vector<T>::operator[](const int index) const
+{
+  return mArrayPointer[index];
+}
+
+template <typename T>
+GPUh() T Vector<T>::getElementFromDevice(const int index) const
+{
+  T element;
+  Utils::Host::gpuMemcpyDeviceToHost(&element, mArrayPointer + index, sizeof(T));
+
+  return element;
+}
+
+template <typename T>
+GPUd() int Vector<T>::size() const
+{
+  return *mDeviceSize;
+}
+
+template <typename T>
+GPUd() int Vector<T>::extend(const int sizeIncrement) const
+{
+  const int startIndex = Utils::Device::gpuAtomicAdd(mDeviceSize, sizeIncrement);
+  assert(size() <= mCapacity);
+
+  return startIndex;
+}
+
+template <typename T>
+template <typename... Args>
+GPUd() void Vector<T>::emplace(const int index, Args&&... arguments)
+{
+  new (mArrayPointer + index) T(std::forward<Args>(arguments)...);
+}
+
+template <typename T>
+GPUhd() void Vector<T>::dump()
+{
+  printf("mArrayPointer = %p\nmDeviceSize   = %p\nmCapacity     = %d\nmIsWeak       = %s\n",
+         mArrayPointer, mDeviceSize, mCapacity, mIsWeak ? "true" : "false");
+}
+} // namespace GPU
+} // namespace its
+} // namespace o2
+
+#endif /* TRACKINGITS_INCLUDE_VECTOR_HIP_H_ */

--- a/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/VectorHIP.h
+++ b/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/VectorHIP.h
@@ -51,7 +51,7 @@ class Vector final
 
   int getSizeFromDevice() const;
 
-  T getElementFromDevice(const int) const;
+  GPUh() T getElementFromDevice(const int) const;
 
   void resize(const int);
   void reset(const int, const int = 0);

--- a/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/VectorHIP.h
+++ b/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/VectorHIP.h
@@ -8,12 +8,12 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 ///
-/// \file Vector.h
+/// \file VectorHIP.h
 /// \brief
 ///
 
-#ifndef TRACKINGITS_INCLUDE_VECTOR_HIP_H_
-#define TRACKINGITS_INCLUDE_VECTOR_HIP_H_
+#ifndef O2_ITS_TRACKING_INCLUDE_VECTOR_HIP_H_
+#define O2_ITS_TRACKING_INCLUDE_VECTOR_HIP_H_
 
 #include <assert.h>
 #include <new>
@@ -328,4 +328,4 @@ GPUhd() void Vector<T>::dump()
 } // namespace its
 } // namespace o2
 
-#endif /* TRACKINGITS_INCLUDE_VECTOR_HIP_H_ */
+#endif /* O2_ITS_TRACKING_INCLUDE_VECTOR_HIP_H_ */

--- a/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/VertexerTraitsHIP.h
+++ b/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/VertexerTraitsHIP.h
@@ -8,12 +8,12 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 ///
-/// \file VertexerTraitsGPU.h
+/// \file VertexerTraitsHIP.h
 /// \brief
 /// \author matteo.concas@cern.ch
 
-#ifndef O2_ITS_TRACKING_VERTEXER_TRAITS_GPU_H_
-#define O2_ITS_TRACKING_VERTEXER_TRAITS_GPU_H_
+#ifndef O2_ITS_TRACKING_VERTEXERTRAITS_HIP_H_
+#define O2_ITS_TRACKING_VERTEXERTRAITS_HIP_H_
 
 #include <vector>
 #include <array>
@@ -24,8 +24,8 @@
 #include "ITStracking/Definitions.h"
 #include "ITStracking/Tracklet.h"
 
-#include "ITStrackingCUDA/DeviceStoreVertexerGPU.h"
-#include "ITStrackingCUDA/UniquePointer.h"
+#include "ITStrackingHIP/DeviceStoreVertexerHIP.h"
+#include "ITStrackingHIP/UniquePointerHIP.h"
 
 #ifdef _ALLOW_DEBUG_TREES_ITS_
 #include "ITStracking/StandaloneDebugger.h"
@@ -60,9 +60,12 @@ class VertexerTraitsGPU : public VertexerTraits
   // GPU-specific getters
   GPUd() static const int2 getBinsPhiRectWindow(const Cluster&, float maxdeltaphi);
   GPUhd() GPU::DeviceStoreVertexerGPU& getDeviceContext();
+  GPUhd() GPU::DeviceStoreVertexerGPU* getDeviceContextPtr();
 
  protected:
-
+  // #ifdef _ALLOW_DEBUG_TREES_ITS_
+  //   StandaloneDebugger* mDebugger;
+  // #endif
   GPU::DeviceStoreVertexerGPU mStoreVertexerGPU;
   GPU::UniquePointer<GPU::DeviceStoreVertexerGPU> mStoreVertexerGPUPtr;
 };
@@ -81,8 +84,13 @@ inline GPU::DeviceStoreVertexerGPU& VertexerTraitsGPU::getDeviceContext()
   return *mStoreVertexerGPUPtr;
 }
 
+inline GPU::DeviceStoreVertexerGPU* VertexerTraitsGPU::getDeviceContextPtr()
+{
+  return mStoreVertexerGPUPtr.get();
+}
+
 extern "C" VertexerTraits* createVertexerTraitsGPU();
 
 } // namespace its
 } // namespace o2
-#endif /* O2_ITS_TRACKING_VERTEXER_TRAITS_GPU_H_ */
+#endif /* O2_ITS_TRACKING_VERTEXERTRAITS_HIP_H_ */

--- a/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/VertexerTraitsHIP.h
+++ b/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/VertexerTraitsHIP.h
@@ -21,7 +21,7 @@
 #include "ITStracking/VertexerTraits.h"
 #include "ITStracking/Cluster.h"
 #include "ITStracking/Constants.h"
-#include "ITStracking/Definitions.h"
+// #include "ITStracking/Definitions.h"
 #include "ITStracking/Tracklet.h"
 
 #include "ITStrackingHIP/DeviceStoreVertexerHIP.h"
@@ -39,15 +39,15 @@ class ROframe;
 
 using constants::index_table::InversePhiBinSize;
 
-class VertexerTraitsGPU : public VertexerTraits
+class VertexerTraitsHIP : public VertexerTraits
 {
  public:
 #ifdef _ALLOW_DEBUG_TREES_ITS_
-  VertexerTraitsGPU();
-  virtual ~VertexerTraitsGPU();
+  VertexerTraitsHIP();
+  virtual ~VertexerTraitsHIP();
 #else
-  VertexerTraitsGPU();
-  virtual ~VertexerTraitsGPU() = default;
+  VertexerTraitsHIP();
+  virtual ~VertexerTraitsHIP() = default;
 #endif
   void initialise(ROframe*) override;
   void computeTracklets() override;
@@ -59,18 +59,18 @@ class VertexerTraitsGPU : public VertexerTraits
 
   // GPU-specific getters
   GPUd() static const int2 getBinsPhiRectWindow(const Cluster&, float maxdeltaphi);
-  GPUhd() GPU::DeviceStoreVertexerGPU& getDeviceContext();
-  GPUhd() GPU::DeviceStoreVertexerGPU* getDeviceContextPtr();
+  GPUhd() GPU::DeviceStoreVertexerHIP& getDeviceContext();
+  GPUhd() GPU::DeviceStoreVertexerHIP* getDeviceContextPtr();
 
  protected:
   // #ifdef _ALLOW_DEBUG_TREES_ITS_
   //   StandaloneDebugger* mDebugger;
   // #endif
-  GPU::DeviceStoreVertexerGPU mStoreVertexerGPU;
-  GPU::UniquePointer<GPU::DeviceStoreVertexerGPU> mStoreVertexerGPUPtr;
+  GPU::DeviceStoreVertexerHIP mStoreVertexerGPU;
+  GPU::UniquePointer<GPU::DeviceStoreVertexerHIP> mStoreVertexerGPUPtr;
 };
 
-inline GPUd() const int2 VertexerTraitsGPU::getBinsPhiRectWindow(const Cluster& currentCluster, float phiCut)
+inline GPUd() const int2 VertexerTraitsHIP::getBinsPhiRectWindow(const Cluster& currentCluster, float phiCut)
 {
   // This function returns the lowest PhiBin and the number of phi bins to be spanned, In the form int2{phiBinLow, PhiBinSpan}
   const int phiBinMin{index_table_utils::getPhiBinIndex(
@@ -79,17 +79,17 @@ inline GPUd() const int2 VertexerTraitsGPU::getBinsPhiRectWindow(const Cluster& 
   return int2{phiBinMin, phiBinSpan};
 }
 
-inline GPU::DeviceStoreVertexerGPU& VertexerTraitsGPU::getDeviceContext()
+inline GPU::DeviceStoreVertexerHIP& VertexerTraitsHIP::getDeviceContext()
 {
   return *mStoreVertexerGPUPtr;
 }
 
-inline GPU::DeviceStoreVertexerGPU* VertexerTraitsGPU::getDeviceContextPtr()
+inline GPU::DeviceStoreVertexerHIP* VertexerTraitsHIP::getDeviceContextPtr()
 {
   return mStoreVertexerGPUPtr.get();
 }
 
-extern "C" VertexerTraits* createVertexerTraitsGPU();
+extern "C" VertexerTraits* createVertexerTraitsHIP();
 
 } // namespace its
 } // namespace o2

--- a/Detectors/ITSMFT/ITS/tracking/hip/src/ClusterLinesHIP.hip.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/hip/src/ClusterLinesHIP.hip.cxx
@@ -7,6 +7,10 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
+///
+/// \file ClusterLinesHIP.hip.cxx
+/// \brief
+/// \author matteo.concas@cern.ch
 
 #include "ITStrackingHIP/ClusterLinesHIP.h"
 

--- a/Detectors/ITSMFT/ITS/tracking/hip/src/ClusterLinesHIP.hip.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/hip/src/ClusterLinesHIP.hip.cxx
@@ -1,0 +1,134 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "ITStrackingHIP/ClusterLinesHIP.h"
+
+namespace o2
+{
+namespace its
+{
+namespace GPU
+{
+
+GPUd() ClusterLinesGPU::ClusterLinesGPU(const Line& firstLine, const Line& secondLine)
+{
+  float covarianceFirst[3];
+  float covarianceSecond[3];
+
+  for (int i{0}; i < 3; ++i) {
+    covarianceFirst[i] = 1.f;
+    covarianceSecond[i] = 1.f;
+  }
+
+  float determinantFirst =
+    firstLine.cosinesDirector[2] * firstLine.cosinesDirector[2] * covarianceFirst[0] * covarianceFirst[1] +
+    firstLine.cosinesDirector[1] * firstLine.cosinesDirector[1] * covarianceFirst[0] * covarianceFirst[2] +
+    firstLine.cosinesDirector[0] * firstLine.cosinesDirector[0] * covarianceFirst[1] * covarianceFirst[2];
+  float determinantSecond =
+    secondLine.cosinesDirector[2] * secondLine.cosinesDirector[2] * covarianceSecond[0] * covarianceSecond[1] +
+    secondLine.cosinesDirector[1] * secondLine.cosinesDirector[1] * covarianceSecond[0] * covarianceSecond[2] +
+    secondLine.cosinesDirector[0] * secondLine.cosinesDirector[0] * covarianceSecond[1] * covarianceSecond[2];
+
+  mAMatrix[0] = (firstLine.cosinesDirector[2] * firstLine.cosinesDirector[2] * covarianceFirst[1] +
+                 firstLine.cosinesDirector[1] * firstLine.cosinesDirector[1] * covarianceFirst[2]) /
+                  determinantFirst +
+                (secondLine.cosinesDirector[2] * secondLine.cosinesDirector[2] * covarianceSecond[1] +
+                 secondLine.cosinesDirector[1] * secondLine.cosinesDirector[1] * covarianceSecond[2]) /
+                  determinantSecond;
+
+  mAMatrix[1] = -firstLine.cosinesDirector[0] * firstLine.cosinesDirector[1] * covarianceFirst[2] / determinantFirst -
+                secondLine.cosinesDirector[0] * secondLine.cosinesDirector[1] * covarianceSecond[2] / determinantSecond;
+
+  mAMatrix[2] = -firstLine.cosinesDirector[0] * firstLine.cosinesDirector[2] * covarianceFirst[1] / determinantFirst -
+                secondLine.cosinesDirector[0] * secondLine.cosinesDirector[2] * covarianceSecond[1] / determinantSecond;
+
+  mAMatrix[3] = (firstLine.cosinesDirector[2] * firstLine.cosinesDirector[2] * covarianceFirst[0] +
+                 firstLine.cosinesDirector[0] * firstLine.cosinesDirector[0] * covarianceFirst[2]) /
+                  determinantFirst +
+                (secondLine.cosinesDirector[2] * secondLine.cosinesDirector[2] * covarianceSecond[0] +
+                 secondLine.cosinesDirector[0] * secondLine.cosinesDirector[0] * covarianceSecond[2]) /
+                  determinantSecond;
+
+  mAMatrix[4] = -firstLine.cosinesDirector[1] * firstLine.cosinesDirector[2] * covarianceFirst[0] / determinantFirst -
+                secondLine.cosinesDirector[1] * secondLine.cosinesDirector[2] * covarianceSecond[0] / determinantSecond;
+
+  mAMatrix[5] = (firstLine.cosinesDirector[1] * firstLine.cosinesDirector[1] * covarianceFirst[0] +
+                 firstLine.cosinesDirector[0] * firstLine.cosinesDirector[0] * covarianceFirst[1]) /
+                  determinantFirst +
+                (secondLine.cosinesDirector[1] * secondLine.cosinesDirector[1] * covarianceSecond[0] +
+                 secondLine.cosinesDirector[0] * secondLine.cosinesDirector[0] * covarianceSecond[1]) /
+                  determinantSecond;
+
+  mBMatrix[0] =
+    (firstLine.cosinesDirector[1] * covarianceFirst[2] * (-firstLine.cosinesDirector[1] * firstLine.originPoint[0] + firstLine.cosinesDirector[0] * firstLine.originPoint[1]) +
+     firstLine.cosinesDirector[2] * covarianceFirst[1] * (-firstLine.cosinesDirector[2] * firstLine.originPoint[0] + firstLine.cosinesDirector[0] * firstLine.originPoint[2])) /
+    determinantFirst;
+
+  mBMatrix[0] +=
+    (secondLine.cosinesDirector[1] * covarianceSecond[2] * (-secondLine.cosinesDirector[1] * secondLine.originPoint[0] + secondLine.cosinesDirector[0] * secondLine.originPoint[1]) +
+     secondLine.cosinesDirector[2] * covarianceSecond[1] *
+       (-secondLine.cosinesDirector[2] * secondLine.originPoint[0] +
+        secondLine.cosinesDirector[0] * secondLine.originPoint[2])) /
+    determinantSecond;
+
+  mBMatrix[1] =
+    (firstLine.cosinesDirector[0] * covarianceFirst[2] * (-firstLine.cosinesDirector[0] * firstLine.originPoint[1] + firstLine.cosinesDirector[1] * firstLine.originPoint[0]) +
+     firstLine.cosinesDirector[2] * covarianceFirst[0] * (-firstLine.cosinesDirector[2] * firstLine.originPoint[1] + firstLine.cosinesDirector[1] * firstLine.originPoint[2])) /
+    determinantFirst;
+
+  mBMatrix[1] +=
+    (secondLine.cosinesDirector[0] * covarianceSecond[2] * (-secondLine.cosinesDirector[0] * secondLine.originPoint[1] + secondLine.cosinesDirector[1] * secondLine.originPoint[0]) +
+     secondLine.cosinesDirector[2] * covarianceSecond[0] *
+       (-secondLine.cosinesDirector[2] * secondLine.originPoint[1] +
+        secondLine.cosinesDirector[1] * secondLine.originPoint[2])) /
+    determinantSecond;
+
+  mBMatrix[2] =
+    (firstLine.cosinesDirector[0] * covarianceFirst[1] * (-firstLine.cosinesDirector[0] * firstLine.originPoint[2] + firstLine.cosinesDirector[2] * firstLine.originPoint[0]) +
+     firstLine.cosinesDirector[1] * covarianceFirst[0] * (-firstLine.cosinesDirector[1] * firstLine.originPoint[2] + firstLine.cosinesDirector[2] * firstLine.originPoint[1])) /
+    determinantFirst;
+
+  mBMatrix[2] +=
+    (secondLine.cosinesDirector[0] * covarianceSecond[1] * (-secondLine.cosinesDirector[0] * secondLine.originPoint[2] + secondLine.cosinesDirector[2] * secondLine.originPoint[0]) +
+     secondLine.cosinesDirector[1] * covarianceSecond[0] *
+       (-secondLine.cosinesDirector[1] * secondLine.originPoint[2] +
+        secondLine.cosinesDirector[2] * secondLine.originPoint[1])) /
+    determinantSecond;
+
+  computeClusterCentroid();
+}
+
+GPUd() void ClusterLinesGPU::computeClusterCentroid()
+{
+
+  float determinant{mAMatrix[0] * (mAMatrix[3] * mAMatrix[5] - mAMatrix[4] * mAMatrix[4]) -
+                    mAMatrix[1] * (mAMatrix[1] * mAMatrix[5] - mAMatrix[4] * mAMatrix[2]) +
+                    mAMatrix[2] * (mAMatrix[1] * mAMatrix[4] - mAMatrix[2] * mAMatrix[3])};
+
+  if (determinant == 0) {
+    return;
+  }
+
+  mVertex[0] = -(mBMatrix[0] * (mAMatrix[3] * mAMatrix[5] - mAMatrix[4] * mAMatrix[4]) -
+                 mAMatrix[1] * (mBMatrix[1] * mAMatrix[5] - mAMatrix[4] * mBMatrix[2]) +
+                 mAMatrix[2] * (mBMatrix[1] * mAMatrix[4] - mBMatrix[2] * mAMatrix[3])) /
+               determinant;
+  mVertex[1] = -(mAMatrix[0] * (mBMatrix[1] * mAMatrix[5] - mBMatrix[2] * mAMatrix[4]) -
+                 mBMatrix[0] * (mAMatrix[1] * mAMatrix[5] - mAMatrix[4] * mAMatrix[2]) +
+                 mAMatrix[2] * (mAMatrix[1] * mBMatrix[2] - mAMatrix[2] * mBMatrix[1])) /
+               determinant;
+  mVertex[2] = -(mAMatrix[0] * (mAMatrix[3] * mBMatrix[2] - mBMatrix[1] * mAMatrix[4]) -
+                 mAMatrix[1] * (mAMatrix[1] * mBMatrix[2] - mBMatrix[1] * mAMatrix[2]) +
+                 mBMatrix[0] * (mAMatrix[1] * mAMatrix[4] - mAMatrix[2] * mAMatrix[3])) /
+               determinant;
+}
+} // namespace GPU
+} // namespace its
+} // namespace o2

--- a/Detectors/ITSMFT/ITS/tracking/hip/src/ClusterLinesHIP.hip.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/hip/src/ClusterLinesHIP.hip.cxx
@@ -21,7 +21,7 @@ namespace its
 namespace GPU
 {
 
-GPUd() ClusterLinesGPU::ClusterLinesGPU(const Line& firstLine, const Line& secondLine)
+GPUd() ClusterLinesHIP::ClusterLinesHIP(const Line& firstLine, const Line& secondLine)
 {
   float covarianceFirst[3];
   float covarianceSecond[3];
@@ -109,7 +109,7 @@ GPUd() ClusterLinesGPU::ClusterLinesGPU(const Line& firstLine, const Line& secon
   computeClusterCentroid();
 }
 
-GPUd() void ClusterLinesGPU::computeClusterCentroid()
+GPUd() void ClusterLinesHIP::computeClusterCentroid()
 {
 
   float determinant{mAMatrix[0] * (mAMatrix[3] * mAMatrix[5] - mAMatrix[4] * mAMatrix[4]) -

--- a/Detectors/ITSMFT/ITS/tracking/hip/src/ContextHIP.hip.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/hip/src/ContextHIP.hip.cxx
@@ -23,47 +23,13 @@
 namespace
 {
 
-inline int getHIPCores(const int major, const int minor)
+inline int getStreamProcessors(const int major, const int minor)
 {
-  // Defines for GPU Architecture types (using the SM version to determine the # of cores per SM
-  typedef struct
-  {
-    int SM; // 0xMm (hexidecimal notation), M = SM Major version, and m = SM minor version
-    int Cores;
-  } sSMtoCores;
-
-  sSMtoCores nGpuArchCoresPerSM[] =
-    {
-      {0x20, 32},  // Fermi Generation (SM 2.0) GF100 class
-      {0x21, 48},  // Fermi Generation (SM 2.1) GF10x class
-      {0x30, 192}, // Kepler Generation (SM 3.0) GK10x class
-      {0x32, 192}, // Kepler Generation (SM 3.2) GK10x class
-      {0x35, 192}, // Kepler Generation (SM 3.5) GK11x class
-      {0x37, 192}, // Kepler Generation (SM 3.7) GK21x class
-      {0x50, 128}, // Maxwell Generation (SM 5.0) GM10x class
-      {0x52, 128}, // Maxwell Generation (SM 5.2) GM20x class
-      {0x53, 128}, // Maxwell Generation (SM 5.3) GM20x class
-      {0x60, 64},  // Pascal Generation (SM 6.0) GP100 class
-      {0x61, 128}, // Pascal Generation (SM 6.1) GP10x class
-      {0x62, 128}, // Pascal Generation (SM 6.2) GP10x class
-      {-1, -1}};
-
-  int index = 0;
-
-  while (nGpuArchCoresPerSM[index].SM != -1) {
-    if (nGpuArchCoresPerSM[index].SM == ((major << 4) + minor)) {
-      return nGpuArchCoresPerSM[index].Cores;
-    }
-
-    index++;
-  }
-
-  // If we don't find the values, we default use the previous one to run properly
-  printf("MapSMtoCores for SM %d.%d is undefined.  Default to use %d Cores/SM\n", major, minor, nGpuArchCoresPerSM[index - 1].Cores);
-  return nGpuArchCoresPerSM[index - 1].Cores;
+  // Hardcoded result for AMD RADEON WX 9100, to be decided if and how determine this paramter
+  return 4096;
 }
 
-inline int getMaxThreadsPerSM(const int major, const int minor)
+inline int getMaxThreadsPerComputingUnit(const int major, const int minor)
 {
   return 8;
 }
@@ -84,8 +50,7 @@ Context::Context(bool dumpDevices)
   checkHIPError(hipGetDeviceCount(&mDevicesNum), __FILE__, __LINE__);
 
   if (mDevicesNum == 0) {
-
-    throw std::runtime_error{"There are no available device(s) that support CUDA\n"};
+    throw std::runtime_error{"There are no available device(s) that support HIP\n"};
   }
 
   mDeviceProperties.resize(mDevicesNum, DeviceProperties{});
@@ -100,12 +65,12 @@ Context::Context(bool dumpDevices)
     checkHIPError(hipSetDevice(iDevice), __FILE__, __LINE__);
     checkHIPError(hipGetDeviceProperties(&deviceProperties, iDevice), __FILE__, __LINE__);
 
-    // int major = deviceProperties.major; // Codacy warning
-    // int minor = deviceProperties.minor; // Codacy warning
+    int major = deviceProperties.major; // Codacy warning
+    int minor = deviceProperties.minor; // Codacy warning
 
     mDeviceProperties[iDevice].name = deviceProperties.name;
     mDeviceProperties[iDevice].gpuProcessors = deviceProperties.multiProcessorCount;
-    // mDeviceProperties[iDevice].hipCores = getHIPCores(major, minor) * deviceProperties.multiProcessorCount; // >>>> alarm
+    mDeviceProperties[iDevice].streamProcessors = getStreamProcessors(major, minor) * deviceProperties.multiProcessorCount; // >>>> alarm
     mDeviceProperties[iDevice].globalMemorySize = deviceProperties.totalGlobalMem;
     mDeviceProperties[iDevice].constantMemorySize = deviceProperties.totalConstMem;
     mDeviceProperties[iDevice].sharedMemorySize = deviceProperties.sharedMemPerBlock;
@@ -115,7 +80,7 @@ Context::Context(bool dumpDevices)
     mDeviceProperties[iDevice].registersPerBlock = deviceProperties.regsPerBlock;
     mDeviceProperties[iDevice].warpSize = deviceProperties.warpSize;
     mDeviceProperties[iDevice].maxThreadsPerBlock = deviceProperties.maxThreadsPerBlock;
-    // mDeviceProperties[iDevice].maxBlocksPerSM = getMaxThreadsPerSM(major, minor);
+    mDeviceProperties[iDevice].maxBlocksPerSM = getMaxThreadsPerComputingUnit(major, minor);
     mDeviceProperties[iDevice].maxThreadsDim = dim3{static_cast<unsigned int>(deviceProperties.maxThreadsDim[0]),
                                                     static_cast<unsigned int>(deviceProperties.maxThreadsDim[1]),
                                                     static_cast<unsigned int>(deviceProperties.maxThreadsDim[2])};
@@ -125,7 +90,8 @@ Context::Context(bool dumpDevices)
     if (dumpDevices) {
       std::cout << "################ HIP DEVICE " << iDevice << " ################" << std::endl;
       std::cout << "Name " << mDeviceProperties[iDevice].name << std::endl;
-      std::cout << "gpuProcessors " << mDeviceProperties[iDevice].gpuProcessors << std::endl; // >>>>> ALLARME
+      std::cout << "gpuProcessors " << mDeviceProperties[iDevice].gpuProcessors << std::endl;
+      std::cout << "minor " << minor << " major " << major << std::endl;
       // std::cout << "hipCores " << mDeviceProperties[iDevice].hipCores << std::endl;
       std::cout << "globalMemorySize " << mDeviceProperties[iDevice].globalMemorySize << std::endl;
       std::cout << "constantMemorySize " << mDeviceProperties[iDevice].constantMemorySize << std::endl;
@@ -136,7 +102,7 @@ Context::Context(bool dumpDevices)
       std::cout << "registersPerBlock " << mDeviceProperties[iDevice].registersPerBlock << std::endl;
       std::cout << "warpSize " << mDeviceProperties[iDevice].warpSize << std::endl;
       std::cout << "maxThreadsPerBlock " << mDeviceProperties[iDevice].maxThreadsPerBlock << std::endl;
-      // std::cout << "maxBlocksPerSM " << mDeviceProperties[iDevice].maxBlocksPerSM << std::endl;
+      std::cout << "maxBlocksPerSM " << mDeviceProperties[iDevice].maxBlocksPerSM << std::endl;
       std::cout << "maxThreadsDim " << mDeviceProperties[iDevice].maxThreadsDim.x << ", " << mDeviceProperties[iDevice].maxThreadsDim.y << ", " << mDeviceProperties[iDevice].maxThreadsDim.z << std::endl;
       std::cout << "maxGridDim " << mDeviceProperties[iDevice].maxGridDim.x << ", " << mDeviceProperties[iDevice].maxGridDim.y << ", " << mDeviceProperties[iDevice].maxGridDim.z << std::endl;
       std::cout << std::endl;

--- a/Detectors/ITSMFT/ITS/tracking/hip/src/ContextHIP.hip.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/hip/src/ContextHIP.hip.cxx
@@ -8,7 +8,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 ///
-/// \file Context.cu
+/// \file ContextHIP.hip.cxx
 /// \brief
 ///
 

--- a/Detectors/ITSMFT/ITS/tracking/hip/src/ContextHIP.hip.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/hip/src/ContextHIP.hip.cxx
@@ -43,12 +43,11 @@ namespace its
 namespace GPU
 {
 
-using Utils::Host::checkHIPError;
+using Utils::HostHIP::checkHIPError;
 
-Context::Context(bool dumpDevices)
+ContextHIP::ContextHIP(bool dumpDevices)
 {
   checkHIPError(hipGetDeviceCount(&mDevicesNum), __FILE__, __LINE__);
-
   if (mDevicesNum == 0) {
     throw std::runtime_error{"There are no available device(s) that support HIP\n"};
   }
@@ -92,7 +91,6 @@ Context::Context(bool dumpDevices)
       std::cout << "Name " << mDeviceProperties[iDevice].name << std::endl;
       std::cout << "gpuProcessors " << mDeviceProperties[iDevice].gpuProcessors << std::endl;
       std::cout << "minor " << minor << " major " << major << std::endl;
-      // std::cout << "hipCores " << mDeviceProperties[iDevice].hipCores << std::endl;
       std::cout << "globalMemorySize " << mDeviceProperties[iDevice].globalMemorySize << std::endl;
       std::cout << "constantMemorySize " << mDeviceProperties[iDevice].constantMemorySize << std::endl;
       std::cout << "sharedMemorySize " << mDeviceProperties[iDevice].sharedMemorySize << std::endl;
@@ -112,13 +110,13 @@ Context::Context(bool dumpDevices)
   checkHIPError(hipSetDevice(currentDeviceIndex), __FILE__, __LINE__);
 }
 
-Context& Context::getInstance()
+ContextHIP& ContextHIP::getInstance()
 {
-  static Context gpuContext;
-  return gpuContext;
+  static ContextHIP gpuContextHIP;
+  return gpuContextHIP;
 }
 
-const DeviceProperties& Context::getDeviceProperties()
+const DeviceProperties& ContextHIP::getDeviceProperties()
 {
   int currentDeviceIndex;
   checkHIPError(hipGetDevice(&currentDeviceIndex), __FILE__, __LINE__);
@@ -126,7 +124,7 @@ const DeviceProperties& Context::getDeviceProperties()
   return getDeviceProperties(currentDeviceIndex);
 }
 
-const DeviceProperties& Context::getDeviceProperties(const int deviceIndex)
+const DeviceProperties& ContextHIP::getDeviceProperties(const int deviceIndex)
 {
   return mDeviceProperties[deviceIndex];
 }

--- a/Detectors/ITSMFT/ITS/tracking/hip/src/DeviceStoreVertexerHIP.hip.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/hip/src/DeviceStoreVertexerHIP.hip.cxx
@@ -1,4 +1,3 @@
-#include "hip/hip_runtime.h"
 // Copyright CERN and copyright holders of ALICE O2. This software is
 // distributed under the terms of the GNU General Public License v3 (GPL
 // Version 3), copied verbatim in the file "COPYING".

--- a/Detectors/ITSMFT/ITS/tracking/hip/src/DeviceStoreVertexerHIP.hip.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/hip/src/DeviceStoreVertexerHIP.hip.cxx
@@ -1,0 +1,107 @@
+#include "hip/hip_runtime.h"
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+///
+/// \file DeviceStoreVertexerGPU.cu
+/// \brief
+/// \author matteo.concas@cern.ch
+
+#include <iostream>
+
+#include "ITStrackingHIP/DeviceStoreVertexerHIP.h"
+#include "ITStracking/Configuration.h"
+
+namespace o2
+{
+namespace its
+{
+namespace GPU
+{
+GPUg() void defaultInitArrayKernel(int* array, const size_t arraySize, const int initValue = 0)
+{
+  for (size_t i{blockIdx.x * blockDim.x + threadIdx.x}; i < arraySize; i += blockDim.x * gridDim.x) {
+    if (i < arraySize) {
+      array[i] = initValue;
+    }
+  }
+}
+
+DeviceStoreVertexerGPU::DeviceStoreVertexerGPU()
+{
+  mDuplets01 = Vector<Tracklet>{mGPUConf.dupletsCapacity, mGPUConf.dupletsCapacity};                         // 200 * 4e4 * sizeof(Tracklet) = 128MB
+  mDuplets12 = Vector<Tracklet>{mGPUConf.dupletsCapacity, mGPUConf.dupletsCapacity};                         // 200 * 4e4 * sizeof(Tracklet) = 128MB
+  mTracklets = Vector<Line>{mGPUConf.processedTrackletsCapacity, mGPUConf.processedTrackletsCapacity};       // 200 * 4e4 * sizeof(Line) = 296MB
+  mCUBTmpBuffer = Vector<int>{mGPUConf.tmpCUBBufferSize, mGPUConf.tmpCUBBufferSize};                         // 5e3 * sizeof(int) = 20KB
+  mXYCentroids = Vector<float>{2 * mGPUConf.maxCentroidsXYCapacity, 2 * mGPUConf.maxCentroidsXYCapacity};    //
+  mZCentroids = Vector<float>{mGPUConf.processedTrackletsCapacity, mGPUConf.processedTrackletsCapacity};     //
+  mNFoundLines = Vector<int>{mGPUConf.clustersPerLayerCapacity, mGPUConf.clustersPerLayerCapacity};          // 4e4 * sizeof(int) = 160KB
+  mNExclusiveFoundLines = Vector<int>{mGPUConf.clustersPerLayerCapacity, mGPUConf.clustersPerLayerCapacity}; // 4e4 * sizeof(int) = 160KB, tot = <10MB
+  mTmpVertexPositionBins = Vector<hipcub::KeyValuePair<int, int>>{3, 3};
+  mGPUVertices = Vector<GPUVertex>{mGPUConf.nMaxVertices, mGPUConf.nMaxVertices};
+  mBeamPosition = Vector<float>{2, 2};
+
+  for (int iTable{0}; iTable < 2; ++iTable) {
+    mIndexTables[iTable] = Vector<int>{constants::index_table::ZBins * constants::index_table::PhiBins + 1}; // 2*20*20+1 * sizeof(int) = 802B
+  }
+  for (int iLayer{0}; iLayer < constants::its::LayersNumberVertexer; ++iLayer) { // 4e4 * 3 * sizof(Cluster) = 3.36MB
+    mClusters[iLayer] = Vector<Cluster>{mGPUConf.clustersPerLayerCapacity, mGPUConf.clustersPerLayerCapacity};
+  }
+  for (int iPair{0}; iPair < constants::its::LayersNumberVertexer - 1; ++iPair) {
+    mNFoundDuplets[iPair] = Vector<int>{mGPUConf.clustersPerLayerCapacity, mGPUConf.clustersPerLayerCapacity}; // 4e4 * 2 * sizeof(int) = 320KB
+  }
+  for (int iHisto{0}; iHisto < 3; ++iHisto) {
+    mHistogramXYZ[iHisto] = Vector<int>{mGPUConf.nBinsXYZ[iHisto], mGPUConf.nBinsXYZ[iHisto]};
+  }
+
+#ifdef _ALLOW_DEBUG_TREES_ITS_
+  for (int iLayersCouple{0}; iLayersCouple < 2; ++iLayersCouple) {
+    mDupletIndices[iLayersCouple] = Vector<int>{mGPUConf.processedTrackletsCapacity, mGPUConf.processedTrackletsCapacity};
+  }
+  mSizes = Vector<int>{constants::its::LayersNumberVertexer};
+#endif
+} // namespace GPU
+
+UniquePointer<DeviceStoreVertexerGPU> DeviceStoreVertexerGPU::initialise(const std::array<std::vector<Cluster>, constants::its::LayersNumberVertexer>& clusters,
+                                                                         const std::array<std::array<int, constants::index_table::ZBins * constants::index_table::PhiBins + 1>,
+                                                                                          constants::its::LayersNumberVertexer>& indexTables)
+{
+  std::array<int, constants::its::LayersNumberVertexer> tmpSizes = {static_cast<int>(clusters[0].size()),
+                                                                    static_cast<int>(clusters[1].size()),
+                                                                    static_cast<int>(clusters[2].size())};
+  for (int iLayer{0}; iLayer < constants::its::LayersNumberVertexer; ++iLayer) {
+    mClusters[iLayer].reset(clusters[iLayer].data(), static_cast<int>(clusters[iLayer].size()));
+  }
+  mIndexTables[0].reset(indexTables[0].data(), static_cast<int>(indexTables[0].size()));
+  mIndexTables[1].reset(indexTables[2].data(), static_cast<int>(indexTables[2].size()));
+
+  const dim3 threadsPerBlock{Utils::Host::getBlockSize(mClusters[1].capacity())};
+  const dim3 blocksGrid{Utils::Host::getBlocksGrid(threadsPerBlock, mClusters[1].capacity())};
+
+  UniquePointer<DeviceStoreVertexerGPU> deviceStoreVertexerPtr{*this};
+
+  hipLaunchKernelGGL((defaultInitArrayKernel), dim3(blocksGrid), dim3(threadsPerBlock), 0, 0, getNFoundTracklets(TrackletingLayerOrder::fromInnermostToMiddleLayer).get(),
+                                                          getNFoundTracklets(TrackletingLayerOrder::fromInnermostToMiddleLayer).capacity(), 0);
+  hipLaunchKernelGGL((defaultInitArrayKernel), dim3(blocksGrid), dim3(threadsPerBlock), 0, 0, getNFoundTracklets(TrackletingLayerOrder::fromMiddleToOuterLayer).get(),
+                                                          getNFoundTracklets(TrackletingLayerOrder::fromMiddleToOuterLayer).capacity(), 0);
+
+  return deviceStoreVertexerPtr;
+}
+
+GPUd() const Vector<int>& DeviceStoreVertexerGPU::getIndexTable(const VertexerLayerName layer)
+{
+  if (layer == VertexerLayerName::innermostLayer) {
+    return mIndexTables[0];
+  }
+  return mIndexTables[1];
+}
+
+} // namespace GPU
+} // namespace its
+} // namespace o2

--- a/Detectors/ITSMFT/ITS/tracking/hip/src/DeviceStoreVertexerHIP.hip.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/hip/src/DeviceStoreVertexerHIP.hip.cxx
@@ -33,68 +33,65 @@ GPUg() void defaultInitArrayKernel(int* array, const size_t arraySize, const int
   }
 }
 
-DeviceStoreVertexerGPU::DeviceStoreVertexerGPU()
+DeviceStoreVertexerHIP::DeviceStoreVertexerHIP()
 {
-  mDuplets01 = Vector<Tracklet>{mGPUConf.dupletsCapacity, mGPUConf.dupletsCapacity};                         // 200 * 4e4 * sizeof(Tracklet) = 128MB
-  mDuplets12 = Vector<Tracklet>{mGPUConf.dupletsCapacity, mGPUConf.dupletsCapacity};                         // 200 * 4e4 * sizeof(Tracklet) = 128MB
-  mTracklets = Vector<Line>{mGPUConf.processedTrackletsCapacity, mGPUConf.processedTrackletsCapacity};       // 200 * 4e4 * sizeof(Line) = 296MB
-  mCUBTmpBuffer = Vector<int>{mGPUConf.tmpCUBBufferSize, mGPUConf.tmpCUBBufferSize};                         // 5e3 * sizeof(int) = 20KB
-  mXYCentroids = Vector<float>{2 * mGPUConf.maxCentroidsXYCapacity, 2 * mGPUConf.maxCentroidsXYCapacity};    //
-  mZCentroids = Vector<float>{mGPUConf.processedTrackletsCapacity, mGPUConf.processedTrackletsCapacity};     //
-  mNFoundLines = Vector<int>{mGPUConf.clustersPerLayerCapacity, mGPUConf.clustersPerLayerCapacity};          // 4e4 * sizeof(int) = 160KB
-  mNExclusiveFoundLines = Vector<int>{mGPUConf.clustersPerLayerCapacity, mGPUConf.clustersPerLayerCapacity}; // 4e4 * sizeof(int) = 160KB, tot = <10MB
-  mTmpVertexPositionBins = Vector<hipcub::KeyValuePair<int, int>>{3, 3};
-  mGPUVertices = Vector<GPUVertex>{mGPUConf.nMaxVertices, mGPUConf.nMaxVertices};
-  mBeamPosition = Vector<float>{2, 2};
+  mDuplets01 = VectorHIP<Tracklet>{mGPUConf.dupletsCapacity, mGPUConf.dupletsCapacity};                         // 200 * 4e4 * sizeof(Tracklet) = 128MB
+  mDuplets12 = VectorHIP<Tracklet>{mGPUConf.dupletsCapacity, mGPUConf.dupletsCapacity};                         // 200 * 4e4 * sizeof(Tracklet) = 128MB
+  mTracklets = VectorHIP<Line>{mGPUConf.processedTrackletsCapacity, mGPUConf.processedTrackletsCapacity};       // 200 * 4e4 * sizeof(Line) = 296MB
+  mCUBTmpBuffer = VectorHIP<int>{mGPUConf.tmpCUBBufferSize, mGPUConf.tmpCUBBufferSize};                         // 5e3 * sizeof(int) = 20KB
+  mXYCentroids = VectorHIP<float>{2 * mGPUConf.maxCentroidsXYCapacity, 2 * mGPUConf.maxCentroidsXYCapacity};    //
+  mZCentroids = VectorHIP<float>{mGPUConf.processedTrackletsCapacity, mGPUConf.processedTrackletsCapacity};     //
+  mNFoundLines = VectorHIP<int>{mGPUConf.clustersPerLayerCapacity, mGPUConf.clustersPerLayerCapacity};          // 4e4 * sizeof(int) = 160KB
+  mNExclusiveFoundLines = VectorHIP<int>{mGPUConf.clustersPerLayerCapacity, mGPUConf.clustersPerLayerCapacity}; // 4e4 * sizeof(int) = 160KB, tot = <10MB
+  mTmpVertexPositionBins = VectorHIP<hipcub::KeyValuePair<int, int>>{3, 3};
+  mGPUVertices = VectorHIP<GPUVertex>{mGPUConf.nMaxVertices, mGPUConf.nMaxVertices};
+  mBeamPosition = VectorHIP<float>{2, 2};
 
   for (int iTable{0}; iTable < 2; ++iTable) {
-    mIndexTables[iTable] = Vector<int>{constants::index_table::ZBins * constants::index_table::PhiBins + 1}; // 2*20*20+1 * sizeof(int) = 802B
+    mIndexTables[iTable] = VectorHIP<int>{constants::index_table::ZBins * constants::index_table::PhiBins + 1}; // 2*20*20+1 * sizeof(int) = 802B
   }
   for (int iLayer{0}; iLayer < constants::its::LayersNumberVertexer; ++iLayer) { // 4e4 * 3 * sizof(Cluster) = 3.36MB
-    mClusters[iLayer] = Vector<Cluster>{mGPUConf.clustersPerLayerCapacity, mGPUConf.clustersPerLayerCapacity};
+    mClusters[iLayer] = VectorHIP<Cluster>{mGPUConf.clustersPerLayerCapacity, mGPUConf.clustersPerLayerCapacity};
   }
   for (int iPair{0}; iPair < constants::its::LayersNumberVertexer - 1; ++iPair) {
-    mNFoundDuplets[iPair] = Vector<int>{mGPUConf.clustersPerLayerCapacity, mGPUConf.clustersPerLayerCapacity}; // 4e4 * 2 * sizeof(int) = 320KB
+    mNFoundDuplets[iPair] = VectorHIP<int>{mGPUConf.clustersPerLayerCapacity, mGPUConf.clustersPerLayerCapacity}; // 4e4 * 2 * sizeof(int) = 320KB
   }
   for (int iHisto{0}; iHisto < 3; ++iHisto) {
-    mHistogramXYZ[iHisto] = Vector<int>{mGPUConf.nBinsXYZ[iHisto], mGPUConf.nBinsXYZ[iHisto]};
+    mHistogramXYZ[iHisto] = VectorHIP<int>{mGPUConf.nBinsXYZ[iHisto], mGPUConf.nBinsXYZ[iHisto]};
   }
 
 #ifdef _ALLOW_DEBUG_TREES_ITS_
   for (int iLayersCouple{0}; iLayersCouple < 2; ++iLayersCouple) {
-    mDupletIndices[iLayersCouple] = Vector<int>{mGPUConf.processedTrackletsCapacity, mGPUConf.processedTrackletsCapacity};
+    mDupletIndices[iLayersCouple] = VectorHIP<int>{mGPUConf.processedTrackletsCapacity, mGPUConf.processedTrackletsCapacity};
   }
-  mSizes = Vector<int>{constants::its::LayersNumberVertexer};
+  mSizes = VectorHIP<int>{constants::its::LayersNumberVertexer};
 #endif
 } // namespace GPU
 
-UniquePointer<DeviceStoreVertexerGPU> DeviceStoreVertexerGPU::initialise(const std::array<std::vector<Cluster>, constants::its::LayersNumberVertexer>& clusters,
+UniquePointer<DeviceStoreVertexerHIP> DeviceStoreVertexerHIP::initialise(const std::array<std::vector<Cluster>, constants::its::LayersNumberVertexer>& clusters,
                                                                          const std::array<std::array<int, constants::index_table::ZBins * constants::index_table::PhiBins + 1>,
                                                                                           constants::its::LayersNumberVertexer>& indexTables)
 {
-  std::array<int, constants::its::LayersNumberVertexer> tmpSizes = {static_cast<int>(clusters[0].size()),
-                                                                    static_cast<int>(clusters[1].size()),
-                                                                    static_cast<int>(clusters[2].size())};
   for (int iLayer{0}; iLayer < constants::its::LayersNumberVertexer; ++iLayer) {
     mClusters[iLayer].reset(clusters[iLayer].data(), static_cast<int>(clusters[iLayer].size()));
   }
   mIndexTables[0].reset(indexTables[0].data(), static_cast<int>(indexTables[0].size()));
   mIndexTables[1].reset(indexTables[2].data(), static_cast<int>(indexTables[2].size()));
 
-  const dim3 threadsPerBlock{Utils::Host::getBlockSize(mClusters[1].capacity())};
-  const dim3 blocksGrid{Utils::Host::getBlocksGrid(threadsPerBlock, mClusters[1].capacity())};
+  const dim3 threadsPerBlock{Utils::HostHIP::getBlockSize(mClusters[1].capacity())};
+  const dim3 blocksGrid{Utils::HostHIP::getBlocksGrid(threadsPerBlock, mClusters[1].capacity())};
 
-  UniquePointer<DeviceStoreVertexerGPU> deviceStoreVertexerPtr{*this};
+  UniquePointer<DeviceStoreVertexerHIP> deviceStoreVertexerPtr{*this};
 
   hipLaunchKernelGGL((defaultInitArrayKernel), dim3(blocksGrid), dim3(threadsPerBlock), 0, 0, getNFoundTracklets(TrackletingLayerOrder::fromInnermostToMiddleLayer).get(),
-                                                          getNFoundTracklets(TrackletingLayerOrder::fromInnermostToMiddleLayer).capacity(), 0);
+                     getNFoundTracklets(TrackletingLayerOrder::fromInnermostToMiddleLayer).capacity(), 0);
   hipLaunchKernelGGL((defaultInitArrayKernel), dim3(blocksGrid), dim3(threadsPerBlock), 0, 0, getNFoundTracklets(TrackletingLayerOrder::fromMiddleToOuterLayer).get(),
-                                                          getNFoundTracklets(TrackletingLayerOrder::fromMiddleToOuterLayer).capacity(), 0);
+                     getNFoundTracklets(TrackletingLayerOrder::fromMiddleToOuterLayer).capacity(), 0);
 
   return deviceStoreVertexerPtr;
 }
 
-GPUd() const Vector<int>& DeviceStoreVertexerGPU::getIndexTable(const VertexerLayerName layer)
+GPUd() const VectorHIP<int>& DeviceStoreVertexerHIP::getIndexTable(const VertexerLayerName layer)
 {
   if (layer == VertexerLayerName::innermostLayer) {
     return mIndexTables[0];

--- a/Detectors/ITSMFT/ITS/tracking/hip/src/DeviceStoreVertexerHIP.hip.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/hip/src/DeviceStoreVertexerHIP.hip.cxx
@@ -9,7 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 ///
-/// \file DeviceStoreVertexerGPU.cu
+/// \file DeviceStoreVertexerHIP.hip.cxx
 /// \brief
 /// \author matteo.concas@cern.ch
 

--- a/Detectors/ITSMFT/ITS/tracking/hip/src/StreamHIP.hip.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/hip/src/StreamHIP.hip.cxx
@@ -12,7 +12,7 @@
 /// \brief
 ///
 
-#include "ITStrackingCUDA/Stream.h"
+#include "ITStrackingHIP/StreamHIP.h"
 
 namespace o2
 {
@@ -21,17 +21,17 @@ namespace its
 namespace GPU
 {
 
-Stream::Stream()
+StreamHIP::StreamHIP()
 {
-  hipStreamCreateWithFlags(&mStream, hipStreamNonBlocking);
+  (void)hipStreamCreateWithFlags(&mStream, hipStreamNonBlocking);
 }
 
-Stream::~Stream()
+StreamHIP::~StreamHIP()
 {
-  hipStreamDestroy(mStream);
+  (void)hipStreamDestroy(mStream);
 }
 
-const GPUStream& Stream::get() const
+const hipStream_t& StreamHIP::get() const
 {
   return mStream;
 }

--- a/Detectors/ITSMFT/ITS/tracking/hip/src/StreamHIP.hip.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/hip/src/StreamHIP.hip.cxx
@@ -8,7 +8,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 ///
-/// \file Stream.cu
+/// \file StreamHIP.hip.cxx
 /// \brief
 ///
 

--- a/Detectors/ITSMFT/ITS/tracking/hip/src/UtilsHIP.hip.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/hip/src/UtilsHIP.hip.cxx
@@ -8,7 +8,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 ///
-/// \file Utils.cu
+/// \file UtilsHIP.hip.cxx
 /// \brief
 ///
 
@@ -18,8 +18,7 @@
 #include <sstream>
 #include <stdexcept>
 
-// #include <HIP_profiler_api.h>
-
+#include <hip/hip_runtime_api.h>
 #include "ITStrackingHIP/ContextHIP.h"
 
 namespace
@@ -28,32 +27,22 @@ namespace
 int roundUp(const int numToRound, const int multiple)
 {
   if (multiple == 0) {
-
     return numToRound;
   }
-
   int remainder{numToRound % multiple};
-
   if (remainder == 0) {
-
     return numToRound;
   }
-
   return numToRound + multiple - remainder;
 }
 
 int findNearestDivisor(const int numToRound, const int divisor)
 {
-
   if (numToRound > divisor) {
-
     return divisor;
   }
-
   int result = numToRound;
-
   while (divisor % result != 0) {
-
     ++result;
   }
 
@@ -72,12 +61,9 @@ namespace GPU
 void Utils::Host::checkHIPError(const hipError_t error, const char* file, const int line)
 {
   if (error != hipSuccess) {
-
     std::ostringstream errorString{};
-
     errorString << file << ":" << line << " HIP API returned error [" << hipGetErrorString(error) << "] (code "
                 << error << ")" << std::endl;
-
     throw std::runtime_error{errorString.str()};
   }
 }
@@ -90,7 +76,7 @@ dim3 Utils::Host::getBlockSize(const int colsNum)
 dim3 Utils::Host::getBlockSize(const int colsNum, const int rowsNum)
 {
   const DeviceProperties& deviceProperties = Context::getInstance().getDeviceProperties();
-  return getBlockSize(colsNum, rowsNum, deviceProperties.streamProcessors / deviceProperties.maxBlocksPerSM); /// <<<<<<< ALLARME
+  return getBlockSize(colsNum, rowsNum, deviceProperties.streamProcessors / deviceProperties.maxBlocksPerSM);
 }
 
 dim3 Utils::Host::getBlockSize(const int colsNum, const int rowsNum, const int maxThreadsPerBlock)
@@ -100,14 +86,11 @@ dim3 Utils::Host::getBlockSize(const int colsNum, const int rowsNum, const int m
   int yThreads = std::max(std::min(rowsNum, static_cast<int>(deviceProperties.maxThreadsDim.y)), 1);
   const int totalThreads = roundUp(std::min(xThreads * yThreads, maxThreadsPerBlock),
                                    static_cast<int>(deviceProperties.warpSize));
-
   if (xThreads > yThreads) {
-
     xThreads = findNearestDivisor(xThreads, totalThreads);
     yThreads = totalThreads / xThreads;
 
   } else {
-
     yThreads = findNearestDivisor(yThreads, totalThreads);
     xThreads = totalThreads / yThreads;
   }
@@ -117,13 +100,11 @@ dim3 Utils::Host::getBlockSize(const int colsNum, const int rowsNum, const int m
 
 dim3 Utils::Host::getBlocksGrid(const dim3& threadsPerBlock, const int rowsNum)
 {
-
   return getBlocksGrid(threadsPerBlock, rowsNum, 1);
 }
 
 dim3 Utils::Host::getBlocksGrid(const dim3& threadsPerBlock, const int rowsNum, const int colsNum)
 {
-
   return dim3{1 + (rowsNum - 1) / threadsPerBlock.x, 1 + (colsNum - 1) / threadsPerBlock.y};
 }
 

--- a/Detectors/ITSMFT/ITS/tracking/hip/src/UtilsHIP.hip.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/hip/src/UtilsHIP.hip.cxx
@@ -82,16 +82,16 @@ void Utils::Host::checkHIPError(const hipError_t error, const char* file, const 
   }
 }
 
-// dim3 Utils::Host::getBlockSize(const int colsNum)
-// {
-//   return getBlockSize(colsNum, 1);
-// }
+dim3 Utils::Host::getBlockSize(const int colsNum)
+{
+  return getBlockSize(colsNum, 1);
+}
 
-// dim3 Utils::Host::getBlockSize(const int colsNum, const int rowsNum)
-// {
-//   const DeviceProperties& deviceProperties = Context::getInstance().getDeviceProperties();
-//   return getBlockSize(colsNum, rowsNum, deviceProperties.hipCores / deviceProperties.maxBlocksPerSM); /// <<<<<<< ALLARME
-// }
+dim3 Utils::Host::getBlockSize(const int colsNum, const int rowsNum)
+{
+  const DeviceProperties& deviceProperties = Context::getInstance().getDeviceProperties();
+  return getBlockSize(colsNum, rowsNum, deviceProperties.streamProcessors / deviceProperties.maxBlocksPerSM); /// <<<<<<< ALLARME
+}
 
 dim3 Utils::Host::getBlockSize(const int colsNum, const int rowsNum, const int maxThreadsPerBlock)
 {

--- a/Detectors/ITSMFT/ITS/tracking/hip/src/UtilsHIP.hip.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/hip/src/UtilsHIP.hip.cxx
@@ -12,7 +12,6 @@
 /// \brief
 ///
 
-#include "ITStrackingHIP/UtilsHIP.h"
 #include <iostream>
 #include <algorithm>
 #include <sstream>
@@ -20,6 +19,7 @@
 
 #include <hip/hip_runtime_api.h>
 #include "ITStrackingHIP/ContextHIP.h"
+#include "ITStrackingHIP/UtilsHIP.h"
 
 namespace
 {
@@ -58,7 +58,7 @@ namespace its
 namespace GPU
 {
 
-void Utils::Host::checkHIPError(const hipError_t error, const char* file, const int line)
+void Utils::HostHIP::checkHIPError(const hipError_t error, const char* file, const int line)
 {
   if (error != hipSuccess) {
     std::ostringstream errorString{};
@@ -68,20 +68,20 @@ void Utils::Host::checkHIPError(const hipError_t error, const char* file, const 
   }
 }
 
-dim3 Utils::Host::getBlockSize(const int colsNum)
+dim3 Utils::HostHIP::getBlockSize(const int colsNum)
 {
   return getBlockSize(colsNum, 1);
 }
 
-dim3 Utils::Host::getBlockSize(const int colsNum, const int rowsNum)
+dim3 Utils::HostHIP::getBlockSize(const int colsNum, const int rowsNum)
 {
-  const DeviceProperties& deviceProperties = Context::getInstance().getDeviceProperties();
+  const DeviceProperties& deviceProperties = ContextHIP::getInstance().getDeviceProperties();
   return getBlockSize(colsNum, rowsNum, deviceProperties.streamProcessors / deviceProperties.maxBlocksPerSM);
 }
 
-dim3 Utils::Host::getBlockSize(const int colsNum, const int rowsNum, const int maxThreadsPerBlock)
+dim3 Utils::HostHIP::getBlockSize(const int colsNum, const int rowsNum, const int maxThreadsPerBlock)
 {
-  const DeviceProperties& deviceProperties = Context::getInstance().getDeviceProperties();
+  const DeviceProperties& deviceProperties = ContextHIP::getInstance().getDeviceProperties();
   int xThreads = std::max(std::min(colsNum, static_cast<int>(deviceProperties.maxThreadsDim.x)), 1);
   int yThreads = std::max(std::min(rowsNum, static_cast<int>(deviceProperties.maxThreadsDim.y)), 1);
   const int totalThreads = roundUp(std::min(xThreads * yThreads, maxThreadsPerBlock),
@@ -98,57 +98,57 @@ dim3 Utils::Host::getBlockSize(const int colsNum, const int rowsNum, const int m
   return dim3{static_cast<unsigned int>(xThreads), static_cast<unsigned int>(yThreads)};
 }
 
-dim3 Utils::Host::getBlocksGrid(const dim3& threadsPerBlock, const int rowsNum)
+dim3 Utils::HostHIP::getBlocksGrid(const dim3& threadsPerBlock, const int rowsNum)
 {
   return getBlocksGrid(threadsPerBlock, rowsNum, 1);
 }
 
-dim3 Utils::Host::getBlocksGrid(const dim3& threadsPerBlock, const int rowsNum, const int colsNum)
+dim3 Utils::HostHIP::getBlocksGrid(const dim3& threadsPerBlock, const int rowsNum, const int colsNum)
 {
   return dim3{1 + (rowsNum - 1) / threadsPerBlock.x, 1 + (colsNum - 1) / threadsPerBlock.y};
 }
 
-void Utils::Host::gpuMalloc(void** p, const int size)
+void Utils::HostHIP::gpuMalloc(void** p, const int size)
 {
   checkHIPError(hipMalloc(p, size), __FILE__, __LINE__);
 }
 
-void Utils::Host::gpuFree(void* p)
+void Utils::HostHIP::gpuFree(void* p)
 {
   checkHIPError(hipFree(p), __FILE__, __LINE__);
 }
 
-void Utils::Host::gpuMemset(void* p, int value, int size)
+void Utils::HostHIP::gpuMemset(void* p, int value, int size)
 {
   checkHIPError(hipMemset(p, value, size), __FILE__, __LINE__);
 }
 
-void Utils::Host::gpuMemcpyHostToDevice(void* dst, const void* src, int size)
+void Utils::HostHIP::gpuMemcpyHostToDevice(void* dst, const void* src, int size)
 {
   checkHIPError(hipMemcpy(dst, src, size, hipMemcpyHostToDevice), __FILE__, __LINE__);
 }
 
-void Utils::Host::gpuMemcpyHostToDeviceAsync(void* dst, const void* src, int size, hipStream_t& stream)
+void Utils::HostHIP::gpuMemcpyHostToDeviceAsync(void* dst, const void* src, int size, hipStream_t& stream)
 {
   checkHIPError(hipMemcpyAsync(dst, src, size, hipMemcpyHostToDevice, stream), __FILE__, __LINE__);
 }
 
-void Utils::Host::gpuMemcpyDeviceToHost(void* dst, const void* src, int size)
+void Utils::HostHIP::gpuMemcpyDeviceToHost(void* dst, const void* src, int size)
 {
   checkHIPError(hipMemcpy(dst, src, size, hipMemcpyDeviceToHost), __FILE__, __LINE__);
 }
 
-void Utils::Host::gpuStartProfiler()
+void Utils::HostHIP::gpuStartProfiler()
 {
   checkHIPError(hipProfilerStart(), __FILE__, __LINE__);
 }
 
-void Utils::Host::gpuStopProfiler()
+void Utils::HostHIP::gpuStopProfiler()
 {
   checkHIPError(hipProfilerStop(), __FILE__, __LINE__);
 }
 
-GPUd() int Utils::Device::getLaneIndex()
+GPUd() int Utils::DeviceHIP::getLaneIndex()
 {
   uint32_t laneIndex;
   asm volatile("mov.u32 %0, %%laneid;"

--- a/Detectors/ITSMFT/ITS/tracking/hip/src/VertexerTraitsHIP.hip.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/hip/src/VertexerTraitsHIP.hip.cxx
@@ -1,4 +1,3 @@
-#include "hip/hip_runtime.h"
 // Copyright CERN and copyright holders of ALICE O2. This software is
 // distributed under the terms of the GNU General Public License v3 (GPL
 // Version 3), copied verbatim in the file "COPYING".

--- a/Detectors/ITSMFT/ITS/tracking/hip/src/VertexerTraitsHIP.hip.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/hip/src/VertexerTraitsHIP.hip.cxx
@@ -1,0 +1,495 @@
+#include "hip/hip_runtime.h"
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+///
+/// \file VertexerTraitsHIP.hip.cxx
+/// \brief
+/// \author matteo.concas@cern.ch
+
+#include <iostream>
+#include <sstream>
+#include <array>
+#include <assert.h>
+#include <hipcub/hipcub.hpp>
+
+#include "ITStracking/MathUtils.h"
+#include "ITStracking/Configuration.h"
+#include "ITStracking/ClusterLines.h"
+#include "ITStracking/Tracklet.h"
+
+#include "ITStrackingHIP/UtilsHIP.h"
+#include "ITStrackingHIP/ClusterLinesHIP.h"
+#include "ITStrackingHIP/ContextHIP.h"
+#include "ITStrackingHIP/StreamHIP.h"
+#include "ITStrackingHIP/VertexerTraitsHIP.h"
+
+namespace o2
+{
+namespace its
+{
+
+using constants::index_table::PhiBins;
+using constants::index_table::ZBins;
+using constants::its::LayersRCoordinate;
+using constants::its::LayersZCoordinate;
+using constants::its::VertexerHistogramVolume;
+using constants::math::TwoPi;
+using index_table_utils::getPhiBinIndex;
+using index_table_utils::getZBinIndex;
+using math_utils::getNormalizedPhiCoordinate;
+
+GPUh() void gpuThrowOnError()
+{
+  hipError_t error = hipGetLastError();
+
+  if (error != hipSuccess) {
+    std::ostringstream errorString{};
+    errorString << "CUDA API returned error  [" << hipGetErrorString(error) << "] (code " << error << ")" << std::endl;
+    throw std::runtime_error{errorString.str()};
+  }
+}
+
+#ifdef _ALLOW_DEBUG_TREES_ITS_
+VertexerTraitsGPU::VertexerTraitsGPU()
+{
+  setIsGPU(true);
+  std::cout << "[DEBUG] Creating file: dbg_ITSVertexerGPU.root" << std::endl;
+  mDebugger = new StandaloneDebugger::StandaloneDebugger("dbg_ITSVertexerGPU.root");
+}
+
+VertexerTraitsGPU::~VertexerTraitsGPU()
+{
+  delete mDebugger;
+}
+#else
+VertexerTraitsGPU::VertexerTraitsGPU()
+{
+  setIsGPU(true);
+}
+
+#endif
+
+void VertexerTraitsGPU::initialise(ROframe* event)
+{
+  reset();
+  arrangeClusters(event);
+  mStoreVertexerGPUPtr = mStoreVertexerGPU.initialise(mClusters, mIndexTables);
+}
+
+namespace GPU
+{
+
+template <typename... Args>
+GPUd() void printOnThread(const int tId, const char* str, Args... args)
+{
+  if (blockIdx.x * blockDim.x + threadIdx.x == tId) {
+    printf(str, args...);
+  }
+}
+
+GPUd() void printVectorOnThread(const char* name, Vector<int>& vector, size_t size, const int tId = 0)
+{
+  if (blockIdx.x * blockDim.x + threadIdx.x == tId) {
+    printf("vector %s :", name);
+    for (int i{0}; i < size; ++i) {
+      printf("%d ", vector[i]);
+    }
+    printf("\n");
+  }
+}
+
+GPUg() void printVectorKernel(DeviceStoreVertexerGPU* store, const int threadId)
+{
+  if (blockIdx.x * blockDim.x + threadIdx.x == threadId) {
+    for (int i{0}; i < store->getConfig().nBinsXYZ[0] - 1; ++i) {
+      printf("%d: %d\n", i, store->getHistogramXYZ()[0].get()[i]);
+    }
+    printf("\n");
+    for (int i{0}; i < store->getConfig().nBinsXYZ[1] - 1; ++i) {
+      printf("%d: %d\n", i, store->getHistogramXYZ()[1].get()[i]);
+    }
+    printf("\n");
+    for (int i{0}; i < store->getConfig().nBinsXYZ[2] - 1; ++i) {
+      printf("%d: %d\n", i, store->getHistogramXYZ()[2].get()[i]);
+    }
+    printf("\n");
+  }
+}
+
+GPUg() void dumpMaximaKernel(DeviceStoreVertexerGPU* store, const int threadId)
+{
+  if (blockIdx.x * blockDim.x + threadIdx.x == threadId) {
+    printf("XmaxBin: %d at index: %d | YmaxBin: %d at index: %d | ZmaxBin: %d at index: %d\n",
+           store->getTmpVertexPositionBins()[0].value, store->getTmpVertexPositionBins()[0].key,
+           store->getTmpVertexPositionBins()[1].value, store->getTmpVertexPositionBins()[1].key,
+           store->getTmpVertexPositionBins()[2].value, store->getTmpVertexPositionBins()[2].key);
+  }
+}
+
+GPUg() void trackleterKernel(
+  DeviceStoreVertexerGPU* store,
+  const TrackletingLayerOrder layerOrder,
+  const float phiCut)
+{
+  const size_t nClustersMiddleLayer = store->getClusters()[1].size();
+  for (int currentClusterIndex = blockIdx.x * blockDim.x + threadIdx.x; currentClusterIndex < nClustersMiddleLayer; currentClusterIndex += blockDim.x * gridDim.x) {
+    if (currentClusterIndex < nClustersMiddleLayer) {
+      int storedTracklets{0};
+      const int stride{currentClusterIndex * store->getConfig().maxTrackletsPerCluster};
+      const Cluster& currentCluster = store->getClusters()[1][currentClusterIndex]; // assign-constructor may be a problem, check
+      const VertexerLayerName adjacentLayerIndex{layerOrder == TrackletingLayerOrder::fromInnermostToMiddleLayer ? VertexerLayerName::innermostLayer : VertexerLayerName::outerLayer};
+      const int4 selectedBinsRect{VertexerTraits::getBinsRect(currentCluster, static_cast<int>(adjacentLayerIndex), 0.f, 50.f, phiCut)};
+      if (selectedBinsRect.x != 0 || selectedBinsRect.y != 0 || selectedBinsRect.z != 0 || selectedBinsRect.w != 0) {
+        int phiBinsNum{selectedBinsRect.w - selectedBinsRect.y + 1};
+        if (phiBinsNum < 0) {
+          phiBinsNum += PhiBins;
+        }
+        const size_t nClustersAdjacentLayer = store->getClusters()[static_cast<int>(adjacentLayerIndex)].size();
+        for (size_t iPhiBin{static_cast<size_t>(selectedBinsRect.y)}, iPhiCount{0}; iPhiCount < phiBinsNum; iPhiBin = ++iPhiBin == PhiBins ? 0 : iPhiBin, iPhiCount++) {
+          const int firstBinIndex{index_table_utils::getBinIndex(selectedBinsRect.x, iPhiBin)};
+          const int firstRowClusterIndex{store->getIndexTable(adjacentLayerIndex)[firstBinIndex]};
+          const int maxRowClusterIndex{store->getIndexTable(adjacentLayerIndex)[firstBinIndex + selectedBinsRect.z - selectedBinsRect.x + 1]};
+          for (int iAdjacentCluster{firstRowClusterIndex}; iAdjacentCluster < maxRowClusterIndex && iAdjacentCluster < nClustersAdjacentLayer; ++iAdjacentCluster) {
+            const Cluster& adjacentCluster = store->getClusters()[static_cast<int>(adjacentLayerIndex)][iAdjacentCluster]; // assign-constructor may be a problem, check
+            if (gpu::GPUCommonMath::Abs(currentCluster.phiCoordinate - adjacentCluster.phiCoordinate) < phiCut) {
+              if (storedTracklets < store->getConfig().maxTrackletsPerCluster) {
+                if (layerOrder == TrackletingLayerOrder::fromInnermostToMiddleLayer) {
+                  store->getDuplets01().emplace(stride + storedTracklets, iAdjacentCluster, currentClusterIndex, adjacentCluster, currentCluster);
+                } else {
+                  store->getDuplets12().emplace(stride + storedTracklets, currentClusterIndex, iAdjacentCluster, currentCluster, adjacentCluster);
+                }
+                ++storedTracklets;
+              } else {
+                printf("debug: leaving tracklet behind\n");
+              }
+            }
+          }
+        }
+      }
+      store->getNFoundTracklets(layerOrder).emplace(currentClusterIndex, storedTracklets);
+    }
+  }
+}
+
+GPUg() void trackletSelectionKernel(
+  DeviceStoreVertexerGPU* store,
+  const unsigned char isInitRun = false,
+  const float tanLambdaCut = 0.025f,
+  const float phiCut = 0.002f)
+{
+  const size_t nClustersMiddleLayer = store->getClusters()[1].size();
+  for (size_t currentClusterIndex = blockIdx.x * blockDim.x + threadIdx.x; currentClusterIndex < nClustersMiddleLayer; currentClusterIndex += blockDim.x * gridDim.x) {
+    const int stride{static_cast<int>(currentClusterIndex * store->getConfig().maxTrackletsPerCluster)};
+    int validTracklets{0};
+    for (int iTracklet12{0}; iTracklet12 < store->getNFoundTracklets(TrackletingLayerOrder::fromMiddleToOuterLayer)[currentClusterIndex]; ++iTracklet12) {
+      for (int iTracklet01{0}; iTracklet01 < store->getNFoundTracklets(TrackletingLayerOrder::fromInnermostToMiddleLayer)[currentClusterIndex] && validTracklets < store->getConfig().maxTrackletsPerCluster; ++iTracklet01) {
+        const float deltaTanLambda{gpu::GPUCommonMath::Abs(store->getDuplets01()[stride + iTracklet01].tanLambda - store->getDuplets12()[stride + iTracklet12].tanLambda)};
+        const float deltaPhi{gpu::GPUCommonMath::Abs(store->getDuplets01()[stride + iTracklet01].phiCoordinate - store->getDuplets12()[stride + iTracklet12].phiCoordinate)};
+        if (deltaTanLambda < tanLambdaCut && deltaPhi < phiCut && validTracklets != store->getConfig().maxTrackletsPerCluster) {
+          assert(store->getDuplets01()[stride + iTracklet01].secondClusterIndex == store->getDuplets12()[stride + iTracklet12].firstClusterIndex);
+          if (!isInitRun) {
+            store->getLines().emplace(store->getNExclusiveFoundLines()[currentClusterIndex] + validTracklets, store->getDuplets01()[stride + iTracklet01], store->getClusters()[0].get(), store->getClusters()[1].get());
+#ifdef _ALLOW_DEBUG_TREES_ITS_
+            store->getDupletIndices()[0].emplace(store->getNExclusiveFoundLines()[currentClusterIndex] + validTracklets, stride + iTracklet01);
+            store->getDupletIndices()[1].emplace(store->getNExclusiveFoundLines()[currentClusterIndex] + validTracklets, stride + iTracklet12);
+#endif
+          }
+          ++validTracklets;
+        }
+      }
+    }
+    if (isInitRun) {
+      store->getNFoundLines().emplace(currentClusterIndex, validTracklets);
+      if (validTracklets >= store->getConfig().maxTrackletsPerCluster) {
+        printf("Warning: not enough space for tracklet selection, some lines will be left behind\n");
+      }
+    }
+  }
+  if (blockIdx.x * blockDim.x + threadIdx.x == 0) {
+    // first thread I want to write an empty line after last found, as adebug flag. Might delete later
+    store->getLines().emplace(store->getNExclusiveFoundLines()[store->getClusters()[1].size() - 1] + store->getNFoundLines()[store->getClusters()[1].size() - 1]);
+  }
+}
+
+GPUg() void computeCentroidsKernel(DeviceStoreVertexerGPU* store,
+                                   const float pairCut)
+{
+  const int nLines = store->getNExclusiveFoundLines()[store->getClusters()[1].size() - 1] + store->getNFoundLines()[store->getClusters()[1].size() - 1];
+  const int maxIterations{nLines * (nLines - 1) / 2};
+  for (size_t currentThreadIndex = blockIdx.x * blockDim.x + threadIdx.x; currentThreadIndex < maxIterations; currentThreadIndex += blockDim.x * gridDim.x) {
+    int iFirstLine = currentThreadIndex / nLines;
+    int iSecondLine = currentThreadIndex % nLines;
+    if (iSecondLine <= iFirstLine) {
+      iFirstLine = nLines - iFirstLine - 2;
+      iSecondLine = nLines - iSecondLine - 1;
+    }
+    if (Line::getDCA(store->getLines()[iFirstLine], store->getLines()[iSecondLine]) < pairCut) {
+      ClusterLinesGPU cluster{store->getLines()[iFirstLine], store->getLines()[iSecondLine]};
+      if (cluster.getVertex()[0] * cluster.getVertex()[0] + cluster.getVertex()[1] * cluster.getVertex()[1] < 1.98f * 1.98f) {
+        // printOnThread(0, "xCentr: %f, yCentr: %f \n", cluster.getVertex()[0], cluster.getVertex()[1]);
+        store->getXYCentroids().emplace(2 * currentThreadIndex, cluster.getVertex()[0]);
+        store->getXYCentroids().emplace(2 * currentThreadIndex + 1, cluster.getVertex()[1]);
+      } else {
+        // writing some data anyway outside the histogram, they will not be put in the histogram, by construction.
+        store->getXYCentroids().emplace(2 * currentThreadIndex, 2 * store->getConfig().lowHistBoundariesXYZ[0]);
+        store->getXYCentroids().emplace(2 * currentThreadIndex + 1, 2 * store->getConfig().lowHistBoundariesXYZ[1]);
+      }
+    } else {
+      // writing some data anyway outside the histogram, they will not be put in the histogram, by construction.
+      store->getXYCentroids().emplace(2 * currentThreadIndex, 2 * store->getConfig().lowHistBoundariesXYZ[0]);
+      store->getXYCentroids().emplace(2 * currentThreadIndex + 1, 2 * store->getConfig().lowHistBoundariesXYZ[1]);
+    }
+  }
+}
+
+GPUg() void computeZCentroidsKernel(DeviceStoreVertexerGPU* store,
+                                    const float pairCut, const int binOpeningX, const int binOpeningY)
+{
+  const int nLines = store->getNExclusiveFoundLines()[store->getClusters()[1].size() - 1] + store->getNFoundLines()[store->getClusters()[1].size() - 1];
+  for (size_t currentThreadIndex = blockIdx.x * blockDim.x + threadIdx.x; currentThreadIndex < nLines; currentThreadIndex += blockDim.x * gridDim.x) {
+    // printOnThread(0, "Max X: %d Max Y %d \n", store->getTmpVertexPositionBins()[0].value, store->getTmpVertexPositionBins()[1].value);
+    if (store->getTmpVertexPositionBins()[0].value || store->getTmpVertexPositionBins()[1].value) {
+      float tmpX{store->getConfig().lowHistBoundariesXYZ[0] + store->getTmpVertexPositionBins()[0].key * store->getConfig().binSizeHistX + store->getConfig().binSizeHistX / 2};
+      int sumWX{store->getTmpVertexPositionBins()[0].value};
+      float wX{tmpX * store->getTmpVertexPositionBins()[0].value};
+      for (int iBin{gpu::GPUCommonMath::Max(0, store->getTmpVertexPositionBins()[0].key - binOpeningX)}; iBin < gpu::GPUCommonMath::Min(store->getTmpVertexPositionBins()[0].key + binOpeningX + 1, store->getConfig().nBinsXYZ[0] - 1); ++iBin) {
+        if (iBin != store->getTmpVertexPositionBins()[0].key) {
+          wX += (store->getConfig().lowHistBoundariesXYZ[0] + iBin * store->getConfig().binSizeHistX + store->getConfig().binSizeHistX / 2) * store->getHistogramXYZ()[0].get()[iBin];
+          sumWX += store->getHistogramXYZ()[0].get()[iBin];
+        }
+      }
+      float tmpY{store->getConfig().lowHistBoundariesXYZ[1] + store->getTmpVertexPositionBins()[1].key * store->getConfig().binSizeHistY + store->getConfig().binSizeHistY / 2};
+      int sumWY{store->getTmpVertexPositionBins()[1].value};
+      float wY{tmpY * store->getTmpVertexPositionBins()[1].value};
+      for (int iBin{gpu::GPUCommonMath::Max(0, store->getTmpVertexPositionBins()[1].key - binOpeningY)}; iBin < gpu::GPUCommonMath::Min(store->getTmpVertexPositionBins()[1].key + binOpeningY + 1, store->getConfig().nBinsXYZ[1] - 1); ++iBin) {
+        if (iBin != store->getTmpVertexPositionBins()[1].key) {
+          wY += (store->getConfig().lowHistBoundariesXYZ[1] + iBin * store->getConfig().binSizeHistY + store->getConfig().binSizeHistY / 2) * store->getHistogramXYZ()[1].get()[iBin];
+          sumWY += store->getHistogramXYZ()[1].get()[iBin];
+        }
+      }
+      store->getBeamPosition().emplace(0, wX / sumWX);
+      store->getBeamPosition().emplace(1, wY / sumWY);
+      float fakeBeamPoint1[3] = {store->getBeamPosition()[0], store->getBeamPosition()[1], -1}; // get two points laying at different z, to create line object
+      float fakeBeamPoint2[3] = {store->getBeamPosition()[0], store->getBeamPosition()[1], 1};
+      Line pseudoBeam{fakeBeamPoint1, fakeBeamPoint2};
+      if (Line::getDCA(store->getLines()[currentThreadIndex], pseudoBeam) < pairCut) {
+        ClusterLinesGPU cluster{store->getLines()[currentThreadIndex], pseudoBeam};
+        store->getZCentroids().emplace(currentThreadIndex, cluster.getVertex()[2]);
+      } else {
+        store->getZCentroids().emplace(currentThreadIndex, 2 * store->getConfig().lowHistBoundariesXYZ[2]);
+      }
+    }
+  }
+}
+
+GPUg() void computeVertexKernel(DeviceStoreVertexerGPU* store, const int vertIndex, const int minContributors, const int binOpeningZ)
+{
+  for (size_t currentThreadIndex = blockIdx.x * blockDim.x + threadIdx.x; currentThreadIndex < binOpeningZ; currentThreadIndex += blockDim.x * gridDim.x) {
+    if (currentThreadIndex == 0) {
+      if (store->getTmpVertexPositionBins()[2].value > 1) {
+        float z{store->getConfig().lowHistBoundariesXYZ[2] + store->getTmpVertexPositionBins()[2].key * store->getConfig().binSizeHistZ + store->getConfig().binSizeHistZ / 2};
+        float ex{0.f};
+        float ey{0.f};
+        float ez{0.f};
+        int sumWZ{store->getTmpVertexPositionBins()[2].value};
+        float wZ{z * store->getTmpVertexPositionBins()[2].value};
+        for (int iBin{gpu::GPUCommonMath::Max(0, store->getTmpVertexPositionBins()[2].key - binOpeningZ)}; iBin < gpu::GPUCommonMath::Min(store->getTmpVertexPositionBins()[2].key + binOpeningZ + 1, store->getConfig().nBinsXYZ[2] - 1); ++iBin) {
+          if (iBin != store->getTmpVertexPositionBins()[2].key) {
+            wZ += (store->getConfig().lowHistBoundariesXYZ[2] + iBin * store->getConfig().binSizeHistZ + store->getConfig().binSizeHistZ / 2) * store->getHistogramXYZ()[2].get()[iBin];
+            sumWZ += store->getHistogramXYZ()[2].get()[iBin];
+          }
+          store->getHistogramXYZ()[2].get()[iBin] = 0;
+        }
+        if (sumWZ > minContributors || vertIndex == 0) {
+          store->getVertices().emplace(vertIndex, store->getBeamPosition()[0], store->getBeamPosition()[1], wZ / sumWZ, ex, ey, ez, sumWZ);
+        } else {
+          store->getVertices().emplace(vertIndex);
+        }
+      } else {
+        store->getVertices().emplace(vertIndex);
+      }
+    }
+  }
+}
+} // namespace GPU
+
+void VertexerTraitsGPU::computeTracklets()
+{
+  const dim3 threadsPerBlock{GPU::Utils::Host::getBlockSize(mClusters[1].capacity())};
+  const dim3 blocksGrid{GPU::Utils::Host::getBlocksGrid(threadsPerBlock, mClusters[1].capacity())};
+
+  hipLaunchKernelGGL((GPU::trackleterKernel), dim3(blocksGrid), dim3(threadsPerBlock), 0, 0, 
+    getDeviceContextPtr(),
+    GPU::TrackletingLayerOrder::fromInnermostToMiddleLayer,
+    mVrtParams.phiCut);
+
+  hipLaunchKernelGGL((GPU::trackleterKernel), dim3(blocksGrid), dim3(threadsPerBlock), 0, 0, 
+    getDeviceContextPtr(),
+    GPU::TrackletingLayerOrder::fromMiddleToOuterLayer,
+    mVrtParams.phiCut);
+
+  gpuThrowOnError();
+
+#ifdef _ALLOW_DEBUG_TREES_ITS_
+  if (isDebugFlag(VertexerDebug::CombinatoricsTreeAll)) {
+    mDebugger->fillCombinatoricsTree(mStoreVertexerGPU.getDupletsFromGPU(GPU::TrackletingLayerOrder::fromInnermostToMiddleLayer),
+                                     mStoreVertexerGPU.getDupletsFromGPU(GPU::TrackletingLayerOrder::fromMiddleToOuterLayer));
+  }
+#endif
+}
+
+void VertexerTraitsGPU::computeTrackletMatching()
+{
+  const dim3 threadsPerBlock{GPU::Utils::Host::getBlockSize(mClusters[1].capacity())};
+  const dim3 blocksGrid{GPU::Utils::Host::getBlocksGrid(threadsPerBlock, mClusters[1].capacity())};
+  size_t bufferSize = mStoreVertexerGPU.getConfig().tmpCUBBufferSize * sizeof(int);
+
+  hipLaunchKernelGGL((GPU::trackletSelectionKernel), dim3(blocksGrid), dim3(threadsPerBlock), 0, 0, 
+    getDeviceContextPtr(),
+    true, // isInitRun
+    mVrtParams.tanLambdaCut,
+    mVrtParams.phiCut);
+
+  (void)hipcub::DeviceScan::ExclusiveSum(reinterpret_cast<void*>(mStoreVertexerGPU.getCUBTmpBuffer().get()),
+                                bufferSize,
+                                mStoreVertexerGPU.getNFoundLines().get(),
+                                mStoreVertexerGPU.getNExclusiveFoundLines().get(),
+                                mClusters[1].size());
+
+  hipLaunchKernelGGL((GPU::trackletSelectionKernel), dim3(blocksGrid), dim3(threadsPerBlock), 0, 0, 
+    getDeviceContextPtr(),
+    false, // isInitRun
+    mVrtParams.tanLambdaCut,
+    mVrtParams.phiCut);
+
+  gpuThrowOnError();
+
+#ifdef _ALLOW_DEBUG_TREES_ITS_
+  if (isDebugFlag(VertexerDebug::TrackletTreeAll)) {
+    mDebugger->fillTrackletSelectionTree(mClusters,
+                                         mStoreVertexerGPU.getRawDupletsFromGPU(GPU::TrackletingLayerOrder::fromInnermostToMiddleLayer),
+                                         mStoreVertexerGPU.getRawDupletsFromGPU(GPU::TrackletingLayerOrder::fromMiddleToOuterLayer),
+                                         mStoreVertexerGPU.getDupletIndicesFromGPU(),
+                                         mEvent);
+  }
+  mTracklets = mStoreVertexerGPU.getLinesFromGPU();
+  if (isDebugFlag(VertexerDebug::LineTreeAll)) {
+    mDebugger->fillPairsInfoTree(mTracklets, mEvent);
+  }
+  if (isDebugFlag(VertexerDebug::LineSummaryAll)) {
+    mDebugger->fillLinesSummaryTree(mTracklets, mEvent);
+  }
+#endif
+}
+
+void VertexerTraitsGPU::computeVertices()
+{
+  const dim3 threadsPerBlock{GPU::Utils::Host::getBlockSize(mClusters[1].capacity())};
+  const dim3 blocksGrid{GPU::Utils::Host::getBlocksGrid(threadsPerBlock, mClusters[1].capacity())};
+  size_t bufferSize = mStoreVertexerGPU.getConfig().tmpCUBBufferSize * sizeof(int);
+  int nLines = mStoreVertexerGPU.getNExclusiveFoundLines().getElementFromDevice(mClusters[1].size() - 1) + mStoreVertexerGPU.getNFoundLines().getElementFromDevice(mClusters[1].size() - 1);
+  int nCentroids{static_cast<int>(nLines * (nLines - 1) / 2)};
+  int* histogramXY[2] = {mStoreVertexerGPU.getHistogramXYZ()[0].get(), mStoreVertexerGPU.getHistogramXYZ()[1].get()};
+  float tmpArrayLow[2] = {mStoreVertexerGPU.getConfig().lowHistBoundariesXYZ[0], mStoreVertexerGPU.getConfig().lowHistBoundariesXYZ[1]};
+  float tmpArrayHigh[2] = {mStoreVertexerGPU.getConfig().highHistBoundariesXYZ[0], mStoreVertexerGPU.getConfig().highHistBoundariesXYZ[1]};
+  hipLaunchKernelGGL((GPU::computeCentroidsKernel), dim3(blocksGrid), dim3(threadsPerBlock), 0, 0, getDeviceContextPtr(),
+                                                               mVrtParams.histPairCut);
+
+  (void)hipcub::DeviceHistogram::MultiHistogramEven<2, 2>(reinterpret_cast<void*>(mStoreVertexerGPU.getCUBTmpBuffer().get()), // d_temp_storage
+                                                 bufferSize,                                                         // temp_storage_bytes
+                                                 mStoreVertexerGPU.getXYCentroids().get(),                           // d_samples
+                                                 histogramXY,                                                        // d_histogram
+                                                 mStoreVertexerGPU.getConfig().nBinsXYZ,                             // num_levels
+                                                 tmpArrayLow,                                                        // lower_level
+                                                 tmpArrayHigh,                                                       // fupper_level
+                                                 nCentroids);                                                        // num_row_pixels
+
+  (void)hipcub::DeviceReduce::ArgMax(reinterpret_cast<void*>(mStoreVertexerGPU.getCUBTmpBuffer().get()),
+                            bufferSize,
+                            histogramXY[0],
+                            mStoreVertexerGPU.getTmpVertexPositionBins().get(),
+                            mStoreVertexerGPU.getConfig().nBinsXYZ[0]);
+  (void)hipcub::DeviceReduce::ArgMax(reinterpret_cast<void*>(mStoreVertexerGPU.getCUBTmpBuffer().get()),
+                            bufferSize,
+                            histogramXY[1],
+                            mStoreVertexerGPU.getTmpVertexPositionBins().get() + 1,
+                            mStoreVertexerGPU.getConfig().nBinsXYZ[0]);
+
+  hipLaunchKernelGGL((GPU::computeZCentroidsKernel), dim3(blocksGrid), dim3(threadsPerBlock), 0, 0, getDeviceContextPtr(), mVrtParams.histPairCut, mStoreVertexerGPU.getConfig().binSpanXYZ[0], mStoreVertexerGPU.getConfig().binSpanXYZ[1]);
+
+  (void)hipcub::DeviceHistogram::HistogramEven(reinterpret_cast<void*>(mStoreVertexerGPU.getCUBTmpBuffer().get()), // d_temp_storage
+                                      bufferSize,                                                         // temp_storage_bytes
+                                      mStoreVertexerGPU.getZCentroids().get(),                            // d_samples
+                                      mStoreVertexerGPU.getHistogramXYZ()[2].get(),                       // d_histogram
+                                      mStoreVertexerGPU.getConfig().nBinsXYZ[2],                          // num_levels
+                                      mStoreVertexerGPU.getConfig().lowHistBoundariesXYZ[2],              // lower_level
+                                      mStoreVertexerGPU.getConfig().highHistBoundariesXYZ[2],             // fupper_level
+                                      nLines);                                                            // num_row_pixels
+
+  for (int iVertex{0}; iVertex < mStoreVertexerGPU.getConfig().nMaxVertices; ++iVertex) {
+    (void)hipcub::DeviceReduce::ArgMax(reinterpret_cast<void*>(mStoreVertexerGPU.getCUBTmpBuffer().get()),
+                              bufferSize,
+                              mStoreVertexerGPU.getHistogramXYZ()[2].get(),
+                              mStoreVertexerGPU.getTmpVertexPositionBins().get() + 2,
+                              mStoreVertexerGPU.getConfig().nBinsXYZ[2]);
+#ifdef _ALLOW_DEBUG_TREES_ITS_
+    if (isDebugFlag(VertexerDebug::HistCentroids) && !iVertex) {
+      mDebugger->fillXYZHistogramTree(std::array<std::vector<int>, 3>{mStoreVertexerGPU.getHistogramXYFromGPU()[0],
+                                                                      mStoreVertexerGPU.getHistogramXYFromGPU()[1], mStoreVertexerGPU.getHistogramZFromGPU()},
+                                      std::array<int, 3>{mStoreVertexerGPU.getConfig().nBinsXYZ[0] - 1,
+                                                         mStoreVertexerGPU.getConfig().nBinsXYZ[1] - 1,
+                                                         mStoreVertexerGPU.getConfig().nBinsXYZ[2] - 1});
+    }
+#endif
+    hipLaunchKernelGGL((GPU::computeVertexKernel), dim3(blocksGrid), dim3(5), 0, 0, getDeviceContextPtr(), iVertex, mVrtParams.clusterContributorsCut, mStoreVertexerGPU.getConfig().binSpanXYZ[2]);
+  }
+  std::vector<GPU::GPUVertex> vertices;
+  vertices.resize(mStoreVertexerGPU.getConfig().nMaxVertices);
+  mStoreVertexerGPU.getVertices().copyIntoSizedVector(vertices);
+
+  for (auto& vertex : vertices) {
+    if (vertex.realVertex) {
+      mVertices.emplace_back(vertex.xCoord, vertex.yCoord, vertex.zCoord, std::array<float, 6>{0.f, 0.f, 0.f, 0.f, 0.f, 0.f}, vertex.contributors, 0.f, -9);
+    }
+  }
+
+  gpuThrowOnError();
+}
+
+#ifdef _ALLOW_DEBUG_TREES_ITS_
+void VertexerTraitsGPU::computeMCFiltering()
+{
+  std::vector<Tracklet> tracklets01 = mStoreVertexerGPU.getRawDupletsFromGPU(GPU::TrackletingLayerOrder::fromInnermostToMiddleLayer);
+  std::vector<Tracklet> tracklets12 = mStoreVertexerGPU.getRawDupletsFromGPU(GPU::TrackletingLayerOrder::fromMiddleToOuterLayer);
+  std::vector<int> labels01 = mStoreVertexerGPU.getNFoundTrackletsFromGPU(GPU::TrackletingLayerOrder::fromInnermostToMiddleLayer);
+  std::vector<int> labels12 = mStoreVertexerGPU.getNFoundTrackletsFromGPU(GPU::TrackletingLayerOrder::fromMiddleToOuterLayer);
+  VertexerStoreConfigurationGPU tmpGPUConf;
+  const int stride = tmpGPUConf.maxTrackletsPerCluster;
+
+  filterTrackletsWithMC(tracklets01, tracklets12, labels01, labels12, stride);
+  mStoreVertexerGPU.updateFoundDuplets(GPU::TrackletingLayerOrder::fromInnermostToMiddleLayer, labels01);
+  mStoreVertexerGPU.updateDuplets(GPU::TrackletingLayerOrder::fromInnermostToMiddleLayer, tracklets01);
+  mStoreVertexerGPU.updateFoundDuplets(GPU::TrackletingLayerOrder::fromMiddleToOuterLayer, labels12);
+  mStoreVertexerGPU.updateDuplets(GPU::TrackletingLayerOrder::fromMiddleToOuterLayer, tracklets12);
+
+  if (isDebugFlag(VertexerDebug::CombinatoricsTreeAll)) {
+    mDebugger->fillCombinatoricsMCTree(mStoreVertexerGPU.getDupletsFromGPU(GPU::TrackletingLayerOrder::fromInnermostToMiddleLayer),
+                                       mStoreVertexerGPU.getDupletsFromGPU(GPU::TrackletingLayerOrder::fromMiddleToOuterLayer));
+  }
+}
+#endif
+
+VertexerTraits* createVertexerTraitsGPU()
+{
+  return new VertexerTraitsGPU;
+}
+
+} // namespace its
+} // namespace o2

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/IndexTableUtils.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/IndexTableUtils.h
@@ -24,6 +24,7 @@
 #include "ITStracking/Constants.h"
 #include "ITStracking/Definitions.h"
 #include "GPUCommonMath.h"
+#include "GPUCommonDef.h"
 
 namespace o2
 {
@@ -33,10 +34,10 @@ namespace its
 namespace index_table_utils
 {
 float getInverseZBinSize(const int);
-GPU_HOST_DEVICE int getZBinIndex(const int, const float);
-GPU_HOST_DEVICE int getPhiBinIndex(const float);
-GPU_HOST_DEVICE int getBinIndex(const int, const int);
-GPU_HOST_DEVICE int countRowSelectedBins(
+GPUhdi() int getZBinIndex(const int, const float);
+GPUhdi() int getPhiBinIndex(const float);
+GPUhdi() int getBinIndex(const int, const int);
+GPUhdi() int countRowSelectedBins(
   const GPUArray<int, constants::index_table::ZBins * constants::index_table::PhiBins + 1>&, const int, const int,
   const int);
 } // namespace index_table_utils
@@ -46,24 +47,24 @@ inline float getInverseZCoordinate(const int layerIndex)
   return 0.5f * constants::index_table::ZBins / constants::its::LayersZCoordinate()[layerIndex];
 }
 
-GPU_HOST_DEVICE inline int index_table_utils::getZBinIndex(const int layerIndex, const float zCoordinate)
+GPUhdi() int index_table_utils::getZBinIndex(const int layerIndex, const float zCoordinate)
 {
   return (zCoordinate + constants::its::LayersZCoordinate()[layerIndex]) *
          constants::index_table::InverseZBinSize()[layerIndex];
 }
 
-GPU_HOST_DEVICE inline int index_table_utils::getPhiBinIndex(const float currentPhi)
+GPUhdi() int index_table_utils::getPhiBinIndex(const float currentPhi)
 {
   return (currentPhi * constants::index_table::InversePhiBinSize);
 }
 
-GPU_HOST_DEVICE inline int index_table_utils::getBinIndex(const int zIndex, const int phiIndex)
+GPUhdi() int index_table_utils::getBinIndex(const int zIndex, const int phiIndex)
 {
   return gpu::GPUCommonMath::Min(phiIndex * constants::index_table::ZBins + zIndex,
                                  constants::index_table::ZBins * constants::index_table::PhiBins - 1);
 }
 
-GPU_HOST_DEVICE inline int index_table_utils::countRowSelectedBins(
+GPUhdi() int index_table_utils::countRowSelectedBins(
   const GPUArray<int, constants::index_table::ZBins * constants::index_table::PhiBins + 1>& indexTable,
   const int phiBinIndex, const int minZBinIndex, const int maxZBinIndex)
 {

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracklet.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracklet.h
@@ -46,7 +46,7 @@ inline Tracklet::Tracklet() : firstClusterIndex{0}, secondClusterIndex{0}, tanLa
 }
 
 GPUdi() Tracklet::Tracklet(const int firstClusterOrderingIndex, const int secondClusterOrderingIndex,
-                                     const Cluster& firstCluster, const Cluster& secondCluster)
+                           const Cluster& firstCluster, const Cluster& secondCluster)
   : firstClusterIndex{firstClusterOrderingIndex},
     secondClusterIndex{secondClusterOrderingIndex},
     tanLambda{(firstCluster.zCoordinate - secondCluster.zCoordinate) /

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracklet.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracklet.h
@@ -18,6 +18,7 @@
 #include "ITStracking/Cluster.h"
 #include <iostream>
 #include "GPUCommonMath.h"
+#include "GPUCommonDef.h"
 
 namespace o2
 {
@@ -26,7 +27,7 @@ namespace its
 
 struct Tracklet final {
   Tracklet();
-  GPU_DEVICE Tracklet(const int, const int, const Cluster&, const Cluster&);
+  GPUdi() Tracklet(const int, const int, const Cluster&, const Cluster&);
 #ifdef _ALLOW_DEBUG_TREES_ITS_
   unsigned char isEmpty() const;
   void dump();
@@ -44,7 +45,7 @@ inline Tracklet::Tracklet() : firstClusterIndex{0}, secondClusterIndex{0}, tanLa
   // Nothing to do
 }
 
-inline GPU_DEVICE Tracklet::Tracklet(const int firstClusterOrderingIndex, const int secondClusterOrderingIndex,
+GPUdi() Tracklet::Tracklet(const int firstClusterOrderingIndex, const int secondClusterOrderingIndex,
                                      const Cluster& firstCluster, const Cluster& secondCluster)
   : firstClusterIndex{firstClusterOrderingIndex},
     secondClusterIndex{secondClusterOrderingIndex},

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
@@ -29,6 +29,7 @@
 #include "ITStracking/Tracklet.h"
 
 #include "GPUCommonMath.h"
+#include "GPUCommonDef.h"
 
 namespace o2
 {
@@ -89,12 +90,12 @@ class VertexerTraits
   virtual ~VertexerTraits() = default;
 #endif
 
-  GPU_HOST_DEVICE static constexpr int4 getEmptyBinsRect()
+  GPUhd() static constexpr int4 getEmptyBinsRect()
   {
     return int4{0, 0, 0, 0};
   }
-  GPU_HOST_DEVICE static const int4 getBinsRect(const Cluster&, const int, const float, float maxdeltaz, float maxdeltaphi);
-  GPU_HOST_DEVICE static const int2 getPhiBins(float phi, float deltaPhi);
+  GPUhd() static const int4 getBinsRect(const Cluster&, const int, const float, float maxdeltaz, float maxdeltaphi);
+  GPUhd() static const int2 getPhiBins(float phi, float deltaPhi);
 
   // virtual vertexer interface
   virtual void reset();
@@ -178,13 +179,13 @@ inline void VertexerTraits::updateVertexingParameters(const VertexingParameters&
   mVrtParams = vrtPar;
 }
 
-inline GPU_HOST_DEVICE const int2 VertexerTraits::getPhiBins(float phi, float dPhi)
+GPUhdi() const int2 VertexerTraits::getPhiBins(float phi, float dPhi)
 {
   return int2{index_table_utils::getPhiBinIndex(math_utils::getNormalizedPhiCoordinate(phi - dPhi)),
               index_table_utils::getPhiBinIndex(math_utils::getNormalizedPhiCoordinate(phi + dPhi))};
 }
 
-inline GPU_HOST_DEVICE const int4 VertexerTraits::getBinsRect(const Cluster& currentCluster, const int layerIndex,
+GPUhdi() const int4 VertexerTraits::getBinsRect(const Cluster& currentCluster, const int layerIndex,
                                                               const float directionZIntersection, float maxdeltaz, float maxdeltaphi)
 {
   const float zRangeMin = directionZIntersection - 2 * maxdeltaz;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
@@ -186,7 +186,7 @@ GPUhdi() const int2 VertexerTraits::getPhiBins(float phi, float dPhi)
 }
 
 GPUhdi() const int4 VertexerTraits::getBinsRect(const Cluster& currentCluster, const int layerIndex,
-                                                              const float directionZIntersection, float maxdeltaz, float maxdeltaphi)
+                                                const float directionZIntersection, float maxdeltaz, float maxdeltaphi)
 {
   const float zRangeMin = directionZIntersection - 2 * maxdeltaz;
   const float phiRangeMin = currentCluster.phiCoordinate - maxdeltaphi;

--- a/GPU/GPUTracking/Base/hip/CMakeLists.txt
+++ b/GPU/GPUTracking/Base/hip/CMakeLists.txt
@@ -25,7 +25,7 @@ if(ALIGPU_BUILD_TYPE STREQUAL "O2")
   o2_add_library(
     ${MODULE}
     SOURCES ${SRCS}
-    PUBLIC_LINK_LIBRARIES O2::GPUTracking hip::host hip::device hip::hipcub ROCm::rocThrust
+    PUBLIC_LINK_LIBRARIES O2::GPUTracking O2::ITStrackingHIP hip::host hip::device hip::hipcub ROCm::rocThrust
     PUBLIC_INCLUDE_DIRECTORIES ${CMAKE_SOURCE_DIR}/Detectors/TRD/base/src
                                ${CMAKE_SOURCE_DIR}/Detectors/Base/src
     TARGETVARNAME targetName)
@@ -69,7 +69,7 @@ endif()
 if(ALIGPU_BUILD_TYPE STREQUAL "Standalone")
   add_definitions(-DGPUCA_GPULIBRARY=HIP)
   add_library(${MODULE} SHARED ${SRCS})
-  target_link_libraries(${MODULE} GPUTracking)
+  target_link_libraries(${MODULE} GPUTracking hip::hipcub)
   set(targetName "${MODULE}")
   install(TARGETS GPUTrackingHIP)
 endif()

--- a/GPU/GPUTracking/Base/hip/GPUReconstructionHIP.h
+++ b/GPU/GPUTracking/Base/hip/GPUReconstructionHIP.h
@@ -50,6 +50,8 @@ class GPUReconstructionHIPBackend : public GPUReconstructionDeviceBase
   void ReleaseEvent(deviceEvent* ev) override;
   void RecordMarker(deviceEvent* ev, int stream) override;
 
+  void GetITSTraits(/*std::unique_ptr<o2::its::TrackerTraits>* trackerTraits,*/ std::unique_ptr<o2::its::VertexerTraits>* vertexerTraits) override;
+
   template <class T, int I = 0, typename... Args>
   int runKernelBackend(const krnlExec& x, const krnlRunRange& y, const krnlEvent& z, Args... args);
 

--- a/GPU/GPUTracking/Base/hip/GPUReconstructionHIP.h
+++ b/GPU/GPUTracking/Base/hip/GPUReconstructionHIP.h
@@ -50,7 +50,7 @@ class GPUReconstructionHIPBackend : public GPUReconstructionDeviceBase
   void ReleaseEvent(deviceEvent* ev) override;
   void RecordMarker(deviceEvent* ev, int stream) override;
 
-  void GetITSTraits(/*std::unique_ptr<o2::its::TrackerTraits>* trackerTraits,*/ std::unique_ptr<o2::its::VertexerTraits>* vertexerTraits) override;
+  void GetITSTraits(std::unique_ptr<o2::its::TrackerTraits>* trackerTraits, std::unique_ptr<o2::its::VertexerTraits>* vertexerTraits) override;
 
   template <class T, int I = 0, typename... Args>
   int runKernelBackend(const krnlExec& x, const krnlRunRange& y, const krnlEvent& z, Args... args);

--- a/GPU/GPUTracking/Base/hip/GPUReconstructionHIP.hip.cxx
+++ b/GPU/GPUTracking/Base/hip/GPUReconstructionHIP.hip.cxx
@@ -122,13 +122,13 @@ GPUReconstructionHIPBackend::~GPUReconstructionHIPBackend()
 
 GPUReconstruction* GPUReconstruction_Create_HIP(const GPUSettingsProcessing& cfg) { return new GPUReconstructionHIP(cfg); }
 
-void GPUReconstructionHIPBackend::GetITSTraits(/*std::unique_ptr<o2::its::TrackerTraits>* trackerTraits,*/ std::unique_ptr<o2::its::VertexerTraits>* vertexerTraits)
+void GPUReconstructionHIPBackend::GetITSTraits(std::unique_ptr<o2::its::TrackerTraits>* trackerTraits, std::unique_ptr<o2::its::VertexerTraits>* vertexerTraits)
 {
   // if (trackerTraits) {
   //   trackerTraits->reset(new o2::its::TrackerTraitsNV);
   // }
   if (vertexerTraits) {
-    vertexerTraits->reset(new o2::its::VertexerTraitsGPU);
+    vertexerTraits->reset(new o2::its::VertexerTraitsHIP);
   }
 }
 

--- a/GPU/GPUTracking/Base/hip/GPUReconstructionHIP.hip.cxx
+++ b/GPU/GPUTracking/Base/hip/GPUReconstructionHIP.hip.cxx
@@ -45,6 +45,19 @@ __global__ void gHIPMemSetWorkaround(char* ptr, char val, size_t size)
   }
 }
 
+#ifdef HAVE_O2HEADERS
+#include "ITStrackingHIP/VertexerTraitsHIP.h"
+#else
+namespace o2
+{
+namespace its
+{
+class VertexerTraitsHIP : public VertexerTraits
+{
+};
+} // namespace its
+} // namespace o2
+#endif
 namespace o2
 {
 namespace its
@@ -108,6 +121,16 @@ GPUReconstructionHIPBackend::~GPUReconstructionHIPBackend()
 }
 
 GPUReconstruction* GPUReconstruction_Create_HIP(const GPUSettingsProcessing& cfg) { return new GPUReconstructionHIP(cfg); }
+
+void GPUReconstructionHIPBackend::GetITSTraits(/*std::unique_ptr<o2::its::TrackerTraits>* trackerTraits,*/ std::unique_ptr<o2::its::VertexerTraits>* vertexerTraits)
+{
+  // if (trackerTraits) {
+  //   trackerTraits->reset(new o2::its::TrackerTraitsNV);
+  // }
+  if (vertexerTraits) {
+    vertexerTraits->reset(new o2::its::VertexerTraitsGPU);
+  }
+}
 
 int GPUReconstructionHIPBackend::InitDevice_Runtime()
 {


### PR DESCRIPTION
Hi @shahor02, @iouribelikov, @davidrohr 

This PR would implement the corresponding HIP-based GPU vertexer.
Good news is that it is consistent with the CUDA one and runs on a `Vega 10 XT [Radeon PRO WX 9100]`.
I am putting WIP because of some things I would like to improve before merging, for instance the automatic calibration of parameters to use based on the detected GPU (we have something already in place for CUDA, wondering if something similar could be done with HIP+AMD).
On this and other things I will probably bug you again, David.
To the reviewer: the code is not written _ex-novo_, is derived from already implemented upstream CUDA version by mean of using `hipify-perl` that translates this for you. Then indeed the resulting files have been extensively adapted, but not in its core algorithms or memory structures.

After first clang-format run I'll squash useless commits.

Cheers

PS: I see there, that `-Werror` on HIP compilation won't make my life easy...
 