### PR TITLE
Fix data driven dangling inputs

### DIFF
--- a/Framework/Core/include/Framework/TimesliceIndex.h
+++ b/Framework/Core/include/Framework/TimesliceIndex.h
@@ -30,8 +30,11 @@ struct TimesliceId {
 
 struct TimesliceSlot {
   static constexpr uint64_t INVALID = -1;
+  static constexpr uint64_t ANY = -2;
   size_t index;
   static bool isValid(TimesliceSlot const& slot);
+  bool operator==(const TimesliceSlot that) const;
+  bool operator!=(const TimesliceSlot that) const;
 };
 
 /// This class keeps the information relative to a given slot in the cache, in

--- a/Framework/Core/include/Framework/TimesliceIndex.inc
+++ b/Framework/Core/include/Framework/TimesliceIndex.inc
@@ -15,6 +15,18 @@ namespace framework
 inline bool TimesliceId::isValid(TimesliceId const& timeslice) { return timeslice.value != INVALID; }
 inline bool TimesliceSlot::isValid(TimesliceSlot const& slot) { return slot.index != INVALID; }
 
+inline bool TimesliceSlot::operator==(const TimesliceSlot that) const;
+{
+  return index == TimesliceSlot::ANY && TimesliceSlot::INVALID != that.index ||
+         index != TimesliceSlot::INVALID && TimesliceSlot::ANY == that.index ||
+         index == that.index;
+}
+
+inline bool TimesliceSlot::operator!=(const TimesliceSlot that) const;
+{
+  return !(*this == that);
+}
+
 inline void TimesliceIndex::resize(size_t s)
 {
   mVariables.resize(s);

--- a/Framework/Core/include/Framework/TimesliceIndex.inc
+++ b/Framework/Core/include/Framework/TimesliceIndex.inc
@@ -15,14 +15,14 @@ namespace framework
 inline bool TimesliceId::isValid(TimesliceId const& timeslice) { return timeslice.value != INVALID; }
 inline bool TimesliceSlot::isValid(TimesliceSlot const& slot) { return slot.index != INVALID; }
 
-inline bool TimesliceSlot::operator==(const TimesliceSlot that) const;
+inline bool TimesliceSlot::operator==(const TimesliceSlot that) const
 {
   return index == that.index ||
          index == TimesliceSlot::ANY && TimesliceSlot::INVALID != that.index ||
-         index != TimesliceSlot::INVALID && TimesliceSlot::ANY == that.index ||;
+         index != TimesliceSlot::INVALID && TimesliceSlot::ANY == that.index;
 }
 
-inline bool TimesliceSlot::operator!=(const TimesliceSlot that) const;
+inline bool TimesliceSlot::operator!=(const TimesliceSlot that) const
 {
   return !(*this == that);
 }

--- a/Framework/Core/include/Framework/TimesliceIndex.inc
+++ b/Framework/Core/include/Framework/TimesliceIndex.inc
@@ -17,9 +17,9 @@ inline bool TimesliceSlot::isValid(TimesliceSlot const& slot) { return slot.inde
 
 inline bool TimesliceSlot::operator==(const TimesliceSlot that) const;
 {
-  return index == TimesliceSlot::ANY && TimesliceSlot::INVALID != that.index ||
-         index != TimesliceSlot::INVALID && TimesliceSlot::ANY == that.index ||
-         index == that.index;
+  return index == that.index ||
+         index == TimesliceSlot::ANY && TimesliceSlot::INVALID != that.index ||
+         index != TimesliceSlot::INVALID && TimesliceSlot::ANY == that.index ||;
 }
 
 inline bool TimesliceSlot::operator!=(const TimesliceSlot that) const;

--- a/Framework/Core/include/Framework/TimesliceIndex.inc
+++ b/Framework/Core/include/Framework/TimesliceIndex.inc
@@ -18,8 +18,8 @@ inline bool TimesliceSlot::isValid(TimesliceSlot const& slot) { return slot.inde
 inline bool TimesliceSlot::operator==(const TimesliceSlot that) const
 {
   return index == that.index ||
-         index == TimesliceSlot::ANY && TimesliceSlot::INVALID != that.index ||
-         index != TimesliceSlot::INVALID && TimesliceSlot::ANY == that.index;
+         (index == TimesliceSlot::ANY && TimesliceSlot::INVALID != that.index) ||
+         (index != TimesliceSlot::INVALID && TimesliceSlot::ANY == that.index);
 }
 
 inline bool TimesliceSlot::operator!=(const TimesliceSlot that) const

--- a/Framework/Core/src/DataRelayer.cxx
+++ b/Framework/Core/src/DataRelayer.cxx
@@ -107,7 +107,7 @@ void DataRelayer::processDanglingInputs(std::vector<ExpirationHandler> const& ex
       if (!expirator.checker) {
         continue;
       }
-      if (slotsCreatedByHandlers[ei].index != slot.index) {
+      if (slotsCreatedByHandlers[ei] != slot) {
         continue;
       }
       if (expirator.checker(timestamp.value) == false) {

--- a/Framework/Core/src/LifetimeHelpers.cxx
+++ b/Framework/Core/src/LifetimeHelpers.cxx
@@ -45,8 +45,8 @@ size_t getCurrentTime()
 
 ExpirationHandler::Creator LifetimeHelpers::dataDrivenCreation()
 {
-  return [](TimesliceIndex&) -> TimesliceSlot {
-    return {TimesliceSlot::INVALID};
+  return [](TimesliceIndex& index) -> TimesliceSlot {
+    return {TimesliceSlot::ANY};
   };
 }
 


### PR DESCRIPTION
@ktf This should bring the original behaviour of data driven dangling inputs while not destroying the timers logic.
I haven't tried it yet locally, I am waiting until the latest stack compiles...