### PR TITLE
DPL support for vectored IO

### DIFF
--- a/Framework/Core/include/Framework/CompletionPolicy.h
+++ b/Framework/Core/include/Framework/CompletionPolicy.h
@@ -10,7 +10,7 @@
 #ifndef FRAMEWORK_COMPLETIONPOLICY_H
 #define FRAMEWORK_COMPLETIONPOLICY_H
 
-#include "Framework/PartRef.h"
+#include "Framework/DataRef.h"
 
 #include <functional>
 #include <string>
@@ -50,7 +50,7 @@ struct CompletionPolicy {
   };
 
   using Matcher = std::function<bool(DeviceSpec const& device)>;
-  using InputSetElement = PartRef;
+  using InputSetElement = DataRef;
   using InputSet = gsl::span<InputSetElement const> const&;
   using Callback = std::function<CompletionOp(InputSet)>;
 

--- a/Framework/Core/include/Framework/CompletionPolicyHelpers.h
+++ b/Framework/Core/include/Framework/CompletionPolicyHelpers.h
@@ -57,7 +57,7 @@ struct CompletionPolicyHelpers {
     // DataHeader interface requires to specify header pointer type, need to check if the template parameter
     // is already pointer type, and add pointer if not
     using return_type = typename std::conditional<std::is_pointer<T>::value, T, typename std::add_pointer<T>::type>::type;
-    return o2::header::get<return_type>(input.header ? input.header->GetData() : nullptr);
+    return o2::header::get<return_type>(input.header);
   }
 };
 

--- a/Framework/Core/include/Framework/DataRelayer.h
+++ b/Framework/Core/include/Framework/DataRelayer.h
@@ -14,7 +14,7 @@
 #include "Framework/DataDescriptorMatcher.h"
 #include "Framework/ForwardRoute.h"
 #include "Framework/CompletionPolicy.h"
-#include "Framework/PartRef.h"
+#include "Framework/MessageSet.h"
 #include "Framework/TimesliceIndex.h"
 
 #include <cstddef>
@@ -106,7 +106,7 @@ class DataRelayer
   /// Notice that we store them as a NxM sized vector, where
   /// N is the maximum number of inflight timeslices, while
   /// M is the number of inputs which are requested.
-  std::vector<PartRef> mCache;
+  std::vector<MessageSet> mCache;
 
   /// This is the index which maps a given timestamp to the associated
   /// cacheline.

--- a/Framework/Core/include/Framework/DataRelayer.h
+++ b/Framework/Core/include/Framework/DataRelayer.h
@@ -76,8 +76,7 @@ class DataRelayer
   /// Returns an input registry associated to the given timeslice and gives
   /// ownership to the caller. This is because once the inputs are out of the
   /// DataRelayer they need to be deleted once the processing is concluded.
-  std::vector<std::unique_ptr<FairMQMessage>>
-    getInputsForTimeslice(TimesliceSlot id);
+  std::vector<MessageSet> getInputsForTimeslice(TimesliceSlot id);
 
   /// Returns the index of the arguments which have to be forwarded to
   /// the next processor

--- a/Framework/Core/include/Framework/DispatchPolicy.h
+++ b/Framework/Core/include/Framework/DispatchPolicy.h
@@ -10,8 +10,6 @@
 #ifndef FRAMEWORK_DISPATCHPOLICY_H
 #define FRAMEWORK_DISPATCHPOLICY_H
 
-#include "Framework/PartRef.h"
-
 #include <functional>
 #include <string>
 #include <vector>

--- a/Framework/Core/include/Framework/InputRecord.h
+++ b/Framework/Core/include/Framework/InputRecord.h
@@ -165,17 +165,28 @@ class InputRecord
   int getPos(const char* name) const;
   int getPos(const std::string& name) const;
 
-  DataRef getByPos(int pos) const
+  DataRef getByPos(int pos, int part = 0) const
   {
     if (pos >= mSpan.size() || pos < 0) {
       throw std::runtime_error("Unknown message requested at position " + std::to_string(pos));
     }
-    if (pos > mInputsSchema.size()) {
+    if (part >= getNofParts(pos)) {
+      throw std::runtime_error("Invalid message part index at " + std::to_string(pos) + ":" + std::to_string(part));
+    }
+    if (pos >= mInputsSchema.size()) {
       throw std::runtime_error("Unknown schema at position" + std::to_string(pos));
     }
-    auto ref = mSpan.get(pos);
+    auto ref = mSpan.get(pos, part);
     ref.spec = &mInputsSchema[pos].matcher;
     return ref;
+  }
+
+  size_t getNofParts(int pos) const
+  {
+    if (pos < 0) {
+      return 0;
+    }
+    return mSpan.getNofParts(pos);
   }
 
   template <typename T = DataRef, typename std::enable_if_t<std::is_same<T, DataRef>::value == true, int> = 0>
@@ -199,7 +210,7 @@ class InputRecord
   }
 
   /// get object of the specified type from input
