### PR TITLE
TPCClusterFinder: Fix memleak and undefined behavior in mc labels.

### DIFF
--- a/GPU/GPUTracking/Global/GPUChainTracking.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTracking.cxx
@@ -789,8 +789,9 @@ int GPUChainTracking::RunTPCClusterizer()
   clsMemory.reserve(mRec->MemoryScalers()->nTPCHits);
 
   // setup MC Labels
-  auto* digitsMC = processors()->ioPtrs.tpcPackedDigits ? processors()->ioPtrs.tpcPackedDigits->tpcDigitsMC : nullptr;
-  bool propagateMCLabels = !doGPU && digitsMC != nullptr && GetDeviceProcessingSettings().runMC;
+  bool propagateMCLabels = !doGPU && GetDeviceProcessingSettings().runMC && processors()->ioPtrs.tpcPackedDigits->tpcDigitsMC != nullptr;
+
+  auto* digitsMC = propagateMCLabels ? processors()->ioPtrs.tpcPackedDigits->tpcDigitsMC : nullptr;
 
   GPUTPCLinearLabels mcLinearLabels;
   if (propagateMCLabels) {
@@ -803,16 +804,17 @@ int GPUChainTracking::RunTPCClusterizer()
       unsigned int iSlice = iSliceBase + lane;
       GPUTPCClusterFinder& clusterer = processors()->tpcClusterer[iSlice];
       GPUTPCClusterFinder& clustererShadow = doGPU ? processorsShadow()->tpcClusterer[iSlice] : clusterer;
+      SetupGPUProcessor(&clusterer, false);
+      clusterer.mPmemory->counters.nPeaks = clusterer.mPmemory->counters.nClusters = 0;
 
       if (propagateMCLabels) {
+        clusterer.PrepareMC();
         clusterer.mPinputLabels = digitsMC->v[iSlice];
         // TODO: Why is the number of header entries in truth container
         // sometimes larger than the number of digits?
         assert(clusterer.mPinputLabels->getIndexedSize() >= mIOPtrs.tpcPackedDigits->nTPCDigits[iSlice]);
       }
 
-      SetupGPUProcessor(&clusterer, false);
-      clusterer.mPmemory->counters.nPeaks = clusterer.mPmemory->counters.nClusters = 0;
       unsigned int nPagesTotal = 0;
       if (mIOPtrs.tpcZS) {
         for (unsigned int j = 0; j < GPUTrackingInOutZS::NENDPOINTS; j++) {

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCClusterFinder.h
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCClusterFinder.h
@@ -59,6 +59,7 @@ class GPUTPCClusterFinder : public GPUProcessor
   };
 
 #ifndef GPUCA_GPUCODE
+  ~GPUTPCClusterFinder();
   void InitializeProcessor();
   void RegisterMemoryAllocation();
   void SetMaxData(const GPUTrackingInOutPointers& io);
@@ -71,6 +72,9 @@ class GPUTPCClusterFinder : public GPUProcessor
 
   size_t getNSteps(size_t items) const;
   void SetNMaxDigits(size_t nDigits, size_t nPages);
+
+  void PrepareMC();
+  void clearMCMemory();
 #endif
   unsigned char* mPzs = nullptr;
   ZSOffset* mPzsOffsets = nullptr;

--- a/GPU/GPUTracking/TPCClusterFinder/MCLabelAccumulator.cxx
+++ b/GPU/GPUTracking/TPCClusterFinder/MCLabelAccumulator.cxx
@@ -22,7 +22,9 @@ using namespace GPUCA_NAMESPACE::gpu;
 MCLabelAccumulator::MCLabelAccumulator(GPUTPCClusterFinder& clusterer)
   : mIndexMap(clusterer.mPindexMap), mLabels(clusterer.mPinputLabels), mOutput(clusterer.mPlabelsByRow)
 {
-  mClusterLabels.reserve(32);
+  if (engaged()) {
+    mClusterLabels.reserve(32);
+  }
 }
 
 void MCLabelAccumulator::collect(const ChargePos& pos, Charge q)
@@ -52,7 +54,7 @@ void MCLabelAccumulator::collect(const ChargePos& pos, Charge q)
 
 void MCLabelAccumulator::commit(Row row, uint indexInRow, uint maxElemsPerBucket)
 {
-  if (indexInRow > maxElemsPerBucket || !engaged()) {
+  if (indexInRow >= maxElemsPerBucket || !engaged()) {
     return;
   }
 


### PR DESCRIPTION
This PR fixes a memleak and some undefined behavior in the tpc cluster finder.

@davidrohr: This patch should fix the crash on your testset. I also didn't see anymore address sanitizer warnings.