### PR TITLE
DPL: Extending dispatching policy

### DIFF
--- a/Framework/Core/include/Framework/DispatchControl.h
+++ b/Framework/Core/include/Framework/DispatchControl.h
@@ -1,0 +1,45 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef FRAMEWORK_DISPATCHCONTROL_H
+#define FRAMEWORK_DISPATCHCONTROL_H
+
+#include "Framework/DispatchPolicy.h"
+#include <functional>
+#include <string>
+
+class FairMQParts;
+
+namespace o2
+{
+namespace header
+{
+struct DataHeader;
+}
+
+namespace framework
+{
+/// @struct DispatchControl
+/// @brief Control for the message dispatching within message context.
+/// Depending on dispatching policy, objects which get ready to be sent during
+/// computing can be scheduled to be sent immediately. The trigger callback
+/// is used to decide when to sent the scheduled messages via the actual dispatch
+/// callback.
+struct DispatchControl {
+  using DispatchCallback = std::function<void(FairMQParts&& message, std::string const&, int)>;
+  using DispatchTrigger = std::function<bool(o2::header::DataHeader const&)>;
+  // dispatcher callback
+  DispatchCallback dispatch;
+  // matcher to trigger sending of scheduled messages
+  DispatchTrigger trigger;
+};
+
+} // namespace framework
+} // namespace o2
+#endif // FRAMEWORK_DISPATCHCONTROL_H

