### PR TITLE
Using gsl::span as input to EMCAL clusterizer

### DIFF
--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/Clusterizer.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/Clusterizer.h
@@ -14,6 +14,7 @@
 #define ALICEO2_EMCAL_CLUSTERIZER_H
 
 #include <array>
+#include <gsl/gsl>
 #include "Rtypes.h"
 #include "DataFormatsEMCAL/Cluster.h"
 #include "DataFormatsEMCAL/Digit.h"
@@ -62,7 +63,7 @@ class Clusterizer
   ~Clusterizer() = default;
 
   void initialize(double timeCut, double timeMin, double timeMax, double gradientCut, bool doEnergyGradientCut, double thresholdSeedE, double thresholdCellE);
-  void findClusters(const std::vector<InputType>& inputArray);
+  void findClusters(const gsl::span<InputType const>& inputArray);
   const std::vector<Cluster>* getFoundClusters() const { return &mFoundClusters; }
   const std::vector<ClusterIndex>* getFoundClustersInputIndices() const { return &mInputIndices; }
   void setGeometry(Geometry* geometry) { mEMCALGeometry = geometry; }

--- a/Detectors/EMCAL/reconstruction/src/Clusterizer.cxx
+++ b/Detectors/EMCAL/reconstruction/src/Clusterizer.cxx
@@ -121,7 +121,7 @@ void Clusterizer<InputType>::getTopologicalRowColumn(const InputType& input, int
 /// Return number of found clusters. Start clustering from highest energy cell.
 //____________________________________________________________________________
 template <class InputType>
-void Clusterizer<InputType>::findClusters(const std::vector<InputType>& inputArray)
+void Clusterizer<InputType>::findClusters(const gsl::span<InputType const>& inputArray)
 {
   mFoundClusters.clear();
   mInputIndices.clear();


### PR DESCRIPTION
Making the EMCAL clusterizer more flexible regarding input by using
gsl::span for the read-only input data. GSL provides an automatic conversion
from std::vector.

This makes the code more flexible with respect to DPL IO API changes.