### PR TITLE
Correctly treat in-bunch pileup in MID simulations

### DIFF
--- a/Detectors/MUON/MID/Simulation/include/MIDSimulation/DigitsMerger.h
+++ b/Detectors/MUON/MID/Simulation/include/MIDSimulation/DigitsMerger.h
@@ -29,7 +29,7 @@ namespace mid
 class DigitsMerger
 {
  public:
-  void process(const std::vector<ColumnDataMC>& inDigitStore, const o2::dataformats::MCTruthContainer<MCLabel>& inMCContainer, const std::vector<ROFRecord>& inROFRecords);
+  void process(const std::vector<ColumnDataMC>& inDigitStore, const o2::dataformats::MCTruthContainer<MCLabel>& inMCContainer, const std::vector<ROFRecord>& inROFRecords, bool mergeInBunchPileup = true);
 
   /// Gets the merged column data
   const std::vector<ColumnData>& getColumnData() const { return mDigitStore; }

--- a/Detectors/MUON/MID/Simulation/test/testSimulation.cxx
+++ b/Detectors/MUON/MID/Simulation/test/testSimulation.cxx
@@ -15,6 +15,7 @@
 #include <boost/test/data/test_case.hpp>
 #include <sstream>
 #include "MathUtils/Cartesian3D.h"
+#include "CommonConstants/LHCConstants.h"
 #include "DataFormatsMID/Cluster2D.h"
 #include "DataFormatsMID/Cluster3D.h"
 #include "DataFormatsMID/ColumnData.h"
@@ -303,7 +304,7 @@ BOOST_DATA_TEST_CASE(MID_DigitMerger, boost::unit_test::data::make(getDEList()),
     digitsCollection.push_back({});
     mcContainerCollection.push_back({});
     simDigitizer.digitizer.process(hits, digitsCollection.back(), mcContainerCollection.back());
-    rofRecords.emplace_back(10 * ievent, EventType::Standard, digits.size(), digitsCollection.back().size());
+    rofRecords.emplace_back(o2::constants::lhc::LHCBunchSpacingNS * ievent, EventType::Standard, digits.size(), digitsCollection.back().size());
     std::copy(digitsCollection.back().begin(), digitsCollection.back().end(), std::back_inserter(digits));
     mcContainer.mergeAtBack(mcContainerCollection.back());
   }
@@ -392,7 +393,7 @@ BOOST_DATA_TEST_CASE(MID_SingleCluster, boost::unit_test::data::make(getDEList()
     int nGenClusters = 1, nRecoClusters = 0;
     simDigitizer.digitizer.process(hits, digitStoreMC, digitLabelsMC);
     rofRecords.clear();
-    rofRecords.emplace_back(10 * ievent, EventType::Standard, 0, digitStoreMC.size());
+    rofRecords.emplace_back(o2::constants::lhc::LHCBunchSpacingNS * ievent, EventType::Standard, 0, digitStoreMC.size());
     simDigitizer.digitsMerger.process(digitStoreMC, digitLabelsMC, rofRecords);
     simClustering.preClusterizer.process(simDigitizer.digitsMerger.getColumnData(), simDigitizer.digitsMerger.getROFRecords());
     simClustering.clusterizer.process(simClustering.preClusterizer.getPreClusters(), simClustering.preClusterizer.getROFRecords());
@@ -432,7 +433,7 @@ BOOST_DATA_TEST_CASE(MID_SimClusters, boost::unit_test::data::make(getDEList()),
     auto hits = generateHits(10, deId, simBase.mapping, simBase.geoTrans);
     hitsCollection.emplace_back(hits);
     simDigitizer.digitizer.process(hits, digitStoreMC, digitLabelsMC);
-    digitsROF.emplace_back(ievent, EventType::Standard, digitsAccum.size(), digitStoreMC.size());
+    digitsROF.emplace_back(o2::constants::lhc::LHCBunchSpacingNS * ievent, EventType::Standard, digitsAccum.size(), digitStoreMC.size());
     std::copy(digitStoreMC.begin(), digitStoreMC.end(), std::back_inserter(digitsAccum));
     digitLabelsAccum.mergeAtBack(digitLabelsMC);
   }
@@ -505,7 +506,7 @@ BOOST_DATA_TEST_CASE(MID_SimTracks, boost::unit_test::data::make({1, 2, 3, 4, 5,
   // In the tracking algorithm, if we have two tracks that are compatible within uncertainties
   // we keep only one of the two. This is done to avoid duplicated tracks.
   // In this test we can have many tracks in the same event.
-  // If two tracks are close, they can give two reconstucted tracks compatible among each others,
+  // If two tracks are close, they can give two reconstructed tracks compatible among each others,
   // within their uncertainties. One of the two is therefore rejected.
   // However, the track might not be compatible with the (rejected) generated track that has no uncertainty.
   // To avoid this, compare adding a factor 2 in the sigma cut.
@@ -525,7 +526,7 @@ BOOST_DATA_TEST_CASE(MID_SimTracks, boost::unit_test::data::make({1, 2, 3, 4, 5,
     genTrackCollection.emplace_back(genTracks);
 
     simDigitizer.digitizerNoClusterSize.process(hits, digitStoreMC, digitLabelsMC);
-    digitsROF.emplace_back(ievent, EventType::Standard, digitsAccum.size(), digitStoreMC.size());
+    digitsROF.emplace_back(o2::constants::lhc::LHCBunchSpacingNS * ievent, EventType::Standard, digitsAccum.size(), digitStoreMC.size());
     std::copy(digitStoreMC.begin(), digitStoreMC.end(), std::back_inserter(digitsAccum));
     digitLabelsAccum.mergeAtBack(digitLabelsMC);
   }

--- a/Steer/DigitizerWorkflow/src/MIDDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/MIDDigitizerSpec.cxx
@@ -107,6 +107,7 @@ class MIDDPLDigitizerTask
     for (int collID = 0; collID < irecords.size(); ++collID) {
       // for each collision, loop over the constituents event and source IDs
       // (background signal merging is basically taking place here)
+      auto firstEntry = digitsAccum.size();
       for (auto& part : eventParts[collID]) {
         mDigitizer->setEventID(part.entryID);
         mDigitizer->setSrcID(part.sourceID);
@@ -120,9 +121,12 @@ class MIDDPLDigitizerTask
         if (digits.empty()) {
           continue;
         }
-        rofRecords.emplace_back(irecords[collID], EventType::Standard, digitsAccum.size(), digits.size());
         std::copy(digits.begin(), digits.end(), std::back_inserter(digitsAccum));
         labelsAccum.mergeAtBack(labels);
+      }
+      auto nEntries = digitsAccum.size() - firstEntry;
+      if (nEntries > 0) {
+        rofRecords.emplace_back(irecords[collID], EventType::Standard, firstEntry, nEntries);
       }
     }
 


### PR DESCRIPTION
This PR consists of 2 commits:
- the first one solves a bug due to which two parts of the same event were attributed to different ROFRecords
- the second part correctly treat the in-bunch pilup. These events have the same orbit and bc counter, but occur at few (fraction of) ns difference. The resulting digits are correctly identified as "separate" vertex from the MC. However, when running the clustering, they need to be merged since the MID is not capable to separate them.
The commit allows to correctly handle the in-bunch pileup (and the MC labels insure that we are still able to distingish the digits coming from different vertexes)