### PR TITLE
read and process data from any flat tree

### DIFF
--- a/Analysis/Tutorials/CMakeLists.txt
+++ b/Analysis/Tutorials/CMakeLists.txt
@@ -64,3 +64,8 @@ o2_add_executable(aodwriter
                   SOURCES src/aodwriter.cxx
                   PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME AnalysisTutorial)
+                  
+o2_add_executable(aodreader
+                  SOURCES src/aodreader.cxx
+                  PUBLIC_LINK_LIBRARIES O2::Framework
+                  COMPONENT_NAME AnalysisTutorial)

--- a/Analysis/Tutorials/src/aodreader.cxx
+++ b/Analysis/Tutorials/src/aodreader.cxx
@@ -18,67 +18,80 @@ namespace uno
 DECLARE_SOA_COLUMN(Eta, eta, float, "fEta1");
 DECLARE_SOA_COLUMN(Phi, phi, int, "fPhi1");
 DECLARE_SOA_COLUMN(Mom, mom, double, "fMom1");
-} // namespace uno
+} // namespace etaphi
 
 DECLARE_SOA_TABLE(Uno, "AOD", "UNO",
                   uno::Eta, uno::Phi, uno::Mom);
 
 namespace due
 {
-DECLARE_SOA_COLUMN(Eta, eta, short int, "fEta2");
+DECLARE_SOA_COLUMN(Eta, eta, double, "fEta2");
 DECLARE_SOA_COLUMN(Phi, phi, double, "fPhi2");
 } // namespace due
 
 DECLARE_SOA_TABLE(Due, "AOD", "DUE",
                   due::Eta, due::Phi);
+
 } // namespace o2::aod
 
 using namespace o2;
 using namespace o2::framework;
 
-// This is a very simple example to test the
-// CommonDataProcessors::getGlobalAODSink
-// In this case the two tables Uno and Due are produced
-// but not consumed -> they are saved into a root file
-//
-// e.g. the table Uno will be saved as TTree UNO with branches
-// fEta1, fPhi1, fMom1
-//
-// The tree can be used for further processing (see aodreader.cxx)
+// This task is related to the ATask in aodwriter.cxx
+// It reads and processes data which was created and saved by aodwriter
 //
 // To test use:
 //  o2-analysistutorial-aodwriter --aod-file AO2D.root --res-file tabletotree > log
 //  o2-analysistutorial-aodreader --aod-file tabletotree_0.root > log
+
 //
 struct ATask {
-  Produces<aod::Uno> uno;
-  Produces<aod::Due> due;
-
-  void init(InitContext&)
+  void process(aod::Uno const& unos, aod::Due const& dues)
   {
-    cnt = 0;
-  }
+    int cnt = 0;
+    for (auto& uno : unos) {
+      auto eta = uno.eta();
+      auto phi = uno.phi();
+      auto mom = uno.mom();
 
-  void process(aod::Tracks const& tracks)
-  {
-    for (auto& track : tracks) {
-      float phi = asin(track.snp()) + track.alpha() + static_cast<float>(M_PI);
-      float eta = log(tan(0.25f * static_cast<float>(M_PI) - 0.5f * atan(track.tgl())));
-      float mom = track.tgl();
-
-      uno(phi, eta, mom);
-      due(phi, eta);
+      //LOGF(INFO, "(%f, %f, %f)", eta, phi, mom);
       cnt++;
     }
-    LOGF(INFO, "ATask Processed %i data points from Tracks", cnt);
-  }
+    LOGF(INFO, "ATask Processed %i data points from Uno", cnt);
+    
+    cnt = 0;
+    for (auto& due : dues) {
+      auto eta = due.eta();
+      auto phi = due.phi();
 
-  size_t cnt = 0;
+      //LOGF(INFO, "(%f, %f)", eta, phi);
+      cnt++;
+    }
+    LOGF(INFO, "ATask Processed %i data points from Due", cnt);
+  }
 };
+
+
+struct BTask {
+  void process(aod::Due const& dues)
+  {
+    int cnt = 0;
+    for (auto& etaPhi : dues) {
+      auto eta = etaPhi.eta();
+      auto phi = etaPhi.phi();
+
+      //LOGF(INFO, "(%f, %f)", eta, phi);
+      cnt++;
+    }
+    LOGF(INFO, "BTask Processed %i data points from Due", cnt);
+  }
+};
+
 
 WorkflowSpec defineDataProcessing(ConfigContext const&)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<ATask>("produce-unodue")
+    adaptAnalysisTask<ATask>("process-unodue"),
+    adaptAnalysisTask<BTask>("process-due")
   };
 }

--- a/Analysis/Tutorials/src/aodreader.cxx
+++ b/Analysis/Tutorials/src/aodreader.cxx
@@ -18,7 +18,7 @@ namespace uno
 DECLARE_SOA_COLUMN(Eta, eta, float, "fEta1");
 DECLARE_SOA_COLUMN(Phi, phi, int, "fPhi1");
 DECLARE_SOA_COLUMN(Mom, mom, double, "fMom1");
