### PR TITLE
FV0 digitization - optimization and bug fix

### DIFF
--- a/DataFormats/Detectors/FIT/FV0/include/DataFormatsFV0/BCData.h
+++ b/DataFormats/Detectors/FIT/FV0/include/DataFormatsFV0/BCData.h
@@ -31,18 +31,12 @@ struct BCData {
   o2::dataformats::RangeRefComp<6> ref;
   o2::InteractionRecord ir;
 
-  // TODO: These are not implemented yet - always set to 0
-  int64_t channels = 0; // pattern of channels it refers to
-  int64_t triggers = 0; // pattern of channels that triggered
-
   BCData() = default;
-  BCData(int first, int ne, o2::InteractionRecord iRec, uint32_t channelsStored, uint32_t chTrig)
+  BCData(int first, int ne, o2::InteractionRecord iRec)
   {
     ref.setFirstEntry(first);
     ref.setEntries(ne);
     ir = iRec;
-    channels = channelsStored;
-    triggers = chTrig;
   }
 
   gsl::span<const ChannelData> getBunchChannelData(const gsl::span<const ChannelData> tfdata) const;

--- a/DataFormats/Detectors/FIT/FV0/src/BCData.cxx
+++ b/DataFormats/Detectors/FIT/FV0/src/BCData.cxx
@@ -17,19 +17,6 @@ using namespace o2::fv0;
 void BCData::print() const
 {
   ir.print();
-  // printf("[FV0] %d channels starting from %d\n", ref.getEntries(), ref.getFirstEntry());
-  printf("Read : [");
-  for (int ic = 0; ic < 48; ic++) {
-    if (channels & ((int64_t)0x1 << ic)) {
-      printf("%d ", ic);
-    }
-  }
-  printf("] Triggered: [");
-  for (int ic = 0; ic < 48; ic++) {
-    if (triggers & ((int64_t)0x1 << ic)) {
-      printf("%d ", ic);
-    }
-  }
   printf("]\n");
 }
 

--- a/Detectors/FIT/FV0/macro/readFV0Digits.C
+++ b/Detectors/FIT/FV0/macro/readFV0Digits.C
@@ -50,11 +50,6 @@ void readFV0Digits(std::string digiFName = "fv0digits.root")
 
     for (int ibc = 0; ibc < nbc; ibc++) {
       const auto& bcd = fv0BCData[ibc];
-      if (bcd.triggers) {
-        LOG(INFO) << "Triggered BC " << itrig++;
-      } else {
-        LOG(INFO) << "Non-Triggered BC ";
-      }
       bcd.print();
       int chEnt = bcd.ref.getFirstEntry();
       for (int ic = 0; ic < bcd.ref.getEntries(); ic++) {

--- a/Detectors/FIT/FV0/simulation/include/FV0Simulation/DigitizationParameters.h
+++ b/Detectors/FIT/FV0/simulation/include/FV0Simulation/DigitizationParameters.h
@@ -39,6 +39,8 @@ struct DigitizationParameters {
   static constexpr int photoelMin = 0;             // Integration lower limit
   static constexpr int photoelMax = 30;            // Integration upper limit
   static constexpr float singleMipThreshold = 3.0; // in [MeV] of deposited energy
+  // Optimization-related, derived constants
+  static constexpr float mPmtTransitTime2 = mPmtTransitTime * mPmtTransitTime;
 };
 } // namespace o2::fv0
 #endif

--- a/Detectors/FIT/FV0/simulation/include/FV0Simulation/Digitizer.h
+++ b/Detectors/FIT/FV0/simulation/include/FV0Simulation/Digitizer.h
@@ -63,7 +63,7 @@ class Digitizer
   // Internal helper methods related to conversion of energy-deposition into photons -> photoelectrons -> el. signal
   Int_t SimulateLightYield(Int_t pmt, Int_t nPhot);
   Float_t SimulateTimeCfd(Int_t channel);
-  static Float_t PmtResponse(const Float_t x, const Float_t par);
+  static Float_t PmtResponse(Float_t x);
   Double_t SinglePhESpectrum(Double_t* x, Double_t* par);
   Float_t mPmtTimeIntegral; //
 


### PR DESCRIPTION
Cleanup, optimization and one significant bug fix:
- Bug: `SimulateLightYield()` always returned number of photons set as input, instead of reducing their number by a factor of ~40. The present fix results in the similar reduction factor in CPU time of digitization.
- Cleanup: removed unused `channels` and `triggers` members of `BCData`
- Minor optimizations (% replaced with `if`, followed by counter reset)