### PR TITLE
ValueMonitor: Facility to record values in a hist

### DIFF
--- a/Common/Utils/CMakeLists.txt
+++ b/Common/Utils/CMakeLists.txt
@@ -11,8 +11,8 @@
 o2_add_library(CommonUtils
                SOURCES src/TreeStream.cxx src/TreeStreamRedirector.cxx
                        src/RootChain.cxx src/CompStream.cxx src/ShmManager.cxx
-	               src/HBFUtils.cxx
-               PUBLIC_LINK_LIBRARIES ROOT::Tree Boost::iostreams O2::CommonDataFormat O2::Headers
+	               src/HBFUtils.cxx  src/ValueMonitor.cxx
+               PUBLIC_LINK_LIBRARIES ROOT::Hist ROOT::Tree Boost::iostreams O2::CommonDataFormat O2::Headers
                                      FairLogger::FairLogger)
 
 o2_target_root_dictionary(CommonUtils
@@ -23,7 +23,8 @@ o2_target_root_dictionary(CommonUtils
                                   include/CommonUtils/ShmManager.h
                                   include/CommonUtils/RngHelper.h
                                   include/CommonUtils/StringUtils.h
-				  include/CommonUtils/HBFUtils.h)
+				  include/CommonUtils/HBFUtils.h
+                                  include/CommonUtils/ValueMonitor.h)
 
 o2_add_test(TreeStream
             COMPONENT_NAME CommonUtils
@@ -48,3 +49,8 @@ o2_add_test(HBFUtils
             SOURCES test/testHBFUtils.cxx
             LABELS steer)
 
+o2_add_test(ValueMonitor
+            COMPONENT_NAME CommonUtils
+            LABELS utils
+            SOURCES test/testValueMonitor.cxx
+            PUBLIC_LINK_LIBRARIES O2::CommonUtils)

--- a/Common/Utils/include/CommonUtils/ValueMonitor.h
+++ b/Common/Utils/include/CommonUtils/ValueMonitor.h
@@ -1,0 +1,107 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_MATHUTILS_VALUEMONITOR_H_
+#define ALICEO2_MATHUTILS_VALUEMONITOR_H_
+
+#include "TH1.h"
+#include <unordered_map>
+#include <string>
+
+namespace o2
+{
+namespace utils
+{
+
+/*
+ ValueMonitor: Facility to record values in a hist
+    
+ Mainly meant as a service class that makes it easy
+ to dump variable values (within an algorithm) to a histogram
+ for later visual inspection.
+ The class is similar in spirit with the TreeStreamer facility
+ but complementary since directly using histograms in memory.
+    
+ Different histograms are saved to the same file.
+    
+ ```C++
+  ValueMonitor mon(filename);
+    
+  float x;
+  mon.Collect<float>("x", x); --> collects x in histogram named "x"
+   
+  double y;
+  mon.Collect<double>("y", y); --> collects y in histogram named "y"
+ ```
+*/
+class ValueMonitor
+{
+ public:
+  ValueMonitor(std::string filename);
+  ~ValueMonitor();
+
+  /// main interface to add a value to a histogram called "key"
+  template <typename T>
+  void Collect(const char* key, T value);
+
+ private:
+  std::string mFileName; // name of file where histograms are dumped to
+
+  std::unordered_map<const char*, TH1*> mHistos; // container of histograms (identified by name)
+};
+
+namespace
+{
+template <typename T>
+inline TH1* makeHist(const char* key)
+{
+  return nullptr;
+}
+
+template <>
+inline TH1* makeHist<int>(const char* key)
+{
+  return new TH1I(key, key, 200, 0, 1);
+}
+
+template <>
+inline TH1* makeHist<double>(const char* key)
+{
+  return new TH1D(key, key, 200, 0, 1);
+}
+
+template <>
+inline TH1* makeHist<float>(const char* key)
+{
+  return new TH1F(key, key, 200, 0, 1);
+}
+} // namespace
+
+template <typename T>
+inline void ValueMonitor::Collect(const char* key, T value)
+{
+  // see if we have this histogram already
+  TH1* h = nullptr;
+  auto iter = mHistos.find(key);
+  if (iter == mHistos.end()) {
+    auto newHist = makeHist<T>(key);
+    newHist->SetCanExtend(TH1::kAllAxes);
+    mHistos[key] = newHist;
+    h = newHist;
+  } else {
+    h = (*iter).second;
+  }
+  h->Fill(value);
+}
+
+} // namespace utils
+} // namespace o2
+
+#endif

--- a/Common/Utils/src/ValueMonitor.cxx
+++ b/Common/Utils/src/ValueMonitor.cxx
@@ -1,0 +1,31 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "CommonUtils/ValueMonitor.h"
+#include "TFile.h"
+#include <fairlogger/Logger.h>
+#include <memory>
+
+using namespace o2::utils;
+
+ValueMonitor::ValueMonitor(std::string filename) : mFileName(filename) {}
+
+ValueMonitor::~ValueMonitor()
+{
+  if (mHistos.size() > 0) {
+    auto outfile = std::make_unique<TFile>(mFileName.c_str(), "RECREATE");
+    // write all histos
+    for (auto& h : mHistos) {
+      LOG(INFO) << "ValueMonitor: WRITING HISTO " << h.second->GetName();
+      h.second->Write();
+    }
+    outfile->Close();
+  }
+}

--- a/Common/Utils/test/testValueMonitor.cxx
+++ b/Common/Utils/test/testValueMonitor.cxx
@@ -1,0 +1,28 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test ValueMonitor
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include "CommonUtils/ValueMonitor.h"
+#include <TRandom.h>
+
+using namespace o2;
+
+BOOST_AUTO_TEST_CASE(ValueMonitor_test)
+{
+  utils::ValueMonitor m("foo.root");
+  for (int i = 0; i < 100000; ++i) {
+    double x = gRandom->Gaus(0, 10) * 10;
+    m.Collect<float>("x", (float)x);
+    m.Collect<int>("xi", (int)x * 20);
+  }
+}


### PR DESCRIPTION
Mainly meant as a service class that makes it easy
to dump variable values (within an algorithm) to a histogram
for later visual inspection.
The class is similar in spirit with the TreeStreamer facility
but complementary since directly using histograms in memory.

Different histograms are saved to the same file.

```C++
ValueMonitor mon(filename);

float x;
mon.Collect<float>("x", x); --> collects x in histogram named "x"

double y;
mon.Collect<double>("y", y); --> collects y in histogram named "y"
```