### PR TITLE
Updating TPC reco workflow

### DIFF
--- a/Detectors/TPC/workflow/include/TPCWorkflow/ClustererSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/ClustererSpec.h
@@ -22,7 +22,7 @@ namespace tpc
 
 /// create a processor spec
 /// read simulated TPC clusters from file and publish
-framework::DataProcessorSpec getClustererSpec(bool sendMC, bool haveDigTriggers = false);
+framework::DataProcessorSpec getClustererSpec(bool sendMC);
 
 } // end namespace tpc
 } // end namespace o2

--- a/Detectors/TPC/workflow/src/ClustererSpec.cxx
+++ b/Detectors/TPC/workflow/src/ClustererSpec.cxx
@@ -40,7 +40,7 @@ using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
 
 /// create a processor spec
 /// runs the TPC HwClusterer in a DPL process with digits and mc as input
-DataProcessorSpec getClustererSpec(bool sendMC, bool haveDigTriggers)
+DataProcessorSpec getClustererSpec(bool sendMC)
 {
   std::string processorName = "tpc-clusterer";
 
@@ -186,19 +186,13 @@ DataProcessorSpec getClustererSpec(bool sendMC, bool haveDigTriggers)
     return processingFct;
   };
 
-  auto createInputSpecs = [](bool makeMcInput, bool makeTriggersInput = false) {
+  auto createInputSpecs = [](bool makeMcInput) {
     std::vector<InputSpec> inputSpecs{
       InputSpec{"digits", gDataOriginTPC, "DIGITS", 0, Lifetime::Timeframe},
     };
     if (makeMcInput) {
       constexpr o2::header::DataDescription datadesc("DIGITSMCTR");
       inputSpecs.emplace_back("mclabels", gDataOriginTPC, datadesc, 0, Lifetime::Timeframe);
-    }
-    if (makeTriggersInput) {
-      // this is an additional output by the TPC digitizer, need to check if that
-      // has to go into the clusterer as well
-      constexpr o2::header::DataDescription datadesc("DIGTRIGGERS");
-      inputSpecs.emplace_back("digtriggers", gDataOriginTPC, datadesc, 0, Lifetime::Timeframe);
     }
     return std::move(inputSpecs);
   };
@@ -217,7 +211,7 @@ DataProcessorSpec getClustererSpec(bool sendMC, bool haveDigTriggers)
   };
 
   return DataProcessorSpec{processorName,
-                           {createInputSpecs(sendMC, haveDigTriggers)},
+                           {createInputSpecs(sendMC)},
                            {createOutputSpecs(sendMC)},
                            AlgorithmSpec(initFunction)};
 }

