### PR TITLE
[EMCAL-610] Encoding RCU trailer, TF-based raw format

### DIFF
--- a/Detectors/EMCAL/base/include/EMCALBase/RCUTrailer.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/RCUTrailer.h
@@ -127,9 +127,17 @@ class RCUTrailer
   /// \throw Error if the RCU trailer was not properly initializied
   double getTimeSample() const;
 
+  /// \brief set time sample
+  /// \param timesample Time sample (in ns)
+  void setTimeSample(double timesample);
+
   /// \brief Access to the L1 phase
   /// \return L1 phase w.r.t to the LHC clock
   double getL1Phase() const;
+
+  /// \brief Set the L1 phase
+  /// \param l1phase L1 phase (in ns)
+  void setL1Phase(double l1phase);
 
   void setFECErrorsA(unsigned int value) { mFECERRA = value; }
   void setFECErrorsB(unsigned int value) { mFECERRB = value; }
@@ -139,10 +147,14 @@ class RCUTrailer
   void setActiveFECsB(unsigned short value) { mActiveFECsB = value; }
   void setAltroCFGReg1(unsigned int value) { mAltroCFG1 = value; }
   void setAltroCFGReg2(unsigned int value) { mAltroCFG2 = value; }
+  void setFirmwareVersion(unsigned char version) { mFirmwareVersion = version; }
+  void setPayloadSize(unsigned int size) { mPayloadSize = size; }
 
   /// \brief checlks whether the RCU trailer is initialzied
   /// \return True if the trailer is initialized, false otherwise
   bool isInitialized() const { return mIsInitialized; }
+
+  std::vector<uint32_t> encode() const;
 
   static RCUTrailer constructFromPayloadWords(const gsl::span<const uint32_t> payloadwords);
 

