### PR TITLE
Modify MID raw data decoder/encoder to cope with the new user logic

### DIFF
--- a/Detectors/MUON/MID/Base/include/MIDBase/DetectorParameters.h
+++ b/Detectors/MUON/MID/Base/include/MIDBase/DetectorParameters.h
@@ -40,6 +40,10 @@ inline int getChamber(int deId) { return (deId % NDetectionElementsPerSide) / NR
 /// @param deId The detection element ID
 inline int getRPCLine(int deId) { return deId % NRPCLines; }
 
+/// Check if the detection element is in the right side
+/// @param deId The detection element ID
+inline bool isRightSide(int deId) { return (deId / NDetectionElementsPerSide) == 0; }
+
 void assertDEId(int deId);
 
 int getDEId(bool isRight, int chamber, int rpc);

--- a/Detectors/MUON/MID/Raw/CMakeLists.txt
+++ b/Detectors/MUON/MID/Raw/CMakeLists.txt
@@ -8,10 +8,11 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
-o2_add_library(MIDRaw
-               SOURCES src/Decoder.cxx src/Encoder.cxx
-               PUBLIC_LINK_LIBRARIES ms_gsl::ms_gsl O2::DataFormatsMID
-                                     O2::Headers)
+o2_add_library(
+  MIDRaw
+  SOURCES src/CrateMapper.cxx src/Decoder.cxx src/Encoder.cxx
+  PUBLIC_LINK_LIBRARIES ms_gsl::ms_gsl O2::DataFormatsMID O2::Headers
+                        O2::MIDBase)
 
 if(BUILD_TESTING)
   add_subdirectory(test)

--- a/Detectors/MUON/MID/Raw/CMakeLists.txt
+++ b/Detectors/MUON/MID/Raw/CMakeLists.txt
@@ -11,7 +11,7 @@
 o2_add_library(
   MIDRaw
   SOURCES src/CrateMapper.cxx src/Decoder.cxx src/Encoder.cxx
-          src/LocalBoardRO.cxx
+          src/LocalBoardRO.cxx src/RawBuffer.cxx
   PUBLIC_LINK_LIBRARIES ms_gsl::ms_gsl O2::DataFormatsMID O2::Headers
                         O2::MIDBase)
 

--- a/Detectors/MUON/MID/Raw/CMakeLists.txt
+++ b/Detectors/MUON/MID/Raw/CMakeLists.txt
@@ -11,7 +11,7 @@
 o2_add_library(
   MIDRaw
   SOURCES src/CrateMapper.cxx src/Decoder.cxx src/Encoder.cxx
-          src/LocalBoardRO.cxx src/RawBuffer.cxx
+          src/LocalBoardRO.cxx src/RawBuffer.cxx src/RawFileReader.cxx
   PUBLIC_LINK_LIBRARIES ms_gsl::ms_gsl O2::DataFormatsMID O2::Headers
                         O2::MIDBase)
 

--- a/Detectors/MUON/MID/Raw/CMakeLists.txt
+++ b/Detectors/MUON/MID/Raw/CMakeLists.txt
@@ -11,6 +11,7 @@
 o2_add_library(
   MIDRaw
   SOURCES src/CrateMapper.cxx src/Decoder.cxx src/Encoder.cxx
+          src/LocalBoardRO.cxx
   PUBLIC_LINK_LIBRARIES ms_gsl::ms_gsl O2::DataFormatsMID O2::Headers
                         O2::MIDBase)
 

--- a/Detectors/MUON/MID/Raw/CMakeLists.txt
+++ b/Detectors/MUON/MID/Raw/CMakeLists.txt
@@ -10,10 +10,16 @@
 
 o2_add_library(
   MIDRaw
-  SOURCES src/CrateMapper.cxx src/Decoder.cxx src/Encoder.cxx
-          src/LocalBoardRO.cxx src/RawBuffer.cxx src/RawFileReader.cxx
+  SOURCES src/CrateMapper.cxx
+          src/CRUUserLogicDecoder.cxx
+          src/CRUUserLogicEncoder.cxx
+          src/Decoder.cxx
+          src/Encoder.cxx
+          src/LocalBoardRO.cxx
+          src/RawBuffer.cxx
+          src/RawFileReader.cxx
   PUBLIC_LINK_LIBRARIES ms_gsl::ms_gsl O2::DataFormatsMID O2::Headers
-                        O2::MIDBase)
+                        O2::CommonConstants O2::CommonUtils O2::MIDBase)
 
 if(BUILD_TESTING)
   add_subdirectory(test)

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/CRUUserLogicDecoder.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/CRUUserLogicDecoder.h
@@ -1,0 +1,52 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDRaw/CRUUserLogicDecoder.h
+/// \brief  MID CRU user logic decoder
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   18 November 2019
+#ifndef O2_MID_CRUUSERLOGICDECODER_H
+#define O2_MID_CRUUSERLOGICDECODER_H
+
+#include <cstdint>
+#include <vector>
+#include <gsl/gsl>
+#include "DataFormatsMID/ROFRecord.h"
+#include "MIDRaw/LocalBoardRO.h"
+#include "MIDRaw/RawBuffer.h"
+#include "MIDRaw/RawUnit.h"
+
+namespace o2
+{
+namespace mid
+{
+class CRUUserLogicDecoder
+{
+ public:
+  void process(gsl::span<const raw::RawUnit> bytes);
+  /// Gets the vector of data
+  const std::vector<LocalBoardRO>& getData() { return mData; }
+
+  /// Gets the vector of data RO frame records
+  const std::vector<ROFRecord>& getROFRecords() { return mROFRecords; }
+
+ private:
+  RawBuffer<raw::RawUnit> mBuffer{};    /// Raw buffer handler
+  std::vector<LocalBoardRO> mData{};    /// Vector of output data
+  std::vector<ROFRecord> mROFRecords{}; /// List of ROF records
+  uint8_t mCrateId{0};                  /// Crate ID (from RDH)
+
+  bool processBlock();
+  void reset();
+};
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_CRUUSERLOGICDECODER_H */

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/CRUUserLogicEncoder.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/CRUUserLogicEncoder.h
@@ -1,0 +1,55 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDRaw/CRUUserLogicEncoder.h
+/// \brief  Raw data encoder for MID CRU user logic
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   18 November 2019
+#ifndef O2_MID_CRUUSERLOGICENCODER_H
+#define O2_MID_CRUUSERLOGICENCODER_H
+
+#include <cstdint>
+#include <vector>
+#include <gsl/gsl>
+#include "Headers/RAWDataHeader.h"
+#include "DataFormatsMID/ROFRecord.h"
+#include "MIDRaw/LocalBoardRO.h"
+#include "MIDRaw/RawUnit.h"
+
+namespace o2
+{
+namespace mid
+{
+class CRUUserLogicEncoder
+{
+ public:
+  void newHeader(uint16_t feeId, const header::RAWDataHeader& baseRDH);
+  void process(gsl::span<const LocalBoardRO> data, const uint16_t bc, EventType eventType = EventType::Standard);
+  const std::vector<raw::RawUnit>& getBuffer();
+  /// Gets the buffer size in bytes
+  size_t getBufferSize() const { return mBytes.size() * raw::sElementSizeInBytes; }
+  /// Sets flag to add a constant header offset
+  void setHeaderOffset(bool headerOffset = true) { mHeaderOffset = headerOffset; }
+  void clear();
+
+ private:
+  void add(int value, unsigned int nBits);
+  void completePage(bool stop);
+  header::RAWDataHeader* getRDH() { return reinterpret_cast<header::RAWDataHeader*>(&(mBytes[mHeaderIndex])); }
+
+  std::vector<raw::RawUnit> mBytes{}; /// Vector with encoded information
+  size_t mBitIndex{0};                /// Index of the current bit
+  size_t mHeaderIndex{0};             /// Index in the the current header
+  bool mHeaderOffset{false};          /// Header offset
+};
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_CRUUSERLOGICENCODER_H */

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/CrateMapper.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/CrateMapper.h
@@ -1,0 +1,51 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDRaw/CrateMapper.h
+/// \brief  Mapper to convert the RO Ids to a format suitable for O2
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   15 November 2019
+#ifndef O2_MID_CRATEMAPPER_H
+#define O2_MID_CRATEMAPPER_H
+
+#include <cstdint>
+#include <map>
+
+namespace o2
+{
+namespace mid
+{
+class CrateMapper
+{
+ public:
+  CrateMapper();
+  ~CrateMapper() = default;
+
+  /// Builds the local board ID in the detection element
+  static uint16_t deBoardId(uint8_t rpcLineId, uint8_t columnId, uint8_t lineId) { return (rpcLineId | (columnId << 4) | (lineId << 7)); }
+  /// Gets the RPC line from the DE board ID
+  static uint8_t getRPCLine(uint16_t deBoardId) { return deBoardId & 0xF; }
+  /// Gets the column ID from the DE board ID
+  static uint8_t getColumnId(uint16_t deBoardId) { return (deBoardId >> 4) & 0x7; }
+  /// Gets the line ID from the DE board ID
+  static uint8_t getLineId(uint16_t deBoardId) { return (deBoardId >> 7) & 0x3; }
+  uint16_t deLocalBoardToRO(uint8_t deId, uint8_t columnId, uint8_t lineId) const;
+
+  uint16_t roLocalBoardToDE(uint8_t crateId, uint8_t boardId) const;
+
+ private:
+  void init();
+  std::map<uint16_t, uint16_t> mROToDEMap; /// Correspondence between RO and DE board
+  std::map<uint16_t, uint16_t> mDEToROMap; /// Correspondence between DE and RO board
+};
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_CRATEMAPPER_H */

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/CrateParameters.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/CrateParameters.h
@@ -1,0 +1,64 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDRaw/CrateParameters.h
+/// \brief  MID RO crate parameters
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   19 November 2019
+#ifndef O2_MID_CRATEPARAMETERS_H
+#define O2_MID_CRATEPARAMETERS_H
+
+#include <cstdint>
+#include <array>
+
+namespace o2
+{
+namespace mid
+{
+namespace crateparams
+{
+static constexpr unsigned int sNCratesPerSide = 8;
+static constexpr unsigned int sNCrates = 2 * sNCratesPerSide;
+static constexpr unsigned int sNGBTsPerCrate = 2;
+static constexpr unsigned int sNGBTsPerSide = sNGBTsPerCrate * sNCratesPerSide;
+static constexpr unsigned int sNGBTs = 2 * sNGBTsPerSide;
+static constexpr unsigned int sMaxNBoardsInLink = 8;
+static constexpr unsigned int sMaxNBoardsInCrate = sMaxNBoardsInLink * sNGBTsPerCrate;
+static constexpr unsigned int sNELinksPerGBT = 10;
+
+/// Builds the RO ID from the crate ID and the GBT ID in the crate
+inline uint16_t makeROId(uint8_t crateId, uint8_t gbtId) { return sNGBTsPerCrate * crateId + gbtId; }
+/// Gets the crate ID from the RO ID
+inline uint8_t getCrateIdFromROId(uint16_t roId) { return roId / sNGBTsPerCrate; }
+/// Gets the link ID in crate from the RO ID
+inline uint8_t getGBTIdInCrate(uint16_t roId) { return roId % sNGBTsPerCrate; }
+/// Gets the link ID in crate from the board ID
+inline uint8_t getGBTIdFromBoardInCrate(uint16_t locId) { return locId / sMaxNBoardsInLink; }
+/// Gets the absolute crate ID
+inline uint8_t getCrateId(bool isRightSide, uint8_t crateIdOneSide) { return isRightSide ? crateIdOneSide : crateIdOneSide + sNCratesPerSide; }
+/// Tests if the crate is in the right side
+inline bool isRightSide(uint8_t crateId) { return (crateId / sNCratesPerSide) == 0; }
+/// Builds the unique loc ID from the crate ID and the loc ID in the crate
+inline uint8_t makeUniqueLocID(uint8_t crateId, uint8_t locId) { return locId | (crateId << 4); }
+/// Gets the crate ID from the absolute local board ID
+inline uint8_t getCrateId(uint8_t uniqueLocId) { return (uniqueLocId >> 4) & 0xF; }
+/// Gets the loc ID in the crate from the unique local board ID
+inline uint8_t getLocId(uint16_t uniqueLocId) { return uniqueLocId & 0xF; }
+/// Tests the local card bit
+inline bool isLoc(uint8_t statusWord) { return (statusWord >> 6) & 0x1; }
+/// Tests if the calibration bit of the card
+inline bool isCalibration(uint8_t eventWord) { return ((eventWord & 0xc) == 0x8); }
+/// Tests if this is a Front End Test event
+inline bool isFET(uint8_t eventWord) { return ((eventWord & 0xc) == 0xc); }
+} // namespace crateparams
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_CRATEPARAMETERS_H */

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/LocalBoardRO.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/LocalBoardRO.h
@@ -1,0 +1,38 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDRaw/LocalBoardRO.h
+/// \brief  Structure to store the FEE local board information
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   19 November 2019
+#ifndef O2_MID_LocalBoardRO_H
+#define O2_MID_LocalBoardRO_H
+
+#include <cstdint>
+#include <array>
+
+namespace o2
+{
+namespace mid
+{
+struct LocalBoardRO {
+  uint8_t statusWord{0};                 /// Status word
+  uint8_t eventWord{0};                  /// Event word
+  uint8_t boardId{0};                    /// Board ID in crate
+  uint8_t firedChambers{0};              /// Fired chambers
+  std::array<uint16_t, 4> patternsBP{};  /// Bending plane pattern
+  std::array<uint16_t, 4> patternsNBP{}; /// Non-bending plane pattern
+};
+
+std::ostream& operator<<(std::ostream& os, const LocalBoardRO& loc);
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_LocalBoardRO_H */

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/RawBuffer.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/RawBuffer.h
@@ -1,0 +1,64 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDRaw/RawBuffer.h
+/// \brief  Handler of the RAW buffer
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   28 November 2019
+#ifndef O2_MID_RAWBUFFER_H
+#define O2_MID_RAWBUFFER_H
+
+#include <cstdint>
+#include <vector>
+#include <gsl/gsl>
+#include "Headers/RAWDataHeader.h"
+
+namespace o2
+{
+namespace mid
+{
+template <typename T>
+class RawBuffer
+{
+ public:
+  void setBuffer(gsl::span<const T> bytes, bool keepUnconsumed = true);
+
+  /// Gets the current RDH
+  const header::RAWDataHeader* getRDH() { return mRDH; }
+
+  unsigned int next(unsigned int nBits);
+  T next();
+  bool nextHeader(gsl::span<const T> bytes);
+
+  bool hasNext(unsigned int nBytes);
+
+  void skipOverhead();
+
+  bool isHBClosed();
+
+ private:
+  gsl::span<const T> mBytes{};                                    /// gsl span with encoded information
+  gsl::span<const T> mCurrentBuffer{};                            /// gsl span with the current encoded information
+  std::vector<T> mUnconsumed;                                     /// Unconsumed buffer
+  size_t mElementIndex{0};                                        /// Index of the current element in the buffer
+  size_t mBitIndex{0};                                            /// Index of the current bit
+  size_t mNextHeaderIndex{0};                                     /// Index of the next header
+  size_t mEndOfPayloadIndex{0};                                   /// Index of the end of payload
+  const unsigned int mElementSizeInBytes{sizeof(T)};              /// Element size in bytes
+  const unsigned int mElementSizeInBits{mElementSizeInBytes * 8}; /// Element size in bits
+  const header::RAWDataHeader* mRDH{nullptr};                     /// Current header (not owner)
+
+  bool nextPayload();
+  void reset();
+};
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_RAWBUFFER_H */

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/RawFileReader.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/RawFileReader.h
@@ -1,0 +1,66 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDRaw/RawFileReader.h
+/// \brief  MID raw file reader
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   25 November 2019
+#ifndef O2_MID_RAWFILEREADER_H
+#define O2_MID_RAWFILEREADER_H
+
+#include <fstream>
+#include <vector>
+#include <array>
+#include "MIDRaw/CrateParameters.h"
+#include "MIDRaw/RawBuffer.h"
+#include "MIDRaw/RawUnit.h"
+
+namespace o2
+{
+namespace mid
+{
+template <typename T>
+class RawFileReader
+{
+ public:
+  bool init(const char* inFilename, bool readContinuous = false);
+  bool readAllGBTs(bool reset = true);
+  bool readHB(bool sendCompleteHBs = true);
+  void clear();
+
+  /// Gets the number of HBs read
+  unsigned long int getNumberOfHBs(uint16_t feeId) { return mHBCounters.at(feeId); }
+
+  /// Gets the state
+  int getState() { return mState; }
+
+  /// Gets the vector of data
+  const std::vector<T>& getData() { return mBytes; }
+
+  void setCustomRDH(const header::RAWDataHeader& rdh) { mCustomRDH = rdh; }
+
+ private:
+  void read(size_t nBytes);
+  bool hasFullInfo();
+  bool replaceRDH(size_t headerIndex);
+
+  std::ifstream mFile{};                                            /// Raw file
+  std::vector<T> mBytes;                                            /// Buffer
+  RawBuffer<T> mBuffer;                                             /// Raw buffer handler
+  std::array<unsigned long int, crateparams::sNGBTs> mHBCounters{}; /// HB counters per GBT
+  bool mReadContinuous{false};                                      /// Continuous readout mode
+  int mState{0};                                                    /// Status flag
+
+  header::RAWDataHeader mCustomRDH{}; /// Custom RDH
+};
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_RAWFILEREADER_H */

--- a/Detectors/MUON/MID/Raw/src/CRUUserLogicDecoder.cxx
+++ b/Detectors/MUON/MID/Raw/src/CRUUserLogicDecoder.cxx
@@ -1,0 +1,90 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Raw/src/CRUUserLogicDecoder.cxx
+/// \brief  MID CRU user logic decoder
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   30 September 2019
+
+#include "MIDRaw/CRUUserLogicDecoder.h"
+
+#include "RawInfo.h"
+
+#include "MIDRaw/CrateParameters.h"
+#include "CommonConstants/Triggers.h"
+
+namespace o2
+{
+namespace mid
+{
+
+void CRUUserLogicDecoder::reset()
+{
+  /// Rewind bytes
+  mData.clear();
+  mROFRecords.clear();
+}
+
+void CRUUserLogicDecoder::process(gsl::span<const raw::RawUnit> bytes)
+{
+  /// Sets the buffer and reset the internal indexes
+  reset();
+  mBuffer.setBuffer(bytes);
+
+  // Each data block consists of:
+  // 28 bits of event type
+  // up to 8 local boards info consisting of at most 136 bits
+  // So, if we want to have a full block,
+  // the buffer size must be at least 28 + 8 * 136 = 1116 bits
+  // i.e. 35 uint32_t
+  while (mBuffer.hasNext(35)) {
+    processBlock();
+  }
+}
+
+bool CRUUserLogicDecoder::processBlock()
+{
+  /// Processes the next block of data
+  size_t firstEntry = mData.size();
+
+  uint8_t eventWord = mBuffer.next(sNBitsEventWord);
+  uint16_t localClock = mBuffer.next(sNBitsLocalClock);
+  uint8_t crateId = mBuffer.next(sNBitsCrateId);
+  int nFiredBoards = mBuffer.next(sNBitsNFiredBoards);
+
+  EventType eventType = EventType::Standard;
+  if (crateparams::isCalibration(eventWord)) {
+    eventType = EventType::Noise;
+  } else if (crateparams::isFET(eventWord)) {
+    eventType = EventType::Dead;
+  }
+  InteractionRecord intRec(localClock, mBuffer.getRDH()->triggerOrbit);
+
+  for (int iboard = 0; iboard < nFiredBoards; ++iboard) {
+    uint8_t locId = mBuffer.next(sNBitsLocId);
+    uint8_t firedChambers = mBuffer.next(sNBitsFiredChambers);
+    mData.push_back({0, 0, crateparams::makeUniqueLocID(crateId, locId), firedChambers});
+    for (int ich = 0; ich < 4; ++ich) {
+      if ((firedChambers >> ich) & 0x1) {
+        mData.back().patternsBP[ich] = mBuffer.next(sNBitsFiredStrips);
+        mData.back().patternsNBP[ich] = mBuffer.next(sNBitsFiredStrips);
+      }
+    }
+  }
+
+  mROFRecords.emplace_back(intRec, eventType, firstEntry, mData.size() - firstEntry);
+
+  mBuffer.skipOverhead();
+
+  return true;
+}
+
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/Raw/src/CRUUserLogicEncoder.cxx
+++ b/Detectors/MUON/MID/Raw/src/CRUUserLogicEncoder.cxx
@@ -1,0 +1,129 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Raw/src/CRUUserLogicEncoder.cxx
+/// \brief  Raw data encoder for MID CRU user logic
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   18 November 2019
+
+#include "MIDRaw/CRUUserLogicEncoder.h"
+
+#include "MIDRaw/CrateParameters.h"
+#include "RawInfo.h"
+
+namespace o2
+{
+namespace mid
+{
+void CRUUserLogicEncoder::add(int value, unsigned int nBits)
+{
+  /// Add information
+  for (int ibit = 0; ibit < nBits; ++ibit) {
+    if (mBitIndex == raw::sElementSizeInBits) {
+      mBitIndex = 0;
+      if (mBytes.size() == mHeaderIndex + sMaxPageSize) {
+        completePage(false);
+        // Copy previous header
+        std::vector<raw::RawUnit> oldHeader(mBytes.begin() + mHeaderIndex, mBytes.begin() + mHeaderIndex + raw::sHeaderSizeInElements);
+        mHeaderIndex = mBytes.size();
+        std::copy(oldHeader.begin(), oldHeader.end(), std::back_inserter(mBytes));
+        // And increase the page counter
+        ++getRDH()->pageCnt;
+      }
+      mBytes.push_back(0);
+    }
+    bool isOn = (value >> ibit) & 0x1;
+    if (isOn) {
+      mBytes.back() |= (1 << mBitIndex);
+    }
+    ++mBitIndex;
+  }
+}
+
+void CRUUserLogicEncoder::clear()
+{
+  /// Reset bytes
+  mBytes.clear();
+  mBitIndex = 0;
+  mHeaderIndex = 0;
+}
+
+void CRUUserLogicEncoder::newHeader(uint16_t feeId, const header::RAWDataHeader& baseRDH)
+{
+  /// Add new RDH
+  completePage(true);
+  mHeaderIndex = mBytes.size();
+  for (size_t iel = 0; iel < raw::sHeaderSizeInElements; ++iel) {
+    mBytes.emplace_back(0);
+  }
+  auto rdh = getRDH();
+  *rdh = baseRDH;
+  rdh->feeId = feeId;
+  mBitIndex = raw::sElementSizeInBits;
+}
+
+void CRUUserLogicEncoder::completePage(bool stop)
+{
+  /// Complete the information on the page
+  if (mBytes.empty()) {
+    return;
+  }
+  auto pageSizeInElements = mBytes.size() - mHeaderIndex;
+  if (mHeaderOffset && pageSizeInElements < sMaxPageSize) {
+    // Write zeros up to the end of the page
+    mBytes.resize(mHeaderIndex + sMaxPageSize, 0);
+  }
+
+  // This has to be done after the resize
+  auto rdh = getRDH();
+  rdh->memorySize = pageSizeInElements * raw::sElementSizeInBytes;
+  rdh->offsetToNext = (mBytes.size() - mHeaderIndex) * raw::sElementSizeInBytes;
+  rdh->stop = stop;
+}
+
+const std::vector<raw::RawUnit>& CRUUserLogicEncoder::getBuffer()
+{
+  /// Gets the buffer
+  if (!mBytes.empty() && !getRDH()->stop) {
+    // Close page before getting buffer
+    completePage(true);
+  }
+  return mBytes;
+}
+
+void CRUUserLogicEncoder::process(gsl::span<const LocalBoardRO> sortedData, const uint16_t bc, EventType eventType)
+{
+  /// Encode data
+
+  // FIXME: Finalize the final format of the event word together with the CRU + RO team
+  uint16_t eventWord = 0;
+  if (eventType == EventType::Noise) {
+    eventWord = 0x8;
+  } else if (eventType == EventType::Dead) {
+    eventWord = 0xc;
+  }
+  add(eventWord, sNBitsEventWord);
+  add(bc, sNBitsLocalClock);
+  add(crateparams::getCrateIdFromROId(getRDH()->feeId), sNBitsCrateId);
+  add(sortedData.size(), sNBitsNFiredBoards);
+  for (auto& loc : sortedData) {
+    add(loc.boardId, sNBitsLocId);
+    add(loc.firedChambers, sNBitsFiredChambers);
+    for (int ich = 0; ich < 4; ++ich) {
+      if ((loc.firedChambers >> ich) & 0x1) {
+        add(loc.patternsBP[ich], sNBitsFiredStrips);
+        add(loc.patternsNBP[ich], sNBitsFiredStrips);
+      }
+    }
+  }
+}
+
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/Raw/src/CrateMapper.cxx
+++ b/Detectors/MUON/MID/Raw/src/CrateMapper.cxx
@@ -1,0 +1,158 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Raw/src/CrateMapper.cxx
+/// \brief  FEE ID to board ID converter
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   15 November 2019
+
+#include "MIDRaw/CrateMapper.h"
+
+#include <sstream>
+#include <exception>
+#include "MIDBase/DetectorParameters.h"
+#include "MIDRaw/CrateParameters.h"
+
+namespace o2
+{
+namespace mid
+{
+CrateMapper::CrateMapper()
+{
+  /// Ctor
+  init();
+}
+
+void CrateMapper::init()
+{
+  /// Initalizes the inner mapping
+  // Crate 0
+  // link 0
+  mROToDEMap.emplace(crateparams::makeUniqueLocID(0, 0), deBoardId(0, 0, 0));
+  mROToDEMap.emplace(crateparams::makeUniqueLocID(0, 1), deBoardId(1, 0, 0));
+  mROToDEMap.emplace(crateparams::makeUniqueLocID(0, 2), deBoardId(1, 0, 1));
+  mROToDEMap.emplace(crateparams::makeUniqueLocID(0, 3), deBoardId(2, 0, 0));
+  mROToDEMap.emplace(crateparams::makeUniqueLocID(0, 4), deBoardId(2, 0, 1));
+  mROToDEMap.emplace(crateparams::makeUniqueLocID(0, 5), deBoardId(3, 0, 0));
+  mROToDEMap.emplace(crateparams::makeUniqueLocID(0, 6), deBoardId(3, 0, 1));
+  mROToDEMap.emplace(crateparams::makeUniqueLocID(0, 7), deBoardId(3, 0, 2));
+  // link 1
+  mROToDEMap.emplace(crateparams::makeUniqueLocID(0, 8), deBoardId(5, 0, 1));
+  mROToDEMap.emplace(crateparams::makeUniqueLocID(0, 9), deBoardId(5, 0, 2));
+  mROToDEMap.emplace(crateparams::makeUniqueLocID(0, 10), deBoardId(5, 0, 3));
+  mROToDEMap.emplace(crateparams::makeUniqueLocID(0, 11), deBoardId(6, 0, 0));
+  mROToDEMap.emplace(crateparams::makeUniqueLocID(0, 12), deBoardId(6, 0, 1));
+  mROToDEMap.emplace(crateparams::makeUniqueLocID(0, 13), deBoardId(7, 0, 0));
+  mROToDEMap.emplace(crateparams::makeUniqueLocID(0, 14), deBoardId(7, 0, 1));
+  mROToDEMap.emplace(crateparams::makeUniqueLocID(0, 15), deBoardId(8, 0, 0));
+
+  // Crate 1, 3
+  for (int icrate = 0; icrate < 2; ++icrate) {
+    uint8_t crateId = (icrate == 0) ? 1 : 3;
+    uint8_t columnId = (icrate == 0) ? 1 : 2;
+    // link 0
+    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 0), deBoardId(0, columnId, 0));
+    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 1), deBoardId(1, columnId, 0));
+    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 2), deBoardId(1, columnId, 1));
+    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 3), deBoardId(2, columnId, 0));
+    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 4), deBoardId(2, columnId, 1));
+    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 5), deBoardId(3, columnId, 0));
+    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 6), deBoardId(3, columnId, 1));
+    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 7), deBoardId(3, columnId, 2));
+    // link 1
+    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 8), deBoardId(3, columnId, 3));
+    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 9), deBoardId(4, columnId, 0));
+    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 10), deBoardId(4, columnId, 1));
+    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 11), deBoardId(4, columnId, 2));
+    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 12), deBoardId(4, columnId, 3));
+    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 13), deBoardId(5, columnId, 0));
+    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 14), deBoardId(5, columnId, 1));
+  }
+
+  // Crate 2
+  // link 0
+  mROToDEMap.emplace(crateparams::makeUniqueLocID(2, 0), deBoardId(5, 1, 2));
+  mROToDEMap.emplace(crateparams::makeUniqueLocID(2, 1), deBoardId(5, 1, 3));
+  mROToDEMap.emplace(crateparams::makeUniqueLocID(2, 2), deBoardId(6, 1, 0));
+  mROToDEMap.emplace(crateparams::makeUniqueLocID(2, 3), deBoardId(6, 1, 1));
+  mROToDEMap.emplace(crateparams::makeUniqueLocID(2, 4), deBoardId(7, 1, 0));
+  mROToDEMap.emplace(crateparams::makeUniqueLocID(2, 5), deBoardId(7, 1, 1));
+  mROToDEMap.emplace(crateparams::makeUniqueLocID(2, 6), deBoardId(8, 1, 0));
+  // link 1
+  mROToDEMap.emplace(crateparams::makeUniqueLocID(2, 8), deBoardId(5, 2, 2));
+  mROToDEMap.emplace(crateparams::makeUniqueLocID(2, 9), deBoardId(5, 2, 3));
+  mROToDEMap.emplace(crateparams::makeUniqueLocID(2, 10), deBoardId(6, 2, 0));
+  mROToDEMap.emplace(crateparams::makeUniqueLocID(2, 11), deBoardId(6, 2, 1));
+  mROToDEMap.emplace(crateparams::makeUniqueLocID(2, 12), deBoardId(7, 2, 0));
+  mROToDEMap.emplace(crateparams::makeUniqueLocID(2, 13), deBoardId(7, 2, 1));
+  mROToDEMap.emplace(crateparams::makeUniqueLocID(2, 14), deBoardId(8, 2, 0));
+
+  // Crate 4, 5, 6
+  for (int icrate = 0; icrate < 3; ++icrate) {
+    uint16_t crateId = icrate + 4;
+    uint8_t columnId = icrate + 3;
+    // link 0
+    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 0), deBoardId(0, columnId, 0));
+    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 1), deBoardId(1, columnId, 0));
+    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 2), deBoardId(1, columnId, 1));
+    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 3), deBoardId(2, columnId, 0));
+    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 4), deBoardId(2, columnId, 1));
+    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 5), deBoardId(3, columnId, 0));
+    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 6), deBoardId(3, columnId, 1));
+    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 7), deBoardId(4, columnId, 0));
+    // link 1
+    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 8), deBoardId(4, columnId, 1));
+    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 9), deBoardId(5, columnId, 0));
+    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 10), deBoardId(5, columnId, 1));
+    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 11), deBoardId(6, columnId, 0));
+    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 12), deBoardId(6, columnId, 1));
+    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 13), deBoardId(7, columnId, 0));
+    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 14), deBoardId(7, columnId, 1));
+    mROToDEMap.emplace(crateparams::makeUniqueLocID(crateId, 15), deBoardId(8, columnId, 0));
+  }
+
+  // Crate 7
+  uint8_t rpcLineId = 0;
+  for (uint8_t iboard = 0; iboard < 9; ++iboard) {
+    mROToDEMap.emplace(crateparams::makeUniqueLocID(7, iboard), deBoardId(rpcLineId++, 6, 0));
+  }
+
+  /// Build the inverse map
+  for (auto& item : mROToDEMap) {
+    mDEToROMap.emplace(item.second, item.first);
+  }
+}
+
+uint16_t CrateMapper::deLocalBoardToRO(uint8_t deId, uint8_t columnId, uint8_t lineId) const
+{
+  /// Converts the local board ID in  in MT11 right to the local board ID in FEE
+  auto item = mDEToROMap.find(deBoardId(detparams::getRPCLine(deId), columnId, lineId));
+  if (item == mDEToROMap.end()) {
+    std::stringstream ss;
+    ss << "Non-existant deId: " << static_cast<int>(deId) << "  columnId: " << static_cast<int>(columnId) << "  lineId: " << static_cast<int>(lineId);
+    throw std::runtime_error(ss.str());
+  }
+  return detparams::isRightSide(deId) ? item->second : item->second + (crateparams::sNCratesPerSide << 4);
+}
+
+uint16_t CrateMapper::roLocalBoardToDE(uint8_t crateId, uint8_t boardId) const
+{
+  /// Converts the local board ID in FEE to the local board ID in MT11 right
+  auto item = mROToDEMap.find(crateparams::makeUniqueLocID(crateId % crateparams::sNCratesPerSide, boardId));
+  if (item == mROToDEMap.end()) {
+    std::stringstream ss;
+    ss << "Non-existant crateId: " << static_cast<int>(crateId) << "  boardId: " << static_cast<int>(boardId);
+    throw std::runtime_error(ss.str());
+  }
+  return item->second;
+}
+
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/Raw/src/Decoder.cxx
+++ b/Detectors/MUON/MID/Raw/src/Decoder.cxx
@@ -14,138 +14,85 @@
 /// \date   30 September 2019
 
 #include "MIDRaw/Decoder.h"
