### PR TITLE
DPL Analysis: Fixed edge case for combinations from a small table

### DIFF
--- a/Framework/Core/include/Framework/ASoAHelpers.h
+++ b/Framework/Core/include/Framework/ASoAHelpers.h
@@ -47,7 +47,7 @@ struct CombinationsIndexPolicyBase {
                                                      mCurrent(tables.begin()...)
   {
     constexpr auto k = sizeof...(Ts);
-    if (((tables.size() <= k) || ...)) {
+    if (((tables.size() < k) || ...)) {
       mIsEnd = true;
     }
   }


### PR DESCRIPTION
The only one possible combination wasn't generated when table size was equal to requested combination size.

Added more tests for combinations with small tables, `continue` and `break`.