### PR TITLE
Adding DPL RawParser utility

### DIFF
--- a/Framework/Utils/CMakeLists.txt
+++ b/Framework/Utils/CMakeLists.txt
@@ -87,6 +87,12 @@ o2_add_test(RawParser
             COMPONENT_NAME DPLUtils
             LABELS dplutils)
 
+o2_add_test(DPLRawParser
+            SOURCES test/test_DPLRawParser.cxx
+            PUBLIC_LINK_LIBRARIES O2::DPLUtils
+            COMPONENT_NAME DPLUtils
+            LABELS dplutils)
+
 foreach(b
         RawParser
         )

--- a/Framework/Utils/include/DPLUtils/DPLRawParser.h
+++ b/Framework/Utils/include/DPLUtils/DPLRawParser.h
@@ -1,0 +1,284 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef FRAMEWORK_UTILS_DPLRAWPARSER_H
+#define FRAMEWORK_UTILS_DPLRAWPARSER_H
+
+/// @file   DPLRawParser.h
+/// @author Matthias Richter
+/// @since  2020-02-27
+/// @brief  A raw page parser for DPL input
+
+#include "DPLUtils/RawParser.h"
+#include "Framework/InputRecord.h"
+#include "Framework/DataRef.h"
+#include "Framework/DataRefUtils.h"
+#include "Headers/DataHeader.h"
+#include <utility> // std::declval
+
+namespace o2::framework
+{
+
+/// @class DPLRawParser
+/// @brief The parser handles transparently input in the format of raw pages.
+///
+/// A DPL processor will receive raw pages accumulated on three levels:
+///   1) the DPL processor has one or more input route(s)
+///   2) multiple parts per input route (split payloads or multiple input
+///      specs matching the same route spec
+///   3) variable number of raw pages in one payload
+///
+/// Internally, class @ref RawParser is used to access raw pages withon one
+/// payload message and dynamically adopt to RAWDataHeader version.
+///
+/// The parser provides an iterator interface to loop over raw pages,
+/// starting at the first raw page of the first payload at the first route
+/// and going to the next route when all payloads are processed. The iterator
+/// element is @ref RawDataHeaderInfo containing just the two least significant
+/// bytes of the RDH where we have the version and header size.
+///
+/// The iterator object provides methods to access the concrete RDH, the raw
+/// buffer, the payload, etc.
+///
+/// Usage:
+///   DPLRawParser parser(inputs);
+///   for (auto it = parser.begin(), end = parser.end(); it != end; ++it) {
+///     // retrieving RDH v4
+///     auto const* rdh = it.get_if<o2::header::RAWDataHeaderV4>();
+///     // retrieving the raw pointer of the page
+///     auto const* raw = it.raw();
+///     // retrieving payload pointer of the page
+///     auto const* payload = it.data();
+///     // size of payload
+///     size_t payloadSize = it.size();
+///     // offset of payload in the raw page
+///     size_t offset = it.offset();
+///   }
+class DPLRawParser
+{
+ public:
+  using rawparser_type = RawParser<8192>;
+  using buffer_type = typename rawparser_type::buffer_type;
+
+  DPLRawParser() = delete;
+  DPLRawParser(InputRecord& inputs, std::vector<InputSpec> filterSpecs = {}) : mInputs(inputs), mFilterSpecs(filterSpecs) {}
+
+  // this is a dummy default buffer used to initialize the RawParser in the iterator
+  // constructor
+  static constexpr o2::header::RAWDataHeaderV4 initializer = o2::header::RAWDataHeaderV4{};
+  template <typename T>
+  using IteratorBase = std::iterator<std::forward_iterator_tag, T>;
+
+  /// Iterator implementation
+  /// Supports the following operations:
+  /// - increment (there is no decrement, its not a bidirectional parser)
+  /// - dereference operator returns @a RawDataHeaderInfo as common header
+  /// - member function data() returns pointer to payload at current position
+  /// - member function size() return size of payload at current position
+  template <typename T>
+  class Iterator : public IteratorBase<T>
+  {
+   public:
+    using self_type = Iterator;
+    using value_type = typename IteratorBase<T>::value_type;
+    using reference = typename IteratorBase<T>::reference;
+    using pointer = typename IteratorBase<T>::pointer;
+    // the iterator over the input channels
+    using input_iterator = decltype(std::declval<InputRecord>().begin());
+    // the parser type
+    using parser_type = rawparser_type const;
+
+    Iterator() = delete;
+
+    Iterator(InputRecord& parent, input_iterator it, input_iterator end, std::vector<InputSpec> const& filterSpecs)
+      : mParent(parent), mInputIterator(it), mEnd(end), mPartIterator(mInputIterator.begin()), mParser(std::make_unique<parser_type>(reinterpret_cast<const char*>(&initializer), sizeof(initializer))), mCurrent(mParser->begin()), mFilterSpecs(filterSpecs)
+    {
+      mParser.reset();
+      next();
+    }
+
+    ~Iterator() = default;
+
+    // prefix increment
+    self_type& operator++()
+    {
+      next();
+      return *this;
+    }
+    // postfix increment
+    self_type operator++(int /*unused*/)
+    {
+      self_type copy(*this);
+      operator++();
+      return copy;
+    }
+    // return reference
+    reference operator*()
+    {
+      return *mCurrent;
+    }
+    // comparison
+    bool operator==(const self_type& other) const
+    {
+      bool result = mInputIterator == other.mInputIterator;
+      result = result && mPartIterator == other.mPartIterator;
+      if (mParser != nullptr && other.mParser != nullptr) {
+        result = result && mCurrent == other.mCurrent;
+      }
+      return result;
+    }
+
+    bool operator!=(const self_type& rh) const
+    {
+      return not operator==(rh);
+    }
+
+    /// get DataHeader of the current input message
+    o2::header::DataHeader const* o2DataHeader() const
+    {
+      if (mInputIterator != mEnd) {
+        return DataRefUtils::getHeader<o2::header::DataHeader*>(*mPartIterator);
+      }
+    }
+
+    /// get pointer to raw block at current position, rdh starts here
+    buffer_type const* raw() const
+    {
+      return mCurrent.raw();
+    }
+
+    /// get pointer to payload at current position
+    buffer_type const* data() const
+    {
+      return mCurrent.data();
+    }
+
+    /// offset of payload at current position
+    size_t offset() const
+    {
+      return mCurrent.offset();
+    }
+
+    /// get size of payload at current position
+    size_t size() const
+    {
+      return mCurrent.size();
+    }
+
+    /// get header as specific type
+    /// @return pointer to header of the specified type, or nullptr if type does not match to actual type
+    template <typename U>
+    U const* get_if() const
+    {
+      return mCurrent.get_if<U>();
+    }
+
+    friend std::ostream& operator<<(std::ostream& os, self_type const& it)
+    {
+      if (it.mInputIterator != it.mEnd && it.mPartIterator != it.mInputIterator.end() && it.mParser != nullptr) {
+        os << *it.mParser << std::endl;
+        os << it.mCurrent;
+      }
+      return os;
+    }
+
+   private:
+    // the iterator over the parts in one channel
+    using part_iterator = typename input_iterator::const_iterator;
+    // the iterator over the over the parser pages
+    using parser_iterator = typename parser_type::const_iterator;
+
+    bool next()
+    {
+      while (mInputIterator != mEnd) {
+        bool isInitial = mParser == nullptr;
+        while (mPartIterator != mInputIterator.end()) {
+          // first increment on the parser level
+          if (mParser && mCurrent != mParser->end() && ++mCurrent != mParser->end()) {
+            // we have an active parser and there is still data at the incremented iterator
+            return true;
+          }
+          // now increment on the level of one input
+          mParser.reset();
+          if (!isInitial && (mPartIterator == mInputIterator.end() || ++mPartIterator == mInputIterator.end())) {
+            // no more parts, go to next input
+            break;
+          }
+          isInitial = false;
+          // check filter rules
+          if (mFilterSpecs.size() > 0) {
+            bool isSelected = false;
+            for (auto const& spec : mFilterSpecs) {
+              if ((isSelected = DataRefUtils::match(*mPartIterator, spec)) == true) {
+                break;
+              }
+            }
+            if (!isSelected) {
+              continue;
+            }
+          }
+          gsl::span<const char> raw;
+          try {
+            raw = mParent.get<gsl::span<char>>(*mPartIterator);
+          } catch (const std::runtime_error& e) {
+            // TODO: need some better handling to avoid to be spammed by error messages
+            LOG(ERROR) << "failed to read data from " << (*mInputIterator).spec->binding;
+            LOG(ERROR) << e.what();
+          }
+          if (raw.size() == 0) {
+            continue;
+          }
+
+          try {
+            mParser = std::make_unique<parser_type>(raw.data(), raw.size());
+          } catch (const std::runtime_error& e) {
+            LOG(ERROR) << "can not create raw parser form input data";
+            LOG(ERROR) << e.what();
+          }
+
+          if (mParser != nullptr) {
+            mCurrent = mParser->begin();
+            return true;
+          }
+        } // end loop over parts on one input
+        ++mInputIterator;
+        mPartIterator = mInputIterator.begin();
+      } // end loop over inputs
+      return false;
+    }
+
+    InputRecord& mParent;
+    input_iterator mInputIterator;
+    input_iterator mEnd;
+    part_iterator mPartIterator;
+    std::unique_ptr<parser_type> mParser;
+    parser_iterator mCurrent;
+    std::vector<InputSpec> const& mFilterSpecs;
+  };
+
+  using const_iterator = Iterator<DataRef const>;
+
+  const_iterator begin() const
+  {
+    return const_iterator(mInputs, mInputs.begin(), mInputs.end(), mFilterSpecs);
+  }
+
+  const_iterator end() const
+  {
+    return const_iterator(mInputs, mInputs.end(), mInputs.end(), mFilterSpecs);
+  }
+
+ private:
+  InputRecord& mInputs;
+  std::vector<InputSpec> mFilterSpecs;
+};
+
+} // namespace o2::framework
+
+#endif //FRAMEWORK_UTILS_DPLRAWPARSER_H

