### PR TITLE
use spans in ITS clusterization, reconstruction workflows instead of …

### DIFF
--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTracker.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTracker.h
@@ -74,7 +74,7 @@ class CookedTracker
   Int_t getNumberOfThreads() const { return mNumOfThreads; }
 
   // These functions must be implemented
-  void process(const std::vector<Cluster>& clusters, std::vector<TrackITS>& tracks, std::vector<int>& clusIdx, o2::itsmft::ROFRecord& rof);
+  void process(gsl::span<const Cluster> clusters, std::vector<TrackITS>& tracks, std::vector<int>& clusIdx, o2::itsmft::ROFRecord& rof);
   const Cluster* getCluster(Int_t index) const;
 
   void setGeometry(o2::its::GeometryTGeo* geom);
@@ -95,7 +95,7 @@ class CookedTracker
  protected:
   static constexpr int kNLayers = 7;
   void addOutputTrack(const TrackITSExt& t, std::vector<TrackITS>& tracks, std::vector<int>& clusIdx);
-  int loadClusters(const std::vector<Cluster>& clusters, const o2::itsmft::ROFRecord& rof);
+  int loadClusters(gsl::span<const Cluster> clusters, const o2::itsmft::ROFRecord& rof);
   void unloadClusters();
   void processLoadedClusters(std::vector<TrackITS>& tracks, std::vector<int>& clusIdx);
 

--- a/Detectors/ITSMFT/ITS/reconstruction/src/ClustererTask.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/ClustererTask.cxx
@@ -126,12 +126,17 @@ void ClustererTask::run(const std::string inpName, const std::string outName)
       mClusterer.process(*mReaderMC.get(), mFullClusPtr, mCompClusPtr, mClsLabelsPtr, mROFRecVecPtr);
     }
   }
-  /*
-  if (!mRawDataMode && mReaderMC->getMC2ROFRecords()) {
-    auto mc2rof = *mReaderMC->getMC2ROFRecords(); // clone
-    auto* mc2rofPtr = &mc2rof;
+
+  std::vector<o2::itsmft::MC2ROFRecord> mc2rof, *mc2rofPtr = &mc2rof;
+  if (!mRawDataMode && mUseMCTruth) {
+    auto mc2rofOrig = mReaderMC->getMC2ROFRecords();
+    mc2rof.reserve(mc2rofOrig.size());
+    for (const auto& m2r : mc2rofOrig) { // clone from the span
+      mc2rof.push_back(m2r);
+    }
+    outTree->Branch("ITSClustersMC2ROF", mc2rofPtr);
   }
-  */
+
   outTree->Fill();
   outTree->Write();
 

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/IOUtils.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/IOUtils.h
@@ -55,9 +55,9 @@ namespace ioutils
 {
 void loadConfigurations(const std::string&);
 std::vector<ROframe> loadEventData(const std::string&);
-void loadEventData(ROframe& events, const std::vector<itsmft::Cluster>* mClustersArray,
-                   const dataformats::MCTruthContainer<MCCompLabel>* mClsLabels = nullptr);
-int loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& events, const std::vector<itsmft::Cluster>* mClustersArray,
+void loadEventData(ROframe& events, gsl::span<const itsmft::Cluster> clusters,
+                   const dataformats::MCTruthContainer<MCCompLabel>* clsLabels = nullptr);
+int loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& events, gsl::span<const itsmft::Cluster> clusters,
                     const dataformats::MCTruthContainer<MCCompLabel>* mClsLabels = nullptr);
 void generateSimpleData(ROframe& event, const int phiDivs, const int zDivs);
 

--- a/Detectors/ITSMFT/ITS/tracking/src/IOUtils.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/IOUtils.cxx
@@ -105,10 +105,10 @@ std::vector<ROframe> ioutils::loadEventData(const std::string& fileName)
   return events;
 }
 
