### PR TITLE
DPL: introduce exponential backoff when idle (O2-626, O2-714)

### DIFF
--- a/Framework/Core/include/Framework/DataProcessingDevice.h
+++ b/Framework/Core/include/Framework/DataProcessingDevice.h
@@ -83,6 +83,7 @@ class DataProcessingDevice : public FairMQDevice
   uint64_t mLastMetricFlushedTimestamp = 0;  /// The timestamp of the last time we actually flushed metrics
   uint64_t mBeginIterationTimestamp = 0;     /// The timestamp of when the current ConditionalRun was started
   DataProcessingStats mStats;                /// Stats about the actual data processing.
+  int mCurrentBackoff = 0;                   /// The current exponential backoff value.
 };
 
 } // namespace o2::framework

--- a/Framework/Core/test/test_CallbackService.cxx
+++ b/Framework/Core/test/test_CallbackService.cxx
@@ -48,7 +48,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
          };
          ic.services().get<CallbackService>().set(CallbackService::Id::ClockTick, callback);
          return [count](ProcessingContext& ctx) {
-           if (*count > 1000) {
+           if (*count > 10) {
              ctx.services().get<ControlService>().readyToQuit(QuitRequest::All);
            }
          };

--- a/Framework/Core/test/test_SimpleStringProcessing.cxx
+++ b/Framework/Core/test/test_SimpleStringProcessing.cxx
@@ -34,6 +34,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
         auto& out1 = ctx.outputs().make<std::string>(Output{"TES", "STRING"}, "default");
         assert(out1 == "default");
         out1 = "Hello";
+        ctx.services().get<ControlService>().endOfStream();
+        ctx.services().get<ControlService>().readyToQuit(QuitRequest::Me);
       }} //
     },   //
     DataProcessorSpec{
@@ -51,7 +53,6 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
           } else {
             LOG(INFO) << "Everything OK";
           }
-          ctx.services().get<ControlService>().readyToQuit(QuitRequest::All);
         } //
       }   //
     }     //


### PR DESCRIPTION
This should reduce the amount of CPU used by data processors when they are idle
while retaining the ability to increase back the rate, should it be needed.