-} // namespace etaphi
+} // namespace uno
 
 DECLARE_SOA_TABLE(Uno, "AOD", "UNO",
                   uno::Eta, uno::Phi, uno::Mom);
@@ -58,7 +58,7 @@ struct ATask {
       cnt++;
     }
     LOGF(INFO, "ATask Processed %i data points from Uno", cnt);
-    
+
     cnt = 0;
     for (auto& due : dues) {
       auto eta = due.eta();
@@ -70,7 +70,6 @@ struct ATask {
     LOGF(INFO, "ATask Processed %i data points from Due", cnt);
   }
 };
-
 
 struct BTask {
   void process(aod::Due const& dues)
@@ -87,11 +86,9 @@ struct BTask {
   }
 };
 
-
 WorkflowSpec defineDataProcessing(ConfigContext const&)
 {
   return WorkflowSpec{
     adaptAnalysisTask<ATask>("process-unodue"),
-    adaptAnalysisTask<BTask>("process-due")
-  };
+    adaptAnalysisTask<BTask>("process-due")};
 }

--- a/Analysis/Tutorials/src/aodwriter.cxx
+++ b/Analysis/Tutorials/src/aodwriter.cxx
@@ -79,6 +79,5 @@ struct ATask {
 WorkflowSpec defineDataProcessing(ConfigContext const&)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<ATask>("produce-unodue")
-  };
+    adaptAnalysisTask<ATask>("produce-unodue")};
 }

--- a/Analysis/Tutorials/src/dynamicColumns.cxx
+++ b/Analysis/Tutorials/src/dynamicColumns.cxx
@@ -60,15 +60,15 @@ struct BTask {
 WorkflowSpec defineDataProcessing(ConfigContext const&)
 {
   // create and use table
-  //  return WorkflowSpec{
-  //    adaptAnalysisTask<ATask>("produce-track-copy"),
-  //    adaptAnalysisTask<BTask>("check-eta-phi")};
+  return WorkflowSpec{
+    adaptAnalysisTask<ATask>("produce-track-copy"),
+    adaptAnalysisTask<BTask>("check-eta-phi")};
 
   //  only create table -> tabwle is written to file
   //return WorkflowSpec{
   //  adaptAnalysisTask<ATask>("produce-track-copy")};
 
   // only use table -> table is read from file
-  return WorkflowSpec{
-   adaptAnalysisTask<BTask>("check-eta-phi")};
+  //return WorkflowSpec{
+  // adaptAnalysisTask<BTask>("check-eta-phi")};
 }

--- a/Analysis/Tutorials/src/dynamicColumns.cxx
+++ b/Analysis/Tutorials/src/dynamicColumns.cxx
@@ -52,14 +52,23 @@ struct BTask {
       auto phi = asin(etaPhi.snp()) + etaPhi.alpha() + M_PI;
       auto eta = log(tan(0.25 * M_PI - 0.5 * atan(etaPhi.tgl())));
 
-      LOGF(ERROR, "(%f, %f, %f, %f)", etaPhi.eta(), etaPhi.phi(), eta - etaPhi.eta(), phi - etaPhi.phi());
+      //LOGF(INFO, "(%f, %f, %f, %f)", etaPhi.eta(), etaPhi.phi(), eta - etaPhi.eta(), phi - etaPhi.phi());
     }
   }
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const&)
 {
+  // create and use table
+  //  return WorkflowSpec{
+  //    adaptAnalysisTask<ATask>("produce-track-copy"),
+  //    adaptAnalysisTask<BTask>("check-eta-phi")};
+
+  //  only create table -> tabwle is written to file
+  //return WorkflowSpec{
+  //  adaptAnalysisTask<ATask>("produce-track-copy")};
+
+  // only use table -> table is read from file
   return WorkflowSpec{
-    adaptAnalysisTask<ATask>("produce-track-copy"),
-    adaptAnalysisTask<BTask>("check-eta-phi")};
+   adaptAnalysisTask<BTask>("check-eta-phi")};
 }

--- a/Framework/Core/include/Framework/DataAllocator.h
+++ b/Framework/Core/include/Framework/DataAllocator.h
@@ -144,7 +144,7 @@ class DataAllocator
         t2t = new std::decay_t<decltype(*p)>(args...);
         t2t->AddAllColumns();
         adopt(spec, t2t);
-      });      
+      });
       return *t2t;
     } else if constexpr (sizeof...(Args) == 0) {
       if constexpr (is_messageable<T>::value == true) {

--- a/Framework/Core/include/Framework/DataAllocator.h
+++ b/Framework/Core/include/Framework/DataAllocator.h
@@ -27,6 +27,7 @@
 #include "Framework/Traits.h"
 #include "Framework/SerializationMethods.h"
 #include "Framework/CheckTypes.h"
+#include "Framework/TableTreeHelpers.h"
 
 #include "Headers/DataHeader.h"
 #include <TClass.h>
@@ -137,6 +138,14 @@ class DataAllocator
         adopt(spec, tb);
       });
       return *tb;