-  /// The actual operation and cast dependd on the target data type and the serialization type of the
+  /// The actual operation and cast depends on the target data type and the serialization type of the
   /// incoming data. See @ref Inputrecord class description for supported types.
   /// @param binding   the input to extract the data from
   template <typename T, typename std::enable_if_t<std::is_same<T, DataRef>::value == false, int> = 0>
@@ -207,13 +218,22 @@ class InputRecord
   {
     // make sure the selection is working
     static_assert(std::is_same<T, DataRef>::value == false);
+    return get<T>(get<DataRef>(binding));
+  }
+
+  /// get object of specified type for input DataRef
+  /// The actual operation and cast depends on the target data type and the serialization type of the
+  /// incoming data. See @ref Inputrecord class description for supported types.
+  /// @param ref   DataRef with pointers to input spec, header, and payload
+  template <typename T>
+  decltype(auto) get(DataRef ref) const
+  {
     if constexpr (std::is_same<T, std::string>::value) {
       // substitution for std::string
       // If we ask for a string, we need to duplicate it because we do not want
       // the buffer to be deleted when it goes out of scope. The string is built
       // from the data and its lengh, null-termination is not necessary.
       // return std::string object
-      DataRef ref = get<DataRef>(binding);
       auto header = header::get<const header::DataHeader*>(ref.header);
       assert(header);
       return std::string(ref.payload, header->payloadSize);
@@ -226,14 +246,13 @@ class InputRecord
       // If you want to actually get hold of the buffer, use gsl::span<char> as that will
       // give you the size as well.
       // return pointer to payload content
-      return reinterpret_cast<char const*>(get<DataRef>(binding).payload);
+      return reinterpret_cast<char const*>(ref.payload);
 
       // implementation (d)
     } else if constexpr (std::is_same<T, TableConsumer>::value) {
       // substitution for TableConsumer
       // For the moment this is dummy, as it requires proper support to
       // create the RDataSource from the arrow buffer.
-      DataRef ref = get<DataRef>(binding);
       auto header = header::get<const header::DataHeader*>(ref.header);
       assert(header);
       auto data = reinterpret_cast<uint8_t const*>(ref.payload);
@@ -245,7 +264,6 @@ class InputRecord
       // We have to deserialize the ostringstream.
       // FIXME: check that the string is null terminated.
       // @return deserialized copy of payload
-      DataRef ref = get<DataRef>(binding);
       auto header = header::get<const header::DataHeader*>(ref.header);
       assert(header);
       auto str = std::string(ref.payload, header->payloadSize);
@@ -261,7 +279,6 @@ class InputRecord
       // substitution for span of messageable objects
       // FIXME: there will be std::span in C++20
       static_assert(is_messageable<typename T::value_type>::value, "span can only be created for messageable types");
-      DataRef ref = get<DataRef>(binding);
       auto header = header::get<const header::DataHeader*>(ref.header);
       assert(header);
       if (sizeof(typename T::value_type) > 1 && header->payloadSerializationMethod != o2::header::gSerializationMethodNone) {
@@ -269,7 +286,7 @@ class InputRecord
       }
       using ValueT = typename T::value_type;
       if (header->payloadSize % sizeof(ValueT)) {
-        throw std::runtime_error("Inconsistent type and payload size at " + std::string(binding) +
+        throw std::runtime_error("Inconsistent type and payload size at " + std::string(ref.spec->binding) +
                                  ": type size " + std::to_string(sizeof(ValueT)) +
                                  "  payload size " + std::to_string(header->payloadSize));
       }
@@ -279,7 +296,6 @@ class InputRecord
     } else if constexpr (is_container<T>::value) {
       // currently implemented only for vectors
       if constexpr (is_specialization<typename std::remove_const<T>::type, std::vector>::value) {
-        DataRef ref = get<DataRef>(binding);
         auto header = o2::header::get<const DataHeader*>(ref.header);
         auto method = header->payloadSerializationMethod;
         if (method == o2::header::gSerializationMethodNone) {
@@ -319,7 +335,6 @@ class InputRecord
       // unserialized objects
       using DataHeader = o2::header::DataHeader;
 
-      DataRef ref = get<DataRef>(binding);
       auto header = o2::header::get<const DataHeader*>(ref.header);
       auto method = header->payloadSerializationMethod;
       if (method != o2::header::gSerializationMethodNone) {
@@ -337,7 +352,6 @@ class InputRecord
       using DataHeader = o2::header::DataHeader;
       using ValueT = typename std::remove_pointer<T>::type;
 
-      DataRef ref = get<DataRef>(binding);
       auto header = o2::header::get<const DataHeader*>(ref.header);
       auto method = header->payloadSerializationMethod;
       if (method == o2::header::gSerializationMethodNone) {
@@ -380,7 +394,6 @@ class InputRecord
       // the operation depends on the transmitted serialization method
       using DataHeader = o2::header::DataHeader;
 
-      DataRef ref = get<DataRef>(binding);
       auto header = o2::header::get<const DataHeader*>(ref.header);
       auto method = header->payloadSerializationMethod;
       if (method == o2::header::gSerializationMethodNone) {
@@ -528,6 +541,16 @@ class InputRecord
       return matches(o2::header::DataHeader{description, origin, subspec});
     }
 
+    ParentType const* parent() const
+    {
+      return mParent;
+    }
+
+    size_t position() const
+    {
+      return mPosition;
+    }
+
    private:
     size_t mPosition;
     size_t mSize;
@@ -535,8 +558,58 @@ class InputRecord
     ElementType mElement;
   };
 
-  using iterator = Iterator<InputRecord, DataRef>;
-  using const_iterator = Iterator<InputRecord, const DataRef>;
+  /// @class InputRecordIterator
+  /// An iterator over the input slots
+  /// It supports an iterator interface to access the parts in the slot
+  template <typename T>
+  class InputRecordIterator : public Iterator<InputRecord, T>
+  {
+   public:
+    using SelfType = InputRecordIterator;
+    using BaseType = Iterator<InputRecord, T>;
+    using value_type = typename BaseType::value_type;
+    using reference = typename BaseType::reference;
+    using pointer = typename BaseType::pointer;
+    using ElementType = typename std::remove_const<value_type>::type;
+    using iterator = Iterator<SelfType, T>;
+    using const_iterator = Iterator<SelfType, const T>;
+
+    InputRecordIterator(InputRecord const* parent, size_t position = 0, size_t size = 0)
+      : BaseType(parent, position, size)
+    {
+    }
+
+    /// Get element at {slotindex, partindex}
+    ElementType getByPos(size_t pos) const
+    {
+      return this->parent()->getByPos(this->position(), pos);
+    }
+
+    /// Check if slot is valid, index of part is not used
+    bool isValid(size_t = 0) const
+    {
+      return this->parent()->isValid(this->position());
+    }
+
+    /// Get number of parts in input slot
+    size_t size() const
+    {
+      return this->parent()->getNofParts(this->position());
+    }
+
+    const_iterator begin() const
+    {
+      return const_iterator(this, 0, size());
+    }
+
+    const_iterator end() const
+    {
+      return const_iterator(this, size());
+    }
+  };
+
+  using iterator = InputRecordIterator<DataRef>;
+  using const_iterator = InputRecordIterator<const DataRef>;
 
   const_iterator begin() const
   {

--- a/Framework/Core/include/Framework/InputRecord.h
+++ b/Framework/Core/include/Framework/InputRecord.h
@@ -167,19 +167,15 @@ class InputRecord
 
   DataRef getByPos(int pos) const
   {
-    if (pos * 2 + 1 > mSpan.size() || pos < 0) {
+    if (pos >= mSpan.size() || pos < 0) {
       throw std::runtime_error("Unknown message requested at position " + std::to_string(pos));
     }
     if (pos > mInputsSchema.size()) {
       throw std::runtime_error("Unknown schema at position" + std::to_string(pos));
     }
-    if (mSpan.get(pos * 2) != nullptr && mSpan.get(pos * 2 + 1) != nullptr) {
-      return DataRef{&mInputsSchema[pos].matcher,
-                     mSpan.get(pos * 2),
-                     mSpan.get(pos * 2 + 1)};
-    } else {
-      return DataRef{&mInputsSchema[pos].matcher, nullptr, nullptr};
-    }
+    auto ref = mSpan.get(pos);
+    ref.spec = &mInputsSchema[pos].matcher;
+    return ref;
   }
 
   template <typename T = DataRef, typename std::enable_if_t<std::is_same<T, DataRef>::value == true, int> = 0>
@@ -433,7 +429,7 @@ class InputRecord
 
   size_t size() const
   {
-    return mSpan.size() / 2;
+    return mSpan.size();
   }
 
   template <typename T>

--- a/Framework/Core/include/Framework/InputRecord.h
+++ b/Framework/Core/include/Framework/InputRecord.h
@@ -170,7 +170,7 @@ class InputRecord
     if (pos >= mSpan.size() || pos < 0) {
       throw std::runtime_error("Unknown message requested at position " + std::to_string(pos));
     }
-    if (part >= getNofParts(pos)) {
+    if (part > 0 && part >= getNofParts(pos)) {
       throw std::runtime_error("Invalid message part index at " + std::to_string(pos) + ":" + std::to_string(part));
     }
     if (pos >= mInputsSchema.size()) {

--- a/Framework/Core/include/Framework/MessageSet.h
+++ b/Framework/Core/include/Framework/MessageSet.h
@@ -1,0 +1,79 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef FRAMEWORK_MESSAGESET_H
+#define FRAMEWORK_MESSAGESET_H
+
+#include "Framework/PartRef.h"
+#include <memory>
+#include <vector>
+
+namespace o2
+{
+namespace framework
+{
+
+/// A set of associated inflight messages.
+struct MessageSet {
+  std::vector<PartRef> parts;
+
+  size_t size() const
+  {
+    return parts.size();
+  }
+
+  void clear()
+  {
+    parts.clear();
+  }
+
+  PartRef& operator[](size_t index)
+  {
+    return parts[index];
+  }
+
+  PartRef const& operator[](size_t index) const
+  {
+    return parts[index];
+  }
+
+  PartRef& at(size_t index)
+  {
+    return parts.at(index);
+  }
+
+  PartRef const& at(size_t index) const
+  {
+    return parts.at(index);
+  }
+
+  decltype(auto) begin()
+  {
+    return parts.begin();
+  }
+
+  decltype(auto) begin() const
+  {
+    return parts.begin();
+  }
+
+  decltype(auto) end()
+  {
+    return parts.end();
+  }
+
+  decltype(auto) end() const
+  {
+    return parts.end();
+  }
+};
+
+} // namespace framework
+} // namespace o2
+#endif // FRAMEWORK_MESSAGESET_H

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -40,6 +40,7 @@
 
 #include <vector>
 #include <memory>
+#include <unordered_map>
 
 using namespace o2::framework;
 using Key = o2::monitoring::tags::Key;
@@ -589,6 +590,10 @@ bool DataProcessingDevice::tryDispatchComputation()
   // FIXME: do it in a smarter way than O(N^2)
   auto forwardInputs = [&reportError, &forwards, &device, &currentSetOfInputs](TimesliceSlot slot, InputRecord& record) {
     assert(record.size() == currentSetOfInputs.size());
+    // we collect all messages per forward in a map and send them together
+    // because the forwards are stable during this function, we use the pointer
+    // to channel string as key to avoid string allocation in the map
+    std::unordered_map<const std::string*, FairMQParts> forwardedParts;
     for (size_t ii = 0, ie = record.size(); ii < ie; ++ii) {
       DataRef input = record.getByPos(ii);
 
@@ -639,15 +644,20 @@ bool DataProcessingDevice::tryDispatchComputation()
             LOG(ERROR) << "Forwarded data does not have a DataHeader";
             continue;
           }
-          FairMQParts forwardedParts;
-          forwardedParts.AddPart(std::move(header));
-          forwardedParts.AddPart(std::move(payload));
-          assert(forwardedParts.Size() == 2);
-          assert(o2::header::get<DataProcessingHeader*>(forwardedParts.At(0)->GetData()));
-          // FIXME: this should use a correct subchannel
-          device.Send(forwardedParts, forward.channel, 0);
+          const std::string* key = &(forward.channel);
+          forwardedParts[key].AddPart(std::move(header));
+          forwardedParts[key].AddPart(std::move(payload));
         }
       }
+    }
+    for (auto& [channelName, channelParts] : forwardedParts) {
+      if (channelParts.Size() == 0) {
+        continue;
+      }
+      assert(channelParts.Size() % 2 == 0);
+      assert(o2::header::get<DataProcessingHeader*>(channelParts.At(0)->GetData()));
+      // in DPL we are using subchannel 0 only
+      device.Send(channelParts, *channelName, 0);
     }
   };
 

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -497,10 +497,15 @@ bool DataProcessingDevice::tryDispatchComputation()
   // the execution.
   auto fillInputs = [&relayer, &inputsSchema, &currentSetOfInputs](TimesliceSlot slot) -> InputRecord {
     currentSetOfInputs = std::move(relayer.getInputsForTimeslice(slot));
-    InputSpan span{[&currentSetOfInputs](size_t i) -> char const* {
-                     return currentSetOfInputs.at(i) ? static_cast<char const*>(currentSetOfInputs.at(i)->GetData()) : nullptr;
-                   },
-                   currentSetOfInputs.size()};
+    auto getter = [&currentSetOfInputs](size_t i) -> DataRef {
+      if (currentSetOfInputs.at(2 * i) && currentSetOfInputs.at(2 * i + 1)) {
+        return DataRef{nullptr,
+                       static_cast<char const*>(currentSetOfInputs.at(2 * i)->GetData()),
+                       static_cast<char const*>(currentSetOfInputs.at(2 * i + 1)->GetData())};
+      }
+      return DataRef{nullptr, nullptr, nullptr};
+    };
+    InputSpan span{getter, currentSetOfInputs.size() / 2};
     return InputRecord{inputsSchema, std::move(span)};
   };
 

--- a/Framework/Core/src/DataRelayer.cxx
+++ b/Framework/Core/src/DataRelayer.cxx
@@ -469,8 +469,7 @@ std::vector<o2::framework::MessageSet> DataRelayer::getInputsForTimeslice(Timesl
 {
   const auto numInputTypes = mDistinctRoutesIndex.size();
   // State of the computation
-  std::vector<MessageSet> messages;
-  messages.reserve(numInputTypes);
+  std::vector<MessageSet> messages(numInputTypes);
   auto& cache = mCache;
   auto& index = mTimesliceIndex;
   auto& metrics = mMetrics;
@@ -492,7 +491,7 @@ std::vector<o2::framework::MessageSet> DataRelayer::getInputsForTimeslice(Timesl
     // TODO: in the original implementation of the cache, there have been only two messages per entry,
     // check if the 2 above corresponds to the number of messages.
     if (cache[cacheId].size() > 0) {
-      messages.emplace_back(std::move(cache[cacheId]));
+      messages[arg] = std::move(cache[cacheId]);
     }
     index.markAsInvalid(s);
   };

--- a/Framework/Core/src/DataRelayer.cxx
+++ b/Framework/Core/src/DataRelayer.cxx
@@ -244,13 +244,10 @@ DataRelayer::RelayChoice
     auto cacheIdx = numInputTypes * slot.index + input;
     std::vector<PartRef>& parts = cache[cacheIdx].parts;
     cachedStateMetrics[cacheIdx] = 1;
-    // TODO: here we have to change the logic if we want to allow more than one
-    // message pair
-    if (parts.size() == 0) {
-      parts.resize(1);
-    }
-    parts[0].header = std::move(header);
-    parts[0].payload = std::move(payload);
+    // TODO: make sure that multiple parts can only be added within the same call of
+    // DataRelayer::relay
+    PartRef entry{std::move(header), std::move(payload)};
+    parts.emplace_back(std::move(entry));
     assert(header.get() == nullptr && payload.get() == nullptr);
   };
 

--- a/Framework/Core/src/InputRecord.cxx
+++ b/Framework/Core/src/InputRecord.cxx
@@ -36,7 +36,6 @@ InputRecord::InputRecord(std::vector<InputRoute> const& inputsSchema,
   : mInputsSchema{inputsSchema},
     mSpan{span}
 {
-  assert(mSpan.size() % 2 == 0);
 }
 
 int InputRecord::getPos(const char* binding) const

--- a/Framework/Core/test/benchmark_DataRelayer.cxx
+++ b/Framework/Core/test/benchmark_DataRelayer.cxx
@@ -107,7 +107,8 @@ static void BM_RelaySingleSlot(benchmark::State& state)
     assert(ready[0].slot.index == 0);
     assert(ready[0].op == CompletionPolicy::CompletionOp::Consume);
     auto result = relayer.getInputsForTimeslice(ready[0].slot);
-    assert(result.size() == 2);
+    assert(result.size() == 1);
+    assert(result.at(0).size() == 1);
   }
   // One for the header, one for the payload
 }
@@ -157,7 +158,8 @@ static void BM_RelayMultipleSlots(benchmark::State& state)
     assert(ready.size() == 1);
     assert(ready[0].op == CompletionPolicy::CompletionOp::Consume);
     auto result = relayer.getInputsForTimeslice(ready[0].slot);
-    assert(result.size() == 2);
+    assert(result.size() == 1);
+    assert(result.at(0).size() == 1);
   }
   // One for the header, one for the payload
 }
@@ -228,7 +230,9 @@ static void BM_RelayMultipleRoutes(benchmark::State& state)
     assert(ready.size() == 1);
     assert(ready[0].op == CompletionPolicy::CompletionOp::Consume);
     auto result = relayer.getInputsForTimeslice(ready[0].slot);
-    assert(result.size() == 4);
+    assert(result.size() == 2);
+    assert(result.at(0).size() == 1);
+    assert(result.at(1).size() == 1);
   }
   // One for the header, one for the payload
 }

--- a/Framework/Core/test/benchmark_InputRecord.cxx
+++ b/Framework/Core/test/benchmark_InputRecord.cxx
@@ -45,7 +45,7 @@ static void BM_InputRecordGenericGetters(benchmark::State& state)
     createRoute("z_source", spec3)};
   // First of all we test if an empty registry behaves as expected, raising a
   // bunch of exceptions.
-  InputRecord emptyRecord(schema, {[](size_t) { return nullptr; }, 0});
+  InputRecord emptyRecord(schema, {[](size_t) { return DataRef{nullptr, nullptr, nullptr}; }, 0});
 
   std::vector<void*> inputs;
 
@@ -78,7 +78,7 @@ static void BM_InputRecordGenericGetters(benchmark::State& state)
   createMessage(dh1, 1);
   createMessage(dh2, 2);
   createEmpty();
-  InputSpan span{[&inputs](size_t i) { return static_cast<char const*>(inputs[i]); }, inputs.size()};
+  InputSpan span{[&inputs](size_t i) { return DataRef{nullptr, static_cast<char const*>(inputs[2 * i]), static_cast<char const*>(inputs[2 * i + 1])}; }, inputs.size() / 2};
   InputRecord record{schema, std::move(span)};
 
   for (auto _ : state) {

--- a/Framework/Core/test/test_DataAllocator.cxx
+++ b/Framework/Core/test/test_DataAllocator.cxx
@@ -126,6 +126,14 @@ DataProcessorSpec getSourceSpec()
     messageablevector.push_back(a);
     messageablevector.emplace_back(10, 20, 0xacdc);
 
+    // create multiple parts matching the same output spec with subspec wildcard
+    // we are using ConcreteDataTypeMatcher to define the output spec matcher independent
+    // of subspec (i.a. a wildcard), all data blcks will go on the same channel regardless
+    // of sebspec.
+    pc.outputs().make<int>(OutputRef{"multiparts", 0}) = 10;
+    pc.outputs().make<int>(OutputRef{"multiparts", 1}) = 20;
+    pc.outputs().make<int>(OutputRef{"multiparts", 2}) = 30;
+
     // make a PMR std::vector, make it large to test the auto transport buffer resize funtionality as well
     Output pmrOutputSpec{"TST", "PMRTESTVECTOR", 0};
     auto pmrvec = o2::vector<o2::test::TriviallyCopyable>(pc.outputs().getMemoryResource(pmrOutputSpec));
@@ -147,6 +155,9 @@ DataProcessorSpec getSourceSpec()
                             OutputSpec{{"makerootserlzblobj"}, "TST", "ROOTSERLZBLOBJ", 0, Lifetime::Timeframe},
                             OutputSpec{{"rootserlzblvector"}, "TST", "ROOTSERLZBLVECT", 0, Lifetime::Timeframe},
                             OutputSpec{{"messageablevector"}, "TST", "MSGABLVECTOR", 0, Lifetime::Timeframe},
+                            OutputSpec{{"multiparts"}, "TST", "MULTIPARTS", 0, Lifetime::Timeframe},
+                            OutputSpec{{"multiparts"}, "TST", "MULTIPARTS", 1, Lifetime::Timeframe},
+                            OutputSpec{{"multiparts"}, "TST", "MULTIPARTS", 2, Lifetime::Timeframe},
                             OutputSpec{"TST", "ADOPTCHUNK", 0, Lifetime::Timeframe},
                             OutputSpec{"TST", "MSGBLEROOTSRLZ", 0, Lifetime::Timeframe},
                             OutputSpec{"TST", "ROOTNONTOBJECT", 0, Lifetime::Timeframe},
@@ -161,9 +172,15 @@ DataProcessorSpec getSinkSpec()
 {
   auto processingFct = [](ProcessingContext& pc) {
     using DataHeader = o2::header::DataHeader;
-    for (auto& input : pc.inputs()) {
+    for (auto iit = pc.inputs().begin(), iend = pc.inputs().end(); iit != iend; ++iit) {
+      auto const& input = *iit;
+      LOG(INFO) << (*iit).spec->binding << " " << (iit.isValid() ? "is valid" : "is not valid");
+      if (iit.isValid() == false) {
+        continue;
+      }
       auto* dh = o2::header::get<const DataHeader*>(input.header);
-      LOG(INFO) << dh->dataOrigin.str << " " << dh->dataDescription.str << " " << dh->payloadSize;
+      LOG(INFO) << "{" << dh->dataOrigin.str << ":" << dh->dataDescription.str << ":" << dh->subSpecification << "}"
+                << " payload size " << dh->payloadSize;
 
       using DumpStackFctType = std::function<void(const o2::header::BaseHeader*)>;
       DumpStackFctType dumpStack = [&](const o2::header::BaseHeader* h) {
@@ -175,6 +192,17 @@ DataProcessorSpec getSinkSpec()
       };
 
       dumpStack(dh);
+
+      if ((*iit).spec->binding == "inputMP") {
+        LOG(INFO) << "inputMP with " << iit.size() << " part(s)";
+        int nPart = 0;
+        for (auto const& ref : iit) {
+          LOG(INFO) << "accessing part " << nPart++ << " of input slot 'inputMP':"
+                    << pc.inputs().get<int>(ref);
+          ASSERT_ERROR(pc.inputs().get<int>(ref) == nPart * 10);
+        }
+        ASSERT_ERROR(nPart == 3);
+      }
     }
     // plain, unserialized object in input1 channel
     LOG(INFO) << "extracting o2::test::TriviallyCopyable from input1";
@@ -300,7 +328,8 @@ DataProcessorSpec getSinkSpec()
                             InputSpec{"input13", "TST", "MAKETOBJECT", 0, Lifetime::Timeframe},
                             InputSpec{"input14", "TST", "ROOTSERLZBLOBJ", 0, Lifetime::Timeframe},
                             InputSpec{"input15", "TST", "ROOTSERLZBLVECT", 0, Lifetime::Timeframe},
-                            InputSpec{"inputPMR", "TST", "PMRTESTVECTOR", 0, Lifetime::Timeframe}},
+                            InputSpec{"inputPMR", "TST", "PMRTESTVECTOR", 0, Lifetime::Timeframe},
+                            InputSpec{"inputMP", ConcreteDataTypeMatcher{"TST", "MULTIPARTS"}, Lifetime::Timeframe}},
                            Outputs{},
                            AlgorithmSpec(processingFct)};
 }

--- a/Framework/Core/test/test_DataRelayer.cxx
+++ b/Framework/Core/test/test_DataRelayer.cxx
@@ -65,8 +65,9 @@ BOOST_AUTO_TEST_CASE(TestNoWait)
   BOOST_CHECK_EQUAL(ready[0].slot.index, 0);
   BOOST_CHECK_EQUAL(ready[0].op, CompletionPolicy::CompletionOp::Consume);
   auto result = relayer.getInputsForTimeslice(ready[0].slot);
-  // One for the header, one for the payload
-  BOOST_REQUIRE_EQUAL(result.size(), 2);
+  // one MessageSet with one PartRef with header and payload
+  BOOST_REQUIRE_EQUAL(result.size(), 1);
+  BOOST_REQUIRE_EQUAL(result.at(0).size(), 1);
 }
 
 //
@@ -104,8 +105,9 @@ BOOST_AUTO_TEST_CASE(TestNoWaitMatcher)
   BOOST_CHECK_EQUAL(ready[0].slot.index, 0);
   BOOST_CHECK_EQUAL(ready[0].op, CompletionPolicy::CompletionOp::Consume);
   auto result = relayer.getInputsForTimeslice(ready[0].slot);
-  // One for the header, one for the payload
-  BOOST_REQUIRE_EQUAL(result.size(), 2);
+  // one MessageSet with one PartRef with header and payload
+  BOOST_REQUIRE_EQUAL(result.size(), 1);
+  BOOST_REQUIRE_EQUAL(result.at(0).size(), 1);
 }
 
 // This test a more complicated set of inputs, and verifies that data is
