### PR TITLE
GPU: Fix sorting of start hits

### DIFF
--- a/GPU/Common/GPUDefConstantsAndSettings.h
+++ b/GPU/Common/GPUDefConstantsAndSettings.h
@@ -28,7 +28,6 @@
   #error Invalid Compile Definitions, need to build for either AliRoot or O2 or Standalone
 #endif
 
-#define GPUCA_EXTERN_ROW_HITS
 #define GPUCA_TRACKLET_SELECTOR_MIN_HITS(QPT) (CAMath::Abs(QPT) > 10 ? 10 : (CAMath::Abs(QPT) > 5 ? 15 : 29)) // Minimum hits should depend on Pt, low Pt tracks can have few hits. 29 Hits default, 15 for < 200 mev, 10 for < 100 mev
 
 #define GPUCA_GLOBAL_TRACKING_RANGE 45                // Number of rows from the upped/lower limit to search for global track candidates in for
@@ -50,8 +49,6 @@
 #define GPUCA_MERGER_COV_LIMIT 1000                   // Abort fit when y/z cov exceed the limit
 #define GPUCA_MIN_TRACK_PT_DEFAULT 0.010              // Default setting for minimum track Pt at some places
 
-#define GPUCA_MAX_SLICE_NTRACK (2 << 24)              // Maximum number of tracks per slice (limited by track id format)
-
 #define GPUCA_MAX_SIN_PHI_LOW 0.99f                   // Must be preprocessor define because c++ pre 11 cannot use static constexpr for initializes
 #define GPUCA_MAX_SIN_PHI 0.999f
 
@@ -70,13 +67,11 @@
   #endif
 #endif
 
-//#define GPUCA_MERGER_BY_MC_LABEL
-#define GPUCA_REPRODUCIBLE_CLUSTER_SORTING
-
-//#define GPUCA_FULL_CLUSTERDATA                      //Store all cluster information in the cluster data, also those not needed for tracking.
-//#define GPUCA_TPC_RAW_PROPAGATE_PAD_ROW_TIME        //Propagate Pad, Row, Time cluster information to GM
-//#define GPUCA_GM_USE_FULL_FIELD                     //Use offline magnetic field during GMPropagator prolongation
-//#define GPUCA_TPC_USE_STAT_ERROR                    //Use statistical errors from offline in track fit
+//#define GPUCA_MERGER_BY_MC_LABEL                    // Use MC labels for TPC track merging - for performance studies
+//#define GPUCA_FULL_CLUSTERDATA                      // Store all cluster information in the cluster data, also those not needed for tracking.
+//#define GPUCA_TPC_RAW_PROPAGATE_PAD_ROW_TIME        // Propagate Pad, Row, Time cluster information to GM
+//#define GPUCA_GM_USE_FULL_FIELD                     // Use offline magnetic field during GMPropagator prolongation
+//#define GPUCA_TPC_USE_STAT_ERROR                    // Use statistical errors from offline in track fit
 
 // clang-format on
 

--- a/GPU/Common/GPUDefGPUParameters.h
+++ b/GPU/Common/GPUDefGPUParameters.h
@@ -40,12 +40,13 @@
   #define GPUCA_NEIGHBORSFINDER_REGS REG, (GPUCA_THREAD_COUNT_FINDER, 1)
   #define GPUCA_NEIGHBOURS_FINDER_MAX_NNEIGHUP 6
   #define GPUCA_TRACKLET_SELECTOR_HITS_REG_SIZE 12
-  //#define GPUCA_USE_TEXTURES
+  // #define GPUCA_USE_TEXTURES
 #elif defined(GPUCA_GPUTYPE_OPENCL)
 #elif defined(GPUCA_GPUCODE)
   #error GPU TYPE NOT SET
 #endif
 
+// Default settings, if not already set for selected GPU type
 #ifndef GPUCA_BLOCK_COUNT_CONSTRUCTOR_MULTIPLIER
 #define GPUCA_BLOCK_COUNT_CONSTRUCTOR_MULTIPLIER 2
 #endif
@@ -91,14 +92,11 @@
 #define GPUCA_MAX_THREADS 1024
 #define GPUCA_MAX_STREAMS 32
 
+#define GPUCA_EXTERN_ROW_HITS                                          // Store row hits in separate array outside of tracklets
+#define GPUCA_SORT_STARTHITS_GPU                                       // Sort the start hits when running on GPU
 #define GPUCA_ROWALIGNMENT uint4                                       // Align Row Hits and Grid
 
