### PR TITLE
Fix OpenMP CMake

### DIFF
--- a/Detectors/TRD/simulation/CMakeLists.txt
+++ b/Detectors/TRD/simulation/CMakeLists.txt
@@ -8,22 +8,23 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
-set (_libs O2::DetectorsBase O2::SimulationDataFormat O2::TRDBase)
-if (OpenMP_FOUND)
-set (_libs ${_libs} OpenMP::OpenMP)
-endif()
-
 o2_add_library(TRDSimulation
+               TARGETVARNAME targetName
                SOURCES src/Detector.cxx
                        src/TRsim.cxx
-	               src/Digitizer.cxx
-		       src/TRDSimParams.cxx
-               PUBLIC_LINK_LIBRARIES ${_libs})
+                       src/Digitizer.cxx
+                       src/TRDSimParams.cxx
+               PUBLIC_LINK_LIBRARIES O2::DetectorsBase O2::SimulationDataFormat O2::TRDBase)
 
 o2_target_root_dictionary(TRDSimulation
                           HEADERS include/TRDSimulation/Detector.h
                                   include/TRDSimulation/TRsim.h
                                   include/TRDSimulation/Digitizer.h
-				  include/TRDSimulation/TRDSimParams.h)
+                                  include/TRDSimulation/TRDSimParams.h)
+
+if (OpenMP_CXX_FOUND)
+    target_compile_definitions(${targetName} PRIVATE WITH_OPENMP)
+    target_link_libraries(${targetName} PRIVATE OpenMP::OpenMP_CXX)
+endif()
 
 o2_data_file(COPY data DESTINATION Detectors/TRD/simulation)

