### PR TITLE
Fixing a typo which made raw-parser crashing std namespace instead of gls for span

### DIFF
--- a/Framework/Utils/src/raw-parser.cxx
+++ b/Framework/Utils/src/raw-parser.cxx
@@ -39,38 +39,38 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
     select(config.options().get<std::string>("input-spec").c_str()),
     Outputs{},
     AlgorithmSpec{[](InitContext& setup) {
-	auto loglevel = setup.options().get<int>("log-level");
-	return adaptStateless([loglevel](InputRecord& inputs, DataAllocator& outputs) {
-	    for (auto& input : inputs) {
-	      const auto* dh = DataRefUtils::getHeader<o2::header::DataHeader*>(input);
-	      if (loglevel > 0) {
-		// InputSpec implements operator<< so we could print (input.spec) but that is the
-		// matcher instead of the matched data
-		LOG(INFO) << dh->dataOrigin.as<std::string>() << "/"
-			  << dh->dataDescription.as<std::string>() << "/"
-			  << dh->subSpecification << " payload size " << dh->payloadSize;
-	      }
+        auto loglevel = setup.options().get<int>("log-level");
+        return adaptStateless([loglevel](InputRecord& inputs, DataAllocator& outputs) {
+            for (auto& input : inputs) {
+              const auto* dh = DataRefUtils::getHeader<o2::header::DataHeader*>(input);
+              if (loglevel > 0) {
+                // InputSpec implements operator<< so we could print (input.spec) but that is the
+                // matcher instead of the matched data
+                LOG(INFO) << dh->dataOrigin.as<std::string>() << "/"
+                          << dh->dataDescription.as<std::string>() << "/"
+                          << dh->subSpecification << " payload size " << dh->payloadSize;
+              }
 
-	      auto raw = inputs.get<std::span<char>>(input.spec->binding.c_str());
+              auto raw = inputs.get<std::span<char>>(input.spec->binding.c_str());
 
-	      try {
-		o2::framework::RawParser parser(raw.data(), raw.size());
+              try {
+                o2::framework::RawParser parser(raw.data(), raw.size());
 
-		std::stringstream rdhprintout;
-		rdhprintout << parser;
-		for (auto it = parser.begin(), end = parser.end(); it != end; ++it) {
-		  rdhprintout << it << ": payload size " << it.size() << std::endl;
-		}
-		if (loglevel > 1) {
-		  LOG(INFO) << rdhprintout.str();
-		}
-	      } catch (const std::runtime_error& e) {
-		LOG(ERROR) << "can not create raw parser form input data";
-		o2::header::hexDump("payload", input.payload, dh->payloadSize, 64);
-		LOG(ERROR) << e.what();
-	      }
-	    }
-	  }); }},
+                std::stringstream rdhprintout;
+                rdhprintout << parser;
+                for (auto it = parser.begin(), end = parser.end(); it != end; ++it) {
+                  rdhprintout << it << ": payload size " << it.size() << std::endl;
+                }
+                if (loglevel > 1) {
+                  LOG(INFO) << rdhprintout.str();
+                }
+              } catch (const std::runtime_error& e) {
+                LOG(ERROR) << "can not create raw parser form input data";
+                o2::header::hexDump("payload", input.payload, dh->payloadSize, 64);
+                LOG(ERROR) << e.what();
+              }
+            }
+          }); }},
     Options{
       {"log-level", VariantType::Int, 1, {"Logging level [0-2]"}}}});
   return workflow;

--- a/Framework/Utils/src/raw-parser.cxx
+++ b/Framework/Utils/src/raw-parser.cxx
@@ -51,7 +51,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
                           << dh->subSpecification << " payload size " << dh->payloadSize;
               }
 
-              auto raw = inputs.get<std::span<char>>(input.spec->binding.c_str());
+              auto raw = inputs.get<gsl::span<char>>(input.spec->binding.c_str());
 
               try {
                 o2::framework::RawParser parser(raw.data(), raw.size());


### PR DESCRIPTION
Instead of gsl::span, std::span was used. This lead to a wrong pointer of
the raw buffer used by the parser class.

Need to investigate:
- [ ] why there hasn't been any compilation error, std::span is c++20
- [ ] what the InputRecord API deduced and what kind of object it returned

