### PR TITLE
GPU: Add first thread-parallelization for ZS decoding over pad rows

### DIFF
--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/ZeroSuppression.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/ZeroSuppression.h
@@ -26,6 +26,7 @@ namespace tpc
 struct TPCZSHDR {
   static constexpr size_t TPC_ZS_PAGE_SIZE = 8192;
   static constexpr size_t TPC_MAX_SEQ_LEN = 138;
+  static constexpr size_t TPC_MAX_ZS_ROW_IN_ENDPOINT = 9;
   static constexpr unsigned int MAX_DIGITS_IN_PAGE = (TPC_ZS_PAGE_SIZE - 64 - 6 - 4 - 3) * 8 / 10;
   static constexpr unsigned int TPC_ZS_NBITS_V1 = 10;
   static constexpr unsigned int TPC_ZS_NBITS_V2 = 12;

--- a/GPU/GPUTracking/Base/GPUReconstructionConvert.cxx
+++ b/GPU/GPUTracking/Base/GPUReconstructionConvert.cxx
@@ -346,6 +346,9 @@ void GPUReconstructionConvert::RunZSEncoder(const GPUTrackingInOutDigits* in, GP
           throw std::runtime_error("invalid TPC sector");
         }
         region = cruid % 10;
+        if ((unsigned int)region != j / 2) {
+          throw std::runtime_error("CRU ID / endpoint mismatch");
+        }
         int nRowsRegion = param.tpcGeometry.GetRegionRows(region);
 
         int timeBin = hdr->timeOffset;
@@ -359,7 +362,7 @@ void GPUReconstructionConvert::RunZSEncoder(const GPUTrackingInOutDigits* in, GP
             throw std::runtime_error("invalid endpoint");
           }
           const int rowOffset = param.tpcGeometry.GetRegionStart(region) + (upperRows ? (nRowsRegion / 2) : 0);
-          const int nRows = upperRows ? (nRowsRegion - nRowsRegion / 2) : nRowsRegion;
+          const int nRows = upperRows ? (nRowsRegion - nRowsRegion / 2) : (nRowsRegion / 2);
           const int nRowsUsed = __builtin_popcount((unsigned int)(tbHdr->rowMask & 0x7FFF));
           pagePtr += nRowsUsed ? (2 * nRowsUsed) : 2;
           int rowPos = 0;

--- a/GPU/GPUTracking/TPCClusterFinder/DecodeZS.cxx
+++ b/GPU/GPUTracking/TPCClusterFinder/DecodeZS.cxx
@@ -34,17 +34,25 @@ struct RAWDataHeader {
 using namespace GPUCA_NAMESPACE::gpu;
 using namespace o2::tpc;
 
-GPUd() void DecodeZS::decode(GPUTPCClusterFinder& clusterer, int nBlocks, int nThreads, int iBlock, int iThread)
+GPUd() void DecodeZS::decode(GPUTPCClusterFinder& clusterer, GPUTPCClusterFinderKernels::GPUTPCSharedMemory& s, int nBlocks, int nThreads, int iBlock, int iThread)
 {
-  if (iThread) {
-    return;
-  }
   const unsigned int slice = clusterer.mISlice;
   const unsigned int endpoint = iBlock;
   deprecated::PackedDigit* digits = clusterer.mPdigits;
-  size_t nDigits = clusterer.mPmemory->nDigitsOffset[endpoint];
+  const size_t nDigits = clusterer.mPmemory->nDigitsOffset[endpoint];
+  unsigned int rowOffsetCounter = 0;
   GPUTrackingInOutZS::GPUTrackingInOutZSSlice& zs = clusterer.GetConstantMem()->ioPtrs.tpcZS->slice[slice];
   unsigned short streamBuffer[TPCZSHDR::TPC_MAX_SEQ_LEN];
+  if (iThread == 0) {
+    const int region = endpoint / 2;
+    s.zs.nRowsRegion = clusterer.Param().tpcGeometry.GetRegionRows(region);
+    s.zs.regionStartRow = clusterer.Param().tpcGeometry.GetRegionStart(region);
+    s.zs.nThreadsPerRow = CAMath::Max(1u, nThreads / ((s.zs.nRowsRegion + (endpoint & 1)) / 2));
+    s.zs.rowStride = nThreads / s.zs.nThreadsPerRow;
+  }
+  GPUbarrier();
+  const int myRow = iThread / s.zs.nThreadsPerRow;
+  const int mySequence = iThread % s.zs.nThreadsPerRow;
   for (unsigned int i = 0; i < zs.count[endpoint]; i++) {
     for (unsigned int j = 0; j < zs.nZSPtr[endpoint][i]; j++) {
       unsigned char* page = ((unsigned char*)zs.zsPtr[endpoint][i]) + j * TPCZSHDR::TPC_ZS_PAGE_SIZE;
@@ -52,44 +60,47 @@ GPUd() void DecodeZS::decode(GPUTPCClusterFinder& clusterer, int nBlocks, int nT
       pagePtr += sizeof(o2::header::RAWDataHeader);
       TPCZSHDR* hdr = reinterpret_cast<TPCZSHDR*>(pagePtr);
       pagePtr += sizeof(*hdr);
-      if (hdr->version != 1 && hdr->version != 2) {
-        return;
-      }
       bool decode12bit = hdr->version == 2;
       unsigned int decodeBits = decode12bit ? TPCZSHDR::TPC_ZS_NBITS_V2 : TPCZSHDR::TPC_ZS_NBITS_V1;
       const float decodeBitsFactor = 1.f / (1 << (decodeBits - 10));
       unsigned int mask = (1 << decodeBits) - 1;
-      int cruid = hdr->cruID;
-      unsigned int sector = cruid / 10;
-      if (sector != slice) {
-        return;
-      }
-      int region = cruid % 10;
-      int nRowsRegion = clusterer.Param().tpcGeometry.GetRegionRows(region);
-
       int timeBin = hdr->timeOffset;
       for (int l = 0; l < hdr->nTimeBins; l++) {
-        if ((pagePtr - page) & 1) {
-          pagePtr++;
-        }
+        pagePtr += (pagePtr - page) & 1; //Ensure 16 bit alignment
         TPCZSTBHDR* tbHdr = reinterpret_cast<TPCZSTBHDR*>(pagePtr);
-        if (tbHdr->rowMask && (endpoint & 1) != (unsigned int)(tbHdr->rowMask & 0x8000) >> 15) {
-          return;
+        if ((tbHdr->rowMask & 0x7FFF) == 0) {
+          pagePtr += 2;
+          continue;
         }
-        const int rowOffset = clusterer.Param().tpcGeometry.GetRegionStart(region) + ((endpoint & 1) ? (nRowsRegion / 2) : 0);
-        const int nRows = (endpoint & 1) ? (nRowsRegion - nRowsRegion / 2) : nRowsRegion;
+        const int rowOffset = s.zs.regionStartRow + ((endpoint & 1) ? (s.zs.nRowsRegion / 2) : 0);
+        const int nRows = (endpoint & 1) ? (s.zs.nRowsRegion - s.zs.nRowsRegion / 2) : (s.zs.nRowsRegion / 2);
         const int nRowsUsed = CAMath::Popcount((unsigned int)(tbHdr->rowMask & 0x7FFF));
-        pagePtr += nRowsUsed ? (2 * nRowsUsed) : 2;
-        int rowPos = 0;
-        for (int m = 0; m < nRows; m++) {
+        pagePtr += 2 * nRowsUsed;
+        GPUbarrier();
+        if (iThread == 0) {
+          for (int n = 0; n < nRowsUsed; n++) {
+            s.zs.RowClusterOffset[n] = rowOffsetCounter;
+            unsigned char* rowData = n == 0 ? pagePtr : (page + tbHdr->rowAddr1[n - 1]);
+            rowOffsetCounter += rowData[2 * *rowData]; // Sum up number of ADC samples per row to compute offset in target buffer
+          }
+        }
+        GPUbarrier();
+        if (myRow >= s.zs.rowStride) {
+          continue;
+        }
+        for (int m = myRow; m < nRows; m += s.zs.rowStride) {
           if ((tbHdr->rowMask & (1 << m)) == 0) {
             continue;
           }
+          const int rowPos = CAMath::Popcount((unsigned int)(tbHdr->rowMask & ((1 << m) - 1)));
+          size_t nDigitsTmp = nDigits + s.zs.RowClusterOffset[rowPos];
           unsigned char* rowData = rowPos == 0 ? pagePtr : (page + tbHdr->rowAddr1[rowPos - 1]);
           const int nSeqRead = *rowData;
+          if (mySequence) {
+            continue;
+          }
           unsigned char* adcData = rowData + 2 * nSeqRead + 1;
           int nADC = (rowData[2 * nSeqRead] * decodeBits + 7) / 8;
-          pagePtr += 1 + 2 * nSeqRead + nADC;
           unsigned int byte = 0, bits = 0, pos10 = 0;
           for (int n = 0; n < nADC; n++) {
             byte |= *(adcData++) << bits;
@@ -104,11 +115,15 @@ GPUd() void DecodeZS::decode(GPUTPCClusterFinder& clusterer, int nBlocks, int nT
           for (int n = 0; n < nSeqRead; n++) {
             const int seqLen = rowData[(n + 1) * 2] - (n ? rowData[n * 2] : 0);
             for (int o = 0; o < seqLen; o++) {
-              digits[nDigits++] = deprecated::PackedDigit{(float)streamBuffer[pos10++] * decodeBitsFactor, (Timestamp)(timeBin + l), (Pad)(rowData[n * 2 + 1] + o), (Row)(rowOffset + m)};
+              digits[nDigitsTmp++] = deprecated::PackedDigit{(float)streamBuffer[pos10++] * decodeBitsFactor, (Timestamp)(timeBin + l), (Pad)(rowData[n * 2 + 1] + o), (Row)(rowOffset + m)};
             }
           }
-          rowPos++;
         }
+        if (nRowsUsed > 1) {
+          pagePtr = page + tbHdr->rowAddr1[nRowsUsed - 2];
+        }
+        pagePtr += 2 * *pagePtr;                        // Go to entry for last sequence length
+        pagePtr += 1 + (*pagePtr * decodeBits + 7) / 8; // Go to beginning of next time bin
       }
     }
   }

--- a/GPU/GPUTracking/TPCClusterFinder/DecodeZS.h
+++ b/GPU/GPUTracking/TPCClusterFinder/DecodeZS.h
@@ -26,7 +26,7 @@ class GPUTPCClusterFinder;
 class DecodeZS
 {
  public:
-  static GPUd() void decode(GPUTPCClusterFinder& clusterer, int nBlocks, int nThreads, int iBlock, int iThread);
+  static GPUd() void decode(GPUTPCClusterFinder& clusterer, GPUTPCClusterFinderKernels::GPUTPCSharedMemory& s, int nBlocks, int nThreads, int iBlock, int iThread);
 };
 
 } // namespace gpu

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCClusterFinderKernels.cxx
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCClusterFinderKernels.cxx
@@ -121,5 +121,5 @@ GPUd() int GPUTPCClusterFinderKernels::compactionElems(processorType& clusterer,
 template <>
 GPUd() void GPUTPCClusterFinderKernels::Thread<GPUTPCClusterFinderKernels::decodeZS>(int nBlocks, int nThreads, int iBlock, int iThread, GPUsharedref() GPUTPCSharedMemory& smem, processorType& clusterer)
 {
-  DecodeZS::decode(clusterer, nBlocks, nThreads, iBlock, iThread);
+  DecodeZS::decode(clusterer, smem, nBlocks, nThreads, iBlock, iThread);
 }

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCClusterFinderKernels.h
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCClusterFinderKernels.h
@@ -35,6 +35,7 @@ class GPUTPCClusterFinderKernels : public GPUKernelTemplate
       GPUTPCSharedMemoryData::noise_t noise;
       GPUTPCSharedMemoryData::count_t count;
       GPUTPCSharedMemoryData::build_t build;
+      GPUTPCSharedMemoryData::zs_t zs;
     };
   };
 

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCSharedMemoryData.h
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCSharedMemoryData.h
@@ -16,6 +16,7 @@
 
 #include "clusterFinderDefs.h"
 #include "PackedCharge.h"
+#include "DataFormatsTPC/ZeroSuppression.h"
 
 #ifndef SCRATCH_PAD_WORK_GROUP_SIZE
 #error "Work group size not defined"
@@ -50,6 +51,15 @@ class GPUTPCSharedMemoryData
     ChargePos posBcast[SCRATCH_PAD_WORK_GROUP_SIZE];
     PackedCharge buf[SCRATCH_PAD_WORK_GROUP_SIZE * SCRATCH_PAD_BUILD_N];
     uchar innerAboveThreshold[SCRATCH_PAD_WORK_GROUP_SIZE];
+  };
+
+  struct zs_t {
+    //unsigned char ZSPage[o2::tpc::TPCZSHDR::TPC_ZS_PAGE_SIZE];
+    unsigned int RowClusterOffset[o2::tpc::TPCZSHDR::TPC_MAX_ZS_ROW_IN_ENDPOINT];
+    int nRowsRegion;
+    int regionStartRow;
+    int nThreadsPerRow;
+    int rowStride;
   };
 };
 


### PR DESCRIPTION
First parallelization level over threads. Still to come in independent follow-up PRs:
- parallelize over ADC sequences.
- Prefetch 8kb page into shared memory.
- Decode into target buffer directly instead of using the streamBuffer cache