### PR TITLE
Empty shell VMCReplay structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,11 +73,13 @@ add_subdirectory(EventVisualisation)
 add_subdirectory(Generators)
 add_subdirectory(Steer) # consider building this only for simulation ?
 
+
 if(BUILD_EXAMPLES)
   add_subdirectory(Examples)
 endif()
 
 if(BUILD_SIMULATION)
+  add_subdirectory(VMCReplay)
   add_subdirectory(run)
 endif()
 

--- a/Detectors/gconfig/CMakeLists.txt
+++ b/Detectors/gconfig/CMakeLists.txt
@@ -9,13 +9,14 @@
 # submit itself to any jurisdiction.
 
 o2_add_library(SimSetup
-               SOURCES src/G3Config.cxx src/G4Config.cxx
+               SOURCES src/G3Config.cxx src/G4Config.cxx src/VMCReplayConfig.cxx
                        src/GlobalProcessCutSimParam.cxx src/SimSetup.cxx
                PUBLIC_LINK_LIBRARIES MC::Geant3
                                      MC::Geant4VMC
                                      MC::Geant4
                                      O2::SimulationDataFormat
                                      O2::DetectorsPassive
+                                     O2::VMCReplay
                                      MC::Pythia6 # this is needed by Geant3 and
                                                  # EGPythia6
                                      ROOT::EGPythia6 # this is needed by Geant4
@@ -48,3 +49,7 @@ o2_add_test_root_macro(g3Config.C
 o2_add_test_root_macro(g4Config.C
                        PUBLIC_LINK_LIBRARIES O2::SimSetup
                        LABELS simsetup)
+
+o2_add_test_root_macro(VMCReplayConfig.C
+        PUBLIC_LINK_LIBRARIES O2::SimSetup
+        LABELS simsetup)

--- a/Detectors/gconfig/VMCReplayConfig.C
+++ b/Detectors/gconfig/VMCReplayConfig.C
@@ -1,0 +1,40 @@
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include "VMCReplay/VMCReplay.h"
+#include "FairRunSim.h"
+#include <iostream>
+#endif
+#include "commonConfig.C"
+
+void Config()
+{
+  FairRunSim* run = FairRunSim::Instance();
+  TString* gModel = run->GetGeoModel();
+
+  // THIS WOULD A GOOD MOMENT TO PASS IN THE CACHED STEP INFORMATION
+  auto replayvmc = new VMCReplay("Hello");
+
+  stackSetup(replayvmc, run);
+
+  // ******* replayvmc  specific configuration for simulated Runs  *******
+  //
+  replayvmc->SetTRIG(1); // Number of events to be processed
+  replayvmc->SetSWIT(4, 100);
+  replayvmc->SetDEBU(0, 0, 1);
+
+  replayvmc->SetRAYL(1);
+  replayvmc->SetSTRA(0);
+
+  // NOTE: Please avoid changing this setting, unless justified as this might lead to very many steps
+  // performed by G3; AUTO(1) is the G3 default
+  replayvmc->SetAUTO(1); // Select automatic STMIN etc... calc. (AUTO 1) or manual (AUTO 0)
+
+  replayvmc->SetABAN(0); // Restore 3.16 behaviour for abandoned tracks
+  replayvmc->SetOPTI(2); // Select optimisation level for GEANT geometry searches (0,1,2)
+  replayvmc->SetERAN(5.e-7);
+  replayvmc->SetCKOV(1); // cerenkov photons
+
+  // allow many steps per track (per volume)
+  // since this is needed in the TPC
+  // (this does not seem to be possible per module)
+  replayvmc->SetMaxNStep(1E5);
+}

--- a/Detectors/gconfig/src/SimSetup.cxx
+++ b/Detectors/gconfig/src/SimSetup.cxx
@@ -23,6 +23,10 @@ namespace g4config
 {
 void G4Config();
 }
+namespace vmcreplayconfig
+{
+void VMCReplayConfig();
+}
 
 void SimSetup::setup(const char* engine)
 {
@@ -30,6 +34,8 @@ void SimSetup::setup(const char* engine)
     g3config::G3Config();
   } else if (strcmp(engine, "TGeant4") == 0) {
     g4config::G4Config();
+  } else if (strcmp(engine, "VMCReplay") == 0) {
+    vmcreplayconfig::VMCReplayConfig();
   } else {
     LOG(FATAL) << "Unsupported engine " << engine;
   }

--- a/Detectors/gconfig/src/VMCReplayConfig.cxx
+++ b/Detectors/gconfig/src/VMCReplayConfig.cxx
@@ -1,0 +1,48 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "FairRunSim.h"
+#include "TGeant3.h"
+#include "TGeant3TGeo.h"
+#include "SimulationDataFormat/Stack.h"
+#include "SimulationDataFormat/StackParam.h"
+#include <iostream>
+#include "FairLogger.h"
+#include "FairModule.h"
+#include <DetectorsPassive/Cave.h>
+#include "DetectorsBase/MaterialManager.h"
+#include "SimSetup/GlobalProcessCutSimParam.h"
+
+//using declarations here since SetCuts.C and g3Config.C are included within namespace
+// these are needed for SetCuts.C inclusion
+using o2::GlobalProcessCutSimParam;
+using o2::base::ECut;
+using o2::base::EProc;
+using o2::base::MaterialManager;
+// these are used in g3Config.C
+using std::cout;
+using std::endl;
+#include <SimSetup/SimSetup.h>
+
+#include "../VMCReplayConfig.C"
+#include "../SetCuts.h"
+
+namespace o2
+{
+namespace vmcreplayconfig
+{
+void VMCReplayConfig()
+{
+  LOG(INFO) << "Setting up VMCReplay simulation";
+  Config();
+  SetCuts();
+}
+} // namespace vmcreplayconfig
+} // namespace o2

--- a/VMCReplay/CMakeLists.txt
+++ b/VMCReplay/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Copyright CERN and copyright holders of ALICE O2. This software is distributed
+# under the terms of the GNU General Public License v3 (GPL Version 3), copied
+# verbatim in the file "COPYING".
+#
+# See http://alice-o2.web.cern.ch/license for full licensing information.
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization or
+# submit itself to any jurisdiction.
+
+
+o2_add_library(VMCReplay
+        SOURCES src/VMCReplay.cxx
+        PUBLIC_LINK_LIBRARIES MC::Geant3
+        )
+
+set(headers
+        include/VMCReplay/VMCReplay.h)
+
+o2_target_root_dictionary(VMCReplay HEADERS ${headers})

--- a/VMCReplay/include/VMCReplay/VMCReplay.h
+++ b/VMCReplay/include/VMCReplay/VMCReplay.h
@@ -1,0 +1,24 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_VMCREPLAY_H
+#define O2_VMCREPLAY_H
+
+#include "TGeant3TGeo.h"
+
+class VMCReplay : public TGeant3TGeo
+{
+ public:
+  using TGeant3TGeo::TGeant3TGeo;
+
+  ClassDef(VMCReplay, 1); // needed as long we inherit from TObject
+};
+
+#endif //O2_VMCREPLAY_H

--- a/VMCReplay/src/VMCReplay.cxx
+++ b/VMCReplay/src/VMCReplay.cxx
@@ -1,0 +1,13 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "VMCReplay/VMCReplay.h"
+
+ClassImp(VMCReplay);

--- a/VMCReplay/src/VMCReplayLinkDef.h
+++ b/VMCReplay/src/VMCReplayLinkDef.h
@@ -1,0 +1,19 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifdef __CLING__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class VMCReplay;
+
+#endif


### PR DESCRIPTION
Basic (trivial) setup for a new
VMC implementation targeting replay
functionality of a simulation without
executing the transport/physics code.

The new engine should take step information
from a previous run and the goal is to use
it to study influence of production cuts
on the hits/digits efficiently.

Together with @benedikt-voelkel