--- a/Detectors/TPC/workflow/src/PublisherSpec.cxx
+++ b/Detectors/TPC/workflow/src/PublisherSpec.cxx
@@ -110,10 +110,10 @@ DataProcessorSpec getPublisherSpec(PublisherConf const& config, bool propagateMC
                                                              sectorfile.c_str(), // input file name
                                                              nofEvents,          // number of entries to publish
                                                              publishingMode,
-                                                             Output{dto.origin, dto.description, subSpec, persistency},
-                                                             clusterbranchname.c_str(), // name of cluster branch
                                                              Output{mco.origin, mco.description, subSpec, persistency},
-                                                             mcbranchname.c_str() // name of mc label branch
+                                                             mcbranchname.c_str(), // name of mc label branch
+                                                             Output{dto.origin, dto.description, subSpec, persistency},
+                                                             clusterbranchname.c_str() // name of cluster branch
           );
         } else {
           readers[sector] = std::make_shared<RootTreeReader>(treename.c_str(),   // tree name
@@ -136,7 +136,7 @@ DataProcessorSpec getPublisherSpec(PublisherConf const& config, bool propagateMC
     // function gets out of scope
     // FIXME: wanted to use it = sectors.begin() in the variable capture but the iterator
     // is const and can not be incremented
-    auto processingFct = [processAttributes, index = std::make_shared<int>(0), propagateMC](ProcessingContext& pc) {
+    auto processingFct = [processAttributes, index = std::make_shared<unsigned>(0), propagateMC](ProcessingContext& pc) {
       if (processAttributes->finished) {
         return;
       }

--- a/Detectors/TPC/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/TPC/workflow/src/RecoWorkflow.cxx
@@ -107,6 +107,10 @@ framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors, std::vec
 
   WorkflowSpec specs;
 
+  // The OutputSpec of the PublisherSpec is configured depending on the input
+  // type. Note that the configuration of the dispatch trigger in the main file
+  // needs to be done in accordance. This means, if a new input option is added
+  // also the dispatch trigger needs to be updated.
   if (inputType == InputType::Digits) {
     specs.emplace_back(o2::tpc::getPublisherSpec(PublisherConf{
                                                    "tpc-digit-reader",

--- a/Detectors/TPC/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/TPC/workflow/src/RecoWorkflow.cxx
@@ -166,7 +166,7 @@ framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors, std::vec
   //
   //
   if (runClusterer) {
-    parallelProcessors.push_back(o2::tpc::getClustererSpec(propagateMC, inputType == InputType::Digitizer));
+    parallelProcessors.push_back(o2::tpc::getClustererSpec(propagateMC));
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////

--- a/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
+++ b/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
@@ -16,7 +16,7 @@
 #include "Framework/WorkflowSpec.h"
 #include "Framework/DeviceSpec.h"
 #include "Framework/ConfigParamSpec.h"
-#include "Framework/CompletionPolicy.h"
+#include "Framework/CompletionPolicyHelpers.h"
 #include "Framework/DispatchPolicy.h"
 #include "Framework/PartRef.h"
 #include "TPCWorkflow/RecoWorkflow.h"
@@ -27,10 +27,11 @@
 #include <string>
 #include <stdexcept>
 #include <unordered_map>
+#include <regex>
 
-// we need a global variable to know how many parts are expected in the completion policy check
-bool gDoMC = true;
-bool gDispatchPrompt = true;
+// we need a global variable to propagate the type the message dispatching of the
+// publisher will trigger on. This is dependent on the input type
+o2::framework::Output gDispatchTrigger{"", ""};
 
 // add workflow options, note that customization needs to be declared before
 // including Framework/runDataProcessing
@@ -55,77 +56,29 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 // customize dispatch policy, dispatch immediately what is ready
 void customize(std::vector<o2::framework::DispatchPolicy>& policies)
 {
+  using DispatchOp = o2::framework::DispatchPolicy::DispatchOp;
   // we customize all devices to dispatch data immediately
-  policies.push_back({"prompt-for-all", [](auto const&) { return gDispatchPrompt; }, o2::framework::DispatchPolicy::DispatchOp::WhenReady});
+  auto readerMatcher = [](auto const& spec) {
+    return std::regex_match(spec.name.begin(), spec.name.end(), std::regex(".*-reader"));
+  };
+  auto triggerMatcher = [](auto const& query) {
+    // a bit of a hack but we want this to be configurable from the command line,
+    // however DispatchPolicy is inserted before all other setup. Triggering depending
+    // on the global variable set from the command line option. If scheduled messages
+    // are not triggered they are sent out at the end of the computation
+    return gDispatchTrigger.origin == query.origin && gDispatchTrigger.description == query.description;
+  };
+  policies.push_back({"prompt-for-reader", readerMatcher, DispatchOp::WhenReady, triggerMatcher});
 }
 
 // customize clusterers and cluster decoders to process immediately what comes in
 void customize(std::vector<o2::framework::CompletionPolicy>& policies)
 {
-  // we customize the processors to consume data as it comes
-  policies.push_back({"tpc-sector-processors",
-                      [](o2::framework::DeviceSpec const& spec) {
-                        // the decoder should process immediately
-                        bool apply = spec.name.find("decoder") != std::string::npos || spec.name.find("clusterer") != std::string::npos;
-                        if (apply) {
-                          LOG(INFO) << "Applying completion policy 'consume' to device " << spec.name;
-                        }
-                        return apply;
-                      },
-                      [](gsl::span<o2::framework::PartRef const> const& inputs) {
-                        o2::framework::CompletionPolicy::CompletionOp policy = o2::framework::CompletionPolicy::CompletionOp::Wait;
-                        int nValidParts = 0;
-                        bool eod = false;
-                        if (!gDoMC) {
-                          for (auto const& part : inputs) {
-                            if (part.header == nullptr) {
-                              continue;
-                            }
-                            nValidParts++;
-                            auto const* header = o2::header::get<o2::header::DataHeader*>(part.header->GetData(), part.header->GetSize());
-                            auto const* sectorHeader = o2::header::get<o2::tpc::TPCSectorHeader*>(part.header->GetData(), part.header->GetSize());
-                            if (sectorHeader && sectorHeader->sector < 0) {
-                              eod = true;
-                            }
-                          }
-                          if (nValidParts == inputs.size()) {
-                            policy = o2::framework::CompletionPolicy::CompletionOp::Consume;
-                          } else if (eod == false) {
-                            policy = o2::framework::CompletionPolicy::CompletionOp::Consume;
-                          }
-                          return policy;
-                        }
-                        using IndexType = o2::header::DataHeader::SubSpecificationType;
-
-                        std::set<IndexType> matchIndices;
-                        for (auto const& part : inputs) {
-                          if (part.header == nullptr) {
-                            continue;
-                          }
-                          nValidParts++;
-                          auto const* header = o2::header::get<o2::header::DataHeader*>(part.header->GetData(), part.header->GetSize());
-                          assert(header != nullptr);
-                          auto haveAlready = matchIndices.find(header->subSpecification);
-                          if (haveAlready != matchIndices.end()) {
-                            // inputs should be data-mc pairs if the index is already in the list
-                            // the pair is complete and we can remove the index
-                            matchIndices.erase(haveAlready);
-                          } else {
-                            // store the index in order to check if there is a pair
-                            matchIndices.emplace(header->subSpecification);
-                          }
-                          auto const* sectorHeader = o2::header::get<o2::tpc::TPCSectorHeader*>(part.header->GetData(), part.header->GetSize());
-                          if (sectorHeader && sectorHeader->sector < 0) {
-                            eod = true;
-                          }
-                        }
-                        if (nValidParts == inputs.size()) {
-                          policy = o2::framework::CompletionPolicy::CompletionOp::Consume;
-                        } else if (matchIndices.size() == 0 && eod == false) {
-                          policy = o2::framework::CompletionPolicy::CompletionOp::Consume;
-                        }
-                        return policy;
-                      }});
+  // we customize the pipeline processors to consume data as it comes
+  using CompletionPolicy = o2::framework::CompletionPolicy;
+  using CompletionPolicyHelpers = o2::framework::CompletionPolicyHelpers;
+  policies.push_back(CompletionPolicyHelpers::defineByName("tpc-cluster-decoder.*", CompletionPolicy::CompletionOp::Consume));
+  policies.push_back(CompletionPolicyHelpers::defineByName("tpc-clusterer.*", CompletionPolicy::CompletionOp::Consume));
 }
 
 #include "Framework/runDataProcessing.h" // the main driver
@@ -161,17 +114,29 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     laneConfiguration = tpcSectors;
   }
 
+  // depending on whether to dispatch early (prompt) and on the input type, we
+  // set the matcher. Note that this has to be in accordance with the OutputSpecs
+  // configured for the PublisherSpec
+  auto dispmode = cfgc.options().get<std::string>("dispatching-mode");
+  if (dispmode == "complete") {
+    // nothing to do we leave the matcher empty which will suppress the dispatch
+    // trigger and all messages will be sent out together at end of computation
+  } else if (inputType == "digits") {
+    gDispatchTrigger = o2::framework::Output{"TPC", "DIGITS"};
+  } else if (inputType == "raw") {
+    gDispatchTrigger = o2::framework::Output{"TPC", "CLUSTERHW"};
+  } else if (inputType == "clusters") {
+    gDispatchTrigger = o2::framework::Output{"TPC", "CLUSTERNATIVE"};
+  }
   // set up configuration
   o2::conf::ConfigurableParam::updateFromFile(cfgc.options().get<std::string>("configFile"));
   o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
   o2::conf::ConfigurableParam::writeINI("o2tpcrecoworkflow_configuration.ini");
 
-  gDoMC = not cfgc.options().get<bool>("disable-mc");
-  auto dispmode = cfgc.options().get<std::string>("dispatching-mode");
-  gDispatchPrompt = !(dispmode == "single");
+  bool doMC = not cfgc.options().get<bool>("disable-mc");
   return o2::tpc::reco_workflow::getWorkflow(tpcSectors,                                     // sector configuration
                                              laneConfiguration,                              // lane configuration
-                                             gDoMC,                                          //
+                                             doMC,                                           //
                                              nLanes,                                         //
                                              inputType,                                      //
                                              cfgc.options().get<std::string>("output-type"), //


### PR DESCRIPTION
1. Simplifying the completion policy in TPC workflow

The custom completion policy was implemented in a complecated way to make
sure that data and mc of the same sector are available before starting the
computation. After moving to grouped output messages for one computation/each
triggered dispatch in commit f6d950b, we can rely on the fact that these
two inputs are arriving together.

The custom dispatch policy of the TPC reco workflow has been extended to trigger
dispatch on published digits/clusters/etc and publishing the optional mc data
before.

2.  Removing obsolete DIGTRIGGERS channel in the tpc-reco-workflow

The TPCDigitizer publishes also the DIGTRIGGERS channel but the information
is not used in the connected cluster finder. Before introducing a central
gatherer for dangling outputs in DPL, this channel had to be defined in the
ClustererSpec to allow the workflow to build.

