### PR TITLE
fix calculation of T0 in calibrations

### DIFF
--- a/Detectors/TRD/base/src/Calibrations.cxx
+++ b/Detectors/TRD/base/src/Calibrations.cxx
@@ -81,7 +81,7 @@ double Calibrations::getVDrift(int det, int col, int row) const
 double Calibrations::getT0(int det, int col, int row) const
 {
   if (mChamberCalibrations && mLocalT0)
-    return (double)mChamberCalibrations->getT0(det) * (double)mLocalT0->getValue(det, col, row);
+    return (double)mChamberCalibrations->getT0(det) + (double)mLocalT0->getValue(det, col, row);
   else
     return -1;
 }


### PR DESCRIPTION
LocalT0 seems to be zero in all the places I looked including of course the one we are currently using.
This means that LocalT0 is essentially not used ? @tdietel 

Calculation of T0 is now (ChamberValue+LocalT0) instead of what we had (ChamberValue*LocalT0) which of course always gave zero.