### PR TITLE
TPCClusterFinder: Fix rounding issue when accessing 2D array.

### DIFF
--- a/GPU/GPUTracking/TPCClusterFinder/Array2D.h
+++ b/GPU/GPUTracking/TPCClusterFinder/Array2D.h
@@ -64,15 +64,29 @@ class TilingLayout
 
     return (tileTime * widthInTiles + tilePad) * (Width * Height) + inTileTime * Width + inTilePad;
   }
+
+#if !defined(__OPENCL__)
+  GPUh() static size_t items()
+  {
+    return (TPC_NUM_OF_PADS + Width - 1) / Width * Width * (TPC_MAX_TIME_PADDED + Height - 1) / Height * Height;
+  }
+#endif
 };
 
-template <typename T>
 class LinearLayout
 {
+ public:
   GPUdi() static size_t idx(const ChargePos& p)
   {
     return TPC_NUM_OF_PADS * p.timePadded + p.gpad;
   }
+
+#if !defined(__OPENCL__)
+  GPUh() static size_t items()
+  {
+    return TPC_NUM_OF_PADS * TPC_MAX_TIME_PADDED;
+  }
+#endif
 };
 
 template <size_t S>
@@ -104,11 +118,14 @@ struct GridSize<4> {
 
 #if defined(CHARGEMAP_TILING_LAYOUT)
 template <typename T>
-using Array2D = AbstractArray2D<T, TilingLayout<GridSize<sizeof(T)>>>;
+using TPCMapMemoryLayout = TilingLayout<GridSize<sizeof(T)>>;
 #else
 template <typename T>
-using Array2D = AbstractArray2D<T, LinearLayout>;
+using TPCMapMemoryLayout = LinearLayout;
 #endif
+
+template <typename T>
+using Array2D = AbstractArray2D<T, TPCMapMemoryLayout<T>>;
 
 } // namespace gpu
 } // namespace GPUCA_NAMESPACE

--- a/GPU/GPUTracking/TPCClusterFinder/ChargePos.h
+++ b/GPU/GPUTracking/TPCClusterFinder/ChargePos.h
@@ -44,6 +44,12 @@ struct ChargePos {
   GPUdi() Pad pad() const { return gpad % TPC_PADS_PER_ROW_PADDED - PADDING_PAD; }
   GPUdi() Timestamp time() const { return timePadded - PADDING_TIME; }
 
+  GPUdi() bool isPadding() const
+  {
+    Pad pad = gpad % TPC_PADS_PER_ROW_PADDED;
+    return timePadded < PADDING_TIME || timePadded >= TPC_MAX_TIME || pad < PADDING_PAD;
+  }
+
  private:
   // Maps the position of a pad given as row and index in that row to a unique
   // index between 0 and TPC_NUM_OF_PADS.

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFNoiseSuppression.cxx
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFNoiseSuppression.cxx
@@ -80,8 +80,6 @@ GPUd() void GPUTPCCFNoiseSuppression::noiseSuppressionImpl(int nBlocks, int nThr
     return;
   }
 
-  DBG_PRINT("%d: p:%lx, m:%lx, b:%lx.", int(idx), peaksAroundBack, minimas, bigger);
-
   isPeakPredicate[idx] = keepMe;
 }
 

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCClusterFinder.cxx
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCClusterFinder.cxx
@@ -17,7 +17,10 @@
 #include "GPUHostDataTypes.h"
 
 #include "DataFormatsTPC/ZeroSuppression.h"
+
 #include "ChargePos.h"
+#include "Array2D.h"
+#include "Digit.h"
 
 using namespace GPUCA_NAMESPACE::gpu;
 using namespace o2::tpc;
@@ -62,10 +65,10 @@ void* GPUTPCClusterFinder::SetPointersScratch(void* mem)
   computePointerWithAlignment(mem, mPpeakPositions, mNMaxPeaks);
   computePointerWithAlignment(mem, mPfilteredPeakPositions, mNMaxClusters);
   computePointerWithAlignment(mem, mPisPeak, mNMaxDigits);
-  computePointerWithAlignment(mem, mPchargeMap, TPC_NUM_OF_PADS * TPC_MAX_TIME_PADDED);
-  computePointerWithAlignment(mem, mPpeakMap, TPC_NUM_OF_PADS * TPC_MAX_TIME_PADDED);
+  computePointerWithAlignment(mem, mPchargeMap, TPCMapMemoryLayout<decltype(*mPchargeMap)>::items());
+  computePointerWithAlignment(mem, mPpeakMap, TPCMapMemoryLayout<decltype(*mPpeakMap)>::items());
   if (not mRec->IsGPU() && mRec->GetDeviceProcessingSettings().runMC) {
-    computePointerWithAlignment(mem, mPindexMap, TPC_NUM_OF_PADS * TPC_MAX_TIME_PADDED);
+    computePointerWithAlignment(mem, mPindexMap, TPCMapMemoryLayout<decltype(*mPindexMap)>::items());
     computePointerWithAlignment(mem, mPlabelsByRow, GPUCA_ROW_COUNT * mNMaxClusterPerRow);
     computePointerWithAlignment(mem, mPlabelHeaderOffset, GPUCA_ROW_COUNT);
     computePointerWithAlignment(mem, mPlabelDataOffset, GPUCA_ROW_COUNT);


### PR DESCRIPTION
This PR fixes a rounding issue when accessing 2D arrays, when the width / height of the array was not a multiple of the tiling width / height.

@davidrohr This also fixes the difference between cpu and gpu on edge charges.