### PR TITLE
isOnMassShell will try to fix particles with wrong kinematics

### DIFF
--- a/Generators/include/Generators/GeneratorFromFile.h
+++ b/Generators/include/Generators/GeneratorFromFile.h
@@ -17,6 +17,7 @@
 
 class TBranch;
 class TFile;
+class TParticle;
 
 namespace o2
 {
@@ -45,13 +46,15 @@ class GeneratorFromFile : public FairGenerator
   void SetStartEvent(int start);
 
   void SetSkipNonTrackable(bool b) { mSkipNonTrackable = b; }
+  void setFixOffShell(bool b) { mFixOffShell = b; }
+  bool rejectOrFixKinematics(TParticle& p);
 
  private:
   TFile* mEventFile = nullptr; //! the file containing the persistent events
   int mEventCounter = 0;
   int mEventsAvailable = 0;
   bool mSkipNonTrackable = true; //! whether to pass non-trackable (decayed particles) to the MC stack
-
+  bool mFixOffShell = true;      // fix particles with M_assigned != M_calculated
   ClassDefOverride(GeneratorFromFile, 1);
 };
 


### PR DESCRIPTION
After the check for the discrepancy between the M_PDG and M=sqrt(E^2-P^2) (off-shell particles) we check if the calculated mass TParticles::GetCalcMass() is consistent with the PDG mass. If it is, we assume that the kinematics is simply wrong and assign correct E as sqrt(P^2 + M_PDG^2).

@sawenzel this was to fix primarily the RELDIS Kinematics for ZDC tests, where the neutrons appear to be off-shell. But I've checked also on Hijing and most of the particles I've seen being off-shell were stable ones (except some lambdas):
````
[WARN] Particle -211 has off-shell mass: M_PDG= 0.13957 (assigned= 0.13957) calculated= 0.140711 -> diff= 0.00114135 | fixing
[WARN] Particle -211 has off-shell mass: M_PDG= 0.13957 (assigned= 0.13957) calculated= 0.139352 -> diff= 0.000218301 | fixing
[WARN] Particle 211 has off-shell mass: M_PDG= 0.13957 (assigned= 0.13957) calculated= 0.139384 -> diff= 0.000185833 | fixing
[WARN] Particle 22 has off-shell mass: M_PDG= 0 (assigned= 0) calculated= 0.000180065 -> diff= 0.000180065 | fixing
[WARN] Particle 22 has off-shell mass: M_PDG= 0 (assigned= 0) calculated= 0.000638558 -> diff= 0.000638558 | fixing
[WARN] Particle 22 has off-shell mass: M_PDG= 0 (assigned= 0) calculated= 0.00474189 -> diff= 0.00474189 | fixing
[WARN] Particle 22 has off-shell mass: M_PDG= 0 (assigned= 0) calculated= -0.000594799 -> diff= 0.000594799 | fixing
[WARN] Particle 22 has off-shell mass: M_PDG= 0 (assigned= 0) calculated= -0.0014865 -> diff= 0.0014865 | fixing
[WARN] Particle 22 has off-shell mass: M_PDG= 0 (assigned= 0) calculated= 0.00120977 -> diff= 0.00120977 | fixing
````
In fact, in the 1 Hijing event I've checked out of 25924 primary particles 5906 had wrong kinematics (with ``GetCalcMass()==M_PDG != sqrt(E^2 - P^2)``). I've simulated "fixed" event using G4 and have not seen any crash.
