### PR TITLE
[DOC] Trying to get organisation of pages correct in doxygen

### DIFF
--- a/Detectors/MUON/MCH/Contour/README.md
+++ b/Detectors/MUON/MCH/Contour/README.md
@@ -1,5 +1,5 @@
 <!-- doxy
-\page refMUONMCHContour MCH Contour
+\page refDetectorsMUONMCHContour Contour Library
 /doxy -->
 
 # MCH Contour library
@@ -7,9 +7,10 @@
 A header-only library to work with contours (polygons).
 
 The main purpose of this library is to merge collection of polygons.
- Starting from polygons representing MCH pad, we can [construct](include/MCHContour/ContourCreator.h) polygons
-  representing FEE (aka _motifs_ in AliRoot parlance, or _padgroups_), PCBs
+ Starting from polygons representing MCH pad, we can
+ [construct](include/MCHContour/ContourCreator.h) polygons representing FEE
+ (aka *motifs* in AliRoot parlance, or *padgroups*), PCBs
   or even full detection elements.
-  
-The `SVGWriter` class can be used to produce SVG representations of those contours.
- 
+
+The `SVGWriter` class can be used to produce SVG representations of those
+contours.

--- a/Detectors/MUON/MCH/Mapping/Factory/README.md
+++ b/Detectors/MUON/MCH/Mapping/Factory/README.md
@@ -1,5 +1,5 @@
 <!-- doxy
-\page refMUONMCHMappingFactory MCH Mapping Factory
+\page refDetectorsMUONMCHMappingFactory Factory (helper function)
 /doxy -->
 
 A single utility function to create segmentations, avoiding duplications
@@ -32,5 +32,5 @@ object creation time).
 Note that depending on your use case, both approaches might be valid ones.
 While the factory one ensures you get only get one object for each detection
 element, it creates all detection elements at once. So, if you only need the
-segmentation of one detection element, you'd better off _not_ using the
+segmentation of one detection element, you'd better off *not* using the
 factory.

--- a/Detectors/MUON/MCH/Mapping/Impl3/README.md
+++ b/Detectors/MUON/MCH/Mapping/Impl3/README.md
@@ -1,20 +1,24 @@
 <!-- doxy
-\page refMUONMCHMappingImpl3 MCH Mapping Impl3
+\page refDetectorsMUONMCHMappingImpl3 Impl3
 /doxy -->
 
 # MCH Mapping Implementation
 
-This is an implementation of the [C interface](../Interface/include/MCHMappingInterface/SegmentationCInterface.h) of the MCH mapping.
- The C function themselves are implemented using a [C++ class](src/SegmentationImpl3.h).
-  (which is not to be confused with the [C++ interface](../Interface/include/MCHMappingInterface/Segmentation.h)).
-  
+This is an implementation of the [C
+interface](../Interface/include/MCHMappingInterface/SegmentationCInterface.h)
+of the MCH mapping.  The C function themselves are implemented using a [C++
+class](src/SegmentationImpl3.h).  (which is not to be confused with the [C++
+interface](../Interface/include/MCHMappingInterface/Segmentation.h)).
+
 This implementation is the first complete version of the original idea
  to move to a self-contained mapping, i.e. mapping fully contained into
  code, without requiring external files (either ASCII or OCDB files).
