### PR TITLE
update of the TPCFastTransform interface

### DIFF
--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/TPCFastTransformHelperO2.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/TPCFastTransformHelperO2.h
@@ -78,7 +78,7 @@ class TPCFastTransformHelperO2
 
   static TPCFastTransformHelperO2* sInstance;                                                  ///< singleton instance
   bool mIsInitialized = 0;                                                                     ///< initialization flag
-  std::function<void(const double XYZ[3], double dXdYdZ[3])> mSpaceChargeCorrection = nullptr; ///< pointer to an external correction method
+  std::function<void(int roc, const double XYZ[3], double dXdYdZ[3])> mSpaceChargeCorrection = nullptr; ///< pointer to an external correction method
   TPCFastTransformGeo mGeo;                                                                    ///< geometry parameters
 
   ClassDefNV(TPCFastTransformHelperO2, 2);

--- a/Detectors/TPC/reconstruction/src/TPCFastTransformHelperO2.cxx
+++ b/Detectors/TPC/reconstruction/src/TPCFastTransformHelperO2.cxx
@@ -120,6 +120,8 @@ std::unique_ptr<TPCFastTransform> TPCFastTransformHelperO2::create(Long_t TimeSt
 
     // adjust the number of knots and the knot positions for the TPC distortion splines
 
+    /*
+     TODO: update the calibrator
     IrregularSpline2D3DCalibrator calibrator;
     calibrator.setRasterSize(41, 41);
     calibrator.setMaxNKnots(21, 21);
@@ -128,13 +130,16 @@ std::unique_ptr<TPCFastTransform> TPCFastTransformHelperO2::create(Long_t TimeSt
     IrregularSpline2D3D raster;
     raster.constructRegular(101, 101);
     std::vector<float> rasterData(3 * raster.getNumberOfKnots());
-
+    */
     for (int scenario = 0; scenario < nDistortionScenarios; scenario++) {
       int row = scenario * 10;
       IrregularSpline2D3D spline;
-      if (!mSpaceChargeCorrection || row >= nRows) {
-        spline.constructRegular(21, 21);
+      if (!mSpaceChargeCorrection || row >= nRows) { //SG!!!
+        spline.constructRegular(15, 40);
       } else {
+        // TODO: update the calibrator
+        spline.constructRegular(15, 40);
+        /*
         // create the input function
         for (int knot = 0; knot < raster.getNumberOfKnots(); knot++) {
           float su = 0.f, sv = 0.f;
@@ -156,6 +161,7 @@ std::unique_ptr<TPCFastTransform> TPCFastTransformHelperO2::create(Long_t TimeSt
         std::cout << "calibrated spline for scenario " << scenario << ", TPC row " << row << ": knots u "
                   << spline.getGridU().getNumberOfKnots() << ", v "
                   << spline.getGridV().getNumberOfKnots() << std::endl;
+                  */
       }
       distortion.setSplineScenario(scenario, spline);
     }
@@ -316,7 +322,7 @@ int TPCFastTransformHelperO2::getSpaceChargeCorrection(int slice, int row, float
   {
     double xyz[3] = {gx, gy, gz};
     double dxyz[3] = {0., 0., 0.};
-    mSpaceChargeCorrection(xyz, dxyz);
+    mSpaceChargeCorrection(slice, xyz, dxyz);
     gx1 += dxyz[0];
     gy1 += dxyz[1];
     gz1 += dxyz[2];

--- a/Detectors/TPC/reconstruction/test/testTPCFastTransform.cxx
+++ b/Detectors/TPC/reconstruction/test/testTPCFastTransform.cxx
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE(FastTransform_test1)
 
 BOOST_AUTO_TEST_CASE(FastTransform_test_setSpaceChargeCorrection)
 {
-  auto correctionFunction = [](const double XYZ[3], double dXdYdZ[3]) {
+  auto correctionFunction = [](int /*roc*/, const double XYZ[3], double dXdYdZ[3]) {
     dXdYdZ[0] = 1.;
     dXdYdZ[1] = 2.;
     dXdYdZ[2] = 3.;
@@ -150,7 +150,7 @@ BOOST_AUTO_TEST_CASE(FastTransform_test_setSpaceChargeCorrection)
 
           double xyz[3] = {gx0, gy0, gz0};
           double d[3] = {0, 0, 0};
-          correctionFunction(xyz, d);
+          correctionFunction(0, xyz, d);
           statDiff += fabs((gx1 - gx0) - d[0]) + fabs((gy1 - gy0) - d[1]) + fabs((gz1 - gz0) - d[2]);
           statN += 3;
           //std::cout << (x1g-x0g) - d[0]<<" "<< (y1g-y0g) - d[1]<<" "<< (z1g-z0g) - d[2]<<std::endl;

--- a/GPU/TPCFastTransformation/TPCFastTransformGeo.cxx
+++ b/GPU/TPCFastTransformation/TPCFastTransformGeo.cxx
@@ -71,10 +71,10 @@ void TPCFastTransformGeo::setTPCzLength(float tpcZlengthSideA, float tpcZlengthS
 
   mTPCzLengthA = tpcZlengthSideA;
   mTPCzLengthC = tpcZlengthSideC;
-  mScaleVtoSVsideA = 1. / tpcZlengthSideA;
-  mScaleVtoSVsideC = 1. / tpcZlengthSideC;
-  mScaleSVtoVsideA = tpcZlengthSideA;
-  mScaleSVtoVsideC = tpcZlengthSideC;
+  mScaleSVtoVsideA = tpcZlengthSideA + 3.; // add some extra possible drift length due to the space charge distortions
+  mScaleSVtoVsideC = tpcZlengthSideC + 3.;
+  mScaleVtoSVsideA = 1. / mScaleSVtoVsideA;
+  mScaleVtoSVsideC = 1. / mScaleSVtoVsideC;
 
   mConstructionMask |= ConstructionState::GeometryIsSet;
 }
@@ -132,7 +132,7 @@ void TPCFastTransformGeo::finishConstruction()
 
 void TPCFastTransformGeo::print() const
 {
-  /// Prints the geometry
+/// Prints the geometry
 #if !defined(GPUCA_GPUCODE)
   std::cout << "TPC Fast Transformation Geometry: " << std::endl;
   std::cout << "mNumberOfRows = " << mNumberOfRows << std::endl;


### PR DESCRIPTION
- Add roc number to the interface to the SpaceCharge Correction. It is needed to avoid the ambiguity of the TPC side identification at nominal Z~=0.
- Temporary switch off an automatic calibration of the spline grid. It needs to be updated. 