### PR TITLE
DPL: Extend OutpuObj so that an object can be set later

### DIFF
--- a/Framework/AnalysisTutorial/src/histograms.cxx
+++ b/Framework/AnalysisTutorial/src/histograms.cxx
@@ -47,11 +47,22 @@ struct BTask {
 
 struct CTask {
   OutputObj<TH1F> ptH{TH1F("pt", "pt", 100, -0.01, 10.01)};
+  OutputObj<TH1F> trZ;
+
+  void init(InitContext const&)
+  {
+    trZ.setObject(new TH1F("Z", "Z", 100, -10., 10.));
+    // other options:
+    // TH1F* t = new TH1F(); trZ.setObject(t);
+    // TH1F t(); trZ.setObject(t) <- makes a copy
+    // trZ.setObject({"Z","Z",100,-10.,10.}); <- creates new
+  }
 
   void process(aod::Tracks const& tracks)
   {
     for (auto& track : tracks) {
-      ptH->Fill(abs(track.signed1Pt()));
+      ptH->Fill(abs(1.f / track.signed1Pt()));
+      trZ->Fill(track.z());
     }
   }
 };

--- a/Framework/AnalysisTutorial/src/histograms.cxx
+++ b/Framework/AnalysisTutorial/src/histograms.cxx
@@ -46,14 +46,17 @@ struct BTask {
 };
 
 struct CTask {
+  // needs to be initialized with a label or an obj
+  // when adding an object to OutputObj later, the object name will be
+  // *reset* to OutputObj label - needed for correct placement in the output file
   OutputObj<TH1F> ptH{TH1F("pt", "pt", 100, -0.01, 10.01)};
-  OutputObj<TH1F> trZ;
+  OutputObj<TH1F> trZ{"trZ"};
 
   void init(InitContext const&)
   {
     trZ.setObject(new TH1F("Z", "Z", 100, -10., 10.));
     // other options:
-    // TH1F* t = new TH1F(); trZ.setObject(t);
+    // TH1F* t = new TH1F(); trZ.setObject(t); <- resets content!
     // TH1F t(); trZ.setObject(t) <- makes a copy
     // trZ.setObject({"Z","Z",100,-10.,10.}); <- creates new
   }

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -115,40 +115,48 @@ struct OutputObj {
   using obj_t = T;
 
   OutputObj(T const& t)
-    : object(std::make_shared<T>(t))
+    : object(std::make_shared<T>(t)),
+      label(t.GetName())
   {
   }
 
-  OutputObj()
-    : object(nullptr)
+  OutputObj(std::string const& label_)
+    : object(nullptr),
+      label(label_)
   {
   }
 
   void setObject(T const& t)
   {
     object = std::make_shared<T>(t);
+    object->SetName(label.c_str());
   }
 
   void setObject(T&& t)
   {
     object = std::make_shared<T>(t);
+    object->SetName(label.c_str());
   }
 
   void setObject(T* t)
   {
     object.reset(t);
+    object->SetName(label.c_str());
   }
 
   // @return the associated OutputSpec
   OutputSpec const spec()
   {
     static_assert(std::is_base_of_v<TNamed, T>, "You need a TNamed derived class to use OutputObj");
-    std::string label{object->GetName()};
     header::DataDescription desc{};
-    // FIXME: for the moment we use GetTitle(), in the future
-    //        we should probably use a unique hash to allow
-    //        names longer than 16 bytes.
-    strncpy(desc.str, object->GetTitle(), 16);
+    if (object == nullptr) {
+      strncpy(desc.str, "__OUTPUTOBJECT__", 16);
+    } else {
+      // FIXME: for the moment we use GetTitle(), in the future
+      //        we should probably use a unique hash to allow
+      //        names longer than 16 bytes.
+      strncpy(desc.str, object->GetTitle(), 16);
+    }
 
     return OutputSpec{OutputLabel{label}, "ATSK", desc, 0};
   }
@@ -165,11 +173,11 @@ struct OutputObj {
 
   OutputRef ref()
   {
-    std::string label{object->GetName()};
     return OutputRef{label, 0};
   }
 
   std::shared_ptr<T> object;
+  std::string label;
 };
 
 struct AnalysisTask {

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -119,6 +119,26 @@ struct OutputObj {
   {
   }
 
+  OutputObj()
+    : object(nullptr)
+  {
+  }
+
+  void setObject(T const& t)
+  {
+    object = std::make_shared<T>(t);
+  }
+
+  void setObject(T&& t)
+  {
+    object = std::make_shared<T>(t);
+  }
+
+  void setObject(T* t)
+  {
+    object.reset(t);
+  }
+
   // @return the associated OutputSpec
   OutputSpec const spec()
   {

--- a/Framework/Core/src/CommonDataProcessors.cxx
+++ b/Framework/Core/src/CommonDataProcessors.cxx
@@ -73,13 +73,11 @@ DataProcessorSpec CommonDataProcessors::getOutputObjSink(outputObjMap const& out
       for (auto& [route, entry] : *outputObjects) {
         std::string nextDirectory = route.directory;
         if (nextDirectory != currentDirectory) {
-          LOGP(INFO, "Now writing in {}", nextDirectory);
           if (!f->FindKey(nextDirectory.c_str())) {
             f->mkdir(nextDirectory.c_str());
           }
           currentDirectory = nextDirectory;
         }
-        LOGP(INFO, "Now writing {}", entry.name);
         (f->GetDirectory(currentDirectory.c_str()))->WriteObjectAny(entry.obj, entry.kind, entry.name.c_str());
       }
       if (f) {
@@ -115,7 +113,6 @@ DataProcessorSpec CommonDataProcessors::getOutputObjSink(outputObjMap const& out
 
       obj.obj = tm.ReadObjectAny(obj.kind);
       TNamed* named = static_cast<TNamed*>(obj.obj);
-      LOGP(info, "Object name {}", named->GetName());
       obj.name = named->GetName();
       auto lookup = outMap.find(obj.name);
       std::string directory{"VariousObjects"};


### PR DESCRIPTION
Allows to export objects, that can not be statically initialized (like THn)