### PR TITLE
Sample workflows for calibration in groups of TFs, case of LHC clock calibration in TOF

### DIFF
--- a/CCDB/src/CCDBLinkDef.h
+++ b/CCDB/src/CCDBLinkDef.h
@@ -17,5 +17,6 @@
 #pragma link C++ class o2::ccdb::IdPath + ;
 #pragma link C++ class o2::ccdb::CcdbApi + ;
 #pragma link C++ class o2::ccdb::CCDBQuery + ;
+#pragma link C++ class o2::ccdb::CcdbObjectInfo + ;
 #pragma link C++ class o2::ccdb::BasicCCDBManager + ;
 #endif

--- a/Detectors/CMakeLists.txt
+++ b/Detectors/CMakeLists.txt
@@ -32,6 +32,8 @@ add_subdirectory(GlobalTracking)
 add_subdirectory(GlobalTrackingWorkflow)
 add_subdirectory(Vertexing)
 
+add_subdirectory(Calibration)
+
 if(BUILD_SIMULATION)
   add_subdirectory(gconfig)
 endif()

--- a/Detectors/Calibration/CMakeLists.txt
+++ b/Detectors/Calibration/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Copyright CERN and copyright holders of ALICE O2. This software is distributed
+# under the terms of the GNU General Public License v3 (GPL Version 3), copied
+# verbatim in the file "COPYING".
+#
+# See http://alice-o2.web.cern.ch/license for full licensing information.
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization or
+# submit itself to any jurisdiction.
+
+o2_add_header_only_library(DetectorsCalibration
+                           INTERFACE_LINK_LIBRARIES O2::Headers
+	                                            O2::CCDB
+                                                    O2::CommonUtils
+	                                            ms_gsl::ms_gsl)
+
+#o2_target_root_dictionary(DetectorsCalibration
+#                          HEADERS include/DetectorsCalibration/TimeSlotCalibration.h
+#			          include/DetectorsCalibration/TimeSlot.h
+#			          include/DetectorsCalibration/Utils.h)
+
+o2_add_executable(ccdb-populator-workflow
+                  COMPONENT_NAME calibration
+                  SOURCES workflow/ccdb-populator-workflow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::Framework
+ 		                        O2::TOFCalibration
+	                                O2::DetectorsCalibration
+					O2::DataFormatsTOF
+					O2::CCDB)

--- a/Detectors/Calibration/include/DetectorsCalibration/TimeSlot.h
+++ b/Detectors/Calibration/include/DetectorsCalibration/TimeSlot.h
@@ -1,0 +1,82 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef DETECTOR_CALIB_TIMESLOT_H_
+#define DETECTOR_CALIB_TIMESLOT_H_
+
+#include <Rtypes.h>
+#include "Framework/Logger.h"
+
+/// @brief Wrapper for the container of calibration data for single time slot
+
+namespace o2
+{
+namespace calibration
+{
+
+template <typename Container>
+class TimeSlot
+{
+  using TFType = uint64_t;
+
+ public:
+  TimeSlot() = default;
+  TimeSlot(TFType tfS, TFType tfE) : mTFStart(tfS), mTFEnd(tfE) {}
+  TimeSlot(const TimeSlot& src) : mTFStart(src.mTFStart), mTFEnd(src.mTFEnd), mContainer(std::make_unique<Container>(*src.getContainer())) {}
+  TimeSlot& operator=(const TimeSlot& src)
+  {
+    if (&src != this) {
+      mTFStart = src.mTFStart;
+      mTFEnd = src.mTFEnd;
+      mContainer = std::make_unique<Container>(*src.getContainer());
+    }
+    return *this;
+  }
+
+  ~TimeSlot() = default;
+
+  TFType getTFStart() const { return mTFStart; }
+  TFType getTFEnd() const { return mTFEnd; }
+  const Container* getContainer() const { return mContainer.get(); }
+  Container* getContainer() { return mContainer.get(); }
+  void setContainer(std::unique_ptr<Container> ptr) { mContainer = std::move(ptr); }
+
+  void setTFStart(TFType v) { mTFStart = v; }
+  void setTFEnd(TFType v) { mTFEnd = v; }
+
+  // compare the TF with this slot boundaties
+  int relateToTF(TFType tf) { return tf < mTFStart ? -1 : (tf > mTFEnd ? 1 : 0); }
+
+  // merge data of previous slot to this one and extend the mTFStart to cover prev
+  void mergeToPrevious(TimeSlot& prev)
+  {
+    mContainer->merge(prev.mContainer.get());
+    mTFStart = prev.mTFStart;
+  }
+
+  void print() const
+  {
+    LOGF(INFO, "Calibration slot %5d <=TF<=  %5d", mTFStart, mTFEnd);
+    mContainer->print();
+  }
+
+ private:
+  TFType mTFStart = 0;
+  TFType mTFEnd = 0;
+  size_t mEntries = 0;
+  std::unique_ptr<Container> mContainer; // user object to accumulate the calibration data for this slot
+
+  ClassDefNV(TimeSlot, 1);
+};
+
+} // namespace calibration
+} // namespace o2
+
+#endif

