### PR TITLE
Fix RawParser: set proper size estimate for payload

### DIFF
--- a/Framework/Utils/include/DPLUtils/RawParser.h
+++ b/Framework/Utils/include/DPLUtils/RawParser.h
@@ -117,8 +117,7 @@ class ConcreteRawParser
       return 0;
     }
     header_type const& h = header();
-    // FIXME: block length disappeared in V5, check what can be used
-    return max_size - h.headerSize;
+    return h.memorySize - h.headerSize;
   }
 
   /// Get pointer to payload data at current position

--- a/Framework/Utils/test/test_RawParser.cxx
+++ b/Framework/Utils/test/test_RawParser.cxx
@@ -30,6 +30,7 @@ BOOST_AUTO_TEST_CASE(test_RawParser)
     rdh->version = 5;
     rdh->headerSize = sizeof(V5);
     rdh->offsetToNext = PageSize;
+    rdh->memorySize = PageSize;
     rdh->pageCnt = NofPages;
     rdh->packetCounter = pageNo;
     rdh->stop = pageNo + 1 == NofPages;


### PR DESCRIPTION
So far the fixed page size has been used to calculate the size of the payload,
simply because of the lack of information at the time of implmenting the parser.
The variable size of the payload is stored in the member memorySize in both
RDH v4 and v5. Since the raw parser does only supports those two versions at
the moment, the fix can be applied as it is. there is no need to support RDH v2
which has a member blockLength.