### PR TITLE
Move RandomRing to common place.

### DIFF
--- a/Common/MathUtils/CMakeLists.txt
+++ b/Common/MathUtils/CMakeLists.txt
@@ -15,12 +15,14 @@ o2_add_library(MathUtils
                        src/Chebyshev3D.cxx
                        src/Chebyshev3DCalc.cxx
                        src/MathBase.cxx
+                       src/RandomRing.cxx
                PUBLIC_LINK_LIBRARIES ROOT::Hist
                                      FairRoot::Base
                                      O2::CommonConstants
                                      O2::GPUCommon
                                      ROOT::GenVector
-                                     ROOT::Geom)
+                                     ROOT::Geom
+                                     Vc::Vc)
 
 o2_target_root_dictionary(MathUtils
                           HEADERS include/MathUtils/Chebyshev3D.h
@@ -28,7 +30,8 @@ o2_target_root_dictionary(MathUtils
                                   include/MathUtils/MathBase.h
                                   include/MathUtils/Cartesian2D.h
                                   include/MathUtils/Cartesian3D.h
-                                  include/MathUtils/CachingTF1.h)
+                                  include/MathUtils/CachingTF1.h
+                                  include/MathUtils/RandomRing.h)
 
 o2_add_test(CachingTF1
             SOURCES test/testCachingTF1.cxx

--- a/Common/MathUtils/include/MathUtils/RandomRing.h
+++ b/Common/MathUtils/include/MathUtils/RandomRing.h
@@ -26,8 +26,6 @@
 #ifndef ALICEO2_MATHUTILS_RANDOMRING_H_
 #define ALICEO2_MATHUTILS_RANDOMRING_H_
 
-// #include <boost/format.hpp>
-
 #include "Vc/Vc"
 #include <array>
 

--- a/Common/MathUtils/include/MathUtils/RandomRing.h
+++ b/Common/MathUtils/include/MathUtils/RandomRing.h
@@ -21,13 +21,12 @@
 /// The numbers can then be used as a continuous stream in
 /// a ring buffer
 ///
-/// origin: TPC
 /// @author Jens Wiechula, Jens.Wiechula@cern.ch
 
-#ifndef ALICEO2_TPC_RANDOMRING_H_
-#define ALICEO2_TPC_RANDOMRING_H_
+#ifndef ALICEO2_MATHUTILS_RANDOMRING_H_
+#define ALICEO2_MATHUTILS_RANDOMRING_H_
 
-#include <boost/format.hpp>
+// #include <boost/format.hpp>
 
 #include "Vc/Vc"
 #include <array>
@@ -39,7 +38,7 @@ using float_v = Vc::float_v;
 
 namespace o2
 {
-namespace tpc
+namespace math_utils
 {
 
 template <size_t N = float_v::size() * 100000>
@@ -170,6 +169,6 @@ inline void RandomRing<N>::initialize(TF1& function)
   }
 }
 
-} // namespace tpc
+} // namespace math_utils
 } // namespace o2
 #endif

--- a/Common/MathUtils/src/RandomRing.cxx
+++ b/Common/MathUtils/src/RandomRing.cxx
@@ -13,4 +13,4 @@
 /// @author Jens Wiechula, Jens.Wiechula@cern.ch
 ///
 
-#include "TPCBase/RandomRing.h"
+#include "MathUtils/RandomRing.h"

