### PR TITLE
Actually quit test when no more data to read

### DIFF
--- a/Framework/Utils/test/test_RootTreeReader.cxx
+++ b/Framework/Utils/test/test_RootTreeReader.cxx
@@ -77,7 +77,7 @@ DataProcessorSpec getSourceSpec()
         // test signature without headers for the rest of the entries
         (++(*reader))(pc);
       }
-      if (reader->getCount() >= kTreeSize) {
+      if ((reader->getCount() + 1) >= kTreeSize) {
         pc.services().get<ControlService>().endOfStream();
       }
     };


### PR DESCRIPTION
This handles the fact that getCount() is in [0,9] while kTreeSize
is 10 resulting in the fact that the source would not always quit
before the sink.