### PR TITLE
DPL: add utility to create external output proxies

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -268,6 +268,7 @@ foreach(w
         SimpleWildcard
         SingleDataSource
         Task
+        ExternalFairMQDeviceWorkflow
         )
   o2_add_test(${w} NAME test_Framework_test_${w}
               SOURCES test/test_${w}.cxx
@@ -290,6 +291,12 @@ set_property(TEST test_Framework_test_DanglingInputs PROPERTY DISABLED TRUE)
 set_property(TEST test_Framework_test_SimpleTracksED PROPERTY DISABLED TRUE)
 set_property(TEST test_Framework_test_CustomGUIGL PROPERTY DISABLED TRUE)
 set_property(TEST test_Framework_test_CustomGUISokol PROPERTY DISABLED TRUE)
+
+# there is a problem in the termination of the FairMQDevice by signals because
+# the pending input polling is aborted and this throws an error
+#    [ERROR] Failed receiving on socket input-proxy.input-proxy[0].pull, reason: Interrupted system call, nbytes = -1
+# this can either be fixed in FairMQ or in the DPL driver
+set_property(TEST test_Framework_test_ExternalFairMQDeviceWorkflow PROPERTY DISABLED TRUE)
 
 # TODO: investigate the problem and re-enable
 set_property(TEST test_Framework_test_BoostSerializedProcessing

--- a/Framework/Core/include/Framework/ExternalFairMQDeviceProxy.h
+++ b/Framework/Core/include/Framework/ExternalFairMQDeviceProxy.h
@@ -73,15 +73,39 @@ static auto gDefaultConverter = incrementalConverter(OutputSpec{"TST", "TEST", 0
 /// @param label is the label of the DataProcessorSpec associated.
 /// @param outputs is the type of messages which this source produces.
 /// @param channelConfig is string to be passed to fairmq to create the device.
-///        notice that the name of the device will be the same as the label.
+///        notice that the name of the device will be added as the name of the channel if the
+///        name tag is not yet in the configuration
 /// @param converter is a lambda to be invoked to convert @a inputs into
 ///        messages of the DPL. By default @a incrementalConverter is used
 ///        which attaches to each @input FairMQPart a DataProcessingHeader
 ///        with an incremental number as start time.
 DataProcessorSpec specifyExternalFairMQDeviceProxy(char const* label,
                                                    std::vector<OutputSpec> const& outputs,
-                                                   const char* channelConfig,
+                                                   const char* defaultChannelConfig,
                                                    InjectorFunction converter);
+
+/// Create a DataProcessorSpec for a DPL processor with an out-of-band channel to relay DPL
+/// workflow data to an external FairMQDevice channel.
+///
+/// The output configuration is determined by one or multiple entries of the FairMQDevice
+/// command line option '--channel-config' in the format
+///    --channel-config "name=channel-name;..."
+/// A default string is build from the provided parameter.
+///
+/// The target of each input data matcher is specified as the binding identifier and matched to the
+/// configured output channels
+/// @param label is the label of the DataProcessorSpec associated.
+/// @param inputSpecs the list of inputs to read from, the binding of the spec must
+///        correspond to an output channel
+/// @param defaultChannelConfig is the default configuration of the out-of-band channel
+///        the string is passed to fairmq to create the device channel and can be adjusted
+///        by command line option '--channel-config'
+///        notice that the name of the device will be added as the name of the channel if the
+///        name tag is not yet in the configuration
+DataProcessorSpec specifyFairMQDeviceOutputProxy(char const* label,
+                                                 Inputs const& inputSpecs,
+                                                 const char* defaultChannelConfig);
+
 } // namespace framework
 } // namespace o2
 

--- a/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
+++ b/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
@@ -9,6 +9,7 @@
 // or submit itself to any jurisdiction.
 #include "Framework/AlgorithmSpec.h"
 #include "Framework/ConfigParamSpec.h"
+#include "Framework/AlgorithmSpec.h"
 #include "Framework/DataProcessingHeader.h"
 #include "Framework/DataSpecUtils.h"
 #include "Framework/DeviceSpec.h"
@@ -16,7 +17,9 @@
 #include "Framework/InitContext.h"
 #include "Framework/ProcessingContext.h"
 #include "Framework/RawDeviceService.h"
+#include "Framework/CallbackService.h"
 #include "Headers/DataHeader.h"
+#include "Headers/Stack.h"
 
 #include "./DeviceSpecHelpers.h"
 
@@ -28,6 +31,8 @@
 #include <optional>
 #include <unordered_map>
 #include <numeric> // std::accumulate
+#include <sstream>
+#include <stdexcept>
 
 namespace o2
 {
@@ -80,7 +85,7 @@ void sendOnChannel(FairMQDevice& device, FairMQParts& messages, std::string cons
     }
   }
   if (timeout > 0 && timeout <= maxTimeout) {
-    LOG(WARNING) << "dispatching on channel " << channel << "was delayed by " << timeout << " ms";
+    LOG(WARNING) << "dispatching on channel " << channel << " was delayed by " << timeout << " ms";
   }
   // TODO: feeling this is a bit awkward, but the interface of FairMQParts does not provide a
   // method to clear the content.
@@ -375,7 +380,7 @@ InjectorFunction incrementalConverter(OutputSpec const& spec, uint64_t startTime
 
 DataProcessorSpec specifyExternalFairMQDeviceProxy(char const* name,
                                                    std::vector<OutputSpec> const& outputs,
-                                                   char const* channelConfig,
+                                                   char const* defaultChannelConfig,
                                                    std::function<void(FairMQDevice&,
                                                                       FairMQParts&,
                                                                       std::function<std::string(OutputSpec const&)>)>
@@ -412,9 +417,75 @@ DataProcessorSpec specifyExternalFairMQDeviceProxy(char const* name,
     device->OnData(channel, handler);
     return [](ProcessingContext&) {};
   }};
-  const char* d = strdup((std::string("name=") + name + "," + channelConfig).c_str());
+  const char* d = strdup(((std::string(defaultChannelConfig).find("name=") == std::string::npos ? (std::string("name=") + name + ",") : "") + std::string(defaultChannelConfig)).c_str());
   spec.options = {
     ConfigParamSpec{"channel-config", VariantType::String, d, {"Out-of-band channel config"}}};
+  return spec;
+}
+
+DataProcessorSpec specifyFairMQDeviceOutputProxy(char const* name,
+                                                 Inputs const& inputSpecs,
+                                                 const char* defaultChannelConfig)
+{
+  DataProcessorSpec spec;
+  spec.name = name;
+  spec.inputs = inputSpecs;
+  spec.outputs = {};
+  spec.algorithm = adaptStateful([inputSpecs](CallbackService& callbacks, RawDeviceService& rds) {
+    auto device = rds.device();
+    // check that the input spec bindings have corresponding output channels
+    // FairMQDevice calls the custom init before the channels have been configured
+    // so we do the check before starting in a dedicated callback
+    auto channelConfigurationChecker = [inputSpecs = std::move(inputSpecs), device]() {
+      LOG(INFO) << "checking channel configuration";
+      for (auto const& spec : inputSpecs) {
+        if (device->fChannels.count(spec.binding) == 0) {
+          throw std::runtime_error("no corresponding output channel found for input '" + spec.binding + "'");
+        }
+      }
+    };
+    callbacks.set(CallbackService::Id::Start, channelConfigurationChecker);
+    return adaptStateless([](RawDeviceService& rds, InputRecord& inputs) {
+      std::unordered_map<std::string, FairMQParts> outputs;
+      auto& device = *rds.device();
+      for (auto& input : inputs) {
+        // TODO: we need to make a copy of the messages, maybe we can implement functionality in
+        // the RawDeviceService to forward messages, but this also needs to take into account that
+        // other consumers might exist
+        size_t headerMsgSize = o2::header::Stack::headerStackSize(reinterpret_cast<o2::byte const*>(input.header));
+        auto* dh = o2::header::get<DataHeader*>(input.header);
+        if (!dh) {
+          std::stringstream errorMessage;
+          errorMessage << "no data header in " << *input.spec;
+          throw std::runtime_error(errorMessage.str());
+        }
+        size_t payloadMsgSize = dh->payloadSize;
+        // we could probably do something like this but we do not know when the message is going to be sent
+        // and if DPL is still owning a valid copy.
+        //auto headerMessage = device.NewMessageFor(input.spec->binding, input.header, headerMsgSize, [](void*, void*) {});
+
+        // Note: DPL is only setting up one instance of a channel while FairMQ allows to have an
+        // array of channels, the index is 0 in the call
+        constexpr auto index = 0;
+        auto headerMessage = device.NewMessageFor(input.spec->binding, index, headerMsgSize);
+        memcpy(headerMessage->GetData(), input.header, headerMsgSize);
+        auto payloadMessage = device.NewMessageFor(input.spec->binding, index, payloadMsgSize);
+        memcpy(payloadMessage->GetData(), input.payload, payloadMsgSize);
+        outputs[input.spec->binding].AddPart(std::move(headerMessage));
+        outputs[input.spec->binding].AddPart(std::move(payloadMessage));
+      }
+      for (auto& [channelName, channelParts] : outputs) {
+        if (channelParts.Size() == 0) {
+          continue;
+        }
+        sendOnChannel(device, channelParts, channelName);
+      }
+    });
+  });
+  const char* d = strdup(((std::string(defaultChannelConfig).find("name=") == std::string::npos ? (std::string("name=") + name + ",") : "") + std::string(defaultChannelConfig)).c_str());
+  spec.options = {
+    ConfigParamSpec{"channel-config", VariantType::String, d, {"Out-of-band channel config"}}};
+
   return spec;
 }
 

--- a/Framework/Core/test/test_ExternalFairMQDeviceWorkflow.cxx
+++ b/Framework/Core/test/test_ExternalFairMQDeviceWorkflow.cxx
@@ -1,0 +1,183 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/ExternalFairMQDeviceProxy.h"
+
+using namespace o2::framework;
+
+#include "Framework/AlgorithmSpec.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/ChannelSpec.h"
+#include "Framework/DataSpecUtils.h"
+#include "Framework/ExternalFairMQDeviceProxy.h"
+#include "Framework/ControlService.h"
+#include "Framework/Logger.h"
+#include "Headers/DataHeader.h"
+#include "fairmq/FairMQDevice.h"
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  workflowOptions.push_back(
+    ConfigParamSpec{
+      "default-transport", VariantType::String, "shmem", {"default transport: shmem, zeromq"}});
+  workflowOptions.push_back(
+    ConfigParamSpec{
+      "number-of-events,n", VariantType::Int, 10, {"number of events to process"}});
+}
+
+#include "Framework/runDataProcessing.h"
+
+#define ASSERT_ERROR(condition)                                   \
+  if ((condition) == false) {                                     \
+    LOG(ERROR) << R"(Test condition ")" #condition R"(" failed)"; \
+  }
+
+std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const& config)
+{
+  std::string defaultTransportConfig = config.options().get<std::string>("default-transport");
+  int nRolls = config.options().get<int>("number-of-events");
+  if (defaultTransportConfig == "zeromq") {
+    // nothing to do for the moment
+  } else if (defaultTransportConfig == "shmem") {
+    // nothing to do for the moment
+  } else {
+    throw std::runtime_error("invalid argument for option --default-transport : '" + defaultTransportConfig + "'");
+  }
+  std::vector<DataProcessorSpec> workflow;
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // a producer process steered by a timer
+  //
+  // the compute callback of the producer
+  auto producerCallback = [nRolls, counter = std::make_shared<int>()](DataAllocator& outputs, ControlService& control) {
+    outputs.make<int>(OutputRef{"data", 0}) = *counter;
+    if (++(*counter) >= nRolls) {
+      control.endOfStream();
+      control.readyToQuit(QuitRequest::Me);
+    }
+  };
+
+  workflow.emplace_back(DataProcessorSpec{"producer",
+                                          {InputSpec{"timer", "TST", "TIMER", 0, Lifetime::Timer}},
+                                          {OutputSpec{{"data"}, "TST", "DATA", 0, Lifetime::Timeframe}},
+                                          AlgorithmSpec{adaptStateless(producerCallback)},
+                                          {ConfigParamSpec{"period-timer", VariantType::Int, 100000, {"period of timer"}}}});
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // the dpl sink proxy process
+
+  // use the OutputChannelSpec as a tool to create the default configuration for the out-of-band channel
+  OutputChannelSpec externalChannelSpec;
+  // Note: the name has to match the binding of the input spec
+  externalChannelSpec.name = "external";
+  externalChannelSpec.type = ChannelType::Push;
+  externalChannelSpec.method = ChannelMethod::Bind;
+  externalChannelSpec.hostname = "localhost";
+  externalChannelSpec.port = 42042;
+  externalChannelSpec.listeners = 0;
+  if (!defaultTransportConfig.empty()) {
+    if (defaultTransportConfig == "zeromq") {
+      externalChannelSpec.protocol = ChannelProtocol::Network;
+    } else if (defaultTransportConfig == "shmem") {
+      externalChannelSpec.protocol = ChannelProtocol::IPC;
+    }
+  }
+  std::string channelConfig = formatExternalChannelConfiguration(externalChannelSpec);
+  // at some point the formatting tool might add the transport as well so we have to check
+  if (!defaultTransportConfig.empty() && defaultTransportConfig.find("transport=") == std::string::npos) {
+    channelConfig += ",transport=" + defaultTransportConfig;
+  }
+
+  Inputs sinkInputs = {InputSpec{"external", "TST", "DATA", 0, Lifetime::Timeframe}};
+  workflow.emplace_back(std::move(specifyFairMQDeviceOutputProxy("dpl-sink", sinkInputs, channelConfig.c_str())));
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // a simple checker process subscribing to the output of the input proxy
+  //
+  // the compute callback of the checker
+  auto checkerCallback = [nRolls](InputRecord& inputs, ControlService& control) {
+    LOG(DEBUG) << "got inputs " << inputs.size();
+    if (inputs.get<int>("datain") == nRolls - 1) {
+      LOG(INFO) << "terminating after " << nRolls << " successful event(s)";
+      control.endOfStream();
+      control.readyToQuit(QuitRequest::All);
+    }
+  };
+
+  // the checker process connects to the proxy
+  workflow.emplace_back(DataProcessorSpec{"checker",
+                                          {InputSpec{"datain", "PRX", "DATA", 0, Lifetime::Timeframe}},
+                                          {},
+                                          AlgorithmSpec{adaptStateless(checkerCallback)}});
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // the input proxy process
+  // reads the messages from the output proxy via the out-of-band channel
+
+  // converter callback for the external FairMQ device proxy ProcessorSpec generator
+  auto converter = [](FairMQDevice& device, FairMQParts& inputs, ChannelRetriever channelRetriever) {
+    ASSERT_ERROR(inputs.Size() >= 2);
+    if (inputs.Size() < 2) {
+      return;
+    }
+    int msgidx = 0;
+    auto dh = o2::header::get<o2::header::DataHeader*>(inputs.At(msgidx)->GetData());
+    if (!dh) {
+      LOG(ERROR) << "data on input " << msgidx << " does not follow the O2 data model, DataHeader missing";
+      return;
+    }
+
+    // Note: we want to run both the output and input proxy in the same workflow and thus we need
+    // different data identifiers and change the data origin in the forwarding
+    OutputSpec query{"PRX", dh->dataDescription, dh->subSpecification};
+    auto channelName = channelRetriever(query);
+    ASSERT_ERROR(!channelName.empty());
+    LOG(DEBUG) << "using channel '" << channelName << "' for " << DataSpecUtils::describe(OutputSpec{dh->dataOrigin, dh->dataDescription, dh->subSpecification});
+    if (channelName.empty()) {
+      return;
+    }
+    // make a copy of the header message, get the data header and change origin
+    auto outHeaderMessage = device.NewMessageFor(channelName, 0, inputs.At(msgidx)->GetSize());
+    memcpy(outHeaderMessage->GetData(), inputs.At(msgidx)->GetData(), inputs.At(msgidx)->GetSize());
+    // this we obviously need to fix in the get API, const'ness of the returned header pointer
+    // should depend on const'ness of the buffer
+    auto odh = const_cast<o2::header::DataHeader*>(o2::header::get<o2::header::DataHeader*>(outHeaderMessage->GetData()));
+    odh->dataOrigin = o2::header::DataOrigin("PRX");
+    FairMQParts output;
+    output.AddPart(std::move(outHeaderMessage));
+    output.AddPart(std::move(inputs.At(msgidx + 1)));
+    LOG(DEBUG) << "sending " << DataSpecUtils::describe(OutputSpec{odh->dataOrigin, odh->dataDescription, odh->subSpecification});
+    o2::framework::sendOnChannel(device, output, channelName);
+  };
+
+  // we use the same spec to build the configuration string, ideally we would have some helpers
+  // which convert an OutputChannelSpec to an InputChannelSpec replacing 'bind' <--> 'connect'
+  // and 'push' <--> 'pull'
+  //
+  // skip the name in the configuration string as it is added in specifyExternalFairMQDeviceProxy
+  externalChannelSpec.name = "";
+  externalChannelSpec.type = ChannelType::Pull;
+  externalChannelSpec.method = ChannelMethod::Connect;
+  channelConfig = formatExternalChannelConfiguration(externalChannelSpec);
+  if (!defaultTransportConfig.empty() && defaultTransportConfig.find("transport=") == std::string::npos) {
+    channelConfig += ",transport=" + defaultTransportConfig;
+  }
+
+  // Note: in order to make the DPL output proxy and an input proxy working in the same
+  // workflow, we use different data description
+  Outputs inputProxyOutputs = {OutputSpec{"PRX", "DATA", 0, Lifetime::Timeframe}};
+  workflow.emplace_back(specifyExternalFairMQDeviceProxy(
+    "input-proxy",
+    std::move(inputProxyOutputs),
+    channelConfig.c_str(),
+    converter));
+
+  return workflow;
+}


### PR DESCRIPTION
Adding specifyFairMQDeviceOutputProxy helper method to create a DataProcessorSpec
for a DPL processor with an out-of-band channel to relay DPL workflow data to an
external FairMQDevice device.

The output configuration is determined by one or multiple entries of the FairMQDevice
command line option '--channel-config' in the format. The binding of each input spec
must correspond to an output channel.

Adding unit test to connect an out-of-band output channel with a DPL input proxy,
but this must be disabled for the moment because of FairMQ printing an error message
when the input poller is aborted during device shutdown.

To be done in later update
- [ ] activation of the unit test once the error message is fixed