### PR TITLE
Improvements for bz=0 tracking

### DIFF
--- a/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
+++ b/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
@@ -154,10 +154,10 @@ int GPUCATracking::runTracking(GPUO2InterfaceIOPtrs* data)
         float delta = 0.f;
         for (int iCl = 1; iCl < tracks[i].NClusters(); iCl++) {
           if (lastSide ^ (trackClusters[tracks[i].FirstClusterRef() + iCl].slice < Sector::MAXSECTOR / 2)) {
-            auto& hltcl1 = trackClusters[tracks[i].FirstClusterRef() + iCl];
-            auto& hltcl2 = trackClusters[tracks[i].FirstClusterRef() + iCl - 1];
-            auto& cl1 = clusters->clusters[hltcl1.slice][hltcl1.row][hltcl1.num];
-            auto& cl2 = clusters->clusters[hltcl2.slice][hltcl2.row][hltcl2.num];
+            auto& cacl1 = trackClusters[tracks[i].FirstClusterRef() + iCl];
+            auto& cacl2 = trackClusters[tracks[i].FirstClusterRef() + iCl - 1];
+            auto& cl1 = clusters->clusters[cacl1.slice][cacl1.row][cacl1.num];
+            auto& cl2 = clusters->clusters[cacl2.slice][cacl2.row][cacl2.num];
             delta = fabs(cl1.getTime() - cl2.getTime()) * 0.5f;
             break;
           }
@@ -226,12 +226,10 @@ int GPUCATracking::runTracking(GPUO2InterfaceIOPtrs* data)
       int clusterId = trackClusters[tracks[i].FirstClusterRef() + j].num;
       Sector sector = trackClusters[tracks[i].FirstClusterRef() + j].slice;
       int globalRow = trackClusters[tracks[i].FirstClusterRef() + j].row;
-      const ClusterNative& cl = clusters->clusters[sector][globalRow][clusterId];
       int regionNumber = 0;
       while (globalRow > mapper.getGlobalRowOffsetRegion(regionNumber) + mapper.getNumberOfRowsRegion(regionNumber)) {
         regionNumber++;
       }
-      CRU cru(sector, regionNumber);
       clIndArr[nOutCl] = clusterId;
       sectorIndexArr[nOutCl] = sector;
       rowIndexArr[nOutCl] = globalRow;

--- a/GPU/Common/GPUCommonDef.h
+++ b/GPU/Common/GPUCommonDef.h
@@ -44,10 +44,12 @@
   #define CON_DELETE = delete
   #define CON_DEFAULT = default
   #define CONSTEXPR constexpr
+  #define CONSTEXPRRET CONSTEXPR
 #else
   #define CON_DELETE
   #define CON_DEFAULT
   #define CONSTEXPR const
+  #define CONSTEXPRRET
 #endif
 
 //Set AliRoot / O2 namespace

--- a/GPU/GPUTracking/Base/GPUGeneralKernels.h
+++ b/GPU/GPUTracking/Base/GPUGeneralKernels.h
@@ -58,7 +58,7 @@ class GPUKernelTemplate
   };
 
   typedef GPUconstantref() MEM_CONSTANT(GPUConstantMem) processorType;
