### PR TITLE
TRD Trap simulator

### DIFF
--- a/Detectors/TRD/README.md
+++ b/Detectors/TRD/README.md
@@ -2,9 +2,7 @@
 \page refDetectorsTRD TRD
 /doxy -->
 
-# TRD
-
-This is a top page for the TRD detector documentation.
+# TRD 
 
 <!-- doxy
 * \subpage refTRDbase

--- a/Detectors/TRD/base/CMakeLists.txt
+++ b/Detectors/TRD/base/CMakeLists.txt
@@ -28,7 +28,7 @@ o2_add_library(TRDBase
                        src/Calibrations.cxx
                        src/ChamberNoise.cxx
                        src/CalOnlineGainTables.cxx
-                       src/TrapConfig.cxx
+                       src/Tracklet.cxx
                PUBLIC_LINK_LIBRARIES O2::GPUCommon
                                      O2::DetectorsCommonDataFormats
                                      O2::Field
@@ -61,7 +61,7 @@ o2_target_root_dictionary(TRDBase
                                   include/TRDBase/Calibrations.h
                                   include/TRDBase/ChamberNoise.h
                                   include/TRDBase/CalOnlineGainTables.h
-                                  include/TRDBase/TrapConfig.h)
+                                  include/TRDBase/Tracklet.h)
 
 o2_add_test(DiffusionCoefficient
             SOURCES test/testTRDDiffusionCoefficient.cxx

--- a/Detectors/TRD/base/include/TRDBase/CalOnlineGainTables.h
+++ b/Detectors/TRD/base/include/TRDBase/CalOnlineGainTables.h
@@ -26,34 +26,45 @@ namespace o2
 {
 namespace trd
 {
+
 class CalOnlineGainTables
 {
  public:
   CalOnlineGainTables() = default;
   ~CalOnlineGainTables() = default;
   // get and set the various values stored internally in the gain tables.
+  float getGainCorrectionFactorrm(int det, int rob, int mcm) const;
   float getGainCorrectionFactor(int det, int row, int col) const;
   float getGainCorrectionFactor(int sector, int stack, int layer, int row, int col) const { return getGainCorrectionFactor(TRDGeometry::getDetector(sector, stack, layer), row, col); };
+  short getAdcdacrm(int det, int rob, int mcm) const;
   short getAdcdac(int det, int row, int col) const;
   short getAdcdac(int sector, int stack, int layer, int row, int col) const { return getAdcdac(TRDGeometry::getDetector(sector, stack, layer), row, col); };
+  float getMCMGainrm(int det, int rob, int mcm) const;
   float getMCMGain(int det, int row, int col) const;
   float getMCMGain(int sector, int stack, int layer, int row, int col) const { return getMCMGain(TRDGeometry::getDetector(sector, stack, layer), row, col); };
+  short getFGANrm(int det, int rob, int mcm, int channel) const;
   short getFGAN(int det, int row, int col) const;
   short getFGAN(int sector, int stack, int layer, int row, int col) const { return getFGAN(TRDGeometry::getDetector(sector, stack, layer), row, col); };
+  short getFGFNrm(int det, int rob, int mcm, int channel) const;
   short getFGFN(int det, int row, int col) const;
   short getFGFN(int sector, int stack, int layer, int row, int col) const { return getFGFN(TRDGeometry::getDetector(sector, stack, layer), row, col); };
+  void setGainCorrectionFactorrm(int det, int rob, int mcm, float gain);
   void setGainCorrectionFactor(int det, int row, int col, float gain);
   void setGainCorrectionFactor(int sector, int stack, int layer, int row, int col, float gain) { setGainCorrectionFactor(TRDGeometry::getDetector(sector, stack, layer), row, col, gain); };
+  void setAdcdacrm(int det, int rob, int mcm, short gain);
   void setAdcdac(int det, int row, int col, short gain);
   void setAdcdac(int sector, int stack, int layer, int row, int col, short gain) { setAdcdac(TRDGeometry::getDetector(sector, stack, layer), row, col, gain); };
+  void setMCMGainrm(int det, int rob, int mcm, float gain);
   void setMCMGain(int det, int row, int col, float gain);
   void setMCMGain(int sector, int stack, int layer, int row, int col, float gain) { setMCMGain(TRDGeometry::getDetector(sector, stack, layer), row, col, gain); };
+  void setFGANrm(int det, int rob, int mcm, int channel, short gain);
   void setFGAN(int det, int row, int col, short gain);
   void setFGAN(int sector, int stack, int layer, int row, int col, short gain) { setFGAN(TRDGeometry::getDetector(sector, stack, layer), row, col, gain); };
+  void setFGFNrm(int det, int rob, int mcm, int channel, short gain);
   void setFGFN(int det, int row, int col, short gain);
   void setFGFN(int sector, int stack, int layer, int row, int col, short gain) { setFGFN(TRDGeometry::getDetector(sector, stack, layer), row, col, gain); };
 
-  // these 4 are used primarily to reading in from run2, might have other uses.
+  // these 4 are used primarily to reading in from run2 ocdb, might have wider uses.
   void setAdcdac(int arrayoffset, short adc) { mGainTable[arrayoffset].mAdcdac = adc; };
   void setMCMGain(int arrayoffset, float gain) { mGainTable[arrayoffset].mMCMGain = gain; };
   void setFGAN(int arrayoffset, int channel, short gain) { mGainTable[arrayoffset].mFGAN[channel] = gain; };
@@ -61,16 +72,17 @@ class CalOnlineGainTables
 
   // two methods to localise the algorithms replacing many copies of the calculations.
   int getArrayOffset(int det, int row, int col) const;
+  int getArrayOffsetrm(int det, int row, int col) const;
   int getChannel(int col) const;
 
   static float UnDef;
   class MCMGain
   {
    public:
-    short mAdcdac;                 // Reference voltage of the ADCs  U_Ref =  (1.05V + (fAdcdac/31)*0.4V
+    short mAdcdac{0};              // Reference voltage of the ADCs  U_Ref =  (1.05V + (fAdcdac/31)*0.4V
     std::array<short, 21> mFGFN{}; // Gain Correction Filter Factor
     std::array<short, 21> mFGAN{}; // Gain Correction Filter Additive
-    float mMCMGain;
+    float mMCMGain{0};
   };
 
   std::array<MCMGain, 540 * 128> mGainTable;

--- a/Detectors/TRD/base/include/TRDBase/CalPad.h
+++ b/Detectors/TRD/base/include/TRDBase/CalPad.h
@@ -1,0 +1,77 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TRD_CALPAD_H
+#define O2_TRD_CALPAD_H
+
+///////////////////////////////////////////////////////////////////////////////
+//                                                                           //
+//  TRD calibration class for parameters which are saved per pad             //
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////
+
+class CalROC;
+class CalDet;
+class TH2F;
+class TH1F;
+
+class CalPad
+{
+
+ public:
+  enum { kNplan = 6,
+         kNcham = 5,
+         kNsect = 18,
+         kNdet = 540 };
+
+  CalPad();
+  CalPad(const std::string& name, const std::String& title);
+  CalPad(const CalPad& c);
+  ~CalPad();
+  CalPad& operator=(const CalPad& c);
+
+  static int getDet(int p, int c, int s) { return p + c * kNplan + s * kNplan * kNcham; };
+
+  CalROC* getCalROC(int d) const { return mROC[d]; };
+  CalROC* getCalROC(int p, int c, int s) const
+  {
+    return mROC[getDet(p, c, s)];
+  };
+
+  bool scaleROCs(const CalDet* values);
+
+  void setCalROC(int det, CalROC* calroc);
+
+  // Statistic
+  double getMeanRMS(double& rms, const CalDet* calDet = 0, int type = 0);
+  double getMean(const CalDet* calDet = 0, int type = 0, CalPad* const outlierPad = 0);
+  double getRMS(const CalDet* calDet = 0, int type = 0, CalPad* const outlierPad = 0);
+  double getMedian(const CalDet* calDet = 0, int type = 0, CalPad* const outlierPad = 0);
+  double getLTM(double* sigma = 0, double fraction = 0.9, const CalDet* calDet = 0, int type = 0, CalPad* const outlierPad = 0);
+
+  // Plot functions
+  TH1F* makeHisto1D(const CalDet* calDet = 0, int typedet = 0, float min = 4, float max = -4, int type = 0);
+  TH2F* makeHisto2DSmPl(int sm, int pl, const CalDet* calDet = 0, int typedet = 0, float min = 4, float max = -4, int type = 0);
+  TH2F* makeHisto2DCh(int ch, const CalDet* calDet = 0, int typedet = 0, float min = 4, float max = -4, int type = 0);
+
+  // Algebra functions
+  bool add(float c1);
+  bool multiply(float c1);
+  bool add(const CalPad* pad, double c1 = 1, const CalDet* calDet1 = 0, const CalDet* calDet2 = 0, int type = 0);
+  bool multiply(const CalPad* pad, const CalDet* calDet1 = 0, const CalDet* calDet2 = 0, int type = 0);
+  bool divide(const CalPad* pad, const CalDet* calDet1 = 0, const CalDet* calDet2 = 0, int type = 0);
+
+ protected:
+  std::vector<CalROC> mROC(kNdet); //  Array of ROC objects which contain the values per pad
+
+  ClassDef(CalPad, 1) //  TRD calibration class for parameters which are saved per pad
+};
+
+#endif

--- a/Detectors/TRD/base/include/TRDBase/Calibrations.h
+++ b/Detectors/TRD/base/include/TRDBase/Calibrations.h
@@ -43,6 +43,7 @@
 #include "TRDBase/ChamberNoise.h"
 #include "TRDBase/PadNoise.h"
 #include "TRDBase/PadStatus.h"
+#include "TRDBase/CalOnlineGainTables.h"
 
 class TRDGeometry;
 
@@ -116,7 +117,7 @@ class Calibrations
   ChamberStatus* mChamberStatus;
   PadStatus* mPadStatus;
   ChamberNoise* mChamberNoise;
-  //std::shared_ptr<OnlineGainFactors> mOnlineGainFactors;
+  CalOnlineGainTables* mOnlineGainFactors;
   //
 };
 } // namespace trd

--- a/Detectors/TRD/base/include/TRDBase/ChamberStatus.h
+++ b/Detectors/TRD/base/include/TRDBase/ChamberStatus.h
@@ -39,7 +39,6 @@ class ChamberStatus
          kNoDataHalfChamberSideB = 3,
          kBadCalibrated = 4,
          kNotCalibrated = 5 };
-  // the above it the bitth position of the status, i.e. kGood is the 0th bit being true
   enum { kGoodpat = 1,
          kNoDatapat = 2,
          kNoDataHalfChamberSideApat = 4,

--- a/Detectors/TRD/base/include/TRDBase/Digit.h
+++ b/Detectors/TRD/base/include/TRDBase/Digit.h
@@ -59,7 +59,6 @@ class Digit : public TimeStamp
   std::uint8_t mPad{0};       // pad within pad row, 0-143
   ArrayADC mADC{};            // ADC vector (30 time-bins)
   size_t mLabelIdx{0};        // index for mc label
-
   ClassDefNV(Digit, 1);
 };
 

--- a/Detectors/TRD/base/include/TRDBase/FeeParam.h
+++ b/Detectors/TRD/base/include/TRDBase/FeeParam.h
@@ -11,10 +11,6 @@
 #ifndef O2_TRD_FEEPARAM_H
 #define O2_TRD_FEEPARAM_H
 
-namespace o2
-{
-namespace trd
-{
 
 ////////////////////////////////////////////////////////////////////////////
 //                                                                        //
@@ -30,13 +26,17 @@ namespace trd
 //                                                                        //
 ////////////////////////////////////////////////////////////////////////////
 
-#include <iosfwd>
 #include <array>
+#include <vector>
 
 class TRDCommonParam;
 class TRDPadPlane;
 class TRDGeometry;
 
+namespace o2
+{
+namespace trd
+{
 //_____________________________________________________________________________
 class FeeParam
 {
@@ -79,8 +79,7 @@ class FeeParam
   static int getNcolMcm() { return mgkNcolMcm; }
   static int getNrowC0() { return mgkNrowC0; }
   static int getNrowC1() { return mgkNrowC1; }
-
-  // Basic Geometrical numbers these were private but as they are static and const it seems pointless.
+  // Basic Geometrical numbers
   static const int mgkLHCfrequency = 40079000; // [Hz] LHC clock
   static const int mgkNmcmRob = 16;            // Number of MCMs per ROB
   static const int mgkNmcmRobInRow = 4;        // Number of MCMs per ROB in row dir.
@@ -95,13 +94,13 @@ class FeeParam
 
   // tracklet simulation
   bool getTracklet() const { return mgTracklet; }
-  static void setTracklet(bool trackletSim = kTRUE) { mgTracklet = trackletSim; }
+  static void setTracklet(bool trackletSim = true) { mgTracklet = trackletSim; }
   bool getRejectMultipleTracklets() const { return mgRejectMultipleTracklets; }
-  static void setRejectMultipleTracklets(bool rej = kTRUE) { mgRejectMultipleTracklets = rej; }
+  static void setRejectMultipleTracklets(bool rej = true) { mgRejectMultipleTracklets = rej; }
   bool getUseMisalignCorr() const { return mgUseMisalignCorr; }
-  static void setUseMisalignCorr(bool misalign = kTRUE) { mgUseMisalignCorr = misalign; }
+  static void setUseMisalignCorr(bool misalign = true) { mgUseMisalignCorr = misalign; }
   bool getUseTimeOffset() const { return mgUseTimeOffset; }
-  static void setUseTimeOffset(bool timeOffset = kTRUE) { mgUseTimeOffset = timeOffset; }
+  static void setUseTimeOffset(bool timeOffset = true) { mgUseTimeOffset = timeOffset; }
 
   // Concerning raw data format
   int getRAWversion() const { return mRAWversion; }

--- a/Detectors/TRD/base/include/TRDBase/Tracklet.h
+++ b/Detectors/TRD/base/include/TRDBase/Tracklet.h
@@ -1,0 +1,161 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+//#include "TRDBase/TRDGeometryBase.h"
+//#include "DetectorsCommonDataFormats/DetMatrixCache.h"
+//#include "DetectorsCommonDataFormats/DetID.h"
+
+#ifndef O2_TRDTRAPTRACKLET_H
+#define O2_TRDTRAPTRACKLET_H
+
+////////////////////////////////////////////////////////////////////////////
+//                                                                        //
+// TRD TRAP tracklet                                                      //
+// class for TRD tracklets from the TRAP                                  //
+//   (originall TrackletBase and TrackletMCM)                             //
+//
+// Authors                                                                //
+//  Alex Bercuci (A.Bercuci@gsi.de)                                       //
+//  Jochen Klein (jochen.klein@cern.ch)                                   //
+//  Sean Murray (murrays@cern.ch)                                         //
+//
+////////////////////////////////////////////////////////////////////////////
+#include <vector>
+#include <array>
+#include <memory>   // for std::unique_ptr
+#include "Rtypes.h" // for ClassDef
+
+//#include "fairlogger/Logger.h"
+#include "TRDBase/TRDGeometry.h"
+
+namespace o2
+{
+namespace trd
+{
+
+//TODO check with ?? I think Ole, about this as I think my freedom to
+//define my own thing is limited by his requirements.
+
+class Tracklet
+{
+
+  //-----------------------------------
+  //
+  // TRD tracklet word (as from FEE)
+  // only 32-bit of information + detector ID
+  //
+  //----------------------------------
+ public:
+  Tracklet(unsigned int trackletWord = 0);
+  Tracklet(unsigned int trackletWword, int hcid);
+  Tracklet(unsigned int trackletWword, int hcid, int rob, int mcm);
+  Tracklet(const Tracklet& rhs);
+  ~Tracklet() = default;
+
+  Tracklet& operator=(const Tracklet& o) { return *this; }
+
+  // int getHCId() const { return 2 * getDetector() + (getYbin() > 0 ? 1 : 0); }
+
+  float getdZdX() const { return 0; }
+
+  void localToGlobal(float&, float&, float&, float&) {}
+
+  void print(std::string* /*option=""*/) const {}
+
+  // ----- Getters for contents of tracklet word -----
+  int getYbin() const;                                          // in units of 160 um
+  int getdY() const;                                            // in units of 140 um
+  int getZbin() const { return ((mTrackletWord >> 20) & 0xf); } // in pad length units
+  int getPID() const { return ((mTrackletWord >> 24) & 0xff); }
+
+  // ----- Getters for MCM-tracklet information -----
+  int getMCM() const { return mMCM; }
+  int getROB() const { return mROB; }
+  int getLabel() const { return mLabel[0]; }
+  int getLabel(const int i) const { return mLabel[i]; }
+  const std::array<int, 3>& getLabels() const { return mLabel; }
+  bool hasLabel(const int label) const { return (mLabel[0] == label || mLabel[1] == label || mLabel[2] == label); }
+
+  // ----- Getters for offline corresponding values -----
+  bool cookPID() { return false; }
+  double getPID(int /* is */) const { return getPID() / 256.; }
+  int getDetector() const { return mHCId / 2; }
+  int getHCId() const { return mHCId; }
+  float getdYdX() const { return (getdY() * 140e-4 / 3.); }
+  float getX() const;
+  float getY() const;
+  float getZ() const;
+
+  float getLocalZ() const;
+
+  int getQ0() const { return mQ0; }
+  int getQ1() const { return mQ1; }
+  int getNHits() const { return mNHits; }
+  int getNHits0() const { return mNHits0; }
+  int getNHits1() const { return mNHits1; }
+
+  unsigned int getTrackletWord() const { return mTrackletWord; }
+  void setTrackletWord(unsigned int trackletWord) { mTrackletWord = trackletWord; }
+
+  void setDetector(int id) { mHCId = 2 * id + (getYbin() < 0 ? 0 : 1); }
+  void setHCId(int id) { mHCId = id; }
+  void setMCM(int mcm) { mMCM = mcm; }
+  void setROB(int rob) { mROB = rob; }
+  void setLabel(std::array<int, 3>& label);
+  void setQ0(int charge) { mQ0 = charge; }
+  void setQ1(int charge) { mQ1 = charge; }
+  void setNHits(int nhits) { mNHits = nhits; }
+  void setNHits0(int nhits) { mNHits0 = nhits; }
+  void setNHits1(int nhits) { mNHits1 = nhits; }
+
+  void setSlope(float slope) { mSlope = slope; }
+  void setOffset(float offset) { mOffset = offset; }
+  void setError(float error) { mError = error; }
+  void setClusters(std::vector<float>& res, std::vector<float>& q, int n);
+
+  float getSlope() const { return mSlope; }
+  float getOffset() const { return mOffset; }
+  float getError() const { return mError; }
+  int getNClusters() const { return mNClusters; }
+  std::vector<float> getResiduals() const { return mResiduals; }   //TODO this is a problem, giving a pointer out to an internal class member
+  std::vector<float> getClsCharges() const { return mClsCharges; } //TODO this is a problem, giving a pointer out to an internal class member
+
+ protected:
+  TRDGeometry* mGeo; //! TRD geometry
+
+  int mHCId;                  // half-chamber ID (only transient)
+  unsigned int mTrackletWord; // tracklet word: PID | Z | deflection length | Y
+                              //          bits:  12   4            7          13
+  int mMCM;                   // MCM no. in which the tracklet was found
+  int mROB;                   // ROB no. on which the tracklet was found
+
+  int mQ0; // accumulated charge in the first time window
+  int mQ1; // accumulated charge in the second time window
+
+  int mNHits;                // no. of contributing clusters
+  int mNHits0;               // no. of contributing clusters in window 0
+  int mNHits1;               // no. of contributing clusters in window 1
+                             //int  mNHits2 TODO if we add windows we need to add another mNHits2
+  std::array<int, 3> mLabel; // up to 3 labels for MC track  TODO no limit on labels in O2 ....
+
+  float mSlope;                   // tracklet slope
+  float mOffset;                  // tracklet offset
+  float mError;                   // tracklet error
+  int mNClusters;                 // no. of clusters
+  std::vector<float> mResiduals;  //[mNClusters] cluster to tracklet residuals
+  std::vector<float> mClsCharges; //[mNClusters] cluster charge
+
+ private:
+  //  TrackletMCM& operator=(const TrackletMCM &rhs);   // not implemented
+  ClassDefNV(Tracklet, 2);
+};
+} //namespace trd
+} //namespace o2
+#endif

--- a/Detectors/TRD/base/src/CalOnlineGainTables.cxx
+++ b/Detectors/TRD/base/src/CalOnlineGainTables.cxx
@@ -29,14 +29,19 @@ int CalOnlineGainTables::getArrayOffset(int det, int row, int col) const
   FeeParam* mFeeParam = FeeParam::instance();
   int rob = mFeeParam->getROBfromPad(row, col);
   int mcm = mFeeParam->getMCMfromPad(row, col);
-  int detoffset = det * 128;
+  int detoffset = det * 128; //TODO find this constant from somewhere else max rob=8, max mcm=16, so 7x16+15=127
   int mcmoffset = rob * (mFeeParam->mgkNmcmRob) + mcm;
   return detoffset + mcmoffset;
 }
 
 int CalOnlineGainTables::getChannel(int col) const
 {
-  return 19 - (col % 18);
+  return 19 - (col % 18); //TODO find both of these constants from somewhere else.
+}
+
+int CalOnlineGainTables::getArrayOffsetrm(int det, int rob, int mcm) const
+{
+  return det * 128 + rob * FeeParam::instance()->mgkNmcmRob + mcm;
 }
 
 float CalOnlineGainTables::getGainCorrectionFactor(int det, int row, int col) const
@@ -61,28 +66,55 @@ float CalOnlineGainTables::getGainCorrectionFactor(int det, int row, int col) co
   return GainCorrectionFactor;
 }
 
+short CalOnlineGainTables::getAdcdacrm(int det, int rob, int mcm) const
+{
+  return mGainTable[getArrayOffsetrm(det, rob, mcm)].mAdcdac;
+}
+
 short CalOnlineGainTables::getAdcdac(int det, int row, int col) const
 {
   int arrayoffset = getArrayOffset(det, row, col);
   return mGainTable[arrayoffset].mAdcdac;
 };
 
+float CalOnlineGainTables::getMCMGainrm(int det, int rob, int mcm) const
+{
+  return mGainTable[getArrayOffsetrm(det, rob, mcm)].mMCMGain;
+}
+
 float CalOnlineGainTables::getMCMGain(int det, int row, int col) const
 {
   int arrayoffset = getArrayOffset(det, row, col);
   return mGainTable[arrayoffset].mMCMGain;
 }
+
+short CalOnlineGainTables::getFGANrm(int det, int rob, int mcm, int channel) const
+{
+  return mGainTable[getArrayOffsetrm(det, rob, mcm)].mFGAN[channel];
+}
+
 short CalOnlineGainTables::getFGAN(int det, int row, int col) const
 {
   int arrayoffset = getArrayOffset(det, row, col);
   int channel = getChannel(col);
   return mGainTable[arrayoffset].mFGAN[channel];
 }
+
+short CalOnlineGainTables::getFGFNrm(int det, int rob, int mcm, int channel) const
+{
+  return mGainTable[getArrayOffsetrm(det, rob, mcm)].mFGFN[channel];
+}
+
 short CalOnlineGainTables::getFGFN(int det, int row, int col) const
 {
   int arrayoffset = getArrayOffset(det, row, col);
   int channel = getChannel(col);
   return mGainTable[arrayoffset].mFGFN[channel];
+}
+
+void CalOnlineGainTables::setAdcdacrm(int det, int rob, int mcm, short adcdac)
+{
+  mGainTable[getArrayOffsetrm(det, rob, mcm)].mAdcdac = adcdac;
 }
 
 void CalOnlineGainTables::setAdcdac(int det, int row, int col, short adcdac)
@@ -91,10 +123,20 @@ void CalOnlineGainTables::setAdcdac(int det, int row, int col, short adcdac)
   mGainTable[arrayoffset].mAdcdac = adcdac;
 }
 
+void CalOnlineGainTables::setMCMGainrm(int det, int rob, int mcm, float gain)
+{
+  mGainTable[getArrayOffsetrm(det, rob, mcm)].mMCMGain = gain;
+}
+
 void CalOnlineGainTables::setMCMGain(int det, int row, int col, float gain)
 {
   int arrayoffset = getArrayOffset(det, row, col);
   mGainTable[arrayoffset].mMCMGain = gain;
+}
+
+void CalOnlineGainTables::setFGANrm(int det, int rob, int mcm, int channel, short gain)
+{
+  mGainTable[getArrayOffsetrm(det, rob, mcm)].mFGAN[channel] = gain;
 }
 
 void CalOnlineGainTables::setFGAN(int det, int row, int col, short gain)
@@ -102,6 +144,11 @@ void CalOnlineGainTables::setFGAN(int det, int row, int col, short gain)
   int arrayoffset = getArrayOffset(det, row, col);
   int channel = getChannel(col);
   mGainTable[arrayoffset].mFGAN[channel] = gain;
+}
+
+void CalOnlineGainTables::setFGFNrm(int det, int rob, int mcm, int channel, short gain)
+{
+  mGainTable[getArrayOffsetrm(det, rob, mcm)].mFGFN[channel] = gain;
 }
 
 void CalOnlineGainTables::setFGFN(int det, int row, int col, short gain)

--- a/Detectors/TRD/base/src/CalPad.cxx
+++ b/Detectors/TRD/base/src/CalPad.cxx
@@ -1,0 +1,805 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <TMath.h>
+#include <TH2F.h>
+#include <TH1F.h>
+#include <TStyle.h>
+
+#include "TRDBase/CalPad.h"
+#include "TRDBase/TRDGeometry.h"
+#include "TRDBase/TRDPadPlane.h"
+
+#include "CalROC.h"
+#include "CalDet.h"
+
+using namespace o2::trd;
+
+///////////////////////////////////////////////////////////////////////////////
+//                                                                           //
+//  TRD calibration class for parameters which saved per pad                 //
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////
+
+//_____________________________________________________________________________
+CalPad::CalPad()
+{
+  //
+  // CalPad default constructor
+  //
+
+  for (int idet = 0; idet < kNdet; idet++) {
+    fROC[idet] = nullptr;
+  }
+}
+
+//_____________________________________________________________________________
+CalPad::CalPad(const Text_t* name, const Text_t* title)
+{
+  //
+  // CalPad constructor
+  //
+
+  for (int isec = 0; isec < kNsect; isec++) {
+    for (int ipla = 0; ipla < kNplan; ipla++) {
+      for (int icha = 0; icha < kNcham; icha++) {
+        int idet = getDet(ipla, icha, isec);
+        fROC[idet] = new CalROC(ipla, icha);
+      }
+    }
+  }
+  mName = name;
+  mTitle = title;
+}
+
+//_____________________________________________________________________________
+CalPad::CalPad(const CalPad& c)
+{
+  //
+  // CalPad copy constructor
+  //
+
+  for (int idet = 0; idet < kNdet; idet++) {
+    fROC[idet] = new CalROC(*((CalPad&)c).fROC[idet]);
+  }
+  mName = c.mName;
+  mTitle = c.mTitle;
+}
+
+//_____________________________________________________________________________
+CalPad::~CalPad()
+{
+  //
+  // CalPad destructor
+  //
+
+  for (int idet = 0; idet < kNdet; idet++) {
+    if (fROC[idet]) {
+      delete fROC[idet];
+      fROC[idet] = 0;
+    }
+  }
+}
+
+//_____________________________________________________________________________
+CalPad& CalPad::operator=(const CalPad& c)
+{
+  //
+  // Assignment operator
+  //
+
+  if (this != &c)
+    ((CalPad&)c).Copy(*this);
+  return *this;
+}
+
+//_____________________________________________________________________________
+void CalPad::Copy(TObject& c) const
+{
+  //
+  // Copy function
+  //
+
+  for (int idet = 0; idet < kNdet; idet++) {
+    if (((CalPad&)c).fROC[idet]) {
+      delete ((CalPad&)c).fROC[idet];
+    }
+    ((CalPad&)c).fROC[idet] = new CalROC();
+    if (fROC[idet]) {
+      fROC[idet]->Copy(*((CalPad&)c).fROC[idet]);
+    }
+  }
+
+  c.mName = mName;
+  c.mTitle = mTitle;
+}
+
+//_____________________________________________________________________________
+bool CalPad::scaleROCs(const CalDet* values)
+{
+  //
+  // Scales ROCs of this class with the values from the class <values>
+  // Is used if an CalPad object defines local variations of a parameter
+  // defined per detector using a CalDet class
+  //
+
+  if (!values)
+    return kFALSE;
+  bool result = kTRUE;
+  for (int idet = 0; idet < kNdet; idet++) {
+    if (fROC[idet]) {
+      if (!fROC[idet]->multiply(values->getValue(idet)))
+        result = kFALSE;
+    }
+  }
+  return result;
+}
+
+//_____________________________________________________________________________
+void CalPad::setCalROC(int det, CalROC* calroc)
+{
+  //
+  // Set the CalROC to this one
+  //
+
+  if (!calroc)
+    return;
+  if (fROC[det]) {
+    for (int icol = 0; icol < calroc->getNcols(); icol++) {
+      for (int irow = 0; irow < calroc->getNrows(); irow++) {
+        fROC[det]->SetValue(icol, irow, calroc->getValue(icol, irow));
+      }
+    }
+  }
+}
+//_____________________________________________________________________________
+double CalPad::getMeanRMS(double& rms, const CalDet* calDet, int type)
+{
+  //
+  // Calculate mean an RMS of all rocs
+  // If calDet correct the CalROC from the detector coefficient
+  // type == 0 for gain and vdrift
+  // type == 1 for t0
+  //
+  double factor = 0.0;
+  if (type == 0)
+    factor = 1.0;
+  double sum = 0, sum2 = 0, n = 0, val;
+  for (int idet = 0; idet < kNdet; idet++) {
+    if (calDet)
+      factor = calDet->getValue(idet);
+    CalROC* calRoc = fROC[idet];
+    if (calRoc) {
+      for (int irow = 0; irow < calRoc->getNrows(); irow++) {
+        for (int icol = 0; icol < calRoc->getNcols(); icol++) {
+          if (type == 0)
+            val = calRoc->getValue(icol, irow) * factor;
+          else
+            val = calRoc->getValue(icol, irow) + factor;
+          sum += val;
+          sum2 += val * val;
+          n++;
+        }
+      }
+    }
+  }
+  double n1 = 1. / n;
+  double mean = sum * n1;
+  rms = TMath::Sqrt(TMath::Abs(sum2 * n1 - mean * mean));
+  return mean;
+}
+
+//_____________________________________________________________________________
+double CalPad::getMean(const CalDet* calDet, int type, CalPad* const outlierPad)
+{
+  //
+  // return mean of the mean of all ROCs
+  // If calDet correct the CalROC from the detector coefficient
+  // type == 0 for gain and vdrift
+  // type == 1 for t0
+  //
+  double factor = 0.0;
+  if (type == 0)
+    factor = 1.0;
+  double arr[kNdet];
+  int n = 0;
+  for (int idet = 0; idet < kNdet; idet++) {
+    if (calDet)
+      factor = calDet->getValue(idet);
+    CalROC* calRoc = fROC[idet];
+    if (calRoc) {
+      CalROC* outlierROC = 0;
+      if (outlierPad)
+        outlierROC = outlierPad->getCalROC(idet);
+      if (type == 0)
+        arr[n] = calRoc->getMean(outlierROC) * factor;
+      else
+        arr[n] = calRoc->getMean(outlierROC) + factor;
+      n++;
+    }
+  }
+  return TMath::Mean(n, arr);
+}
+
+//_____________________________________________________________________________
+double CalPad::getRMS(const CalDet* calDet, int type, CalPad* const outlierPad)
+{
+  //
+  // return mean of the RMS of all ROCs
+  // If calDet correct the CalROC from the detector coefficient
+  // type == 0 for gain and vdrift
+  // type == 1 for t0
+  //
+  double factor = 0.0;
+  if (type == 0)
+    factor = 1.0;
+  double arr[kNdet];
+  int n = 0;
+  for (int idet = 0; idet < kNdet; idet++) {
+    if (calDet)
+      factor = calDet->getValue(idet);
+    CalROC* calRoc = fROC[idet];
+    if (calRoc) {
+      CalROC* outlierROC = 0;
+      if (outlierPad)
+        outlierROC = outlierPad->getCalROC(idet);
+      if (type == 0)
+        arr[n] = calRoc->getRMS(outlierROC) * factor;
+      else
+        arr[n] = calRoc->getRMS(outlierROC);
+      n++;
+    }
+  }
+  return TMath::Mean(n, arr);
+}
+
+//_____________________________________________________________________________
+double CalPad::getMedian(const CalDet* calDet, int type, CalPad* const outlierPad)
+{
+  //
+  // return mean of the median of all ROCs
+  // If CalDet, the correct the CalROC from the detector coefficient
+  // type == 0 for gain and vdrift
+  // type == 1 for t0
+  //
+  double factor = 0.0;
+  if (type == 0)
+    factor = 1.0;
+  double arr[kNdet];
+  int n = 0;
+  for (int idet = 0; idet < kNdet; idet++) {
+    if (calDet)
+      factor = calDet->getValue(idet);
+    CalROC* calRoc = fROC[idet];
+    if (calRoc) {
+      CalROC* outlierROC = 0;
+      if (outlierPad)
+        outlierROC = outlierPad->getCalROC(idet);
+      if (type == 0)
+        arr[n] = calRoc->getMedian(outlierROC) * factor;
+      else
+        arr[n] = calRoc->getMedian(outlierROC) + factor;
+      n++;
+    }
+  }
+  return TMath::Mean(n, arr);
+}
+
+//_____________________________________________________________________________
+double CalPad::getLTM(double* sigma, double fraction, const CalDet* calDet, int type, CalPad* const outlierPad)
+{
+  //
+  // return mean of the LTM and sigma of all ROCs
+  // If calDet correct the CalROC from the detector coefficient
+  // type == 0 for gain and vdrift
+  // type == 1 for t0
+  //
+  double factor = 0.0;
+  if (type == 0)
+    factor = 1.0;
+  double arrm[kNdet];
+  double arrs[kNdet];
+  double* sTemp = 0x0;
+  int n = 0;
+
+  for (int idet = 0; idet < kNdet; idet++) {
+    if (calDet)
+      factor = calDet->getValue(idet);
+    CalROC* calRoc = fROC[idet];
+    if (calRoc) {
+      if (sigma)
+        sTemp = arrs + n;
+      CalROC* outlierROC = 0;
+      if (outlierPad)
+        outlierROC = outlierPad->getCalROC(idet);
+      if (type == 0)
+        arrm[n] = calRoc->getLTM(sTemp, fraction, outlierROC) * factor;
+      else
+        arrm[n] = calRoc->getLTM(sTemp, fraction, outlierROC) + factor;
+      n++;
+    }
+  }
+  if (sigma)
+    *sigma = TMath::Mean(n, arrs);
+  return TMath::Mean(n, arrm);
+}
+
+//_____________________________________________________________________________
+TH1F* CalPad::makeHisto1D(const CalDet* calDet, int typedet, float min, float max, int type)
+{
+  //
+  // make 1D histo
+  // type -1 = user defined range
+  //       0 = nsigma cut nsigma=min
+  // If calDet correct the CalROC from the detector coefficient
+  // typedet == 0 for gain and vdrift
+  // typedet == 1 for t0
+  //
+
+  double factor = 0.0;
+  if (typedet == 0)
+    factor = 1.0;
+
+  if (type >= 0) {
+    if (type == 0) {
+      // nsigma range
+      float mean = getMean(calDet, typedet);
+      float sigma = 0.0;
+      float kEpsilonr = 0.005;
+      if (getRMS(calDet, typedet) > kEpsilonr)
+        sigma = getRMS(calDet, typedet);
+      else {
+        double rms = 0.0;
+        sigma = getMeanRMS(rms, calDet, typedet);
+      }
+      float nsigma = TMath::Abs(min);
+      sigma *= nsigma;
+      if (sigma < kEpsilonr)
+        sigma = kEpsilonr;
+      min = mean - sigma;
+      max = mean + sigma;
+    }
+    if (type == 1) {
+      // fixed range
+      float mean = getMedian(calDet, typedet);
+      float delta = min;
+      min = mean - delta;
+      max = mean + delta;
+    }
+    if (type == 2) {
+      //
+      // LTM mean +- nsigma
+      //
+      double sigma;
+      float mean = getLTM(&sigma, max, calDet, typedet);
+      sigma *= min;
+      float kEpsilonr = 0.005;
+      if (sigma < kEpsilonr)
+        sigma = kEpsilonr;
+      min = mean - sigma;
+      max = mean + sigma;
+    }
+  }
+  char name[1000];
+  snprintf(name, 1000, "%s Pad 1D", getTitle());
+  TH1F* his = new TH1F(name, name, 100, min, max);
+  for (int idet = 0; idet < kNdet; idet++) {
+    if (calDet)
+      factor = calDet->getValue(idet);
+    if (fROC[idet]) {
+      for (int irow = 0; irow < fROC[idet]->getNrows(); irow++) {
+        for (int icol = 0; icol < fROC[idet]->getNcols(); icol++) {
+          if (typedet == 0)
+            his->Fill(fROC[idet]->getValue(irow, icol) * factor);
+          else
+            his->Fill(fROC[idet]->getValue(irow, icol) + factor);
+        }
+      }
+    }
+  }
+  return his;
+}
+
+//_____________________________________________________________________________
+TH2F* CalPad::makeHisto2DSmPl(int sm, int pl, const CalDet* calDet, int typedet, float min, float max, int type)
+{
+  //
+  // Make 2D graph
+  // sm    - supermodule number
+  // pl    - plane number
+  // If calDet correct the CalROC from the detector coefficient
+  // typedet == 0 for gain and vdrift
+  // typedet == 1 for t0
+  //
+  gStyle->SetPalette(1);
+  double factor = 0.0;
+  if (typedet == 0)
+    factor = 1.0;
+
+  float kEpsilon = 0.000000000001;
+
+  TRDGeometry* trdGeo = new TRDGeometry();
+
+  if (type >= 0) {
+    float kEpsilonr = 0.005;
+    if (type == 0) {
+      // nsigma range
+      float mean = getMean(calDet, typedet);
+      float sigma = 0.0;
+      if (getRMS(calDet, typedet) > kEpsilonr)
+        sigma = getRMS(calDet, typedet);
+      else {
+        double rms = 0.0;
+        sigma = getMeanRMS(rms, calDet, typedet);
+      }
+      float nsigma = TMath::Abs(min);
+      sigma *= nsigma;
+      if (sigma < kEpsilonr)
+        sigma = kEpsilonr;
+      min = mean - sigma;
+      max = mean + sigma;
+    }
+    if (type == 1) {
+      // fixed range
+      float mean = getMedian(calDet, typedet);
+      float delta = min;
+      min = mean - delta;
+      max = mean + delta;
+    }
+    if (type == 2) {
+      //
+      // LTM mean +- nsigma
+      //
+      double sigma;
+      float mean = getLTM(&sigma, max, calDet, typedet);
+      sigma *= min;
+      if (sigma < kEpsilonr)
+        sigma = kEpsilonr;
+      min = mean - sigma;
+      max = mean + sigma;
+    }
+  }
+
+  AliTRDpadPlane* padPlane0 = trdGeo->getPadPlane(pl, 0);
+  double row0 = padPlane0->getRow0();
+  double col0 = padPlane0->getCol0();
+
+  char name[1000];
+  snprintf(name, 1000, "%s Pad 2D sm %d pl %d", getTitle(), sm, pl);
+  TH2F* his = new TH2F(name, name, 76, -TMath::Abs(row0), TMath::Abs(row0), 144, -TMath::Abs(col0), TMath::Abs(col0));
+
+  // Where we begin
+  int offsetsmpl = 30 * sm + pl;
+
+  for (int k = 0; k < kNcham; k++) {
+    int det = offsetsmpl + k * 6;
+    if (calDet)
+      factor = calDet->getValue(det);
+    if (fROC[det]) {
+      CalROC* calRoc = fROC[det];
+      for (int irow = 0; irow < calRoc->getNrows(); irow++) {
+        for (int icol = 0; icol < calRoc->getNcols(); icol++) {
+          if (TMath::Abs(calRoc->getValue(icol, irow)) > kEpsilon) {
+            int binz = 0;
+            int kb = kNcham - 1 - k;
+            int krow = calRoc->getNrows() - 1 - irow;
+            int kcol = calRoc->getNcols() - 1 - icol;
+            if (kb > 2)
+              binz = 16 * (kb - 1) + 12 + krow + 1;
+            else
+              binz = 16 * kb + krow + 1;
+            int biny = kcol + 1;
+            float value = calRoc->getValue(icol, irow);
+            if (typedet == 0)
+              his->SetBinContent(binz, biny, value * factor);
+            else
+              his->SetBinContent(binz, biny, value + factor);
+          }
+        }
+      }
+    }
+  }
+  his->SetXTitle("z (cm)");
+  his->SetYTitle("y (cm)");
+  his->SetStats(0);
+  his->SetMaximum(max);
+  his->SetMinimum(min);
+  delete trdGeo;
+  return his;
+}
+
+//_____________________________________________________________________________
+TH2F* CalPad::makeHisto2DCh(int ch, const CalDet* calDet, int typedet, float min, float max, int type)
+{
+  //
+  // Make 2D graph mean value in z direction
+  // ch    - chamber
+  // If calDet correct the CalROC from the detector coefficient
+  // typedet == 0 for gain and vdrift
+  // typedet == 1 for t0
+  //
+  gStyle->SetPalette(1);
+  double factor = 0.0;
+  if (typedet == 0)
+    factor = 1.0;
+
+  if (type >= 0) {
+    float kEpsilonr = 0.005;
+    if (type == 0) {
+      // nsigma range
+      float mean = getMean(calDet, typedet);
+      float sigma = 0.0;
+      if (getRMS(calDet, typedet) > kEpsilonr)
+        sigma = getRMS(calDet, typedet);
+      else {
+        double rms = 0.0;
+        sigma = getMeanRMS(rms, calDet, typedet);
+      }
+      float nsigma = TMath::Abs(min);
+      sigma *= nsigma;
+      if (sigma < kEpsilonr)
+        sigma = kEpsilonr;
+      min = mean - sigma;
+      max = mean + sigma;
+    }
+    if (type == 1) {
+      // fixed range
+      float mean = getMedian(calDet, typedet);
+      float delta = min;
+      min = mean - delta;
+      max = mean + delta;
+    }
+    if (type == 2) {
+      //
+      // LTM mean +- nsigma
+      //
+      double sigma;
+      float mean = getLTM(&sigma, max, calDet, typedet);
+      sigma *= min;
+      if (sigma < kEpsilonr)
+        sigma = kEpsilonr;
+      min = mean - sigma;
+      max = mean + sigma;
+    }
+  }
+
+  TRDGeometry* trdGeo = new TRDGeometry();
+
+  float kEpsilon = 0.000000000001;
+
+  double poslocal[3] = {0.0, 0.0, 0.0};
+  double posglobal[3] = {0.0, 0.0, 0.0};
+
+  std::string name;
+  name << mTitle << " Pad 2D ch " << ch;
+  TH2F* his = new TH2F(name.c_str(), name.c_str(), 400, -400.0, 400.0, 400, -400.0, 400.0);
+
+  // Where we begin
+  int offsetch = 6 * ch;
+
+  for (int isec = 0; isec < kNsect; isec++) {
+    for (int ipl = 0; ipl < kNplan; ipl++) {
+      int det = offsetch + isec * 30 + ipl;
+      if (calDet)
+        factor = calDet->getValue(det);
+      if (fROC[det]) {
+        CalROC* calRoc = fROC[det];
+        PadPlane* padPlane = trdGeo->getPadPlane(ipl, ch);
+        for (int icol = 0; icol < calRoc->getNcols(); icol++) {
+          poslocal[0] = trdGeo->getTime0(ipl);
+          poslocal[2] = padPlane->getRowPos(0);
+          poslocal[1] = padPlane->getColPos(icol);
+          trdGeo->rotateBack(det, poslocal, posglobal);
+          int binx = 1 + TMath::Nint((posglobal[0] + 400.0) * 0.5);
+          int biny = 1 + TMath::Nint((posglobal[1] + 400.0) * 0.5);
+          float value = 0.0;
+          int nb = 0;
+          for (int irow = 0; irow < calRoc->getNrows(); irow++) {
+            if (TMath::Abs(calRoc->getValue(icol, irow)) > kEpsilon) {
+              value += calRoc->getValue(icol, irow);
+              nb++;
+            }
+          }
+          if (nb > 0) {
+            value = value / nb;
+          }
+          if (typedet == 0)
+            his->SetBinContent(binx, biny, value * factor);
+          else
+            his->SetBinContent(binx, biny, value + factor);
+        }
+      }
+    }
+  }
+  his->SetXTitle("x (cm)");
+  his->SetYTitle("y (cm)");
+  his->SetStats(0);
+  his->SetMaximum(max);
+  his->SetMinimum(min);
+  delete trdGeo;
+  return his;
+}
+
+//_____________________________________________________________________________
+bool CalPad::add(float c1)
+{
+  //
+  // add constant for all channels of all ROCs
+  //
+
+  bool result = kTRUE;
+  for (int idet = 0; idet < kNdet; idet++) {
+    if (fROC[idet]) {
+      if (!fROC[idet]->add(c1))
+        result = kFALSE;
+    }
+  }
+  return result;
+}
+
+//_____________________________________________________________________________
+bool CalPad::multiply(float c1)
+{
+  //
+  // multiply constant for all channels of all ROCs
+  //
+  bool result = kTRUE;
+  for (int idet = 0; idet < kNdet; idet++) {
+    if (fROC[idet]) {
+      if (!fROC[idet]->multiply(c1))
+        result = kFALSE;
+    }
+  }
+  return result;
+}
+
+//_____________________________________________________________________________
+bool CalPad::add(const CalPad* pad, double c1, const CalDet* calDet1, const CalDet* calDet2, int type)
+{
+  //
+  // add calpad channel by channel multiplied by c1 - all ROCs
+  // If calDet1 and calDet2, the correct the CalROC from the detector coefficient
+  // then you have calDet1 and the calPad together
+  // calDet2 and pad together
+  // typedet == 0 for gain and vdrift
+  // typedet == 1 for t0
+  //
+  float kEpsilon = 0.000000000001;
+
+  double factor1 = 0.0;
+  double factor2 = 0.0;
+  if (type == 0) {
+    factor1 = 1.0;
+    factor2 = 1.0;
+  }
+  bool result = kTRUE;
+  for (int idet = 0; idet < kNdet; idet++) {
+    if (calDet1)
+      factor1 = calDet1->getValue(idet);
+    if (calDet2)
+      factor2 = calDet2->getValue(idet);
+    if (fROC[idet]) {
+      if (type == 0) {
+        if (TMath::Abs(factor1) > kEpsilon) {
+          if (!fROC[idet]->add(pad->getCalROC(idet), c1 * factor2 / factor1))
+            result = kFALSE;
+        } else
+          result = kFALSE;
+      } else {
+        CalROC* croc = new CalROC((const CalROC)*pad->getCalROC(idet));
+        if (!croc->add(factor2))
+          result = kFALSE;
+        if (!fROC[idet]->add(croc, c1))
+          result = kFALSE;
+      }
+    }
+  }
+  return result;
+}
+
+//_____________________________________________________________________________
+bool CalPad::multiply(const CalPad* pad, const CalDet* calDet1, const CalDet* calDet2, int type)
+{
+  //
+  // multiply calpad channel by channel - all ROCs
+  // If calDet1 and calDet2, the correct the CalROC from the detector coefficient
+  // then you have calDet1 and the calPad together
+  // calDet2 and pad together
+  // typedet == 0 for gain and vdrift
+  // typedet == 1 for t0
+  //
+  float kEpsilon = 0.000000000001;
+  bool result = kTRUE;
+  double factor1 = 0.0;
+  double factor2 = 0.0;
+  if (type == 0) {
+    factor1 = 1.0;
+    factor2 = 1.0;
+  }
+  for (int idet = 0; idet < kNdet; idet++) {
+    if (calDet1)
+      factor1 = calDet1->getValue(idet);
+    if (calDet2)
+      factor2 = calDet2->getValue(idet);
+    if (fROC[idet]) {
+      if (type == 0) {
+        if (TMath::Abs(factor1) > kEpsilon) {
+          CalROC* croc = new CalROC((const CalROC)*pad->getCalROC(idet));
+          if (!croc->multiply(factor2))
+            result = kFALSE;
+          if (!fROC[idet]->multiply(croc))
+            result = kFALSE;
+        } else
+          result = kFALSE;
+      } else {
+        CalROC* croc2 = new CalROC((const CalROC)*pad->getCalROC(idet));
+        if (!croc2->add(factor2))
+          result = kFALSE;
+        if (!fROC[idet]->add(factor1))
+          result = kFALSE;
+        if (!fROC[idet]->multiply(croc2))
+          result = kFALSE;
+        if (!fROC[idet]->add(-factor1))
+          result = kFALSE;
+      }
+    }
+  }
+  return result;
+}
+
+//_____________________________________________________________________________
+bool CalPad::divide(const CalPad* pad, const CalDet* calDet1, const CalDet* calDet2, int type)
+{
+  //
+  // divide calpad channel by channel - all ROCs
+  // If calDet1 and calDet2, the correct the CalROC from the detector coefficient
+  // then you have calDet1 and the calPad together
+  // calDet2 and pad together
+  // typedet == 0 for gain and vdrift
+  // typedet == 1 for t0
+  //
+  float kEpsilon = 0.000000000001;
+  bool result = kTRUE;
+  double factor1 = 0.0;
+  double factor2 = 0.0;
+  if (type == 0) {
+    factor1 = 1.0;
+    factor2 = 1.0;
+  }
+  for (int idet = 0; idet < kNdet; idet++) {
+    if (calDet1)
+      factor1 = calDet1->getValue(idet);
+    if (calDet2)
+      factor2 = calDet2->getValue(idet);
+    if (fROC[idet]) {
+      if (type == 0) {
+        if (TMath::Abs(factor1) > kEpsilon) {
+          CalROC* croc = new CalROC((const CalROC)*pad->getCalROC(idet));
+          if (!croc->multiply(factor2))
+            result = kFALSE;
+          if (!fROC[idet]->divide(croc))
+            result = kFALSE;
+        } else
+          result = kFALSE;
+      } else {
+        CalROC* croc2 = new CalROC((const CalROC)*pad->getCalROC(idet));
+        if (!croc2->add(factor2))
+          result = kFALSE;
+        if (!fROC[idet]->add(factor1))
+          result = kFALSE;
+        if (!fROC[idet]->divide(croc2))
+          result = kFALSE;
+        if (!fROC[idet]->add(-factor1))
+          result = kFALSE;
+      }
+    }
+  }
+  return result;
+}

--- a/Detectors/TRD/base/src/Calibrations.cxx
+++ b/Detectors/TRD/base/src/Calibrations.cxx
@@ -82,8 +82,9 @@ double Calibrations::getT0(int det, int col, int row) const
 {
   if (mChamberCalibrations && mLocalT0)
     return (double)mChamberCalibrations->getT0(det) + (double)mLocalT0->getValue(det, col, row);
-  else
+  else {
     return -1;
+  }
 }
 double Calibrations::getExB(int det) const
 {

--- a/Detectors/TRD/base/src/TRDBaseLinkDef.h
+++ b/Detectors/TRD/base/src/TRDBaseLinkDef.h
@@ -40,8 +40,11 @@
 #pragma link C++ class o2::trd::Calibrations + ;
 #pragma link C++ class o2::trd::ChamberNoise + ;
 #pragma link C++ class o2::trd::CalOnlineGainTables + ;
-#pragma link C++ class o2::trd::TrapConfig + ;
 #pragma link C++ class o2::trd::PadNoise + ;
+#pragma link C++ class o2::trd::PadResponse + ;
+#pragma link C++ class o2::trd::MCLabel + ;
+#pragma link C++ class o2::trd::Tracklet + ;
+#pragma link C++ class std::vector < o2::trd::Tracklet > +;
 
 #include "SimulationDataFormat/MCTruthContainer.h"
 

--- a/Detectors/TRD/base/src/Tracklet.cxx
+++ b/Detectors/TRD/base/src/Tracklet.cxx
@@ -1,0 +1,124 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+////////////////////////////////////////////////////////////////////////////
+//                                                                        //
+// TRD tracklet                                                           //
+// class for TRD tracklets from TRAP chip                                 //
+//                                                                        //
+// Authors                                                                //
+//  Alex Bercuci (A.Bercuci@gsi.de)                                       //
+//  Jochen Klein (jochen.klein@cern.ch)                                   //
+//  S. Murray (murrays@cern.ch)                                           //
+//                                                                        //
+////////////////////////////////////////////////////////////////////////////
+
+#include "TRDBase/Tracklet.h"
+#include <fairlogger/Logger.h>
+#include "TRDBase/TRDGeometry.h"
+
+//_____________________________________________________________________________
+
+using namespace std;
+using namespace o2::trd;
+
+Tracklet::Tracklet(unsigned int trackletWord) : mTrackletWord(trackletWord)
+{
+  // constructor
+
+  mGeo = TRDGeometry::instance();
+  mLabel[0] = -1;
+  mLabel[1] = -1;
+  mLabel[2] = -1;
+}
+
+Tracklet::Tracklet(unsigned int trackletWord, int hcid) : mHCId(hcid), mTrackletWord(trackletWord)
+{
+  // constructor
+
+  mGeo = TRDGeometry::instance();
+  mLabel[0] = -1;
+  mLabel[1] = -1;
+  mLabel[2] = -1;
+}
+
+Tracklet::Tracklet(unsigned int trackletWord, int hcid, int rob, int mcm) : mHCId(hcid), mTrackletWord(trackletWord), mMCM(mcm), mROB(rob)
+{
+  // constructor
+
+  mGeo = TRDGeometry::instance();
+  mLabel[0] = -1;
+  mLabel[1] = -1;
+  mLabel[2] = -1;
+}
+
+Tracklet::Tracklet(const Tracklet& rhs) : mHCId(rhs.mHCId), mTrackletWord(rhs.mTrackletWord), mMCM(rhs.mMCM), mROB(rhs.mROB), mQ0(rhs.mQ0), mQ1(rhs.mQ1), mNHits(rhs.mNHits), mNHits0(rhs.mNHits0), mNHits1(rhs.mNHits1), mSlope(rhs.mSlope), mOffset(rhs.mOffset), mError(rhs.mError), mNClusters(rhs.mNClusters)
+{
+  // copy constructor
+
+  mGeo = TRDGeometry::instance();
+  mResiduals = rhs.mResiduals;
+  mClsCharges = rhs.mClsCharges;
+  mLabel = rhs.mLabel;
+}
+
+int Tracklet::getYbin() const
+{
+  // returns (signed) value of Y
+  if (mTrackletWord & 0x1000) {
+    return -((~(mTrackletWord - 1)) & 0x1fff);
+  } else {
+    return (mTrackletWord & 0x1fff);
+  }
+}
+
+int Tracklet::getdY() const
+{
+  // returns (signed) value of the deflection length
+  if (mTrackletWord & (1 << 19)) {
+    return -((~((mTrackletWord >> 13) - 1)) & 0x7f);
+  } else {
+    return ((mTrackletWord >> 13) & 0x7f);
+  }
+}
+
+void Tracklet::setLabel(std::array<int, 3>& label)
+{
+  // set the labels (up to 3)
+
+  mLabel = label;
+}
+
+void Tracklet::setClusters(std::vector<float>& res, std::vector<float>& q, int n)
+{
+  mNClusters = n;
+
+  mResiduals = res;
+  mClsCharges = q;
+}
+
+float Tracklet::getX() const
+{
+  return mGeo->getTime0((mHCId % 12) / 2);
+}
+
+float Tracklet::getY() const
+{
+  return (getYbin() * 160e-4);
+}
+float Tracklet::getZ() const
+{
+  return mGeo->getRowPos((mHCId % 12) / 2, (mHCId / 12) % 5, 4 * (mROB / 2) + mMCM / 4) -
+         mGeo->getRowSize((mHCId % 12) / 2, (mHCId / 12) % 5, 4 * (mROB / 2) + mMCM / 4) * .5;
+}
+float Tracklet::getLocalZ() const
+{
+  return getZ() - mGeo->getRow0((mHCId % 12) / 2, (mHCId / 12) % 5) + mGeo->getRowEnd((mHCId % 12) / 2, (mHCId / 12) % 5) / 2.;
+}

--- a/Detectors/TRD/simulation/CMakeLists.txt
+++ b/Detectors/TRD/simulation/CMakeLists.txt
@@ -8,19 +8,28 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
+
+#add_compile_options(-O0 -g -fPIC) 
+
 o2_add_library(TRDSimulation
                TARGETVARNAME targetName
                SOURCES src/Detector.cxx
                        src/TRsim.cxx
                        src/Digitizer.cxx
                        src/TRDSimParams.cxx
+                       src/TrapConfig.cxx 
+                       src/TrapConfigHandler.cxx 
+                       src/TrapSimulator.cxx
                PUBLIC_LINK_LIBRARIES O2::DetectorsBase O2::SimulationDataFormat O2::TRDBase)
 
 o2_target_root_dictionary(TRDSimulation
                           HEADERS include/TRDSimulation/Detector.h
                                   include/TRDSimulation/TRsim.h
                                   include/TRDSimulation/Digitizer.h
-                                  include/TRDSimulation/TRDSimParams.h)
+				                  include/TRDSimulation/TRDSimParams.h
+                                  include/TRDSimulation/TrapConfig.h
+                                  include/TRDSimulation/TrapConfigHandler.h
+                                  include/TRDSimulation/TrapSimulator.h)
 
 if (OpenMP_CXX_FOUND)
     target_compile_definitions(${targetName} PRIVATE WITH_OPENMP)

--- a/Detectors/TRD/simulation/include/TRDSimulation/TrapConfig.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/TrapConfig.h
@@ -36,7 +36,7 @@ namespace trd
 class TrapConfig
 {
  public:
-  TrapConfig();
+  TrapConfig(std::string configname);
   ~TrapConfig();
 
   // allocation
@@ -489,6 +489,7 @@ class TrapConfig
                    kDMDELA,
                    kDMDELS,
                    kLastReg }; // enum of all TRAP registers, to be used for access to them
+
   static const int mlastAlloc = kAllocLast;
   bool setTrapRegAlloc(TrapReg_t reg, Alloc_t mode) { return mRegisterValue[reg].allocate(mode); }
   bool setTrapReg(TrapReg_t reg, int value, int det);
@@ -511,6 +512,11 @@ class TrapConfig
   unsigned int getDmemUnsigned(int addr, int det, int rob, int mcm);
 
   void resetDmem();
+  void configureOnlineGains();
+  // not implemented due to not doing online gains
+  //  double getFGANrm(int det, int rob, int mcm, int ch){return mGainTable.getFGANrm(det,rob,mcm,ch);};
+  //  double getFGFNrm(int det, int rob,int  mcm, int ch){return mGainTable.getFGFNrm(det,rob,mcm,ch);};
+  //  double getAdcdacrm(int det, int rob, int mcm){return mGainTable.getAdcdacrm(det,rob,mcm);};
 
   // access by 16-bit address
   unsigned int peek(int addr, int det, int rob, int mcm);

--- a/Detectors/TRD/simulation/include/TRDSimulation/TrapConfigHandler.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/TrapConfigHandler.h
@@ -1,0 +1,95 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TRD_TRAPCONFIGHANDLER_H
+#define O2_TRD_TRAPCONFIGHANDLER_H
+
+////////////////////////////////////////////////////////////////
+//                                                            //
+//  Multi Chip Module Simulation Configuration Handler Class  //
+//                                                            //
+////////////////////////////////////////////////////////////////
+
+#include <string>
+#include "TRDBase/CalOnlineGainTables.h"
+#include "SimulationDataFormat/MCTruthContainer.h"
+#include "TRDBase/MCLabel.h"
+
+namespace o2
+{
+namespace trd
+{
+
+class TrapConfig;
+
+class TrapConfigHandler
+{
+ public:
+  TrapConfigHandler(TrapConfig* cfg = nullptr);
+  ~TrapConfigHandler();
+
+  void init();                                 // Set DMEM allocation modes
+  void resetMCMs();                            // Reset all trap registers and DMEM of the MCMs
+  int loadConfig();                            // load a default configuration suitable for simulation
+  int loadConfig(std::string filename);        // load a TRAP configuration from a file
+  int setGaintable(CalOnlineGainTables& gtbl); // Set a gain table to correct Q0 and Q1 for PID
+
+  void processLTUparam(int dest, int addr, unsigned int data); // Process the LTU parameters
+  void printGeoTest();                                         // Prints some information about the geometry. Only for debugging
+
+  // unsigned int peek(int rob, int mcm, int addr);   // not implemented yet
+  // int poke(int rob, int mcm, int addr, unsigned int value);   // not implemented yet
+
+ private:
+  bool addValues(unsigned int det, unsigned int cmd, unsigned int extali, int addr, unsigned int data);
+
+  void configureDyCorr(int det);    // deflection length correction due to Lorentz angle and tilted pad correction
+  void configureDRange(int det);    // deflection range LUT,  range calculated according to B-field (in T) and pt_min (in GeV/c)
+  void configureNTimebins(int det); // timebins in the drift region
+  void configurePIDcorr(int det);   // Calculate the mcm individual correction factors for the PID
+
+  double square(double val) const { return val * val; }; // returns the square of a given number
+
+  TrapConfigHandler(const TrapConfigHandler& h);            // not implemented
+  TrapConfigHandler& operator=(const TrapConfigHandler& h); // not implemented
+
+  static const unsigned int mgkScsnCmdReset = 6;     // SCSN command for reset
+  static const unsigned int mgkScsnCmdPause = 8;     // SCSN command to pause
+  static const unsigned int mgkScsnCmdRead = 9;      // SCSN command to read
+  static const unsigned int mgkScsnCmdWrite = 10;    // SCSN command to write
+  static const unsigned int mgkScsnCmdPtrg = 12;     // SCSN command for pretrigger
+  static const unsigned int mgkScsnCmdRobPower = 16; // SCSN command to switch ROB power
+  static const unsigned int mgkScsnCmdRobReset = 17; // SCSN command for ROB reset
+
+  static const unsigned int mgkScsnCmdRestr = 18;   // SCSN command to restrict commands to specified chambers
+  static const unsigned int mgkScsnCmdTtcRx = 19;   // SCSN command to configure TTCrx
+  static const unsigned int mgkScsnCmdHwPtrg = 20;  // SCSN command to issue pretrigger pulse
+  static const unsigned int mgkScsnCmdSetHC = 22;   // SCSN command to set HC ID
+  static const unsigned int mgkScsnCmdMcmTemp = 24; // SCSN command for MCM temperature sensors
+  static const unsigned int mgkScsnCmdPM = 25;      // SCSN command for patchmaker
+  static const unsigned int mgkScsnCmdOri = 26;     // SCSN command for ORI configuration
+  static const unsigned int mgkScsnLTUparam = 27;   // extended SCSN command for the LTU configuration
+
+  static const int mgkMCMperROBCol = 4; // MCMs per ROB column
+  static const int mgkPadsPerMCM = 18;  // readout pads per MCM
+  static const int mgkMCMperROBRow = 4; // MCMs per ROB row
+
+  static const int mgkMaxLinkPairs = 4;  // number of linkpairs used during configuration
+  static const int mgkMcmlistSize = 256; // list of MCMs to which a value has to be written
+
+  unsigned int mRestrictiveMask; // mask to restrict subsequent commands to specified chambers
+  FeeParam* mFeeParam;           //pointer to a singleton
+  TrapConfig* mTrapConfig;       // pointer to TRAP config in use
+  CalOnlineGainTables mGtbl;     // gain table
+};
+
+} //namespace trd
+} //namespace o2
+#endif

--- a/Detectors/TRD/simulation/include/TRDSimulation/TrapSimulator.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/TrapSimulator.h
@@ -1,0 +1,352 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TRD_TRAPSIMULATOR_H
+#define O2_TRD_TRAPSIMULATOR_H
+
+///////////////////////////////////////////////////////
+//                                                   //
+//  TRAP Chip Simulation Class               //
+//                                                   //
+///////////////////////////////////////////////////////
+
+#include <iosfwd>
+#include <iostream>
+#include <ostream>
+#include <fstream>
+
+#include "TRDBase/Tracklet.h"
+#include "TRDBase/FeeParam.h"
+#include "TRDBase/Digit.h"
+#include "TRDBase/MCLabel.h"
+#include "TRDSimulation/Digitizer.h"
+#include "TRDSimulation/TrapConfigHandler.h"
+#include "TRDSimulation/TrapConfig.h"
+
+class TH2F;
+
+namespace o2
+{
+namespace trd
+{
+
+class TrapSimulator
+{
+ public:
+  TrapSimulator();
+  ~TrapSimulator() = default;
+
+  enum { PRINTRAW = 1,
+         PRINTFILTERED = 2,
+         PRINTDETECTED = 4,
+         PRINTFOUND = 8 };
+  enum { PLOTRAW = 1,
+         PLOTHITS = 2,
+         PLOTTRACKLETS = 4 };
+
+  void init(TrapConfig* trapconfig, int det, int rob, int mcm);
+  // Initialize MCM by the position parameters
+
+  void reset();
+  // clears filter registers and internal data
+  void clear();
+  //  void setDebugStream(TTreeSRedirector* stream) { mDebugStream = stream; }
+  //  TTreeSRedirector* getDebugStream() const { return mDebugStream; }
+
+  bool loadMCM(/*AliRunLoader* const runloader, */ int det, int rob, int mcm);
+
+  void noiseTest(int nsamples, int mean, int sigma, int inputGain = 1, int inputTail = 2);
+
+  int getDataRaw(int iadc, int timebin) const { return (mADCR[iadc * mNTimeBin + timebin] >> 2); }
+  // get unfiltered ADC data
+  int getDataFiltered(int iadc, int timebin) const { return (mADCF[iadc * mNTimeBin + timebin] >> 2); }
+  // get filtered ADC data
+  int getZeroSupressionMap(int iadc) const { return (mZSMap[iadc]); }
+  bool isDataSet() { return mDataIsSet; };
+  void unsetData()
+  {
+    mDataIsSet = false;
+    //if(mHits.size()>50) LOG(warn) << "mHits size is >50 ==" << mHits.size();
+    //    for(int i=0;i<mNHits;i++) mHits[i].ClearHits();//I dont need to unset this as I am setting mNHits to zero
+    //if(mFitReg.size()>50) LOG(warn) << "mFitReg size is >50 ==" << mFitReg.size();
+    for (auto& fitreg : mFitReg)
+      fitreg.ClearReg();
+    mNHits = 0;
+  };
+  void setData(int iadc, const std::vector<int>& adc);                                                                              // set ADC data with array
+  void setData(int iadc, const ArrayADC& adc);                                                                                      // set ADC data with array
+  void setData(int iadc, int it, int adc);                                                                                          // set ADC data
+  void setDataFromDigitizerAndRun(std::vector<o2::trd::Digit>& data, o2::dataformats::MCTruthContainer<MCLabel>&);                  // data coming in manually from the the digitizer.
+                                                                                                                                    /*   void setData(TRDArrayADC* const adcArray,
+               TRDdigitsManager* const digitsManager = 0x0); // set ADC data from adcArray
+  void setDataByPad(const TRDArrayADC* const adcArray,
+                    TRDdigitsManager* const digitsManager = 0x0); // set ADC data from adcArray
+*/
+  void setDataByPad(std::vector<o2::trd::Digit>& padrowdata, o2::dataformats::MCTruthContainer<MCLabel>& labels, int padrowoffset); // data coming in manually from the the digitizer.
+  void setDataPedestal(int iadc);                                                                                                   // Fill ADC data with pedestal values
+
+  static bool getApplyCut() { return mgApplyCut; }
+  static void setApplyCut(bool applyCut) { mgApplyCut = applyCut; }
+
+  static int getAddBaseline() { return mgAddBaseline; }
+  static void setAddBaseline(int baseline) { mgAddBaseline = baseline; }
+  // Additional baseline which is added for the processing
+  // in the TRAP and removed when writing back the data.
+  // This is needed to run with TRAP parameters set for a
+  // different baseline but it will not change the baseline
+  // of the output.
+
+  static void setStoreClusters(bool storeClusters) { mgStoreClusters = storeClusters; }
+  static bool getStoreClusters() { return mgStoreClusters; }
+
+  int getDetector() const { return mDetector; }; // Returns Chamber ID (0-539)
+  int getRobPos() const { return mRobPos; };     // Returns ROB position (0-7)
+  int getMcmPos() const { return mMcmPos; };     // Returns MCM position (0-17) (16,17 are mergers)
+  int getRow() const { return mRow; };           // Returns Row number on chamber where the MCM is sitting
+  int getCol(int iadc);                          // get corresponding column (0-143) from for ADC channel iadc = [0:20]
+  // for the ADC/Col mapping, see: http://wiki.kip.uni-heidelberg.de/ti/TRD/index.php/Image:ROB_MCM_numbering.pdf
+  const int getNumberOfTimeBins() const { return mNTimeBin; };
+  bool storeTracklets(); // Stores tracklets to file -- debug purposes
+  std::string getTrklBranchName() const { return mTrklBranchName; }
+  void setTrklBranchName(std::string name) { mTrklBranchName = name; }
+
+  int produceRawStream(unsigned int* buf, int bufsize, unsigned int iEv = 0) const; // Produce raw data stream - Real data format
+  int produceTrackletStream(unsigned int* buf, int bufsize);                        // produce the tracklet stream for this MCM
+
+  // different stages of processing in the TRAP
+  void filter();                // Apply digital filters for existing data (according to configuration)
+  void zeroSupressionMapping(); // Do ZS mapping for existing data
+  void tracklet();              // Run tracklet preprocessor and perform tracklet fit
+
+  // apply individual filters to all channels and timebins
+  void filterPedestal(); // Apply pedestal filter
+  void filterGain();     // Apply gain filter
+  void filterTail();     // Apply tail filter
+
+  // filter initialization (resets internal registers)
+  void filterPedestalInit(int baseline = 10);
+  void filterGainInit();
+  void filterTailInit(int baseline = -1);
+
+  // feed single sample to individual filter
+  // this changes the internal registers
+  // all filters operate on (10+2)-bit values!
+  unsigned short filterPedestalNextSample(int adc, int timebin, unsigned short value);
+  unsigned short filterGainNextSample(int adc, unsigned short value);
+  unsigned short filterTailNextSample(int adc, unsigned short value);
+
+  // tracklet calculation
+  void addHitToFitreg(int adc, unsigned short timebin, unsigned short qtot, short ypos);
+  void calcFitreg();
+  void trackletSelection();
+  void fitTracklet();
+
+  int getNHits() const { return mHits.size(); }
+  bool getHit(int index, int& channel, int& timebin, int& qtot, int& ypos, float& y, int& label) const;
+
+  // data display
+  void print(int choice) const;     // print stored data to stdout
+  void draw(int choice, int index); // draw data (ADC data, hits and tracklets)
+
+  friend std::ostream& operator<<(std::ostream& os, const TrapSimulator& mcm); // data output using ostream (e.g. cout << mcm;)
+  static ostream& cfdat(ostream& os);                                          // manipulator to activate cfdat output
+  static ostream& raw(ostream& os);                                            // manipulator to activate raw output
+  static ostream& text(ostream& os);                                           // manipulator to activate text output
+
+  // PID
+  int getPID(int q0, int q1);
+  void printPidLutHuman();
+
+  // I/O
+  void printFitRegXml(ostream& os) const;
+  void printTrackletsXml(ostream& os) const;
+  void printAdcDatTxt(ostream& os) const;
+  void printAdcDatHuman(ostream& os) const;
+  void printAdcDatXml(ostream& os) const;
+  void printAdcDatDatx(ostream& os, bool broadcast = kFALSE, int timeBinOffset = -1) const;
+
+  static bool readPackedConfig(TrapConfig* cfg, int hc, unsigned int* data, int size);
+
+  // DMEM addresses
+  static const int mgkDmemAddrLUTcor0 = 0xC02A;
+  static const int mgkDmemAddrLUTcor1 = 0xC028;
+  static const int mgkDmemAddrLUTnbins = 0xC029;
+
+  static const int mgkDmemAddrLUTStart = 0xC100;  // LUT start address
+  static const int mgkDmemAddrLUTEnd = 0xC3FF;    // maximum possible end address for the LUT table
+  static const int mgkDmemAddrLUTLength = 0xC02B; // address where real size of the LUT table is stored
+
+  static const int mgkDmemAddrTrackletStart = 0xC0E0; // Storage area for tracklets, start address
+  static const int mgkDmemAddrTrackletEnd = 0xC0E3;   // Storage area for tracklets, end address
+
+  static const int mgkDmemAddrDeflCorr = 0xc022;     // DMEM address of deflection correction
+  static const int mgkDmemAddrNdrift = 0xc025;       // DMEM address of Ndrift
+  static const int mgkDmemAddrDeflCutStart = 0xc030; // DMEM start address of deflection cut
+  static const int mgkDmemAddrDeflCutEnd = 0xc055;   // DMEM end address of deflection cut
+  static const int mgkDmemAddrTimeOffset = 0xc3fe;   // DMEM address of time offset t0
+  static const int mgkDmemAddrYcorr = 0xc3ff;        // DMEM address of y correction (mis-alignment)
+  static const int mgkMaxTracklets = 4;              // maximum number of tracklet-words submitted per MCM (one per CPU)
+  //std::array<TrackletMCM> getTrackletArray() const { return mTrackletArray; }
+  std::vector<Tracklet>& getTrackletArray() { return mTrackletArray; }
+  void getTracklets(std::vector<Tracklet>& TrackletStore); // place the trapsim tracklets nto the incoming vector
+
+  bool checkInitialized() const;     // Check whether the class is initialized
+  static const int mgkFormatIndex;   // index for format settings in stream
+                                     //TODO should this change to 3 for the new format ????? I cant remember now, ask someone.
+  static const int mgkAddDigits = 2; // additional digits used for internal representation of ADC data
+                                     // all internal data as after data control block (i.e. 12 bit), s. TRAP manual
+  static const int mgkNCPU = 4;      // Number of CPUs in the TRAP
+  static const int mgkNHitsMC = 100; // maximum number of hits for which MC information is kept
+
+  static const std::array<unsigned short, 4> mgkFPshifts; // shifts for pedestal filter
+  // hit detection
+  // individual hits can be stored as MC info
+  class Hit
+  { // Array of detected hits (only available in MC)
+   public:
+    Hit() = default;
+    Hit(int channel, int timebin, int qtot, int ypos) : mChannel(channel), mTimebin(timebin), mQtot(qtot), mYpos(ypos) {}
+    ~Hit() = default;
+    int mChannel; // ADC channel of the hit
+    int mTimebin; // timebin of the hit
+    int mQtot;    // total charge of the hit
+    int mYpos;    // calculated y-position
+                  //  std::array<int, 3> mLabel{}; // up to 3 labels (only in MC) run3 is free to have many, but does more than 1 per digit make sense.
+    void ClearHits()
+    {
+      mChannel = 0;
+      mTimebin = 0;
+      mQtot = 0;
+      mYpos = 0;
+    }
+  }; //mHits[mgkNHitsMC];
+  //std::array<Hit, 50> mHits;
+  std::array<Hit, mgkNHitsMC> mHits{}; // was 100 in the run2 via fgkNHitsMC;
+  class FilterReg
+  {
+   public:
+    FilterReg() = default;
+    ~FilterReg() = default;
+    unsigned int mPedAcc;          // Accumulator for pedestal filter
+    unsigned int mGainCounterA;    // Counter for values above FGTA in the gain filter
+    unsigned int mGainCounterB;    // Counter for values above FGTB in the gain filter
+    unsigned short mTailAmplLong;  // Amplitude of the long component in the tail filter
+    unsigned short mTailAmplShort; // Amplitude of the short component in the tail filter
+    void ClearReg()
+    {
+      mPedAcc = 0;
+      mGainCounterA = 0;
+      mGainCounterB = 0;
+      mTailAmplLong = 0;
+      mTailAmplShort = 0;
+    };
+  };
+  // tracklet calculation
+  class FitReg
+  { // pointer to the 18 fit registers
+   public:
+    FitReg() = default;
+    ~FitReg() = default;
+    int mNhits;          // number of hits
+    unsigned int mQ0;    // charge accumulated in first window
+    unsigned int mQ1;    // charge accumulated in second window
+    unsigned int mSumX;  // sum x
+    int mSumY;           // sum y
+    unsigned int mSumX2; // sum x**2
+    unsigned int mSumY2; // sum y**2
+    int mSumXY;          // sum x*y
+    void ClearReg()
+    {
+      mNhits = 0;
+      mQ0 = 0;
+      mQ1 = 0;
+      mSumX = 0;
+      mSumY = 0;
+      mSumX2 = 0;
+      mSumY2 = 0;
+      mSumXY = 0;
+    }
+  };
+  std::array<FitReg, 25> mFitReg{}; // TODO come back and make this 21 or 22, I cant remember now which one, so making it 25 to be safe ;-)
+                                    //std::vector<FitReg,FeeParam::mgkNadcMcm> mFitReg;
+
+ protected:
+  void setNTimebins(int ntimebins); // allocate data arrays corr. to the no. of timebins
+
+  bool mInitialized;      // memory is allocated if initialized
+  int mDetector;          // Chamber ID
+  int mRobPos;            // ROB Position on chamber
+  int mMcmPos;            // MCM Position on chamber
+  int mRow;               // Pad row number (0-11 or 0-15) of the MCM on chamber
+  int mNTimeBin;          // Number of timebins currently allocated
+  std::vector<int> mADCR; // Array with MCM ADC values (Raw, 12 bit) 2d with dimension mNTimeBin
+  std::vector<int> mADCF; // Array with MCM ADC values (Filtered, 12 bit) 2d with dimension mNTimeBin
+
+  std::vector<unsigned int> mMCMT;      // tracklet word for one mcm/trap-chip
+  std::vector<Tracklet> mTrackletArray; // Array of TRDtrackletMCM which contains MC information in addition to the tracklet word
+  std::vector<int> mZSMap;              // Zero suppression map (1 dimensional projection)
+
+  std::array<int, mgkNCPU> mFitPtr{}; // pointer to the tracklet to be calculated by CPU i
+
+  std::string mTrklBranchName; // name of the tracklet branch to write to
+
+  // Parameter classes
+  FeeParam* mFeeParam;     // FEE parameters
+  TrapConfig* mTrapConfig; // TRAP config
+  TrapConfigHandler mTrapConfigHandler;
+  CalOnlineGainTables mGainTable;
+
+  static const int NOfAdcPerMcm = 21;
+  //TRDdigitsManager* mDigitsManager; // pointer to digits manager used for MC label calculation
+  //  TRDArrayDictionary* mDict[3];     // pointers to label dictionaries
+  // Dictionaries are now done a differentway ??? to be determined TODO
+  //  std::vector<int> mDict1;
+  //  std::vector<int> mDict2;
+  //  std::vector<int> mDict3;
+  // internal filter registers
+
+  std::array<FilterReg, NOfAdcPerMcm> mInternalFilterRegisters;
+
+  int mNHits; // Number of detected hits
+
+  // Sort functions as in TRAP
+  void sort2(unsigned short idx1i, unsigned short idx2i, unsigned short val1i, unsigned short val2i,
+             unsigned short* const idx1o, unsigned short* const idx2o, unsigned short* const val1o, unsigned short* const val2o) const;
+  void sort3(unsigned short idx1i, unsigned short idx2i, unsigned short idx3i,
+             unsigned short val1i, unsigned short val2i, unsigned short val3i,
+             unsigned short* const idx1o, unsigned short* const idx2o, unsigned short* const idx3o,
+             unsigned short* const val1o, unsigned short* const val2o, unsigned short* const val3o);
+  void sort6To4(unsigned short idx1i, unsigned short idx2i, unsigned short idx3i, unsigned short idx4i, unsigned short idx5i, unsigned short idx6i,
+                unsigned short val1i, unsigned short val2i, unsigned short val3i, unsigned short val4i, unsigned short val5i, unsigned short val6i,
+                unsigned short* const idx1o, unsigned short* const idx2o, unsigned short* const idx3o, unsigned short* const idx4o,
+                unsigned short* const val1o, unsigned short* const val2o, unsigned short* const val3o, unsigned short* const val4o);
+  void sort6To2Worst(unsigned short idx1i, unsigned short idx2i, unsigned short idx3i, unsigned short idx4i, unsigned short idx5i, unsigned short idx6i,
+                     unsigned short val1i, unsigned short val2i, unsigned short val3i, unsigned short val4i, unsigned short val5i, unsigned short val6i,
+                     unsigned short* const idx5o, unsigned short* const idx6o);
+
+  unsigned int addUintClipping(unsigned int a, unsigned int b, unsigned int nbits) const;
+  // Add a and b (unsigned) with clipping to the maximum value representable by nbits
+
+ private:
+  TrapSimulator(const TrapSimulator& m);            // not implemented
+  TrapSimulator& operator=(const TrapSimulator& m); // not implemented
+
+  static bool mgApplyCut; // apply cut on deflection length
+
+  static int mgAddBaseline; // add baseline to the ADC values
+
+  static bool mgStoreClusters; // whether to store all clusters in the tracklets
+  bool mDataIsSet = false;
+};
+
+std::ostream& operator<<(std::ostream& os, const TrapSimulator& mcm);
+} //namespace trd
+} //namespace o2
+#endif

--- a/Detectors/TRD/simulation/src/TRDSimulationLinkDef.h
+++ b/Detectors/TRD/simulation/src/TRDSimulationLinkDef.h
@@ -19,6 +19,9 @@
 #pragma link C++ class o2::trd::HitType + ;
 #pragma link C++ class o2::trd::TRsim + ;
 #pragma link C++ class o2::trd::Digitizer + ;
+#pragma link C++ class o2::trd::TrapConfigHandler + ;
+#pragma link C++ class o2::trd::TrapConfig + ;
+#pragma link C++ class o2::trd::TrapSimulator + ;
 
 #pragma link C++ class o2::trd::TRDSimParams + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::trd::TRDSimParams> + ;

--- a/Detectors/TRD/simulation/src/TrapConfig.cxx
+++ b/Detectors/TRD/simulation/src/TrapConfig.cxx
@@ -18,7 +18,7 @@
 
 #include "TRDBase/TRDGeometry.h"
 #include "TRDBase/FeeParam.h"
-#include "TRDBase/TrapConfig.h"
+#include "TRDSimulation/TrapConfig.h"
 #include <fairlogger/Logger.h>
 
 #include <fstream>
@@ -33,7 +33,7 @@ bool TrapConfig::mgRegAddressMapInitialized = false;
 
 const std::array<int, TrapConfig::mlastAlloc> o2::trd::TrapConfig::TrapValue::mgkSize = {0, 1, 540, 1080, 8 * 18 * 540, 4, 6, 8 * 18 * 30};
 
-TrapConfig::TrapConfig()
+TrapConfig::TrapConfig(std::string configname)
 {
   // default constructor
 
@@ -864,9 +864,10 @@ int TrapConfig::TrapValue::getIdx(int det, int rob, int mcm)
       LOG(error) << "Invalid allocation mode";
   }
   if (idx < mData.size()) {
+    // LOG(info) << "Index ok " << dec << idx << " (size " << mData.size() << ") for " << this->getName() << " getIdx : " << det <<"::"<< rob<< "::" << mcm << "::" << mAllocMode;
     return idx;
   } else {
-    LOG(error) << "Index too large " << dec << idx << " (size " << mData.size() << ") for " << this->getName();
+    LOG(fatal) << "Index too large " << dec << idx << " (size " << mData.size() << ") for " << this->getName() << " getIdx : " << det << "::" << rob << "::" << mcm << "::" << mAllocMode;
     return -1;
   }
 }
@@ -985,4 +986,48 @@ void TrapConfig::TrapRegister::initfromrun2(const char* name, int addr, int nBit
   mNbits = nBits;
   mResetValue = resetValue;
   //LOG(fatal) << "Re-initialising an existing TRAP register " << name << ":" << mName << " : " << addr << ":" << mAddr << " : " << nBits << ":" << mNbits <<  " : " << resetValue << ":" << mResetValue;
+  LOG(fatal) << "Re-initialising an existing TRAP register";
+}
+
+void TrapConfig::configureOnlineGains()
+{
+  // we dont want to do this anymore .... but here for future reference.
+  /* if (hasOnlineFilterGain()) {
+    const int nDets = kNdet;
+    const int nMcms = TRDGeometry::MCMmax();
+    const int nChs = TRDGeometry::ADCmax();
+
+    for (int ch = 0; ch < nChs; ++ch) {
+      TrapConfig::TrapReg_t regFGAN = (TrapConfig::TrapReg_t)(TrapConfig::kFGA0 + ch);
+      TrapConfig::TrapReg_t regFGFN = (TrapConfig::TrapReg_t)(TrapConfig::kFGF0 + ch);
+      mTrapConfig->setTrapRegAlloc(regFGAN, TrapConfig::kAllocByMCM);
+      mTrapConfig->setTrapRegAlloc(regFGFN, TrapConfig::kAllocByMCM);
+    }
+
+    for (int iDet = 0; iDet < nDets; ++iDet) {
+      //const int MaxRows = TRDGeometry::getStack(iDet) == 2 ? FeeParam::mgkNrowC0 : FeeParam::mgkNrowC1;
+      int MaxCols = FeeParam::mgkNcol;
+      //	CalOnlineGainTableROC gainTbl = mGainTable.getGainTableROC(iDet);
+      const int nRobs = TRDGeometry::getStack(iDet) == 2 ? TRDGeometry::ROBmaxC0() : TRDGeometry::ROBmaxC1();
+
+      for (int rob = 0; rob < nRobs; ++rob) {
+        for (int mcm = 0; mcm < nMcms; ++mcm) {
+          //          for (int row = 0; row < MaxRows; row++) {
+          //            for (int col = 0; col < MaxCols; col++) {
+          //TODO  set ADC reference voltage
+          mTrapConfig->setTrapReg(TrapConfig::kADCDAC, mTrapConfig.getAdcdacrm(iDet, rob, mcm), iDet, rob, mcm);
+
+          // set constants channel-wise
+          for (int ch = 0; ch < nChs; ++ch) {
+            TrapConfig::TrapReg_t regFGAN = (TrapConfig::TrapReg_t)(TrapConfig::kFGA0 + ch);
+            TrapConfig::TrapReg_t regFGFN = (TrapConfig::TrapReg_t)(TrapConfig::kFGF0 + ch);
+            mTrapConfig->setTrapReg(regFGAN, mTrapConfig.getFGANrm(iDet, rob, mcm, ch), iDet, rob, mcm); //TODO can put these internal to TrapConfig
+            mTrapConfig->setTrapReg(regFGFN, mTrapConfig.getFGFNrm(iDet, rob, mcm, ch), iDet, rob, mcm);
+          }
+        }
+        //        }
+        //    }
+      }
+    }
+        }*/
 }

--- a/Detectors/TRD/simulation/src/TrapConfigHandler.cxx
+++ b/Detectors/TRD/simulation/src/TrapConfigHandler.cxx
@@ -1,0 +1,640 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+////////////////////////////////////////////////////////////////////////////
+//                                                                        //
+//  Trap configuraton handler                                             //
+//                                                                        //
+//  based on work by U. Westerhoff                                        //
+//                                                                        //
+////////////////////////////////////////////////////////////////////////////
+
+#include <iostream>
+#include <sstream>
+#include <iomanip>
+
+#include "TRDBase/FeeParam.h"
+#include "TRDBase/Tracklet.h"
+#include "TRDBase/TRDGeometry.h"
+#include "TRDBase/CalOnlineGainTables.h"
+#include "TRDBase/PadResponse.h"
+#include "TRDSimulation/TrapConfigHandler.h"
+#include "TRDSimulation/TrapConfig.h"
+#include "TRDSimulation/TrapSimulator.h"
+#include "TMath.h"
+#include "TGeoMatrix.h"
+#include "TGraph.h"
+
+using namespace std;
+using namespace o2::trd;
+
+TrapConfigHandler::TrapConfigHandler(TrapConfig* cfg) : mFeeParam(), mRestrictiveMask((0x3ffff << 11) | (0x1f << 6) | 0x3f), mTrapConfig(cfg), mGtbl()
+{
+}
+
+TrapConfigHandler::~TrapConfigHandler() = default;
+
+void TrapConfigHandler::init()
+{
+  if (!mTrapConfig) {
+    LOG(error) << "No TRAPconfig given";
+    return;
+  }
+
+  // setup of register allocation
+  // I/O configuration which we don't care about
+  mTrapConfig->setTrapRegAlloc(TrapConfig::kSEBDOU, TrapConfig::kAllocNone);
+  // position look-up table by layer
+  for (int iBin = 0; iBin < 128; iBin++)
+    mTrapConfig->setTrapRegAlloc((TrapConfig::TrapReg_t)(TrapConfig::kTPL00 + iBin), TrapConfig::kAllocByLayer);
+  // ... individual
+  mTrapConfig->setTrapRegAlloc(TrapConfig::kC14CPUA, TrapConfig::kAllocByMCM);
+  mTrapConfig->setTrapRegAlloc(TrapConfig::kC15CPUA, TrapConfig::kAllocByMCM);
+
+  // setup of DMEM allocation
+  for (int iAddr = TrapConfig::mgkDmemStartAddress;
+       iAddr < (TrapConfig::mgkDmemWords + TrapConfig::mgkDmemStartAddress); iAddr++) {
+
+    if (iAddr == TrapSimulator::mgkDmemAddrDeflCorr)
+      mTrapConfig->setDmemAlloc(iAddr, TrapConfig::kAllocByMCMinSM);
+
+    else if (iAddr == TrapSimulator::mgkDmemAddrNdrift)
+      mTrapConfig->setDmemAlloc(iAddr, TrapConfig::kAllocByDetector);
+
+    else if ((iAddr >= TrapSimulator::mgkDmemAddrDeflCutStart) && (iAddr <= TrapSimulator::mgkDmemAddrDeflCutEnd))
+      mTrapConfig->setDmemAlloc(iAddr, TrapConfig::kAllocByMCMinSM);
+
+    else if ((iAddr >= TrapSimulator::mgkDmemAddrTrackletStart) && (iAddr <= TrapSimulator::mgkDmemAddrTrackletEnd))
+      mTrapConfig->setDmemAlloc(iAddr, TrapConfig::kAllocByMCM);
+
+    else if ((iAddr >= TrapSimulator::mgkDmemAddrLUTStart) && (iAddr <= TrapSimulator::mgkDmemAddrLUTEnd))
+      mTrapConfig->setDmemAlloc(iAddr, TrapConfig::kAllocGlobal);
+
+    else if (iAddr == TrapSimulator::mgkDmemAddrLUTcor0)
+      mTrapConfig->setDmemAlloc(iAddr, TrapConfig::kAllocByMCMinSM);
+
+    else if (iAddr == TrapSimulator::mgkDmemAddrLUTcor1)
+      mTrapConfig->setDmemAlloc(iAddr, TrapConfig::kAllocByMCMinSM);
+
+    else if (iAddr == TrapSimulator::mgkDmemAddrLUTnbins)
+      mTrapConfig->setDmemAlloc(iAddr, TrapConfig::kAllocGlobal);
+
+    else if (iAddr == TrapSimulator::mgkDmemAddrLUTLength)
+      mTrapConfig->setDmemAlloc(iAddr, TrapConfig::kAllocGlobal);
+
+    else
+      mTrapConfig->setDmemAlloc(iAddr, TrapConfig::kAllocGlobal);
+  }
+  mFeeParam = FeeParam::instance();
+}
+
+void TrapConfigHandler::resetMCMs()
+{
+  //
+  // Reset all MCM registers and DMEM
+  //
+
+  if (!mTrapConfig) {
+    LOG(error) << "No TRAPconfig given";
+    return;
+  }
+
+  mTrapConfig->resetRegs();
+  mTrapConfig->resetDmem();
+}
+
+int TrapConfigHandler::loadConfig()
+{
+  // load a default configuration which is suitable for simulation
+  // for a detailed description of the registers see the TRAP manual
+  // if you want to resimulate tracklets on real data use the appropriate config instead
+
+  if (!mTrapConfig) {
+    LOG(error) << "No TRAPconfig given";
+    return -1;
+  }
+
+  // prepare mFeeParam
+  // ndrift (+ 5 binary digits)
+  mFeeParam->setNtimebins(20 << 5);
+  // deflection + tilt correction
+  mFeeParam->setRawOmegaTau(0.16133);
+  // deflection range table
+  mFeeParam->setRawPtMin(0.1);
+  // magnetic field
+  mFeeParam->setRawMagField(0.0);
+  // scaling factors for q0, q1
+  mFeeParam->setRawScaleQ0(0);
+  mFeeParam->setRawScaleQ1(0);
+  // disable length correction and tilting correction
+  mFeeParam->setRawLengthCorrectionEnable(false);
+  mFeeParam->setRawTiltCorrectionEnable(false);
+
+  for (int iDet = 0; iDet < 540; iDet++) {
+    // HC header configuration bits
+    mTrapConfig->setTrapReg(TrapConfig::kC15CPUA, 0x2102, iDet); // zs, deh
+
+    // no. of timebins
+    mTrapConfig->setTrapReg(TrapConfig::kC13CPUA, 24, iDet);
+
+    // pedestal filter
+    mTrapConfig->setTrapReg(TrapConfig::kFPNP, 4 * 10, iDet);
+    mTrapConfig->setTrapReg(TrapConfig::kFPTC, 0, iDet);
+    mTrapConfig->setTrapReg(TrapConfig::kFPBY, 0, iDet); // bypassed!
+
+    // gain filter
+    for (int adc = 0; adc < 20; adc++) {
+      mTrapConfig->setTrapReg(TrapConfig::TrapReg_t(TrapConfig::kFGA0 + adc), 40, iDet);
+      mTrapConfig->setTrapReg(TrapConfig::TrapReg_t(TrapConfig::kFGF0 + adc), 15, iDet);
+    }
+    mTrapConfig->setTrapReg(TrapConfig::kFGTA, 20, iDet);
+    mTrapConfig->setTrapReg(TrapConfig::kFGTB, 2060, iDet);
+    mTrapConfig->setTrapReg(TrapConfig::kFGBY, 0, iDet); // bypassed!
+
+    // tail cancellation
+    mTrapConfig->setTrapReg(TrapConfig::kFTAL, 200, iDet);
+    mTrapConfig->setTrapReg(TrapConfig::kFTLL, 0, iDet);
+    mTrapConfig->setTrapReg(TrapConfig::kFTLS, 200, iDet);
+    mTrapConfig->setTrapReg(TrapConfig::kFTBY, 0, iDet);
+
+    // tracklet calculation
+    mTrapConfig->setTrapReg(TrapConfig::kTPQS0, 5, iDet);
+    mTrapConfig->setTrapReg(TrapConfig::kTPQE0, 10, iDet);
+    mTrapConfig->setTrapReg(TrapConfig::kTPQS1, 11, iDet);
+    mTrapConfig->setTrapReg(TrapConfig::kTPQE1, 20, iDet);
+    mTrapConfig->setTrapReg(TrapConfig::kTPFS, 5, iDet);
+    mTrapConfig->setTrapReg(TrapConfig::kTPFE, 20, iDet);
+    mTrapConfig->setTrapReg(TrapConfig::kTPVBY, 0, iDet);
+    mTrapConfig->setTrapReg(TrapConfig::kTPVT, 10, iDet);
+    mTrapConfig->setTrapReg(TrapConfig::kTPHT, 150, iDet);
+    mTrapConfig->setTrapReg(TrapConfig::kTPFP, 40, iDet);
+    mTrapConfig->setTrapReg(TrapConfig::kTPCL, 1, iDet);
+    mTrapConfig->setTrapReg(TrapConfig::kTPCT, 10, iDet);
+
+    // apply mFeeParams
+    configureDyCorr(iDet);
+    configureDRange(iDet);    // deflection range
+    configureNTimebins(iDet); // timebins in the drift region
+    configurePIDcorr(iDet);   // scaling parameters for the PID
+
+    // event buffer
+    mTrapConfig->setTrapReg(TrapConfig::kEBSF, 1, iDet); // 0: store filtered; 1: store unfiltered
+
+    // zs applied to data stored in event buffer (sel. by EBSF)
+    mTrapConfig->setTrapReg(TrapConfig::kEBIS, 15, iDet);   // single indicator threshold (plus two digits)
+    mTrapConfig->setTrapReg(TrapConfig::kEBIT, 30, iDet);   // sum indicator threshold (plus two digits)
+    mTrapConfig->setTrapReg(TrapConfig::kEBIL, 0xf0, iDet); // lookup table
+    mTrapConfig->setTrapReg(TrapConfig::kEBIN, 0, iDet);    // neighbour sensitivity
+
+    // raw data
+    mTrapConfig->setTrapReg(TrapConfig::kNES, (0x0000 << 16) | 0x1000, iDet);
+  }
+
+  // ****** hit position LUT
+
+  // now calculate it from PRF
+  PadResponse padresponse;
+  double padResponse[3];  // pad response left, central, right
+  double padResponseR[3]; // pad response left, central, right
+  double padResponseL[3]; // pad response left, central, right
+
+  for (int iLayer = 0; iLayer < 6; iLayer++) {
+    TGraph gr(128);
+    for (int iBin = 0; iBin < 256 * 0.5; iBin++) {
+      padresponse.getPRF(1., iBin * 1. / 256., iLayer, padResponse);
+      padresponse.getPRF(1., iBin * 1. / 256. - 1., iLayer, padResponseR);
+      padresponse.getPRF(1., iBin * 1. / 256. + 1., iLayer, padResponseL);
+      gr.SetPoint(iBin, (0.5 * (padResponseR[1] - padResponseL[1]) / padResponse[1] * 256), iBin);
+    }
+    for (int iBin = 0; iBin < 128; iBin++) {
+      int corr = (int)(gr.Eval(iBin)) - iBin;
+      if (corr < 0)
+        corr = 0;
+      else if (corr > 31)
+        corr = 31;
+      for (int iStack = 0; iStack < 540 / 6; iStack++) {
+        mTrapConfig->setTrapReg((TrapConfig::TrapReg_t)(TrapConfig::kTPL00 + iBin), corr, 6 * iStack + iLayer);
+      }
+    }
+  }
+  // ****** hit position LUT configuration end
+
+  return 0;
+}
+
+int TrapConfigHandler::loadConfig(std::string filename)
+{
+  //
+  // load a TRAP configuration from a file
+  // The file format is the format created by the standalone
+  // command coder scc / show_cfdat but without the running number
+  // scc /show_cfdat adds as the first column
+  // which are two tools to inspect/export configurations from wingDB
+  //
+
+  if (!mTrapConfig) {
+    LOG(error) << "No TRAPconfig given";
+    return -1;
+  }
+
+  int ignoredLines = 0;
+  int ignoredCmds = 0;
+  int readLines = 0;
+
+  LOG(debug3) << "Processing file " << filename.c_str();
+  std::ifstream infile;
+  infile.open(filename.c_str(), std::ifstream::in);
+  if (!infile.is_open()) {
+    LOG(error) << "Can not open MCM configuration file  " << filename;
+    return false;
+  }
+
+  int addr;
+
+  // reset restrictive mask
+  mRestrictiveMask = (0x3ffff << 11) | (0x1f << 6) | 0x3f;
+  char linebuffer[512];
+  istringstream line;
+
+  while (infile.getline(linebuffer, 512) && infile.good()) {
+    unsigned int cmd = 999;
+    int data = -1;
+    int extali = -1;
+    line.clear();
+    line.str(linebuffer);
+    data = -1;
+    line >> std::skipws >> cmd >> addr >> data >> extali; // the lines read from config file can contain additional columns.
+    // Therefore the detour via istringstream
+
+    if (cmd != 999 && addr != -1 && extali != -1) {
+
+      if (cmd == mgkScsnCmdWrite) {
+        for (int det = 0; det < kNdet; det++) {
+          unsigned int rocpos = (1 << (TRDGeometry::getSector(det) + 11)) | (1 << (TRDGeometry::getStack(det) + 6)) | (1 << TRDGeometry::getLayer(det));
+          LOG(debug) << "checking restriction: mask=0x" << hex << std::setw(8) << mRestrictiveMask << " rocpos=0x" << hex << std::setw(8) << rocpos;
+          if ((mRestrictiveMask & rocpos) == rocpos) {
+            LOG(debug) << "match:"
+                       << " " << cmd << " " << extali << " " << addr << " " << data;
+            addValues(det, cmd, extali, addr, data);
+          }
+        }
+      }
+
+      else if (cmd == mgkScsnLTUparam) {
+        //     processLTUparam(extali, addr, data);
+      }
+
+      else if (cmd == mgkScsnCmdRestr) {
+        mRestrictiveMask = data;
+        LOG(debug) << "updated restrictive mask to 0x" << hex << std::setw(8) << mRestrictiveMask;
+      }
+
+      else if ((cmd == mgkScsnCmdReset) ||
+               (cmd == mgkScsnCmdRobReset)) {
+        mTrapConfig->resetRegs();
+      }
+
+      else if (cmd == mgkScsnCmdSetHC) {
+        int fullVersion = ((data & 0x7F00) >> 1) | (data & 0x7f);
+
+        for (int iDet = 0; iDet < kNdet; iDet++) {
+          int smls = (TRDGeometry::getSector(iDet) << 6) | (TRDGeometry::getLayer(iDet) << 3) | TRDGeometry::getStack(iDet);
+
+          for (int iRob = 0; iRob < 8; iRob++) {
+            // HC mergers
+            mTrapConfig->setTrapReg(TrapConfig::kC14CPUA, 0xc << 16, iDet, iRob, 17);
+            mTrapConfig->setTrapReg(TrapConfig::kC15CPUA, ((1 << 29) | (fullVersion << 15) | (1 << 12) | (smls << 1) | (iRob % 2)), iDet, iRob, 17);
+
+            // board mergers
+            mTrapConfig->setTrapReg(TrapConfig::kC14CPUA, 0, iDet, iRob, 16);
+            mTrapConfig->setTrapReg(TrapConfig::kC15CPUA, ((1 << 29) | (fullVersion << 15) | (1 << 12) | (smls << 1) | (iRob % 2)), iDet, iRob, 16);
+
+            // and now for the others
+            for (int iMcm = 0; iMcm < 16; iMcm++) {
+              mTrapConfig->setTrapReg(TrapConfig::kC14CPUA, iMcm | (iRob << 4) | (3 << 16), iDet, iRob, iMcm);
+              mTrapConfig->setTrapReg(TrapConfig::kC15CPUA, ((1 << 29) | (fullVersion << 15) | (1 << 12) | (smls << 1) | (iRob % 2)), iDet, iRob, iMcm);
+            }
+          }
+        }
+      }
+
+      else if ((cmd == mgkScsnCmdRead) ||
+               (cmd == mgkScsnCmdPause) ||
+               (cmd == mgkScsnCmdPtrg) ||
+               (cmd == mgkScsnCmdHwPtrg) ||
+               (cmd == mgkScsnCmdRobPower) ||
+               (cmd == mgkScsnCmdTtcRx) ||
+               (cmd == mgkScsnCmdMcmTemp) ||
+               (cmd == mgkScsnCmdOri) ||
+               (cmd == mgkScsnCmdPM)) {
+        LOG(debug2) << "ignored SCSN command: " << cmd << " " << addr << " " << data << " " << extali;
+      }
+
+      else {
+        LOG(warn) << "unknown SCSN command: " << cmd << " " << addr << " " << data << " " << extali;
+        ignoredCmds++;
+      }
+
+      readLines++;
+    }
+
+    else if (!infile.eof() && !infile.good()) {
+      infile.clear();
+      infile.ignore(256, '\n');
+      ignoredLines++;
+    }
+
+    if (!infile.eof())
+      infile.clear();
+  }
+
+  infile.close();
+
+  LOG(debug3) << "Ignored lines: " << ignoredLines << ", ignored cmds: " << ignoredCmds;
+
+  if (ignoredLines > readLines)
+    LOG(error) << "More than 50 %% of the input file could not be processed. Perhaps you should check the input file %s", filename.c_str();
+
+  return true;
+}
+
+int TrapConfigHandler::setGaintable(CalOnlineGainTables& gtbl)
+{
+  mGtbl = gtbl;
+  return 0;
+}
+
+void TrapConfigHandler::processLTUparam(int dest, int addr, unsigned int data)
+{
+  //
+  // Process the LTU parameters and stores them in internal class variables
+  // or transfer the stored values to TrapConfig, depending on the dest parameter
+  //
+
+  switch (dest) {
+
+    case 0: // set the parameters in TrapConfig
+      for (int det = 0; det < kNdet; det++) {
+        configureDyCorr(det);
+        configureDRange(det);    // deflection range
+        configureNTimebins(det); // timebins in the drift region
+        configurePIDcorr(det);   // scaling parameters for the PID
+      }
+      break;
+
+    case 1: // set variables
+      switch (addr) {
+
+        case 0:
+          mFeeParam->setPtMin(data);
+          break; // pt_min in GeV/c (*1000)
+        case 1:
+          mFeeParam->setMagField(data);
+          break; // B in T (*1000)
+        case 2:
+          mFeeParam->setOmegaTau(data);
+          break; // omega*tau
+        case 3:
+          mFeeParam->setNtimebins(data);
+          break;
+          // ntimbins: drift time (for 3 cm) in timebins (5 add. bin. digits)
+        case 4:
+          mFeeParam->setScaleQ0(data);
+          break;
+        case 5:
+          mFeeParam->setScaleQ1(data);
+          break;
+        case 6:
+          mFeeParam->setLengthCorrectionEnable(data);
+          break;
+        case 7:
+          mFeeParam->setTiltCorrectionEnable(data);
+          break;
+      }
+      break;
+
+    default:
+      LOG(error) << "dest " << dest << " not implemented";
+  }
+}
+
+void TrapConfigHandler::configureNTimebins(int det)
+{
+  //
+  // set timebins in the drift region
+  //
+
+  if (!mTrapConfig) {
+    LOG(error) << "No TRAPconfig given";
+    return;
+  }
+
+  addValues(det, mgkScsnCmdWrite, 127, TrapSimulator::mgkDmemAddrNdrift, mFeeParam->getNtimebins());
+}
+
+void TrapConfigHandler::configureDyCorr(int det)
+{
+  //
+  //  Deflection length correction
+  //  due to Lorentz angle and tilted pad correction
+  //  This correction is in units of padwidth / (256*32)
+  //
+
+  if (!mTrapConfig) {
+    LOG(error) << "No TRAPconfig given";
+    return;
+  }
+
+  int nRobs = TRDGeometry::getStack(det) == 2 ? 6 : 8;
+
+  for (int r = 0; r < nRobs; r++) {
+    for (int m = 0; m < 16; m++) {
+      int dest = 1 << 10 | r << 7 | m;
+      int dyCorrInt = mFeeParam->getDyCorrection(det, r, m);
+      addValues(det, mgkScsnCmdWrite, dest, TrapSimulator::mgkDmemAddrDeflCorr, dyCorrInt);
+    }
+  }
+}
+
+void TrapConfigHandler::configureDRange(int det)
+{
+  //
+  // deflection range LUT
+  // range calculated according to B-field (in T) and pt_min (in GeV/c)
+  // if pt_min < 0.1 GeV/c the maximal allowed range for the tracklet
+  // deflection (-64..63) is used
+  //
+
+  if (!mTrapConfig) {
+    LOG(error) << "No TRAPconfig given";
+    return;
+  }
+
+  int nRobs = TRDGeometry::getStack(det) == 2 ? 6 : 8;
+
+  int dyMinInt;
+  int dyMaxInt;
+
+  for (int r = 0; r < nRobs; r++) {
+    for (int m = 0; m < 16; m++) {
+      for (int c = 0; c < 18; c++) {
+
+        // cout << "maxdefl: " << maxDeflAngle << ", localPhi " << localPhi << endl;
+        // cout << "r " << r << ", m" << m << ", c " << c << ", min angle: " << localPhi-maxDeflAngle << ", max: " << localPhi+maxDeflAngle
+        // 	<< ", min int: " << dyMinInt << ", max int: " << dyMaxInt << endl;
+        int dest = 1 << 10 | r << 7 | m;
+        int lutAddr = TrapSimulator::mgkDmemAddrDeflCutStart + 2 * c;
+        mFeeParam->getDyRange(det, r, m, c, dyMinInt, dyMaxInt);
+        addValues(det, mgkScsnCmdWrite, dest, lutAddr + 0, dyMinInt);
+        addValues(det, mgkScsnCmdWrite, dest, lutAddr + 1, dyMaxInt);
+      }
+    }
+  }
+}
+
+void TrapConfigHandler::printGeoTest()
+{
+  //
+  // Prints some information about the geometry. Only for debugging
+  //
+
+  int sm = 0;
+  //   for(int sm=0; sm<6; sm++) {
+  for (int stack = 0; stack < 5; stack++) {
+    for (int layer = 0; layer < 6; layer++) {
+
+      int det = sm * 30 + stack * 6 + layer;
+      for (int r = 0; r < 6; r++) {
+        for (int m = 0; m < 16; m++) {
+          for (int c = 7; c < 8; c++) {
+            cout << stack << ";" << layer << ";" << r << ";" << m
+                 << ";" << mFeeParam->getX(det, r, m)
+                 << ";" << mFeeParam->getLocalY(det, r, m, c)
+                 << ";" << mFeeParam->getLocalZ(det, r, m) << endl;
+          }
+        }
+      }
+    }
+  }
+  // }
+}
+
+void TrapConfigHandler::configurePIDcorr(int det)
+{
+  //
+  // Calculate the MCM individual correction factors for the PID
+  // and transfer them to TrapConfig
+  //
+
+  if (!mTrapConfig) {
+    LOG(error) << "No TRAPconfig given";
+    return;
+  }
+
+  static const int addrLUTcor0 = TrapSimulator::mgkDmemAddrLUTcor0;
+  static const int addrLUTcor1 = TrapSimulator::mgkDmemAddrLUTcor1;
+
+  unsigned int cor0;
+  unsigned int cor1;
+  int readoutboard;
+  int mcm;
+  // int nRobs = TRDGeometry::getStack(det) == 2 ? 6 : 8;
+  int MaxRows;
+  FeeParam* feeparam = FeeParam::instance();
+  if (TRDGeometry::getStack(det) == 2)
+    MaxRows = FeeParam::mgkNrowC0;
+  else
+    MaxRows = FeeParam::mgkNrowC1;
+  int MaxCols = FeeParam::mgkNcol;
+  for (int row = 0; row < MaxRows; row++) { //TODO put this back to rob/mcm and not row/col as done in TrapSimulator
+    for (int col = 0; col < MaxCols; col++) {
+      readoutboard = feeparam->getROBfromPad(row, col);
+      mcm = feeparam->getMCMfromPad(row, col);
+      int dest = 1 << 10 | readoutboard << 7 | mcm;
+      //TODO impelment a method for determining if gaintables are valid, used to be if pointer was valid.
+      if (mGtbl.getMCMGain(det, row, col) != 0.0) //TODO check this logic there might be problems here.
+        mFeeParam->getCorrectionFactors(det, readoutboard, mcm, 9, cor0, cor1, mGtbl.getMCMGain(det, row, col));
+      else
+        mFeeParam->getCorrectionFactors(det, readoutboard, mcm, 9, cor0, cor1);
+      addValues(det, mgkScsnCmdWrite, dest, addrLUTcor0, cor0);
+      addValues(det, mgkScsnCmdWrite, dest, addrLUTcor1, cor1);
+    }
+  }
+}
+
+bool TrapConfigHandler::addValues(unsigned int det, unsigned int cmd, unsigned int extali, int addr, unsigned int data)
+{
+  // transfer the informations provided by LoadConfig to the internal class variables
+
+  if (!mTrapConfig) {
+    LOG(error) << "No TRAPconfig given";
+    return false;
+  }
+
+  if (cmd != mgkScsnCmdWrite) {
+    LOG(error) << "Invalid command received: " << cmd;
+    return false;
+  }
+
+  TrapConfig::TrapReg_t mcmReg = mTrapConfig->getRegByAddress(addr);
+  int rocType = TRDGeometry::getStack(det) == 2 ? 0 : 1;
+
+  static const int mcmListSize = 40; // 40 is more or less arbitrary
+  int mcmList[mcmListSize];
+
+  // configuration registers
+  if (mcmReg >= 0 && mcmReg < TrapConfig::kLastReg) {
+
+    for (int linkPair = 0; linkPair < mgkMaxLinkPairs; linkPair++) {
+      if (FeeParam::extAliToAli(extali, linkPair, rocType, mcmList, mcmListSize) != 0) {
+        int i = 0;
+        while ((i < mcmListSize) && (mcmList[i] != -1)) {
+          if (mcmList[i] == 127) {
+            LOG(debug) << "broadcast write to " << mTrapConfig->getRegName((TrapConfig::TrapReg_t)mcmReg) << ": 0x" << hex << std::setw(8) << data;
+            mTrapConfig->setTrapReg((TrapConfig::TrapReg_t)mcmReg, data, det);
+          } else {
+            LOG(debug) << "individual write to " << mTrapConfig->getRegName((TrapConfig::TrapReg_t)mcmReg) << " (" << (mcmList[i] >> 7) << "," << (mcmList[i] & 0x7F) << "): 0x" << hex << std::setw(8) << data;
+            mTrapConfig->setTrapReg((TrapConfig::TrapReg_t)mcmReg, data, det, (mcmList[i] >> 7) & 0x7, (mcmList[i] & 0x7F));
+          }
+          i++;
+        }
+      }
+    }
+    return true;
+  }
+  // DMEM
+  else if ((addr >= TrapConfig::mgkDmemStartAddress) &&
+           (addr < (TrapConfig::mgkDmemStartAddress + TrapConfig::mgkDmemWords))) {
+    for (int linkPair = 0; linkPair < mgkMaxLinkPairs; linkPair++) {
+      if (FeeParam::extAliToAli(extali, linkPair, rocType, mcmList, mcmListSize) != 0) {
+        int i = 0;
+        while (i < mcmListSize && mcmList[i] != -1) {
+          if (mcmList[i] == 127)
+            mTrapConfig->setDmem(addr, data, det, 0, 127);
+          else
+            mTrapConfig->setDmem(addr, data, det, mcmList[i] >> 7, mcmList[i] & 0x7f);
+          i++;
+        }
+      }
+    }
+    return true;
+  } else if ((addr >= TrapConfig::mgkImemStartAddress) &&
+             (addr < (TrapConfig::mgkImemStartAddress + TrapConfig::mgkImemWords))) {
+    // IMEM is ignored for now
+    return true;
+  } else if ((addr >= TrapConfig::mgkDbankStartAddress) &&
+             (addr < (TrapConfig::mgkDbankStartAddress + TrapConfig::mgkImemWords))) {
+    // DBANK is ignored for now
+    return true;
+  } else {
+    LOG(error) << "Writing to unhandled address 0x" << hex << std::setw(4) << addr;
+    return false;
+  }
+}

--- a/Detectors/TRD/simulation/src/TrapSimulator.cxx
+++ b/Detectors/TRD/simulation/src/TrapSimulator.cxx
@@ -1,0 +1,2345 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///////////////////////////////////////////////////////////////////////////////
+//                                                                           //
+//  TRD MCM (Multi Chip Module) simulator                                    //
+//  which simulates the TRAP processing after the AD-conversion.             //
+//  The relevant parameters (i.e. configuration settings of the TRAP)        //
+//  are taken from TrapConfig.                                         //
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////
+
+//#include "TTreeStream.h"
+
+#include "TRDBase/TRDSimParam.h"
+#include "TRDBase/TRDCommonParam.h"
+#include "TRDBase/TRDGeometry.h"
+#include "TRDBase/FeeParam.h"
+#include "TRDBase/Tracklet.h"
+#include "TRDBase/CalOnlineGainTables.h"
+#include "TRDSimulation/TrapConfigHandler.h"
+#include "TRDSimulation/TrapConfig.h"
+#include "TRDSimulation/TrapSimulator.h"
+#include "fairlogger/Logger.h"
+
+//to pull in the digitzer incomnig data.
+#include "TRDBase/Digit.h"
+#include "TRDSimulation/Digitizer.h"
+#include <SimulationDataFormat/MCCompLabel.h>
+#include <SimulationDataFormat/MCTruthContainer.h>
+
+#include <iostream>
+#include <iomanip>
+#include "TCanvas.h"
+#include "TH1F.h"
+#include "TH2F.h"
+#include "TGraph.h"
+#include "TLine.h"
+#include "TRandom.h"
+#include "TMath.h"
+#include <TTree.h>
+#include <ostream>
+#include <fstream>
+
+using namespace o2::trd;
+using namespace std;
+
+#define DEBUGTRAP 1
+
+bool TrapSimulator::mgApplyCut = true;
+int TrapSimulator::mgAddBaseline = 0;
+bool TrapSimulator::mgStoreClusters = true;
+const int TrapSimulator::mgkFormatIndex = std::ios_base::xalloc();
+const std::array<unsigned short, 4> TrapSimulator::mgkFPshifts{11, 14, 17, 21};
+
+TrapSimulator::TrapSimulator()
+  : mInitialized(false), mDetector(-1), mRobPos(-1), mMcmPos(-1), mRow(-1), mNTimeBin(-1), mTrklBranchName("mcmtrklbranch"), mFeeParam(nullptr), mTrapConfig(nullptr)
+{
+  //
+  // TrapSimulator default constructor
+  // By default, nothing is initialized.
+  // It is necessary to issue init before use.
+
+  mFitPtr[0] = 0;
+  mFitPtr[1] = 0;
+  mFitPtr[2] = 0;
+  mFitPtr[3] = 0;
+  mNHits = 0;
+}
+
+void TrapSimulator::init(TrapConfig* trapconfig, int det, int robPos, int mcmPos)
+{
+  //
+  // Initialize the class with new MCM position information
+  // memory is allocated in the first initialization
+  //
+  //
+  LOG(debug4) << " : trap sim is at : 0x" << hex << trapconfig;
+  if (!mInitialized) {
+    mFeeParam = FeeParam::instance();
+    mTrapConfig = trapconfig;
+  }
+
+  mDetector = det;
+  mRobPos = robPos;
+  mMcmPos = mcmPos;
+  mRow = mFeeParam->getPadRowFromMCM(mRobPos, mMcmPos);
+
+  if (!mInitialized) {
+    mNTimeBin = mTrapConfig->getTrapReg(TrapConfig::kC13CPUA, mDetector, mRobPos, mMcmPos);
+    mZSMap.resize(FeeParam::getNadcMcm());
+
+    // tracklet calculation
+    //now a 25 slot array mFitReg.resize(FeeParam::getNadcMcm()); //TODO for now this is constant size in an array not a vector
+    //  mTrackletArray-.resize(mgkMaxTracklets);
+    //now a 100 slot array as per run2  mHits.resize(50);
+    mMCMT.resize(mgkMaxTracklets);
+
+    mADCR.resize(mNTimeBin * FeeParam::getNadcMcm());
+    mADCF.resize(mNTimeBin * FeeParam::getNadcMcm());
+  }
+
+  mInitialized = true;
+
+  mNHits = 0;
+
+  reset();
+}
+
+void TrapSimulator::reset()
+{
+  // Resets the data values and internal filter registers
+  // by re-initialising them
+
+  if (!checkInitialized())
+    return;
+
+  memset(&mADCR[0], 0, sizeof(mADCR[0]) * mADCR.size());
+  memset(&mADCF[0], 0, sizeof(mADCF[0]) * mADCF.size());
+
+  for (auto filterreg : mInternalFilterRegisters)
+    filterreg.ClearReg();
+  // Default unread, low active bit mask
+  memset(&mZSMap[0], 0, sizeof(mZSMap[0]) * FeeParam::getNadcMcm());
+  memset(&mMCMT[0], 0, sizeof(mMCMT[0]) * mgkMaxTracklets);
+  //mDict1.clear();
+  //mDict2.clear();
+  //mDict3.clear();
+
+  filterPedestalInit();
+  filterGainInit();
+  filterTailInit();
+  //labelsInit();
+}
+
+// ----- I/O implementation -----
+
+ostream& TrapSimulator::text(ostream& os)
+{
+  // manipulator to activate output in text format (default)
+
+  os.iword(mgkFormatIndex) = 0;
+  return os;
+}
+
+ostream& TrapSimulator::cfdat(ostream& os)
+{
+  // manipulator to activate output in CFDAT format
+  // to send to the FEE via SCSN
+
+  os.iword(mgkFormatIndex) = 1;
+  return os;
+}
+
+ostream& TrapSimulator::raw(ostream& os)
+{
+  // manipulator to activate output as raw data dump
+
+  os.iword(mgkFormatIndex) = 2;
+  return os;
+}
+
+//std::ostream& operator<<(std::ostream& os, const TrapSimulator& mcm); // data output using ostream (e.g. cout << mcm;)
+std::ostream& o2::trd::operator<<(std::ostream& os, const TrapSimulator& mcm)
+{
+  // output implementation
+
+  // no output for non-initialized MCM
+  if (!mcm.checkInitialized())
+    return os;
+
+  // ----- human-readable output -----
+  if (os.iword(TrapSimulator::mgkFormatIndex) == 0) {
+
+    os << "TRAP " << mcm.getMcmPos() << " on ROB " << mcm.getRobPos() << " in detector " << mcm.getDetector() << std::endl;
+
+    os << "----- Unfiltered ADC data (10 bit) -----" << std::endl;
+    os << "ch    ";
+    for (int iChannel = 0; iChannel < FeeParam::getNadcMcm(); iChannel++)
+      os << std::setw(5) << iChannel;
+    os << std::endl;
+    for (int iTimeBin = 0; iTimeBin < mcm.getNumberOfTimeBins(); iTimeBin++) {
+      os << "tb " << std::setw(2) << iTimeBin << ":";
+      for (int iChannel = 0; iChannel < FeeParam::getNadcMcm(); iChannel++) {
+        os << std::setw(5) << (mcm.getDataRaw(iChannel, iTimeBin) >> mcm.mgkAddDigits);
+      }
+      os << std::endl;
+    }
+
+    os << "----- Filtered ADC data (10+2 bit) -----" << std::endl;
+    os << "ch    ";
+    for (int iChannel = 0; iChannel < FeeParam::getNadcMcm(); iChannel++)
+      os << std::setw(4) << iChannel
+         << ((~mcm.getZeroSupressionMap(iChannel) != 0) ? "!" : " ");
+    os << std::endl;
+    for (int iTimeBin = 0; iTimeBin < mcm.getNumberOfTimeBins(); iTimeBin++) {
+      os << "tb " << std::setw(2) << iTimeBin << ":";
+      for (int iChannel = 0; iChannel < FeeParam::getNadcMcm(); iChannel++) {
+        os << std::setw(4) << (mcm.getDataFiltered(iChannel, iTimeBin))
+           << (((mcm.getZeroSupressionMap(iChannel) & (1 << iTimeBin)) == 0) ? "!" : " ");
+      }
+      os << std::endl;
+    }
+  }
+
+  // ----- CFDAT output -----
+  else if (os.iword(TrapSimulator::mgkFormatIndex) == 1) {
+    int dest = 127;
+    int addrOffset = 0x2000;
+    int addrStep = 0x80;
+
+    for (int iTimeBin = 0; iTimeBin < mcm.getNumberOfTimeBins(); iTimeBin++) {
+      for (int iChannel = 0; iChannel < FeeParam::getNadcMcm(); iChannel++) {
+        os << std::setw(5) << 10
+           << std::setw(5) << addrOffset + iChannel * addrStep + iTimeBin
+           << std::setw(5) << (mcm.getDataFiltered(iChannel, iTimeBin))
+           << std::setw(5) << dest << std::endl;
+      }
+      os << std::endl;
+    }
+  }
+
+  // ----- raw data ouptut -----
+  else if (os.iword(TrapSimulator::mgkFormatIndex) == 2) {
+    int bufSize = 300;
+    unsigned int* buf = new unsigned int[bufSize];
+
+    int bufLength = mcm.produceRawStream(&buf[0], bufSize);
+
+    for (int i = 0; i < bufLength; i++)
+      std::cout << "0x" << std::hex << buf[i] << std::dec << std::endl;
+
+    delete[] buf;
+  }
+
+  else {
+    os << "unknown format set" << std::endl;
+  }
+
+  return os;
+}
+
+void TrapSimulator::printFitRegXml(ostream& os) const
+{
+  // print fit registres in XML format
+
+  bool tracklet = false;
+
+  for (int cpu = 0; cpu < 4; cpu++) {
+    if (mFitPtr[cpu] != 31)
+      tracklet = true;
+  }
+  const char* const aquote{R"(")"};
+  const char* const cmdid{R"(" cmdid="0">)"};
+  if (tracklet == true) {
+    os << "<nginject>" << std::endl;
+    os << "<ack roc=\"" << mDetector << cmdid << std::endl;
+    os << "<dmem-readout>" << std::endl;
+    os << "<d det=\"" << mDetector << "\">" << std::endl;
+    os << " <ro-board rob=\"" << mRobPos << "\">" << std::endl;
+    os << "  <m mcm=\"" << mMcmPos << "\">" << std::endl;
+
+    for (int cpu = 0; cpu < 4; cpu++) {
+      os << "   <c cpu=\"" << cpu << "\">" << std::endl;
+      if (mFitPtr[cpu] != 31) {
+        for (int adcch = mFitPtr[cpu]; adcch < mFitPtr[cpu] + 2; adcch++) {
+          if (adcch > 24)
+            LOG(error) << "adcch going awol : " << adcch << " > 25";
+          os << "    <ch chnr=\"" << adcch << "\">" << std::endl;
+          os << "     <hits>" << mFitReg[adcch].mNhits << "</hits>" << std::endl;
+          os << "     <q0>" << mFitReg[adcch].mQ0 << "</q0>" << std::endl;
+          os << "     <q1>" << mFitReg[adcch].mQ1 << "</q1>" << std::endl;
+          os << "     <sumx>" << mFitReg[adcch].mSumX << "</sumx>" << std::endl;
+          os << "     <sumxsq>" << mFitReg[adcch].mSumX2 << "</sumxsq>" << std::endl;
+          os << "     <sumy>" << mFitReg[adcch].mSumY << "</sumy>" << std::endl;
+          os << "     <sumysq>" << mFitReg[adcch].mSumY2 << "</sumysq>" << std::endl;
+          os << "     <sumxy>" << mFitReg[adcch].mSumXY << "</sumxy>" << std::endl;
+          os << "    </ch>" << std::endl;
+        }
+      }
+      os << "      </c>" << std::endl;
+    }
+    os << "    </m>" << std::endl;
+    os << "  </ro-board>" << std::endl;
+    os << "</d>" << std::endl;
+    os << "</dmem-readout>" << std::endl;
+    os << "</ack>" << std::endl;
+    os << "</nginject>" << std::endl;
+  }
+}
+
+void TrapSimulator::printTrackletsXml(ostream& os) const
+{
+  // print tracklets in XML format
+
+  const char* const cmdid{R"(" cmdid="0">)"};
+  os << "<nginject>" << std::endl;
+  os << "<ack roc=\"" << mDetector << cmdid << std::endl;
+  os << "<dmem-readout>" << std::endl;
+  os << "<d det=\"" << mDetector << "\">" << std::endl;
+  os << "  <ro-board rob=\"" << mRobPos << "\">" << std::endl;
+  os << "    <m mcm=\"" << mMcmPos << "\">" << std::endl;
+
+  int pid, padrow, slope, offset;
+  for (int cpu = 0; cpu < 4; cpu++) {
+    if (mMCMT[cpu] == 0x10001000) {
+      pid = -1;
+      padrow = -1;
+      slope = -1;
+      offset = -1;
+    } else {
+      pid = (mMCMT[cpu] & 0xFF000000) >> 24;
+      padrow = (mMCMT[cpu] & 0xF00000) >> 20;
+      slope = (mMCMT[cpu] & 0xFE000) >> 13;
+      offset = (mMCMT[cpu] & 0x1FFF);
+    }
+    os << "      <trk> <pid>" << pid << "</pid>"
+       << " <padrow>" << padrow << "</padrow>"
+       << " <slope>" << slope << "</slope>"
+       << " <offset>" << offset << "</offset>"
+       << "</trk>" << std::endl;
+  }
+
+  os << "    </m>" << std::endl;
+  os << "  </ro-board>" << std::endl;
+  os << "</d>" << std::endl;
+  os << "</dmem-readout>" << std::endl;
+  os << "</ack>" << std::endl;
+  os << "</nginject>" << std::endl;
+}
+
+void TrapSimulator::printAdcDatTxt(ostream& os) const
+{
+  // print ADC data in text format (suitable as Modelsim stimuli)
+
+  os << "# MCM " << mMcmPos << " on ROB " << mRobPos << " in detector " << mDetector << std::endl;
+
+  for (int iTimeBin = 0; iTimeBin < mNTimeBin; iTimeBin++) {
+    for (int iChannel = 0; iChannel < FeeParam::getNadcMcm(); ++iChannel) {
+      os << std::setw(5) << (getDataRaw(iChannel, iTimeBin) >> mgkAddDigits);
+    }
+    os << std::endl;
+  }
+}
+
+void TrapSimulator::printAdcDatHuman(ostream& os) const
+{
+  // print ADC data in human-readable format
+
+  os << "MCM " << mMcmPos << " on ROB " << mRobPos << " in detector " << mDetector << std::endl;
+
+  os << "----- Unfiltered ADC data (10 bit) -----" << std::endl;
+  os << "ch    ";
+  for (int iChannel = 0; iChannel < FeeParam::getNadcMcm(); iChannel++)
+    os << std::setw(5) << iChannel;
+  os << std::endl;
+  for (int iTimeBin = 0; iTimeBin < mNTimeBin; iTimeBin++) {
+    os << "tb " << std::setw(2) << iTimeBin << ":";
+    for (int iChannel = 0; iChannel < FeeParam::getNadcMcm(); iChannel++) {
+      os << std::setw(5) << (getDataRaw(iChannel, iTimeBin) >> mgkAddDigits);
+    }
+    os << std::endl;
+  }
+
+  os << "----- Filtered ADC data (10+2 bit) -----" << std::endl;
+  os << "ch    ";
+  for (int iChannel = 0; iChannel < FeeParam::getNadcMcm(); iChannel++)
+    os << std::setw(4) << iChannel
+       << ((~mZSMap[iChannel] != 0) ? "!" : " ");
+  os << std::endl;
+  for (int iTimeBin = 0; iTimeBin < mNTimeBin; iTimeBin++) {
+    os << "tb " << std::setw(2) << iTimeBin << ":";
+    for (int iChannel = 0; iChannel < FeeParam::getNadcMcm(); iChannel++) {
+      os << std::setw(4) << (getDataFiltered(iChannel, iTimeBin))
+         << (((mZSMap[iChannel] & (1 << iTimeBin)) == 0) ? "!" : " ");
+    }
+    os << std::endl;
+  }
+}
+
+void TrapSimulator::printAdcDatXml(ostream& os) const
+{
+  // print ADC data in XML format
+
+  const char* const cmdid{R"(" cmdid="0">)"};
+  os << "<nginject>" << std::endl;
+  os << "<ack roc=\"" << mDetector << cmdid << std::endl;
+  os << "<dmem-readout>" << std::endl;
+  os << "<d det=\"" << mDetector << "\">" << std::endl;
+  os << " <ro-board rob=\"" << mRobPos << "\">" << std::endl;
+  os << "  <m mcm=\"" << mMcmPos << "\">" << std::endl;
+
+  for (int iChannel = 0; iChannel < FeeParam::getNadcMcm(); iChannel++) {
+    os << "   <ch chnr=\"" << iChannel << "\">" << std::endl;
+    for (int iTimeBin = 0; iTimeBin < mNTimeBin; iTimeBin++) {
+      os << "<tb>" << mADCF[iChannel * mNTimeBin + iTimeBin] / 4 << "</tb>";
+    }
+    os << "   </ch>" << std::endl;
+  }
+
+  os << "  </m>" << std::endl;
+  os << " </ro-board>" << std::endl;
+  os << "</d>" << std::endl;
+  os << "</dmem-readout>" << std::endl;
+  os << "</ack>" << std::endl;
+  os << "</nginject>" << std::endl;
+}
+
+void TrapSimulator::printAdcDatDatx(ostream& os, bool broadcast, int timeBinOffset) const
+{
+  // print ADC data in datx format (to send to FEE)
+
+  mTrapConfig->printDatx(os, 2602, 1, 0, 127); // command to enable the ADC clock - necessary to write ADC values to MCM
+  os << std::endl;
+
+  int addrOffset = 0x2000;
+  int addrStep = 0x80;
+  int addrOffsetEBSIA = 0x20;
+
+  for (int iTimeBin = 0; iTimeBin < mNTimeBin; iTimeBin++) {
+    for (int iChannel = 0; iChannel < FeeParam::getNadcMcm(); iChannel++) {
+      if ((iTimeBin < timeBinOffset) || (iTimeBin >= mNTimeBin + timeBinOffset)) {
+        if (broadcast == false)
+          mTrapConfig->printDatx(os, addrOffset + iChannel * addrStep + addrOffsetEBSIA + iTimeBin, 10, getRobPos(), getMcmPos());
+        else
+          mTrapConfig->printDatx(os, addrOffset + iChannel * addrStep + addrOffsetEBSIA + iTimeBin, 10, 0, 127);
+      } else {
+        if (broadcast == false)
+          mTrapConfig->printDatx(os, addrOffset + iChannel * addrStep + addrOffsetEBSIA + iTimeBin, (getDataFiltered(iChannel, iTimeBin - timeBinOffset) / 4), getRobPos(), getMcmPos());
+        else
+          mTrapConfig->printDatx(os, addrOffset + iChannel * addrStep + addrOffsetEBSIA + iTimeBin, (getDataFiltered(iChannel, iTimeBin - timeBinOffset) / 4), 0, 127);
+      }
+    }
+    os << std::endl;
+  }
+}
+
+void TrapSimulator::printPidLutHuman()
+{
+  // print PID LUT in human readable format
+
+  unsigned int addrEnd = mgkDmemAddrLUTStart + mTrapConfig->getDmemUnsigned(mgkDmemAddrLUTLength, mDetector, mRobPos, mMcmPos) / 4; // /4 because each addr contains 4 values
+  unsigned int nBinsQ0 = mTrapConfig->getDmemUnsigned(mgkDmemAddrLUTnbins, mDetector, mRobPos, mMcmPos);
+
+  std::cout << "nBinsQ0: " << nBinsQ0 << std::endl;
+  std::cout << "LUT table length: " << mTrapConfig->getDmemUnsigned(mgkDmemAddrLUTLength, mDetector, mRobPos, mMcmPos) << std::endl;
+
+  if (nBinsQ0 > 0) {
+    for (unsigned int addr = mgkDmemAddrLUTStart; addr < addrEnd; addr++) {
+      unsigned int result;
+      result = mTrapConfig->getDmemUnsigned(addr, mDetector, mRobPos, mMcmPos);
+      std::cout << addr << " # x: " << ((addr - mgkDmemAddrLUTStart) % ((nBinsQ0) / 4)) * 4 << ", y: " << (addr - mgkDmemAddrLUTStart) / (nBinsQ0 / 4)
+                << "  #  " << ((result >> 0) & 0xFF)
+                << " | " << ((result >> 8) & 0xFF)
+                << " | " << ((result >> 16) & 0xFF)
+                << " | " << ((result >> 24) & 0xFF) << std::endl;
+    }
+  }
+}
+
+void TrapSimulator::setNTimebins(int ntimebins)
+{
+  // Reallocate memory if a change in the number of timebins
+  // is needed (should not be the case for real data)
+
+  LOG(fatal) << "setNTimebins(" << ntimebins << ") not implemented as we can no longer change the size of the ADC array";
+  if (!checkInitialized())
+    return;
+
+  mNTimeBin = ntimebins;
+  // for( int iAdc = 0 ; iAdc < FeeParam::getNadcMcm(); iAdc++ ) {
+  //  delete [] mADCR[iAdc];
+  //  delete [] mADCF[iAdc];
+  //  mADCR[iAdc] = new int[mNTimeBin];
+  //  mADCF[iAdc] = new int[mNTimeBin];
+  // }
+}
+
+bool TrapSimulator::loadMCM(int det, int rob, int mcm)
+{
+  // loads the ADC data as obtained from the digitsManager for the specified MCM.
+  // This method is meant for rare execution, e.g. in the visualization. When called
+  // frequently use SetData(...) instead.
+  LOG(fatal) << "no longer implemented, this is left incase script calls it that I have not found yet.";
+
+  return false;
+}
+
+void TrapSimulator::noiseTest(int nsamples, int mean, int sigma, int inputGain, int inputTail)
+{
+  // This function can be used to test the filters.
+  // It feeds nsamples of ADC values with a gaussian distribution specified by mean and sigma.
+  // The filter chain implemented here consists of:
+  // Pedestal -> Gain -> Tail
+  // With inputGain and inputTail the input to the gain and tail filter, respectively,
+  // can be chosen where
+  // 0: noise input
+  // 1: pedestal output
+  // 2: gain output
+  // The input has to be chosen from a stage before.
+  // The filter behaviour is controlled by the TRAP parameters from TrapConfig in the
+  // same way as in normal simulation.
+  // The functions produces four histograms with the values at the different stages.
+
+  if (!checkInitialized())
+    return;
+
+  std::string nameInputGain;
+  std::string nameInputTail;
+
+  switch (inputGain) {
+    case 0:
+      nameInputGain = "Noise";
+      break;
+
+    case 1:
+      nameInputGain = "Pedestal";
+      break;
+
+    default:
+      LOG(error) << "Undefined input to tail cancellation filter";
+      return;
+  }
+
+  switch (inputTail) {
+    case 0:
+      nameInputTail = "Noise";
+      break;
+
+    case 1:
+      nameInputTail = "Pedestal";
+      break;
+
+    case 2:
+      nameInputTail = "Gain";
+      break;
+
+    default:
+      LOG(error) << "Undefined input to tail cancellation filter";
+      return;
+  }
+
+  TH1F* h = new TH1F("noise", "Gaussian Noise;sample;ADC count",
+                     nsamples, 0, nsamples);
+  TH1F* hfp = new TH1F("ped", "Noise #rightarrow Pedestal filter;sample;ADC count", nsamples, 0, nsamples);
+  TH1F* hfg = new TH1F("gain",
+                       (nameInputGain + "#rightarrow Gain;sample;ADC count").c_str(),
+                       nsamples, 0, nsamples);
+  TH1F* hft = new TH1F("tail",
+                       (nameInputTail + "#rightarrow Tail;sample;ADC count").c_str(),
+                       nsamples, 0, nsamples);
+  h->SetStats(false);
+  hfp->SetStats(false);
+  hfg->SetStats(false);
+  hft->SetStats(false);
+
+  for (int i = 0; i < nsamples; i++) {
+    int value;                               // ADC count with noise (10 bit)
+    int valuep;                              // pedestal filter output (12 bit)
+    int valueg;                              // gain filter output (12 bit)
+    int valuet;                              // tail filter value (12 bit)
+    value = (int)gRandom->Gaus(mean, sigma); // generate noise with gaussian distribution
+    h->SetBinContent(i, value);
+
+    valuep = filterPedestalNextSample(1, 0, ((int)value) << 2);
+
+    if (inputGain == 0)
+      valueg = filterGainNextSample(1, ((int)value) << 2);
+    else
+      valueg = filterGainNextSample(1, valuep);
+
+    if (inputTail == 0)
+      valuet = filterTailNextSample(1, ((int)value) << 2);
+    else if (inputTail == 1)
+      valuet = filterTailNextSample(1, valuep);
+    else
+      valuet = filterTailNextSample(1, valueg);
+
+    hfp->SetBinContent(i, valuep >> 2);
+    hfg->SetBinContent(i, valueg >> 2);
+    hft->SetBinContent(i, valuet >> 2);
+  }
+
+  TCanvas* c = new TCanvas;
+  c->Divide(2, 2);
+  c->cd(1);
+  h->Draw();
+  c->cd(2);
+  hfp->Draw();
+  c->cd(3);
+  hfg->Draw();
+  c->cd(4);
+  hft->Draw();
+}
+
+bool TrapSimulator::checkInitialized() const
+{
+  //
+  // Check whether object is initialized
+  //
+
+  //  if (!mInitialized)
+  //   LOG(debug4) << "TrapSimulator is not initialized but function other than Init() is called.";
+
+  return mInitialized;
+}
+
+void TrapSimulator::print(int choice) const
+{
+  // Prints the data stored and/or calculated for this TRAP
+  // The output is controlled by option which can be any bitpattern defined in the header
+  // PRINTRAW - prints raw ADC data
+  // PRINTFILTERED - prints filtered data
+  // PRINTHITS - prints detected hits
+  // PRINTTRACKLETS - prints found tracklets
+  // The later stages are only meaningful after the corresponding calculations
+  // have been performed.
+  // Codacy wont let us use string choices, as it says we must use string::starts_with() instead of string::find()
+
+  if (!checkInitialized())
+    return;
+
+  LOG(info) << "MCM " << mMcmPos << "  on ROB " << mRobPos << " in detector " << mDetector;
+
+  //std::string opt = option;
+  if ((choice & PRINTRAW) != 0 || (choice & PRINTFILTERED) != 0) {
+    std::cout << *this;
+  }
+
+  if ((choice & PRINTDETECTED) != 0) {
+    LOG(info) << "Found " << mNHits << " hits:";
+    for (int iHit = 0; iHit < mNHits; iHit++) {
+      LOG(info) << "Hit " << std::setw(3) << iHit << " in timebin " << std::setw(2) << mHits[iHit].mTimebin << ", ADC " << std::setw(2) << mHits[iHit].mChannel << " has charge " << std::setw(3) << mHits[iHit].mQtot << " and position " << mHits[iHit].mYpos;
+    }
+  }
+
+  if ((choice & PRINTFOUND) != 0) {
+    LOG(info) << "Trackletsi:";
+    for (int iTrkl = 0; iTrkl < mTrackletArray.size(); iTrkl++) {
+      LOG(info) << "tracklet " << iTrkl << ": 0x" << hex << std::setw(8) << mTrackletArray[iTrkl].getTrackletWord();
+    }
+  }
+}
+
+void TrapSimulator::draw(int choice, int index)
+{
+  // Plots the data stored in a 2-dim. timebin vs. ADC channel plot.
+  // The choice selects what data is plotted and is enumated in the header.
+  // PLOTRAW - plot raw data (default)
+  // PLOTFILTERED - plot filtered data (meaningless if R is specified)
+  // In addition to the ADC values:
+  // PLOTHITS - plot hits
+  // PLOTTRACKLETS - plot tracklets
+
+  if (!checkInitialized())
+    return;
+  TFile* rootfile = new TFile(Form("Spectra_%i.root", index), "RECREATE");
+  TH2F* hist = new TH2F(Form("mcmdata_%i", index),
+                        Form("Data of MCM %i on ROB %i in detector %i", mMcmPos, mRobPos, mDetector),
+                        FeeParam::getNadcMcm(),
+                        -0.5,
+                        FeeParam::getNadcMcm() - 0.5,
+                        getNumberOfTimeBins(),
+                        -0.5,
+                        getNumberOfTimeBins() - 0.5);
+  hist->GetXaxis()->SetTitle("ADC Channel");
+  hist->GetYaxis()->SetTitle("Timebin");
+  hist->SetStats(false);
+
+  if ((choice & PLOTRAW) != 0) {
+    for (int iTimeBin = 0; iTimeBin < mNTimeBin; iTimeBin++) {
+      for (int iAdc = 0; iAdc < FeeParam::getNadcMcm(); iAdc++) {
+        hist->SetBinContent(iAdc + 1, iTimeBin + 1, mADCR[iAdc * mNTimeBin + iTimeBin] >> mgkAddDigits);
+      }
+    }
+  } else {
+    for (int iTimeBin = 0; iTimeBin < mNTimeBin; iTimeBin++) {
+      for (int iAdc = 0; iAdc < FeeParam::getNadcMcm(); iAdc++) {
+        hist->SetBinContent(iAdc + 1, iTimeBin + 1, mADCF[iAdc * mNTimeBin + iTimeBin] >> mgkAddDigits);
+      }
+    }
+  }
+  hist->Draw("colz");
+
+  if ((choice & PLOTHITS) != 0) {
+    TGraph* grHits = new TGraph();
+    for (int iHit = 0; iHit < mNHits; iHit++) {
+      grHits->SetPoint(iHit,
+                       mHits[iHit].mChannel + 1 + mHits[iHit].mYpos / 256.,
+                       mHits[iHit].mTimebin);
+    }
+    grHits->Draw("*");
+  }
+
+  if ((choice & PLOTTRACKLETS) != 0) {
+    TLine* trklLines = new TLine[4];
+    for (int iTrkl = 0; iTrkl < mTrackletArray.size(); iTrkl++) {
+      Tracklet trkl = mTrackletArray[iTrkl];
+      float padWidth = 0.635 + 0.03 * (mDetector % 6);
+      float offset = padWidth / 256. * ((((((mRobPos & 0x1) << 2) + (mMcmPos & 0x3)) * 18) << 8) - ((18 * 4 * 2 - 18 * 2 - 3) << 7)); // revert adding offset in FitTracklet
+                                                                                                                                      //TODO replace the 18, 4 3 and 7 with constants for readability
+      int ndrift = mTrapConfig->getDmemUnsigned(mgkDmemAddrNdrift, mDetector, mRobPos, mMcmPos) >> 5;
+      float slope = 0;
+      if (ndrift)
+        slope = trkl.getdY() * 140e-4 / ndrift;
+
+      int t0 = mTrapConfig->getTrapReg(TrapConfig::kTPFS, mDetector, mRobPos, mMcmPos);
+      int t1 = mTrapConfig->getTrapReg(TrapConfig::kTPFE, mDetector, mRobPos, mMcmPos);
+
+      trklLines[iTrkl].SetX1((offset - (trkl.getY() - slope * t0)) / padWidth); // ??? sign?
+      trklLines[iTrkl].SetY1(t0);
+      trklLines[iTrkl].SetX2((offset - (trkl.getY() - slope * t1)) / padWidth); // ??? sign?
+      trklLines[iTrkl].SetY2(t1);
+      trklLines[iTrkl].SetLineColor(2);
+      trklLines[iTrkl].SetLineWidth(2);
+      LOG(info) << "Tracklet " << iTrkl << ": y = " << trkl.getY() << ", dy = " << (trkl.getdY() * 140e-4) << " offset : " << offset;
+      //TODO put that 140e-4 in some constant somewhere
+
+      trklLines[iTrkl].Draw();
+    }
+  }
+  rootfile->Close();
+}
+
+void TrapSimulator::setData(int adc, const ArrayADC& data)
+{
+  //
+  // Store ADC data into array of raw data
+  //
+
+  if (!checkInitialized())
+    return;
+
+  if (adc < 0 || adc >= FeeParam::getNadcMcm()) {
+    LOG(error) << "Error: ADC " << adc << " is out of range (0 .. " << FeeParam::getNadcMcm() - 1 << ")";
+    return;
+  }
+
+  for (int it = 0; it < mNTimeBin; it++) {
+    mADCR[adc * mNTimeBin + it] = (int)(data[it]) << mgkAddDigits;
+    mADCF[adc * mNTimeBin + it] = (int)(data[it]) << mgkAddDigits;
+  }
+  mDataIsSet = true;
+}
+
+void TrapSimulator::setData(int adc, int it, int data)
+{
+  //
+  // Store ADC data into array of raw data
+  // This time enter it element by element.
+  //
+
+  if (!checkInitialized())
+    return;
+
+  if (adc < 0 || adc >= FeeParam::getNadcMcm()) {
+    LOG(error) << "Error: ADC " << adc << " is out of range (0 .. " << FeeParam::getNadcMcm() - 1 << ")";
+    return;
+  }
+
+  mADCR[adc * mNTimeBin + it] = data << mgkAddDigits;
+  mADCF[adc * mNTimeBin + it] = data << mgkAddDigits;
+}
+
+void TrapSimulator::setDataByPad(std::vector<o2::trd::Digit>& padrowdigits, o2::dataformats::MCTruthContainer<MCLabel>& labels, int padrowoffset)
+{
+  // Set the ADC data from the incoming digits vector which contains an entire row
+  // (by pad, to be used during initial reading in simulation)
+  // digits contains an entire padrow from the simulation, this is done to sort out the shared pads.
+
+  if (!checkInitialized())
+    return;
+  //Do we need to copy the labels into an internal format or just keep for passing through later.
+  //
+  if (mNTimeBin != o2::trd::kTimeBins) {
+    LOG(debug) << "Changing number of time bins in the simulation from " << mNTimeBin << " to " << o2::trd::kTimeBins;
+    setNTimebins(o2::trd::kTimeBins);
+    LOG(fatal) << "Changing number of time bins in the simulation this is fatal as I think this timebin changee is going to mess things up. timebins are fixed with in digit class.";
+  }
+  //this is the offset with in a padrow, and due to the reverse number of mcm adcs vs the pads, we offset to the end and then loop back through the adcs
+  int offset = padrowoffset; //(mMcmPos % 4 + 1) * 18 + (mRobPos % 2) * 72 + 1;
+
+  for (int adc = 0; adc < FeeParam::getNadcMcm(); adc++) {
+    ArrayADC timebins;
+    int pad = offset - adc;
+    if (pad > -1 && pad < 144)
+      timebins = padrowdigits[pad].getADC();
+    for (int timebin = 0; timebin < mNTimeBin; timebin++) {
+      int value = timebins[timebin];
+      if (value < 0 || (offset - adc < 1) || (offset - adc > 165)) {
+        mADCR[adc * mNTimeBin + timebin] = mTrapConfig->getTrapReg(TrapConfig::kFPNP, mDetector, mRobPos, mMcmPos) + (mgAddBaseline << mgkAddDigits);
+        mADCF[adc * mNTimeBin + timebin] = mTrapConfig->getTrapReg(TrapConfig::kTPFP, mDetector, mRobPos, mMcmPos) + (mgAddBaseline << mgkAddDigits);
+      } else {
+        mZSMap[adc] = 0;
+        mADCR[adc * mNTimeBin + timebin] = (value << mgkAddDigits) + (mgAddBaseline << mgkAddDigits);
+        mADCF[adc * mNTimeBin + timebin] = (value << mgkAddDigits) + (mgAddBaseline << mgkAddDigits);
+      }
+    }
+  }
+}
+
+void TrapSimulator::setDataPedestal(int adc)
+{
+  //
+  // Store ADC data into array of raw data
+  //
+
+  if (!checkInitialized())
+    return;
+
+  if (adc < 0 || adc >= FeeParam::getNadcMcm()) {
+    return;
+  }
+
+  for (int it = 0; it < mNTimeBin; it++) {
+    mADCR[adc * mNTimeBin + it] = mTrapConfig->getTrapReg(TrapConfig::kFPNP, mDetector, mRobPos, mMcmPos) + (mgAddBaseline << mgkAddDigits);
+    mADCF[adc * mNTimeBin + it] = mTrapConfig->getTrapReg(TrapConfig::kTPFP, mDetector, mRobPos, mMcmPos) + (mgAddBaseline << mgkAddDigits);
+  }
+}
+
+bool TrapSimulator::getHit(int index, int& channel, int& timebin, int& qtot, int& ypos, float& y, int& label) const
+{
+  // retrieve the MC hit information (not available in TRAP hardware)
+
+  if (index < 0 || index >= mNHits)
+    return false;
+
+  channel = mHits[index].mChannel;
+  timebin = mHits[index].mTimebin;
+  qtot = mHits[index].mQtot;
+  ypos = mHits[index].mYpos;
+  y = (float)((((((mRobPos & 0x1) << 2) + (mMcmPos & 0x3)) * 18) << 8) - ((18 * 4 * 2 - 18 * 2 - 1) << 7) -
+              (channel << 8) - ypos) *
+      (0.635 + 0.03 * (mDetector % 6)) / 256.0;
+  //label = mHits[index].mLabel[0];
+
+  return true;
+}
+
+int TrapSimulator::getCol(int adc)
+{
+  //
+  // Return column id of the pad for the given ADC channel
+  //
+
+  if (!checkInitialized())
+    return -1;
+
+  int col = mFeeParam->getPadColFromADC(mRobPos, mMcmPos, adc);
+  if (col < 0 || col >= mFeeParam->getNcol())
+    return -1;
+  else
+    return col;
+}
+
+int TrapSimulator::produceRawStream(unsigned int* buf, int bufSize, unsigned int iEv) const
+{
+  //
+  // Produce raw data stream from this MCM and put in buf
+  // Returns number of words filled, or negative value
+  // with -1 * number of overflowed words
+  //
+
+  if (!checkInitialized())
+    return 0;
+
+  unsigned int x;
+  unsigned int mcmHeader = 0;
+  unsigned int adcMask = 0;
+  int nw = 0; // Number of written words
+  int of = 0; // Number of overflowed words
+  int rawVer = mFeeParam->getRAWversion();
+  std::vector<int> adc;
+
+  if (!checkInitialized())
+    return 0;
+
+  if (mTrapConfig->getTrapReg(TrapConfig::kEBSF, mDetector, mRobPos, mMcmPos) != 0) // store unfiltered data
+    adc = mADCR;
+  else
+    adc = mADCF;
+
+  // Produce ADC mask : nncc cccm mmmm mmmm mmmm mmmm mmmm 1100
+  // 				n : unused , c : ADC count, m : selected ADCs
+  if (rawVer >= 3 &&
+      (mTrapConfig->getTrapReg(TrapConfig::kC15CPUA, mDetector, mRobPos, mMcmPos) & (1 << 13))) { // check for zs flag in TRAP configuration
+    int nActiveADC = 0;                                                                           // number of activated ADC bits in a word
+    for (int iAdc = 0; iAdc < FeeParam::getNadcMcm(); iAdc++) {
+      if (~mZSMap[iAdc] != 0) {       //  0 means not suppressed
+        adcMask |= (1 << (iAdc + 4)); // last 4 digit reserved for 1100=0xc
+        nActiveADC++;                 // number of 1 in mmm....m
+      }
+    }
+
+    if ((nActiveADC == 0) &&
+        (mTrapConfig->getTrapReg(TrapConfig::kC15CPUA, mDetector, mRobPos, mMcmPos) & (1 << 8))) // check for DEH flag in TRAP configuration
+      return 0;
+
+    // assemble adc mask word
+    adcMask |= (1 << 30) | ((0x3FFFFFFC) & (~(nActiveADC) << 25)) | 0xC; // nn = 01, ccccc are inverted, 0xc=1100
+  }
+
+  // MCM header
+  mcmHeader = (1 << 31) | (mRobPos << 28) | (mMcmPos << 24) | ((iEv % 0x100000) << 4) | 0xC;
+  if (nw < bufSize)
+    buf[nw++] = mcmHeader;
+  else
+    of++;
+
+  // ADC mask
+  if (adcMask != 0) {
+    if (nw < bufSize)
+      buf[nw++] = adcMask;
+    else
+      of++;
+  }
+
+  // Produce ADC data. 3 timebins are packed into one 32 bits word
+  // In this version, different ADC channel will NOT share the same word
+
+  unsigned int aa = 0, a1 = 0, a2 = 0, a3 = 0;
+
+  for (int iAdc = 0; iAdc < 21; iAdc++) {
+    if (rawVer >= 3 && ~mZSMap[iAdc] == 0)
+      continue; // Zero Suppression, 0 means not suppressed
+    aa = !(iAdc & 1) + 2;
+    for (int iT = 0; iT < mNTimeBin; iT += 3) {
+      a1 = ((iT) < mNTimeBin) ? adc[iAdc * mNTimeBin + iT] >> mgkAddDigits : 0;
+      a2 = ((iT + 1) < mNTimeBin) ? adc[iAdc * mNTimeBin + iT + 1] >> mgkAddDigits : 0;
+      a3 = ((iT + 2) < mNTimeBin) ? adc[iAdc * mNTimeBin + iT + 2] >> mgkAddDigits : 0;
+      x = (a3 << 22) | (a2 << 12) | (a1 << 2) | aa;
+      if (nw < bufSize) {
+        buf[nw++] = x;
+      } else {
+        of++;
+      }
+    }
+  }
+
+  if (of != 0)
+    return -of;
+  else
+    return nw;
+}
+
+int TrapSimulator::produceTrackletStream(unsigned int* buf, int bufSize)
+{
+  //
+  // Produce tracklet data stream from this MCM and put in buf
+  // Returns number of words filled, or negative value
+  // with -1 * number of overflowed words
+  //
+
+  if (!checkInitialized())
+    return 0;
+
+  int nw = 0; // Number of written words
+  int of = 0; // Number of overflowed words
+
+  // Produce tracklet data. A maximum of four 32 Bit words will be written per MCM
+  // mMCMT is filled continuously until no more tracklet words available
+
+  for (int iTracklet = 0; iTracklet < mTrackletArray.size(); iTracklet++) {
+    if (nw < bufSize)
+      buf[nw++] = mTrackletArray[iTracklet].getTrackletWord();
+    else
+      of++;
+  }
+
+  if (of != 0)
+    return -of;
+  else
+    return nw;
+}
+
+void TrapSimulator::filter()
+{
+  //
+  // Filter the raw ADC values. The active filter stages and their
+  // parameters are taken from TrapConfig.
+  // The raw data is stored separate from the filtered data. Thus,
+  // it is possible to run the filters on a set of raw values
+  // sequentially for parameter tuning.
+  //
+
+  if (!checkInitialized())
+    return;
+
+  // Apply filters sequentially. Bypass is handled by filters
+  // since counters and internal registers may be updated even
+  // if the filter is bypassed.
+  // The first filter takes the data from mADCR and
+  // outputs to mADCF.
+
+  // Non-linearity filter not implemented.
+  filterPedestal();
+  filterGain();
+  filterTail();
+  // Crosstalk filter not implemented.
+}
+
+void TrapSimulator::filterPedestalInit(int baseline)
+{
+  // Initializes the pedestal filter assuming that the input has
+  // been constant for a long time (compared to the time constant).
+
+  unsigned short fptc = mTrapConfig->getTrapReg(TrapConfig::kFPTC, mDetector, mRobPos, mMcmPos); // 0..3, 0 - fastest, 3 - slowest
+
+  for (int adc = 0; adc < FeeParam::getNadcMcm(); adc++)
+    mInternalFilterRegisters[adc].mPedAcc = (baseline << 2) * (1 << mgkFPshifts[fptc]);
+}
+
+unsigned short TrapSimulator::filterPedestalNextSample(int adc, int timebin, unsigned short value)
+{
+  // Returns the output of the pedestal filter given the input value.
+  // The output depends on the internal registers and, thus, the
+  // history of the filter.
+
+  unsigned short fpnp = mTrapConfig->getTrapReg(TrapConfig::kFPNP, mDetector, mRobPos, mMcmPos); // 0..511 -> 0..127.75, pedestal at the output
+  unsigned short fptc = mTrapConfig->getTrapReg(TrapConfig::kFPTC, mDetector, mRobPos, mMcmPos); // 0..3, 0 - fastest, 3 - slowest
+  unsigned short fpby = mTrapConfig->getTrapReg(TrapConfig::kFPBY, mDetector, mRobPos, mMcmPos); // 0..1 bypass, active low
+
+  unsigned short accumulatorShifted;
+  unsigned short inpAdd;
+
+  inpAdd = value + fpnp;
+
+  accumulatorShifted = (mInternalFilterRegisters[adc].mPedAcc >> mgkFPshifts[fptc]) & 0x3FF; // 10 bits
+  if (timebin == 0)                                                                          // the accumulator is disabled in the drift time
+  {
+    int correction = (value & 0x3FF) - accumulatorShifted;
+    mInternalFilterRegisters[adc].mPedAcc = (mInternalFilterRegisters[adc].mPedAcc + correction) & 0x7FFFFFFF; // 31 bits
+  }
+
+  if (fpby == 0)
+    return value;
+
+  if (inpAdd <= accumulatorShifted)
+    return 0;
+  else {
+    inpAdd = inpAdd - accumulatorShifted;
+    if (inpAdd > 0xFFF)
+      return 0xFFF;
+    else
+      return inpAdd;
+  }
+}
+
+void TrapSimulator::filterPedestal()
+{
+  //
+  // Apply pedestal filter
+  //
+  // As the first filter in the chain it reads data from mADCR
+  // and outputs to mADCF.
+  // It has only an effect if previous samples have been fed to
+  // find the pedestal. Currently, the simulation assumes that
+  // the input has been stable for a sufficiently long time.
+
+  for (int iTimeBin = 0; iTimeBin < mNTimeBin; iTimeBin++) {
+    for (int iAdc = 0; iAdc < FeeParam::getNadcMcm(); iAdc++) {
+      mADCF[iAdc * mNTimeBin + iTimeBin] = filterPedestalNextSample(iAdc, iTimeBin, mADCR[iAdc * mNTimeBin + iTimeBin]);
+    }
+  }
+}
+
+void TrapSimulator::filterGainInit()
+{
+  // Initializes the gain filter. In this case, only threshold
+  // counters are reset.
+
+  for (int adc = 0; adc < FeeParam::getNadcMcm(); adc++) {
+    // these are counters which in hardware continue
+    // until maximum or reset
+    mInternalFilterRegisters[adc].mGainCounterA = 0;
+    mInternalFilterRegisters[adc].mGainCounterB = 0;
+  }
+}
+
+unsigned short TrapSimulator::filterGainNextSample(int adc, unsigned short value)
+{
+  // Apply the gain filter to the given value.
+  // BEGIN_LATEX O_{i}(t) = #gamma_{i} * I_{i}(t) + a_{i} END_LATEX
+  // The output depends on the internal registers and, thus, the
+  // history of the filter.
+
+  unsigned short mgby = mTrapConfig->getTrapReg(TrapConfig::kFGBY, mDetector, mRobPos, mMcmPos);                             // bypass, active low
+  unsigned short mgf = mTrapConfig->getTrapReg(TrapConfig::TrapReg_t(TrapConfig::kFGF0 + adc), mDetector, mRobPos, mMcmPos); // 0x700 + (0 & 0x1ff);
+  unsigned short mga = mTrapConfig->getTrapReg(TrapConfig::TrapReg_t(TrapConfig::kFGA0 + adc), mDetector, mRobPos, mMcmPos); // 40;
+  unsigned short mgta = mTrapConfig->getTrapReg(TrapConfig::kFGTA, mDetector, mRobPos, mMcmPos);                             // 20;
+  unsigned short mgtb = mTrapConfig->getTrapReg(TrapConfig::kFGTB, mDetector, mRobPos, mMcmPos);                             // 2060;
+
+  unsigned int mgfExtended = 0x700 + mgf; // The corr factor which is finally applied has to be extended by 0x700 (hex) or 0.875 (dec)
+                                          // because fgf=0 correspons to 0.875 and fgf=511 correspons to 1.125 - 2^(-11)
+                                          // (see TRAP User Manual for details)
+
+  unsigned int corr; // corrected value
+
+  value &= 0xFFF;
+  corr = (value * mgfExtended) >> 11;
+  corr = corr > 0xfff ? 0xfff : corr;
+  corr = addUintClipping(corr, mga, 12);
+
+  // Update threshold counters
+  // not really useful as they are cleared with every new event
+  if (!((mInternalFilterRegisters[adc].mGainCounterA == 0x3FFFFFF) || (mInternalFilterRegisters[adc].mGainCounterB == 0x3FFFFFF)))
+  // stop when full
+  {
+    if (corr >= mgtb)
+      mInternalFilterRegisters[adc].mGainCounterB++;
+    else if (corr >= mgta)
+      mInternalFilterRegisters[adc].mGainCounterA++;
+  }
+
+  if (mgby == 1)
+    return corr;
+  else
+    return value;
+}
+
+void TrapSimulator::filterGain()
+{
+  // Read data from mADCF and apply gain filter.
+
+  for (int adc = 0; adc < FeeParam::getNadcMcm(); adc++) {
+    for (int iTimeBin = 0; iTimeBin < mNTimeBin; iTimeBin++) {
+      mADCF[adc * mNTimeBin + iTimeBin] = filterGainNextSample(adc, mADCF[adc * mNTimeBin + iTimeBin]);
+    }
+  }
+}
+
+void TrapSimulator::filterTailInit(int baseline)
+{
+  // Initializes the tail filter assuming that the input has
+  // been at the baseline value (configured by FTFP) for a
+  // sufficiently long time.
+
+  // exponents and weight calculated from configuration
+  unsigned short alphaLong = 0x3ff & mTrapConfig->getTrapReg(TrapConfig::kFTAL, mDetector, mRobPos, mMcmPos);                            // the weight of the long component
+  unsigned short lambdaLong = (1 << 10) | (1 << 9) | (mTrapConfig->getTrapReg(TrapConfig::kFTLL, mDetector, mRobPos, mMcmPos) & 0x1FF);  // the multiplier
+  unsigned short lambdaShort = (0 << 10) | (1 << 9) | (mTrapConfig->getTrapReg(TrapConfig::kFTLS, mDetector, mRobPos, mMcmPos) & 0x1FF); // the multiplier
+
+  float lambdaL = lambdaLong * 1.0 / (1 << 11);
+  float lambdaS = lambdaShort * 1.0 / (1 << 11);
+  float alphaL = alphaLong * 1.0 / (1 << 11);
+  float qup, qdn;
+  qup = (1 - lambdaL) * (1 - lambdaS);
+  qdn = 1 - lambdaS * alphaL - lambdaL * (1 - alphaL);
+  float kdc = qup / qdn;
+
+  float ql, qs;
+
+  if (baseline < 0)
+    baseline = mTrapConfig->getTrapReg(TrapConfig::kFPNP, mDetector, mRobPos, mMcmPos);
+
+  ql = lambdaL * (1 - lambdaS) * alphaL;
+  qs = lambdaS * (1 - lambdaL) * (1 - alphaL);
+
+  for (int adc = 0; adc < FeeParam::getNadcMcm(); adc++) {
+    int value = baseline & 0xFFF;
+    int corr = (value * mTrapConfig->getTrapReg(TrapConfig::TrapReg_t(TrapConfig::kFGF0 + adc), mDetector, mRobPos, mMcmPos)) >> 11;
+    corr = corr > 0xfff ? 0xfff : corr;
+    corr = addUintClipping(corr, mTrapConfig->getTrapReg(TrapConfig::TrapReg_t(TrapConfig::kFGA0 + adc), mDetector, mRobPos, mMcmPos), 12);
+
+    float kt = kdc * baseline;
+    unsigned short aout = baseline - (unsigned short)kt;
+
+    mInternalFilterRegisters[adc].mTailAmplLong = (unsigned short)(aout * ql / (ql + qs));
+    mInternalFilterRegisters[adc].mTailAmplShort = (unsigned short)(aout * qs / (ql + qs));
+  }
+}
+
+unsigned short TrapSimulator::filterTailNextSample(int adc, unsigned short value)
+{
+  // Returns the output of the tail filter for the given input value.
+  // The output depends on the internal registers and, thus, the
+  // history of the filter.
+
+  // exponents and weight calculated from configuration
+  unsigned short alphaLong = 0x3ff & mTrapConfig->getTrapReg(TrapConfig::kFTAL, mDetector, mRobPos, mMcmPos);                            // the weight of the long component
+  unsigned short lambdaLong = (1 << 10) | (1 << 9) | (mTrapConfig->getTrapReg(TrapConfig::kFTLL, mDetector, mRobPos, mMcmPos) & 0x1FF);  // the multiplier of the long component
+  unsigned short lambdaShort = (0 << 10) | (1 << 9) | (mTrapConfig->getTrapReg(TrapConfig::kFTLS, mDetector, mRobPos, mMcmPos) & 0x1FF); // the multiplier of the short component
+
+  // intermediate signals
+  unsigned int aDiff;
+  unsigned int alInpv;
+  unsigned short aQ;
+  unsigned int tmp;
+
+  unsigned short inpVolt = value & 0xFFF; // 12 bits
+
+  // add the present generator outputs
+  aQ = addUintClipping(mInternalFilterRegisters[adc].mTailAmplLong, mInternalFilterRegisters[adc].mTailAmplShort, 12);
+
+  // calculate the difference between the input and the generated signal
+  if (inpVolt > aQ)
+    aDiff = inpVolt - aQ;
+  else
+    aDiff = 0;
+
+  // the inputs to the two generators, weighted
+  alInpv = (aDiff * alphaLong) >> 11;
+
+  // the new values of the registers, used next time
+  // long component
+  tmp = addUintClipping(mInternalFilterRegisters[adc].mTailAmplLong, alInpv, 12);
+  tmp = (tmp * lambdaLong) >> 11;
+  mInternalFilterRegisters[adc].mTailAmplLong = tmp & 0xFFF;
+  // short component
+  tmp = addUintClipping(mInternalFilterRegisters[adc].mTailAmplShort, aDiff - alInpv, 12);
+  tmp = (tmp * lambdaShort) >> 11;
+  mInternalFilterRegisters[adc].mTailAmplShort = tmp & 0xFFF;
+
+  // the output of the filter
+  if (mTrapConfig->getTrapReg(TrapConfig::kFTBY, mDetector, mRobPos, mMcmPos) == 0) // bypass mode, active low
+    return value;
+  else
+    return aDiff;
+}
+
+void TrapSimulator::filterTail()
+{
+  // Apply tail cancellation filter to all data.
+
+  for (int iTimeBin = 0; iTimeBin < mNTimeBin; iTimeBin++) {
+    for (int iAdc = 0; iAdc < FeeParam::getNadcMcm(); iAdc++) {
+      mADCF[iAdc * mNTimeBin + iTimeBin] = filterTailNextSample(iAdc, mADCF[iAdc * mNTimeBin + iTimeBin]);
+    }
+  }
+}
+
+void TrapSimulator::zeroSupressionMapping()
+{
+  //
+  // Zero Suppression Mapping implemented in TRAP chip
+  // only implemented for up to 30 timebins
+  //
+  // See detail TRAP manual "Data Indication" section:
+  // http://www.kip.uni-heidelberg.de/ti/TRD/doc/trap/TRAP-UserManual.pdf
+  //
+
+  if (!checkInitialized())
+    return;
+
+  int eBIS = mTrapConfig->getTrapReg(TrapConfig::kEBIS, mDetector, mRobPos, mMcmPos);
+  int eBIT = mTrapConfig->getTrapReg(TrapConfig::kEBIT, mDetector, mRobPos, mMcmPos);
+  int eBIL = mTrapConfig->getTrapReg(TrapConfig::kEBIL, mDetector, mRobPos, mMcmPos);
+  int eBIN = mTrapConfig->getTrapReg(TrapConfig::kEBIN, mDetector, mRobPos, mMcmPos);
+
+  for (int iAdc = 0; iAdc < FeeParam::getNadcMcm(); iAdc++)
+    mZSMap[iAdc] = -1;
+
+  for (int it = 0; it < mNTimeBin; it++) {
+    int iAdc; // current ADC channel
+    int ap;
+    int ac;
+    int an;
+    int mask;
+    int supp; // suppression of the current channel (low active)
+
+    // ----- first channel -----
+    iAdc = 0;
+
+    ap = 0 >> mgkAddDigits;                                  // previous
+    ac = mADCF[iAdc * mNTimeBin + it] >> mgkAddDigits;       // current
+    an = mADCF[(iAdc + 1) * mNTimeBin + it] >> mgkAddDigits; // next
+
+    mask = (ac >= ap && ac >= an) ? 0 : 0x1; // peak center detection
+    mask += (ap + ac + an > eBIT) ? 0 : 0x2; // cluster
+    mask += (ac > eBIS) ? 0 : 0x4;           // absolute large peak
+
+    supp = (eBIL >> mask) & 1;
+
+    mZSMap[iAdc] &= ~((1 - supp) << it);
+    if (eBIN == 0) { // neighbour sensitivity
+      mZSMap[iAdc + 1] &= ~((1 - supp) << it);
+    }
+
+    // ----- last channel -----
+    iAdc = FeeParam::getNadcMcm() - 1;
+
+    ap = mADCF[(iAdc - 1) * mNTimeBin + it] >> mgkAddDigits; // previous
+    ac = mADCF[iAdc * mNTimeBin + it] >> mgkAddDigits;       // current
+    an = 0 >> mgkAddDigits;                                  // next
+
+    mask = (ac >= ap && ac >= an) ? 0 : 0x1; // peak center detection
+    mask += (ap + ac + an > eBIT) ? 0 : 0x2; // cluster
+    mask += (ac > eBIS) ? 0 : 0x4;           // absolute large peak
+
+    supp = (eBIL >> mask) & 1;
+
+    mZSMap[iAdc] &= ~((1 - supp) << it);
+    if (eBIN == 0) { // neighbour sensitivity
+      mZSMap[iAdc - 1] &= ~((1 - supp) << it);
+    }
+
+    // ----- middle channels -----
+    for (iAdc = 1; iAdc < FeeParam::getNadcMcm() - 1; iAdc++) {
+      ap = mADCF[(iAdc - 1) * mNTimeBin + it] >> mgkAddDigits; // previous
+      ac = mADCF[iAdc * mNTimeBin + it] >> mgkAddDigits;       // current
+      an = mADCF[(iAdc + 1) * mNTimeBin + it] >> mgkAddDigits; // next
+
+      mask = (ac >= ap && ac >= an) ? 0 : 0x1; // peak center detection
+      mask += (ap + ac + an > eBIT) ? 0 : 0x2; // cluster
+      mask += (ac > eBIS) ? 0 : 0x4;           // absolute large peak
+
+      supp = (eBIL >> mask) & 1;
+
+      mZSMap[iAdc] &= ~((1 - supp) << it);
+      if (eBIN == 0) { // neighbour sensitivity
+        mZSMap[iAdc - 1] &= ~((1 - supp) << it);
+        mZSMap[iAdc + 1] &= ~((1 - supp) << it);
+      }
+    }
+  }
+}
+
+void TrapSimulator::addHitToFitreg(int adc, unsigned short timebin, unsigned short qtot, short ypos)
+{
+  // Add the given hit to the fit register which will be used for
+  // the tracklet calculation.
+  // In addition to the fit sums in the fit register
+  //
+
+  if (adc > 24)
+    LOG(error) << " adc channel into addHitToFitReg is out of bounds for mFitReg : " << adc;
+  //  LOG(debug2) << "ENTER: " << __FILE__ << ":" << __func__ << ":" << __LINE__ << " with mNHits = " << mNHits;
+  if ((timebin >= mTrapConfig->getTrapReg(TrapConfig::kTPQS0, mDetector, mRobPos, mMcmPos)) &&
+      (timebin < mTrapConfig->getTrapReg(TrapConfig::kTPQE0, mDetector, mRobPos, mMcmPos)))
+    mFitReg[adc].mQ0 += qtot;
+
+  if ((timebin >= mTrapConfig->getTrapReg(TrapConfig::kTPQS1, mDetector, mRobPos, mMcmPos)) &&
+      (timebin < mTrapConfig->getTrapReg(TrapConfig::kTPQE1, mDetector, mRobPos, mMcmPos)))
+    mFitReg[adc].mQ1 += qtot;
+
+  if ((timebin >= mTrapConfig->getTrapReg(TrapConfig::kTPFS, mDetector, mRobPos, mMcmPos)) &&
+      (timebin < mTrapConfig->getTrapReg(TrapConfig::kTPFE, mDetector, mRobPos, mMcmPos))) {
+    mFitReg[adc].mSumX += timebin;
+    mFitReg[adc].mSumX2 += timebin * timebin;
+    mFitReg[adc].mNhits++;
+    mFitReg[adc].mSumY += ypos;
+    mFitReg[adc].mSumY2 += ypos * ypos;
+    mFitReg[adc].mSumXY += timebin * ypos;
+    //    LOG(debug) << "fitreg[" << adc << "] in timebin " << timebin << ": X=" << mFitReg[adc].mSumX
+    //             << ", X2=" << mFitReg[adc].mSumX2 << ", N=" << mFitReg[adc].mNhits << ", Y="
+    //           << mFitReg[adc].mSumY << ", Y2=" << mFitReg[adc].mSumY2 << ", XY=" << mFitReg[adc].mSumXY
+    //         << ", Q0=" << mFitReg[adc].mQ0 << ", Q1=" << mFitReg[adc].mQ1;
+  }
+
+  // register hits (MC info)
+  //
+  if (mNHits < mgkNHitsMC) {
+    mHits[mNHits].mChannel = adc;
+    mHits[mNHits].mQtot = qtot;
+    mHits[mNHits].mYpos = ypos;
+    mHits[mNHits].mTimebin = timebin;
+    //TODO link to the labels.
+    mNHits++;
+    //.emplace_back(adc, timebin, qtot, ypos); // TODO add label indexes into the labels container for all those labels pertaining to this hit.
+  }
+  //  else{
+  //      LOG(warn) << "no space left to store the MC information for the hit >100";
+  //  }
+  //  LOG(debug) << "added hit of : "<<  adc<<":"<< qtot<<":"<< ypos<<":"<< timebin; // TODO add label indexes into the labels container for all those labels pertaining to this hit.
+}
+
+void TrapSimulator::calcFitreg()
+{
+  // Preprocessing.
+  // Detect the hits and fill the fit registers.
+  // Requires 12-bit data from mADCF which means Filter()
+  // has to be called before even if all filters are bypassed.
+  //??? to be clarified:
+  //    LOG(debug) << __FILE__ << ":" << __func__ << ":" << __LINE__;
+  unsigned int adcMask = 0xffffffff;
+
+  bool hitQual;
+  int adcLeft, adcCentral, adcRight;
+  unsigned short timebin, adcch, timebin1, timebin2, qtotTemp;
+  Short_t ypos, fromLeft, fromRight, found;
+  std::array<unsigned short, 20> qTotal{}; //[19 + 1]; // the last is dummy
+  std::array<unsigned short, 6> marked{}, qMarked{};
+  unsigned short worse1, worse2;
+  int debugstop = 1;
+
+  if (mgStoreClusters) {
+    timebin1 = 0;
+    timebin2 = mNTimeBin;
+  } else {
+    // find first timebin to be looked at
+    timebin1 = mTrapConfig->getTrapReg(TrapConfig::kTPFS, mDetector, mRobPos, mMcmPos);
+    if (mTrapConfig->getTrapReg(TrapConfig::kTPQS0, mDetector, mRobPos, mMcmPos) < timebin1)
+      timebin1 = mTrapConfig->getTrapReg(TrapConfig::kTPQS0, mDetector, mRobPos, mMcmPos);
+    if (mTrapConfig->getTrapReg(TrapConfig::kTPQS1, mDetector, mRobPos, mMcmPos) < timebin1)
+      timebin1 = mTrapConfig->getTrapReg(TrapConfig::kTPQS1, mDetector, mRobPos, mMcmPos);
+
+    // find last timebin to be looked at
+    timebin2 = mTrapConfig->getTrapReg(TrapConfig::kTPFE, mDetector, mRobPos, mMcmPos);
+    if (mTrapConfig->getTrapReg(TrapConfig::kTPQE0, mDetector, mRobPos, mMcmPos) > timebin2)
+      timebin2 = mTrapConfig->getTrapReg(TrapConfig::kTPQE0, mDetector, mRobPos, mMcmPos);
+    if (mTrapConfig->getTrapReg(TrapConfig::kTPQE1, mDetector, mRobPos, mMcmPos) > timebin2)
+      timebin2 = mTrapConfig->getTrapReg(TrapConfig::kTPQE1, mDetector, mRobPos, mMcmPos);
+  }
+
+  // reset the fit registers
+  for (auto& fitreg : mFitReg)
+    fitreg.ClearReg();
+
+  //  mFitReg.clear();
+  for (int i = 0; i < mNHits; i++)
+    mHits[i].ClearHits(); // do it this way as we dont want to 100 members if we only used 3 ....
+                          //  for (int i=0;i<mNHits;i++) LOG(info) << "mHits.["<<i << "].mTimebin="<< mHits[i].mTimebin;
+
+  for (timebin = timebin1; timebin < timebin2; timebin++) {
+    // first find the hit candidates and store the total cluster charge in qTotal array
+    // in case of not hit store 0 there.
+    for (adcch = 0; adcch < FeeParam::getNadcMcm() - 2; adcch++) {
+      if (((adcMask >> adcch) & 7) == 7) //??? all 3 channels are present in case of ZS
+      {
+        adcLeft = mADCF[adcch * mNTimeBin + timebin];
+        adcCentral = mADCF[(adcch + 1) * mNTimeBin + timebin];
+        adcRight = mADCF[(adcch + 2) * mNTimeBin + timebin];
+
+        if (mTrapConfig->getTrapReg(TrapConfig::kTPVBY, mDetector, mRobPos, mMcmPos) == 0) {
+          // bypass the cluster verification
+          hitQual = true;
+        } else {
+          hitQual = ((adcLeft * adcRight) <
+                     ((mTrapConfig->getTrapReg(TrapConfig::kTPVT, mDetector, mRobPos, mMcmPos) * adcCentral * adcCentral) >> 10));
+          // TODO PUT THIS BACK !       if (hitQual)
+          //          LOG(debug) << "cluster quality cut passed with " << adcLeft << ", " << adcCentral << ", "
+          //                    << adcRight << " - threshold " << mTrapConfig->getTrapReg(TrapConfig::kTPVT, mDetector, mRobPos, mMcmPos)
+          //                  << " -> " << mTrapConfig->getTrapReg(TrapConfig::kTPVT, mDetector, mRobPos, mMcmPos) * adcCentral * adcCentral;
+        }
+
+        // The accumulated charge is with the pedestal!!!
+        qtotTemp = adcLeft + adcCentral + adcRight;
+        /*	if ((mDebugStream) && (qtotTemp > 130)) {
+	  (*mDebugStream) << "testtree"
+			  << "qtot=" << qtotTemp
+			  << "qleft=" << adcLeft
+			  << "qcent=" << adcCentral
+			  << "qright=" << adcRight
+			  << "\n";
+	} TODO figure out another way for a debugstream not using TTreeSRedirector, check what that class actually does .... */
+        //TODO for now simply log it to LOG system can parse and dump to a tree if
+        //TODO if i really want later.
+        if ((qtotTemp > 130)) {
+          LOG(debug) << "testtree "
+                     << "qtot=" << qtotTemp
+                     << " qleft=" << adcLeft
+                     << " qcent=" << adcCentral
+                     << " qright=" << adcRight;
+        }
+
+        if ((hitQual) &&
+            (qtotTemp >= mTrapConfig->getTrapReg(TrapConfig::kTPHT, mDetector, mRobPos, mMcmPos)) &&
+            (adcLeft <= adcCentral) &&
+            (adcCentral > adcRight)) {
+          qTotal[adcch] = qtotTemp;
+        } else {
+          qTotal[adcch] = 0;
+        }
+      } else {
+        qTotal[adcch] = 0; //jkl
+      }
+      //   if (qTotal[adcch] != 0)
+      //    LOG(debug) << "ch " << setw(2) << adcch << "   qTotal " << qTotal[adcch];
+    }
+
+    fromLeft = -1;
+    adcch = 0;
+    found = 0;
+    marked[4] = 19; // invalid channel
+    marked[5] = 19; // invalid channel
+    qTotal[19] = 0;
+    int loopcount = 0;
+    while ((adcch < 16) && (found < 3)) {
+      if (qTotal[adcch] > 0) {
+        fromLeft = adcch;
+        marked[2 * found + 1] = adcch;
+        found++;
+      }
+      adcch++;
+    }
+
+    fromRight = -1;
+    adcch = 18;
+    found = 0;
+    while ((adcch > 2) && (found < 3)) {
+      if (qTotal[adcch] > 0) {
+        marked[2 * found] = adcch;
+        found++;
+        fromRight = adcch;
+      }
+      adcch--;
+    }
+
+    // here mask the hit candidates in the middle, if any
+    if ((fromLeft >= 0) && (fromRight >= 0) && (fromLeft < fromRight)) {
+      for (adcch = fromLeft + 1; adcch < fromRight; adcch++) {
+        qTotal[adcch] = 0;
+      }
+    }
+
+    found = 0;
+    for (adcch = 0; adcch < 19; adcch++) {
+      if (qTotal[adcch] > 0) {
+        found++;
+        // NOT READY
+      }
+    }
+    if (found > 4) // sorting like in the TRAP in case of 5 or 6 candidates!
+    {
+      if (marked[4] == marked[5])
+        marked[5] = 19;
+      for (found = 0; found < 6; found++) {
+        qMarked[found] = qTotal[marked[found]] >> 4;
+      }
+
+      sort6To2Worst(marked[0], marked[3], marked[4], marked[1], marked[2], marked[5],
+                    qMarked[0],
+                    qMarked[3],
+                    qMarked[4],
+                    qMarked[1],
+                    qMarked[2],
+                    qMarked[5],
+                    &worse1, &worse2);
+      // Now mask the two channels with the smallest charge
+      if (worse1 < 19) {
+        qTotal[worse1] = 0;
+        //LOG(debug3) << "Kill ch " << worse1;
+      }
+      if (worse2 < 19) {
+        qTotal[worse2] = 0;
+        // LOG(debug3) << "Kill ch " << worse2;
+      }
+    }
+
+    for (adcch = 0; adcch < 19; adcch++) {
+      if (qTotal[adcch] > 0) // the channel is marked for processing
+      {
+        adcLeft = getDataFiltered(adcch, timebin);
+        adcCentral = getDataFiltered(adcch + 1, timebin);
+        adcRight = getDataFiltered(adcch + 2, timebin);
+        // hit detected, in TRAP we have 4 units and a hit-selection, here we proceed all channels!
+        // subtract the pedestal TPFP, clipping instead of wrapping
+
+        int regTPFP = mTrapConfig->getTrapReg(TrapConfig::kTPFP, mDetector, mRobPos, mMcmPos); //TODO put this together with the others as members of trapsim, which is initiliased by det,rob,mcm.
+        //LOG(debug) << "Hit found, time=" << timebin << ", adcch=" << adcch << "/" << adcch + 1 << "/"
+        //         << adcch + 2 << ", adc values=" << adcLeft << "/" << adcCentral << "/"
+        //       << adcRight << ", regTPFP=" << regTPFP << ", TPHT=" << mTrapConfig->getTrapReg(TrapConfig::kTPHT, mDetector, mRobPos, mMcmPos);
+        if (timebin == 19 && adcch == 8 && adcLeft == 0 && adcCentral == 107 && adcRight == 89 && regTPFP == 40) {
+          //LOG(info) << "I think about to crash";
+          //while(debugstop){
+          //   //LOG(info) << "debug stopped";
+          // }
+        }
+        if (adcLeft < regTPFP)
+          adcLeft = 0;
+        else
+          adcLeft -= regTPFP;
+        if (adcCentral < regTPFP)
+          adcCentral = 0;
+        else
+          adcCentral -= regTPFP;
+        if (adcRight < regTPFP)
+          adcRight = 0;
+        else
+          adcRight -= regTPFP;
+
+        // Calculate the center of gravity
+        // checking for adcCentral != 0 (in case of "bad" configuration)
+        if (adcCentral == 0)
+          continue;
+        ypos = 128 * (adcRight - adcLeft) / adcCentral;
+        if (ypos < 0)
+          ypos = -ypos;
+        // make the correction using the position LUT
+        ypos = ypos + mTrapConfig->getTrapReg((TrapConfig::TrapReg_t)(TrapConfig::kTPL00 + (ypos & 0x7F)),
+                                              mDetector, mRobPos, mMcmPos);
+        if (adcLeft > adcRight)
+          ypos = -ypos;
+        /*   TODO this is left in here as a ref for what was done with labels, its stored externally now figure something out.
+*/
+        // add the hit to the fitregister
+        //      int a=qTotal[adcch] >> mgkAddDigits;
+        // LOG(debug) << "calling addHitToFitreg with :" << adcch << " :: " << timebin << " :: " << hex << qTotal[adcch] << dec << " :: shifted bits  :" << 2 << " :: " << ypos;
+        //  addHitToFitreg(adcch, timebin, qTotal[adcch] >> 2, ypos);
+        addHitToFitreg(adcch, timebin, qTotal[adcch] >> mgkAddDigits, ypos);
+        // LOG(debug) << __FILE__ << ":" << __LINE__ << " :: added hit to fit re ";
+      }
+    }
+  }
+
+#ifdef DEBUGTRAP
+  for (int iAdc = 0; iAdc < FeeParam::getNadcMcm(); iAdc++) {
+    if (mFitReg[iAdc].mNhits != 0) {
+      LOG(debug) << "fitreg[" << iAdc << "]: nHits = " << mFitReg[iAdc].mNhits << "]: sumX = " << mFitReg[iAdc].mSumX << ", sumY = " << mFitReg[iAdc].mSumY << ", sumX2 = " << mFitReg[iAdc].mSumX2 << ", sumY2 = " << mFitReg[iAdc].mSumY2 << ", sumXY = " << mFitReg[iAdc].mSumXY;
+    }
+  }
+#endif
+}
+
+void TrapSimulator::trackletSelection()
+{
+  // Select up to 4 tracklet candidates from the fit registers
+  // and assign them to the CPUs.
+  unsigned short adcIdx, i, j, ntracks, tmp;
+  std::array<unsigned short, 18> trackletCandch{};   // store the adcch[0] and number of hits[1] for all tracklet candidates
+  std::array<unsigned short, 18> trackletCandhits{}; // store the adcch[0] and number of hits[1] for all tracklet candidates
+
+  ntracks = 0;
+  for (adcIdx = 0; adcIdx < 18; adcIdx++) { // ADCs
+    if ((mFitReg[adcIdx].mNhits >= mTrapConfig->getTrapReg(TrapConfig::kTPCL, mDetector, mRobPos, mMcmPos)) &&
+        (mFitReg[adcIdx].mNhits + mFitReg[adcIdx + 1].mNhits >= mTrapConfig->getTrapReg(TrapConfig::kTPCT, mDetector, mRobPos, mMcmPos))) {
+      trackletCandch[ntracks] = adcIdx;
+      trackletCandhits[ntracks] = mFitReg[adcIdx].mNhits + mFitReg[adcIdx + 1].mNhits;
+      LOG(debug) << ntracks << " " << trackletCandch[ntracks] << " " << trackletCandhits[ntracks];
+      ntracks++;
+    };
+  }
+  for (i = 0; i < ntracks; i++)
+    LOG(debug) << "TRACKS: " << i << " " << trackletCandch[i] << " " << trackletCandhits[i];
+
+  if (ntracks > 4) {
+    // primitive sorting according to the number of hits
+    for (j = 0; j < (ntracks - 1); j++) {
+      for (i = j + 1; i < ntracks; i++) {
+        if ((trackletCandhits[j] < trackletCandhits[i]) ||
+            ((trackletCandhits[j] == trackletCandhits[i]) && (trackletCandch[j] < trackletCandch[i]))) {
+          // swap j & i
+          tmp = trackletCandhits[j];
+          trackletCandhits[j] = trackletCandhits[i];
+          trackletCandhits[i] = tmp;
+          tmp = trackletCandch[j];
+          trackletCandch[j] = trackletCandch[i];
+          trackletCandch[i] = tmp;
+        }
+      }
+    }
+    ntracks = 4; // cut the rest, 4 is the max
+  }
+  // else is not necessary to sort
+
+  // now sort, so that the first tracklet going to CPU0 corresponds to the highest adc channel - as in the TRAP
+  for (j = 0; j < (ntracks - 1); j++) {
+    for (i = j + 1; i < ntracks; i++) {
+      if (trackletCandch[j] < trackletCandch[i]) {
+        // swap j & i
+        tmp = trackletCandhits[j];
+        trackletCandhits[j] = trackletCandhits[i];
+        trackletCandhits[i] = tmp;
+        tmp = trackletCandch[j];
+        trackletCandch[j] = trackletCandch[i];
+        trackletCandch[i] = tmp;
+      }
+    }
+  }
+  for (i = 0; i < ntracks; i++)     // CPUs with tracklets.
+    mFitPtr[i] = trackletCandch[i]; // pointer to the left channel with tracklet for CPU[i]
+  for (i = ntracks; i < 4; i++)     // CPUs without tracklets
+    mFitPtr[i] = 31;                // pointer to the left channel with tracklet for CPU[i] = 31 (invalid)
+  //LOG(debug3) << "-------------------------------------------- found " << ntracks << " tracklet candidates";
+  //for (i = 0; i < 4; i++)
+  // LOG(debug3) << "fitPtr[" << i << "]: " << mFitPtr[i];
+
+  // reject multiple tracklets
+  if (FeeParam::instance()->getRejectMultipleTracklets()) {
+    unsigned short counts = 0;
+    for (j = 0; j < (ntracks - 1); j++) {
+      if (mFitPtr[j] == 31)
+        continue;
+
+      for (i = j + 1; i < ntracks; i++) {
+        // check if tracklets are from neighbouring ADC channels
+        if (TMath::Abs(mFitPtr[j] - mFitPtr[i]) > 1.)
+          continue;
+
+        // check which tracklet candidate has higher amount of hits
+        if ((mFitReg[mFitPtr[j]].mNhits + mFitReg[mFitPtr[j] + 1].mNhits) >=
+            (mFitReg[mFitPtr[i]].mNhits + mFitReg[mFitPtr[i] + 1].mNhits)) {
+          mFitPtr[i] = 31;
+          counts++;
+        } else {
+          mFitPtr[j] = 31;
+          counts++;
+          break;
+        }
+      }
+    }
+
+    /* ntracks = ntracks - counts;
+    LOG(debug1) << "found " << ntracks << " tracklet candidates";
+    for (i = 0; i < 4; i++)
+      LOG(debug1) << "fitPtr[" << i << "]: " << mFitPtr[i];
+      */
+  }
+}
+
+void TrapSimulator::fitTracklet()
+{
+  // Perform the actual tracklet fit based on the fit sums
+  // which have been filled in the fit registers.
+  //  LOG(debug) << "$$$$$$$$$$$$$@@@@@@@@@@@@@$$$$$$$$$$$$$$$$$$  Tracklet array size is : " << mTrackletArray.size();
+  // parameters in fitred.asm (fit program)
+  int rndAdd = 0;
+  int decPlaces = 5; // must be larger than 1 or change the following code
+                     // if (decPlaces >  1)
+  rndAdd = (1 << (decPlaces - 1)) + 1;
+  // else if (decPlaces == 1)
+  //   rndAdd = 1;
+  int ndriftDp = 5; // decimal places for drift time
+  long shift = ((long)1 << 32);
+
+  // calculated in fitred.asm
+  int padrow = ((mRobPos >> 1) << 2) | (mMcmPos >> 2);
+  int yoffs = (((((mRobPos & 0x1) << 2) + (mMcmPos & 0x3)) * 18) << 8) -
+              ((18 * 4 * 2 - 18 * 2 - 1) << 7);
+
+  // add corrections for mis-alignment
+  if (FeeParam::instance()->getUseMisalignCorr()) {
+    LOG(debug3) << "using mis-alignment correction";
+    yoffs += (int)mTrapConfig->getDmemUnsigned(mgkDmemAddrYcorr, mDetector, mRobPos, mMcmPos);
+  }
+
+  yoffs = yoffs << decPlaces; // holds position of ADC channel 1
+  int layer = mDetector % 6;
+  unsigned int scaleY = (unsigned int)((0.635 + 0.03 * layer) / (256.0 * 160.0e-4) * shift);
+  unsigned int scaleD = (unsigned int)((0.635 + 0.03 * layer) / (256.0 * 140.0e-4) * shift);
+
+  int deflCorr = (int)mTrapConfig->getDmemUnsigned(mgkDmemAddrDeflCorr, mDetector, mRobPos, mMcmPos);
+  int ndrift = (int)mTrapConfig->getDmemUnsigned(mgkDmemAddrNdrift, mDetector, mRobPos, mMcmPos);
+
+  // local variables for calculation
+  long mult, temp, denom;       //???
+  unsigned int q0, q1, pid;     // charges in the two windows and total charge
+  unsigned short nHits;         // number of hits
+  int slope, offset;            // slope and offset of the tracklet
+  int sumX, sumY, sumXY, sumX2; // fit sums from fit registers
+  int sumY2;                    // not used in the current TRAP program, now used for error calculation (simulation only)
+  float fitError, fitSlope, fitOffset;
+  FitReg *fit0, *fit1; // pointers to relevant fit registers
+
+  //  const uint32_t OneDivN[32] = {  // 2**31/N : exactly like in the TRAP, the simple division here gives the same result!
+  //      0x00000000, 0x80000000, 0x40000000, 0x2AAAAAA0, 0x20000000, 0x19999990, 0x15555550, 0x12492490,
+  //      0x10000000, 0x0E38E380, 0x0CCCCCC0, 0x0BA2E8B0, 0x0AAAAAA0, 0x09D89D80, 0x09249240, 0x08888880,
+  //      0x08000000, 0x07878780, 0x071C71C0, 0x06BCA1A0, 0x06666660, 0x06186180, 0x05D17450, 0x0590B210,
+  //      0x05555550, 0x051EB850, 0x04EC4EC0, 0x04BDA120, 0x04924920, 0x0469EE50, 0x04444440, 0x04210840};
+
+  for (int cpu = 0; cpu < 4; cpu++) {
+    if (mFitPtr[cpu] == 31) {
+      mMCMT[cpu] = 0x10001000; //??? FeeParam::getTrackletEndmarker();
+    } else {
+      fit0 = &mFitReg[mFitPtr[cpu]];
+      fit1 = &mFitReg[mFitPtr[cpu] + 1]; // next channel
+
+      mult = 1;
+      mult = mult << (32 + decPlaces);
+      mult = -mult;
+
+      // time offset for fit sums
+      const int t0 = FeeParam::instance()->getUseTimeOffset() ? (int)mTrapConfig->getDmemUnsigned(mgkDmemAddrTimeOffset, mDetector, mRobPos, mMcmPos) : 0;
+
+      //    LOG(debug3) << "using time offset t0 = " << t0;
+
+      // Merging
+      nHits = fit0->mNhits + fit1->mNhits; // number of hits
+      sumX = fit0->mSumX + fit1->mSumX;
+      sumX2 = fit0->mSumX2 + fit1->mSumX2;
+      denom = ((long)nHits) * ((long)sumX2) - ((long)sumX) * ((long)sumX);
+
+      mult = mult / denom; // exactly like in the TRAP program
+      q0 = fit0->mQ0 + fit1->mQ0;
+      q1 = fit0->mQ1 + fit1->mQ1;
+      sumY = fit0->mSumY + fit1->mSumY + 256 * fit1->mNhits;
+      sumXY = fit0->mSumXY + fit1->mSumXY + 256 * fit1->mSumX;
+      sumY2 = fit0->mSumY2 + fit1->mSumY2 + 512 * fit1->mSumY + 256 * 256 * fit1->mNhits;
+
+      slope = nHits * sumXY - sumX * sumY;
+      //offset  = sumX2*sumY  - sumX*sumXY - t0 * sumX*sumY + t0 * nHits*sumXY;
+      offset = sumX2 * sumY - sumX * sumXY;
+      offset = offset << 5;
+      offset += t0 * nHits * sumXY - t0 * sumX * sumY;
+      offset = offset >> 5;
+
+      temp = mult * slope;
+      slope = temp >> 32; // take the upper 32 bits
+      slope = -slope;
+      temp = mult * offset;
+      offset = temp >> 32; // take the upper 32 bits
+
+      offset = offset + yoffs;
+      //     LOG(debug3) << "slope = " << slope << ", slope * ndrift = " << slope * ndrift << ", deflCorr: " << deflCorr;
+      slope = ((slope * ndrift) >> ndriftDp) + deflCorr;
+      offset = offset - (mFitPtr[cpu] << (8 + decPlaces));
+
+      temp = slope;
+      temp = temp * scaleD;
+      slope = (temp >> 32);
+      temp = offset;
+      temp = temp * scaleY;
+      offset = (temp >> 32);
+
+      // rounding, like in the TRAP
+      slope = (slope + rndAdd) >> decPlaces;
+      offset = (offset + rndAdd) >> decPlaces;
+
+      //    LOG(debug) << "Det: " << setw(3) << mDetector << ", ROB: " << mRobPos << ", MCM: " << setw(2) << mMcmPos << setw(-1) << ": deflection: " << slope << ", min: " << (int)mTrapConfig->getDmemUnsigned(mgkDmemAddrDeflCutStart + 2 * mFitPtr[cpu], mDetector, mRobPos, mMcmPos) << " max : " << (int)mTrapConfig->getDmemUnsigned(mgkDmemAddrDeflCutStart + 1 + 2 * mFitPtr[cpu], mDetector, mRobPos, mMcmPos);
+
+      //     LOG(debug3) << "Fit sums: x = " << sumX << ", X = " << sumX2 << ", y = " << sumY << ", Y = " << sumY2 << ", Z = " << sumXY << ", q0 = " << q0 << ", q1 = " << q1;
+
+      fitSlope = (float)(nHits * sumXY - sumX * sumY) / (nHits * sumX2 - sumX * sumX);
+
+      fitOffset = (float)(sumX2 * sumY - sumX * sumXY) / (nHits * sumX2 - sumX * sumX);
+
+      float sx = (float)sumX;
+      float sx2 = (float)sumX2;
+      float sy = (float)sumY;
+      float sy2 = (float)sumY2;
+      float sxy = (float)sumXY;
+      fitError = sy2 - (sx2 * sy * sy - 2 * sx * sxy * sy + nHits * sxy * sxy) / (nHits * sx2 - sx * sx);
+      //fitError = (float) sumY2 - (float) (sumY*sumY) / nHits - fitSlope * ((float) (sumXY - sumX*sumY) / nHits);
+
+      bool rejected = false;
+      // deflection range table from DMEM
+      if ((slope < ((int)mTrapConfig->getDmemUnsigned(mgkDmemAddrDeflCutStart + 2 * mFitPtr[cpu], mDetector, mRobPos, mMcmPos))) ||
+          (slope > ((int)mTrapConfig->getDmemUnsigned(mgkDmemAddrDeflCutStart + 1 + 2 * mFitPtr[cpu], mDetector, mRobPos, mMcmPos))))
+        rejected = true;
+
+      //   LOG(debug) << "slope : " << slope << " getDmemUnsigned " << mTrapConfig->getDmemUnsigned(mgkDmemAddrDeflCutStart + 2 * mFitPtr[cpu], mDetector, mRobPos, mMcmPos);
+
+      if (rejected && getApplyCut()) {
+        mMCMT[cpu] = 0x10001000; //??? FeeParam::getTrackletEndmarker();
+      } else {
+        if (slope > 63 || slope < -64) { // wrapping in TRAP!
+                                         //      LOG(debug) << "Overflow in slope: " << slope << ", tracklet discarded!";
+          mMCMT[cpu] = 0x10001000;
+          continue;
+        }
+
+        slope = slope & 0x7F; // 7 bit
+
+        if (offset > 0xfff || offset < -0xfff)
+          LOG(warning) << "Overflow in offset";
+        offset = offset & 0x1FFF; // 13 bit
+
+        pid = getPID(q0, q1);
+
+        // if (pid > 0xff)
+        //     LOG(warning) << "Overflow in PID";
+        pid = pid & 0xFF; // 8 bit, exactly like in the TRAP program
+
+        // assemble and store the tracklet word
+        mMCMT[cpu] = (pid << 24) | (padrow << 20) | (slope << 13) | offset;
+
+        // calculate number of hits and MC label
+        std::array<int, 3> mcLabel = {-1, -1, -1};
+        int nHits0 = 0;
+        int nHits1 = 0;
+
+        const int maxLabels = 30;
+        std::array<int, 30> label{}; // up to 30 different labels possible
+        std::array<int, 30> count{};
+        int nLabels = 0;
+
+        for (int iHit = 0; iHit < mNHits; iHit++) {
+          if ((mHits[iHit].mChannel - mFitPtr[cpu] < 0) ||
+              (mHits[iHit].mChannel - mFitPtr[cpu] > 1))
+            continue;
+
+          // counting contributing hits
+          if (mHits[iHit].mTimebin >= mTrapConfig->getTrapReg(TrapConfig::kTPQS0, mDetector, mRobPos, mMcmPos) &&
+              mHits[iHit].mTimebin < mTrapConfig->getTrapReg(TrapConfig::kTPQE0, mDetector, mRobPos, mMcmPos))
+            nHits0++;
+          if (mHits[iHit].mTimebin >= mTrapConfig->getTrapReg(TrapConfig::kTPQS1, mDetector, mRobPos, mMcmPos) &&
+              mHits[iHit].mTimebin < mTrapConfig->getTrapReg(TrapConfig::kTPQE1, mDetector, mRobPos, mMcmPos))
+            nHits1++;
+
+          // TODO label calculation only if there is a digitsmanager to get the labels from
+        }
+        ///  LOG(debug) << "TrapSim Trackletarray size is : " << mTrackletArray.size() << "  :: adding a track at " << mMCMT[cpu] << ":" << mDetector * 2 + mRobPos % 2 << ":" << mRobPos << ":" << mMcmPos;
+        mTrackletArray.emplace_back((unsigned int)mMCMT[cpu], mDetector * 2 + mRobPos % 2, mRobPos, mMcmPos);
+        int newtrackposition = mTrackletArray.size() - 1;
+        //        mTrackletArray[newtrackposition].setLabel(mcLabel);
+        mTrackletArray[newtrackposition].setNHits(fit0->mNhits + fit1->mNhits);
+        mTrackletArray[newtrackposition].setNHits0(nHits0);
+        mTrackletArray[newtrackposition].setNHits1(nHits1);
+        mTrackletArray[newtrackposition].setQ0(q0);
+        mTrackletArray[newtrackposition].setQ1(q1);
+        mTrackletArray[newtrackposition].setSlope(fitSlope);
+        mTrackletArray[newtrackposition].setOffset(fitOffset);
+        mTrackletArray[newtrackposition].setError(TMath::Sqrt(TMath::Abs(fitError) / nHits));
+
+        // store cluster information (if requested)
+        if (mgStoreClusters) {
+          std::vector<float> res(getNumberOfTimeBins());
+          std::vector<float> qtot(getNumberOfTimeBins());
+          for (int iTimebin = 0; iTimebin < getNumberOfTimeBins(); ++iTimebin) {
+            res[iTimebin] = 0;
+            qtot[iTimebin] = 0;
+          }
+
+          for (int iHit = 0; iHit < mNHits; iHit++) {
+            int timebin = mHits[iHit].mTimebin;
+
+            // check if hit contributes
+            if (mHits[iHit].mChannel == mFitPtr[cpu]) {
+              //  for (int i=0;i<mNHits;i++) LOG(info) << "mHits.["<<i << "].mTimebin="<< mHits[i].mTimebin;
+              res[timebin] = mHits[iHit].mYpos - (fitSlope * timebin + fitOffset);
+              qtot[timebin] = mHits[iHit].mQtot;
+            } else if (mHits[iHit].mChannel == mFitPtr[cpu] + 1) {
+              res[timebin] = mHits[iHit].mYpos + 256 - (fitSlope * timebin + fitOffset);
+              qtot[timebin] = mHits[iHit].mQtot;
+            }
+          }
+          mTrackletArray[newtrackposition].setClusters(res, qtot, getNumberOfTimeBins());
+        }
+
+        //TODO dont leave this commented out !  if (fitError < 0) {
+        //   LOG(debug) << "fit slope: " << fitSlope << ", offset: " << fitOffset << ", error: " << TMath::Sqrt(TMath::Abs(fitError) / nHits);
+        //   LOG(error) << "Strange fit error: " << fitError << " from Sx: " << sumX << ", Sy: " << sumY << ", Sxy: " << sumXY << ", Sx2: " << sumX2 << ", Sy2: " << sumY2 << ", nHits: " << nHits;
+        // }
+      }
+    }
+  }
+}
+
+void TrapSimulator::tracklet()
+{
+  // Run the tracklet calculation by calling sequentially:
+  // CalcFitreg(); TrackletSelection(); FitTracklet()
+  // and store the tracklets
+
+  if (!mInitialized) {
+    return;
+  }
+  mTrackletArray.clear();
+
+  calcFitreg();
+  if (mNHits == 0) {
+    return;
+  }
+  trackletSelection();
+  fitTracklet();
+}
+
+void TrapSimulator::getTracklets(std::vector<Tracklet>& TrackletStore)
+{
+  // simply returns the found tracklets for the O2 dpl to then do its thing.
+  //
+  TrackletStore.insert(std::end(TrackletStore), std::begin(mTrackletArray), std::end(mTrackletArray));
+  //std::copy(mTrackletArray.begin(),mTrackletArray.end(),std::back_inserter(TrackletStore));
+}
+
+// ******************************
+// PID section
+//
+// Memory area for the LUT: 0xC100 to 0xC3FF
+//
+// The addresses for the parameters (the order is optimized for maximum calculation speed in the MCMs):
+// 0xC028: cor1
+// 0xC029: nBins(sF)
+// 0xC02A: cor0
+// 0xC02B: TableLength
+// Defined in TrapConfig.h
+//
+// The algorithm implemented in the TRAP program of the MCMs (Venelin Angelov)
+//  1) set the read pointer to the beginning of the Parameters in DMEM
+//  2) shift right the FitReg with the Q0 + (Q1 << 16) to get Q1
+//  3) read cor1 with rpointer++
+//  4) start cor1*Q1
+//  5) read nBins with rpointer++
+//  6) start nBins*cor1*Q1
+//  7) read cor0 with rpointer++
+//  8) swap hi-low parts in FitReg, now is Q1 + (Q0 << 16)
+//  9) shift right to get Q0
+// 10) start cor0*Q0
+// 11) read TableLength
+// 12) compare cor0*Q0 with nBins
+// 13) if >=, clip cor0*Q0 to nBins-1
+// 14) add cor0*Q0 to nBins*cor1*Q1
+// 15) compare the result with TableLength
+// 16) if >=, clip to TableLength-1
+// 17) read from the LUT 8 bits
+
+int TrapSimulator::getPID(int q0, int q1)
+{
+  // return PID calculated from charges accumulated in two time windows
+
+  unsigned long long addrQ0;
+  unsigned long long addr;
+
+  unsigned int nBinsQ0 = mTrapConfig->getDmemUnsigned(mgkDmemAddrLUTnbins, mDetector, mRobPos, mMcmPos); // number of bins in q0 / 4 !!
+  unsigned int pidTotalSize = mTrapConfig->getDmemUnsigned(mgkDmemAddrLUTLength, mDetector, mRobPos, mMcmPos);
+  if (nBinsQ0 == 0 || pidTotalSize == 0) // make sure we don't run into trouble if the value for Q0 is not configured
+    return 0;                            // Q1 not configured is ok for 1D LUT
+
+  unsigned long corrQ0 = mTrapConfig->getDmemUnsigned(mgkDmemAddrLUTcor0, mDetector, mRobPos, mMcmPos);
+  unsigned long corrQ1 = mTrapConfig->getDmemUnsigned(mgkDmemAddrLUTcor1, mDetector, mRobPos, mMcmPos);
+  if (corrQ0 == 0) // make sure we don't run into trouble if one of the values is not configured
+    return 0;
+
+  addrQ0 = corrQ0;
+  addrQ0 = (((addrQ0 * q0) >> 16) >> 16); // because addrQ0 = (q0 * corrQ0) >> 32; does not work for unknown reasons
+
+  if (addrQ0 >= nBinsQ0) { // check for overflow
+                           //    LOG(debug3) << "Overflow in q0: " << addrQ0 << "/4 is bigger then " << nBinsQ0;
+    addrQ0 = nBinsQ0 - 1;
+  }
+
+  addr = corrQ1;
+  addr = (((addr * q1) >> 16) >> 16);
+  addr = addrQ0 + nBinsQ0 * addr; // because addr = addrQ0 + nBinsQ0* (((corrQ1*q1)>>32); does not work
+
+  if (addr >= pidTotalSize) {
+    //  LOG(debug3) << "Overflow in q1. Address " << addr << "/4 is bigger then " << pidTotalSize;
+    addr = pidTotalSize - 1;
+  }
+
+  // For a LUT with 11 input and 8 output bits, the first memory address is set to  LUT[0] | (LUT[1] << 8) | (LUT[2] << 16) | (LUT[3] << 24)
+  // and so on
+  unsigned int result = mTrapConfig->getDmemUnsigned(mgkDmemAddrLUTStart + (addr / 4), mDetector, mRobPos, mMcmPos);
+  return (result >> ((addr % 4) * 8)) & 0xFF;
+}
+
+// help functions, to be cleaned up
+
+unsigned int TrapSimulator::addUintClipping(unsigned int a, unsigned int b, unsigned int nbits) const
+{
+  //
+  // This function adds a and b (unsigned) and clips to
+  // the specified number of bits.
+  //
+
+  unsigned int sum = a + b;
+  if (nbits < 32) {
+    unsigned int maxv = (1 << nbits) - 1;
+    if (sum > maxv)
+      sum = maxv;
+  } else {
+    if ((sum < a) || (sum < b))
+      sum = 0xFFFFFFFF;
+  }
+  return sum;
+}
+
+void TrapSimulator::sort2(unsigned short idx1i, unsigned short idx2i,
+                          unsigned short val1i, unsigned short val2i,
+                          unsigned short* const idx1o, unsigned short* const idx2o,
+                          unsigned short* const val1o, unsigned short* const val2o) const
+{
+  // sorting for tracklet selection
+
+  if (val1i > val2i) {
+    *idx1o = idx1i;
+    *idx2o = idx2i;
+    *val1o = val1i;
+    *val2o = val2i;
+  } else {
+    *idx1o = idx2i;
+    *idx2o = idx1i;
+    *val1o = val2i;
+    *val2o = val1i;
+  }
+}
+
+void TrapSimulator::sort3(unsigned short idx1i, unsigned short idx2i, unsigned short idx3i,
+                          unsigned short val1i, unsigned short val2i, unsigned short val3i,
+                          unsigned short* const idx1o, unsigned short* const idx2o, unsigned short* const idx3o,
+                          unsigned short* const val1o, unsigned short* const val2o, unsigned short* const val3o)
+{
+  // sorting for tracklet selection
+
+  int sel;
+
+  if (val1i > val2i)
+    sel = 4;
+  else
+    sel = 0;
+  if (val2i > val3i)
+    sel = sel + 2;
+  if (val3i > val1i)
+    sel = sel + 1;
+  switch (sel) {
+    case 6: // 1 >  2  >  3            => 1 2 3
+    case 0: // 1 =  2  =  3            => 1 2 3 : in this case doesn't matter, but so is in hardware!
+      *idx1o = idx1i;
+      *idx2o = idx2i;
+      *idx3o = idx3i;
+      *val1o = val1i;
+      *val2o = val2i;
+      *val3o = val3i;
+      break;
+
+    case 4: // 1 >  2, 2 <= 3, 3 <= 1  => 1 3 2
+      *idx1o = idx1i;
+      *idx2o = idx3i;
+      *idx3o = idx2i;
+      *val1o = val1i;
+      *val2o = val3i;
+      *val3o = val2i;
+      break;
+
+    case 2: // 1 <= 2, 2 > 3, 3 <= 1   => 2 1 3
+      *idx1o = idx2i;
+      *idx2o = idx1i;
+      *idx3o = idx3i;
+      *val1o = val2i;
+      *val2o = val1i;
+      *val3o = val3i;
+      break;
+
+    case 3: // 1 <= 2, 2 > 3, 3  > 1   => 2 3 1
+      *idx1o = idx2i;
+      *idx2o = idx3i;
+      *idx3o = idx1i;
+      *val1o = val2i;
+      *val2o = val3i;
+      *val3o = val1i;
+      break;
+
+    case 1: // 1 <= 2, 2 <= 3, 3 > 1   => 3 2 1
+      *idx1o = idx3i;
+      *idx2o = idx2i;
+      *idx3o = idx1i;
+      *val1o = val3i;
+      *val2o = val2i;
+      *val3o = val1i;
+      break;
+
+    case 5: // 1 > 2, 2 <= 3, 3 >  1   => 3 1 2
+      *idx1o = idx3i;
+      *idx2o = idx1i;
+      *idx3o = idx2i;
+      *val1o = val3i;
+      *val2o = val1i;
+      *val3o = val2i;
+      break;
+
+    default: // the rest should NEVER happen!
+      LOG(error) << "ERROR in Sort3!!!";
+      break;
+  }
+}
+
+void TrapSimulator::sort6To4(unsigned short idx1i, unsigned short idx2i, unsigned short idx3i, unsigned short idx4i, unsigned short idx5i, unsigned short idx6i,
+                             unsigned short val1i, unsigned short val2i, unsigned short val3i, unsigned short val4i, unsigned short val5i, unsigned short val6i,
+                             unsigned short* const idx1o, unsigned short* const idx2o, unsigned short* const idx3o, unsigned short* const idx4o,
+                             unsigned short* const val1o, unsigned short* const val2o, unsigned short* const val3o, unsigned short* const val4o)
+{
+  // sorting for tracklet selection
+
+  unsigned short idx21s, idx22s, idx23s, dummy;
+  unsigned short val21s, val22s, val23s;
+  unsigned short idx23as, idx23bs;
+  unsigned short val23as, val23bs;
+
+  sort3(idx1i, idx2i, idx3i, val1i, val2i, val3i,
+        idx1o, &idx21s, &idx23as,
+        val1o, &val21s, &val23as);
+
+  sort3(idx4i, idx5i, idx6i, val4i, val5i, val6i,
+        idx2o, &idx22s, &idx23bs,
+        val2o, &val22s, &val23bs);
+
+  sort2(idx23as, idx23bs, val23as, val23bs, &idx23s, &dummy, &val23s, &dummy);
+
+  sort3(idx21s, idx22s, idx23s, val21s, val22s, val23s,
+        idx3o, idx4o, &dummy,
+        val3o, val4o, &dummy);
+}
+
+void TrapSimulator::sort6To2Worst(unsigned short idx1i, unsigned short idx2i, unsigned short idx3i, unsigned short idx4i, unsigned short idx5i, unsigned short idx6i,
+                                  unsigned short val1i, unsigned short val2i, unsigned short val3i, unsigned short val4i, unsigned short val5i, unsigned short val6i,
+                                  unsigned short* const idx5o, unsigned short* const idx6o)
+{
+  // sorting for tracklet selection
+
+  unsigned short idx21s, idx22s, idx23s, dummy1, dummy2, dummy3, dummy4, dummy5;
+  unsigned short val21s, val22s, val23s;
+  unsigned short idx23as, idx23bs;
+  unsigned short val23as, val23bs;
+
+  sort3(idx1i, idx2i, idx3i, val1i, val2i, val3i,
+        &dummy1, &idx21s, &idx23as,
+        &dummy2, &val21s, &val23as);
+
+  sort3(idx4i, idx5i, idx6i, val4i, val5i, val6i,
+        &dummy1, &idx22s, &idx23bs,
+        &dummy2, &val22s, &val23bs);
+
+  sort2(idx23as, idx23bs, val23as, val23bs, &idx23s, idx5o, &val23s, &dummy1);
+
+  sort3(idx21s, idx22s, idx23s, val21s, val22s, val23s,
+        &dummy1, &dummy2, idx6o,
+        &dummy3, &dummy4, &dummy5);
+}
+
+bool TrapSimulator::readPackedConfig(TrapConfig* cfg, int hc, unsigned int* data, int size)
+{
+  // Read the packed configuration from the passed memory block
+  //
+  // To be used to retrieve the TRAP configuration from the
+  // configuration as sent in the raw data.
+
+  LOG(debug) << "Reading packed configuration";
+
+  int det = hc / 2;
+
+  int idx = 0;
+  int err = 0;
+  int step, bwidth, nwords, exitFlag, bitcnt;
+
+  unsigned short caddr;
+  unsigned int dat, msk, header, dataHi;
+
+  while (idx < size && *data != 0x00000000) {
+
+    int rob = (*data >> 28) & 0x7;
+    int mcm = (*data >> 24) & 0xf;
+
+    LOG(debug) << "Config of det. " << det << " MCM " << rob << ":" << mcm << " (0x" << std::hex << *data << ")";
+    data++;
+
+    while (idx < size && *data != 0x00000000) {
+
+      header = *data;
+      data++;
+      idx++;
+
+      LOG(debug3) << "read: 0x" << hex << header;
+
+      if (header & 0x01) // single data
+      {
+        dat = (header >> 2) & 0xFFFF;    // 16 bit data
+        caddr = (header >> 18) & 0x3FFF; // 14 bit address
+
+        if (caddr != 0x1FFF) // temp!!! because the end marker was wrong
+        {
+          if (header & 0x02) // check if > 16 bits
+          {
+            dataHi = *data;
+            LOG(debug3) << "read: 0x" << hex << dataHi;
+            data++;
+            idx++;
+            err += ((dataHi ^ (dat | 1)) & 0xFFFF) != 0;
+            dat = (dataHi & 0xFFFF0000) | dat;
+          }
+          LOG(debug3) << "addr=0x" << hex << caddr << "(" << cfg->getRegName(cfg->getRegByAddress(caddr)) << ") data=0x" << hex << dat;
+          if (!cfg->poke(caddr, dat, det, rob, mcm))
+            LOG(debug3) << "(single-write): non-existing address 0x" << std::hex << caddr << " containing 0x" << std::hex << header;
+          if (idx > size) {
+            LOG(debug3) << "(single-write): no more data, missing end marker";
+            return -err;
+          }
+        } else {
+          LOG(debug3) << "(single-write): address 0x" << setw(4) << std::hex << caddr << " => old endmarker?" << std::dec;
+          return err;
+        }
+      }
+
+      else // block of data
+      {
+        step = (header >> 1) & 0x0003;
+        bwidth = ((header >> 3) & 0x001F) + 1;
+        nwords = (header >> 8) & 0x00FF;
+        caddr = (header >> 16) & 0xFFFF;
+        exitFlag = (step == 0) || (step == 3) || (nwords == 0);
+
+        if (exitFlag)
+          break;
+
+        switch (bwidth) {
+          case 15:
+          case 10:
+          case 7:
+          case 6:
+          case 5: {
+            msk = (1 << bwidth) - 1;
+            bitcnt = 0;
+            while (nwords > 0) {
+              nwords--;
+              bitcnt -= bwidth;
+              if (bitcnt < 0) {
+                header = *data;
+                LOG(debug3) << "read 0x" << setw(8) << std::hex << header << std::dec;
+                data++;
+                idx++;
+                err += (header & 1);
+                header = header >> 1;
+                bitcnt = 31 - bwidth;
+              }
+              LOG(debug3) << "addr=0x" << setw(4) << std::hex << caddr << "(" << cfg->getRegName(cfg->getRegByAddress(caddr)) << ") data=0x" << setw(8) << std::hex << (header & msk);
+              if (!cfg->poke(caddr, header & msk, det, rob, mcm))
+                LOG(debug3) << "(single-write): non-existing address 0x" << setw(4) << std::hex << caddr << " containing 0x" << setw(8) << std::hex << header << std::dec;
+
+              caddr += step;
+              header = header >> bwidth;
+              if (idx >= size) {
+                LOG(debug3) << "(block-write): no end marker! " << idx << " words read";
+                return -err;
+              }
+            }
+            break;
+          } // end case 5-15
+          case 31: {
+            while (nwords > 0) {
+              header = *data;
+              LOG(debug3) << "read 0x" << setw(8) << std::hex << header;
+              data++;
+              idx++;
+              nwords--;
+              err += (header & 1);
+
+              LOG(debug3) << "addr=0x" << hex << setw(4) << caddr << " (" << cfg->getRegName(cfg->getRegByAddress(caddr)) << ")  data=0x" << hex << setw(8) << (header >> 1);
+              if (!cfg->poke(caddr, header >> 1, det, rob, mcm))
+                LOG(debug3) << "(single-write): non-existing address 0x" << setw(4) << std::hex << " containing 0x" << setw(8) << std::hex << header << std::dec;
+
+              caddr += step;
+              if (idx >= size) {
+                LOG(debug3) << "no end marker! " << idx << " words read";
+                return -err;
+              }
+            }
+            break;
+          }
+          default:
+            return err;
+        } // end switch
+      }   // end block case
+    }
+  } // end while
+  LOG(debug) << "no end marker! " << idx << " words read";
+  return -err; // only if the max length of the block reached!
+}
+
+//calgainfactor=.47;

--- a/Detectors/TRD/workflow/CMakeLists.txt
+++ b/Detectors/TRD/workflow/CMakeLists.txt
@@ -8,12 +8,26 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
-add_compile_options(-O0 -g -fPIC) 
+#add_compile_options(-O0 -pg -fPIC) 
 
 o2_add_library(TRDWorkflow
                TARGETVARNAME targetName
-               SOURCES src/TRDDigitizerSpec.cxx src/TRDDigitWriterSpec.cxx
-               PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::Steer O2::Algorithm O2::DataFormatsTRD O2::TRDSimulation O2::DetectorsBase O2::SimulationDataFormat O2::TRDBase)
+               SOURCES src/TRDDigitizerSpec.cxx
+                       src/TRDDigitWriterSpec.cxx
+                       src/TRDDigitReaderSpec.cxx
+                       src/TRDTrackletWriterSpec.cxx
+                       src/TRDTrapSimulatorSpec.cxx
+                       PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::Steer O2::Algorithm O2::DataFormatsTRD O2::TRDSimulation O2::DetectorsBase O2::SimulationDataFormat O2::TRDBase)
 
