### PR TITLE
Fix to pythia8 heavy-ion configuration

### DIFF
--- a/Generators/share/egconfig/pythia8_hi.cfg
+++ b/Generators/share/egconfig/pythia8_hi.cfg
@@ -6,7 +6,7 @@ Beams:eCM 5520. 		# GeV
 ### heavy-ion settings (valid for Pb-Pb 5520 only)
 HeavyIon:SigFitNGen 0
 HeavyIon:SigFitDefPar 14.82,1.82,0.25,0.0,0.0,0.0,0.0,0.0
-HeavyIon:bWidth			# impact parameter from 0-x [fm]
+HeavyIon:bWidth	15.		# impact parameter from 0-x [fm]
 
 ### processes (apparently not to be defined)
 


### PR DESCRIPTION
There was a mistype in the pythia8 configuration file.