### PR TITLE
fix disabling TRD trapsimulator

### DIFF
--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
@@ -36,7 +36,7 @@ class TRDDPLTrapSimulatorTask : public Task
 {
 
  public:
-  TRDDPLTrapSimulatorTask(bool disabletrapsim) : mDisableTrapSimulation(disabletrapsim) { cout << " TRAPDISABLE SET TO : " << disabletrapsim << endl; }
+  TRDDPLTrapSimulatorTask() = default;
   ~TRDDPLTrapSimulatorTask() override = default;
   void init(o2::framework::InitContext& ic) override;
   void run(o2::framework::ProcessingContext& pc) override;
@@ -51,7 +51,6 @@ class TRDDPLTrapSimulatorTask : public Task
   int mPrintTrackletOptions = 0;    // print the tracklets to the screen, ascii art
   int mDrawTrackletOptions = 0;     //draw the tracklets 1 per file
   int mShowTrackletStats = 0;       //the the accumulated total tracklets found
-  int mDisableTrapSimulation = 0;   // option to not do trapsimulation, mostly for the digitizer
   std::vector<Tracklet> mTracklets; // store of tracklets to then be inserted into a message.
   std::string mTrapConfigName;      // the name of the config to be used.
   std::string mTrapConfigBaseName = "TRD_test/TrapConfig/";
@@ -59,7 +58,7 @@ class TRDDPLTrapSimulatorTask : public Task
   void loadTrapConfig();
 };
 
-o2::framework::DataProcessorSpec getTRDTrapSimulatorSpec(int channelfan, bool disabletrapsim = false);
+o2::framework::DataProcessorSpec getTRDTrapSimulatorSpec();
 
 } // end namespace trd
 } // end namespace o2

--- a/Detectors/TRD/workflow/src/TRDDigitizerSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDDigitizerSpec.cxx
@@ -125,9 +125,7 @@ class TRDDPLDigitizerTask
         std::vector<o2::trd::Digit> digits;                         // digits which get filled
         o2::dataformats::MCTruthContainer<o2::trd::MCLabel> labels; // labels which get filled
         mDigitizer.process(hits, digits, labels);
-        for (auto& digit : digits) {
-          digit.setTimeStamp(irecords[collID].timeNS);
-        }
+
         // Add trigger record
         triggers.emplace_back(irecords[collID], digitsAccum.size(), digits.size());
 

--- a/Detectors/TRD/workflow/src/TRDTrapSimulatorSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrapSimulatorSpec.cxx
@@ -215,7 +215,6 @@ void TRDDPLTrapSimulatorTask::init(o2::framework::InitContext& ic)
   mDrawTrackletOptions = ic.options().get<int>("drawtracklets");
   mShowTrackletStats = ic.options().get<int>("show-trd-trackletstats");
   mTrapConfigName = ic.options().get<std::string>("trapconfig");
-  LOG(info) << "disable trap simualtor is : " << mDisableTrapSimulation;
   LOG(info) << "Trap Simulator Device initialising with trap config of : " << mTrapConfigName;
   //  if(mDisableTrapSimulation){
   //  //now get a trapconfig to work with.
@@ -230,10 +229,7 @@ void TRDDPLTrapSimulatorTask::init(o2::framework::InitContext& ic)
 void TRDDPLTrapSimulatorTask::run(o2::framework::ProcessingContext& pc)
 {
   LOG(info) << "TRD Trap Simulator Device running over incoming message ...";
-  if (mDisableTrapSimulation) {
-    LOG(warn) << " you elected to not do a trap chip simulation";
-    return;
-  }
+
   // get the relevant inputs for the TrapSimulator
   auto digits = pc.inputs().get<std::vector<o2::trd::Digit>>("digitinput");
   //auto mMCLabels = pc.inputs().get<o2::dataformats::MCTruthContainer<o2::trd::MCLabel>*>("labelinput");
@@ -409,13 +405,13 @@ void TRDDPLTrapSimulatorTask::run(o2::framework::ProcessingContext& pc)
   //pc.outputs().snapshot(Output{"TRD","TRGRRecords",0,Lifetime::Timeframe},mTriggerRecords);
 }
 
