### PR TITLE
Split TrackTPC and its clusters and use span<POD> to receive DPL inputs

### DIFF
--- a/Common/MathUtils/include/MathUtils/Cartesian3D.h
+++ b/Common/MathUtils/include/MathUtils/Cartesian3D.h
@@ -226,4 +226,22 @@ class Transform3D : public ROOT::Math::Transform3D
 
 std::ostream& operator<<(std::ostream& os, const o2::Rotation2D& t);
 
+namespace std
+{
+
+/// Defining Point3D explicitly as trivially copyable
+///
+/// std::is_trivially_copyable<ROOT::Math::Cartesian3D<T>> fails because the class
+/// implements a copy constructor, although it does not much more than the default copy
+/// constructor. We need Point3D to fulfill the condition in order to make types
+/// inheriting from it or using it as member can be safely detected as messageable.
+///
+/// We believe that Point3D is messageable and explicitly specialize the type trait.
+/// There is a unit test for checking trivial copy
+/// This is a workaround, we will also make suggestions to fix the cause in ROOT itself
+/// TODO: delete once it is fixed in ROOT
+template <typename T>
+struct is_trivially_copyable<Point3D<T>> : std::true_type {
+};
+} // namespace std
 #endif

--- a/DataFormats/Detectors/ITSMFT/common/CMakeLists.txt
+++ b/DataFormats/Detectors/ITSMFT/common/CMakeLists.txt
@@ -15,7 +15,7 @@ o2_add_library(DataFormatsITSMFT
                        src/ClusterPattern.cxx
                        src/ClusterTopology.cxx
                        src/TopologyDictionary.cxx
-               PUBLIC_LINK_LIBRARIES O2::ITSMFTBase O2::ReconstructionDataFormats)
+               PUBLIC_LINK_LIBRARIES O2::ITSMFTBase O2::ReconstructionDataFormats O2::Framework)
 
 o2_target_root_dictionary(DataFormatsITSMFT
                           HEADERS include/DataFormatsITSMFT/ROFRecord.h
@@ -25,3 +25,8 @@ o2_target_root_dictionary(DataFormatsITSMFT
                                   include/DataFormatsITSMFT/ClusterTopology.h
                                   include/DataFormatsITSMFT/TopologyDictionary.h
                           LINKDEF src/ITSMFTDataFormatsLinkDef.h)
+
+o2_add_test(Cluster
+            SOURCES test/test_Cluster.cxx
+            COMPONENT_NAME DataFormatsITSMFT
+            PUBLIC_LINK_LIBRARIES O2::DataFormatsITSMFT)

--- a/DataFormats/Detectors/ITSMFT/common/CMakeLists.txt
+++ b/DataFormats/Detectors/ITSMFT/common/CMakeLists.txt
@@ -15,7 +15,8 @@ o2_add_library(DataFormatsITSMFT
                        src/ClusterPattern.cxx
                        src/ClusterTopology.cxx
                        src/TopologyDictionary.cxx
-               PUBLIC_LINK_LIBRARIES O2::ITSMFTBase O2::ReconstructionDataFormats O2::Framework)
+               PUBLIC_LINK_LIBRARIES O2::ITSMFTBase
+	                             O2::ReconstructionDataFormats)
 
 o2_target_root_dictionary(DataFormatsITSMFT
                           HEADERS include/DataFormatsITSMFT/ROFRecord.h

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/Cluster.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/Cluster.h
@@ -14,6 +14,7 @@
 #define ALICEO2_ITSMFT_CLUSTER_H
 
 #include "ReconstructionDataFormats/BaseCluster.h"
+#include "Framework/TypeTraits.h"
 
 // uncomment this to have cluster topology stored
 #define _ClusterTopology_
@@ -184,6 +185,25 @@ inline void Cluster::setClusterUsage(Int_t n)
     resetBit(kUsed);
 }
 } // namespace itsmft
+
+/// Defining o2::itsmft::Cluster explicitly as messageable
+///
+/// o2::itsmft::Cluster does not fulfill is_messageable because the underlying ROOT
+/// classes of Point3D are note trivially copyable.
+/// std::is_trivially_copyable<ROOT::Math::Cartesian3D<float>> fails because the class
+/// implements a copy constructor, although it does not much more than the default copy
+/// constructor. Have been trying to specialize std::is_trivially_copyable for Point3D
+/// alias in MathUtils/Cartesian3D.h, but structures with a member of Point3D are
+/// still not fulfilling the condition. Need to understand how the type trait checks
+/// the condition for members.
+/// We believe that o2::itsmft::Cluster is messageable and explicitly specialize the
+/// type trait, adding a corresponding unit test to go beyond make-believe
+namespace framework
+{
+template <>
+struct is_messageable<o2::itsmft::Cluster> : public std::true_type {
+};
+} // namespace framework
 } // namespace o2
 
 #endif /* ALICEO2_ITSMFT_CLUSTER_H */

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/Cluster.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/Cluster.h
@@ -14,7 +14,6 @@
 #define ALICEO2_ITSMFT_CLUSTER_H
 
 #include "ReconstructionDataFormats/BaseCluster.h"
-#include "Framework/TypeTraits.h"
 
 // uncomment this to have cluster topology stored
 #define _ClusterTopology_
@@ -200,14 +199,13 @@ inline void Cluster::setClusterUsage(Int_t n)
 /// type trait, adding a corresponding unit test to go beyond make-believe
 namespace framework
 {
+template <typename T>
+struct is_messageable;
 template <>
-struct is_messageable<o2::itsmft::Cluster> : public std::true_type {
+struct is_messageable<o2::itsmft::Cluster> : std::true_type {
 };
 } // namespace framework
-} // namespace o2
 
-template <>
-struct o2::framework::is_messageable<o2::itsmft::Cluster> : std::true_type {
-};
+} // namespace o2
 
 #endif /* ALICEO2_ITSMFT_CLUSTER_H */

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/Cluster.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/Cluster.h
@@ -206,4 +206,8 @@ struct is_messageable<o2::itsmft::Cluster> : public std::true_type {
 } // namespace framework
 } // namespace o2
 
+template <>
+struct o2::framework::is_messageable<o2::itsmft::Cluster> : std::true_type {
+};
+
 #endif /* ALICEO2_ITSMFT_CLUSTER_H */

--- a/DataFormats/Detectors/ITSMFT/common/test/test_Cluster.cxx
+++ b/DataFormats/Detectors/ITSMFT/common/test/test_Cluster.cxx
@@ -1,0 +1,47 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test DataFormatsITSMFT
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include "DataFormatsITSMFT/Cluster.h"
+
+namespace o2::itsmft
+{
+
+// we explicitly declare o2::itsmft::Cluster as messageable and have to make
+// sure that this is fulfilled
+BOOST_AUTO_TEST_CASE(Cluster_messageable)
+{
+  using ElementType = Cluster;
+  static_assert(o2::framework::is_messageable<ElementType>::value == true);
+  std::vector<ElementType> clusters(10);
+  auto makeElement = [](size_t idx) {
+    return ElementType{};
+  };
+  size_t idx = 0;
+  for (auto& cluster : clusters) {
+    cluster.setXYZ(idx, idx + 10, idx + 20);
+    idx++;
+  }
+
+  size_t memsize = sizeof(ElementType) * clusters.size();
+  auto buffer = std::make_unique<char[]>(memsize);
+  memcpy(buffer.get(), (char*)clusters.data(), memsize);
+  auto* pclone = reinterpret_cast<ElementType*>(buffer.get());
+
+  for (auto const& cluster : clusters) {
+    BOOST_REQUIRE(cluster.getXYZ() == pclone->getXYZ());
+    ++pclone;
+  }
+}
+
+} // namespace o2::itsmft

