### PR TITLE
Improve default parameters for forward generators

### DIFF
--- a/Generators/src/GeneratorFactory.cxx
+++ b/Generators/src/GeneratorFactory.cxx
@@ -76,7 +76,7 @@ void GeneratorFactory::setPrimaryGenerator(o2::conf::SimConfig const& conf, Fair
   } else if (genconfig.compare("fwmugen") == 0) {
     // a simple "box" generator for forward muons
     LOG(INFO) << "Init box forward muons generator";
-    auto boxGen = makeBoxGen(13, 100, -2.5, -4.0, 1000, 1000, 0., 360);
+    auto boxGen = makeBoxGen(13, 1, -4, -2.5, 50., 50., 0., 360);
     primGen->AddGenerator(boxGen);
   } else if (genconfig.compare("hmpidgun") == 0) {
     // a simple "box" generator for forward muons
@@ -85,13 +85,13 @@ void GeneratorFactory::setPrimaryGenerator(o2::conf::SimConfig const& conf, Fair
     primGen->AddGenerator(boxGen);
   } else if (genconfig.compare("fwpigen") == 0) {
     // a simple "box" generator for forward pions
-    LOG(INFO) << "Init box forward muons generator";
-    auto boxGen = makeBoxGen(-211, 100, -2.5, -4.5, 7, 7, 0, 360);
+    LOG(INFO) << "Init box forward pions generator";
+    auto boxGen = makeBoxGen(-211, 10, -4, -2.5, 7, 7, 0, 360);
     primGen->AddGenerator(boxGen);
   } else if (genconfig.compare("fwrootino") == 0) {
     // a simple "box" generator for forward rootinos
     LOG(INFO) << "Init box forward rootinos generator";
-    auto boxGen = makeBoxGen(0, 1, -2.5, -4.0, 1, 5, 0, 360);
+    auto boxGen = makeBoxGen(0, 1, -4, -2.5, 1, 5, 0, 360);
     primGen->AddGenerator(boxGen);
   } else if (genconfig.compare("zdcgen") == 0) {
     // a simple "box" generator for forward neutrons

--- a/prodtests/check_embedding_pileup.sh
+++ b/prodtests/check_embedding_pileup.sh
@@ -12,7 +12,7 @@
 #    and check whether the output digits have multiple labels --> checks embedding
 
 dets=(         ITS   TPC     TOF    EMC    HMP      MCH     MID    MFT     FV0     FT0   FDD   TRD     PHS    CPV    ZDC )
-generators=( boxgen boxgen boxgen boxgen hmpidgun fwpigen fwpigen fwpigen fddgen fddgen fddgen boxgen boxgen boxgen zdcgen )
+generators=( boxgen boxgen boxgen boxgen hmpidgun fwmugen fwmugen fwmugen fddgen fddgen fddgen boxgen boxgen boxgen zdcgen )
 
 simtask() {
  d=$1  # detector


### PR DESCRIPTION
- Use 1 muon per event instead of 100
- Fix the momentum range
- Use muons instead of pions when testing MCH, MFT, MID