### PR TITLE
[EMCAL-534] Fix determination of next page in RawReaderMemory

### DIFF
--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RawReaderMemory.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RawReaderMemory.h
@@ -92,7 +92,7 @@ class RawReaderMemory
 
   /// \brief check if more pages are available in the raw file
   /// \return true if there is a next page
-  bool hasNext() const { return mCurrentPosition < mNumData; }
+  bool hasNext() const { return mCurrentPosition < mRawMemoryBuffer.size(); }
 
  protected:
   /// \brief Initialize the raw stream


### PR DESCRIPTION
Comparison in hasNext was done by mistake against the
number of pages in payload and not against the raw
buffer size, therefore the has nextNext always returned
false as the page offset (used as current position) is
larger than the average number of pages.