+    } else if constexpr (std::is_base_of_v<struct TreeToTable, T>) {
+      TreeToTable* t2t = nullptr;
+      call_if_defined<struct TreeToTable>([&](auto* p) {
+        t2t = new std::decay_t<decltype(*p)>(args...);
+        t2t->AddAllColumns();
+        adopt(spec, t2t);
+      });      
+      return *t2t;
     } else if constexpr (sizeof...(Args) == 0) {
       if constexpr (is_messageable<T>::value == true) {
         return *reinterpret_cast<T*>(newChunk(spec, sizeof(T)).data());
@@ -193,6 +202,11 @@ class DataAllocator
   /// it as an Arrow table to all consumers of @a spec once done
   void
     adopt(const Output& spec, struct TableBuilder*);
+
+  /// Adopt a Tree2Table in the framework and serialise / send
+  /// it as an Arrow table to all consumers of @a spec once done
+  void
+    adopt(const Output& spec, struct TreeToTable*);
 
   /// Adopt a raw buffer in the framework and serialize / send
   /// it to the consumers of @a spec once done.

--- a/Framework/Core/include/Framework/RootTableBuilderHelpers.h
+++ b/Framework/Core/include/Framework/RootTableBuilderHelpers.h
@@ -12,6 +12,7 @@
 #define o2_framework_RootTableBuilderHelpers_H_INCLUDED
 
 #include "Framework/TableBuilder.h"
+#include "Framework/Logger.h"
 
 #include <arrow/stl.h>
 #include <arrow/type_traits.h>

--- a/Framework/Core/include/Framework/TableTreeHelpers.h
+++ b/Framework/Core/include/Framework/TableTreeHelpers.h
@@ -653,7 +653,7 @@ class TreeToTable
     // create the table
     return Finalize();
   }
-  
+
   // do the looping with the TTreeReader
   void Fill()
   {
@@ -683,7 +683,6 @@ class TreeToTable
 
     return ta;
   }
-
 };
 
 // -----------------------------------------------------------------------------

--- a/Framework/Core/include/Framework/TableTreeHelpers.h
+++ b/Framework/Core/include/Framework/TableTreeHelpers.h
@@ -644,14 +644,28 @@ class TreeToTable
     return status;
   }
 
-  // do the looping with the TTreeReader and fill the table
+  // do the looping with the TTreeReader and create the table
   std::shared_ptr<arrow::Table> Process()
   {
+    // do the looping with the TTreeReader
+    Fill();
 
+    // create the table
+    return Finalize();
+  }
+  
+  // do the looping with the TTreeReader
+  void Fill()
+  {
     // copy all values from the tree to the table builders
     reader->Restart();
     while (reader->Next())
       push();
+  }
+
+  // create the table
+  std::shared_ptr<arrow::Table> Finalize()
+  {
 
     // prepare the elements needed to create the final table
     std::vector<std::shared_ptr<arrow::Array>> array_vector;
@@ -669,6 +683,7 @@ class TreeToTable
 
     return ta;
   }
+
 };
 
 // -----------------------------------------------------------------------------

--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -1,4 +1,3 @@
-
 // Copyright CERN and copyright holders of ALICE O2. This software is
 // distributed under the terms of the GNU General Public License v3 (GPL
 // Version 3), copied verbatim in the file "COPYING".

--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -127,8 +127,8 @@ uint64_t getMask(header::DataDescription description)
   } else if (description == header::DataDescription{"DZEROFLAGGED"}) {
     return AODTypeMask::DZeroFlagged;
   } else {
+    LOG(DEBUG) << "This is a tree of unknown type! " << description.str;
     return AODTypeMask::Unknown;
-    LOG(INFO) << "This is a tree of unknown type! " << description.str;
   }
 }
 

--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -1,3 +1,4 @@
+
 // Copyright CERN and copyright holders of ALICE O2. This software is
 // distributed under the terms of the GNU General Public License v3 (GPL
 // Version 3), copied verbatim in the file "COPYING".
@@ -100,8 +101,37 @@ enum AODTypeMask : uint64_t {
   VZero = 1 << 5,
   Collisions = 1 << 6,
   Timeframe = 1 << 7,
-  DZeroFlagged = 1 << 8
+  DZeroFlagged = 1 << 8,
+  Unknown = 1 << 9
 };
