### PR TITLE
[O2-1079, EMCAL-637] Fix overlaps between EMCAL and PHOS/CPV

### DIFF
--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/Detector.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/Detector.h
@@ -186,15 +186,15 @@ class Detector : public o2::base::DetImpl<Detector>
   Double_t mBirkC1; ///< Birk parameter C1
   Double_t mBirkC2; ///< Birk parameter C2
 
-  std::vector<std::string> mSensitive;               //!<! List of sensitive volumes
-  std::unordered_map<int, EMCALSMType> mSMVolumeID;  //!<! map of EMCAL supermodule volume IDs
+  std::vector<std::string> mSensitive;                      //!<! List of sensitive volumes
+  std::unordered_map<int, EMCALSMType> mSMVolumeID;         //!<! map of EMCAL supermodule volume IDs
   std::unordered_map<std::string, EMCALSMType> mSMVolNames; //!<! map of EMCAL supermodule names
-  Int_t mVolumeIDScintillator;                       //!<! Volume ID of the scintillator volume
-  std::vector<Hit>* mHits;                           //!<! Collection of EMCAL hits
-  Geometry* mGeometry;                               //!<! Geometry pointer
-  std::unordered_map<int, int> mSuperParentsIndices; //!<! Super parent indices (track index - superparent index)
-  std::unordered_map<int, Parent> mSuperParents;     //!<! Super parent kine info (superparent index - superparent object)
-  Parent* mCurrentSuperparent;                       //!<! Pointer to the current superparent
+  Int_t mVolumeIDScintillator;                              //!<! Volume ID of the scintillator volume
+  std::vector<Hit>* mHits;                                  //!<! Collection of EMCAL hits
+  Geometry* mGeometry;                                      //!<! Geometry pointer
+  std::unordered_map<int, int> mSuperParentsIndices;        //!<! Super parent indices (track index - superparent index)
+  std::unordered_map<int, Parent> mSuperParents;            //!<! Super parent kine info (superparent index - superparent object)
+  Parent* mCurrentSuperparent;                              //!<! Pointer to the current superparent
 
   // Worker variables during hit creation
   Int_t mCurrentTrack;     //!<! Current track

--- a/Detectors/EMCAL/simulation/src/Detector.cxx
+++ b/Detectors/EMCAL/simulation/src/Detector.cxx
@@ -150,7 +150,7 @@ void Detector::ConstructGeometry()
   SpaceFrame emcalframe;
   emcalframe.CreateGeometry();
 
-  CreateEmcalEnvelope();
+  //CreateEmcalEnvelope();
 
   // COMPACT, TRD1
   LOG(DEBUG2) << "Shish-Kebab geometry : " << GetTitle();
@@ -448,8 +448,14 @@ void Detector::CreateShiskebabGeometry()
   //  idAL = 1602;
   Double_t par[10], xpos = 0., ypos = 0., zpos = 0.;
 
-  LOG(DEBUG2) << "Name of mother volume: " << g->GetNameOfEMCALEnvelope();
-  CreateSupermoduleGeometry(g->GetNameOfEMCALEnvelope());
+  std::string mothervolume;
+  if (contains(g->GetName(), "WSUC")) {
+    mothervolume = "WSUC";
+  } else {
+    mothervolume = "cave";
+  }
+  LOG(DEBUG2) << "Name of mother volume: " << mothervolume;
+  CreateSupermoduleGeometry(mothervolume);
 
   auto SMTypeList = g->GetEMCSystem();
   auto tmpType = NOT_EXISTENT;


### PR DESCRIPTION
Removing EMCAL mother volume XEN (envelope) and putting the supermodules directly into cave. Creating EMCAL mother volumes would always run into overlaps with PHOS/CPV.