### PR TITLE
Using gsl::span for the optional FIT info input of GlobalTracking workers

### DIFF
--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTOF.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTOF.h
@@ -19,6 +19,7 @@
 #include <array>
 #include <vector>
 #include <string>
+#include <gsl/span>
 #include <TStopwatch.h>
 #include "ReconstructionDataFormats/Track.h"
 #include "ReconstructionDataFormats/TrackTPCITS.h"
@@ -178,7 +179,19 @@ class MatchTOF
   std::vector<o2::MCCompLabel>& getMatchedTPCLabelsVector() { return mOutTPCLabels; } ///< get vector of TPC label of matched tracks
   std::vector<o2::MCCompLabel>& getMatchedITSLabelsVector() { return mOutITSLabels; } ///< get vector of ITS label of matched tracks
 
-  void setFITRecPoints(const std::vector<o2::ft0::RecPoints>* recpoints) { mFITRecPoints = recpoints; }
+  // this method is deprecated
+  void setFITRecPoints(const std::vector<o2::ft0::RecPoints>* recpoints)
+  {
+    if (recpoints) {
+      // need explicit cast because the gsl index_type is signed
+      mFITRecPoints = {recpoints->data(), static_cast<decltype(mFITRecPoints)::index_type>(recpoints->size())};
+    }
+  }
+  void setFITRecPoints(gsl::span<o2::ft0::RecPoints const> recpoints)
+  {
+    mFITRecPoints = recpoints;
+  }
+
   int findFITIndex(int bc);
 
  private:
@@ -234,7 +247,7 @@ class MatchTOF
   const std::vector<o2::MCCompLabel>* mTPCLabels = nullptr; ///< TPC label of input tracks
   const std::vector<o2::MCCompLabel>* mITSLabels = nullptr; ///< ITS label of input tracks
 
-  const std::vector<o2::ft0::RecPoints>* mFITRecPoints = nullptr; ///< FIT recpoints
+  gsl::span<o2::ft0::RecPoints const> mFITRecPoints; ///< FIT recpoints
 
   /// <<<-----
 

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
@@ -408,8 +408,7 @@ class MatchTPCITS
   }
 
   ///< set input FIT info received via DPL
