### PR TITLE
Adding posibility to disable writers in tpc-reco-workflow

### DIFF
--- a/Detectors/TPC/workflow/include/TPCWorkflow/RecoWorkflow.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/RecoWorkflow.h
@@ -37,6 +37,7 @@ enum struct OutputType { Digits,
                          Raw,
                          Clusters,
                          Tracks,
+                         DisableWriter,
 };
 
 /// create the workflow for TPC reconstruction

--- a/Detectors/TPC/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/TPC/workflow/src/RecoWorkflow.cxx
@@ -65,6 +65,7 @@ const std::unordered_map<std::string, OutputType> OutputMap{
   {"raw", OutputType::Raw},
   {"clusters", OutputType::Clusters},
   {"tracks", OutputType::Tracks},
+  {"disable-writer", OutputType::DisableWriter},
 };
 
 framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors, std::vector<int> const& laneConfiguration,
@@ -282,7 +283,7 @@ framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors, std::vec
   // a writer process for digits
   //
   // selected by output type 'difits'
-  if (isEnabled(OutputType::Digits)) {
+  if (isEnabled(OutputType::Digits) && !isEnabled(OutputType::DisableWriter)) {
     using DigitOutputType = std::vector<o2::tpc::Digit>;
     using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
     specs.push_back(makeWriterSpec("tpc-digits-writer",
@@ -301,7 +302,7 @@ framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors, std::vec
   // a writer process for raw hardware clusters
   //
   // selected by output type 'raw'
-  if (isEnabled(OutputType::Raw)) {
+  if (isEnabled(OutputType::Raw) && !isEnabled(OutputType::DisableWriter)) {
     using MCLabelContainer = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
     specs.push_back(makeWriterSpec("tpc-raw-cluster-writer",
                                    inputType == InputType::Raw ? "tpc-filtered-raw-clusters.root" : "tpc-raw-clusters.root",
@@ -319,7 +320,7 @@ framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors, std::vec
   // a writer process for TPC native clusters
   //
   // selected by output type 'clusters'
-  if (isEnabled(OutputType::Clusters)) {
+  if (isEnabled(OutputType::Clusters) && !isEnabled(OutputType::DisableWriter)) {
     using MCLabelCollection = std::vector<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>;
     specs.push_back(makeWriterSpec("tpc-native-cluster-writer",
                                    inputType == InputType::Clusters ? "tpc-filtered-native-clusters.root" : "tpc-native-clusters.root",
@@ -346,7 +347,7 @@ framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors, std::vec
   // a writer process for tracks
   //
   // selected by output type 'tracks'
-  if (isEnabled(OutputType::Tracks)) {
+  if (isEnabled(OutputType::Tracks) && !isEnabled(OutputType::DisableWriter)) {
     // defining the track writer process using the generic RootTreeWriter and generator tool
     //
     // defaults

--- a/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
+++ b/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
@@ -41,7 +41,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 
   std::vector<ConfigParamSpec> options{
     {"input-type", VariantType::String, "digits", {"digitizer, digits, raw, clusters"}},
-    {"output-type", VariantType::String, "tracks", {"digits, raw, clusters, tracks"}},
+    {"output-type", VariantType::String, "tracks", {"digits, raw, clusters, tracks, disable-writer"}},
     {"ca-clusterer", VariantType::Bool, false, {"Use clusterer of GPUCATracking"}},
     {"disable-mc", VariantType::Bool, false, {"disable sending of MC information"}},
     {"tpc-sectors", VariantType::String, "0-35", {"TPC sector range, e.g. 5-7,8,9"}},


### PR DESCRIPTION
The running processors are configured by the type of desired output, like
e.g. raw, clusters, tracks. A writer process is by default added For each
of the configured outputs. When combining the workflow with other workflows,
the writers are not always necessary and can now be removed from the workflow
using the key 'disable-writer' in the '--output-type' option.

This can also be used to prevent a routing bug which is triggered when attaching
the DPL output proxy or the QC workflow to the TPC reco workflow.

    o2-tpc-reco-workflow ... | o2-dpl-output-proxy --dataspec "dpl-output-proxy:TPC/TRACKS ...

The proxy is added between tracker and writer, however the writer is trying to
send back data to the proxy via a channel which is not existing

    [23170:tpc-track-writer]: [23:46:43][ERROR] requested channel has not been configured? check channel names/configuration.
    [23170:tpc-track-writer]: [23:46:43][ERROR] channel: from_tpc-track-writer_to_dpl-output-proxy, index: 0