### PR TITLE
Changes needed for the analysis of ITS commissioning data

### DIFF
--- a/Detectors/ITSMFT/ITS/macros/EVE/.o2eve_config
+++ b/Detectors/ITSMFT/ITS/macros/EVE/.o2eve_config
@@ -14,11 +14,12 @@ background.color:                       1
 camera.3D.rotation.horizontal:          -0.4
 camera.3D.rotation.vertical:            1.0
 camera.3D.zoom:                         1.0
-camera.R-Phi.zoom:                      1.0
-camera.Rho-Z.zoom:                      1.0
+camera.R-Phi.zoom:                      4.0
+camera.Rho-Z.zoom:                      4.0
 
-#simple.geom.path:                       /data1/belikov/alice/ali-master/O2/Detectors/ITSMFT/ITS/macros/EVE
-simple.geom.path:                       ~/
+simple.geom.default:                      R3 
+simple.geom.R3.path:                       ./
+simple.geom.R2.path:                       ./
 
 tracks.width:                           2
 

--- a/Detectors/ITSMFT/ITS/macros/EVE/DisplayEvents.C
+++ b/Detectors/ITSMFT/ITS/macros/EVE/DisplayEvents.C
@@ -6,6 +6,7 @@
 #include <array>
 #include <algorithm>
 #include <fstream>
+#include <vector>
 
 #include <TFile.h>
 #include <TTree.h>
@@ -22,6 +23,9 @@
 #include <TEvePointSet.h>
 #include <TEveTrackPropagator.h>
 #include <TEveTrack.h>
+#include <TEveEventManager.h>
+#include <TEveProjectionManager.h>
+#include <TEveScene.h>
 
 #include "EventVisualisationView/MultiView.h"
 
@@ -39,6 +43,7 @@
 using namespace o2::itsmft;
 
 extern TEveManager* gEve;
+static TEveScene* chipScene;
 
 static TGNumberEntry* gEntry;
 static TGNumberEntry* gChipID;
@@ -55,7 +60,8 @@ class Data
     reader->openInput(input);
     mPixelReader = reader;
     mPixelReader->getNextChipData(mChipData);
-    mIR = mChipData.getInteractionRecord();
+    mHB = mPixelReader->getInteractionRecordHB();
+    mTr = mPixelReader->getInteractionRecord();
   }
   void setDigitPixelReader(std::string input)
   {
@@ -65,7 +71,8 @@ class Data
     reader->readNextEntry();
     mPixelReader = reader;
     mPixelReader->getNextChipData(mChipData);
-    mIR = mChipData.getInteractionRecord();
+    mHB = mPixelReader->getInteractionRecordHB();
+    mTr = mPixelReader->getInteractionRecord();
   }
   void setDigiTree(TTree* t) { mDigiTree = t; }
   void setClusTree(TTree* t);
@@ -76,7 +83,8 @@ class Data
   int mLastEvent = 0;
   PixelReader* mPixelReader = nullptr;
   ChipPixelData mChipData;
-  o2::InteractionRecord mIR;
+  o2::InteractionRecord mHB;
+  o2::InteractionRecord mTr;
   std::vector<Digit> mDigits;
   std::vector<Cluster>* mClusterBuffer = nullptr;
   gsl::span<Cluster> mClusters;
@@ -101,12 +109,15 @@ class Data
   TEveElement* getEveChipClusters(int chip);
   TEveElement* getEveClusters();
   TEveElement* getEveTracks();
