### PR TITLE
Fixes in Doxygen documentation:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,8 +71,8 @@ matrix:
         # This is required because of differences between doxygen and github
         # markdown syntax for code blocks. The committed code should use
         # the github flavour and we generate the doxygen one on the fly.
-        git grep -l '^```[a-zA-Z]' | xargs sed -i .old -e 's|```\([a-zA-Z][a-zA-Z]*\)|\n```{.\1}\n|g;s|[.]bash|.sh|g;s|```|~~~~~~~|g'
-        find . -name "*.old" -delete
+        #git grep -l '^```[a-zA-Z]' | xargs sed -i .old -e 's|```\([a-zA-Z][a-zA-Z]*\)|\n```{.\1}\n|g;s|[.]bash|.sh|g;s|```|~~~~~~~|g'
+        #find . -name "*.old" -delete
         cmake .
         make doc
       deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,8 +64,17 @@ matrix:
             - doxygen-gui
             - graphviz
             - cmake
-      script: 
-        cmake --build . --target doc
+      script: |
+        cat > CMakeLists.txt <<\EOF
+        add_subdirectory(doc)
+        EOF
+        # This is required because of differences between doxygen and github
+        # markdown syntax for code blocks. The committed code should use
+        # the github flavour and we generate the doxygen one on the fly.
+        git grep -l '^```[a-zA-Z]' | xargs sed -i .old -e 's|```\([a-zA-Z][a-zA-Z]*\)|\n```{.\1}\n|g;s|[.]bash|.sh|g;s|```|~~~~~~~|g'
+        find . -name "*.old" -delete
+        cmake .
+        make doc
       deploy:
         provider: pages
         skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,11 +68,6 @@ matrix:
         cat > CMakeLists.txt <<\EOF
         add_subdirectory(doc)
         EOF
-        # This is required because of differences between doxygen and github
-        # markdown syntax for code blocks. The committed code should use
-        # the github flavour and we generate the doxygen one on the fly.
-        #git grep -l '^```[a-zA-Z]' | xargs sed -i .old -e 's|```\([a-zA-Z][a-zA-Z]*\)|\n```{.\1}\n|g;s|[.]bash|.sh|g;s|```|~~~~~~~|g'
-        #find . -name "*.old" -delete
         cmake .
         make doc
       deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,17 +64,8 @@ matrix:
             - doxygen-gui
             - graphviz
             - cmake
-      script: |
-        cat > CMakeLists.txt <<\EOF
-        add_subdirectory(doc)
-        EOF
-        # This is required because of differences between doxygen and github
-        # markdown syntax for code blocks. The committed code should use
-        # the github flavour and we generate the doxygen one on the fly.
-        git grep -l '^```[a-zA-Z]' | xargs sed -i .old -e 's|```\([a-zA-Z][a-zA-Z]*\)|\n```{.\1}\n|g;s|[.]bash|.sh|g;s|```|~~~~~~~|g'
-        find . -name "*.old" -delete
-        cmake .
-        make doc
+      script: 
+        cmake --build . --target doc
       deploy:
         provider: pages
         skip_cleanup: true

--- a/Algorithm/README.md
+++ b/Algorithm/README.md
@@ -1,3 +1,7 @@
+<!-- doxy
 \page refAlgorithm Module 'Algorithm'
+/doxy -->
+
+# Algorithm
 
 A description of this module is not yet available.

--- a/CCDB/README.md
+++ b/CCDB/README.md
@@ -1,4 +1,6 @@
+<!-- doxy
 \page refCCDB Module 'CCDB'
+/doxy -->
 
 # CCDB
 

--- a/Common/Field/macro/README.md
+++ b/Common/Field/macro/README.md
@@ -1,3 +1,5 @@
+\page refCommonFieldMacros Magnetic Field Macros
+
 ## Macros for magnetic field manipulations
 
 ```o2::field::MagneticWrapperChebyshev``` class allows to dump the field data to text file and recreate it back as a ROOT object from this file. This is useful if one needs to change the name or the namespace of this class or persistent classes it usese internally (e.g. ``MathUtils/Chebyshev3D.h``, ``MathUtils/Chebyshev3DCalc.h``)

--- a/Common/Field/macro/README.md
+++ b/Common/Field/macro/README.md
@@ -1,4 +1,6 @@
-\page refCommonFieldMacros Magnetic Field Macros
+<!-- doxy
+\page refCommonFieldMacros Field Macros
+/doxy -->
 
 ## Macros for magnetic field manipulations
 

--- a/Common/README.md
+++ b/Common/README.md
@@ -1,12 +1,20 @@
+<!-- doxy
 \page refCommon Module 'Common'
+/doxy -->
 
+# Common
+
+There is no module description yet.
+
+<!-- doxy
 This module contains the following submodules:
 
-- \subpage refCommonConstants
-- \subpage refCommonFieldMacros
-- \subpage refCommonMathUtils
-- \subpage refCommonSimConfig
-- \subpage refCommonTopologies
-- \subpage refCommonTypes
-- \subpage refCommonUtils
-- \subpage refCommonmaps
+* \subpage refCommonConstants
+* \subpage refCommonFieldMacros
+* \subpage refCommonMathUtils
+* \subpage refCommonSimConfig
+* \subpage refCommonTopologies
+* \subpage refCommonTypes
+* \subpage refCommonUtils
+* \subpage refCommonmaps
+/doxy -->

--- a/Common/README.md
+++ b/Common/README.md
@@ -3,7 +3,7 @@
 This module contains the following submodules:
 
 - \subpage refCommonConstants
