### PR TITLE
Convert TRDGeometry to a singleton O2-1197

### DIFF
--- a/Detectors/TRD/base/CMakeLists.txt
+++ b/Detectors/TRD/base/CMakeLists.txt
@@ -69,3 +69,14 @@ o2_add_test(DiffusionCoefficient
             PUBLIC_LINK_LIBRARIES O2::TRDBase
             ENVIRONMENT VMCWORKDIR=${CMAKE_BINARY_DIR}/stage/share
             LABELS trd)
+
+o2_add_test(Geometry
+            COMPONENT_NAME trd
+            PUBLIC_LINK_LIBRARIES O2::TRDBase
+            SOURCES test/testTRDGeometry.cxx
+            ENVIRONMENT O2_ROOT=${CMAKE_BINARY_DIR}/stage
+            LABELS trd
+            )
+
+
+

--- a/Detectors/TRD/base/include/TRDBase/FeeParam.h
+++ b/Detectors/TRD/base/include/TRDBase/FeeParam.h
@@ -51,24 +51,24 @@ class FeeParam
   static void terminate();
 
   // Translation from MCM to Pad and vice versa
-  virtual int getPadRowFromMCM(Int_t irob, Int_t imcm) const;
-  virtual int getPadColFromADC(Int_t irob, Int_t imcm, Int_t iadc) const;
-  virtual int getExtendedPadColFromADC(Int_t irob, Int_t imcm, Int_t iadc) const;
-  virtual int getMCMfromPad(Int_t irow, Int_t icol) const;
-  virtual int getMCMfromSharedPad(Int_t irow, Int_t icol) const;
-  virtual int getROBfromPad(Int_t irow, Int_t icol) const;
-  virtual int getROBfromSharedPad(Int_t irow, Int_t icol) const;
-  virtual int getRobSide(Int_t irob) const;
-  virtual int getColSide(Int_t icol) const;
+  virtual int getPadRowFromMCM(int irob, int imcm) const;
+  virtual int getPadColFromADC(int irob, int imcm, int iadc) const;
+  virtual int getExtendedPadColFromADC(int irob, int imcm, int iadc) const;
+  virtual int getMCMfromPad(int irow, int icol) const;
+  virtual int getMCMfromSharedPad(int irow, int icol) const;
+  virtual int getROBfromPad(int irow, int icol) const;
+  virtual int getROBfromSharedPad(int irow, int icol) const;
+  virtual int getRobSide(int irob) const;
+  virtual int getColSide(int icol) const;
 
   // SCSN-related
-  static unsigned int aliToExtAli(Int_t rob, Int_t aliid);                                               // Converts the MCM-ROB combination to the extended MCM ALICE ID (used to address MCMs on the SCSN Bus)
-  static int extAliToAli(UInt_t dest, UShort_t linkpair, UShort_t rocType, Int_t* list, Int_t listSize); // translates an extended MCM ALICE ID to a list of MCMs
-  static Short_t chipmaskToMCMlist(unsigned int cmA, UInt_t cmB, UShort_t linkpair, Int_t* mcmList, Int_t listSize);
-  static Short_t getRobAB(UShort_t robsel, UShort_t linkpair); // Returns the chamber side (A=0, B=0) of a ROB
+  static unsigned int aliToExtAli(int rob, int aliid);                                                                 // Converts the MCM-ROB combination to the extended MCM ALICE ID (used to address MCMs on the SCSN Bus)
+  static int extAliToAli(unsigned int dest, unsigned short linkpair, unsigned short rocType, int* list, int listSize); // translates an extended MCM ALICE ID to a list of MCMs
+  static short chipmaskToMCMlist(unsigned int cmA, unsigned int cmB, unsigned short linkpair, int* mcmList, int listSize);
+  static short getRobAB(unsigned short robsel, unsigned short linkpair); // Returns the chamber side (A=0, B=0) of a ROB
 
   // geometry
-  static Float_t getSamplingFrequency() { return (Float_t)mgkLHCfrequency / 4000000.0; } //TODO put the 40MHz into a static variable somewhere.
+  static float getSamplingFrequency() { return (float)mgkLHCfrequency / 4000000.0; } //TODO put the 40MHz into a static variable somewhere.
   static int getNmcmRob() { return mgkNmcmRob; }
   static int getNmcmRobInRow() { return mgkNmcmRobInRow; }
   static int getNmcmRobInCol() { return mgkNmcmRobInCol; }

