### PR TITLE
Templated secondary N-prong vertex fitter

### DIFF
--- a/Detectors/Base/CMakeLists.txt
+++ b/Detectors/Base/CMakeLists.txt
@@ -49,6 +49,15 @@ if(BUILD_SIMULATION)
                 VMCWORKDIR=${CMAKE_BINARY_DIR}/stage/${CMAKE_INSTALL_DATADIR})
 endif()
 
+o2_add_test(
+  DCAFitter
+  SOURCES test/testDCAFitter.cxx
+  COMPONENT_NAME DetectorsBase
+  PUBLIC_LINK_LIBRARIES O2::DetectorsBase
+  LABELS detectorsbase
+  ENVIRONMENT O2_ROOT=${CMAKE_BINARY_DIR}/stage
+  VMCWORKDIR=${CMAKE_BINARY_DIR}/stage/${CMAKE_INSTALL_DATADIR})
+
 o2_add_test_root_macro(test/buildMatBudLUT.C
                        PUBLIC_LINK_LIBRARIES O2::DetectorsBase
                        LABELS detectorsbase)

--- a/Detectors/Base/test/README.md
+++ b/Detectors/Base/test/README.md
@@ -2,8 +2,9 @@
 \page refDetectorsBasetest Detectors Base test
 /doxy -->
 
-# WORK IN PROGRESS: Mat.Budget LUT classes
+# Tests
 
+## Mat.Budget LUT classes
 
 To generate the LUT (at the moment for R<400, with layers above 270 cm not optimized) run
 ```

--- a/Detectors/Base/test/README.md
+++ b/Detectors/Base/test/README.md
@@ -4,7 +4,7 @@
 
 # Tests
 
-## Mat.Budget LUT classes
+## Material Budget LUT classes
 
 To generate the LUT (at the moment for R<400, with layers above 270 cm not optimized) run
 ```

--- a/Detectors/Base/test/testDCAFitter.cxx
+++ b/Detectors/Base/test/testDCAFitter.cxx
@@ -8,7 +8,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#define BOOST_TEST_MODULE Test MCTruthContainer class
+#define BOOST_TEST_MODULE Test DCAFitter class
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>

--- a/Detectors/CMakeLists.txt
+++ b/Detectors/CMakeLists.txt
@@ -30,6 +30,7 @@ add_subdirectory(TPC)
 
 add_subdirectory(GlobalTracking)
 add_subdirectory(GlobalTrackingWorkflow)
+add_subdirectory(Vertexing)
 
 if(BUILD_SIMULATION)
   add_subdirectory(gconfig)

--- a/Detectors/README.md
+++ b/Detectors/README.md
@@ -10,11 +10,13 @@ There is no module description yet.
 This module contains the following submodules:
 
 * \subpage refDetectorsRaw
+* \subpage refDetectorsBase
 * \subpage refDetectorsBasetest
+* \subpage refDetectorsGlobalTracking
+* \subpage refDetectorsVertexing
 * \subpage refDetectorsEMCAL
 * \subpage refDetectorsFIT
 * \subpage refDetectorsGeometry
-* \subpage refDetectorsGlobalTracking
 * \subpage refDetectorsHMPID
 * \subpage refDetectorsITSMFT
 * \subpage refDetectorsMUON

--- a/Detectors/Vertexing/CMakeLists.txt
+++ b/Detectors/Vertexing/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright CERN and copyright holders of ALICE O2. This software is distributed
+# under the terms of the GNU General Public License v3 (GPL Version 3), copied
+# verbatim in the file "COPYING".
+#
+# See http://alice-o2.web.cern.ch/license for full licensing information.
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization or
+# submit itself to any jurisdiction.
+
+o2_add_library(Vertexing
+               SOURCES src/DCAFitterN.cxx
+               PUBLIC_LINK_LIBRARIES ROOT::Core
+	                             O2::CommonUtils
+                                     O2::ReconstructionDataFormats)
+
+o2_target_root_dictionary(Vertexing
+                          HEADERS include/DetectorsVertexing/HelixHelper.h
+                                  include/DetectorsVertexing/DCAFitterN.h)
+
+o2_add_test(
+  DCAFitterN
+  SOURCES test/testDCAFitterN.cxx
+  COMPONENT_NAME Vertexing
+  PUBLIC_LINK_LIBRARIES O2::Vertexing ROOT::Core ROOT::Physics
+  LABELS vertexing
+  ENVIRONMENT O2_ROOT=${CMAKE_BINARY_DIR}/stage
+  VMCWORKDIR=${CMAKE_BINARY_DIR}/stage/${CMAKE_INSTALL_DATADIR})

--- a/Detectors/Vertexing/README.md
+++ b/Detectors/Vertexing/README.md
@@ -1,0 +1,57 @@
+<!-- doxy
+\page refDetectorsVertexing Detectors Vertexing
+/doxy -->
+
+# Classes for Vertexing
+
+## DCAFitterN
+
+Templated class to fit the Point of Closest Approach (PCA) of secondary vertex with N prongs. Allows minimization of either absolute or weighted Distances of Closest Approach (DCA) of N tracks to their common PCA. 
+
+For every N (prongs) a separate specialization must be instantiated, e.g.
+```cpp
+using Track = o2::track::TrackParCov;
+o2::vertexing::DCAFitterN<2,Track> ft2; // 2-prongs fitter
+// or, to set at once some parameters
+float bz = 5.;           // field in kGauss
+bool useAbsDCA = true;   // use abs. DCA minimizaition instead of default weighted
+bool propToDCA = true;   // after fit, create a copy of tracks at the found PCA
+o2::vertexing::DCAFitterN<3,Track> ft3(bz, useAbsDCA, propToDCA); // 3-prongs fitter
+```
+One can also use predefined aliases ``o2::vertexing::DCAFitter2`` and ``o2::vertexing::DCAFitter3``; 
+The main processing method is
+```cpp
+o2::vertexing::DCAFitterN<N,Track>::process(const Track& trc1,..., cons Track& trcN);
+```
+
+The typical use case is (for e.g. 3-prong fitter):
+```cpp
+using Vec3D    =  ROOT::Math::SVector<double,3>; // this is a type of the fitted vertex
+o2::vertexing::DCAFitter3 ft;
+ft.setBz(5.0);
+ft.setPropagateToPCA(true); // After finding the vertex, propagate tracks to the DCA. This is default anyway
+ft.setMaxR(200);            // do not consider V0 seeds with 2D circles crossing above this R. This is default anyway
+ft.setMaxDZIni(4);          // do not consider V0 seeds with tracks Z-distance exceeding this. This is default anyway
+ft.setMinParamChange(1e-3); // stop iterations if max correction is below this value. This is default anyway
+ft.setMinRelChi2Change(0.9);// stop iterations if chi2 improves by less that this factor
+ft.setMaxChi2(10);          // discard vertices with chi2/Nprongs (or sum{DCAi^2}/Nprongs for abs. distance minimization) 
+
+Track tr0,tr1,tr2;                  // decide candidate tracks
+int nc = ft.process(tr0,tr1,tr2);   // one can have up to 2 candidates, though the 2nd (if any) will have worse quality
+if (nc) {
+   Vec3D vtx = ft.getPCACandidate(); // same as ft.getPCACandidate(0);
+   LOG(INFO) << "found vertex " << vtx[0] << ' ' << vtx[1] << ' ' << vtx[2];
+   // access the track's X parameters at PCA
+   for (int i=0;i<3;i++) {
+    LOG(INFO) << "Track " << i << " at PCA for X = " << ft.getTrackX(i);
+   }
+   // access directly the tracks propagated to the DCA
+   for (int i=0;i<3;i++) {
+     const auto& track = ft.getTrack(i);
+     track.print();
+   }
+}
+```
+
+See ``O2/Detectors/Base/test/testDCAFitterN.cxx`` for more extended example.
+Currently only 2 and 3 prongs permitted, thought this can be changed by modifying ``DCAFitterN::NMax`` constant.