- 
-Note that most of the files here (the `Gen*` ones) have been _generated_ 
+
+Note that most of the files here (the `Gen*` ones) have been *generated* 
 with [alo/jsonmap/codegen](https://github.com/mrrtf/alo/tree/master/jsonmap/codegen)
 from a [JSON](https://www.json.org) representation of the mapping.
 
-Internally we use a data structure meant for spatial searching : a `R-tree` 
-(from the [Boost Geometry Index](http://www.boost.org/doc/libs/1_66_0/libs/geometry/doc/html/geometry/spatial_indexes/introduction.html) library) to store and query the pads.
+Internally we use a data structure meant for spatial searching : a `R-tree`
+(from the [Boost Geometry
+Index](http://www.boost.org/doc/libs/1_66_0/libs/geometry/doc/html/geometry/spatial_indexes/introduction.html)
+library) to store and query the pads.

--- a/Detectors/MUON/MCH/Mapping/README.md
+++ b/Detectors/MUON/MCH/Mapping/README.md
@@ -1,10 +1,12 @@
 <!-- doxy
-\page refMUONMCHMapping MCH Mapping
+\page refDetectorsMUONMCHMapping Mapping
+* \subpage refDetectorsMUONMCHMappingImpl3 
+* \subpage refDetectorsMUONMCHMappingtest
+* \subpage refDetectorsMUONMCHMappingSegContour
+* \subpage refDetectorsMUONMCHMappingFactory
 /doxy -->
 
-# MCH Mapping
-
-# API
+# MCH Mapping Interface
 
 Two APIs are offered to the MCH Mapping :
 a [C interface](Interface/include/MCHMappingInterface/SegmentationCInterface.h)
@@ -14,11 +16,12 @@ The pattern of this dual interface follows the [Hourglass idea](https://github.c
 In a nutshell, the core interface is written in C so it can be accessed easily
 from different languages and offers a stable ABI.
 
-But most users are only exposed to a header-only [C++ interface](Interface/include/MCHMappingInterface/Segmentation.h) which sits on top
-of this core C interface.
+But most users are only exposed to a header-only [C++
+interface](Interface/include/MCHMappingInterface/Segmentation.h) which sits on
+top of this core C interface.
 
-Details are to be found in the interface file or in the doxygen documentation, but
-the basics of the interface is :
+Details are to be found in the interface file or in the doxygen documentation,
+but the basics of the interface is :
 
 ```c++
 int detElemId{100};
@@ -38,23 +41,27 @@ std::cout << "There is a bending pad at position " << x << "," << y << "\n"
 }
 
 assert(b == seg.findPadByFEE(76, 9));
-
 ```
 
 Note that cathode-specific segmentations can be retrieved from `Segmentation`
 objects (using bending() and nonBending() methods) or created from scratch
 using the `CathodeSegmentation(int detElemId, bool isBendingPlane)` constructor.
 
-# Implementations
+## Implementations
 
-Currently [one implementation](Impl3/README.md) is provided. It is faster than the legacy AliRoot one
-(but not by an order of magnitude...). Extensive checks have been made to insure it yields
-the same results as AliRoot (see the `vsaliroot` directory in the [alo repository](https://github.com/mrrtf/alo) ).
+Currently [one implementation](Impl3/README.md) is provided. It is faster than
+the legacy AliRoot one (but not by an order of magnitude...). Extensive checks
+have been made to insure it yields the same results as AliRoot (see the
+`vsaliroot` directory in the [alo repository](https://github.com/mrrtf/alo) ).
 
-# Contours
+## Contours
 
 Besides to core API (finding pads by position and by electronic ids), we offer
 [convenience functions](SegContour/README.md) to compute the bounding box and [envelop of the segmentations](SegContour/include/MCHMappingSegContour/SegmentationContours.h).
 
 A simple executable, `o2-mch-mapping-svg-segmentation3` can be used to produce [SVG](https://developer.mozilla.org/en-US/docs/Web/SVG) plots
 of the segmentations.
+
+## Tests
+
+A collection of [tests](test/README.md) (with or without input) are available.

--- a/Detectors/MUON/MCH/Mapping/SegContour/README.md
+++ b/Detectors/MUON/MCH/Mapping/SegContour/README.md
@@ -1,15 +1,15 @@
 <!-- doxy
-\page refMUONMCHMappingSegContour MCH Mapping SegContour
+\page refDetectorsMUONMCHMappingSegContour Segmentation contours
 /doxy -->
 
-# Segmentation contours
+# MCH Segmentation Contours
 
 This module contains convenience functions that can compute the
  envelop (in the form of a polygon) of segmentations.
- 
+
 Also an executable is provided which can produce SVG representation
  of those segmentations.
- 
+
 ```c++
 > o2-mch-mapping-svg-segmentation3 --help
 Generic options:
@@ -31,5 +31,3 @@ Example usage :
 ```
 
 Will produce an HTML file showing the FEE boundaries of [one quadrant of Station 1](chamber1-100-B.html)
-
-

--- a/Detectors/MUON/MCH/Mapping/test/src/README.md
+++ b/Detectors/MUON/MCH/Mapping/test/src/README.md
@@ -1,11 +1,16 @@
 <!-- doxy
-\page refMUONMCHMappingtest MCH Mapping test
+\page refDetectorsMUONMCHMappingtest Tests
 /doxy -->
+
+# MCH Mapping Tests
 
 By default the tests are running without any input.
 
-If you want to go further though, you can input a JSON file containing test positions using the  `--testpos` option (it is an option of the test module, not of the test program itself, hence the `--` syntax) and call (part of) the test like so :  
+If you want to go further though, you can input a JSON file containing test
+positions using the  `--testpos` option (it is an option of the test module,
+not of the test program itself, hence the `--` syntax) and call (part of) the
+test like so :
 
-```
+```bash
 ./test_MCHMappingTest --run_test="*/*/*TestPos*" -- --testpos /some/dir/to/test_random_pos.json
-````
+```

--- a/Detectors/MUON/MCH/README.md
+++ b/Detectors/MUON/MCH/README.md
@@ -1,0 +1,13 @@
+<!-- doxy
+\page refDetectorsMUONMCH MCH
+/doxy -->
+
+# MUON MCH
+
+This is a top page for the MCH detector documentation.
+
+<!-- doxy
+\subpage refDetectorsMUONMCHContour
+\subpage refDetectorsMUONMCHRaw
+\subpage refDetectorsMUONMCHMapping
+/doxy -->

--- a/Detectors/MUON/MCH/Raw/Decoder/README.md
+++ b/Detectors/MUON/MCH/Raw/Decoder/README.md
@@ -1,5 +1,5 @@
 <!-- doxy
-\page refMUONMCHRawDecoder MCH Raw Data Decoder
+\page refDetectorsMUONMCHRawDecoder Decoder
 /doxy -->
 
 # MCH Raw Data Decoder
@@ -62,7 +62,7 @@ using RawDataHeaderHandler = std::function<std::optional<RDH>(const RDH& rdh)>;
 ```
 
 If no RDH is returned (i.e. `std::nullopt` is returned) then that part of the
-raw data is _not_ decoded at all.
+raw data is *not* decoded at all.
 The returned RDH can be a modified version of the argument, e.g. to change some
 of the values (like `feeId` according to some mapping).
 
@@ -73,7 +73,7 @@ identifier (in electronics realm, aka solar,group,index tuple), a channel
 identifier within that dual sampa, a `SampaCluster` and returns nothing, i.e. :
 
 > A word of caution here about the naming. A `SampaCluster` is a group of raw
-> data samples of _one_ dual sampa channel, and has nothing to do with a
+> data samples of *one* dual sampa channel, and has nothing to do with a
 > cluster of pads or something alike. 
 
 ```.cpp

--- a/Detectors/MUON/MCH/Raw/ElecMap/README.md
+++ b/Detectors/MUON/MCH/Raw/ElecMap/README.md
@@ -1,5 +1,5 @@
 <!-- doxy
-\page refMUONMCHRawElecMap MCH Raw Electronic Mapping
+\page refDetectorsMUONMCHRawElecMap Electronic Mapping
 /doxy -->
 
 # MCH Raw Electronic Mapping

--- a/Detectors/MUON/MCH/Raw/README.md
+++ b/Detectors/MUON/MCH/Raw/README.md
@@ -1,5 +1,5 @@
 <!-- doxy
-\page refMUONMCHRaw MCH Raw Data CoDec
+\page refDetectorsMUONMCHRaw Raw CoDec
 /doxy -->
 
 # MCH Raw Data CoDec
@@ -8,7 +8,7 @@ This is the top page for the documentation relative to MCH Raw Data Encoding
 and Decoding.
 
 <!-- doxy
-* \subpage refMUONMCHRawElecMap
-* \subpage refMUONMCHRawDecoder
-* \subpage refMUONMCHRawTools
+* \subpage refDetectorsMUONMCHRawElecMap
+* \subpage refDetectorsMUONMCHRawDecoder
+* \subpage refDetectorsMUONMCHRawTools
 /doxy -->

--- a/Detectors/MUON/MCH/Raw/Tools/README.md
+++ b/Detectors/MUON/MCH/Raw/Tools/README.md
@@ -1,5 +1,5 @@
 <!-- doxy
-\page refMUONMCHRawTools MCH Raw Data Tools
+\page refDetectorsMUONMCHRawTools Tools
 /doxy -->
 
 # MCH RawData Tools

--- a/Detectors/MUON/MID/README.md
+++ b/Detectors/MUON/MID/README.md
@@ -1,0 +1,14 @@
+<!-- doxy
+\page refDetectorsMUONMID MID
+/doxy -->
+
+# MUON MID
+
+This is a top page for the MID detector documentation.
+
+<!-- doxy
+* \subpage refMUONMIDClustering
+* \subpage refMUONMIDRawExe
+* \subpage refMUONMIDTracking
+* \subpage refMUONMIDWorkflow
+/doxy -->

--- a/Detectors/MUON/README.md
+++ b/Detectors/MUON/README.md
@@ -4,17 +4,10 @@
 
 # MUON
 
-This is a top page for the MUON detector documentation.
+The MUON subsystem is composed of three detectors : [MFT](../ITSMFT/MFT), [MCH](./MCH) and [MID](./MID).
 
 <!-- doxy
-* \subpage refMUONMIDClustering
-* \subpage refMUONMIDRawExe
-* \subpage refMUONMIDTracking
-* \subpage refMUONMIDWorkflow
-* \subpage refMUONMCHMappingSegContour
-* \subpage refMUONMCHMapping
-* \subpage refMUONMCHMappingtest
-* \subpage refMUONMCHMappingImpl3
-* \subpage refMUONMCHContour
-* \subpage refMUONMCHRaw
+* \subpage refDetectorsITSMFT
+* \subpage refDetectorsMUONMID
+* \subpage refDetectorsMUONMCH
 /doxy -->


### PR DESCRIPTION
Documentation only.

- avoid to pollute top level Doxygen menu
- group all muon tracker doc under MCH and all muon identifier doc under MID

