### PR TITLE
DPL Analysis: Bind filters to tables

### DIFF
--- a/Framework/AnalysisTutorial/src/filters.cxx
+++ b/Framework/AnalysisTutorial/src/filters.cxx
@@ -36,21 +36,18 @@ struct ATask {
   void process(aod::Tracks const& tracks)
   {
     for (auto& track : tracks) {
-      auto phi = asin(track.snp()) + track.alpha() + M_PI;
-      auto eta = log(tan(0.25 * M_PI - 0.5 * atan(track.tgl())));
-
-      etaphi(phi, eta);
+      etaphi(track.phi(), track.eta());
     }
   }
 };
 
 struct BTask {
-  Filter ptFilter = (aod::etaphi::phi > 1) && (aod::etaphi::phi < 2);
+  Filter ptFilter = (aod::etaphi::phi > 1.f) && (aod::etaphi::phi < 2.f);
 
   void process(soa::Filtered<aod::EtaPhi> const& etaPhis)
   {
     for (auto& etaPhi : etaPhis) {
-      LOGF(ERROR, "(%f, %f)", etaPhi.eta(), etaPhi.phi());
+      LOGF(INFO, "(%f, 1 < %f < 2)", etaPhi.eta(), etaPhi.phi());
     }
   }
 };

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -446,9 +446,14 @@ struct FilteredIndexPolicy : IndexPolicyBase {
   gandiva::SelectionVector* mSelection = nullptr;
 };
 
+template <typename... C>
+class Table;
+
 template <typename IP, typename... C>
 struct RowViewBase : public IP, C... {
  public:
+  using policy_t = IP;
+  using table_t = o2::soa::Table<C...>;
   using persistent_columns_t = framework::selected_pack<is_persistent_t, C...>;
   using dynamic_columns_t = framework::selected_pack<is_dynamic_t, C...>;
   using index_columns_t = framework::selected_pack<is_index_t, C...>;
@@ -860,7 +865,12 @@ class TableMetadata
   template <>                                                          \
   struct MetadataTrait<_Name_::iterator> {                             \
     using metadata = _Name_##Metadata;                                 \
-  }
+  };                                                                   \
+                                                                       \
+  template <>                                                          \
+  struct MetadataTrait<o2::soa::Filtered<_Name_>::iterator> {          \
+    using metadata = _Name_##Metadata;                                 \
+  };
 
 namespace o2::soa
 {
@@ -969,7 +979,6 @@ auto filter(T&& t, framework::expressions::Filter const& expr)
 {
   return Filtered<T>(t.asArrowTable(), expr);
 }
-
 } // namespace o2::soa
 
 #endif // O2_FRAMEWORK_ASOA_H_

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -32,9 +32,9 @@ DECLARE_SOA_COLUMN(Z, z, float, "fZ");
 DECLARE_SOA_COLUMN(Snp, snp, float, "fSnp");
 DECLARE_SOA_COLUMN(Tgl, tgl, float, "fTgl");
 DECLARE_SOA_COLUMN(Signed1Pt, signed1Pt, float, "fSigned1Pt");
-DECLARE_SOA_DYNAMIC_COLUMN(Phi, phi, [](float snp, float alpha) { return asin(snp) + alpha + M_PI; });
-DECLARE_SOA_DYNAMIC_COLUMN(Eta, eta, [](float tgl) { return log(tan(0.25 * M_PI - 0.5 * atan(tgl))); });
-DECLARE_SOA_DYNAMIC_COLUMN(Pt, pt, [](float signed1Pt) { return fabs(1.0 / signed1Pt); });
+DECLARE_SOA_DYNAMIC_COLUMN(Phi, phi, [](float snp, float alpha) -> float { return asin(snp) + alpha + M_PI; });
+DECLARE_SOA_DYNAMIC_COLUMN(Eta, eta, [](float tgl) -> float { return log(tan(0.25 * M_PI - 0.5 * atan(tgl))); });
+DECLARE_SOA_DYNAMIC_COLUMN(Pt, pt, [](float signed1Pt) -> float { return fabs(1.0 / signed1Pt); });
 // TRACKPARCOV TABLE definition
 DECLARE_SOA_COLUMN(CYY, cZZ, float, "fCYY");
 DECLARE_SOA_COLUMN(CZY, cZY, float, "fCZY");

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -17,6 +17,7 @@
 #include "Framework/CallbackService.h"
 #include "Framework/ControlService.h"
 #include "Framework/DataProcessorSpec.h"
+#include "Framework/Expressions.h"
 #include "Framework/EndOfStreamContext.h"
 #include "Framework/Kernels.h"
 #include "Framework/Logger.h"
@@ -30,6 +31,7 @@
 #include <arrow/compute/context.h>
 #include <arrow/compute/kernel.h>
 #include <arrow/table.h>
