### PR TITLE
[EMCAL-507, EMCAL-548, EMCAL-611, EMCAL-612] Prepare publishers for time frames

### DIFF
--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/CellConverterSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/CellConverterSpec.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "DataFormatsEMCAL/Cell.h"
+#include "DataFormatsEMCAL/TriggerRecord.h"
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
 
@@ -59,14 +60,17 @@ class CellConverterSpec : public framework::Task
   ///
   /// The following branches are linked:
   /// Input digits: {"EMC", "DIGITS", 0, Lifetime::Timeframe}
+  /// Input trigers: {"EMC", "DIGITSTRGR", 0, Lifetime::Timeframe}
   /// Input MC-truth: {"EMC", "DIGITSMCTR", 0, Lifetime::Timeframe}
   /// Output cells: {"EMC", "CELLS", 0, Lifetime::Timeframe}
+  /// Output trigers: {"EMC", "CELLSTRGR", 0, Lifetime::Timeframe}
   /// Output MC-truth: {"EMC", "CELLSMCTR", 0, Lifetime::Timeframe}
   void run(framework::ProcessingContext& ctx) final;
 
  private:
-  bool mPropagateMC = false;                 ///< Switch whether to process MC true labels
-  std::vector<o2::emcal::Cell> mOutputCells; ///< Container with output cells
+  bool mPropagateMC = false;                             ///< Switch whether to process MC true labels
+  std::vector<o2::emcal::Cell> mOutputCells;             ///< Container with output cells
+  std::vector<o2::emcal::TriggerRecord> mOutputTriggers; ///< Container with output trigger records
 };
 
 /// \brief Creating DataProcessorSpec for the EMCAL Cell Converter Spec

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/DigitsPrinterSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/DigitsPrinterSpec.h
@@ -8,6 +8,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#include <string>
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
 
@@ -29,6 +30,7 @@ namespace reco_workflow
 /// Example payload for workflows using o2::emcal::Digit as payload.
 /// Printing several digit-related information for each digit. Refer
 /// to run for the list of input spec to be specified.
+template <class InputType>
 class DigitsPrinterSpec : public framework::Task
 {
  public:
@@ -56,7 +58,10 @@ class DigitsPrinterSpec : public framework::Task
 ///
 /// Refer to DigitsPrinterSpec::run for a list of input
 /// specs
-o2::framework::DataProcessorSpec getEmcalDigitsPrinterSpec();
+o2::framework::DataProcessorSpec getEmcalDigitsPrinterSpec(std::string inputtype);
+
+//using DigitsPrinterSpecDigit = o2::emcal::reco_workflow::DigitsPrinterSpec<o2::emcal::Digit>;
+//using DigitsPrinterSpecCell = o2::emcal::reco_workflow::DigitsPrinterSpec<o2::emcal::Cell>;
 } // namespace reco_workflow
 } // namespace emcal
 

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/PublisherSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/PublisherSpec.h
@@ -8,8 +8,12 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#include "DPLUtils/RootTreeReader.h"
 #include "Framework/DataProcessorSpec.h"
+#include "Framework/DataSpecUtils.h"
+#include "Framework/Output.h"
 #include "Framework/OutputSpec.h"
+#include "DataFormatsEMCAL/TriggerRecord.h"
 #include <string>
 #include <vector>
 
@@ -31,12 +35,55 @@ struct PublisherConf {
   std::string processName;
   std::string defaultTreeName;
   BranchOptionConfig databranch;
+  BranchOptionConfig triggerrecordbranch;
   BranchOptionConfig mcbranch;
   OutputSpec dataoutput;
+  OutputSpec triggerrecordoutput;
   OutputSpec mcoutput;
 };
 
