### PR TITLE
TRD: Add basic trigger (frame) information

### DIFF
--- a/DataFormats/Detectors/TRD/CMakeLists.txt
+++ b/DataFormats/Detectors/TRD/CMakeLists.txt
@@ -8,14 +8,12 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
-# @brief  cmake setup for the DataFormats module of AliceO2
+o2_add_library(DataFormatsTRD
+               SOURCES src/TriggerRecord.cxx
+               PUBLIC_LINK_LIBRARIES O2::CommonDataFormat 
+                                     O2::SimulationDataFormat
+                                     )
 
-add_subdirectory(Common)
-add_subdirectory(TPC)
-add_subdirectory(ITSMFT)
-add_subdirectory(MUON)
-add_subdirectory(TOF)
-add_subdirectory(FIT)
-add_subdirectory(EMCAL)
-add_subdirectory(ZDC)
-add_subdirectory(TRD)
+o2_target_root_dictionary(DataFormatsTRD
+                          HEADERS include/DataFormatsTRD/TriggerRecord.h)
+

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/TriggerRecord.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/TriggerRecord.h
@@ -1,0 +1,63 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_TRD_TRIGGERRECORD_H
+#define ALICEO2_TRD_TRIGGERRECORD_H
+
+#include <iosfwd>
+#include "Rtypes.h"
+#include "CommonDataFormat/InteractionRecord.h"
+#include "CommonDataFormat/RangeReference.h"
+
+namespace o2
+{
+
+namespace trd
+{
+
+/// \class TriggerRecord
+/// \brief Header for data corresponding to the same hardware trigger
+/// adapted from DataFormatsITSMFT/ROFRecord
+class TriggerRecord
+{
+  using BCData = o2::InteractionRecord;
+  using DataRange = o2::dataformats::RangeReference<int>;
+
+ public:
+  TriggerRecord() = default;
+  TriggerRecord(const BCData& bunchcrossing, int firstentry, int nentries) : mBCData(bunchcrossing), mDataRange(firstentry, nentries) {}
+  ~TriggerRecord() = default;
+
+  void setBCData(const BCData& data) { mBCData = data; }
+  void setDataRange(int firstentry, int nentries) { mDataRange.set(firstentry, nentries); }
+  void setIndexFirstObject(int firstentry) { mDataRange.setFirstEntry(firstentry); }
+  void setNumberOfObjects(int nentries) { mDataRange.setEntries(nentries); }
+
+  const BCData& getBCData() const { return mBCData; }
+  BCData& getBCData() { return mBCData; }
+  int getNumberOfObjects() const { return mDataRange.getEntries(); }
+  int getFirstEntry() const { return mDataRange.getFirstEntry(); }
+
+  void printStream(std::ostream& stream) const;
+
+ private:
+  BCData mBCData;       /// Bunch crossing data of the trigger
+  DataRange mDataRange; /// Index of the triggering event (event index and first entry in the container)
+
+  ClassDefNV(TriggerRecord, 1);
+};
+
+std::ostream& operator<<(std::ostream& stream, const TriggerRecord& trg);
+
+} // namespace trd
+
+} // namespace o2
+
+#endif

--- a/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
+++ b/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
@@ -1,0 +1,20 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifdef __CLING__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class o2::trd::TriggerRecord + ;
+#pragma link C++ class std::vector < o2::trd::TriggerRecord > +;
+
+#endif

--- a/DataFormats/Detectors/TRD/src/TriggerRecord.cxx
+++ b/DataFormats/Detectors/TRD/src/TriggerRecord.cxx
@@ -1,0 +1,32 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <iostream>
+#include "DataFormatsTRD/TriggerRecord.h"
+
+namespace o2
+{
+
+namespace trd
+{
+
+void TriggerRecord::printStream(std::ostream& stream) const
+{
+  stream << "Data for bc " << getBCData().bc << ", orbit " << getBCData().orbit << ", starting from entry " << getFirstEntry() << " with " << getNumberOfObjects() << " objects";
+}
+
+std::ostream& operator<<(std::ostream& stream, const TriggerRecord& trg)
+{
+  trg.printStream(stream);
+  return stream;
+}
+
+} // namespace trd
+} // namespace o2

--- a/Steer/DigitizerWorkflow/CMakeLists.txt
+++ b/Steer/DigitizerWorkflow/CMakeLists.txt
@@ -50,4 +50,5 @@ o2_add_executable(digitizer-workflow
                                         O2::TPCSimulation
                                         O2::TPCWorkflow
                                         O2::TRDSimulation
+                                        O2::DataFormatsTRD
                                         O2::ZDCSimulation)

