### PR TITLE
Digitizer workflow: Ability to use arbitrary GRP file

### DIFF
--- a/Steer/DigitizerWorkflow/src/GRPUpdaterSpec.h
+++ b/Steer/DigitizerWorkflow/src/GRPUpdaterSpec.h
@@ -21,7 +21,7 @@ namespace parameters
 {
 
 o2::framework::DataProcessorSpec
-  getGRPUpdaterSpec(const std::vector<o2::detectors::DetID>& detList);
+  getGRPUpdaterSpec(const std::string& grpfilename, const std::vector<o2::detectors::DetID>& detList);
 
 } // end namespace parameters
 } // end namespace o2

--- a/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
+++ b/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
@@ -134,6 +134,10 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   workflowOptions.push_back(
     ConfigParamSpec{"tpc-reco-type", VariantType::String, "", {tpcrthelp}});
 
+  std::string grphelp("GRP file describing the simulation");
+  workflowOptions.push_back(
+    ConfigParamSpec{"GRP", VariantType::String, "o2sim_grp.root", {grphelp}});
+
   // option allowing to set parameters
   std::string keyvaluehelp("Semicolon separated key=value strings (e.g.: 'TPC.gasDensity=1;...')");
   workflowOptions.push_back(
@@ -314,7 +318,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 
   // First, read the GRP to detect which components need instantiations
   // (for the moment this assumes the file o2sim_grp.root to be in the current directory)
-  const auto grp = readGRP();
+  const auto grp = readGRP(configcontext.options().get<std::string>("GRP"));
   if (!grp) {
     return WorkflowSpec{};
   }
@@ -509,7 +513,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   }
 
   // GRP updater: must come after all detectors since requires their list
-  specs.emplace_back(o2::parameters::getGRPUpdaterSpec(detList));
+  specs.emplace_back(o2::parameters::getGRPUpdaterSpec(configcontext.options().get<std::string>("GRP"), detList));
 
   // The SIM Reader. NEEDS TO BE LAST
   specs[0] = o2::steer::getSimReaderSpec(fanoutsize, tpcsectors, tpclanes);


### PR DESCRIPTION
This commit fixes a problem in the digitizer workflow.
Up until now, this was only working with files named "o2sim.root"
and "o2sim_grp.root". Now it is possible to use arbitrary names

```
o2-sim-digitizer-workflow --GRP o2simTRD_grp.root --simFile o2simTRD.root -b --onlyDet TRD
```