-framework::DataProcessorSpec getPublisherSpec(PublisherConf const& config, bool propagateMC = true);
+template <typename T = void>
+framework::DataProcessorSpec getPublisherSpec(PublisherConf const& config, bool propagateMC = true)
+{
+  using Reader = o2::framework::RootTreeReader;
+  using Output = o2::framework::Output;
+  using TriggerInputType = std::vector<o2::emcal::TriggerRecord>;
+  auto dto = o2::framework::DataSpecUtils::asConcreteDataTypeMatcher(config.dataoutput);
+  auto tro = o2::framework::DataSpecUtils::asConcreteDataTypeMatcher(config.triggerrecordoutput);
+  auto mco = o2::framework::DataSpecUtils::asConcreteDataTypeMatcher(config.mcoutput);
+
+  // a creator callback for the actual reader instance
+  auto creator = [dto, tro, mco, propagateMC](const char* treename, const char* filename, int nofEvents, Reader::PublishingMode publishingMode, const char* branchname, const char* triggerbranchname, const char* mcbranchname) {
+    constexpr auto persistency = o2::framework::Lifetime::Timeframe;
+    if (propagateMC) {
+      return std::make_shared<Reader>(treename,
+                                      filename,
+                                      nofEvents,
+                                      publishingMode,
+                                      Output{mco.origin, mco.description, 0, persistency},
+                                      mcbranchname,
+                                      Reader::BranchDefinition<T>{Output{dto.origin, dto.description, 0, persistency}, branchname},
+                                      Reader::BranchDefinition<TriggerInputType>{Output{tro.origin, tro.description, 0, persistency}, triggerbranchname});
+    } else {
+      return std::make_shared<Reader>(treename,
+                                      filename,
+                                      nofEvents,
+                                      publishingMode,
+                                      Reader::BranchDefinition<T>{Output{dto.origin, dto.description, 0, persistency}, branchname},
+                                      Reader::BranchDefinition<TriggerInputType>{Output{tro.origin, tro.description, 0, persistency}, triggerbranchname});
+    }
+  };
+
+  return createPublisherSpec(config, propagateMC, creator);
+}
+
+namespace workflow_reader
+{
+using Reader = o2::framework::RootTreeReader;
+using Creator = std::function<std::shared_ptr<Reader>(const char*, const char*, int, Reader::PublishingMode, const char*, const char*, const char*)>;
+} // namespace workflow_reader
+
+framework::DataProcessorSpec createPublisherSpec(PublisherConf const& config, bool propagateMC, workflow_reader::Creator creator);
 
 } // namespace emcal
 } // end namespace o2

--- a/Detectors/EMCAL/workflow/src/DigitsPrinterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/DigitsPrinterSpec.cxx
@@ -8,28 +8,43 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#include <vector>
 #include <iostream>
+#include <vector>
+#include <type_traits>
+#include <gsl/span>
 
 #include "FairLogger.h"
 
 #include "Framework/ControlService.h"
 #include "Framework/DataRefUtils.h"
 #include "DataFormatsEMCAL/EMCALBlockHeader.h"
+#include "DataFormatsEMCAL/Cell.h"
 #include "DataFormatsEMCAL/Digit.h"
+#include "DataFormatsEMCAL/TriggerRecord.h"
 #include "EMCALWorkflow/DigitsPrinterSpec.h"
 
 using namespace o2::emcal::reco_workflow;
 
-void DigitsPrinterSpec::init(framework::InitContext& ctx)
+template <class InputType>
+void DigitsPrinterSpec<InputType>::init(o2::framework::InitContext& ctx)
 {
 }
 
