### PR TITLE
TPC/ITS matching fixes + AfterBurner

### DIFF
--- a/Common/MathUtils/CMakeLists.txt
+++ b/Common/MathUtils/CMakeLists.txt
@@ -8,49 +8,55 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
-o2_add_library(MathUtils
-               SOURCES src/CachingTF1.cxx
-                       src/Cartesian2D.cxx
-                       src/Cartesian3D.cxx
-                       src/Chebyshev3D.cxx
-                       src/Chebyshev3DCalc.cxx
-                       src/MathBase.cxx
-                       src/RandomRing.cxx
-		       src/Primitive2D.cxx
-               PUBLIC_LINK_LIBRARIES ROOT::Hist
-                                     FairRoot::Base
-                                     O2::CommonConstants
-                                     O2::GPUCommon
-                                     ROOT::GenVector
-                                     ROOT::Geom
-                                     Vc::Vc)
+o2_add_library(
+  MathUtils
+  SOURCES src/CachingTF1.cxx
+          src/Cartesian2D.cxx
+          src/Cartesian3D.cxx
+          src/Chebyshev3D.cxx
+          src/Chebyshev3DCalc.cxx
+          src/MathBase.cxx
+          src/RandomRing.cxx
+          src/Primitive2D.cxx
+  PUBLIC_LINK_LIBRARIES
+    ROOT::Hist
+    FairRoot::Base
+    O2::CommonConstants
+    O2::GPUCommon
+    ROOT::GenVector
+    ROOT::Geom
+    Vc::Vc)
 
-o2_target_root_dictionary(MathUtils
-                          HEADERS include/MathUtils/Utils.h
-			          include/MathUtils/Chebyshev3D.h
-				  include/MathUtils/Chebyshev3DCalc.h
-                                  include/MathUtils/MathBase.h
-                                  include/MathUtils/Cartesian2D.h
-                                  include/MathUtils/Cartesian3D.h
-                                  include/MathUtils/CachingTF1.h
-                                  include/MathUtils/RandomRing.h
-                                  include/MathUtils/Primitive2D.h
-				  include/MathUtils/Bracket.h)
+o2_target_root_dictionary(
+  MathUtils
+  HEADERS include/MathUtils/Utils.h
+          include/MathUtils/Chebyshev3D.h
+          include/MathUtils/Chebyshev3DCalc.h
+          include/MathUtils/MathBase.h
+          include/MathUtils/Cartesian2D.h
+          include/MathUtils/Cartesian3D.h
+          include/MathUtils/CachingTF1.h
+          include/MathUtils/RandomRing.h
+          include/MathUtils/Primitive2D.h
+          include/MathUtils/Bracket.h)
 
-o2_add_test(CachingTF1
-            SOURCES test/testCachingTF1.cxx
-            COMPONENT_NAME MathUtils
-            PUBLIC_LINK_LIBRARIES O2::MathUtils
-            LABELS utils)
+o2_add_test(
+  CachingTF1
+  SOURCES test/testCachingTF1.cxx
+  COMPONENT_NAME MathUtils
+  PUBLIC_LINK_LIBRARIES O2::MathUtils
+  LABELS utils)
 
-o2_add_test(Cartesian3D
-            SOURCES test/testCartesian3D.cxx
-            COMPONENT_NAME MathUtils
-            PUBLIC_LINK_LIBRARIES O2::MathUtils
-            LABELS utils)
+o2_add_test(
+  Cartesian3D
+  SOURCES test/testCartesian3D.cxx
+  COMPONENT_NAME MathUtils
+  PUBLIC_LINK_LIBRARIES O2::MathUtils
+  LABELS utils)
 
-o2_add_test(Utils
-            SOURCES test/testUtils.cxx
-            COMPONENT_NAME MathUtils
-            PUBLIC_LINK_LIBRARIES O2::MathUtils
-            LABELS utils)
+o2_add_test(
+  Utils
+  SOURCES test/testUtils.cxx
+  COMPONENT_NAME MathUtils
+  PUBLIC_LINK_LIBRARIES O2::MathUtils
+  LABELS utils)

--- a/Common/MathUtils/CMakeLists.txt
+++ b/Common/MathUtils/CMakeLists.txt
@@ -16,6 +16,7 @@ o2_add_library(MathUtils
                        src/Chebyshev3DCalc.cxx
                        src/MathBase.cxx
                        src/RandomRing.cxx
+		       src/Primitive2D.cxx
                PUBLIC_LINK_LIBRARIES ROOT::Hist
                                      FairRoot::Base
                                      O2::CommonConstants
@@ -25,13 +26,16 @@ o2_add_library(MathUtils
                                      Vc::Vc)
 
 o2_target_root_dictionary(MathUtils
-                          HEADERS include/MathUtils/Chebyshev3D.h
-                                  include/MathUtils/Chebyshev3DCalc.h
+                          HEADERS include/MathUtils/Utils.h
+			          include/MathUtils/Chebyshev3D.h
+				  include/MathUtils/Chebyshev3DCalc.h
                                   include/MathUtils/MathBase.h
                                   include/MathUtils/Cartesian2D.h
                                   include/MathUtils/Cartesian3D.h
                                   include/MathUtils/CachingTF1.h
-                                  include/MathUtils/RandomRing.h)
+                                  include/MathUtils/RandomRing.h
+                                  include/MathUtils/Primitive2D.h
+				  include/MathUtils/Bracket.h)
 
 o2_add_test(CachingTF1
             SOURCES test/testCachingTF1.cxx

--- a/Common/MathUtils/include/MathUtils/Bracket.h
+++ b/Common/MathUtils/include/MathUtils/Bracket.h
@@ -1,0 +1,101 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file Bracket.h
+/// \brief Class to represent an interval and some operations over it
+/// \author ruben.shahoyan@cern.ch
+
+#ifndef ALICEO2_BRACKET_H
+#define ALICEO2_BRACKET_H
+
+#include <Rtypes.h>
+
+namespace o2
+{
+namespace utils
+{
+
+template <typename T = float>
+class Bracket
+{
+ public:
+  enum Relation : int { Below = -1,
+                        Inside = 0,
+                        Above = 1 };
+
+  Bracket(T minv, T maxv) : mMin(minv), mMax(maxv) {}
+  Bracket(const Bracket<T>& src) = default;
+  Bracket() = default;
+  ~Bracket() = default;
+  void set(T minv, T maxv)
+  {
+    mMin = minv;
+    mMax = maxv;
+  }
+  bool operator<(const T rhs)
+  {
+    return mMax < rhs;
+  }
+  bool operator>(const T rhs)
+  {
+    return mMin > rhs;
+  }
+
+  bool operator<(const Bracket<T>& rhs)
+  {
+    return mMax < rhs.mMin;
+  }
+  bool operator>(const Bracket<T>& rhs)
+  {
+    return mMin > rhs.mMax;
+  }
+  bool operator==(const Bracket<T>& rhs)
+  {
+    return mMin == rhs.mMin && mMax == rhs.mMax;
+  }
+
+  void setMax(T v) { mMax = v; }
+  void setMin(T v) { mMin = v; }
+  T& max() { return mMax; }
+  T& min() { return mMin; }
+  T max() const { return mMax; }
+  T min() const { return mMin; }
+  T mean() const { return (mMin + mMax) / 2; }
+  T delta() const { return mMax - mMin; }
+  void update(T v)
+  {
+    // update limits
+    if (v > mMax) {
+      mMax = v;
+    }
+    if (v < mMin) {
+      mMin = v;
+    }
+  }
+  Relation isOutside(const Bracket<T>& t) const
+  {
+    ///< check if provided bracket is outside of this bracket
+    return t.mMax < mMin ? Below : (t.mMin > mMax ? Above : Inside);
+  }
+  int isOutside(T t, T tErr) const
+  {
+    ///< check if the provided value t with error tErr is outside of the bracket
+    return t + tErr < mMin ? Below : (t - tErr > mMax ? Above : Inside);
+  }
+
+ private:
+  T mMin = 0, mMax = 0;
+
+  ClassDefNV(Bracket, 1);
+};
+} // namespace utils
+} // namespace o2
+
+#endif

--- a/Common/MathUtils/include/MathUtils/Primitive2D.h
+++ b/Common/MathUtils/include/MathUtils/Primitive2D.h
@@ -1,0 +1,69 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file Primitive2D.h
+/// \brief Declarations of 2D primitives: straight line (XY interval) and circle
+/// \author ruben.shahoyan@cern.ch
+
+#ifndef ALICEO2_COMMON_MATH_PRIMITIVE2D_H
+#define ALICEO2_COMMON_MATH_PRIMITIVE2D_H
+
+#include "GPUCommonRtypes.h"
+
+namespace o2
+{
+namespace utils
+{
+
+struct CircleXY {
+  float rC, xC, yC; // circle radius, x-center, y-center
+  CircleXY(float r = 0., float x = 0., float y = 0.) : rC(r), xC(x), yC(y) {}
+  float getCenterD2() const { return xC * xC + yC * yC; }
+  ClassDefNV(CircleXY, 1);
+};
+
+struct IntervalXY {
+  ///< 2D interval in lab frame defined by its one edge and signed projection lengths on X,Y axes
+  float xP, yP;   ///< one of edges
+  float dxP, dyP; ///< other edge minus provided
+  IntervalXY(float x = 0, float y = 0, float dx = 0, float dy = 0) : xP(x), yP(y), dxP(dx), dyP(dy) {}
+  float getX0() const { return xP; }
+  float getY0() const { return yP; }
+  float getX1() const { return xP + dxP; }
+  float getY1() const { return yP + dyP; }
+  float getDX() const { return dxP; }
+  float getDY() const { return dyP; }
+  void eval(float t, float& x, float& y) const
+  {
+    x = xP + t * dxP;
+    y = yP + t * dyP;
+  }
+  void getLineCoefs(float& a, float& b, float& c) const;
+
+  void setEdges(float x0, float y0, float x1, float y1)
+  {
+    xP = x0;
+    yP = y0;
+    dxP = x1 - x0;
+    dyP = y1 - y0;
+  }
+  bool seenByCircle(const CircleXY& circle, float eps) const;
+  bool circleCrossParam(const CircleXY& cicle, float& t) const;
+
+  bool seenByLine(const IntervalXY& other, float eps) const;
+  bool lineCrossParam(const IntervalXY& other, float& t) const;
+
+  ClassDefNV(IntervalXY, 1);
+};
+
+} // namespace utils
+} // namespace o2
+
+#endif

--- a/Common/MathUtils/include/MathUtils/Utils.h
+++ b/Common/MathUtils/include/MathUtils/Utils.h
@@ -74,6 +74,32 @@ inline void sincosf(float ang, float& s, float& c)
   c = o2::gpu::CAMath::Cos(ang);
 }
 
+inline void rotateZ(float xL, float yL, float& xG, float& yG, float snAlp, float csAlp)
+{
+  // 2D rotation of the point by angle alpha (local to global)
+  xG = xL * csAlp - yL * snAlp;
+  yG = xL * snAlp + yL * csAlp;
+}
+
+inline void rotateZInv(float xG, float yG, float& xL, float& yL, float snAlp, float csAlp)
+{
+  // inverse 2D rotation of the point by angle alpha (global to local)
+  rotateZ(xG, yG, xL, yL, -snAlp, csAlp);
+}
+
+inline void rotateZ(double xL, double yL, double& xG, double& yG, double snAlp, double csAlp)
+{
+  // 2D rotation of the point by angle alpha (local to global)
+  xG = xL * csAlp - yL * snAlp;
+  yG = xL * snAlp + yL * csAlp;
+}
+
+inline void rotateZInv(double xG, double yG, double& xL, double& yL, double snAlp, double csAlp)
+{
+  // inverse 2D rotation of the point by angle alpha (global to local)
+  rotateZ(xG, yG, xL, yL, -snAlp, csAlp);
+}
+
 #ifndef __OPENCL__
 inline void RotateZ(std::array<float, 3>& xy, float alpha)
 {

--- a/Common/MathUtils/src/MathUtilsLinkDef.h
+++ b/Common/MathUtils/src/MathUtilsLinkDef.h
@@ -30,4 +30,8 @@
 #pragma link C++ class o2::Rotation2D + ;
 #pragma link C++ class o2::base::CachingTF1 + ;
 
+#pragma link C++ class o2::utils::CircleXY + ;
+#pragma link C++ class o2::utils::IntervalXY + ;
+#pragma link C++ class o2::utils::Bracket < float> + ;
+
 #endif

--- a/Common/MathUtils/src/Primitive2D.cxx
+++ b/Common/MathUtils/src/Primitive2D.cxx
@@ -1,0 +1,110 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file Primitive.cxx
+/// \brief Implementation of 2D primitives: straight line (XY interval) and circle
+/// \author ruben.shahoyan@cern.ch
+
+#include "MathUtils/Primitive2D.h"
+#include <cmath>
+
+using namespace o2::utils;
+
+//_____________________________________________________________________
+bool IntervalXY::seenByCircle(const CircleXY& circle, float eps) const
+{
+  // check if XY interval is seen by the circle.
+  // The tolerance parameter eps is interpreted as a fraction of the interval
+  // lenght to be added to the edges along the interval (i.e. while the points
+  // within the interval are spanning
+  // x = xc + dx*t
+  // y = yc + dy*t
+  // with 0<t<1., we acctually check the interval for -eps<t<1+eps
+  auto dx0 = xP - circle.xC, dy0 = yP - circle.yC, dx1 = dx0 + dxP, dy1 = dy0 + dyP;
+  if (eps > 0.) {
+    auto dxeps = eps * dxP, dyeps = eps * dyP;
+    dx0 -= dxeps;
+    dx1 += dxeps;
+    dy0 -= dyeps;
+    dy1 += dyeps;
+  }
+  auto d02 = dx0 * dx0 + dy0 * dy0, d12 = dx1 * dx1 + dy1 * dy1, rC2 = circle.rC * circle.rC; // distance^2 from circle center to edges
+  return (d02 - rC2) * (d12 - rC2) < 0;
+}
+
+//_____________________________________________________________________
+bool IntervalXY::seenByLine(const IntervalXY& other, float eps) const
+{
+  // check if XY interval is seen by the line defined by other interval
+  // The tolerance parameter eps is interpreted as a fraction of the interval
+  // lenght to be added to the edges along the interval (i.e. while the points
+  // within the interval are spanning
+  // x = xc + dx*t
+  // y = yc + dy*t
+  // with 0<t<1., we acctually check the interval for -eps<t<1+eps
+  float a, b, c, x0, y0, x1, y1; // find equation of the line a*x+b*y+c = 0
+  other.getLineCoefs(a, b, c);
+  eval(-eps, x0, y0);
+  eval(1.f + eps, x1, y1);
+  return (a * x0 + b * y0 + c) * (a * x1 + b * y1 + c) < 0;
+}
+
+//_____________________________________________________________________
+bool IntervalXY::lineCrossParam(const IntervalXY& other, float& t) const
+{
+  // get crossing parameter of 2 intervals
+  float dx = other.xP - xP, dy = other.yP - yP;
+  float det = -dxP * other.dyP + dyP * other.dxP;
+  if (fabs(det) < 1.e-9) {
+    return false; // parallel
+  }
+  t = (-dx * other.dyP + dy * other.dxP) / det;
+  return true;
+}
+
+//_____________________________________________________________________
+bool IntervalXY::circleCrossParam(const CircleXY& circle, float& t) const
+{
+  // get crossing point of circle with the interval
+  // solution of the system (wrt t)
+  // (x-xC)^2+(y-yC)^2 = rC2
+  // x = xEdge + xProj * t;
+  // y = yEdge + yProj * t;
+  float dx = xP - circle.xC, dy = yP - circle.yC, del2I = 1. / (dxP * dxP + dyP * dyP),
+        b = (dx * dxP + dy * dyP) * del2I, c = del2I * (dx * dx + dy * dy - circle.rC * circle.rC);
+  float det = b * b - c;
+  if (det < 0.) {
+    return false;
+  }
+  det = sqrtf(det);
+  float t0 = -b - det, t1 = -b + det;
+  // select the one closer to [0:1] interval
+  t = (fabs(t0 - 0.5) < fabs(t1 - 0.5)) ? t0 : t1;
+  return true;
+}
+
+//_____________________________________________________________________
+void IntervalXY::getLineCoefs(float& a, float& b, float& c) const
+{
+  // convert to line parameters in canonical form: a*x+b*y+c = 0
+  c = xP * dyP - yP * dxP;
+  if (c) {
+    a = -dyP;
+    b = dxP;
+  } else if (fabs(dxP) > fabs(dyP)) {
+    a = 0.;
+    b = -1.;
+    c = yP;
+  } else {
+    a = -1.;
+    b = 0.;
+    c = xP;
+  }
+}

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/Cluster.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/Cluster.h
@@ -63,8 +63,6 @@ class Cluster : public o2::BaseCluster<float>
 
   ~Cluster() = default;
 
-  Cluster& operator=(const Cluster& cluster) = delete; // RS why?
-
   //****** Basic methods ******************
   void setUsed() { setBit(kUsed); }
   void setShared() { setBit(kShared); }

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/Cluster.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/Cluster.h
@@ -206,8 +206,4 @@ struct is_messageable<o2::itsmft::Cluster> : std::true_type {
 
 } // namespace o2
 
-template <>
-struct o2::framework::is_messageable<o2::itsmft::Cluster> : std::true_type {
-};
-
 #endif /* ALICEO2_ITSMFT_CLUSTER_H */

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/Cluster.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/Cluster.h
@@ -206,4 +206,8 @@ struct is_messageable<o2::itsmft::Cluster> : std::true_type {
 
 } // namespace o2
 
+template <>
+struct o2::framework::is_messageable<o2::itsmft::Cluster> : std::true_type {
+};
+
 #endif /* ALICEO2_ITSMFT_CLUSTER_H */

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/CompCluster.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/CompCluster.h
@@ -102,6 +102,7 @@ class CompClusterExt : public CompCluster
   }
 
   UShort_t getChipID() const { return mChipID; }
+  UShort_t getSensorID() const { return mChipID; } // to have the same signature as BaseCluster
 
   void setChipID(UShort_t c) { mChipID = c; }
 

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/Track.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/Track.h
@@ -28,6 +28,7 @@
 
 #ifndef GPUCA_ALIGPUCODE //Used only by functions that are hidden on the GPU
 #include "ReconstructionDataFormats/BaseCluster.h"
+#include <string>
 #endif
 
 #include "CommonConstants/MathConstants.h"
