### PR TITLE
DPL workflow creation: pass presence of --help

### DIFF
--- a/Framework/Core/include/Framework/ConfigContext.h
+++ b/Framework/Core/include/Framework/ConfigContext.h
@@ -24,12 +24,17 @@ namespace framework
 class ConfigContext
 {
  public:
-  ConfigContext(ConfigParamRegistry& options) : mOptions{options} {}
+  ConfigContext(ConfigParamRegistry& options, int argc, char** argv) : mOptions{options}, mArgc{argc}, mArgv{argv} {}
 
   ConfigParamRegistry& options() const { return mOptions; }
+  int argc() const { return mArgc; }
+  char* const* const argv() const { return mArgv; }
 
  private:
   ConfigParamRegistry& mOptions;
+  // additionaly keep information about the original command line
+  int mArgc = 0;
+  char** mArgv = nullptr;
 };
 
 } // namespace framework

--- a/Framework/Core/include/Framework/runDataProcessing.h
+++ b/Framework/Core/include/Framework/runDataProcessing.h
@@ -137,7 +137,7 @@ int main(int argc, char** argv)
 
     std::unique_ptr<ParamRetriever> retriever{new BoostOptionsRetriever(workflowOptions, true, argc, argv)};
     ConfigParamRegistry workflowOptionsRegistry(std::move(retriever));
-    ConfigContext configContext{workflowOptionsRegistry};
+    ConfigContext configContext(workflowOptionsRegistry, argc, argv);
     o2::framework::WorkflowSpec specs = defineDataProcessing(configContext);
     overridePipeline(configContext, specs);
     result = doMain(argc, argv, specs, channelPolicies, completionPolicies, dispatchPolicies, workflowOptions, configContext);

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -666,7 +666,7 @@ struct DataMatcherId {
 
 std::tuple<std::vector<InputSpec>, std::vector<unsigned char>> WorkflowHelpers::analyzeOutputs(WorkflowSpec const& workflow)
 {
-  LOG(INFO) << "Analyzing OutputSpecs";
+  LOG(DEBUG) << "Analyzing OutputSpecs";
 
   // compute total number of input/output
   size_t totalInputs = 0;

--- a/Framework/Core/test/benchmark_WorkflowHelpers.cxx
+++ b/Framework/Core/test/benchmark_WorkflowHelpers.cxx
@@ -25,7 +25,7 @@ std::unique_ptr<ConfigContext> makeEmptyConfigContext()
   //        either owns or shares ownership of the registry.
   static std::unique_ptr<ParamRetriever> retriever(new SimpleOptionsRetriever);
   static ConfigParamRegistry registry{std::move(retriever)};
-  auto context = std::make_unique<ConfigContext>(registry);
+  auto context = std::make_unique<ConfigContext>(registry, 0, nullptr);
   return context;
 }
 

--- a/Framework/Core/test/test_WorkflowHelpers.cxx
+++ b/Framework/Core/test/test_WorkflowHelpers.cxx
@@ -30,7 +30,7 @@ std::unique_ptr<ConfigContext> makeEmptyConfigContext()
   //        either owns or shares ownership of the registry.
   static std::unique_ptr<ParamRetriever> retriever(new SimpleOptionsRetriever);
   static ConfigParamRegistry registry{std::move(retriever)};
-  auto context = std::make_unique<ConfigContext>(registry);
+  auto context = std::make_unique<ConfigContext>(registry, 0, nullptr);
   return context;
 }
 

--- a/Steer/DigitizerWorkflow/src/SimReaderSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/SimReaderSpec.cxx
@@ -63,7 +63,7 @@ DataProcessorSpec getSimReaderSpec(int fanoutsize, const std::vector<std::string
     if (size < tpcinvocations) {
       for (int k = 0; k < tpcinvocations - size; ++k) {
         tpcsectormessages->operator[](i).emplace_back(-2); // -2 is NOP
-        LOG(INFO) << "ADDING NOP TO CHANNEL " << i << "\n";
+        LOG(DEBUG) << "ADDING NOP TO CHANNEL " << i;
       }
       assert(tpcsectormessages->operator[](i).size() == tpcinvocations);
     }

--- a/Steer/DigitizerWorkflow/src/TPCDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TPCDigitizerSpec.cxx
@@ -345,7 +345,7 @@ o2::framework::DataProcessorSpec getTPCDigitizerSpec(int channel, bool writeGRP)
   outputs.emplace_back("TPC", "COMMONMODE", static_cast<SubSpecificationType>(channel), Lifetime::Timeframe);
   if (writeGRP) {
     outputs.emplace_back("TPC", "ROMode", 0, Lifetime::Timeframe);
-    LOG(INFO) << "TPC: Channel " << channel << " will supply ROMode";
+    LOG(DEBUG) << "TPC: Channel " << channel << " will supply ROMode";
   }
 
   return DataProcessorSpec{


### PR DESCRIPTION
So far, during topology construction, we could not know
if the command line was invoked merely to list program options.
This is problematic since topology construction might need to
do some computation / read files / etc. which influence the workflow.
In case of --help this should not be needed.

This commit tries to address this issue by adding additional information
to the ConfigContext which is passed to the workflow construction function.

The principle is applied to the digitizer workflow, which for the first
time prints out the expected output when invoked with
`o2-sim-digitizer-workflow --help` (up until now one needed a GRP file
for this to work).