### PR TITLE
[MRRTF-87] [O2-972] Initial support for MCH Raw Data Encoder

### DIFF
--- a/Detectors/MUON/MCH/Raw/Encoder/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Raw/Encoder/CMakeLists.txt
@@ -1,0 +1,66 @@
+# Copyright CERN and copyright holders of ALICE O2. This software is distributed
+# under the terms of the GNU General Public License v3 (GPL Version 3), copied
+# verbatim in the file "COPYING".
+#
+# See http://alice-o2.web.cern.ch/license for full licensing information.
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization or
+# submit itself to any jurisdiction.
+
+o2_add_library(MCHRawEncoder
+        SOURCES
+        Payload/Encoder.cxx
+        Payload/BitSet.cxx
+        Payload/ElinkEncoder.cxx
+        Payload/DataBlock.cxx
+        PUBLIC_LINK_LIBRARIES O2::MCHRawCommon O2::MCHMappingFactory
+        O2::MCHRawElecMap
+        O2::MCHBase
+        O2::CommonDataFormat
+        O2::DetectorsRaw
+        PRIVATE_LINK_LIBRARIES O2::MCHRawImplHelpers)
+
+if(BUILD_TESTING)
+
+        o2_add_test(elink-encoder
+                SOURCES Payload/testElinkEncoder.cxx
+                COMPONENT_NAME mchraw
+                LABELS "muon;mch;raw"
+                PUBLIC_LINK_LIBRARIES O2::MCHRawEncoder O2::MCHRawImplHelpers)
+
+        o2_add_test(gbt-encoder
+                SOURCES Payload/testGBTEncoder.cxx
+                COMPONENT_NAME mchraw
+                LABELS "muon;mch;raw"
+                PUBLIC_LINK_LIBRARIES O2::MCHRawEncoder O2::MCHTestRawRefBuffers
+                O2::MCHRawImplHelpers)
+
+        o2_add_test(encoder
+                SOURCES Payload/testEncoder.cxx Payload/CruBufferCreator.cxx
+                COMPONENT_NAME mchraw
+                LABELS "muon;mch;raw"
+                PUBLIC_LINK_LIBRARIES O2::MCHRawEncoder O2::MCHRawImplHelpers)
+
+        o2_add_test(bitset
+                SOURCES Payload/testBitSet.cxx
+                COMPONENT_NAME mchraw
+                LABELS "muon;mch;raw"
+                PUBLIC_LINK_LIBRARIES O2::MCHRawEncoder)
+
+        o2_add_test(bare-elink-encoder
+                SOURCES Payload/testBareElinkEncoder.cxx
+                COMPONENT_NAME mchraw
+                LABELS "muon;mch;raw"
+                PUBLIC_LINK_LIBRARIES O2::MCHRawEncoder O2::MCHRawImplHelpers)
+
+endif()
+
+if(benchmark_FOUND)
+        o2_add_executable(bitset
+                COMPONENT_NAME mchraw
+                SOURCES Payload/benchBitSet.cxx
+                PUBLIC_LINK_LIBRARIES O2::MCHRawEncoder benchmark::benchmark
+                IS_BENCHMARK)
+endif()
+

--- a/Detectors/MUON/MCH/Raw/Encoder/Payload/BareElinkEncoder.h
+++ b/Detectors/MUON/MCH/Raw/Encoder/Payload/BareElinkEncoder.h
@@ -1,0 +1,264 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_MCH_RAW_BARE_ELINK_ENCODER_H
+#define O2_MCH_RAW_BARE_ELINK_ENCODER_H
+
+#include "ElinkEncoder.h"
+#include "Assertions.h"
+#include "BitSet.h"
+#include "MCHRawCommon/DataFormats.h"
+#include "MCHRawCommon/SampaCluster.h"
+#include "MCHRawCommon/SampaHeader.h"
+#include "NofBits.h"
+#include <fmt/format.h>
+#include <fmt/printf.h>
+#include <gsl/span>
+#include <iostream>
+#include <vector>
+
+namespace o2::mch::raw
+{
+
+/// @brief Center piece of the MCH Bare Raw Data Format encoder logic.
+///
+/// Converts the data from one SampaCluster into a bit stream
+/// that mimics the way Elinks see data.
+
+template <typename CHARGESUM>
+class ElinkEncoder<BareFormat, CHARGESUM>
+{
+ public:
+  /// Constructs an Encoder for one Elink.
+  ///
+  /// \param elinkId is the elink identifier and _must_ be between 0 and 39
+  /// \param phase can be used to simulate a different time alignment
+  /// between elinks
+  ///
+  /// if elinkId is not within allowed range an exception is thrown.
+  explicit ElinkEncoder(uint8_t elinkId, int phase = 0);
+
+  /// addChannelData converts the SampaCluster data into a bit sequence.
+  ///
+  /// \param chId is the Sampa channel to associated this data with
+  /// \param data is a vector of SampaCluster representing the SampaCluster(s)
+  /// of this channel within one Sampa time window.
+  void addChannelData(uint8_t chId, const std::vector<SampaCluster>& data);
+
+  /// Empty the bit stream.
+  void clear();
+
+  /// fillWithSync appends bits from the sync word until the length
+  /// is `upto`
+  void fillWithSync(int upto);
+
+  /// get the i-th bit in our bit stream.
+  bool get(int i) const;
+
+  /// len returns the number of bits we have in our bit stream
+  int len() const;
+
+  /// reset our local bunch crossing counter
+  void resetLocalBunchCrossing();
+
+  /// converts the bits within a range into an integer value.
+  /// throws if the range [a,b] does not fit within 64 bits.
+  uint64_t range(int a, int b) const;
+
+ private:
+  void append(bool value);
+  void append(const SampaCluster& sc);
+  void append10(uint16_t value);
+  void append20(uint32_t value);
+  void append50(uint64_t value);
+  void appendCharges(const SampaCluster& sc);
+  void assertPhase();
+  void assertSync();
+  uint64_t nofSync() const { return mNofSync; }
+
+ private:
+  uint8_t mElinkId;             //< Elink id 0..39
+  BitSet mBitSet;               //< bitstream
+  uint64_t mNofSync;            //< number of sync words seen so far
+  int mSyncIndex;               //< at which sync bit position should the next fillWithSync start
+  uint64_t mNofBitSeen;         //< total number of bits seen so far
+  int mPhase;                   //< initial number of bits
+  uint32_t mLocalBunchCrossing; //< bunchcrossing to be used in header
+};
+
+namespace
+{
+const BitSet sync(sampaSync().uint64(), 50);
+}
+
+template <typename CHARGESUM>
+ElinkEncoder<BareFormat, CHARGESUM>::ElinkEncoder(uint8_t elinkId,
+                                                  int phase)
+  : mElinkId(elinkId),
+    mBitSet{},
+    mNofSync{0},
+    mSyncIndex{0},
+    mNofBitSeen{0},
+    mLocalBunchCrossing{0},
+    mPhase{phase}
+{
+  impl::assertIsInRange("elinkId", elinkId, 0, 39);
+
+  // the phase is used to "simulate" a possible different timing alignment between elinks.
+
+  if (phase < 0) {
+    mPhase = static_cast<int>(rand() % 20);
+  }
+
+  for (int i = 0; i < mPhase; i++) {
+    // filling the phase with random bits
+    append(static_cast<bool>(rand() % 2));
+  }
+}
+
+template <typename CHARGESUM>
+void ElinkEncoder<BareFormat, CHARGESUM>::addChannelData(uint8_t chId, const std::vector<SampaCluster>& data)
+{
+  if (data.empty()) {
+    throw std::invalid_argument("cannot add empty data");
+  }
+  assertSync();
+  assertNotMixingClusters<CHARGESUM>(data);
+
+  auto header = buildHeader(mElinkId, chId, data);
+
+  append50(header.uint64());
+
+  for (const auto& s : data) {
+    append(s);
+  }
+}
+
+/// append the data of a SampaCluster
+template <typename CHARGESUM>
+void ElinkEncoder<BareFormat, CHARGESUM>::append(const SampaCluster& sc)
+{
+  append10(sc.nofSamples());
+  append10(sc.timestamp);
+  appendCharges(sc);
+}
+
+template <>
+void ElinkEncoder<BareFormat, ChargeSumMode>::appendCharges(const SampaCluster& sc)
+{
+  append20(sc.chargeSum);
+}
+
+template <>
+void ElinkEncoder<BareFormat, SampleMode>::appendCharges(const SampaCluster& sc)
+{
+  for (auto& s : sc.samples) {
+    append10(s);
+  }
+}
+
+/// append one bit (either set or unset)
+template <typename CHARGESUM>
+void ElinkEncoder<BareFormat, CHARGESUM>::append(bool value)
+{
+  mBitSet.append(value);
+  mNofBitSeen++;
+}
+
+/// append 10 bits (if value is more than 10 bits an exception is thrown)
+template <typename CHARGESUM>
+void ElinkEncoder<BareFormat, CHARGESUM>::append10(uint16_t value)
+{
+  mBitSet.append(value, 10);
+  mNofBitSeen += 10;
+}
+
+/// append 20 bits (if value is more than 20 bits an exception is thrown)
+template <typename CHARGESUM>
+void ElinkEncoder<BareFormat, CHARGESUM>::append20(uint32_t value)
+{
+  mBitSet.append(value, 20);
+  mNofBitSeen += 20;
+}
+
+/// append 50 bits (if value is more than 50 bits an exception is thrown)
+template <typename CHARGESUM>
+void ElinkEncoder<BareFormat, CHARGESUM>::append50(uint64_t value)
+{
+  mBitSet.append(value, 50);
+  mNofBitSeen += 50;
+}
+
+template <typename CHARGESUM>
+void ElinkEncoder<BareFormat, CHARGESUM>::assertSync()
+{
+  bool firstSync = (mNofSync == 0);
+
+  // if mSyncIndex is not zero it means
+  // we have a pending sync to finish to transmit
+  // (said otherwise we're not aligned to an expected 50bits mark)
+  bool pendingSync = (mSyncIndex != 0);
+
+  if (firstSync || pendingSync) {
+    for (int i = mSyncIndex; i < 50; i++) {
+      append(sync.get(i));
+    }
+    mSyncIndex = 0;
+    if (firstSync) {
+      mNofSync++;
+    }
+  }
+}
+
+template <typename CHARGESUM>
+void ElinkEncoder<BareFormat, CHARGESUM>::clear()
+{
+  // we are not resetting the global counters mNofSync, mNofBitSeen,
+  // just the bit stream
+  mBitSet.clear();
+}
+
+template <typename CHARGESUM>
+void ElinkEncoder<BareFormat, CHARGESUM>::fillWithSync(int upto)
+{
+  auto d = upto - len();
+  mSyncIndex = circularAppend(mBitSet, sync, mSyncIndex, d);
+  mNofSync += d / 50;
+  mNofBitSeen += d;
+}
+
+template <typename CHARGESUM>
+bool ElinkEncoder<BareFormat, CHARGESUM>::get(int i) const
+{
+  impl::assertIsInRange("i", i, 0, len() - 1);
+  return mBitSet.get(i);
+}
+
+template <typename CHARGESUM>
+int ElinkEncoder<BareFormat, CHARGESUM>::len() const
+{
+  return mBitSet.len();
+}
+
+template <typename CHARGESUM>
+uint64_t ElinkEncoder<BareFormat, CHARGESUM>::range(int a, int b) const
+{
+  return mBitSet.subset(a, b).uint64(0, b - a + 1);
+}
+
+template <typename CHARGESUM>
+void ElinkEncoder<BareFormat, CHARGESUM>::resetLocalBunchCrossing()
+{
+  mLocalBunchCrossing = mPhase;
+}
+
+} // namespace o2::mch::raw
+
+#endif

--- a/Detectors/MUON/MCH/Raw/Encoder/Payload/BareElinkEncoderMerger.h
+++ b/Detectors/MUON/MCH/Raw/Encoder/Payload/BareElinkEncoderMerger.h
@@ -1,0 +1,97 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_MCH_RAW_ENCODER_BARE_ELINK_ENCODER_MERGER_H
+#define O2_MCH_RAW_ENCODER_BARE_ELINK_ENCODER_MERGER_H
+
+#include "ElinkEncoder.h"
+#include "ElinkEncoderMerger.h"
+#include "MCHRawCommon/DataFormats.h"
+#include <gsl/span>
+
+namespace o2::mch::raw
+{
+
+template <typename CHARGESUM>
+bool areElinksAligned(gsl::span<ElinkEncoder<BareFormat, CHARGESUM>> elinks)
+{
+  auto len = elinks[0].len();
+  for (auto i = 1; i < elinks.size(); i++) {
+    if (elinks[i].len() != len) {
+      return false;
+    }
+  }
+  return true;
+}
+
+template <typename CHARGESUM>
+void align(gsl::span<ElinkEncoder<BareFormat, CHARGESUM>> elinks)
+{
+  if (areElinksAligned(elinks)) {
+    return;
+  }
+  auto e = std::max_element(elinks.begin(), elinks.end(),
+                            [](const ElinkEncoder<BareFormat, CHARGESUM>& a, const ElinkEncoder<BareFormat, CHARGESUM>& b) {
+                              return a.len() < b.len();
+                            });
+
+  // align all elink sizes by adding sync bits
+  for (auto& elink : elinks) {
+    elink.fillWithSync(e->len());
+  }
+}
+
+template <typename CHARGESUM>
+uint64_t aggregate(gsl::span<ElinkEncoder<BareFormat, CHARGESUM>> elinks, int jstart, int jend, int i)
+{
+  uint64_t w{0};
+  for (int j = jstart; j < jend; j += 2) {
+    for (int k = 0; k <= 1; k++) {
+      bool v = elinks[j / 2].get(i + 1 - k);
+      uint64_t mask = static_cast<uint64_t>(1) << (j + k);
+      if (v) {
+        w |= mask;
+      } else {
+        w &= ~mask;
+      }
+    }
+  }
+  return w;
+}
+
+template <typename CHARGESUM>
+void elink2gbt(gsl::span<ElinkEncoder<BareFormat, CHARGESUM>> elinks, std::vector<uint64_t>& b64)
+{
+  int n = elinks[0].len();
+
+  for (int i = 0; i < n - 1; i += 2) {
+    uint64_t w0 = aggregate(elinks, 0, 64, i);
+    uint64_t w1 = aggregate(elinks, 64, 80, i);
+    b64.push_back(w0);
+    b64.push_back(w1);
+  }
+}
+
+template <typename CHARGESUM>
+struct ElinkEncoderMerger<BareFormat, CHARGESUM> {
+  void operator()(uint16_t gbtId,
+                  gsl::span<ElinkEncoder<BareFormat, CHARGESUM>> elinks,
+                  std::vector<uint64_t>& b64)
+  {
+    // align sizes of all elinks by adding sync bits
+    align(elinks);
+
+    // convert elinks to GBT words
+    elink2gbt(elinks, b64);
+  }
+};
+
+} // namespace o2::mch::raw
+#endif

