### PR TITLE
DPL: Regexp matching in CompletionPolicyHelpers::defineByName

### DIFF
--- a/Framework/Core/include/Framework/DataSampling.h
+++ b/Framework/Core/include/Framework/DataSampling.h
@@ -17,7 +17,6 @@
 /// \author Piotr Konopka, piotr.jan.konopka@cern.ch
 
 #include "Framework/WorkflowSpec.h"
-#include "Framework/CompletionPolicy.h"
 #include "Framework/ChannelConfigurationPolicy.h"
 #include "Framework/InputSpec.h"
 
@@ -29,6 +28,8 @@ namespace o2
 {
 namespace framework
 {
+
+class CompletionPolicy;
 
 /// A class responsible for providing data from main processing flow to QC tasks.
 ///

--- a/Framework/Core/src/CompletionPolicyHelpers.cxx
+++ b/Framework/Core/src/CompletionPolicyHelpers.cxx
@@ -18,6 +18,7 @@
 #include <gsl/span>
 
 #include <cassert>
+#include <regex>
 
 namespace o2
 {
@@ -27,7 +28,7 @@ namespace framework
 CompletionPolicy CompletionPolicyHelpers::defineByName(std::string const& name, CompletionPolicy::CompletionOp op)
 {
   auto matcher = [name](DeviceSpec const& device) -> bool {
-    return device.name == name;
+    return std::regex_match(device.name.begin(), device.name.end(), std::regex(name));
   };
   auto callback = [op](gsl::span<PartRef const> const& inputs) -> CompletionPolicy::CompletionOp {
     return op;

--- a/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
@@ -8,7 +8,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 #include "Framework/ConfigParamSpec.h"
-#include "Framework/CompletionPolicy.h"
+#include "Framework/CompletionPolicyHelpers.h"
 #include "Framework/DeviceSpec.h"
 #include <InfoLogger/InfoLogger.hxx>
 
@@ -32,13 +32,7 @@ void customize(std::vector<ConfigParamSpec>& options)
 // will process an InputRecord which had any of its constituent updated.
 void customize(std::vector<CompletionPolicy>& policies)
 {
-  auto matcher = [](DeviceSpec const& device) -> bool {
-    return device.name == "D";
-  };
-  auto policy = [](gsl::span<PartRef const> const& inputs) -> CompletionPolicy::CompletionOp {
-    return CompletionPolicy::CompletionOp::Process;
-  };
-  policies.push_back({CompletionPolicy{"process-any", matcher, policy}});
+  policies.push_back(CompletionPolicyHelpers::defineByName("D", CompletionPolicy::CompletionOp::Process));
 }
 
 #include "Framework/runDataProcessing.h"

--- a/Framework/Utils/src/esd-2-arrow-converter.cxx
+++ b/Framework/Utils/src/esd-2-arrow-converter.cxx
@@ -8,7 +8,6 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 #include "Framework/ConfigParamSpec.h"
-#include "Framework/CompletionPolicy.h"
 #include "Framework/DeviceSpec.h"
 #include "Framework/AODReaderHelpers.h"
 


### PR DESCRIPTION
Cleaning also up includes of CompletionPolicy.h and using the default
completion policy utilities.