### PR TITLE
Excluding macros from the CI test

### DIFF
--- a/cmake/O2RootMacroExclusionList.cmake
+++ b/cmake/O2RootMacroExclusionList.cmake
@@ -18,6 +18,7 @@ include(O2GetListOfMacros)
 
 list(APPEND O2_ROOT_MACRO_EXCLUSION_LIST
             DataFormats/simulation/test/checkStack.C
+            Detectors/CPV/testsimulation/plot_dig_cpv.C
             Detectors/ITSMFT/ITS/macros/EVE/rootlogon.C
             Detectors/ITSMFT/ITS/macros/test/rootlogon.C
             Detectors/MUON/MCH/Simulation/macros/rootlogon.C


### PR DESCRIPTION
The following macros are failing the CI tests and are excluded
    Detectors/CPV/testsimulation/plot_dig_cpv.C

The error is weird, execution of the compiled macro is failing without any further
information. The warning is not understood at all, especially because there is no
library libO2DataFormatsCPV.so created by the project. In the installed project,
the class is defined once in libO2CPVBase.so.

    === Detectors/CPV/testsimulation/plot_dig_cpv.C_compiled - Process running as 16147 for attempt 2 ===
    Warning in <TInterpreter::ReadRootmapFile>: class  o2::cpv::Digit found in libO2DataFormatsCPV.so  is already in libO2CPVBase.so
    Info in <TUnixSystem::ACLiC>: creating shared library /mnt/mesos/sandbox/sandbox/sw/BUILD/6454ec8698ed06726ab4c956421ef6958d86612a/O2/compiled_macros//mnt/mesos/sandbox/sandbox/sw/SOURCES/O2/build_o2checkcode_o2/0/Detectors/CPV/testsimulation/plot_dig_cpv_C.so

     *** Break *** segmentation violation

Same error has been observed for Detectors/PHOS/testsimulation/plot_dig_cpv.C
before commit 7fae2eaa.