### PR TITLE
Optimization for ITS tracking workflows and cleaning up workflow control

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/src/ClusterWriterSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ClusterWriterSpec.cxx
@@ -85,7 +85,6 @@ void ClusterWriter::run(ProcessingContext& pc)
   mFile->Close();
 
   mState = 2;
-  pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
 }
 
 DataProcessorSpec getClusterWriterSpec(bool useMC)

--- a/Detectors/ITSMFT/ITS/workflow/src/ClustererSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ClustererSpec.cxx
@@ -135,7 +135,6 @@ void ClustererDPL::run(ProcessingContext& pc)
   }
 
   mState = 2;
-  pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
 }
 
 DataProcessorSpec getClustererSpec(bool useMC)

--- a/Detectors/ITSMFT/ITS/workflow/src/CookedTrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/CookedTrackerSpec.cxx
@@ -140,8 +140,6 @@ void CookedTrackerDPL::run(ProcessingContext& pc)
   }
 
   mState = 2;
-  pc.services().get<ControlService>().endOfStream();
-  pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
 }
 
 DataProcessorSpec getCookedTrackerSpec(bool useMC)

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackWriterSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackWriterSpec.cxx
@@ -94,7 +94,6 @@ void TrackWriter::run(ProcessingContext& pc)
   mFile->Close();
 
   mState = 2;
-  pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
 }
 
 DataProcessorSpec getTrackWriterSpec(bool useMC)

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -71,28 +71,34 @@ void TrackerDPL::run(ProcessingContext& pc)
 
   auto compClusters = pc.inputs().get<gsl::span<o2::itsmft::CompClusterExt>>("compClusters");
   auto clusters = pc.inputs().get<gsl::span<o2::itsmft::Cluster>>("clusters");
-  auto rofs = pc.inputs().get<std::vector<o2::itsmft::ROFRecord>>("ROframes"); // use vector rather than span, since used for output
+
+  // code further down does assignment to the rofs and the altered object is used for output
+  // we therefore need a copy of the vector rather than an object created directly on the input data,
+  // the output vector however is created directly inside the message memory thus avoiding copy by
+  // snapshot
+  auto rofsinput = pc.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("ROframes");
+  auto& rofs = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{"ITS", "ITSTrackROF", 0, Lifetime::Timeframe}, rofsinput.begin(), rofsinput.end());
 
   LOG(INFO) << "ITSTracker pulled " << clusters.size() << " clusters, "
             << rofs.size() << " RO frames and ";
 
   const dataformats::MCTruthContainer<MCCompLabel>* labels = nullptr;
-  std::vector<itsmft::MC2ROFRecord> mc2rofs;
+  gsl::span<itsmft::MC2ROFRecord const> mc2rofs;
   if (mIsMC) {
     labels = pc.inputs().get<const dataformats::MCTruthContainer<MCCompLabel>*>("labels").release();
-    // use vector rather than span since we are using it also for the output
-    mc2rofs = pc.inputs().get<std::vector<itsmft::MC2ROFRecord>>("MC2ROframes");
+    // get the array as read-onlt span, a snapshot is send forward
+    mc2rofs = pc.inputs().get<gsl::span<itsmft::MC2ROFRecord>>("MC2ROframes");
     LOG(INFO) << labels->getIndexedSize() << " MC label objects , in " << mc2rofs.size() << " MC events";
   }
 
   std::vector<o2::its::TrackITSExt> tracks;
-  std::vector<int> allClusIdx;
+  auto& allClusIdx = pc.outputs().make<std::vector<int>>(Output{"ITS", "TRACKCLSID", 0, Lifetime::Timeframe});
   o2::dataformats::MCTruthContainer<o2::MCCompLabel> trackLabels;
-  std::vector<o2::its::TrackITS> allTracks;
+  auto& allTracks = pc.outputs().make<std::vector<o2::its::TrackITS>>(Output{"ITS", "TRACKS", 0, Lifetime::Timeframe});
   o2::dataformats::MCTruthContainer<o2::MCCompLabel> allTrackLabels;
 
-  std::vector<o2::itsmft::ROFRecord> vertROFvec;
-  std::vector<Vertex> vertices;
+  auto& vertROFvec = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{"ITS", "VERTICESROF", 0, Lifetime::Timeframe});
+  auto& vertices = pc.outputs().make<std::vector<Vertex>>(Output{"ITS", "VERTICES", 0, Lifetime::Timeframe});
 
   std::uint32_t roFrame = 0;
   ROframe event(0);
@@ -153,12 +159,6 @@ void TrackerDPL::run(ProcessingContext& pc)
   }
 
   LOG(INFO) << "ITSTracker pushed " << allTracks.size() << " tracks";
