### PR TITLE
DPL: move is_specialization to Foundation

### DIFF
--- a/Framework/Core/include/Framework/TypeTraits.h
+++ b/Framework/Core/include/Framework/TypeTraits.h
@@ -7,12 +7,13 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#ifndef FRAMEWORK_TYPETRAITS_H
-#define FRAMEWORK_TYPETRAITS_H
+#ifndef O2_FRAMEWORK_TYPETRAITS_H_
+#define O2_FRAMEWORK_TYPETRAITS_H_
 
 #include <type_traits>
 #include <vector>
 #include <memory>
+#include "Framework/Traits.h"
 
 #include <boost/archive/binary_iarchive.hpp>
 #include <boost/archive/binary_oarchive.hpp>
@@ -20,18 +21,6 @@
 
 namespace o2::framework
 {
-/// Helper trait to determine if a given type T
-/// is a specialization of a given reference type Ref.
-/// See Framework/Core/test_TypeTraits.cxx for an example
-
-template <typename T, template <typename...> class Ref>
-struct is_specialization : std::false_type {
-};
-
-template <template <typename...> class Ref, typename... Args>
-struct is_specialization<Ref<Args...>, Ref> : std::true_type {
-};
-
 // helper struct to mark a type as non-messageable by defining a type alias
 // with name 'non-messageable'
 struct MarkAsNonMessageable {

--- a/Framework/Foundation/include/Framework/Traits.h
+++ b/Framework/Foundation/include/Framework/Traits.h
@@ -7,16 +7,24 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-
 #ifndef O2_FRAMEWORK_TRAITS_H_
 #define O2_FRAMEWORK_TRAITS_H_
 
 #include <type_traits>
 
-namespace o2
+namespace o2::framework
 {
-namespace framework
-{
+/// Helper trait to determine if a given type T
+/// is a specialization of a given reference type Ref.
+/// See Framework/Core/test_TypeTraits.cxx for an example
+
+template <typename T, template <typename...> class Ref>
+struct is_specialization : std::false_type {
+};
+
+template <template <typename...> class Ref, typename... Args>
+struct is_specialization<Ref<Args...>, Ref> : std::true_type {
+};
 
 template <typename A, typename B>
 struct is_overriding : public std::bool_constant<std::is_same_v<A, B> == false && std::is_member_function_pointer_v<A> && std::is_member_function_pointer_v<B>> {
@@ -29,7 +37,6 @@ struct always_static_assert : std::false_type {
 template <typename... T>
 inline constexpr bool always_static_assert_v = always_static_assert<T...>::value;
 
-} // namespace framework
-} // namespace o2
+} // namespace o2::framework
 
 #endif // O2_FRAMEWORK_TRAITS_H_


### PR DESCRIPTION
No need to intertwine it with ROOT or BOOST.