### PR TITLE
DPL: optimize processDanglingInputs

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -49,6 +49,7 @@ o2_add_library(Framework
                        src/SourceInfoHeader.cxx
                        src/DataProcessor.cxx
                        src/DataRelayer.cxx
+                       src/DataRelayerHelpers.cxx
                        src/DataSampling.cxx
                        src/DataSamplingConditionFactory.cxx
                        src/DataSamplingHeader.cxx

--- a/Framework/Core/include/Framework/DataRelayer.h
+++ b/Framework/Core/include/Framework/DataRelayer.h
@@ -53,8 +53,7 @@ class DataRelayer
   };
 
   DataRelayer(CompletionPolicy const&,
-              std::vector<InputRoute> const&,
-              std::vector<ForwardRoute> const&,
+              std::vector<InputRoute> const& routes,
               monitoring::Monitoring&,
               TimesliceIndex&);
 
@@ -94,10 +93,9 @@ class DataRelayer
 
   /// Send metrics with the VariableContext information
   void sendContextState();
+  void publishMetrics();
 
  private:
-  std::vector<InputRoute> const& mInputRoutes;
-  std::vector<ForwardRoute> const& mForwardRoutes;
   monitoring::Monitoring& mMetrics;
 
   /// This is the actual cache of all the parts in flight.
@@ -110,7 +108,6 @@ class DataRelayer
   /// cacheline.
   TimesliceIndex& mTimesliceIndex;
 
-  std::vector<bool> mForwardingMask;
   CompletionPolicy mCompletionPolicy;
   std::vector<size_t> mDistinctRoutesIndex;
   std::vector<data_matcher::DataDescriptorMatcher> mInputMatchers;

--- a/Framework/Core/include/Framework/ExpirationHandler.h
+++ b/Framework/Core/include/Framework/ExpirationHandler.h
@@ -25,11 +25,17 @@ struct ServiceRegistry;
 struct TimesliceIndex;
 struct TimesliceSlot;
 
