### PR TITLE
[EMCAL-642] Determine end-of-data via valid RCU trailer

### DIFF
--- a/Detectors/EMCAL/base/CMakeLists.txt
+++ b/Detectors/EMCAL/base/CMakeLists.txt
@@ -12,7 +12,8 @@ o2_add_library(EMCALBase
                SOURCES src/Geometry.cxx src/Hit.cxx
                        src/ShishKebabTrd1Module.cxx
                        src/Mapper.cxx
-               PUBLIC_LINK_LIBRARIES O2::CommonDataFormat Boost::serialization
+                       src/RCUTrailer.cxx
+               PUBLIC_LINK_LIBRARIES O2::CommonDataFormat O2::Headers Boost::serialization
                                      O2::MathUtils O2::DataFormatsEMCAL
                                      O2::SimulationDataFormat ROOT::Physics)
 
@@ -21,7 +22,9 @@ o2_target_root_dictionary(EMCALBase
                                   include/EMCALBase/Geometry.h
                                   include/EMCALBase/Hit.h
                                   include/EMCALBase/ShishKebabTrd1Module.h
-                                  include/EMCALBase/Mapper.h)
+                                  include/EMCALBase/Mapper.h
+                                  include/EMCALBase/RCUTrailer.h
+                                  )
 
 o2_data_file(COPY files DESTINATION Detectors/EMC)
 

--- a/Detectors/EMCAL/base/include/EMCALBase/RCUTrailer.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/RCUTrailer.h
@@ -13,8 +13,9 @@
 #include <exception>
 #include <iosfwd>
 #include <string>
+#include <cstdint>
+#include <gsl/span>
 #include "Rtypes.h"
-#include "EMCALReconstruction/RawPayload.h"
 
 namespace o2
 {
@@ -24,7 +25,7 @@ namespace emcal
 
 /// \class RCUTrailer
 /// \brief Information stored in the RCU trailer
-/// \ingroup EMCALreconstruction
+/// \ingroup EMCALbase
 ///
 /// The RCU trailer can be found at the end of
 /// the payload and contains general information
@@ -90,7 +91,7 @@ class RCUTrailer
   ///
   /// Read the RCU trailer according to the RCU formware version
   /// specified in CDH.
-  void constructFromRawPayload(const RawPayload& buffer);
+  void constructFromRawPayload(const gsl::span<const uint32_t> payloadwords);
 
   unsigned int getFECErrorsA() const { return mFECERRA; }
   unsigned int getFECErrorsB() const { return mFECERRB; }
@@ -142,6 +143,8 @@ class RCUTrailer
   /// \brief checlks whether the RCU trailer is initialzied
   /// \return True if the trailer is initialized, false otherwise
   bool isInitialized() const { return mIsInitialized; }
+
+  static RCUTrailer constructFromPayloadWords(const gsl::span<const uint32_t> payloadwords);
 
  private:
   int mRCUId = -1;                    ///< current RCU identifier

--- a/Detectors/EMCAL/base/src/RCUTrailer.cxx
+++ b/Detectors/EMCAL/base/src/RCUTrailer.cxx
@@ -10,7 +10,7 @@
 #include <iostream>
 #include <boost/format.hpp>
 #include "CommonConstants/LHCConstants.h"
-#include "EMCALReconstruction/RCUTrailer.h"
+#include "EMCALBase/RCUTrailer.h"
 
 using namespace o2::emcal;
 
@@ -31,10 +31,9 @@ void RCUTrailer::reset()
   mIsInitialized = false;
 }
 
-void RCUTrailer::constructFromRawPayload(const RawPayload& buffer)
+void RCUTrailer::constructFromRawPayload(const gsl::span<const uint32_t> payloadwords)
 {
   reset();
-  auto payloadwords = buffer.getPayloadWords();
   int index = payloadwords.size() - 1;
   auto word = payloadwords[index];
   if ((word >> 30) != 3)
@@ -181,6 +180,13 @@ void RCUTrailer::printStream(std::ostream& stream) const
     }
   }
   stream << "==================================================\n";
+}
+
+RCUTrailer RCUTrailer::constructFromPayloadWords(const gsl::span<const uint32_t> payloadwords)
+{
+  RCUTrailer result;
+  result.constructFromRawPayload(payloadwords);
+  return result;
 }
 
 std::ostream& o2::emcal::operator<<(std::ostream& stream, const o2::emcal::RCUTrailer& trailer)

