### PR TITLE
[EMCAL-501] fix timing bug, set busy time

### DIFF
--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/Digitizer.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/Digitizer.h
@@ -63,7 +63,7 @@ class Digitizer : public TObject
   bool isContinuous() const { return mContinuous; }
 
   bool isEmpty() const { return mEmpty; }
-  bool readyToFlush(double t) const { return ((t > mLiveTime) && !isEmpty()); }
+  bool readyToFlush(double t) const { return ((t - mTriggerTime > mLiveTime) && !isEmpty()); }
 
   void fillOutputContainer(std::vector<Digit>& digits, o2::dataformats::MCTruthContainer<o2::emcal::MCLabel>& labels);
 

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/SimParam.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/SimParam.h
@@ -81,7 +81,7 @@ class SimParam : public o2::conf::ConfigurableParamHelper<SimParam>
   // Timing
   Float_t mSignalDelay{700}; ///< Signal delay time (ns)
   Float_t mLiveTime{1500};   ///< EMCal live time (ns)
-  Float_t mBusyTime{0};      ///< EMCal busy time (ns)
+  Float_t mBusyTime{35000};  ///< EMCal busy time (ns)
 
   // DigitizerSpec
   Bool_t mDisablePileup{false}; ///< disable pileup simulation


### PR DESCRIPTION
Fixed timing bug in Digitizer::readyToFlush(), set default busy time to 35 microseconds