### PR TITLE
Possibility to optionally save cluster topology information for grouped topologies

### DIFF
--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/ClusterPattern.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/ClusterPattern.h
@@ -59,6 +59,10 @@ class ClusterPattern
   void setPattern(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes]);
   /// Sets the whole bitmask: the number of rows, the number of columns and the pattern
   void setPattern(const unsigned char bitmask[kExtendedPatternBytes]);
+  /// Static: Compute pattern's COG position. Returns the number of fired pixels
+  static int getCOG(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes], float& xCOG, float& zCOG);
+  /// Compute pattern's COG position. Returns the number of fired pixels
+  int getCOG(float& xCOG, float& zCOG) const;
 
   friend ClusterTopology;
   friend TopologyDictionary;

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/ClusterTopology.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/ClusterTopology.h
@@ -49,7 +49,6 @@ class ClusterTopology
   int getUsedBytes() const { return mPattern.getUsedBytes(); }
   /// Returns the hashcode
   unsigned long getHash() const { return mHash; }
-  void setHash(unsigned long hash) { mHash = hash; }
   /// Prints the topology
   friend std::ostream& operator<<(std::ostream& os, const ClusterTopology& top);
   /// Prints to the stdout
@@ -59,9 +58,6 @@ class ClusterTopology
   /// Compute the complete hash as defined for mHash
   static unsigned long getCompleteHash(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes]);
   static unsigned long getCompleteHash(const ClusterTopology& topology);
-  // compute position of COG pixel wrt top-left corner
-  static void getCOGshift(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes], int& rowShift, int& colShift);
-  static void getCOG(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes], int& rowShift, int& colShift, float& xCOG, float& zCOG);
   /// Sets the pattern
   void setPattern(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes]);
 
@@ -74,7 +70,10 @@ class ClusterTopology
     }
   }
 
+  friend class Clusterer;
+
  private:
+  void setHash(unsigned long hash) { mHash = hash; }
   ClusterPattern mPattern; ///< Pattern of pixels
   /// Hashcode computed from the pattern
   ///

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/ClusterTopology.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/ClusterTopology.h
@@ -40,6 +40,7 @@ class ClusterTopology
   unsigned char getByte(int n) const { return mPattern.getByte(n); }
   /// Returns the pattern
   std::array<unsigned char, ClusterPattern::kExtendedPatternBytes> getPattern() const { return mPattern.getPattern(); }
+  ClusterPattern getClusterPattern() const { return mPattern; }
   /// Returns the number of rows
   int getRowSpan() const { return mPattern.getRowSpan(); }
   /// Returns the number of columns
@@ -48,6 +49,7 @@ class ClusterTopology
   int getUsedBytes() const { return mPattern.getUsedBytes(); }
   /// Returns the hashcode
   unsigned long getHash() const { return mHash; }
+  void setHash(unsigned long hash) { mHash = hash; }
   /// Prints the topology
   friend std::ostream& operator<<(std::ostream& os, const ClusterTopology& top);
   /// Prints to the stdout
@@ -61,6 +63,15 @@ class ClusterTopology
   static void getCOGshift(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes], int& rowShift, int& colShift);
   /// Sets the pattern
   void setPattern(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes]);
+
+  ///Helper function useful for analyses with topologies stored on a separate branch
+  static void makeRareTopologyMap(const std::vector<ClusterTopology>& vec, std::map<int, ClusterPattern>& map)
+  {
+    for (const auto& topo : vec) {
+      auto key = topo.getHash();
+      map[key] = topo.getClusterPattern();
+    }
+  }
 
  private:
   ClusterPattern mPattern; ///< Pattern of pixels

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/ClusterTopology.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/ClusterTopology.h
@@ -61,6 +61,7 @@ class ClusterTopology
   static unsigned long getCompleteHash(const ClusterTopology& topology);
   // compute position of COG pixel wrt top-left corner
   static void getCOGshift(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes], int& rowShift, int& colShift);
+  static void getCOG(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes], int& rowShift, int& colShift, float& xCOG, float& zCOG);
   /// Sets the pattern
   void setPattern(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes]);
 

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TopologyDictionary.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TopologyDictionary.h
@@ -114,6 +114,7 @@ class TopologyDictionary
   int GetSize() const { return (int)mVectorOfGroupIDs.size(); }
   ///Returns the local position of a compact cluster
   Point3D<float> getClusterCoordinates(const CompCluster& cl) const;