--- a/DataFormats/Detectors/TPC/CMakeLists.txt
+++ b/DataFormats/Detectors/TPC/CMakeLists.txt
@@ -16,32 +16,36 @@
 # * GPUCommonDef -> GPUCommonDef to follow more closely the rest of the AliceO2
 #   code, but probably the name should be simplified to remove some common ...
 
-o2_add_library(DataFormatsTPC
-               SOURCES src/Helpers.cxx src/TrackTPC.cxx src/TPCSectorHeader.cxx
-                       src/ClusterNativeHelper.cxx
-               PUBLIC_LINK_LIBRARIES O2::GPUCommon O2::SimulationDataFormat
-                                     O2::Headers O2::Algorithm)
+o2_add_library(
+  DataFormatsTPC
+  SOURCES src/Helpers.cxx src/TrackTPC.cxx src/TPCSectorHeader.cxx
+          src/ClusterNativeHelper.cxx
+  PUBLIC_LINK_LIBRARIES O2::GPUCommon O2::SimulationDataFormat
+                        O2::CommonDataFormat O2::Headers O2::Algorithm)
 
-o2_target_root_dictionary(DataFormatsTPC
-                          HEADERS include/DataFormatsTPC/ClusterGroupAttribute.h
-                                  include/DataFormatsTPC/ClusterNative.h
-                                  include/DataFormatsTPC/ClusterNativeHelper.h
-                                  include/DataFormatsTPC/ClusterHardware.h
-                                  include/DataFormatsTPC/Helpers.h
-                                  include/DataFormatsTPC/TrackTPC.h
-                                  include/DataFormatsTPC/Constants.h
-                                  include/DataFormatsTPC/Defs.h
-                                  include/DataFormatsTPC/dEdxInfo.h
-                                  include/DataFormatsTPC/CompressedClusters.h)
+o2_target_root_dictionary(
+  DataFormatsTPC
+  HEADERS include/DataFormatsTPC/ClusterGroupAttribute.h
+          include/DataFormatsTPC/ClusterNative.h
+          include/DataFormatsTPC/ClusterNativeHelper.h
+          include/DataFormatsTPC/ClusterHardware.h
+          include/DataFormatsTPC/Helpers.h
+          include/DataFormatsTPC/TrackTPC.h
+          include/DataFormatsTPC/Constants.h
+          include/DataFormatsTPC/Defs.h
+          include/DataFormatsTPC/dEdxInfo.h
+          include/DataFormatsTPC/CompressedClusters.h)
 
-o2_add_test(ClusterNative
-            SOURCES test/testClusterNative.cxx
-            COMPONENT_NAME DataFormats-TPC
-            PUBLIC_LINK_LIBRARIES O2::DataFormatsTPC
-            LABELS tpc dataformats)
+o2_add_test(
+  ClusterNative
+  SOURCES test/testClusterNative.cxx
+  COMPONENT_NAME DataFormats-TPC
+  PUBLIC_LINK_LIBRARIES O2::DataFormatsTPC
+  LABELS tpc dataformats)
 
-o2_add_test(ClusterHardware
-            SOURCES test/testClusterHardware.cxx
-            COMPONENT_NAME DataFormats-TPC
-            PUBLIC_LINK_LIBRARIES O2::DataFormatsTPC
-            LABELS tpc dataformats)
+o2_add_test(
+  ClusterHardware
+  SOURCES test/testClusterHardware.cxx
+  COMPONENT_NAME DataFormats-TPC
+  PUBLIC_LINK_LIBRARIES O2::DataFormatsTPC
+  LABELS tpc dataformats)

--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/TrackTPC.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/TrackTPC.h
@@ -12,10 +12,11 @@
 #define ALICEO2_TPC_TRACKTPC
 
 #include "ReconstructionDataFormats/Track.h"
-
+#include "CommonDataFormat/RangeReference.h"
 #include "DataFormatsTPC/ClusterNative.h"
 #include "DataFormatsTPC/Defs.h"
 #include "DataFormatsTPC/dEdxInfo.h"
