### PR TITLE
TRD: Fixed ADC spectrum

### DIFF
--- a/Detectors/TRD/base/include/TRDBase/Digit.h
+++ b/Detectors/TRD/base/include/TRDBase/Digit.h
@@ -101,9 +101,9 @@ class Digit
   }
 
  private:
-  std::uint16_t mDetector{0}; // TRD detector number, 0-539
-  std::uint8_t mRow{0};       // pad row, 0-15
-  std::uint8_t mPad{0};       // pad within pad row, 0-143
+  int mDetector{0}; // TRD detector number, 0-539
+  int mRow{0};       // pad row, 0-15
+  int mPad{0};       // pad within pad row, 0-143
   ArrayADC_t mADC{};          // ADC vector (30 time-bins)
   size_t mLabelIdx{0};        // index for mc label
 

--- a/Detectors/TRD/base/include/TRDBase/Digit.h
+++ b/Detectors/TRD/base/include/TRDBase/Digit.h
@@ -79,7 +79,7 @@ class Digit
       digitCont.emplace_back(Digit::getDetectorFromKey(key),
                              Digit::getRowFromKey(key),
                              Digit::getColFromKey(key),
-                             adcs, idx);
+                             adcs, idx);  
     }
   }
   static void convertVectorsToMap(const DigitContainer_t& digitCont,

--- a/Detectors/TRD/base/include/TRDBase/Digit.h
+++ b/Detectors/TRD/base/include/TRDBase/Digit.h
@@ -29,10 +29,11 @@ constexpr int KEY_MIN = 0;
 constexpr int KEY_MAX = 2211727;
 
 typedef std::uint16_t ADC_t;                                      // the ADC value type
-typedef std::array<ADC_t, kTB> ArrayADC_t;                        // the array ADC
-typedef std::array<ADC_t, kTB + 1> ArrayADCext_t;                 // the array ADC + label index
-typedef std::vector<Digit> DigitContainer_t;                      // the digit container type
-typedef std::unordered_map<int, ArrayADCext_t> SignalContainer_t; // a map container type for signal handling during digitization
+typedef float Signal_t;                                           // the signal value type
+typedef std::array<ADC_t, kTB> ArrayADC_t;                        // the array ADC - the main member of the Digit class
+typedef std::array<Signal_t, kTB + 1> ArraySignal_t;              // the signal array + 1 element for mc label indexing - for the digitization process only
+typedef std::vector<Digit> DigitContainer_t;                      // the digit container type to send the digits to the DPL
+typedef std::unordered_map<int, ArraySignal_t> SignalContainer_t; // a map container type for signal handling during digitization
 
 class Digit
 {
@@ -91,11 +92,11 @@ class Digit
       const int key = calculateKey(element.getDetector(),
                                    element.getRow(),
                                    element.getPad());
-      ArrayADCext_t adcsext{};
+      ArraySignal_t adcs{};
       for (int i = 0; i < kTB; ++i) {
-        adcsext[i] = element.getADC()[i];
+        adcs[i] = element.getADC()[i];
       }
-      adcMapCont[key] = adcsext;
+      adcMapCont[key] = adcs;
     }
   }
 

--- a/Detectors/TRD/base/include/TRDBase/Digit.h
+++ b/Detectors/TRD/base/include/TRDBase/Digit.h
@@ -101,9 +101,9 @@ class Digit
   }
 
  private:
-  int mDetector{0}; // TRD detector number, 0-539
-  int mRow{0};       // pad row, 0-15
-  int mPad{0};       // pad within pad row, 0-143
+  std::uint16_t mDetector{0}; // TRD detector number, 0-539
+  std::uint8_t mRow{0};       // pad row, 0-15
+  std::uint8_t mPad{0};       // pad within pad row, 0-143
   ArrayADC_t mADC{};          // ADC vector (30 time-bins)
   size_t mLabelIdx{0};        // index for mc label
 

