### PR TITLE
 Defining Point3D  and itsmft::Cluster messageable

### DIFF
--- a/Common/MathUtils/include/MathUtils/Cartesian3D.h
+++ b/Common/MathUtils/include/MathUtils/Cartesian3D.h
@@ -226,4 +226,22 @@ class Transform3D : public ROOT::Math::Transform3D
 
 std::ostream& operator<<(std::ostream& os, const o2::Rotation2D& t);
 
+namespace std
+{
+
+/// Defining Point3D explicitly as trivially copyable
+///
+/// std::is_trivially_copyable<ROOT::Math::Cartesian3D<T>> fails because the class
+/// implements a copy constructor, although it does not much more than the default copy
+/// constructor. We need Point3D to fulfill the condition in order to make types
+/// inheriting from it or using it as member can be safely detected as messageable.
+///
+/// We believe that Point3D is messageable and explicitly specialize the type trait.
+/// There is a unit test for checking trivial copy
+/// This is a workaround, we will also make suggestions to fix the cause in ROOT itself
+/// TODO: delete once it is fixed in ROOT
+template <typename T>
+struct is_trivially_copyable<Point3D<T>> : std::true_type {
+};
+} // namespace std
 #endif


### PR DESCRIPTION
`std::is_trivially_copyable<ROOT::Math::Cartesian3D<T>>` fails because the class
implements a copy constructor, although it does not much more than the default copy
constructor. We need `Point3D` to fulfill the condition in order to make types
inheriting from it or using it as member can be safely detected as messageable

We believe that `Point3D` is trivially copyable and explicitly specialize the type trait
`std::is_trivially_copyable`. Also adding unit test for checking trivial copy.
This is a workaround, we will also make suggestions to fix the cause in ROOT itself

Still this does not make `itsmft::Cluster` trivially copyable, there is more magic in checking
the condition for class members. We need to specialize our type trait `is_messageable`