### PR TITLE
DPL Analysis: Temporary solution for filtering on multiple variables at once

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1391,12 +1391,6 @@ template <typename T>
 using is_soa_filtered_t = typename framework::is_specialization<T, soa::Filtered>;
 
 template <typename T>
-auto filter(T&& t, framework::expressions::Filter const& expr)
-{
-  return Filtered<T>(t.asArrowTable(), expr);
-}
-
-template <typename T>
 std::vector<std::decay_t<T>> slice(T&& t, std::string const& columnName)
 {
   arrow::compute::FunctionContext ctx;

--- a/Framework/Core/test/benchmark_ASoAHelpers.cxx
+++ b/Framework/Core/test/benchmark_ASoAHelpers.cxx
@@ -717,4 +717,596 @@ static void BM_ASoAHelpersCombGenCollisionsFivesCategories(benchmark::State& sta
 
 BENCHMARK(BM_ASoAHelpersCombGenCollisionsFivesCategories)->RangeMultiplier(2)->Range(8, 8 << (maxFivesRange + 1));
 
+static void BM_ASoAHelpersCombGenSimplePairsFilters(benchmark::State& state)
+{
+  // Seed with a real random value, if available
+  std::default_random_engine e1(1234567891);
+  std::uniform_real_distribution<float> uniform_dist(0, 1);
+
+  TableBuilder builder;
+  auto rowWriter = builder.persist<float, float, float>({"x", "y", "z"});
+  for (auto i = 0; i < state.range(0); ++i) {
+    rowWriter(0, uniform_dist(e1), uniform_dist(e1), uniform_dist(e1));
+  }
+  auto table = builder.finalize();
+
+  using Test = o2::soa::Table<test::X>;
+  Test tests{table};
+
+  int64_t count = 0;
+  expressions::Filter filter = test::x > (test::x * (-1.0f) + 1.0f);
+  for (auto _ : state) {
+    count = 0;
+    for (auto& [t0, t1] : selfCombinations(filter, tests, tests)) {
+      count++;
+    }
+    benchmark::DoNotOptimize(count);
+  }
+  state.counters["Combinations"] = count;
+  int64_t filteringCount = state.range(0) * state.range(0);
+  state.SetBytesProcessed(state.iterations() * sizeof(float) * filteringCount);
+}
+
+BENCHMARK(BM_ASoAHelpersCombGenSimplePairsFilters)->RangeMultiplier(2)->Range(8, 8 << 6);
+
+static void BM_ASoAHelpersCombGenSimpleFivesFilters(benchmark::State& state)
+{
+  // Seed with a real random value, if available
+  std::default_random_engine e1(1234567891);
+  std::uniform_real_distribution<float> uniform_dist(0, 1);
+
+  TableBuilder builder;
+  auto rowWriter = builder.persist<float, float, float>({"x", "y", "z"});
+  for (auto i = 0; i < state.range(0); ++i) {
+    rowWriter(0, uniform_dist(e1), uniform_dist(e1), uniform_dist(e1));
+  }
+  auto table = builder.finalize();
+
+  using Test = o2::soa::Table<test::X>;
+  Test tests{table};
+
+  int64_t count = 0;
+  expressions::Filter filter = (test::x > 0.3f) && (test::x > (test::x * (-1.0f) + 1.0f)) && (test::x > (test::x * (-1.0f) + 1.0f));
+  for (auto _ : state) {
+    count = 0;
+    for (auto& [t0, t1, t2, t3, t4] : selfCombinations(filter, tests, tests, tests, tests, tests)) {
+      count++;
+    }
+    benchmark::DoNotOptimize(count);
+  }
+  state.counters["Combinations"] = count;
+  int64_t filteringCount = state.range(0) * state.range(0) * state.range(0) * state.range(0) * state.range(0);
+  state.SetBytesProcessed(state.iterations() * sizeof(float) * filteringCount);
+}
+
+BENCHMARK(BM_ASoAHelpersCombGenSimpleFivesFilters)->RangeMultiplier(2)->Range(8, 16);
+
+static void BM_ASoAHelpersCombGenTracksPairsFilters(benchmark::State& state)
+{
+  // Seed with a real random value, if available
+  std::default_random_engine e1(1234567891);
+  std::uniform_real_distribution<float> uniform_dist(0, 1);
+
+  TableBuilder builder;
+  auto rowWriter = builder.cursor<o2::aod::Tracks>();
+  for (auto i = 0; i < state.range(0); ++i) {
+    rowWriter(0, uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
+              uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
+              uniform_dist(e1), uniform_dist(e1), uniform_dist(e1));
+  }
+  auto table = builder.finalize();
+
+  o2::aod::Tracks tracks{table};
+
+  int64_t count = 0;
+  expressions::Filter filter = o2::aod::track::x > (o2::aod::track::x * (-1.0f) + 1.0f);
+  for (auto _ : state) {
+    count = 0;
+    for (auto& [t0, t1] : selfCombinations(filter, tracks, tracks)) {
+      count++;
+    }
+    benchmark::DoNotOptimize(count);
+  }
+  state.counters["Combinations"] = count;
+  int64_t filteringCount = state.range(0) * state.range(0);
+  state.SetBytesProcessed(state.iterations() * sizeof(float) * filteringCount);
+}
+
+BENCHMARK(BM_ASoAHelpersCombGenTracksPairsFilters)->RangeMultiplier(2)->Range(8, 8 << 6);
+
+static void BM_ASoAHelpersCombGenTracksFivesFilters(benchmark::State& state)
+{
+  // Seed with a real random value, if available
+  std::default_random_engine e1(1234567891);
+  std::uniform_real_distribution<float> uniform_dist(0, 1);
+
+  TableBuilder builder;
+  auto rowWriter = builder.cursor<o2::aod::Tracks>();
+  for (auto i = 0; i < state.range(0); ++i) {
+    rowWriter(0, uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
+              uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
+              uniform_dist(e1), uniform_dist(e1), uniform_dist(e1));
+  }
+  auto table = builder.finalize();
+
+  o2::aod::Tracks tracks{table};
+
+  int64_t count = 0;
+  expressions::Filter filter = (o2::aod::track::x > 0.3f) && (o2::aod::track::x > (o2::aod::track::x * (-1.0f) + 1.0f)) && (o2::aod::track::x > (o2::aod::track::x * (-1.0f) + 1.0f));
+  for (auto _ : state) {
+    count = 0;
+    for (auto& [t0, t1, t2, t3, t4] : selfCombinations(filter, tracks, tracks, tracks, tracks, tracks)) {
+      count++;
+    }
+    benchmark::DoNotOptimize(count);
+  }
+  state.counters["Combinations"] = count;
+  int64_t filteringCount = state.range(0) * state.range(0) * state.range(0) * state.range(0) * state.range(0);
+  state.SetBytesProcessed(state.iterations() * sizeof(float) * filteringCount);
+}
+
+BENCHMARK(BM_ASoAHelpersCombGenTracksFivesFilters)->RangeMultiplier(2)->Range(8, 16);
+
+static void BM_ASoAHelpersCombGenSimplePairsIfs(benchmark::State& state)
+{
+  // Seed with a real random value, if available
+  std::default_random_engine e1(1234567891);
+  std::uniform_real_distribution<float> uniform_dist(0, 1);
+
+  TableBuilder builder;
+  auto rowWriter = builder.persist<float, float, float>({"x", "y", "z"});
+  for (auto i = 0; i < state.range(0); ++i) {
+    rowWriter(0, uniform_dist(e1), uniform_dist(e1), uniform_dist(e1));
+  }
+  auto table = builder.finalize();
+
+  using Test = o2::soa::Table<test::X>;
+  Test tests{table};
+
+  int64_t count = 0;
+  int64_t filteringCount = 0;
+
+  for (auto _ : state) {
+    count = 0;
+    for (auto& [t0, t1] : combinations(tests, tests)) {
+      filteringCount++;
+      if (t0.x() > (t1.x() * (-1.0f) + 1.0f)) {
+        auto comb = std::make_tuple(t0, t1);
+        count++;
+        benchmark::DoNotOptimize(comb);
+      }
+    }
+    benchmark::DoNotOptimize(count);
+    benchmark::DoNotOptimize(filteringCount);
+  }
+  state.counters["Combinations"] = count;
+  state.SetBytesProcessed(state.iterations() * sizeof(float) * filteringCount);
+}
+
+BENCHMARK(BM_ASoAHelpersCombGenSimplePairsIfs)->RangeMultiplier(2)->Range(8, 8 << 6);
+
+static void BM_ASoAHelpersCombGenSimpleFivesIfs(benchmark::State& state)
+{
+  // Seed with a real random value, if available
+  std::default_random_engine e1(1234567891);
+  std::uniform_real_distribution<float> uniform_dist(0, 1);
+
+  TableBuilder builder;
+  auto rowWriter = builder.persist<float, float, float>({"x", "y", "z"});
+  for (auto i = 0; i < state.range(0); ++i) {
+    rowWriter(0, uniform_dist(e1), uniform_dist(e1), uniform_dist(e1));
+  }
+  auto table = builder.finalize();
+
+  using Test = o2::soa::Table<test::X>;
+  Test tests{table};
+
+  int64_t count = 0;
+  int64_t filteringCount = 0;
+
+  for (auto _ : state) {
+    count = 0;
+    for (auto& [t0, t1, t2, t3, t4] : combinations(tests, tests, tests, tests, tests)) {
+      filteringCount++;
+      if ((t0.x() > 0.3f) && (t2.x() > (t1.x() * (-1.0f) + 1.0f)) && (t4.x() > (t3.x() * (-1.0f) + 1.0f))) {
+        auto comb = std::make_tuple(t0, t1, t2, t3, t4);
+        count++;
+        benchmark::DoNotOptimize(comb);
+      }
+    }
+    benchmark::DoNotOptimize(count);
+    benchmark::DoNotOptimize(filteringCount);
+  }
+  state.counters["Combinations"] = count;
+  state.SetBytesProcessed(state.iterations() * sizeof(float) * filteringCount);
+}
+
+BENCHMARK(BM_ASoAHelpersCombGenSimpleFivesIfs)->RangeMultiplier(2)->Range(8, 16);
+
+static void BM_ASoAHelpersCombGenTracksPairsIfs(benchmark::State& state)
+{
+  // Seed with a real random value, if available
+  std::default_random_engine e1(1234567891);
+  std::uniform_real_distribution<float> uniform_dist(0, 1);
+
+  TableBuilder builder;
+  auto rowWriter = builder.cursor<o2::aod::Tracks>();
+  for (auto i = 0; i < state.range(0); ++i) {
+    rowWriter(0, uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
+              uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
+              uniform_dist(e1), uniform_dist(e1), uniform_dist(e1));
+  }
+  auto table = builder.finalize();
+
+  o2::aod::Tracks tracks{table};
+
+  int64_t count = 0;
+  int64_t filteringCount = 0;
+
+  for (auto _ : state) {
+    count = 0;
+    for (auto& [t0, t1] : combinations(tracks, tracks)) {
+      filteringCount++;
+      if (t1.x() > (t0.x() * (-1.0f) + 1.0f)) {
+        auto comb = std::make_tuple(t0, t1);
+        count++;
+        benchmark::DoNotOptimize(comb);
+      }
+    }
+    benchmark::DoNotOptimize(count);
+    benchmark::DoNotOptimize(filteringCount);
+  }
+  state.counters["Combinations"] = count;
+  state.SetBytesProcessed(state.iterations() * sizeof(float) * filteringCount);
+}
+
+BENCHMARK(BM_ASoAHelpersCombGenTracksPairsIfs)->RangeMultiplier(2)->Range(8, 8 << 6);
+
+static void BM_ASoAHelpersCombGenTracksFivesIfs(benchmark::State& state)
+{
+  // Seed with a real random value, if available
+  std::default_random_engine e1(1234567891);
+  std::uniform_real_distribution<float> uniform_dist(0, 1);
+
+  TableBuilder builder;
+  auto rowWriter = builder.cursor<o2::aod::Tracks>();
+  for (auto i = 0; i < state.range(0); ++i) {
+    rowWriter(0, uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
+              uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
+              uniform_dist(e1), uniform_dist(e1), uniform_dist(e1));
+  }
+  auto table = builder.finalize();
+
+  o2::aod::Tracks tracks{table};
+
+  int64_t count = 0;
+  int64_t filteringCount = 0;
+
+  for (auto _ : state) {
+    count = 0;
+    for (auto& [t0, t1, t2, t3, t4] : combinations(tracks, tracks, tracks, tracks, tracks)) {
+      filteringCount++;
+      if ((t0.x() > 0.3f) && (t2.x() > (t1.x() * (-1.0f) + 1.0f)) && (t4.x() > (t3.x() * (-1.0f) + 1.0f))) {
+        auto comb = std::make_tuple(t0, t1, t2, t3, t4);
+        count++;
+        benchmark::DoNotOptimize(comb);
+      }
+    }
+    benchmark::DoNotOptimize(count);
+    benchmark::DoNotOptimize(filteringCount);
+  }
+  state.counters["Combinations"] = count;
+  state.SetBytesProcessed(state.iterations() * sizeof(float) * filteringCount);
+}
+
+BENCHMARK(BM_ASoAHelpersCombGenTracksFivesIfs)->RangeMultiplier(2)->Range(8, 16);
+
+static void BM_ASoAHelpersNaiveSimplePairsIfs(benchmark::State& state)
+{
+  // Seed with a real random value, if available
+  std::default_random_engine e1(1234567891);
+  std::uniform_real_distribution<float> uniform_dist(0, 1);
+
+  TableBuilder builder;
+  auto rowWriter = builder.persist<float, float, float>({"x", "y", "z"});
+  for (auto i = 0; i < state.range(0); ++i) {
+    rowWriter(0, uniform_dist(e1), uniform_dist(e1), uniform_dist(e1));
+  }
+  auto table = builder.finalize();
+
+  using Test = o2::soa::Table<test::X>;
+  Test tests{table};
+
+  int64_t count = 0;
+  int64_t filteringCount = 0;
+
+  for (auto _ : state) {
+    count = 0;
+    for (auto t0 = tests.begin(); t0 + 1 != tests.end(); ++t0) {
+      for (auto t1 = t0 + 1; t1 != tests.end(); ++t1) {
+        filteringCount++;
+        if ((*t1).x() > ((*t0).x() * (-1.0f) + 1.0f)) {
+          auto comb = std::make_tuple(t0, t1);
+          count++;
+          benchmark::DoNotOptimize(comb);
+        }
+      }
+    }
+    benchmark::DoNotOptimize(count);
+    benchmark::DoNotOptimize(filteringCount);
+  }
+  state.counters["Combinations"] = count;
+  state.SetBytesProcessed(state.iterations() * sizeof(float) * filteringCount);
+}
+
+BENCHMARK(BM_ASoAHelpersNaiveSimplePairsIfs)->RangeMultiplier(2)->Range(8, 8 << 6);
+
+static void BM_ASoAHelpersNaiveSimpleFivesIfs(benchmark::State& state)
+{
+  // Seed with a real random value, if available
+  std::default_random_engine e1(1234567891);
+  std::uniform_real_distribution<float> uniform_dist(0, 1);
+
+  TableBuilder builder;
+  auto rowWriter = builder.persist<float, float, float>({"x", "y", "z"});
+  for (auto i = 0; i < state.range(0); ++i) {
+    rowWriter(0, uniform_dist(e1), uniform_dist(e1), uniform_dist(e1));
+  }
+  auto table = builder.finalize();
+
+  using Test = o2::soa::Table<test::X>;
+  Test tests{table};
+
+  int64_t count = 0;
+  int64_t filteringCount = 0;
+
+  for (auto _ : state) {
+    count = 0;
+    for (auto t0 = tests.begin(); t0 + 4 != tests.end(); ++t0) {
+      for (auto t1 = t0 + 1; t1 + 3 != tests.end(); ++t1) {
+        for (auto t2 = t1 + 1; t2 + 2 != tests.end(); ++t2) {
+          for (auto t3 = t2 + 1; t3 + 1 != tests.end(); ++t3) {
+            for (auto t4 = t3 + 1; t4 != tests.end(); ++t4) {
+              filteringCount++;
+              if (((*t0).x() > 0.3f) && ((*t2).x() > ((*t1).x() * (-1.0f) + 1.0f)) && ((*t4).x() > ((*t3).x() * (-1.0f) + 1.0f))) {
+                auto comb = std::make_tuple(t0, t1, t2, t3, t4);
+                count++;
+                benchmark::DoNotOptimize(comb);
+              }
+            }
+          }
+        }
+      }
+    }
+    benchmark::DoNotOptimize(count);
+    benchmark::DoNotOptimize(filteringCount);
+  }
+  state.counters["Combinations"] = count;
+  state.SetBytesProcessed(state.iterations() * sizeof(float) * filteringCount);
+}
+
+BENCHMARK(BM_ASoAHelpersNaiveSimpleFivesIfs)->RangeMultiplier(2)->Range(8, 16);
+
+static void BM_ASoAHelpersNaiveTracksPairsIfs(benchmark::State& state)
+{
+  // Seed with a real random value, if available
+  std::default_random_engine e1(1234567891);
+  std::uniform_real_distribution<float> uniform_dist(0, 1);
+
+  TableBuilder builder;
+  auto rowWriter = builder.cursor<o2::aod::Tracks>();
+  for (auto i = 0; i < state.range(0); ++i) {
+    rowWriter(0, uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
+              uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
+              uniform_dist(e1), uniform_dist(e1), uniform_dist(e1));
+  }
+  auto table = builder.finalize();
+
+  o2::aod::Tracks tracks{table};
+
+  int64_t count = 0;
+  int64_t filteringCount = 0;
+
+  for (auto _ : state) {
+    count = 0;
+    for (auto t0 = tracks.begin(); t0 + 1 != tracks.end(); ++t0) {
+      for (auto t1 = t0 + 1; t1 != tracks.end(); ++t1) {
+        filteringCount++;
+        if ((*t1).x() > ((*t0).x() * (-1.0f) + 1.0f)) {
+          auto comb = std::make_tuple(t0, t1);
+          count++;
+          benchmark::DoNotOptimize(comb);
+        }
+      }
+    }
+    benchmark::DoNotOptimize(count);
+    benchmark::DoNotOptimize(filteringCount);
+  }
+  state.counters["Combinations"] = count;
+  state.SetBytesProcessed(state.iterations() * sizeof(float) * filteringCount);
+}
+
+BENCHMARK(BM_ASoAHelpersNaiveTracksPairsIfs)->RangeMultiplier(2)->Range(8, 8 << 6);
+
+static void BM_ASoAHelpersNaiveTracksFivesIfs(benchmark::State& state)
+{
+  // Seed with a real random value, if available
+  std::default_random_engine e1(1234567891);
+  std::uniform_real_distribution<float> uniform_dist(0, 1);
+
+  TableBuilder builder;
+  auto rowWriter = builder.cursor<o2::aod::Tracks>();
+  for (auto i = 0; i < state.range(0); ++i) {
+    rowWriter(0, uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
+              uniform_dist(e1), uniform_dist(e1), uniform_dist(e1),
+              uniform_dist(e1), uniform_dist(e1), uniform_dist(e1));
+  }
+  auto table = builder.finalize();
+
+  o2::aod::Tracks tracks{table};
+
+  int64_t count = 0;
+  int64_t filteringCount = 0;
+
+  for (auto _ : state) {
+    count = 0;
+    for (auto t0 = tracks.begin(); t0 + 4 != tracks.end(); ++t0) {
+      for (auto t1 = t0 + 1; t1 + 3 != tracks.end(); ++t1) {
+        for (auto t2 = t1 + 1; t2 + 2 != tracks.end(); ++t2) {
+          for (auto t3 = t2 + 1; t3 + 1 != tracks.end(); ++t3) {
+            for (auto t4 = t3 + 1; t4 != tracks.end(); ++t4) {
+              filteringCount++;
+              if (((*t0).x() > 0.3f) && ((*t2).x() > ((*t1).x() * (-1.0f) + 1.0f)) && ((*t4).x() > ((*t3).x() * (-1.0f) + 1.0f))) {
+                auto comb = std::make_tuple(t0, t1, t2, t3, t4);
+                count++;
+                benchmark::DoNotOptimize(comb);
+              }
+            }
+          }
+        }
+      }
+    }
+    benchmark::DoNotOptimize(count);
+    benchmark::DoNotOptimize(filteringCount);
+  }
+  state.counters["Combinations"] = count;
+  state.SetBytesProcessed(state.iterations() * sizeof(float) * filteringCount);
+}
+
+BENCHMARK(BM_ASoAHelpersNaiveTracksFivesIfs)->RangeMultiplier(2)->Range(8, 16);
+
+static void BM_ASoAHelpersNaiveSimplePairsFilters(benchmark::State& state)
+{
+  // Seed with a real random value, if available
+  std::default_random_engine e1(1234567891);
+  std::uniform_real_distribution<float> uniform_dist(0, 1);
+
+  TableBuilder builder;
+  auto rowWriter = builder.persist<float, float, float>({"x", "y", "z"});
+  for (auto i = 0; i < state.range(0); ++i) {
+    rowWriter(0, uniform_dist(e1), uniform_dist(e1), uniform_dist(e1));
+  }
+  auto table = builder.finalize();
+
+  using Test = o2::soa::Table<test::X>;
+  Test tests{table};
+
+  int64_t count = 0;
+
+  for (auto _ : state) {
+    count = 0;
+    o2::framework::expressions::Filter filter = test::x > (test::x * (-1.0f) + 1.0f);
+    o2::framework::expressions::Operations operations = createOperations(filter);
+    int i = 0;
+    for (; i < operations.size() && operations[i].left.datum.index() != 3; i++)
+      ;
+
+    for (int j = 0; j < tests.size(); j++) {
+      setColumnValue(tests, "x", operations[i].left, j);
+      o2::framework::expressions::Selection selection = o2::framework::expressions::createSelection(tests.asArrowTable(), createFilter(tests.asArrowTable()->schema(), operations));
+      // Find first index bigger than the index of 1st iterator
+      int beginSelectionIndex = 0;
+      for (; beginSelectionIndex < selection->GetNumSlots() &&
+             selection->GetIndex(beginSelectionIndex) <= j;
+           beginSelectionIndex++) {
+        ;
+      }
+      if (beginSelectionIndex != selection->GetNumSlots()) {
+        Filtered<Test> filtered{{tests.asArrowTable()}, selection};
+        for (auto t0 = filtered.begin() + beginSelectionIndex; t0 != filtered.end(); ++t0) {
+          count++;
+        }
+      }
+    }
+    benchmark::DoNotOptimize(count);
+  }
+  state.counters["Combinations"] = count;
+  int64_t filteringCount = state.range(0) * state.range(0);
+  state.SetBytesProcessed(state.iterations() * sizeof(float) * filteringCount);
+}
+
+BENCHMARK(BM_ASoAHelpersNaiveSimplePairsFilters)->RangeMultiplier(2)->Range(8, 8 << 6);
+
+static void BM_ASoAHelpersNaiveFullSimplePairsIfs(benchmark::State& state)
+{
+  // Seed with a real random value, if available
+  std::default_random_engine e1(1234567891);
+  std::uniform_real_distribution<float> uniform_dist(0, 1);
+
+  TableBuilder builder;
+  auto rowWriter = builder.persist<float, float, float>({"x", "y", "z"});
+  for (auto i = 0; i < state.range(0); ++i) {
+    rowWriter(0, uniform_dist(e1), uniform_dist(e1), uniform_dist(e1));
+  }
+  auto table = builder.finalize();
+
+  using Test = o2::soa::Table<test::X>;
+  Test tests{table};
+
+  int64_t count = 0;
+  int64_t filteringCount = 0;
+
+  for (auto _ : state) {
+    count = 0;
+    for (auto t0 = tests.begin(); t0 != tests.end(); ++t0) {
+      for (auto t1 = tests.begin(); t1 != tests.end(); ++t1) {
+        filteringCount++;
+        if ((*t1).x() > ((*t0).x() * (-1.0f) + 1.0f)) {
+          auto comb = std::make_tuple(t0, t1);
+          count++;
+          benchmark::DoNotOptimize(comb);
+        }
+      }
+    }
+    benchmark::DoNotOptimize(count);
+    benchmark::DoNotOptimize(filteringCount);
+  }
+  state.counters["Combinations"] = count;
+  state.SetBytesProcessed(state.iterations() * sizeof(float) * filteringCount);
+}
+
+BENCHMARK(BM_ASoAHelpersNaiveFullSimplePairsIfs)->RangeMultiplier(2)->Range(8, 8 << 6);
+
+static void BM_ASoAHelpersNaiveFullSimplePairsFilters(benchmark::State& state)
+{
+  // Seed with a real random value, if available
+  std::default_random_engine e1(1234567891);
+  std::uniform_real_distribution<float> uniform_dist(0, 1);
+
+  TableBuilder builder;
+  auto rowWriter = builder.persist<float, float, float>({"x", "y", "z"});
+  for (auto i = 0; i < state.range(0); ++i) {
+    rowWriter(0, uniform_dist(e1), uniform_dist(e1), uniform_dist(e1));
+  }
+  auto table = builder.finalize();
+
+  using Test = o2::soa::Table<test::X>;
+  Test tests{table};
+
+  int64_t count = 0;
+
+  for (auto _ : state) {
+    count = 0;
+    o2::framework::expressions::Filter filter = test::x > (test::x * (-1.0f) + 1.0f);
+    o2::framework::expressions::Operations operations = createOperations(filter);
+    int i = 0;
+    for (; i < operations.size() && operations[i].left.datum.index() != 3; i++)
+      ;
+    for (int j = 0; j < tests.size(); j++) {
+      setColumnValue(tests, "x", operations[i].left, j);
+      o2::framework::expressions::Selection selection = o2::framework::expressions::createSelection(tests.asArrowTable(), createFilter(tests.asArrowTable()->schema(), operations));
+      Filtered<Test> filtered{{tests.asArrowTable()}, selection};
+      for (auto t0 = filtered.begin(); t0 != filtered.end(); ++t0) {
+        count++;
+      }
+    }
+    benchmark::DoNotOptimize(count);
+  }
+  state.counters["Combinations"] = count;
+  int64_t filteringCount = state.range(0) * state.range(0);
+  state.SetBytesProcessed(state.iterations() * sizeof(float) * filteringCount);
+}
+
+BENCHMARK(BM_ASoAHelpersNaiveFullSimplePairsFilters)->RangeMultiplier(2)->Range(8, 8 << 6);
+
 BENCHMARK_MAIN();

--- a/Framework/Core/test/test_ASoAHelpers.cxx
+++ b/Framework/Core/test/test_ASoAHelpers.cxx
@@ -90,6 +90,29 @@ BOOST_AUTO_TEST_CASE(IteratorTuple)
   BOOST_REQUIRE_NE(static_cast<test::X>(it3).getIterator().mCurrentPos, nullptr);
   BOOST_REQUIRE_EQUAL(*(static_cast<test::X>(it3).getIterator().mCurrentPos), 4);
   BOOST_REQUIRE_EQUAL(static_cast<test::X>(it3).getIterator().mCurrentChunk, 0);
+  auto it4 = std::get<1>(filteredTuple).begin() + 1;
+  BOOST_REQUIRE_NE(static_cast<test::X>(it4).getIterator().mCurrentPos, nullptr);
+  BOOST_REQUIRE_EQUAL(*(static_cast<test::X>(it4).getIterator().mCurrentPos), 5);
+  BOOST_REQUIRE_EQUAL(static_cast<test::X>(it4).getIterator().mCurrentChunk, 0);
+
+  auto filteredItTuple = std::make_tuple(filtered.begin(), filtered.begin());
+  BOOST_REQUIRE_NE(static_cast<test::X>(std::get<0>(filteredItTuple)).getIterator().mCurrentPos, nullptr);
+  BOOST_REQUIRE_EQUAL(*(static_cast<test::X>(std::get<0>(filteredItTuple)).getIterator().mCurrentPos), 4);
+  BOOST_REQUIRE_EQUAL(static_cast<test::X>(std::get<0>(filteredItTuple)).getIterator().mCurrentChunk, 0);
+  BOOST_REQUIRE_NE(static_cast<test::X>(std::get<1>(filteredItTuple)).getIterator().mCurrentPos, nullptr);
+  BOOST_REQUIRE_EQUAL(*(static_cast<test::X>(std::get<1>(filteredItTuple)).getIterator().mCurrentPos), 4);
+  BOOST_REQUIRE_EQUAL(static_cast<test::X>(std::get<1>(filteredItTuple)).getIterator().mCurrentChunk, 0);
+
+  expressions::Filter filter2 = test::x < 3;
+  auto filtered2 = Filtered<TestA>{{tests.asArrowTable()}, o2::framework::expressions::createSelection(tests.asArrowTable(), filter2)};
+  auto filteredBeginIt = filtered2.begin() + 1;
+  std::get<0>(filteredItTuple) = filteredBeginIt;
+  BOOST_REQUIRE_NE(static_cast<test::X>(std::get<0>(filteredItTuple)).getIterator().mCurrentPos, nullptr);
+  BOOST_REQUIRE_EQUAL(*(static_cast<test::X>(std::get<0>(filteredItTuple)).getIterator().mCurrentPos), 1);
+  BOOST_REQUIRE_EQUAL(static_cast<test::X>(std::get<0>(filteredItTuple)).getIterator().mCurrentChunk, 0);
+  BOOST_REQUIRE_NE(static_cast<test::X>(filteredBeginIt).getIterator().mCurrentPos, nullptr);
+  BOOST_REQUIRE_EQUAL(*(static_cast<test::X>(filteredBeginIt).getIterator().mCurrentPos), 1);
+  BOOST_REQUIRE_EQUAL(static_cast<test::X>(filteredBeginIt).getIterator().mCurrentChunk, 0);
 }
 
 BOOST_AUTO_TEST_CASE(CombinationsGeneratorConstruction)
@@ -280,6 +303,53 @@ BOOST_AUTO_TEST_CASE(CombinationsGeneratorConstruction)
   BOOST_REQUIRE_NE(static_cast<test::X>(std::get<4>(endBadCombination)).getIterator().mCurrentPos, nullptr);
   BOOST_REQUIRE_EQUAL(*(static_cast<test::X>(std::get<4>(endBadCombination)).getIterator().mCurrentPos), 4);
   BOOST_REQUIRE_EQUAL(static_cast<test::X>(std::get<4>(endBadCombination)).getIterator().mCurrentChunk, 0);
+
+  o2::framework::expressions::Filter combFilter = test::x > test::x * (-1) + 9;
+  auto comb2FilterComb = selfCombinations<CombinationsFilteredFullIndexPolicy>(combFilter, testsA, testsA);
+
+  static_assert(std::is_same_v<decltype(comb2FilterComb.begin()), CombinationsGenerator<CombinationsFilteredFullIndexPolicy<TestA, TestA>>::CombinationsIterator>, "Wrong iterator type");
+  static_assert(std::is_same_v<decltype(*(comb2FilterComb.begin())), CombinationsFilteredFullIndexPolicy<TestA, TestA>::CombinationType&>, "Wrong combination type");
+
+  auto beginCombFilterCombination = *(comb2FilterComb.begin());
+  BOOST_REQUIRE_NE(static_cast<test::X>(std::get<0>(beginCombFilterCombination)).getIterator().mCurrentPos, nullptr);
+  BOOST_REQUIRE_EQUAL(*(static_cast<test::X>(std::get<0>(beginCombFilterCombination)).getIterator().mCurrentPos), 7);
+  BOOST_REQUIRE_EQUAL(static_cast<test::X>(std::get<0>(beginCombFilterCombination)).getIterator().mCurrentChunk, 0);
+  BOOST_REQUIRE_NE(static_cast<test::X>(std::get<1>(beginCombFilterCombination)).getIterator().mCurrentPos, nullptr);
+  BOOST_REQUIRE_EQUAL(*(static_cast<test::X>(std::get<1>(beginCombFilterCombination)).getIterator().mCurrentPos), 3);
+  BOOST_REQUIRE_EQUAL(static_cast<test::X>(std::get<1>(beginCombFilterCombination)).getIterator().mCurrentChunk, 0);
+
+  BOOST_REQUIRE(comb2FilterComb.begin() != comb2FilterComb.end());
+
+  auto endCombFilterCombination = *(comb2FilterComb.end());
+  BOOST_REQUIRE_NE(static_cast<test::X>(std::get<0>(endCombFilterCombination)).getIterator().mCurrentPos, nullptr);
+  BOOST_REQUIRE_EQUAL(*(static_cast<test::X>(std::get<0>(endCombFilterCombination)).getIterator().mCurrentPos), -1);
+  BOOST_REQUIRE_EQUAL(static_cast<test::X>(std::get<0>(endCombFilterCombination)).getIterator().mCurrentChunk, 0);
+  BOOST_REQUIRE_NE(static_cast<test::X>(std::get<1>(endCombFilterCombination)).getIterator().mCurrentPos, nullptr);
+  BOOST_REQUIRE_EQUAL(*(static_cast<test::X>(std::get<1>(endCombFilterCombination)).getIterator().mCurrentPos), 8);
+  BOOST_REQUIRE_EQUAL(static_cast<test::X>(std::get<1>(endCombFilterCombination)).getIterator().mCurrentChunk, 0);
+
+  auto comb2FilterStrictlyUpperComb = selfCombinations<CombinationsFilteredStrictlyUpperIndexPolicy>(combFilter, testsA, testsA);
+
+  static_assert(std::is_same_v<decltype(comb2FilterStrictlyUpperComb.begin()), CombinationsGenerator<CombinationsFilteredStrictlyUpperIndexPolicy<TestA, TestA>>::CombinationsIterator>, "Wrong iterator type");
+  static_assert(std::is_same_v<decltype(*(comb2FilterStrictlyUpperComb.begin())), CombinationsFilteredStrictlyUpperIndexPolicy<TestA, TestA>::CombinationType&>, "Wrong combination type");
+
+  auto beginCombFilterStrictlyUpperCombination = *(comb2FilterStrictlyUpperComb.begin());
+  BOOST_REQUIRE_NE(static_cast<test::X>(std::get<0>(beginCombFilterStrictlyUpperCombination)).getIterator().mCurrentPos, nullptr);
+  BOOST_REQUIRE_EQUAL(*(static_cast<test::X>(std::get<0>(beginCombFilterStrictlyUpperCombination)).getIterator().mCurrentPos), 7);
+  BOOST_REQUIRE_EQUAL(static_cast<test::X>(std::get<0>(beginCombFilterStrictlyUpperCombination)).getIterator().mCurrentChunk, 0);
+  BOOST_REQUIRE_NE(static_cast<test::X>(std::get<1>(beginCombFilterStrictlyUpperCombination)).getIterator().mCurrentPos, nullptr);
+  BOOST_REQUIRE_EQUAL(*(static_cast<test::X>(std::get<1>(beginCombFilterStrictlyUpperCombination)).getIterator().mCurrentPos), 3);
+  BOOST_REQUIRE_EQUAL(static_cast<test::X>(std::get<1>(beginCombFilterStrictlyUpperCombination)).getIterator().mCurrentChunk, 0);
+
+  BOOST_REQUIRE(comb2FilterStrictlyUpperComb.begin() != comb2FilterStrictlyUpperComb.end());
+
+  auto endCombFilterStrictlyUpperCombination = *(comb2FilterStrictlyUpperComb.end());
+  BOOST_REQUIRE_NE(static_cast<test::X>(std::get<0>(endCombFilterStrictlyUpperCombination)).getIterator().mCurrentPos, nullptr);
+  BOOST_REQUIRE_EQUAL(*(static_cast<test::X>(std::get<0>(endCombFilterStrictlyUpperCombination)).getIterator().mCurrentPos), -1);
+  BOOST_REQUIRE_EQUAL(static_cast<test::X>(std::get<0>(endCombFilterStrictlyUpperCombination)).getIterator().mCurrentChunk, 0);
+  BOOST_REQUIRE_NE(static_cast<test::X>(std::get<1>(endCombFilterStrictlyUpperCombination)).getIterator().mCurrentPos, nullptr);
+  BOOST_REQUIRE_EQUAL(*(static_cast<test::X>(std::get<1>(endCombFilterStrictlyUpperCombination)).getIterator().mCurrentPos), 7);
+  BOOST_REQUIRE_EQUAL(static_cast<test::X>(std::get<1>(endCombFilterStrictlyUpperCombination)).getIterator().mCurrentChunk, 0);
 }
 
 BOOST_AUTO_TEST_CASE(Combinations)
