### PR TITLE
ZDC: new hit accounting and possibility to extract spatial calorimeter response

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/MCTrack.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCTrack.h
@@ -32,7 +32,7 @@ namespace o2
 /// secondary one produced by the transport through decay or interaction.
 /// This is a light weight particle class that is saved to disk
 /// instead of saving the TParticle class. It is also used for filtering the stack
-template <class T>
+template <class _T>
 class MCTrackT
 {
  public:
@@ -68,6 +68,15 @@ class MCTrackT
   Double_t GetMass() const;
 
   Double_t GetEnergy() const;
+
+  // Alternative accessors with TParticle like shorter names
+  Double_t Px() const { return mStartVertexMomentumX; }
+  Double_t Py() const { return mStartVertexMomentumY; }
+  Double_t Pz() const { return mStartVertexMomentumZ; }
+  Double_t Vx() const { return mStartVertexCoordinatesX; }
+  Double_t Vy() const { return mStartVertexCoordinatesY; }
+  Double_t Vz() const { return mStartVertexCoordinatesZ; }
+  Double_t T() const { return mStartVertexCoordinatesT; }
 
   Double_t GetPt() const
   {
@@ -147,10 +156,10 @@ class MCTrackT
 
  private:
   /// Momentum components at start vertex [GeV]
-  T mStartVertexMomentumX, mStartVertexMomentumY, mStartVertexMomentumZ;
+  _T mStartVertexMomentumX, mStartVertexMomentumY, mStartVertexMomentumZ;
 
   /// Coordinates of start vertex [cm, ns]
-  T mStartVertexCoordinatesX, mStartVertexCoordinatesY, mStartVertexCoordinatesZ, mStartVertexCoordinatesT;
+  _T mStartVertexCoordinatesX, mStartVertexCoordinatesY, mStartVertexCoordinatesZ, mStartVertexCoordinatesT;
 
   ///  PDG particle code
   Int_t mPdgCode;

--- a/Detectors/ZDC/simulation/CMakeLists.txt
+++ b/Detectors/ZDC/simulation/CMakeLists.txt
@@ -10,7 +10,7 @@
 
 o2_add_library(ZDCSimulation
                SOURCES src/Detector.cxx src/Digitizer.cxx src/SimCondition.cxx
-	       src/ZDCSimParam.cxx
+	       src/ZDCSimParam.cxx src/SpatialPhotonResponse.cxx
                PUBLIC_LINK_LIBRARIES O2::SimulationDataFormat O2::ZDCBase
 	       			     O2::DataFormatsZDC O2::CCDB O2::SimConfig)
 
@@ -19,6 +19,7 @@ o2_target_root_dictionary(ZDCSimulation
                                   include/ZDCSimulation/Digitizer.h
                                   include/ZDCSimulation/Detector.h
 				  include/ZDCSimulation/SimCondition.h
-				  include/ZDCSimulation/ZDCSimParam.h)
+				  include/ZDCSimulation/ZDCSimParam.h
+                                  include/ZDCSimulation/SpatialPhotonResponse.h)
 
 o2_data_file(COPY data DESTINATION Detectors/ZDC/simulation)

--- a/Detectors/ZDC/simulation/include/ZDCSimulation/Detector.h
+++ b/Detectors/ZDC/simulation/include/ZDCSimulation/Detector.h
@@ -19,6 +19,9 @@
 #include "DetectorsCommonDataFormats/DetID.h" // for Detector
 #include "ZDCBase/Geometry.h"
 #include "ZDCSimulation/Hit.h"
+#include "ZDCSimulation/SpatialPhotonResponse.h"
+#include "TParticle.h"
+#include <utility>
 
 class FairVolume;
 
@@ -104,6 +107,9 @@ class Detector : public o2::base::DetImpl<Detector>
 
   void resetHitIndices();
 
+  // helper function taking care of writing the photon response pattern at cern moments
+  void flushSpatialResponse();
+
   Float_t mTrackEta;
   Float_t mPrimaryEnergy;
   Vector3D<float> mXImpact;
@@ -143,6 +149,19 @@ class Detector : public o2::base::DetImpl<Detector>
 
   float mLightTableZN[4][ANGLEBINS][ZNRADIUSBINS] = {1.}; //!
   float mLightTableZP[4][ANGLEBINS][ZPRADIUSBINS] = {1.}; //!
+
+  SpatialPhotonResponse mNeutronResponseImage;
+  // there is only one proton detector per side
+  SpatialPhotonResponse mProtonResponseImage;
+
+  TParticle mCurrentPrincipalParticle{};
+
+  // collecting the responses for the current event
+  using ParticlePhotonResponse = std::vector<std::pair<TParticle,
+                                                       std::pair<SpatialPhotonResponse, SpatialPhotonResponse>>>;
+
+  ParticlePhotonResponse mResponses;
+  ParticlePhotonResponse* mResponsesPtr = &mResponses;
 
   template <typename Det>
   friend class o2::base::DetImpl;

--- a/Detectors/ZDC/simulation/include/ZDCSimulation/Detector.h
+++ b/Detectors/ZDC/simulation/include/ZDCSimulation/Detector.h
@@ -72,6 +72,8 @@ class Detector : public o2::base::DetImpl<Detector>
   void EndOfEvent() final;
   void FinishPrimary() final;
 
+  void BeginPrimary() final;
+
   void ConstructGeometry() final;
 
   void createMaterials();

--- a/Detectors/ZDC/simulation/include/ZDCSimulation/SpatialPhotonResponse.h
+++ b/Detectors/ZDC/simulation/include/ZDCSimulation/SpatialPhotonResponse.h
@@ -1,0 +1,76 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file SpatialPhotonResponse.h
+/// \brief Visualizing spatial photon response in ZDC neutron and proton calorimeters
+
+#ifndef DETECTORS_ZDC_SIMULATION_INCLUDE_ZDCSIMULATION_SPATIALPHOTONRESPONSE_H_
+#define DETECTORS_ZDC_SIMULATION_INCLUDE_ZDCSIMULATION_SPATIALPHOTONRESPONSE_H_
+
+#include <array>
+#include <vector>
+
+namespace o2
+{
+namespace zdc
+{
+
+static constexpr int ZDCCHANNELSPERTOWER = 1;
+
+/// Class representing the spatial photon response in a ZDC
+/// calorimeter
+class SpatialPhotonResponse
+{
+ public:
+  // Nx number of pixels in x direction
+  // Ny number of pixels in y direction
+  SpatialPhotonResponse(int Nx, int Ny, double lowerx, double lowery, double lengthx, double lengthy);
+
+  SpatialPhotonResponse() = default;
+
+  void addPhoton(double x, double y, int nphotons);
+  // void exportToPNG() const;
+  void printToScreen() const;
+  void reset();
+
+  double getCellLx() const { return mLxOfCell; }
+  double getCellLy() const { return mLyOfCell; }
+
+  double getNx() const { return mNx; }
+  double getNy() const { return mNy; }
+  double getLowerX() const { return mLowerX; }
+  double getLowerY() const { return mLowerY; }
+
+  bool hasSignal() const { return mPhotonSum > 0; }
+  int getPhotonSum() const { return mPhotonSum; }
+
+  std::vector<std::vector<int>> const& getImageData() const { return mImageData; }
+
+ private:
+  double mLxOfCell = 1.; // x length of cell corresponding to one pixel
+  double mLyOfCell = 1.; // y length of cell corresponding to one pixel
+
+  double mInvLxOfCell = 1.; // x length of cell corresponding to one pixel
+  double mInvLyOfCell = 1.; // y length of cell corresponding to one pixel
+
+  double mLowerX = 0.; // lowerX coordinate of image (used to convert to pixels in addPhoton)
+  double mLowerY = 0.; // lowerY coordinate of image (used to convert to pixels in addPhoton)
+
+  int mNx = 1;        // number of "towers" in x direction
+  int mNy = 1;        // number of "towers" in y direction
+  int mPhotonSum = 0; // accumulated photon number (for quick filtering)
+
+  std::vector<std::vector<int>> mImageData;
+};
+
+} // namespace zdc
+} // namespace o2
+
+#endif /* DETECTORS_ZDC_SIMULATION_INCLUDE_ZDCSIMULATION_SPATIALPHOTONRESPONSE_H_ */

--- a/Detectors/ZDC/simulation/include/ZDCSimulation/ZDCSimParam.h
+++ b/Detectors/ZDC/simulation/include/ZDCSimulation/ZDCSimParam.h
@@ -18,13 +18,14 @@ namespace o2
 {
 namespace zdc
 {
-// parameters of ZDC digitization
+// parameters of ZDC digitization / transport simulation
 
 struct ZDCSimParam : public o2::conf::ConfigurableParamHelper<ZDCSimParam> {
 
   bool continuous = true; ///< flag for continuous simulation
   int nBCAheadCont = 1;   ///< number of BC to read ahead of trigger in continuous mode
   int nBCAheadTrig = 3;   ///< number of BC to read ahead of trigger in triggered mode
+  bool recordSpatialResponse = false; ///< whether to record 2D spatial response showering images in proton/neutron detector
 
   O2ParamDef(ZDCSimParam, "ZDCSimParam");
 };

--- a/Detectors/ZDC/simulation/src/Detector.cxx
+++ b/Detectors/ZDC/simulation/src/Detector.cxx
@@ -28,6 +28,7 @@
 #include <TRandom.h>
 #include <cassert>
 #include <fstream>
+#include "ZDCSimulation/ZDCSimParam.h"
 
 using namespace o2::zdc;
 
@@ -38,7 +39,19 @@ ClassImp(o2::zdc::Detector);
 Detector::Detector(Bool_t active)
   : o2::base::DetImpl<Detector>("ZDC", active),
     mHits(new std::vector<o2::zdc::Hit>),
-    mXImpact(-999, -999, -999)
+    mXImpact(-999, -999, -999),
+    mNeutronResponseImage(Geometry::ZNDIVISION[0] * Geometry::ZNSECTORS[0] * 2,
+                          Geometry::ZNDIVISION[1] * Geometry::ZNSECTORS[1] * 2,
+                          Geometry::ZNAPOSITION[0] - Geometry::ZNDIMENSION[0],
+                          Geometry::ZNAPOSITION[1] - Geometry::ZNDIMENSION[1],
+                          Geometry::ZNDIMENSION[0] * 2,
+                          Geometry::ZNDIMENSION[1] * 2),
+    mProtonResponseImage(Geometry::ZPDIVISION[0] * Geometry::ZPSECTORS[0] * 2,
+                         Geometry::ZPDIVISION[1] * Geometry::ZPSECTORS[1] * 2,
+                         Geometry::ZPAPOSITION[0] - Geometry::ZPDIMENSION[0],
+                         Geometry::ZPAPOSITION[1] - Geometry::ZPDIMENSION[1],
+                         Geometry::ZPDIMENSION[0] * 2,
+                         Geometry::ZPDIMENSION[1] * 2)
 {
   mTrackEta = 999;
   // REsetting summed variables
@@ -254,6 +267,19 @@ void Detector::resetHitIndices()
   mTotLightPMQ = 0;
 }
 
+void Detector::flushSpatialResponse()
+{
+  if (o2::zdc::ZDCSimParam::Instance().recordSpatialResponse) {
+    // only write non-trivial image pairs
+    if (mNeutronResponseImage.getPhotonSum() > 0 || mProtonResponseImage.getPhotonSum() > 0) {
+      mResponses.push_back(std::make_pair(mCurrentPrincipalParticle,
+                                          std::make_pair(mNeutronResponseImage, mProtonResponseImage)));
+    }
+    mNeutronResponseImage.reset();
+    mProtonResponseImage.reset();
+  }
+}
+
 //_____________________________________________________________________________
 Bool_t Detector::ProcessHits(FairVolume* v)
 {
@@ -328,6 +354,16 @@ Bool_t Detector::ProcessHits(FairVolume* v)
       }
     }
    }
+  }
+
+  if (o2::zdc::ZDCSimParam::Instance().recordSpatialResponse) {
+    // some diagnostic; trying to really get the pixel fired
+    if (nphe > 0 && (detector == 1 || detector == 4)) {
+      mNeutronResponseImage.addPhoton(x[0], x[1], nphe);
+    }
+    if (nphe > 0 && (detector == 2 || detector == 5)) {
+      mProtonResponseImage.addPhoton(x[0], x[1], nphe);
+    }
   }
 
   // A new hit is created when there is nothing yet for this det + sector
