### PR TITLE
TRD: Fix digitizer bug and small improvement in speed.

### DIFF
--- a/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
@@ -44,11 +44,11 @@ class Digitizer
   void setCalibrations(Calibrations* calibrations) { mCalib = calibrations; }
 
  private:
-  TRDGeometry* mGeo = nullptr;            // access to TRDGeometry
-  PadResponse* mPRF = nullptr;            // access to PadResponse
-  TRDSimParam* mSimParam = nullptr;       // access to TRDSimParam instance
-  TRDCommonParam* mCommonParam = nullptr; // access to TRDCommonParam instance
-  Calibrations* mCalib = nullptr;         // access to Calibrations in CCDB
+  TRDGeometry* mGeo = nullptr;              // access to TRDGeometry
+  PadResponse* mPRF = nullptr;              // access to PadResponse
+  TRDSimParam* mSimParam = nullptr;         // access to TRDSimParam instance
+  TRDCommonParam* mCommonParam = nullptr;   // access to TRDCommonParam instance
+  Calibrations* mCalib = nullptr;           // access to Calibrations in CCDB
   math_utils::RandomRing<> mGausRandomRing; // pre-generated normal distributed random numbers
   math_utils::RandomRing<> mFlatRandomRing; // pre-generated flat distributed random numbers
   math_utils::RandomRing<> mLogRandomRing;  // pre-generated exp distributed random number
@@ -63,9 +63,9 @@ class Digitizer
   void getHitContainerPerDetector(const std::vector<HitType>&, std::array<std::vector<HitType>, kNdet>&);
   // Digitization chaing methods
   bool convertHits(const int, const std::vector<HitType>&, SignalContainer_t&, o2::dataformats::MCTruthContainer<MCLabel>&); // True if hit-to-signal conversion is successful
-  bool convertSignalsToDigits(const int, SignalContainer_t&);                                                                // True if signal-to-digit conversion is successful
-  bool convertSignalsToSDigits(const int, SignalContainer_t&);                                                               // True if signal-to-sdigit conversion is successful
-  bool convertSignalsToADC(const int, SignalContainer_t&);                                                                   // True if signal-to-ADC conversion is successful
+  bool convertSignalsToDigits(SignalContainer_t&);                                                                           // True if signal-to-digit conversion is successful
+  bool convertSignalsToSDigits(SignalContainer_t&);                                                                          // True if signal-to-sdigit conversion is successful
+  bool convertSignalsToADC(SignalContainer_t&);                                                                              // True if signal-to-ADC conversion is successful
 
   bool diffusion(float, float, float, float, float, float, double&, double&, double&); // True if diffusion is applied successfully
 };

--- a/Detectors/TRD/simulation/src/Detector.cxx
+++ b/Detectors/TRD/simulation/src/Detector.cxx
@@ -164,8 +164,8 @@ bool Detector::ProcessHits(FairVolume* v)
 
   // Calculate the charge according to GEANT Edep
   // Create a new dEdx hit
-  const float enDep = TMath::Max(fMC->Edep(), 0.0) * 1e9; // Energy in eV
-  const int totalChargeDep = (int)(enDep / mWion);        // Total charge
+  const float enDep = std::max(fMC->Edep(), 0.0) * 1e9; // Energy in eV
+  const int totalChargeDep = (int)(enDep / mWion);      // Total charge
 
   // Store those hits with enDep bigger than the ionization potential of the gas mixture for in-flight tracks
   // or store hits of tracks that are entering or exiting
@@ -176,7 +176,10 @@ bool Detector::ProcessHits(FairVolume* v)
     double pos[3] = {xp, yp, zp};
     double loc[3] = {-99, -99, -99};
     gGeoManager->MasterToLocal(pos, loc); // Go to the local coordinate system (locR, locC, locT)
-    const float locC = loc[0], locR = loc[1], locT = loc[2];
+    float locC = loc[0], locR = loc[1], locT = loc[2];
+    if (drRegion) {
+      locT = locT - 0.5 * (TRDGeometry::drThick() + TRDGeometry::amThick());
+    }
     addHit(xp, yp, zp, locC, locR, locT, tof, totalChargeDep, trackID, det, drRegion);
     stack->addHit(GetDetId());
     return true;
@@ -264,7 +267,8 @@ void Detector::createTRhit(int det)
     double pos[3] = {x, y, z};
     double loc[3] = {-99, -99, -99};
     gGeoManager->MasterToLocal(pos, loc); // Go to the local coordinate system (locR, locC, locT)
-    const float locC = loc[0], locR = loc[1], locT = loc[2];
+    float locC = loc[0], locR = loc[1], locT = loc[2];
+    locT = locT - 0.5 * (TRDGeometry::drThick() + TRDGeometry::amThick());
     addHit(x, y, z, locC, locR, locT, tof, totalChargeDep, trackID, det, true); // All TR hits are in drift region
     stack->addHit(GetDetId());
   }


### PR DESCRIPTION
- Fix a bug found by @sawenzel.
- Moves calculation from digitization to hits processing.

As expected, the ADC spectrum changes because this stops the repetitive reprocessing of converted ADCs, but we still need to have the correct `T0` from the CCDB to solve the ADC spectrum problem.