### PR TITLE
Using span of o2::tpc::Digit as input to TPC HwClusterer

### DIFF
--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/Clusterer.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/Clusterer.h
@@ -49,8 +49,8 @@ class Clusterer
   /// Processing all digits
   /// \param digits Container with TPC digits
   /// \param mcDigitTruth MC Digit Truth container
-  virtual void process(std::vector<o2::tpc::Digit> const& digits, MCLabelContainer const* mcDigitTruth) = 0;
-  virtual void finishProcess(std::vector<o2::tpc::Digit> const& digits, MCLabelContainer const* mcDigitTruth) = 0;
+  virtual void process(gsl::span<o2::tpc::Digit const> const& digits, MCLabelContainer const* mcDigitTruth) = 0;
+  virtual void finishProcess(gsl::span<o2::tpc::Digit const> const& digits, MCLabelContainer const* mcDigitTruth) = 0;
 
   /// Setter for noise object, noise will be added before cluster finding
   /// \param noiseObject CalDet object, containing noise simulation

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/HwClusterer.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/HwClusterer.h
@@ -71,15 +71,15 @@ class HwClusterer : public Clusterer
   /// \param digits Container with TPC digits
   /// \param mcDigitTruth MC Digit Truth container
   /// \param clearContainerFirst Clears the outpcontainer for clusters and MC labels first, before processing
-  void process(std::vector<o2::tpc::Digit> const& digits, MCLabelContainer const* mcDigitTruth) override;
-  void process(std::vector<o2::tpc::Digit> const& digits, MCLabelContainer const* mcDigitTruth, bool clearContainerFirst);
+  void process(gsl::span<o2::tpc::Digit const> const& digits, MCLabelContainer const* mcDigitTruth) override;
+  void process(gsl::span<o2::tpc::Digit const> const& digits, MCLabelContainer const* mcDigitTruth, bool clearContainerFirst);
 
   /// Finish processing digits
   /// \param digits Container with TPC digits
   /// \param mcDigitTruth MC Digit Truth container
   /// \param clearContainerFirst Clears the outpcontainer for clusters and MC labels first, before processing
-  void finishProcess(std::vector<o2::tpc::Digit> const& digits, MCLabelContainer const* mcDigitTruth) override;
-  void finishProcess(std::vector<o2::tpc::Digit> const& digits, MCLabelContainer const* mcDigitTruth, bool clearContainerFirst);
+  void finishProcess(gsl::span<o2::tpc::Digit const> const& digits, MCLabelContainer const* mcDigitTruth) override;
+  void finishProcess(gsl::span<o2::tpc::Digit const> const& digits, MCLabelContainer const* mcDigitTruth, bool clearContainerFirst);
 
   /// Switch for triggered / continuous readout
   /// \param isContinuous - false for triggered readout, true for continuous readout
@@ -216,12 +216,12 @@ class HwClusterer : public Clusterer
   MCLabelContainer* mClusterMcLabelArray;                  ///< Pointer to MC Label container
 };
 
-inline void HwClusterer::process(std::vector<o2::tpc::Digit> const& digits, o2::dataformats::MCTruthContainer<o2::MCCompLabel> const* mcDigitTruth)
+inline void HwClusterer::process(gsl::span<o2::tpc::Digit const> const& digits, o2::dataformats::MCTruthContainer<o2::MCCompLabel> const* mcDigitTruth)
 {
   process(digits, mcDigitTruth, true);
 }
 
-inline void HwClusterer::finishProcess(std::vector<o2::tpc::Digit> const& digits, o2::dataformats::MCTruthContainer<o2::MCCompLabel> const* mcDigitTruth)
+inline void HwClusterer::finishProcess(gsl::span<o2::tpc::Digit const> const& digits, o2::dataformats::MCTruthContainer<o2::MCCompLabel> const* mcDigitTruth)
 {
   finishProcess(digits, mcDigitTruth, true);
 }

--- a/Detectors/TPC/reconstruction/src/ClustererTask.cxx
+++ b/Detectors/TPC/reconstruction/src/ClustererTask.cxx
@@ -102,7 +102,7 @@ void ClustererTask::Exec(Option_t* option)
   if (mHwClustersMCTruthArray)
     mHwClustersMCTruthArray->clear();
 
-  mHwClusterer->process(*mDigitsArray.get(), mDigitMCTruthArray.get());
+  mHwClusterer->process(gsl::span<o2::tpc::Digit const>(mDigitsArray->data(), mDigitsArray->size()), mDigitMCTruthArray.get());
   LOG(DEBUG) << "Hw clusterer delivered " << mHwClustersArray->size() << " cluster container";
 
   ++mEventCount;

--- a/Detectors/TPC/reconstruction/src/HwClusterer.cxx
+++ b/Detectors/TPC/reconstruction/src/HwClusterer.cxx
@@ -125,7 +125,7 @@ void HwClusterer::init()
 }
 
 //______________________________________________________________________________
-void HwClusterer::process(std::vector<o2::tpc::Digit> const& digits, MCLabelContainer const* mcDigitTruth, bool clearContainerFirst)
+void HwClusterer::process(gsl::span<o2::tpc::Digit const> const& digits, MCLabelContainer const* mcDigitTruth, bool clearContainerFirst)
 {
   if (clearContainerFirst) {
     if (mClusterArray)
@@ -252,11 +252,11 @@ void HwClusterer::process(std::vector<o2::tpc::Digit> const& digits, MCLabelCont
     finishFrame(true);
 
   if (digits.size() != 0)
-    LOG(DEBUG) << "Event ranged from time bin " << digits.front().getTimeStamp() << " to " << digits.back().getTimeStamp() << ".";
+    LOG(DEBUG) << "Event ranged from time bin " << digits[0].getTimeStamp() << " to " << digits[digits.size() - 1].getTimeStamp() << ".";
 }
 
 //______________________________________________________________________________
-void HwClusterer::finishProcess(std::vector<o2::tpc::Digit> const& digits, MCLabelContainer const* mcDigitTruth, bool clearContainerFirst)
+void HwClusterer::finishProcess(gsl::span<o2::tpc::Digit const> const& digits, MCLabelContainer const* mcDigitTruth, bool clearContainerFirst)
 {
   // Process the last digits (if there are any)
   process(digits, mcDigitTruth, clearContainerFirst);


### PR DESCRIPTION
Does not change the actual algorithm which accesses data object via iterators,
the read-only span can be build from any array and vector, e.g. pmr::vector or
even with custom allocator.