### PR TITLE
GPU: Compile GPU HIP code during compilation, not linking

### DIFF
--- a/GPU/GPUTracking/Base/hip/CMakeLists.txt
+++ b/GPU/GPUTracking/Base/hip/CMakeLists.txt
@@ -15,19 +15,14 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 string(REPLACE " -g " " " CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS} ")
 string(REPLACE " -g " " " CMAKE_CXX_FLAGS_${CMAKE_BUILT_TYPE} " ${CMAKE_CXX_FLAGS_${CMAKE_BUILT_TYPE}} ")
-string(REPLACE " -g " " " CMAKE_LINK_FLAGS " ${CMAKE_LINK_FLAGS} ")
-string(REPLACE " -g " " " CMAKE_LINK_FLAGS_${CMAKE_BUILT_TYPE} " ${CMAKE_LINK_FLAGS_${CMAKE_BUILT_TYPE}} ")
 
 string(REPLACE " -ggdb " " " CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS} ")
 string(REPLACE " -ggdb " " " CMAKE_CXX_FLAGS_${CMAKE_BUILT_TYPE} " ${CMAKE_CXX_FLAGS_${CMAKE_BUILT_TYPE}} ")
-string(REPLACE " -ggdb " " " CMAKE_LINK_FLAGS " ${CMAKE_LINK_FLAGS} ")
-string(REPLACE " -ggdb " " " CMAKE_LINK_FLAGS_${CMAKE_BUILT_TYPE} " ${CMAKE_LINK_FLAGS_${CMAKE_BUILT_TYPE}} ")
 
 #setting flags as a global option for all HIP targets.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-invalid-command-line-argument -Wno-unused-command-line-argument -Wno-invalid-constexpr -Wno-ignored-optimization-argument -Wno-unused-private-field")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-gpu-rdc -Wno-invalid-command-line-argument -Wno-unused-command-line-argument -Wno-invalid-constexpr -Wno-ignored-optimization-argument -Wno-unused-private-field")
 if(DEFINED HIP_AMDGPUTARGET)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --amdgpu-target=${HIP_AMDGPUTARGET}")
-  set(CMAKE_LINK_FLAGS "${CMAKE_LINK_FLAGS} --amdgpu-target=${HIP_AMDGPUTARGET}")
   set(TMP_TARGET "(GPU Target ${HIP_AMDGPUTARGET})")
 endif()
 


### PR DESCRIPTION
@mpuccio @mconcas @MichaelLettrich : They send the flag `-fno-gpu-rdc` which one has to pass to the compiler to avoid the GPU compilation during linking.