### PR TITLE
[EMCAL-501] modified timing in Digitizer

### DIFF
--- a/DataFormats/Detectors/EMCAL/CMakeLists.txt
+++ b/DataFormats/Detectors/EMCAL/CMakeLists.txt
@@ -28,7 +28,8 @@ o2_target_root_dictionary(DataFormatsEMCAL
                                   include/DataFormatsEMCAL/Constants.h
                                   include/DataFormatsEMCAL/Cell.h
                                   include/DataFormatsEMCAL/Digit.h
-                                  include/DataFormatsEMCAL/Cluster.h)
+                                  include/DataFormatsEMCAL/Cluster.h
+                                  include/DataFormatsEMCAL/MCLabel.h)
 
 o2_add_test(Cell
             SOURCES test/testCell.cxx

--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/MCLabel.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/MCLabel.h
@@ -30,6 +30,8 @@ class MCLabel : public o2::MCCompLabel
   MCLabel(Bool_t noise, Double_t efraction) : o2::MCCompLabel(noise), mEnergyFraction(efraction) {}
   void setEnergyFraction(Double_t efraction) { mEnergyFraction = efraction; }
   Double_t getEnergyFraction() const { return mEnergyFraction; }
+
+  ClassDefNV(MCLabel, 1);
 };
 } // namespace emcal
 } //namespace o2

--- a/DataFormats/Detectors/EMCAL/src/DataFormatsEMCALLinkDef.h
+++ b/DataFormats/Detectors/EMCAL/src/DataFormatsEMCALLinkDef.h
@@ -19,11 +19,15 @@
 #pragma link C++ class o2::emcal::Cell + ;
 #pragma link C++ class o2::emcal::Digit + ;
 #pragma link C++ class o2::emcal::Cluster + ;
+#pragma link C++ class o2::emcal::MCLabel + ;
 
 #pragma link C++ class std::vector < o2::emcal::TriggerRecord > +;
 #pragma link C++ class std::vector < o2::emcal::Cell > +;
 #pragma link C++ class std::vector < o2::emcal::Digit > +;
 #pragma link C++ class std::vector < o2::emcal::Cluster > +;
+
+#include "SimulationDataFormat/MCTruthContainer.h"
+#pragma link C++ class o2::dataformats::MCTruthContainer < o2::emcal::MCLabel > + ;
 
 // For channel type in digits and cells
 #pragma link C++ enum o2::emcal::ChannelType_t + ;

--- a/Detectors/EMCAL/simulation/CMakeLists.txt
+++ b/Detectors/EMCAL/simulation/CMakeLists.txt
@@ -12,16 +12,15 @@ o2_add_library(EMCALSimulation
                SOURCES src/Detector.cxx src/Digitizer.cxx src/DigitizerTask.cxx
                        src/SpaceFrame.cxx src/SimParam.cxx src/LabeledDigit.cxx
 		       src/DMAOutputStream.cxx
-               PUBLIC_LINK_LIBRARIES O2::EMCALBase O2::DetectorsBase O2::SimulationDataFormat)
+               PUBLIC_LINK_LIBRARIES O2::EMCALBase O2::DetectorsBase O2::SimConfig O2::SimulationDataFormat)
 
 o2_target_root_dictionary(EMCALSimulation
                           HEADERS include/EMCALSimulation/Detector.h
                                   include/EMCALSimulation/Digitizer.h
                                   include/EMCALSimulation/DigitizerTask.h
-				  include/EMCALSimulation/DMAOutputStream.h
+                                  include/EMCALSimulation/DMAOutputStream.h
                                   include/EMCALSimulation/SpaceFrame.h
                                   include/EMCALSimulation/SimParam.h
-                                  include/EMCALSimulation/MCLabel.h
                                   include/EMCALSimulation/LabeledDigit.h)
 
 o2_data_file(COPY data DESTINATION Detectors/EMC/simulation)

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/Digitizer.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/Digitizer.h
@@ -27,7 +27,6 @@
 #include "EMCALSimulation/SimParam.h"
 #include "EMCALSimulation/LabeledDigit.h"
 
