### PR TITLE
DPL: small optimization to DataAllocator

### DIFF
--- a/Framework/Core/include/Framework/DataAllocator.h
+++ b/Framework/Core/include/Framework/DataAllocator.h
@@ -112,7 +112,7 @@ class DataAllocator
       // this catches all std::vector objects with messageable value type before checking if is also
       // has a root dictionary, so non-serialized transmission is preferred
       using ValueType = typename T::value_type;
-      std::string channel = matchDataHeader(spec, mTimingInfo->timeslice);
+      std::string const& channel = matchDataHeader(spec, mTimingInfo->timeslice);
       auto context = mContextRegistry->get<MessageContext>();
 
       // Note: initial payload size is 0 and will be set by the context before sending
@@ -121,7 +121,7 @@ class DataAllocator
     } else if constexpr (has_root_dictionary<T>::value == true && is_messageable<T>::value == false) {
       // Extended support for types implementing the Root ClassDef interface, both TObject
       // derived types and others
-      std::string channel = matchDataHeader(spec, mTimingInfo->timeslice);
+      std::string const& channel = matchDataHeader(spec, mTimingInfo->timeslice);
       auto context = mContextRegistry->get<MessageContext>();
 
       // Note: initial payload size is 0 and will be set by the context before sending
@@ -151,7 +151,7 @@ class DataAllocator
         if constexpr (is_messageable<T>::value == true) {
           auto [nElements] = std::make_tuple(args...);
           auto size = nElements * sizeof(T);
-          std::string channel = matchDataHeader(spec, mTimingInfo->timeslice);
+          std::string const& channel = matchDataHeader(spec, mTimingInfo->timeslice);
           auto context = mContextRegistry->get<MessageContext>();
 
           FairMQMessagePtr headerMessage = headerMessageFromOutput(spec, channel, o2::header::gSerializationMethodNone, size);
@@ -213,7 +213,7 @@ class DataAllocator
     using type = T;
 
     char* payload = reinterpret_cast<char*>(ptr);
-    std::string channel = matchDataHeader(spec, mTimingInfo->timeslice);
+    std::string const& channel = matchDataHeader(spec, mTimingInfo->timeslice);
     // the correct payload size is set later when sending the
     // RawBufferContext, see DataProcessor::doSend
     auto header = headerMessageFromOutput(spec, channel, o2::header::gSerializationMethodNone, 0);
@@ -373,7 +373,7 @@ class DataAllocator
   //get the memory resource associated with an output
   o2::pmr::FairMQMemoryResource* getMemoryResource(const Output& spec)
   {
-    std::string channel = matchDataHeader(spec, mTimingInfo->timeslice);
+    std::string const& channel = matchDataHeader(spec, mTimingInfo->timeslice);
     auto context = mContextRegistry->get<MessageContext>();
     return *context->proxy().getTransport(channel);
   }
@@ -394,7 +394,7 @@ class DataAllocator
   {
     // Find a matching channel, extract the message for it form the container
     // and put it in the queue to be sent at the end of the processing
-    std::string channel = matchDataHeader(spec, mTimingInfo->timeslice);
+    std::string const& channel = matchDataHeader(spec, mTimingInfo->timeslice);
 
     auto context = mContextRegistry->get<MessageContext>();
     FairMQMessagePtr payloadMessage = o2::pmr::getMessage(std::forward<ContainerT>(container), *context->proxy().getTransport(channel));
@@ -423,7 +423,7 @@ class DataAllocator
   TimingInfo* mTimingInfo;
   ContextRegistry* mContextRegistry;
 
-  std::string matchDataHeader(const Output& spec, size_t timeframeId);
+  std::string const& matchDataHeader(const Output& spec, size_t timeframeId);
   FairMQMessagePtr headerMessageFromOutput(Output const& spec,                                  //
                                            std::string const& channel,                          //
                                            o2::header::SerializationMethod serializationMethod, //

--- a/Framework/Core/src/DataAllocator.cxx
+++ b/Framework/Core/src/DataAllocator.cxx
@@ -43,7 +43,7 @@ DataAllocator::DataAllocator(TimingInfo* timingInfo,
 {
 }
 
-std::string DataAllocator::matchDataHeader(const Output& spec, size_t timeslice)
+std::string const& DataAllocator::matchDataHeader(const Output& spec, size_t timeslice)
 {
   // FIXME: we should take timeframeId into account as well.
   for (auto& output : mAllowedOutputRoutes) {
@@ -61,7 +61,7 @@ std::string DataAllocator::matchDataHeader(const Output& spec, size_t timeslice)
 
 DataChunk& DataAllocator::newChunk(const Output& spec, size_t size)
 {
-  std::string channel = matchDataHeader(spec, mTimingInfo->timeslice);
+  std::string const& channel = matchDataHeader(spec, mTimingInfo->timeslice);
   auto context = mContextRegistry->get<MessageContext>();
 
   FairMQMessagePtr headerMessage = headerMessageFromOutput(spec, channel,                        //
@@ -76,7 +76,7 @@ void DataAllocator::adoptChunk(const Output& spec, char* buffer, size_t size, fa
 {
   // Find a matching channel, create a new message for it and put it in the
   // queue to be sent at the end of the processing
-  std::string channel = matchDataHeader(spec, mTimingInfo->timeslice);
+  std::string const& channel = matchDataHeader(spec, mTimingInfo->timeslice);
 
   FairMQMessagePtr headerMessage = headerMessageFromOutput(spec, channel,                        //
                                                            o2::header::gSerializationMethodNone, //
@@ -110,7 +110,7 @@ FairMQMessagePtr DataAllocator::headerMessageFromOutput(Output const& spec,     
 void DataAllocator::addPartToContext(FairMQMessagePtr&& payloadMessage, const Output& spec,
                                      o2::header::SerializationMethod serializationMethod)
 {
-  std::string channel = matchDataHeader(spec, mTimingInfo->timeslice);
+  std::string const& channel = matchDataHeader(spec, mTimingInfo->timeslice);
   // the correct payload size is st later when sending the
   // RootObjectContext, see DataProcessor::doSend
   auto headerMessage = headerMessageFromOutput(spec, channel, serializationMethod, 0);
@@ -130,7 +130,7 @@ void DataAllocator::addPartToContext(FairMQMessagePtr&& payloadMessage, const Ou
 void DataAllocator::adopt(const Output& spec, TObject* ptr)
 {
   std::unique_ptr<TObject> payload(ptr);
-  std::string channel = matchDataHeader(spec, mTimingInfo->timeslice);
+  std::string const& channel = matchDataHeader(spec, mTimingInfo->timeslice);
   // the correct payload size is set later when sending the
   // RootObjectContext, see DataProcessor::doSend
   auto header = headerMessageFromOutput(spec, channel, o2::header::gSerializationMethodROOT, 0);
@@ -141,7 +141,7 @@ void DataAllocator::adopt(const Output& spec, TObject* ptr)
 void DataAllocator::adopt(const Output& spec, std::string* ptr)
 {
   std::unique_ptr<std::string> payload(ptr);
-  std::string channel = matchDataHeader(spec, mTimingInfo->timeslice);
+  std::string const& channel = matchDataHeader(spec, mTimingInfo->timeslice);
   // the correct payload size is set later when sending the
   // StringContext, see DataProcessor::doSend
   auto header = headerMessageFromOutput(spec, channel, o2::header::gSerializationMethodNone, 0);
@@ -151,7 +151,7 @@ void DataAllocator::adopt(const Output& spec, std::string* ptr)
 
 void DataAllocator::adopt(const Output& spec, TableBuilder* tb)
 {
-  std::string channel = matchDataHeader(spec, mTimingInfo->timeslice);
+  std::string const& channel = matchDataHeader(spec, mTimingInfo->timeslice);
   auto header = headerMessageFromOutput(spec, channel, o2::header::gSerializationMethodArrow, 0);
   auto context = mContextRegistry->get<ArrowContext>();
 
@@ -192,7 +192,7 @@ void DataAllocator::create(const Output& spec,
                            std::shared_ptr<arrow::ipc::RecordBatchWriter>* writer,
                            std::shared_ptr<arrow::Schema> schema)
 {
-  std::string channel = matchDataHeader(spec, mTimingInfo->timeslice);
+  std::string const& channel = matchDataHeader(spec, mTimingInfo->timeslice);
   auto header = headerMessageFromOutput(spec, channel, o2::header::gSerializationMethodArrow, 0);
   auto context = mContextRegistry->get<ArrowContext>();
 


### PR DESCRIPTION
Using const reference as return for string to matching channel name, i.e.
internal string variable from matching output route. The rout configuration
is stable during computation. This avoids one level of allocation.