### PR TITLE
Do not generate dict.for alias of MCCompLabel

### DIFF
--- a/Detectors/TRD/base/src/TRDBaseLinkDef.h
+++ b/Detectors/TRD/base/src/TRDBaseLinkDef.h
@@ -42,7 +42,6 @@
 #pragma link C++ class o2::trd::CalOnlineGainTables + ;
 #pragma link C++ class o2::trd::PadNoise + ;
 #pragma link C++ class o2::trd::PadResponse + ;
-#pragma link C++ class o2::trd::MCLabel + ;
 #pragma link C++ class o2::trd::Tracklet + ;
 #pragma link C++ class std::vector < o2::trd::Tracklet > +;
 


### PR DESCRIPTION
Since the TRD/MCLabel is just an alias to o2::MCCompLabel, adding it to LinkDef leads to duplicate dictionary.

This is to avoid ``Warning in <TInterpreter::ReadRootmapFile>: class  o2::MCCompLabel found in libO2TRDBase.so  is already in libO2SimulationDataFormat.so
``