+  Point3D<float> getClusterCoordinates(const CompCluster& cl, const ClusterPattern& patt) const;
 
   friend BuildTopologyDictionary;
   friend LookUp;

--- a/DataFormats/Detectors/ITSMFT/common/src/ClusterPattern.cxx
+++ b/DataFormats/Detectors/ITSMFT/common/src/ClusterPattern.cxx
@@ -98,5 +98,49 @@ std::ostream& operator<<(std::ostream& os, const ClusterPattern& pattern)
   os << std::endl;
   return os;
 }
+
+int ClusterPattern::getCOG(int rowSpan, int colSpan, const unsigned char patt[Cluster::kMaxPatternBytes], float& xCOG, float& zCOG)
+{
+  int tempxCOG = 0, tempzCOG = 0, tempFiredPixels = 0, ic = 0, ir = 0;
+  int nBits = rowSpan * colSpan;
+  int nBytes = nBits / 8;
+  if (nBits % 8 != 0) {
+    nBytes++;
+  }
+  for (unsigned int i = 0; i < nBytes; i++) {
+    unsigned char tempChar = patt[i];
+    int s = 128; // 0b10000000
+    while (s > 0) {
+      if ((tempChar & s) != 0) {
+        tempFiredPixels++;
+        tempxCOG += ir;
+        tempzCOG += ic;
+      }
+      ic++;
+      s /= 2;
+      if ((ir + 1) * ic == nBits) {
+        break;
+      }
+      if (ic == colSpan) {
+        ic = 0;
+        ir++;
+      }
+    }
+    if ((ir + 1) * ic == nBits) {
+      break;
+    }
+  }
+  xCOG = float(tempxCOG) / tempFiredPixels;
+  zCOG = float(tempzCOG) / tempFiredPixels;
+
+  return tempFiredPixels;
+}
+
+int ClusterPattern::getCOG(float& xCOG, float& zCOG) const
+{
+  auto patt = getPattern();
+  return ClusterPattern::getCOG(getRowSpan(), getColumnSpan(), &patt[2], xCOG, zCOG);
+}
+
 } // namespace itsmft
 } // namespace o2

--- a/DataFormats/Detectors/ITSMFT/common/src/ClusterTopology.cxx
+++ b/DataFormats/Detectors/ITSMFT/common/src/ClusterTopology.cxx
@@ -144,49 +144,5 @@ std::ostream& operator<<(std::ostream& os, const ClusterTopology& topology)
   return os;
 }
 
-void ClusterTopology::getCOG(int nRows, int nCols, const unsigned char patt[Cluster::kMaxPatternBytes], int& rowShift, int& colShift, float& xCOG, float& zCOG)
-{
-  int tempxCOG = 0, tempzCOG = 0, tempFiredPixels = 0, s = 0, ic = 0, ir = 0;
-  int nBits = nRows * nCols;
-  int nBytes = nBits / 8;
-  if (nBits % 8 != 0) {
-    nBytes++;
-  }
-  for (unsigned int i = 0; i < nBytes; i++) {
-    unsigned char tempChar = patt[i];
-    s = 128; // 0b10000000
-    while (s > 0) {
-      if ((tempChar & s) != 0) {
-        tempFiredPixels++;
-        tempxCOG += ir;
-        tempzCOG += ic;
-      }
-      ic++;
-      s /= 2;
-      if ((ir + 1) * ic == nBits) {
-        break;
-      }
-      if (ic == nCols) {
-        ic = 0;
-        ir++;
-      }
-    }
-    if ((ir + 1) * ic == nBits) {
-      break;
-    }
-  }
-  xCOG = float(tempxCOG) / tempFiredPixels;
-  zCOG = float(tempzCOG) / tempFiredPixels;
-
-  rowShift = TMath::Nint(xCOG);
-  colShift = TMath::Nint(zCOG);
-}
-
-void ClusterTopology::getCOGshift(int nRows, int nCols, const unsigned char patt[Cluster::kMaxPatternBytes], int& rowShift, int& colShift)
-{
-  float tempxCOG = 0., tempzCOG = 0.;
-  getCOG(nRows, nCols, patt, rowShift, colShift, tempxCOG, tempzCOG);
-}
-
 } // namespace itsmft
 } // namespace o2

--- a/DataFormats/Detectors/ITSMFT/common/src/ClusterTopology.cxx
+++ b/DataFormats/Detectors/ITSMFT/common/src/ClusterTopology.cxx
@@ -144,7 +144,7 @@ std::ostream& operator<<(std::ostream& os, const ClusterTopology& topology)
   return os;
 }
 
