### PR TITLE
Update travis platform for doxygen generation to bionic to get newer …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ matrix:
           fi
         fi
     - os: linux
+      dist: bionic
       env: JOB=doxygen
       addons:
         apt:

--- a/doc/doxyfile.in
+++ b/doc/doxyfile.in
@@ -106,10 +106,9 @@ EXCLUDE                = .git/ \
                          build/ \
                          build-dir/ \
                          html-docs/ \
-                         md md_ \
                          doxygen cmake config  gconfig geometry input parameters .svn vis
 EXCLUDE_SYMLINKS       = NO
-EXCLUDE_PATTERNS       = G__* ClassImp build_* */md*
+EXCLUDE_PATTERNS       = G__* ClassImp build_*
 EXCLUDE_SYMBOLS        =
 EXAMPLE_PATH           =
 EXAMPLE_PATTERNS       =


### PR DESCRIPTION
…version of doxygen

- The problem with unwanted empty README pages seems to be affected by a bug in Doxygen
  which was fixed in Doxygen 1.8.12, while travis uses version 1.8.11
- Reverted back previous changes in doxyfile.in which did not work