### PR TITLE
Adding some helper methods to RawParser iterator

### DIFF
--- a/Framework/Utils/src/raw-parser.cxx
+++ b/Framework/Utils/src/raw-parser.cxx
@@ -51,18 +51,15 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
 			  << dh->subSpecification << " payload size " << dh->payloadSize;
 	      }
 
-	      // there is a bug in InpuRecord::get for vectors of simple types, not catched in
-	      // DataAllocator unit test
-	      //auto data = inputs.get<std::vector<char>>(input.spec->binding.c_str());
-	      //LOG(INFO) << "data size " << data.size();
+	      auto raw = inputs.get<std::span<char>>(input.spec->binding.c_str());
 
 	      try {
-		o2::framework::RawParser parser(input.payload, dh->payloadSize);
+		o2::framework::RawParser parser(raw.data(), raw.size());
 
 		std::stringstream rdhprintout;
 		rdhprintout << parser;
 		for (auto it = parser.begin(), end = parser.end(); it != end; ++it) {
-		  rdhprintout << it << ": block length " << it.length() << std::endl;
+		  rdhprintout << it << ": payload size " << it.size() << std::endl;
 		}
 		if (loglevel > 1) {
 		  LOG(INFO) << rdhprintout.str();

--- a/Framework/Utils/test/test_RawParser.cxx
+++ b/Framework/Utils/test/test_RawParser.cxx
@@ -38,10 +38,10 @@ BOOST_AUTO_TEST_CASE(test_RawParser)
   }
 
   size_t count = 0;
-  auto processor = [&count](auto data, size_t length) {
-    BOOST_CHECK(length == PageSize - sizeof(V5));
+  auto processor = [&count](auto data, size_t size) {
+    BOOST_CHECK(size == PageSize - sizeof(V5));
     BOOST_CHECK(*reinterpret_cast<size_t const*>(data) == count);
-    std::cout << "Processing block of length " << length << std::endl;
+    std::cout << "Processing block of size " << size << std::endl;
     count++;
   };
   RawParser parser(buffer.data(), buffer.size());
@@ -53,11 +53,12 @@ BOOST_AUTO_TEST_CASE(test_RawParser)
   std::cout << parser << std::endl;
   count = 0;
   for (auto it = parser.begin(), end = parser.end(); it != end; ++it, ++count) {
-    BOOST_CHECK(it.length() == PageSize - sizeof(V5));
+    BOOST_CHECK(it.size() == PageSize - sizeof(V5));
     BOOST_CHECK(*reinterpret_cast<size_t const*>(it.data()) == count);
     BOOST_CHECK(it.get_if<V5>() != nullptr);
     BOOST_CHECK(it.get_if<V4>() == nullptr);
-    std::cout << it << ": block length " << it.length() << std::endl;
+    BOOST_CHECK(it.raw() + it.offset() == it.data());
+    std::cout << it << ": block size " << it.size() << std::endl;
   }
 }
 


### PR DESCRIPTION
Adding methods to access the raw buffer at position and payload offset.
Renaming length() -> size()

The raw buffer points to the beginning of the RDH which can be different
versions and thus we can not return a concrete type. See get_if for this.