### PR TITLE
Macro to analyse and check labels for digits

### DIFF
--- a/macro/CMakeLists.txt
+++ b/macro/CMakeLists.txt
@@ -16,6 +16,7 @@ install(FILES CheckClusters_mft.C
               CheckDigits_mft.C
               SetIncludePath.C
               analyzeHits.C
+              analyzeDigitLabels.C
               analyzeOriginHits.C
               build_geometry.C
               checkTOFMatching.C
@@ -92,7 +93,11 @@ o2_add_test_root_macro(analyzeHits.C
                                              O2::HMPIDBase
                                              O2::TPCSimulation
                                              O2::PHOSBase
-                                             O2::FDDSimulation)
+                                             O2::FDDSimulation
+                                             O2::MCHSimulation
+                                             O2::MIDSimulation
+					     O2::ZDCSimulation
+					     O2::CPVBase)
 
 o2_add_test_root_macro(analyzeOriginHits.C
                        PUBLIC_LINK_LIBRARIES O2::SimulationDataFormat
@@ -133,6 +138,26 @@ o2_add_test_root_macro(eventDisplay.C PUBLIC_LINK_LIBRARIES FairRoot::Base)
 o2_add_test_root_macro(
   initSimGeomAndField.C
   PUBLIC_LINK_LIBRARIES O2::DataFormatsParameters O2::Field)
+
+o2_add_test_root_macro(
+        analyzeDigitLabels.C
+        PUBLIC_LINK_LIBRARIES O2::SimulationDataFormat O2::ITSMFTSimulation
+                                             O2::TOFSimulation
+                                             O2::EMCALBase
+                                             O2::TRDSimulation
+                                             O2::FT0Simulation
+                                             O2::DataFormatsFV0
+                                             O2::HMPIDBase
+                                             O2::TPCSimulation
+                                             O2::PHOSBase
+                                             O2::PHOSSimulation
+                                             O2::FDDSimulation
+                                             O2::MCHSimulation
+                                             O2::MIDSimulation
+					     O2::ZDCSimulation
+					     O2::CPVBase 
+                                             O2::CPVSimulation
+                                             O2::ZDCSimulation)
 
 if(Geant4_FOUND)
 o2_add_test_root_macro(o2sim.C

--- a/macro/analyzeDigitLabels.C
+++ b/macro/analyzeDigitLabels.C
@@ -1,0 +1,299 @@
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include "TFile.h"
+#include "TTree.h"
+#include "TString.h"
+#include "SimulationDataFormat/MCTruthContainer.h"
+#include "SimulationDataFormat/MCCompLabel.h"
+#include "PHOSSimulation/MCLabel.h"
+#include "DataFormatsFT0/MCLabel.h"
+#include "DataFormatsFDD/MCLabel.h"
+#include "ZDCSimulation/MCLabel.h"
+#include "MIDSimulation/MCLabel.h"
+#include "TRDBase/MCLabel.h"
+
+#include <gsl/gsl> // for guideline support library; array_view
+#include <unordered_map>
+#endif
+
+TString gPrefix("");
+
+// see if multiple labels refer to pileup situation
+template <typename Labels>
+bool isPileup(Labels labels)
+{
+  std::unordered_map<int, int> events;
+  for (auto& label : labels) {
+    events[label.getEventID()] = 1;
+  }
+  return events.size() > 1;
+}
+
+// see if multiple labels refer to embedding situation
+template <typename Labels>
+bool isEmbedding(Labels labels)
+{
+  std::unordered_map<int, int> sources;
+  for (auto& label : labels) {
+    sources[label.getSourceID()] = 1;
+  }
+  return sources.size() > 1;
+}
+
+struct LabelStats {
+  int NIndices = 0; // number of indexed digits
+  int NLabels = 0;  // number of labels
+  bool eventpileup = false;
+  bool embedding = false;
+  bool trackpileup = false;
+
+  template <typename Labels>
+  void addLabels(Labels labels)
+  {
+    NIndices++;
+    NLabels += labels.size();
+    if (labels.size() > 1) {
+      eventpileup |= isPileup(labels);
+      embedding |= isEmbedding(labels);
+    }
+  }
+
+  void print()
+  {
+    std::cout << NIndices << " "
+              << NLabels << " "
+              << "pileup " << eventpileup << " "
+              << "embedding " << embedding << " "
+              << "\n";
+  }
+};
+
+template <typename LabelType, typename Accumulator = LabelStats>
+void analyse(TTree* tr, const char* brname, Accumulator& prop)
+{
+  auto br = tr->GetBranch(brname);
+  if (!br) {
+    return;
+  }
+  auto entries = br->GetEntries();
+  o2::dataformats::MCTruthContainer<LabelType>* labels = nullptr;
+  br->SetAddress(&labels);
+
+  for (int i = 0; i < entries; ++i) {
+    br->GetEntry(i);
+
+    for (int i = 0; i < (int)labels->getIndexedSize(); ++i) {
+      prop.addLabels(labels->getLabels(i));
+    }
+  }
+};
+
+// tof is special
+template <typename LabelType, typename Accumulator = LabelStats>
+void analyseTOF(TTree* tr, const char* brname, Accumulator& prop)
+{
+  auto br = tr->GetBranch(brname);
+  if (!br) {
+    return;
+  }
+  auto entries = br->GetEntries();
+  std::vector<o2::dataformats::MCTruthContainer<LabelType>>* container = nullptr;
+  br->SetAddress(&container);
+
+  for (int i = 0; i < entries; ++i) {
+    br->GetEntry(i);
+
+    for (auto& labels : *container) {
+      for (int i = 0; i < (int)labels.getIndexedSize(); ++i) {
+        prop.addLabels(labels.getLabels(i));
+      }
+    }
+  }
+};
+
+// need a special version for TPC since loop over sectors
+void analyzeTPC(TTree* reftree)
+{
+  LabelStats result;
+  for (int sector = 0; sector < 35; ++sector) {
+    std::stringstream brnamestr;
+    brnamestr << "TPCDigitMCTruth_" << sector;
+    analyse<o2::MCCompLabel>(reftree, brnamestr.str().c_str(), result);
+  }
+  std::cout << gPrefix << " TPC ";
+  result.print();
+};
+
+// do comparison for ITS
+void analyzeITS(TTree* reftree)
+{
+  LabelStats result;
+  analyse<o2::MCCompLabel>(reftree, "ITSDigitMCTruth", result);
+  std::cout << gPrefix << " ITS ";
+  result.print();
+}
+
+// do comparison for MFT
+void analyzeMFT(TTree* reftree)
+{
+  LabelStats result;
+  analyse<o2::MCCompLabel>(reftree, "MFTDigitMCTruth", result);
+  std::cout << gPrefix << " MFT ";
+  result.print();
+}
+
+// do comparison for EMC
+void analyzeEMC(TTree* reftree)
+{
+  LabelStats result;
+  analyse<o2::MCCompLabel>(reftree, "EMCALDigitMCTruth", result);
+  std::cout << gPrefix << " EMC ";
+  result.print();
+}
+
+// do comparison for PHS
+void analyzePHS(TTree* reftree)
+{
+  LabelStats result;
+  analyse<o2::phos::MCLabel>(reftree, "PHOSDigitMCTruth", result);
+  std::cout << gPrefix << " PHS ";
+  result.print();
+}
+
+// do comparison for CPV
+void analyzeCPV(TTree* reftree)
+{
+  LabelStats result;
+  analyse<o2::phos::MCLabel>(reftree, "CPVDigitMCTruth", result);
+  std::cout << gPrefix << " CPV ";
+  result.print();
+}
+
+// do comparison for FT0
+void analyzeFT0(TTree* reftree)
+{
+  LabelStats result;
+  analyse<o2::ft0::MCLabel>(reftree, "FT0DigitMCTruth", result);
+  std::cout << gPrefix << " FT0 ";
+  result.print();
+}
+
+// do comparison for FDD
+void analyzeFDD(TTree* reftree)
+{
+  LabelStats result;
+  analyse<o2::fdd::MCLabel>(reftree, "FDDDigitMCTruth", result);
+  std::cout << gPrefix << " FDD ";
+  result.print();
+}
+
+// do comparison for HMP
+void analyzeHMP(TTree* reftree)
+{
+  LabelStats result;
+  analyse<o2::MCCompLabel>(reftree, "HMPDigitLabels", result);
+  std::cout << gPrefix << " HMP ";
+  result.print();
+}
+
+// do comparison for ZDC
+void analyzeZDC(TTree* reftree)
+{
+  LabelStats result;
+  analyse<o2::zdc::MCLabel>(reftree, "ZDCDigitLabels", result);
+  std::cout << gPrefix << " ZDC ";
+  result.print();
+}
+
+// do comparison for MID
+void analyzeMID(TTree* reftree)
+{
+  LabelStats result;
+  analyse<o2::mid::MCLabel>(reftree, "MIDDigitMCLabels", result);
+  std::cout << gPrefix << " MID ";
+  result.print();
+}
+
+// do comparison for MID
+void analyzeMCH(TTree* reftree)
+{
+  LabelStats result;
+  analyse<o2::MCCompLabel>(reftree, "MCHMCLabels", result);
+  std::cout << gPrefix << " MCH ";
+  result.print();
+}
+
+// do comparison for MFT
+void analyzeTOF(TTree* reftree)
+{
+  LabelStats result;
+  analyseTOF<o2::MCCompLabel>(reftree, "TOFDigitMCTruth", result);
+  std::cout << gPrefix << " TOF ";
+  result.print();
+}
+
+// do comparison for MFT
+void analyzeTRD(TTree* reftree)
+{
+  LabelStats result;
+  analyse<o2::trd::MCLabel>(reftree, "TRDMCLabels", result);
+  std::cout << gPrefix << " TRD ";
+  result.print();
+}
+
+// Simple macro to get basic mean properties of simulated digits.
+//
+// A prefix (such as a parameter) can be given which will be  prepended before each line of printout.
+// This could be useful for plotting.
+//
+void analyzeDigitLabels(const char* filename, const char* detname = nullptr, const char* prefix = "")
+{
+  TFile rf(filename, "OPEN");
+  auto reftree = (TTree*)rf.Get("o2sim");
+
+  gPrefix = prefix;
+  // should correspond to the same number as defined in DetID
+  if (strcmp(detname, "ITS") == 0) {
+    analyzeITS(reftree);
+  }
+  if (strcmp(detname, "MFT") == 0) {
+    analyzeMFT(reftree);
+  }
+  if (strcmp(detname, "TPC") == 0) {
+    analyzeTPC(reftree);
+  }
+  if (strcmp(detname, "TOF") == 0) {
+    analyzeTOF(reftree);
+  }
+  if (strcmp(detname, "TRD") == 0) {
+    analyzeTRD(reftree);
+  }
+  if (strcmp(detname, "EMC") == 0) {
+    analyzeEMC(reftree);
+  }
+  if (strcmp(detname, "PHS") == 0) {
+    analyzePHS(reftree);
+  }
+  if (strcmp(detname, "CPV") == 0) {
+    analyzeCPV(reftree);
+  }
+  if (strcmp(detname, "FT0") == 0) {
+    analyzeFT0(reftree);
+  }
+  // analyzeFV0(reftree);
+  if (strcmp(detname, "FDD") == 0) {
+    analyzeFDD(reftree);
+  }
+  if (strcmp(detname, "HMP") == 0) {
+    analyzeHMP(reftree);
+  }
+  if (strcmp(detname, "MCH") == 0) {
+    analyzeMCH(reftree);
+  }
+  if (strcmp(detname, "MID") == 0) {
+    analyzeMID(reftree);
+  }
+  if (strcmp(detname, "ZDC") == 0) {
+    analyzeZDC(reftree);
+  }
+  // analyzeACO(reftree);
+}

--- a/macro/analyzeHits.C
+++ b/macro/analyzeHits.C
@@ -12,7 +12,10 @@
 #include "TPCSimulation/Point.h"
 #include "PHOSBase/Hit.h"
 #include "DataFormatsFDD/Hit.h"
-
+#include "MCHSimulation/Hit.h"
+#include "MIDSimulation/Hit.h"
+#include "CPVBase/Hit.h"
+#include "ZDCSimulation/Hit.h"
 #endif
 
 TString gPrefix("");
@@ -255,7 +258,7 @@ void analyzeFT0(TTree* reftree)
 void analyzeHMP(TTree* reftree)
 {
   auto refresult = analyse<o2::hmpid::HitType, HitStats<o2::hmpid::HitType>>(reftree, "HMPHit");
-  std::cout << gPrefix << " HMPID ";
+  std::cout << gPrefix << " HMP ";
   refresult.print();
 }
 
@@ -280,6 +283,34 @@ void analyzeFV0(TTree* reftree)
   refresult.print();
 }
 
+void analyzeMCH(TTree* reftree)
+{
+  auto refresult = analyse<o2::mch::Hit, HitStats<o2::mch::Hit>>(reftree, "MCHHit");
+  std::cout << gPrefix << " MCH ";
+  refresult.print();
+}
+
+void analyzeMID(TTree* reftree)
+{
+  auto refresult = analyse<o2::mid::Hit, HitStats<o2::mid::Hit>>(reftree, "MIDHit");
+  std::cout << gPrefix << " MID ";
+  refresult.print();
+}
+
+void analyzeCPV(TTree* reftree)
+{
+  auto refresult = analyse<o2::cpv::Hit, HitStats<o2::cpv::Hit>>(reftree, "CPVHit");
+  std::cout << gPrefix << " CPV ";
+  refresult.print();
+}
+
+void analyzeZDC(TTree* reftree)
+{
+  auto refresult = analyse<o2::zdc::Hit, HitStats<o2::zdc::Hit>>(reftree, "ZDCHit");
+  std::cout << gPrefix << " ZDC ";
+  refresult.print();
+}
+
 void analyzeTPC(TTree* reftree)
 {
   // need to loop over sectors
@@ -301,6 +332,7 @@ void analyzeHits(const char* filename = "o2sim.root", const char* prefix = "")
   auto reftree = (TTree*)rf.Get("o2sim");
 
   gPrefix = prefix;
+  // should correspond to the same number as defined in DetID
   analyzeITS(reftree);
   analyzeTPC(reftree);
   analyzeMFT(reftree);
@@ -308,8 +340,13 @@ void analyzeHits(const char* filename = "o2sim.root", const char* prefix = "")
   analyzeEMC(reftree);
   analyzeTRD(reftree);
   analyzePHS(reftree);
+  analyzeCPV(reftree);
   analyzeFT0(reftree);
   analyzeFV0(reftree);
   analyzeFDD(reftree);
   analyzeHMP(reftree);
+  analyzeMCH(reftree);
+  analyzeMID(reftree);
+  analyzeZDC(reftree);
+  // analyzeACO(reftree);
 }

--- a/prodtests/check_embedding_pileup.sh
+++ b/prodtests/check_embedding_pileup.sh
@@ -1,0 +1,51 @@
+# Script verifying pileup / embedding features of digitizers
+# It is a basic and fully automatic status check of what should
+# work
+
+# The approach is the following:
+# 1) for each detector we simulate 2 events that both leave hits
+# 2) we digitize the events with the same collision time assigned to both of them
+#    and check whether the output digits have multiple labels --> checks pileup
+# 3) we digitize with trivial embedding: background and signal events are the same
+#    and check whether the output digits have multiple labels --> checks embedding
+
+# o2-sim -j 4 -g pythia8 -n 4 --seed 1 ok for 
+# CVP, MCH, MID, HMP need special gun
+
+dets=(       ITS     TPC   TRD    EMC     PHS    TOF      CPV    HMP     MCH   MID   MFT   FV0   FT0   FDD   ZDC )
+generators=(boxgen boxgen boxgen boxgen hmpidgun  boxgen  boxgen  hmpidgun fwpigen fwpigen fwpigen  fddgen fddgen fddgen pythia8 )
+
+for idx in "${!dets[@]}"; do
+  d=${dets[$idx]}
+  gen=${generators[$idx]}
+  # we put the detector plus pipe and magnet as materials
+  o2-sim-serial -m PIPE MAG ${d} -g ${gen} -n 2 --seed 1 -o o2sim${d} > simlog${d} 2>&1
+
+  unlink o2sim.root
+  unlink o2sim_grp.root
+  ln -s o2sim${d}.root o2sim.root
+  ln -s o2sim${d}_grp.root o2sim_grp.root
+
+  # verify that we have hits
+  NUMHITS=`root -q -b -l ~/alisw_new/O2/macro/analyzeHits.C | grep "${d}" | awk '//{print $2}'`
+  echo "Found ${NUMHITS} hits for ${d}" 
+  
+  # digitize with extreme bunch crossing
+  o2-sim-digitizer-workflow --onlyDet ${d} -b --tpc-lanes 1 > digilog${d} 2>&1
+
+  # verify that digit file is here
+  if [ -a ${d}digits.root ]; then
+    # verify that we have a single digit (here checked via the labels)
+    # root -q -b -l checkEmbeddingPileupFeature("DETECTOR", file);
+    echo "checking pileup for $d"
+
+      
+    # digitize with embedding but normal bunch crossing
+    # o2-sim-digitizer-workflow --onlyDet ${d} -b --simFile o2sim.root --simFileS o2sim.root
+
+    # root -q -b -l checkEmbeddingPileupFeature("DETECTOR", file);
+  else
+    # no digit file file
+    echo "NO DIGIT FILE FOUND FOR ${d}"
+  fi 
+done


### PR DESCRIPTION
A Root macro permitting to analyse the digit labels
automatically for signs of embedding / pileup.

The goal is to use this to check if the labels
satisfy our expectations.

The macro can be much reduced once
we have proper naming schemes in place.