### PR TITLE
added functionality to write dangling outputs into root trees

### DIFF
--- a/Analysis/Tutorials/CMakeLists.txt
+++ b/Analysis/Tutorials/CMakeLists.txt
@@ -60,3 +60,7 @@ o2_add_executable(filters
                   PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME AnalysisTutorial)
 
+o2_add_executable(aodwriter
+                  SOURCES src/aodwriter.cxx
+                  PUBLIC_LINK_LIBRARIES O2::Framework
+                  COMPONENT_NAME AnalysisTutorial)

--- a/Analysis/Tutorials/aodwriter.cxx
+++ b/Analysis/Tutorials/aodwriter.cxx
@@ -1,0 +1,73 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+
+namespace o2::aod
+{
+  namespace etaphi
+  {
+    DECLARE_SOA_COLUMN(Eta, eta, float, "fEta1");
+    DECLARE_SOA_COLUMN(Phi, phi, long, "fPhi1");
+    DECLARE_SOA_COLUMN(Mom, mom, double,"fMom1");
+  } // namespace etaphi
+  
+  DECLARE_SOA_TABLE(EtaPhi, "AOD", "ETAPHI",
+                  etaphi::Eta, etaphi::Phi, etaphi::Mom);
+
+  namespace due
+  {
+    DECLARE_SOA_COLUMN(Eta, eta, short int,  "fEta2");
+    DECLARE_SOA_COLUMN(Phi, phi, double, "fPhi2");
+  } // namespace due
+  
+  DECLARE_SOA_TABLE(Due, "AOD", "DUE",
+                  due::Eta, due::Phi);
+} // namespace o2::aod
+
+using namespace o2;
+using namespace o2::framework;
+
+// This is a very simple example to test the
+// CommonDataProcessors::getGlobalAODSink
+struct ATask {
+  Produces<aod::EtaPhi> etaphi;
+  Produces<aod::Due> due;
+
+  void init(InitContext&)
+  {
+    count = 0;
+  }
+
+  void process(aod::Tracks const& tracks)
+  {
+    for (auto& track : tracks) {
+      float phi = asin(track.snp()) + track.alpha() + static_cast<float>(M_PI);
+      float eta = log(tan(0.25f * static_cast<float>(M_PI) - 0.5f * atan(track.tgl())));
+      float mom = track.tgl();
+      
+      etaphi(phi, eta, mom);
+      due(phi, eta);
+      count++;
+    }
+    LOG(INFO) << "number of tracks: " << count << std::endl;;
+  }
+
+  size_t count = 0;
+  
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const&)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<ATask>("produce-etaphi"),
+  };
+}

--- a/Analysis/Tutorials/src/aodwriter.cxx
+++ b/Analysis/Tutorials/src/aodwriter.cxx
@@ -13,23 +13,23 @@
 
 namespace o2::aod
 {
-  namespace etaphi
-  {
-    DECLARE_SOA_COLUMN(Eta, eta, float, "fEta1");
-    DECLARE_SOA_COLUMN(Phi, phi, long, "fPhi1");
-    DECLARE_SOA_COLUMN(Mom, mom, double,"fMom1");
-  } // namespace etaphi
-  
-  DECLARE_SOA_TABLE(EtaPhi, "AOD", "ETAPHI",
+namespace etaphi
+{
+DECLARE_SOA_COLUMN(Eta, eta, float, "fEta1");
+DECLARE_SOA_COLUMN(Phi, phi, long, "fPhi1");
+DECLARE_SOA_COLUMN(Mom, mom, double, "fMom1");
+} // namespace etaphi
+
+DECLARE_SOA_TABLE(EtaPhi, "AOD", "ETAPHI",
                   etaphi::Eta, etaphi::Phi, etaphi::Mom);
 
-  namespace due
-  {
-    DECLARE_SOA_COLUMN(Eta, eta, short int,  "fEta2");
-    DECLARE_SOA_COLUMN(Phi, phi, double, "fPhi2");
-  } // namespace due
-  
-  DECLARE_SOA_TABLE(Due, "AOD", "DUE",
+namespace due
+{
+DECLARE_SOA_COLUMN(Eta, eta, short int, "fEta2");
+DECLARE_SOA_COLUMN(Phi, phi, double, "fPhi2");
+} // namespace due
+
+DECLARE_SOA_TABLE(Due, "AOD", "DUE",
                   due::Eta, due::Phi);
 } // namespace o2::aod
 
@@ -53,16 +53,16 @@ struct ATask {
       float phi = asin(track.snp()) + track.alpha() + static_cast<float>(M_PI);
       float eta = log(tan(0.25f * static_cast<float>(M_PI) - 0.5f * atan(track.tgl())));
       float mom = track.tgl();
-      
+
       etaphi(phi, eta, mom);
       due(phi, eta);
       count++;
     }
-    LOG(INFO) << "number of tracks: " << count << std::endl;;
+    LOG(INFO) << "number of tracks: " << count << std::endl;
+    ;
   }
 
   size_t count = 0;
-  
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const&)

