### PR TITLE
[its-GPU] Protect reset method in case of uninitialised Vectors

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/cuda/include/ITStrackingCUDA/Vector.h
+++ b/Detectors/ITSMFT/ITS/tracking/cuda/include/ITStrackingCUDA/Vector.h
@@ -203,17 +203,18 @@ void Vector<T>::reset(const T* const source, const int size, const int initialSi
     if (mArrayPointer != nullptr) {
       Utils::Host::gpuFree(mArrayPointer);
     }
-
     Utils::Host::gpuMalloc(reinterpret_cast<void**>(&mArrayPointer), size * sizeof(T));
     mCapacity = size;
   }
 
   if (source != nullptr) {
-
     Utils::Host::gpuMemcpyHostToDevice(mArrayPointer, source, size * sizeof(T));
     Utils::Host::gpuMemcpyHostToDevice(mDeviceSize, &size, sizeof(int));
 
   } else {
+    if (mDeviceSize == nullptr) {
+      Utils::Host::gpuMalloc(reinterpret_cast<void**>(&mDeviceSize), sizeof(int));
+    }
     Utils::Host::gpuMemcpyHostToDevice(mDeviceSize, &initialSize, sizeof(int));
   }
 }


### PR DESCRIPTION
@mpuccio this protects the `reset` calls on `Vector`s that did not allocate GPU memory at construction time.
From this, running the `cuda-memcheck o2-its-reco-workflow --trackerCA --gpuDevice=2` or steering macro you should spot the next error.