--- a/Detectors/TRD/base/include/TRDBase/Digit.h
+++ b/Detectors/TRD/base/include/TRDBase/Digit.h
@@ -79,7 +79,7 @@ class Digit
       digitCont.emplace_back(Digit::getDetectorFromKey(key),
                              Digit::getRowFromKey(key),
                              Digit::getColFromKey(key),
-                             adcs, idx);  
+                             adcs, idx);
     }
   }
   static void convertVectorsToMap(const DigitContainer_t& digitCont,

--- a/Detectors/TRD/macros/CheckDigits.C
+++ b/Detectors/TRD/macros/CheckDigits.C
@@ -19,6 +19,7 @@
 
 #include "FairLogger.h"
 #include "TRDBase/Digit.h"
+#include "TRDBase/TRDSimParam.h"
 #endif
 
 void CheckDigits(std::string digifile = "trddigits.root",
@@ -36,7 +37,7 @@ void CheckDigits(std::string digifile = "trddigits.root",
   TH1F* hDet = new TH1F("hDet", ";Detector number;Counts", 504, 0, 539);
   TH1F* hRow = new TH1F("hRow", ";Row number;Counts", 16, 0, 15);
   TH1F* hPad = new TH1F("hPad", ";Pad number;Counts", 144, 0, 143);
-  TH1* hADC = new TH1F("hADC", ";ADC value;Counts", 300, 0, 300);
+  TH1* hADC = new TH1F("hADC", ";ADC value;Counts", 1024, 0, 1023);
 
   LOG(INFO) << nev << " entries found";
   for (int iev = 0; iev < nev; ++iev) {
@@ -50,10 +51,12 @@ void CheckDigits(std::string digifile = "trddigits.root",
       hDet->Fill(det);
       hRow->Fill(row);
       hPad->Fill(pad);
-      int tb = 0;
-      for (const auto& adc : adcs) {
-        if (++tb > 30)
-          break;
+      for (int tb = 0; tb < kTimeBins; ++tb) {
+        ADC_t adc = adcs[tb];
+        if (adc == (ADC_t)TRDSimParam::Instance()->GetADCoutRange()) {
+          LOG(INFO) << "Out of range ADC " << adc;
+          continue;
+        }
         hADC->Fill(adc);
       }
     }

--- a/Detectors/TRD/macros/CheckDigits.C
+++ b/Detectors/TRD/macros/CheckDigits.C
@@ -37,7 +37,7 @@ void CheckDigits(std::string digifile = "trddigits.root",
   TH1F* hDet = new TH1F("hDet", ";Detector number;Counts", 504, 0, 539);
   TH1F* hRow = new TH1F("hRow", ";Row number;Counts", 16, 0, 15);
   TH1F* hPad = new TH1F("hPad", ";Pad number;Counts", 144, 0, 143);
-  TH1* hADC = new TH1F("hADC", ";ADC value;Counts", 1024, 0, 1023);
+  TH1* hADC = new TH1F("hADC", ";ADC value;Counts", 512, 0, 511);
 
   LOG(INFO) << nev << " entries found";
   for (int iev = 0; iev < nev; ++iev) {

--- a/Detectors/TRD/macros/CheckDigits.C
+++ b/Detectors/TRD/macros/CheckDigits.C
@@ -22,6 +22,8 @@
 #include "TRDBase/TRDSimParam.h"
 #endif
 
+constexpr int kMINENTRIES = 1000;
+
 void CheckDigits(std::string digifile = "trddigits.root",
                  std::string hitfile = "o2sim.root",
                  std::string inputGeom = "O2geometry.root",
@@ -57,7 +59,7 @@ void CheckDigits(std::string digifile = "trddigits.root",
       for (int tb = 0; tb < kTimeBins; ++tb) {
         ADC_t adc = adcs[tb];
         if (adc == (ADC_t)TRDSimParam::Instance()->GetADCoutRange()) {
-          LOG(INFO) << "Out of range ADC " << adc;
+          // LOG(INFO) << "Out of range ADC " << adc;
           continue;
         }
         hADC[det]->Fill(adc);
@@ -74,10 +76,64 @@ void CheckDigits(std::string digifile = "trddigits.root",
   hPad->Draw();
   c->cd(4);
   c->cd(4)->SetLogy();
-  hADC[0]->Draw();
+  int first = 0;
+  int count = 0;
+  int max = 0;
   for (int d = 1; d < 540; ++d) {
-    // hADC[d]->SetLineColor(d+1);
-    hADC[d]->Draw("SAME");
+    if (hADC[d]->GetEntries() < kMINENTRIES) {
+      continue;
+    }
+    if (count > 6) {
+      break;
+    }
+    hADC[d]->SetLineColor(count + 1);
+    if (count == 0) {
+      hADC[d]->Draw();
+      first = d;
+      if (max < hADC[d]->GetMaximum()) {
+        max = hADC[d]->GetMaximum();
+      }
+      count++;
+    } else {
+      hADC[d]->Draw("SAME");
+      if (max < hADC[d]->GetMaximum()) {
+        max = hADC[d]->GetMaximum();
+      }
+      count++;
+    }
   }
+  hADC[first]->GetYaxis()->SetLimits(1.1,max+100);
   c->SaveAs("testCheckDigits.pdf");
+
+
+  TCanvas* c1 = new TCanvas("c1", "trd digits analysis", 600, 600);
+  first = 0;
+  count = 0;
+  max = 0;
+  for (int d = 1; d < 540; ++d) {
+    if (hADC[d]->GetEntries() < kMINENTRIES) {
+      continue;
+    }
+    if (count > 6) {
+      break;
+    }
+    hADC[d]->SetLineColor(count + 1);
+    if (count == 0) {
+      hADC[d]->Draw();
+      first = d;
+      if (max < hADC[d]->GetMaximum()) {
+        max = hADC[d]->GetMaximum();
+      }
+      count++;
+    } else {
+      hADC[d]->Draw("SAME");
+      if (max < hADC[d]->GetMaximum()) {
+        max = hADC[d]->GetMaximum();
+      }
+      count++;
+    }
+  }
+  hADC[first]->GetYaxis()->SetLimits(1.1,max+100);
+  c1->SetLogy();
+  c1->SaveAs("testCheckDigits_ADCs.pdf");
 }

--- a/Detectors/TRD/macros/CheckDigits.C
+++ b/Detectors/TRD/macros/CheckDigits.C
@@ -37,7 +37,10 @@ void CheckDigits(std::string digifile = "trddigits.root",
   TH1F* hDet = new TH1F("hDet", ";Detector number;Counts", 504, 0, 539);
   TH1F* hRow = new TH1F("hRow", ";Row number;Counts", 16, 0, 15);
   TH1F* hPad = new TH1F("hPad", ";Pad number;Counts", 144, 0, 143);
-  TH1* hADC = new TH1F("hADC", ";ADC value;Counts", 512, 0, 511);
+  TH1* hADC[540];
+  for (int d = 0; d < 540; ++d) {
+    hADC[d] = new TH1F(Form("hADC_%d", d), ";ADC value;Counts", 1024, 0, 1023);
+  }
 
   LOG(INFO) << nev << " entries found";
   for (int iev = 0; iev < nev; ++iev) {
@@ -57,7 +60,7 @@ void CheckDigits(std::string digifile = "trddigits.root",
           LOG(INFO) << "Out of range ADC " << adc;
           continue;
         }
-        hADC->Fill(adc);
+        hADC[det]->Fill(adc);
       }
     }
   }
@@ -71,6 +74,10 @@ void CheckDigits(std::string digifile = "trddigits.root",
   hPad->Draw();
   c->cd(4);
   c->cd(4)->SetLogy();
-  hADC->Draw();
+  hADC[0]->Draw();
+  for (int d = 1; d < 540; ++d) {
+    // hADC[d]->SetLineColor(d+1);
+    hADC[d]->Draw("SAME");
+  }
   c->SaveAs("testCheckDigits.pdf");
 }

--- a/Detectors/TRD/macros/CheckDigits.C
+++ b/Detectors/TRD/macros/CheckDigits.C
@@ -102,9 +102,8 @@ void CheckDigits(std::string digifile = "trddigits.root",
       count++;
     }
   }
-  hADC[first]->GetYaxis()->SetLimits(1.1,max+100);
+  hADC[first]->GetYaxis()->SetLimits(1.1, max + 100);
   c->SaveAs("testCheckDigits.pdf");
-
 
   TCanvas* c1 = new TCanvas("c1", "trd digits analysis", 600, 600);
   first = 0;
@@ -133,7 +132,7 @@ void CheckDigits(std::string digifile = "trddigits.root",
       count++;
     }
   }
-  hADC[first]->GetYaxis()->SetLimits(1.1,max+100);
+  hADC[first]->GetYaxis()->SetLimits(1.1, max + 100);
   c1->SetLogy();
   c1->SaveAs("testCheckDigits_ADCs.pdf");
 }

--- a/Detectors/TRD/macros/CheckDigits.C
+++ b/Detectors/TRD/macros/CheckDigits.C
@@ -20,7 +20,10 @@
 #include "FairLogger.h"
 #include "TRDBase/Digit.h"
 #include "TRDBase/TRDSimParam.h"
+#include "TRDBase/TRDCommonParam.h"
 #endif
+
+using namespace o2::trd;
 
 constexpr int kMINENTRIES = 1000;
 
@@ -29,10 +32,9 @@ void CheckDigits(std::string digifile = "trddigits.root",
                  std::string inputGeom = "O2geometry.root",
                  std::string paramfile = "o2sim_par.root")
 {
-  using o2::trd::Digit;
   TFile* fin = TFile::Open(digifile.data());
   TTree* digitTree = (TTree*)fin->Get("o2sim");
-  std::vector<o2::trd::Digit>* digitCont = nullptr;
+  std::vector<Digit>* digitCont = nullptr;
   digitTree->SetBranchAddress("TRDDigit", &digitCont);
   int nev = digitTree->GetEntries();
 

--- a/Detectors/TRD/macros/CheckHits.C
+++ b/Detectors/TRD/macros/CheckHits.C
@@ -42,7 +42,7 @@ void CheckHits(const int detector = 50, // 354, 14, 242, 50
   TH1F* hlocC = new TH1F("hlocC", ";locC (cm);Counts", 100, -60, 60);
   TH1F* hlocR = new TH1F("hlocR", ";locR (cm);Counts", 100, -80, 80);
   TH1F* hlocT = new TH1F("hlocT", ";locT (cm);Counts", 100, -3.5, 0.5);
-  TH1F* hnEl = new TH1F("hnEl", ";locT (cm);Counts", 100, 0, 5000);
+  TH1F* hnEl = new TH1F("hnEl", ";Number of Electrons;Counts", 100, 0, 5000);
   TH1F* hnElPhoton = new TH1F("hnElPhoton", ";Number of Electrons;Counts", 100, 0, 1000);
 
   TH2F* h2locClocT = new TH2F("h2locClocT", ";locC (cm);locT(cm)", 100, -60, 60, 100, -3.5, 0.5);

--- a/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
@@ -71,9 +71,9 @@ class Digitizer
   void getHitContainerPerDetector(const std::vector<HitType>&, std::array<std::vector<HitType>, kNdet>&);
   // Digitization chaing methods
   bool convertHits(const int, const std::vector<HitType>&, SignalContainer_t&, o2::dataformats::MCTruthContainer<MCLabel>&, int thread = 0); // True if hit-to-signal conversion is successful
-  bool convertSignalsToDigits(const int, SignalContainer_t&, int thread = 0);                                                                // True if signal-to-digit conversion is successful
+  bool convertSignalsToDigits(const int, SignalContainer_t&, DigitContainer_t&, int thread = 0);                                             // True if signal-to-digit conversion is successful
   bool convertSignalsToSDigits(const int, SignalContainer_t&, int thread = 0);                                                               // True if signal-to-sdigit conversion is successful
-  bool convertSignalsToADC(const int, SignalContainer_t&, int thread = 0);                                                                   // True if signal-to-ADC conversion is successful
+  bool convertSignalsToADC(const int, SignalContainer_t&, DigitContainer_t&, int thread = 0);                                                // True if signal-to-ADC conversion is successful
 
   bool diffusion(float, float, float, float, float, float, double&, double&, double&, int thread = 0); // True if diffusion is applied successfully
 };

--- a/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
@@ -71,8 +71,6 @@ class Digitizer
   void getHitContainerPerDetector(const std::vector<HitType>&, std::array<std::vector<HitType>, kNdet>&);
   // Digitization chaing methods
   bool convertHits(const int, const std::vector<HitType>&, SignalContainer_t&, o2::dataformats::MCTruthContainer<MCLabel>&, int thread = 0); // True if hit-to-signal conversion is successful
-  bool convertSignalsToDigits(const int, SignalContainer_t&, DigitContainer_t&, int thread = 0);                                             // True if signal-to-digit conversion is successful
-  bool convertSignalsToSDigits(const int, SignalContainer_t&, int thread = 0);                                                               // True if signal-to-sdigit conversion is successful
   bool convertSignalsToADC(const int, SignalContainer_t&, DigitContainer_t&, int thread = 0);                                                // True if signal-to-ADC conversion is successful
 
   bool diffusion(float, float, float, float, float, float, double&, double&, double&, int thread = 0); // True if diffusion is applied successfully

--- a/Detectors/TRD/simulation/src/Detector.cxx
+++ b/Detectors/TRD/simulation/src/Detector.cxx
@@ -144,7 +144,7 @@ bool Detector::ProcessHits(FairVolume* v)
     // Update track status
     trkStat = 1;
     // Create the hits from TR photons if electron/positron is entering the drift volume
-    const bool ele = (TMath::Abs(fMC->TrackPid()) == 11); // electron PDG code.
+    const bool ele = (std::fabs(fMC->TrackPid()) == 11); // electron PDG code.
     if (mTRon && ele) {
       createTRhit(det);
     }
@@ -164,8 +164,8 @@ bool Detector::ProcessHits(FairVolume* v)
 
   // Calculate the charge according to GEANT Edep
   // Create a new dEdx hit
-  const float enDep = TMath::Max(fMC->Edep(), 0.0) * 1e9; // Energy in eV
-  const int totalChargeDep = (int)(enDep / mWion);        // Total charge
+  const float enDep = std::max(fMC->Edep(), 0.0) * 1e9; // Energy in eV
+  const int totalChargeDep = (int)(enDep / mWion);      // Total charge
 
   // Store those hits with enDep bigger than the ionization potential of the gas mixture for in-flight tracks
   // or store hits of tracks that are entering or exiting
@@ -176,7 +176,10 @@ bool Detector::ProcessHits(FairVolume* v)
     double pos[3] = {xp, yp, zp};
     double loc[3] = {-99, -99, -99};
     gGeoManager->MasterToLocal(pos, loc); // Go to the local coordinate system (locR, locC, locT)
-    const float locC = loc[0], locR = loc[1], locT = loc[2];
+    float locC = loc[0], locR = loc[1], locT = loc[2];
+    if (drRegion) {
+      locT = locT - 0.5 * (TRDGeometry::drThick() + TRDGeometry::amThick()); // Relative to middle of amplification region
+    }
     addHit(xp, yp, zp, locC, locR, locT, tof, totalChargeDep, trackID, det, drRegion);
     stack->addHit(GetDetId());
     return true;
@@ -199,7 +202,7 @@ void Detector::createTRhit(int det)
 
   float px, py, pz, etot;
   fMC->TrackMomentum(px, py, pz, etot);
-  float pTot = TMath::Sqrt(px * px + py * py + pz * pz);
+  float pTot = std::sqrt(px * px + py * py + pz * pz);
   std::vector<float> photonEnergyContainer;            // energy in keV
   mTR->createPhotons(11, pTot, photonEnergyContainer); // Create TR photons
   if (photonEnergyContainer.size() > mMaxNumberOfTRPhotons) {
@@ -264,7 +267,8 @@ void Detector::createTRhit(int det)
     double pos[3] = {x, y, z};
     double loc[3] = {-99, -99, -99};
     gGeoManager->MasterToLocal(pos, loc); // Go to the local coordinate system (locR, locC, locT)
-    const float locC = loc[0], locR = loc[1], locT = loc[2];
+    float locC = loc[0], locR = loc[1], locT = loc[2];
+    locT = locT - 0.5 * (TRDGeometry::drThick() + TRDGeometry::amThick());      // Relative to middle of amplification region
     addHit(x, y, z, locC, locR, locT, tof, totalChargeDep, trackID, det, true); // All TR hits are in drift region
     stack->addHit(GetDetId());
   }

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -459,7 +459,7 @@ bool Digitizer::convertSignalsToADC(const int det, SignalContainer_t& adcMapCont
       signalAmp *= padgain;                  // Gain factors
       // Add the noise, starting from minus ADC baseline in electrons
       signalAmp = std::max((double)drawGaus(mGausRandomRings[thread], signalAmp, mSimParam->GetNoise()), -baselineEl);
-      signalAmp *= convert; // Convert to mV
+      signalAmp *= convert;  // Convert to mV
       signalAmp += baseline; // Add ADC baseline in mV
       // Convert to ADC counts
       // Set the overflow-bit fADCoutRange if the signal is larger than fADCinRange

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -166,7 +166,6 @@ bool Digitizer::convertHits(const int det, const std::vector<HitType>& hits, Sig
 
   int timeBinTRFend = 0;
   double padSignal[kNpad];
-  double signalOld[kNpad];
 
   if (mSimParam->TRFOn()) {
     timeBinTRFend = ((int)(mSimParam->GetTRFhi() * mCommonParam->GetSamplingFrequency())) - 1;
@@ -351,16 +350,16 @@ bool Digitizer::convertHits(const int det, const std::vector<HitType>& hits, Sig
           if (mSimParam->CTOn()) {
             crossTalk = mSimParam->CrossTalk(t);
           }
-          signalOld[iPad] = currentSignal[iTimeBin];
+          float signalOld = currentSignal[iTimeBin];
           if (colPos != colE) {
             // Cross talk added to non-central pads
-            signalOld[iPad] += padSignal[iPad] * (timeResponse + crossTalk);
+            signalOld += padSignal[iPad] * (timeResponse + crossTalk);
           } else {
             // Without cross talk at central pad
-            signalOld[iPad] += padSignal[iPad] * timeResponse;
+            signalOld += padSignal[iPad] * timeResponse;
           }
           // Update the final signal
-          currentSignal[iTimeBin] = signalOld[iPad];
+          currentSignal[iTimeBin] = signalOld;
         } // Loop: time bins
       }   // Loop: pads
     }     // end of loop over electrons

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -137,12 +137,6 @@ void Digitizer::process(std::vector<HitType> const& hits, DigitContainer_t& digi
   // Finalize: Dump the digitCollection to the output digitCont
   for (int det = 0; det < kNdet; ++det) {
     auto& digits = digitCollection[det];
-    for (const auto& digit : digits) {
-      auto digitDet = digit.getDetector();
-      if (digitDet != det) {
-        LOG(FATAL) << "process: Digit is carryng the wrong detector number (" << digitDet << ") for loop " << det;
-      }
-    }
     digitCont.insert(digitCont.end(), digits.begin(), digits.end());
     // std::move(digits.begin(), digits.end(), std::back_inserter(digitCont));
     // digitCont.insert(digitCont.end(), std::make_move_iterator(digits.begin()), std::make_move_iterator(digits.end()));
@@ -392,7 +386,6 @@ bool Digitizer::convertSignalsToADC(const int det, SignalContainer_t& signalMapC
   //
   // Converts the sampled electron signals to ADC values for a given chamber
   //
-  LOG(INFO) << "Signal2ADC: Starting signal to adc conversion for detector " << det;
   if (signalMapCont.size() == 0) {
     return false;
   }
@@ -453,7 +446,6 @@ bool Digitizer::convertSignalsToADC(const int det, SignalContainer_t& signalMapC
     } // loop over timebins
     // Convert the map to digits here, and push them to the container
     size_t labelIdx = adcArray[kTB];
-    LOG(INFO) << "Signal2ADC: Pushing digit with detector number " << det;
     digits.emplace_back(det, row, col, adcs, labelIdx);
   } // loop over digits
   return true;

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -137,8 +137,8 @@ void Digitizer::process(std::vector<HitType> const& hits, DigitContainer_t& digi
   // Finalize: Dump the digitCollection to the output digitCont
   for (int det = 0; det < kNdet; ++det) {
     auto& digits = digitCollection[det];
-    digitCont.insert(digitCont.end(), digits.begin(), digits.end());
-    // std::move(digits.begin(), digits.end(), std::back_inserter(digitCont));
+    // digitCont.insert(digitCont.end(), digits.begin(), digits.end());
+    std::move(digits.begin(), digits.end(), std::back_inserter(digitCont));
     // digitCont.insert(digitCont.end(), std::make_move_iterator(digits.begin()), std::make_move_iterator(digits.end()));
     labels.mergeAtBack(labelsperdetector[det]);
   }
@@ -412,7 +412,7 @@ bool Digitizer::convertSignalsToADC(const int det, SignalContainer_t& signalMapC
     if (mCalib->isHalfChamberNoData(det, halfchamberside)) {
       continue;
     }
-/ *
+*/
     // Check whether pad is masked
     // Bridged pads are not considered yet!!!
     if (mCalib->isPadMasked(det, col, row) || mCalib->isPadNotConnected(det, col, row)) {

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -405,17 +405,19 @@ bool Digitizer::convertSignalsToADC(const int det, SignalContainer_t& signalMapC
     const int row = Digit::getRowFromKey(key);
     const int col = Digit::getColFromKey(key);
     // halfchamber masking
-    int iMcm = (int)(col / 18);               // current group of 18 col pads
-    int halfchamberside = (iMcm > 3 ? 1 : 0); // 0=Aside, 1=Bside
-    // // Halfchambers that are switched off, masked by mCalib
-    // if (mCalib->isHalfChamberNoData(det, halfchamberside)) {
-    //   continue;
-    // }
-    // // Check whether pad is masked
-    // // Bridged pads are not considered yet!!!
-    // if (mCalib->isPadMasked(det, col, row) || mCalib->isPadNotConnected(det, col, row)) {
-    //   continue;
-    // }
+    int mcm = (int)(col / 18);               // current group of 18 col pads
+    int halfchamberside = (mcm > 3 ? 1 : 0); // 0=Aside, 1=Bside
+/* Something is wrong with isHalfChamberNoData - deactivated for now
+    // Halfchambers that are switched off, masked by mCalib
+    if (mCalib->isHalfChamberNoData(det, halfchamberside)) {
+      continue;
+    }
+/ *
+    // Check whether pad is masked
+    // Bridged pads are not considered yet!!!
+    if (mCalib->isPadMasked(det, col, row) || mCalib->isPadNotConnected(det, col, row)) {
+      continue;
+    }
 
     float padgain = mCalib->getPadGainFactor(det, row, col); // The gain factor
     if (padgain <= 0) {

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -449,7 +449,7 @@ bool Digitizer::convertSignalsToADC(const int det, SignalContainer_t& signalMapC
       adcs[tb] = adc;
     } // loop over timebins
     // Convert the map to digits here, and push them to the container
-    size_t labelIdx = adcArray[kTB];
+    size_t labelIdx = (size_t)    adcArray[kTB];
     digits.emplace_back(det, row, col, adcs, labelIdx);
   } // loop over digits
   return true;

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -449,7 +449,7 @@ bool Digitizer::convertSignalsToADC(const int det, SignalContainer_t& signalMapC
       adcs[tb] = adc;
     } // loop over timebins
     // Convert the map to digits here, and push them to the container
-    size_t labelIdx = (size_t)    adcArray[kTB];
+    size_t labelIdx = (size_t)adcArray[kTB];
     digits.emplace_back(det, row, col, adcs, labelIdx);
   } // loop over digits
   return true;

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -407,12 +407,14 @@ bool Digitizer::convertSignalsToADC(const int det, SignalContainer_t& signalMapC
     // halfchamber masking
     int mcm = (int)(col / 18);               // current group of 18 col pads
     int halfchamberside = (mcm > 3 ? 1 : 0); // 0=Aside, 1=Bside
-/* Something is wrong with isHalfChamberNoData - deactivated for now
+
     // Halfchambers that are switched off, masked by mCalib
+    /* Something is wrong with isHalfChamberNoData - deactivated for now
     if (mCalib->isHalfChamberNoData(det, halfchamberside)) {
       continue;
     }
-*/
+    */
+
     // Check whether pad is masked
     // Bridged pads are not considered yet!!!
     if (mCalib->isPadMasked(det, col, row) || mCalib->isPadNotConnected(det, col, row)) {


### PR DESCRIPTION
This PR adds the following:

- Correct type for digitized signals: `float` instead of `int`. Only ADC values need to be integer type, signals al continues variables. Now we have:
```
typedef std::uint16_t ADC_t;                                      // the ADC value type
typedef float Signal_t;                                           // the signal value type
typedef std::array<ADC_t, kTB> ArrayADC_t;                        // the array ADC - the main member of the Digit class
typedef std::array<Signal_t, kTB + 1> ArraySignal_t;              // the signal array + 1 element for mc label indexing - for the digitization process only
typedef std::vector<Digit> DigitContainer_t;                      // the digit container type to send the digits to the DPL
typedef std::unordered_map<int, ArraySignal_t> SignalContainer_t; // a map container type for signal handling during digitization
```

- The conversion from map to vector container for the digits is moved to the end of the SignalToADC method. Since there is no need to re-access the map container once again. The digits can be dumped to the vector container at this stage. This fixes the problem of the ADC spectrum. This deprecates the use of `Digit:: convertVectorsToMap `.
![Screen Shot 2020-01-10 at 12 39 29](https://user-images.githubusercontent.com/3409812/72276785-7e530200-360f-11ea-8c0c-7f0be864f6f8.png)

- Something is wrong with CCDB method: `isHalfChamberNoData`.
- One minor bug removed.
- Digit macros adapted to show the more relevant information. 
- Many minor changes elsewhere.