### PR TITLE
DPL: decouple DataAllocator from TableBuilder

### DIFF
--- a/Framework/Core/include/Framework/AODReaderHelpers.h
+++ b/Framework/Core/include/Framework/AODReaderHelpers.h
@@ -11,6 +11,7 @@
 #ifndef o2_framework_readers_AODReaderHelpers_INCLUDED_H
 #define o2_framework_readers_AODReaderHelpers_INCLUDED_H
 
+#include "Framework/TableBuilder.h"
 #include "Framework/AlgorithmSpec.h"
 
 namespace o2

--- a/Framework/Core/include/Framework/TableTreeHelpers.h
+++ b/Framework/Core/include/Framework/TableTreeHelpers.h
@@ -13,6 +13,7 @@
 #include "TFile.h"
 #include "TTreeReader.h"
 #include "TTreeReaderValue.h"
+#include "TableBuilder.h"
 
 // =============================================================================
 namespace o2

--- a/Framework/Core/src/CommonDataProcessors.cxx
+++ b/Framework/Core/src/CommonDataProcessors.cxx
@@ -18,6 +18,7 @@
 #include "Framework/DataDescriptorMatcher.h"
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/DataSpecUtils.h"
+#include "Framework/TableBuilder.h"
 #include "Framework/EndOfStreamContext.h"
 #include "Framework/InitContext.h"
 #include "Framework/InputSpec.h"

--- a/Framework/Core/src/DataAllocator.cxx
+++ b/Framework/Core/src/DataAllocator.cxx
@@ -8,6 +8,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 #include "Framework/CompilerBuiltins.h"
+#include "Framework/TableBuilder.h"
 #include "Framework/DataAllocator.h"
 #include "Framework/MessageContext.h"
 #include "Framework/ArrowContext.h"

--- a/Framework/TestWorkflows/src/o2AODDummy.cxx
+++ b/Framework/TestWorkflows/src/o2AODDummy.cxx
@@ -7,6 +7,7 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
+#include "Framework/TableBuilder.h"
 #include "Framework/runDataProcessing.h"
 
 #include <ROOT/RDataFrame.hxx>


### PR DESCRIPTION
If one needs DataAllocator to create arrow tables, the
TableBuilder.h header should be included before DataAllocator.h.

This way we avoid rebuilding everything when ASoA.h changes.

We should probably do the same for boost and ROOT.