### PR TITLE
Optimization on TRD digitizer

### DIFF
--- a/Common/MathUtils/include/MathUtils/RandomRing.h
+++ b/Common/MathUtils/include/MathUtils/RandomRing.h
@@ -15,7 +15,9 @@
 
 /// @brief  Ring with random number
 ///
-/// This class creates a set of random numbers.
+/// This class creates a set of random (or any sort of pregenerated) numbers
+/// in a ring buffer.
+
 /// The idea is to create a set of random numbers that can be
 /// reused in order to save computing time.
 /// The numbers can then be used as a continuous stream in
@@ -31,6 +33,7 @@
 
 #include "TF1.h"
 #include "TRandom.h"
+#include <functional>
 
 using float_v = Vc::float_v;
 
@@ -44,9 +47,10 @@ class RandomRing
 {
  public:
   enum class RandomType : char {
-    Gaus,     ///< Gaussian distribution
-    Flat,     ///< Flat distribution
-    CustomTF1 ///< Custom TF1 function to be used
+    Gaus,         ///< Gaussian distribution
+    Flat,         ///< Flat distribution
+    CustomTF1,    ///< Custom TF1 function to be used
+    CustomLambda, ///< Initialized through external lambda
   };
 
   /// disallow copy constructor
@@ -70,6 +74,10 @@ class RandomRing
   /// initialisation of the random ring
   /// @param [in] randomType type of the random generator
   void initialize(TF1& function);
+
+  /// initialisation of the random ring
+  /// @param [in] randomType type of the random generator
+  void initialize(std::function<float()> function);
 
   /// next random value from the ring buffer
   /// This function return a value from the ring buffer
@@ -162,8 +170,19 @@ inline void RandomRing<N>::initialize(const RandomType randomType)
 template <size_t N>
 inline void RandomRing<N>::initialize(TF1& function)
 {
+  mRandomType = RandomType::CustomTF1;
   for (auto& v : mRandomNumbers) {
     v = function.GetRandom();
+  }
+}
+
+//______________________________________________________________________________
+template <size_t N>
+inline void RandomRing<N>::initialize(std::function<float()> function)
+{
+  mRandomType = RandomType::CustomLambda;
+  for (auto& v : mRandomNumbers) {
+    v = function();
   }
 }
 

--- a/Detectors/TRD/base/src/TRDBaseLinkDef.h
+++ b/Detectors/TRD/base/src/TRDBaseLinkDef.h
@@ -42,6 +42,7 @@
 #pragma link C++ class o2::trd::ChamberNoise + ;
 #pragma link C++ class o2::trd::CalOnlineGainTables + ;
 #pragma link C++ class o2::trd::TrapConfig + ;
+#pragma link C++ class o2::trd::PadNoise + ;
 
 #include "SimulationDataFormat/MCTruthContainer.h"
 

--- a/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
@@ -19,6 +19,8 @@
 #include "TRDBase/TRDCommonParam.h"
 #include "TRDBase/Calibrations.h"
 
+#include "MathUtils/RandomRing.h"
+
 namespace o2
 {
 namespace trd
@@ -47,6 +49,9 @@ class Digitizer
   TRDSimParam* mSimParam = nullptr;       // access to TRDSimParam instance
   TRDCommonParam* mCommonParam = nullptr; // access to TRDCommonParam instance
   Calibrations* mCalib = nullptr;         // access to Calibrations in CCDB
+  math_utils::RandomRing<> mGausRandomRing; // pre-generated normal distributed random numbers
+  math_utils::RandomRing<> mFlatRandomRing; // pre-generated flat distributed random numbers
+  math_utils::RandomRing<> mLogRandomRing;  // pre-generated exp distributed random number
 
   double mTime = 0.;
   int mEventID = 0;
@@ -62,7 +67,7 @@ class Digitizer
   bool convertSignalsToSDigits(const int, SignalContainer_t&);                                                               // True if signal-to-sdigit conversion is successful
   bool convertSignalsToADC(const int, SignalContainer_t&);                                                                   // True if signal-to-ADC conversion is successful
 
-  bool diffusion(float, double, double, double, double, double, double&, double&, double&); // True if diffusion is applied successfully
+  bool diffusion(float, float, float, float, float, float, double&, double&, double&); // True if diffusion is applied successfully
 };
 } // namespace trd
 } // namespace o2


### PR DESCRIPTION
Speed up TRD digitizer by using circular pre-computed random numbers.
This is also a step towards multi-threading since we are no longer using the gRandom singleton.

See previous discussion here https://alice.its.cern.ch/jira/browse/O2-734. 