### PR TITLE
[O2-893] Introducing dispatch policy to ExternalFairMQDeviceProxy

### DIFF
--- a/Framework/Core/include/Framework/ExternalFairMQDeviceProxy.h
+++ b/Framework/Core/include/Framework/ExternalFairMQDeviceProxy.h
@@ -31,10 +31,15 @@ using InjectorFunction = std::function<void(FairMQDevice& device, FairMQParts& i
 /// FIXME: can in principle drop the OutputSpec parameter and take the DataHeader
 void sendOnChannel(FairMQDevice& device, o2::header::Stack&& headerStack, FairMQMessagePtr&& payloadMessage, OutputSpec const& spec, ChannelRetriever& channelRetriever);
 
+void sendOnChannel(FairMQDevice& device, FairMQParts& messages, std::string const& channel);
+
 /// Helper function which takes a set of inputs coming from a device,
 /// massages them so that they are valid DPL messages using @param spec as header
 /// and sends them to the downstream components.
 InjectorFunction incrementalConverter(OutputSpec const& spec, uint64_t startTime, uint64_t step);
+
+std::tuple<std::vector<size_t>, size_t> findSplitParts(FairMQParts& parts, size_t start, std::vector<bool>& indicesDone);
+FairMQMessagePtr mergePayloads(FairMQDevice& device, FairMQParts& parts, std::vector<size_t> const& indexList, size_t payloadSize, std::string const channel);
 
 /// This is to be used for sources which already have an O2 Data Model /
 /// (header, payload) structure for their output. At the moment what this /

--- a/Framework/Utils/include/DPLUtils/RawParser.h
+++ b/Framework/Utils/include/DPLUtils/RawParser.h
@@ -439,7 +439,7 @@ class RawParser
 
     friend std::ostream& operator<<(std::ostream& os, self_type const& it)
     {
-      std::visit([&os](auto& parser) { return parser.format(os); }, it.mParser);
+      std::visit([&os](auto& parser) { return parser.format(os, raw_parser::FormatSpec::Entry, ""); }, it.mParser);
       return os;
     }
 

--- a/Framework/Utils/src/raw-parser.cxx
+++ b/Framework/Utils/src/raw-parser.cxx
@@ -17,6 +17,7 @@
 #include "DPLUtils/RawParser.h"
 #include "Headers/DataHeader.h"
 #include <vector>
+#include <sstream>
 
 using namespace o2::framework;
 
@@ -32,38 +33,48 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 
 WorkflowSpec defineDataProcessing(ConfigContext const& config)
 {
-
   WorkflowSpec workflow;
   workflow.emplace_back(DataProcessorSpec{
     "raw-parser",
     select(config.options().get<std::string>("input-spec").c_str()),
     Outputs{},
-    AlgorithmSpec{[](InitContext& setup) { return adaptStateless([](InputRecord& inputs, DataAllocator& outputs) {
-                                             for (auto& input : inputs) {
-                                               const auto* dh = DataRefUtils::getHeader<o2::header::DataHeader*>(input);
-                                               // InputSpec implements operator<< so we could print (input.spec) but that is the
-                                               // matcher instead of the matched data
-                                               LOG(INFO) << dh->dataOrigin.as<std::string>() << "/"
-                                                         << dh->dataDescription.as<std::string>() << "/"
-                                                         << dh->subSpecification << " payload size " << dh->payloadSize;
+    AlgorithmSpec{[](InitContext& setup) {
+	auto loglevel = setup.options().get<int>("log-level");
+	return adaptStateless([loglevel](InputRecord& inputs, DataAllocator& outputs) {
+	    for (auto& input : inputs) {
+	      const auto* dh = DataRefUtils::getHeader<o2::header::DataHeader*>(input);
+	      if (loglevel > 0) {
+		// InputSpec implements operator<< so we could print (input.spec) but that is the
+		// matcher instead of the matched data
+		LOG(INFO) << dh->dataOrigin.as<std::string>() << "/"
+			  << dh->dataDescription.as<std::string>() << "/"
+			  << dh->subSpecification << " payload size " << dh->payloadSize;
+	      }
 
-                                               // there is a bug in InpuRecord::get for vectors of simple types, not catched in
-                                               // DataAllocator unit test
-                                               //auto data = inputs.get<std::vector<char>>(input.spec->binding.c_str());
-                                               //LOG(INFO) << "data size " << data.size();
-                                               try {
-                                                 o2::framework::RawParser parser(input.payload, dh->payloadSize);
+	      // there is a bug in InpuRecord::get for vectors of simple types, not catched in
+	      // DataAllocator unit test
+	      //auto data = inputs.get<std::vector<char>>(input.spec->binding.c_str());
+	      //LOG(INFO) << "data size " << data.size();
 
-                                                 LOG(INFO) << parser << std::endl;
-                                                 for (auto it = parser.begin(), end = parser.end(); it != end; ++it) {
-                                                   LOG(INFO) << it << ": block length " << it.length() << std::endl;
-                                                 }
-                                               } catch (const std::runtime_error& e) {
-                                                 LOG(ERROR) << "can not create raw parser form input data";
-                                                 o2::header::hexDump("payload", input.payload, dh->payloadSize, 64);
-                                                 LOG(ERROR) << e.what();
-                                               }
-                                             }
-                                           }); }}});
+	      try {
+		o2::framework::RawParser parser(input.payload, dh->payloadSize);
+
+		std::stringstream rdhprintout;
+		rdhprintout << parser;
+		for (auto it = parser.begin(), end = parser.end(); it != end; ++it) {
+		  rdhprintout << it << ": block length " << it.length() << std::endl;
+		}
+		if (loglevel > 1) {
+		  LOG(INFO) << rdhprintout.str();
+		}
+	      } catch (const std::runtime_error& e) {
+		LOG(ERROR) << "can not create raw parser form input data";
+		o2::header::hexDump("payload", input.payload, dh->payloadSize, 64);
+		LOG(ERROR) << e.what();
+	      }
+	    }
+	  }); }},
+    Options{
+      {"log-level", VariantType::Int, 1, {"Logging level [0-2]"}}}});
   return workflow;
 }


### PR DESCRIPTION
Immediate dispatch is hardcoded for the moment, which is probably anyhow
a suitable default. Need to make this configurable. Preferably through
the workflow configuration mechanism.

Polishing the raw parser printout and introducing argument `--log-level`.