--- a/Detectors/Calibration/include/DetectorsCalibration/TimeSlotCalibration.h
+++ b/Detectors/Calibration/include/DetectorsCalibration/TimeSlotCalibration.h
@@ -1,0 +1,184 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef DETECTOR_CALIB_TIMESLOTCALIB_H_
+#define DETECTOR_CALIB_TIMESLOTCALIB_H_
+
+/// @brief Processor for the multiple time slots calibration
+
+#include "DetectorsCalibration/TimeSlot.h"
+#include <deque>
+#include <gsl/gsl>
+
+namespace o2
+{
+namespace calibration
+{
+
+template <typename Input, typename Container>
+class TimeSlotCalibration
+{
+  using Slot = TimeSlot<Container>;
+  using TFType = uint64_t;
+
+ public:
+  uint32_t getMaxSlotsDelay() const { return mMaxSlotsDelay; }
+  void setMaxSlotsDelay(uint32_t v) { mMaxSlotsDelay = v < 1 ? 1 : v; }
+
+  uint32_t getSlotLength() const { return mSlotLength; }
+  void setSlotLength(uint32_t v) { mSlotLength = v < 1 ? 1 : v; }
+
+  int getNSlots() const { return mSlots.size(); }
+  Slot& getSlotForTF(TFType tf);
+  Slot& getSlot(int i) { return (Slot&)mSlots.at(i); }
+  const Slot& getSlot(int i) const { return (Slot&)mSlots.at(i); }
+  const Slot& getLastSlot() const { return (Slot&)mSlots.back(); }
+  const Slot& getFirstSlot() const { return (Slot&)mSlots.front(); }
+
+  virtual bool process(TFType tf, const gsl::span<const Input> data);
+  virtual void checkSlotsToFinalize(TFType tf, int maxDelay = 0);
+
+  // Methods to be implemented by the derived user class
+
+  // implement and call this method te reset the output slots once they are not needed
+  virtual void initOutput() = 0;
+  // process the time slot container and add results to the output
+  virtual void finalizeSlot(Slot& slot) = 0;
+  // create new time slot in the beginning or the end of the slots pool
+  virtual Slot& emplaceNewSlot(bool front, TFType tstart, TFType tend) = 0;
+  // check if the slot has enough data to be finalized
+  virtual bool hasEnoughData(const Slot& slot) const = 0;
+
+  virtual void print() const;
+
+ protected:
+  auto& getSlots() { return mSlots; }
+
+ private:
+  size_t tf2SlotMin(TFType tf) const;
+
+  std::deque<Slot> mSlots;
+
+  TFType mLastClosedTF = 0;
+  TFType mTFStart = 0;
+  uint32_t mSlotLength = 1;
+  uint32_t mMaxSlotsDelay = 3;
+
+  ClassDef(TimeSlotCalibration, 1);
+};
+
+//_________________________________________________
+template <typename Input, typename Container>
+bool TimeSlotCalibration<Input, Container>::process(TFType tf, const gsl::span<const Input> data)
+{
+  int maxDelay = mMaxSlotsDelay * mSlotLength;
+  //  if (tf<mLastClosedTF || (!mSlots.empty() && getSlot(0).getTFStart() > tf + maxDelay)) { // ignore TF
+  if (tf < mLastClosedTF || (!mSlots.empty() && getLastSlot().getTFStart() > tf + maxDelay)) { // ignore TF
+    LOG(INFO) << "Ignoring TF " << tf;
+    return false;
+  }
+
+  // check if some slots are done
+  checkSlotsToFinalize(tf, maxDelay);
+
+  // process current TF
+  auto& slotTF = getSlotForTF(tf);
+  slotTF.getContainer()->fill(data);
+
+  return true;
+}
+
+//_________________________________________________
+template <typename Input, typename Container>
+void TimeSlotCalibration<Input, Container>::checkSlotsToFinalize(TFType tf, int maxDelay)
+{
+  // Check which slots can be finalized, provided the newly arrived TF is tf
+  // check if some slots are done
+  for (auto slot = mSlots.begin(); slot != mSlots.end(); slot++) {
+    if ((slot->getTFEnd() + maxDelay) < tf) {
+      if (hasEnoughData(*slot)) {
+        finalizeSlot(*slot); // will be removed after finalization
+      } else if ((slot + 1) != mSlots.end()) {
+        LOG(INFO) << "Merging underpopulated slot " << slot->getTFStart() << " <= TF <= " << slot->getTFEnd()
+                  << " to slot " << (slot + 1)->getTFStart() << " <= TF <= " << (slot + 1)->getTFEnd();
+        (slot + 1)->mergeToPrevious(*slot);
+      } else {
+        LOG(INFO) << "Discard underpopulated slot " << slot->getTFStart() << " <= TF <= " << slot->getTFEnd();
+        break; // slot has no enough stat. and there is no other slot to merge it to
+      }
+      mLastClosedTF = slot->getTFEnd() + 1; // do not accept any TF below this
+      LOG(INFO) << "closing slot " << slot->getTFStart() << " <= TF <= " << slot->getTFEnd();
+      mSlots.erase(slot);
+    } else {
+      break;
+    }
+    if (mSlots.empty()) { // since erasing the very last entry may invalidate mSlots.end()
+      break;
+    }
+  }
+}
+
+//________________________________________
+template <typename Input, typename Container>
+inline size_t TimeSlotCalibration<Input, Container>::tf2SlotMin(TFType tf) const
+{
+  if (tf < mTFStart) {
+    throw std::runtime_error("invalide TF");
+  }
+  return int((tf - mTFStart) / mSlotLength) * mSlotLength + mTFStart;
+}
+
+//_________________________________________________
+template <typename Input, typename Container>
+TimeSlot<Container>& TimeSlotCalibration<Input, Container>::getSlotForTF(TFType tf)
+{
+  if (!mSlots.empty() && mSlots.front().getTFStart() > tf) {
+    auto tfmn = tf2SlotMin(mSlots.front().getTFStart() - 1);
+    while (tfmn >= tf) {
+      LOG(INFO) << "Adding new slot for " << tfmn << " <= TF <= " << tfmn + mSlotLength - 1;
+      emplaceNewSlot(true, tfmn, tfmn + mSlotLength - 1);
+      if (!tfmn) {
+        break;
+      }
+      tfmn = tf2SlotMin(mSlots.front().getTFStart() - 1);
+    }
+    return mSlots[0];
+  }
+  for (auto it = mSlots.begin(); it != mSlots.end(); it++) {
+    auto rel = (*it).relateToTF(tf);
+    if (rel == 0) {
+      return (*it);
+    }
+  }
+  // need to add in the end
+  auto tfmn = mSlots.empty() ? tf2SlotMin(tf) : tf2SlotMin(mSlots.back().getTFEnd() + 1);
+  do {
+    LOG(INFO) << "Adding new slot for " << tfmn << " <= TF <= " << tfmn + mSlotLength - 1;
+    emplaceNewSlot(false, tfmn, tfmn + mSlotLength - 1);
+    tfmn = tf2SlotMin(mSlots.back().getTFEnd() + 1);
+  } while (tf > mSlots.back().getTFEnd());
+
+  return mSlots.back();
+}
+
+//_________________________________________________
+template <typename Input, typename Container>
+void TimeSlotCalibration<Input, Container>::print() const
+{
+  for (int i = 0; i < getNSlots(); i++) {
+    LOG(INFO) << "Slot #" << i << " of " << getNSlots();
+    getSlot(i).print();
+  }
+}
+
+} // namespace calibration
+} // namespace o2
+
+#endif

