### PR TITLE
DPL Analysis: fix for crash when using filters

### DIFF
--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -211,8 +211,12 @@ struct AnalysisDataProcessorBuilder {
   static void appendSomethingWithMetadata(std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eInfos)
   {
     using dT = std::decay_t<T>;
-    if constexpr (framework::is_specialization<dT, soa::Filtered>::value || framework::is_specialization<dT, soa::RowViewFiltered>::value) {
+    if constexpr (framework::is_specialization<dT, soa::Filtered>::value) {
       eInfos.push_back({At, createSchemaFromColumns(typename dT::table_t::persistent_columns_t{}), nullptr});
+    } else if constexpr (soa::is_type_with_policy_v<dT>) {
+      if (std::is_same_v<typename dT::policy_t, soa::FilteredIndexPolicy>) {
+        eInfos.push_back({At, createSchemaFromColumns(typename dT::table_t::persistent_columns_t{}), nullptr});
+      }
     }
     doAppendInputWithMetadata(soa::make_originals_from_type<dT>(), inputs);
   }

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -210,10 +210,11 @@ struct AnalysisDataProcessorBuilder {
   template <typename T, size_t At>
   static void appendSomethingWithMetadata(std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eInfos)
   {
-    if constexpr (framework::is_specialization<T, soa::Filtered>::value || framework::is_specialization<T, soa::RowViewFiltered>::value) {
-      eInfos.push_back({At, createSchemaFromColumns(typename T::table_t::persistent_columns_t{}), nullptr});
+    using dT = std::decay_t<T>;
+    if constexpr (framework::is_specialization<dT, soa::Filtered>::value || framework::is_specialization<dT, soa::RowViewFiltered>::value) {
+      eInfos.push_back({At, createSchemaFromColumns(typename dT::table_t::persistent_columns_t{}), nullptr});
     }
-    doAppendInputWithMetadata(soa::make_originals_from_type<T>(), inputs);
+    doAppendInputWithMetadata(soa::make_originals_from_type<dT>(), inputs);
   }
 
   template <typename R, typename C, typename... Args>

--- a/Framework/Core/src/Expressions.cxx
+++ b/Framework/Core/src/Expressions.cxx
@@ -370,6 +370,9 @@ bool isSchemaCompatible(gandiva::SchemaPtr const& Schema, Operations const& opSp
 
 void updateExpressionInfos(expressions::Filter const& filter, std::vector<ExpressionInfo>& eInfos)
 {
+  if (eInfos.empty()) {
+    throw std::runtime_error("Empty expression info vector.");
+  }
   Operations ops = createOperations(filter);
   for (auto& info : eInfos) {
     if (isSchemaCompatible(info.schema, ops)) {

--- a/Framework/Core/test/test_AnalysisTask.cxx
+++ b/Framework/Core/test/test_AnalysisTask.cxx
@@ -123,6 +123,7 @@ struct GTask {
 //};
 
 struct ITask {
+  expressions::Filter flt = aod::test::bar > 0.;
   void process(o2::aod::Collision const&, o2::soa::Filtered<o2::soa::Join<o2::aod::Foos, o2::aod::Bars, o2::aod::XYZ>> const& foobars)
   {
     for (auto foobar : foobars) {


### PR DESCRIPTION
@ktf filters were not working after latest update due to the type not being decayed. ExpressionInfo vector was not populated when inputs were attached leading to a segfault.