### PR TITLE
Output for ITS vertices + standalone reader

### DIFF
--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/ROFRecord.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/ROFRecord.h
@@ -63,8 +63,21 @@ class ROFRecord
   {
     return gsl::span<const T>(&tfdata[getFirstEntry()], getNEntries());
   }
+
   template <typename T>
   const T* getROFDataAt(int i, const gsl::span<const T> tfdata) const
+  {
+    return i < getNEntries() ? &tfdata[getFirstEntry() + i] : nullptr;
+  }
+
+  template <typename T>
+  gsl::span<const T> getROFData(const std::vector<T>& tfdata) const
+  {
+    return gsl::span<const T>(&tfdata[getFirstEntry()], getNEntries());
+  }
+
+  template <typename T>
+  const T* getROFDataAt(int i, const std::vector<T>& tfdata) const
   {
     return i < getNEntries() ? &tfdata[getFirstEntry() + i] : nullptr;
   }

--- a/DataFormats/Detectors/ITSMFT/common/src/ITSMFTDataFormatsLinkDef.h
+++ b/DataFormats/Detectors/ITSMFT/common/src/ITSMFTDataFormatsLinkDef.h
@@ -36,10 +36,24 @@
 #pragma link C++ function o2::itsmft::getROFData(const gsl::span <const o2::itsmft::Cluster> tfdata) const;
 #pragma link C++ function o2::itsmft::getROFData(const gsl::span <const o2::itsmft::CompCluster> tfdata) const;
 #pragma link C++ function o2::itsmft::getROFData(const gsl::span <const o2::itsmft::CompClusterExt> tfdata) const;
+#pragma link C++ function o2::itsmft::getROFData(const gsl::span < const o2::dataformats::Vertex <o2::dataformats::TimeStamp <int>> tfdata) const;
 
 #pragma link C++ function o2::itsmft::getROFDataAt(int i, const gsl::span <const o2::itsmft::Digit> tfdata) const;
 #pragma link C++ function o2::itsmft::getROFDataAt(int i, const gsl::span <const o2::itsmft::Cluster> tfdata) const;
 #pragma link C++ function o2::itsmft::getROFDataAt(int i, const gsl::span <const o2::itsmft::CompCluster> tfdata) const;
 #pragma link C++ function o2::itsmft::getROFDataAt(int i, const gsl::span <const o2::itsmft::CompClusterExt> tfdata) const;
+#pragma link C++ function o2::itsmft::getROFDataAt(int i, const gsl::span <const o2::dataformats::Vertex <o2::dataformats::TimeStamp <int>>> tfdata) const;
+
+#pragma link C++ function o2::itsmft::getROFData(const std::vector <o2::itsmft::Digit>& tfdata) const;
+#pragma link C++ function o2::itsmft::getROFData(const std::vector <o2::itsmft::Cluster>& tfdata) const;
+#pragma link C++ function o2::itsmft::getROFData(const std::vector <o2::itsmft::CompCluster>& tfdata) const;
+#pragma link C++ function o2::itsmft::getROFData(const std::vector <o2::itsmft::CompClusterExt>& tfdata) const;
+#pragma link C++ function o2::itsmft::getROFData(const gsl::span < const o2::dataformats::Vertex <o2::dataformats::TimeStamp <int>>& tfdata) const;
+
+#pragma link C++ function o2::itsmft::getROFDataAt(int i, const std::vector <o2::itsmft::Digit>& tfdata) const;
+#pragma link C++ function o2::itsmft::getROFDataAt(int i, const std::vector <o2::itsmft::Cluster>& tfdata) const;
+#pragma link C++ function o2::itsmft::getROFDataAt(int i, const std::vector <o2::itsmft::CompCluster>& tfdata) const;
+#pragma link C++ function o2::itsmft::getROFDataAt(int i, const std::vector <o2::itsmft::CompClusterExt>& tfdata) const;
+#pragma link C++ function o2::itsmft::getROFDataAt(int i, const std::vector <o2::dataformats::Vertex <o2::dataformats::TimeStamp <int>>>& tfdata) const;
 
 #endif

