### PR TITLE
Add o2 interface for TRD tracker

### DIFF
--- a/GPU/GPUTracking/Base/GPUConstantMem.h
+++ b/GPU/GPUTracking/Base/GPUConstantMem.h
@@ -30,6 +30,18 @@ namespace gpu
 class GPUTPCGMMerger
 {
 };
+class TRDBaseTrackGPU;
+class TRDBasePropagatorGPU;
+template <class T>
+class trackInterface;
+template <class T>
+class propagatorInterface;
+template <class T>
+class GPUTRDTrack_t;
+// clang-format off
+typedef GPUTRDTrack_t<trackInterface<TRDBaseTrackGPU> > GPUTRDTrackGPU;
+// clang-format on
+typedef propagatorInterface<TRDBasePropagatorGPU> GPUTRDPropagatorGPU;
 template <class T, class P>
 class GPUTRDTracker_t
 {

--- a/GPU/GPUTracking/Base/GPUConstantMem.h
+++ b/GPU/GPUTracking/Base/GPUConstantMem.h
@@ -30,10 +30,12 @@ namespace gpu
 class GPUTPCGMMerger
 {
 };
-class GPUTRDTracker
+template <class T, class P>
+class GPUTRDTracker_t
 {
   void SetMaxData(const GPUTrackingInOutPointers& io) {}
 };
+typedef GPUTRDTracker_t<GPUTRDTrackGPU, GPUTRDPropagatorGPU> GPUTRDTrackerGPU;
 } // namespace gpu
 } // namespace GPUCA_NAMESPACE
 #endif