@@ -2262,13 +2298,18 @@ void Detector::FinishPrimary()
 {
   // after each primary we should definitely reset
   mLastPrincipalTrackEntered = -1;
+  flushSpatialResponse();
 }
 
 void Detector::BeginPrimary()
 {
   // set current principal track
-  mLastPrincipalTrackEntered = fMC->GetStack()->GetCurrentTrackNumber();
+  auto stack = (o2::data::Stack*)fMC->GetStack();
+
+  mLastPrincipalTrackEntered = stack->GetCurrentTrackNumber();
   resetHitIndices();
+
+  mCurrentPrincipalParticle = *stack->GetCurrentTrack();
 }
 
 //_____________________________________________________________________________
@@ -2280,6 +2321,10 @@ void Detector::Register()
 
   if (FairRootManager::Instance()) {
     FairRootManager::Instance()->RegisterAny(addNameTo("Hit").data(), mHits, kTRUE);
+
+    if (o2::zdc::ZDCSimParam::Instance().recordSpatialResponse) {
+      FairRootManager::Instance()->RegisterAny(addNameTo("ResponseImage").data(), mResponsesPtr, kTRUE);
+    }
   }
 }
 
@@ -2289,6 +2334,7 @@ void Detector::Reset()
   if (!o2::utils::ShmManager::Instance().isOperational()) {
     mHits->clear();
   }
