### PR TITLE
DPL: Improving InputRecord iterator

### DIFF
--- a/Framework/Core/include/Framework/DataRef.h
+++ b/Framework/Core/include/Framework/DataRef.h
@@ -20,9 +20,9 @@ struct InputSpec;
 struct DataRef {
   // FIXME: had to remove the second 'const' in const T* const
   // to allow assignment
-  const InputSpec* spec;
-  const char* header;
-  const char* payload;
+  const InputSpec* spec = nullptr;
+  const char* header = nullptr;
+  const char* payload = nullptr;
 };
 
 } // namespace framework

--- a/Framework/Core/src/InputRecord.cxx
+++ b/Framework/Core/src/InputRecord.cxx
@@ -61,7 +61,7 @@ int InputRecord::getPos(std::string const& binding) const
   return -1;
 }
 
-bool InputRecord::isValid(char const* s)
+bool InputRecord::isValid(char const* s) const
 {
   DataRef ref = get(s);
   if (ref.header == nullptr || ref.payload == nullptr) {
@@ -70,7 +70,7 @@ bool InputRecord::isValid(char const* s)
   return true;
 }
 
-bool InputRecord::isValid(int s)
+bool InputRecord::isValid(int s) const
 {
   DataRef ref = getByPos(s);
   if (ref.header == nullptr || ref.payload == nullptr) {

--- a/Framework/Core/test/test_InputRecord.cxx
+++ b/Framework/Core/test/test_InputRecord.cxx
@@ -127,6 +127,23 @@ BOOST_AUTO_TEST_CASE(TestInputRecord)
   // A few more time just to make sure we are not stateful..
   BOOST_CHECK_EQUAL(record.get<int>("x"), 1);
   BOOST_CHECK_EQUAL(record.get<int>("x"), 1);
+
+  // test the iterator
+  int position = 0;
+  for (auto input = record.begin(), end = record.end(); input != end; input++, position++) {
+    if (position == 0) {
+      BOOST_CHECK(input.matches("TPC") == true);
+      BOOST_CHECK(input.matches("TPC", "CLUSTERS") == true);
+      BOOST_CHECK(input.matches("ITS", "CLUSTERS") == false);
+    }
+    if (position == 1) {
+      BOOST_CHECK(input.matches("ITS") == true);
+      BOOST_CHECK(input.matches("ITS", "CLUSTERS") == true);
+      BOOST_CHECK(input.matches("TPC", "CLUSTERS") == false);
+    }
+    // check if invalid slots are filtered out by the iterator
+    BOOST_CHECK(position != 2);
+  }
 }
 
 // TODO:


### PR DESCRIPTION
The iterator API did not reflect the features introduced with the completion policies. Slots might be invalid.

- filtering out invalid input slots from the iteration
- `nullptr` as default values of DataRef members
- fixing const'ness of `InputRecord::isValid` method