### PR TITLE
[EMCAL-626] Separating digits from different Triggers

### DIFF
--- a/DataFormats/Detectors/EMCAL/CMakeLists.txt
+++ b/DataFormats/Detectors/EMCAL/CMakeLists.txt
@@ -10,6 +10,7 @@
 
 o2_add_library(DataFormatsEMCAL
                SOURCES src/EMCALBlockHeader.cxx 
+                       src/TriggerRecord.cxx
                        src/Constants.cxx
                        src/Cluster.cxx
                        src/Cell.cxx 
@@ -23,6 +24,7 @@ o2_add_library(DataFormatsEMCAL
 
 o2_target_root_dictionary(DataFormatsEMCAL
                           HEADERS include/DataFormatsEMCAL/EMCALBlockHeader.h
+                                  include/DataFormatsEMCAL/TriggerRecord.h
                                   include/DataFormatsEMCAL/Constants.h
                                   include/DataFormatsEMCAL/Cell.h
                                   include/DataFormatsEMCAL/Digit.h

--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/TriggerRecord.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/TriggerRecord.h
@@ -1,0 +1,63 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_EMCAL_TRIGGERRECORD_H
+#define ALICEO2_EMCAL_TRIGGERRECORD_H
+
+#include <iosfwd>
+#include "Rtypes.h"
+#include "CommonDataFormat/InteractionRecord.h"
+#include "CommonDataFormat/RangeReference.h"
+
+namespace o2
+{
+
+namespace emcal
+{
+
+/// \class TriggerRecord
+/// \brief Header for data corresponding to the same hardware trigger
+/// adapted from DataFormatsITSMFT/ROFRecord
+class TriggerRecord
+{
+  using BCData = o2::InteractionRecord;
+  using DataRange = o2::dataformats::RangeReference<int>;
+
+ public:
+  TriggerRecord() = default;
+  TriggerRecord(const BCData& bunchcrossing, int firstentry, int nentries) : mBCData(bunchcrossing), mDataRange(firstentry, nentries) {}
+  ~TriggerRecord() = default;
+
+  void setBCData(const BCData& data) { mBCData = data; }
+  void setDataRange(int firstentry, int nentries) { mDataRange.set(firstentry, nentries); }
+  void setIndexFirstObject(int firstentry) { mDataRange.setFirstEntry(firstentry); }
+  void setNumberOfObjects(int nentries) { mDataRange.setEntries(nentries); }
+
+  const BCData& getBCData() const { return mBCData; }
+  BCData& getBCData() { return mBCData; }
+  int getNumberOfObjects() const { return mDataRange.getEntries(); }
+  int getFirstEntry() const { return mDataRange.getFirstEntry(); }
+
+  void printStream(std::ostream& stream) const;
+
+ private:
+  BCData mBCData;       /// Bunch crossing data of the trigger
+  DataRange mDataRange; /// Index of the triggering event (event index and first entry in the container)
+
+  ClassDefNV(TriggerRecord, 1);
+};
+
+std::ostream& operator<<(std::ostream& stream, const TriggerRecord& trg);
+
+} // namespace emcal
+
+} // namespace o2
+
+#endif

--- a/DataFormats/Detectors/EMCAL/src/DataFormatsEMCALLinkDef.h
+++ b/DataFormats/Detectors/EMCAL/src/DataFormatsEMCALLinkDef.h
@@ -14,10 +14,12 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
+#pragma link C++ class o2::emcal::TriggerRecord + ;
 #pragma link C++ class o2::emcal::Cell + ;
 #pragma link C++ class o2::emcal::Digit + ;
 #pragma link C++ class o2::emcal::Cluster + ;
 
+#pragma link C++ class std::vector < o2::emcal::TriggerRecord > +;
 #pragma link C++ class std::vector < o2::emcal::Cell > +;
 #pragma link C++ class std::vector < o2::emcal::Digit > +;
 #pragma link C++ class std::vector < o2::emcal::Cluster > +;

--- a/DataFormats/Detectors/EMCAL/src/TriggerRecord.cxx
+++ b/DataFormats/Detectors/EMCAL/src/TriggerRecord.cxx
@@ -1,0 +1,31 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <iostream>
+#include "DataFormatsEMCAL/TriggerRecord.h"
+
+namespace o2
+{
+
+namespace emcal
+{
+
+void TriggerRecord::printStream(std::ostream& stream) const
+{
+  stream << "Data for bc " << getBCData().bc << ", orbit " << getBCData().orbit << ", starting from entry " << getFirstEntry() << " with " << getNumberOfObjects() << " objects";
+}
+
+std::ostream& operator<<(std::ostream& stream, const TriggerRecord& trg)
+{
+  trg.printStream(stream);
+  return stream;
+}
+} // namespace emcal
+} // namespace o2

--- a/Steer/DigitizerWorkflow/src/EMCALDigitWriterSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/EMCALDigitWriterSpec.cxx
@@ -45,6 +45,7 @@ void DigitsWriterSpec::init(framework::InitContext& ctx)
   mOutputFile = std::make_shared<TFile>(filename.c_str(), "RECREATE");
   mOutputTree = std::make_shared<TTree>(treename.c_str(), treename.c_str());
   mDigits = std::make_shared<std::vector<o2::emcal::Digit>>();
+  mTriggerRecords = std::make_shared<std::vector<o2::emcal::TriggerRecord>>();
   mFinished = false;
 
   // the callback to be set as hook at stop of processing for the framework
@@ -67,10 +68,20 @@ void DigitsWriterSpec::run(framework::ProcessingContext& ctx)
   auto indata = ctx.inputs().get<std::vector<o2::emcal::Digit>>("emcaldigits");
   LOG(INFO) << "RECEIVED DIGITS SIZE " << indata.size();
   *mDigits.get() = std::move(indata);
+  auto trgrecords = ctx.inputs().get<std::vector<o2::emcal::TriggerRecord>>("trgrecorddigits");
+  LOG(INFO) << "GOT " << trgrecords.size() << " TRIGGER RECORDS" << std::endl;
+  *mTriggerRecords.get() = std::move(trgrecords);
+  std::cout << "Before tree writing" << std::endl;
 
   // connect this to a particular branch
   auto br = getOrMakeBranch(*mOutputTree.get(), "EMCALDigit", mDigits.get());
   br->Fill();
+
+  // connect trigger records branch
+  std::cout << "Before trigger record writing" << std::endl;
+  auto trgbranch = getOrMakeBranch(*mOutputTree.get(), "EMCALDigitTRGR", mTriggerRecords.get());
+  trgbranch->Fill();
+  std::cout << "After trigger digit tree writing" << std::endl;
 
   // retrieve labels from the input
   auto labeldata = ctx.inputs().get<o2::dataformats::MCTruthContainer<o2::MCCompLabel>*>("emcaldigitlabels");
@@ -91,6 +102,7 @@ DataProcessorSpec getEMCALDigitWriterSpec()
   return DataProcessorSpec{
     "EMCALDigitWriter",
     Inputs{InputSpec{"emcaldigits", "EMC", "DIGITS", 0, Lifetime::Timeframe},
+           InputSpec{"trgrecorddigits", "EMC", "TRGRDIG", 0, Lifetime::Timeframe},
            InputSpec{"emcaldigitlabels", "EMC", "DIGITSMCTR", 0, Lifetime::Timeframe}},
     {}, // no output
     AlgorithmSpec(framework::adaptFromTask<DigitsWriterSpec>()),

--- a/Steer/DigitizerWorkflow/src/EMCALDigitWriterSpec.h
+++ b/Steer/DigitizerWorkflow/src/EMCALDigitWriterSpec.h
@@ -19,6 +19,7 @@
 #include <TTree.h>
 
 #include "DataFormatsEMCAL/Digit.h"
+#include "DataFormatsEMCAL/TriggerRecord.h"
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
 
@@ -50,10 +51,11 @@ class DigitsWriterSpec : public framework::Task
   void run(framework::ProcessingContext& ctx) final;
 
  private:
-  bool mFinished = false;                                 ///< flag indicating whether work is completed
-  std::shared_ptr<TFile> mOutputFile;                     ///< Common output file
-  std::shared_ptr<TTree> mOutputTree;                     ///< Common output tree
-  std::shared_ptr<std::vector<o2::emcal::Digit>> mDigits; ///< Container for incoming digits (Sink responsible for deleting the digits)
+  bool mFinished = false;                                                 ///< flag indicating whether work is completed
+  std::shared_ptr<TFile> mOutputFile;                                     ///< Common output file
+  std::shared_ptr<TTree> mOutputTree;                                     ///< Common output tree
+  std::shared_ptr<std::vector<o2::emcal::Digit>> mDigits;                 ///< Container for incoming digits (Sink responsible for deleting the digits)
+  std::shared_ptr<std::vector<o2::emcal::TriggerRecord>> mTriggerRecords; ///< Container for incoming trigger records
 };
 
 /// \brief Create new digits writer spec

--- a/Steer/DigitizerWorkflow/src/EMCALDigitizerSpec.h
+++ b/Steer/DigitizerWorkflow/src/EMCALDigitizerSpec.h
@@ -73,7 +73,7 @@ class DigitizerSpec : public framework::Task
   std::vector<TChain*> mSimChains;
   std::vector<Hit> mHits;                ///< Vector with input hits
   std::vector<Digit> mDigits;            ///< Vector with non-accumulated digits (per collision)
-  std::vector<Digit> mAccumulatedDigits; /// Vector with accumulated digits (time frame)
+  std::vector<Digit> mAccumulatedDigits; ///< Vector with accumulated digits (time frame)
   dataformats::MCTruthContainer<o2::MCCompLabel> mLabels;
 };
 


### PR DESCRIPTION
- Adding class o2::emcal::TriggerRecord (adapted
  from o2::itsmft::ROFRecord in order to separate
  digits from various triggers in the output container
- Include Channels for the trigger record in the
  digitizer spec and the digits writer spec