### PR TITLE
Fixing DPL test workflows to use reference variable

### DIFF
--- a/Framework/Core/test/test_CCDBFetcher.cxx
+++ b/Framework/Core/test/test_CCDBFetcher.cxx
@@ -34,7 +34,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
             LOG(ERROR) << "Wrong size for condition payload (expected " << 1024 << ", found " << header->payloadSize;
           }
           header->payloadSize;
-          auto aData = outputs.make<int>(Output{"TST", "A1", 0}, 1);
+          auto& aData = outputs.make<int>(Output{"TST", "A1", 0}, 1);
           control.readyToQuit(QuitRequest::All);
         })},
       Options{

--- a/Framework/Core/test/test_CallbackService.cxx
+++ b/Framework/Core/test/test_CallbackService.cxx
@@ -34,7 +34,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
      AlgorithmSpec{
        [](ProcessingContext& ctx) {
          std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-         auto out = ctx.outputs().make<int>(OutputRef{"test", 0});
+         auto& out = ctx.outputs().make<int>(OutputRef{"test", 0});
        }}},
     {"dest",
      Inputs{

--- a/Framework/Core/test/test_CustomGUIGL.cxx
+++ b/Framework/Core/test/test_CustomGUIGL.cxx
@@ -36,7 +36,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
      AlgorithmSpec{
        adaptStateless([](DataAllocator& outputs) {
          std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-         auto out = outputs.make<int>(OutputRef{"test", 0});
+         auto& out = outputs.make<int>(OutputRef{"test", 0});
        })}},
     {"dest",
      Inputs{

--- a/Framework/Core/test/test_CustomGUISokol.cxx
+++ b/Framework/Core/test/test_CustomGUISokol.cxx
@@ -38,7 +38,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
      AlgorithmSpec{
        adaptStateless([](DataAllocator& outputs) {
          std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-         auto out = outputs.make<int>(OutputRef{"test", 0});
+         auto& out = outputs.make<int>(OutputRef{"test", 0});
        })}},
     {"dest",
      Inputs{

--- a/Framework/Core/test/test_DanglingInputs.cxx
+++ b/Framework/Core/test/test_DanglingInputs.cxx
@@ -22,7 +22,7 @@ AlgorithmSpec simplePipe(std::string const& what, int minDelay)
   return AlgorithmSpec{[what, minDelay](InitContext& ic) {
     srand(getpid());
     return [what, minDelay](ProcessingContext& ctx) {
-      auto bData = ctx.outputs().make<int>(OutputRef{what}, 1);
+      auto& bData = ctx.outputs().make<int>(OutputRef{what}, 1);
     };
   }};
 }
@@ -38,8 +38,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& specs)
      AlgorithmSpec{
        [](ProcessingContext& ctx) {
          std::this_thread::sleep_for(std::chrono::milliseconds((rand() % 2 + 1) * 1000));
-         auto aData = ctx.outputs().make<int>(OutputRef{"a1"}, 1);
-         auto bData = ctx.outputs().make<int>(OutputRef{"a2"}, 1);
+         auto& aData = ctx.outputs().make<int>(OutputRef{"a1"}, 1);
+         auto& bData = ctx.outputs().make<int>(OutputRef{"a2"}, 1);
        }}},
     {"B",
      {InputSpec{"x", "TST", "A1"}},

--- a/Framework/Core/test/test_DanglingOutputs.cxx
+++ b/Framework/Core/test/test_DanglingOutputs.cxx
@@ -23,7 +23,7 @@ AlgorithmSpec simplePipe(std::string const& what, int minDelay)
   return AlgorithmSpec{[what, minDelay](InitContext& ic) {
     srand(getpid());
     return [what, minDelay](ProcessingContext& ctx) {
-      auto bData = ctx.outputs().make<int>(OutputRef{what}, 1);
+      auto& bData = ctx.outputs().make<int>(OutputRef{what}, 1);
     };
   }};
 }
@@ -39,8 +39,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& specs)
      AlgorithmSpec{
        [](ProcessingContext& ctx) {
          std::this_thread::sleep_for(std::chrono::milliseconds((rand() % 2 + 1) * 1000));
-         auto aData1 = ctx.outputs().make<int>(OutputRef{"a1"}, 1);
-         auto aData2 = ctx.outputs().make<int>(Output{"TST", "A2"}, 1);
+         auto& aData1 = ctx.outputs().make<int>(OutputRef{"a1"}, 1);
+         auto& aData2 = ctx.outputs().make<int>(Output{"TST", "A2"}, 1);
          ctx.services().get<ControlService>().endOfStream();
        }}},
     {"B",

--- a/Framework/Core/test/test_Forwarding.cxx
+++ b/Framework/Core/test/test_Forwarding.cxx
@@ -25,7 +25,7 @@ AlgorithmSpec simplePipe(std::string const& what, int minDelay)
   return AlgorithmSpec{[what, minDelay](InitContext& ic) {
     srand(getpid());
     return [what, minDelay](ProcessingContext& ctx) {
-      auto bData = ctx.outputs().make<int>(OutputRef{what}, 1);
+      auto& bData = ctx.outputs().make<int>(OutputRef{what}, 1);
     };
   }};
 }
