### PR TITLE
DPL: Optimization for associating output messages with actual channels

### DIFF
--- a/Framework/Core/include/Framework/MessageContext.h
+++ b/Framework/Core/include/Framework/MessageContext.h
@@ -242,14 +242,14 @@ class MessageContext
     /// constructor taking header message by move and creating the payload message for the span
     template <typename ContextType>
     SpanObject(ContextType* context, FairMQMessagePtr&& headerMsg, const std::string& bindingChannel, int index, size_t nElements)
+      : ContextObject(std::forward<FairMQMessagePtr>(headerMsg), bindingChannel)
     {
       // create the span object for the memory of the payload message
       // TODO: we probably also want to check consistency of the header message, i.e. payloadSize member
       auto payloadMsg = context->createMessage(bindingChannel, index, nElements * sizeof(T));
       mValue = value_type(reinterpret_cast<T*>(payloadMsg->GetData()), nElements);
-      mParts.AddPart(std::move(headerMsg));
+      assert(mParts.Size() == 1);
       mParts.AddPart(std::move(payloadMsg));
-      mChannel = bindingChannel;
     }
     ~SpanObject() override = default;
 

--- a/Framework/Core/src/DataProcessor.cxx
+++ b/Framework/Core/src/DataProcessor.cxx
@@ -38,7 +38,7 @@ void DataProcessor::doSend(FairMQDevice& device, FairMQParts&& parts, const char
 
 void DataProcessor::doSend(FairMQDevice& device, MessageContext& context)
 {
-  std::unordered_map<std::string, FairMQParts> outputs;
+  std::unordered_map<std::string const*, FairMQParts> outputs;
   auto contextMessages = context.getMessagesForSending();
   for (auto& message : contextMessages) {
     //     monitoringService.send({ message->parts.Size(), "outputs/total" });
@@ -46,11 +46,11 @@ void DataProcessor::doSend(FairMQDevice& device, MessageContext& context)
     assert(message->empty());
     assert(parts.Size() == 2);
     for (auto& part : parts) {
-      outputs[message->channel()].AddPart(std::move(part));
+      outputs[&(message->channel())].AddPart(std::move(part));
     }
   }
   for (auto& [channel, parts] : outputs) {
-    device.Send(parts, channel, 0);
+    device.Send(parts, *channel, 0);
   }
 }
 


### PR DESCRIPTION
This is a follow-up to commit f6d950b

1. Introducing a registry of channel names in the MessageContext

The unique references of string objects from the registry allow fast access
and association of messages to actual FairMQChannels by avoiding string
allocation.

2. Optimization to unordered_map

Using pointer to channel string as key to avoid allocation of strings.
The ContextObjects hold references of the string variables from the registry.
The string references from the OutputRoute definition of the device do not
fulfill the requirement to refer to one single string object per channel,
because the device stores a vector of OutputRoutes.

