### PR TITLE
DPL Analysis: use std:vector for filter selection

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -28,7 +28,7 @@
 
 namespace o2::soa
 {
-using selectionVector = std::vector<int64_t>;
+using SelectionVector = std::vector<int64_t>;
 
 template <typename, typename = void>
 constexpr bool is_index_column_v = false;
@@ -465,7 +465,7 @@ struct FilteredIndexPolicy : IndexPolicyBase {
   // which happens below which will properly setup the first index
   // by remapping the filtered index 0 to whatever unfiltered index
   // it belongs to.
-  FilteredIndexPolicy(selectionVector* selection = nullptr, uint64_t offset = 0)
+  FilteredIndexPolicy(SelectionVector* selection = nullptr, uint64_t offset = 0)
     : IndexPolicyBase{-1, offset},
       mSelectedRows(selection),
       mMaxSelection(selection == nullptr ? 0 : selection->size())
@@ -535,7 +535,7 @@ struct FilteredIndexPolicy : IndexPolicyBase {
   }
 
  private:
-  selectionVector* mSelectedRows = nullptr;
+  SelectionVector* mSelectedRows = nullptr;
   int64_t mSelectionRow = 0;
   int64_t mMaxSelection = 0;
 };
@@ -725,7 +725,7 @@ template <typename... C>
 using RowViewFiltered = RowViewBase<FilteredIndexPolicy, C...>;
 
 template <typename... C>
-auto&& makeRowViewFiltered(std::tuple<std::pair<C*, arrow::Column*>...> const& columnIndex, selectionVector* selection, uint64_t offset)
+auto&& makeRowViewFiltered(std::tuple<std::pair<C*, arrow::Column*>...> const& columnIndex, SelectionVector* selection, uint64_t offset)
 {
   return std::move(RowViewBase<FilteredIndexPolicy, C...>{columnIndex, FilteredIndexPolicy{selection, offset}});
 }
@@ -781,7 +781,7 @@ class Table
     return unfiltered_iterator{mEnd};
   }
 
-  filtered_iterator filtered_begin(selectionVector* selection)
+  filtered_iterator filtered_begin(SelectionVector* selection)
   {
     // Note that the FilteredIndexPolicy will never outlive the selection which
     // is held by the table, so we are safe passing the bare pointer. If it does it
@@ -790,7 +790,7 @@ class Table
     return filtered_iterator(mColumnIndex, {selection, mOffset});
   }
 