--- a/Detectors/TRD/base/include/TRDBase/TRDGeometry.h
+++ b/Detectors/TRD/base/include/TRDBase/TRDGeometry.h
@@ -29,8 +29,13 @@ namespace trd
 class TRDGeometry : public TRDGeometryBase, public o2::detectors::DetMatrixCacheIndirect
 {
  public:
-  TRDGeometry();
   ~TRDGeometry() override = default;
+
+  static TRDGeometry* instance()
+  {
+    static TRDGeometry mGeom;
+    return &mGeom;
+  }
 
   void createGeometry(std::vector<int> const& idtmed);
   void addAlignableVolumes() const;
@@ -57,7 +62,9 @@ class TRDGeometry : public TRDGeometryBase, public o2::detectors::DetMatrixCache
   // helper function to create volumes and registering them automatically
   void createVolume(const char* name, const char* shape, int nmed, float* upar, int np);
 
-  ClassDefOverride(TRDGeometry, 1); //  TRD geometry class
+  TRDGeometry();
+
+  ClassDefOverride(TRDGeometry, 2); //  TRD geometry class
 };
 } // end namespace trd
 } // end namespace o2

--- a/Detectors/TRD/base/include/TRDBase/TRDGeometryBase.h
+++ b/Detectors/TRD/base/include/TRDBase/TRDGeometryBase.h
@@ -54,6 +54,11 @@ class TRDGeometryBase
   GPUd() float getRow0(int layer, int stack, int /*sector*/) const { return getPadPlane(layer, stack)->getRow0(); }
   GPUd() float getCol0(int layer) const { return getPadPlane(layer, 0)->getCol0(); }
 
+  GPUd() float getRowPos(int layer, int stack, int row) { return mPadPlanes[getDetectorSec(layer, stack)].getRowPos(row); }
+  GPUd() float getRowSize(int layer, int stack, int row) { return mPadPlanes[getDetectorSec(layer, stack)].getRowSize(row); }
+  GPUd() float getRow0(int layer, int stack) { return mPadPlanes[getDetectorSec(layer, stack)].getRow0(); }
+  GPUd() float getRowEnd(int layer, int stack) { return mPadPlanes[getDetectorSec(layer, stack)].getRowEnd(); }
+
   static constexpr int getSector(int det) { return (det / (kNlayer * kNstack)); }
   static constexpr float getTime0(int layer) { return TIME0[layer]; }
   static constexpr float getXtrdBeg() { return XTRDBEG; }

--- a/Detectors/TRD/base/src/CalDet.cxx
+++ b/Detectors/TRD/base/src/CalDet.cxx
@@ -321,7 +321,7 @@ TH2F* CalDet::makeHisto2DCh(int ch, float min, float max, int type)
     }
   }
 
-  TRDGeometry* trdGeo = new TRDGeometry();
+  TRDGeometry* trdGeo = TRDGeometry::instance();
 
   float poslocal[3] = {0, 0, 0};
   float posglobal[3] = {0, 0, 0};
@@ -354,7 +354,6 @@ TH2F* CalDet::makeHisto2DCh(int ch, float min, float max, int type)
   his->SetStats(0);
   his->SetMaximum(max);
   his->SetMinimum(min);
-  delete trdGeo;
   return his;
 }
 
@@ -395,7 +394,7 @@ TH2F* CalDet::makeHisto2DSmPl(int sm, int pl, float min, float max, int type)
     }
   }
 
-  TRDGeometry* trdGeo = new TRDGeometry();
+  TRDGeometry* trdGeo = TRDGeometry::instance();
   const TRDPadPlane* padPlane0 = trdGeo->getPadPlane(pl, 0);
   double row0 = padPlane0->getRow0();
   double col0 = padPlane0->getCol0();
@@ -418,7 +417,6 @@ TH2F* CalDet::makeHisto2DSmPl(int sm, int pl, float min, float max, int type)
   his->SetStats(0);
   his->SetMaximum(max);
   his->SetMinimum(min);
-  delete trdGeo;
   return his;
 }
 

--- a/Detectors/TRD/base/src/FeeParam.cxx
+++ b/Detectors/TRD/base/src/FeeParam.cxx
@@ -45,12 +45,12 @@ using namespace o2::trd;
 //_____________________________________________________________________________
 
 FeeParam* FeeParam::mgInstance = nullptr;