-  pc.outputs().snapshot(Output{"ITS", "TRACKS", 0, Lifetime::Timeframe}, allTracks);
-  pc.outputs().snapshot(Output{"ITS", "TRACKCLSID", 0, Lifetime::Timeframe}, allClusIdx);
-  pc.outputs().snapshot(Output{"ITS", "TRACKSMCTR", 0, Lifetime::Timeframe}, allTrackLabels);
-  pc.outputs().snapshot(Output{"ITS", "ITSTrackROF", 0, Lifetime::Timeframe}, rofs);
-  pc.outputs().snapshot(Output{"ITS", "VERTICES", 0, Lifetime::Timeframe}, vertices);
-  pc.outputs().snapshot(Output{"ITS", "VERTICESROF", 0, Lifetime::Timeframe}, vertROFvec);
   if (mIsMC) {
     pc.outputs().snapshot(Output{"ITS", "TRACKSMCTR", 0, Lifetime::Timeframe}, allTrackLabels);
     pc.outputs().snapshot(Output{"ITS", "ITSTrackMC2ROF", 0, Lifetime::Timeframe}, mc2rofs);

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -165,8 +165,6 @@ void TrackerDPL::run(ProcessingContext& pc)
   }
 
   mState = 2;
-  pc.services().get<ControlService>().endOfStream();
-  pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
 }
 
 DataProcessorSpec getTrackerSpec(bool useMC)

--- a/Detectors/ITSMFT/ITS/workflow/src/VertexReaderSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/VertexReaderSpec.cxx
@@ -67,7 +67,6 @@ void VertexReader::run(ProcessingContext& pc)
   pc.outputs().snapshot(Output{"ITS", "VERTICESROF", 0, Lifetime::Timeframe}, mVerticesROFRec);
 
   mFinished = true;
-
   pc.services().get<ControlService>().endOfStream();
   pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
 }

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/IOUtils.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/IOUtils.h
@@ -19,6 +19,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <gsl/gsl>
 
 #include "MFTTracking/ROframe.h"
 #include "DataFormatsITSMFT/ROFRecord.h"
@@ -44,7 +45,7 @@ namespace mft
 
 namespace ioutils
 {
-Int_t loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& event, const std::vector<itsmft::Cluster>* clusters, const dataformats::MCTruthContainer<MCCompLabel>* mcLabels = nullptr);
+Int_t loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& event, gsl::span<itsmft::Cluster const> const& clusters, const dataformats::MCTruthContainer<MCCompLabel>* mcLabels = nullptr);
 void loadEventData(ROframe& event, const std::vector<itsmft::Cluster>* clusters,
                    const dataformats::MCTruthContainer<MCCompLabel>* mcLabels = nullptr);
 } // namespace IOUtils

