### PR TITLE
o2-sim: More robust communication (retry failed receive)

### DIFF
--- a/run/O2HitMerger.h
+++ b/run/O2HitMerger.h
@@ -65,6 +65,15 @@ namespace o2
 namespace devices
 {
 
+// signal handler
+void sighandler(int signal)
+{
+  if (signal == SIGSEGV) {
+    LOG(WARN) << "segmentation violation ... just exit without coredump in order not to hang";
+    raise(SIGKILL);
+  }
+}
+
 class O2HitMerger : public FairMQDevice
 {
 
@@ -101,6 +110,7 @@ class O2HitMerger : public FairMQDevice
   /// Overloads the InitTask() method of FairMQDevice
   void InitTask() final
   {
+    signal(SIGSEGV, sighandler);
     ROOT::EnableThreadSafety();
 
     std::string outfilename("o2sim_merged_hits.root"); // default name


### PR DESCRIPTION
Sometimes we seem to encounter "interrupted system calls"
in the request-reply pattern between particle server and worker.

This commit is trying to achieve a more robust handling of those cases.
Instead of simply exiting (and hanging) we try to read from the socket
again in the hope to recover...

We also change the default behaviour of segmentation violation signals
for the hit merger. Instead of producing a coredump we simply exit immediately
in order not to hang and produce zombie processes (which sometimes happens on MacOS).