### PR TITLE
Use span<digits>  instead of a vector in the TPC tracking

### DIFF
--- a/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
+++ b/Detectors/TPC/reconstruction/src/GPUCATracking.cxx
@@ -93,7 +93,7 @@ int GPUCATracking::runTracking(GPUO2InterfaceIOPtrs* data)
     ptrs.clustersNative = nullptr;
     const float zsThreshold = mTrackingCAO2Interface->getConfig().configReconstruction.tpcZSthreshold;
     for (int i = 0; i < Sector::MAXSECTOR; i++) {
-      const std::vector<o2::tpc::Digit>& d = (*(data->o2Digits))[i];
+      const auto& d = (*(data->o2Digits))[i];
       gpuDigits[i].reserve(d.size());
       gpuDigitsMap.tpcDigits[i] = gpuDigits[i].data();
       for (int j = 0; j < d.size(); j++) {

--- a/Detectors/TPC/workflow/src/CATrackerSpec.cxx
+++ b/Detectors/TPC/workflow/src/CATrackerSpec.cxx
@@ -266,7 +266,7 @@ DataProcessorSpec getCATrackerSpec(bool processMC, bool caClusterer, std::vector
       // FIXME cleanup almost duplicated code
       auto& validMcInputs = processAttributes->validMcInputs;
       auto& mcInputs = processAttributes->mcInputs;
-      std::array<std::vector<o2::tpc::Digit>, NSectors> inputDigits;
+      std::array<gsl::span<const o2::tpc::Digit>, NSectors> inputDigits;
       std::array<std::unique_ptr<const MCLabelContainer>, NSectors> inputDigitsMC;
       if (processMC) {
         // we can later extend this to multiple inputs
@@ -343,7 +343,8 @@ DataProcessorSpec getCATrackerSpec(bool processMC, bool caClusterer, std::vector
         validInputs.set(sector);
         datarefs[sector] = ref;
         if (caClusterer) {
-          inputDigits[sector] = std::move(pc.inputs().get<const std::vector<o2::tpc::Digit>>(inputLabel));
+          inputDigits[sector] = pc.inputs().get<gsl::span<o2::tpc::Digit>>(inputLabel);
+          LOG(INFO) << "GOT SPAN FOR SECTOR " << sector << " -> " << inputDigits[sector].size();
         }
       }
 

--- a/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
+++ b/GPU/GPUTracking/Interface/GPUO2InterfaceConfiguration.h
@@ -27,6 +27,7 @@
 #include <memory>
 #include <array>
 #include <vector>
+#include <gsl/gsl>
 #include "GPUSettings.h"
 #include "GPUDisplayConfig.h"
 #include "GPUQAConfig.h"
@@ -82,7 +83,7 @@ struct GPUO2InterfaceConfiguration {
 struct GPUO2InterfaceIOPtrs {
   // Input: TPC clusters in cluster native format, or digits, or list of ZS pages -  const as it can only be input
   const o2::tpc::ClusterNativeAccess* clusters = nullptr;
-  const std::array<std::vector<o2::tpc::Digit>, o2::tpc::Constants::MAXSECTOR>* o2Digits = nullptr;
+  const std::array<gsl::span<const o2::tpc::Digit>, o2::tpc::Constants::MAXSECTOR>* o2Digits = nullptr;
   std::array<std::unique_ptr<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>>, o2::tpc::Constants::MAXSECTOR>* o2DigitsMC = nullptr;
   const o2::gpu::GPUTrackingInOutZS* tpcZS = nullptr;
 


### PR DESCRIPTION
Hi @matthiasrichter 

To test your https://github.com/AliceO2Group/AliceO2/pull/2982 I've fixed the TPC code to use ``span<o2::tpc::Digit>`` instead of the vector in the clusterizers and tracking interface, but it still dies with 
````
 Exception caught: Inconsistent serialization method for extracting span
````
I've checked in the gdb, the RootTreeReader still uses ``snapshot(mKey, std::move(ROOTSerializedByClass(*data, mClassInfo)));`` to send the digits.
So, the behaviour is exactly the same as w/o your patch (which is cherry-picked in this PR).

If you cherry-pick my commit from this PR, you can check yourself  it as:

````
o2-sim -m TPC  -n 20
o2-sim-digitizer-workflow -b

o2-tpc-reco-workflow   --infile tpcdigits.root --output-type tracks
# using HwClusterer, exception is produced in the ``tpc-clusterer`` device

o2-tpc-reco-workflow  --disable-mc --ca-clusterer  --infile tpcdigits.root --output-type tracks
# using caClusterer, exception is produced in the ``tpc-tracker``
````

Note, since I did not manage to run the full workflow, I am not sure the modifications I did are fully ok, 
after the reader problem is solved, other problems may pop up.