-- \subpage refCommonField
+- \subpage refCommonFieldMacros
 - \subpage refCommonMathUtils
 - \subpage refCommonSimConfig
 - \subpage refCommonTopologies

--- a/Common/SimConfig/doc/ConfigurableParam.md
+++ b/Common/SimConfig/doc/ConfigurableParam.md
@@ -1,4 +1,6 @@
+<!-- doxy
 \page refCommonSimConfig SimConfig
+/doxy -->
 
 # Configurable Parameters
 

--- a/DataFormats/README.md
+++ b/DataFormats/README.md
@@ -1,13 +1,21 @@
+<!-- doxy
 \page refDataFormats Module 'DataFormats'
+/doxy -->
 
+# Data Formats
+
+There is no module description yet.
+
+<!-- doxy
 This module contains the following submodules:
 
-- \subpage refDataFormatsDetectors
-- \subpage refDataFormatsHeaders
-- \subpage refDataFormatsLegacy
-- \subpage refDataFormatsMemoryResources
-- \subpage refDataFormatsParameters
-- \subpage refDataFormatsReconstruction
-- \subpage refDataFormatsTimeFrame
-- \subpage refDataFormatscommon
-- \subpage refDataFormatssimulation
+* \subpage refDataFormatsDetectors
+* \subpage refDataFormatsHeaders
+* \subpage refDataFormatsLegacy
+* \subpage refDataFormatsMemoryResources
+* \subpage refDataFormatsParameters
+* \subpage refDataFormatsReconstruction
+* \subpage refDataFormatsTimeFrame
+* \subpage refDataFormatscommon
+* \subpage refDataFormatssimulation
+/doxy -->

--- a/Detectors/Base/test/README.md
+++ b/Detectors/Base/test/README.md
@@ -1,3 +1,5 @@
+\page refDetectorsBasetest DetectorsBasetest
+
 # WORK IN PROGRESS: Mat.Budget LUT classes
 
 

--- a/Detectors/Base/test/README.md
+++ b/Detectors/Base/test/README.md
@@ -1,4 +1,6 @@
-\page refDetectorsBasetest DetectorsBasetest
+<!-- doxy
+\page refDetectorsBasetest Detectors Base test
+/doxy -->
 
 # WORK IN PROGRESS: Mat.Budget LUT classes
 

--- a/Detectors/ITSMFT/MFT/README.md
+++ b/Detectors/ITSMFT/MFT/README.md
@@ -1,7 +1,8 @@
+<!-- doxy
 \page refMFT MFT
+/doxy -->
 
-The Muon Forward Tracker
-========================
+# The Muon Forward Tracker
 
 #### When? 
 * After the second LHC Long Shutdown.

--- a/Detectors/ITSMFT/MFT/base/README.md
+++ b/Detectors/ITSMFT/MFT/base/README.md
@@ -1,4 +1,6 @@
+<!-- doxy
 \page refMFTbase MFT base
+/doxy -->
 
 # MFT base classes 
 

--- a/Detectors/ITSMFT/MFT/reconstruction/README.md
+++ b/Detectors/ITSMFT/MFT/reconstruction/README.md
@@ -1,7 +1,8 @@
+<!-- doxy
 \page refMFTreconstruction MFT reconstruction
+/doxy -->
 
-MFT track reconstruction
-========================
+# MFT track reconstruction
 
 (for the moment see macros/README)
 

--- a/Detectors/ITSMFT/README.md
+++ b/Detectors/ITSMFT/README.md
@@ -1,7 +1,13 @@
+<!-- doxy
 \page refDetectorsITSMFT ITSMFT
+/doxy -->
+
+# ITSMFT
 
 This is a top page for the ITSMFT detector documentation.
 
-- \subpage refMFT
-- \subpage refMFTbase
-- \subpage refMFTreconstruction
+<!-- doxy
+* \subpage refMFT
+* \subpage refMFTbase
+* \subpage refMFTreconstruction
+/doxy -->

--- a/Detectors/MUON/MCH/Contour/README.md
+++ b/Detectors/MUON/MCH/Contour/README.md
@@ -1,4 +1,6 @@
+<!-- doxy
 \page refMUONMCHContour MCH Contour
+/doxy -->
 
 # MCH Contour library
 

--- a/Detectors/MUON/MCH/Mapping/Impl3/README.md
+++ b/Detectors/MUON/MCH/Mapping/Impl3/README.md
@@ -1,4 +1,6 @@
+<!-- doxy
 \page refMUONMCHMappingImpl3 MCH Mapping Impl3
+/doxy -->
 
 # MCH Mapping Implementation
 

--- a/Detectors/MUON/MCH/Mapping/README.md
+++ b/Detectors/MUON/MCH/Mapping/README.md
@@ -1,4 +1,6 @@
+<!-- doxy
 \page refMUONMCHMapping MCH Mapping
+/doxy -->
 
 # MCH Mapping
 

--- a/Detectors/MUON/MCH/Mapping/SegContour/README.md
+++ b/Detectors/MUON/MCH/Mapping/SegContour/README.md
@@ -1,4 +1,6 @@
+<!-- doxy
 \page refMUONMCHMappingSegContour MCH Mapping SegContour
+/doxy -->
 
 # Segmentation contours
 

--- a/Detectors/MUON/MCH/Mapping/test/src/README.md
+++ b/Detectors/MUON/MCH/Mapping/test/src/README.md
@@ -1,4 +1,6 @@
-\page refMUONMCHMappingtest  MCH Mapping test
+<!-- doxy
+\page refMUONMCHMappingtest MCH Mapping test
+/doxy -->
 
 By default the tests are running without any input.
 

