### PR TITLE
Bugfix: test_ParallelPipeline

### DIFF
--- a/Framework/Core/include/Framework/DataRefUtils.h
+++ b/Framework/Core/include/Framework/DataRefUtils.h
@@ -175,6 +175,11 @@ struct DataRefUtils {
                   "pointer to BaseHeader-derived type required");
     return o2::header::get<T>(ref.header);
   }
+
+  static bool isValid(DataRef const& ref)
+  {
+    return ref.header != nullptr && ref.payload != nullptr;
+  }
 };
 
 } // namespace framework


### PR DESCRIPTION
Workflow spec helper MergeInputs requires amend callback to adjust also
binding name in order to have unique binding identifiers

Fixing and enhancing unit test test_ParallelPipeline
- unique binding names
- fixed to check of pipeline numbers for every channel on the final consumer
  the intended check was not working because the shared object can not be
  used in different processes, but the ambigous binding names made the test
  work anyhow
- testing also partially valid InputRecord by using completion policy 'consume'

Adding a helper method DataSpecUtils::isValid