+#include <gsl/span>
 
 namespace o2
 {
@@ -24,8 +25,23 @@ namespace tpc
 /// \class TrackTPC
 /// This is the definition of the TPC Track Object
 
+/* 
+   Currently the RootTreeWriter does not support vector<trivial_type> branches, 
+   see https://github.com/AliceO2Group/AliceO2/pull/2645
+   Therefore, at the moment we have to wrap trivial_type to struct and generate streamer 
+   for it.
+   Once the RootTreeWriter is fixed, this struct should be eliminated
+*/
+struct TPCClRefElem {
+  uint32_t v = 0;
+  operator uint32_t() const { return v; }
+  ClassDefNV(TPCClRefElem, 1);
+};
+
 class TrackTPC : public o2::track::TrackParCov
 {
+  using ClusRef = o2::dataformats::RangeReference<uint32_t, uint16_t>;
+
  public:
   enum Flags : unsigned short {
     HasASideClusters = 0x1 << 0,                                ///< track has clusters on A side
@@ -64,32 +80,45 @@ class TrackTPC : public o2::track::TrackParCov
   void setTime0(float v) { mTime0 = v; }
   void setChi2(float v) { mChi2 = v; }
   void setOuterParam(o2::track::TrackParCov&& v) { mOuterParam = v; }
-  void resetClusterReferences(int nClusters);
-  int getNClusterReferences() const { return mNClusters; }
-  void setClusterReference(int nCluster, uint8_t sectorIndex, uint8_t rowIndex, uint32_t clusterIndex)
+  const ClusRef& getClusterRef() const { return mClustersReference; }
+  void shiftFirstClusterRef(int dif) { mClustersReference.setFirstEntry(dif + mClustersReference.getFirstEntry()); }
+  int getNClusters() const { return mClustersReference.getEntries(); }
+  int getNClusterReferences() const { return getNClusters(); }
+  void setClusterRef(uint32_t entry, uint16_t ncl) { mClustersReference.set(entry, ncl); }
+
+  // TODO Temporary solution, see disclaimer about TPCClRefElem. Later will be changed to uint32_t
+  void getClusterReference(gsl::span<const o2::tpc::TPCClRefElem> clinfo, int nCluster,
+                           uint8_t& sectorIndex, uint8_t& rowIndex, uint32_t& clusterIndex) const
   {
-    mClusterReferences[nCluster] = clusterIndex;
-    reinterpret_cast<uint8_t*>(mClusterReferences.data())[4 * mNClusters + nCluster] = sectorIndex;
-    reinterpret_cast<uint8_t*>(mClusterReferences.data())[5 * mNClusters + nCluster] = rowIndex;
+    // data for given tracks starts at clinfo[ mClustersReference.getFirstEntry() ],
+    // 1st mClustersReference.getEntries() cluster indices are stored as uint32_t
+    // then sector indices as uint8_t, then row indices ar uin8_t
+
+    //    const uint32_t* clIndArr = &clinfo[ mClustersReference.getFirstEntry() ];
+    const uint32_t* clIndArr = reinterpret_cast<const uint32_t*>(&clinfo[mClustersReference.getFirstEntry()]); // TODO remove this trick
+    clusterIndex = clIndArr[nCluster];
+    const uint8_t* srIndexArr = reinterpret_cast<const uint8_t*>(clIndArr + mClustersReference.getEntries());
+    sectorIndex = srIndexArr[nCluster];
+    rowIndex = srIndexArr[nCluster + mClustersReference.getEntries()];
   }
-  void getClusterReference(int nCluster, uint8_t& sectorIndex, uint8_t& rowIndex, uint32_t& clusterIndex) const
-  {
-    clusterIndex = mClusterReferences[nCluster];
-    sectorIndex = reinterpret_cast<const uint8_t*>(mClusterReferences.data())[4 * mNClusters + nCluster];
-    rowIndex = reinterpret_cast<const uint8_t*>(mClusterReferences.data())[5 * mNClusters + nCluster];
-  }
-  const o2::tpc::ClusterNative& getCluster(int nCluster, const o2::tpc::ClusterNativeAccess& clusters,
-                                           uint8_t& sectorIndex, uint8_t& rowIndex) const
+
+  // TODO Temporary solution, see disclaimer about TPCClRefElem. Later will be changed to uint32_t
+  const o2::tpc::ClusterNative& getCluster(gsl::span<const o2::tpc::TPCClRefElem> clinfo, int nCluster,
+                                           const o2::tpc::ClusterNativeAccess& clusters, uint8_t& sectorIndex, uint8_t& rowIndex) const
   {
     uint32_t clusterIndex;
-    getClusterReference(nCluster, sectorIndex, rowIndex, clusterIndex);
+    getClusterReference(clinfo, nCluster, sectorIndex, rowIndex, clusterIndex);
     return (clusters.clusters[sectorIndex][rowIndex][clusterIndex]);
   }
-  const o2::tpc::ClusterNative& getCluster(int nCluster, const o2::tpc::ClusterNativeAccess& clusters) const
+
+  // TODO Temporary solution, see disclaimer about TPCClRefElem. Later will be changed to uint32_t
+  const o2::tpc::ClusterNative& getCluster(gsl::span<const o2::tpc::TPCClRefElem> clinfo, int nCluster,
+                                           const o2::tpc::ClusterNativeAccess& clusters) const
   {
     uint8_t sectorIndex, rowIndex;
-    return (getCluster(nCluster, clusters, sectorIndex, rowIndex));
+    return (getCluster(clinfo, nCluster, clusters, sectorIndex, rowIndex));
   }
+
   const dEdxInfo& getdEdx() const { return mdEdx; }
   void setdEdx(const dEdxInfo& v) { mdEdx = v; }
 
@@ -99,16 +128,13 @@ class TrackTPC : public o2::track::TrackParCov
                                       ///< side of TPC compatible with edge clusters sides.
   short mDeltaTFwd = 0;               ///< max possible increment to track time
   short mDeltaTBwd = 0;               ///< max possible decrement to track time
-  short mNClusters = 0;               ///< number of clusters attached
   short mFlags = 0;                   ///< various flags, see Flags enum
   float mChi2 = 0.f;                  // Chi2 of the track
   o2::track::TrackParCov mOuterParam; // Track parameters at outer end of TPC.
   dEdxInfo mdEdx;                     // dEdx Information
+  ClusRef mClustersReference;         // reference to externale cluster indices
 
-  // New structure to store cluster references
-  std::vector<uint32_t> mClusterReferences;
-
-  ClassDefNV(TrackTPC, 2); // RS TODO set to 1
+  ClassDefNV(TrackTPC, 3);
 };
 
 } // namespace tpc

--- a/DataFormats/Detectors/TPC/src/DataFormatsTPCLinkDef.h
+++ b/DataFormats/Detectors/TPC/src/DataFormatsTPCLinkDef.h
@@ -37,4 +37,8 @@
 #pragma link C++ class o2::tpc::CompressedClustersPtrs_helper < o2::tpc::CompressedClustersCounters> + ;
 #pragma link C++ class o2::tpc::CompressedClusters + ;
 
+// TODO Temporary solution, see disclaimer about TPCClRefElem in the TrackTPC.h
+#pragma link C++ class o2::tpc::TPCClRefElem + ;
+#pragma link C++ class std::vector < o2::tpc::TPCClRefElem> + ;
+
 #endif

--- a/DataFormats/Detectors/TPC/src/TrackTPC.cxx
+++ b/DataFormats/Detectors/TPC/src/TrackTPC.cxx
@@ -15,9 +15,3 @@
 #include "DataFormatsTPC/TrackTPC.h"
 
 using namespace o2::tpc;
-
-void TrackTPC::resetClusterReferences(int nClusters)
-{
-  mNClusters = short(nClusters);
-  mClusterReferences.resize(nClusters + (nClusters + 1) / 2);
-}

--- a/DataFormats/common/src/CommonDataFormatLinkDef.h
+++ b/DataFormats/common/src/CommonDataFormatLinkDef.h
@@ -32,6 +32,7 @@
 
 #pragma link C++ class o2::dataformats::EvIndex < int, int> + ;
 #pragma link C++ class o2::dataformats::RangeReference < int, int> + ;
+#pragma link C++ class o2::dataformats::RangeReference < uint32_t, uint16_t> + ;
 #pragma link C++ class o2::dataformats::RangeReference < o2::dataformats::EvIndex < int, int>, int> + ;
 
 #pragma link C++ class o2::dataformats::RangeRefComp < 4> + ; // reference to a set with 15 entries max (ITS clusters)

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
@@ -21,6 +21,7 @@
 #include <array>
 #include <vector>
 #include <string>
+#include <gsl/span>
 #include <TStopwatch.h>
 #include "DataFormatsTPC/TrackTPC.h"
 #include "ReconstructionDataFormats/Track.h"
@@ -195,52 +196,53 @@ class MatchTPCITS
   }
 
   ///< set input ITS tracks received via DPL
-  void setITSTracksInp(const std::vector<o2::its::TrackITS>* inp)
+  void setITSTracksInp(const gsl::span<const o2::its::TrackITS> inp)
   {
     assertDPLIO(true);
     mITSTracksArrayInp = inp;
   }
 
   ///< set input ITS tracks cluster indices received via DPL
-  void setITSTrackClusIdxInp(const std::vector<int>* inp)
+  void setITSTrackClusIdxInp(const gsl::span<const int> inp)
   {
     assertDPLIO(true);
     mITSTrackClusIdxInp = inp;
   }
 
-  ///< set input ITS tracks cluster indices received via DPL
-  void setITSTrackClusIdxInp(gsl::span<const int> inp)
-  {
-    assertDPLIO(true);
-    mITSTrackClusIdxSPAN = inp;
-  }
-
   ///< set input ITS tracks ROF records received via DPL
-  void setITSTrackROFRecInp(const std::vector<o2::itsmft::ROFRecord>* inp)
+  void setITSTrackROFRecInp(const gsl::span<const o2::itsmft::ROFRecord> inp)
   {
     assertDPLIO(true);
     mITSTrackROFRec = inp;
   }
 
   ///< set input ITS clusters received via DPL
-  void setITSClustersInp(const std::vector<o2::itsmft::Cluster>* inp)
+  void setITSClustersInp(const gsl::span<const o2::itsmft::Cluster> inp)
   {
     assertDPLIO(true);
     mITSClustersArrayInp = inp;
   }
 
   ///< set input ITS clusters ROF records received via DPL
-  void setITSClusterROFRecInp(const std::vector<o2::itsmft::ROFRecord>* inp)
+  void setITSClusterROFRecInp(const gsl::span<const o2::itsmft::ROFRecord> inp)
   {
     assertDPLIO(true);
     mITSClusterROFRec = inp;
   }
 
   ///< set input TPC tracks received via DPL
-  void setTPCTracksInp(const std::vector<o2::tpc::TrackTPC>* inp)
+  void setTPCTracksInp(const gsl::span<const o2::tpc::TrackTPC> inp)
   {
     assertDPLIO(true);
     mTPCTracksArrayInp = inp;
+  }
+
+  ///< set input TPC tracks cluster indices received via DPL
+  // TODO Temporary solution, see disclaimer about TPCClRefElem in TrackTPC. Later should be changed to uint32_t
+  void setTPCTrackClusIdxInp(const gsl::span<const o2::tpc::TPCClRefElem> inp)
+  {
+    assertDPLIO(true);
+    mTPCTrackClusIdxInp = inp;
   }
 
   ///< set input TPC clusters received via DPL
