### PR TITLE
Using the standard RootTreeWriter in the DMCAL digitization

### DIFF
--- a/Steer/DigitizerWorkflow/src/EMCALDigitWriterSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/EMCALDigitWriterSpec.cxx
@@ -11,16 +11,13 @@
 /// @brief  Processor spec for a ROOT file writer for EMCAL digits
 
 #include "EMCALDigitWriterSpec.h"
-#include "Framework/CallbackService.h"
-#include "Framework/ConfigParamRegistry.h"
-#include "Framework/ControlService.h"
-#include <DataFormatsEMCAL/MCLabel.h>
+#include "DPLUtils/MakeRootTreeWriterSpec.h"
 #include <SimulationDataFormat/MCTruthContainer.h>
-#include "TBranch.h"
-#include <iostream>
+#include "DataFormatsEMCAL/Digit.h"
+#include <DataFormatsEMCAL/MCLabel.h>
+#include "DataFormatsEMCAL/TriggerRecord.h"
 
 using namespace o2::framework;
-using SubSpecificationType = o2::framework::DataAllocator::SubSpecificationType;
 
 namespace o2
 {
@@ -28,89 +25,21 @@ namespace emcal
 {
 
 template <typename T>
-TBranch* getOrMakeBranch(TTree& tree, std::string brname, T* ptr)
-{
-  if (auto br = tree.GetBranch(brname.c_str())) {
-    br->SetAddress(static_cast<void*>(&ptr));
-    return br;
-  }
-  // otherwise make it
-  return tree.Branch(brname.c_str(), ptr);
-}
-
-void DigitsWriterSpec::init(framework::InitContext& ctx)
-{
-  // get the option from the init context
-  auto filename = ctx.options().get<std::string>("emcal-digit-outfile");
-  auto treename = ctx.options().get<std::string>("treename");
-  mOutputFile = std::make_shared<TFile>(filename.c_str(), "RECREATE");
-  mOutputTree = std::make_shared<TTree>(treename.c_str(), treename.c_str());
-  mDigits = std::make_shared<std::vector<o2::emcal::Digit>>();
-  mTriggerRecords = std::make_shared<std::vector<o2::emcal::TriggerRecord>>();
-  mFinished = false;
-
-  // the callback to be set as hook at stop of processing for the framework
-  auto outputfile = mOutputFile;
-  auto outputtree = mOutputTree;
-  auto finishWriting = [outputfile, outputtree]() {
-    outputtree->SetEntries(1);
-    outputtree->Write();
-    outputfile->Close();
-  };
-  ctx.services().get<CallbackService>().set(CallbackService::Id::Stop, finishWriting);
-}
-
-void DigitsWriterSpec::run(framework::ProcessingContext& ctx)
-{
-  if (mFinished)
-    return;
-
-  // retrieve the digits from the input
-  auto indata = ctx.inputs().get<std::vector<o2::emcal::Digit>>("emcaldigits");
-  LOG(INFO) << "RECEIVED DIGITS SIZE " << indata.size();
-  *mDigits.get() = std::move(indata);
-  auto trgrecords = ctx.inputs().get<std::vector<o2::emcal::TriggerRecord>>("trgrecorddigits");
-  LOG(INFO) << "GOT " << trgrecords.size() << " TRIGGER RECORDS" << std::endl;
-  *mTriggerRecords.get() = std::move(trgrecords);
-  std::cout << "Before tree writing" << std::endl;
-
-  // connect this to a particular branch
-  auto br = getOrMakeBranch(*mOutputTree.get(), "EMCALDigit", mDigits.get());
-  br->Fill();
-
-  // connect trigger records branch
-  std::cout << "Before trigger record writing" << std::endl;
-  auto trgbranch = getOrMakeBranch(*mOutputTree.get(), "EMCALDigitTRGR", mTriggerRecords.get());
-  trgbranch->Fill();
-  std::cout << "After trigger digit tree writing" << std::endl;
-
-  // retrieve labels from the input
-  auto labeldata = ctx.inputs().get<o2::dataformats::MCTruthContainer<MCLabel>*>("emcaldigitlabels");
-  LOG(INFO) << "EMCAL GOT " << labeldata->getNElements() << " LABELS ";
-  auto labeldataraw = labeldata.get();
-  // connect this to a particular branch
-  auto labelbr = getOrMakeBranch(*mOutputTree.get(), "EMCALDigitMCTruth", &labeldataraw);
-  labelbr->Fill();
-
-  mFinished = true;
-  ctx.services().get<ControlService>().readyToQuit(QuitRequest::Me);
-}
+using BranchDefinition = framework::MakeRootTreeWriterSpec::BranchDefinition<T>;
 
 /// create the processor spec
 /// describing a processor receiving digits for EMCal writing them to file
 DataProcessorSpec getEMCALDigitWriterSpec()
 {
-  return DataProcessorSpec{
-    "EMCALDigitWriter",
-    Inputs{InputSpec{"emcaldigits", "EMC", "DIGITS", 0, Lifetime::Timeframe},
-           InputSpec{"trgrecorddigits", "EMC", "TRGRDIG", 0, Lifetime::Timeframe},
-           InputSpec{"emcaldigitlabels", "EMC", "DIGITSMCTR", 0, Lifetime::Timeframe}},
-    {}, // no output
-    AlgorithmSpec(framework::adaptFromTask<DigitsWriterSpec>()),
-    Options{
-      {"emcal-digit-outfile", VariantType::String, "emcaldigits.root", {"Name of the input file"}},
-      {"treename", VariantType::String, "o2sim", {"Name of top-level TTree"}},
-    }};
+  using InputSpec = framework::InputSpec;
+  using MakeRootTreeWriterSpec = framework::MakeRootTreeWriterSpec;
+  return MakeRootTreeWriterSpec("EMCALDigitWriter",
+                                "emcaldigits.root",
+                                "o2sim",
+                                1,
+                                BranchDefinition<std::vector<o2::emcal::Digit>>{InputSpec{"emcaldigits", "EMC", "DIGITS"}, "EMCALDigit"},
+                                BranchDefinition<std::vector<o2::emcal::TriggerRecord>>{InputSpec{"trgrecorddigits", "EMC", "TRGRDIG"}, "EMCALDigitTRGR"},
+                                BranchDefinition<o2::dataformats::MCTruthContainer<o2::emcal::MCLabel>>{InputSpec{"emcaldigitlabels", "EMC", "DIGITSMCTR"}, "EMCALDigitMCTruth"})();
 }
 } // end namespace emcal
 } // end namespace o2

