### PR TITLE
[EMCAL-637] Fix geometry path in loading geo matrices

### DIFF
--- a/Detectors/EMCAL/base/src/Geometry.cxx
+++ b/Detectors/EMCAL/base/src/Geometry.cxx
@@ -1439,7 +1439,7 @@ const TGeoHMatrix* Geometry::GetMatrixForSuperModuleFromGeoManager(Int_t smod) c
   else
     LOG(ERROR) << "Unkown SM Type!!\n";
 
-  snprintf(path, buffersize, "/ALIC_1/XEN1_1/%s_%d", smName.Data(), smOrder);
+  snprintf(path, buffersize, "/cave/%s_%d", smName.Data(), smOrder);
 
   if (!gGeoManager->cd(path))
     LOG(FATAL) << "Geo manager can not find path " << path << "!\n";
@@ -1460,7 +1460,7 @@ void Geometry::RecalculateTowerPosition(Float_t drow, Float_t dcol, const Int_t 
 
     const Int_t nSMod = mNumberOfSuperModules;
 
-    gGeoManager->cd("ALIC_1/XEN1_1");
+    gGeoManager->cd("/cave");
     TGeoNode* geoXEn1 = gGeoManager->GetCurrentNode();
     TGeoNodeMatrix* geoSM[nSMod];
     TGeoVolume* geoSMVol[nSMod];


### PR DESCRIPTION
- Convert remaining ALIC instances to cave
- Remove XEN from paths which was dropped due to
  overlaps with CPV/PHOS