### PR TITLE
Define signature of CompletionPolicy callback in the header and adding helper method

### DIFF
--- a/Framework/Core/include/Framework/CompletionPolicy.h
+++ b/Framework/Core/include/Framework/CompletionPolicy.h
@@ -50,7 +50,9 @@ struct CompletionPolicy {
   };
 
   using Matcher = std::function<bool(DeviceSpec const& device)>;
-  using Callback = std::function<CompletionOp(gsl::span<PartRef const> const&)>;
+  using InputSetElement = PartRef;
+  using InputSet = gsl::span<InputSetElement const> const&;
+  using Callback = std::function<CompletionOp(InputSet)>;
 
   /// Name of the policy itself.
   std::string name;

--- a/Framework/Core/include/Framework/CompletionPolicyHelpers.h
+++ b/Framework/Core/include/Framework/CompletionPolicyHelpers.h
@@ -13,9 +13,11 @@
 #include "Framework/ChannelSpec.h"
 #include "Framework/CompletionPolicyHelpers.h"
 #include "Framework/CompletionPolicy.h"
+#include "Headers/DataHeader.h"
 
 #include <functional>
 #include <string>
+#include <type_traits>
 
 namespace o2
 {
@@ -34,6 +36,12 @@ struct CompletionPolicyHelpers {
   static CompletionPolicy processWhenAny();
   /// Attach a given @a op to a device matching @name.
   static CompletionPolicy defineByName(std::string const& name, CompletionPolicy::CompletionOp op);
+  /// Get a specific header from the input
+  template <typename T, typename U>
+  static auto getHeader(U const& input)
+  {
+    return o2::header::get<typename std::add_pointer<T>::type>(input.header ? input.header->GetData() : nullptr);
+  }
 };
 
 } // namespace framework

--- a/Framework/Core/src/CompletionPolicyHelpers.cxx
+++ b/Framework/Core/src/CompletionPolicyHelpers.cxx
@@ -30,7 +30,7 @@ CompletionPolicy CompletionPolicyHelpers::defineByName(std::string const& name, 
   auto matcher = [name](DeviceSpec const& device) -> bool {
     return std::regex_match(device.name.begin(), device.name.end(), std::regex(name));
   };
-  auto callback = [op](gsl::span<PartRef const> const& inputs) -> CompletionPolicy::CompletionOp {
+  auto callback = [op](CompletionPolicy::InputSet) -> CompletionPolicy::CompletionOp {
     return op;
   };
   switch (op) {
@@ -53,7 +53,7 @@ CompletionPolicy CompletionPolicyHelpers::defineByName(std::string const& name, 
 CompletionPolicy CompletionPolicyHelpers::consumeWhenAll()
 {
   auto matcher = [](DeviceSpec const&) -> bool { return true; };
-  auto callback = [](gsl::span<PartRef const> const& inputs) -> CompletionPolicy::CompletionOp {
+  auto callback = [](CompletionPolicy::InputSet inputs) -> CompletionPolicy::CompletionOp {
     for (auto& input : inputs) {
       if (input.header == nullptr && input.payload == nullptr) {
         return CompletionPolicy::CompletionOp::Wait;
@@ -67,7 +67,7 @@ CompletionPolicy CompletionPolicyHelpers::consumeWhenAll()
 CompletionPolicy CompletionPolicyHelpers::consumeWhenAny()
 {
   auto matcher = [](DeviceSpec const&) -> bool { return true; };
-  auto callback = [](gsl::span<PartRef const> const& inputs) -> CompletionPolicy::CompletionOp {
+  auto callback = [](CompletionPolicy::InputSet inputs) -> CompletionPolicy::CompletionOp {
     for (auto& input : inputs) {
       if (input.header != nullptr && input.payload != nullptr) {
         return CompletionPolicy::CompletionOp::Consume;
@@ -81,7 +81,7 @@ CompletionPolicy CompletionPolicyHelpers::consumeWhenAny()
 CompletionPolicy CompletionPolicyHelpers::processWhenAny()
 {
   auto matcher = [](DeviceSpec const&) -> bool { return true; };
-  auto callback = [](gsl::span<PartRef const> const& inputs) -> CompletionPolicy::CompletionOp {
+  auto callback = [](CompletionPolicy::InputSet inputs) -> CompletionPolicy::CompletionOp {
     size_t present = 0;
     for (auto& input : inputs) {
       if (input.header != nullptr) {

--- a/Framework/Core/test/test_CompletionPolicy.cxx
+++ b/Framework/Core/test/test_CompletionPolicy.cxx
@@ -13,7 +13,12 @@
 #define BOOST_TEST_DYN_LINK
 
 #include <boost/test/unit_test.hpp>
+#include <fairmq/FairMQTransportFactory.h>
 #include "Framework/CompletionPolicy.h"
+#include "Framework/CompletionPolicyHelpers.h"
+#include "Headers/DataHeader.h"
+#include "Headers/NameHeader.h"
+#include "Headers/Stack.h"
 
 using namespace o2::framework;
 
@@ -26,4 +31,33 @@ BOOST_AUTO_TEST_CASE(TestCompletionPolicy)
       << CompletionPolicy::CompletionOp::Discard;
 
   BOOST_REQUIRE_EQUAL(oss.str(), "consumeprocesswaitdiscard");
+}
+
+BOOST_AUTO_TEST_CASE(TestCompletionPolicy_callback)
+{
+  o2::header::Stack stack{o2::header::DataHeader{"SOMEDATA", "TST", 0, 0}, o2::header::NameHeader<9>{"somename"}};
+  auto transport = FairMQTransportFactory::CreateTransportFactory("zeromq");
+  FairMQMessagePtr header = transport->CreateMessage(stack.size());
+  auto* pointer = header->GetData();
+  memcpy(pointer, stack.data(), stack.size());
+  FairMQMessagePtr payload = transport->CreateMessage();
+
+  auto matcher = [](auto const&) {
+    return true;
+  };
+
+  auto callback = [&stack, &pointer](CompletionPolicy::InputSet inputRefs) {
+    for (auto const& ref : inputRefs) {
+      auto const* header = CompletionPolicyHelpers::getHeader<o2::header::DataHeader>(ref);
+      BOOST_CHECK_EQUAL(header, reinterpret_cast<o2::header::DataHeader*>(pointer));
+      BOOST_CHECK(CompletionPolicyHelpers::getHeader<o2::header::NameHeader<9>>(ref) != nullptr);
+    }
+    return CompletionPolicy::CompletionOp::Consume;
+  };
+
+  CompletionPolicy policy{"test", matcher, callback};
+
+  CompletionPolicy::InputSetElement ref{std::move(header), std::move(payload)};
+  CompletionPolicy::InputSet inputs{&ref, 1};
+  policy.callback(inputs);
 }


### PR DESCRIPTION
We aim to implement depending packages like e.g. QualityControl independently
of the actual policy implementation by using definitions from the CompletionPolicy
header file.

Adding helper method to retrieve DataHeader from CompletionPolicy input set

This PR is supposed to be merge before #2886 and AliceO2Group/QualityControl#304 will be adjusted accordingly.
