### PR TITLE
Do not wait for EndOfStream on fake input channels

### DIFF
--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -255,8 +255,8 @@ bool DataProcessingDevice::ConditionalRun()
   bool active = false;
 
   // Notice that fake input channels (InputChannelState::Pull) cannot possibly
-  // expect to receive an EndOfStream signal. Thus we do not wait until these
-  // are completed. In the case of data source devices, as they do not have real
+  // expect to receive an EndOfStream signal. Thus we do not wait for these
+  // to be completed. In the case of data source devices, as they do not have real
   // data input channels, they have to signal EndOfStream themselves.
   bool allDone = std::any_of(mState.inputChannelInfos.begin(), mState.inputChannelInfos.end(), [](const auto& info) {
     return info.state != InputChannelState::Pull;
@@ -265,7 +265,7 @@ bool DataProcessingDevice::ConditionalRun()
   for (size_t ci = 0; ci < mSpec.inputChannels.size(); ++ci) {
     auto& channel = mSpec.inputChannels[ci];
     auto& info = mState.inputChannelInfos[ci];
-
+    
     if (info.state != InputChannelState::Completed && info.state != InputChannelState::Pull) {
       allDone = false;
     }

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -253,6 +253,7 @@ bool DataProcessingDevice::ConditionalRun()
   mServiceRegistry.get<CallbackService>()(CallbackService::Id::ClockTick);
   // Whether or not we had something to do.
   bool active = false;
+
   // Notice that fake input channels (InputChannelState::Pull) cannot possibly
   // expect to receive an EndOfStream signal. Thus we do not wait for these
   // to be completed. In the case of data source devices, as they do not have

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -256,8 +256,8 @@ bool DataProcessingDevice::ConditionalRun()
 
   // Notice that fake input channels (InputChannelState::Pull) cannot possibly
   // expect to receive an EndOfStream signal. Thus we do not wait for these
-  // to be completed. In the case of data source devices, as they do not have real
-  // data input channels, they have to signal EndOfStream themselves.
+  // to be completed. In the case of data source devices, as they do not have
+  // real data input channels, they have to signal EndOfStream themselves.
   bool allDone = std::any_of(mState.inputChannelInfos.begin(), mState.inputChannelInfos.end(), [](const auto& info) {
     return info.state != InputChannelState::Pull;
   });

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -253,7 +253,6 @@ bool DataProcessingDevice::ConditionalRun()
   mServiceRegistry.get<CallbackService>()(CallbackService::Id::ClockTick);
   // Whether or not we had something to do.
   bool active = false;
-
   // Notice that fake input channels (InputChannelState::Pull) cannot possibly
   // expect to receive an EndOfStream signal. Thus we do not wait for these
   // to be completed. In the case of data source devices, as they do not have

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -265,7 +265,7 @@ bool DataProcessingDevice::ConditionalRun()
   for (size_t ci = 0; ci < mSpec.inputChannels.size(); ++ci) {
     auto& channel = mSpec.inputChannels[ci];
     auto& info = mState.inputChannelInfos[ci];
-    
+
     if (info.state != InputChannelState::Completed && info.state != InputChannelState::Pull) {
       allDone = false;
     }

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -251,18 +251,22 @@ bool DataProcessingDevice::ConditionalRun()
   mBeginIterationTimestamp = (uint64_t)std::chrono::duration<double, std::milli>(now.time_since_epoch()).count();
 
   mServiceRegistry.get<CallbackService>()(CallbackService::Id::ClockTick);
-  // Wether or not we had something to do.
+  // Whether or not we had something to do.
   bool active = false;
-  // Notice that in case there are no input channels we should the allDone
-  // state will have to be set explicitly in the code, like we do, for example
-  // for implicit data sources or timers.  This also implies that whatever is
-  // time driven will have to signal EndOfStream itself.
-  bool allDone = mSpec.inputChannels.empty() == false;
+
+  // Notice that fake input channels (InputChannelState::Pull) cannot possibly
+  // expect to receive an EndOfStream signal. Thus we do not wait until these
+  // are completed. In the case of data source devices, as they do not have real
+  // data input channels, they have to signal EndOfStream themselves.
+  bool allDone = std::any_of(mState.inputChannelInfos.begin(), mState.inputChannelInfos.end(), [](const auto& info) {
+    return info.state != InputChannelState::Pull;
+  });
   // Whether or not all the channels are completed
   for (size_t ci = 0; ci < mSpec.inputChannels.size(); ++ci) {
     auto& channel = mSpec.inputChannels[ci];
     auto& info = mState.inputChannelInfos[ci];
-    if (info.state != InputChannelState::Completed) {
+
+    if (info.state != InputChannelState::Completed && info.state != InputChannelState::Pull) {
       allDone = false;
     }
     if (info.state != InputChannelState::Running) {


### PR DESCRIPTION
Devices which have data-driven inputs and a timer or ccdb input couldn't properly receive an EndOfStream signal. They also have no way of knowing that an EndOfStream arrived on certain input channels, so they could trigger it on their own.
This changes the default behaviour of EndOfStream, so input channels marked as `Pull` (not related to the push-pull channel types) don't have to be completed, unless a certain device is a only data source. I am open to discuss other solutions for that, I will also have to see if that breaks anything else.