-} evdata;
+};
+
+std::vector<Data> evdata;
 
 void Data::loadDigits()
 {
-  auto ir = mChipData.getInteractionRecord();
-  std::cout << "orbit/crossing: " << ' ' << ir.orbit << '/' << ir.bc << '\n';
+  auto hb = mPixelReader->getInteractionRecordHB();
+  auto tr = mPixelReader->getInteractionRecord();
+  std::cout << "orbit/crossing: " << ' ' << tr.orbit << '/' << tr.bc << '\n';
 
   mDigits.clear();
 
@@ -115,16 +126,18 @@ void Data::loadDigits()
     auto pixels = mChipData.getData();
     for (auto& pixel : pixels) {
       auto col = pixel.getCol();
-      auto row = pixel.getRow();
-      mDigits.emplace_back(chipID, 0, row, col);
+      auto row = pixel.getRowDirect();
+      mDigits.emplace_back(chipID, row, col, 0);
     }
     if (!mPixelReader->getNextChipData(mChipData))
       return;
-    ir = mChipData.getInteractionRecord();
-  } while (mIR == ir);
-  mIR = ir;
+    hb = mPixelReader->getInteractionRecordHB();
+    tr = mPixelReader->getInteractionRecord();
+  } while (mHB == hb && mTr == tr);
+  mHB = hb;
+  mTr = tr;
 
-  std::cout << "Number of ITSDigits: " << mDigits.size() << '\n';
+  //std::cout << "Number of ITSDigits: " << mDigits.size() << '\n';
 }
 
 void Data::loadDigits(int entry)
@@ -133,13 +146,16 @@ void Data::loadDigits(int entry)
     return;
 
   for (; mLastEvent < entry; mLastEvent++) {
-    auto ir = mChipData.getInteractionRecord();
+    auto hb = mPixelReader->getInteractionRecordHB();
+    auto tr = mPixelReader->getInteractionRecord();
     do {
       if (!mPixelReader->getNextChipData(mChipData))
         return;
-      ir = mChipData.getInteractionRecord();
-    } while (mIR == ir);
-    mIR = ir;
+      hb = mPixelReader->getInteractionRecordHB();
+      tr = mPixelReader->getInteractionRecord();
+    } while (mHB == hb && mTr == tr);
+    mHB = hb;
+    mTr = tr;
   }
   mLastEvent++;
   loadDigits();
@@ -171,7 +187,7 @@ void Data::loadClusters(int entry)
   }
   mClusters = gsl::make_span(&(*mClusterBuffer)[first], last - first);
 
-  std::cout << "Number of ITSClusters: " << mClusters.size() << '\n';
+  //std::cout << "Number of ITSClusters: " << mClusters.size() << '\n';
 }
 
 void Data::setTracTree(TTree* tree)
@@ -203,7 +219,7 @@ void Data::loadTracks(int entry)
   }
   mTracks = gsl::make_span(&(*mTrackBuffer)[first], last - first);
 
-  std::cout << "Number of ITSTracks: " << mTracks.size() << '\n';
+  //std::cout << "Number of ITSTracks: " << mTracks.size() << '\n';
 }
 
 void Data::loadData(int entry)