+#include <gandiva/node.h>
 #include <type_traits>
 #include <utility>
 #include <memory>
@@ -186,6 +188,14 @@ struct AnalysisTask {
 
 // Helper struct which builds a DataProcessorSpec from
 // the contents of an AnalysisTask...
+
+template <typename... C>
+gandiva::SchemaPtr createSchemaFromColumns(framework::pack<C...>)
+{
+  return std::make_shared<arrow::Schema>(std::vector<std::shared_ptr<arrow::Field>>{
+    std::make_shared<arrow::Field>(C::mLabel, expressions::concreteArrowType(expressions::selectArrowType<typename C::type>()))...});
+}
+
 struct AnalysisDataProcessorBuilder {
   template <typename Arg>
   static void doAppendInputWithMetadata(std::vector<InputSpec>& inputs)
@@ -197,7 +207,8 @@ struct AnalysisDataProcessorBuilder {
   }
 
   template <typename T>
-  static void appendSomethingWithMetadata(std::vector<InputSpec>& inputs)
+  static void appendSomethingWithMetadata(std::vector<InputSpec>& inputs,
+                                          std::vector<SchemaInfo>& filteredSchemas)
   {
     if constexpr (is_specialization<std::decay_t<T>, soa::Join>::value || is_specialization<std::decay_t<T>, soa::Concat>::value) {
       using left_t = typename std::decay_t<T>::left_t;
@@ -205,32 +216,34 @@ struct AnalysisDataProcessorBuilder {
       doAppendInputWithMetadata<left_t>(inputs);
       doAppendInputWithMetadata<right_t>(inputs);
     } else if constexpr (is_specialization<std::decay_t<T>, soa::Filtered>::value) {
-      doAppendInputWithMetadata<typename std::decay_t<T>::table_t>(inputs);
+      using table_t = typename std::decay_t<T>::table_t;
+      doAppendInputWithMetadata<table_t>(inputs);
+      filteredSchemas.push_back({aod::MetadataTrait<table_t>::metadata::label(), createSchemaFromColumns(typename table_t::persistent_columns_t())});
     } else {
       doAppendInputWithMetadata<T>(inputs);
     }
   }
 
   template <typename R, typename C, typename... Args>
-  static void inputsFromArgs(R (C::*)(Args...), std::vector<InputSpec>& inputs)
+  static void inputsFromArgs(R (C::*)(Args...), std::vector<InputSpec>& inputs, std::vector<SchemaInfo>& filteredSchemas)
   {
-    (appendSomethingWithMetadata<Args>(inputs), ...);
+    (appendSomethingWithMetadata<Args>(inputs, filteredSchemas), ...);
   }
 
   template <typename R, typename C, typename Grouping, typename... Args>
-  static auto signatures(InputRecord& record, R (C::*)(Grouping, Args...))
+  static auto signatures(InputRecord&, R (C::*)(Grouping, Args...))
   {
     return std::declval<std::tuple<Grouping, Args...>>();
   }
 
   template <typename R, typename C, typename Grouping, typename... Args>
-  static auto bindGroupingTable(InputRecord& record, R (C::*)(Grouping, Args...))
+  static auto bindGroupingTable(InputRecord& record, R (C::*)(Grouping, Args...), std::vector<ExpressionInfo> const& infos)
   {
-    return extractSomethingFromRecord<Grouping>(record);
+    return extractSomethingFromRecord<Grouping>(record, infos);
   }
 
   template <typename R, typename C>
-  static auto bindGroupingTable(InputRecord& record, R (C::*)())
+  static auto bindGroupingTable(InputRecord&, R (C::*)(), std::vector<ExpressionInfo> const&)
   {
     static_assert(always_static_assert_v<C>, "Your task process method needs at least one argument");
     return o2::soa::Table<>{nullptr};
@@ -244,11 +257,19 @@ struct AnalysisDataProcessorBuilder {
   }
 
   template <typename T>
-  static auto extractFilteredTableFromRecord(InputRecord& record)
+  static auto extractFilteredTableFromRecord(InputRecord& record, std::vector<ExpressionInfo> const infos)
   {
     using metadata = typename aod::MetadataTrait<typename std::decay_t<T>::table_t>::metadata;
     auto at = record.get<TableConsumer>(metadata::label())->asArrowTable();
-    return soa::Filtered<typename metadata::table_t>(at, nullptr);
+    /// this assumes one gandiva expression tree per table name:
+    /// filters should be &&-ed at the previous stage
+    for (auto& info : infos) {
+      if (std::string{metadata::label()} != info.first)
+        continue;
+      auto selection = expressions::createSelection(at, expressions::createFilter(at->schema(), expressions::createCondition(info.second)));
+      return soa::Filtered<typename metadata::table_t>(at, selection);
+    }
+    throw std::runtime_error("Failed to match filter with a table.");
   }
 
   template <typename T1, typename T2>
@@ -268,7 +289,7 @@ struct AnalysisDataProcessorBuilder {
   }
 
   template <typename T>
-  static auto extractSomethingFromRecord(InputRecord& record)
+  static auto extractSomethingFromRecord(InputRecord& record, std::vector<ExpressionInfo> const infos)
   {
     if constexpr (is_specialization<std::decay_t<T>, soa::Join>::value) {
       using left_t = typename std::decay_t<T>::left_t;
@@ -279,30 +300,36 @@ struct AnalysisDataProcessorBuilder {
       using right_t = typename std::decay_t<T>::right_t;
       return extractConcatFromRecord<left_t, right_t>(record);
     } else if constexpr (is_specialization<std::decay_t<T>, soa::Filtered>::value) {
-      return extractFilteredTableFromRecord<T>(record);
+      return extractFilteredTableFromRecord<T>(record, infos);
+    } else if constexpr (is_specialization<std::decay_t<T>, soa::RowViewBase>::value) {
+      if constexpr (std::is_same_v<soa::DefaultIndexPolicy, typename std::decay_t<T>::policy_t>) {
+        return extractTableFromRecord<std::decay_t<T>>(record);
+      } else if constexpr (std::is_same_v<soa::FilteredIndexPolicy, typename std::decay_t<T>::policy_t>) {
+        return extractFilteredTableFromRecord<std::decay_t<T>>(record, infos);
+      }
     } else {
       return extractTableFromRecord<std::decay_t<T>>(record);
     }
   }
 
   template <typename R, typename C, typename Grouping, typename... Args>
-  static auto bindAssociatedTables(InputRecord& record, R (C::*)(Grouping, Args...))
+  static auto bindAssociatedTables(InputRecord& record, R (C::*)(Grouping, Args...), std::vector<ExpressionInfo> const infos)
   {
-    return std::make_tuple(extractSomethingFromRecord<Args>(record)...);
+    return std::make_tuple(extractSomethingFromRecord<Args>(record, infos)...);
   }
 
   template <typename R, typename C>
-  static auto bindAssociatedTables(InputRecord& record, R (C::*)())
+  static auto bindAssociatedTables(InputRecord&, R (C::*)(), std::vector<ExpressionInfo> const)
   {
     static_assert(always_static_assert_v<C>, "Your task process method needs at least one argument");
     return std::tuple<>{};
   }
 
   template <typename Task, typename R, typename C, typename Grouping, typename... Associated>
-  static void invokeProcess(Task& task, InputRecord& inputs, R (C::*)(Grouping, Associated...))
+  static void invokeProcess(Task& task, InputRecord& inputs, R (C::*)(Grouping, Associated...), std::vector<ExpressionInfo> const infos)
   {
-    auto groupingTable = AnalysisDataProcessorBuilder::bindGroupingTable(inputs, &C::process);
-    auto associatedTables = AnalysisDataProcessorBuilder::bindAssociatedTables(inputs, &C::process);
+    auto groupingTable = AnalysisDataProcessorBuilder::bindGroupingTable(inputs, &C::process, infos);
+    auto associatedTables = AnalysisDataProcessorBuilder::bindAssociatedTables(inputs, &C::process, infos);
 
     if constexpr (sizeof...(Associated) == 0) {
       // No extra tables: we need to either iterate over the contents of
@@ -310,7 +337,7 @@ struct AnalysisDataProcessorBuilder {
       // is a o2::soa::Table or a o2::soa::RowView
       if constexpr (is_specialization<std::decay_t<Grouping>, o2::soa::Table>::value) {
         task.process(groupingTable);
-      } else if constexpr (is_specialization<std::decay_t<Grouping>, o2::soa::RowViewBase>::value) {
+      } else if constexpr (is_base_of_template<o2::soa::RowViewBase, std::decay_t<Grouping>>::value) {
         for (auto& groupedElement : groupingTable) {
           task.process(groupedElement);
         }
@@ -404,6 +431,24 @@ struct AnalysisDataProcessorBuilder {
       static_assert(always_static_assert_v<Grouping, Associated...>,
                     "Unable to find a way to iterate on the provided set of arguments. Probably unimplemented");
     }
+  }
+};
+
+template <typename T>
+struct FilterManager {
+  template <typename ANY>
+  static bool createExpressionTrees(std::vector<SchemaInfo> const&, ANY&, std::vector<ExpressionInfo>&)
+  {
+    return false;
+  }
+};
+
+template <>
+struct FilterManager<expressions::Filter> {
+  static bool createExpressionTrees(std::vector<SchemaInfo> const& infos, expressions::Filter const& filter, std::vector<ExpressionInfo>& expressionInfos)
+  {
+    expressionInfos = createExpressionInfos(infos, filter);
+    return true;
   }
 };
 
@@ -569,11 +614,20 @@ DataProcessorSpec adaptAnalysisTask(std::string name, Args&&... args)
                 "At least one of process(...), T::run(...), init(...) must be defined");
 
   std::vector<InputSpec> inputs;
+  std::vector<SchemaInfo> filteredSchemas;
+  std::vector<ExpressionInfo> expressionInfos;
+
   if constexpr (has_process<T>::value) {
-    AnalysisDataProcessorBuilder::inputsFromArgs(&T::process, inputs);
+    AnalysisDataProcessorBuilder::inputsFromArgs(&T::process, inputs, filteredSchemas);
+    std::apply([&filteredSchemas, &expressionInfos](auto&... x) {
+      return (FilterManager<std::decay_t<decltype(x)>>::createExpressionTrees(filteredSchemas, x, expressionInfos), ...);
+    },
+               tupledTask);
   }
 
-  auto algo = AlgorithmSpec::InitCallback{[task](InitContext& ic) {
+  std::apply([&outputs](auto&... x) { return (OutputManager<std::decay_t<decltype(x)>>::appendOutput(outputs, x), ...); }, tupledTask);
+
+  auto algo = AlgorithmSpec::InitCallback{[task, expressionInfos](InitContext& ic) {
     auto& callbacks = ic.services().get<CallbackService>();
     auto endofdatacb = [task](EndOfStreamContext& eosContext) {
       auto tupledTask = o2::framework::to_tuple_refs(*task.get());
@@ -585,14 +639,14 @@ DataProcessorSpec adaptAnalysisTask(std::string name, Args&&... args)
     if constexpr (has_init<T>::value) {
       task->init(ic);
     }
-    return [task](ProcessingContext& pc) {
+    return [task, expressionInfos](ProcessingContext& pc) {
       auto tupledTask = o2::framework::to_tuple_refs(*task.get());
       std::apply([&pc](auto&&... x) { return (OutputManager<std::decay_t<decltype(x)>>::prepare(pc, x), ...); }, tupledTask);
       if constexpr (has_run<T>::value) {
         task->run(pc);
       }
       if constexpr (has_process<T>::value) {
-        AnalysisDataProcessorBuilder::invokeProcess(*(task.get()), pc.inputs(), &T::process);
+        AnalysisDataProcessorBuilder::invokeProcess(*(task.get()), pc.inputs(), &T::process, expressionInfos);
       }
       std::apply([&pc](auto&&... x) { return (OutputManager<std::decay_t<decltype(x)>>::finalize(pc, x), ...); }, tupledTask);
     };

--- a/Framework/Core/test/test_AnalysisTask.cxx
+++ b/Framework/Core/test/test_AnalysisTask.cxx
@@ -76,11 +76,21 @@ struct ETask {
   }
 };
 
+// FIXME: for the moment we do not derive from AnalysisTask as
+// we need GCC 7.4+ to fix a bug.
+struct FTask {
+  expressions::Filter fooFilter = aod::track::foo > 1.;
+  void process(soa::Filtered<o2::aod::FooBars>::iterator const& foobar)
+  {
+    foobar.sum();
+  }
+};
+
 BOOST_AUTO_TEST_CASE(AdaptorCompilation)
 {
   auto task1 = adaptAnalysisTask<ATask>("test1");
   BOOST_CHECK_EQUAL(task1.inputs.size(), 1);
-  BOOST_CHECK_EQUAL(task1.outputs.size(), 1);
+  BOOST_CHECK_EQUAL(task1.outputs.size(), 2);
   BOOST_CHECK_EQUAL(task1.inputs[0].binding, std::string("Tracks"));
   BOOST_CHECK_EQUAL(task1.outputs[0].binding.value, std::string("FooBars"));
 
@@ -101,4 +111,8 @@ BOOST_AUTO_TEST_CASE(AdaptorCompilation)
   auto task5 = adaptAnalysisTask<ETask>("test5");
   BOOST_CHECK_EQUAL(task5.inputs.size(), 1);
   BOOST_CHECK_EQUAL(task5.inputs[0].binding, "FooBars");
+
+  auto task6 = adaptAnalysisTask<FTask>("test6");
+  BOOST_CHECK_EQUAL(task6.inputs.size(), 1);
+  BOOST_CHECK_EQUAL(task6.inputs[0].binding, "FooBars");
 }


### PR DESCRIPTION
Warning: includes #2639, #2663 and #2664  

@ktf I've made the combined code compile and added support for Filtered<>::iterator as an argument for process(). The only thing that is missing for the filters to work is merging expressions, and creating/propagating the selection vectors.