### PR TITLE
Bugfix RootTreeWriter

### DIFF
--- a/Framework/Core/test/FrameworkCoreTestLinkDef.h
+++ b/Framework/Core/test/FrameworkCoreTestLinkDef.h
@@ -15,4 +15,5 @@
 #pragma link C++ class o2::test::TriviallyCopyable + ;
 #pragma link C++ class o2::test::Base + ;
 #pragma link C++ class o2::test::Polymorphic + ;
+#pragma link C++ class std::vector < o2::test::TriviallyCopyable> + ;
 #pragma link C++ class std::vector < o2::test::Polymorphic> + ;

--- a/Framework/Utils/test/test_RootTreeWriter.cxx
+++ b/Framework/Utils/test/test_RootTreeWriter.cxx
@@ -26,6 +26,7 @@
 #include "../../Core/test/TestClasses.h"
 #include <vector>
 #include <memory>
+#include <iostream>
 #include <type_traits> // std::is_fundamental
 #include <TClass.h>
 #include <TFile.h>
@@ -35,6 +36,15 @@
 
 using namespace o2::framework;
 using DataHeader = o2::header::DataHeader;
+
+namespace o2::test
+{
+
+/// test struct without ROOT dictionary, used to provoke raising of runtime_error
+struct TrivialStruct {
+  int x;
+  int y;
+};
 
 template <typename T>
 struct BranchContent {
@@ -104,10 +114,11 @@ BOOST_AUTO_TEST_CASE(test_RootTreeWriter)
                           // the branch names are simply built by adding the index
                           [](std::string base, size_t i) { return base + "_" + std::to_string(i); }},
                         RootTreeWriter::BranchDef<const char*>{"input4", "binarybranch"},
-                        RootTreeWriter::BranchDef<std::vector<int>>{"input5", "intvecbranch"},
-                        RootTreeWriter::BranchDef<std::vector<o2::test::TriviallyCopyable>>{"input6", "trivvecbranch"});
+                        RootTreeWriter::BranchDef<o2::test::TriviallyCopyable>{"input6", "msgablebranch"},
+                        RootTreeWriter::BranchDef<std::vector<int>>{"input6", "intvecbranch"},
+                        RootTreeWriter::BranchDef<std::vector<o2::test::TriviallyCopyable>>{"input7", "trivvecbranch"});
 
-  BOOST_CHECK(writer.getStoreSize() == 5);
+  BOOST_CHECK(writer.getStoreSize() == 6);
 
   // need to mimic a context to actually call the processing
   auto transport = FairMQTransportFactory::CreateTransportFactory("zeromq");
@@ -156,12 +167,14 @@ BOOST_AUTO_TEST_CASE(test_RootTreeWriter)
   int a = 23;
   Container b{{0}};
   Container c{{21}};
+  o2::test::TriviallyCopyable msgable{10, 21, 42};
   std::vector<int> intvec{10, 21, 42};
   std::vector<o2::test::TriviallyCopyable> trivvec{{10, 21, 42}, {1, 2, 3}};
   createPlainMessage(o2::header::DataHeader{"INT", "TST", 0}, a);
   createSerializedMessage(o2::header::DataHeader{"CONTAINER", "TST", 0}, b);
   createSerializedMessage(o2::header::DataHeader{"CONTAINER", "TST", 1}, c);
   createPlainMessage(o2::header::DataHeader{"BINARY", "TST", 0}, a);
+  createPlainMessage(o2::header::DataHeader{"MSGABLE", "TST", 0}, msgable);
   createVectorMessage(o2::header::DataHeader{"FDMTLVEC", "TST", 0}, intvec);
   createVectorMessage(o2::header::DataHeader{"TRIV_VEC", "TST", 0}, trivvec);
 
@@ -176,8 +189,9 @@ BOOST_AUTO_TEST_CASE(test_RootTreeWriter)
     {InputSpec{"input2", "TST", "CONTAINER"}, 1, "input2", 0}, //
     {InputSpec{"input3", "TST", "CONTAINER"}, 2, "input3", 1}, //
     {InputSpec{"input4", "TST", "BINARY"}, 3, "input4", 0},    //
-    {InputSpec{"input5", "TST", "FDMTLVEC"}, 4, "input5", 0},  //
-    {InputSpec{"input6", "TST", "TRIV_VEC"}, 5, "input6", 0},  //
+    {InputSpec{"input5", "TST", "MSGABLE"}, 5, "input5", 0},   //
+    {InputSpec{"input6", "TST", "FDMTLVEC"}, 6, "input6", 0},  //
+    {InputSpec{"input7", "TST", "TRIV_VEC"}, 7, "input7", 0},  //
   };
 
   auto getter = [&store](size_t i) -> char const* { return static_cast<char const*>(store[i]->GetData()); };
