### PR TITLE
DPL: Support for Run2ESDConverter a separate workflow

### DIFF
--- a/Framework/AnalysisTutorial/src/dynamicColumns.cxx
+++ b/Framework/AnalysisTutorial/src/dynamicColumns.cxx
@@ -21,7 +21,7 @@ DECLARE_SOA_COLUMN(Alpha, alpha, float, "fAlpha");
 DECLARE_SOA_DYNAMIC_COLUMN(Eta, eta, [](float tgl) { return log(tan(0.25 * M_PI - 0.5 * atan(tgl))); });
 DECLARE_SOA_DYNAMIC_COLUMN(Phi, phi, [](float snp, float alpha) { return asin(snp) + alpha + M_PI; });
 } // namespace etaphi
-DECLARE_SOA_TABLE(EtaPhis, "RN2", "ETAPHI",
+DECLARE_SOA_TABLE(EtaPhis, "AOD", "ETAPHI",
                   etaphi::Tgl, etaphi::Snp, etaphi::Alpha,
                   etaphi::Eta<etaphi::Tgl>,
                   etaphi::Phi<etaphi::Snp, etaphi::Alpha>);

--- a/Framework/AnalysisTutorial/src/filters.cxx
+++ b/Framework/AnalysisTutorial/src/filters.cxx
@@ -18,7 +18,7 @@ namespace etaphi
 DECLARE_SOA_COLUMN(Eta, eta, float, "fEta");
 DECLARE_SOA_COLUMN(Phi, phi, float, "fPhi");
 } // namespace etaphi
-DECLARE_SOA_TABLE(EtaPhi, "RN2", "ETAPHI",
+DECLARE_SOA_TABLE(EtaPhi, "AOD", "ETAPHI",
                   etaphi::Eta, etaphi::Phi);
 } // namespace o2::aod
 

--- a/Framework/AnalysisTutorial/src/newCollections.cxx
+++ b/Framework/AnalysisTutorial/src/newCollections.cxx
@@ -18,7 +18,7 @@ namespace etaphi
 DECLARE_SOA_COLUMN(Eta, eta, float, "fEta");
 DECLARE_SOA_COLUMN(Phi, phi, float, "fPhi");
 } // namespace etaphi
-DECLARE_SOA_TABLE(EtaPhi, "RN2", "ETAPHI",
+DECLARE_SOA_TABLE(EtaPhi, "AOD", "ETAPHI",
                   etaphi::Eta, etaphi::Phi);
 } // namespace o2::aod
 

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -68,7 +68,7 @@ DECLARE_SOA_COLUMN(Lenght, lenght, float, "fLength");
 
 } // namespace track
 
