### PR TITLE
TRD: Use of a signal array structure instead of extra time bin for keeping MC label index

### DIFF
--- a/Detectors/TRD/base/include/TRDBase/Digit.h
+++ b/Detectors/TRD/base/include/TRDBase/Digit.h
@@ -50,7 +50,7 @@ class Digit : TimeStamp
   int getDetector() const { return mDetector; }
   int getRow() const { return mRow; }
   int getPad() const { return mPad; }
-  ArrayADC getADC() const { return mADC; }
+  ArrayADC getADC() const& { return mADC; }
   size_t getLabelIndex() const { return mLabelIdx; }
 
  private:

--- a/Detectors/TRD/base/include/TRDBase/Digit.h
+++ b/Detectors/TRD/base/include/TRDBase/Digit.h
@@ -17,31 +17,26 @@
 #include <unordered_map>
 #include "Rtypes.h" // for ClassDef
 
+#include "CommonDataFormat/TimeStamp.h"
+#include "TRDBase/TRDCommonParam.h"
+
 namespace o2
 {
 namespace trd
 {
 
-class Digit;
+using ADC_t = std::uint16_t;
+using ArrayADC = std::array<ADC_t, kTimeBins>;
 
-constexpr int kTB = 30;
-constexpr int KEY_MIN = 0;
-constexpr int KEY_MAX = 2211727;
+using TimeStamp = o2::dataformats::TimeStamp<double>;
 
-typedef std::uint16_t ADC_t;                                      // the ADC value type
-typedef float Signal_t;                                           // the signal value type
-typedef std::array<ADC_t, kTB> ArrayADC_t;                        // the array ADC - the main member of the Digit class
-typedef std::array<Signal_t, kTB + 1> ArraySignal_t;              // the signal array + 1 element for mc label indexing - for the digitization process only
-typedef std::vector<Digit> DigitContainer_t;                      // the digit container type to send the digits to the DPL
-typedef std::unordered_map<int, ArraySignal_t> SignalContainer_t; // a map container type for signal handling during digitization
-
-class Digit
+class Digit : TimeStamp
 {
  public:
   Digit() = default;
   ~Digit() = default;
-  Digit(const int det, const int row, const int pad, const ArrayADC_t adc, const size_t idx)
-    : mDetector(det), mRow(row), mPad(pad), mADC(adc), mLabelIdx(idx) {}
+  Digit(const int det, const int row, const int pad, const ArrayADC adc, const size_t idx, double t)
+    : mDetector(det), mRow(row), mPad(pad), mADC(adc), mLabelIdx(idx), TimeStamp(t) {}
   // Copy
   Digit(const Digit&) = default;
   // Assignment
@@ -50,61 +45,19 @@ class Digit
   void setDetector(int det) { mDetector = det; }
   void setRow(int row) { mRow = row; }
   void setPad(int pad) { mPad = pad; }
-  void setADC(ArrayADC_t adc) { mADC = adc; }
+  void setADC(ArrayADC adc) { mADC = adc; }
   // Get methods
   int getDetector() const { return mDetector; }
   int getRow() const { return mRow; }
   int getPad() const { return mPad; }
-  ArrayADC_t getADC() const { return mADC; }
+  ArrayADC getADC() const { return mADC; }
   size_t getLabelIndex() const { return mLabelIdx; }
-
-  // Set of static helper methods
-  static int calculateKey(const int det, const int row, const int col) { return ((det << 12) | (row << 8) | col); }
-  static int getDetectorFromKey(const int key) { return (key >> 12) & 0xFFF; }
-  static int getRowFromKey(const int key) { return (key >> 8) & 0xF; }
-  static int getColFromKey(const int key) { return key & 0xFF; }
-  static void convertMapToVectors(const SignalContainer_t& adcMapCont,
-                                  DigitContainer_t& digitCont)
-  {
-    //
-    // Create a digit and a digit-index container from a map container
-    //
-    for (const auto& element : adcMapCont) {
-      const int key = element.first;
-      ArrayADC_t adcs{};
-      for (int i = 0; i < kTB; ++i) {
-        adcs[i] = element.second[i];
-      }
-      size_t idx = element.second[kTB];
-      digitCont.emplace_back(Digit::getDetectorFromKey(key),
-                             Digit::getRowFromKey(key),
-                             Digit::getColFromKey(key),
-                             adcs, idx);
-    }
-  }
-  static void convertVectorsToMap(const DigitContainer_t& digitCont,
-                                  SignalContainer_t& adcMapCont)
-  {
-    //
-    // Create a map container from a digit and a digit-index container
-    //
-    for (const auto& element : digitCont) {
-      const int key = calculateKey(element.getDetector(),
-                                   element.getRow(),
-                                   element.getPad());
-      ArraySignal_t adcs{};
-      for (int i = 0; i < kTB; ++i) {
-        adcs[i] = element.getADC()[i];
-      }
-      adcMapCont[key] = adcs;
-    }
-  }
 
  private:
   std::uint16_t mDetector{0}; // TRD detector number, 0-539
   std::uint8_t mRow{0};       // pad row, 0-15
   std::uint8_t mPad{0};       // pad within pad row, 0-143
-  ArrayADC_t mADC{};          // ADC vector (30 time-bins)
+  ArrayADC mADC{};            // ADC vector (30 time-bins)
   size_t mLabelIdx{0};        // index for mc label
 
   ClassDefNV(Digit, 1);

--- a/Detectors/TRD/base/include/TRDBase/Digit.h
+++ b/Detectors/TRD/base/include/TRDBase/Digit.h
@@ -45,12 +45,12 @@ class Digit : TimeStamp
   void setDetector(int det) { mDetector = det; }
   void setRow(int row) { mRow = row; }
   void setPad(int pad) { mPad = pad; }
-  void setADC(ArrayADC adc) { mADC = adc; }
+  void setADC(ArrayADC const& adc) { mADC = adc; }
   // Get methods
   int getDetector() const { return mDetector; }
   int getRow() const { return mRow; }
   int getPad() const { return mPad; }
-  ArrayADC getADC() const& { return mADC; }
+  ArrayADC const& getADC() const { return mADC; }
   size_t getLabelIndex() const { return mLabelIdx; }
 
  private:

--- a/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
@@ -77,8 +77,8 @@ class Digitizer
   int mEventID = 0;
   int mSrcID = 0;
 
-  bool mSDigits{false};                    // true: convert signals to summable digits, false by defaults
-  std::vector<HitType> mHitContainer;      // the container of hits in a given detector
+  bool mSDigits{false};               // true: convert signals to summable digits, false by defaults
+  std::vector<HitType> mHitContainer; // the container of hits in a given detector
 
   void getHitContainerPerDetector(const std::vector<HitType>&, std::array<std::vector<HitType>, kNdet>&);
   // Digitization chaing methods

--- a/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
@@ -79,7 +79,6 @@ class Digitizer
 
   bool mSDigits{false};                    // true: convert signals to summable digits, false by defaults
   std::vector<HitType> mHitContainer;      // the container of hits in a given detector
-  std::queue<Digit> mPileupDigitContainer; // first-in first out continer for pileup digits
 
   void getHitContainerPerDetector(const std::vector<HitType>&, std::array<std::vector<HitType>, kNdet>&);
   // Digitization chaing methods

--- a/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
@@ -33,16 +33,28 @@ class TRDPadPlane;
 class TRDArraySignal;
 class PadResponse;
 
+struct SignalArray {
+  std::array<float, kTimeBins> signals{};
+  size_t labelIndex{0};
+};
+
+using DigitContainer = std::vector<Digit>;
+using SignalContainer = std::unordered_map<int, SignalArray>;
+
 class Digitizer
 {
  public:
   Digitizer();
   ~Digitizer() = default;
-  void process(std::vector<HitType> const&, DigitContainer_t&, o2::dataformats::MCTruthContainer<MCLabel>&);
+  void process(std::vector<HitType> const&, DigitContainer&, o2::dataformats::MCTruthContainer<MCLabel>&);
   void setEventTime(double timeNS) { mTime = timeNS; }
   void setEventID(int entryID) { mEventID = entryID; }
   void setSrcID(int sourceID) { mSrcID = sourceID; }
   void setCalibrations(Calibrations* calibrations) { mCalib = calibrations; }
+
+  int getEventTime() const { return mTime; }
+  int getEventID() const { return mEventID; }
+  int getSrcID() const { return mSrcID; }
 
  private:
   TRDGeometry* mGeo = nullptr;            // access to TRDGeometry
@@ -65,15 +77,24 @@ class Digitizer
   int mEventID = 0;
   int mSrcID = 0;
 
-  bool mSDigits{false};               // true: convert signals to summable digits, false by defaults
-  std::vector<HitType> mHitContainer; // the container of hits in a given detector
+  bool mSDigits{false};                    // true: convert signals to summable digits, false by defaults
+  std::vector<HitType> mHitContainer;      // the container of hits in a given detector
+  std::queue<Digit> mPileupDigitContainer; // first-in first out continer for pileup digits
 
   void getHitContainerPerDetector(const std::vector<HitType>&, std::array<std::vector<HitType>, kNdet>&);
   // Digitization chaing methods
-  bool convertHits(const int, const std::vector<HitType>&, SignalContainer_t&, o2::dataformats::MCTruthContainer<MCLabel>&, int thread = 0); // True if hit-to-signal conversion is successful
-  bool convertSignalsToADC(const int, SignalContainer_t&, DigitContainer_t&, int thread = 0);                                                // True if signal-to-ADC conversion is successful
+  bool convertHits(const int, const std::vector<HitType>&, SignalContainer&, o2::dataformats::MCTruthContainer<MCLabel>&, int thread = 0); // True if hit-to-signal conversion is successful
+  bool convertSignalsToADC(const int, SignalContainer&, DigitContainer&, int thread = 0);                                                  // True if signal-to-ADC conversion is successful
 
   bool diffusion(float, float, float, float, float, float, double&, double&, double&, int thread = 0); // True if diffusion is applied successfully
+
+  // Helpers for signal handling
+  static constexpr int KEY_MIN = 0;
+  static constexpr int KEY_MAX = 2211727;
+  int calculateKey(const int det, const int row, const int col) { return ((det << 12) | (row << 8) | col); }
+  int getDetectorFromKey(const int key) { return (key >> 12) & 0xFFF; }
+  int getRowFromKey(const int key) { return (key >> 8) & 0xF; }
+  int getColFromKey(const int key) { return key & 0xFF; }
 };
 } // namespace trd
 } // namespace o2

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -430,7 +430,7 @@ bool Digitizer::convertSignalsToADC(const int det, SignalContainer& signalMapCon
     // Loop over the all timebins in the ADC array
     SignalArray& signalData = signalMapIter.second;
     auto& signalArray = signalData.signals;
-    ArrayADC adcs{}; // fails if declared as AdcArray_t
+    ArrayADC adcs{};
     for (int tb = 0; tb < nTimeTotal; ++tb) {
       float signalAmp = (float)signalArray[tb]; // The signal amplitude
       signalAmp *= coupling;                    // Pad and time coupling

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -75,7 +75,7 @@ Digitizer::Digitizer()
   mSDigits = false;
 }
 
-void Digitizer::process(std::vector<HitType> const& hits, DigitContainer_t& digitCont, o2::dataformats::MCTruthContainer<MCLabel>& labels)
+void Digitizer::process(std::vector<HitType> const& hits, DigitContainer& digitCont, o2::dataformats::MCTruthContainer<MCLabel>& labels)
 {
   if (!mCalib) {
     LOG(FATAL) << "TRD Calibration database not available";
@@ -83,8 +83,8 @@ void Digitizer::process(std::vector<HitType> const& hits, DigitContainer_t& digi
 
   // TODO: it might be worth making these member variables
   // in order to have less memory allocations
-  std::array<SignalContainer_t, kNdet> signalsMapCollection;
-  std::array<DigitContainer_t, kNdet> digitCollection;
+  std::array<SignalContainer, kNdet> signalsMapCollection;
+  std::array<DigitContainer, kNdet> digitCollection;
   std::array<o2::dataformats::MCTruthContainer<MCLabel>, kNdet> labelsperdetector;
 
   // Get the a hit container for all the hits in a given detector then call convertHits for a given detector (0 - 539)
@@ -156,7 +156,7 @@ void Digitizer::getHitContainerPerDetector(const std::vector<HitType>& hits, std
   }
 }
 
-bool Digitizer::convertHits(const int det, const std::vector<HitType>& hits, SignalContainer_t& signalMapCont, o2::dataformats::MCTruthContainer<MCLabel>& labels, int thread)
+bool Digitizer::convertHits(const int det, const std::vector<HitType>& hits, SignalContainer& signalMapCont, o2::dataformats::MCTruthContainer<MCLabel>& labels, int thread)
 {
   //
   // Convert the detector-wise sorted hits to detector signals
@@ -335,13 +335,14 @@ bool Digitizer::convertHits(const int det, const std::vector<HitType>& hits, Sig
         if (colPos >= nColMax) {
           break;
         }
-        const int key = Digit::calculateKey(det, rowE, colPos);
+        const int key = calculateKey(det, rowE, colPos);
         if (key < KEY_MIN || key > KEY_MAX) {
           LOG(FATAL) << "Wrong TRD key " << key << " for (det,row,col) = (" << det << ", " << rowE << ", " << colPos << ")";
         }
-        auto& currentSignal = signalMapCont[key]; // Get the old signal
         isDigit = true;
-        currentSignal[kTB] = labelIndex; // store the label index in this extra timebin to pass it to the digit structure
+        auto& currentSignalData = signalMapCont[key]; // Get the old signal or make a new one if it doesn't exist
+        auto& currentSignal = currentSignalData.signals;
+        currentSignalData.labelIndex = labelIndex;
         for (int tb = firstTimeBin; tb < lastTimeBin; ++tb) {
           // Apply the time response
           double timeResponse = 1;
@@ -367,7 +368,7 @@ bool Digitizer::convertHits(const int det, const std::vector<HitType>& hits, Sig
       }   // Loop: pads
     }     // end of loop over electrons
     if (isDigit) {
-      MCLabel label(hit.GetTrackID(), mEventID, mSrcID); // add one label if at least one digit is created
+      MCLabel label(hit.GetTrackID(), getEventID(), getSrcID()); // add one label if at least one digit is created
       labels.addElement(labelIndex, label);
     }
   } // end of loop over hits
@@ -381,7 +382,7 @@ float drawGaus(o2::math_utils::RandomRing<>& normaldistRing, float mu, float sig
   return mu + sigma * normaldistRing.getNextValue();
 }
 
-bool Digitizer::convertSignalsToADC(const int det, SignalContainer_t& signalMapCont, DigitContainer_t& digits, int thread)
+bool Digitizer::convertSignalsToADC(const int det, SignalContainer& signalMapCont, DigitContainer& digits, int thread)
 {
   //
   // Converts the sampled electron signals to ADC values for a given chamber
@@ -401,9 +402,9 @@ bool Digitizer::convertSignalsToADC(const int det, SignalContainer_t& signalMapC
 
   for (auto& signalMapIter : signalMapCont) {
     const auto key = signalMapIter.first;
-    const int det = Digit::getDetectorFromKey(key);
-    const int row = Digit::getRowFromKey(key);
-    const int col = Digit::getColFromKey(key);
+    const int det = getDetectorFromKey(key);
+    const int row = getRowFromKey(key);
+    const int col = getColFromKey(key);
     // halfchamber masking
     int mcm = (int)(col / 18);               // current group of 18 col pads
     int halfchamberside = (mcm > 3 ? 1 : 0); // 0=Aside, 1=Bside
@@ -427,12 +428,13 @@ bool Digitizer::convertSignalsToADC(const int det, SignalContainer_t& signalMapC
     }
 
     // Loop over the all timebins in the ADC array
-    auto& adcArray = signalMapIter.second;
-    std::array<ADC_t, kTB> adcs{}; // fails if declared as AdcArray_t
+    SignalArray& signalData = signalMapIter.second;
+    auto& signalArray = signalData.signals;
+    ArrayADC adcs{}; // fails if declared as AdcArray_t
     for (int tb = 0; tb < nTimeTotal; ++tb) {
-      float signalAmp = (float)adcArray[tb]; // The signal amplitude
-      signalAmp *= coupling;                 // Pad and time coupling
-      signalAmp *= padgain;                  // Gain factors
+      float signalAmp = (float)signalArray[tb]; // The signal amplitude
+      signalAmp *= coupling;                    // Pad and time coupling
+      signalAmp *= padgain;                     // Gain factors
       // Add the noise, starting from minus ADC baseline in electrons
       signalAmp = std::max((double)drawGaus(mGausRandomRings[thread], signalAmp, mSimParam->GetNoise()), -baselineEl);
       signalAmp *= convert;  // Convert to mV
@@ -449,8 +451,8 @@ bool Digitizer::convertSignalsToADC(const int det, SignalContainer_t& signalMapC
       adcs[tb] = adc;
     } // loop over timebins
     // Convert the map to digits here, and push them to the container
-    size_t labelIdx = (size_t)adcArray[kTB];
-    digits.emplace_back(det, row, col, adcs, labelIdx);
+    size_t labelIndex = signalData.labelIndex;
+    digits.emplace_back(det, row, col, adcs, labelIndex, getEventTime());
   } // loop over digits
   return true;
 }


### PR DESCRIPTION
In preparation for adding pileup to the TRD digitizer.

- Use of a signal array structure instead of extra time bin for keeping MC label index.
- Cleaning of Digit class, making it POD. Signal handler methods moved to the Digitizer, since they are not used elsewhere for now.