### PR TITLE
[EMCAL-554] Development of a class containing the trigger DCS information in the CCDB

### DIFF
--- a/Detectors/EMCAL/calib/CMakeLists.txt
+++ b/Detectors/EMCAL/calib/CMakeLists.txt
@@ -15,6 +15,10 @@ o2_add_library(EMCALCalib
                        src/TempCalibrationParams.cxx
                        src/TempCalibParamSM.cxx
                        src/GainCalibrationFactors.cxx
+                       src/TriggerTRUDCS.cxx
+                       src/TriggerSTUDCS.cxx
+                       src/TriggerSTUErrorCounter.cxx
+                       src/TriggerDCS.cxx
                        src/CalibDB.cxx
 	       PUBLIC_LINK_LIBRARIES O2::CCDB O2::EMCALBase)
 
@@ -25,6 +29,10 @@ o2_target_root_dictionary(EMCALCalib
                                   include/EMCALCalib/TempCalibrationParams.h
                                   include/EMCALCalib/TempCalibParamSM.h
                                   include/EMCALCalib/GainCalibrationFactors.h
+                                  include/EMCALCalib/TriggerTRUDCS.h
+                                  include/EMCALCalib/TriggerSTUDCS.h
+                                  include/EMCALCalib/TriggerSTUErrorCounter.h
+                                  include/EMCALCalib/TriggerDCS.h
                                   include/EMCALCalib/CalibDB.h
                           LINKDEF src/EMCALCalibLinkDef.h)
 