@@ -171,8 +173,10 @@ BOOST_AUTO_TEST_CASE(TestRelay)
   BOOST_CHECK_EQUAL(ready[0].op, CompletionPolicy::CompletionOp::Consume);
 
   auto result = relayer.getInputsForTimeslice(ready[0].slot);
-  // One for the header, one for the payload, for two inputs.
-  BOOST_REQUIRE_EQUAL(result.size(), 4);
+  // two MessageSets, each with one PartRef
+  BOOST_REQUIRE_EQUAL(result.size(), 2);
+  BOOST_REQUIRE_EQUAL(result.at(0).size(), 1);
+  BOOST_REQUIRE_EQUAL(result.at(1).size(), 1);
 }
 
 // This test a more complicated set of inputs, and verifies that data is
@@ -313,8 +317,8 @@ BOOST_AUTO_TEST_CASE(TestCache)
   auto result1 = relayer.getInputsForTimeslice(ready[0].slot);
   auto result2 = relayer.getInputsForTimeslice(ready[1].slot);
   // One for the header, one for the payload
-  BOOST_REQUIRE_EQUAL(result1.size(), 2);
-  BOOST_REQUIRE_EQUAL(result2.size(), 2);
+  BOOST_REQUIRE_EQUAL(result1.size(), 1);
+  BOOST_REQUIRE_EQUAL(result2.size(), 1);
 }
 
 // This the any policy. Even when there are two inputs, given the any policy

