### PR TITLE
DPL: introduce standalone driver

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -180,6 +180,11 @@ foreach(t
               PUBLIC_LINK_LIBRARIES O2::Framework)
 endforeach()
 
+o2_add_executable(dpl-run
+                  SOURCES src/dplRun.cxx
+                  PUBLIC_LINK_LIBRARIES O2::Framework
+                  )
+
 o2_add_executable(verify-aod-file
                   SOURCES src/verifyAODFile.cxx
                   PUBLIC_LINK_LIBRARIES O2::Framework

--- a/Framework/Core/src/dplRun.cxx
+++ b/Framework/Core/src/dplRun.cxx
@@ -1,0 +1,19 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/WorkflowSpec.h"
+#include "Framework/ConfigContext.h"
+#include "Framework/runDataProcessing.h"
+
+using namespace o2::framework;
+
+std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
+{
+  return {};
+}


### PR DESCRIPTION
This is a standalone driver which can be used
to run DPL configurations dumped via the --dump
option.