### PR TITLE
Create DPL AlgorithmSpec Task only in the InitCallback

### DIFF
--- a/Framework/Core/include/Framework/Task.h
+++ b/Framework/Core/include/Framework/Task.h
@@ -66,8 +66,8 @@ class Task
 template <typename T, typename... Args>
 AlgorithmSpec adaptFromTask(Args&&... args)
 {
-  auto task = std::make_shared<T>(std::forward<Args>(args)...);
-  return AlgorithmSpec::InitCallback{[task](InitContext& ic) {
+  return AlgorithmSpec::InitCallback{[=](InitContext& ic) {
+    auto task = std::make_shared<T>(args...);
     if constexpr (has_endOfStream<T>::value) {
       auto& callbacks = ic.services().get<CallbackService>();
       callbacks.set(CallbackService::Id::EndOfStream, [task](EndOfStreamContext& eosContext) {

--- a/Utilities/Mergers/include/Mergers/Merger.h
+++ b/Utilities/Mergers/include/Mergers/Merger.h
@@ -38,7 +38,7 @@ class Merger : public framework::Task
 {
  public:
   /// \brief Default constructor. It expects merger configuration and subSpec of output channel.
-  Merger(MergerConfig, header::DataHeader::SubSpecificationType);
+  Merger(const MergerConfig&, const header::DataHeader::SubSpecificationType&);
   /// \brief Default destructor.
   ~Merger() override = default;
 

--- a/Utilities/Mergers/src/Merger.cxx
+++ b/Utilities/Mergers/src/Merger.cxx
@@ -36,7 +36,7 @@ namespace o2
 namespace experimental::mergers
 {
 
-Merger::Merger(MergerConfig config, header::DataHeader::SubSpecificationType subSpec)
+Merger::Merger(const MergerConfig& config, const header::DataHeader::SubSpecificationType& subSpec)
   : mConfig(config),
     mSubSpec(subSpec),
     mCache(config.ownershipMode.value == OwnershipMode::Full)


### PR DESCRIPTION
This is an attempt to fix https://alice.its.cern.ch/jira/browse/O2-735 (thx for @sawenzel for finding out that the task is created in each process of the workflow, not only the one that runs a particular task.)

This fix tries to cure that by running the constructor of the task object only during the InitCallback.
@sawenzel : FYI: I couldn't make our previous approach work with perfect forwarding, but I found a much simpler and cleaner solution.

So far checked only that it compiles for me, we should do a performance test, and let's see what the CI says.