--- a/Detectors/Calibration/include/DetectorsCalibration/Utils.h
+++ b/Detectors/Calibration/include/DetectorsCalibration/Utils.h
@@ -1,0 +1,40 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   Utils.h
+/// @brief  Utils and constants for calibration and related workflows
+
+#ifndef O2_CALIBRATION_CONVENTIONS_H
+#define O2_CALIBRATION_CONVENTIONS_H
+
+#include <typeinfo>
+#include <utility>
+#include <fstream>
+#include <TMemFile.h>
+#include "Headers/DataHeader.h"
+#include "CommonUtils/StringUtils.h"
+#include "CCDB/CCDBTimeStampUtils.h"
+
+namespace o2
+{
+namespace calibration
+{
+
+struct Utils {
+
+  static constexpr o2::header::DataOrigin gDataOriginCLB{"CLB"};                          // generic DataOrigin for calibrations
+  static constexpr o2::header::DataDescription gDataDescriptionCLBPayload = "CLBPAYLOAD"; // DataDescription for TMemFile sent for CCDB storage
+  static constexpr o2::header::DataDescription gDataDescriptionCLBInfo = "CCDBWRAPPER";   // DataDescription for wrapper helper
+};
+
+} // namespace calibration
+} // namespace o2
+
+#endif

