### PR TITLE
BC duration changed from 25 ns to LHCBunchSpacingNS constant

### DIFF
--- a/Detectors/TOF/reconstruction/src/Clusterer.cxx
+++ b/Detectors/TOF/reconstruction/src/Clusterer.cxx
@@ -148,8 +148,8 @@ void Clusterer::buildCluster(Cluster& c, MCLabelContainer const* digitMCTruth)
   }
 
   c.setMainContributingChannel(mContributingDigit[0]->getChannel());
-  c.setTime(mContributingDigit[0]->getTDC() * Geo::TDCBIN + double(mContributingDigit[0]->getBC() * 25000.));    // time in ps (for now we assume it calibrated)
-  c.setTimeRaw(mContributingDigit[0]->getTDC() * Geo::TDCBIN + double(mContributingDigit[0]->getBC() * 25000.)); // time in ps (for now we assume it calibrated)
+  c.setTime(mContributingDigit[0]->getTDC() * Geo::TDCBIN + mContributingDigit[0]->getBC() * o2::constants::lhc::LHCBunchSpacingNS * 1E3);
+  c.setTimeRaw(mContributingDigit[0]->getTDC() * Geo::TDCBIN + mContributingDigit[0]->getBC() * o2::constants::lhc::LHCBunchSpacingNS * 1E3));
 
   c.setTot(mContributingDigit[0]->getTOT() * Geo::TOTBIN * 1E-3); // TOT in ns (for now we assume it calibrated)
   //setL0L1Latency(); // to be filled (maybe)

--- a/Detectors/TOF/reconstruction/src/Clusterer.cxx
+++ b/Detectors/TOF/reconstruction/src/Clusterer.cxx
@@ -149,7 +149,7 @@ void Clusterer::buildCluster(Cluster& c, MCLabelContainer const* digitMCTruth)
 
   c.setMainContributingChannel(mContributingDigit[0]->getChannel());
   c.setTime(mContributingDigit[0]->getTDC() * Geo::TDCBIN + mContributingDigit[0]->getBC() * o2::constants::lhc::LHCBunchSpacingNS * 1E3);
-  c.setTimeRaw(mContributingDigit[0]->getTDC() * Geo::TDCBIN + mContributingDigit[0]->getBC() * o2::constants::lhc::LHCBunchSpacingNS * 1E3));
+  c.setTimeRaw(mContributingDigit[0]->getTDC() * Geo::TDCBIN + mContributingDigit[0]->getBC() * o2::constants::lhc::LHCBunchSpacingNS * 1E3);
 
   c.setTot(mContributingDigit[0]->getTOT() * Geo::TOTBIN * 1E-3); // TOT in ns (for now we assume it calibrated)
   //setL0L1Latency(); // to be filled (maybe)


### PR DESCRIPTION
Rough hardcoded 25 ns bc duration changed to o2::constants::lhc::LHCBunchSpacingNS. Previous value resulted in a drop of the TOF matching efficiency after several orbits because TOF clusters get out of sync with ITS-TPC tracks for relatively large orbit counts. This fix recovers expected TOF matching efficiency for long periods. See attached.

![TOF_matching_efficiency](https://user-images.githubusercontent.com/11978853/69809884-f645a400-11ea-11ea-8954-1e839f8715f4.jpeg)