@@ -180,7 +181,10 @@ class TrackPar
   bool propagateParamTo(float xk, const std::array<float, 3>& b);
   void invertParam();
 
+#ifndef GPUCA_ALIGPUCODE
   void printParam() const;
+  std::string asString() const;
+#endif
 
  protected:
   void updateParam(float delta, int i) { mP[i] += delta; }
@@ -233,7 +237,11 @@ class TrackParCov : public TrackPar
   float getSigma1Pt2() const { return mC[kSigQ2Pt2]; }
   float getCovarElem(int i, int j) const { return mC[CovarMap[i][j]]; }
   float getDiagError2(int i) const { return mC[DiagMap[i]]; }
+
+#ifndef GPUCA_ALIGPUCODE
   void print() const;
+  std::string asString() const;
+#endif
 
   // parameters + covmat manipulation
   bool rotate(float alpha);
@@ -421,6 +429,7 @@ inline TrackParCov::TrackParCov(float x, float alpha, const std::array<float, kN
   // explicit constructor
   std::copy(cov.begin(), cov.end(), mC);
 }
+
 } // namespace track
 } // namespace o2
 

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/Track.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/Track.h
@@ -281,9 +281,9 @@ class TrackParCov : public TrackPar
 
   void resetCovariance(float s2 = 0);
   void checkCovariance();
+  void setCov(float v, int i) { mC[i] = v; }
 
  protected:
-  void setCov(float v, int i) { mC[i] = v; }
   void updateCov(const float delta[kCovMatSize])
   {
     for (int i = kCovMatSize; i--;)

--- a/DataFormats/Reconstruction/src/Track.cxx
+++ b/DataFormats/Reconstruction/src/Track.cxx
@@ -421,6 +421,182 @@ void TrackPar::printParam() const
 }
 
 //______________________________________________________________