--- a/Framework/Core/test/test_InputRecord.cxx
+++ b/Framework/Core/test/test_InputRecord.cxx
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE(TestInputRecord)
     createRoute("z_source", spec3)};
   // First of all we test if an empty registry behaves as expected, raising a
   // bunch of exceptions.
-  InputRecord emptyRecord(schema, {[](size_t) { return nullptr; }, 0});
+  InputRecord emptyRecord(schema, {[](size_t) { return DataRef{nullptr, nullptr, nullptr}; }, 0});
 
   BOOST_CHECK_EXCEPTION(emptyRecord.get("x"), std::exception, any_exception);
   BOOST_CHECK_EXCEPTION(emptyRecord.get("y"), std::exception, any_exception);
@@ -87,7 +87,7 @@ BOOST_AUTO_TEST_CASE(TestInputRecord)
   createMessage(dh1, 1);
   createMessage(dh2, 2);
   createEmpty();
-  InputSpan span{[&inputs](size_t i) { return static_cast<char const*>(inputs[i]); }, inputs.size()};
+  InputSpan span{[&inputs](size_t i) { return DataRef{nullptr, static_cast<char const*>(inputs[2 * i]), static_cast<char const*>(inputs[2 * i + 1])}; }, inputs.size() / 2};
   InputRecord record{schema, std::move(span)};
 
   // Checking we can get the whole ref by name

