### PR TITLE
Allowing the SpectatorAllocator to be propagated

### DIFF
--- a/DataFormats/MemoryResources/include/MemoryResources/MemoryResources.h
+++ b/DataFormats/MemoryResources/include/MemoryResources/MemoryResources.h
@@ -191,6 +191,7 @@ class SpectatorAllocator : public boost::container::pmr::polymorphic_allocator<T
 {
  public:
   using boost::container::pmr::polymorphic_allocator<T>::polymorphic_allocator;
+  using propagate_on_container_move_assignment = std::true_type;
 
   // skip default construction of empty elements
   // this is important for two reasons: one: it allows us to adopt an existing buffer (e.g. incoming message) and

--- a/DataFormats/MemoryResources/test/testMemoryResources.cxx
+++ b/DataFormats/MemoryResources/test/testMemoryResources.cxx
@@ -207,6 +207,12 @@ BOOST_AUTO_TEST_CASE(test_SpectatorMemoryResource)
   BOOST_CHECK(vecclone.data() == vectordata);
   BOOST_CHECK(vecclone.size() == size);
   BOOST_CHECK_THROW(vecclone.resize(2 * size), std::runtime_error);
+
+  std::vector<int, o2::pmr::SpectatorAllocator<int>> vecmove;
+  vecmove = std::move(vecclone);
+  BOOST_CHECK(vecclone.size() == 0);
+  BOOST_CHECK(vecmove.data() == vectordata);
+  BOOST_CHECK(vecmove.size() == size);
 }
 
 }; // namespace o2::pmr


### PR DESCRIPTION
We want the allocator with the underlying stateful memory resource to be
propagated to target object on move assignment, a specific type trait
indicator needs to be defined.