+
+uint64_t getMask(header::DataDescription description)
+{
+
+  if (description == header::DataDescription{"TRACKPAR"}) {
+    return AODTypeMask::Tracks;
+  } else if (description == header::DataDescription{"TRACKPARCOV"}) {
+    return AODTypeMask::TracksCov;
+  } else if (description == header::DataDescription{"TRACKEXTRA"}) {
+    return AODTypeMask::TracksExtra;
+  } else if (description == header::DataDescription{"CALO"}) {
+    return AODTypeMask::Calo;
+  } else if (description == header::DataDescription{"MUON"}) {
+    return AODTypeMask::Muon;
+  } else if (description == header::DataDescription{"VZERO"}) {
+    return AODTypeMask::VZero;
+  } else if (description == header::DataDescription{"COLLISION"}) {
+    return AODTypeMask::Collisions;
+  } else if (description == header::DataDescription{"TIMEFRAME"}) {
+    return AODTypeMask::Timeframe;
+  } else if (description == header::DataDescription{"DZEROFLAGGED"}) {
+    return AODTypeMask::DZeroFlagged;
+  } else {
+    return AODTypeMask::Unknown;
+    LOG(INFO) << "This is a tree of unknown type! " << description.str;
+  }
+
+}
 
 uint64_t calculateReadMask(std::vector<OutputRoute> const& routes, header::DataOrigin const& origin)
 {
@@ -109,29 +139,26 @@ uint64_t calculateReadMask(std::vector<OutputRoute> const& routes, header::DataO
   for (auto& route : routes) {
     auto concrete = DataSpecUtils::asConcreteDataTypeMatcher(route.matcher);
     auto description = concrete.description;
-    if (description == header::DataDescription{"TRACKPAR"}) {
-      readMask |= AODTypeMask::Tracks;
-    } else if (description == header::DataDescription{"TRACKPARCOV"}) {
-      readMask |= AODTypeMask::TracksCov;
-    } else if (description == header::DataDescription{"TRACKEXTRA"}) {
-      readMask |= AODTypeMask::TracksExtra;
-    } else if (description == header::DataDescription{"CALO"}) {
-      readMask |= AODTypeMask::Calo;
-    } else if (description == header::DataDescription{"MUON"}) {
-      readMask |= AODTypeMask::Muon;
-    } else if (description == header::DataDescription{"VZERO"}) {
-      readMask |= AODTypeMask::VZero;
-    } else if (description == header::DataDescription{"COLLISION"}) {
-      readMask |= AODTypeMask::Collisions;
-    } else if (description == header::DataDescription{"TIMEFRAME"}) {
-      readMask |= AODTypeMask::Timeframe;
-    } else if (description == header::DataDescription{"DZEROFLAGGED"}) {
-      readMask |= AODTypeMask::DZeroFlagged;
-    } else {
-      throw std::runtime_error(std::string("Unknown AOD type: ") + description.str);
-    }
+    
+    readMask |= getMask(description);
+    
   }
   return readMask;
+}
+
+std::vector<OutputRoute> getListOfUnknown(std::vector<OutputRoute> const& routes)
+{
+
+  std::vector<OutputRoute> unknows;
+  for (auto& route : routes) {
+    auto concrete = DataSpecUtils::asConcreteDataTypeMatcher(route.matcher);
+    
+    if (getMask(concrete.description) == AODTypeMask::Unknown)
+      unknows.push_back(route);
+    
+  }
+  return unknows;
+
 }
 
 AlgorithmSpec AODReaderHelpers::run2ESDConverterCallback()
@@ -278,9 +305,15 @@ AlgorithmSpec AODReaderHelpers::rootFileReaderCallback()
       filenames.push_back(filename);
     }
 
+    // analyze type of requested tables
     uint64_t readMask = calculateReadMask(spec.outputs, header::DataOrigin{"AOD"});
+    std::vector<OutputRoute> unknowns;
+    if (readMask & AODTypeMask::Unknown)
+      unknowns = getListOfUnknown(spec.outputs);
+
     auto counter = std::make_shared<int>(0);
     return adaptStateless([readMask,
+                           unknowns,
                            counter,
                            filenames](DataAllocator& outputs, ControlService& control, DeviceSpec const& device) {
       // Each parallel reader reads the files whose index is associated to
@@ -377,6 +410,33 @@ AlgorithmSpec AODReaderHelpers::rootFileReaderCallback()
                                               c8, c9, c10, c11, c12, c13, c14,
                                               c15, c16, c17, c18, c19, c20);
       }
+      
+      // tables not included in the DataModel
+      if (readMask & AODTypeMask::Unknown) {
+      
+        // loop over unknowns
+        for (auto route: unknowns) {
+          auto concrete = DataSpecUtils::asConcreteDataMatcher(route.matcher);
+      
+          // get the tree from infile
+          auto trname = concrete.description.str;
+          auto tr = (TTree*)infile.get()->Get(trname);
+          if (!tr) {
+            LOG(ERROR) << "Tree " << trname << "is not contained in file " << f;
+            return;
+          }
+          
+          // create a TreeToTable object
+          auto h = header::DataHeader(concrete.description, concrete.origin, concrete.subSpec);
+          auto o = Output(h);
+          auto& t2t = outputs.make<TreeToTable>(o,tr);
+          
+          // fill the table
+          t2t.Fill();
+      
+        }
+      }
+      
     });
   })};
 

