### PR TITLE
DPL: Adding helper to iteratate over all parts of all input routes

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -154,6 +154,7 @@ foreach(t
         HistogramRegistry
         InfoLogger
         InputRecord
+        InputRecordWalker
         InputSpan
         Kernels
         LogParsingHelpers

--- a/Framework/Core/include/Framework/InputRecordWalker.h
+++ b/Framework/Core/include/Framework/InputRecordWalker.h
@@ -1,0 +1,177 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef FRAMEWORK_INPUTRECORDWALKER_H
+#define FRAMEWORK_INPUTRECORDWALKER_H
+
+/// @file   InputRecordWalker.h
+/// @author Matthias Richter
+/// @since  2020-03-25
+/// @brief  A helper class to iteratate over all parts of all input routes
+
+#include "Framework/InputRecord.h"
+
+namespace o2::framework
+{
+
+/// @class InputRecordWalker
+/// @brief A helper class to iteratate over all parts of all input routes
+///
+/// Each input route can have multiple parts per input route and computation.
+/// This class allows simple iteration over all parts available in the computation.
+/// Optionally, a filter can be used to define valid parts and ignore all parts not
+/// matching the filter.
+///
+/// The iterator has DataRef as value type.
+///
+/// Usage:
+///   // 'inputs' refers to the DPL InputRecord instance returned by
+///   // ProcessingContext::inputs()
+///
+///   // iterate over all parts
+///   for (auto const& ref : InputRecordWalker(inputs)) {
+///     // do something with the data described by the DataRef object, e.g.
+///     auto data = inputs.get<TYPE>(ref)
+///   }
+///
+///   // iterate with a filter
+///   std::vector<InputSpec> filter{
+///     {"tpc", "TPC", "SOMEDATA", 0, Lifetime::Timeframe},
+///     {"its", ConcreteDataTypeMatcher{"ITS", "SOMEDATA"}, Lifetime::Timeframe},
+///   };
+///   for (auto const& ref : InputRecordWalker(inputs, filter)) {
+///     // do something with the data
+///   }
+class InputRecordWalker
+{
+ public:
+  InputRecordWalker() = delete;
+  InputRecordWalker(InputRecord& record, std::vector<InputSpec> filterSpecs = {}) : mRecord(record), mFilterSpecs(filterSpecs) {}
+
+  template <typename T>
+  using IteratorBase = std::iterator<std::forward_iterator_tag, T>;
+
+  /// Iterator implementation
+  /// Supports the following operations:
+  /// - increment (there is no decrement, its not a bidirectional parser)
+  /// - dereference operator returns @a RawDataHeaderInfo as common header
+  template <typename T>
+  class Iterator : public IteratorBase<T>
+  {
+   public:
+    using self_type = Iterator;
+    using value_type = typename IteratorBase<T>::value_type;
+    using reference = typename IteratorBase<T>::reference;
+    using pointer = typename IteratorBase<T>::pointer;
+    // the iterator over the input routes
+    using input_iterator = decltype(std::declval<InputRecord>().begin());
+
+    Iterator() = delete;
+
+    Iterator(InputRecord& parent, input_iterator it, input_iterator end, std::vector<InputSpec> const& filterSpecs)
+      : mParent(parent), mInputIterator(it), mEnd(end), mCurrent(mInputIterator.begin()), mFilterSpecs(filterSpecs)
+    {
+      next(true);
+    }
+
+    ~Iterator() = default;
+
+    // prefix increment
+    self_type& operator++()
+    {
+      next();
+      return *this;
+    }
+    // postfix increment
+    self_type operator++(int /*unused*/)
+    {
+      self_type copy(*this);
+      operator++();
+      return copy;
+    }
+    // return reference
+    reference operator*()
+    {
+      return *mCurrent;
+    }
+    // comparison
+    bool operator==(const self_type& other) const
+    {
+      bool result = mInputIterator == other.mInputIterator;
+      result = result && mCurrent == other.mCurrent;
+      return result;
+    }
+
+    bool operator!=(const self_type& rh) const
+    {
+      return not operator==(rh);
+    }
+
+   private:
+    // the iterator over the parts in one channel
+    using part_iterator = typename input_iterator::const_iterator;
+
+    bool next(bool isInitialPart = false)
+    {
+      while (mInputIterator != mEnd) {
+        while (mCurrent != mInputIterator.end()) {
+          // increment on the level of one input
+          if (!isInitialPart && (mCurrent == mInputIterator.end() || ++mCurrent == mInputIterator.end())) {
+            // no more parts, go to next input
+            break;
+          }
+          isInitialPart = false;
+          // check filter rules
+          if (mFilterSpecs.size() > 0) {
+            bool isSelected = false;
+            for (auto const& spec : mFilterSpecs) {
+              if ((isSelected = DataRefUtils::match(*mCurrent, spec)) == true) {
+                break;
+              }
+            }
+            if (!isSelected) {
+              continue;
+            }
+          }
+          return true;
+        }
+        ++mInputIterator;
+        mCurrent = mInputIterator.begin();
+        isInitialPart = true;
+      } // end loop over record
+      return false;
+    }
+
+    InputRecord& mParent;
+    input_iterator mInputIterator;
+    input_iterator mEnd;
+    part_iterator mCurrent;
+    std::vector<InputSpec> const& mFilterSpecs;
+  };
+
+  using const_iterator = Iterator<DataRef const>;
+
+  const_iterator begin() const
+  {
+    return const_iterator(mRecord, mRecord.begin(), mRecord.end(), mFilterSpecs);
+  }
+
+  const_iterator end() const
+  {
+    return const_iterator(mRecord, mRecord.end(), mRecord.end(), mFilterSpecs);
+  }
+
+ private:
+  InputRecord& mRecord;
+  std::vector<InputSpec> mFilterSpecs;
+};
+
+} // namespace o2::framework
+
+#endif // FRAMEWORK_INPUTRECORDWALKER_H

--- a/Framework/Core/test/test_InputRecordWalker.cxx
+++ b/Framework/Core/test/test_InputRecordWalker.cxx
@@ -1,0 +1,169 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test Framework InputRecordWalker
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include "Framework/InputRecord.h"
+#include "Framework/InputRecordWalker.h"
+#include "Framework/WorkflowSpec.h" // o2::framework::select
+#include "Framework/DataRefUtils.h"
+#include "Headers/DataHeader.h"
+#include "Headers/Stack.h"
+#include <boost/test/unit_test.hpp>
+#include <vector>
+#include <memory>
+#include <iostream>
+#include <string>
+#include <unordered_map>
+
+using namespace o2::framework;
+using DataHeader = o2::header::DataHeader;
+using Stack = o2::header::Stack;
+
+// simple helper struct to keep the InputRecord and ownership of messages
+struct DataSet {
+  // not nice with the double vector but for quick unit test ok
+  using MessageSet = std::vector<std::unique_ptr<std::vector<char>>>;
+  using TaggedSet = std::pair<o2::header::DataOrigin, MessageSet>;
+  using Messages = std::vector<TaggedSet>;
+  using CheckType = std::vector<std::string>;
+  DataSet(std::vector<InputRoute>&& s, Messages&& m, CheckType&& v)
+    : schema{std::move(s)}, messages{std::move(m)}, record{schema, {[this](size_t i, size_t part) {
+                                                                      BOOST_REQUIRE(i < this->messages.size());
+                                                                      BOOST_REQUIRE(part < this->messages[i].second.size() / 2);
+                                                                      auto header = static_cast<char const*>(this->messages[i].second.at(2 * part)->data());
+                                                                      auto payload = static_cast<char const*>(this->messages[i].second.at(2 * part + 1)->data());
+                                                                      return DataRef{nullptr, header, payload};
+                                                                    },
+                                                                    [this](size_t i) { return i < this->messages.size() ? messages[i].second.size() / 2 : 0; }, this->messages.size()}},
+      values{std::move(v)}
+  {
+    BOOST_REQUIRE(messages.size() == schema.size());
+  }
+
+  std::vector<InputRoute> schema;
+  Messages messages;
+  InputRecord record;
+  CheckType values;
+};
+
+DataSet createData()
+{
+  // Create the routes we want for the InputRecord
+  std::vector<InputSpec> inputspecs = {
+    InputSpec{"tpc", "TPC", "SOMEDATA", 0, Lifetime::Timeframe},
+    InputSpec{"its", ConcreteDataTypeMatcher{"ITS", "SOMEDATA"}, Lifetime::Timeframe},
+    InputSpec{"tof", "TOF", "SOMEDATA", 1, Lifetime::Timeframe}};
+
+  size_t i = 0;
+  auto createRoute = [&i](const char* source, InputSpec& spec) {
+    return InputRoute{
+      spec,
+      i++,
+      source};
+  };
+
+  std::vector<InputRoute> schema = {
+    createRoute("tpc_source", inputspecs[0]),
+    createRoute("its_source", inputspecs[1]),
+    createRoute("tof_source", inputspecs[2])};
+
+  decltype(DataSet::values) checkValues;
+  DataSet::Messages messages;
+
+  auto createMessage = [&messages, &checkValues](DataHeader dh) {
+    checkValues.emplace_back(dh.dataOrigin.as<std::string>() + "_" + dh.dataDescription.as<std::string>() + "_" + std::to_string(dh.subSpecification));
+    std::string const& data = checkValues.back();
+    dh.payloadSize = data.size();
+    DataProcessingHeader dph{0, 1};
+    Stack stack{dh, dph};
+    auto it = messages.begin(), end = messages.end();
+    for (; it != end; ++it) {
+      if (it->first == dh.dataOrigin) {
+        break;
+      }
+    }
+    if (it == end) {
+      messages.resize(messages.size() + 1);
+      it = messages.end() - 1;
+      it->first = dh.dataOrigin;
+    }
+    auto& routemessages = it->second;
+    routemessages.emplace_back(std::make_unique<std::vector<char>>(stack.size()));
+    memcpy(routemessages.back()->data(), stack.data(), routemessages.back()->size());
+    routemessages.emplace_back(std::make_unique<std::vector<char>>(dh.payloadSize));
+    memcpy(routemessages.back()->data(), data.data(), routemessages.back()->size());
+  };
+
+  // we create message for the 3 input routes, the messages have different page size
+  // and the second messages has 3 parts, each with the same page size
+  // the test value is written as payload after the RDH and all values are cached for
+  // later checking when parsing the data set
+  DataHeader dh1;
+  dh1.dataDescription = "SOMEDATA";
+  dh1.dataOrigin = "TPC";
+  dh1.subSpecification = 0;
+  dh1.payloadSerializationMethod = o2::header::gSerializationMethodNone;
+  DataHeader dh2;
+  dh2.dataDescription = "SOMEDATA";
+  dh2.dataOrigin = "ITS";
+  dh2.subSpecification = 0;
+  dh2.payloadSerializationMethod = o2::header::gSerializationMethodNone;
+  DataHeader dh3;
+  dh3.dataDescription = "SOMEDATA";
+  dh3.dataOrigin = "ITS";
+  dh3.subSpecification = 1;
+  dh3.payloadSerializationMethod = o2::header::gSerializationMethodNone;
+  DataHeader dh4;
+  dh4.dataDescription = "SOMEDATA";
+  dh4.dataOrigin = "TOF";
+  dh4.subSpecification = 255;
+  dh4.payloadSerializationMethod = o2::header::gSerializationMethodNone;
+  createMessage(dh1);
+  createMessage(dh2);
+  createMessage(dh3);
+  createMessage(dh4);
+
+  return {std::move(schema), std::move(messages), std::move(checkValues)};
+}
+
+BOOST_AUTO_TEST_CASE(test_DPLRawParser)
+{
+  auto dataset = createData();
+  InputRecord& inputs = dataset.record;
+  BOOST_REQUIRE(dataset.messages.size() > 0);
+  BOOST_REQUIRE(dataset.messages[0].second.at(0) != nullptr);
+  BOOST_REQUIRE(inputs.size() == 3);
+  BOOST_CHECK((*inputs.begin()).header == dataset.messages[0].second.at(0)->data());
+
+  int count = 0;
+  for (auto const& ref : InputRecordWalker(inputs)) {
+    auto const* dh = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
+    auto const data = inputs.get<std::string>(ref);
+    BOOST_CHECK(data == dataset.values[count]);
+    count++;
+  }
+  BOOST_REQUIRE(count == 4);
+
+  std::vector<InputSpec> filter{
+    {"tpc", "TPC", "SOMEDATA", 0, Lifetime::Timeframe},
+    {"its", ConcreteDataTypeMatcher{"ITS", "SOMEDATA"}, Lifetime::Timeframe},
+  };
+
+  count = 0;
+  for (auto const& ref : InputRecordWalker(inputs, filter)) {
+    auto const data = inputs.get<std::string>(ref);
+    BOOST_CHECK(data == dataset.values[count]);
+    count++;
+  }
+  BOOST_REQUIRE(count == 3);
+}


### PR DESCRIPTION
Each input route can have multiple parts per input route and computation.
Adding `InputRecordWalker` helper to allow simple iteration over all parts
available in the computation. Optionally a filter can be used to define
valid parts and ignore all parts not matching the filter.

The iterator is using DataRef as value type.

Usage
```
for (auto const& ref : InputRecordWalker(inputs)) {
  // do something with the data described by the DataRef object, e.g.
  auto data = inputs.get<TYPE>(ref)
}
```