-DECLARE_SOA_TABLE(Tracks, "RN2", "TRACKPAR",
+DECLARE_SOA_TABLE(Tracks, "AOD", "TRACKPAR",
                   track::CollisionId, track::X, track::Alpha,
                   track::Y, track::Z, track::Snp, track::Tgl,
                   track::Signed1Pt,
@@ -76,13 +76,13 @@ DECLARE_SOA_TABLE(Tracks, "RN2", "TRACKPAR",
                   track::Eta<track::Tgl>,
                   track::Pt<track::Signed1Pt>);
 
-DECLARE_SOA_TABLE(TracksCov, "RN2", "TRACKPARCOV",
+DECLARE_SOA_TABLE(TracksCov, "AOD", "TRACKPARCOV",
                   track::CYY, track::CZY, track::CZZ, track::CSnpY,
                   track::CSnpZ, track::CSnpSnp, track::CTglY,
                   track::CTglZ, track::CTglSnp, track::CTglTgl,
                   track::C1PtY, track::C1PtZ, track::C1PtSnp, track::C1PtTgl,
                   track::C1Pt21Pt2);
-DECLARE_SOA_TABLE(TracksExtra, "RN2", "TRACKEXTRA",
+DECLARE_SOA_TABLE(TracksExtra, "AOD", "TRACKEXTRA",
                   track::TPCInnerParam, track::Flags, track::ITSClusterMap,
                   track::TPCNCls, track::TRDNTracklets, track::ITSChi2NCl,
                   track::TPCchi2Ncl, track::TRDchi2, track::TOFchi2,
@@ -102,7 +102,7 @@ DECLARE_SOA_COLUMN(CellType, cellType, int8_t, "fCellType");
 DECLARE_SOA_COLUMN(CaloType, caloType, int8_t, "fType");
 } // namespace calo
 
-DECLARE_SOA_TABLE(Calos, "RN2", "CALO",
+DECLARE_SOA_TABLE(Calos, "AOD", "CALO",
                   calo::CollisionId, calo::CellNumber, calo::Amplitude, calo::Time, calo::CellType, calo::CaloType);
 using Calo = Calos::iterator;
 
@@ -117,7 +117,7 @@ DECLARE_SOA_COLUMN(Triggerbits, triggerbits, int32_t, "fTriggerBits");
 DECLARE_SOA_COLUMN(CaloType, caloType, int8_t, "fType");
 } // namespace calotrigger
 
-DECLARE_SOA_TABLE(CaloTriggers, "RN2", "CALOTRIGGER",
+DECLARE_SOA_TABLE(CaloTriggers, "AOD", "CALOTRIGGER",
                   calotrigger::CollisionId, calotrigger::FastorAbsId, calotrigger::L0Amplitude, calotrigger::L1Timesum, calotrigger::NL0Times, calotrigger::Triggerbits, calotrigger::CaloType);
 using CaloTrigger = CaloTriggers::iterator;
 
@@ -136,7 +136,7 @@ DECLARE_SOA_COLUMN(Chi2, chi2, float, "fChi2");
 DECLARE_SOA_COLUMN(Chi2MatchTrigger, chi2MatchTrigger, float, "fChi2MatchTrigger");
 } // namespace muon
 
-DECLARE_SOA_TABLE(Muons, "RN2", "MUON",
+DECLARE_SOA_TABLE(Muons, "AOD", "MUON",
                   muon::CollisionId, muon::InverseBendingMomentum,
                   muon::ThetaX, muon::ThetaY, muon::ZMu,
                   muon::BendingCoor, muon::NonBendingCoor,
@@ -149,7 +149,7 @@ DECLARE_SOA_COLUMN(CollisionId, collisionId, int, "fIDvz");
 // FIXME: add missing arrays...
 } // namespace vzero
 
-DECLARE_SOA_TABLE(VZeros, "RN2", "VZERO", vzero::CollisionId);
+DECLARE_SOA_TABLE(VZeros, "AOD", "VZERO", vzero::CollisionId);
 using VZero = VZeros::iterator;
 
 namespace collision
@@ -181,7 +181,7 @@ DECLARE_SOA_COLUMN(OrbitNum, orbitnum, int, "orbitnum"); // LHC orbit number, Al
 DECLARE_SOA_COLUMN(TriggerMask, triggermask, int, "triggermask"); // Trigger mask, AliESDHeader.h, ULong64_t
 } // namespace collision
 
-DECLARE_SOA_TABLE(Collisions, "RN2", "COLLISION", collision::TimeframeID, collision::NumTracks, collision::VtxID, collision::PosX, collision::PosY, collision::PosZ, collision::CovXX, collision::CovXY, collision::CovXZ, collision::CovYX, collision::CovYY, collision::CovYZ, collision::CovZX, collision::CovZY, collision::CovZZ, collision::Chi2, collision::BCNum, collision::OrbitNum, collision::TriggerMask);
+DECLARE_SOA_TABLE(Collisions, "AOD", "COLLISION", collision::TimeframeID, collision::NumTracks, collision::VtxID, collision::PosX, collision::PosY, collision::PosZ, collision::CovXX, collision::CovXY, collision::CovXZ, collision::CovYX, collision::CovYY, collision::CovYZ, collision::CovZX, collision::CovZY, collision::CovZZ, collision::Chi2, collision::BCNum, collision::OrbitNum, collision::TriggerMask);
 
 using Collision = Collisions::iterator;
 
@@ -190,7 +190,7 @@ namespace timeframe
 DECLARE_SOA_COLUMN(Timestamp, timestamp, uint64_t, "timestamp");
 } // namespace timeframe
 
-DECLARE_SOA_TABLE(Timeframes, "RN2", "TIMEFRAME",
+DECLARE_SOA_TABLE(Timeframes, "AOD", "TIMEFRAME",
                   timeframe::Timestamp);
 using Timeframe = Timeframes::iterator;
 

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -193,7 +193,7 @@ struct AnalysisDataProcessorBuilder {
     using metadata = typename aod::MetadataTrait<std::decay_t<Arg>>::metadata;
     static_assert(std::is_same_v<metadata, void> == false,
                   "Could not find metadata. Did you register your type?");
-    inputs.push_back({metadata::label(), "RN2", metadata::description()});
+    inputs.push_back({metadata::label(), "AOD", metadata::description()});
   }
 
   template <typename T>

--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -166,7 +166,7 @@ AlgorithmSpec AODReaderHelpers::run2ESDConverterCallback()
       filenames.push_back(filename);
     }
 
-    uint64_t readMask = calculateReadMask(spec.outputs, header::DataOrigin{"RN2"});
+    uint64_t readMask = calculateReadMask(spec.outputs, header::DataOrigin{"AOD"});
     auto counter = std::make_shared<unsigned int>(0);
     return adaptStateless([readMask,
                            counter,
@@ -220,21 +220,21 @@ AlgorithmSpec AODReaderHelpers::run2ESDConverterCallback()
           batch->schema()->metadata()->ToUnorderedMap(&meta);
           std::shared_ptr<arrow::ipc::RecordBatchWriter> writer;
           if (meta["description"] == "TRACKPAR" && (readMask & AODTypeMask::Tracks)) {
-            writer = outputs.make<arrow::ipc::RecordBatchWriter>(Output{"RN2", "TRACKPAR"}, batch->schema());
+            writer = outputs.make<arrow::ipc::RecordBatchWriter>(Output{"AOD", "TRACKPAR"}, batch->schema());
           } else if (meta["description"] == "TRACKPARCOV" && (readMask & AODTypeMask::TracksCov)) {
-            writer = outputs.make<arrow::ipc::RecordBatchWriter>(Output{"RN2", "TRACKPARCOV"}, batch->schema());
+            writer = outputs.make<arrow::ipc::RecordBatchWriter>(Output{"AOD", "TRACKPARCOV"}, batch->schema());
           } else if (meta["description"] == "TRACKEXTRA" && (readMask & AODTypeMask::TracksExtra)) {
-            writer = outputs.make<arrow::ipc::RecordBatchWriter>(Output{"RN2", "TRACKEXTRA"}, batch->schema());
+            writer = outputs.make<arrow::ipc::RecordBatchWriter>(Output{"AOD", "TRACKEXTRA"}, batch->schema());
           } else if (meta["description"] == "CALO" && (readMask & AODTypeMask::Calo)) {
-            writer = outputs.make<arrow::ipc::RecordBatchWriter>(Output{"RN2", "CALO"}, batch->schema());
+            writer = outputs.make<arrow::ipc::RecordBatchWriter>(Output{"AOD", "CALO"}, batch->schema());
           } else if (meta["description"] == "MUON" && (readMask & AODTypeMask::Muon)) {
-            writer = outputs.make<arrow::ipc::RecordBatchWriter>(Output{"RN2", "MUON"}, batch->schema());
+            writer = outputs.make<arrow::ipc::RecordBatchWriter>(Output{"AOD", "MUON"}, batch->schema());
           } else if (meta["description"] == "VZERO" && (readMask & AODTypeMask::VZero)) {
-            writer = outputs.make<arrow::ipc::RecordBatchWriter>(Output{"RN2", "VZERO"}, batch->schema());
+            writer = outputs.make<arrow::ipc::RecordBatchWriter>(Output{"AOD", "VZERO"}, batch->schema());
           } else if (meta["description"] == "COLLISION" && (readMask & AODTypeMask::Collisions)) {
-            writer = outputs.make<arrow::ipc::RecordBatchWriter>(Output{"RN2", "COLLISION"}, batch->schema());
+            writer = outputs.make<arrow::ipc::RecordBatchWriter>(Output{"AOD", "COLLISION"}, batch->schema());
           } else if (meta["description"] == "TIMEFRAME" && (readMask & AODTypeMask::Timeframe)) {
-            writer = outputs.make<arrow::ipc::RecordBatchWriter>(Output{"RN2", "TIMEFRAME"}, batch->schema());
+            writer = outputs.make<arrow::ipc::RecordBatchWriter>(Output{"AOD", "TIMEFRAME"}, batch->schema());
           } else {
             continue;
           }

--- a/Framework/Core/test/test_WorkflowHelpers.cxx
+++ b/Framework/Core/test/test_WorkflowHelpers.cxx
@@ -310,7 +310,7 @@ BOOST_AUTO_TEST_CASE(TestGraphConstruction)
   std::vector<ConcreteDataMatcher> expectedMatchers = {
     ConcreteDataMatcher{"TST", "A", 0},
     ConcreteDataMatcher{"TST", "B", 0},
-    ConcreteDataMatcher{"DPL", "ENUM", 2}, // Enums value
+    ConcreteDataMatcher{"DPL", "ENUM", 1}, // Enums value
   };
 
   std::vector<Lifetime> expectedLifetimes = {

--- a/Framework/TestWorkflows/src/o2SimpleTracksAnalysis.cxx
+++ b/Framework/TestWorkflows/src/o2SimpleTracksAnalysis.cxx
@@ -50,14 +50,14 @@ WorkflowSpec defineDataProcessing(ConfigContext const& specs)
       // The name of my analysis
       "tracks-analysis",
       Inputs{
-        // Dangling inputs of type RN2 will be automatically picked up by DPL
-        // and an extra reader device will be instanciated to convert them from
-        // RUN2 ESDs. In this particular case the signature RN2/TRACKPAR is
+        // Dangling inputs of type AOD will be automatically picked up by DPL
+        // and an extra reader device will be instanciated to read them from
+        // file. In this particular case the signature AOD/TRACKPAR is
         // associated to the basic trajectory parameters for a track described
         // in Ruben's table. The first string is just a label so that the
         // algorithm can be in principle be reused for different kind of
         // tracks.
-        InputSpec{"tracks", "RN2", "TRACKPAR"},
+        InputSpec{"tracks", "AOD", "TRACKPAR"},
       },
       // No outputs for the time being.
       Outputs{

--- a/Framework/Utils/CMakeLists.txt
+++ b/Framework/Utils/CMakeLists.txt
@@ -29,6 +29,12 @@ o2_add_executable(raw-parser
                   SOURCES src/raw-parser.cxx
                   PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils)
 
+# Converter can now be a separate workflow which we merge if needed
+o2_add_executable(esd-2-arrow-converter
+                  COMPONENT_NAME dpl
+                  SOURCES src/esd-2-arrow-converter.cxx
+                  PUBLIC_LINK_LIBRARIES O2::Framework)
+
 o2_add_test(DPLBroadcasterMerger
             SOURCES test/test_DPLBroadcasterMerger.cxx src/Utils.cxx
                     test/DPLBroadcasterMerger.cxx src/DPLMerger.cxx

--- a/Framework/Utils/src/esd-2-arrow-converter.cxx
+++ b/Framework/Utils/src/esd-2-arrow-converter.cxx
@@ -1,0 +1,58 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicy.h"
+#include "Framework/DeviceSpec.h"
+#include "Framework/AODReaderHelpers.h"
+
+using namespace o2::framework;
+
+void customize(std::vector<ConfigParamSpec>& options)
+{
+  //  options.push_back(ConfigParamSpec{"anInt", VariantType::Int, 1, {"an int option"}});
+  //  options.push_back(ConfigParamSpec{"aFloat", VariantType::Float, 2.0f, {"a float option"}});
+  //  options.push_back(ConfigParamSpec{"aDouble", VariantType::Double, 3., {"a double option"}});
+  //  options.push_back(ConfigParamSpec{"aString", VariantType::String, "foo", {"a string option"}});
+  //  options.push_back(ConfigParamSpec{"aBool", VariantType::Bool, true, {"a boolean option"}});
+}
+
+#include "Framework/runDataProcessing.h"
+
+using namespace o2::framework;
+
+// This is how you can define your processing in a declarative way
+WorkflowSpec defineDataProcessing(ConfigContext const& specs)
+{
+  std::vector<OutputSpec> outputs = {
+    OutputSpec{"AOD", "TRACKPAR"},
+    OutputSpec{"AOD", "TRACKPARCOV"},
+    OutputSpec{"AOD", "TRACKEXTRA"},
+    OutputSpec{"AOD", "CALO"},
+    OutputSpec{"AOD", "MUON"},
+    OutputSpec{"AOD", "VZERO"},
+    OutputSpec{"AOD", "COLLISION"},
+    OutputSpec{"AOD", "TIMEFRAME"}};
+  int separateEnumerations = 0;
+  DataProcessorSpec run2Converter{
+    "esd-2-arrow-converter",
+    {InputSpec{"enumeration",
+               "DPL",
+               "ENUM",
+               static_cast<DataAllocator::SubSpecificationType>(separateEnumerations++), Lifetime::Enumeration}},
+    outputs,
+    readers::AODReaderHelpers::run2ESDConverterCallback(),
+    {ConfigParamSpec{"esd-file", VariantType::String, "AliESDs.root", {"Input ESD file"}},
+     ConfigParamSpec{"events", VariantType::Int, 0, {"Number of events to process (0 = all)"}},
+     ConfigParamSpec{"start-value-enumeration", VariantType::Int, 0, {"initial value for the enumeration"}},
+     ConfigParamSpec{"end-value-enumeration", VariantType::Int, -1, {"final value for the enumeration"}},
+     ConfigParamSpec{"step-value-enumeration", VariantType::Int, 1, {"step between one value and the other"}}}};
+
+  return {run2Converter};
+}


### PR DESCRIPTION
The idea is that we can use the workflow merging capabilities of
DPL to inject the converter via:

o2-dpl-esd-2-arrow-converter --esd-file AliESD.root | my-analysis-workflow