--- a/Framework/Utils/test/test_RootTreeWriter.cxx
+++ b/Framework/Utils/test/test_RootTreeWriter.cxx
@@ -198,11 +198,13 @@ BOOST_AUTO_TEST_CASE(test_RootTreeWriter)
     {InputSpec{"input8", "TST", "SRLZDVEC"}, 8, "input8", 0},  //
   };
 
-  auto getter = [&store](size_t i) -> char const* { return static_cast<char const*>(store[i]->GetData()); };
+  auto getter = [&store](size_t i) -> DataRef {
+    return DataRef{nullptr, static_cast<char const*>(store[2 * i]->GetData()), static_cast<char const*>(store[2 * i + 1]->GetData())};
+  };
 
   InputRecord inputs{
     schema,
-    InputSpan{getter, store.size()}};
+    InputSpan{getter, store.size() / 2}};
 
   writer(inputs);
   writer.close();


### PR DESCRIPTION
Implementing support for multiple input parts per cache entry. @ktf in the end I decided to keep the layout of the cache and indexing. My original idea was to store an `{index, number of entries}`-pair in the cache, the index referring to a position in a list of messages per input. But having separate lists for all the inputs, i.e. rows in the cache, is pretty much the same like having one list for all and using the existing indexing.

- CompletionPolicy API has been adjusted to work with `span<DataRef>` instead of `span<PartRef>`
- DataRelayer cache entries changed to `MessageSet` containing vector of `PartRef` owning the input messages
- extending `InputSpan` to hold multiple inputs per route
- extending `InputRecord` API to access multiple parts per input slots through an iterator API

So far only the existing functionality has been tested, i.e. with one message pair per cache entry.

Still actively working on this, TODO:
- [x] unit test for multiple inputs
- [x] unit test for forwarding of multiple inputs
- [ ] benchmark tests
- [x] add `InputRecord` API method to access multiple inputs per route
- [x] memcheck
- [x] get  AliceO2Group/QualityControl working with this PR