### PR TITLE
Add jet finding

### DIFF
--- a/Analysis/DataModel/include/Analysis/Jet.h
+++ b/Analysis/DataModel/include/Analysis/Jet.h
@@ -1,0 +1,50 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+// table definitions for jets
+//
+// Author: Jochen Klein
+
+#pragma once
+
+#include "Framework/AnalysisDataModel.h"
+
+namespace o2::aod
+{
+namespace jet
+{
+DECLARE_SOA_INDEX_COLUMN(Collision, collision);
+DECLARE_SOA_COLUMN(Eta, eta, float, "fEta");
+DECLARE_SOA_COLUMN(Phi, phi, float, "fPhi");
+DECLARE_SOA_COLUMN(Pt, pt, float, "fPt");
+DECLARE_SOA_COLUMN(Area, area, float, "fArea");
+DECLARE_SOA_COLUMN(Energy, energy, float, "fEnergy");
+DECLARE_SOA_COLUMN(Mass, mass, float, "fMass");
+} // namespace jet
+
+DECLARE_SOA_TABLE(Jets, "AOD", "JET",
+                  o2::soa::Index<>, jet::CollisionId,
+                  jet::Eta, jet::Phi, jet::Pt, jet::Area, jet::Energy, jet::Mass);
+
+using Jet = Jets::iterator;
+
+// TODO: absorb in jet table
+// when list of references available
+namespace constituents
+{
+DECLARE_SOA_INDEX_COLUMN(Jet, jet);
+DECLARE_SOA_INDEX_COLUMN(Track, track);
+} // namespace constituents
+
+DECLARE_SOA_TABLE(JetConstituents, "AOD", "JETCONSTITUENTS",
+                  constituents::JetId, constituents::TrackId);
+
+using JetConstituent = JetConstituents::iterator;
+} // namespace o2::aod

--- a/Analysis/Tasks/CMakeLists.txt
+++ b/Analysis/Tasks/CMakeLists.txt
@@ -9,21 +9,29 @@
 # submit itself to any jurisdiction.
 
 o2_add_executable(correlations
-                  SOURCES correlations.cxx 
+                  SOURCES correlations.cxx
                   PUBLIC_LINK_LIBRARIES O2::Framework O2::AnalysisCore
                   COMPONENT_NAME Analysis)
 
 o2_add_executable(correlations-collection
-                  SOURCES correlationsCollection.cxx 
+                  SOURCES correlationsCollection.cxx
                   PUBLIC_LINK_LIBRARIES O2::Framework O2::AnalysisCore
                   COMPONENT_NAME Analysis)
-                  
+
 o2_add_executable(vertexing-hf
 	  	  SOURCES vertexerhf.cxx
-		  PUBLIC_LINK_LIBRARIES O2::Framework O2::AnalysisDataModel O2::DetectorsBase 
+		  PUBLIC_LINK_LIBRARIES O2::Framework O2::AnalysisDataModel O2::DetectorsBase
 	          COMPONENT_NAME Analysis)
 
 o2_add_executable(validation
 	  	  SOURCES validation.cxx
-		  PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase 
+		  PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase
 	          COMPONENT_NAME Analysis)
+
+if(FastJet_FOUND)
+o2_add_executable(jetfinder
+  SOURCES jetfinder.cxx
+  PUBLIC_LINK_LIBRARIES O2::Framework O2::AnalysisCore O2::AnalysisDataModel
+                        FastJet::FastJet
+  COMPONENT_NAME Analysis)
+endif()

--- a/Analysis/Tasks/jetfinder.cxx
+++ b/Analysis/Tasks/jetfinder.cxx
@@ -1,0 +1,78 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+// jet finder task
+//
+// Author: Jochen Klein
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/ASoA.h"
+
+#include "fastjet/PseudoJet.hh"
+#include "fastjet/ClusterSequenceArea.hh"
+#include "fastjet/AreaDefinition.hh"
+#include "fastjet/JetDefinition.hh"
+
+#include "Analysis/Jet.h"
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+
+struct JetFinderTask {
+  Produces<o2::aod::Jets> jets;
+  Produces<o2::aod::JetConstituents> constituents;
+
+  Filter trackCuts = aod::track::signed1Pt < 10.f;
+
+  // TODO: use configurables (when available)
+  double rParam = 0.4;
+  fastjet::Strategy strategy = fastjet::Best;
+  fastjet::RecombinationScheme recombScheme = fastjet::E_scheme;
+  fastjet::JetAlgorithm algorithm = fastjet::antikt_algorithm;
+  float ghostEtamax = 1.0;
+  fastjet::AreaType areaType = fastjet::passive_area;
+
+  void process(aod::Collision const& collision,
+               soa::Filtered<aod::Tracks> const& fullTracks)
+  {
+    std::vector<fastjet::PseudoJet> inputParticles;
+    for (auto& track : fullTracks) {
+      auto dummyE = std::sqrt(track.x() * track.x() + track.y() * track.y() +
+                              track.z() * track.z() + 0.14 * 0.14);
+      inputParticles.emplace_back(track.x(), track.y(), track.z(), dummyE);
+      inputParticles.back().set_user_index(track.globalIndex());
+    }
+
+    fastjet::GhostedAreaSpec ghostSpec(ghostEtamax);
+    fastjet::AreaDefinition areaDef(areaType, ghostSpec);
+    fastjet::JetDefinition jetDef(algorithm, rParam, recombScheme, strategy);
+    fastjet::ClusterSequenceArea clust_seq(inputParticles, jetDef, areaDef);
+
+    std::vector<fastjet::PseudoJet> inclusiveJets = clust_seq.inclusive_jets();
+    for (const auto& pjet : inclusiveJets) {
+      jets(collision, pjet.eta(), pjet.phi(), pjet.pt(),
+           pjet.area(), pjet.Et(), pjet.m());
+      for (const auto& track : pjet.constituents()) {
+        LOGF(INFO, "jet %d constituent %d: %f %f %f", jets.lastIndex(),
+             track.user_index(), track.eta(), track.phi(), track.pt());
+        constituents(jets.lastIndex(), track.user_index());
+      }
+    }
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const&)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<JetFinderTask>("jet-finder")};
+}