@@ -300,6 +302,7 @@ class MatchTPCITS
   ///< set input branch names for the input from the tree
   void setITSTrackBranchName(const std::string& nm) { mITSTrackBranchName = nm; }
   void setTPCTrackBranchName(const std::string& nm) { mTPCTrackBranchName = nm; }
+  void setTPCTrackClusIdxBranchName(const std::string& nm) { mTPCTrackClusIdxBranchName = nm; }
   void setITSClusterBranchName(const std::string& nm) { mITSClusterBranchName = nm; }
   void setITSMCTruthBranchName(const std::string& nm) { mITSMCTruthBranchName = nm; }
   void setTPCMCTruthBranchName(const std::string& nm) { mTPCMCTruthBranchName = nm; }
@@ -311,6 +314,7 @@ class MatchTPCITS
   ///< get input branch names for the input from the tree
   const std::string& getITSTrackBranchName() const { return mITSTrackBranchName; }
   const std::string& getTPCTrackBranchName() const { return mTPCTrackBranchName; }
+  const std::string& getTPCTrackClusIdxBranchName() const { return mTPCTrackClusIdxBranchName; }
   const std::string& getITSClusterBranchName() const { return mITSClusterBranchName; }
   const std::string& getITSMCTruthBranchName() const { return mITSMCTruthBranchName; }
   const std::string& getTPCMCTruthBranchName() const { return mTPCMCTruthBranchName; }
@@ -555,13 +559,28 @@ class MatchTPCITS
 
   ///>>>------ these are input arrays which should not be modified by the matching code
   //           since this info is provided by external device
-  const std::vector<o2::itsmft::ROFRecord>* mITSTrackROFRec = nullptr;    ///< input ITS tracks ROFRecord
-  const std::vector<o2::its::TrackITS>* mITSTracksArrayInp = nullptr;     ///< input ITS tracks
-  const std::vector<o2::tpc::TrackTPC>* mTPCTracksArrayInp = nullptr;     ///< input TPC tracks
-  gsl::span<const int> mITSTrackClusIdxSPAN;                              ///< input ITS track cluster indices span from DPL
-  const std::vector<int>* mITSTrackClusIdxInp = nullptr;                  ///< input ITS track cluster indices
-  const std::vector<o2::itsmft::Cluster>* mITSClustersArrayInp = nullptr; ///< input ITS clusters
-  const std::vector<o2::itsmft::ROFRecord>* mITSClusterROFRec = nullptr;  ///< input ITS clusters ROFRecord
+  std::vector<o2::tpc::TrackTPC>* mTPCTracksArrayPtr = nullptr; ///< input TPC tracks from tree
+  gsl::span<const o2::tpc::TrackTPC> mTPCTracksArrayInp;        ///< input TPC tracks span
+
+  // TODO Temporary solution, see disclaimer about TPCClRefElem in TrackTPC. Later will be changed to uint32_t
+  std::vector<o2::tpc::TPCClRefElem>* mTPCTrackClusIdxPtr = nullptr; ///< input TPC track cluster indices from tree
+  gsl::span<const o2::tpc::TPCClRefElem> mTPCTrackClusIdxInp;        ///< input TPC track cluster indices span from DPL
+
+  std::vector<o2::itsmft::ROFRecord>* mITSTrackROFRecPtr = nullptr; ///< input ITS tracks ROFRecord from tree
+  gsl::span<const o2::itsmft::ROFRecord> mITSTrackROFRec;           ///< input ITS tracks ROFRecord span from DPL
+
+  std::vector<o2::its::TrackITS>* mITSTracksArrayPtr = nullptr; ///< input ITS tracks read from tree
+  gsl::span<const o2::its::TrackITS> mITSTracksArrayInp;        ///< input ITS tracks span
+
+  std::vector<int>* mITSTrackClusIdxPtr = nullptr; ///< input ITS track cluster indices from tree
+  gsl::span<const int> mITSTrackClusIdxInp;        ///< input ITS track cluster indices span from DPL
+
+  const std::vector<o2::itsmft::Cluster>* mITSClustersArrayPtr = nullptr; ///< input ITS clusters from tree
+  gsl::span<const o2::itsmft::Cluster> mITSClustersArrayInp;              ///< input ITS clusters from tree from DPL
+
+  const std::vector<o2::itsmft::ROFRecord>* mITSClusterROFRecPtr = nullptr; ///< input ITS clusters ROFRecord from tree
+  gsl::span<const o2::itsmft::ROFRecord> mITSClusterROFRec;                 ///< input ITS clusters ROFRecord span from DPL
+
   const std::vector<o2::ft0::RecPoints>* mFITInfoInp = nullptr;           ///< optional input FIT info
   const o2::tpc::ClusterNativeAccess* mTPCClusterIdxStruct = nullptr;     ///< struct holding the TPC cluster indices
 
@@ -613,6 +632,7 @@ class MatchTPCITS
   std::string mITSTrackClusIdxBranchName = "ITSTrackClusIdx"; ///< name of branch containing input ITS tracks cluster indices
   std::string mITSTrackROFRecBranchName = "ITSTracksROF";     ///< name of branch containing input ITS tracks ROFRecords
   std::string mTPCTrackBranchName = "Tracks";                 ///< name of branch containing input TPC tracks
+  std::string mTPCTrackClusIdxBranchName = "ClusRefs";        ///< name of branch containing input TPC tracks cluster references
   std::string mITSClusterBranchName = "ITSCluster";           ///< name of branch containing input ITS clusters
   std::string mITSClusterROFRecBranchName = "ITSClustersROF"; ///< name of branch containing input ITS clusters ROFRecords
   std::string mITSMCTruthBranchName = "ITSTrackMCTruth";      ///< name of branch containing ITS MC labels

--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -7,6 +7,8 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
+
+#include <TSystem.h>
 #include <TTree.h>
 #include <cassert>
 
@@ -337,42 +339,49 @@ void MatchTPCITS::attachInputTrees()
   if (!mTreeITSTracks->GetBranch(mITSTrackBranchName.data())) {
     LOG(FATAL) << "Did not find ITS tracks branch " << mITSTrackBranchName << " in the input tree";
   }
-  mTreeITSTracks->SetBranchAddress(mITSTrackBranchName.data(), &mITSTracksArrayInp);
+  mTreeITSTracks->SetBranchAddress(mITSTrackBranchName.data(), &mITSTracksArrayPtr);
   LOG(INFO) << "Attached ITS tracks " << mITSTrackBranchName << " branch with " << mTreeITSTracks->GetEntries()
             << " entries";
 
   if (!mTreeITSTracks->GetBranch(mITSTrackClusIdxBranchName.data())) {
     LOG(FATAL) << "Did not find ITS track cluster indices branch " << mITSTrackClusIdxBranchName << " in the input tree";
   }
-  mTreeITSTracks->SetBranchAddress(mITSTrackClusIdxBranchName.data(), &mITSTrackClusIdxInp);
+  mTreeITSTracks->SetBranchAddress(mITSTrackClusIdxBranchName.data(), &mITSTrackClusIdxPtr);
   LOG(INFO) << "Attached ITS track cluster indices " << mITSTrackClusIdxBranchName << " branch with "
             << mTreeITSTracks->GetEntries() << " entries";
 
   if (!mTreeITSTrackROFRec->GetBranch(mITSTrackROFRecBranchName.data())) {
     LOG(FATAL) << "Did not find ITS tracks ROFRecords branch " << mITSTrackROFRecBranchName << " in the input tree";
   }
