### PR TITLE
DPL: adapt filters to be used over joins and concats

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -24,6 +24,7 @@
 #include <gandiva/selection_vector.h>
 #include <cassert>
 
+
 namespace o2::soa
 {
 
@@ -32,6 +33,44 @@ constexpr bool is_index_column_v = false;
 
 template <typename T>
 constexpr bool is_index_column_v<T, std::void_t<decltype(sizeof(typename T::binding_t))>> = true;
+
+template<typename, typename = void>
+constexpr bool is_type_with_originals_v = false;
+
+template<typename T>
+constexpr bool is_type_with_originals_v
+    <T, std::void_t<decltype(sizeof(typename T::originals))>> = true;
+
+
+template<typename T, typename TLambda>
+void call_if_has_originals(TLambda&& lambda)
+{
+  if constexpr (is_type_with_originals_v<T>) {
+    lambda(static_cast<T*>(nullptr));
+  } 
+}
+
+template<typename T, typename TLambda>
+void call_if_has_not_originals(TLambda&& lambda)
+{
+  if constexpr (!is_type_with_originals_v<T>) {
+    lambda(static_cast<T*>(nullptr));
+  } 
+}
+
+template<typename T>
+constexpr auto make_originals_from_type()
+{
+  using decayed = std::decay_t<T>;
+  if constexpr (is_type_with_originals_v<decayed>) {
+    return typename decayed::originals{};
+  } else if constexpr (is_type_with_originals_v<typename decayed::table_t>) {
+    return typename decayed::table_t::originals{};
+  } else {
+    return framework::pack<decayed>{};
+  }
+//  return framework::pack<>{};
+}
 
 template <typename T>
 struct arrow_array_for {
@@ -1028,6 +1067,9 @@ using JoinBase = decltype(join(std::declval<Ts>()...));
 template <typename T1, typename T2>
 using ConcatBase = decltype(concat(std::declval<T1>(), std::declval<T2>()));
 
+template <typename T>
+using originals_pack_t = decltype(make_originals_from_type<T>());
+
 template <typename... Ts>
 struct Join : JoinBase<Ts...> {
   Join(std::vector<std::shared_ptr<arrow::Table>>&& tables, uint64_t offset = 0)
@@ -1039,7 +1081,7 @@ struct Join : JoinBase<Ts...> {
   {
   }
 
-  using originals = framework::pack<Ts...>;
+  using originals = framework::concatenated_pack_t<originals_pack_t<Ts>...>;
   using table_t = JoinBase<Ts...>;
 };
 
@@ -1050,7 +1092,7 @@ struct Concat : ConcatBase<T1, T2> {
   Concat(std::vector<std::shared_ptr<arrow::Table>> tables, uint64_t offset = 0)
     : ConcatBase<T1, T2>{ArrowHelpers::concatTables(std::move(tables)), offset} {}
 
-  using originals = framework::pack<T1, T2>;
+  using originals = framework::concatenated_pack_t<originals_pack_t<T1>, originals_pack_t<T2>>;
   // FIXME: can be remove when we do the same treatment we did for Join to Concatenate
   using left_t = T1;
   using right_t = T2;
@@ -1061,6 +1103,7 @@ template <typename T>
 class Filtered : public T
 {
  public:
+  using originals = originals_pack_t<T>;
   using iterator = typename T::filtered_iterator;
   using const_iterator = typename T::filtered_const_iterator;
 

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -207,27 +207,19 @@ struct AnalysisDataProcessorBuilder {
     (doAppendInputWithMetadata<Args>(inputs), ...);
   }
 
-  template <typename... Args>
-  static void doAppendFilteredMetadata(framework::pack<Args...>, std::vector<SchemaInfo>& filteredSchemas) {
-    (filteredSchemas.push_back({aod::MetadataTrait<Args>::metadata::label(), createSchemaFromColumns(typename Args::persistent_columns_t())}), ...);
-  }
-
-  template <typename T>
-  static void appendSomethingWithMetadata(std::vector<InputSpec>& inputs,
-                                          std::vector<SchemaInfo>& filteredSchemas)
+  template <typename T, size_t At>
+  static void appendSomethingWithMetadata(std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eInfos)
   {
+    if constexpr (framework::is_specialization<T, soa::Filtered>::value || framework::is_specialization<T, soa::RowViewFiltered>::value) {
+      eInfos.push_back({At, createSchemaFromColumns(typename T::table_t::persistent_columns_t{}), nullptr});
+    }
     doAppendInputWithMetadata(soa::make_originals_from_type<T>(), inputs);
-    
-    // Filtered tables need some extra specialization
-    if constexpr (is_specialization<std::decay_t<T>, soa::Filtered>::value) {
-      doAppendFilteredMetadata(soa::make_originals_from_type<T>(), filteredSchemas);
-    } 
   }
 
   template <typename R, typename C, typename... Args>
-  static void inputsFromArgs(R (C::*)(Args...), std::vector<InputSpec>& inputs, std::vector<SchemaInfo>& filteredSchemas)
+  static void inputsFromArgs(R (C::*)(Args...), std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eInfos)
   {
-    (appendSomethingWithMetadata<Args>(inputs, filteredSchemas), ...);
+    (appendSomethingWithMetadata<Args, has_type_at<Args>(pack<Args...>{})>(inputs, eInfos), ...);
   }
 
   template <typename R, typename C, typename Grouping, typename... Args>
@@ -239,7 +231,7 @@ struct AnalysisDataProcessorBuilder {
   template <typename R, typename C, typename Grouping, typename... Args>
   static auto bindGroupingTable(InputRecord& record, R (C::*)(Grouping, Args...), std::vector<ExpressionInfo> const& infos)
   {
-    return extractSomethingFromRecord<Grouping>(record, infos);
+    return extractSomethingFromRecord<Grouping, 0>(record, infos);
   }
 
   template <typename R, typename C>
@@ -252,73 +244,62 @@ struct AnalysisDataProcessorBuilder {
   template <typename T>
   static auto extractTableFromRecord(InputRecord& record)
   {
-    auto at = record.get<TableConsumer>(aod::MetadataTrait<T>::metadata::label())->asArrowTable();
-    return typename aod::MetadataTrait<T>::metadata::table_t(at);
-  }
-
-  template <typename T>
-  static auto extractFilteredTableFromRecord(InputRecord& record, std::vector<ExpressionInfo> const& infos)
-  {
-    using metadata = typename aod::MetadataTrait<typename std::decay_t<T>::table_t>::metadata;
-    auto at = record.get<TableConsumer>(metadata::label())->asArrowTable();
-    /// this assumes one gandiva expression tree per table name:
-    /// filters should be &&-ed at the previous stage
-    for (auto& info : infos) {
-      if (std::string{metadata::label()} != info.first)
-        continue;
-      auto selection = expressions::createSelection(at, expressions::createFilter(at->schema(), expressions::createCondition(info.second)));
-      return soa::Filtered<typename metadata::table_t>(at, selection);
+    if constexpr (soa::is_type_with_metadata_v<aod::MetadataTrait<T>>) {
+      return record.get<TableConsumer>(aod::MetadataTrait<T>::metadata::label())->asArrowTable();
+    } else {
+      static_assert(always_static_assert_v<T>, "Iterators on Joins/Concats are not supported yet!");
     }
-    throw std::runtime_error("Failed to match filter with a table.");
+    O2_BUILTIN_UNREACHABLE();
   }
 
-  template <typename... Ts>
-  static auto extractFilteredTableFromRecord(framework::pack<Ts...>, InputRecord &record, std::vector<ExpressionInfo> const& infos) {
-    return std::get<0>(std::make_tuple(extractFilteredTableFromRecord<Ts>(record, infos)...));
-  }
-
-  template <typename... Ts>
-  static auto extractJoinFromRecord(framework::pack<Ts...>, InputRecord& record)
+  template <typename T, typename... Os>
+  static auto extractFromRecord(InputRecord& record, pack<Os...> const&)
   {
-    std::vector<std::shared_ptr<arrow::Table>> tables = {
-      record.get<TableConsumer>(aod::MetadataTrait<std::decay_t<Ts>>::metadata::label())->asArrowTable()...};
-    return typename soa::Join<Ts...>(std::move(tables), 0);
+    if constexpr (soa::is_type_with_policy_v<T>) {
+      return typename T::table_t{extractTableFromRecord<Os>(record)...};
+    } else {
+      return T{{extractTableFromRecord<Os>(record)...}};
+    }
   }
 
-  template <typename T1, typename T2>
-  static auto extractConcatFromRecord(InputRecord& record)
+  template <typename T, typename... Os>
+  static auto extractFilteredFromRecord(InputRecord& record, ExpressionInfo const& info, pack<Os...> const&)
   {
-    auto at1 = record.get<TableConsumer>(aod::MetadataTrait<std::decay_t<T1>>::metadata::label())->asArrowTable();
-    auto at2 = record.get<TableConsumer>(aod::MetadataTrait<std::decay_t<T2>>::metadata::label())->asArrowTable();
-    return typename soa::Concat<T1, T2>(at1, at2);
+    if constexpr (soa::is_type_with_policy_v<T>) {
+      return soa::Filtered<typename T::table_t>(std::vector<std::shared_ptr<arrow::Table>>{extractTableFromRecord<Os>(record)...}, info.tree);
+    } else {
+      return T(std::vector<std::shared_ptr<arrow::Table>>{extractTableFromRecord<Os>(record)...}, info.tree);
+    }
   }
 
-  template <typename T>
+  template <typename T, size_t At>
   static auto extractSomethingFromRecord(InputRecord& record, std::vector<ExpressionInfo> const infos)
   {
-    if constexpr (is_specialization<std::decay_t<T>, soa::Join>::value) {
-      return extractJoinFromRecord(soa::make_originals_from_type<std::decay_t<T>>(), record);
-    } else if constexpr (is_specialization<std::decay_t<T>, soa::Concat>::value) {
-      using left_t = typename std::decay_t<T>::left_t;
-      using right_t = typename std::decay_t<T>::right_t;
-      return extractConcatFromRecord<left_t, right_t>(record);
-    } else if constexpr (is_specialization<std::decay_t<T>, soa::Filtered>::value) {
-      return extractFilteredTableFromRecord(soa::make_originals_from_type<std::decay_t<T>>(), record, infos);
-    } else if constexpr (is_specialization<std::decay_t<T>, soa::RowViewBase>::value) {
-      if constexpr (std::is_same_v<soa::DefaultIndexPolicy, typename std::decay_t<T>::policy_t>) {
-        return extractTableFromRecord<std::decay_t<T>>(record);
-      } else if constexpr (std::is_same_v<soa::FilteredIndexPolicy, typename std::decay_t<T>::policy_t>) {
-        return extractFilteredTableFromRecord(soa::make_originals_from_type<std::decay_t<T>>(), record, infos);
+    using decayed = std::decay_t<T>;
+    if constexpr (is_specialization<decayed, soa::Filtered>::value) {
+      for (auto& info : infos) {
+        if (info.I == At)
+          return extractFilteredFromRecord<decayed>(record, info, soa::make_originals_from_type<decayed>());
+      }
+    } else if constexpr (soa::is_type_with_policy_v<decayed>) {
+      if constexpr (std::is_same_v<typename decayed::policy_t, soa::FilteredIndexPolicy>) {
+        for (auto& info : infos) {
+          if (info.I == At)
+            return extractFilteredFromRecord<decayed>(record, info, soa::make_originals_from_type<decayed>());
+        }
+      } else {
+        return extractFromRecord<decayed>(record, soa::make_originals_from_type<decayed>());
       }
     } else {
-      return extractTableFromRecord<std::decay_t<T>>(record);
+      return extractFromRecord<decayed>(record, soa::make_originals_from_type<decayed>());
     }
+    O2_BUILTIN_UNREACHABLE();
   }
 
   template <typename R, typename C, typename Grouping, typename... Args>
   static auto bindAssociatedTables(InputRecord& record, R (C::*)(Grouping, Args...), std::vector<ExpressionInfo> const infos)
   {
-    return std::make_tuple(extractSomethingFromRecord<Args>(record, infos)...);
+    return std::make_tuple(extractSomethingFromRecord<Args, has_type_at<Args>(pack<Args...>{})>(record, infos)...);
   }
 
   template <typename R, typename C>
@@ -417,7 +398,8 @@ struct AnalysisDataProcessorBuilder {
               ++const_cast<std::decay_t<Grouping>&>(groupingElement);
               ++oi;
             }
-          } if constexpr (is_specialization<std::decay_t<AssociatedType>, o2::soa::Filtered>::value) {
+          }
+          if constexpr (is_specialization<std::decay_t<AssociatedType>, o2::soa::Filtered>::value) {
             // FIXME: we need to implement the case for the grouped filtered case.
           } else if constexpr (is_specialization<std::decay_t<AssociatedType>, o2::soa::Join>::value || is_specialization<std::decay_t<AssociatedType>, o2::soa::Concat>::value) {
             for (auto& groupedDatum : groupsCollection) {
@@ -444,7 +426,7 @@ struct AnalysisDataProcessorBuilder {
 template <typename T>
 struct FilterManager {
   template <typename ANY>
-  static bool createExpressionTrees(std::vector<SchemaInfo> const&, ANY&, std::vector<ExpressionInfo>&)
+  static bool createExpressionTrees(ANY&, std::vector<ExpressionInfo>&)
   {
     return false;
   }
@@ -452,9 +434,9 @@ struct FilterManager {
 
 template <>
 struct FilterManager<expressions::Filter> {
-  static bool createExpressionTrees(std::vector<SchemaInfo> const& infos, expressions::Filter const& filter, std::vector<ExpressionInfo>& expressionInfos)
+  static bool createExpressionTrees(expressions::Filter const& filter, std::vector<ExpressionInfo>& expressionInfos)
   {
-    expressionInfos = createExpressionInfos(infos, filter);
+    updateExpressionInfos(filter, expressionInfos);
     return true;
   }
 };
@@ -620,13 +602,15 @@ DataProcessorSpec adaptAnalysisTask(std::string name, Args&&... args)
                 "At least one of process(...), T::run(...), init(...) must be defined");
 
   std::vector<InputSpec> inputs;
-  std::vector<SchemaInfo> filteredSchemas;
+  // vector of pairs (number of argument in process(), pointer to gandiva expression tree)
   std::vector<ExpressionInfo> expressionInfos;
 
   if constexpr (has_process<T>::value) {
-    AnalysisDataProcessorBuilder::inputsFromArgs(&T::process, inputs, filteredSchemas);
-    std::apply([&filteredSchemas, &expressionInfos](auto&... x) {
-      return (FilterManager<std::decay_t<decltype(x)>>::createExpressionTrees(filteredSchemas, x, expressionInfos), ...);
+    // this pushes (I,schemaPtr,nullptr) into expressionInfos for arguments that are Filtered/filtered_iterators
+    AnalysisDataProcessorBuilder::inputsFromArgs(&T::process, inputs, expressionInfos);
+    // here the FilterManager will prepare the gandiva trees matched to schemas and put the pointers into expressionInfos
+    std::apply([&expressionInfos](auto&... x) {
+      return (FilterManager<std::decay_t<decltype(x)>>::createExpressionTrees(x, expressionInfos), ...);
     },
                tupledTask);
   }

--- a/Framework/Core/include/Framework/Expressions.h
+++ b/Framework/Core/include/Framework/Expressions.h
@@ -23,8 +23,11 @@
 #include <memory>
 
 using atype = arrow::Type;
-using SchemaInfo = std::pair<std::string, gandiva::SchemaPtr>;
-using ExpressionInfo = std::pair<std::string, gandiva::NodePtr>;
+struct ExpressionInfo {
+  size_t I;
+  gandiva::SchemaPtr schema;
+  gandiva::NodePtr tree;
+};
 
 namespace o2::framework::expressions
 {
@@ -268,7 +271,7 @@ std::shared_ptr<gandiva::Filter> createFilter(gandiva::SchemaPtr const& Schema,
                                               gandiva::ConditionPtr condition);
 std::shared_ptr<gandiva::Filter> createFilter(gandiva::SchemaPtr const& Schema,
                                               Operations const& opSpecs);
-std::vector<ExpressionInfo> createExpressionInfos(std::vector<SchemaInfo> const& infos, expressions::Filter const& filter);
+void updateExpressionInfos(expressions::Filter const& filter, std::vector<ExpressionInfo>& eInfos);
 gandiva::ConditionPtr createCondition(gandiva::NodePtr node);
 } // namespace o2::framework::expressions
 

--- a/Framework/Core/include/Framework/Expressions.h
+++ b/Framework/Core/include/Framework/Expressions.h
@@ -24,7 +24,7 @@
 
 using atype = arrow::Type;
 struct ExpressionInfo {
-  size_t I;
+  size_t index;
   gandiva::SchemaPtr schema;
   gandiva::NodePtr tree;
 };

--- a/Framework/Core/src/ASoA.cxx
+++ b/Framework/Core/src/ASoA.cxx
@@ -16,8 +16,9 @@ namespace o2::soa
 
 std::shared_ptr<arrow::Table> ArrowHelpers::joinTables(std::vector<std::shared_ptr<arrow::Table>>&& tables)
 {
-  if (tables.size() == 1)
+  if (tables.size() == 1) {
     return tables[0];
+  }
   std::vector<std::shared_ptr<arrow::Column>> columns;
   std::vector<std::shared_ptr<arrow::Field>> fields;
 
@@ -32,8 +33,9 @@ std::shared_ptr<arrow::Table> ArrowHelpers::joinTables(std::vector<std::shared_p
 
 std::shared_ptr<arrow::Table> ArrowHelpers::concatTables(std::vector<std::shared_ptr<arrow::Table>>&& tables)
 {
-  if (tables.size() == 1)
+  if (tables.size() == 1) {
     return tables[0];
+  }
   std::vector<std::shared_ptr<arrow::Column>> columns;
   assert(tables.size() > 1);
   std::vector<std::shared_ptr<arrow::Field>> resultFields = tables[0]->schema()->fields();

--- a/Framework/Core/src/ASoA.cxx
+++ b/Framework/Core/src/ASoA.cxx
@@ -16,6 +16,8 @@ namespace o2::soa
 
 std::shared_ptr<arrow::Table> ArrowHelpers::joinTables(std::vector<std::shared_ptr<arrow::Table>>&& tables)
 {
+  if (tables.size() == 1)
+    return tables[0];
   std::vector<std::shared_ptr<arrow::Column>> columns;
   std::vector<std::shared_ptr<arrow::Field>> fields;
 
@@ -30,6 +32,8 @@ std::shared_ptr<arrow::Table> ArrowHelpers::joinTables(std::vector<std::shared_p
 
 std::shared_ptr<arrow::Table> ArrowHelpers::concatTables(std::vector<std::shared_ptr<arrow::Table>>&& tables)
 {
+  if (tables.size() == 1)
+    return tables[0];
   std::vector<std::shared_ptr<arrow::Column>> columns;
   assert(tables.size() > 1);
   std::vector<std::shared_ptr<arrow::Field>> resultFields = tables[0]->schema()->fields();

--- a/Framework/Core/src/Expressions.cxx
+++ b/Framework/Core/src/Expressions.cxx
@@ -368,19 +368,16 @@ bool isSchemaCompatible(gandiva::SchemaPtr const& Schema, Operations const& opSp
                        opFieldNames.begin(), opFieldNames.end());
 }
 
-std::vector<ExpressionInfo> createExpressionInfos(std::vector<SchemaInfo> const& infos, expressions::Filter const& filter)
+void updateExpressionInfos(expressions::Filter const& filter, std::vector<ExpressionInfo>& eInfos)
 {
-  std::vector<ExpressionInfo> eInfos;
   Operations ops = createOperations(filter);
-  for (auto& info : infos) {
-    if (isSchemaCompatible(info.second, ops)) {
-      // FIXME: if there is already a tree for a given label, merge a new
-      //        one into it
-      eInfos.push_back({info.first, createExpressionTree(ops, info.second)});
+  for (auto& info : eInfos) {
+    if (isSchemaCompatible(info.schema, ops)) {
+      /// FIXME: check if there is already a tree assigned for an entry and
+      ///        and if so merge the new tree into it with 'and' node
+      info.tree = createExpressionTree(ops, info.schema);
     }
   }
-
-  return eInfos;
 }
 
 } // namespace o2::framework::expressions

--- a/Framework/Core/test/test_ASoA.cxx
+++ b/Framework/Core/test/test_ASoA.cxx
@@ -349,7 +349,7 @@ BOOST_AUTO_TEST_CASE(TestConcatTables)
   expressions::Selection selection_f = expressions::createSelection(tableA, testf);
 
   TestA testA{tableA};
-  FilteredTest filtered{testA.asArrowTable(), selection_f};
+  FilteredTest filtered{{testA.asArrowTable()}, selection_f};
   BOOST_CHECK_EQUAL(2, filtered.size());
 
   auto i = 0;
@@ -372,7 +372,7 @@ BOOST_AUTO_TEST_CASE(TestConcatTables)
   selectionConcat->SetIndex(2, 10);
   selectionConcat->SetNumSlots(3);
   ConcatTest concatTest{tableA, tableB};
-  FilteredConcatTest concatTestTable{concatTest.asArrowTable(), selectionConcat};
+  FilteredConcatTest concatTestTable{{concatTest.asArrowTable()}, selectionConcat};
   BOOST_CHECK_EQUAL(3, concatTestTable.size());
 
   i = 0;
@@ -403,7 +403,7 @@ BOOST_AUTO_TEST_CASE(TestConcatTables)
   selectionJoin->SetIndex(2, 4);
   selectionJoin->SetNumSlots(3);
   JoinedTest testJoin{0, tableA, tableC};
-  FilteredJoinTest filteredJoin{testJoin.asArrowTable(), selectionJoin};
+  FilteredJoinTest filteredJoin{{testJoin.asArrowTable()}, selectionJoin};
 
   i = 0;
   BOOST_CHECK(filteredJoin.begin() != filteredJoin.end());

--- a/Framework/Core/test/test_AnalysisTask.cxx
+++ b/Framework/Core/test/test_AnalysisTask.cxx
@@ -28,6 +28,7 @@ DECLARE_SOA_COLUMN(Y, y, float, "fY");
 DECLARE_SOA_COLUMN(Z, z, float, "fZ");
 DECLARE_SOA_COLUMN(Foo, foo, float, "fBar");
 DECLARE_SOA_COLUMN(Bar, bar, float, "fFoo");
+DECLARE_SOA_COLUMN(EventProperty, eventProperty, float, "fEventProperty");
 DECLARE_SOA_DYNAMIC_COLUMN(Sum, sum, [](float x, float y) { return x + y; });
 } // namespace track
 DECLARE_SOA_TABLE(Foos, "AOD", "FOO",
@@ -39,6 +40,8 @@ DECLARE_SOA_TABLE(FooBars, "AOD", "FOOBAR",
                   test::Sum<test::Foo, test::Bar>);
 DECLARE_SOA_TABLE(XYZ, "AOD", "XYZ",
                   test::X, test::Y, test::Z);
+DECLARE_SOA_TABLE(Events, "AOD", "EVENTS",
+                  test::EventProperty);
 } // namespace o2::aod
 
 // FIXME: for the moment we do not derive from AnalysisTask as
@@ -110,14 +113,26 @@ struct GTask {
 
 // FIXME: for the moment we do not derive from AnalysisTask as
 // we need GCC 7.4+ to fix a bug.
-struct HTask {
-  void process(o2::soa::Join<o2::aod::Foos, o2::aod::Bars, o2::aod::XYZ>::iterator const& foobar)
+//struct HTask {
+//  void process(o2::soa::Join<o2::aod::Foos, o2::aod::Bars, o2::aod::XYZ>::iterator const& foobar)
+//  {
+//    foobar.x();
+//    foobar.foo();
+//    foobar.bar();
+//  }
+//};
+//
+struct ITask {
+  void process(o2::aod::Events::iterator const&, o2::soa::Filtered<o2::soa::Join<o2::aod::Foos, o2::aod::Bars, o2::aod::XYZ>> const& foobars)
   {
-    foobar.x();
-    foobar.foo();
-    foobar.bar();
+    for (auto foobar : foobars) {
+      foobar.x();
+      foobar.foo();
+      foobar.bar();
+    }
   }
 };
+
 
 BOOST_AUTO_TEST_CASE(AdaptorCompilation)
 {
@@ -151,4 +166,10 @@ BOOST_AUTO_TEST_CASE(AdaptorCompilation)
 
   auto task7 = adaptAnalysisTask<GTask>("test7");
   BOOST_CHECK_EQUAL(task7.inputs.size(), 3);
+
+//  auto task8 = adaptAnalysisTask<HTask>("test8");
+//  BOOST_CHECK_EQUAL(task8.inputs.size(), 3);
+
+  auto task9 = adaptAnalysisTask<ITask>("test9");
+  BOOST_CHECK_EQUAL(task9.inputs.size(), 3);
 }

--- a/Framework/Core/test/test_AnalysisTask.cxx
+++ b/Framework/Core/test/test_AnalysisTask.cxx
@@ -123,7 +123,7 @@ struct GTask {
 //};
 
 struct ITask {
-  void process(o2::aod::Events::iterator const&, o2::soa::Filtered<o2::soa::Join<o2::aod::Foos, o2::aod::Bars, o2::aod::XYZ>> const& foobars)
+  void process(o2::soa::Filtered<o2::soa::Join<o2::aod::Foos, o2::aod::Bars, o2::aod::XYZ>> const& foobars)
   {
     for (auto foobar : foobars) {
       foobar.x();
@@ -170,5 +170,5 @@ BOOST_AUTO_TEST_CASE(AdaptorCompilation)
   //  BOOST_CHECK_EQUAL(task8.inputs.size(), 3);
 
   auto task9 = adaptAnalysisTask<ITask>("test9");
-  BOOST_CHECK_EQUAL(task9.inputs.size(), 4);
+  BOOST_CHECK_EQUAL(task9.inputs.size(), 3);
 }

--- a/Framework/Core/test/test_AnalysisTask.cxx
+++ b/Framework/Core/test/test_AnalysisTask.cxx
@@ -30,7 +30,7 @@ DECLARE_SOA_COLUMN(Foo, foo, float, "fBar");
 DECLARE_SOA_COLUMN(Bar, bar, float, "fFoo");
 DECLARE_SOA_COLUMN(EventProperty, eventProperty, float, "fEventProperty");
 DECLARE_SOA_DYNAMIC_COLUMN(Sum, sum, [](float x, float y) { return x + y; });
-} // namespace track
+} // namespace test
 DECLARE_SOA_TABLE(Foos, "AOD", "FOO",
                   test::Foo);
 DECLARE_SOA_TABLE(Bars, "AOD", "BAR",
@@ -121,7 +121,7 @@ struct GTask {
 //    foobar.bar();
 //  }
 //};
-//
+
 struct ITask {
   void process(o2::aod::Events::iterator const&, o2::soa::Filtered<o2::soa::Join<o2::aod::Foos, o2::aod::Bars, o2::aod::XYZ>> const& foobars)
   {
@@ -132,7 +132,6 @@ struct ITask {
     }
   }
 };
-
 
 BOOST_AUTO_TEST_CASE(AdaptorCompilation)
 {
@@ -167,9 +166,9 @@ BOOST_AUTO_TEST_CASE(AdaptorCompilation)
   auto task7 = adaptAnalysisTask<GTask>("test7");
   BOOST_CHECK_EQUAL(task7.inputs.size(), 3);
 
-//  auto task8 = adaptAnalysisTask<HTask>("test8");
-//  BOOST_CHECK_EQUAL(task8.inputs.size(), 3);
+  //  auto task8 = adaptAnalysisTask<HTask>("test8");
+  //  BOOST_CHECK_EQUAL(task8.inputs.size(), 3);
 
   auto task9 = adaptAnalysisTask<ITask>("test9");
-  BOOST_CHECK_EQUAL(task9.inputs.size(), 3);
+  BOOST_CHECK_EQUAL(task9.inputs.size(), 4);
 }


### PR DESCRIPTION
Streamlines the manipulation of filtered/join/concat by tracking the types of predefined tables so they can be bound from external inputs. 