### PR TITLE
Eliminate unused itsmft::Digit::mROFrame data member

### DIFF
--- a/Detectors/ITSMFT/ITS/QC/TestDataReaderWorkflow/src/TestDataReader.cxx
+++ b/Detectors/ITSMFT/ITS/QC/TestDataReaderWorkflow/src/TestDataReader.cxx
@@ -260,7 +260,7 @@ void TestDataReader::run(ProcessingContext& pc)
 
       if (mNewFileInj == 1) {
         cout << "New File Injected, Now Updating the Canvas and Light" << endl;
-        mDigitsTest.emplace_back(0, 0, 0, 0, 0);
+        mDigitsTest.emplace_back(0, 0, 0, 0);
         mMultiDigitsTest.push_back(mDigitsTest[0]);
         mErrorsVecTest.push_back(mErrors);
         mFileDone = 1;
@@ -379,7 +379,7 @@ void TestDataReader::run(ProcessingContext& pc)
             break;
           int col = pixel.getCol();
           int row = pixel.getRow();
-          mDigits.emplace_back(ChipID, NEvent, row, col, 0);
+          mDigits.emplace_back(ChipID, row, col, 0);
           Index = Index + 1;
         }
         NChip = NChip + 1;

--- a/Detectors/ITSMFT/common/base/include/ITSMFTBase/Digit.h
+++ b/Detectors/ITSMFT/common/base/include/ITSMFTBase/Digit.h
@@ -30,7 +30,7 @@ class Digit
 
  public:
   /// Constructor, initializing values for position, charge and readout frame
-  Digit(UShort_t chipindex = 0, UInt_t frame = 0, UShort_t row = 0, UShort_t col = 0, Int_t charge = 0);
+  Digit(UShort_t chipindex = 0, UShort_t row = 0, UShort_t col = 0, Int_t charge = 0);
 
   /// Destructor
   ~Digit() = default;
@@ -63,12 +63,6 @@ class Digit
   /// Add charge to the digit, registering the label if provided
   void addCharge(int charge) { setCharge(charge + int(mCharge)); }
 
-  /// Get the RO frame ID
-  UInt_t getROFrame() const { return mROFrame; }
-
-  /// Set RO frame ID
-  void setROFrame(UInt_t v) { mROFrame = v; }
-
   /// Print function: Print basic digit information on the  output stream
   std::ostream& print(std::ostream& output) const;
 
@@ -84,10 +78,9 @@ class Digit
   UShort_t mChipIndex = 0; ///< Chip index
   UShort_t mRow = 0;       ///< Pixel index in X
   UShort_t mCol = 0;       ///< Pixel index in Z
-  UShort_t mCharge = 0.f;  ///< Accumulated N electrons
-  UInt_t mROFrame = 0;     ///< readout frame ID
+  UShort_t mCharge = 0;    ///< Accumulated N electrons
 
-  ClassDefNV(Digit, 1);
+  ClassDefNV(Digit, 2);
 };
 } // namespace itsmft
 } // namespace o2

--- a/Detectors/ITSMFT/common/base/src/Digit.cxx
+++ b/Detectors/ITSMFT/common/base/src/Digit.cxx
@@ -18,16 +18,14 @@ ClassImp(o2::itsmft::Digit);
 
 using namespace o2::itsmft;
 
-Digit::Digit(UShort_t chipindex, UInt_t frame, UShort_t row, UShort_t col, Int_t charge)
-  : mChipIndex(chipindex), mRow(row), mCol(col), mROFrame(0)
+Digit::Digit(UShort_t chipindex, UShort_t row, UShort_t col, Int_t charge)
+  : mChipIndex(chipindex), mRow(row), mCol(col)
 {
-  setROFrame(frame);
   setCharge(charge);
 }
 
 std::ostream& Digit::print(std::ostream& output) const
 {
-  output << "ITSMFTDigit chip [" << mChipIndex << "] R:" << mRow << " C:" << mCol << " Q: " << mCharge << "ROFrame "
-         << getROFrame();
+  output << "ITSMFTDigit chip [" << mChipIndex << "] R:" << mRow << " C:" << mCol << " Q: " << mCharge;
   return output;
 }

--- a/Detectors/ITSMFT/common/simulation/src/Digitizer.cxx
+++ b/Detectors/ITSMFT/common/simulation/src/Digitizer.cxx
@@ -153,7 +153,7 @@ void Digitizer::fillOutputContainer(UInt_t frameLast)
         auto& preDig = iter->second; // preDigit
         if (preDig.charge >= mParams.getChargeThreshold()) {
           int digID = mDigits->size();
-          mDigits->emplace_back(chip.getChipIndex(), mROFrameMin, preDig.row, preDig.col, preDig.charge);
+          mDigits->emplace_back(chip.getChipIndex(), preDig.row, preDig.col, preDig.charge);
           mMCLabels->addElement(digID, preDig.labelRef.label);
           auto& nextRef = preDig.labelRef; // extra contributors are in extra array
           while (nextRef.next >= 0) {


### PR DESCRIPTION
mROFRame per digit is not used since we used external reference on digits belonging to a given ROFrame