--- a/Detectors/Vertexing/include/DetectorsVertexing/DCAFitterN.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/DCAFitterN.h
@@ -1,0 +1,810 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file DCAFitterN.h
+/// \brief Defintions for N-prongs secondary vertex fit
+/// \author ruben.shahoyan@cern.ch
+/// For the formulae derivation see /afs/cern.ch/user/s/shahoian/public/O2/DCAFitter/DCAFitterN.pdf
+
+#ifndef _ALICEO2_DCA_FITTERN_
+#define _ALICEO2_DCA_FITTERN_
+#include <TMath.h>
+#include <Math/SMatrix.h>
+#include <Math/SVector.h>
+#include "ReconstructionDataFormats/Track.h"
+#include "DetectorsVertexing/HelixHelper.h"
+
+namespace o2
+{
+namespace vertexing
+{
+///__________________________________________________________________________________
+///< Inverse cov matrix (augmented by a dummy X error) of the point defined by the track
+struct TrackCovI {
+  float sxx, syy, syz, szz;
+
+  TrackCovI(const o2::track::TrackParCov& trc) { set(trc); }
+
+  TrackCovI() = default;
+
+  void set(const o2::track::TrackParCov& trc)
+  {
+    // we assign Y error to X for DCA calculation
+    // (otherwise for quazi-collinear tracks the X will not be constrained)
+    float cyy = trc.getSigmaY2(), czz = trc.getSigmaZ2(), cyz = trc.getSigmaZY(), cxx = cyy;
+    float detYZ = cyy * czz - cyz * cyz;
+    if (detYZ > 0.) {
+      auto detYZI = 1. / detYZ;
+      sxx = 1. / cxx;
+      syy = czz * detYZI;
+      syz = -cyz * detYZI;
+      szz = cyy * detYZI;
+    } else {
+      throw std::runtime_error("invalid track covariance");
+    }
+  }
+};
+
+///__________________________________________________________________________
+///< Derivative (up to 2) of the TrackParam position over its running param X
+struct TrackDeriv {
+  float dydx, dzdx, d2ydx2, d2zdx2;
+  TrackDeriv() = default;
+  TrackDeriv(const o2::track::TrackPar& trc, float bz) { set(trc, bz); }
+  void set(const o2::track::TrackPar& trc, float bz)
+  {
+    float snp = trc.getSnp(), csp = std::sqrt((1. - snp) * (1. + snp)), cspI = 1. / csp, crv2c = trc.getCurvature(bz) * cspI;
+    dydx = snp * cspI;            // = snp/csp
+    dzdx = trc.getTgl() * cspI;   // = tgl/csp
+    d2ydx2 = crv2c * cspI * cspI; // = crv/csp^3
+    d2zdx2 = crv2c * dzdx * dydx; // = crv*tgl*snp/csp^3
+  }
+};
+
+template <int N, typename... Args>
+class DCAFitterN
+{
+  static constexpr double NMin = 2;
+  static constexpr double NMax = 4;
+  static constexpr double NInv = 1. / N;
+  static constexpr int MAXHYP = 2;
+
+  using Track = o2::track::TrackParCov;
+  using TrackAuxPar = o2::track::TrackAuxPar;
+  using CircleCrossInfo = o2::track::CircleCrossInfo;
+
+  using Vec3D = ROOT::Math::SVector<double, 3>;
+  using VecND = ROOT::Math::SVector<double, N>;
+  using MatSym3D = ROOT::Math::SMatrix<double, 3, 3, ROOT::Math::MatRepSym<double, 3>>;
+  using MatStd3D = ROOT::Math::SMatrix<double, 3, 3, ROOT::Math::MatRepStd<double, 3>>;
+  using MatSymND = ROOT::Math::SMatrix<double, N, N, ROOT::Math::MatRepSym<double, N>>;
+  using MatStdND = ROOT::Math::SMatrix<double, N, N, ROOT::Math::MatRepStd<double, N>>;
+  using TrackCoefVtx = MatStd3D;
+  using ArrTrack = std::array<Track, N>;         // container for prongs (tracks) at single vertex cand.
+  using ArrTrackCovI = std::array<TrackCovI, N>; // container for inv.cov.matrices at single vertex cand.
+  using ArrTrCoef = std::array<TrackCoefVtx, N>; // container of TrackCoefVtx coefficients at single vertex cand.
+  using ArrTrDer = std::array<TrackDeriv, N>;    // container of Track 1st and 2nd derivative over their X param
+  using ArrTrPos = std::array<Vec3D, N>;         // container of Track positions
+
+ public:
+  static constexpr int getNProngs() { return N; }
+
+  DCAFitterN() = default;
+  DCAFitterN(float bz, bool useAbsDCA, bool prop2DCA) : mBz(bz), mUseAbsDCA(useAbsDCA), mPropagateToPCA(prop2DCA)
+  {
+    static_assert(N >= NMin && N <= NMax, "N prongs outside of allowed range");
+  }
+
+  //=========================================================================
+  ///< return PCA candidate, by default best on is provided (no check for the index validity)
+  const Vec3D& getPCACandidate(int cand = 0) const { return mPCA[mOrder[cand]]; }
+
+  ///< return Chi2 at PCA candidate (no check for its validity)
+  float getChi2AtPCACandidate(int cand = 0) const { return mChi2[mOrder[cand]]; }
+
+  ///< track param positions at V0 candidate (no check for the candidate validity)
+  const Vec3D& getTrackPos(int i, int cand = 0) const { return mTrPos[mOrder[cand]][i]; }
+
+  ///< prapare copies of tracks at the V0 candidate (no check for the candidate validity)
+  ///  must be called before getTrack(i,cand) query
+  bool propagateTracksToVertex(int cand = 0);
+
+  ///< track X-param at V0 candidate (no check for the candidate validity)
+  float getTrackX(int i, int cand = 0) const { return getTrackPos(i, cand)[0]; }
+
+  ///< track param propagated to V0 candidate (no check for the candidate validity)
+  ///  propagateTracksToVertex must be called in advance
+  const Track& getTrack(int i, int cand = 0) const
+  {
+    if (!mTrPropDone[mOrder[cand]]) {
+      throw std::runtime_error("propagateTracksToVertex was not called yet");
+    }
+    return mCandTr[mOrder[cand]][i];
+  }
+
+  const Track* getOrigTrackPtr(int i) const { return mOrigTrPtr[i]; }
+
+  ///< return number of iterations during minimization (no check for its validity)
+  int getNIterations(int cand = 0) const { return mNIters[mOrder[cand]]; }
+  void setPropagateToPCA(bool v = true) { mPropagateToPCA = v; }
+  void setMaxIter(int n = 20) { mMaxIter = n > 2 ? n : 2; }
+  void setMaxR(float r = 200.) { mMaxR2 = r * r; }
+  void setMaxDZIni(float d = 4.) { mMaxDZIni = d; }
+  void setMaxChi2(float chi2 = 999.) { mMaxChi2 = chi2; }
+  void setBz(float bz) { mBz = bz; }
+  void setMinParamChange(float x = 1e-3) { mMinParamChange = x > 1e-4 ? x : 1.e-4; }
+  void setMinRelChi2Change(float r = 0.9) { mMinRelChi2Change = r > 0.1 ? r : 999.; }
+  void setUseAbsDCA(bool v) { mUseAbsDCA = v; }
+
+  int getNCandidates() const { return mCurHyp; }
+  int getMaxIter() const { return mMaxIter; }
+  float getMaxR() const { return std::sqrt(mMaxR2); }
+  float getMaxDZIni() const { return mMaxDZIni; }
+  float getMaxChi2() const { return mMaxChi2; }
+  float getMinParamChange() const { return mMinParamChange; }
+  float getBz() const { return mBz; }
+  bool getUseAbsDCA() const { return mUseAbsDCA; }
+  bool getPropagateToPCA() const { mPropagateToPCA; }
+
+  template <class... Tr>
+  int process(const Tr&... args);
+  void print() const;
+
+ protected:
+  bool calcPCACoefs();
+  bool calcInverseWeight();
+  void calcResidDerivatives();
+  void calcResidDerivativesNoErr();
+  void calcRMatrices();
+  void calcChi2Derivatives();
+  void calcChi2DerivativesNoErr();
+  void calcPCA();
+  void calcPCANoErr();
+  void calcTrackResiduals();
+  void calcTrackDerivatives();
+  double calcChi2() const;
+  double calcChi2NoErr() const;
+  bool correctTracks(const VecND& corrX);
+  bool minimizeChi2();
+  bool minimizeChi2NoErr();
+  bool roughDZCut() const;
+  bool closerToAlternative() const;
+  static double getAbsMax(const VecND& v);
+
+  void assign(int) {}
+  template <class T, class... Tr>
+  void assign(int i, const T& t, const Tr&... args)
+  {
+    static_assert(std::is_convertible<T, Track>(), "Wrong track type");
+    mOrigTrPtr[i] = &t;
+    assign(i + 1, args...);
+  }
+
+  void clear() { mCurHyp = 0; }
+
+  static void setTrackPos(Vec3D& pnt, const Track& tr)
+  {
+    pnt[0] = tr.getX();
+    pnt[1] = tr.getY();
+    pnt[2] = tr.getZ();
+  }
+
+ private:
+  // vectors of 1st derivatives of track local residuals over X parameters
+  std::array<std::array<Vec3D, N>, N> mDResidDx;
+  // vectors of 1nd derivatives of track local residuals over X parameters
+  // (cross-derivatives DR/(dx_j*dx_k) = 0 for j!=k, therefore the hessian is diagonal)
+  std::array<std::array<Vec3D, N>, N> mD2ResidDx2;
+  VecND mDChi2Dx;      // 1st derivatives of chi2 over tracks X params
+  MatSymND mD2Chi2Dx2; // 2nd derivatives of chi2 over tracks X params (symmetric matrix)
+  MatSymND mCosDif;    // matrix with cos(alp_j-alp_i) for j<i
+  MatSymND mSinDif;    // matrix with sin(alp_j-alp_i) for j<i
+  std::array<const Track*, N> mOrigTrPtr;
+  std::array<TrackAuxPar, N> mTrAux; // Aux track info for each track at each cand. vertex
+  CircleCrossInfo mCrossings;        // info on track crossing
+
+  std::array<ArrTrackCovI, MAXHYP> mTrcEInv; // errors for each track at each cand. vertex
+  std::array<ArrTrack, MAXHYP> mCandTr;      // tracks at each cond. vertex (Note: Errors are at seed XY point)
+  std::array<ArrTrCoef, MAXHYP> mTrCFVT;     // TrackCoefVtx for each track at each cand. vertex
+  std::array<ArrTrDer, MAXHYP> mTrDer;       // Track derivativse
+  std::array<ArrTrPos, MAXHYP> mTrPos;       // Track positions
+  std::array<ArrTrPos, MAXHYP> mTrRes;       // Track residuals
+  std::array<Vec3D, MAXHYP> mPCA;            // PCA for each vertex candidate
+  std::array<float, MAXHYP> mChi2 = {0};     // Chi2 at PCA candidate
+  std::array<int, MAXHYP> mNIters;           // number of iterations for each seed
+  std::array<bool, MAXHYP> mTrPropDone;      // Flag that the tracks are fully propagated to PCA
+  MatSym3D mWeightInv;                       // inverse weight of single track, [sum{M^T E M}]^-1 in EQ.T
+  std::array<int, MAXHYP> mOrder{0};
+  int mCurHyp = 0;
+  int mCrossIDCur = 0;
+  int mCrossIDAlt = 1;
+  bool mUseAbsDCA = false;       // use abs. distance minimization rather than chi2
+  bool mPropagateToPCA = true;   // create tracks version propagated to PCA
+  int mMaxIter = 20;             // max number of iterations
+  float mBz = 0;                 // bz field, to be set by user
+  float mMaxR2 = 200. * 200.;    // reject PCA's above this radius
+  float mMaxDZIni = 4.;          // reject (if>0) PCA candidate if tracks DZ exceeds threshold
+  float mMinParamChange = 1e-3;  // stop iterations if largest change of any X is smaller than this
+  float mMinRelChi2Change = 0.9; // stop iterations is chi2/chi2old > this
+  float mMaxChi2 = 100;          // abs cut on chi2 or abs distance
+
+  ClassDefNV(DCAFitterN, 1);
+};
+
+///_________________________________________________________________________
+template <int N, typename... Args>
+template <class... Tr>
+int DCAFitterN<N, Args...>::process(const Tr&... args)
+{
+  // This is a main entry point: fit PCA of N tracks
+  static_assert(sizeof...(args) == N, "incorrect number of input tracks");
+  assign(0, args...);
+  clear();
+  for (int i = 0; i < N; i++) {
+    mTrAux[i].set(*mOrigTrPtr[i], mBz);
+  }
+  if (!mCrossings.set(mTrAux[0], mTrAux[1])) { // even for N>2 it should be enough to test just 1 loop
+    return 0;                                  // no crossing
+  }
+  if (mUseAbsDCA) {
+    calcRMatrices(); // needed for fast residuals derivatives calculation in case of abs. distance minimization
+  }
+  // check all crossings
+  for (int ic = 0; ic < mCrossings.nDCA; ic++) {
+    // check if radius is acceptable
+    if (mCrossings.xDCA[ic] * mCrossings.xDCA[ic] + mCrossings.yDCA[ic] * mCrossings.yDCA[ic] > mMaxR2) {
+      continue;
+    }
+    mCrossIDCur = ic;
+    mCrossIDAlt = mCrossings.nDCA == 2 ? 1 - ic : -1; // works for max 2 crossings
+    mNIters[mCurHyp] = 0;
+    mTrPropDone[mCurHyp] = false;
+    mChi2[mCurHyp] = -1.;
+    mPCA[mCurHyp][0] = mCrossings.xDCA[ic];
+    mPCA[mCurHyp][1] = mCrossings.yDCA[ic];
+
+    if (mUseAbsDCA ? minimizeChi2NoErr() : minimizeChi2()) {
+      mOrder[mCurHyp] = mCurHyp;
+      if (mPropagateToPCA && !propagateTracksToVertex(mCurHyp)) {
+        return false;
+      }
+      mCurHyp++;
+    }
+  }
+
+  for (int i = mCurHyp; i--;) { // order in quality
+    for (int j = i; j--;) {
+      if (mChi2[mOrder[i]] < mChi2[mOrder[j]]) {
+        std::swap(mOrder[i], mOrder[j]);
+      }
+    }
+  }
+  return mCurHyp;
+}
+
+//__________________________________________________________________________
+template <int N, typename... Args>
+bool DCAFitterN<N, Args...>::calcPCACoefs()
+{
+  //< calculate Ti matrices for global vertex decomposition to V = sum_{0<i<N} Ti pi, see EQ.T in the ref
+  if (!calcInverseWeight()) {
+    return false;
+  }
+  for (int i = N; i--;) { // build Mi*Ei matrix
+    const auto& taux = mTrAux[i];
+    const auto& tcov = mTrcEInv[mCurHyp][i];
+    MatStd3D miei;
+    miei[0][0] = taux.c * tcov.sxx;
+    miei[0][1] = -taux.s * tcov.syy;
+    miei[0][2] = -taux.s * tcov.syz;
+    miei[1][0] = taux.s * tcov.sxx;
+    miei[1][1] = taux.c * tcov.syy;
+    miei[1][2] = taux.c * tcov.syz;
+    //miei[2][0] = 0;
+    miei[2][1] = tcov.syz;
+    miei[2][2] = tcov.szz;
+    mTrCFVT[mCurHyp][i] = mWeightInv * miei;
+  }
+  return true;
+}
+
+//__________________________________________________________________________
+template <int N, typename... Args>
+bool DCAFitterN<N, Args...>::calcInverseWeight()
+{
+  //< calculate [sum_{0<j<N} M_j*E_j*M_j^T]^-1 used for Ti matrices, see EQ.T
+  auto* arrmat = mWeightInv.Array();
+  memset(arrmat, 0, sizeof(mWeightInv));
+  enum { XX,
+         XY,
+         YY,
+         XZ,
+         YZ,
+         ZZ };
+  for (int i = N; i--;) {
+    const auto& taux = mTrAux[i];
+    const auto& tcov = mTrcEInv[mCurHyp][i];
+    arrmat[XX] += taux.cc * tcov.sxx + taux.ss * tcov.syy;
+    arrmat[XY] += taux.cs * (tcov.sxx - tcov.syy);
+    arrmat[XZ] += -taux.s * tcov.syz;
+    arrmat[YY] += taux.cc * tcov.syy + taux.ss * tcov.sxx;
+    arrmat[YZ] += taux.c * tcov.syz;
+    arrmat[ZZ] += tcov.szz;
+  }
+  // invert 3x3 symmetrix matrix
+  return mWeightInv.Invert();
+}
+
+//__________________________________________________________________________
+template <int N, typename... Args>
+void DCAFitterN<N, Args...>::calcResidDerivatives()
+{
+  //< calculate matrix of derivatives for weighted chi2: residual i vs parameter X of track j
+  MatStd3D matMT;
+  for (int i = N; i--;) { // residual being differentiated
+    const auto& taux = mTrAux[i];
+    for (int j = N; j--;) {                   // track over which we differentiate
+      const auto& matT = mTrCFVT[mCurHyp][j]; // coefficient matrix for track J
+      const auto& trDx = mTrDer[mCurHyp][j];  // track point derivs over track X param
+      auto& dr1 = mDResidDx[i][j];
+      auto& dr2 = mD2ResidDx2[i][j];
+      // calculate M_i^tr * T_j
+      matMT[0][0] = taux.c * matT[0][0] + taux.s * matT[1][0];
+      matMT[0][1] = taux.c * matT[0][1] + taux.s * matT[1][1];
+      matMT[0][2] = taux.c * matT[0][2] + taux.s * matT[1][2];
+      matMT[1][0] = -taux.s * matT[0][0] + taux.c * matT[1][0];
+      matMT[1][1] = -taux.s * matT[0][1] + taux.c * matT[1][1];
+      matMT[1][2] = -taux.s * matT[0][2] + taux.c * matT[1][2];
+      matMT[2][0] = matT[2][0];
+      matMT[2][1] = matT[2][1];
+      matMT[2][2] = matT[2][2];
+
+      // calculate DResid_i/Dx_j = (delta_ij - M_i^tr * T_j) * DTrack_k/Dx_k
+      dr1[0] = -(matMT[0][0] + matMT[0][1] * trDx.dydx + matMT[0][2] * trDx.dzdx);
+      dr1[1] = -(matMT[1][0] + matMT[1][1] * trDx.dydx + matMT[1][2] * trDx.dzdx);
+      dr1[2] = -(matMT[2][0] + matMT[2][1] * trDx.dydx + matMT[2][2] * trDx.dzdx);
+
+      // calculate D2Resid_I/(Dx_J Dx_K) = (delta_ijk - M_i^tr * T_j * delta_jk) * D2Track_k/dx_k^2
+      dr2[0] = -(matMT[0][1] * trDx.d2ydx2 + matMT[0][2] * trDx.d2zdx2);
+      dr2[1] = -(matMT[1][1] * trDx.d2ydx2 + matMT[1][2] * trDx.d2zdx2);
+      dr2[2] = -(matMT[2][1] * trDx.d2ydx2 + matMT[2][2] * trDx.d2zdx2);
+
+      if (i == j) {
+        dr1[0] += 1.;
+        dr1[1] += trDx.dydx;
+        dr1[2] += trDx.dzdx;
+
+        dr2[1] += trDx.d2ydx2;
+        dr2[2] += trDx.d2zdx2;
+      }
+    } // track over which we differentiate
+  }   // residual being differentiated
+}
+
+//__________________________________________________________________________
+template <int N, typename... Args>
+void DCAFitterN<N, Args...>::calcResidDerivativesNoErr()
+{
+  //< calculate matrix of derivatives for absolute distance chi2: residual i vs parameter X of track j
+  constexpr double NInv1 = 1. - NInv;       // profit from Rii = I/Ninv
+  for (int i = N; i--;) {                   // residual being differentiated
+    const auto& trDxi = mTrDer[mCurHyp][i]; // track point derivs over track X param
+    auto& dr1ii = mDResidDx[i][i];
+    auto& dr2ii = mD2ResidDx2[i][i];
+    dr1ii[0] = NInv1;
+    dr1ii[1] = NInv1 * trDxi.dydx;
+    dr1ii[2] = NInv1 * trDxi.dzdx;
+
+    dr2ii[0] = 0;
+    dr2ii[1] = NInv1 * trDxi.d2ydx2;
+    dr2ii[2] = NInv1 * trDxi.d2zdx2;
+
+    for (int j = i; j--;) { // track over which we differentiate
+      auto& dr1ij = mDResidDx[i][j];
+      auto& dr1ji = mDResidDx[j][i];
+      const auto& trDxj = mTrDer[mCurHyp][j];        // track point derivs over track X param
+      auto cij = mCosDif[i][j], sij = mSinDif[i][j]; // M_i^T*M_j / N matrices non-trivial elements = {ci*cj+si*sj , si*cj-ci*sj }, see 5 in ref.
+
+      // calculate DResid_i/Dx_j = (delta_ij - R_ij) * DTrack_j/Dx_j  for j<i
+      dr1ij[0] = -(cij + sij * trDxj.dydx);
+      dr1ij[1] = -(-sij + cij * trDxj.dydx);
+      dr1ij[2] = -trDxj.dzdx * NInv;
+
+      // calculate DResid_j/Dx_i = (delta_ij - R_ji) * DTrack_i/Dx_i  for j<i
+      dr1ji[0] = -(cij - sij * trDxi.dydx);
+      dr1ji[1] = -(sij + cij * trDxi.dydx);
+      dr1ji[2] = -trDxi.dzdx * NInv;
+
+      auto& dr2ij = mD2ResidDx2[i][j];
+      auto& dr2ji = mD2ResidDx2[j][i];
+      // calculate D2Resid_I/(Dx_J Dx_K) = (delta_ij - Rij) * D2Track_j/dx_j^2 * delta_jk for j<i
+      dr2ij[0] = -sij * trDxj.d2ydx2;
+      dr2ij[1] = -cij * trDxj.d2ydx2;
+      dr2ij[2] = -trDxj.d2zdx2 * NInv;
+
+      // calculate D2Resid_j/(Dx_i Dx_k) = (delta_ij - Rji) * D2Track_i/dx_i^2 * delta_ik for j<i
+      dr2ji[0] = sij * trDxi.d2ydx2;
+      dr2ji[1] = -cij * trDxi.d2ydx2;
+      dr2ji[2] = -trDxi.d2zdx2 * NInv;
+
+    } // track over which we differentiate
+  }   // residual being differentiated
+}
+
+//__________________________________________________________________________
+template <int N, typename... Args>
+void DCAFitterN<N, Args...>::calcRMatrices()
+{
+  //< calculate Rij = 1/N M_i^T * M_j matrices (rotation from j-th track to i-th track frame)
+  for (int i = N; i--;) {
+    const auto& mi = mTrAux[i];
+    for (int j = i; j--;) {
+      const auto& mj = mTrAux[j];
+      mCosDif[i][j] = (mi.c * mj.c + mi.s * mj.s) * NInv; // cos(alp_i-alp_j) / N
+      mSinDif[i][j] = (mi.s * mj.c - mi.c * mj.s) * NInv; // sin(alp_i-alp_j) / N
+    }
+  }
+}
+
+//__________________________________________________________________________
+template <int N, typename... Args>
+void DCAFitterN<N, Args...>::calcChi2Derivatives()
+{
+  //< calculate 1st and 2nd derivatives of wighted DCA (chi2) over track parameters X, see EQ.Chi2 in the ref
+  std::array<std::array<Vec3D, N>, N> covIDrDx; // tempory vectors of covI_j * dres_j/dx_i
+
+  // chi2 1st derivative
+  for (int i = N; i--;) {
+    auto& dchi1 = mDChi2Dx[i]; // DChi2/Dx_i = sum_j { res_j * covI_j * Dres_j/Dx_i }
+    dchi1 = 0;
+    for (int j = N; j--;) {
+      const auto& res = mTrRes[mCurHyp][j];    // vector of residuals of track j
+      const auto& covI = mTrcEInv[mCurHyp][j]; // inverse cov matrix of track j
+      const auto& dr1 = mDResidDx[j][i];       // vector of j-th residuals 1st derivative over X param of track i
+      auto& cidr = covIDrDx[i][j];             // vector covI_j * dres_j/dx_i, save for 2nd derivative calculation
+      cidr[0] = covI.sxx * dr1[0];
+      cidr[1] = covI.syy * dr1[1] + covI.syz * dr1[2];
+      cidr[2] = covI.syz * dr1[1] + covI.szz * dr1[2];
+      // calculate res_i * covI_j * dres_j/dx_i
+      dchi1 += ROOT::Math::Dot(res, cidr);
+    }
+  }
+  // chi2 2nd derivative
+  for (int i = N; i--;) {
+    for (int j = i + 1; j--;) {       // symmetric matrix
+      auto& dchi2 = mD2Chi2Dx2[i][j]; // D2Chi2/Dx_i/Dx_j = sum_k { Dres_k/Dx_j * covI_k * Dres_k/Dx_i + res_k * covI_k * D2res_k/Dx_i/Dx_j }
+      dchi2 = 0;
+      for (int k = N; k--;) {
+        const auto& dr1j = mDResidDx[k][j];  // vector of k-th residuals 1st derivative over X param of track j
+        const auto& cidrkj = covIDrDx[i][k]; // vector covI_k * dres_k/dx_i
+        dchi2 += ROOT::Math::Dot(dr1j, cidrkj);
+        if (k == j) {
+          const auto& res = mTrRes[mCurHyp][k];    // vector of residuals of track k
+          const auto& covI = mTrcEInv[mCurHyp][k]; // inverse cov matrix of track k
+          const auto& dr2ij = mD2ResidDx2[k][j];   // vector of k-th residuals 2nd derivative over X params of track j
+          dchi2 += res[0] * covI.sxx * dr2ij[0] + res[1] * (covI.syy * dr2ij[1] + covI.syz * dr2ij[2]) + res[2] * (covI.syz * dr2ij[1] + covI.szz * dr2ij[2]);
+        }
+      }
+    }
+  }
+}
+
+//__________________________________________________________________________
+template <int N, typename... Args>
+void DCAFitterN<N, Args...>::calcChi2DerivativesNoErr()
+{
+  //< calculate 1st and 2nd derivatives of abs DCA (chi2) over track parameters X, see (6) in the ref
+  for (int i = N; i--;) {
+    auto& dchi1 = mDChi2Dx[i]; // DChi2/Dx_i = sum_j { res_j * Dres_j/Dx_i }
+    dchi1 = 0;                 // chi2 1st derivative
+    for (int j = N; j--;) {
+      const auto& res = mTrRes[mCurHyp][j]; // vector of residuals of track j
+      const auto& dr1 = mDResidDx[j][i];    // vector of j-th residuals 1st derivative over X param of track i
+      dchi1 += ROOT::Math::Dot(res, dr1);
+      if (i >= j) { // symmetrix matrix
+        // chi2 2nd derivative
+        auto& dchi2 = mD2Chi2Dx2[i][j]; // D2Chi2/Dx_i/Dx_j = sum_k { Dres_k/Dx_j * covI_k * Dres_k/Dx_i + res_k * covI_k * D2res_k/Dx_i/Dx_j }
+        dchi2 = ROOT::Math::Dot(mTrRes[mCurHyp][i], mD2ResidDx2[i][j]);
+        for (int k = N; k--;) {
+          dchi2 += ROOT::Math::Dot(mDResidDx[k][i], mDResidDx[k][j]);
+        }
+      }
+    }
+  }
+}
+
+//___________________________________________________________________
+template <int N, typename... Args>
+void DCAFitterN<N, Args...>::calcPCA()
+{
+  // calculate point of closest approach for N prongs
+  mPCA[mCurHyp] = mTrCFVT[mCurHyp][N - 1] * mTrPos[mCurHyp][N - 1];
+  for (int i = N - 1; i--;) {
+    mPCA[mCurHyp] += mTrCFVT[mCurHyp][i] * mTrPos[mCurHyp][i];
+  }
+}
+
+//___________________________________________________________________
+template <int N, typename... Args>
+void DCAFitterN<N, Args...>::calcPCANoErr()
+{
+  // calculate point of closest approach for N prongs w/o errors
+  auto& pca = mPCA[mCurHyp];
+  o2::utils::rotateZ(mTrPos[mCurHyp][N - 1][0], mTrPos[mCurHyp][N - 1][1], pca[0], pca[1], mTrAux[N - 1].s, mTrAux[N - 1].c);
+  //RRRR    mTrAux[N-1].loc2glo(mTrPos[mCurHyp][N-1][0], mTrPos[mCurHyp][N-1][1], pca[0], pca[1] );
+  pca[2] = mTrPos[mCurHyp][N - 1][2];
+  for (int i = N - 1; i--;) {
+    double x, y;
+    o2::utils::rotateZ(mTrPos[mCurHyp][i][0], mTrPos[mCurHyp][i][1], x, y, mTrAux[i].s, mTrAux[i].c);
+    //RRRR mTrAux[i].loc2glo(mTrPos[mCurHyp][i][0], mTrPos[mCurHyp][i][1], x, y );
+    pca[0] += x;
+    pca[1] += y;
+    pca[2] += mTrPos[mCurHyp][i][2];
+  }
+  pca[0] *= NInv;
+  pca[1] *= NInv;
+  pca[2] *= NInv;
+}
+
+//___________________________________________________________________
+template <int N, typename... Args>
+void DCAFitterN<N, Args...>::calcTrackResiduals()
+{
+  // calculate residuals
+  Vec3D vtxLoc;
+  for (int i = N; i--;) {
+    mTrRes[mCurHyp][i] = mTrPos[mCurHyp][i];
+    vtxLoc = mPCA[mCurHyp];
+    o2::utils::rotateZInv(vtxLoc[0], vtxLoc[1], vtxLoc[0], vtxLoc[1], mTrAux[i].s, mTrAux[i].c); // glo->loc
+    mTrRes[mCurHyp][i] -= vtxLoc;
+  }
+}
+
+//___________________________________________________________________
+template <int N, typename... Args>
+inline void DCAFitterN<N, Args...>::calcTrackDerivatives()
+{
+  // calculate track derivatives over X param
+  for (int i = N; i--;) {
+    mTrDer[mCurHyp][i].set(mCandTr[mCurHyp][i], mBz);
+  }
+}
+
+//___________________________________________________________________
+template <int N, typename... Args>
+inline double DCAFitterN<N, Args...>::calcChi2() const
+{
+  // calculate current chi2
+  double chi2 = 0;
+  for (int i = N; i--;) {
+    const auto& res = mTrRes[mCurHyp][i];
+    const auto& covI = mTrcEInv[mCurHyp][i];
+    chi2 += res[0] * res[0] * covI.sxx + res[1] * res[1] * covI.syy + res[2] * res[2] * covI.szz + 2. * res[1] * res[2] * covI.syz;
+  }
+  return chi2;
+}
+
+//___________________________________________________________________
+template <int N, typename... Args>
+inline double DCAFitterN<N, Args...>::calcChi2NoErr() const
+{
+  // calculate current chi2 of abs. distance minimization
+  double chi2 = 0;
+  for (int i = N; i--;) {
+    const auto& res = mTrRes[mCurHyp][i];
+    chi2 += res[0] * res[0] + res[1] * res[1] + res[2] * res[2];
+  }
+  return chi2;
+}
+
+//___________________________________________________________________
+template <int N, typename... Args>
+bool DCAFitterN<N, Args...>::correctTracks(const VecND& corrX)
+{
+  // propagate tracks to updated X
+  for (int i = N; i--;) {
+    const auto& trDer = mTrDer[mCurHyp][i];
+    auto dx2h = 0.5 * corrX[i] * corrX[i];
+    mTrPos[mCurHyp][i][0] -= corrX[i];
+    mTrPos[mCurHyp][i][1] -= trDer.dydx * corrX[i] - dx2h * trDer.d2ydx2;
+    mTrPos[mCurHyp][i][2] -= trDer.dzdx * corrX[i] - dx2h * trDer.d2zdx2;
+  }
+  return true;
+}
+
+//___________________________________________________________________
+template <int N, typename... Args>
+bool DCAFitterN<N, Args...>::propagateTracksToVertex(int icand)
+{
+  // propagate tracks to current vertex
+  int ord = mOrder[icand];
+  if (mTrPropDone[ord]) {
+    return true;
+  }
+  const Vec3D& pca = mPCA[ord];
+  for (int i = N; i--;) {
+    if (mUseAbsDCA) {
+      mCandTr[ord][i] = *mOrigTrPtr[i]; // fetch the track again, as mCandTr might have been propagated w/o errors
+    }
+    auto& trc = mCandTr[ord][i];
+    auto x = mTrAux[i].c * pca[0] + mTrAux[i].s * pca[1]; // X of PCA in the track frame
+    if (!trc.propagateTo(x, mBz)) {
+      return false;
+    }
+  }
+  mTrPropDone[ord] = true;
+  return true;
+}
+
+//___________________________________________________________________
+template <int N, typename... Args>
+inline double DCAFitterN<N, Args...>::getAbsMax(const VecND& v)
+{
+  double mx = -1;
+  for (int i = N; i--;) {
+    auto vai = std::abs(v[i]);
+    if (mx < vai) {
+      mx = vai;
+    }
+  }
+  return mx;
+}
+
+//___________________________________________________________________
+template <int N, typename... Args>
+bool DCAFitterN<N, Args...>::minimizeChi2()
+{
+  // find best chi2 (weighted DCA) of N tracks in the vicinity of the seed PCA
+  for (int i = N; i--;) {
+    mCandTr[mCurHyp][i] = *mOrigTrPtr[i];
+    auto x = mTrAux[i].c * mPCA[mCurHyp][0] + mTrAux[i].s * mPCA[mCurHyp][1]; // X of PCA in the track frame
+    if (!mCandTr[mCurHyp][i].propagateTo(x, mBz)) {
+      return false;
+    }
+    setTrackPos(mTrPos[mCurHyp][i], mCandTr[mCurHyp][i]); // prepare positions
+    mTrcEInv[mCurHyp][i].set(mCandTr[mCurHyp][i]);        // prepare inverse cov.matrices at starting point
+  }
+
+  if (mMaxDZIni > 0 && !roughDZCut()) { // apply rough cut on tracks Z difference
+    return false;
+  }
+
+  if (!calcPCACoefs()) { // prepare tracks contribution matrices to the global PCA
+    return false;
+  }
+  calcPCA();            // current PCA
+  calcTrackResiduals(); // current track residuals
+  float chi2Upd, chi2 = calcChi2();
+  do {
+    calcTrackDerivatives(); // current track derivatives (1st and 2nd)
+    calcResidDerivatives(); // current residals derivatives (1st and 2nd)
+    calcChi2Derivatives();  // current chi2 derivatives (1st and 2nd)
+
+    // do Newton-Rapson iteration with corrections = - dchi2/d{x0..xN} * [ d^2chi2/d{x0..xN}^2 ]^-1
+    if (!mD2Chi2Dx2.Invert()) {
+      LOG(ERROR) << "InversionFailed";
+      return false;
+    }
+    VecND dx = mD2Chi2Dx2 * mDChi2Dx;
+    if (!correctTracks(dx)) {
+      return false;
+    }
+    calcPCA(); // updated PCA
+    if (mCrossIDAlt >= 0 && closerToAlternative()) {
+      return false;
+    }
+    calcTrackResiduals(); // updated residuals
+    chi2Upd = calcChi2(); // updated chi2
+    if (getAbsMax(dx) < mMinParamChange || chi2Upd > chi2 * mMinRelChi2Change) {
+      chi2 = chi2Upd;
+      break; // converged
+    }
+    chi2 = chi2Upd;
+  } while (++mNIters[mCurHyp] < mMaxIter);
+  //
+  mChi2[mCurHyp] = chi2 * NInv;
+  return mChi2[mCurHyp] < mMaxChi2;
+}
+
+//___________________________________________________________________
+template <int N, typename... Args>
+bool DCAFitterN<N, Args...>::minimizeChi2NoErr()
+{
+  // find best chi2 (absolute DCA) of N tracks in the vicinity of the PCA seed
+
+  for (int i = N; i--;) {
+    mCandTr[mCurHyp][i] = *mOrigTrPtr[i];
+    auto x = mTrAux[i].c * mPCA[mCurHyp][0] + mTrAux[i].s * mPCA[mCurHyp][1]; // X of PCA in the track frame
+    if (!mCandTr[mCurHyp][i].propagateParamTo(x, mBz)) {
+      return false;
+    }
+    setTrackPos(mTrPos[mCurHyp][i], mCandTr[mCurHyp][i]); // prepare positions
+  }
+  if (mMaxDZIni > 0 && !roughDZCut()) { // apply rough cut on tracks Z difference
+    return false;
+  }
+
+  calcPCANoErr();       // current PCA
+  calcTrackResiduals(); // current track residuals
+  float chi2Upd, chi2 = calcChi2NoErr();
+  do {
+    calcTrackDerivatives();      // current track derivatives (1st and 2nd)
+    calcResidDerivativesNoErr(); // current residals derivatives (1st and 2nd)
+    calcChi2DerivativesNoErr();  // current chi2 derivatives (1st and 2nd)
+
+    // do Newton-Rapson iteration with corrections = - dchi2/d{x0..xN} * [ d^2chi2/d{x0..xN}^2 ]^-1
+    if (!mD2Chi2Dx2.Invert()) {
+      LOG(ERROR) << "InversionFailed";
+      return false;
+    }
+    VecND dx = mD2Chi2Dx2 * mDChi2Dx;
+    if (!correctTracks(dx)) {
+      return false;
+    }
+    calcPCANoErr(); // updated PCA
+    if (mCrossIDAlt >= 0 && closerToAlternative()) {
+      return false;
+    }
+    calcTrackResiduals();      // updated residuals
+    chi2Upd = calcChi2NoErr(); // updated chi2
+    if (getAbsMax(dx) < mMinParamChange || chi2Upd > chi2 * mMinRelChi2Change) {
+      chi2 = chi2Upd;
+      break; // converged
+    }
+    chi2 = chi2Upd;
+  } while (++mNIters[mCurHyp] < mMaxIter);
+  //
+  mChi2[mCurHyp] = chi2 * NInv;
+  return mChi2[mCurHyp] < mMaxChi2;
+}
+
+//___________________________________________________________________
+template <int N, typename... Args>
+bool DCAFitterN<N, Args...>::roughDZCut() const
+{
+  // apply rough cut on DZ between the tracks in the seed point
+  bool accept = true;
+  for (int i = N; accept && i--;) {
+    for (int j = i; j--;) {
+      if (std::abs(mCandTr[mCurHyp][i].getZ() - mCandTr[mCurHyp][j].getZ()) > mMaxDZIni) {
+        accept = false;
+        break;
+      }
+    }
+  }
+  return accept;
+}
+
+//___________________________________________________________________
+template <int N, typename... Args>
+bool DCAFitterN<N, Args...>::closerToAlternative() const
+{
+  // check if the point current PCA point is closer to the seeding XY point being tested or to alternative see (if any)
+  auto dxCur = mPCA[mCurHyp][0] - mCrossings.xDCA[mCrossIDCur], dyCur = mPCA[mCurHyp][1] - mCrossings.yDCA[mCrossIDCur];
+  auto dxAlt = mPCA[mCurHyp][0] - mCrossings.xDCA[mCrossIDAlt], dyAlt = mPCA[mCurHyp][1] - mCrossings.yDCA[mCrossIDAlt];
+  return dxCur * dxCur + dyCur * dyCur > dxAlt * dxAlt + dyAlt * dyAlt;
+}
+
+//___________________________________________________________________
+template <int N, typename... Args>
+void DCAFitterN<N, Args...>::print() const
+{
+  LOG(INFO) << N << "-prong vertex fitter in " << (mUseAbsDCA ? "abs." : "weighted") << " distance minimization mode";
+  LOG(INFO) << "Bz: " << mBz << " MaxIter: " << mMaxIter << " MaxChi2: " << mMaxChi2;
+  LOG(INFO) << "Stopping condition: Max.param change < " << mMinParamChange << " Rel.Chi2 change > " << mMinRelChi2Change;
+  LOG(INFO) << "Discard candidates for : Rvtx > " << getMaxR() << " DZ between tracks > " << mMaxDZIni;
+}
+
+using DCAFitter2 = DCAFitterN<2, o2::track::TrackParCov>;
+using DCAFitter3 = DCAFitterN<3, o2::track::TrackParCov>;
+
+} // namespace vertexing
+} // namespace o2
+#endif // _ALICEO2_DCA_FITTERN_

