### PR TITLE
TPCClusterFinder: Fix mc label behavior.

### DIFF
--- a/GPU/GPUTracking/Base/GPUHostDataTypes.h
+++ b/GPU/GPUTracking/Base/GPUHostDataTypes.h
@@ -42,7 +42,7 @@ struct GPUTPCDigitsMCInput {
 };
 
 struct GPUTPCClusterMCInterim {
-  std::vector<uint64_t> labels;
+  std::vector<o2::MCCompLabel> labels;
   uint offset;
 };
 

--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -873,6 +873,10 @@ int GPUChainTracking::RunTPCClusterizer()
         clusterer.DumpChargeMap(mDebugFile, "Charges");
       }
 
+      if (propagateMCLabels) {
+        runKernel<GPUTPCCFChargeMapFiller, GPUTPCCFChargeMapFiller::fillIndexMap>(GetGrid(clusterer.mPmemory->counters.nDigits, ClustererThreadCount(), lane), {iSlice}, {});
+      }
+
       runKernel<GPUTPCCFPeakFinder, GPUTPCCFPeakFinder::findPeaks>(GetGrid(clusterer.mPmemory->counters.nDigits, ClustererThreadCount(), lane), {iSlice}, {});
       DoDebugAndDump(RecoStep::TPCClusterFinding, 0, clusterer, &GPUTPCClusterFinder::DumpPeaks, mDebugFile);
 

--- a/GPU/GPUTracking/TPCClusterFinder/MCLabelAccumulator.h
+++ b/GPU/GPUTracking/TPCClusterFinder/MCLabelAccumulator.h
@@ -54,7 +54,7 @@ class MCLabelAccumulator
   GPUTPCClusterMCInterim* mOutput = nullptr;
 
   std::bitset<64> mMaybeHasLabel;
-  std::vector<uint64_t> mClusterLabels;
+  std::vector<o2::MCCompLabel> mClusterLabels;
 };
 
 } // namespace gpu


### PR DESCRIPTION
@davidrohr This PR fixes the broken mc labels produced by the cluster finder.

Two bugs are fixed here. First one is that a kernel required for the mc labels wasn't called.

The second bug was caused by the implicit `MCCompLabel(bool noise)` constructor which caused the raw `uint64` labels to be treated as noise. I didn't change the definition in `MCCompLabel` because this implicit constructor is used all over the place. But some of these usages look like they might be bugs...