--- a/Detectors/Calibration/workflow/CCDBPopulatorSpec.h
+++ b/Detectors/Calibration/workflow/CCDBPopulatorSpec.h
@@ -1,0 +1,96 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_CALIBRATION_CCDBPOPULATOR_H
+#define O2_CALIBRATION_CCDBPOPULATOR_H
+
+/// @file   CCDBPopulator.h
+/// @brief  device to populate CCDB
+
+#include "Framework/DeviceSpec.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "Framework/WorkflowSpec.h"
+#include "Framework/Task.h"
+#include "Framework/CompletionPolicyHelpers.h"
+#include "Framework/DataRefUtils.h"
+#include "Headers/DataHeader.h"
+#include "DetectorsCalibration/Utils.h"
+#include "CCDB/BasicCCDBManager.h"
+#include "CCDB/CcdbApi.h"
+#include "CCDB/CcdbObjectInfo.h"
+
+using CcdbManager = o2::ccdb::BasicCCDBManager;
+
+namespace o2
+{
+namespace calibration
+{
+
+class CCDBPopulator : public o2::framework::Task
+{
+  using CcdbObjectInfo = o2::ccdb::CcdbObjectInfo;
+  using CcdbApi = o2::ccdb::CcdbApi;
+
+ public:
+  void init(o2::framework::InitContext& ic) final
+  {
+    mCCDBpath = ic.options().get<std::string>("ccdb-path");
+    auto& mgr = CcdbManager::instance();
+    mgr.setURL(mCCDBpath);
+    mAPI.init(mgr.getURL());
+  }
+
+  void run(o2::framework::ProcessingContext& pc) final
+  {
+    int nSlots = pc.inputs().getNofParts(0);
+    assert(pc.inputs().getNofParts(1) == nSlots);
+
+    for (int isl = 0; isl < nSlots; isl++) {
+      const auto wrp = pc.inputs().get<CcdbObjectInfo*>("clbInfo", isl);
+      const auto pld = pc.inputs().get<gsl::span<char>>("clbPayload", isl); // this is actually an image of TMemFile
+
+      LOG(INFO) << "Storing in ccdb " << wrp->getPath() << "/" << wrp->getFileName() << " of size " << pld.size()
+                << " Valid for " << wrp->getStartValidityTimestamp() << " : " << wrp->getEndValidityTimestamp();
+      mAPI.storeAsBinaryFile(&pld[0], pld.size(), wrp->getFileName(), wrp->getObjectType(), wrp->getPath(),
+                             wrp->getMetaData(), wrp->getStartValidityTimestamp(), wrp->getEndValidityTimestamp());
+    }
+  }
+
+ private:
+  CcdbApi mAPI;
+  std::string mCCDBpath = "http://ccdb-test.cern.ch:8080"; // CCDB path
+};
+
+} // namespace calibration
+
+namespace framework
+{
+
+DataProcessorSpec getCCDBPopulatorDeviceSpec()
+{
+  using clbUtils = o2::calibration::Utils;
+  std::vector<InputSpec> inputs;
+  inputs.emplace_back("clbPayload", ConcreteDataTypeMatcher{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBPayload});
+  inputs.emplace_back("clbInfo", ConcreteDataTypeMatcher{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBInfo});
+
+  return DataProcessorSpec{
+    "ccdb-populator",
+    inputs,
+    Outputs{},
+    AlgorithmSpec{adaptFromTask<o2::calibration::CCDBPopulator>()},
+    Options{
+      {"ccdb-path", VariantType::String, "http://ccdb-test.cern.ch:8080", {"Path to CCDB"}}}};
+}
+
+} // namespace framework
+} // namespace o2
+
+#endif

--- a/Detectors/Calibration/workflow/ccdb-populator-workflow.cxx
+++ b/Detectors/Calibration/workflow/ccdb-populator-workflow.cxx
@@ -1,0 +1,34 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/DataProcessorSpec.h"
+#include "CCDBPopulatorSpec.h"
+
+using namespace o2::framework;
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // we customize the pipeline processors to consume data as it comes
+  using CompletionPolicy = o2::framework::CompletionPolicy;
+  using CompletionPolicyHelpers = o2::framework::CompletionPolicyHelpers;
+  policies.push_back(CompletionPolicyHelpers::defineByName("lhc-clockphase-workflow.*", CompletionPolicy::CompletionOp::Consume));
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  WorkflowSpec specs;
+  specs.emplace_back(getCCDBPopulatorDeviceSpec());
+  return specs;
+}

--- a/Detectors/TOF/calibration/CMakeLists.txt
+++ b/Detectors/TOF/calibration/CMakeLists.txt
@@ -9,10 +9,35 @@
 # submit itself to any jurisdiction.
 
 o2_add_library(TOFCalibration
-               SOURCES src/CalibTOFapi.cxx src/CalibTOF.cxx src/CollectCalibInfoTOF.cxx
+               SOURCES src/CalibTOFapi.cxx
+	               src/CalibTOF.cxx
+		       src/CollectCalibInfoTOF.cxx
+                       src/LHCClockCalibrator.cxx
                PUBLIC_LINK_LIBRARIES O2::DataFormatsTOF O2::TOFBase
-                                     O2::CCDB)
-
+                                     O2::CCDB
+	                             O2::DetectorsCalibration
+				     ROOT::Minuit
+	                             ms_gsl::ms_gsl)
+				  
+				   
 o2_target_root_dictionary(TOFCalibration
-                          HEADERS include/TOFCalibration/CalibTOFapi.h include/TOFCalibration/CalibTOF.h
+                          HEADERS include/TOFCalibration/CalibTOFapi.h
+                                  include/TOFCalibration/CalibTOF.h
+                                  include/TOFCalibration/LHCClockCalibrator.h
                                   include/TOFCalibration/CollectCalibInfoTOF.h)
+
+
+o2_add_executable(data-generator-workflow
+                  COMPONENT_NAME calibration
+                  SOURCES testWorkflow/data-generator-workflow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::Framework
+	                                O2::DataFormatsTOF
+					O2::TOFBase)
+
+o2_add_executable(lhc-clockphase-workflow
+                  COMPONENT_NAME calibration
+                  SOURCES testWorkflow/lhc-clockphase-workflow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::Framework
+ 		                        O2::TOFCalibration
+	                                O2::DetectorsCalibration)
+

