### PR TITLE
DPL Utils: properly handle some tests

### DIFF
--- a/Framework/Utils/CMakeLists.txt
+++ b/Framework/Utils/CMakeLists.txt
@@ -39,12 +39,14 @@ o2_add_test(DPLBroadcasterMerger
             SOURCES test/test_DPLBroadcasterMerger.cxx src/Utils.cxx
                     test/DPLBroadcasterMerger.cxx src/DPLMerger.cxx
                     src/DPLBroadcaster.cxx
+            NO_BOOST_TEST
             PUBLIC_LINK_LIBRARIES O2::DPLUtils
             COMPONENT_NAME DPLUtils
             LABELS dplutils
             COMMAND_LINE_ARGS ${DPL_WORKFLOW_TESTS_EXTRA_OPTIONS} --run)
 
 o2_add_test(DPLOutput
+            NO_BOOST_TEST
             SOURCES test/test_DPLOutputTest.cxx src/Utils.cxx
                     test/DPLOutputTest.cxx
             PUBLIC_LINK_LIBRARIES O2::DPLUtils
@@ -67,6 +69,7 @@ o2_add_test(RootTreeWriterWorkflow
             COMMAND_LINE_ARGS ${DPL_WORKFLOW_TESTS_EXTRA_OPTIONS} --run)
 
 o2_add_test(RootTreeReader
+            NO_BOOST_TEST
             SOURCES test/test_RootTreeReader.cxx
             PUBLIC_LINK_LIBRARIES O2::DPLUtils
             COMPONENT_NAME DPLUtils

--- a/Framework/Utils/test/DPLBroadcasterMerger.cxx
+++ b/Framework/Utils/test/DPLBroadcasterMerger.cxx
@@ -14,15 +14,14 @@
 #include "DPLBroadcasterMerger.h"
 #include "DPLUtils/Utils.h"
 #include "Framework/DataProcessorSpec.h"
+#include "Framework/ControlService.h"
 #include "random"
 #include "Framework/Logger.h"
 #include <thread>
 
 namespace o2f = o2::framework;
 
-namespace o2
-{
-namespace workflows
+namespace o2::workflows
 {
 
 o2f::Inputs noInputs{};
@@ -44,6 +43,9 @@ o2f::DataProcessorSpec defineGenerator(o2f::OutputSpec usrOutput)
             // Processing context in captured from return on InitCallback
             return [usrOutput_shptr, msgCounter_shptr](o2f::ProcessingContext& ctx) {
               int msgIndex = (*msgCounter_shptr)++;
+              if (msgIndex > 10) {
+                ctx.services().get<framework::ControlService>().endOfStream();
+              }
               LOG(INFO) << ">>> MSG:" << msgIndex;
               std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 

--- a/Framework/Utils/test/DPLBroadcasterMerger.cxx
+++ b/Framework/Utils/test/DPLBroadcasterMerger.cxx
@@ -142,5 +142,4 @@ o2::framework::WorkflowSpec DPLBroadcasterMergerWorkflow()
   return std::move(lspec);
 }
 
-} // namespace workflows
-} // namespace o2
+} // namespace o2::workflows

--- a/Framework/Utils/test/DPLOutputTest.cxx
+++ b/Framework/Utils/test/DPLOutputTest.cxx
@@ -16,12 +16,11 @@
 #include "Framework/DataProcessorSpec.h"
 #include "random"
 #include "Framework/Logger.h"
+#include "Framework/ControlService.h"
 
 namespace o2f = o2::framework;
 
-namespace o2
-{
-namespace workflows
+namespace o2::workflows
 {
 
 o2f::DataProcessorSpec defineTestGenerator()
@@ -39,6 +38,9 @@ o2f::DataProcessorSpec defineTestGenerator()
             // Processing context in captured from return on InitCallback
             return [msgCounter_shptr](o2f::ProcessingContext& ctx) {
               int msgIndex = (*msgCounter_shptr)++;
+              if (msgIndex > 10) {
+                ctx.services().get<framework::ControlService>().endOfStream();
+              }
               LOG(INFO) << ">>> MSG:" << msgIndex << "\n";
 
               LOG(INFO) << ">>> Preparing MSG:" << msgIndex;
@@ -96,5 +98,4 @@ o2::framework::WorkflowSpec DPLOutputTest()
   return std::move(lspec);
 }
 
-} // namespace workflows
-} // namespace o2
+} // namespace o2::workflows

--- a/Framework/Utils/test/test_RootTreeReader.cxx
+++ b/Framework/Utils/test/test_RootTreeReader.cxx
@@ -77,6 +77,9 @@ DataProcessorSpec getSourceSpec()
         // test signature without headers for the rest of the entries
         (++(*reader))(pc);
       }
+      if (reader->getCount() >= kTreeSize) {
+        pc.services().get<ControlService>().endOfStream();
+      }
     };
 
     return processingFct;
@@ -117,7 +120,8 @@ DataProcessorSpec getSinkSpec()
       ASSERT_ERROR(data[idx].get() == 10 * counter + idx);
     }
     if (++counter >= kTreeSize) {
-      pc.services().get<ControlService>().readyToQuit(QuitRequest::All);
+      pc.services().get<ControlService>().endOfStream();
+      pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
     }
   };
 


### PR DESCRIPTION
The new CMake infrastructure assumes all tests are boost tests
by default, silently breaking any DPL based test which does not
declare itself as NO_BOOST_TEST.