@@ -193,6 +207,7 @@ BOOST_AUTO_TEST_CASE(test_RootTreeWriter)
             BranchContent<decltype(a)>{"intbranch", a},
             BranchContent<decltype(b)>{"containerbranch_0", b},
             BranchContent<decltype(c)>{"containerbranch_1", c},
+            BranchContent<decltype(msgable)>{"msgablebranch", msgable},
             BranchContent<decltype(intvec)>{"intvecbranch", intvec},
             BranchContent<decltype(trivvec)>{"trivvecbranch", trivvec});
 }
@@ -210,12 +225,21 @@ BOOST_AUTO_TEST_CASE(test_MakeRootTreeWriterSpec)
                          )();
 }
 
+BOOST_AUTO_TEST_CASE(test_ThrowOnMissingDictionary)
+{
+  // trying to set up a branch for a collection class without dictionary which must throw
+  const char* filename = "test_RootTreeWriterTrow.root";
+  const char* treename = "testtree";
+  RootTreeWriter writer(nullptr, nullptr, RootTreeWriter::BranchDef<std::vector<TrivialStruct>>{"input1", "vecbranch"});
+  BOOST_REQUIRE_THROW(writer.init(filename, treename), std::runtime_error);
+  // we print this note to explain the error message in the log
+  std::cout << "Note: This error has been provoked by the configuration, the exception has been handled" << std::endl;
+}
+
 template <typename T>
 using Trait = RootTreeWriter::StructureElementTypeTrait<T>;
 template <typename T>
 using BinaryBranchStoreType = RootTreeWriter::BinaryBranchStoreType<T>;
-template <typename T>
-using VectorBranchStoreType = RootTreeWriter::VectorBranchStoreType<T>;
 BOOST_AUTO_TEST_CASE(test_RootTreeWriterSpec_store_types)
 {
   using TriviallyCopyable = o2::test::TriviallyCopyable;
@@ -223,29 +247,30 @@ BOOST_AUTO_TEST_CASE(test_RootTreeWriterSpec_store_types)
 
   // simple fundamental type
   // type itself used as store type
-  static_assert(std::is_same<Trait<int>::type, int>::value == true);
+  static_assert(std::is_same<Trait<int>::store_type, int>::value == true);
 
   // messageable type with or without ROOT dictionary
   // type itself used as store type
-  static_assert(std::is_same<Trait<TriviallyCopyable>::type, TriviallyCopyable>::value == true);
+  static_assert(std::is_same<Trait<TriviallyCopyable>::store_type, TriviallyCopyable>::value == true);
 
   // non-messageable type with ROOT dictionary
   // pointer type used as store type
-  static_assert(std::is_same<Trait<Polymorphic>::type, Polymorphic*>::value == true);
+  static_assert(std::is_same<Trait<Polymorphic>::store_type, Polymorphic*>::value == true);
 
   // binary branch indicated through const char*
   // BinaryBranchStoreType is used
-  static_assert(std::is_same<Trait<const char*>::type, BinaryBranchStoreType<char>>::value == true);
+  static_assert(std::is_same<Trait<const char*>::store_type, BinaryBranchStoreType<char>>::value == true);
 
   // vectors of fundamental types
-  // VectorBranchStoreType is used
-  static_assert(std::is_same<Trait<std::vector<int>>::type, VectorBranchStoreType<std::vector<int>>>::value == true);
+  // type itself (the vector) is used
+  static_assert(std::is_same<Trait<std::vector<int>>::store_type, std::vector<int>*>::value == true);
 
   // vector of messageable type with or without ROOT dictionary
-  // VectorBranchStoreType is used
-  static_assert(std::is_same<Trait<std::vector<TriviallyCopyable>>::type, VectorBranchStoreType<std::vector<TriviallyCopyable>>>::value == true);
+  // type itself (the vector) is used
+  static_assert(std::is_same<Trait<std::vector<TriviallyCopyable>>::store_type, std::vector<TriviallyCopyable>*>::value == true);
 
   // vector of non-messageable type with ROOT dictionary
   // pointer type used as store type
-  static_assert(std::is_same<Trait<std::vector<Polymorphic>>::type, std::vector<Polymorphic>*>::value == true);
+  static_assert(std::is_same<Trait<std::vector<Polymorphic>>::store_type, std::vector<Polymorphic>*>::value == true);
 }
+} // namespace o2::test


### PR DESCRIPTION
Wrong pointer instance was used for vectors when writing to branch after PR #2645.
This resulted into unwanted formatting of the data in the root file, though the ROOT IO appeared to be quite flexible and the readback was successful.

Adding also check for failed branch creation and enhancing the unit test.