--- a/Framework/Utils/include/DPLUtils/RawParser.h
+++ b/Framework/Utils/include/DPLUtils/RawParser.h
@@ -481,12 +481,12 @@ class RawParser
   // only define the const_iterator because the parser will allow read-only access
   using const_iterator = Iterator<RawDataHeaderInfo const, raw_parser::ConcreteParserVariants<MAX_SIZE>>;
 
-  const_iterator begin()
+  const_iterator begin() const
   {
     return const_iterator(mParser);
   }
 
-  const_iterator end()
+  const_iterator end() const
   {
     return const_iterator(mParser, -1);
   }

--- a/Framework/Utils/test/test_DPLRawParser.cxx
+++ b/Framework/Utils/test/test_DPLRawParser.cxx
@@ -1,0 +1,185 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test Framework Utils DPLRawParser
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include "DPLUtils/DPLRawParser.h"
+#include "Framework/InputRecord.h"
+#include "Framework/WorkflowSpec.h" // o2::framework::select
+#include "Headers/DataHeader.h"
+#include "Headers/Stack.h"
+#include <vector>
+#include <memory>
+#include <iostream>
+
+using namespace o2::framework;
+using DataHeader = o2::header::DataHeader;
+using Stack = o2::header::Stack;
+using RAWDataHeaderV4 = o2::header::RAWDataHeaderV4;
+
+static const size_t PAGESIZE = 8192;
+
+// simple helper struct to keep the InputRecord and ownership of messages
+struct DataSet {
+  // not nice with the double vector but for quick unit test ok
+  using Messages = std::vector<std::vector<std::unique_ptr<std::vector<char>>>>;
+  DataSet(std::vector<InputRoute>&& s, Messages&& m, std::vector<int>&& v)
+    : schema{std::move(s)}, messages{std::move(m)}, record{schema, {[this](size_t i, size_t part) {
+                                                                      BOOST_REQUIRE(i < this->messages.size());
+                                                                      BOOST_REQUIRE(part < this->messages[i].size() / 2);
+                                                                      auto header = static_cast<char const*>(this->messages[i].at(2 * part)->data());
+                                                                      auto payload = static_cast<char const*>(this->messages[i].at(2 * part + 1)->data());
+                                                                      return DataRef{nullptr, header, payload};
+                                                                    },
+                                                                    [this](size_t i) { return i < this->messages.size() ? messages[i].size() / 2 : 0; }, this->messages.size()}},
+      values{std::move(v)}
+  {
+    BOOST_REQUIRE(messages.size() == schema.size());
+  }
+
+  std::vector<InputRoute> schema;
+  Messages messages;
+  InputRecord record;
+  std::vector<int> values;
+};
+
+DataSet createData()
+{
+  // Create the routes we want for the InputRecord
+  std::vector<InputSpec> inputspecs = {
+    InputSpec{"tpc0", "TPC", "RAWDATA", 0, Lifetime::Timeframe},
+    InputSpec{"its1", "ITS", "RAWDATA", 0, Lifetime::Timeframe},
+    InputSpec{"its1", "ITS", "RAWDATA", 1, Lifetime::Timeframe}};
+
+  size_t i = 0;
+  auto createRoute = [&i](const char* source, InputSpec& spec) {
+    return InputRoute{
+      spec,
+      i++,
+      source};
+  };
+
+  std::vector<InputRoute> schema = {
+    createRoute("tpc_source", inputspecs[0]),
+    createRoute("its_source", inputspecs[1]),
+    createRoute("tof_source", inputspecs[2])};
+
+  std::vector<int> checkValues;
+  DataSet::Messages messages;
+
+  auto initRawPage = [&checkValues](char* buffer, size_t size, int value) {
+    char* wrtptr = buffer;
+    while (wrtptr < buffer + size) {
+      auto* header = reinterpret_cast<RAWDataHeaderV4*>(wrtptr);
+      *header = RAWDataHeaderV4();
+      header->offsetToNext = PAGESIZE;
+      *reinterpret_cast<decltype(value)*>(wrtptr + header->headerSize) = value;
+      wrtptr += PAGESIZE;
+      checkValues.emplace_back(value);
+      ++value;
+    }
+  };
+
+  auto createMessage = [&messages, &initRawPage](DataHeader dh, int value) {
+    DataProcessingHeader dph{0, 1};
+    Stack stack{dh, dph};
+    if (dh.splitPayloadParts == 0 || dh.splitPayloadIndex == 0) {
+      // add new message collection
+      messages.emplace_back();
+    }
+    messages.back().emplace_back(std::make_unique<std::vector<char>>(stack.size()));
+    memcpy(messages.back().back()->data(), stack.data(), messages.back().back()->size());
+    messages.back().emplace_back(std::make_unique<std::vector<char>>(dh.payloadSize));
+    initRawPage(messages.back().back()->data(), messages.back().back()->size(), value);
+  };
+
+  // we create message for the 3 input routes, the messages have different page size
+  // and the second messages has 3 parts, each with the same page size
+  // the test value is written as payload after the RDH and all values are cached for
+  // later checking when parsing the data set
+  DataHeader dh1;
+  dh1.dataDescription = "RAWDATA";
+  dh1.dataOrigin = "TPC";
+  dh1.subSpecification = 0;
+  dh1.payloadSerializationMethod = o2::header::gSerializationMethodNone;
+  dh1.payloadSize = 5 * PAGESIZE;
+  DataHeader dh2;
+  dh2.dataDescription = "RAWDATA";
+  dh2.dataOrigin = "ITS";
+  dh2.subSpecification = 0;
+  dh2.payloadSerializationMethod = o2::header::gSerializationMethodNone;
+  dh2.payloadSize = 3 * PAGESIZE;
+  dh2.splitPayloadParts = 3;
+  dh2.splitPayloadIndex = 0;
+  DataHeader dh3;
+  dh3.dataDescription = "RAWDATA";
+  dh3.dataOrigin = "ITS";
+  dh3.subSpecification = 1;
+  dh3.payloadSerializationMethod = o2::header::gSerializationMethodNone;
+  dh3.payloadSize = 4 * PAGESIZE;
+  createMessage(dh1, 10);
+  createMessage(dh2, 20);
+  dh2.splitPayloadIndex++;
+  createMessage(dh2, 23);
+  dh2.splitPayloadIndex++;
+  createMessage(dh2, 26);
+  createMessage(dh3, 30);
+
+  return {std::move(schema), std::move(messages), std::move(checkValues)};
+}
+
+BOOST_AUTO_TEST_CASE(test_DPLRawParser)
+{
+  auto dataset = createData();
+  InputRecord& inputs = dataset.record;
+  BOOST_REQUIRE(dataset.messages.size() > 0);
+  BOOST_REQUIRE(dataset.messages[0].at(0) != nullptr);
+  BOOST_REQUIRE(inputs.size() > 0);
+  BOOST_CHECK((*inputs.begin()).header == dataset.messages[0].at(0)->data());
+  DPLRawParser parser(inputs);
+  int count = 0;
+  for (auto it = parser.begin(), end = parser.end(); it != end; ++it, ++count) {
+    LOG(INFO) << "data " << count << " " << *((int*)it.data());
+    // now check the iterator API
+    // retrieving RDH v4
+    auto const* rdh = it.get_if<o2::header::RAWDataHeaderV4>();
+    // retrieving the raw pointer of the page
+    auto const* raw = it.raw();
+    // retrieving payload pointer of the page
+    auto const* payload = it.data();
+    // size of payload
+    size_t payloadSize = it.size();
+    // offset of payload in the raw page
+    size_t offset = it.offset();
+    BOOST_REQUIRE(rdh != nullptr);
+    BOOST_REQUIRE(payload == raw + offset);
+    BOOST_REQUIRE(*reinterpret_cast<int const*>(payload) == dataset.values[count]);
+    std::cout << it << ": payload size " << it.size() << std::endl;
+  }
+
+  // test the parser with filter on data specs, this will filter out the first input
+  // route with 5 raw pages in the payload, so we start checking at count 5
+  DPLRawParser filteredparser(inputs, o2::framework::select("its:ITS/RAWDATA"));
+  count = 5;
+  for (auto it = filteredparser.begin(), end = filteredparser.end(); it != end; ++it, ++count) {
+    LOG(INFO) << "data " << count << " " << *((int*)it.data());
+    BOOST_REQUIRE(*reinterpret_cast<int const*>(it.data()) == dataset.values[count]);
+  }
+
+  // test with filter not matching any input route
+  DPLRawParser nomatchingparser(inputs, o2::framework::select("nmatch:NO/MATCH"));
+  count = 0;
+  for (auto it = nomatchingparser.begin(), end = nomatchingparser.end(); it != end; ++it, ++count) {
+    LOG(INFO) << "data " << count << " " << *((int*)it.data());
+  }
+  BOOST_CHECK(count == 0);
+}


### PR DESCRIPTION
The parser handles transparently input in the format of raw pages.
There three levels:
- the DPL processor has one or more input route(s)
- multiple parts per input route (split payloads or multiple input
  specs matching the same route spec
- variable number of raw pages in one payload

The parser provides an iterator interface to loop over raw pages,
starting at the first payload at the first route and going to the
next route when all payloads are processed.

TODO:
- [x] documentation
- [x] configurable DataSpec matcher filtering