-void ClusterTopology::getCOGshift(int nRows, int nCols, const unsigned char patt[Cluster::kMaxPatternBytes], int& rowShift, int& colShift)
+void ClusterTopology::getCOG(int nRows, int nCols, const unsigned char patt[Cluster::kMaxPatternBytes], int& rowShift, int& colShift, float& xCOG, float& zCOG)
 {
   int tempxCOG = 0, tempzCOG = 0, tempFiredPixels = 0, s = 0, ic = 0, ir = 0;
   int nBits = nRows * nCols;
@@ -175,8 +175,17 @@ void ClusterTopology::getCOGshift(int nRows, int nCols, const unsigned char patt
       break;
     }
   }
-  rowShift = TMath::Nint(float(tempxCOG) / tempFiredPixels);
-  colShift = TMath::Nint(float(tempzCOG) / tempFiredPixels);
+  xCOG = float(tempxCOG) / tempFiredPixels;
+  zCOG = float(tempzCOG) / tempFiredPixels;
+
+  rowShift = TMath::Nint(xCOG);
+  colShift = TMath::Nint(zCOG);
+}
+
+void ClusterTopology::getCOGshift(int nRows, int nCols, const unsigned char patt[Cluster::kMaxPatternBytes], int& rowShift, int& colShift)
+{
+  float tempxCOG = 0., tempzCOG = 0.;
+  getCOG(nRows, nCols, patt, rowShift, colShift, tempxCOG, tempzCOG);
 }
 
 } // namespace itsmft

--- a/DataFormats/Detectors/ITSMFT/common/src/ITSMFTDataFormatsLinkDef.h
+++ b/DataFormats/Detectors/ITSMFT/common/src/ITSMFTDataFormatsLinkDef.h
@@ -28,6 +28,7 @@
 #pragma link C++ class std::vector < o2::itsmft::CompCluster> + ;
 #pragma link C++ class std::vector < o2::itsmft::CompClusterExt> + ;
 #pragma link C++ class o2::itsmft::ClusterPattern + ;
+#pragma link C++ class std::map < int, o2::itsmft::ClusterPattern> + ;
 #pragma link C++ class o2::itsmft::ClusterTopology + ;
 #pragma link C++ class o2::itsmft::TopologyDictionary + ;
 #pragma link C++ class o2::itsmft::GroupStruct + ;

--- a/DataFormats/Detectors/ITSMFT/common/src/TopologyDictionary.cxx
+++ b/DataFormats/Detectors/ITSMFT/common/src/TopologyDictionary.cxx
@@ -14,6 +14,7 @@
 /// \author Luca Barioglio, University and INFN of Torino
 
 #include "DataFormatsITSMFT/TopologyDictionary.h"
+#include "DataFormatsITSMFT/ClusterTopology.h"
 #include <iostream>
 #include "ITSMFTBase/SegmentationAlpide.h"
 
@@ -181,6 +182,18 @@ Point3D<float> TopologyDictionary::getClusterCoordinates(const CompCluster& cl) 
   o2::itsmft::SegmentationAlpide::detectorToLocalUnchecked(cl.getRow(), cl.getCol(), locCl);
   locCl.SetX(locCl.X() + this->GetXcog(cl.getPatternID()));
   locCl.SetZ(locCl.Z() + this->GetZcog(cl.getPatternID()));
+  return locCl;
+}
+
+Point3D<float>
+  TopologyDictionary::getClusterCoordinates(const CompCluster& cl, const ClusterPattern& patt) const
+{
+  int rowShift = 0, colShift = 0;
+  float xCOG = 0, zCOG = 0;
+  auto tmp = patt.getPattern();
+  ClusterTopology::getCOG(patt.getRowSpan(), patt.getColumnSpan(), &tmp[2], rowShift, colShift, xCOG, zCOG);
+  Point3D<float> locCl;
+  o2::itsmft::SegmentationAlpide::detectorToLocalUnchecked(cl.getRow() - rowShift + xCOG, cl.getCol() - colShift + zCOG, locCl);
   return locCl;
 }
 

--- a/DataFormats/Detectors/ITSMFT/common/src/TopologyDictionary.cxx
+++ b/DataFormats/Detectors/ITSMFT/common/src/TopologyDictionary.cxx
@@ -185,15 +185,12 @@ Point3D<float> TopologyDictionary::getClusterCoordinates(const CompCluster& cl) 
   return locCl;
 }
 
