### PR TITLE
Removing AliceO2Group/core from EMCAL codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -41,7 +41,7 @@
 /Detectors/Base                    @AliceO2Group/framework-admins
 /Detectors/Geometry                @AliceO2Group/framework-admins
 /Detectors/CPV                     @peressounko @kharlov
-/Detectors/EMCAL                   @mfasDa @AliceO2Group/core
+/Detectors/EMCAL                   @mfasDa
 /Detectors/FIT                     @AllaMaevskaya @jotwinow @mslupeck
 /Detectors/GlobalTracking          @shahor02
 /Detectors/GlobalTrackingWorkflow  @shahor02


### PR DESCRIPTION
This is already the situation for all other detectors
except EMCAL