--- a/Detectors/ITSMFT/MFT/tracking/src/IOUtils.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/IOUtils.cxx
@@ -34,13 +34,9 @@ namespace o2
 namespace mft
 {
 
-Int_t ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& event, const std::vector<itsmft::Cluster>* clusters,
+Int_t ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& event, gsl::span<itsmft::Cluster const> const& clusters,
                                const dataformats::MCTruthContainer<MCCompLabel>* mcLabels)
 {
-  if (!clusters) {
-    std::cerr << "Missing clusters." << std::endl;
-    return -1;
-  }
   event.clear();
   GeometryTGeo* geom = GeometryTGeo::Instance();
   geom->fillMatrixCache(utils::bit2Mask(TransformType::T2G));
@@ -48,7 +44,7 @@ Int_t ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& event,
 
   auto first = rof.getFirstEntry();
   auto number = rof.getNEntries();
-  auto clusters_in_frame = gsl::make_span(&(*clusters)[first], number);
+  auto clusters_in_frame = gsl::make_span(&(clusters)[first], number);
   for (auto& c : clusters_in_frame) {
     Int_t layer = geom->getLayer(c.getSensorID());
 

--- a/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
@@ -72,14 +72,22 @@ void TrackerDPL::run(ProcessingContext& pc)
 
   auto compClusters = pc.inputs().get<const std::vector<o2::itsmft::CompClusterExt>>("compClusters");
   auto clusters = pc.inputs().get<const std::vector<o2::itsmft::Cluster>>("clusters");
-  auto rofs = pc.inputs().get<const std::vector<o2::itsmft::ROFRecord>>("ROframes");
+
+  // code further down does assignment to the rofs and the altered object is used for output
+  // we therefore need a copy of the vector rather than an object created directly on the input data,
+  // the output vector however is created directly inside the message memory thus avoiding copy by
+  // snapshot
+  auto rofsinput = pc.inputs().get<const std::vector<o2::itsmft::ROFRecord>>("ROframes");
+  auto& rofs = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{"MFT", "MFTTrackROF", 0, Lifetime::Timeframe}, rofsinput.begin(), rofsinput.end());
 
   LOG(INFO) << "MFTTracker pulled " << clusters.size() << " clusters in "
             << rofs.size() << " RO frames";
 
   const dataformats::MCTruthContainer<MCCompLabel>* labels = mUseMC ? pc.inputs().get<const dataformats::MCTruthContainer<MCCompLabel>*>("labels").release() : nullptr;
-  std::vector<itsmft::MC2ROFRecord> mc2rofs = mUseMC ? pc.inputs().get<std::vector<itsmft::MC2ROFRecord>>("MC2ROframes") : std::vector<itsmft::MC2ROFRecord>();
+  gsl::span<itsmft::MC2ROFRecord const> mc2rofs;
   if (mUseMC) {
+    // get the array as read-only span, a snapshot of the object is sent forward
+    mc2rofs = pc.inputs().get<gsl::span<itsmft::MC2ROFRecord>>("MC2ROframes");
     LOG(INFO) << labels->getIndexedSize() << " MC label objects , in "
               << mc2rofs.size() << " MC events";
   }
@@ -87,12 +95,12 @@ void TrackerDPL::run(ProcessingContext& pc)
   std::vector<o2::mft::TrackMFTExt> tracks;
   std::vector<int> allClusIdx;
   o2::dataformats::MCTruthContainer<o2::MCCompLabel> trackLabels;
-  std::vector<o2::mft::TrackMFT> allTracks;
+  auto& allTracks = pc.outputs().make<std::vector<o2::mft::TrackMFT>>(Output{"MFT", "TRACKS", 0, Lifetime::Timeframe});
   o2::dataformats::MCTruthContainer<o2::MCCompLabel> allTrackLabels;
   std::vector<o2::mft::TrackLTF> tracksLTF;
-  std::vector<o2::mft::TrackLTF> allTracksLTF;
+  auto& allTracksLTF = pc.outputs().make<std::vector<o2::mft::TrackLTF>>(Output{"MFT", "TRACKSLTF", 0, Lifetime::Timeframe});
   std::vector<o2::mft::TrackCA> tracksCA;
-  std::vector<o2::mft::TrackCA> allTracksCA;
+  auto& allTracksCA = pc.outputs().make<std::vector<o2::mft::TrackCA>>(Output{"MFT", "TRACKSCA", 0, Lifetime::Timeframe});
 
   std::uint32_t roFrame = 0;
   o2::mft::ROframe event(0);
@@ -114,7 +122,7 @@ void TrackerDPL::run(ProcessingContext& pc)
 
   if (continuous) {
     for (const auto& rof : rofs) {
-      Int_t nclUsed = o2::mft::ioutils::loadROFrameData(rof, event, &clusters, labels);
+      Int_t nclUsed = o2::mft::ioutils::loadROFrameData(rof, event, gsl::span(clusters.data(), clusters.size()), labels);
       if (nclUsed) {
         event.setROFrameId(roFrame);
         event.initialise();
@@ -152,10 +160,6 @@ void TrackerDPL::run(ProcessingContext& pc)
   LOG(INFO) << "MFTTracker pushed " << allTracks.size() << " tracks";
   LOG(INFO) << "MFTTracker pushed " << allTracksLTF.size() << " tracks LTF";
   LOG(INFO) << "MFTTracker pushed " << allTracksCA.size() << " tracks CA";
-  pc.outputs().snapshot(Output{"MFT", "TRACKS", 0, Lifetime::Timeframe}, allTracks);
-  pc.outputs().snapshot(Output{"MFT", "TRACKSLTF", 0, Lifetime::Timeframe}, allTracksLTF);
-  pc.outputs().snapshot(Output{"MFT", "TRACKSCA", 0, Lifetime::Timeframe}, allTracksCA);
-  pc.outputs().snapshot(Output{"MFT", "MFTTrackROF", 0, Lifetime::Timeframe}, rofs);
   if (mUseMC) {
     pc.outputs().snapshot(Output{"MFT", "TRACKSMCTR", 0, Lifetime::Timeframe}, allTrackLabels);
     pc.outputs().snapshot(Output{"MFT", "MFTTrackMC2ROF", 0, Lifetime::Timeframe}, mc2rofs);


### PR DESCRIPTION
Hi Ruben, while working on the DPL IO API I came across these possible optimizations. I have so far quickly tested the standard its-reco-workflow with the cooked tracker, and from the first glimpse some histogrammed track parameters look the same. But verification would need a better one-to-one comparison, also for the MC labels.

Please have a look, and if there are some standard tests I'm happy to run those to verify the changes.

Optimization:
Avoid snapshot copies by allocating vectors directly in output message memory.

Cleanup:
The processors should be independent of the control, removing the forced
termination after one computation. The DPL now handles an end-of-stream
signal issued by upstream processors (data publishers) and automatically
terminates the workflow (depending on configurable policy).
   
- [ ] the writers should use a callback service to write the tree and
close the file at either end-of-stream or device stop. Alternatively we
can use the DPL RootTreeWriter utility which implements this.