--- a/Detectors/TOF/calibration/include/TOFCalibration/LHCClockCalibrator.h
+++ b/Detectors/TOF/calibration/include/TOFCalibration/LHCClockCalibrator.h
@@ -1,0 +1,89 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef TOF_CALIBWORKFLOW_H_
+#define TOF_CALIBWORKFLOW_H_
+
+#include "DetectorsCalibration/TimeSlotCalibration.h"
+#include "DetectorsCalibration/TimeSlot.h"
+#include "DataFormatsTOF/CalibInfoTOF.h"
+#include "TOFCalibration/CalibTOFapi.h"
+#include "DataFormatsTOF/CalibLHCphaseTOF.h"
+#include "CCDB/CcdbObjectInfo.h"
+#include <array>
+
+namespace o2
+{
+namespace tof
+{
+
+struct LHCClockDataHisto {
+  float range = 24400;
+  int nbins = 1000;
+  float v2Bin = nbins / (2 * range);
+  int entries = 0;
+  std::vector<float> histo{0};
+
+  LHCClockDataHisto();
+
+  LHCClockDataHisto(int nb, float r) : nbins(nb), range(r), v2Bin(0)
+  {
+    if (r <= 0. || nb < 1) {
+      throw std::runtime_error("Wrong initialization of the histogram");
+    }
+    v2Bin = nbins / (2 * range);
+    histo.resize(nbins, 0.);
+  }
+
+  size_t getEntries() const { return entries; }
+  void print() const;
+  void fill(const gsl::span<const o2::dataformats::CalibInfoTOF> data);
+  void merge(const LHCClockDataHisto* prev);
+
+  ClassDefNV(LHCClockDataHisto, 1);
+};
+
+class LHCClockCalibrator : public o2::calibration::TimeSlotCalibration<o2::dataformats::CalibInfoTOF, o2::tof::LHCClockDataHisto>
+{
+  using TFType = uint64_t;
+  using Slot = o2::calibration::TimeSlot<o2::tof::LHCClockDataHisto>;
+  using CalibTOFapi = o2::tof::CalibTOFapi;
+  using LHCphase = o2::dataformats::CalibLHCphaseTOF;
+  using CcdbObjectInfo = o2::ccdb::CcdbObjectInfo;
+  using CcdbObjectInfoVector = std::vector<CcdbObjectInfo>;
+  using LHCphaseVector = std::vector<LHCphase>;
+
+ public:
+  LHCClockCalibrator(int minEnt = 500, int nb = 1000, float r = 24400, const std::string path = "http://ccdb-test.cern.ch:8080") : mMinEntries(minEnt), mNBins(nb), mRange(r) { mCalibTOFapi.setURL(path); }
+
+  bool hasEnoughData(const Slot& slot) const final { return slot.getContainer()->entries >= mMinEntries; }
+  void initOutput() final;
+  void finalizeSlot(Slot& slot) final;
+  Slot& emplaceNewSlot(bool front, TFType tstart, TFType tend) final;
+
+  const LHCphaseVector& getLHCphaseVector() const { return mLHCphaseVector; }
+  const CcdbObjectInfoVector& getLHCphaseInfoVector() const { return mInfoVector; }
+  CcdbObjectInfoVector& getLHCphaseInfoVector() { return mInfoVector; }
+
+ private:
+  int mMinEntries = 0;
+  int mNBins = 0;
+  float mRange = 0.;
+  CalibTOFapi mCalibTOFapi;
+  CcdbObjectInfoVector mInfoVector; // vector of CCDB Infos , each element is filled with the CCDB description of the accompanying LHCPhase
+  LHCphaseVector mLHCphaseVector;   // vector of LhcPhase, each element is filled in "process" when we finalize one slot (multiple can be finalized during the same "process", which is why we have a vector. Each element is to be considered the output of the device, and will go to the CCDB
+
+  ClassDefOverride(LHCClockCalibrator, 1);
+};
+
+} // end namespace tof
+} // end namespace o2
+
+#endif /* TOF_CALIBWORKFLOW_H_ */

