### PR TITLE
Add missing includes

### DIFF
--- a/Detectors/CPV/workflow/src/DigitsPrinterSpec.cxx
+++ b/Detectors/CPV/workflow/src/DigitsPrinterSpec.cxx
@@ -9,6 +9,7 @@
 // or submit itself to any jurisdiction.
 
 #include <vector>
+#include <iostream>
 
 #include "FairLogger.h"
 

--- a/Detectors/EMCAL/workflow/src/DigitsPrinterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/DigitsPrinterSpec.cxx
@@ -9,6 +9,7 @@
 // or submit itself to any jurisdiction.
 
 #include <vector>
+#include <iostream>
 
 #include "FairLogger.h"
 

--- a/Detectors/PHOS/workflow/src/DigitsPrinterSpec.cxx
+++ b/Detectors/PHOS/workflow/src/DigitsPrinterSpec.cxx
@@ -9,6 +9,7 @@
 // or submit itself to any jurisdiction.
 
 #include <vector>
+#include <iostream>
 
 #include "FairLogger.h"
 

--- a/Framework/TestWorkflows/src/o2DataQueryWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DataQueryWorkflow.cxx
@@ -16,6 +16,7 @@
 #include <chrono>
 #include <thread>
 #include <vector>
+#include <iostream>
 
 using namespace o2::framework;
 

--- a/Steer/DigitizerWorkflow/src/CollisionTimePrinter.cxx
+++ b/Steer/DigitizerWorkflow/src/CollisionTimePrinter.cxx
@@ -23,6 +23,7 @@
 #include <memory>     // std::unique_ptr
 #include <cstring>    // memcpy
 #include <string>     // std::string
+#include <iostream>   // std::cout
 
 using namespace o2::framework;
 using SubSpecificationType = o2::framework::DataAllocator::SubSpecificationType;

--- a/Steer/DigitizerWorkflow/src/EMCALDigitWriterSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/EMCALDigitWriterSpec.cxx
@@ -17,6 +17,7 @@
 #include <DataFormatsEMCAL/MCLabel.h>
 #include <SimulationDataFormat/MCTruthContainer.h>
 #include "TBranch.h"
+#include <iostream>
 
 using namespace o2::framework;
 using SubSpecificationType = o2::framework::DataAllocator::SubSpecificationType;


### PR DESCRIPTION
These files are using std::cout but not including <iostream>, which, depending on the setup, misses the symbol. I think when std::cout is used, one should explicitly include <iostream>