@@ -221,7 +237,7 @@ constexpr float gap = 1e-4; // For a better visualization of pixels
 
 TEveElement* Data::getEveChipDigits(int chip)
 {
-  static TEveFrameBox* box = new TEveFrameBox();
+  TEveFrameBox* box = new TEveFrameBox();
   box->SetAAQuadXY(0, 0, 0, sizex, sizey);
   box->SetFrameColor(kGray);
 
@@ -250,15 +266,20 @@ TEveElement* Data::getEveChipDigits(int chip)
   t.SetPos(0, 0, 0);
 
   auto most = std::distance(occup.begin(), std::max_element(occup.begin(), occup.end()));
-  std::cout << "Most occupied chip: " << most << " (" << occup[most] << " digits)\n";
-  std::cout << "Chip " << chip << " number of digits " << occup[chip] << '\n';
-
-  return qdigi;
+  if (occup[most] > 0) {
+    std::cout << "Most occupied chip: " << most << " (" << occup[most] << " digits)\n";
+  }
+  if (occup[chip] > 0) {
+    std::cout << "Chip " << chip << " number of digits " << occup[chip] << '\n';
+    return qdigi;
+  }
+  delete qdigi;
+  return nullptr;
 }
 
 TEveElement* Data::getEveChipClusters(int chip)
 {
-  static TEveFrameBox* box = new TEveFrameBox();
+  TEveFrameBox* box = new TEveFrameBox();
   box->SetAAQuadXY(0, 0, 0, sizex, sizey);
   box->SetFrameColor(kGray);
 
@@ -288,13 +309,19 @@ TEveElement* Data::getEveChipClusters(int chip)
   ct.RotateLF(1, 3, 0.5 * TMath::Pi());
   ct.SetPos(0, 0, 0);
 
-  std::cout << "Chip " << chip << " number of clusters " << ncl << '\n';
-
-  return qclus;
+  if (ncl > 0) {
+    std::cout << "Chip " << chip << " number of clusters " << ncl << '\n';
+    return qclus;
+  }
+  delete qclus;
+  return nullptr;
 }
 
 TEveElement* Data::getEveClusters()
 {
+  if (mClusters.empty())
+    return nullptr;
+
   auto gman = o2::its::GeometryTGeo::Instance();
   TEvePointSet* clusters = new TEvePointSet("clusters");
   clusters->SetMarkerColor(kBlue);
@@ -307,6 +334,9 @@ TEveElement* Data::getEveClusters()
 
 TEveElement* Data::getEveTracks()
 {
+  if (mTracks.empty())
+    return nullptr;
+
   auto gman = o2::its::GeometryTGeo::Instance();
   TEveTrackList* tracks = new TEveTrackList("tracks");
   auto prop = tracks->GetPropagator();
@@ -343,54 +373,72 @@ TEveElement* Data::getEveTracks()
 
 void Data::displayData(int entry, int chip)
 {
-  std::string ename("Event #");
+  std::string ename("Part of Event #");
   ename += std::to_string(entry);
 
   // Chip display
   auto chipDigits = getEveChipDigits(chip);
   auto chipClusters = getEveChipClusters(chip);
+
   delete mChip;
-  std::string cname(ename + "  ALPIDE chip #");
-  cname += std::to_string(chip);
-  mChip = new TEveElementList(cname.c_str());
-  mChip->AddElement(chipDigits);
-  mChip->AddElement(chipClusters);
-  gEve->AddElement(mChip);
+  mChip = nullptr;
+  if (chipDigits || chipClusters) {
+    std::string cname(ename + "  ALPIDE chip #");
+    cname += std::to_string(chip);
+    mChip = new TEveElementList(cname.c_str());
+    if (chipDigits) {
+      mChip->AddElement(chipDigits);
+    }
+    if (chipClusters) {
+      mChip->AddElement(chipClusters);
+    }
+    gEve->AddElement(mChip, chipScene);
+  }
 
   // Event display
   auto clusters = getEveClusters();
   auto tracks = getEveTracks();
+
   delete mEvent;
-  mEvent = new TEveElementList(ename.c_str());
-  mEvent->AddElement(clusters);
-  mEvent->AddElement(tracks);
-  auto multi = o2::event_visualisation::MultiView::getInstance();
-  multi->registerEvent(mEvent);
+  mEvent = nullptr;
+  if (clusters || tracks) {
+    mEvent = new TEveElementList(ename.c_str());
+    if (clusters) {
+      mEvent->AddElement(clusters);
+    }
+    if (tracks) {
+      mEvent->AddElement(tracks);
+    }
+    auto multi = o2::event_visualisation::MultiView::getInstance();
+    multi->registerEvent(mEvent);
+  }
 
   gEve->Redraw3D(kFALSE);
 }
 
 void load(int entry, int chip)
 {
-  int lastEvent = evdata.getLastEvent();
-  if (lastEvent > entry) {
-    std::cerr << "\nERROR: Cannot stay or go back over events. Please increase the event number !\n\n";
-    gEntry->SetIntNumber(lastEvent - 1);
-    return;
-  }
-
+  std::cout << "\n*** RO frame #" << entry << " ***\n";
   gEntry->SetIntNumber(entry);
   gChipID->SetIntNumber(chip);
 
-  std::cout << "\n*** Event #" << entry << " ***\n";
-  evdata.loadData(entry);
-  evdata.displayData(entry, chip);
+  for (auto& evdat : evdata) {
+    int lastEvent = evdat.getLastEvent();
+    if (lastEvent > entry) {
+      std::cerr << "\nERROR: Cannot stay or go back over events. Please increase the event number !\n\n";
+      gEntry->SetIntNumber(lastEvent - 1);
+      continue;
+    }
+
+    evdat.loadData(entry);
+    evdat.displayData(entry, chip);
+  }
 }
 
 void init(int entry = 0, int chip = 13,
-          std::string digifile = "itsdigits.root",
+          std::vector<std::string> digifiles = {"itsdigits.root"},
           bool rawdata = false,
-          std::string clusfile = "o2clus_its.root",
+          const std::vector<std::string> clusfiles = {"data-ep4-link0"},
           std::string tracfile = "o2trac_its.root",
           std::string inputGeom = "O2geometry.root")
 {
@@ -405,6 +453,11 @@ void init(int entry = 0, int chip = 13,
 
   // Chip View
   browser->GetTabRight()->SetText("Chip View");
+  auto chipView = gEve->GetDefaultViewer();
+  chipView->SetName("Chip Viewer");
+  chipView->DestroyElements();
+  chipScene = gEve->SpawnNewScene("Chip View", "Chip view desciption");
+  chipView->AddScene(chipScene);
   TGLViewer* v = gEve->GetDefaultGLViewer();
   v->SetCurrentCamera(TGLViewer::kCameraOrthoZOY);
   TGLCameraOverlay* co = v->GetCameraOverlay();
@@ -414,6 +467,8 @@ void init(int entry = 0, int chip = 13,
   // Event View
   auto multi = o2::event_visualisation::MultiView::getInstance();
   multi->drawGeometryForDetector("ITS");
+
+  gEve->AddEvent(new TEveEventManager());
 
   // Event navigation
   browser->StartEmbedding(TRootBrowser::kBottom);
@@ -445,39 +500,45 @@ void init(int entry = 0, int chip = 13,
   browser->StopEmbedding("Navigator");
 
   TFile* file;
-
   // Data sources
-  if (rawdata) {
-    std::ifstream* rawfile = new std::ifstream(digifile.data(), std::ifstream::binary);
-    if (rawfile->good()) {
-      delete rawfile;
-      std::cout << "Running with raw digits...\n";
-      evdata.setRawPixelReader(digifile.data());
-    } else
-      std::cerr << "\nERROR: Cannot open file: " << digifile << "\n\n";
-  } else {
-    file = TFile::Open(digifile.data());
-    if (file && gFile->IsOpen()) {
-      file->Close();
-      std::cout << "Running with MC digits...\n";
-      evdata.setDigitPixelReader(digifile.data());
-      //evdata.setDigiTree((TTree*)gFile->Get("o2sim"));
-    } else
-      std::cerr << "\nERROR: Cannot open file: " << digifile << "\n\n";
+
+  std::vector<Data> tmp(std::max(digifiles.size(), clusfiles.size()));
+  evdata.swap(tmp);
+  int i = 0;
+  for (auto& digifile : digifiles) {
+    if (rawdata) {
+      std::ifstream* rawfile = new std::ifstream(digifile.data(), std::ifstream::binary);
+      if (rawfile->good()) {
+        delete rawfile;
+        evdata[i++].setRawPixelReader(digifile.data());
+      } else
+        std::cerr << "\nERROR: Cannot open file: " << digifile << "\n\n";
+    } else {
+      file = TFile::Open(digifile.data());
+      if (file && gFile->IsOpen()) {
+        file->Close();
+        evdata[i++].setDigitPixelReader(digifile.data());
+      } else
+        std::cerr << "\nERROR: Cannot open file: " << digifile << "\n\n";
+    }
   }
 
-  file = TFile::Open(clusfile.data());
-  if (file && gFile->IsOpen())
-    evdata.setClusTree((TTree*)gFile->Get("o2sim"));
-  else
-    std::cerr << "ERROR: Cannot open file: " << clusfile << "\n\n";
-
+  i = 0;
+  for (auto& clusfile : clusfiles) {
+    file = TFile::Open(clusfile.data());
+    if (file && gFile->IsOpen()) {
+      evdata[i++].setClusTree((TTree*)gFile->Get("o2sim"));
+    } else {
+      std::cerr << "ERROR: Cannot open file: " << clusfile << "\n\n";
+    }
+  }
+  /*
   file = TFile::Open(tracfile.data());
   if (file && gFile->IsOpen())
     evdata.setTracTree((TTree*)gFile->Get("o2sim"));
   else
     std::cerr << "\nERROR: Cannot open file: " << tracfile << "\n\n";
-
+  */
   std::cout << "\n **** Navigation over events and chips ****\n";
   std::cout << " load(event, chip) \t jump to the specified event and chip\n";
   std::cout << " next() \t\t load next event \n";
@@ -518,7 +579,9 @@ void loadChip()
 {
   auto event = gEntry->GetNumberEntry()->GetIntNumber();
   auto chip = gChipID->GetNumberEntry()->GetIntNumber();
-  evdata.displayData(event, chip);
+  for (auto& evdat : evdata) {
+    evdat.displayData(event, chip);
+  }
 }
 
 void loadChip(int chip)

--- a/Detectors/ITSMFT/ITS/macros/EVE/rootlogon.C
+++ b/Detectors/ITSMFT/ITS/macros/EVE/rootlogon.C
@@ -1,6 +1,56 @@
 {
   std::cout << "\n *** This is ITS visualisation ! ***\n\n";
-  gROOT->LoadMacro("./DisplayEvents.C+");
-  init();
+  gROOT->LoadMacro("./DisplayEvents.C+g");
+  std::vector<std::string> digifiles{
+    "data-ep4-link0",
+    "data-ep4-link1",
+    "data-ep4-link2",
+    "data-ep4-link3",
+    "data-ep4-link4",
+    "data-ep4-link5",
+    "data-ep4-link6",
+    "data-ep4-link7",
+    "data-ep4-link8",
+    "data-ep4-link9",
+    "data-ep4-link10",
+    "data-ep4-link11",
+    "data-ep5-link0",
+    "data-ep5-link1",
+    "data-ep5-link2",
+    "data-ep5-link3",
+    "data-ep5-link4",
+    "data-ep5-link5",
+    "data-ep5-link6",
+    "data-ep5-link7",
+    "data-ep5-link8",
+    "data-ep5-link9",
+    "data-ep5-link10",
+    "data-ep5-link11"};
+  std::vector<std::string> clusfiles{
+    "data-ep4-link0.root",
+    "data-ep4-link1.root",
+    "data-ep4-link2.root",
+    "data-ep4-link3.root",
+    "data-ep4-link4.root",
+    "data-ep4-link5.root",
+    "data-ep4-link6.root",
+    "data-ep4-link7.root",
+    "data-ep4-link8.root",
+    "data-ep4-link9.root",
+    "data-ep4-link10.root",
+    "data-ep4-link11.root",
+    "data-ep5-link0.root",
+    "data-ep5-link1.root",
+    "data-ep5-link2.root",
+    "data-ep5-link3.root",
+    "data-ep5-link4.root",
+    "data-ep5-link5.root",
+    "data-ep5-link6.root",
+    "data-ep5-link7.root",
+    "data-ep5-link8.root",
+    "data-ep5-link9.root",
+    "data-ep5-link10.root",
+    "data-ep5-link11.root"};
+  init(0, 132, digifiles, true, clusfiles);
   gEve->GetBrowser()->GetTabRight()->SetTab(1);
 }

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/ClustererTask.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/ClustererTask.h
@@ -26,6 +26,7 @@
 #include "SimulationDataFormat/MCTruthContainer.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include <memory>
+#include <limits>
 
 namespace o2
 {
@@ -54,14 +55,16 @@ class ClustererTask
   void Init();
   Clusterer& getClusterer() { return mClusterer; }
   void run(const std::string inpName, const std::string outName);
-  void setSelfManagedMode(bool v) { mSelfManagedMode = v; }
-  bool isSelfManagedMode() const { return mSelfManagedMode; }
   o2::itsmft::PixelReader* getReader() const { return (o2::itsmft::PixelReader*)mReader; }
 
   void loadDictionary(std::string fileName) { mClusterer.loadDictionary(fileName); }
 
+  void writeTree(std::string basename, int i);
+  void setMaxROframe(int max) { maxROframe = max; }
+  int getMaxROframe() const { return maxROframe; }
+
  private:
-  bool mSelfManagedMode = false;                                                      ///< manages itself input output
+  int maxROframe = std::numeric_limits<int>::max();                                   ///< maximal number of RO frames per a file
   bool mRawDataMode = false;                                                          ///< input from raw data or MC digits
   bool mUseMCTruth = true;                                                            ///< flag to use MCtruth if available
   o2::itsmft::PixelReader* mReader = nullptr;                                         ///< Pointer on the relevant Pixel reader
@@ -72,16 +75,12 @@ class ClustererTask
   Clusterer mClusterer;                                ///< Cluster finder
 
   std::vector<Cluster> mFullClus;               //!< vector of full clusters
-  std::vector<Cluster>* mFullClusPtr = nullptr; //!< vector of full clusters pointer
 
   std::vector<CompClusterExt> mCompClus;               //!< vector of compact clusters
-  std::vector<CompClusterExt>* mCompClusPtr = nullptr; //!< vector of compact clusters pointer
 
   std::vector<o2::itsmft::ROFRecord> mROFRecVec;               //!< vector of ROFRecord references
-  std::vector<o2::itsmft::ROFRecord>* mROFRecVecPtr = nullptr; //!< vector of ROFRecord references pointer
 
   MCTruth mClsLabels;               //! MC labels
-  MCTruth* mClsLabelsPtr = nullptr; //! MC labels pointer (optional)
 
   ClassDefNV(ClustererTask, 1);
 };

--- a/Detectors/ITSMFT/ITS/reconstruction/src/ClustererTask.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/ClustererTask.cxx
@@ -73,49 +73,58 @@ void ClustererTask::Init()
 void ClustererTask::run(const std::string inpName, const std::string outName)
 {
   // standalone execution
-  setSelfManagedMode(true);
   Init(); // create reader, clusterer
 
-  std::unique_ptr<TFile> outFile(TFile::Open(outName.data(), "recreate"));
-  if (!outFile || outFile->IsZombie()) {
-    LOG(FATAL) << "Failed to open output file " << outName;
-  }
-  std::unique_ptr<TTree> outTree = std::make_unique<TTree>("o2sim", "ITS Clusters");
-
-  if (mClusterer.getWantFullClusters()) {
-    mFullClusPtr = &mFullClus;
-    outTree->Branch("ITSCluster", &mFullClusPtr);
-    LOG(INFO) << Class()->GetName() << " output of full clusters is requested";
-  } else {
-    LOG(INFO) << Class()->GetName() << " output of full clusters is not requested";
-  }
-
-  if (mClusterer.getWantCompactClusters()) {
-    mCompClusPtr = &mCompClus;
-    outTree->Branch("ITSClusterComp", &mCompClusPtr);
-    LOG(INFO) << Class()->GetName() << " output of compact clusters is requested";
-  } else {
-    LOG(INFO) << Class()->GetName() << " output of compact clusters is not requested";
-  }
-
-  mROFRecVecPtr = &mROFRecVec;
-  outTree->Branch("ITSClustersROF", mROFRecVecPtr);
-
   if (mRawDataMode) {
+
     mReaderRaw->openInput(inpName);
-    mClusterer.process(*mReaderRaw.get(), mFullClusPtr, mCompClusPtr, nullptr, mROFRecVecPtr);
+    mClusterer.process(*mReaderRaw.get(), &mFullClus, &mCompClus, nullptr, &mROFRecVec);
+
+    auto basename = outName.substr(0, outName.size() - sizeof("root"));
+    auto nFiles = int(mROFRecVec.size() / maxROframe);
+    int i = 0;
+    for (; i < nFiles; i++) {
+      writeTree(basename, i);
+    }
+    writeTree(basename, i); // The remainder
+
   } else {
+
     mReaderMC->openInput(inpName, o2::detectors::DetID("ITS"));
+
+    TFile outFile(outName.data(), "new");
+    if (!outFile.IsOpen()) {
+      LOG(FATAL) << "Failed to open output file " << outName;
+    }
+
+    TTree outTree("o2sim", "ITS Clusters");
+
+    auto fullClusPtr = &mFullClus;
+    if (mClusterer.getWantFullClusters()) {
+      outTree.Branch("ITSCluster", &fullClusPtr);
+    } else {
+      LOG(INFO) << Class()->GetName() << " output of full clusters is not requested";
+    }
+
+    auto compClusPtr = &mCompClus;
+    if (mClusterer.getWantCompactClusters()) {
+      outTree.Branch("ITSClusterComp", &compClusPtr);
+    } else {
+      LOG(INFO) << Class()->GetName() << " output of compact clusters is not requested";
+    }
+
+    auto rofRecVecPtr = &mROFRecVec;
+    outTree.Branch("ITSClustersROF", &rofRecVecPtr);
 
     if (mUseMCTruth && !(mClusterer.getWantFullClusters() || mClusterer.getWantCompactClusters())) {
       mUseMCTruth = false;
       LOG(WARNING) << "ITS clusters storage is not requested, suppressing MCTruth storage";
     }
 
+    auto clsLabelsPtr = &mClsLabels;
     if (mUseMCTruth && mReaderMC->getDigitsMCTruth()) {
       // digit labels are provided directly to clusterer
-      mClsLabelsPtr = &mClsLabels;
-      outTree->Branch("ITSClusterMCTruth", &mClsLabelsPtr);
+      outTree.Branch("ITSClusterMCTruth", &clsLabelsPtr);
     } else {
       mUseMCTruth = false;
     }
@@ -123,26 +132,64 @@ void ClustererTask::run(const std::string inpName, const std::string outName)
 
     // loop over entries of the input tree
     while (mReaderMC->readNextEntry()) {
-      mClusterer.process(*mReaderMC.get(), mFullClusPtr, mCompClusPtr, mClsLabelsPtr, mROFRecVecPtr);
+      mClusterer.process(*mReaderMC.get(), &mFullClus, &mCompClus, &mClsLabels, &mROFRecVec);
     }
-  }
 
-  std::vector<o2::itsmft::MC2ROFRecord> mc2rof, *mc2rofPtr = &mc2rof;
-  if (!mRawDataMode && mUseMCTruth) {
-    auto mc2rofOrig = mReaderMC->getMC2ROFRecords();
-    mc2rof.reserve(mc2rofOrig.size());
-    for (const auto& m2r : mc2rofOrig) { // clone from the span
-      mc2rof.push_back(m2r);
+    std::vector<o2::itsmft::MC2ROFRecord> mc2rof, *mc2rofPtr = &mc2rof;
+    if (mUseMCTruth) {
+      auto mc2rofOrig = mReaderMC->getMC2ROFRecords();
+      mc2rof.reserve(mc2rofOrig.size());
+      for (const auto& m2r : mc2rofOrig) { // clone from the span
+        mc2rof.push_back(m2r);
+      }
+      outTree.Branch("ITSClustersMC2ROF", mc2rofPtr);
     }
-    outTree->Branch("ITSClustersMC2ROF", mc2rofPtr);
+
+    outTree.Fill();
+    outTree.Write();
   }
-
-  outTree->Fill();
-  outTree->Write();
-
-  outTree.reset(); // tree should be destroyed before the file is closed
-
-  outFile->Close();
 
   mClusterer.clear();
+}
+
+void ClustererTask::writeTree(std::string basename, int i)
+{
+  auto name = basename + std::to_string(i) + ".root";
+  TFile outFile(name.data(), "new");
+  if (!outFile.IsOpen()) {
+    LOG(FATAL) << "Failed to open output file " << name;
+  }
+  TTree outTree("o2sim", "ITS Clusters");
+
+  auto max = (i + 1) * maxROframe;
+  auto lastf = (max < mROFRecVec.size()) ? mROFRecVec.begin() + max : mROFRecVec.end();
+  std::vector<o2::itsmft::ROFRecord> rofRecBuffer(mROFRecVec.begin() + i * maxROframe, lastf);
+  std::vector<o2::itsmft::ROFRecord>* rofRecPtr = &rofRecBuffer;
+  outTree.Branch("ITSClustersROF", rofRecPtr);
+
+  auto first = rofRecBuffer[0].getFirstEntry();
+  auto last = rofRecBuffer.back().getFirstEntry() + rofRecBuffer.back().getNEntries();
+
+  std::vector<Cluster> fullClusBuffer, *fullClusPtr = &fullClusBuffer;
+  if (mClusterer.getWantFullClusters()) {
+    fullClusBuffer.assign(&mFullClus[first], &mFullClus[last]);
+    outTree.Branch("ITSCluster", &fullClusPtr);
+  } else {
+    LOG(INFO) << Class()->GetName() << " output of full clusters is not requested";
+  }
+
+  std::vector<CompClusterExt> compClusBuffer, *compClusPtr = &compClusBuffer;
+  if (mClusterer.getWantCompactClusters()) {
+    compClusBuffer.assign(&mCompClus[first], &mCompClus[last]);
+    outTree.Branch("ITSClusterComp", &compClusPtr);
+  } else {
+    LOG(INFO) << Class()->GetName() << " output of compact clusters is not requested";
+  }
+
+  for (auto& rof : rofRecBuffer) {
+    rof.setFirstEntry(rof.getFirstEntry() - first);
+  }
+
+  outTree.Fill();
+  outTree.Write();
 }

--- a/macro/run_clus_itsSA.C
+++ b/macro/run_clus_itsSA.C
@@ -40,6 +40,7 @@ void run_clus_itsSA(std::string inputfile = "rawits.bin", // output file name
   // Setup clusterizer
   Bool_t useMCTruth = kTRUE;  // kFALSE if no comparison with MC needed
   o2::its::ClustererTask* clus = new o2::its::ClustererTask(useMCTruth, raw);
+  clus->setMaxROframe(2 << 21); // about 3 cluster files per a raw data chunk
   if (withDictionary) {
     clus->loadDictionary(dictionaryfile.c_str());
   }


### PR DESCRIPTION
1) Writing several cluster files per a raw data chunk. Since the sub-time-frame boundaries are not embedded into the commissioning data, a new cluster file gets open after a large (settable) number of processed RO frames.
2) Visualisaton of clusters and raw data coming from several RU files.  Since the tracks are not local to RUs, the display of tracks has been temporarily disabled.  