### PR TITLE
Updates for ZDC hit processing 

### DIFF
--- a/Detectors/ZDC/simulation/data/simcuts.dat
+++ b/Detectors/ZDC/simulation/data/simcuts.dat
@@ -9,27 +9,25 @@
 *
 * ZDC
 * ===
-* 
+*
 *   Med  GAM   ELEC  NHAD  CHAD  MUON  EBREM MUHAB EDEL  MUDEL MUPA ANNI BREM COMP DCAY DRAY HADR LOSS MULS PAIR PHOT RAYL STRA
 * W alloy
-ZDC  1   1e-3  1e-3  1e-2  1e-2
+ZDC  kWalloy   1e-3  1e-3  1e-2  1e-2
 * brass
-ZDC  2   1e-3  1e-3  1e-2  1e-2
+ZDC  kCuZn   1e-3  1e-3  1e-2  1e-2
 * Si02 (I)
-ZDC  3   1e-3  1e-3  1e-3  1e-3  0.01  1e-3  1e-3  -1     -1  -1     0    0    0    0   0     0   1     0    0    0   0
+ZDC  kSiO2pmc   1e-3  1e-3  1e-3  1e-3  0.01  1e-3  1e-3  -1     -1  -1     0    0    0    0   0     0   1     0    0    0   0
 * Si02 (II)
-ZDC  4   1e-3  1e-3  1e-3  1e-3  0.01  1e-3  1e-3  -1     -1  -1     0    0    0    0   0     0   1     0    0    0   0
+ZDC  kSiO2pmq   1e-3  1e-3  1e-3  1e-3  0.01  1e-3  1e-3  -1     -1  -1     0    0    0    0   0     0   1     0    0    0   0
 * Pb
-ZDC  5   1e-3  1e-3  1e-2  1e-2
+ZDC  kPb   1e-3  1e-3  1e-2  1e-2
 * Cu (to avoid too detailed showering in TDI)
-ZDC  6   .1  .1  1.  1.
+ZDC  kCu   .1  .1  1.  1.
 * Fe with energy loss and high thresholds (beam pipe)
-ZDC  7   .1  .1  1.  1.
+ZDC  kFe   .1  .1  1.  1.
 * Fe with energy loss and low threshold (recombination chamber)
-ZDC  8   1e-3  1e-3  1e-2  1e-2
+ZDC  kFeLowTh   1e-3  1e-3  1e-2  1e-2
 * Cu (luminometer)
-ZDC  9   1e-3  1e-3  1e-2  1e-2
+ZDC  kCuLumi   1e-3  1e-3  1e-2  1e-2
 * void with field
-ZDC  11  1e-3  1e-3  1e-3  1e-3  0.01  1e-3  1e-3  -1     -1  -1     0    0    0    0   0     0   0     0    0    0   0
-* Graphite
-ZDC  14  .1  .1  1.  1.
+ZDC  kVoidwField  1e-3  1e-3  1e-3  1e-3  0.01  1e-3  1e-3  -1     -1  -1     0    0    0    0   0     0   0     0    0    0   0

--- a/Detectors/ZDC/simulation/src/Detector.cxx
+++ b/Detectors/ZDC/simulation/src/Detector.cxx
@@ -288,7 +288,7 @@ Bool_t Detector::ProcessHits(FairVolume* v)
     if ((mLastPrincipalTrackEntered == -1) || !(stack->isTrackDaughterOf(trackn, mLastPrincipalTrackEntered))) {
       mLastPrincipalTrackEntered = trackn;
       resetHitIndices();
-      printf(">>> RESETTING HITS!!!!\n\n");
+      //printf(">>> RESETTING HITS!!!!\n\n");
 
       // there is nothing more to do here as we are not
       // in the fiber volumes
@@ -304,7 +304,7 @@ Bool_t Detector::ProcessHits(FairVolume* v)
     // if we come here we are definitely in a sensitive volume !!
     mLastPrincipalTrackEntered = trackn;
     resetHitIndices();
-    printf(" Problem with principal track detection\n >>> RESETTING HITS!!!!\n");
+    //printf(" Problem with principal track detection\n >>> RESETTING HITS!!!!\n");
   }
 
   Float_t p[3] = {0., 0., 0.};
@@ -388,9 +388,8 @@ Bool_t Detector::ProcessHits(FairVolume* v)
       curHit.SetEnergyLoss(incenloss);
       curHit.setPMCLightYield(mTotLightPMC);
       curHit.setPMQLightYield(mTotLightPMQ);