-  GPUhdi() CONSTEXPR static GPUDataTypes::RecoStep GetRecoStep() { return GPUCA_RECO_STEP::NoRecoStep; }
+  GPUhdi() CONSTEXPRRET static GPUDataTypes::RecoStep GetRecoStep() { return GPUCA_RECO_STEP::NoRecoStep; }
   MEM_TEMPLATE()
   GPUhdi() static processorType* Processor(MEM_TYPE(GPUConstantMem) & processors)
   {
@@ -81,7 +81,7 @@ class GPUKernelTemplate
 class GPUMemClean16 : public GPUKernelTemplate
 {
  public:
-  GPUhdi() CONSTEXPR static GPUDataTypes::RecoStep GetRecoStep() { return GPUCA_RECO_STEP::NoRecoStep; }
+  GPUhdi() CONSTEXPRRET static GPUDataTypes::RecoStep GetRecoStep() { return GPUCA_RECO_STEP::NoRecoStep; }
   template <int iKernel = 0>
   GPUd() static void Thread(int nBlocks, int nThreads, int iBlock, int iThread, GPUsharedref() MEM_LOCAL(GPUTPCSharedMemory) & smem, processorType& processors, GPUglobalref() void* ptr, unsigned long size);
 };

--- a/GPU/GPUTracking/Base/GPUSettings.cxx
+++ b/GPU/GPUTracking/Base/GPUSettings.cxx
@@ -45,6 +45,7 @@ void GPUSettingsRec::SetDefaults()
   tpcSigBitsWidth = 3;
   tpcZSthreshold = 2;
   fwdTPCDigitsAsClusters = 0;
+  bz0Pt = 60;
 }
 
 void GPUSettingsEvent::SetDefaults()

--- a/GPU/GPUTracking/Base/GPUSettings.h
+++ b/GPU/GPUTracking/Base/GPUSettings.h
@@ -75,6 +75,7 @@ struct GPUSettingsRec {
   unsigned char tpcSigBitsWidth;         // Number of significant bits for TPC cluster width in compression mode 1
   unsigned char tpcZSthreshold;          // TPC Zero Suppression Threshold (for loading digits / forwarging digits as clusters)
   unsigned char fwdTPCDigitsAsClusters;  // Simply forward TPC digits as clusters
+  unsigned char bz0Pt;                   // Nominal Pt to set when bz = 0 (in 10 MeV)
 };
 
 // Settings describing the events / time frames

