### PR TITLE
Do not pass char* to construct a device adopted through adoptTask

### DIFF
--- a/Detectors/MUON/MID/Workflow/src/DigitReaderSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/DigitReaderSpec.cxx
@@ -86,7 +86,7 @@ class DigitsReaderDeviceDPL
     pc.outputs().snapshot(of::Output{"MID", "DATALABELS", 0, of::Lifetime::Timeframe}, mDigitsMerger.getMCContainer());
 
     mState = 2;
-    pc.services().get<of::ControlService>().readyToQuit(of::QuitRequest::Me);
+    pc.services().get<of::ControlService>().endOfStream();
   }
 
  private:


### PR DESCRIPTION
This PR fixes some issues in the MID specs. Passing a const char* to construct a divice adopted through adoptTask recently resulted in an error, since it seems that the pointer was copied as is by the framework and the corresponding object could have already been destroyed when the pointer was used.
The PR also removes the readyToQuit command. The quit is indeed handled in a better way through the endOfStream command.