### PR TITLE
DPL: Cleaning up class o2::framework::Output

### DIFF
--- a/Framework/Core/include/Framework/Output.h
+++ b/Framework/Core/include/Framework/Output.h
@@ -53,16 +53,29 @@ struct Output {
   Output(header::DataHeader const& header)
     : origin(header.dataOrigin), description(header.dataDescription), subSpec(header.subSpecification)
   {
-    // TODO: we might also want to create the stack object as a copy
   }
 
-  Output(const Output&& rhs)
+  Output(const Output&) = delete;
+
+  Output(Output&& rhs)
     : origin(rhs.origin),
       description(rhs.description),
       subSpec(rhs.subSpec),
       lifetime(rhs.lifetime),
       metaHeader(std::move(rhs.metaHeader))
   {
+  }
+
+  Output& operator=(const Output&) = delete;
+
+  Output& operator=(Output&& rhs)
+  {
+    origin = rhs.origin;
+    description = rhs.description;
+    subSpec = rhs.subSpec;
+    lifetime = rhs.lifetime;
+    metaHeader = std::move(rhs.metaHeader);
+    return *this;
   }
 
   bool operator==(const Output& that) const


### PR DESCRIPTION
- Explicitely deleting copy constructor and assignment operator because
  that would require to copy the stack instance
- Adding move assignment operator
- Correcting move constructor