### PR TITLE
A few improvements to DPL InputRecord

### DIFF
--- a/Framework/Core/include/Framework/InputRecord.h
+++ b/Framework/Core/include/Framework/InputRecord.h
@@ -183,7 +183,7 @@ class InputRecord
 
   size_t getNofParts(int pos) const
   {
-    if (pos < 0) {
+    if (pos < 0 || pos >= mSpan.size()) {
       return 0;
     }
     return mSpan.getNofParts(pos);
@@ -226,7 +226,7 @@ class InputRecord
   /// incoming data. See @ref Inputrecord class description for supported types.
   /// @param ref   DataRef with pointers to input spec, header, and payload
   template <typename T>
-  decltype(auto) get(DataRef ref) const
+  static decltype(auto) get(DataRef ref)
   {
     if constexpr (std::is_same<T, std::string>::value) {
       // substitution for std::string
@@ -468,7 +468,7 @@ class InputRecord
         if (mParent->isValid(mPosition)) {
           mElement = mParent->getByPos(mPosition);
         } else {
-          (*this)++;
+          ++(*this);
         }
       }
     }
@@ -499,17 +499,17 @@ class InputRecord
       return copy;
     }
     // return reference
-    reference operator*()
+    reference operator*() const
     {
       return mElement;
     }
     // comparison
-    bool operator==(const SelfType& rh)
+    bool operator==(const SelfType& rh) const
     {
       return mPosition == rh.mPosition;
     }
     // comparison
-    bool operator!=(const SelfType& rh)
+    bool operator!=(const SelfType& rh) const
     {
       return mPosition != rh.mPosition;
     }
@@ -588,7 +588,10 @@ class InputRecord
     /// Check if slot is valid, index of part is not used
     bool isValid(size_t = 0) const
     {
-      return this->parent()->isValid(this->position());
+      if (this->position() < this->parent()->size()) {
+        return this->parent()->isValid(this->position());
+      }
+      return false;
     }
 
     /// Get number of parts in input slot

--- a/Framework/Core/include/Framework/InputSpan.h
+++ b/Framework/Core/include/Framework/InputSpan.h
@@ -23,6 +23,10 @@ namespace framework
 class InputSpan
 {
  public:
+  InputSpan() = delete;
+  InputSpan(InputSpan const&) = delete;
+  InputSpan(InputSpan&&) = default;
+
   /// @a getter is the mapping between an element of the span referred by
   /// index and the buffer associated.
   /// @a size is the number of elements in the span.
@@ -60,6 +64,9 @@ class InputSpan
   /// @a number of parts in the i-th element of the InputSpan
   size_t getNofParts(size_t i) const
   {
+    if (i >= mSize) {
+      return 0;
+    }
     if (!mNofPartsGetter) {
       return 1;
     }

--- a/Framework/Core/src/InputRecord.cxx
+++ b/Framework/Core/src/InputRecord.cxx
@@ -34,7 +34,7 @@ namespace framework
 InputRecord::InputRecord(std::vector<InputRoute> const& inputsSchema,
                          InputSpan&& span)
   : mInputsSchema{inputsSchema},
-    mSpan{span}
+    mSpan{std::move(span)}
 {
 }
 
@@ -71,6 +71,9 @@ bool InputRecord::isValid(char const* s) const
 
 bool InputRecord::isValid(int s) const
 {
+  if (s >= size()) {
+    return false;
+  }
   DataRef ref = getByPos(s);
   if (ref.header == nullptr || ref.payload == nullptr) {
     return false;

--- a/Framework/Core/test/test_InputRecord.cxx
+++ b/Framework/Core/test/test_InputRecord.cxx
@@ -144,6 +144,14 @@ BOOST_AUTO_TEST_CASE(TestInputRecord)
     // check if invalid slots are filtered out by the iterator
     BOOST_CHECK(position != 2);
   }
+
+  // the 2-level iterator to access inputs and their parts
+  // all inputs have 1 part, we check the first input
+  BOOST_CHECK(record.begin().size() == 1);
+  // the end-instance of the inputs has no parts
+  BOOST_CHECK(record.end().size() == 0);
+  // thus there is no element and begin == end
+  BOOST_CHECK(record.end().begin() == record.end().end());
 }
 
 // TODO:


### PR DESCRIPTION
- fix the end iterator instance of part iterator
- making const what should be const
- bounds check before getNofParts callback to check against span size
- init InputRecord from InputSpan by move (which was intended but there was
  an unwanted copy)
- making InputRecord::get<T>(DataRef) a static method
  This method actually only requires the pointers from the DataRef argument, no
  concrete object or state is needed.
  At some point this can be also seperated from InputRecord, thus separating data
  and serialization method.