-           o2_target_root_dictionary(TRDWorkflow
-               HEADERS include/TRDWorkflow/TRDDigitizerSpec.h)
+                   #o2_target_root_dictionary(TRDWorkflow
+                   # HEADERS include/TRDWorkflow/TRDTrapSimulatorSpec.h)
+
+o2_add_executable(trap-sim
+                  COMPONENT_NAME trd
+                  SOURCES src/TRDTrapSimulatorWorkFlow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::Framework
+                                        O2::DPLUtils
+                                        O2::Steer
+                                        O2::TRDBase
+                                        O2::DataFormatsTRD
+                                        O2::TRDWorkflow)

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDDigitReaderSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDDigitReaderSpec.h
@@ -1,0 +1,64 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TRDTRAPSIMULATORRAWREADERSPEC_H
+#define O2_TRDTRAPSIMULATORRAWREADERSPEC_H
+
+#include "TRDBase/Digit.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/DataRefUtils.h"
+#include "Framework/Lifetime.h"
+#include "Framework/Task.h"
+#include <SimulationDataFormat/MCTruthContainer.h>
+#include "TRDBase/MCLabel.h"
+#include "DataFormatsTRD/TriggerRecord.h"
+#include "TFile.h"
+#include "TTree.h"
+
+using namespace std;
+
+namespace o2
+{
+namespace trd
+{
+
+class TRDDigitReaderSpec : public o2::framework::Task
+{
+ public:
+  TRDDigitReaderSpec(int channels) : mChannels(channels){};
+  ~TRDDigitReaderSpec() override = default;
+  void init(o2::framework::InitContext& ic) override;
+  void run(o2::framework::ProcessingContext& pc) override;
+
+ private:
+  bool mFinished = false;
+  int mState = 0;
+  bool mUseRun2 = false;
+  int mChannels;
+  std::unique_ptr<TFile> mFile = nullptr;
+  //std::unique_ptr<TTree> DPLTree;
+  std::vector<o2::trd::Digit> mDigits, *mPDigits = &mDigits;
+  o2::dataformats::MCTruthContainer<o2::trd::MCLabel> mMCLabels, *mPMCLabels = &mMCLabels;
+  std::vector<o2::trd::TriggerRecord> mTriggerRecords, *mPTriggerRecords = &mTriggerRecords;
+  std::string mInputFileName = "";
+  std::string mDigitTreeName = "o2sim";
+  std::string mDigitBranchName = "TRDDigit";
+  std::string mTriggerRecordBranchName = "TriggerRecord";
+  std::string mMCLabelsBranchName = "TRDMCLabels";
+};
+
+o2::framework::DataProcessorSpec getTRDDigitReaderSpec(int channels);
+
+} // end namespace trd
+} // end namespace o2
+
+#endif // O2_TRDTRAPSIMULATORTRACKLETWRITER_H

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrackletWriterSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrackletWriterSpec.h
@@ -1,0 +1,39 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TRDTRAPSIMULATORTRACKLETWRITER_H
+#define O2_TRDTRAPSIMULATORTRACKLETWRITER_H
+
+#include "TRDBase/Digit.h"
+#include <SimulationDataFormat/MCTruthContainer.h>
+#include "TRDBase/MCLabel.h"
+#include "TRDBase/Tracklet.h"
+#include <fstream>
+#include <iostream>
+
+namespace o2
+{
+namespace framework
+{
+struct DataProcessorSpec;
+}
+} // namespace o2
+
+namespace o2
+{
+namespace trd
+{
+
+o2::framework::DataProcessorSpec getTRDTrackletWriterSpec();
+
+} // end namespace trd
+} // end namespace o2
+
+#endif // O2_TRDTRAPSIMULATORTRACKLETWRITER_H

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
@@ -1,0 +1,67 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TRD_TRAPSIMULATORWORKFLOW_SRC_TRDTRAPSIMULATORSPEC_H_
+#define O2_TRD_TRAPSIMULATORWORKFLOW_SRC_TRDTRAPSIMULATORSPEC_H_
+
+#include <vector>
+#include <array>
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+#include "TRDBase/FeeParam.h"
+#include "TRDBase/Tracklet.h"
+#include "TRDSimulation/TrapSimulator.h"
+
+#include "TRDSimulation/TrapConfig.h"
+#include "TRDSimulation/TrapConfigHandler.h"
+#include "CCDB/BasicCCDBManager.h"
+#include <iostream>
+
+using namespace o2::framework;
+using namespace std;
+namespace o2
+{
+namespace trd
+{
+
+class TRDDPLTrapSimulatorTask : public Task
+{
+
+ public:
+  TRDDPLTrapSimulatorTask(bool disabletrapsim) : mDisableTrapSimulation(disabletrapsim) { cout << " TRAPDISABLE SET TO : " << disabletrapsim << endl; }
+  ~TRDDPLTrapSimulatorTask() override = default;
+  void init(o2::framework::InitContext& ic) override;
+  void run(o2::framework::ProcessingContext& pc) override;
+
+ private:
+  std::array<TrapSimulator, 8> mTrapSimulator; //the 8 trap simulators for a given padrow.
+  FeeParam* mfeeparam;
+  TrapConfig* mTrapConfig;
+  std::unique_ptr<TRDGeometry> mGeo;
+  //  std::unique_ptr<TrapConfigHandler> mTrapConfigHandler;
+  bool mDriveFromConfig{false};     // option to disable using the trapconfig to drive the simulation
+  int mPrintTrackletOptions = 0;    // print the tracklets to the screen, ascii art
+  int mDrawTrackletOptions = 0;     //draw the tracklets 1 per file
+  int mShowTrackletStats = 0;       //the the accumulated total tracklets found
+  int mDisableTrapSimulation = 0;   // option to not do trapsimulation, mostly for the digitizer
+  std::vector<Tracklet> mTracklets; // store of tracklets to then be inserted into a message.
+  std::string mTrapConfigName;      // the name of the config to be used.
+  std::string mTrapConfigBaseName = "TRD_test/TrapConfig/";
+  TrapConfig* getTrapConfig();
+  void loadTrapConfig();
+};
+
+o2::framework::DataProcessorSpec getTRDTrapSimulatorSpec(int channelfan, bool disabletrapsim = false);
+
+} // end namespace trd
+} // end namespace o2
+
+#endif //O2_TRD_TRAPSIMULATORWORKFLOW_SRC_TRDTRAPSIMULATORSPEC_H_

