### PR TITLE
Introduce object caching and ownership in BasicCCDBManager

### DIFF
--- a/CCDB/CMakeLists.txt
+++ b/CCDB/CMakeLists.txt
@@ -50,3 +50,9 @@ o2_add_test(CcdbApi
             COMPONENT_NAME ccdb
             PUBLIC_LINK_LIBRARIES O2::CCDB
             LABELS ccdb)
+
+o2_add_test(BasicCCDBManager
+            SOURCES test/testBasicCCDBManager.cxx
+            COMPONENT_NAME ccdb
+            PUBLIC_LINK_LIBRARIES O2::CCDB
+            LABELS ccdb)

--- a/CCDB/README.md
+++ b/CCDB/README.md
@@ -86,6 +86,15 @@ auto& mgr = o2::ccdb::BasicCCDBManager::instance();
 auto alignment = mgr.get<o2::FOO::GeomAlignment>("/FOO/Alignment");
 ```
 
+By default loaded object are cached in the `BasicCCDBManager` and owned by it, therefore user should not delete retrieved objects.
+If the query is done for the object which is already in the cache, its pointer is returned instead of loading again the object from the CCDB server,
+unless the validity range of the cached object does not match to requested timestamp.
+In case user wants to enforce a fresh copy loading, the cache for particular CCDB path can be cleaned by invoking `mgr.clear(<path>)`.
+One can also reset whole cache using `mgr.clear()`.
+
+Uncached mode can be imposed by invoking `mgr.setCachingEnabled(false)`, in which case every query will retrieve a new copy of object from the server and
+the user should take care himself of deleting retrieved objects to avoid memory leaks.
+
 ## Future ideas / todo:
 
 - [ ] offer improved error handling / exceptions

--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -148,11 +148,12 @@ class CcdbApi //: public DatabaseInterface
    * @param metadata Key-values representing the metadata to filter out objects.
    * @param timestamp Timestamp of the object to retrieve. If omitted, current timestamp is used.
    * @param headers Map to be populated with the headers we received, if it is not null.
+   * @param optional etag from previous call
    * @return the object, or nullptr if none were found.
    * @deprecated in favour of retrieveFromTFileAny as it is not limited to TObjects.
    */
   TObject* retrieveFromTFile(std::string const& path, std::map<std::string, std::string> const& metadata,
-                             long timestamp = -1, std::map<std::string, std::string>* headers = nullptr) const;
+                             long timestamp = -1, std::map<std::string, std::string>* headers = nullptr, std::string const& etag = "") const;
 
   /**
    * Retrieve object at the given path for the given timestamp.
@@ -161,11 +162,12 @@ class CcdbApi //: public DatabaseInterface
    * @param metadata Key-values representing the metadata to filter out objects.
    * @param timestamp Timestamp of the object to retrieve. If omitted, current timestamp is used.
    * @param headers Map to be populated with the headers we received, if it is not null.
+   * @param optional etag from previous call
    * @return the object, or nullptr if none were found or type does not match serialized type.
    */
   template <typename T>
   T* retrieveFromTFileAny(std::string const& path, std::map<std::string, std::string> const& metadata,
-                          long timestamp = -1, std::map<std::string, std::string>* headers = nullptr) const;
+                          long timestamp = -1, std::map<std::string, std::string>* headers = nullptr, std::string const& etag = "") const;
 
   /**
    * Delete all versions of the object at this path.
@@ -358,7 +360,7 @@ class CcdbApi //: public DatabaseInterface
    * A generic helper implementation to query obj whose type is given by a std::type_info
    */
   void* retrieveFromTFile(std::type_info const&, std::string const& path, std::map<std::string, std::string> const& metadata,
-                          long timestamp = -1, std::map<std::string, std::string>* headers = nullptr) const;
+                          long timestamp = -1, std::map<std::string, std::string>* headers = nullptr, std::string const& etag = "") const;
 
   /**
    * A helper function to extract object from a local ROOT file
@@ -383,9 +385,9 @@ class CcdbApi //: public DatabaseInterface
 
 template <typename T>
 T* CcdbApi::retrieveFromTFileAny(std::string const& path, std::map<std::string, std::string> const& metadata,
-                                 long timestamp, std::map<std::string, std::string>* headers) const
+                                 long timestamp, std::map<std::string, std::string>* headers, std::string const& etag) const
 {
-  return static_cast<T*>(retrieveFromTFile(typeid(T), path, metadata, timestamp, headers));
+  return static_cast<T*>(retrieveFromTFile(typeid(T), path, metadata, timestamp, headers, etag));
 }
 
 } // namespace ccdb

--- a/CCDB/test/testBasicCCDBManager.cxx
+++ b/CCDB/test/testBasicCCDBManager.cxx
@@ -1,0 +1,111 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   testBasicCCDBManager.cxx
+/// \brief  Test BasicCCDBManager and caching functionality
+/// \author ruben.shahoyan@cern.ch
+///
+
+#define BOOST_TEST_MODULE CCDB
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include "CCDB/CcdbApi.h"
+#include "CCDB/BasicCCDBManager.h"
+#include "Framework/Logger.h"
+#include <boost/test/unit_test.hpp>
+
+using namespace o2::ccdb;
+
+BOOST_AUTO_TEST_CASE(TestBasicCCDBManager)
+{
+  CcdbApi api;
+  const std::string uri = "http://ccdb-test.cern.ch:8080";
+  api.init(uri);
+  if (!api.isHostReachable()) {
+    LOG(WARNING) << "Host " << uri << " is not reacheable, abandoning the test";
+    return;
+  }
+  //
+  std::string pathA = "Test/CachingA";
+  std::string pathB = "Test/CachingB";
+  std::string ccdbObjO = "testObjectO";
+  std::string ccdbObjN = "testObjectN";
+  std::map<std::string, std::string> md;
+  long start = 1000, stop = 2000;
+  api.storeAsTFileAny(&ccdbObjO, pathA, md, start, stop);
+  api.storeAsTFileAny(&ccdbObjN, pathA, md, stop, stop + (stop - start)); // extra slot
+  api.storeAsTFileAny(&ccdbObjO, pathB, md, start, stop);
+
+  // test reading
+  auto& cdb = o2::ccdb::BasicCCDBManager::instance();
+  cdb.setURL(uri);
+  cdb.setTimestamp((start + stop) / 2);
+  cdb.setCachingEnabled(true);
+
+  auto* objA = cdb.get<std::string>(pathA); // will be loaded from scratch and fill the cache
+  LOG(INFO) << "1st reading of A: " << *objA;
+  BOOST_CHECK(objA && (*objA) == ccdbObjO); // make sure correct object is loaded
+
+  auto* objB = cdb.get<std::string>(pathB); // will be loaded from scratch and fill the cache
+  BOOST_CHECK(objB && (*objB) == ccdbObjO); // make sure correct object is loaded
+
+  std::string hack = "Cached";
+  (*objA) = hack;
+  (*objB) = hack;
+  objA = cdb.get<std::string>(pathA); // should get already cached and hacked object
+  LOG(INFO) << "Reading of cached and modified A: " << *objA;
+  BOOST_CHECK(objA && (*objA) == hack); // make sure correct object is loaded
+
+  // now check wrong object reading, 0 will be returned and cache will be cleaned
+  objA = cdb.getForTimeStamp<std::string>(pathA, start - (stop - start) / 2); // wrong time
+  LOG(INFO) << "Read for wrong time, expect null: " << objA;
+  BOOST_CHECK(objA == nullptr);
+  objA = cdb.get<std::string>(pathA); // cache again
+  LOG(INFO) << "Reading of A from scratch after error: " << *objA;
+  BOOST_CHECK(objA && (*objA) != hack); // make sure we did not get cached object
+  (*objA) = hack;
+
+  // read object from another time slot
+  objA = cdb.getForTimeStamp<std::string>(pathA, stop + (stop - start) / 2); // will be loaded from scratch and fill the cache
+  LOG(INFO) << "Reading of A for different time slost, expect non-cached object: " << *objA;
+  BOOST_CHECK(objA && (*objA) == ccdbObjN); // make sure correct object is loaded
+
+  // clear specific object cache
+  cdb.clearCache(pathA);
+  objA = cdb.get<std::string>(pathA); // will be loaded from scratch and fill the cache
+  LOG(INFO) << "Reading of A after cleaning its cache, expect non-cached object: " << *objA;
+  BOOST_CHECK(objA && (*objA) == ccdbObjO); // make sure correct object is loaded
+  (*objA) = hack;
+  objA = cdb.get<std::string>(pathA); // should get already cached and hacked object
+  LOG(INFO) << "Reading same A, expect cached and modified value: " << *objA;
+  BOOST_CHECK(objA && (*objA) == hack); // make sure correct object is loaded
+
+  objB = cdb.get<std::string>(pathB); // should get already cached and hacked object, since is was not reset
+  LOG(INFO) << "Reading B, expect cached since only A cache was cleaned: " << *objB;
+  BOOST_CHECK(objB && (*objB) == hack); // make sure correct object is loaded
+
+  // clear all caches
+  cdb.clearCache();
+  objB = cdb.get<std::string>(pathB); // will be loaded from scratch and fill the cache
+  LOG(INFO) << "Reading B after cleaning cache completely: " << *objB;
+  BOOST_CHECK(objB && (*objB) == ccdbObjO); // make sure correct object is loaded
+
+  // disable cache at all (will also clean it)
+  cdb.setCachingEnabled(false);
+  objA = cdb.get<std::string>(pathA); // will be loaded from scratch, w/o filling the cache
+  LOG(INFO) << "Reading A after disabling the cache: " << *objA;
+  BOOST_CHECK(objA && (*objA) == ccdbObjO); // make sure correct object is loaded
+  (*objA) = hack;
+  objA = cdb.get<std::string>(pathA); // will be loaded from scratch
+  LOG(INFO) << "Reading A again, it should not be cached: " << *objA;
+  BOOST_CHECK(objA && (*objA) != hack); // make sure correct object is loaded
+}


### PR DESCRIPTION
By default loaded object will be cached in the BasicCCDBManager and owned by it,
therefore user should not delete retrieved objects.
If the query is done for the object which is already in the cache, its pointer is
returned instead of loading again the object from the CCDB server, unless the
validity range of the cached object does not match to requested timestamp.

In case user wants to enforce a fresh copy loading, the cache for particular CCDB
path can be cleaned by invoking ``mgr.clear(<path>)``.
One can also reset whole cache using ``mgr.clear()``.

Uncached mode can be imposed by invoking ``mgr.setCachingEnabled(false)``, in which
case every query will retrieve a new copy of object from the server and
the user should take care himself of deleting retrieved objects to avoid memory leaks.

@costing could you check if this is what you meant.