@@ -976,4 +1046,114 @@ BOOST_AUTO_TEST_CASE(BlockCombinations)
     count++;
   }
   BOOST_CHECK_EQUAL(count, expectedUpperFives.size());
+}
+
+BOOST_AUTO_TEST_CASE(FilteredCombinations)
+{
+  TableBuilder builderA;
+  auto rowWriterA = builderA.persist<int32_t, int32_t>({"x", "y"});
+  rowWriterA(0, 0, 0);
+  rowWriterA(0, 1, 0);
+  rowWriterA(0, 2, 0);
+  rowWriterA(0, 3, 0);
+  rowWriterA(0, 4, 0);
+  rowWriterA(0, 5, 0);
+  rowWriterA(0, 6, 0);
+  rowWriterA(0, 7, 0);
+  auto tableA = builderA.finalize();
+  BOOST_REQUIRE_EQUAL(tableA->num_rows(), 8);
+
+  using TestA = o2::soa::Table<o2::soa::Index<>, test::X, test::Y>;
+
+  TestA testsA{tableA};
+
+  BOOST_REQUIRE_EQUAL(8, testsA.size());
+  int nA = testsA.size();
+
+  int count = 0;
+  expressions::Filter pairsFilter = test::x > test::x * (-1) + 9;
+  std::vector<std::tuple<int32_t, int32_t>> expectedStrictlyUpperPairs{{7, 3}, {6, 4}, {7, 4}, {6, 5}, {7, 5}, {7, 6}};
+  std::vector<std::tuple<int32_t, int32_t>> expectedUpperPairs{{7, 3}, {6, 4}, {7, 4}, {5, 5}, {6, 5}, {7, 5}, {6, 6}, {7, 6}, {7, 7}};
+  std::vector<std::tuple<int32_t, int32_t>> expectedFullPairs{{7, 3}, {6, 4}, {7, 4}, {5, 5}, {6, 5}, {7, 5}, {4, 6}, {5, 6}, {6, 6}, {7, 6}, {3, 7}, {4, 7}, {5, 7}, {6, 7}, {7, 7}};
+
+  for (auto& [t0, t1] : selfCombinations<CombinationsFilteredFullIndexPolicy>(pairsFilter, testsA, testsA)) {
+    BOOST_CHECK_EQUAL(t0.x(), std::get<0>(expectedFullPairs[count]));
+    BOOST_CHECK_EQUAL(t1.x(), std::get<1>(expectedFullPairs[count]));
+    count++;
+  }
+  BOOST_CHECK_EQUAL(count, expectedFullPairs.size());
+
+  count = 0;
+  for (auto& [t0, t1] : selfCombinations<CombinationsFilteredStrictlyUpperIndexPolicy>(pairsFilter, testsA, testsA)) {
+    BOOST_CHECK_EQUAL(t0.x(), std::get<0>(expectedStrictlyUpperPairs[count]));
+    BOOST_CHECK_EQUAL(t1.x(), std::get<1>(expectedStrictlyUpperPairs[count]));
+    count++;
+  }
+  BOOST_CHECK_EQUAL(count, expectedStrictlyUpperPairs.size());
+
+  count = 0;
+  for (auto& [t0, t1] : selfCombinations<CombinationsFilteredUpperIndexPolicy>(pairsFilter, testsA, testsA)) {
+    BOOST_CHECK_EQUAL(t0.x(), std::get<0>(expectedUpperPairs[count]));
+    BOOST_CHECK_EQUAL(t1.x(), std::get<1>(expectedUpperPairs[count]));
+    count++;
+  }
+  BOOST_CHECK_EQUAL(count, expectedUpperPairs.size());
+
+  // TODO: Change to sum of 3 table elements once it will be possible
+  expressions::Filter triplesFilter = (test::x > 4) && (test::x > test::x * (-1) + 9);
+  std::vector<std::tuple<int32_t, int32_t, int32_t>> expectedStrictlyUpperTriples{{7, 6, 4}, {7, 6, 5}};
+  std::vector<std::tuple<int32_t, int32_t, int32_t>> expectedUpperTriples{{7, 7, 3}, {6, 6, 4}, {7, 6, 4}, {7, 7, 4}, {5, 5, 5}, {6, 5, 5}, {7, 5, 5}, {6, 6, 5}, {7, 6, 5}, {7, 7, 5}, {6, 6, 6}, {7, 6, 6}, {7, 7, 6}, {7, 7, 7}};
+
+  count = 0;
+  for (auto& [t0, t1, t2] : selfCombinations<CombinationsFilteredFullIndexPolicy>(triplesFilter, testsA, testsA, testsA)) {
+    BOOST_CHECK_EQUAL(t0.x(), count % 3 + 5);
+    BOOST_CHECK_EQUAL(t1.x(), std::get<0>(expectedFullPairs[count / 3]));
+    BOOST_CHECK_EQUAL(t2.x(), std::get<1>(expectedFullPairs[count / 3]));
+    count++;
+  }
+  BOOST_CHECK_EQUAL(count, 3 * expectedFullPairs.size());
+
+  count = 0;
+  for (auto& [t0, t1, t2] : selfCombinations<CombinationsFilteredStrictlyUpperIndexPolicy>(triplesFilter, testsA, testsA, testsA)) {
+    BOOST_CHECK_EQUAL(t0.x(), std::get<0>(expectedStrictlyUpperTriples[count]));
+    BOOST_CHECK_EQUAL(t1.x(), std::get<1>(expectedStrictlyUpperTriples[count]));
+    BOOST_CHECK_EQUAL(t2.x(), std::get<2>(expectedStrictlyUpperTriples[count]));
+    count++;
+  }
+  BOOST_CHECK_EQUAL(count, expectedStrictlyUpperTriples.size());
+
+  count = 0;
+  for (auto& [t0, t1, t2] : selfCombinations<CombinationsFilteredUpperIndexPolicy>(triplesFilter, testsA, testsA, testsA)) {
+    BOOST_CHECK_EQUAL(t0.x(), std::get<0>(expectedUpperTriples[count]));
+    BOOST_CHECK_EQUAL(t1.x(), std::get<1>(expectedUpperTriples[count]));
+    BOOST_CHECK_EQUAL(t2.x(), std::get<2>(expectedUpperTriples[count]));
+    count++;
+  }
+  BOOST_CHECK_EQUAL(count, expectedUpperTriples.size());
+
+  std::vector<std::tuple<int32_t, int32_t, int32_t>> expectedStrictlyUpperTriples2{{7, 3, 0}, {6, 4, 0}, {7, 4, 0}, {6, 5, 0}, {7, 5, 0}, {7, 6, 0}, {7, 3, 1}, {6, 4, 1}, {7, 4, 1}, {6, 5, 1}, {7, 5, 1}, {7, 6, 1}, {7, 3, 2}, {6, 4, 2}, {7, 4, 2}, {6, 5, 2}, {7, 5, 2}, {7, 6, 2}, {6, 4, 3}, {7, 4, 3}, {6, 5, 3}, {7, 5, 3}, {7, 6, 3}, {6, 5, 4}, {7, 5, 4}, {7, 6, 4}, {7, 6, 5}};
+
+  count = 0;
+  for (auto& [t0, t1, t2] : selfCombinations<CombinationsFilteredStrictlyUpperIndexPolicy>(pairsFilter, testsA, testsA, testsA)) {
+    BOOST_CHECK_EQUAL(t0.x(), std::get<0>(expectedStrictlyUpperTriples2[count]));
+    BOOST_CHECK_EQUAL(t1.x(), std::get<1>(expectedStrictlyUpperTriples2[count]));
+    BOOST_CHECK_EQUAL(t2.x(), std::get<2>(expectedStrictlyUpperTriples2[count]));
+    count++;
+  }
+  BOOST_CHECK_EQUAL(count, 27);
+
+  // Order in tuple: (t0 > 5) && (t2 + t1 > 10) && (t4 + t3 > 9)
+  expressions::Filter fivesFilter = (test::x > 5) && (test::x > (test::x * (-1) + 9)) && (test::x > (test::x * (-1) + 4));
+
+  std::vector<std::tuple<int32_t, int32_t, int32_t, int32_t, int32_t>> expectedStrictlyUpperFives{{7, 6, 5, 4, 1}, {7, 6, 4, 3, 2}, {7, 6, 5, 3, 2}, {7, 6, 5, 4, 2}, {7, 6, 5, 4, 3}};
+  count = 0;
+  for (auto& [t0, t1, t2, t3, t4] : selfCombinations<CombinationsFilteredStrictlyUpperIndexPolicy>(fivesFilter, testsA, testsA, testsA, testsA, testsA)) {
+    BOOST_CHECK_EQUAL(t0.x(), std::get<0>(expectedStrictlyUpperFives[count]));
+    BOOST_CHECK_EQUAL(t1.x(), std::get<1>(expectedStrictlyUpperFives[count]));
+    BOOST_CHECK_EQUAL(t2.x(), std::get<2>(expectedStrictlyUpperFives[count]));
+    BOOST_CHECK_EQUAL(t3.x(), std::get<3>(expectedStrictlyUpperFives[count]));
+    BOOST_CHECK_EQUAL(t4.x(), std::get<4>(expectedStrictlyUpperFives[count]));
+    count++;
+  }
+  BOOST_CHECK_EQUAL(count, expectedStrictlyUpperFives.size());
 }


### PR DESCRIPTION
This would enable to apply a filter to a combination of elements e.g. `tracks1.pt() + tracks2.pt() > cut`.