### PR TITLE
[O2-1037] Fix handling of SCMX volume cache for Geant4

### DIFF
--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/Detector.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/Detector.h
@@ -187,6 +187,7 @@ class Detector : public o2::base::DetImpl<Detector>
 
   std::vector<std::string> mSensitive;               //!<! List of sensitive volumes
   std::unordered_map<int, EMCALSMType> mSMVolumeID;  //!<! map of EMCAL supermodule volume IDs
+  std::unordered_map<std::string, EMCALSMType> mSMVolNames; //!<! map of EMCAL supermodule names
   Int_t mVolumeIDScintillator;                       //!<! Volume ID of the scintillator volume
   std::vector<Hit>* mHits;                           //!<! Collection of EMCAL hits
   Geometry* mGeometry;                               //!<! Geometry pointer

--- a/Detectors/EMCAL/simulation/src/Detector.cxx
+++ b/Detectors/EMCAL/simulation/src/Detector.cxx
@@ -45,6 +45,7 @@ Detector::Detector(Bool_t active)
     mBirkC2(0.),
     mSensitive(),
     mSMVolumeID(),
+    mSMVolNames(),
     mVolumeIDScintillator(-1),
     mHits(o2::utils::createSimVector<Hit>()),
     mGeometry(nullptr),
@@ -82,6 +83,7 @@ Detector::Detector(const Detector& rhs)
     mBirkC2(rhs.mBirkC2),
     mSensitive(),
     mSMVolumeID(),
+    mSMVolNames(),
     mVolumeIDScintillator(-1),
     mHits(o2::utils::createSimVector<Hit>()),
     mGeometry(rhs.mGeometry),
@@ -113,10 +115,15 @@ void Detector::InitializeO2Detector()
   // the decay chains are broken by volumes not processed in ProceeHits
   for (const auto& child : mSensitive) {
     LOG(DEBUG1) << "Adding sensitive volume " << child;
-    auto svolID = registerSensitiveVolumeAndGetVolID(child); 
+    auto svolID = registerSensitiveVolumeAndGetVolID(child);
     if (child == "SCMX") {
       LOG(DEBUG1) << "Adding SCMX volume as sensitive volume with ID " << svolID;
       mVolumeIDScintillator = svolID;
+    }
+    auto smtype = mSMVolNames.find(child);
+    if (smtype != mSMVolNames.end()) {
+      std::cout << "Adding supermodule type " << smtype->second << " for SM " << smtype->first << " with volume ID " << svolID << std::endl;
+      mSMVolumeID[svolID] = smtype->second;
     }
   }
 
@@ -801,8 +808,8 @@ void Detector::CreateSupermoduleGeometry(const std::string_view mother)
       };
 
       if (SMOrder == 1) { // first time, create the SM
-        auto volID = CreateEMCALVolume(smName, "BOX", ID_AIR, parC, 3);
-        mSMVolumeID[volID] = EMCALSMType(tmpType);
+        CreateEMCALVolume(smName, "BOX", ID_AIR, parC, 3);
+        mSMVolNames[smName] = EMCALSMType(tmpType);
 
         LOG(DEBUG2) << R"( Super module with name \")" << smName << R"(\" was created in \"box\" with: par[0] = )"
                     << parC[0] << ", par[1] = " << parC[1] << ", par[2] = " << parC[2];

--- a/Detectors/EMCAL/simulation/src/Detector.cxx
+++ b/Detectors/EMCAL/simulation/src/Detector.cxx
@@ -112,12 +112,11 @@ void Detector::InitializeO2Detector()
   // All EMCAL volumes must be declared as sensitive, otherwise
   // the decay chains are broken by volumes not processed in ProceeHits
   for (const auto& child : mSensitive) {
-    auto vsense = gGeoManager->GetVolume(child.data());
-    if (vsense) {
-      LOG(DEBUG1) << "Adding sensitive volume " << child;
-      AddSensitiveVolume(vsense);
-    } else {
-      LOG(ERROR) << "EMCAL sensitive volume " << child << " not found ";
+    LOG(DEBUG1) << "Adding sensitive volume " << child;
+    auto svolID = registerSensitiveVolumeAndGetVolID(child); 
+    if (child == "SCMX") {
+      LOG(DEBUG1) << "Adding SCMX volume as sensitive volume with ID " << svolID;
+      mVolumeIDScintillator = svolID;
     }
   }
 


### PR DESCRIPTION
Volume ID for the SCMX (scintillator) volume different
when constructing the geometry and in the VMC specifically
for geant4. In order to circumvent this the sensitive volumes
are added with registerSensitiveVolumeAndGetVolID, and for
the SCMX volume the resulting index is used for the volume
cache.