@@ -65,7 +67,7 @@ struct GPUConstantMem {
   GPUTPCConvert tpcConverter;
   GPUTPCCompression tpcCompressor;
   GPUTPCGMMerger tpcMerger;
-  GPUTRDTracker trdTracker;
+  GPUTRDTrackerGPU trdTracker;
   GPUTPCClusterFinder tpcClusterer[GPUCA_NSLICES];
   GPUITSFitter itsFitter;
   GPUTrackingInOutPointers ioPtrs;

--- a/GPU/GPUTracking/Base/GPUDataTypes.h
+++ b/GPU/GPUTracking/Base/GPUDataTypes.h
@@ -229,7 +229,7 @@ struct GPUTrackingInOutPointers {
   unsigned int nTRDTracklets = 0;
   const GPUTRDTrackletLabels* trdTrackletsMC = nullptr;
   unsigned int nTRDTrackletsMC = 0;
-  const GPUTRDTrack* trdTracks = nullptr;
+  const GPUTRDTrackGPU* trdTracks = nullptr;
   unsigned int nTRDTracks = 0;
 };
 #else

--- a/GPU/GPUTracking/Base/GPUReconstructionCPU.h
+++ b/GPU/GPUTracking/Base/GPUReconstructionCPU.h
@@ -29,7 +29,7 @@
 #include "GPUTPCTrackletConstructor.h"
 #include "GPUTPCTrackletSelector.h"
 #include "GPUTPCGMMergerGPU.h"
-#include "GPUTRDTrackerGPU.h"
+#include "GPUTRDTrackerKernels.h"
 #ifdef HAVE_O2HEADERS
 #include "GPUITSFitterKernels.h"
 #include "GPUTPCConvertKernel.h"

--- a/GPU/GPUTracking/Base/GPUReconstructionIncludesDevice.h
+++ b/GPU/GPUTracking/Base/GPUReconstructionIncludesDevice.h
@@ -76,7 +76,7 @@ using namespace GPUCA_NAMESPACE::gpu;
 #include "GPUTPCCFDecodeZS.cxx"
 
 // Files for TRD Tracking
-#include "GPUTRDTrackerGPU.cxx"
+#include "GPUTRDTrackerKernels.cxx"
 #include "GPUTRDTrack.cxx"
 #include "GPUTRDTracker.cxx"
 #include "GPUTRDTrackletWord.cxx"

--- a/GPU/GPUTracking/Base/GPUReconstructionKernels.h
+++ b/GPU/GPUTracking/Base/GPUReconstructionKernels.h
@@ -26,7 +26,7 @@ GPUCA_KRNL((GPUMemClean16                                ), (simple, REG, (GPUCA
 #if !defined(GPUCA_OPENCL1) && (!defined(GPUCA_ALIROOT_LIB) || !defined(GPUCA_GPUCODE))
 GPUCA_KRNL((GPUTPCGMMergerTrackFit                       ), (simple, REG, (GPUCA_THREAD_COUNT_FIT, 1)), (, int mode), (, mode))
 #ifdef HAVE_O2HEADERS
-GPUCA_KRNL((GPUTRDTrackerGPU                             ), (simple, REG, (GPUCA_THREAD_COUNT_TRD, 1)), (), ())
+GPUCA_KRNL((GPUTRDTrackerKernels                         ), (simple, REG, (GPUCA_THREAD_COUNT_TRD, 1)), (), ())
 GPUCA_KRNL((GPUITSFitterKernel                           ), (simple, REG, (GPUCA_THREAD_COUNT_ITS, 1)), (), ())
 GPUCA_KRNL((GPUTPCConvertKernel                          ), (simple, REG, (GPUCA_THREAD_COUNT_CONVERTER, 1)), (), ())
 GPUCA_KRNL((GPUTPCCompressionKernels,   step0attached    ), (simple, REG, (GPUCA_THREAD_COUNT_COMPRESSION1, 1)), (), ())

--- a/GPU/GPUTracking/CMakeLists.txt
+++ b/GPU/GPUTracking/CMakeLists.txt
@@ -55,7 +55,7 @@ set(SRCS
     TRDTracking/GPUTRDTrack.cxx
     TRDTracking/GPUTRDTracker.cxx
     TRDTracking/GPUTRDTrackletWord.cxx
-    TRDTracking/GPUTRDTrackerGPU.cxx
+    TRDTracking/GPUTRDTrackerKernels.cxx
     Base/GPUParam.cxx)
 
 set(SRCS_NO_CINT

--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -1560,9 +1560,9 @@ int GPUChainTracking::RunTRDTracking()
   if (!processors()->trdTracker.IsInitialized()) {
     return 1;
   }
-  std::vector<GPUTRDTrack> tracksTPC;
+  std::vector<GPUTRDTrackGPU> tracksTPC;
   std::vector<int> tracksTPCLab;
-  GPUTRDTracker& Tracker = processors()->trdTracker;
+  GPUTRDTrackerGPU& Tracker = processors()->trdTracker;
   mRec->SetThreadCounts(RecoStep::TRDTracking);
 
   for (unsigned int i = 0; i < mIOPtrs.nMergedTracks; i++) {
@@ -1614,8 +1614,8 @@ int GPUChainTracking::DoTRDGPUTracking()
 {
 #ifdef HAVE_O2HEADERS
   bool doGPU = GetRecoStepsGPU() & RecoStep::TRDTracking;
-  GPUTRDTracker& Tracker = processors()->trdTracker;
-  GPUTRDTracker& TrackerShadow = doGPU ? processorsShadow()->trdTracker : Tracker;
+  GPUTRDTrackerGPU& Tracker = processors()->trdTracker;
+  GPUTRDTrackerGPU& TrackerShadow = doGPU ? processorsShadow()->trdTracker : Tracker;
 
   const auto& threadContext = GetThreadContext();
   SetupGPUProcessor(&Tracker, false);
@@ -1624,7 +1624,7 @@ int GPUChainTracking::DoTRDGPUTracking()
   WriteToConstantMemory(RecoStep::TRDTracking, (char*)&processors()->trdTracker - (char*)processors(), &TrackerShadow, sizeof(TrackerShadow), 0);
   TransferMemoryResourcesToGPU(RecoStep::TRDTracking, &Tracker);
 
-  runKernel<GPUTRDTrackerGPU>({BlockCount(), TRDThreadCount(), 0}, krnlRunRangeNone);
+  runKernel<GPUTRDTrackerKernels>({BlockCount(), TRDThreadCount(), 0}, krnlRunRangeNone);
   SynchronizeGPU();
 
   TransferMemoryResourcesToHost(RecoStep::TRDTracking, &Tracker);

--- a/GPU/GPUTracking/Global/GPUChainTracking.h
+++ b/GPU/GPUTracking/Global/GPUChainTracking.h
@@ -49,7 +49,7 @@ namespace GPUCA_NAMESPACE
 {
 namespace gpu
 {
-class GPUTRDTracker;
+//class GPUTRDTrackerGPU;
 class GPUTPCGPUTracker;
 class GPUDisplay;
 class GPUQA;
@@ -96,7 +96,7 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
     std::unique_ptr<GPUTPCGMMergedTrackHit[]> mergedTrackHits;
     std::unique_ptr<GPUTRDTrackletWord[]> trdTracklets;
     std::unique_ptr<GPUTRDTrackletLabels[]> trdTrackletsMC;
-    std::unique_ptr<GPUTRDTrack[]> trdTracks;
+    std::unique_ptr<GPUTRDTrackGPU[]> trdTracks;
   } mIOMem;
 
   // Read / Dump / Clear Data
@@ -117,7 +117,7 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
   void ConvertZSFilter(bool zs12bit);
 
   // Getters for external usage of tracker classes
-  GPUTRDTracker* GetTRDTracker() { return &processors()->trdTracker; }
+  GPUTRDTrackerGPU* GetTRDTracker() { return &processors()->trdTracker; }
   GPUTPCTracker* GetTPCSliceTrackers() { return processors()->tpcTrackers; }
   const GPUTPCTracker* GetTPCSliceTrackers() const { return processors()->tpcTrackers; }
   const GPUTPCGMMerger& GetTPCMerger() const { return processors()->tpcMerger; }

--- a/GPU/GPUTracking/Standalone/display/GPUDisplay.cxx
+++ b/GPU/GPUTracking/Standalone/display/GPUDisplay.cxx
@@ -97,7 +97,7 @@ GPUDisplay::GPUDisplay(GPUDisplayBackend* backend, GPUChainTracking* rec, GPUQA*
 
 const GPUParam& GPUDisplay::param() { return mChain->GetParam(); }
 const GPUTPCTracker& GPUDisplay::sliceTracker(int iSlice) { return mChain->GetTPCSliceTrackers()[iSlice]; }
-const GPUTRDTracker& GPUDisplay::trdTracker() { return *mChain->GetTRDTracker(); }
+const GPUTRDTrackerGPU& GPUDisplay::trdTracker() { return *mChain->GetTRDTracker(); }
 const GPUTrackingInOutPointers GPUDisplay::ioptrs() { return mChain->mIOPtrs; }
 
 inline void GPUDisplay::drawVertices(const vboList& v, const GLenum t)

--- a/GPU/GPUTracking/Standalone/display/GPUDisplay.h
+++ b/GPU/GPUTracking/Standalone/display/GPUDisplay.h
@@ -229,7 +229,7 @@ class GPUDisplay
   int InitGL_internal();
   const GPUParam& param();
   const GPUTPCTracker& sliceTracker(int iSlice);
-  const GPUTRDTracker& trdTracker();
+  const GPUTRDTrackerGPU& trdTracker();
   const GPUTrackingInOutPointers ioptrs();
   void drawVertices(const vboList& v, const GLenum t);
   void insertVertexList(std::pair<vecpod<GLint>*, vecpod<GLsizei>*>& vBuf, size_t first, size_t last);

--- a/GPU/GPUTracking/TRDTracking/GPUTRDDef.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDDef.h
@@ -25,6 +25,18 @@
 #ifdef GPUCA_ALIROOT_LIB
 class AliExternalTrackParam;
 class AliTrackerBase;
+#else
+namespace o2
+{
+namespace track
+{
+class TrackParCov;
+} // namespace track
+namespace base
+{
+class Propagator;
+} // namespace base
+} // namespace o2
 #endif
 
 namespace GPUCA_NAMESPACE
@@ -40,20 +52,24 @@ typedef float My_Float;
 
 #if defined(TRD_TRACK_TYPE_ALIROOT)
 typedef AliExternalTrackParam TRDBaseTrack;
+typedef AliExternalTrackParam TRDBaseTrackGPU;
 // class GPUTPCGMTrackParam;
 // typedef GPUTPCGMTrackParam TRDBaseTrack;
 #elif defined(TRD_TRACK_TYPE_O2)
+typedef o2::track::TrackParCov TRDBaseTrack;
 class GPUTPCGMTrackParam;
-typedef GPUTPCGMTrackParam TRDBaseTrack;
+typedef GPUTPCGMTrackParam TRDBaseTrackGPU;
 #endif
 
 #ifdef GPUCA_ALIROOT_LIB
 typedef AliTrackerBase TRDBasePropagator;
+typedef AliTrackerBase TRDBasePropagatorGPU;
 // class GPUTPCGMPropagator;
 // typedef GPUTPCGMPropagator TRDBasePropagator;
 #else
+typedef o2::base::Propagator TRDBasePropagator;
 class GPUTPCGMPropagator;
-typedef GPUTPCGMPropagator TRDBasePropagator;
+typedef GPUTPCGMPropagator TRDBasePropagatorGPU;
 #endif
 
 template <class T>
@@ -63,7 +79,14 @@ class propagatorInterface;
 template <class T>
 class GPUTRDTrack_t;
 typedef GPUTRDTrack_t<trackInterface<TRDBaseTrack>> GPUTRDTrack;
+typedef GPUTRDTrack_t<trackInterface<TRDBaseTrackGPU>> GPUTRDTrackGPU;
 typedef propagatorInterface<TRDBasePropagator> GPUTRDPropagator;
+typedef propagatorInterface<TRDBasePropagatorGPU> GPUTRDPropagatorGPU;
+
+template <class T, class P>
+class GPUTRDTracker_t;
+typedef GPUTRDTracker_t<GPUTRDTrack, GPUTRDPropagator> GPUTRDTracker;
+typedef GPUTRDTracker_t<GPUTRDTrackGPU, GPUTRDPropagatorGPU> GPUTRDTrackerGPU;
 
 #if defined(GPUCA_ALIGPUCODE) && !defined(GPUCA_ALIROOT_LIB) && !defined(__CLING__) && !defined(__ROOTCLING__) && !defined(G__ROOT)
 #define Error(...)

--- a/GPU/GPUTracking/TRDTracking/GPUTRDGeometry.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDGeometry.h
@@ -43,7 +43,7 @@ class GPUTRDGeometry : public AliTRDgeometry
 } // namespace gpu
 } // namespace GPUCA_NAMESPACE
 
-#elif defined(HAVE_O2HEADERS)
+#elif defined(HAVE_O2HEADERS) //&& defined(GPUCA_GPUCODE)
 
 class TObjArray;
 #include "GPUDef.h"
@@ -103,7 +103,7 @@ class GPUTRDGeometry : private o2::trd::TRDGeometryFlat
 } // namespace gpu
 } // namespace GPUCA_NAMESPACE
 
-#else
+#else // below are dummy definitions to enable building the standalone version with AliRoot
 
 #include "GPUDef.h"
 
@@ -162,7 +162,7 @@ class GPUTRDGeometry
   GPUd() int GetStack(float z, int layer) const { return 0; }
   GPUd() float GetAlpha() const { return 0; }
   GPUd() bool IsHole(int la, int st, int se) const { return false; }
-  GPUd() int GetRowMax(int layer, int stack, int /*sector*/) const { return 0; }
+  GPUd() int GetRowMax(int layer, int stack, int /* sector */) const { return 0; }
   GPUd() bool ChamberInGeometry(int det) const { return false; }
 
   static CONSTEXPR int kNstack = 0;

--- a/GPU/GPUTracking/TRDTracking/GPUTRDInterfaces.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDInterfaces.h
@@ -127,7 +127,7 @@ class propagatorInterface<AliTrackerBase> : public AliTrackerBase
 #endif // GPUCA_ALIROOT_LIB
 
 #if defined(GPUCA_O2_LIB) || defined(GPUCA_O2_INTERFACE) // Interface for O2, build only with O2
-/*
+
 #include "ReconstructionDataFormats/Track.h"
 #include "DetectorsBase/Propagator.h"
 
@@ -136,23 +136,100 @@ namespace GPUCA_NAMESPACE
 
 namespace gpu
 {
-// TODO namespace trd??
 
 template <>
 class trackInterface<o2::track::TrackParCov> : public o2::track::TrackParCov
 {
+ public:
+  trackInterface<o2::track::TrackParCov>() : o2::track::TrackParCov(){};
+  trackInterface<o2::track::TrackParCov>(const trackInterface<o2::track::TrackParCov>& param) : o2::track::TrackParCov(param){};
+  trackInterface<o2::track::TrackParCov>(const o2::track::TrackParCov& param) = delete;
+  trackInterface<o2::track::TrackParCov>(const GPUTPCGMMergedTrack& trk)
+  {
+    setX(trk.OuterParam().X);
+    setAlpha(trk.OuterParam().alpha);
+    for (int i = 0; i < 5; i++) {
+      setParam(trk.OuterParam().P[i], i);
+    }
+    for (int i = 0; i < 15; i++) {
+      setCov(trk.OuterParam().C[i], i);
+    }
+  }
+  trackInterface<o2::track::TrackParCov>(const GPUTPCGMTrackParam::GPUTPCOuterParam& param)
+  {
+    setX(param.X);
+    setAlpha(param.alpha);
+    for (int i = 0; i < 5; i++) {
+      setParam(param.P[i], i);
+    }
+    for (int i = 0; i < 15; i++) {
+      setCov(param.C[i], i);
+    }
+  };
+
+  void set(float x, float alpha, const float param[5], const float cov[15])
+  {
+    setX(x);
+    setAlpha(alpha);
+    for (int i = 0; i < 5; i++) {
+      setParam(param[i], i);
+    }
+    for (int i = 0; i < 15; i++) {
+      setCov(cov[i], i);
+    }
+  }
+
+  const float* getPar() { return getParams(); }
+
+  bool CheckNumericalQuality() const { return true; }
+
   typedef o2::track::TrackParCov baseClass;
 };
 
 template <>
-class propagatorInterface<o2::base::Propagator> : public o2::base::Propagator
+class propagatorInterface<o2::base::Propagator>
 {
+ public:
+  propagatorInterface<o2::base::Propagator>(const void* = nullptr){};
+  propagatorInterface<o2::base::Propagator>(const propagatorInterface<o2::base::Propagator>&) = delete;
+  propagatorInterface<o2::base::Propagator>& operator=(const propagatorInterface<o2::base::Propagator>&) = delete;
 
+  bool propagateToX(float x, float maxSnp, float maxStep) { return mProp->PropagateToXBxByBz(*mParam, x, 0.13957, maxSnp, maxStep); }
+  int getPropagatedYZ(My_Float x, My_Float& projY, My_Float& projZ) { return static_cast<int>(mParam->getYZAt(x, mProp->getNominalBz(), projY, projZ)); }
+
+  void setTrack(trackInterface<o2::track::TrackParCov>* trk) { mParam = trk; }
+  void setFitInProjections(bool flag) {}
+
+  float getAlpha() { return (mParam) ? mParam->getAlpha() : 99999.f; }
+  bool update(const My_Float p[2], const My_Float cov[3])
+  {
+    if (mParam) {
+      std::array<float, 2> pTmp = {p[0], p[1]};
+      std::array<float, 3> covTmp = {cov[0], cov[1], cov[3]};
+      return mParam->update(pTmp, covTmp);
+    } else {
+      return false;
+    }
+  }
+  float getPredictedChi2(const My_Float p[2], const My_Float cov[3])
+  {
+    if (mParam) {
+      std::array<float, 2> pTmp = {p[0], p[1]};
+      std::array<float, 3> covTmp = {cov[0], cov[1], cov[3]};
+      return mParam->getPredictedChi2(pTmp, covTmp);
+    } else {
+      return 99999.f;
+    }
+  }
+  bool rotate(float alpha) { return (mParam) ? mParam->rotate(alpha) : false; }
+
+  trackInterface<o2::track::TrackParCov>* mParam{nullptr};
+  o2::base::Propagator* mProp{o2::base::Propagator::Instance()};
 };
 
 } // namespace gpu
 } // namespace GPUCA_NAMESPACE
-*/
+
 #endif // GPUCA_O2_LIB || GPUCA_O2_INTERFACE
 
 #include "GPUTPCGMPropagator.h"
@@ -261,7 +338,10 @@ class propagatorInterface<GPUTPCGMPropagator> : public GPUTPCGMPropagator
   }
   GPUd() bool propagateToX(float x, float maxSnp, float maxStep)
   {
-    bool ok = PropagateToXAlpha(x, GetAlpha(), true) == 0 ? true : false;
+    //bool ok = PropagateToXAlpha(x, GetAlpha(), true) == 0 ? true : false;
+    int retVal = PropagateToXAlpha(x, GetAlpha(), true);
+    printf("Return value of PropagateToXAlpha: %i\n", retVal);
+    bool ok = (retVal == 0) ? true : false;
     ok = mTrack->CheckNumericalQuality();
     return ok;
   }

--- a/GPU/GPUTracking/TRDTracking/GPUTRDInterfaces.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDInterfaces.h
@@ -141,8 +141,8 @@ template <>
 class trackInterface<o2::track::TrackParCov> : public o2::track::TrackParCov
 {
  public:
-  trackInterface<o2::track::TrackParCov>() : o2::track::TrackParCov(){};
-  trackInterface<o2::track::TrackParCov>(const trackInterface<o2::track::TrackParCov>& param) : o2::track::TrackParCov(param){};
+  trackInterface<o2::track::TrackParCov>() = default;
+  trackInterface<o2::track::TrackParCov>(const trackInterface<o2::track::TrackParCov>& param) = default;
   trackInterface<o2::track::TrackParCov>(const o2::track::TrackParCov& param) = delete;
   trackInterface<o2::track::TrackParCov>(const GPUTPCGMMergedTrack& trk)
   {

--- a/GPU/GPUTracking/TRDTracking/GPUTRDInterfaces.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDInterfaces.h
@@ -126,7 +126,7 @@ class propagatorInterface<AliTrackerBase> : public AliTrackerBase
 
 #endif // GPUCA_ALIROOT_LIB
 
-#if defined(GPUCA_O2_LIB) || defined(GPUCA_O2_INTERFACE) // Interface for O2, build only with O2
+#if (defined(GPUCA_O2_LIB) || defined(GPUCA_O2_INTERFACE)) && !defined(GPUCA_GPUCODE) // Interface for O2, build only with O2
 
 #include "ReconstructionDataFormats/Track.h"
 #include "DetectorsBase/Propagator.h"

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTrack.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTrack.cxx
@@ -208,11 +208,13 @@ namespace GPUCA_NAMESPACE
 {
 namespace gpu
 {
+#ifndef GPUCA_GPUCODE
 #ifdef GPUCA_ALIROOT_LIB // Instantiate AliRoot track version
 template class GPUTRDTrack_t<trackInterface<AliExternalTrackParam>>;
 #endif
 #ifdef GPUCA_O2_LIB // Instantiate O2 track version
 template class GPUTRDTrack_t<trackInterface<o2::track::TrackParCov>>;
+#endif
 #endif
 template class GPUTRDTrack_t<trackInterface<GPUTPCGMTrackParam>>; // Always instatiate GM track version
 } // namespace gpu

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTrack.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTrack.cxx
@@ -212,7 +212,7 @@ namespace gpu
 template class GPUTRDTrack_t<trackInterface<AliExternalTrackParam>>;
 #endif
 #ifdef GPUCA_O2_LIB // Instantiate O2 track version
-// Not yet existing
+template class GPUTRDTrack_t<trackInterface<o2::track::TrackParCov>>;
 #endif
 template class GPUTRDTrack_t<trackInterface<GPUTPCGMTrackParam>>; // Always instatiate GM track version
 } // namespace gpu

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
@@ -51,7 +51,8 @@ static const float piMass = 0.139f;
 
 #include "GPUChainTracking.h"
 
-void GPUTRDTracker::SetMaxData(const GPUTrackingInOutPointers& io)
+template <class TRDTRK, class PROP>
+void GPUTRDTracker_t<TRDTRK, PROP>::SetMaxData(const GPUTrackingInOutPointers& io)
 {
   mNMaxTracks = mChainTracking->mIOPtrs.nMergedTracks;
   mNMaxSpacePoints = mChainTracking->mIOPtrs.nTRDTracklets;
@@ -61,20 +62,26 @@ void GPUTRDTracker::SetMaxData(const GPUTrackingInOutPointers& io)
   }
 }
 
-void GPUTRDTracker::RegisterMemoryAllocation()
+template <class TRDTRK, class PROP>
+void GPUTRDTracker_t<TRDTRK, PROP>::RegisterMemoryAllocation()
 {
-  mMemoryPermanent = mRec->RegisterMemoryAllocation(this, &GPUTRDTracker::SetPointersBase, GPUMemoryResource::MEMORY_PERMANENT, "TRDInitialize");
-  mMemoryTracklets = mRec->RegisterMemoryAllocation(this, &GPUTRDTracker::SetPointersTracklets, GPUMemoryResource::MEMORY_INPUT, "TRDTracklets");
+  mMemoryPermanent = mRec->RegisterMemoryAllocation(this, &GPUTRDTracker_t<TRDTRK, PROP>::SetPointersBase, GPUMemoryResource::MEMORY_PERMANENT, "TRDInitialize");
+  mMemoryTracklets = mRec->RegisterMemoryAllocation(this, &GPUTRDTracker_t<TRDTRK, PROP>::SetPointersTracklets, GPUMemoryResource::MEMORY_INPUT, "TRDTracklets");
   auto type = GPUMemoryResource::MEMORY_INOUT;
   if (mRec->GetDeviceProcessingSettings().memoryAllocationStrategy == GPUMemoryResource::ALLOCATION_INDIVIDUAL) {
     type = GPUMemoryResource::MEMORY_CUSTOM;
   }
-  mMemoryTracks = mRec->RegisterMemoryAllocation(this, &GPUTRDTracker::SetPointersTracks, type, "TRDTracks");
+  mMemoryTracks = mRec->RegisterMemoryAllocation(this, &GPUTRDTracker_t<TRDTRK, PROP>::SetPointersTracks, type, "TRDTracks");
 }
 
-void GPUTRDTracker::InitializeProcessor() { Init((TRD_GEOMETRY_CONST GPUTRDGeometry*)mChainTracking->GetTRDGeometry()); }
+template <class TRDTRK, class PROP>
+void GPUTRDTracker_t<TRDTRK, PROP>::InitializeProcessor()
+{
+  Init((TRD_GEOMETRY_CONST GPUTRDGeometry*)mChainTracking->GetTRDGeometry());
+}
 
-void* GPUTRDTracker::SetPointersBase(void* base)
+template <class TRDTRK, class PROP>
+void* GPUTRDTracker_t<TRDTRK, PROP>::SetPointersBase(void* base)
 {
   //--------------------------------------------------------------------
   // Allocate memory for fixed size objects (needs to be done only once)
@@ -88,7 +95,8 @@ void* GPUTRDTracker::SetPointersBase(void* base)
   return base;
 }
 
-void* GPUTRDTracker::SetPointersTracklets(void* base)
+template <class TRDTRK, class PROP>
+void* GPUTRDTracker_t<TRDTRK, PROP>::SetPointersTracklets(void* base)
 {
   //--------------------------------------------------------------------
   // Allocate memory for tracklets and space points
@@ -100,7 +108,8 @@ void* GPUTRDTracker::SetPointersTracklets(void* base)
   return base;
 }
 
-void* GPUTRDTracker::SetPointersTracks(void* base)
+template <class TRDTRK, class PROP>
+void* GPUTRDTracker_t<TRDTRK, PROP>::SetPointersTracks(void* base)
 {
   //--------------------------------------------------------------------
   // Allocate memory for tracks (this is done once per event)
@@ -109,15 +118,17 @@ void* GPUTRDTracker::SetPointersTracks(void* base)
   return base;
 }
 
-GPUTRDTracker::GPUTRDTracker()
-  : mR(nullptr), mIsInitialized(false), mMemoryPermanent(-1), mMemoryTracklets(-1), mMemoryTracks(-1), mNMaxTracks(0), mNMaxSpacePoints(0), mTracks(nullptr), mNCandidates(1), mNTracks(0), mNEvents(0), mTracklets(nullptr), mMaxThreads(100), mNTracklets(0), mNTrackletsInChamber(nullptr), mTrackletIndexArray(nullptr), mHypothesis(nullptr), mCandidates(nullptr), mSpacePoints(nullptr), mTrackletLabels(nullptr), mGeo(nullptr), mDebugOutput(false), mRadialOffset(-0.1), mMinPt(0.6f), mMaxEta(0.84f), mExtraRoadY(2.f), mRoadZ(18.f), mMaxChi2(15.0f), mMaxMissingLy(6), mChi2Penalty(12.0f), mZCorrCoefNRC(1.4f), mMCEvent(nullptr), mDebug(new GPUTRDTrackerDebug()), mChainTracking(nullptr)
+template <class TRDTRK, class PROP>
+GPUTRDTracker_t<TRDTRK, PROP>::GPUTRDTracker_t()
+  : mR(nullptr), mIsInitialized(false), mMemoryPermanent(-1), mMemoryTracklets(-1), mMemoryTracks(-1), mNMaxTracks(0), mNMaxSpacePoints(0), mTracks(nullptr), mNCandidates(1), mNTracks(0), mNEvents(0), mTracklets(nullptr), mMaxThreads(100), mNTracklets(0), mNTrackletsInChamber(nullptr), mTrackletIndexArray(nullptr), mHypothesis(nullptr), mCandidates(nullptr), mSpacePoints(nullptr), mTrackletLabels(nullptr), mGeo(nullptr), mDebugOutput(false), mRadialOffset(-0.1), mMinPt(2.f), mMaxEta(0.84f), mExtraRoadY(2.f), mRoadZ(18.f), mMaxChi2(15.0f), mMaxMissingLy(6), mChi2Penalty(12.0f), mZCorrCoefNRC(1.4f), mMCEvent(nullptr), mDebug(new GPUTRDTrackerDebug<TRDTRK>()), mChainTracking(nullptr)
 {
   //--------------------------------------------------------------------
   // Default constructor
   //--------------------------------------------------------------------
 }
 
-GPUTRDTracker::~GPUTRDTracker()
+template <class TRDTRK, class PROP>
+GPUTRDTracker_t<TRDTRK, PROP>::~GPUTRDTracker_t()
 {
   //--------------------------------------------------------------------
   // Destructor
@@ -125,7 +136,8 @@ GPUTRDTracker::~GPUTRDTracker()
   delete mDebug;
 }
 
-bool GPUTRDTracker::Init(TRD_GEOMETRY_CONST GPUTRDGeometry* geo)
+template <class TRDTRK, class PROP>
+bool GPUTRDTracker_t<TRDTRK, PROP>::Init(TRD_GEOMETRY_CONST GPUTRDGeometry* geo)
 {
   //--------------------------------------------------------------------
   // Initialise tracker
@@ -139,7 +151,7 @@ bool GPUTRDTracker::Init(TRD_GEOMETRY_CONST GPUTRDGeometry* geo)
 
 #ifdef GPUCA_ALIROOT_LIB
   for (int iCandidate = 0; iCandidate < mNCandidates * 2 * mMaxThreads; ++iCandidate) {
-    new (&mCandidates[iCandidate]) GPUTRDTrack;
+    new (&mCandidates[iCandidate]) TRDTRK;
   }
 #endif
 
@@ -168,7 +180,8 @@ bool GPUTRDTracker::Init(TRD_GEOMETRY_CONST GPUTRDGeometry* geo)
   return true;
 }
 
-void GPUTRDTracker::Reset(bool fast)
+template <class TRDTRK, class PROP>
+void GPUTRDTracker_t<TRDTRK, PROP>::Reset(bool fast)
 {
   //--------------------------------------------------------------------
   // Reset tracker
@@ -199,7 +212,8 @@ void GPUTRDTracker::Reset(bool fast)
   }
 }
 
-void GPUTRDTracker::DoTracking()
+template <class TRDTRK, class PROP>
+void GPUTRDTracker_t<TRDTRK, PROP>::DoTracking()
 {
   //--------------------------------------------------------------------
   // Steering function for the tracking
@@ -250,11 +264,12 @@ void GPUTRDTracker::DoTracking()
   std::cout << " nTracklets: " << mNTracklets;
   std::cout << std::endl;
   */
-  // DumpTracks();
+  DumpTracks();
   mNEvents++;
 }
 
-void GPUTRDTracker::SetNCandidates(int n)
+template <class TRDTRK, class PROP>
+void GPUTRDTracker_t<TRDTRK, PROP>::SetNCandidates(int n)
 {
   //--------------------------------------------------------------------
   // set the number of candidates to be used
@@ -266,7 +281,8 @@ void GPUTRDTracker::SetNCandidates(int n)
   }
 }
 
-void GPUTRDTracker::PrintSettings() const
+template <class TRDTRK, class PROP>
+void GPUTRDTracker_t<TRDTRK, PROP>::PrintSettings() const
 {
   //--------------------------------------------------------------------
   // print current settings to screen
@@ -278,7 +294,8 @@ void GPUTRDTracker::PrintSettings() const
   GPUInfo("##############################################################");
 }
 
-void GPUTRDTracker::CountMatches(const int trackID, std::vector<int>* matches) const
+template <class TRDTRK, class PROP>
+void GPUTRDTracker_t<TRDTRK, PROP>::CountMatches(const int trackID, std::vector<int>* matches) const
 {
 //--------------------------------------------------------------------
 // search in all TRD chambers for matching tracklets
@@ -327,7 +344,8 @@ void GPUTRDTracker::CountMatches(const int trackID, std::vector<int>* matches) c
 #endif
 }
 
-GPUd() void GPUTRDTracker::CheckTrackRefs(const int trackID, bool* findableMC) const
+template <class TRDTRK, class PROP>
+GPUd() void GPUTRDTracker_t<TRDTRK, PROP>::CheckTrackRefs(const int trackID, bool* findableMC) const
 {
 #ifdef ENABLE_GPUMC
   //--------------------------------------------------------------------
@@ -392,10 +410,10 @@ GPUd() void GPUTRDTracker::CheckTrackRefs(const int trackID, bool* findableMC) c
   }
 #endif
 }
-
 #endif //! GPUCA_GPUCODE
 
-GPUd() int GPUTRDTracker::LoadTracklet(const GPUTRDTrackletWord& tracklet, const int* labels)
+template <class TRDTRK, class PROP>
+GPUd() int GPUTRDTracker_t<TRDTRK, PROP>::LoadTracklet(const GPUTRDTrackletWord& tracklet, const int* labels)
 {
   //--------------------------------------------------------------------
   // Add single tracklet to tracker
@@ -414,31 +432,35 @@ GPUd() int GPUTRDTracker::LoadTracklet(const GPUTRDTrackletWord& tracklet, const
   return 0;
 }
 
-GPUd() void GPUTRDTracker::DumpTracks()
+template <class TRDTRK, class PROP>
+GPUd() void GPUTRDTracker_t<TRDTRK, PROP>::DumpTracks()
 {
   //--------------------------------------------------------------------
   // helper function (only for debugging purposes)
   //--------------------------------------------------------------------
   GPUInfo("There are %i tracks loaded. mNMaxTracks(%i)\n", mNTracks, mNMaxTracks);
   for (int i = 0; i < mNTracks; ++i) {
-    GPUTRDTrack* trk = &(mTracks[i]);
+    auto* trk = &(mTracks[i]);
     GPUInfo("track %i: x=%f, alpha=%f, nTracklets=%i, pt=%f", i, trk->getX(), trk->getAlpha(), trk->GetNtracklets(), trk->getPt());
   }
 }
 
-GPUd() void GPUTRDTracker::DoTrackingThread(int iTrk, int threadId)
+template <class TRDTRK, class PROP>
+GPUd() void GPUTRDTracker_t<TRDTRK, PROP>::DoTrackingThread(int iTrk, int threadId)
 {
   //--------------------------------------------------------------------
   // perform the tracking for one track (must be threadsafe)
   //--------------------------------------------------------------------
-  GPUTRDPropagator prop(&Param().polynomialField);
-  GPUTRDTrack trkCopy = mTracks[iTrk];
+  PROP prop(&Param().polynomialField);
+  auto trkCopy = mTracks[iTrk];
   prop.setTrack(&trkCopy);
   prop.setFitInProjections(true);
   FollowProlongation(&prop, &trkCopy, threadId);
+  mTracks[iTrk] = trkCopy; // copy back the resulting track
 }
 
-GPUd() bool GPUTRDTracker::CalculateSpacePoints()
+template <class TRDTRK, class PROP>
+GPUd() bool GPUTRDTracker_t<TRDTRK, PROP>::CalculateSpacePoints()
 {
   //--------------------------------------------------------------------
   // Calculates TRD space points in sector tracking coordinates
@@ -475,6 +497,7 @@ GPUd() bool GPUTRDTracker::CalculateSpacePoints()
       xTrkltDet[0] = mGeo->AnodePos() + mRadialOffset;
       xTrkltDet[1] = mTracklets[trkltIdx].GetY();
       xTrkltDet[2] = pp->GetRowPos(trkltZbin) - pp->GetRowSize(trkltZbin) / 2.f - pp->GetRowPos(pp->GetNrows() / 2);
+      //GPUInfo("Space point local %i: x=%f, y=%f, z=%f", iTrklt, xTrkltDet[0], xTrkltDet[1], xTrkltDet[2]);
       matrix->LocalToMaster(xTrkltDet, xTrkltSec);
       mSpacePoints[trkltIdx].mR = xTrkltSec[0];
       mSpacePoints[trkltIdx].mX[0] = xTrkltSec[1];
@@ -491,13 +514,14 @@ GPUd() bool GPUTRDTracker::CalculateSpacePoints()
       int modId = mGeo->GetSector(iDet) * GPUTRDGeometry::kNstack + mGeo->GetStack(iDet); // global TRD stack number
       unsigned short volId = mGeo->GetGeomManagerVolUID(iDet, modId);
       mSpacePoints[trkltIdx].mVolumeId = volId;
-      // GPUInfo("Space point %i: x=%f, y=%f, z=%f", iTrklt, mSpacePoints[trkltIdx].mR, mSpacePoints[trkltIdx].mX[0], mSpacePoints[trkltIdx].mX[1]);
+      //GPUInfo("Space point global %i: x=%f, y=%f, z=%f", iTrklt, mSpacePoints[trkltIdx].mR, mSpacePoints[trkltIdx].mX[0], mSpacePoints[trkltIdx].mX[1]);
     }
   }
   return result;
 }
 
-GPUd() bool GPUTRDTracker::FollowProlongation(GPUTRDPropagator* prop, GPUTRDTrack* t, int threadId)
+template <class TRDTRK, class PROP>
+GPUd() bool GPUTRDTracker_t<TRDTRK, PROP>::FollowProlongation(PROP* prop, TRDTRK* t, int threadId)
 {
   //--------------------------------------------------------------------
   // Propagate TPC track layerwise through TRD and pick up closest
@@ -505,14 +529,14 @@ GPUd() bool GPUTRDTracker::FollowProlongation(GPUTRDPropagator* prop, GPUTRDTrac
   // -> returns false if prolongation could not be executed fully
   //    or track does not fullfill threshold conditions
   //--------------------------------------------------------------------
-
+  GPUInfo("Start track following for track %i at x=%f with pt=%f", t->GetTPCtrackId(), t->getX(), t->getPt());
   mDebug->Reset();
   int iTrack = t->GetTPCtrackId();
   t->SetChi2(0.f);
   const GPUTRDpadPlane* pad = nullptr;
 
 #ifdef ENABLE_GPUTRDDEBUG
-  GPUTRDTrack trackNoUp(*t);
+  TRDTRK trackNoUp(*t);
 #endif
 
   // look for matching tracklets via MC label
@@ -531,7 +555,7 @@ GPUd() bool GPUTRDTracker::FollowProlongation(GPUTRDPropagator* prop, GPUTRDTrac
   int candidateIdxOffset = threadId * 2 * mNCandidates;
   int hypothesisIdxOffset = threadId * mNCandidates;
 
-  GPUTRDTrack* trkWork = t;
+  auto trkWork = t;
   if (mNCandidates > 1) {
     // copy input track to first candidate
     mCandidates[candidateIdxOffset] = *t;
@@ -578,17 +602,19 @@ GPUd() bool GPUTRDTracker::FollowProlongation(GPUTRDPropagator* prop, GPUTRDTrac
 
       // propagate track to average radius of TRD layer iLayer (sector 0, stack 2 is chosen as a reference)
       if (!prop->propagateToX(mR[2 * kNLayers + iLayer], .8f, 2.f)) {
-        if (ENABLE_INFO) {
-          Info("FollowProlongation", "Track propagation failed for track %i candidate %i in layer %i (pt=%f, x=%f, mR[layer]=%f)", iTrack, iCandidate, iLayer, trkWork->getPt(), trkWork->getX(), mR[2 * kNLayers + iLayer]);
-        }
+        //if (ENABLE_INFO) {
+        GPUInfo("Track propagation failed for track %i candidate %i in layer %i (pt=%f, x=%f, mR[layer]=%f)", iTrack, iCandidate, iLayer, trkWork->getPt(), trkWork->getX(), mR[2 * kNLayers + iLayer]);
+        //}
+        GPUInfo("Propagation failed");
         continue;
       }
 
       // rotate track in new sector in case of sector crossing
       if (!AdjustSector(prop, trkWork, iLayer)) {
         if (ENABLE_INFO) {
-          Info("FollowProlongation", "Adjusting sector failed for track %i candidate %i in layer %i", iTrack, iCandidate, iLayer);
+          GPUInfo("FollowProlongation: Adjusting sector failed for track %i candidate %i in layer %i", iTrack, iCandidate, iLayer);
         }
+        GPUInfo("Adjust sector failed");
         continue;
       }
 
@@ -604,8 +630,9 @@ GPUd() bool GPUTRDTracker::FollowProlongation(GPUTRDPropagator* prop, GPUTRDTrac
       //
       if (CAMath::Abs(trkWork->getZ()) - roadZ >= zMaxTRD) {
         if (ENABLE_INFO) {
-          Info("FollowProlongation", "Track out of TRD acceptance with z=%f in layer %i (eta=%f)", trkWork->getZ(), iLayer, trkWork->getEta());
+          GPUInfo("FollowProlongation: Track out of TRD acceptance with z=%f in layer %i (eta=%f)", trkWork->getZ(), iLayer, trkWork->getEta());
         }
+        GPUInfo("Out of z acceptance");
         continue;
       }
 
@@ -827,8 +854,8 @@ GPUd() bool GPUTRDTracker::FollowProlongation(GPUTRDPropagator* prop, GPUTRDTrac
         continue;
       }
       if (!trkWork->CheckNumericalQuality()) {
-        if (ENABLE_WARNING) {
-          Info("FollowProlongation", "Track %i has invalid covariance matrix. Aborting track following\n", iTrack);
+        if (ENABLE_INFO) {
+          GPUInfo("FollowProlongation: Track %i has invalid covariance matrix. Aborting track following\n", iTrack);
         }
         return false;
       }
@@ -842,7 +869,7 @@ GPUd() bool GPUTRDTracker::FollowProlongation(GPUTRDPropagator* prop, GPUTRDTrac
 
     if (!isOK) {
       if (ENABLE_INFO) {
-        Info("FollowProlongation", "Track %i cannot be followed. Stopped in layer %i", iTrack, iLayer);
+        GPUInfo("FollowProlongation: Track %i cannot be followed. Stopped in layer %i", iTrack, iLayer);
       }
       return false;
     }
@@ -923,11 +950,13 @@ GPUd() bool GPUTRDTracker::FollowProlongation(GPUTRDPropagator* prop, GPUTRDTrac
     mDebug->SetUpdates(update);
     mDebug->Output();
   }
-
+  GPUInfo("Ended track following for track %i at x=%f with pt=%f", t->GetTPCtrackId(), t->getX(), t->getPt());
+  GPUInfo("Attached %i tracklets", t->GetNtracklets());
   return true;
 }
 
-GPUd() float GPUTRDTracker::GetPredictedChi2(const My_Float* pTRD, const My_Float* covTRD, const My_Float* pTrk, const My_Float* covTrk) const
+template <class TRDTRK, class PROP>
+GPUd() float GPUTRDTracker_t<TRDTRK, PROP>::GetPredictedChi2(const My_Float* pTRD, const My_Float* covTRD, const My_Float* pTrk, const My_Float* covTrk) const
 {
   // FIXME: This function cannot yet be used in production (maybe it is not necessary at all?)
   // conversion from tracklet deflection to sin(phi) needs to be parametrized
@@ -961,7 +990,8 @@ GPUd() float GPUTRDTracker::GetPredictedChi2(const My_Float* pTRD, const My_Floa
   return (c11 * deltaY * deltaY + 2.f * c21 * deltaY * deltaZ + 2.f * c31 * deltaY * deltaS + c22 * deltaZ * deltaZ + 2.f * c32 * deltaZ * deltaS + c33 * deltaS * deltaS) * det;
 }
 
-GPUd() void GPUTRDTracker::InsertHypothesis(Hypothesis hypo, int& nCurrHypothesis, int idxOffset)
+template <class TRDTRK, class PROP>
+GPUd() void GPUTRDTracker_t<TRDTRK, PROP>::InsertHypothesis(Hypothesis hypo, int& nCurrHypothesis, int idxOffset)
 {
   // Insert hypothesis into the array. If the array is full and the reduced chi2 is worse
   // than the worst hypothesis in the array it is dropped.
@@ -1004,7 +1034,8 @@ GPUd() void GPUTRDTracker::InsertHypothesis(Hypothesis hypo, int& nCurrHypothesi
   }
 }
 
-GPUd() int GPUTRDTracker::GetDetectorNumber(const float zPos, const float alpha, const int layer) const
+template <class TRDTRK, class PROP>
+GPUd() int GPUTRDTracker_t<TRDTRK, PROP>::GetDetectorNumber(const float zPos, const float alpha, const int layer) const
 {
   //--------------------------------------------------------------------
   // if track position is within chamber return the chamber number
@@ -1019,7 +1050,8 @@ GPUd() int GPUTRDTracker::GetDetectorNumber(const float zPos, const float alpha,
   return mGeo->GetDetector(layer, stack, sector);
 }
 
-GPUd() bool GPUTRDTracker::AdjustSector(GPUTRDPropagator* prop, GPUTRDTrack* t, const int layer) const
+template <class TRDTRK, class PROP>
+GPUd() bool GPUTRDTracker_t<TRDTRK, PROP>::AdjustSector(PROP* prop, TRDTRK* t, const int layer) const
 {
   //--------------------------------------------------------------------
   // rotate track in new sector if necessary and
@@ -1057,7 +1089,8 @@ GPUd() bool GPUTRDTracker::AdjustSector(GPUTRDPropagator* prop, GPUTRDTrack* t, 
   return true;
 }
 
-GPUd() int GPUTRDTracker::GetSector(float alpha) const
+template <class TRDTRK, class PROP>
+GPUd() int GPUTRDTracker_t<TRDTRK, PROP>::GetSector(float alpha) const
 {
   //--------------------------------------------------------------------
   // TRD sector number for reference system alpha
@@ -1070,7 +1103,8 @@ GPUd() int GPUTRDTracker::GetSector(float alpha) const
   return (int)(alpha * kNSectors / (2.f * M_PI));
 }
 
-GPUd() float GPUTRDTracker::GetAlphaOfSector(const int sec) const
+template <class TRDTRK, class PROP>
+GPUd() float GPUTRDTracker_t<TRDTRK, PROP>::GetAlphaOfSector(const int sec) const
 {
   //--------------------------------------------------------------------
   // rotation angle for TRD sector sec
@@ -1078,7 +1112,8 @@ GPUd() float GPUTRDTracker::GetAlphaOfSector(const int sec) const
   return (2.0f * M_PI / (float)kNSectors * ((float)sec + 0.5f));
 }
 
-GPUd() void GPUTRDTracker::RecalcTrkltCov(const float tilt, const float snp, const float rowSize, My_Float (&cov)[3])
+template <class TRDTRK, class PROP>
+GPUd() void GPUTRDTracker_t<TRDTRK, PROP>::RecalcTrkltCov(const float tilt, const float snp, const float rowSize, My_Float (&cov)[3])
 {
   //--------------------------------------------------------------------
   // recalculate tracklet covariance taking track phi angle into account
@@ -1093,7 +1128,8 @@ GPUd() void GPUTRDTracker::RecalcTrkltCov(const float tilt, const float snp, con
   cov[2] = c2 * (t2 * sy2 + sz2);
 }
 
-GPUd() float GPUTRDTracker::GetAngularPull(float dYtracklet, float snp) const
+template <class TRDTRK, class PROP>
+GPUd() float GPUTRDTracker_t<TRDTRK, PROP>::GetAngularPull(float dYtracklet, float snp) const
 {
   float dYtrack = ConvertAngleToDy(snp);
   float dYresolution = GetAngularResolution(snp);
@@ -1103,7 +1139,8 @@ GPUd() float GPUTRDTracker::GetAngularPull(float dYtracklet, float snp) const
   return (dYtracklet - dYtrack) / CAMath::Sqrt(dYresolution);
 }
 
-GPUd() void GPUTRDTracker::FindChambersInRoad(const GPUTRDTrack* t, const float roadY, const float roadZ, const int iLayer, int* det, const float zMax, const float alpha) const
+template <class TRDTRK, class PROP>
+GPUd() void GPUTRDTracker_t<TRDTRK, PROP>::FindChambersInRoad(const TRDTRK* t, const float roadY, const float roadZ, const int iLayer, int* det, const float zMax, const float alpha) const
 {
   //--------------------------------------------------------------------
   // determine initial chamber where the track ends up
@@ -1177,7 +1214,8 @@ GPUd() void GPUTRDTracker::FindChambersInRoad(const GPUTRDTrack* t, const float 
   }
 }
 
-GPUd() bool GPUTRDTracker::IsGeoFindable(const GPUTRDTrack* t, const int layer, const float alpha) const
+template <class TRDTRK, class PROP>
+GPUd() bool GPUTRDTracker_t<TRDTRK, PROP>::IsGeoFindable(const TRDTRK* t, const int layer, const float alpha) const
 {
   //--------------------------------------------------------------------
   // returns true if track position inside active area of the TRD
@@ -1215,3 +1253,19 @@ GPUd() bool GPUTRDTracker::IsGeoFindable(const GPUTRDTrack* t, const int layer, 
 
   return true;
 }
+
+#ifndef GPUCA_GPUCODE
+namespace GPUCA_NAMESPACE
+{
+namespace gpu
+{
+// instatiate the tracker for both for GPU data types and for AliRoot/O2 data types
+#ifndef GPUCA_STANDALONE
+template class GPUTRDTracker_t<GPUTRDTrack, GPUTRDPropagator>;
+#endif
+#ifndef GPUCA_ALIROOT_LIB
+template class GPUTRDTracker_t<GPUTRDTrackGPU, GPUTRDPropagatorGPU>;
+#endif
+} // namespace gpu
+} // namespace GPUCA_NAMESPACE
+#endif

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
@@ -1260,7 +1260,7 @@ namespace GPUCA_NAMESPACE
 namespace gpu
 {
 // instatiate the tracker for both for GPU data types and for AliRoot/O2 data types
-#ifndef GPUCA_STANDALONE
+#if !defined(GPUCA_STANDALONE) && !defined(GPUCA_GPUCODE)
 template class GPUTRDTracker_t<GPUTRDTrack, GPUTRDPropagator>;
 #endif
 #ifndef GPUCA_ALIROOT_LIB

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTrackerComponent.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTrackerComponent.h
@@ -27,11 +27,11 @@
 class TH1F;
 class TList;
 
+#include "GPUTRDDef.h"
 namespace GPUCA_NAMESPACE
 {
 namespace gpu
 {
-class GPUTRDTracker;
 class GPUTRDGeometry;
 } // namespace gpu
 } // namespace GPUCA_NAMESPACE

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTrackerDebug.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTrackerDebug.h
@@ -526,7 +526,7 @@ class GPUTRDTrackerDebug
 #ifndef GPUCA_ALIROOT_LIB
 template class GPUTRDTrackerDebug<GPUTRDTrackGPU>;
 #endif
-#ifndef GPUCA_STANDALONE
+#if !defined(GPUCA_STANDALONE) && !defined(GPUCA_GPUCODE)
 template class GPUTRDTrackerDebug<GPUTRDTrack>;
 #endif
 } // namespace gpu

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTrackerDebug.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTrackerDebug.h
@@ -28,6 +28,7 @@ namespace GPUCA_NAMESPACE
 namespace gpu
 {
 
+template <class T>
 class GPUTRDTrackerDebug
 {
  public:
@@ -197,7 +198,7 @@ class GPUTRDTrackerDebug
   }
 
   // track parameters
-  void SetTrackParameter(const GPUTRDTrack& trk, int ly)
+  void SetTrackParameter(const T& trk, int ly)
   {
     fTrackX(ly) = trk.getX();
     fTrackY(ly) = trk.getY();
@@ -210,7 +211,7 @@ class GPUTRDTrackerDebug
     fTrackYerr(ly) = trk.getSigmaY2();
     fTrackZerr(ly) = trk.getSigmaZ2();
   }
-  void SetTrackParameterNoUp(const GPUTRDTrack& trk, int ly)
+  void SetTrackParameterNoUp(const T& trk, int ly)
   {
     fTrackNoUpX(ly) = trk.getX();
     fTrackNoUpY(ly) = trk.getY();
@@ -222,14 +223,14 @@ class GPUTRDTrackerDebug
     fTrackNoUpYerr(ly) = trk.getSigmaY2();
     fTrackNoUpZerr(ly) = trk.getSigmaZ2();
   }
-  void SetTrackParameterReal(const GPUTRDTrack& trk, int ly)
+  void SetTrackParameterReal(const T& trk, int ly)
   {
     fTrackXReal(ly) = trk.getX();
     fTrackYReal(ly) = trk.getY();
     fTrackZReal(ly) = trk.getZ();
     fTrackSecReal(ly) = GetSector(trk.getAlpha());
   }
-  void SetTrack(const GPUTRDTrack& trk)
+  void SetTrack(const T& trk)
   {
     fChi2 = trk.GetChi2();
     fNlayers = trk.GetNlayers();
@@ -469,6 +470,7 @@ class GPUTRDTrackerDebug
 
   TTreeSRedirector* fStreamer;
 };
+template class GPUTRDTrackerDebug<GPUTRDTrack>;
 } // namespace gpu
 } // namespace GPUCA_NAMESPACE
 
@@ -479,6 +481,7 @@ namespace GPUCA_NAMESPACE
 namespace gpu
 {
 
+template <class T>
 class GPUTRDTrackerDebug
 {
  public:
@@ -491,10 +494,10 @@ class GPUTRDTrackerDebug
   GPUd() void SetTrackProperties(int nMatch = 0, int nFake = 0, int nRelated = 0) {}
 
   // track parameters
-  GPUd() void SetTrackParameter(const GPUTRDTrack& trk, int ly) {}
-  GPUd() void SetTrackParameterNoUp(const GPUTRDTrack& trk, int ly) {}
-  GPUd() void SetTrackParameterReal(const GPUTRDTrack& trk, int ly) {}
-  GPUd() void SetTrack(const GPUTRDTrack& trk) {}
+  GPUd() void SetTrackParameter(const T& trk, int ly) {}
+  GPUd() void SetTrackParameterNoUp(const T& trk, int ly) {}
+  GPUd() void SetTrackParameterReal(const T& trk, int ly) {}
+  GPUd() void SetTrack(const T& trk) {}
 
   // tracklet parameters
   GPUd() void SetRawTrackletPosition(const float fX, const float* fYZ, int ly) {}
@@ -520,6 +523,12 @@ class GPUTRDTrackerDebug
   GPUd() void SetMCinfo(float xv, float yv, float zv, int pdg) {}
   GPUd() void Output() {}
 };
+#ifndef GPUCA_ALIROOT_LIB
+template class GPUTRDTrackerDebug<GPUTRDTrackGPU>;
+#endif
+#ifndef GPUCA_STANDALONE
+template class GPUTRDTrackerDebug<GPUTRDTrack>;
+#endif
 } // namespace gpu
 } // namespace GPUCA_NAMESPACE
 

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTrackerKernels.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTrackerKernels.cxx
@@ -8,10 +8,10 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file GPUTRDTrackerGPU.cxx
+/// \file GPUTRDTrackerKernels.cxx
 /// \author David Rohr
 
-#include "GPUTRDTrackerGPU.h"
+#include "GPUTRDTrackerKernels.h"
 #include "GPUTRDGeometry.h"
 #include "GPUConstantMem.h"
 #if defined(WITH_OPENMP) && !defined(GPUCA_GPUCODE)
@@ -21,7 +21,7 @@
 using namespace GPUCA_NAMESPACE::gpu;
 
 template <>
-GPUdii() void GPUTRDTrackerGPU::Thread<0>(int nBlocks, int nThreads, int iBlock, int iThread, GPUsharedref() GPUSharedMemory& smem, processorType& processors)
+GPUdii() void GPUTRDTrackerKernels::Thread<0>(int nBlocks, int nThreads, int iBlock, int iThread, GPUsharedref() GPUSharedMemory& smem, processorType& processors)
 {
 #if defined(WITH_OPENMP) && !defined(GPUCA_GPUCODE)
 #pragma omp parallel for num_threads(processors.trdTracker.GetRec().GetDeviceProcessingSettings().nThreads)

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTrackerKernels.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTrackerKernels.h
@@ -8,11 +8,11 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file GPUTRDTrackerGPU.h
+/// \file GPUTRDTrackerKernels.h
 /// \author David Rohr
 
-#ifndef GPUTRDTRACKERGPUCA_H
-#define GPUTRDTRACKERGPUCA_H
+#ifndef GPUTRDTRACKERKERNELSCA_H
+#define GPUTRDTRACKERKERNELSCA_H
 
 #include "GPUGeneralKernels.h"
 
@@ -21,7 +21,7 @@ namespace GPUCA_NAMESPACE
 namespace gpu
 {
 
-class GPUTRDTrackerGPU : public GPUKernelTemplate
+class GPUTRDTrackerKernels : public GPUKernelTemplate
 {
  public:
   GPUhdi() CONSTEXPR static GPUDataTypes::RecoStep GetRecoStep() { return GPUCA_RECO_STEP::TRDTracking; }
@@ -31,4 +31,4 @@ class GPUTRDTrackerGPU : public GPUKernelTemplate
 } // namespace gpu
 } // namespace GPUCA_NAMESPACE
 
-#endif // GPUTRDTRACKERGPUCA_H
+#endif // GPUTRDTRACKERKERNELSCA_H

--- a/GPU/GPUTracking/TRDTracking/macros/run_trd_tracker.C
+++ b/GPU/GPUTracking/TRDTracking/macros/run_trd_tracker.C
@@ -1,0 +1,136 @@
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+// ROOT header
+#include <TChain.h>
+// GPU header
+#include "GPUO2Interface.h"
+#include "GPUReconstruction.h"
+#include "GPUChainTracking.h"
+#include "GPUSettings.h"
+#include "GPUDataTypes.h"
+#include "GPUTRDDef.h"
+#include "GPUTRDTrack.h"
+#include "GPUTRDTracker.h"
+#include "GPUTRDTrackletWord.h"
+#include "GPUTRDInterfaces.h"
+#include "GPUTRDGeometry.h"
+
+// O2 header
+#include "DetectorsBase/GeometryManager.h"
+#include "DetectorsBase/Propagator.h"
+#include "ReconstructionDataFormats/TrackTPCITS.h"
+#include "TRDBase/Tracklet.h"
+
+#endif
+
+using namespace GPUCA_NAMESPACE::gpu;
+
+void run_trd_tracker(std::string path = "./",
+                     std::string inputGeom = "O2geometry.root",
+                     std::string inputGRP = "o2sim_grp.root",
+                     std::string inputTracks = "o2match_itstpc.root",
+                     std::string inputTracklets = "trdtracklets.root")
+{
+
+  //-------- init geometry and field --------//
+  o2::base::GeometryManager::loadGeometry(path + inputGeom, "FAIRGeom");
+  o2::base::Propagator::initFieldFromGRP(path + inputGRP);
+
+  auto geo = o2::trd::TRDGeometry::instance();
+  geo->createPadPlaneArray();
+  geo->createClusterMatrixArray();
+  const o2::trd::TRDGeometryFlat geoFlat(*geo);
+
+  //-------- init GPU reconstruction --------//
+  GPUSettingsEvent cfgEvent;                       // defaults should be ok
+  GPUSettingsRec cfgRec;                           // don't care for now, NWaysOuter is set in here for instance
+  GPUSettingsDeviceProcessing cfgDeviceProcessing; // also keep defaults here, or adjust debug level
+  cfgDeviceProcessing.debugLevel = 10;
+  GPURecoStepConfiguration cfgRecoStep;
+  cfgRecoStep.steps = GPUDataTypes::RecoStep::NoRecoStep;
+  auto rec = GPUReconstruction::CreateInstance("CPU", true);
+  rec->SetSettings(&cfgEvent, &cfgRec, &cfgDeviceProcessing, &cfgRecoStep);
+
+  auto chainTracking = rec->AddChain<GPUChainTracking>();
+
+  auto tracker = new GPUTRDTracker();
+  tracker->SetNCandidates(1); // must be set before initialization
+
+  rec->RegisterGPUProcessor(tracker, false);
+  chainTracking->SetTRDGeometry(&geoFlat);
+  tracker->SetTrackingChain(chainTracking);
+  rec->Init();
+  rec->AllocateRegisteredMemory(nullptr);
+
+  // configure the tracker
+  //tracker->EnableDebugOutput();
+  //tracker->StartDebugging();
+  tracker->SetPtThreshold(0.5);
+  tracker->SetChi2Threshold(15);
+  tracker->SetChi2Penalty(12);
+  tracker->SetMaxMissingLayers(6);
+  tracker->PrintSettings();
+
+  // load input tracks
+  TChain tracksItsTpc("matchTPCITS");
+  tracksItsTpc.AddFile((path + inputTracks).c_str());
+
+  std::vector<o2::dataformats::TrackTPCITS>* tracksInArrayPtr = nullptr;
+  tracksItsTpc.SetBranchAddress("TPCITS", &tracksInArrayPtr);
+  printf("Attached ITS-TPC tracks branch with %lli entries\n", (tracksItsTpc.GetBranch("TPCITS"))->GetEntries());
+
+  tracksItsTpc.GetEntry(0);
+  int nTracks = tracksInArrayPtr->size();
+  printf("There are %i tracks in total\n", nTracks);
+
+  // and load input tracklets
+  TChain trdTracklets("o2sim");
+  trdTracklets.AddFile((path + inputTracklets).c_str());
+
+  std::vector<o2::trd::Tracklet>* trackletsInArrayPtr = nullptr;
+  trdTracklets.SetBranchAddress("Tracklet", &trackletsInArrayPtr);
+  trdTracklets.GetEntry(0);
+  int nTracklets = trackletsInArrayPtr->size();
+  printf("There are %i tracklets in total\n", nTracklets);
+
+  auto pp = geo->getPadPlane(0, 0);
+  printf("Tilt=%f\n", pp->getTiltingAngle());
+
+  tracker->Reset(true);
+
+  chainTracking->mIOPtrs.nMergedTracks = nTracks;
+  chainTracking->mIOPtrs.nTRDTracklets = nTracklets;
+  chainTracking->AllocateIOMemory();
+  rec->PrepareEvent();
+  rec->AllocateRegisteredMemory(tracker->MemoryTracks());
+
+  // load everything into the tracker
+  for (int iTrk = 0; iTrk < nTracks; ++iTrk) {
+    auto trk = tracksInArrayPtr->at(iTrk);
+    GPUTRDTrack trkLoad;
+    trkLoad.setX(trk.getX());
+    trkLoad.setAlpha(trk.getAlpha());
+    for (int i = 0; i < 5; ++i) {
+      trkLoad.setParam(trk.getParam(i), i);
+    }
+    for (int i = 0; i < 15; ++i) {
+      trkLoad.setCov(trk.getCov()[i], i);
+    }
+    tracker->LoadTrack(trkLoad);
+  }
+  for (int iTrklt = 0; iTrklt < nTracklets; ++iTrklt) {
+    auto trklt = trackletsInArrayPtr->at(iTrklt);
+    unsigned int trkltWord = trklt.getTrackletWord();
+    GPUTRDTrackletWord trkltLoad;
+    trkltLoad.SetId(iTrklt);
+    trkltLoad.SetHCId(trklt.getHCId());
+    trkltLoad.SetTrackletWord(trkltWord);
+    if (tracker->LoadTracklet(trkltLoad) > 0) {
+      printf("Could not load tracklet %i\n", iTrklt);
+    }
+  }
+  tracker->DumpTracks();
+  tracker->DoTracking();
+  tracker->DumpTracks();
+
+  printf("Done\n");
+}

--- a/cmake/O2RootMacroExclusionList.cmake
+++ b/cmake/O2RootMacroExclusionList.cmake
@@ -38,6 +38,7 @@ list(APPEND O2_ROOT_MACRO_EXCLUSION_LIST
             GPU/TPCFastTransformation/alirootMacro/initTPCcalibration.C # Needs AliTPCCalibDB
             GPU/TPCFastTransformation/devtools/loadlibs.C # Special macro
             GPU/TPCFastTransformation/alirootMacro/moveTPCFastTransform.C # Relies on initTPCcalibration.C
+            GPU/GPUTracking/TRDTracking/macros/run_trd_tracker.C # Not yet ready
 	    Detectors/TOF/prototyping/ConvertRun2CalibrationToO2.C
             Generators/share/external/hijing.C
 	    Generators/share/external/QEDepem.C


### PR DESCRIPTION
Hi @shahor02 , hi @davidrohr 
I am trying to add the interface to O2 to the TRD tracker, but I cannot include the necessary headers.
The build fails when trying to include DetectorsBase/Propagator.h.
I am not sure whether I am missing something in the CMake configuration or if there is another issue with the Propagator class.
The error log is attached. But as the error is found in TObject.h of ROOT it does not really help me..
[o2-build-error-trd-interface.log](https://github.com/AliceO2Group/AliceO2/files/4328618/o2-build-error-trd-interface.log)

Do you know what might go wrong?
Cheers,
Ole