### PR TITLE
DPL Analysis: add reserve method for table building

### DIFF
--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -85,9 +85,17 @@ struct WritingCursor<soa::Table<PC...>> {
 
   bool resetCursor(TableBuilder& builder)
   {
+    mBuilder = &builder;
     cursor = std::move(FFL(builder.cursor<persistent_table_t>()));
     mCount = -1;
     return true;
+  }
+
+  /// reserve @a size rows when filling, so that we do not
+  /// spend time reallocating the buffers.
+  void reserve(int64_t size)
+  {
+    mBuilder->reserve(typename persistent_table_t::columns{}, size);
   }
 
   decltype(FFL(std::declval<cursor_t>())) cursor;
@@ -104,6 +112,10 @@ struct WritingCursor<soa::Table<PC...>> {
     }
   }
 
+  /// The table builder which actually performs the
+  /// construction of the table. We keep it around to be
+  /// able to do all-columns methods like reserve.
+  TableBuilder* mBuilder = nullptr;
   int64_t mCount = -1;
 };
 

--- a/Framework/Core/test/benchmark_TableBuilder.cxx
+++ b/Framework/Core/test/benchmark_TableBuilder.cxx
@@ -41,8 +41,25 @@ static void BM_TableBuilderScalar(benchmark::State& state)
   }
 }
 
-BENCHMARK(BM_TableBuilderScalar)->Arg(1 << 20);
+BENCHMARK(BM_TableBuilderScalar)->Arg(1 << 21);
 BENCHMARK(BM_TableBuilderScalar)->Range(8, 8 << 16);
+
+static void BM_TableBuilderScalarReserved(benchmark::State& state)
+{
+  using namespace o2::framework;
+  for (auto _ : state) {
+    TableBuilder builder;
+    auto rowWriter = builder.persist<float>({"x"});
+    builder.reserve(o2::framework::pack<float>{}, state.range(0));
+    for (size_t i = 0; i < state.range(0); ++i) {
+      rowWriter(0, 0.f);
+    }
+    auto table = builder.finalize();
+  }
+}
+
+BENCHMARK(BM_TableBuilderScalarReserved)->Arg(1 << 21);
+BENCHMARK(BM_TableBuilderScalarReserved)->Range(8, 8 << 16);
 
 static void BM_TableBuilderScalarPresized(benchmark::State& state)
 {

--- a/Framework/Core/test/test_TableBuilder.cxx
+++ b/Framework/Core/test/test_TableBuilder.cxx
@@ -133,6 +133,7 @@ BOOST_AUTO_TEST_CASE(TestTableBuilderMore)
   using namespace o2::framework;
   TableBuilder builder;
   auto rowWriter = builder.persist<int, float, std::string, bool>({"x", "y", "s", "b"});
+  builder.reserve(pack<int, float, std::string, bool>{}, 5);
   rowWriter(0, 0, 0., "foo", true);
   rowWriter(0, 1, 1., "bar", false);
   rowWriter(0, 2, 2., "fbr", false);


### PR DESCRIPTION
Using the two new methods of TableBuilder and WritingCursor
can result in much faster table building, especially for large table,
if the number of rows of the final table is (roughly) known in
advance.