### PR TITLE
Improvements for the RawParser utility

### DIFF
--- a/Framework/Utils/CMakeLists.txt
+++ b/Framework/Utils/CMakeLists.txt
@@ -14,6 +14,7 @@ o2_add_library(DPLUtils
                        src/DPLGatherer.cxx
                        src/DPLMerger.cxx
                        src/DPLRouter.cxx
+                       src/RawParser.cxx
                        test/DPLBroadcasterMerger.cxx
                        test/DPLOutputTest.cxx
                PUBLIC_LINK_LIBRARIES O2::Framework)
@@ -71,3 +72,13 @@ o2_add_test(RawParser
             PUBLIC_LINK_LIBRARIES O2::DPLUtils
             COMPONENT_NAME DPLUtils
             LABELS dplutils)
+
+foreach(b
+        RawParser
+        )
+  o2_add_test(benchmark_${b} NAME test_Framework_benchmark_${b}
+              SOURCES test/benchmark_${b}.cxx
+              COMPONENT_NAME DPLUtils
+              LABELS dplutils benchmark
+              PUBLIC_LINK_LIBRARIES O2::DPLUtils benchmark::benchmark)
+endforeach()

--- a/Framework/Utils/include/DPLUtils/RawParser.h
+++ b/Framework/Utils/include/DPLUtils/RawParser.h
@@ -32,6 +32,37 @@ namespace o2::framework
 namespace raw_parser
 {
 
+/// specifier for printout
+enum struct FormatSpec {
+  Info,          // basic info: version
+  TableHeader,   // table header
+  Entry,         // table entry, i.e. RDH at current position
+  FullTable,     // full table with header and all entiries
+  FullTableInfo, // info and full table with header and all entries
+};
+
+template <typename T>
+struct RDHFormatter {
+  using type = T;
+  static void apply(std::ostream&, type const&, FormatSpec, const char* = "")
+  {
+  }
+};
+
+template <>
+struct RDHFormatter<header::RAWDataHeaderV5> {
+  using type = header::RAWDataHeaderV5;
+  static const char* sFormatString;
+  static void apply(std::ostream&, type const&, FormatSpec, const char* = "");
+};
+
+template <>
+struct RDHFormatter<header::RAWDataHeaderV4> {
+  using type = header::RAWDataHeaderV4;
+  static const char* sFormatString;
+  static void apply(std::ostream&, type const&, FormatSpec, const char* = "");
+};
+
 /// @class ConcreteRawParser
 /// Raw parser implementation for a particular version of RAWDataHeader.
 /// Parses a contiguous sequence of raw pages in a raw buffer.
@@ -170,6 +201,11 @@ class ConcreteRawParser
     }
   }
 
+  void format(std::ostream& os, FormatSpec choice = FormatSpec::Entry, const char* delimiter = "\n") const
+  {
+    RDHFormatter<header_type>::apply(os, header(), choice, delimiter);
+  }
+
  private:
   buffer_type const* mRawBuffer;
   buffer_type const* mPosition = nullptr;
@@ -214,6 +250,40 @@ ConcreteParserVariants<PageSize> create(T const* buffer, size_t size)
   throw std::runtime_error("can not create RawParser: invalid version " + std::to_string(v5->version));
 }
 
+/// iteratively walk through the available instances and parse with instance
+/// specified by index
+template <size_t N, typename T, typename P>
+void walk_parse(T& instances, P&& processor, size_t index)
+{
+  if constexpr (N > 0) {
+    if (index == N - 1) {
+      std::get<N - 1>(instances).parse(processor);
+    }
+
+    walk_parse<N - 1>(instances, processor, index);
+  }
+}
+
+template <typename U, typename T, size_t N = std::variant_size_v<T>>
+U const* get_if(T& instances)
+{
+  if constexpr (N > 0) {
+    auto* parser = std::get_if<N - 1>(&instances);
+    if (parser) {
+      // we are in the active instance, return header if type matches
+      using parser_type = typename std::variant_alternative<N - 1, T>::type;
+      using header_type = typename parser_type::header_type;
+      if constexpr (std::is_same<U, header_type>::value == true) {
+        return &(parser->header());
+      }
+    } else {
+      // continue walking through instances until active one is found
+      return get_if<U, T, N - 1>(instances);
+    }
+  }
+  return nullptr;
+}
+
 } // namespace raw_parser
 
 /// @class RawParser parser for the O2 raw data
