### PR TITLE
FIT: fix warnings

### DIFF
--- a/Detectors/FIT/FV0/base/include/FV0Base/Geometry.h
+++ b/Detectors/FIT/FV0/base/include/FV0Base/Geometry.h
@@ -75,7 +75,7 @@ class Geometry
   /// and continues clockwise one ring at a time.
   /// \param  fMC The virtual Monte Carlo interface.
   /// \return The ID of the current scintillator cell during simulation.
-  const int getCurrentCellId(const TVirtualMC* fMC) const;
+  int getCurrentCellId(const TVirtualMC* fMC) const;
 
   /// Get the names of all the sensitive volumes of the geometry.
   /// \return The names of all the sensitive volumes of the geometry.
@@ -86,7 +86,7 @@ class Geometry
   /// \param  component   The geometry component to be enabled/disabled.
   /// \param  enable      Setting the enabled state. Default is true.
   /// \return The enabled state of the geometry component.
-  const bool enableComponent(EGeoComponent component, bool enable = true);
+  bool enableComponent(EGeoComponent component, bool enable = true);
 
   /// Build the geometry.
   void buildGeometry() const;


### PR DESCRIPTION
const does not apply on a basic type returned by value.