-bool FeeParam::mgTerminated = kFALSE;
-bool FeeParam::mgTracklet = kTRUE;
-bool FeeParam::mgRejectMultipleTracklets = kFALSE;
-bool FeeParam::mgUseMisalignCorr = kFALSE;
-bool FeeParam::mgUseTimeOffset = kFALSE;
-bool FeeParam::mgLUTPadNumberingFilled = kFALSE;
+bool FeeParam::mgTerminated = false;
+bool FeeParam::mgTracklet = true;
+bool FeeParam::mgRejectMultipleTracklets = false;
+bool FeeParam::mgUseMisalignCorr = false;
+bool FeeParam::mgUseTimeOffset = false;
+bool FeeParam::mgLUTPadNumberingFilled = false;
 std::vector<short> FeeParam::mgLUTPadNumbering;
 
 // definition of geometry constants
@@ -85,7 +85,7 @@ FeeParam* FeeParam::instance()
   // Instance constructor
   //
 
-  if (mgTerminated != kFALSE) {
+  if (mgTerminated != false) {
     return nullptr;
   }
 
@@ -103,7 +103,7 @@ void FeeParam::terminate()
   // Terminate the class and release memory
   //
 
-  mgTerminated = kTRUE;
+  mgTerminated = true;
 
   if (mgInstance != nullptr) {
     delete mgInstance;
@@ -512,7 +512,7 @@ void FeeParam::createPad2MCMLookUpTable()
         FeeParam::instance()->mgLUTPadNumbering[index] = index + shiftposition;
       }
     }
-    mgLUTPadNumberingFilled = kTRUE;
+    mgLUTPadNumberingFilled = true;
   }
 }
 

