### PR TITLE
dpl header: make the class header only

### DIFF
--- a/Framework/Core/include/Framework/DataProcessingHeader.h
+++ b/Framework/Core/include/Framework/DataProcessingHeader.h
@@ -16,6 +16,7 @@
 #include <cstdio>
 #include <memory>
 #include <cassert>
+#include <chrono>
 
 namespace o2
 {
@@ -42,8 +43,13 @@ namespace framework
 ///
 /// @ingroup aliceo2_dataformats_dataheader
 struct DataProcessingHeader : public header::BaseHeader {
+
+  static uint64_t getCreationTime()
+  {
+    auto now = std::chrono::steady_clock::now();
+    return std::chrono::duration<double, std::milli>(now.time_since_epoch()).count();
+  }
   // Required to do the lookup
-  static uint64_t getCreationTime();
   constexpr static const o2::header::HeaderType sHeaderType = "DataFlow";
   static const uint32_t sVersion = 1;
 

--- a/Framework/Core/src/DataProcessingHeader.cxx
+++ b/Framework/Core/src/DataProcessingHeader.cxx
@@ -11,21 +11,11 @@
 #include "Framework/DataProcessingHeader.h"
 #include "Headers/DataHeader.h"
 
-#include <cstdint>
-#include <chrono>
-
 namespace o2
 {
 namespace framework
 {
 
-uint64_t DataProcessingHeader::getCreationTime()
-{
-  auto now = std::chrono::steady_clock::now();
-  return std::chrono::duration<double, std::milli>(now.time_since_epoch()).count();
-}
-
-constexpr o2::header::HeaderType DataProcessingHeader::sHeaderType;
 
 } // namespace framework
 } // namespace o2


### PR DESCRIPTION
this change removes the need for linking against O2::Framework for
users only interested in this header, such as DataDistribution.

Reduced number of library dependencies with this change:
ldd `which StfBuilder` | wc -l
157 -> 41

Alternatively, this header def can be moved to O2::Header library.
What do you think? @ktf @mkrzewic 