--- a/Detectors/TOF/calibration/src/LHCClockCalibrator.cxx
+++ b/Detectors/TOF/calibration/src/LHCClockCalibrator.cxx
@@ -1,0 +1,115 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "TOFCalibration/LHCClockCalibrator.h"
+#include "Framework/Logger.h"
+#include "MathUtils/MathBase.h"
+#include "CommonUtils/MemFileHelper.h"
+#include "CCDB/CcdbApi.h"
+#include "DetectorsCalibration/Utils.h"
+
+namespace o2
+{
+namespace tof
+{
+
+using Slot = o2::calibration::TimeSlot<o2::tof::LHCClockDataHisto>;
+using o2::math_utils::math_base::fitGaus;
+using LHCphase = o2::dataformats::CalibLHCphaseTOF;
+using clbUtils = o2::calibration::Utils;
+
+//_____________________________________________
+LHCClockDataHisto::LHCClockDataHisto()
+{
+  LOG(INFO) << "Default c-tor, not to be used";
+}
+
+//_____________________________________________
+void LHCClockDataHisto::fill(const gsl::span<const o2::dataformats::CalibInfoTOF> data)
+{
+  // fill container
+  for (int i = data.size(); i--;) {
+    auto dt = data[i].getDeltaTimePi();
+    dt += range;
+    if (dt > 0 && dt < 2 * range) {
+      histo[int(dt * v2Bin)]++;
+      entries++;
+    }
+  }
+}
+
+//_____________________________________________
+void LHCClockDataHisto::merge(const LHCClockDataHisto* prev)
+{
+  // merge data of 2 slots
+  for (int i = histo.size(); i--;) {
+    histo[i] += prev->histo[i];
+  }
+  entries += prev->entries;
+}
+
+//_____________________________________________
+void LHCClockDataHisto::print() const
+{
+  LOG(INFO) << entries << " entries";
+}
+
+//===================================================================
+
+//_____________________________________________
+void LHCClockCalibrator::initOutput()
+{
+  // Here we initialize the vector of our output objects
+  mInfoVector.clear();
+  mLHCphaseVector.clear();
+  return;
+}
+
+//_____________________________________________
+void LHCClockCalibrator::finalizeSlot(Slot& slot)
+{
+  // Extract results for the single slot
+  o2::tof::LHCClockDataHisto* c = slot.getContainer();
+  LOG(INFO) << "Finalize slot " << slot.getTFStart() << " <= TF <= " << slot.getTFEnd() << " with "
+            << c->getEntries() << " entries";
+  std::vector<float> fitValues;
+  float* array = &c->histo[0];
+  int fitres = fitGaus(c->nbins, array, -(c->range), c->range, fitValues);
+  if (fitres >= 0) {
+    LOG(INFO) << "Fit result " << fitres << " Mean = " << fitValues[1] << " Sigma = " << fitValues[2];
+  } else {
+    LOG(ERROR) << "Fit failed with result = " << fitres;
+  }
+
+  // TODO: the timestamp is now given with the TF index, but it will have
+  // to become an absolute time. This is true both for the lhc phase object itself
+  // and the CCDB entry
+  std::map<std::string, std::string> md;
+  LHCphase l;
+  l.addLHCphase(slot.getTFStart(), fitValues[1]);
+  auto clName = o2::utils::MemFileHelper::getClassName(l);
+  auto flName = o2::ccdb::CcdbApi::generateFileName(clName);
+  mInfoVector.emplace_back("TOF/LHCphase", clName, flName, md, slot.getTFStart(), 99999999999999);
+  mLHCphaseVector.emplace_back(l);
+
+  slot.print();
+}
+
+//_____________________________________________
+Slot& LHCClockCalibrator::emplaceNewSlot(bool front, TFType tstart, TFType tend)
+{
+  auto& cont = getSlots();
+  auto& slot = front ? cont.emplace_front(tstart, tend) : cont.emplace_back(tstart, tend);
+  slot.setContainer(std::make_unique<LHCClockDataHisto>(mNBins, mRange));
+  return slot;
+}
+
+} // end namespace tof
+} // end namespace o2

--- a/Detectors/TOF/calibration/src/TOFCalibrationLinkDef.h
+++ b/Detectors/TOF/calibration/src/TOFCalibrationLinkDef.h
@@ -18,4 +18,9 @@
 #pragma link C++ class o2::globaltracking::CalibTOF + ;
 #pragma link C++ class o2::globaltracking::CollectCalibInfoTOF + ;
 
+#pragma link C++ class o2::tof::LHCClockDataHisto + ;
+#pragma link C++ class o2::calibration::TimeSlot < o2::tof::LHCClockDataHisto> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::dataformats::CalibInfoTOF, o2::tof::LHCClockDataHisto> + ;
+#pragma link C++ class o2::tof::LHCClockCalibrator + ;
+
 #endif

