### PR TITLE
build: Fix build with o2-dataflow defaults without HepMC (O2-1051)

### DIFF
--- a/Generators/src/GeneratorsLinkDef.h
+++ b/Generators/src/GeneratorsLinkDef.h
@@ -26,7 +26,6 @@
 #pragma link off all functions;
 
 #pragma link C++ class o2::eventgen::Generator + ;
-#pragma link C++ class o2::eventgen::GeneratorHepMC + ;
 #pragma link C++ class o2::eventgen::GeneratorTGenerator + ;
 #ifdef GENERATORS_WITH_HEPMC3
 #pragma link C++ class o2::eventgen::GeneratorHepMC + ;


### PR DESCRIPTION
This fixes build issue on centos with o2-dataflow defaults where HepMC is disabled. The same pragma appears later at L32, appropriately guarded, so I guess this was intended to be removed.

fixes Jira: [O2-1051](https://alice.its.cern.ch/jira/browse/O2-1051)