--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -222,6 +222,7 @@ foreach(b
         WorkflowHelpers
         ASoA
         HistogramRegistry
+        Table2Tree
         )
   o2_add_test(benchmark_${b} NAME test_Framework_benchmark_${b}
               SOURCES test/benchmark_${b}.cxx

--- a/Framework/Core/include/Framework/CommonDataProcessors.h
+++ b/Framework/Core/include/Framework/CommonDataProcessors.h
@@ -12,6 +12,7 @@
 
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/InputSpec.h"
+#include "TTree.h"
 
 #include <vector>
 
@@ -32,6 +33,11 @@ struct CommonDataProcessors {
   /// not going to be used by the returned DataProcessorSpec.
   static DataProcessorSpec getGlobalFileSink(std::vector<InputSpec> const& danglingInputs,
                                              std::vector<InputSpec>& unmatched);
+  /// Helper function to create and write TTree
+  static void table2tree(TTree* tout,
+                         std::shared_ptr<arrow::Table> table,
+                         bool tupdate);
+  static DataProcessorSpec getGlobalAODSink(std::vector<InputSpec> const& danglingInputs);
   /// @return a dummy DataProcessorSpec which requires all the passed @a InputSpec
   /// and simply discards them.
   static DataProcessorSpec getDummySink(std::vector<InputSpec> const& danglingInputs);

--- a/Framework/Core/src/CommonDataProcessors.cxx
+++ b/Framework/Core/src/CommonDataProcessors.cxx
@@ -137,6 +137,9 @@ class branchIterator
         case arrow::Type::type::INT64:
           leaflist = col->name() + "/L";
           break;
+        default:
+          LOG(FATAL) << "Type not handled: " << dt << std::endl;
+          break;
       }
 
       br = tree->Branch(brn, dbuf, leaflist.c_str());
@@ -181,6 +184,9 @@ class branchIterator
       case arrow::Type::type::INT64:
         vL = (Long64_t*)std::dynamic_pointer_cast<arrow::NumericArray<arrow::Int64Type>>(chs.at(ib))->raw_values();
         v = (void*)vL;
+        break;
+      default:
+        LOG(FATAL) << "Type not handled: " << dt << std::endl;
         break;
     }
     br->SetAddress(v);
@@ -264,6 +270,10 @@ class branchIterator
           break;
         case arrow::Type::type::INT64:
           v = (void*)vL++;
+          break;
+        default:
+          LOG(FATAL) << "Type not handled: " << dt << std::endl;
+          v = 0;
           break;
       }
     }

--- a/Framework/Core/src/CommonDataProcessors.cxx
+++ b/Framework/Core/src/CommonDataProcessors.cxx
@@ -28,7 +28,12 @@
 #include "Framework/OutputObjHeader.h"
 
 #include "TFile.h"
+#include "TTree.h"
 
+#include <ROOT/RSnapshotOptions.hxx>
+#include <ROOT/RDataFrame.hxx>
+#include <ROOT/RArrowDS.hxx>
+#include <ROOT/RVec.hxx>
 #include <chrono>
 #include <exception>
 #include <fstream>
