### PR TITLE
Optimization of storing rare cluster patterns

### DIFF
--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/ClusterPattern.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/ClusterPattern.h
@@ -41,6 +41,8 @@ class ClusterPattern
   ClusterPattern();
   /// Standard constructor
   ClusterPattern(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes]);
+  /// Constructor from a vector with cluster patterns
+  ClusterPattern(std::vector<unsigned char>::iterator& patternIter);
   /// Maximum number of bytes for the cluster puttern + 2 bytes respectively for the number of rows and columns of the bounding box
   static constexpr int kExtendedPatternBytes = Cluster::kMaxPatternBytes + 2;
   /// Returns the pattern

--- a/DataFormats/Detectors/ITSMFT/common/src/ClusterPattern.cxx
+++ b/DataFormats/Detectors/ITSMFT/common/src/ClusterPattern.cxx
@@ -29,6 +29,18 @@ ClusterPattern::ClusterPattern(int nRow, int nCol, const unsigned char patt[Clus
   setPattern(nRow, nCol, patt);
 }
 
+ClusterPattern::ClusterPattern(std::vector<unsigned char>::iterator& pattIt)
+{
+  mBitmap[0] = *pattIt++;
+  mBitmap[1] = *pattIt++;
+  int nbits = mBitmap[0] * mBitmap[1];
+  int nBytes = nbits / 8;
+  if (((nbits) % 8) != 0)
+    nBytes++;
+  memcpy(&mBitmap[2], &(*pattIt), nBytes);
+  pattIt += nBytes;
+}
+
 unsigned char ClusterPattern::getByte(int n) const
 {
   if (n < 0 || n > Cluster::kMaxPatternBytes + 1) {

--- a/Detectors/ITSMFT/ITS/macros/test/CheckCOG.C
+++ b/Detectors/ITSMFT/ITS/macros/test/CheckCOG.C
@@ -46,7 +46,7 @@ void CheckCOG(std::string clusfile = "o2clus_its.root", std::string inputGeom = 
   clusTree->SetBranchAddress("ITSCluster", &clusArr);
   std::vector<CompClusterExt>* compclusArr = nullptr;
   clusTree->SetBranchAddress("ITSClusterComp", &compclusArr);
-  std::vector<o2::itsmft::ClusterPattern>* patternsPtr = nullptr;
+  std::vector<unsigned char>* patternsPtr = nullptr;
   auto pattBranch = clusTree->GetBranch("ITSClusterPatt");
   if (pattBranch) {
     pattBranch->SetAddress(&patternsPtr);
@@ -80,7 +80,7 @@ void CheckCOG(std::string clusfile = "o2clus_its.root", std::string inputGeom = 
     }
     printf("processing cluster event %d\n", ievC);
 
-    int pattIdx = 0;
+    auto pattIdx = patternsPtr->begin();
     for (int i = 0; i < nc; i++) {
       // cluster is in tracking coordinates always
       Cluster& c = (*clusArr)[i];
@@ -107,7 +107,17 @@ void CheckCOG(std::string clusfile = "o2clus_its.root", std::string inputGeom = 
 
       if (dict.IsGroup(cComp.getPatternID())) {
         if (patternsPtr) { // Restore the full pixel pattern information from the auxiliary branch
-          auto patt = (*patternsPtr)[pattIdx++];
+          auto rowSpan = *pattIdx++;
+          auto colSpan = *pattIdx++;
+
+          int nBytes = rowSpan * colSpan / 8;
+          if (((rowSpan * colSpan) % 8) != 0)
+            nBytes++;
+          unsigned char tmp[Cluster::kMaxPatternBytes];
+          for (int i = 0; i < nBytes; i++)
+            tmp[i] = *pattIdx++;
+
+          o2::itsmft::ClusterPattern patt(rowSpan, colSpan, tmp);
           auto locCl = dict.getClusterCoordinates(cComp, patt);
           dx = (locC.X() - locCl.X()) * 10000;
           dz = (locC.Z() - locCl.Z()) * 10000;

--- a/Detectors/ITSMFT/ITS/macros/test/CheckCOG.C
+++ b/Detectors/ITSMFT/ITS/macros/test/CheckCOG.C
@@ -107,17 +107,7 @@ void CheckCOG(std::string clusfile = "o2clus_its.root", std::string inputGeom = 
 
       if (dict.IsGroup(cComp.getPatternID())) {
         if (patternsPtr) { // Restore the full pixel pattern information from the auxiliary branch
-          auto rowSpan = *pattIdx++;
-          auto colSpan = *pattIdx++;
-
-          int nBytes = rowSpan * colSpan / 8;
-          if (((rowSpan * colSpan) % 8) != 0)
-            nBytes++;
-          unsigned char tmp[Cluster::kMaxPatternBytes];
-          for (int i = 0; i < nBytes; i++)
-            tmp[i] = *pattIdx++;
-
-          o2::itsmft::ClusterPattern patt(rowSpan, colSpan, tmp);
+          o2::itsmft::ClusterPattern patt(pattIdx);
           auto locCl = dict.getClusterCoordinates(cComp, patt);
           dx = (locC.X() - locCl.X()) * 10000;
           dz = (locC.Z() - locCl.Z()) * 10000;

--- a/Detectors/ITSMFT/ITS/macros/test/CheckCOG.C
+++ b/Detectors/ITSMFT/ITS/macros/test/CheckCOG.C
@@ -46,7 +46,7 @@ void CheckCOG(std::string clusfile = "o2clus_its.root", std::string inputGeom = 
   clusTree->SetBranchAddress("ITSCluster", &clusArr);
   std::vector<CompClusterExt>* compclusArr = nullptr;
   clusTree->SetBranchAddress("ITSClusterComp", &compclusArr);
-  std::map<int, o2::itsmft::ClusterPattern>* patternsPtr = nullptr;
+  std::vector<o2::itsmft::ClusterPattern>* patternsPtr = nullptr;
   auto pattBranch = clusTree->GetBranch("ITSClusterPatt");
   if (pattBranch) {
     pattBranch->SetAddress(&patternsPtr);
@@ -80,12 +80,13 @@ void CheckCOG(std::string clusfile = "o2clus_its.root", std::string inputGeom = 
     }
     printf("processing cluster event %d\n", ievC);
 
-    while (nc--) {
+    int pattIdx = 0;
+    for (int i = 0; i < nc; i++) {
       // cluster is in tracking coordinates always
-      Cluster& c = (*clusArr)[nc];
+      Cluster& c = (*clusArr)[i];
       const auto locC = c.getXYZLoc(*gman); // convert from tracking to local frame
 
-      CompClusterExt& cComp = (*compclusArr)[nc];
+      CompClusterExt& cComp = (*compclusArr)[i];
       Point3D<float> locComp = dict.getClusterCoordinates(cComp);
 
       float xComp = locComp.X();
@@ -106,7 +107,7 @@ void CheckCOG(std::string clusfile = "o2clus_its.root", std::string inputGeom = 
 
       if (dict.IsGroup(cComp.getPatternID())) {
         if (patternsPtr) { // Restore the full pixel pattern information from the auxiliary branch
-          auto patt = (*patternsPtr)[nc];
+          auto patt = (*patternsPtr)[pattIdx++];
           auto locCl = dict.getClusterCoordinates(cComp, patt);
           dx = (locC.X() - locCl.X()) * 10000;
           dz = (locC.Z() - locCl.Z()) * 10000;

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/ClustererTask.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/ClustererTask.h
@@ -84,7 +84,7 @@ class ClustererTask
 
   MCTruth mClsLabels;               //! MC labels
 
-  std::vector<o2::itsmft::ClusterPattern> mPatterns;
+  std::vector<unsigned char> mPatterns;
 
   ClassDefNV(ClustererTask, 2);
 };

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/ClustererTask.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/ClustererTask.h
@@ -84,7 +84,7 @@ class ClustererTask
 
   MCTruth mClsLabels;               //! MC labels
 
-  std::vector<o2::itsmft::ClusterTopology> mPatterns;
+  std::vector<o2::itsmft::ClusterPattern> mPatterns;
 
   ClassDefNV(ClustererTask, 2);
 };

--- a/Detectors/ITSMFT/ITS/reconstruction/src/ClustererTask.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/ClustererTask.cxx
@@ -135,11 +135,8 @@ void ClustererTask::run(const std::string inpName, const std::string outName)
       mClusterer.process(*mReaderMC.get(), &mFullClus, &mCompClus, &mClsLabels, &mROFRecVec);
     }
 
-    // This conversion vector -> map is just for the convenience of "offline" analyses
-    std::map<int, o2::itsmft::ClusterPattern> map;
     if (mClusterer.getPatterns()) {
-      o2::itsmft::ClusterTopology::makeRareTopologyMap(mPatterns, map);
-      outTree.Branch("ITSClusterPatt", &map);
+      outTree.Branch("ITSClusterPatt", &mPatterns);
     } else {
       LOG(INFO) << Class()->GetName() << " output of cluster patterns is not requested";
     }
@@ -195,11 +192,8 @@ void ClustererTask::writeTree(std::string basename, int i)
     LOG(INFO) << Class()->GetName() << " output of compact clusters is not requested";
   }
 
-  // This conversion vector -> map is just for the convenience of "offline" analyses
-  std::map<int, o2::itsmft::ClusterPattern> map;
   if (mClusterer.getPatterns()) {
-    o2::itsmft::ClusterTopology::makeRareTopologyMap(mPatterns, map);
-    outTree.Branch("ITSClusterPatt", &map);
+    outTree.Branch("ITSClusterPatt", &mPatterns);
   } else {
     LOG(INFO) << Class()->GetName() << " output of cluster patterns is not requested";
   }

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ClusterWriterSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ClusterWriterSpec.h
@@ -14,6 +14,7 @@
 #define O2_ITS_CLUSTERWRITER
 
 #include "TFile.h"
+#include "TTree.h"
 
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
@@ -37,6 +38,7 @@ class ClusterWriter : public Task
   int mState = 0;
   bool mUseMC = true;
   std::unique_ptr<TFile> mFile = nullptr;
+  std::unique_ptr<TTree> mTree = nullptr;
 };
 
 /// create a processor spec

--- a/Detectors/ITSMFT/ITS/workflow/src/ClusterWriterSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ClusterWriterSpec.cxx
@@ -11,7 +11,6 @@
 /// @file   ClusterWriterSpec.cxx
 
 #include <vector>
-#include <map>
 
 #include "TTree.h"
 
@@ -19,7 +18,7 @@
 #include "Framework/ConfigParamRegistry.h"
 #include "ITSWorkflow/ClusterWriterSpec.h"
 #include "DataFormatsITSMFT/CompCluster.h"
-#include "DataFormatsITSMFT/ClusterTopology.h"
+#include "DataFormatsITSMFT/ClusterPattern.h"
 #include "DataFormatsITSMFT/Cluster.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
@@ -48,7 +47,7 @@ void ClusterWriter::run(ProcessingContext& pc)
     return;
 
   auto compClusters = pc.inputs().get<const std::vector<o2::itsmft::CompClusterExt>>("compClusters");
-  auto patterns = pc.inputs().get<const std::vector<o2::itsmft::ClusterTopology>>("patterns");
+  auto patterns = pc.inputs().get<const std::vector<o2::itsmft::ClusterPattern>>("patterns");
   auto clusters = pc.inputs().get<const std::vector<o2::itsmft::Cluster>>("clusters");
   auto rofs = pc.inputs().get<const std::vector<o2::itsmft::ROFRecord>>("ROframes");
   auto* rofsPtr = &rofs;
@@ -60,13 +59,9 @@ void ClusterWriter::run(ProcessingContext& pc)
   LOG(INFO) << "ITSClusterWriter pulled " << clusters.size() << " clusters, in "
             << rofs.size() << " RO frames";
 
-  // This conversion vector -> map is just for the convenience of "offline" analyses
-  std::map<int, o2::itsmft::ClusterPattern> map;
-  o2::itsmft::ClusterTopology::makeRareTopologyMap(patterns, map);
-
   TTree tree("o2sim", "Tree with ITS clusters");
   tree.Branch("ITSClusterComp", &compClusters);
-  tree.Branch("ITSClusterPatt", &map);
+  tree.Branch("ITSClusterPatt", &patterns);
   tree.Branch("ITSCluster", &clusters);
   tree.Branch("ITSClustersROF", &rofsPtr);
 

--- a/Detectors/ITSMFT/ITS/workflow/src/ClusterWriterSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ClusterWriterSpec.cxx
@@ -18,7 +18,6 @@
 #include "Framework/ConfigParamRegistry.h"
 #include "ITSWorkflow/ClusterWriterSpec.h"
 #include "DataFormatsITSMFT/CompCluster.h"
-#include "DataFormatsITSMFT/ClusterPattern.h"
 #include "DataFormatsITSMFT/Cluster.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
@@ -47,7 +46,7 @@ void ClusterWriter::run(ProcessingContext& pc)
     return;
 
   auto compClusters = pc.inputs().get<const std::vector<o2::itsmft::CompClusterExt>>("compClusters");
-  auto patterns = pc.inputs().get<const std::vector<o2::itsmft::ClusterPattern>>("patterns");
+  auto pspan = pc.inputs().get<gsl::span<unsigned char>>("patterns");
   auto clusters = pc.inputs().get<const std::vector<o2::itsmft::Cluster>>("clusters");
   auto rofs = pc.inputs().get<const std::vector<o2::itsmft::ROFRecord>>("ROframes");
   auto* rofsPtr = &rofs;
@@ -61,6 +60,7 @@ void ClusterWriter::run(ProcessingContext& pc)
 
   TTree tree("o2sim", "Tree with ITS clusters");
   tree.Branch("ITSClusterComp", &compClusters);
+  std::vector<unsigned char> patterns(pspan.begin(), pspan.end());
   tree.Branch("ITSClusterPatt", &patterns);
   tree.Branch("ITSCluster", &clusters);
   tree.Branch("ITSClustersROF", &rofsPtr);

--- a/Detectors/ITSMFT/ITS/workflow/src/ClustererSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ClustererSpec.cxx
@@ -18,7 +18,6 @@
 #include "DataFormatsITSMFT/Digit.h"
 #include "ITSMFTReconstruction/ChipMappingITS.h"
 #include "DataFormatsITSMFT/CompCluster.h"
-#include "DataFormatsITSMFT/ClusterTopology.h"
 #include "DataFormatsITSMFT/Cluster.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
@@ -111,7 +110,7 @@ void ClustererDPL::run(ProcessingContext& pc)
   std::vector<o2::itsmft::CompClusterExt> compClusters;
   std::vector<o2::itsmft::Cluster> clusters;
   std::vector<o2::itsmft::ROFRecord> clusterROframes; // To be filled in future
-  std::vector<o2::itsmft::ClusterTopology> patterns;
+  std::vector<o2::itsmft::ClusterPattern> patterns;
 
   if (mCompactClusters) {
     LOG(INFO) << "Will produce compact clusters";

--- a/Detectors/ITSMFT/ITS/workflow/src/ClustererSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ClustererSpec.cxx
@@ -110,7 +110,7 @@ void ClustererDPL::run(ProcessingContext& pc)
   std::vector<o2::itsmft::CompClusterExt> compClusters;
   std::vector<o2::itsmft::Cluster> clusters;
   std::vector<o2::itsmft::ROFRecord> clusterROframes; // To be filled in future
-  std::vector<o2::itsmft::ClusterPattern> patterns;
+  std::vector<unsigned char> patterns;
 
   if (mCompactClusters) {
     LOG(INFO) << "Will produce compact clusters";

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
@@ -106,8 +106,8 @@ class Clusterer
     mPattIdConverter.loadDictionary(fileName);
   }
 
-  void setPatterns(std::vector<o2::itsmft::ClusterTopology>* patt) { mPatterns = patt; }
-  std::vector<o2::itsmft::ClusterTopology>* getPatterns() const { return mPatterns; }
+  void setPatterns(std::vector<o2::itsmft::ClusterPattern>* patt) { mPatterns = patt; }
+  std::vector<o2::itsmft::ClusterPattern>* getPatterns() const { return mPatterns; }
 
  private:
   void initChip(UInt_t first);
@@ -235,7 +235,7 @@ class Clusterer
 
   LookUp mPattIdConverter; //! Convert the cluster topology to the corresponding entry in the dictionary.
 
-  std::vector<o2::itsmft::ClusterTopology>* mPatterns = nullptr; // Not owned
+  std::vector<o2::itsmft::ClusterPattern>* mPatterns = nullptr; // Not owned
 
 #ifdef _PERFORM_TIMING_
   TStopwatch mTimer;

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
@@ -106,8 +106,8 @@ class Clusterer
     mPattIdConverter.loadDictionary(fileName);
   }
 
-  void setPatterns(std::vector<o2::itsmft::ClusterPattern>* patt) { mPatterns = patt; }
-  std::vector<o2::itsmft::ClusterPattern>* getPatterns() const { return mPatterns; }
+  void setPatterns(std::vector<unsigned char>* patt) { mPatterns = patt; }
+  std::vector<unsigned char>* getPatterns() const { return mPatterns; }
 
  private:
   void initChip(UInt_t first);
@@ -235,7 +235,7 @@ class Clusterer
 
   LookUp mPattIdConverter; //! Convert the cluster topology to the corresponding entry in the dictionary.
 
-  std::vector<o2::itsmft::ClusterPattern>* mPatterns = nullptr; // Not owned
+  std::vector<unsigned char>* mPatterns = nullptr; // Not owned
 
 #ifdef _PERFORM_TIMING_
   TStopwatch mTimer;

--- a/Detectors/ITSMFT/common/reconstruction/src/Clusterer.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/Clusterer.cxx
@@ -308,7 +308,12 @@ void Clusterer::finishChip(std::vector<Cluster>* fullClus, std::vector<CompClust
         rowMin += round(xCOG);
         colMin += round(zCOG);
         if (mPatterns) {
-          mPatterns->emplace_back(rowSpan, colSpan, patt);
+          mPatterns->emplace_back((unsigned char)rowSpan);
+          mPatterns->emplace_back((unsigned char)colSpan);
+          int nBytes = rowSpan * colSpan / 8;
+          if (((rowSpan * colSpan) % 8) != 0)
+            nBytes++;
+          mPatterns->insert(mPatterns->end(), std::begin(patt), std::begin(patt) + nBytes);
         }
       }
       compClus->emplace_back(rowMin, colMin, pattID, mChipData->getChipID());

--- a/Detectors/ITSMFT/common/reconstruction/src/Clusterer.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/Clusterer.cxx
@@ -309,7 +309,6 @@ void Clusterer::finishChip(std::vector<Cluster>* fullClus, std::vector<CompClust
         colMin += round(zCOG);
         if (mPatterns) {
           mPatterns->emplace_back(rowSpan, colSpan, patt);
-          mPatterns->back().setHash(mClustersCount);
         }
       }
       compClus->emplace_back(rowMin, colMin, pattID, mChipData->getChipID());


### PR DESCRIPTION
This PR is intended to reduce the RAM (and disk) usage when working with preserved rare cluster patterns. If I am not wrong, the RAM needed for the rare patterns should already be reduced by a factor ~10 with respect to the PR #3183 (for PbPb).

The information about the rare patterns is stored in std::vector\<unsigned char\>.
For the moment, the changes are backward compatible.

Possible next steps:
1) Build the topology dictionary from compact clusters and stored patterns.
2) Drop the "full" clusters.

@shahor02 @lbariogl  Could you have a look please ?