--- a/Steer/DigitizerWorkflow/src/TRDDigitWriterSpec.h
+++ b/Steer/DigitizerWorkflow/src/TRDDigitWriterSpec.h
@@ -15,6 +15,7 @@
 #include "DPLUtils/MakeRootTreeWriterSpec.h"
 #include "Framework/InputSpec.h"
 #include "TRDBase/Digit.h"
+#include "DataFormatsTRD/TriggerRecord.h"
 #include <SimulationDataFormat/MCTruthContainer.h>
 #include "TRDBase/MCLabel.h"
 
@@ -35,6 +36,7 @@ o2::framework::DataProcessorSpec getTRDDigitWriterSpec()
                                 "o2sim",
                                 1,
                                 BranchDefinition<std::vector<o2::trd::Digit>>{InputSpec{"input", "TRD", "DIGITS"}, "TRDDigit"},
+                                BranchDefinition<std::vector<o2::trd::TriggerRecord>>{InputSpec{"trinput", "TRD", "TRGRDIG"}, "TriggerRecord"},
                                 BranchDefinition<o2::dataformats::MCTruthContainer<o2::trd::MCLabel>>{InputSpec{"labelinput", "TRD", "LABELS"}, "TRDMCLabels"})();
 }
 

--- a/Steer/DigitizerWorkflow/src/TRDDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TRDDigitizerSpec.cxx
@@ -27,6 +27,7 @@
 #include "TRDSimulation/Detector.h" // for the Hit type
 #include "DetectorsBase/GeometryManager.h"
 #include "TRDBase/Calibrations.h"
+#include "DataFormatsTRD/TriggerRecord.h"
 
 using namespace o2::framework;
 using SubSpecificationType = o2::framework::DataAllocator::SubSpecificationType;
@@ -100,6 +101,7 @@ class TRDDPLDigitizerTask
     auto& eventParts = context->getEventParts();
     std::vector<o2::trd::Digit> digitsAccum; // accumulator for digits
     o2::dataformats::MCTruthContainer<o2::trd::MCLabel> labelsAccum;
+    std::vector<TriggerRecord> triggers;
 
     TStopwatch timer;
     timer.Start();
@@ -123,6 +125,9 @@ class TRDDPLDigitizerTask
         std::vector<o2::trd::Digit> digits;                         // digits which get filled
         o2::dataformats::MCTruthContainer<o2::trd::MCLabel> labels; // labels which get filled
         mDigitizer.process(hits, digits, labels);
+        // Add trigger record
+        triggers.emplace_back(irecords[collID], digitsAccum.size(), digits.size());
+
         std::copy(digits.begin(), digits.end(), std::back_inserter(digitsAccum));
         labelsAccum.mergeAtBack(labels);
       }
@@ -137,6 +142,8 @@ class TRDDPLDigitizerTask
     pc.outputs().snapshot(Output{"TRD", "LABELS", 0, Lifetime::Timeframe}, labelsAccum);
     LOG(INFO) << "TRD: Sending ROMode= " << mROMode << " to GRPUpdater";
     pc.outputs().snapshot(Output{"TRD", "ROMode", 0, Lifetime::Timeframe}, mROMode);
+    LOG(INFO) << "TRD: Sending trigger records";
+    pc.outputs().snapshot(Output{"TRD", "TRGRDIG", 0, Lifetime::Timeframe}, triggers);
 
     // we should be only called once; tell DPL that this process is ready to exit
     pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
@@ -162,6 +169,7 @@ o2::framework::DataProcessorSpec getTRDDigitizerSpec(int channel)
     Inputs{InputSpec{"collisioncontext", "SIM", "COLLISIONCONTEXT", static_cast<SubSpecificationType>(channel), Lifetime::Timeframe}},
 
     Outputs{OutputSpec{"TRD", "DIGITS", 0, Lifetime::Timeframe},
+            OutputSpec{"TRD", "TRGRDIG", 0, Lifetime::Timeframe},
             OutputSpec{"TRD", "LABELS", 0, Lifetime::Timeframe},
             OutputSpec{"TRD", "ROMode", 0, Lifetime::Timeframe}},
 


### PR DESCRIPTION
Adding a trigger (readout record) to the digitization process.
@tdietel @bazinski : This is a basic version of what we talked about last week.
You can take it as a basis for your own customized trigger information.