### PR TITLE
Export geometry earlier

### DIFF
--- a/Steer/include/Steer/O2MCApplicationBase.h
+++ b/Steer/include/Steer/O2MCApplicationBase.h
@@ -47,6 +47,7 @@ class O2MCApplicationBase : public FairMCApplication
   void FinishEvent() override;
   void ConstructGeometry() override;
   void InitGeometry() override;
+  bool MisalignGeometry() override;
 
   // specific implementation of our hard geometry limits
   double TrackingRmax() const override { return mCutParams.maxRTracking; }

--- a/Steer/src/O2MCApplication.cxx
+++ b/Steer/src/O2MCApplication.cxx
@@ -114,6 +114,26 @@ void O2MCApplicationBase::InitGeometry()
   }
 }
 
+bool O2MCApplicationBase::MisalignGeometry()
+{
+  for (auto det : listActiveDetectors) {
+    if (dynamic_cast<o2::base::Detector*>(det)) {
+      ((o2::base::Detector*)det)->addAlignableVolumes();
+    }
+  }
+
+  auto b = FairMCApplication::MisalignGeometry();
+  // we use this moment to stream our geometry (before other
+  // VMC engine dependent modifications are done)
+
+  std::stringstream geomss;
+  geomss << "O2geometry.root";
+  gGeoManager->Export(geomss.str().c_str());
+
+  // return original return value of misalignment procedure
+  return b;
+}
+
 void O2MCApplicationBase::finishEventCommon()
 {
   LOG(INFO) << "This event/chunk did " << mStepCounter << " steps";

--- a/macro/build_geometry.C
+++ b/macro/build_geometry.C
@@ -245,33 +245,5 @@ void build_geometry(FairRunSim* run = nullptr)
 
   if (geomonly) {
     run->Init();
-    finalize_geometry(run);
-    gGeoManager->Export("O2geometry.root");
-  }
-}
-
-void finalize_geometry(FairRunSim* run)
-{
-  // finalize geometry and declare alignable volumes
-  // this should be called geometry is fully built
-
-  if (!gGeoManager) {
-    LOG(ERROR) << "gGeomManager is not available";
-    return;
-  }
-
-  gGeoManager->CloseGeometry();
-  if (!run) {
-    LOG(ERROR) << "FairRunSim is not available";
-    return;
-  }
-
-  const TObjArray* modArr = run->GetListOfModules();
-  TIter next(modArr);
-  FairModule* module = nullptr;
-  while ((module = (FairModule*)next())) {
-    o2::base::Detector* det = dynamic_cast<o2::base::Detector*>(module);
-    if (det)
-      det->addAlignableVolumes();
   }
 }

--- a/macro/o2sim.C
+++ b/macro/o2sim.C
@@ -107,22 +107,6 @@ FairRunSim* o2sim_init(bool asservice)
 
   // run init
   run->Init();
-  finalize_geometry(run);
-  std::stringstream geomss;
-  geomss << "O2geometry";
-  if (asservice) {
-    geomss << "_" << pid;
-  }
-  geomss << ".root";
-  gGeoManager->Export(geomss.str().c_str());
-  if (asservice) {
-    // create a link of expected file name to actually produced file
-    // (deletes link if previously existing)
-    unlink("O2geometry.root");
-    if (symlink(geomss.str().c_str(), "O2geometry.root") != 0) {
-      LOG(ERROR) << "Failed to create simlink to geometry file";
-    }
-  }
   std::time_t runStart = std::time(nullptr);
 
   // runtime database


### PR DESCRIPTION
Writing the geometry to the TFile now happens
earlier, as soon as misaligning the geometry finished.

This prevents to write purely run-time features that
are added to the geometry by specific VMC engines
and fixes/avoids memory corruption problems introduced
by TGeant4

Fixes issue https://alice.its.cern.ch/jira/browse/O2-1008