--- a/GPU/GPUTracking/Interface/GPUO2Interface.cxx
+++ b/GPU/GPUTracking/Interface/GPUO2Interface.cxx
@@ -106,9 +106,6 @@ void GPUTPCO2Interface::Clear(bool clearOutputs) { mRec->ClearAllocatedMemory(cl
 
 void GPUTPCO2Interface::GetClusterErrors2(int row, float z, float sinPhi, float DzDs, short clusterState, float& ErrY2, float& ErrZ2) const
 {
-  if (!mInitialized) {
-    return;
-  }
   mRec->GetParam().GetClusterErrors2(row, z, sinPhi, DzDs, ErrY2, ErrZ2);
   mRec->GetParam().UpdateClusterError2ByState(clusterState, ErrY2, ErrZ2);
 }

--- a/GPU/GPUTracking/Merger/GPUTPCGMMerger.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMMerger.cxx
@@ -1285,6 +1285,10 @@ void GPUTPCGMMerger::CollectMergedTracks()
     p1.DzDs() = p2.DzDs();
     p1.QPt() = p2.QPt();
     mergedTrack.SetAlpha(p2.Alpha());
+    const double kCLight = 0.000299792458;
+    if (CAMath::Abs(Param().polynomialField.GetNominalBz()) < (0.01 * kCLight)) {
+      p1.QPt() = 0.01f * Param().rec.bz0Pt;
+    }
 
     // if (nParts > 1) printf("Merged %d: QPt %f %d parts %d hits\n", mNOutputTracks, p1.QPt(), nParts, nHits);
 

--- a/GPU/GPUTracking/Merger/GPUTPCGMPropagator.h
+++ b/GPU/GPUTracking/Merger/GPUTPCGMPropagator.h
@@ -150,7 +150,7 @@ class GPUTPCGMPropagator
   const o2::base::MatLayerCylSet* mMatLUT = nullptr;
 };
 
-GPUd() inline void GPUTPCGMPropagator::SetMaterial(float radLen, float rho)
+GPUdi() void GPUTPCGMPropagator::SetMaterial(float radLen, float rho)
 {
   mMaterial.rho = rho;
   mMaterial.radLen = radLen;
@@ -158,7 +158,7 @@ GPUd() inline void GPUTPCGMPropagator::SetMaterial(float radLen, float rho)
   CalculateMaterialCorrection();
 }
 
-GPUd() inline void GPUTPCGMPropagator::SetTrack(GPUTPCGMTrackParam* track, float Alpha)
+GPUdi() void GPUTPCGMPropagator::SetTrack(GPUTPCGMTrackParam* track, float Alpha)
 {
   mT = track;
   if (!mT) {
@@ -169,13 +169,13 @@ GPUd() inline void GPUTPCGMPropagator::SetTrack(GPUTPCGMTrackParam* track, float
   CalculateMaterialCorrection();
 }
 
-GPUd() inline float GPUTPCGMPropagator::GetMirroredYModel() const
+GPUdi() float GPUTPCGMPropagator::GetMirroredYModel() const
 {
   float Bz = GetBz(mAlpha, mT0.GetX(), mT0.GetY(), mT0.GetZ());
   return mT0.GetMirroredY(Bz);
 }
 
-GPUd() inline float GPUTPCGMPropagator::GetMirroredYTrack() const
+GPUdi() float GPUTPCGMPropagator::GetMirroredYTrack() const
 {
   if (!mT) {
     return -1.E10f;

--- a/GPU/GPUTracking/Merger/GPUTPCGMTrackParam.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMTrackParam.cxx
@@ -94,7 +94,7 @@ GPUd() bool GPUTPCGMTrackParam::Fit(const GPUTPCGMMerger* merger, int iTrk, GPUT
       outerParam->alpha = prop.GetAlpha();
     }
 
-    int resetT0 = CAMath::Max(10.f, CAMath::Min(40.f, 150.f / mP[4]));
+    int resetT0 = initResetT0();
     const bool refit = (nWays == 1 || iWay >= 1);
     const float maxSinForUpdate = CAMath::Sin(70.f * kDeg2Rad);
     if (!(refit && attempt == 0)) {
@@ -183,7 +183,7 @@ GPUd() bool GPUTPCGMTrackParam::Fit(const GPUTPCGMMerger* merger, int iTrk, GPUT
           lastSlice = clusters[ihit].slice;
           lastRow = 255;
           N++;
-          resetT0 = CAMath::Max(10.f, CAMath::Min(40.f, 150.f / mP[4]));
+          resetT0 = initResetT0();
           // clang-format off
           CADEBUG(printf("\n"));
           CADEBUG(printf("\t%21sMirror  Alpha %8.3f    , X %8.3f - Y %8.3f, Z %8.3f   -   QPt %7.2f (%7.2f), SP %5.2f (%5.2f) %28s    ---   Cov sY %8.3f sZ %8.3f sSP %8.3f sPt %8.3f   -   YPt %8.3f\n", "", prop.GetAlpha(), mX, mP[0], mP[1], mP[4], prop.GetQPt0(), mP[2], prop.GetSinPhi0(), "", sqrtf(mC[0]), sqrtf(mC[2]), sqrtf(mC[5]), sqrtf(mC[14]), mC[10]));
@@ -236,7 +236,7 @@ GPUd() bool GPUTPCGMTrackParam::Fit(const GPUTPCGMMerger* merger, int iTrk, GPUT
           lastLeg = clusters[ihit].leg;
           lastRow = 255;
           N++;
-          resetT0 = CAMath::Max(10.f, CAMath::Min(40.f, 150.f / mP[4]));
+          resetT0 = initResetT0();
           // clang-format off
           CADEBUG(printf("\n"));
           CADEBUG(printf("\t%21sMirror  Alpha %8.3f    , X %8.3f - Y %8.3f, Z %8.3f   -   QPt %7.2f (%7.2f), SP %5.2f (%5.2f) %28s    ---   Cov sY %8.3f sZ %8.3f sSP %8.3f sPt %8.3f   -   YPt %8.3f\n", "", prop.GetAlpha(), mX, mP[0], mP[1], mP[4], prop.GetQPt0(), mP[2], prop.GetSinPhi0(), "", sqrtf(mC[0]), sqrtf(mC[2]), sqrtf(mC[5]), sqrtf(mC[14]), mC[10]));
@@ -700,7 +700,8 @@ GPUd() void GPUTPCGMTrackParam::ShiftZ(const GPUTPCGMMergedTrackHit* clusters, c
   const float cosPhi = CAMath::Abs(mP[2]) < 1.f ? CAMath::Sqrt(1 - mP[2] * mP[2]) : 0.f;
   const float dxf = -CAMath::Abs(mP[2]);
   const float dyf = cosPhi * (mP[2] > 0 ? 1.f : -1.f);
-  const float r = 1.f / CAMath::Abs(mP[4] * merger->Param().polynomialField.GetNominalBz());
+  const float r1 = CAMath::Abs(mP[4] * merger->Param().polynomialField.GetNominalBz());
+  const float r = r1 > 0.0001 ? (1.f / CAMath::Abs(r1)) : 10000;
   float xp = mX + dxf * r;
   float yp = mP[0] + dyf * r;
   // printf("X %f Y %f SinPhi %f QPt %f R %f --> XP %f YP %f\n", mX, mP[0], mP[2], mP[4], r, xp, yp);

--- a/GPU/GPUTracking/Merger/GPUTPCGMTrackParam.h
+++ b/GPU/GPUTracking/Merger/GPUTPCGMTrackParam.h
@@ -211,6 +211,7 @@ class GPUTPCGMTrackParam
 
  private:
   GPUd() bool FollowCircleChk(float lrFactor, float toY, float toX, bool up, bool right);
+  GPUd() int initResetT0();
 
   float mX; // x position
   float mZOffset;
@@ -220,7 +221,16 @@ class GPUTPCGMTrackParam
   int mNDF;     // the Number of Degrees of Freedom
 };
 
-GPUd() inline void GPUTPCGMTrackParam::ResetCovariance()
+GPUdi() int GPUTPCGMTrackParam::initResetT0()
+{
+  const float absQPt = CAMath::Abs(mP[4]);
+  if (absQPt < (150.f / 40.f)) {
+    return 150.f / 40.f;
+  }
+  return CAMath::Max(10.f, 150.f / mP[4]);
+}
+
+GPUdi() void GPUTPCGMTrackParam::ResetCovariance()
 {
   mC[0] = 100.f;
   mC[1] = 0.f;
@@ -241,7 +251,7 @@ GPUd() inline void GPUTPCGMTrackParam::ResetCovariance()
   mNDF = -5;
 }
 
-GPUd() inline float GPUTPCGMTrackParam::GetMirroredY(float Bz) const
+GPUdi() float GPUTPCGMTrackParam::GetMirroredY(float Bz) const
 {
   // get Y of the point which has the same X, but located on the other side of trajectory
   float qptBz = GetQPt() * Bz;

--- a/GPU/GPUTracking/SliceTracker/GPUTPCNeighboursCleaner.h
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCNeighboursCleaner.h
@@ -54,7 +54,7 @@ class GPUTPCNeighboursCleaner : public GPUKernelTemplate
   };
 
   typedef GPUconstantref() MEM_GLOBAL(GPUTPCTracker) processorType;
-  GPUhdi() CONSTEXPR static GPUDataTypes::RecoStep GetRecoStep() { return GPUCA_RECO_STEP::TPCSliceTracking; }
+  GPUhdi() CONSTEXPRRET static GPUDataTypes::RecoStep GetRecoStep() { return GPUCA_RECO_STEP::TPCSliceTracking; }
   MEM_TEMPLATE()
   GPUhdi() static processorType* Processor(MEM_TYPE(GPUConstantMem) & processors)
   {

--- a/GPU/GPUTracking/SliceTracker/GPUTPCNeighboursFinder.h
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCNeighboursFinder.h
@@ -68,7 +68,7 @@ class GPUTPCNeighboursFinder : public GPUKernelTemplate
   };
 
   typedef GPUconstantref() MEM_GLOBAL(GPUTPCTracker) processorType;
-  GPUhdi() CONSTEXPR static GPUDataTypes::RecoStep GetRecoStep() { return GPUCA_RECO_STEP::TPCSliceTracking; }
+  GPUhdi() CONSTEXPRRET static GPUDataTypes::RecoStep GetRecoStep() { return GPUCA_RECO_STEP::TPCSliceTracking; }
   MEM_TEMPLATE()
   GPUhdi() static processorType* Processor(MEM_TYPE(GPUConstantMem) & processors)
   {

--- a/GPU/GPUTracking/SliceTracker/GPUTPCStartHitsFinder.h
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCStartHitsFinder.h
@@ -55,7 +55,7 @@ class GPUTPCStartHitsFinder : public GPUKernelTemplate
   };
 
   typedef GPUconstantref() MEM_GLOBAL(GPUTPCTracker) processorType;
-  GPUhdi() CONSTEXPR static GPUDataTypes::RecoStep GetRecoStep() { return GPUCA_RECO_STEP::TPCSliceTracking; }
+  GPUhdi() CONSTEXPRRET static GPUDataTypes::RecoStep GetRecoStep() { return GPUCA_RECO_STEP::TPCSliceTracking; }
   MEM_TEMPLATE()
   GPUhdi() static processorType* Processor(MEM_TYPE(GPUConstantMem) & processors)
   {

--- a/GPU/GPUTracking/SliceTracker/GPUTPCStartHitsSorter.h
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCStartHitsSorter.h
@@ -55,7 +55,7 @@ class GPUTPCStartHitsSorter : public GPUKernelTemplate
   };
 
   typedef GPUconstantref() MEM_GLOBAL(GPUTPCTracker) processorType;
-  GPUhdi() CONSTEXPR static GPUDataTypes::RecoStep GetRecoStep() { return GPUCA_RECO_STEP::TPCSliceTracking; }
+  GPUhdi() CONSTEXPRRET static GPUDataTypes::RecoStep GetRecoStep() { return GPUCA_RECO_STEP::TPCSliceTracking; }
   MEM_TEMPLATE()
   GPUhdi() static processorType* Processor(MEM_TYPE(GPUConstantMem) & processors)
   {

--- a/GPU/GPUTracking/SliceTracker/GPUTPCTrackLinearisation.h
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCTrackLinearisation.h
@@ -66,7 +66,7 @@ class GPUTPCTrackLinearisation
   float mQPt;    // QPt
 };
 
-GPUdi() MEM_CLASS_PRE2() GPUTPCTrackLinearisation::GPUTPCTrackLinearisation(const MEM_LG2(GPUTPCTrackParam) & t) : mSinPhi(t.SinPhi()), mCosPhi(0), mDzDs(t.DzDs()), mQPt(t.QPt())
+GPUd() MEM_CLASS_PRE2() inline GPUTPCTrackLinearisation::GPUTPCTrackLinearisation(const MEM_LG2(GPUTPCTrackParam) & t) : mSinPhi(t.SinPhi()), mCosPhi(0), mDzDs(t.DzDs()), mQPt(t.QPt())
 {
   if (mSinPhi > GPUCA_MAX_SIN_PHI) {
     mSinPhi = GPUCA_MAX_SIN_PHI;

--- a/GPU/GPUTracking/SliceTracker/GPUTPCTrackLinearisation.h
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCTrackLinearisation.h
@@ -66,7 +66,7 @@ class GPUTPCTrackLinearisation
   float mQPt;    // QPt
 };
 
-GPUd() MEM_CLASS_PRE2() inline GPUTPCTrackLinearisation::GPUTPCTrackLinearisation(const MEM_LG2(GPUTPCTrackParam) & t) : mSinPhi(t.SinPhi()), mCosPhi(0), mDzDs(t.DzDs()), mQPt(t.QPt())
+GPUdi() MEM_CLASS_PRE2() GPUTPCTrackLinearisation::GPUTPCTrackLinearisation(const MEM_LG2(GPUTPCTrackParam) & t) : mSinPhi(t.SinPhi()), mCosPhi(0), mDzDs(t.DzDs()), mQPt(t.QPt())
 {
   if (mSinPhi > GPUCA_MAX_SIN_PHI) {
     mSinPhi = GPUCA_MAX_SIN_PHI;
@@ -79,7 +79,7 @@ GPUd() MEM_CLASS_PRE2() inline GPUTPCTrackLinearisation::GPUTPCTrackLinearisatio
   }
 }
 
-GPUd() inline void GPUTPCTrackLinearisation::Set(float SinPhi1, float CosPhi1, float DzDs1, float QPt1)
+GPUdi() void GPUTPCTrackLinearisation::Set(float SinPhi1, float CosPhi1, float DzDs1, float QPt1)
 {
   SetSinPhi(SinPhi1);
   SetCosPhi(CosPhi1);

--- a/GPU/GPUTracking/SliceTracker/GPUTPCTrackParam.h
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCTrackParam.h
@@ -151,7 +151,7 @@ class GPUTPCTrackParam
   int mNDF;          // the Number of Degrees of Freedom
 };
 
-GPUdi() MEM_CLASS_PRE() void MEM_LG(GPUTPCTrackParam)::InitParam()
+GPUd() MEM_CLASS_PRE() inline void MEM_LG(GPUTPCTrackParam)::InitParam()
 {
   // Initialize Tracklet Parameters using default values
   SetSinPhi(0);

--- a/GPU/GPUTracking/SliceTracker/GPUTPCTrackParam.h
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCTrackParam.h
@@ -151,7 +151,7 @@ class GPUTPCTrackParam
   int mNDF;          // the Number of Degrees of Freedom
 };
 
-GPUd() MEM_CLASS_PRE() inline void MEM_LG(GPUTPCTrackParam)::InitParam()
+GPUdi() MEM_CLASS_PRE() void MEM_LG(GPUTPCTrackParam)::InitParam()
 {
   // Initialize Tracklet Parameters using default values
   SetSinPhi(0);

--- a/GPU/GPUTracking/SliceTracker/GPUTPCTrackletConstructor.h
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCTrackletConstructor.h
@@ -117,7 +117,7 @@ class GPUTPCTrackletConstructor
 #endif // GPUCA_GPUCODE
 
   typedef GPUconstantref() MEM_GLOBAL(GPUTPCTracker) processorType;
-  GPUhdi() CONSTEXPR static GPUDataTypes::RecoStep GetRecoStep() { return GPUCA_RECO_STEP::TPCSliceTracking; }
+  GPUhdi() CONSTEXPRRET static GPUDataTypes::RecoStep GetRecoStep() { return GPUCA_RECO_STEP::TPCSliceTracking; }
   MEM_TEMPLATE()
   GPUhdi() static processorType* Processor(MEM_TYPE(GPUConstantMem) & processors)
   {

--- a/GPU/GPUTracking/SliceTracker/GPUTPCTrackletSelector.h
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCTrackletSelector.h
@@ -48,7 +48,7 @@ class GPUTPCTrackletSelector : public GPUKernelTemplate
   };
 
   typedef GPUconstantref() MEM_GLOBAL(GPUTPCTracker) processorType;
-  GPUhdi() CONSTEXPR static GPUDataTypes::RecoStep GetRecoStep() { return GPUCA_RECO_STEP::TPCSliceTracking; }
+  GPUhdi() CONSTEXPRRET static GPUDataTypes::RecoStep GetRecoStep() { return GPUCA_RECO_STEP::TPCSliceTracking; }
   MEM_TEMPLATE()
   GPUhdi() static processorType* Processor(MEM_TYPE(GPUConstantMem) & processors)
   {


### PR DESCRIPTION
- Tracking with bz=0 failed before in continuous mode due to a floating point exception when estimating the shift of a track in z with infinite radius leading to an undefined shift.
- This also adds a nominal Pt value (currently defaulting to 200 MeV) which is applied when bz = 0 (< 0.01 kG). The value cannot be set externally yet because command line passing for the options of the TPC workflow is still missing.
- I verified whether this nominal value remains stable during the tracking, and it more or less the case (within 1 per mille).