### PR TITLE
Possibility to impose custom BC patter in digitization + macro to create it

### DIFF
--- a/DataFormats/common/include/CommonDataFormat/BunchFilling.h
+++ b/DataFormats/common/include/CommonDataFormat/BunchFilling.h
@@ -15,6 +15,7 @@
 
 #include "CommonConstants/LHCConstants.h"
 #include <bitset>
+#include <string>
 
 namespace o2
 {
@@ -34,6 +35,8 @@ class BunchFilling
   {
     setBCTrains(12, 96, 48, 2, 0);
   }
+
+  static BunchFilling* loadFrom(const std::string& fileName, const std::string& objName = "");
 
  private:
   std::bitset<o2::constants::lhc::LHCMaxBunches> mPattern;

--- a/DataFormats/common/src/BunchFilling.cxx
+++ b/DataFormats/common/src/BunchFilling.cxx
@@ -10,6 +10,7 @@
 
 #include "FairLogger.h"
 #include "CommonDataFormat/BunchFilling.h"
+#include "TFile.h"
 
 using namespace o2;
 
@@ -61,4 +62,22 @@ void BunchFilling::print(int bcPerLine) const
   if (!endlOK) {
     printf("\n");
   }
+}
+
+//_______________________________________________
+BunchFilling* BunchFilling::loadFrom(const std::string& fileName, const std::string& objName)
+{
+  // load object from file
+  TFile fl(fileName.data());
+  if (fl.IsZombie()) {
+    LOG(ERROR) << "Failed to open " << fileName;
+    return nullptr;
+  }
+  std::string nm = objName.empty() ? o2::BunchFilling::Class()->GetName() : objName;
+  auto bf = reinterpret_cast<o2::BunchFilling*>(fl.GetObjectChecked(nm.c_str(), o2::BunchFilling::Class()));
+  if (!bf) {
+    LOG(ERROR) << "Did not find object named " << nm;
+    return nullptr;
+  }
+  return bf;
 }

--- a/Steer/DigitizerWorkflow/src/SimReaderSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/SimReaderSpec.cxx
@@ -158,6 +158,12 @@ DataProcessorSpec getSimReaderSpec(int fanoutsize, const std::vector<int>& tpcse
       }
       LOG(INFO) << "Imposing hadronic interaction rate " << intRate << "Hz";
       mgr.getInteractionSampler().setInteractionRate(intRate);
+
+      auto bcPatternFile = ctx.options().get<std::string>("bcPatternFile");
+      if (!bcPatternFile.empty()) {
+        mgr.getInteractionSampler().setBunchFilling(bcPatternFile);
+      }
+
       mgr.getInteractionSampler().init();
 
       // number of collisions asked?
