### PR TITLE
Moving DeviceSpecHelpers.h to Framework/Core/include/Framework

### DIFF
--- a/Framework/Core/include/Framework/DeviceSpecHelpers.h
+++ b/Framework/Core/include/Framework/DeviceSpecHelpers.h
@@ -22,9 +22,6 @@
 #include "Framework/AlgorithmSpec.h"
 #include "Framework/ConfigParamSpec.h"
 #include "Framework/OutputRoute.h"
-#include "ResourceManager.h"
-#include "DataProcessorInfo.h"
-#include "WorkflowHelpers.h"
 #include <boost/program_options.hpp>
 
 #include <vector>
@@ -37,6 +34,13 @@ namespace framework
 {
 struct InputChannelSpec;
 struct OutputChannelSpec;
+struct ResourceManager;
+struct DataProcessorInfo;
+struct DeviceId;
+struct DeviceConnectionId;
+struct DeviceConnectionEdge;
+struct EdgeAction;
+struct LogicalForwardInfo;
 
 struct DeviceSpecHelpers {
   /// Helper to convert from an abstract dataflow specification, @a workflow,

--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -7,7 +7,7 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#include "DeviceSpecHelpers.h"
+#include "Framework/DeviceSpecHelpers.h"
 #include "ChannelSpecHelpers.h"
 #include <wordexp.h>
 #include <algorithm>
@@ -29,7 +29,8 @@
 #include "Framework/WorkflowSpec.h"
 #include "Framework/ComputingResource.h"
 #include "Framework/Logger.h"
-
+#include "ResourceManager.h"
+#include "DataProcessorInfo.h"
 #include "WorkflowHelpers.h"
 
 namespace bpo = boost::program_options;

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -39,17 +39,18 @@
 #include "Framework/TextControlService.h"
 #include "Framework/CallbackService.h"
 #include "Framework/WorkflowSpec.h"
+#include "Framework/DeviceSpecHelpers.h"
 
 #include "ComputingResourceHelpers.h"
 #include "DataProcessingStatus.h"
 #include "DDSConfigHelpers.h"
 #include "O2ControlHelpers.h"
-#include "DeviceSpecHelpers.h"
 #include "DriverControl.h"
 #include "DriverInfo.h"
 #include "DataProcessorInfo.h"
 #include "GraphvizHelpers.h"
 #include "SimpleResourceManager.h"
+#include "WorkflowHelpers.h"
 #include "WorkflowSerializationHelpers.h"
 
 #include <Monitoring/MonitoringFactory.h>

--- a/Framework/Core/test/test_DeviceSpec.cxx
+++ b/Framework/Core/test/test_DeviceSpec.cxx
@@ -13,7 +13,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include "../src/ChannelSpecHelpers.h"
-#include "../src/DeviceSpecHelpers.h"
+#include "Framework/DeviceSpecHelpers.h"
 #include "../src/GraphvizHelpers.h"
 #include "../src/WorkflowHelpers.h"
 #include "Framework/DeviceSpec.h"

--- a/Framework/Core/test/test_DeviceSpecHelpers.cxx
+++ b/Framework/Core/test/test_DeviceSpecHelpers.cxx
@@ -14,7 +14,7 @@
 #include "Framework/WorkflowSpec.h"
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/DeviceExecution.h"
-#include "../src/DeviceSpecHelpers.h"
+#include "Framework/DeviceSpecHelpers.h"
 #include <boost/test/unit_test.hpp>
 #include <boost/test/tools/detail/per_element_manip.hpp>
 #include <algorithm>
@@ -24,6 +24,7 @@
 #include <map>
 #include "../src/SimpleResourceManager.h"
 #include "../src/ComputingResourceHelpers.h"
+#include "../src/DataProcessorInfo.h"
 
 namespace o2
 {

--- a/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
+++ b/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
@@ -13,9 +13,10 @@
 
 #include <boost/test/unit_test.hpp>
 #include "../src/DDSConfigHelpers.h"
-#include "../src/DeviceSpecHelpers.h"
+#include "Framework/DeviceSpecHelpers.h"
 #include "../src/SimpleResourceManager.h"
 #include "../src/ComputingResourceHelpers.h"
+#include "../src/DataProcessorInfo.h"
 #include "Framework/DataAllocator.h"
 #include "Framework/DeviceControl.h"
 #include "Framework/DeviceSpec.h"

--- a/Framework/Core/test/test_Graphviz.cxx
+++ b/Framework/Core/test/test_Graphviz.cxx
@@ -12,7 +12,7 @@
 #define BOOST_TEST_DYN_LINK
 
 #include "../src/ComputingResourceHelpers.h"
-#include "../src/DeviceSpecHelpers.h"
+#include "Framework/DeviceSpecHelpers.h"
 #include "../src/GraphvizHelpers.h"
 #include "../src/SimpleResourceManager.h"
 #include "Framework/DeviceSpec.h"

--- a/Framework/Core/test/test_TimeParallelPipelining.cxx
+++ b/Framework/Core/test/test_TimeParallelPipelining.cxx
@@ -12,7 +12,7 @@
 #define BOOST_TEST_DYN_LINK
 
 #include <boost/test/unit_test.hpp>
-#include "../src/DeviceSpecHelpers.h"
+#include "Framework/DeviceSpecHelpers.h"
 #include "../src/SimpleResourceManager.h"
 #include "../src/ComputingResourceHelpers.h"
 #include "Framework/DeviceControl.h"

--- a/Framework/Core/test/test_WorkflowSerialization.cxx
+++ b/Framework/Core/test/test_WorkflowSerialization.cxx
@@ -13,6 +13,7 @@
 
 #include "Framework/WorkflowSpec.h"
 #include "../src/WorkflowSerializationHelpers.h"
+#include "../src/DataProcessorInfo.h"
 #include <boost/test/unit_test.hpp>
 
 using namespace o2::framework;


### PR DESCRIPTION
Make the DeviceSpecHelpers available for e.g. the DPL utilities.