### PR TITLE
Control of the grooves creation on heat exchangers

### DIFF
--- a/Detectors/ITSMFT/MFT/base/include/MFTBase/Geometry.h
+++ b/Detectors/ITSMFT/MFT/base/include/MFTBase/Geometry.h
@@ -79,6 +79,7 @@ class Geometry : public TNamed
   static const Double_t sGlueRohacellCarbonThickness;
   static const Double_t sKaptonOnCarbonThickness;
   static const Double_t sKaptonGlueThickness;
+  static const Int_t sGrooves;
 
   static TGeoHMatrix sTransMFT2ITS; ///< transformation due to the different conventions
 

--- a/Detectors/ITSMFT/MFT/base/src/Geometry.cxx
+++ b/Detectors/ITSMFT/MFT/base/src/Geometry.cxx
@@ -68,6 +68,8 @@ const Double_t Geometry::sGlueRohacellCarbonThickness = 0.0025 / 2; // glue betw
 const Double_t Geometry::sKaptonOnCarbonThickness = 0.0013 / 2;     // thickness of the kapton layer on the heat exchanger carbone plate
 const Double_t Geometry::sKaptonGlueThickness = 0.0027 / 2;         // thickness of the kapton layer glue
 
+const Int_t Geometry::sGrooves = 0; // grooves or not grooves, that's the question... 0 without grooves, 1 with grooves at your own risks!
+
 // need to do this, because of the different conventions between
 // ITS and MFT in placing the chips (rows, cols) in the geometry
 // at construction time

--- a/Detectors/ITSMFT/MFT/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/MFT/simulation/src/Detector.cxx
@@ -27,7 +27,6 @@
 #include "TLorentzVector.h"
 #include "TVector3.h"
 #include "TGeoManager.h"
-
 #include "FairLogger.h"
 #include "FairRootManager.h"
 #include "FairVolume.h"
@@ -256,17 +255,18 @@ void Detector::createMaterials()
   Float_t aCM55J[4] = {12.0107, 14.0067, 15.9994, 1.00794};
   Float_t zCM55J[4] = {6., 7., 8., 1.};
   Float_t wCM55J[4] = {0.908508078, 0.010387573, 0.055957585, 0.025146765};
-  // Float_t dCM55J = 1.33; // from J.M. Buhour infos
-  Float_t dCM55J = 1.548; // increase by 16.4% to account that water pipes are outside the rohacell plate
+  Float_t dCM55J = 1.33; // from J.M. Buhour infos
 
   // Rohacell mixture
   const Int_t nRohacell = 3;
   Float_t aRohacell[nRohacell] = {1.00794, 12.0107, 15.9994};
   Float_t zRohacell[nRohacell] = {1., 6., 8.};
   Float_t wRohacell[nRohacell] = {0.0858, 0.5964, 0.3178};
-  // Float_t dRohacell = 0.032;  // 0.032 g/cm3 rohacell 31, 0.075 g/cm3 rohacell 71;
-  Float_t dRohacell = 0.032 / (1 - 0.3134); // the density is increased since the water pipes are not inside the
-                                            // rohacell in the code ==> thickness decreased by 31.34%
+  Float_t dRohacell;
+  if (Geometry::sGrooves == 0)
+    dRohacell = 0.032 / (1 - 0.15); //  No grooves, water pipes outside rohacell ==> smaller thcikness, greater rohacell density by 15%
+  if (Geometry::sGrooves == 1)
+    dRohacell = 0.032; // With grooves, usual rohacell density: 0.032 g/cm3 rohacell 31, 0.075 g/cm3 rohacell 71;
 
   // Polyimide pipe mixture
   const Int_t nPolyimide = 4;
@@ -314,17 +314,17 @@ void Detector::createMaterials()
     3;                 // type of field intergration 0 no field -1 user in guswim 1 Runge Kutta 2 helix 3 const field along z
   Float_t maxfld = 5.; // max field value
 
-  Float_t tmaxfd = -10.0; // max deflection angle due to magnetic field in one step
-  Float_t stemax = 0.001; // max step allowed [cm]
-  Float_t deemax = -0.2;  // maximum fractional energy loss in one step 0<deemax<=1
-  Float_t epsil = 0.001;  // tracking precision [cm]
-  Float_t stmin = -0.001; // minimum step due to continuous processes [cm] (negative value: choose it automatically)
+  Float_t tmaxfd = 0.1;   // -10.0;  // max deflection angle due to magnetic field in one step
+  Float_t stemax = 1.0;   // 0.001; // max step allowed [cm]
+  Float_t deemax = 0.1;   // -0.2;   // maximum fractional energy loss in one step 0<deemax<=1
+  Float_t epsil = 1.0e-4; // 0.001;   // tracking precision [cm]
+  Float_t stmin = 0.0;    // -0.001;  // minimum step due to continuous processes [cm] (negative value: choose it automatically)
 
-  Float_t tmaxfdSi = 0.1;    // max deflection angle due to magnetic field in one step
-  Float_t stemaxSi = 5.0e-4; // maximum step allowed [cm]
-  Float_t deemaxSi = 0.1;    // maximum fractional energy loss in one step 0<deemax<=1
-  Float_t epsilSi = 0.5e-4;  // tracking precision [cm]
-  Float_t stminSi = -0.001;  // minimum step due to continuous processes [cm] (negative value: choose it automatically)
+  Float_t tmaxfdSi = 0.1;   // max deflection angle due to magnetic field in one step
+  Float_t stemaxSi = 0.075; // 5.0e-4; // maximum step allowed [cm]
+  Float_t deemaxSi = 0.1;   // maximum fractional energy loss in one step 0<deemax<=1
+  Float_t epsilSi = 1.0e-4; // 0.5e-4;  // tracking precision [cm]
+  Float_t stminSi = 0.0;    // -0.001;  // minimum step due to continuous processes [cm] (negative value: choose it automatically)
 
   Int_t fieldType;
   Float_t maxField;


### PR DESCRIPTION
Addition of a new parameter sGrooves to create or not the grooves of the MFT heat exchangers, default is sGrooves =0 to save time and memory in simulations.