### PR TITLE
[O2-1049] test_ProcessorOptions flawed termination logic fails

### DIFF
--- a/Framework/Core/test/test_ProcessorOptions.cxx
+++ b/Framework/Core/test/test_ProcessorOptions.cxx
@@ -8,7 +8,10 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 #include "Framework/runDataProcessing.h"
+#include "Framework/CallbackService.h"
 #include "Framework/ControlService.h"
+
+#include <memory>
 
 using namespace o2::framework;
 
@@ -34,11 +37,15 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
           // read back the option from the command line, see CMakeLists.txt
           ASSERT_ERROR(configstring == "require-me");
 
-          return [](ProcessingContext& ctx) {
+          return [isReady = std::make_shared<bool>(false)](ProcessingContext& ctx) {
+            if (*isReady == true) {
+              return;
+            }
             // there is nothing to do, simply stop the workflow but we have to send at least one message
             // to make sure that the callback of the consumer is called
             ctx.outputs().make<int>(Output{"TST", "TEST", 0, Lifetime::Timeframe}) = 42;
             ctx.services().get<ControlService>().endOfStream();
+            *isReady = true;
           };
         },
       },
@@ -84,8 +91,14 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
           ASSERT_ERROR(configstring == "consumer-config");
           ASSERT_ERROR(anotheroption == "hello-aliceo2");
 
-          return [](ProcessingContext& ctx) {
+          auto data = std::make_shared<int>(0);
+          ic.services().get<CallbackService>().set(CallbackService::Id::EndOfStream,
+                                                   [data](EndOfStreamContext& context) {
+                                                     ASSERT_ERROR(*data == 42);
+                                                   });
+          return [data](ProcessingContext& ctx) {
             // there is nothing to do, simply stop the workflow
+            *data = ctx.inputs().get<int>("in");
           };
         },
       },


### PR DESCRIPTION
Follow-up to 7aa2497c, DPL unit test test_ProcessorOptions still failing
occasionally. Skipping now also sending of further messages after sending
the end of stream control command.

The error occurs when sending on a FairMQ channel is interrupted when the
devices are shut down. The problem is that the producer is continuously sending.
Failed sending on socket xyz, reason: Interrupted system call
This can probably be fixed on a FairMQ level.