### PR TITLE
ITS-GPU: Fix undetected checkode errors

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/VectorHIP.h
+++ b/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/VectorHIP.h
@@ -15,7 +15,7 @@
 #ifndef O2_ITS_TRACKING_INCLUDE_VECTOR_HIP_H_
 #define O2_ITS_TRACKING_INCLUDE_VECTOR_HIP_H_
 
-#include <assert.h>
+#include <cassert>
 #include <new>
 #include <type_traits>
 #include <vector>

--- a/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/VertexerTraitsHIP.h
+++ b/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/VertexerTraitsHIP.h
@@ -44,10 +44,10 @@ class VertexerTraitsHIP : public VertexerTraits
  public:
 #ifdef _ALLOW_DEBUG_TREES_ITS_
   VertexerTraitsHIP();
-  virtual ~VertexerTraitsHIP();
+  ~VertexerTraitsHIP();
 #else
   VertexerTraitsHIP();
-  virtual ~VertexerTraitsHIP() = default;
+  ~VertexerTraitsHIP() = default;
 #endif
   void initialise(ROframe*) override;
   void computeTracklets() override;

--- a/Detectors/ITSMFT/ITS/tracking/hip/src/StreamHIP.hip.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/hip/src/StreamHIP.hip.cxx
@@ -26,7 +26,7 @@ StreamHIP::StreamHIP()
   (void)hipStreamCreateWithFlags(&mStream, hipStreamNonBlocking);
 }
 
-StreamHIP::~StreamHIP()
+StreamHIP::~StreamHIP() // NOLINT: clang-tidy doesn't understand hip macro magic, and thinks this is trivial
 {
   (void)hipStreamDestroy(mStream);
 }

--- a/Detectors/ITSMFT/ITS/tracking/hip/src/VertexerTraitsHIP.hip.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/hip/src/VertexerTraitsHIP.hip.cxx
@@ -15,7 +15,7 @@
 #include <iostream>
 #include <sstream>
 #include <array>
-#include <assert.h>
+#include <cassert>
 #include <hipcub/hipcub.hpp>
 
 #include "ITStracking/MathUtils.h"


### PR DESCRIPTION
Errors to fix:
```
/home/qon/alice-builder/sw/SOURCES/O2/v1.1.0/0/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/VectorHIP.h:18:10: error: inclusion of deprecated C++ header 'assert.h'; consider using 'cassert' instead [modernize-deprecated-headers]
/home/qon/alice-builder/sw/SOURCES/O2/v1.1.0/0/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/VertexerTraitsHIP.h:50:11: error: prefer using 'override' or (rarely) 'final' instead of 'virtual' [modernize-use-override]
/home/qon/alice-builder/sw/SOURCES/O2/v1.1.0/0/Detectors/ITSMFT/ITS/tracking/hip/src/StreamHIP.hip.cxx:24:12: error: use '= default' to define a trivial default constructor [modernize-use-equals-default]
/home/qon/alice-builder/sw/SOURCES/O2/v1.1.0/0/Detectors/ITSMFT/ITS/tracking/hip/src/StreamHIP.hip.cxx:29:12: error: use '= default' to define a trivial destructor [modernize-use-equals-default]
/home/qon/alice-builder/sw/SOURCES/O2/v1.1.0/0/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/VectorHIP.h:18:10: error: inclusion of deprecated C++ header 'assert.h'; consider using 'cassert' instead [modernize-deprecated-headers]
/home/qon/alice-builder/sw/SOURCES/O2/v1.1.0/0/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/VectorHIP.h:18:10: error: inclusion of deprecated C++ header 'assert.h'; consider using 'cassert' instead [modernize-deprecated-headers]
/home/qon/alice-builder/sw/SOURCES/O2/v1.1.0/0/Detectors/ITSMFT/ITS/tracking/hip/include/ITStrackingHIP/VertexerTraitsHIP.h:50:11: error: prefer using 'override' or (rarely) 'final' instead of 'virtual' [modernize-use-override]
/home/qon/alice-builder/sw/SOURCES/O2/v1.1.0/0/Detectors/ITSMFT/ITS/tracking/hip/src/VertexerTraitsHIP.hip.cxx:18:10: error: inclusion of deprecated C++ header 'assert.h'; consider using 'cassert' instead [modernize-deprecated-headers]
```