### PR TITLE
DPL Analysis: add support for filtered tables

### DIFF
--- a/Framework/AnalysisTutorial/src/filters.cxx
+++ b/Framework/AnalysisTutorial/src/filters.cxx
@@ -47,7 +47,7 @@ struct ATask {
 struct BTask {
   Filter ptFilter = (aod::etaphi::phi > 1) && (aod::etaphi::phi < 2);
 
-  void process(aod::EtaPhi const& etaPhis)
+  void process(soa::Filtered<aod::EtaPhi> const& etaPhis)
   {
     for (auto& etaPhi : etaPhis) {
       LOGF(ERROR, "(%f, %f)", etaPhi.eta(), etaPhi.phi());

--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -121,7 +121,9 @@ o2_add_library(Framework
                                      ROOT::ROOTDataFrame
                                      ${DEBUGGUI_TARGET}
                                      O2::FrameworkLogger
-                                     Boost::serialization)
+                                     Boost::serialization
+                                     arrow::gandiva_shared
+                                     )
 
 o2_target_root_dictionary(Framework
                           HEADERS test/TestClasses.h

--- a/Framework/Core/include/Framework/Expressions.h
+++ b/Framework/Core/include/Framework/Expressions.h
@@ -12,6 +12,9 @@
 
 #include "Framework/BasicOps.h"
 
+#include <arrow/table.h>
+#include <gandiva/selection_vector.h>
+
 #include <variant>
 #include <string>
 #include <memory>
@@ -117,6 +120,10 @@ struct Filter {
 
   std::unique_ptr<Node> node;
 };
+
+using Selection = std::shared_ptr<gandiva::SelectionVector>;
+Selection createSelection(std::shared_ptr<arrow::Table> table, Filter const& filter);
+
 } // namespace o2::framework::expressions
 
 #endif // O2_FRAMEWORK_EXPRESSIONS_H_

--- a/Framework/Core/src/Expressions.cxx
+++ b/Framework/Core/src/Expressions.cxx
@@ -10,6 +10,9 @@
 
 #include "../src/ExpressionHelpers.h"
 #include "Framework/VariantHelpers.h"
+
+#include <arrow/table.h>
+#include <gandiva/selection_vector.h>
 #include <stack>
 #include <iostream>
 
@@ -131,6 +134,16 @@ std::vector<ColumnOperationSpec> createKernelsFromFilter(Filter const& filter)
       path.emplace(right, ri);
   }
   return columnOperationSpecs;
+}
+
+Selection createSelection(std::shared_ptr<arrow::Table> table, Filter const& expr)
+{
+  std::shared_ptr<gandiva::SelectionVector> result;
+  auto status = gandiva::SelectionVector::MakeInt32(table->num_rows(), arrow::default_memory_pool(), &result);
+  if (status.ok() == false) {
+    throw std::runtime_error("Unable to create selection");
+  }
+  return result;
 }
 
 } // namespace o2::framework::expressions

--- a/dependencies/Findarrow.cmake
+++ b/dependencies/Findarrow.cmake
@@ -19,3 +19,7 @@ endif()
 set_target_properties(arrow_shared PROPERTIES IMPORTED_GLOBAL TRUE)
 
 add_library(arrow::arrow_shared ALIAS arrow_shared)
+
+# Promote the imported target to global visibility (so we can alias it)
+set_target_properties(gandiva_shared PROPERTIES IMPORTED_GLOBAL TRUE)
+add_library(arrow::gandiva_shared ALIAS gandiva_shared)


### PR DESCRIPTION
- [x] Propagate "filtered" everywhere.
- [x] Move `operator[]` to some `setIndex()` method and use it everywhere we touch `mRowIndex`.