### PR TITLE
Commandline option to limit number of events given by the Converter

### DIFF
--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -204,6 +204,7 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow)
     {},
     readers::AODReaderHelpers::run2ESDConverterCallback(),
     {ConfigParamSpec{"esd-file", VariantType::String, "AliESDs.root", {"Input ESD file"}},
+     ConfigParamSpec{"events", VariantType::Int, 0, {"Number of events to process (0 = all)"}},
      ConfigParamSpec{"start-value-enumeration", VariantType::Int, 0, {"initial value for the enumeration"}},
      ConfigParamSpec{"end-value-enumeration", VariantType::Int, -1, {"final value for the enumeration"}},
      ConfigParamSpec{"step-value-enumeration", VariantType::Int, 1, {"step between one value and the other"}}}};


### PR DESCRIPTION
- Use "--event=100000 --esd-file=AliESDs.root"
- Needs Converter patch: https://github.com/AliceO2Group/Run2ESDConverter/pull/16