-Point3D<float>
-  TopologyDictionary::getClusterCoordinates(const CompCluster& cl, const ClusterPattern& patt) const
+Point3D<float> TopologyDictionary::getClusterCoordinates(const CompCluster& cl, const ClusterPattern& patt) const
 {
-  int rowShift = 0, colShift = 0;
   float xCOG = 0, zCOG = 0;
-  auto tmp = patt.getPattern();
-  ClusterTopology::getCOG(patt.getRowSpan(), patt.getColumnSpan(), &tmp[2], rowShift, colShift, xCOG, zCOG);
+  patt.getCOG(xCOG, zCOG);
   Point3D<float> locCl;
-  o2::itsmft::SegmentationAlpide::detectorToLocalUnchecked(cl.getRow() - rowShift + xCOG, cl.getCol() - colShift + zCOG, locCl);
+  o2::itsmft::SegmentationAlpide::detectorToLocalUnchecked(cl.getRow() - round(xCOG) + xCOG, cl.getCol() - round(zCOG) + zCOG, locCl);
   return locCl;
 }
 

--- a/Detectors/ITSMFT/ITS/macros/test/CheckCOG.C
+++ b/Detectors/ITSMFT/ITS/macros/test/CheckCOG.C
@@ -46,6 +46,11 @@ void CheckCOG(std::string clusfile = "o2clus_its.root", std::string inputGeom = 
   clusTree->SetBranchAddress("ITSCluster", &clusArr);
   std::vector<CompClusterExt>* compclusArr = nullptr;
   clusTree->SetBranchAddress("ITSClusterComp", &compclusArr);
+  std::map<int, o2::itsmft::ClusterPattern>* patternsPtr = nullptr;
+  auto pattBranch = clusTree->GetBranch("ITSClusterPatt");
+  if (pattBranch) {
+    pattBranch->SetAddress(&patternsPtr);
+  }
 
   int nevCl = clusTree->GetEntries(); // clusters in cont. readout may be grouped as few events per entry
   int ievC = 0;
@@ -100,6 +105,12 @@ void CheckCOG(std::string clusfile = "o2clus_its.root", std::string inputGeom = 
       fOut << Form("***************************************\n");
 
       if (dict.IsGroup(cComp.getPatternID())) {
+        if (patternsPtr) { // Restore the full pixel pattern information from the auxiliary branch
+          auto patt = (*patternsPtr)[nc];
+          auto locCl = dict.getClusterCoordinates(cComp, patt);
+          dx = (locC.X() - locCl.X()) * 10000;
+          dz = (locC.Z() - locCl.Z()) * 10000;
+        }
         hGroupX->Fill(dx);
         hGroupZ->Fill(dz);
       } else {

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/ClustererTask.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/ClustererTask.h
@@ -63,6 +63,8 @@ class ClustererTask
   void setMaxROframe(int max) { maxROframe = max; }
   int getMaxROframe() const { return maxROframe; }
 
+  void setPatterns() { mClusterer.setPatterns(&mPatterns); }
+
  private:
   int maxROframe = std::numeric_limits<int>::max();                                   ///< maximal number of RO frames per a file
   bool mRawDataMode = false;                                                          ///< input from raw data or MC digits
@@ -82,7 +84,9 @@ class ClustererTask
 
   MCTruth mClsLabels;               //! MC labels
 
-  ClassDefNV(ClustererTask, 1);
+  std::vector<o2::itsmft::ClusterTopology> mPatterns;
+
+  ClassDefNV(ClustererTask, 2);
 };
 } // namespace its
 } // namespace o2

--- a/Detectors/ITSMFT/ITS/reconstruction/src/ClustererTask.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/ClustererTask.cxx
@@ -135,6 +135,15 @@ void ClustererTask::run(const std::string inpName, const std::string outName)
       mClusterer.process(*mReaderMC.get(), &mFullClus, &mCompClus, &mClsLabels, &mROFRecVec);
     }
 
