### PR TITLE
DPL: Update to completion policy helpers

### DIFF
--- a/Framework/Core/include/Framework/CompletionPolicy.h
+++ b/Framework/Core/include/Framework/CompletionPolicy.h
@@ -55,15 +55,22 @@ struct CompletionPolicy {
   using Callback = std::function<CompletionOp(InputSet)>;
 
   /// Name of the policy itself.
-  std::string name;
+  std::string name = "";
   /// Callback to be used to understand if the policy should apply
   /// to the given device.
-  Matcher matcher;
+  Matcher matcher = nullptr;
   /// Actual policy which decides what to do with a partial InputRecord.
-  Callback callback;
+  Callback callback = nullptr;
 
   /// Helper to create the default configuration.
   static std::vector<CompletionPolicy> createDefaultPolicies();
+
+  /// Constructor
+  CompletionPolicy()
+    : name(), matcher(), callback() {}
+  /// Constructor for emplace_back
+  CompletionPolicy(std::string _name, Matcher _matcher, Callback _callback)
+    : name(_name), matcher(_matcher), callback(_callback) {}
 };
 
 std::ostream& operator<<(std::ostream& oss, CompletionPolicy::CompletionOp const& val);

--- a/Framework/Core/include/Framework/CompletionPolicyHelpers.h
+++ b/Framework/Core/include/Framework/CompletionPolicyHelpers.h
@@ -26,21 +26,38 @@ namespace framework
 
 /// Helper class which holds commonly used policies.
 struct CompletionPolicyHelpers {
-  /// Default Completion policy. When all the parts of a record have
-  /// arrived, consume them.
-  static CompletionPolicy consumeWhenAll();
+  /// Default Completion policy. When all the parts of a record have arrived, consume them.
+  static CompletionPolicy consumeWhenAll(const char* name, CompletionPolicy::Matcher matcher);
+  /// Default matcher applies for all devices
+  static CompletionPolicy consumeWhenAll(CompletionPolicy::Matcher matcher = [](auto const&) -> bool { return true; })
+  {
+    return consumeWhenAll("consume-all", matcher);
+  }
   /// When any of the parts of the record have been received, consume them.
-  static CompletionPolicy consumeWhenAny();
+  static CompletionPolicy consumeWhenAny(const char* name, CompletionPolicy::Matcher matcher);
+  /// Default matcher applies for all devices
+  static CompletionPolicy consumeWhenAny(CompletionPolicy::Matcher matcher = [](auto const&) -> bool { return true; })
+  {
+    return consumeWhenAny("consume-any", matcher);
+  }
   /// When any of the parts of the record have been received, process them,
   /// without actually consuming them.
-  static CompletionPolicy processWhenAny();
+  static CompletionPolicy processWhenAny(const char* name, CompletionPolicy::Matcher matcher);
+  /// Default matcher applies for all devices
+  static CompletionPolicy processWhenAny(CompletionPolicy::Matcher matcher = [](auto const&) -> bool { return true; })
+  {
+    return processWhenAny("process-any", matcher);
+  }
   /// Attach a given @a op to a device matching @name.
   static CompletionPolicy defineByName(std::string const& name, CompletionPolicy::CompletionOp op);
   /// Get a specific header from the input
   template <typename T, typename U>
   static auto getHeader(U const& input)
   {
-    return o2::header::get<typename std::add_pointer<T>::type>(input.header ? input.header->GetData() : nullptr);
+    // DataHeader interface requires to specify header pointer type, need to check if the template parameter
+    // is already pointer type, and add pointer if not
+    using return_type = typename std::conditional<std::is_pointer<T>::value, T, typename std::add_pointer<T>::type>::type;
+    return o2::header::get<return_type>(input.header ? input.header->GetData() : nullptr);
   }
 };
 

--- a/Framework/Core/src/CompletionPolicyHelpers.cxx
+++ b/Framework/Core/src/CompletionPolicyHelpers.cxx
@@ -50,9 +50,8 @@ CompletionPolicy CompletionPolicyHelpers::defineByName(std::string const& name, 
   O2_BUILTIN_UNREACHABLE();
 }
 