+  mResponses.clear();
   mLastPrincipalTrackEntered = -1;
   resetHitIndices();
 }

--- a/Detectors/ZDC/simulation/src/Detector.cxx
+++ b/Detectors/ZDC/simulation/src/Detector.cxx
@@ -283,29 +283,10 @@ Bool_t Detector::ProcessHits(FairVolume* v)
   //printf("ProcessHits:  x=(%f, %f, %f)  \n",x[0], x[1], x[2]);
   //printf("\tDET %d  SEC %d  -> XImpact=(%f, %f, %f)\n",detector,sector, xImp.X(), xImp.Y(), xImp.Z());
 
-  // a new principal track is a track which previously was not seen by any ZDC detector
-  // we will account all detector response associated to principal tracks only
-  if ((volID == mZNENVVolID || volID == mZPENVVolID || volID == mZEMVolID) && fMC->IsTrackEntering()) {
-    if ((mLastPrincipalTrackEntered == -1) || !(stack->isTrackDaughterOf(trackn, mLastPrincipalTrackEntered))) {
-      mLastPrincipalTrackEntered = trackn;
-      resetHitIndices();
-      //printf(">>> RESETTING HITS!!!!\n\n");
-
-      // there is nothing more to do here as we are not
-      // in the fiber volumes
-      return false;
-    }
-  }
-
-  // it could be that the entering track was not noticed
-  // (tracking precision problems); warn about it for the moment until we have
-  // a better solution (like checking the origin coordinates of the track)
-  if (mLastPrincipalTrackEntered == -1) {
-    LOG(WARN) << "Problem with principal track detection ; now in " << volname;
-    // if we come here we are definitely in a sensitive volume !!
-    mLastPrincipalTrackEntered = trackn;
-    resetHitIndices();
-    //printf(" Problem with principal track detection\n >>> RESETTING HITS!!!!\n");
+  if ((volID == mZNENVVolID || volID == mZPENVVolID || volID == mZEMVolID)) {
+    // there is nothing more to do here as we are not
+    // in the fiber volumes
+    return false;
   }
 
   Float_t p[3] = {0., 0., 0.};
@@ -2281,6 +2262,12 @@ void Detector::FinishPrimary()
 {
   // after each primary we should definitely reset
   mLastPrincipalTrackEntered = -1;
+}
+
+void Detector::BeginPrimary()
+{
+  // set current principal track
+  mLastPrincipalTrackEntered = fMC->GetStack()->GetCurrentTrackNumber();
   resetHitIndices();
 }
 

--- a/Detectors/ZDC/simulation/src/SpatialPhotonResponse.cxx
+++ b/Detectors/ZDC/simulation/src/SpatialPhotonResponse.cxx
@@ -1,0 +1,84 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "ZDCSimulation/SpatialPhotonResponse.h"
+#include <cmath>
+#include <iostream>
+
+using namespace o2::zdc;
+
+SpatialPhotonResponse::SpatialPhotonResponse(int Nx, int Ny, double lowerx,
+                                             double lowery, double lengthx, double lengthy) : mNx{Nx},
+                                                                                              mNy{Ny},
+                                                                                              mLxOfCell{lengthx / Nx},
+                                                                                              mLyOfCell{lengthy / Ny},
+                                                                                              mInvLxOfCell{1. / mLxOfCell},
+                                                                                              mInvLyOfCell{1. / mLyOfCell},
+                                                                                              mLowerX{lowerx},
+                                                                                              mLowerY{lowery}
+{
+  mImageData.resize(Nx);
+  for (int x = 0; x < Nx; ++x) {
+    mImageData[x].resize(Ny);
+  }
+  // now the image should be null initialized
+  std::cout << " Image initialized with " << mNx << " x " << mNy << " pixels ";
+}
+
+void SpatialPhotonResponse::addPhoton(double x, double y, int nphotons)
+{
+  const int xpixel = (int)(std::floor((x - mLowerX) * mInvLxOfCell));
+  const int ypixel = (int)(std::floor((y - mLowerY) * mInvLyOfCell));
+  if (nphotons < 0) {
+    std::cerr << "negative photon number\n";
+    return;
+  }
+  if (xpixel < 0 || xpixel >= mNx) {
+    std::cerr << "X-PIXEL OUT OF RANGE " << xpixel << " " << x << " , " << y << "\n";
+    return;
+  }
+  if (ypixel < 0 || ypixel >= mNy) {
+    std::cerr << "Y-PIXEL OUT OF RANGE " << ypixel << " " << x << " , " << y << "\n";
+    return;
+  }
+  mImageData[xpixel][ypixel] += nphotons;
+  mPhotonSum += nphotons;
+}
+
+// will print pixel 0 == (0,0) at the lower left corner
+void SpatialPhotonResponse::printToScreen() const
+{
+  std::cout << "Response START " << mPhotonSum << " ----\n";
+  for (int y = mNy - 1; y >= 0; --y) {
+    {
+      for (int x = 0; x < mNx; ++x) {
+        const auto val = mImageData[x][y];
+        if (val < 0) {
+          std::cerr << "SHIT\n";
+        }
+        std::cout << ((val < 10) ? std::to_string(val) : "x");
+      }
+      std::cout << "\n";
+    }
+  }
+  std::cout << "Response END ----\n";
+}
+
+void SpatialPhotonResponse::reset()
+{
+  mPhotonSum = 0;
+  for (int x = 0; x < mNx; ++x) {
+    {
+      for (int y = 0; y < mNy; ++y) {
+        mImageData[x][y] = 0;
+      }
+    }
+  }
+}

--- a/Detectors/ZDC/simulation/src/ZDCSimulationLinkDef.h
+++ b/Detectors/ZDC/simulation/src/ZDCSimulationLinkDef.h
@@ -10,6 +10,9 @@
 
 #ifdef __CLING__
 
+#include <utility>
+#include "TParticle.h"
+
 #pragma link off all globals;
 #pragma link off all classes;
 #pragma link off all functions;
@@ -28,5 +31,11 @@
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::zdc::ZDCSimParam> + ;
 
 #pragma link C++ class o2::dataformats::MCTruthContainer < o2::zdc::MCLabel> + ;
+
+#pragma link C++ class std::vector < std::vector < int>> + ;
+#pragma link C++ class o2::zdc::SpatialPhotonResponse + ;
+#pragma link C++ class std::pair < o2::zdc::SpatialPhotonResponse, o2::zdc::SpatialPhotonResponse> + ;
+#pragma link C++ class std::pair < TParticle, std::pair < o2::zdc::SpatialPhotonResponse, o2::zdc::SpatialPhotonResponse>> + ;
+#pragma link C++ class std::vector < std::pair < TParticle, std::pair < o2::zdc::SpatialPhotonResponse, o2::zdc::SpatialPhotonResponse>>> + ;
 
 #endif


### PR DESCRIPTION
This PR provides

1. An easier accounting and summing up of hits. It is now done just per primary track.
This seems to be sufficient and avoids complicated user logic to detect when to start a new hit.
(We can go back to such a scheme if required)

2. Possibility to extract the actual spatial response image (in terms of number of photons triggered per optical fibre). This is useful for the machine learning fast simulation studies.
Extraction has to be switched on via a parameter option.

