### PR TITLE
Remove workaround for storing TPC cluster indices

### DIFF
--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/TrackTPC.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/TrackTPC.h
@@ -25,18 +25,7 @@ namespace tpc
 /// \class TrackTPC
 /// This is the definition of the TPC Track Object
 
-/* 
-   Currently the RootTreeWriter does not support vector<trivial_type> branches, 
-   see https://github.com/AliceO2Group/AliceO2/pull/2645
-   Therefore, at the moment we have to wrap trivial_type to struct and generate streamer 
-   for it.
-   Once the RootTreeWriter is fixed, this struct should be eliminated
-*/
-struct TPCClRefElem {
-  uint32_t v = 0;
-  operator uint32_t() const { return v; }
-  ClassDefNV(TPCClRefElem, 1);
-};
+using TPCClRefElem = uint32_t;
 
 class TrackTPC : public o2::track::TrackParCov
 {
@@ -86,7 +75,6 @@ class TrackTPC : public o2::track::TrackParCov
   int getNClusterReferences() const { return getNClusters(); }
   void setClusterRef(uint32_t entry, uint16_t ncl) { mClustersReference.set(entry, ncl); }
 
-  // TODO Temporary solution, see disclaimer about TPCClRefElem. Later will be changed to uint32_t
   void getClusterReference(gsl::span<const o2::tpc::TPCClRefElem> clinfo, int nCluster,
                            uint8_t& sectorIndex, uint8_t& rowIndex, uint32_t& clusterIndex) const
   {
@@ -102,7 +90,6 @@ class TrackTPC : public o2::track::TrackParCov
     rowIndex = srIndexArr[nCluster + mClustersReference.getEntries()];
   }
 
-  // TODO Temporary solution, see disclaimer about TPCClRefElem. Later will be changed to uint32_t
   const o2::tpc::ClusterNative& getCluster(gsl::span<const o2::tpc::TPCClRefElem> clinfo, int nCluster,
                                            const o2::tpc::ClusterNativeAccess& clusters, uint8_t& sectorIndex, uint8_t& rowIndex) const
   {
@@ -111,7 +98,6 @@ class TrackTPC : public o2::track::TrackParCov
     return (clusters.clusters[sectorIndex][rowIndex][clusterIndex]);
   }
 
-  // TODO Temporary solution, see disclaimer about TPCClRefElem. Later will be changed to uint32_t
   const o2::tpc::ClusterNative& getCluster(gsl::span<const o2::tpc::TPCClRefElem> clinfo, int nCluster,
                                            const o2::tpc::ClusterNativeAccess& clusters) const
   {

--- a/DataFormats/Detectors/TPC/src/DataFormatsTPCLinkDef.h
+++ b/DataFormats/Detectors/TPC/src/DataFormatsTPCLinkDef.h
@@ -37,8 +37,4 @@
 #pragma link C++ class o2::tpc::CompressedClustersPtrs_helper < o2::tpc::CompressedClustersCounters> + ;
 #pragma link C++ class o2::tpc::CompressedClusters + ;
 
-// TODO Temporary solution, see disclaimer about TPCClRefElem in the TrackTPC.h
-#pragma link C++ class o2::tpc::TPCClRefElem + ;
-#pragma link C++ class std::vector < o2::tpc::TPCClRefElem> + ;
-
 #endif

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
@@ -238,7 +238,6 @@ class MatchTPCITS
   }
 
   ///< set input TPC tracks cluster indices received via DPL
-  // TODO Temporary solution, see disclaimer about TPCClRefElem in TrackTPC. Later should be changed to uint32_t
   void setTPCTrackClusIdxInp(const gsl::span<const o2::tpc::TPCClRefElem> inp)
   {
     assertDPLIO(true);
@@ -562,7 +561,6 @@ class MatchTPCITS
   std::vector<o2::tpc::TrackTPC>* mTPCTracksArrayPtr = nullptr; ///< input TPC tracks from tree
   gsl::span<const o2::tpc::TrackTPC> mTPCTracksArrayInp;        ///< input TPC tracks span
 
-  // TODO Temporary solution, see disclaimer about TPCClRefElem in TrackTPC. Later will be changed to uint32_t
   std::vector<o2::tpc::TPCClRefElem>* mTPCTrackClusIdxPtr = nullptr; ///< input TPC track cluster indices from tree
   gsl::span<const o2::tpc::TPCClRefElem> mTPCTrackClusIdxInp;        ///< input TPC track cluster indices span from DPL
 

--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -713,7 +713,6 @@ bool MatchTPCITS::loadTPCTracksNextChunk()
       continue;
     }
     mTPCTracksArrayInp = gsl::span<const o2::tpc::TrackTPC>(mTPCTracksArrayPtr->data(), mTPCTracksArrayPtr->size());
-    // TODO Temporary solution, see disclaimer about TPCClRefElem in TrackTPC. Later should be changed to uint32_t
     mTPCTrackClusIdxInp = gsl::span<const o2::tpc::TPCClRefElem>(mTPCTrackClusIdxPtr->data(), mTPCTrackClusIdxPtr->size());
 
     mTimerIO.Stop();

--- a/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
@@ -76,7 +76,6 @@ void TPCITSMatchingDPL::run(ProcessingContext& pc)
   const auto clusITS = pc.inputs().get<gsl::span<o2::itsmft::Cluster>>("clusITS");
   const auto clusITSROF = pc.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("clusITSROF");
   const auto tracksTPC = pc.inputs().get<gsl::span<o2::tpc::TrackTPC>>("trackTPC");
-  // TODO Temporary solution, see disclaimer about TPCClRefElem in TrackTPC. Later should be changed to uint32_t
   const auto tracksTPCClRefs = pc.inputs().get<gsl::span<o2::tpc::TPCClRefElem>>("trackTPCClRefs");
 
   //---------------------------->> TPC Clusters loading >>------------------------------------------

--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackInterpolation.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackInterpolation.h
@@ -223,7 +223,6 @@ class TrackInterpolation
   TTree* mTreeTOFClusters{nullptr};                                                                              ///< input tree for TOF clusters
   std::vector<o2::dataformats::TrackTPCITS>* mITSTPCTrackVecInput{nullptr};                                      ///< input vector with ITS-TPC matched tracks
   std::vector<TrackTPC>* mTPCTrackVecInput{nullptr};                                                             ///< input vector with TPC tracks
-  // TODO Temporary solution, see disclaimer about TPCClRefElem in TrackTPC. Later will be changed to uint32_t
   std::vector<TPCClRefElem>* mTPCTrackClIdxVecInput{nullptr};                                                    ///< input vector with TPC tracks cluster indicies
   std::vector<o2::its::TrackITS>* mITSTrackVecInput{nullptr};                                                    ///< input vector with ITS tracks
   std::vector<o2::itsmft::Cluster>* mITSClusterVecInput{nullptr};                                                ///< input vector with ITS clusters

--- a/Detectors/TPC/reconstruction/test/testGPUCATracking.cxx
+++ b/Detectors/TPC/reconstruction/test/testGPUCATracking.cxx
@@ -95,9 +95,8 @@ BOOST_AUTO_TEST_CASE(CATracking_test1)
   std::vector<TrackTPC> tracks;
   ptrs.clusters = clusters.get();
   ptrs.outputTracks = &tracks;
-  // TODO Temporary solution, see disclaimer about TPCClRefElem in TrackTPC. Later will be changed to uint32_t and remove the cast
   std::vector<TPCClRefElem> trackClusRefs;
-  ptrs.outputClusRefs = reinterpret_cast<std::vector<uint32_t>*>(&trackClusRefs);
+  ptrs.outputClusRefs = &trackClusRefs;
 
   int retVal = tracker.runTracking(&ptrs);
   BOOST_CHECK_EQUAL(retVal, 0);

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TrackReaderSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TrackReaderSpec.h
@@ -42,7 +42,6 @@ class TrackReader : public Task
   void accumulate();
 
   std::vector<o2::tpc::TrackTPC>*mTracksInp = nullptr, mTracksOut;
-  // TODO Temporary solution, see disclaimer about TPCClRefElem in TrackTOC. Later will be changed to uint32_t
   std::vector<o2::tpc::TPCClRefElem>*mCluRefVecInp = nullptr, mCluRefVecOut;
   o2::dataformats::MCTruthContainer<o2::MCCompLabel>*mMCTruthInp = nullptr, mMCTruthOut;
 

--- a/Detectors/TPC/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/TPC/workflow/src/RecoWorkflow.cxx
@@ -355,8 +355,6 @@ framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors, std::vec
     //branch definitions for RootTreeWriter spec
     using TrackOutputType = std::vector<o2::tpc::TrackTPC>;
 
-    // Temporary solution, see disclaimer about TPCClRefElem in the TrackTPC.h
-    //    using ClusRefsOutputType = std::vector<uint32_t>;
     using ClusRefsOutputType = std::vector<o2::tpc::TPCClRefElem>;
 
     using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;

--- a/macro/runCATrackingClusterNative.C
+++ b/macro/runCATrackingClusterNative.C
@@ -99,7 +99,6 @@ int runCATrackingClusterNative(TString inputFile, TString outputFile)
     ClusterNativeHelper::createClusterNativeIndex(clusterBuffer, cont, doMC ? &clusterMCBuffer : nullptr, doMC ? &contMC : nullptr);
 
   vector<TrackTPC> tracks;
-  // TODO Temporary solution, see disclaimer about TPCClRefElem in TrackTPC. Later will be changed to uint32_t
   vector<TPCClRefElem> trackClusRefs;
   MCLabelContainer tracksMC;
 
@@ -113,8 +112,7 @@ int runCATrackingClusterNative(TString inputFile, TString outputFile)
   GPUO2InterfaceIOPtrs ptrs;
   ptrs.clusters = clusters.get();
   ptrs.outputTracks = &tracks;
-  // TODO Temporary solution, see disclaimer about TPCClRefElem in TrackTPC. Later will remove the cast
-  ptrs.outputClusRefs = reinterpret_cast<vector<uint32_t>*>(&trackClusRefs);
+  ptrs.outputClusRefs = &trackClusRefs;
   ptrs.outputTracksMCTruth = doMC ? &tracksMC : nullptr;
   if (tracker.runTracking(&ptrs) == 0) {
     printf("\tFound %d tracks\n", (int)tracks.size());


### PR DESCRIPTION
Since the RootTreeWriter is now able to accept vector<basic_types>, we don't need anymore to wrap
the uint32_t to struct with dictionary to store cluster indices.