--- a/Detectors/TRD/workflow/src/TRDDigitReaderSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDDigitReaderSpec.cxx
@@ -1,0 +1,126 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "TRDWorkflow/TRDDigitReaderSpec.h"
+
+#include <cstdlib>
+// this is somewhat assuming that a DPL workflow will run on one node
+
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/DataRefUtils.h"
+#include "Framework/Lifetime.h"
+#include "DPLUtils/RootTreeReader.h"
+#include "Headers/DataHeader.h"
+#include "TStopwatch.h"
+#include "Steer/HitProcessingManager.h" // for RunContext
+#include "TChain.h"
+#include <SimulationDataFormat/MCCompLabel.h>
+#include <SimulationDataFormat/MCTruthContainer.h>
+#include "Framework/Task.h"
+#include "DataFormatsParameters/GRPObject.h"
+#include "TRDBase/Digit.h" // for the Digit type
+#include "TRDSimulation/TrapSimulator.h"
+#include "TRDSimulation/Digitizer.h"
+#include "TRDSimulation/Detector.h" // for the Hit type
+
+#include "DetectorsBase/GeometryManager.h"
+
+#include "DataFormatsTRD/TriggerRecord.h"
+
+#include <TTree.h>
+#include <TFile.h>
+#include <TSystem.h>
+#include <TRandom1.h>
+
+#include <sstream>
+#include <cmath>
+#include <unistd.h>   // for getppid
+#include <TMessage.h> // object serialization
+#include <memory>     // std::unique_ptr
+#include <cstring>    // memcpy
+#include <string>     // std::string
+#include <cassert>
+#include <chrono>
+#include <thread>
+#include <algorithm>
+
+using namespace o2::framework;
+using SubSpecificationType = o2::framework::DataAllocator::SubSpecificationType;
+
+namespace o2
+{
+namespace trd
+{
+
+void TRDDigitReaderSpec::init(InitContext& ic)
+{
+  LOG(info) << "input filename is :  " << ic.options().get<std::string>("digitsfile").c_str();
+
+  mInputFileName = ic.options().get<std::string>("digitsfile");
+  mFile = std::make_unique<TFile>(mInputFileName.c_str(), "OLD");
+  if (!mFile->IsOpen()) {
+    LOG(error) << "Cannot open digits input file : " << mInputFileName;
+    mState = 0; //prevent from getting into run method.
+
+  } else {
+    mState = 1;
+  }
+}
+
+void TRDDigitReaderSpec::run(ProcessingContext& pc)
+{
+  if (mState != 1) {
+    LOG(info) << "mState is not 1";
+    return;
+  }
+  LOG(info) << "in TRDDigitReadSpec run method ";
+  TTree* DPLTree = ((TTree*)mFile->Get(mDigitTreeName.c_str()));
+  if (DPLTree) {
+    DPLTree->SetBranchAddress(mDigitBranchName.c_str(), &mPDigits);
+    DPLTree->SetBranchAddress(mTriggerRecordBranchName.c_str(), &mPTriggerRecords);
+    DPLTree->SetBranchAddress(mMCLabelsBranchName.c_str(), &mPMCLabels);
+    DPLTree->GetEntry(0);
+    LOG(info) << "TRDDigitReader digits size=" << mDigits.size() << " triggerrecords size=" << mTriggerRecords.size() << " mc labels size=" << mMCLabels.getNElements();
+    pc.outputs().snapshot(Output{"TRD", "DIGITS", 0, Lifetime::Timeframe}, mDigits);
+    pc.outputs().snapshot(Output{"TRD", "TRGRDIG", 0, Lifetime::Timeframe}, mTriggerRecords);
+    pc.outputs().snapshot(Output{"TRD", "LABELS", 0, Lifetime::Timeframe}, mMCLabels);
+  }
+  //delete DPLTree; // next line will delete the pointer as well.
+  mFile->Close();
+  LOG(info) << "returning from run method of TRDDigitReader";
+
+  mState = 2; // prevent coming in here again.
+              // send endOfData control event and mark the reader as ready to finish
+  pc.services().get<ControlService>().endOfStream();
+  pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+  LOG(info) << "returning from run method of TRDDigitReader finally";
+}
+
+DataProcessorSpec getTRDDigitReaderSpec(int channels)
+{
+
+  LOG(info) << "get TRDDigitReaderSpec";
+  return DataProcessorSpec{"TRDDIGITREADER",
+                           Inputs{},
+                           Outputs{
+                             OutputSpec{"TRD", "DIGITS", 0, Lifetime::Timeframe},
+                             OutputSpec{"TRD", "TRGRDIG", 0, Lifetime::Timeframe},
+                             OutputSpec{"TRD", "LABELS", 0, Lifetime::Timeframe}},
+                           // outputs,
+                           AlgorithmSpec{adaptFromTask<TRDDigitReaderSpec>(channels)},
+                           Options{
+                             {"digitsfile", VariantType::String, "trddigits.root", {"Input data file containing run3 digitizer going into Trap Simulator"}},
+                             {"run2digitsfile", VariantType::String, "run2digits.root", {"Input data file containing run2 digitis going into Trap Simulator"}}}};
+};
+
+} //end namespace trd
+} //end namespace o2