-  filtered_iterator filtered_end(selectionVector* selection)
+  filtered_iterator filtered_end(SelectionVector* selection)
   {
     auto end = filtered_iterator(mColumnIndex, {selection, mOffset});
     end.moveToEnd();
@@ -1155,9 +1155,9 @@ class Filtered : public T
   using iterator = typename table_t::filtered_iterator;
   using const_iterator = typename table_t::filtered_const_iterator;
 
-  Filtered(std::vector<std::shared_ptr<arrow::Table>>&& tables, selectionVector&& selection, uint64_t offset = 0)
+  Filtered(std::vector<std::shared_ptr<arrow::Table>>&& tables, SelectionVector&& selection, uint64_t offset = 0)
     : T{std::move(tables), offset},
-      mSelectedRows{std::forward<selectionVector>(selection)},
+      mSelectedRows{std::forward<SelectionVector>(selection)},
       mFilteredBegin{table_t::filtered_begin(&mSelectedRows)},
       mFilteredEnd{table_t::filtered_end(&mSelectedRows)}
   {
@@ -1211,14 +1211,14 @@ class Filtered : public T
     return table_t::asArrowTable()->num_rows();
   }
 
-  selectionVector const& getSelectedRows() const
+  SelectionVector const& getSelectedRows() const
   {
     return mSelectedRows;
   }
 
-  static inline selectionVector copySelection(framework::expressions::Selection const& sel)
+  static inline SelectionVector copySelection(framework::expressions::Selection const& sel)
   {
-    selectionVector rows;
+    SelectionVector rows;
     for (auto i = 0; i < sel->GetNumSlots(); ++i) {
       rows.push_back(sel->GetIndex(i));
     }
@@ -1236,7 +1236,7 @@ class Filtered : public T
   }
 
  private:
-  selectionVector mSelectedRows;
+  SelectionVector mSelectedRows;
   iterator mFilteredBegin;
   iterator mFilteredEnd;
 };

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -28,6 +28,7 @@
 
 namespace o2::soa
 {
+using selectionVector = std::vector<int64_t>;
 
 template <typename, typename = void>
 constexpr bool is_index_column_v = false;
@@ -464,10 +465,10 @@ struct FilteredIndexPolicy : IndexPolicyBase {
   // which happens below which will properly setup the first index
   // by remapping the filtered index 0 to whatever unfiltered index
   // it belongs to.
-  FilteredIndexPolicy(gandiva::SelectionVector* selection = nullptr, uint64_t offset = 0)
+  FilteredIndexPolicy(selectionVector* selection = nullptr, uint64_t offset = 0)
     : IndexPolicyBase{-1, offset},
-      mSelection(selection),
-      mMaxSelection(selection ? selection->GetNumSlots() : 0)
+      mSelectedRows(selection),
+      mMaxSelection(selection == nullptr ? 0 : selection->size())
   {
     this->setCursor(0);
   }
@@ -500,13 +501,13 @@ struct FilteredIndexPolicy : IndexPolicyBase {
   void setCursor(int64_t i)
   {
     mSelectionRow = i;
-    this->mRowIndex = mSelection ? mSelection->GetIndex(mSelectionRow) : mSelectionRow;
+    this->mRowIndex = mSelectedRows != nullptr ? (*mSelectedRows)[mSelectionRow] : mSelectionRow;
   }
 
   void moveByIndex(int64_t i)
   {
     mSelectionRow += i;
-    this->mRowIndex = mSelection ? mSelection->GetIndex(mSelectionRow) : mSelectionRow;
+    this->mRowIndex = mSelectedRows != nullptr ? (*mSelectedRows)[mSelectionRow] : mSelectionRow;
   }
 
   bool operator!=(FilteredIndexPolicy const& other) const
@@ -534,9 +535,9 @@ struct FilteredIndexPolicy : IndexPolicyBase {
   }
 
  private:
+  selectionVector* mSelectedRows = nullptr;
   int64_t mSelectionRow = 0;
   int64_t mMaxSelection = 0;
-  gandiva::SelectionVector* mSelection = nullptr;
 };
 
 template <typename... C>
@@ -724,7 +725,7 @@ template <typename... C>
 using RowViewFiltered = RowViewBase<FilteredIndexPolicy, C...>;
 
 template <typename... C>
-auto&& makeRowViewFiltered(std::tuple<std::pair<C*, arrow::Column*>...> const& columnIndex, gandiva::SelectionVector* selection, uint64_t offset)
+auto&& makeRowViewFiltered(std::tuple<std::pair<C*, arrow::Column*>...> const& columnIndex, selectionVector* selection, uint64_t offset)
 {
   return std::move(RowViewBase<FilteredIndexPolicy, C...>{columnIndex, FilteredIndexPolicy{selection, offset}});
 }
@@ -780,18 +781,18 @@ class Table
     return unfiltered_iterator{mEnd};
   }
 
-  filtered_iterator filtered_begin(framework::expressions::Selection selection)
+  filtered_iterator filtered_begin(selectionVector* selection)
   {
     // Note that the FilteredIndexPolicy will never outlive the selection which
     // is held by the table, so we are safe passing the bare pointer. If it does it
     // means that the iterator on a table is outliving the table itself, which is
     // a bad idea.
-    return filtered_iterator(mColumnIndex, {selection.get(), mOffset});
+    return filtered_iterator(mColumnIndex, {selection, mOffset});
   }
 
-  filtered_iterator filtered_end(framework::expressions::Selection selection)
+  filtered_iterator filtered_end(selectionVector* selection)
   {
-    auto end = filtered_iterator(mColumnIndex, {selection.get(), mOffset});
+    auto end = filtered_iterator(mColumnIndex, {selection, mOffset});
     end.moveToEnd();
     return end;
   }
@@ -1154,21 +1155,29 @@ class Filtered : public T
   using iterator = typename table_t::filtered_iterator;
   using const_iterator = typename table_t::filtered_const_iterator;
 
+  Filtered(std::vector<std::shared_ptr<arrow::Table>>&& tables, selectionVector&& selection, uint64_t offset = 0)
+    : T{std::move(tables), offset},
+      mSelectedRows{std::forward<selectionVector>(selection)},
+      mFilteredBegin{table_t::filtered_begin(&mSelectedRows)},
+      mFilteredEnd{table_t::filtered_end(&mSelectedRows)}
+  {
+  }
+
   Filtered(std::vector<std::shared_ptr<arrow::Table>>&& tables, framework::expressions::Selection selection, uint64_t offset = 0)
     : T{std::move(tables), offset},
-      mSelection{selection},
-      mFilteredBegin{table_t::filtered_begin(mSelection)},
-      mFilteredEnd{table_t::filtered_end(mSelection)}
+      mSelectedRows{copySelection(selection)},
+      mFilteredBegin{table_t::filtered_begin(&mSelectedRows)},
+      mFilteredEnd{table_t::filtered_end(&mSelectedRows)}
   {
   }
 
   Filtered(std::vector<std::shared_ptr<arrow::Table>>&& tables, gandiva::NodePtr const& tree, uint64_t offset = 0)
     : T{std::move(tables), offset},
-      mSelection{framework::expressions::createSelection(this->asArrowTable(),
-                                                         framework::expressions::createFilter(this->asArrowTable()->schema(),
-                                                                                              framework::expressions::createCondition(tree)))},
-      mFilteredBegin{table_t::filtered_begin(mSelection)},
-      mFilteredEnd{table_t::filtered_end(mSelection)}
+      mSelectedRows{copySelection(framework::expressions::createSelection(this->asArrowTable(),
+                                                                          framework::expressions::createFilter(this->asArrowTable()->schema(),
+                                                                                                               framework::expressions::createCondition(tree))))},
+      mFilteredBegin{table_t::filtered_begin(&mSelectedRows)},
+      mFilteredEnd{table_t::filtered_end(&mSelectedRows)}
   {
   }
 
@@ -1194,7 +1203,7 @@ class Filtered : public T
 
   int64_t size() const
   {
-    return mSelection->GetNumSlots();
+    return mSelectedRows.size();
   }
 
   int64_t tableSize() const
@@ -1202,13 +1211,32 @@ class Filtered : public T
     return table_t::asArrowTable()->num_rows();
   }
 
