### PR TITLE
Adding unit test for output proxy connecting to output specs of a workflow

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -330,3 +330,19 @@ o2_add_test(
     arguments --consumer
     "--global-config consumer-config --local-option hello-aliceo2 --a-boolean3 --an-int2 20 --a-double2 22. --an-int64-2 50000000000000"
   )
+
+# Helper script for unit test 'test-ProxyForwarding', need a helper to combine
+# two executables on the command line.
+# Test runs a combined workflow with the DanglingOutputs tests and the o2-dpl-output-proxy.
+# The output proxy connects to the data spec which is not dangling, i.e. it is consumed
+# by both processor B and the output proxy.
+configure_file(test/test-ProxyForwarding.sh.in ${CMAKE_BINARY_DIR}/stage/tests/o2-test-framework-ProxyForwarding.sh COPYONLY)
+add_test(
+  NAME
+  test-ProxyForwarding
+  COMMAND
+  o2-test-framework-ProxyForwarding.sh
+  WORKING_DIRECTORY
+  "${CMAKE_BINARY_DIR}/stage/tests"
+  )
+set_tests_properties(test-ProxyForwarding PROPERTIES TIMEOUT 5)

--- a/Framework/Core/test/test-ProxyForwarding.sh.in
+++ b/Framework/Core/test/test-ProxyForwarding.sh.in
@@ -1,0 +1,10 @@
+#!/bin/bash -e
+
+# Helper script for unit test 'test-ProxyForwarding', need a helper to combine
+# two executables on the command line.
+# Run a combined workflow with the DanglingOutputs tests and the o2-dpl-output-proxy.
+# The output proxy connects to the data spec which is not dangling, i.e. it is consumed
+# by both processor B and the output proxy.
+./o2-test-framework-DanglingOutputs | \
+  ../bin/o2-dpl-output-proxy --run --dataspec dpl-output-proxy:TST/A1/0 \
+  --channel-config name=dpl-output-proxy,type=pub,method=bind,address=ipc://localhost${PID}_4200,rateLogging=10,transport=zeromq


### PR DESCRIPTION
A workflow is combined on the command line with the o2-dpl-output-proxy workflow.

Currently there is a bug in DPL when building the routing configuration. If the
output proxy connects to a spec which is also subscribed by another process in the
workflow, this processor tries to forward data on a channel which is not configured,
and which should not exist.

The same can be seen when connecting the QC workflow to detector reco workflows, e.g.
attaching a QC workflow subscribing clusters from the TPC reco workflow.