+bool TrackPar::getXatLabR(float r, float& x, float bz, o2::track::DirType dir) const
+{
+  // Get local X of the track position estimated at the radius lab radius r.
+  // The track curvature is accounted exactly
+  //
+  // The flag "dir" can be used to remove the ambiguity of which intersection to take (out of 2 possible)
+  // DirAuto (==0)  - take the intersection closest to the current track position
+  // DirOutward (==1) - go along the track (increasing mX)
+  // DirInward (==-1) - go backward (decreasing mX)
+  //
+  const auto fy = mP[0], sn = mP[2];
+  const float kEps = 1.e-6;
+  //
+  auto crv = getCurvature(bz);
+  if (fabs(crv) > o2::constants::math::Almost0) { // helix
+    // get center of the track circle
+    o2::utils::CircleXY circle;
+    getCircleParamsLoc(bz, circle);
+    auto r0 = sqrtf(circle.getCenterD2());
+    if (r0 <= o2::constants::math::Almost0) {
+      return false; // the track is concentric to circle
+    }
+    float tR2r0 = 1., g = 0., tmp = 0.;
+    if (fabs(circle.rC - r0) > kEps) {
+      tR2r0 = circle.rC / r0;
+      g = 0.5 * (r * r / (r0 * circle.rC) - tR2r0 - 1. / tR2r0);
+      tmp = 1. + g * tR2r0;
+    } else {
+      tR2r0 = 1.0;
+      g = 0.5 * r * r / (r0 * circle.rC) - 1.;
+      tmp = 0.5 * r * r / (r0 * r0);
+    }
+    auto det = (1. - g) * (1. + g);
+    if (det < 0.) {
+      return false; // does not reach raduis r
+    }
+    det = sqrtf(det);
+    //
+    // the intersection happens in 2 points: {circle.xC+tR*C,circle.yC+tR*S}
+    // with C=f*c0+-|s0|*det and S=f*s0-+c0 sign(s0)*det
+    // where s0 and c0 make direction for the circle center (=circle.xC/r0 and circle.yC/r0)
+    //
+    x = circle.xC * tmp;
+    auto y = circle.yC * tmp;
+    if (fabs(circle.yC) > o2::constants::math::Almost0) { // when circle.yC==0 the x,y is unique
+      auto dfx = tR2r0 * fabs(circle.yC) * det;
+      auto dfy = tR2r0 * circle.xC * (circle.yC > 0. ? det : -det);
+      if (dir == DirAuto) {                           // chose the one which corresponds to smallest step
+        auto delta = (x - mX) * dfx - (y - fy) * dfy; // the choice of + in C will lead to smaller step if delta<0
+        x += delta < 0. ? dfx : -dfx;
+      } else if (dir == DirOutward) { // along track direction: x must be > mX
+        x -= dfx;                     // try the smallest step (dfx is positive)
+        auto dfeps = mX - x;          // handle special case of very small step
+        if (dfeps < -kEps) {
+          return true;
+        }
+        if (fabs(dfeps) < kEps && fabs(mX * mX + fy * fy - r * r) < kEps) { // are we already in right r?
+          return mX;
+        }
+        x += dfx + dfx;
+        auto dxm = x - mX;
+        if (dxm > 0.) {
+          return true;
+        } else if (dxm < -kEps) {
+          return false;
+        }
+        x = mX;              // don't move
+      } else {               // backward: x must be < mX
+        x += dfx;            // try the smallest step (dfx is positive)
+        auto dfeps = x - mX; // handle special case of very small step
+        if (dfeps < -kEps) {
+          return true;
+        }
+        if (fabs(dfeps) < kEps && fabs(mX * mX + fy * fy - r * r) < kEps) { // are we already in right r?
+          return mX;
+        }
+        x -= dfx + dfx;
+        auto dxm = x - mX;
+        if (dxm < 0.) {
+          return true;
+        }
+        if (dxm > kEps) {
+          return false;
+        }
+        x = mX; // don't move
+      }
+    } else { // special case: track touching the circle just in 1 point
+      if ((dir == DirOutward && x < mX) || (dir == DirInward && x > mX)) {
+        return false;
+      }
+    }
+  } else {                                          // this is a straight track
+    if (fabs(sn) >= o2::constants::math::Almost1) { // || to Y axis
+      auto det = (r - mX) * (r + mX);
+      if (det < 0.) {
+        return false; // does not reach raduis r
+      }
+      x = mX;
+      if (dir == DirAuto) {
+        return true;
+      }
+      det = sqrtf(det);
+      if (dir == DirOutward) { // along the track direction
+        if (sn > 0.) {
+          if (fy > det) {
+            return false; // track is along Y axis and above the circle
+          }
+        } else {
+          if (fy < -det) {
+            return false; // track is against Y axis amd belo the circle
+          }
+        }
+      } else if (dir == DirInward) { // against track direction
+        if (sn > 0.) {
+          if (fy < -det) {
+            return false; // track is along Y axis
+          }
+        } else if (fy > det) {
+          return false; // track is against Y axis
+        }
+      }
+    } else if (fabs(sn) <= o2::constants::math::Almost0) { // || to X axis
+      auto det = (r - fy) * (r + fy);
+      if (det < 0.) {
+        return false; // does not reach raduis r
+      }
+      det = sqrtf(det);
+      if (dir == DirAuto) {
+        x = mX > 0. ? det : -det; // choose the solution requiring the smalest step
+        return true;
+      } else if (dir == DirOutward) { // along the track direction
+        if (mX > det) {
+          return false; // current point is in on the right from the circle
+        } else {
+          x = (mX < -det) ? -det : det; // on the left : within the circle
+        }
+      } else { // against the track direction
+        if (mX < -det) {
+          return false;
+        } else {
+          x = mX > det ? det : -det;
+        }
+      }
+    } else { // general case of straight line
+      auto cs = sqrtf((1 - sn) * (1 + sn));
+      auto xsyc = mX * sn - fy * cs;
+      auto det = (r - xsyc) * (r + xsyc);
+      if (det < 0.) {
+        return false; // does not reach raduis r
+      }
+      det = sqrtf(det);
+      auto xcys = mX * cs + fy * sn;
+      auto t = -xcys;
+      if (dir == DirAuto) {
+        t += t > 0. ? -det : det; // chose the solution requiring the smalest step
+      } else if (dir > 0) {       // go in increasing mX direction. ( t+-det > 0)
+        if (t >= -det) {
+          t += -det; // take minimal step giving t>0
+        } else {
+          return false; // both solutions have negative t
+        }
+      } else { // go in increasing mX direction. (t+-det < 0)
+        if (t < det) {
+          t -= det; // take minimal step giving t<0
+        } else {
+          return false; // both solutions have positive t
+        }
+      }
+      x = mX + cs * t;
+    }
+  }
+  //
+  return true;
+}
+
+//______________________________________________________________
 void TrackParCov::invert()
 {
   // Transform this track to the local coord. system rotated by 180 deg.

--- a/DataFormats/common/include/CommonDataFormat/InteractionRecord.h
+++ b/DataFormats/common/include/CommonDataFormat/InteractionRecord.h
@@ -59,8 +59,6 @@ struct InteractionRecord {
     bc = ns2bc(ns, orbit);
   }
 
-  double bc2ns() const { return bc2ns(bc, orbit); }
-
   static double bc2ns(int bc, unsigned int orbit)
   {
     return bc * o2::constants::lhc::LHCBunchSpacingNS + orbit * o2::constants::lhc::LHCOrbitNS;

--- a/DataFormats/common/include/CommonDataFormat/InteractionRecord.h
+++ b/DataFormats/common/include/CommonDataFormat/InteractionRecord.h
@@ -59,6 +59,8 @@ struct InteractionRecord {
     bc = ns2bc(ns, orbit);
   }
 
+  double bc2ns() const { return bc2ns(bc, orbit); }
+
   static double bc2ns(int bc, unsigned int orbit)
   {
     return bc * o2::constants::lhc::LHCBunchSpacingNS + orbit * o2::constants::lhc::LHCOrbitNS;

--- a/Detectors/GlobalTracking/CMakeLists.txt
+++ b/Detectors/GlobalTracking/CMakeLists.txt
@@ -16,6 +16,7 @@ o2_add_library(GlobalTracking
                                      O2::DataFormatsITS
                                      O2::DataFormatsFT0
                                      O2::DataFormatsTOF
+				     O2::ITSReconstruction
                                      O2::TPCFastTransformation
                                      O2::GPUTracking
                                      O2::TPCBase

--- a/Detectors/GlobalTracking/CMakeLists.txt
+++ b/Detectors/GlobalTracking/CMakeLists.txt
@@ -8,24 +8,27 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
-o2_add_library(GlobalTracking
-               SOURCES src/MatchTPCITS.cxx src/MatchTOF.cxx src/CalibTOF.cxx
-                       src/CollectCalibInfoTOF.cxx
-               PUBLIC_LINK_LIBRARIES O2::DataFormatsTPC
-                                     O2::DataFormatsITSMFT
-                                     O2::DataFormatsITS
-                                     O2::DataFormatsFT0
-                                     O2::DataFormatsTOF
-				     O2::ITSReconstruction
-                                     O2::TPCFastTransformation
-                                     O2::GPUTracking
-                                     O2::TPCBase
-                                     O2::TPCReconstruction
-                                     O2::TOFBase
-				     O2::TOFCalibration)
+o2_add_library(
+  GlobalTracking
+  SOURCES src/MatchTPCITS.cxx src/MatchTOF.cxx src/CalibTOF.cxx
+          src/MatchTPCITSParams.cxx src/CollectCalibInfoTOF.cxx
+  PUBLIC_LINK_LIBRARIES
+    O2::DataFormatsTPC
+    O2::DataFormatsITSMFT
+    O2::DataFormatsITS
+    O2::DataFormatsFT0
+    O2::DataFormatsTOF
+    O2::ITSReconstruction
+    O2::TPCFastTransformation
+    O2::GPUTracking
+    O2::TPCBase
+    O2::TPCReconstruction
+    O2::TOFBase
+    O2::TOFCalibration
+    O2::SimConfig)
 
-o2_target_root_dictionary(GlobalTracking
-                          HEADERS include/GlobalTracking/MatchTPCITS.h
-                                  include/GlobalTracking/MatchTOF.h
-                                  include/GlobalTracking/CalibTOF.h
-                                  include/GlobalTracking/CollectCalibInfoTOF.h)
+o2_target_root_dictionary(
+  GlobalTracking
+  HEADERS include/GlobalTracking/MatchTPCITS.h include/GlobalTracking/MatchTPCITSParams.h
+          include/GlobalTracking/MatchTOF.h include/GlobalTracking/CalibTOF.h
+          include/GlobalTracking/CollectCalibInfoTOF.h)

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTOF.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTOF.h
@@ -54,13 +54,13 @@ namespace globaltracking
 ///< original track in the currently loaded TPC-ITS reco output
 struct TrackLocTPCITS : public o2::track::TrackParCov {
   o2::dataformats::EvIndex<int, int> source; ///< track origin id
-  TimeBracket timeBins;                      ///< bracketing time-bins
+  o2::utils::Bracket<float> timeBins;        ///< bracketing time-bins
   float zMin = 0;                            // min possible Z of this track
   float zMax = 0;                            // max possible Z of this track
   int matchID = MinusOne;                    ///< entry (none if MinusOne) of TOF matchTOF struct in the mMatchesTOF
   TrackLocTPCITS(const o2::track::TrackParCov& src, int tch, int tid) : o2::track::TrackParCov(src), source(tch, tid) {}
   TrackLocTPCITS() = default;
-  ClassDefNV(TrackLocTPCITS, 1);
+  ClassDefNV(TrackLocTPCITS, 1); // RS TODO: is this class needed?
 };
 
 class MatchTOF

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
@@ -382,6 +382,14 @@ class MatchTPCITS
     mTPCTrackClusIdx = inp;
   }
 
+  ///< set input TPC tracks cluster indices received via DPL
+  // TODO Temporary solution, see disclaimer about TPCClRefElem in TrackTPC. Later should be changed to uint32_t
+  void setTPCTrackClusIdxInp(const gsl::span<const o2::tpc::TPCClRefElem> inp)
+  {
+    assertDPLIO(true);
+    mTPCTrackClusIdxInp = inp;
+  }
+
   ///< set input TPC clusters received via DPL
   void setTPCClustersInp(const o2::tpc::ClusterNativeAccess* inp)
   {

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITSParams.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITSParams.h
@@ -1,0 +1,55 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author ruben.shahoyan@cern.ch
+
+#ifndef ALICEO2_MATCHITSTPC_PARAMS_H
+#define ALICEO2_MATCHITSTPC_PARAMS_H
+
+#include "SimConfig/ConfigurableParam.h"
+#include "SimConfig/ConfigurableParamHelper.h"
+#include "ReconstructionDataFormats/Track.h"
+
+namespace o2
+{
+namespace globaltracking
+{
+
+// There are configurable params for TPC-ITS matching
+struct MatchITSTPCParams : public o2::conf::ConfigurableParamHelper<MatchITSTPCParams> {
+  bool runAfterBurner = false;
+  float crudeAbsDiffCut[o2::track::kNParams] = {2.f, 2.f, 0.2f, 0.2f, 4.f};
+  float crudeNSigma2Cut[o2::track::kNParams] = {49.f, 49.f, 49.f, 49.f, 49.f};
+
+  float minTPCPt = 0.04;   ///< cut on minimal pT of TPC tracks to consider for matching
+  int minTPCClusters = 25; ///< minimum number of clusters to consider
+  int askMinTPCRow = 15;   ///< disregard tracks starting above this row
+
+  float cutMatchingChi2 = 30.f; ///< cut on matching chi2
+
+  float cutABTrack2ClChi2 = 30.f; ///< cut on AfterBurner track-cluster chi2
+
+  int maxMatchCandidates = 5; ///< max allowed matching candidates per TPC track
+
+  int ABRequireToReachLayer = 5; ///< AB tracks should reach at least this layer from above
+
+  float TPCITSTimeBinSafeMargin = 1.f; ///< safety margin (in TPC time bins) for ITS-TPC tracks time (in TPC time bins!) comparison
+
+  float TPCTimeEdgeZSafeMargin = 20.f; ///< safety margin in cm when estimating TPC track tMin and tMax from assigned time0 and its track Z position
+
+  float TimeBinTolerance = 10.f; ///<tolerance in time-bin for ITS-TPC time bracket matching (not used ? TODO)
+
+  O2ParamDef(MatchITSTPCParams, "tpcitsMatch");
+};
+
+} // namespace globaltracking
+} // end namespace o2
+
+#endif

--- a/Detectors/GlobalTracking/src/GlobalTrackingLinkDef.h
+++ b/Detectors/GlobalTracking/src/GlobalTrackingLinkDef.h
@@ -20,6 +20,10 @@
 #pragma link C++ class o2::globaltracking::CollectCalibInfoTOF + ;
 #pragma link C++ class o2::globaltracking::TrackLocTPC + ;
 #pragma link C++ class o2::globaltracking::TrackLocITS + ;
+
+#pragma link C++ class o2::globaltracking::ABDebugLink + ;
+#pragma link C++ class o2::globaltracking::ABDebugTrack + ;
+
 #pragma link C++ class std::pair < o2::dataformats::EvIndex < int, int>, o2::dataformats::MatchInfoTOF> + ;
 #pragma link C++ class std::vector < std::pair < o2::dataformats::EvIndex < int, int>, o2::dataformats::MatchInfoTOF>> + ;
 #pragma link C++ class std::vector < o2::dataformats::TrackTPCITS> + ;

--- a/Detectors/GlobalTracking/src/GlobalTrackingLinkDef.h
+++ b/Detectors/GlobalTracking/src/GlobalTrackingLinkDef.h
@@ -18,7 +18,6 @@
 #pragma link C++ class o2::globaltracking::MatchTOF + ;
 #pragma link C++ class o2::globaltracking::CalibTOF + ;
 #pragma link C++ class o2::globaltracking::CollectCalibInfoTOF + ;
-#pragma link C++ class o2::globaltracking::TimeBracket + ;
 #pragma link C++ class o2::globaltracking::TrackLocTPC + ;
 #pragma link C++ class o2::globaltracking::TrackLocITS + ;
 #pragma link C++ class std::pair < o2::dataformats::EvIndex < int, int>, o2::dataformats::MatchInfoTOF> + ;

--- a/Detectors/GlobalTracking/src/GlobalTrackingLinkDef.h
+++ b/Detectors/GlobalTracking/src/GlobalTrackingLinkDef.h
@@ -20,6 +20,7 @@
 #pragma link C++ class o2::globaltracking::CollectCalibInfoTOF + ;
 #pragma link C++ class o2::globaltracking::TrackLocTPC + ;
 #pragma link C++ class o2::globaltracking::TrackLocITS + ;
+#pragma link C++ class o2::globaltracking::MatchITSTPCParams + ;
 
 #pragma link C++ class o2::globaltracking::ABDebugLink + ;
 #pragma link C++ class o2::globaltracking::ABDebugTrack + ;

--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -88,7 +88,7 @@ void MatchTPCITS::run()
 
   clear();
 
-  if (!prepareITSTracks() || !prepareTPCTracks() || !prepareFITInfo()) {
+  if (!prepareITSClusters() || !prepareITSTracks() || !prepareTPCTracks() || !prepareFITInfo()) {
     return;
   }
 
@@ -103,11 +103,13 @@ void MatchTPCITS::run()
     mTimerTot.Start(false);
   }
 
-  buildMatch2TrackTables();
-
   selectBestMatches();
 
   refitWinners();
+
+  if (isRunAfterBurner()) {
+    runAfterBurner();
+  }
 
 #ifdef _ALLOW_DEBUG_TREES_
   if (mDBGOut && isDebugFlag(WinnerMatchesTree)) {
@@ -137,8 +139,6 @@ void MatchTPCITS::clear()
   ///< clear results of previous TF reconstruction
   mMatchRecordsTPC.clear();
   mMatchRecordsITS.clear();
-  mMatchesTPC.clear();
-  mMatchesITS.clear();
   mWinnerChi2Refit.clear();
   mMatchedTracks.clear();
   if (mMCTruthON) {
@@ -183,6 +183,7 @@ void MatchTPCITS::init()
   mTPCTransform = std::move(fastTransform);
   mTPCClusterParam = std::make_unique<o2::gpu::GPUParam>();
   mTPCClusterParam->SetDefaults(o2::base::Propagator::Instance()->getNominalBz()); // TODO this may change
+  mFieldON = std::abs(o2::base::Propagator::Instance()->getNominalBz()) > 0.01;
 
   if (!mDPLIO) {
     attachInputTrees();
@@ -209,6 +210,10 @@ void MatchTPCITS::init()
   }
 #endif
 
+  if (isRunAfterBurner()) {
+    mRGHelper.init(); // prepare helper for TPC track / ITS clusters matching
+  }
+
   clear();
 
   mInitDone = true;
@@ -233,57 +238,59 @@ void MatchTPCITS::init()
 void MatchTPCITS::selectBestMatches()
 {
   ///< loop over match records and select the ones with best chi2
-  LOG(INFO) << "Selecting best matches for " << mMatchesTPC.size() << " TPC tracks";
-
+  LOG(INFO) << "Selecting best matches";
   int nValidated = 0, iter = 0;
 
   do {
     nValidated = 0;
-    for (int imtTPC = 0; imtTPC < mMatchesTPC.size(); imtTPC++) {
-      auto& tpcMatch = mMatchesTPC[imtTPC];
-      if (isDisabledTPC(tpcMatch))
+    int ntpc = mTPCWork.size(), nremaining = 0;
+    ;
+    for (int it = 0; it < ntpc; it++) {
+      auto& tTPC = mTPCWork[it];
+      if (isDisabledTPC(tTPC) || isValidatedTPC(tTPC)) {
         continue;
-      if (isValidatedTPC(tpcMatch))
-        continue;
-      if (validateTPCMatch(imtTPC)) {
+      }
+      nremaining++;
+      if (validateTPCMatch(it)) {
         nValidated++;
         continue;
       }
     }
-    printf("iter %d Validated %d of %d\n", iter, nValidated, int(mMatchesTPC.size()));
+    printf("iter %d Validated %d of %d remaining matches\n", iter, nValidated, nremaining);
     iter++;
   } while (nValidated);
 }
 
 //______________________________________________
-bool MatchTPCITS::validateTPCMatch(int mtID)
+bool MatchTPCITS::validateTPCMatch(int iTPC)
 {
-  auto& tpcMatch = mMatchesTPC[mtID];
-  auto& rcTPC = mMatchRecordsTPC[tpcMatch.first]; // best TPC->ITS match
-  if (rcTPC.nextRecID == Validated)
+  const auto& tTPC = mTPCWork[iTPC];
+  auto& rcTPC = mMatchRecordsTPC[tTPC.matchID]; // best TPC->ITS match
+  if (rcTPC.nextRecID == Validated) {
     return false; // RS do we need this
+  }
   // check if it is consistent with corresponding ITS->TPC match
-  auto& itsMatch = mMatchesITS[rcTPC.matchID];    // matchCand of partner ITS track
-  auto& rcITS = mMatchRecordsITS[itsMatch.first]; // best ITS->TPC match
-  if (rcTPC.nextRecID == Validated)
+  auto& tITS = mITSWork[rcTPC.partnerID];       //  partner ITS track
+  auto& rcITS = mMatchRecordsITS[tITS.matchID]; // best ITS->TPC match record
+  if (rcITS.nextRecID == Validated) {
     return false;              // RS do we need this ?
-  if (rcITS.matchID == mtID) { // is best matching TPC track for this ITS track actually mtID?
-
+  }
+  if (rcITS.partnerID == iTPC) { // is best matching TPC track for this ITS track actually iTPC?
     // unlink winner TPC track from all ITS candidates except winning one
     int nextTPC = rcTPC.nextRecID;
     while (nextTPC > MinusOne) {
       auto& rcTPCrem = mMatchRecordsTPC[nextTPC];
-      removeTPCfromITS(mtID, rcTPCrem.matchID); // remove references on mtID from ITS match=rcTPCrem.matchID
+      removeTPCfromITS(iTPC, rcTPCrem.partnerID); // remove references on mtID from ITS match=rcTPCrem.partnerID
       nextTPC = rcTPCrem.nextRecID;
     }
     rcTPC.nextRecID = Validated;
-    int itsWinID = rcTPC.matchID;
+    int itsWinID = rcTPC.partnerID;
 
     // unlink winner ITS match from all TPC matches using it
     int nextITS = rcITS.nextRecID;
     while (nextITS > MinusOne) {
       auto& rcITSrem = mMatchRecordsITS[nextITS];
-      removeITSfromTPC(itsWinID, rcITSrem.matchID); // remove references on itsWinID from TPC match=rcITSrem.matchID
+      removeITSfromTPC(itsWinID, rcITSrem.partnerID); // remove references on itsWinID from TPC match=rcITSrem.partnerID
       nextITS = rcITSrem.nextRecID;
     }
     rcITS.nextRecID = Validated;
@@ -293,10 +300,10 @@ bool MatchTPCITS::validateTPCMatch(int mtID)
 }
 
 //______________________________________________
-int MatchTPCITS::getNMatchRecordsTPC(const matchCand& tpcMatch) const
+int MatchTPCITS::getNMatchRecordsTPC(const TrackLocTPC& tTPC) const
 {
-  ///< get number of matching records for TPC track referring to this matchCand
-  int count = 0, recID = tpcMatch.first;
+  ///< get number of matching records for TPC track
+  int count = 0, recID = tTPC.matchID;
   while (recID > MinusOne) {
     recID = mMatchRecordsTPC[recID].nextRecID;
     count++;
@@ -305,10 +312,10 @@ int MatchTPCITS::getNMatchRecordsTPC(const matchCand& tpcMatch) const
 }
 
 //______________________________________________
-int MatchTPCITS::getNMatchRecordsITS(const matchCand& itsMatch) const
+int MatchTPCITS::getNMatchRecordsITS(const TrackLocITS& tTPC) const
 {
-  ///< get number of matching records for ITS track referring to this matchCand
-  int count = 0, recID = itsMatch.first;
+  ///< get number of matching records for ITS track
+  int count = 0, recID = tTPC.matchID;
   while (recID > MinusOne) {
     auto& itsRecord = mMatchRecordsITS[recID];
     recID = itsRecord.nextRecID;
@@ -371,15 +378,13 @@ void MatchTPCITS::attachInputTrees()
     LOG(FATAL) << "Did not find ITS clusters branch " << mITSClusterBranchName << " in the input tree";
   }
   mTreeITSClusters->SetBranchAddress(mITSClusterBranchName.data(), &mITSClustersArrayPtr);
-  LOG(INFO) << "Attached ITS clusters " << mITSClusterBranchName << " branch with " << mTreeITSClusters->GetEntries()
-            << " entries";
+  LOG(INFO) << "Attached ITS clusters " << mITSClusterBranchName << " branch with " << mTreeITSClusters->GetEntries() << " entries";
 
   if (!mTreeITSClusters->GetBranch(mITSClusterROFRecBranchName.data())) {
     LOG(FATAL) << "Did not find ITS clusters ROFRecords branch " << mITSClusterROFRecBranchName << " in the input tree";
   }
   mTreeITSClusters->SetBranchAddress(mITSClusterROFRecBranchName.data(), &mITSClusterROFRecPtr);
-  LOG(INFO) << "Attached ITS clusters ROFRec " << mITSClusterROFRecBranchName << " branch with "
-            << mTreeITSClusters->GetEntries() << " entries";
+  LOG(INFO) << "Attached ITS clusters ROFRec " << mITSClusterROFRecBranchName << " branch with " << mTreeITSClusters->GetEntries() << " entries";
 
   if (!mTPCClusterReader) {
     LOG(FATAL) << "TPC clusters reader is not set";
@@ -396,17 +401,17 @@ void MatchTPCITS::attachInputTrees()
   }
 
   // is there MC info available ?
-  if (mTreeITSTracks->GetBranch(mITSMCTruthBranchName.data())) {
+  if (mMCTruthON && mTreeITSTracks->GetBranch(mITSMCTruthBranchName.data())) {
     mTreeITSTracks->SetBranchAddress(mITSMCTruthBranchName.data(), &mITSTrkLabels);
     LOG(INFO) << "Found ITS Track MCLabels branch " << mITSMCTruthBranchName;
   }
   // is there MC info available ?
-  if (mTreeTPCTracks->GetBranch(mTPCMCTruthBranchName.data())) {
+  if (mMCTruthON && mTreeTPCTracks->GetBranch(mTPCMCTruthBranchName.data())) {
     mTreeTPCTracks->SetBranchAddress(mTPCMCTruthBranchName.data(), &mTPCTrkLabels);
     LOG(INFO) << "Found TPC Track MCLabels branch " << mTPCMCTruthBranchName;
   }
 
-  mMCTruthON = (mITSTrkLabels && mTPCTrkLabels);
+  mMCTruthON &= (mITSTrkLabels && mTPCTrkLabels && mTreeITSClusters->GetBranch(mITSClusMCTruthBranchName.data()));
 }
 
 //______________________________________________
@@ -422,7 +427,6 @@ bool MatchTPCITS::prepareTPCTracks()
   }
 
   int ntr = mTPCTracksArray.size();
-  mMatchesTPC.reserve(mMatchesTPC.size() + ntr);
   // number of records might be actually more than N tracks!
   mMatchRecordsTPC.reserve(mMatchRecordsTPC.size() + mMaxMatchCandidates * ntr);
 
@@ -486,11 +490,11 @@ bool MatchTPCITS::prepareTPCTracks()
     std::sort(indexCache.begin(), indexCache.end(), [this](int a, int b) {
       auto& trcA = mTPCWork[a];
       auto& trcB = mTPCWork[b];
-      return (trcA.timeBins.tmax - trcB.timeBins.tmax) < 0.;
+      return (trcA.timeBins.max() - trcB.timeBins.max()) < 0.;
     });
 
     // build array of 1st entries with tmax corresponding to each ITS ROF (or trigger)
-    float tmax = mTPCWork[indexCache.back()].timeBins.tmax;
+    float tmax = mTPCWork[indexCache.back()].timeBins.max();
     if (maxTimeBin < tmax) {
       maxTimeBin = tmax;
     }
@@ -502,7 +506,7 @@ bool MatchTPCITS::prepareTPCTracks()
     for (int itr = 0; itr < (int)indexCache.size(); itr++) {
       auto& trc = mTPCWork[indexCache[itr]];
 
-      while (trc.timeBins.tmax < mITSROFTimes[itsROF].tmin && itsROF < nITSROFs) {
+      while (trc.timeBins < mITSROFTimes[itsROF] && itsROF < nITSROFs) {
         itsROF++;
       }
       if (tbinStart[itsROF] == -1) {
@@ -518,17 +522,66 @@ bool MatchTPCITS::prepareTPCTracks()
 
   // create mapping from TPC time-bins to ITS ROFs
 
-  if (maxTimeBin < mITSROFTimes.back().tmax) {
-    maxTimeBin = mITSROFTimes.back().tmax;
+  if (mITSROFTimes.back() < maxTimeBin) {
+    maxTimeBin = mITSROFTimes.back().max();
   }
   int nb = int(maxTimeBin) + 1;
   mITSROFofTPCBin.resize(nb, -1);
   int itsROF = 0;
   for (int ib = 0; ib < nb; ib++) {
-    while (ib < mITSROFTimes[itsROF].tmin && itsROF < nITSROFs) {
+    while (ib < mITSROFTimes[itsROF].min() && itsROF < nITSROFs) {
       itsROF++;
     }
     mITSROFofTPCBin[ib] = itsROF;
+  }
+  return true;
+}
+
+//_____________________________________________________
+bool MatchTPCITS::prepareITSClusters()
+{
+  if (!mDPLIO) { // for input from tree read ROFrecords vector, in DPL IO mode the vector should be already attached
+    mTimerIO.Start(false);
+
+    std::vector<o2::itsmft::Cluster> bufferCl, *buffClPtr = &bufferCl;
+    MCLabCont bufferMC, *buffMCPtr = &bufferMC;
+    auto rofrPtr = &mITSClusterROFRecBuffer;
+    mTreeITSClusterROFRec->SetBranchAddress(mITSClusterROFRecBranchName.data(), &rofrPtr);
+    mTreeITSClusters->SetBranchAddress(mITSClusterBranchName.data(), &buffClPtr);
+    if (mMCTruthON) {
+      mTreeITSClusters->SetBranchAddress(mITSClusMCTruthBranchName.data(), &buffMCPtr);
+      mITSClsLabels = &mITSClsLabelsBuffer;
+    }
+    mTreeITSClusterROFRec->GetEntry(0); // keep clusters ROFRecs ready
+    int nROFs = mITSClusterROFRecBuffer.size();
+
+    // estimate total number of clusters and reserve the space
+    size_t nclTot = 0;
+    int lastROREnt = -1;
+    for (int ir = 0; ir < nROFs; ir++) {
+      o2::itsmft::ROFRecord& clROF = mITSClusterROFRecBuffer[ir];
+      clROF.getROFEntry().setIndex(nclTot); // linearize
+      clROF.getROFEntry().setEvent(0);      // fix entry, though it is not used
+      nclTot += clROF.getNROFEntries();
+    }
+    mITSClusterROFRec = &mITSClusterROFRecBuffer;
+    mTreeITSClusterROFRec->SetBranchAddress(mITSClusterROFRecBranchName.data(), nullptr); // detach
+
+    mITSClustersBuffer.reserve(nclTot);
+    for (int iev = 0; iev < mTreeITSClusters->GetEntries(); iev++) {
+      mTreeITSClusters->GetEntry(iev);
+      std::copy(bufferCl.begin(), bufferCl.end(), std::inserter(mITSClustersBuffer, mITSClustersBuffer.end()));
+      if (mMCTruthON) {
+        mITSClsLabelsBuffer.mergeAtBack(bufferMC);
+      }
+    }
+    LOG(INFO) << "Merged " << mTreeITSClusters->GetEntries() << " ITS cluster entries to single container";
+    mITSClustersArrayInp = &mITSClustersBuffer;
+    mTreeITSClusters->SetBranchAddress(mITSClusterBranchName.data(), nullptr); // detach input array
+    if (mMCTruthON) {
+      mTreeITSClusters->SetBranchAddress(mITSClusMCTruthBranchName.data(), nullptr); // detach input container
+    }
+    mTimerIO.Stop();
   }
   return true;
 }
@@ -551,8 +604,6 @@ bool MatchTPCITS::prepareITSTracks()
   }
   int nROFs = mITSTrackROFRec.size();
 
-  mMatchesITS.clear();
-
   if (!nROFs) {
     LOG(INFO) << "Empty TF";
     return false;
@@ -566,19 +617,25 @@ bool MatchTPCITS::prepareITSTracks()
     mITSLblWork.clear();
   }
 
+  // total N ITS clusters in TF
+  const auto& lastClROF = mITSClusterROFRec->back();
+  int nITSClus = lastClROF.getROFEntry().getIndex() + lastClROF.getNROFEntries();
+  mITSClustersFlags.clear();
+  mITSClustersFlags.resize(nITSClus, 0);
+
   for (int sec = o2::constants::math::NSectors; sec--;) {
     mITSSectIndexCache[sec].clear();
     mITSTimeBinStart[sec].clear();
     mITSTimeBinStart[sec].resize(nROFs, -1); // start of ITS work tracks in every sector
   }
   setStartIR(mITSTrackROFRec[0].getBCData());
+  if (!mDPLIO) { // in DPL IO mode the input tracks must be already attached
+    mITSTracksArray = gsl::span<const o2::its::TrackITS>(mITSTracksArrayPtr->data(), mITSTracksArrayPtr->size());
+    mITSTrackClusIdx = gsl::span<const int>(mITSTrackClusIdxPtr->data(), mITSTrackClusIdxPtr->size());
+  }
   for (int irof = 0; irof < nROFs; irof++) {
     const auto& rofRec = mITSTrackROFRec[irof];
-    // in case of the input from the tree make sure needed entry is loaded
-    if (!mDPLIO) { // in DPL IO mode the input tracks must be already attached
-      mITSTracksArray = gsl::span<const o2::its::TrackITS>(mITSTracksArrayPtr->data(), mITSTracksArrayPtr->size());
-      mITSTrackClusIdx = gsl::span<const int>(mITSTrackClusIdxPtr->data(), mITSTrackClusIdxPtr->size());
-    }
+    int cluROFOffset = mITSClusterROFRec[irof].getFirstEntry(); // clusters of this ROF start at this offset
     float tmn = intRecord2TPCTimeBin(rofRec.getBCData());     // ITS track min time in TPC time-bins
     mITSROFTimes.emplace_back(tmn, tmn + mITSROFrame2TPCBin); // ITS track min/max time in TPC time-bins
 
@@ -589,6 +646,11 @@ bool MatchTPCITS::prepareITSTracks()
     int trlim = rofRec.getFirstEntry() + rofRec.getNEntries();
     for (int it = rofRec.getFirstEntry(); it < trlim; it++) {
       const auto& trcOrig = mITSTracksArray[it];
+
+      if (isRunAfterBurner()) {
+        flagUsedITSClusters(trcOrig, cluROFOffset);
+      }
+
       if (trcOrig.getParamOut().getX() < 1.) {
         continue; // backward refit failed
       }
@@ -674,7 +736,6 @@ bool MatchTPCITS::prepareITSTracks()
     }
     */
   } // loop over tracks of single sector
-  mMatchesITS.reserve(mITSWork.size());
   mMatchRecordsITS.reserve(mITSWork.size() * mMaxMatchCandidates);
 
   return true;
@@ -744,7 +805,7 @@ void MatchTPCITS::doMatching(int sec)
     auto& trefTPC = mTPCWork[cacheTPC[itpc]];
     // estimate ITS 1st ROframe bin this track may match to: TPC track are sorted according to their
     // timeMax, hence the timeMax - MaxmNTPCBinsFullDrift are non-decreasing
-    int itsROBin = tpcTimeBin2ITSROFrame(trefTPC.timeBins.tmax - maxTDriftSafe);
+    int itsROBin = tpcTimeBin2ITSROFrame(trefTPC.timeBins.max() - maxTDriftSafe);
     if (itsROBin >= int(tbinStartITS.size())) { // time of TPC track exceeds the max time of ITS in the cache
       break;
     }
@@ -754,12 +815,12 @@ void MatchTPCITS::doMatching(int sec)
       auto& trefITS = mITSWork[cacheITS[iits]];
       const auto& timeITS = mITSROFTimes[trefITS.roFrame];
       // compare if the ITS and TPC tracks may overlap in time
-      if (trefTPC.timeBins.tmax < timeITS.tmin) {
+      if (trefTPC.timeBins < timeITS) {
         // since TPC tracks are sorted in timeMax and ITS tracks are sorted in timeMin
         // all following ITS tracks also will not match
         break;
       }
-      if (trefTPC.timeBins.tmin > timeITS.tmax) { // its bracket is fully before TPC bracket
+      if (trefTPC.timeBins > timeITS) { // its bracket precedes TPC bracket
         continue;
       }
       nCheckITSControl++;
@@ -794,7 +855,7 @@ void MatchTPCITS::doMatching(int sec)
         continue;
       }
       mTimerReg.Start(false);
-      registerMatchRecordTPC(trefITS, trefTPC, chi2); // register matching candidate
+      registerMatchRecordTPC(cacheITS[iits], cacheTPC[itpc], chi2); // register matching candidate
       mTimerReg.Stop();
       nMatchesControl++;
     }
@@ -806,17 +867,16 @@ void MatchTPCITS::doMatching(int sec)
 }
 
 //______________________________________________
-void MatchTPCITS::suppressMatchRecordITS(int matchITSID, int matchTPCID)
+void MatchTPCITS::suppressMatchRecordITS(int itsID, int tpcID)
 {
-  ///< suppress the reference on the matchCand with id=matchTPCID in
-  ///< the list of matches recorded by for matchCand with id matchITSID
-  auto& itsMatch = mMatchesITS[matchITSID];
-  int topID = MinusOne, recordID = itsMatch.first; // 1st entry in mMatchRecordsITS
+  ///< suppress the reference on the tpcID in the list of matches recorded for itsID
+  auto& tITS = mITSWork[itsID];
+  int topID = MinusOne, recordID = tITS.matchID;   // 1st entry in mMatchRecordsITS
   while (recordID > MinusOne) {                    // navigate over records for given ITS track
-    if (mMatchRecordsITS[recordID].matchID == matchTPCID) {
+    if (mMatchRecordsITS[recordID].partnerID == tpcID) {
       // unlink this record, connecting its child to its parrent
       if (topID < 0) {
-        itsMatch.first = mMatchRecordsITS[recordID].nextRecID;
+        tITS.matchID = mMatchRecordsITS[recordID].nextRecID;
       } else {
         mMatchRecordsITS[topID].nextRecID = mMatchRecordsITS[recordID].nextRecID;
       }
@@ -828,21 +888,19 @@ void MatchTPCITS::suppressMatchRecordITS(int matchITSID, int matchTPCID)
 }
 
 //______________________________________________
-bool MatchTPCITS::registerMatchRecordTPC(TrackLocITS& tITS, TrackLocTPC& tTPC, float chi2)
+bool MatchTPCITS::registerMatchRecordTPC(int iITS, int iTPC, float chi2)
 {
   ///< record matching candidate, making sure that number of ITS candidates per TPC track, sorted
   ///< in matching chi2 does not exceed allowed number
-
-  auto& mtcTPC = getTPCMatchEntry(tTPC);               // get matchCand structure of this TPC track, create if none
-  int nextID = mtcTPC.first;                           // get 1st matchRecord this matchCand refers to
-  if (nextID < 0) {                                    // no matches yet, just add new record
-    registerMatchRecordITS(tITS, tTPC.matchID, chi2);  // register matchCand entry in the ITS records
-    mtcTPC.first = mMatchRecordsTPC.size();            // new record will be added in the end
-    mMatchRecordsTPC.emplace_back(tITS.matchID, chi2); // create new record with empty reference on next match
+  auto& tTPC = mTPCWork[iTPC];                 // get matchRecord structure of this TPC track, create if none
+  if (tTPC.matchID < 0) {                      // no matches yet, just add new record
+    registerMatchRecordITS(iITS, iTPC, chi2);  // register TPC track in the ITS records
+    tTPC.matchID = mMatchRecordsTPC.size();    // new record will be added in the end
+    mMatchRecordsTPC.emplace_back(iITS, chi2); // create new record with empty reference on next match
     return true;
   }
 
-  int count = 0, topID = MinusOne;
+  int count = 0, nextID = tTPC.matchID, topID = MinusOne;
   do {
     auto& nextMatchRec = mMatchRecordsTPC[nextID];
     count++;
@@ -851,9 +909,9 @@ bool MatchTPCITS::registerMatchRecordTPC(TrackLocITS& tITS, TrackLocTPC& tTPC, f
         break; // will insert in front of nextID
       } else { // max number of candidates reached, will overwrite the last one
         nextMatchRec.chi2 = chi2;
-        suppressMatchRecordITS(nextMatchRec.matchID, tTPC.matchID); // flag as disabled the overriden ITS match
-        registerMatchRecordITS(tITS, tTPC.matchID, chi2);           // register matchCand entry in the ITS records
-        nextMatchRec.matchID = tITS.matchID;                        // reuse the record of suppressed ITS match to store better one
+        suppressMatchRecordITS(nextMatchRec.partnerID, iTPC); // flag as disabled the overriden ITS match
+        registerMatchRecordITS(iITS, tTPC.matchID, chi2);     // register TPC track entry in the ITS records
+        nextMatchRec.partnerID = iITS;                        // reuse the record of suppressed ITS match to store better one
         return true;
       }
     }
@@ -866,18 +924,18 @@ bool MatchTPCITS::registerMatchRecordTPC(TrackLocITS& tITS, TrackLocTPC& tTPC, f
   // existing candidate. Otherwise, we need to add new entry
   if (count < mMaxMatchCandidates) {
     if (topID < 0) {                                                       // the new match is top candidate
-      topID = mtcTPC.first = mMatchRecordsTPC.size();                      // register new record as top one
+      topID = tTPC.matchID = mMatchRecordsTPC.size();                      // register new record as top one
     } else {                                                               // there are better candidates
       topID = mMatchRecordsTPC[topID].nextRecID = mMatchRecordsTPC.size(); // register to his parent
     }
     // nextID==-1 will mean that the while loop run over all candidates->the new one is the worst (goes to the end)
-    registerMatchRecordITS(tITS, tTPC.matchID, chi2);          // register matchCand entry in the ITS records
-    mMatchRecordsTPC.emplace_back(tITS.matchID, chi2, nextID); // create new record with empty reference on next match
+    registerMatchRecordITS(iITS, tTPC.matchID, chi2);  // register TPC track in the ITS records
+    mMatchRecordsTPC.emplace_back(iITS, chi2, nextID); // create new record with empty reference on next match
     // make sure that after addition the number of candidates don't exceed allowed number
     count++;
     while (nextID > MinusOne) {
       if (count > mMaxMatchCandidates) {
-        suppressMatchRecordITS(mMatchRecordsTPC[nextID].matchID, tTPC.matchID);
+        suppressMatchRecordITS(mMatchRecordsTPC[nextID].partnerID, iTPC);
         // exclude nextID record, w/o changing topID (which becomes the last record)
         nextID = mMatchRecordsTPC[topID].nextRecID = mMatchRecordsTPC[nextID].nextRecID;
         continue;
@@ -893,27 +951,27 @@ bool MatchTPCITS::registerMatchRecordTPC(TrackLocITS& tITS, TrackLocTPC& tTPC, f
 }
 
 //______________________________________________
-void MatchTPCITS::registerMatchRecordITS(TrackLocITS& tITS, int matchTPCID, float chi2)
+void MatchTPCITS::registerMatchRecordITS(int iITS, int iTPC, float chi2)
 {
-  ///< register TPC match in ITS match records, ordering then in chi2
-  auto& itsMatch = getITSMatchEntry(tITS); // if needed, create new entry
-  int nextRecord = itsMatch.first;         // entry of 1st match record in mMatchRecordsITS
+  ///< register TPC match in ITS tracks match records, ordering then in chi2
+  auto& tITS = mITSWork[iITS];
   int idnew = mMatchRecordsITS.size();
-  mMatchRecordsITS.emplace_back(matchTPCID, chi2); // associate index of matchCand with this record
-  if (nextRecord < 0) {                            // this is the 1st match for this TPC track
-    itsMatch.first = idnew;
+  mMatchRecordsITS.emplace_back(iTPC, chi2); // associate iTPC with this record
+  if (tITS.matchID < 0) {
+    tITS.matchID = idnew;
     return;
   }
   // there are other matches for this ITS track, insert the new record preserving chi2 order
   // navigate till last record or the one with worse chi2
-  int topID = MinusOne;
+  int topID = MinusOne, nextRecord = tITS.matchID;
+  mMatchRecordsITS.emplace_back(iTPC, chi2); // associate iTPC with this record
   auto& newRecord = mMatchRecordsITS.back();
   do {
     auto& recITS = mMatchRecordsITS[nextRecord];
     if (chi2 < recITS.chi2) {           // insert before this one
       newRecord.nextRecID = nextRecord; // new one will refer to old one it overtook
       if (topID < 0) {
-        itsMatch.first = idnew; // the new one is the best match, the matchCand will refer to it
+        tITS.matchID = idnew; // the new one is the best match, track will refer to it
       } else {
         mMatchRecordsITS[topID].nextRecID = idnew; // new record will follow existing better one
       }
@@ -1001,15 +1059,17 @@ int MatchTPCITS::compareTPCITSTracks(const TrackLocITS& tITS, const TrackLocTPC&
 void MatchTPCITS::printCandidatesTPC() const
 {
   ///< print mathing records
-
-  printf("\n\nPrinting all %zu TPC -> ITS matches\n", mMatchesTPC.size());
-  for (const auto& tpcMatch : mMatchesTPC) {
-    printf("*** trackTPC# %6d : Ncand = %d\n", tpcMatch.sourceID, getNMatchRecordsTPC(tpcMatch));
-    int count = 0, recID = tpcMatch.first;
+  int ntpc = mTPCWork.size();
+  printf("\n\nPrinting all TPC -> ITS matches for %d TPC tracks\n", ntpc);
+  for (int i = 0; i < ntpc; i++) {
+    const auto& tTPC = mTPCWork[i];
+    int nm = getNMatchRecordsTPC(tTPC);
+    printf("*** trackTPC#%6d %6d : Ncand = %d\n", i, tTPC.sourceID, nm);
+    int count = 0, recID = tTPC.matchID;
     while (recID > MinusOne) {
       const auto& rcTPC = mMatchRecordsTPC[recID];
-      const auto& itsMatch = mMatchesITS[rcTPC.matchID];
-      printf("  * cand %2d : ITS track %6d Chi2: %.2f\n", count, itsMatch.sourceID, rcTPC.chi2);
+      const auto& tITS = mITSWork[rcTPC.partnerID];
+      printf("  * cand %2d : ITS track %6d Chi2: %.2f\n", count, tITS.sourceID, rcTPC.chi2);
       count++;
       recID = rcTPC.nextRecID;
     }
@@ -1020,40 +1080,19 @@ void MatchTPCITS::printCandidatesTPC() const
 void MatchTPCITS::printCandidatesITS() const
 {
   ///< print mathing records
+  int nits = mITSWork.size();
+  printf("\n\nPrinting all ITS -> TPC matches for %d ITS tracks\n", nits);
 
-  printf("\n\nPrinting all %zu ITS -> TPC matches\n", mMatchesITS.size());
-  for (const auto& itsMatch : mMatchesITS) {
-    printf("*** trackITS# %6d : Ncand = %d\n", itsMatch.sourceID, getNMatchRecordsITS(itsMatch));
-    int count = 0, recID = itsMatch.first;
+  for (int i = 0; i < nits; i++) {
+    const auto& tITS = mITSWork[i];
+    printf("*** trackITS#%6d %6d(%4d) : Ncand = %d\n", i, tITS.sourceID, getNMatchRecordsITS(tITS));
+    int count = 0, recID = tITS.matchID;
     while (recID > MinusOne) {
       const auto& rcITS = mMatchRecordsITS[recID];
-      const auto& tpcMatch = mMatchesTPC[rcITS.matchID];
-      printf("  * cand %2d : TPC track %6d Chi2: %.2f\n", count, tpcMatch.sourceID, rcITS.chi2);
+      const auto& tTPC = mTPCWork[rcITS.partnerID];
+      printf("  * cand %2d : TPC track %6d Chi2: %.2f\n", count, tTPC.sourceID, rcITS.chi2);
       count++;
       recID = rcITS.nextRecID;
-    }
-  }
-}
-
-//______________________________________________
-void MatchTPCITS::buildMatch2TrackTables()
-{
-  ///< refer each match to corrsponding track
-  mITSMatch2Track.clear();
-  mITSMatch2Track.resize(mMatchesITS.size(), MinusOne);
-  for (int i = 0; i < int(mITSWork.size()); i++) {
-    const auto& its = mITSWork[i];
-    if (its.matchID > MinusOne) {
-      mITSMatch2Track[its.matchID] = i;
-    }
-  }
-
-  mTPCMatch2Track.clear();
-  mTPCMatch2Track.resize(mMatchesTPC.size(), MinusOne);
-  for (int i = 0; i < int(mTPCWork.size()); i++) {
-    const auto& tpc = mTPCWork[i];
-    if (tpc.matchID > MinusOne) {
-      mTPCMatch2Track[tpc.matchID] = i;
     }
   }
 }
@@ -1201,17 +1240,31 @@ void MatchTPCITS::print() const
 void MatchTPCITS::refitWinners()
 {
   ///< refit winning tracks
+  bool loopInITS = false; //true;  // TODO decide final loop
 
   mTimerRefit.Start(false);
 
   LOG(INFO) << "Refitting winner matches";
   mWinnerChi2Refit.resize(mITSWork.size(), -1.f);
-  for (int iITS = 0; iITS < mITSWork.size(); iITS++) {
-    if (!refitTrackTPCITS(iITS)) {
-      continue;
+  if (loopInITS) {
+    int iTPC = 0; // will be ignored
+    for (int iITS = 0; iITS < (int)mITSWork.size(); iITS++) {
+      if (!refitTrackTPCITSloopITS(iITS, iTPC)) {
+        continue;
+      }
+      mWinnerChi2Refit[iITS] = mMatchedTracks.back().getChi2Refit();
     }
-    mWinnerChi2Refit[iITS] = mMatchedTracks.back().getChi2Refit();
+  } else {
+    int iITS;
+    for (int iTPC = 0; iTPC < (int)mTPCWork.size(); iTPC++) {
+      if (!refitTrackTPCITSloopTPC(iTPC, iITS)) {
+        continue;
+      }
+      mWinnerChi2Refit[iITS] = mMatchedTracks.back().getChi2Refit();
+    }
   }
+  /*
+  */
   // flush last tracks
   if (mMatchedTracks.size() && mOutputTree) {
     mOutputTree->Fill();
@@ -1220,7 +1273,7 @@ void MatchTPCITS::refitWinners()
 }
 
 //______________________________________________
-bool MatchTPCITS::refitTrackTPCITS(int iITS)
+bool MatchTPCITS::refitTrackTPCITSloopITS(int iITS, int& iTPC)
 {
   ///< refit in inward direction the pair of TPC and ITS tracks
 
@@ -1228,12 +1281,11 @@ bool MatchTPCITS::refitTrackTPCITS(int iITS)
   const int matCorr = 1;     // material correction method
 
   const auto& tITS = mITSWork[iITS];
-  if (tITS.matchID < 0 || isDisabledITS(mMatchesITS[tITS.matchID])) {
+  if (isDisabledITS(tITS)) {
     return false; // no match
   }
-  const auto& itsMatch = mMatchesITS[tITS.matchID];
-  const auto& itsMatchRec = mMatchRecordsITS[itsMatch.first];
-  int iTPC = mTPCMatch2Track[itsMatchRec.matchID];
+  const auto& itsMatchRec = mMatchRecordsITS[tITS.matchID];
+  iTPC = itsMatchRec.partnerID;
   const auto& tTPC = mTPCWork[iTPC];
   const auto& itsTrOrig = mITSTracksArray[tITS.sourceID]; // currently we store clusterIDs in the track
 
@@ -1416,6 +1468,613 @@ bool MatchTPCITS::loadTPCClusters()
   return true;
 }
 
+//______________________________________________
+bool MatchTPCITS::refitTrackTPCITSloopTPC(int iTPC, int& iITS)
+{
+  ///< refit in inward direction the pair of TPC and ITS tracks
+
+  const float maxStep = 2.f; // max propagation step (TODO: tune)
+  const int matCorr = 1;     // material correction method
+
+  const auto& tTPC = mTPCWork[iTPC];
+  if (isDisabledTPC(tTPC)) {
+    return false; // no match
+  }
+  const auto& tpcMatchRec = mMatchRecordsTPC[tTPC.matchID];
+  iITS = tpcMatchRec.partnerID;
+  const auto& tITS = mITSWork[iITS];
+  const auto& itsTrOrig = mITSTracksArray[tITS.sourceID];
+
+  mMatchedTracks.emplace_back(tTPC, tITS); // create a copy of TPC track at xRef
+  auto& trfit = mMatchedTracks.back();
+  // in continuos mode the Z of TPC track is meaningless, unless it is CE crossing
+  // track (currently absent, TODO)
+  if (!mCompareTracksDZ) {
+    trfit.setZ(tITS.getZ()); // fix the seed Z
+  }
+  auto dzCorr = trfit.getZ() - tTPC.getZ();
+  float deltaT = dzCorr * mZ2TPCBin; // time correction in time-bins
+
+  // refit TPC track inward into the ITS
+  int nclRefit = 0, ncl = itsTrOrig.getNumberOfClusters();
+  float chi2 = 0.f;
+  auto geom = o2::its::GeometryTGeo::Instance();
+  auto propagator = o2::base::Propagator::Instance();
+  // NOTE: the ITS cluster index is stored wrt 1st cluster of relevant ROF, while here we extract clusters from the
+  // buffer for the whole TF. Therefore, we should shift the index by the entry of the ROF's 1st cluster in the global cluster buffer
+  int clusIndOffs = mITSClusterROFRec[tITS.roFrame].getFirstEntry();
+  int clEntry = itsTrOrig.getFirstClusterEntry();
+  for (int icl = 0; icl < ncl; icl++) {
+    const auto& clus = mITSClustersArrayInp[clusIndOffs + mITSTrackClusIdx[clEntry++];
+    float alpha = geom->getSensorRefAlpha(clus.getSensorID()), x = clus.getX();
+    if (!trfit.rotate(alpha) ||
+        // note: here we also calculate the L,T integral (in the inward direction, but this is irrelevant)
+        // note: we should eventually use TPC pid in the refit (TODO)
+        // note: since we are at small R, we can use field BZ component at origin rather than 3D field
+        // !propagator->PropagateToXBxByBz(trfit, x, o2::constants::physics::MassPionCharged,
+        !propagator->propagateToX(trfit, x, propagator->getNominalBz(), o2::constants::physics::MassPionCharged,
+                                  MaxSnp, maxStep, matCorr, &trfit.getLTIntegralOut())) {
+      break;
+    }
+    chi2 += trfit.getPredictedChi2(static_cast<const o2::BaseCluster<float>&>(clus));
+    if (!trfit.update(static_cast<const o2::BaseCluster<float>&>(clus))) {
+      break;
+    }
+    nclRefit++;
+  }
+  if (nclRefit != ncl) {
+    printf("FAILED after ncl=%d\n", nclRefit);
+    printf("its was:  ");
+    tITS.print();
+    printf("tpc was:  ");
+    tTPC.print();
+    mMatchedTracks.pop_back(); // destroy failed track
+    return false;
+  }
+
+  // we need to update the LTOF integral by the distance to the "primary vertex"
+  const Point3D<float> vtxDummy; // at the moment using dummy vertex: TODO use MeanVertex constraint instead
+  if (!propagator->propagateToDCA(vtxDummy, trfit, propagator->getNominalBz(), o2::constants::physics::MassPionCharged,
+                                  maxStep, matCorr, &trfit.getLTIntegralOut())) {
+    LOG(ERROR) << "LTOF integral might be incorrect";
+  }
+
+  /// precise time estimate
+  const auto& tpcTrOrig = mTPCTracksArray[tTPC.source.getIndex()];
+  float timeTB = tpcTrOrig.getTime0() - mNTPCBinsFullDrift;
+  if (tpcTrOrig.hasASideClustersOnly()) {
+    timeTB += deltaT;
+  } else if (tpcTrOrig.hasCSideClustersOnly()) {
+    timeTB -= deltaT;
+  } else {
+    // TODO : special treatment of tracks crossing the CE
+  }
+  // convert time in timebins to time in microseconds
+  float time = timeTB * mTPCTBinMUS;
+  // estimate the error on time
+  float timeErr = std::sqrt(tITS.getSigmaZ2() + tTPC.getSigmaZ2()) * mTPCVDrift0Inv;
+
+  // outward refit
+  auto& tracOut = trfit.getParamOut(); // this track is already at the matching reference X
+  {
+    int icl = tpcTrOrig.getNClusterReferences() - 1;
+    uint8_t sector, prevsector, row, prevrow;
+    uint32_t clusterIndexInRow;
+    std::array<float, 2> clsYZ;
+    std::array<float, 3> clsCov = {};
+    float clsX;
+
+    const auto& cl = tpcTrOrig.getCluster(mTPCTrackClusIdx, icl, *mTPCClusterIdxStruct, sector, row);
+    mTPCTransform->Transform(sector, row, cl.getPad(), cl.getTime() - timeTB, clsX, clsYZ[0], clsYZ[1]);
+    // rotate to 1 cluster's sector
+    if (!tracOut.rotate(o2::utils::Sector2Angle(sector % 18))) {
+      LOG(WARNING) << "Rotation to sector " << int(sector % 18) << " failed";
+      mMatchedTracks.pop_back(); // destroy failed track
+      return false;
+    }
+    // TODO: consider propagating in empty space till TPC entrance in large step, and then in more detailed propagation with mat. corrections
+
+    // propagate to 1st cluster X
+    if (!propagator->PropagateToXBxByBz(tracOut, clsX, o2::constants::physics::MassPionCharged, MaxSnp, 10., 1, &trfit.getLTIntegralOut())) {
+      LOG(WARNING) << "Propagation to 1st cluster at X=" << clsX << " failed, Xtr=" << tracOut.getX() << " snp=" << tracOut.getSnp();
+      mMatchedTracks.pop_back(); // destroy failed track
+      return false;
+    }
+    //
+    mTPCClusterParam->GetClusterErrors2(row, clsYZ[1], tracOut.getSnp(), tracOut.getTgl(), clsCov[0], clsCov[2]);
+    //
+    float chi2Out = tracOut.getPredictedChi2(clsYZ, clsCov);
+    if (!tracOut.update(clsYZ, clsCov)) {
+      LOG(WARNING) << "Update failed at 1st cluster, chi2 =" << chi2Out;
+      mMatchedTracks.pop_back(); // destroy failed track
+      return false;
+    }
+    prevrow = row;
+    prevsector = sector;
+
+    for (; icl--;) {
+      const auto& cl = tpcTrOrig.getCluster(mTPCTrackClusIdx, icl, *mTPCClusterIdxStruct, sector, row);
+      if (row <= prevrow) {
+        LOG(WARNING) << "New row/sect " << int(row) << '/' << int(sector) << " is <= the previous " << int(prevrow)
+                     << '/' << int(prevsector) << " TrackID: " << tTPC.source.getIndex() << " Pt:" << tracOut.getPt();
+        if (row < prevrow) {
+          break;
+        } else {
+          continue; // just skip duplicate clusters
+        }
+      }
+      prevrow = row;
+      mTPCTransform->Transform(sector, row, cl.getPad(), cl.getTime() - timeTB, clsX, clsYZ[0], clsYZ[1]);
+      if (prevsector != sector) {
+        prevsector = sector;
+        if (!tracOut.rotate(o2::utils::Sector2Angle(sector % 18))) {
+          LOG(WARNING) << "Rotation to sector " << int(sector % 18) << " failed";
+          mMatchedTracks.pop_back(); // destroy failed track
+          return false;
+        }
+      }
+      if (!propagator->PropagateToXBxByBz(tracOut, clsX, o2::constants::physics::MassPionCharged, MaxSnp,
+                                          10., 0, &trfit.getLTIntegralOut())) { // no material correction!
+        LOG(INFO) << "Propagation to cluster " << icl << " (of " << tpcTrOrig.getNClusterReferences() << ") at X="
+                  << clsX << " failed, Xtr=" << tracOut.getX() << " snp=" << tracOut.getSnp() << " pT=" << tracOut.getPt();
+        mMatchedTracks.pop_back(); // destroy failed track
+        return false;
+      }
+      chi2Out += tracOut.getPredictedChi2(clsYZ, clsCov);
+      if (!tracOut.update(clsYZ, clsCov)) {
+        LOG(WARNING) << "Update failed at cluster " << icl << ", chi2 =" << chi2Out;
+        mMatchedTracks.pop_back(); // destroy failed track
+        return false;
+      }
+    }
+    // propagate to the outer edge of the TPC, TODO: check outer radius
+    // Note: it is allowed to not reach the requested radius
+    propagator->PropagateToXBxByBz(tracOut, XTPCOuterRef, o2::constants::physics::MassPionCharged, MaxSnp,
+                                   10., 1, &trfit.getLTIntegralOut());
+
+    //    LOG(INFO) << "Refitted with chi2 = " << chi2Out;
+  }
+
+  trfit.setChi2Match(tpcMatchRec.chi2);
+  trfit.setChi2Refit(chi2);
+  trfit.setTimeMUS(time, timeErr);
+  trfit.setRefTPC(tTPC.source);
+  trfit.setRefITS(tITS.source);
+
+  if (mMCTruthON) { // store MC info
+    mOutITSLabels.emplace_back(mITSLblWork[iITS]);
+    mOutTPCLabels.emplace_back(mTPCLblWork[iTPC]);
+  }
+
+  //  trfit.print(); // DBG
+
+  return true;
+}
+
+//>>============================= AfterBurner for TPC-track / ITS cluster matching ===================>>
+//______________________________________________
+int MatchTPCITS::prepareTPCTracksAfterBurner()
+{
+  ///< select TPC tracks to be considered in afterburner
+  mTPCABIndexCache.clear();
+  mTPCABTimeBinStart.clear();
+  const auto& outerLr = mRGHelper.layers.back();
+  auto propagator = o2::base::Propagator::Instance();
+
+  for (int iTPC = 0; iTPC < (int)mTPCWork.size(); iTPC++) {
+    auto& tTPC = mTPCWork[iTPC];
+    if (isDisabledTPC(tTPC)) {
+      // Popagate to the vicinity of the out layer. Note: the Z of the track might be uncertain,
+      // in this case the material corrections will be correct only in the limit of their uniformity in Z,
+      // which should be good assumption....
+      float xTgt;
+      if (!tTPC.getXatLabR(outerLr.rRange.max(), xTgt, propagator->getNominalBz(), o2::track::DirInward) ||
+          !propagator->PropagateToXBxByBz(tTPC, xTgt, o2::constants::physics::MassPionCharged, MaxSnp, 2., 0)) {
+        continue;
+      }
+      mTPCABIndexCache.push_back(iTPC);
+    }
+  }
+  // sort tracks according to their timeMin
+  LOG(INFO) << "Sorting " << mTPCABIndexCache.size() << " selected TPC tracks for AfterBurner in tMin";
+  std::sort(mTPCABIndexCache.begin(), mTPCABIndexCache.end(), [this](int a, int b) {
+    auto& trcA = mTPCWork[a];
+    auto& trcB = mTPCWork[b];
+    return (trcA.timeBins.min() - trcB.timeBins.min()) < 0.;
+  });
+
+  return mTPCABIndexCache.size();
+}
+
+//______________________________________________
+int MatchTPCITS::prepareInteractionTimes()
+{
+  // guess interaction times from various sources and relate with ITS rofs
+  const float T0UncertaintyTB = 0.5 / (1e3 * mTPCTBinMUS); // assumed T0 time uncertainty (~0.5ns) in TPC timeBins
+  mInteractions.clear();
+  int nITSROFs = mITSROFTimes.size(), rof = 0;
+  if (mFITInfoInp) {
+    for (const auto& ft : *mFITInfoInp) {
+      if (!ft.isValidTime(o2::t0::RecPoints::TimeMean)) {
+        continue;
+      }
+      auto fitTime = intRecord2TPCTimeBin(ft.getInteractionRecord()); // FIT time in TPC timebins
+      // find corresponding ITS ROF, works both in cont. and trigg. modes (ignore T0 MeanTime within the BC)
+      for (; rof < nITSROFs; rof++) {
+        if (mITSROFTimes[rof] < fitTime) {
+          continue;
+        }
+        if (fitTime >= mITSROFTimes[rof].min()) { // belongs to this ROF
+          mInteractions.emplace_back(ft.getInteractionRecord(), fitTime, T0UncertaintyTB, rof, o2::detectors::DetID::T0);
+        }
+        break; // this or next ITSrof in time is > fitTime
+      }
+    }
+  }
+  return mInteractions.size();
+}
+
+//______________________________________________
+void MatchTPCITS::runAfterBurner()
+{
+  const float MinTBToCleanCache = 600.; // clean ITS clusters cache when they precede TPC track by this amount of timeBins
+  int nIntCand = prepareInteractionTimes();
+  int nTPCCand = prepareTPCTracksAfterBurner();
+  LOG(INFO) << "AfterBurner will check " << nIntCand << " interaction candindates for " << nTPCCand << " TPC tracks";
+  if (!nIntCand || !nTPCCand) {
+    return;
+  }
+  int iC = 0, iCRes;                         // interaction candindate to consider and result of its time-bracket comparison to TPC track
+  int iCClean = iC;                          // id of the next candidate whose cache to be cleaned
+  for (int itr = 0; itr < nTPCCand; itr++) { // TPC track indices are sorted in tMin
+    const auto& tTPC = mTPCWork[mTPCABIndexCache[itr]];
+    // find 1st interaction candidate compatible with time brackets of this track
+    while ((iCRes = tTPC.timeBins.isOutside(mInteractions[iC].timeBins)) < 0 && ++iC < nIntCand) { // interaction precedes the track time-bracket
+      // check if some cached cluster references can be released, they will be necessarily in front slots of the mITSChipClustersRefs
+      while (iCClean < iC && mInteractions[iC].timeBins.min() - mInteractions[iCClean].timeBins.max() > MinTBToCleanCache) {
+        LOG(INFO) << "CAN REMOVE CACHE FOR " << iCClean << " curent IC=" << iC;
+        while (mInteractions[iCClean].clRefPtr == &mITSChipClustersRefs.front()) {
+          LOG(INFO) << "Reset cache pointer" << mInteractions[iCClean].clRefPtr << " for ICClean=" << iCClean;
+          mInteractions[iCClean++].clRefPtr = nullptr;
+        }
+        LOG(INFO) << "Reset cache slot " << &mITSChipClustersRefs.front();
+        mITSChipClustersRefs.pop_front();
+      }
+    }
+    if (iCRes == 0) {
+      int iCC = iC; // check all interaction candidates matching to this this TPC track
+      do {
+        if (!mInteractions[iCC].clRefPtr) { // if not done yet, fill sorted cluster references for interaction candidate
+          mInteractions[iCC].clRefPtr = &mITSChipClustersRefs.emplace_back();
+          fillClustersForAfterBurner(mITSChipClustersRefs.back(), mInteractions[iCC].rofITS);
+          // tst
+          int ncl = mITSChipClustersRefs.back().clusterID.size();
+          printf("loaded %d clusters at cache at %p\n", ncl, mInteractions[iCC].clRefPtr);
+        }
+
+        auto lbl = mTPCLblWork[mTPCABIndexCache[itr]];
+        runAfterBurner(tTPC, mInteractions[iCC]);
+        lbl.print();
+      } while (++iCC < nIntCand && !tTPC.timeBins.isOutside(mInteractions[iCC].timeBins));
+    } else if (iCRes > 0) {
+      continue; // TPC track precedes the intercation (means orphan track?), no need to check it
+    } else {
+      LOG(INFO) << "All interation candidates precede track " << itr << " [" << tTPC.timeBins.min() << ":" << tTPC.timeBins.max() << "]";
+      break; // all interaction candidates precede TPC track
+    }
+  }
+}
+
+//______________________________________________
+bool MatchTPCITS::runAfterBurner(const TrackLocTPC& tTPC, InteractionCandidate& cand)
+{
+  // Try to match TPC tracks to ITS clusters, assuming that it comes from given interaction candidate
+  // The track is already propagated to the outer R of the outermost layer
+
+  LOG(INFO) << "Check track TPC mtc=" << tTPC.matchID
+            << " [" << tTPC.timeBins.min() << ":" << tTPC.timeBins.max() << "] for interaction "
+            << " [" << cand.timeBins.min() << ":" << cand.timeBins.max() << "]";
+
+  const int maxMissed = 0;
+  const float nSigmaZ = 5., nSigmaY = 5.;
+  const float YErr2Extra = 0.1 * 0.1;
+  const auto& clRefs = *static_cast<ITSChipClustersRefs*>(cand.clRefPtr);
+  constexpr int NZSpan = 3;
+  const int chipIDZSpan[NZSpan] = { -1, 1, 0 }; // check chips in this nieghbourhood
+  //
+  auto tpcTrOrig = (*mTPCTracksArrayInp)[tTPC.source.getIndex()];
+  o2::track::TrackParCov trc(tTPC); // operate with track copy
+  float driftErr = correctTPCTrack(trc, tTPC, cand);
+
+  auto propagator = o2::base::Propagator::Instance();
+  float sna, csa; // circle parameters for B ON data
+  o2::utils::CircleXY trcCircle;
+  o2::utils::IntervalXY trcLinPar; // line parameters fpr B OFF data
+  int nMissed = 0;
+  for (int ilr = mRGHelper.getNLayers(); ilr--;) {
+    if (ilr != 6)
+      break;
+    const auto& lr = mRGHelper.layers[ilr];
+    float zDRStep = -trc.getTgl() * lr.rRange.delta(); // approximate Z span when going from layer rMin to rMax
+    float errZ = std::sqrt(trc.getSigmaZ2());
+    if (lr.zRange.isOutside(trc.getZ(), nSigmaZ * errZ + driftErr + std::abs(zDRStep))) {
+      nMissed++;
+      printf("Lr %d (skip %d) missed by Z = %.2f + %.3f\n", ilr, nMissed, trc.getZ(), nSigmaZ * errZ + driftErr + std::abs(zDRStep));
+      if (nMissed > maxMissed) {
+        break;
+      }
+      continue;
+    }
+    // approximate errors
+    float errY = std::sqrt(trc.getSigmaY2() + YErr2Extra), errYFrac = errY * mRGHelper.ladderWidthInv(), errPhi = errY * lr.rInv;
+    float xCurr, yCurr, phi;
+    if (mFieldON) {
+      trc.getCircleParams(propagator->getNominalBz(), trcCircle, sna, csa);
+    } else {
+      trc.getLineParams(trcLinPar, sna, csa);
+    }
+    o2::utils::rotateZ(trc.getX(), trc.getY(), xCurr, yCurr, sna, csa);
+    phi = std::atan2(yCurr, xCurr);
+    // find approximate ladder and chip_in_ladder corresponding to this track extrapolation
+    int nLad2Check = 0, ladIDguess = lr.getLadderID(phi), chipIDguess = lr.getChipID(trc.getZ() + 0.5 * zDRStep);
+    std::array<int, MaxLadderCand> lad2Check;
+    nLad2Check = mFieldON ? findLaddersToCheckBOn(ilr, ladIDguess, trcCircle, errYFrac, lad2Check) : findLaddersToCheckBOff(ilr, ladIDguess, trcLinPar, errYFrac, lad2Check);
+
+    // tmp
+    auto lblTrc = mTPCTrkLabels->getLabels(tTPC.source.getIndex())[0];
+
+    for (int ilad = nLad2Check; ilad--;) {
+      int ladID = lad2Check[ilad];
+      const auto& lad = lr.ladders[ladID];
+
+      // we assume that close chips on the same ladder with have close xyEdges, so it is enough to calculate track-chip crossing
+      // coordinates xCross,yCross,zCross for this central chipIDguess, although we are going to check also neighbours
+      float t = 1e9, xCross, yCross;
+      const auto& chipC = lad.chips[chipIDguess];
+      bool res = mFieldON ? chipC.xyEdges.circleCrossParam(trcCircle, t) : chipC.xyEdges.lineCrossParam(trcLinPar, t);
+      chipC.xyEdges.eval(t, xCross, yCross);
+      float dx = xCross - xCurr, dy = yCross - yCurr, dst2 = dx * dx + dy * dy, dst = sqrtf(dst2);
+      // Z-step sign depends on radius decreasing or increasing during the propagation
+      float zCross = trc.getZ() + trc.getTgl() * (dst2 < 2 * (dx * xCurr + dy * yCurr) ? dst : -dst);
+
+      for (int ich = NZSpan; ich--;) {
+        int chipID = chipIDguess + ich;
+        if (chipID < 0 || chipID >= lad.chips.size()) {
+          continue;
+        }
+        const auto& chip = lad.chips[chipID];
+        if (chip.zRange.isOutside(zCross, driftErr + nSigmaZ * errZ)) {
+          continue;
+        }
+        int chipGID = chip.id;
+        const auto& clRange = clRefs.chipRefs[chipGID];
+        if (!clRange.getEntries()) {
+          continue;
+        }
+        printf("Lr %d #%d/%d LadID: %d (phi:%+d) ChipID: %d [%d Ncl: %d from %d] (rRhi:%d Z:%+d[%+.1f:%+.1f]) | %+.3f %+.3f -> %+.3f %+.3f %+.3f (zErr: %.3f)\n",
+               ilr, ilad, ich, ladID, lad.isPhiOutside(phi, errPhi), chipID,
+               chipGID, clRange.getEntries(), clRange.getFirstEntry(),
+               chip.xyEdges.seenByCircle(trcCircle, errYFrac), chip.zRange.isOutside(zCross, driftErr + 3 * errZ), chip.zRange.min(), chip.zRange.max(),
+               xCurr, yCurr, xCross, yCross, zCross, errZ);
+
+        // track Y error in chip frame
+        float errYcalp = errY * (csa * chipC.csAlp + sna * chipC.snAlp); // sigY_rotate(from alpha0 to alpha1) = sigY * cos(alpha1 - alpha0);
+        float tolerZ = errZ * nSigmaZ, tolerY = errYcalp * nSigmaY;
+        float yTrack = -xCross * chipC.snAlp + yCross * chipC.csAlp; // track-chip crossing Y in chip frame
+
+        auto trcLC = trc; // tmp
+        if (!trcLC.rotate(chipC.alp) || !trcLC.propagateTo(chipC.xRef, propagator->getNominalBz())) {
+          LOG(INFO) << " failed to rotate to alpha=" << chipC.alp << " or prop to X=" << chipC.xRef;
+          trcLC.print();
+          continue;
+        }
+
+        int icID = clRange.getFirstEntry();
+        for (int icl = clRange.getEntries(); icl--;) { // note: clusters within a chip are sorted in Z
+          int clID = clRefs.clusterID[icID++];         // so, we go in clusterID increasing direction
+          const auto cls = (*mITSClustersArrayInp)[clID];
+
+          float dz = zCross - cls.getZ();
+
+          auto label = mITSClsLabels->getLabels(clID)[0]; // tmp
+          if (label != lblTrc)
+            continue; // tmp
+
+          LOG(INFO) << "cl" << icl << '/' << clID << " " << label
+                    << " Z: " << cls.getZ() << " [" << tolerZ << "|" << trcLC.getZ() - zCross << "] Y: " << cls.getY() << " [" << tolerY << "]";
+
+          if (dz > tolerZ) {
+            float clsZ = cls.getZ();
+            LOG(INFO) << "Skip the rest since " << zCross << " > " << clsZ << "\n";
+            break;
+          } else if (dz < -tolerZ) {
+            LOG(INFO) << "Skip cluster dz=" << dz << " Ztr=" << zCross << " zCl=" << cls.getZ()
+                      << " true track: y=" << trcLC.getY() << " erry=" << std::sqrt(trcLC.getSigmaY2()) * nSigmaY
+                      << " z=" << trcLC.getZ() << " errz=" << std::sqrt(trcLC.getSigmaZ2()) * nSigmaZ << "\n";
+            continue;
+          }
+          if (fabs(yTrack - cls.getY()) > tolerY) {
+            LOG(INFO) << "Skip cluster dy= " << yTrack - cls.getY() << " Ytr=" << yTrack << " yCl=" << cls.getY()
+                      << " true track: y=" << trcLC.getY() << " erry=" << std::sqrt(trcLC.getSigmaY2()) * nSigmaY
+                      << " z=" << trcLC.getZ() << " errz=" << std::sqrt(trcLC.getSigmaZ2()) * nSigmaZ << "\n";
+            continue;
+          }
+
+          int aside = tpcTrOrig.hasASideClustersOnly();
+          float zc = cls.getZ(), ztlc = trcLC.getZ();
+          float pt = trc.getPt();
+          (*mDBGOut) << "ab"
+                     << "sideA=" << aside << "pt=" << pt << "zt=" << zCross << "zc=" << zc << "ztl=" << ztlc << "lbl=" << label << "trc0=" << trc << "trcL= " << trcLC << "\n";
+        }
+      }
+    }
+  }
+
+  return true;
+}
+
+//______________________________________________
+int MatchTPCITS::findLaddersToCheckBOn(int ilr, int lad0, const o2::utils::CircleXY& circle, float errYFrac,
+                                       std::array<int, MatchTPCITS::MaxLadderCand>& lad2Check) const
+{
+  // check if ladder lad0 and at most +-MaxUpDnLadders around it are compatible with circular track of
+  // r^2 = r2 and centered at xC,yC
+  const auto& lr = mRGHelper.layers[ilr];
+  int nacc = 0, jmp = 0;
+  if (lr.ladders[lad0].xyEdges.seenByCircle(circle, errYFrac)) {
+    lad2Check[nacc++] = lad0;
+  }
+  bool doUp = true, doDn = true;
+  while ((doUp || doDn) && jmp++ < MaxUpDnLadders) {
+    if (doUp) {
+      int ldID = (lad0 + jmp) % lr.nLadders;
+      if (lr.ladders[ldID].xyEdges.seenByCircle(circle, errYFrac)) {
+        lad2Check[nacc++] = ldID;
+      } else {
+        doUp = false;
+      }
+    }
+    if (doDn) {
+      int ldID = lad0 - jmp;
+      if (ldID < 0) {
+        ldID += lr.nLadders;
+      }
+      if (lr.ladders[ldID].xyEdges.seenByCircle(circle, errYFrac)) {
+        lad2Check[nacc++] = ldID;
+      } else {
+        doDn = false;
+      }
+    }
+  }
+  return nacc;
+}
+
+//______________________________________________
+int MatchTPCITS::findLaddersToCheckBOff(int ilr, int lad0, const o2::utils::IntervalXY& trcLinPar, float errYFrac,
+                                        std::array<int, MatchTPCITS::MaxLadderCand>& lad2Check) const
+{
+  // check if ladder lad0 and at most +-MaxUpDnLadders around it are compatible with linear track
+
+  const auto& lr = mRGHelper.layers[ilr];
+  int nacc = 0, jmp = 0;
+  if (lr.ladders[lad0].xyEdges.seenByLine(trcLinPar, errYFrac)) {
+    lad2Check[nacc++] = lad0;
+  }
+  bool doUp = true, doDn = true;
+  while ((doUp || doDn) && jmp++ < MaxUpDnLadders) {
+    if (doUp) {
+      int ldID = (lad0 + jmp) % lr.nLadders;
+      if (lr.ladders[ldID].xyEdges.seenByLine(trcLinPar, errYFrac)) {
+        lad2Check[nacc++] = ldID;
+      } else {
+        doUp = false;
+      }
+    }
+    if (doDn) {
+      int ldID = lad0 - jmp;
+      if (ldID < 0) {
+        ldID += lr.nLadders;
+      }
+      if (lr.ladders[ldID].xyEdges.seenByLine(trcLinPar, errYFrac)) {
+        lad2Check[nacc++] = ldID;
+      } else {
+        doDn = false;
+      }
+    }
+  }
+  return nacc;
+}
+
+//______________________________________________
+float MatchTPCITS::correctTPCTrack(o2::track::TrackParCov& trc, const TrackLocTPC& tTPC, InteractionCandidate& cand) const
+{
+  // Correct the track copy trc of the working TPC track tTPC in continuous RO mode for the assumed interaction time
+  // return extra uncertainty in Z due to the interaction time incertainty
+  // TODO: at the moment, apply simple shift, but with Z-dependent calibration we may
+  // need to do corrections on TPC cluster level and refit
+  auto tpcTrOrig = (*mTPCTracksArrayInp)[tTPC.source.getIndex()];
+  if (tpcTrOrig.hasBothSidesClusters()) {
+    return 0.;
+  }
+  float timeIC = cand.timeBins.mean(), timeTrc = tpcTrOrig.getTime0() - mNTPCBinsFullDrift;
+  // if interaction time precedes the initial assumption on t0 (i.e. timeIC < timeTrc),
+  // the track actually was drifting longer, i.e. tracks should be shifted closer to the CE
+  float dDrift = (timeIC - timeTrc) * mTPCBin2Z, driftErr = cand.timeBins.delta() * mTPCBin2Z;
+
+  trc.setZ(tTPC.getZ() + (tpcTrOrig.hasASideClustersOnly() ? dDrift : -dDrift));
+
+  // tmp
+  printf("Ttrack A=%d: pT:%.1f Ncl:%2d T:%.2f  TIC: %.2f -> Z=%+.2f -> %+.2f +- %.3f [shift = %f]\n",
+         tpcTrOrig.hasASideClustersOnly(), trc.getPt(), tpcTrOrig.getNClusterReferences(), timeTrc, timeIC, tTPC.getZ(), trc.getZ(),
+         driftErr, (tpcTrOrig.hasASideClustersOnly() ? dDrift : -dDrift));
+
+  return driftErr;
+}
+
+//______________________________________________
+void MatchTPCITS::fillClustersForAfterBurner(ITSChipClustersRefs& refCont, int rofStart, int nROFs)
+{
+  // Prepare unused clusters of given ROFs range for matching in the afterburner
+  // Note: normally only 1 ROF needs to be filled (nROFs==1 ) unless we want
+  // to account for interaction on the boundary of 2 rofs, which then may contribute to both ROFs.
+  int first = (*mITSClusterROFRec)[rofStart].getROFEntry().getIndex(), last = first;
+  for (int ir = nROFs; ir--;) {
+    last += (*mITSClusterROFRec)[rofStart + ir].getNROFEntries();
+  }
+  refCont.clear();
+  auto& idxSort = refCont.clusterID;
+  for (int icl = first; icl < last; icl++) {
+    if (!mITSClustersFlags[icl]) {
+      idxSort.push_back(icl);
+    }
+  }
+  // sort in chip, Z
+  sort(idxSort.begin(), idxSort.end(), [clusArr = mITSClustersArrayInp](int i, int j) {
+    const auto &clI = (*clusArr)[i], &clJ = (*clusArr)[j];
+    if (clI.getSensorID() < clJ.getSensorID()) {
+      return true;
+    }
+    if (clI.getSensorID() == clJ.getSensorID()) {
+      return clI.getZ() < clJ.getZ();
+    }
+    return false;
+  });
+
+  int ncl = idxSort.size();
+  int lastSens = -1, nClInSens = 0;
+  ClusRange* chipClRefs = nullptr;
+  for (int icl = 0; icl < ncl; icl++) {
+    const auto& clus = (*mITSClustersArrayInp)[idxSort[icl]];
+    int sens = clus.getSensorID();
+    if (sens != lastSens) {
+      if (chipClRefs) { // finalize chip reference
+        chipClRefs->setEntries(nClInSens);
+        nClInSens = 0;
+      }
+      chipClRefs = &refCont.chipRefs[(lastSens = sens)];
+      chipClRefs->setFirstEntry(icl);
+    }
+    nClInSens++;
+  }
+  if (chipClRefs) {
+    chipClRefs->setEntries(nClInSens); // finalize last chip reference
+  }
+}
+
+/*
+{
+  auto rcen2 = xc*xc+yc*yc, rcen = sqrtf(rcen2); // radius^2 of the circle center
+  auto rlPrt = rLr + rTra, rlMrt = rLr - rTra; // sum and differenc of layer and track radii
+  auto dtPart = (rcen2-rlMrt*rlMrt)*(rcen2-rlPrt*rlPrt);
+  if (dtPart>0.) {
+    return false; // no intersection
+  }
+
+}
+*/
+
+//<<============================= AfterBurner for TPC-track / ITS cluster matching ===================<<
+
 #ifdef _ALLOW_DEBUG_TREES_
 //______________________________________________
 void MatchTPCITS::setDebugFlag(UInt_t flag, bool on)
@@ -1464,18 +2123,17 @@ void MatchTPCITS::dumpWinnerMatches()
 
   LOG(INFO) << "Dumping debug tree for winner matches";
   for (int iits = 0; iits < int(mITSWork.size()); iits++) {
-    auto& its = mITSWork[iits];
-    if (its.matchID < 0 || isDisabledITS(mMatchesITS[its.matchID])) {
+    auto& tITS = mITSWork[iits];
+    if (isDisabledITS(tITS)) {
       continue;
     }
-    auto& itsMatch = mMatchesITS[its.matchID];
-    auto& itsMatchRec = mMatchRecordsITS[itsMatch.first];
-    int itpc = mTPCMatch2Track[itsMatchRec.matchID];
-    auto& tpc = mTPCWork[itpc];
+    auto& itsMatchRec = mMatchRecordsITS[tITS.matchID];
+    int itpc = itsMatchRec.partnerID;
+    auto& tTPC = mTPCWork[itpc];
 
     (*mDBGOut) << "matchWin"
-               << "chi2Match=" << itsMatchRec.chi2 << "chi2Refit=" << mWinnerChi2Refit[iits] << "its=" << its
-               << "tpc=" << tpc;
+               << "chi2Match=" << itsMatchRec.chi2 << "chi2Refit=" << mWinnerChi2Refit[iits] << "its=" << tITS
+               << "tpc=" << tTPC;
 
     o2::MCCompLabel lblITS, lblTPC;
     if (mMCTruthON) {

--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -797,9 +797,9 @@ bool MatchTPCITS::prepareITSTracks()
 
   if (!mDPLIO) { // for input from tree read ROFrecords vector, in DPL IO mode the vector should be already attached
     mTimerIO.Start(false);
-    mTreeITSTracks->GetEntry(0);
+    mTreeITSTrackROFRec->GetEntry(0);
     mITSTrackROFRec = gsl::span<const o2::itsmft::ROFRecord>(mITSTrackROFRecPtr->data(), mITSTrackROFRecPtr->size());
-    mTreeITSClusters->GetEntry(0); // keep clusters ROFRecs ready
+    mTreeITSClusterROFRec->GetEntry(0); // keep clusters ROFRecs ready
     mITSClustersArray = gsl::span<const o2::itsmft::Cluster>(mITSClustersArrayPtr->data(), mITSClustersArrayPtr->size());
     mITSClusterROFRec = gsl::span<const o2::itsmft::ROFRecord>(mITSClusterROFRecPtr->data(), mITSClusterROFRecPtr->size());
     mTimerIO.Stop();
@@ -848,7 +848,6 @@ bool MatchTPCITS::prepareITSTracks()
     int trlim = rofRec.getFirstEntry() + rofRec.getNEntries();
     for (int it = rofRec.getFirstEntry(); it < trlim; it++) {
       const auto& trcOrig = mITSTracksArray[it];
-
       if (isRunAfterBurner()) {
         flagUsedITSClusters(trcOrig, cluROFOffset);
       }
@@ -1670,7 +1669,7 @@ bool MatchTPCITS::loadTPCClusters()
 bool MatchTPCITS::refitTrackTPCITSloopTPC(int iTPC, int& iITS)
 {
   ///< refit in inward direction the pair of TPC and ITS tracks
-
+  
   const float maxStep = 2.f; // max propagation step (TODO: tune)
 
   const auto& tTPC = mTPCWork[iTPC];

--- a/Detectors/GlobalTracking/src/MatchTPCITSParams.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITSParams.cxx
@@ -8,20 +8,9 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifndef O2_MATCHT_TPCITS_WORKFLOW_H
-#define O2_MATCHT_TPCITS_WORKFLOW_H
+/// \file MatchTPCITSParams.h
+/// \brief Configurable params for TPC ITS matching
+/// \author ruben.shahoyan@cern.ch
 
-/// @file   RecoWorkflow.h
-
-#include "Framework/WorkflowSpec.h"
-
-namespace o2
-{
-namespace globaltracking
-{
-
-framework::WorkflowSpec getMatchTPCITSWorkflow(bool useMC);
-
-} // namespace globaltracking
-} // namespace o2
-#endif
+#include "GlobalTracking/MatchTPCITSParams.h"
+O2ParamImpl(o2::globaltracking::MatchITSTPCParams);

--- a/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/TPCITSMatchingSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/TPCITSMatchingSpec.h
@@ -32,8 +32,8 @@ namespace globaltracking
 class TPCITSMatchingDPL : public Task
 {
  public:
-  TPCITSMatchingDPL(bool useMC, bool useFIT, const std::vector<int>& tpcClusLanes)
-    : mUseMC(useMC), mUseFIT(useFIT), mTPCClusLanes(tpcClusLanes) {}
+  TPCITSMatchingDPL(bool useMC, const std::vector<int>& tpcClusLanes)
+    : mUseMC(useMC), mTPCClusLanes(tpcClusLanes) {}
   ~TPCITSMatchingDPL() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
@@ -44,15 +44,12 @@ class TPCITSMatchingDPL : public Task
   std::vector<int> mTPCClusLanes;
   std::array<std::vector<char>, o2::tpc::Constants::MAXSECTOR> mBufferedTPCClusters; // at the moment not used
 
-  bool mUseFIT = false;
-
   bool mFinished = false;
   bool mUseMC = true;
 };
 
 /// create a processor spec
-/// write ITS tracks a root file
-framework::DataProcessorSpec getTPCITSMatchingSpec(bool useMC, bool useFIT, const std::vector<int>& tpcClusLanes);
+framework::DataProcessorSpec getTPCITSMatchingSpec(bool useMC, const std::vector<int>& tpcClusLanes);
 
 } // namespace globaltracking
 } // namespace o2

--- a/Detectors/GlobalTrackingWorkflow/src/MatchTPCITSWorkflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/MatchTPCITSWorkflow.cxx
@@ -20,13 +20,14 @@
 #include "GlobalTrackingWorkflow/TrackWriterTPCITSSpec.h"
 #include "Algorithm/RangeTokenizer.h"
 #include "DataFormatsTPC/Constants.h"
+#include "GlobalTracking/MatchTPCITSParams.h"
 
 namespace o2
 {
 namespace globaltracking
 {
 
-framework::WorkflowSpec getMatchTPCITSWorkflow(bool useMC, bool useFIT)
+framework::WorkflowSpec getMatchTPCITSWorkflow(bool useMC)
 {
   framework::WorkflowSpec specs;
 
@@ -51,10 +52,10 @@ framework::WorkflowSpec getMatchTPCITSWorkflow(bool useMC, bool useFIT)
                                                  tpcClusLanes},
                                                useMC));
 
-  specs.emplace_back(o2::globaltracking::getTPCITSMatchingSpec(useMC, useFIT, tpcClusLanes));
+  specs.emplace_back(o2::globaltracking::getTPCITSMatchingSpec(useMC, tpcClusLanes));
   specs.emplace_back(o2::globaltracking::getTrackWriterTPCITSSpec(useMC));
 
-  if (useFIT) {
+  if (o2::globaltracking::MatchITSTPCParams::Instance().runAfterBurner) {
     specs.emplace_back(o2::ft0::getFT0RecPointReaderSpec(useMC));
   }
 

--- a/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
@@ -221,11 +221,20 @@ void TPCITSMatchingDPL::run(ProcessingContext& pc)
   //
   const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* lblITSPtr = nullptr;
   std::unique_ptr<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>> lblITS;
+
+  const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* lblClusITSPtr = nullptr;
+  std::unique_ptr<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>> lblClusITS;
+
   const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* lblTPCPtr = nullptr;
   std::unique_ptr<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>> lblTPC;
+
   if (mUseMC) {
     lblITS = pc.inputs().get<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>*>("trackITSMCTR");
     lblITSPtr = lblITS.get();
+
+    lblClusITS = pc.inputs().get<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>*>("clusITSMCTR");
+    lblClusITSPtr = lblClusITS.get();
+
     lblTPC = pc.inputs().get<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>*>("trackTPCMCTR");
     lblTPCPtr = lblTPC.get();
   }
@@ -242,6 +251,7 @@ void TPCITSMatchingDPL::run(ProcessingContext& pc)
 
   if (mUseMC) {
     mMatching.setITSTrkLabelsInp(lblITSPtr);
+    mMatching.setITSClsLabelsInp(lblClusITSPtr);
     mMatching.setTPCTrkLabelsInp(lblTPCPtr);
   }
 
@@ -297,6 +307,7 @@ DataProcessorSpec getTPCITSMatchingSpec(bool useMC, bool useFIT, const std::vect
   if (useMC) {
     inputs.emplace_back("trackITSMCTR", "ITS", "TRACKSMCTR", 0, Lifetime::Timeframe);
     inputs.emplace_back("trackTPCMCTR", "TPC", "TRACKSMCLBL", 0, Lifetime::Timeframe);
+    inputs.emplace_back("clusITSMCTR", "ITS", "CLUSTERSMCTR", 0, Lifetime::Timeframe);
     //
     outputs.emplace_back("GLO", "TPCITS_ITSMC", 0, Lifetime::Timeframe);
     outputs.emplace_back("GLO", "TPCITS_TPCMC", 0, Lifetime::Timeframe);

--- a/Detectors/GlobalTrackingWorkflow/src/tpcits-match-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/tpcits-match-workflow.cxx
@@ -22,9 +22,6 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   workflowOptions.push_back(ConfigParamSpec{
     "disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation even if available"}});
 
-  workflowOptions.push_back(ConfigParamSpec{
-    "use-FIT", o2::framework::VariantType::Bool, false, {"use FIT info for matching"}});
-
   std::string keyvaluehelp("Semicolon separated key=value strings ...");
   workflowOptions.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {keyvaluehelp}});
 }
@@ -37,10 +34,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 {
   // Update the (declared) parameters if changed from the command line
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
-  // write the configuration used for the digitizer workflow
-  o2::conf::ConfigurableParam::writeINI("o2tpcits-match-recoflow_configuration.ini");
+  // write the configuration used for the workflow
+  o2::conf::ConfigurableParam::writeINI("o2matchtpcits-workflow_configuration.ini");
 
   auto useMC = !configcontext.options().get<bool>("disable-mc");
-  auto useFIT = configcontext.options().get<bool>("use-FIT");
-  return std::move(o2::globaltracking::getMatchTPCITSWorkflow(useMC, useFIT));
+  return std::move(o2::globaltracking::getMatchTPCITSWorkflow(useMC));
 }

--- a/Detectors/ITSMFT/ITS/reconstruction/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/reconstruction/CMakeLists.txt
@@ -9,11 +9,13 @@
 # submit itself to any jurisdiction.
 
 o2_add_library(ITSReconstruction
-               SOURCES src/ClustererTask.cxx src/CookedTracker.cxx
-                       src/TrivialVertexer.cxx
+               SOURCES src/ClustererTask.cxx
+	               src/CookedTracker.cxx
+                       src/RecoGeomHelper.cxx
                PUBLIC_LINK_LIBRARIES O2::ITSBase O2::ITSMFTReconstruction
                                      O2::DataFormatsITS)
 
 o2_target_root_dictionary(ITSReconstruction
-                          HEADERS include/ITSReconstruction/ClustererTask.h
-                                  include/ITSReconstruction/CookedTracker.h)
+                          HEADERS include/ITSReconstruction/ClustererTask.h			          
+                                  include/ITSReconstruction/CookedTracker.h
+				  include/ITSReconstruction/RecoGeomHelper.h)

--- a/Detectors/ITSMFT/ITS/reconstruction/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/reconstruction/CMakeLists.txt
@@ -8,14 +8,13 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
-o2_add_library(ITSReconstruction
-               SOURCES src/ClustererTask.cxx
-	               src/CookedTracker.cxx
-                       src/RecoGeomHelper.cxx
-               PUBLIC_LINK_LIBRARIES O2::ITSBase O2::ITSMFTReconstruction
-                                     O2::DataFormatsITS)
+o2_add_library(
+  ITSReconstruction
+  SOURCES src/ClustererTask.cxx src/CookedTracker.cxx src/RecoGeomHelper.cxx
+  PUBLIC_LINK_LIBRARIES O2::ITSBase O2::ITSMFTReconstruction O2::DataFormatsITS)
 
-o2_target_root_dictionary(ITSReconstruction
-                          HEADERS include/ITSReconstruction/ClustererTask.h			          
-                                  include/ITSReconstruction/CookedTracker.h
-				  include/ITSReconstruction/RecoGeomHelper.h)
+o2_target_root_dictionary(
+  ITSReconstruction
+  HEADERS include/ITSReconstruction/ClustererTask.h
+          include/ITSReconstruction/CookedTracker.h
+          include/ITSReconstruction/RecoGeomHelper.h)

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/RecoGeomHelper.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/RecoGeomHelper.h
@@ -1,0 +1,147 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file RecoGeomHelper.h
+/// \brief Declarations of the helper class for clusters / roadwidth matching
+/// \author ruben.shahoyan@cern.ch
+
+#ifndef ALICEO2_ITS_RECOGEOMHELPER_H
+#define ALICEO2_ITS_RECOGEOMHELPER_H
+
+#include <Rtypes.h>
+#include <vector>
+#include <array>
+#include "MathUtils/Cartesian3D.h"
+#include "MathUtils/Utils.h"
+#include "MathUtils/Primitive2D.h"
+#include "CommonConstants/MathConstants.h"
+#include "MathUtils/Bracket.h"
+#include "ITSMFTReconstruction/ChipMappingITS.h"
+#include "ITSMFTBase/SegmentationAlpide.h"
+
+namespace o2
+{
+namespace its
+{
+struct RecoGeomHelper {
+  //
+  using BracketF = o2::utils::Bracket<float>;
+  using Vec2D = o2::utils::IntervalXY;
+
+  enum Relation : int { Below = -1,
+                        Inside = 0,
+                        Above = 1 };
+
+  struct RecoChip {
+    ///< boundaries + frame data for single chip
+    uint16_t id = 0xffff;                                        // global chip id
+    float alp = 0.f, snAlp = 0.f, csAlp = 0.f;                   // cos and sin of sensor alpha
+    float xRef = 0.f;                                            // reference X
+    BracketF yRange = { 1.e9, -1.e9 }, zRange = { 1.e9, -1.e9 }; // bounding box in tracking frame
+    Vec2D xyEdges;
+
+    void updateLimits(const Point3D<float>& pnt);
+    void print() const;
+    ClassDefNV(RecoChip, 0);
+  };
+
+  struct RecoLadder {
+    ///< group of chips at same (modulo alignment) phi, r (stave in IB, 1/4 stave in OB)
+    int id = 0; // assigned ladder ID within the layer
+    BracketF phiRange = { o2::constants::math::TwoPI, 0. };
+    BracketF zRange = { 1e9, -1e9 }; // Z ranges in lab frame
+    Vec2D xyEdges;                   // envelop for chip edges
+    float phiMean = 0., dphiH = 0.;
+    std::vector<RecoChip> chips;
+
+    Relation isPhiOutside(float phi, float toler = 0) const;
+    void updateLimits(const Point3D<float>& pnt);
+    void init();
+    void print() const;
+    ClassDefNV(RecoLadder, 0);
+  };
+
+  struct RecoLayer {
+    // navigation over ladders of single layer
+    int id = 0;       // layer ID
+    int nLadders = 0; // number of ladders
+    int lastChipInLadder = 0;
+    float z2chipID = 0;              // conversion factor for Z (relative to zmin) to rough chip ID
+    float rInv = 0.;                 // inverse mean radius
+    BracketF rRange = { 1e9, 0. };   // min and max radii
+    BracketF zRange = { 1e9, -1e9 }; // min and max Z
+    std::vector<RecoLadder> ladders;
+    std::vector<uint16_t> phi2ladder; // mapping from phi to ladderID
+
+    const RecoLadder& getLadder(int id) const { return ladders[id % nLadders]; }
+    void init();
+    void updateLimits(const Point3D<float>& pnt);
+    void print() const;
+    int getLadderID(float phi) const;
+    int getChipID(float z) const;
+    ClassDefNV(RecoLayer, 0);
+  };
+  //---------------------------<< aux classes
+
+  std::array<RecoLayer, o2::itsmft::ChipMappingITS::NLayers> layers;
+  static constexpr int getNLayers() { return o2::itsmft::ChipMappingITS::NLayers; }
+  static constexpr int getNChips() { return o2::itsmft::ChipMappingITS::getNChips(); }
+  static constexpr float ladderWidth() { return o2::itsmft::SegmentationAlpide::SensorSizeRows; }
+  static constexpr float ladderWidthInv() { return 1. / ladderWidth(); }
+
+  void init();
+  void print() const;
+
+  ClassDefNV(RecoGeomHelper, 0);
+};
+
+//_____________________________________________________________________
+inline RecoGeomHelper::Relation RecoGeomHelper::RecoLadder::isPhiOutside(float phi, float toler) const
+{
+  // check if phi+-toler is out of the limits of the ladder phi.
+  // return -1 or +1 if phi is above or below the region. If inside, return 0
+  float dif = phi - phiMean, difa = fabs(dif);
+  if (difa < dphiH + toler) {
+    return RecoGeomHelper::Inside;
+  }
+  if (difa > o2::constants::math::PI) { // wraps?
+    difa = o2::constants::math::TwoPI - difa;
+    if (difa < dphiH + toler) {
+      return RecoGeomHelper::Inside;
+    }
+    return dif < 0 ? RecoGeomHelper::Above : RecoGeomHelper::Below;
+  }
+  return dif < 0 ? RecoGeomHelper::Below : RecoGeomHelper::Above;
+}
+
+//_____________________________________________________________________
+inline int RecoGeomHelper::RecoLayer::getChipID(float z) const
+{
+  // Get chip ID within the ladder corresponding to this phi
+  // Note: this is an approximate method, one should check also the neighbouring ladders +/-1
+  int ic = (z - zRange.min()) * z2chipID;
+  return ic < 0 ? 0 : (ic < lastChipInLadder ? ic : lastChipInLadder);
+}
+
+//_____________________________________________________________________
+inline int RecoGeomHelper::RecoLayer::getLadderID(float phi) const
+{
+  // Get ladder ID corresponding to phi.
+  // Note: this is an approximate method, precise within 1/3 of average ladder width,
+  // one should check also the neighbouring ladders +/-1
+  o2::utils::BringTo02Pi(phi);
+  constexpr float PI2Inv = 1.f / o2::constants::math::TwoPI;
+  return phi2ladder[int(phi * PI2Inv * phi2ladder.size())];
+}
+
+} // namespace its
+} // namespace o2
+
+#endif /* ALICEO2_ITS_RECOGEOMHELPER_H */

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/RecoGeomHelper.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/RecoGeomHelper.h
@@ -53,9 +53,12 @@ struct RecoGeomHelper {
   };
 
   struct RecoLadder {
-    enum Overlap : int8_t {Undefined, Above, NoOverlap, Below};
+    enum Overlap : int8_t { Undefined,
+                            Above,
+                            NoOverlap,
+                            Below };
     ///< group of chips at same (modulo alignment) phi, r (stave in IB, 1/4 stave in OB)
-    short id = 0; // assigned ladder ID within the layer
+    short id = 0;                        // assigned ladder ID within the layer
     Overlap overlapWithNext = Undefined; // special flag saying if for double-hit layers this one is above, excluded or below the next one
     BracketF phiRange = {o2::constants::math::TwoPI, 0.};
     BracketF zRange = {1e9, -1e9}; // Z ranges in lab frame

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/RecoGeomHelper.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/RecoGeomHelper.h
@@ -41,10 +41,10 @@ struct RecoGeomHelper {
 
   struct RecoChip {
     ///< boundaries + frame data for single chip
-    uint16_t id = 0xffff;                                        // global chip id
-    float alp = 0.f, snAlp = 0.f, csAlp = 0.f;                   // cos and sin of sensor alpha
-    float xRef = 0.f;                                            // reference X
-    BracketF yRange = { 1.e9, -1.e9 }, zRange = { 1.e9, -1.e9 }; // bounding box in tracking frame
+    uint16_t id = 0xffff;                                    // global chip id
+    float alp = 0.f, snAlp = 0.f, csAlp = 0.f;               // cos and sin of sensor alpha
+    float xRef = 0.f;                                        // reference X
+    BracketF yRange = {1.e9, -1.e9}, zRange = {1.e9, -1.e9}; // bounding box in tracking frame
     Vec2D xyEdges;
 
     void updateLimits(const Point3D<float>& pnt);
@@ -53,11 +53,13 @@ struct RecoGeomHelper {
   };
 
   struct RecoLadder {
+    enum Overlap : int8_t {Undefined, Above, NoOverlap, Below};
     ///< group of chips at same (modulo alignment) phi, r (stave in IB, 1/4 stave in OB)
-    int id = 0; // assigned ladder ID within the layer
-    BracketF phiRange = { o2::constants::math::TwoPI, 0. };
-    BracketF zRange = { 1e9, -1e9 }; // Z ranges in lab frame
-    Vec2D xyEdges;                   // envelop for chip edges
+    short id = 0; // assigned ladder ID within the layer
+    Overlap overlapWithNext = Undefined; // special flag saying if for double-hit layers this one is above, excluded or below the next one
+    BracketF phiRange = {o2::constants::math::TwoPI, 0.};
+    BracketF zRange = {1e9, -1e9}; // Z ranges in lab frame
+    Vec2D xyEdges;                 // envelop for chip edges
     float phiMean = 0., dphiH = 0.;
     std::vector<RecoChip> chips;
 
@@ -73,10 +75,10 @@ struct RecoGeomHelper {
     int id = 0;       // layer ID
     int nLadders = 0; // number of ladders
     int lastChipInLadder = 0;
-    float z2chipID = 0;              // conversion factor for Z (relative to zmin) to rough chip ID
-    float rInv = 0.;                 // inverse mean radius
-    BracketF rRange = { 1e9, 0. };   // min and max radii
-    BracketF zRange = { 1e9, -1e9 }; // min and max Z
+    float z2chipID = 0;            // conversion factor for Z (relative to zmin) to rough chip ID
+    float rInv = 0.;               // inverse mean radius
+    BracketF rRange = {1e9, 0.};   // min and max radii
+    BracketF zRange = {1e9, -1e9}; // min and max Z
     std::vector<RecoLadder> ladders;
     std::vector<uint16_t> phi2ladder; // mapping from phi to ladderID
 

--- a/Detectors/ITSMFT/ITS/reconstruction/src/ITSReconstructionLinkDef.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/ITSReconstructionLinkDef.h
@@ -14,8 +14,9 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
-//#pragma link C++ class o2::its::TrivialClustererTask+;
 #pragma link C++ class o2::its::ClustererTask + ;
 #pragma link C++ class o2::its::CookedTracker + ;
+
+#pragma link C++ class o2::its::RecoGeomHelper + ;
 
 #endif

--- a/Detectors/ITSMFT/ITS/reconstruction/src/RecoGeomHelper.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/RecoGeomHelper.cxx
@@ -1,0 +1,206 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file RecoLayer.cxx
+/// \brief Implementation of the Aux. container for clusters, optimized for tracking
+/// \author iouri.belikov@cern.ch
+
+#include "ITSReconstruction/RecoGeomHelper.h"
+#include "ITSMFTBase/SegmentationAlpide.h"
+#include "ITSBase/GeometryTGeo.h"
+
+using namespace o2::its;
+
+//_____________________________________________________________________
+void RecoGeomHelper::RecoChip::updateLimits(const Point3D<float>& pntTra)
+{
+  // update limits from the edge point in tracking frame
+  yRange.update(pntTra.Y());
+  zRange.update(pntTra.Z());
+}
+
+//_____________________________________________________________________
+void RecoGeomHelper::RecoChip::print() const
+{
+  printf("Ch#%4d Alp: %+.3f X:%5.2f %+6.3f<y<%+6.3f  %+6.3f<z<%+6.3f | XYEdges: {%+6.3f,%+6.3f}{%+6.3f,%+6.3f}\n",
+         id, alp, xRef, yRange.min(), yRange.max(), zRange.min(), zRange.max(),
+         xyEdges.getX0(), xyEdges.getY0(), xyEdges.getX1(), xyEdges.getY1());
+}
+
+//_____________________________________________________________________
+void RecoGeomHelper::RecoLadder::updateLimits(const Point3D<float>& pntGlo)
+{
+  // update limits from the point in Global frame
+  float phi = pntGlo.phi();    // -pi:pi range
+  o2::utils::BringTo02Pi(phi); // temporary bring to 0:2pi range
+  o2::utils::BringTo02Pi(phiRange.min());
+  o2::utils::BringTo02Pi(phiRange.max());
+  phiRange.update(phi);
+  phiMean = phiRange.mean();
+  dphiH = 0.5 * phiRange.delta();
+  if (phiRange.delta() > o2::constants::math::PI) { // wrapping, swap
+    phiRange.set(phiRange.max(), phiRange.min());   // swap
+    phiMean -= o2::constants::math::PI;
+    dphiH = o2::constants::math::PI - dphiH;
+  }
+  o2::utils::BringToPMPi(phiRange.min()); // -pi:pi range
+  o2::utils::BringToPMPi(phiRange.max());
+  o2::utils::BringToPMPi(phiMean);
+  //
+  zRange.update(pntGlo.Z());
+}
+
+//_____________________________________________________________________
+void RecoGeomHelper::RecoLadder::init()
+{
+  auto& chip = chips[0].xyEdges;
+  float x0(chip.getX0()), y0(chip.getY0()), x1(chip.getX1()), y1(chip.getY1());
+  for (int i = 1; i < (int)chips.size(); i++) {
+    chip = chips[i].xyEdges;
+    x0 = chip.getDX() > 0 ? std::min(x0, chip.getX0()) : std::max(x0, chip.getX0());
+    x1 = chip.getDX() > 0 ? std::max(x1, chip.getX1()) : std::min(x1, chip.getX1());
+    y0 = chip.getDY() > 0 ? std::min(y0, chip.getY0()) : std::max(y0, chip.getY0());
+    y1 = chip.getDY() > 0 ? std::max(y1, chip.getY1()) : std::min(y1, chip.getY1());
+  }
+  xyEdges.setEdges(x0, y0, x1, y1);
+}
+
+//_____________________________________________________________________
+void RecoGeomHelper::RecoLadder::print() const
+{
+  printf("Ladder %3d  %.3f<phi[<%.3f>]<%.3f dPhiH:%.3f | XYEdges: {%+6.3f,%+6.3f}{%+6.3f,%+6.3f} | %3d chips\n",
+         id, phiRange.min(), phiMean, phiRange.max(), dphiH,
+         xyEdges.getX0(), xyEdges.getY0(), xyEdges.getX1(), xyEdges.getY1(), (int)chips.size());
+  for (const auto& ch : chips) {
+    ch.print();
+  }
+}
+
+//_____________________________________________________________________
+void RecoGeomHelper::RecoLayer::init()
+{
+  auto gm = o2::its::GeometryTGeo::Instance();
+  gm->fillMatrixCache(o2::utils::bit2Mask(o2::TransformType::T2GRot, o2::TransformType::T2L)); // more matrices ?
+
+  int nHStaves = gm->getNumberOfHalfStaves(id);
+  int nStaves = gm->getNumberOfStaves(id);
+  float dxH = o2::itsmft::SegmentationAlpide::SensorSizeRows / 2; // half width in rphi
+  float dzH = o2::itsmft::SegmentationAlpide::SensorSizeCols / 2; // half width in Z
+  int nCh = gm->getNumberOfChipsPerLayer(id), chip0 = gm->getFirstChipIndex(id);
+  int nChMod = gm->getNumberOfChipsPerModule(id), nChModH = nChMod / 2;
+  nLadders = nStaves * nHStaves * (id > 2 ? 2 : 1); // 2 ladders per h-stave for OB
+  ladders.resize(nLadders);
+
+  for (auto lad : ladders) {
+    lad.chips.reserve(gm->getNumberOfChipsPerHalfStave(id) / (id > 2 ? 2 : 1)); // 2 ladders per h-stave for OB
+  }
+  for (int ich = 0; ich < nCh; ich++) {
+    int chipID = chip0 + ich, lay, sta, ssta, mod, chipInMod;
+    gm->getChipId(chipID, lay, sta, ssta, mod, chipInMod);
+    int ladID = sta, chipInLadder = nChMod - chipInMod - 1; // count from negative to positive Z, contrary to official chips numbering
+    if (nHStaves > 1) {                                     // OB
+      int modUpper = chipInMod / nChModH;
+      ladID = sta * 4 + ssta * 2 + modUpper; // OB module covers 2 "ladders"
+    }
+    auto& ladder = ladders[ladID];
+    auto& chip = ladder.chips.emplace_back();
+    chip.id = chipID;
+    gm->getSensorXAlphaRefPlane(chipID, chip.xRef, chip.alp);
+    o2::utils::sincosf(chip.alp, chip.snAlp, chip.csAlp);
+
+    Point3D<float> edgeLoc(-dxH, 0.f, -dzH);
+    auto edgeTra = gm->getMatrixT2L(chipID) ^ (edgeLoc); // edge in tracking frame
+    chip.updateLimits(edgeTra);
+    auto edgeGloM = gm->getMatrixT2GRot(chipID)(edgeTra); // edge in global frame
+    updateLimits(edgeGloM);
+    ladder.updateLimits(edgeGloM);
+
+    edgeLoc.SetXYZ(dxH, 0.f, dzH);
+    edgeTra = gm->getMatrixT2L(chipID) ^ (edgeLoc); // edge in tracking frame
+    chip.updateLimits(edgeTra);
+    auto edgeGloP = gm->getMatrixT2GRot(chipID)(edgeTra); // edge in globalframe
+    updateLimits(edgeGloP);
+    ladder.updateLimits(edgeGloP);
+    chip.xyEdges.setEdges(edgeGloM.X(), edgeGloM.Y(), edgeGloP.X(), edgeGloP.Y());
+  }
+
+  // sort according to mean phi (in -pi:pi range!!!)
+  std::sort(ladders.begin(), ladders.end(), [](auto& a, auto& b) {
+    float pha = a.phiMean, phb = b.phiMean;
+    o2::utils::BringTo02Pi(pha);
+    o2::utils::BringTo02Pi(phb);
+    return pha < phb;
+  });
+
+  // make sure chips within the ladder are ordered in Z, renumber ladders
+  for (int i = nLadders; i--;) {
+    auto& lad = ladders[i];
+    std::sort(lad.chips.begin(), lad.chips.end(), [](auto& a, auto& b) { return a.zRange.min() < b.zRange.min(); });
+    lad.id = i;
+    lad.init();
+  }
+  int ndiv = nLadders * 3; // number of bins for mapping
+  phi2ladder.resize(ndiv);
+  float dphi = o2::constants::math::TwoPI / ndiv;
+  int laddId = 0;
+  for (int i = 0; i < ndiv; i++) {
+    float phi = (0.5 + i) * dphi;
+    o2::utils::BringToPMPi(phi);
+    while (laddId < nLadders) {
+      const auto& lad = ladders[laddId];
+      auto rel = lad.isPhiOutside(phi);
+      if (rel != RecoGeomHelper::Above) {
+        break;
+      }
+      laddId++; // laddId was below phi, catch up
+    }
+    phi2ladder[i] = laddId % nLadders;
+  }
+  lastChipInLadder = ladders[0].chips.size();
+  z2chipID = lastChipInLadder / zRange.delta();
+  lastChipInLadder--;
+  rInv = 1. / rRange.mean();
+}
+
+//_____________________________________________________________________
+void RecoGeomHelper::RecoLayer::updateLimits(const Point3D<float>& pntGlo)
+{
+  // update limits from the point in global frame
+  rRange.update(pntGlo.Rho());
+  zRange.update(pntGlo.Z());
+}
+
+//_____________________________________________________________________
+void RecoGeomHelper::RecoLayer::print() const
+{
+  printf("\nLayer %d %.2f<r<%.2f %+.2f<z<%+.2f  %d ladders\n",
+         id, rRange.min(), rRange.max(), zRange.min(), zRange.max(), (int)ladders.size());
+  for (const auto& ld : ladders) {
+    ld.print();
+  }
+}
+
+//_____________________________________________________________________
+void RecoGeomHelper::init()
+{
+  for (int il = int(layers.size()); il--;) {
+    auto& lr = layers[il];
+    lr.id = il;
+    lr.init();
+  }
+}
+
+//_____________________________________________________________________
+void RecoGeomHelper::print() const
+{
+  for (const auto& lr : layers) {
+    lr.print();
+  }
+}

--- a/Detectors/ITSMFT/ITS/reconstruction/src/RecoGeomHelper.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/RecoGeomHelper.cxx
@@ -75,11 +75,11 @@ void RecoGeomHelper::RecoLadder::init()
 //_____________________________________________________________________
 void RecoGeomHelper::RecoLadder::print() const
 {
-  assert(overlapWithNext!=Undefined || chips.size()==0);  // make sure there are no undefined ladders after init is done
+  assert(overlapWithNext != Undefined || chips.size() == 0); // make sure there are no undefined ladders after init is done
   printf("Ladder %3d  %.3f<phi[<%.3f>]<%.3f dPhiH:%.3f | XYEdges: {%+6.3f,%+6.3f}{%+6.3f,%+6.3f} | %3d chips | OvlNext: %s\n",
          id, phiRange.min(), phiMean, phiRange.max(), dphiH,
          xyEdges.getX0(), xyEdges.getY0(), xyEdges.getX1(), xyEdges.getY1(), (int)chips.size(),
-	 overlapWithNext==Undefined ? "N/A" : ((overlapWithNext==NoOverlap ? "NO" : (overlapWithNext==Above ? "Above" : "Below") )) );
+         overlapWithNext == Undefined ? "N/A" : ((overlapWithNext == NoOverlap ? "NO" : (overlapWithNext == Above ? "Above" : "Below"))));
   for (const auto& ch : chips) {
     ch.print();
   }
@@ -151,38 +151,38 @@ void RecoGeomHelper::RecoLayer::init()
   // relate to its neighbour: is the egde at higher R than the edge of the next ladder and do we check for overlaps ?
   for (int i = nLadders; i--;) {
     auto& lad = ladders[i];
-    auto& plad = i>0 ? ladders[i-1] : ladders[nLadders-1];
-    if (nHStaves==2) { // on the OB the ladders of the same halfstave do not overlap
+    auto& plad = i > 0 ? ladders[i - 1] : ladders[nLadders - 1];
+    if (nHStaves == 2) { // on the OB the ladders of the same halfstave do not overlap
       int tlay, tsta, tssta, tmod, tchipInMod;
       int play, psta, pssta, pmod, pchipInMod;
-      gm->getChipId( lad.chips.front().id, tlay, tsta, tssta, tmod, tchipInMod);
+      gm->getChipId(lad.chips.front().id, tlay, tsta, tssta, tmod, tchipInMod);
       gm->getChipId(plad.chips.front().id, play, psta, pssta, pmod, pchipInMod);
-      if (tsta==psta && tssta==pssta) { // these are 2 ladders of the same halfstave, no overlap
-	plad.overlapWithNext = RecoLadder::NoOverlap;
-	continue;
+      if (tsta == psta && tssta == pssta) { // these are 2 ladders of the same halfstave, no overlap
+        plad.overlapWithNext = RecoLadder::NoOverlap;
+        continue;
       }
     }
     // need to compare the radius of the edge at lowest phi for this ladder with radius at highest phi of prev ladder
     // find the radius of the edge at low phi
-    float phi0 = std::atan2(lad.xyEdges.getY0(),lad.xyEdges.getX0());
-    float phi1 = std::atan2(lad.xyEdges.getY1(),lad.xyEdges.getX1());
+    float phi0 = std::atan2(lad.xyEdges.getY0(), lad.xyEdges.getX0());
+    float phi1 = std::atan2(lad.xyEdges.getY1(), lad.xyEdges.getX1());
     o2::utils::BringTo02Pi(phi0); // we don't know a priori if edge0/1 corresponds to low/high phi or vice versa
     o2::utils::BringTo02Pi(phi1);
-    float r2This = (phi0<phi1 && phi1-phi0<o2::constants::math::PI) ?  // pick R of lowest angle
-      lad.xyEdges.getX0()*lad.xyEdges.getX0() + lad.xyEdges.getY0()*lad.xyEdges.getY0() :
-      lad.xyEdges.getX1()*lad.xyEdges.getX1() + lad.xyEdges.getY1()*lad.xyEdges.getY1();
+    float r2This = (phi0 < phi1 && phi1 - phi0 < o2::constants::math::PI) ? // pick R of lowest angle
+                     lad.xyEdges.getX0() * lad.xyEdges.getX0() + lad.xyEdges.getY0() * lad.xyEdges.getY0()
+                                                                          : lad.xyEdges.getX1() * lad.xyEdges.getX1() + lad.xyEdges.getY1() * lad.xyEdges.getY1();
     //
-    phi0 = std::atan2(plad.xyEdges.getY0(),plad.xyEdges.getX0());
-    phi1 = std::atan2(plad.xyEdges.getY1(),plad.xyEdges.getX1());
+    phi0 = std::atan2(plad.xyEdges.getY0(), plad.xyEdges.getX0());
+    phi1 = std::atan2(plad.xyEdges.getY1(), plad.xyEdges.getX1());
     o2::utils::BringTo02Pi(phi0); // we don't know a priori if edge0/1 corresponds to low/high phi or vice versa
     o2::utils::BringTo02Pi(phi1);
-    float r2Prev = (phi0<phi1 && phi1-phi0<o2::constants::math::PI) ? // pick R of highest angle
-      plad.xyEdges.getX1()*plad.xyEdges.getX1() + plad.xyEdges.getY1()*plad.xyEdges.getY1() :
-      plad.xyEdges.getX0()*plad.xyEdges.getX0() + plad.xyEdges.getY0()*plad.xyEdges.getY0();
-      //      
+    float r2Prev = (phi0 < phi1 && phi1 - phi0 < o2::constants::math::PI) ? // pick R of highest angle
+                     plad.xyEdges.getX1() * plad.xyEdges.getX1() + plad.xyEdges.getY1() * plad.xyEdges.getY1()
+                                                                          : plad.xyEdges.getX0() * plad.xyEdges.getX0() + plad.xyEdges.getY0() * plad.xyEdges.getY0();
+    //
     plad.overlapWithNext = r2Prev > r2This ? RecoLadder::Above : RecoLadder::Below;
   }
-  
+
   int ndiv = nLadders * 3; // number of bins for mapping
   phi2ladder.resize(ndiv);
   float dphi = o2::constants::math::TwoPI / ndiv;

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ChipMappingITS.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ChipMappingITS.h
@@ -201,11 +201,11 @@ class ChipMappingITS
     return sid + ruOnLr;
   }
 
- private:
   // sub-barrel types, their number, N layers, Max N GBT Links per RU
   static constexpr int IB = 0, MB = 1, OB = 2, NSubB = 3, NLayers = 7, NLinks = 3;
 
-  static constexpr std::array<uint8_t, NSubB> GBTHeaderFlagSB = {0x1 << 5, 0x1 << 6, 0x1 << 6}; // prefixes for data GBT header byte
+ private:
+  static constexpr std::array<uint8_t, NSubB> GBTHeaderFlagSB = { 0x1 << 5, 0x1 << 6, 0x1 << 6 }; // prefixes for data GBT header byte
 
   ///< N chips per cable of each sub-barrel
   static constexpr std::array<int, NSubB> NChipsPerCableSB = {1, 7, 7};

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ChipMappingITS.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ChipMappingITS.h
@@ -205,7 +205,7 @@ class ChipMappingITS
   static constexpr int IB = 0, MB = 1, OB = 2, NSubB = 3, NLayers = 7, NLinks = 3;
 
  private:
-  static constexpr std::array<uint8_t, NSubB> GBTHeaderFlagSB = { 0x1 << 5, 0x1 << 6, 0x1 << 6 }; // prefixes for data GBT header byte
+  static constexpr std::array<uint8_t, NSubB> GBTHeaderFlagSB = {0x1 << 5, 0x1 << 6, 0x1 << 6}; // prefixes for data GBT header byte
 
   ///< N chips per cable of each sub-barrel
   static constexpr std::array<int, NSubB> NChipsPerCableSB = {1, 7, 7};

--- a/macro/run_match_TPCITS.C
+++ b/macro/run_match_TPCITS.C
@@ -85,12 +85,7 @@ void run_match_TPCITS(std::string path = "./", std::string outputfile = "o2match
   //-------------------- settings -----------//
   const auto& alpParams = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance();
   matching.setITSROFrameLengthMUS(alpParams.roFrameLength / 1.e3); // ITS ROFrame duration in \mus
-  matching.setCutMatchingChi2(100.);
-  std::array<float, o2::track::kNParams> cutsAbs = {2.f, 2.f, 0.2f, 0.2f, 4.f};
-  std::array<float, o2::track::kNParams> cutsNSig2 = {49.f, 49.f, 49.f, 49.f, 49.f};
-  matching.setCrudeAbsDiffCut(cutsAbs);
-  matching.setCrudeNSigma2Cut(cutsNSig2);
-  matching.setTPCTimeEdgeZSafeMargin(3);
+  // Note: parameters are set via o2::globaltracking::MatchITSTPCParams
   matching.init();
 
   matching.run();


### PR DESCRIPTION
AfterBurner is not yet fully functional (by default off, can be activated via ``o2-tpcits-match-workflow --configKeyValues "tpcitsMatch.runAfterBurner=true"``) but still want to merge to avoid divergences.