### PR TITLE
Minor change to TPC ZS Format

### DIFF
--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/ZeroSuppression.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/ZeroSuppression.h
@@ -34,6 +34,7 @@ struct TPCZSHDR {
   unsigned char nTimeBins;
   unsigned short cruID;
   unsigned short timeOffset;
+  unsigned short nADCsamples;
 };
 struct TPCZSTBHDR {
   unsigned short rowMask;

--- a/GPU/GPUTracking/Base/GPUReconstructionConvert.cxx
+++ b/GPU/GPUTracking/Base/GPUReconstructionConvert.cxx
@@ -292,6 +292,7 @@ void GPUReconstructionConvert::RunZSEncoder(const GPUTrackingInOutDigits* in, GP
       (*nSeq)++;
       streamBuffer8[streamSize8++] = tmpBuffer[k].pad;
       streamBuffer8[streamSize8++] = streamSize + seqLen;
+      hdr->nADCsamples += seqLen;
       for (int l = 0; l < seqLen; l++) {
         streamBuffer[streamSize++] = (unsigned short)(tmpBuffer[k + l].charge * encodeBitsFactor + 0.5f);
       }
@@ -329,12 +330,12 @@ void GPUReconstructionConvert::RunZSEncoder(const GPUTrackingInOutDigits* in, GP
             pagePtr++;
           }
           tbHdr = reinterpret_cast<TPCZSTBHDR*>(pagePtr);
-          endpoint = tbHdr->rowMask & 0x8000;
-          if (tbHdr->rowMask != 0 && ((endpoint != 0) ^ ((j & 1) != 0))) {
+          bool upperRows = tbHdr->rowMask & 0x8000;
+          if (tbHdr->rowMask != 0 && ((upperRows) ^ ((j & 1) != 0))) {
             throw std::runtime_error("invalid endpoint");
           }
-          const int rowOffset = param.tpcGeometry.GetRegionStart(region) + (endpoint ? (nRowsRegion / 2) : 0);
-          const int nRows = endpoint ? (nRowsRegion - nRowsRegion / 2) : nRowsRegion;
+          const int rowOffset = param.tpcGeometry.GetRegionStart(region) + (upperRows ? (nRowsRegion / 2) : 0);
+          const int nRows = upperRows ? (nRowsRegion - nRowsRegion / 2) : nRowsRegion;
           const int nRowsUsed = __builtin_popcount((unsigned int)(tbHdr->rowMask & 0x7FFF));
           pagePtr += nRowsUsed ? (2 * nRowsUsed) : 2;
           int rowPos = 0;

--- a/GPU/GPUTracking/Standalone/tools/testCL.sh
+++ b/GPU/GPUTracking/Standalone/tools/testCL.sh
@@ -9,7 +9,9 @@ LLVM_SPIRV=llvm-spirv
 #COMPILER=/home/qon/clang-build/install/bin/clang++
 #LLVM_SPIRV=/home/qon/clang-build/SPIRV-LLVM-Translator/build/tools/llvm-spirv/llvm-spirv
 
-INCLUDES="-I../. -I../Base -I../SliceTracker -I../Common -I../Merger -I../TRDTracking -I../ITS -I../dEdx -I../TPCConvert -I../TPCFastTransformation -I../DataCompression -I../gpucf -I$HOME/alice/O2/DataFormats/Detectors/TPC/include -I$HOME/alice/O2/Detectors/Base/include -I$HOME/alice/O2/Detectors/Base/src -I$HOME/alice/O2/Common/MathUtils/include -I$HOME/alice/O2/Detectors/TRD/base/include -I$HOME/alice/O2/Detectors/TRD/base/src -I$HOME/alice/O2/Detectors/ITSMFT/ITS/tracking/include -I$HOME/alice/O2/Detectors/ITSMFT/ITS/tracking/cuda/include -I$HOME/alice/O2/Common/Constants/include"
+INCLUDES="-I../. -I../Base -I../SliceTracker -I../Common -I../Merger -I../TRDTracking -I../ITS -I../dEdx -I../TPCConvert -I../TPCFastTransformation -I../DataCompression -I../TPCClusterFinder \
+          -I$HOME/alice/O2/DataFormats/Detectors/TPC/include -I$HOME/alice/O2/Detectors/Base/include -I$HOME/alice/O2/Detectors/Base/src -I$HOME/alice/O2/Common/MathUtils/include -I$HOME/alice/O2/DataFormats/Headers/include \
+          -I$HOME/alice/O2/Detectors/TRD/base/include -I$HOME/alice/O2/Detectors/TRD/base/src -I$HOME/alice/O2/Detectors/ITSMFT/ITS/tracking/include -I$HOME/alice/O2/Detectors/ITSMFT/ITS/tracking/cuda/include -I$HOME/alice/O2/Common/Constants/include"
 DEFINES="-DGPUCA_STANDALONE -DGPUCA_ENABLE_GPU_TRACKER -DGPUCA_GPULIBRARY=OCL -DNDEBUG -D__OPENCLCPP__ -DHAVE_O2HEADERS"
 FLAGS="-O3 -cl-denorms-are-zero -cl-mad-enable -cl-no-signed-zeros -ferror-limit=1000 -Xclang -finclude-default-header -Dcl_clang_storage_class_specifiers"
 

--- a/GPU/GPUTracking/TPCClusterFinder/ClusterAccumulator.cxx
+++ b/GPU/GPUTracking/TPCClusterFinder/ClusterAccumulator.cxx
@@ -17,9 +17,9 @@
 
 #if !defined(__OPENCL__)
 #include <cmath>
+using namespace std;
 #endif
 
-using namespace std;
 using namespace GPUCA_NAMESPACE::gpu;
 
 GPUd() void ClusterAccumulator::toNative(const deprecated::Digit& d, deprecated::ClusterNative& cn) const

--- a/GPU/GPUTracking/TPCClusterFinder/DecodeZS.cxx
+++ b/GPU/GPUTracking/TPCClusterFinder/DecodeZS.cxx
@@ -14,8 +14,22 @@
 #include "DecodeZS.h"
 #include "GPUCommonMath.h"
 #include "GPUTPCClusterFinder.h"
-#include "Headers/RAWDataHeader.h"
 #include "DataFormatsTPC/ZeroSuppression.h"
+
+#ifndef __OPENCL__
+#include "Headers/RAWDataHeader.h"
+#else
+namespace o2
+{
+namespace header
+{
+struct RAWDataHeader {
+  unsigned int words[16];
+};
+} // namespace header
+} // namespace o2
+
+#endif
 
 using namespace GPUCA_NAMESPACE::gpu;
 using namespace o2::tpc;


### PR DESCRIPTION
Store the total number of ADC samples in the header, for fast computation of cluster memory layout after decoding.