### PR TITLE
Allow for simultaneous o2sim runs

### DIFF
--- a/run/o2sim_parallel.cxx
+++ b/run/o2sim_parallel.cxx
@@ -29,6 +29,12 @@
 #include "Framework/FreePortFinder.h"
 #include <sys/types.h>
 
+#include "rapidjson/document.h"
+#include "rapidjson/writer.h"
+#include "rapidjson/stringbuffer.h"
+#include "rapidjson/filereadstream.h"
+#include "rapidjson/filewritestream.h"
+
 static const char* serverlogname = "serverlog";
 static const char* workerlogname = "workerlog";
 static const char* mergerlogname = "mergerlog";
@@ -97,42 +103,6 @@ void sighandler(int signal)
   }
 }
 
-// updates/sets up the ports to be used in this simulation run
-// this should enable parallel instances of o2sim ... to be generalized
-// with DDS for example
-bool updatePorts(std::string configfilename)
-{
-  // original ports
-  const int SERVERPORT = 25005;
-  const int MERGERPORT = 25009;
-
-  auto pid = getpid();
-
-  int portstart = SERVERPORT + pid % 64; // somewhat randomize the port start
-  int portend = 50000;
-  int step = 2; // we need 2 ports
-  o2::framework::FreePortFinder finder(portstart, portend, step);
-  finder.setVerbose(false); // disable verbose output
-  finder.scan();
-  auto newserverport = finder.port();
-  auto newmergerport = newserverport + 1;
-
-  LOG(INFO) << "SERVER PORT " << newserverport;
-  LOG(INFO) << "MERGER PORT " << newmergerport;
-  // publish these numbers for other processes
-  setenv("ALICE_O2SIM_SERVERPORT", std::to_string(newserverport).c_str(), 1);
-  setenv("ALICE_O2SIM_MERGERPORT", std::to_string(newmergerport).c_str(), 1);
-
-  // fix ports in the configuration file template (there are for sure nicer ways of doing that
-  std::stringstream sedcmd;
-  sedcmd << "sed -i'.original' "
-         << "-e 's/:" << SERVERPORT << "/:" << newserverport << "/' "
-         << "-e 's/:" << MERGERPORT << "/:" << newmergerport << "/' "
-         << configfilename;
-  auto r = system(sedcmd.str().c_str());
-  return true;
-}
-
 // monitores a certain incoming pipe and displays new information
 void launchThreadMonitoringEvents(int pipefd, std::string text)
 {
@@ -181,12 +151,87 @@ int main(int argc, char* argv[])
   std::stringstream configss;
   configss << rootpath << "/share/config/o2simtopology.json";
   std::string localconfig = std::string("o2simtopology_") + std::to_string(getpid()) + std::string(".json");
-  std::stringstream cpcmd;
-  cpcmd << "cp " << configss.str() << " " << localconfig;
-  if (system(cpcmd.str().c_str()) != 0) {
-    LOG(WARN) << "error executing system call";
+
+  // need to add pid to channel urls to allow simultaneous deploys!
+  // open otiginal config and read the JSON config
+  FILE* fp = fopen(configss.str().c_str(), "r");
+  constexpr unsigned short usmax = std::numeric_limits<unsigned short>::max() - 1;
+  char Buffer[usmax];
+  rapidjson::FileReadStream is(fp, Buffer, sizeof(Buffer));
+  rapidjson::Document d;
+  d.ParseStream(is);
+  fclose(fp);
+  // find and manipulate URLS
+  std::string serveraddress;
+  std::string mergeraddress;
+  std::string s;
+
+  auto& options = d["fairMQOptions"];
+  assert(options.IsObject());
+  for (auto option = options.MemberBegin(); option != options.MemberEnd();
+       ++option) {
+    s = option->name.GetString();
+    if (s == "devices") {
+      assert(option->value.IsArray());
+      auto devices = option->value.GetArray();
+      for (auto& device : devices) {
+        s = device["id"].GetString();
+        if (s == "primary-server") {
+          auto channels = device["channels"].GetArray();
+          auto sockets = (channels[0])["sockets"].GetArray();
+          auto& addressv = (sockets[0])["address"];
+          auto address = addressv.GetString();
+          serveraddress = address + std::to_string(getpid());
+          addressv.SetString(serveraddress.c_str(), d.GetAllocator());
+        }
+        if (s == "hitmerger") {
+          auto channels = device["channels"].GetArray();
+          for (auto& channel : channels) {
+            s = channel["name"].GetString();
+            // set server's address for merger
+            if (s == "primary-get") {
+              auto sockets = channel["sockets"].GetArray();
+              auto& addressv = (sockets[0])["address"];
+              addressv.SetString(serveraddress.c_str(), d.GetAllocator());
+            }
+            if (s == "simdata") {
+              auto sockets = channel["sockets"].GetArray();
+              auto& addressv = (sockets[0])["address"];
+              auto address = addressv.GetString();
+              mergeraddress = address + std::to_string(getpid());
+              addressv.SetString(mergeraddress.c_str(), d.GetAllocator());
+            }
+          }
+        }
+      }
+      //loop over devices again and set URLs for the workers
+      for (auto& device : devices) {
+        s = device["id"].GetString();
+        if (s == "worker") {
+          auto channels = device["channels"].GetArray();
+          for (auto& channel : channels) {
+            s = channel["name"].GetString();
+            if (s == "primary-get") {
+              auto sockets = channel["sockets"].GetArray();
+              auto& addressv = (sockets[0])["address"];
+              addressv.SetString(serveraddress.c_str(), d.GetAllocator());
+            }
+            if (s == "simdata") {
+              auto sockets = channel["sockets"].GetArray();
+              auto& addressv = (sockets[0])["address"];
+              addressv.SetString(mergeraddress.c_str(), d.GetAllocator());
+            }
+          }
+        }
+      }
+    }
   }
-  //  updatePorts(localconfig.c_str());
+  // write the config copy with new name
+  fp = fopen(localconfig.c_str(), "w");
+  rapidjson::FileWriteStream os(fp, Buffer, sizeof(Buffer));
+  rapidjson::Writer<rapidjson::FileWriteStream> writer(os);
+  d.Accept(writer);
+  fclose(fp);
 
   auto& conf = o2::conf::SimConfig::Instance();
   if (!conf.resetFromArguments(argc, argv)) {


### PR DESCRIPTION
* Instead of copying config JSON, modifies it adding pid to URLs, and saves a copy.
  This allows multiple 'o2sim's on one node without clashing
* Should fix the CI tests...

@sawenzel since you've merged #2526 a bit too early, here is the part that I missed. 