--- a/Detectors/TRD/workflow/src/TRDDigitizerSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDDigitizerSpec.cxx
@@ -125,6 +125,9 @@ class TRDDPLDigitizerTask
         std::vector<o2::trd::Digit> digits;                         // digits which get filled
         o2::dataformats::MCTruthContainer<o2::trd::MCLabel> labels; // labels which get filled
         mDigitizer.process(hits, digits, labels);
+        for (auto& digit : digits) {
+          digit.setTimeStamp(irecords[collID].timeNS);
+        }
         // Add trigger record
         triggers.emplace_back(irecords[collID], digitsAccum.size(), digits.size());
 

--- a/Detectors/TRD/workflow/src/TRDTrackletWriterSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrackletWriterSpec.cxx
@@ -1,0 +1,63 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TRDTRAPSIMULATORTRACKLETWRITER_H
+#define O2_TRDTRAPSIMULATORTRACKLETWRITER_H
+
+#include "Framework/DataProcessorSpec.h"
+#include "DPLUtils/MakeRootTreeWriterSpec.h"
+#include "Framework/InputSpec.h"
+#include "TRDWorkflow/TRDTrackletWriterSpec.h"
+#include "TRDBase/Digit.h"
+#include <SimulationDataFormat/MCTruthContainer.h>
+#include "TRDBase/MCLabel.h"
+#include "TRDBase/Tracklet.h"
+
+#include <fstream>
+#include <iostream>
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace trd
+{
+
+template <typename T>
+using BranchDefinition = framework::MakeRootTreeWriterSpec::BranchDefinition<T>;
+
+o2::framework::DataProcessorSpec getTRDTrackletWriterSpec()
+{
+  //  using InputSpec = framework::InputSpec;
+  using MakeRootTreeWriterSpec = framework::MakeRootTreeWriterSpec;
+  /* int producejson=1;
+  if(producejson){
+      //write tracklets in json format for Samesh javascript ui
+      //probably only going to be for deubgging.
+      //filename format is : E#.sector#.stack#.json E=Eventnumber(nominal) ... will use timestamp
+      LOG(info) << " now to produce json";
+      ofstream output("E15.0.1.json");
+      output << " 10 " << endl;
+  }*/
+  //  LOG(info) << "before writing out the tracklet size is " << Tracklet.size();
+  return MakeRootTreeWriterSpec("TRDTrkltWrt",
+                                "trdtracklets.root",
+                                "o2sim",
+                                1,
+                                BranchDefinition<std::vector<o2::trd::Tracklet>>{InputSpec{"tracklets", "TRD", "TRACKLETS"}, "Tracklet"})();
+  //BranchDefinition<o2::dataformats::MCTruthContainer<o2::trd::MCLabel> >{InputSpec{"labels", "TRD", "TRKLABELS"}, "TRKLabels"},
+  //                                BranchDefinition<std::vector<o2::trd::Tracklet> >{InputSpec{"triggerrecords", "TRD", "TRGRRecords"}, "TRGRRecords"})();
+  //TODO maybe dont pass the labels through, come back and check this
+};
+
+} // end namespace trd
+} // end namespace o2
+
+#endif // O2_TRDTRAPSIMULATORTRACKLETWRITER_H