@@ -63,6 +68,271 @@ struct InputObject {
 const static std::unordered_map<OutputObjHandlingPolicy, std::string> ROOTfileNames = {{OutputObjHandlingPolicy::AnalysisObject, "AnalysisResults.root"},
                                                                                        {OutputObjHandlingPolicy::QAObject, "QAResults.root"}};
 
+
+// =============================================================================
+// class branchIterator is a data iterator
+// it basically allows to iterate over the elements of an arrow::table::Column and
+// successively fill the branches with branchIterator::fillnext()
+// it is used in CommonDataProcessors::table2tree
+class branchIterator
+{
+
+  private:
+  const char *brn;          // branch name
+  arrow::ArrayVector chs;   // chunks
+  Int_t nchs;               // number of chunks
+  Int_t ich;                // chunk counter
+  Int_t nr;                 // number of rows
+  Int_t ir;                 // row counter
+
+  // data buffers for each data type
+  arrow::Type::type dt;
+  std::string leaflist;
+
+  TBranch *br   = nullptr;
+  
+  char *dbuf    = nullptr;
+  void *v       = nullptr;
+  
+  Float_t  *vF  = nullptr;
+  Double_t *vD  = nullptr;
+  UShort_t *vs  = nullptr;
+  UInt_t *vi    = nullptr;
+  ULong64_t *vl = nullptr;
+  Short_t *vS   = nullptr;
+  Int_t *vI     = nullptr;
+  Long64_t *vL  = nullptr;
+
+
+  // initialize a branch
+  void branchini(TTree *tree, std::shared_ptr<arrow::Column> col, bool tupdate)
+  {
+        
+    if (tupdate)
+    {
+      br = tree->GetBranch(brn);
+
+    } else {
+      
+      // create new branch of given data type
+      switch (dt) {
+        case arrow::Type::type::FLOAT:
+          leaflist = col->name()+"/F";
+          break;
+        case arrow::Type::type::DOUBLE:
+          leaflist = col->name()+"/D";
+          break;
+        case arrow::Type::type::UINT16:
+          leaflist = col->name()+"/s";
+          break;
+        case arrow::Type::type::UINT32:
+          leaflist = col->name()+"/i";
+          break;
+        case arrow::Type::type::UINT64:
+          leaflist = col->name()+"/l";
+          break;
+        case arrow::Type::type::INT16:
+          leaflist = col->name()+"/S";
+          break;
+        case arrow::Type::type::INT32:
+          leaflist = col->name()+"/I";
+          break;
+        case arrow::Type::type::INT64:
+          leaflist = col->name()+"/L";
+          break;
+      }
+
+      br = tree->Branch(brn,dbuf,leaflist.c_str());
+
+    }
+    if (!br)
+      throw std::runtime_error("Branch does not exist!");
+
+  };
+    
+  
+  // initialize chunk ib
+  void dbufini(Int_t ib)
+  {
+    // get next chunk of given data type dt
+    switch (dt)
+    {
+      case arrow::Type::type::FLOAT:
+        vF = (Float_t*)std::dynamic_pointer_cast<arrow::NumericArray<arrow::FloatType>>(chs.at(ib))->raw_values();
+        v = (void*) vF;
+        break;
+      case arrow::Type::type::DOUBLE:
+        vD = (Double_t*)std::dynamic_pointer_cast<arrow::NumericArray<arrow::DoubleType>>(chs.at(ib))->raw_values();
+        v = (void*) vD;
+        break;
+      case arrow::Type::type::UINT16:
+        vs = (UShort_t*)std::dynamic_pointer_cast<arrow::NumericArray<arrow::UInt16Type>>(chs.at(ib))->raw_values();
+        v = (void*) vs;
+        break;
+      case arrow::Type::type::UINT32:
+        vi = (UInt_t*)std::dynamic_pointer_cast<arrow::NumericArray<arrow::UInt32Type>>(chs.at(ib))->raw_values();
+        v = (void*) vi;
+        break;
+      case arrow::Type::type::UINT64:
+        vl = (ULong64_t*)std::dynamic_pointer_cast<arrow::NumericArray<arrow::UInt64Type>>(chs.at(ib))->raw_values();
+        v = (void*) vl;
+        break;
+      case arrow::Type::type::INT16:
+        vS = (Short_t*)std::dynamic_pointer_cast<arrow::NumericArray<arrow::Int16Type>>(chs.at(ib))->raw_values();
+        v = (void*) vS;
+        break;
+      case arrow::Type::type::INT32:
+        vI = (Int_t*)std::dynamic_pointer_cast<arrow::NumericArray<arrow::Int32Type>>(chs.at(ib))->raw_values();
+        v = (void*) vI;
+        break;
+      case arrow::Type::type::INT64:
+        vL = (Long64_t*)std::dynamic_pointer_cast<arrow::NumericArray<arrow::Int64Type>>(chs.at(ib))->raw_values();
+        v = (void*) vL;
+        break;
+    }
+    br->SetAddress(v);
+    
+    // reset number of rows nr and row counter ir
+    nr = chs.at(ib)->length();
+    ir = 0;
+  };
+    
+  
+  public:  
+  branchIterator()
+  {
+    dt = arrow::Type::type::NA;
+    nchs = 0;
+    ich  = 0;
+    nr   = 0;
+    ir   = 0;
+
+  };
+  branchIterator(TTree* tree, std::shared_ptr<arrow::Column> col, bool tupdate)
+  {
+    brn  = col->name().c_str();
+    dt   = col->type()->id();
+    chs  = col->data()->chunks();
+    nchs = chs.size();
+    
+    // initialize the branch
+    branchini(tree,col,tupdate);
+    
+    ich  = 0;
+    dbufini(ich);
+    LOG(DEBUG) << "datait: " << col->type()->ToString() << " with " << nchs << " chunks" << std::endl;
+
+  };
+  ~branchIterator();
+
+  // return branch
+  TBranch* branch() { return br; };
+  
+  // return the data type
+  arrow::Type::type type() { return dt; };
+  
+  // fills buffer with next value
+  // returns fals if end of buffer reached
+  bool fillnext()
+  {
+
+    // ich and ir contain the current chunk and row
+    // return the next element if available
+    if (ir>=nr)
+    {
+      ich++;
+      if (ich<nchs)
+      {
+        dbufini(ich);
+      } else {
+        // end of data buffer reached
+        return false;
+      }
+    } else {
+      switch (dt)
+      {
+        case arrow::Type::type::FLOAT:
+          v = (void*)vF++;
+          break;
+        case arrow::Type::type::DOUBLE:
+          v = (void*)vD++;
+          break;
+        case arrow::Type::type::UINT16:
+          v = (void*)vs++;
+          break;
+        case arrow::Type::type::UINT32:
+          v = (void*)vi++;
+          break;
+        case arrow::Type::type::UINT64:
+          v = (void*)vl++;
+          break;
+        case arrow::Type::type::INT16:
+          v = (void*)vS++;
+          break;
+        case arrow::Type::type::INT32:
+          v = (void*)vI++;
+          break;
+        case arrow::Type::type::INT64:
+          v = (void*)vL++;
+          break;
+      }
+    }
+    br->SetAddress(v);
+    ir++;
+    
+    return true;
+    
+  };
+    
+};
+
+// .............................................................................
+void CommonDataProcessors::table2tree(TTree* tout,
+                                      std::shared_ptr<arrow::Table> table,
+                                      bool tupdate)
+{
+
+  LOG(DEBUG) << "table2tree: " << table->num_columns();
+  
+  // first create a vector of branchIterators
+  std::vector<branchIterator*> itbuf;
+
+  for (int ii=0; ii<table->num_columns(); ii++)
+  {
+
+    auto col = table->column(ii);
+    const char *cname = col->name().c_str();
+  
+    // for each column get a branchIterator
+    // fill the branchIterator into a std::vector
+    branchIterator *brit = new branchIterator(tout,col,tupdate);
+    itbuf.push_back(brit);
+  
+  }
+  LOG(DEBUG) << "table2tree: size of itbuf " << itbuf.size();
+  
+  
+  // with this loop over the columns again as long as togo is true.
+  // togo is set false when any of the data iterators returns false
+  bool togo = true;
+  while (togo)
+  {
+    // fill the tree
+    tout->Fill();
+  
+    // update the branches
+    for (int ii=0; ii<table->num_columns(); ii++)
+      togo &= itbuf.at(ii)->fillnext();
+
+  }
+  
+  // write the tree
+  tout->Write("", TObject::kOverwrite);
+
+}
+
+
+// =============================================================================
 DataProcessorSpec CommonDataProcessors::getOutputObjSink(outputObjMap const& outMap)
 {
   auto writerFunction = [outMap](InitContext& ic) -> std::function<void(ProcessingContext&)> {
@@ -70,7 +340,7 @@ DataProcessorSpec CommonDataProcessors::getOutputObjSink(outputObjMap const& out
     auto outputObjects = std::make_shared<std::map<InputObjectRoute, InputObject>>();
 
     auto endofdatacb = [outputObjects](EndOfStreamContext& context) {
-      LOG(INFO) << "Writing merged objects to file";
+      LOG(DEBUG) << "Writing merged objects to file";
       std::string currentDirectory = "";
       std::string currentFile = "";
       TFile* f[OutputObjHandlingPolicy::numPolicies];
@@ -100,7 +370,7 @@ DataProcessorSpec CommonDataProcessors::getOutputObjSink(outputObjMap const& out
           f[i]->Close();
         }
       }
-      LOG(INFO) << "All outputs merged in their respective target files";
+      LOG(DEBUG) << "All outputs merged in their respective target files";
       context.services().get<ControlService>().readyToQuit(QuitRequest::All);
     };
 
@@ -175,6 +445,176 @@ DataProcessorSpec CommonDataProcessors::getOutputObjSink(outputObjMap const& out
   return spec;
 }
 
+
+// add sink for dangling AODs 
+DataProcessorSpec
+  CommonDataProcessors::getGlobalAODSink(std::vector<InputSpec> const& danglingOutputInputs)
+{
+
+  auto writerFunction = [danglingOutputInputs](InitContext& ic) -> std::function<void(ProcessingContext&)>
+  {
+    
+    LOG(DEBUG) << "======== getGlobalAODSink::Inint ==========";
+    
+    // analyze ic and take actions accordingly
+    auto fnbase     = ic.options().get<std::string>("res-file");
+    auto filemode   = ic.options().get<std::string>("res-mode");
+    auto keepString = ic.options().get<std::string>("keep");
+    auto ntfmerge   = ic.options().get<Int_t>("ntfmerge");
+    
+    // find out if any tables need to be saved
+    bool hasOutputsToWrite = true;
+    bool usematch          = false;
+    
+    
+    // use the parameter keep to create a matcher
+    std::shared_ptr<data_matcher::DataDescriptorMatcher> matcher;
+    if (!keepString.empty())
+    {
+      usematch = true;
+      auto [variables, outputMatcher] = DataDescriptorQueryBuilder::buildFromKeepConfig(keepString);
+      matcher = outputMatcher;
+      
+      VariableContext context;
+      for (auto& spec : danglingOutputInputs) {
+        auto concrete = DataSpecUtils::asConcreteDataMatcher(spec);
+        if (outputMatcher->match(concrete, context)) {
+          hasOutputsToWrite = true;
+        }
+      }
+    }
+
+    // if nothing needs to be saved then return a trivial functor
+    if (!hasOutputsToWrite) {
+      return std::move([](ProcessingContext& pc) mutable -> void {
+        static bool once = false;
+        if (!once) {
+          LOG(DEBUG) << "No dangling output to be saved.";
+          once = true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+      });
+    }
+    
+    // end of data functor is called at the end of the data stream
+    auto fout = std::make_shared<TFile>();
+    auto endofdatacb = [fout](EndOfStreamContext& context) {
+      
+      if (fout)
+        fout->Close();
+      
+      context.services().get<ControlService>().readyToQuit(QuitRequest::All);
+    
+    };
+
+    auto& callbacks = ic.services().get<CallbackService>();
+    callbacks.set(CallbackService::Id::EndOfStream, endofdatacb);
+ 
+
+    // this functor is called once per time frame
+    Int_t ntf = 0;
+    return std::move([fout,fnbase,filemode,ntf,ntfmerge,usematch,matcher](ProcessingContext& pc) mutable -> void {
+      LOG(DEBUG) << "======== getGlobalAODSink::processing ==========";
+      LOG(DEBUG) << " processing data set with " << pc.inputs().size() << " entries";
+      LOG(DEBUG) << " result are saved to " << fnbase << "_*.root";
+      
+      // return immediately if pc.inputs() is empty
+      auto ninputs = pc.inputs().size();
+      if (ninputs==0) {
+        LOG(DEBUG) << "no inputs available!";
+        return;
+      }
+      
+      // new strategy since RDataFrame::Snapshot does not work
+      //
+      // loop over all inputs and extract the arrow::tables
+      // create a tree for each arrow::table
+      // loop over the columns of a table
+      // for each column create a branch
+      // loop over the rows of the column
+      // fill the values into the corresponding branches
+      // write the table
+      // see table2tree
+      
+      // open new file if ntfmerge time frames is reached
+      LOG(DEBUG) << "This is time frame number "<< ntf;
+      bool tupdate = true;
+      std::string fname;
+      if ((ntf%ntfmerge)==0)
+      {
+        if (fout) fout->Close();
+        
+        fname = fnbase+"_"+std::to_string((Int_t)(ntf/ntfmerge))+".root";
+        fout =
+          std::make_shared<TFile>(fname.c_str(),filemode.c_str());
+        tupdate = false;
+      }
+      ntf++;
+      
+      // loop over the DataRefs which are contained in pc.inputs()
+      TTree *tout = nullptr;
+      VariableContext matchingContext;
+      for (const auto& ref : pc.inputs()) {
+        
+        // is this table to be saved?
+        auto dh = DataRefUtils::getHeader<header::DataHeader*>(ref);
+        // only arrow tables are processed here
+        if (dh->payloadSerializationMethod != o2::header::gSerializationMethodArrow)
+          continue;
+
+        // does it match the keep parameter
+        if (usematch && !matcher->match(*dh, matchingContext))
+          continue;
+
+
+        // get the table name
+        auto treename = dh->dataDescription.as<std::string>();
+    
+        // get the TableConsumer and convert it into an arrow table
+        auto s = pc.inputs().get<TableConsumer>(ref.spec->binding);
+        auto table = s->asArrowTable();
+        LOG(DEBUG) << "The tree name is " << treename; 
+        LOG(DEBUG) << "Number of columns " << table->num_columns(); 
+        LOG(DEBUG) << "Number of rows     " << table->num_rows();
+        
+        // we need finite number of rows and columns
+        if (table->num_columns()==0 || table->num_rows()==0)
+          continue;
+
+        
+        // this table needs to be saved to file
+        // create the corresponding tree
+        if (tupdate)
+        {
+          tout = (TTree*)fout->Get(treename.c_str());
+        } else {
+          tout = new TTree(treename.c_str(),treename.c_str());
+        }
+    
+        // write the table to the TTree
+        table2tree(tout,table,tupdate);
+
+      }
+      
+    });  
+  };      // end of writerFunction
+
+
+  DataProcessorSpec spec{
+    "internal-dpl-AOD-writter",
+    danglingOutputInputs,
+    Outputs{},
+    AlgorithmSpec(writerFunction),
+    {{"res-file", VariantType::String, "AnalysisResults", {"Name of the output file"}},
+     {"res-mode", VariantType::String, "RECREATE",        {"Creation mode of the result file: NEW, CREATE, RECREATE, UPDATE"}},
+     {"ntfmerge", VariantType::Int,     10,               {"number of time frames to merge into one file"}},
+     {"keep",     VariantType::String,  "",               {"Comma separated list of ORIGIN/DESCRIPTION/SUBSPECIFICATION to save in outfile"}}}
+  };
+
+  return spec;
+}
+
+
 DataProcessorSpec
   CommonDataProcessors::getGlobalFileSink(std::vector<InputSpec> const& danglingOutputInputs,
                                           std::vector<InputSpec>& unmatched)
@@ -202,7 +642,7 @@ DataProcessorSpec
         /// We do it like this until we can use the interruptible sleep
         /// provided by recent FairMQ releases.
         if (!once) {
-          LOG(INFO) << "No dangling output to be dumped.";
+          LOG(DEBUG) << "No dangling output to be dumped.";
           once = true;
         }
         std::this_thread::sleep_for(std::chrono::milliseconds(1000));
@@ -211,9 +651,9 @@ DataProcessorSpec
     auto output = std::make_shared<std::ofstream>(filename.c_str(), std::ios_base::binary);
     return std::move([output, matcher = outputMatcher](ProcessingContext& pc) mutable -> void {
       VariableContext matchingContext;
-      LOG(INFO) << "processing data set with " << pc.inputs().size() << " entries";
+      LOG(DEBUG) << "processing data set with " << pc.inputs().size() << " entries";
       for (const auto& entry : pc.inputs()) {
-        LOG(INFO) << "  " << *(entry.spec);
+        LOG(DEBUG) << "  " << *(entry.spec);
         auto header = DataRefUtils::getHeader<header::DataHeader*>(entry);
         auto dataProcessingHeader = DataRefUtils::getHeader<DataProcessingHeader*>(entry);
         if (matcher->match(*header, matchingContext) == false) {
@@ -222,7 +662,7 @@ DataProcessorSpec
         output->write(reinterpret_cast<char const*>(header), sizeof(header::DataHeader));
         output->write(reinterpret_cast<char const*>(dataProcessingHeader), sizeof(DataProcessingHeader));
         output->write(entry.payload, o2::framework::DataRefUtils::getPayloadSize(entry));
-        LOG(INFO) << "wrote data, size " << o2::framework::DataRefUtils::getPayloadSize(entry);
+        LOG(DEBUG) << "wrote data, size " << o2::framework::DataRefUtils::getPayloadSize(entry);
       }
     });
   };

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -251,11 +251,13 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
         requestedAODs.emplace_back(input);
       }
     }
+    
     for (size_t oi = 0; oi < processor.outputs.size(); ++oi) {
       auto& output = processor.outputs[oi];
       if (DataSpecUtils::partialMatch(output, header::DataOrigin{"AOD"})) {
         providedAODs.emplace_back(output);
-      } else if (DataSpecUtils::partialMatch(output, header::DataOrigin{"ATSK"})) {
+        
+     } else if (DataSpecUtils::partialMatch(output, header::DataOrigin{"ATSK"})) {
         providedOutputObj.emplace_back(output);
         outMap.insert({output.binding.value, processor.name});
       }
@@ -298,10 +300,22 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
 
   workflow.insert(workflow.end(), extraSpecs.begin(), extraSpecs.end());
 
-  /// This will inject a file sink so that any dangling
-  /// output is actually written to it.
+  /// This will create file sinks for dangling outputs of origin ...
+  ///   . AOD         - getGlobalAODSink
+  ///   . not AOD     - getGlobalFileSink
+  ///
+  // First find all the dangling ouputs
   auto danglingOutputsInputs = computeDanglingOutputs(workflow);
+  
+  // From that list select the ones of origin AOD ...
+  // .. and remove them also from the original list
+  LOG(DEBUG) << "1 danglingOutputsInputs.size() " << danglingOutputsInputs.size() << std::endl;
+  auto danglingOutputsInputsAOD = selectAODs(danglingOutputsInputs);
+  LOG(DEBUG) << "2 danglingOutputsInputsAOD.size() " << danglingOutputsInputsAOD.size() << std::endl;
+  LOG(DEBUG) << "2 danglingOutputsInputs.size() " << danglingOutputsInputs.size() << std::endl;
 
+  
+  // file sink for notAOD dangling outputs
   extraSpecs.clear();
 
   std::vector<InputSpec> unmatched;
@@ -313,6 +327,16 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
   }
   if (unmatched.size() > 0) {
     extraSpecs.push_back(CommonDataProcessors::getDummySink(unmatched));
+  }
+  workflow.insert(workflow.end(), extraSpecs.begin(), extraSpecs.end());
+
+
+  // file sink for AOD dangling outputs
+  extraSpecs.clear();
+
+  if (danglingOutputsInputsAOD.size() > 0) {
+    auto fileSink = CommonDataProcessors::getGlobalAODSink(danglingOutputsInputsAOD);
+    extraSpecs.push_back(fileSink);
   }
   workflow.insert(workflow.end(), extraSpecs.begin(), extraSpecs.end());
 }
@@ -621,6 +645,7 @@ struct DataMatcherId {
 
 std::vector<InputSpec> WorkflowHelpers::computeDanglingOutputs(WorkflowSpec const& workflow)
 {
+  
   std::vector<DataMatcherId> inputs;
   std::vector<DataMatcherId> outputs;
   std::vector<InputSpec> results;
@@ -665,15 +690,46 @@ std::vector<InputSpec> WorkflowHelpers::computeDanglingOutputs(WorkflowSpec cons
 
     if (matched == false) {
       auto& outputSpec = workflow[output.workflowId].outputs[output.id];
+      
       auto input = DataSpecUtils::matchingInput(outputSpec);
       char buf[64];
       input.binding = (snprintf(buf, 63, "dangling_%zu_%zu", output.workflowId, output.id), buf);
       results.emplace_back(input);
+      
     }
   }
 
   return results;
 }
+
+std::vector<InputSpec> WorkflowHelpers::selectAODs(std::vector<InputSpec> &specs)
+{
+  LOG(DEBUG) << "Selecting dangling OutputSpecs of origin AOD - " << specs.size();
+  
+  // create result list
+  std::vector<InputSpec> results;
+  for (auto specit = specs.begin(); specit != specs.end(); ) {
+
+    // only add if origin=="AOD"
+    if (DataSpecUtils::partialMatch(*specit, header::DataOrigin("AOD")))
+    {
+      // add it to the AOD list ...
+      results.emplace_back(*specit);
+    
+      // ... and remove it from the original list
+      specit = specs.erase(specit);
+    } else {
+      ++specit;
+    }
+  }
+
+  LOG(DEBUG) << "Number of AODs " << results.size() << " - " << specs.size() << std::endl;
+  
+  return results;
+
+}
+
+
 
 } // namespace framework
 } // namespace o2

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -251,13 +251,13 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
         requestedAODs.emplace_back(input);
       }
     }