-void DigitsPrinterSpec::run(framework::ProcessingContext& pc)
+template <class InputType>
+void DigitsPrinterSpec<InputType>::run(framework::ProcessingContext& pc)
 {
   // Get the EMCAL block header and check whether it contains digits
   LOG(DEBUG) << "[EMCALDigitsPrinter - process] called";
-  auto dataref = pc.inputs().get("digits");
+  std::string objectbranch;
+  if constexpr (std::is_same<InputType, o2::emcal::Digit>::value)
+    objectbranch = "digits";
+  else if constexpr (std::is_same<InputType, o2::emcal::Cell>::value)
+    objectbranch = "cells";
+  else {
+    LOG(ERROR) << "Unsupported input type ... ";
+    return;
+  }
+  auto dataref = pc.inputs().get(objectbranch);
   auto const* emcheader = o2::framework::DataRefUtils::getHeader<o2::emcal::EMCALBlockHeader*>(dataref);
   if (!emcheader->mHasPayload) {
     LOG(DEBUG) << "[EMCALDigitsPrinter - process] No more digits" << std::endl;
@@ -37,22 +52,43 @@ void DigitsPrinterSpec::run(framework::ProcessingContext& pc)
     return;
   }
 
-  auto digits = pc.inputs().get<std::vector<o2::emcal::Digit>>("digits");
-  std::cout << "[EMCALDigitsPrinter - process] receiveed " << digits.size() << " digits ..." << std::endl;
-  if (digits.size()) {
-    for (const auto& d : digits) {
-      std::cout << "[EMCALDigitsPrinter - process] Channel: " << d.getTower() << std::endl;
-      std::cout << "[EMCALDigitsPrinter - process] Energy: " << d.getEnergy() << std::endl;
-      //std::cout << d << std::endl;
+  auto objects = pc.inputs().get<gsl::span<InputType>>(objectbranch);
+  auto triggerrecords = pc.inputs().get<gsl::span<o2::emcal::TriggerRecord>>("triggerrecord");
+  std::cout << "[EMCALDigitsPrinter - process] receiveed " << objects.size() << " digits from " << triggerrecords.size() << " triggers ..." << std::endl;
+  if (triggerrecords.size()) {
+    for (const auto& trg : triggerrecords) {
+      if (!trg.getNumberOfObjects()) {
+        std::cout << "[EMCALDigitsPrinter - process] Trigger does not contain " << objectbranch << ", skipping ..." << std::endl;
+        continue;
+      }
+      std::cout << "[EMCALDigitsPrinter - process] Trigger has " << trg.getNumberOfObjects() << " " << objectbranch << " ..." << std::endl;
+      gsl::span<const InputType> objectsTrigger(objects.data() + trg.getFirstEntry(), trg.getNumberOfObjects());
+      for (const auto& d : objectsTrigger) {
+        std::cout << "[EMCALDigitsPrinter - process] Channel: " << d.getTower() << std::endl;
+        std::cout << "[EMCALDigitsPrinter - process] Energy: " << d.getEnergy() << std::endl;
+        //std::cout << d << std::endl;
+      }
     }
   }
 }
 
-o2::framework::DataProcessorSpec o2::emcal::reco_workflow::getEmcalDigitsPrinterSpec()
+o2::framework::DataProcessorSpec o2::emcal::reco_workflow::getEmcalDigitsPrinterSpec(std::string inputtype)
 {
-
-  return o2::framework::DataProcessorSpec{"EMCALDigitsPrinter",
-                                          {{"digits", o2::header::gDataOriginEMC, "DIGITS", 0, o2::framework::Lifetime::Timeframe}},
-                                          {},
-                                          o2::framework::adaptFromTask<o2::emcal::reco_workflow::DigitsPrinterSpec>()};
+  if (inputtype == "digits") {
+    return o2::framework::DataProcessorSpec{"EMCALDigitsPrinter",
+                                            {{"digits", o2::header::gDataOriginEMC, "DIGITS", 0, o2::framework::Lifetime::Timeframe},
+                                             {"triggerrecord", o2::header::gDataOriginEMC, "DIGITSTRGR", 0, o2::framework::Lifetime::Timeframe}},
+                                            {},
+                                            o2::framework::adaptFromTask<o2::emcal::reco_workflow::DigitsPrinterSpec<o2::emcal::Digit>>()};
+  } else if (inputtype == "cells") {
+    return o2::framework::DataProcessorSpec{"EMCALDigitsPrinter",
+                                            {{"cells", o2::header::gDataOriginEMC, "CELLS", 0, o2::framework::Lifetime::Timeframe},
+                                             {"triggerrecord", o2::header::gDataOriginEMC, "CELLSTRGR", 0, o2::framework::Lifetime::Timeframe}},
+                                            {},
+                                            o2::framework::adaptFromTask<o2::emcal::reco_workflow::DigitsPrinterSpec<o2::emcal::Cell>>()};
+  }
+  throw std::runtime_error("Input type not supported");
 }
+
+//template class o2::emcal::reco_workflow::DigitsPrinterSpec<o2::emcal::Digit>;
+//template class o2::emcal::reco_workflow::DigitsPrinterSpec<o2::emcal::Cell>;

--- a/Detectors/EMCAL/workflow/src/PublisherSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/PublisherSpec.cxx
@@ -13,8 +13,6 @@
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/ControlService.h"
 #include "Headers/DataHeader.h"
-#include "DPLUtils/RootTreeReader.h"
-#include "Framework/DataSpecUtils.h"
 #include <memory>
 #include <utility>
 
@@ -24,7 +22,7 @@ namespace o2
 namespace emcal
 {
 
-o2::framework::DataProcessorSpec getPublisherSpec(PublisherConf const& config, bool propagateMC)
+o2::framework::DataProcessorSpec createPublisherSpec(PublisherConf const& config, bool propagateMC, workflow_reader::Creator creator)
 {
   struct ProcessAttributes {
     std::shared_ptr<o2::framework::RootTreeReader> reader;
@@ -33,43 +31,31 @@ o2::framework::DataProcessorSpec getPublisherSpec(PublisherConf const& config, b
     bool finished;
   };
 
-  auto initFunction = [config, propagateMC](o2::framework::InitContext& ic) {
+  auto initFunction = [config, propagateMC, creator](o2::framework::InitContext& ic) {
     // get the option from the init context
     auto filename = ic.options().get<std::string>("infile");
     auto treename = ic.options().get<std::string>("treename");
-    auto dtbrName = ic.options().get<std::string>(config.databranch.option.c_str()); // databranch name
-    auto mcbrName = ic.options().get<std::string>(config.mcbranch.option.c_str());   // mcbranch name
+    auto dtbrName = ic.options().get<std::string>(config.databranch.option.c_str());           // databranch name
+    auto trgbrName = ic.options().get<std::string>(config.triggerrecordbranch.option.c_str()); // triggerbranch name
+    auto mcbrName = ic.options().get<std::string>(config.mcbranch.option.c_str());             // mcbranch name
     auto nofEvents = ic.options().get<int>("nevents");
     auto publishingMode = nofEvents == -1 ? o2::framework::RootTreeReader::PublishingMode::Single : o2::framework::RootTreeReader::PublishingMode::Loop;
 
     auto processAttributes = std::make_shared<ProcessAttributes>();
     {
+      using Reader = o2::framework::RootTreeReader;
+      using TriggerInputType = std::vector<o2::emcal::TriggerRecord>;
       processAttributes->terminateOnEod = ic.options().get<bool>("terminate-on-eod");
       processAttributes->finished = false;
       processAttributes->datatype = config.databranch.defval;
-      auto dto = o2::framework::DataSpecUtils::asConcreteDataTypeMatcher(config.dataoutput);
-      auto mco = o2::framework::DataSpecUtils::asConcreteDataTypeMatcher(config.mcoutput);
-      constexpr auto persistency = o2::framework::Lifetime::Timeframe;
       o2::header::DataHeader::SubSpecificationType subSpec = 0;
-      if (propagateMC) {
-        processAttributes->reader = std::make_shared<o2::framework::RootTreeReader>(treename.c_str(), // tree name
-                                                                                    filename.c_str(), // input file name
-                                                                                    nofEvents,        // number of entries to publish
-                                                                                    publishingMode,
-                                                                                    o2::framework::Output{dto.origin, dto.description, subSpec, persistency},
-                                                                                    dtbrName.c_str(), // name of cluster branch
-                                                                                    o2::framework::Output{mco.origin, mco.description, subSpec, persistency},
-                                                                                    mcbrName.c_str() // name of mc label branch
-        );
-      } else {
-        processAttributes->reader = std::make_shared<o2::framework::RootTreeReader>(treename.c_str(), // tree name
-                                                                                    filename.c_str(), // input file name
-                                                                                    nofEvents,        // number of entries to publish
-                                                                                    publishingMode,
-                                                                                    o2::framework::Output{dto.origin, dto.description, subSpec, persistency},
-                                                                                    dtbrName.c_str() // name of cluster branch
-        );
-      }
+      processAttributes->reader = creator(treename.c_str(), // tree name
+                                          filename.c_str(), // input file name
+                                          nofEvents,        // number of entries to publish
+                                          publishingMode,
+                                          dtbrName.c_str(),  // databranch name
+                                          trgbrName.c_str(), // triggerbranch name
+                                          mcbrName.c_str()); // mcbranch name
     }
 
     auto processFunction = [processAttributes, propagateMC](o2::framework::ProcessingContext& pc) {
@@ -94,6 +80,7 @@ o2::framework::DataProcessorSpec getPublisherSpec(PublisherConf const& config, b
         // Send dummy header with no payload option
         o2::emcal::EMCALBlockHeader dummyheader(false);
         pc.outputs().snapshot(o2::framework::OutputRef{"output", 0, {dummyheader}}, 0);
+        pc.outputs().snapshot(o2::framework::OutputRef{"outputTRG", 0, {dummyheader}}, 0);
         if (propagateMC) {
           pc.outputs().snapshot(o2::framework::OutputRef{"outputMC", 0, {dummyheader}}, 0);
         }
@@ -109,14 +96,17 @@ o2::framework::DataProcessorSpec getPublisherSpec(PublisherConf const& config, b
   auto createOutputSpecs = [&config, propagateMC]() {
     std::vector<o2::framework::OutputSpec> outputSpecs;
     auto dto = o2::framework::DataSpecUtils::asConcreteDataTypeMatcher(config.dataoutput);
+    auto tro = o2::framework::DataSpecUtils::asConcreteDataTypeMatcher(config.triggerrecordoutput);
     auto mco = o2::framework::DataSpecUtils::asConcreteDataTypeMatcher(config.mcoutput);
     outputSpecs.emplace_back(o2::framework::OutputSpec{{"output"}, dto.origin, dto.description, 0, o2::framework::Lifetime::Timeframe});
+    outputSpecs.emplace_back(o2::framework::OutputSpec{{"outputTRG"}, tro.origin, tro.description, 0, o2::framework::Lifetime::Timeframe});
     outputSpecs.emplace_back(o2::framework::OutputSpec{{"outputMC"}, mco.origin, mco.description, 0, o2::framework::Lifetime::Timeframe});
     return std::move(outputSpecs);
   };
 
   auto& dtb = config.databranch;
   auto& mcb = config.mcbranch;
+  auto& trb = config.triggerrecordbranch;
   return o2::framework::DataProcessorSpec{
     config.processName.c_str(),
     o2::framework::Inputs{}, // no inputs
@@ -126,6 +116,7 @@ o2::framework::DataProcessorSpec getPublisherSpec(PublisherConf const& config, b
       {"infile", o2::framework::VariantType::String, "", {"Name of the input file"}},
       {"treename", o2::framework::VariantType::String, config.defaultTreeName.c_str(), {"Name of input tree"}},
       {dtb.option.c_str(), o2::framework::VariantType::String, dtb.defval.c_str(), {dtb.help.c_str()}},
+      {trb.option.c_str(), o2::framework::VariantType::String, trb.defval.c_str(), {trb.help.c_str()}},
       {mcb.option.c_str(), o2::framework::VariantType::String, mcb.defval.c_str(), {mcb.help.c_str()}},
       {"nevents", o2::framework::VariantType::Int, -1, {"number of events to run"}},
       {"terminate-on-eod", o2::framework::VariantType::Bool, true, {"terminate on end-of-data"}},


### PR DESCRIPTION
Cell and digit vectors are supposed to handle the objects
from an entire time frame. For EMCAL the time frame will
contain several triggers. In order to separate data from
different triggers a second object, vector of TriggerRecords,
is provided in addition to the vector of objects marking
ranges belonging to the same trigger. The publisher has to
read the trigger records branch from the digit/cell tree
and provide it to the various workflows.