### PR TITLE
o2-sim: improved hit merging

### DIFF
--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -45,7 +45,7 @@ void SimConfig::initOptions(boost::program_options::options_description& options
     "logverbosity", bpo::value<std::string>()->default_value("low"), "level of verbosity for FairLogger (low, medium, high, veryhigh)")(
     "configKeyValues", bpo::value<std::string>()->default_value(""), "semicolon separated key=value strings (e.g.: 'TPC.gasDensity=1;...")(
     "configFile", bpo::value<std::string>()->default_value(""), "Path to an INI or JSON configuration file")(
-    "chunkSize", bpo::value<unsigned int>()->default_value(5000), "max size of primary chunk (subevent) distributed by server")(
+    "chunkSize", bpo::value<unsigned int>()->default_value(500), "max size of primary chunk (subevent) distributed by server")(
     "chunkSizeI", bpo::value<int>()->default_value(-1), "internalChunkSize")(
     "seed", bpo::value<int>()->default_value(-1), "initial seed (default: -1 random)")(
     "field", bpo::value<int>()->default_value(-5), "L3 field rounded to kGauss, allowed values +-2,+-5 and 0")(

--- a/run/O2HitMerger.h
+++ b/run/O2HitMerger.h
@@ -452,7 +452,7 @@ class O2HitMerger : public FairMQDevice
   std::string mOutFileName;    //!
 
   TFile* mOutFile;    //!
-  std::unordered_map<int, TTree*> mEventToTTreeMap; //! in memory trees to collect / presort incoming data per event
+  std::unordered_map<int, TTree*> mEventToTTreeMap;       //! in memory trees to collect / presort incoming data per event
   std::unordered_map<int, TMemFile*> mEventToTMemFileMap; //! files associated to the TTrees
   TTree* mOutTree;    //!
   std::thread mMergerIOThread; //! a thread used to do hit merging and IO flushing asynchronously

--- a/run/o2sim_parallel.cxx
+++ b/run/o2sim_parallel.cxx
@@ -324,7 +324,7 @@ int main(int argc, char* argv[])
     childpids.push_back(pid);
     close(pipe_serverdriver_fd[1]);
     std::cout << "Spawning particle server on PID " << pid << "; Redirect output to " << serverlogname << "\n";
-    launchThreadMonitoringEvents(pipe_serverdriver_fd[0], "EVENTS DISTRIBUTED : ");
+    launchThreadMonitoringEvents(pipe_serverdriver_fd[0], "DISTRIBUTING EVENT : ");
   }
 
   auto internalfork = getenv("ALICE_SIMFORKINTERNAL");


### PR DESCRIPTION
This commit makes the hit merging
- asynchronous
- be performed after each event instead of at the end of simulation

This should solve a problem where the IO became
an important serial bottleneck for PbPb simulations.

Note:

We can potentially achieve still better performance by parallelizing
over the different branches in the output tree.