### PR TITLE
Full multi-threaded GPU ZS decoding, parallelized over ADC sequences

### DIFF
--- a/GPU/Common/GPUDef.h
+++ b/GPU/Common/GPUDef.h
@@ -42,16 +42,16 @@
   #define CA_SHARED_CACHE(target, src, size) \
     static_assert((size) % sizeof(int) == 0, "Invalid shared cache size"); \
     for (unsigned int i_shared_cache = get_local_id(0); i_shared_cache < (size) / sizeof(int); i_shared_cache += get_local_size(0)) { \
-      reinterpret_cast<GPUsharedref() int*>(target)[i_shared_cache] = reinterpret_cast<GPUglobalref() int*>(src)[i_shared_cache]; \
+      reinterpret_cast<GPUsharedref() int*>(target)[i_shared_cache] = reinterpret_cast<GPUglobalref() const int*>(src)[i_shared_cache]; \
     }
   #define CA_SHARED_CACHE_REF(target, src, size, reftype, ref) \
     CA_SHARED_CACHE(target, src, size) \
-    GPUsharedref() reftype* ref = (target)
+    GPUsharedref() const reftype* ref = (target)
 #else
   #define CA_MAKE_SHARED_REF(vartype, varname, varglobal, varshared) const GPUglobalref() MEM_GLOBAL(vartype) &varname = varglobal;
   #define CA_SHARED_STORAGE(storage)
   #define CA_SHARED_CACHE(target, src, size)
-  #define CA_SHARED_CACHE_REF(target, src, size, reftype, ref) GPUglobalref() reftype* ref = src
+  #define CA_SHARED_CACHE_REF(target, src, size, reftype, ref) GPUglobalref() const reftype* ref = src
 #endif
 
 #ifdef GPUCA_TEXTURE_FETCH_CONSTRUCTOR

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCSharedMemoryData.h
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCSharedMemoryData.h
@@ -57,10 +57,12 @@ class GPUTPCSharedMemoryData
   struct zs_t {
     CA_SHARED_STORAGE(unsigned int ZSPage[o2::tpc::TPCZSHDR::TPC_ZS_PAGE_SIZE / sizeof(unsigned int)]);
     unsigned int RowClusterOffset[o2::tpc::TPCZSHDR::TPC_MAX_ZS_ROW_IN_ENDPOINT];
-    int nRowsRegion;
-    int regionStartRow;
-    int nThreadsPerRow;
-    int rowStride;
+    unsigned int nRowsRegion;
+    unsigned int regionStartRow;
+    unsigned int nThreadsPerRow;
+    unsigned int rowStride;
+    unsigned int decodeBits;
+    float decodeBitsFactor;
   };
 };
 


### PR DESCRIPTION
This is the final threading implementation for now.
In the future, one could also parallelize over multiple 8kb pages.
Shared memory is 48kb, which would allow to cache 5 pages per multiprocessor in parallel to have more GPU threads running concurrently.
But this would make the code even more complicated. Before, some benchmarks are needed to judge whether this is necessary.