--- a/Detectors/TRD/workflow/src/TRDTrapSimulatorSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrapSimulatorSpec.cxx
@@ -1,0 +1,427 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+//#include "Framework/runDataProcessing.h"
+#include "TRDWorkflow/TRDTrapSimulatorSpec.h"
+
+#include <cstdlib>
+// this is somewhat assuming that a DPL workflow will run on one node
+#include <thread> // to detect number of hardware threads
+#include <string>
+#include <sstream>
+#include <cmath>
+#include <unistd.h> // for getppid
+#include <chrono>
+
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/DataRefUtils.h"
+#include "Framework/Lifetime.h"
+#include "Framework/Task.h"
+#include "Headers/DataHeader.h"
+#include "TStopwatch.h"
+#include "Steer/HitProcessingManager.h" // for RunContext
+#include "TChain.h"
+#include <SimulationDataFormat/MCCompLabel.h>
+#include <SimulationDataFormat/MCTruthContainer.h>
+#include "DataFormatsParameters/GRPObject.h"
+#include "TRDBase/Digit.h" // for the Digit type
+#include "TRDSimulation/TrapSimulator.h"
+#include "TRDSimulation/Digitizer.h"
+#include "TRDSimulation/Detector.h" // for the Hit type
+#include "DetectorsBase/GeometryManager.h"
+#include "TRDBase/FeeParam.h"
+#include "TRDSimulation/TrapSimulator.h"
+#include "DataFormatsTRD/TriggerRecord.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace trd
+{
+
+bool DigitSortComparator(o2::trd::Digit const& a, o2::trd::Digit const& b)
+{
+  FeeParam* fee = FeeParam::instance();
+  int rowa = a.getRow();
+  int rowb = b.getRow();
+  int pada = a.getPad();
+  int padb = b.getPad();
+  double timea = a.getTimeStamp();
+  double timeb = b.getTimeStamp();
+  int roba = fee->getROBfromPad(rowa, pada);
+  int robb = fee->getROBfromPad(rowb, padb);
+  int mcma = fee->getMCMfromPad(rowa, pada);
+  int mcmb = fee->getMCMfromPad(rowb, padb);
+  if (timea < timeb) {
+    //  LOG(info) << "yip timea < timeb " << timea <<"<" << timeb;
+    return 1;
+  } else if (timea == timeb) {
+
+    if (a.getDetector() < b.getDetector())
+      return 1;
+    else {
+      if (a.getDetector() == b.getDetector()) {
+        if (roba < robb)
+          return 1;
+        else {
+          if (roba == robb) {
+            if (mcma < mcmb)
+              return 1;
+            else
+              return 0;
+          } else
+            return 0;
+        }
+        return 0;
+      }
+      return 0;
+    }
+    return 0;
+  }
+  return 0;
+}
+
+bool DigitSortComparatorPadRow(o2::trd::Digit const& a, o2::trd::Digit const& b)
+{
+  //this sorts the data into pad rows, and pads with in that pad row.
+  //this allows us to generate a structure of 144 pads to then pass to the trap simulator
+  //taking into account the shared pads.
+  int rowa = a.getRow();
+  int rowb = b.getRow();
+  int pada = a.getPad();
+  int padb = b.getPad();
+  double timea = a.getTimeStamp();
+  double timeb = b.getTimeStamp();
+  if (timea < timeb)
+    return 1;
+  else if (timea == timeb) {
+
+    if (a.getDetector() < b.getDetector())
+      return 1;
+    else {
+      if (a.getDetector() == b.getDetector()) {
+        if (rowa < rowb)
+          return 1;
+        else {
+          if (rowa == rowb) {
+            if (pada < padb)
+              return 1; //leaving in for now. so I dont have to have a 144x30 entry array for the pad data. dont have to deal with pad sorting, its going to be 1 of 144 and inserted into the required array.
+            else
+              return 0;
+          } else
+            return 0;
+        }
+        return 0;
+      }
+      return 0;
+    }
+    return 0;
+  }
+  return 0;
+}
+
+TrapConfig* TRDDPLTrapSimulatorTask::getTrapConfig()
+{
+  // return an existing TRAPconfig or load it from the CCDB
+  // in case of failure, a default TRAPconfig is created
+  LOG(debug) << "start of gettrapconfig";
+  if (mTrapConfig) {
+    LOG(debug) << "mTrapConfig is valid : 0x" << hex << mTrapConfig << dec;
+    return mTrapConfig;
+  } else {
+    LOG(debug) << "mTrapConfig is invalid : 0x" << hex << mTrapConfig << dec;
+
+    //can I just ignore the old default and pull a new "default" from ccdb?
+    //// bypass pulling in trapconfigs from ccdb, will sort out later.
+    if (0) //mTrapConfigName!= std::string("default"))
+    {
+      // try to load the requested configuration
+      loadTrapConfig();
+      //calib.
+    } else {
+      // if we still don't have a valid TRAPconfig, we give up
+      LOG(debug) << "mTrapConfig is not valid now : 0x" << hex << mTrapConfig << dec;
+      LOG(warn) << "Falling back to default configuration for year<2012";
+      static TrapConfig trapConfigDefault(mTrapConfigName);
+      mTrapConfig = &trapConfigDefault; //new TrapConfig; //&trapConfigDefault;
+      TrapConfigHandler cfgHandler(mTrapConfig);
+      cfgHandler.init();
+      cfgHandler.loadConfig();
+    }
+    LOG(debug) << "using TRAPconfig :" << mTrapConfig->getConfigName().c_str() << "." << mTrapConfig->getConfigVersion().c_str();
+
+    // we still have to load the gain tables
+    // if the gain filter is active
+    return mTrapConfig;
+  } // end of else from if mTrapConfig
+}
+
+void TRDDPLTrapSimulatorTask::loadTrapConfig()
+{
+  // try to load the specified configuration from the CCDB
+
+  LOG(info) << "looking for TRAPconfig " << mTrapConfigName;
+
+  // const CalTrapConfig *caltrap = dynamic_cast<const CalTrapConfig*> (GetCachedCDBObject(kIDTrapConfig));
+  //TODO get trap config from OCDB/CCDB
+  //pull values from CDDB incoming structure or message ??
+
+  LOG(info) << "looking for TRAPconfig " << mTrapConfigName << __FILE__ << ":" << __LINE__;
+  auto& ccdbmgr = o2::ccdb::BasicCCDBManager::instance();
+  LOG(info) << "looking for TRAPconfig " << mTrapConfigName << __FILE__ << ":" << __LINE__;
+  ccdbmgr.setTimestamp(297595);
+  LOG(info) << "looking for TRAPconfig " << mTrapConfigName << __FILE__ << ":" << __LINE__;
+  mTrapConfig = ccdbmgr.get<o2::trd::TrapConfig>(mTrapConfigBaseName + std::string("/") + mTrapConfigName);
+  LOG(info) << "looking for TRAPconfig " << mTrapConfigName << __FILE__ << ":" << __LINE__ << "   trapconfig is : " << &mTrapConfig;
+  if (mTrapConfig == nullptr) {
+    LOG(info) << "looking for TRAPconfig " << mTrapConfigName << __FILE__ << ":" << __LINE__;
+    //failed to find or open or connect or something to get the trapconfig from the ccdb.
+    //first check the directory listing.
+    LOG(warn) << " failed to get trapconfig from ccdb with name :  " << mTrapConfigName;
+    LOG(info) << "looking for TRAPconfig " << mTrapConfigName << __FILE__ << ":" << __LINE__;
+  }
+  LOG(info) << "looking for TRAPconfig " << mTrapConfigName << __FILE__ << ":" << __LINE__;
+  //  mTrapConfig = caltrap->Get(configName); //TODO it is not clear to me how this actually comes in.
+  //}
+  /// else {
+  //    if(mTrapConfig != nullptr){
+  //      delete mTrapConfig;
+  //    mTrapConfig = nullptr;
+  //  }
+  // mTrapConfig->LOADFROMDISKDEFAULT();
+  LOG(info) << "looking for TRAPconfig " << mTrapConfigName << __FILE__ << ":" << __LINE__;
+  LOG(warn) << "No TRAPconfig entry found for name of " << mTrapConfigName;
+  LOG(info) << "looking for TRAPconfig " << mTrapConfigName << __FILE__ << ":" << __LINE__;
+  //  }
+}
+
+void TRDDPLTrapSimulatorTask::init(o2::framework::InitContext& ic)
+{
+  //               LOG(debug) << "Input data file is : " << ic.options().get<std::string>("simdatasrc");
+  //               LOG(info) << "simSm is : " << ic.options().get<int>("simSM");
+  LOG(debug1) << "TRD Trap Simulator Device with pid of : " << ::getpid();
+  mfeeparam = FeeParam::instance();
+  mPrintTrackletOptions = ic.options().get<int>("printtracklets");
+  mDrawTrackletOptions = ic.options().get<int>("drawtracklets");
+  mShowTrackletStats = ic.options().get<int>("show-trd-trackletstats");
+  mTrapConfigName = ic.options().get<std::string>("trapconfig");
+  LOG(info) << "disable trap simualtor is : " << mDisableTrapSimulation;
+  LOG(info) << "Trap Simulator Device initialising with trap config of : " << mTrapConfigName;
+  //  if(mDisableTrapSimulation){
+  //  //now get a trapconfig to work with.
+  //    LOG(warn) << "You elected to not do a trap chip simulation and hence no trapconfig was saught";
+  //  }
+  //  else{
+  getTrapConfig();
+  LOG(info) << "Trap Simulator Device initialised ... ";
+  //  }
+}
+
+void TRDDPLTrapSimulatorTask::run(o2::framework::ProcessingContext& pc)
+{
+  LOG(info) << "TRD Trap Simulator Device running over incoming message ...";
+  if (mDisableTrapSimulation) {
+    LOG(warn) << " you elected to not do a trap chip simulation";
+    return;
+  }
+  // get the relevant inputs for the TrapSimulator
+  auto digits = pc.inputs().get<std::vector<o2::trd::Digit>>("digitinput");
+  //auto mMCLabels = pc.inputs().get<o2::dataformats::MCTruthContainer<o2::trd::MCLabel>*>("labelinput");
+  //auto mTriggerRecords = pc.inputs().get<std::vector<o2::trd::TriggerRecord>>("triggerrecords");
+
+  LOG(debug) << "Read in Digits with size of : " << digits.size();
+
+  //set up structures to hold the returning tracklets.
+  std::vector<Tracklet> mMCMTracklets; //vector to store the retrieved tracklets from an mcm
+  std::vector<Tracklet> mMCMTrackletsAccum;
+  mMCMTracklets.reserve(30);
+  mMCMTrackletsAccum.reserve(digits.size() / 3); //attempt to a. conserve mem, b. stop a vector resize
+
+  //TODO we can ignore time, and use the triggerrecords as to defined subsets to sort. TriggerRecord has the time in it for all the digits, by creation.
+  //
+  std::chrono::duration<double> sortingtime{0}; ///< full timer
+  auto sortstart = std::chrono::high_resolution_clock::now();
+
+  std::sort(digits.begin(), digits.end(), DigitSortComparator);
+
+  sortingtime = std::chrono::high_resolution_clock::now() - sortstart;
+
+  //TODO Do we care about tracklet order so long as its time stamped.
+  //TODO Dont sort, just build an index array
+  //TODO sort from mTriggerRecords.getFirstEntry() to mTriggerRecords.getFirstEntry()+mTriggerRecords.getNumberOfObjects();
+
+  int olddetector = -1;
+  int oldrow = -1;
+  int oldpad = -1;
+  int loopindex = 0;
+  int counttrackletadditions = 0;
+  int oldsize = 0;
+  double trackletrate;
+  unsigned long oldtrackletcount = 0;
+  //various timers so we can see how long things take
+  std::chrono::duration<double> trapsimaccumulatedtime{0}; ///< full timer
+  std::chrono::duration<double> digitlooptime{0};          ///< full timer
+  std::chrono::duration<double> traplooptime{0};           ///< full timer
+  std::chrono::duration<double> oldelse{0};                ///< full timer
+  std::chrono::duration<double> tracklettime{0};           ///< full timer
+
+  // now to loop over the incoming digits.
+  auto digitloopstart = std::chrono::high_resolution_clock::now();
+
+  for (std::vector<o2::trd::Digit>::iterator digititerator = digits.begin(); digititerator != digits.end(); ++digititerator) {
+    //in here we have an entire padrow which corresponds to 8 TRAPs.
+    //while on a single padrow, populate data structures in the 8 trapsimulator.
+    //on change of padrow
+    //  fireup trapsim, do its thing with each 18 sequence of pads data that already exists inside the class from previous iterations of the loop
+    double digittime = digititerator->getTimeStamp();
+    int pad = digititerator->getPad();
+    int row = digititerator->getRow();
+    int detector = digititerator->getDetector();
+    int rob = mfeeparam->getROBfromPad(row, pad);
+    int mcm = mfeeparam->getMCMfromPad(row, pad);
+    if (digititerator == digits.begin()) { // first time in loop
+      oldrow = row;
+      olddetector = detector;
+    }
+    if (olddetector != detector || oldrow != row) {
+      // we haved gone over the pad row. //TODO ??? do we need to check for change of time as well?
+      //all data is inside the 8 relavent trapsimulators
+      rob = mfeeparam->getROBfromPad(oldrow, oldpad); //
+      LOG(debug) << "processing of row,mcm"
+                 << " padrow changed from " << olddetector << "," << oldrow << " to " << detector << "," << row;
+      //fireup Trapsim.
+      auto traploopstart = std::chrono::high_resolution_clock::now();
+      for (int trapcounter = 0; trapcounter < 8; trapcounter++) {
+        unsigned int isinit = mTrapSimulator[trapcounter].checkInitialized();
+        LOG(debug) << "is init : " << isinit;
+        if (mTrapSimulator[trapcounter].isDataSet()) { //firedtraps & (1<<trapcounter){ /}/mTrapSimulator[trapcounter].checkInitialized()){
+          //this one has been filled with data for the now previous pad row.
+          auto trapsimtimerstart = std::chrono::high_resolution_clock::now();
+
+          mTrapSimulator[trapcounter].filter();
+          mTrapSimulator[trapcounter].tracklet();
+
+          mMCMTracklets = mTrapSimulator[trapcounter].getTrackletArray(); //TODO remove the copy and send the Accumulated array into the Trapsimulator
+
+          LOG(debug) << mMCMTrackletsAccum.size() << " :: " << mMCMTracklets.size() << " count tracklet additions :  " << counttrackletadditions;
+          counttrackletadditions++;
+          mMCMTrackletsAccum.insert(mMCMTrackletsAccum.end(), mMCMTracklets.begin(), mMCMTracklets.end());
+          trapsimaccumulatedtime += std::chrono::high_resolution_clock::now() - trapsimtimerstart;
+          if (mShowTrackletStats > 0) {
+            if (mMCMTrackletsAccum.size() - oldsize > mShowTrackletStats) {
+              LOG(debug) << "TrapSim Accumulated tracklets: " << mMCMTrackletsAccum.size() << " :: " << mMCMTracklets.size();
+              oldsize = mMCMTrackletsAccum.size();
+            }
+          }
+
+          // mTrapSimulator[trapcounter].zeroSupressionMapping();
+
+          if (mDrawTrackletOptions != 0)
+            mTrapSimulator[trapcounter].draw(mDrawTrackletOptions, loopindex);
+          if (mPrintTrackletOptions != 0)
+            mTrapSimulator[trapcounter].print(mPrintTrackletOptions);
+
+          loopindex++;
+          //set this trap sim object to have not data (effectively) reset.
+          mTrapSimulator[trapcounter].unsetData();
+        } else {
+          LOG(debug) << "if statement is init failed [" << trapcounter << "] PROCESSING TRAP !";
+        }
+      } //end of loop over trap chips
+      traplooptime += std::chrono::high_resolution_clock::now() - traploopstart;
+      LOG(debug) << "Row change ... Tracklets so far: " << mMCMTrackletsAccum.size();
+      if (mShowTrackletStats > 0) {
+        if (mMCMTrackletsAccum.size() - oldtrackletcount > mShowTrackletStats) {
+          oldtrackletcount = mMCMTrackletsAccum.size();
+          unsigned long mcmTrackletsize = mMCMTrackletsAccum.size();
+          tracklettime = std::chrono::high_resolution_clock::now() - digitloopstart;
+          trackletrate = mcmTrackletsize / tracklettime.count();
+          LOG(info) << "Getting tracklets at the rate of : " << trackletrate << " Tracklets/s ... Accumulated tracklets : " << mMCMTrackletsAccum.size();
+        }
+      }
+    } //if oldetector!= detector ....
+    //we are still on the same detector and row.
+    //add the digits to the padrow.
+    //copy pad time data into where they belong in the 8 TrapSimulators for this pad.
+    int mcmoffset = -1;
+    int firstrob = mfeeparam->getROBfromPad(row, 5); // 5 is arbitrary, but above the lower shared pads. so will get first rob and mcm
+    int firstmcm = mfeeparam->getMCMfromPad(row, 5); // 5 for same reason
+    int trapindex = pad / 18;
+    //check trap is initialised.
+    if (!mTrapSimulator[trapindex].isDataSet()) {
+      LOG(debug) << "Initialising trapsimulator for triplet (" << detector << "," << rob << ","
+                 << mcm << ") as its not initialized and we need to send it some adc data.";
+      mTrapSimulator[trapindex].init(mTrapConfig, detector, rob, mcm);
+    }
+    int adc = 0;
+    adc = 20 - (pad % 18) - 1;
+    LOG(debug) << "setting data for simulator : " << trapindex << " and adc : " << adc;
+    mTrapSimulator[trapindex].setData(adc, digititerator->getADC());
+    // mTrapSimulator[trapindex].printAdcDatHuman(cout);
+
+    // now take care of the case of shared pads (the whole reason for doing this pad row wise).
+
+    if (pad % 18 == 0 || (pad + 1) % 18 == 0) { //case of pad 18 and 19 must be shared to preceding trap chip adc 1 and 0 respectively.
+                                                //check trap is initialised.
+
+      adc = 20 - (pad % 18) - 1;
+      LOG(debug) << "setting data for simulator : " << trapindex - 1 << " and adc : " << adc;
+      mTrapSimulator[trapindex - 1].setData(adc, digititerator->getADC());
+    }
+    if ((pad - 1) % 18 == 0) { // case of pad 17 must shared to next trap chip as adc 20
+                               //check trap is initialised.
+      adc = 20 - (pad % 18) - 1;
+      LOG(debug) << "setting data for simulator : " << trapindex + 1 << " and adc : " << adc;
+      if (trapindex + 1 != 8) {
+        mTrapSimulator[trapindex + 1].setData(adc, digititerator->getADC());
+      }
+      //else { // this is not an issue as its a shared pad, simply the sharing to the next trap chip is meaningless.
+      //}
+    }
+
+    olddetector = detector;
+    oldrow = row;
+    oldpad = pad;
+  } // end of loop over digits.
+
+  LOG(info) << "Trap simulator found " << mMCMTrackletsAccum.size() << " tracklets from " << digits.size() << " Digits";
+  if (mShowTrackletStats > 0) {
+    digitlooptime = std::chrono::high_resolution_clock::now() - digitloopstart;
+    LOG(info) << "Trap Simulator done \\o/ ";
+    LOG(info) << "Sorting took " << sortingtime.count();
+    LOG(info) << "Digit loop took : " << digitlooptime.count();
+    LOG(info) << "Trapsim took : " << trapsimaccumulatedtime.count();
+    LOG(info) << "Traploop took : " << traplooptime.count();
+  }
+  //pc.outputs().snapshot(Output{"TRD","DIGITS",0,Lifetime::Timeframe},mDigits);
+  pc.outputs().snapshot(Output{"TRD", "TRACKLETS", 0, Lifetime::Timeframe}, mMCMTrackletsAccum);
+  //  pc.outputs().snapshot(Output{"TRD","TRKLABELS",0,Lifetime::Timeframe},mMCLabels);
+  //pc.outputs().snapshot(Output{"TRD","TRGRRecords",0,Lifetime::Timeframe},mTriggerRecords);
+}
+
+o2::framework::DataProcessorSpec getTRDTrapSimulatorSpec(int channelfan, bool disabletrapsim)
+{
+  return DataProcessorSpec{"TRAP", Inputs{InputSpec{"digitinput", "TRD", "DIGITS", 0}, InputSpec{"triggerrecords", "TRD", "TRGRDIG", 0}, InputSpec{"labelinput", "TRD", "LABELS", 0}},
+                           Outputs{OutputSpec{"TRD", "TRACKLETS", 0, Lifetime::Timeframe}},
+                           //                                   OutputSpec{"TRD","TRGRRecords",0,Lifetime::Timeframe}},
+                           //                               OutputSpec{"TRD","TRKLABELS",0, Lifetime::Timeframe},
+                           AlgorithmSpec{adaptFromTask<TRDDPLTrapSimulatorTask>(disabletrapsim)},
+                           Options{
+                             {"show-trd-trackletstats", VariantType::Int, 25000, {"Display the accumulated size and capacity at number of track intervals"}},
+                             {"trapconfig", VariantType::String, "default", {"Name of the trap config from the CCDB"}},
+                             {"drawtracklets", VariantType::Int, 0, {"Bitpattern of input to TrapSimulator Draw method (be very careful) one file per track"}},
+                             {"printtracklets", VariantType::Int, 0, {"Bitpattern of input to TrapSimulator print method"}}}};
+};
+
+} //end namespace trd
+} //end namespace o2