--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -130,7 +130,6 @@ uint64_t getMask(header::DataDescription description)
     return AODTypeMask::Unknown;
     LOG(INFO) << "This is a tree of unknown type! " << description.str;
   }
-
 }
 
 uint64_t calculateReadMask(std::vector<OutputRoute> const& routes, header::DataOrigin const& origin)
@@ -139,9 +138,8 @@ uint64_t calculateReadMask(std::vector<OutputRoute> const& routes, header::DataO
   for (auto& route : routes) {
     auto concrete = DataSpecUtils::asConcreteDataTypeMatcher(route.matcher);
     auto description = concrete.description;
-    
+
     readMask |= getMask(description);
-    
   }
   return readMask;
 }
@@ -152,13 +150,11 @@ std::vector<OutputRoute> getListOfUnknown(std::vector<OutputRoute> const& routes
   std::vector<OutputRoute> unknows;
   for (auto& route : routes) {
     auto concrete = DataSpecUtils::asConcreteDataTypeMatcher(route.matcher);
-    
+
     if (getMask(concrete.description) == AODTypeMask::Unknown)
       unknows.push_back(route);
-    
   }
   return unknows;
-
 }
 
 AlgorithmSpec AODReaderHelpers::run2ESDConverterCallback()
@@ -410,14 +406,14 @@ AlgorithmSpec AODReaderHelpers::rootFileReaderCallback()
                                               c8, c9, c10, c11, c12, c13, c14,
                                               c15, c16, c17, c18, c19, c20);
       }
-      
+
       // tables not included in the DataModel
       if (readMask & AODTypeMask::Unknown) {
-      
+
         // loop over unknowns
-        for (auto route: unknowns) {
+        for (auto route : unknowns) {
           auto concrete = DataSpecUtils::asConcreteDataMatcher(route.matcher);
-      
+
           // get the tree from infile
           auto trname = concrete.description.str;
           auto tr = (TTree*)infile.get()->Get(trname);
@@ -425,18 +421,16 @@ AlgorithmSpec AODReaderHelpers::rootFileReaderCallback()
             LOG(ERROR) << "Tree " << trname << "is not contained in file " << f;
             return;
           }
-          
+
           // create a TreeToTable object
           auto h = header::DataHeader(concrete.description, concrete.origin, concrete.subSpec);
           auto o = Output(h);
-          auto& t2t = outputs.make<TreeToTable>(o,tr);
-          
+          auto& t2t = outputs.make<TreeToTable>(o, tr);
+
           // fill the table
           t2t.Fill();
-      
         }
       }
-      
     });
   })};
 

--- a/Framework/Core/src/CommonDataProcessors.cxx
+++ b/Framework/Core/src/CommonDataProcessors.cxx
@@ -27,6 +27,7 @@
 #include "Framework/Variant.h"
 #include "../../../Algorithm/include/Algorithm/HeaderStack.h"
 #include "Framework/OutputObjHeader.h"
+#include "Framework/TableTreeHelpers.h"
 
 #include "TFile.h"
 #include "TTree.h"
