### PR TITLE
Initial support of externally provided GPU output buffers in O2

### DIFF
--- a/GPU/GPUTracking/Base/GPUOutputControl.h
+++ b/GPU/GPUTracking/Base/GPUOutputControl.h
@@ -25,14 +25,13 @@ namespace gpu
 {
 struct GPUOutputControl {
   enum OutputTypeStruct { AllocateInternal = 0,
-                          UseExternalBuffer = 1,
-                          ControlledExternal = 2 };
+                          UseExternalBuffer = 1 };
 #ifndef GPUCA_GPUCODE_DEVICE
   GPUOutputControl() = default;
 #endif
 
-  char* OutputPtr = nullptr;                      // Pointer to Output Space
-  volatile size_t Offset = 0;                     // Offset to write into output pointer
+  void* OutputBase = nullptr;                     // Base ptr to memory pool, occupied size is OutputPtr - OutputBase
+  void* OutputPtr = nullptr;                      // Pointer to Output Space
   size_t OutputMaxSize = 0;                       // Max Size of Output Data if Pointer to output space is given
   OutputTypeStruct OutputType = AllocateInternal; // How to perform the output
   char EndOfSpace = 0;                            // end of space flag

--- a/GPU/GPUTracking/Base/GPUReconstruction.h
+++ b/GPU/GPUTracking/Base/GPUReconstruction.h
@@ -157,6 +157,8 @@ class GPUReconstruction
   void PrepareEvent();
   virtual int RunChains() = 0;
   unsigned int getNEventsProcessed() { return mNEventsProcessed; }
+  virtual int registerMemoryForGPU(void* ptr, size_t size) = 0;
+  virtual int unregisterMemoryForGPU(void* ptr) = 0;
 
   // Helpers for memory allocation
   GPUMemoryResource& Res(short num) { return mMemoryResources[num]; }

--- a/GPU/GPUTracking/Base/GPUReconstruction.h
+++ b/GPU/GPUTracking/Base/GPUReconstruction.h
@@ -166,7 +166,7 @@ class GPUReconstruction
   short RegisterMemoryAllocation(T* proc, void* (T::*setPtr)(void*), int type, const char* name = "", const GPUMemoryReuse& re = GPUMemoryReuse());
   size_t AllocateMemoryResources();
   size_t AllocateRegisteredMemory(GPUProcessor* proc);
-  size_t AllocateRegisteredMemory(short res);
+  size_t AllocateRegisteredMemory(short res, GPUOutputControl* control = nullptr);
   void* AllocateUnmanagedMemory(size_t size, int type);
   void FreeRegisteredMemory(GPUProcessor* proc, bool freeCustom = false, bool freePermanent = false);
   void FreeRegisteredMemory(short res);

--- a/GPU/GPUTracking/Base/GPUReconstructionCPU.h
+++ b/GPU/GPUTracking/Base/GPUReconstructionCPU.h
@@ -118,6 +118,8 @@ class GPUReconstructionCPU : public GPUReconstructionKernels<GPUReconstructionCP
   constexpr static const char* GetKernelName();
 
   virtual int GPUDebug(const char* state = "UNKNOWN", int stream = -1);
+  int registerMemoryForGPU(void* ptr, size_t size) override { return 0; }
+  int unregisterMemoryForGPU(void* ptr) override { return 0; }
   int GPUStuck() { return mGPUStuck; }
   int NStreams() { return mNStreams; }
   void SetThreadCounts(RecoStep step);

--- a/GPU/GPUTracking/Base/GPUReconstructionDeviceBase.cxx
+++ b/GPU/GPUTracking/Base/GPUReconstructionDeviceBase.cxx
@@ -300,3 +300,13 @@ int GPUReconstructionDeviceBase::GetMaxThreads()
   int retVal = mTRDThreadCount * mBlockCount;
   return std::max(retVal, GPUReconstruction::GetMaxThreads());
 }
+
+int GPUReconstructionDeviceBase::registerMemoryForGPU(void* ptr, size_t size)
+{
+  return IsGPU();
+}
+
+int GPUReconstructionDeviceBase::unregisterMemoryForGPU(void* ptr)
+{
+  return IsGPU();
+}

--- a/GPU/GPUTracking/Base/GPUReconstructionDeviceBase.h
+++ b/GPU/GPUTracking/Base/GPUReconstructionDeviceBase.h
@@ -42,6 +42,8 @@ class GPUReconstructionDeviceBase : public GPUReconstructionCPU
   virtual int InitDevice_Runtime() = 0;
   int ExitDevice() override;
   virtual int ExitDevice_Runtime() = 0;
