### PR TITLE
GPU: 2 minor workarounds for bugs in clang and llvm spirv converter

### DIFF
--- a/GPU/Common/GPUCommonMath.h
+++ b/GPU/Common/GPUCommonMath.h
@@ -138,7 +138,7 @@ GPUhdi() unsigned int GPUCommonMath::Clz(unsigned int x)
 
 GPUhdi() unsigned int GPUCommonMath::Popcount(unsigned int x)
 {
-#if (defined(__GNUC__) || defined(__clang__) || defined(__CUDACC__) || defined(__HIPCC__)) && (!defined(__OPENCL__) || defined(__OPENCLCPP__))
+#if (defined(__GNUC__) || defined(__clang__) || defined(__CUDACC__) || defined(__HIPCC__)) && (!defined(__OPENCL__) /*|| defined(__OPENCLCPP__)*/) // TODO: remove OPENCLCPP workaround when reported SPIR-V bug is fixed
   return CHOICE(__builtin_popcount(x), __popc(x), __builtin_popcount(x)); // use builtin if available
 #else
   unsigned int retVal = 0;

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFPeakFinder.cxx
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFPeakFinder.cxx
@@ -99,11 +99,11 @@ GPUd() bool GPUTPCCFPeakFinder::isPeak(
 
   bool peak = true;
 
-#define CMP_NEIGHBOR(dp, dt, cmpOp)                  \
-  do {                                               \
-    PackedCharge p = chargeMap[pos.delta({dp, dt})]; \
-    const Charge otherCharge = p.unpack();           \
-    peak &= (otherCharge cmpOp myCharge);            \
+#define CMP_NEIGHBOR(dp, dt, cmpOp)                        \
+  do {                                                     \
+    PackedCharge p = chargeMap[pos.delta(Delta2{dp, dt})]; \
+    const Charge otherCharge = p.unpack();                 \
+    peak &= (otherCharge cmpOp myCharge);                  \
   } while (false)
 
 #define CMP_LT CMP_NEIGHBOR(-1, -1, <=)


### PR DESCRIPTION
I opened bug reports, but so long we can live with these workarounds.
This is btw the first time clang11 master and the llvm converter are able to process the full GPU source code. Next step is to set up some hardware and actually test it.