### PR TITLE
GPU: Fix missing synchronization of number of clusters after clusterizer

### DIFF
--- a/GPU/GPUTracking/SliceTracker/GPUTPCSliceData.h
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCSliceData.h
@@ -138,7 +138,7 @@ class GPUTPCSliceData
   GPUhdi() char* GPUTextureBaseConst() const { return ((char*)mGPUTextureBase); }
 
 #if !defined(__OPENCL__)
-  GPUhi() const GPUTPCClusterData* ClusterData() const
+  GPUhdi() const GPUTPCClusterData* ClusterData() const
   {
     return mClusterData;
   }


### PR DESCRIPTION
Fix long-standing problem if incorrectly found adjacent clusters on GPU. Number of clusters after clusterizer was updated from upper bound to real number, but the GPU tracker was initialized before and not updated, leading to a shift in adjacent cluster IDs.