-CompletionPolicy CompletionPolicyHelpers::consumeWhenAll()
+CompletionPolicy CompletionPolicyHelpers::consumeWhenAll(const char* name, CompletionPolicy::Matcher matcher)
 {
-  auto matcher = [](DeviceSpec const&) -> bool { return true; };
   auto callback = [](CompletionPolicy::InputSet inputs) -> CompletionPolicy::CompletionOp {
     for (auto& input : inputs) {
       if (input.header == nullptr && input.payload == nullptr) {
@@ -61,12 +60,11 @@ CompletionPolicy CompletionPolicyHelpers::consumeWhenAll()
     }
     return CompletionPolicy::CompletionOp::Consume;
   };
-  return CompletionPolicy{"consume-all", matcher, callback};
+  return CompletionPolicy{name, matcher, callback};
 }
 
-CompletionPolicy CompletionPolicyHelpers::consumeWhenAny()
+CompletionPolicy CompletionPolicyHelpers::consumeWhenAny(const char* name, CompletionPolicy::Matcher matcher)
 {
-  auto matcher = [](DeviceSpec const&) -> bool { return true; };
   auto callback = [](CompletionPolicy::InputSet inputs) -> CompletionPolicy::CompletionOp {
     for (auto& input : inputs) {
       if (input.header != nullptr && input.payload != nullptr) {
@@ -75,12 +73,11 @@ CompletionPolicy CompletionPolicyHelpers::consumeWhenAny()
     }
     return CompletionPolicy::CompletionOp::Wait;
   };
-  return CompletionPolicy{"consume-any", matcher, callback};
+  return CompletionPolicy{name, matcher, callback};
 }
 
-CompletionPolicy CompletionPolicyHelpers::processWhenAny()
+CompletionPolicy CompletionPolicyHelpers::processWhenAny(const char* name, CompletionPolicy::Matcher matcher)
 {
-  auto matcher = [](DeviceSpec const&) -> bool { return true; };
   auto callback = [](CompletionPolicy::InputSet inputs) -> CompletionPolicy::CompletionOp {
     size_t present = 0;
     for (auto& input : inputs) {
@@ -95,7 +92,7 @@ CompletionPolicy CompletionPolicyHelpers::processWhenAny()
     }
     return CompletionPolicy::CompletionOp::Process;
   };
-  return CompletionPolicy{"process-any", matcher, callback};
+  return CompletionPolicy{name, matcher, callback};
 }
 
 } // namespace framework

--- a/Framework/Core/test/test_CompletionPolicy.cxx
+++ b/Framework/Core/test/test_CompletionPolicy.cxx
@@ -51,13 +51,17 @@ BOOST_AUTO_TEST_CASE(TestCompletionPolicy_callback)
       auto const* header = CompletionPolicyHelpers::getHeader<o2::header::DataHeader>(ref);
       BOOST_CHECK_EQUAL(header, reinterpret_cast<o2::header::DataHeader*>(pointer));
       BOOST_CHECK(CompletionPolicyHelpers::getHeader<o2::header::NameHeader<9>>(ref) != nullptr);
+      BOOST_CHECK(CompletionPolicyHelpers::getHeader<o2::header::NameHeader<9>*>(ref) != nullptr);
     }
     return CompletionPolicy::CompletionOp::Consume;
   };
 
-  CompletionPolicy policy{"test", matcher, callback};
+  std::vector<CompletionPolicy> policies;
+  policies.emplace_back("test", matcher, callback);
 
   CompletionPolicy::InputSetElement ref{std::move(header), std::move(payload)};
   CompletionPolicy::InputSet inputs{&ref, 1};
-  policy.callback(inputs);
+  for (auto& policy : policies) {
+    policy.callback(inputs);
+  }
 }


### PR DESCRIPTION
Making the default completion policies more flexible by introducing an optional
device matcher to allow fine-grained configuration with the helpers

Checking if the template type argument of getHeader is already a pointer.