-#ifdef GPUCA_USE_TEXTURES
-  #define GPUCA_TEXTURE_FETCH_CONSTRUCTOR                              // Fetch data through texture cache
-  #define GPUCA_TEXTURE_FETCH_NEIGHBORS                                // Fetch also in Neighbours Finder
-#endif
-
-// #define GPUCA_TRACKLET_CONSTRUCTOR_DO_PROFILE                        // Output Profiling Data for Tracklet Constructor Tracklet Scheduling
+// #define GPUCA_TRACKLET_CONSTRUCTOR_DO_PROFILE                       // Output Profiling Data for Tracklet Constructor Tracklet Scheduling
 
 #define GPUCA_TRACKLET_SELECTOR_SLICE_COUNT 8                          // Currently must be smaller than avaiable MultiProcessors on GPU or will result in wrong results
 
@@ -113,11 +111,22 @@
 #define GPUCA_HOST_MEMORY_SIZE       ((size_t) 6 * 1024 * 1024 * 1024) // Size of memory allocated on Host
 #define GPUCA_GPU_STACK_SIZE         ((size_t)               8 * 1024) // Stack size per GPU thread
 
+#define GPUCA_MAX_SLICE_NTRACK (2 << 24)                               // Maximum number of tracks per slice (limited by track id format)
+
 // #define GPUCA_KERNEL_DEBUGGER_OUTPUT
 
 // Some assertions to make sure out parameters are not invalid
 #ifdef GPUCA_NOCOMPAT
   static_assert(GPUCA_MAXN > GPUCA_NEIGHBOURS_FINDER_MAX_NNEIGHUP);
+#endif
+
+// Derived parameters
+#ifdef GPUCA_USE_TEXTURES
+  #define GPUCA_TEXTURE_FETCH_CONSTRUCTOR                              // Fetch data through texture cache
+  #define GPUCA_TEXTURE_FETCH_NEIGHBORS                                // Fetch also in Neighbours Finder
+#endif
+#if defined(GPUCA_SORT_STARTHITS_GPU) && defined(GPUCA_GPUCODE)
+  #define GPUCA_SORT_STARTHITS
 #endif
 
 // Error Codes for GPU Tracker

--- a/GPU/GPUTracking/Base/GPUReconstruction.h
+++ b/GPU/GPUTracking/Base/GPUReconstruction.h
@@ -156,7 +156,7 @@ class GPUReconstruction
 
   void PrepareEvent();
   virtual int RunChains() = 0;
-  int getNEventsProcessed() { return mStatNEvents; }
+  unsigned int getNEventsProcessed() { return mNEventsProcessed; }
 
   // Helpers for memory allocation
   GPUMemoryResource& Res(short num) { return mMemoryResources[num]; }
@@ -292,7 +292,8 @@ class GPUReconstruction
 
   // Others
   bool mInitialized = false;
