### PR TITLE
DPL: add an out-of-band output proxy

### DIFF
--- a/Framework/Utils/CMakeLists.txt
+++ b/Framework/Utils/CMakeLists.txt
@@ -29,6 +29,11 @@ o2_add_executable(raw-parser
                   SOURCES src/raw-parser.cxx
                   PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils)
 
+o2_add_executable(output-proxy
+                  COMPONENT_NAME dpl
+                  SOURCES src/dpl-output-proxy.cxx
+                  PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils)
+
 # Converter can now be a separate workflow which we merge if needed
 o2_add_executable(esd-2-arrow-converter
                   COMPONENT_NAME dpl

--- a/Framework/Utils/Readme.md
+++ b/Framework/Utils/Readme.md
@@ -109,5 +109,43 @@ Options:
 
 The workflow can be connected to the o2-dpl-raw-proxy workflow using pipe on command line.
 
+### DPL output proxy
+Executable:
+```
+o2-dpl-output-proxy
+```
+
+A proxy workflow to connect to workflow output and forward it to out-of-band channels,
+meaning channels outside DPL.
+
+#### Usage: `o2-dpl-output-proxy`
+```
+o2-dpl-output-proxy --dataspec "channelname:TPC/TRACKS" --channel-config name=channelname,...
+```
+
+Output channel(s): to be defined with the FairMQ device channel configuration option, e.g.
+```
+--channel-config name=downstream,type=push,method=bind,address=icp://localhost_4200,rateLogging=60,transport=shmem
+```
+
+Input to the proxy is defined by the DPL data spec syntax
+```
+binding1:origin1/description1/subspecification1;binding2:origin2/descritption2;...
+```
+The binding label can be used internally to access the input, here it is used to match to
+a configured output channel. That binding can be the same for multiple data specs.
+
+Options:
+```
+  --dataspec       specs           Data specs of data to be proxied
+  --channel-config config          FairMQ device channel configuration for the output channel
+  --proxy-name     name            name of the proxy processor, used also as default output channel name
+  --default-transport arg (=shmem) default transport: shmem, zeromq
+  --default-port arg (=4200)       default port number
+```
+Note: the 'default-*' options are only for building the the default of the channel configuration.
+The default channel name is build from the name of the proxy device. Having a default channel
+configuration allows to skip the '--channel-config' option on the command line.
+
 ### ROOT Tree reader and writer
 documentation to be filled

--- a/Framework/Utils/src/dpl-output-proxy.cxx
+++ b/Framework/Utils/src/dpl-output-proxy.cxx
@@ -1,0 +1,92 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/WorkflowSpec.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Logger.h"
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/ExternalFairMQDeviceProxy.h"
+#include <vector>
+
+using namespace o2::framework;
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  workflowOptions.push_back(
+    ConfigParamSpec{
+      "proxy-name", VariantType::String, "dpl-output-proxy", {"name of the proxy processor, will be the default output channel name as well"}});
+
+  workflowOptions.push_back(
+    ConfigParamSpec{
+      "dataspec", VariantType::String, "dpl-output-proxy:TST/CLUSTERS;dpl-output-proxy:TST/TRACKS", {"selection string for the data to be proxied"}});
+
+  workflowOptions.push_back(
+    ConfigParamSpec{
+      "default-transport", VariantType::String, "shmem", {"default transport: shmem, zeromq"}});
+
+  workflowOptions.push_back(
+    ConfigParamSpec{
+      "default-port", VariantType::Int, 4200, {"default port number"}});
+}
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& config)
+{
+  std::string processorName = config.options().get<std::string>("proxy-name");
+  std::string inputConfig = config.options().get<std::string>("dataspec");
+  int defaultPort = config.options().get<int>("default-port");
+  std::string defaultTransportConfig = config.options().get<std::string>("default-transport");
+  if (defaultTransportConfig == "zeromq") {
+    // nothing to do for the moment
+  } else if (defaultTransportConfig == "shmem") {
+    // nothing to do for the moment
+  } else {
+    throw std::runtime_error("invalid argument for option --default-transport : '" + defaultTransportConfig + "'");
+  }
+
+  std::vector<InputSpec> inputs = select(inputConfig.c_str());
+  if (inputs.size() == 0) {
+    throw std::runtime_error("invalid dataspec '" + inputConfig + "'");
+  }
+
+  // we build the default channel configuration from the binding of the first input
+  // in order to have more than one we would need to possibility to have support for
+  // vectored options
+  // use the OutputChannelSpec as a tool to create the default configuration for the out-of-band channel
+  OutputChannelSpec externalChannelSpec;
+  externalChannelSpec.name = inputs[0].binding;
+  externalChannelSpec.type = ChannelType::Push;
+  externalChannelSpec.method = ChannelMethod::Bind;
+  externalChannelSpec.hostname = "localhost";
+  externalChannelSpec.port = defaultPort;
+  externalChannelSpec.listeners = 0;
+  // in principle, protocol and transport are two different things but fur simplicity
+  // we use ipc when shared memory is selected and the normal tcp url whith zeromq,
+  // this is for building the default configuration which can be simply changed from the
+  // command line
+  if (!defaultTransportConfig.empty()) {
+    if (defaultTransportConfig == "zeromq") {
+      externalChannelSpec.protocol = ChannelProtocol::Network;
+    } else if (defaultTransportConfig == "shmem") {
+      externalChannelSpec.protocol = ChannelProtocol::IPC;
+    }
+  }
+  std::string defaultChannelConfig = formatExternalChannelConfiguration(externalChannelSpec);
+  // at some point the formatting tool might add the transport as well so we have to check
+  if (!defaultTransportConfig.empty() && defaultTransportConfig.find("transport=") == std::string::npos) {
+    defaultChannelConfig += ",transport=" + defaultTransportConfig;
+  }
+
+  std::vector<DataProcessorSpec> workflow;
+  workflow.emplace_back(std::move(specifyFairMQDeviceOutputProxy(processorName.c_str(), inputs, defaultChannelConfig.c_str())));
+  return workflow;
+}


### PR DESCRIPTION
Adding the o2-dpl-output-proxy utility provides a configurable output proxy workflow
to forward workflow output to out-of-band channels, meaning channels outside DPL.

Output channel(s) are defined with the FairMQ device channel configuration option.
Input to the proxy is defined by the DPL data spec syntax. The binding label is used
to match to a configured output channel. Binding can be the same for multiple data specs
in order to forward multiple input specs to the same channel.

Example:

    o2-dpl-output-proxy --dataspec "channelname:TPC/TRACKS" --channel-config name=channelname,...

Upcoming:
- [ ] integrate proxy functionality as a common device in the DPL workflow builder