@@ -60,6 +68,30 @@ o2_add_test(TempCalibParamSM
 
 o2_add_test(GainCalibrationFactors
             SOURCES test/testGainCalibration.cxx
+            PUBLIC_LINK_LIBRARIES O2::EMCALCalib
+            COMPONENT_NAME emcal
+            LABELS emcal)
+
+o2_add_test(TriggerTRUDCS
+            SOURCES test/testTriggerTRUDCS.cxx
+            PUBLIC_LINK_LIBRARIES O2::EMCALCalib
+            COMPONENT_NAME emcal
+            LABELS emcal)
+
+o2_add_test(TriggerSTUDCS
+            SOURCES test/testTriggerSTUDCS.cxx
+            PUBLIC_LINK_LIBRARIES O2::EMCALCalib
+            COMPONENT_NAME emcal
+            LABELS emcal)
+
+o2_add_test(TriggerSTUErrorCounter
+            SOURCES test/testTriggerSTUErrorCounter.cxx
+            PUBLIC_LINK_LIBRARIES O2::EMCALCalib
+            COMPONENT_NAME emcal
+            LABELS emcal)
+
+o2_add_test(TriggerDCS
+            SOURCES test/testTriggerDCS.cxx
             PUBLIC_LINK_LIBRARIES O2::EMCALCalib
             COMPONENT_NAME emcal
             LABELS emcal)
@@ -109,6 +141,14 @@ o2_add_test_root_macro(macros/GainCalibrationFactors_CCDBApiTest.C
             LABELS emcal COMPILE_ONLY)
 
 o2_add_test_root_macro(macros/GainCalibrationFactors_CalibDBTest.C
+            PUBLIC_LINK_LIBRARIES O2::EMCALCalib
+            LABELS emcal COMPILE_ONLY)
+
+o2_add_test_root_macro(macros/TriggerDCS_CCDBApiTest.C
+            PUBLIC_LINK_LIBRARIES O2::EMCALCalib
+            LABELS emcal COMPILE_ONLY)
+
+o2_add_test_root_macro(macros/TriggerDCS_CalibDBTest.C
             PUBLIC_LINK_LIBRARIES O2::EMCALCalib
             LABELS emcal COMPILE_ONLY)
 

--- a/Detectors/EMCAL/calib/include/EMCALCalib/BadChannelMap.h
+++ b/Detectors/EMCAL/calib/include/EMCALCalib/BadChannelMap.h
@@ -10,7 +10,6 @@
 #include <iosfwd>
 #include <bitset>
 #include <Rtypes.h>
-#include <CCDB/TObjectWrapper.h> // Needed to trigger dictionary build
 
 class TH2;
 

--- a/Detectors/EMCAL/calib/include/EMCALCalib/CalibDB.h
+++ b/Detectors/EMCAL/calib/include/EMCALCalib/CalibDB.h
@@ -26,6 +26,7 @@ class TempCalibParamSM;
 class TimeCalibrationParams;
 class TimeCalibParamL1Phase;
 class GainCalibrationFactors;
+class TriggerDCS;
 
 /// \class CalibDB
 /// \brief Interface to calibration data from CCDB for EMCAL
@@ -252,6 +253,20 @@ class CalibDB
   /// \throw ObjectNotFoundException if object is not found for the given timestamp
   /// \throw TypeMismatchException if object is present but type is different (CCDB corrupted)
   GainCalibrationFactors* readGainCalibFactors(ULong_t timestamp, const std::map<std::string, std::string>& metadata);
+
+  /// \brief Store Trigger DCS data in the CCDB
+  /// \brief dcs trigger DCS data to be stored
+  /// \brief metadata Additional metadata that can be used in the query
+  /// \timestart Start of the time range of the validity of the object
+  /// \timeend End of the time range of the validity of the object
+  void storeTriggerDCSData(TriggerDCS* dcs, const std::map<std::string, std::string>& metadata, ULong_t timestart, ULong_t timeend);
+
+  /// \brief Find trigger DCS data in the CCDB for given timestamp
+  /// \param timestamp Timestamp used in query
+  /// \param metadata Additional metadata to be used in the query
+  /// \throw ObjectNotFoundException if object is not found for the given timestamp
+  /// \throw TypeMismatchException if object is present but type is different (CCDB corrupted)
+  TriggerDCS* readTriggerDCSData(ULong_t timestamp, const std::map<std::string, std::string>& metadata);
 
   /// \brief Set new CCDB server URL
   /// \param server Name of the CCDB server to be used in queries

--- a/Detectors/EMCAL/calib/include/EMCALCalib/TriggerDCS.h
+++ b/Detectors/EMCAL/calib/include/EMCALCalib/TriggerDCS.h
@@ -1,0 +1,82 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include <iosfwd>
+#include <array>
+#include <Rtypes.h>
+
+#include "EMCALCalib/TriggerTRUDCS.h"
+#include "EMCALCalib/TriggerSTUDCS.h"
+
+namespace o2
+{
+
+namespace emcal
+{
+
+/// \class TriggerDCS
+/// \brief CCDB container for the DCS data in EMCAL
+/// based on AliEMCALTriggerDCSConfig class authored by R. GUERNANE
+/// \author Hadi Hassan <hadi.hassan@cern.ch>, Oak Ridge National Laboratory
+/// \since December 4th, 2019
+
+class TriggerDCS
+{
+ public:
+  /// \brief default constructor
+  TriggerDCS() = default;
+
+  /// \brief Destructor
+  ~TriggerDCS() = default;
+
+  /// \brief Comparison of two DCS data
+  /// \return true if the TRU data are identical, false otherwise
+  ///
+  /// Testing two DCS for equalness. DCS are considered identical
+  /// if the contents are identical.
+  bool operator==(const TriggerDCS& other) const;
+
+  /// \brief Serialize object to JSON format
+  /// \return JSON-serialized trigger DCS config object
+  std::string toJSON() const;
+
+  void setTRUArr(std::vector<TriggerTRUDCS>& ta) { mTRUArr = ta; }
+  void setTRU(TriggerTRUDCS tru) { mTRUArr.emplace_back(tru); }
+
+  void setSTUEMCal(TriggerSTUDCS so) { mSTUEMCal = so; }
+  void setSTUDCal(TriggerSTUDCS so) { mSTUDCAL = so; }
+
+  std::vector<TriggerTRUDCS> getTRUArr() const { return mTRUArr; }
+
+  TriggerSTUDCS getSTUDCSEMCal() const { return mSTUEMCal; }
+  TriggerSTUDCS getSTUDCSDCal() const { return mSTUDCAL; }
+  TriggerTRUDCS getTRUDCS(Int_t iTRU) const { return mTRUArr.at(iTRU); }
+
+  /// \brief Check whether TRU is enabled
+  /// Enabled-status defined via presence of the TRU in the STU region: TRU
+  /// is enabled if the corresponding bit is set in the STU region
+  bool isTRUEnabled(int iTRU) const;
+
+ private:
+  std::vector<TriggerTRUDCS> mTRUArr; ///< TRU array
+  TriggerSTUDCS mSTUEMCal;            ///< STU of EMCal
+  TriggerSTUDCS mSTUDCAL;             ///< STU of DCAL
+
+  ClassDefNV(TriggerDCS, 1);
+};
+
+/// \brief Streaming operator
+/// \param in Stream where the TRU parameters are printed on
+/// \param tru TRU to be printed
+/// \return Stream after printing the TRU parameters
+std::ostream& operator<<(std::ostream& in, const TriggerDCS& dcs);
+
+} // namespace emcal
+
+} // namespace o2

--- a/Detectors/EMCAL/calib/include/EMCALCalib/TriggerSTUDCS.h
+++ b/Detectors/EMCAL/calib/include/EMCALCalib/TriggerSTUDCS.h
@@ -1,0 +1,126 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef ALICEO2_EMCAL_TRIGGERSTUDCS_H
+#define ALICEO2_EMCAL_TRIGGERSTUDCS_H
+
+#include <iosfwd>
+#include <array>
+#include <Rtypes.h>
+
+namespace o2
+{
+
+namespace emcal
+{
+
+/// \class TriggerSTUDCS
+/// \brief CCDB container for STU DCS data in EMCAL
+/// based on AliEMCALTriggerSTUDCSConfig class authored by R. GUERNANE
+/// \author Hadi Hassan <hadi.hassan@cern.ch>, Oak Ridge National Laboratory
+/// \since December 4th, 2019
+
+class TriggerSTUDCS
+{
+ public:
+  /// \brief default constructor
+  TriggerSTUDCS() = default;
+
+  /// \brief copy constructor
+  TriggerSTUDCS(const TriggerSTUDCS& stu) = default;
+
+  /// \brief Assignment operator
+  TriggerSTUDCS& operator=(const TriggerSTUDCS& source) = default;
+
+  /// \brief nomral constructor
+  explicit TriggerSTUDCS(std::array<int, 3> Gammahigh,
+                         std::array<int, 3> Jethigh,
+                         std::array<int, 3> Gammalow,
+                         std::array<int, 3> Jetlow,
+                         int rawData,
+                         int region,
+                         int fw,
+                         int patchSize,
+                         int median,
+                         std::array<int, 4> phosScale);
+
+  /// \brief Destructor
+  ~TriggerSTUDCS() = default;
+
+  /// \brief Comparison of two STU data
+  /// \return true if the STU data are identical, false otherwise
+  ///
+  /// Testing two STUs for equalness. STUs are considered identical
+  /// if the contents are identical.
+  bool operator==(const TriggerSTUDCS& other) const;
+
+  /// \brief Serialize object to JSON format
+  /// \return JSON-serialized STU DCS config object
+  std::string toJSON() const;
+
+  void setGammaHigh(int vzpar, int val) { mGammaHigh[vzpar] = val; }
+  void setJetHigh(int vzpar, int val) { mJetHigh[vzpar] = val; }
+  void setGammaLow(int vzpar, int val) { mGammaLow[vzpar] = val; }
+  void setJetLow(int vzpar, int val) { mJetLow[vzpar] = val; }
+  void setRawData(int rd) { mGetRawData = rd; }
+  void setRegion(int rg) { mRegion = rg; }
+  void setFw(int fv) { mFw = fv; }
+  void setPHOSScale(int iscale, int val) { mPHOSScale[iscale] = val; }
+  void setPatchSize(int size) { mPatchSize = size; }
+  void setMedianMode(int mode) { mMedian = mode; }
+
+  int getGammaHigh(int vzpar) const { return mGammaHigh[vzpar]; }
+  int getJetHigh(int vzpar) const { return mJetHigh[vzpar]; }
+  int getGammaLow(int vzpar) const { return mGammaLow[vzpar]; }
+  int getJetLow(int vzpar) const { return mJetLow[vzpar]; }
+  int getRawData() const { return mGetRawData; }
+  int getRegion() const { return mRegion; }
+  int getFw() const { return mFw; }
+  int getPHOSScale(int iscale) const { return mPHOSScale[iscale]; }
+  int getPatchSize() const { return mPatchSize; }
+  int getMedianMode() const { return mMedian; }
+
+  //void    getSegmentation(TVector2& v1, TVector2& v2, TVector2& v3, TVector2& v4) const;
+
+  /// \brief Print STUs on a given stream
+  /// \param stream Stream on which the STU is printed on
+  ///
+  /// Printing all the parameters of the STU on the stream.
+  ///
+  /// The function is called in the operator<< providing direct access
+  /// to protected members. Explicit calls by the users is normally not
+  /// necessary.
+  void PrintStream(std::ostream& stream) const;
+
+ private:
+  std::array<int, 3> mGammaHigh; ///< Gamma high trigger
+  std::array<int, 3> mJetHigh;   ///< jet low trigger
+  std::array<int, 3> mGammaLow;  ///< Gamma low trigger
+  std::array<int, 3> mJetLow;    ///< jet low trigger
+  int mGetRawData = 1;           ///< GetRawData
+  int mRegion = 0xFFFFFFFF;      ///< Region
+  int mFw = 0x2A012;             ///< Firmware version
+  std::array<int, 4> mPHOSScale; ///< PHOS scale factors
+  int mPatchSize = 0;            ///< Jet patch size: 0 for 8x8 and 2 for 16x16
+  int mMedian = 0;               ///< 1 in case of using EMCAL/DCAL for estimating the median
+
+  ClassDefNV(TriggerSTUDCS, 1);
+};
+
+/// \brief Streaming operator
+/// \param in Stream where the STU parameters are printed on
+/// \param tru STU to be printed
+/// \return Stream after printing the STU parameters
+std::ostream& operator<<(std::ostream& in, const TriggerSTUDCS& stu);
+
+} // namespace emcal
+
+} // namespace o2
+
+#endif

--- a/Detectors/EMCAL/calib/include/EMCALCalib/TriggerSTUErrorCounter.h
+++ b/Detectors/EMCAL/calib/include/EMCALCalib/TriggerSTUErrorCounter.h
@@ -1,0 +1,79 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include <iosfwd>
+#include <array>
+#include <Rtypes.h>
+
+namespace o2
+{
+
+namespace emcal
+{
+
+/// \class TriggerSTUErrorCounter
+/// \brief CCDB container for STU error counts
+/// based on AliEMCALTriggerSTUConfig class authored by R. GUERNANE
+/// \author Hadi Hassan <hadi.hassan@cern.ch>, Oak Ridge National Laboratory
+/// \since December 4th, 2019
+
+class TriggerSTUErrorCounter
+{
+ public:
+  /// \brief default constructor
+  TriggerSTUErrorCounter() = default;
+
+  /// \brief copy constructor
+  TriggerSTUErrorCounter(const TriggerSTUErrorCounter& error) = default;
+
+  /// \brief Assignment operator
+  TriggerSTUErrorCounter& operator=(const TriggerSTUErrorCounter& source) = default;
+
+  /// \brief nomral constructor
+  explicit TriggerSTUErrorCounter(std::pair<int, unsigned long> TimeAndError);
+
+  /// \brief nomral constructor
+  explicit TriggerSTUErrorCounter(int Time, unsigned long Error);
+
+  /// \brief Destructor
+  ~TriggerSTUErrorCounter() = default;
+
+  /// \brief Comparison of two TRU data
+  /// \return true if the TRU data are identical, false otherwise
+  ///
+  /// Testing two TRUs for equalness. TRUs are considered identical
+  /// if the contents are identical.
+  bool operator==(const TriggerSTUErrorCounter& other) const;
+
+  /// \brief Checks for equalness according to the time stamp.
+  bool isEqual(TriggerSTUErrorCounter& counter) const;
+
+  /// \brief Compare time-dependent error counts based on the time information.
+  int compare(TriggerSTUErrorCounter& counter) const;
+
+  void setValue(int time, unsigned long errorcount)
+  {
+    mTimeErrorCount.first = time;
+    mTimeErrorCount.second = errorcount;
+  }
+  void setValue(std::pair<int, unsigned long> TimeAndError) { mTimeErrorCount = TimeAndError; }
+
+  int getTime() const { return mTimeErrorCount.first; }
+  unsigned long getErrorCount() const { return mTimeErrorCount.second; }
+  std::pair<int, unsigned long> getTimeAndErrorCount() const { return mTimeErrorCount; }
+
+ private:
+  std::pair<int, unsigned long> mTimeErrorCount; ///< Pair for the time and the number of errors at this time
+
+  ClassDefNV(TriggerSTUErrorCounter, 1);
+};
+
+} // namespace emcal
+
+} // namespace o2

--- a/Detectors/EMCAL/calib/include/EMCALCalib/TriggerTRUDCS.h
+++ b/Detectors/EMCAL/calib/include/EMCALCalib/TriggerTRUDCS.h
@@ -1,0 +1,114 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef ALICEO2_EMCAL_TRIGGERTRUDCS_H
+#define ALICEO2_EMCAL_TRIGGERTRUDCS_H
+
+#include <iosfwd>
+#include <array>
+#include <Rtypes.h>
+
+namespace o2
+{
+
+namespace emcal
+{
+
+/// \class TriggerTRUDCS
+/// \brief CCDB container for TRU DCS data in EMCAL
+/// based on AliEMCALTriggerTRUDCSConfig class authored by R. GUERNANE
+/// \author Hadi Hassan <hadi.hassan@cern.ch>, Oak Ridge National Laboratory
+/// \since December 4th, 2019
+
+class TriggerTRUDCS
+{
+ public:
+  /// \brief default constructor
+  TriggerTRUDCS() = default;
+
+  /// \brief copy constructor
+  TriggerTRUDCS(const TriggerTRUDCS& tru) = default;
+
+  /// \brief Assignment operator
+  TriggerTRUDCS& operator=(const TriggerTRUDCS& source) = default;
+
+  /// \brief nomral constructor
+  explicit TriggerTRUDCS(uint64_t selpf,
+                         uint64_t l0sel,
+                         uint64_t l0cosm,
+                         uint64_t gthrl0,
+                         uint64_t rlbkstu,
+                         uint64_t fw,
+                         std::array<uint32_t, 6> maskReg);
+
+  /// \brief Destructor
+  ~TriggerTRUDCS() = default;
+
+  /// \brief Comparison of two TRU data
+  /// \return true if the TRU data are identical, false otherwise
+  ///
+  /// Testing two TRUs for equalness. TRUs are considered identical
+  /// if the contents are identical.
+  bool operator==(const TriggerTRUDCS& other) const;
+
+  /// \brief Serialize object to JSON format
+  /// \return JSON-serialized TRU DCS config object
+  std::string toJSON() const;
+
+  void setSELPF(uint64_t pf) { mSELPF = pf; }
+  void setL0SEL(uint64_t la) { mL0SEL = la; }
+  void setL0COSM(uint64_t lc) { mL0COSM = lc; }
+  void setGTHRL0(uint64_t lg) { mGTHRL0 = lg; }
+  void setMaskReg(uint32_t msk, int pos) { mMaskReg[pos] = msk; }
+  void setRLBKSTU(uint64_t rb) { mRLBKSTU = rb; }
+  void setFw(uint64_t fw) { mFw = fw; }
+
+  uint64_t getSELPF() const { return mSELPF; }
+  uint64_t getL0SEL() const { return mL0SEL; }
+  uint64_t getL0COSM() const { return mL0COSM; }
+  uint64_t getGTHRL0() const { return mGTHRL0; }
+  uint32_t getMaskReg(int pos) const { return mMaskReg[pos]; }
+  uint64_t getRLBKSTU() const { return mRLBKSTU; }
+  uint64_t getFw() const { return mFw; }
+
+  //int   getSegmentation();
+
+  /// \brief Print TRUs on a given stream
+  /// \param stream Stream on which the TRU is printed on
+  ///
+  /// Printing all the parameters of the TRU on the stream.
+  ///
+  /// The function is called in the operator<< providing direct access
+  /// to protected members. Explicit calls by the users is normally not
+  /// necessary.
+  void PrintStream(std::ostream& stream) const;
+
+ private:
+  uint64_t mSELPF = 0x1e1f;         ///< PeakFinder setup
+  uint64_t mL0SEL = 0x1;            ///< L0 Algo selection
+  uint64_t mL0COSM = 0;             ///< 2x2
+  uint64_t mGTHRL0 = 0;             ///< 4x4
+  std::array<uint32_t, 6> mMaskReg; ///< 6*16 = 96 mask bits per TRU
+  uint64_t mRLBKSTU = 0;            ///< TRU circular buffer rollback
+  uint64_t mFw = 0x21;              ///< TRU fw version
+
+  ClassDefNV(TriggerTRUDCS, 1);
+};
+
+/// \brief Streaming operator
+/// \param in Stream where the TRU parameters are printed on
+/// \param tru TRU to be printed
+/// \return Stream after printing the TRU parameters
+std::ostream& operator<<(std::ostream& in, const TriggerTRUDCS& tru);
+
+} // namespace emcal
+
+} // namespace o2
+
+#endif

--- a/Detectors/EMCAL/calib/macros/BadChannelMap_CCDBApitest.C
+++ b/Detectors/EMCAL/calib/macros/BadChannelMap_CCDBApitest.C
@@ -10,7 +10,6 @@
 
 #if !defined(__CLING__) || defined(__ROOTCLING__)
 #include "CCDB/CcdbApi.h"
-#include "CCDB/TObjectWrapper.h"
 #include "EMCALCalib/BadChannelMap.h"
 #include "RStringView.h"
 #include <ctime>
@@ -61,25 +60,14 @@ void BadChannelMap_CCDBApitest(const std::string_view ccdbserver = "emcccdb-test
        rangeend = create_timestamp(2018, 8, 6, 0, 31, 52);
   std::cout << "Using time stamps " << rangestart << " and " << rangeend << std::endl;
   std::map<std::string, std::string> metadata;
-  ccdbhandler.storeAsTFile(new o2::TObjectWrapper<o2::emcal::BadChannelMap>(bcm), "EMC/BadChannelMap", metadata, rangestart, rangeend);
+  ccdbhandler.storeAsTFileAny(bcm, "EMC/BadChannelMap", metadata, rangestart, rangeend);
 
   // Read bad channel map from CCDB, check whether they are the same
   // using test timestamp from next run (290223)
   auto rangetest = create_timestamp(2018, 7, 30, 12, 13, 20);
   std::cout << "Using read timestamp " << rangetest << std::endl;
   o2::emcal::BadChannelMap* read(nullptr);
-  auto res = ccdbhandler.retrieveFromTFile("EMC/BadChannelMap", metadata, rangetest);
-  if (!res) {
-    std::cerr << "Failed retrieving object from CCDB" << std::endl;
-    return;
-  }
-  std::cout << "Object found, type " << res->IsA()->GetName() << std::endl;
-  auto objw = dynamic_cast<o2::TObjectWrapper<o2::emcal::BadChannelMap>*>(res);
-  if (!objw) {
-    std::cerr << "failed casting to TObjectWrapper" << std::endl;
-    return;
-  }
-  read = objw->getObj();
+  read = ccdbhandler.retrieveFromTFileAny<o2::emcal::BadChannelMap>("EMC/BadChannelMap", metadata, rangetest);
   if (!read) {
     std::cerr << "No object received from CCDB" << std::endl;
     return;

--- a/Detectors/EMCAL/calib/macros/GainCalibrationFactors_CCDBApiTest.C
+++ b/Detectors/EMCAL/calib/macros/GainCalibrationFactors_CCDBApiTest.C
@@ -10,7 +10,6 @@
 
 #if !defined(__CLING__) || defined(__ROOTCLING__)
 #include "CCDB/CcdbApi.h"
-#include "CCDB/TObjectWrapper.h"
 #include "EMCALCalib/GainCalibrationFactors.h"
 #include "RStringView.h"
 #include "TH1F.h"
@@ -53,7 +52,7 @@ void GainCalibrationFactors_CCDBApiTest(const std::string_view ccdbserver = "emc
   std::string inputDir = " ";
   if (aliceO2env)
     inputDir = aliceO2env;
-  inputDir += "/share/Detectors/EMCAL/files/";
+  inputDir += "/share/Detectors/EMC/files/";
 
   std::string fileNameGainCalib = inputDir + "GainCalibrationFactors_LHC18q.txt";
   std::ifstream fileGainCalib(fileNameGainCalib, std::ifstream::in);
@@ -85,25 +84,14 @@ void GainCalibrationFactors_CCDBApiTest(const std::string_view ccdbserver = "emc
 
   std::cout << "Using time stamps " << rangestart << " and " << rangeend << std::endl;
   std::map<std::string, std::string> metadata;
-  ccdbhandler.storeAsTFile(new o2::TObjectWrapper<o2::emcal::GainCalibrationFactors>(gcf), "EMC/GainCalibFactors", metadata, rangestart, rangeend);
+  ccdbhandler.storeAsTFileAny(gcf, "EMC/GainCalibFactors", metadata, rangestart, rangeend);
 
   // Read gain calibration factors from CCDB, check whether they are the same
   auto rangetest = create_timestamp(2018, 11, 16, 20, 55, 3); //LHC18q run 296273
   //auto rangetest = create_timestamp(2015, 12, 9, 23, 10, 3); //LHC15 run 246583
   std::cout << "Using read timestamp " << rangetest << std::endl;
   o2::emcal::GainCalibrationFactors* read(nullptr);
-  auto res = ccdbhandler.retrieveFromTFile("EMC/GainCalibFactors", metadata, rangetest);
-  if (!res) {
-    std::cerr << "Failed retrieving object from CCDB" << std::endl;
-    return;
-  }
-  std::cout << "Object found, type " << res->IsA()->GetName() << std::endl;
-  auto objw = dynamic_cast<o2::TObjectWrapper<o2::emcal::GainCalibrationFactors>*>(res);
-  if (!objw) {
-    std::cerr << "failed casting to TObjectWrapper" << std::endl;
-    return;
-  }
-  read = objw->getObj();
+  read = ccdbhandler.retrieveFromTFileAny<o2::emcal::GainCalibrationFactors>("EMC/GainCalibFactors", metadata, rangetest);
   if (!read) {
     std::cerr << "No object received from CCDB" << std::endl;
     return;

--- a/Detectors/EMCAL/calib/macros/GainCalibrationFactors_CalibDBTest.C
+++ b/Detectors/EMCAL/calib/macros/GainCalibrationFactors_CalibDBTest.C
@@ -51,7 +51,7 @@ void GainCalibrationFactors_CalibDBTest(const std::string_view ccdbserver = "emc
   std::string inputDir = " ";
   if (aliceO2env)
     inputDir = aliceO2env;
-  inputDir += "/share/Detectors/EMCAL/files/";
+  inputDir += "/share/Detectors/EMC/files/";
 
   std::string fileNameGainCalib = inputDir + "GainCalibrationFactors_LHC18q.txt";
   std::ifstream fileGainCalib(fileNameGainCalib, std::ifstream::in);

--- a/Detectors/EMCAL/calib/macros/TempCalibParamSM_CCDBApiTest.C
+++ b/Detectors/EMCAL/calib/macros/TempCalibParamSM_CCDBApiTest.C
@@ -10,7 +10,6 @@
 
 #if !defined(__CLING__) || defined(__ROOTCLING__)
 #include "CCDB/CcdbApi.h"
-#include "CCDB/TObjectWrapper.h"
 #include "EMCALCalib/TempCalibParamSM.h"
 #include "RStringView.h"
 #include "TH1F.h"
@@ -53,7 +52,7 @@ void TempCalibParamSM_CCDBApiTest(const std::string_view ccdbserver = "emcccdb-t
   std::string inputDir = " ";
   if (aliceO2env)
     inputDir = aliceO2env;
-  inputDir += "/share/Detectors/EMCAL/files/";
+  inputDir += "/share/Detectors/EMC/files/";
 
   std::string file = inputDir + "TempCalibSM_LHC18k_289166.txt";
   std::ifstream fileTempCalibSM(file, std::ifstream::in);
@@ -85,7 +84,7 @@ void TempCalibParamSM_CCDBApiTest(const std::string_view ccdbserver = "emcccdb-t
 
   std::cout << "Using time stamps " << rangestart << " and " << rangeend << std::endl;
   std::map<std::string, std::string> metadata;
-  ccdbhandler.storeAsTFile(new o2::TObjectWrapper<o2::emcal::TempCalibParamSM>(tcp), "EMC/TempCalibParamsSM", metadata, rangestart, rangeend);
+  ccdbhandler.storeAsTFileAny(tcp, "EMC/TempCalibParamsSM", metadata, rangestart, rangeend);
 
   // Read temperature calibration coefficients from CCDB, check whether they are the same
   auto rangetest = create_timestamp(2018, 7, 8, 7, 22, 0); //LHC18k 289166
@@ -93,18 +92,7 @@ void TempCalibParamSM_CCDBApiTest(const std::string_view ccdbserver = "emcccdb-t
 
   std::cout << "Using read timestamp " << rangetest << "(omitted untill function is implemented server side)" << std::endl;
   o2::emcal::TempCalibParamSM* read(nullptr);
-  auto res = ccdbhandler.retrieveFromTFile("EMC/TempCalibParamsSM", metadata, rangetest);
-  if (!res) {
-    std::cerr << "Failed retrieving object from CCDB" << std::endl;
-    return;
-  }
-  std::cout << "Object found, type " << res->IsA()->GetName() << std::endl;
-  auto objw = dynamic_cast<o2::TObjectWrapper<o2::emcal::TempCalibParamSM>*>(res);
-  if (!objw) {
-    std::cerr << "failed casting to TObjectWrapper" << std::endl;
-    return;
-  }
-  read = objw->getObj();
+  read = ccdbhandler.retrieveFromTFileAny<o2::emcal::TempCalibParamSM>("EMC/TempCalibParamsSM", metadata, rangetest);
   if (!read) {
     std::cerr << "No object received from CCDB" << std::endl;
     return;

--- a/Detectors/EMCAL/calib/macros/TempCalibParamSM_CalibDBTest.C
+++ b/Detectors/EMCAL/calib/macros/TempCalibParamSM_CalibDBTest.C
@@ -51,7 +51,7 @@ void TempCalibParamSM_CalibDBTest(const std::string_view ccdbserver = "emcccdb-t
   std::string inputDir = " ";
   if (aliceO2env)
     inputDir = aliceO2env;
-  inputDir += "/share/Detectors/EMCAL/files/";
+  inputDir += "/share/Detectors/EMC/files/";
 
   std::string file = inputDir + "TempCalibSM_LHC18k_289166.txt";
   std::ifstream fileTempCalibSM(file, std::ifstream::in);

--- a/Detectors/EMCAL/calib/macros/TempCalibrationParams_CCDBApiTest.C
+++ b/Detectors/EMCAL/calib/macros/TempCalibrationParams_CCDBApiTest.C
@@ -10,7 +10,6 @@
 
 #if !defined(__CLING__) || defined(__ROOTCLING__)
 #include "CCDB/CcdbApi.h"
-#include "CCDB/TObjectWrapper.h"
 #include "EMCALCalib/TempCalibrationParams.h"
 #include "RStringView.h"
 #include "TH1F.h"
@@ -53,7 +52,7 @@ void TempCalibrationParams_CCDBApiTest(const std::string_view ccdbserver = "emcc
   std::string inputDir = " ";
   if (aliceO2env)
     inputDir = aliceO2env;
-  inputDir += "/share/Detectors/EMCAL/files/";
+  inputDir += "/share/Detectors/EMC/files/";
 
   std::string file = inputDir + "TempCalibCoeff.txt";
   std::ifstream fileTemp(file, std::ifstream::in);
@@ -93,7 +92,7 @@ void TempCalibrationParams_CCDBApiTest(const std::string_view ccdbserver = "emcc
 
   std::cout << "Using time stamps " << rangestart << " and " << rangeend << std::endl;
   std::map<std::string, std::string> metadata;
-  ccdbhandler.storeAsTFile(new o2::TObjectWrapper<o2::emcal::TempCalibrationParams>(tcp), "EMC/TempCalibParams", metadata, rangestart, rangeend);
+  ccdbhandler.storeAsTFileAny(tcp, "EMC/TempCalibParams", metadata, rangestart, rangeend);
 
   // Read temperature calibration coefficients from CCDB, check whether they are the same
   auto rangetest = create_timestamp(2018, 4, 27, 1, 5, 52); //LHC18 run 285396
@@ -102,18 +101,7 @@ void TempCalibrationParams_CCDBApiTest(const std::string_view ccdbserver = "emcc
   //auto rangetest = create_timestamp(2015, 12, 9, 23, 10, 3); //LHC15 run 246583
   std::cout << "Using read timestamp " << rangetest << std::endl;
   o2::emcal::TempCalibrationParams* read(nullptr);
-  auto res = ccdbhandler.retrieveFromTFile("EMC/TempCalibParams", metadata, rangetest);
-  if (!res) {
-    std::cerr << "Failed retrieving object from CCDB" << std::endl;
-    return;
-  }
-  std::cout << "Object found, type " << res->IsA()->GetName() << std::endl;
-  auto objw = dynamic_cast<o2::TObjectWrapper<o2::emcal::TempCalibrationParams>*>(res);
-  if (!objw) {
-    std::cerr << "failed casting to TObjectWrapper" << std::endl;
-    return;
-  }
-  read = objw->getObj();
+  read = ccdbhandler.retrieveFromTFileAny<o2::emcal::TempCalibrationParams>("EMC/TempCalibParams", metadata, rangetest);
   if (!read) {
     std::cerr << "No object received from CCDB" << std::endl;
     return;

--- a/Detectors/EMCAL/calib/macros/TempCalibrationParams_CalibDBTest.C
+++ b/Detectors/EMCAL/calib/macros/TempCalibrationParams_CalibDBTest.C
@@ -51,7 +51,7 @@ void TempCalibrationParams_CalibDBTest(const std::string_view ccdbserver = "emcc
   std::string inputDir = " ";
   if (aliceO2env)
     inputDir = aliceO2env;
-  inputDir += "/share/Detectors/EMCAL/files/";
+  inputDir += "/share/Detectors/EMC/files/";
 
   std::string file = inputDir + "TempCalibCoeff.txt";
   std::ifstream fileTemp(file, std::ifstream::in);

--- a/Detectors/EMCAL/calib/macros/TimeCalibParamsL1Phase_CCDBApiTest.C
+++ b/Detectors/EMCAL/calib/macros/TimeCalibParamsL1Phase_CCDBApiTest.C
@@ -10,7 +10,6 @@
 
 #if !defined(__CLING__) || defined(__ROOTCLING__)
 #include "CCDB/CcdbApi.h"
-#include "CCDB/TObjectWrapper.h"
 #include "EMCALCalib/TimeCalibParamL1Phase.h"
 #include "RStringView.h"
 #include "TH1C.h"
@@ -53,7 +52,7 @@ void TimeCalibParamsL1Phase_CCDBApiTest(const std::string_view ccdbserver = "emc
   std::string inputDir = " ";
   if (aliceO2env)
     inputDir = aliceO2env;
-  inputDir += "/share/Detectors/EMCAL/files/";
+  inputDir += "/share/Detectors/EMC/files/";
 
   std::string file = inputDir + "TimeL1Phase_LHC18q_295585.txt";
   std::ifstream fileL1Phase(file, std::ifstream::in);
@@ -85,25 +84,14 @@ void TimeCalibParamsL1Phase_CCDBApiTest(const std::string_view ccdbserver = "emc
 
   std::cout << "Using time stamps " << rangestart << " and " << rangeend << std::endl;
   std::map<std::string, std::string> metadata;
-  ccdbhandler.storeAsTFile(new o2::TObjectWrapper<o2::emcal::TimeCalibParamL1Phase>(tcp), "EMC/TimeCalibParamsL1Phase", metadata, rangestart, rangeend);
+  ccdbhandler.storeAsTFileAny(tcp, "EMC/TimeCalibParamsL1Phase", metadata, rangestart, rangeend);
 
   // Read time calibration coefficients from CCDB, check whether they are the same
   auto rangetest = create_timestamp(2018, 11, 8, 21, 57, 7); //LHC18q 295585
   //auto rangetest = create_timestamp(2018, 11, 21, 6, 27, 28); //LHC18q 296623
   std::cout << "Using read timestamp " << rangetest << "(omitted untill function is implemented server side)" << std::endl;
   o2::emcal::TimeCalibParamL1Phase* read(nullptr);
-  auto res = ccdbhandler.retrieveFromTFile("EMC/TimeCalibParamsL1Phase", metadata, rangetest);
-  if (!res) {
-    std::cerr << "Failed retrieving object from CCDB" << std::endl;
-    return;
-  }
-  std::cout << "Object found, type " << res->IsA()->GetName() << std::endl;
-  auto objw = dynamic_cast<o2::TObjectWrapper<o2::emcal::TimeCalibParamL1Phase>*>(res);
-  if (!objw) {
-    std::cerr << "failed casting to TObjectWrapper" << std::endl;
-    return;
-  }
-  read = objw->getObj();
+  read = ccdbhandler.retrieveFromTFileAny<o2::emcal::TimeCalibParamL1Phase>("EMC/TimeCalibParamsL1Phase", metadata, rangetest);
   if (!read) {
     std::cerr << "No object received from CCDB" << std::endl;
     return;

--- a/Detectors/EMCAL/calib/macros/TimeCalibParamsL1Phase_CalibDBTest.C
+++ b/Detectors/EMCAL/calib/macros/TimeCalibParamsL1Phase_CalibDBTest.C
@@ -51,7 +51,7 @@ void TimeCalibParamsL1Phase_CalibDBTest(const std::string_view ccdbserver = "emc
   std::string inputDir = " ";
   if (aliceO2env)
     inputDir = aliceO2env;
-  inputDir += "/share/Detectors/EMCAL/files/";
+  inputDir += "/share/Detectors/EMC/files/";
 
   std::string file = inputDir + "TimeL1Phase_LHC18q_295585.txt";
   std::ifstream fileL1Phase(file, std::ifstream::in);

--- a/Detectors/EMCAL/calib/macros/TimeCalibrationParams_CCDBApiTest.C
+++ b/Detectors/EMCAL/calib/macros/TimeCalibrationParams_CCDBApiTest.C
@@ -10,7 +10,6 @@
 
 #if !defined(__CLING__) || defined(__ROOTCLING__)
 #include "CCDB/CcdbApi.h"
-#include "CCDB/TObjectWrapper.h"
 #include "EMCALCalib/TimeCalibrationParams.h"
 #include "RStringView.h"
 #include "TH1S.h"
@@ -51,7 +50,7 @@ void TimeCalibrationParams_CCDBApiTest(const std::string_view ccdbserver = "emcc
   std::string inputDir = " ";
   if (aliceO2env)
     inputDir = aliceO2env;
-  inputDir += "/share/Detectors/EMCAL/files/";
+  inputDir += "/share/Detectors/EMC/files/";
 
   std::string fileHG = inputDir + "TimeCalibCoeffHG.txt";
   std::ifstream allTimeAvHG(fileHG, std::ifstream::in);
@@ -95,25 +94,14 @@ void TimeCalibrationParams_CCDBApiTest(const std::string_view ccdbserver = "emcc
 
   std::cout << "Using time stamps " << rangestart << " and " << rangeend << std::endl;
   std::map<std::string, std::string> metadata;
-  ccdbhandler.storeAsTFile(new o2::TObjectWrapper<o2::emcal::TimeCalibrationParams>(tcp), "EMC/TimeCalibParams", metadata, rangestart, rangeend);
+  ccdbhandler.storeAsTFileAny(tcp, "EMC/TimeCalibParams", metadata, rangestart, rangeend);
 
   // Read time calibration coefficients from CCDB, check whether they are the same
   auto rangetest = create_timestamp(2018, 4, 21, 23, 18, 54); //LHC18b run 285165
   //auto rangetest = create_timestamp(2017, 6, 5, 5, 25, 28); //LHC17g run 271381
   std::cout << "Using read timestamp " << rangetest << std::endl;
   o2::emcal::TimeCalibrationParams* read(nullptr);
-  auto res = ccdbhandler.retrieveFromTFile("EMC/TimeCalibParams", metadata, rangetest);
-  if (!res) {
-    std::cerr << "Failed retrieving object from CCDB" << std::endl;
-    return;
-  }
-  std::cout << "Object found, type " << res->IsA()->GetName() << std::endl;
-  auto objw = dynamic_cast<o2::TObjectWrapper<o2::emcal::TimeCalibrationParams>*>(res);
-  if (!objw) {
-    std::cerr << "failed casting to TObjectWrapper" << std::endl;
-    return;
-  }
-  read = objw->getObj();
+  read = ccdbhandler.retrieveFromTFileAny<o2::emcal::TimeCalibrationParams>("EMC/TimeCalibParams", metadata, rangetest);
   if (!read) {
     std::cerr << "No object received from CCDB" << std::endl;
     return;

--- a/Detectors/EMCAL/calib/macros/TimeCalibrationParams_CalibDBTest.C
+++ b/Detectors/EMCAL/calib/macros/TimeCalibrationParams_CalibDBTest.C
@@ -49,7 +49,7 @@ void TimeCalibrationParams_CalibDBTest(const std::string_view ccdbserver = "emcc
   std::string inputDir = " ";
   if (aliceO2env)
     inputDir = aliceO2env;
-  inputDir += "/share/Detectors/EMCAL/files/";
+  inputDir += "/share/Detectors/EMC/files/";
 
   std::string fileHG = inputDir + "TimeCalibCoeffHG.txt";
   std::ifstream allTimeAvHG(fileHG, std::ifstream::in);

--- a/Detectors/EMCAL/calib/macros/TriggerDCS_CCDBApiTest.C
+++ b/Detectors/EMCAL/calib/macros/TriggerDCS_CCDBApiTest.C
@@ -1,0 +1,123 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include "CCDB/CcdbApi.h"
+#include "EMCALCalib/TriggerDCS.h"
+#include "RStringView.h"
+#include <ctime>
+#include <iostream>
+#include <sstream>
+#endif
+
+// functions getting test data
+void ConfigureTRU(o2::emcal::TriggerTRUDCS& testobject)
+{
+  testobject.setSELPF(7711);
+  testobject.setL0SEL(1);
+  testobject.setL0COSM(100);
+  testobject.setGTHRL0(132);
+  testobject.setMaskReg(1024, 0);
+  testobject.setMaskReg(0, 1);
+  testobject.setMaskReg(512, 2);
+  testobject.setMaskReg(31985, 3);
+  testobject.setMaskReg(0, 4);
+  testobject.setMaskReg(0, 5);
+  testobject.setRLBKSTU(0);
+  testobject.setFw(0x21);
+}
+
+void ConfigureSTU(o2::emcal::TriggerSTUDCS& testobject)
+{
+  testobject.setGammaHigh(0, 0);
+  testobject.setGammaHigh(1, 0);
+  testobject.setGammaHigh(2, 115);
+  testobject.setGammaLow(0, 0);
+  testobject.setGammaLow(1, 0);
+  testobject.setGammaLow(2, 51);
+  testobject.setJetHigh(0, 0);
+  testobject.setJetHigh(1, 0);
+  testobject.setJetHigh(2, 255);
+  testobject.setJetLow(0, 0);
+  testobject.setJetLow(1, 0);
+  testobject.setJetLow(2, 204);
+  testobject.setPatchSize(2);
+  testobject.setFw(0x2A012);
+  testobject.setMedianMode(0);
+  testobject.setRegion(0xffffffff);
+  for (int i = 0; i < 4; i++)
+    testobject.setPHOSScale(i, 0);
+}
+
+/// \brief Converting time into numerical time stamp representation
+unsigned long create_timestamp(int year, int month, int day, int hour, int minutes, int seconds)
+{
+  struct tm timeinfo;
+  timeinfo.tm_year = year;
+  timeinfo.tm_mon = month;
+  timeinfo.tm_mday = day;
+  timeinfo.tm_hour = hour;
+  timeinfo.tm_min = minutes;
+  timeinfo.tm_sec = seconds;
+
+  time_t timeformat = mktime(&timeinfo);
+  return static_cast<unsigned long>(timeformat);
+}
+
+/// \brief Read-write test
+///
+/// Writing to EMCAL CCDB server
+/// Attention: Might overwrite existing CCDB content - use with care!
+void TriggerDCS_CCDBApiTest(const std::string_view ccdbserver = "emcccdb-test.cern.ch")
+{
+  std::cout << "Using CCDB server " << ccdbserver << std::endl;
+  o2::ccdb::CcdbApi ccdbhandler;
+  ccdbhandler.init(ccdbserver.data());
+
+  // Prepare database object
+  o2::emcal::TriggerDCS* dcs = new o2::emcal::TriggerDCS;
+
+  o2::emcal::TriggerSTUDCS stuEMCal;
+  ConfigureSTU(stuEMCal);
+
+  o2::emcal::TriggerSTUDCS stuDCal;
+  ConfigureSTU(stuDCal);
+  stuDCal.setRegion(0xffffff7f);
+
+  o2::emcal::TriggerTRUDCS tru;
+  ConfigureTRU(tru);
+
+  dcs->setSTUEMCal(stuEMCal);
+  dcs->setSTUDCal(stuDCal);
+  dcs->setTRU(tru);
+
+  // Set time limits: These are from the start of the run validity range (252235) to the end of the run validity range (267166) LHC16
+  auto rangestart = create_timestamp(2016, 4, 23, 0, 58, 40),
+       rangeend = create_timestamp(2016, 12, 5, 6, 3, 19);
+  std::cout << "Using time stamps " << rangestart << " and " << rangeend << std::endl;
+  std::map<std::string, std::string> metadata;
+  ccdbhandler.storeAsTFileAny(dcs, "EMC/TriggerDCS", metadata, rangestart, rangeend);
+
+  // Read Trigger DCS data from CCDB, check whether they are the same
+  auto rangetest = create_timestamp(2016, 4, 23, 0, 58, 40); //LHC16
+  std::cout << "Using read timestamp " << rangetest << std::endl;
+  o2::emcal::TriggerDCS* read(nullptr);
+  read = ccdbhandler.retrieveFromTFileAny<o2::emcal::TriggerDCS>("EMC/TriggerDCS", metadata, rangetest);
+  if (!read) {
+    std::cerr << "No object received from CCDB" << std::endl;
+    return;
+  }
+  std::cout << "Obtained Trigger DCS data from CCDB - test for match" << std::endl;
+  if (*dcs == *read) {
+    std::cout << "Trigger DCS data matching - test successfull" << std::endl;
+  } else {
+    std::cerr << "Trigger DCS data don't match" << std::endl;
+  }
+}

--- a/Detectors/EMCAL/calib/macros/TriggerDCS_CalibDBTest.C
+++ b/Detectors/EMCAL/calib/macros/TriggerDCS_CalibDBTest.C
@@ -1,0 +1,130 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include "EMCALCalib/TriggerDCS.h"
+#include "EMCALCalib/CalibDB.h"
+#include "RStringView.h"
+#include <ctime>
+#include <iostream>
+#include <sstream>
+#endif
+
+// functions getting test data
+void ConfigureTRU(o2::emcal::TriggerTRUDCS& testobject)
+{
+  testobject.setSELPF(7711);
+  testobject.setL0SEL(1);
+  testobject.setL0COSM(100);
+  testobject.setGTHRL0(132);
+  testobject.setMaskReg(1024, 0);
+  testobject.setMaskReg(0, 1);
+  testobject.setMaskReg(512, 2);
+  testobject.setMaskReg(31985, 3);
+  testobject.setMaskReg(0, 4);
+  testobject.setMaskReg(0, 5);
+  testobject.setRLBKSTU(0);
+  testobject.setFw(0x21);
+}
+
+void ConfigureSTU(o2::emcal::TriggerSTUDCS& testobject)
+{
+  testobject.setGammaHigh(0, 0);
+  testobject.setGammaHigh(1, 0);
+  testobject.setGammaHigh(2, 115);
+  testobject.setGammaLow(0, 0);
+  testobject.setGammaLow(1, 0);
+  testobject.setGammaLow(2, 51);
+  testobject.setJetHigh(0, 0);
+  testobject.setJetHigh(1, 0);
+  testobject.setJetHigh(2, 255);
+  testobject.setJetLow(0, 0);
+  testobject.setJetLow(1, 0);
+  testobject.setJetLow(2, 204);
+  testobject.setPatchSize(2);
+  testobject.setFw(0x2A012);
+  testobject.setMedianMode(0);
+  testobject.setRegion(0xffffffff);
+  for (int i = 0; i < 4; i++)
+    testobject.setPHOSScale(i, 0);
+}
+
+/// \brief Converting time into numerical time stamp representation
+unsigned long create_timestamp(int year, int month, int day, int hour, int minutes, int seconds)
+{
+  struct tm timeinfo;
+  timeinfo.tm_year = year;
+  timeinfo.tm_mon = month;
+  timeinfo.tm_mday = day;
+  timeinfo.tm_hour = hour;
+  timeinfo.tm_min = minutes;
+  timeinfo.tm_sec = seconds;
+
+  time_t timeformat = mktime(&timeinfo);
+  return static_cast<unsigned long>(timeformat);
+}
+
+/// \brief Read-write test
+///
+/// Writing to EMCAL CCDB server
+/// Attention: Might overwrite existing CCDB content - use with care!
+void TriggerDCS_CalibDBTest(const std::string_view ccdbserver = "emcccdb-test.cern.ch")
+{
+  std::cout << "Using CCDB server " << ccdbserver << std::endl;
+  o2::emcal::CalibDB ccdbhandler(ccdbserver);
+
+  // Prepare database object
+  o2::emcal::TriggerDCS* dcs = new o2::emcal::TriggerDCS;
+
+  o2::emcal::TriggerSTUDCS stuEMCal;
+  ConfigureSTU(stuEMCal);
+
+  o2::emcal::TriggerSTUDCS stuDCal;
+  ConfigureSTU(stuDCal);
+  stuDCal.setRegion(0xffffff7f);
+
+  o2::emcal::TriggerTRUDCS tru;
+  ConfigureTRU(tru);
+
+  dcs->setSTUEMCal(stuEMCal);
+  dcs->setSTUDCal(stuDCal);
+  dcs->setTRU(tru);
+
+  // Set time limits: These are from the start of the run validity range (252235) to the end of the run validity range (267166) LHC16
+  auto rangestart = create_timestamp(2016, 4, 23, 0, 58, 40),
+       rangeend = create_timestamp(2016, 12, 5, 6, 3, 19);
+  std::cout << "Using time stamps " << rangestart << " and " << rangeend << std::endl;
+  std::map<std::string, std::string> metadata;
+  ccdbhandler.storeTriggerDCSData(dcs, metadata, rangestart, rangeend);
+
+  // Read Trigger DCS from CCDB, check whether they are the same
+  auto rangetest = create_timestamp(2016, 4, 23, 0, 58, 40); //LHC16
+  std::cout << "Using read timestamp " << rangetest << std::endl;
+  o2::emcal::TriggerDCS* read(nullptr);
+  try {
+    read = ccdbhandler.readTriggerDCSData(rangetest, metadata);
+  } catch (o2::emcal::CalibDB::ObjectNotFoundException& oe) {
+    std::cerr << "CCDB error: " << oe.what() << std::endl;
+    return;
+  } catch (o2::emcal::CalibDB::TypeMismatchException& te) {
+    std::cout << "CCDB error: " << te.what() << std::endl;
+    return;
+  }
+  if (!read) {
+    std::cerr << "No object received from CCDB" << std::endl;
+    return;
+  }
+  std::cout << "Obtained Trigger DCS data from CCDB - test for match" << std::endl;
+  if (*dcs == *read) {
+    std::cout << "Trigger DCS data matching - test successfull" << std::endl;
+  } else {
+    std::cerr << "Trigger DCS data don't match" << std::endl;
+  }
+}

--- a/Detectors/EMCAL/calib/src/CalibDB.cxx
+++ b/Detectors/EMCAL/calib/src/CalibDB.cxx
@@ -13,6 +13,8 @@
 #include "EMCALCalib/TempCalibrationParams.h"
 #include "EMCALCalib/TimeCalibParamL1Phase.h"
 #include "EMCALCalib/TempCalibParamSM.h"
+#include "EMCALCalib/GainCalibrationFactors.h"
+#include "EMCALCalib/TriggerDCS.h"
 #include "EMCALCalib/CalibDB.h"
 
 using namespace o2::emcal;
@@ -32,130 +34,117 @@ void CalibDB::storeBadChannelMap(BadChannelMap* bcm, const std::map<std::string,
 {
   if (!mInit)
     init();
-  mCCDBManager.storeAsTFile(new o2::TObjectWrapper<o2::emcal::BadChannelMap>(bcm), "EMC/BadChannelMap", metadata, rangestart, rangeend);
+  mCCDBManager.storeAsTFileAny(bcm, "EMC/BadChannelMap", metadata, rangestart, rangeend);
 }
 
 void CalibDB::storeTimeCalibParam(TimeCalibrationParams* tcp, const std::map<std::string, std::string>& metadata, ULong_t rangestart, ULong_t rangeend)
 {
   if (!mInit)
     init();
-  mCCDBManager.storeAsTFile(new o2::TObjectWrapper<o2::emcal::TimeCalibrationParams>(tcp), "EMC/TimeCalibParams", metadata, rangestart, rangeend);
+  mCCDBManager.storeAsTFileAny(tcp, "EMC/TimeCalibParams", metadata, rangestart, rangeend);
 }
 
 void CalibDB::storeTimeCalibParamL1Phase(TimeCalibParamL1Phase* tcp, const std::map<std::string, std::string>& metadata, ULong_t rangestart, ULong_t rangeend)
 {
   if (!mInit)
     init();
-  mCCDBManager.storeAsTFile(new o2::TObjectWrapper<o2::emcal::TimeCalibParamL1Phase>(tcp), "EMC/TimeCalibParamsL1Phase", metadata, rangestart, rangeend);
+  mCCDBManager.storeAsTFileAny(tcp, "EMC/TimeCalibParamsL1Phase", metadata, rangestart, rangeend);
 }
 
 void CalibDB::storeTempCalibParam(TempCalibrationParams* tcp, const std::map<std::string, std::string>& metadata, ULong_t rangestart, ULong_t rangeend)
 {
   if (!mInit)
     init();
-  mCCDBManager.storeAsTFile(new o2::TObjectWrapper<o2::emcal::TempCalibrationParams>(tcp), "EMC/TempCalibParams", metadata, rangestart, rangeend);
+  mCCDBManager.storeAsTFileAny(tcp, "EMC/TempCalibParams", metadata, rangestart, rangeend);
 }
 
 void CalibDB::storeTempCalibParamSM(TempCalibParamSM* tcp, const std::map<std::string, std::string>& metadata, ULong_t rangestart, ULong_t rangeend)
 {
   if (!mInit)
     init();
-  mCCDBManager.storeAsTFile(new o2::TObjectWrapper<o2::emcal::TempCalibParamSM>(tcp), "EMC/TempCalibParamsSM", metadata, rangestart, rangeend);
+  mCCDBManager.storeAsTFileAny(tcp, "EMC/TempCalibParamsSM", metadata, rangestart, rangeend);
 }
 
 void CalibDB::storeGainCalibFactors(GainCalibrationFactors* gcf, const std::map<std::string, std::string>& metadata, ULong_t rangestart, ULong_t rangeend)
 {
   if (!mInit)
     init();
-  mCCDBManager.storeAsTFile(new o2::TObjectWrapper<o2::emcal::GainCalibrationFactors>(gcf), "EMC/GainCalibFactors", metadata, rangestart, rangeend);
+  mCCDBManager.storeAsTFileAny(gcf, "EMC/GainCalibFactors", metadata, rangestart, rangeend);
+}
+
+void CalibDB::storeTriggerDCSData(TriggerDCS* dcs, const std::map<std::string, std::string>& metadata, ULong_t rangestart, ULong_t rangeend)
+{
+  if (!mInit)
+    init();
+  mCCDBManager.storeAsTFileAny(dcs, "EMC/TriggerDCS", metadata, rangestart, rangeend);
 }
 
 BadChannelMap* CalibDB::readBadChannelMap(ULong_t timestamp, const std::map<std::string, std::string>& metadata)
 {
   if (!mInit)
     init();
-  auto result = mCCDBManager.retrieveFromTFile("EMC/BadChannelMap", metadata, timestamp);
+  BadChannelMap* result = mCCDBManager.retrieveFromTFileAny<o2::emcal::BadChannelMap>("EMC/BadChannelMap", metadata, timestamp);
   if (!result)
     throw ObjectNotFoundException(mCCDBServer, "EMC/BadChannelMap", metadata, timestamp);
-  if (result->IsA() != TObjectWrapper<o2::emcal::BadChannelMap>::Class())
-    throw TypeMismatchException("TObjectWrapper<o2::emcal::BadChannelMap>", result->IsA()->GetName());
-  auto wrap = dynamic_cast<TObjectWrapper<o2::emcal::BadChannelMap>*>(result);
-  if (!wrap)
-    throw TypeMismatchException("TObjectWrapper<o2::emcal::BadChannelMap>", result->IsA()->GetName()); // type checked before - should not enter here
-  return wrap->getObj();
+  return result;
 }
 
 TimeCalibrationParams* CalibDB::readTimeCalibParam(ULong_t timestamp, const std::map<std::string, std::string>& metadata)
 {
   if (!mInit)
     init();
-  auto result = mCCDBManager.retrieveFromTFile("EMC/TimeCalibParams", metadata, timestamp);
+  TimeCalibrationParams* result = mCCDBManager.retrieveFromTFileAny<o2::emcal::TimeCalibrationParams>("EMC/TimeCalibParams", metadata, timestamp);
   if (!result)
     throw ObjectNotFoundException(mCCDBServer, "EMC/TimeCalibParams", metadata, timestamp);
-  if (result->IsA() != TObjectWrapper<o2::emcal::TimeCalibrationParams>::Class())
-    throw TypeMismatchException("TObjectWrapper<o2::emcal::TimeCalibrationParams>", result->IsA()->GetName());
-  auto wrap = dynamic_cast<TObjectWrapper<o2::emcal::TimeCalibrationParams>*>(result);
-  if (!wrap)
-    throw TypeMismatchException("TObjectWrapper<o2::emcal::TimeCalibrationParams>", result->IsA()->GetName()); // type checked before - should not enter here
-  return wrap->getObj();
+  return result;
 }
 
 TimeCalibParamL1Phase* CalibDB::readTimeCalibParamL1Phase(ULong_t timestamp, const std::map<std::string, std::string>& metadata)
 {
   if (!mInit)
     init();
-  auto result = mCCDBManager.retrieveFromTFile("EMC/TimeCalibParamsL1Phase", metadata, timestamp);
+  TimeCalibParamL1Phase* result = mCCDBManager.retrieveFromTFileAny<o2::emcal::TimeCalibParamL1Phase>("EMC/TimeCalibParamsL1Phase", metadata, timestamp);
   if (!result)
     throw ObjectNotFoundException(mCCDBServer, "EMC/TimeCalibParamsL1Phase", metadata, timestamp);
-  if (result->IsA() != TObjectWrapper<o2::emcal::TimeCalibParamL1Phase>::Class())
-    throw TypeMismatchException("TObjectWrapper<o2::emcal::TimeCalibParamL1Phase>", result->IsA()->GetName());
-  auto wrap = dynamic_cast<TObjectWrapper<o2::emcal::TimeCalibParamL1Phase>*>(result);
-  if (!wrap)
-    throw TypeMismatchException("TObjectWrapper<o2::emcal::TimeCalibParamL1Phase>", result->IsA()->GetName()); // type checked before - should not enter here
-  return wrap->getObj();
+  return result;
 }
 
 TempCalibrationParams* CalibDB::readTempCalibParam(ULong_t timestamp, const std::map<std::string, std::string>& metadata)
 {
   if (!mInit)
     init();
-  auto result = mCCDBManager.retrieveFromTFile("EMC/TempCalibParams", metadata, timestamp);
+  TempCalibrationParams* result = mCCDBManager.retrieveFromTFileAny<o2::emcal::TempCalibrationParams>("EMC/TempCalibParams", metadata, timestamp);
   if (!result)
     throw ObjectNotFoundException(mCCDBServer, "EMC/TempCalibParams", metadata, timestamp);
-  if (result->IsA() != TObjectWrapper<o2::emcal::TempCalibrationParams>::Class())
-    throw TypeMismatchException("TObjectWrapper<o2::emcal::TempCalibrationParams>", result->IsA()->GetName());
-  auto wrap = dynamic_cast<TObjectWrapper<o2::emcal::TempCalibrationParams>*>(result);
-  if (!wrap)
-    throw TypeMismatchException("TObjectWrapper<o2::emcal::TempCalibrationParams>", result->IsA()->GetName()); // type checked before - should not enter here
-  return wrap->getObj();
+  return result;
 }
 
 TempCalibParamSM* CalibDB::readTempCalibParamSM(ULong_t timestamp, const std::map<std::string, std::string>& metadata)
 {
   if (!mInit)
     init();
-  auto result = mCCDBManager.retrieveFromTFile("EMC/TempCalibParamsSM", metadata, timestamp);
+  TempCalibParamSM* result = mCCDBManager.retrieveFromTFileAny<o2::emcal::TempCalibParamSM>("EMC/TempCalibParamsSM", metadata, timestamp);
   if (!result)
     throw ObjectNotFoundException(mCCDBServer, "EMC/TempCalibParamsSM", metadata, timestamp);
-  if (result->IsA() != TObjectWrapper<o2::emcal::TempCalibParamSM>::Class())
-    throw TypeMismatchException("TObjectWrapper<o2::emcal::TempCalibParamSM>", result->IsA()->GetName());
-  auto wrap = dynamic_cast<TObjectWrapper<o2::emcal::TempCalibParamSM>*>(result);
-  if (!wrap)
-    throw TypeMismatchException("TObjectWrapper<o2::emcal::TempCalibParamSM>", result->IsA()->GetName()); // type checked before - should not enter here
-  return wrap->getObj();
+  return result;
 }
 
 GainCalibrationFactors* CalibDB::readGainCalibFactors(ULong_t timestamp, const std::map<std::string, std::string>& metadata)
 {
   if (!mInit)
     init();
-  auto result = mCCDBManager.retrieveFromTFile("EMC/GainCalibFactors", metadata, timestamp);
+  GainCalibrationFactors* result = mCCDBManager.retrieveFromTFileAny<o2::emcal::GainCalibrationFactors>("EMC/GainCalibFactors", metadata, timestamp);
   if (!result)
     throw ObjectNotFoundException(mCCDBServer, "EMC/GainCalibFactors", metadata, timestamp);
-  if (result->IsA() != TObjectWrapper<o2::emcal::GainCalibrationFactors>::Class())
-    throw TypeMismatchException("TObjectWrapper<o2::emcal::GainCalibrationFactors>", result->IsA()->GetName());
-  auto wrap = dynamic_cast<TObjectWrapper<o2::emcal::GainCalibrationFactors>*>(result);
-  if (!wrap)
-    throw TypeMismatchException("TObjectWrapper<o2::emcal::GainCalibrationFactors>", result->IsA()->GetName()); // type checked before - should not enter here
-  return wrap->getObj();
+  return result;
+}
+
+TriggerDCS* CalibDB::readTriggerDCSData(ULong_t timestamp, const std::map<std::string, std::string>& metadata)
+{
+  if (!mInit)
+    init();
+  TriggerDCS* result = mCCDBManager.retrieveFromTFileAny<o2::emcal::TriggerDCS>("EMC/TriggerDCS", metadata, timestamp);
+  if (!result)
+    throw ObjectNotFoundException(mCCDBServer, "EMC/TriggerDCS", metadata, timestamp);
+  return result;
 }

--- a/Detectors/EMCAL/calib/src/EMCALCalibLinkDef.h
+++ b/Detectors/EMCAL/calib/src/EMCALCalibLinkDef.h
@@ -16,16 +16,14 @@
 
 #pragma link C++ class o2::emcal::CalibDB + ;
 #pragma link C++ class o2::emcal::BadChannelMap + ;
-#pragma link C++ class o2::TObjectWrapper < o2::emcal::BadChannelMap> + ;
 #pragma link C++ class o2::emcal::TimeCalibrationParams + ;
-#pragma link C++ class o2::TObjectWrapper < o2::emcal::TimeCalibrationParams> + ;
 #pragma link C++ class o2::emcal::TimeCalibParamL1Phase + ;
-#pragma link C++ class o2::TObjectWrapper < o2::emcal::TimeCalibParamL1Phase> + ;
 #pragma link C++ class o2::emcal::TempCalibrationParams + ;
-#pragma link C++ class o2::TObjectWrapper < o2::emcal::TempCalibrationParams> + ;
 #pragma link C++ class o2::emcal::TempCalibParamSM + ;
-#pragma link C++ class o2::TObjectWrapper < o2::emcal::TempCalibParamSM> + ;
 #pragma link C++ class o2::emcal::GainCalibrationFactors + ;
-#pragma link C++ class o2::TObjectWrapper < o2::emcal::GainCalibrationFactors> + ;
+#pragma link C++ class o2::emcal::TriggerTRUDCS + ;
+#pragma link C++ class o2::emcal::TriggerSTUDCS + ;
+#pragma link C++ class o2::emcal::TriggerSTUErrorCounter + ;
+#pragma link C++ class o2::emcal::TriggerDCS + ;
 
 #endif

--- a/Detectors/EMCAL/calib/src/TimeCalibParamL1Phase.cxx
+++ b/Detectors/EMCAL/calib/src/TimeCalibParamL1Phase.cxx
@@ -34,7 +34,7 @@ TH1* TimeCalibParamL1Phase::getHistogramRepresentation() const
   hist->SetDirectory(nullptr);
 
   for (std::size_t iSM{0}; iSM < mTimeCalibParamsL1Phase.size(); ++iSM)
-    hist->SetBinContent(iSM + 1, mTimeCalibParamsL1Phase[iSM]);
+    hist->SetBinContent(iSM + 1, mTimeCalibParamsL1Phase[iSM] - '0');
 
   return hist;
 }

--- a/Detectors/EMCAL/calib/src/TriggerDCS.cxx
+++ b/Detectors/EMCAL/calib/src/TriggerDCS.cxx
@@ -1,0 +1,66 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "EMCALCalib/TriggerDCS.h"
+#include "EMCALCalib/TriggerTRUDCS.h"
+#include "EMCALCalib/TriggerSTUDCS.h"
+
+#include "FairLogger.h"
+
+#include <bitset>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+
+using namespace o2::emcal;
+
+bool TriggerDCS::operator==(const TriggerDCS& other) const
+{
+  return (mSTUEMCal == other.mSTUEMCal) && (mSTUDCAL == other.mSTUDCAL) && (mTRUArr == other.mTRUArr);
+}
+
+bool TriggerDCS::isTRUEnabled(int itru) const
+{
+  if (itru < 32) {
+    return std::bitset<32>(mSTUEMCal.getRegion()).test(itru);
+  } else {
+    return std::bitset<32>(mSTUDCAL.getRegion()).test(itru - 32);
+  }
+}
+
+std::ostream& o2::emcal::operator<<(std::ostream& stream, const TriggerDCS& config)
+{
+  stream << "EMCAL trigger DCS config:" << std::endl;
+  stream << "================================" << std::endl;
+  for (int i = 0; i < config.getTRUArr().size(); i++) {
+    TriggerTRUDCS tru = config.getTRUDCS(i);
+    stream << "TRU" << i << ": " << tru << std::endl;
+  }
+  TriggerSTUDCS emcalstu(config.getSTUDCSEMCal()), dcalstu(config.getSTUDCSDCal());
+  std::cout << "EMCAL STU: " << emcalstu << std::endl;
+  std::cout << "DCAL STU:  " << dcalstu << std::endl;
+  return stream;
+}
+
+std::string TriggerDCS::toJSON() const
+{
+  std::stringstream jsonstring;
+  jsonstring << "{";
+  jsonstring << "\"mSTUEMCal\":" << mSTUEMCal.toJSON() << ",";
+  jsonstring << "\"mSTUDCAL\":" << mSTUDCAL.toJSON() << ",";
+  jsonstring << "mTRUArr:[";
+  for (int ien = 0; ien < mTRUArr.size(); ien++) {
+    jsonstring << "{\"TRU" << ien << "\":" << mTRUArr.at(ien).toJSON() << "}";
+    if (ien != mTRUArr.size() - 1)
+      jsonstring << ",";
+  }
+  jsonstring << "]}";
+  return jsonstring.str();
+}

--- a/Detectors/EMCAL/calib/src/TriggerSTUDCS.cxx
+++ b/Detectors/EMCAL/calib/src/TriggerSTUDCS.cxx
@@ -1,0 +1,80 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "EMCALCalib/TriggerSTUDCS.h"
+
+#include "FairLogger.h"
+
+#include <bitset>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+
+using namespace o2::emcal;
+
+TriggerSTUDCS::TriggerSTUDCS(std::array<int, 3> Gammahigh, std::array<int, 3> Jethigh,
+                             std::array<int, 3> Gammalow, std::array<int, 3> Jetlow,
+                             int rawData, int region, int fw, int patchSize, int median,
+                             std::array<int, 4> phosScale) : mGammaHigh(Gammahigh),
+                                                             mJetHigh(Jethigh),
+                                                             mGammaLow(Gammalow),
+                                                             mJetLow(Jetlow),
+                                                             mGetRawData(rawData),
+                                                             mRegion(region),
+                                                             mFw(fw),
+                                                             mPatchSize(patchSize),
+                                                             mMedian(median),
+                                                             mPHOSScale(phosScale)
+{
+}
+
+bool TriggerSTUDCS::operator==(const TriggerSTUDCS& other) const
+{
+  return (mGetRawData == other.mGetRawData) && (mRegion == other.mRegion) &&
+         (mFw == other.mFw) && (mPatchSize == other.mPatchSize) && (mMedian == other.mMedian) &&
+         (mPHOSScale == other.mPHOSScale) && (mGammaHigh == other.mGammaHigh) &&
+         (mJetHigh == other.mJetHigh) && (mGammaLow == other.mGammaLow) && (mJetLow == other.mJetLow);
+}
+
+void TriggerSTUDCS::PrintStream(std::ostream& stream) const
+{
+  stream << "Gamma High: (" << mGammaHigh[0] << ", " << mGammaHigh[1] << ", " << mGammaHigh[2] << ")" << std::endl;
+  stream << "Gamma Low:  (" << mGammaLow[0] << ", " << mGammaLow[1] << ", " << mGammaLow[2] << ")" << std::endl;
+  stream << "Jet High:   (" << mJetHigh[0] << ", " << mJetHigh[1] << ", " << mJetHigh[2] << ")" << std::endl;
+  stream << "Jet Low:    (" << mJetLow[0] << ", " << mJetLow[1] << ", " << mJetLow[2] << ")" << std::endl;
+  stream << "GetRawData: " << mGetRawData
+         << ", Region: " << std::hex << mRegion << std::dec << " (" << std::bitset<sizeof(mRegion) * 8>(mRegion) << ")"
+         << ", Median: " << mMedian
+         << ", Firmware: " << std::hex << mFw << std::dec
+         << ", PHOS Scale: (" << mPHOSScale[0] << ", " << mPHOSScale[1] << ", " << mPHOSScale[2] << ", " << mPHOSScale[3]
+         << ")" << std::endl;
+}
+
+std::ostream& o2::emcal::operator<<(std::ostream& stream, const TriggerSTUDCS& stu)
+{
+  stu.PrintStream(stream);
+  return stream;
+}
+
+std::string TriggerSTUDCS::toJSON() const
+{
+  std::stringstream jsonstring;
+  jsonstring << "{"
+             << "\"mGammaHigh\":[[" << mGammaHigh[0] << "," << mGammaHigh[1] << "," << mGammaHigh[2] << "],[" << mGammaLow[0] << "," << mGammaLow[1] << "," << mGammaLow[2] << "]],"
+             << "\"mJetHigh\":[[" << mJetHigh[0] << "," << mJetHigh[1] << "," << mJetHigh[2] << "],[" << mJetLow[0] << "," << mJetLow[1] << "," << mJetLow[2] << "]],"
+             << "\"mRawData\":" << mGetRawData << ","
+             << "\"mRegion\":" << mRegion << ","
+             << "\"mFirmware\":" << mFw << ","
+             << "\"mMedian\":" << mMedian << ","
+             << "\"mPHOSScale\":[" << mPHOSScale[0] << "," << mPHOSScale[1] << "," << mPHOSScale[2] << "," << mPHOSScale[3] << "]"
+             << "}";
+
+  return jsonstring.str();
+}

--- a/Detectors/EMCAL/calib/src/TriggerSTUErrorCounter.cxx
+++ b/Detectors/EMCAL/calib/src/TriggerSTUErrorCounter.cxx
@@ -1,0 +1,48 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "EMCALCalib/TriggerSTUErrorCounter.h"
+
+#include "FairLogger.h"
+
+#include <bitset>
+#include <iomanip>
+
+using namespace o2::emcal;
+
+TriggerSTUErrorCounter::TriggerSTUErrorCounter(int Time, unsigned long Error)
+{
+  setValue(Time, Error);
+}
+
+TriggerSTUErrorCounter::TriggerSTUErrorCounter(std::pair<int, unsigned long> TimeAndError)
+{
+  setValue(TimeAndError);
+}
+
+bool TriggerSTUErrorCounter::operator==(const TriggerSTUErrorCounter& other) const
+{
+  return (mTimeErrorCount == other.mTimeErrorCount);
+}
+
+bool TriggerSTUErrorCounter::isEqual(TriggerSTUErrorCounter& counter) const
+{
+  return counter.mTimeErrorCount.first == mTimeErrorCount.first;
+}
+
+int TriggerSTUErrorCounter::compare(TriggerSTUErrorCounter& counter) const
+{
+  if (mTimeErrorCount.first > counter.mTimeErrorCount.first)
+    return 1;
+  if (mTimeErrorCount.first < counter.mTimeErrorCount.first)
+    return -1;
+
+  return 0;
+}

--- a/Detectors/EMCAL/calib/src/TriggerTRUDCS.cxx
+++ b/Detectors/EMCAL/calib/src/TriggerTRUDCS.cxx
@@ -1,0 +1,68 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "EMCALCalib/TriggerTRUDCS.h"
+
+#include "FairLogger.h"
+
+#include <bitset>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+
+using namespace o2::emcal;
+
+TriggerTRUDCS::TriggerTRUDCS(uint64_t selpf, uint64_t l0sel, uint64_t l0cosm,
+                             uint64_t gthrl0, uint64_t rlbkstu, uint64_t fw,
+                             std::array<uint32_t, 6> maskReg) : mSELPF(selpf),
+                                                                mL0SEL(l0sel),
+                                                                mL0COSM(l0cosm),
+                                                                mGTHRL0(gthrl0),
+                                                                mRLBKSTU(rlbkstu),
+                                                                mFw(fw),
+                                                                mMaskReg(maskReg)
+{
+}
+
+bool TriggerTRUDCS::operator==(const TriggerTRUDCS& other) const
+{
+  return (mSELPF == other.mSELPF) && (mL0SEL == other.mL0SEL) && (mL0COSM == other.mL0COSM) && (mGTHRL0 == other.mGTHRL0) && (mRLBKSTU == other.mRLBKSTU) && (mFw == other.mFw) && (mMaskReg == other.mMaskReg);
+}
+
+void TriggerTRUDCS::PrintStream(std::ostream& stream) const
+{
+  stream << "SELPF: " << std::hex << mSELPF << ", L0SEL: " << mL0SEL << ", L0COSM: " << std::dec
+         << mL0COSM << ", GTHRL0: " << mGTHRL0 << ", RLBKSTU: " << mRLBKSTU << ", FW: " << std::hex
+         << mFw << std::dec << std::endl;
+  for (int ireg = 0; ireg < 6; ireg++) {
+    stream << "Reg" << ireg << ": " << std::bitset<sizeof(uint32_t) * 8>(mMaskReg[ireg]) << " (" << mMaskReg[ireg] << ")" << std::endl;
+  }
+}
+
+std::ostream& o2::emcal::operator<<(std::ostream& stream, const TriggerTRUDCS& tru)
+{
+  tru.PrintStream(stream);
+  return stream;
+}
+
+std::string TriggerTRUDCS::toJSON() const
+{
+  std::stringstream jsonstring;
+  jsonstring << "{"
+             << "\"mSELPF\":" << mSELPF << ","
+             << "\"mL0SEL\":" << mL0SEL << ","
+             << "\"mL0COSM\":" << mL0COSM << ","
+             << "\"mGTHRL0\":" << mGTHRL0 << ","
+             << "\"mRLBKSTU\":" << mRLBKSTU << ","
+             << "\"mFw\":" << mFw << ","
+             << "\"mMaskReg\":[" << mMaskReg[0] << "," << mMaskReg[1] << "," << mMaskReg[2] << "," << mMaskReg[3] << "," << mMaskReg[4] << "," << mMaskReg[5] << "]"
+             << "}";
+  return jsonstring.str();
+}

--- a/Detectors/EMCAL/calib/test/testTriggerDCS.cxx
+++ b/Detectors/EMCAL/calib/test/testTriggerDCS.cxx
@@ -1,0 +1,115 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test EMCAL Calib
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include "EMCALCalib/TriggerDCS.h"
+#include "EMCALCalib/TriggerTRUDCS.h"
+#include "EMCALCalib/TriggerSTUDCS.h"
+
+#include <algorithm>
+
+namespace o2
+{
+
+namespace emcal
+{
+
+/// \brief Apply reference configuration
+/// Reference configuration taken from pp 2016
+/// \param testobject Object for test to be configured
+///
+void ConfigureReferenceTRU(TriggerTRUDCS& testobject)
+{
+  testobject.setSELPF(7711);
+  testobject.setL0SEL(1);
+  testobject.setL0COSM(100);
+  testobject.setGTHRL0(132);
+  testobject.setMaskReg(1024, 0);
+  testobject.setMaskReg(0, 1);
+  testobject.setMaskReg(512, 2);
+  testobject.setMaskReg(31985, 3);
+  testobject.setMaskReg(0, 4);
+  testobject.setMaskReg(0, 5);
+  testobject.setRLBKSTU(0);
+  testobject.setFw(0x21);
+}
+
+void ConfigureReferenceSTU(TriggerSTUDCS& testobject)
+{
+  testobject.setGammaHigh(0, 0);
+  testobject.setGammaHigh(1, 0);
+  testobject.setGammaHigh(2, 115);
+  testobject.setGammaLow(0, 0);
+  testobject.setGammaLow(1, 0);
+  testobject.setGammaLow(2, 51);
+  testobject.setJetHigh(0, 0);
+  testobject.setJetHigh(1, 0);
+  testobject.setJetHigh(2, 255);
+  testobject.setJetLow(0, 0);
+  testobject.setJetLow(1, 0);
+  testobject.setJetLow(2, 204);
+  testobject.setPatchSize(2);
+  testobject.setFw(0x2A012);
+  testobject.setMedianMode(0);
+  testobject.setRegion(0xffffffff);
+  for (int i = 0; i < 4; i++)
+    testobject.setPHOSScale(i, 0);
+}
+
+BOOST_AUTO_TEST_CASE(TriggerDCS_test)
+{
+
+  /// \brief testing all the getters and setters
+  TriggerSTUDCS testSTUDCal;
+  ConfigureReferenceSTU(testSTUDCal);
+
+  TriggerSTUDCS testSTUEMCal;
+  ConfigureReferenceSTU(testSTUEMCal);
+  testSTUEMCal.setRegion(0xffffff7f);
+
+  TriggerTRUDCS testTRU;
+  ConfigureReferenceTRU(testTRU);
+
+  TriggerDCS testobject;
+  testobject.setSTUEMCal(testSTUEMCal);
+  testobject.setSTUDCal(testSTUDCal);
+  testobject.setTRU(testTRU);
+
+  BOOST_CHECK_EQUAL(testobject.getSTUDCSEMCal(), testSTUEMCal);
+  BOOST_CHECK_EQUAL(testobject.getSTUDCSDCal(), testSTUDCal);
+  BOOST_CHECK_EQUAL(testobject.getTRUDCS(0), testTRU);
+
+  /// \brief Test for operator== on itself
+  /// Tests whether operator== returns true in case the object is tested
+  /// against itself.
+  BOOST_CHECK_EQUAL(testobject == testobject, true);
+
+  /// \brief Test for operator== on different objects
+  /// Tests whether the operator== returns false if at least one setting
+  /// is different. For this operator== is tested with multiple objects
+  /// based on a reference setting where only one parameter is changed at
+  /// the time.
+  TriggerDCS ref;
+
+  TriggerTRUDCS testTRU1;
+  ConfigureReferenceTRU(testTRU1);
+  testTRU1.setSELPF(7000);
+  ref.setSTUEMCal(testSTUEMCal);
+  ref.setSTUDCal(testSTUDCal);
+  ref.setTRU(testTRU1);
+  BOOST_CHECK_EQUAL(ref == testobject, false);
+}
+
+} // namespace emcal
+
+} // namespace o2

--- a/Detectors/EMCAL/calib/test/testTriggerSTUDCS.cxx
+++ b/Detectors/EMCAL/calib/test/testTriggerSTUDCS.cxx
@@ -1,0 +1,139 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test EMCAL Calib
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include "EMCALCalib/TriggerSTUDCS.h"
+
+#include <algorithm>
+
+namespace o2
+{
+
+namespace emcal
+{
+
+/// \brief Apply reference configuration
+/// Reference configuration taken from pp 2016
+/// \param testobject Object for test to be configured
+///
+void ConfigureReference(TriggerSTUDCS& testobject)
+{
+  testobject.setGammaHigh(0, 0);
+  testobject.setGammaHigh(1, 0);
+  testobject.setGammaHigh(2, 115);
+  testobject.setGammaLow(0, 0);
+  testobject.setGammaLow(1, 0);
+  testobject.setGammaLow(2, 51);
+  testobject.setJetHigh(0, 0);
+  testobject.setJetHigh(1, 0);
+  testobject.setJetHigh(2, 255);
+  testobject.setJetLow(0, 0);
+  testobject.setJetLow(1, 0);
+  testobject.setJetLow(2, 204);
+  testobject.setPatchSize(2);
+  testobject.setFw(0x2A012);
+  testobject.setMedianMode(0);
+  testobject.setRegion(0xffffffff);
+  for (int i = 0; i < 4; i++)
+    testobject.setPHOSScale(i, 0);
+}
+
+BOOST_AUTO_TEST_CASE(TriggerSTUDCS_test)
+{
+
+  /// \brief testing all the getters and setters
+  TriggerSTUDCS testobject;
+  ConfigureReference(testobject);
+
+  std::array<int, 3> Ghigh = {0, 0, 115};
+  std::array<int, 3> Glow = {0, 0, 51};
+  std::array<int, 3> Jhigh = {0, 0, 255};
+  std::array<int, 3> Jlow = {0, 0, 204};
+  int PatchSize = 2;
+  int Fw = 0x2A012;
+  int MedianMode = 0;
+  int Region = 0xffffffff;
+  int RawData = 1;
+
+  BOOST_CHECK_EQUAL(testobject.getRegion(), Region);
+  BOOST_CHECK_EQUAL(testobject.getFw(), Fw);
+  BOOST_CHECK_EQUAL(testobject.getPatchSize(), PatchSize);
+  BOOST_CHECK_EQUAL(testobject.getMedianMode(), MedianMode);
+  BOOST_CHECK_EQUAL(testobject.getRawData(), RawData);
+
+  for (int itrig = 0; itrig < 3; itrig++) {
+    BOOST_CHECK_EQUAL(testobject.getGammaHigh(itrig), Ghigh[itrig]);
+    BOOST_CHECK_EQUAL(testobject.getJetHigh(itrig), Jhigh[itrig]);
+    BOOST_CHECK_EQUAL(testobject.getGammaLow(itrig), Glow[itrig]);
+    BOOST_CHECK_EQUAL(testobject.getJetLow(itrig), Jlow[itrig]);
+  }
+
+  /// \brief Test for operator== on itself
+  /// Tests whether operator== returns true in case the object is tested
+  /// against itself.
+  BOOST_CHECK_EQUAL(testobject == testobject, true);
+
+  /// \brief Test for operator== on same object
+  /// Tests whether operator== returns true in case both
+  /// objects have the same content.
+  TriggerSTUDCS test1, test2;
+  ConfigureReference(test1);
+  ConfigureReference(test2);
+  BOOST_CHECK_EQUAL(test1 == test2, true);
+
+  /// \brief Testing the copy constructor
+  TriggerSTUDCS test3(test1);
+  BOOST_CHECK_EQUAL(test3 == test1, true);
+
+  /// \brief Testing the assignment operator
+  TriggerSTUDCS test4 = test1;
+  BOOST_CHECK_EQUAL(test4 == test1, true);
+
+  /// \brief Test for operator== on different objects
+  /// Tests whether the operator== returns false if at least one setting
+  /// is different. For this operator== is tested with multiple objects
+  /// based on a reference setting where only one parameter is changed at
+  /// the time.
+  TriggerSTUDCS ref;
+  ConfigureReference(ref);
+  ref.setRegion(0xffffff7f);
+  BOOST_CHECK_EQUAL(ref == testobject, false);
+  ref.setGammaHigh(2, 77);
+  ref.setGammaLow(2, 51);
+  ref.setJetHigh(2, 191);
+  ref.setJetLow(2, 128);
+  ref.setPatchSize(0);
+  ref.setFw(0x1A012);
+  ref.setMedianMode(1);
+  ref.setPHOSScale(0, 1);
+  ref.setPHOSScale(1, 2);
+  ref.setPHOSScale(2, 1);
+  ref.setPHOSScale(3, 0);
+  BOOST_CHECK_EQUAL(ref == testobject, false);
+
+  /// \brief Test for the stream operator
+  /// Test if operator<< for a reference configuration produces
+  /// the expected reference string. Test is implemented using a streaming
+  /// operator.
+  std::string reference = std::string("Gamma High: (0, 0, 115)\nGamma Low:  (0, 0, 51)\nJet High:   (0, 0, 255)\nJet Low:    (0, 0, 204)\n") + std::string("GetRawData: 1, Region: ffffffff (11111111111111111111111111111111), Median: 0, Firmware: 2a012, PHOS Scale: (0, 0, 0, 0)\n");
+
+  TriggerSTUDCS test;
+  ConfigureReference(test);
+  std::stringstream testmaker;
+  testmaker << test;
+  BOOST_CHECK_EQUAL(testmaker.str() == reference, true);
+}
+
+} // namespace emcal
+
+} // namespace o2

--- a/Detectors/EMCAL/calib/test/testTriggerSTUErrorCounter.cxx
+++ b/Detectors/EMCAL/calib/test/testTriggerSTUErrorCounter.cxx
@@ -1,0 +1,75 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test EMCAL Calib
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include "EMCALCalib/TriggerSTUErrorCounter.h"
+
+#include <algorithm>
+
+namespace o2
+{
+
+namespace emcal
+{
+
+BOOST_AUTO_TEST_CASE(TriggerSTUErrorCounter_test)
+{
+
+  /// \brief testing all the getters and setters
+  TriggerSTUErrorCounter testobject1, testobject2;
+
+  std::pair<int, unsigned long> TimeAndError(123, 10);
+  int Time = 123;
+  unsigned long Error = 10;
+
+  testobject1.setValue(TimeAndError);
+  testobject2.setValue(Time, Error);
+
+  BOOST_CHECK_EQUAL(testobject1.getTime(), TimeAndError.first);
+  BOOST_CHECK_EQUAL(testobject1.getErrorCount(), TimeAndError.second);
+  BOOST_CHECK_EQUAL(testobject2.getTime(), Time);
+  BOOST_CHECK_EQUAL(testobject2.getErrorCount(), Error);
+
+  /// \brief Test for operator== on itself
+  /// Tests whether operator== returns true in case the object is tested
+  /// against itself.
+  BOOST_CHECK_EQUAL(testobject1 == testobject1, true);
+
+  /// \brief Test for operator== on same object
+  /// Tests whether operator== returns true in case both
+  /// objects have the same content.
+  BOOST_CHECK_EQUAL(testobject1 == testobject2, true);
+
+  /// \brief Testing the copy constructor
+  TriggerSTUErrorCounter testobject3(testobject1);
+  BOOST_CHECK_EQUAL(testobject3 == testobject1, true);
+
+  /// \brief Testing the assignment operator
+  TriggerSTUErrorCounter testobject4 = testobject1;
+  BOOST_CHECK_EQUAL(testobject4 == testobject1, true);
+
+  /// \brief Test for operator== on different objects
+  /// Tests whether the operator== returns false if at least one setting
+  /// is different. For this operator== is tested with multiple objects
+  /// based on a reference setting where only one parameter is changed at
+  /// the time.
+  TriggerSTUErrorCounter ref;
+  ref.setValue(std::make_pair(2, 77));
+  BOOST_CHECK_EQUAL(ref == testobject1, false);
+  ref.setValue(2, 51);
+  BOOST_CHECK_EQUAL(ref == testobject1, false);
+}
+
+} // namespace emcal
+
+} // namespace o2

--- a/Detectors/EMCAL/calib/test/testTriggerTRUDCS.cxx
+++ b/Detectors/EMCAL/calib/test/testTriggerTRUDCS.cxx
@@ -1,0 +1,129 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test EMCAL Calib
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include "EMCALCalib/TriggerTRUDCS.h"
+
+#include <algorithm>
+
+namespace o2
+{
+
+namespace emcal
+{
+
+/// \brief Apply reference configuration
+/// Reference configuration taken from pp 2016
+/// \param testobject Object for test to be configured
+///
+void ConfigureReference(TriggerTRUDCS& testobject)
+{
+  testobject.setSELPF(7711);
+  testobject.setL0SEL(1);
+  testobject.setL0COSM(100);
+  testobject.setGTHRL0(132);
+  testobject.setMaskReg(1024, 0);
+  testobject.setMaskReg(0, 1);
+  testobject.setMaskReg(512, 2);
+  testobject.setMaskReg(31985, 3);
+  testobject.setMaskReg(0, 4);
+  testobject.setMaskReg(0, 5);
+  testobject.setRLBKSTU(0);
+  testobject.setFw(0x21);
+}
+
+BOOST_AUTO_TEST_CASE(TriggerTRUDCS_test)
+{
+
+  /// \brief testing all the getters and setters
+  TriggerTRUDCS testobject;
+  ConfigureReference(testobject);
+
+  uint64_t SELPF = 7711;
+  uint64_t L0SEL = 1;
+  uint64_t L0COSM = 100;
+  uint64_t GTHRL0 = 132;
+  std::array<uint32_t, 6> MaskReg = {1024, 0, 512, 31985, 0, 0};
+  uint64_t RLBKSTU = 0;
+  uint64_t Fw = 0x21;
+
+  BOOST_CHECK_EQUAL(testobject.getSELPF(), SELPF);
+  BOOST_CHECK_EQUAL(testobject.getL0SEL(), L0SEL);
+  BOOST_CHECK_EQUAL(testobject.getL0COSM(), L0COSM);
+  BOOST_CHECK_EQUAL(testobject.getGTHRL0(), GTHRL0);
+  BOOST_CHECK_EQUAL(testobject.getRLBKSTU(), RLBKSTU);
+
+  for (int ireg = 0; ireg < 6; ireg++)
+    BOOST_CHECK_EQUAL(testobject.getMaskReg(ireg), MaskReg[ireg]);
+
+  BOOST_CHECK_EQUAL(testobject.getFw(), Fw);
+
+  /// \brief Test for operator== on itself
+  /// Tests whether operator== returns true in case the object is tested
+  /// against itself.
+  BOOST_CHECK_EQUAL(testobject == testobject, true);
+
+  /// \brief Test for operator== on same object
+  /// Tests whether operator== returns true in case both
+  /// objects have the same content.
+  TriggerTRUDCS test1, test2;
+  ConfigureReference(test1);
+  ConfigureReference(test2);
+  BOOST_CHECK_EQUAL(test1 == test2, true);
+
+  /// \brief Testing the copy constructor
+  TriggerTRUDCS test3(test1);
+  BOOST_CHECK_EQUAL(test3 == test1, true);
+
+  /// \brief Testing the assignment operator
+  TriggerTRUDCS test4 = test1;
+  BOOST_CHECK_EQUAL(test4 == test1, true);
+
+  /// \brief Test for operator== on different objects
+  /// Tests whether the operator== returns false if at least one setting
+  /// is different. For this operator== is tested with multiple objects
+  /// based on a reference setting where only one parameter is changed at
+  /// the time.
+  TriggerTRUDCS ref;
+  ConfigureReference(ref);
+  ref.setSELPF(7000);
+  BOOST_CHECK_EQUAL(ref == testobject, false);
+  ref.setL0SEL(2);
+  ref.setL0COSM(1000);
+  ref.setGTHRL0(184);
+  ref.setRLBKSTU(1);
+  ref.setFw(0x11);
+  ref.setMaskReg(768, 0);
+  ref.setMaskReg(15, 1);
+  ref.setMaskReg(37632, 2);
+  ref.setMaskReg(63, 3);
+  ref.setMaskReg(0, 4);
+  ref.setMaskReg(208, 5);
+  BOOST_CHECK_EQUAL(ref == testobject, false);
+
+  /// \brief Test for the stream operator
+  /// Test if operator<< for a reference configuration produces
+  /// the expected reference string. Test is implemented using a streaming
+  /// operator.
+  std::string reference = std::string("SELPF: 1e1f, L0SEL: 1, L0COSM: 100, GTHRL0: 132, RLBKSTU: 0, FW: 21\n") + std::string("Reg0: 00000000000000000000010000000000 (1024)\nReg1: 00000000000000000000000000000000 (0)\n") + std::string("Reg2: 00000000000000000000001000000000 (512)\nReg3: 00000000000000000111110011110001 (31985)\n") + std::string("Reg4: 00000000000000000000000000000000 (0)\nReg5: 00000000000000000000000000000000 (0)\n");
+
+  TriggerTRUDCS test;
+  ConfigureReference(test);
+  std::stringstream testmaker;
+  testmaker << test;
+  BOOST_CHECK_EQUAL(testmaker.str() == reference, true);
+}
+
+} // namespace emcal
+
+} // namespace o2


### PR DESCRIPTION
 Development of a container class for the trigger information received from the DCS (TRU and STU) along with the unit tests, and the read write tests. Several containers were added: 

1. TriggerSTUDCS: container class for the STU information with unit tests.
2. TriggerTRUDCS: container class for the TRU information with unit tests.
3. TriggerSTUErrorCount: container class for the STU errors with unit tests.
4. TriggerDCS: container class for the DCS information with the unit tests and the read write tests.