### PR TITLE
DPL Inputrecord: fixing compilation error when trying to use get<std::vector<pod>>

### DIFF
--- a/Framework/Core/include/Framework/InputRecord.h
+++ b/Framework/Core/include/Framework/InputRecord.h
@@ -314,14 +314,18 @@ class InputRecord
           /// container, C++11 and beyond will implicitly apply return value optimization.
           /// @return std container object
           using NonConstT = typename std::remove_const<T>::type;
-          // we expect the unique_ptr to hold an object, exception should have been thrown
-          // otherwise
-          auto object = DataRefUtils::as<NonConstT>(ref);
-          // need to swap the content of the deserialized container to a local variable to force return
-          // value optimization
-          T container;
-          std::swap(const_cast<NonConstT&>(container), *object);
-          return container;
+          if constexpr (is_specialization<T, ROOTSerialized>::value == true || has_root_dictionary<T>::value == true) {
+            // we expect the unique_ptr to hold an object, exception should have been thrown
+            // otherwise
+            auto object = DataRefUtils::as<NonConstT>(ref);
+            // need to swap the content of the deserialized container to a local variable to force return
+            // value optimization
+            T container;
+            std::swap(const_cast<NonConstT&>(container), *object);
+            return container;
+          } else {
+            throw std::runtime_error("No supported conversion function for ROOT serialized message");
+          }
         } else {
           throw std::runtime_error("Attempt to extract object from message with unsupported serialization type");
         }

--- a/Framework/Core/test/test_DataAllocator.cxx
+++ b/Framework/Core/test/test_DataAllocator.cxx
@@ -27,6 +27,7 @@
 #include <vector>
 #include <chrono>
 #include <cstring>
+#include <utility> // std::declval
 #include <TNamed.h>
 
 using namespace o2::framework;
@@ -141,6 +142,11 @@ DataProcessorSpec getSourceSpec()
     pmrvec.reserve(100);
     pmrvec.emplace_back(o2::test::TriviallyCopyable{1, 2, 3});
     pc.outputs().adoptContainer(pmrOutputSpec, std::move(pmrvec));
+
+    // make a vector of POD and set some data
+    pc.outputs().make<std::vector<int>>(OutputRef{"podvector"}) = {10, 21, 42};
+
+    // now we are done and signal this downstream
     pc.services().get<ControlService>().endOfStream();
     pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
 
@@ -169,7 +175,8 @@ DataProcessorSpec getSourceSpec()
                             OutputSpec{"TST", "ROOTVECTOR", 0, Lifetime::Timeframe},
                             OutputSpec{"TST", "ROOTSERLZDVEC", 0, Lifetime::Timeframe},
                             OutputSpec{"TST", "ROOTSERLZDVEC2", 0, Lifetime::Timeframe},
-                            OutputSpec{"TST", "PMRTESTVECTOR", 0, Lifetime::Timeframe}},
+                            OutputSpec{"TST", "PMRTESTVECTOR", 0, Lifetime::Timeframe},
+                            OutputSpec{{"podvector"}, "TST", "PODVECTOR", 0, Lifetime::Timeframe}},
                            AlgorithmSpec(processingFct)};
 }
 
@@ -316,6 +323,14 @@ DataProcessorSpec getSinkSpec()
     auto header = o2::header::get<const o2::header::DataHeader*>(dataref.header);
     ASSERT_ERROR((header->payloadSize == sizeof(o2::test::TriviallyCopyable)));
 
+    LOG(INFO) << "extracting POD vector";
+    // TODO: use the ReturnType helper once implemented
+    //InputRecord::ReturnType<std::vector<int>> podvector;
+    decltype(std::declval<InputRecord>().get<std::vector<int>>(DataRef{nullptr, nullptr, nullptr})) podvector;
+    podvector = pc.inputs().get<std::vector<int>>("inputPODvector");
+    ASSERT_ERROR(podvector.size() == 3);
+    ASSERT_ERROR(podvector[0] == 10 && podvector[1] == 21 && podvector[2] == 42);
+
     pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
   };
 
@@ -336,6 +351,7 @@ DataProcessorSpec getSinkSpec()
                             InputSpec{"input14", "TST", "ROOTSERLZBLOBJ", 0, Lifetime::Timeframe},
                             InputSpec{"input15", "TST", "ROOTSERLZBLVECT", 0, Lifetime::Timeframe},
                             InputSpec{"inputPMR", "TST", "PMRTESTVECTOR", 0, Lifetime::Timeframe},
+                            InputSpec{"inputPODvector", "TST", "PODVECTOR", 0, Lifetime::Timeframe},
                             InputSpec{"inputMP", ConcreteDataTypeMatcher{"TST", "MULTIPARTS"}, Lifetime::Timeframe}},
                            Outputs{OutputSpec{"TST", "MSGABLVECTORCPY", 0, Lifetime::Timeframe}},
                            AlgorithmSpec(processingFct)};


### PR DESCRIPTION
There was compilation problem when using the InputRecord API with vectors of
PODs. Adding also a test case to the unit test.