### PR TITLE
Signal endOfStream when ready to quit

### DIFF
--- a/Detectors/TPC/workflow/src/PublisherSpec.cxx
+++ b/Detectors/TPC/workflow/src/PublisherSpec.cxx
@@ -194,6 +194,7 @@ DataProcessorSpec getPublisherSpec(PublisherConf const& config, bool propagateMC
       }
 
       if ((processAttributes->finished = (operation == -1)) && processAttributes->terminateOnEod) {
+        pc.services().get<ControlService>().endOfStream();
         pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
       }
     };


### PR DESCRIPTION
@matthiasrichter w/o this the flows requiring TPC input do not exit on completion due to the dangling inputs sink device not knowing that it should not expect data anymore (e.g. o2-tpcits-match-workflow)