-    
+
     for (size_t oi = 0; oi < processor.outputs.size(); ++oi) {
       auto& output = processor.outputs[oi];
       if (DataSpecUtils::partialMatch(output, header::DataOrigin{"AOD"})) {
         providedAODs.emplace_back(output);
-        
-     } else if (DataSpecUtils::partialMatch(output, header::DataOrigin{"ATSK"})) {
+
+      } else if (DataSpecUtils::partialMatch(output, header::DataOrigin{"ATSK"})) {
         providedOutputObj.emplace_back(output);
         outMap.insert({output.binding.value, processor.name});
       }
@@ -306,7 +306,7 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
   ///
   // First find all the dangling ouputs
   auto danglingOutputsInputs = computeDanglingOutputs(workflow);
-  
+
   // From that list select the ones of origin AOD ...
   // .. and remove them also from the original list
   LOG(DEBUG) << "1 danglingOutputsInputs.size() " << danglingOutputsInputs.size() << std::endl;
@@ -314,7 +314,6 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
   LOG(DEBUG) << "2 danglingOutputsInputsAOD.size() " << danglingOutputsInputsAOD.size() << std::endl;
   LOG(DEBUG) << "2 danglingOutputsInputs.size() " << danglingOutputsInputs.size() << std::endl;
 
-  
   // file sink for notAOD dangling outputs
   extraSpecs.clear();
 
@@ -329,7 +328,6 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
     extraSpecs.push_back(CommonDataProcessors::getDummySink(unmatched));
   }
   workflow.insert(workflow.end(), extraSpecs.begin(), extraSpecs.end());
