### PR TITLE
Support int64 as argument to DPL executables

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -311,5 +311,5 @@ o2_add_test(
     --global-config require-me --run ${DPL_WORKFLOW_TESTS_EXTRA_OPTIONS}
     # Note: the group switch makes process consumer parse only the group
     arguments --consumer
-    "--global-config consumer-config --local-option hello-aliceo2 --a-boolean3 --an-int2 20 --a-double2 22."
+    "--global-config consumer-config --local-option hello-aliceo2 --a-boolean3 --an-int2 20 --a-double2 22. --an-int64-2 50000000000000"
   )

--- a/Framework/Core/include/Framework/BoostOptionsRetriever.h
+++ b/Framework/Core/include/Framework/BoostOptionsRetriever.h
@@ -33,6 +33,7 @@ class BoostOptionsRetriever : public ParamRetriever
                         int& argc, char**& argv);
 
   int getInt(const char* name) const final;
+  int64_t getInt64(const char* name) const final;
   float getFloat(const char* name) const final;
   double getDouble(const char* name) const final;
   bool getBool(const char* name) const final;

--- a/Framework/Core/include/Framework/ConfigParamRegistry.h
+++ b/Framework/Core/include/Framework/ConfigParamRegistry.h
@@ -45,6 +45,8 @@ class ConfigParamRegistry
     try {
       if constexpr (std::is_same_v<T, int>) {
         return mRetriever->getInt(key);
+      } else if constexpr (std::is_same_v<T, int64_t>) {
+        return mRetriever->getInt64(key);
       } else if constexpr (std::is_same_v<T, float>) {
         return mRetriever->getFloat(key);
       } else if constexpr (std::is_same_v<T, double>) {

--- a/Framework/Core/include/Framework/FairOptionsRetriever.h
+++ b/Framework/Core/include/Framework/FairOptionsRetriever.h
@@ -35,6 +35,7 @@ class FairOptionsRetriever : public ParamRetriever
   FairOptionsRetriever(std::vector<ConfigParamSpec> const& schema, const FairMQProgOptions* opts);
 
   int getInt(const char* name) const final;
+  int64_t getInt64(const char* name) const final;
   float getFloat(const char* name) const final;
   double getDouble(const char* name) const final;
   bool getBool(const char* name) const final;

--- a/Framework/Core/include/Framework/ParamRetriever.h
+++ b/Framework/Core/include/Framework/ParamRetriever.h
@@ -25,6 +25,7 @@ class ParamRetriever
 {
  public:
   virtual int getInt(const char* name) const = 0;
+  virtual int64_t getInt64(const char* name) const = 0;
   virtual float getFloat(const char* name) const = 0;
   virtual double getDouble(const char* name) const = 0;
   virtual bool getBool(const char* name) const = 0;

--- a/Framework/Core/include/Framework/SimpleOptionsRetriever.h
+++ b/Framework/Core/include/Framework/SimpleOptionsRetriever.h
@@ -21,6 +21,7 @@ class SimpleOptionsRetriever : public ParamRetriever
 {
  public:
   int getInt(const char* name) const final;
+  int64_t getInt64(const char* name) const final;
   float getFloat(const char* name) const final;
   double getDouble(const char* name) const final;
   bool getBool(const char* name) const final;
@@ -28,6 +29,7 @@ class SimpleOptionsRetriever : public ParamRetriever
   boost::property_tree::ptree getPTree(const char* name) const final;
 
   void setInt(char const* name, int);
+  void setInt64(char const* name, int64_t);
   void setFloat(char const* name, float);
   void setDouble(char const* name, double);
   void setBool(char const* name, bool);

--- a/Framework/Core/include/Framework/Variant.h
+++ b/Framework/Core/include/Framework/Variant.h
@@ -41,7 +41,7 @@ struct variant_trait<int> {
   static VariantType type() { return VariantType::Int; }
 };
 template <>
-struct variant_trait<int64_t> {
+struct variant_trait<long int> {
   static VariantType type() { return VariantType::Int64; }
 };
 template <>

--- a/Framework/Core/include/Framework/Variant.h
+++ b/Framework/Core/include/Framework/Variant.h
@@ -45,6 +45,10 @@ struct variant_trait<int64_t> {
   static VariantType type() { return VariantType::Int64; }
 };
 template <>
+struct variant_trait<long long int> {
+  static VariantType type() { return VariantType::Int64; }
+};
+template <>
 struct variant_trait<float> {
   static VariantType type() { return VariantType::Float; }
 };

--- a/Framework/Core/src/BoostOptionsRetriever.cxx
+++ b/Framework/Core/src/BoostOptionsRetriever.cxx
@@ -42,8 +42,10 @@ BoostOptionsRetriever::BoostOptionsRetriever(std::vector<ConfigParamSpec> const&
     // FIXME: propagate default value?
     switch (spec.type) {
       case VariantType::Int:
-      case VariantType::Int64:
         options = options(name, bpo::value<int>()->default_value(spec.defaultValue.get<int>()), help);
+        break;
+      case VariantType::Int64:
+        options = options(name, bpo::value<int64_t>()->default_value(spec.defaultValue.get<int64_t>()), help);
         break;
       case VariantType::Float:
         options = options(name, bpo::value<float>()->default_value(spec.defaultValue.get<float>()), help);
@@ -73,6 +75,11 @@ BoostOptionsRetriever::BoostOptionsRetriever(std::vector<ConfigParamSpec> const&
 int BoostOptionsRetriever::getInt(const char* key) const
 {
   return mStore.get<int>(key);
+}
+
+int64_t BoostOptionsRetriever::getInt64(const char* key) const
+{
+  return mStore.get<int64_t>(key);
 }
 
 float BoostOptionsRetriever::getFloat(const char* key) const

--- a/Framework/Core/src/ConfigParamsHelper.cxx
+++ b/Framework/Core/src/ConfigParamsHelper.cxx
@@ -41,8 +41,10 @@ void ConfigParamsHelper::populateBoostProgramOptions(
       // FIXME: Should we handle int and size_t diffently?
       // FIXME: We should probably raise an error if the type is unknown
       case VariantType::Int:
-      case VariantType::Int64:
         addConfigSpecOption<VariantType::Int>(spec, options);
+        break;
+      case VariantType::Int64:
+        addConfigSpecOption<VariantType::Int64>(spec, options);
         break;
       case VariantType::Float:
         addConfigSpecOption<VariantType::Float>(spec, options);

--- a/Framework/Core/src/FairOptionsRetriever.cxx
+++ b/Framework/Core/src/FairOptionsRetriever.cxx
@@ -38,6 +38,11 @@ int FairOptionsRetriever::getInt(const char* key) const
   return mStore.get<int>(key);
 }
 
+int64_t FairOptionsRetriever::getInt64(const char* key) const
+{
+  return mStore.get<int64_t>(key);
+}
+
 float FairOptionsRetriever::getFloat(const char* key) const
 {
   return mStore.get<float>(key);

--- a/Framework/Core/src/SimpleOptionsRetriever.cxx
+++ b/Framework/Core/src/SimpleOptionsRetriever.cxx
@@ -31,6 +31,11 @@ int SimpleOptionsRetriever::getInt(char const* key) const
   return mStore.get<int>(key);
 }
 
+int64_t SimpleOptionsRetriever::getInt64(char const* key) const
+{
+  return mStore.get<int64_t>(key);
+}
+
 float SimpleOptionsRetriever::getFloat(char const* key) const
 {
   return mStore.get<float>(key);
@@ -59,6 +64,11 @@ boost::property_tree::ptree SimpleOptionsRetriever::getPTree(char const* key) co
 void SimpleOptionsRetriever::setInt(char const* key, int value)
 {
   mStore.put<int>(key, value);
+}
+
+void SimpleOptionsRetriever::setInt64(char const* key, int64_t value)
+{
+  mStore.put<int64_t>(key, value);
 }
 
 void SimpleOptionsRetriever::setFloat(char const* key, float value)

--- a/Framework/Core/test/test_BoostOptionsRetriever.cxx
+++ b/Framework/Core/test/test_BoostOptionsRetriever.cxx
@@ -28,7 +28,7 @@ BOOST_AUTO_TEST_CASE(TrivialBoostOptionsRetrieverTest)
 
   auto specs = std::vector<ConfigParamSpec>{
     {"someInt", VariantType::Int, 2, {"some int option"}},
-    {"someInt64", VariantType::Int64, 3ll, {"some int64 option"}},
+    {"someInt64", VariantType::Int64, 4ll, {"some int64 option"}},
     {"someBool", VariantType::Bool, false, {"some bool option"}},
     {"someFloat", VariantType::Float, 2.0f, {"some float option"}},
     {"someDouble", VariantType::Double, 2.0, {"some double option"}},

--- a/Framework/Core/test/test_BoostOptionsRetriever.cxx
+++ b/Framework/Core/test/test_BoostOptionsRetriever.cxx
@@ -28,6 +28,7 @@ BOOST_AUTO_TEST_CASE(TrivialBoostOptionsRetrieverTest)
 
   auto specs = std::vector<ConfigParamSpec>{
     {"someInt", VariantType::Int, 2, {"some int option"}},
+    {"someInt64", VariantType::Int64, 3l, {"some int64 option"}},
     {"someBool", VariantType::Bool, false, {"some bool option"}},
     {"someFloat", VariantType::Float, 2.0f, {"some float option"}},
     {"someDouble", VariantType::Double, 2.0, {"some double option"}},
@@ -36,6 +37,7 @@ BOOST_AUTO_TEST_CASE(TrivialBoostOptionsRetrieverTest)
     "test",
     "--someBool",
     "--someInt", "1",
+    "--someInt64", "50000000000000",
     "--someFloat", "0.5",
     "--someDouble", "0.5",
     "--someString", "foobar"};
@@ -47,6 +49,7 @@ BOOST_AUTO_TEST_CASE(TrivialBoostOptionsRetrieverTest)
   bpo::store(parse_command_line(sizeof(args) / sizeof(char*), args, opts), vm);
   bpo::notify(vm);
   BOOST_CHECK(vm["someInt"].as<int>() == 1);
+  BOOST_CHECK(vm["someInt64"].as<int64_t>() == 50000000000000l);
   BOOST_CHECK(vm["someBool"].as<bool>() == true);
   BOOST_CHECK(vm["someString"].as<std::string>() == "foobar");
   BOOST_CHECK(vm["someFloat"].as<float>() == 0.5);

--- a/Framework/Core/test/test_BoostOptionsRetriever.cxx
+++ b/Framework/Core/test/test_BoostOptionsRetriever.cxx
@@ -28,7 +28,7 @@ BOOST_AUTO_TEST_CASE(TrivialBoostOptionsRetrieverTest)
 
   auto specs = std::vector<ConfigParamSpec>{
     {"someInt", VariantType::Int, 2, {"some int option"}},
-    {"someInt64", VariantType::Int64, 3l, {"some int64 option"}},
+    {"someInt64", VariantType::Int64, 3ll, {"some int64 option"}},
     {"someBool", VariantType::Bool, false, {"some bool option"}},
     {"someFloat", VariantType::Float, 2.0f, {"some float option"}},
     {"someDouble", VariantType::Double, 2.0, {"some double option"}},
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_CASE(TrivialBoostOptionsRetrieverTest)
   bpo::store(parse_command_line(sizeof(args) / sizeof(char*), args, opts), vm);
   bpo::notify(vm);
   BOOST_CHECK(vm["someInt"].as<int>() == 1);
-  BOOST_CHECK(vm["someInt64"].as<int64_t>() == 50000000000000l);
+  BOOST_CHECK(vm["someInt64"].as<int64_t>() == 50000000000000ll);
   BOOST_CHECK(vm["someBool"].as<bool>() == true);
   BOOST_CHECK(vm["someString"].as<std::string>() == "foobar");
   BOOST_CHECK(vm["someFloat"].as<float>() == 0.5);

--- a/Framework/Core/test/test_ConfigParamRegistry.cxx
+++ b/Framework/Core/test/test_ConfigParamRegistry.cxx
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(TestConfigParamRegistry)
     ("aFloat", bpo::value<float>()->default_value(10.f))                  //
     ("aDouble", bpo::value<double>()->default_value(20.))                 //
     ("anInt", bpo::value<int>()->default_value(1))                        //
-    ("anInt64", bpo::value<int64_t>()->default_value(1l))                 //
+    ("anInt64", bpo::value<int64_t>()->default_value(1ll))                //
     ("aBoolean", bpo::value<bool>()->zero_tokens()->default_value(false)) //
     ("aString,s", bpo::value<std::string>()->default_value("something"))  //
     ("aNested.x", bpo::value<int>()->default_value(2))                    //
@@ -59,7 +59,7 @@ BOOST_AUTO_TEST_CASE(TestConfigParamRegistry)
                     false);
   std::vector<ConfigParamSpec> specs{
     ConfigParamSpec{"anInt", VariantType::Int, 1, {"an int option"}},
-    ConfigParamSpec{"anInt64", VariantType::Int64, 1l, {"an int64_t option"}},
+    ConfigParamSpec{"anInt64", VariantType::Int64, 1ll, {"an int64_t option"}},
     ConfigParamSpec{"aFloat", VariantType::Float, 2.0f, {"a float option"}},
     ConfigParamSpec{"aDouble", VariantType::Double, 3., {"a double option"}},
     ConfigParamSpec{"aString,s", VariantType::String, "foo", {"a string option"}},
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE(TestConfigParamRegistry)
   BOOST_CHECK_EQUAL(registry.get<float>("aFloat"), 1.0);
   BOOST_CHECK_EQUAL(registry.get<double>("aDouble"), 2.0);
   BOOST_CHECK_EQUAL(registry.get<int>("anInt"), 10);
-  BOOST_CHECK_EQUAL(registry.get<int64_t>("anInt64"), 50000000000000l);
+  BOOST_CHECK_EQUAL(registry.get<int64_t>("anInt64"), 50000000000000ll);
   BOOST_CHECK_EQUAL(registry.get<bool>("aBoolean"), true);
   BOOST_CHECK_EQUAL(registry.get<std::string>("aString"), "somethingelse");
   BOOST_CHECK_EQUAL(registry.get<int>("aNested.x"), 1);

--- a/Framework/Core/test/test_ConfigParamRegistry.cxx
+++ b/Framework/Core/test/test_ConfigParamRegistry.cxx
@@ -40,6 +40,7 @@ BOOST_AUTO_TEST_CASE(TestConfigParamRegistry)
     ("aFloat", bpo::value<float>()->default_value(10.f))                  //
     ("aDouble", bpo::value<double>()->default_value(20.))                 //
     ("anInt", bpo::value<int>()->default_value(1))                        //
+    ("anInt64", bpo::value<int64_t>()->default_value(1l))                 //
     ("aBoolean", bpo::value<bool>()->zero_tokens()->default_value(false)) //
     ("aString,s", bpo::value<std::string>()->default_value("something"))  //
     ("aNested.x", bpo::value<int>()->default_value(2))                    //
@@ -50,6 +51,7 @@ BOOST_AUTO_TEST_CASE(TestConfigParamRegistry)
   options->ParseAll({"cmd", "--aFloat", "1.0",
                      "--aDouble", "2.0",
                      "--anInt", "10",
+                     "--anInt64", "50000000000000",
                      "--aBoolean",
                      "-s", "somethingelse",
                      "--aNested.x", "1",
@@ -57,6 +59,7 @@ BOOST_AUTO_TEST_CASE(TestConfigParamRegistry)
                     false);
   std::vector<ConfigParamSpec> specs{
     ConfigParamSpec{"anInt", VariantType::Int, 1, {"an int option"}},
+    ConfigParamSpec{"anInt64", VariantType::Int64, 1l, {"an int64_t option"}},
     ConfigParamSpec{"aFloat", VariantType::Float, 2.0f, {"a float option"}},
     ConfigParamSpec{"aDouble", VariantType::Double, 3., {"a double option"}},
     ConfigParamSpec{"aString,s", VariantType::String, "foo", {"a string option"}},
@@ -71,6 +74,7 @@ BOOST_AUTO_TEST_CASE(TestConfigParamRegistry)
   BOOST_CHECK_EQUAL(registry.get<float>("aFloat"), 1.0);
   BOOST_CHECK_EQUAL(registry.get<double>("aDouble"), 2.0);
   BOOST_CHECK_EQUAL(registry.get<int>("anInt"), 10);
+  BOOST_CHECK_EQUAL(registry.get<int64_t>("anInt64"), 50000000000000l);
   BOOST_CHECK_EQUAL(registry.get<bool>("aBoolean"), true);
   BOOST_CHECK_EQUAL(registry.get<std::string>("aString"), "somethingelse");
   BOOST_CHECK_EQUAL(registry.get<int>("aNested.x"), 1);

--- a/Framework/Core/test/test_FairMQOptionsRetriever.cxx
+++ b/Framework/Core/test/test_FairMQOptionsRetriever.cxx
@@ -26,6 +26,7 @@ BOOST_AUTO_TEST_CASE(TestOptionsRetriever)
     ("aFloat", bpo::value<float>()->default_value(10.f))                  //
     ("aDouble", bpo::value<double>()->default_value(20.))                 //
     ("anInt", bpo::value<int>()->default_value(1))                        //
+    ("anInt64", bpo::value<int64_t>()->default_value(1l))                 //
     ("aBoolean", bpo::value<bool>()->zero_tokens()->default_value(false)) //
     ("aString", bpo::value<std::string>()->default_value("something"))    //
     ("aNested.int", bpo::value<int>()->default_value(2))                  //
@@ -36,6 +37,7 @@ BOOST_AUTO_TEST_CASE(TestOptionsRetriever)
   options->ParseAll({"cmd", "--aFloat", "1.0",
                      "--aDouble", "2.0",
                      "--anInt", "10",
+                     "--anInt64", "50000000000000",
                      "--aBoolean",
                      "--aString", "somethingelse",
                      "--aNested.int", "1",
@@ -43,6 +45,7 @@ BOOST_AUTO_TEST_CASE(TestOptionsRetriever)
                     false);
   std::vector<ConfigParamSpec> specs{
     ConfigParamSpec{"anInt", VariantType::Int, 1, {"an int option"}},
+    ConfigParamSpec{"anInt64", VariantType::Int64, 1l, {"an int64_t option"}},
     ConfigParamSpec{"aFloat", VariantType::Float, 2.0f, {"a float option"}},
     ConfigParamSpec{"aDouble", VariantType::Double, 3., {"a double option"}},
     ConfigParamSpec{"aString", VariantType::String, "foo", {"a string option"}},
@@ -54,6 +57,7 @@ BOOST_AUTO_TEST_CASE(TestOptionsRetriever)
   BOOST_CHECK_EQUAL(retriever.getFloat("aFloat"), 1.0);
   BOOST_CHECK_EQUAL(retriever.getDouble("aDouble"), 2.0);
   BOOST_CHECK_EQUAL(retriever.getInt("anInt"), 10);
+  BOOST_CHECK_EQUAL(retriever.getInt64("anInt64"), 50000000000000l);
   BOOST_CHECK_EQUAL(retriever.getBool("aBoolean"), true);
   BOOST_CHECK_EQUAL(retriever.getString("aString"), "somethingelse");
   BOOST_CHECK_EQUAL(retriever.getInt("aNested.int"), 1);
@@ -71,6 +75,7 @@ BOOST_AUTO_TEST_CASE(TestOptionsDefaults)
     ("aFloat", bpo::value<float>()->default_value(10.f))                  //
     ("aDouble", bpo::value<double>()->default_value(20.))                 //
     ("anInt", bpo::value<int>()->default_value(1))                        //
+    ("anInt64", bpo::value<int64_t>()->default_value(-50000000000000l))   //
     ("aBoolean", bpo::value<bool>()->zero_tokens()->default_value(false)) //
     ("aString", bpo::value<std::string>()->default_value("something"))    //
     ("aNested.int", bpo::value<int>()->default_value(2))                  //
@@ -81,6 +86,7 @@ BOOST_AUTO_TEST_CASE(TestOptionsDefaults)
   options->ParseAll({"cmd"}, false);
   std::vector<ConfigParamSpec> specs{
     ConfigParamSpec{"anInt", VariantType::Int, 1, {"an int option"}},
+    ConfigParamSpec{"anInt64", VariantType::Int64, -50000000000000l, {"an int64_t option"}},
     ConfigParamSpec{"aFloat", VariantType::Float, 2.0f, {"a float option"}},
     ConfigParamSpec{"aDouble", VariantType::Double, 3., {"a double option"}},
     ConfigParamSpec{"aString", VariantType::String, "foo", {"a string option"}},
@@ -92,6 +98,7 @@ BOOST_AUTO_TEST_CASE(TestOptionsDefaults)
   BOOST_CHECK_EQUAL(retriever.getFloat("aFloat"), 10.f);
   BOOST_CHECK_EQUAL(retriever.getDouble("aDouble"), 20.);
   BOOST_CHECK_EQUAL(retriever.getInt("anInt"), 1);
+  BOOST_CHECK_EQUAL(retriever.getInt64("anInt64"), -50000000000000l);
   BOOST_CHECK_EQUAL(retriever.getBool("aBoolean"), false);
   BOOST_CHECK_EQUAL(retriever.getString("aString"), "something");
   BOOST_CHECK_EQUAL(retriever.getInt("aNested.int"), 2);

--- a/Framework/Core/test/test_FairMQOptionsRetriever.cxx
+++ b/Framework/Core/test/test_FairMQOptionsRetriever.cxx
@@ -26,7 +26,7 @@ BOOST_AUTO_TEST_CASE(TestOptionsRetriever)
     ("aFloat", bpo::value<float>()->default_value(10.f))                  //
     ("aDouble", bpo::value<double>()->default_value(20.))                 //
     ("anInt", bpo::value<int>()->default_value(1))                        //
-    ("anInt64", bpo::value<int64_t>()->default_value(1ll))                 //
+    ("anInt64", bpo::value<int64_t>()->default_value(1ll))                //
     ("aBoolean", bpo::value<bool>()->zero_tokens()->default_value(false)) //
     ("aString", bpo::value<std::string>()->default_value("something"))    //
     ("aNested.int", bpo::value<int>()->default_value(2))                  //

--- a/Framework/Core/test/test_FairMQOptionsRetriever.cxx
+++ b/Framework/Core/test/test_FairMQOptionsRetriever.cxx
@@ -26,7 +26,7 @@ BOOST_AUTO_TEST_CASE(TestOptionsRetriever)
     ("aFloat", bpo::value<float>()->default_value(10.f))                  //
     ("aDouble", bpo::value<double>()->default_value(20.))                 //
     ("anInt", bpo::value<int>()->default_value(1))                        //
-    ("anInt64", bpo::value<int64_t>()->default_value(1l))                 //
+    ("anInt64", bpo::value<int64_t>()->default_value(1ll))                 //
     ("aBoolean", bpo::value<bool>()->zero_tokens()->default_value(false)) //
     ("aString", bpo::value<std::string>()->default_value("something"))    //
     ("aNested.int", bpo::value<int>()->default_value(2))                  //
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE(TestOptionsRetriever)
                     false);
   std::vector<ConfigParamSpec> specs{
     ConfigParamSpec{"anInt", VariantType::Int, 1, {"an int option"}},
-    ConfigParamSpec{"anInt64", VariantType::Int64, 1l, {"an int64_t option"}},
+    ConfigParamSpec{"anInt64", VariantType::Int64, 1ll, {"an int64_t option"}},
     ConfigParamSpec{"aFloat", VariantType::Float, 2.0f, {"a float option"}},
     ConfigParamSpec{"aDouble", VariantType::Double, 3., {"a double option"}},
     ConfigParamSpec{"aString", VariantType::String, "foo", {"a string option"}},
@@ -57,7 +57,7 @@ BOOST_AUTO_TEST_CASE(TestOptionsRetriever)
   BOOST_CHECK_EQUAL(retriever.getFloat("aFloat"), 1.0);
   BOOST_CHECK_EQUAL(retriever.getDouble("aDouble"), 2.0);
   BOOST_CHECK_EQUAL(retriever.getInt("anInt"), 10);
-  BOOST_CHECK_EQUAL(retriever.getInt64("anInt64"), 50000000000000l);
+  BOOST_CHECK_EQUAL(retriever.getInt64("anInt64"), 50000000000000ll);
   BOOST_CHECK_EQUAL(retriever.getBool("aBoolean"), true);
   BOOST_CHECK_EQUAL(retriever.getString("aString"), "somethingelse");
   BOOST_CHECK_EQUAL(retriever.getInt("aNested.int"), 1);
@@ -75,7 +75,7 @@ BOOST_AUTO_TEST_CASE(TestOptionsDefaults)
     ("aFloat", bpo::value<float>()->default_value(10.f))                  //
     ("aDouble", bpo::value<double>()->default_value(20.))                 //
     ("anInt", bpo::value<int>()->default_value(1))                        //
-    ("anInt64", bpo::value<int64_t>()->default_value(-50000000000000l))   //
+    ("anInt64", bpo::value<int64_t>()->default_value(-50000000000000ll))  //
     ("aBoolean", bpo::value<bool>()->zero_tokens()->default_value(false)) //
     ("aString", bpo::value<std::string>()->default_value("something"))    //
     ("aNested.int", bpo::value<int>()->default_value(2))                  //
@@ -86,7 +86,7 @@ BOOST_AUTO_TEST_CASE(TestOptionsDefaults)
   options->ParseAll({"cmd"}, false);
   std::vector<ConfigParamSpec> specs{
     ConfigParamSpec{"anInt", VariantType::Int, 1, {"an int option"}},
-    ConfigParamSpec{"anInt64", VariantType::Int64, -50000000000000l, {"an int64_t option"}},
+    ConfigParamSpec{"anInt64", VariantType::Int64, -50000000000000ll, {"an int64_t option"}},
     ConfigParamSpec{"aFloat", VariantType::Float, 2.0f, {"a float option"}},
     ConfigParamSpec{"aDouble", VariantType::Double, 3., {"a double option"}},
     ConfigParamSpec{"aString", VariantType::String, "foo", {"a string option"}},
@@ -98,7 +98,7 @@ BOOST_AUTO_TEST_CASE(TestOptionsDefaults)
   BOOST_CHECK_EQUAL(retriever.getFloat("aFloat"), 10.f);
   BOOST_CHECK_EQUAL(retriever.getDouble("aDouble"), 20.);
   BOOST_CHECK_EQUAL(retriever.getInt("anInt"), 1);
-  BOOST_CHECK_EQUAL(retriever.getInt64("anInt64"), -50000000000000l);
+  BOOST_CHECK_EQUAL(retriever.getInt64("anInt64"), -50000000000000ll);
   BOOST_CHECK_EQUAL(retriever.getBool("aBoolean"), false);
   BOOST_CHECK_EQUAL(retriever.getString("aString"), "something");
   BOOST_CHECK_EQUAL(retriever.getInt("aNested.int"), 2);

--- a/Framework/Core/test/test_ProcessorOptions.cxx
+++ b/Framework/Core/test/test_ProcessorOptions.cxx
@@ -66,6 +66,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
           auto aBoolean3 = ic.options().get<bool>("a-boolean3");
           auto anInt = ic.options().get<int>("an-int");
           auto anInt2 = ic.options().get<int>("an-int2");
+          auto anInt64 = ic.options().get<int64_t>("an-int64");
+          auto anInt64_2 = ic.options().get<int64_t>("an-int64-2");
           auto aDouble = ic.options().get<double>("a-double");
           auto aDouble2 = ic.options().get<double>("a-double2");
 
@@ -74,6 +76,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
           ASSERT_ERROR(aBoolean3 == true);
           ASSERT_ERROR(anInt == 10);
           ASSERT_ERROR(anInt2 == 20);
+          ASSERT_ERROR(anInt64 == 1l);
+          ASSERT_ERROR(anInt64_2 == 50000000000000l);
           ASSERT_ERROR(aDouble == 11.);
           ASSERT_ERROR(aDouble2 == 22.);
           ASSERT_ERROR(configstring == "consumer-config");
@@ -93,6 +97,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
         ConfigParamSpec{"a-boolean3", VariantType::Bool, false, {"Another boolean which we pick from the outside options"}},
         ConfigParamSpec{"an-int", VariantType::Int, 10, {"An int for which we pick up the default"}},
         ConfigParamSpec{"an-int2", VariantType::Int, 1, {"An int for which we pick up the override"}},
+        ConfigParamSpec{"an-int64", VariantType::Int64, 1l, {"An int64 for which we pick up the default"}},
+        ConfigParamSpec{"an-int64-2", VariantType::Int64, 2l, {"An int64 for which we pick up the override"}},
         ConfigParamSpec{"a-double", VariantType::Double, 11., {"A double for which we pick up the override"}},
         ConfigParamSpec{"a-double2", VariantType::Double, 12., {"A double for which we pick up the override"}},
       },

--- a/Framework/Core/test/test_ProcessorOptions.cxx
+++ b/Framework/Core/test/test_ProcessorOptions.cxx
@@ -76,8 +76,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
           ASSERT_ERROR(aBoolean3 == true);
           ASSERT_ERROR(anInt == 10);
           ASSERT_ERROR(anInt2 == 20);
-          ASSERT_ERROR(anInt64 == 1l);
-          ASSERT_ERROR(anInt64_2 == 50000000000000l);
+          ASSERT_ERROR(anInt64 == 1ll);
+          ASSERT_ERROR(anInt64_2 == 50000000000000ll);
           ASSERT_ERROR(aDouble == 11.);
           ASSERT_ERROR(aDouble2 == 22.);
           ASSERT_ERROR(configstring == "consumer-config");
@@ -97,8 +97,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
         ConfigParamSpec{"a-boolean3", VariantType::Bool, false, {"Another boolean which we pick from the outside options"}},
         ConfigParamSpec{"an-int", VariantType::Int, 10, {"An int for which we pick up the default"}},
         ConfigParamSpec{"an-int2", VariantType::Int, 1, {"An int for which we pick up the override"}},
-        ConfigParamSpec{"an-int64", VariantType::Int64, 1l, {"An int64 for which we pick up the default"}},
-        ConfigParamSpec{"an-int64-2", VariantType::Int64, 2l, {"An int64 for which we pick up the override"}},
+        ConfigParamSpec{"an-int64", VariantType::Int64, 1ll, {"An int64 for which we pick up the default"}},
+        ConfigParamSpec{"an-int64-2", VariantType::Int64, 2ll, {"An int64 for which we pick up the override"}},
         ConfigParamSpec{"a-double", VariantType::Double, 11., {"A double for which we pick up the override"}},
         ConfigParamSpec{"a-double2", VariantType::Double, 12., {"A double for which we pick up the override"}},
       },


### PR DESCRIPTION
This is needed to set realistic timestamps for enumerated timeframe data sources.