### PR TITLE
Include MCStepLogger as requrirement

### DIFF
--- a/VMCReplay/CMakeLists.txt
+++ b/VMCReplay/CMakeLists.txt
@@ -12,6 +12,7 @@
 o2_add_library(VMCReplay
         SOURCES src/VMCReplay.cxx
         PUBLIC_LINK_LIBRARIES MC::Geant3
+        PUBLIC_LINK_LIBRARIES MC::MCStepLogger
         )
 
 set(headers

--- a/VMCReplay/include/VMCReplay/VMCReplay.h
+++ b/VMCReplay/include/VMCReplay/VMCReplay.h
@@ -11,12 +11,36 @@
 #ifndef O2_VMCREPLAY_H
 #define O2_VMCREPLAY_H
 
+#include <vector>
+
+#include "TChain.h"
+
+#include "MCStepLogger/StepInfo.h"
+
 #include "TGeant3TGeo.h"
 
 class VMCReplay : public TGeant3TGeo
 {
  public:
-  using TGeant3TGeo::TGeant3TGeo;
+  VMCReplay(const std::string& inputTreeName);
+
+  void AddInputFiles(std::initializer_list<std::string> inputFileNames);
+
+  virtual Bool_t ProcessRun(Int_t nofEvents) override;
+
+ private:
+  bool ConnectToStepTree();
+  bool ProcessStepTree();
+
+  bool LoadNextStep();
+  bool ProcessStep();
+
+ private:
+  TChain mChain;
+
+  std::vector<o2::StepInfo>* mStepInfo = nullptr;
+  std::vector<o2::MagCallInfo>* mMagInfo = nullptr;
+  o2::StepLookups* mLookups = nullptr;
 
   ClassDef(VMCReplay, 1); // needed as long we inherit from TObject
 };

--- a/VMCReplay/src/VMCReplay.cxx
+++ b/VMCReplay/src/VMCReplay.cxx
@@ -10,4 +10,16 @@
 
 #include "VMCReplay/VMCReplay.h"
 
+VMCReplay::VMC::Replay(const std::string& inputTreeName)
+  : TGeant3TGeo("VMCReplay"), mChain(inputTreeName.c_str())
+{
+}
+
+VMCReplay::AddInputFiles(std::initializer_list<std::string> inputFileNames)
+{
+  for (auto& f : inputFileNames) {
+    mChain.Add(f.c_str());
+  }
+}
+
 ClassImp(VMCReplay);

--- a/dependencies/FindMCStepLogger.cmake
+++ b/dependencies/FindMCStepLogger.cmake
@@ -1,0 +1,42 @@
+# Copyright CERN and copyright holders of ALICE O2. This software is distributed
+# under the terms of the GNU General Public License v3 (GPL Version 3), copied
+# verbatim in the file "COPYING".
+#
+# See http://alice-o2.web.cern.ch/license for full licensing information.
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization or
+# submit itself to any jurisdiction.
+
+set(PKGNAME ${CMAKE_FIND_PACKAGE_NAME})
+string(TOUPPER ${PKGNAME} PKGENVNAME)
+
+find_path(${PKGNAME}_INCLUDE_DIR
+    NAMES "${PKGNAME}/MCAnalysis.h"
+          PATHS $ENV{${PKGENVNAME}_ROOT}/include)
+
+find_library(${PKGNAME}_LIBRARY_SHARED
+             NAMES libMCStepLogger.so
+             PATHS $ENV{${PKGENVNAME}_ROOT}/lib)
+
+if(${PKGNAME}_INCLUDE_DIR AND ${PKGNAME}_LIBRARY_SHARED)
+  add_library(MCStepLogger SHARED IMPORTED)
+  get_filename_component(incdir ${${PKGNAME}_INCLUDE_DIR}/.. ABSOLUTE)
+  set_target_properties(MCStepLogger
+                        PROPERTIES IMPORTED_LOCATION
+                                   ${${PKGNAME}_LIBRARY_SHARED}
+                                   INTERFACE_INCLUDE_DIRECTORIES ${incdir})
+  # Promote the imported target to global visibility (so we can alias it)
+  set_target_properties(MCStepLogger PROPERTIES IMPORTED_GLOBAL TRUE)
+  add_library(MC::MCStepLogger ALIAS MCStepLogger)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(${PKGNAME}
+                                  REQUIRED_VARS ${PKGNAME}_INCLUDE_DIR
+                                                ${PKGNAME}_LIBRARY_SHARED)
+
+mark_as_advanced(${PKGNAME}_INCLUDE_DIR ${PKGNAME}_LIBRARY_SHARED)
+
+unset(PKGNAME)
+unset(PKGENVNAME)

--- a/dependencies/O2SimulationDependencies.cmake
+++ b/dependencies/O2SimulationDependencies.cmake
@@ -66,6 +66,11 @@ set_package_properties(HepMC
 		       PROPERTIES
 		       TYPE ${mcPackageRequirement} DESCRIPTION
 		       	    "the HepMC3 event record package")
+find_package(MCStepLogger MODULE)
+set_package_properties(MCStepLogger
+                       PROPERTIES
+                       TYPE ${mcPackageRequirement} DESCRIPTION
+                            "log steps done in VMC transport engine")
 set(doBuildSimulation OFF)
 
 if(pythia_FOUND


### PR DESCRIPTION
MCStepLogger becomes a requirement as VMCReplay depends on it in order
to digest the serialised step log files.