### PR TITLE
GPU: Add some more simple transformation functions to TPCFastTransform

### DIFF
--- a/GPU/TPCFastTransformation/TPCFastTransform.h
+++ b/GPU/TPCFastTransformation/TPCFastTransform.h
@@ -149,6 +149,8 @@ class TPCFastTransform : public FlatObject
 
   GPUd() float convTimeToZinTimeFrame(int slice, float time, float maxTimeBin) const;
   GPUd() float convZtoTimeInTimeFrame(float z, float maxTimeBin) const;
+  GPUd() float convDeltaTimeToDeltaZinTimeFrame(int slice, float deltaTime) const;
+  GPUd() float convDeltaZtoDeltaTimeInTimeFrame(int slice, float deltaZ) const;
 
   GPUd() void getTOFcorrection(int slice, int row, float x, float y, float z, float& dz) const;
 
@@ -408,6 +410,18 @@ GPUdi() float TPCFastTransform::convZtoTimeInTimeFrame(float z, float maxTimeBin
   z = z - getGeometry().getTPCalignmentZ(); // global TPC alignment
   float v = fabs(z);
   return mT0 + maxTimeBin + (v - mLdriftCorr) / mVdrift;
+}
+
+GPUdi() float TPCFastTransform::convDeltaTimeToDeltaZinTimeFrame(int slice, float deltaTime) const
+{
+  float deltaZ = deltaTime * mVdrift;
+  return slice < getGeometry().getNumberOfSlicesA() ? -deltaZ : deltaZ;
+}
+
+GPUdi() float TPCFastTransform::convDeltaZtoDeltaTimeInTimeFrame(int slice, float deltaZ) const
+{
+  float deltaT = deltaZ / mVdrift;
+  return slice < getGeometry().getNumberOfSlicesA() ? -deltaT : deltaT;
 }
 
 GPUdi() float TPCFastTransform::getLastCalibratedTimeBin(int slice) const


### PR DESCRIPTION
@sgorbuno : I have added 2 additional simple transformation functions, which I need for convenience.
I was wondering why you have the division / mVDrift. Perhaps it would make sense to compute mVDriftInverse ahead of time, and store it in the object.