-void ioutils::loadEventData(ROframe& event, const std::vector<itsmft::Cluster>* clusters,
-                            const dataformats::MCTruthContainer<MCCompLabel>* mcLabels)
+void ioutils::loadEventData(ROframe& event, gsl::span<const itsmft::Cluster> clusters,
+                            const dataformats::MCTruthContainer<MCCompLabel>* clsLabels)
 {
-  if (!clusters) {
+  if (clusters.empty()) {
     std::cerr << "Missing clusters." << std::endl;
     return;
   }
@@ -117,7 +117,7 @@ void ioutils::loadEventData(ROframe& event, const std::vector<itsmft::Cluster>* 
   geom->fillMatrixCache(utils::bit2Mask(TransformType::T2GRot));
   int clusterId{0};
 
-  for (auto& c : *clusters) {
+  for (auto& c : clusters) {
     int layer = geom->getLayer(c.getSensorID());
 
     /// Clusters are stored in the tracking frame
@@ -128,29 +128,24 @@ void ioutils::loadEventData(ROframe& event, const std::vector<itsmft::Cluster>* 
 
     /// Rotate to the global frame
     event.addClusterToLayer(layer, xyz.x(), xyz.y(), xyz.z(), event.getClustersOnLayer(layer).size());
-    if (mcLabels) {
-      event.addClusterLabelToLayer(layer, *(mcLabels->getLabels(clusterId).begin()));
+    if (clsLabels) {
+      event.addClusterLabelToLayer(layer, *(clsLabels->getLabels(clusterId).begin()));
     }
     event.addClusterExternalIndexToLayer(layer, clusterId);
     clusterId++;
   }
 }
 
-int ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& event, const std::vector<itsmft::Cluster>* clusters,
+int ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& event, gsl::span<const itsmft::Cluster> clusters,
                              const dataformats::MCTruthContainer<MCCompLabel>* mcLabels)
 {
-  if (!clusters) {
-    std::cerr << "Missing clusters." << std::endl;
-    return -1;
-  }
   event.clear();
   GeometryTGeo* geom = GeometryTGeo::Instance();
   geom->fillMatrixCache(utils::bit2Mask(TransformType::T2GRot));
   int clusterId{0};
 
   auto first = rof.getFirstEntry();
-  auto number = rof.getNEntries();
-  auto clusters_in_frame = gsl::make_span(&(*clusters)[first], number);
+  auto clusters_in_frame = rof.getROFData(clusters);
   for (auto& c : clusters_in_frame) {
     int layer = geom->getLayer(c.getSensorID());
 
@@ -168,7 +163,7 @@ int ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& event, c
     event.addClusterExternalIndexToLayer(layer, first + clusterId);
     clusterId++;
   }
-  return number;
+  return clusters_in_frame.size();
 }
 
 void ioutils::generateSimpleData(ROframe& event, const int phiDivs, const int zDivs = 1)

--- a/Detectors/ITSMFT/ITS/workflow/src/ClustererSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ClustererSpec.cxx
@@ -84,24 +84,24 @@ void ClustererDPL::run(ProcessingContext& pc)
   if (mState > 1)
     return;
 
-  auto digits = pc.inputs().get<const std::vector<o2::itsmft::Digit>>("digits");
-  auto rofs = pc.inputs().get<const std::vector<o2::itsmft::ROFRecord>>("ROframes");
+  auto digits = pc.inputs().get<gsl::span<o2::itsmft::Digit>>("digits");
+  auto rofs = pc.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("ROframes");
 
   std::unique_ptr<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>> labels;
-  std::vector<o2::itsmft::MC2ROFRecord> mc2rofs;
+  gsl::span<const o2::itsmft::MC2ROFRecord> mc2rofs;
   if (mUseMC) {
-    labels = pc.inputs().get<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>*>("labels");
-    mc2rofs = pc.inputs().get<const std::vector<o2::itsmft::MC2ROFRecord>>("MC2ROframes");
+    labels = pc.inputs().get<o2::dataformats::MCTruthContainer<o2::MCCompLabel>*>("labels");
+    mc2rofs = pc.inputs().get<gsl::span<o2::itsmft::MC2ROFRecord>>("MC2ROframes");
   }
 
   LOG(INFO) << "ITSClusterer pulled " << digits.size() << " digits, in "
             << rofs.size() << " RO frames";
 
   o2::itsmft::DigitPixelReader reader;
-  reader.setDigits(&digits);
-  reader.setROFRecords(&rofs);
+  reader.setDigits(digits);
+  reader.setROFRecords(rofs);
   if (mUseMC) {
-    reader.setMC2ROFRecords(&mc2rofs);
+    reader.setMC2ROFRecords(mc2rofs);
     reader.setDigitsMCTruth(labels.get());
   }
   reader.init();
@@ -127,7 +127,10 @@ void ClustererDPL::run(ProcessingContext& pc)
   pc.outputs().snapshot(Output{"ITS", "ITSClusterROF", 0, Lifetime::Timeframe}, clusterROframes);
   if (mUseMC) {
     pc.outputs().snapshot(Output{"ITS", "CLUSTERSMCTR", 0, Lifetime::Timeframe}, *clusterLabels.get());
-    std::vector<o2::itsmft::MC2ROFRecord>& clusterMC2ROframes = mc2rofs; // Simply, replicate it from digits ?
+    std::vector<o2::itsmft::MC2ROFRecord> clusterMC2ROframes(mc2rofs.size());
+    for (int i = mc2rofs.size(); i--;) {
+      clusterMC2ROframes[i] = mc2rofs[i]; // Simply, replicate it from digits ?
+    }
     pc.outputs().snapshot(Output{"ITS", "ITSClusterMC2ROF", 0, Lifetime::Timeframe}, clusterMC2ROframes);
   }
 

--- a/Detectors/ITSMFT/ITS/workflow/src/CookedTrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/CookedTrackerSpec.cxx
@@ -76,15 +76,15 @@ void CookedTrackerDPL::run(ProcessingContext& pc)
   if (mState != 1)
     return;
 
-  auto compClusters = pc.inputs().get<const std::vector<o2::itsmft::CompClusterExt>>("compClusters");
-  auto clusters = pc.inputs().get<const std::vector<o2::itsmft::Cluster>>("clusters");
-  auto rofs = pc.inputs().get<const std::vector<o2::itsmft::ROFRecord>>("ROframes");
+  auto compClusters = pc.inputs().get<gsl::span<o2::itsmft::CompClusterExt>>("compClusters");
+  auto clusters = pc.inputs().get<gsl::span<o2::itsmft::Cluster>>("clusters");
+  auto rofs = pc.inputs().get<std::vector<o2::itsmft::ROFRecord>>("ROframes"); // since we use it also for output, use the vector instead of span
 
   std::unique_ptr<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>> labels;
-  std::vector<o2::itsmft::MC2ROFRecord> mc2rofs;
+  std::vector<o2::itsmft::MC2ROFRecord> mc2rofs; // use vector rather than span (since we use it for output)
   if (mUseMC) {
     labels = pc.inputs().get<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>*>("labels");
-    mc2rofs = pc.inputs().get<const std::vector<o2::itsmft::MC2ROFRecord>>("MC2ROframes");
+    mc2rofs = pc.inputs().get<std::vector<o2::itsmft::MC2ROFRecord>>("MC2ROframes");
   }
 
   LOG(INFO) << "ITSCookedTracker pulled " << clusters.size() << " clusters, in "
@@ -102,7 +102,7 @@ void CookedTrackerDPL::run(ProcessingContext& pc)
   std::vector<o2::its::TrackITS> tracks;
   std::vector<int> clusIdx;
   for (auto& rof : rofs) {
-    o2::its::ioutils::loadROFrameData(rof, event, &clusters, labels.get());
+    o2::its::ioutils::loadROFrameData(rof, event, clusters, labels.get());
     vertexer.clustersToVertices(event);
     auto vertices = vertexer.exportVertices();
     if (vertices.empty()) {

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackWriterSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackWriterSpec.cxx
@@ -73,10 +73,13 @@ void TrackWriter::run(ProcessingContext& pc)
   auto* rofsPtr = &rofs;
   tree.Branch("ITSTracksROF", &rofsPtr);
 
+  std::vector<o2::itsmft::MC2ROFRecord> mc2rofs, *mc2rofsPtr = &mc2rofs;
   if (mUseMC) {
-    // write MC2ROFrecord vector (directly inherited from digits input) to a tree
-    auto mc2rofs = pc.inputs().get<const std::vector<o2::itsmft::MC2ROFRecord>>("MC2ROframes");
-    auto* mc2rofsPtr = &mc2rofs;
+    const auto m2rvec = pc.inputs().get<gsl::span<o2::itsmft::MC2ROFRecord>>("MC2ROframes");
+    mc2rofs.reserve(m2rvec.size());
+    for (const auto& m2rv : m2rvec) {
+      mc2rofs.push_back(m2rv);
+    }
     tree.Branch("ITSTracksMC2ROF", &mc2rofsPtr);
   }
 

--- a/Detectors/ITSMFT/MFT/reconstruction/src/ClustererTask.cxx
+++ b/Detectors/ITSMFT/MFT/reconstruction/src/ClustererTask.cxx
@@ -129,9 +129,14 @@ void ClustererTask::run(const std::string inpName, const std::string outName)
     }
   }
 
-  if (!mRawDataMode && mReaderMC->getMC2ROFRecords()) {
-    auto mc2rof = *mReaderMC->getMC2ROFRecords(); // clone
-    auto* mc2rofPtr = &mc2rof;
+  std::vector<o2::itsmft::MC2ROFRecord> mc2rof, *mc2rofPtr = &mc2rof;
+  if (!mRawDataMode && mUseMCTruth) {
+    auto mc2rofOrig = mReaderMC->getMC2ROFRecords();
+    mc2rof.reserve(mc2rofOrig.size());
+    for (const auto& m2r : mc2rofOrig) { // clone from the span
+      mc2rof.push_back(m2r);
+    }
+    outTree->Branch("MFTClustersMC2ROF", mc2rofPtr);
   }
 
   outTree->Fill();

--- a/Detectors/ITSMFT/MFT/workflow/src/ClustererSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/ClustererSpec.cxx
@@ -82,24 +82,24 @@ void ClustererDPL::run(ProcessingContext& pc)
   if (mState > 1)
     return;
 
-  auto digits = pc.inputs().get<const std::vector<o2::itsmft::Digit>>("digits");
-  auto rofs = pc.inputs().get<const std::vector<o2::itsmft::ROFRecord>>("ROframes");
+  auto digits = pc.inputs().get<gsl::span<o2::itsmft::Digit>>("digits");
+  auto rofs = pc.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("ROframes");
 
   std::unique_ptr<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>> labels;
-  std::vector<o2::itsmft::MC2ROFRecord> mc2rofs;
+  gsl::span<const o2::itsmft::MC2ROFRecord> mc2rofs;
   if (mUseMC) {
-    labels = pc.inputs().get<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>*>("labels");
-    mc2rofs = pc.inputs().get<const std::vector<o2::itsmft::MC2ROFRecord>>("MC2ROframes");
+    labels = pc.inputs().get<o2::dataformats::MCTruthContainer<o2::MCCompLabel>*>("labels");
+    mc2rofs = pc.inputs().get<gsl::span<o2::itsmft::MC2ROFRecord>>("MC2ROframes");
   }
 
   LOG(INFO) << "MFTClusterer pulled " << digits.size() << " digits, in "
             << rofs.size() << " RO frames";
 
   o2::itsmft::DigitPixelReader reader;
-  reader.setDigits(&digits);
-  reader.setROFRecords(&rofs);
+  reader.setDigits(digits);
+  reader.setROFRecords(rofs);
   if (mUseMC) {
-    reader.setMC2ROFRecords(&mc2rofs);
+    reader.setMC2ROFRecords(mc2rofs);
     reader.setDigitsMCTruth(labels.get());
   }
   reader.init();
@@ -126,7 +126,10 @@ void ClustererDPL::run(ProcessingContext& pc)
   pc.outputs().snapshot(Output{"MFT", "MFTClusterROF", 0, Lifetime::Timeframe}, clusterROframes);
   if (mUseMC) {
     pc.outputs().snapshot(Output{"MFT", "CLUSTERSMCTR", 0, Lifetime::Timeframe}, *clusterLabels.get());
-    std::vector<o2::itsmft::MC2ROFRecord>& clusterMC2ROframes = mc2rofs; // Simply, replicate it from digits ?
+    std::vector<o2::itsmft::MC2ROFRecord> clusterMC2ROframes(mc2rofs.size());
+    for (int i = mc2rofs.size(); i--;) {
+      clusterMC2ROframes[i] = mc2rofs[i]; // Simply, replicate it from digits ?
+    }
     pc.outputs().snapshot(Output{"MFT", "MFTClusterMC2ROF", 0, Lifetime::Timeframe}, clusterMC2ROframes);
   }
 

--- a/Detectors/ITSMFT/MFT/workflow/src/TrackWriterSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/TrackWriterSpec.cxx
@@ -75,10 +75,14 @@ void TrackWriter::run(ProcessingContext& pc)
   auto* rofsPtr = &rofs;
   tree.Branch("MFTTracksROF", &rofsPtr);
 
+  std::vector<o2::itsmft::MC2ROFRecord> mc2rofs, *mc2rofsPtr = &mc2rofs;
   if (mUseMC) {
     // write MC2ROFrecord vector (directly inherited from digits input) to a tree
-    auto mc2rofs = pc.inputs().get<const std::vector<o2::itsmft::MC2ROFRecord>>("MC2ROframes");
-    auto* mc2rofsPtr = &mc2rofs;
+    const auto m2rvec = pc.inputs().get<gsl::span<o2::itsmft::MC2ROFRecord>>("MC2ROframes");
+    mc2rofs.reserve(m2rvec.size());
+    for (const auto& m2rv : m2rvec) {
+      mc2rofs.push_back(m2rv);
+    }
     tree.Branch("MFTTracksMC2ROF", &mc2rofsPtr);
   }
 

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/DigitPixelReader.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/DigitPixelReader.h
@@ -24,6 +24,7 @@
 #include <TTree.h>
 #include <vector>
 #include <memory>
+#include <gsl/span>
 
 namespace o2
 {
@@ -36,23 +37,23 @@ class DigitPixelReader : public PixelReader
   DigitPixelReader() = default;
   ~DigitPixelReader() override;
 
-  const std::vector<o2::itsmft::MC2ROFRecord>* getMC2ROFRecords() const
+  const auto getMC2ROFRecords() const
   {
     return mMC2ROFRecVec;
   }
 
-  void setMC2ROFRecords(const std::vector<o2::itsmft::MC2ROFRecord>* a)
+  void setMC2ROFRecords(const gsl::span<const o2::itsmft::MC2ROFRecord> a)
   {
     mMC2ROFRecVec = a;
   }
 
-  void setROFRecords(const std::vector<o2::itsmft::ROFRecord>* a)
+  void setROFRecords(const gsl::span<const o2::itsmft::ROFRecord> a)
   {
     mROFRecVec = a;
     mIdROF = -1;
   }
 
-  void setDigits(const std::vector<o2::itsmft::Digit>* a)
+  void setDigits(const gsl::span<const o2::itsmft::Digit> a)
   {
     mDigits = a;
     mIdDig = 0;
@@ -98,9 +99,9 @@ class DigitPixelReader : public PixelReader
   std::vector<o2::itsmft::MC2ROFRecord>* mMC2ROFRecVecSelf = nullptr;
   o2::dataformats::MCTruthContainer<o2::MCCompLabel>* mDigitsMCTruthSelf = nullptr;
 
-  const std::vector<o2::itsmft::Digit>* mDigits = nullptr;
-  const std::vector<o2::itsmft::ROFRecord>* mROFRecVec = nullptr;
-  const std::vector<o2::itsmft::MC2ROFRecord>* mMC2ROFRecVec = nullptr;
+  gsl::span<const o2::itsmft::Digit> mDigits;
+  gsl::span<const o2::itsmft::ROFRecord> mROFRecVec;
+  gsl::span<const o2::itsmft::MC2ROFRecord> mMC2ROFRecVec;
 
   const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* mDigitsMCTruth = nullptr;
   const Digit* mLastDigit = nullptr;

--- a/macro/run_primary_vertexer_ITS.C
+++ b/macro/run_primary_vertexer_ITS.C
@@ -137,7 +137,7 @@ int run_primary_vertexer_ITS(const float phiCut = -1.f,
     auto& rof = (*rofs)[iROfCount];
     o2::its::ROframe frame(iROfCount); // to get meaningful roframeId
     std::cout << "ROframe: " << iROfCount << std::endl;
-    int nclUsed = o2::its::ioutils::loadROFrameData(rof, frame, clusters, labels);
+    int nclUsed = o2::its::ioutils::loadROFrameData(rof, frame, gsl::span(clusters->data(), clusters->size()), labels);
 
     std::array<float, 3> total{0.f, 0.f, 0.f};
     o2::its::ROframe* eventptr = &frame;

--- a/macro/run_trac_ca_its.C
+++ b/macro/run_trac_ca_its.C
@@ -117,6 +117,12 @@ void run_trac_ca_its(std::string path = "./",
   o2::dataformats::MCTruthContainer<o2::MCCompLabel>* labels = nullptr;
   itsClusters.SetBranchAddress("ITSClusterMCTruth", &labels);
 
+  std::vector<o2::itsmft::MC2ROFRecord>* mc2rofs = nullptr;
+  if (!itsClusters.GetBranch("ITSClustersMC2ROF")) {
+    LOG(FATAL) << "Did not find ITS clusters branch ITSClustersROF in the input tree";
+  }
+  itsClusters.SetBranchAddress("ITSClustersMC2ROF", &mc2rofs);
+
   std::vector<o2::its::TrackITSExt> tracks;
   // create/attach output tree
   TFile outFile((path + outputfile).data(), "recreate");
@@ -127,7 +133,7 @@ void run_trac_ca_its(std::string path = "./",
   outTree.Branch("ITSTrack", &tracksITSPtr);
   outTree.Branch("ITSTrackClusIdx", &trackClIdxPtr);
   outTree.Branch("ITSTrackMCTruth", &trackLabelsPtr);
-
+  outTree.Branch("ITSTracksMC2ROF", &mc2rofs);
   if (!itsClusters.GetBranch("ITSClustersROF")) {
     LOG(FATAL) << "Did not find ITS clusters branch ITSClustersROF in the input tree";
   }
@@ -158,7 +164,7 @@ void run_trac_ca_its(std::string path = "./",
 
     auto start = std::chrono::high_resolution_clock::now();
 
-    o2::its::ioutils::loadROFrameData(rof, event, clusters, labels);
+    o2::its::ioutils::loadROFrameData(rof, event, gsl::span(clusters->data(), clusters->size()), labels);
 
     vertexer.initialiseVertexer(&event);
     vertexer.findTracklets();


### PR DESCRIPTION
…vectors

(except cases when the input vector is directly used also for outputs, like in the writers)

This should complete ITS changes for what concerns https://alice.its.cern.ch/jira/browse/O2-1017