### PR TITLE
DPL: Adding transport to channel configuration

### DIFF
--- a/Framework/Core/src/ChannelSpecHelpers.cxx
+++ b/Framework/Core/src/ChannelSpecHelpers.cxx
@@ -42,6 +42,17 @@ char const* ChannelSpecHelpers::methodAsString(enum ChannelMethod method)
   throw std::runtime_error("Unknown ChannelMethod");
 }
 
+char const* ChannelSpecHelpers::transportAsString(enum ChannelProtocol protocol)
+{
+  switch (protocol) {
+    case ChannelProtocol::Network:
+      return "zeromq";
+    case ChannelProtocol::IPC:
+      return "shmem";
+  }
+  throw std::runtime_error("Unknown ChannelProtocol");
+}
+
 std::string ChannelSpecHelpers::channelUrl(OutputChannelSpec const& channel)
 {
   switch (channel.protocol) {

--- a/Framework/Core/src/ChannelSpecHelpers.h
+++ b/Framework/Core/src/ChannelSpecHelpers.h
@@ -26,6 +26,8 @@ struct ChannelSpecHelpers {
   static char const* typeAsString(enum ChannelType type);
   /// return a ChannelMethod as a lowercase string
   static char const* methodAsString(enum ChannelMethod method);
+  /// @return transport configuration id as lowercase string
+  static char const* transportAsString(enum ChannelProtocol protocol);
   /// @return a url associated to an InputChannelSpec
   static std::string channelUrl(InputChannelSpec const&);
   /// @return a url associated to an OutputChannelSpec

--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -164,27 +164,33 @@ struct ExpirationHandlerHelpers {
 
 /// This creates a string to configure channels of a FairMQDevice
 /// FIXME: support shared memory
-std::string inputChannel2String(const InputChannelSpec& channel)
+std::string DeviceSpecHelpers::inputChannel2String(const InputChannelSpec& channel)
 {
   std::string result;
 
-  result += "name=" + channel.name;
-  result += std::string(",type=") + ChannelSpecHelpers::typeAsString(channel.type);
+  if (!channel.name.empty()) {
+    result += "name=" + channel.name + ",";
+  }
+  result += std::string("type=") + ChannelSpecHelpers::typeAsString(channel.type);
   result += std::string(",method=") + ChannelSpecHelpers::methodAsString(channel.method);
   result += std::string(",address=") + ChannelSpecHelpers::channelUrl(channel);
+  result += std::string(",transport=") + ChannelSpecHelpers::transportAsString(channel.protocol);
   result += std::string(",rateLogging=60");
 
   return result;
 }
 
-std::string outputChannel2String(const OutputChannelSpec& channel)
+std::string DeviceSpecHelpers::outputChannel2String(const OutputChannelSpec& channel)
 {
   std::string result;
 
-  result += "name=" + channel.name;
-  result += std::string(",type=") + ChannelSpecHelpers::typeAsString(channel.type);
+  if (!channel.name.empty()) {
+    result += "name=" + channel.name + ",";
+  }
+  result += std::string("type=") + ChannelSpecHelpers::typeAsString(channel.type);
   result += std::string(",method=") + ChannelSpecHelpers::methodAsString(channel.method);
   result += std::string(",address=") + ChannelSpecHelpers::channelUrl(channel);
+  result += std::string(",transport=") + ChannelSpecHelpers::transportAsString(channel.protocol);
   result += std::string(",rateLogging=60");
 
   return result;

--- a/Framework/Core/src/DeviceSpecHelpers.h
+++ b/Framework/Core/src/DeviceSpecHelpers.h
@@ -35,6 +35,8 @@ namespace o2
 {
 namespace framework
 {
+struct InputChannelSpec;
+struct OutputChannelSpec;
 
 struct DeviceSpecHelpers {
   /// Helper to convert from an abstract dataflow specification, @a workflow,
@@ -59,6 +61,12 @@ struct DeviceSpecHelpers {
     std::vector<DispatchPolicy> dispatchPolicies = DispatchPolicy::createDefaultPolicies();
     dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, dispatchPolicies, devices, resourceManager, uniqueWorkflowId);
   }
+
+  /// Helper to provide the channel configuration string for an input channel
+  static std::string inputChannel2String(const InputChannelSpec& channel);
+
+  /// Helper to provide the channel configuration string for an output channel
+  static std::string outputChannel2String(const OutputChannelSpec& channel);
 
   /// Helper to prepare the arguments which will be used to
   /// start the various devices.


### PR DESCRIPTION
The transport needs to be in sync with the protocol. If no transport is specified
in the channel config, the default transport of the device will be used. This is
apparently not a problem if all devices use the same transport, but as soon as
one device is using the wrong and the receiver the correct transport configuration,
the following error is observed:

    [ERROR] Unable to locate the region info
    [ERROR] error closing message: Unable to locate remote region info

Followed by segfault in fair::mq::shmem::Message::~Message

Further minor changes:
- Making inputChannel2String and outputChannel2String class methods
  The two methods are now static methods of class DeviceSpecHelpers
- skip name parameter in the channel config string if name is empty