--- a/Detectors/TRD/workflow/src/TRDTrapSimulatorWorkFlow.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrapSimulatorWorkFlow.cxx
@@ -1,0 +1,89 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "DetectorsBase/Propagator.h"
+#include "Framework/WorkflowSpec.h"
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicy.h"
+#include "Framework/DeviceSpec.h"
+#include "Algorithm/RangeTokenizer.h"
+#include "DetectorsCommonDataFormats/DetID.h"
+#include "SimConfig/ConfigurableParam.h"
+
+// for TRD
+#include "TRDWorkflow/TRDTrapSimulatorSpec.h"
+#include "TRDWorkflow/TRDTrackletWriterSpec.h"
+#include "TRDWorkflow/TRDDigitReaderSpec.h"
+
+#include "DataFormatsParameters/GRPObject.h"
+
+#include <cstdlib>
+// this is somewhat assuming that a DPL workflow will run on one node
+#include <thread> // to detect number of hardware threads
+#include <string>
+#include <sstream>
+#include <cmath>
+#include <unistd.h> // for getppid
+
+using namespace o2::framework;
+
+// ------------------------------------------------------------------
+
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowoptions)
+{
+  //able to specify inputs
+  //could be disk, upstream digitizer, run2 convert.
+  //most of these are probably purely for debugging.
+  //specify where the data is coming from i.e. ignore incoming message and use data as specified here, mostly for debugging as well.
+  std::string filename;
+
+  //    std::string trapsimindatahelp("Specify the location of incoming data for the simulator, full name of file");
+  //    workflowoptions.push_back(ConfigParamSpec{"simdatasrc", VariantType::String, "none", {trapsimindatahelp}});
+
+  //limit the trapsim to a specific roc or multiple rocs mostly for debugging.
+  std::string trapsimrochelp("Specify the ROC to work on [0-540]");
+  workflowoptions.push_back(ConfigParamSpec{"simROC", VariantType::Int, -1, {trapsimrochelp}});
+
+  //limit to 1 supermodule.
+  std::string trapsimsupermodulehelp("Specify the Supermodule to work on [0-18]");
+  workflowoptions.push_back(ConfigParamSpec{"simSM", VariantType::Int, -1, {trapsimsupermodulehelp}});
+  //limit to a stack in a supermodule
+  std::string trapsimstackhelp("Specify the specific stack to work on [0-5] within the supermodule");
+  workflowoptions.push_back(ConfigParamSpec{"simStack", VariantType::Int, -1, {trapsimstackhelp}});
+  //limit to a stack in a supermodule
+  // the next one is now done inside the trapsim spec.
+  //  std::string trapsimconfighelp("Specify the Trap config to use from CCDB yes those long names like cf_pg-fpnp32_zs-s16-deh_tb24_trkl-b2p-fs1e24-ht200-qs0e24s24e23-pidlinear-pt100_ptrg.r5585");
+  //  workflowoptions.push_back(ConfigParamSpec{"trapconfigname", VariantType::Int, -1, {trapsimconfighelp}});
+
+  // json output
+  // run2 input
+  // trap configuration
+  //
+}
+
+#include "Framework/runDataProcessing.h"
+
+/// This function is required to be implemented to define the workflow
+/// specifications
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  // Reserve one entry which fill be filled with the SimReaderSpec
+  // at the end. This places the processor at the beginning of the
+  // workflow in the upper left corner of the GUI.
+  //
+  return WorkflowSpec{
+    //?? maybe a read spec to define the input in the case of my text run2 data and possible a proper data input reader.
+    o2::trd::getTRDDigitReaderSpec(1),
+    //o2::trd::getTRDDigitReaderSpec(1),
+    // connect the TRD digitization
+    o2::trd::getTRDTrapSimulatorSpec(0),
+    // connect the TRD digit writer
+    o2::trd::getTRDTrackletWriterSpec()};
+}

