### PR TITLE
DPL: do not sleep when no dangling outputs available

### DIFF
--- a/Framework/Core/src/CommonDataProcessors.cxx
+++ b/Framework/Core/src/CommonDataProcessors.cxx
@@ -479,7 +479,6 @@ DataProcessorSpec
           LOG(DEBUG) << "No dangling output to be saved.";
           once = true;
         }
-        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
       });
     }
 
@@ -615,13 +614,10 @@ DataProcessorSpec
     if (hasOutputsToWrite == false) {
       return std::move([](ProcessingContext& pc) mutable -> void {
         static bool once = false;
-        /// We do it like this until we can use the interruptible sleep
-        /// provided by recent FairMQ releases.
         if (!once) {
           LOG(DEBUG) << "No dangling output to be dumped.";
           once = true;
         }
-        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
       });
     }
     auto output = std::make_shared<std::ofstream>(filename.c_str(), std::ios_base::binary);


### PR DESCRIPTION
This actually fills the FairMQ queue in any case, so we must avoid it. One more reason to do the adaptive rate.