--- a/Detectors/MUON/MID/Clustering/README.md
+++ b/Detectors/MUON/MID/Clustering/README.md
@@ -1,4 +1,6 @@
+<!-- doxy
 \page refMUONMIDClustering MID Clustering
+/doxy -->
 
 # Running MID clustering
 

--- a/Detectors/MUON/MID/Tracking/README.md
+++ b/Detectors/MUON/MID/Tracking/README.md
@@ -1,4 +1,6 @@
+<!-- doxy
 \page refMUONMIDTracking MID Tracking
+/doxy -->
 
 # Running MID Tracking
 

--- a/Detectors/MUON/MID/Workflow/README.md
+++ b/Detectors/MUON/MID/Workflow/README.md
@@ -1,4 +1,6 @@
+<!-- doxy
 \page refMUONMIDWorkflow MID Workflow
+/doxy -->
 
 # Running MID workflow
 

--- a/Detectors/MUON/README.md
+++ b/Detectors/MUON/README.md
@@ -1,12 +1,18 @@
+<!-- doxy
 \page refDetectorsMUON MUON
+/doxy -->
+
+# MUON
 
 This is a top page for the MUON detector documentation.
 
-- \subpage refMUONMIDClustering
-- \subpage refMUONMIDTracking
-- \subpage refMUONMIDWorkflow
-- \subpage refMUONMCHMappingSegContour
-- \subpage refMUONMCHMapping
-- \subpage refMUONMCHMappingtest
-- \subpage refMUONMCHMappingImpl3
-- \subpage refMUONMCHContour
+<!-- doxy
+* \subpage refMUONMIDClustering
+* \subpage refMUONMIDTracking
+* \subpage refMUONMIDWorkflow
+* \subpage refMUONMCHMappingSegContour
+* \subpage refMUONMCHMapping
+* \subpage refMUONMCHMappingtest
+* \subpage refMUONMCHMappingImpl3
+* \subpage refMUONMCHContour
+/doxy -->

--- a/Detectors/MUON/README.md
+++ b/Detectors/MUON/README.md
@@ -4,6 +4,7 @@ This is a top page for the MUON detector documentation.
 
 - \subpage refMUONMIDClustering
 - \subpage refMUONMIDTracking
+- \subpage refMUONMIDWorkflow
 - \subpage refMUONMCHMappingSegContour
 - \subpage refMUONMCHMapping
 - \subpage refMUONMCHMappingtest

--- a/Detectors/README.md
+++ b/Detectors/README.md
@@ -2,7 +2,7 @@
 
 This module contains the following submodules:
 
-- \subpage refDetectorsBase
+- \subpage refDetectorsBasetest
 - \subpage refDetectorsEMCAL
 - \subpage refDetectorsFIT
 - \subpage refDetectorsGeometry

--- a/Detectors/README.md
+++ b/Detectors/README.md
@@ -1,18 +1,26 @@
+<!-- doxy
 \page refDetectors Module 'Detectors'
+/doxy -->
 
+# Detectors
+
+There is no module description yet.
+
+<!-- doxy
 This module contains the following submodules:
 
-- \subpage refDetectorsBasetest
-- \subpage refDetectorsEMCAL
-- \subpage refDetectorsFIT
-- \subpage refDetectorsGeometry
-- \subpage refDetectorsGlobalTracking
-- \subpage refDetectorsHMPID
-- \subpage refDetectorsITSMFT
-- \subpage refDetectorsMUON
-- \subpage refDetectorsPHOS
-- \subpage refDetectorsPassive
-- \subpage refDetectorsTOF
-- \subpage refDetectorsTPC
-- \subpage refDetectorsTRD
-- \subpage refDetectorsZDC
+* \subpage refDetectorsBasetest
+* \subpage refDetectorsEMCAL
+* \subpage refDetectorsFIT
+* \subpage refDetectorsGeometry
+* \subpage refDetectorsGlobalTracking
+* \subpage refDetectorsHMPID
+* \subpage refDetectorsITSMFT
+* \subpage refDetectorsMUON
+* \subpage refDetectorsPHOS
+* \subpage refDetectorsPassive
+* \subpage refDetectorsTOF
+* \subpage refDetectorsTPC
+* \subpage refDetectorsTRD
+* \subpage refDetectorsZDC
+/doxy -->

--- a/Detectors/TPC/README.md
+++ b/Detectors/TPC/README.md
@@ -1,5 +1,11 @@
+<!-- doxy
 \page refDetectorsTPC TPC
+/doxy -->
+
+# TPC
 
 This is a top page for the TPC detector documentation.
 
-- \subpage refTPCworkflow
+<!-- doxy
+* \subpage refTPCworkflow
+/doxy -->

--- a/Detectors/TPC/workflow/README.md
+++ b/Detectors/TPC/workflow/README.md
@@ -1,4 +1,6 @@
+<!-- doxy
 \page refTPCworkflow TPC workflow
+/doxy -->
 
 # DPL workflows for the TPC
 

--- a/Detectors/TRD/README.md
+++ b/Detectors/TRD/README.md
@@ -1,5 +1,11 @@
+<!-- doxy
 \page refDetectorsTRD TRD
+/doxy -->
+
+# TRD
 
 This is a top page for the TRD detector documentation.
 
