### PR TITLE
Header optimization: more constexpr!

### DIFF
--- a/DataFormats/Headers/include/Headers/DataHeader.h
+++ b/DataFormats/Headers/include/Headers/DataHeader.h
@@ -394,7 +394,7 @@ constexpr o2::header::SerializationMethod gSerializationMethodArrow{"ARROW"};
 /// @ingroup aliceo2_dataformats_dataheader
 struct BaseHeader {
   // static definitions
-  static const uint32_t sMagicString;
+  static constexpr uint32_t sMagicString{String2<uint32_t>("O2O2")};
 
   static const uint32_t sVersion;
   static const o2::header::HeaderType sHeaderType;
@@ -436,8 +436,11 @@ struct BaseHeader {
   BaseHeader() = delete;
   BaseHeader(const BaseHeader&) = default;
   /// Special ctor for initialization in derived types
-  BaseHeader(uint32_t mySize, HeaderType description,
-             SerializationMethod serialization, uint32_t version);
+  constexpr BaseHeader(uint32_t mySize, HeaderType desc,
+                       SerializationMethod ser, uint32_t version)
+    : magicStringInt(sMagicString), headerSize(mySize), flags(0), headerVersion(version), description(desc), serialization(ser)
+  {
+  }
 
   /// @brief access header in buffer
   ///
@@ -458,8 +461,8 @@ struct BaseHeader {
                                                                                : nullptr;
   }
 
-  inline uint32_t size() const noexcept { return headerSize; }
-  inline const o2::byte* data() const noexcept { return reinterpret_cast<const o2::byte*>(this); }
+  constexpr uint32_t size() const noexcept { return headerSize; }
+  constexpr const o2::byte* data() const noexcept { return reinterpret_cast<const o2::byte*>(this); }
 
   /// get the next header if any (const version)
   inline const BaseHeader* next() const noexcept

--- a/DataFormats/Headers/include/Headers/Stack.h
+++ b/DataFormats/Headers/include/Headers/Stack.h
@@ -94,14 +94,14 @@ struct Stack {
 
   //______________________________________________________________________________________________
   template <typename T, typename... Args>
-  static size_t calculateSize(T&& h, Args&&... args) noexcept
+  constexpr static size_t calculateSize(T&& h, Args&&... args) noexcept
   {
     return calculateSize(std::forward<T>(h)) + calculateSize(std::forward<Args>(args)...);
   }
 
   //______________________________________________________________________________________________
   template <typename T>
-  static size_t calculateSize(T&& h) noexcept
+  constexpr static size_t calculateSize(T&& h) noexcept
   {
     if constexpr (std::is_convertible_v<T, o2::byte*>) {
       const BaseHeader* next = BaseHeader::get(std::forward<T>(h));
@@ -142,7 +142,7 @@ struct Stack {
       last->flagsNextHeader = more;
       return here + h.size();
     } else if constexpr (std::is_base_of_v<BaseHeader, headerType>) {
-      std::copy(h.data(), h.data() + h.size(), here);
+      ::new (static_cast<void*>(here)) headerType(std::forward<T>(h));
       reinterpret_cast<BaseHeader*>(here)->flagsNextHeader = more;
       return here + h.size();
     } else if constexpr (std::is_same_v<headerType, o2::byte*>) {

--- a/DataFormats/Headers/src/DataHeader.cxx
+++ b/DataFormats/Headers/src/DataHeader.cxx
@@ -29,51 +29,7 @@ const uint32_t o2::header::BaseHeader::sVersion = o2::header::gInvalidToken32;
 const o2::header::HeaderType o2::header::BaseHeader::sHeaderType = o2::header::gInvalidToken64;
 const o2::header::SerializationMethod o2::header::BaseHeader::sSerializationMethod = o2::header::gInvalidToken64;
 
-//storage for DataHeader static members
-const uint32_t o2::header::DataHeader::sVersion = 1;
-const o2::header::HeaderType o2::header::DataHeader::sHeaderType = String2<uint64_t>("DataHead");
-const o2::header::SerializationMethod o2::header::DataHeader::sSerializationMethod = o2::header::gSerializationMethodNone;
-
 using namespace o2::header;
-
-//__________________________________________________________________________________________________
-o2::header::DataHeader::DataHeader()
-  : BaseHeader(sizeof(DataHeader), sHeaderType, sSerializationMethod, sVersion),
-    dataDescription(gDataDescriptionInvalid),
-    dataOrigin(gDataOriginInvalid),
-    splitPayloadParts(1),
-    payloadSerializationMethod(gSerializationMethodInvalid),
-    subSpecification(0),
-    splitPayloadIndex(0),
-    payloadSize(0)
-{
-}
-
-//__________________________________________________________________________________________________
-o2::header::DataHeader::DataHeader(DataDescription desc, DataOrigin origin, SubSpecificationType subspec, PayloadSizeType size)
-  : BaseHeader(sizeof(DataHeader), sHeaderType, sSerializationMethod, sVersion),
-    dataDescription(desc),
-    dataOrigin(origin),
-    splitPayloadParts(1),
-    payloadSerializationMethod(gSerializationMethodInvalid),
-    subSpecification(subspec),
-    splitPayloadIndex(0),
-    payloadSize(size)
-{
-}
-
-//__________________________________________________________________________________________________
-o2::header::DataHeader::DataHeader(DataDescription desc, DataOrigin origin, SubSpecificationType subspec, PayloadSizeType size, SplitPayloadIndexType partIndex, SplitPayloadPartsType parts)
-  : BaseHeader(sizeof(DataHeader), sHeaderType, sSerializationMethod, sVersion),
-    dataDescription(desc),
-    dataOrigin(origin),
-    splitPayloadParts(parts),
-    payloadSerializationMethod(gSerializationMethodInvalid),
-    subSpecification(subspec),
-    splitPayloadIndex(partIndex),
-    payloadSize(size)
-{
-}
 
 //__________________________________________________________________________________________________
 void o2::header::DataHeader::print() const

--- a/DataFormats/Headers/src/DataHeader.cxx
+++ b/DataFormats/Headers/src/DataHeader.cxx
@@ -24,9 +24,6 @@
 #include <cstdio>  // printf
 #include <cstring> // strncpy
 
-//the answer to life and everything
-const uint32_t o2::header::BaseHeader::sMagicString = String2<uint32_t>("O2O2");
-
 //storage for BaseHeader static members, all invalid
 const uint32_t o2::header::BaseHeader::sVersion = o2::header::gInvalidToken32;
 const o2::header::HeaderType o2::header::BaseHeader::sHeaderType = o2::header::gInvalidToken64;
@@ -38,12 +35,6 @@ const o2::header::HeaderType o2::header::DataHeader::sHeaderType = String2<uint6
 const o2::header::SerializationMethod o2::header::DataHeader::sSerializationMethod = o2::header::gSerializationMethodNone;
 
 using namespace o2::header;
-
-//__________________________________________________________________________________________________
-o2::header::BaseHeader::BaseHeader(uint32_t mySize, HeaderType desc, SerializationMethod ser, uint32_t version)
-  : magicStringInt(sMagicString), headerSize(mySize), flags(0), headerVersion(version), description(desc), serialization(ser)
-{
-}
 
 //__________________________________________________________________________________________________
 o2::header::DataHeader::DataHeader()


### PR DESCRIPTION
- Stack::calculateSize() is now constexpr
- Stack construction without a copy in some cases by allowing copy elision in the Stack ctor