### PR TITLE
Fixed missing includes in macros

### DIFF
--- a/Detectors/CPV/testsimulation/plot_dig_cpv.C
+++ b/Detectors/CPV/testsimulation/plot_dig_cpv.C
@@ -1,6 +1,8 @@
 #if !defined(__CLING__) || defined(__ROOTCLING__)
 #include <sstream>
+#include <iostream>
 
+#include "TROOT.h"
 #include <TStopwatch.h>
 #include "TCanvas.h"
 #include "TH2.h"

--- a/Detectors/CPV/testsimulation/plot_hit_cpv.C
+++ b/Detectors/CPV/testsimulation/plot_hit_cpv.C
@@ -1,6 +1,7 @@
 #if !defined(__CLING__) || defined(__ROOTCLING__)
 #include <sstream>
 
+#include "TROOT.h"
 #include <TStopwatch.h>
 #include "TCanvas.h"
 #include "TH2.h"

--- a/macro/run_digi.C
+++ b/macro/run_digi.C
@@ -1,4 +1,6 @@
 #if !defined(__CLING__) || defined(__ROOTCLING__)
+#include <iostream>
+
 #include <Rtypes.h>
 #include <TString.h>
 #include <TStopwatch.h>


### PR DESCRIPTION
Due to missing includes these tests were failing when testing with new versions of FairRoot and MC packages