@@ -68,261 +69,6 @@ struct InputObject {
 
 const static std::unordered_map<OutputObjHandlingPolicy, std::string> ROOTfileNames = {{OutputObjHandlingPolicy::AnalysisObject, "AnalysisResults.root"},
                                                                                        {OutputObjHandlingPolicy::QAObject, "QAResults.root"}};
-
-// =============================================================================
-// class branchIterator is a data iterator
-// it basically allows to iterate over the elements of an arrow::table::Column and
-// successively fill the branches with branchIterator::fillnext()
-// it is used in CommonDataProcessors::table2tree
-class branchIterator
-{
-
- private:
-  const char* brn;        // branch name
-  arrow::ArrayVector chs; // chunks
-  Int_t nchs;             // number of chunks
-  Int_t ich;              // chunk counter
-  Int_t nr;               // number of rows
-  Int_t ir;               // row counter
-
-  // data buffers for each data type
-  arrow::Type::type dt;
-  std::string leaflist;
-
-  TBranch* br = nullptr;
-
-  char* dbuf = nullptr;
-  void* v = nullptr;
-
-  Float_t* var_f = nullptr;
-  Double_t* var_d = nullptr;
-  UShort_t* vs = nullptr;
-  UInt_t* vi = nullptr;
-  ULong64_t* vl = nullptr;
-  Short_t* var_s = nullptr;
-  Int_t* var_i = nullptr;
-  Long64_t* var_l = nullptr;
-
-  // initialize a branch
-  void branchini(TTree* tree, std::shared_ptr<arrow::Column> col, bool tupdate)
-  {
-
-    if (tupdate) {
-      br = tree->GetBranch(brn);
-
-    } else {
-
-      // create new branch of given data type
-      switch (dt) {
-        case arrow::Type::type::FLOAT:
-          leaflist = col->name() + "/F";
-          break;
-        case arrow::Type::type::DOUBLE:
-          leaflist = col->name() + "/D";
-          break;
-        case arrow::Type::type::UINT16:
-          leaflist = col->name() + "/s";
-          break;
-        case arrow::Type::type::UINT32:
-          leaflist = col->name() + "/i";
-          break;
-        case arrow::Type::type::UINT64:
-          leaflist = col->name() + "/l";
-          break;
-        case arrow::Type::type::INT16:
-          leaflist = col->name() + "/S";
-          break;
-        case arrow::Type::type::INT32:
-          leaflist = col->name() + "/I";
-          break;
-        case arrow::Type::type::INT64:
-          leaflist = col->name() + "/L";
-          break;
-        default:
-          LOG(FATAL) << "Type not handled: " << dt << std::endl;
-          break;
-      }
-
-      br = tree->Branch(brn, dbuf, leaflist.c_str());
-    }
-    if (!br)
-      throw std::runtime_error("Branch does not exist!");
-  };
-
-  // initialize chunk ib
-  void dbufini(Int_t ib)
-  {
-    // get next chunk of given data type dt
-    switch (dt) {
-      case arrow::Type::type::FLOAT:
-        var_f = (Float_t*)std::dynamic_pointer_cast<arrow::NumericArray<arrow::FloatType>>(chs.at(ib))->raw_values();
-        v = (void*)var_f;
-        break;
-      case arrow::Type::type::DOUBLE:
-        var_d = (Double_t*)std::dynamic_pointer_cast<arrow::NumericArray<arrow::DoubleType>>(chs.at(ib))->raw_values();
-        v = (void*)var_d;
-        break;
-      case arrow::Type::type::UINT16:
-        vs = (UShort_t*)std::dynamic_pointer_cast<arrow::NumericArray<arrow::UInt16Type>>(chs.at(ib))->raw_values();
-        v = (void*)vs;
-        break;
-      case arrow::Type::type::UINT32:
-        vi = (UInt_t*)std::dynamic_pointer_cast<arrow::NumericArray<arrow::UInt32Type>>(chs.at(ib))->raw_values();
-        v = (void*)vi;
-        break;
-      case arrow::Type::type::UINT64:
-        vl = (ULong64_t*)std::dynamic_pointer_cast<arrow::NumericArray<arrow::UInt64Type>>(chs.at(ib))->raw_values();
-        v = (void*)vl;
-        break;
-      case arrow::Type::type::INT16:
-        var_s = (Short_t*)std::dynamic_pointer_cast<arrow::NumericArray<arrow::Int16Type>>(chs.at(ib))->raw_values();
-        v = (void*)var_s;
-        break;
-      case arrow::Type::type::INT32:
-        var_i = (Int_t*)std::dynamic_pointer_cast<arrow::NumericArray<arrow::Int32Type>>(chs.at(ib))->raw_values();
-        v = (void*)var_i;
-        break;
-      case arrow::Type::type::INT64:
-        var_l = (Long64_t*)std::dynamic_pointer_cast<arrow::NumericArray<arrow::Int64Type>>(chs.at(ib))->raw_values();
-        v = (void*)var_l;
-        break;
-      default:
-        LOG(FATAL) << "Type not handled: " << dt << std::endl;
-        break;
-    }
-    br->SetAddress(v);
-
-    // reset number of rows nr and row counter ir
-    nr = chs.at(ib)->length();
-    ir = 0;
-  };
-
- public:
-  branchIterator() : brn(nullptr),
-                     nchs(0),
-                     ich(0),
-                     nr(0),
-                     ir(0),
-                     dt(arrow::Type::type::NA){};
-  branchIterator(TTree* tree, std::shared_ptr<arrow::Column> col, bool tupdate) : brn(nullptr),
-                                                                                  nchs(0),
-                                                                                  ich(0),
-                                                                                  nr(0),
-                                                                                  ir(0),
-                                                                                  dt(arrow::Type::type::NA)
-  {
-    brn = col->name().c_str();
-    dt = col->type()->id();
-    chs = col->data()->chunks();
-    nchs = chs.size();
-
-    // initialize the branch
-    branchini(tree, col, tupdate);
-
-    ich = 0;
-    dbufini(ich);
-    LOG(DEBUG) << "datait: " << col->type()->ToString() << " with " << nchs << " chunks" << std::endl;
-  };
-  ~branchIterator();
-
-  // return branch
-  TBranch* branch() { return br; };
-
-  // return the data type
-  arrow::Type::type type() { return dt; };
-
-  // fills buffer with next value
-  // returns fals if end of buffer reached
-  bool fillnext()
-  {
-
-    // ich and ir contain the current chunk and row
-    // return the next element if available
-    if (ir >= nr) {
-      ich++;
-      if (ich < nchs) {
-        dbufini(ich);
-      } else {
-        // end of data buffer reached
-        return false;
-      }
-    } else {
-      switch (dt) {
-        case arrow::Type::type::FLOAT:
-          v = (void*)var_f++;
-          break;
-        case arrow::Type::type::DOUBLE:
-          v = (void*)var_d++;
-          break;
-        case arrow::Type::type::UINT16:
-          v = (void*)vs++;
-          break;
-        case arrow::Type::type::UINT32:
-          v = (void*)vi++;
-          break;
-        case arrow::Type::type::UINT64:
-          v = (void*)vl++;
-          break;
-        case arrow::Type::type::INT16:
-          v = (void*)var_s++;
-          break;
-        case arrow::Type::type::INT32:
-          v = (void*)var_i++;
-          break;
-        case arrow::Type::type::INT64:
-          v = (void*)var_l++;
-          break;
-        default:
-          LOG(FATAL) << "Type not handled: " << dt << std::endl;
-          v = nullptr;
-          break;
-      }
-    }
-    br->SetAddress(v);
-    ir++;
-
-    return true;
-  };
-};
-
-// .............................................................................
-void CommonDataProcessors::table2tree(TTree* tout,
-                                      std::shared_ptr<arrow::Table> table,
-                                      bool tupdate)
-{
-
-  LOG(DEBUG) << "table2tree: " << table->num_columns();
-
-  // first create a vector of branchIterators
-  std::vector<branchIterator*> itbuf;
-
-  for (int ii = 0; ii < table->num_columns(); ii++) {
-
-    auto col = table->column(ii);
-    const char* cname = col->name().c_str();
-
-    // for each column get a branchIterator
-    // fill the branchIterator into a std::vector
-    branchIterator* brit = new branchIterator(tout, col, tupdate);
-    itbuf.push_back(brit);
-  }
-  LOG(DEBUG) << "table2tree: size of itbuf " << itbuf.size();
-
-  // with this loop over the columns again as long as togo is true.
-  // togo is set false when any of the data iterators returns false
-  bool togo = true;
-  while (togo) {
-    // fill the tree
-    tout->Fill();
-
-    // update the branches
-    for (int ii = 0; ii < table->num_columns(); ii++)
-      togo &= itbuf.at(ii)->fillnext();
-  }
-
-  // write the tree
-  tout->Write("", TObject::kOverwrite);
-}
 
 // =============================================================================
 DataProcessorSpec CommonDataProcessors::getOutputObjSink(outputObjMap const& outMap)
@@ -508,20 +254,10 @@ DataProcessorSpec
         return;
       }
 