-#include "RawInfo.h"
 
-#include <map>
+#include "MIDBase/DetectorParameters.h"
+
+#include "MIDRaw/CrateParameters.h"
 
 namespace o2
 {
 namespace mid
 {
 
-void Decoder::init()
+ColumnData& Decoder::FindColumnData(uint8_t deId, uint8_t columnId, size_t firstEntry)
 {
-  mData.reserve(8000);
-  mROFRecords.reserve(2000);
-}
-
-int Decoder::next(unsigned int nBits)
-{
-  /// Get value
-  int value = 0;
-  for (int ibit = 0; ibit < nBits; ++ibit) {
-    if (mBitIndex == raw::sElementSizeInBits) {
-      mBitIndex = 0;
-      ++mVectorIndex;
-      nextPayload();
+  /// Gets the matching column data
+  /// Adds one if not found
+  for (auto colIt = mData.begin() + firstEntry; colIt != mData.end(); ++colIt) {
+    if (colIt->deId == deId && colIt->columnId == columnId) {
+      return *colIt;
     }
-    bool isOn = (mBytes[mVectorIndex] >> mBitIndex) & 0x1;
-    if (isOn) {
-      value |= (1 << ibit);
-    }
-    ++mBitIndex;
   }
-  return value;
+  mData.push_back({deId, columnId});
+  return mData.back();
 }
 
-void Decoder::reset()
+void Decoder::addData(const LocalBoardRO& loc, size_t firstEntry)
 {
-  /// Rewind bytes
-  mVectorIndex = 0;
-  mHeaderIndex = 0;
-  mNextHeaderIndex = 0;
-  mBitIndex = 0;
-  mRDH = nullptr;
-  mData.clear();
-  mROFRecords.clear();
+  /// Convert the loc data to ColumnData
+  uint8_t uniqueLocId = loc.boardId;
+  uint8_t crateId = crateparams::getCrateId(uniqueLocId);
+  bool isRightSide = crateparams::isRightSide(crateId);
+  uint16_t deBoardId = mCrateMapper.roLocalBoardToDE(crateId, crateparams::getLocId(loc.boardId));
+  auto rpcLineId = mCrateMapper.getRPCLine(deBoardId);
+  auto columnId = mCrateMapper.getColumnId(deBoardId);
+  auto lineId = mCrateMapper.getLineId(deBoardId);
+  for (int ich = 0; ich < 4; ++ich) {
+    if (((loc.firedChambers >> ich) & 0x1) == 0) {
+      continue;
+    }
+    uint8_t deId = detparams::getDEId(isRightSide, ich, rpcLineId);
+    auto& col = FindColumnData(deId, columnId, firstEntry);
+    col.setBendPattern(loc.patternsBP[ich], lineId);
+    col.setNonBendPattern(loc.patternsNBP[ich]);
+  }
 }
 
 void Decoder::process(gsl::span<const raw::RawUnit> bytes)
 {
-  /// Sets the buffer and reset the internal indexes
-  reset();
-  if (bytes.empty()) {
+  /// Decode the raw data
+
+  // First clear the output
+  mData.clear();
+  mROFRecords.clear();
+
+  // Process the input data
+  mCRUUserLogicDecoder.process(bytes);
+
+  if (mCRUUserLogicDecoder.getROFRecords().empty()) {
     return;
   }
-  mBytes = bytes;
-  while (nextColumnData())
-    ;
-}
 
-bool Decoder::isEndOfBuffer() const
-{
-  /// We are at the end of the buffer
-  return mVectorIndex == mBytes.size();
-}
+  // Fill the map with ordered events
+  for (auto rofIt = mCRUUserLogicDecoder.getROFRecords().begin(); rofIt != mCRUUserLogicDecoder.getROFRecords().end(); ++rofIt) {
+    mOrderIndexes[rofIt->interactionRecord.toLong()].emplace_back(rofIt - mCRUUserLogicDecoder.getROFRecords().begin());
+  }
 
-bool Decoder::nextPayload()
-{
-  /// Go to next payload
-  while (mVectorIndex == mNextHeaderIndex) {
-    mRDH = reinterpret_cast<const header::RAWDataHeader*>(&mBytes[mVectorIndex]);
-    mHeaderIndex = mNextHeaderIndex;
-    mNextHeaderIndex += mRDH->offsetToNext / raw::sElementSizeInBytes;
-    mBitIndex = 0;
-    if (mRDH->memorySize > raw::sHeaderSizeInBytes) {
-      // Payload is not empty: go to end of header
-      mVectorIndex += raw::sHeaderSizeInElements;
-    } else {
-      // Payload is empty: go directly to next header and check it
-      mVectorIndex = mNextHeaderIndex;
-      if (isEndOfBuffer()) {
-        return false;
+  const ROFRecord* rof = nullptr;
+  for (auto& item : mOrderIndexes) {
+    size_t firstEntry = mData.size();
+    for (auto& idx : item.second) {
+      // In principle all of these ROF records have the same timestamp
+      rof = &mCRUUserLogicDecoder.getROFRecords()[idx];
+      for (size_t iloc = rof->firstEntry; iloc < rof->firstEntry + rof->nEntries; ++iloc) {
+        addData(mCRUUserLogicDecoder.getData()[iloc], firstEntry);
       }
     }
-  }
-  return true;
-}
-
-bool Decoder::nextColumnData()
-{
-  /// Gets the array of column data
-  if (isEndOfBuffer() || !nextPayload()) {
-    return false;
+    mROFRecords.emplace_back(rof->interactionRecord, rof->eventType, firstEntry, mData.size() - firstEntry);
   }
 
-  EventType eventType = static_cast<EventType>(next(sNBitsEventType));
-  uint16_t localClock = next(sNBitsLocalClock);
-  InteractionRecord intRec(localClock, mRDH->triggerOrbit);
-  auto firstEntry = mData.size();
-  int nFiredRPCs = next(sNBitsNFiredRPCs);
-  ColumnData colData;
-  for (int irpc = 0; irpc < nFiredRPCs; ++irpc) {
-    int rpcId = next(sNBitsRPCId);
-    int nFiredColumns = next(sNBitsNFiredColumns);
-    colData.deId = static_cast<uint8_t>(rpcId);
-    for (int icol = 0; icol < nFiredColumns; ++icol) {
-      colData.columnId = static_cast<uint8_t>(next(sNBitsColumnId));
-      for (int iline = 0; iline < 4; ++iline) {
-        // Reset pattern
-        colData.setBendPattern(0, iline);
-      }
-      int nFiredBoards = next(sNBitsNFiredBoards);
-      for (int iboard = 0; iboard < nFiredBoards; ++iboard) {
-        int boardId = next(sNBitsBoardId);
-        colData.setNonBendPattern(next(sNBitsFiredStrips));
-        colData.setBendPattern(next(sNBitsFiredStrips), boardId);
-      }
-      mData.emplace_back(colData);
-    }
-  }
-
-  mROFRecords.emplace_back(intRec, eventType, firstEntry, mData.size() - firstEntry);
-
-  // The payload bits are contiguous.
-  // However there is an overhead between the last payload byte and the next header.
-  // If we read the full memory size, we
-  // Which means that the size is too small to have another block of data.
-  // When we are close to the new header, we jump directly to the next header
-  if ((mVectorIndex - mHeaderIndex + 1) * raw::sElementSizeInBytes == mRDH->memorySize) {
-    mVectorIndex = mNextHeaderIndex;
-    mBitIndex = 0;
-  }
-
-  return true;
+  // Clear the inner objects when the computation is done
+  mOrderIndexes.clear();
 }
 
 } // namespace mid

--- a/Detectors/MUON/MID/Raw/src/LocalBoardRO.cxx
+++ b/Detectors/MUON/MID/Raw/src/LocalBoardRO.cxx
@@ -1,0 +1,37 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Raw/src/LocalBoardRO.cxx
+/// \brief  Structure to store the FEE local board information
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   19 November 2019
+
+#include "MIDRaw/LocalBoardRO.h"
+
+#include <iostream>
+#include "fmt/format.h"
+#include "MIDRaw/CrateParameters.h"
+
+namespace o2
+{
+namespace mid
+{
+std::ostream& operator<<(std::ostream& os, const LocalBoardRO& loc)
+{
+  /// Stream operator for LocalBoardRO
+  os << fmt::format("Crate ID: {:2d}  Loc ID: {:2d}  status: 0x{:2x}  event: 0x{:2x}  firedChambers: 0x{:1x}", static_cast<int>(crateparams::getCrateId(loc.boardId)), static_cast<int>(crateparams::getLocId(loc.boardId)), static_cast<int>(loc.statusWord), static_cast<int>(loc.eventWord), static_cast<int>(loc.firedChambers));
+  for (int ich = 0; ich < 4; ++ich) {
+    os << fmt::format("  X: 0x{:4x} Y: 0x{:4x}", loc.patternsBP[ich], loc.patternsNBP[ich]);
+  }
+  return os;
+}
+
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/Raw/src/RawBuffer.cxx
+++ b/Detectors/MUON/MID/Raw/src/RawBuffer.cxx
@@ -1,0 +1,174 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Raw/src/RawBuffer.cxx
+/// \brief  MID CRU user logic decoder
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   30 September 2019
+
+#include "MIDRaw/RawBuffer.h"
+
+#include "MIDRaw/RawUnit.h"
+#include "RawInfo.h"
+
+namespace o2
+{
+namespace mid
+{
+
+template <typename T>
+unsigned int RawBuffer<T>::next(unsigned int nBits)
+{
+  /// Reads the next nBits
+  unsigned int value = 0;
+  for (int ibit = 0; ibit < nBits; ++ibit) {
+    if (mBitIndex == mElementSizeInBits) {
+      mBitIndex = 0;
+      ++mElementIndex;
+      nextPayload();
+    }
+    bool isOn = (mBytes[mElementIndex] >> mBitIndex) & 0x1;
+    if (isOn) {
+      value |= (1 << ibit);
+    }
+    ++mBitIndex;
+  }
+  return value;
+}
+
+template <typename T>
+T RawBuffer<T>::next()
+{
+  /// Reads the next word
+  nextPayload();
+  return mBytes[mElementIndex++];
+}
+
+template <typename T>
+bool RawBuffer<T>::nextPayload()
+{
+  /// Goes to next payload
+  while (mElementIndex == mEndOfPayloadIndex) {
+    if (mNextHeaderIndex == mBytes.size()) {
+      // This is the end of the buffer
+      if (mUnconsumed.empty()) {
+        mElementIndex = mNextHeaderIndex;
+        mEndOfPayloadIndex = mNextHeaderIndex;
+        return false;
+      }
+      // We were reading the unconsumed part: switch to new buffer
+      mUnconsumed.clear();
+      reset();
+      mBytes = mCurrentBuffer;
+    }
+    mRDH = reinterpret_cast<const header::RAWDataHeader*>(&mBytes[mNextHeaderIndex]);
+    mEndOfPayloadIndex = mNextHeaderIndex + (mRDH->memorySize / mElementSizeInBytes);
+    // Go to end of header, i.e. beginning of payload
+    mElementIndex = mNextHeaderIndex + (mRDH->headerSize / mElementSizeInBytes);
+    mNextHeaderIndex += mRDH->offsetToNext / mElementSizeInBytes;
+    mBitIndex = 0;
+  }
+
+  return true;
+}
+
+template <typename T>
+void RawBuffer<T>::reset()
+{
+  /// Rewind bytes
+  mElementIndex = 0;
+  mNextHeaderIndex = 0;
+  mEndOfPayloadIndex = 0;
+  mBitIndex = 0;
+  mRDH = nullptr;
+  mUnconsumed.clear();
+}
+
+template <typename T>
+void RawBuffer<T>::setBuffer(gsl::span<const T> bytes, bool keepUnconsumed)
+{
+  /// Sets the buffer and reset the internal indexes
+  if (keepUnconsumed && !mUnconsumed.empty()) {
+    // There are some unconsumed bytes from the previous buffer
+    mNextHeaderIndex = mUnconsumed.size();
+    mEndOfPayloadIndex -= mElementIndex;
+    mElementIndex = 0;
+    mBytes = gsl::span<const T>(mUnconsumed);
+  } else {
+    mBytes = bytes;
+    reset();
+  }
+  mCurrentBuffer = bytes;
+  nextPayload();
+}
+
+template <typename T>
+bool RawBuffer<T>::isHBClosed()
+{
+  /// Tests if the HB is closed
+  if (!mRDH) {
+    return false;
+  }
+  return mRDH->stop;
+}
+
+template <typename T>
+void RawBuffer<T>::skipOverhead()
+{
+  /// This function must be called after reading a block of data
+  /// if the payload is not provided and/or readout in bytes.
+  ///
+  /// In this case, indeed, there can  be an overhead between the last useful bit and the declared memory size,
+  /// which is in bytes.
+  /// Calling this function allows to jump directly to the next header when needed
+  if (mElementIndex == mEndOfPayloadIndex - 1) {
+    mElementIndex = mEndOfPayloadIndex;
+    mBitIndex = 0;
+  }
+}
+
+template <typename T>
+bool RawBuffer<T>::hasNext(unsigned int nBytes)
+{
+  /// Tests if the buffer has nBytes left
+
+  // We first need to go to the next payload
+  // If we do not, we could have a set of empty HBs in front of us
+  // With lot of memory left in the buffer but no payload
+  nextPayload();
+  bool isOk = mCurrentBuffer.size() + mUnconsumed.size() - mNextHeaderIndex + mEndOfPayloadIndex - mElementIndex >= nBytes / mElementSizeInBytes;
+  if (!isOk) {
+    // Store the remaining bits for further use
+    // We need to do it here because we know that the vector of which the mBytes is just a spas, is valid
+    // If we do it in set buffer, this might not be the case anymore
+    std::copy(mBytes.begin() + mElementIndex, mBytes.end(), std::back_inserter(mUnconsumed));
+  }
+  return isOk;
+}
+
+template <typename T>
+bool RawBuffer<T>::nextHeader(gsl::span<const T> bytes)
+{
+  /// Go to next header
+  /// This is only useful when one reads from file
+  /// and wants to read up to the next header to find out how many bytes to read next
+  mBytes = bytes;
+  if (mElementIndex >= mBytes.size()) {
+    reset();
+  }
+  mEndOfPayloadIndex = mElementIndex;
+  return nextPayload();
+}
+
+template class RawBuffer<raw::RawUnit>;
+template class RawBuffer<uint8_t>;
+
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/Raw/src/RawFileReader.cxx
+++ b/Detectors/MUON/MID/Raw/src/RawFileReader.cxx
@@ -1,0 +1,170 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Raw/src/RawFileReader.cxx
+/// \brief  MID raw file reader
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   25 November 2019
+
+#include "MIDRaw/RawFileReader.h"
+
+#include <iostream>
+#include "Headers/RAWDataHeader.h"
+
+namespace o2
+{
+namespace mid
+{
+template <typename T>
+bool RawFileReader<T>::init(const char* inFilename, bool readContinuous)
+{
+  /// Initializes the raw file reader
+  mFile.open(inFilename, std::ios::binary);
+  if (!mFile.is_open()) {
+    std::cerr << "Cannot open the " << inFilename << " file !";
+    mState = 2;
+    return false;
+  }
+  mBytes.reserve(2 * raw::sMaxBufferSize);
+  mReadContinuous = readContinuous;
+  mHBCounters.fill(0);
+
+  return true;
+}
+
+template <typename T>
+void RawFileReader<T>::read(size_t nBytes)
+{
+  /// Reads nBytes of the file
+  size_t currentIndex = mBytes.size();
+  mBytes.resize(currentIndex + nBytes / sizeof(T));
+  mFile.read(reinterpret_cast<char*>(&(mBytes[currentIndex])), nBytes);
+}
+
+template <typename T>
+void RawFileReader<T>::clear()
+{
+  /// Clears the bytes and counters
+  mBytes.clear();
+  mHBCounters.fill(0);
+}
+
+template <typename T>
+bool RawFileReader<T>::hasFullInfo()
+{
+  /// Tests if we have read the same number of HBs for all GBT links
+
+  // We assume here that we read the data of one HV for all of the GBT links
+  // before moving to the next HB
+  for (uint16_t feeId = 1; feeId < crateparams::sNGBTs; ++feeId) {
+    if (mHBCounters[feeId] != mHBCounters[0]) {
+      return false;
+    }
+  }
+  return mHBCounters[0] != 0;
+}
+
+template <typename T>
+bool RawFileReader<T>::readAllGBTs(bool reset)
+{
+  /// Keeps reading the file until it reads the information of all GBT links
+  /// It returns the number of HBs read
+
+  if (reset) {
+    clear();
+  }
+
+  while (!hasFullInfo()) {
+    if (!readHB()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+template <typename T>
+bool RawFileReader<T>::replaceRDH(size_t headerIndex)
+{
+  /// Replaces the current RDH with a custom one if needed.
+  /// This is done to be able to correctly read test data
+  /// that have a wrong RDH
+  if (mCustomRDH.offsetToNext > 0) {
+    header::RAWDataHeader* rdh = reinterpret_cast<header::RAWDataHeader*>(&mBytes[headerIndex]);
+    *rdh = mCustomRDH;
+    return true;
+  }
+  return false;
+}
+
+template <typename T>
+bool RawFileReader<T>::readHB(bool sendCompleteHBs)
+{
+  /// Reads one HB
+  if (mState != 0) {
+    return false;
+  }
+  auto gbtId = 0;
+  bool isHBClosed = false;
+  while (!isHBClosed) {
+    // Read header
+    size_t headerIndex = mBytes.size();
+    read(raw::sHeaderSizeInBytes);
+
+    // The check on the eof needs to be placed here and not at the beginning of the function.
+    // The reason is that the eof flag is set if we try to read after the eof
+    // But, since we know the size, we read up to the last character.
+    // So we turn on the eof flag only if we try to read past the last data.
+    // Of course, we resized the mBytes before trying to read.
+    // Since we read 0, we need to remove the last bytes
+    if (mFile.eof()) {
+      mBytes.resize(headerIndex);
+      if (mReadContinuous) {
+        mFile.clear();
+        mFile.seekg(0, std::ios::beg);
+        read(raw::sHeaderSizeInBytes);
+      } else {
+        mState = 1;
+        return false;
+      }
+    }
+    replaceRDH(headerIndex);
+    // We use the buffer only to correctly initialize the RDH
+    mBuffer.nextHeader(mBytes);
+    isHBClosed = mBuffer.isHBClosed();
+    gbtId = mBuffer.getRDH()->feeId;
+    // CAVEAT: do not call mBuffer.getRDH() beyond this line
+    // To save memory/CPU time, the RawBuffer does not hold a copy of the buffer,
+    // but just a span of it.
+    // If we add bytes to mBytes, the vector can go beyond the capacity
+    // and the memory is re-allocated.
+    // If this happens, the span is no longer valid, and we can no longer
+    // call mBuffer.getRDH() until we pass it mBytes again
+    if (gbtId >= crateparams::sNGBTs) {
+      // FIXME: this is a problem of the header of some test files
+      gbtId = 0;
+    }
+    if (mBuffer.getRDH()->offsetToNext > raw::sHeaderSizeInBytes) {
+      read(mBuffer.getRDH()->offsetToNext - raw::sHeaderSizeInBytes);
+    }
+    if (!sendCompleteHBs) {
+      break;
+    }
+  }
+
+  ++mHBCounters[gbtId];
+
+  return true;
+}
+
+template class RawFileReader<raw::RawUnit>;
+template class RawFileReader<uint8_t>;
+
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/Raw/src/RawInfo.h
+++ b/Detectors/MUON/MID/Raw/src/RawInfo.h
@@ -21,30 +21,27 @@ namespace o2
 {
 namespace mid
 {
-
 // Local board patterns
-static constexpr unsigned int sNBitsBoardId = 2;
+static constexpr unsigned int sNBitsLocId = 4;
 static constexpr unsigned int sNBitsFiredStrips = 16;
 
 // Column info
-static constexpr unsigned int sNBitsColumnId = 3;
-static constexpr unsigned int sNBitsNFiredBoards = 3;
+static constexpr unsigned int sNBitsCrateId = 4;
+static constexpr unsigned int sNBitsNFiredBoards = 4;
 
-// RPC info
-static constexpr unsigned int sNBitsRPCId = 7;
-static constexpr unsigned int sNBitsNFiredColumns = 3;
-
-static constexpr unsigned int sNBitsNFiredRPCs = 7;
+// Chamber info
+static constexpr unsigned int sNBitsFiredChambers = 4;
 
 // Local clock
 static constexpr unsigned int sNBitsLocalClock = 16;
 
-// Trigger info
-static constexpr unsigned int sNBitsEventType = 2;
-static constexpr unsigned int sStandardEvent = 0;
-static constexpr unsigned int sSoftwareTriggerEvent = 1;
-static constexpr unsigned int sFEEEvent = 2;
+// Event info
+static constexpr unsigned int sNBitsEventWord = 8;
+static constexpr uint16_t sDelayCalibToFET = 10;
+static constexpr uint16_t sDelayBCToLocal = 0;
 
+// Buffer info
+static constexpr unsigned int sMaxPageSize = 0x2000;
 } // namespace mid
 } // namespace o2
 

--- a/Detectors/MUON/MID/Raw/test/CMakeLists.txt
+++ b/Detectors/MUON/MID/Raw/test/CMakeLists.txt
@@ -8,16 +8,25 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
-o2_add_test(Raw
-            SOURCES testRaw.cxx
-            PUBLIC_LINK_LIBRARIES O2::DataFormatsMID O2::MIDRaw
-            COMPONENT_NAME mid
-            LABELS mid muon)
+o2_add_test(
+  Raw
+  SOURCES testRaw.cxx
+  PUBLIC_LINK_LIBRARIES O2::DataFormatsMID O2::MIDRaw
+  COMPONENT_NAME mid
+  LABELS mid muon)
+
+o2_add_test(
+  CrateMapper
+  SOURCES testCrateMapper.cxx
+  PUBLIC_LINK_LIBRARIES O2::MIDRaw
+  COMPONENT_NAME mid
+  LABELS mid muon)
 
 if(benchmark_FOUND)
-  o2_add_executable(raw
-                    COMPONENT_NAME mid
-                    SOURCES bench_Raw.cxx
-                    IS_BENCHMARK
-                    PUBLIC_LINK_LIBRARIES O2::MIDRaw benchmark::benchmark)
+  o2_add_executable(
+    raw
+    COMPONENT_NAME mid
+    SOURCES bench_Raw.cxx
+    IS_BENCHMARK
+    PUBLIC_LINK_LIBRARIES O2::MIDRaw benchmark::benchmark)
 endif()

--- a/Detectors/MUON/MID/Raw/test/testCrateMapper.cxx
+++ b/Detectors/MUON/MID/Raw/test/testCrateMapper.cxx
@@ -1,0 +1,96 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// @author  Diego Stocco
+
+#define BOOST_TEST_MODULE Test MID CrateMapper
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+
+#include <boost/test/data/test_case.hpp>
+#include <iostream>
+#include "MIDBase/Mapping.h"
+#include "MIDBase/DetectorParameters.h"
+#include "MIDRaw/CrateMapper.h"
+#include "MIDRaw/CrateParameters.h"
+
+BOOST_AUTO_TEST_SUITE(o2_mid_CrateMapper)
+
+BOOST_AUTO_TEST_CASE(FEEBoardToDE)
+{
+  o2::mid::CrateMapper crateMapper;
+  for (uint8_t icrate = 0; icrate < o2::mid::crateparams::sNCrates; ++icrate) {
+    int crateIdInSide = icrate % (o2::mid::crateparams::sNCrates / 2);
+    for (uint8_t iboard = 0; iboard < o2::mid::crateparams::sMaxNBoardsInCrate; ++iboard) {
+      int boardInSide = iboard % o2::mid::crateparams::sMaxNBoardsInLink;
+      bool exceptionExpected = false;
+      if ((crateIdInSide == 1 || crateIdInSide == 3) && iboard == 15) {
+        exceptionExpected = true;
+      } else if (crateIdInSide == 2 && boardInSide == 7) {
+        exceptionExpected = true;
+      } else if (crateIdInSide == 7 && iboard > 8) {
+        exceptionExpected = true;
+      }
+      bool exceptionReceived = false;
+      try {
+        crateMapper.roLocalBoardToDE(icrate, iboard);
+      } catch (std::runtime_error except) {
+        exceptionReceived = true;
+      }
+      std::stringstream ss;
+      ss << "CrateId: " << static_cast<int>(icrate) << "  boardId: " << static_cast<int>(iboard) << "  exception expected: " << exceptionExpected << "  received: " << exceptionReceived;
+      BOOST_TEST(exceptionExpected == exceptionReceived, ss.str());
+    }
+  }
+}
+
+BOOST_AUTO_TEST_CASE(DEBoardToFEE)
+{
+  o2::mid::Mapping mapping;
+  o2::mid::CrateMapper crateMapper;
+  for (int ide = 0; ide < o2::mid::detparams::NDetectionElements; ++ide) {
+    for (int icol = mapping.getFirstColumn(ide); icol < 7; ++icol) {
+      for (int iline = mapping.getFirstBoardBP(icol, ide); iline <= mapping.getLastBoardBP(icol, ide); ++iline) {
+        try {
+          crateMapper.deLocalBoardToRO(ide, icol, iline);
+        } catch (std::runtime_error except) {
+          std::stringstream ss;
+          ss << "DEId: " << static_cast<int>(ide) << "  colId: " << static_cast<int>(icol) << "  lineId: " << static_cast<int>(iline) << "  exception received!";
+          BOOST_TEST(false, ss.str());
+        }
+      }
+    }
+  }
+}
+
+BOOST_AUTO_TEST_CASE(Consistency)
+{
+  o2::mid::Mapping mapping;
+  o2::mid::CrateMapper crateMapper;
+  for (int ide = 0; ide < o2::mid::detparams::NDetectionElements; ++ide) {
+    for (int icol = mapping.getFirstColumn(ide); icol < 7; ++icol) {
+      for (int iline = mapping.getFirstBoardBP(icol, ide); iline <= mapping.getLastBoardBP(icol, ide); ++iline) {
+        auto uniqueLocId = crateMapper.deLocalBoardToRO(ide, icol, iline);
+        auto crateId = o2::mid::crateparams::getCrateId(uniqueLocId);
+        auto deBoardId = crateMapper.roLocalBoardToDE(crateId, o2::mid::crateparams::getLocId(uniqueLocId));
+        BOOST_TEST(static_cast<int>(crateMapper.getColumnId(deBoardId)) == icol);
+        BOOST_TEST(static_cast<int>(crateMapper.getLineId(deBoardId)) == iline);
+        int rpcLineId = crateMapper.getRPCLine(deBoardId);
+        BOOST_TEST(rpcLineId == o2::mid::detparams::getRPCLine(ide));
+        int ich = o2::mid::detparams::getChamber(ide);
+        BOOST_TEST(o2::mid::detparams::getDEId(o2::mid::crateparams::isRightSide(crateId), ich, rpcLineId) == ide);
+      }
+    }
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/Detectors/MUON/MID/Raw/test/testRaw.cxx
+++ b/Detectors/MUON/MID/Raw/test/testRaw.cxx
@@ -20,9 +20,14 @@
 #include <iostream>
 #include <vector>
 #include <map>
+#include "CommonDataFormat/InteractionRecord.h"
 #include "DataFormatsMID/ColumnData.h"
-#include "MIDRaw/Encoder.h"
+#include "MIDBase/DetectorParameters.h"
+#include "MIDBase/Mapping.h"
+#include "MIDRaw/CrateParameters.h"
 #include "MIDRaw/Decoder.h"
+#include "MIDRaw/Encoder.h"
+#include "MIDRaw/CRUUserLogicDecoder.h"
 #include "MIDRaw/RawUnit.h"
 
 BOOST_AUTO_TEST_SUITE(o2_mid_raw)
@@ -40,6 +45,13 @@ o2::mid::ColumnData getColData(uint8_t deId, uint8_t columnId, uint16_t nbp = 0,
   return col;
 }
 
+std::vector<o2::mid::ColumnData> sortData(const std::vector<o2::mid::ColumnData>& data, size_t first, size_t last)
+{
+  std::vector<o2::mid::ColumnData> sortedData(data.begin() + first, data.begin() + last);
+  std::sort(sortedData.begin(), sortedData.end(), [](o2::mid::ColumnData& a, o2::mid::ColumnData& b) { if (a.deId == b.deId ) return (a.columnId < b.columnId); return (a.deId < b.deId); });
+  return sortedData;
+}
+
 void doTest(const o2::mid::EventType& inEventType, const std::map<uint16_t, std::vector<o2::mid::ColumnData>>& inData, const std::vector<o2::mid::ROFRecord>& rofRecords, const std::vector<o2::mid::ColumnData>& data)
 {
   BOOST_TEST(rofRecords.size() == inData.size());
@@ -48,77 +60,110 @@ void doTest(const o2::mid::EventType& inEventType, const std::map<uint16_t, std:
     BOOST_TEST(static_cast<int>(rofIt->eventType) == static_cast<int>(inEventType));
     BOOST_TEST(rofIt->interactionRecord.bc == inItMap->first);
     BOOST_TEST(rofIt->nEntries == inItMap->second.size());
-    for (size_t icol = rofIt->firstEntry; icol < rofIt->firstEntry + rofIt->nEntries; ++icol) {
-      size_t inCol = icol - rofIt->firstEntry;
-      BOOST_TEST(data[icol].deId == inItMap->second[inCol].deId);
-      BOOST_TEST(data[icol].columnId == inItMap->second[inCol].columnId);
-      BOOST_TEST(data[icol].getNonBendPattern() == inItMap->second[inCol].getNonBendPattern());
+    auto sortedIn = sortData(inItMap->second, 0, inItMap->second.size());
+    auto sortedOut = sortData(data, rofIt->firstEntry, rofIt->firstEntry + rofIt->nEntries);
+    for (size_t icol = 0; icol < sortedOut.size(); ++icol) {
+      // size_t inCol = icol - rofIt->firstEntry;
+      BOOST_TEST(sortedOut[icol].deId == sortedIn[icol].deId);
+      BOOST_TEST(sortedOut[icol].columnId == sortedIn[icol].columnId);
+      BOOST_TEST(sortedOut[icol].getNonBendPattern() == sortedIn[icol].getNonBendPattern());
       for (int iline = 0; iline < 4; ++iline) {
-        BOOST_TEST(data[icol].getBendPattern(iline) == inItMap->second[inCol].getBendPattern(iline));
+        BOOST_TEST(sortedOut[icol].getBendPattern(iline) == sortedIn[icol].getBendPattern(iline));
       }
     }
     ++inItMap;
   }
 }
 
-BOOST_AUTO_TEST_CASE(TestRawSmall)
+BOOST_AUTO_TEST_CASE(CRUUserLogicDecoder)
+{
+  /// Event with just one link fired
+
+  std::map<uint16_t, std::vector<o2::mid::ColumnData>> inData;
+  uint16_t bc = 100;
+  // Crate 5 link 0
+  inData[bc].emplace_back(getColData(2, 4, 0, 0xFFFF));
+
+  bc = 200;
+  inData[bc].emplace_back(getColData(3, 4, 0xFF00, 0xFF));
+  o2::mid::Encoder encoder;
+  uint32_t orbit = 0;
+  for (auto& item : inData) {
+    o2::InteractionRecord ir(item.first, orbit);
+    encoder.process(item.second, ir, o2::mid::EventType::Standard);
+  }
+  o2::mid::CRUUserLogicDecoder CRUUserLogicDecoder;
+  CRUUserLogicDecoder.process(encoder.getBuffer());
+  BOOST_TEST(CRUUserLogicDecoder.getROFRecords().size() == inData.size());
+}
+
+BOOST_AUTO_TEST_CASE(SmallSample)
 {
   std::map<uint16_t, std::vector<o2::mid::ColumnData>> inData;
   // Small standard event
-  uint16_t localClock = 100;
-  inData[localClock].emplace_back(getColData(2, 4, 0, 0xFFFF));
-  inData[localClock].emplace_back(getColData(2, 5, 0xFFFF, 0));
-  inData[localClock].emplace_back(getColData(4, 6, 0xFF0F, 0, 0xF0FF, 0xF));
-  localClock = 200;
-  inData[localClock].emplace_back(getColData(34, 3, 0xFF00, 0xFF));
+  uint16_t bc = 100;
+
+  // Crate 5 link 0
+  inData[bc].emplace_back(getColData(2, 4, 0, 0xFFFF));
+  inData[bc].emplace_back(getColData(11, 4, 0, 0xFFFF));
+
+  // Crate 1 link 1 and crate 2 link 0
+  inData[bc].emplace_back(getColData(5, 1, 0xFFFF, 0, 0xF, 0xF0));
+  // Crate 10 link 1 and crate 11 link 1
+  inData[bc].emplace_back(getColData(41, 2, 0xFF0F, 0, 0xF0FF, 0xF));
+  bc = 200;
+  // Crate 12 link 1
+  inData[bc].emplace_back(getColData(70, 3, 0xFF00, 0xFF));
   o2::mid::EventType inEventType = o2::mid::EventType::Standard;
   o2::mid::Encoder encoder;
-  o2::mid::Decoder decoder;
-  decoder.init();
-  uint32_t orbit = 20;
+  uint32_t orbit = 0;
   for (auto& item : inData) {
-    encoder.newHeader(40, ++orbit, 0);
-    encoder.process(item.second, item.first, inEventType);
+    o2::InteractionRecord ir(item.first, orbit);
+    encoder.process(item.second, ir, o2::mid::EventType::Standard);
   }
+  o2::mid::Decoder decoder;
   decoder.process(encoder.getBuffer());
   doTest(inEventType, inData, decoder.getROFRecords(), decoder.getData());
 }
 
-BOOST_AUTO_TEST_CASE(TestRawBig)
+BOOST_AUTO_TEST_CASE(LargeBufferSample)
 {
+  o2::mid::Mapping mapping;
   std::map<uint16_t, std::vector<o2::mid::ColumnData>> inData;
   // Big event that should pass the 8kB
-  for (int irepeat = 0; irepeat < 4; ++irepeat) {
-    uint16_t localClock = 100 + irepeat;
-    for (int ide = 0; ide < 72; ++ide) {
-      for (int icol = 0; icol < 7; ++icol) {
-        inData[localClock].emplace_back(getColData(ide, icol, 0xFF00, 0xFFFF));
+  for (int irepeat = 0; irepeat < 150; ++irepeat) {
+    uint16_t bc = 100 + irepeat;
+    for (int ide = 0; ide < o2::mid::detparams::NDetectionElements; ++ide) {
+      // Since we have 1 RDH per GBT, we can put data only on 1 column
+      int icol = 4;
+      // for (int icol = mapping.getFirstColumn(ide); icol < 7; ++icol) {
+      if (mapping.getFirstBoardBP(icol, ide) != 0) {
+        continue;
       }
+      inData[bc].emplace_back(getColData(ide, icol, 0xFF00, 0xFFFF));
     }
   }
   o2::mid::EventType inEventType = o2::mid::EventType::Standard;
   o2::mid::Encoder encoder;
-  uint32_t orbit = 20;
-  encoder.newHeader(40, ++orbit, 0);
+  uint32_t orbit = 0;
   for (auto& item : inData) {
-    encoder.process(item.second, item.first, inEventType);
+    o2::InteractionRecord ir(item.first, orbit);
+    encoder.process(item.second, ir, inEventType);
   }
   o2::mid::Decoder decoder;
-  decoder.init();
   decoder.process(encoder.getBuffer());
   doTest(inEventType, inData, decoder.getROFRecords(), decoder.getData());
 }
 
-BOOST_AUTO_TEST_CASE(TestRawHeaderOnly)
+BOOST_AUTO_TEST_CASE(RawHeaderOnly)
 {
   o2::mid::Encoder encoder;
+  std::vector<o2::mid::ColumnData> data;
   for (uint32_t iorbit = 1; iorbit < 10; ++iorbit) {
-    encoder.newHeader(40, iorbit, 0);
+    o2::InteractionRecord ir(0, iorbit);
+    encoder.process(data, ir, o2::mid::EventType::Standard);
   }
-  // End of data
-  encoder.newHeader(0, 0, 1);
   o2::mid::Decoder decoder;
-  decoder.init();
   decoder.process(encoder.getBuffer());
   BOOST_TEST(decoder.getROFRecords().size() == 0);
 }

--- a/Detectors/MUON/MID/Workflow/src/RawReaderSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/RawReaderSpec.cxx
@@ -23,7 +23,9 @@
 #include "Framework/Output.h"
 #include "Framework/Task.h"
 #include "DataFormatsMID/ColumnData.h"
+#include "MIDRaw/CrateParameters.h"
 #include "MIDRaw/Decoder.h"
+#include "MIDRaw/RawFileReader.h"
 
 namespace of = o2::framework;
 
@@ -38,104 +40,62 @@ class RawReaderDeviceDPL
   void init(of::InitContext& ic)
   {
     auto filename = ic.options().get<std::string>("mid-raw-infile");
-    mFile.open(filename.c_str());
-    if (!mFile.is_open()) {
-      LOG(ERROR) << "Cannot open the " << filename << " file !";
-      mState = 1;
+    auto readContinuous = ic.options().get<bool>("mid-read-continuous");
+    if (!mRawFileReader.init(filename.c_str(), readContinuous)) {
       return;
     }
-    mBytes.reserve(2 * raw::sMaxBufferSize);
-    mDecoder.init();
 
     mHBperTimeframe = ic.options().get<int>("mid-hb-per-timeframe");
 
-    mState = 0;
-
     auto stop = [this]() {
       LOG(INFO) << "Capacities: ROFRecords: " << mDecoder.getROFRecords().capacity() << "  data: " << mDecoder.getData().capacity();
-      LOG(INFO) << "Read " << mHBCounter << " HBs in " << mElapsedTime.count() << " s";
+      LOG(INFO) << "Read " << mHBCounter << " HBs in " << mTimer.count() << " s";
+      double scaleFactor = 1.e6 / mNROFs;
+      LOG(INFO) << "Processing time / " << mNROFs << " ROFs: full: " << mTimer.count() * scaleFactor << " us  decoding: " << mTimerAlgo.count() * scaleFactor << " us";
     };
     ic.services().get<of::CallbackService>().set(of::CallbackService::Id::Stop, stop);
   }
 
   void run(of::ProcessingContext& pc)
   {
-    if (mState != 0) {
+    if (mRawFileReader.getState() != 0) {
       return;
     }
 
     auto tStart = std::chrono::high_resolution_clock::now();
 
-    readTF();
+    size_t nHBs = 0;
 
-    mDecoder.process(mBytes);
+    while (nHBs < mHBperTimeframe && mRawFileReader.readAllGBTs(false)) {
+      nHBs += mRawFileReader.getNumberOfHBs(0);
+    }
+    mHBCounter += nHBs;
+
+    auto tAlgoStart = std::chrono::high_resolution_clock::now();
+    mDecoder.process(mRawFileReader.getData());
+    mTimerAlgo += std::chrono::high_resolution_clock::now() - tAlgoStart;
+
+    mRawFileReader.clear();
 
     pc.outputs().snapshot(of::Output{"MID", "DATA", 0, of::Lifetime::Timeframe}, mDecoder.getData());
     pc.outputs().snapshot(of::Output{"MID", "DATAROF", 0, of::Lifetime::Timeframe}, mDecoder.getROFRecords());
-    LOG(DEBUG) << "Sent " << mDecoder.getData().size() << " column data";
 
-    mElapsedTime += std::chrono::high_resolution_clock::now() - tStart;
+    mTimer += std::chrono::high_resolution_clock::now() - tStart;
+    mNROFs += mDecoder.getROFRecords().size();
 
-    if (mState == 1) {
-      pc.services().get<of::ControlService>().readyToQuit(of::QuitRequest::Me);
+    if (mRawFileReader.getState() == 1) {
+      pc.services().get<of::ControlService>().endOfStream();
     }
   }
 
  private:
-  void read(size_t nBytes)
-  {
-    size_t currentIndex = mBytes.size();
-    mBytes.resize(currentIndex + nBytes / raw::sElementSizeInBytes);
-    mFile.read(reinterpret_cast<char*>(&(mBytes[currentIndex])), nBytes);
-  }
-
-  bool readTF()
-  {
-    mBytes.clear();
-    while (readBlock()) {
-      ++mHBCounter;
-      if (mHBCounter % mHBperTimeframe == 0) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  bool readBlock()
-  {
-    bool stop = false;
-    while (!stop) {
-      // Read header
-      read(raw::sHeaderSizeInBytes);
-
-      // The check on the eof needs to be placed here and not at the beginning of the function.
-      // The reason is that the eof flag is set if we try to read after the eof
-      // But, since we know the size, we read up to the last character.
-      // So we turn on the eof flag only if we try to read past the last data.
-      // Of course, we resized the mBytes before trying to read.
-      // Since we read 0, we need to remove the last bytes
-      if (mFile.eof()) {
-        mBytes.resize(mBytes.size() - raw::sHeaderSizeInElements);
-        mState = 1;
-        return false;
-      }
-      const header::RAWDataHeader* rdh = reinterpret_cast<const header::RAWDataHeader*>(&(mBytes[mBytes.size() - raw::sHeaderSizeInElements]));
-      stop = rdh->stop;
-      if (rdh->offsetToNext > raw::sHeaderSizeInBytes) {
-        read(rdh->offsetToNext - raw::sHeaderSizeInBytes);
-      }
-    }
-
-    return true;
-  }
-
   Decoder mDecoder{};
-  std::ifstream mFile{};
-  std::vector<raw::RawUnit> mBytes{};
+  RawFileReader<raw::RawUnit> mRawFileReader{};
   int mHBperTimeframe{256};
   unsigned long int mHBCounter{0};
-  int mState{0};
-  std::chrono::duration<double> mElapsedTime{0}; ///< timer
+  std::chrono::duration<double> mTimer{0};     ///< full timer
+  std::chrono::duration<double> mTimerAlgo{0}; ///< algorithm timer
+  unsigned int mNROFs{0};                      /// Total number of processed ROFs
 };
 
 framework::DataProcessorSpec getRawReaderSpec()
@@ -146,8 +106,9 @@ framework::DataProcessorSpec getRawReaderSpec()
     of::Outputs{of::OutputSpec{"MID", "DATA"}, of::OutputSpec{"MID", "DATAROF"}},
     of::AlgorithmSpec{of::adaptFromTask<o2::mid::RawReaderDeviceDPL>()},
     of::Options{
-      {"mid-raw-infile", of::VariantType::String, "mid_raw.dat", {"Name of the input file"}},
-      {"mid-hb-per-timeframe", of::VariantType::Int, 256, {"Number of heart beats per timeframe"}}}};
+      {"mid-raw-infile", of::VariantType::String, "mid_raw.dat", {"Raw input file"}},
+      {"mid-hb-per-timeframe", of::VariantType::Int, 256, {"Number of heart beats per timeframe"}},
+      {"mid-read-continuous", of::VariantType::Bool, false, {"Rewind the file when reaching the end so to simulate a continuous readout"}}}};
 }
 } // namespace mid
 } // namespace o2


### PR DESCRIPTION
The old MID encoder/decoder assumed that the CRU user logic could merge the info coming from different GBTs.
This is actually not possible, so a new data format was implemented.
Thenew code makes use of the recent HBFUtils to correctly treat the RDHs.
The PR consists of several atomic commits: please do not squash.