### PR TITLE
MID decoder for raw data obtained without the CRU user logic

### DIFF
--- a/Detectors/MUON/MID/Raw/CMakeLists.txt
+++ b/Detectors/MUON/MID/Raw/CMakeLists.txt
@@ -23,6 +23,8 @@ o2_add_library(
   PUBLIC_LINK_LIBRARIES ms_gsl::ms_gsl O2::DataFormatsMID O2::Headers
                         O2::CommonConstants O2::CommonUtils O2::MIDBase)
 
+add_subdirectory(exe)
+
 if(BUILD_TESTING)
   add_subdirectory(test)
 endif()

--- a/Detectors/MUON/MID/Raw/CMakeLists.txt
+++ b/Detectors/MUON/MID/Raw/CMakeLists.txt
@@ -11,9 +11,11 @@
 o2_add_library(
   MIDRaw
   SOURCES src/CrateMapper.cxx
+          src/CRUBareDecoder.cxx
           src/CRUUserLogicDecoder.cxx
           src/CRUUserLogicEncoder.cxx
           src/Decoder.cxx
+          src/ELinkDecoder.cxx
           src/Encoder.cxx
           src/LocalBoardRO.cxx
           src/RawBuffer.cxx

--- a/Detectors/MUON/MID/Raw/exe/CMakeLists.txt
+++ b/Detectors/MUON/MID/Raw/exe/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Copyright CERN and copyright holders of ALICE O2. This software is distributed
+# under the terms of the GNU General Public License v3 (GPL Version 3), copied
+# verbatim in the file "COPYING".
+#
+# See http://alice-o2.web.cern.ch/license for full licensing information.
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization or
+# submit itself to any jurisdiction.
+
+o2_add_executable(
+  rawdump
+  COMPONENT_NAME mid
+  SOURCES mid-rawdump.cxx
+  PUBLIC_LINK_LIBRARIES O2::MIDRaw)
+
+o2_add_executable(
+  raw-checker
+  COMPONENT_NAME mid
+  SOURCES mid-raw-checker.cxx CRUBareDataChecker.cxx
+  PUBLIC_LINK_LIBRARIES O2::MIDRaw)

--- a/Detectors/MUON/MID/Raw/exe/CRUBareDataChecker.cxx
+++ b/Detectors/MUON/MID/Raw/exe/CRUBareDataChecker.cxx
@@ -1,0 +1,200 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   CRUBareDataChecker.cxx
+/// \brief  Class to check the bare data from the CRU
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   9 December 2019
+
+#include "CRUBareDataChecker.h"
+
+#include <array>
+#include <sstream>
+#include "MIDRaw/CrateParameters.h"
+
+namespace o2
+{
+namespace mid
+{
+
+bool CRUBareDataChecker::checkSameEventWord(const std::vector<LocalBoardRO>& boards, uint8_t refEventWord) const
+{
+  /// Checks the event word
+  for (auto loc : boards) {
+    if (loc.eventWord != refEventWord) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool CRUBareDataChecker::checkPatterns(const LocalBoardRO& board, uint8_t expected) const
+{
+  /// Checks that the board has the expected non-null patterns
+  uint8_t inputs = (expected > 0xF) ? board.firedChambers : expected;
+  for (int ich = 0; ich < 4; ++ich) {
+    bool isExpectedNull = (((inputs >> ich) & 0x1) == 0);
+    bool isNull = (board.patternsBP[ich] == 0 && board.patternsNBP[ich] == 0);
+    if (isExpectedNull != isNull) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool CRUBareDataChecker::checkPatterns(const std::vector<LocalBoardRO>& boards, uint8_t expected) const
+{
+  /// Checks that the boards have the expected non-null patterns
+  for (auto& board : boards) {
+    if (!checkPatterns(board, expected)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool CRUBareDataChecker::checkConsistency(const LocalBoardRO& board) const
+{
+  /// Checks that the event information is consistent
+
+  bool isSoxOrReset = board.eventWord & 0xc2;
+  bool isCalib = crateparams::isCalibration(board.eventWord);
+  bool isPhysOrHC = board.eventWord & 0x5;
+
+  if (isPhysOrHC) {
+    if (isCalib) {
+      return false;
+    }
+    if (crateparams::isLoc(board.statusWord)) {
+      if (board.firedChambers) {
+        return false;
+      }
+    }
+  }
+  if (isSoxOrReset && (isCalib || isPhysOrHC)) {
+    return false;
+  }
+
+  return true;
+}
+
+bool CRUBareDataChecker::checkConsistency(const std::vector<LocalBoardRO>& boards) const
+{
+  /// Checks that the event information is consistent
+  for (auto& board : boards) {
+    if (!checkConsistency(board)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool CRUBareDataChecker::checkBC(const std::vector<LocalBoardRO>& regs, const std::vector<LocalBoardRO>& locs, std::string& debugMsg)
+{
+  /// Checks the cards belonging to the same BC
+  bool isOk = true;
+
+  if (locs.size() != 4 * regs.size()) {
+    std::stringstream ss;
+    ss << "missing cards info:  nLocs (" << locs.size() << ") != 4 x nRegs (" << regs.size() << ");  ";
+    debugMsg += ss.str();
+    isOk = false;
+  }
+
+  uint8_t refEventWord = 0;
+  if (!regs.empty()) {
+    refEventWord = regs.front().eventWord;
+  } else if (!locs.empty()) {
+    // FIXME: in some files, a series of 0xeeee wrongly added before the new RDH
+    // This is a known problem, so we do not check further in this case
+    // if (locs.front().statusWord == 0xee && locs.front().eventWord == 0xee && locs.front().firedChambers == 0xe) {
+    //   return true;
+    // }
+    refEventWord = locs.front().eventWord;
+  }
+
+  if (!checkSameEventWord(regs, refEventWord) || !checkSameEventWord(locs, refEventWord)) {
+    debugMsg += "wrong event word;  ";
+    isOk = false;
+  }
+
+  if (!checkPatterns(regs, 0) || !checkPatterns(locs)) {
+    debugMsg += "wrong size;  ";
+    isOk = false;
+  }
+
+  if (!checkConsistency(regs) || !checkConsistency(locs)) {
+    debugMsg += "inconsistency in the event;  ";
+    isOk = false;
+  }
+
+  return isOk;
+}
+
+bool CRUBareDataChecker::process(gsl::span<const LocalBoardRO> localBoards, gsl::span<const ROFRecord> rofRecords, bool resetStat)
+{
+  /// Checks the raw data
+
+  bool isOk = true;
+  if (resetStat) {
+    mStatistics.fill(0);
+  }
+
+  mDebugMsg.clear();
+
+  // Fill the map with ordered events
+  for (auto rofIt = rofRecords.begin(); rofIt != rofRecords.end(); ++rofIt) {
+    mOrderIndexes[rofIt->interactionRecord.toLong()].emplace_back(rofIt - rofRecords.begin());
+  }
+
+  std::vector<LocalBoardRO> locs;
+  std::vector<LocalBoardRO> regs;
+
+  for (auto& item : mOrderIndexes) {
+    for (auto& idx : item.second) {
+      // In principle all of these ROF records have the same timestamp
+      for (size_t iloc = rofRecords[idx].firstEntry; iloc < rofRecords[idx].firstEntry + rofRecords[idx].nEntries; ++iloc) {
+        if (crateparams::isLoc(localBoards[iloc].statusWord)) {
+          // This is a local card
+          locs.push_back(localBoards[iloc]);
+        } else {
+          regs.push_back(localBoards[iloc]);
+        }
+      }
+    }
+    // std::sort(locs.begin(), locs.end(), [](const LocalBoardRO& a, const LocalBoardRO& b) { return a.boardId < b.boardId; });
+    ++mStatistics[0];
+    std::string debugStr;
+    if (!checkBC(regs, locs, debugStr)) {
+      isOk = false;
+      std::stringstream ss;
+      ss << std::hex << std::showbase << rofRecords[item.second.front()].interactionRecord << "  problems: " << debugStr << "\n";
+      for (auto& reg : regs) {
+        ss << "  " << reg << "\n";
+      }
+      for (auto& loc : locs) {
+        ss << "  " << loc << "\n";
+      }
+      mDebugMsg += ss.str();
+      ++mStatistics[1];
+    }
+
+    locs.clear();
+    regs.clear();
+  }
+
+  // Clear the inner objects when the computation is done
+  mOrderIndexes.clear();
+
+  return isOk;
+}
+
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/Raw/exe/CRUBareDataChecker.h
+++ b/Detectors/MUON/MID/Raw/exe/CRUBareDataChecker.h
@@ -1,0 +1,56 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   CRUBareDataChecker.h
+/// \brief  Class to check the bare data from the CRU
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   9 December 2019
+#ifndef O2_MID_CRUBAREDATACHECKER_H
+#define O2_MID_CRUBAREDATACHECKER_H
+
+#include <cstdint>
+#include <vector>
+#include <string>
+#include <map>
+#include <gsl/gsl>
+#include "DataFormatsMID/ROFRecord.h"
+#include "MIDRaw/LocalBoardRO.h"
+
+namespace o2
+{
+namespace mid
+{
+class CRUBareDataChecker
+{
+ public:
+  bool process(gsl::span<const LocalBoardRO> localBoards, gsl::span<const ROFRecord> rofRecords, bool resetStat = true);
+  /// Gets the number of processed events
+  unsigned int getNBCsProcessed() const { return mStatistics[0]; }
+  /// Gets the number of faulty events
+  unsigned int getNBCsFaulty() const { return mStatistics[1]; }
+  /// Gets the
+  std::string getDebugMessage() const { return mDebugMsg; }
+
+ private:
+  bool checkBC(const std::vector<LocalBoardRO>& regs, const std::vector<LocalBoardRO>& locs, std::string& debugMsg);
+  bool checkSameEventWord(const std::vector<LocalBoardRO>& boards, uint8_t refEventWord) const;
+  bool checkConsistency(const LocalBoardRO& board) const;
+  bool checkConsistency(const std::vector<LocalBoardRO>& boards) const;
+  bool checkPatterns(const LocalBoardRO& board, uint8_t expected = 0xFF) const;
+  bool checkPatterns(const std::vector<LocalBoardRO>& boards, uint8_t expected = 0xFF) const;
+
+  std::map<uint64_t, std::vector<size_t>> mOrderIndexes; /// Map for time ordering the entries
+  std::string mDebugMsg{};                               /// Debug message
+  std::array<unsigned long int, 2> mStatistics{};        /// Processed events statistics
+};
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_CRUBAREDATACHECKER_H */

--- a/Detectors/MUON/MID/Raw/exe/README.md
+++ b/Detectors/MUON/MID/Raw/exe/README.md
@@ -1,0 +1,50 @@
+\page refMUONMIDRawExe MID RAW executable
+
+# Utilities for MID RAW data
+This directory contains two utilities that can be executed to verify the raw data.
+This is particularly important for testing and debugging the MID Read-out.
+
+## MID raw dumper
+This utility allows to dump the decoded raw data content.
+Basic usage:
+```bash
+o2-mid-rawdump filename [filename_2 filename_3 ...]
+```
+The output is a file containing a list with:
+-   the interaction record
+
+-   the list of decoded [LocalBoardRO](../include/MIDRaw/LocalBoardRO.h)
+For a list of the other available options:
+```bash
+o2-mid-rawdump --help
+```
+
+## MID raw file checker
+This utility allows to test files produced by the CRU w/o using the User Logic.
+Basic usage:
+```bash
+o2-mid-raw-checker filename [filename_2 filename_3 ...]
+```
+The output is a file (or a series of files if a list of inputs is provided), named after the input file as `check_filename.txt`, so that it is easy to understand to which input file the output is referring to.
+The different e-links are read out and then grouped according to their interaction record.
+The output file contains:
+-   a list of possible problems (if any) for each event processed
+
+-   a summary with the number of faulty events
+The list of problems is preceded by the identifier of the processed HB and the corresponding "line" in the file where the HB is.
+The line is counted assuming that one reads the file as a series of 4 words of 32 bits each (this is the typical way the binary file is converted into text during the tests).
+Notice that one can have more than 1 HB per event, since the data might be split into different pages if the maximum page size is reached.
+For a list of the other available options:
+```bash
+o2-mid-raw-checker --help
+```
+### Performed checks
+The decoded information is read HB per HB (multiple pages are read out when needed).
+For each HB, the decoded information are gathered according to their interaction.
+Notice that, in principle, events belonging to different HBs should have different interaction records, so one could in principle read the full file and then perform the check.
+However, in the tests the RDH is not always correctly set, and the orbit number might not increase. That is why we read the HB one by one, and limit the tests to 1 HB at the time. This makes it easier to tag HBs with issues in the RO.
+For each interaction record, a number of checks are performed:
+-   The number of local cards read must be 4 times the number of regional cards. Notice that this error often implies that there is a mismatch between the regional and local clocks (so the cards gets split into different interaction records)
+-   The word describing the event (SOX, EOX, HC, Calibration, etc.) should be the same for all cards in the interaction record.
+-   The number of non-zero patterns read must match the information written in the corresponding word that indicates the non-zero detector planes. Notice that this might not be true when the patterns represent the masks, since in this case it is fine to transmit a zero pattern. However, for the sake of simplicity, we do not account for this possibility. Of course, this implies that must run the check on tests where all masks are non-zero.
+-   For each card we check that the information is consistent. For example we cannot have SOX and Calibration bits fired at the same time. Also, during an HC, we expect to have no chamber fired for the local boards. Notice that during tests this information is added by hand, so we should not have any issue by design.

--- a/Detectors/MUON/MID/Raw/exe/mid-raw-checker.cxx
+++ b/Detectors/MUON/MID/Raw/exe/mid-raw-checker.cxx
@@ -1,0 +1,139 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   mid-raw-checker.cxx
+/// \brief  CRU bare data checker for MID
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   09 December 2019
+
+#include <iostream>
+#include <fstream>
+#include "boost/program_options.hpp"
+#include "MIDRaw/CRUBareDecoder.h"
+#include "MIDRaw/RawFileReader.h"
+#include "CRUBareDataChecker.h"
+
+namespace po = boost::program_options;
+
+o2::header::RAWDataHeader buildCustomRDH()
+{
+  o2::header::RAWDataHeader rdh;
+  rdh.word1 |= 0x2000;
+  rdh.word1 |= ((0x2000 - 0x100)) << 16;
+  return rdh;
+}
+
+int main(int argc, char* argv[])
+{
+  po::variables_map vm;
+  po::options_description generic("Generic options");
+  unsigned long int nHBs = 0;
+  bool onlyClosedHBs = false;
+  bool ignoreRDH = true;
+
+  // clang-format off
+  generic.add_options()
+          ("help", "produce help message")
+          ("nHBs", po::value<unsigned long int>(&nHBs),"Number of HBs read")
+          ("only-closed-HBs", po::value<bool>(&onlyClosedHBs)->implicit_value(true),"Return only closed HBs")
+          ("ignore-RDH", po::value<bool>(&ignoreRDH)->implicit_value(true),"Ignore read RDH. Use custom one instead");
+
+
+  po::options_description hidden("hidden options");
+  hidden.add_options()
+          ("input", po::value<std::vector<std::string>>(),"Input filename");
+  // clang-format on
+
+  po::options_description cmdline;
+  cmdline.add(generic).add(hidden);
+
+  po::positional_options_description pos;
+  pos.add("input", -1);
+
+  po::store(po::command_line_parser(argc, argv).options(cmdline).positional(pos).run(), vm);
+  po::notify(vm);
+
+  if (vm.count("help")) {
+    std::cout << "Usage: " << argv[0] << " <input_raw_filename> [input_raw_filename_1 ...]\n";
+    std::cout << generic << std::endl;
+    return 2;
+  }
+  if (vm.count("input") == 0) {
+    std::cout << "no input file specified" << std::endl;
+    return 1;
+  }
+
+  std::vector<std::string> inputfiles{vm["input"].as<std::vector<std::string>>()};
+
+  o2::mid::CRUBareDecoder decoder;
+  decoder.init(true);
+
+  o2::mid::CRUBareDataChecker checker;
+
+  unsigned long int iHB = 0;
+
+  for (auto& filename : inputfiles) {
+    o2::mid::RawFileReader<uint8_t> rawFileReader;
+    std::string outFilename = filename;
+    auto pos = outFilename.find_last_of("/");
+    if (pos == std::string::npos) {
+      pos = 0;
+    } else {
+      ++pos;
+    }
+    outFilename.insert(pos, "check_");
+    outFilename += ".txt";
+    std::ofstream outFile(outFilename.c_str());
+    if (!rawFileReader.init(filename.c_str())) {
+      return 2;
+    }
+    if (ignoreRDH) {
+      rawFileReader.setCustomRDH(buildCustomRDH());
+    }
+    std::vector<o2::mid::LocalBoardRO> data;
+    std::vector<o2::mid::ROFRecord> rofRecords;
+    std::stringstream ss;
+    bool isFirst = true;
+    while (rawFileReader.getState() == 0) {
+      rawFileReader.readHB(onlyClosedHBs);
+      decoder.process(rawFileReader.getData());
+      rawFileReader.clear();
+      size_t offset = data.size();
+      std::copy(decoder.getData().begin(), decoder.getData().end(), std::back_inserter(data));
+      for (auto& rof : decoder.getROFRecords()) {
+        rofRecords.emplace_back(rof.interactionRecord, rof.eventType, rof.firstEntry + offset, rof.nEntries);
+      }
+      ss << "  HB: " << iHB << "  (line: " << 512 * iHB + 1 << ")";
+      if (decoder.isComplete()) {
+        // The check assumes that we have all data corresponding to one event.
+        // However this might not be true since we read one HB at the time.
+        // So we must test that the event was fully read before running the check.
+        if (!checker.process(data, rofRecords, isFirst)) {
+          outFile << ss.str() << "\n";
+          outFile << checker.getDebugMessage() << "\n";
+        }
+        isFirst = false;
+        std::stringstream clean;
+        ss.swap(clean);
+        data.clear();
+        rofRecords.clear();
+      }
+      ++iHB;
+      if (nHBs > 0 && iHB >= nHBs) {
+        break;
+      }
+    }
+    outFile << "Fraction of faulty events: " << checker.getNBCsFaulty() << " / " << checker.getNBCsProcessed() << " = " << static_cast<double>(checker.getNBCsFaulty()) / static_cast<double>(checker.getNBCsProcessed());
+
+    outFile.close();
+  }
+
+  return 0;
+}

--- a/Detectors/MUON/MID/Raw/exe/mid-rawdump.cxx
+++ b/Detectors/MUON/MID/Raw/exe/mid-rawdump.cxx
@@ -1,0 +1,95 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   mid-rawdump.cxx
+/// \brief  Raw dumper for MID
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   05 December 2019
+
+#include <iostream>
+#include "boost/program_options.hpp"
+#include "MIDRaw/CRUBareDecoder.h"
+#include "MIDRaw/RawFileReader.h"
+
+namespace po = boost::program_options;
+
+int main(int argc, char* argv[])
+{
+  po::variables_map vm;
+  po::options_description generic("Generic options");
+  std::string outFilename = "mid_raw.txt";
+  unsigned long int nHBs = 0;
+  bool onlyClosedHBs = false;
+
+  // clang-format off
+  generic.add_options()
+          ("help", "produce help message")
+          ("output", po::value<std::string>(&outFilename),"Output text file")
+          ("nHBs", po::value<unsigned long int>(&nHBs),"Number of HBs read")
+          ("only-closed-HBs", po::value<bool>(&onlyClosedHBs)->implicit_value(true),"Return only closed HBs");
+
+
+  po::options_description hidden("hidden options");
+  hidden.add_options()
+          ("input", po::value<std::vector<std::string>>(),"Input filename");
+  // clang-format on
+
+  po::options_description cmdline;
+  cmdline.add(generic).add(hidden);
+
+  po::positional_options_description pos;
+  pos.add("input", -1);
+
+  po::store(po::command_line_parser(argc, argv).options(cmdline).positional(pos).run(), vm);
+  po::notify(vm);
+
+  if (vm.count("help")) {
+    std::cout << "Usage: " << argv[0] << " <input_raw_filename> [input_raw_filename_1 ...]\n";
+    std::cout << generic << std::endl;
+    return 2;
+  }
+  if (vm.count("input") == 0) {
+    std::cout << "no input file specified" << std::endl;
+    return 1;
+  }
+
+  std::vector<std::string> inputfiles{vm["input"].as<std::vector<std::string>>()};
+
+  o2::mid::CRUBareDecoder decoder;
+
+  std::ofstream outFile(outFilename);
+
+  unsigned long int iHB = 0;
+
+  for (auto& filename : inputfiles) {
+    o2::mid::RawFileReader<uint8_t> rawFileReader;
+    if (!rawFileReader.init(filename.c_str())) {
+      return 2;
+    }
+    while (rawFileReader.getState() == 0) {
+      rawFileReader.readHB(onlyClosedHBs);
+      decoder.process(rawFileReader.getData());
+      rawFileReader.clear();
+      for (auto& rof : decoder.getROFRecords()) {
+        outFile << "Orbit: " << rof.interactionRecord.orbit << " bc: " << rof.interactionRecord.bc << std::endl;
+        for (auto colIt = decoder.getData().begin() + rof.firstEntry; colIt != decoder.getData().begin() + rof.firstEntry + rof.nEntries; ++colIt) {
+          outFile << *colIt << std::endl;
+        }
+      }
+      ++iHB;
+      if (nHBs > 0 && iHB >= nHBs) {
+        break;
+      }
+    }
+  }
+  outFile.close();
+
+  return 0;
+}

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/CRUBareDecoder.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/CRUBareDecoder.h
@@ -1,0 +1,68 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDRaw/CRUBareDecoder.h
+/// \brief  MID CRU core decoder
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   18 November 2019
+#ifndef O2_MID_CRUBAREDECODER_H
+#define O2_MID_CRUBAREDECODER_H
+
+#include <cstdint>
+#include <vector>
+#include <gsl/gsl>
+#include "DataFormatsMID/ROFRecord.h"
+#include "MIDRaw/CrateMapper.h"
+#include "MIDRaw/CrateParameters.h"
+#include "MIDRaw/ELinkDecoder.h"
+#include "MIDRaw/LocalBoardRO.h"
+#include "MIDRaw/RawBuffer.h"
+
+namespace o2
+{
+namespace mid
+{
+class CRUBareDecoder
+{
+ public:
+  void init(bool debugMode = false);
+  void process(gsl::span<const uint8_t> bytes);
+  /// Gets the vector of data
+  const std::vector<LocalBoardRO>& getData() const { return mData; }
+
+  /// Gets the vector of data RO frame records
+  const std::vector<ROFRecord>& getROFRecords() const { return mROFRecords; }
+
+  bool isComplete() const;
+
+ private:
+  RawBuffer<uint8_t> mBuffer{};                                           /// Raw buffer handler
+  std::vector<LocalBoardRO> mData{};                                      /// Vector of output data
+  std::vector<ROFRecord> mROFRecords{};                                   /// List of ROF records
+  CrateMapper mCrateMapper{};                                             /// Crate mapper
+  uint8_t mCrateId{0};                                                    /// Crate ID
+  std::array<uint16_t, crateparams::sNELinksPerGBT> mCalibClocks{};       /// Calibration clock
+  std::array<ELinkDecoder, crateparams::sNELinksPerGBT> mELinkDecoders{}; /// E-link decoders
+  std::function<void(size_t)> mAddReg{[](size_t) {}};                     ///! Add regional board
+
+  std::function<bool(size_t)> mCheckBoard{std::bind(&CRUBareDecoder::checkBoard, this, std::placeholders::_1)}; ///! Check board
+
+  bool nextGBTWord();
+  void processGBT(size_t offset);
+  void reset();
+  void addBoard(size_t ilink);
+  bool checkBoard(size_t ilink);
+  void addLoc(size_t ilink);
+  uint16_t getPattern(uint16_t pattern, bool invert) const;
+};
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_CRUBAREDECODER_H */

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/ELinkDecoder.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/ELinkDecoder.h
@@ -1,0 +1,59 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDRaw/ELinkDecoder.h
+/// \brief  MID e-link decoder
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   26 November 2019
+#ifndef O2_MID_ELINKDECODER_H
+#define O2_MID_ELINKDECODER_H
+
+#include <cstdint>
+#include <vector>
+
+namespace o2
+{
+namespace mid
+{
+class ELinkDecoder
+{
+ public:
+  bool add(const uint8_t byte, uint8_t expectedStart);
+  /// Checks if we have all of the information needed for the decoding
+  bool isComplete() const { return mBytes.size() == mTotalSize; };
+  /// Gets the status word
+  uint8_t getStatusWord() const { return mBytes[0]; }
+  /// Gets the event word
+  uint8_t getEventWord() const { return mBytes[1]; }
+  /// Gets the counter
+  uint16_t getCounter() const { return joinBytes(2); }
+  // uint16_t getCounter() const { return (mBytes[2] << 8) | mBytes[3]; }
+  /// Gets the card ID
+  uint8_t getId() const { return (mBytes[4] >> 4) & 0xF; }
+  /// Gets the inputs
+  uint8_t getInputs() const { return (mBytes[4] & 0xF); }
+  uint16_t getPattern(int cathode, int chamber) const;
+  /// Gets the number of bytes read
+  size_t getNBytes() const { return mBytes.size(); }
+
+  void reset();
+
+ private:
+  inline uint16_t joinBytes(int idx) const { return (mBytes[idx] << 8 | mBytes[idx + 1]); };
+
+  static constexpr size_t sMinimumSize{5};  /// Minimum size of the buffer
+  static constexpr size_t sMaximumSize{21}; /// Maximum size of the buffer
+  std::vector<uint8_t> mBytes{};            /// Vector with encoded information
+  size_t mTotalSize{sMinimumSize};          /// Expected size of the read-out buffer
+};
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_ELINKDECODER_H */

--- a/Detectors/MUON/MID/Raw/src/CRUBareDecoder.cxx
+++ b/Detectors/MUON/MID/Raw/src/CRUBareDecoder.cxx
@@ -1,0 +1,150 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Raw/src/CRUBareDecoder.cxx
+/// \brief  MID CRU core decoder
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   30 September 2019
+
+#include "MIDRaw/CRUBareDecoder.h"
+
+#include "RawInfo.h"
+
+namespace o2
+{
+namespace mid
+{
+
+void CRUBareDecoder::reset()
+{
+  /// Rewind bytes
+  mData.clear();
+  mROFRecords.clear();
+}
+
+void CRUBareDecoder::init(bool debugMode)
+{
+  /// Initializes the task
+  if (debugMode == true) {
+    mAddReg = std::bind(&CRUBareDecoder::addBoard, this, std::placeholders::_1);
+    mCheckBoard = [](size_t) { return true; };
+  }
+}
+
+void CRUBareDecoder::process(gsl::span<const uint8_t> bytes)
+{
+  /// Decodes the buffer
+  reset();
+
+  mBuffer.setBuffer(bytes);
+
+  // Each CRU word consists of 128 bits, i.e 16 bytes
+  while (mBuffer.hasNext(16)) {
+    processGBT(0);
+    processGBT(5);
+    // The GBT word consists of 10 bytes
+    // but the CRU word is 16 bytes
+    // So we have 6 empty bytes
+    for (int iword = 0; iword < 6; ++iword) {
+      mBuffer.next();
+    }
+  }
+}
+
+void CRUBareDecoder::processGBT(size_t offset)
+{
+  /// Processes the GBT
+
+  // Regional link
+  // loc#0 loc#1 loc#2 loc#3 reg
+  std::array<uint8_t, 5> bytes{mBuffer.next(), mBuffer.next(), mBuffer.next(), mBuffer.next(), mBuffer.next()};
+
+  // Byte corresponding to regional
+  size_t ibyte = 4;
+  size_t ilink = offset + ibyte;
+
+  if (mELinkDecoders[ilink].add(bytes[ibyte], 0x80) && mELinkDecoders[ilink].isComplete()) {
+    // In principle, in the same HB we should have the info of only 1 crate
+    // So it should be safe to store this information
+    // and apply it to all subsequent e-links, without checking the clock
+    mCrateId = mELinkDecoders[ilink].getId();
+    mAddReg(ilink);
+    mELinkDecoders[ilink].reset();
+  }
+
+  // local links
+  for (ibyte = 0; ibyte < 4; ++ibyte) {
+    ilink = offset + ibyte;
+    if (mELinkDecoders[ilink].add(bytes[ibyte], 0xc0) && mELinkDecoders[ilink].isComplete()) {
+      if (mCheckBoard(ilink)) {
+        addLoc(ilink);
+      }
+      mELinkDecoders[ilink].reset();
+    }
+  }
+}
+
+bool CRUBareDecoder::checkBoard(size_t ilink)
+{
+  /// Performs checks on the board
+  uint8_t expectedId = ilink - (ilink / 5);
+  return (expectedId == mELinkDecoders[ilink].getId() % 8);
+}
+
+void CRUBareDecoder::addBoard(size_t ilink)
+{
+  /// Adds the local or regional board to the output data vector
+  uint16_t localClock = mELinkDecoders[ilink].getCounter();
+  EventType eventType = EventType::Standard;
+  if (mELinkDecoders[ilink].getEventWord() & (1 << 4)) {
+    mCalibClocks[ilink] = localClock;
+    eventType = EventType::Noise;
+  } else if (localClock == mCalibClocks[ilink] + sDelayCalibToFET) {
+    eventType = EventType::Dead;
+  }
+  auto firstEntry = mData.size();
+  InteractionRecord intRec(localClock - sDelayBCToLocal, mBuffer.getRDH()->triggerOrbit);
+  mData.push_back({mELinkDecoders[ilink].getStatusWord(), mELinkDecoders[ilink].getEventWord(), crateparams::makeUniqueLocID(mCrateId, mELinkDecoders[ilink].getId()), mELinkDecoders[ilink].getInputs()});
+  mROFRecords.emplace_back(intRec, eventType, firstEntry, 1);
+}
+
+void CRUBareDecoder::addLoc(size_t ilink)
+{
+  /// Adds the local board to the output data vector
+  addBoard(ilink);
+  bool invert = (mROFRecords.back().eventType == EventType::Dead);
+  for (int ich = 0; ich < 4; ++ich) {
+    if ((mData.back().firedChambers & (1 << ich))) {
+      mData.back().patternsBP[ich] = getPattern(mELinkDecoders[ilink].getPattern(0, ich), invert);
+      mData.back().patternsNBP[ich] = getPattern(mELinkDecoders[ilink].getPattern(1, ich), invert);
+    }
+  }
+  mELinkDecoders[ilink].reset();
+}
+
+uint16_t CRUBareDecoder::getPattern(uint16_t pattern, bool invert) const
+{
+  /// Gets the proper pattern
+  return (invert) ? ~pattern : pattern;
+}
+
+bool CRUBareDecoder::isComplete() const
+{
+  /// Checks that all links have finished reading
+  for (auto& elink : mELinkDecoders) {
+    if (elink.getNBytes() > 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/Raw/src/ELinkDecoder.cxx
+++ b/Detectors/MUON/MID/Raw/src/ELinkDecoder.cxx
@@ -1,0 +1,75 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Raw/src/ELinkDecoder.cxx
+/// \brief  MID CRU core decoder
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   30 September 2019
+
+#include "MIDRaw/ELinkDecoder.h"
+
+#include "MIDRaw/CrateParameters.h"
+
+namespace o2
+{
+namespace mid
+{
+
+bool ELinkDecoder::add(uint8_t byte, uint8_t expectedStart)
+{
+  /// Add next byte
+  if (mBytes.empty() && (byte & 0xc0) != expectedStart) {
+    return false;
+  }
+  mBytes.emplace_back(byte);
+  if (mBytes.size() == sMinimumSize) {
+    if (crateparams::isLoc(mBytes[0])) {
+      // This is a local card
+      uint8_t mask = getInputs();
+      for (int ich = 0; ich < 4; ++ich) {
+        if ((mask >> ich) & 0x1) {
+          // We expect 2 bytes for the BP and 2 for the NBP
+          mTotalSize += 4;
+        }
+      }
+    }
+  }
+  return true;
+}
+
+void ELinkDecoder::reset()
+{
+  /// Reset inner objects
+  mBytes.clear();
+  mTotalSize = sMinimumSize;
+}
+
+uint16_t ELinkDecoder::getPattern(int cathode, int chamber) const
+{
+  /// Gets the pattern
+  uint8_t mask = getInputs();
+  if (((mask >> chamber) & 0x1) == 0) {
+    return 0;
+  }
+
+  int idx = mBytes.size();
+  for (int ich = 0; ich <= chamber; ++ich) {
+    if ((mask >> ich) & 0x1) {
+      idx -= 4;
+    }
+  }
+
+  idx += 2 * cathode;
+
+  return joinBytes(idx);
+}
+
+} // namespace mid
+} // namespace o2


### PR DESCRIPTION
This PR consists of two commits: one implementing the decoder and the other implementing 2 utilities to check the raw data (using the decoder).
A README.md is provided to explain how to run the checks.
The commits are atomic: please do not squash.