### PR TITLE
[QC-262] Data Sampling Benchmark

### DIFF
--- a/Framework/Core/scripts/o2-datasampling-benchmark.sh
+++ b/Framework/Core/scripts/o2-datasampling-benchmark.sh
@@ -26,7 +26,7 @@ RESULTS_FILE='data-sampling-benchmark-'$(date +"%y-%m-%d_%H%M")
 # \param 6 : test duration
 # \param 7 : warm up cycles - how many first metrics should be ignored (they are sent each 10s)
 # \param 8 : test name
-# \param 9 : free_memory_bytes
+# \param 9 : available memory for the benchmark (in MB)
 # \param 10: fill - (yes/no) should write zeroes to the produced messages (prevents memory overcommitting)
 function benchmark() {
 
@@ -44,7 +44,7 @@ function benchmark() {
   local test_duration=$6
   local warm_up_cycles=$7
   local test_name=$8
-  local free_memory_bytes=$9'000000'
+  local available_memory_bytes=$9'000000'
   local fill=${10}
 
   if [ ! -z $TESTS ] && [[ ! " ${TESTS[@]} " =~ " ${test_name} " ]]; then
@@ -60,7 +60,7 @@ function benchmark() {
   local repo_branch=$(git rev-parse --abbrev-ref HEAD)
   local results_filename='data-sampling-benchmark-'$(date +"%y-%m-%d_%H%M")'-'$test_name
   local test_date=$(date +"%y-%m-%d %H:%M:%S")
-  local memory_soft_limit_mbytes=$((free_memory_bytes / 5000000)) # we stop creating new messages at 4/5 of the maximum allowed usage
+  local memory_soft_limit_mbytes=$((available_memory_bytes / 5000000)) # we stop creating new messages at 4/5 of the maximum allowed usage
 
   printf "DATA SAMPLING BENCHMARK RESULTS\n" > $results_filename
   printf "Test date:              %s\n" "$test_date" >> $results_filename
@@ -69,11 +69,11 @@ function benchmark() {
   printf "Repetitions:            %s\n" "$repetitions" >> $results_filename
   printf "Test duration [s]:      %s\n" "$test_duration" >> $results_filename
   printf "Warm up cycles:         %s\n" "$warm_up_cycles" >> $results_filename
-  printf "Free memory [B]:        %s\n" "$free_memory_bytes" >> $results_filename
+  printf "Available memory [B]:   %s\n" "$available_memory_bytes" >> $results_filename
   printf "Memory soft limit [MB]: %s\n" "$memory_soft_limit_mbytes" >> $results_filename
   echo "fraction       , payload size   , nb producers   , nb dispatchers , messages per second" >> $results_filename
 
-  local common_args="--run -b --infologger-severity info --shm-segment-size "$free_memory_bytes" --test-duration "$test_duration" --throttling "$memory_soft_limit_mbytes
+  local common_args="--run -b --infologger-severity info --shm-segment-size "$available_memory_bytes" --test-duration "$test_duration" --throttling "$memory_soft_limit_mbytes
   if [[ $fill == "yes" ]]; then
     common_args=$common_args' --fill'
   fi

--- a/Framework/Core/scripts/o2-datasampling-benchmark.sh
+++ b/Framework/Core/scripts/o2-datasampling-benchmark.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+
+#set -e ;# exit on error
+set -u ;# exit when using undeclared variable
+#set -x ;# debugging
+
+trap kill_benchmark INT
+
+function kill_benchmark() {
+  echo "Killing any running benchmark workflows..."
+  pkill -9 -f o2-testworkflows-datasampling-benchmark
+  exit 1
+}
+
+# todo:
+#  get stddev out of the monitoring metrics
+
+RESULTS_FILE='data-sampling-benchmark-'$(date +"%y-%m-%d_%H%M")
+
+# Run the benchmark with given parameters
+# \param 1 : fractions array name
+# \param 2 : payload sizes array name
+# \param 3 : number of producers array name
+# \param 4 : number of dispatchers array name
+# \param 5 : repetitions
+# \param 6 : test duration
+# \param 7 : warm up cycles - how many first metrics should be ignored (they are sent each 10s)
+# \param 8 : test name
+# \param 9 : free_memory_bytes
+# \param 10: fill - (yes/no) should write zeroes to the produced messages (prevents memory overcommitting)
+function benchmark() {
+
+  local fractions_array_name=$1[@]
+  local payload_sizes_array_name=$2[@]
+  local number_of_producers_array_name=$3[@]
+  local number_of_dispatchers_array_name=$4[@]
+
+  local fractions=("${!fractions_array_name}")
+  local payload_sizes=("${!payload_sizes_array_name}")
+  local number_of_producers=("${!number_of_producers_array_name}")
+  local number_of_dispatchers=("${!number_of_dispatchers_array_name}")
+
+  local repetitions=$5
+  local test_duration=$6
+  local warm_up_cycles=$7
+  local test_name=$8
+  local free_memory_bytes=$9'000000'
+  local fill=${10}
+
+  if [ ! -z $TESTS ] && [[ ! " ${TESTS[@]} " =~ " ${test_name} " ]]; then
+    echo "Test '"$test_name"' ignored"
+    return
+  fi
+
+  echo "======================================================================="
+  echo "Running the test '"$test_name"'"
+
+  local test_duration_timeout=$((test_duration + 60))
+  local repo_latest_commit=$(git rev-list --format=oneline --max-count=1 HEAD)
+  local repo_branch=$(git rev-parse --abbrev-ref HEAD)
+  local results_filename='data-sampling-benchmark-'$(date +"%y-%m-%d_%H%M")'-'$test_name
+  local test_date=$(date +"%y-%m-%d %H:%M:%S")
+  local memory_soft_limit_mbytes=$((free_memory_bytes / 5000000)) # we stop creating new messages at 4/5 of the maximum allowed usage
+
+  printf "DATA SAMPLING BENCHMARK RESULTS\n" > $results_filename
+  printf "Test date:              %s\n" "$test_date" >> $results_filename
+  printf "Latest commit:          %s\n" "$repo_latest_commit" >> $results_filename
+  printf "Branch:                 %s\n" "$repo_branch" >> $results_filename
+  printf "Repetitions:            %s\n" "$repetitions" >> $results_filename
+  printf "Test duration [s]:      %s\n" "$test_duration" >> $results_filename
+  printf "Warm up cycles:         %s\n" "$warm_up_cycles" >> $results_filename
+  printf "Free memory [B]:        %s\n" "$free_memory_bytes" >> $results_filename
+  printf "Memory soft limit [MB]: %s\n" "$memory_soft_limit_mbytes" >> $results_filename
+  echo "fraction       , payload size   , nb producers   , nb dispatchers , messages per second" >> $results_filename
+
+  local common_args="--run -b --infologger-severity info --shm-segment-size "$free_memory_bytes" --test-duration "$test_duration" --throttling "$memory_soft_limit_mbytes
+  if [[ $fill == "yes" ]]; then
+    common_args=$common_args' --fill'
+  fi
+
+  for fraction in ${fractions[@]}; do
+    for payload_size in ${payload_sizes[@]}; do
+      for nb_producers in ${number_of_producers[@]}; do
+        for nb_dispatchers in ${number_of_dispatchers[@]}; do
+          for ((rep=0;rep<repetitions;rep++)); do
+            echo "************************************************************"
+            echo "Launching test for payload size $payload_size bytes, $nb_producers producers, $nb_dispatchers dispatchers, sampling fraction $fraction"
+
+            printf "%15s," "$fraction" >> $results_filename
+            printf "%16s," "$payload_size" >> $results_filename
+            printf "%16s," "$nb_producers" >> $results_filename
+            printf "%16s," "$nb_dispatchers" >> $results_filename
+
+            messages_per_second=
+            while [ "$messages_per_second" == 'error' ] || [ -z "$messages_per_second" ]; do
+              if [ "$messages_per_second" == 'error' ]; then
+                echo "Retrying the test because of an error"
+              fi
+
+              # running the benchmark, extracting an array of metrics, ignoring the first warm_up_cycles-1
+              # fixme: we assume that the metrics are produced in even (10s) time intervals and all are printed,
+              #        we should at least be able notice when something doesn't seem right
+
+              metrics=
+              mapfile -t metrics < \
+                <( timeout -k 60s $test_duration_timeout o2-testworkflows-datasampling-benchmark $common_args --payload-size $payload_size --producers $nb_producers --dispatchers $nb_dispatchers --sampling-fraction $fraction \
+                 | grep -o 'Dispatcher_messages_evaluated,[0-9] [0-9]\{1,\}' \
+                 | sed -e 's/Dispatcher_messages_evaluated,[0-9]\{1,\} //'   \
+                 | tail -n +$((warm_up_cycles * nb_dispatchers + 1)) )
+
+              pkill -9 -f o2-testworkflows-datasampling-benchmark
+
+              if [ ${#metrics[@]} -ge $(( 2 * nb_dispatchers )) ]; then
+
+                total_start=0
+                for ((i = 0; i < nb_dispatchers; i++))
+                do
+                  (( total_start+=metrics[i] ))
+                done
+
+                total_end=0
+                for ((i = 1; i < $((1 + nb_dispatchers)); i++))
+                do
+                  (( total_end+=metrics[-i] ))
+                done
+
+                (( messages_per_second = (total_end - total_start) / (${#metrics[@]} / nb_dispatchers - 1 ) ))
+                # divide by 10, keeping the last digit
+                if [ $messages_per_second -gt 9 ]; then
+                  messages_per_second=${messages_per_second:0:-1}.${messages_per_second: -1}
+                else
+                  messages_per_second=0.$messages_per_second
+                fi
+              else
+                messages_per_second='error'
+              fi
+            done
+
+            printf "%20s" "$messages_per_second" >> $results_filename
+            printf "\n" >> $results_filename
+
+            echo "Dispatcher_messages_evaluated metrics:"
+            if [ ${#metrics[@]} -gt 0 ]; then
+              printf '%s\n' "${metrics[@]}"
+            else
+              echo $metrics
+            fi
+            printf 'Messages per second: %s\n' "${messages_per_second}"
+          done
+        done
+      done
+    done
+  done
+}
+
+function print_usage() {
+  echo "Usage: ./o2-datasampling-benchmark.sh [-f] [-m MEMORY_USAGE] [-t TEST]
+
+Run Data Sampling Benchmark and create report files in the directory.
+
+Options:
+ -h               Print this message
+ -f               Fill messages with zeroes in data procuders. This prevents Linux from overcommitting memory, but
+                  slows down the message production rates. It should be used for tests with ZeroMQ. For shmem tests the
+                  default protection mechanism is sufficient.
+ -m MEMORY_USAGE  Amount of memory (in MB) to be reserved by benchmark. When tested with shared memory, it must be less
+                  than the size of /dev/shm. If not specified, it will reserve a half of the free memory at the
+                  beginning of the benchmark. The data producers will aim to use less than 4/5 of it. For versions
+                  without shared memory enabled, the data producers will aim to leave free one fifth of the amount
+                  specified.
+ -t TEST          Test name to be run. Use it multiple times to run multiple tests. If not specified, all are run. See
+                  the last part of this script to find the available tests.
+"
+}
+
+MEMORY_USAGE=$(cat /proc/meminfo | grep 'MemFree:' | grep -o "[0-9]\{1,\}")
+MEMORY_USAGE=$((MEMORY_USAGE / 1000 / 2))
+FILL=no
+TESTS=
+
+while getopts 'hfm:t:' option; do
+  case "${option}" in
+  \?)
+    print_usage
+    exit 1
+    ;;
+  h)
+    print_usage
+    exit 0
+    ;;
+  f)
+    FILL=yes
+    ;;
+  m)
+    MEMORY_USAGE=$OPTARG
+    ;;
+  t)
+    TESTS=("$OPTARG")
+    printf '%s\n' "${TESTS[@]}"
+    ;;
+  esac
+done
+
+FRACTIONS=(1.00);
+PAYLOAD_SIZE=(16777216 67108864 268435456 1073741824);
+NB_PRODUCERS=(8);
+NB_DISPATCHERS=(1);
+REPETITIONS=1;
+TEST_DURATION=300;
+WARM_UP_CYCLES=2;
+TEST_NAME='memory'
+
+benchmark FRACTIONS PAYLOAD_SIZE NB_PRODUCERS NB_DISPATCHERS $REPETITIONS $TEST_DURATION $WARM_UP_CYCLES $TEST_NAME $MEMORY_USAGE $FILL
+
+FRACTIONS=(0.00 1.00);
+PAYLOAD_SIZE=(1 256 1024 4096 16384 65536 262144 1048576 4194304 16777216 67108864 268435456 1073741824);
+NB_PRODUCERS=(8);
+NB_DISPATCHERS=(1);
+REPETITIONS=1;
+TEST_DURATION=300;
+WARM_UP_CYCLES=6;
+TEST_NAME='payloads'
+
+benchmark FRACTIONS PAYLOAD_SIZE NB_PRODUCERS NB_DISPATCHERS $REPETITIONS $TEST_DURATION $WARM_UP_CYCLES $TEST_NAME $MEMORY_USAGE $FILL
+
+FRACTIONS=(0.00 1.00);
+PAYLOAD_SIZE=(2097152);
+NB_PRODUCERS=(1 2 4 8 16 32);
+NB_DISPATCHERS=(1);
+REPETITIONS=1;
+TEST_DURATION=300;
+WARM_UP_CYCLES=6;
+TEST_NAME='producers-2MiB'
+
+benchmark FRACTIONS PAYLOAD_SIZE NB_PRODUCERS NB_DISPATCHERS $REPETITIONS $TEST_DURATION $WARM_UP_CYCLES $TEST_NAME $MEMORY_USAGE $FILL
+
+FRACTIONS=(0.0000 0.0001 0.0010 0.0100 0.1000 0.5000 1.0000);
+PAYLOAD_SIZE=(2097152);
+NB_PRODUCERS=(8);
+NB_DISPATCHERS=(1);
+REPETITIONS=1;
+TEST_DURATION=300;
+WARM_UP_CYCLES=6;
+TEST_NAME='fractions'
+
+benchmark FRACTIONS PAYLOAD_SIZE NB_PRODUCERS NB_DISPATCHERS $REPETITIONS $TEST_DURATION $WARM_UP_CYCLES $TEST_NAME $MEMORY_USAGE $FILL
+
+FRACTIONS=(0.0000 1.0000);
+PAYLOAD_SIZE=(256 2097152);
+NB_PRODUCERS=(8);
+NB_DISPATCHERS=(1 2 4 8);
+REPETITIONS=1;
+TEST_DURATION=300;
+WARM_UP_CYCLES=6;
+TEST_NAME='dispatchers'
+
+benchmark FRACTIONS PAYLOAD_SIZE NB_PRODUCERS NB_DISPATCHERS $REPETITIONS $TEST_DURATION $WARM_UP_CYCLES $TEST_NAME $MEMORY_USAGE $FILL

--- a/Framework/Core/src/Dispatcher.cxx
+++ b/Framework/Core/src/Dispatcher.cxx
@@ -77,7 +77,6 @@ void Dispatcher::run(ProcessingContext& ctx)
         // todo: consider matching (and deciding) in completion policy to save some time
 
         if (policy->match(inputMatcher) && policy->decide(input)) {
-
           // We copy every header which is not DataHeader or DataProcessingHeader,
           // so that custom data-dependent headers are passed forward,
           // and we add a DataSamplingHeader.
@@ -86,7 +85,8 @@ void Dispatcher::run(ProcessingContext& ctx)
             std::move(prepareDataSamplingHeader(*policy.get(), ctx.services().get<const DeviceSpec>()))};
 
           if (!policy->getFairMQOutputChannel().empty()) {
-            sendFairMQ(ctx.services().get<RawDeviceService>().device(), input, policy->getFairMQOutputChannelName(), std::move(headerStack));
+            sendFairMQ(ctx.services().get<RawDeviceService>().device(), input, policy->getFairMQOutputChannelName(),
+                       std::move(headerStack));
           } else {
             Output output = policy->prepareOutput(inputMatcher, input.spec->lifetime);
             output.metaHeader = std::move(header::Stack{std::move(output.metaHeader), std::move(headerStack)});

--- a/Framework/TestWorkflows/CMakeLists.txt
+++ b/Framework/TestWorkflows/CMakeLists.txt
@@ -113,6 +113,11 @@ o2_add_executable(ccdb-fetch-to-timeframe
                   PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME TestWorkflows)
 
+o2_add_executable(datasampling-benchmark
+                  SOURCES src/dataSamplingBenchmark.cxx
+                  PUBLIC_LINK_LIBRARIES O2::Framework
+                  COMPONENT_NAME TestWorkflows)
+
 # Detector specific dummy workflows
 o2_add_executable(tof-dummy-ccdb
                   SOURCES src/tof-dummy-ccdb.cxx

--- a/Framework/TestWorkflows/src/dataSamplingBenchmark.cxx
+++ b/Framework/TestWorkflows/src/dataSamplingBenchmark.cxx
@@ -1,0 +1,247 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/DataSampling.h"
+#include "Framework/CompletionPolicyHelpers.h"
+#include <vector>
+
+using namespace o2::framework;
+
+void customize(std::vector<CompletionPolicy>& policies)
+{
+  DataSampling::CustomizeInfrastructure(policies);
+  policies.push_back(CompletionPolicyHelpers::defineByName("dataSink", CompletionPolicy::CompletionOp::Consume));
+}
+
+void customize(std::vector<ChannelConfigurationPolicy>& policies)
+{
+  DataSampling::CustomizeInfrastructure(policies);
+}
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  workflowOptions.push_back(ConfigParamSpec{"sampling-fraction", VariantType::Double, 1.0, {"sampling fraction"}});
+  workflowOptions.push_back(ConfigParamSpec{"payload-size", VariantType::Int, 10000, {"payload size"}});
+  workflowOptions.push_back(ConfigParamSpec{"producers", VariantType::Int, 1, {"number of producers"}});
+  workflowOptions.push_back(ConfigParamSpec{"dispatchers", VariantType::Int, 1, {"number of dispatchers"}});
+  workflowOptions.push_back(ConfigParamSpec{"usleep", VariantType::Int, 0, {"usleep time of producers"}});
+  workflowOptions.push_back(ConfigParamSpec{
+    "test-duration", VariantType::Int, 300, {"how long should the test run (in seconds, max. 2147)"}});
+  workflowOptions.push_back(
+    ConfigParamSpec{"throttling", VariantType::Int, 0, {"stop producing messages if freeram < throttling * 1MB"}});
+  workflowOptions.push_back(ConfigParamSpec{
+    "fill", VariantType::Bool, false, {"should fill the messages (prevents memory overcommitting)"}});
+}
+
+#include <memory>
+#include <boost/algorithm/string.hpp>
+#include <boost/filesystem/operations.hpp>
+#include <boost/interprocess/managed_shared_memory.hpp>
+#include <boost/functional/hash.hpp>
+#include <fairmq/FairMQDevice.h>
+#if defined(__APPLE__)
+struct sysinfo {
+  unsigned long freeram = -1;
+};
+void sysinfo(sysinfo* info)
+{
+  info->freeram = -1;
+}
+#else
+#include <sys/sysinfo.h>
+#endif
+
+#include "Headers/DataHeader.h"
+#include "Framework/ControlService.h"
+#include "Framework/DataSampling.h"
+#include "Framework/DataSamplingPolicy.h"
+#include "Framework/RawDeviceService.h"
+#include "Framework/runDataProcessing.h"
+
+using namespace o2::framework;
+using SubSpec = o2::header::DataHeader::SubSpecificationType;
+
+namespace bipc = ::boost::interprocess;
+
+// fixme: this is from fairmq/shmem/Common.h (it is not public), try to find a more maintainable solution
+inline std::string buildShmIdFromSessionIdAndUserId(const std::string& sessionId)
+{
+  boost::hash<std::string> stringHash;
+  std::string shmId(std::to_string(stringHash(std::string((std::to_string(geteuid()) + sessionId)))));
+  shmId.resize(8, '_');
+  return shmId;
+}
+
+std::function<size_t(void)> createFreeMemoryGetter(InitContext& ictx)
+{
+  std::string sessionID;
+  std::string channelConfig;
+  if (FairMQDevice* device = ictx.services().get<RawDeviceService>().device()) {
+    if (auto options = device->GetConfig()) {
+      sessionID = options->GetPropertyAsString("session", "");
+      channelConfig = options->GetPropertyAsString("channel-config", "");
+    }
+  }
+  if (!sessionID.empty() && sessionID != "default" && channelConfig.find("transport=shmem") != std::string::npos) {
+    LOG(INFO) << "The benchmark is running with shared memory,"
+                 " producing messages will be throttled by looking at available memory in the segment: "
+              << sessionID;
+    std::string segmentID = "fmq_" + buildShmIdFromSessionIdAndUserId(sessionID) + "_main";
+    auto segment = std::make_shared<bipc::managed_shared_memory>(bipc::open_only, segmentID.c_str());
+
+    return [segment]() {
+      return segment->get_free_memory();
+    };
+  } else {
+#if defined(__APPLE__)
+    LOG(WARNING) << "The benchmark is running without shared memory. "
+                    "The throttling mechanism is not supported on MacOS for the ZeroMQ transport, "
+                    "the results might be incorrect for larger payload sizes.";
+#else
+    LOG(INFO) << "The benchmark is running without shared memory,"
+                 " producing messages will be throttled by looking at the global free RAM";
+#endif
+
+    auto sysInfo = std::make_shared<struct sysinfo>();
+
+    return [sysInfo]() {
+      sysinfo(sysInfo.get());
+      return sysInfo->freeram;
+    };
+  }
+}
+// clang-format off
+WorkflowSpec defineDataProcessing(ConfigContext const& config)
+{
+  double samplingFraction = config.options().get<double>("sampling-fraction");
+  size_t payloadSize = config.options().get<int>("payload-size");
+  size_t producers = config.options().get<int>("producers");
+  size_t dispatchers = config.options().get<int>("dispatchers");
+  size_t usleepTime = config.options().get<int>("usleep");
+  size_t testDuration = config.options().get<int>("test-duration");
+  size_t throttlingMB = config.options().get<int>("throttling");
+  bool fill = config.options().get<bool>("fill");
+
+  std::string configurationPath = "/tmp/dataSamplingBenchmark-" + std::to_string(samplingFraction) + ".json";
+  std::string configuration =
+    "{\n"
+    "  \"dataSamplingPolicies\": [\n"
+    "    {\n"
+    "      \"id\": \"benchmark\",\n"
+    "      \"active\": \"true\",\n"
+    "      \"machines\": [],\n"
+    "      \"query\": \"TST:TST/RAWDATA\",\n"
+    "      \"samplingConditions\": [\n"
+    "        {\n"
+    "          \"condition\": \"random\",\n"
+    "          \"fraction\": \"" + std::to_string(samplingFraction) + "\",\n"
+    "          \"seed\": \"22222\"\n"
+    "        }\n"
+    "      ],\n"
+    "      \"blocking\": \"false\"\n"
+    "    }\n"
+    "  ]\n"
+    "}";
+
+  if (!boost::filesystem::exists(configurationPath)) {
+    std::ofstream configurationFile(configurationPath);
+    configurationFile << configuration;
+    configurationFile.close();
+  }
+
+  WorkflowSpec specs;
+
+  for (size_t p = 0; p < producers; p++) {
+    specs.push_back(DataProcessorSpec{
+      "dataProducer" + std::to_string(p),
+      Inputs{},
+      Outputs{
+        OutputSpec{ "TST", "RAWDATA", static_cast<SubSpec>(p) }
+      },
+      AlgorithmSpec{
+        (AlgorithmSpec::InitCallback) [=](InitContext& ictx) {
+
+          sleep(5); // wait a few seconds before trying to open a shmem segment to make sure it is there
+
+          std::function<size_t(void)> getFreeMemory = createFreeMemoryGetter(ictx);
+          const size_t maxFreeMemory = getFreeMemory(); // that may vary on the process sync
+          size_t maximumAllowedMessages = (maxFreeMemory - throttlingMB * 1000000) / payloadSize / producers;
+          LOG(INFO) << "First cycle, this producer will send " << maximumAllowedMessages << " messages";
+
+          auto messagesProducedSinceLastCycle = std::make_shared<size_t>(0);
+          std::shared_ptr<bool> mightSaturate = nullptr;
+
+          return (AlgorithmSpec::ProcessCallback) [=](ProcessingContext& pctx) mutable {
+            usleep(usleepTime);
+
+            // This is a mechanism which protects the benchmark from reaching the maximum of available memory.
+            // In that case it is likely that we get killed by oom-killer or trapped inside a deadlock.
+            // It works well for shmem tests, but not for zeromq - the latter increases the memory usage
+            // muuuch more inertia (slower and harder to control) and we cannot observe it this way.
+            // Then, it is recommended to use the '--fill' parameter, which prevents Linux from overcommitting
+            // the memory by writing on the produced messages before sending (which unfortunately slows down the
+            // message production rate).
+            if (*messagesProducedSinceLastCycle < maximumAllowedMessages) {
+              auto data = pctx.outputs().make<char>(Output{ "TST", "RAWDATA", static_cast<SubSpec>(p) }, payloadSize);
+              *messagesProducedSinceLastCycle += 1;
+              if (fill) {
+                memset(data.data(), 0x00, payloadSize);
+              }
+            } else if (mightSaturate == nullptr) {
+              // maximumAllowedMessages has been reached, so we check if we should protect the benchmark from asking
+              // for too much memory.
+              sleep(1);
+              // 4 is a magic number - an arbitrary high limit of free memory is 4 times larger than the low limit.
+              mightSaturate = std::make_shared<bool>(getFreeMemory() < 4 * throttlingMB * 1000000);
+            } else if (*mightSaturate == false) {
+              // there is no risk of reaching the maximum available memory,
+              // so we allow for a continuous message production.
+              *messagesProducedSinceLastCycle = 0;
+              maximumAllowedMessages = -1;
+              LOG(INFO) << "The memory usage should not reach the limits, we allow to produce as much messages as possible";
+            } else if (size_t freeMemory = getFreeMemory(); freeMemory > 4 * throttlingMB * 1000000) {
+              // if we are here, then the maximumAllowedMessages has been reached and we have waited until
+              // the memory usage dropped to the safe level again.
+              *messagesProducedSinceLastCycle = 0;
+              maximumAllowedMessages = (freeMemory - throttlingMB * 1000000) / payloadSize / producers;
+              LOG(INFO) << "New cycle, this producer will send " << maximumAllowedMessages << " messages";
+            }
+          };
+        }
+      }
+    });
+  }
+
+  DataSampling::GenerateInfrastructure(specs, "json:/" + configurationPath, dispatchers);
+
+  DataProcessorSpec podDataSink{
+    "dataSink",
+    Inputs{{"test-data", {DataSamplingPolicy::createPolicyDataOrigin(), DataSamplingPolicy::createPolicyDataDescription("benchmark", 0)}},
+           {"test-timer", "TST", "TIMER", 0, Lifetime::Timer}},
+    Outputs{},
+    AlgorithmSpec{
+      (AlgorithmSpec::ProcessCallback)[](ProcessingContext & ctx){
+        // todo: maybe add a check
+        if (ctx.inputs().isValid("test-timer")){
+          ctx.services().get<ControlService>().readyToQuit(QuitRequest::All);
+        }
+      }
+    },
+    Options{
+      { "period-test-timer", VariantType::Int, static_cast<int>(testDuration * 1000000), { "timer period" }}
+    }
+  };
+
+  specs.push_back(podDataSink);
+  return specs;
+}
+// clang-format on

--- a/Framework/TestWorkflows/src/dataSamplingBenchmark.cxx
+++ b/Framework/TestWorkflows/src/dataSamplingBenchmark.cxx
@@ -72,7 +72,7 @@ using SubSpec = o2::header::DataHeader::SubSpecificationType;
 
 namespace bipc = ::boost::interprocess;
 
-// fixme: this is from fairmq/shmem/Common.h (it is not public), try to find a more maintainable solution
+// fixme: This is from fairmq/shmem/Common.h (it is not public), try to find a more maintainable solution
 inline std::string buildShmIdFromSessionIdAndUserId(const std::string& sessionId)
 {
   boost::hash<std::string> stringHash;


### PR DESCRIPTION
This introduces a script which runs Data Sampling benchmarks and prints results to files. It is supposed to work both with zeromq and shmem transport (as enabled in this PR: https://github.com/AliceO2Group/AliceO2/pull/2670 ).
There is a mechanism which prevents the benchmark from allocating too much memory, to avoid deadlocks (Dispatcher need to copy data, but there is not enough memory for that and it waits until there is, but only Dispatcher can free it by processing messages).
However, with that fixed, I can see still some crashes related to shared memory (appearing only for larger throughputs/message payload sizes):
```
[193856:Dispatcher]:  *** Break *** bus error
[193856:Dispatcher]: essor_id=Dispatcher
...
[193856:Dispatcher]: ===========================================================
[193856:Dispatcher]: 
[193856:Dispatcher]: 
[193856:Dispatcher]: The lines below might hint at the cause of the crash.
[193856:Dispatcher]: You may get help by asking at the ROOT forum http://root.cern.ch/forum
[193856:Dispatcher]: Only if you are really convinced it is a bug in ROOT then please submit a
[193856:Dispatcher]: report at http://root.cern.ch/bugs Please post the ENTIRE stack trace
[193856:Dispatcher]: from above as an attachment in addition to anything else
[193856:Dispatcher]: that might help us fixing this issue.
[193856:Dispatcher]: ===========================================================
[193856:Dispatcher]: #7  0x00007fc9308a9b5a in __memcpy_ssse3_back () from /lib64/libc.so.6
[193856:Dispatcher]: #8  0x00007fc93bd25549 in o2::framework::DataAllocator::snapshot (this=0x20e2de0, spec=..., payload=0x7fb3d997c350 "", payloadSize=100000000, serializationMethod=...) at /home/datasam
pling/alice/sw/SOURCES/O2/0_O2_DATAFLOW/0/Framework/Core/src/DataAllocator.cxx:186
[193856:Dispatcher]: #9  0x00007fc93bd653ce in o2::framework::Dispatcher::send (this=this
[193856:Dispatcher]: entry=0x2104bc0, dataAllocator=..., inputData=..., output=...) at /home/datasampling/alice/sw/SOURCES/O2/0_O2_DATAFLOW/0/Framework/Core/src/Dispatcher.cxx:157
[193856:Dispatcher]: #10 0x00007fc93bd67731 in o2::framework::Dispatcher::run (this=0x2104bc0, ctx=...) at /home/datasampling/alice/sw/SOURCES/O2/0_O2_DATAFLOW/0/Framework/Core/src/Dispatcher.cxx:99
```
@dennisklein @rbx Have you seen perhaps something like that before? Could it happen because I open a shmem segment to monitor the free memory used by my workflow?  (see dataSamplingBenchmark.cxx:227)