### PR TITLE
DPL Analysis: prevent ROOT from overwriting histos in OutputObj

### DIFF
--- a/Analysis/Tutorials/src/outputs.cxx
+++ b/Analysis/Tutorials/src/outputs.cxx
@@ -24,7 +24,7 @@ using namespace o2::framework;
 using namespace o2::framework::expressions;
 
 struct DummyTask {
-  OutputObj<TH1F> pt{TH1F("pt1", "pt", 100, 0., 50.)};
+  OutputObj<TH1F> pt{TH1F("pt", "pt", 100, 0., 50.)};
   void process(aod::Track const& track)
   {
     pt->Fill(track.pt());
@@ -32,7 +32,7 @@ struct DummyTask {
 };
 
 struct DummyTask2 {
-  OutputObj<TH1F> pt{TH1F("pt2", "pt", 100, 0., 50.)};
+  OutputObj<TH1F> pt{TH1F("pt", "pt", 100, 0., 50.)};
 
   void process(aod::Track const& track)
   {
@@ -41,7 +41,7 @@ struct DummyTask2 {
 };
 
 struct DummyTask3 {
-  OutputObj<TH1F> pt{TH1F("pt3", "pt", 100, 0., 50.)};
+  OutputObj<TH1F> pt{TH1F("pt", "pt", 100, 0., 50.)};
   void process(aod::Track const& track)
   {
     pt->Fill(track.pt());

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -722,6 +722,7 @@ class has_init
 template <typename T, typename... Args>
 DataProcessorSpec adaptAnalysisTask(char const* name, Args&&... args)
 {
+  TH1::AddDirectory(false);
   auto task = std::make_shared<T>(std::forward<Args>(args)...);
   auto hash = compile_time_hash(name);
 


### PR DESCRIPTION
* Force ROOT not to store histo references in a default directory to allow having multiple histos with the same name
* Fix output object routing to use hashes 
* Remove extra 'std::move'