### PR TITLE
DPL Analysis: add initial support for boolean columns

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -89,6 +89,10 @@ template <typename T>
 struct arrow_array_for {
 };
 template <>
+struct arrow_array_for<bool> {
+  using type = arrow::Int8Array;
+};
+template <>
 struct arrow_array_for<int8_t> {
   using type = arrow::Int8Array;
 };
@@ -165,7 +169,7 @@ class ColumnIterator : ChunkingPolicy
   {
     auto chunks = mColumn->data();
     auto array = std::static_pointer_cast<arrow_array_for_t<T>>(chunks->chunk(mCurrentChunk));
-    mCurrent = array->raw_values();
+    mCurrent = reinterpret_cast<T const*>(array->raw_values());
     mLast = mCurrent + array->length();
   }
 
@@ -184,7 +188,7 @@ class ColumnIterator : ChunkingPolicy
     mFirstIndex += previousArray->length();
     mCurrentChunk++;
     auto array = std::static_pointer_cast<arrow_array_for_t<T>>(chunks->chunk(mCurrentChunk));
-    mCurrent = array->raw_values() - mFirstIndex;
+    mCurrent = reinterpret_cast<T const*>(array->raw_values() - mFirstIndex);
     mLast = mCurrent + array->length() + mFirstIndex;
   }
 
@@ -195,7 +199,7 @@ class ColumnIterator : ChunkingPolicy
     mFirstIndex -= previousArray->length();
     mCurrentChunk--;
     auto array = std::static_pointer_cast<arrow_array_for_t<T>>(chunks->chunk(mCurrentChunk));
-    mCurrent = array->raw_values() - mFirstIndex;
+    mCurrent = reinterpret_cast<T const*>(array->raw_values() - mFirstIndex);
     mLast = mCurrent + array->length() + mFirstIndex;
   }
 
@@ -220,7 +224,7 @@ class ColumnIterator : ChunkingPolicy
     auto array = std::static_pointer_cast<arrow_array_for_t<T>>(chunks->chunk(mCurrentChunk));
     assert(array.get());
     mFirstIndex = mColumn->length() - array->length();
-    mCurrent = array->raw_values() - mFirstIndex;
+    mCurrent = reinterpret_cast<T const*>(array->raw_values() - mFirstIndex);
     mLast = mCurrent + array->length() + mFirstIndex;
   }
 

--- a/Framework/Core/include/Framework/TableBuilder.h
+++ b/Framework/Core/include/Framework/TableBuilder.h
@@ -57,7 +57,8 @@ struct ConversionTraits {
     using ArrowType = ::arrow::ArrowType_;          \
   };
 
-O2_ARROW_STL_CONVERSION(bool, BooleanType)
+// FIXME: for now we use Int8 to store booleans
+O2_ARROW_STL_CONVERSION(bool, Int8Type)
 O2_ARROW_STL_CONVERSION(int8_t, Int8Type)
 O2_ARROW_STL_CONVERSION(int16_t, Int16Type)
 O2_ARROW_STL_CONVERSION(int32_t, Int32Type)

--- a/Framework/Core/test/test_ASoA.cxx
+++ b/Framework/Core/test/test_ASoA.cxx
@@ -36,10 +36,11 @@ DECLARE_SOA_TABLE(Points, "TST", "POINTS", test::X, test::Y);
 
 namespace test
 {
+DECLARE_SOA_COLUMN(SomeBool, someBool, bool, "someBool");
 DECLARE_SOA_COLUMN(Color, color, int32_t, "color");
 } // namespace test
 
-DECLARE_SOA_TABLE(Infos, "TST", "INFOS", test::Color);
+DECLARE_SOA_TABLE(Infos, "TST", "INFOS", test::Color, test::SomeBool);
 
 namespace test
 {
@@ -456,11 +457,15 @@ BOOST_AUTO_TEST_CASE(TestDereference)
 
   TableBuilder builderA2;
   auto infoWriter = builderA2.cursor<Infos>();
-  infoWriter(0, 0);
-  infoWriter(0, 1);
-  infoWriter(0, 4);
+  infoWriter(0, 0, 1);
+  infoWriter(0, 1, 0);
+  infoWriter(0, 4, 1);
   auto infosT = builderA2.finalize();
   Infos infos{infosT};
+  BOOST_REQUIRE_EQUAL(infos.begin().someBool(), true);
+  BOOST_REQUIRE_EQUAL((infos.begin() + 1).someBool(), false);
+  BOOST_REQUIRE_EQUAL((infos.begin() + 2).someBool(), true);
+  BOOST_REQUIRE_EQUAL((infos.begin() + 2).color(), 4);
   BOOST_REQUIRE_EQUAL(infosT->num_rows(), 3);
 
   TableBuilder builderB;
@@ -485,6 +490,7 @@ BOOST_AUTO_TEST_CASE(TestDereference)
   i.bindExternalIndices(&points, &infos);
   BOOST_CHECK_EQUAL(i.n(), 10);
   BOOST_CHECK_EQUAL(i.info().color(), 4);
+  BOOST_CHECK_EQUAL(i.info().someBool(), true);
   BOOST_CHECK_EQUAL(i.pointA().x(), 0);
   BOOST_CHECK_EQUAL(i.pointA().y(), 0);
   BOOST_CHECK_EQUAL(i.pointB().x(), 3);
@@ -494,6 +500,7 @@ BOOST_AUTO_TEST_CASE(TestDereference)
   auto j = segments.begin();
   BOOST_CHECK_EQUAL(j.n(), 10);
   BOOST_CHECK_EQUAL(j.info().color(), 4);
+  BOOST_CHECK_EQUAL(j.info().someBool(), true);
   BOOST_CHECK_EQUAL(j.pointA().x(), 0);
   BOOST_CHECK_EQUAL(j.pointA().y(), 0);
   BOOST_CHECK_EQUAL(j.pointB().x(), 3);

--- a/Framework/Core/test/test_TableBuilder.cxx
+++ b/Framework/Core/test/test_TableBuilder.cxx
@@ -151,7 +151,7 @@ BOOST_AUTO_TEST_CASE(TestTableBuilderMore)
   BOOST_REQUIRE_EQUAL(table->column(0)->type()->id(), arrow::int32()->id());
   BOOST_REQUIRE_EQUAL(table->column(1)->type()->id(), arrow::float32()->id());
   BOOST_REQUIRE_EQUAL(table->column(2)->type()->id(), arrow::utf8()->id());
-  BOOST_REQUIRE_EQUAL(table->column(3)->type()->id(), arrow::boolean()->id());
+  BOOST_REQUIRE_EQUAL(table->column(3)->type()->id(), arrow::int8()->id());
 }
 
 // Use RDataFrame to build the table


### PR DESCRIPTION
For the moment we use 1 byte per bool.