### PR TITLE
Remove redundant memcleans in TPCClusterFinder

### DIFF
--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFNoiseSuppression.cxx
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFNoiseSuppression.cxx
@@ -32,7 +32,7 @@ template <>
 GPUd() void GPUTPCCFNoiseSuppression::Thread<GPUTPCCFNoiseSuppression::updatePeaks>(int nBlocks, int nThreads, int iBlock, int iThread, GPUTPCSharedMemory& smem, processorType& clusterer)
 {
   Array2D<uchar> isPeakMap(clusterer.mPpeakMap);
-  GPUTPCCFNoiseSuppression::updatePeaksImpl(get_num_groups(0), get_local_size(0), get_group_id(0), get_local_id(0), clusterer.mPpeaks, clusterer.mPisPeak, isPeakMap);
+  GPUTPCCFNoiseSuppression::updatePeaksImpl(get_num_groups(0), get_local_size(0), get_group_id(0), get_local_id(0), clusterer.mPpeaks, clusterer.mPisPeak, clusterer.mPmemory->counters.nPeaks, isPeakMap);
 }
 
 GPUd() void GPUTPCCFNoiseSuppression::noiseSuppressionImpl(int nBlocks, int nThreads, int iBlock, int iThread, GPUTPCSharedMemory& smem,
@@ -90,9 +90,14 @@ GPUd() void GPUTPCCFNoiseSuppression::noiseSuppressionImpl(int nBlocks, int nThr
 GPUd() void GPUTPCCFNoiseSuppression::updatePeaksImpl(int nBlocks, int nThreads, int iBlock, int iThread,
                                                       const Digit* peaks,
                                                       const uchar* isPeak,
+                                                      const uint peakNum,
                                                       Array2D<uchar>& peakMap)
 {
   size_t idx = get_global_id(0);
+
+  if (idx >= peakNum) {
+    return;
+  }
 
   Digit myDigit = peaks[idx];
 

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFNoiseSuppression.h
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFNoiseSuppression.h
@@ -60,7 +60,7 @@ class GPUTPCCFNoiseSuppression : GPUKernelTemplate
 
   static GPUd() void noiseSuppressionImpl(int, int, int, int, GPUTPCSharedMemory&, const Array2D<PackedCharge>&, const Array2D<uchar>&, const deprecated::Digit*, const uint, uchar*);
 
-  static GPUd() void updatePeaksImpl(int, int, int, int, const deprecated::Digit*, const uchar*, Array2D<uchar>&);
+  static GPUd() void updatePeaksImpl(int, int, int, int, const deprecated::Digit*, const uchar*, const uint, Array2D<uchar>&);
 
  private:
   static GPUd() void checkForMinima(float, float, PackedCharge, int, ulong*, ulong*);


### PR DESCRIPTION
@davidrohr This PR removes redundant memcleans in the TPCClusterFinder. They were required because of a buffer overflow in the noise suppresion which is now fixed as well.

Also I removed additional memcleans that are already handled by the `resetMaps` kernel.