### PR TITLE
DPL: Enable unit test test_ExternalFairMQDeviceWorkflow

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -309,12 +309,6 @@ set_property(TEST test_Framework_test_CustomGUIGL PROPERTY DISABLED TRUE)
 set_property(TEST test_Framework_test_CustomGUISokol PROPERTY DISABLED TRUE)
 endif()
 
-# there is a problem in the termination of the FairMQDevice by signals because
-# the pending input polling is aborted and this throws an error
-#    [ERROR] Failed receiving on socket input-proxy.input-proxy[0].pull, reason: Interrupted system call, nbytes = -1
-# this can either be fixed in FairMQ or in the DPL driver
-set_property(TEST test_Framework_test_ExternalFairMQDeviceWorkflow PROPERTY DISABLED TRUE)
-
 # TODO: investigate the problem and re-enable
 set_property(TEST test_Framework_test_BoostSerializedProcessing
              PROPERTY DISABLED TRUE)


### PR DESCRIPTION
Want to enable the unit test, but we first need to fix this in FairMQ or in the DPL driver.

There is a problem in the termination of the FairMQDevice by signals because
the pending input polling is aborted and this throws an error
```
[ERROR] Failed receiving on socket input-proxy.input-proxy[0].pull, reason: Interrupted system call, nbytes = -1
```
 This make the unit test fail for the moment.