--- a/Detectors/TRD/workflow/src/TRDWorkflowLinkDef.h
+++ b/Detectors/TRD/workflow/src/TRDWorkflowLinkDef.h
@@ -16,6 +16,5 @@
 
 //#pragma link C++ class o2::trd::TRDDPLDigitizerTask + ;
 
-
 #endif
 

--- a/Steer/DigitizerWorkflow/CMakeLists.txt
+++ b/Steer/DigitizerWorkflow/CMakeLists.txt
@@ -47,7 +47,7 @@ o2_add_executable(digitizer-workflow
                                         O2::PHOSSimulation
                                         O2::CPVSimulation
                                         O2::TOFSimulation
-                    					O2::TOFCalibration
+					                    O2::TOFCalibration
                                         O2::TOFReconstruction
                                         O2::TOFWorkflowUtils
                                         O2::TPCSimulation

--- a/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
+++ b/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
@@ -60,6 +60,8 @@
 // for TRD
 #include "TRDWorkflow/TRDDigitizerSpec.h"
 #include "TRDWorkflow/TRDDigitWriterSpec.h"
+#include "TRDWorkflow/TRDTrapSimulatorSpec.h"
+#include "TRDWorkflow/TRDTrackletWriterSpec.h"
 
 //for MUON MCH
 #include "MCHDigitizerSpec.h"
@@ -147,6 +149,9 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 
   // option to use/not use CCDB for TOF
   workflowOptions.push_back(ConfigParamSpec{"use-ccdb-tof", o2::framework::VariantType::Bool, false, {"enable access to ccdb tof calibration objects"}});
+
+  // option to use or not use the Trap Simulator after digitisation (debate of digitization or reconstruction is for others)
+  workflowOptions.push_back(ConfigParamSpec{"enable-trd-trapsim", VariantType::Bool, false, {"disable the trap simulation of the TRD"}});
 }
 
 // ------------------------------------------------------------------