+/// Typesafe index inside
+struct RouteIndex {
+  int value;
+};
+
 struct ExpirationHandler {
   using Creator = std::function<TimesliceSlot(TimesliceIndex&)>;
   using Checker = std::function<bool(uint64_t timestamp)>;
   using Handler = std::function<void(ServiceRegistry&, PartRef& expiredInput, uint64_t timestamp)>;
 
+  RouteIndex routeIndex;
   Lifetime lifetime;
   Creator creator;
   Checker checker;

--- a/Framework/Core/include/Framework/InputRoute.h
+++ b/Framework/Core/include/Framework/InputRoute.h
@@ -15,6 +15,7 @@
 #include <cstddef>
 #include <string>
 #include <functional>
+#include <optional>
 
 namespace o2
 {
@@ -25,6 +26,16 @@ struct PartRef;
 struct ServiceRegistry;
 class ConfigParamRegistry;
 
+struct RouteConfigurator {
+  using CreationConfigurator = std::function<ExpirationHandler::Creator(ConfigParamRegistry const&)>;
+  using DanglingConfigurator = std::function<ExpirationHandler::Checker(ConfigParamRegistry const&)>;
+  using ExpirationConfigurator = std::function<ExpirationHandler::Handler(ConfigParamRegistry const&)>;
+
+  CreationConfigurator creatorConfigurator = nullptr;
+  DanglingConfigurator danglingConfigurator = nullptr;
+  ExpirationConfigurator expirationConfigurator = nullptr;
+};
+
 /// This uniquely identifies a route to from which data matching @a matcher
 /// input spec gets to the device. In case of time pipelining @a timeslice
 /// refers to the timeslice associated to this route. The three callbacks @a
@@ -34,9 +45,6 @@ class ConfigParamRegistry;
 /// how.  By default inputs are never considered valid and they are never
 /// created from nothing.
 struct InputRoute {
-  using CreationConfigurator = std::function<ExpirationHandler::Creator(ConfigParamRegistry const&)>;
-  using DanglingConfigurator = std::function<ExpirationHandler::Checker(ConfigParamRegistry const&)>;
-  using ExpirationConfigurator = std::function<ExpirationHandler::Handler(ConfigParamRegistry const&)>;
 
   // FIXME: This should really go away and we should make sure that
   //        whenever we pass the input routes we also have the associated
@@ -45,9 +53,7 @@ struct InputRoute {
   size_t inputSpecIndex;
   std::string sourceChannel;
   size_t timeslice;
-  CreationConfigurator creatorConfigurator = nullptr;
-  DanglingConfigurator danglingConfigurator = nullptr;
-  ExpirationConfigurator expirationConfigurator = nullptr;
+  std::optional<RouteConfigurator> configurator;
 };
 
 } // namespace framework

--- a/Framework/Core/src/DataRelayer.cxx
+++ b/Framework/Core/src/DataRelayer.cxx
@@ -18,8 +18,9 @@
 #include "Framework/Logger.h"
 #include "Framework/PartRef.h"
 #include "Framework/TimesliceIndex.h"
-#include "DataProcessingStatus.h"
 #include "Framework/Signpost.h"
+#include "DataProcessingStatus.h"
+#include "DataRelayerHelpers.h"
 
 #include <Monitoring/Monitoring.h>
 
@@ -35,56 +36,6 @@ namespace o2
 namespace framework
 {
 
-namespace
-{
-/// Calculate how many input routes there are, doublecounting different
-/// timeslices.
-std::vector<size_t> createDistinctRouteIndex(std::vector<InputRoute> const& routes)
-{
-  std::vector<size_t> result;
-  for (size_t ri = 0; ri < routes.size(); ++ri) {
-    auto& route = routes[ri];
-    if (route.timeslice == 0) {
-      result.push_back(ri);
-    }
-  }
-  return result;
-}
-
-DataDescriptorMatcher fromConcreteMatcher(ConcreteDataMatcher const& matcher)
-{
-  return DataDescriptorMatcher{
-    DataDescriptorMatcher::Op::And,
-    StartTimeValueMatcher{ContextRef{0}},
-    std::make_unique<DataDescriptorMatcher>(
-      DataDescriptorMatcher::Op::And,
-      OriginValueMatcher{matcher.origin.as<std::string>()},
-      std::make_unique<DataDescriptorMatcher>(
-        DataDescriptorMatcher::Op::And,
-        DescriptionValueMatcher{matcher.description.as<std::string>()},
-        std::make_unique<DataDescriptorMatcher>(
-          DataDescriptorMatcher::Op::Just,
-          SubSpecificationTypeValueMatcher{matcher.subSpec})))};
-}
-
-/// This converts from InputRoute to the associated DataDescriptorMatcher.
-std::vector<DataDescriptorMatcher> createInputMatchers(std::vector<InputRoute> const& routes)
-{
-  std::vector<DataDescriptorMatcher> result;
-
-  for (auto& route : routes) {
-    if (auto pval = std::get_if<ConcreteDataMatcher>(&route.matcher.matcher)) {
-      result.emplace_back(fromConcreteMatcher(*pval));
-    } else if (auto matcher = std::get_if<DataDescriptorMatcher>(&route.matcher.matcher)) {
-      result.push_back(*matcher);
-    } else {
-      throw std::runtime_error("Unsupported InputSpec type");
-    }
-  }
-
-  return result;
-}
-} // namespace
 
 constexpr int INVALID_INPUT = -1;
 
@@ -94,64 +45,76 @@ constexpr int DEFAULT_PIPELINE_LENGTH = 16;
 
 // FIXME: do we really need to pass the forwards?
 DataRelayer::DataRelayer(const CompletionPolicy& policy,
-                         const std::vector<InputRoute>& inputRoutes,
-                         const std::vector<ForwardRoute>& forwardRoutes,
+                         std::vector<InputRoute> const& routes,
                          monitoring::Monitoring& metrics,
                          TimesliceIndex& index)
-  : mInputRoutes{inputRoutes},
-    mForwardRoutes{forwardRoutes},
-    mTimesliceIndex{index},
+  : mTimesliceIndex{index},
     mMetrics{metrics},
     mCompletionPolicy{policy},
-    mDistinctRoutesIndex{createDistinctRouteIndex(inputRoutes)},
-    mInputMatchers{createInputMatchers(inputRoutes)}
+    mDistinctRoutesIndex{DataRelayerHelpers::createDistinctRouteIndex(routes)},
+    mInputMatchers{DataRelayerHelpers::createInputMatchers(routes)}
 {
   setPipelineLength(DEFAULT_PIPELINE_LENGTH);
-  for (size_t ci = 0; ci < mCache.size(); ci++) {
-    metrics.send({0, sMetricsNames[ci]});
-  }
-  for (size_t ci = 0; ci < mVariableContextes.size() * 16; ci++) {
-    metrics.send({std::string("null"), sVariablesMetricsNames[ci]});
+
+  // The queries are all the same, so we only have width 1
+  auto numInputTypes = mDistinctRoutesIndex.size();
+  sQueriesMetricsNames.resize(numInputTypes * 1);
+  mMetrics.send({(int)numInputTypes, "data_queries/h"});
+  mMetrics.send({(int)1, "data_queries/w"});
+  for (size_t i = 0; i < numInputTypes; ++i) {
+    sQueriesMetricsNames[i] = std::string("data_queries/") + std::to_string(i);
+    char buffer[128];
+    assert(mDistinctRoutesIndex[i] < routes.size());
+    auto& matcher = routes[mDistinctRoutesIndex[i]].matcher;
+    DataSpecUtils::describe(buffer, 127, matcher);
+    mMetrics.send({std::string{buffer}, sQueriesMetricsNames[i]});
   }
 }
 
 void DataRelayer::processDanglingInputs(std::vector<ExpirationHandler> const& expirationHandlers,
                                         ServiceRegistry& services)
 {
+  /// Nothing to do if nothing can expire.
+  if (expirationHandlers.empty()) {
+    return;
+  }
   // Create any slot for the time based fields
   std::vector<TimesliceSlot> slotsCreatedByHandlers(expirationHandlers.size());
-  for (size_t hi = 0; hi < expirationHandlers.size(); ++hi) {
-    slotsCreatedByHandlers[hi] = expirationHandlers[hi].creator(mTimesliceIndex);
+  for (auto& handler : expirationHandlers) {
+    slotsCreatedByHandlers.push_back(handler.creator(mTimesliceIndex));
   }
-  // Expire the records as needed.
+  // Outer loop, we process all the records because the fact that the record
+  // expires is independent from having received data for it.
   for (size_t ti = 0; ti < mTimesliceIndex.size(); ++ti) {
     TimesliceSlot slot{ti};
     if (mTimesliceIndex.isValid(slot) == false) {
       continue;
     }
     assert(mDistinctRoutesIndex.empty() == false);
-    for (size_t ri = 0; ri < mDistinctRoutesIndex.size(); ++ri) {
-      auto& route = mInputRoutes[mDistinctRoutesIndex[ri]];
-      auto& expirator = expirationHandlers[mDistinctRoutesIndex[ri]];
-      auto timestamp = mTimesliceIndex.getTimesliceForSlot(slot);
-      auto& part = mCache[ti * mDistinctRoutesIndex.size() + ri];
+    auto timestamp = mTimesliceIndex.getTimesliceForSlot(slot);
+    // We iterate on all the hanlders checking if they need to be expired.
+    for (size_t ei = 0; ei < expirationHandlers.size(); ++ei) {
+      auto& expirator = expirationHandlers[ei];
+      // We check that no data is already there for the given cell
+      auto& part = mCache[ti * mDistinctRoutesIndex.size() + expirator.routeIndex.value];
       if (part.header != nullptr) {
         continue;
       }
       if (part.payload != nullptr) {
         continue;
       }
+      // We check that the cell can actually be expired.
       if (!expirator.checker) {
         continue;
       }
-      if (slotsCreatedByHandlers[mDistinctRoutesIndex[ri]].index != slot.index) {
+      if (slotsCreatedByHandlers[ei].index != slot.index) {
         continue;
       }
       if (expirator.checker(timestamp.value) == false) {
         continue;
       }
 
-      assert(ti * mDistinctRoutesIndex.size() + ri < mCache.size());
+      assert(ti * mDistinctRoutesIndex.size() + expirator.routeIndex.value < mCache.size());
       assert(expirator.handler);
       expirator.handler(services, part, timestamp.value);
       mTimesliceIndex.markAsDirty(slot, true);
@@ -207,7 +170,6 @@ DataRelayer::RelayChoice
   // This is the class level state of the relaying. If we start supporting
   // multithreading this will have to be made thread safe before we can invoke
   // relay concurrently.
-  auto const& inputRoutes = mInputRoutes;
   auto& index = mTimesliceIndex;
 
   auto& cache = mCache;
@@ -552,6 +514,11 @@ void DataRelayer::setPipelineLength(size_t s)
 {
   mTimesliceIndex.resize(s);
   mVariableContextes.resize(s);
+  publishMetrics();
+}
+
+void DataRelayer::publishMetrics()
+{
   auto numInputTypes = mDistinctRoutesIndex.size();
   mCache.resize(numInputTypes * mTimesliceIndex.size());
   mMetrics.send({(int)numInputTypes, "data_relayer/h"});
@@ -571,16 +538,14 @@ void DataRelayer::setPipelineLength(size_t s)
     sVariablesMetricsNames[i] = std::string("matcher_variables/") + std::to_string(i);
     mMetrics.send({std::string("null"), sVariablesMetricsNames[i % 16]});
   }
-  // The queries are all the same, so we only have width 1
-  sQueriesMetricsNames.resize(numInputTypes * 1);
-  mMetrics.send({(int)numInputTypes, "data_queries/h"});
-  mMetrics.send({(int)1, "data_queries/w"});
-  for (size_t i = 0; i < numInputTypes; ++i) {
-    sQueriesMetricsNames[i] = std::string("data_queries/") + std::to_string(i);
-    char buffer[128];
-    auto& matcher = mInputRoutes[mDistinctRoutesIndex[i]].matcher;
-    DataSpecUtils::describe(buffer, 127, matcher);
-    mMetrics.send({std::string{buffer}, sQueriesMetricsNames[i]});
+
+  for (size_t ci = 0; ci < mCache.size(); ci++) {
+    assert(ci < sMetricsNames.size());
+    mMetrics.send({0, sMetricsNames[ci]});
+  }
+  for (size_t ci = 0; ci < mVariableContextes.size() * 16; ci++) {
+    assert(ci < sVariablesMetricsNames.size());
+    mMetrics.send({std::string("null"), sVariablesMetricsNames[ci]});
   }
 }
 

--- a/Framework/Core/src/DataRelayerHelpers.cxx
+++ b/Framework/Core/src/DataRelayerHelpers.cxx
@@ -1,0 +1,71 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "DataRelayerHelpers.h"
+#include "Framework/DataDescriptorMatcher.h"
+#include <stdexcept>
+
+using namespace o2::framework::data_matcher;
+
+namespace o2::framework
+{
+
+namespace
+{
+DataDescriptorMatcher fromConcreteMatcher(ConcreteDataMatcher const& matcher)
+{
+  return DataDescriptorMatcher{
+    DataDescriptorMatcher::Op::And,
+    StartTimeValueMatcher{ContextRef{0}},
+    std::make_unique<DataDescriptorMatcher>(
+      DataDescriptorMatcher::Op::And,
+      OriginValueMatcher{matcher.origin.as<std::string>()},
+      std::make_unique<DataDescriptorMatcher>(
+        DataDescriptorMatcher::Op::And,
+        DescriptionValueMatcher{matcher.description.as<std::string>()},
+        std::make_unique<DataDescriptorMatcher>(
+          DataDescriptorMatcher::Op::Just,
+          SubSpecificationTypeValueMatcher{matcher.subSpec})))};
+}
+} // namespace
+
+std::vector<size_t>
+  DataRelayerHelpers::createDistinctRouteIndex(std::vector<InputRoute> const& routes)
+{
+  std::vector<size_t> result;
+  for (size_t ri = 0; ri < routes.size(); ++ri) {
+    auto& route = routes[ri];
+    if (route.timeslice == 0) {
+      result.push_back(ri);
+    }
+  }
+  return result;
+}
+
+/// This converts from InputRoute to the associated DataDescriptorMatcher.
+std::vector<DataDescriptorMatcher>
+  DataRelayerHelpers::createInputMatchers(std::vector<InputRoute> const& routes)
+{
+  std::vector<DataDescriptorMatcher> result;
+
+  for (auto& route : routes) {
+    if (auto pval = std::get_if<ConcreteDataMatcher>(&route.matcher.matcher)) {
+      result.emplace_back(fromConcreteMatcher(*pval));
+    } else if (auto matcher = std::get_if<DataDescriptorMatcher>(&route.matcher.matcher)) {
+      result.push_back(*matcher);
+    } else {
+      throw std::runtime_error("Unsupported InputSpec type");
+    }
+  }
+
+  return result;
+}
+
+} // namespace o2::framework

--- a/Framework/Core/src/DataRelayerHelpers.h
+++ b/Framework/Core/src/DataRelayerHelpers.h
@@ -1,0 +1,29 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef O2_FRAMEWORK_DATARELAYERHELPERS_H_
+#define O2_FRAMEWORK_DATARELAYERHELPERS_H_
+
+#include "Framework/InputRoute.h"
+#include <vector>
+
+namespace o2::framework
+{
+
+struct DataRelayerHelpers {
+  /// Calculate how many input routes there are, doublecounting different
+  /// timeslices.
+  static std::vector<size_t> createDistinctRouteIndex(std::vector<InputRoute> const&);
+  /// This converts from InputRoute to the associated DataDescriptorMatcher.
+  static std::vector<data_matcher::DataDescriptorMatcher> createInputMatchers(std::vector<InputRoute> const&);
+};
+
+} // namespace o2::framework
+
+#endif // O2_FRAMEWORK_DATARELAYERHELPERS_H_

--- a/Framework/Core/test/benchmark_DataRelayer.cxx
+++ b/Framework/Core/test/benchmark_DataRelayer.cxx
@@ -14,6 +14,7 @@
 #include "Framework/CompletionPolicyHelpers.h"
 #include "Framework/DataRelayer.h"
 #include "Framework/DataProcessingHeader.h"
+#include "../src/DataRelayerHelpers.h"
 #include <Monitoring/Monitoring.h>
 #include <fairmq/FairMQTransportFactory.h>
 #include <cstring>
@@ -37,7 +38,7 @@ static void BM_RelayMessageCreation(benchmark::State& state)
   TimesliceIndex index;
 
   auto policy = CompletionPolicyHelpers::consumeWhenAny();
-  DataRelayer relayer(policy, inputs, forwards, metrics, index);
+  DataRelayer relayer(policy, inputs, metrics, index);
   relayer.setPipelineLength(4);
 
   // Let's create a dummy O2 Message with two headers in the stack:
@@ -78,7 +79,7 @@ static void BM_RelaySingleSlot(benchmark::State& state)
   TimesliceIndex index;
 
   auto policy = CompletionPolicyHelpers::consumeWhenAny();
-  DataRelayer relayer(policy, inputs, forwards, metrics, index);
+  DataRelayer relayer(policy, inputs, metrics, index);
   relayer.setPipelineLength(4);
 
   // Let's create a dummy O2 Message with two headers in the stack:
@@ -126,7 +127,7 @@ static void BM_RelayMultipleSlots(benchmark::State& state)
   TimesliceIndex index;
 
   auto policy = CompletionPolicyHelpers::consumeWhenAny();
-  DataRelayer relayer(policy, inputs, forwards, metrics, index);
+  DataRelayer relayer(policy, inputs, metrics, index);
   relayer.setPipelineLength(4);
 
   // Let's create a dummy O2 Message with two headers in the stack:
@@ -178,7 +179,7 @@ static void BM_RelayMultipleRoutes(benchmark::State& state)
   TimesliceIndex index;
 
   auto policy = CompletionPolicyHelpers::consumeWhenAny();
-  DataRelayer relayer(policy, inputs, forwards, metrics, index);
+  DataRelayer relayer(policy, inputs, metrics, index);
   relayer.setPipelineLength(4);
 
   // Let's create a dummy O2 Message with two headers in the stack:

--- a/Framework/Core/test/test_DataRelayer.cxx
+++ b/Framework/Core/test/test_DataRelayer.cxx
@@ -17,6 +17,7 @@
 #include "Headers/Stack.h"
 #include "Framework/CompletionPolicyHelpers.h"
 #include "Framework/DataRelayer.h"
+#include "../src/DataRelayerHelpers.h"
 #include "Framework/DataProcessingHeader.h"
 #include "Framework/WorkflowSpec.h"
 #include <Monitoring/Monitoring.h>
@@ -42,7 +43,7 @@ BOOST_AUTO_TEST_CASE(TestNoWait)
   TimesliceIndex index;
 
   auto policy = CompletionPolicyHelpers::consumeWhenAny();
-  DataRelayer relayer(policy, inputs, forwards, metrics, index);
+  DataRelayer relayer(policy, inputs, metrics, index);
   relayer.setPipelineLength(4);
 
   // Let's create a dummy O2 Message with two headers in the stack:
@@ -81,7 +82,7 @@ BOOST_AUTO_TEST_CASE(TestNoWaitMatcher)
   TimesliceIndex index;
 
   auto policy = CompletionPolicyHelpers::consumeWhenAny();
-  DataRelayer relayer(policy, inputs, forwards, metrics, index);
+  DataRelayer relayer(policy, inputs, metrics, index);
   relayer.setPipelineLength(4);
 
   // Let's create a dummy O2 Message with two headers in the stack:
@@ -132,7 +133,7 @@ BOOST_AUTO_TEST_CASE(TestRelay)
   TimesliceIndex index;
 
   auto policy = CompletionPolicyHelpers::consumeWhenAll();
-  DataRelayer relayer(policy, inputs, forwards, metrics, index);
+  DataRelayer relayer(policy, inputs, metrics, index);
   relayer.setPipelineLength(4);
 
   auto transport = FairMQTransportFactory::CreateTransportFactory("zeromq");
@@ -199,7 +200,7 @@ BOOST_AUTO_TEST_CASE(TestRelayBug)
   TimesliceIndex index;
 
   auto policy = CompletionPolicyHelpers::consumeWhenAll();
-  DataRelayer relayer(policy, inputs, forwards, metrics, index);
+  DataRelayer relayer(policy, inputs, metrics, index);
   relayer.setPipelineLength(3);
 
   auto transport = FairMQTransportFactory::CreateTransportFactory("zeromq");
@@ -266,7 +267,7 @@ BOOST_AUTO_TEST_CASE(TestCache)
 
   auto policy = CompletionPolicyHelpers::consumeWhenAll();
   TimesliceIndex index;
-  DataRelayer relayer(policy, inputs, forwards, metrics, index);
+  DataRelayer relayer(policy, inputs, metrics, index);
   // Only two messages to fill the cache.
   relayer.setPipelineLength(2);
 
@@ -333,7 +334,7 @@ BOOST_AUTO_TEST_CASE(TestPolicies)
   TimesliceIndex index;
 
   auto policy = CompletionPolicyHelpers::processWhenAny();
-  DataRelayer relayer(policy, inputs, forwards, metrics, index);
+  DataRelayer relayer(policy, inputs, metrics, index);
   // Only two messages to fill the cache.
   relayer.setPipelineLength(2);
 


### PR DESCRIPTION
Before this processDanglingInputs does NxM complex pass on the
inputs and the expirators, checking if there is anything to be
expired and eventually expiring it.

This changes things so that we do Nxm complex pass, where m is
the actual inputs that can expire, i.e. we do not do the pass
for all the inputs which do not have an expiration policy attach.
Since not having an expiration policy is the norm, this should
minimize the impact of processDanglingInputs for normal usage.