+  int registerMemoryForGPU(void* ptr, size_t size) override;
+  int unregisterMemoryForGPU(void* ptr) override;
 
   virtual const GPUTPCTracker* CPUTracker(int iSlice) { return &processors()->tpcTrackers[iSlice]; }
 

--- a/GPU/GPUTracking/Base/cuda/GPUReconstructionCUDA.cu
+++ b/GPU/GPUTracking/Base/cuda/GPUReconstructionCUDA.cu
@@ -553,3 +553,13 @@ void GPUReconstructionCUDABackend::SetThreadCounts()
   mClustererThreadCount = GPUCA_THREAD_COUNT_CLUSTERER;
   mScanThreadCount = GPUCA_THREAD_COUNT_SCAN;
 }
+
+int GPUReconstructionCUDABackend::registerMemoryForGPU(void* ptr, size_t size)
+{
+  return GPUFailedMsgI(cudaHostRegister(ptr, size, cudaHostRegisterDefault));
+}
+
+int GPUReconstructionCUDABackend::unregisterMemoryForGPU(void* ptr)
+{
+  return GPUFailedMsgI(cudaHostUnregister(ptr));
+}

--- a/GPU/GPUTracking/Base/cuda/GPUReconstructionCUDA.h
+++ b/GPU/GPUTracking/Base/cuda/GPUReconstructionCUDA.h
@@ -59,6 +59,8 @@ class GPUReconstructionCUDABackend : public GPUReconstructionDeviceBase
   bool IsEventDone(deviceEvent* evList, int nEvents = 1) override;
 
   int PrepareTextures() override;
+  int registerMemoryForGPU(void* ptr, size_t size) override;
+  int unregisterMemoryForGPU(void* ptr) override;
 
   size_t WriteToConstantMemory(size_t offset, const void* src, size_t size, int stream = -1, deviceEvent* ev = nullptr) override;
   size_t TransferMemoryInternal(GPUMemoryResource* res, int stream, deviceEvent* ev, deviceEvent* evList, int nEvents, bool toGPU, const void* src, void* dst) override;

--- a/GPU/GPUTracking/Base/hip/GPUReconstructionHIP.h
+++ b/GPU/GPUTracking/Base/hip/GPUReconstructionHIP.h
@@ -43,6 +43,8 @@ class GPUReconstructionHIPBackend : public GPUReconstructionDeviceBase
   void SynchronizeStream(int stream) override;
   void SynchronizeEvents(deviceEvent* evList, int nEvents = 1) override;
   bool IsEventDone(deviceEvent* evList, int nEvents = 1) override;
+  int registerMemoryForGPU(void* ptr, size_t size) override;
+  int unregisterMemoryForGPU(void* ptr) override;
 
   size_t WriteToConstantMemory(size_t offset, const void* src, size_t size, int stream = -1, deviceEvent* ev = nullptr) override;
   size_t TransferMemoryInternal(GPUMemoryResource* res, int stream, deviceEvent* ev, deviceEvent* evList, int nEvents, bool toGPU, const void* src, void* dst) override;

--- a/GPU/GPUTracking/Base/hip/GPUReconstructionHIP.hip.cxx
+++ b/GPU/GPUTracking/Base/hip/GPUReconstructionHIP.hip.cxx
@@ -492,3 +492,13 @@ void GPUReconstructionHIPBackend::SetThreadCounts()
   mClustererThreadCount = GPUCA_THREAD_COUNT_CLUSTERER;
   mScanThreadCount = GPUCA_THREAD_COUNT_SCAN;
 }
+
+int GPUReconstructionHIPBackend::registerMemoryForGPU(void* ptr, size_t size)
+{
+  return GPUFailedMsgI(hipHostRegister(ptr, size, hipHostRegisterDefault));
+}
+
+int GPUReconstructionHIPBackend::unregisterMemoryForGPU(void* ptr)
+{
+  return GPUFailedMsgI(hipHostUnregister(ptr));
+}

--- a/GPU/GPUTracking/Base/opencl-common/GPUReconstructionOCLInternals.h
+++ b/GPU/GPUTracking/Base/opencl-common/GPUReconstructionOCLInternals.h
@@ -231,7 +231,7 @@ int GPUReconstructionOCL::AddKernel(bool multi)
   std::string kname("krnl_" + name);
 
   cl_int ocl_error;
