### PR TITLE
Keep DeviceSpecHelpers.h a private tool of the DPL builder logic

### DIFF
--- a/Framework/Core/include/Framework/ExternalFairMQDeviceProxy.h
+++ b/Framework/Core/include/Framework/ExternalFairMQDeviceProxy.h
@@ -26,6 +26,15 @@ namespace framework
 using ChannelRetriever = std::function<std::string(OutputSpec const&)>;
 using InjectorFunction = std::function<void(FairMQDevice& device, FairMQParts& inputs, ChannelRetriever)>;
 
+struct InputChannelSpec;
+struct OutputChannelSpec;
+
+/// helper method to format a configuration string for an external channel
+std::string formatExternalChannelConfiguration(InputChannelSpec const&);
+
+/// helper method to format a configuration string for an external channel
+std::string formatExternalChannelConfiguration(OutputChannelSpec const&);
+
 /// send header/payload O2 message for an OutputSpec, a channel retriever callback is required to
 /// get the associated FairMQChannel
 /// FIXME: can in principle drop the OutputSpec parameter and take the DataHeader

--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -7,7 +7,7 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#include "Framework/DeviceSpecHelpers.h"
+#include "DeviceSpecHelpers.h"
 #include "ChannelSpecHelpers.h"
 #include <wordexp.h>
 #include <algorithm>
@@ -29,8 +29,7 @@
 #include "Framework/WorkflowSpec.h"
 #include "Framework/ComputingResource.h"
 #include "Framework/Logger.h"
-#include "ResourceManager.h"
-#include "DataProcessorInfo.h"
+
 #include "WorkflowHelpers.h"
 
 namespace bpo = boost::program_options;

--- a/Framework/Core/src/DeviceSpecHelpers.h
+++ b/Framework/Core/src/DeviceSpecHelpers.h
@@ -22,6 +22,9 @@
 #include "Framework/AlgorithmSpec.h"
 #include "Framework/ConfigParamSpec.h"
 #include "Framework/OutputRoute.h"
+#include "ResourceManager.h"
+#include "DataProcessorInfo.h"
+#include "WorkflowHelpers.h"
 #include <boost/program_options.hpp>
 
 #include <vector>