-  mTreeITSTrackROFRec->SetBranchAddress(mITSTrackROFRecBranchName.data(), &mITSTrackROFRec);
+  mTreeITSTrackROFRec->SetBranchAddress(mITSTrackROFRecBranchName.data(), &mITSTrackROFRecPtr);
   LOG(INFO) << "Attached ITS tracks ROFRec " << mITSTrackROFRecBranchName << " branch with "
             << mTreeITSTrackROFRec->GetEntries() << " entries";
 
   if (!mTreeTPCTracks->GetBranch(mTPCTrackBranchName.data())) {
     LOG(FATAL) << "Did not find TPC tracks branch " << mTPCTrackBranchName << " in the input tree";
   }
-  mTreeTPCTracks->SetBranchAddress(mTPCTrackBranchName.data(), &mTPCTracksArrayInp);
-  LOG(INFO) << "Attached TPC tracks " << mTPCTrackBranchName << " branch with " << mTreeTPCTracks->GetEntries()
-            << " entries";
+  mTreeTPCTracks->SetBranchAddress(mTPCTrackBranchName.data(), &mTPCTracksArrayPtr);
+  LOG(INFO) << "Attached TPC tracks " << mTPCTrackBranchName << " branch with "
+            << mTreeTPCTracks->GetBranch(mTPCTrackBranchName.data())->GetEntries() << " entries";
+
+  if (!mTreeTPCTracks->GetBranch(mTPCTrackClusIdxBranchName.data())) {
+    LOG(FATAL) << "Did not find TPC tracks cluster references branch " << mTPCTrackClusIdxBranchName << " in the input tree";
+  }
+  mTreeTPCTracks->SetBranchAddress(mTPCTrackClusIdxBranchName.data(), &mTPCTrackClusIdxPtr);
+  LOG(INFO) << "Attached TPC tracks cluster references " << mTPCTrackClusIdxBranchName << " branch with "
+            << mTreeTPCTracks->GetBranch(mTPCTrackClusIdxBranchName.data())->GetEntries() << " entries";
 
   if (!mTreeITSClusters->GetBranch(mITSClusterBranchName.data())) {
     LOG(FATAL) << "Did not find ITS clusters branch " << mITSClusterBranchName << " in the input tree";
   }
-  mTreeITSClusters->SetBranchAddress(mITSClusterBranchName.data(), &mITSClustersArrayInp);
+  mTreeITSClusters->SetBranchAddress(mITSClusterBranchName.data(), &mITSClustersArrayPtr);
   LOG(INFO) << "Attached ITS clusters " << mITSClusterBranchName << " branch with " << mTreeITSClusters->GetEntries()
             << " entries";
 
   if (!mTreeITSClusterROFRec->GetBranch(mITSClusterROFRecBranchName.data())) {
     LOG(FATAL) << "Did not find ITS clusters ROFRecords branch " << mITSClusterROFRecBranchName << " in the input tree";
   }
-  mTreeITSClusterROFRec->SetBranchAddress(mITSClusterROFRecBranchName.data(), &mITSClusterROFRec);
+  mTreeITSClusterROFRec->SetBranchAddress(mITSClusterROFRecBranchName.data(), &mITSClusterROFRecPtr);
   LOG(INFO) << "Attached ITS clusters ROFRec " << mITSClusterROFRecBranchName << " branch with "
             << mTreeITSClusterROFRec->GetEntries() << " entries";
 
@@ -418,7 +427,7 @@ bool MatchTPCITS::prepareTPCTracks()
     curTracksEntry = mTreeTPCTracks ? mTreeTPCTracks->GetReadEntry() : 0;
   }
 
-  int ntr = mTPCTracksArrayInp->size();
+  int ntr = mTPCTracksArrayInp.size();
   mMatchesTPC.reserve(mMatchesTPC.size() + ntr);
   // number of records might be actually more than N tracks!
   mMatchRecordsTPC.reserve(mMatchRecordsTPC.size() + mMaxMatchCandidates * ntr);
@@ -438,7 +447,7 @@ bool MatchTPCITS::prepareTPCTracks()
 
   for (int it = 0; it < ntr; it++) {
 
-    const auto& trcOrig = (*mTPCTracksArrayInp)[it];
+    const auto& trcOrig = mTPCTracksArrayInp[it];
 
     // make sure the track was propagated to inner TPC radius at the ref. radius
     if (trcOrig.getX() > XTPCInnerRef + 0.1)
@@ -539,9 +548,11 @@ bool MatchTPCITS::prepareITSTracks()
 
   if (!mDPLIO) { // for input from tree read ROFrecords vector, in DPL IO mode the vector should be already attached
     mTreeITSTrackROFRec->GetEntry(0);
+    mITSTrackROFRec = gsl::span<const o2::itsmft::ROFRecord>(mITSTrackROFRecPtr->data(), mITSTrackROFRecPtr->size());
     mTreeITSClusterROFRec->GetEntry(0); // keep clusters ROFRecs ready
+    mITSClusterROFRec = gsl::span<const o2::itsmft::ROFRecord>(mITSClusterROFRecPtr->data(), mITSClusterROFRecPtr->size());
   }
-  int nROFs = mITSTrackROFRec->size();
+  int nROFs = mITSTrackROFRec.size();
 
   mMatchesITS.clear();
 
@@ -563,13 +574,15 @@ bool MatchTPCITS::prepareITSTracks()
     mITSTimeBinStart[sec].clear();
     mITSTimeBinStart[sec].resize(nROFs, -1); // start of ITS work tracks in every sector
   }