-      printf("  >>> Hit updated in vol %d %d  for track %d (mother: %d) \t light %1.0f %1.0f \n",
-        detector, sector, trackn, stack->GetCurrentTrack()->GetFirstMother(), mTotLightPMC, mTotLightPMQ);
-        //detector, sector, trackn, stack->GetCurrentTrack()->GetMother(0), mTotLightPMC, mTotLightPMQ);
+      //printf("  >>> Hit updated in vol %d %d  for track %d (mother: %d) \t light %1.0f %1.0f \n",
+        //detector, sector, trackn, stack->GetCurrentTrack()->GetFirstMother(), mTotLightPMC, mTotLightPMQ);
     }
     return true;
   }

--- a/Detectors/ZDC/simulation/src/Detector.cxx
+++ b/Detectors/ZDC/simulation/src/Detector.cxx
@@ -369,9 +369,9 @@ Bool_t Detector::ProcessHits(FairVolume* v)
     mCurrentHitsIndices[detector - 1][sector] = mHits->size() - 1;
 
     mXImpact = xImp;
-    printf("### NEW HIT CREATED in vol %d %d for track %d (mother: %d) \t E %f  light %1.0f %1.0f\n",
-      //detector, sector, trackn, stack->GetCurrentTrack()->GetMother(0), eDep, mTotLightPMC, mTotLightPMQ);
-      detector, sector, trackn, stack->GetCurrentTrack()->GetFirstMother(), eDep, mTotLightPMC, mTotLightPMQ);
+    printf("### NEW HIT CREATED in vol %d %d for track %d (mother: %d) \t light %1.0f %1.0f\n",
+      //detector, sector, trackn, stack->GetCurrentTrack()->GetMother(0), mTotLightPMC, mTotLightPMQ);
+      detector, sector, trackn, stack->GetCurrentTrack()->GetFirstMother(), mTotLightPMC, mTotLightPMQ);
     return true;
 
   } else {
@@ -384,14 +384,13 @@ Bool_t Detector::ProcessHits(FairVolume* v)
       mTotLightPMQ += nphe;
     }
     float incenloss = curHit.GetEnergyLoss() + eDep;
-    //if (eDep > 0 || nphe > 0) {
     if (nphe > 0) {
       curHit.SetEnergyLoss(incenloss);
       curHit.setPMCLightYield(mTotLightPMC);
       curHit.setPMQLightYield(mTotLightPMQ);
-      printf("  >>> Hit updated in vol %d %d  for track %d (mother: %d) \t E %f  light %1.0f %1.0f \n",
-        detector, sector, trackn, stack->GetCurrentTrack()->GetFirstMother(), incenloss, mTotLightPMC, mTotLightPMQ);
-        //detector, sector, trackn, stack->GetCurrentTrack()->GetMother(0), incenloss, mTotLightPMC, mTotLightPMQ);
+      printf("  >>> Hit updated in vol %d %d  for track %d (mother: %d) \t light %1.0f %1.0f \n",
+        detector, sector, trackn, stack->GetCurrentTrack()->GetFirstMother(), mTotLightPMC, mTotLightPMQ);
+        //detector, sector, trackn, stack->GetCurrentTrack()->GetMother(0), mTotLightPMC, mTotLightPMQ);
     }
     return true;
   }
@@ -400,7 +399,8 @@ Bool_t Detector::ProcessHits(FairVolume* v)
 
 //_____________________________________________________________________________
 o2::zdc::Hit* Detector::addHit(Int_t trackID, Int_t parentID, Int_t sFlag, Float_t primaryEnergy, Int_t detID,
-                               Int_t secID, Vector3D<float> pos, Vector3D<float> mom, Float_t tof, Vector3D<float> xImpact, Double_t energyloss, Int_t nphePMC, Int_t nphePMQ)
+                               Int_t secID, Vector3D<float> pos, Vector3D<float> mom, Float_t tof, Vector3D<float> xImpact,
+                               Double_t energyloss, Int_t nphePMC, Int_t nphePMQ)
 {
   LOG(DEBUG4) << "Adding hit for track " << trackID << " X (" << pos.X() << ", " << pos.Y() << ", "
               << pos.Z() << ") P (" << mom.X() << ", " << mom.Y() << ", " << mom.Z() << ")  Ekin "


### PR DESCRIPTION
Changes introduced in the commit:
- materials for which the cut are applied have been fixed (remnants from AliRoot were left)
- in ProcessHit the hits are now correctly summed per PMT: the number of produced phototelectrons is obtained by adding the current no. of generated phe to the correct hit (the one generated in the same detector/sector)
