### PR TITLE
Using endOfStream in the digitizer workflow

### DIFF
--- a/Steer/DigitizerWorkflow/src/SimReaderSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/SimReaderSpec.cxx
@@ -96,7 +96,8 @@ DataProcessorSpec getSimReaderSpec(int fanoutsize, const std::vector<int>& tpcse
         }
         tpc_end_messagesent = true;
       }
-      // now mark the reader as ready to finish
+      // send endOfData control event and mark the reader as ready to finish
+      pc.services().get<ControlService>().endOfStream();
       pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
       return;
     }

--- a/Steer/DigitizerWorkflow/src/TPCDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TPCDigitizerSpec.cxx
@@ -177,10 +177,6 @@ class TPCDPLDigitizerTask
     static int callcounter = 0;
     callcounter++;
 
-    static bool finished = false;
-    if (finished) {
-      return;
-    }
     LOG(INFO) << "Processing TPC digitization";
 
     /// For the time being use the defaults for the CDB
@@ -273,11 +269,6 @@ class TPCDPLDigitizerTask
       snapshotCommonMode(commonModeAccum);
       snapshotLabels(labelAccum);
 
-      if (sector == -1) {
-        LOG(INFO) << "TPC: Processing done - exit through the gift shop...";
-        pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
-        finished = true;
-      }
       return;
     }
 


### PR DESCRIPTION
endOfStream control event is issued by the SimReader device as data source
of the workflow. The event is propagated through the DPL workflow devices.
DPL decides how to change the state of the device and can terminate devices.