### PR TITLE
Fix pedestal value calculation

### DIFF
--- a/Detectors/TPC/calibration/src/CalibPedestal.cxx
+++ b/Detectors/TPC/calibration/src/CalibPedestal.cxx
@@ -117,11 +117,11 @@ void CalibPedestal::analyse()
     for (Int_t ichannel = 0; ichannel < numberOfPads; ++ichannel) {
       size_t offset = ichannel * mNumberOfADCs;
       if (mStatisticsType == StatisticsType::GausFit) {
-        fitGaus(mNumberOfADCs, array + offset, float(mADCMin), float(mADCMax + 1), fitValues);
+        fitGaus(mNumberOfADCs, array + offset, float(mADCMin) - 0.5f, float(mADCMax + 1) - 0.5f, fitValues); // -0.5 since ADC values are discrete
         pedestal = fitValues[1];
         noise = fitValues[2];
       } else if (mStatisticsType == StatisticsType::MeanStdDev) {
-        StatisticsData data = getStatisticsData(array + offset, mNumberOfADCs, double(mADCMin), double(mADCMax));
+        StatisticsData data = getStatisticsData(array + offset, mNumberOfADCs, double(mADCMin) - 0.5, double(mADCMax) - 0.5); // -0.5 since ADC values are discrete
         pedestal = data.mCOG;
         noise = data.mStdDev;
       }


### PR DESCRIPTION
Shift binning by -0.5 to account for the discrete nature of ADC values.
Fit and statistics data are evaluated at the bin centre.