### PR TITLE
Revert "Allow usage of (padding) 2bytes in the IR for user data (#3083)"

### DIFF
--- a/DataFormats/common/include/CommonDataFormat/InteractionRecord.h
+++ b/DataFormats/common/include/CommonDataFormat/InteractionRecord.h
@@ -27,9 +27,8 @@ struct InteractionRecord {
   static constexpr uint32_t DummyOrbit = 0xffffffff;
   static constexpr double DummyTime = DummyBC * o2::constants::lhc::LHCBunchSpacingNS + DummyOrbit * o2::constants::lhc::LHCOrbitNS;
 
-  uint32_t orbit = DummyOrbit; ///< LHC orbit
   uint16_t bc = DummyBC;       ///< bunch crossing ID of interaction
-  uint16_t user = 0;           ///< extra member for used data (the space would be anyway lost due to the alignment)
+  uint32_t orbit = DummyOrbit; ///< LHC orbit
 
   InteractionRecord() = default;
 
@@ -230,7 +229,7 @@ struct InteractionRecord {
 
   friend std::ostream& operator<<(std::ostream& stream, InteractionRecord const& ir);
 
-  ClassDefNV(InteractionRecord, 4);
+  ClassDefNV(InteractionRecord, 3);
 };
 
 struct InteractionTimeRecord : public InteractionRecord {
@@ -263,7 +262,7 @@ struct InteractionTimeRecord : public InteractionRecord {
 
   friend std::ostream& operator<<(std::ostream& stream, InteractionTimeRecord const& ir);
 
-  ClassDefNV(InteractionTimeRecord, 2);
+  ClassDefNV(InteractionTimeRecord, 1);
 };
 } // namespace o2
 

--- a/DataFormats/common/src/InteractionRecord.cxx
+++ b/DataFormats/common/src/InteractionRecord.cxx
@@ -17,7 +17,7 @@ namespace o2
 
 std::ostream& operator<<(std::ostream& stream, o2::InteractionRecord const& ir)
 {
-  stream << "BCid: " << ir.bc << " Orbit: " << ir.orbit << " UserWord: " << ir.user;
+  stream << "BCid: " << ir.bc << " Orbit: " << ir.orbit;
   return stream;
 }
 


### PR DESCRIPTION
This reverts commit b9ea5d9cefb376b644c48375a5d884db3e8c41f2.

We are observing problems with writing the InteractionRecord to ROOT tree, like in #3098.
    [12401:its-cluster-writer]: Fatal in <TBranchElement::InitializeOffsets>: Could not find the real data member 'ITSClustersROF.mBCData.user' when constructing the branch 'ITSClustersROF' [Likely an internal error, please report to the developers].

The same is for the ITSDigitWriter of the digitizer workflow.

Because of this sim_challenge is not running anymore.