### PR TITLE
New attempt to eliminate unwanted empty README pages in Doxygen doc:

### DIFF
--- a/doc/doxyfile.in
+++ b/doc/doxyfile.in
@@ -98,24 +98,7 @@ WARN_LOGFILE           =
 #---------------------------------------------------------------------------
 # Configuration options related to the input files
 #---------------------------------------------------------------------------
-INPUT                  = @CMAKE_SOURCE_DIR@/README.md \
-                         @CMAKE_SOURCE_DIR@/doc \
-                         @CMAKE_SOURCE_DIR@/Algorithm \
-                         @CMAKE_SOURCE_DIR@/CCDB \
-                         @CMAKE_SOURCE_DIR@/Common \
-                         @CMAKE_SOURCE_DIR@/DataFormats \
-                         @CMAKE_SOURCE_DIR@/Detectors \
-                         @CMAKE_SOURCE_DIR@/EventVisualisation \
-                         @CMAKE_SOURCE_DIR@/Examples \
-                         @CMAKE_SOURCE_DIR@/Framework \
-                         @CMAKE_SOURCE_DIR@/GPU \
-                         @CMAKE_SOURCE_DIR@/Generators \
-                         @CMAKE_SOURCE_DIR@/Steer \
-                         @CMAKE_SOURCE_DIR@/Testing \
-                         @CMAKE_SOURCE_DIR@/Utilities \
-                         @CMAKE_SOURCE_DIR@/macro \
-                         @CMAKE_SOURCE_DIR@/run \
-                         @CMAKE_SOURCE_DIR@/tests
+INPUT                  = "@CMAKE_SOURCE_DIR@"
 INPUT_ENCODING         = UTF-8
 FILE_PATTERNS          = *.cxx *.h *.inl *.md
 RECURSIVE              = YES
@@ -123,9 +106,10 @@ EXCLUDE                = .git/ \
                          build/ \
                          build-dir/ \
                          html-docs/ \
+                         md md_ \
                          doxygen cmake config  gconfig geometry input parameters .svn vis
 EXCLUDE_SYMLINKS       = NO
-EXCLUDE_PATTERNS       = G__* ClassImp build_*
+EXCLUDE_PATTERNS       = G__* ClassImp build_* */md*
 EXCLUDE_SYMBOLS        =
 EXAMPLE_PATH           =
 EXAMPLE_PATTERNS       =


### PR DESCRIPTION
- Exclude processing md* files and directories
- Changed INPUT back to @CMAKE_SOURCE_DIR@