--- a/Detectors/EMCAL/reconstruction/CMakeLists.txt
+++ b/Detectors/EMCAL/reconstruction/CMakeLists.txt
@@ -16,7 +16,6 @@ o2_add_library(EMCALReconstruction
                        src/RAWDataHeader.cxx
                        src/RawPayload.cxx
                        src/AltroDecoder.cxx
-                       src/RCUTrailer.cxx
                        src/Bunch.cxx
                        src/Channel.cxx
                        src/CaloFitResults.cxx
@@ -37,7 +36,6 @@ o2_target_root_dictionary(
                           HEADERS include/EMCALReconstruction/RawReaderFile.h
                                   include/EMCALReconstruction/RawReaderMemory.h
                                   include/EMCALReconstruction/AltroDecoder.h
-                                  include/EMCALReconstruction/RCUTrailer.h
                                   include/EMCALReconstruction/RawPayload.h
                                   include/EMCALReconstruction/Bunch.h
                                   include/EMCALReconstruction/Channel.h

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/AltroDecoder.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/AltroDecoder.h
@@ -14,7 +14,7 @@
 #include <iosfwd>
 #include <gsl/span>
 #include <string>
-#include "EMCALReconstruction/RCUTrailer.h"
+#include "EMCALBase/RCUTrailer.h"
 #include "EMCALReconstruction/Bunch.h"
 #include "EMCALReconstruction/Channel.h"
 

--- a/Detectors/EMCAL/reconstruction/src/AltroDecoder.cxx
+++ b/Detectors/EMCAL/reconstruction/src/AltroDecoder.cxx
@@ -40,7 +40,9 @@ template <class RawReader>
 void AltroDecoder<RawReader>::readRCUTrailer()
 {
   try {
-    mRCUTrailer.constructFromRawPayload(mRawReader.getPayload());
+    auto payloadwordsOrig = mRawReader.getPayload().getPayloadWords();
+    gsl::span<const uint32_t> payloadwords(payloadwordsOrig.data(), payloadwordsOrig.size());
+    mRCUTrailer.constructFromRawPayload(payloadwords);
   } catch (RCUTrailer::Error& e) {
     AliceO2::InfoLogger::InfoLogger logger;
     logger << e.what();

--- a/Detectors/EMCAL/reconstruction/src/RawReaderFile.cxx
+++ b/Detectors/EMCAL/reconstruction/src/RawReaderFile.cxx
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <iomanip>
 
+#include "EMCALBase/RCUTrailer.h"
 #include "EMCALReconstruction/RawHeaderStream.h"
 #include "EMCALReconstruction/RawReaderFile.h"
 #include "EMCALReconstruction/RawDecodingError.h"
@@ -59,9 +60,18 @@ template <class RawHeader>
 void RawReaderFile<RawHeader>::next()
 {
   mRawPayload.reset();
+  bool isDataTerminated = false;
   do {
     nextPage(false);
-  } while (!isStop(mRawHeader));
+    // check if we find a valid RCU trailer
+    // the payload must be at the end of the buffer
+    // if not present and error will be thrown
+    try {
+      RCUTrailer::constructFromPayloadWords(mRawBuffer.getDataWords());
+      isDataTerminated = true;
+    } catch (...) {
+    }
+  } while (!isDataTerminated);
 }
 
 template <class RawHeader>

--- a/Detectors/EMCAL/reconstruction/src/RawReaderMemory.cxx
+++ b/Detectors/EMCAL/reconstruction/src/RawReaderMemory.cxx
@@ -10,6 +10,7 @@
 
 #include <sstream>
 #include <string>
+#include "EMCALBase/RCUTrailer.h"
 #include "EMCALReconstruction/RawHeaderStream.h"
 #include "EMCALReconstruction/RawReaderMemory.h"
 #include "EMCALReconstruction/RawDecodingError.h"
@@ -43,9 +44,18 @@ template <class RawHeader>
 void RawReaderMemory<RawHeader>::next()
 {
   mRawPayload.reset();
+  bool isDataTerminated = false;
   do {
     nextPage(false);
-  } while (!isStop(mRawHeader));
+    // check if we find a valid RCU trailer
+    // the payload must be at the end of the buffer
+    // if not present and error will be thrown
+    try {
+      RCUTrailer::constructFromPayloadWords(mRawBuffer.getDataWords());
+      isDataTerminated = true;
+    } catch (...) {
+    }
+  } while (!isDataTerminated);
 }
 
 template <class RawHeader>


### PR DESCRIPTION
As with the current FW/readoutCard version the
StopBit in the RDH header is not set, a valid
RCU trailer must be required in order to decide
whether the payload ends with the current page.

In addition move RCUTrailer to EMCALbase as
it will be needed as well in the raw data
encoding.