### PR TITLE
DPL: OutputObj: support for writing in multiple files

### DIFF
--- a/Framework/AnalysisTutorial/src/histograms.cxx
+++ b/Framework/AnalysisTutorial/src/histograms.cxx
@@ -10,7 +10,6 @@
 #include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
-#include "Framework/HistogramRegistry.h"
 #include <TH1F.h>
 
 #include <cmath>
@@ -50,7 +49,7 @@ struct CTask {
   // when adding an object to OutputObj later, the object name will be
   // *reset* to OutputObj label - needed for correct placement in the output file
   OutputObj<TH1F> ptH{TH1F("pt", "pt", 100, -0.01, 10.01)};
-  OutputObj<TH1F> trZ{"trZ"};
+  OutputObj<TH1F> trZ{"trZ", OutputObjHandlingPolicy::QAObject};
 
   void init(InitContext const&)
   {

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -1,4 +1,4 @@
-﻿// Copyright CERN and copyright holders of ALICE O2. This software is
+// Copyright CERN and copyright holders of ALICE O2. This software is
 // distributed under the terms of the GNU General Public License v3 (GPL
 // Version 3), copied verbatim in the file "COPYING".
 //
@@ -7,6 +7,7 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
+
 #ifndef FRAMEWORK_ANALYSIS_TASK_H_
 #define FRAMEWORK_ANALYSIS_TASK_H_
 

--- a/Framework/Core/include/Framework/OutputObjHeader.h
+++ b/Framework/Core/include/Framework/OutputObjHeader.h
@@ -1,0 +1,48 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_FRAMEWORK_OUTPUTOBJHEADER_H_
+#define O2_FRAMEWORK_OUTPUTOBJHEADER_H_
+
+#include "Headers/DataHeader.h"
+
+using BaseHeader = o2::header::BaseHeader;
+
+namespace o2::framework
+{
+
+/// Policy enum to determine OutputObj handling when writing.
+enum OutputObjHandlingPolicy : unsigned int {
+  AnalysisObject,
+  QAObject,
+  TransientObject,
+  numPolicies
+};
+
+/// @struct OutputObjHeader
+/// @brief O2 header for OutputObj metadata
+struct OutputObjHeader : public BaseHeader {
+  constexpr static const uint32_t sVersion = 1;
+  constexpr static const o2::header::HeaderType sHeaderType = "OytObjMD";
+  constexpr static const o2::header::SerializationMethod sSerializationMethod = o2::header::gSerializationMethodNone;
+  OutputObjHandlingPolicy mPolicy;
+
+  constexpr OutputObjHeader()
+    : BaseHeader(sizeof(OutputObjHeader), sHeaderType, sSerializationMethod, sVersion),
+      mPolicy{OutputObjHandlingPolicy::AnalysisObject} {}
+  constexpr OutputObjHeader(OutputObjHandlingPolicy policy)
+    : BaseHeader(sizeof(OutputObjHeader), sHeaderType, sSerializationMethod, sVersion),
+      mPolicy{policy} {}
+  constexpr OutputObjHeader(OutputObjHeader const&) = default;
+};
+
+} // namespace o2::framework
+
+#endif // O2_FRAMEWORK_OUTPUTOBJHEADER_H_

--- a/Framework/Core/src/CommonDataProcessors.cxx
+++ b/Framework/Core/src/CommonDataProcessors.cxx
@@ -24,6 +24,8 @@
 #include "Framework/Logger.h"
 #include "Framework/OutputSpec.h"
 #include "Framework/Variant.h"
+#include "../../../Algorithm/include/Algorithm/HeaderStack.h"
+#include "Framework/OutputObjHeader.h"
 
 #include "TFile.h"
 
@@ -45,6 +47,7 @@ namespace framework
 struct InputObjectRoute {
   std::string uniqueId;
   std::string directory;
+  OutputObjHandlingPolicy policy;
   bool operator<(InputObjectRoute const& other) const
   {
     return this->uniqueId < other.uniqueId;
@@ -57,10 +60,8 @@ struct InputObject {
   std::string name;
 };
 
-std::string outputROOTfilename()
-{
-  return "AnalysisResults.root";
-}
+const static std::unordered_map<OutputObjHandlingPolicy, std::string> ROOTfileNames = {{OutputObjHandlingPolicy::AnalysisObject, "AnalysisResults.root"},
+                                                                                       {OutputObjHandlingPolicy::QAObject, "QAResults.root"}};
 
 DataProcessorSpec CommonDataProcessors::getOutputObjSink(outputObjMap const& outMap)
 {
@@ -71,19 +72,33 @@ DataProcessorSpec CommonDataProcessors::getOutputObjSink(outputObjMap const& out
     auto endofdatacb = [outputObjects](EndOfStreamContext& context) {
       LOG(INFO) << "Writing merged objects to file";
       std::string currentDirectory = "";
-      TFile* f = TFile::Open(outputROOTfilename().c_str(), "RECREATE");
-      for (auto& [route, entry] : *outputObjects) {
-        std::string nextDirectory = route.directory;
-        if (nextDirectory != currentDirectory) {
-          if (!f->FindKey(nextDirectory.c_str())) {
-            f->mkdir(nextDirectory.c_str());
-          }
-          currentDirectory = nextDirectory;
-        }
-        (f->GetDirectory(currentDirectory.c_str()))->WriteObjectAny(entry.obj, entry.kind, entry.name.c_str());
+      std::string currentFile = "";
+      TFile* f[OutputObjHandlingPolicy::numPolicies];
+      for (auto i = 0u; i < OutputObjHandlingPolicy::numPolicies; ++i) {
+        f[i] = nullptr;
       }
-      if (f) {
-        f->Close();
+      for (auto& [route, entry] : *outputObjects) {
+        auto file = ROOTfileNames.find(route.policy);
+        if (file != ROOTfileNames.end()) {
+          auto filename = file->second;
+          if (f[route.policy] == nullptr) {
+            f[route.policy] = TFile::Open(filename.c_str(), "RECREATE");
+          }
+          auto nextDirectory = route.directory;
+          if ((nextDirectory != currentDirectory) || (filename != currentFile)) {
+            if (!f[route.policy]->FindKey(nextDirectory.c_str())) {
+              f[route.policy]->mkdir(nextDirectory.c_str());
+            }
+            currentDirectory = nextDirectory;
+            currentFile = filename;
+          }
+          (f[route.policy]->GetDirectory(currentDirectory.c_str()))->WriteObjectAny(entry.obj, entry.kind, entry.name.c_str());
+        }
+      }
+      for (auto i = 0u; i < OutputObjHandlingPolicy::numPolicies; ++i) {
+        if (f[i] != nullptr) {
+          f[i]->Close();
+        }
       }
       LOG(INFO) << "All outputs merged in their respective target files";
       context.services().get<ControlService>().readyToQuit(QuitRequest::All);
@@ -100,18 +115,29 @@ DataProcessorSpec CommonDataProcessors::getOutputObjSink(outputObjMap const& out
         LOG(ERROR) << "Payload not found";
         return;
       }
-      auto dh = o2::header::get<o2::header::DataHeader*>(ref.header);
-      if (!dh) {
-        LOG(ERROR) << "DataHeader not found";
+      auto datah = o2::header::get<o2::header::DataHeader*>(ref.header);
+      if (!datah) {
+        LOG(ERROR) << "No data header in stack";
         return;
       }
-      FairTMessage tm(const_cast<char*>(ref.payload), dh->payloadSize);
+
+      auto objh = o2::header::get<o2::framework::OutputObjHeader*>(ref.header);
+      if (!objh) {
+        LOG(ERROR) << "No output object header in stack";
+        return;
+      }
+
+      FairTMessage tm(const_cast<char*>(ref.payload), datah->payloadSize);
       InputObject obj;
       obj.kind = tm.GetClass();
       if (obj.kind == nullptr) {
         LOGP(error, "Cannot read class info from buffer.");
         return;
       }
+
+      OutputObjHandlingPolicy policy = OutputObjHandlingPolicy::AnalysisObject;
+      if (objh)
+        policy = objh->mPolicy;
 
       obj.obj = tm.ReadObjectAny(obj.kind);
       TNamed* named = static_cast<TNamed*>(obj.obj);
@@ -121,7 +147,7 @@ DataProcessorSpec CommonDataProcessors::getOutputObjSink(outputObjMap const& out
       if (lookup != outMap.end()) {
         directory = lookup->second;
       }
-      InputObjectRoute key{obj.name, directory};
+      InputObjectRoute key{obj.name, directory, policy};
       auto existing = outputObjects->find(key);
       if (existing == outputObjects->end()) {
         outputObjects->insert(std::make_pair(key, obj));

--- a/Framework/Foundation/include/Framework/StructToTuple.h
+++ b/Framework/Foundation/include/Framework/StructToTuple.h
@@ -16,7 +16,7 @@ namespace o2::framework
 {
 struct any_type {
   template <class T>
-  constexpr operator T(); // non explicit
+  constexpr operator T();  // non explicit
 };
 
 template <class T, typename... Args>
@@ -77,4 +77,4 @@ auto constexpr to_tuple_refs(T&& object) noexcept
   }
 }
 
-} // namespace o2::framework
+}  // namespace o2::framework

--- a/Framework/Foundation/include/Framework/StructToTuple.h
+++ b/Framework/Foundation/include/Framework/StructToTuple.h
@@ -16,7 +16,7 @@ namespace o2::framework
 {
 struct any_type {
   template <class T>
-  constexpr operator T();  // non explicit
+  constexpr operator T(); // non explicit
 };
 
 template <class T, typename... Args>
@@ -77,4 +77,4 @@ auto constexpr to_tuple_refs(T&& object) noexcept
   }
 }
 
-}  // namespace o2::framework
+} // namespace o2::framework


### PR DESCRIPTION
* Added a specialized header for OutputObj metadata (can be extended)
* Added a policy enum that determines the destination of OutputObj
* Added header parsing in common root file sink to use the policy
* Updated analysis tutorial example to use different policies