@@ -39,7 +39,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& specs)
      {OutputSpec{{"a1"}, "TST", "A1"}},
      AlgorithmSpec{
        [](ProcessingContext& ctx) {
-         auto aData = ctx.outputs().make<int>(OutputRef{"a1"}, 1);
+         auto& aData = ctx.outputs().make<int>(OutputRef{"a1"}, 1);
          ctx.services().get<ControlService>().endOfStream();
          ctx.services().get<ControlService>().readyToQuit(QuitRequest::Me);
        }}},

--- a/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
+++ b/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
@@ -31,7 +31,7 @@ using namespace o2::framework;
 AlgorithmSpec simplePipe(o2::header::DataDescription what)
 {
   return AlgorithmSpec{[what](ProcessingContext& ctx) {
-    auto bData = ctx.outputs().make<int>(Output{"TST", what, 0}, 1);
+    auto& bData = ctx.outputs().make<int>(Output{"TST", what, 0}, 1);
   }};
 }
 
@@ -43,8 +43,8 @@ WorkflowSpec defineDataProcessing()
                    OutputSpec{"TST", "A2"}},
            AlgorithmSpec{[](ProcessingContext& ctx) {
              std::this_thread::sleep_for(std::chrono::seconds(1));
-             auto aData = ctx.outputs().make<int>(Output{"TST", "A1", 0}, 1);
-             auto bData = ctx.outputs().make<int>(Output{"TST", "A2", 0}, 1);
+             auto& aData = ctx.outputs().make<int>(Output{"TST", "A1", 0}, 1);
+             auto& bData = ctx.outputs().make<int>(Output{"TST", "A2", 0}, 1);
            }}},
           {"B",
            {InputSpec{"x", "TST", "A1"}},

--- a/Framework/Core/test/test_GenericSource.cxx
+++ b/Framework/Core/test/test_GenericSource.cxx
@@ -27,7 +27,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& specs)
            ServiceRegistry& services,
            DataAllocator& allocator) {
           std::this_thread::sleep_for(std::chrono::seconds(1));
-          auto aData = allocator.make<int>(Output{"TST", "A1", 0}, 1);
+          auto& aData = allocator.make<int>(Output{"TST", "A1", 0}, 1);
         }},
       Options{{"test-option", VariantType::String, "test", "A test option"}},
     }};

--- a/Framework/Core/test/test_Parallel.cxx
+++ b/Framework/Core/test/test_Parallel.cxx
@@ -111,7 +111,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
     LOG(DEBUG) << "DataSampler sends data from subSpec: " << matcher.subSpec;
 
     const auto* inputHeader = o2::header::get<o2::header::DataHeader*>(input.header);