--- a/Detectors/Vertexing/include/DetectorsVertexing/HelixHelper.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/HelixHelper.h
@@ -1,0 +1,130 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file HelixHelper.h
+/// \brief Helper classes for helical tracks manipulations
+/// \author ruben.shahoyan@cern.ch
+
+#ifndef _ALICEO2_HELIX_HELPER_
+#define _ALICEO2_HELIX_HELPER_
+
+#include "MathUtils/Primitive2D.h"
+#include "ReconstructionDataFormats/Track.h"
+
+namespace o2
+{
+namespace track
+{
+
+///__________________________________________________________________________
+//< precalculated track radius, center, alpha sin,cos and their combinations
+struct TrackAuxPar : public o2::utils::CircleXY {
+  using Track = o2::track::TrackPar;
+
+  float c, s, cc, ss, cs; // cos ans sin of track alpha and their products
+
+  TrackAuxPar() = default;
+  TrackAuxPar(const Track& trc, float bz) { set(trc, bz); }
+  float cosDif(const TrackAuxPar& t) const { return c * t.c + s * t.s; } // cos(alpha_this - alha_t)
+  float sinDif(const TrackAuxPar& t) const { return s * t.c - c * t.s; } // sin(alpha_this - alha_t)
+  void set(const Track& trc, float bz)
+  {
+    trc.getCircleParams(bz, *this, s, c);
+    cc = c * c;
+    ss = s * s;
+    cs = c * s;
+  }
+};
+
+//__________________________________________________________
+//< crossing coordinates of 2 circles
+struct CircleCrossInfo {
+  float xDCA[2];
+  float yDCA[2];
+  int nDCA;
+
+  CircleCrossInfo() = default;
+
+  CircleCrossInfo(const TrackAuxPar& trc0, const TrackAuxPar& trc1) { set(trc0, trc1); }
+  int set(const TrackAuxPar& trc0, const TrackAuxPar& trc1)
+  {
+    // calculate up to 2 crossings between 2 circles
+    nDCA = 0;
+    const auto& trcA = trc0.rC > trc1.rC ? trc0 : trc1; // designate the largest circle as A
+    const auto& trcB = trc0.rC > trc1.rC ? trc1 : trc0;
+    float xDist = trcB.xC - trcA.xC, yDist = trcB.yC - trcA.yC;
+    float dist2 = xDist * xDist + yDist * yDist, dist = std::sqrt(dist2), rsum = trcA.rC + trcB.rC;
+    if (std::abs(dist) < 1e-12) {
+      return nDCA; // circles are concentric?
+    }
+    if (dist > rsum) { // circles don't touch, chose a point in between
+      // the parametric equation of lines connecting the centers is
+      // x = x0 + t/dist * (x1-x0), y = y0 + t/dist * (y1-y0)
+      notTouchingXY(dist, xDist, yDist, trcA, trcB.rC);
+    } else if (dist + trcB.rC < trcA.rC) { // the small circle is nestled into large one w/o touching
+      // select the point of closest approach of 2 circles
+      notTouchingXY(dist, xDist, yDist, trcA, -trcB.rC);
+    } else { // 2 intersection points
+      // to simplify calculations, we move to new frame x->x+Xc0, y->y+Yc0, so that
+      // the 1st one is centered in origin
+      if (std::abs(xDist) < std::abs(yDist)) {
+        float a = (trcA.rC * trcA.rC - trcB.rC * trcB.rC + dist2) / (2. * yDist), b = -xDist / yDist, ab = a * b, bb = b * b;
+        float det = ab * ab - (1. + bb) * (a * a - trcA.rC * trcA.rC);
+        if (det > 0.) {
+          det = std::sqrt(det);
+          xDCA[0] = (-ab + det) / (1. + b * b);
+          yDCA[0] = a + b * xDCA[0] + trcA.yC;
+          xDCA[0] += trcA.xC;
+          xDCA[1] = (-ab - det) / (1. + b * b);
+          yDCA[1] = a + b * xDCA[1] + trcA.yC;
+          xDCA[1] += trcA.xC;
+          nDCA = 2;
+        } else { // due to the finite precision the det<=0, i.e. the circles are barely touching, fall back to this special case
+          notTouchingXY(dist, xDist, yDist, trcA, trcB.rC);
+        }
+      } else {
+        float a = (trcA.rC * trcA.rC - trcB.rC * trcB.rC + dist2) / (2. * xDist), b = -yDist / xDist, ab = a * b, bb = b * b;
+        float det = ab * ab - (1. + bb) * (a * a - trcA.rC * trcA.rC);
+        if (det > 0.) {
+          det = std::sqrt(det);
+          yDCA[0] = (-ab + det) / (1. + bb);
+          xDCA[0] = a + b * yDCA[0] + trcA.xC;
+          yDCA[0] += trcA.yC;
+          yDCA[1] = (-ab - det) / (1. + bb);
+          xDCA[1] = a + b * yDCA[1] + trcA.xC;
+          yDCA[1] += trcA.yC;
+          nDCA = 2;
+        } else { // due to the finite precision the det<=0, i.e. the circles are barely touching, fall back to this special case
+          notTouchingXY(dist, xDist, yDist, trcA, trcB.rC);
+        }
+      }
+    }
+    return nDCA;
+  }
+
+  void notTouchingXY(float dist, float xDist, float yDist, const TrackAuxPar& trcA, float rBSign)
+  {
+    // fast method to calculate DCA between 2 circles, assuming that they don't touch each outer:
+    // the parametric equation of lines connecting the centers is x = xA + t/dist * xDist, y = yA + t/dist * yDist
+    // with xA,yY being the center of the circle A ( = trcA.xC, trcA.yC ), xDist = trcB.xC = trcA.xC ...
+    // There are 2 special cases:
+    // (a) small circle is inside the large one: provide rBSign as -trcB.rC
+    // (b) circle are side by side: provide rBSign as trcB.rC
+    nDCA = 1;
+    auto t2d = (dist + trcA.rC - rBSign) / dist;
+    xDCA[0] = trcA.xC + 0.5 * (xDist * t2d);
+    yDCA[0] = trcA.yC + 0.5 * (yDist * t2d);
+  }
+};
+
+} // namespace track
+} // namespace o2
+
+#endif