-  setStartIR((*mITSTrackROFRec)[0].getBCData());
+  setStartIR(mITSTrackROFRec[0].getBCData());
   for (int irof = 0; irof < nROFs; irof++) {
-    const auto& rofRec = (*mITSTrackROFRec)[irof];
+    const auto& rofRec = mITSTrackROFRec[irof];
     // in case of the input from the tree make sure needed entry is loaded
     auto rEntry = rofRec.getROFEntry().getEvent();
     if (!mDPLIO && mCurrITSTracksTreeEntry != rEntry) { // in DPL IO mode the input tracks must be already attached
       mTreeITSTracks->GetEntry((mCurrITSTracksTreeEntry = rEntry));
+      mITSTracksArrayInp = gsl::span<const o2::its::TrackITS>(mITSTracksArrayPtr->data(), mITSTracksArrayPtr->size());
+      mITSTrackClusIdxInp = gsl::span<const int>(mITSTrackClusIdxPtr->data(), mITSTrackClusIdxPtr->size());
     }
     float tmn = intRecord2TPCTimeBin(rofRec.getBCData());     // ITS track min time in TPC time-bins
     mITSROFTimes.emplace_back(tmn, tmn + mITSROFrame2TPCBin); // ITS track min/max time in TPC time-bins
@@ -580,7 +593,7 @@ bool MatchTPCITS::prepareITSTracks()
 
     int trlim = rofRec.getROFEntry().getIndex() + rofRec.getNROFEntries();
     for (int it = rofRec.getROFEntry().getIndex(); it < trlim; it++) {
-      auto& trcOrig = (*mITSTracksArrayInp)[it];
+      const auto& trcOrig = mITSTracksArrayInp[it];
       if (trcOrig.getParamOut().getX() < 1.) {
         continue; // backward refit failed
       }
@@ -694,11 +707,15 @@ bool MatchTPCITS::loadTPCTracksNextChunk()
   mTimerIO.Start(false);
   while (++mCurrTPCTracksTreeEntry < mTreeTPCTracks->GetEntries()) {
     mTreeTPCTracks->GetEntry(mCurrTPCTracksTreeEntry);
-    LOG(DEBUG) << "Loading TPC tracks entry " << mCurrTPCTracksTreeEntry << " -> " << mTPCTracksArrayInp->size()
+    LOG(DEBUG) << "Loading TPC tracks entry " << mCurrTPCTracksTreeEntry << " -> " << mTPCTracksArrayPtr->size()
                << " tracks";
-    if (mTPCTracksArrayInp->size() < 1) {
+    if (mTPCTrackClusIdxPtr->size() < 1) {
       continue;
     }
+    mTPCTracksArrayInp = gsl::span<const o2::tpc::TrackTPC>(mTPCTracksArrayPtr->data(), mTPCTracksArrayPtr->size());
+    // TODO Temporary solution, see disclaimer about TPCClRefElem in TrackTPC. Later should be changed to uint32_t
+    mTPCTrackClusIdxInp = gsl::span<const o2::tpc::TPCClRefElem>(mTPCTrackClusIdxPtr->data(), mTPCTrackClusIdxPtr->size());
+
     mTimerIO.Stop();
     return true;
   }
@@ -1243,7 +1260,7 @@ bool MatchTPCITS::refitTrackTPCITS(int iITS)
     loadTPCTracksChunk(tTPC.source.getEvent());
     loadTPCClustersChunk(tTPC.source.getEvent());
   }
-  auto itsTrOrig = (*mITSTracksArrayInp)[tITS.source.getIndex()]; // currently we store clusterIDs in the track
+  const auto& itsTrOrig = mITSTracksArrayInp[tITS.source.getIndex()]; // currently we store clusterIDs in the track
 
   mMatchedTracks.emplace_back(tTPC, tITS); // create a copy of TPC track at xRef
   auto& trfit = mMatchedTracks.back();
@@ -1262,11 +1279,11 @@ bool MatchTPCITS::refitTrackTPCITS(int iITS)
   auto propagator = o2::base::Propagator::Instance();
   // NOTE: the ITS cluster index is stored wrt 1st cluster of relevant ROF, while here we extract clusters from the
   // buffer for the whole TF. Therefore, we should shift the index by the entry of the ROF's 1st cluster in the global cluster buffer
-  int clusIndOffs = (*mITSClusterROFRec)[tITS.roFrame].getROFEntry().getIndex();
+  int clusIndOffs = mITSClusterROFRec[tITS.roFrame].getROFEntry().getIndex();
 
   int clEntry = itsTrOrig.getFirstClusterEntry();
   for (int icl = 0; icl < ncl; icl++) {
-    const auto& clus = (*mITSClustersArrayInp)[clusIndOffs + (*mITSTrackClusIdxInp)[clEntry++]];
+    const auto& clus = mITSClustersArrayInp[clusIndOffs + mITSTrackClusIdxInp[clEntry++]];
     float alpha = geom->getSensorRefAlpha(clus.getSensorID()), x = clus.getX();
     if (!trfit.rotate(alpha) ||
         // note: here we also calculate the L,T integral (in the inward direction, but this is irrelevant)
@@ -1301,7 +1318,7 @@ bool MatchTPCITS::refitTrackTPCITS(int iITS)
   }
 
   /// precise time estimate
-  auto tpcTrOrig = (*mTPCTracksArrayInp)[tTPC.source.getIndex()];
+  auto tpcTrOrig = mTPCTracksArrayInp[tTPC.source.getIndex()];
   float timeTB = tpcTrOrig.getTime0() - mNTPCBinsFullDrift;
   if (tpcTrOrig.hasASideClustersOnly()) {
     timeTB += deltaT;
@@ -1325,7 +1342,7 @@ bool MatchTPCITS::refitTrackTPCITS(int iITS)
     std::array<float, 3> clsCov = {};
     float clsX;
 
-    const auto& cl = tpcTrOrig.getCluster(icl, *mTPCClusterIdxStruct, sector, row);
+    const auto& cl = tpcTrOrig.getCluster(mTPCTrackClusIdxInp, icl, *mTPCClusterIdxStruct, sector, row);
     mTPCTransform->Transform(sector, row, cl.getPad(), cl.getTime(), clsX, clsYZ[0], clsYZ[1], timeTB);
     // rotate to 1 cluster's sector
     if (!tracOut.rotate(o2::utils::Sector2Angle(sector % 18))) {
@@ -1354,7 +1371,7 @@ bool MatchTPCITS::refitTrackTPCITS(int iITS)
     prevsector = sector;
 
     for (; icl--;) {
-      const auto& cl = tpcTrOrig.getCluster(icl, *mTPCClusterIdxStruct, sector, row);
+      const auto& cl = tpcTrOrig.getCluster(mTPCTrackClusIdxInp, icl, *mTPCClusterIdxStruct, sector, row);
       if (row <= prevrow) {
         LOG(WARNING) << "New row/sect " << int(row) << '/' << int(sector) << " is <= the previous " << int(prevrow)
                      << '/' << int(prevsector) << " TrackID: " << tTPC.source.getIndex() << " Pt:" << tracOut.getPt();
@@ -1419,6 +1436,7 @@ void MatchTPCITS::loadITSClustersChunk(int chunk)
   if (mCurrITSClustersTreeEntry != chunk) {
     mTimerIO.Start(false);
     mTreeITSClusters->GetEntry(mCurrITSClustersTreeEntry = chunk);
+    mITSClustersArrayInp = gsl::span<const o2::itsmft::Cluster>(mITSClustersArrayPtr->data(), mITSClustersArrayPtr->size());
     mTimerIO.Stop();
   }
 }

--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackInterpolation.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackInterpolation.h
@@ -177,6 +177,7 @@ class TrackInterpolation
   /// Setters and Getters for the input branch/file names
   void setITSTPCTrackBranchName(const std::string& name) { mITSTPCTrackBranchName = name; }
   void setTPCTrackBranchName(const std::string& name) { mTPCTrackBranchName = name; }
+  void setTPCTrackClIdxBranchName(const std::string& name) { mTPCTrackClIdxBranchName = name; }
   void setTPCClusterFileName(const std::string& name) { mTPCClusterFileName = name; }
   void setITSTrackBranchName(const std::string& name) { mITSTrackBranchName = name; }
   void setITSClusterBranchName(const std::string& name) { mITSClusterBranchName = name; }
@@ -185,6 +186,7 @@ class TrackInterpolation
 
   const std::string& getITSTPCTrackBranchName() const { return mITSTPCTrackBranchName; }
   const std::string& getTPCTrackBranchName() const { return mTPCTrackBranchName; }
+  const std::string& getTPCTrackClIdxBranchName() const { return mTPCTrackClIdxBranchName; }
   const std::string& getTPCClusterFileName() const { return mTPCClusterFileName; }
   const std::string& getITSTrackBranchName() const { return mITSTrackBranchName; }
   const std::string& getITSClusterBranchName() const { return mITSClusterBranchName; }
@@ -195,6 +197,7 @@ class TrackInterpolation
   // names of input files / branches
   std::string mITSTPCTrackBranchName{"TPCITS"};                ///< name of branch containing ITS-TPC matched tracks
   std::string mTPCTrackBranchName{"Tracks"};                   ///< name of branch containing TPC tracks (needed for TPC cluster access)
+  std::string mTPCTrackClIdxBranchName{"ClusRefs"};            ///< name of branch containing TPC tracks cluster refs (needed for TPC cluster access)
   std::string mTPCClusterFileName{"tpc-native-clusters.root"}; ///< name of file containing TPC native clusters
   std::string mITSTrackBranchName{"ITSTrack"};                 ///< name of branch containing input ITS tracks
   std::string mITSClusterBranchName{"ITSCluster"};             ///< name of branch containing input ITS clusters
@@ -220,6 +223,8 @@ class TrackInterpolation
   TTree* mTreeTOFClusters{nullptr};                                                                              ///< input tree for TOF clusters
   std::vector<o2::dataformats::TrackTPCITS>* mITSTPCTrackVecInput{nullptr};                                      ///< input vector with ITS-TPC matched tracks
   std::vector<TrackTPC>* mTPCTrackVecInput{nullptr};                                                             ///< input vector with TPC tracks
+  // TODO Temporary solution, see disclaimer about TPCClRefElem in TrackTPC. Later will be changed to uint32_t
+  std::vector<TPCClRefElem>* mTPCTrackClIdxVecInput{nullptr};                                                    ///< input vector with TPC tracks cluster indicies
   std::vector<o2::its::TrackITS>* mITSTrackVecInput{nullptr};                                                    ///< input vector with ITS tracks
   std::vector<o2::itsmft::Cluster>* mITSClusterVecInput{nullptr};                                                ///< input vector with ITS clusters
   ClusterNativeHelper::Reader* mTPCClusterReader = nullptr;                                                      ///< TPC cluster reader

--- a/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
+++ b/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
@@ -162,8 +162,8 @@ bool TrackInterpolation::interpolateTrackITSTOF(const std::pair<o2::dataformats:
   for (int iCl = trkTPC.getNClusterReferences(); iCl--;) {
     uint8_t sector, row;
     uint32_t clusterIndexInRow;
-    trkTPC.getClusterReference(iCl, sector, row, clusterIndexInRow);
-    const auto& clTPC = trkTPC.getCluster(iCl, *mTPCClusterIdxStruct, sector, row);
+    trkTPC.getClusterReference(*mTPCTrackClIdxVecInput, iCl, sector, row, clusterIndexInRow);
+    const auto& clTPC = trkTPC.getCluster(*mTPCTrackClIdxVecInput, iCl, *mTPCClusterIdxStruct, sector, row);
     float clTPCX;
     std::array<float, 2> clTPCYZ;
     mFastTransform->TransformIdeal(sector, row, clTPC.getPad(), clTPC.getTime(), clTPCX, clTPCYZ[0], clTPCYZ[1], clusterTimeBinOffset);
@@ -299,8 +299,8 @@ bool TrackInterpolation::extrapolateTrackITS(const o2::its::TrackITS& trkITS, co
   for (int iCl = trkTPC.getNClusterReferences(); iCl--;) {
     uint8_t sector, row;
     uint32_t clusterIndexInRow;
-    trkTPC.getClusterReference(iCl, sector, row, clusterIndexInRow);
-    const auto& cl = trkTPC.getCluster(iCl, *mTPCClusterIdxStruct, sector, row);
+    trkTPC.getClusterReference(*mTPCTrackClIdxVecInput, iCl, sector, row, clusterIndexInRow);
+    const auto& cl = trkTPC.getCluster(*mTPCTrackClIdxVecInput, iCl, *mTPCClusterIdxStruct, sector, row);
     float x = 0, y = 0, z = 0;
     mFastTransform->TransformIdeal(sector, row, cl.getPad(), cl.getTime(), x, y, z, clusterTimeBinOffset);
     if (!trk.rotate(o2::utils::Sector2Angle(sector))) {
@@ -371,6 +371,10 @@ void TrackInterpolation::attachInputTrees()
   mTreeTPCTracks->SetBranchAddress(mTPCTrackBranchName.data(), &mTPCTrackVecInput);
   LOG(info) << "Attached TPC tracks " << mTPCTrackBranchName << " branch with "
             << mTreeTPCTracks->GetEntries() << " entries";
+  mTreeTPCTracks->SetBranchAddress(mTPCTrackClIdxBranchName.data(), &mTPCTrackClIdxVecInput);
+  LOG(info) << "Attached TPC tracks cluster indices " << mTPCTrackClIdxBranchName << " branch with "
+            << mTreeTPCTracks->GetBranch(mTPCTrackClIdxBranchName.data())->GetEntries() << " entries";
+
   // access input for TPC clusters
   if (!mTPCClusterReader) {
     LOG(fatal) << "TPC clusters reader is not set";

--- a/Detectors/TPC/reconstruction/test/testGPUCATracking.cxx
+++ b/Detectors/TPC/reconstruction/test/testGPUCATracking.cxx
@@ -95,6 +95,9 @@ BOOST_AUTO_TEST_CASE(CATracking_test1)
   std::vector<TrackTPC> tracks;
   ptrs.clusters = clusters.get();
   ptrs.outputTracks = &tracks;
+  // TODO Temporary solution, see disclaimer about TPCClRefElem in TrackTPC. Later will be changed to uint32_t and remove the cast
+  std::vector<TPCClRefElem> trackClusRefs;
+  ptrs.outputClusRefs = reinterpret_cast<std::vector<uint32_t>*>(&trackClusRefs);
 
   int retVal = tracker.runTracking(&ptrs);
   BOOST_CHECK_EQUAL(retVal, 0);

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TrackReaderSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TrackReaderSpec.h
@@ -42,6 +42,8 @@ class TrackReader : public Task
   void accumulate();
 
   std::vector<o2::tpc::TrackTPC>*mTracksInp = nullptr, mTracksOut;
+  // TODO Temporary solution, see disclaimer about TPCClRefElem in TrackTOC. Later will be changed to uint32_t
+  std::vector<o2::tpc::TPCClRefElem>*mCluRefVecInp = nullptr, mCluRefVecOut;
   o2::dataformats::MCTruthContainer<o2::MCCompLabel>*mMCTruthInp = nullptr, mMCTruthOut;
 
   bool mFinished = false;
@@ -50,6 +52,7 @@ class TrackReader : public Task
   std::string mInputFileName = "tpctracks.root";
   std::string mTrackTreeName = "events";
   std::string mTrackBranchName = "Tracks";
+  std::string mClusRefBranchName = "ClusRefs";
   std::string mTrackMCTruthBranchName = "TracksMCTruth";
 };
 

--- a/Detectors/TPC/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/TPC/workflow/src/RecoWorkflow.cxx
@@ -354,24 +354,32 @@ framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors, std::vec
 
     //branch definitions for RootTreeWriter spec
     using TrackOutputType = std::vector<o2::tpc::TrackTPC>;
-    using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
-    auto tracksdef = BranchDefinition<TrackOutputType>{InputSpec{"input", "TPC", "TRACKS"},     //
-                                                       "TPCTracks", "track-branch-name"};       //
-    auto mcdef = BranchDefinition<MCLabelContainer>{InputSpec{"mcinput", "TPC", "TRACKMCLBL"},  //
-                                                    "TPCTracksMCTruth", "trackmc-branch-name"}; //
 
-    // depending on the MC propagation flag, the RootTreeWriter spec is created with two
-    // or one branch definition
+    // Temporary solution, see disclaimer about TPCClRefElem in the TrackTPC.h
+    //    using ClusRefsOutputType = std::vector<uint32_t>;
+    using ClusRefsOutputType = std::vector<o2::tpc::TPCClRefElem>;
+
+    using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
+    auto tracksdef = BranchDefinition<TrackOutputType>{InputSpec{"inputTracks", "TPC", "TRACKS"},      //
+                                                       "TPCTracks", "track-branch-name"};              //
+    auto clrefdef = BranchDefinition<ClusRefsOutputType>{InputSpec{"inputClusRef", "TPC", "CLUSREFS"}, //
+                                                         "ClusRefs", "trackclusref-branch-name"};      //
+    auto mcdef = BranchDefinition<MCLabelContainer>{InputSpec{"mcinput", "TPC", "TRACKMCLBL"},         //
+                                                    "TPCTracksMCTruth", "trackmc-branch-name"};        //
+
+    // depending on the MC propagation flag, the RootTreeWriter spec is created with 3 or 2
+    // branch definition
     if (propagateMC) {
       specs.push_back(MakeRootTreeWriterSpec(processName, defaultFileName, defaultTreeName,            //
                                              MakeRootTreeWriterSpec::TerminationPolicy::Process,       //
                                              MakeRootTreeWriterSpec::TerminationCondition{checkReady}, //
-                                             std::move(tracksdef), std::move(mcdef))());               //
+                                             std::move(tracksdef), std::move(clrefdef),                //
+                                             std::move(mcdef))());                                     //
     } else {                                                                                           //
       specs.push_back(MakeRootTreeWriterSpec(processName, defaultFileName, defaultTreeName,            //
                                              MakeRootTreeWriterSpec::TerminationPolicy::Process,       //
                                              MakeRootTreeWriterSpec::TerminationCondition{checkReady}, //
-                                             std::move(tracksdef))());                                 //
+                                             std::move(tracksdef), std::move(clrefdef))());            //
     }
   }
 

--- a/Detectors/TPC/workflow/src/TrackReaderSpec.cxx
+++ b/Detectors/TPC/workflow/src/TrackReaderSpec.cxx
@@ -45,6 +45,7 @@ void TrackReader::run(ProcessingContext& pc)
 
   LOG(INFO) << "TPCTrackReader pushes " << mTracksOut.size() << " tracks";
   pc.outputs().snapshot(Output{"TPC", "TRACKS", 0, Lifetime::Timeframe}, mTracksOut);
+  pc.outputs().snapshot(Output{"TPC", "CLUSREFS", 0, Lifetime::Timeframe}, mCluRefVecOut);
   if (mUseMC) {
     pc.outputs().snapshot(Output{"TPC", "TRACKSMCLBL", 0, Lifetime::Timeframe}, mMCTruthOut);
   }
@@ -67,6 +68,7 @@ void TrackReader::accumulate()
   LOG(INFO) << "Loaded tracks tree " << mTrackTreeName << " from " << mInputFileName;
 
   trTree->SetBranchAddress(mTrackBranchName.c_str(), &mTracksInp);
+  trTree->SetBranchAddress(mClusRefBranchName.c_str(), &mCluRefVecInp);
   if (mUseMC) {
     if (trTree->GetBranch(mTrackMCTruthBranchName.c_str())) {
       trTree->SetBranchAddress(mTrackMCTruthBranchName.c_str(), &mMCTruthInp);
@@ -80,6 +82,7 @@ void TrackReader::accumulate()
   if (nEnt == 1) {
     trTree->GetEntry(0);
     mTracksOut.swap(*mTracksInp);
+    mCluRefVecOut.swap(*mCluRefVecInp);
     if (mUseMC) {
       mMCTruthOut.mergeAtBack(*mMCTruthInp);
     }
@@ -87,9 +90,22 @@ void TrackReader::accumulate()
     int lastEntry = -1;
     int ntrAcc = 0;
     for (int iev = 0; iev < nEnt; iev++) {
-      trTree->GetEntry(0);
+      trTree->GetEntry(iev);
+      //
+      uint32_t shift = mCluRefVecOut.size(); // during accumulation clusters refs need to be shifted
+
+      auto cl0 = mCluRefVecInp->begin();
+      auto cl1 = mCluRefVecInp->end();
+      std::copy(cl0, cl1, std::back_inserter(mCluRefVecOut));
+
       auto tr0 = mTracksInp->begin();
       auto tr1 = mTracksInp->end();
+      // fix cluster references
+      if (shift) {
+        for (auto tr = tr0; tr != tr1; tr++) {
+          tr->shiftFirstClusterRef(shift);
+        }
+      }
       std::copy(tr0, tr1, std::back_inserter(mTracksOut));
       // MC
       if (mUseMC) {
@@ -103,6 +119,7 @@ DataProcessorSpec getTPCTrackReaderSpec(bool useMC)
 {
   std::vector<OutputSpec> outputSpec;
   outputSpec.emplace_back("TPC", "TRACKS", 0, Lifetime::Timeframe);
+  outputSpec.emplace_back("TPC", "CLUSREFS", 0, Lifetime::Timeframe);
   if (useMC) {
     outputSpec.emplace_back("TPC", "TRACKSMCLBL", 0, Lifetime::Timeframe);
   }

--- a/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
+++ b/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
@@ -85,6 +85,7 @@ struct GPUO2InterfaceIOPtrs {
 
   // Input / Output for Merged TPC tracks, two ptrs, for the tracks themselves, and for the MC labels.
   std::vector<o2::tpc::TrackTPC>* outputTracks = nullptr;
+  std::vector<uint32_t>* outputClusRefs = nullptr;
   o2::dataformats::MCTruthContainer<o2::MCCompLabel>* outputTracksMCTruth = nullptr;
 
   // Output for entropy-reduced clusters of TPC compression

--- a/macro/runCATrackingClusterNative.C
+++ b/macro/runCATrackingClusterNative.C
@@ -99,17 +99,22 @@ int runCATrackingClusterNative(TString inputFile, TString outputFile)
     ClusterNativeHelper::createClusterNativeIndex(clusterBuffer, cont, doMC ? &clusterMCBuffer : nullptr, doMC ? &contMC : nullptr);
 
   vector<TrackTPC> tracks;
+  // TODO Temporary solution, see disclaimer about TPCClRefElem in TrackTPC. Later will be changed to uint32_t
+  vector<TPCClRefElem> trackClusRefs;
   MCLabelContainer tracksMC;
 
   TFile fout(outputFile, "recreate");
   TTree tout("events", "events");
   tout.Branch("Tracks", &tracks);
+  tout.Branch("TracksClusRefs", &trackClusRefs);
   tout.Branch("TracksMCTruth", &tracksMC);
 
   printf("Processing time frame\n");
   GPUO2InterfaceIOPtrs ptrs;
   ptrs.clusters = clusters.get();
   ptrs.outputTracks = &tracks;
+  // TODO Temporary solution, see disclaimer about TPCClRefElem in TrackTPC. Later will remove the cast
+  ptrs.outputClusRefs = reinterpret_cast<vector<uint32_t>*>(&trackClusRefs);
   ptrs.outputTracksMCTruth = doMC ? &tracksMC : nullptr;
   if (tracker.runTracking(&ptrs) == 0) {
     printf("\tFound %d tracks\n", (int)tracks.size());
@@ -129,9 +134,9 @@ int runCATrackingClusterNative(TString inputFile, TString outputFile)
       // Get cluster references
       uint8_t sector, row;
       uint32_t clusterIndexInRow;
-      tracks[i].getClusterReference(j, sector, row, clusterIndexInRow);
-      const ClusterNative& cl = tracks[i].getCluster(j, *clusters, sector, row);
-      const ClusterNative& clLast = tracks[i].getCluster(0, *clusters);
+      tracks[i].getClusterReference(trackClusRefs, j, sector, row, clusterIndexInRow);
+      const ClusterNative& cl = tracks[i].getCluster(trackClusRefs, j, *clusters, sector, row);
+      const ClusterNative& clLast = tracks[i].getCluster(trackClusRefs, 0, *clusters);
       // RS: TODO: account for possible A/C merged tracks
       float sideFactor = tracks[i].hasASideClustersOnly() ? -1.f : 1.f;
       printf(


### PR DESCRIPTION
@wiechula @davidrohr @matthiasrichter I've eliminated the ``vector<uint32_t>`` from the TrackTPC to make it POD and modified the dependent code.
This allows to use spans instead of vectors for the DPL inputs (hence to avoid copying the input data). 
Together with other vector->span changes this alone saves ``~0.7 GB`` of memory in TPCITS matching component for 50 pbpb events.

@martenole I've also modified your interpolation code to account for modified TrackTPC.