-
 
   // file sink for AOD dangling outputs
   extraSpecs.clear();
@@ -645,7 +643,7 @@ struct DataMatcherId {
 
 std::vector<InputSpec> WorkflowHelpers::computeDanglingOutputs(WorkflowSpec const& workflow)
 {
-  
+
   std::vector<DataMatcherId> inputs;
   std::vector<DataMatcherId> outputs;
   std::vector<InputSpec> results;
@@ -690,32 +688,30 @@ std::vector<InputSpec> WorkflowHelpers::computeDanglingOutputs(WorkflowSpec cons
 
     if (matched == false) {
       auto& outputSpec = workflow[output.workflowId].outputs[output.id];
-      
+
       auto input = DataSpecUtils::matchingInput(outputSpec);
       char buf[64];
       input.binding = (snprintf(buf, 63, "dangling_%zu_%zu", output.workflowId, output.id), buf);
       results.emplace_back(input);
-      
     }
   }
 
   return results;
 }
 
-std::vector<InputSpec> WorkflowHelpers::selectAODs(std::vector<InputSpec> &specs)
+std::vector<InputSpec> WorkflowHelpers::selectAODs(std::vector<InputSpec>& specs)
 {
   LOG(DEBUG) << "Selecting dangling OutputSpecs of origin AOD - " << specs.size();
-  
+
   // create result list
   std::vector<InputSpec> results;
-  for (auto specit = specs.begin(); specit != specs.end(); ) {
+  for (auto specit = specs.begin(); specit != specs.end();) {
 
     // only add if origin=="AOD"
-    if (DataSpecUtils::partialMatch(*specit, header::DataOrigin("AOD")))
-    {
+    if (DataSpecUtils::partialMatch(*specit, header::DataOrigin("AOD"))) {
       // add it to the AOD list ...
       results.emplace_back(*specit);
-    
+
       // ... and remove it from the original list
       specit = specs.erase(specit);
     } else {
@@ -724,12 +720,9 @@ std::vector<InputSpec> WorkflowHelpers::selectAODs(std::vector<InputSpec> &specs
   }
 
   LOG(DEBUG) << "Number of AODs " << results.size() << " - " << specs.size() << std::endl;
-  
+
   return results;
-
 }
-
-
 
 } // namespace framework
 } // namespace o2

--- a/Framework/Core/src/WorkflowHelpers.h
+++ b/Framework/Core/src/WorkflowHelpers.h
@@ -172,6 +172,8 @@ struct WorkflowHelpers {
   /// a corresponding InputSpec. I.e. they are dangling.
   /// @return a vector of InputSpec which would have matched said dangling outputs.
   static std::vector<InputSpec> computeDanglingOutputs(WorkflowSpec const& workflow);
+  static std::vector<InputSpec> selectAODs(std::vector<InputSpec>&outputs);
+
 };
 
 } // namespace o2::framework

--- a/Framework/Core/src/WorkflowHelpers.h
+++ b/Framework/Core/src/WorkflowHelpers.h
@@ -172,8 +172,7 @@ struct WorkflowHelpers {
   /// a corresponding InputSpec. I.e. they are dangling.
   /// @return a vector of InputSpec which would have matched said dangling outputs.
   static std::vector<InputSpec> computeDanglingOutputs(WorkflowSpec const& workflow);
-  static std::vector<InputSpec> selectAODs(std::vector<InputSpec>&outputs);
-
+  static std::vector<InputSpec> selectAODs(std::vector<InputSpec>& outputs);
 };
 
 } // namespace o2::framework

--- a/Framework/Core/test/benchmark_Table2Tree.cxx
+++ b/Framework/Core/test/benchmark_Table2Tree.cxx
@@ -38,14 +38,13 @@ constexpr unsigned int maxrange = 20;
 
 static void BM_Table2Tree(benchmark::State& state)
 {
- 
+
   // initialize a random generator
   std::default_random_engine e1(1234567891);
   std::uniform_real_distribution<double> rd(0, 1);
-  std::normal_distribution<float>        rf(5.,2.);
-  std::discrete_distribution<long>       rl({10,20,30,30,5,5});
-  std::discrete_distribution<int>        ri({10,20,30,30,5,5});
-
+  std::normal_distribution<float> rf(5., 2.);
+  std::discrete_distribution<long> rl({10, 20, 30, 30, 5, 5});
+  std::discrete_distribution<int> ri({10, 20, 30, 30, 5, 5});
 
   // create a table and fill the columns with random numbers
   TableBuilder builder;
@@ -55,29 +54,25 @@ static void BM_Table2Tree(benchmark::State& state)
     rowWriter(0, rd(e1), rf(e1), rl(e1), ri(e1));
   }
   auto table = builder.finalize();
-    
-  
+
   // loop over elements of state
   for (auto _ : state) {
 
     // Open file and create tree
-    TFile *fout = new TFile("table2tree.root","RECREATE");
-    TTree *tout = new TTree("table2tree","table2tree");
+    TFile* fout = new TFile("table2tree.root", "RECREATE");
+    TTree* tout = new TTree("table2tree", "table2tree");
 
     // benchmark the CommonDataProcessors::table2tree function
-    CommonDataProcessors::table2tree(tout,table,false);
-    
+    CommonDataProcessors::table2tree(tout, table, false);
+
     // clean up
     fout->Close();
     delete fout;
-  
   }
 
-  state.SetBytesProcessed(state.iterations()*state.range(0)*24);
+  state.SetBytesProcessed(state.iterations() * state.range(0) * 24);
 }
 
 BENCHMARK(BM_Table2Tree)->Range(8, 8 << maxrange);
