### PR TITLE
Fix: dont clear ZDC hits when ShmManager is operational

### DIFF
--- a/Detectors/ZDC/simulation/src/Detector.cxx
+++ b/Detectors/ZDC/simulation/src/Detector.cxx
@@ -2271,7 +2271,7 @@ void Detector::Reset()
 {
   if (!o2::utils::ShmManager::Instance().isOperational()) {
     mHits->clear();
-    mLastPrincipalTrackEntered = -1;
-    resetHitIndices();
   }
+  mLastPrincipalTrackEntered = -1;
+  resetHitIndices();
 }

--- a/Detectors/ZDC/simulation/src/Detector.cxx
+++ b/Detectors/ZDC/simulation/src/Detector.cxx
@@ -2269,7 +2269,9 @@ void Detector::Register()
 //_____________________________________________________________________________
 void Detector::Reset()
 {
-  mHits->clear();
-  mLastPrincipalTrackEntered = -1;
-  resetHitIndices();
+  if (!o2::utils::ShmManager::Instance().isOperational()) {
+    mHits->clear();
+    mLastPrincipalTrackEntered = -1;
+    resetHitIndices();
+  }
 }


### PR DESCRIPTION
Otherwise the hits are created but the container is reset before they are stored.