### PR TITLE
DPL: unify the InputRecord::get API

### DIFF
--- a/Framework/Core/include/Framework/InputRecord.h
+++ b/Framework/Core/include/Framework/InputRecord.h
@@ -189,46 +189,48 @@ class InputRecord
     return mSpan.getNofParts(pos);
   }
 
-  template <typename T = DataRef, typename std::enable_if_t<std::is_same<T, DataRef>::value == true, int> = 0>
-  decltype(auto) get(char const* binding) const
-  {
-    // implementation (a)
-    // DataRef is special. Since there is no point in storing one in a payload,
-    // what it actually does is to return the DataRef used to hold the
-    // (header, payload) pair.
-    // returns DataRef object
-    try {
-      auto pos = getPos(binding);
-      if (pos < 0) {
-        throw std::invalid_argument("no matching route found for " + std::string(binding));
-      }
-      return getByPos(pos);
-    } catch (const std::exception& e) {
-      throw std::runtime_error("Unknown argument requested " + std::string(binding) +
-                               " - " + e.what());
-    }
-  }
-
-  /// get object of the specified type from input
-  /// The actual operation and cast depends on the target data type and the serialization type of the
-  /// incoming data. See @ref Inputrecord class description for supported types.
-  /// @param binding   the input to extract the data from
-  template <typename T, typename std::enable_if_t<std::is_same<T, DataRef>::value == false, int> = 0>
-  decltype(auto) get(char const* binding) const
-  {
-    // make sure the selection is working
-    static_assert(std::is_same<T, DataRef>::value == false);
-    return get<T>(get<DataRef>(binding));
-  }
-
-  /// get object of specified type for input DataRef
-  /// The actual operation and cast depends on the target data type and the serialization type of the
-  /// incoming data. See @ref Inputrecord class description for supported types.
+  /// Get the object of specified type T for the binding R.
+  /// If R is a string like object, we look up by name the InputSpec and
+  /// return the data associated to the given label.
+  /// If R is a DataRef, we extract the result object from the Payload,
+  /// following the information provided by the Header.
+  /// The actual operation and cast depends on the target data type and the
+  /// serialization type of the incoming data.
+  /// By default we return a DataRef, which is the pair of pointers to
+  /// the header and payload of the O2 Message.
+  /// See @ref Inputrecord class description for supported types.
   /// @param ref   DataRef with pointers to input spec, header, and payload
-  template <typename T>
-  static decltype(auto) get(DataRef ref)
+  template <typename T = DataRef, typename R>
+  decltype(auto) get(R binding, int part = 0) const
   {
-    if constexpr (std::is_same<T, std::string>::value) {
+    DataRef ref{nullptr, nullptr};
+    // Get the actual dataref
+    if constexpr (std::is_same_v<std::decay_t<R>, char const*> ||
+                  std::is_same_v<std::decay_t<R>, char*> ||
+                  std::is_same_v<std::decay_t<R>, std::string>) {
+      try {
+        int pos = -1;
+        if constexpr (std::is_same_v<std::decay_t<R>, std::string>) {
+          pos = getPos(binding.c_str());
+        } else {
+          pos = getPos(binding);
+        }
+        if (pos < 0) {
+          throw std::invalid_argument("no matching route found for " + std::string(binding));
+        }
+        ref = this->getByPos(pos, part);
+      } catch (const std::exception& e) {
+        throw std::runtime_error("Unknown argument requested " + std::string(binding) +
+                                 " - " + e.what());
+      }
+    } else if constexpr (std::is_same_v<std::decay_t<R>, DataRef>) {
+      ref = binding;
+    } else {
+      static_assert(always_static_assert_v<R>, "Unknown binding type");
+    }
+    if constexpr (std::is_same_v<std::decay_t<T>, DataRef>) {
+      return ref;
+    } else if constexpr (std::is_same<T, std::string>::value) {
       // substitution for std::string
       // If we ask for a string, we need to duplicate it because we do not want
       // the buffer to be deleted when it goes out of scope. The string is built
@@ -411,12 +413,6 @@ class InputRecord
         throw std::runtime_error("Attempt to extract object from message with unsupported serialization type");
       }
     }
-  }
-
-  template <typename T = DataRef>
-  decltype(auto) get(std::string const& binding) const
-  {
-    return get<T>(binding.c_str());
   }
 
   template <typename T>


### PR DESCRIPTION
Support getting the sub-parts while doing so.