-#include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
 
 namespace o2
@@ -43,18 +42,25 @@ class Digitizer : public TObject
   Digitizer& operator=(const Digitizer&) = delete;
 
   void init();
+  void initCycle();
+  void clear();
   void finish();
 
   /// Steer conversion of hits to digits
-  void process(const std::vector<Hit>& hits, std::vector<Digit>& digits);
+  void process(const std::vector<Hit>& hits);
 
   void setEventTime(double t);
+  double getTriggerTime() const { return mTriggerTime; }
   double getEventTime() const { return mEventTime; }
+  bool isLive() const { return (mEventTime <= mLiveTime); }
 
   void setContinuous(bool v) { mContinuous = v; }
   bool isContinuous() const { return mContinuous; }
 
-  void fillOutputContainer(std::vector<Digit>& digits);
+  bool isEmpty() const { return mEmpty; }
+  bool readyToFlush(double t) const { return ((t > mLiveTime) && !isEmpty()); }
+
+  void fillOutputContainer(std::vector<Digit>& digits, o2::dataformats::MCTruthContainer<o2::emcal::MCLabel>& labels);
 
   void setSmearEnergy(bool v) { mSmearEnergy = v; }
   bool doSmearEnergy() const { return mSmearEnergy; }
@@ -85,7 +91,9 @@ class Digitizer : public TObject
 
  private:
   const Geometry* mGeometry = nullptr;     ///< EMCAL geometry
+  double mTriggerTime = -1e20;             ///< global trigger time
   double mEventTime = 0;                   ///< global event time
+  short mPhase = 0;                        ///< event phase
   double mCoeffToNanoSecond = 1.0;         ///< coefficient to convert event time (Fair) to ns
   bool mContinuous = false;                ///< flag for continuous simulation
   UInt_t mROFrameMin = 0;                  ///< lowest RO frame of current digits
@@ -97,14 +105,18 @@ class Digitizer : public TObject
   bool mRemoveDigitsBelowThreshold = true; ///< remove digits below threshold
   bool mSimulateNoiseDigits = true;        ///< simulate noise digits
   const SimParam* mSimParam = nullptr;     ///< SimParam object
+  bool mEmpty = true;                      ///< Digitizer contains no digits/labels
 
   std::vector<Digit> mTempDigitVector;                          ///< temporary digit storage
   std::unordered_map<Int_t, std::list<LabeledDigit>> mDigits;   ///< used to sort digits and labels by tower
-  o2::dataformats::MCTruthContainer<MCLabel> mMCTruthContainer; ///< contains MC truth information
 
-  TRandom3* mRandomGenerator = nullptr; // random number generator
-  Int_t mTimeBinOffset = 0;             // offset of first time bin
-  std::vector<double> mSignalFractionInTimeBins; // fraction of signal for each time bin
+  TRandom3* mRandomGenerator = nullptr;                       // random number generator
+  std::vector<int> mTimeBinOffset;                            // offset of first time bin
+  std::vector<std::vector<double>> mSignalFractionInTimeBins; // fraction of signal for each time bin
+
+  float mLiveTime = 1500; // EMCal live time (ns)
+  float mBusyTime = 0;    // EMCal busy time (ns)
+  int mDelay = 0;         // number of (full) time bins corresponding to the signal time delay
 
   ClassDefOverride(Digitizer, 1);
 };

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/LabeledDigit.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/LabeledDigit.h
@@ -17,7 +17,7 @@
 #include "CommonDataFormat/TimeStamp.h"
 #include "DataFormatsEMCAL/Constants.h"
 #include "DataFormatsEMCAL/Digit.h"