-  cl_kernel krnl = clCreateKernel(mInternals->program, name.c_str(), &ocl_error);
+  cl_kernel krnl = clCreateKernel(mInternals->program, kname.c_str(), &ocl_error);
   if (GPUFailedMsgI(ocl_error)) {
     GPUError("Error creating OPENCL Kernel: %s", name.c_str());
     return 1;

--- a/GPU/GPUTracking/Global/GPUChain.h
+++ b/GPU/GPUTracking/Global/GPUChain.h
@@ -177,7 +177,7 @@ class GPUChain
   inline unsigned int ScanThreadCount() const { return mRec->mScanThreadCount; }
   inline unsigned int TRDThreadCount() const { return mRec->mTRDThreadCount; }
   inline size_t AllocateRegisteredMemory(GPUProcessor* proc) { return mRec->AllocateRegisteredMemory(proc); }
-  inline size_t AllocateRegisteredMemory(short res) { return mRec->AllocateRegisteredMemory(res); }
+  inline size_t AllocateRegisteredMemory(short res, GPUOutputControl* control = nullptr) { return mRec->AllocateRegisteredMemory(res, control); }
   template <class T>
   inline void SetupGPUProcessor(T* proc, bool allocate)
   {

--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -1625,7 +1625,7 @@ int GPUChainTracking::RunTPCCompression()
   Compressor.mOutput.nAttachedClustersReduced = Compressor.mOutput.nAttachedClusters - Compressor.mOutput.nTracks;
   Compressor.mOutput.nSliceRows = NSLICES * GPUCA_ROW_COUNT;
   Compressor.mOutput.nComppressionModes = param().rec.tpcCompressionModes;
-  AllocateRegisteredMemory(Compressor.mMemoryResOutputHost);
+  AllocateRegisteredMemory(Compressor.mMemoryResOutputHost, &mRec->OutputControl());
   GPUMemCpyAlways(myStep, Compressor.mOutput.nSliceRowClusters, CompressorShadow.mPtrs.nSliceRowClusters, NSLICES * GPUCA_ROW_COUNT * sizeof(Compressor.mOutput.nSliceRowClusters[0]), 0, false);
   GPUMemCpyAlways(myStep, Compressor.mOutput.nTrackClusters, CompressorShadow.mPtrs.nTrackClusters, Compressor.mOutput.nTracks * sizeof(Compressor.mOutput.nTrackClusters[0]), 0, false);
   SynchronizeGPU();

--- a/GPU/GPUTracking/SliceTracker/GPUTPCSliceOutput.cxx
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCSliceOutput.cxx
@@ -29,14 +29,14 @@ void GPUTPCSliceOutput::Allocate(GPUTPCSliceOutput*& ptrOutput, int nTracks, int
   // Allocate All memory needed for slice output
   const size_t memsize = EstimateSize(nTracks, nTrackHits);
 
-  if (outputControl->OutputType != GPUOutputControl::AllocateInternal) {
-    if (outputControl->OutputMaxSize - outputControl->Offset < memsize) {
+  if (outputControl && outputControl->OutputType != GPUOutputControl::AllocateInternal) {
+    if (outputControl->OutputMaxSize - ((char*)outputControl->OutputPtr - (char*)outputControl->OutputBase) < memsize) {
       outputControl->EndOfSpace = 1;
       ptrOutput = nullptr;
       return;
     }
-    ptrOutput = reinterpret_cast<GPUTPCSliceOutput*>(outputControl->OutputPtr + outputControl->Offset);
-    outputControl->Offset += memsize;
+    ptrOutput = reinterpret_cast<GPUTPCSliceOutput*>(outputControl->OutputPtr);
+    outputControl->OutputPtr = (char*)outputControl->OutputPtr + memsize;
   } else {
     if (internalMemory) {
       free(internalMemory);

--- a/GPU/GPUTracking/Standalone/standalone.cxx
+++ b/GPU/GPUTracking/Standalone/standalone.cxx
@@ -394,6 +394,9 @@ int SetupReconstruction()
     printf("Error initializing GPUReconstruction!\n");
     return 1;
   }
+  if (configStandalone.outputcontrolmem && rec->IsGPU() && rec->registerMemoryForGPU(outputmemory.get(), configStandalone.outputcontrolmem)) {
+    printf("ERROR registering memory for the GPU!!!\n");
+  }
   return (0);
 }
 
@@ -631,6 +634,9 @@ breakrun:
 #endif
 
   rec->Finalize();
+  if (configStandalone.outputcontrolmem && rec->IsGPU()) {
+    rec->unregisterMemoryForGPU(outputmemory.get());
+  }
   rec->Exit();
 
   if (!configStandalone.noprompt) {


### PR DESCRIPTION
Can provide external output buffers (standalone benchmark does it already)
Can register the memory for GPU DMA transfers.
Can write compressed TPC clusters into it (more is comming)