--- a/Detectors/EMCAL/simulation/CMakeLists.txt
+++ b/Detectors/EMCAL/simulation/CMakeLists.txt
@@ -11,8 +11,8 @@
 o2_add_library(EMCALSimulation
                SOURCES src/Detector.cxx src/Digitizer.cxx src/DigitizerTask.cxx
                        src/SpaceFrame.cxx src/SimParam.cxx src/LabeledDigit.cxx
-                       src/RawWriter.cxx src/DMAOutputStream.cxx
-               PUBLIC_LINK_LIBRARIES O2::EMCALBase O2::DetectorsBase O2::SimConfig O2::SimulationDataFormat O2::Headers)
+                       src/RawWriter.cxx src/DMAOutputStream.cxx src/RawOutputPageHandler.cxx
+               PUBLIC_LINK_LIBRARIES O2::EMCALBase O2::DetectorsBase O2::SimConfig O2::SimulationDataFormat O2::Headers O2::DetectorsRaw)
 
 o2_target_root_dictionary(EMCALSimulation
                           HEADERS include/EMCALSimulation/Detector.h

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/DMAOutputStream.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/DMAOutputStream.h
@@ -87,13 +87,21 @@ class DMAOutputStream
   /// \brief Write output payload to the output stream
   /// \param header Raw data header
   /// \param buffer Raw data payload
+  /// \return Current page count
   ///
   /// Converting output payload to DMA papges. If the payload is larger than
   /// the pagesize - header size the payload is automatically split to multiple
   /// pages. Page counter, memory size, page size and stop bit of the header are
   /// handled internally and are overwritten from the header provided. All other
   /// header information must be provided externally.
-  void writeData(RawHeader header, gsl::span<char> buffer);
+  int writeData(RawHeader header, gsl::span<const char> buffer);
+
+  /// \brief Write single raw data header
+  /// \param header raw data header
+  ///
+  /// Write header with no payload assinged. Function is used for writing
+  /// open/close header of the timeframe
+  void writeSingleHeader(const RawHeader& header);
 
  protected:
   /// \brief Write DMA page
@@ -103,7 +111,7 @@ class DMAOutputStream
   ///
   /// Expects that the size of the payload is smaller than the size ot the DMA
   /// page. Parameter pagesize supporting variable page size.
-  void writeDMAPage(const RawHeader& header, gsl::span<char> payload, int pagesize);
+  void writeDMAPage(const RawHeader& header, gsl::span<const char> payload, int pagesize);
 
  private:
   std::string mFilename = ""; ///< Name of the output file

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/RawOutputPageHandler.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/RawOutputPageHandler.h
@@ -1,0 +1,162 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <exception>
+#include <map>
+#include <string>
+#include <vector>
+#include <CommonDataFormat/InteractionRecord.h>
+#include <EMCALSimulation/DMAOutputStream.h>
+
+namespace o2
+{
+namespace emcal
+{
+
+/// \class RawOutputPageHandler
+/// \brief Handler for EMCAL raw page buffering, timeframe building and output streaming
+/// \ingroup EMCALsimulation
+/// \author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
+/// \since March 22, 2020
+///
+/// # General
+/// The raw format for EMCAL consists of separate superpages of timeframes arranged per
+/// (DDL) link. Each timeframe consists of
+/// - Empty RDH without payload indicating start of timeframe. Counters are reset
+/// - Pages with RDH and payload for each trigger BC within the timeframe
+/// - Empty RDH without payload indicating end of timeframe. Contains the number of pages
+///   in the timeframe, the stop bit and the timeframe trigger.
+/// At the start of data an empty timeframe (without pages) consisting only of star and stop
+/// RDH will mark the beginning of the data stream.
+///
+/// # Usage
+/// For each new trigger the function initTrigger is to be called with the InteractionRecord
+/// of the bunch crossing corresponding to the trigger. Pages created by the raw writer and added
+/// via addPageForLink are buffered per link. The HBFUtils, provided from outside, decide on whether
+/// a new timeframe is triggered. In case of a new timeframe raw timeframes are created for all
+/// links with pages, containing all pages of a link and streamed to file (in initTrigger). In case
+/// the buffer still contains pages when the destructor is called, the pages are streamed as remaining
+/// pages of the last timeframe (in the destructor).
+class RawOutputPageHandler
+{
+ public:
+  using RawHeader = o2::header::RAWDataHeaderV4;
+
+  /// \class LinkIDException
+  /// \brief Exception handling invalid link IDs (outside the range of EMCAL links)
+  class LinkIDException : public std::exception
+  {
+   public:
+    /// \brief Constructor, defining
+    LinkIDException(int linkID);
+
+    /// \brief Destructor
+    ~LinkIDException() noexcept final = default;
+
+    /// \brief Access to error message of the exception
+    /// \return Error message of the exception
+    const char* what() const noexcept final { return mMessage.data(); }
+
+    /// \brief Access to Link ID raising the exception
+    /// \return Link ID raising the exception
+    int getLinkID() const { return mLinkID; }
+
+   private:
+    int mLinkID;          ///< ID of the link raising the exception
+    std::string mMessage; ///< Error message;
+  };
+
+  /// \class RawPageBuffer
+  /// \brief Buffer for raw pages
+  ///
+  /// Internal helper class for buffering raw pages within a timeframe for a certain link.
+  /// The functionality consists of:
+  /// - add page: adding new page to the raw buffer
+  /// - getPages: access to all pages. Mainly used when building the timeframe
+  /// - flush: clear buffer (after timeframe building)
+  class RawPageBuffer
+  {
+   public:
+    /// \struct PageData
+    /// \brief Structure for a raw page (header and payload words)
+    struct PageData {
+      RawHeader mHeader;       ///< Header template of the page, containing link ID, fee ID and trigger
+      std::vector<char> mPage; ///< Payload page
+    };
+
+    /// \brief Constructor
+    RawPageBuffer() = default;
+
+    /// \brief Destructor
+    ~RawPageBuffer() = default;
+
+    /// \brief Adding new raw page to the page buffer
+    /// \brief header Template raw header, containing link/fee ID and trigger
+    /// \brief page Raw page (as char words) to be added to the buffer
+    void addPage(const RawHeader& header, const std::vector<char>& page) { mPages.push_back({header, page}); }
+
+    /// \brief Cleaning page buffer
+    void flush() { mPages.clear(); }
+
+    /// \brief Access to pages in the buffer
+    /// \return vector with all pages in the buffer
+    const std::vector<PageData>& getPages() const { return mPages; }
+
+   private:
+    std::vector<PageData> mPages; ///< Buffer for pages
+  };
+
+  /// \brief Constructor, initializing page handler with output filename and HBF utils
+  /// \param rawfilename Name of the output file
+  RawOutputPageHandler(const char* rawfilename);
+
+  /// \brief Destructor
+  ///
+  /// In case buffers contain payload the page is streamed as last
+  /// timeframe for the links containing payload pages.
+  ~RawOutputPageHandler();
+
+  /// \brief Initialize new trigger
+  /// \param currentIR Interaction record of the collision triggering
+  ///
+  /// Initialize new trigger. In case the Timeframe changes with the trigger
+  /// the buffers belonging to the previous buffer are streamed to file. For
+  /// each link a separate timeframe is created, starting with empty open/close
+  /// raw data header. Timeframes are only created for links which buffer pages.
+  void initTrigger(const o2::InteractionRecord& currentIR);
+
+  /// \brief Add new page for link to the page buffer
+  /// \param linkID ID of the link
+  /// \param header Template raw header of the page
+  /// \param dmapage Payload page
+  /// \throw LinkIDException in case link ID is invalid
+  void addPageForLink(int linkID, const RawHeader& header, const std::vector<char>& dmapage);
+
+ private:
+  /// \brief Write timeframe for an entire link
+  /// \param linkID ID of the link
+  /// \param pagebuffer Buffer with raw pages in timeframe belonging to the link
+  ///
+  /// Timeframes for raw data in EMCAL contain:
+  /// - Empty RDH, indicating start of timeframe. No payload assigned. Counters 0
+  /// - Raw page for every trigger in the timeframe: Each raw page starts with a
+  ///   RDH. In case the payload exceeds the 8 kB page it is split into multiple
+  ///   pages. The page counter is calculated with respect to the first header in a
+  ///   timeframe
+  /// - Empty RDH, closing the timeframe, containing the number of pages in the
+  ///   timeframe
+  void writeTimeframe(int linkID, const RawPageBuffer& pagebuffer);
+
+  int mCurrentTimeframe = -1;             ///< Current timeframe ID (needed to detect whether a new timeframe starts)
+  std::map<int, RawPageBuffer> mRawPages; ///< Buffer with raw pages for all links
+  DMAOutputStream mOutputStream;          ///< File output stream
+};
+} // namespace emcal
+} // namespace o2

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/RawWriter.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/RawWriter.h
@@ -22,6 +22,7 @@
 
 #include "EMCALBase/Mapper.h"
 #include "EMCALSimulation/DMAOutputStream.h"
+#include "EMCALSimulation/RawOutputPageHandler.h"
 #include "DataFormatsEMCAL/Digit.h"
 #include "DataFormatsEMCAL/TriggerRecord.h"
 
@@ -77,7 +78,7 @@ class RawWriter
   RawWriter(const char* rawfilename) { setRawFileName(rawfilename); }
   ~RawWriter() = default;
 
-  void setRawFileName(const char* filename) { mOutputStream.setOutputFilename(filename); }
+  void setRawFileName(const char* filename) { mRawFilename = filename; }
   void setDigits(std::vector<o2::emcal::Digit>* digits) { mDigits = digits; }
   void setTriggerRecords(std::vector<o2::emcal::TriggerRecord>* triggers);
   void setNumberOfADCSamples(int nsamples) { mNADCSamples = nsamples; }
@@ -95,19 +96,20 @@ class RawWriter
   std::tuple<int, int, int> getOnlineID(int towerID);
 
   ChannelHeader createChannelHeader(int hardwareAddress, int payloadSize, bool isBadChannel);
-  std::vector<char> createRCUTrailer();
+  std::vector<char> createRCUTrailer(int payloadsize, int feca, int fecb, double timesample, double l1phase);
   std::vector<int> encodeBunchData(const std::vector<int>& data);
 
  private:
-  DMAOutputStream mOutputStream;                                   ///< DMA output stream
   int mNADCSamples = 15;                                           ///< Number of time samples
   int mPedestal = 0;                                               ///< Pedestal
   o2::emcal::Geometry* mGeometry = nullptr;                        ///< EMCAL geometry
+  std::string mRawFilename;                                        ///< Rawfile name
   std::array<o2::emcal::Mapper, 4> mMappers;                       ///< EMCAL mappers
   std::vector<o2::emcal::Digit>* mDigits;                          ///< Digits input vector - must be in digitized format including the time response
   std::vector<o2::emcal::TriggerRecord>* mTriggers;                ///< Trigger records, separating the data from different triggers
   std::vector<SRUDigitContainer> mSRUdata;                         ///< Internal helper of digits assigned to SRUs
   std::vector<o2::emcal::TriggerRecord>::iterator mCurrentTrigger; ///< Current trigger in the trigger records
+  std::unique_ptr<RawOutputPageHandler> mPageHandler;              ///< Output page handler
 
   ClassDefNV(RawWriter, 1);
 };