@@ -240,12 +310,17 @@ ConcreteParserVariants<PageSize> create(T const* buffer, size_t size)
 ///       std::cout << "Iterating block of length " << it.length() << std::endl;
 ///       auto dataptr = it.data();
 ///     }
+///
+/// TODO:
+/// - iterators are not independent at the moment and this can cause conflicts, this must be
+///   improved
 template <size_t MAX_SIZE = 8192>
 class RawParser
 {
  public:
   using buffer_type = unsigned char;
   size_t max_size = MAX_SIZE;
+  using self_type = RawParser<MAX_SIZE>;
 
   RawParser() = delete;
 
@@ -262,7 +337,11 @@ class RawParser
   template <typename Processor>
   void parse(Processor&& processor)
   {
-    return std::visit([&processor](auto& parser) { return parser.parse(processor); }, mParser);
+    constexpr size_t NofAlternatives = std::variant_size_v<decltype(mParser)>;
+    static_assert(NofAlternatives == 2);
+    raw_parser::walk_parse<NofAlternatives>(mParser, processor, mParser.index());
+    // it turned out that using a iterative function is faster than using std::visit
+    //std::visit([&processor](auto& parser) { return parser.parse(processor); }, mParser);
   }
 
   /// Reset parser and set position to beginning of buffer
@@ -353,20 +432,15 @@ class RawParser
     /// get header as specific type
     /// @return pointer to header of the specified type, or nullptr if type does not match to actual type
     template <typename U>
-    U const* as() const
+    U const* get_if() const
     {
-      return std::visit([](auto& parser) {
-        using header_type = typename std::remove_reference<decltype(parser)>::type::header_type;
-        if constexpr (std::is_same<U, header_type>::value == true) {
-          U const* h = &parser.header();
-          // FIXME: does not want to compile when return ing the pointer
-          throw std::runtime_error("code path not yet implemented");
-          return nullptr;
-        } else {
-          return nullptr;
-        }
-      },
-                        mParser);
+      return raw_parser::get_if<U>(mParser);
+    }
+
+    friend std::ostream& operator<<(std::ostream& os, self_type const& it)
+    {
+      std::visit([&os](auto& parser) { return parser.format(os); }, it.mParser);
+      return os;
     }
 
    private:
@@ -384,6 +458,20 @@ class RawParser
   const_iterator end()
   {
     return const_iterator(mParser, -1);
+  }
+
+  friend std::ostream& operator<<(std::ostream& os, self_type const& parser)
+  {
+    std::visit([&os](auto& parser) { return parser.format(os, raw_parser::FormatSpec::Info, "\n"); }, parser.mParser);
+    std::visit([&os](auto& parser) { return parser.format(os, raw_parser::FormatSpec::TableHeader); }, parser.mParser);
+    // FIXME: need to decide what kind of information we want to have in the printout
+    // for the moment its problematic, because the parser has only one variable determining the position and all
+    // iterators work with the same instance which is asking for conflicts
+    // this needs to be changed in order to have fully independent iterators over the same constant buffer
+    //for (auto it = parser.begin(), end = parser.end(); it != end; ++it) {
+    //  os << "\n" << it;
+    //}
+    return os;
   }
 
  private:

--- a/Framework/Utils/src/RawParser.cxx
+++ b/Framework/Utils/src/RawParser.cxx
@@ -1,0 +1,67 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   RawParser.cxx
+/// @author Matthias Richter
+/// @since  2019-10-15
+/// @brief  Generic parser for consecutive raw pages
+
+#include "DPLUtils/RawParser.h"
+#include "fmt/format.h"
+#include <iostream>
+
+namespace o2::framework::raw_parser
+{
+
+const char* RDHFormatter<V5>::sFormatString = "{:>5} {:>4} {:>4} {:>4} {:>3} {:>3} {:>3}  {:>1}";
+void RDHFormatter<V5>::apply(std::ostream& os, V5 const& header, FormatSpec choice, const char* delimiter)
+{
+  if (choice == FormatSpec::Info) {
+    os << "RDH v5";
+  } else if (choice == FormatSpec::TableHeader) {
+    os << fmt::format(sFormatString, "PkC", "pCnt", "fId", "Mem", "CRU", "EP", "LID", "s");
+  } else if (choice == FormatSpec::Entry) {
+    os << fmt::format(sFormatString,
+                      header.packetCounter,
+                      header.pageCnt,
+                      header.feeId,
+                      header.memorySize,
+                      header.cruID,
+                      header.endPointID,
+                      header.linkID,
+                      header.stop);
+  }
+  os << delimiter;
+}
+
+const char* RDHFormatter<V4>::sFormatString = "{:>5} {:>4} {:>4} {:>4} {:>3} {:>3} {:>3} {:>10} {:>5}  {:>1}";
+void RDHFormatter<V4>::apply(std::ostream& os, V4 const& header, FormatSpec choice, const char* delimiter)
+{
+  if (choice == FormatSpec::Info) {
+    os << "RDH v4";
+  } else if (choice == FormatSpec::TableHeader) {
+    os << fmt::format(sFormatString, "PkC", "pCnt", "fId", "Mem", "CRU", "EP", "LID", "s");
+  } else if (choice == FormatSpec::Entry) {
+    os << fmt::format(sFormatString,
+                      header.packetCounter,
+                      header.pageCnt,
+                      header.feeId,
+                      header.memorySize,
+                      header.cruID,
+                      header.endPointID,
+                      header.linkID,
+                      header.heartbeatOrbit,
+                      header.heartbeatBC,
+                      header.stop);
+  }
+  os << delimiter;
+}
+
+} // namespace o2::framework::raw_parser

--- a/Framework/Utils/src/raw-parser.cxx
+++ b/Framework/Utils/src/raw-parser.cxx
@@ -41,8 +41,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
     AlgorithmSpec{[](InitContext& setup) { return adaptStateless([](InputRecord& inputs, DataAllocator& outputs) {
                                              for (auto& input : inputs) {
                                                const auto* dh = DataRefUtils::getHeader<o2::header::DataHeader*>(input);
-                                               LOG(INFO) << dh->dataOrigin.as<std::string>() << "/" << dh->dataDescription.as<std::string>() << "/"
-                                                         << dh->subSpecification << " payload size " << dh->payloadSize;
+                                               LOG(INFO) << *(input.spec) << " payload size " << dh->payloadSize;
 
                                                // there is a bug in InpuRecord::get for vectors of simple types, not catched in
                                                // DataAllocator unit test
@@ -51,8 +50,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
                                                try {
                                                  o2::framework::RawParser parser(input.payload, dh->payloadSize);
 
+                                                 LOG(INFO) << parser << std::endl;
                                                  for (auto it = parser.begin(), end = parser.end(); it != end; ++it) {
-                                                   LOG(INFO) << "Iterating block of length " << it.length() << std::endl;
+                                                   LOG(INFO) << it << ": block length " << it.length() << std::endl;
                                                  }
                                                } catch (const std::runtime_error& e) {
                                                  LOG(ERROR) << "can not create raw parser form input data";

--- a/Framework/Utils/test/benchmark_RawParser.cxx
+++ b/Framework/Utils/test/benchmark_RawParser.cxx
@@ -1,0 +1,94 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include <benchmark/benchmark.h>
+
+#include "DPLUtils/RawParser.h"
+
+using namespace o2::framework;
+
+class TestPages
+{
+ public:
+  using V4 = o2::header::RAWDataHeaderV4;
+  static constexpr size_t MaxNPages = 256 * 1024;
+  static constexpr size_t PageSize = 8192;
+  static constexpr size_t PageDataSize = PageSize - sizeof(V4);
+  struct RawPage {
+    V4 rdh;
+    char data[PageDataSize];
+  };
+  static_assert(sizeof(RawPage) == PageSize);
+
+  TestPages()
+    : mPages(MaxNPages)
+  {
+    for (int pageNo = 0; pageNo < mPages.size(); pageNo++) {
+      mPages[pageNo].rdh.version = 4;
+      mPages[pageNo].rdh.headerSize = sizeof(V4);
+      mPages[pageNo].rdh.offsetToNext = PageSize;
+      auto* data = reinterpret_cast<size_t*>(&mPages[pageNo].data);
+      *data = pageNo;
+    }
+  }
+
+  const char* data() const
+  {
+    return reinterpret_cast<const char*>(mPages.data());
+  }
+
+  size_t size() const
+  {
+    return mPages.size() * sizeof(decltype(mPages)::value_type);
+  }
+
+ private:
+  std::vector<RawPage> mPages;
+};
+
+TestPages gPages;
+
+static void BM_RawParserAuto(benchmark::State& state)
+{
+  size_t nofPages = state.range(0);
+  if (nofPages > TestPages::MaxNPages) {
+    return;
+  }
+  using Parser = RawParser<TestPages::PageSize>;
+  Parser parser(reinterpret_cast<const char*>(gPages.data()), nofPages * TestPages::PageSize);
+  size_t count = 0;
+  auto processor = [&count](auto data, size_t length) {
+    count++;
+  };
+  for (auto _ : state) {
+    parser.parse(processor);
+  }
+}
+
+static void BM_RawParserV4(benchmark::State& state)
+{
+  size_t nofPages = state.range(0);
+  if (nofPages > TestPages::MaxNPages) {
+    return;
+  }
+  using Parser = raw_parser::ConcreteRawParser<TestPages::V4, TestPages::PageSize>;
+  Parser parser(reinterpret_cast<const char*>(gPages.data()), nofPages * TestPages::PageSize);
+  size_t count = 0;
+  auto processor = [&count](auto data, size_t length) {
+    count++;
+  };
+  for (auto _ : state) {
+    parser.parse(processor);
+  }
+}
+
+BENCHMARK(BM_RawParserV4)->Arg(1)->Arg(8)->Arg(256)->Arg(1024)->Arg(16 * 1024)->Arg(256 * 1024);
+BENCHMARK(BM_RawParserAuto)->Arg(1)->Arg(8)->Arg(256)->Arg(1024)->Arg(16 * 1024)->Arg(256 * 1024);
+
+BENCHMARK_MAIN();

--- a/Framework/Utils/test/test_RawParser.cxx
+++ b/Framework/Utils/test/test_RawParser.cxx
@@ -27,9 +27,12 @@ BOOST_AUTO_TEST_CASE(test_RawParser)
   std::array<unsigned char, NofPages * PageSize> buffer;
   for (int pageNo = 0; pageNo < buffer.size() / PageSize; pageNo++) {
     auto* rdh = reinterpret_cast<V5*>(buffer.data() + pageNo * PageSize);
-    rdh->version = 4;
+    rdh->version = 5;
     rdh->headerSize = sizeof(V5);
     rdh->offsetToNext = PageSize;
+    rdh->pageCnt = NofPages;
+    rdh->packetCounter = pageNo;
+    rdh->stop = pageNo + 1 == NofPages;
     auto* data = reinterpret_cast<size_t*>(buffer.data() + pageNo * PageSize + rdh->headerSize);
     *data = pageNo;
   }
@@ -47,13 +50,14 @@ BOOST_AUTO_TEST_CASE(test_RawParser)
 
   parser.reset();
 
+  std::cout << parser << std::endl;
   count = 0;
   for (auto it = parser.begin(), end = parser.end(); it != end; ++it, ++count) {
     BOOST_CHECK(it.length() == PageSize - sizeof(V5));
     BOOST_CHECK(*reinterpret_cast<size_t const*>(it.data()) == count);
-    //BOOST_CHECK(it.as<V5>() != nullptr);
-    //BOOST_CHECK(it.as<V4>() == nullptr);
-    std::cout << "Iterating block of length " << it.length() << std::endl;
+    BOOST_CHECK(it.get_if<V5>() != nullptr);
+    BOOST_CHECK(it.get_if<V4>() == nullptr);
+    std::cout << it << ": block length " << it.length() << std::endl;
   }
 }
 


### PR DESCRIPTION
- Adding benchmark
- Using iterative approach to forward to concrete instance
  slightly faster than std::visit
- Introducing get_if method for iterator to retrieve a concrete RDH
- Adding stream output operator
- Printing RDH properties in the raw parser example process