### PR TITLE
First version of TPC QC Tracks task

### DIFF
--- a/Detectors/TPC/qc/CMakeLists.txt
+++ b/Detectors/TPC/qc/CMakeLists.txt
@@ -1,28 +1,29 @@
-#Copyright CERN and copyright holders of ALICE O2.This software is distributed
-#under the terms of the GNU General Public License v3(GPL Version 3), copied
-#verbatim in the file "COPYING".
+# Copyright CERN and copyright holders of ALICE O2. This software is distributed
+# under the terms of the GNU General Public License v3 (GPL Version 3), copied
+# verbatim in the file "COPYING".
 #
-#See http://alice-o2.web.cern.ch/license for full licensing information.
+# See http://alice-o2.web.cern.ch/license for full licensing information.
 #
-#In applying this license CERN does not waive the privileges and immunities
-#granted to it by virtue of its status as an Intergovernmental Organization or
-#submit itself to any jurisdiction.
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization or
+# submit itself to any jurisdiction.
 
 o2_add_library(TPCQC
                SOURCES src/PID.cxx
                        src/Helpers.cxx
                        src/TrackCuts.cxx
                        src/Clusters.cxx
+                       src/Tracks.cxx
                PUBLIC_LINK_LIBRARIES O2::TPCBase
                                      O2::DataFormatsTPC)
