### PR TITLE
New functionality and bug fixes for TPCSpaceChargeBase code 

### DIFF
--- a/GPU/TPCSpaceChargeBase/AliTPCPoissonSolver.cxx
+++ b/GPU/TPCSpaceChargeBase/AliTPCPoissonSolver.cxx
@@ -1707,7 +1707,7 @@ void AliTPCPoissonSolver::Restrict2D(TMatrixD& matricesCurrentCharge, TMatrixD& 
   }
 
   // for boundary
-  for (Int_t i = 0, ii = 0; i < tnZColumn; i++, ii += 2) {
+  for (Int_t i = 0, ii = 0; i < tnRRow; i++, ii += 2) {
     matricesCurrentCharge(i, 0) = residue(ii, 0);
     matricesCurrentCharge(i, tnZColumn - 1) = residue(ii, (tnZColumn - 1) * 2);
   }
@@ -1732,7 +1732,7 @@ void AliTPCPoissonSolver::RestrictBoundary2D(TMatrixD& matricesCurrentCharge, TM
   }
 
   // for boundary
-  for (Int_t i = 0, ii = 0; i < tnZColumn; i++, ii += 2) {
+  for (Int_t i = 0, ii = 0; i < tnRRow; i++, ii += 2) {
     matricesCurrentCharge(i, 0) = residue(ii, 0);
     matricesCurrentCharge(i, tnZColumn - 1) = residue(ii, (tnZColumn - 1) * 2);
   }
@@ -1815,7 +1815,7 @@ void AliTPCPoissonSolver::Restrict3D(TMatrixD** matricesCurrentCharge, TMatrixD*
       }
 
       // for boundary
-      for (Int_t i = 0, ii = 0; i < tnZColumn; i++, ii += 2) {
+      for (Int_t i = 0, ii = 0; i < tnRRow; i++, ii += 2) {
         arrayCharge(i, 0) = arrayResidue(ii, 0);
         arrayCharge(i, tnZColumn - 1) = arrayResidue(ii, (tnZColumn - 1) * 2);
       }
@@ -1858,7 +1858,7 @@ void AliTPCPoissonSolver::RestrictBoundary3D(TMatrixD** matricesCurrentCharge, T
       }
 
       // for boundary
-      for (Int_t i = 0, ii = 0; i < tnZColumn; i++, ii += 2) {
+      for (Int_t i = 0, ii = 0; i < tnRRow; i++, ii += 2) {
         arrayCharge(i, 0) = arrayResidue(ii, 0);
         arrayCharge(i, tnZColumn - 1) = arrayResidue(ii, (tnZColumn - 1) * 2);
       }

--- a/GPU/TPCSpaceChargeBase/AliTPCSpaceCharge3DCalc.cxx
+++ b/GPU/TPCSpaceChargeBase/AliTPCSpaceCharge3DCalc.cxx
@@ -3418,7 +3418,11 @@ void AliTPCSpaceCharge3DCalc::SetInputSpaceCharge(TH3* hisSpaceCharge3D, Double_
         radius0 = fListR[i];
 
         for (Int_t j = 0; j < fNZColumns; j++) {
-          z0 = fListZ[j];
+          if (iSide == 0) {
+            z0 = fListZ[j];
+          } else {
+            z0 = -fListZ[j];
+          }
 
           if (radius0 > rMin && radius0 < rMax && z0 > zMin && z0 < zMax) {
 

--- a/GPU/TPCSpaceChargeBase/AliTPCSpaceCharge3DCalc.cxx
+++ b/GPU/TPCSpaceChargeBase/AliTPCSpaceCharge3DCalc.cxx
@@ -3509,10 +3509,6 @@ void AliTPCSpaceCharge3DCalc::SetInputSpaceCharge(TH3* hisSpaceCharge3D, Double_
   fInitLookUp = kFALSE;
 
   Info("AliTPCSpaceCharge3DCalc:SetInputSpaceCharge", "Set Input Space Charge by 3D");
-  Double_t rMin = hisSpaceCharge3D->GetYaxis()->GetBinCenter(0);
-  Double_t rMax = hisSpaceCharge3D->GetYaxis()->GetBinUpEdge(hisSpaceCharge3D->GetYaxis()->GetNbins());
-  Double_t zMin = hisSpaceCharge3D->GetZaxis()->GetBinCenter(0);
-  Double_t zMax = hisSpaceCharge3D->GetZaxis()->GetBinCenter(hisSpaceCharge3D->GetZaxis()->GetNbins());
 
   Double_t radius0, z0, phi0;
   TMatrixD* charge;
@@ -3536,11 +3532,8 @@ void AliTPCSpaceCharge3DCalc::SetInputSpaceCharge(TH3* hisSpaceCharge3D, Double_
             z0 = -fListZ[j];
           }
 
-          if (radius0 > rMin && radius0 < rMax && z0 > zMin && z0 < zMax) {
+          (*charge)(i, j) = norm * InterpolatePhi(hisSpaceCharge3D, phi0, radius0, z0);
 
-            (*charge)(i, j) = norm * InterpolatePhi(hisSpaceCharge3D, phi0, radius0, z0);
-          }
-          //}
         } // end j
       }   // end i
     }     // end phi

--- a/GPU/TPCSpaceChargeBase/AliTPCSpaceCharge3DCalc.h
+++ b/GPU/TPCSpaceChargeBase/AliTPCSpaceCharge3DCalc.h
@@ -19,6 +19,7 @@
 #define ALI_TPC_SPACECHARGE3D_CALC_H
 
 #include "TF1.h"
+#include "TF2.h"
 #include "TH3F.h"
 #include "TMatrixD.h"
 
@@ -54,13 +55,7 @@ class AliTPCSpaceCharge3DCalc
 
   void InitSpaceCharge3DPoissonIntegralDz(
     Int_t nRRow, Int_t nZColumn, Int_t phiSlice, Int_t maxIteration, Double_t stopConvergence,
-    TMatrixD** matricesErA, TMatrixD** matricesEphiA, TMatrixD** matricesEzA,
-    TMatrixD** matricesErC, TMatrixD** matricesEphiC, TMatrixD** matricesEzC,
-    TMatrixD** matricesDistDrDzA, TMatrixD** matricesDistDPhiRDzA, TMatrixD** matricesDistDzA,
-    TMatrixD** matricesCorrDrDzA, TMatrixD** matricesCorrDPhiRDzA, TMatrixD** matricesCorrDzA,
-    TMatrixD** matricesDistDrDzC, TMatrixD** matricesDistDPhiRDzC, TMatrixD** matricesDistDzC,
-    TMatrixD** matricesCorrDrDzC, TMatrixD** matricesCorrDPhiRDzC, TMatrixD** matricesCorrDzC,
-    TFormula* intErDzTestFunction, TFormula* intEPhiRDzTestFunction, TFormula* intDzTestFunction, TFormula* ezF);
+    TFormula* intErDzTestFunction, TFormula* intEPhiRDzTestFunction, TFormula* intDzTestFunction);
 
   void
     InitSpaceCharge3DPoisson(Int_t nRRow, Int_t nZColumn, Int_t phiSlice, Int_t maxIteration, Double_t stopConvergence);
@@ -205,19 +200,19 @@ class AliTPCSpaceCharge3DCalc
   TFormula* GetPotentialVFormula() const { return fFormulaPotentialV; }
   TFormula* GetChargeRhoFormula() const { return fFormulaChargeRho; }
 
-  void SetBoundaryIFCA(TF1* f1) { fFormulaBoundaryIFCA = new TF1(*f1); }
+  void SetBoundaryIFCA(TF1* f1) { fFormulaBoundaryIFCA = f1; }
 
-  void SetBoundaryIFCC(TF1* f1) { fFormulaBoundaryIFCC = new TF1(*f1); }
+  void SetBoundaryIFCC(TF1* f1) { fFormulaBoundaryIFCC = f1; }
 
-  void SetBoundaryOFCA(TF1* f1) { fFormulaBoundaryOFCA = new TF1(*f1); }
+  void SetBoundaryOFCA(TF1* f1) { fFormulaBoundaryOFCA = f1; }
 
-  void SetBoundaryOFCC(TF1* f1) { fFormulaBoundaryOFCC = new TF1(*f1); }
+  void SetBoundaryOFCC(TF1* f1) { fFormulaBoundaryOFCC = f1; }
 
-  void SetBoundaryROCA(TF1* f1) { fFormulaBoundaryROCA = new TF1(*f1); }
+  void SetBoundaryROCA(TF1* f1) { fFormulaBoundaryROCA = f1; }
 
-  void SetBoundaryROCC(TF1* f1) { fFormulaBoundaryROCC = new TF1(*f1); }
+  void SetBoundaryROCC(TF1* f1) { fFormulaBoundaryROCC = f1; }
 
-  void SetBoundaryCE(TF1* f1) { fFormulaBoundaryCE = new TF1(*f1); }
+  void SetBoundaryCE(TF1* f1) { fFormulaBoundaryCE = f1; }
 
   void SetElectricFieldFormula(TFormula* formulaEr, TFormula* formulaEPhi, TFormula* formulaEz)
   {
@@ -373,6 +368,12 @@ class AliTPCSpaceCharge3DCalc
 
   void
     LocalDistCorrDz(TMatrixD** matricesEr, TMatrixD** matricesEPhi, TMatrixD** matricesEz, TMatrixD** matricesDistDrDz,
+                    TMatrixD** matricesDistDPhiRDz, TMatrixD** matricesDistDz, TMatrixD** matricesCorrDrDz,
+                    TMatrixD** matricesCorrDPhiRDz, TMatrixD** matricesCorrDz, const Int_t nRRow, const Int_t nZColumn,
+                    const Int_t phiSlice, const Float_t gridSizeZ, const Double_t ezField);
+  void
+    LocalDistCorrDz(TFormula* intErDzFunction, TFormula* intEPhiRDzFunction, TFormula* intDzFunction, TFormula* ezFunction,
+                    Double_t* rList, Double_t* phiList, Double_t* zList, TMatrixD** matricesDistDrDz,
                     TMatrixD** matricesDistDPhiRDz, TMatrixD** matricesDistDz, TMatrixD** matricesCorrDrDz,
                     TMatrixD** matricesCorrDPhiRDz, TMatrixD** matricesCorrDz, const Int_t nRRow, const Int_t nZColumn,
                     const Int_t phiSlice, const Float_t gridSizeZ, const Double_t ezField);

--- a/GPU/TPCSpaceChargeBase/AliTPCSpaceCharge3DCalc.h
+++ b/GPU/TPCSpaceChargeBase/AliTPCSpaceCharge3DCalc.h
@@ -192,6 +192,9 @@ class AliTPCSpaceCharge3DCalc
 
   void GetLocalDistortionCyl(const Float_t x[], Short_t roc, Float_t dx[]);
 
+  void GetLocalCorrectionCyl(const Float_t x[], Short_t roc, Float_t dx[]);
+
+
   void SetIrregularGridSize(Int_t size) { fIrregularGridSize = size; }
 
   Int_t GetIrregularGridSize() { return fIrregularGridSize; }
@@ -334,6 +337,8 @@ class AliTPCSpaceCharge3DCalc
   AliTPCLookUpTable3DInterpolatorD* fLookupIntENoDriftC = nullptr;               //!<! look-up table for no drift integration side C
   AliTPCLookUpTable3DInterpolatorD* fLookupDistA = nullptr;                      //!<! look-up table for local distortion side A
   AliTPCLookUpTable3DInterpolatorD* fLookupDistC = nullptr;                      //!<! look-up table for local distortion side C
+  AliTPCLookUpTable3DInterpolatorD* fLookupCorrA = nullptr;                      //!<! look-up table for local correction side A
+  AliTPCLookUpTable3DInterpolatorD* fLookupCorrC = nullptr;                      //!<! look-up table for local correction side C
   AliTPCLookUpTable3DInterpolatorD* fLookupInverseDistA = nullptr;               //!<! look-up table for local distortion (from inverse) side A
   AliTPCLookUpTable3DInterpolatorD* fLookupInverseDistC = nullptr;               //!<! look-up table for local distortion (from inverse) side C
 

--- a/GPU/TPCSpaceChargeBase/AliTPCSpaceCharge3DCalc.h
+++ b/GPU/TPCSpaceChargeBase/AliTPCSpaceCharge3DCalc.h
@@ -189,7 +189,6 @@ class AliTPCSpaceCharge3DCalc
 
   void GetLocalCorrectionCyl(const Float_t x[], Short_t roc, Float_t dx[]);
 
-
   void SetIrregularGridSize(Int_t size) { fIrregularGridSize = size; }
 
   Int_t GetIrregularGridSize() { return fIrregularGridSize; }


### PR DESCRIPTION
Adopting changes from un-merged PR 2165 (https://github.com/AliceO2Group/AliceO2/pull/2165).

Bug fix in AliTPCPoissonSolver in loop range variables to allow different number of bins in z and r.

Changes in AliTPCSpaceCharge3DCalc:
* Adding local correction lookup tables for debug purposes
* Fixing z sign of SetInputSpaceCharge function
* Bug fixes in fast global distortion integration method