### PR TITLE
TPCClusterFinder: Decode ZS directly to charge map.

### DIFF
--- a/GPU/GPUTracking/Base/GPUReconstructionKernels.h
+++ b/GPU/GPUTracking/Base/GPUReconstructionKernels.h
@@ -31,7 +31,8 @@ GPUCA_KRNL((GPUITSFitterKernel                           ), (simple, REG, (GPUCA
 GPUCA_KRNL((GPUTPCConvertKernel                          ), (simple, REG, (GPUCA_THREAD_COUNT_CONVERTER, 1)), (), ())
 GPUCA_KRNL((GPUTPCCompressionKernels,   step0attached    ), (simple, REG, (GPUCA_THREAD_COUNT_COMPRESSION1, 1)), (), ())
 GPUCA_KRNL((GPUTPCCompressionKernels,   step1unattached  ), (simple, REG, (GPUCA_THREAD_COUNT_COMPRESSION2, 1)), (), ())
-GPUCA_KRNL((GPUTPCCFChargeMapFiller,    fillChargeMap    ), (single, REG, (GPUCA_THREAD_COUNT_CLUSTERER, 1)), (), ())
+GPUCA_KRNL((GPUTPCCFChargeMapFiller,    fillIndexMap     ), (single, REG, (GPUCA_THREAD_COUNT_CLUSTERER, 1)), (), ())
+GPUCA_KRNL((GPUTPCCFChargeMapFiller,    fillFromDigits   ), (single, REG, (GPUCA_THREAD_COUNT_CLUSTERER, 1)), (), ())
 GPUCA_KRNL((GPUTPCCFChargeMapFiller,    resetMaps        ), (single, REG, (GPUCA_THREAD_COUNT_CLUSTERER, 1)), (), ())
 GPUCA_KRNL((GPUTPCCFPeakFinder                           ), (single, REG, (GPUCA_THREAD_COUNT_CLUSTERER, 1)), (), ())
 GPUCA_KRNL((GPUTPCCFNoiseSuppression,   noiseSuppression ), (single, REG, (GPUCA_THREAD_COUNT_CLUSTERER, 1)), (), ())
@@ -44,7 +45,7 @@ GPUCA_KRNL((GPUTPCCFStreamCompaction,   nativeScanUpStart), (single, REG, (GPUCA
 GPUCA_KRNL((GPUTPCCFStreamCompaction,   nativeScanUp     ), (single, REG, (GPUCA_THREAD_COUNT_SCAN, 1)), (, int iBuf, int nElems), (, iBuf, nElems))
 GPUCA_KRNL((GPUTPCCFStreamCompaction,   nativeScanTop    ), (single, REG, (GPUCA_THREAD_COUNT_SCAN, 1)), (, int iBuf, int nElems), (, iBuf, nElems))
 GPUCA_KRNL((GPUTPCCFStreamCompaction,   nativeScanDown   ), (single, REG, (GPUCA_THREAD_COUNT_SCAN, 1)), (, int iBuf, unsigned int offset, int nElems), (, iBuf, offset, nElems))
-GPUCA_KRNL((GPUTPCCFStreamCompaction,   compactDigit     ), (single, REG, (GPUCA_THREAD_COUNT_SCAN, 1)), (, int iBuf, int stage, GPUPtr1(deprecated::PackedDigit*, in), GPUPtr1(deprecated::PackedDigit*, out)), (, iBuf, stage, GPUPtr2(deprecated::PackedDigit*, in), GPUPtr2(deprecated::PackedDigit*, out)))
+GPUCA_KRNL((GPUTPCCFStreamCompaction,   compact          ), (single, REG, (GPUCA_THREAD_COUNT_SCAN, 1)), (, int iBuf, int stage, GPUPtr1(ChargePos*, in), GPUPtr1(ChargePos*, out)), (, iBuf, stage, GPUPtr2(ChargePos*, in), GPUPtr2(ChargePos*, out)))
 GPUCA_KRNL((GPUTPCCFDecodeZS                             ), (single, REG, (GPUCA_THREAD_COUNT_CFDECODE, GPUCA_BLOCK_COUNT_DECODE_MULTIPLIER)), (), ())
 #endif
 #endif

--- a/GPU/GPUTracking/TPCClusterFinder/Array2D.h
+++ b/GPU/GPUTracking/TPCClusterFinder/Array2D.h
@@ -57,10 +57,10 @@ class TilingLayout
     const size_t widthInTiles = (TPC_NUM_OF_PADS + Width - 1) / Width;
 
     const size_t tilePad = p.gpad / Width;
-    const size_t tileTime = p.time / Height;
+    const size_t tileTime = p.timePadded / Height;
 
     const size_t inTilePad = p.gpad % Width;
-    const size_t inTileTime = p.time % Height;
+    const size_t inTileTime = p.timePadded % Height;
 
     return (tileTime * widthInTiles + tilePad) * (Width * Height) + inTileTime * Width + inTilePad;
   }
@@ -71,7 +71,7 @@ class LinearLayout
 {
   GPUdi() static size_t idx(const ChargePos& p)
   {
-    return TPC_NUM_OF_PADS * p.time + p.gpad;
+    return TPC_NUM_OF_PADS * p.timePadded + p.gpad;
   }
 };
 

--- a/GPU/GPUTracking/TPCClusterFinder/CfUtils.h
+++ b/GPU/GPUTracking/TPCClusterFinder/CfUtils.h
@@ -29,9 +29,9 @@ class CfUtils
 {
 
  public:
-  static GPUdi() bool isAtEdge(const deprecated::Digit* d)
+  static GPUdi() bool isAtEdge(const ChargePos& pos)
   {
-    return (d->pad < 2 || d->pad >= TPC_PADS_PER_ROW - 2);
+    return (pos.pad() < 2 || pos.pad() >= TPC_PADS_PER_ROW - 2);
   }
 
   static GPUdi() bool innerAboveThreshold(uchar aboveThreshold, ushort outerIdx)

--- a/GPU/GPUTracking/TPCClusterFinder/ChargePos.h
+++ b/GPU/GPUTracking/TPCClusterFinder/ChargePos.h
@@ -23,22 +23,26 @@ namespace gpu
 
 struct ChargePos {
   GlobalPad gpad;
-  Timestamp time;
+  Timestamp timePadded;
 
   GPUdDefault() ChargePos() CON_DEFAULT;
 
-  GPUdi() explicit ChargePos(const deprecated::Digit& d)
+  GPUdi() ChargePos(Row row, Pad pad, Timestamp t)
   {
-    gpad = tpcGlobalPadIdx(d.row, d.pad);
-    time = d.time + PADDING_TIME;
+    gpad = tpcGlobalPadIdx(row, pad);
+    timePadded = t + PADDING_TIME;
   }
 
-  GPUdi() ChargePos(const GlobalPad& p, const Timestamp& t) : gpad(p), time(t) {}
+  GPUdi() ChargePos(const GlobalPad& p, const Timestamp& t) : gpad(p), timePadded(t) {}
 
   GPUdi() ChargePos delta(const Delta2& d) const
   {
-    return {GlobalPad(gpad + d.x), Timestamp(time + d.y)};
+    return {GlobalPad(gpad + d.x), Timestamp(timePadded + d.y)};
   }
+
+  GPUdi() Row row() const { return gpad / TPC_PADS_PER_ROW_PADDED; }
+  GPUdi() Pad pad() const { return gpad % TPC_PADS_PER_ROW_PADDED - PADDING_PAD; }
+  GPUdi() Timestamp time() const { return timePadded - PADDING_TIME; }
 
  private:
   // Maps the position of a pad given as row and index in that row to a unique

--- a/GPU/GPUTracking/TPCClusterFinder/ClusterAccumulator.cxx
+++ b/GPU/GPUTracking/TPCClusterFinder/ClusterAccumulator.cxx
@@ -17,9 +17,9 @@
 
 using namespace GPUCA_NAMESPACE::gpu;
 
-GPUd() void ClusterAccumulator::toNative(const deprecated::Digit& d, tpc::ClusterNative& cn) const
+GPUd() void ClusterAccumulator::toNative(const ChargePos& pos, Charge q, tpc::ClusterNative& cn) const
 {
-  bool isEdgeCluster = CfUtils::isAtEdge(&d);
+  bool isEdgeCluster = CfUtils::isAtEdge(pos);
   bool wasSplitInTime = mSplitInTime >= MIN_SPLIT_NUM;
   bool wasSplitInPad = mSplitInPad >= MIN_SPLIT_NUM;
 
@@ -28,7 +28,7 @@ GPUd() void ClusterAccumulator::toNative(const deprecated::Digit& d, tpc::Cluste
   flags |= (wasSplitInTime) ? tpc::ClusterNative::flagSplitTime : 0;
   flags |= (wasSplitInPad) ? tpc::ClusterNative::flagSplitPad : 0;
 
-  cn.qMax = d.charge;
+  cn.qMax = q;
   cn.qTot = mQtot;
   cn.setTimeFlags(mTimeMean, flags);
   cn.setPad(mPadMean);
@@ -73,12 +73,9 @@ GPUd() Charge ClusterAccumulator::updateOuter(PackedCharge charge, Delta2 d)
   return q;
 }
 
-GPUd() void ClusterAccumulator::finalize(const deprecated::Digit& myDigit)
+GPUd() void ClusterAccumulator::finalize(const ChargePos& pos, Charge q)
 {
-  mQtot += myDigit.charge;
-  if (mQtot == 0) {
-    return; // TODO: Why does this happen?
-  }
+  mQtot += q;
 
   mPadMean /= mQtot;
   mTimeMean /= mQtot;
@@ -88,14 +85,14 @@ GPUd() void ClusterAccumulator::finalize(const deprecated::Digit& myDigit)
   mPadSigma = CAMath::Sqrt(mPadSigma - mPadMean * mPadMean);
   mTimeSigma = CAMath::Sqrt(mTimeSigma - mTimeMean * mTimeMean);
 
-  mPadMean += myDigit.pad;
-  mTimeMean += myDigit.time;
+  mPadMean += pos.pad();
+  mTimeMean += pos.time();
 
 #if defined(CORRECT_EDGE_CLUSTERS)
-  if (CfUtils::isAtEdge(myDigit)) {
-    float s = (myDigit->pad < 2) ? 1.f : -1.f;
-    bool c = s * (mPadMean - myDigit->pad) > 0.f;
-    mPadMean = (c) ? myDigit->pad : mPadMean;
+  if (CfUtils::isAtEdge(pos)) {
+    float s = (pos.pad() < 2) ? 1.f : -1.f;
+    bool c = s * (mPadMean - pos.pad()) > 0.f;
+    mPadMean = (c) ? pos.pad() : mPadMean;
   }
 #endif
 }

--- a/GPU/GPUTracking/TPCClusterFinder/ClusterAccumulator.h
+++ b/GPU/GPUTracking/TPCClusterFinder/ClusterAccumulator.h
@@ -28,6 +28,8 @@ struct ClusterNative;
 namespace gpu
 {
 
+struct ChargePos;
+
 class ClusterAccumulator
 {
 
@@ -35,8 +37,8 @@ class ClusterAccumulator
   GPUd() Charge updateInner(PackedCharge, Delta2);
   GPUd() Charge updateOuter(PackedCharge, Delta2);
 
-  GPUd() void finalize(const deprecated::Digit&);
-  GPUd() void toNative(const deprecated::Digit&, tpc::ClusterNative&) const;
+  GPUd() void finalize(const ChargePos&, Charge);
+  GPUd() void toNative(const ChargePos&, Charge, tpc::ClusterNative&) const;
 
  private:
   float mQtot = 0;

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFChargeMapFiller.h
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFChargeMapFiller.h
@@ -20,18 +20,22 @@
 #include "GPUTPCClusterFinder.h"
 #include "Array2D.h"
 #include "PackedCharge.h"
+#include "Digit.h"
 
 namespace GPUCA_NAMESPACE
 {
 namespace gpu
 {
 
+struct ChargePos;
+
 class GPUTPCCFChargeMapFiller : public GPUKernelTemplate
 {
  public:
   enum K : int {
-    fillChargeMap = 0,
-    resetMaps = 1,
+    fillIndexMap,
+    fillFromDigits,
+    resetMaps,
   };
 
 #ifdef HAVE_O2HEADERS
@@ -50,9 +54,11 @@ class GPUTPCCFChargeMapFiller : public GPUKernelTemplate
   template <int iKernel = defaultKernel, typename... Args>
   GPUd() static void Thread(int nBlocks, int nThreads, int iBlock, int iThread, GPUSharedMemory& smem, processorType& clusterer, Args... args);
 
-  static GPUd() void fillChargeMapImpl(int, int, int, int, const deprecated::Digit*, Array2D<PackedCharge>&, Array2D<uint>&, size_t);
+  static GPUd() void fillIndexMapImpl(int, int, int, int, const ChargePos*, Array2D<uint>&, size_t);
 
-  static GPUd() void resetMapsImpl(int, int, int, int, const deprecated::Digit*, Array2D<PackedCharge>&, Array2D<uchar>&);
+  static GPUd() void fillFromDigitsImpl(int, int, int, int, const deprecated::Digit*, ChargePos*, Array2D<PackedCharge>&, size_t);
+
+  static GPUd() void resetMapsImpl(int, int, int, int, const ChargePos*, Array2D<PackedCharge>&, Array2D<uchar>&, size_t);
 };
 
 } // namespace gpu

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFClusterizer.h
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFClusterizer.h
@@ -49,7 +49,7 @@ class GPUTPCCFClusterizer : public GPUKernelTemplate
     computeClusters = 0,
   };
 
-  static GPUd() void computeClustersImpl(int, int, int, int, GPUSharedMemory&, const Array2D<PackedCharge>&, const deprecated::Digit*, uint, MCLabelAccumulator*, uint, uint*, tpc::ClusterNative*);
+  static GPUd() void computeClustersImpl(int, int, int, int, GPUSharedMemory&, const Array2D<PackedCharge>&, const ChargePos*, uint, MCLabelAccumulator*, uint, uint*, tpc::ClusterNative*);
 
 #ifdef HAVE_O2HEADERS
   typedef GPUTPCClusterFinder processorType;
@@ -67,7 +67,7 @@ class GPUTPCCFClusterizer : public GPUKernelTemplate
   template <int iKernel = defaultKernel, typename... Args>
   GPUd() static void Thread(int nBlocks, int nThreads, int iBlock, int iThread, GPUSharedMemory& smem, processorType& clusterer, Args... args);
 
-  static GPUd() void computeClustersImpl(int, int, int, int, GPUSharedMemory&, const Array2D<PackedCharge>&, const deprecated::Digit*, MCLabelAccumulator*, uint, uint, uint*, tpc::ClusterNative*);
+  static GPUd() void computeClustersImpl(int, int, int, int, GPUSharedMemory&, const Array2D<PackedCharge>&, const ChargePos*, MCLabelAccumulator*, uint, uint, uint*, tpc::ClusterNative*);
 
  private:
   static GPUd() void addOuterCharge(const Array2D<PackedCharge>&, ClusterAccumulator*, const ChargePos&, Delta2);

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFDeconvolution.h
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFDeconvolution.h
@@ -40,7 +40,7 @@ class GPUTPCCFDeconvolution : public GPUKernelTemplate
     countPeaks,
   };
 
-  static GPUd() void countPeaksImpl(int, int, int, int, GPUSharedMemory&, const Array2D<uchar>&, Array2D<PackedCharge>&, const deprecated::Digit*, const uint);
+  static GPUd() void countPeaksImpl(int, int, int, int, GPUSharedMemory&, const Array2D<uchar>&, Array2D<PackedCharge>&, const ChargePos*, const uint);
 
 #ifdef HAVE_O2HEADERS
   typedef GPUTPCClusterFinder processorType;

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFNoiseSuppression.h
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFNoiseSuppression.h
@@ -26,6 +26,8 @@ namespace GPUCA_NAMESPACE
 namespace gpu
 {
 
+struct ChargePos;
+
 class GPUTPCCFNoiseSuppression : GPUKernelTemplate
 {
 
@@ -56,9 +58,9 @@ class GPUTPCCFNoiseSuppression : GPUKernelTemplate
   template <int iKernel = defaultKernel, typename... Args>
   GPUd() static void Thread(int nBlocks, int nThreads, int iBlock, int iThread, GPUSharedMemory& smem, processorType& clusterer, Args... args);
 
-  static GPUd() void noiseSuppressionImpl(int, int, int, int, GPUSharedMemory&, const Array2D<PackedCharge>&, const Array2D<uchar>&, const deprecated::Digit*, const uint, uchar*);
+  static GPUd() void noiseSuppressionImpl(int, int, int, int, GPUSharedMemory&, const Array2D<PackedCharge>&, const Array2D<uchar>&, const ChargePos*, const uint, uchar*);
 
-  static GPUd() void updatePeaksImpl(int, int, int, int, const deprecated::Digit*, const uchar*, const uint, Array2D<uchar>&);
+  static GPUd() void updatePeaksImpl(int, int, int, int, const ChargePos*, const uchar*, const uint, Array2D<uchar>&);
 
  private:
   static GPUd() void checkForMinima(float, float, PackedCharge, int, ulong*, ulong*);

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFPeakFinder.cxx
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFPeakFinder.cxx
@@ -26,7 +26,7 @@ GPUdii() void GPUTPCCFPeakFinder::Thread<GPUTPCCFPeakFinder::findPeaks>(int nBlo
 {
   Array2D<PackedCharge> chargeMap(reinterpret_cast<PackedCharge*>(clusterer.mPchargeMap));
   Array2D<uchar> isPeakMap(clusterer.mPpeakMap);
-  findPeaksImpl(get_num_groups(0), get_local_size(0), get_group_id(0), get_local_id(0), smem, chargeMap, clusterer.mPdigits, clusterer.mPmemory->counters.nDigits, clusterer.mPisPeak, isPeakMap);
+  findPeaksImpl(get_num_groups(0), get_local_size(0), get_group_id(0), get_local_id(0), smem, chargeMap, clusterer.mPpositions, clusterer.mPmemory->counters.nDigits, clusterer.mPisPeak, isPeakMap);
 }
 
 GPUd() bool GPUTPCCFPeakFinder::isPeakScratchPad(
@@ -152,7 +152,7 @@ GPUd() bool GPUTPCCFPeakFinder::isPeak(
 
 GPUd() void GPUTPCCFPeakFinder::findPeaksImpl(int nBlocks, int nThreads, int iBlock, int iThread, GPUSharedMemory& smem,
                                               const Array2D<PackedCharge>& chargeMap,
-                                              const Digit* digits,
+                                              const ChargePos* positions,
                                               uint digitnum,
                                               uchar* isPeakPredicate,
                                               Array2D<uchar>& peakMap)
@@ -162,15 +162,14 @@ GPUd() void GPUTPCCFPeakFinder::findPeaksImpl(int nBlocks, int nThreads, int iBl
   // For certain configurations dummy work items are added, so the total
   // number of work items is dividable by 64.
   // These dummy items also compute the last digit but discard the result.
-  Digit myDigit = digits[CAMath::Min(idx, (size_t)(digitnum - 1))];
-
-  ChargePos pos(myDigit);
+  ChargePos pos = positions[CAMath::Min(idx, (size_t)(digitnum - 1))];
+  Charge charge = chargeMap[pos].unpack();
 
   uchar peak;
 #if defined(BUILD_CLUSTER_SCRATCH_PAD)
-  peak = isPeakScratchPad(smem, myDigit.charge, pos, SCRATCH_PAD_SEARCH_N, chargeMap, smem.posBcast, smem.buf);
+  peak = isPeakScratchPad(smem, charge, pos, SCRATCH_PAD_SEARCH_N, chargeMap, smem.posBcast, smem.buf);
 #else
-  peak = isPeak(myDigit.charge, pos, chargeMap);
+  peak = isPeak(charge, pos, chargeMap);
 #endif
 
   // Exit early if dummy. See comment above.
@@ -181,5 +180,5 @@ GPUd() void GPUTPCCFPeakFinder::findPeaksImpl(int nBlocks, int nThreads, int iBl
 
   isPeakPredicate[idx] = peak;
 
-  peakMap[pos] = (uchar(myDigit.charge > CHARGE_THRESHOLD) << 1) | peak;
+  peakMap[pos] = (uchar(charge > CHARGE_THRESHOLD) << 1) | peak;
 }

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFPeakFinder.h
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFPeakFinder.h
@@ -26,6 +26,8 @@ namespace GPUCA_NAMESPACE
 namespace gpu
 {
 
+struct ChargePos;
+
 class GPUTPCCFPeakFinder : public GPUKernelTemplate
 {
 
@@ -39,7 +41,7 @@ class GPUTPCCFPeakFinder : public GPUKernelTemplate
     findPeaks,
   };
 
-  static GPUd() void findPeaksImpl(int, int, int, int, GPUSharedMemory&, const Array2D<gpu::PackedCharge>&, const deprecated::Digit*, uint, uchar*, Array2D<uchar>&);
+  static GPUd() void findPeaksImpl(int, int, int, int, GPUSharedMemory&, const Array2D<PackedCharge>&, const ChargePos*, uint, uchar*, Array2D<uchar>&);
 
 #ifdef HAVE_O2HEADERS
   typedef GPUTPCClusterFinder processorType;

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFStreamCompaction.h
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFStreamCompaction.h
@@ -36,7 +36,7 @@ class GPUTPCCFStreamCompaction
     nativeScanUp,
     nativeScanTop,
     nativeScanDown,
-    compactDigit,
+    compact,
   };
 
   static GPUd() void nativeScanUpStartImpl(int, int, int, int, GPUSharedMemory&,
@@ -52,10 +52,10 @@ class GPUTPCCFStreamCompaction
   static GPUd() void nativeScanDownImpl(int, int, int, int, GPUSharedMemory&,
                                         int*, const int*, unsigned int, int);
 
-  static GPUd() void compactDigitImpl(int, int, int, int, GPUSharedMemory&,
-                                      const deprecated::Digit*, deprecated::Digit*,
-                                      const uchar*, int*, const int*,
-                                      int, size_t);
+  static GPUd() void compactImpl(int, int, int, int, GPUSharedMemory&,
+                                 const ChargePos*, ChargePos*,
+                                 const uchar*, int*, const int*,
+                                 int, size_t);
 
 #ifdef HAVE_O2HEADERS
   typedef GPUTPCClusterFinder processorType;

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCClusterFinder.cxx
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCClusterFinder.cxx
@@ -17,7 +17,7 @@
 #include "GPUHostDataTypes.h"
 
 #include "DataFormatsTPC/ZeroSuppression.h"
-#include "Digit.h"
+#include "ChargePos.h"
 
 using namespace GPUCA_NAMESPACE::gpu;
 using namespace o2::tpc;
@@ -35,7 +35,7 @@ void* GPUTPCClusterFinder::SetPointersInput(void* mem)
   if (mNMaxPages && (mRec->GetRecoStepsGPU() & GPUDataTypes::RecoStep::TPCClusterFinding)) {
     computePointerWithAlignment(mem, mPzs, mNMaxPages * TPCZSHDR::TPC_ZS_PAGE_SIZE);
   }
-  if (mNMaxPages || (mRec->GetRecoStepsGPU() & GPUDataTypes::RecoStep::TPCClusterFinding)) {
+  if (mNMaxPages == 0 && (mRec->GetRecoStepsGPU() & GPUDataTypes::RecoStep::TPCClusterFinding)) {
     computePointerWithAlignment(mem, mPdigits, mNMaxDigits);
   }
   return mem;
@@ -58,8 +58,9 @@ void* GPUTPCClusterFinder::SetPointersOutput(void* mem)
 
 void* GPUTPCClusterFinder::SetPointersScratch(void* mem)
 {
-  computePointerWithAlignment(mem, mPpeaks, mNMaxPeaks);
-  computePointerWithAlignment(mem, mPfilteredPeaks, mNMaxClusters);
+  computePointerWithAlignment(mem, mPpositions, mNMaxDigits);
+  computePointerWithAlignment(mem, mPpeakPositions, mNMaxPeaks);
+  computePointerWithAlignment(mem, mPfilteredPeakPositions, mNMaxClusters);
   computePointerWithAlignment(mem, mPisPeak, mNMaxDigits);
   computePointerWithAlignment(mem, mPchargeMap, TPC_NUM_OF_PADS * TPC_MAX_TIME_PADDED);
   computePointerWithAlignment(mem, mPpeakMap, TPC_NUM_OF_PADS * TPC_MAX_TIME_PADDED);

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCClusterFinder.h
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCClusterFinder.h
@@ -17,6 +17,7 @@
 #include "GPUDef.h"
 #include "GPUProcessor.h"
 #include "GPUDataTypes.h"
+#include "Digit.h"
 
 namespace GPUCA_NAMESPACE
 {
@@ -37,10 +38,7 @@ namespace gpu
 {
 struct GPUTPCClusterMCInterim;
 
-namespace deprecated
-{
-struct PackedDigit;
-} // namespace deprecated
+struct ChargePos;
 
 class GPUTPCClusterFinder : public GPUProcessor
 {
@@ -76,9 +74,10 @@ class GPUTPCClusterFinder : public GPUProcessor
 #endif
   unsigned char* mPzs = nullptr;
   ZSOffset* mPzsOffsets = nullptr;
-  deprecated::PackedDigit* mPdigits = nullptr;
-  deprecated::PackedDigit* mPpeaks = nullptr;
-  deprecated::PackedDigit* mPfilteredPeaks = nullptr;
+  deprecated::Digit* mPdigits = nullptr; // input digits, only set if ZS is skipped
+  ChargePos* mPpositions = nullptr;
+  ChargePos* mPpeakPositions = nullptr;
+  ChargePos* mPfilteredPeakPositions = nullptr;
   unsigned char* mPisPeak = nullptr;
   ushort* mPchargeMap = nullptr;
   unsigned char* mPpeakMap = nullptr;

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCClusterFinderDump.cxx
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCClusterFinderDump.cxx
@@ -22,7 +22,7 @@ void GPUTPCClusterFinder::DumpDigits(std::ostream& out)
 {
   out << "Clusterer - Digits - Slice " << mISlice << ": " << mPmemory->counters.nDigits << "\n";
   for (size_t i = 0; i < mPmemory->counters.nDigits; i++) {
-    out << i << ": " << mPdigits[i].charge << ", " << mPdigits[i].time << ", " << (int)mPdigits[i].pad << ", " << (int)mPdigits[i].row << "\n";
+    out << i << ": " << mPpositions[i].time() << ", " << (int)mPpositions[i].pad() << ", " << (int)mPpositions[i].row() << "\n";
   }
 }
 
@@ -69,7 +69,7 @@ void GPUTPCClusterFinder::DumpPeaksCompacted(std::ostream& out)
 {
   out << "Clusterer - Compacted Peaks - Slice " << mISlice << ": " << mPmemory->counters.nPeaks << "\n";
   for (size_t i = 0; i < mPmemory->counters.nPeaks; i++) {
-    out << i << ": " << mPpeaks[i].charge << ", " << mPpeaks[i].time << ", " << (int)mPpeaks[i].pad << ", " << (int)mPpeaks[i].row << "\n";
+    out << i << ": " << mPpeakPositions[i].time() << ", " << (int)mPpeakPositions[i].pad() << ", " << (int)mPpeakPositions[i].row() << "\n";
   }
 }
 
@@ -89,7 +89,7 @@ void GPUTPCClusterFinder::DumpSuppressedPeaksCompacted(std::ostream& out)
 {
   out << "Clusterer - Noise Suppression Peaks Compacted - Slice " << mISlice << ": " << mPmemory->counters.nClusters << "\n";
   for (size_t i = 0; i < mPmemory->counters.nClusters; i++) {
-    out << i << ": " << mPfilteredPeaks[i].charge << ", " << mPfilteredPeaks[i].time << ", " << (int)mPfilteredPeaks[i].pad << ", " << (int)mPfilteredPeaks[i].row << "\n";
+    out << i << ": " << mPfilteredPeakPositions[i].time() << ", " << (int)mPfilteredPeakPositions[i].pad() << ", " << (int)mPfilteredPeakPositions[i].row() << "\n";
   }
 }
 

--- a/GPU/GPUTracking/TPCClusterFinder/clusterFinderDefs.h
+++ b/GPU/GPUTracking/TPCClusterFinder/clusterFinderDefs.h
@@ -122,6 +122,4 @@ GPUconstexpr() int MIN_SPLIT_NUM = 1;
 } // namespace gpu
 } // namespace GPUCA_NAMESPACE
 
-#include "Digit.h"
-
 #endif


### PR DESCRIPTION
This PR adjusts the ZS decoder to write charges directly to the chargeMap buffer. So the cluster finder only has to store charge positions instead of entire digits in intermediate buffers.