### PR TITLE
DPL: avoid clashes between expressions and fmt

### DIFF
--- a/Framework/Core/include/Framework/Expressions.h
+++ b/Framework/Core/include/Framework/Expressions.h
@@ -57,11 +57,6 @@ struct Node;
 
 struct Node {
   template <typename T>
-  Node(T v) : self{LiteralNode<T>(v)}, left{nullptr}, right{nullptr}
-  {
-  }
-
-  template <typename T>
   Node(LiteralNode<T> v) : self{v}, left{nullptr}, right{nullptr}
   {
   }


### PR DESCRIPTION
The extra constructor would have allowed to build `Node`s from way too many other types.