### PR TITLE
Simplify and extend CcdbApi storeAs.. methods

### DIFF
--- a/CCDB/CMakeLists.txt
+++ b/CCDB/CMakeLists.txt
@@ -23,6 +23,7 @@ o2_add_library(CCDB
 o2_target_root_dictionary(CCDB
                           HEADERS
                                   include/CCDB/CcdbApi.h
+			          include/CCDB/CcdbObjectInfo.h
                                   include/CCDB/TObjectWrapper.h
                                   include/CCDB/IdPath.h
                                   include/CCDB/BasicCCDBManager.h

--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -22,6 +22,7 @@
 #include <curl/curl.h>
 #include <TObject.h>
 #include <TMessage.h>
+#include "CCDB/CcdbObjectInfo.h"
 
 class TFile;
 
@@ -62,6 +63,38 @@ class CcdbApi //: public DatabaseInterface
   std::string const& getURL() const { return mUrl; }
 
   /**
+   * Create a binary image of the arbitrary type object, if CcdbObjectInfo pointer is provided, register there 
+   *
+   * the assigned object class name and the filename
+   * @param obj: Raw pointer to the object to store.
+   * @param info: optinal info where assigned object name and filename will be filled
+   */
+  template <typename T>
+  inline static std::unique_ptr<std::vector<char>> createObjectImage(const T* obj, CcdbObjectInfo* info = nullptr)
+  {
+    return createObjectImage(reinterpret_cast<const void*>(obj), typeid(T), info);
+  }
+
+  /**
+   * Create a binary image of the TObject, if CcdbObjectInfo pointer is provided, register there 
+   *
+   * the assigned object class name and the filename
+   * @param obj: Raw pointer to the object to store.
+   * @param info: optinal info where assigned object name and filename will be filled
+   */
+  static std::unique_ptr<std::vector<char>> createObjectImage(const TObject* obj, CcdbObjectInfo* info = nullptr);
+
+  /**
+   * Create a binary image of the object, if CcdbObjectInfo pointer is provided, register there 
+   *
+   * the assigned object class name and the filename
+   * @param obj: Raw pointer to the object to store.
+   * @param tinfo: object type info
+   * @param info: optinal info where assigned object name and filename will be filled
+   */
+  static std::unique_ptr<std::vector<char>> createObjectImage(const void* obj, std::type_info const& tinfo, CcdbObjectInfo* info = nullptr);
+
+  /**
      * Store into the CCDB a TFile containing the ROOT object.
      *
      * @param rootObject Raw pointer to the object to store.
@@ -70,7 +103,7 @@ class CcdbApi //: public DatabaseInterface
      * @param startValidityTimestamp Start of validity. If omitted, current timestamp is used.
      * @param endValidityTimestamp End of validity. If omitted, current timestamp + 1 year is used.
      */
-  void storeAsTFile(TObject* rootObject, std::string const& path, std::map<std::string, std::string> const& metadata,
+  void storeAsTFile(const TObject* rootObject, std::string const& path, std::map<std::string, std::string> const& metadata,
                     long startValidityTimestamp = -1, long endValidityTimestamp = -1) const;
 
   /**
@@ -83,8 +116,18 @@ class CcdbApi //: public DatabaseInterface
      * @param endValidityTimestamp End of validity. If omitted, current timestamp + 1 year is used.
      */
   template <typename T>
-  void storeAsTFileAny(T* obj, std::string const& path, std::map<std::string, std::string> const& metadata,
-                       long startValidityTimestamp = -1, long endValidityTimestamp = -1) const;
+  void storeAsTFileAny(const T* obj, std::string const& path, std::map<std::string, std::string> const& metadata,
+                       long startValidityTimestamp = -1, long endValidityTimestamp = -1) const
+  {
+    storeAsTFile_impl(reinterpret_cast<const void*>(obj), typeid(T), path, metadata, startValidityTimestamp, endValidityTimestamp);
+  }
+
+  // interface for storing TObject via storeAsTFileAny
+  void storeAsTFileAny(const TObject* rootobj, std::string const& path, std::map<std::string, std::string> const& metadata,
+                       long startValidityTimestamp = -1, long endValidityTimestamp = -1) const
+  {
+    storeAsTFile(rootobj, path, metadata, startValidityTimestamp, endValidityTimestamp);
+  }
 
   /**
    * Retrieve object at the given path for the given timestamp.
@@ -244,6 +287,11 @@ class CcdbApi //: public DatabaseInterface
    */
   static std::map<std::string, std::string>* retrieveMetaInfo(TFile&);
 
+  /**
+   * Generates a file-name where the object will be stored (usually, from the provided class name)
+   */
+  static std::string generateFileName(const std::string& inp);
+
   constexpr static const char* CCDBQUERY_ENTRY = "ccdb_query";
   constexpr static const char* CCDBMETA_ENTRY = "ccdb_meta";
   constexpr static const char* CCDBOBJECT_ENTRY = "ccdb_object";
@@ -293,9 +341,16 @@ class CcdbApi //: public DatabaseInterface
 
  public:
   /**
+   * A generic method to store a binary buffer (e.g. an image of the TMemFile)
+   */
+  void storeAsBinaryFile(const char* buffer, size_t size, const std::string& fileName, const std::string& objectType,
+                         const std::string& path, const std::map<std::string, std::string>& metadata,
+                         long startValidityTimestamp, long endValidityTimestamp) const;
+
+  /**
    * A generic helper implementation to store an obj whose type is given by a std::type_info
    */
-  void storeAsTFile_impl(void* obj, std::type_info const& info, std::string const& path, std::map<std::string, std::string> const& metadata,
+  void storeAsTFile_impl(const void* obj1, std::type_info const& info, std::string const& path, std::map<std::string, std::string> const& metadata,
                          long startValidityTimestamp = -1, long endValidityTimestamp = -1) const;
 
  private:
@@ -325,15 +380,6 @@ class CcdbApi //: public DatabaseInterface
 
   ClassDefNV(CcdbApi, 1);
 };
-
-template <typename T>
-inline void CcdbApi::storeAsTFileAny(T* obj, std::string const& path, std::map<std::string, std::string> const& metadata,
-                                     long startValidityTimestamp, long endValidityTimestamp) const
-{
-  // get the type_info and dispatch to generic (untyped) implementation
-  storeAsTFile_impl(reinterpret_cast<void*>(obj), typeid(T), path, metadata,
-                    startValidityTimestamp, endValidityTimestamp);
-}
 
 template <typename T>
 T* CcdbApi::retrieveFromTFileAny(std::string const& path, std::map<std::string, std::string> const& metadata,

--- a/CCDB/include/CCDB/CcdbObjectInfo.h
+++ b/CCDB/include/CCDB/CcdbObjectInfo.h
@@ -1,0 +1,65 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef DETECTOR_CALIB_WRAPPER_H_
+#define DETECTOR_CALIB_WRAPPER_H_
+
+#include <Rtypes.h>
+#include "Framework/Logger.h"
+
+/// @brief information complementary to a CCDB object (path, metadata, startTimeValidity, endTimeValidity etc)
+
+namespace o2
+{
+namespace ccdb
+{
+class CcdbObjectInfo
+{
+ public:
+  CcdbObjectInfo() = default;
+  CcdbObjectInfo(std::string const& path, std::string const& objType, std::string const& flName,
+                 std::map<std::string, std::string> const& metadata,
+                 long startValidityTimestamp, long endValidityTimestamp)
+    : mPath(path), mObjType(objType), mFileName(flName), mMD(metadata), mStart(startValidityTimestamp), mEnd(endValidityTimestamp) {}
+  ~CcdbObjectInfo() = default;
+
+  const std::string& getObjectType() const { return mObjType; }
+  void setObjectType(const std::string& tp) { mObjType = tp; }
+
+  const std::string& getFileName() const { return mFileName; }
+  void setFileName(const std::string& nm) { mFileName = nm; }
+
+  const std::string& getPath() const { return mPath; }
+  void setPath(const std::string& path) { mPath = path; }
+
+  const std::map<std::string, std::string>& getMetaData() const { return mMD; }
+  void setMetaData(const std::map<std::string, std::string>& md) { mMD = md; }
+
+  long getStartValidityTimestamp() const { return mStart; }
+  void setStartValidityTimestamp(long start) { mStart = start; }
+
+  long getEndValidityTimestamp() const { return mEnd; }
+  void setEndValidityTimestamp(long end) { mEnd = end; }
+
+ private:
+  std::string mObjType{};                 // object type (e.g. class)
+  std::string mFileName{};                // file name in the CCDB
+  std::string mPath{};                    // path in the CCDB
+  std::map<std::string, std::string> mMD; // metadata
+  long mStart = 0;                        // start of the validity of the object
+  long mEnd = 0;                          // end of the validity of the object
+
+  ClassDefNV(CcdbObjectInfo, 1);
+};
+
+} // namespace ccdb
+} // namespace o2
+
+#endif

--- a/Common/Utils/CMakeLists.txt
+++ b/Common/Utils/CMakeLists.txt
@@ -23,7 +23,8 @@ o2_target_root_dictionary(CommonUtils
                                   include/CommonUtils/ShmManager.h
                                   include/CommonUtils/RngHelper.h
                                   include/CommonUtils/StringUtils.h
-                                  include/CommonUtils/ValueMonitor.h)
+                                  include/CommonUtils/ValueMonitor.h
+				  include/CommonUtils/MemFileHelper.h)
 
 o2_add_test(TreeStream
             COMPONENT_NAME CommonUtils
@@ -47,4 +48,10 @@ o2_add_test(ValueMonitor
             COMPONENT_NAME CommonUtils
             LABELS utils
             SOURCES test/testValueMonitor.cxx
+            PUBLIC_LINK_LIBRARIES O2::CommonUtils)
+
+o2_add_test(MemFileHelper
+            COMPONENT_NAME CommonUtils
+            LABELS utils
+            SOURCES test/testMemFileHelper.cxx
             PUBLIC_LINK_LIBRARIES O2::CommonUtils)

--- a/Common/Utils/include/CommonUtils/MemFileHelper.h
+++ b/Common/Utils/include/CommonUtils/MemFileHelper.h
@@ -1,0 +1,152 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   MemFileUtils.h
+/// @brief  Utilities to create a memory image of the object stored to file
+
+#ifndef O2_MEMFILE_UTILS_H
+#define O2_MEMFILE_UTILS_H
+
+#include <typeinfo>
+#include <utility>
+#include <TMemFile.h>
+#include "Framework/Logger.h"
+#include "CommonUtils/StringUtils.h"
+
+namespace o2
+{
+namespace utils
+{
+
+/// Static class for with methods to dump any root-persistent class to a TMemFile or its
+/// binary image
+
+struct MemFileHelper {
+  using FileImage = std::vector<char>;
+
+  //________________________________________________________________
+  /// get the class name of the object
+  template <typename T>
+  inline static std::string getClassName(const T& obj)
+  {
+    return getClassName(typeid(T));
+  }
+
+  //________________________________________________________________
+  /// dump object into the TMemFile named fileName. The stored object will be named according to the optName or its className
+  template <typename T>
+  inline static std::unique_ptr<TMemFile> createTMemFile(const T& obj, const std::string& fName, const std::string& optName = "")
+  {
+    return createTMemFile(&obj, typeid(T), fName, optName);
+  }
+
+  //________________________________________________________________
+  /// create binary image of the TMemFile containing the object and named fileName.
+  /// The stored object will be named according to the objName
+  static std::unique_ptr<FileImage> createFileImage(const TObject& obj, const std::string& fileName, const std::string& objName)
+  {
+    auto memfUPtr = createTMemFile(obj, fileName, objName);
+    std::unique_ptr<FileImage> img = std::make_unique<FileImage>(memfUPtr->GetSize());
+    auto sz = memfUPtr->CopyTo(img->data(), memfUPtr->GetSize());
+    img->resize(sz);
+    return img;
+  }
+
+  //________________________________________________________________
+  /// create binary image of the TMemFile containing the object and named fileName.
+  /// The stored object will be named according to the objName
+  template <typename T>
+  inline static std::unique_ptr<FileImage> createFileImage(const T& obj, const std::string& fileName, const std::string& optName = "")
+  {
+    return createFileImage(&obj, typeid(T), fileName, optName);
+  }
+
+  //________________________________________________________________
+  /// get the class name of the object
+  static std::string getClassName(const std::type_info& tinfo)
+  {
+    auto tcl = TClass::GetClass(tinfo);
+    std::string clname;
+    if (!tcl) {
+      LOG(ERROR) << "Could not retrieve ROOT dictionary for type " << tinfo.name();
+    } else {
+      clname = tcl->GetName();
+      utils::trim(clname);
+    }
+    return clname;
+  }
+
+  //________________________________________________________________
+  /// dump TObject the TMemFile named fileName. The stored object will be named according to the optName or its className
+  static std::unique_ptr<TMemFile> createTMemFile(const TObject& rootObject, const std::string& fName, const std::string& objName)
+  {
+    std::unique_ptr<TMemFile> uptr;
+#if ROOT_VERSION_CODE < ROOT_VERSION(6, 18, 0)
+    uptr = std::make_unique<TMemFile>(fName.c_str(), "RECREATE");
+#else
+    uptr = std::make_unique<TMemFile>(fName.c_str(), "RECREATE", "", ROOT::RCompressionSetting::EDefaults::kUseGeneralPurpose, 1024);
+#endif
+    if (uptr->IsZombie()) {
+      uptr->Close();
+      uptr.reset();
+      throw std::runtime_error(std::string("Error opening memory file ") + fName.c_str());
+    } else {
+      rootObject.Write(objName.c_str());
+      uptr->Close();
+    }
+    return uptr;
+  }
+
+  //________________________________________________________________
+  /// dump object into the TMemFile named fileName. The stored object will be named according to the optName or its className
+  static std::unique_ptr<TMemFile> createTMemFile(const void* obj, const std::type_info& tinfo, const std::string& fName, const std::string& optName = "")
+  {
+    std::unique_ptr<TMemFile> uptr;
+    std::string clsName = getClassName(tinfo);
+    if (clsName.empty()) {
+      return uptr;
+    }
+    std::string objName = optName.empty() ? clsName : optName;
+    std::string fileName = fName.empty() ? (objName + ".root") : fName;
+#if ROOT_VERSION_CODE < ROOT_VERSION(6, 18, 0)
+    uptr = std::make_unique<TMemFile>(fileName.c_str(), "RECREATE");
+#else
+    uptr = std::make_unique<TMemFile>(fileName.c_str(), "RECREATE", "", ROOT::RCompressionSetting::EDefaults::kUseGeneralPurpose, 1024);
+#endif
+    if (uptr->IsZombie()) {
+      uptr->Close();
+      uptr.reset();
+      throw std::runtime_error(std::string("Error opening memory file ") + fileName.c_str());
+    } else {
+      uptr->WriteObjectAny(obj, clsName.c_str(), objName.c_str());
+      uptr->Close();
+    }
+    return uptr;
+  }
+
+  //________________________________________________________________
+  /// create binary image of the TMemFile containing the object and named fileName.
+  /// The stored object will be named according to the optName or its className
+  static std::unique_ptr<FileImage> createFileImage(const void* obj, const std::type_info& tinfo, const std::string& fileName, const std::string& optName = "")
+  {
+    auto memfUPtr = createTMemFile(obj, tinfo, fileName, optName);
+    std::unique_ptr<FileImage> img = std::make_unique<FileImage>(memfUPtr->GetSize());
+    auto sz = memfUPtr->CopyTo(img->data(), memfUPtr->GetSize());
+    img->resize(sz);
+    return img;
+  }
+
+  ClassDefNV(MemFileHelper, 1);
+};
+
+} // namespace utils
+} // namespace o2
+
+#endif

--- a/Common/Utils/src/CommonUtilsLinkDef.h
+++ b/Common/Utils/src/CommonUtilsLinkDef.h
@@ -18,5 +18,6 @@
 #pragma link C++ class o2::utils::TreeStreamRedirector + ;
 #pragma link C++ class o2::utils::RootChain + ;
 #pragma link C++ class o2::utils::RngHelper;
+#pragma link C++ class o2::utils::MemFileHelper + ;
 
 #endif

--- a/Common/Utils/test/testMemFileHelper.cxx
+++ b/Common/Utils/test/testMemFileHelper.cxx
@@ -1,0 +1,41 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   testMemFileHelper.cxx
+/// @author ruben.shahoyan@cern.ch
+/// @brief  unit tests for TMemFile and its binary image creation
+
+#define BOOST_TEST_MODULE MemFileUtils unit test
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include <boost/filesystem.hpp>
+#include <cstdio>
+#include <vector>
+#include <TFile.h>
+#include "CommonUtils/MemFileHelper.h"
+
+BOOST_AUTO_TEST_CASE(test_memfile_helper)
+{
+  std::vector<int> vec = {1, 2, 3};
+  std::string fname = "test_MemFile.root";
+  std::string objname = o2::utils::MemFileHelper::getClassName(vec);
+  BOOST_CHECK(!objname.empty());
+  auto img = o2::utils::MemFileHelper::createFileImage(vec, "test_MemFile.root");
+  FILE* fp = fopen(fname.c_str(), "wb");
+  fwrite(img->data(), img->size(), 1, fp);
+  fclose(fp);
+  //
+  // try to read back
+  TFile rdf(fname.c_str());
+  auto* rvec = (std::vector<int>*)rdf.GetObjectChecked(objname.c_str(), objname.c_str());
+  BOOST_CHECK(rvec);
+  BOOST_CHECK(*rvec == vec);
+}


### PR DESCRIPTION
Moved repetetive TMemFile creation code to CommonUtils/MemFileHelper
Added possibility to store binary blob (e.g. TMemFile binary image), this should allow to
CCDB writer devices to be agnostic of the particular object type.