--- a/Detectors/Vertexing/src/DCAFitterN.cxx
+++ b/Detectors/Vertexing/src/DCAFitterN.cxx
@@ -1,0 +1,32 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file DCAFitterN.cxx
+/// \brief Defintions for N-prongs secondary vertex fit
+/// \author ruben.shahoyan@cern.ch
+
+#include "DetectorsVertexing/DCAFitterN.h"
+
+namespace o2
+{
+namespace vertexing
+{
+
+void __dummy_instance__()
+{
+  DCAFitter2 ft2;
+  DCAFitter3 ft3;
+  o2::track::TrackParCov tr;
+  ft2.process(tr, tr);
+  ft3.process(tr, tr, tr);
+}
+
+} // namespace vertexing
+} // namespace o2

--- a/Detectors/Vertexing/src/VertexingLinkDef.h
+++ b/Detectors/Vertexing/src/VertexingLinkDef.h
@@ -1,0 +1,25 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifdef __CLING__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+// this aliase are defined in the DCAFitterN.h as o2::vertexing::DCAFitterN<2,o2::track::TrackParCov>
+#pragma link C++ class o2::vertexing::DCAFitter2 + ;
+// this aliase are defined in the DCAFitterN.h as o2::vertexing::DCAFitterN<3,o2::track::TrackParCov>
+#pragma link C++ class o2::vertexing::DCAFitter3 + ;
+
+#pragma link C++ function o2::vertexing::DCAFitter2::process(const o2::track::TrackParCov&, const o2::track::TrackParCov&);
+#pragma link C++ function o2::vertexing::DCAFitter3::process(const o2::track::TrackParCov&, const o2::track::TrackParCov&, const o2::track::TrackParCov&);
+
+#endif