@@ -34,13 +37,6 @@ namespace framework
 {
 struct InputChannelSpec;
 struct OutputChannelSpec;
-struct ResourceManager;
-struct DataProcessorInfo;
-struct DeviceId;
-struct DeviceConnectionId;
-struct DeviceConnectionEdge;
-struct EdgeAction;
-struct LogicalForwardInfo;
 
 struct DeviceSpecHelpers {
   /// Helper to convert from an abstract dataflow specification, @a workflow,

--- a/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
+++ b/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
@@ -16,8 +16,9 @@
 #include "Framework/InitContext.h"
 #include "Framework/ProcessingContext.h"
 #include "Framework/RawDeviceService.h"
-
 #include "Headers/DataHeader.h"
+
+#include "./DeviceSpecHelpers.h"
 
 #include <fairmq/FairMQParts.h>
 #include <fairmq/FairMQDevice.h>
@@ -34,6 +35,18 @@ namespace framework
 {
 
 using DataHeader = o2::header::DataHeader;
+
+std::string formatExternalChannelConfiguration(InputChannelSpec const& spec)
+{
+  return DeviceSpecHelpers::inputChannel2String(spec);
+}
+
+std::string formatExternalChannelConfiguration(OutputChannelSpec const& spec)
+{
+  return DeviceSpecHelpers::outputChannel2String(spec);
+}
+
+std::string formatExternalChannelConfiguration(OutputChannelSpec const&);
 
 void sendOnChannel(FairMQDevice& device, FairMQParts& messages, std::string const& channel)
 {

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -39,18 +39,17 @@
 #include "Framework/TextControlService.h"
 #include "Framework/CallbackService.h"
 #include "Framework/WorkflowSpec.h"
-#include "Framework/DeviceSpecHelpers.h"
 
 #include "ComputingResourceHelpers.h"
 #include "DataProcessingStatus.h"
 #include "DDSConfigHelpers.h"
 #include "O2ControlHelpers.h"
+#include "DeviceSpecHelpers.h"
 #include "DriverControl.h"
 #include "DriverInfo.h"
 #include "DataProcessorInfo.h"
 #include "GraphvizHelpers.h"
 #include "SimpleResourceManager.h"
-#include "WorkflowHelpers.h"
 #include "WorkflowSerializationHelpers.h"
 
 #include <Monitoring/MonitoringFactory.h>

--- a/Framework/Core/test/test_DeviceSpec.cxx
+++ b/Framework/Core/test/test_DeviceSpec.cxx
@@ -13,7 +13,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include "../src/ChannelSpecHelpers.h"
-#include "Framework/DeviceSpecHelpers.h"
+#include "../src/DeviceSpecHelpers.h"
 #include "../src/GraphvizHelpers.h"
 #include "../src/WorkflowHelpers.h"
 #include "Framework/DeviceSpec.h"

--- a/Framework/Core/test/test_DeviceSpecHelpers.cxx
+++ b/Framework/Core/test/test_DeviceSpecHelpers.cxx
@@ -14,7 +14,7 @@
 #include "Framework/WorkflowSpec.h"
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/DeviceExecution.h"
-#include "Framework/DeviceSpecHelpers.h"
+#include "../src/DeviceSpecHelpers.h"
 #include <boost/test/unit_test.hpp>
 #include <boost/test/tools/detail/per_element_manip.hpp>
 #include <algorithm>
@@ -24,7 +24,6 @@
 #include <map>
 #include "../src/SimpleResourceManager.h"
 #include "../src/ComputingResourceHelpers.h"
-#include "../src/DataProcessorInfo.h"
 
 namespace o2
 {

--- a/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
+++ b/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
@@ -13,10 +13,9 @@
 
 #include <boost/test/unit_test.hpp>
 #include "../src/DDSConfigHelpers.h"
-#include "Framework/DeviceSpecHelpers.h"
+#include "../src/DeviceSpecHelpers.h"
 #include "../src/SimpleResourceManager.h"
 #include "../src/ComputingResourceHelpers.h"
-#include "../src/DataProcessorInfo.h"
 #include "Framework/DataAllocator.h"
 #include "Framework/DeviceControl.h"
 #include "Framework/DeviceSpec.h"

--- a/Framework/Core/test/test_Graphviz.cxx
+++ b/Framework/Core/test/test_Graphviz.cxx
@@ -12,7 +12,7 @@
 #define BOOST_TEST_DYN_LINK
 
 #include "../src/ComputingResourceHelpers.h"
-#include "Framework/DeviceSpecHelpers.h"
+#include "../src/DeviceSpecHelpers.h"
 #include "../src/GraphvizHelpers.h"
 #include "../src/SimpleResourceManager.h"
 #include "Framework/DeviceSpec.h"

--- a/Framework/Core/test/test_TimeParallelPipelining.cxx
+++ b/Framework/Core/test/test_TimeParallelPipelining.cxx
@@ -12,7 +12,7 @@
 #define BOOST_TEST_DYN_LINK
 
 #include <boost/test/unit_test.hpp>
-#include "Framework/DeviceSpecHelpers.h"
+#include "../src/DeviceSpecHelpers.h"
 #include "../src/SimpleResourceManager.h"
 #include "../src/ComputingResourceHelpers.h"
 #include "Framework/DeviceControl.h"

--- a/Framework/Core/test/test_WorkflowSerialization.cxx
+++ b/Framework/Core/test/test_WorkflowSerialization.cxx
@@ -13,7 +13,6 @@
 
 #include "Framework/WorkflowSpec.h"
 #include "../src/WorkflowSerializationHelpers.h"
-#include "../src/DataProcessorInfo.h"
 #include <boost/test/unit_test.hpp>
 
 using namespace o2::framework;


### PR DESCRIPTION
This reverts "Moving DeviceSpecHelpers.h to Framework/Core/include/Framework"
commit 0547343

We decided that the details of the builder logic should not be exposed.

Adding a helper method to ExternalFairMQDeviceProxy to provide the required functionality to
configure external channels.