### PR TITLE
ZDC: Improvements on SpatialPhotonResponse

### DIFF
--- a/Detectors/ZDC/simulation/include/ZDCSimulation/SpatialPhotonResponse.h
+++ b/Detectors/ZDC/simulation/include/ZDCSimulation/SpatialPhotonResponse.h
@@ -50,10 +50,24 @@ class SpatialPhotonResponse
 
   bool hasSignal() const { return mPhotonSum > 0; }
   int getPhotonSum() const { return mPhotonSum; }
+  void setDetectorID(int det)
+  {
+    if (mDetectorID != -1 && det != mDetectorID) {
+      printErrMsg("trying to change detector ID");
+    }
+    mDetectorID = det;
+  }
+  int getDetectorID() const { return mDetectorID; }
+  void setHitTime(float t) { mTime = t; }
+  float getHitTime() const { return mTime; }
+
+  std::array<int, 5> getPhotonsPerChannel() const;
 
   std::vector<std::vector<int>> const& getImageData() const { return mImageData; }
 
  private:
+  void printErrMsg(const char* mgs) const;
+
   double mLxOfCell = 1.; // x length of cell corresponding to one pixel
   double mLyOfCell = 1.; // y length of cell corresponding to one pixel
 
@@ -66,6 +80,10 @@ class SpatialPhotonResponse
   int mNx = 1;        // number of "towers" in x direction
   int mNy = 1;        // number of "towers" in y direction
   int mPhotonSum = 0; // accumulated photon number (for quick filtering)
+
+  int mDetectorID = -1; // the detectorID (ZNA, ZNC, ZPA, ZPC) to which this image corresponds (if available)
+
+  float mTime = -1.; // the time (time difference between creation of response and the collission time); negative is unitialized
 
   std::vector<std::vector<int>> mImageData;
 };

--- a/Detectors/ZDC/simulation/src/Detector.cxx
+++ b/Detectors/ZDC/simulation/src/Detector.cxx
@@ -358,20 +358,26 @@ Bool_t Detector::ProcessHits(FairVolume* v)
    }
   }
 
+  auto tof = 1.e09 * fMC->TrackTime(); //TOF in ns
+
   if (o2::zdc::ZDCSimParam::Instance().recordSpatialResponse) {
     // some diagnostic; trying to really get the pixel fired
-    if (nphe > 0 && (detector == 1 || detector == 4)) {
-      mNeutronResponseImage.addPhoton(x[0], x[1], nphe);
-    }
-    if (nphe > 0 && (detector == 2 || detector == 5)) {
-      mProtonResponseImage.addPhoton(x[0], x[1], nphe);
+    if (nphe > 0) {
+      if (detector == ZNA || detector == ZNC) {
+        mNeutronResponseImage.setDetectorID(detector);
+        mNeutronResponseImage.addPhoton(x[0], x[1], nphe);
+        mNeutronResponseImage.setHitTime(tof);
+      }
+      if (detector == ZPA || detector == ZPC) {
+        mProtonResponseImage.setDetectorID(detector);
+        mProtonResponseImage.addPhoton(x[0], x[1], nphe);
+        mProtonResponseImage.setHitTime(tof);
+      }
     }
   }
 
   // A new hit is created when there is nothing yet for this det + sector
   if (mCurrentHitsIndices[detector - 1][sector] == -1) {
-
-    auto tof = 1.e09 * fMC->TrackTime(); //TOF in ns
     bool issecondary = trackn != stack->getCurrentPrimaryIndex();
     //if(!issecondary) printf("     !!! primary track (index %d)\n",stack->getCurrentPrimaryIndex());
 

--- a/Detectors/ZDC/simulation/src/SpatialPhotonResponse.cxx
+++ b/Detectors/ZDC/simulation/src/SpatialPhotonResponse.cxx
@@ -98,9 +98,8 @@ std::array<int, 5> SpatialPhotonResponse::getPhotonsPerChannel() const
     return photonsum;
   }
 
-  // could be put inside the image class
   auto determineChannel = [](int detector, int x, int y, int Nx, int Ny) {
-    if ((x + y) % 2 == 1) {
+    if ((x + y) % 2 == 0) {
       return (int)ChannelTypeZNP::Common;
     }
 

--- a/Detectors/ZDC/simulation/src/SpatialPhotonResponse.cxx
+++ b/Detectors/ZDC/simulation/src/SpatialPhotonResponse.cxx
@@ -9,6 +9,7 @@
 // or submit itself to any jurisdiction.
 
 #include "ZDCSimulation/SpatialPhotonResponse.h"
+#include "ZDCBase/Constants.h"
 #include <cmath>
 #include <iostream>
 
@@ -81,4 +82,67 @@ void SpatialPhotonResponse::reset()
       }
     }
   }
+  mTime = 0;
+  mDetectorID = -1;
+}
+
+std::array<int, 5> SpatialPhotonResponse::getPhotonsPerChannel() const
+{
+  std::array<int, 5> photonsum = {0, 0, 0, 0, 0};
+  if (mPhotonSum == 0) {
+    return photonsum;
+  }
+
+  if (mDetectorID == -1) {
+    std::cerr << "SpatialPhotonResponse has no detectorID ";
+    return photonsum;
+  }
+
+  // could be put inside the image class
+  auto determineChannel = [](int detector, int x, int y, int Nx, int Ny) {
+    if ((x + y) % 2 == 1) {
+      return (int)ChannelTypeZNP::Common;
+    }
+
+    if (detector == DetectorID::ZNA || detector == DetectorID::ZNC) {
+      if (x < Nx / 2) {
+        if (y < Ny / 2) {
+          return (int)ChannelTypeZNP::Ch1;
+        } else {
+          return (int)ChannelTypeZNP::Ch3;
+        }
+      } else {
+        if (y >= Ny / 2) {
+          return (int)ChannelTypeZNP::Ch4;
+        } else {
+          return (int)ChannelTypeZNP::Ch2;
+        }
+      }
+    }
+
+    if (detector == DetectorID::ZPA || detector == DetectorID::ZPC) {
+      auto i = (int)(4.f * x / Nx);
+      return (int)(i + 1);
+    }
+    return -1;
+  };
+
+  int sum = 0;
+  for (int x = 0; x < mNx; ++x) {
+    // loop over y = rows
+    for (int y = 0; y < mNy; ++y) {
+      // get channel
+      int channel = determineChannel(mDetectorID, x, y, mNx, mNy);
+      photonsum[channel] += mImageData[x][y];
+      sum += 0;
+    }
+  }
+  // assert (mPhotonSum == photonsum[0] + photonsum[1] + photonsum[2] + photonsum[3] + photonsum[4]);
+
+  return photonsum;
+}
+
+void SpatialPhotonResponse::printErrMsg(const char* str) const
+{
+  std::cerr << str << "\n";
 }


### PR DESCRIPTION
* be able to calculate photon count per readout channel
* associate a detectorID to the response image
* keep hit time in response