@@ -466,6 +471,12 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     specs.emplace_back(o2::trd::getTRDDigitizerSpec(fanoutsize++));
     // connect the TRD digit writer
     specs.emplace_back(o2::trd::getTRDDigitWriterSpec());
+
+    auto disableTrapSim = configcontext.options().get<bool>("enable-trd-trapsim");
+    // connect the TRD Trap SimulatorA
+    specs.emplace_back(o2::trd::getTRDTrapSimulatorSpec(0, (bool)disableTrapSim));
+    // connect to the device to write out the tracklets.
+    specs.emplace_back(o2::trd::getTRDTrackletWriterSpec());
   }
 
   //add MUON MCH


### PR DESCRIPTION
Trap Simulator working in o2-sim-digitizer-workflow, and standalone as o2-trd-trap-sim
- Not connecting to ccdb for trapconfigs for now, using the default via TrapConfigHandler.
- set to not permit trapsimulation in the digitizer workflow by default, use  --enable-trd-trapsim to do trap sim in digitizer, else call standalone afterwards.
- getting between 650 and 770 tracklets/s now, depending on data set.
- lots of places for speed improvments, check results against run2 first.
- labels need fixing and are out in this version.
- due to the nature of the time allocation to digits in the digitizer, the sorted digits in the trapsim still align with the Trigger Records.