### PR TITLE
Cleaning up usage of DPL CompletionPolicy

### DIFF
--- a/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
+++ b/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
@@ -12,6 +12,7 @@
 #include "Framework/WorkflowSpec.h"
 #include "Framework/ConfigParamSpec.h"
 #include "Framework/CompletionPolicy.h"
+#include "Framework/CompletionPolicyHelpers.h"
 #include "Framework/DeviceSpec.h"
 #include "Algorithm/RangeTokenizer.h"
 #include "SimReaderSpec.h"
@@ -93,19 +94,7 @@ void customize(std::vector<o2::framework::CompletionPolicy>& policies)
 {
   using o2::framework::CompletionPolicy;
   // we customize the completion policy for the writer since it should stream immediately
-  auto matcher = [](DeviceSpec const& device) {
-    bool matched = device.name == "TPCDigitWriter";
-    if (matched) {
-      LOG(INFO) << "DPL completion policy for " << device.name << " customized";
-    }
-    return matched;
-  };
-
-  auto policy = [](gsl::span<o2::framework::PartRef const> const& inputs) {
-    return CompletionPolicy::CompletionOp::Consume;
-  };
-
-  policies.push_back({CompletionPolicy{"process-any", matcher, policy}});
+  policies.push_back(CompletionPolicyHelpers::defineByName("TPCDigitWriter", CompletionPolicy::CompletionOp::Consume));
 }
 
 // ------------------------------------------------------------------

--- a/Utilities/Mergers/include/Mergers/MergerBuilder.h
+++ b/Utilities/Mergers/include/Mergers/MergerBuilder.h
@@ -19,12 +19,16 @@
 #include "Mergers/MergerConfig.h"
 
 #include <Framework/DataProcessorSpec.h>
-#include <Framework/CompletionPolicy.h>
 
 #include <string>
 
 namespace o2
 {
+namespace framework
+{
+class CompletionPolicy;
+}
+
 namespace experimental::mergers
 {
 

--- a/Utilities/Mergers/src/Merger.cxx
+++ b/Utilities/Mergers/src/Merger.cxx
@@ -16,7 +16,6 @@
 #include "Mergers/Merger.h"
 #include "Mergers/MergerBuilder.h"
 
-#include <Framework/CompletionPolicyHelpers.h>
 #include <Framework/TimesliceIndex.h>
 #include <Framework/CallbackService.h>
 

--- a/Utilities/Mergers/src/MergerBuilder.cxx
+++ b/Utilities/Mergers/src/MergerBuilder.cxx
@@ -15,6 +15,7 @@
 
 #include <Framework/DeviceSpec.h>
 #include "Framework/DataSpecUtils.h"
+#include <Framework/CompletionPolicyHelpers.h>
 
 #include "Mergers/MergerBuilder.h"
 #include "Mergers/Merger.h"
@@ -94,14 +95,8 @@ framework::DataProcessorSpec MergerBuilder::buildSpec()
 
 void MergerBuilder::customizeInfrastructure(std::vector<framework::CompletionPolicy>& policies)
 {
-  auto matcher = [](framework::DeviceSpec const& device) {
-    return device.name.find(MergerBuilder::mergerIdString()) != std::string::npos;
-  };
-  auto callback = [](gsl::span<framework::PartRef const> const& inputs) {
-    return framework::CompletionPolicy::CompletionOp::Consume;
-  };
-  framework::CompletionPolicy mergerConsumes{"mergerConsumes", matcher, callback};
-  policies.push_back(mergerConsumes);
+  // merger is identified by the ID string and should always consume
+  policies.push_back(CompletionPolicyHelpers::defineByName(MergerBuilder::mergerIdString(), CompletionPolicy::CompletionOp::Consume));
 }
 
 } // namespace experimental::mergers


### PR DESCRIPTION
In simple cases, default policy implementations from CompletionPolicyhelpers
are used.