-- \subpage refTRDbase
+<!-- doxy
+* \subpage refTRDbase
+/doxy -->

--- a/EventVisualisation/Base/README.md
+++ b/EventVisualisation/Base/README.md
@@ -1,3 +1,7 @@
+<!-- doxy
 \page refEventVisualisationBase EventVisualisation Base
+/doxy -->
+
+# Event Visualisation Base
 
 A description of this module is not yet available.

--- a/EventVisualisation/README.md
+++ b/EventVisualisation/README.md
@@ -1,6 +1,14 @@
+<!-- doxy
 \page refEventVisualisation Module 'EventVisualisation'
+/doxy -->
 
+# Event Visualisation
+
+There is no module description yet.
+
+<!-- doxy
 This module contains the following submodules:
 
-- \subpage refEventVisualisationBase
+* \subpage refEventVisualisationBase
+/doxy -->
 

--- a/Examples/Ex1/README.md
+++ b/Examples/Ex1/README.md
@@ -1,3 +1,7 @@
-\page refEx1 Ex1 A basic example with one library
+<!-- doxy
+\page refExamplesEx1 Ex1 A basic example with one library
+/doxy -->
+
+## Ex1 A basic example with one library
 
 See [CMakeInstructions](../doc/CMakeInstructions.md) for an explanation about this directory.

--- a/Examples/Ex2/README.md
+++ b/Examples/Ex2/README.md
@@ -1,3 +1,7 @@
-\page refEx2 Ex2 A basic library with a Root dictionary
+<!-- doxy
+\page refExamplesEx2 Ex2 A basic library with a Root dictionary
+/doxy -->
+
+## Ex2 A basic library with a Root dictionary
 
 See [CMakeInstructions](../doc/CMakeInstructions.md) for an explanation about this directory.

--- a/Examples/Ex3/README.md
+++ b/Examples/Ex3/README.md
@@ -1,3 +1,7 @@
-\page refEx3 Ex3 Adding an executable
+<!-- doxy
+\page refExamplesEx3 Ex3 Adding an executable
+/doxy -->
+
+## Ex3 Adding an executable
 
 See [CMakeInstructions](../doc/CMakeInstructions.md) for an explanation about this directory.

--- a/Examples/Ex4/README.md
+++ b/Examples/Ex4/README.md
@@ -1,3 +1,7 @@
-\page refEx4 Ex4 Adding tests
+<!-- doxy
+\page refExamplesEx4 Ex4 Adding tests
+/doxy -->
+
+## Ex4 Adding tests
 
 See [CMakeInstructions](../doc/CMakeInstructions.md) for an explanation about this directory.

--- a/Examples/Ex5/README.md
+++ b/Examples/Ex5/README.md
@@ -1,3 +1,7 @@
-\page refEx5 Ex5 Adding a man page
+<!-- doxy
+\page refExamplesEx5 Ex5 Adding a man page
+/doxy -->
+
+## Ex5 Adding a man page
 
 See [CMakeInstructions](../doc/CMakeInstructions.md) for an explanation about this directory.

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -1,13 +1,13 @@
-\\page refExamples Module 'Examples'
+\page refExamples Module 'Examples'
 
 This module contains the following submodules:
 
--   \\subpage refExamplesflp2epn
--   \\subpage refExamplesflp2epn-distributed
--   \\subpage refEx1
--   \\subpage refEx2
--   \\subpage refEx3
--   \\subpage refEx4
--   \\subpage refEx5
+-   \subpage refExamplesflp2epn
+-   \subpage refExamplesflp2epn-distributed
+-   \subpage refEx1
+-   \subpage refEx2
+-   \subpage refEx3
+-   \subpage refEx4
+-   \subpage refEx5
 
 The various `Ex` directories are incremental illustrations of [how to write](../doc/CMakeInstructions.md) `CMakeLists.txt` files within AliceO2 repository.

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -1,13 +1,17 @@
+<!-- doxy
 \page refExamples Module 'Examples'
+/doxy -->
 
-This module contains the following submodules:
-
--   \subpage refExamplesflp2epn
--   \subpage refExamplesflp2epn-distributed
--   \subpage refEx1
--   \subpage refEx2
--   \subpage refEx3
--   \subpage refEx4
--   \subpage refEx5
+# Examples
 
 The various `Ex` directories are incremental illustrations of [how to write](../doc/CMakeInstructions.md) `CMakeLists.txt` files within AliceO2 repository.
+
+<!-- doxy
+* \subpage refExamplesflp2epn
+* \subpage refExamplesflp2epn-distributed
+* \subpage refExamplesEx1
+* \subpage refExamplesEx2
+* \subpage refExamplesEx3
+* \subpage refExamplesEx4
+* \subpage refExamplesEx5
+/doxy -->

--- a/Examples/flp2epn-distributed/README.md
+++ b/Examples/flp2epn-distributed/README.md
@@ -1,4 +1,8 @@
+<!-- doxy
 \page refExamplesflp2epn-distributed Example flp2epn-distributed
+/doxy -->
+
+## Example flp2epn-distributed
 
 #### Prototype Devices for the transport between FLPs and EPNs
 --------------------------------------------------------------

--- a/Examples/flp2epn/README.md
+++ b/Examples/flp2epn/README.md
@@ -1,4 +1,8 @@
+<!-- doxy
 \page refExamplesflp2epn Example flp2epn
+/doxy -->
+
+## Example flp2epn
 
 #### Example devices - testFLP and testEPN
 

