### PR TITLE
Coment update: Header descriptors are NOT always null terminated

### DIFF
--- a/DataFormats/Headers/include/Headers/DataHeader.h
+++ b/DataFormats/Headers/include/Headers/DataHeader.h
@@ -69,7 +69,7 @@ namespace header
 /// The header uses char fields for several members. This allows to define self
 /// consistent unique identifiers. The identifiers are human readable in memory
 /// and, rather than enumerators, independent of software versions. The string
-/// is always zero terminated.
+/// is **NOT** required to be zero terminated!.
 ///
 /// This section defines constant field lengths for char fields
 /// @ingroup aliceo2_dataformats_dataheader


### PR DESCRIPTION
the descriptors are not required to be null terminated. By convention they usually are, but when using binary content please use the supported methods, e.g. the as<string> helper.
I think historically we tried to enforce that convention, but in the end there were too many use cases against. @matthiasrichter do you remember what that was? @davidrohr thanks for pointing it out.