### PR TITLE
Use fwpigen for MCH, MID and MFT in pileup tests

### DIFF
--- a/prodtests/check_embedding_pileup.sh
+++ b/prodtests/check_embedding_pileup.sh
@@ -12,7 +12,7 @@
 #    and check whether the output digits have multiple labels --> checks embedding
 
 dets=(         ITS   TPC     TOF    EMC    HMP      MCH     MID    MFT     FV0     FT0   FDD   TRD     PHS    CPV    ZDC )
-generators=( boxgen boxgen boxgen boxgen hmpidgun fwmugen fwmugen fwmugen fddgen fddgen fddgen boxgen boxgen boxgen zdcgen )
+generators=( boxgen boxgen boxgen boxgen hmpidgun fwpigen fwpigen fwpigen fddgen fddgen fddgen boxgen boxgen boxgen zdcgen )
 
 simtask() {
  d=$1  # detector


### PR DESCRIPTION
The generated particle PID does not really matter since we do noyt simulate absorption elements.
The use of fwpigen allows to genarate a larger number of particles per event.
This prevents the case where no hit is created because the only produced muon falls outside the acceptance.