-o2::framework::DataProcessorSpec getTRDTrapSimulatorSpec(int channelfan, bool disabletrapsim)
+o2::framework::DataProcessorSpec getTRDTrapSimulatorSpec()
 {
   return DataProcessorSpec{"TRAP", Inputs{InputSpec{"digitinput", "TRD", "DIGITS", 0}, InputSpec{"triggerrecords", "TRD", "TRGRDIG", 0}, InputSpec{"labelinput", "TRD", "LABELS", 0}},
                            Outputs{OutputSpec{"TRD", "TRACKLETS", 0, Lifetime::Timeframe}},
                            //                                   OutputSpec{"TRD","TRGRRecords",0,Lifetime::Timeframe}},
                            //                               OutputSpec{"TRD","TRKLABELS",0, Lifetime::Timeframe},
-                           AlgorithmSpec{adaptFromTask<TRDDPLTrapSimulatorTask>(disabletrapsim)},
+                           AlgorithmSpec{adaptFromTask<TRDDPLTrapSimulatorTask>()},
                            Options{
                              {"show-trd-trackletstats", VariantType::Int, 25000, {"Display the accumulated size and capacity at number of track intervals"}},
                              {"trapconfig", VariantType::String, "default", {"Name of the trap config from the CCDB"}},

--- a/Detectors/TRD/workflow/src/TRDTrapSimulatorWorkFlow.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrapSimulatorWorkFlow.cxx
@@ -83,7 +83,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     o2::trd::getTRDDigitReaderSpec(1),
     //o2::trd::getTRDDigitReaderSpec(1),
     // connect the TRD digitization
-    o2::trd::getTRDTrapSimulatorSpec(0),
+    o2::trd::getTRDTrapSimulatorSpec(),
     // connect the TRD digit writer
     o2::trd::getTRDTrackletWriterSpec()};
 }

--- a/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
+++ b/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
@@ -151,7 +151,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   workflowOptions.push_back(ConfigParamSpec{"use-ccdb-tof", o2::framework::VariantType::Bool, false, {"enable access to ccdb tof calibration objects"}});
 
   // option to use or not use the Trap Simulator after digitisation (debate of digitization or reconstruction is for others)
-  workflowOptions.push_back(ConfigParamSpec{"enable-trd-trapsim", VariantType::Bool, false, {"disable the trap simulation of the TRD"}});
+  workflowOptions.push_back(ConfigParamSpec{"enable-trd-trapsim", VariantType::Bool, false, {"enable the trap simulation of the TRD"}});
 }
 
 // ------------------------------------------------------------------
@@ -471,12 +471,13 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     specs.emplace_back(o2::trd::getTRDDigitizerSpec(fanoutsize++));
     // connect the TRD digit writer
     specs.emplace_back(o2::trd::getTRDDigitWriterSpec());
-
-    auto disableTrapSim = configcontext.options().get<bool>("enable-trd-trapsim");
-    // connect the TRD Trap SimulatorA
-    specs.emplace_back(o2::trd::getTRDTrapSimulatorSpec(0, (bool)disableTrapSim));
-    // connect to the device to write out the tracklets.
-    specs.emplace_back(o2::trd::getTRDTrackletWriterSpec());
+    auto enableTrapSim = configcontext.options().get<bool>("enable-trd-trapsim");
+    if (enableTrapSim) {
+      // connect the TRD Trap SimulatorA
+      specs.emplace_back(o2::trd::getTRDTrapSimulatorSpec());
+      // connect to the device to write out the tracklets.
+      specs.emplace_back(o2::trd::getTRDTrackletWriterSpec());
+    }
   }
 
   //add MUON MCH


### PR DESCRIPTION
- Change the logic of disabling TrapSimulator.
- Remove the manual setting of time for digits.
- trdtracklets.root is no longer created when trapsimulator is disabled in digitizer.
- option parameters stay the same.