+    // This conversion vector -> map is just for the convenience of "offline" analyses
+    std::map<int, o2::itsmft::ClusterPattern> map;
+    if (mClusterer.getPatterns()) {
+      o2::itsmft::ClusterTopology::makeRareTopologyMap(mPatterns, map);
+      outTree.Branch("ITSClusterPatt", &map);
+    } else {
+      LOG(INFO) << Class()->GetName() << " output of cluster patterns is not requested";
+    }
+
     std::vector<o2::itsmft::MC2ROFRecord> mc2rof, *mc2rofPtr = &mc2rof;
     if (mUseMCTruth) {
       auto mc2rofOrig = mReaderMC->getMC2ROFRecords();
@@ -184,6 +193,15 @@ void ClustererTask::writeTree(std::string basename, int i)
     outTree.Branch("ITSClusterComp", &compClusPtr);
   } else {
     LOG(INFO) << Class()->GetName() << " output of compact clusters is not requested";
+  }
+
+  // This conversion vector -> map is just for the convenience of "offline" analyses
+  std::map<int, o2::itsmft::ClusterPattern> map;
+  if (mClusterer.getPatterns()) {
+    o2::itsmft::ClusterTopology::makeRareTopologyMap(mPatterns, map);
+    outTree.Branch("ITSClusterPatt", &map);
+  } else {
+    LOG(INFO) << Class()->GetName() << " output of cluster patterns is not requested";
   }
 
   for (auto& rof : rofRecBuffer) {

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ClustererSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ClustererSpec.h
@@ -40,6 +40,7 @@ class ClustererDPL : public Task
   bool mUseMC = true;
   bool mFullClusters = true;
   bool mCompactClusters = true;
+  bool mPatterns = true;
   std::unique_ptr<std::ifstream> mFile = nullptr;
   std::unique_ptr<o2::itsmft::Clusterer> mClusterer = nullptr;
 };

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
@@ -106,6 +106,9 @@ class Clusterer
     mPattIdConverter.loadDictionary(fileName);
   }
 
+  void setPatterns(std::vector<o2::itsmft::ClusterTopology>* patt) { mPatterns = patt; }
+  std::vector<o2::itsmft::ClusterTopology>* getPatterns() const { return mPatterns; }
+
  private:
   void initChip(UInt_t first);
 
@@ -231,6 +234,8 @@ class Clusterer
   std::array<PixelData, Cluster::kMaxPatternBits * 2> mPixArrBuff; //! temporary buffer for pattern calc.
 
   LookUp mPattIdConverter; //! Convert the cluster topology to the corresponding entry in the dictionary.
+
+  std::vector<o2::itsmft::ClusterTopology>* mPatterns = nullptr; // Not owned
 
 #ifdef _PERFORM_TIMING_
   TStopwatch mTimer;

