### PR TITLE
Move GRID dimension macros to CommonDefAPI

### DIFF
--- a/GPU/Common/GPUCommonDefAPI.h
+++ b/GPU/Common/GPUCommonDefAPI.h
@@ -157,5 +157,31 @@
   #define GPUconstantref()
 #endif
 
+// Macros for GRID dimension
+#if defined(__CUDACC__)
+  #define get_global_id(dim) (blockIdx.x * blockDim.x + threadIdx.x)
+  #define get_global_size(dim) (blockDim.x * gridDim.x)
+  #define get_num_groups(dim) (gridDim.x)
+  #define get_local_id(dim) (threadIdx.x)
+  #define get_local_size(dim) (blockDim.x)
+  #define get_group_id(dim) (blockIdx.x)
+#elif defined(__HIPCC__)
+  #define get_global_id(dim) (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x)
+  #define get_global_size(dim) (hipBlockDim_x * hipGridDim_x)
+  #define get_num_groups(dim) (hipGridDim_x)
+  #define get_local_id(dim) (hipThreadIdx_x)
+  #define get_local_size(dim) (hipBlockDim_x)
+  #define get_group_id(dim) (hipBlockIdx_x)
+#elif defined(__OPENCL__)
+  // Using OpenCL defaults
+#else
+  #define get_global_id(dim) iBlock
+  #define get_global_size(dim) nBlocks
+  #define get_num_groups(dim) nBlocks
+  #define get_local_id(dim) 0
+  #define get_local_size(dim) 1
+  #define get_group_id(dim) iBlock
+#endif
+
 // clang-format on
 #endif

--- a/GPU/Common/GPUCommonDefAPI.h
+++ b/GPU/Common/GPUCommonDefAPI.h
@@ -183,5 +183,5 @@
   #define get_group_id(dim) iBlock
 #endif
 
-// clang-format on
+  // clang-format on
 #endif

--- a/GPU/Common/GPUDef.h
+++ b/GPU/Common/GPUDef.h
@@ -21,32 +21,6 @@
 #include "GPUDefOpenCL12Templates.h"
 #include "GPUCommonRtypes.h"
 
-// Macros for GRID dimension
-#if defined(__CUDACC__)
-  #define get_global_id(dim) (blockIdx.x * blockDim.x + threadIdx.x)
-  #define get_global_size(dim) (blockDim.x * gridDim.x)
-  #define get_num_groups(dim) (gridDim.x)
-  #define get_local_id(dim) (threadIdx.x)
-  #define get_local_size(dim) (blockDim.x)
-  #define get_group_id(dim) (blockIdx.x)
-#elif defined(__HIPCC__)
-  #define get_global_id(dim) (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x)
-  #define get_global_size(dim) (hipBlockDim_x * hipGridDim_x)
-  #define get_num_groups(dim) (hipGridDim_x)
-  #define get_local_id(dim) (hipThreadIdx_x)
-  #define get_local_size(dim) (hipBlockDim_x)
-  #define get_group_id(dim) (hipBlockIdx_x)
-#elif defined(__OPENCL__)
-  // Using OpenCL defaults
-#else
-  #define get_global_id(dim) iBlock
-  #define get_global_size(dim) nBlocks
-  #define get_num_groups(dim) nBlocks
-  #define get_local_id(dim) 0
-  #define get_local_size(dim) 1
-  #define get_group_id(dim) iBlock
-#endif
-
 // Macros for masking ptrs in OpenCL kernel calls as unsigned long (The API only allows us to pass buffer objects)
 #ifdef __OPENCL__
   #define GPUPtr1(a, b) unsigned long b


### PR DESCRIPTION
Macros for GPU thread block dimensions should be exposed outside of Tracking code. 