@@ -189,6 +195,7 @@ DataProcessorSpec getSimReaderSpec(int fanoutsize, const std::vector<int>& tpcse
     /* OPTIONS */
     Options{
       {"interactionRate", VariantType::Float, 50000.0f, {"Total hadronic interaction rate (Hz)"}},
+      {"bcPatternFile", VariantType::String, "", {"Interacting BC pattern file (e.g. from CreateBCPattern.C)"}},
       {"simFile", VariantType::String, "o2sim.root", {"Sim input filename"}},
       {"simFileS", VariantType::String, "", {"Sim (signal) input filename"}},
       {"simFileQED", VariantType::String, "", {"Sim (QED) input filename"}},

--- a/Steer/include/Steer/InteractionSampler.h
+++ b/Steer/include/Steer/InteractionSampler.h
@@ -43,6 +43,8 @@ class InteractionSampler
   float getBCTimeRMS() const { return mBCTimeRMS; }
   const BunchFilling& getBunchFilling() const { return mBCFilling; }
   BunchFilling& getBunchFilling() { return mBCFilling; }
+  void setBunchFilling(const BunchFilling& bc) { mBCFilling = bc; }
+  void setBunchFilling(const std::string& bcFillingFile);
   int getBCMin() const { return mBCMin; }
   int getBCMax() const { return mBCMax; }
 

--- a/Steer/src/InteractionSampler.cxx
+++ b/Steer/src/InteractionSampler.cxx
@@ -119,3 +119,15 @@ void InteractionSampler::warnOrbitWrapped() const
   print();
   LOG(FATAL) << "Max orbit " << o2::constants::lhc::MaxNOrbits << " overflow";
 }
+
+//_________________________________________________
+void InteractionSampler::setBunchFilling(const std::string& bcFillingFile)
+{
+  // load bunch filling from the file
+  auto* bc = o2::BunchFilling::loadFrom(bcFillingFile);
+  if (!bc) {
+    LOG(FATAL) << "Failed to load bunch filling from " << bcFillingFile;
+  }
+  mBCFilling = *bc;
+  delete bc;
+}

--- a/macro/CMakeLists.txt
+++ b/macro/CMakeLists.txt
@@ -57,6 +57,7 @@ install(FILES CheckClusters_mft.C
               run_trac_ca_its.C
               run_trac_its.C
               run_trac_mft.C
+	      CreateBCPattern.C
         DESTINATION share/macro/)
 
 # FIXME: a lot of macros that are here should really be elsewhere. Those which
@@ -300,6 +301,9 @@ o2_add_test_root_macro(run_rawdecoding_tof.C
                       PUBLIC_LINK_LIBRARIES O2::TOFSimulation
                                             O2::TOFReconstruction
                        LABELS tof)
+
+o2_add_test_root_macro(CreateBCPattern.C
+                      PUBLIC_LINK_LIBRARIES O2::CommonDataFormat)
 
 # FIXME: move to subsystem dir + check compilation o2_add_test_root_macro(
 # run_rec_ca.C PUBLIC_LINK_LIBRARIES O2::DetectorsCommonDataFormats

--- a/macro/CreateBCPattern.C
+++ b/macro/CreateBCPattern.C
@@ -1,0 +1,37 @@
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include "CommonDataFormat/BunchFilling.h"
+#include "CommonConstants/LHCConstants.h"
+#include <TFile.h>
+#include <string>
+#endif
+
+#include "FairLogger.h"
+
+void CreateBCPattern(const std::string& outFileName = "bcPattern.root", const string& objName = "")
+{
+  // example of interacting BC pattern creation
+
+  o2::BunchFilling pattern;
+
+  // create 16 trains spaced by 96 BCs, with 48 interacting BCs per train
+  // and 50 ns spacing between the BCs of the train and starting at BC 20
+  pattern.setBCTrains(16, 96, 48, 2, 20);
+
+  // add extra train of 6 bunches with 25 ns spacing in the very end
+  pattern.setBCTrain(6, 1, o2::constants::lhc::LHCMaxBunches - 6);
+
+  // add isolated bunchs at slots 1,3,5
+  pattern.setBC(1);
+  pattern.setBC(3);
+  pattern.setBC(5);
+  //
+  pattern.print();
+
+  if (!outFileName.empty()) {
+    std::string nm = objName.empty() ? objName : o2::BunchFilling::Class()->GetName();
+    LOG(INFO) << "Storing pattern with name " << nm << " in a file " << outFileName;
+    TFile outf(outFileName.c_str(), "update");
+    outf.WriteObjectAny(&pattern, pattern.Class(), nm.c_str());
+    outf.Close();
+  }
+}


### PR DESCRIPTION
@ekryshen : this will allow to run digitization with custom interacting BC patterns, e.g.
````
# create file bcPattern.root with some custom BC pattern
root -b -q $O2_ROOT/share/macro/CreateBCPattern.C+ 
# ...
# use it in digitization
o2-sim-digitizer-workflow --interactionRate 1000000 --bcPatternFile bcPattern.root
````