-    auto output = ctx.outputs().make<char>(description, inputHeader->size());
+    auto& output = ctx.outputs().make<char>(description, inputHeader->size());
 
     //todo: use some std function or adopt(), when it is available for POD data
     const char* input_ptr = input.payload;
@@ -177,7 +177,7 @@ void someDataProducerAlgorithm(ProcessingContext& ctx)
   size_t index = ctx.services().get<ParallelContext>().index1D();
   // Creates a new message of size collectionChunkSize which
   // has "TPC" as data origin and "CLUSTERS" as data description.
-  auto tpcClusters = ctx.outputs().make<FakeCluster>(
+  auto& tpcClusters = ctx.outputs().make<FakeCluster>(
     Output{"TPC", "CLUSTERS", static_cast<o2::header::DataHeader::SubSpecificationType>(index)}, collectionChunkSize);
   int i = 0;
 
@@ -198,7 +198,7 @@ void someProcessingStageAlgorithm(ProcessingContext& ctx)
 
   const FakeCluster* inputDataTpc = reinterpret_cast<const FakeCluster*>(ctx.inputs().get("dataTPC").payload);
 
-  auto processedTpcClusters = ctx.outputs().make<FakeCluster>(
+  auto& processedTpcClusters = ctx.outputs().make<FakeCluster>(
     Output{"TPC", "CLUSTERS_P", static_cast<o2::header::DataHeader::SubSpecificationType>(index)},
     collectionChunkSize);
 

--- a/Framework/Core/test/test_ParallelPipeline.cxx
+++ b/Framework/Core/test/test_ParallelPipeline.cxx
@@ -49,7 +49,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
          LOG(DEBUG) << "instance " << parallelContext.index1D() << " of " << parallelContext.index1DSize() << ": "
                     << *input.spec << ": " << *((int*)input.payload);
          auto const* dataheader = DataRefUtils::getHeader<o2::header::DataHeader*>(input);
-         //auto data& = ctx.outputs().make<int>(OutputRef{"output", dataheader->subSpecification});
+         //auto& data = ctx.outputs().make<int>(OutputRef{"output", dataheader->subSpecification});
          auto& data = ctx.outputs().make<int>(Output{"TST", "PREPROC", dataheader->subSpecification, Lifetime::Timeframe});
          ASSERT_ERROR(ctx.inputs().get<int>(input.spec->binding.c_str()) == parallelContext.index1D());
          data = parallelContext.index1D();
@@ -73,7 +73,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
          //auto& data = ctx.outputs().make<int>(OutputRef{"output", dataheader->subSpecification});
          auto& data = ctx.outputs().make<int>(Output{"TST", "DATA", dataheader->subSpecification, Lifetime::Timeframe});
          data = ctx.inputs().get<int>(input.spec->binding.c_str());
-         //auto meta& = ctx.outputs().make<int>(OutputRef{"metadt", dataheader->subSpecification});
+         //auto& meta = ctx.outputs().make<int>(OutputRef{"metadt", dataheader->subSpecification});
          auto& meta = ctx.outputs().make<int>(Output{"TST", "META", dataheader->subSpecification, Lifetime::Timeframe});
          meta = dataheader->subSpecification;
        }

--- a/Framework/Core/test/test_ParallelProducer.cxx
+++ b/Framework/Core/test/test_ParallelProducer.cxx
@@ -42,7 +42,7 @@ DataProcessorSpec templateProducer()
                                // Create a single output.
                                size_t index = ctx.services().get<ParallelContext>().index1D();
                                std::this_thread::sleep_for(std::chrono::seconds(1));
-                               auto aData = ctx.outputs().make<int>(
+                               auto& aData = ctx.outputs().make<int>(
                                  Output{"TST", "A", static_cast<o2::header::DataHeader::SubSpecificationType>(index)}, 1);
                                ctx.services().get<ControlService>().readyToQuit(QuitRequest::All);
                              };

--- a/Framework/Core/test/test_SimpleDataProcessingDevice01.cxx
+++ b/Framework/Core/test/test_SimpleDataProcessingDevice01.cxx
@@ -43,7 +43,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
         service.device()->WaitFor(std::chrono::milliseconds(1000));
         // Creates a new message of size 1000 which
         // has "TPC" as data origin and "CLUSTERS" as data description.
-        auto tpcClusters = outputs.make<FakeCluster>(Output{"TPC", "CLUSTERS", 0}, 1000);
+        auto& tpcClusters = outputs.make<FakeCluster>(Output{"TPC", "CLUSTERS", 0}, 1000);
         int i = 0;
 
         for (auto& cluster : tpcClusters) {
@@ -55,7 +55,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
           i++;
         }
 
-        auto itsClusters = outputs.make<FakeCluster>(Output{"ITS", "CLUSTERS", 0}, 1000);
+        auto& itsClusters = outputs.make<FakeCluster>(Output{"ITS", "CLUSTERS", 0}, 1000);
         i = 0;
         for (auto& cluster : itsClusters) {
           assert(i < 1000);

--- a/Framework/Core/test/test_SingleDataSource.cxx
+++ b/Framework/Core/test/test_SingleDataSource.cxx
@@ -27,7 +27,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
       AlgorithmSpec{
         [](ProcessingContext& ctx) {
           std::this_thread::sleep_for(std::chrono::seconds(1));
-          auto aData = ctx.outputs().make<int>(Output{"TST", "A1", 0}, 1);
+          auto& aData = ctx.outputs().make<int>(Output{"TST", "A1", 0}, 1);
           ctx.services().get<ControlService>().readyToQuit(QuitRequest::All);
         }},
       Options{{"test-option", VariantType::String, "test", {"A test option"}}},

--- a/Framework/Core/test/test_Task.cxx
+++ b/Framework/Core/test/test_Task.cxx
@@ -32,7 +32,7 @@ class ATask : public Task
   }
   void run(ProcessingContext& pc) final
   {
-    auto result = pc.outputs().make<int>({"dummy"}, 1);
+    auto& result = pc.outputs().make<int>({"dummy"}, 1);
     result[0] = mSomeState;
     pc.services().get<o2::monitoring::Monitoring>().send({result[0], "output"});
     pc.services().get<ControlService>().endOfStream();

--- a/Framework/Core/test/test_TimePipeline.cxx
+++ b/Framework/Core/test/test_TimePipeline.cxx
@@ -68,7 +68,7 @@ void someDataProducerAlgorithm(ProcessingContext& ctx)
   std::this_thread::sleep_for(std::chrono::seconds(1));
   // Creates a new message of size collectionChunkSize which
   // has "TPC" as data origin and "CLUSTERS" as data description.
-  auto tpcClusters = ctx.outputs().make<FakeCluster>(Output{"TPC", "CLUSTERS", index}, collectionChunkSize);
+  auto& tpcClusters = ctx.outputs().make<FakeCluster>(Output{"TPC", "CLUSTERS", index}, collectionChunkSize);
   int i = 0;
 
   for (auto& cluster : tpcClusters) {

--- a/Framework/TestWorkflows/src/dataSamplingParallel.cxx
+++ b/Framework/TestWorkflows/src/dataSamplingParallel.cxx
@@ -144,7 +144,7 @@ void someDataProducerAlgorithm(ProcessingContext& ctx)
   std::this_thread::sleep_for(std::chrono::seconds(1));
   // Creates a new message of size collectionChunkSize which
   // has "TPC" as data origin and "CLUSTERS" as data description.
-  auto tpcClusters = ctx.outputs().make<FakeCluster>(
+  auto& tpcClusters = ctx.outputs().make<FakeCluster>(
     Output{"TPC", "CLUSTERS", static_cast<o2::header::DataHeader::SubSpecificationType>(index)}, collectionChunkSize);
   int i = 0;
 
@@ -163,7 +163,7 @@ void someProcessingStageAlgorithm(ProcessingContext& ctx)
   size_t index = ctx.services().get<ParallelContext>().index1D();
 
   const FakeCluster* inputDataTpc = reinterpret_cast<const FakeCluster*>(ctx.inputs().get("dataTPC").payload);
-  auto processedTpcClusters = ctx.outputs().make<FakeCluster>(
+  auto& processedTpcClusters = ctx.outputs().make<FakeCluster>(
     Output{"TPC", "CLUSTERS_P", static_cast<o2::header::DataHeader::SubSpecificationType>(index)},
     collectionChunkSize);
 

--- a/Framework/TestWorkflows/src/dataSamplingPodAndRoot.cxx
+++ b/Framework/TestWorkflows/src/dataSamplingPodAndRoot.cxx
@@ -226,7 +226,7 @@ void someDataProducerAlgorithm(ProcessingContext& ctx)
   std::this_thread::sleep_for(std::chrono::seconds(1));
   // Creates a new message of size collectionChunkSize which
   // has "TPC" as data origin and "CLUSTERS" as data description.
-  auto tpcClusters = ctx.outputs().make<FakeCluster>(Output{"TPC", "CLUSTERS", 0}, collectionChunkSize);
+  auto& tpcClusters = ctx.outputs().make<FakeCluster>(Output{"TPC", "CLUSTERS", 0}, collectionChunkSize);
   int i = 0;
 
   for (auto& cluster : tpcClusters) {
@@ -238,7 +238,7 @@ void someDataProducerAlgorithm(ProcessingContext& ctx)
     i++;
   }
 
-  auto itsClusters = ctx.outputs().make<FakeCluster>(Output{"ITS", "CLUSTERS", 0}, collectionChunkSize);
+  auto& itsClusters = ctx.outputs().make<FakeCluster>(Output{"ITS", "CLUSTERS", 0}, collectionChunkSize);
   i = 0;
   for (auto& cluster : itsClusters) {
     assert(i < collectionChunkSize);

--- a/Framework/TestWorkflows/src/dataSamplingTimePipeline.cxx
+++ b/Framework/TestWorkflows/src/dataSamplingTimePipeline.cxx
@@ -131,7 +131,7 @@ void someDataProducerAlgorithm(ProcessingContext& ctx)
   std::this_thread::sleep_for(std::chrono::seconds(1));
   // Creates a new message of size collectionChunkSize which
   // has "TPC" as data origin and "CLUSTERS" as data description.
-  auto tpcClusters = ctx.outputs().make<FakeCluster>(
+  auto& tpcClusters = ctx.outputs().make<FakeCluster>(
     Output{"TPC", "CLUSTERS", static_cast<o2::header::DataHeader::SubSpecificationType>(index)}, collectionChunkSize);
   int i = 0;
 
@@ -151,7 +151,7 @@ void someProcessingStageAlgorithm(ProcessingContext& ctx)
 
   const FakeCluster* inputDataTpc = reinterpret_cast<const FakeCluster*>(ctx.inputs().get("dataTPC").payload);
 
-  auto processedTpcClusters = ctx.outputs().make<FakeCluster>(
+  auto& processedTpcClusters = ctx.outputs().make<FakeCluster>(
     Output{"TPC", "CLUSTERS_P", static_cast<o2::header::DataHeader::SubSpecificationType>(index)},
     collectionChunkSize);
 

--- a/Framework/TestWorkflows/src/o2DataQueryWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DataQueryWorkflow.cxx
@@ -25,7 +25,7 @@ AlgorithmSpec simplePipe(std::string const& what, o2::header::DataHeader::SubSpe
     srand(getpid());
     return [what, minDelay, subSpec](ProcessingContext& ctx) {
       std::this_thread::sleep_for(std::chrono::seconds((rand() % 5) + minDelay));
-      auto bData = ctx.outputs().make<int>(OutputRef{what, subSpec}, 1);
+      auto& bData = ctx.outputs().make<int>(OutputRef{what, subSpec}, 1);
       bData[0] = subSpec;
     };
   }};
@@ -43,8 +43,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& specs)
      AlgorithmSpec{
        [](ProcessingContext& ctx) {
          std::this_thread::sleep_for(std::chrono::seconds(rand() % 2));
-         auto aData = ctx.outputs().make<int>(OutputRef{"a1"}, 1);
-         auto bData = ctx.outputs().make<int>(OutputRef{"a2"}, 1);
+         auto& aData = ctx.outputs().make<int>(OutputRef{"a1"}, 1);
+         auto& bData = ctx.outputs().make<int>(OutputRef{"a2"}, 1);
        }}},
     {"B",
      select("x:TST/A1/0"), // This will match TST/A1/0 as <origin>/<description>/<subspec> and bind it to x

--- a/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
@@ -49,7 +49,7 @@ AlgorithmSpec simplePipe(std::string const& what, int minDelay)
     srand(getpid());
     return adaptStateless([what, minDelay](DataAllocator& outputs) {
       std::this_thread::sleep_for(std::chrono::seconds((rand() % 5) + minDelay));
-      auto bData = outputs.make<int>(OutputRef{what}, 1);
+      auto& bData = outputs.make<int>(OutputRef{what}, 1);
     });
   })};
 }
@@ -65,8 +65,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& specs)
      AlgorithmSpec{adaptStateless(
        [](DataAllocator& outputs, InfoLogger& logger) {
          std::this_thread::sleep_for(std::chrono::seconds(rand() % 2));
-         auto aData = outputs.make<int>(OutputRef{"a1"}, 1);
-         auto bData = outputs.make<int>(OutputRef{"a2"}, 1);
+         auto& aData = outputs.make<int>(OutputRef{"a1"}, 1);
+         auto& bData = outputs.make<int>(OutputRef{"a2"}, 1);
          logger.log("This goes to infologger");
        })}},
     {"B",

--- a/Framework/TestWorkflows/src/o2DummyWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DummyWorkflow.cxx
@@ -45,7 +45,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
         std::this_thread::sleep_for(std::chrono::seconds(1));
         // Creates a new message of size 1000 which
         // has "TPC" as data origin and "CLUSTERS" as data description.
-        auto tpcClusters = ctx.outputs().make<FakeCluster>(OutputRef{"tpc"}, 1000);
+        auto& tpcClusters = ctx.outputs().make<FakeCluster>(OutputRef{"tpc"}, 1000);
         int i = 0;
 
         for (auto& cluster : tpcClusters) {
@@ -59,7 +59,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
           i++;
         }
 
-        auto itsClusters = ctx.outputs().make<FakeCluster>(OutputRef{"its"}, 1000);
+        auto& itsClusters = ctx.outputs().make<FakeCluster>(OutputRef{"its"}, 1000);
         i = 0;
         for (auto& cluster : itsClusters) {
           assert(i < 1000);
@@ -77,7 +77,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
     {InputSpec{"clusters", "TPC", "CLUSTERS"}},
     {OutputSpec{{"summary"}, "TPC", "SUMMARY"}},
     AlgorithmSpec{[](ProcessingContext& ctx) {
-      auto tpcSummary = ctx.outputs().make<Summary>(OutputRef{"summary"}, 1);
+      auto& tpcSummary = ctx.outputs().make<Summary>(OutputRef{"summary"}, 1);
       tpcSummary.at(0).inputCount = ctx.inputs().size();
     }},
     {ConfigParamSpec{"some-cut", VariantType::Float, 1.0f, {"some cut"}}},
@@ -90,7 +90,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
       OutputSpec{{"summary"}, "ITS", "SUMMARY"},
     },
     AlgorithmSpec{[](ProcessingContext& ctx) {
-      auto itsSummary = ctx.outputs().make<Summary>(OutputRef{"summary"}, 1);
+      auto& itsSummary = ctx.outputs().make<Summary>(OutputRef{"summary"}, 1);
       itsSummary.at(0).inputCount = ctx.inputs().size();
     }},
     {ConfigParamSpec{"some-cut", VariantType::Float, 1.0f, {"some cut"}}},

--- a/Framework/TestWorkflows/src/o2ParallelWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2ParallelWorkflow.cxx
@@ -56,7 +56,7 @@ DataProcessorSpec templateProcessor()
                              return [](ProcessingContext& ctx) {
                                // Create a single output.
                                size_t index = ctx.services().get<ParallelContext>().index1D();
-                               auto aData = ctx.outputs().make<int>(
+                               auto& aData = ctx.outputs().make<int>(
                                  Output{"TST", "P", static_cast<o2::header::DataHeader::SubSpecificationType>(index)}, 1);
                                std::this_thread::sleep_for(std::chrono::seconds(rand() % 5));
                              };

--- a/Framework/TestWorkflows/src/o2SyncReconstructionDummy.cxx
+++ b/Framework/TestWorkflows/src/o2SyncReconstructionDummy.cxx
@@ -23,7 +23,7 @@ AlgorithmSpec simplePipe(std::string const& what)
     return [what, delay, messageSize](ProcessingContext& ctx) {
       auto tStart = std::chrono::high_resolution_clock::now();
       auto tEnd = std::chrono::high_resolution_clock::now();
-      auto msg = ctx.outputs().make<char>(OutputRef{what}, messageSize);
+      auto& msg = ctx.outputs().make<char>(OutputRef{what}, messageSize);
       while (std::chrono::duration_cast<std::chrono::seconds>(tEnd - tStart) < std::chrono::seconds(delay)) {
         for (size_t i = 0; i < messageSize; ++i) {
           msg[i] = 0;

--- a/Framework/TestWorkflows/test/test_MakeDPLObjects.cxx
+++ b/Framework/TestWorkflows/test/test_MakeDPLObjects.cxx
@@ -37,13 +37,13 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
       AlgorithmSpec{
         [](ProcessingContext& ctx) {
           // A new message with 1 XYZ instance in it
-          XYZ& x = ctx.outputs().make<XYZ>(Output{"TST", "POINT", 0});
+          auto& x = ctx.outputs().make<XYZ>(Output{"TST", "POINT", 0});
           // A new message with a gsl::span<XYZ> with 1000 items
-          gsl::span<XYZ> y = ctx.outputs().make<XYZ>(Output{"TST", "POINTS", 0}, 1000);
+          auto& y = ctx.outputs().make<XYZ>(Output{"TST", "POINTS", 0}, 1000);
           y[0] = XYZ{1, 2, 3};
           y[999] = XYZ{1, 2, 3};
           // A new message with a TH1F inside
-          auto h = ctx.outputs().make<TH1F>(Output{"TST", "HISTO"}, "h", "test", 100, -10., 10.);
+          auto& h = ctx.outputs().make<TH1F>(Output{"TST", "HISTO"}, "h", "test", 100, -10., 10.);
           // A snapshot for an std::vector
           std::vector<XYZ> v{1000};
           v[0] = XYZ{1, 2, 3};


### PR DESCRIPTION
Reference variable have to be used to refer to resources created by
DataAllocator::make. Otherwise the variable is simply copied and the data
does not correctly end up in the output.

EDIT:
The examples and tests have been consistently changed even though for the returned
reference to gsl::span (make<messageable>(Output{}, size)) it is also working without
reference because gsl::span provides copy constructor and transfers the underlying
buffer to the copy.
 
TODO: while doing this search and replace, many of the unit test and test workflows
have been found in a need-urgently-maintenace state. Some are not compile at all,
some do not check for data integrity, some are inconststent.

An (incomplete) list:
- o2-testworkflows-datasampling-time-pipeline does not run
- data integrity check should be added basically to all workflows corrected in this
  commit.
- Framework/Core/test/test_Parallel.cxx is not compiled