### PR TITLE
Fix parsing of log from dictionary generation

### DIFF
--- a/cmake/rootcling_wrapper.sh.in
+++ b/cmake/rootcling_wrapper.sh.in
@@ -81,7 +81,7 @@ LOGFILE=${DICTIONARY_FILE}.log
 
 MSG="Warning: Unused class rule"
 if [[ -s ${LOGFILE} ]]; then
-  WARNINGS=$(grep -c "${MSG}" ${LOGFILE})
+  WARNINGS=$(grep -c "${MSG}" ${LOGFILE} || :)
   if [[ ! $WARNINGS == 0 ]]; then
     echo "ERROR: please fix the warnings below about unused class rule" >&2
     grep "$MSG" ${LOGFILE} >&2


### PR DESCRIPTION
Need to catch a non-zero return value from grep in case of not finding any occurence (most of the time hidden because of empty log files).