-  void setFITInfoInp(const std::vector<o2::ft0::RecPoints>* inp)
-  //  void setFITInfoInp(const gsl::span<const o2::ft0::RecPoints> inp) // FT0 recpoints are not yet
+  void setFITInfoInp(const gsl::span<const o2::ft0::RecPoints> inp)
   {
     assertDPLIO(true);
     mFITInfo = inp;
@@ -669,9 +668,7 @@ class MatchTPCITS
   gsl::span<const o2::itsmft::ROFRecord> mITSClusterROFRec;                 ///< input ITS clusters ROFRecord span from DPL
 
   const std::vector<o2::ft0::RecPoints>* mFITInfoPtr = nullptr; ///< optional input FIT info from the tree
-  // FT0 is not POD yet
-  const std::vector<o2::ft0::RecPoints>* mFITInfo = nullptr; ///<  optional input FIT info span from DPL
-  //gsl::span<const o2::ft0::RecPoints> mFITInfo;                           ///<  optional input FIT info span from DPL
+  gsl::span<const o2::ft0::RecPoints> mFITInfo;                 ///< optional input FIT info span from DPL
 
   const o2::tpc::ClusterNativeAccess* mTPCClusterIdxStruct = nullptr;     ///< struct holding the TPC cluster indices
 

--- a/Detectors/GlobalTracking/src/MatchTOF.cxx
+++ b/Detectors/GlobalTracking/src/MatchTOF.cxx
@@ -818,14 +818,15 @@ void MatchTOF::doMatching(int sec)
 //______________________________________________
 int MatchTOF::findFITIndex(int bc)
 {
-  if (!mFITRecPoints)
+  if (mFITRecPoints.size() == 0) {
     return -1;
+  }
 
   int index = -1;
   int distMax = 5; // require bc distance below 5
 
-  for (int i = 0; i < mFITRecPoints->size(); i++) {
-    const o2::InteractionRecord ir = mFITRecPoints->at(i).getInteractionRecord();
+  for (int i = 0; i < mFITRecPoints.size(); i++) {
+    const o2::InteractionRecord ir = mFITRecPoints[i].getInteractionRecord();
     int bct0 = ir.orbit * o2::constants::lhc::LHCMaxBunches + ir.bc;
     int dist = bc - bct0;
 
@@ -863,11 +864,11 @@ void MatchTOF::selectBestMatches()
     // get fit info
     double t0info = 0;
 
-    if (mFITRecPoints) {
+    if (mFITRecPoints.size() > 0) {
       int index = findFITIndex(mTOFClusWork[matchingPair.getTOFClIndex()].getBC());
 
       if (index > -1) {
-        o2::InteractionRecord ir = (*mFITRecPoints)[index].getInteractionRecord();
+        o2::InteractionRecord ir = mFITRecPoints[index].getInteractionRecord();
         t0info = ir.bc2ns() * 1E3;
       }
     }

--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -901,11 +901,10 @@ bool MatchTPCITS::prepareFITInfo()
     if (!mDPLIO) {
       mTimerIO.Start(false);
       mTreeFITInfo->GetEntry(0);
-      //    mFITInfo = gsl::span<const o2::ft0::RecPoints>(mFITInfoPtr->data(), mFITInfoPtr->size()); // FT0 not yet POD
-      mFITInfo = mFITInfoPtr; // temporary
+      mFITInfo = gsl::span<const o2::ft0::RecPoints>(mFITInfoPtr->data(), mFITInfoPtr->size()); // FT0 not yet POD
       mTimerIO.Stop();
     }
-    LOG(INFO) << "Loaded FIT Info with " << (*mFITInfo).size() << " entries";
+    LOG(INFO) << "Loaded FIT Info with " << mFITInfo.size() << " entries";
   }
 
   return true;
@@ -1933,8 +1932,8 @@ int MatchTPCITS::prepareInteractionTimes()
   // guess interaction times from various sources and relate with ITS rofs
   const float T0UncertaintyTB = 0.5 / (1e3 * mTPCTBinMUS); // assumed T0 time uncertainty (~0.5ns) in TPC timeBins
   mInteractions.clear();
-  if ((*mFITInfo).size()) {
-    for (const auto& ft : (*mFITInfo)) {
+  if (mFITInfo.size()) {
+    for (const auto& ft : mFITInfo) {
       if (!ft.isValidTime(o2::ft0::RecPoints::TimeMean)) {
         continue;
       }

--- a/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
@@ -248,23 +248,13 @@ void TPCITSMatchingDPL::run(ProcessingContext& pc)
     mMatching.setTPCTrkLabelsInp(lblTPCPtr);
   }
 
-  //  const gsl::span<o2::ft0::RecPoints> fitInfo; // not yet POD
-  std::vector<o2::ft0::RecPoints> fitInfo;
   if (o2::globaltracking::MatchITSTPCParams::Instance().runAfterBurner) {
-    //    fitInfo = pc.inputs().get<gsl::span<o2::ft0::RecPoints>>("fitInfo");
-    fitInfo = pc.inputs().get<std::vector<o2::ft0::RecPoints>>("fitInfo");
-    mMatching.setFITInfoInp(&fitInfo);
+    // Note: the particular variable will go out of scope, but the span is passed by copy to the
+    // worker and the underlying memory is valid throughout the whole computation
+    auto fitInfo = pc.inputs().get<gsl::span<o2::ft0::RecPoints>>("fitInfo");
+    mMatching.setFITInfoInp(fitInfo);
   }
 
-  /*
-  const std::vector<o2::ft0::RecPoints>* rpFIT = nullptr;
-  std::unique_ptr<const std::vector<o2::ft0::RecPoints>> rpFITU;
-  if (o2::globaltracking::MatchITSTPCParams::Instance().runAfterBurner) {
-    rpFITU = pc.inputs().get<const std::vector<o2::ft0::RecPoints>*>("fitInfo");
-    rpFIT = rpFITU.get();
-    mMatching.setFITInfoInp(rpFIT);
-  }
-  */
   mMatching.run();
 
   /* // at the moment we don't assume need for bufferization, no nead to clear

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/RecoWorkflowSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/RecoWorkflowSpec.cxx
@@ -79,11 +79,11 @@ class TOFDPLRecoWorkflowTask
       *tpclab.get() = std::move(*tpclabel);
     }
 
-    auto recPointsPtr = std::make_shared<std::vector<o2::ft0::RecPoints>>();
     if (mUseFIT) {
-      auto recPoints = pc.inputs().get<const std::vector<o2::ft0::RecPoints>>("fitrecpoints");
-      *recPointsPtr.get() = std::move(recPoints);
-      mMatcher.setFITRecPoints(recPointsPtr.get());
+      // Note: the particular variable will go out of scope, but the span is passed by copy to the
+      // worker and the underlying memory is valid throughout the whole computation
+      auto recPoints = std::move(pc.inputs().get<gsl::span<o2::ft0::RecPoints>>("fitrecpoints"));
+      mMatcher.setFITRecPoints(recPoints);
       LOG(INFO) << "TOF Reco Workflow pulled " << recPoints.size() << " FIT RecPoints";
     }
 


### PR DESCRIPTION
Determining the type of the local FIT info variable from the InputRecord return
type. The info is passed as gsl::span to the workers, we benefit from the span
constructor provided by gsl::span.

This makes the code independent of upcoming API changes.