--- a/Analysis/Tutorials/CMakeLists.txt
+++ b/Analysis/Tutorials/CMakeLists.txt
@@ -64,7 +64,7 @@ o2_add_executable(aodwriter
                   SOURCES src/aodwriter.cxx
                   PUBLIC_LINK_LIBRARIES O2::Framework
                   COMPONENT_NAME AnalysisTutorial)
-                  
+
 o2_add_executable(aodreader
                   SOURCES src/aodreader.cxx
                   PUBLIC_LINK_LIBRARIES O2::Framework
@@ -73,4 +73,9 @@ o2_add_executable(aodreader
 o2_add_executable(outputs
                   SOURCES src/outputs.cxx
                   PUBLIC_LINK_LIBRARIES O2::Framework
+                  COMPONENT_NAME AnalysisTutorial)
+
+o2_add_executable(jet-analysis
+                  SOURCES src/jetAnalysis.cxx
+                  PUBLIC_LINK_LIBRARIES O2::Framework O2::AnalysisDataModel
                   COMPONENT_NAME AnalysisTutorial)

--- a/Analysis/Tutorials/src/jetAnalysis.cxx
+++ b/Analysis/Tutorials/src/jetAnalysis.cxx
@@ -1,0 +1,53 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+// jet analysis tasks (subscribing to jet finder task)
+//
+// Author: Jochen Klein
+//
+// o2-analysis-jetfinder --aod-file <aod> -b | o2-analysistutorial-jet-analysis -b
+
+#include "TH1F.h"
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/ASoA.h"
+
+#include "Analysis/Jet.h"
+
+using namespace o2;
+using namespace o2::framework;
+
+struct JetAnalysis {
+  OutputObj<TH1F> hJetPt{"pt"};
+
+  void init(InitContext const&)
+  {
+    hJetPt.setObject(new TH1F("pt", "jet p_{T};p_{T} (GeV/#it{c})",
+                              100, 0., 100.));
+  }
+
+  // TODO: add aod::Tracks (when available)
+  void process(aod::Jet const& jet,
+               aod::JetConstituents const& constituents)
+  {
+    hJetPt->Fill(jet.pt());
+    for (const auto c : constituents) {
+      LOGF(INFO, "jet %d: track id %d", jet.index(), c.trackId());
+    }
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const&)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<JetAnalysis>("jet-analysis")};
+}

--- a/dependencies/FindFastJet.cmake
+++ b/dependencies/FindFastJet.cmake
@@ -1,0 +1,113 @@
+# Copyright CERN and copyright holders of ALICE O2. This software is distributed
+# under the terms of the GNU General Public License v3 (GPL Version 3), copied
+# verbatim in the file "COPYING".
+#
+# See http://alice-o2.web.cern.ch/license for full licensing information.
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization or
+# submit itself to any jurisdiction.
+
+# Author: Jochen Klein
+#
+# add FastJet::FastJet as library to targets depending on FastJet,
+# place code depending on FastJet in blocks:
+# if(FastJet_FOUND) ... endif() (in cmake)
+# #ifdef HAVE_FASTJET ... #endif (in C++)
+
+set(PKGNAME ${CMAKE_FIND_PACKAGE_NAME})
+string(TOUPPER ${PKGNAME} PKGENVNAME)
+string(TOLOWER "${PKGNAME}-config" PKGCONFIG)
+
+find_program(${PKGNAME}_CONFIG
+             NAMES ${PKGCONFIG}
+             PATHS $ENV{${PKGENVNAME}})
+mark_as_advanced(${PKGNAME}_CONFIG)
+
+if(${PKGNAME}_CONFIG)
+  execute_process(COMMAND ${${PKGNAME}_CONFIG} --cxxflags
+                  OUTPUT_VARIABLE ${PKGNAME}_CXXFLAGS
+                  ERROR_VARIABLE error
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  set(${PKGNAME}_INCLUDE_DIRS)
+  mark_as_advanced(${PKGNAME}_INCLUDE_DIRS)
+  if(${PKGNAME}_CXXFLAGS)
+    string(REGEX MATCHALL "(^| )-I[^ ]+" incdirs ${${PKGNAME}_CXXFLAGS})
+    foreach(incdir ${incdirs})
+      string(STRIP ${incdir} incdir)
+      string(SUBSTRING ${incdir} 2 -1 incdir)
+      list(APPEND ${PKGNAME}_INCLUDE_DIRS ${incdir})
+    endforeach()
+  endif(${PKGNAME}_CXXFLAGS)
+
+  execute_process(COMMAND ${${PKGNAME}_CONFIG} --libs
+                  OUTPUT_VARIABLE ${PKGNAME}_CONFIGLIBS
+                  ERROR_VARIABLE error
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  set(${PKGNAME}_LIBS)
+  set(${PKGNAME}_LIB_DIRS)
+  mark_as_advanced(${PKGNAME}_LIBS ${PKGNAME}_LIB_DIRS)
+  if(${PKGNAME}_CONFIGLIBS)
+    string(REGEX MATCHALL "(^| )-l[^ ]+" libs ${${PKGNAME}_CONFIGLIBS})
+    foreach(lib ${libs})
+        string(STRIP ${lib} lib)
+        string(SUBSTRING ${lib} 2 -1 lib)
+        list(APPEND ${PKGNAME}_LIBS ${lib})
+    endforeach()
+
+    string(REGEX MATCHALL "(^| )-L[^ ]+" libdirs ${${PKGNAME}_CONFIGLIBS})
+    foreach(libdir ${libdirs})
+        string(STRIP ${libdir} libdir)
+        string(SUBSTRING ${libdir} 2 -1 libdir)
+        list(APPEND ${PKGNAME}_LIB_DIRS ${libdir})
+    endforeach()
+
+    # append directories of exposed libraries
+    if ("CGAL" IN_LIST ${PKGNAME}_LIBS)
+      find_library(lib_cgal NAMES "CGAL" PATHS $ENV{CGAL_ROOT}/lib NO_DEFAULT_PATH)
+      if (NOT lib_cgal)
+        message(FATAL_ERROR "CGAL not found in $ENV{CGAL_ROOT}/lib")
+      endif()
+      get_filename_component(dir_cgal ${lib_cgal} DIRECTORY)
+      list(APPEND ${PKGNAME}_LIB_DIRS ${dir_cgal})
+    endif()
+
+    if ("gmp" IN_LIST ${PKGNAME}_LIBS)
+      find_library(lib_gmp NAMES "gmp" PATHS $ENV{GMP_ROOT}/lib NO_DEFAULT_PATH)
+      if (NOT lib_gmp)
+        message(FATAL_ERROR "GMP not found in $ENV{GMP_ROOT}/lib")
+      endif()
+      get_filename_component(dir_gmp ${lib_gmp} DIRECTORY)
+      list(APPEND ${PKGNAME}_LIB_DIRS ${dir_gmp})
+    endif()
+  endif(${PKGNAME}_CONFIGLIBS)
+endif(${PKGNAME}_CONFIG)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(${PKGNAME}
+                                  REQUIRED_VARS ${PKGNAME}_INCLUDE_DIRS
+                                                ${PKGNAME}_LIB_DIRS
+                                                ${PKGNAME}_LIBS)
+
+# if everything was found, assemble target with dependencies
+if(${${PKGNAME}_FOUND})
+  add_library(${PKGNAME}::${PKGNAME} IMPORTED INTERFACE GLOBAL)
+  target_compile_definitions(${PKGNAME}::${PKGNAME} INTERFACE "HAVE_${PKGENVNAME}")
+
+  foreach(lib ${${PKGNAME}_LIBS})
+    target_link_libraries(${PKGNAME}::${PKGNAME} INTERFACE ${lib})
+  endforeach()
+
+  foreach(libdir ${${PKGNAME}_LIB_DIRS})
+    target_link_directories(${PKGNAME}::${PKGNAME} INTERFACE ${libdir})
+  endforeach()
+
+  foreach(incdir ${${PKGNAME}_INCLUDE_DIRS})
+    target_include_directories(${PKGNAME}::${PKGNAME} INTERFACE ${incdir})
+  endforeach()
+endif()
+
+unset(PKGNAME)
+unset(PKGENVNAME)

--- a/dependencies/O2Dependencies.cmake
+++ b/dependencies/O2Dependencies.cmake
@@ -148,4 +148,6 @@ endif()
 
 find_package(O2GPU)
 
+find_package(FastJet)
+
 feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)


### PR DESCRIPTION
Hi @ktf,

as discussed with Jan and Nima, I started working on the integration of fastjet. As a first step, I would add linking against fastjet in AnalysisCore (with the intention of then using it for analysis and input to the skimming layer). If you have a better proposal, where or how to add this, let me know.

I will also add fastjet as a dependency to O2 in a PR against alidist.

Cheers,
   Jochen