### PR TITLE
[EMCAL-622][Doxygen] Create initial EMCAL documentation structure

### DIFF
--- a/Detectors/EMCAL/README.md
+++ b/Detectors/EMCAL/README.md
@@ -1,0 +1,13 @@
+<!-- doxy
+\page refDetectorsEMCAL EMCAL
+/doxy -->
+
+# EMCAL
+
+This is a top page for the EMCAL detector documentation.
+
+<!-- doxy
+* \subpage refEMCALsimulation
+* \subpage refEMCALreconstruction
+* \subpage refEMCALworkflow
+/doxy -->

--- a/Detectors/EMCAL/base/include/EMCALBase/Geometry.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/Geometry.h
@@ -38,7 +38,6 @@ class ShishKebabTrd1Module;
 class Geometry
 {
  public:
-
   /// \brief Default constructor.
   /// It must be kept public for root persistency purposes,
   /// but should never be called by the outside world
@@ -74,7 +73,7 @@ class Geometry
   static Geometry* GetInstance();
 
   /// \brief Get instance of the EMCAL geometry
-  /// \param name Geometry name (see constructor for definition) 
+  /// \param name Geometry name (see constructor for definition)
   /// \param title Geometry title
   /// \param mcname Geant3/4, Fluka, needed for settings of transport
   /// \param mctitle: Geant4 physics list

--- a/Detectors/EMCAL/base/include/EMCALBase/Geometry.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/Geometry.h
@@ -32,77 +32,75 @@ namespace emcal
 {
 class ShishKebabTrd1Module;
 
+/// \class Geometry
+/// \brief EMCAL geometry definition
+/// \ingroup EMCALbase
 class Geometry
 {
  public:
-  ///
-  /// Default constructor.
+
+  /// \brief Default constructor.
   /// It must be kept public for root persistency purposes,
   /// but should never be called by the outside world
   Geometry() = default;
 
+  /// \brief Constructor for normal use.
+  /// \param name Name of the geometry (see table for options)
+  /// \param title Geometry title
+  /// \param mcname Geant3/4, Flukla, needed for settings of transport
+  /// \param mctitle Geant4 physics list
   ///
-  /// Constructor for normal use.
-  ///
-  /// \param name: geometry name, EMCAL_COMPLETEV1, EMCAL_COMPLETE12SMV1, EMCAL_COMPLETE12SMV1_DCAL,
-  /// EMCAL_COMPLETE12SMV1_DCAL_8SM, EMCAL_COMPLETE12SMV1_DCAL_DEV (see main class description for definition) \param
-  /// title \param mcname: Geant3/4, Flukla, needed for settings of transport (check) \param mctitle: Geant4 physics
-  /// list (check)
-  ///
+  /// Supported geometries:
+  /// | Name                                  | Description                                              |
+  /// |---------------------------------------|----------------------------------------------------------|
+  /// | EMCAL_COMPLETEV1                      | 10 Supermodules (run1 - 2011)                            |
+  /// | EMCAL_COMPLETE12SMV1                  | 12 Supermodules (run1 - 2012/2013)                       |
+  /// | EMCAL_COMPLETE12SMV1_DCAL             | Full EMCAL, 10 DCAL Supermodules (not used in practice)  |
+  /// | EMCAL_COMPLETE12SMV1_DCAL_8SM         | Full EMCAL, 8 DCAL Supermodules (run2)                   |
+  /// | EMCAL_COMPLETE12SMV1_DCAL_DEV         | Full EMCAL, DCAL development geometry (not used)         |
   Geometry(const std::string_view name, const std::string_view mcname = "", const std::string_view mctitle = "");
 
-  ///
-  /// Copy constructor.
-  ///
+  /// \brief Copy constructor.
   Geometry(const Geometry& geom);
 
-  ///
-  /// Destructor.
-  ///
+  /// \brief Destructor.
   ~Geometry();
 
-  ///
-  /// Assign operator.
-  ///
+  /// \brief Assignment operator
   Geometry& operator=(const Geometry& rvalue);
 
-  ///
+  /// \brief Get geometry instance. It should have been set before.
   /// \return the pointer of the unique instance of the geometry
-  ///
-  /// It should have been set before.
-  ///
   static Geometry* GetInstance();
 
-  ///
+  /// \brief Get instance of the EMCAL geometry
+  /// \param name Geometry name (see constructor for definition) 
+  /// \param title Geometry title
+  /// \param mcname Geant3/4, Fluka, needed for settings of transport
+  /// \param mctitle: Geant4 physics list
   /// \return the pointer of the unique instance of the geometry
   ///
-  /// \param name: geometry name, EMCAL_COMPLETEV1, EMCAL_COMPLETE12SMV1, EMCAL_COMPLETE12SMV1_DCAL,
-  /// EMCAL_COMPLETE12SMV1_DCAL_8SM, EMCAL_COMPLETE12SMV1_DCAL_DEV (see main class description for definition) \param
-  /// title \param mcname: Geant3/4, Fluka, needed for settings of transport (check) \param mctitle: Geant4 physics list
-  /// (check)
-  ///
+  /// Also initializes the geometry if
+  /// - not yet initialized
+  /// - settings are different
   static Geometry* GetInstance(const std::string_view name, const std::string_view mcname = "TGeant3",
                                const std::string_view mctitle = "");
 
-  ///
-  /// Instanciate geometry depending on the run number. Mostly used in analysis and MC anchors.
-  ///
-  /// \return the pointer of the unique instance
-  ///
-  /// \param runNumber: as indicated
-  /// \param geoName: geometry name, EMCAL_COMPLETEV1, etc. Not really needed to be specified.
+  /// \brief Instanciate geometry depending on the run number. Mostly used in analysis and MC anchors.
+  /// \param runNumber as indicated
+  /// \param geoName Geometry name, see constructor for options
   /// \param mcname: Geant3/4, Fluka, needed for settings of transport (check). Not really needed to be specified.
   /// \param mctitle:  Geant4 physics list (check). Not really needed to be specified.
-  ///
+  /// \return the pointer of the unique instance
   static Geometry* GetInstanceFromRunNumber(Int_t runNumber, const std::string_view = "",
                                             const std::string_view mcname = "TGeant3",
                                             const std::string_view mctitle = "");
 
-  /// Set the value of the Sampling used to calibrate the MC hits energy (check)
-  /// Called in Detector::ConstructGeometry and not anymore here in Init() in order to be able to work with Geant4
+  /// \brief Set the value of the Sampling used to calibrate the MC hits energy (check)
+  /// \param mcname Geant3/4, Flukla, ...
+  /// \param mctitle Geant4 physics list tag name
   ///
-  /// \param mcname: Geant3/4, Flukla, ...
-  /// \param mctitle: Geant4 physics list tag name
+  /// Called in Detector::ConstructGeometry and not anymore here in Init() in order to be able to work with Geant4
   void DefineSamplingFraction(const std::string_view mcname = "", const std::string_view mctitle = "");
 
   //////////
@@ -124,52 +122,51 @@ class Geometry
 
   const std::vector<ShishKebabTrd1Module>& GetShishKebabTrd1Modules() const { return mShishKebabTrd1Modules; }
 
-  ///
+  /// \brief Get the Module parameters for a eta
   /// \return  the shishkebabmodule at a given eta index point.
-  ///
   const ShishKebabTrd1Module& GetShishKebabModule(Int_t neta) const;
 
-  ///
-  /// Given a TParticle, check if it falls in the EMCal/DCal geometry
-  /// Call ImpactOnEmcal.
-  ///
-  /// \param particle TParticle
+  /// \brief Check if particle falls in the EMCal/DCal geometry
+  /// \param particle Particle to be checked
   /// \return true in EMCal/DCa;
   ///
+  /// Call ImpactOnEmcal.
   Bool_t Impact(const TParticle* particle) const;
 
+  /// \brief Get the impact coordinates on EMCAL
+  /// \param vtx[in] TVector3 with vertex
+  /// \param theta[in] theta location
+  /// \param phi[in] azimuthal angle
+  /// \param absId[out] absolute ID number
+  /// \param vimpact[out] TVector3 of impact coordinates?
   ///
   /// Calculates the impact coordinates on EMCAL (centre of a tower/not on EMCAL surface)
   /// of a neutral particle emitted in the vertex vtx[3] with direction theta and phi in
   /// the global coordinate system
-  ///
-  /// \param[in] vtx TVector3 with vertex
-  /// \param[in] theta theta location
-  /// \param[in] phi azimuthal angle
-  /// \param[out] absId absolute ID number
-  /// \param[out] vimpact TVector3 of impact coordinates?
-  ///
   void ImpactOnEmcal(const Point3D<double>& vtx, Double_t theta, Double_t phi, Int_t& absId, Point3D<double>& vimpact) const;
 
+  /// \brief Checks whether point is inside the EMCal volume
+  /// \param pnt Point to be checked
+  /// \return True if the point is inside EMCAL, false otherwise
   ///
-  /// Checks whether point is inside the EMCal volume
-  ///
+  /// See IsInEMCALOrDCAL for the definition of the acceptance check
   Bool_t IsInEMCAL(const Point3D<double>& pnt) const;
 
+  /// \brief Checks whether point is inside the DCal volume
+  /// \param pnt Point to be checked
+  /// \return True if the point is inside DCAL, false otherwise
   ///
-  /// Checks whether point is inside the DCal volume
-  ///
+  /// See IsInEMCALOrDCAL for the definition of the acceptance check
   Bool_t IsInDCAL(const Point3D<double>& pnt) const;
 
+  /// \brief Checks whether point is inside the EMCal volume (included DCal)
+  /// \param pnt Point to be checked
+  /// \return calo acceptance type
   ///
-  /// Checks whether point is inside the EMCal volume (included DCal), used in AliEMCALv*.cxx
   /// Code uses cylindrical approximation made of inner radius (for speed)
   ///
   /// Points behind EMCAl/DCal, i.e. R > outer radius, but eta, phi in acceptance
   /// are considered to inside
-  ///
-  /// \return calo acceptance type
-  ///
   AcceptanceType_t IsInEMCALOrDCAL(const Point3D<double>& pnt) const;
 
   //////////////////////////////////////
@@ -240,14 +237,14 @@ class Geometry
     return mEMCSMSystem[nSupMod];
   }
 
-  ///
-  /// Method to check if iSupMod is a valid DCal SM
-  ///
+  /// \brief Check if iSupMod is a valid DCal standard SM
+  /// \param nSupMod ID of the supermodule to check
+  /// \return True if the supermodule is a DCAL supermodule
   Bool_t IsDCALSM(Int_t nSupMod) const;
 
-  ///
-  /// Method to check if iSupMod is a valid DCal SM from 1/3rd
-  ///
+  /// \brief Check if iSupMod is a valid DCal 1/3rd SM
+  /// \param nSupMod ID of the supermodule to check
+  /// \return True if the supermodule is a DCAL supermodule
   Bool_t IsDCALExtSM(Int_t nSupMod) const;
 
   // Methods needed for SM in extension, where center of SM != center of the SM-section.
@@ -270,25 +267,20 @@ class Geometry
   // Global geometry methods
   //
 
+  /// \brief  Figure out the global coordinates from local coordinates on a supermodule.
+  /// \param loc[in] local coordinates (double[3])
+  /// \param glob[out] global coordinates (double[2])
+  /// \param iSM super module number
   ///
-  /// Figure out the global coordinates from local coordinates on a supermodule.
-  /// Use the supermodule alignment. Use double[3]
-  ///
-  /// \param loc: double[3] local coordinates, input
-  /// \param glob: double[3] global coordinates, output
-  /// \param iSM: super module number
-  ///
+  /// Use the supermodule alignment.
   void GetGlobal(const Double_t* loc, Double_t* glob, int ind) const;
 
-  ///
-  /// Figure out the global coordinates from local coordinates on a supermodule.
-  /// Use the supermodule alignment. Use TVector3.
-  ///
-  /// \param vloc: 3-vector local coordinates, input (remove & ?)
-  /// \param vglob: 3-vector global coordinates, output
+  /// \brief Figure out the global coordinates from local coordinates on a supermodule.
+  /// \param vloc[in] local coordinates
+  /// \param vglob[out] global coordinates
   /// \param iSM: super module number
   ///
-
+  /// Use the supermodule alignment.
   void GetGlobal(const TVector3& vloc, TVector3& vglob, int ind) const;
 
   ///
@@ -300,13 +292,11 @@ class Geometry
   ///
   void GetGlobal(Int_t absId, Double_t glob[3]) const;
 
+  /// \brief Figure out the global coordinates of a cell.
+  /// \param absId cell absolute id. number.
+  /// \param vglob TVector3 coordinates, output
   ///
-  /// Figure out the global coordinates of a cell.
   /// Use the supermodule alignment. Use TVector3.
-  ///
-  /// \param absId: cell absolute id. number.
-  /// \param vglob: TVector3 coordinates, output
-  ///
   void GetGlobal(Int_t absId, TVector3& vglob) const;
 
   ////////////////////////////////////////
@@ -332,23 +322,19 @@ class Geometry
   //
   // for a given tower index absId returns eta and phi of gravity center of tower.
 
-  ///
-  /// Figure out the eta/phi coordinates of a cell.
-  /// Call to GetGlobal().
-  ///
+  /// \brief Figure out the eta/phi coordinates of a cell.
   /// \param absId cell absolute id. number.
   /// \return tuple with (pseudorapidity, polar angle)
   ///
+  /// Call to GetGlobal().
   std::tuple<double, double> EtaPhiFromIndex(Int_t absId) const;
 
-  ///
-  /// Get cell absolute ID number from eta and phi location.
+  /// \brief Get cell absolute ID number from eta and phi location.
   ///
   /// \param eta pseudorapidity location
   /// \param phi azimutal location
   /// \return cell absolute ID number
-  /// \thow InvalidPositionException
-  ///
+  /// \throw InvalidPositionException
   int GetAbsCellIdFromEtaPhi(Double_t eta, Double_t phi) const;
 
   /// \brief get (Column,Row) pair of cell in global numbering scheme
@@ -366,53 +352,38 @@ class Geometry
   /// \return Row number in global numbering scheme
   int GlobalRow(int cellID) const;
 
-  ///
-  /// Given a global eta/phi point check if it belongs to a supermodule covered region.
-  ///
+  /// \brief Given a global eta/phi point check if it belongs to a supermodule covered region.
   /// \param eta pseudorapidity location
   /// \param phi azimutal location
   /// \return super module number
   /// \throw InvalidPositionException
-  ///
   int SuperModuleNumberFromEtaPhi(Double_t eta, Double_t phi) const;
 
-  ///
-  /// Get cell absolute ID number from location module (2 times 2 cells) of a super module
-  ///
+  /// \brief Get cell absolute ID number from location module (2 times 2 cells) of a super module
   /// \param nSupMod super module number
   /// \param nModule module number
   /// \param nIphi index of cell in module in phi direction 0 or 1
   /// \param nIeta index of cell in module in eta direction 0 or 1
   /// \return cell absolute ID number
-  ///
   Int_t GetAbsCellId(Int_t nSupMod, Int_t nModule, Int_t nIphi, Int_t nIeta) const;
 
-  ///
+  /// \brief Check whether a cell number is valid
+  /// \param absId input absolute cell ID number to check
   /// \return true if cell ID number exists
-  ///
-  /// \param absId: input absolute cell ID number to check
-  ///
   Bool_t CheckAbsCellId(Int_t absId) const;
 
-  ///
-  /// Get cell SM, module numbers from absolute ID number
-  ///
+  /// \brief Get cell SM, module numbers from absolute ID number
   /// \param absId cell absolute id. number
   /// \param nSupMod super module number
   /// \param nModule module number
-  ///
   /// \return tuple(supermodule ID, module number, index of cell in module in phi, index of cell in module in eta)
   /// \throw InvalidCellIDException
-  ///
   std::tuple<int, int, int, int> GetCellIndex(Int_t absId) const;
 
-  ///
   /// \brief Get eta-phi indexes of module in SM
-  ///
   /// \param[in] nSupMod: super module number, input
   /// \param[in] nModule: module number, input
   /// \return tuple (index in phi direction of module, index in eta direction of module)
-  ///
   std::tuple<int, int> GetModulePhiEtaIndexInSModule(Int_t nSupMod, Int_t nModule) const;
 
   /// \brief Get eta-phi indexes of cell in SM
@@ -423,9 +394,9 @@ class Geometry
   std::tuple<int, int> GetCellPhiEtaIndexInSModule(Int_t nSupMod, Int_t nModule, Int_t nIphi, Int_t nIeta) const;
 
   /// \brief Adapt cell indices in supermodule to online indexing
-  /// \param supermoduleID: super module number of the channel/cell
-  /// \param iphi: row/phi cell index, modified for DCal
-  /// \param ieta: column/eta index, modified for DCal
+  /// \param supermoduleID super module number of the channel/cell
+  /// \param iphi row/phi cell index, modified for DCal
+  /// \param ieta column/eta index, modified for DCal
   /// \return tuple with (0 - row/phi, 1 - col, eta) after shift
   ///
   /// Online mapping and numbering is the same for EMCal and DCal SMs but:
@@ -438,9 +409,9 @@ class Geometry
   std::tuple<int, int> ShiftOnlineToOfflineCellIndexes(Int_t supermoduleID, Int_t iphi, Int_t ieta) const;
 
   /// \brief Adapt cell indices in supermodule to offline indexing
-  /// \param supermoduleID: super module number of the channel/cell
-  /// \param iphi: row/phi cell index, modified for DCal
-  /// \param ieta: column/eta index, modified for DCal
+  /// \param supermoduleID super module number of the channel/cell
+  /// \param iphi row/phi cell index, modified for DCal
+  /// \param ieta column/eta index, modified for DCal
   /// \return tuple with (0 - row/phi, 1 - col, eta) after shift
   ///
   /// Here shift the DCal online cols or rows depending on the
@@ -450,12 +421,9 @@ class Geometry
   /// ShiftOnlineToOfflineCellIndexes().
   std::tuple<int, int> ShiftOfflineToOnlineCellIndexes(Int_t supermoduleID, Int_t iphi, Int_t ieta) const;
 
-  ///
   /// \brief Get cell SM,  from absolute ID number
-  ///
-  /// \param absId: cell absolute id. number
+  /// \param absId cell absolute id. number
   /// \return super module number
-  ///
   Int_t GetSuperModuleNumber(Int_t absId) const;
   Int_t GetNumberOfModuleInPhiDirection(Int_t nSupMod) const
   {
@@ -469,12 +437,10 @@ class Geometry
       return mNPhi;
   }
 
-  ///
-  /// Transition from cell indexes (iphi, ieta) to module indexes (iphim, ietam, nModule)
-  //
-  /// \param nSupMod: super module number
-  /// \param iphi: index of cell in phi direction inside super module
-  /// \param ieta: index of cell in eta direction inside super module
+  /// \brief Transition from cell indexes (iphi, ieta) to module indexes (iphim, ietam, nModule)
+  /// \param nSupMod super module number
+  /// \param iphi index of cell in phi direction inside super module
+  /// \param ieta index of cell in eta direction inside super module
   /// \return tuple:
   ///               iphim: index of cell in module in phi direction: 0 or 1
   ///               ietam: index of cell in module in eta direction: 0 or 1
@@ -482,36 +448,27 @@ class Geometry
   ///
   std::tuple<Int_t, Int_t, Int_t> GetModuleIndexesFromCellIndexesInSModule(Int_t nSupMod, Int_t iphi, Int_t ieta) const;
 
-  ///
-  /// Transition from super module number (nSupMod) and cell indexes (ieta,iphi) to cell absolute ID number.
-  ///
-  /// \param nSupMod: super module number
-  /// \param iphi: index of cell in phi direction inside super module
-  /// \param ieta: index of cell in eta direction inside super module
-  ///
+  /// \brief Transition from super module number (nSupMod) and cell indexes (ieta,iphi) to cell absolute ID number.
+  /// \param nSupMod super module number
+  /// \param iphi index of cell in phi direction inside super module
+  /// \param ieta index of cell in eta direction inside super module
   /// \return cell absolute ID number
   Int_t GetAbsCellIdFromCellIndexes(Int_t nSupMod, Int_t iphi, Int_t ieta) const;
 
-  ///
   /// \brief Look to see what the relative position inside a given cell is for a recpoint.
+  /// \param absId[in] cell absolute id. number, input
+  /// \param distEff[in] shower max position? check call in RecPoint!
+  /// \return Point3D with x,y,z coordinates of cell with absId inside SM
+  /// \throw InvalidCellIDException if cell ID does not exist
   ///
   /// Same as RelPosCellInSModule(Int_t absId, Double_t &xr, Double_t &yr, Double_t &zr)
   /// but taking into account position of shower max.
-  ///
-  /// \param[in] absId cell absolute id. number, input
-  /// \param[in] distEff shower max position? check call in RecPoint!
-  /// \return Point3D with x,y,z coordinates of cell with absId inside SM
-  /// \throw InvalidCellIDException if cell ID does not exist
-  ///
   Point3D<double> RelPosCellInSModule(Int_t absId, Double_t distEf) const;
 
-  ///
   /// \brief Look to see what the relative position inside a given cell is for a recpoint.
-  ///
   /// \param absId cell absolute id. number, input
   /// \return Point3D with x,y,z coordinates of cell with absId inside SM
   /// \throw InvalidCellIDException if cell ID does not exist
-  ///
   Point3D<double> RelPosCellInSModule(Int_t absId) const;
 
   std::vector<EMCALSMType> GetEMCSystem() const { return mEMCSMSystem; } // EMC System, SM type list
@@ -570,36 +527,30 @@ class Geometry
                                 const Float_t misaligTransShifts[15], const Float_t misaligRotShifts[15],
                                 Float_t global[3]) const;
 
-  ///
   /// \brief Provides shift-rotation matrix for EMCAL from externally set matrix or
   /// from TGeoManager
+  /// \param smod super module number
   /// \return alignment matrix for a super module number
-  /// \param smod: super module number
-  ///
   const TGeoHMatrix* GetMatrixForSuperModule(Int_t smod) const;
 
-  ///
   /// \brief Provides shift-rotation matrix for EMCAL from the TGeoManager.
+  /// \param smod super module number
   /// \return alignment matrix for a super module number
-  /// \param smod: super module number
-  ///
   const TGeoHMatrix* GetMatrixForSuperModuleFromGeoManager(Int_t smod) const;
 
+  /// \brief Provides shift-rotation matrix for EMCAL from fkSModuleMatrix[smod]
+  /// \param smod super module number
+  /// \return alignment matrix for a super module number
   ///
-  /// Provides shift-rotation matrix for EMCAL from fkSModuleMatrix[smod]
   /// Unsafe method, not to be used in reconstruction, just check there is
   /// something in the array of matrices without crashing, for EVE checks.
-  ///
-  /// \return alignment matrix for a super module number
-  /// \param smod: super module number
-  ///
   const TGeoHMatrix* GetMatrixForSuperModuleFromArray(Int_t smod) const;
 
  protected:
   /// \brief initializes the parameters of EMCAL
   void Init();
 
-  /// Init function of previous class EMCGeometry
+  /// \brief Init function of previous class EMCGeometry
   void DefineEMC(std::string_view mcname, std::string_view mctitle);
 
   std::string mGeoName;                     ///< Geometry name string

--- a/Detectors/EMCAL/base/include/EMCALBase/GeometryBase.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/GeometryBase.h
@@ -34,6 +34,7 @@ const std::string DEFAULT_GEOMETRY = "EMCAL_COMPLETE12SMV1_DCAL_8SM";
 
 /// \class InvalidModuleException
 /// \brief Error Handling when an invalid module ID (outside the limits) is called
+/// \ingroup EMCALbase
 class InvalidModuleException : public std::exception
 {
  public:
@@ -70,6 +71,7 @@ class InvalidModuleException : public std::exception
 
 /// \class InvalidPositionException
 /// \brief Exception handling errors due to positions not in the EMCAL area
+/// \ingroup EMCALbase
 class InvalidPositionException : public std::exception
 {
  public:
@@ -106,6 +108,7 @@ class InvalidPositionException : public std::exception
 
 /// \class InvalidCellIDException
 /// \brief Exception handling non-existing cell IDs
+/// \ingroup EMCALbase
 class InvalidCellIDException : public std::exception
 {
  public:
@@ -135,6 +138,7 @@ class InvalidCellIDException : public std::exception
 
 /// \class InvalidSupermoduleTypeException
 /// \brief Exception handling improper or uninitialized supermodule types
+/// \ingroup EMCALbase
 class InvalidSupermoduleTypeException : public std::exception
 {
  public:
@@ -150,6 +154,7 @@ class InvalidSupermoduleTypeException : public std::exception
 
 /// \class SupermoduleIndexException
 /// \brief Handling error due to invalid supermodule
+/// \ingroup EMCALbase
 class SupermoduleIndexException : public std::exception
 {
  public:

--- a/Detectors/EMCAL/base/include/EMCALBase/Hit.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/Hit.h
@@ -20,6 +20,7 @@ namespace emcal
 {
 /// \class Hit
 /// \brief EMCAL simulation hit information
+/// \ingroup EMCALbase
 class Hit : public o2::BasicXYZEHit<float>
 {
  public:

--- a/Detectors/EMCAL/base/include/EMCALBase/Mapper.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/Mapper.h
@@ -32,6 +32,7 @@ namespace emcal
 
 /// \class Mapper
 /// \brief ALTRO mapping for calorimeters
+/// \ingroup EMCALbase
 /// \author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
 /// \since Aug 19, 2019
 ///

--- a/Detectors/EMCAL/base/include/EMCALBase/ShishKebabTrd1Module.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/ShishKebabTrd1Module.h
@@ -25,10 +25,9 @@ namespace o2
 namespace emcal
 {
 
-//_________________________________________________________________________
 /// \class ShishKebabTrd1Module
-/// \ingroup EMCALUtils
 /// \brief Main class for TRD1 geometry of Shish-Kebab case.
+/// \ingroup EMCALbase
 ///
 /// Sep 20004 - Nov 2006; Apr 2010
 /// See web page with description of Shish-Kebab geometries:
@@ -40,29 +39,19 @@ namespace emcal
 class ShishKebabTrd1Module
 {
  public:
-  ///
-  /// Constructor.
-  ///
+  /// \brief Constructor.
   ShishKebabTrd1Module(Double_t theta = 0.0, Geometry* g = nullptr);
 
-  ///
-  /// Constructor.
-  ///
+  /// \brief Constructor.
   ShishKebabTrd1Module(ShishKebabTrd1Module& leftNeighbor);
 
-  ///
-  /// Init (add explanation)
-  ///
+  /// \brief Init (add explanation)
   void Init(Double_t A, Double_t B);
 
-  ///
-  /// Define more things (add explanation)
-  ///
+  /// \brief Define more things (add explanation)
   void DefineAllStuff();
 
-  ///
-  /// Copy Constructor.
-  ///
+  /// \brief Copy Constructor.
   ShishKebabTrd1Module(const ShishKebabTrd1Module& mod);
 
   ShishKebabTrd1Module& operator=(const ShishKebabTrd1Module& /*rvalue*/)
@@ -73,9 +62,7 @@ class ShishKebabTrd1Module
 
   ~ShishKebabTrd1Module() = default;
 
-  ///
-  /// Recover module parameters stored in geometry
-  ///
+  /// \brief Recover module parameters stored in geometry
   Bool_t SetParameters();
 
   ///

--- a/Detectors/EMCAL/calib/include/EMCALCalib/BadChannelMap.h
+++ b/Detectors/EMCAL/calib/include/EMCALCalib/BadChannelMap.h
@@ -21,6 +21,7 @@ namespace emcal
 
 /// \class BadChannelMap
 /// \brief CCDB container for masked cells in EMCAL
+/// \ingroup EMCALcalib
 /// \author Markus Fasel <>, Oak Ridge National Laboratory
 /// \since June 25th, 2019
 ///

--- a/Detectors/EMCAL/calib/include/EMCALCalib/CalibDB.h
+++ b/Detectors/EMCAL/calib/include/EMCALCalib/CalibDB.h
@@ -30,6 +30,7 @@ class TriggerDCS;
 
 /// \class CalibDB
 /// \brief Interface to calibration data from CCDB for EMCAL
+/// \ingroup EMCALcalib
 /// \author Markus Fasel <> Oak Ridge National Laboratory
 /// \since July 12, 2019
 ///

--- a/Detectors/EMCAL/calib/include/EMCALCalib/GainCalibrationFactors.h
+++ b/Detectors/EMCAL/calib/include/EMCALCalib/GainCalibrationFactors.h
@@ -10,6 +10,7 @@
 
 /// \class GainCalibrationFactors
 /// \brief CCDB container for the gain calibration factors
+/// \ingroup EMCALcalib
 /// \author Hadi Hassan <hadi.hassan@cern.ch>, Oak Ridge National Laboratory
 /// \since August 5th, 2019
 ///

--- a/Detectors/EMCAL/calib/include/EMCALCalib/TempCalibParamSM.h
+++ b/Detectors/EMCAL/calib/include/EMCALCalib/TempCalibParamSM.h
@@ -10,6 +10,7 @@
 
 /// \class TempCalibParamSM
 /// \brief CCDB container for the temperature calibration coefficients per SM
+/// \ingroup EMCALcalib
 /// \author Hadi Hassan <hadi.hassan@cern.ch>, Oak Ridge National Laboratory
 /// \since August 13th, 2019
 ///

--- a/Detectors/EMCAL/calib/include/EMCALCalib/TempCalibrationParams.h
+++ b/Detectors/EMCAL/calib/include/EMCALCalib/TempCalibrationParams.h
@@ -10,6 +10,7 @@
 
 /// \class TempCalibrationParams
 /// \brief CCDB container for the temperature calibration coefficients
+/// \ingroup EMCALcalib
 /// \author Hadi Hassan <hadi.hassan@cern.ch>, Oak Ridge National Laboratory
 /// \since July 16th, 2019
 ///

--- a/Detectors/EMCAL/calib/include/EMCALCalib/TimeCalibParamL1Phase.h
+++ b/Detectors/EMCAL/calib/include/EMCALCalib/TimeCalibParamL1Phase.h
@@ -10,6 +10,7 @@
 
 /// \class TimeCalibParamL1Phase
 /// \brief CCDB container for the L1 phase shifts
+/// \ingroup EMCALcalib
 /// \author Hadi Hassan <hadi.hassan@cern.ch>, Oak Ridge National Laboratory
 /// \since Aug 12th, 2019
 ///

--- a/Detectors/EMCAL/calib/include/EMCALCalib/TimeCalibrationParams.h
+++ b/Detectors/EMCAL/calib/include/EMCALCalib/TimeCalibrationParams.h
@@ -10,6 +10,7 @@
 
 /// \class TimeCalibrationParams
 /// \brief CCDB container for the time calibration coefficients
+/// \ingroup EMCALcalib
 /// \author Hadi Hassan <hadi.hassan@cern.ch>, Oak Ridge National Laboratory
 /// \since July 16th, 2019
 ///

--- a/Detectors/EMCAL/calib/include/EMCALCalib/TriggerDCS.h
+++ b/Detectors/EMCAL/calib/include/EMCALCalib/TriggerDCS.h
@@ -22,9 +22,11 @@ namespace emcal
 
 /// \class TriggerDCS
 /// \brief CCDB container for the DCS data in EMCAL
-/// based on AliEMCALTriggerDCSConfig class authored by R. GUERNANE
+/// \ingroup EMCALcalib
 /// \author Hadi Hassan <hadi.hassan@cern.ch>, Oak Ridge National Laboratory
 /// \since December 4th, 2019
+///
+/// based on AliEMCALTriggerDCSConfig class authored by R. GUERNANE
 
 class TriggerDCS
 {

--- a/Detectors/EMCAL/calib/include/EMCALCalib/TriggerSTUDCS.h
+++ b/Detectors/EMCAL/calib/include/EMCALCalib/TriggerSTUDCS.h
@@ -22,9 +22,11 @@ namespace emcal
 
 /// \class TriggerSTUDCS
 /// \brief CCDB container for STU DCS data in EMCAL
-/// based on AliEMCALTriggerSTUDCSConfig class authored by R. GUERNANE
+/// \ingroup EMCALcalib
 /// \author Hadi Hassan <hadi.hassan@cern.ch>, Oak Ridge National Laboratory
 /// \since December 4th, 2019
+///
+/// based on AliEMCALTriggerSTUDCSConfig class authored by R. GUERNANE
 
 class TriggerSTUDCS
 {

--- a/Detectors/EMCAL/calib/include/EMCALCalib/TriggerSTUErrorCounter.h
+++ b/Detectors/EMCAL/calib/include/EMCALCalib/TriggerSTUErrorCounter.h
@@ -19,9 +19,11 @@ namespace emcal
 
 /// \class TriggerSTUErrorCounter
 /// \brief CCDB container for STU error counts
-/// based on AliEMCALTriggerSTUConfig class authored by R. GUERNANE
+/// \ingroup EMCALcalib
 /// \author Hadi Hassan <hadi.hassan@cern.ch>, Oak Ridge National Laboratory
 /// \since December 4th, 2019
+///
+/// based on AliEMCALTriggerSTUConfig class authored by R. GUERNANE
 
 class TriggerSTUErrorCounter
 {

--- a/Detectors/EMCAL/calib/include/EMCALCalib/TriggerTRUDCS.h
+++ b/Detectors/EMCAL/calib/include/EMCALCalib/TriggerTRUDCS.h
@@ -22,9 +22,11 @@ namespace emcal
 
 /// \class TriggerTRUDCS
 /// \brief CCDB container for TRU DCS data in EMCAL
-/// based on AliEMCALTriggerTRUDCSConfig class authored by R. GUERNANE
+/// \ingroup EMCALcalib
 /// \author Hadi Hassan <hadi.hassan@cern.ch>, Oak Ridge National Laboratory
 /// \since December 4th, 2019
+///
+/// based on AliEMCALTriggerTRUDCSConfig class authored by R. GUERNANE
 
 class TriggerTRUDCS
 {

--- a/Detectors/EMCAL/doxymodules.h
+++ b/Detectors/EMCAL/doxymodules.h
@@ -1,0 +1,56 @@
+/**
+ * @defgroup DetectorEMCAL
+ * @brief EMCAL simulation and reconstruction 
+ * 
+ * See \ref refDetectorsEMCAL for more information
+ */
+
+/**
+ * @defgroup EMCALbase
+ * @brief Main EMCAL components
+ * @ingroup DetectorEMCAL
+ * 
+ * Main EMCAL components used in various libraries
+ * - Geometry
+ * - Mapping
+ * - Basic data types not part of the EMCAL format
+ */
+
+/**
+ * @defgroup EMCALcalibration
+ * @brief EMCAL calibration objects
+ * @ingroup DetectorEMCAL
+ * 
+ * EMCAL calibration objects for
+ * - Bad channel map
+ * - Time calibration
+ * - Gain calibration
+ * - Temperature calibration
+ */
+
+/**
+ * @defgroup EMCALsimulation
+ * @brief EMCAL simulation code
+ * @ingroup DetectorEMCAL
+ * 
+ * EMCAL simulation package. See \subpage refEMCALsimulation
+ * for more information
+ */
+
+/**
+ * @defgroup EMCALreconstruction
+ * @brief EMCAL reconstruction code
+ * @ingroup DetectorEMCAL
+ * 
+ * EMCAL reconstruction package. See \subpage refEMCALreconstruction
+ * for more information
+ */
+ 
+ /**
+  * @defgroup EMCALworkflow
+  * @brief EMCAL reconstruction workflow
+  * @ingroup DetectorEMCAL
+  * 
+  * EMCAL reconstruction workflow package. See \subpage refEMCALworkflow
+  * for more information.
+  */

--- a/Detectors/EMCAL/doxymodules.h
+++ b/Detectors/EMCAL/doxymodules.h
@@ -45,8 +45,8 @@
  * EMCAL reconstruction package. See \subpage refEMCALreconstruction
  * for more information
  */
- 
- /**
+
+/**
   * @defgroup EMCALworkflow
   * @brief EMCAL reconstruction workflow
   * @ingroup DetectorEMCAL

--- a/Detectors/EMCAL/reconstruction/README.md
+++ b/Detectors/EMCAL/reconstruction/README.md
@@ -1,0 +1,9 @@
+<!-- doxy
+\page refEMCALreconstruction EMCAL reconstruction module
+/doxy -->
+
+# EMCAL reconstruction
+
+## Raw decoding and raw fitting
+
+## Clusterization

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/AltroDecoder.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/AltroDecoder.h
@@ -31,6 +31,7 @@ namespace emcal
 
 /// \class AltroDecoderError
 /// \brief Error handling of the ALTRO Decoder
+/// \ingroup EMCALreconstruction
 class AltroDecoderError : public std::exception
 {
  public:
@@ -71,6 +72,7 @@ class AltroDecoderError : public std::exception
 
 /// \class AltroDecoder
 /// \brief Decoder of the ALTRO data in the raw page
+/// \ingroup EMCALreconstruction
 /// \author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
 /// \since Aug. 12, 2019
 ///

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/Bunch.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/Bunch.h
@@ -22,6 +22,7 @@ namespace emcal
 {
 /// \class Bunch
 /// \brief ALTRO bunch information
+/// \ingroup EMCALreconstruction
 ///
 /// The bunch contains the ADC values of a given
 /// data bunch for a channel in the ALTRO stream.

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CaloFitResults.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CaloFitResults.h
@@ -8,21 +8,6 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \class CaloFitResults
-/// \brief  Container class to hold results from fitting
-///
-/// Container class to hold results from fitting
-/// as well as other methods for
-/// raw data signals extraction. The class memebers
-/// mChi2Sig, mNdfSig is only relevant if a fitting procedure is
-/// Applied. mStatus holds information on wether or not
-/// The signal was fitted sucessfully. mStatus might have a different meaning If other
-/// procedures than A different meaning Fitting is applied
-///
-/// \author Hadi Hassan <hadi.hassan@cern.ch>, Oak Ridge National Laboratory
-/// \since November 4th, 2019
-///
-
 #ifndef CALOFITRESULTS_H_
 #define CALOFITRESULTS_H_
 
@@ -36,6 +21,19 @@ namespace o2
 namespace emcal
 {
 
+/// \class CaloFitResults
+/// \brief  Container class to hold results from fitting
+/// \ingroup EMCALreconstruction
+/// \author Hadi Hassan <hadi.hassan@cern.ch>, Oak Ridge National Laboratory
+/// \since November 4th, 2019
+///
+/// Container class to hold results from fitting
+/// as well as other methods for
+/// raw data signals extraction. The class memebers
+/// mChi2Sig, mNdfSig is only relevant if a fitting procedure is
+/// Applied. mStatus holds information on wether or not
+/// The signal was fitted sucessfully. mStatus might have a different meaning If other
+/// procedures than A different meaning Fitting is applied
 class CaloFitResults
 {
 

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CaloRawFitter.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CaloRawFitter.h
@@ -7,20 +7,6 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-
-/// \class EMCalRawFitter
-///
-/// \brief  Base class for extraction of signal amplitude and peak position
-/// Base class for extraction
-/// of signal amplitude and peak position
-/// from CALO Calorimeter RAW data.
-/// It contains some utilities for preparing / selecting
-/// signals suitable for signal extraction
-///
-/// \author Hadi Hassan <hadi.hassan@cern.ch>, Oak Ridge National Laboratory
-/// \since November 4th, 2019
-///
-
 #ifndef EMCALRAWFITTER_H_
 #define EMCALRAWFITTER_H_
 
@@ -39,6 +25,16 @@ namespace o2
 namespace emcal
 {
 
+/// \class EMCalRawFitter
+/// \brief  Base class for extraction of signal amplitude and peak position
+/// \author Hadi Hassan <hadi.hassan@cern.ch>, Oak Ridge National Laboratory
+/// \since November 4th, 2019
+///
+/// Base class for extraction
+/// of signal amplitude and peak position
+/// from CALO Calorimeter RAW data.
+/// It contains some utilities for preparing / selecting
+/// signals suitable for signal extraction
 class CaloRawFitter
 {
 

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CaloRawFitterStandard.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CaloRawFitterStandard.h
@@ -8,19 +8,6 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \class CaloRawFitterStandard
-/// \brief  Raw data fitting: standard TMinuit fit
-///
-/// Extraction of amplitude and peak position
-/// from CALO raw data using
-/// least square fit for the
-/// Moment assuming identical and
-/// independent errors (equivalent with chi square)
-///
-/// \author Hadi Hassan <hadi.hassan@cern.ch>, Oak Ridge National Laboratory
-/// \since November 4th, 2019
-///
-
 #ifndef EMCALRAWFITTERSTANDARD_H_
 #define EMCALRAWFITTERSTANDARD_H_
 
@@ -41,6 +28,17 @@ namespace o2
 namespace emcal
 {
 
+/// \class CaloRawFitterStandard
+/// \brief  Raw data fitting: standard TMinuit fit
+/// \ingroup EMCALreconstruction
+/// \author Hadi Hassan <hadi.hassan@cern.ch>, Oak Ridge National Laboratory
+/// \since November 4th, 2019
+///
+/// Extraction of amplitude and peak position
+/// from CALO raw data using
+/// least square fit for the
+/// Moment assuming identical and
+/// independent errors (equivalent with chi square)
 class CaloRawFitterStandard : public CaloRawFitter
 {
 

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/Channel.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/Channel.h
@@ -24,6 +24,7 @@ namespace emcal
 
 /// \class Channel
 /// \brief ALTRO channel representation
+/// \ingroup EMCALreconstruction
 ///
 /// The channel contains information about
 /// a hardware channel in the raw stream. Those

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/Clusterizer.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/Clusterizer.h
@@ -31,15 +31,13 @@ constexpr unsigned int NCOLS = 48 * 2 + 1;         // 2x  supermodule columns + 
 
 using ClusterIndex = Short_t;
 
-//_________________________________________________________________________
 /// \class Clusterizer
 /// \brief Meta class for recursive clusterizer
+/// \ingroup EMCALreconstruction
+/// \author Rudiger Haake (Yale)
 ///
 ///  Implementation of same algorithm version as in AliEMCALClusterizerv2,
 ///  but optimized.
-///
-/// \author Rudiger Haake (Yale)
-//_________________________________________________________________________
 class Clusterizer
 {
   struct cellWithE {

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/ClusterizerParameters.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/ClusterizerParameters.h
@@ -21,13 +21,10 @@ namespace o2
 namespace emcal
 {
 
-//_________________________________________________________________________
 /// \class ClusterizerParameters
 /// \brief Contains all parameters to set up the clusterizer
-///
-///
+/// \ingroup EMCALreconstruction
 /// \author Rudiger Haake (Yale)
-//_________________________________________________________________________
 class ClusterizerParameters
 {
  public:

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/ClusterizerTask.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/ClusterizerTask.h
@@ -27,6 +27,10 @@ namespace o2
 namespace emcal
 {
 
+/// \class ClusterizerTask
+/// \brief Stand-alone task running EMCAL clusterization
+/// \ingroup EMCALreconstruction
+/// \author Rudiger Haake (Yale)
 class ClusterizerTask
 {
 

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/DigitReader.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/DigitReader.h
@@ -23,7 +23,8 @@ namespace emcal
 {
 /// \class DigitReader
 /// \brief DigitReader class for EMCAL. Loads digits and feeds them to clusterizer
-///
+/// \ingroup EMCALreconstruction
+/// \author Rudiger Haake (Yale)
 class DigitReader
 {
  public:

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RCUTrailer.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RCUTrailer.h
@@ -24,6 +24,7 @@ namespace emcal
 
 /// \class RCUTrailer
 /// \brief Information stored in the RCU trailer
+/// \ingroup EMCALreconstruction
 ///
 /// The RCU trailer can be found at the end of
 /// the payload and contains general information

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RawBuffer.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RawBuffer.h
@@ -21,7 +21,8 @@ namespace emcal
 {
 
 /// \class RawBuffer
-/// \brief Buffer for
+/// \brief Buffer for EMCAL raw pages
+/// \ingroup EMCALreconstruction
 /// \author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
 /// \since Aug. 9, 2019
 class RawBuffer

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RawDecodingError.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RawDecodingError.h
@@ -20,6 +20,7 @@ namespace emcal
 
 /// \class RawDecodingError
 /// \brief Error handling of the raw reader
+/// \ingroup EMCALreconstruction
 ///
 /// The following error types are defined:
 /// - Page not found

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RawPayload.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RawPayload.h
@@ -24,6 +24,7 @@ namespace emcal
 
 /// \class RawPayload
 /// \brief Class for raw payload excluding raw data headers from one or multiple DMA pages
+/// \ingroup EMCALreconstruction
 /// \author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
 /// \since Nov 14, 2019
 ///

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RawReaderFile.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RawReaderFile.h
@@ -32,6 +32,7 @@ namespace emcal
 
 /// \class RawReaderFile
 /// \brief Reader for raw data produced by the ReadoutCard from a binary file
+/// \ingroup EMCALreconstruction
 /// \author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
 /// \since Aug. 12, 2019
 ///

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RawReaderMemory.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RawReaderMemory.h
@@ -26,10 +26,11 @@ namespace emcal
 
 /// \class RawReaderMemory
 /// \brief Reader for raw data produced by the Readout application in in-memory format
+/// \ingroup EMCALreconstruction
 /// \author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
 /// \since Nov. 14, 2019
 ///
-//
+///
 template <class RawHeader>
 class RawReaderMemory
 {

--- a/Detectors/EMCAL/simulation/README.md
+++ b/Detectors/EMCAL/simulation/README.md
@@ -1,0 +1,11 @@
+<!-- doxy
+\page refEMCALsimulation EMCAL simulation module
+/doxy -->
+
+# EMCAL simulation
+
+## Detector simulation
+
+## Digitization
+
+## Trigger simulation

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/DMAOutputStream.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/DMAOutputStream.h
@@ -29,6 +29,7 @@ namespace emcal
 
 /// \class DMAOutputStream
 /// \brief Output stream of a payload to DMA raw files
+/// \ingroup EMCALsimulation
 /// \author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
 /// \since Nov 6, 2019
 ///

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/Detector.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/Detector.h
@@ -33,6 +33,7 @@ class Geometry;
 
 /// \struct Parent
 /// \brief Information about superparent (particle entering EMCAL)
+/// \ingroup EMCALsimulation
 struct Parent {
   int mPDG;                ///< PDG code
   double mEnergy;          ///< Total energy
@@ -41,6 +42,7 @@ struct Parent {
 
 /// \class Detector
 /// \brief Detector simulation class for the EMCAL detector
+/// \ingroup EMCALsimulation
 ///
 /// The detector class handles the implementation of the EMCAL detector
 /// within the virtual Monte-Carlo framework and the simulation of the
@@ -75,14 +77,14 @@ class Detector : public o2::base::DetImpl<Detector>
   Bool_t ProcessHits(FairVolume* v = nullptr) final;
 
   /// \brief Add EMCAL hit
-  /// \param[in] trackID Index of the track in the MC stack
-  /// \param[in] primary Index of the primary particle in the MC stack
-  /// \param[in] initialEnergy Energy of the particle entering the EMCAL
-  /// \param[in] detID Index of the detector (cell) for which the hit is created
-  /// \param[in] pos Position vector of the particle at the hit
-  /// \param[in] mom Momentum vector of the particle at the hit
-  /// \param[in] time Time of the hit
-  /// \param[in] energyloss Energy deposit in EMCAL
+  /// \param trackID[in] Index of the track in the MC stack
+  /// \param primary[in] Index of the primary particle in the MC stack
+  /// \param initialEnergy[in] Energy of the particle entering the EMCAL
+  /// \param detID[in] Index of the detector (cell) for which the hit is created
+  /// \param pos[in] Position vector of the particle at the hit
+  /// \param mom[in] Momentum vector of the particle at the hit
+  /// \param time[in] Time of the hit
+  /// \param energyloss[in] Energy deposit in EMCAL
   /// \return Pointer to the current hit
   ///
   /// Internally adding hits coming from the same track

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/Digitizer.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/Digitizer.h
@@ -33,6 +33,11 @@ namespace o2
 {
 namespace emcal
 {
+
+/// \class Digitizer
+/// \brief EMCAL FEE digitizer
+/// \ingroup EMCALsimulation
+/// \author Anders Knospe, University of Houston
 class Digitizer : public TObject
 {
  public:

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/DigitizerTask.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/DigitizerTask.h
@@ -22,6 +22,11 @@ namespace o2
 {
 namespace emcal
 {
+
+/// \class DigitizerTask
+/// \brief FairTask running EMCAL digitization
+/// \ingroup EMCALsimulation
+/// \author Anders Knospe, University of Houston
 class DigitizerTask : public FairTask
 {
  public:

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/LabeledDigit.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/LabeledDigit.h
@@ -28,6 +28,7 @@ namespace emcal
 {
 /// \class LabeledDigit
 /// \brief EMCAL labeled digit implementation
+/// \ingroup EMCALsimulation
 
 class LabeledDigit
 {

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/SimParam.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/SimParam.h
@@ -21,6 +21,7 @@ namespace emcal
 {
 /// \class SimParam
 /// \brief EMCal simulation parameters
+/// \ingroup EMCALsimulation
 
 class SimParam : public o2::conf::ConfigurableParamHelper<SimParam>
 {

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/SpaceFrame.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/SpaceFrame.h
@@ -17,30 +17,22 @@ namespace o2
 {
 namespace emcal
 {
-////////////////////////////////////////////////////////////////////////////
-///
 /// \class  SpaceFrame
 /// \brief Space Frame implementation
-///
-/// EMCAL Space Frame implementation (converted from AliRoot)
-///
+/// \ingroup EMCALsimulation
 /// \author Ryan M. Ward, <rmward@calpoly.edu>, Cal Poly
 ///
-////////////////////////////////////////////////////////////////////////////
+/// EMCAL Space Frame implementation (converted from AliRoot)
 class SpaceFrame
 {
  public:
-  ///
-  /// Default constructor. Initialize parameters
+  /// \brief Default constructor. Initialize parameters
   SpaceFrame() = default;
 
-  ///
-  /// Destructor
+  /// \brief Destructor
   virtual ~SpaceFrame() = default;
 
-  ///
-  /// This method assembles the Geometries and places them into the
-  /// Alice master volume
+  /// \brief Assembles the Geometries and places them into the Alice master volume
   void CreateGeometry();
 };
 } // namespace emcal

--- a/Detectors/EMCAL/workflow/README.md
+++ b/Detectors/EMCAL/workflow/README.md
@@ -1,0 +1,5 @@
+<!-- doxy
+\page refEMCALworkflow EMCAL reconstruction workflow
+/doxy -->
+
+# The EMCAL reconstruction workflow

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/CellConverterSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/CellConverterSpec.h
@@ -25,6 +25,7 @@ namespace reco_workflow
 
 /// \class CellConverterSpec
 /// \brief Coverter task for EMCAL digits to EMCAL cells
+/// \ingroup EMCALworkflow
 /// \author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
 /// \since Sept 24, 2019
 ///
@@ -69,6 +70,7 @@ class CellConverterSpec : public framework::Task
 };
 
 /// \brief Creating DataProcessorSpec for the EMCAL Cell Converter Spec
+/// \ingroup EMCALworkflow
 /// \param propagateMC If true the MC truth container is propagated to the output
 ///
 /// Refer to CellConverterSpec::run for input and output specs

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/ClusterizerSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/ClusterizerSpec.h
@@ -27,6 +27,7 @@ namespace reco_workflow
 
 /// \class ClusterizerSpec
 /// \brief Clusterizer task for EMCAL digits
+/// \ingroup EMCALworkflow
 /// \author Ruediger Haake  <ruediger.haake@cern.ch>, Yale University
 /// \since Oct 23, 2019
 ///
@@ -66,6 +67,7 @@ class ClusterizerSpec : public framework::Task
 };
 
 /// \brief Creating DataProcessorSpec for the EMCAL Clusterizer Spec
+/// \ingroup EMCALworkflow
 ///
 /// Refer to ClusterizerSpec::run for input and output specs
 framework::DataProcessorSpec getClusterizerSpec();

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/DigitsPrinterSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/DigitsPrinterSpec.h
@@ -22,6 +22,7 @@ namespace reco_workflow
 
 /// \class DigitsPrinterSpec
 /// \brief Example task for EMCAL digits monitoring
+/// \ingroup EMCALworkflow
 /// \author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
 /// \since July 11, 2019
 ///
@@ -51,6 +52,7 @@ class DigitsPrinterSpec : public framework::Task
 };
 
 /// \brief Creating digits printer spec
+/// \ingroup EMCALworkflow
 ///
 /// Refer to DigitsPrinterSpec::run for a list of input
 /// specs

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/RecoWorkflow.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/RecoWorkflow.h
@@ -37,15 +37,15 @@ enum struct InputType { Digitizer, ///< directly read digits from channel {TPC:D
 /// \enum OutputType
 /// \brief Output types of the workflow
 /// \ingroup EMCALworkflow
-enum struct OutputType { Digits,        ///< EMCAL digits
-                         Cells,         ///< EMCAL cells
-                         Raw,           ///< EMCAL raw data
-                         Clusters       ///< EMCAL clusters
+enum struct OutputType { Digits,  ///< EMCAL digits
+                         Cells,   ///< EMCAL cells
+                         Raw,     ///< EMCAL raw data
+                         Clusters ///< EMCAL clusters
 };
 
 /// \brief create the workflow for EMCAL reconstruction
 /// \param propagateMC If true MC labels are propagated to the output files
-/// \param enableDigitsPrinter If true 
+/// \param enableDigitsPrinter If true
 /// \param cfgInput Input objects processed in the workflow
 /// \param cfgOutput Output objects created in the workflow
 /// \return EMCAL reconstruction workflow for the configuration provided

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/RecoWorkflow.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/RecoWorkflow.h
@@ -24,20 +24,32 @@ namespace emcal
 namespace reco_workflow
 {
 
-/// define input and output types of the workflow
-enum struct InputType { Digitizer, // directly read digits from channel {TPC:DIGITS)
-                        Digits,    // read digits from file
-                        Cells,     // read compressed cells from file
-                        Raw,       // read data in raw page format from file
-                        Clusters   // read native clusters from file
-};
-enum struct OutputType { Digits,
-                         Cells,
-                         Raw,
-                         Clusters
+/// \enum InputType
+/// \brief Input types of the workflow
+/// \ingroup EMCALworkflow
+enum struct InputType { Digitizer, ///< directly read digits from channel {TPC:DIGITS)
+                        Digits,    ///< read digits from file
+                        Cells,     ///< read compressed cells from file
+                        Raw,       ///< read data in raw page format from file
+                        Clusters   ///< read native clusters from file
 };
 
-/// create the workflow for EMCAL reconstruction
+/// \enum OutputType
+/// \brief Output types of the workflow
+/// \ingroup EMCALworkflow
+enum struct OutputType { Digits,        ///< EMCAL digits
+                         Cells,         ///< EMCAL cells
+                         Raw,           ///< EMCAL raw data
+                         Clusters       ///< EMCAL clusters
+};
+
+/// \brief create the workflow for EMCAL reconstruction
+/// \param propagateMC If true MC labels are propagated to the output files
+/// \param enableDigitsPrinter If true 
+/// \param cfgInput Input objects processed in the workflow
+/// \param cfgOutput Output objects created in the workflow
+/// \return EMCAL reconstruction workflow for the configuration provided
+/// \ingroup EMCALwokflow
 framework::WorkflowSpec getWorkflow(bool propagateMC = true,
                                     bool enableDigitsPrinter = false,
                                     std::string const& cfgInput = "digits",   //


### PR DESCRIPTION
- Provide inital README.md files for documentation page structure
- doxymodules.h: Declaration of EMCAL groups
  + EMCALbase
  + EMCALcalib
  + EMCALsimulation
  + EMCALreconstruction
  + EMCALworkflow
- Put existing classes into new groups
- Align doxygen class header (consiting of at least class,brief,
  ingroup) where needed
- Fix member documentation where needed

Documentation is missing in several classes in the EMCAL code.
This documentation has to be provided by the users at a later
stage.