### PR TITLE
Raw data files reader workflow

### DIFF
--- a/Detectors/Raw/CMakeLists.txt
+++ b/Detectors/Raw/CMakeLists.txt
@@ -10,27 +10,38 @@
 
 o2_add_library(DetectorsRaw
                SOURCES src/RawFileReader.cxx
-	               src/HBFUtils.cxx  
+  	               src/RawFileReaderWorkflow.cxx
+	               src/HBFUtils.cxx
                PUBLIC_LINK_LIBRARIES FairRoot::Base
 		                     O2::Headers
 		                     O2::CommonDataFormat  
-                                     O2::DetectorsCommonDataFormats)
+                                     O2::DetectorsCommonDataFormats
+				     O2::Framework
+				     FairMQ::FairMQ)
 
 o2_target_root_dictionary(DetectorsRaw
                           HEADERS include/DetectorsRaw/RawFileReader.h
+                                  include/DetectorsRaw/RawFileReaderWorkflow.h
 				  include/DetectorsRaw/HBFUtils.h)
 
 
 			
-o2_add_executable(filecheck 
-                  COMPONENT_NAME Raw
+o2_add_executable(file-check 
+                  COMPONENT_NAME raw
                   SOURCES src/rawfileCheck.cxx
                   PUBLIC_LINK_LIBRARIES O2::DetectorsRaw
                                         Boost::program_options)
 
+o2_add_executable(file-reader-workflow
+                  COMPONENT_NAME raw
+                  SOURCES src/rawfile-reader-workflow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::DetectorsRaw)
+
+				      
 o2_add_test(HBFUtils
             PUBLIC_LINK_LIBRARIES O2::DetectorsRaw
                                   O2::Steer
             SOURCES test/testHBFUtils.cxx
             COMPONENT_NAME raw
             LABELS raw)
+	  

--- a/Detectors/Raw/include/DetectorsRaw/RawFileReader.h
+++ b/Detectors/Raw/include/DetectorsRaw/RawFileReader.h
@@ -17,10 +17,14 @@
 
 #include <cstdio>
 #include <unordered_map>
+#include <map>
 #include <vector>
 #include <string>
+#include <utility>
 #include <Rtypes.h>
 #include "Headers/RAWDataHeader.h"
+#include "Headers/DataHeader.h"
+#include "DetectorsRaw/HBFUtils.h"
 
 namespace o2
 {
@@ -29,10 +33,11 @@ namespace raw
 
 class RawFileReader
 {
-
+  using LinkSpec_t = uint64_t; // = (origin<<32) | LinkSubSpec
  public:
   using RDH = o2::header::RAWDataHeaderV4;
-  using LinkSpec_t = uint32_t;
+  using OrDesc = std::pair<o2::header::DataOrigin, o2::header::DataDescription>;
+  using InputsMap = std::map<OrDesc, std::vector<std::string>>;
   //================================================================================
   enum ErrTypes { ErrWrongPacketCounterIncrement,
                   ErrWrongPageCounterIncrement,
@@ -40,6 +45,7 @@ class RawFileReader
                   ErrHBFNoStop,
                   ErrWrongFirstPage,
                   ErrWrongHBFsPerTF,
+                  ErrWrongNumberOfTF,
                   ErrHBFJump,
                   ErrNoSuperPageForTF,
                   NErrorsDefined
@@ -52,6 +58,7 @@ class RawFileReader
     "New HBF starts w/o closing old one",    // ErrHBFNoStop
     "Data does not start with TF/HBF",       // ErrWrongFirstPage
     "Number of HBFs per TF not as expected", // ErrWrongHBFsPerTF
+    "Number of TFs is less than expected",   // ErrWrongNumberOfTF
     "Wrong HBF orbit increment",             // ErrHBFJump
     "TF does not start by new superpage"     // ErrNoSuperPageForTF
   };
@@ -62,61 +69,72 @@ class RawFileReader
     "missing-stop",
     "starts-with-tf",
     "hbf-per-tf",
+    "tf-per-link",
     "hbf-jump",
     "no-spage-for-tf"};
   //================================================================================
 
   //=====================================================================================
+  // info on the smallest block of data to be read when fetching the HBF
   struct LinkBlock {
-    enum {StartTF=0x1, StartHB=0x1<<1, StartSP=0x1<<2, EndHB=0x1<<3};
+    enum { StartTF = 0x1,
+           StartHB = 0x1 << 1,
+           StartSP = 0x1 << 2,
+           EndHB = 0x1 << 3 };
     size_t offset = 0;    // where data of the block starts
     uint32_t size = 0;    // block size
     uint32_t tfID = 0;    // tf counter (from 0)
     uint32_t orbit = 0;   // orbit starting the block
     uint16_t fileID = 0;  // file id where the block is located
-    uint8_t  flags = 0;   // different flags
+    uint8_t flags = 0;    // different flags
     LinkBlock() = default;
     LinkBlock(int fid, size_t offs) : offset(offs), fileID(fid) {}
-    void setFlag(uint8_t fl, bool v=true) {
+    void setFlag(uint8_t fl, bool v = true)
+    {
       if (v)
-	flags |= fl;
-      else 
-	flags &= ~fl;
+        flags |= fl;
+      else
+        flags &= ~fl;
     }
-    bool testFlag(uint8_t fl) const { return (flags&fl)==fl; }
-    void print(const std::string pref = "") const;
+    bool testFlag(uint8_t fl) const { return (flags & fl) == fl; }
+    void print(const std::string& pref = "") const;
   };
 
   //=====================================================================================
   struct LinkData {
     RDH rdhl;             // RDH with the running info of the last RDH seen
-    uint32_t subspec = 0; // subspec according to DataDistribution
+    LinkSpec_t spec = 0;  // Link subspec augmented by its origin
+    LinkSubSpec_t subspec = 0; // subspec according to DataDistribution
     uint32_t nTimeFrames = 0;
     uint32_t nHBFrames = 0;
     uint32_t nCRUPages = 0;
     uint32_t nSPages = 0;
+    o2::header::DataOrigin origin = o2::header::gDataOriginInvalid;
+    o2::header::DataDescription description = o2::header::gDataDescriptionInvalid;
+    std::string fairMQChannel{}; // name of the fairMQ channel for the output
     int nErrors = 0;
-    char* dataPtr = nullptr; // pointer on currently fetched (TF) data (buffer not owned by the link) //RSTODO used?
-    int dataSize = 0; // size of link's data attached to dataPtr. //RSTODO used?
     std::vector<LinkBlock> blocks;
     //
     // transient info during processing
     bool openHB = false;
     int nHBFinTF = 0;
-    int nextBlock2Read = 0;  // next block which should be read
-    
+    int nextBlock2Read = 0; // next block which should be read
+
     LinkData() = default;
     LinkData(const o2::header::RAWDataHeaderV4& rdh, const RawFileReader* r);
     LinkData(const o2::header::RAWDataHeaderV5& rdh, const RawFileReader* r);
     bool preprocessCRUPage(const RDH& rdh, bool newSPage);
     size_t getLargestSuperPage() const;
     size_t getLargestTF() const;
-
     size_t getNextHBFSize() const;
     size_t getNextTFSize() const;
-    size_t readNextHBF(char* buff) const;
-    
-    void print(bool verbose = false, const std::string pref = "") const;
+    int getNHBFinTF() const;
+
+    size_t readNextHBF(char* buff);
+    size_t readNextTF(char* buff);
+
+    void print(bool verbose = false, const std::string& pref = "") const;
+    std::string describe() const;
 
    private:
     const RawFileReader* reader = nullptr;
@@ -124,17 +142,30 @@ class RawFileReader
 
   //=====================================================================================
 
+  RawFileReader(const std::string& config = "", int verbosity = 0);
   ~RawFileReader() { clear(); }
+
+  void loadFromInputsMap(const InputsMap& inp);
   bool init();
   void clear();
-  bool addFile(const std::string& sname);
+  bool addFile(const std::string& sname, o2::header::DataOrigin origin, o2::header::DataDescription desc);
+  bool addFile(const std::string& sname) { return addFile(sname, mDefDataOrigin, mDefDataDescription); }
+  void setDefaultDataOrigin(const std::string& orig) { mDefDataOrigin = getDataOrigin(orig); }
+  void setDefaultDataDescription(const std::string& desc) { mDefDataDescription = getDataDescription(desc); }
+  void setDefaultDataOrigin(const o2::header::DataOrigin o) { mDefDataOrigin = o; }
+  void setDefaultDataDescription(const o2::header::DataDescription d) { mDefDataDescription = d; }
   int getNLinks() const { return mLinksData.size(); }
   int getNFiles() const { return mFiles.size(); }
 
+  uint32_t getNextTFToRead() const { return mNextTF2Read; }
+  void setNextTFToRead(uint32_t tf) { mNextTF2Read = tf; }
+
   const std::vector<int>& getLinksOrder() const { return mOrderedIDs; }
   const LinkData& getLink(int i) const { return mLinksData[mOrderedIDs[i]]; }
-  const LinkData& getLinkWithSubSpec(LinkSpec_t s) const { return mLinksData[mLinkEntries.at(s)]; }
-  int getLinkSubSpec(int i) const { return getLink(i).subspec; }
+  const LinkData& getLinkWithSpec(LinkSpec_t s) const { return mLinksData[mLinkEntries.at(s)]; }
+  LinkData& getLink(int i) { return mLinksData[mOrderedIDs[i]]; }
+  LinkSubSpec_t getLinkSubSpec(int i) const { return getLink(i).subspec; }
+  LinkSpec_t getLinkSpec(int i) const { return getLink(i).spec; }
 
   void printStat(bool verbose = false) const;
 
@@ -149,25 +180,39 @@ class RawFileReader
   void setNominalHBFperTF(int n = 256) { mNominalHBFperTF = n > 1 ? n : 1; }
   int getNominalHBFperTF() const { return mNominalHBFperTF; }
 
-  uint32_t getOrbitMin() const {return mOrbitMin;}
-  uint32_t getOrbitMax() const {return mOrbitMax;}  
-  
+  uint32_t getNTimeFrames() const { return mNTimeFrames; }
+  uint32_t getOrbitMin() const { return mOrbitMin; }
+  uint32_t getOrbitMax() const { return mOrbitMax; }
+
+  o2::header::DataOrigin getDefaultDataOrigin() const { return mDefDataOrigin; }
+  o2::header::DataDescription getDefaultDataSpecification() const { return mDefDataDescription; }
+
+  static o2::header::DataOrigin getDataOrigin(const std::string& ors);
+  static o2::header::DataDescription getDataDescription(const std::string& ors);
+  static InputsMap parseInput(const std::string& confUri);
+
  private:
-  bool checkRDH(const o2::header::RAWDataHeaderV4& rdh) const;
-  bool checkRDH(const o2::header::RAWDataHeaderV5& rdh) const;
-  LinkSpec_t getSubSpec(uint16_t cru, uint8_t link, uint8_t endpoint) const;
-  int getLinkLocalID(const RDH& rdh);
+  int getLinkLocalID(const RDH& rdh, o2::header::DataOrigin orig);
   bool preprocessFile(int ifl);
+  static LinkSpec_t createSpec(o2::header::DataOrigin orig, LinkSubSpec_t ss) { return (LinkSpec_t(orig) << 32) | ss; }
+
+  static constexpr o2::header::DataOrigin DEFDataOrigin = o2::header::gDataOriginFLP;
+  static constexpr o2::header::DataDescription DEFDataDescription = o2::header::gDataDescriptionRawData;
+
+  o2::header::DataOrigin mDefDataOrigin = DEFDataOrigin;
+  o2::header::DataDescription mDefDataDescription = DEFDataDescription;
 
   std::vector<std::string> mFileNames; // input file names
   std::vector<FILE*> mFiles;           // input file handlers
+  std::vector<OrDesc> mDataSpecs;      // data origin and description for every input file
   bool mInitDone = false;
   std::unordered_map<LinkSpec_t, int> mLinkEntries; // mapping between RDH specs and link entry in the mLinksData
   std::vector<LinkData> mLinksData;                 // info on links data in the files
   std::vector<int> mOrderedIDs;                     // links entries ordered in Specs
+  uint32_t mNTimeFrames = 0;                        // total number of time frames
   uint32_t mNextTF2Read = 0;                        // next TF to read
   uint32_t mOrbitMin = 0xffffffff;                  // lowest orbit seen by any link
-  uint32_t mOrbitMax = 0;                           // highest orbit seen by any link  
+  uint32_t mOrbitMax = 0;                           // highest orbit seen by any link
   int mNominalSPageSize = 0x1 << 20;                // expected super-page size in B
   int mNominalHBFperTF = 256;                       // expected N HBF per TF
   int mCurrentFileID = 0;                           // current file being processed
@@ -179,13 +224,6 @@ class RawFileReader
   ClassDefNV(RawFileReader, 1);
 };
 
-//_____________________________________________________________________
-inline RawFileReader::LinkSpec_t RawFileReader::getSubSpec(uint16_t cru, uint8_t link, uint8_t endpoint) const
-{
-  // define subspecification as in DataDistribution
-  int linkValue = (RawFileReader::LinkSpec_t(link) + 1) << (endpoint == 1 ? 8 : 0);
-  return (RawFileReader::LinkSpec_t(cru) << 16) | linkValue;
-}
 
 } // namespace raw
 } // namespace o2

--- a/Detectors/Raw/include/DetectorsRaw/RawFileReaderWorkflow.h
+++ b/Detectors/Raw/include/DetectorsRaw/RawFileReaderWorkflow.h
@@ -1,0 +1,27 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_RAWFILE_READER_WORKFLOW_H
+#define O2_RAWFILE_READER_WORKFLOW_H
+
+/// @file   RawFileReaderWorkflow.h
+
+#include "Framework/WorkflowSpec.h"
+
+namespace o2
+{
+namespace raw
+{
+
+framework::WorkflowSpec getRawFileReaderWorkflow(std::string inifile, bool tfAsMessage = false, int loop = 0);
+
+} // namespace raw
+} // namespace o2
+#endif

--- a/Detectors/Raw/src/HBFUtils.cxx
+++ b/Detectors/Raw/src/HBFUtils.cxx
@@ -55,9 +55,9 @@ void HBFUtils::print() const
 void HBFUtils::printRDH(const o2::header::RAWDataHeaderV4& rdh)
 {
   std::bitset<32> trb(rdh.triggerType);
-  LOGF(INFO, "EP:%d CRU:0x%04x Packet:%-3d Link:%-3d MemSize:%-4d OffsNext:%-4d prio.:%d FEEID:0x%04x BL:%-5d HS:%-2d HV:%d",
-       int(rdh.endPointID), int(rdh.cruID), int(rdh.packetCounter), int(rdh.linkID), int(rdh.memorySize),
-       int(rdh.offsetToNext), int(rdh.priority), int(rdh.feeId), int(rdh.blockLength), int(rdh.headerSize), int(rdh.version));
+  LOGF(INFO, "EP:%d CRU:0x%04x Link:%-3d FEEID:0x%04x Packet:%-3d MemSize:%-4d OffsNext:%-4d prio.:%d BL:%-5d HS:%-2d HV:%d",
+       int(rdh.endPointID), int(rdh.cruID), int(rdh.linkID), int(rdh.feeId), int(rdh.packetCounter), int(rdh.memorySize),
+       int(rdh.offsetToNext), int(rdh.priority), int(rdh.blockLength), int(rdh.headerSize), int(rdh.version));
   LOGF(INFO, "HBOrb:%-9u TrOrb:%-9u Trg:%32s HBBC:%-4d TrBC:%-4d Page:%-5d Stop:%d Par:%-5d DetFld:0x%04x", //
        rdh.heartbeatOrbit, rdh.triggerOrbit, trb.to_string().c_str(), int(rdh.heartbeatBC), int(rdh.triggerBC),
        int(rdh.pageCnt), int(rdh.stop), int(rdh.par), int(rdh.detectorField));
@@ -67,25 +67,163 @@ void HBFUtils::printRDH(const o2::header::RAWDataHeaderV4& rdh)
 void HBFUtils::printRDH(const o2::header::RAWDataHeaderV5& rdh)
 {
   std::bitset<32> trb(rdh.triggerType);
-  LOGF(INFO, "EP:%d CRU:0x%04x Packet:%-3d Link:%-3d MemSize:%-5d OffsNext:%-5d  prio.:%d FEEID:0x%04x HS:%-2d HV:%d",
-       int(rdh.endPointID), int(rdh.cruID), int(rdh.packetCounter), int(rdh.linkID), int(rdh.memorySize),
-       int(rdh.offsetToNext), int(rdh.priority), int(rdh.feeId), int(rdh.headerSize), int(rdh.version));
+  LOGF(INFO, "EP:%d CRU:0x%04x Link:%-3d FEEID:0x%04x Packet:%-3d MemSize:%-5d OffsNext:%-5d  prio.:%d HS:%-2d HV:%d",
+       int(rdh.endPointID), int(rdh.cruID), int(rdh.linkID), int(rdh.feeId), int(rdh.packetCounter), int(rdh.memorySize),
+       int(rdh.offsetToNext), int(rdh.priority), int(rdh.headerSize), int(rdh.version));
   LOGF(INFO, "Orbit:%-9u BC:%-4d Stop:%d Page:%-5d Trg:%32s Par:%-5d DetFld:0x%04x",
        rdh.orbit, int(rdh.bunchCrossing), int(rdh.stop), int(rdh.pageCnt), trb.to_string().c_str(),
        int(rdh.detectorPAR), int(rdh.detectorField));
 }
 
 //_________________________________________________
-void HBFUtils::dumpRDH(const o2::header::RAWDataHeaderV5& rdh)
+void HBFUtils::printRDH(const void* rdhP)
 {
-  constexpr int hsz = sizeof(o2::header::RAWDataHeaderV5);
-  static_assert(hsz == 64, "Expect 64 bytes long header");
-  const uint16_t* w16 = reinterpret_cast<const uint16_t*>(&rdh);
-  for (int il = 0; il < 4; il++) { // 4 lines
-    printf("[rdh%d] 0x:", il);
-    for (int iw = 8; iw--;) { // with 4 shorts per line
-      printf(" %04x", w16[il * 4 + iw]);
-    }
-    printf("\n");
+  int version = (reinterpret_cast<const char*>(rdhP))[0];
+  switch (version) {
+    case 4:
+      printRDH(*reinterpret_cast<const o2::header::RAWDataHeaderV4*>(rdhP));
+      break;
+    case 5:
+      printRDH(*reinterpret_cast<const o2::header::RAWDataHeaderV5*>(rdhP));
+      break;
+    default:
+      LOG(ERROR) << "Unexpected RDH version " << version << " from";
+      dumpRDH(rdhP);
+      break;
+  };
+}
+
+//_________________________________________________
+void HBFUtils::dumpRDH(const void* rdhP)
+{
+  const uint32_t* w32 = reinterpret_cast<const uint32_t*>(rdhP);
+  for (int i = 0; i < 4; i++) {
+    int l = 4 * i;
+    LOGF(INFO, "[rdh%d] 0x%08x 0x%08x 0x%08x 0x%08x", i, w32[l + 3], w32[l + 2], w32[l + 1], w32[l]);
   }
+}
+
+//_________________________________________________
+bool HBFUtils::checkRDH(const void* rdhP, bool verbose)
+{
+  int version = (reinterpret_cast<const char*>(rdhP))[0];
+  bool ok = true;
+  switch (version) {
+    case 4:
+      ok = checkRDH(*reinterpret_cast<const o2::header::RAWDataHeaderV4*>(rdhP), verbose);
+      break;
+    case 5:
+      ok = checkRDH(*reinterpret_cast<const o2::header::RAWDataHeaderV5*>(rdhP), verbose);
+      break;
+    default:
+      ok = false;
+      if (verbose) {
+        LOG(ERROR) << "Unexpected RDH version " << version << " from";
+      }
+      break;
+  };
+  if (!ok && verbose) {
+    dumpRDH(rdhP);
+  }
+  return ok;
+}
+
+//_________________________________________________
+uint32_t HBFUtils::getHBOrbit(const void* rdhP)
+{
+  int version = (reinterpret_cast<const char*>(rdhP))[0];
+  if (version == 4) {
+    return getHBOrbit(*reinterpret_cast<const o2::header::RAWDataHeaderV4*>(rdhP));
+  } else if (version == 5) {
+    return getHBOrbit(*reinterpret_cast<const o2::header::RAWDataHeaderV5*>(rdhP));
+  }
+  LOG(ERROR) << "Unexpected RDH version " << version << " from";
+  dumpRDH(rdhP);
+  return o2::InteractionRecord::DummyOrbit;
+}
+
+//_________________________________________________
+uint32_t HBFUtils::getHBBC(const void* rdhP)
+{
+  int version = (reinterpret_cast<const char*>(rdhP))[0];
+  if (version == 4) {
+    return getHBBC(*reinterpret_cast<const o2::header::RAWDataHeaderV4*>(rdhP));
+  } else if (version == 5) {
+    return getHBBC(*reinterpret_cast<const o2::header::RAWDataHeaderV5*>(rdhP));
+  }
+  LOG(ERROR) << "Unexpected RDH version " << version << " from";
+  dumpRDH(rdhP);
+  return o2::InteractionRecord::DummyBC;
+}
+
+//_____________________________________________________________________
+bool HBFUtils::checkRDH(const o2::header::RAWDataHeaderV4& rdh, bool verbose)
+{
+  // check if rdh conforms with RDH4 fields
+  bool ok = true;
+  if (rdh.version != 4) {
+    if (verbose) {
+      LOG(ERROR) << "RDH version 4 is expected instead of " << int(rdh.version);
+    }
+    ok = false;
+  }
+  if (rdh.headerSize != 64) {
+    if (verbose) {
+      LOG(ERROR) << "RDH with header size of 64 B is expected instead of " << int(rdh.headerSize);
+    }
+    ok = false;
+  }
+  if (rdh.memorySize < 64 || rdh.offsetToNext < 64) {
+    if (verbose) {
+      LOG(ERROR) << "RDH expected to have memory size/offset to next >= 64 B instead of "
+                 << int(rdh.memorySize) << '/' << int(rdh.offsetToNext);
+    }
+    ok = false;
+  }
+  if (rdh.zero0 || rdh.word3 || rdh.zero41 || rdh.zero42 || rdh.word5 || rdh.zero6 || rdh.word7) {
+    if (verbose) {
+      LOG(ERROR) << "Some reserved fields of RDH v4 are not empty";
+    }
+    ok = false;
+  }
+  if (!ok && verbose) {
+    dumpRDH(rdh);
+  }
+  return ok;
+}
+
+//_____________________________________________________________________
+bool HBFUtils::checkRDH(const o2::header::RAWDataHeaderV5& rdh, bool verbose)
+{
+  // check if rdh conforms with RDH5 fields
+  bool ok = true;
+  if (rdh.version != 5) {
+    if (verbose) {
+      LOG(ERROR) << "RDH version 5 is expected instead of " << int(rdh.version);
+    }
+    ok = false;
+  }
+  if (rdh.headerSize != 64) {
+    if (verbose) {
+      LOG(ERROR) << "RDH with header size of 64 B is expected instead of " << int(rdh.headerSize);
+    }
+    ok = false;
+  }
+  if (rdh.memorySize < 64 || rdh.offsetToNext < 64) {
+    if (verbose) {
+      LOG(ERROR) << "RDH expected to have memory size and offset to next >= 64 B instead of "
+                 << int(rdh.memorySize) << '/' << int(rdh.offsetToNext);
+    }
+    ok = false;
+  }
+  if (rdh.zero0 || rdh.word3 || rdh.zero4 || rdh.word5 || rdh.zero6 || rdh.word7) {
+    if (verbose) {
+      LOG(ERROR) << "Some reserved fields of RDH v5 are not empty";
+    }
+    ok = false;
+  }
+  if (!ok && verbose) {
+    dumpRDH(rdh);
+  }
+  return ok;
 }

--- a/Detectors/Raw/src/RawFileReader.cxx
+++ b/Detectors/Raw/src/RawFileReader.cxx
@@ -17,18 +17,20 @@
 #include <iostream>
 #include <iomanip>
 #include <sstream>
-#include <pair>
+#include <iostream>
 #include "DetectorsRaw/RawFileReader.h"
 #include "CommonConstants/Triggers.h"
 #include "DetectorsRaw/HBFUtils.h"
 #include "Framework/Logger.h"
-#include "Headers/DataHeader.h"
+
+#include <Common/Configuration.h>
 
 using namespace o2::raw;
+namespace o2h = o2::header;
 
 //====================== methods of LinkBlock ========================
 //____________________________________________
-void RawFileReader::LinkBlock::print(const std::string pref) const
+void RawFileReader::LinkBlock::print(const std::string& pref) const
 {
   LOGF(INFO, "%sfile:%3d offs:%10zu size:%8d newSP:%d newTF:%d newHB:%d endHB:%d | Orbit %u TF %u",
        pref, fileID, offset, size, testFlag(StartSP), testFlag(StartTF), testFlag(StartHB),
@@ -38,22 +40,31 @@ void RawFileReader::LinkBlock::print(const std::string pref) const
 //====================== methods of LinkData ========================
 
 //____________________________________________
-RawFileReader::LinkData::LinkData(const o2::header::RAWDataHeaderV4& rdh, const RawFileReader* r) : reader(r)
+RawFileReader::LinkData::LinkData(const o2h::RAWDataHeaderV4& rdh, const RawFileReader* r) : reader(r)
 {
   std::memcpy(&rdhl, &rdh, sizeof(rdh));
 }
 
 //____________________________________________
-RawFileReader::LinkData::LinkData(const o2::header::RAWDataHeaderV5& rdh, const RawFileReader* r) : reader(r)
+RawFileReader::LinkData::LinkData(const o2h::RAWDataHeaderV5& rdh, const RawFileReader* r) : reader(r)
 {
   std::memcpy(&rdhl, &rdh, sizeof(rdh));
 }
 
 //____________________________________________
-void RawFileReader::LinkData::print(bool verbose, const std::string pref) const
+std::string RawFileReader::LinkData::describe() const
 {
-  LOGF(INFO, "%sSSpec:0x%-8d FEE:0x%4x CRU:%4d Lnk:%3d EP:%d | SPages:%4d Pages:%6d TFs:%6d with %6d HBF in %4d blocks (%d err)",
-       pref, subspec, int(rdhl.feeId), int(rdhl.cruID), int(rdhl.linkID), int(rdhl.endPointID), nSPages, nCRUPages,
+  std::stringstream ss;
+  ss << "Link " << origin.as<std::string>() << '/' << description.as<std::string>() << "/0x"
+     << std::hex << std::setw(8) << std::setfill('0') << subspec;
+  return ss.str();
+}
+
+//____________________________________________
+void RawFileReader::LinkData::print(bool verbose, const std::string& pref) const
+{
+  LOGF(INFO, "%s %s FEE:0x%4x CRU:%4d Lnk:%3d EP:%d | SPages:%4d Pages:%6d TFs:%6d with %6d HBF in %4d blocks (%d err)",
+       pref, describe(), int(rdhl.feeId), int(rdhl.cruID), int(rdhl.linkID), int(rdhl.endPointID), nSPages, nCRUPages,
        nTimeFrames, nHBFrames, int(blocks.size()), nErrors);
   if (verbose) {
     for (int i = 0; i < int(blocks.size()); i++) {
@@ -71,7 +82,7 @@ size_t RawFileReader::LinkData::getNextHBFSize() const
   // The blocks are guaranteed to not cover more than 1 HB
   size_t sz = 0;
   int ibl = nextBlock2Read, nbl = blocks.size();
-  while(ibl<nbl && (blocks[ibl].orbit == blocks[nextBlock2Read].orbit)) {
+  while (ibl < nbl && (blocks[ibl].orbit == blocks[nextBlock2Read].orbit)) {
     sz += blocks[ibl].size;
     ibl++;
   }
@@ -81,18 +92,19 @@ size_t RawFileReader::LinkData::getNextHBFSize() const
 //____________________________________________
 size_t RawFileReader::LinkData::readNextHBF(char* buff)
 {
-  // read data of the next complete HB
+  // read data of the next complete HB, buffer of getNextHBFSize() must be allocated in advance
   size_t sz = 0;
   int ibl = nextBlock2Read, nbl = blocks.size();
   bool error = false;
-  while(ibl<nbl) {
-    const auto& blc = blocks[ibl++];
+  while (ibl < nbl) {
+    const auto& blc = blocks[ibl];
     if (blc.orbit != blocks[nextBlock2Read].orbit) {
       break;
     }
+    ibl++;
     auto fl = reader->mFiles[blc.fileID];
-    if (fseek(fl, blc.offset, SEED_SET) || fread(fuff, 1, blc.size, fl)!=blc.size) {
-      LOGF(ERROR,"Failed to read for the link with subspec %x a bloc:", subspec);
+    if (fseek(fl, blc.offset, SEEK_SET) || fread(buff, 1, blc.size, fl) != blc.size) {
+      LOGF(ERROR, "Failed to read for the %s a bloc:", describe());
       blc.print();
       error = true;
     }
@@ -108,12 +120,43 @@ size_t RawFileReader::LinkData::getNextTFSize() const
   // estimate the memory size of the next TF to read
   // (assuming nextBlock2Read is at the start of the TF)
   size_t sz = 0;
-  int ibl = nextBlock2Read, nbl = blocks.size();  
-  while(ibl<nbl && (blocks[ibl].tfID==blocks[nextBlock2Read].tfID)) {
+  int ibl = nextBlock2Read, nbl = blocks.size();
+  while (ibl < nbl && (blocks[ibl].tfID == blocks[nextBlock2Read].tfID)) {
     sz += blocks[ibl].size;
     ibl++;
   }
   return sz;
+}
+
+//_____________________________________________________________________
+size_t RawFileReader::LinkData::readNextTF(char* buff)
+{
+  // read next complete TF, buffer of getNextTFSize() must be allocated in advance
+  size_t sz = 0;
+  int ibl0 = nextBlock2Read, nbl = blocks.size();
+  bool error = false;
+  while (nextBlock2Read < nbl && (blocks[nextBlock2Read].tfID == blocks[ibl0].tfID)) { // nextBlock2Read is incremented by the readNextHBF!
+    auto szb = readNextHBF(buff + sz);
+    if (!szb) {
+      error = true;
+    }
+    sz += szb;
+  }
+  return error ? 0 : sz; // in case of the error we ignore the data
+}
+
+//____________________________________________
+int RawFileReader::LinkData::getNHBFinTF() const
+{
+  // estimate number of HBFs left in the TF
+  int ibl = nextBlock2Read, nbl = blocks.size(), nHB = 0;
+  while (ibl < nbl && (blocks[ibl].tfID == blocks[nextBlock2Read].tfID)) {
+    if (blocks[ibl].testFlag(LinkBlock::StartHB)) {
+      nHB++;
+    }
+    ibl++;
+  }
+  return nHB;
 }
 
 //____________________________________________
@@ -158,12 +201,12 @@ bool RawFileReader::LinkData::preprocessCRUPage(const RDH& rdh, bool newSPage)
   bool newTF = false, newHB = false;
 
   if (rdh.feeId != rdhl.feeId) { // make sure links with different FEEID were not assigned same subspec
-    LOGF(ERROR, "Same SubSpec is found for Links with different RDH.feeId");
+    LOGF(ERROR, "Same SubSpec is found for %s with different RDH.feeId", describe());
     LOGF(ERROR, "old RDH assigned SubSpec=0x%-8d:", subspec);
-    o2::raw::HBFUtils::dumpRDH(rdhl);
+    HBFUtils::dumpRDH(rdhl);
     LOGF(ERROR, "new RDH assigned SubSpec=0x%-8d:", subspec);
-    o2::raw::HBFUtils::dumpRDH(rdh);
-    LOG(FATAL) << "Critical error, aborting";
+    HBFUtils::dumpRDH(rdh);
+    throw std::runtime_error("Confliting SubSpecs are provided");
     ok = false;
     nErrors++;
   }
@@ -228,12 +271,12 @@ bool RawFileReader::LinkData::preprocessCRUPage(const RDH& rdh, bool newSPage)
       }
       if ((reader->mCheckErrors & (0x1 << ErrHBFJump)) &&
           (nCRUPages && // skip this check for the very 1st RDH
-           !(o2::raw::HBFUtils::getHBBC(rdh) == o2::raw::HBFUtils::getHBBC(rdhl) &&
-             o2::raw::HBFUtils::getHBOrbit(rdh) == o2::raw::HBFUtils::getHBOrbit(rdhl) + 1))) {
+           !(HBFUtils::getHBBC(rdh) == HBFUtils::getHBBC(rdhl) &&
+             HBFUtils::getHBOrbit(rdh) == HBFUtils::getHBOrbit(rdhl) + 1))) {
         LOG(ERROR) << ErrNames[ErrHBFJump] << " @ HBF#" << nHBFrames << " New HB orbit/bc="
-                   << o2::raw::HBFUtils::getHBOrbit(rdh) << '/' << int(o2::raw::HBFUtils::getHBBC(rdh))
+                   << HBFUtils::getHBOrbit(rdh) << '/' << int(HBFUtils::getHBBC(rdh))
                    << " is not incremented by 1 orbit wrt Old HB orbit/bc="
-                   << o2::raw::HBFUtils::getHBOrbit(rdhl) << '/' << int(o2::raw::HBFUtils::getHBBC(rdhl));
+                   << HBFUtils::getHBOrbit(rdhl) << '/' << int(HBFUtils::getHBBC(rdhl));
         ok = false;
         nErrors++;
       }
@@ -247,7 +290,7 @@ bool RawFileReader::LinkData::preprocessCRUPage(const RDH& rdh, bool newSPage)
 
   if (newTF || newSPage || newHB) {
     auto& bl = blocks.emplace_back(reader->mCurrentFileID, reader->mPosInFile);
-    if (newTF) {      
+    if (newTF) {
       nTimeFrames++;
       bl.setFlag(LinkBlock::StartTF);
       if (reader->mCheckErrors & ErrNoSuperPageForTF) {
@@ -258,9 +301,9 @@ bool RawFileReader::LinkData::preprocessCRUPage(const RDH& rdh, bool newSPage)
         }
       } // end of check errors
     }
-    bl.orbit = o2::raw::HBFUtils::getHBOrbit(rdh);
-    bl.tfID = nTimeFrames-1;
-    
+    bl.orbit = HBFUtils::getHBOrbit(rdh);
+    bl.tfID = nTimeFrames - 1;
+
     if (newSPage) {
       nSPages++;
       bl.setFlag(LinkBlock::StartSP);
@@ -269,18 +312,18 @@ bool RawFileReader::LinkData::preprocessCRUPage(const RDH& rdh, bool newSPage)
       bl.setFlag(LinkBlock::StartHB);
     }
   }
-  blocks.back().setFlag(LinkBlock::EndHB, rdh.stop);  // last processed RDH defines this flag
-  blocks.back().size += rdh.offsetToNext; 
+  blocks.back().setFlag(LinkBlock::EndHB, rdh.stop); // last processed RDH defines this flag
+  blocks.back().size += rdh.offsetToNext;
   rdhl = rdh;
   nCRUPages++;
   if (!ok) {
     LOG(ERROR) << " ^^^Problem(s) was encountered at offset " << reader->mPosInFile << " of file " << reader->mCurrentFileID;
-    o2::raw::HBFUtils::printRDH(rdh);
+    HBFUtils::printRDH(rdh);
   } else if (reader->mVerbosity > 1) {
     if (reader->mVerbosity > 2) {
-      o2::raw::HBFUtils::dumpRDH(rdh);
+      HBFUtils::dumpRDH(rdh);
     } else {
-      o2::raw::HBFUtils::printRDH(rdh);
+      HBFUtils::printRDH(rdh);
     }
   }
   return true;
@@ -289,74 +332,29 @@ bool RawFileReader::LinkData::preprocessCRUPage(const RDH& rdh, bool newSPage)
 //====================== methods of RawFileReader ========================
 
 //_____________________________________________________________________
-
-//_____________________________________________________________________
-bool RawFileReader::checkRDH(const o2::header::RAWDataHeaderV4& rdh) const
+RawFileReader::RawFileReader(const std::string& config, int verbosity) : mVerbosity(verbosity)
 {
-  // check if rdh conforms with RDH4 fields
-  bool ok = true;
-  if (rdh.version != 4) {
-    LOG(ERROR) << "RDH version 4 is expected instead of " << int(rdh.version);
-    ok = false;
+  if (!config.empty()) {
+    auto inp = parseInput(config);
+    loadFromInputsMap(inp);
   }
-  if (rdh.headerSize != 64) {
-    LOG(ERROR) << "RDH with header size of 64 B is expected instead of " << int(rdh.headerSize);
-    ok = false;
-  }
-  if (rdh.memorySize < 64 || rdh.offsetToNext < 64) {
-    LOG(ERROR) << "RDH expected to have memory size/offset to next >= 64 B instead of "
-               << int(rdh.memorySize) << '/' << int(rdh.offsetToNext);
-    ok = false;
-  }
-  if (rdh.zero0 || rdh.word3 || rdh.zero41 || rdh.zero42 || rdh.word5 || rdh.zero6 || rdh.word7) {
-    LOG(ERROR) << "Some reserved fields of RDH v4 are not empty";
-    ok = false;
-  }
-  if (!ok) {
-    o2::raw::HBFUtils::dumpRDH(rdh);
-  }
-  return ok;
 }
 
 //_____________________________________________________________________
-bool RawFileReader::checkRDH(const o2::header::RAWDataHeaderV5& rdh) const
-{
-  // check if rdh conforms with RDH5 fields
-  bool ok = true;
-  if (rdh.version != 5) {
-    LOG(ERROR) << "RDH version 5 is expected instead of " << int(rdh.version);
-    ok = false;
-  }
-  if (rdh.headerSize != 64) {
-    LOG(ERROR) << "RDH with header size of 64 B is expected instead of " << int(rdh.headerSize);
-    ok = false;
-  }
-  if (rdh.memorySize < 64 || rdh.offsetToNext < 64) {
-    LOG(ERROR) << "RDH expected to have memory size and offset to next >= 64 B instead of "
-               << int(rdh.memorySize) << '/' << int(rdh.offsetToNext);
-    ok = false;
-  }
-  if (rdh.zero0 || rdh.word3 || rdh.zero4 || rdh.word5 || rdh.zero6 || rdh.word7) {
-    LOG(ERROR) << "Some reserved fields of RDH v5 are not empty";
-    ok = false;
-  }
-  if (!ok) {
-    o2::raw::HBFUtils::dumpRDH(rdh);
-  }
-  return ok;
-}
-
-//_____________________________________________________________________
-int RawFileReader::getLinkLocalID(const RDH& rdh)
+int RawFileReader::getLinkLocalID(const RDH& rdh, const o2::header::DataOrigin orig)
 {
   // get id of the link subspec. in the parser (create entry if new)
-  LinkSpec_t subspec = getSubSpec(rdh.cruID, rdh.linkID, rdh.endPointID);
-  auto entryMap = mLinkEntries.find(subspec);
+  LinkSubSpec_t subspec = HBFUtils::getSubSpec(rdh);
+  LinkSpec_t spec = createSpec(orig, subspec);
+  auto entryMap = mLinkEntries.find(spec);
   if (entryMap == mLinkEntries.end()) { // need to register a new link
     int n = mLinkEntries.size();
-    mLinkEntries[subspec] = n;
+    mLinkEntries[spec] = n;
     auto& lnk = mLinksData.emplace_back(rdh, this);
     lnk.subspec = subspec;
+    lnk.origin = mDataSpecs[mCurrentFileID].first;
+    lnk.description = mDataSpecs[mCurrentFileID].second;
+    lnk.spec = spec;
     return n;
   }
   return entryMap->second;
@@ -370,7 +368,7 @@ bool RawFileReader::preprocessFile(int ifl)
   mCurrentFileID = ifl;
   RDH rdh;
 
-  LinkSpec_t subspecPrev = 0xffffffff;
+  LinkSpec_t specPrev = 0xffffffffffffffff;
   int lIDPrev = -1;
   mMultiLinkFile = false;
   rewind(fl);
@@ -385,18 +383,18 @@ bool RawFileReader::preprocessFile(int ifl)
       ok = false;
       break;
     }
-    if (!(ok = checkRDH(rdh))) {
+    if (!(ok = HBFUtils::checkRDH(rdh))) {
       break;
     }
     nRDHread++;
-    LinkSpec_t subspec = getSubSpec(rdh.cruID, rdh.linkID, rdh.endPointID);
+    LinkSpec_t spec = createSpec(mDataSpecs[mCurrentFileID].first, HBFUtils::getSubSpec(rdh));
     int lID = lIDPrev;
-    if (subspec != subspecPrev) { // link has changed
-      subspecPrev = subspec;
+    if (spec != specPrev) { // link has changed
+      specPrev = spec;
       if (lIDPrev != -1) {
         mMultiLinkFile = true;
       }
-      lID = getLinkLocalID(rdh);
+      lID = getLinkLocalID(rdh, mDataSpecs[mCurrentFileID].first);
     }
     bool newSPage = lID != lIDPrev;
     mLinksData[lID].preprocessCRUPage(rdh, newSPage);
@@ -448,19 +446,32 @@ void RawFileReader::clear()
 }
 
 //_____________________________________________________________________
-bool RawFileReader::addFile(const std::string& sname)
+bool RawFileReader::addFile(const std::string& sname, o2::header::DataOrigin origin, o2::header::DataDescription desc)
 {
   if (mInitDone) {
     LOG(ERROR) << "Cannot add new files after initialization";
     return false;
   }
   auto inFile = fopen(sname.c_str(), "rb");
+  bool ok = true;
   if (!inFile) {
     LOG(ERROR) << "Failed to open input file " << sname;
-    return false;
+    ok = false;
+  }
+  if (origin == o2h::gDataOriginInvalid) {
+    LOG(ERROR) << "Invalid data origin " << origin.as<std::string>() << " for file " << sname;
+    ok = false;
+  }
+  if (desc == o2h::gDataDescriptionInvalid) {
+    LOG(ERROR) << "Invalid data description " << desc.as<std::string>() << " for file " << sname;
+    ok = false;
+  }
+  if (!ok) {
+    fclose(inFile);
   }
   mFileNames.push_back(sname);
   mFiles.push_back(inFile);
+  mDataSpecs.emplace_back(origin, desc);
   return true;
 }
 
@@ -468,7 +479,7 @@ bool RawFileReader::addFile(const std::string& sname)
 bool RawFileReader::init()
 {
   // make initialization, preprocess files and chack for errors if asked
-  
+
   for (int i = 0; i < NErrorsDefined; i++) {
     if (mCheckErrors & (0x1 << i))
       LOGF(INFO, "perform check for /%s/", ErrNames[i].data());
@@ -482,12 +493,15 @@ bool RawFileReader::init()
   mOrderedIDs.resize(mLinksData.size());
   for (int i = mLinksData.size(); i--;) {
     mOrderedIDs[i] = i;
+    if (mNTimeFrames < mLinksData[i].nTimeFrames) {
+      mNTimeFrames = mLinksData[i].nTimeFrames;
+    }
   }
   std::sort(mOrderedIDs.begin(), mOrderedIDs.end(),
-            [& links = mLinksData](int a, int b) { return links[a].subspec < links[b].subspec; });
+            [& links = mLinksData](int a, int b) { return links[a].spec < links[b].spec; });
 
   size_t maxSP = 0, maxTF = 0;
-  
+
   LOGF(INFO, "Summary of preprocessing:");
   for (int i = 0; i < int(mLinksData.size()); i++) {
     const auto& link = getLink(i);
@@ -508,13 +522,17 @@ bool RawFileReader::init()
     }
     // min max orbits
     if (link.blocks.front().orbit < mOrbitMin) {
-      mOrbitMin = link.blocks.front().orbit;      
+      mOrbitMin = link.blocks.front().orbit;
     }
     if (link.blocks.back().orbit > mOrbitMax) {
-      mOrbitMax = link.blocks.back().orbit;      
-    }    
+      mOrbitMax = link.blocks.back().orbit;
+    }
+    if ((mCheckErrors & (0x1 << ErrWrongNumberOfTF)) && (mNTimeFrames != link.nTimeFrames)) {
+      LOGF(ERROR, "%s for %s: %u TFs while %u were seen for other links", ErrNames[ErrWrongNumberOfTF],
+           link.describe(), link.nTimeFrames, mNTimeFrames);
+    }
   }
-  LOGF(INFO, "First orbit: %d, Last orbit: %d",mOrbitMin, mOrbitMax);
+  LOGF(INFO, "First orbit: %d, Last orbit: %d", mOrbitMin, mOrbitMax);
   LOGF(INFO, "Largest super-page: %zu B, largest TF: %zu B", maxSP, maxTF);
   if (!mCheckErrors) {
     LOGF(INFO, "Detailed data format check was disabled");
@@ -525,26 +543,115 @@ bool RawFileReader::init()
 }
 
 //_____________________________________________________________________
-bool RawFileReader::readNextTF()
+o2h::DataOrigin RawFileReader::getDataOrigin(const std::string& ors)
 {
-  size_t sz = 0;
-  for (int i = 0; i < int(mLinksData.size()); i++) {
-    const auto& link = getLink(i);
-    sz += link.getNextTFSize(); // size of TF and number of HBFs (don't trust to expected value?)
-  }
-  // create a buffer for new TF
-  std::unique<char[]> buff = std::make_unique<char[]>(sz);
-  char* buffPtr = buff.get();
-  
-  for (int i = 0; i < int(mLinksData.size()); i++) {
-    auto& link = getLink(i);
-    if (link.nextBlock2Read<int(link.blocks.size()) && link.blocks[link.nextBlock2Read].tfID == mNextTF2Read) {
-      auto szHBF = link->readNextHBF(buffPtr);
-      //
-      // RSTODO: create a DataHeader, add to multipart
-      //
+  constexpr int NGoodOrigins = 18;
+  constexpr std::array<o2h::DataOrigin, NGoodOrigins> goodOrigins{
+    o2h::gDataOriginFLP, o2h::gDataOriginACO, o2h::gDataOriginCPV, o2h::gDataOriginCTP, o2h::gDataOriginEMC,
+    o2h::gDataOriginFT0, o2h::gDataOriginFV0, o2h::gDataOriginFDD, o2h::gDataOriginHMP, o2h::gDataOriginITS,
+    o2h::gDataOriginMCH, o2h::gDataOriginMFT, o2h::gDataOriginMID, o2h::gDataOriginPHS, o2h::gDataOriginTOF,
+    o2h::gDataOriginTPC, o2h::gDataOriginTRD, o2h::gDataOriginZDC};
+  for (auto orgood : goodOrigins) {
+    if (ors == orgood.as<std::string>()) {
+      return orgood;
     }
   }
-  mNextTF2Read++;
-  return true;
+  return o2h::gDataOriginInvalid;
+}
+
+//_____________________________________________________________________
+o2h::DataDescription RawFileReader::getDataDescription(const std::string& ors)
+{
+  constexpr int NGoodDesc = 5;
+  constexpr std::array<o2h::DataDescription, NGoodDesc> goodDesc{
+    o2h::gDataDescriptionRawData, o2h::gDataDescriptionClusters, o2h::gDataDescriptionTracks,
+    o2h::gDataDescriptionConfig, o2h::gDataDescriptionInfo};
+
+  for (auto dgood : goodDesc) {
+    if (ors == dgood.as<std::string>()) {
+      return dgood;
+    }
+  }
+  return o2h::gDataDescriptionInvalid;
+}
+
+//_____________________________________________________________________
+void RawFileReader::loadFromInputsMap(const RawFileReader::InputsMap& inp)
+{
+  // load from already parsed input
+  for (const auto& entry : inp) {
+    const auto& ordesc = entry.first;
+    const auto& files = entry.second;
+    if (files.empty()) { // these are default origin and decription
+      setDefaultDataOrigin(ordesc.first);
+      setDefaultDataDescription(ordesc.second);
+      continue;
+    }
+    for (const auto& fnm : files) { // specific file names
+      addFile(fnm, ordesc.first, ordesc.second);
+    }
+  }
+}
+
+//_____________________________________________________________________
+RawFileReader::InputsMap RawFileReader::parseInput(const std::string& confUri)
+{
+  // read input files from configuration
+  std::map<std::pair<o2h::DataOrigin, o2h::DataDescription>, std::vector<std::string>> entries;
+
+  if (confUri.empty()) {
+    throw std::runtime_error("Input configuration file is not provided");
+  }
+  std::string confFile = confUri;
+  ConfigFile cfg;
+  // ConfigFile file requires input as file:///absolute_path or file:local
+  if (confFile.rfind("file:", 0) != 0) {
+    confFile.insert(0, "file:");
+  }
+  try {
+    cfg.load(confFile);
+  } catch (std::string& e) { // unfortunately, the ConfigFile::load throws a string rather than the std::exception
+    throw std::runtime_error(std::string("Failed to parse configuration ") + confFile + " : " + e);
+  }
+  //
+  try {
+    std::string origStr, descStr, defstr = "defaults";
+    cfg.getOptionalValue<std::string>(defstr + ".dataOrigin", origStr, DEFDataOrigin.as<std::string>());
+    auto defDataOrigin = getDataOrigin(origStr);
+    if (defDataOrigin == o2h::gDataOriginInvalid) {
+      throw std::runtime_error(std::string("Invalid default data origin ") + origStr);
+    }
+    cfg.getOptionalValue<std::string>(defstr + ".dataDescription", descStr, DEFDataDescription.as<std::string>());
+    auto defDataDescription = getDataDescription(descStr);
+    if (defDataDescription == o2h::gDataDescriptionInvalid) {
+      throw std::runtime_error(std::string("Invalid default data description ") + descStr);
+    }
+    entries[{defDataOrigin, defDataDescription}]; // insert
+    LOG(DEBUG) << "Setting default dataOrigin/Description " << defDataOrigin.as<std::string>() << '/' << defDataDescription.as<std::string>();
+
+    for (auto flsect : ConfigFileBrowser(&cfg, "input-")) {
+      std::string flNameStr, defs{""};
+      cfg.getOptionalValue<std::string>(flsect + ".dataOrigin", origStr, defDataOrigin.as<std::string>());
+      cfg.getOptionalValue<std::string>(flsect + ".dataDescription", descStr, defDataDescription.as<std::string>());
+      cfg.getOptionalValue<std::string>(flsect + ".filePath", flNameStr, defs);
+      if (flNameStr.empty()) {
+        LOG(DEBUG) << "Skipping incomplete input " << flsect;
+        continue;
+      }
+      auto dataOrigin = getDataOrigin(origStr);
+      if (dataOrigin == o2h::gDataOriginInvalid) {
+        throw std::runtime_error(std::string("Invalid data origin ") + origStr + " for " + flsect);
+      }
+      auto dataDescription = getDataDescription(descStr);
+      if (dataDescription == o2h::gDataDescriptionInvalid) {
+        throw std::runtime_error(std::string("Invalid data description ") + descStr + " for " + flsect);
+      }
+      entries[{dataOrigin, dataDescription}].push_back(flNameStr);
+      LOG(DEBUG) << "adding file " << flNameStr << " to dataOrigin/Description " << dataOrigin.as<std::string>() << '/' << dataDescription.as<std::string>();
+    }
+  } catch (std::string& e) { // to catch exceptions from the parser
+    throw std::runtime_error(std::string("Aborting due to the exception: ") + e);
+  }
+
+  return entries;
 }

--- a/Detectors/Raw/src/RawFileReaderWorkflow.cxx
+++ b/Detectors/Raw/src/RawFileReaderWorkflow.cxx
@@ -1,0 +1,198 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/ConfigContext.h"
+#include "Framework/WorkflowSpec.h"
+#include "Framework/RawDeviceService.h"
+#include "Framework/DeviceSpec.h"
+#include "Framework/DataSpecUtils.h" // RSTODO remove?
+#include "Framework/ConcreteDataMatcher.h"
+#include "Framework/ControlService.h"
+#include "Framework/DataProcessingHeader.h"
+#include "Framework/Task.h"
+#include "Framework/Logger.h"
+
+#include "DetectorsRaw/RawFileReader.h"
+#include "DetectorsRaw/RawFileReaderWorkflow.h"
+#include "DetectorsRaw/HBFUtils.h"
+
+#include "Headers/DataHeader.h"
+#include "Headers/Stack.h"
+
+#include <fairmq/FairMQDevice.h>
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+
+using namespace o2::raw;
+
+namespace o2f = o2::framework;
+namespace o2h = o2::header;
+
+class rawReaderSpecs : public o2f::Task
+{
+ public:
+  explicit rawReaderSpecs(const std::string& config, bool tfAsMessage = false, int loop = 1)
+    : mLoop(loop), mHBFPerMessage(!tfAsMessage), mReader(std::make_unique<o2::raw::RawFileReader>(config))
+  {
+    LOG(INFO) << "Number of loops over whole data requested: " << mLoop;
+    if (mHBFPerMessage) {
+      LOG(INFO) << "Every link TF will be sent as multipart of HBF messages";
+    } else {
+      LOG(INFO) << "HBF of single TF of each link will be sent as a single message";
+    }
+  }
+
+  void init(o2f::InitContext& ic) final
+  {
+    assert(mReader);
+    mReader->init();
+  }
+
+  void run(o2f::ProcessingContext& ctx) final
+  {
+    assert(mReader);
+    static size_t loopsDone = 0, sentSize = 0, sentMessages = 0;
+
+    if (mDone) {
+      return;
+    }
+
+    auto device = ctx.services().get<o2f::RawDeviceService>().device();
+    assert(device);
+
+    auto findOutputChannel = [&ctx](RawFileReader::LinkData& link) {
+      auto outputRoutes = ctx.services().get<o2f::RawDeviceService>().spec().outputs;
+      for (auto& oroute : outputRoutes) {
+        LOG(INFO) << "comparing with matcher to route " << oroute.matcher << " TSlice:" << oroute.timeslice;
+        if (o2f::DataSpecUtils::match(oroute.matcher, link.origin, link.description, link.subspec)) {
+          link.fairMQChannel = oroute.channel;
+          LOG(INFO) << "picking the route:" << o2f::DataSpecUtils::describe(oroute.matcher) << " channel " << oroute.channel;
+          return true;
+        }
+      }
+      LOGF(ERROR, "Failed to find output channel for %s/%s/0x%x", link.origin.as<std::string>(),
+           link.description.as<std::string>(), link.subspec);
+      return false;
+    };
+
+    auto tfID = mReader->getNextTFToRead();
+    int nlinks = mReader->getNLinks();
+    if (tfID >= mReader->getNTimeFrames()) {
+      if (mReader->getNTimeFrames() && mLoop--) {
+        tfID = 0;
+        mReader->setNextTFToRead(tfID);
+        loopsDone++;
+        for (int il = 0; il < nlinks; il++) {
+          mReader->getLink(il).nextBlock2Read = 0; // think about more elaborate looping scheme, e.g. incrementing the orbits in RDHs
+        }
+        LOG(INFO) << "Starting new loop " << loopsDone << " from the beginning of data";
+      } else {
+        LOGF(INFO, "Finished: payload of %zu bytes in %zu messages sent for %d TFs", sentSize, sentMessages, mTFIDaccum);
+        ctx.services().get<o2f::ControlService>().endOfStream();
+        ctx.services().get<o2f::ControlService>().readyToQuit(o2f::QuitRequest::Me);
+        mDone = true;
+        return;
+      }
+    }
+
+    // read next time frame
+    size_t tfMessages = 0, tfSize = 0;
+    LOG(INFO) << "Reading TF#" << mTFIDaccum << " (" << tfID << " at iteration " << loopsDone << ')';
+
+    for (int il = 0; il < nlinks; il++) {
+      auto& link = mReader->getLink(il);
+
+      o2h::DataHeader hdrTmpl(link.description, link.origin, link.subspec); // template with 0 size
+      hdrTmpl.payloadSerializationMethod = o2h::gSerializationMethodNone;
+      hdrTmpl.splitPayloadParts = mHBFPerMessage ? link.getNHBFinTF() : 1;
+
+      FairMQParts parts;
+      while (hdrTmpl.splitPayloadIndex < hdrTmpl.splitPayloadParts) {
+
+        tfSize += hdrTmpl.payloadSize = mHBFPerMessage ? link.getNextHBFSize() : link.getNextTFSize();
+        o2::header::Stack headerStack{hdrTmpl, o2::framework::DataProcessingHeader{mTFIDaccum}};
+
+        auto hdMessage = device->NewMessage(headerStack.size());
+        memcpy(hdMessage->GetData(), headerStack.data(), headerStack.size());
+
+        auto plMessage = device->NewMessage(hdrTmpl.payloadSize);
+        auto bread = mHBFPerMessage ? link.readNextHBF(reinterpret_cast<char*>(plMessage->GetData())) : link.readNextTF(reinterpret_cast<char*>(plMessage->GetData()));
+        if (bread != hdrTmpl.payloadSize) {
+          LOG(ERROR) << "Link " << il << " read " << bread << " bytes instead of " << hdrTmpl.payloadSize
+                     << " expected in TF=" << mTFIDaccum << " part=" << hdrTmpl.splitPayloadIndex;
+        }
+        // check if the RDH to send corresponds to expected orbit
+        if (hdrTmpl.splitPayloadIndex == 0) {
+          uint32_t hbOrbExpected = mReader->getOrbitMin() + tfID * mReader->getNominalHBFperTF();
+          uint32_t hbOrbRead = o2::raw::HBFUtils::getHBOrbit(plMessage->GetData());
+          if (hbOrbExpected != hbOrbRead) {
+            LOGF(ERROR, "Expected orbit=%u but got %u for %d-th HBF in TF#%d of %s/%s/0x%u",
+                 hbOrbExpected, hbOrbRead, hdrTmpl.splitPayloadIndex, tfID,
+                 link.origin.as<std::string>(), link.description.as<std::string>(), link.subspec);
+          }
+        }
+        parts.AddPart(std::move(hdMessage));
+        parts.AddPart(std::move(plMessage));
+        hdrTmpl.splitPayloadIndex++; // prepare for next
+        tfMessages++;
+      }
+      LOGF(INFO, "Sending %d parts for TF#%d(%d in iteration %d) of %s/%s/0x%u", hdrTmpl.splitPayloadParts, mTFIDaccum, tfID,
+           loopsDone, link.origin.as<std::string>(), link.description.as<std::string>(), link.subspec);
+
+      if (link.fairMQChannel.empty() && !findOutputChannel(link)) { // no output channel
+        continue;
+      }
+      device->Send(parts, link.fairMQChannel);
+    }
+    LOGF(INFO, "Sent payload of %zu bytes in %zu messages for TF %d", tfSize, tfMessages, mTFIDaccum);
+    sentSize += tfSize;
+    sentMessages += tfMessages;
+
+    mReader->setNextTFToRead(++tfID);
+    ++mTFIDaccum;
+  }
+
+ private:
+  int mLoop = 0;                                   // once last TF reached, loop while mLoop>=0
+  size_t mTFIDaccum = 0;                           // TFId accumulator (accounts for looping)
+  bool mHBFPerMessage = true;                      // true: send TF as multipart of HBFs, false: single message per TF
+  bool mDone = false;                              // processing is over or not
+  std::unique_ptr<o2::raw::RawFileReader> mReader; // matching engine
+};
+
+o2f::DataProcessorSpec getReaderSpec(std::string config, bool tfAsMessage, int loop)
+{
+  // check which inputs are present in files to read
+  o2f::Outputs outputs;
+  if (!config.empty()) {
+    auto conf = o2::raw::RawFileReader::parseInput(config);
+    for (const auto& entry : conf) {
+      const auto& ordesc = entry.first;
+      if (!entry.second.empty()) { // origin and decription for files to process
+        outputs.emplace_back(o2f::OutputSpec(o2f::ConcreteDataTypeMatcher{ordesc.first, ordesc.second}));
+      }
+    }
+  }
+  return o2f::DataProcessorSpec{
+    "raw-file-reader",
+    o2f::Inputs{},
+    outputs,
+    o2f::AlgorithmSpec{o2f::adaptFromTask<rawReaderSpecs>(config, tfAsMessage, loop)},
+    o2f::Options{}};
+}
+
+o2f::WorkflowSpec o2::raw::getRawFileReaderWorkflow(std::string inifile, bool tfAsMessage, int loop)
+{
+  o2f::WorkflowSpec specs;
+  specs.emplace_back(getReaderSpec(inifile, tfAsMessage, loop));
+  return specs;
+}

--- a/Detectors/Raw/src/rawfile-reader-workflow.cxx
+++ b/Detectors/Raw/src/rawfile-reader-workflow.cxx
@@ -1,0 +1,35 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "DetectorsRaw/RawFileReaderWorkflow.h"
+#include <string>
+
+using namespace o2::framework;
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  workflowOptions.push_back(ConfigParamSpec{"conf", o2::framework::VariantType::String, "", {"configuration file to init from (obligatory)"}});
+  workflowOptions.push_back(ConfigParamSpec{"loop", o2::framework::VariantType::Int, 0, {"loop N times (infinite for N<0)"}});
+  workflowOptions.push_back(ConfigParamSpec{"message-per-tf", o2::framework::VariantType::Bool, false, {"send TF of each link as a single FMQ message rather than multipart with message per HB"}});
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  auto inifile = configcontext.options().get<std::string>("conf");
+  auto loop = configcontext.options().get<int>("loop");
+  auto tfAsMessage = configcontext.options().get<bool>("message-per-tf");
+  return std::move(o2::raw::getRawFileReaderWorkflow(inifile, tfAsMessage, loop));
+}


### PR DESCRIPTION
Allows to feed raw data from files (create from MC or real ones) into the DPL workflows w/o going via
``readout.exe -> StfBuilder -> o2-dpl-raw-proxy `` processes.
See README for details.