-  framework::expressions::Selection getSelection() const
+  selectionVector const& getSelectedRows() const
   {
-    return mSelection;
+    return mSelectedRows;
+  }
+
+  static inline selectionVector copySelection(framework::expressions::Selection const& sel)
+  {
+    selectionVector rows;
+    for (auto i = 0; i < sel->GetNumSlots(); ++i) {
+      rows.push_back(sel->GetIndex(i));
+    }
+    return rows;
+  }
+
+  /// Bind the columns which refer to other tables
+  /// to the associated tables.
+  template <typename... TA>
+  void bindExternalIndices(TA*... current)
+  {
+    table_t::bindExternalIndices(current...);
+    mFilteredBegin.bindExternalIndices(current...);
+    mFilteredEnd.bindExternalIndices(current...);
   }
 
  private:
-  framework::expressions::Selection mSelection;
+  selectionVector mSelectedRows;
   iterator mFilteredBegin;
   iterator mFilteredEnd;
 };

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -42,7 +42,7 @@ DECLARE_SOA_COLUMN(EventTimeRes, eventTimeRes, float, "fEventTimeRes");
 DECLARE_SOA_COLUMN(EventTimeMask, eventTimeMask, uint8_t, "fEventTimeMask");
 } // namespace collision
 
-DECLARE_SOA_TABLE(Collisions, "AOD", "COLLISION", collision::RunNumber, collision::VtxId, collision::PosX, collision::PosY, collision::PosZ, collision::CovXX, collision::CovXY, collision::CovXZ, collision::CovYY, collision::CovYZ, collision::CovZZ, collision::Chi2, collision::NumContrib, collision::EventTime, collision::EventTimeRes, collision::EventTimeMask);
+DECLARE_SOA_TABLE(Collisions, "AOD", "COLLISION", o2::soa::Index<>, collision::RunNumber, collision::VtxId, collision::PosX, collision::PosY, collision::PosZ, collision::CovXX, collision::CovXY, collision::CovXZ, collision::CovYY, collision::CovYZ, collision::CovZZ, collision::Chi2, collision::NumContrib, collision::EventTime, collision::EventTimeRes, collision::EventTimeMask);
 
 using Collision = Collisions::iterator;
 

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -431,7 +431,7 @@ struct AnalysisDataProcessorBuilder {
               // for each grouping element we need to slice the selection vector
               auto iterator_start = std::find(fullSelection.begin(), fullSelection.end(), offsets[oi]);
               auto iterator_end = std::find(iterator_start, fullSelection.end(), offsets[oi + 1]);
-              soa::selectionVector slicedSelection{iterator_start, iterator_end};
+              soa::SelectionVector slicedSelection{iterator_start, iterator_end};
               std::transform(slicedSelection.begin(), slicedSelection.end(), slicedSelection.begin(), [&](int64_t index) { return index - static_cast<int64_t>(offsets[oi]); });
 
               std::decay_t<AssociatedType> typedTable{{groupedElementsTable}, std::move(slicedSelection), offsets[oi]};

--- a/Framework/Foundation/include/Framework/Pack.h
+++ b/Framework/Foundation/include/Framework/Pack.h
@@ -12,6 +12,7 @@
 
 #include <cstddef>
 #include <utility>
+#include <cstdio>
 
 namespace o2::framework
 {


### PR DESCRIPTION
* Filters are now correctly processed when grouping
* Updated filters.cxx example
* Fixed index binds for unfiltered/ungrouped case