--- a/Detectors/TPC/base/CMakeLists.txt
+++ b/Detectors/TPC/base/CMakeLists.txt
@@ -30,7 +30,6 @@ o2_add_library(TPCBase
                        src/ParameterGas.cxx
                        src/ParameterGEM.cxx
                        src/PartitionInfo.cxx
-                       src/RandomRing.cxx
                        src/ROC.cxx
                        src/Sector.cxx
                PUBLIC_LINK_LIBRARIES Vc::Vc Boost::boost O2::DataFormatsTPC
@@ -58,7 +57,6 @@ o2_target_root_dictionary(TPCBase
                                   include/TPCBase/ParameterGas.h
                                   include/TPCBase/ParameterGEM.h
                                   include/TPCBase/PartitionInfo.h
-                                  include/TPCBase/RandomRing.h
                                   include/TPCBase/ROC.h
                                   include/TPCBase/Sector.h)
 

--- a/Detectors/TPC/simulation/include/TPCSimulation/ElectronTransport.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/ElectronTransport.h
@@ -19,7 +19,7 @@
 #include "TPCBase/ParameterGas.h"
 
 #include "TPCBase/Mapper.h"
-#include "TPCBase/RandomRing.h"
+#include "MathUtils/RandomRing.h"
 
 namespace o2
 {
@@ -75,9 +75,9 @@ class ElectronTransport
 
   /// Circular random buffer containing random values of the Gauss distribution to take into account diffusion of the
   /// electrons
-  RandomRing<> mRandomGaus;
+  math_utils::RandomRing<> mRandomGaus;
   /// Circular random buffer containing flat random values to take into account electron attachment during drift
-  RandomRing<> mRandomFlat;
+  math_utils::RandomRing<> mRandomFlat;
 
   const ParameterDetector* mDetParam; ///< Caching of the parameter class to avoid multiple CDB calls
   const ParameterGas* mGasParam;      ///< Caching of the parameter class to avoid multiple CDB calls

--- a/Detectors/TPC/simulation/include/TPCSimulation/GEMAmplification.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/GEMAmplification.h
@@ -15,7 +15,7 @@
 #ifndef ALICEO2_TPC_GEMAmplification_H_
 #define ALICEO2_TPC_GEMAmplification_H_
 
-#include "TPCBase/RandomRing.h"
+#include "MathUtils/RandomRing.h"
 #include "TPCBase/ParameterGas.h"
 #include "TPCBase/ParameterGEM.h"
 #include "TPCBase/CRU.h"
@@ -93,13 +93,13 @@ class GEMAmplification
 
   /// Circular random buffer containing random Gaus values for gain fluctuation if the number of electrons is larger
   /// (central limit theorem)
-  RandomRing<> mRandomGaus;
+  math_utils::RandomRing<> mRandomGaus;
   /// Circular random buffer containing flat random values for the collection/extraction
-  RandomRing<> mRandomFlat;
+  math_utils::RandomRing<> mRandomFlat;
   /// Container with random Polya distributions, one for each GEM in the stack
-  std::array<RandomRing<>, 4> mGain;
+  std::array<math_utils::RandomRing<>, 4> mGain;
   /// Container with random Polya distributions for the full stack amplification
-  RandomRing<> mGainFullStack;
+  math_utils::RandomRing<> mGainFullStack;
 
   const ParameterGEM* mGEMParam; ///< Caching of the parameter class to avoid multiple CDB calls
   const ParameterGas* mGasParam; ///< Caching of the parameter class to avoid multiple CDB calls

--- a/Detectors/TPC/simulation/include/TPCSimulation/SAMPAProcessing.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/SAMPAProcessing.h
@@ -20,7 +20,7 @@
 #include "TPCBase/PadPos.h"
 #include "TPCBase/CalDet.h"
 #include "TPCBase/CRU.h"
-#include "TPCBase/RandomRing.h"
+#include "MathUtils/RandomRing.h"
 #include "TPCBase/ParameterDetector.h"
 #include "TPCBase/ParameterElectronics.h"
 #include "TPCBase/ParameterGas.h"
@@ -131,7 +131,7 @@ class SAMPAProcessing
   const ParameterElectronics* mEleParam; ///< Caching of the parameter class to avoid multiple CDB calls
   const CalPad* mNoiseMap;               ///< Caching of the parameter class to avoid multiple CDB calls
   const CalPad* mPedestalMap;            ///< Caching of the parameter class to avoid multiple CDB calls
-  RandomRing<> mRandomNoiseRing;         ///< Ring with random number for noise
+  math_utils::RandomRing<> mRandomNoiseRing; ///< Ring with random number for noise
 };
 
 template <typename T>

--- a/Detectors/TPC/simulation/include/TPCSimulation/SpaceCharge.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/SpaceCharge.h
@@ -39,7 +39,7 @@
 
 #include "AliTPCSpaceCharge3DCalc.h"
 #include "DataFormatsTPC/Defs.h"
-#include "TPCBase/RandomRing.h"
+#include "MathUtils/RandomRing.h"
 
 class TH3;
 
@@ -233,7 +233,7 @@ class SpaceCharge
   std::unique_ptr<AliTPCLookUpTable3DInterpolatorD> mLookUpIonDriftC; ///< lookup table for ion drift along E field on C side in cm
   bool mMemoryAllocated;
 
-  RandomRing<> mRandomFlat; //!<! Circular random buffer containing flat random values to convert the charge density to a flat ion distribution inside the voxel
+  math_utils::RandomRing<> mRandomFlat; //!<! Circular random buffer containing flat random values to convert the charge density to a flat ion distribution inside the voxel
 
   ClassDefNV(SpaceCharge, 1);
 };

--- a/Detectors/TPC/simulation/src/ElectronTransport.cxx
+++ b/Detectors/TPC/simulation/src/ElectronTransport.cxx
@@ -18,6 +18,7 @@
 #include <cmath>
 
 using namespace o2::tpc;
+using namespace o2::math_utils;
 
 ElectronTransport::ElectronTransport() : mRandomGaus(), mRandomFlat(RandomRing<>::RandomType::Flat)
 {

--- a/Detectors/TPC/simulation/src/GEMAmplification.cxx
+++ b/Detectors/TPC/simulation/src/GEMAmplification.cxx
@@ -21,6 +21,7 @@
 #include "FairLogger.h"
 
 using namespace o2::tpc;
+using namespace o2::math_utils;
 using boost::format;
 
 GEMAmplification::GEMAmplification()

--- a/Detectors/TPC/simulation/src/SpaceCharge.cxx
+++ b/Detectors/TPC/simulation/src/SpaceCharge.cxx
@@ -28,6 +28,7 @@
 #include "TPCSimulation/SpaceCharge.h"
 
 using namespace o2::tpc;
+using namespace o2::math_utils;
 
 const float o2::tpc::SpaceCharge::sEzField = (AliTPCPoissonSolver::fgkCathodeV - AliTPCPoissonSolver::fgkGG) / AliTPCPoissonSolver::fgkTPCZ0;
 


### PR DESCRIPTION
Make RandomRing available to other detectors.
In particular targetting use in TRD for the moment.