-
-
 
 BENCHMARK_MAIN();

--- a/Framework/Core/test/benchmark_Table2Tree.cxx
+++ b/Framework/Core/test/benchmark_Table2Tree.cxx
@@ -1,0 +1,83 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/ASoA.h"
+#include "Framework/TableBuilder.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/CommonDataProcessors.h"
+#include <benchmark/benchmark.h>
+#include <random>
+#include <vector>
+
+#include <TFile.h>
+
+using namespace o2::framework;
+using namespace arrow;
+using namespace o2::soa;
+
+namespace test
+{
+DECLARE_SOA_COLUMN(X, x, float, "x");
+DECLARE_SOA_COLUMN(Y, y, float, "y");
+DECLARE_SOA_COLUMN(Z, z, float, "z");
+DECLARE_SOA_DYNAMIC_COLUMN(Sum, sum, [](float x, float y) { return x + y; });
+} // namespace test
+
+#ifdef __APPLE__
+constexpr unsigned int maxrange = 15;
+#else
+constexpr unsigned int maxrange = 20;
+#endif
+
+static void BM_Table2Tree(benchmark::State& state)
+{
+ 
+  // initialize a random generator
+  std::default_random_engine e1(1234567891);
+  std::uniform_real_distribution<double> rd(0, 1);
+  std::normal_distribution<float>        rf(5.,2.);
+  std::discrete_distribution<long>       rl({10,20,30,30,5,5});
+  std::discrete_distribution<int>        ri({10,20,30,30,5,5});
+
+
+  // create a table and fill the columns with random numbers
+  TableBuilder builder;
+  auto rowWriter =
+    builder.persist<double, float, long, int>({"a", "b", "c", "d"});
+  for (auto i = 0; i < state.range(0); ++i) {
+    rowWriter(0, rd(e1), rf(e1), rl(e1), ri(e1));
+  }
+  auto table = builder.finalize();
+    
+  
+  // loop over elements of state
+  for (auto _ : state) {
+
+    // Open file and create tree
+    TFile *fout = new TFile("table2tree.root","RECREATE");
+    TTree *tout = new TTree("table2tree","table2tree");
+
+    // benchmark the CommonDataProcessors::table2tree function
+    CommonDataProcessors::table2tree(tout,table,false);
+    
+    // clean up
+    fout->Close();
+    delete fout;
+  
+  }
+
+  state.SetBytesProcessed(state.iterations()*state.range(0)*24);
+}
+
+BENCHMARK(BM_Table2Tree)->Range(8, 8 << maxrange);
+
+
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
This replaces #2842 (after needed rebase)
All code work by @pbuehler

update tabel2tree with
. parameters keep and ntfmerge
  keep: allows to specify the tables to save
  ntfmerge: the number of time frames to mege in a single file
. parameter res-file is not the base name of the output file, the actual filename is 'res-file'_'n'.root where n is a running counter
. if the keep parameter is empty (default) all dangling AOD outputs are saved