### PR TITLE
Provide a way to trigger on generated event

### DIFF
--- a/Common/SimConfig/include/SimConfig/SimConfig.h
+++ b/Common/SimConfig/include/SimConfig/SimConfig.h
@@ -24,11 +24,14 @@ struct SimConfigData {
   std::vector<std::string> mActiveDetectors; // list of active detectors
   std::string mMCEngine;                     // chosen VMC engine
   std::string mGenerator;                    // chosen VMC generator
+  std::string mTrigger;                      // chosen VMC generator trigger
   unsigned int mNEvents;                     // number of events to be simulated
   std::string mExtKinFileName;               // file name of external kinematics file (needed for ext kinematics generator)
   std::string mHepMCFileName;                // file name of HepMC file
   std::string mExtGenFileName;               // file name containing the external generator configuration
   std::string mExtGenFuncName;               // function call to retrieve the external generator configuration
+  std::string mExtTrgFileName;               // file name containing the external trigger configuration
+  std::string mExtTrgFuncName;               // function call to retrieve the external trigger configuration
   std::string mEmbedIntoFileName;            // filename containing the reference events to be used for the embedding
   unsigned int mStartEvent;                  // index of first event to be taken
   float mBMax;                               // maximum for impact parameter sampling
@@ -94,12 +97,15 @@ class SimConfig
   std::vector<std::string> const& getActiveDetectors() const { return mConfigData.mActiveDetectors; }
   // get selected generator (to be used to select a genconfig)
   std::string getGenerator() const { return mConfigData.mGenerator; }
+  std::string getTrigger() const { return mConfigData.mTrigger; }
   unsigned int getNEvents() const { return mConfigData.mNEvents; }
 
   std::string getExtKinematicsFileName() const { return mConfigData.mExtKinFileName; }
   std::string getHepMCFileName() const { return mConfigData.mHepMCFileName; }
   std::string getExtGeneratorFileName() const { return mConfigData.mExtGenFileName; }
   std::string getExtGeneratorFuncName() const { return mConfigData.mExtGenFuncName; }
+  std::string getExtTriggerFileName() const { return mConfigData.mExtTrgFileName; }
+  std::string getExtTriggerFuncName() const { return mConfigData.mExtTrgFuncName; }
   std::string getEmbedIntoFileName() const { return mConfigData.mEmbedIntoFileName; }
   unsigned int getStartEvent() const { return mConfigData.mStartEvent; }
   float getBMax() const { return mConfigData.mBMax; }

--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -25,6 +25,7 @@ void SimConfig::initOptions(boost::program_options::options_description& options
   options.add_options()(
     "mcEngine,e", bpo::value<std::string>()->default_value("TGeant3"), "VMC backend to be used.")(
     "generator,g", bpo::value<std::string>()->default_value("boxgen"), "Event generator to be used.")(
+    "trigger,t", bpo::value<std::string>()->default_value(""), "Event generator trigger to be used.")(
     "modules,m", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>({"all"}), "all modules"), "list of detectors")(
     "skipModules", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>({""}), ""), "list of detectors to skip (precendence over -m")("nEvents,n", bpo::value<unsigned int>()->default_value(1), "number of events")(
     "startEvent", bpo::value<unsigned int>()->default_value(0), "index of first event to be used (when applicable)")(
@@ -36,6 +37,10 @@ void SimConfig::initOptions(boost::program_options::options_description& options
     "name of .C file with definition of external event generator")(
     "extGenFunc", bpo::value<std::string>()->default_value(""),
     "function call to load the definition of external event generator")(
+    "extTrgFile", bpo::value<std::string>()->default_value("exttrg.C"),
+    "name of .C file with definition of external event generator trigger")(
+    "extTrgFunc", bpo::value<std::string>()->default_value(""),
+    "function call to load the definition of external event generator trigger")(
     "embedIntoFile", bpo::value<std::string>()->default_value(""),
     "filename containing the reference events to be used for the embedding")(
     "bMax,b", bpo::value<float>()->default_value(0.), "maximum value for impact parameter sampling (when applicable)")(
@@ -86,11 +91,14 @@ bool SimConfig::resetFromParsedMap(boost::program_options::variables_map const& 
   }
 
   mConfigData.mGenerator = vm["generator"].as<std::string>();
+  mConfigData.mTrigger = vm["trigger"].as<std::string>();
   mConfigData.mNEvents = vm["nEvents"].as<unsigned int>();
   mConfigData.mExtKinFileName = vm["extKinFile"].as<std::string>();
   mConfigData.mHepMCFileName = vm["HepMCFile"].as<std::string>();
   mConfigData.mExtGenFileName = vm["extGenFile"].as<std::string>();
   mConfigData.mExtGenFuncName = vm["extGenFunc"].as<std::string>();
+  mConfigData.mExtTrgFileName = vm["extTrgFile"].as<std::string>();
+  mConfigData.mExtTrgFuncName = vm["extTrgFunc"].as<std::string>();
   mConfigData.mEmbedIntoFileName = vm["embedIntoFile"].as<std::string>();
   mConfigData.mStartEvent = vm["startEvent"].as<unsigned int>();
   mConfigData.mBMax = vm["bMax"].as<float>();

--- a/Generators/CMakeLists.txt
+++ b/Generators/CMakeLists.txt
@@ -18,12 +18,15 @@ endif()
 
 o2_add_library(Generators
                SOURCES src/Generator.cxx
+	       	       src/Trigger.cxx
+	       	       src/TriggerParticle.cxx
                        src/GeneratorTGenerator.cxx
                        src/GeneratorFromFile.cxx
                        src/Pythia6Generator.cxx
                        src/PDG.cxx
                        src/PrimaryGenerator.cxx
                        src/InteractionDiamondParam.cxx
+                       src/TriggerParticleParam.cxx
                        src/BoxGunParam.cxx
 		       src/QEDGenParam.cxx
                        src/GeneratorFactory.cxx
@@ -44,12 +47,15 @@ endif()
 
 set(headers
     include/Generators/Generator.h
+    include/Generators/Trigger.h
+    include/Generators/TriggerParticle.h
     include/Generators/GeneratorTGenerator.h
     include/Generators/GeneratorFromFile.h
     include/Generators/Pythia6Generator.h
     include/Generators/PDG.h
     include/Generators/PrimaryGenerator.h
     include/Generators/InteractionDiamondParam.h
+    include/Generators/TriggerParticleParam.h
     include/Generators/BoxGunParam.h
     include/Generators/QEDGenParam.h)
 
@@ -85,7 +91,12 @@ o2_add_test_root_macro(share/external/tgenerator.C
                        PUBLIC_LINK_LIBRARIES O2::Generators
                        LABELS generators)
 
+o2_add_test_root_macro(share/external/multiphi_trigger.C
+                       PUBLIC_LINK_LIBRARIES O2::Generators
+                       LABELS generators)
+
 		     
 install(FILES share/external/extgen.C share/external/pythia6.C
               share/external/tgenerator.C share/external/QEDLoader.C share/external/QEDepem.C
+	      share/external/multiphi_trigger.C
         DESTINATION share/Generators/external/)

--- a/Generators/include/Generators/Generator.h
+++ b/Generators/include/Generators/Generator.h
@@ -17,25 +17,41 @@
 #include <vector>
 #include <array>
 
+class TClonesArray;
+
 namespace o2
 {
 namespace eventgen
 {
+
+class Trigger;
+
+/*****************************************************************/
+/*****************************************************************/
+
 // this class implements a generic FairGenerator extension
 // that provides a base class for the ALICEo2 simulation needs
 // such that different interfaces to the event generators
 // (i.e. TGenerator, HEPdata reader) can be implemented
 // according to a common protocol
+
 class Generator : public FairGenerator
 {
 
  public:
+  enum ETriggerMode_t { kTriggerOFF,
+                        kTriggerOR,
+                        kTriggerAND };
+
   /** default constructor **/
   Generator();
   /** constructor **/
   Generator(const Char_t* name, const Char_t* title = "ALICEo2 Generator");
   /** destructor **/
-  ~Generator() override = default;
+  ~Generator() override;
+
+  /** Initialize the generator if needed **/
+  Bool_t Init() override;
 
   /** Abstract method ReadEvent must be implemented by any derived class.
 	It has to handle the generation of input tracks (reading from input
@@ -52,6 +68,8 @@ class Generator : public FairGenerator
   void setPositionUnit(double val) { mPositionUnit = val; };
   void setTimeUnit(double val) { mTimeUnit = val; };
   void setBoost(Double_t val) { mBoost = val; };
+  void setTriggerMode(ETriggerMode_t val) { mTriggerMode = val; };
+  void addTrigger(Trigger* trigger) { mTriggers.push_back(trigger); };
 
  protected:
   /** copy constructor **/
@@ -61,14 +79,25 @@ class Generator : public FairGenerator
 
   /** methods to override **/
   virtual Bool_t generateEvent() = 0;
-  virtual Bool_t boostEvent(Double_t boost) = 0;
-  virtual Bool_t addTracks(FairPrimaryGenerator* primGen) const = 0;
+  virtual Bool_t importParticles() = 0;
+
+  /** internal methods **/
+  Bool_t addTracks(FairPrimaryGenerator* primGen);
+  Bool_t boostEvent();
+  Bool_t triggerEvent();
+
+  /** trigger data members **/
+  ETriggerMode_t mTriggerMode = kTriggerOFF;
+  std::vector<Trigger*> mTriggers;
 
   /** conversion data members **/
   double mMomentumUnit = 1.;        // [GeV/c]
   double mEnergyUnit = 1.;          // [GeV/c]
   double mPositionUnit = 0.1;       // [cm]
   double mTimeUnit = 3.3356410e-12; // [s]
+
+  /** particle array **/
+  TClonesArray* mParticles; //!
 
   /** lorentz boost data members **/
   Double_t mBoost;

--- a/Generators/include/Generators/GeneratorHepMC.h
+++ b/Generators/include/Generators/GeneratorHepMC.h
@@ -57,8 +57,7 @@ class GeneratorHepMC : public Generator
 
   /** methods to override **/
   Bool_t generateEvent() override;
-  Bool_t boostEvent(Double_t boost) override;
-  Bool_t addTracks(FairPrimaryGenerator* primGen) const override;
+  Bool_t importParticles() override;
 
   /** methods **/
   const HepMC::FourVector getBoostedVector(const HepMC::FourVector& vector, Double_t boost);

--- a/Generators/include/Generators/GeneratorTGenerator.h
+++ b/Generators/include/Generators/GeneratorTGenerator.h
@@ -16,7 +16,6 @@
 #include "Generators/Generator.h"
 
 class TGenerator;
-class TClonesArray;
 
 namespace o2
 {
@@ -35,7 +34,7 @@ class GeneratorTGenerator : public Generator
   /** constructor with name and title **/
   GeneratorTGenerator(const Char_t* name, const Char_t* title = "ALICEo2 TGenerator Generator");
   /** destructor **/
-  ~GeneratorTGenerator() override;
+  ~GeneratorTGenerator() override = default;
 
   /** setters **/
   void setTGenerator(TGenerator* val) { mTGenerator = val; };
@@ -51,12 +50,10 @@ class GeneratorTGenerator : public Generator
 
   /** methods to override **/
   Bool_t generateEvent() override;
-  Bool_t boostEvent(Double_t boost) override;
-  Bool_t addTracks(FairPrimaryGenerator* primGen) const override;
+  Bool_t importParticles() override;
 
   /** TGenerator interface **/
   TGenerator* mTGenerator;
-  TClonesArray* mParticles;
 
   ClassDefOverride(GeneratorTGenerator, 1);
 

--- a/Generators/include/Generators/Trigger.h
+++ b/Generators/include/Generators/Trigger.h
@@ -1,0 +1,56 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author R+Preghenella - August 2017
+
+#ifndef ALICEO2_EVENTGEN_TRIGGER_H_
+#define ALICEO2_EVENTGEN_TRIGGER_H_
+
+#include "TNamed.h"
+
+class TClonesArray;
+
+namespace o2
+{
+namespace eventgen
+{
+
+/*****************************************************************/
+/*****************************************************************/
+
+class Trigger : public TNamed
+{
+
+ public:
+  /** default constructor **/
+  Trigger() = default;
+  /** destructor **/
+  ~Trigger() override = default;
+
+  /** methods to override **/
+  virtual Bool_t fired(TClonesArray* particles) = 0;
+
+ protected:
+  /** copy constructor **/
+  Trigger(const Trigger&);
+  /** operator= **/
+  Trigger& operator=(const Trigger&);
+
+  ClassDefOverride(Trigger, 1);
+
+}; /** class Trigger **/
+
+/*****************************************************************/
+/*****************************************************************/
+
+} // namespace eventgen
+} // namespace o2
+
+#endif /* ALICEO2_EVENTGEN_TRIGGER_H_ */

--- a/Generators/include/Generators/TriggerParticle.h
+++ b/Generators/include/Generators/TriggerParticle.h
@@ -1,0 +1,88 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author R+Preghenella - September 2019
+
+#ifndef ALICEO2_EVENTGEN_TRIGGERPARTICLE_H_
+#define ALICEO2_EVENTGEN_TRIGGERPARTICLE_H_
+
+#include "Generators/Trigger.h"
+
+namespace o2
+{
+namespace eventgen
+{
+
+/*****************************************************************/
+/*****************************************************************/
+
+class TriggerParticle : public Trigger
+{
+
+ public:
+  /** default constructor **/
+  TriggerParticle() = default;
+  /** destructor **/
+  ~TriggerParticle() override = default;
+
+  /** methods to override **/
+  Bool_t fired(TClonesArray* particles) override;
+
+  /** setters **/
+  void setPDG(Int_t val) { mPDG = val; };
+  void setPtRange(Double_t min, Double_t max)
+  {
+    mPtMin = min;
+    mPtMax = max;
+  };
+  void setEtaRange(Double_t min, Double_t max)
+  {
+    mEtaMin = min;
+    mEtaMax = max;
+  };
+  void setPhiRange(Double_t min, Double_t max)
+  {
+    mPhiMin = min;
+    mPhiMax = max;
+  };
+  void setYRange(Double_t min, Double_t max)
+  {
+    mYMin = min;
+    mYMax = max;
+  };
+
+ protected:
+  /** copy constructor **/
+  TriggerParticle(const TriggerParticle&);
+  /** operator= **/
+  TriggerParticle& operator=(const TriggerParticle&);
+
+  /** trigger particle selection **/
+  Int_t mPDG = 0;
+  Double_t mPtMin = 0.;
+  Double_t mPtMax = 1.e6;
+  Double_t mEtaMin = -1.e6;
+  Double_t mEtaMax = 1.e6;
+  Double_t mPhiMin = -1.e6;
+  Double_t mPhiMax = 1.e6;
+  Double_t mYMin = -1.e6;
+  Double_t mYMax = 1.e6;
+
+  ClassDefOverride(TriggerParticle, 1);
+
+}; /** class TriggerParticle **/
+
+/*****************************************************************/
+/*****************************************************************/
+
+} // namespace eventgen
+} // namespace o2
+
+#endif /* ALICEO2_EVENTGEN_TRIGGERPARTICLE_H_ */

--- a/Generators/include/Generators/TriggerParticleParam.h
+++ b/Generators/include/Generators/TriggerParticleParam.h
@@ -1,0 +1,45 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author R+Preghenella - January 2020
+
+#ifndef ALICEO2_EVENTGEN_TRIGGERPARTICLEPARAM_H_
+#define ALICEO2_EVENTGEN_TRIGGERPARTICLEPARAM_H_
+
+#include "SimConfig/ConfigurableParam.h"
+#include "SimConfig/ConfigurableParamHelper.h"
+
+namespace o2
+{
+namespace eventgen
+{
+
+/**
+ ** a parameter class/struct to keep the settings of
+ ** the event-generator trigger particle and 
+ ** allow the user to modify them 
+ **/
+struct TriggerParticleParam : public o2::conf::ConfigurableParamHelper<TriggerParticleParam> {
+  int pdg = 0;
+  double ptMin = 0.;
+  double ptMax = 1.e6;
+  double etaMin = -1.e6;
+  double etaMax = 1.e6;
+  double phiMin = -1.e6;
+  double phiMax = 1.e6;
+  double yMin = -1.e6;
+  double yMax = 1.e6;
+  O2ParamDef(TriggerParticleParam, "TriggerParticle");
+};
+
+} // end namespace eventgen
+} // end namespace o2
+
+#endif // ALICEO2_EVENTGEN_TRIGGERPARTICLEPARAM_H_

--- a/Generators/share/external/multiphi_trigger.C
+++ b/Generators/share/external/multiphi_trigger.C
@@ -1,0 +1,84 @@
+// configures a trigger class
+//   usage: o2sim --trigger external --extTrgFile multiphi_trigger.C
+// options:                          --extTrgFunc multiphi_trigger(2)
+
+/// \author R+Preghenella - January 2020
+
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include "Generators/Trigger.h"
+#include "TClonesArray.h"
+#include "TParticle.h"
+#endif
+
+#include "FairLogger.h"
+
+/** class definition **/
+
+class MultiPhiTrigger : public o2::eventgen::Trigger
+{
+ public:
+  // constructor, destructor
+  MultiPhiTrigger() = default;
+  ~MultiPhiTrigger() = default;
+
+  // method to override
+  Bool_t fired(TClonesArray* particles) override;
+
+  // setters
+  void setNumberOfPhis(Int_t val) { mNumberOfPhis = val; };
+
+ private:
+  Int_t mMaxNumberOfAttempts = 1000000;
+  Int_t mWarnNumberOfAttempts = 10000;
+  Int_t mNumberOfAttempts = 0;
+  Int_t mNumberOfPhis = 2;
+};
+
+/** class implementation **/
+
+Bool_t MultiPhiTrigger::fired(TClonesArray* particles)
+{
+  // loop over generated particles
+  Int_t nParticles = particles->GetEntries();
+  TParticle* particle = nullptr;
+  Int_t nPhis = 0;
+  for (Int_t iparticle = 0; iparticle < nParticles; iparticle++) {
+    particle = (TParticle*)particles->At(iparticle);
+    if (!particle)
+      continue;
+    // count phi mesons at mid rapidity with pt > 500 MeV/c
+    if (particle->GetPdgCode() == 333 && fabs(particle->Y()) < 0.5 && particle->Pt() > 0.5)
+      nPhis++;
+  }
+
+  // increment number of attempts
+  mNumberOfAttempts++;
+
+  // trigger fired
+  if (nPhis >= mNumberOfPhis) {
+    LOG(INFO) << "MultiPhiTrigger fired: " << nPhis << " phi mesons";
+    mNumberOfAttempts = 0;
+    return kTRUE;
+  }
+
+  // warning message
+  if (mNumberOfAttempts % mWarnNumberOfAttempts == 0)
+    LOG(WARNING) << "MultiPhiTrigger did not fire yet: " << mNumberOfAttempts << " number of attempts";
+
+  // fatal message
+  if (mNumberOfAttempts >= mMaxNumberOfAttempts)
+    LOG(FATAL) << "MultiPhiTrigger did not fire after " << mMaxNumberOfAttempts;
+
+  // trigger did not fire
+  return kFALSE;
+};
+
+/** main function **/
+
+o2::eventgen::Trigger*
+  multiphi_trigger(Int_t numberOfPhis = 2)
+{
+  auto trigger = new MultiPhiTrigger();
+  trigger->setNumberOfPhis(numberOfPhis);
+  return trigger;
+}

--- a/Generators/src/Generator.cxx
+++ b/Generators/src/Generator.cxx
@@ -11,9 +11,12 @@
 /// \author R+Preghenella - August 2017
 
 #include "Generators/Generator.h"
+#include "Generators/Trigger.h"
 #include "FairPrimaryGenerator.h"
 #include "FairLogger.h"
 #include <cmath>
+#include "TClonesArray.h"
+#include "TParticle.h"
 
 namespace o2
 {
@@ -24,17 +27,48 @@ namespace eventgen
 /*****************************************************************/
 
 Generator::Generator() : FairGenerator("ALICEo2", "ALICEo2 Generator"),
+                         mParticles(nullptr),
                          mBoost(0.)
 {
   /** default constructor **/
+
+  /** array of generated particles **/
+  mParticles = new TClonesArray("TParticle");
+  mParticles->SetOwner(kTRUE);
 }
 
 /*****************************************************************/
 
 Generator::Generator(const Char_t* name, const Char_t* title) : FairGenerator(name, title),
+                                                                mParticles(nullptr),
                                                                 mBoost(0.)
 {
   /** constructor **/
+
+  /** array of generated particles **/
+  mParticles = new TClonesArray("TParticle");
+  mParticles->SetOwner(kTRUE);
+}
+
+/*****************************************************************/
+
+Generator::~Generator()
+{
+  /** default destructor **/
+
+  if (mParticles)
+    delete mParticles;
+}
+
+/*****************************************************************/
+
+Bool_t
+  Generator::Init()
+{
+  /** init **/
+
+  /** success **/
+  return kTRUE;
 }
 
 /*****************************************************************/
@@ -44,14 +78,21 @@ Bool_t
 {
   /** read event **/
 
-  /** generate event **/
-  if (!generateEvent())
-    return kFALSE;
+  /** endless generate-and-trigger loop **/
+  while (true) {
 
-  /** boost event **/
-  if (fabs(mBoost) > 0.001)
-    if (!boostEvent(mBoost))
+    /** generate event **/
+    if (!generateEvent())
       return kFALSE;
+
+    /** import particles **/
+    if (!importParticles())
+      return kFALSE;
+
+    /** trigger event **/
+    if (triggerEvent())
+      break;
+  }
 
   /** add tracks **/
   if (!addTracks(primGen))
@@ -59,6 +100,86 @@ Bool_t
 
   /** success **/
   return kTRUE;
+}
+
+/*****************************************************************/
+
+Bool_t
+  Generator::addTracks(FairPrimaryGenerator* primGen)
+{
+  /** add tracks **/
+
+  /** loop over particles **/
+  Int_t nParticles = mParticles->GetEntries();
+  TParticle* particle = nullptr;
+  for (Int_t iparticle = 0; iparticle < nParticles; iparticle++) {
+    particle = (TParticle*)mParticles->At(iparticle);
+    if (!particle)
+      continue;
+    if (particle->GetStatusCode() != 1)
+      continue;
+    primGen->AddTrack(particle->GetPdgCode(),
+                      particle->Px() * mMomentumUnit,
+                      particle->Py() * mMomentumUnit,
+                      particle->Pz() * mMomentumUnit,
+                      particle->Vx() * mPositionUnit,
+                      particle->Vy() * mPositionUnit,
+                      particle->Vz() * mPositionUnit,
+                      particle->GetMother(0),
+                      particle->GetStatusCode() == 1,
+                      particle->Energy() * mEnergyUnit,
+                      particle->T() * mTimeUnit,
+                      particle->GetWeight());
+  }
+
+  /** success **/
+  return kTRUE;
+}
+
+/*****************************************************************/
+
+Bool_t
+  Generator::boostEvent()
+{
+  /** boost event **/
+
+  /** success **/
+  return kTRUE;
+}
+
+/*****************************************************************/
+
+Bool_t
+  Generator::triggerEvent()
+{
+  /** trigger event **/
+
+  /** check trigger presence **/
+  if (mTriggers.size() == 0)
+    return kTRUE;
+
+  /** check trigger mode **/
+  Bool_t triggered;
+  if (mTriggerMode == kTriggerOFF)
+    return kTRUE;
+  else if (mTriggerMode == kTriggerOR)
+    triggered = kFALSE;
+  else if (mTriggerMode == kTriggerAND)
+    triggered = kTRUE;
+  else
+    return kTRUE;
+
+  /** loop over triggers **/
+  for (const auto& trigger : mTriggers) {
+    auto retval = trigger->fired(mParticles);
+    if (mTriggerMode == kTriggerOR)
+      triggered |= retval;
+    if (mTriggerMode == kTriggerAND)
+      triggered &= retval;
+  }
+
+  /** return **/
+  return triggered;
 }
 
 /*****************************************************************/

--- a/Generators/src/GeneratorTGenerator.cxx
+++ b/Generators/src/GeneratorTGenerator.cxx
@@ -13,7 +13,6 @@
 #include "FairPrimaryGenerator.h"
 #include "TGenerator.h"
 #include "TClonesArray.h"
-#include "TParticle.h"
 
 namespace o2
 {
@@ -24,8 +23,7 @@ namespace eventgen
 /*****************************************************************/
 
 GeneratorTGenerator::GeneratorTGenerator() : Generator("ALICEo2", "ALICEo2 TGenerator Generator"),
-                                             mTGenerator(nullptr),
-                                             mParticles(nullptr)
+                                             mTGenerator(nullptr)
 {
   /** default constructor **/
 }
@@ -33,20 +31,9 @@ GeneratorTGenerator::GeneratorTGenerator() : Generator("ALICEo2", "ALICEo2 TGene
 /*****************************************************************/
 
 GeneratorTGenerator::GeneratorTGenerator(const Char_t* name, const Char_t* title) : Generator(name, title),
-                                                                                    mTGenerator(nullptr),
-                                                                                    mParticles(nullptr)
+                                                                                    mTGenerator(nullptr)
 {
   /** constructor **/
-}
-
-/*****************************************************************/
-
-GeneratorTGenerator::~GeneratorTGenerator()
-{
-  /** default destructor **/
-
-  if (mParticles)
-    delete mParticles;
 }
 
 /*****************************************************************/
@@ -57,7 +44,6 @@ Bool_t
   /** generate event **/
 
   mTGenerator->GenerateEvent();
-  mTGenerator->ImportParticles(mParticles, "Final");
 
   /** success **/
   return kTRUE;
@@ -66,41 +52,11 @@ Bool_t
 /*****************************************************************/
 
 Bool_t
-  GeneratorTGenerator::boostEvent(Double_t boost)
+  GeneratorTGenerator::importParticles()
 {
-  /** boost event **/
+  /** import particles **/
 
-  LOG(WARNING) << "Boost not implemented yet" << std::endl;
-  return kTRUE;
-}
-
-/*****************************************************************/
-
-Bool_t
-  GeneratorTGenerator::addTracks(FairPrimaryGenerator* primGen) const
-{
-  /** add tracks **/
-
-  /* loop over particles */
-  Int_t nParticles = mParticles->GetEntries();
-  TParticle* particle = nullptr;
-  for (Int_t iparticle = 0; iparticle < nParticles; iparticle++) {
-    particle = (TParticle*)mParticles->At(iparticle);
-    if (!particle)
-      continue;
-    primGen->AddTrack(particle->GetPdgCode(),
-                      particle->Px() * mMomentumUnit,
-                      particle->Py() * mMomentumUnit,
-                      particle->Pz() * mMomentumUnit,
-                      particle->Vx() * mPositionUnit,
-                      particle->Vy() * mPositionUnit,
-                      particle->Vz() * mPositionUnit,
-                      particle->GetMother(0),
-                      particle->GetStatusCode() == 1,
-                      particle->Energy() * mEnergyUnit,
-                      particle->T() * mTimeUnit,
-                      particle->GetWeight());
-  }
+  mTGenerator->ImportParticles(mParticles, "All");
 
   /** success **/
   return kTRUE;
@@ -113,14 +69,13 @@ Bool_t
 {
   /** init **/
 
+  /** init base class **/
+  Generator::Init();
+
   if (!mTGenerator) {
     LOG(FATAL) << "No TGenerator inteface assigned" << std::endl;
     return kFALSE;
   }
-
-  /** array of generated particles **/
-  mParticles = new TClonesArray("TParticle");
-  mParticles->SetOwner(kTRUE);
 
   /** success **/
   return kTRUE;

--- a/Generators/src/GeneratorsLinkDef.h
+++ b/Generators/src/GeneratorsLinkDef.h
@@ -26,6 +26,7 @@
 #pragma link off all functions;
 
 #pragma link C++ class o2::eventgen::Generator + ;
+#pragma link C++ class o2::eventgen::GeneratorHepMC + ;
 #pragma link C++ class o2::eventgen::GeneratorTGenerator + ;
 #ifdef GENERATORS_WITH_HEPMC3
 #pragma link C++ class o2::eventgen::GeneratorHepMC + ;
@@ -38,13 +39,17 @@
 #pragma link C++ class o2::eventgen::GeneratorFromFile + ;
 #pragma link C++ class o2::PDG + ;
 #pragma link C++ class o2::eventgen::PrimaryGenerator + ;
+#pragma link C++ class o2::eventgen::Trigger + ;
+#pragma link C++ class o2::eventgen::TriggerParticle + ;
 
 #pragma link C++ enum o2::eventgen::EVertexDistribution;
-#pragma link C++ class o2::eventgen::InteractionDiamondParam +;
-#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::eventgen::InteractionDiamondParam> + ;
+#pragma link C++ class o2::eventgen::InteractionDiamondParam + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::eventgen::InteractionDiamondParam > +;
+#pragma link C++ class o2::eventgen::TriggerParticleParam + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::eventgen::TriggerParticleParam > +;
 #pragma link C++ class o2::eventgen::BoxGunParam + ;
-#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::eventgen::BoxGunParam> + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::eventgen::BoxGunParam > +;
 #pragma link C++ class o2::eventgen::QEDGenParam + ;
-#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::eventgen::QEDGenParam> + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::eventgen::QEDGenParam > +;
 
 #endif

--- a/Generators/src/Trigger.cxx
+++ b/Generators/src/Trigger.cxx
@@ -1,0 +1,29 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author R+Preghenella - August 2017
+
+#include "Generators/Trigger.h"
+
+namespace o2
+{
+namespace eventgen
+{
+
+/*****************************************************************/
+/*****************************************************************/
+
+/*****************************************************************/
+/*****************************************************************/
+
+} /* namespace eventgen */
+} /* namespace o2 */
+
+ClassImp(o2::eventgen::Trigger);

--- a/Generators/src/TriggerParticle.cxx
+++ b/Generators/src/TriggerParticle.cxx
@@ -1,0 +1,77 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author R+Preghenella - September 2019
+
+#include "Generators/TriggerParticle.h"
+#include "TClonesArray.h"
+#include "TParticle.h"
+
+namespace o2
+{
+namespace eventgen
+{
+
+/*****************************************************************/
+/*****************************************************************/
+
+Bool_t
+  TriggerParticle::fired(TClonesArray* particles)
+{
+  /** fired **/
+
+  /** loop over particles **/
+  Int_t nParticles = particles->GetEntries();
+  TParticle* particle = nullptr;
+  for (Int_t iparticle = 0; iparticle < nParticles; iparticle++) {
+    particle = (TParticle*)particles->At(iparticle);
+    if (!particle)
+      continue;
+
+    /** check PDG **/
+    auto pdg = particle->GetPdgCode();
+    if (pdg != mPDG)
+      continue;
+
+    /** check pt **/
+    auto pt = particle->Pt();
+    if (pt < mPtMin || pt > mPtMax)
+      continue;
+
+    /** check eta **/
+    auto eta = particle->Eta();
+    if (eta < mEtaMin || eta > mEtaMax)
+      continue;
+
+    /** check phi **/
+    auto phi = particle->Phi();
+    if (phi < mPhiMin || phi > mPhiMax)
+      continue;
+
+    /** check rapidity **/
+    auto y = particle->Y();
+    if (y < mYMin || phi > mYMax)
+      continue;
+
+    /** success **/
+    return kTRUE;
+  }
+
+  /** failure **/
+  return kFALSE;
+}
+
+/*****************************************************************/
+/*****************************************************************/
+
+} /* namespace eventgen */
+} /* namespace o2 */
+
+ClassImp(o2::eventgen::TriggerParticle);

--- a/Generators/src/TriggerParticleParam.cxx
+++ b/Generators/src/TriggerParticleParam.cxx
@@ -1,0 +1,14 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author R+Preghenella - January 2020
+
+#include "Generators/TriggerParticleParam.h"
+O2ParamImpl(o2::eventgen::TriggerParticleParam);


### PR DESCRIPTION
This PR provides a way to attach triggers to event generators.
The event generators supported are those that implement the `o2::eventgen::Generator` protocol, namely that inherit from the abstract base class and provide a realisation of the pure virtual functions.

Triggers are defined as classes that implement the `o2::eventgen::Trigger` protocol and can be added to an event generator. The specification of the trigger can be fully costumised by defining the logic in the `o2::eventgen::Trigger::fired(TClonesArray *particles)` function, which receives all particles generated by a given event generator. The user can analyse the event and decide whether to trigger the reconstruction on that event (`return true`) or not (`return false`). If the trigger does not fire, the event generator will process another event, pass it to the trigger, and so on.

Multiple triggers can be attached to an event generators.
A scheme based on logical AND or OR of the trigger outputs can be selected to trigger the reconstruction. As an example, suppose two triggers are attached to an event generator, trigger1 looking for phi mesons, trigger2 looking for Lambda baryons. One can configure the generator to request (trigger1 OR trigger2) or (trigger1 AND trigger2).

A basic concrete realisation of a trigger class has been implemented in the `o2::eventgen::TriggerParticle`. This trigger selects one particle according to PDG, pt, eta, phi, y.
It can be configured by the user via a configurable parameter `o2::conf::ConfigurableParamHelper < o2::eventgen::TriggerParticleParam >` 

```
o2-sim -g pythia8 -t particle --configKeyValues "TriggerParticle.pdg=333;TriggerParticle.ptMin=5.;TriggerParticle.yMin=-0.5;TriggerParticle.yMax=0.5"
```

Custom trigger realisations can be defined by the user following the philosophy of external generators.
An example is provided in `Generators/share/external/multiphi_trigger.C`. Custom external triggers can be attached to the simulation as follows

```
o2-sim -g pythia8 -t external --extTrgFile path_to_trigger_macro.C --extTrgFunc "the_function(some, parameters)"
```

Small improvements will be added in the future, but for the time being this is a functioning feature.

Notice that the above example will not work, as the current interface to pythia8 does not comply to the `o2::eventgen::Generator` protocol. An upcoming PR will provide a new interface compliant with the protocol.