### PR TITLE
TPCClusterFinder: Adjust maxCluster size and bucket size.

### DIFF
--- a/GPU/GPUTracking/Base/GPUMemorySizeScalers.h
+++ b/GPU/GPUTracking/Base/GPUMemorySizeScalers.h
@@ -30,7 +30,8 @@ struct GPUMemorySizeScalers {
   static constexpr double offset = 1000.;
 
   // Scaling Factors
-  static constexpr double tpcClustersPerDigit = 0.2;
+  static constexpr double tpcPeaksPerDigit = 0.2;
+  static constexpr double tpcClustersPerPeak = 0.9;
   static constexpr double tpcClustersNoiseOffset = 20000;
   static constexpr double tpcTrackletsPerHit = 0.08;
   static constexpr double tpcSectorTracksPerHit = 0.02;
@@ -38,7 +39,8 @@ struct GPUMemorySizeScalers {
   static constexpr double tpcTracksPerHit = 0.012;
   static constexpr double tpcTrackHitsPerHit = 0.7;
 
-  double NTPCClusters(double tpcDigits) { return offset + tpcDigits * tpcClustersPerDigit + tpcClustersNoiseOffset; }
+  double NTPCPeaks(double tpcDigits) { return offset + tpcDigits * tpcPeaksPerDigit + tpcClustersNoiseOffset; }
+  double NTPCClusters(double tpcDigits) { return tpcClustersPerPeak * NTPCPeaks(tpcDigits); }
   double NTPCTracklets(double tpcHits) { return offset + tpcHits * tpcTrackletsPerHit; }
   double NTPCSectorTracks(double tpcHits) { return offset + tpcHits * tpcSectorTracksPerHit; }
   double NTPCSectorTrackHits(double tpcHits) { return offset + tpcHits * tpcSectorTrackHitsPerHit; }

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCClusterFinder.cxx
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCClusterFinder.cxx
@@ -50,7 +50,7 @@ void* GPUTPCClusterFinder::SetPointersOutput(void* mem)
 void* GPUTPCClusterFinder::SetPointersScratch(void* mem)
 {
   computePointerWithAlignment(mem, mPpeaks, mNMaxPeaks);
-  computePointerWithAlignment(mem, mPfilteredPeaks, mNMaxPeaks);
+  computePointerWithAlignment(mem, mPfilteredPeaks, mNMaxClusters);
   computePointerWithAlignment(mem, mPisPeak, mNMaxDigits);
   computePointerWithAlignment(mem, mPchargeMap, TPC_NUM_OF_PADS * TPC_MAX_TIME_PADDED);
   computePointerWithAlignment(mem, mPpeakMap, TPC_NUM_OF_PADS * TPC_MAX_TIME_PADDED);
@@ -68,9 +68,9 @@ void GPUTPCClusterFinder::RegisterMemoryAllocation()
 
 void GPUTPCClusterFinder::SetMaxData(const GPUTrackingInOutPointers& io)
 {
-  mNMaxPeaks = mRec->MemoryScalers()->NTPCClusters(mNMaxDigits);
-  mNMaxClusters = mNMaxPeaks; // Noise suppression doesn't remove that many peaks, so don't scale this
-  mNMaxClusterPerRow = 0.01f * mNMaxDigits;
+  mNMaxPeaks = mRec->MemoryScalers()->NTPCPeaks(mNMaxDigits);
+  mNMaxClusters = mRec->MemoryScalers()->NTPCClusters(mNMaxDigits);
+  mNMaxClusterPerRow = 0.01f * mNMaxClusters;
   mBufSize = nextMultipleOf<std::max<int>(GPUCA_MEMALIGN, mScanWorkGroupSize)>(mNMaxDigits);
   mNBufs = getNSteps(mBufSize);
 }


### PR DESCRIPTION
This PR adjusts the size of cluster buckets and fixes some naming issue in the memory scaler.