### PR TITLE
Fix in InteractionSampler for mu>100

### DIFF
--- a/Steer/include/Steer/InteractionSampler.h
+++ b/Steer/include/Steer/InteractionSampler.h
@@ -107,9 +107,14 @@ inline int InteractionSampler::genPoissonZT()
   // generate 0-truncated poisson number
   // https://en.wikipedia.org/wiki/Zero-truncated_Poisson_distribution
   int k = 1;
-  double t = mMuBCZTRed, u = gRandom->Rndm(), s = t;
-  while (s < u) {
-    s += t *= mMuBC / (++k);
+  if (mMuBCZTRed > 0) {
+    double t = mMuBCZTRed, u = gRandom->Rndm(), s = t;
+    while (s < u) {
+      s += t *= mMuBC / (++k);
+    }
+  } else { // need to generate explicitly since the prob of
+    while (!(k = gRandom->Poisson(mMuBC))) {
+    };
   }
   return k;
 }


### PR DESCRIPTION
For very large per-BC interaction rate (>100, i.e. IR > 1e9 with default bunch filling)
the interacting BC sampling was stuck due to the numerical limitations of truncated
Poisson generation algo.