-  int mStatNEvents = 0;
+  unsigned int mStatNEvents = 0;
+  unsigned int mNEventsProcessed = 0;
 
   // Management for GPUProcessors
   struct ProcessorData {

--- a/GPU/GPUTracking/Base/GPUReconstructionCPU.cxx
+++ b/GPU/GPUTracking/Base/GPUReconstructionCPU.cxx
@@ -181,6 +181,7 @@ int GPUReconstructionCPU::getRecoStepNum(RecoStep step, bool validCheck)
 int GPUReconstructionCPU::RunChains()
 {
   mStatNEvents++;
+  mNEventsProcessed++;
 
   if (mThreadId != GetThread()) {
     if (mDeviceProcessingSettings.debugLevel >= 2) {

--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -272,7 +272,7 @@ int GPUChainTracking::Init()
     WriteToConstantMemory(RecoStep::NoRecoStep, (char*)&processors()->calibObjects - (char*)processors(), &mFlatObjectsDevice.mCalibObjects, sizeof(mFlatObjectsDevice.mCalibObjects), -1);
   }
 
-  if (GetDeviceProcessingSettings().debugLevel >= 4) {
+  if (GetDeviceProcessingSettings().debugLevel >= 6) {
     mDebugFile.open(mRec->IsGPU() ? "GPU.out" : "CPU.out");
   }
 
@@ -389,7 +389,7 @@ int GPUChainTracking::Finalize()
   if (GetDeviceProcessingSettings().runQA && mQA->IsInitialized()) {
     mQA->DrawQAHistograms();
   }
-  if (GetDeviceProcessingSettings().debugLevel >= 4) {
+  if (GetDeviceProcessingSettings().debugLevel >= 6) {
     mDebugFile.close();
   }
   if (mCompressionStatistics) {
@@ -1161,16 +1161,12 @@ int GPUChainTracking::RunTPCTrackingSlices_internal()
         continue;
       }
     }
-    if (!doGPU && trk.CheckEmptySlice()) {
+    if (!doGPU && trk.CheckEmptySlice() && GetDeviceProcessingSettings().debugLevel == 0) {
       continue;
     }
 
-    if (GetDeviceProcessingSettings().debugLevel >= 4) {
-      if (!GetDeviceProcessingSettings().comparableDebutOutput) {
-        mDebugFile << std::endl
-                   << std::endl
-                   << "Reconstruction: Slice " << iSlice << "/" << NSLICES << std::endl;
-      }
+    if (GetDeviceProcessingSettings().debugLevel >= 6) {
+      mDebugFile << "\n\nReconstruction: Slice " << iSlice << "/" << NSLICES << std::endl;
       if (GetDeviceProcessingSettings().debugMask & 1) {
         trk.DumpSliceData(mDebugFile);
       }
@@ -1767,6 +1763,9 @@ int GPUChainTracking::RunChain()
   }
   static HighResTimer timerTracking, timerMerger, timerQA, timerTransform, timerCompression, timerClusterer;
   int nCount = mRec->getNEventsProcessed();
+  if (GetDeviceProcessingSettings().debugLevel >= 6) {
+    mDebugFile << "\n\nProcessing event " << nCount << std::endl;
+  }
 
 #ifdef GPUCA_STANDALONE
   mRec->PrepareEvent();

--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -1207,9 +1207,11 @@ int GPUChainTracking::RunTPCTrackingSlices_internal()
     DoDebugAndDump(RecoStep::TPCSliceTracking, 4, trk, &GPUTPCTracker::DumpLinks, mDebugFile);
 
     runKernel<GPUTPCStartHitsFinder>({GPUCA_ROW_COUNT - 6, ThreadCount(), useStream}, {iSlice});
+#ifdef GPUCA_SORT_STARTHITS_GPU
     if (doGPU) {
       runKernel<GPUTPCStartHitsSorter>({BlockCount(), ThreadCount(), useStream}, {iSlice});
     }
+#endif
     DoDebugAndDump(RecoStep::TPCSliceTracking, 32, trk, &GPUTPCTracker::DumpStartHits, mDebugFile);
 
     if (GetDeviceProcessingSettings().memoryAllocationStrategy == GPUMemoryResource::ALLOCATION_INDIVIDUAL) {

--- a/GPU/GPUTracking/SliceTracker/GPUTPCGeometry.h
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCGeometry.h
@@ -84,6 +84,8 @@ class GPUTPCGeometry
 
  public:
   GPUd() int GetRegion(int row) const { return (row < 63 ? 0 : row < 63 + 64 ? 1 : 2); }
+  GPUd() int GetRegionRows(int region) const { return 0; }  // dummy
+  GPUd() int GetRegionStart(int region) const { return 0; } // dummy
   GPUd() int GetROC(int row) const { return GetRegion(row); }
   GPUd() int EndIROC() const { return 63; }
   GPUd() int EndOROC1() const { return 63 + 64; }

--- a/GPU/GPUTracking/SliceTracker/GPUTPCTracker.cxx
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCTracker.cxx
@@ -141,7 +141,7 @@ void GPUTPCTracker::SetMaxData(const GPUTrackingInOutPointers& io)
   mNMaxTracklets = mRec->MemoryScalers()->NTPCTracklets(mData.NumberOfHits());
   mNMaxTracks = mRec->MemoryScalers()->NTPCSectorTracks(mData.NumberOfHits());
   mNMaxTrackHits = mRec->MemoryScalers()->NTPCSectorTrackHits(mData.NumberOfHits());
-#ifdef GPUCA_SORT_STARTHITS
+#ifdef GPUCA_SORT_STARTHITS_GPU
   if (mRec->IsGPU()) {
     if (mNMaxStartHits > mNMaxRowStartHits * GPUCA_ROW_COUNT) {
       mNMaxStartHits = mNMaxRowStartHits * GPUCA_ROW_COUNT;


### PR DESCRIPTION
GPUCA_SORT_STARTHITS was not set correctly since some time, which crashed processing of Run 2 data, and could lead to memory corruption in any case. This sets it correctly, also fixes the behavior when it is not set, and adds some debugging output.