### PR TITLE
Pythia8 generator compliant with o2::eventgen::Generator protocol

### DIFF
--- a/Generators/CMakeLists.txt
+++ b/Generators/CMakeLists.txt
@@ -30,7 +30,8 @@ o2_add_library(Generators
                        src/BoxGunParam.cxx
 		       src/QEDGenParam.cxx
                        src/GeneratorFactory.cxx
-                       $<$<BOOL:${pythia_FOUND}>:src/Pythia8Generator.cxx>
+                       $<$<BOOL:${pythia_FOUND}>:src/GeneratorPythia8.cxx>
+                       $<$<BOOL:${pythia_FOUND}>:src/GeneratorPythia8Param.cxx>
                        $<$<BOOL:${HepMC_FOUND}>:src/GeneratorHepMC.cxx>
                PUBLIC_LINK_LIBRARIES FairRoot::Base O2::SimConfig
                                      O2::SimulationDataFormat ${pythiaTarget} ${hepmcTarget}
@@ -60,7 +61,8 @@ set(headers
     include/Generators/QEDGenParam.h)
 
 if(pythia_FOUND)
-  list(APPEND headers include/Generators/Pythia8Generator.h
+  list(APPEND headers include/Generators/GeneratorPythia8.h
+              include/Generators/GeneratorPythia8Param.h
               include/Generators/GeneratorFactory.h)
 endif()
 
@@ -100,3 +102,8 @@ install(FILES share/external/extgen.C share/external/pythia6.C
               share/external/tgenerator.C share/external/QEDLoader.C share/external/QEDepem.C
 	      share/external/multiphi_trigger.C
         DESTINATION share/Generators/external/)
+
+install(FILES share/egconfig/pythia8_inel.cfg
+              share/egconfig/pythia8_hf.cfg
+	      share/egconfig/pythia8_hi.cfg
+        DESTINATION share/Generators/egconfig/)

--- a/Generators/include/Generators/GeneratorPythia8.h
+++ b/Generators/include/Generators/GeneratorPythia8.h
@@ -1,0 +1,68 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author R+Preghenella - January 2020
+
+#ifndef ALICEO2_EVENTGEN_GENERATORPYTHIA8_H_
+#define ALICEO2_EVENTGEN_GENERATORPYTHIA8_H_
+
+#include "Generators/Generator.h"
+#include "Pythia8/Pythia.h"
+
+namespace o2
+{
+namespace eventgen
+{
+
+/*****************************************************************/
+/*****************************************************************/
+
+class GeneratorPythia8 : public Generator
+{
+
+ public:
+  /** default constructor **/
+  GeneratorPythia8();
+  /** constructor **/
+  GeneratorPythia8(const Char_t* name, const Char_t* title = "ALICEo2 Pythia8 Generator");
+  /** destructor **/
+  virtual ~GeneratorPythia8() = default;
+
+  /** Initialize the generator if needed **/
+  virtual Bool_t Init() override;
+
+  /** methods **/
+  bool readString(std::string val) { return mPythia.readString(val, true); };
+  bool readFile(std::string val) { return mPythia.readFile(val, true); };
+
+ protected:
+  /** copy constructor **/
+  GeneratorPythia8(const GeneratorPythia8&);
+  /** operator= **/
+  GeneratorPythia8& operator=(const GeneratorPythia8&);
+
+  /** methods to override **/
+  Bool_t generateEvent() override;
+  Bool_t importParticles() override;
+
+  /** Pythia8 **/
+  Pythia8::Pythia mPythia; //!
+
+  ClassDefOverride(GeneratorPythia8, 1);
+
+}; /** class GeneratorPythia8 **/
+
+/*****************************************************************/
+/*****************************************************************/
+
+} // namespace eventgen
+} // namespace o2
+
+#endif /* ALICEO2_EVENTGEN_GENERATORPYTHIA8_H_ */

--- a/Generators/include/Generators/GeneratorPythia8Param.h
+++ b/Generators/include/Generators/GeneratorPythia8Param.h
@@ -1,0 +1,39 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author R+Preghenella - January 2020
+
+#ifndef ALICEO2_EVENTGEN_GENERATORPYTHIA8PARAM_H_
+#define ALICEO2_EVENTGEN_GENERATORPYTHIA8PARAM_H_
+
+#include "SimConfig/ConfigurableParam.h"
+#include "SimConfig/ConfigurableParamHelper.h"
+#include <string>
+
+namespace o2
+{
+namespace eventgen
+{
+
+/**
+ ** a parameter class/struct to keep the settings of
+ ** the Pythia8 event generator and
+ ** allow the user to modify them 
+ **/
+
+struct GeneratorPythia8Param : public o2::conf::ConfigurableParamHelper<GeneratorPythia8Param> {
+  std::string config = "";
+  O2ParamDef(GeneratorPythia8Param, "Pythia8");
+};
+
+} // end namespace eventgen
+} // end namespace o2
+
+#endif // ALICEO2_EVENTGEN_GENERATORPYTHIA8PARAM_H_

--- a/Generators/share/egconfig/pythia8_hf.cfg
+++ b/Generators/share/egconfig/pythia8_hf.cfg
@@ -1,0 +1,12 @@
+### beams
+Beams:idA 2212			# proton
+Beams:idB 2212 			# proton
+Beams:eCM 14000. 		# GeV
+
+### processes
+HardQCD:hardccbar on		# scatterings g-g / q-qbar -> c-cbar
+HardQCD:hardbbbar on		# scatterings g-g / q-qbar -> b-bbar
+
+### decays
+ParticleDecays:limitTau0 on	
+ParticleDecays:tau0Max 0.001	

--- a/Generators/share/egconfig/pythia8_hi.cfg
+++ b/Generators/share/egconfig/pythia8_hi.cfg
@@ -1,0 +1,15 @@
+### beams
+Beams:idA 1000822080		# Pb
+Beams:idB 1000822080		# Pb
+Beams:eCM 5520. 		# GeV
+
+### heavy-ion settings (valid for Pb-Pb 5520 only)
+HeavyIon:SigFitNGen 0
+HeavyIon:SigFitDefPar 14.82,1.82,0.25,0.0,0.0,0.0,0.0,0.0
+HeavyIon:bWidth			# impact parameter from 0-x [fm]
+
+### processes (apparently not to be defined)
+
+### decays
+ParticleDecays:limitTau0 on	
+ParticleDecays:tau0Max 0.001	

--- a/Generators/share/egconfig/pythia8_inel.cfg
+++ b/Generators/share/egconfig/pythia8_inel.cfg
@@ -1,0 +1,11 @@
+### beams
+Beams:idA 2212			# proton
+Beams:idB 2212 			# proton
+Beams:eCM 14000. 		# GeV
+
+### processes
+SoftQCD:inelastic on		# all inelastic processes
+
+### decays
+ParticleDecays:limitTau0 on	
+ParticleDecays:tau0Max 0.001	

--- a/Generators/src/GeneratorPythia8.cxx
+++ b/Generators/src/GeneratorPythia8.cxx
@@ -1,0 +1,121 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author R+Preghenella - January 2020
+
+#include "Generators/GeneratorPythia8.h"
+#include <Generators/GeneratorPythia8Param.h>
+#include "FairLogger.h"
+#include "TClonesArray.h"
+#include "TParticle.h"
+
+namespace o2
+{
+namespace eventgen
+{
+
+/*****************************************************************/
+/*****************************************************************/
+
+GeneratorPythia8::GeneratorPythia8() : Generator("ALICEo2", "ALICEo2 Pythia8 Generator")
+{
+  /** default constructor **/
+}
+
+/*****************************************************************/
+
+GeneratorPythia8::GeneratorPythia8(const Char_t* name, const Char_t* title) : Generator(name, title)
+{
+  /** constructor **/
+}
+
+/*****************************************************************/
+
+Bool_t GeneratorPythia8::Init()
+{
+  /** init **/
+
+  /** init base class **/
+  Generator::Init();
+
+  auto& param = GeneratorPythia8Param::Instance();
+  LOG(INFO) << "Init \'Pythia8\' generator with following parameters";
+  LOG(INFO) << param;
+
+  /** read configuration **/
+  if (!param.config.empty()) {
+    if (!mPythia.readFile(param.config, true)) {
+      LOG(FATAL) << "Failed to init \'Pythia8\': problems with configuration file "
+                 << param.config;
+      return false;
+    }
+  }
+
+  /** initialise **/
+  if (!mPythia.init()) {
+    LOG(FATAL) << "Failed to init \'Pythia8\': init returned with error";
+    return false;
+  }
+
+  /** success **/
+  return true;
+}
+
+/*****************************************************************/
+
+Bool_t
+  GeneratorPythia8::generateEvent()
+{
+  /** generate event **/
+
+  return mPythia.next();
+}
+
+/*****************************************************************/
+
+Bool_t
+  GeneratorPythia8::importParticles()
+{
+  /** import particles **/
+
+  TClonesArray& clonesParticles = *mParticles;
+  clonesParticles.Clear();
+
+  /* loop over particles */
+  //  auto weight = mPythia.info.weight(); // TBD: use weights
+  auto nParticles = mPythia.event.size();
+  for (Int_t iparticle = 1; iparticle < nParticles; iparticle++) { // first particle is system
+    auto particle = mPythia.event[iparticle];
+    auto pdg = particle.id();
+    auto st = particle.statusHepMC();
+    auto px = particle.px();
+    auto py = particle.py();
+    auto pz = particle.pz();
+    auto et = particle.e();
+    auto vx = particle.xProd();
+    auto vy = particle.yProd();
+    auto vz = particle.zProd();
+    auto vt = particle.tProd();
+    auto m1 = particle.mother1();
+    auto m2 = particle.mother2();
+    auto d1 = particle.daughter1();
+    auto d2 = particle.daughter2();
+    new (clonesParticles[iparticle]) TParticle(pdg, st, m1, m2, d1, d2, px, py, pz, et, vx, vy, vz, vt);
+  }
+
+  /** success **/
+  return kTRUE;
+}
+
+/*****************************************************************/
+/*****************************************************************/
+
+} /* namespace eventgen */
+} /* namespace o2 */

--- a/Generators/src/GeneratorPythia8Param.cxx
+++ b/Generators/src/GeneratorPythia8Param.cxx
@@ -1,0 +1,14 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author R+Preghenella - January 2020
+
+#include "Generators/GeneratorPythia8Param.h"
+O2ParamImpl(o2::eventgen::GeneratorPythia8Param);

--- a/Generators/src/GeneratorsLinkDef.h
+++ b/Generators/src/GeneratorsLinkDef.h
@@ -32,7 +32,9 @@
 #endif
 #pragma link C++ class o2::eventgen::Pythia6Generator + ;
 #ifdef GENERATORS_WITH_PYTHIA8
-#pragma link C++ class o2::eventgen::Pythia8Generator + ;
+#pragma link C++ class o2::eventgen::GeneratorPythia8 + ;
+#pragma link C++ class o2::eventgen::GeneratorPythia8Param + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::eventgen::GeneratorPythia8Param > +;
 #pragma link C++ class o2::eventgen::GeneratorFactory + ;
 #endif
 #pragma link C++ class o2::eventgen::GeneratorFromFile + ;

--- a/macro/run_sim_pythia8hi.C
+++ b/macro/run_sim_pythia8hi.C
@@ -19,7 +19,7 @@
 
 #include "DetectorsPassive/Cave.h"
 #include "TPCSimulation/Detector.h"
-#include "Generators/Pythia8Generator.h"
+#include "Generators/GeneratorPythia8.h"
 #endif
 
 void run_sim_pythia8hi(Int_t nEvents = 10, TString mcEngine = "TGeant3")
@@ -76,13 +76,13 @@ void run_sim_pythia8hi(Int_t nEvents = 10, TString mcEngine = "TGeant3")
   run->AddModule(tpc);
 
   // Create TGenerator interface
-  auto gen = new o2::eventgen::Pythia8Generator();
-  gen->SetParameters("Beams:idA 1000822080");                                      // Pb ion
-  gen->SetParameters("Beams:idB 1000822080");                                      // Pb ion
-  gen->SetParameters("Beams:eCM 5520.0");                                          // [GeV]
-  gen->SetParameters("HeavyIon:SigFitNGen 0");                                     // valid for Pb-Pb 5520 only
-  gen->SetParameters("HeavyIon:SigFitDefPar 14.82,1.82,0.25,0.0,0.0,0.0,0.0,0.0"); // valid for Pb-Pb 5520 only
-  gen->SetParameters("HeavyIon:bWidth 1");                                         // impact parameter from 0-x [fm]
+  auto gen = new o2::eventgen::GeneratorPythia8();
+  gen->readString("Beams:idA 1000822080");                                      // Pb ion
+  gen->readString("Beams:idB 1000822080");                                      // Pb ion
+  gen->readString("Beams:eCM 5520.0");                                          // [GeV]
+  gen->readString("HeavyIon:SigFitNGen 0");                                     // valid for Pb-Pb 5520 only
+  gen->readString("HeavyIon:SigFitDefPar 14.82,1.82,0.25,0.0,0.0,0.0,0.0,0.0"); // valid for Pb-Pb 5520 only
+  gen->readString("HeavyIon:bWidth 1");                                         // impact parameter from 0-x [fm]
 
   // Create PrimaryGenerator
   auto primGen = new FairPrimaryGenerator();


### PR DESCRIPTION
This PR replaces the Pythia8 event generator interface with a new interface that complies with the `o2::eventgen::Generator` protocol.
This enables the use of event generator triggers as provided in PR #2772 on the native Pythia8 interface.

The previous Pythia8 interface implemented in `Generators/src/Pythia8Generator.cxx` is replaced by `Generators/src/GeneratorPythia8.cxx` throughout the O2. The original file `Generators/src/Pythia8Generator.cxx` is still kept in place for the time being and will be removed at a later stage.

Changes in `Generators/src/GeneratorFactory` are done accordingly. Notice that the already-existing Pythia8 configurations selectable with -g option in o2-sim (pythia8, pythia8hf, pythia8hi) are still available. On the other hand, the configuration has been moved from the previous hard-coded implementation to a file-based implementation. The corresponding files are located in `Generators/share/egconfig/` and are to be installed in `$O2_ROOT/share/Generators/share/egconfig`.
This simplifies the code, removes hard-coded configuration and makes it explicit that the way to configure Pythia8 is not via hard-coded lines, but via external configuration files.

This PR also provides a way for the user to configure the event generator with a custom configuration file. The configuration file must provide a configuration according to the Pythia8 prescriptions. Examples are the ones discussed above.

To configure o2-sim to run Pythia8 event generator, simply run
```
o2-sim -g pythia8
```
as before. This will load the configuration from `pythia8_inel.cfg`, which is for the moment the assumed default Pythia8 configuration (inelastic pp collisions at 14 TeV with simple decay settings).

To configure o2-sim to run Pythia8 event generator with an external configuration file, run
```
o2-sim -g pythia8 --configKeyValues Pythia8.config=path_to_file.cfg
```
This will configure Pythia8 according to `path_to_file.cfg` settings. Notice that a missing file or an error in the configuration will trigger a FATAL abort of the run. Notice also that the default Pythia8 settings are applied before the custom ones, that can in case override them.

