### PR TITLE
PrimaryGenerator: Offer flat vertex distribution

### DIFF
--- a/Generators/include/Generators/InteractionDiamondParam.h
+++ b/Generators/include/Generators/InteractionDiamondParam.h
@@ -21,15 +21,21 @@ namespace o2
 namespace eventgen
 {
 
+/// enumerating the possible vertex smearing settings
+enum class EVertexDistribution {
+  kGaus = 0, /* ordinary Gaus */
+  kFlat = 1  /* flat */
+};
+
 /**
  ** a parameter class/struct to keep the settings of
  ** the interaction diamond (position and width) and 
  ** allow the user to modify them 
  **/
-
 struct InteractionDiamondParam : public o2::conf::ConfigurableParamHelper<InteractionDiamondParam> {
   double position[3] = {0., 0., 0.};
   double width[3] = {0., 0., 0.};
+  EVertexDistribution distribution = EVertexDistribution::kGaus;
   O2ParamDef(InteractionDiamondParam, "Diamond");
 };
 

--- a/Generators/src/GeneratorsLinkDef.h
+++ b/Generators/src/GeneratorsLinkDef.h
@@ -38,7 +38,9 @@
 #pragma link C++ class o2::eventgen::GeneratorFromFile + ;
 #pragma link C++ class o2::PDG + ;
 #pragma link C++ class o2::eventgen::PrimaryGenerator + ;
-#pragma link C++ class o2::eventgen::InteractionDiamondParam + ;
+
+#pragma link C++ enum o2::eventgen::EVertexDistribution;
+#pragma link C++ class o2::eventgen::InteractionDiamondParam +;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::eventgen::InteractionDiamondParam> + ;
 #pragma link C++ class o2::eventgen::BoxGunParam + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::eventgen::BoxGunParam> + ;

--- a/Generators/src/PrimaryGenerator.cxx
+++ b/Generators/src/PrimaryGenerator.cxx
@@ -135,10 +135,21 @@ void PrimaryGenerator::setInteractionDiamond(const Double_t* xyz, const Double_t
             << sigmaxyz[0] << "," << sigmaxyz[1] << "," << sigmaxyz[2] << "} cm";
   SetBeam(xyz[0], xyz[1], sigmaxyz[0], sigmaxyz[1]);
   SetTarget(xyz[2], sigmaxyz[2]);
+
+  auto const& param = InteractionDiamondParam::Instance();
   SmearVertexXY(false);
   SmearVertexZ(false);
-  SmearGausVertexXY(true);
-  SmearGausVertexZ(true);
+  SmearGausVertexXY(false);
+  SmearGausVertexZ(false);
+  if (param.distribution == o2::eventgen::EVertexDistribution::kFlat) {
+    SmearVertexXY(true);
+    SmearVertexZ(true);
+  } else if (param.distribution == o2::eventgen::EVertexDistribution::kGaus) {
+    SmearGausVertexXY(true);
+    SmearGausVertexZ(true);
+  } else {
+    LOG(ERROR) << "PrimaryGenerator: Unsupported vertex distribution";
+  }
 }
 
 /*****************************************************************/


### PR DESCRIPTION
FairRoot is already capable of sampling vertex positions
with a flat distribution.
We are offering now a configuration that can switch between
flat and gaussian sampling.