### PR TITLE
[EMCAL-534] Fix handling of overflow words

### DIFF
--- a/Detectors/EMCAL/reconstruction/src/AltroDecoder.cxx
+++ b/Detectors/EMCAL/reconstruction/src/AltroDecoder.cxx
@@ -83,7 +83,7 @@ void AltroDecoder::readChannels()
 
     // decode bunches
     int currentsample = 0;
-    while (currentsample < numberofsamples) {
+    while (currentsample < currentchannel.getPayloadSize()) {
       int bunchlength = bunchwords[currentsample] - 2, // remove words for bunchlength and starttime
         starttime = bunchwords[currentsample + 1];
       auto& currentbunch = currentchannel.createBunch(bunchlength, starttime);


### PR DESCRIPTION
EMCAL channel data are stored as 10-bit words
within a 32 bit word, meaning each raw data
word has 3 ADC words. In case the payload size
doesn't match exactly the amount of raw data
words (division by three), overflow words
are part of the raw data words and must be
ignored. The number of samples must therefore
be taken from the payload size in the channel
header and not from counting the amount
of 10-bit words within the 32-bit raw data
words.