### PR TITLE
DPL I/O API: Supporting spectator vector as return for InputRecord::get<std::vector<T>>

### DIFF
--- a/Framework/Core/test/test_DataAllocator.cxx
+++ b/Framework/Core/test/test_DataAllocator.cxx
@@ -303,6 +303,11 @@ DataProcessorSpec getSinkSpec()
     // forward the read-only span on a different route
     pc.outputs().snapshot(Output{"TST", "MSGABLVECTORCPY", 0, Lifetime::Timeframe}, object12);
 
+    // extract the trivially copyable vector by std::vector object which will return vector
+    // with special allocator and the underlting pointer is the original input data
+    auto vector12 = pc.inputs().get<std::vector<o2::test::TriviallyCopyable>>("input12");
+    ASSERT_ERROR((object12.data() == vector12.data()) && (object12.size() == vector12.size()));
+
     LOG(INFO) << "extracting TNamed object from input13";
     auto object13 = pc.inputs().get<TNamed*>("input13");
     ASSERT_ERROR(strcmp(object13->GetName(), "a_name") == 0);


### PR DESCRIPTION
I'm opening a new PR in order to discuss this topic even though it depends on the commit in #2617 

When querying vectors, a spectator vactor is returned which is directly using
the raw memory without copy using polymorphic allocator and spectator memory
resource. A unique instance of the spectator memory resource is kept in the
InputRecord and valid for the lifetime of teh record.

This changes the return type to `vector<T const, o2::pmr::SpectatorAllocator<T const>>`
and thus breaks compilation in code where the vector with standard allocator is used.

This is not problematic in cases where the returned instance is only used in the
function itself and not passed onto workers (unless in a templatized function call).

Ways out of this problem:
change access to the read-only input data objects in the worker classes
  1. where possible one could use a templatized function call, and within this reader
     function use iterators
  2. introduce specific vector class like o2::spectator::vector (naming to be discussed)
  3. Use spans over the readonly input arrays

Pros and cons:
option 1) (+) can implement flexible code
          (-) many of the classes use member variables to hold the
              data which are set in advance, implementation must be in the header
          this is more an option for small algorithms
option 2) (+) we introduce a data object which can be used system wide
          (-) while suitable for the workflow implementations and everything which
              is related to messaging in DPL, the worker classes should be kept more
              general in order to be used standalone with little overhead
option 3) (+) generic solution
          (-) no cons