### PR TITLE
[its-GPU] Disable unused methods to fix ROCm 3.0 warnings

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/cuda/include/ITStrackingCUDA/Utils.h
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/include/ITStrackingCUDA/Utils.h
@@ -47,8 +47,8 @@ void gpuMemset(void*, int, int);
 void gpuMemcpyHostToDevice(void*, const void*, int);
 void gpuMemcpyHostToDeviceAsync(void*, const void*, int, Stream&);
 void gpuMemcpyDeviceToHost(void*, const void*, int);
-void gpuStartProfiler();
-void gpuStopProfiler();
+// void gpuStartProfiler();
+// void gpuStopProfiler();
 } // namespace Host
 
 namespace Device

--- a/Detectors/ITSMFT/ITS/tracking/cuda/src/Utils.cu
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/src/Utils.cu
@@ -159,15 +159,15 @@ void Utils::Host::gpuMemcpyDeviceToHost(void* dst, const void* src, int size)
   checkCUDAError(cudaMemcpy(dst, src, size, cudaMemcpyDeviceToHost), __FILE__, __LINE__);
 }
 
-void Utils::Host::gpuStartProfiler()
-{
-  checkCUDAError(cudaProfilerStart(), __FILE__, __LINE__);
-}
+// void Utils::Host::gpuStartProfiler()
+// {
+//   checkCUDAError(cudaProfilerStart(), __FILE__, __LINE__);
+// }
 
-void Utils::Host::gpuStopProfiler()
-{
-  checkCUDAError(cudaProfilerStop(), __FILE__, __LINE__);
-}
+// void Utils::Host::gpuStopProfiler()
+// {
+//   checkCUDAError(cudaProfilerStop(), __FILE__, __LINE__);
+// }
 
 GPUd() int Utils::Device::getLaneIndex()
 {

--- a/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/UtilsHIP.h
+++ b/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/UtilsHIP.h
@@ -48,8 +48,8 @@ void gpuMemset(void*, int, int);
 void gpuMemcpyHostToDevice(void*, const void*, int);
 void gpuMemcpyHostToDeviceAsync(void*, const void*, int, hipStream_t&);
 void gpuMemcpyDeviceToHost(void*, const void*, int);
-void gpuStartProfiler();
-void gpuStopProfiler();
+// void gpuStartProfiler();
+// void gpuStopProfiler();
 } // namespace Host
 //
 namespace DeviceHIP

--- a/Detectors/ITSMFT/ITS/tracking/hip/src/UtilsHIP.hip.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/hip/src/UtilsHIP.hip.cxx
@@ -138,15 +138,15 @@ void Utils::HostHIP::gpuMemcpyDeviceToHost(void* dst, const void* src, int size)
   checkHIPError(hipMemcpy(dst, src, size, hipMemcpyDeviceToHost), __FILE__, __LINE__);
 }
 
-void Utils::HostHIP::gpuStartProfiler()
-{
-  checkHIPError(hipProfilerStart(), __FILE__, __LINE__);
-}
+// void Utils::HostHIP::gpuStartProfiler()
+// {
+//   checkHIPError(hipProfilerStart(), __FILE__, __LINE__);
+// }
 
-void Utils::HostHIP::gpuStopProfiler()
-{
-  checkHIPError(hipProfilerStop(), __FILE__, __LINE__);
-}
+// void Utils::HostHIP::gpuStopProfiler()
+// {
+//   checkHIPError(hipProfilerStop(), __FILE__, __LINE__);
+// }
 
 GPUd() int Utils::DeviceHIP::getLaneIndex()
 {


### PR DESCRIPTION
@davidrohr: this should be sufficient