### PR TITLE
remove double checks to speedup field evaluation

### DIFF
--- a/Common/MathUtils/include/MathUtils/Chebyshev3DCalc.h
+++ b/Common/MathUtils/include/MathUtils/Chebyshev3DCalc.h
@@ -216,20 +216,14 @@ inline Float_t Chebyshev3DCalc::chebyshevEvaluation1D(Float_t x, const Float_t* 
 /// VERY IMPORTANT: par must contain the function arguments ALREADY MAPPED to [-1:1] interval
 inline Float_t Chebyshev3DCalc::Eval(const Float_t* par) const
 {
-  if (!mNumberOfRows) {
-    return 0.;
-  }
-  int ncfRC;
   for (int id0 = mNumberOfRows; id0--;) {
     int nCLoc = mNumberOfColumnsAtRow[id0]; // number of significant coefs on this row
     int col0 = mColumnAtRowBeginning[id0];  // beginning of local column in the 2D boundary matrix
     for (int id1 = nCLoc; id1--;) {
       int id = id1 + col0;
-      mTemporaryCoefficients2D[id1] = (ncfRC = mCoefficientBound2D0[id])
-                                        ? chebyshevEvaluation1D(par[2], mCoefficients + mCoefficientBound2D1[id], ncfRC)
-                                        : 0.0;
+      mTemporaryCoefficients2D[id1] = chebyshevEvaluation1D(par[2], mCoefficients + mCoefficientBound2D1[id], mCoefficientBound2D0[id]);
     }
-    mTemporaryCoefficients1D[id0] = nCLoc > 0 ? chebyshevEvaluation1D(par[1], mTemporaryCoefficients2D, nCLoc) : 0.0;
+    mTemporaryCoefficients1D[id0] = chebyshevEvaluation1D(par[1], mTemporaryCoefficients2D, nCLoc);
   }
   return chebyshevEvaluation1D(par[0], mTemporaryCoefficients1D, mNumberOfRows);
 }
@@ -238,20 +232,14 @@ inline Float_t Chebyshev3DCalc::Eval(const Float_t* par) const
 /// VERY IMPORTANT: par must contain the function arguments ALREADY MAPPED to [-1:1] interval
 inline Double_t Chebyshev3DCalc::Eval(const Double_t* par) const
 {
-  if (!mNumberOfRows) {
-    return 0.;
-  }
-  int ncfRC;
   for (int id0 = mNumberOfRows; id0--;) {
     int nCLoc = mNumberOfColumnsAtRow[id0]; // number of significant coefs on this row
     int col0 = mColumnAtRowBeginning[id0];  // beginning of local column in the 2D boundary matrix
     for (int id1 = nCLoc; id1--;) {
       int id = id1 + col0;
-      mTemporaryCoefficients2D[id1] = (ncfRC = mCoefficientBound2D0[id])
-                                        ? chebyshevEvaluation1D(par[2], mCoefficients + mCoefficientBound2D1[id], ncfRC)
-                                        : 0.0;
+      mTemporaryCoefficients2D[id1] = chebyshevEvaluation1D(par[2], mCoefficients + mCoefficientBound2D1[id], mCoefficientBound2D0[id]);
     }
-    mTemporaryCoefficients1D[id0] = nCLoc > 0 ? chebyshevEvaluation1D(par[1], mTemporaryCoefficients2D, nCLoc) : 0.0;
+    mTemporaryCoefficients1D[id0] = chebyshevEvaluation1D(par[1], mTemporaryCoefficients2D, nCLoc);
   }
   return chebyshevEvaluation1D(par[0], mTemporaryCoefficients1D, mNumberOfRows);
 }


### PR DESCRIPTION
Hi @shahor02 ,

As far as I understand, those test are not needed because the same tests are already done either in the for loop (id0-- is evaluated before id0 is decremented) or at the beginning of the function chebyshevEvaluation1D(...). If this is correct, I propose to remove them.

By removing those tests, I speedup the MCH tracking by about 15% (for the dimuon PbPb events that I use for testing), because most of the time (~80%) is in fact spent in the evaluation of the magnetic field when propagating the tracks. Actually a large part of the improvement with the new algorithm comes from the fact that it reduces the number of track propagation (by reducing the number of combinations considered in the process and by avoiding to go back and forth).