### PR TITLE
Sorting for AMD HIP

### DIFF
--- a/GPU/Common/CMakeLists.txt
+++ b/GPU/Common/CMakeLists.txt
@@ -45,9 +45,9 @@ if(ALIGPU_BUILD_TYPE STREQUAL "O2")
   
   # cuda test, only compile if CUDA
   if(CUDA_ENABLED AND NOT $ENV{ALIBUILT_O2_TESTS})
-    o2_add_test(${MODULE}
-                PUBLIC_LINK_LIBRARIES O2::${MODULE}
+    o2_add_test(GPUsortCUDA NAME test_GPUsortCUDA
                 SOURCES ctest/testGPUsortCUDA.cu
+                PUBLIC_LINK_LIBRARIES O2::${MODULE} cub::cub
                 COMPONENT_NAME GPU
                 LABELS gpu)
   endif()

--- a/GPU/Common/GPUCommonAlgorithm.h
+++ b/GPU/Common/GPUCommonAlgorithm.h
@@ -199,8 +199,8 @@ typedef GPUCommonAlgorithm CAAlgo;
 } // namespace gpu
 } // namespace GPUCA_NAMESPACE
 
-#ifdef __CUDACC__
-#include "GPUCommonAlgorithmCUDA.cuh"
+#if defined(__CUDACC__) || defined(__HIPCC__)
+#include "GPUCommonAlgorithmThrust.h"
 
 #else
 

--- a/GPU/Common/GPUCommonAlgorithmThrust.h
+++ b/GPU/Common/GPUCommonAlgorithmThrust.h
@@ -8,11 +8,11 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file GPUCommonAlgorithmCUDA.cuh
-/// \author David Rohr
+/// \file GPUCommonAlgorithmThrust.h
+/// \author Michael Lettrich
 
-#ifndef GPUCOMMONALGORITHMCUDA_CUH
-#define GPUCOMMONALGORITHMCUDA_CUH
+#ifndef GPUCOMMONALGORITHMTHRUST_H
+#define GPUCOMMONALGORITHMTHRUST_H
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"
@@ -21,7 +21,7 @@
 #include <thrust/device_ptr.h>
 #pragma GCC diagnostic pop
 
-#include <cuda.h>
+#include "GPUCommonDef.h"
 
 namespace GPUCA_NAMESPACE
 {
@@ -47,20 +47,28 @@ GPUdi() void GPUCommonAlgorithm::sort(T* begin, T* end, const S& comp)
 template <class T>
 GPUdi() void GPUCommonAlgorithm::sortInBlock(T* begin, T* end)
 {
-  if (threadIdx.x == 0 && threadIdx.y == 0 && threadIdx.z == 0) {
+  if (get_local_id(0) == 0) {
     thrust::device_ptr<T> thrustBegin(begin);
     thrust::device_ptr<T> thrustEnd(end);
+#if defined(__CUDACC__)
     thrust::sort(thrust::cuda::par, thrustBegin, thrustEnd);
+#elif defined(__HIPCC__)
+    thrust::sort(thrust::hip::par, thrustBegin, thrustEnd);
+#endif
   }
 }
 
 template <class T, class S>
 GPUdi() void GPUCommonAlgorithm::sortInBlock(T* begin, T* end, const S& comp)
 {
-  if (threadIdx.x == 0 && threadIdx.y == 0 && threadIdx.z == 0) {
+  if (get_local_id(0) == 0) {
     thrust::device_ptr<T> thrustBegin(begin);
     thrust::device_ptr<T> thrustEnd(end);
+#if defined(__CUDACC__)
     thrust::sort(thrust::cuda::par, thrustBegin, thrustEnd, comp);
+#elif defined(__HIPCC__)
+    thrust::sort(thrust::hip::par, thrustBegin, thrustEnd, comp);
+#endif
   }
 }
 

--- a/GPU/GPUTracking/Base/hip/CMakeLists.txt
+++ b/GPU/GPUTracking/Base/hip/CMakeLists.txt
@@ -17,6 +17,7 @@ string(REPLACE " -g " " " CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS} ")
 string(REPLACE " -g " " " CMAKE_CXX_FLAGS_${CMAKE_BUILT_TYPE} " ${CMAKE_CXX_FLAGS_${CMAKE_BUILT_TYPE}} ")
 string(REPLACE " -g " " " CMAKE_LINK_FLAGS " ${CMAKE_LINK_FLAGS} ")
 string(REPLACE " -g " " " CMAKE_LINK_FLAGS_${CMAKE_BUILT_TYPE} " ${CMAKE_LINK_FLAGS_${CMAKE_BUILT_TYPE}} ")
+
 string(REPLACE " -ggdb " " " CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS} ")
 string(REPLACE " -ggdb " " " CMAKE_CXX_FLAGS_${CMAKE_BUILT_TYPE} " ${CMAKE_CXX_FLAGS_${CMAKE_BUILT_TYPE}} ")
 string(REPLACE " -ggdb " " " CMAKE_LINK_FLAGS " ${CMAKE_LINK_FLAGS} ")
@@ -24,10 +25,12 @@ string(REPLACE " -ggdb " " " CMAKE_LINK_FLAGS_${CMAKE_BUILT_TYPE} " ${CMAKE_LINK
 
 #setting flags as a global option for all HIP targets.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-invalid-command-line-argument -Wno-unused-command-line-argument -Wno-invalid-constexpr -Wno-ignored-optimization-argument -Wno-unused-private-field")
-
 if(DEFINED HIP_AMDGPUTARGET)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --amdgpu-target=${HIP_AMDGPUTARGET}")
+  set(CMAKE_LINK_FLAGS "${CMAKE_LINK_FLAGS} --amdgpu-target=${HIP_AMDGPUTARGET}")
   set(TMP_TARGET "(GPU Target ${HIP_AMDGPUTARGET})")
 endif()
+
 message(STATUS "Building GPUTracking with HIP support ${TMP_TARGET}")
 
 set(SRCS GPUReconstructionHIP.hip.cxx)
@@ -47,6 +50,14 @@ if(ALIGPU_BUILD_TYPE STREQUAL "O2")
     $<TARGET_PROPERTY:O2::GPUTracking,COMPILE_DEFINITIONS>)
 
   install(FILES ${HDRS} DESTINATION include/GPU)
+
+ if(NOT $ENV{ALIBUILT_O2_TESTS})
+  o2_add_test(GPUsortHIP NAME test_GPUsortHIP
+                  SOURCES ctest/testGPUsortHIP.hip.cxx
+                  PUBLIC_LINK_LIBRARIES O2::GPUCommon hip::host hip::device hip::hipcub ROCm::rocThrust
+                  COMPONENT_NAME GPU
+                  LABELS gpu)
+  endif()
 endif()
 
 if(ALIGPU_BUILD_TYPE STREQUAL "ALIROOT")
@@ -84,9 +95,4 @@ if(ALIGPU_BUILD_TYPE STREQUAL "Standalone")
   target_link_libraries(${MODULE} GPUTracking hip::host hip::device hip::hipcub ROCm::rocThrust)
   set(targetName "${MODULE}")
   install(TARGETS GPUTrackingHIP)
-endif()
-
-if(HIP_AMDGPUTARGET)
-  target_link_options(${targetName} PUBLIC --amdgpu-target=${HIP_AMDGPUTARGET})
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --amdgpu-target=${HIP_AMDGPUTARGET}")
 endif()


### PR DESCRIPTION
Include sorting for AMD GPUs in HIP implementation using [AMD's implementation of the THRUST API](https://github.com/ROCmSoftwarePlatform/rocThrust).  Includes unit tests. 