--- a/Detectors/ITSMFT/ITS/workflow/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/workflow/CMakeLists.txt
@@ -17,7 +17,8 @@ o2_add_library(ITSWorkflow
                        src/CookedTrackerSpec.cxx
                        src/TrackWriterSpec.cxx
                        src/TrackReaderSpec.cxx
-               PUBLIC_LINK_LIBRARIES O2::Framework
+		       src/VertexReaderSpec.cxx
+	       PUBLIC_LINK_LIBRARIES O2::Framework
                                      O2::SimConfig
                                      O2::DataFormatsITS
                                      O2::SimulationDataFormat

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/TrackWriterSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/TrackWriterSpec.h
@@ -18,20 +18,18 @@
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
 
-using namespace o2::framework;
-
 namespace o2
 {
 namespace its
 {
 
-class TrackWriter : public Task
+class TrackWriter : public o2::framework::Task
 {
  public:
   TrackWriter(bool useMC) : mUseMC(useMC) {}
   ~TrackWriter() override = default;
-  void init(InitContext& ic) final;
-  void run(ProcessingContext& pc) final;
+  void init(o2::framework::InitContext& ic) final;
+  void run(o2::framework::ProcessingContext& pc) final;
 
  private:
   int mState = 0;
@@ -41,7 +39,7 @@ class TrackWriter : public Task
 
 /// create a processor spec
 /// write ITS tracks a root file
-framework::DataProcessorSpec getTrackWriterSpec(bool useMC);
+o2::framework::DataProcessorSpec getTrackWriterSpec(bool useMC);
 
 } // namespace its
 } // namespace o2

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/VertexReaderSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/VertexReaderSpec.h
@@ -8,67 +8,54 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// @file   TrackReaderSpec.h
+/// @file   VertexReaderSpec.h
 
-#ifndef O2_ITS_TRACKREADER
-#define O2_ITS_TRACKREADER
+#ifndef O2_ITS_VERTEXREADER
+#define O2_ITS_VERTEXREADER
 
 #include "TFile.h"
 
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
-#include "Headers/DataHeader.h"
-#include "DataFormatsITS/TrackITS.h"
-#include "SimulationDataFormat/MCCompLabel.h"
-#include "SimulationDataFormat/MCTruthContainer.h"
-#include "DataFormatsITSMFT/ROFRecord.h"
 #include "ReconstructionDataFormats/Vertex.h"
+#include "DataFormatsITSMFT/ROFRecord.h"
 
 namespace o2
 {
 namespace its
 {
+// read ITS vertices from the output tree of ITS tracking
 
-class TrackReader : public o2::framework::Task
+class VertexReader : public o2::framework::Task
 {
   using Vertex = o2::dataformats::Vertex<o2::dataformats::TimeStamp<int>>;
 
  public:
-  TrackReader(bool useMC = true);
-  ~TrackReader() override = default;
+  VertexReader() = default;
+  ~VertexReader() override = default;
   void init(o2::framework::InitContext& ic) final;
   void run(o2::framework::ProcessingContext& pc) final;
 
  protected:
   void accumulate();
 
-  std::vector<o2::itsmft::ROFRecord> mROFRec, *mROFRecInp = &mROFRec;
   std::vector<o2::itsmft::ROFRecord> mVerticesROFRec, *mVerticesROFRecInp = &mVerticesROFRec;
-  std::vector<o2::its::TrackITS> mTracks, *mTracksInp = &mTracks;
   std::vector<Vertex> mVertices, *mVerticesInp = &mVertices;
-  std::vector<int> mClusInd, *mClusIndInp = &mClusInd;
-  o2::dataformats::MCTruthContainer<o2::MCCompLabel> mMCTruth, *mMCTruthInp = &mMCTruth;
 
   o2::header::DataOrigin mOrigin = o2::header::gDataOriginITS;
 
   bool mFinished = false;
-  bool mUseMC = true; // use MC truth
-
   std::string mInputFileName = "";
-  std::string mTrackTreeName = "o2sim";
-  std::string mROFBranchName = "ITSTracksROF";
-  std::string mTrackBranchName = "ITSTrack";
-  std::string mClusIdxBranchName = "ITSTrackClusIdx";
+  std::string mVertexTreeName = "o2sim";
   std::string mVertexBranchName = "Vertices";
   std::string mVertexROFBranchName = "VerticesROF";
-  std::string mTrackMCTruthBranchName = "ITSTrackMCTruth";
 };
 
 /// create a processor spec
-/// read ITS track data from a root file
-framework::DataProcessorSpec getITSTrackReaderSpec(bool useMC = true);
+/// read ITS vertex data from a root file
+o2::framework::DataProcessorSpec getITSVertexReaderSpec();
 
 } // namespace its
 } // namespace o2
 
-#endif /* O2_ITS_TRACKREADER */
+#endif /* O2_ITS_VERTEXREADER */

--- a/Detectors/ITSMFT/ITS/workflow/src/CookedTrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/CookedTrackerSpec.cxx
@@ -41,6 +41,8 @@ namespace o2
 namespace its
 {
 
+using Vertex = o2::dataformats::Vertex<o2::dataformats::TimeStamp<int>>;
+
 void CookedTrackerDPL::init(InitContext& ic)
 {
   auto nthreads = ic.options().get<int>("nthreads");
@@ -99,16 +101,27 @@ void CookedTrackerDPL::run(ProcessingContext& pc)
   o2::its::Vertexer vertexer(&vertexerTraits);
   o2::its::ROframe event(0);
 
+  std::vector<o2::itsmft::ROFRecord> vertROFvec;
+  std::vector<Vertex> vertices;
   std::vector<o2::its::TrackITS> tracks;
   std::vector<int> clusIdx;
   for (auto& rof : rofs) {
     o2::its::ioutils::loadROFrameData(rof, event, clusters, labels.get());
     vertexer.clustersToVertices(event);
-    auto vertices = vertexer.exportVertices();
-    if (vertices.empty()) {
-      vertices.emplace_back();
+    auto vtxVecLoc = vertexer.exportVertices();
+
+    // for vertices output
+    auto& vtxROF = vertROFvec.emplace_back(rof); // register entry and number of vertices in the
+    vtxROF.setFirstEntry(vertices.size());       // dedicated ROFRecord
+    vtxROF.setNEntries(vtxVecLoc.size());
+    for (const auto& vtx : vtxVecLoc) {
+      vertices.push_back(vtx);
     }
-    mTracker.setVertices(vertices);
+
+    if (vtxVecLoc.empty()) {
+      vtxVecLoc.emplace_back();
+    }
+    mTracker.setVertices(vtxVecLoc);
     mTracker.process(clusters, tracks, clusIdx, rof);
   }
 
@@ -116,6 +129,8 @@ void CookedTrackerDPL::run(ProcessingContext& pc)
   pc.outputs().snapshot(Output{"ITS", "TRACKS", 0, Lifetime::Timeframe}, tracks);
   pc.outputs().snapshot(Output{"ITS", "TRACKCLSID", 0, Lifetime::Timeframe}, clusIdx);
   pc.outputs().snapshot(Output{"ITS", "ITSTrackROF", 0, Lifetime::Timeframe}, rofs);
+  pc.outputs().snapshot(Output{"ITS", "VERTICES", 0, Lifetime::Timeframe}, vertices);
+  pc.outputs().snapshot(Output{"ITS", "VERTICESROF", 0, Lifetime::Timeframe}, vertROFvec);
 
   if (mUseMC) {
     pc.outputs().snapshot(Output{"ITS", "TRACKSMCTR", 0, Lifetime::Timeframe}, trackLabels);
@@ -123,6 +138,7 @@ void CookedTrackerDPL::run(ProcessingContext& pc)
   }
 
   mState = 2;
+  pc.services().get<ControlService>().endOfStream();
   pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
 }
 
@@ -137,6 +153,8 @@ DataProcessorSpec getCookedTrackerSpec(bool useMC)
   outputs.emplace_back("ITS", "TRACKS", 0, Lifetime::Timeframe);
   outputs.emplace_back("ITS", "TRACKCLSID", 0, Lifetime::Timeframe);
   outputs.emplace_back("ITS", "ITSTrackROF", 0, Lifetime::Timeframe);
+  outputs.emplace_back("ITS", "VERTICES", 0, Lifetime::Timeframe);
+  outputs.emplace_back("ITS", "VERTICESROF", 0, Lifetime::Timeframe);
 
   if (useMC) {
     inputs.emplace_back("labels", "ITS", "CLUSTERSMCTR", 0, Lifetime::Timeframe);

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackReaderSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackReaderSpec.cxx
@@ -49,6 +49,8 @@ void TrackReader::run(ProcessingContext& pc)
   pc.outputs().snapshot(Output{mOrigin, "ITSTrackROF", 0, Lifetime::Timeframe}, mROFRec);
   pc.outputs().snapshot(Output{mOrigin, "TRACKS", 0, Lifetime::Timeframe}, mTracks);
   pc.outputs().snapshot(Output{mOrigin, "TRACKCLSID", 0, Lifetime::Timeframe}, mClusInd);
+  pc.outputs().snapshot(Output{"ITS", "VERTICES", 0, Lifetime::Timeframe}, mVertices);
+  pc.outputs().snapshot(Output{"ITS", "VERTICESROF", 0, Lifetime::Timeframe}, mVerticesROFRec);
   if (mUseMC) {
     pc.outputs().snapshot(Output{mOrigin, "TRACKSMCTR", 0, Lifetime::Timeframe}, mMCTruth);
   }
@@ -77,6 +79,18 @@ void TrackReader::accumulate()
   trTree->SetBranchAddress(mROFBranchName.c_str(), &mROFRecInp);
   trTree->SetBranchAddress(mTrackBranchName.c_str(), &mTracksInp);
   trTree->SetBranchAddress(mClusIdxBranchName.c_str(), &mClusIndInp);
+  if (!trTree->GetBranch(mVertexBranchName.c_str())) {
+    LOG(WARNING) << "No " << mVertexBranchName << " branch in " << mTrackTreeName << " -> vertices will be empty";
+  } else {
+    trTree->SetBranchAddress(mVertexBranchName.c_str(), &mVerticesInp);
+  }
+  if (!trTree->GetBranch(mVertexROFBranchName.c_str())) {
+    LOG(WARNING) << "No " << mVertexROFBranchName << " branch in " << mTrackTreeName
+                 << " -> vertices ROFrecords will be empty";
+  } else {
+    trTree->SetBranchAddress(mVertexROFBranchName.c_str(), &mVerticesROFRecInp);
+  }
+
   if (mUseMC) {
     if (trTree->GetBranch(mTrackMCTruthBranchName.c_str())) {
       trTree->SetBranchAddress(mTrackMCTruthBranchName.c_str(), &mMCTruthInp);
@@ -97,6 +111,8 @@ DataProcessorSpec getITSTrackReaderSpec(bool useMC)
   outputSpec.emplace_back("ITS", "ITSTrackROF", 0, Lifetime::Timeframe);
   outputSpec.emplace_back("ITS", "TRACKS", 0, Lifetime::Timeframe);
   outputSpec.emplace_back("ITS", "TRACKCLSID", 0, Lifetime::Timeframe);
+  outputSpec.emplace_back("ITS", "VERTICES", 0, Lifetime::Timeframe);
+  outputSpec.emplace_back("ITS", "VERTICESROF", 0, Lifetime::Timeframe);
   if (useMC) {
     outputSpec.emplace_back("ITS", "TRACKSMCTR", 0, Lifetime::Timeframe);
   }

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackWriterSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackWriterSpec.cxx
@@ -21,6 +21,7 @@
 #include "DataFormatsITSMFT/ROFRecord.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
+#include "ReconstructionDataFormats/Vertex.h"
 
 using namespace o2::framework;
 
@@ -28,6 +29,7 @@ namespace o2
 {
 namespace its
 {
+using Vertex = o2::dataformats::Vertex<o2::dataformats::TimeStamp<int>>;
 
 void TrackWriter::init(InitContext& ic)
 {
@@ -49,6 +51,8 @@ void TrackWriter::run(ProcessingContext& pc)
   auto tracks = pc.inputs().get<const std::vector<o2::its::TrackITS>>("tracks");
   auto clusIdx = pc.inputs().get<gsl::span<int>>("trackClIdx");
   auto rofs = pc.inputs().get<const std::vector<o2::itsmft::ROFRecord>>("ROframes");
+  auto vertices = pc.inputs().get<const std::vector<Vertex>>("vertices");
+  auto verticesROF = pc.inputs().get<const std::vector<o2::itsmft::ROFRecord>>("verticesROF");
 
   std::unique_ptr<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>> labels;
   const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* plabels = nullptr;
@@ -64,6 +68,8 @@ void TrackWriter::run(ProcessingContext& pc)
   TTree tree("o2sim", "Tree with ITS tracks");
   tree.Branch("ITSTrack", &tracks);
   tree.Branch("ITSTrackClusIdx", &clusIdxOutPtr);
+  tree.Branch("Vertices", &vertices);
+  tree.Branch("VerticesROF", &verticesROF);
   if (mUseMC) {
     labels = pc.inputs().get<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>*>("labels");
     plabels = labels.get();
@@ -97,6 +103,8 @@ DataProcessorSpec getTrackWriterSpec(bool useMC)
   inputs.emplace_back("tracks", "ITS", "TRACKS", 0, Lifetime::Timeframe);
   inputs.emplace_back("trackClIdx", "ITS", "TRACKCLSID", 0, Lifetime::Timeframe);
   inputs.emplace_back("ROframes", "ITS", "ITSTrackROF", 0, Lifetime::Timeframe);
+  inputs.emplace_back("vertices", "ITS", "VERTICES", 0, Lifetime::Timeframe);
+  inputs.emplace_back("verticesROF", "ITS", "VERTICESROF", 0, Lifetime::Timeframe);
   if (useMC) {
     inputs.emplace_back("labels", "ITS", "TRACKSMCTR", 0, Lifetime::Timeframe);
     inputs.emplace_back("MC2ROframes", "ITS", "ITSTrackMC2ROF", 0, Lifetime::Timeframe);

--- a/Detectors/ITSMFT/ITS/workflow/src/VertexReaderSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/VertexReaderSpec.cxx
@@ -1,0 +1,91 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   VertexReaderSpec.cxx
+
+#include <vector>
+
+#include "TTree.h"
+
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "ITSWorkflow/VertexReaderSpec.h"
+
+using namespace o2::framework;
+using namespace o2::its;
+
+namespace o2
+{
+namespace its
+{
+
+void VertexReader::init(InitContext& ic)
+{
+  mInputFileName = ic.options().get<std::string>("its-vertex-infile");
+}
+
+void VertexReader::run(ProcessingContext& pc)
+{
+
+  if (mFinished) {
+    return;
+  }
+
+  // load data from files
+  TFile trFile(mInputFileName.c_str(), "read");
+  if (trFile.IsZombie()) {
+    LOG(FATAL) << "Failed to open tracks file " << mInputFileName;
+  }
+  TTree* trTree = (TTree*)trFile.Get(mVertexTreeName.c_str());
+  if (!trTree) {
+    LOG(FATAL) << "Failed to load tracks tree " << mVertexTreeName << " from " << mInputFileName;
+  }
+  if (!trTree->GetBranch(mVertexBranchName.c_str())) {
+    LOG(FATAL) << "No " << mVertexBranchName << " branch in " << mVertexTreeName;
+  }
+  if (!trTree->GetBranch(mVertexROFBranchName.c_str())) {
+    LOG(FATAL) << "No " << mVertexROFBranchName << " branch in " << mVertexTreeName;
+  }
+  trTree->SetBranchAddress(mVertexBranchName.c_str(), &mVerticesInp);
+  trTree->SetBranchAddress(mVertexROFBranchName.c_str(), &mVerticesROFRecInp);
+
+  trTree->GetBranch(mVertexROFBranchName.c_str())->GetEntry(0);
+  trTree->GetBranch(mVertexBranchName.c_str())->GetEntry(0);
+  delete trTree;
+  trFile.Close();
+
+  LOG(INFO) << "ITSVertexReader pushes " << mVerticesROFRec.size() << " ROFRecords,"
+            << mVertices.size() << " vertices";
+  pc.outputs().snapshot(Output{"ITS", "VERTICES", 0, Lifetime::Timeframe}, mVertices);
+  pc.outputs().snapshot(Output{"ITS", "VERTICESROF", 0, Lifetime::Timeframe}, mVerticesROFRec);
+
+  mFinished = true;
+
+  pc.services().get<ControlService>().endOfStream();
+  pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+}
+
+DataProcessorSpec getITSVertexReaderSpec()
+{
+  std::vector<OutputSpec> outputSpec;
+  outputSpec.emplace_back("ITS", "VERTICES", 0, Lifetime::Timeframe);
+  outputSpec.emplace_back("ITS", "VERTICESROF", 0, Lifetime::Timeframe);
+
+  return DataProcessorSpec{
+    "its-vertex-reader",
+    Inputs{},
+    outputSpec,
+    AlgorithmSpec{adaptFromTask<VertexReader>()},
+    Options{
+      {"its-vertex-infile", VariantType::String, "o2trac_its.root", {"Name of the input ITS vertex file"}}}};
+}
+
+} // namespace its
+} // namespace o2

--- a/macro/run_trac_ca_its.C
+++ b/macro/run_trac_ca_its.C
@@ -129,11 +129,16 @@ void run_trac_ca_its(std::string path = "./",
   TTree outTree("o2sim", "CA ITS Tracks");
   std::vector<o2::its::TrackITS> tracksITS, *tracksITSPtr = &tracksITS;
   std::vector<int> trackClIdx, *trackClIdxPtr = &trackClIdx;
+  std::vector<o2::itsmft::ROFRecord> vertROFvec, *vertROFvecPtr = &vertROFvec;
+  std::vector<Vertex> vertices, *verticesPtr = &vertices;
+
   MCLabCont trackLabels, *trackLabelsPtr = &trackLabels;
   outTree.Branch("ITSTrack", &tracksITSPtr);
   outTree.Branch("ITSTrackClusIdx", &trackClIdxPtr);
   outTree.Branch("ITSTrackMCTruth", &trackLabelsPtr);
   outTree.Branch("ITSTracksMC2ROF", &mc2rofs);
+  outTree.Branch("Vertices", &verticesPtr);
+  outTree.Branch("VerticesROF", &vertROFvecPtr);
   if (!itsClusters.GetBranch("ITSClustersROF")) {
     LOG(FATAL) << "Did not find ITS clusters branch ITSClustersROF in the input tree";
   }
@@ -172,6 +177,13 @@ void run_trac_ca_its(std::string path = "./",
     vertexer.validateTracklets();
     vertexer.findVertices();
     std::vector<Vertex> vertITS = vertexer.exportVertices();
+    auto& vtxROF = vertROFvec.emplace_back(rof); // register entry and number of vertices in the
+    vtxROF.setFirstEntry(vertices.size());       // dedicated ROFRecord
+    vtxROF.setNEntries(vertITS.size());
+    for (const auto& vtx : vertITS) {
+      vertices.push_back(vtx);
+    }
+
     if (!vertITS.empty()) {
       // Using only the first vertex in the list
       cout << " - Reconstructed vertexer: x = " << vertITS[0].getX() << " y = " << vertITS[0].getY() << " x = " << vertITS[0].getZ() << std::endl;


### PR DESCRIPTION
Hi @pzhristov, this PR will store together with ITS tracks the vector of seeding vertices (of the type ``o2::dataformats::Vertex<o2::dataformats::TimeStamp<int>>``) from the vertexer @mconcas + vector ROFRecords for navigation over them (for every ITS ROF it points on the entry of the 1st vertex of this ROF and number of vertices found). They will be read-out by the ITS TrackReader device together with tracks. One can also read vertices + their ROFRecords only by the standalone VertexReader.

Sample code to access them from the DPL: 
````
  auto vertices = pc.inputs().get<gsl::span<Vertex>>("vertices");
  auto verticesROF = pc.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("verticesROF");
  for (const auto& rf : verticesROF) {
      printf("%d Vertices for ROF ", rf.getNEntries());      
      rf.print();                                                                                                                                                                                    
      auto vtxspan = rf.getROFData(vertices);                                                                                                                                                             
      int cntv = 0;                                                                                                                                                                                  
      for (const auto& v : vtxspan) {                                                                                                                                                                
        printf("Vtx%d) ",cntv++);                                                                                                                                                                      
        v.print();                                                                                                                                                                                   
      }                                                                                                                                                                                              
    }                                                                                                                                                                                                
  }          
 // or, if you don't need to relate it to ITS ReadOutFrames, one can just loop
 for (const auto &v : vertices) {
   v.print();
 }
````