--- a/GPU/Common/GPUCommonMath.h
+++ b/GPU/Common/GPUCommonMath.h
@@ -241,7 +241,7 @@ GPUdi() unsigned int GPUCommonMath::AtomicExch(GPUglobalref() GPUAtomic(unsigned
   return ::atomicExch(addr, val);
 #else
   unsigned int old;
-#ifdef GPUCA_HAVE_OPENMP
+#ifdef WITH_OPENMP
 #pragma omp atomic capture
 #endif
   {
@@ -262,7 +262,7 @@ GPUdi() unsigned int GPUCommonMath::AtomicAdd(GPUglobalref() GPUAtomic(unsigned 
   return ::atomicAdd(addr, val);
 #else
   unsigned int old;
-#ifdef GPUCA_HAVE_OPENMP
+#ifdef WITH_OPENMP
 #pragma omp atomic capture
 #endif
   {
@@ -282,7 +282,7 @@ GPUdi() void GPUCommonMath::AtomicMax(GPUglobalref() GPUAtomic(unsigned int) * a
 #elif defined(GPUCA_GPUCODE) && (defined(__CUDACC__) || defined(__HIPCC__))
   ::atomicMax(addr, val);
 #else
-#ifdef GPUCA_HAVE_OPENMP
+#ifdef WITH_OPENMP
   while (*addr < val)
     AtomicExch(addr, val);
 #else
@@ -301,7 +301,7 @@ GPUdi() void GPUCommonMath::AtomicMin(GPUglobalref() GPUAtomic(unsigned int) * a
 #elif defined(GPUCA_GPUCODE) && (defined(__CUDACC__) || defined(__HIPCC__))
   ::atomicMin(addr, val);
 #else
-#ifdef GPUCA_HAVE_OPENMP
+#ifdef WITH_OPENMP
   while (*addr > val)
     AtomicExch(addr, val);
 #else

--- a/GPU/GPUTracking/Base/GPUReconstruction.cxx
+++ b/GPU/GPUTracking/Base/GPUReconstruction.cxx
@@ -28,7 +28,7 @@
 #include <unistd.h>
 #endif
 
-#ifdef GPUCA_HAVE_OPENMP
+#ifdef WITH_OPENMP
 #include <omp.h>
 #endif
 
@@ -123,7 +123,7 @@ int GPUReconstruction::Init()
     mDeviceProcessingSettings.trackletSelectorInPipeline = false;
   }
 
-#ifdef GPUCA_HAVE_OPENMP
+#ifdef WITH_OPENMP
   if (mDeviceProcessingSettings.nThreads <= 0) {
     mDeviceProcessingSettings.nThreads = omp_get_max_threads();
   } else {

--- a/GPU/GPUTracking/Base/GPUReconstructionCPU.cxx
+++ b/GPU/GPUTracking/Base/GPUReconstructionCPU.cxx
@@ -39,7 +39,7 @@
 #include <unistd.h>
 #endif
 
-#if defined(GPUCA_HAVE_OPENMP) || defined(_OPENMP)
+#if defined(WITH_OPENMP) || defined(_OPENMP)
 #include <omp.h>
 #else
 static inline int omp_get_thread_num() { return 0; }

--- a/GPU/GPUTracking/CMakeLists.txt
+++ b/GPU/GPUTracking/CMakeLists.txt
@@ -387,7 +387,7 @@ endif()
 
 if(OpenMP_CXX_FOUND)
   message(STATUS "GPU: Using OpenMP: ${OpenMP_CXX_SPEC_DATE}")
-  target_compile_definitions(${targetName} PRIVATE GPUCA_HAVE_OPENMP)
+  target_compile_definitions(${targetName} PRIVATE WITH_OPENMP)
   # Must be private, depending libraries might be compiled by compiler not understanding -fopenmp
   target_link_libraries(${targetName} PRIVATE OpenMP::OpenMP_CXX)
 endif()

--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -1060,7 +1060,7 @@ int GPUChainTracking::RunTPCTrackingSlices_internal()
   int streamMap[NSLICES];
 
   bool error = false;
-#ifdef GPUCA_HAVE_OPENMP
+#ifdef WITH_OPENMP
 #pragma omp parallel for num_threads(doGPU ? 1 : GetDeviceProcessingSettings().nThreads)
 #endif
   for (unsigned int iSlice = 0; iSlice < NSLICES; iSlice++) {
@@ -1397,7 +1397,7 @@ int GPUChainTracking::RunTPCTrackingSlices_internal()
     WaitForHelperThreads();
   } else {
     mSliceOutputReady = NSLICES;
-#ifdef GPUCA_HAVE_OPENMP
+#ifdef WITH_OPENMP
 #pragma omp parallel for num_threads(doGPU ? 1 : GetDeviceProcessingSettings().nThreads)
 #endif
     for (unsigned int iSlice = 0; iSlice < NSLICES; iSlice++) {

--- a/GPU/GPUTracking/Interface/GPUO2Interface.cxx
+++ b/GPU/GPUTracking/Interface/GPUO2Interface.cxx
@@ -17,7 +17,7 @@
 #include "GPUO2InterfaceConfiguration.h"
 #include <iostream>
 #include <fstream>
-#ifdef GPUCA_HAVE_OPENMP
+#ifdef WITH_OPENMP
 #include <omp.h>
 #endif
 

--- a/GPU/GPUTracking/Merger/GPUTPCGMMergerGPU.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMMergerGPU.cxx
@@ -12,7 +12,7 @@
 /// \author David Rohr
 
 #include "GPUTPCGMMergerGPU.h"
-#if defined(GPUCA_HAVE_OPENMP) && !defined(GPUCA_GPUCODE)
+#if defined(WITH_OPENMP) && !defined(GPUCA_GPUCODE)
 #include "GPUReconstruction.h"
 #endif
 
@@ -21,7 +21,7 @@ using namespace GPUCA_NAMESPACE::gpu;
 template <>
 GPUd() void GPUTPCGMMergerTrackFit::Thread<0>(int nBlocks, int nThreads, int iBlock, int iThread, GPUsharedref() GPUTPCSharedMemory& smem, processorType& merger)
 {
-#if defined(GPUCA_HAVE_OPENMP) && !defined(GPUCA_GPUCODE)
+#if defined(WITH_OPENMP) && !defined(GPUCA_GPUCODE)
 #pragma omp parallel for num_threads(merger.GetRec().GetDeviceProcessingSettings().nThreads)
 #endif
   for (int i = get_global_id(0); i < merger.NOutputTracks(); i += get_global_size(0)) {

--- a/GPU/GPUTracking/Standalone/display/GPUDisplay.cxx
+++ b/GPU/GPUTracking/Standalone/display/GPUDisplay.cxx
@@ -28,7 +28,7 @@
 #include "bitmapfile.h"
 #include "../utils/linux_helpers.h"
 #endif
-#ifdef GPUCA_HAVE_OPENMP
+#ifdef WITH_OPENMP
 #include <omp.h>
 #endif
 
@@ -600,7 +600,7 @@ int GPUDisplay::InitGL_internal()
   setDepthBuffer();
   setQuality();
   ReSizeGLScene(GPUDisplayBackend::INIT_WIDTH, GPUDisplayBackend::INIT_HEIGHT, true);
-#ifdef GPUCA_HAVE_OPENMP
+#ifdef WITH_OPENMP
   int maxThreads = mChain->GetDeviceProcessingSettings().nThreads > 1 ? mChain->GetDeviceProcessingSettings().nThreads : 1;
   omp_set_num_threads(maxThreads);
 #else
@@ -1496,7 +1496,7 @@ int GPUDisplay::DrawGLScene_internal(bool mixAnimation, float mAnimateTime) // H
         mGlDLFinal[iSlice].resize(mNCollissions);
       }
     }
-#ifdef GPUCA_HAVE_OPENMP
+#ifdef WITH_OPENMP
 #pragma omp parallel num_threads(mChain->GetDeviceProcessingSettings().nThreads)
     {
       int numThread = omp_get_thread_num();
@@ -1520,7 +1520,7 @@ int GPUDisplay::DrawGLScene_internal(bool mixAnimation, float mAnimateTime) // H
       prop.SetPolynomialField(&mMerger.Param().polynomialField);
       prop.SetToyMCEventsFlag(mMerger.Param().ToyMCEventsFlag);
 
-#ifdef GPUCA_HAVE_OPENMP
+#ifdef WITH_OPENMP
 #pragma omp barrier
 #pragma omp for
 #endif
@@ -1534,7 +1534,7 @@ int GPUDisplay::DrawGLScene_internal(bool mixAnimation, float mAnimateTime) // H
         mGlDLGrid[iSlice] = DrawGrid(tracker);
       }
 
-#ifdef GPUCA_HAVE_OPENMP
+#ifdef WITH_OPENMP
 #pragma omp barrier
 #pragma omp for
 #endif
@@ -1543,7 +1543,7 @@ int GPUDisplay::DrawGLScene_internal(bool mixAnimation, float mAnimateTime) // H
         mGlDLLines[iSlice][tGLOBALTRACK] = DrawTracks(tracker, 1);
       }
 
-#ifdef GPUCA_HAVE_OPENMP
+#ifdef WITH_OPENMP
 #pragma omp barrier
 #endif
       mThreadTracks[numThread].resize(mNCollissions);
@@ -1554,7 +1554,7 @@ int GPUDisplay::DrawGLScene_internal(bool mixAnimation, float mAnimateTime) // H
           }
         }
       }
-#ifdef GPUCA_HAVE_OPENMP
+#ifdef WITH_OPENMP
 #pragma omp for
 #endif
       for (int i = 0; i < mMerger.NOutputTracks(); i++) {
@@ -1575,7 +1575,7 @@ int GPUDisplay::DrawGLScene_internal(bool mixAnimation, float mAnimateTime) // H
         }
         mThreadTracks[numThread][col][slice][0].emplace_back(i);
       }
-#ifdef GPUCA_HAVE_OPENMP
+#ifdef WITH_OPENMP
 #pragma omp for
 #endif
       for (unsigned int i = 0; i < ioptrs().nMCInfosTPC; i++) {
@@ -1603,7 +1603,7 @@ int GPUDisplay::DrawGLScene_internal(bool mixAnimation, float mAnimateTime) // H
         }
         mThreadTracks[numThread][col][slice][1].emplace_back(i);
       }
-#ifdef GPUCA_HAVE_OPENMP
+#ifdef WITH_OPENMP
 #pragma omp barrier
 #pragma omp for
 #endif
@@ -1625,7 +1625,7 @@ int GPUDisplay::DrawGLScene_internal(bool mixAnimation, float mAnimateTime) // H
         }
       }
 
-#ifdef GPUCA_HAVE_OPENMP
+#ifdef WITH_OPENMP
 #pragma omp barrier
 #pragma omp for
 #endif

--- a/GPU/GPUTracking/Standalone/qa/GPUQA.cxx
+++ b/GPU/GPUTracking/Standalone/qa/GPUQA.cxx
@@ -581,7 +581,7 @@ void GPUQA::RunQA(bool matchOnly)
     // Assign Track MC Labels
     timer.Start();
     bool ompError = false;
-#if defined(GPUCA_HAVE_OPENMP) && QA_DEBUG == 0
+#if defined(WITH_OPENMP) && QA_DEBUG == 0
 #pragma omp parallel for
 #endif
     for (int i = 0; i < merger.NOutputTracks(); i++) {
@@ -815,7 +815,7 @@ void GPUQA::RunQA(bool matchOnly)
     }
     timer.ResetStart();
 
-#ifdef GPUCA_HAVE_OPENMP
+#ifdef WITH_OPENMP
 #pragma omp parallel for
 #endif
     for (unsigned int iCol = 0; iCol < GetNMCCollissions(); iCol++) {

--- a/GPU/GPUTracking/Standalone/standalone.cxx
+++ b/GPU/GPUTracking/Standalone/standalone.cxx
@@ -28,7 +28,7 @@
 #include <chrono>
 #include <tuple>
 #include <algorithm>
-#ifdef GPUCA_HAVE_OPENMP
+#ifdef WITH_OPENMP
 #include <omp.h>
 #endif
 
@@ -198,7 +198,7 @@ int ReadConfiguration(int argc, char** argv)
     configStandalone.OMPThreads = 1;
   }
 
-#ifdef GPUCA_HAVE_OPENMP
+#ifdef WITH_OPENMP
   if (configStandalone.OMPThreads != -1) {
     omp_set_num_threads(configStandalone.OMPThreads);
   } else {

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
@@ -34,7 +34,7 @@ class GPUTPCGMPolynomialField;
 #ifndef GPUCA_GPUCODE
 
 #ifndef __OPENCL__
-#ifdef GPUCA_HAVE_OPENMP
+#ifdef WITH_OPENMP
 #include <omp.h>
 #endif
 #include <chrono>
@@ -232,7 +232,7 @@ void GPUTRDTracker::DoTracking()
   if (mRec->GetRecoStepsGPU() & GPUReconstruction::RecoStep::TRDTracking) {
     mChainTracking->DoTRDGPUTracking();
   } else {
-#ifdef GPUCA_HAVE_OPENMP
+#ifdef WITH_OPENMP
 #pragma omp parallel for
     for (int iTrk = 0; iTrk < mNTracks; ++iTrk) {
       if (omp_get_num_threads() > mMaxThreads) {

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTrackerGPU.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTrackerGPU.cxx
@@ -14,7 +14,7 @@
 #include "GPUTRDTrackerGPU.h"
 #include "GPUTRDGeometry.h"
 #include "GPUConstantMem.h"
-#if defined(GPUCA_HAVE_OPENMP) && !defined(GPUCA_GPUCODE)
+#if defined(WITH_OPENMP) && !defined(GPUCA_GPUCODE)
 #include "GPUReconstruction.h"
 #endif
 
@@ -23,7 +23,7 @@ using namespace GPUCA_NAMESPACE::gpu;
 template <>
 GPUd() void GPUTRDTrackerGPU::Thread<0>(int nBlocks, int nThreads, int iBlock, int iThread, GPUsharedref() GPUTPCSharedMemory& smem, processorType& processors)
 {
-#if defined(GPUCA_HAVE_OPENMP) && !defined(GPUCA_GPUCODE)
+#if defined(WITH_OPENMP) && !defined(GPUCA_GPUCODE)
 #pragma omp parallel for num_threads(processors.trdTracker.GetRec().GetDeviceProcessingSettings().nThreads)
 #endif
   for (int i = get_global_id(0); i < processors.trdTracker.NTracks(); i += get_global_size(0)) {

--- a/dependencies/FindOpenMPMacOS.cmake
+++ b/dependencies/FindOpenMPMacOS.cmake
@@ -9,7 +9,7 @@ find_path(OpenMP_INCLUDE_DIR
 mark_as_advanced(OpenMP_LIBRARY OpenMP_INCLUDE_DIR)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(OpenMP DEFAULT_MSG 
+find_package_handle_standard_args(OpenMP DEFAULT_MSG
     OpenMP_LIBRARY OpenMP_INCLUDE_DIR)
 
 if (OpenMP_FOUND)
@@ -17,8 +17,10 @@ if (OpenMP_FOUND)
     set(OpenMP_INCLUDE_DIRS ${OpenMP_INCLUDE_DIR})
     set(OpenMP_COMPILE_OPTIONS -Xpreprocessor -fopenmp)
 
-    add_library(OpenMP::OpenMP SHARED IMPORTED)
-    set_target_properties(OpenMP::OpenMP PROPERTIES
+    set(OpenMP_CXX_FOUND True)
+    set(OpenMPMacOS_FOUND True)
+    add_library(OpenMP::OpenMP_CXX SHARED IMPORTED)
+    set_target_properties(OpenMP::OpenMP_CXX PROPERTIES
         IMPORTED_LOCATION ${OpenMP_LIBRARIES}
         INTERFACE_INCLUDE_DIRECTORIES "${OpenMP_INCLUDE_DIRS}"
         INTERFACE_COMPILE_OPTIONS "${OpenMP_COMPILE_OPTIONS}"

--- a/dependencies/O2Dependencies.cmake
+++ b/dependencies/O2Dependencies.cmake
@@ -116,8 +116,9 @@ find_package(benchmark CONFIG NAMES benchmark googlebenchmark)
 set_package_properties(benchmark PROPERTIES TYPE OPTIONAL)
 find_package(OpenMP)
 set_package_properties(OpenMP PROPERTIES TYPE OPTIONAL)
-if (OpenMP_FOUND)
-  add_definitions("-DWITH_OPENMP")
+if (NOT OpenMP_CXX_FOUND AND CMAKE_SYSTEM_NAME MATCHES Darwin)
+  message(STATUS "MacOS OpenMP not found, attempting workaround")
+  find_package(OpenMPMacOS)
 endif()
 
 find_package(GLFW MODULE)
@@ -148,4 +149,3 @@ endif()
 find_package(O2GPU)
 
 feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)
-


### PR DESCRIPTION
@sawenzel : let's give this a try. I think this is how it should be done with modern CMake. OpenMP_FOUND was old style. If this works on MacOS, we can do away with the custom FindOpenMP.