-      // new strategy since RDataFrame::Snapshot does not work
-      //
-      // loop over all inputs and extract the arrow::tables
-      // create a tree for each arrow::table
-      // loop over the columns of a table
-      // for each column create a branch
-      // loop over the rows of the column
-      // fill the values into the corresponding branches
-      // write the table
-      // see table2tree
 
       // open new file if ntfmerge time frames is reached
       LOG(DEBUG) << "This is time frame number " << ntf;
-      bool tupdate = true;
+
       std::string fname;
       if ((ntf % ntfmerge) == 0) {
         if (fout)
@@ -530,12 +266,10 @@ DataProcessorSpec
         fname = fnbase + "_" + std::to_string((Int_t)(ntf / ntfmerge)) + ".root";
         fout =
           std::make_shared<TFile>(fname.c_str(), filemode.c_str());
-        tupdate = false;
       }
       ntf++;
 
       // loop over the DataRefs which are contained in pc.inputs()
-      TTree* tout = nullptr;
       VariableContext matchingContext;
       for (const auto& ref : pc.inputs()) {
 
@@ -564,15 +298,15 @@ DataProcessorSpec
           continue;
 
         // this table needs to be saved to file
-        // create the corresponding tree
-        if (tupdate) {
-          tout = (TTree*)fout->Get(treename.c_str());
-        } else {
-          tout = new TTree(treename.c_str(), treename.c_str());
-        }
-
-        // write the table to the TTree
-        table2tree(tout, table, tupdate);
+        // use TableToTree
+        TableToTree ta2tr(table, fout.get(), treename.c_str());
+        
+        // all columns of the table are saved
+        ta2tr.AddAllBranches();
+        // to select specific columns use ...
+        // ta2tr.AddBranch(colname);
+        ta2tr.Process();
+        
       }
     });
   }; // end of writerFunction

--- a/Framework/Core/src/CommonDataProcessors.cxx
+++ b/Framework/Core/src/CommonDataProcessors.cxx
@@ -254,7 +254,6 @@ DataProcessorSpec
         return;
       }
 
-
       // open new file if ntfmerge time frames is reached
       LOG(DEBUG) << "This is time frame number " << ntf;
 
