### PR TITLE
Make FMQ transport tests use unique id for sessions

### DIFF
--- a/DataFormats/MemoryResources/test/testMemoryResources.cxx
+++ b/DataFormats/MemoryResources/test/testMemoryResources.cxx
@@ -14,16 +14,13 @@
 #include <boost/test/unit_test.hpp>
 #include "MemoryResources/MemoryResources.h"
 #include "FairMQTransportFactory.h"
+#include <fairmq/Tools.h>
+#include <fairmq/ProgOptions.h>
 #include <vector>
 #include <cstring>
 
-namespace o2
+namespace o2::pmr
 {
-namespace pmr
-{
-auto factoryZMQ = FairMQTransportFactory::CreateTransportFactory("zeromq");
-auto factorySHM = FairMQTransportFactory::CreateTransportFactory("shmem");
-
 struct testData {
   int i{1};
   static int nconstructions;
@@ -47,11 +44,15 @@ struct testData {
 
 int testData::nconstructions = 0;
 
-auto allocZMQ = getTransportAllocator(factoryZMQ.get());
-auto allocSHM = getTransportAllocator(factorySHM.get());
-
 BOOST_AUTO_TEST_CASE(transportallocatormap_test)
 {
+  size_t session{fair::mq::tools::UuidHash()};
+  fair::mq::ProgOptions config;
+  config.SetProperty<std::string>("session", std::to_string(session));
+  auto factoryZMQ = FairMQTransportFactory::CreateTransportFactory("zeromq");
+  auto factorySHM = FairMQTransportFactory::CreateTransportFactory("shmem");
+  auto allocZMQ = getTransportAllocator(factoryZMQ.get());
+  auto allocSHM = getTransportAllocator(factorySHM.get());
   BOOST_CHECK(allocZMQ != nullptr && allocSHM != allocZMQ);
   auto _tmp = getTransportAllocator(factoryZMQ.get());
   BOOST_CHECK(_tmp == allocZMQ);
@@ -61,6 +62,14 @@ using namespace boost::container::pmr;
 
 BOOST_AUTO_TEST_CASE(allocator_test)
 {
+  size_t session{fair::mq::tools::UuidHash()};
+  fair::mq::ProgOptions config;
+  config.SetProperty<std::string>("session", std::to_string(session));
+  auto factoryZMQ = FairMQTransportFactory::CreateTransportFactory("zeromq");
+  auto factorySHM = FairMQTransportFactory::CreateTransportFactory("shmem");
+  auto allocZMQ = getTransportAllocator(factoryZMQ.get());
+  auto allocSHM = getTransportAllocator(factorySHM.get());
+
   testData::nconstructions = 0;
 
   {
@@ -90,6 +99,14 @@ BOOST_AUTO_TEST_CASE(allocator_test)
 
 BOOST_AUTO_TEST_CASE(getMessage_test)
 {
+  size_t session{fair::mq::tools::UuidHash()};
+  fair::mq::ProgOptions config;
+  config.SetProperty<std::string>("session", std::to_string(session));
+  auto factoryZMQ = FairMQTransportFactory::CreateTransportFactory("zeromq");
+  auto factorySHM = FairMQTransportFactory::CreateTransportFactory("shmem");
+  auto allocZMQ = getTransportAllocator(factoryZMQ.get());
+  auto allocSHM = getTransportAllocator(factorySHM.get());
+
   testData::nconstructions = 0;
 
   FairMQMessagePtr message{nullptr};
@@ -133,6 +150,14 @@ BOOST_AUTO_TEST_CASE(getMessage_test)
 
 BOOST_AUTO_TEST_CASE(adoptVector_test)
 {
+  size_t session{fair::mq::tools::UuidHash()};
+  fair::mq::ProgOptions config;
+  config.SetProperty<std::string>("session", std::to_string(session));
+  auto factoryZMQ = FairMQTransportFactory::CreateTransportFactory("zeromq");
+  auto factorySHM = FairMQTransportFactory::CreateTransportFactory("shmem");
+  auto allocZMQ = getTransportAllocator(factoryZMQ.get());
+  auto allocSHM = getTransportAllocator(factorySHM.get());
+
   testData::nconstructions = 0;
 
   //Create a bogus message
@@ -159,5 +184,4 @@ BOOST_AUTO_TEST_CASE(adoptVector_test)
   BOOST_CHECK(modifiedMessage != nullptr);
   BOOST_CHECK(modifiedMessage.get() != messageAddr);
 }
-}; // namespace pmr
-}; // namespace o2
+}; // namespace o2::pmr

--- a/DataFormats/MemoryResources/test/testMemoryResources.cxx
+++ b/DataFormats/MemoryResources/test/testMemoryResources.cxx
@@ -49,6 +49,7 @@ BOOST_AUTO_TEST_CASE(transportallocatormap_test)
   size_t session{fair::mq::tools::UuidHash()};
   fair::mq::ProgOptions config;
   config.SetProperty<std::string>("session", std::to_string(session));
+
   auto factoryZMQ = FairMQTransportFactory::CreateTransportFactory("zeromq");
   auto factorySHM = FairMQTransportFactory::CreateTransportFactory("shmem");
   auto allocZMQ = getTransportAllocator(factoryZMQ.get());
@@ -65,6 +66,7 @@ BOOST_AUTO_TEST_CASE(allocator_test)
   size_t session{fair::mq::tools::UuidHash()};
   fair::mq::ProgOptions config;
   config.SetProperty<std::string>("session", std::to_string(session));
+
   auto factoryZMQ = FairMQTransportFactory::CreateTransportFactory("zeromq");
   auto factorySHM = FairMQTransportFactory::CreateTransportFactory("shmem");
   auto allocZMQ = getTransportAllocator(factoryZMQ.get());
@@ -102,6 +104,7 @@ BOOST_AUTO_TEST_CASE(getMessage_test)
   size_t session{fair::mq::tools::UuidHash()};
   fair::mq::ProgOptions config;
   config.SetProperty<std::string>("session", std::to_string(session));
+
   auto factoryZMQ = FairMQTransportFactory::CreateTransportFactory("zeromq");
   auto factorySHM = FairMQTransportFactory::CreateTransportFactory("shmem");
   auto allocZMQ = getTransportAllocator(factoryZMQ.get());
@@ -153,6 +156,7 @@ BOOST_AUTO_TEST_CASE(adoptVector_test)
   size_t session{fair::mq::tools::UuidHash()};
   fair::mq::ProgOptions config;
   config.SetProperty<std::string>("session", std::to_string(session));
+
   auto factoryZMQ = FairMQTransportFactory::CreateTransportFactory("zeromq");
   auto factorySHM = FairMQTransportFactory::CreateTransportFactory("shmem");
   auto allocZMQ = getTransportAllocator(factoryZMQ.get());

--- a/Utilities/O2Device/test/test_O2Device.cxx
+++ b/Utilities/O2Device/test/test_O2Device.cxx
@@ -76,7 +76,6 @@ BOOST_AUTO_TEST_CASE(addDataBlockForEach_test)
   auto factoryZMQ = FairMQTransportFactory::CreateTransportFactory("zeromq");
   auto factorySHM = FairMQTransportFactory::CreateTransportFactory("shmem");
   auto allocZMQ = getTransportAllocator(factoryZMQ.get());
-  auto allocSHM = getTransportAllocator(factorySHM.get());
 
   {
     //simple addition of a data block from an exisiting message

--- a/Utilities/O2Device/test/test_O2Device.cxx
+++ b/Utilities/O2Device/test/test_O2Device.cxx
@@ -17,18 +17,22 @@
 #include <boost/test/unit_test.hpp>
 #include <iostream>
 #include <vector>
+#include <fairmq/Tools.h>
+#include <fairmq/ProgOptions.h>
 
 using namespace o2::base;
 using namespace o2::header;
 using namespace o2::pmr;
 
-auto factoryZMQ = FairMQTransportFactory::CreateTransportFactory("zeromq");
-auto factorySHM = FairMQTransportFactory::CreateTransportFactory("shmem");
-auto allocZMQ = getTransportAllocator(factoryZMQ.get());
-auto allocSHM = getTransportAllocator(factorySHM.get());
-
 BOOST_AUTO_TEST_CASE(getMessage_Stack)
 {
+  size_t session{fair::mq::tools::UuidHash()};
+  fair::mq::ProgOptions config;
+  config.SetProperty<std::string>("session", std::to_string(session));
+  auto factoryZMQ = FairMQTransportFactory::CreateTransportFactory("zeromq");
+  auto factorySHM = FairMQTransportFactory::CreateTransportFactory("shmem");
+  auto allocZMQ = getTransportAllocator(factoryZMQ.get());
+  auto allocSHM = getTransportAllocator(factorySHM.get());
   {
     //check that a message is constructed properly with the default new_delete_resource
     Stack s1{DataHeader{gDataDescriptionInvalid, gDataOriginInvalid, DataHeader::SubSpecificationType{0}},
@@ -66,6 +70,14 @@ BOOST_AUTO_TEST_CASE(getMessage_Stack)
 
 BOOST_AUTO_TEST_CASE(addDataBlockForEach_test)
 {
+  size_t session{fair::mq::tools::UuidHash()};
+  fair::mq::ProgOptions config;
+  config.SetProperty<std::string>("session", std::to_string(session));
+  auto factoryZMQ = FairMQTransportFactory::CreateTransportFactory("zeromq");
+  auto factorySHM = FairMQTransportFactory::CreateTransportFactory("shmem");
+  auto allocZMQ = getTransportAllocator(factoryZMQ.get());
+  auto allocSHM = getTransportAllocator(factorySHM.get());
+
   {
     //simple addition of a data block from an exisiting message
     O2Message message;

--- a/Utilities/O2Device/test/test_O2Device.cxx
+++ b/Utilities/O2Device/test/test_O2Device.cxx
@@ -29,6 +29,7 @@ BOOST_AUTO_TEST_CASE(getMessage_Stack)
   size_t session{fair::mq::tools::UuidHash()};
   fair::mq::ProgOptions config;
   config.SetProperty<std::string>("session", std::to_string(session));
+
   auto factoryZMQ = FairMQTransportFactory::CreateTransportFactory("zeromq");
   auto factorySHM = FairMQTransportFactory::CreateTransportFactory("shmem");
   auto allocZMQ = getTransportAllocator(factoryZMQ.get());
@@ -73,6 +74,7 @@ BOOST_AUTO_TEST_CASE(addDataBlockForEach_test)
   size_t session{fair::mq::tools::UuidHash()};
   fair::mq::ProgOptions config;
   config.SetProperty<std::string>("session", std::to_string(session));
+
   auto factoryZMQ = FairMQTransportFactory::CreateTransportFactory("zeromq");
   auto allocZMQ = getTransportAllocator(factoryZMQ.get());
 

--- a/Utilities/O2Device/test/test_O2Device.cxx
+++ b/Utilities/O2Device/test/test_O2Device.cxx
@@ -74,7 +74,6 @@ BOOST_AUTO_TEST_CASE(addDataBlockForEach_test)
   fair::mq::ProgOptions config;
   config.SetProperty<std::string>("session", std::to_string(session));
   auto factoryZMQ = FairMQTransportFactory::CreateTransportFactory("zeromq");
-  auto factorySHM = FairMQTransportFactory::CreateTransportFactory("shmem");
   auto allocZMQ = getTransportAllocator(factoryZMQ.get());
 
   {


### PR DESCRIPTION
A part of investigation of recent test failures in O2Device and MemoryResources, now each test unit has a unique session id and uses their own transport factories and allocators.