### PR TITLE
Framework: add ability to concatenate tables

### DIFF
--- a/Framework/Core/src/ASoA.cxx
+++ b/Framework/Core/src/ASoA.cxx
@@ -9,9 +9,11 @@
 // or submit itself to any jurisdiction.
 
 #include "Framework/ASoA.h"
+#include "ArrowDebugHelpers.h"
 
 namespace o2::soa
 {
+
 std::shared_ptr<arrow::Table> ArrowHelpers::joinTables(std::vector<std::shared_ptr<arrow::Table>>&& tables)
 {
   std::vector<std::shared_ptr<arrow::Column>> columns;
@@ -25,4 +27,42 @@ std::shared_ptr<arrow::Table> ArrowHelpers::joinTables(std::vector<std::shared_p
   }
   return arrow::Table::Make(std::make_shared<arrow::Schema>(fields), columns);
 }
+
+std::shared_ptr<arrow::Table> ArrowHelpers::concatTables(std::vector<std::shared_ptr<arrow::Table>>&& tables)
+{
+  std::vector<std::shared_ptr<arrow::Column>> columns;
+  assert(tables.size() > 1);
+  std::vector<std::shared_ptr<arrow::Field>> resultFields = tables[0]->schema()->fields();
+  auto compareFields = [](std::shared_ptr<arrow::Field> const& f1, std::shared_ptr<arrow::Field> const& f2) {
+    // Let's do this with stable sorting.
+    return (!f1->Equals(f2)) && (f1->name() < f2->name());
+  };
+  for (size_t i = 1; i < tables.size(); ++i) {
+    auto& fields = tables[i]->schema()->fields();
+    std::vector<std::shared_ptr<arrow::Field>> intersection;
+
+    std::set_intersection(resultFields.begin(), resultFields.end(),
+                          fields.begin(), fields.end(),
+                          std::back_inserter(intersection), compareFields);
+    resultFields.swap(intersection);
+  }
+
+  for (auto& field : resultFields) {
+    arrow::ArrayVector chunks;
+    for (auto& table : tables) {
+      auto ci = table->schema()->GetFieldIndex(field->name());
+      if (ci == -1) {
+        throw std::runtime_error("Unable to find field " + field->name());
+      }
+      auto column = table->column(ci);
+      auto otherChunks = column->data()->chunks();
+      chunks.insert(chunks.end(), otherChunks.begin(), otherChunks.end());
+    }
+    columns.push_back(std::make_shared<arrow::Column>(field, chunks));
+  }
+
+  auto result = arrow::Table::Make(std::make_shared<arrow::Schema>(resultFields), columns);
+  return result;
+}
+
 } // namespace o2::soa

--- a/Framework/Core/src/ArrowDebugHelpers.h
+++ b/Framework/Core/src/ArrowDebugHelpers.h
@@ -19,6 +19,7 @@ template class std::shared_ptr<arrow::Column>;
 template class std::shared_ptr<arrow::Field>;
 template class std::shared_ptr<arrow::Schema>;
 template class std::shared_ptr<arrow::Table>;
+template class std::vector<std::shared_ptr<arrow::Table>>;
 template class std::vector<std::shared_ptr<arrow::Column>>;
 template class std::vector<std::shared_ptr<arrow::Field>>;
 #endif

--- a/Framework/Foundation/include/Framework/FunctionalHelpers.h
+++ b/Framework/Foundation/include/Framework/FunctionalHelpers.h
@@ -120,6 +120,27 @@ struct has_type<T, pack<Us...>> : std::disjunction<std::is_same<T, Us>...> {
 template <typename T, typename... Us>
 inline constexpr bool has_type_v = has_type<T, Us...>::value;
 
+/// Intersect two packs
+template <typename S1, typename S2>
+struct pack_intersect {
+  template <std::size_t... Indices>
+  static constexpr auto make_intersection(std::index_sequence<Indices...>)
+  {
+
+    return concatenate_pack(
+      std::conditional_t<
+        has_type_v<
+          pack_element_t<Indices, S1>,
+          S2>,
+        pack<pack_element_t<Indices, S1>>,
+        pack<>>{}...);
+  }
+  using type = decltype(make_intersection(std::make_index_sequence<pack_size(S1{})>{}));
+};
+
+template <typename S1, typename S2>
+using pack_intersect_t = typename pack_intersect<S1, S2>::type;
+
 /// Type helper to hold metadata about a lambda or a class
 /// method.
 template <typename Ret, typename Class, typename... Args>


### PR DESCRIPTION
This allows to take two `soa::Table` with different columns and stack their common columns into a new `soa::Table`. This effectively mimics the ability to have polymorphic collections and access data through the common base class.