-#include "EMCALSimulation/MCLabel.h"
+#include "DataFormatsEMCAL/MCLabel.h"
 
 #include <boost/serialization/base_object.hpp> // for base_object
 

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/SimParam.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/SimParam.h
@@ -11,6 +11,8 @@
 #define ALICEO2_EMCAL_SIMPARAM_H_
 
 #include <iosfwd>
+#include "SimConfig/ConfigurableParam.h"
+#include "SimConfig/ConfigurableParamHelper.h"
 #include "Rtypes.h"
 
 namespace o2
@@ -20,94 +22,70 @@ namespace emcal
 /// \class SimParam
 /// \brief EMCal simulation parameters
 
-class SimParam
+class SimParam : public o2::conf::ConfigurableParamHelper<SimParam>
 {
  public:
-  ~SimParam() = default;
-
-  static SimParam* getInstance()
-  {
-    if (!mSimParam)
-      mSimParam = new SimParam();
-
-    return mSimParam;
-  }
+  ~SimParam() override = default;
 
   // Parameters used in Digitizer
-  void setDigitThreshold(Int_t val) { mDigitThreshold = val; }
   Int_t getDigitThreshold() const { return mDigitThreshold; }
-
-  void setPinNoise(Float_t val) { mPinNoise = val; }
   Float_t getPinNoise() const { return mPinNoise; }
-
-  void setTimeNoise(Float_t val) { mTimeNoise = val; }
   Float_t getTimeNoise() const { return mTimeNoise; }
-
-  void setTimeDelay(Float_t val) { mTimeDelay = val; }
   Float_t getTimeDelay() const { return mTimeDelay; }
-
-  void setTimeDelayFromOCDB(Bool_t val) { mTimeDelayFromCDB = val; }
   Bool_t isTimeDelayFromOCDB() const { return mTimeDelayFromCDB; }
-
-  void setTimeResolutionPar0(Float_t val) { mTimeResolutionPar0 = val; }
   Float_t getTimeResolutionPar0() const { return mTimeResolutionPar0; }
-  void setTimeResolutionPar1(Float_t val) { mTimeResolutionPar1 = val; }
   Float_t getTimeResolutionPar1() const { return mTimeResolutionPar1; }
   Double_t getTimeResolution(Double_t energy) const;
-
-  void setNADCEC(Int_t val) { mNADCEC = val; }
-  Int_t setNADCEC() const { return mNADCEC; }
-
-  void setMeanPhotonElectron(Int_t val) { mMeanPhotonElectron = val; }
+  Int_t getNADCEC() const { return mNADCEC; }
   Int_t getMeanPhotonElectron() const { return mMeanPhotonElectron; }
-
-  void setGainFluctuations(Float_t val) { mGainFluctuations = val; }
   Float_t getGainFluctuations() const { return mGainFluctuations; }
-
-  void setTimeResponseTau(Int_t val) { mTimeResponseTau = val; }
   Int_t getTimeResponseTau() const { return mTimeResponseTau; }
-
-  void setTimeResponsePower(Float_t val) { mTimeResponsePower = val; }
   Float_t getTimeResponsePower() const { return mTimeResponsePower; }
-
-  void setTimeResponseThreshold(Float_t val) { mTimeResponsePower = val; }
   Float_t getTimeResponseThreshold() const { return mTimeResponsePower; }
 
   // Parameters used in SDigitizer
-  void setA(Float_t val) { mA = val; }
   Float_t getA() const { return mA; }
-  void setB(Float_t val) { mB = val; }
   Float_t getB() const { return mB; }
-
-  void setECPrimaryThreshold(Float_t val) { mECPrimThreshold = val; }
   Float_t getECPrimaryThreshold() const { return mECPrimThreshold; }
+
+  Float_t getSignalDelay() const { return mSignalDelay; }
+  Float_t getLiveTime() const { return mLiveTime; }
+  Float_t getBusyTime() const { return mBusyTime; }
+  Bool_t isDisablePileup() const { return mDisablePileup; }
 
   void PrintStream(std::ostream& stream) const;
 
  private:
-  SimParam() = default;
-
-  static o2::emcal::SimParam* mSimParam; // pointer to the unique instance of the class
 
   // Digitizer
-  Int_t mDigitThreshold{3};              // Threshold for storing digits in EMC
-  Int_t mMeanPhotonElectron{4400};       // number of photon electrons per GeV deposited energy
-  Float_t mGainFluctuations{15.};        // correct fMeanPhotonElectron by the gain fluctuations
-  Float_t mPinNoise{0.012};              // Electronics noise in EMC, APD
-  Float_t mTimeNoise{1.28e-5};           // Electronics noise in EMC, time
-  Float_t mTimeDelay{600e-9};            // Simple time delay to mimick roughly delay in data
-  Bool_t mTimeDelayFromCDB{false};       // Get time delay from OCDB
-  Float_t mTimeResolutionPar0{0.26666};  // Time resolution of FEE electronics
-  Float_t mTimeResolutionPar1{1.4586};   // Time resolution of FEE electronics
-  Int_t mNADCEC{0x10000};                // number of channels in EC section ADC
-  Float_t mTimeResponseTau{2.35};        // Raw time response function tau parameter
-  Float_t mTimeResponsePower{2};         // Raw time response function power parameter
-  Float_t mTimeResponseThreshold{0.001}; // Raw time response function energy threshold
+  Int_t mDigitThreshold{3};              ///< Threshold for storing digits in EMC
+  Int_t mMeanPhotonElectron{4400};       ///< number of photon electrons per GeV deposited energy
+  Float_t mGainFluctuations{15.};        ///< correct fMeanPhotonElectron by the gain fluctuations
+  Float_t mPinNoise{0.012};              ///< Electronics noise in EMC, APD
+  Float_t mTimeNoise{1.28e-5};           ///< Electronics noise in EMC, time
+  Float_t mTimeDelay{600e-9};            ///< Simple time delay to mimick roughly delay in data
+  Bool_t mTimeDelayFromCDB{false};       ///< Get time delay from OCDB
+  Float_t mTimeResolutionPar0{0.26666};  ///< Time resolution of FEE electronics
+  Float_t mTimeResolutionPar1{1.4586};   ///< Time resolution of FEE electronics
+  Int_t mNADCEC{0x10000};                ///< number of channels in EC section ADC
+  Float_t mTimeResponseTau{2.35};        ///< Raw time response function tau parameter
+  Float_t mTimeResponsePower{2};         ///< Raw time response function power parameter
+  Float_t mTimeResponseThreshold{0.001}; ///< Raw time response function energy threshold
 
   // SDigitizer
-  Float_t mA{0.};                 // Pedestal parameter
-  Float_t mB{1.e+6};              // Slope Digitizition parameters
-  Float_t mECPrimThreshold{0.05}; // To store primary if EC Shower Elos > threshold
+  Float_t mA{0.};                 ///< Pedestal parameter
+  Float_t mB{1.e+6};              ///< Slope Digitizition parameters
+  Float_t mECPrimThreshold{0.05}; ///< To store primary if EC Shower Elos > threshold
+
+  // Timing
+  Float_t mSignalDelay{700}; ///< Signal delay time (ns)
+  Float_t mLiveTime{1500};   ///< EMCal live time (ns)
+  Float_t mBusyTime{0};      ///< EMCal busy time (ns)
+
+  // DigitizerSpec
+  Bool_t mDisablePileup{false}; ///< disable pileup simulation
+
+  O2ParamDef(SimParam, "EMCSimParam");
 };
 
 std::ostream& operator<<(std::ostream& stream, const SimParam& s);