--- a/Detectors/ITSMFT/common/reconstruction/src/BuildTopologyDictionary.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/BuildTopologyDictionary.cxx
@@ -45,34 +45,7 @@ void BuildTopologyDictionary::accountTopology(const ClusterTopology& cluster, fl
     int& rs = topInf.mSizeX = cluster.getRowSpan();
     int& cs = topInf.mSizeZ = cluster.getColumnSpan();
     //__________________COG_Deterrmination_____________
-    int tempxCOG = 0, tempzCOG = 0, tempFiredPixels = 0, s = 0, ic = 0, ir = 0;
-    unsigned char tempChar = 0;
-    for (unsigned int i = 2; i < cluster.getUsedBytes() + 2; i++) {
-      tempChar = cluster.getByte(i);
-      s = 128; // 0b10000000
-      while (s > 0) {
-        if ((tempChar & s) != 0) {
-          tempFiredPixels++;
-          tempxCOG += ir;
-          tempzCOG += ic;
-        }
-        ic++;
-        s /= 2;
-        if ((ir + 1) * ic == (rs * cs)) {
-          break;
-        }
-        if (ic == cs) {
-          ic = 0;
-          ir++;
-        }
-      }
-      if ((ir + 1) * ic == (rs * cs)) {
-        break;
-      }
-    }
-    topInf.mCOGx = (float)tempxCOG / (float)tempFiredPixels;
-    topInf.mCOGz = (float)tempzCOG / (float)tempFiredPixels;
-    topInf.mNpixels = tempFiredPixels;
+    topInf.mNpixels = cluster.getClusterPattern().getCOG(topInf.mCOGx, topInf.mCOGz);
     if (useDf) {
       topInf.mXmean = dX;
       topInf.mZmean = dZ;

--- a/Detectors/ITSMFT/common/reconstruction/src/Clusterer.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/Clusterer.cxx
@@ -303,10 +303,10 @@ void Clusterer::finishChip(std::vector<Cluster>* fullClus, std::vector<CompClust
       clus.getPattern(&patt[0], Cluster::kMaxPatternBytes);
       UShort_t pattID = mPattIdConverter.findGroupID(rowSpan, colSpan, patt);
       if (mPattIdConverter.IsGroup(pattID)) {
-        int rowShift = 0, colShift = 0;
-        ClusterTopology::getCOGshift(rowSpan, colSpan, patt, rowShift, colShift);
-        rowMin += rowShift;
-        colMin += colShift;
+        float xCOG = 0., zCOG = 0.;
+        ClusterPattern::getCOG(rowSpan, colSpan, patt, xCOG, zCOG);
+        rowMin += round(xCOG);
+        colMin += round(zCOG);
         if (mPatterns) {
           mPatterns->emplace_back(rowSpan, colSpan, patt);
           mPatterns->back().setHash(mClustersCount);

--- a/Detectors/ITSMFT/common/reconstruction/src/Clusterer.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/Clusterer.cxx
@@ -297,14 +297,20 @@ void Clusterer::finishChip(std::vector<Cluster>* fullClus, std::vector<CompClust
     }
 
     if (compClus) { // store compact clusters
+      auto rowSpan = clus.getPatternRowSpan();
+      auto colSpan = clus.getPatternColSpan();
       unsigned char patt[Cluster::kMaxPatternBytes];
       clus.getPattern(&patt[0], Cluster::kMaxPatternBytes);
-      UShort_t pattID = mPattIdConverter.findGroupID(clus.getPatternRowSpan(), clus.getPatternColSpan(), patt);
+      UShort_t pattID = mPattIdConverter.findGroupID(rowSpan, colSpan, patt);
       if (mPattIdConverter.IsGroup(pattID)) {
         int rowShift = 0, colShift = 0;
-        ClusterTopology::getCOGshift(clus.getPatternRowSpan(), clus.getPatternColSpan(), patt, rowShift, colShift);
+        ClusterTopology::getCOGshift(rowSpan, colSpan, patt, rowShift, colShift);
         rowMin += rowShift;
         colMin += colShift;
+        if (mPatterns) {
+          mPatterns->emplace_back(rowSpan, colSpan, patt);
+          mPatterns->back().setHash(mClustersCount);
+        }
       }
       compClus->emplace_back(rowMin, colMin, pattID, mChipData->getChipID());
     }

--- a/macro/run_clus_itsSA.C
+++ b/macro/run_clus_itsSA.C
@@ -27,7 +27,7 @@ void run_clus_itsSA(std::string inputfile = "rawits.bin", // output file name
                     std::string outputfile = "clr.root",  // input file name (root or raw)
                     bool raw = true,                      // flag if this is raw data
                     float strobe = -1.,                   // strobe length in ns of ALPIDE readout, if <0, get automatically
-                    bool withDictionary = false, std::string dictionaryfile = "complete_dictionary.bin")
+                    bool withDictionary = false, std::string dictionaryfile = "complete_dictionary.bin", bool withPatterns = false)
 {
   // Initialize logger
   FairLogger* logger = FairLogger::GetLogger();
@@ -43,7 +43,11 @@ void run_clus_itsSA(std::string inputfile = "rawits.bin", // output file name
   clus->setMaxROframe(2 << 21); // about 3 cluster files per a raw data chunk
   if (withDictionary) {
     clus->loadDictionary(dictionaryfile.c_str());
+    if (withPatterns) {
+      clus->setPatterns();
+    }
   }
+
   // Mask fired pixels separated by <= this number of BCs (for overflow pixels).
   // In continuos mode strobe lenght should be used, in triggered one: signal shaping time (~7mus)
   if (strobe < 0) {


### PR DESCRIPTION
This PR opens a possibility to keep full cluster topology information for topology groups.
This information is stored "in parallel" with the clusters themselves. It does not take much disk
(or RAM) space, because the grouped topologies are rare.
The changes are backward compatible. Both old data structures and interfaces are preserved.
Saving the full topology information can be activated with an optional processing flag.
A use case for this additional information in an "offline" analysis is demonstrated in ITS/macros/test/CheckCOG.C macro (lines 108-113).
![cCommon](https://user-images.githubusercontent.com/15123398/77069431-b51b0f00-69e8-11ea-957b-c3347895fbee.png)
![cGroup](https://user-images.githubusercontent.com/15123398/77069433-b5b3a580-69e8-11ea-80d7-34ae62263897.png)
![cTotal](https://user-images.githubusercontent.com/15123398/77069434-b64c3c00-69e8-11ea-913d-a7a9f42dece6.png)