--- a/Detectors/TOF/calibration/testWorkflow/DataGeneratorSpec.h
+++ b/Detectors/TOF/calibration/testWorkflow/DataGeneratorSpec.h
@@ -1,0 +1,128 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_CALIBRATION_DATAGENERATOR_H
+#define O2_CALIBRATION_DATAGENERATOR_H
+
+/// @file   DataGeneratorSpec.h
+/// @brief  Dummy data generator
+
+#include <unistd.h>
+#include <TRandom.h>
+#include "Framework/DeviceSpec.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "Framework/WorkflowSpec.h"
+#include "Framework/Task.h"
+#include "DataFormatsTOF/CalibInfoTOF.h"
+#include "TOFBase/Geo.h"
+#include "CommonConstants/MathConstants.h"
+
+namespace o2
+{
+namespace calibration
+{
+
+class TFDispatcher : public o2::framework::Task
+{
+ public:
+  void init(o2::framework::InitContext& ic) final
+  {
+    mMaxTF = ic.options().get<int64_t>("max-timeframes");
+  }
+
+  void run(o2::framework::ProcessingContext& pc) final
+  {
+    for (auto& input : pc.inputs()) {
+      auto tfid = header::get<o2::framework::DataProcessingHeader*>(input.header)->startTime;
+      if (tfid >= mMaxTF) {
+        LOG(INFO) << "Data generator reached TF " << tfid << ", stopping";
+        pc.services().get<o2::framework::ControlService>().endOfStream();
+        pc.services().get<o2::framework::ControlService>().readyToQuit(o2::framework::QuitRequest::Me);
+        break;
+      }
+    }
+    int size = 100 + gRandom->Integer(100); // push dummy output
+    pc.outputs().snapshot(o2::framework::OutputRef{"output", 0}, size);
+  }
+
+ private:
+  uint64_t mMaxTF = 1;
+};
+
+class TFProcessor : public o2::framework::Task
+{
+ public:
+  void init(o2::framework::InitContext& ic) final
+  {
+    mDevCopy = ic.services().get<const o2::framework::DeviceSpec>().inputTimesliceId;
+    gRandom->SetSeed(mDevCopy);
+    mMeanLatency = std::max(1, ic.options().get<int>("mean-latency"));
+    mLatencyRMS = std::max(1, ic.options().get<int>("latency-spread"));
+    LOG(INFO) << "TFProcessorCopy: " << mDevCopy << " MeanLatency: " << mMeanLatency << " LatencyRMS: " << mLatencyRMS;
+  }
+
+  void run(o2::framework::ProcessingContext& pc) final
+  {
+    auto tfcounter = o2::header::get<o2::framework::DataProcessingHeader*>(pc.inputs().get("input").header)->startTime;
+    // introduceDelay
+    uint32_t delay = std::abs(gRandom->Gaus(mMeanLatency, mLatencyRMS));
+    LOG(INFO) << "TFProcessorCopy: " << mDevCopy << " Simulate latency of " << delay << " mcs for TF " << tfcounter;
+    usleep(delay);
+
+    // push dummy output
+    auto size = pc.inputs().get<int>("input");
+    auto& output = pc.outputs().make<std::vector<o2::dataformats::CalibInfoTOF>>(o2::framework::OutputRef{"output", 0});
+    output.reserve(size);
+
+    double clockShift = 1e3 * std::sin(tfcounter / 100. * o2::constants::math::PI);
+
+    for (int i = size; i--;) {
+      output.emplace_back(gRandom->Integer(o2::tof::Geo::NCHANNELS), 0, gRandom->Gaus(clockShift, 100.), 0, 0);
+    }
+  }
+
+ private:
+  int mDevCopy = 0;
+  uint32_t mMeanLatency = 0;
+  uint32_t mLatencyRMS = 1;
+};
+
+} // namespace calibration
+
+namespace framework
+{
+
+DataProcessorSpec getTFDispatcherSpec()
+{
+  return DataProcessorSpec{
+    "calib-tf-dispatcher",
+    Inputs{},
+    Outputs{{{"output"}, "DUM", "DATASIZE"}},
+    AlgorithmSpec{adaptFromTask<o2::calibration::TFDispatcher>()},
+    Options{{"max-timeframes", VariantType::Int64, 99999999999ll, {"max TimeFrames to generate"}}}};
+}
+
+DataProcessorSpec getTFProcessorSpec()
+{
+  return DataProcessorSpec{
+    "calib-tf-data-processor",
+    Inputs{{"input", "DUM", "DATASIZE"}},
+    Outputs{{{"output"}, "DUM", "CALIBDATA"}},
+    AlgorithmSpec{adaptFromTask<o2::calibration::TFProcessor>()},
+    Options{
+      {"mean-latency", VariantType::Int, 1000, {"mean latency of the generator in microseconds"}},
+      {"latency-spread", VariantType::Int, 100, {"latency gaussian RMS of the generator in microseconds"}}}};
+}
+
+} // namespace framework
+} // namespace o2
+
+#endif