--- a/Detectors/Vertexing/test/testDCAFitterN.cxx
+++ b/Detectors/Vertexing/test/testDCAFitterN.cxx
@@ -1,0 +1,264 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test DCAFitterN class
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+
+#include "DetectorsVertexing/DCAFitterN.h"
+#include "CommonUtils/TreeStreamRedirector.h"
+#include <TRandom.h>
+#include <TGenPhaseSpace.h>
+#include <TLorentzVector.h>
+#include <TStopwatch.h>
+#include <Math/SVector.h>
+#include <array>
+
+namespace o2
+{
+namespace vertexing
+{
+
+using Vec3D = ROOT::Math::SVector<double, 3>;
+
+template <class FITTER>
+float checkResults(o2::utils::TreeStreamRedirector& outs, std::string& treeName, const FITTER& fitter,
+                   Vec3D& vgen, TLorentzVector& genPar, const std::vector<double>& dtMass)
+{
+  int nCand = fitter.getNCandidates();
+  std::array<float, 3> p;
+  float distMin = 1e9;
+  for (int ic = 0; ic < nCand; ic++) {
+    const auto& vtx = fitter.getPCACandidate(ic);
+    auto df = vgen;
+    df -= vtx;
+
+    TLorentzVector moth, prong;
+    for (int i = 0; i < fitter.getNProngs(); i++) {
+      const auto& trc = fitter.getTrack(i, ic);
+      trc.getPxPyPzGlo(p);
+      prong.SetVectM({p[0], p[1], p[2]}, dtMass[i]);
+      moth += prong;
+    }
+    auto nIter = fitter.getNIterations(ic);
+    auto chi2 = fitter.getChi2AtPCACandidate(ic);
+    double dst = TMath::Sqrt(df[0] * df[0] + df[1] * df[1] + df[2] * df[2]);
+    distMin = dst < distMin ? dst : distMin;
+    //    float genX
+    outs << treeName.c_str() << "cand=" << ic << "ncand=" << nCand << "nIter=" << nIter << "chi2=" << chi2
+         << "genPart=" << genPar << "recPart=" << moth
+         << "genX=" << vgen[0] << "genY=" << vgen[1] << "genZ=" << vgen[2]
+         << "dx=" << df[0] << "dy=" << df[1] << "dz=" << df[2] << "dst=" << dst << "\n";
+  }
+  return distMin;
+}
+
+TLorentzVector generate(Vec3D& vtx, std::vector<o2::track::TrackParCov>& vctr, float bz,
+                        TGenPhaseSpace& genPHS, double parMass, const std::vector<double>& dtMass)
+{
+  const float errYZ = 1e-2, errSlp = 1e-3, errQPT = 2e-2;
+  std::array<float, 15> covm = {
+    errYZ * errYZ,
+    0., errYZ * errYZ,
+    0, 0., errSlp * errSlp,
+    0., 0., 0., errSlp * errSlp,
+    0., 0., 0., 0., errQPT * errQPT};
+  bool accept = true;
+  TLorentzVector parent, d0, d1, d2;
+  do {
+    accept = true;
+    double y = gRandom->Rndm() - 0.5;
+    double pt = 0.1 + gRandom->Rndm() * 3;
+    double mt = TMath::Sqrt(parMass * parMass + pt * pt);
+    double pz = mt * TMath::SinH(y);
+    double phi = gRandom->Rndm() * TMath::Pi() * 2;
+    double en = mt * TMath::CosH(y);
+    double rdec = 10.; // radius of the decay
+    vtx[0] = rdec * TMath::Cos(phi);
+    vtx[1] = rdec * TMath::Sin(phi);
+    vtx[2] = rdec * pz / pt;
+    parent.SetPxPyPzE(pt * TMath::Cos(phi), pt * TMath::Sin(phi), pz, en);
+    int nd = dtMass.size();
+    genPHS.SetDecay(parent, nd, dtMass.data());
+    genPHS.Generate();
+    vctr.clear();
+    float p[4];
+    for (int i = 0; i < nd; i++) {
+      auto* dt = genPHS.GetDecay(i);
+      if (dt->Pt() < 0.05) {
+        accept = false;
+        break;
+      }
+      dt->GetXYZT(p);
+      float s, c, x;
+      std::array<float, 5> params;
+      o2::utils::sincosf(dt->Phi(), s, c);
+      o2::utils::rotateZInv(vtx[0], vtx[1], x, params[0], s, c);
+
+      params[1] = vtx[2];
+      params[2] = 0.; // since alpha = phi
+      params[3] = 1. / TMath::Tan(dt->Theta());
+      params[4] = (i % 2 ? -1. : 1.) / dt->Pt();
+      covm[14] = errQPT * errQPT * params[4] * params[4];
+      //
+      // randomize
+      float r1, r2;
+      gRandom->Rannor(r1, r2);
+      params[0] += r1 * errYZ;
+      params[1] += r2 * errYZ;
+      gRandom->Rannor(r1, r2);
+      params[2] += r1 * errSlp;
+      params[3] += r2 * errSlp;
+      params[4] *= gRandom->Gaus(1., errQPT);
+      auto& trc = vctr.emplace_back(x, dt->Phi(), params, covm);
+      if (!trc.propagateTo(trc.getX() + (gRandom->Rndm() - 0.5) * TMath::Abs(1. / trc.getCurvature(bz)) * 0.05, bz) ||
+          !trc.rotate(trc.getAlpha() + (gRandom->Rndm() - 0.5) * 0.2)) {
+        printf("Failed to randomize ");
+        trc.print();
+      }
+    }
+  } while (!accept);
+
+  return parent;
+}
+
+BOOST_AUTO_TEST_CASE(DCAFitterNProngs)
+{
+  constexpr int NTest = 10000;
+  o2::utils::TreeStreamRedirector outStream("dcafitterNTest.root");
+
+  TGenPhaseSpace genPHS;
+  constexpr double pion = 0.13957;
+  constexpr double k0 = 0.49761;
+  constexpr double kch = 0.49368;
+  constexpr double dch = 1.86965;
+  std::vector<double> k0dec = {pion, pion};
+  std::vector<double> dchdec = {pion, kch, pion};
+  std::vector<o2::track::TrackParCov> vctracks;
+  Vec3D vtxGen;
+
+  double bz = 5.0;
+
+  // 2 prongs vertices
+  {
+    o2::vertexing::DCAFitterN<2> ft; // 2 prong fitter
+    ft.setBz(bz);
+    ft.setPropagateToPCA(true);  // After finding the vertex, propagate tracks to the DCA. This is default anyway
+    ft.setMaxR(200);             // do not consider V0 seeds with 2D circles crossing above this R. This is default anyway
+    ft.setMaxDZIni(4);           // do not consider V0 seeds with tracks Z-distance exceeding this. This is default anyway
+    ft.setMinParamChange(1e-3);  // stop iterations if max correction is below this value. This is default anyway
+    ft.setMinRelChi2Change(0.9); // stop iterations if chi2 improves by less that this factor
+
+    std::string treeName2A = "pr2a", treeName2W = "pr2w";
+    TStopwatch swA, swW;
+    int nfoundA = 0, nfoundW = 0;
+    double meanDA = 0, meanDW = 0;
+    swA.Stop();
+    swW.Stop();
+    for (int iev = 0; iev < NTest; iev++) {
+      auto genParent = generate(vtxGen, vctracks, bz, genPHS, k0, k0dec);
+
+      ft.setUseAbsDCA(true);
+      swA.Start(false);
+      int ncA = ft.process(vctracks[0], vctracks[1]); // HERE WE FIT THE VERTICES
+      swA.Stop();
+      LOG(DEBUG) << "fit abs.dist " << iev << " NC: " << ncA << " Chi2: " << (ncA ? ft.getChi2AtPCACandidate(0) : -1);
+      if (ncA) {
+        auto minD = checkResults(outStream, treeName2A, ft, vtxGen, genParent, k0dec);
+        meanDA += minD;
+        nfoundA++;
+      }
+
+      ft.setUseAbsDCA(false);
+      swW.Start(false);
+      int ncW = ft.process(vctracks[0], vctracks[1]); // HERE WE FIT THE VERTICES
+      swW.Stop();
+      LOG(DEBUG) << "fit wgh.dist " << iev << " NC: " << ncW << " Chi2: " << (ncW ? ft.getChi2AtPCACandidate(0) : -1);
+      if (ncW) {
+        auto minD = checkResults(outStream, treeName2W, ft, vtxGen, genParent, k0dec);
+        meanDW += minD;
+        nfoundW++;
+      }
+    }
+    ft.print();
+    meanDA /= nfoundA ? nfoundA : 1;
+    meanDW /= nfoundW ? nfoundW : 1;
+    LOG(INFO) << "Processed " << NTest << " 2-prong vertices";
+    LOG(INFO) << "2-prongs with abs.dist minization: eff= " << float(nfoundA) / NTest
+              << " mean.dist to truth: " << meanDA << " CPU time: " << swA.CpuTime();
+    LOG(INFO) << "2-prongs with wgh.dist minization: eff= " << float(nfoundW) / NTest
+              << " mean.dist to truth: " << meanDW << " CPU time: " << swW.CpuTime();
+    BOOST_CHECK(nfoundA > 0.99 * NTest);
+    BOOST_CHECK(nfoundW > 0.99 * NTest);
+    BOOST_CHECK(meanDA < 0.1);
+    BOOST_CHECK(meanDW < 0.1);
+  }
+
+  // 3 prongs vertices
+  {
+    o2::vertexing::DCAFitterN<3> ft; // 3 prong fitter
+    ft.setBz(bz);
+    ft.setPropagateToPCA(true);  // After finding the vertex, propagate tracks to the DCA. This is default anyway
+    ft.setMaxR(200);             // do not consider V0 seeds with 2D circles crossing above this R. This is default anyway
+    ft.setMaxDZIni(4);           // do not consider V0 seeds with tracks Z-distance exceeding this. This is default anyway
+    ft.setMinParamChange(1e-3);  // stop iterations if max correction is below this value. This is default anyway
+    ft.setMinRelChi2Change(0.9); // stop iterations if chi2 improves by less that this factor
+
+    std::string treeName3A = "pr3a", treeName3W = "pr3w";
+    TStopwatch swA, swW;
+    int nfoundA = 0, nfoundW = 0;
+    double meanDA = 0, meanDW = 0;
+    swA.Stop();
+    swW.Stop();
+    for (int iev = 0; iev < NTest; iev++) {
+      auto genParent = generate(vtxGen, vctracks, bz, genPHS, dch, dchdec);
+
+      ft.setUseAbsDCA(true);
+      swA.Start(false);
+      int ncA = ft.process(vctracks[0], vctracks[1], vctracks[2]); // HERE WE FIT THE VERTICES
+      swA.Stop();
+      LOG(DEBUG) << "fit abs.dist " << iev << " NC: " << ncA << " Chi2: " << (ncA ? ft.getChi2AtPCACandidate(0) : -1);
+      if (ncA) {
+        auto minD = checkResults(outStream, treeName3A, ft, vtxGen, genParent, dchdec);
+        meanDA += minD;
+        nfoundA++;
+      }
+
+      ft.setUseAbsDCA(false);
+      swW.Start(false);
+      int ncW = ft.process(vctracks[0], vctracks[1], vctracks[2]); // HERE WE FIT THE VERTICES
+      swW.Stop();
+      LOG(DEBUG) << "fit wgh.dist " << iev << " NC: " << ncW << " Chi2: " << (ncW ? ft.getChi2AtPCACandidate(0) : -1);
+      if (ncW) {
+        auto minD = checkResults(outStream, treeName3W, ft, vtxGen, genParent, dchdec);
+        meanDW += minD;
+        nfoundW++;
+      }
+    }
+    ft.print();
+    meanDA /= nfoundA ? nfoundA : 1;
+    meanDW /= nfoundW ? nfoundW : 1;
+    LOG(INFO) << "Processed " << NTest << " 3-prong vertices";
+    LOG(INFO) << "3-prongs with abs.dist minization: eff= " << float(nfoundA) / NTest
+              << " mean.dist to truth: " << meanDA << " CPU time: " << swA.CpuTime();
+    LOG(INFO) << "3-prongs with wgh.dist minization: eff= " << float(nfoundW) / NTest
+              << " mean.dist to truth: " << meanDW << " CPU time: " << swW.CpuTime();
+    BOOST_CHECK(nfoundA > 0.9 * NTest);
+    BOOST_CHECK(nfoundW > 0.9 * NTest);
+    BOOST_CHECK(meanDA < 0.1);
+    BOOST_CHECK(meanDW < 0.1);
+  }
+
+  outStream.Close();
+}
+
+} // namespace vertexing
+} // namespace o2


### PR DESCRIPTION
@ginnocen this is the arbitrary N-prong fitter (if you need N>3, let me know, will change the parameter). The see the Detectors/Base/README for details: the interface is essentially the same, just to get the tracks instead of ``getTrack0()`` , ``getTrack1()`` you should use ``getTrack(0)`` or ``getTrack(1)`` ...

I did not modify you vertexing class to account for the change since this would create a conflict with https://github.com/AliceO2Group/AliceO2/pull/3055 but eventually the current ``DCAFitter`` should be changed by ``DCAFitterN<2>``. Let me know if you want me to do this change, eventually, the old class should be eliminated.

At the moment there is a small instability (present also in the old DCAFitter) sometimes affecting the convergence efficiency (per-mille level for 2 prongs, %-level for 3 prongs), but otherwise, the classes are usable.