### PR TITLE
Enforcing exception on unmatched input data in ExternalFairMQDeviceProxy

### DIFF
--- a/Framework/Core/include/Framework/ExternalFairMQDeviceProxy.h
+++ b/Framework/Core/include/Framework/ExternalFairMQDeviceProxy.h
@@ -54,7 +54,7 @@ InjectorFunction o2DataModelAdaptor(OutputSpec const& spec, uint64_t startTime, 
 /// The list of specs is used as a filter list, all incoming data matching an entry
 /// in the list will be send through the corresponding channel
 InjectorFunction dplModelAdaptor(std::vector<OutputSpec> const& specs = {{header::gDataOriginAny, header::gDataDescriptionAny}},
-                                 bool throwOnUnmatchedInputs = false);
+                                 bool throwOnUnmatchedInputs = true);
 
 /// The default connection method for the custom source
 static auto gDefaultConverter = incrementalConverter(OutputSpec{"TST", "TEST", 0}, 0, 1);


### PR DESCRIPTION
Make the DPL model adaptor more strict about unmatched input data, will throw
by default unless dropping of messages is enabled. Also improving the exception
message. Printing warning about dropped messages if enabled.