--- a/Detectors/EMCAL/simulation/src/RawOutputPageHandler.cxx
+++ b/Detectors/EMCAL/simulation/src/RawOutputPageHandler.cxx
@@ -1,0 +1,83 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <fmt/format.h>
+#include <Headers/RAWDataHeader.h>
+#include <DetectorsRaw/HBFUtils.h>
+#include <EMCALSimulation/RawOutputPageHandler.h>
+
+using namespace o2::emcal;
+
+RawOutputPageHandler::RawOutputPageHandler(const char* rawfilename) : mOutputStream(rawfilename), mCurrentTimeframe(-1)
+{
+  // create page buffers for all (40) links
+  for (int ilink = 0; ilink < 40; ilink++)
+    mRawPages[ilink] = RawPageBuffer();
+  mOutputStream.open();
+}
+
+RawOutputPageHandler::~RawOutputPageHandler()
+{
+  // write pages for last timeframe to file
+  for (const auto& [linkID, pagebuffer] : mRawPages) {
+    // only write pages for links which send data
+    if (pagebuffer.getPages().size())
+      writeTimeframe(linkID, pagebuffer);
+  }
+}
+
+void RawOutputPageHandler::initTrigger(const o2::InteractionRecord& irtrigger)
+{
+  auto currenttimeframe = raw::HBFUtils::Instance().getTF(irtrigger);
+  if (currenttimeframe != mCurrentTimeframe) {
+    // write pages to file
+    for (auto& [linkID, pagebuffer] : mRawPages) {
+      // only write pages for links which send data
+      if (pagebuffer.getPages().size())
+        writeTimeframe(linkID, pagebuffer);
+      pagebuffer.flush();
+    }
+    // set the new timeframe
+    mCurrentTimeframe = currenttimeframe;
+  }
+}
+
+void RawOutputPageHandler::writeTimeframe(int linkID, const RawPageBuffer& pagebuffer)
+{
+  // write pages to file
+  // Write timeframe open
+  RawHeader timeframeheader;
+  timeframeheader.linkID = linkID;
+  mOutputStream.writeSingleHeader(timeframeheader);
+  int pagecounter = 1;
+  for (const auto& page : pagebuffer.getPages()) {
+    auto header = page.mHeader;
+    header.pageCnt = pagecounter;
+    pagecounter = mOutputStream.writeData(header, gsl::span<const char>(page.mPage.data(), page.mPage.size()));
+  }
+
+  // end of timeframe
+  timeframeheader.pageCnt = pagecounter;
+  timeframeheader.stop = 1;
+  timeframeheader.triggerType = o2::trigger::TF;
+  mOutputStream.writeSingleHeader(timeframeheader);
+}
+
+void RawOutputPageHandler::addPageForLink(int linkID, const RawHeader& header, const std::vector<char>& page)
+{
+  if (linkID > 40)
+    throw LinkIDException(linkID);
+  mRawPages[linkID].addPage(header, page);
+}
+
+RawOutputPageHandler::LinkIDException::LinkIDException(int linkID) : std::exception(), mLinkID(linkID), mMessage()
+{
+  mMessage = fmt::format("Link ID invalid: %d (max 40)", linkID);
+}


### PR DESCRIPTION
- Add encoding of the RCU trailer
- Convert to TF-based format for DDL detectors:
    DMA pages are buffered untill the end-
    of-timeframe is reached. At the end-of-
    timeframe pages are sent consecutively
    for all link. Each link gets its own
    timeframe.