--- a/Steer/DigitizerWorkflow/src/EMCALDigitWriterSpec.h
+++ b/Steer/DigitizerWorkflow/src/EMCALDigitWriterSpec.h
@@ -11,52 +11,11 @@
 #ifndef STEER_DIGITIZERWORKFLOW_EMCALDIGITWRITER_H_
 #define STEER_DIGITIZERWORKFLOW_EMCALDIGITWRITER_H_
 
-#include <memory> // for make_shared, make_unique, unique_ptr
-#include <string>
-#include <vector>
-
-#include <TFile.h>
-#include <TTree.h>
-
-#include "DataFormatsEMCAL/Digit.h"
-#include "DataFormatsEMCAL/TriggerRecord.h"
 #include "Framework/DataProcessorSpec.h"
-#include "Framework/Task.h"
-
 namespace o2
 {
 namespace emcal
 {
-
-/// \class DigitsWriterSpec
-/// \brief Task for EMCAL digits writer within the data processing layer
-/// \author Anders Garritt Knospe <anders.knospe@cern.ch>, University of Houston
-/// \author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
-/// \since Nov 12, 2018
-class DigitsWriterSpec : public framework::Task
-{
- public:
-  /// \brief Constructor
-  DigitsWriterSpec() = default;
-
-  /// \brief Destructor
-  ~DigitsWriterSpec() final = default;
-
-  /// \brief Init the digits writer
-  /// \param ctx Init context
-  void init(framework::InitContext& ctx) final;
-
-  /// \brief Write digits and labels to the output file
-  /// \param ctx processing context
-  void run(framework::ProcessingContext& ctx) final;
-
- private:
-  bool mFinished = false;                                                 ///< flag indicating whether work is completed
-  std::shared_ptr<TFile> mOutputFile;                                     ///< Common output file
-  std::shared_ptr<TTree> mOutputTree;                                     ///< Common output tree
-  std::shared_ptr<std::vector<o2::emcal::Digit>> mDigits;                 ///< Container for incoming digits (Sink responsible for deleting the digits)
-  std::shared_ptr<std::vector<o2::emcal::TriggerRecord>> mTriggerRecords; ///< Container for incoming trigger records
-};
 
 /// \brief Create new digits writer spec
 /// \return digits writer spec


### PR DESCRIPTION
The writer implementation does not implement any special handling for
EMCAL data, so it is replaced by the RootTreeWriter workflow utility to simplify the workflow.

@mfasDa, @sawenzel please check if this gives the expected result of the digitization. I have observed, that the digit properties are slightly different when running digitization repeatedly, independently of this PR. There seems to be a random component in the digitization. So I could not do a one-to-one comparison.

Is there a way to make the digitization deterministic? A switch or so, but did not find a configurable option in that respect.