### PR TITLE
Bugfix: argument list of a formated log message

### DIFF
--- a/Framework/Utils/src/RawParser.cxx
+++ b/Framework/Utils/src/RawParser.cxx
@@ -47,7 +47,7 @@ void RDHFormatter<V4>::apply(std::ostream& os, V4 const& header, FormatSpec choi
   if (choice == FormatSpec::Info) {
     os << "RDH v4";
   } else if (choice == FormatSpec::TableHeader) {
-    os << fmt::format(sFormatString, "PkC", "pCnt", "fId", "Mem", "CRU", "EP", "LID", "s");
+    os << fmt::format(sFormatString, "PkC", "pCnt", "fId", "Mem", "CRU", "EP", "LID", "HBOrbit", "HBBC", "s");
   } else if (choice == FormatSpec::Entry) {
     os << fmt::format(sFormatString,
                       header.packetCounter,

--- a/Framework/Utils/src/raw-parser.cxx
+++ b/Framework/Utils/src/raw-parser.cxx
@@ -41,7 +41,11 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
     AlgorithmSpec{[](InitContext& setup) { return adaptStateless([](InputRecord& inputs, DataAllocator& outputs) {
                                              for (auto& input : inputs) {
                                                const auto* dh = DataRefUtils::getHeader<o2::header::DataHeader*>(input);
-                                               LOG(INFO) << *(input.spec) << " payload size " << dh->payloadSize;
+                                               // InputSpec implements operator<< so we could print (input.spec) but that is the
+                                               // matcher instead of the matched data
+                                               LOG(INFO) << dh->dataOrigin.as<std::string>() << "/"
+                                                         << dh->dataDescription.as<std::string>() << "/"
+                                                         << dh->subSpecification << " payload size " << dh->payloadSize;
 
                                                // there is a bug in InpuRecord::get for vectors of simple types, not catched in
                                                // DataAllocator unit test
@@ -57,7 +61,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
                                                } catch (const std::runtime_error& e) {
                                                  LOG(ERROR) << "can not create raw parser form input data";
                                                  o2::header::hexDump("payload", input.payload, dh->payloadSize, 64);
-                                                 throw e;
+                                                 LOG(ERROR) << e.what();
                                                }
                                              }
                                            }); }}});


### PR DESCRIPTION
Printing exception message instead of re-throwing it