--- a/Detectors/TRD/base/src/TRDGeometry.cxx
+++ b/Detectors/TRD/base/src/TRDGeometry.cxx
@@ -2737,10 +2737,12 @@ void TRDGeometry::addAlignableVolumes() const
 //_____________________________________________________________________________
 bool TRDGeometry::createClusterMatrixArray()
 {
+
   if (!gGeoManager) {
     LOG(ERROR) << "Geometry is not loaded yet";
     return false;
   }
+
   if (isBuilt()) {
     LOG(WARNING) << "Already built";
     return true; // already initialized

--- a/Detectors/TRD/base/test/testTRDGeometry.cxx
+++ b/Detectors/TRD/base/test/testTRDGeometry.cxx
@@ -8,9 +8,9 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file testTPCMapper.cxx
-/// \brief This task tests the mapper function
-/// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
+/// \file testTRDGeometry.cxx
+/// \brief This task tests the TRDGeometry
+/// \author Sean Murray, murrays@cern.ch
 
 #define BOOST_TEST_MODULE Test TRD_Geometry
 #define BOOST_TEST_MAIN
@@ -22,6 +22,7 @@
 #include <sstream>
 #include <string>
 #include "TRDBase/TRDGeometry.h"
+#include <iostream>
 
 namespace o2
 {
@@ -31,9 +32,23 @@ namespace trd
 /// \brief Test the TRDGeometry class
 //
 ///
-BOOST_AUTO_TEST_CASE(TRDGeometrytest1)
+BOOST_AUTO_TEST_CASE(TRDGeometry_test1)
 {
-  TRDGeometry& geom = TRDGeometry::instance();
+  //arbitrary chosen
+  BOOST_CHECK_CLOSE(TRDGeometry::instance()->getRowPos(1, 1, 3), 154.5, 1e-3);
+  BOOST_CHECK_CLOSE(TRDGeometry::instance()->getRowSize(1, 1, 3), 7.5, 1e-3);
+  BOOST_CHECK_CLOSE(TRDGeometry::instance()->getRow0(1, 1), 177, 1e-3);
+  BOOST_CHECK_CLOSE(TRDGeometry::instance()->getRowEnd(1, 1), 57, 1e-3);
+  //start
+  BOOST_CHECK_CLOSE(TRDGeometry::instance()->getRowPos(0, 0, 3), 278.5, 1e-3);
+  BOOST_CHECK_CLOSE(TRDGeometry::instance()->getRowSize(0, 0, 3), 7.5, 1e-3);
+  BOOST_CHECK_CLOSE(TRDGeometry::instance()->getRow0(0, 0), 301, 1e-3);
+  BOOST_CHECK_CLOSE(TRDGeometry::instance()->getRowEnd(0, 0), 181, 1e-3);
+  //end of trd.
+  BOOST_CHECK_CLOSE(TRDGeometry::instance()->getRowPos(5, 4, 0), -204, 1e-3);
+  BOOST_CHECK_CLOSE(TRDGeometry::instance()->getRowSize(5, 4, 3), 9, 1e-3);
+  BOOST_CHECK_CLOSE(TRDGeometry::instance()->getRow0(5, 4), -204, 1e-3);
+  BOOST_CHECK_CLOSE(TRDGeometry::instance()->getRowEnd(5, 4), -347, 1e-3);
 }
 
 } // namespace trd

--- a/Detectors/TRD/simulation/src/Detector.cxx
+++ b/Detectors/TRD/simulation/src/Detector.cxx
@@ -508,7 +508,7 @@ void Detector::ConstructGeometry()
   // to the geometry creation
   getMediumIDMappingAsVector(medmapping);
 
-  mGeom = new TRDGeometry();
+  mGeom = TRDGeometry::instance();
   mGeom->createGeometry(medmapping);
 }
 

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -33,19 +33,16 @@ using namespace o2::math_utils;
 Digitizer::Digitizer()
 {
   o2::base::GeometryManager::loadGeometry();
-  mGeo = new TRDGeometry();
+  mGeo = TRDGeometry::instance();
   mGeo->createClusterMatrixArray();          // Requiered for chamberInGeometry()
   mPRF = new PadResponse();                  // Pad response function initialization
   mSimParam = TRDSimParam::Instance();       // Instance for simulation parameters
   mCommonParam = TRDCommonParam::Instance(); // Instance for common parameters
   if (!mSimParam) {
-    LOG(FATAL) << "TRD Simulation Parameters not available";
   }
   if (!mCommonParam) {
-    LOG(FATAL) << "TRD Common Parameters not available";
   } else {
     if (!mCommonParam->cacheMagField()) {
-      LOG(FATAL) << "TRD Common Parameters does not have magnetic field available";
     }
   }
 

--- a/Detectors/TRD/workflow/CMakeLists.txt
+++ b/Detectors/TRD/workflow/CMakeLists.txt
@@ -8,6 +8,7 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
+add_compile_options(-O0 -g -fPIC) 
 
 o2_add_library(TRDWorkflow
                TARGETVARNAME targetName

--- a/Detectors/TRD/workflow/src/TRDDigitizerSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDDigitizerSpec.cxx
@@ -72,10 +72,10 @@ class TRDDPLDigitizerTask
       mSimChains.emplace_back(new TChain("o2sim"));
       mSimChains.back()->AddFile(signalfilename.c_str());
     }
-
     if (!gGeoManager) {
       o2::base::GeometryManager::loadGeometry();
     }
+    LOG(INFO) << "initialed TRD digitization";
   }
 
   void run(framework::ProcessingContext& pc)

--- a/GPU/GPUTracking/Standalone/tools/createGeo.C
+++ b/GPU/GPUTracking/Standalone/tools/createGeo.C
@@ -12,10 +12,10 @@ using namespace GPUCA_NAMESPACE::gpu;
 void createGeo()
 {
   o2::base::GeometryManager::loadGeometry();
-  o2::trd::TRDGeometry gm;
-  gm.createPadPlaneArray();
-  gm.createClusterMatrixArray();
-  o2::trd::TRDGeometryFlat gf(gm);
+  auto gm = o2::trd::TRDGeometry::instance();
+  gm->createPadPlaneArray();
+  gm->createClusterMatrixArray();
+  o2::trd::TRDGeometryFlat gf(*gm);
   gSystem->Load("libO2GPUTracking.so");
   GPUReconstruction* rec = GPUReconstruction::CreateInstance(GPUReconstruction::DeviceType::CPU);
   GPUChainTracking* chain = rec->AddChain<GPUChainTracking>();

--- a/GPU/GPUTracking/Standalone/tools/createGeo.sh
+++ b/GPU/GPUTracking/Standalone/tools/createGeo.sh
@@ -5,7 +5,7 @@ export ALIBUILD_WORK_DIR="$HOME/alice/sw"
 eval "`alienv shell-helper`"
 alienv load O2/latest
 
-o2sim -n 1
+o2-sim -n 1
 
 export ROOT_INCLUDE_PATH=$ROOT_INCLUDE_PATH:/home/qon/alice/GPU/Common/:/home/qon/alice/GPU/GPUTracking/Base:/home/qon/alice/GPU/GPUTracking/SliceTracker:/home/qon/alice/GPU/GPUTracking/Merger:/home/qon/alice/GPU/GPUTracking/TRDTracking
 root -l -q -b createGeo.C+


### PR DESCRIPTION
Convert TRDGeometry to a singleton.
1. removing the TRDGeometry instance in every Tracklet.
2. fix where TRDGeometry is used in various places.
3. move Tracklet functions into TRDGeometry, moving the geometry logic out of tracklets and where it should live.
4. Add some tests for the added functions.