-
 
 
 o2_target_root_dictionary(TPCQC
                           HEADERS include/TPCQC/PID.h
                                   include/TPCQC/Helpers.h
                                   include/TPCQC/TrackCuts.h
-                                  include/TPCQC/Clusters.h)
+                                  include/TPCQC/Clusters.h
+                                  include/TPCQC/Tracks.h)
 
 o2_add_test(PID
             COMPONENT_NAME tpc
@@ -42,6 +43,12 @@ o2_add_test(Clusters
             SOURCES test/test_Clusters.cxx
             LABELS tpc)
 
+o2_add_test(Tracks
+            COMPONENT_NAME tpc
+            PUBLIC_LINK_LIBRARIES O2::TPCQC
+            SOURCES test/test_Tracks.cxx
+            LABELS tpc)
+
 o2_add_test_root_macro(macro/runPID.C
                        PUBLIC_LINK_LIBRARIES O2::TPCQC
                                              O2::DataFormatsTPC
@@ -54,3 +61,8 @@ o2_add_test_root_macro(macro/runClusters.C
                                              O2::TPCBase
                                              LABELS tpc)
 
+o2_add_test_root_macro(macro/runTracks.C
+                       PUBLIC_LINK_LIBRARIES O2::TPCQC
+                                             O2::DataFormatsTPC
+                                             O2::TPCBase
+                                             LABELS tpc)

--- a/Detectors/TPC/qc/include/TPCQC/Tracks.h
+++ b/Detectors/TPC/qc/include/TPCQC/Tracks.h
@@ -1,0 +1,83 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// @file   Tracks.h
+/// @author Stefan Heckel, sheckel@cern.ch
+///
+
+#ifndef AliceO2_TPC_QC_TRACKS_H
+#define AliceO2_TPC_QC_TRACKS_H
+
+#include <vector>
+#include <string_view>
+
+//root includes
+#include "TH1F.h"
+#include "TH2F.h"
+
+//o2 includes
+#include "DataFormatsTPC/Defs.h"
+
+namespace o2
+{
+namespace tpc
+{
+
+class TrackTPC;
+
+namespace qc
+{
+
+/// @brief Tracks quality control class
+///
+/// This class is used to extract track related variables
+/// from TrackTPC objects and store it in histograms.
+///
+/// origin: TPC
+/// @author Stefan Heckel, sheckel@cern.ch
+class Tracks
+{
+ public:
+  // default constructor
+  Tracks() = default;
+
+  /// bool extracts intormation from track and fills it to histograms
+  /// @return true if information can be extracted and filled to histograms
+  bool processTrack(const o2::tpc::TrackTPC& track);
+
+  /// Initialize all histograms
+  void initializeHistograms();
+
+  /// Reset all histograms
+  void resetHistograms();
+
+  /// Dump results to a file
+  void dumpToFile(std::string_view filename);
+
+  /// get 1D histograms
+  std::vector<TH1F>& getHistograms1D() { return mHist1D; }
+  const std::vector<TH1F>& getHistograms1D() const { return mHist1D; }
+
+  /// get 2D histograms
+  std::vector<TH2F>& getHistograms2D() { return mHist2D; }
+  const std::vector<TH2F>& getHistograms2D() const { return mHist2D; }
+
+ private:
+  std::vector<TH1F> mHist1D{}; ///< Initialize vector of 1D histograms
+  std::vector<TH2F> mHist2D{}; ///< Initialize vector of 2D histograms
+
+  ClassDefNV(Tracks, 1)
+};
+} // namespace qc
+} // namespace tpc
+} // namespace o2
+
+#endif

--- a/Detectors/TPC/qc/macro/runTracks.C
+++ b/Detectors/TPC/qc/macro/runTracks.C
@@ -1,0 +1,122 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// @file   runTracks.C
+/// @author Stefan Heckel, sheckel@cern.ch
+///
+
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include "TFile.h"
+#include "TTree.h"
+#include "TStyle.h"
+#include "TCanvas.h"
+#include "TH1.h"
+#include "TH2.h"
+#include "DataFormatsTPC/TrackTPC.h"
+#include "DataFormatsTPC/ClusterNative.h"
+#include "TPCQC/Tracks.h"
+#include "TPCQC/Helpers.h"
+//#include "TPCQC/TrackCuts.h"
+#endif
+
+using namespace o2::tpc;
+
+void runTracks(std::string outputFileName = "tpcQcTracks", std::string_view inputFileName = "tpctracks.root", const size_t maxTracks = 0)
+{
+  // ===| track file and tree |=================================================
+  auto file = TFile::Open(inputFileName.data());
+  auto tree = (TTree*)file->Get("tpcrec");
+  if (tree == nullptr) {
+    std::cout << "Error getting tree\n";
+    return;
+  }
+
+  // ===| branch setup |==========================================================
+  std::vector<TrackTPC>* tpcTracks = nullptr;
+  tree->SetBranchAddress("TPCTracks", &tpcTracks);
+
+  // ===| create Tracks object |=====================================================
+  qc::Tracks tracksQC;
+
+  tracksQC.initializeHistograms();
+  gStyle->SetPalette(kCividis);
+  qc::helpers::setStyleHistogram1D(tracksQC.getHistograms1D());
+  qc::helpers::setStyleHistogram2D(tracksQC.getHistograms2D());
+
+  // ===| event loop |============================================================
+  for (int i = 0; i < tree->GetEntriesFast(); ++i) {
+    tree->GetEntry(i);
+    size_t nTracks = (maxTracks > 0) ? std::min(tpcTracks->size(), maxTracks) : tpcTracks->size();
+    // ---| track loop |---
+    for (int k = 0; k < nTracks; k++) {
+      auto track = (*tpcTracks)[k];
+      tracksQC.processTrack(track);
+    }
+  }
+
+  // ===| get histograms |=======================================================
+  auto& histos1D = tracksQC.getHistograms1D();
+  auto& histos2D = tracksQC.getHistograms2D();
+
+  // ===| create canvases |======================================================
+  auto* c1 = new TCanvas("c1", "eta_phi_pt", 1200, 600);
+  c1->Divide(3, 2);
+  c1->cd(1);
+  histos2D[6].Draw();
+  c1->cd(2);
+  histos1D[2].Draw();
+  c1->cd(3);
+  histos1D[4].Draw();
+  c1->cd(4);
+  histos2D[5].Draw();
+  c1->cd(5);
+  histos1D[5].Draw();
+  gPad->SetLogy();
+  c1->cd(6);
+  histos1D[3].Draw();
+
+  auto* c2 = new TCanvas("c2", "nClustersPerTrack_details", 1200, 300);
+  c2->Divide(3, 1);
+  c2->cd(1);
+  histos2D[0].Draw();
+  c2->cd(2);
+  histos2D[2].Draw();
+  c2->cd(3);
+  histos2D[1].Draw();
+
+  auto* c3 = new TCanvas("c3", "nClustersPerTrack_cuts", 800, 300);
+  c3->Divide(2, 1);
+  c3->cd(1);
+  histos1D[0].Draw();
+  c3->cd(2);
+  histos1D[1].Draw();
+
+  if (outputFileName.find(".root") != std::string::npos) {
+    outputFileName.resize(outputFileName.size() - 5);
+  }
+
+  //===| dump canvases to a file |=============================================
+  std::string canvasFile = outputFileName + "_canvas.root";
+  auto f = std::unique_ptr<TFile>(TFile::Open(canvasFile.c_str(), "recreate"));
+  f->WriteObject(c1, "eta_phi_pt");
+  f->WriteObject(c2, "nClustersPerTrack_details");
+  f->WriteObject(c3, "nClustersPerTrack_cuts");
+  f->Close();
+  delete c1;
+  delete c2;
+  delete c3;
+
+  //===| dump histograms to a file |=============================================
+  std::string histFile = outputFileName + ".root";
+  tracksQC.dumpToFile(histFile);
+
+  tracksQC.resetHistograms();
+}

--- a/Detectors/TPC/qc/src/TPCQCLinkDef.h
+++ b/Detectors/TPC/qc/src/TPCQCLinkDef.h
@@ -17,6 +17,7 @@
 #pragma link C++ class o2::tpc::qc::PID+;
 #pragma link C++ class o2::tpc::qc::TrackCuts+;
 #pragma link C++ class o2::tpc::qc::Clusters+;
+#pragma link C++ class o2::tpc::qc::Tracks+;
 #pragma link C++ function o2::tpc::qc::helpers::makeLogBinning+;
 #pragma link C++ function o2::tpc::qc::helpers::setStyleHistogram1D+;
 #pragma link C++ function o2::tpc::qc::helpers::setStyleHistogram2D+;

--- a/Detectors/TPC/qc/src/Tracks.cxx
+++ b/Detectors/TPC/qc/src/Tracks.cxx
@@ -1,0 +1,122 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define _USE_MATH_DEFINES
+
+#include <cmath>
+#include <memory>
+
+// root includes
+#include "TFile.h"
+
+// o2 includes
+#include "DataFormatsTPC/TrackTPC.h"
+#include "TPCQC/Tracks.h"
+
+ClassImp(o2::tpc::qc::Tracks);
+
+using namespace o2::tpc::qc;
+
+//______________________________________________________________________________
+void Tracks::initializeHistograms()
+{
+  mHist1D.emplace_back("hNClustersBeforeCuts", "Number of clusters before cuts;# TPC clusters", 160, -0.5, 159.5);
+  mHist1D.emplace_back("hNClustersAfterCuts", "Number of clusters after cuts;# TPC clusters", 160, -0.5, 159.5);
+  mHist1D.emplace_back("hEta", "Pseudorapidity;eta", 400, -2., 2.);
+  mHist1D.emplace_back("hPhiAside", "Azimuthal angle, A side;phi", 360, -M_PI, M_PI);
+  mHist1D.emplace_back("hPhiCside", "Azimuthal angle, C side;phi", 360, -M_PI, M_PI);
+  mHist1D.emplace_back("hPt", "Transverse momentum;p_T", 200, 0., 10.);
+  mHist1D.emplace_back("hSign", "Sign of electric charge;charge sign", 3, -1.5, 1.5);
+
+  mHist2D.emplace_back("h2DNClustersEta", "Number of clusters vs. eta;eta;# TPC clusters", 400, -2., 2., 160, -0.5, 159.5);
+  mHist2D.emplace_back("h2DNClustersPhiAside", "Number of clusters vs. phi, A side ;phi;# TPC clusters", 360, -M_PI, M_PI, 160, -0.5, 159.5);
+  mHist2D.emplace_back("h2DNClustersPhiCside", "Number of clusters vs. phi, C side ;phi;# TPC clusters", 360, -M_PI, M_PI, 160, -0.5, 159.5);
+  mHist2D.emplace_back("h2DNClustersPt", "Number of clusters vs. p_T;p_T;# TPC clusters", 200, 0., 10., 160, -0.5, 159.5);
+  mHist2D.emplace_back("h2DEtaPhi", "Tracks in eta vs. phi;phi;eta", 360, -M_PI, M_PI, 400, -2., 2.);
+  mHist2D.emplace_back("h2DEtaPhiNeg", "Negative tracks in eta vs. phi;phi;eta", 360, -M_PI, M_PI, 400, -2., 2.);
+  mHist2D.emplace_back("h2DEtaPhiPos", "Positive tracks in eta vs. phi;phi;eta", 360, -M_PI, M_PI, 400, -2., 2.);
+}
+
+//______________________________________________________________________________
+void Tracks::resetHistograms()
+{
+  for (auto& hist : mHist1D) {
+    hist.Reset();
+  }
+  for (auto& hist2 : mHist2D) {
+    hist2.Reset();
+  }
+}
+
+//______________________________________________________________________________
+bool Tracks::processTrack(const o2::tpc::TrackTPC& track)
+{
+  // ===| variables required for cutting and filling |===
+  const auto eta = track.getEta();
+  const auto phi = track.getPhi();
+  const auto pt = track.getPt();
+  const auto sign = track.getSign();
+  const auto nCls = track.getNClusterReferences();
+
+  // ===| fill one histogram before any cuts |===
+  mHist1D[0].Fill(nCls);
+
+  // ===| cuts |===
+  // hard coded cuts. Should be more configural in future
+  if (nCls < 20) {
+    return false;
+  }
+
+  // ===| 1D histogram filling |===
+  mHist1D[1].Fill(nCls);
+  mHist1D[2].Fill(eta);
+
+  if (eta > 0.) {
+    mHist1D[3].Fill(phi);
+  } else {
+    mHist1D[4].Fill(phi);
+  }
+
+  mHist1D[5].Fill(pt);
+  mHist1D[6].Fill(sign);
+
+  // ===| 2D histogram filling |===
+  mHist2D[0].Fill(eta, nCls);
+
+  if (eta > 0.) {
+    mHist2D[1].Fill(phi, nCls);
+  } else {
+    mHist2D[2].Fill(phi, nCls);
+  }
+
+  mHist2D[3].Fill(pt, nCls);
+  mHist2D[4].Fill(phi, eta);
+
+  if (sign < 0.) {
+    mHist2D[5].Fill(phi, eta);
+  } else {
+    mHist2D[6].Fill(phi, eta);
+  }
+
+  return true;
+}
+
+//______________________________________________________________________________
+void Tracks::dumpToFile(std::string_view filename)
+{
+  auto f = std::unique_ptr<TFile>(TFile::Open(filename.data(), "recreate"));
+  for (auto& hist : mHist1D) {
+    f->WriteObject(&hist, hist.GetName());
+  }
+  for (auto& hist : mHist2D) {
+    f->WriteObject(&hist, hist.GetName());
+  }
+  f->Close();
+}

--- a/Detectors/TPC/qc/test/test_Tracks.cxx
+++ b/Detectors/TPC/qc/test/test_Tracks.cxx
@@ -1,0 +1,22 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test TPC QC
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include "DataFormatsTPC/Defs.h"
+#include "TPCQC/Tracks.h"
+#include <cmath>
+
+BOOST_AUTO_TEST_CASE(ReadWriteROOTFile)
+{
+  o2::tpc::qc::Tracks tracks;
+}


### PR DESCRIPTION
o This is the O2 part of the TPC QC task relating to the tracks
o Several 1D and 2D histograms are implemented
o A root macro is provided to run the task and save the output
o A corresponding workflow will be added to QualityControl