### PR TITLE
[EMCAL-610, EMCAL-628] Add DMA output stream

### DIFF
--- a/Detectors/EMCAL/simulation/CMakeLists.txt
+++ b/Detectors/EMCAL/simulation/CMakeLists.txt
@@ -11,12 +11,14 @@
 o2_add_library(EMCALSimulation
                SOURCES src/Detector.cxx src/Digitizer.cxx src/DigitizerTask.cxx
                        src/SpaceFrame.cxx src/SimParam.cxx src/LabeledDigit.cxx
+		       src/DMAOutputStream.cxx
                PUBLIC_LINK_LIBRARIES O2::EMCALBase O2::DetectorsBase O2::SimulationDataFormat)
 
 o2_target_root_dictionary(EMCALSimulation
                           HEADERS include/EMCALSimulation/Detector.h
                                   include/EMCALSimulation/Digitizer.h
                                   include/EMCALSimulation/DigitizerTask.h
+				  include/EMCALSimulation/DMAOutputStream.h
                                   include/EMCALSimulation/SpaceFrame.h
                                   include/EMCALSimulation/SimParam.h
                                   include/EMCALSimulation/MCLabel.h

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/DMAOutputStream.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/DMAOutputStream.h
@@ -1,0 +1,117 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef ALICEO2_EMCAL_DMAOUTPUTSTREAM_H
+#define ALICEO2_EMCAL_DMAOUTPUTSTREAM_H
+
+#include <exception>
+#include <fstream>
+#include <string>
+
+#include <gsl/span>
+
+#include "Rtypes.h"
+#include "RStringView.h"
+
+#include "Headers/RAWDataHeader.h"
+
+namespace o2
+{
+
+namespace emcal
+{
+
+/// \class DMAOutputStream
+/// \brief Output stream of a payload to DMA raw files
+/// \author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
+/// \since Nov 6, 2019
+///
+/// Stream of output payload with variable size to DMA pages in
+/// a binary raw file. The output payload can be larger than the
+/// size of a DMA page (default: 8 kB) the output is split into
+/// multiple pages. Page counter, memory size, page size and
+/// stop bit are handled internally and are overwritten in the
+/// raw data header provided. All other header information must be
+/// handled externally.
+class DMAOutputStream
+{
+ public:
+  using RawHeader = o2::header::RAWDataHeaderV4;
+
+  class OutputFileException : public std::exception
+  {
+   public:
+    OutputFileException() = default;
+    OutputFileException(const std::string_view filename) : std::exception(), mFilePath(filename), mMessage("Path \"" + mFilePath + "\" invalid") {}
+    ~OutputFileException() noexcept final = default;
+
+    const char* what() const noexcept final
+    {
+      return mMessage.data();
+    }
+
+   private:
+    std::string mFilePath = "";
+    std::string mMessage = "";
+  };
+
+  /// \brief Constructor
+  DMAOutputStream() = default;
+
+  /// \brief Constructor
+  /// \param filename Name of the output file
+  DMAOutputStream(const char* filename);
+
+  /// \brief Destructor
+  ///
+  /// Closing file I/O
+  ~DMAOutputStream();
+
+  /// \brief Open the output stream
+  /// \throw OutputFileException
+  ///
+  /// Opening output file I/O
+  void open();
+
+  /// \brief Set the name of the output file
+  /// \param filename Name of the output file
+  void setOutputFilename(const char* filename) { mFilename = filename; }
+
+  /// \brief Write output payload to the output stream
+  /// \param header Raw data header
+  /// \param buffer Raw data payload
+  ///
+  /// Converting output payload to DMA papges. If the payload is larger than
+  /// the pagesize - header size the payload is automatically split to multiple
+  /// pages. Page counter, memory size, page size and stop bit of the header are
+  /// handled internally and are overwritten from the header provided. All other
+  /// header information must be provided externally.
+  void writeData(RawHeader header, gsl::span<char> buffer);
+
+ protected:
+  /// \brief Write DMA page
+  /// \param header Raw data header for page
+  /// \param payload Page payload (includes size of teh payload)
+  /// \param pagesize Size of the DMA page (not size of the payload)
+  ///
+  /// Expects that the size of the payload is smaller than the size ot the DMA
+  /// page. Parameter pagesize supporting variable page size.
+  void writeDMAPage(const RawHeader& header, gsl::span<char> payload, int pagesize);
+
+ private:
+  std::string mFilename = ""; ///< Name of the output file
+  std::ofstream mOutputFile;  ///< Handler for output raw file
+  bool mInitialized = false;  ///< Switch for whether the output stream is initialized
+
+  ClassDefNV(DMAOutputStream, 1);
+};
+} // namespace emcal
+} // namespace o2
+
+#endif

--- a/Detectors/EMCAL/simulation/src/DMAOutputStream.cxx
+++ b/Detectors/EMCAL/simulation/src/DMAOutputStream.cxx
@@ -1,0 +1,79 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "EMCALSimulation/DMAOutputStream.h"
+
+using namespace o2::emcal;
+
+DMAOutputStream::DMAOutputStream(const char* filename) : mFilename(filename) {}
+
+DMAOutputStream::~DMAOutputStream()
+{
+  if (mOutputFile.is_open())
+    mOutputFile.close();
+}
+
+void DMAOutputStream::open()
+{
+  if (!mOutputFile.is_open()) {
+    if (!mFilename.length())
+      throw OutputFileException(mFilename);
+    mOutputFile.open(mFilename, std::ios::out | std::ios::binary);
+    mInitialized = true;
+  }
+}
+
+void DMAOutputStream::writeData(RawHeader header, gsl::span<char> buffer)
+{
+  if (!mInitialized)
+    open();
+
+  constexpr int PAGESIZE = 8192;
+  // Handling of the termination word (0x001d3082): The termination word is added to the payload
+  // but not included in the payload size (as done in the hardware). Therefore it has to be subtracted
+  // from the maximum possible payload size
+  constexpr int MAXNWORDS = PAGESIZE - sizeof(header) - sizeof(uint32_t);
+  bool writeNext = true;
+  int pagecounter = 0, currentindex = 0;
+  while (writeNext) {
+    int sizeRemain = buffer.size() - currentindex;
+    int nwordspage = MAXNWORDS;
+    if (sizeRemain < MAXNWORDS) {
+      // Last page
+      nwordspage = sizeRemain;
+      writeNext = false;
+      header.stop = true;
+    }
+    header.packetCounter = pagecounter;
+    header.memorySize = nwordspage + sizeof(RawHeader);
+    header.offsetToNext = 8192;
+
+    writeDMAPage(header, gsl::span(buffer.data() + currentindex, nwordspage), PAGESIZE);
+
+    if (writeNext) {
+      currentindex += nwordspage;
+      pagecounter++;
+    }
+  }
+}
+
+void DMAOutputStream::writeDMAPage(const RawHeader& header, gsl::span<char> payload, int pagesize)
+{
+  std::vector<char> dmapage(pagesize);
+  o2::header::RAWDataHeaderV4* outheader = reinterpret_cast<o2::header::RAWDataHeaderV4*>(dmapage.data());
+  *outheader = header;
+  char* outpayload = dmapage.data() + sizeof(header);
+  memcpy(outpayload, payload.data(), payload.size());
+  // Write termination character
+  uint32_t terminationCharacter = 0x001d3082;
+  char* terminationString = reinterpret_cast<char*>(&terminationCharacter);
+  memcpy(outpayload + payload.size(), terminationString, sizeof(uint32_t));
+  mOutputFile.write(dmapage.data(), dmapage.size());
+}

--- a/Detectors/EMCAL/simulation/src/EMCALSimulationLinkDef.h
+++ b/Detectors/EMCAL/simulation/src/EMCALSimulationLinkDef.h
@@ -18,6 +18,7 @@
 #pragma link C++ class o2::base::DetImpl < o2::emcal::Detector> + ;
 #pragma link C++ class o2::emcal::Digitizer + ;
 #pragma link C++ class o2::emcal::DigitizerTask + ;
+#pragma link C++ class o2::emcal::DMAOutputStream + ;
 #pragma link C++ class o2::emcal::SimParam + ;
 #pragma link C++ class o2::emcal::MCLabel + ;
 #pragma link C++ class o2::emcal::LabeledDigit + ;


### PR DESCRIPTION
Class writing header and payload to a binary
file in DMA page format. The output stream
splits the payload into multiple pages
in case the payload is larger than the
8 kB offset. Header fields memorySize,
pageCounter and stop bit are handled by
the DMA output stream similarly as done
in the readout hardware.