### PR TITLE
Cleaning and speeding up the StaggeringWorkflow unit test

### DIFF
--- a/Framework/Core/test/test_StaggeringWorkflow.cxx
+++ b/Framework/Core/test/test_StaggeringWorkflow.cxx
@@ -83,24 +83,18 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
   }
 
   auto producerFct = adaptStateless([subspecs](DataAllocator& outputs, RawDeviceService& device, ControlService& control) {
-    // static bool ready = false;
-    // if (ready) {
-    //   return;
-    // }
 
     for (auto const& subspec : subspecs) {
-      // since the snapshot copy is ready for sending it is scheduled but hald back
+      // since the snapshot copy is ready for sending it is scheduled but held back
       // because of the CompletionPolicy trigger matcher. This message will be
       // sent together with the second message.
       outputs.snapshot(Output{"PROD", "CHANNEL", subspec, Lifetime::Timeframe}, subspec);
-      device.device()->WaitFor(std::chrono::milliseconds(1000));
+      device.device()->WaitFor(std::chrono::milliseconds(100));
       outputs.snapshot(Output{"PROD", "TRIGGER", subspec, Lifetime::Timeframe}, subspec);
-      //  std::cout << "publishing channel " << subspec << std::endl;
-      device.device()->WaitFor(std::chrono::milliseconds(1000));
+      device.device()->WaitFor(std::chrono::milliseconds(100));
     }
     control.endOfStream();
     control.readyToQuit(QuitRequest::Me);
-    // ready = true;
   });
 
   auto processorFct = [](ProcessingContext& pc) {


### PR DESCRIPTION
Reduce staggering time to speed up the unit test. Removing obsolete code, the
compute method is not invoked any more after issuing end of stream, the local
handling is not necessary any more.