--- a/Detectors/EMCAL/simulation/src/Digitizer.cxx
+++ b/Detectors/EMCAL/simulation/src/Digitizer.cxx
@@ -34,22 +34,36 @@ using namespace o2::emcal;
 //_______________________________________________________________________
 void Digitizer::init()
 {
-  mSimParam = SimParam::getInstance();
+  mSimParam = &(o2::emcal::SimParam::Instance());
+  mLiveTime = mSimParam->getLiveTime();
+  mBusyTime = mSimParam->getBusyTime();
   mRandomGenerator = new TRandom3(std::chrono::high_resolution_clock::now().time_since_epoch().count());
 
   float tau = mSimParam->getTimeResponseTau();
   float N = mSimParam->getTimeResponsePower();
-  mTimeBinOffset = ((int)tau + 0.5);
+  float delay = std::fmod(mSimParam->getSignalDelay() / constants::EMCAL_TIMESAMPLE, 1);
+  mDelay = ((int)(std::floor(mSimParam->getSignalDelay() / constants::EMCAL_TIMESAMPLE)));
+
+  mTimeBinOffset.clear();
   mSignalFractionInTimeBins.clear();
+
   TF1 RawResponse("RawResponse", rawResponseFunction, 0, 256, 5);
   RawResponse.SetParameters(1., 0., tau, N, 0.);
-  double RawResponseTotalIntegral = (N > 0) ? pow(N, -N) * exp(N) * std::tgamma(N) : 1.;
-  for (int j = 0; j < constants::EMCAL_MAXTIMEBINS; j++) {
-    double val = RawResponse.Integral(-mTimeBinOffset - 0.5 + j, -mTimeBinOffset + 0.5 + j) / RawResponseTotalIntegral;
-    if (val < 1e-10) {
-      break;
+
+  for (int i = 0; i < 4; i++) {
+    int offset = ((int)(std::ceil(tau - delay - 0.25 * i)));
+    mTimeBinOffset.push_back(offset);
+
+    double RawResponseTotalIntegral = (N > 0) ? pow(N / tau, -N) * exp(N) * std::tgamma(N) * std::pow(1 / tau, N - 1) : 1.;
+    std::vector<double> sf;
+    RawResponse.SetParameter(1, 0.25 * i + delay);
+
+    for (int j = 0; j < constants::EMCAL_MAXTIMEBINS; j++) {
+      double val = RawResponse.Integral(j - offset, j + 1 - offset) / RawResponseTotalIntegral;
+      sf.push_back(val);
     }
-    mSignalFractionInTimeBins.push_back(val);
+
+    mSignalFractionInTimeBins.push_back(sf);
   }
 }
 
@@ -75,16 +89,26 @@ double Digitizer::rawResponseFunction(double* x, double* par)
 void Digitizer::finish() {}
 
 //_______________________________________________________________________
-void Digitizer::process(const std::vector<Hit>& hits, std::vector<Digit>& digits)
+void Digitizer::initCycle()
 {
-  digits.clear();
-  mDigits.clear();
-  mMCTruthContainer.clear();
-
   if (mSimulateNoiseDigits) {
     addNoiseDigits();
   }
 
+  mEmpty = false;
+}
+
+//_______________________________________________________________________
+void Digitizer::clear()
+{
+  mTriggerTime = -1e20;
+  mDigits.clear();
+  mEmpty = true;
+}
+
+//_______________________________________________________________________
+void Digitizer::process(const std::vector<Hit>& hits)
+{
   for (auto hit : hits) {
     try {
       hitToDigits(hit);
@@ -106,7 +130,7 @@ void Digitizer::process(const std::vector<Hit>& hits, std::vector<Digit>& digits
     }
   }
 
-  fillOutputContainer(digits);
+  mEmpty = false;
 }
 
 //_______________________________________________________________________
@@ -117,12 +141,12 @@ void Digitizer::hitToDigits(const Hit& hit)
   Double_t energy = hit.GetEnergyLoss();
 
   if (mSimulateTimeResponse) {
-    for (int j = 0; j < mSignalFractionInTimeBins.size(); j++) {
-      double val = energy * mSignalFractionInTimeBins.at(j);
-      if ((val < mSimParam->getTimeResponseThreshold()) && (j > mTimeBinOffset)) {
+    for (int j = 0; j < mSignalFractionInTimeBins.at(mPhase).size(); j++) {
+      double val = energy * (mSignalFractionInTimeBins.at(mPhase).at(j));
+      if ((val < mSimParam->getTimeResponseThreshold()) && (j > mTimeBinOffset.at(mPhase))) {
         break;
       }
-      Digit digit(tower, val, mEventTime + (j - mTimeBinOffset) * constants::EMCAL_TIMESAMPLE);
+      Digit digit(tower, val, mEventTime + (j - mTimeBinOffset.at(mPhase) + mDelay + 0.5) * constants::EMCAL_TIMESAMPLE);
       mTempDigitVector.push_back(digit);
     }
   } else {
@@ -141,7 +165,17 @@ void Digitizer::setEventTime(double t)
   if (t < mEventTime && mContinuous) {
     LOG(FATAL) << "New event time (" << t << ") is < previous event time (" << mEventTime << ")";
   }
-  mEventTime = t;
+
+  if (t - mTriggerTime >= mLiveTime + mBusyTime) {
+    mTriggerTime = t;
+  }
+
+  mEventTime = t - mTriggerTime;
+
+  mPhase = ((int)((std::fmod(t, 100) + 12.5) / 25));
+  if (mPhase == 4) {
+    mPhase = 0;
+  }
 }
 
 //_______________________________________________________________________
@@ -158,7 +192,7 @@ void Digitizer::addNoiseDigits()
 }
 
 //_______________________________________________________________________
-void Digitizer::fillOutputContainer(std::vector<Digit>& digits)
+void Digitizer::fillOutputContainer(std::vector<Digit>& digits, o2::dataformats::MCTruthContainer<o2::emcal::MCLabel>& labelsout)
 {
   std::list<LabeledDigit> l;
 
@@ -199,11 +233,14 @@ void Digitizer::fillOutputContainer(std::vector<Digit>& digits)
     std::vector<MCLabel> labels = d.getLabels();
     digits.push_back(digit);
 
-    Int_t LabelIndex = mMCTruthContainer.getIndexedSize();
+    Int_t LabelIndex = labelsout.getIndexedSize();
     for (auto label : labels) {
-      mMCTruthContainer.addElementRandomAccess(LabelIndex, label);
+      labelsout.addElementRandomAccess(LabelIndex, label);
     }
   }
+
+  mDigits.clear();
+  mEmpty = true;
 }
 
 //_______________________________________________________________________

--- a/Detectors/EMCAL/simulation/src/DigitizerTask.cxx
+++ b/Detectors/EMCAL/simulation/src/DigitizerTask.cxx
@@ -81,7 +81,7 @@ void DigitizerTask::Exec(Option_t* option)
   mDigitizer.setCurrSrcID(mSourceID);
   mDigitizer.setCurrEvID(mEventID);
 
-  mDigitizer.process(*mHitsArray, *mDigitsArray);
+  mDigitizer.process(*mHitsArray);
 
   mEventID++;
 }

--- a/Detectors/EMCAL/simulation/src/EMCALSimulationLinkDef.h
+++ b/Detectors/EMCAL/simulation/src/EMCALSimulationLinkDef.h
@@ -20,10 +20,8 @@
 #pragma link C++ class o2::emcal::DigitizerTask + ;
 #pragma link C++ class o2::emcal::DMAOutputStream + ;
 #pragma link C++ class o2::emcal::SimParam + ;
-#pragma link C++ class o2::emcal::MCLabel + ;
 #pragma link C++ class o2::emcal::LabeledDigit + ;
 
-#pragma link C++ class std::vector < o2::emcal::MCLabel > +;
 #pragma link C++ class std::list < o2::emcal::LabeledDigit > +;
 
 #endif

--- a/Detectors/EMCAL/simulation/src/SimParam.cxx
+++ b/Detectors/EMCAL/simulation/src/SimParam.cxx
@@ -12,9 +12,9 @@
 #include <iostream>
 #include <TMath.h>
 
-using namespace o2::emcal;
+O2ParamImpl(o2::emcal::SimParam);
 
-SimParam* SimParam::mSimParam = nullptr;
+using namespace o2::emcal;
 
 std::ostream& operator<<(std::ostream& stream, const o2::emcal::SimParam& s)
 {
@@ -40,6 +40,10 @@ void SimParam::PrintStream(std::ostream& stream) const
   stream << "\nEMCal::SimParam.mA = " << mA;
   stream << "\nEMCal::SimParam.mB = " << mB;
   stream << "\nEMCal::SimParam.mECPrimThreshold = " << mECPrimThreshold;
+  stream << "\nEMCal::SimParam.mSignalDelay = " << mSignalDelay;
+  stream << "\nEMCal::SimParam.mLiveTime = " << mLiveTime;
+  stream << "\nEMCal::SimParam.mBusyTime = " << mBusyTime;
+  stream << "\nEMCal::SimParam.mDisablePileup = " << ((mDisablePileup) ? "true" : "false");
 }
 
 Double_t SimParam::getTimeResolution(Double_t energy) const

--- a/Steer/DigitizerWorkflow/src/EMCALDigitWriterSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/EMCALDigitWriterSpec.cxx
@@ -14,7 +14,7 @@
 #include "Framework/CallbackService.h"
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/ControlService.h"
-#include <SimulationDataFormat/MCCompLabel.h>
+#include <DataFormatsEMCAL/MCLabel.h>
 #include <SimulationDataFormat/MCTruthContainer.h>
 #include "TBranch.h"
 
@@ -84,7 +84,7 @@ void DigitsWriterSpec::run(framework::ProcessingContext& ctx)
   std::cout << "After trigger digit tree writing" << std::endl;
 
   // retrieve labels from the input
-  auto labeldata = ctx.inputs().get<o2::dataformats::MCTruthContainer<o2::MCCompLabel>*>("emcaldigitlabels");
+  auto labeldata = ctx.inputs().get<o2::dataformats::MCTruthContainer<MCLabel>*>("emcaldigitlabels");
   LOG(INFO) << "EMCAL GOT " << labeldata->getNElements() << " LABELS ";
   auto labeldataraw = labeldata.get();
   // connect this to a particular branch

--- a/Steer/DigitizerWorkflow/src/EMCALDigitizerSpec.h
+++ b/Steer/DigitizerWorkflow/src/EMCALDigitizerSpec.h
@@ -18,7 +18,6 @@
 #include "DataFormatsEMCAL/Digit.h"
 #include "EMCALBase/Hit.h"
 #include "EMCALSimulation/Digitizer.h"
-#include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
 
 class TChain;
@@ -74,7 +73,7 @@ class DigitizerSpec : public framework::Task
   std::vector<Hit> mHits;                ///< Vector with input hits
   std::vector<Digit> mDigits;            ///< Vector with non-accumulated digits (per collision)
   std::vector<Digit> mAccumulatedDigits; ///< Vector with accumulated digits (time frame)
-  dataformats::MCTruthContainer<o2::MCCompLabel> mLabels;
+  dataformats::MCTruthContainer<MCLabel> mLabels;
 };
 
 /// \brief Create new digitizer spec


### PR DESCRIPTION
The modifications are
1.) accounting for the 4 different phases when dividing the energy into time bins
2.) introducing the 700 ns delay (the value can be modified)
3.) simulating noise digits at the beginning of each 1500 ns period
4.) accumulating digits during the 1500 ns period
5.) summing digits and passing them to the DigitizerSpec at the end of each 1500 ns period