--- a/Framework/Core/ANALYSIS.md
+++ b/Framework/Core/ANALYSIS.md
@@ -1,4 +1,8 @@
+<!-- doxy
 \page refFrameworkCoreANALYSIS Core ANALYSIS
+/doxy -->
+
+##  Core ANALYSIS
 
 This document is WIP and provides an idea of what kind of API to expect from the DPL enabled analysis framework. APIs are neither final nor fully implemented in O2.
 

--- a/Framework/Core/ANALYSIS.md
+++ b/Framework/Core/ANALYSIS.md
@@ -1,3 +1,5 @@
+\page refFrameworkCoreANALYSIS Core ANALYSIS
+
 This document is WIP and provides an idea of what kind of API to expect from the DPL enabled analysis framework. APIs are neither final nor fully implemented in O2.
 
 # Analysis Task infrastructure on top of DPL

--- a/Framework/Core/COOKBOOK.md
+++ b/Framework/Core/COOKBOOK.md
@@ -1,4 +1,6 @@
+<!-- doxy
 \page refFrameworkCoreCOOKBOOK Core COOKBOOK
+/doxy -->
 
 # Data Processing Layer Cookbook
 

--- a/Framework/Core/README.md
+++ b/Framework/Core/README.md
@@ -1,6 +1,8 @@
+<!-- doxy
 \page refFrameworkCore Core
 \subpage refFrameworkCoreCOOKBOOK Core COOKBOOK
 \subpage refFrameworkCoreANALYSIS Core ANALYSIS
+/doxy -->
 
 # Data Processing Layer in O2 Framework
 

--- a/Framework/Core/README.md
+++ b/Framework/Core/README.md
@@ -1,5 +1,6 @@
 \page refFrameworkCore Core
 \subpage refFrameworkCoreCOOKBOOK Core COOKBOOK
+\subpage refFrameworkCoreANALYSIS Core ANALYSIS
 
 # Data Processing Layer in O2 Framework
 

--- a/Framework/Foundation/README.md
+++ b/Framework/Foundation/README.md
@@ -1,4 +1,6 @@
+<!-- doxy
 \page refFrameworkFoundation Foundation
+/doxy -->
 
 ## O2 Framework Foundation
 

--- a/Framework/Logger/README.md
+++ b/Framework/Logger/README.md
@@ -1,4 +1,6 @@
+<!-- doxy
 \page refFrameworkLogger Logger
+/doxy -->
 
 ## O2 Framework Logger
 

--- a/Framework/README.md
+++ b/Framework/README.md
@@ -6,5 +6,6 @@ This module contains the following submodules:
 - \subpage refFrameworkCore
 - \subpage refFrameworkDebugGUI
 - \subpage refFrameworkFoundation
+- \subpage refFrameworkLogger
 - \subpage refFrameworkTestWorkflows
 - \subpage refFrameworkUtils

--- a/Framework/README.md
+++ b/Framework/README.md
@@ -1,11 +1,19 @@
+<!-- doxy
 \page refFramework Module 'Framework'
+/doxy -->
 
+# Framework
+
+There is no module description yet.
+
+<!-- doxy
 This module contains the following submodules:
 
-- \subpage refFrameworkArrowTests
-- \subpage refFrameworkCore
-- \subpage refFrameworkDebugGUI
-- \subpage refFrameworkFoundation
-- \subpage refFrameworkLogger
-- \subpage refFrameworkTestWorkflows
-- \subpage refFrameworkUtils
+* \subpage refFrameworkArrowTests
+* \subpage refFrameworkCore
+* \subpage refFrameworkDebugGUI
+* \subpage refFrameworkFoundation
+* \subpage refFrameworkLogger
+* \subpage refFrameworkTestWorkflows
+* \subpage refFrameworkUtils
+/doxy -->

--- a/Framework/Utils/Readme.md
+++ b/Framework/Utils/Readme.md
@@ -1,4 +1,6 @@
+<!-- doxy
 \page refFrameworkUtils Utils
+/doxy -->
 
 ## DPL Utilities
 

--- a/Framework/Utils/Readme.md
+++ b/Framework/Utils/Readme.md
@@ -1,3 +1,5 @@
+\page refFrameworkUtils Utils
+
 ## DPL Utilities
 
 ### Raw proxy

--- a/Generators/README.md
+++ b/Generators/README.md
@@ -1,10 +1,13 @@
+<!-- doxy
 \page refGenerators Module 'Generators'
+/doxy -->
+
+# Generators
 
 A description of this module is not yet available.
 
 <!-- doxy
 This module contains the following submodules:
 
-- \subpage refGeneratorsshareexternal
-
+* \subpage refGeneratorsshareexternal
 /doxy -->

--- a/Generators/README.md
+++ b/Generators/README.md
@@ -1,3 +1,10 @@
 \page refGenerators Module 'Generators'
 
 A description of this module is not yet available.
+
+<!-- doxy
+This module contains the following submodules:
+
+- \subpage refGeneratorsshareexternal
+
+/doxy -->

--- a/Generators/share/external/README.md
+++ b/Generators/share/external/README.md
@@ -1,3 +1,5 @@
+\page refGeneratorsshareexternal External Generators
+
 # External generators
 
 

--- a/Generators/share/external/README.md
+++ b/Generators/share/external/README.md
@@ -1,4 +1,6 @@
+<!-- doxy
 \page refGeneratorsshareexternal External Generators
