### PR TITLE
DPL: enable shared memory backend

### DIFF
--- a/Framework/Core/src/ChannelSpecHelpers.cxx
+++ b/Framework/Core/src/ChannelSpecHelpers.cxx
@@ -46,7 +46,7 @@ std::string ChannelSpecHelpers::channelUrl(OutputChannelSpec const& channel)
 {
   switch (channel.protocol) {
     case ChannelProtocol::IPC:
-      return fmt::format("ipc://{}_{}", channel.hostname, channel.port);
+      return fmt::format("ipc://{}_{},transport=shmem", channel.hostname, channel.port);
     default:
       return channel.method == ChannelMethod::Bind ? fmt::format("tcp://*:{}", channel.port)
                                                    : fmt::format("tcp://{}:{}", channel.hostname, channel.port);
@@ -57,7 +57,7 @@ std::string ChannelSpecHelpers::channelUrl(InputChannelSpec const& channel)
 {
   switch (channel.protocol) {
     case ChannelProtocol::IPC:
-      return fmt::format("ipc://{}_{}", channel.hostname, channel.port);
+      return fmt::format("ipc://{}_{},transport=shmem", channel.hostname, channel.port);
     default:
       return channel.method == ChannelMethod::Bind ? fmt::format("tcp://*:{}", channel.port)
                                                    : fmt::format("tcp://{}:{}", channel.hostname, channel.port);

--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -742,7 +742,8 @@ void DeviceSpecHelpers::prepareArguments(bool defaultQuiet, bool defaultStopped,
                                          std::vector<DataProcessorInfo> const& processorInfos,
                                          std::vector<DeviceSpec> const& deviceSpecs,
                                          std::vector<DeviceExecution>& deviceExecutions,
-                                         std::vector<DeviceControl>& deviceControls)
+                                         std::vector<DeviceControl>& deviceControls,
+                                         std::string const& uniqueWorkflowId)
 {
   assert(deviceSpecs.size() == deviceExecutions.size());
   assert(deviceControls.size() == deviceExecutions.size());
@@ -794,6 +795,7 @@ void DeviceSpecHelpers::prepareArguments(bool defaultQuiet, bool defaultStopped,
     std::vector<std::string> tmpArgs = {argv[0],
                                         "--id", spec.id.c_str(),
                                         "--control", "static",
+                                        "--session", "dpl_" + uniqueWorkflowId,
                                         "--log-color", "false",
                                         "--color", "false"};
     if (defaultStopped) {
@@ -841,6 +843,7 @@ void DeviceSpecHelpers::prepareArguments(bool defaultQuiet, bool defaultStopped,
         realOdesc.add_options()("child-driver", bpo::value<std::string>());
         realOdesc.add_options()("rate", bpo::value<std::string>());
         realOdesc.add_options()("shm-segment-size", bpo::value<std::string>());
+        realOdesc.add_options()("session", bpo::value<std::string>());
         filterArgsFct(expansions.we_wordc, expansions.we_wordv, realOdesc);
         wordfree(&expansions);
         return;
@@ -932,6 +935,7 @@ boost::program_options::options_description DeviceSpecHelpers::getForwardedDevic
     ("control-port", bpo::value<std::string>(), "Utility port to be used by O2 Control")                        //
     ("rate", bpo::value<std::string>(), "rate for a data source device (Hz)")                                   //
     ("shm-segment-size", bpo::value<std::string>(), "size of the shared memory segment in bytes")               //
+    ("session", bpo::value<std::string>(), "unique label for the shm session")                                  //
     ("monitoring-backend", bpo::value<std::string>(), "monitoring connection string")                           //
     ("infologger-mode", bpo::value<std::string>(), "INFOLOGGER_MODE override")                                  //
     ("infologger-severity", bpo::value<std::string>(), "minimun FairLogger severity which goes to info logger") //

--- a/Framework/Core/src/DeviceSpecHelpers.h
+++ b/Framework/Core/src/DeviceSpecHelpers.h
@@ -68,7 +68,8 @@ struct DeviceSpecHelpers {
     std::vector<DataProcessorInfo> const& processorInfos,
     std::vector<DeviceSpec> const& deviceSpecs,
     std::vector<DeviceExecution>& deviceExecutions,
-    std::vector<DeviceControl>& deviceControls);
+    std::vector<DeviceControl>& deviceControls,
+    std::string const& uniqueWorkflowId);
 
   /// This takes the list of preprocessed edges of a graph
   /// and creates Devices and Channels which are related

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -204,7 +204,7 @@ void killChildren(std::vector<DeviceInfo>& infos, int sig)
 bool areAllChildrenGone(std::vector<DeviceInfo>& infos)
 {
   for (auto& info : infos) {
-    if (info.active) {
+    if ((info.pid != 0) && info.active) {
       return false;
     }
   }
@@ -936,7 +936,8 @@ int runStateMachine(DataProcessorSpecs const& workflow,
                                             driverControl.defaultStopped,
                                             dataProcessorInfos,
                                             deviceSpecs,
-                                            deviceExecutions, controls);
+                                            deviceExecutions, controls,
+                                            driverInfo.uniqueWorkflowId);
 
         std::ostringstream forwardedStdin;
         WorkflowSerializationHelpers::dump(forwardedStdin, workflow, dataProcessorInfos);

--- a/Framework/Core/test/test_DeviceSpecHelpers.cxx
+++ b/Framework/Core/test/test_DeviceSpecHelpers.cxx
@@ -80,7 +80,8 @@ void check(const std::vector<std::string>& arguments,
                                       dataProcessorInfos,
                                       deviceSpecs,
                                       deviceExecutions,
-                                      deviceControls);
+                                      deviceControls,
+                                      "workflow-id");
 
   std::cout << "created execution for " << deviceSpecs.size() << " device(s)" << std::endl;
 

--- a/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
+++ b/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
@@ -92,20 +92,20 @@ BOOST_AUTO_TEST_CASE(TestDDS)
     }};
   DeviceSpecHelpers::prepareArguments(false, false,
                                       dataProcessorInfos,
-                                      devices, executions, controls);
+                                      devices, executions, controls, "workflow-id");
   dumpDeviceSpec2DDS(ss, devices, executions);
   BOOST_CHECK_EQUAL(ss.str(), R"EXPECTED(<topology id="o2-dataflow">
    <decltask id="A">
-       <exe reachable="true">foo --id A --control static --log-color false --color false --jobs 4 --plugin-search-path $FAIRMQ_ROOT/lib --plugin dds</exe>
+       <exe reachable="true">foo --id A --control static --session dpl_workflow-id --log-color false --color false --jobs 4 --plugin-search-path $FAIRMQ_ROOT/lib --plugin dds</exe>
    </decltask>
    <decltask id="B">
-       <exe reachable="true">foo --id B --control static --log-color false --color false --jobs 4 --plugin-search-path $FAIRMQ_ROOT/lib --plugin dds</exe>
+       <exe reachable="true">foo --id B --control static --session dpl_workflow-id --log-color false --color false --jobs 4 --plugin-search-path $FAIRMQ_ROOT/lib --plugin dds</exe>
    </decltask>
    <decltask id="C">
-       <exe reachable="true">foo --id C --control static --log-color false --color false --jobs 4 --plugin-search-path $FAIRMQ_ROOT/lib --plugin dds</exe>
+       <exe reachable="true">foo --id C --control static --session dpl_workflow-id --log-color false --color false --jobs 4 --plugin-search-path $FAIRMQ_ROOT/lib --plugin dds</exe>
    </decltask>
    <decltask id="D">
-       <exe reachable="true">foo --id D --control static --log-color false --color false --jobs 4 --plugin-search-path $FAIRMQ_ROOT/lib --plugin dds</exe>
+       <exe reachable="true">foo --id D --control static --session dpl_workflow-id --log-color false --color false --jobs 4 --plugin-search-path $FAIRMQ_ROOT/lib --plugin dds</exe>
    </decltask>
 </topology>
 )EXPECTED");


### PR DESCRIPTION
Devices sitting on the same resource will use the same shared memory
pool. Notice how we set the FairMQ `--session` to be
`dpl_<driver-process-pid>`.