--- a/Framework/Core/include/Framework/DispatchPolicy.h
+++ b/Framework/Core/include/Framework/DispatchPolicy.h
@@ -41,7 +41,7 @@ struct DispatchPolicy {
 
   using DeviceMatcher = std::function<bool(DeviceSpec const& device)>;
   // OutputMatcher can be a later extension, but not expected to be of high priority
-  using OutputMatcher = std::function<bool(Output const&)>;
+  using TriggerMatcher = std::function<bool(Output const&)>;
 
   /// Name of the policy itself.
   std::string name;
@@ -50,6 +50,8 @@ struct DispatchPolicy {
   DeviceMatcher deviceMatcher;
   /// the action to be used for matched devices
   DispatchOp action = DispatchOp::AfterComputation;
+  /// matcher on specific output to trigger sending
+  TriggerMatcher triggerMatcher = [](Output const&) { return true; };
 
   /// Helper to create the default configuration.
   static std::vector<DispatchPolicy> createDefaultPolicies();

--- a/Framework/Core/include/Framework/Output.h
+++ b/Framework/Core/include/Framework/Output.h
@@ -50,6 +50,12 @@ struct Output {
   {
   }
 
+  Output(header::DataHeader const& header)
+    : origin(header.dataOrigin), description(header.dataDescription), subSpec(header.subSpecification)
+  {
+    // TODO: we might also want to create the stack object as a copy
+  }
+
   Output(const Output&& rhs)
     : origin(rhs.origin),
       description(rhs.description),

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -14,6 +14,8 @@
 #include "Framework/DataProcessor.h"
 #include "Framework/DataSpecUtils.h"
 #include "Framework/DeviceState.h"
+#include "Framework/DispatchPolicy.h"
+#include "Framework/DispatchControl.h"
 #include "Framework/EndOfStreamContext.h"
 #include "Framework/FairOptionsRetriever.h"
 #include "Framework/FairMQDeviceProxy.h"
@@ -79,9 +81,15 @@ DataProcessingDevice::DataProcessingDevice(DeviceSpec const& spec, ServiceRegist
   auto dispatcher = [this](FairMQParts&& parts, std::string const& channel, unsigned int index) {
     DataProcessor::doSend(*this, std::move(parts), channel.c_str(), index);
   };
+  auto matcher = [policy = spec.dispatchPolicy](o2::header::DataHeader const& header) {
+    if (policy.triggerMatcher == nullptr) {
+      return true;
+    }
+    return policy.triggerMatcher(Output{header});
+  };
 
   if (spec.dispatchPolicy.action == DispatchPolicy::DispatchOp::WhenReady) {
-    mFairMQContext.init(dispatcher);
+    mFairMQContext.init(DispatchControl{dispatcher, matcher});
   }
 }
 

--- a/Framework/Core/src/DataProcessor.cxx
+++ b/Framework/Core/src/DataProcessor.cxx
@@ -34,23 +34,23 @@ namespace framework
 
 void DataProcessor::doSend(FairMQDevice& device, FairMQParts&& parts, const char* channel, unsigned int index)
 {
-  assert(parts.Size() == 2);
   device.Send(parts, channel, index);
 }
 
 void DataProcessor::doSend(FairMQDevice& device, MessageContext& context)
 {
-  std::unordered_map<std::string, FairMQParts> messages;
-  for (auto& message : context) {
+  std::unordered_map<std::string, FairMQParts> outputs;
+  auto contextMessages = context.getMessagesForSending();
+  for (auto& message : contextMessages) {
     //     monitoringService.send({ message->parts.Size(), "outputs/total" });
     FairMQParts parts = std::move(message->finalize());
     assert(message->empty());
     assert(parts.Size() == 2);
     for (auto& part : parts) {
-      messages[message->channel()].AddPart(std::move(part));
+      outputs[message->channel()].AddPart(std::move(part));
     }
   }
-  for (auto& [channel, parts] : messages) {
+  for (auto& [channel, parts] : outputs) {
     device.Send(parts, channel, 0);
   }
 }

--- a/Framework/Core/test/test_StaggeringWorkflow.cxx
+++ b/Framework/Core/test/test_StaggeringWorkflow.cxx
@@ -23,15 +23,28 @@
 #include "Framework/Logger.h"
 #include "Framework/DispatchPolicy.h"
 #include "Framework/DeviceSpec.h"
+#include "Framework/Output.h"
 #include <FairMQDevice.h>
 #include <chrono>
 #include <cstring>
 #include <iostream>
+#include <regex>
 
 void customize(std::vector<o2::framework::DispatchPolicy>& policies)
 {
   // we customize all devices to dispatch data immediately
-  policies.push_back({"prompt-for-all", [](auto const&) { return true; }, o2::framework::DispatchPolicy::DispatchOp::WhenReady});
+  auto producerMatcher = [](auto const& spec) {
+    return std::regex_match(spec.name.begin(), spec.name.end(), std::regex("producer.*"));
+  };
+  auto processorMatcher = [](auto const& spec) {
+    return std::regex_match(spec.name.begin(), spec.name.end(), std::regex("processor.*"));
+  };
+  auto triggerMatcher = [](auto const& query) {
+    o2::framework::Output reference{"PROD", "TRIGGER"};
+    return reference.origin == query.origin && reference.description == query.description;
+  };
+  policies.push_back({"producer-policy", producerMatcher, o2::framework::DispatchPolicy::DispatchOp::WhenReady, triggerMatcher});
+  policies.push_back({"processor-policy", processorMatcher, o2::framework::DispatchPolicy::DispatchOp::WhenReady});
 }
 
 void customize(std::vector<o2::framework::CompletionPolicy>& policies)
@@ -66,6 +79,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
   std::vector<OutputSpec> producerOutputs;
   for (auto const& subspec : subspecs) {
     producerOutputs.emplace_back(OutputSpec{"PROD", "CHANNEL", subspec, Lifetime::Timeframe});
+    producerOutputs.emplace_back(OutputSpec{"PROD", "TRIGGER", subspec, Lifetime::Timeframe});
   }
 
   auto producerFct = adaptStateless([subspecs](DataAllocator& outputs, RawDeviceService& device, ControlService& control) {
@@ -75,8 +89,12 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
     // }
 
     for (auto const& subspec : subspecs) {
-      //pc.outputs().make<MyDataType>(Output{ "PROD", "CHANNEL", subspec, Lifetime::Timeframe }) = subspec;
+      // since the snapshot copy is ready for sending it is scheduled but hald back
+      // because of the CompletionPolicy trigger matcher. This message will be
+      // sent together with the second message.
       outputs.snapshot(Output{"PROD", "CHANNEL", subspec, Lifetime::Timeframe}, subspec);
+      device.device()->WaitFor(std::chrono::milliseconds(1000));
+      outputs.snapshot(Output{"PROD", "TRIGGER", subspec, Lifetime::Timeframe}, subspec);
       //  std::cout << "publishing channel " << subspec << std::endl;
       device.device()->WaitFor(std::chrono::milliseconds(1000));
     }
@@ -87,18 +105,22 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
 
   auto processorFct = [](ProcessingContext& pc) {
     int nActiveInputs = 0;
+    LOG(INFO) << "processing ...";
     for (auto const& input : pc.inputs()) {
       if (pc.inputs().isValid(input.spec->binding) == false) {
         // this input slot is empty
         continue;
       }
       auto& data = pc.inputs().get<MyDataType>(input.spec->binding.c_str());
-      std::cout << "processing channel " << data << std::endl;
-      pc.outputs().make<MyDataType>(Output{"PROC", "CHANNEL", data, Lifetime::Timeframe}) = data;
+      LOG(INFO) << "processing " << input.spec->binding << " " << data;
+      // check if the channel binding starts with 'trigger'
+      if (input.spec->binding.find("trigger") == 0) {
+        pc.outputs().make<MyDataType>(Output{"PROC", "CHANNEL", data, Lifetime::Timeframe}) = data;
+      }
       nActiveInputs++;
     }
-    // since we publish with delays, there should be only one active input at a time
-    ASSERT_ERROR(nActiveInputs == 1);
+    // since we publish with delays, and two channels are always sent together
+    ASSERT_ERROR(nActiveInputs == 2);
   };
   auto amendSinkInput = [subspecs](InputSpec& input, size_t index) {
     input.binding += std::to_string(subspecs[index]);
@@ -112,14 +134,15 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
     return adaptStateless([](InputRecord& inputs) {
       for (auto const& input : inputs) {
         auto& data = inputs.get<MyDataType>(input.spec->binding.c_str());
-        std::cout << "received channel " << data << std::endl;
+        LOG(INFO) << "received channel " << data;
       } });
   });
 
   std::vector<DataProcessorSpec> workflow = parallelPipeline(
     std::vector<DataProcessorSpec>{DataProcessorSpec{
       "processor",
-      {InputSpec{"input", "PROD", "CHANNEL", 0, Lifetime::Timeframe}},
+      {InputSpec{"input", "PROD", "CHANNEL", 0, Lifetime::Timeframe},
+       InputSpec{"trigger", "PROD", "TRIGGER", 0, Lifetime::Timeframe}},
       {OutputSpec{"PROC", "CHANNEL", 0, Lifetime::Timeframe}},
       AlgorithmSpec{processorFct}}},
     nPipelines,


### PR DESCRIPTION
Main extensions:
- sending messages in one multimessage at the end of computation
- implementing trigger matcher in `DispatchPolicy`

While messages which become ready for sending during computation are scheduled,
a trigger matcher decides when to send all scheduled messages. All messages
are sent as multimessage. This makes sure that data sets belonging together
will be received together on the receiver side and simplifies implementation
of `CompletionPolicy`.