--- a/Detectors/MUON/MCH/Raw/Encoder/Payload/BitSet.cxx
+++ b/Detectors/MUON/MCH/Raw/Encoder/Payload/BitSet.cxx
@@ -1,0 +1,471 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "BitSet.h"
+#include <algorithm>
+#include <cmath>
+#include <fmt/format.h>
+#include <iostream>
+#include <stdexcept>
+#include "NofBits.h"
+#include "MCHRawCommon/SampaHeader.h"
+
+namespace o2::mch::raw
+{
+
+namespace
+{
+
+template <typename T>
+void assertRange(int a, int b, T s)
+{
+  if (a > b || b - a >= sizeof(T) * 8) {
+    throw std::invalid_argument(fmt::format("Range [a,b]=[{0},{1}] is incorrect (max range={2}])", a, b, sizeof(T) * 8));
+  }
+}
+
+template <typename T>
+void setRangeFromIntegerFast(BitSet& bs, int a, int b, T v)
+{
+  assertRange<T>(a, b, v);
+  if (b > bs.size()) {
+    bs.grow(b);
+  }
+  for (int i = 0; i <= b - a; i++) {
+    T check = static_cast<T>(1) << i;
+    bs.setFast(i + a, (v & check) != 0);
+  }
+}
+
+template <typename T>
+T uint(const BitSet& bs, int a, int b)
+{
+  if (b < 0) {
+    b = bs.len() - 1;
+  }
+  if (a < 0 || b < 0 || (b - a) > (sizeof(T) * 8) || a >= bs.size() || b >= bs.size()) {
+    throw std::out_of_range(fmt::format("Range [{0},{1}] out of range. bs.size()={2}", a, b, bs.size()));
+  }
+  T value{0};
+  for (T i = a; i <= b; i++) {
+    if (bs.get(i)) {
+      value |= (static_cast<T>(1) << (i - a));
+    }
+  }
+  return value;
+}
+
+template <typename T>
+int appendT(BitSet& bs, T val, int n)
+{
+  if (n <= 0) {
+    if (val > 0) {
+      n = impl::nofBits(val);
+    } else {
+      n = 1;
+    }
+  }
+
+  if (n > sizeof(T) * 8) {
+    throw std::invalid_argument(fmt::format("n={0} is invalid :  should be between 0 and {1}",
+                                            n, sizeof(T)));
+  }
+
+  for (T i = 0; i < static_cast<T>(n); i++) {
+    T p = static_cast<T>(1) << i;
+    if ((val & p) == p) {
+      bs.append(true);
+    } else {
+      bs.append(false);
+    }
+  }
+  return n;
+} // namespace
+
+bool isValidString(std::string_view s)
+{
+  auto ones = std::count(begin(s), end(s), '1');
+  auto zeros = std::count(begin(s), end(s), '0');
+  return s.size() == ones + zeros;
+}
+
+void assertString(std::string_view s)
+{
+  if (!isValidString(s)) {
+    throw std::invalid_argument(fmt::format("{0} is not a valid bitset string (should only get 0 and 1 in there", s));
+  }
+}
+
+} // namespace
+
+BitSet::BitSet() : mSize(8), mLen(0), mMaxLen(0), mBytes(1)
+{
+}
+
+BitSet::BitSet(uint8_t v, int n) : mSize(n > 0 ? n : 8), mLen(0), mBytes(1)
+{
+  if (n <= 0) {
+    n = 8;
+  }
+  assertRange(1, n - 1, v);
+  setRangeFromUint(0, n - 1, v);
+}
+
+BitSet::BitSet(uint16_t v, int n) : mSize(n > 0 ? n : 16), mLen(0), mBytes(2)
+{
+  if (n <= 0) {
+    n = 16;
+  }
+  assertRange(1, n - 1, v);
+  setRangeFromUint(0, n - 1, v);
+}
+
+BitSet::BitSet(uint32_t v, int n) : mSize(n > 0 ? n : 32), mLen(0), mBytes(4)
+{
+  if (n <= 0) {
+    n = 32;
+  }
+  assertRange(1, n - 1, v);
+  setRangeFromUint(0, n - 1, v);
+}
+
+BitSet::BitSet(uint64_t v, int n) : mSize(n > 0 ? n : 64), mLen(0), mBytes(8)
+{
+  if (n <= 0) {
+    n = 64;
+  }
+  assertRange(1, n - 1, v);
+  setRangeFromUint(0, n - 1, v);
+}
+
+BitSet::BitSet(std::string_view s) : mSize(8), mLen(0), mBytes(1)
+{
+  setRangeFromString(0, s.size() - 1, s);
+}
+
+bool BitSet::operator==(const BitSet& rhs) const
+{
+  if (len() != rhs.len()) {
+    return false;
+  }
+  for (int i = 0; i < len(); i++) {
+    if (get(i) != rhs.get(i)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool BitSet::operator!=(const BitSet& rhs) const
+{
+  return !(*this == rhs);
+}
+
+int BitSet::append(bool val)
+{
+  set(len(), val);
+  return 1;
+}
+
+int BitSet::append(uint8_t val, int n)
+{
+  return appendT<uint8_t>(*this, val, n);
+}
+
+int BitSet::append(uint16_t val, int n)
+{
+  return appendT<uint16_t>(*this, val, n);
+}
+
+int BitSet::append(uint32_t val, int n)
+{
+  return appendT<uint32_t>(*this, val, n);
+}
+
+int BitSet::append(uint64_t val, int n)
+{
+  return appendT<uint64_t>(*this, val, n);
+}
+
+bool BitSet::any() const
+{
+  for (int i = 0; i < len(); i++) {
+    if (get(i)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void BitSet::clear()
+{
+  std::fill(begin(mBytes), end(mBytes), 0);
+  mLen = 0;
+}
+
+int BitSet::count() const
+{
+  int n{0};
+  for (int i = 0; i < len(); i++) {
+    if (get(i)) {
+      n++;
+    }
+  }
+  return n;
+}
+
+bool BitSet::get(int pos) const
+{
+  if (pos < 0 || pos >= size()) {
+    throw std::out_of_range(fmt::format("pos {0} is out of bounds", pos));
+  }
+  auto b = mBytes[pos / 8];
+  return ((b >> (pos % 8)) & 1) == 1;
+}
+
+bool BitSet::grow(int n)
+{
+  if (n <= 0) {
+    throw std::invalid_argument("n should be >= 0");
+  }
+  if (n < size()) {
+    return false;
+  }
+  if (n > BitSet::maxSize()) {
+    throw std::length_error(fmt::format("trying to allocate a bitset of more than {0} bytes", BitSet::maxSize()));
+  }
+  auto nbytes = mBytes.size();
+  while (nbytes * 8 < n) {
+    nbytes *= 2;
+  }
+  mBytes.resize(nbytes, 0);
+  mSize = mBytes.size() * 8;
+  return true;
+}
+
+BitSet BitSet::last(int n) const
+{
+  if (len() < n) {
+    throw std::length_error(fmt::format("cannot get {0} bits out of a bitset of size {1}", n, len()));
+  }
+  auto subbs = subset(len() - n, len() - 1);
+  if (subbs.len() != n) {
+    throw std::logic_error("subset not of the expected len");
+  }
+  return subbs;
+}
+
+void BitSet::pruneFirst(int n)
+{
+  if (len() < n) {
+    throw std::invalid_argument(fmt::format("cannot prune {0} bits", n));
+  }
+  for (int i = 0; i < len() - n; i++) {
+    set(i, get(i + n));
+  }
+  mLen -= n;
+}
+
+void BitSet::set(int pos, bool val)
+{
+  if (pos >= mSize) {
+    grow(pos + 1);
+  }
+  if (pos < 0) {
+    throw std::invalid_argument("pos should be > 0");
+  }
+  setFast(pos, val);
+}
+
+void BitSet::setFast(int pos, bool val)
+{
+  uint8_t ix = pos % 8;
+  uint8_t& b = mBytes[pos / 8];
+
+  uint8_t mask = 1 << ix;
+
+  if (val) {
+    b |= mask;
+  } else {
+    b &= ~mask;
+  }
+
+  if ((pos + 1) > mLen) {
+    mLen = pos + 1;
+    mMaxLen = std::max(mMaxLen, mLen);
+  }
+}
+
+void BitSet::setFromBytes(gsl::span<uint8_t> bytes)
+{
+  if (mSize < bytes.size() * 8) {
+    grow(bytes.size() * 8);
+  }
+  mBytes.clear();
+  std::copy(bytes.begin(), bytes.end(), std::back_inserter(mBytes));
+  mBytes.resize(bytes.size());
+  mLen = mBytes.size() * 8;
+  mMaxLen = std::max(mMaxLen, mLen);
+  mSize = mLen;
+}
+
+void BitSet::setRangeFromString(int a, int b, std::string_view s)
+{
+  assertString(s);
+  if (a > b) {
+    throw std::invalid_argument(fmt::format("range [{0},{1}] is invalid : {0} > {1}", a, b));
+  }
+  if (b - a + 1 != s.size()) {
+    throw std::invalid_argument(fmt::format("range [{0},{1}] is not the same size as string={2}", a, b, s));
+  }
+  if (a >= size() || b >= size()) {
+    grow(b);
+  }
+  for (int i = 0; i < s.size(); i++) {
+    set(i + a, s[i] == '1');
+  }
+}
+
+void BitSet::setRangeFromUint(int a, int b, uint8_t v)
+{
+  setRangeFromIntegerFast<uint8_t>(*this, a, b, v);
+}
+
+void BitSet::setRangeFromUint(int a, int b, uint16_t v)
+{
+  setRangeFromIntegerFast<uint16_t>(*this, a, b, v);
+}
+
+void BitSet::setRangeFromUint(int a, int b, uint32_t v)
+{
+  setRangeFromIntegerFast<uint32_t>(*this, a, b, v);
+}
+
+void BitSet::setRangeFromUint(int a, int b, uint64_t v)
+{
+  setRangeFromIntegerFast<uint64_t>(*this, a, b, v);
+}
+
+std::string BitSet::stringLSBLeft() const
+{
+  std::string s{""};
+  for (int i = 0; i < len(); i++) {
+    if (get(i)) {
+      s += "1";
+    } else {
+      s += "0";
+    }
+  }
+  return s;
+}
+
+std::string BitSet::stringLSBRight() const
+{
+  std::string s{""};
+  for (int i = len() - 1; i >= 0; i--) {
+    if (get(i)) {
+      s += "1";
+    } else {
+      s += "0";
+    }
+  }
+  return s;
+}
+
+BitSet BitSet::subset(int a, int b) const
+{
+  if (a >= size() || b > size() || b < a) {
+    auto msg = fmt::format("BitSet::subset : range [{},{}] is incorrect. size={}", a, b, size());
+    throw std::invalid_argument(msg);
+  }
+  BitSet sub;
+  sub.grow(b - a);
+  for (int i = a; i <= b; i++) {
+    sub.set(i - a, get(i));
+  }
+  return sub;
+}
+
+uint8_t BitSet::uint8(int a, int b) const
+{
+  return uint<uint8_t>(*this, a, b);
+}
+
+uint16_t BitSet::uint16(int a, int b) const
+{
+  return uint<uint16_t>(*this, a, b);
+}
+
+uint32_t BitSet::uint32(int a, int b) const
+{
+  return uint<uint32_t>(*this, a, b);
+}
+
+uint64_t BitSet::uint64(int a, int b) const
+{
+  return uint<uint64_t>(*this, a, b);
+}
+
+// append n bits to BitSet bs.
+// those n bits are taken from ringBuffer, starting at ringBuffer[startBit]
+// return the value of startBit to be used for a future call to this method
+// so the sequence of ringBuffer is not lost.
+int circularAppend(BitSet& bs, const BitSet& ringBuffer, int startBit, int n)
+{
+  int ix = startBit;
+
+  while (n > 0) {
+    bs.append(ringBuffer.get(ix));
+    --n;
+    ix++;
+    ix %= ringBuffer.len();
+  }
+  return ix;
+}
+
+std::ostream& operator<<(std::ostream& os, const BitSet& bs)
+{
+  os << bs.stringLSBLeft();
+  return os;
+}
+
+std::string compactString(const BitSet& bs)
+{
+  // replaces multiple sync patterns by nxSYNC
+  static BitSet syncWord(sampaSync().uint64(), 50);
+
+  if (bs.size() < 49) {
+    return bs.stringLSBLeft();
+  }
+  std::string s;
+
+  int i = 0;
+  int nsync = 0;
+  while (i + 49 < bs.len()) {
+    bool sync{false};
+    while (i + 49 < bs.len() && bs.subset(i, i + 49) == syncWord) {
+      i += 50;
+      nsync++;
+      sync = true;
+    }
+    if (sync) {
+      s += fmt::format("[{}SYNC]", nsync);
+    } else {
+      nsync = 0;
+      s += bs.get(i) ? "1" : "0";
+      i++;
+    }
+  }
+  for (int j = i; j < bs.len(); j++) {
+    s += bs.get(j) ? "1" : "0";
+  }
+  return s;
+}
+} // namespace o2::mch::raw

--- a/Detectors/MUON/MCH/Raw/Encoder/Payload/BitSet.h
+++ b/Detectors/MUON/MCH/Raw/Encoder/Payload/BitSet.h
@@ -1,0 +1,175 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_MCH_RAW_BITSET_H
+#define O2_MCH_RAW_BITSET_H
+
+#include <cstdlib>
+#include <gsl/span>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace o2
+{
+namespace mch
+{
+namespace raw
+{
+
+class BitSet
+{
+
+ public:
+  BitSet();
+
+  // construct a BitSet using a string composed of '0' (meaning
+  // bit unset) and '1' (meaning bit set) characters
+  // the length of the resulting bitset is that of the string.
+  explicit BitSet(std::string_view s);
+
+  ///@{
+  // construct a bitset initialized with the x-bits value v
+  explicit BitSet(uint8_t v, int n = -1);
+  explicit BitSet(uint16_t v, int n = -1);
+  explicit BitSet(uint32_t v, int n = -1);
+  explicit BitSet(uint64_t v, int n = -1);
+  ///@}
+
+ public:
+  // check equality
+  bool operator==(const BitSet& rhs) const;
+  bool operator!=(const BitSet& rhs) const;
+
+  // any returns true if any of the bits is set
+  bool any() const;
+
+  // appends a bit at the current position (i.e. len-1)
+  int append(bool val);
+
+  ///@{
+  // appends the n first bits from a x-bits word.
+  // if n is < 0 it is computed for val (using log2(val)+1)
+  // otherwise it should be >= log2(val)+1 and <=x
+  // and the exact number of specified bits will be set
+  // (to 0 or 1).
+  // returns the number of bits actually added
+  int append(uint8_t val, int n = -1);
+  int append(uint16_t val, int n = -1);
+  int append(uint32_t val, int n = -1);
+  int append(uint64_t val, int n = -1);
+  ///@}
+
+  // count returns the number of bits set at 1
+  int count() const;
+
+  // sets all the bits to false (i.e. resets)
+  void clear();
+
+  // returns true if we hold not bit at all
+  bool isEmpty() const { return len() == 0; }
+
+  // sets the value of the bit at given pos
+  void set(int pos, bool val);
+
+  // gets the value of the bit at given pos
+  bool get(int pos) const;
+
+  // grows the BitSet so it can accomodate at least n bits. Returns true if size changed.
+  bool grow(int n);
+
+  // last returns a bitset containing the last n bits of the bitset
+  // if there's not enough bits, throw an exception
+  BitSet last(int n) const;
+
+  // return the max number of bits this object can currently hold
+  // it is a multiple of 8.
+  int size() const { return mSize; }
+
+  // return the max number of bits any bitset can hold
+  static int maxSize() { return 2 * 8192; }
+
+  // return the number of bits we are current holding
+  int len() const { return mLen; }
+
+  // return the max number of bits we've ever held
+  int maxlen() const { return mMaxLen; }
+
+  // pruneFirst removes the first n bits from the bitset
+  void pruneFirst(int n);
+
+  void setFast(int pos, bool val);
+
+  void setFromBytes(gsl::span<uint8_t> bytes);
+
+  // setRangeFromString populates the bits at indice [a,b] (inclusive range)
+  // from the characters in the string: 0 to unset the bit (=false)
+  // or 1 to set the bit (=true).
+  // A string containing anything else than '0' or '1' is invalid and
+  // triggers an exception
+  void setRangeFromString(int a, int b, std::string_view s);
+
+  ///@{
+  // setRangeFromUint(a,b,uintX_t) populates the bits at indices [a,b] (inclusive range)
+  // with the bits of value v. b-a must be <=X otherwise throws an exception
+  void setRangeFromUint(int a, int b, uint8_t v);
+  void setRangeFromUint(int a, int b, uint16_t v);
+  void setRangeFromUint(int a, int b, uint32_t v);
+  void setRangeFromUint(int a, int b, uint64_t v);
+  ///@}
+
+  // returns a textual representation of the BitSet
+  // where the LSB is on the left
+  std::string stringLSBLeft() const;
+
+  // returns a textual representation of the BitSet
+  // where the LSB is on the right
+  std::string stringLSBRight() const;
+
+  // subset returns a subset of the bitset.
+  // subset is not a slice (i.e. not a reference, but a copy of the internals)
+  // [a,b] inclusive
+  BitSet subset(int a, int b) const;
+
+  // uint8 converts the bit set into a 8-bits value, if possible.
+  // if b is negative, it is set to the bitset length
+  uint8_t uint8(int a, int b) const;
+
+  // uint16 converts the bit set into a 16-bits value, if possible.
+  // if b is negative, it is set to the bitset length
+  uint16_t uint16(int a, int b) const;
+
+  // uint32 converts the bit set into a 32-bits value, if possible.
+  // if b is negative, it is set to the bitset length
+  uint32_t uint32(int a, int b) const;
+
+  // uint64 converts the bit set into a 64-bits value, if possible.
+  // if b is negative, it is set to the bitset length
+  uint64_t uint64(int a, int b) const;
+
+ private:
+  int mSize;   // max number of bits we can hold
+  int mLen;    // actual number of bits we are holding
+  int mMaxLen; // the max number of bits we've ever held
+  std::vector<uint8_t> mBytes;
+  static int nofInstances;
+};
+
+int circularAppend(BitSet& bs, const BitSet& ringBuffer, int startBit, int n);
+
+std::ostream& operator<<(std::ostream& os, const BitSet& bs);
+
+std::string compactString(const BitSet& bs);
+} // namespace raw
+} // namespace mch
+} // namespace o2
+
+#endif

--- a/Detectors/MUON/MCH/Raw/Encoder/Payload/CruBufferCreator.cxx
+++ b/Detectors/MUON/MCH/Raw/Encoder/Payload/CruBufferCreator.cxx
@@ -1,0 +1,70 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "CruBufferCreator.h"
+
+namespace o2::mch::raw::test
+{
+
+std::vector<uint8_t> fillChargeSum(Encoder& encoder, int norbit)
+{
+  uint16_t ts(0);
+  uint16_t bc(678);
+
+  encoder.startHeartbeatFrame(12345, bc);
+
+  encoder.addChannelData(DsElecId{728, 1, 0}, 3, {SampaCluster(ts, 13)});
+  encoder.addChannelData(DsElecId{728, 1, 0}, 13, {SampaCluster(ts, 133)});
+  encoder.addChannelData(DsElecId{728, 1, 0}, 23, {SampaCluster(ts, 163)});
+
+  encoder.addChannelData(DsElecId{361, 0, 4}, 0, {SampaCluster(ts, 10)});
+  encoder.addChannelData(DsElecId{361, 0, 4}, 1, {SampaCluster(ts, 20)});
+  encoder.addChannelData(DsElecId{361, 0, 4}, 2, {SampaCluster(ts, 30)});
+  encoder.addChannelData(DsElecId{361, 0, 4}, 3, {SampaCluster(ts, 40)});
+
+  encoder.addChannelData(DsElecId{448, 6, 2}, 22, {SampaCluster(ts, 420)});
+  encoder.addChannelData(DsElecId{448, 6, 2}, 23, {SampaCluster(ts, 430)});
+  encoder.addChannelData(DsElecId{448, 6, 2}, 24, {SampaCluster(ts, 440)});
+  encoder.addChannelData(DsElecId{448, 6, 2}, 25, {SampaCluster(ts, 450)});
+  encoder.addChannelData(DsElecId{448, 6, 2}, 26, {SampaCluster(ts, 460)});
+  encoder.addChannelData(DsElecId{448, 6, 2}, 12, {SampaCluster(ts, 420)});
+
+  if (norbit > 1) {
+    encoder.startHeartbeatFrame(12346, bc);
+    encoder.addChannelData(DsElecId{728, 1, 2}, 0, {SampaCluster(ts, 10)});
+    encoder.addChannelData(DsElecId{728, 1, 2}, 1, {SampaCluster(ts, 10)});
+    encoder.addChannelData(DsElecId{361, 0, 4}, 0, {SampaCluster(ts, 10)});
+    encoder.addChannelData(DsElecId{361, 0, 4}, 1, {SampaCluster(ts, 20)});
+    encoder.addChannelData(DsElecId{361, 0, 4}, 2, {SampaCluster(ts, 30)});
+    encoder.addChannelData(DsElecId{361, 0, 4}, 3, {SampaCluster(ts, 40)});
+  }
+
+  if (norbit > 2) {
+    encoder.startHeartbeatFrame(12347, bc);
+    encoder.addChannelData(DsElecId{448, 6, 2}, 12, {SampaCluster(ts, 420)});
+  }
+
+  std::vector<uint8_t> buffer;
+  encoder.moveToBuffer(buffer);
+  // int i{0};
+  // for (auto v : buffer) {
+  //   fmt::printf("0x%02X, ", v);
+  //   if (++i % 12 == 0) {
+  //     fmt::printf("\n");
+  //   }
+  // }
+  // forEachDataBlock(buffer, [](DataBlock b) {
+  //   std::cout << b.header << "\n";
+  //   impl::dumpBuffer(b.payload, std::cout);
+  // });
+  return buffer;
+}
+
+} // namespace o2::mch::raw::test

--- a/Detectors/MUON/MCH/Raw/Encoder/Payload/CruBufferCreator.h
+++ b/Detectors/MUON/MCH/Raw/Encoder/Payload/CruBufferCreator.h
@@ -1,0 +1,38 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "MCHRawCommon/DataFormats.h"
+#include "MCHRawEncoder/Encoder.h"
+#include <vector>
+#include <cstdint>
+
+namespace o2::mch::raw::test
+{
+
+std::vector<uint8_t> fillChargeSum(Encoder& encoder, int norbit);
+
+template <typename FORMAT, typename CHARGESUM>
+struct CruBufferCreator {
+  static std::vector<uint8_t> makeBuffer(int norbit = 1);
+};
+
+std::vector<uint8_t> fillChargeSum(Encoder& encoder);
+
+template <typename FORMAT>
+struct CruBufferCreator<FORMAT, ChargeSumMode> {
+  static std::vector<uint8_t> makeBuffer(int norbit = 1)
+  {
+    auto encoder = createEncoder<FORMAT, ChargeSumMode, true>();
+
+    return fillChargeSum(*(encoder.get()), norbit);
+  }
+};
+
+} // namespace o2::mch::raw::test

--- a/Detectors/MUON/MCH/Raw/Encoder/Payload/DataBlock.cxx
+++ b/Detectors/MUON/MCH/Raw/Encoder/Payload/DataBlock.cxx
@@ -1,0 +1,92 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "MCHRawEncoder/DataBlock.h"
+#include <fmt/format.h>
+
+namespace o2::mch::raw
+{
+void appendDataBlockHeader(std::vector<uint8_t>& outBuffer, DataBlockHeader header)
+{
+  gsl::span<uint8_t> ph(reinterpret_cast<uint8_t*>(&header), sizeof(ph));
+  outBuffer.insert(outBuffer.end(), ph.begin(), ph.end());
+}
+
+int forEachDataBlockRef(gsl::span<const uint8_t> buffer,
+                        std::function<void(DataBlockRef ref)> f)
+{
+  int index{0};
+  int nheaders{0};
+  DataBlockHeader header;
+  while (index < buffer.size()) {
+    memcpy(&header, &buffer[index], sizeof(header));
+    nheaders++;
+    if (f) {
+      DataBlock block{header, buffer.subspan(index, header.payloadSize)};
+      DataBlockRef ref{block, index};
+      f(ref);
+    }
+    index += header.payloadSize + sizeof(header);
+  }
+  return nheaders;
+}
+
+int countHeaders(gsl::span<uint8_t> buffer)
+{
+  return forEachDataBlockRef(buffer, nullptr);
+}
+
+std::ostream& operator<<(std::ostream& os, const DataBlockHeader& header)
+{
+  os << fmt::format("ORB{:6d} BC{:4d} FEE{:4d} PAYLOADSIZE{:6d}",
+                    header.orbit, header.bc, header.feeId, header.payloadSize);
+  return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const DataBlock& block)
+{
+  os << block.header;
+  os << fmt::format(" SIZE {:8d}", block.size());
+  return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const DataBlockRef& ref)
+{
+  os << ref.block;
+  if (ref.offset.has_value()) {
+    os << fmt::format(" OFFSET {:8d}", ref.offset.value());
+  }
+  return os;
+}
+
+bool operator<(const DataBlockHeader& a, const DataBlockHeader& b)
+{
+  if (a.feeId < b.feeId) {
+    return true;
+  }
+  if (a.feeId > b.feeId) {
+    return false;
+  }
+  if (a.orbit < b.orbit) {
+    return true;
+  }
+  if (a.orbit > b.orbit) {
+    return false;
+  }
+  return (a.bc < b.bc);
+  // if (a.bc < b.bc) {
+  //   return true;
+  // }
+  // if (a.bc > b.bc) {
+  //   return false;
+  // }
+};
+
+} // namespace o2::mch::raw

--- a/Detectors/MUON/MCH/Raw/Encoder/Payload/ElinkEncoder.cxx
+++ b/Detectors/MUON/MCH/Raw/Encoder/Payload/ElinkEncoder.cxx
@@ -1,0 +1,58 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Assertions.h"
+#include "ElinkEncoder.h"
+#include "MCHRawCommon/DataFormats.h"
+#include "MCHRawCommon/SampaCluster.h"
+#include "MCHRawCommon/SampaHeader.h"
+#include "MCHRawElecMap/DsElecId.h"
+#include "NofBits.h"
+
+namespace
+{
+uint16_t chipAddress(uint8_t elinkId, uint8_t chId)
+{
+  auto opt = o2::mch::raw::indexFromElinkId(elinkId);
+  if (!opt.has_value()) {
+    throw std::invalid_argument(fmt::format("elinkId {} is not valid", elinkId));
+  }
+  return opt.value() * 2 + (chId > 31);
+}
+} // namespace
+
+namespace o2::mch::raw
+{
+
+SampaHeader buildHeader(uint8_t elinkId, uint8_t chId, const std::vector<SampaCluster>& data)
+{
+  impl::assertIsInRange("chId", chId, 0, 63);
+
+  SampaHeader header;
+  header.packetType(SampaPacketType::Data);
+
+  uint16_t n10{0};
+  for (const auto& s : data) {
+    n10 += s.nof10BitWords();
+  }
+  impl::assertNofBits("nof10BitWords", n10, 10);
+  header.nof10BitWords(n10);
+  header.chipAddress(chipAddress(elinkId, chId));
+  header.channelAddress(chId % 32);
+  header.hammingCode(computeHammingCode(header.uint64()));
+  header.headerParity(computeHeaderParity(header.uint64()));
+
+  //header.bunchCrossingCounter(mLocalBunchCrossing); //FIXME: how is this one evolving ?
+  // FIXME: compute payload parity
+
+  return header;
+}
+
+} // namespace o2::mch::raw

--- a/Detectors/MUON/MCH/Raw/Encoder/Payload/ElinkEncoder.h
+++ b/Detectors/MUON/MCH/Raw/Encoder/Payload/ElinkEncoder.h
@@ -1,0 +1,40 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_MCH_RAW_ELINK_ENCODER_H
+#define O2_MCH_RAW_ELINK_ENCODER_H
+
+#include <vector>
+#include <cstdint>
+#include <gsl/span>
+
+namespace o2::mch::raw
+{
+class SampaCluster;
+class SampaHeader;
+
+template <typename FORMAT, typename CHARGESUM>
+class ElinkEncoder
+{
+ public:
+  explicit ElinkEncoder(uint8_t elinkId, uint8_t chip, int phase = 0);
+
+  void addChannelData(uint8_t chId, const std::vector<SampaCluster>& data);
+
+  size_t moveToBuffer(std::vector<uint64_t>& buffer, uint64_t prefix);
+
+  void clear();
+};
+
+SampaHeader buildHeader(uint8_t elinkId, uint8_t chId, const std::vector<SampaCluster>& data);
+
+} // namespace o2::mch::raw
+
+#endif

--- a/Detectors/MUON/MCH/Raw/Encoder/Payload/ElinkEncoderMerger.h
+++ b/Detectors/MUON/MCH/Raw/Encoder/Payload/ElinkEncoderMerger.h
@@ -1,0 +1,32 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_MCH_RAW_ELINK_ENCODER_MERGER_H
+#define O2_MCH_RAW_ELINK_ENCODER_MERGER_H
+
+#include <gsl/span>
+#include <cstdint>
+#include <vector>
+
+namespace o2::mch::raw
+{
+template <typename FORMAT, typename CHARGESUM>
+struct ElinkEncoder;
+
+template <typename FORMAT, typename CHARGESUM>
+struct ElinkEncoderMerger {
+  void operator()(uint16_t gbtId,
+                  gsl::span<ElinkEncoder<FORMAT, CHARGESUM>> elinks,
+                  std::vector<uint64_t>& b64);
+};
+
+} // namespace o2::mch::raw
+
+#endif

--- a/Detectors/MUON/MCH/Raw/Encoder/Payload/Encoder.cxx
+++ b/Detectors/MUON/MCH/Raw/Encoder/Payload/Encoder.cxx
@@ -1,0 +1,57 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "BareElinkEncoder.h"
+#include "BareElinkEncoderMerger.h"
+#include "EncoderImpl.h"
+#include "MCHRawEncoder/Encoder.h"
+#include "UserLogicElinkEncoder.h"
+#include "UserLogicElinkEncoderMerger.h"
+#include <gsl/span>
+
+namespace o2::mch::raw
+{
+namespace impl
+{
+// cannot partially specialize a function, so create a struct (which can
+// be specialized) and use it within the function below.
+
+template <typename FORMAT, typename CHARGESUM, bool forceNoPhase>
+struct EncoderCreator {
+  static std::unique_ptr<Encoder> _()
+  {
+    GBTEncoder<FORMAT, CHARGESUM>::forceNoPhase = forceNoPhase;
+    return std::make_unique<EncoderImpl<FORMAT, CHARGESUM>>();
+  }
+};
+} // namespace impl
+
+template <typename FORMAT, typename CHARGESUM, bool forceNoPhase>
+std::unique_ptr<Encoder> createEncoder()
+{
+  return impl::EncoderCreator<FORMAT, CHARGESUM, forceNoPhase>::_();
+}
+std::unique_ptr<Encoder> createEncoder();
+
+// define only the specializations we use
+
+template std::unique_ptr<Encoder> createEncoder<BareFormat, SampleMode, true>();
+template std::unique_ptr<Encoder> createEncoder<BareFormat, SampleMode, false>();
+
+template std::unique_ptr<Encoder> createEncoder<BareFormat, ChargeSumMode, true>();
+template std::unique_ptr<Encoder> createEncoder<BareFormat, ChargeSumMode, false>();
+
+template std::unique_ptr<Encoder> createEncoder<UserLogicFormat, SampleMode, true>();
+template std::unique_ptr<Encoder> createEncoder<UserLogicFormat, SampleMode, false>();
+
+template std::unique_ptr<Encoder> createEncoder<UserLogicFormat, ChargeSumMode, true>();
+template std::unique_ptr<Encoder> createEncoder<UserLogicFormat, ChargeSumMode, false>();
+
+} // namespace o2::mch::raw

--- a/Detectors/MUON/MCH/Raw/Encoder/Payload/EncoderImpl.h
+++ b/Detectors/MUON/MCH/Raw/Encoder/Payload/EncoderImpl.h
@@ -1,0 +1,136 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_MCH_RAW_CRU_ENCODER_IMPL_H
+#define O2_MCH_RAW_CRU_ENCODER_IMPL_H
+
+#include "Assertions.h"
+#include "GBTEncoder.h"
+#include "MCHRawEncoder/DataBlock.h"
+#include "MCHRawEncoder/Encoder.h"
+#include "MakeArray.h"
+#include <algorithm>
+#include <cstdlib>
+#include <fmt/format.h>
+#include <functional>
+#include <gsl/span>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <optional>
+#include <set>
+#include <vector>
+#include <cassert>
+
+namespace o2::mch::raw
+{
+
+/// @brief (Default) implementation of Encoder
+///
+/// \nosubgrouping
+
+template <typename FORMAT, typename CHARGESUM>
+class EncoderImpl : public Encoder
+{
+ public:
+  EncoderImpl();
+
+  void addChannelData(DsElecId dsId, uint8_t chId, const std::vector<SampaCluster>& data) override;
+
+  void startHeartbeatFrame(uint32_t orbit, uint16_t bunchCrossing) override;
+
+  size_t moveToBuffer(std::vector<uint8_t>& buffer) override;
+
+ private:
+  void closeHeartbeatFrame(uint32_t orbit, uint16_t bunchCrossing);
+  void gbts2buffer(uint32_t orbit, uint16_t bunchCrossing);
+
+ private:
+  uint32_t mOrbit;
+  uint16_t mBunchCrossing;
+  std::vector<uint8_t> mBuffer;
+  std::map<uint16_t, std::unique_ptr<GBTEncoder<FORMAT, CHARGESUM>>> mGBTs;
+  bool mFirstHBFrame;
+};
+
+template <typename FORMAT, typename CHARGESUM>
+EncoderImpl<FORMAT, CHARGESUM>::EncoderImpl()
+  : mOrbit{},
+    mBunchCrossing{},
+    mBuffer{},
+    mGBTs{},
+    mFirstHBFrame{true}
+{
+}
+
+template <typename FORMAT, typename CHARGESUM>
+void EncoderImpl<FORMAT, CHARGESUM>::addChannelData(DsElecId dsId, uint8_t chId, const std::vector<SampaCluster>& data)
+{
+  auto solarId = dsId.solarId();
+  auto gbt = mGBTs.find(solarId);
+  if (gbt == mGBTs.end()) {
+    mGBTs.emplace(solarId, std::make_unique<GBTEncoder<FORMAT, CHARGESUM>>(solarId));
+    gbt = mGBTs.find(solarId);
+  }
+  gbt->second->addChannelData(dsId.elinkGroupId(), dsId.elinkIndexInGroup(), chId, data);
+}
+
+template <typename FORMAT, typename CHARGESUM>
+void EncoderImpl<FORMAT, CHARGESUM>::gbts2buffer(uint32_t orbit, uint16_t bunchCrossing)
+{
+  // append to our own buffer all the words buffers from all our gbts,
+  // prepending each one with a corresponding payload header
+
+  for (auto& p : mGBTs) {
+    auto& gbt = p.second;
+    std::vector<uint8_t> gbtBuffer;
+    gbt->moveToBuffer(gbtBuffer);
+    if (gbtBuffer.empty()) {
+      continue;
+    }
+    assert(gbtBuffer.size() % 4 == 0);
+    DataBlockHeader header{orbit, bunchCrossing, gbt->id(), gbtBuffer.size()};
+    appendDataBlockHeader(mBuffer, header);
+    mBuffer.insert(mBuffer.end(), gbtBuffer.begin(), gbtBuffer.end());
+  }
+}
+
+template <typename FORMAT, typename CHARGESUM>
+size_t EncoderImpl<FORMAT, CHARGESUM>::moveToBuffer(std::vector<uint8_t>& buffer)
+{
+  closeHeartbeatFrame(mOrbit, mBunchCrossing);
+  buffer.insert(buffer.end(), mBuffer.begin(), mBuffer.end());
+  auto s = mBuffer.size();
+  mBuffer.clear();
+  return s;
+}
+
+template <typename FORMAT, typename CHARGESUM>
+void EncoderImpl<FORMAT, CHARGESUM>::closeHeartbeatFrame(uint32_t orbit, uint16_t bunchCrossing)
+{
+  gbts2buffer(orbit, bunchCrossing);
+}
+
+template <typename FORMAT, typename CHARGESUM>
+void EncoderImpl<FORMAT, CHARGESUM>::startHeartbeatFrame(uint32_t orbit, uint16_t bunchCrossing)
+{
+  impl::assertIsInRange("bunchCrossing", bunchCrossing, 0, 0xFFF);
+  // build a buffer with the _previous_ (orbit,bx)
+  if (!mFirstHBFrame) {
+    closeHeartbeatFrame(mOrbit, mBunchCrossing);
+  }
+  mFirstHBFrame = false;
+  // then save the (orbit,bx) for next time
+  mOrbit = orbit;
+  mBunchCrossing = bunchCrossing;
+}
+
+} // namespace o2::mch::raw
+#endif

--- a/Detectors/MUON/MCH/Raw/Encoder/Payload/GBTEncoder.h
+++ b/Detectors/MUON/MCH/Raw/Encoder/Payload/GBTEncoder.h
@@ -1,0 +1,144 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_MCH_RAW_ENCODER_GBT_ENCODER_H
+#define O2_MCH_RAW_ENCODER_GBT_ENCODER_H
+
+#include <array>
+#include <vector>
+#include <cstdlib>
+#include "MCHRawCommon/SampaCluster.h"
+#include "MCHRawCommon/DataFormats.h"
+#include <functional>
+#include <fmt/printf.h>
+#include <stdexcept>
+#include "MakeArray.h"
+#include "Assertions.h"
+#include "MoveBuffer.h"
+#include "ElinkEncoder.h"
+#include "ElinkEncoderMerger.h"
+#include <gsl/span>
+
+namespace o2::mch::raw
+{
+
+/// @brief A GBTEncoder manages 40 ElinkEncoder to encode the data of one GBT.
+///
+/// Channel data is added using the addChannelData() method.
+/// The encoded data (in the form of 64 bits words)
+/// is exported to 8-bits words buffer using the moveToBuffer() method.
+///
+/// \nosubgrouping
+
+template <typename FORMAT, typename CHARGESUM>
+class GBTEncoder
+{
+ public:
+  /// Constructor.
+  /// \param solarId the (unique) id of this GBT (aka Solar)
+  GBTEncoder(uint16_t solarId);
+
+  /** @name Main interface.
+    */
+  ///@{
+  /// add data for one channel.
+  ///
+  /// \param elinkGroupId 0..7
+  /// \param elinkIndexInGroup 0..4
+  /// \param chId 0..63 dualSampa channel
+  /// \param data vector of SampaCluster objects
+  void addChannelData(uint8_t elinkGroupId, uint8_t elinkIndexInGroup, uint8_t chId, const std::vector<SampaCluster>& data);
+
+  /// reset local bunch-crossing counter.
+  ///
+  /// (the one that is used in the sampa headers)
+  void resetLocalBunchCrossing();
+
+  /// Export our encoded data.
+  ///
+  /// The internal GBT words that have been accumulated so far are
+  /// _moved_ (i.e. deleted from this object) to the external buffer of bytes.
+  /// Returns the number of bytes added to buffer
+  size_t moveToBuffer(std::vector<uint8_t>& buffer);
+  ///@}
+
+  /** @name Methods for testing.
+    */
+  ///@{
+  /// Sets to true to bypass simulation of time misalignment of elinks.
+  static bool forceNoPhase;
+  ///@}
+
+  /// returns the GBT id
+  uint16_t id() const { return mGbtId; }
+
+  /// return the number of bytes our current buffer is
+  size_t size() const { return mGbtWords.size(); }
+
+ private:
+  uint16_t mGbtId;                                         //< id of this GBT (0..23)
+  std::array<ElinkEncoder<FORMAT, CHARGESUM>, 40> mElinks; //< the 40 Elinks we manage
+  std::vector<uint64_t> mGbtWords;                         //< the GBT words (each GBT word of 80 bits is represented by 2 64 bits words) we've accumulated so far
+  ElinkEncoderMerger<FORMAT, CHARGESUM> mElinkMerger;
+};
+
+inline int phase(int i, bool forceNoPhase)
+{
+  // generate the phase for the i-th ElinkEncoder
+  // the default value of -1 means it will be random and decided
+  // by the ElinkEncoder ctor
+  //
+  // if > 0 it will set a fixed phase at the beginning of the life
+  // of the ElinkEncoder
+  //
+  // returning zero will simply disable the phase
+
+  if (forceNoPhase) {
+    return 0;
+  }
+  return -1;
+}
+
+template <typename FORMAT, typename CHARGESUM>
+bool GBTEncoder<FORMAT, CHARGESUM>::forceNoPhase = false;
+
+template <typename FORMAT, typename CHARGESUM>
+GBTEncoder<FORMAT, CHARGESUM>::GBTEncoder(uint16_t linkId)
+  : mGbtId(linkId),
+    mElinks{impl::makeArray<40>([](size_t i) { return ElinkEncoder<FORMAT, CHARGESUM>(i, phase(i, GBTEncoder<FORMAT, CHARGESUM>::forceNoPhase)); })},
+    mGbtWords{},
+    mElinkMerger{}
+{
+}
+
+template <typename FORMAT, typename CHARGESUM>
+void GBTEncoder<FORMAT, CHARGESUM>::addChannelData(uint8_t elinkGroupId, uint8_t elinkIndexInGroup, uint8_t chId,
+                                                   const std::vector<SampaCluster>& data)
+{
+
+  impl::assertIsInRange("elinkGroupId", elinkGroupId, 0, 7);
+  impl::assertIsInRange("elinkIndexInGroup", elinkIndexInGroup, 0, 4);
+  mElinks.at(elinkGroupId * 5 + elinkIndexInGroup).addChannelData(chId, data);
+}
+
+template <typename FORMAT, typename CHARGESUM>
+size_t GBTEncoder<FORMAT, CHARGESUM>::moveToBuffer(std::vector<uint8_t>& buffer)
+{
+  auto s = gsl::span(mElinks.begin(), mElinks.end());
+  mElinkMerger(mGbtId, s, mGbtWords);
+  for (auto& elink : mElinks) {
+    elink.clear();
+  }
+  return impl::moveBuffer(mGbtWords, buffer);
+}
+
+} // namespace o2::mch::raw
+
+#endif

--- a/Detectors/MUON/MCH/Raw/Encoder/Payload/UserLogicElinkEncoder.h
+++ b/Detectors/MUON/MCH/Raw/Encoder/Payload/UserLogicElinkEncoder.h
@@ -1,0 +1,148 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_MCH_RAW_USER_LOGIC_ELINK_ENCODER_H
+#define O2_MCH_RAW_USER_LOGIC_ELINK_ENCODER_H
+
+#include "ElinkEncoder.h"
+#include "Assertions.h"
+#include "MCHRawCommon/SampaCluster.h"
+#include "MCHRawCommon/SampaHeader.h"
+#include "MCHRawCommon/DataFormats.h"
+#include "MoveBuffer.h"
+#include "NofBits.h"
+#include <cstdlib>
+#include <vector>
+#include <fmt/printf.h>
+
+namespace o2::mch::raw
+{
+
+template <typename CHARGESUM>
+class ElinkEncoder<UserLogicFormat, CHARGESUM>
+{
+ public:
+  explicit ElinkEncoder(uint8_t elinkId, int phase = 0);
+
+  void addChannelData(uint8_t chId, const std::vector<SampaCluster>& data);
+
+  size_t moveToBuffer(std::vector<uint64_t>& buffer, uint64_t prefix);
+
+  void clear();
+
+ private:
+  uint8_t mElinkId; //< Elink id 0..39
+  bool mHasSync;    //< whether or not we've already added a sync word
+  std::vector<uint64_t> mBuffer;
+  int mCurrent10BitIndex; // 0..4
+};
+
+namespace
+{
+uint64_t dsId64(int dsId)
+{
+  return (static_cast<uint64_t>(dsId & 0x3F) << 53);
+}
+
+uint64_t error64(int error)
+{
+  return (static_cast<uint64_t>(error & 0x7) << 50);
+}
+} // namespace
+
+template <typename CHARGESUM>
+ElinkEncoder<UserLogicFormat, CHARGESUM>::ElinkEncoder(uint8_t elinkId,
+                                                       int phase)
+  : mElinkId{elinkId},
+    mHasSync{false},
+    mBuffer{},
+    mCurrent10BitIndex{4}
+{
+  impl::assertIsInRange("elinkId", elinkId, 0, 39);
+}
+
+void append(uint64_t prefix, std::vector<uint64_t>& buffer, int& index, uint64_t& word, int data)
+{
+  word |= static_cast<uint64_t>(data) << (index * 10);
+  --index;
+  if (index < 0) {
+    buffer.emplace_back(prefix | word);
+    index = 4;
+    word = 0;
+  }
+}
+
+template <typename CHARGESUM>
+void ElinkEncoder<UserLogicFormat, CHARGESUM>::addChannelData(uint8_t chId,
+                                                              const std::vector<SampaCluster>& data)
+{
+  if (data.empty()) {
+    throw std::invalid_argument("cannot add empty data");
+  }
+  assertNotMixingClusters<CHARGESUM>(data);
+
+  int error{0}; // FIXME: what to do with error ?
+
+  uint64_t b9 = dsId64(mElinkId) | error64(error);
+
+  const uint64_t sync = sampaSync().uint64();
+
+  if (!mHasSync) {
+    mBuffer.emplace_back(b9 | sync);
+    mHasSync = true;
+  }
+
+  auto header = buildHeader(mElinkId, chId, data);
+  mBuffer.emplace_back(b9 | header.uint64());
+
+  mCurrent10BitIndex = 4;
+  CHARGESUM chargeSum;
+  uint64_t word{0};
+  for (auto& cluster : data) {
+    append(b9, mBuffer, mCurrent10BitIndex, word, cluster.nofSamples());
+    append(b9, mBuffer, mCurrent10BitIndex, word, cluster.timestamp);
+    if (chargeSum() == true) {
+      append(b9, mBuffer, mCurrent10BitIndex, word, cluster.chargeSum & 0x3FF);
+      append(b9, mBuffer, mCurrent10BitIndex, word, (cluster.chargeSum & 0xFFC00) >> 10);
+    } else {
+      for (auto& s : cluster.samples) {
+        append(b9, mBuffer, mCurrent10BitIndex, word, s);
+      }
+    }
+  }
+  while (mCurrent10BitIndex != 4) {
+    append(b9, mBuffer, mCurrent10BitIndex, word, 0);
+  }
+}
+
+template <typename CHARGESUM>
+void ElinkEncoder<UserLogicFormat, CHARGESUM>::clear()
+{
+  mBuffer.clear();
+  mHasSync = false;
+}
+
+template <typename CHARGESUM>
+size_t ElinkEncoder<UserLogicFormat, CHARGESUM>::moveToBuffer(std::vector<uint64_t>& buffer, uint64_t prefix)
+{
+  if (mBuffer.empty()) {
+    return 0;
+  }
+  auto n = buffer.size();
+  buffer.reserve(n + mBuffer.size());
+  for (auto& b : mBuffer) {
+    buffer.emplace_back(b | prefix);
+  }
+  clear();
+  return buffer.size() - n;
+}
+} // namespace o2::mch::raw
+
+#endif

--- a/Detectors/MUON/MCH/Raw/Encoder/Payload/UserLogicElinkEncoderMerger.h
+++ b/Detectors/MUON/MCH/Raw/Encoder/Payload/UserLogicElinkEncoderMerger.h
@@ -1,0 +1,35 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_MCH_RAW_ENCODER_USER_LOGIC_ENCODER_MERGER_H
+#define O2_MCH_RAW_ENCODER_USER_LOGIC_ENCODER_MERGER_H
+
+#include "UserLogicElinkEncoder.h"
+#include "MCHRawCommon/DataFormats.h"
+#include <fmt/format.h>
+
+namespace o2::mch::raw
+{
+
+template <typename CHARGESUM>
+struct ElinkEncoderMerger<UserLogicFormat, CHARGESUM> {
+
+  void operator()(uint16_t gbtId,
+                  gsl::span<ElinkEncoder<UserLogicFormat, CHARGESUM>> elinks,
+                  std::vector<uint64_t>& b64)
+  {
+    const uint64_t gbtIdMask((static_cast<uint64_t>(gbtId & 0x1F) << 59));
+    for (auto& elink : elinks) {
+      elink.moveToBuffer(b64, gbtIdMask);
+    }
+  }
+};
+} // namespace o2::mch::raw
+#endif

--- a/Detectors/MUON/MCH/Raw/Encoder/Payload/benchBitSet.cxx
+++ b/Detectors/MUON/MCH/Raw/Encoder/Payload/benchBitSet.cxx
@@ -1,0 +1,88 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <benchmark/benchmark.h>
+#include <bitset>
+#include <array>
+#include "BitSet.h"
+#include <boost/multiprecision/cpp_int.hpp>
+
+constexpr uint64_t one{1};
+
+using namespace o2::mch::raw;
+
+static void BM_BitSetGet(benchmark::State& state)
+{
+  BitSet bs;
+  bs.grow(10024);
+  for (auto _ : state) {
+    for (int i = 0; i < 100; i++) {
+      bs.get(i);
+    }
+  }
+}
+
+static void BM_BitSetSet(benchmark::State& state)
+{
+  BitSet bs;
+  bs.grow(10024);
+  int a{0};
+  for (auto _ : state) {
+    for (int i = 0; i < 100; i++) {
+      bs.set(i, false);
+    }
+  }
+}
+
+static void BM_BitSetSetFast(benchmark::State& state)
+{
+  BitSet bs;
+  bs.grow(10024);
+  for (auto _ : state) {
+    for (int i = 0; i < 100; i++) {
+      bs.setFast(i, false);
+    }
+  }
+}
+
+using namespace boost::multiprecision;
+static void BM_Set(benchmark::State& state)
+{
+  typedef number<cpp_int_backend<16384, 16384, unsigned_magnitude, unchecked, void>> bigint;
+  bigint bs;
+  for (auto _ : state) {
+    for (int i = 0; i < 100; i++) {
+      bit_unset(bs, i);
+    }
+  }
+}
+
+using namespace boost::multiprecision;
+static void BM_Get(benchmark::State& state)
+{
+  typedef number<cpp_int_backend<16384, 16384, unsigned_magnitude, unchecked, void>> bigint;
+  bigint bs;
+  bool a;
+  for (auto _ : state) {
+    for (int i = 0; i < 100; i++) {
+      benchmark::DoNotOptimize(bit_test(bs, i));
+    }
+  }
+}
+
+// Register the function as a benchmark
+BENCHMARK(BM_BitSetSet);
+BENCHMARK(BM_BitSetGet);
+BENCHMARK(BM_BitSetSetFast);
+BENCHMARK(BM_Set);
+BENCHMARK(BM_Get);
+
+// Run the benchmark
+BENCHMARK_MAIN();

--- a/Detectors/MUON/MCH/Raw/Encoder/Payload/testBareElinkEncoder.cxx
+++ b/Detectors/MUON/MCH/Raw/Encoder/Payload/testBareElinkEncoder.cxx
@@ -1,0 +1,156 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test MCHRaw BareElinkEncoder
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+#include <iostream>
+#include "BareElinkEncoder.h"
+#include "MCHRawCommon/SampaHeader.h"
+#include <fstream>
+#include <fmt/printf.h>
+
+using namespace o2::mch::raw;
+
+ElinkEncoder<BareFormat, SampleMode> createBareElinkEncoder10()
+{
+  uint8_t linkId{0};
+
+  ElinkEncoder<BareFormat, SampleMode> enc(linkId);
+
+  enc.addChannelData(1, {SampaCluster{20, std::vector<uint16_t>{20}}});
+  enc.addChannelData(5, {SampaCluster{100, std::vector<uint16_t>{100, 101}}});
+  enc.addChannelData(13, {SampaCluster{260, std::vector<uint16_t>{260, 261, 262}}});
+  enc.addChannelData(31, {SampaCluster{620, std::vector<uint16_t>{620, 621, 622, 623}}});
+
+  return enc;
+}
+
+ElinkEncoder<BareFormat, ChargeSumMode> createBareElinkEncoder20()
+{
+  uint8_t linkId{0};
+
+  ElinkEncoder<BareFormat, ChargeSumMode> enc(linkId);
+
+  enc.addChannelData(1, {SampaCluster{20, 101}});
+  enc.addChannelData(5, {SampaCluster{100, 505}});
+  enc.addChannelData(13, {SampaCluster{260, 1313}});
+  enc.addChannelData(31, {SampaCluster{620, 3131}});
+
+  return enc;
+}
+
+BOOST_AUTO_TEST_SUITE(o2_mch_raw)
+
+BOOST_AUTO_TEST_SUITE(elinkencoder)
+
+BOOST_AUTO_TEST_CASE(CtorBuildsAnEmptyBitSet)
+{
+  ElinkEncoder<BareFormat, SampleMode> enc(0, 0);
+  BOOST_CHECK_EQUAL(enc.len(), 0);
+}
+
+BOOST_AUTO_TEST_CASE(AddSingleHitShouldIncreaseSizeBy140Bits)
+{
+  ElinkEncoder<BareFormat, ChargeSumMode> enc(0);
+  auto initialSize = enc.len();
+  std::vector<SampaCluster> data = {SampaCluster(20, 10)};
+  enc.addChannelData(31, data);
+  // 100 = 50 (sync) + 50 (header)
+  // 40 = 10 (ts) + 10 (cluster size) + 20 (charge sum)
+  int expectedSize = initialSize + 100 + 40;
+  BOOST_CHECK_EQUAL(enc.len(), expectedSize);
+}
+
+BOOST_AUTO_TEST_CASE(AddMultipleHitsShouldIncreateSizeBy40BitsTimeN)
+{
+  ElinkEncoder<BareFormat, ChargeSumMode> enc(0);
+  auto initialSize = enc.len();
+  uint8_t chId{31};
+
+  std::vector<SampaCluster> data = {
+    SampaCluster(10, 1000),
+    SampaCluster(20, 2000),
+    SampaCluster(30, 3000),
+  };
+
+  enc.addChannelData(chId, data);
+
+  int expectedSize = initialSize + 100 + 40 * data.size();
+  BOOST_CHECK_EQUAL(enc.len(), expectedSize);
+}
+
+BOOST_AUTO_TEST_CASE(OneChipChargeSumOneCluster)
+{
+  ElinkEncoder<BareFormat, ChargeSumMode> enc(9, 20);
+  auto initialSize = enc.len();
+  enc.addChannelData(1, {SampaCluster(20, 101)});
+  enc.addChannelData(5, {SampaCluster(100, 505)});
+  enc.addChannelData(13, {SampaCluster(260, 1313)});
+  enc.addChannelData(31, {SampaCluster(620, 3131)});
+  // 50 = 50 (sync)
+  // 90 = 50 (header) + 10 (ts) + 10 (cluster size) + 20 (charge sum)
+  BOOST_CHECK_EQUAL(enc.len(), initialSize + 50 + 4 * 90);
+}
+
+BOOST_AUTO_TEST_CASE(OneChipSamplesOneCluster)
+{
+  uint8_t linkId{0};
+  ElinkEncoder<BareFormat, SampleMode> enc(linkId);
+  auto initialSize = enc.len();
+  enc.addChannelData(1, {SampaCluster(20, std::vector<uint16_t>{1, 10, 100, 10, 1})});
+  enc.addChannelData(5, {SampaCluster(100, std::vector<uint16_t>{5, 50, 5})});
+  enc.addChannelData(13, {SampaCluster(260, std::vector<uint16_t>{
+                                              13, 14, 15, 15, 13})});
+  enc.addChannelData(31, {SampaCluster(620, std::vector<uint16_t>{31})});
+  BOOST_CHECK_EQUAL(enc.len(), initialSize + 50 + 4 * (50 + 20) + 14 * 10);
+}
+
+template <typename FORMAT, typename CHARGESUM>
+void print(const char* msg, const ElinkEncoder<FORMAT, CHARGESUM>& enc)
+{
+  std::cout << msg << "=";
+  for (auto i = 0; i < enc.len(); i++) {
+    std::cout << (enc.get(i) ? "1" : "0");
+  }
+  std::cout << "\n";
+}
+
+BOOST_AUTO_TEST_CASE(GetShouldThrowIfBitNumberIsBeyondLen20)
+{
+  auto enc = createBareElinkEncoder20();
+  print("encoder20", enc);
+  BOOST_CHECK_THROW(enc.get(enc.len()), std::invalid_argument);
+  BOOST_CHECK_NO_THROW(enc.get(enc.len() - 1));
+}
+
+BOOST_AUTO_TEST_CASE(GetShouldThrowIfBitNumberIsBeyondLen10)
+{
+  auto enc = createBareElinkEncoder10();
+  print("encoder10", enc);
+  BOOST_CHECK_THROW(enc.get(enc.len()), std::invalid_argument);
+  BOOST_CHECK_NO_THROW(enc.get(enc.len() - 1));
+}
+
+BOOST_AUTO_TEST_CASE(FillWithSync)
+{
+  auto enc = createBareElinkEncoder20();
+  auto s = enc.len();
+  enc.fillWithSync(s + 154);
+  BOOST_CHECK_EQUAL(enc.len(), s + 154);
+  BOOST_CHECK_EQUAL(enc.range(s, s + 49), sampaSync().uint64());
+  BOOST_CHECK_EQUAL(enc.range(s + 50, s + 99), sampaSync().uint64());
+  BOOST_CHECK_EQUAL(enc.range(s + 100, s + 149), sampaSync().uint64());
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END()

--- a/Detectors/MUON/MCH/Raw/Encoder/Payload/testBitSet.cxx
+++ b/Detectors/MUON/MCH/Raw/Encoder/Payload/testBitSet.cxx
@@ -1,0 +1,480 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// @author  Laurent Aphecetche
+
+#define BOOST_TEST_MODULE Test MCHRaw bitset
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+#include <iostream>
+#include "BitSet.h"
+#include <vector>
+#include <fmt/format.h>
+#include <ctime>
+
+using namespace o2::mch::raw;
+
+uint64_t allones = 0x3FFFFFFFFFFFF;
+BOOST_AUTO_TEST_SUITE(o2_mch_raw)
+
+BOOST_AUTO_TEST_SUITE(bitset)
+
+// Most of the tests (and their names) are adapted from github.com/mrrtf/sampa/pkg/bitset/bitset_test.go
+
+BOOST_AUTO_TEST_CASE(TestCount)
+{
+  BitSet bs;
+  BOOST_CHECK_NO_THROW(bs.set(1, true));
+  BOOST_CHECK_NO_THROW(bs.set(2, true));
+  BOOST_CHECK_NO_THROW(bs.set(3, false));
+  BOOST_CHECK_NO_THROW(bs.set(9, true));
+  BOOST_CHECK_EQUAL(bs.count(), 3);
+}
+
+BOOST_AUTO_TEST_CASE(TestAppend)
+{
+  BitSet bs;
+  bs.append(true);
+  bs.append(true);
+  bs.append(false);
+  bs.append(false);
+  bs.append(true);
+  BOOST_CHECK_EQUAL(bs.uint8(0, 5), 0x13);
+  BitSet bs2;
+  BOOST_CHECK_EQUAL(bs2.len(), 0);
+  bs2.append(static_cast<uint64_t>(0x1555540F00113), 50);
+  BOOST_CHECK_EQUAL(bs2.len(), 50);
+}
+
+BOOST_AUTO_TEST_CASE(TestPruneFirst)
+{
+  BitSet bs;
+  BOOST_CHECK_NO_THROW(bs.setRangeFromString(0, 6, "1101011"));
+  bs.pruneFirst(2);
+  BOOST_CHECK_EQUAL(bs.stringLSBLeft(), "01011");
+}
+
+BOOST_AUTO_TEST_CASE(TestAny)
+{
+  BitSet bs;
+  BOOST_CHECK_EQUAL(bs.any(), false);
+  bs.set(2, true);
+  BOOST_CHECK_EQUAL(bs.any(), true);
+}
+
+BOOST_AUTO_TEST_CASE(TestNew)
+{
+  BOOST_CHECK_NO_THROW(BitSet a(static_cast<uint8_t>(100)));
+}
+
+BOOST_AUTO_TEST_CASE(TestSet)
+{
+  BitSet bs;
+  BOOST_CHECK_NO_THROW(bs.set(0, true));
+  BOOST_CHECK_NO_THROW(bs.set(2, true));
+  BOOST_CHECK_NO_THROW(bs.set(20, true));
+  BOOST_CHECK_EQUAL(bs.size(), 32);
+  BOOST_CHECK_EQUAL(bs.len(), 21);
+  BOOST_CHECK_THROW(bs.set(-1, true), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(TestGet)
+{
+  BitSet bs;
+  BOOST_CHECK_NO_THROW(bs.set(0, true));
+  BOOST_CHECK_NO_THROW(bs.set(2, true));
+  BOOST_CHECK_EQUAL(bs.get(0), true);
+  BOOST_CHECK_EQUAL(bs.get(2), true);
+  BOOST_CHECK_EQUAL(bs.get(1), false);
+  BOOST_CHECK_THROW(bs.get(100), std::out_of_range);
+}
+
+BOOST_AUTO_TEST_CASE(TestClear)
+{
+  BitSet bs;
+  bs.set(24, true);
+  BOOST_CHECK_EQUAL(bs.len(), 25);
+  bs.clear();
+  BOOST_CHECK_EQUAL(bs.len(), 0);
+}
+
+BOOST_AUTO_TEST_CASE(TestString)
+{
+  BitSet bs;
+  bs.set(1, true);
+  bs.set(3, true);
+  bs.set(5, true);
+  BOOST_CHECK_EQUAL(bs.stringLSBLeft(), "010101");
+}
+
+BOOST_AUTO_TEST_CASE(TestFromString)
+{
+  BOOST_CHECK_THROW(BitSet("00011x"), std::invalid_argument);
+  BitSet bs("01011011");
+  BOOST_CHECK_EQUAL(bs.len(), 8);
+  BOOST_CHECK_EQUAL(bs.stringLSBLeft(), "01011011");
+}
+
+BOOST_AUTO_TEST_CASE(TestRangeFromString)
+{
+  BitSet bs("110011");
+  BOOST_CHECK_NO_THROW(bs.setRangeFromString(2, 3, "11"));
+  BOOST_CHECK_EQUAL(bs.stringLSBLeft(), "111111");
+  BOOST_CHECK_THROW(bs.setRangeFromString(2, 3, "x-"), std::invalid_argument);
+  BOOST_CHECK_THROW(bs.setRangeFromString(4, 1, "101"), std::invalid_argument);
+  BOOST_CHECK_THROW(bs.setRangeFromString(32, 38, "1100"), std::invalid_argument);
+  BOOST_CHECK_NO_THROW(bs.setRangeFromString(32, 38, "1100110"));
+  BOOST_CHECK_THROW(BitSet("abcd"), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(TestFromIntegers)
+{
+  uint64_t v = 0xF0F8FCFEFF3F3F1F;
+  BitSet bs(v);
+  std::string s = "1111100011111100111111001111111101111111001111110001111100001111";
+  BOOST_CHECK_EQUAL(bs.stringLSBLeft(), s);
+  uint64_t x = bs.uint64(0, 63);
+  BOOST_CHECK_EQUAL(x, v);
+
+  bs = BitSet(static_cast<uint8_t>(0x13));
+  BOOST_CHECK_EQUAL(bs.uint8(0, 7), 0x13);
+
+  bs = BitSet(static_cast<uint16_t>(0x8000));
+  BOOST_CHECK_EQUAL(bs.uint16(0, 15), 0x8000);
+
+  bs = BitSet(static_cast<uint32_t>(0xF0008000));
+  BOOST_CHECK_EQUAL(bs.uint32(0, 31), 0xF0008000);
+
+  bs = BitSet{};
+  BOOST_CHECK_THROW(bs.setRangeFromUint(0, 9, static_cast<uint8_t>(0)), std::invalid_argument);
+  BOOST_CHECK_THROW(bs.setRangeFromUint(9, 32, static_cast<uint16_t>(0)), std::invalid_argument);
+  BOOST_CHECK_THROW(bs.setRangeFromUint(24, 57, static_cast<uint32_t>(0)), std::invalid_argument);
+  BOOST_CHECK_THROW(bs.setRangeFromUint(56, 122, static_cast<uint64_t>(0)), std::invalid_argument);
+  BOOST_CHECK_NO_THROW(bs.setRangeFromUint(0, 7, static_cast<uint8_t>(0xFF)));
+  BOOST_CHECK_EQUAL(bs.len(), 8);
+}
+
+BOOST_AUTO_TEST_CASE(TestRangeFromUint16)
+{
+  uint16_t v = 0xF0F8;
+
+  auto bs = BitSet(v);
+  bs.setRangeFromUint(12, 14, static_cast<uint16_t>(0));
+  BOOST_CHECK_EQUAL(bs.uint16(0, 15), 0x80F8);
+}
+
+BOOST_AUTO_TEST_CASE(TestRangeFromUint32)
+{
+  uint32_t v = 0xF0F8FCFE;
+
+  auto bs = BitSet(v);
+  bs.setRangeFromUint(28, 30, static_cast<uint32_t>(0));
+  BOOST_CHECK_EQUAL(bs.uint32(0, 31), 0x80F8FCFE);
+}
+
+BOOST_AUTO_TEST_CASE(TestRangeFromUint64)
+{
+  uint64_t v = 0xF0F8FCFEFF3F3F1F;
+
+  auto bs = BitSet(v);
+  bs.setRangeFromUint(60, 62, static_cast<uint64_t>(0));
+  uint64_t expected = 0x80F8FCFEFF3F3F1F;
+  BOOST_CHECK_EQUAL(bs.uint64(0, 63), expected);
+}
+
+BOOST_AUTO_TEST_CASE(TestRangeFromIntegers)
+{
+  BitSet bs(static_cast<uint64_t>(0));
+  BOOST_CHECK_NO_THROW(bs.setRangeFromUint(0, 5, static_cast<uint8_t>(0x13)));
+  bs.set(8, true);
+  BOOST_CHECK_NO_THROW(bs.setRangeFromUint(20, 23, static_cast<uint8_t>(0xF)));
+  BOOST_CHECK_NO_THROW(bs.setRangeFromUint(29, 48, static_cast<uint32_t>(0xAAAAA)));
+  BOOST_CHECK_EQUAL(bs.uint64(0, 63), UINT64_C(0x1555540F00113));
+}
+
+BOOST_AUTO_TEST_CASE(TestFromBytes)
+{
+  BitSet bs;
+  std::vector<uint8_t> bytes = {0xfe, 0x5a, 0x1e, 0xda};
+  bs.setFromBytes(bytes);
+  BOOST_CHECK_EQUAL(bs.uint32(0, 31), 0XDA1E5AFE);
+  BOOST_CHECK_EQUAL(bs.size(), 32);
+  BOOST_CHECK_EQUAL(bs.len(), 32);
+}
+
+BOOST_AUTO_TEST_CASE(TestIsEqual)
+{
+  BitSet b1("110011");
+  BitSet b2("110011");
+  BOOST_CHECK(b1 == b2);
+  b2 = BitSet("1010");
+  BOOST_CHECK(b1 != b2);
+}
+
+BOOST_AUTO_TEST_CASE(TestSub)
+{
+  BitSet bs("110011");
+  auto b = bs.subset(2, 4);
+  BOOST_CHECK_EQUAL(b.stringLSBLeft(), "001");
+  b.set(1, true);
+  BOOST_CHECK_EQUAL(b.stringLSBLeft(), "011");
+}
+
+BOOST_AUTO_TEST_CASE(TestUint64)
+{
+  BitSet bs("110011");
+  auto v2 = bs.uint64(0, 5);
+  BOOST_CHECK_EQUAL(v2, 51);
+  v2 = bs.uint64(0, 1);
+  BOOST_CHECK_EQUAL(v2, 3);
+
+  uint64_t v = UINT64_C(0xFFFFFFFFFFFFFFFF);
+  bs = BitSet(v);
+  BOOST_CHECK_EQUAL(bs.stringLSBLeft(), "1111111111111111111111111111111111111111111111111111111111111111");
+  auto x = bs.uint64(0, 63);
+  BOOST_CHECK_EQUAL(x, v);
+}
+
+BOOST_AUTO_TEST_CASE(TestGrow)
+{
+  BitSet bs(static_cast<uint16_t>(0xFFFF));
+  BOOST_CHECK_EQUAL(bs.grow(15), false);
+  BOOST_CHECK_THROW(bs.grow((BitSet::maxSize() + 1)), std::length_error);
+  BOOST_CHECK_EQUAL(bs.grow(34), true);
+}
+
+BOOST_AUTO_TEST_CASE(TestUint16)
+{
+  uint16_t v = 0xFFFF;
+  BitSet bs = BitSet(v);
+  BOOST_CHECK_EQUAL(bs.stringLSBLeft(), "1111111111111111");
+  auto x = bs.uint16(0, 15);
+  BOOST_CHECK_EQUAL(x, v);
+}
+
+BOOST_AUTO_TEST_CASE(TestUint32)
+{
+  uint32_t v = 0xFFFFFFFF;
+  BitSet bs = BitSet(v);
+  BOOST_CHECK_EQUAL(bs.stringLSBLeft(), "11111111111111111111111111111111");
+  auto x = bs.uint32(0, 31);
+  BOOST_CHECK_EQUAL(x, v);
+}
+
+BOOST_AUTO_TEST_CASE(TestLast)
+{
+  BitSet bs("1010110101111");
+  BOOST_CHECK(bs.last(4) == BitSet("1111"));
+  BOOST_CHECK(bs.last(6) == BitSet("101111"));
+}
+
+BOOST_AUTO_TEST_CASE(TestEmptyBitSet)
+{
+  BitSet bs;
+  BOOST_CHECK_EQUAL(bs.stringLSBLeft(), "");
+  BOOST_CHECK_EQUAL(bs.stringLSBRight(), "");
+  BOOST_CHECK_EQUAL(bs.isEmpty(), true);
+  BOOST_CHECK_EQUAL(bs.len(), 0);
+  BOOST_CHECK(bs.size() > 0);
+}
+
+std::string bitNumberScale(int n, int nspaces, bool right2left)
+{
+  std::string line1;
+  std::string line2;
+  for (int i = 0; i < n; i++) {
+    if (i > 0 && i % 10 == 0) {
+      line1 += std::to_string(i / 10);
+    } else {
+      line1 += " ";
+    }
+    line2 += std::to_string(i % 10);
+  }
+
+  if (right2left) {
+    std::reverse(begin(line1), end(line1));
+    std::reverse(begin(line2), end(line2));
+  }
+  std::string spaces(nspaces, ' ');
+  std::string rv;
+
+  if (n > 10) {
+    rv = spaces + line1 + "\n";
+  }
+  rv += spaces + line2;
+  return rv;
+}
+
+BOOST_AUTO_TEST_CASE(TestAppendUint32)
+{
+  BitSet bs;
+  auto C = UINT32_C(0XDA1E5AFE);
+
+  bs.append(C);
+
+  BOOST_CHECK_EQUAL(bs.len(), 32);
+  BOOST_CHECK_EQUAL(bs.uint32(0, 31), C);
+
+  // std::cout << fmt::format("BS -> {0}\n", bs.stringLSBLeft());
+  // std::cout << bitNumberScale(32, 6, false) << "\n\n";
+  // std::cout << fmt::format("BS <- {0}\n", bs.stringLSBRight());
+  // std::cout << bitNumberScale(32, 6, true) << "\n\n";
+}
+
+BOOST_AUTO_TEST_CASE(TestAppendUint64)
+{
+  BitSet bs;
+
+  auto C = UINT64_C(0x1555540f00113);
+  bs.append(C, 64);
+
+  BOOST_CHECK_EQUAL(bs.len(), 64);
+  BOOST_CHECK_EQUAL(bs.uint64(0, 63), C);
+
+  // std::cout << fmt::format("BS -> {0}\n", bs.stringLSBLeft());
+  // std::cout << bitNumberScale(64, 6, false) << "\n\n";
+  // std::cout << fmt::format("BS <- {0}\n", bs.stringLSBRight());
+  // std::cout << bitNumberScale(64, 6, true) << "\n\n";
+}
+
+BOOST_AUTO_TEST_CASE(TestAppendUint64Bis)
+{
+  BitSet bs;
+
+  for (int i = 0; i < 50; i++) {
+    bs.set(i, true);
+  }
+  BOOST_CHECK_EQUAL(bs.len(), 50);
+  BOOST_CHECK_EQUAL(bs.uint64(0, 49), allones);
+}
+
+BOOST_AUTO_TEST_CASE(TestAppendUint8)
+{
+  BitSet bs;
+
+  uint8_t a(42);
+
+  BOOST_CHECK_THROW(bs.append(a, 9), std::invalid_argument);
+
+  // append bits, letting appendUint8 compute the number
+  // of actual bits to add
+  BOOST_CHECK_NO_THROW(bs.append(a));
+
+  BOOST_CHECK_EQUAL(bs.len(), 6);
+  BOOST_CHECK_EQUAL(bs.uint8(0, 5), a);
+
+  BOOST_CHECK_EQUAL(bs.stringLSBLeft(), "010101");
+  BOOST_CHECK_EQUAL(bs.stringLSBRight(), "101010");
+
+  bs.clear();
+  // append bits, forcing 8 bits to be added
+  bs.append(a, 8);
+  BOOST_CHECK_EQUAL(bs.stringLSBLeft(), "01010100");
+  BOOST_CHECK_EQUAL(bs.uint8(0, 7), a);
+
+  bs = BitSet("111");
+  bs.append(static_cast<uint8_t>(128), 8);
+
+  BOOST_CHECK_EQUAL(bs.stringLSBLeft(), "11100000001");
+}
+
+void compare(std::string_view s1, std::string_view s2)
+{
+  if (s1.size() != s2.size()) {
+    std::cout << "sizes differ\n";
+    return;
+  }
+  std::vector<int> dif;
+
+  for (auto i = 0; i < s1.size(); i++) {
+    if (s1[i] != s2[i]) {
+      dif.push_back(i);
+    }
+  }
+  if (dif.size()) {
+    std::cout << "indices of " << dif.size() << " differences:\n";
+    for (auto d : dif) {
+      std::cout << d << " ";
+    }
+    std::cout << "\n";
+  }
+}
+
+BOOST_AUTO_TEST_CASE(TestLongAppend)
+{
+  std::string expected = "11010101010110010101011011100011000011101000010110010100101100010100001001100100110010110100000000111100110110101101101110001111010110010010000101101111101110101011011111100101101010111011011111000010011010000100111111001000011010100111101101011110110001010";
+  BitSet bs;
+
+  for (int i = 0; i < expected.size(); i++) {
+    if (expected[i] == '1') {
+      bs.append(true);
+    } else {
+      bs.append(false);
+    }
+    if (bs.stringLSBLeft() != expected.substr(0, bs.len())) {
+      std::cout << "diff\n";
+    }
+  }
+  BOOST_CHECK_EQUAL(bs.stringLSBLeft(), expected);
+}
+
+BOOST_AUTO_TEST_CASE(TestLoopAppend)
+{
+  std::string expected;
+  BitSet bs;
+
+  std::srand(std::time(nullptr));
+  for (int i = 0; i < BitSet::maxSize(); i++) {
+    bool bit = static_cast<bool>(rand() % 2);
+    if (bit) {
+      expected += "1";
+    } else {
+      expected += "0";
+    }
+    bs.append(bit);
+  }
+  BOOST_CHECK_EQUAL(bs.stringLSBLeft(), expected);
+}
+
+BOOST_AUTO_TEST_CASE(TestLimitedCtor)
+{
+  BOOST_CHECK_THROW(BitSet bs(static_cast<uint8_t>(123), 9), std::invalid_argument);
+  BOOST_CHECK_NO_THROW(BitSet bs(static_cast<uint8_t>(123), 4));
+  BitSet bs(static_cast<uint8_t>(123), 4);
+  BOOST_CHECK_EQUAL(bs.uint8(0, 3), 11);
+}
+
+BOOST_AUTO_TEST_CASE(TestCircularAppend)
+{
+  uint64_t syncValue = 0x1555540F00113;
+  BitSet bs;
+  BitSet sync(syncValue, 50);
+
+  int next = circularAppend(bs, sync, 0, 10);
+  BOOST_CHECK_EQUAL(bs.len(), 10);
+  BOOST_CHECK_EQUAL(bs, sync.subset(0, 9));
+  BOOST_CHECK_EQUAL(next, 10);
+
+  next = circularAppend(bs, sync, next, 40);
+  BOOST_CHECK_EQUAL(bs.len(), 50);
+  BOOST_CHECK_EQUAL(bs, sync);
+  BOOST_CHECK_EQUAL(next, 0);
+
+  next = circularAppend(bs, sync, next, 145);
+  BitSet expected("110010001000000000001111000000101010101010101010101100100010000000000011110000001010101010101010101011001000100000000000111100000010101010101010101010110010001000000000001111000000101010101010101");
+
+  BOOST_CHECK_EQUAL(bs, expected);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END()

--- a/Detectors/MUON/MCH/Raw/Encoder/Payload/testElinkEncoder.cxx
+++ b/Detectors/MUON/MCH/Raw/Encoder/Payload/testElinkEncoder.cxx
@@ -1,0 +1,67 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test MCHRaw ElinkEncoder
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+#include <iostream>
+#include "BareElinkEncoder.h"
+#include "UserLogicElinkEncoder.h"
+#include "MCHRawCommon/SampaHeader.h"
+#include <fstream>
+#include <fmt/printf.h>
+#include <boost/mpl/list.hpp>
+
+using namespace o2::mch::raw;
+
+BOOST_AUTO_TEST_SUITE(o2_mch_raw)
+
+BOOST_AUTO_TEST_SUITE(elinkencoder)
+
+typedef boost::mpl::list<BareFormat, UserLogicFormat> testTypes;
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(CtorMustHaveElinkIdBetween0And39, T, testTypes)
+{
+  using Encoder = ElinkEncoder<T, ChargeSumMode>;
+  BOOST_CHECK_THROW(Encoder enc(40), std::invalid_argument);
+  BOOST_CHECK_NO_THROW(Encoder enc(39));
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(AddEmptyDataShouldThrow, T, testTypes)
+{
+  ElinkEncoder<T, ChargeSumMode> enc(0);
+  std::vector<SampaCluster> data;
+  BOOST_CHECK_THROW(enc.addChannelData(31, data), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(AddMixedDataShouldThrow, T, testTypes)
+{
+  ElinkEncoder<T, SampleMode> enc(0);
+  std::vector<SampaCluster> data;
+  std::vector<uint16_t> samples{123, 456, 789};
+  data.emplace_back(0, 1000);
+  data.emplace_back(0, samples);
+  BOOST_CHECK_THROW(enc.addChannelData(31, data), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(ChannelIdIsBetween0And63, T, testTypes)
+{
+  ElinkEncoder<T, ChargeSumMode> enc(0);
+  std::vector<SampaCluster> data = {SampaCluster(20, 10)};
+
+  BOOST_CHECK_THROW(enc.addChannelData(64, data),
+                    std::invalid_argument);
+  BOOST_CHECK_NO_THROW(enc.addChannelData(63, data));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END()

--- a/Detectors/MUON/MCH/Raw/Encoder/Payload/testEncoder.cxx
+++ b/Detectors/MUON/MCH/Raw/Encoder/Payload/testEncoder.cxx
@@ -1,0 +1,137 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// @author  Laurent Aphecetche
+///
+/// In those tests we are mainly concerned about testinng
+/// whether the payloads are actually properly simulated.
+///
+#define BOOST_TEST_MODULE Test MCHRaw Encoder
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+#include "MCHRawEncoder/Encoder.h"
+#include "MCHRawCommon/DataFormats.h"
+#include "MCHRawEncoder/DataBlock.h"
+#include <fmt/printf.h>
+#include "DumpBuffer.h"
+#include <boost/mpl/list.hpp>
+#include "CruBufferCreator.h"
+
+using namespace o2::mch::raw;
+
+template <typename FORMAT>
+std::unique_ptr<Encoder> defaultEncoder()
+{
+  return createEncoder<FORMAT, SampleMode, true>();
+}
+
+typedef boost::mpl::list<BareFormat, UserLogicFormat> testTypes;
+
+BOOST_AUTO_TEST_SUITE(o2_mch_raw)
+
+BOOST_AUTO_TEST_SUITE(encoder)
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(StartHBFrameBunchCrossingMustBe12Bits, T, testTypes)
+{
+  auto encoder = defaultEncoder<T>();
+  BOOST_CHECK_THROW(encoder->startHeartbeatFrame(0, 1 << 12), std::invalid_argument);
+  BOOST_CHECK_NO_THROW(encoder->startHeartbeatFrame(0, 0xFFF));
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(EmptyEncoderHasEmptyBufferIfPhaseIsZero, T, testTypes)
+{
+  srand(time(nullptr));
+  auto encoder = defaultEncoder<T>();
+  encoder->startHeartbeatFrame(12345, 123);
+  std::vector<uint8_t> buffer;
+  encoder->moveToBuffer(buffer);
+  BOOST_CHECK_EQUAL(buffer.size(), 0);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(EmptyEncodeIsNotNecessarilyEmptyDependingOnPhase, T, testTypes)
+{
+  srand(time(nullptr));
+  auto encoder = createEncoder<T, SampleMode, false>();
+  encoder->startHeartbeatFrame(12345, 123);
+  std::vector<uint8_t> buffer;
+  encoder->moveToBuffer(buffer);
+  BOOST_CHECK_GE(buffer.size(), 0);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(MultipleOrbitsWithNoDataIsAnEmptyBufferIfPhaseIsZero, T, testTypes)
+{
+  srand(time(nullptr));
+  auto encoder = defaultEncoder<T>();
+  encoder->startHeartbeatFrame(12345, 123);
+  encoder->startHeartbeatFrame(12345, 125);
+  encoder->startHeartbeatFrame(12345, 312);
+  std::vector<uint8_t> buffer;
+  encoder->moveToBuffer(buffer);
+  BOOST_CHECK_EQUAL(buffer.size(), 0);
+}
+
+int estimateUserLogicSize(int nofDS, int maxNofChPerDS)
+{
+  size_t headerSize = 2; // equivalent to 2 64-bits words
+  // one 64-bits header and one 64-bits data per channel
+  // plus one sync per DS
+  // (assuming data = just one sample)
+  size_t ndata = (maxNofChPerDS * 2) + nofDS;
+  return 8 * (ndata + headerSize); // size in bytes
+}
+
+int estimateBareSize(int nofDS, int maxNofChPerGBT)
+{
+  size_t headerSize = 2; // equivalent to 2 64-bits words
+  size_t nbits = nofDS * 50 + maxNofChPerGBT * 90;
+  size_t n128bitwords = nbits / 2;
+  size_t n64bitwords = n128bitwords * 2;
+  return 8 * (n64bitwords + headerSize); // size in bytes
+}
+
+template <typename FORMAT>
+int estimateSize();
+
+template <>
+int estimateSize<BareFormat>()
+{
+
+  return estimateBareSize(1, 3) +
+         estimateBareSize(1, 4) +
+         estimateBareSize(1, 6);
+}
+
+template <>
+int estimateSize<UserLogicFormat>()
+{
+  return estimateUserLogicSize(1, 3) +
+         estimateUserLogicSize(1, 4) +
+         estimateUserLogicSize(1, 6);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(CheckNumberOfPayloadHeaders, T, testTypes)
+{
+  auto buffer = test::CruBufferCreator<T, ChargeSumMode>::makeBuffer();
+  int nheaders = o2::mch::raw::countHeaders(buffer);
+  BOOST_CHECK_EQUAL(nheaders, 3);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(CheckSize, T, testTypes)
+{
+  auto buffer = test::CruBufferCreator<T, ChargeSumMode>::makeBuffer();
+  size_t expectedSize = estimateSize<T>();
+  BOOST_CHECK_EQUAL(buffer.size(), expectedSize);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END()

--- a/Detectors/MUON/MCH/Raw/Encoder/Payload/testGBTEncoder.cxx
+++ b/Detectors/MUON/MCH/Raw/Encoder/Payload/testGBTEncoder.cxx
@@ -1,0 +1,157 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test MCHRaw GBTEncoder
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+#include "BareElinkEncoder.h"
+#include "UserLogicElinkEncoder.h"
+#include "BareElinkEncoderMerger.h"
+#include "UserLogicElinkEncoderMerger.h"
+#include <array>
+#include <array>
+#include <fmt/printf.h>
+#include "RefBuffers.h"
+#include <boost/mpl/list.hpp>
+#include "MoveBuffer.h"
+#include "GBTEncoder.h"
+#include "DumpBuffer.h"
+
+using namespace o2::mch::raw;
+
+template <typename FORMAT, typename MODE>
+std::vector<uint8_t> createGBTBuffer()
+{
+  GBTEncoder<FORMAT, MODE>::forceNoPhase = true;
+  uint8_t gbtId{23};
+  GBTEncoder<FORMAT, MODE> enc(gbtId);
+  uint32_t bx(0);
+  uint16_t ts(12);
+  int elinkGroupId = 0;
+  int elinkIndexInGroup = 0;
+  enc.addChannelData(elinkGroupId, elinkIndexInGroup, 0, {SampaCluster(ts, 10)});
+  enc.addChannelData(elinkGroupId, elinkIndexInGroup, 31, {SampaCluster(ts, 160)});
+  elinkIndexInGroup = 3;
+  enc.addChannelData(elinkGroupId, elinkIndexInGroup, 13, {SampaCluster(ts, 13)});
+  enc.addChannelData(elinkGroupId, elinkIndexInGroup, 33, {SampaCluster(ts, 133)});
+  enc.addChannelData(elinkGroupId, elinkIndexInGroup, 63, {SampaCluster(ts, 163)});
+  std::vector<uint8_t> words;
+  enc.moveToBuffer(words);
+  // std::cout << "createGBTBuffer<" << typeid(FORMAT).name() << "," << std::boolalpha << typeid(MODE).name() << ">\n";
+  // impl::dumpBuffer(gsl::make_span(words));
+  // int i{0};
+  // for (auto v : words) {
+  //   fmt::printf("0x%02X, ", v);
+  //   if (++i % 12 == 0) {
+  //     fmt::printf("\n");
+  //   }
+  // }
+  return words;
+}
+
+BOOST_AUTO_TEST_SUITE(o2_mch_raw)
+
+BOOST_AUTO_TEST_SUITE(gbtencoder)
+
+typedef boost::mpl::list<BareFormat, UserLogicFormat> testTypes;
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(EncodeABufferInChargeSumMode, T, testTypes)
+{
+  auto buffer = createGBTBuffer<T, ChargeSumMode>();
+  auto ref = REF_BUFFER_GBT<T, ChargeSumMode>();
+  size_t n = ref.size();
+  BOOST_CHECK_GE(buffer.size(), n);
+  BOOST_CHECK(std::equal(begin(buffer), end(buffer), begin(ref)));
+}
+
+template <typename FORMAT, typename CHARGESUM>
+float expectedSize();
+
+template <>
+float expectedSize<BareFormat, ChargeSumMode>()
+{
+  return 4 * 640;
+}
+
+template <>
+float expectedSize<UserLogicFormat, ChargeSumMode>()
+{
+  return 96;
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(GBTEncoderAddFewChannels, T, testTypes)
+{
+  GBTEncoder<T, ChargeSumMode>::forceNoPhase = true;
+  GBTEncoder<T, ChargeSumMode> enc(0);
+  uint32_t bx(0);
+  uint16_t ts(0);
+  int elinkGroupId = 0;
+  int elinkIndexInGroup = 0;
+  enc.addChannelData(elinkGroupId, elinkIndexInGroup, 0, {SampaCluster(ts, 10)});
+  enc.addChannelData(elinkGroupId, elinkIndexInGroup, 31, {SampaCluster(ts, 160)});
+  elinkIndexInGroup = 3;
+  enc.addChannelData(elinkGroupId, elinkIndexInGroup, 3, {SampaCluster(ts, 13)});
+  enc.addChannelData(elinkGroupId, elinkIndexInGroup, 13, {SampaCluster(ts, 133)});
+  enc.addChannelData(elinkGroupId, elinkIndexInGroup, 23, {SampaCluster(ts, 163)});
+  BOOST_CHECK_THROW(enc.addChannelData(8, 0, 0, {SampaCluster(ts, 10)}), std::invalid_argument);
+  std::vector<uint8_t> buffer;
+  enc.moveToBuffer(buffer);
+  float e = expectedSize<T, ChargeSumMode>();
+  BOOST_CHECK_EQUAL(buffer.size(), e);
+}
+
+template <typename FORMAT, typename CHARGESUM>
+float expectedMaxSize();
+
+template <>
+float expectedMaxSize<BareFormat, ChargeSumMode>()
+{
+  return 4 * 11620;
+}
+
+template <>
+float expectedMaxSize<UserLogicFormat, ChargeSumMode>()
+{
+  return 1032;
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(GBTEncoderAdd64Channels, T, testTypes)
+{
+  GBTEncoder<T, ChargeSumMode>::forceNoPhase = true;
+  GBTEncoder<T, ChargeSumMode> enc(0);
+  std::vector<uint8_t> buffer;
+  enc.moveToBuffer(buffer);
+  uint32_t bx(0);
+  uint16_t ts(0);
+  int elinkGroupId = 0;
+  for (int i = 0; i < 64; i++) {
+    enc.addChannelData(elinkGroupId, 0, i, {SampaCluster(ts, i * 10)});
+  }
+  enc.moveToBuffer(buffer);
+  impl::dumpBuffer(buffer);
+  float e = expectedMaxSize<T, ChargeSumMode>();
+  BOOST_CHECK_EQUAL(buffer.size(), e);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(GBTEncoderMoveToBufferClearsTheInternalBuffer, T, testTypes)
+{
+  GBTEncoder<T, ChargeSumMode> enc(0);
+  enc.addChannelData(0, 0, 0, {SampaCluster(0, 10)});
+  std::vector<uint8_t> buffer;
+  size_t n = enc.moveToBuffer(buffer);
+  BOOST_CHECK_GE(n, 0);
+  n = enc.moveToBuffer(buffer);
+  BOOST_CHECK_EQUAL(n, 0);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END()

--- a/Detectors/MUON/MCH/Raw/Encoder/README.md
+++ b/Detectors/MUON/MCH/Raw/Encoder/README.md
@@ -1,0 +1,61 @@
+<!-- doxy
+\page refDetectorsMUONMCHRawEncoder Encoder
+/doxy -->
+
+# MCH Raw Data Encoder
+
+Like the decoder, the encoder deals with two formats (Bare and UserLogic), both
+of which in two different modes (charge sum and sample mode). Note that only
+the chargesum mode is fully useable (but that should not be much of a
+    limitation as we're yet to find a real use case for simulating the sample
+    mode).
+
+Generation of MCH raw data buffers is a two stage process : first we
+build payloads and then only we organize them in (RDH,payload) blocks.
+
+The Encoder is mainly about building *payloads*. How those payloads are ordered
+in memory is not the Encoder business. This choice has been made to minimize
+the dependency of the Encoder code on the RawDataHeader itself.  To that end
+the Encoder is producing data buffers consisting of (header,payload) [blocks](/include/MCHRawEncoder/DataBlock.h), where header is *not* a RDH but a
+simpler (and non versioned) struct. Contrary to (RDH,payload) blocks, the
+payload can be any size (while in RDH the size is limited to 65536 bytes). The
+part of the detector that a payload block references is identified through a
+unique `feeId` field which is the `solarId` in MCH case.
+
+Methods are then provided to massage the (header,payload) buffers to produce
+realistic (RDH,payload) buffers that closely ressemble real raw data.
+
+## createEncoder&lt;FORMAT,CHARGESUM>
+
+To creation of a MCH Encoder is handled through a template function.
+For instance, to create an Encoder that builds raw data in BareFormat and
+ChargeSumMode, use :
+
+```.cpp
+#include "MCHRawEncoder/Encoder.h"
+
+auto encoder = o2::mch::raw::Encoder<BareFormat,ChargeSumMode>();
+
+```
+
+Then for each interaction record (aka orbit,bunch crossing pair) you tell
+the encoder to start a new Heartbeat Frame, fill it with all the data
+of the channels and then extract the memory buffer.
+
+```.cpp
+vector<uint8_t> buffer;
+for ( loop over interactions )
+  encoder->startHeartbeatFrame(orbit,bc);
+  for ( loop over digits ) {
+    DsElecId elecId = ... // get electronic dual sampa id from digit
+      int sampaChannelId = ... // get sampa channel id from digits
+      vector<SampaClusters> clusters = ... // create sampa clusters from digits
+      encoder->addChannelData(elecId,sampaChannelId,clusters);
+  }
+encoder->moveToBuffer(buffer);
+}
+```
+
+At this stage the buffer contains (header,payload) blocks for all the
+interactions you looped over. But it is *not* yet a valid raw data, as it lacks
+RDHs (and has mch-specific headers instead).

--- a/Detectors/MUON/MCH/Raw/Encoder/include/MCHRawEncoder/DataBlock.h
+++ b/Detectors/MUON/MCH/Raw/Encoder/include/MCHRawEncoder/DataBlock.h
@@ -1,0 +1,58 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_MCH_RAW_ENCODER_DATABLOCK_H
+#define O2_MCH_RAW_ENCODER_DATABLOCK_H
+
+#include <cstdint>
+#include <vector>
+#include <gsl/span>
+#include <functional>
+#include <iostream>
+#include <optional>
+
+namespace o2::mch::raw
+{
+struct DataBlockHeader {
+  uint32_t orbit;
+  uint16_t bc;
+  uint16_t feeId;
+  uint64_t payloadSize;
+};
+
+struct DataBlock {
+  DataBlockHeader header;
+  gsl::span<const uint8_t> payload;
+  uint64_t size() const
+  {
+    return sizeof(header) + payload.size();
+  }
+};
+
+struct DataBlockRef {
+  DataBlock block;
+  std::optional<uint64_t> offset;
+};
+
+void appendDataBlockHeader(std::vector<uint8_t>& outBuffer, DataBlockHeader header);
+
+int forEachDataBlockRef(gsl::span<const uint8_t> buffer,
+                        std::function<void(DataBlockRef blockRef)> f);
+
+int countHeaders(gsl::span<uint8_t> buffer);
+
+std::ostream& operator<<(std::ostream& os, const DataBlockHeader& header);
+std::ostream& operator<<(std::ostream& os, const DataBlockRef& ref);
+std::ostream& operator<<(std::ostream& os, const DataBlock& block);
+
+bool operator<(const DataBlockHeader& a, const DataBlockHeader& b);
+} // namespace o2::mch::raw
+
+#endif

--- a/Detectors/MUON/MCH/Raw/Encoder/include/MCHRawEncoder/Encoder.h
+++ b/Detectors/MUON/MCH/Raw/Encoder/include/MCHRawEncoder/Encoder.h
@@ -1,0 +1,70 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_MCH_RAW_ENCODER_H
+#define O2_MCH_RAW_ENCODER_H
+
+#include <memory>
+#include <set>
+#include "MCHRawElecMap/DsElecId.h"
+#include "MCHRawCommon/SampaCluster.h"
+#include <functional>
+#include <optional>
+
+namespace o2::mch::raw
+{
+
+/// @brief An Encoder builds MCH raw data
+///
+/// Data is added using the addChannelData() method.
+/// Then it can be exported using the moveToBuffer() method.
+/// \nosubgrouping
+
+class Encoder
+{
+ public:
+  virtual ~Encoder() {}
+
+  /** @name Main interface.
+    */
+  ///@{
+  /// add data for one channel.
+  ///
+  /// \param dsId is the (electronic) identifier of a dual sampa
+  /// \param chId dual sampa channel id 0..63
+  /// \param data the actual data to be added
+  virtual void addChannelData(DsElecId dsId, uint8_t chId, const std::vector<SampaCluster>& data) = 0;
+
+  // startHeartbeatFrame sets the trigger (orbit,bunchCrossing) to be used
+  // for all generated payload headers (until next call to this method).
+  // Causes the alignment of the underlying gbts.
+  virtual void startHeartbeatFrame(uint32_t orbit, uint16_t bunchCrossing) = 0;
+
+  /// Export our encoded data.
+  ///
+  /// The internal words that have been accumulated so far are
+  /// _moved_ (i.e. deleted from this object) to the external buffer of bytes
+  /// Returns the number of bytes added to buffer.
+  virtual size_t moveToBuffer(std::vector<uint8_t>& buffer) = 0;
+  ///@}
+};
+
+/// createEncoder creates an encoder
+///
+/// template parameters :
+///
+/// \tparam FORMAT defines the data format (either BareFormat or UserLogic)
+/// \tparam CHARGESUM defines the data format mode (either SampleMode or ChargeSumMode)
+/// \tparam forceNoPhase to be deprecated ?
+///
+template <typename FORMAT, typename CHARGESUM, bool forceNoPhase = false>
+std::unique_ptr<Encoder> createEncoder();
+} // namespace o2::mch::raw
+#endif

--- a/Detectors/MUON/MCH/Raw/README.md
+++ b/Detectors/MUON/MCH/Raw/README.md
@@ -11,4 +11,5 @@ and Decoding.
 * \subpage refDetectorsMUONMCHRawElecMap
 * \subpage refDetectorsMUONMCHRawDecoder
 * \subpage refDetectorsMUONMCHRawTools
+* \subpage refDetectorsMUONMCHRawEncoder
 /doxy -->


### PR DESCRIPTION
This PR only deals with the encoding of the payload part, in order to minimize the PR's size. 
The handling of the headers (RDH) to reach a valid raw data format will be done in a follow-up PR.

The encoders are separated at elink level for the two raw data format we have (bare and user logic), but there's only one implementation for GBT level and up.

```
├── CMakeLists.txt
├── Payload
│   ├── BareElinkEncoder.h
│   ├── BareElinkEncoderMerger.h
│   ├── BitSet.cxx
│   ├── BitSet.h
│   ├── CruBufferCreator.cxx
│   ├── CruBufferCreator.h
│   ├── DataBlock.cxx
│   ├── ElinkEncoder.cxx
│   ├── ElinkEncoder.h
│   ├── ElinkEncoderMerger.h
│   ├── Encoder.cxx
│   ├── EncoderImpl.h
│   ├── GBTEncoder.h
│   ├── UserLogicElinkEncoder.h
│   ├── UserLogicElinkEncoderMerger.h
│   ├── benchBitSet.cxx
│   ├── testBareElinkEncoder.cxx
│   ├── testBitSet.cxx
│   ├── testElinkEncoder.cxx
│   ├── testEncoder.cxx
│   └── testGBTEncoder.cxx
├── README.md
└── include
    └── MCHRawEncoder
        ├── DataBlock.h
        └── Encoder.h
```