@@ -300,13 +299,12 @@ DataProcessorSpec
         // this table needs to be saved to file
         // use TableToTree
         TableToTree ta2tr(table, fout.get(), treename.c_str());
-        
+
         // all columns of the table are saved
         ta2tr.AddAllBranches();
         // to select specific columns use ...
         // ta2tr.AddBranch(colname);
         ta2tr.Process();
-        
       }
     });
   }; // end of writerFunction

--- a/Framework/Core/src/DataAllocator.cxx
+++ b/Framework/Core/src/DataAllocator.cxx
@@ -165,6 +165,43 @@ void DataAllocator::adopt(const Output& spec, TableBuilder* tb)
   context->addBuffer(std::move(header), buffer, std::move(finalizer), channel);
 }
 
+void DataAllocator::adopt(const Output& spec, TreeToTable* t2t)
+{
+  std::string const& channel = matchDataHeader(spec, mTimingInfo->timeslice);
+  
+  LOG(INFO) << "DataAllocator::adopt channel " << channel.c_str();
+  
+  auto header = headerMessageFromOutput(spec, channel, o2::header::gSerializationMethodArrow, 0);
+  auto context = mContextRegistry->get<ArrowContext>();
+  
+  auto creator = [device = context->proxy().getDevice()](size_t s) -> std::unique_ptr<FairMQMessage> {
+    return device->NewMessage(s);
+  };
+  auto buffer = std::make_shared<FairMQResizableBuffer>(creator);
+
+  /// To finalise this we write the table to the buffer.
+  /// FIXME: most likely not a great idea. We should probably write to the buffer
+  ///        directly in the TableBuilder, incrementally.
+  std::shared_ptr<TreeToTable> p(t2t);
+  auto finalizer = [payload = p](std::shared_ptr<FairMQResizableBuffer> b) -> void {
+    auto table = payload->Finalize();
+    LOG(INFO) << "DataAllocator Table created!";
+    LOG(INFO) << "Number of columns " << table->num_columns();
+    LOG(INFO) << "Number of rows    " << table->num_rows();
+
+    auto stream = std::make_shared<arrow::io::BufferOutputStream>(b);
+    std::shared_ptr<arrow::ipc::RecordBatchWriter> writer;
+    auto outBatch = arrow::ipc::RecordBatchStreamWriter::Open(stream.get(), table->schema(), &writer);
+    auto outStatus = writer->WriteTable(*table);
+    if (outStatus.ok() == false) {
+      throw std::runtime_error("Unable to Write table");
+    }
+  };
+
+  assert(context);
+  context->addBuffer(std::move(header), buffer, std::move(finalizer), channel);
+}
+
 void DataAllocator::snapshot(const Output& spec, const char* payload, size_t payloadSize,
                              o2::header::SerializationMethod serializationMethod)
 {

--- a/Framework/Core/src/DataAllocator.cxx
+++ b/Framework/Core/src/DataAllocator.cxx
@@ -168,12 +168,11 @@ void DataAllocator::adopt(const Output& spec, TableBuilder* tb)
 void DataAllocator::adopt(const Output& spec, TreeToTable* t2t)
 {
   std::string const& channel = matchDataHeader(spec, mTimingInfo->timeslice);
-  
   LOG(INFO) << "DataAllocator::adopt channel " << channel.c_str();
-  
+
   auto header = headerMessageFromOutput(spec, channel, o2::header::gSerializationMethodArrow, 0);
   auto context = mContextRegistry->get<ArrowContext>();
-  
+
   auto creator = [device = context->proxy().getDevice()](size_t s) -> std::unique_ptr<FairMQMessage> {
     return device->NewMessage(s);
   };

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -309,10 +309,7 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
 
   // From that list select the ones of origin AOD ...
   // .. and remove them also from the original list
-  LOG(DEBUG) << "1 danglingOutputsInputs.size() " << danglingOutputsInputs.size() << std::endl;
   auto danglingOutputsInputsAOD = selectAODs(danglingOutputsInputs);
-  LOG(DEBUG) << "2 danglingOutputsInputsAOD.size() " << danglingOutputsInputsAOD.size() << std::endl;
-  LOG(DEBUG) << "2 danglingOutputsInputs.size() " << danglingOutputsInputs.size() << std::endl;
 
   // file sink for notAOD dangling outputs
   extraSpecs.clear();


### PR DESCRIPTION
The functionality was added to read and process data from any flat TTree in a task.
An example is provided by
  Analysis/Tutorials/src/aodwriter.cxx
  Analysis/Tutorials/src/aodreader.cxx

With aodwriter two tables are created and saved to a root file. In aodreader these trees are read and processed.

Usage:
o2-analysistutorial-aodwriter --aod-file AO2D.root --res-file tabletotree > log
o2-analysistutorial-aodreader --aod-file tabletotree_0.root > log

where AO2D.root is an aod file.
