### PR TITLE
Reorganize some MID constants/names

### DIFF
--- a/Detectors/MUON/MID/Raw/exe/CRUBareDataChecker.cxx
+++ b/Detectors/MUON/MID/Raw/exe/CRUBareDataChecker.cxx
@@ -17,7 +17,6 @@
 
 #include <array>
 #include <sstream>
-#include "MIDRaw/CrateParameters.h"
 
 namespace o2
 {
@@ -65,14 +64,14 @@ bool CRUBareDataChecker::checkConsistency(const LocalBoardRO& board) const
   /// Checks that the event information is consistent
 
   bool isSoxOrReset = board.eventWord & 0xc2;
-  bool isCalib = crateparams::isCalibration(board.eventWord);
+  bool isCalib = raw::isCalibration(board.eventWord);
   bool isPhysOrHC = board.eventWord & 0x5;
 
   if (isPhysOrHC) {
     if (isCalib) {
       return false;
     }
-    if (crateparams::isLoc(board.statusWord)) {
+    if (raw::isLoc(board.statusWord)) {
       if (board.firedChambers) {
         return false;
       }
@@ -161,7 +160,7 @@ bool CRUBareDataChecker::process(gsl::span<const LocalBoardRO> localBoards, gsl:
     for (auto& idx : item.second) {
       // In principle all of these ROF records have the same timestamp
       for (size_t iloc = rofRecords[idx].firstEntry; iloc < rofRecords[idx].firstEntry + rofRecords[idx].nEntries; ++iloc) {
-        if (crateparams::isLoc(localBoards[iloc].statusWord)) {
+        if (raw::isLoc(localBoards[iloc].statusWord)) {
           // This is a local card
           locs.push_back(localBoards[iloc]);
         } else {

--- a/Detectors/MUON/MID/Raw/exe/CRUBareDataChecker.cxx
+++ b/Detectors/MUON/MID/Raw/exe/CRUBareDataChecker.cxx
@@ -27,7 +27,7 @@ bool CRUBareDataChecker::checkSameEventWord(const std::vector<LocalBoardRO>& boa
 {
   /// Checks the event word
   for (auto loc : boards) {
-    if (loc.eventWord != refEventWord) {
+    if (loc.triggerWord != refEventWord) {
       return false;
     }
   }
@@ -63,9 +63,9 @@ bool CRUBareDataChecker::checkConsistency(const LocalBoardRO& board) const
 {
   /// Checks that the event information is consistent
 
-  bool isSoxOrReset = board.eventWord & 0xc2;
-  bool isCalib = raw::isCalibration(board.eventWord);
-  bool isPhysOrHC = board.eventWord & 0x5;
+  bool isSoxOrReset = board.triggerWord & 0xc2;
+  bool isCalib = raw::isCalibration(board.triggerWord);
+  bool isPhysOrHC = board.triggerWord & 0x5;
 
   if (isPhysOrHC) {
     if (isCalib) {
@@ -109,14 +109,14 @@ bool CRUBareDataChecker::checkBC(const std::vector<LocalBoardRO>& regs, const st
 
   uint8_t refEventWord = 0;
   if (!regs.empty()) {
-    refEventWord = regs.front().eventWord;
+    refEventWord = regs.front().triggerWord;
   } else if (!locs.empty()) {
     // FIXME: in some files, a series of 0xeeee wrongly added before the new RDH
     // This is a known problem, so we do not check further in this case
-    // if (locs.front().statusWord == 0xee && locs.front().eventWord == 0xee && locs.front().firedChambers == 0xe) {
+    // if (locs.front().statusWord == 0xee && locs.front().triggerWord == 0xee && locs.front().firedChambers == 0xe) {
     //   return true;
     // }
-    refEventWord = locs.front().eventWord;
+    refEventWord = locs.front().triggerWord;
   }
 
   if (!checkSameEventWord(regs, refEventWord) || !checkSameEventWord(locs, refEventWord)) {

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/CrateParameters.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/CrateParameters.h
@@ -50,13 +50,7 @@ inline uint8_t makeUniqueLocID(uint8_t crateId, uint8_t locId) { return locId | 
 /// Gets the crate ID from the absolute local board ID
 inline uint8_t getCrateId(uint8_t uniqueLocId) { return (uniqueLocId >> 4) & 0xF; }
 /// Gets the loc ID in the crate from the unique local board ID
-inline uint8_t getLocId(uint16_t uniqueLocId) { return uniqueLocId & 0xF; }
-/// Tests the local card bit
-inline bool isLoc(uint8_t statusWord) { return (statusWord >> 6) & 0x1; }
-/// Tests if the calibration bit of the card
-inline bool isCalibration(uint8_t eventWord) { return ((eventWord & 0xc) == 0x8); }
-/// Tests if this is a Front End Test event
-inline bool isFET(uint8_t eventWord) { return ((eventWord & 0xc) == 0xc); }
+inline uint8_t getLocId(uint8_t uniqueLocId) { return uniqueLocId & 0xF; }
 } // namespace crateparams
 } // namespace mid
 } // namespace o2

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/ELinkDecoder.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/ELinkDecoder.h
@@ -30,8 +30,8 @@ class ELinkDecoder
   bool isComplete() const { return mBytes.size() == mTotalSize; };
   /// Gets the status word
   uint8_t getStatusWord() const { return mBytes[0]; }
-  /// Gets the event word
-  uint8_t getEventWord() const { return mBytes[1]; }
+  /// Gets the trigger word
+  uint8_t getTriggerWord() const { return mBytes[1]; }
   /// Gets the counter
   uint16_t getCounter() const { return joinBytes(2); }
   // uint16_t getCounter() const { return (mBytes[2] << 8) | mBytes[3]; }

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/LocalBoardRO.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/LocalBoardRO.h
@@ -24,7 +24,7 @@ namespace mid
 {
 struct LocalBoardRO {
   uint8_t statusWord{0};                 /// Status word
-  uint8_t eventWord{0};                  /// Event word
+  uint8_t triggerWord{0};                /// Trigger word
   uint8_t boardId{0};                    /// Board ID in crate
   uint8_t firedChambers{0};              /// Fired chambers
   std::array<uint16_t, 4> patternsBP{};  /// Bending plane pattern
@@ -56,9 +56,9 @@ static constexpr uint32_t sORB = 1;
 /// Tests the local card bit
 inline bool isLoc(uint8_t statusWord) { return (statusWord >> 6) & 0x1; }
 /// Tests the calibration bit of the card
-inline bool isCalibration(uint8_t eventWord) { return ((eventWord & 0xc) == 0x8); }
+inline bool isCalibration(uint8_t triggerWord) { return ((triggerWord & 0xc) == 0x8); }
 /// Tests if this is a Front End Test event
-inline bool isFET(uint8_t eventWord) { return ((eventWord & 0xc) == 0xc); }
+inline bool isFET(uint8_t triggerWord) { return ((triggerWord & 0xc) == 0xc); }
 } // namespace raw
 
 } // namespace mid

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/LocalBoardRO.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/LocalBoardRO.h
@@ -32,6 +32,35 @@ struct LocalBoardRO {
 };
 
 std::ostream& operator<<(std::ostream& os, const LocalBoardRO& loc);
+
+namespace raw
+{
+static constexpr uint32_t sSTARTBIT = 1 << 7;
+static constexpr uint32_t sCARDTYPE = 1 << 6;
+static constexpr uint32_t sLOCALBUSY = 1 << 5;
+static constexpr uint32_t sLOCALDECISION = 1 << 4;
+static constexpr uint32_t sACTIVE = 1 << 3;
+static constexpr uint32_t sREJECTING = 1 << 2;
+static constexpr uint32_t sMASKED = 1 << 1;
+static constexpr uint32_t sOVERWRITTEN = 1;
+
+static constexpr uint32_t sSOX = 1 << 7;
+static constexpr uint32_t sEOX = 1 << 6;
+static constexpr uint32_t sPAUSE = 1 << 5;
+static constexpr uint32_t sRESUME = 1 << 4;
+static constexpr uint32_t sCALIBRATE = 1 << 3;
+static constexpr uint32_t sPHY = 1 << 2;
+static constexpr uint32_t sRESET = 1 << 1;
+static constexpr uint32_t sORB = 1;
+
+/// Tests the local card bit
+inline bool isLoc(uint8_t statusWord) { return (statusWord >> 6) & 0x1; }
+/// Tests the calibration bit of the card
+inline bool isCalibration(uint8_t eventWord) { return ((eventWord & 0xc) == 0x8); }
+/// Tests if this is a Front End Test event
+inline bool isFET(uint8_t eventWord) { return ((eventWord & 0xc) == 0xc); }
+} // namespace raw
+
 } // namespace mid
 } // namespace o2
 

--- a/Detectors/MUON/MID/Raw/src/CRUBareDecoder.cxx
+++ b/Detectors/MUON/MID/Raw/src/CRUBareDecoder.cxx
@@ -103,7 +103,7 @@ void CRUBareDecoder::addBoard(size_t ilink)
   /// Adds the local or regional board to the output data vector
   uint16_t localClock = mELinkDecoders[ilink].getCounter();
   EventType eventType = EventType::Standard;
-  if (mELinkDecoders[ilink].getEventWord() & (1 << 4)) {
+  if (mELinkDecoders[ilink].getTriggerWord() & (1 << 4)) {
     mCalibClocks[ilink] = localClock;
     eventType = EventType::Noise;
   } else if (localClock == mCalibClocks[ilink] + sDelayCalibToFET) {
@@ -111,7 +111,7 @@ void CRUBareDecoder::addBoard(size_t ilink)
   }
   auto firstEntry = mData.size();
   InteractionRecord intRec(localClock - sDelayBCToLocal, mBuffer.getRDH()->triggerOrbit);
-  mData.push_back({mELinkDecoders[ilink].getStatusWord(), mELinkDecoders[ilink].getEventWord(), crateparams::makeUniqueLocID(mCrateId, mELinkDecoders[ilink].getId()), mELinkDecoders[ilink].getInputs()});
+  mData.push_back({mELinkDecoders[ilink].getStatusWord(), mELinkDecoders[ilink].getTriggerWord(), crateparams::makeUniqueLocID(mCrateId, mELinkDecoders[ilink].getId()), mELinkDecoders[ilink].getInputs()});
   mROFRecords.emplace_back(intRec, eventType, firstEntry, 1);
 }
 

--- a/Detectors/MUON/MID/Raw/src/CRUUserLogicDecoder.cxx
+++ b/Detectors/MUON/MID/Raw/src/CRUUserLogicDecoder.cxx
@@ -54,15 +54,15 @@ bool CRUUserLogicDecoder::processBlock()
   /// Processes the next block of data
   size_t firstEntry = mData.size();
 
-  uint8_t eventWord = mBuffer.next(sNBitsEventWord);
+  uint8_t triggerWord = mBuffer.next(sNBitsTriggerWord);
   uint16_t localClock = mBuffer.next(sNBitsLocalClock);
   uint8_t crateId = mBuffer.next(sNBitsCrateId);
   int nFiredBoards = mBuffer.next(sNBitsNFiredBoards);
 
   EventType eventType = EventType::Standard;
-  if (raw::isCalibration(eventWord)) {
+  if (raw::isCalibration(triggerWord)) {
     eventType = EventType::Noise;
-  } else if (raw::isFET(eventWord)) {
+  } else if (raw::isFET(triggerWord)) {
     eventType = EventType::Dead;
   }
   InteractionRecord intRec(localClock, mBuffer.getRDH()->triggerOrbit);

--- a/Detectors/MUON/MID/Raw/src/CRUUserLogicDecoder.cxx
+++ b/Detectors/MUON/MID/Raw/src/CRUUserLogicDecoder.cxx
@@ -60,9 +60,9 @@ bool CRUUserLogicDecoder::processBlock()
   int nFiredBoards = mBuffer.next(sNBitsNFiredBoards);
 
   EventType eventType = EventType::Standard;
-  if (crateparams::isCalibration(eventWord)) {
+  if (raw::isCalibration(eventWord)) {
     eventType = EventType::Noise;
-  } else if (crateparams::isFET(eventWord)) {
+  } else if (raw::isFET(eventWord)) {
     eventType = EventType::Dead;
   }
   InteractionRecord intRec(localClock, mBuffer.getRDH()->triggerOrbit);

--- a/Detectors/MUON/MID/Raw/src/CRUUserLogicEncoder.cxx
+++ b/Detectors/MUON/MID/Raw/src/CRUUserLogicEncoder.cxx
@@ -102,14 +102,14 @@ void CRUUserLogicEncoder::process(gsl::span<const LocalBoardRO> sortedData, cons
 {
   /// Encode data
 
-  // FIXME: Finalize the final format of the event word together with the CRU + RO team
-  uint16_t eventWord = 0;
+  // FIXME: Finalize the final format of the trigger word together with the CRU + RO team
+  uint16_t triggerWord = 0;
   if (eventType == EventType::Noise) {
-    eventWord = 0x8;
+    triggerWord = 0x8;
   } else if (eventType == EventType::Dead) {
-    eventWord = 0xc;
+    triggerWord = 0xc;
   }
-  add(eventWord, sNBitsEventWord);
+  add(triggerWord, sNBitsTriggerWord);
   add(bc, sNBitsLocalClock);
   add(crateparams::getCrateIdFromROId(getRDH()->feeId), sNBitsCrateId);
   add(sortedData.size(), sNBitsNFiredBoards);

--- a/Detectors/MUON/MID/Raw/src/ELinkDecoder.cxx
+++ b/Detectors/MUON/MID/Raw/src/ELinkDecoder.cxx
@@ -15,7 +15,7 @@
 
 #include "MIDRaw/ELinkDecoder.h"
 
-#include "MIDRaw/CrateParameters.h"
+#include "MIDRaw/LocalBoardRO.h"
 
 namespace o2
 {
@@ -30,7 +30,7 @@ bool ELinkDecoder::add(uint8_t byte, uint8_t expectedStart)
   }
   mBytes.emplace_back(byte);
   if (mBytes.size() == sMinimumSize) {
-    if (crateparams::isLoc(mBytes[0])) {
+    if (raw::isLoc(mBytes[0])) {
       // This is a local card
       uint8_t mask = getInputs();
       for (int ich = 0; ich < 4; ++ich) {

--- a/Detectors/MUON/MID/Raw/src/LocalBoardRO.cxx
+++ b/Detectors/MUON/MID/Raw/src/LocalBoardRO.cxx
@@ -26,7 +26,7 @@ namespace mid
 std::ostream& operator<<(std::ostream& os, const LocalBoardRO& loc)
 {
   /// Stream operator for LocalBoardRO
-  os << fmt::format("Crate ID: {:2d}  Loc ID: {:2d}  status: 0x{:2x}  event: 0x{:2x}  firedChambers: 0x{:1x}", static_cast<int>(crateparams::getCrateId(loc.boardId)), static_cast<int>(crateparams::getLocId(loc.boardId)), static_cast<int>(loc.statusWord), static_cast<int>(loc.eventWord), static_cast<int>(loc.firedChambers));
+  os << fmt::format("Crate ID: {:2d}  Loc ID: {:2d}  status: 0x{:2x}  trigger: 0x{:2x}  firedChambers: 0x{:1x}", static_cast<int>(crateparams::getCrateId(loc.boardId)), static_cast<int>(crateparams::getLocId(loc.boardId)), static_cast<int>(loc.statusWord), static_cast<int>(loc.triggerWord), static_cast<int>(loc.firedChambers));
   for (int ich = 0; ich < 4; ++ich) {
     os << fmt::format("  X: 0x{:4x} Y: 0x{:4x}", loc.patternsBP[ich], loc.patternsNBP[ich]);
   }

--- a/Detectors/MUON/MID/Raw/src/RawInfo.h
+++ b/Detectors/MUON/MID/Raw/src/RawInfo.h
@@ -36,7 +36,7 @@ static constexpr unsigned int sNBitsFiredChambers = 4;
 static constexpr unsigned int sNBitsLocalClock = 16;
 
 // Event info
-static constexpr unsigned int sNBitsEventWord = 8;
+static constexpr unsigned int sNBitsTriggerWord = 8;
 static constexpr uint16_t sDelayCalibToFET = 10;
 static constexpr uint16_t sDelayBCToLocal = 0;
 


### PR DESCRIPTION
This PR aims at reorganizing few constants/names used for MID raw data.
It consists of two commits:
- the first moves the functions to test the raw board status outside of CrateParameters...since they are not parameters of the crate, although they test some of them
- the second rename the event word into trigger word, in accordance with the name used in the readout electronics for the same word

The commits are atomic: please do not squash them