+/doxy -->
 
 # External generators
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ALICE O2 software {#mainpage}
 
-<!--  \cond EXCLUDE_FOR_DOXYGEN -->
+<!--  /// \cond EXCLUDE_FOR_DOXYGEN -->
 
 [![codecov](https://codecov.io/gh/AliceO2Group/AliceO2/branch/dev/graph/badge.svg)](https://codecov.io/gh/AliceO2Group/AliceO2/branches/dev)
 [![JIRA](https://img.shields.io/badge/JIRA-Report%20issue-blue.svg)](https://alice.its.cern.ch/jira/secure/CreateIssue.jspa?pid=11201&issuetype=1)
@@ -11,7 +11,7 @@
 [![](http://ali-ci.cern.ch/repo/buildstatus/AliceO2Group/AliceO2/dev/build_o2checkcode_o2.svg)](https://ali-ci.cern.ch/repo/logs/AliceO2Group/AliceO2/dev/latest/build_o2checkcode_o2/fullLog.txt)
 [![](http://ali-ci.cern.ch/repo/buildstatus/AliceO2Group/AliceO2/dev/build_O2_o2-dev-fairroot.svg)](https://ali-ci.cern.ch/repo/logs/AliceO2Group/AliceO2/dev/latest/build_O2_o2-dev-fairroot/fullLog.txt)
 
-<!--  \endcond  -->
+<!--  /// \endcond  -->
 
 ### Scope
 
@@ -20,7 +20,7 @@ Other repositories in AliceO2Group contain a number of large common modules, for
 
 ### Website
 
-The main entry point for O2 information is [here](http://alice-o2.web.cern.ch/).
+The main entry point for O2 information is [here](https://alice-o2-project.web.cern.ch).
 A quickstart page can be found under [https://aliceo2group.github.io/](https://aliceo2group.github.io/).
 
 ### Building / Installation
@@ -46,12 +46,12 @@ To access the resulting documentation, open doc/html/index.html in your
 build directory. To install the documentation when calling `cmake --build . -- install` (or `cmake --install` for CMake >= 3.15)
 turn on the variable `DOC_INSTALL`.
 
-The instruction how to add the documentation pages (README.md) are available [here](doc/DoxygenInstructions.md).
+The instruction how to add the documentation pages (README.md) are available [here](https://aliceo2group.github.io/AliceO2/refdocDoxygenInstructions.html).
 
 ### Build system (cmake) and directory structure
 
-The code organisation is described [here](doc/CodeOrganization.md).
-The build system (cmake) is described [here](doc/CMakeInstructions.md).
+The code organisation is described [here](https://aliceo2group.github.io/AliceO2/refdocCodeOrganization.html).
+The build system (cmake) is described [here](https://aliceo2group.github.io/AliceO2/refdocCMakeInstructions.html).
 
 ### Formatting
 

--- a/Steer/DigitizerWorkflow/README.md
+++ b/Steer/DigitizerWorkflow/README.md
@@ -1,4 +1,8 @@
+<!-- doxy
 \page refSteerDigitizerWorkflow Digitizer Workflow
+/doxy -->
+
+# Digitizer Workflow
 
 This is a short documention for the DPL-DigitizerWorkflow example
 

--- a/Steer/README.md
+++ b/Steer/README.md
@@ -1,4 +1,6 @@
+<!-- doxy
 \page refSteer Module 'Steer'
+/doxy -->
 
 # ALICEO2 Steer
 
@@ -11,6 +13,8 @@ a) quick prototyping of ideas without having to require immediate changes in Fai
 b) adaptations to classes because some things are done differently than in FairRoot
    (MC truth handling, parameter handling etc)
 
+<!-- doxy
 This module contains the following submodules:
 
-\subpage refSteerDigitizerWorkflow
+* \subpage refSteerDigitizerWorkflow
+/doxy -->

--- a/Testing/README.md
+++ b/Testing/README.md
@@ -1,3 +1,7 @@
+<!-- doxy
 \page refTesting Module 'Testing'
+/doxy -->
+
+# Testing
 
 A description of this module is not yet available.

--- a/Utilities/MCStepLogger/README.md
+++ b/Utilities/MCStepLogger/README.md
@@ -1,4 +1,6 @@
+<!-- doxy
 \page refUtilitiesMCStepLogger MCStepLogger
+/doxy -->
 
 ### NOTE: The MCStepLogger has moved to https://github.com/AliceO2Group/VMCStepLogger.git
 

--- a/Utilities/Mergers/README.md
+++ b/Utilities/Mergers/README.md
@@ -1,4 +1,6 @@
+<!-- doxy
 \page refUtilitiesMergers Mergers
+/doxy -->
 
 # O2 Mergers (experimental)
 

--- a/Utilities/Mergers/README.md
+++ b/Utilities/Mergers/README.md
@@ -1,3 +1,5 @@
+\page refUtilitiesMergers Mergers
+
 # O2 Mergers (experimental)
 
 Mergers are DPL devices able to merge ROOT objects produced in parallel. Topologies of mergers can be created using the

--- a/Utilities/O2Device/README.md
+++ b/Utilities/O2Device/README.md
@@ -1,4 +1,6 @@
+<!-- doxy
 \page refUtilitiesO2Device O2Device
+/doxy -->
 
 # O2Device
 

--- a/Utilities/PCG/README.md
+++ b/Utilities/PCG/README.md
@@ -1,4 +1,6 @@
+<!-- doxy
 \page refUtilitiesPCG PCG
+/doxy -->
 
 # PCG Random Number Generation, C++ Edition
 

--- a/Utilities/README.md
+++ b/Utilities/README.md
@@ -2,23 +2,22 @@
 \page refUtilities Module 'Utilities'
 /doxy -->
 
-Module 'Utilities'
-===================
+# Utilities
 
 There is no module description yet.
 
 <!-- doxy
 This module contains the following submodules:
 
-- \subpage refUtilitiesDataCompression
-- \subpage refUtilitiesDataFlow
-- \subpage refUtilitiesMCStepLogger
-- \subpage refUtilitiesMergers
-- \subpage refUtilitiesO2Device
-- \subpage refUtilitiesO2MessageMonitor
-- \subpage refUtilitiesPCG
-- \subpage refUtilitiesPublishers
-- \subpage refUtilitiesTools
-- \subpage refUtilitiesaliceHLTwrapper
-- \subpage refUtilitieshough
+* \subpage refUtilitiesDataCompression
+* \subpage refUtilitiesDataFlow
+* \subpage refUtilitiesMCStepLogger
+* \subpage refUtilitiesMergers
+* \subpage refUtilitiesO2Device
+* \subpage refUtilitiesO2MessageMonitor
+* \subpage refUtilitiesPCG
+* \subpage refUtilitiesPublishers
+* \subpage refUtilitiesTools
+* \subpage refUtilitiesaliceHLTwrapper
+* \subpage refUtilitieshough
 /doxy -->

--- a/Utilities/README.md
+++ b/Utilities/README.md
@@ -13,6 +13,7 @@ This module contains the following submodules:
 - \subpage refUtilitiesDataCompression
 - \subpage refUtilitiesDataFlow
 - \subpage refUtilitiesMCStepLogger
+- \subpage refUtilitiesMergers
 - \subpage refUtilitiesO2Device
 - \subpage refUtilitiesO2MessageMonitor
 - \subpage refUtilitiesPCG

--- a/Utilities/Tools/README.md
+++ b/Utilities/Tools/README.md
@@ -1,4 +1,6 @@
+<!-- doxy
 \page refUtilitiesTools Tools
+/doxy -->
 
 # Using the Code checker / fixer
 

--- a/Utilities/hough/README.md
+++ b/Utilities/hough/README.md
@@ -1,7 +1,8 @@
+<!-- doxy
 \page refUtilitieshough Hough Transform
+/doxy -->
 
-Hough Transform
-===============
+# Hough Transform
 
 This is the groundwork for the Hough Transform algorithm implementation. The runHough executable takes as an argument an event number (i.e. runHough 032) and for the given event it loads all clusters from the corresponding data files.
 

--- a/doc/CLion.md
+++ b/doc/CLion.md
@@ -1,4 +1,8 @@
+<!-- doxy
 \page refdocCLion CLion
+/doxy -->
+
+# CLion
 
 Here are a number of instructions and tips on how to use at best the IDE called [CLion from Jetbrains](https://www.jetbrains.com/clion/).
 

--- a/doc/CMakeInstructions.md
+++ b/doc/CMakeInstructions.md
@@ -1,4 +1,4 @@
-\\page refdocCMakeInstructions CMake Instructions
+\page refdocCMakeInstructions CMake Instructions
 
 <!-- vim-markdown-toc GFM -->
 

--- a/doc/CMakeInstructions.md
+++ b/doc/CMakeInstructions.md
@@ -1,4 +1,8 @@
+<!-- doxy
 \page refdocCMakeInstructions CMake Instructions
+
+\cond DOXYGEN_IGNORE
+/doxy -->
 
 <!-- vim-markdown-toc GFM -->
 
@@ -18,6 +22,10 @@
     - [Speeding up ctest execution](#speeding-up-ctest-execution)
 
 <!-- vim-markdown-toc -->
+
+<!-- doxy
+\endcond
+/doxy -->
 
 # CMake and CTest tips for AliceO2
 

--- a/doc/CMakeMigration.md
+++ b/doc/CMakeMigration.md
@@ -1,4 +1,6 @@
+<!-- doxy
 \page refdocModernCMakeMigration Modern CMake Migration
+/doxy -->
 
 # Migration to "Modern" CMake
 

--- a/doc/CMakeMigration.md
+++ b/doc/CMakeMigration.md
@@ -1,3 +1,5 @@
+\page refdocModernCMakeMigration Modern CMake Migration
+
 # Migration to "Modern" CMake
 
 ## Big picture

--- a/doc/CodeOrganization.md
+++ b/doc/CodeOrganization.md
@@ -1,4 +1,6 @@
+<!-- doxy
 \page refdocCodeOrganization Code Organization
+/doxy -->
 
 # Code organisation
 

--- a/doc/DetectorSimulation.md
+++ b/doc/DetectorSimulation.md
@@ -1,4 +1,6 @@
+<!-- doxy
 \page refdocDetectorSimulation Detector Simulation
+/doxy -->
 
 # Detector simulation documentation
 

--- a/doc/DoxygenInstructions.md
+++ b/doc/DoxygenInstructions.md
@@ -9,6 +9,8 @@ The Doxygen documentation pages are generated from the `README.md` files placed 
 
 The references between the Doxygen pages and subpages are achieved using a Doxygen `page` and `subpage` keywords. All `README.md` files must contain the Doxygen `page` tag on the top, and if the module contains other documentation pages (usually in its sub-directories), it must be linked using the Doxygen `subpage` tag.
 
+*When adding a new documentation page you must always add a `\subpage` declaration in an upper category page otherwise your page will pollute the "global" references in the left tab menu.*
+
 #### An example of a `README` file in the O2 directories at the top level.
 
     \page refModulename Module 'Modulename'

--- a/doc/DoxygenInstructions.md
+++ b/doc/DoxygenInstructions.md
@@ -1,38 +1,44 @@
+<!-- doxy
 \page refdocDoxygenInstructions Doxygen Instructions
+/doxy -->
 
-Doxygen
-=======
+# Doxygen 
 
 ## Instructions for the contributors
 
 The Doxygen documentation pages are generated from the `README.md` files placed in the O2 directories. 
 
-The references between the Doxygen pages and subpages are achieved using a Doxygen `page` and `subpage` keywords. All `README.md` files must contain the Doxygen `page` tag on the top, and if the module contains other documentation pages (usually in its sub-directories), it must be linked using the Doxygen `subpage` tag.
+The references between the Doxygen pages and subpages are achieved using a Doxygen `page` and `subpage` keywords. All `README.md` files must contain the Doxygen `page` tag on the top, and if the module contains other documentation pages (usually in its sub-directories), it must be linked using the Doxygen `subpage` tag. Special markdown comments are used to disable rendering of Doxygen keywords on GitHub.
 
 *When adding a new documentation page you must always add a `\subpage` declaration in an upper category page otherwise your page will pollute the "global" references in the left tab menu.*
 
+
 #### An example of a `README` file in the O2 directories at the top level.
 
+    <!-- doxy
     \page refModulename Module 'Modulename'
+    /doxy -->
 
-    The module title
-    ================
+    # The module title
 
     The paragraph(s) with the module description.
 
+    <!-- doxy
     This module contains the following submodules:
     
-    - \subpage refModulenameSubmodulename1
-    - \subpage refModulenameSubmodulename2
-    - \subpage refModulenameSubmodulename3
+    * \subpage refModulenameSubmodulename1
+    * \subpage refModulenameSubmodulename2
+    * \subpage refModulenameSubmodulename3
+    /doxy -->
 
 
 #### An example of a `README` file at a submodule level:
 
+    <!-- doxy
     \page refModulenameSubmodulename1 Submodulename1
+    /doxy -->
 
-    The submodule1 title
-    ====================
+    # The submodule1 title
 
     The paragraph(s) with the submodule description.
 

--- a/doc/ManPages.md
+++ b/doc/ManPages.md
@@ -1,4 +1,8 @@
+<!-- doxy
 \page refdocManPages Man Pages
+/doxy -->
+
+# Man Pages
 
 You can create man pages in nroff format under:
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,11 +1,17 @@
+<!-- doxy
 \page refdoc Documentation pages
+/doxy -->
 
-This module contains the following documentation pages
+# Documentation pages
 
-- \subpage refdocCLion
-- \subpage refdocCMakeInstructions
-- \subpage refdocModernCMakeMigration
-- \subpage refdocCodeOrganization
-- \subpage refdocDetectorSimulation
-- \subpage refdocDoxygenInstructions
-- \subpage refdocManPages
+This module contains the documentation pages.
+
+<!-- doxy
+* \subpage refdocCLion
+* \subpage refdocCMakeInstructions
+* \subpage refdocModernCMakeMigration
+* \subpage refdocCodeOrganization
+* \subpage refdocDetectorSimulation
+* \subpage refdocDoxygenInstructions
+* \subpage refdocManPages
+/doxy -->

--- a/doc/README.md
+++ b/doc/README.md
@@ -4,6 +4,7 @@ This module contains the following documentation pages
 
 - \subpage refdocCLion
 - \subpage refdocCMakeInstructions
+- \subpage refdocModernCMakeMigration
 - \subpage refdocCodeOrganization
 - \subpage refdocDetectorSimulation
 - \subpage refdocDoxygenInstructions

--- a/doc/scripts/filter_for_doxygen.sh
+++ b/doc/scripts/filter_for_doxygen.sh
@@ -1,7 +1,7 @@
 # Filtering out the HTML comments hiding doxygen keywords from Markdown
 # I. Hrivnacova 25/03/2019
 #
-sed -e '/<!-- doxy/d' -e '/\/doxy -->/d' "$1"
+sed -e '/<!-- doxy/d' -e '/\/doxy -->/d' -e 's/```c++/~~~{.cpp}/g; s/```bash/~~~{.sh}/g; s/```/~~~/g;' "$1"
 
 # Previous instructions applied in .travis.yml
 # git grep -l '^```[a-zA-Z]' | xargs sed -i .old -e 's|```\([a-zA-Z][a-zA-Z]*\)|\n```{.\1}\n|g;s|[.]bash|.sh|g;s|```|~~~~~~~|g'

--- a/doc/scripts/filter_for_doxygen.sh
+++ b/doc/scripts/filter_for_doxygen.sh
@@ -2,3 +2,7 @@
 # I. Hrivnacova 25/03/2019
 #
 sed -e '/<!-- doxy/d' -e '/\/doxy -->/d' "$1"
+
+# Previous instructions applied in .travis.yml
+# git grep -l '^```[a-zA-Z]' | xargs sed -i .old -e 's|```\([a-zA-Z][a-zA-Z]*\)|\n```{.\1}\n|g;s|[.]bash|.sh|g;s|```|~~~~~~~|g'
+# find . -name "*.old" -delete


### PR DESCRIPTION
- Restored the main page and fixed links to internal pages
- Fixed links to sub pages
- Updated DoxygenInstructions.md
- Updated instructions in .travis.yaml and moved the filtering instructions
  (now obsolete) in commented lines in doc/scripts/filter_for_doxygen.sh