--- a/Detectors/TOF/calibration/testWorkflow/LHCClockCalibratorSpec.h
+++ b/Detectors/TOF/calibration/testWorkflow/LHCClockCalibratorSpec.h
@@ -1,0 +1,123 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_CALIBRATION_LHCCLOCK_CALIBRATOR_H
+#define O2_CALIBRATION_LHCCLOCK_CALIBRATOR_H
+
+/// @file   LHCClockCalibratorSpec.h
+/// @brief  Device to calibrate LHC clock phase using TOF data
+
+#include "TOFCalibration/LHCClockCalibrator.h"
+#include "DetectorsCalibration/Utils.h"
+#include "DataFormatsTOF/CalibInfoTOF.h"
+#include "CommonUtils/MemFileHelper.h"
+#include "Framework/Task.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "Framework/WorkflowSpec.h"
+#include "CCDB/CcdbApi.h"
+#include "CCDB/CcdbObjectInfo.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace calibration
+{
+
+class LHCClockCalibDevice : public o2::framework::Task
+{
+ public:
+  void init(o2::framework::InitContext& ic) final
+  {
+    int minEnt = std::max(300, ic.options().get<int>("min-entries"));
+    int nb = std::max(500, ic.options().get<int>("nbins"));
+    int slotL = ic.options().get<int>("tf-per-slot");
+    int delay = ic.options().get<int>("max-delay");
+    mCalibrator = std::make_unique<o2::tof::LHCClockCalibrator>(minEnt, nb);
+    mCalibrator->setSlotLength(slotL);
+    mCalibrator->setMaxSlotsDelay(delay);
+  }
+
+  void run(o2::framework::ProcessingContext& pc) final
+  {
+    auto tfcounter = o2::header::get<o2::framework::DataProcessingHeader*>(pc.inputs().get("input").header)->startTime;
+    auto data = pc.inputs().get<gsl::span<o2::dataformats::CalibInfoTOF>>("input");
+    LOG(INFO) << "Processing TF " << tfcounter << " with " << data.size() << " tracks";
+    mCalibrator->process(tfcounter, data);
+    sendOutput(pc.outputs());
+    const auto& infoVec = mCalibrator->getLHCphaseInfoVector();
+    LOG(INFO) << "Created " << infoVec.size() << " objects for TF " << tfcounter;
+  }
+
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final
+  {
+    LOG(INFO) << "Finalizing calibration";
+    constexpr uint64_t INFINITE_TF = 0xffffffffffffffff;
+    mCalibrator->checkSlotsToFinalize(INFINITE_TF);
+    sendOutput(ec.outputs());
+  }
+
+ private:
+  std::unique_ptr<o2::tof::LHCClockCalibrator> mCalibrator;
+
+  //________________________________________________________________
+  void sendOutput(DataAllocator& output)
+  {
+    // extract CCDB infos and calibration objects, convert it to TMemFile and send them to the output
+    // TODO in principle, this routine is generic, can be moved to Utils.h
+    using clbUtils = o2::calibration::Utils;
+    const auto& payloadVec = mCalibrator->getLHCphaseVector();
+    auto& infoVec = mCalibrator->getLHCphaseInfoVector(); // use non-const version as we update it
+    assert(payloadVec.size() == infoVec.size());
+
+    for (uint32_t i = 0; i < payloadVec.size(); i++) {
+      auto& w = infoVec[i];
+      auto image = o2::ccdb::CcdbApi::createObjectImage(&payloadVec[i], &w);
+      LOG(INFO) << "Senging object " << w.getPath() << "/" << w.getFileName() << " of size " << image->size()
+                << " bytes, valid for " << w.getStartValidityTimestamp() << " : " << w.getEndValidityTimestamp();
+      output.snapshot(Output{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBPayload, i}, *image.get()); // vector<char>
+      output.snapshot(Output{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBInfo, i}, w);               // root-serialized
+    }
+    if (payloadVec.size()) {
+      mCalibrator->initOutput(); // reset the outputs once they are already sent
+    }
+  }
+};
+
+} // namespace calibration
+
+namespace framework
+{
+
+DataProcessorSpec getLHCClockCalibDeviceSpec()
+{
+  using device = o2::calibration::LHCClockCalibDevice;
+  using clbUtils = o2::calibration::Utils;
+
+  std::vector<OutputSpec> outputs;
+  outputs.emplace_back(ConcreteDataTypeMatcher{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBPayload});
+  outputs.emplace_back(ConcreteDataTypeMatcher{clbUtils::gDataOriginCLB, clbUtils::gDataDescriptionCLBInfo});
+  return DataProcessorSpec{
+    "calib-lhcclock-calibration",
+    Inputs{{"input", "DUM", "CALIBDATA"}},
+    outputs,
+    AlgorithmSpec{adaptFromTask<device>()},
+    Options{
+      {"tf-per-slot", VariantType::Int, 5, {"number of TFs per calibration time slot"}},
+      {"max-delay", VariantType::Int, 3, {"number of slots in past to consider"}},
+      {"min-entries", VariantType::Int, 500, {"minimum number of entries to fit single time slot"}},
+      {"nbins", VariantType::Int, 1000, {"number of bins for "}}}};
+}
+
+} // namespace framework
+} // namespace o2
+
+#endif

--- a/Detectors/TOF/calibration/testWorkflow/data-generator-workflow.cxx
+++ b/Detectors/TOF/calibration/testWorkflow/data-generator-workflow.cxx
@@ -1,0 +1,34 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/DataProcessorSpec.h"
+#include "DataGeneratorSpec.h"
+
+using namespace o2::framework;
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  workflowOptions.push_back(ConfigParamSpec{"lanes", o2::framework::VariantType::Int, 2, {"number of data generator lanes"}});
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  WorkflowSpec specs;
+  auto n = configcontext.options().get<int>("lanes");
+  specs.emplace_back(getTFDispatcherSpec());
+  specs.emplace_back(timePipeline(getTFProcessorSpec(), n > 1 ? n : 1));
+  return specs;
+}

--- a/Detectors/TOF/calibration/testWorkflow/lhc-clockphase-workflow.cxx
+++ b/Detectors/TOF/calibration/testWorkflow/lhc-clockphase-workflow.cxx
@@ -1,0 +1,31 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/DataProcessorSpec.h"
+#include "LHCClockCalibratorSpec.h"
+
+using namespace o2::framework;
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  WorkflowSpec specs;
+  specs.emplace_back(getLHCClockCalibDeviceSpec());
+  return specs;
+}


### PR DESCRIPTION
1) Detectors/Calibration defines base classes templates for use time slot definition (container for the data accumulated over a certain number of TFs) and their manipulation. It also provides a generic workflow which receives binary images of the calibration data (the content is irrelevant) accompanied by the ``CcdbObjectInfo`` and puts then on the CCDB

2) Detectors/TOF/calibration implements TOF specific data accumulation slots and their processing, as well as the workflow to aggregate asynchronously TFs from different EPNs and to extract calibration data for groups of TFs.
In real life, the channelling of data from different EPNs to this aggregator device will require a special proxy device (to be written), as a place-holder at the moment data from different EPNs is emulated by the  ``data-generator-workflow`` which spawns multiple lanes (EPNs) each one generating (with randomized latency) a calibration input data for a single TF.

To be run as e.g.
````
o2-calibration-data-generator-workflow --lanes 10 --mean-latency 10000 --latency-spread 1000 --max-timeframes 500 | o2-calibration-lhc-clockphase-workflow --tf-per-slot 20 | o2-calibration-ccdb-populator-workflow --ccdb-path localhost:8080 
````
