### PR TITLE
Naming scheme to simulation geometry / refactor TOF DPL digitizer

### DIFF
--- a/Common/SimConfig/include/SimConfig/DigiParams.h
+++ b/Common/SimConfig/include/SimConfig/DigiParams.h
@@ -21,11 +21,13 @@ namespace o2
 {
 namespace conf
 {
-// Global parameters for digitization
 
+// Global parameters for digitization
 struct DigiParams : public o2::conf::ConfigurableParamHelper<DigiParams> {
 
   std::string ccdb = "http://ccdb-test.cern.ch:8080"; // URL for CCDB acces
+  std::string digitizationgeometry = "";              // with with geometry file to digitize -> leave empty as this needs to be filled by the digitizer workflow
+  std::string grpfile = "";                           // which GRP file to use --> leave empty as this needs to be filled by the digitizer workflow
 
   O2ParamDef(DigiParams, "DigiParams");
 };

--- a/Common/Utils/include/CommonUtils/ConfigurableParam.h
+++ b/Common/Utils/include/CommonUtils/ConfigurableParam.h
@@ -180,13 +180,17 @@ class ConfigurableParam
   template <typename T>
   static void setValue(std::string const& mainkey, std::string const& subkey, T x)
   {
-    auto key = mainkey + "." + subkey;
-    if (sPtree->get_optional<std::string>(key).is_initialized()) {
-      sPtree->put(key, x);
-      auto changed = updateThroughStorageMap(mainkey, subkey, typeid(T), (void*)&x);
-      if (changed) {
-        sValueProvenanceMap->find(key)->second = kRT; // set to runtime
+    try {
+      auto key = mainkey + "." + subkey;
+      if (sPtree->get_optional<std::string>(key).is_initialized()) {
+        sPtree->put(key, x);
+        auto changed = updateThroughStorageMap(mainkey, subkey, typeid(T), (void*)&x);
+        if (changed) {
+          sValueProvenanceMap->find(key)->second = kRT; // set to runtime
+        }
       }
+    } catch (std::exception const& e) {
+      std::cerr << "Error in setValue (T) " << e.what() << "\n";
     }
   }
 
@@ -194,12 +198,16 @@ class ConfigurableParam
   // which means that the type will be converted internally
   static void setValue(std::string const& key, std::string const& valuestring)
   {
-    if (sPtree->get_optional<std::string>(key).is_initialized()) {
-      sPtree->put(key, valuestring);
-      auto changed = updateThroughStorageMapWithConversion(key, valuestring);
-      if (changed) {
-        sValueProvenanceMap->find(key)->second = kRT; // set to runtime
+    try {
+      if (sPtree->get_optional<std::string>(key).is_initialized()) {
+        sPtree->put(key, valuestring);
+        auto changed = updateThroughStorageMapWithConversion(key, valuestring);
+        if (changed) {
+          sValueProvenanceMap->find(key)->second = kRT; // set to runtime
+        }
       }
+    } catch (std::exception const& e) {
+      std::cerr << "Error in setValue (string) " << e.what() << "\n";
     }
   }
 
@@ -207,7 +215,7 @@ class ConfigurableParam
   static void setArrayValue(const std::string&, const std::string&);
 
   // update the storagemap from a vector of key/value pairs, calling setValue for each pair
-  static void setValues(std::vector<std::pair<std::string, std::string>> keyValues);
+  static void setValues(std::vector<std::pair<std::string, std::string>> const& keyValues);
 
   // initializes the parameter database
   static void initialize();

--- a/Common/Utils/include/CommonUtils/StringUtils.h
+++ b/Common/Utils/include/CommonUtils/StringUtils.h
@@ -16,6 +16,8 @@
 #ifndef ALICEO2_STRINGUTILS_H
 #define ALICEO2_STRINGUTILS_H
 
+#include <sstream>
+
 namespace o2
 {
 namespace utils

--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/NameConf.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/NameConf.h
@@ -12,21 +12,18 @@
 #define ALICEO2_NAME_GENERATOR_H_
 
 #include "DetectorsCommonDataFormats/DetID.h"
-#include "CommonUtils/ConfigurableParam.h"
-#include "CommonUtils/ConfigurableParamHelper.h"
 #include "CommonUtils/StringUtils.h"
 #include <string_view>
 
 /// \file NameConf.h
 /// \brief Definition of the Names Generator class
-
 namespace o2
 {
 namespace base
 {
-// class for book-keeping of the names for output files and trees
 
-class NameConf : public o2::conf::ConfigurableParamHelper<NameConf>
+// Class for standardization of the names for output files and trees
+class NameConf
 {
 
  public:
@@ -54,14 +51,23 @@ class NameConf : public o2::conf::ConfigurableParamHelper<NameConf>
     return o2::utils::concat_string(prefix, "_", KINE_STRING, ".root");
   }
 
+  // Filename to store geometry file
+  static std::string getGeomFileName(const std::string_view prefix = "");
+
+  // public standard TTree key (for MC ) -- not a function
+  static constexpr std::string_view MCTTREENAME = "o2sim"; // hardcoded
+
+  // standard name for digitization configuration output
+  static constexpr std::string_view DIGITIZATIONCONFIGFILE = "o2simdigitizerworkflow_configuration.ini";
+
  private:
+  // unmodifiable constants used to construct filenames etc
   static constexpr std::string_view STANDARDSIMPREFIX = "o2sim";
   static constexpr std::string_view HITS_STRING = "Hits";     // hardcoded
   static constexpr std::string_view DIGITS_STRING = "Digits"; // hardcoded
   static constexpr std::string_view GRP_STRING = "grp";       // hardcoded
   static constexpr std::string_view KINE_STRING = "Kine";     // hardcoded
-
-  O2ParamDef(NameConf, "NameConf");
+  static constexpr std::string_view GEOM_STRING = "geometry";
 };
 
 } // namespace base

--- a/DataFormats/Detectors/Common/src/DetectorsCommonDataFormatsLinkDef.h
+++ b/DataFormats/Detectors/Common/src/DetectorsCommonDataFormatsLinkDef.h
@@ -24,6 +24,5 @@
 #pragma link C++ class o2::detectors::SimTraits + ;
 
 #pragma link C++ class o2::base::NameConf + ;
-#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::base::NameConf> + ;
 
 #endif

--- a/DataFormats/Detectors/Common/src/NameConf.cxx
+++ b/DataFormats/Detectors/Common/src/NameConf.cxx
@@ -9,5 +9,24 @@
 // or submit itself to any jurisdiction.
 
 #include "DetectorsCommonDataFormats/NameConf.h"
+#include <sys/stat.h>
 
-O2ParamImpl(o2::base::NameConf);
+bool pathExists(const std::string_view p)
+{
+  struct stat buffer;
+  return (stat(p.data(), &buffer) == 0);
+}
+
+using namespace o2::base;
+
+// Filename to store geometry file
+std::string NameConf::getGeomFileName(const std::string_view prefix)
+{
+  // check if the prefix is an existing path
+  const bool prefixispath = pathExists(prefix);
+  if (prefixispath) {
+    return o2::utils::concat_string(prefix, "/", STANDARDSIMPREFIX, "_", GEOM_STRING, ".root");
+  } else {
+    return o2::utils::concat_string(prefix.empty() ? STANDARDSIMPREFIX : prefix, "_", GEOM_STRING, ".root");
+  }
+}

--- a/Detectors/Base/include/DetectorsBase/GeometryManager.h
+++ b/Detectors/Base/include/DetectorsBase/GeometryManager.h
@@ -48,7 +48,7 @@ class GeometryManager : public TObject
 {
  public:
   ///< load geometry from file
-  static void loadGeometry(std::string geomFileName = "O2geometry.root", std::string geomName = "FAIRGeom");
+  static void loadGeometry(std::string geomFileName = "", std::string geomName = "FAIRGeom");
 
   ///< Get the global transformation matrix (ideal geometry) for a given alignable volume
   ///< The alignable volume is identified by 'symname' which has to be either a valid symbolic

--- a/Detectors/Base/src/GeometryManager.cxx
+++ b/Detectors/Base/src/GeometryManager.cxx
@@ -25,6 +25,7 @@
 
 #include "DetectorsBase/GeometryManager.h"
 #include "DetectorsCommonDataFormats/AlignParam.h"
+#include <DetectorsCommonDataFormats/NameConf.h>
 
 using namespace o2::detectors;
 using namespace o2::base;
@@ -444,8 +445,9 @@ o2::base::MatBudget GeometryManager::meanMaterialBudget(float x0, float y0, floa
 void GeometryManager::loadGeometry(std::string geomFileName, std::string geomName)
 {
   ///< load geometry from file
-  LOG(INFO) << "Loading geometry " << geomName << " from " << geomFileName;
-  TFile flGeom(geomFileName.data());
+  auto fname = geomFileName.empty() ? o2::base::NameConf::getGeomFileName() : geomFileName;
+  LOG(INFO) << "Loading geometry " << geomName << " from " << fname;
+  TFile flGeom(fname.data());
   if (flGeom.IsZombie()) {
     LOG(FATAL) << "Failed to open file " << geomFileName;
   }

--- a/Detectors/Base/test/buildMatBudLUT.C
+++ b/Detectors/Base/test/buildMatBudLUT.C
@@ -15,6 +15,7 @@
 #include "DetectorsBase/MatLayerCylSet.h"
 #include "DetectorsBase/MatLayerCyl.h"
 #include "DetectorsBase/GeometryManager.h"
+#include "DetectorsCommonDataFormats/NameConf.h"
 #include <TFile.h>
 #include <TSystem.h>
 #endif
@@ -27,7 +28,7 @@ bool testMBLUT(std::string lutName = "MatBud", std::string lutFile = "matbud.roo
 
 bool buildMatBudLUT(int nTst = 30, int maxLr = -1,
                     std::string outName = "MatBud", std::string outFile = "matbud.root",
-                    std::string geomName = "O2geometry.root");
+                    std::string geomName = "");
 
 struct LrData {
   float rMin = 0.f;
@@ -42,13 +43,13 @@ struct LrData {
 std::vector<LrData> lrData;
 void configLayers();
 
-bool buildMatBudLUT(int nTst, int maxLr, std::string outName, std::string outFile, std::string geomName)
+bool buildMatBudLUT(int nTst, int maxLr, std::string outName, std::string outFile, std::string geomNameInput)
 {
-
+  auto geomName = geomNameInput.empty() ? o2::base::NameConf::getGeomFileName() : geomNameInput;
   if (gSystem->AccessPathName(geomName.c_str())) { // if needed, create geometry
     std::cout << geomName << " does not exist. Will create it\n";
     gSystem->Exec("$O2_ROOT/bin/o2-sim -n 0");
-    geomName = "./O2geometry.root";
+    geomName = o2::base::NameConf::getGeomFileName();
   }
   o2::base::GeometryManager::loadGeometry(geomName);
   configLayers();

--- a/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
@@ -44,8 +44,10 @@ using SignalContainer = std::unordered_map<int, SignalArray>;
 class Digitizer
 {
  public:
-  Digitizer();
+  Digitizer() = default;
   ~Digitizer() = default;
+  void init(); // setup everything
+
   void process(std::vector<HitType> const&, DigitContainer&, o2::dataformats::MCTruthContainer<MCLabel>&);
   void setEventTime(double timeNS) { mTime = timeNS; }
   void setEventID(int entryID) { mEventID = entryID; }

--- a/Detectors/TRD/simulation/src/Digitizer.cxx
+++ b/Detectors/TRD/simulation/src/Digitizer.cxx
@@ -30,9 +30,9 @@
 using namespace o2::trd;
 using namespace o2::math_utils;
 
-Digitizer::Digitizer()
+// init method for late initialization
+void Digitizer::init()
 {
-  o2::base::GeometryManager::loadGeometry();
   mGeo = TRDGeometry::instance();
   mGeo->createClusterMatrixArray();          // Requiered for chamberInGeometry()
   mPRF = new PadResponse();                  // Pad response function initialization

--- a/Detectors/TRD/workflow/src/TRDDigitizerSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDDigitizerSpec.cxx
@@ -28,6 +28,7 @@
 #include "DetectorsBase/GeometryManager.h"
 #include "TRDBase/Calibrations.h"
 #include "DataFormatsTRD/TriggerRecord.h"
+#include "SimConfig/DigiParams.h"
 
 using namespace o2::framework;
 using SubSpecificationType = o2::framework::DataAllocator::SubSpecificationType;
@@ -44,9 +45,10 @@ class TRDDPLDigitizerTask
   {
     LOG(INFO) << "initializing TRD digitization";
     if (!gGeoManager) {
-      o2::base::GeometryManager::loadGeometry();
+      o2::base::GeometryManager::loadGeometry(o2::conf::DigiParams::Instance().digitizationgeometry);
     }
-    LOG(INFO) << "initialed TRD digitization";
+    mDigitizer.init();
+    LOG(INFO) << "initialized TRD digitization";
   }
 
   void run(framework::ProcessingContext& pc)

--- a/Steer/DigitizerWorkflow/src/CPVDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/CPVDigitizerSpec.cxx
@@ -26,6 +26,7 @@
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
 #include "DetectorsBase/GeometryManager.h"
+#include "SimConfig/DigiParams.h"
 
 using namespace o2::framework;
 using SubSpecificationType = o2::framework::DataAllocator::SubSpecificationType;
@@ -39,7 +40,7 @@ void DigitizerSpec::init(framework::InitContext& ic)
 {
   // make sure that the geometry is loaded (TODO will this be done centrally?)
   if (!gGeoManager) {
-    o2::base::GeometryManager::loadGeometry();
+    o2::base::GeometryManager::loadGeometry(o2::conf::DigiParams::Instance().digitizationgeometry);
   }
   // init digitizer
   mDigitizer.init();

--- a/Steer/DigitizerWorkflow/src/EMCALDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/EMCALDigitizerSpec.cxx
@@ -23,7 +23,7 @@
 #include "DataFormatsParameters/GRPObject.h"
 #include "DataFormatsEMCAL/TriggerRecord.h"
 #include "DetectorsBase/GeometryManager.h"
-#include "CommonUtils/ConfigurableParam.h"
+#include <SimConfig/DigiParams.h>
 
 using namespace o2::framework;
 using SubSpecificationType = o2::framework::DataAllocator::SubSpecificationType;
@@ -37,7 +37,7 @@ void DigitizerSpec::init(framework::InitContext& ctx)
 {
   // make sure that the geometry is loaded (TODO will this be done centrally?)
   if (!gGeoManager) {
-    o2::base::GeometryManager::loadGeometry();
+    o2::base::GeometryManager::loadGeometry(o2::conf::DigiParams::Instance().digitizationgeometry);
   }
   // run 3 geometry == run 2 geometry for EMCAL
   // to be adapted with run numbers at a later stage

--- a/Steer/DigitizerWorkflow/src/HMPIDDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/HMPIDDigitizerSpec.cxx
@@ -27,6 +27,7 @@
 #include "HMPIDSimulation/Detector.h"
 #include "DetectorsBase/GeometryManager.h"
 #include "DetectorsCommonDataFormats/DetID.h"
+#include <SimConfig/DigiParams.h>
 
 using namespace o2::framework;
 using SubSpecificationType = o2::framework::DataAllocator::SubSpecificationType;
@@ -44,7 +45,7 @@ class HMPIDDPLDigitizerTask
   {
     LOG(INFO) << "initializing HMPID digitization";
     if (!gGeoManager) {
-      o2::base::GeometryManager::loadGeometry();
+      o2::base::GeometryManager::loadGeometry(o2::conf::DigiParams::Instance().digitizationgeometry);
     }
   }
 

--- a/Steer/DigitizerWorkflow/src/ITSMFTDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/ITSMFTDigitizerSpec.cxx
@@ -29,6 +29,7 @@
 #include "ITSMFTBase/DPLAlpideParam.h"
 #include "ITSBase/GeometryTGeo.h"
 #include "MFTBase/GeometryTGeo.h"
+#include "SimConfig/DigiParams.h"
 #include <TGeoManager.h>
 #include <TChain.h>
 #include <TStopwatch.h>
@@ -65,7 +66,7 @@ class ITSMFTDPLDigitizerTask
 
     // make sure that the geometry is loaded (TODO will this be done centrally?)
     if (!gGeoManager) {
-      o2::base::GeometryManager::loadGeometry();
+      o2::base::GeometryManager::loadGeometry(o2::conf::DigiParams::Instance().digitizationgeometry);
     }
 
     // configure digitizer

--- a/Steer/DigitizerWorkflow/src/MCHDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/MCHDigitizerSpec.cxx
@@ -26,6 +26,7 @@
 #include "MCHSimulation/Digitizer.h"
 #include "MCHSimulation/Detector.h"
 #include "DetectorsBase/GeometryManager.h"
+#include <SimConfig/DigiParams.h>
 
 using namespace o2::framework;
 using SubSpecificationType = o2::framework::DataAllocator::SubSpecificationType;
@@ -42,7 +43,7 @@ class MCHDPLDigitizerTask
   {
     LOG(DEBUG) << "initializing MCH digitization";
     if (!gGeoManager) {
-      o2::base::GeometryManager::loadGeometry();
+      o2::base::GeometryManager::loadGeometry(o2::conf::DigiParams::Instance().digitizationgeometry);
     }
   }
 

--- a/Steer/DigitizerWorkflow/src/MIDDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/MIDDigitizerSpec.cxx
@@ -29,6 +29,7 @@
 #include "MIDSimulation/ChamberEfficiencyResponse.h"
 #include "MIDSimulation/Geometry.h"
 #include "MIDSimulation/MCLabel.h"
+#include <SimConfig/DigiParams.h>
 
 using namespace o2::framework;
 using SubSpecificationType = o2::framework::DataAllocator::SubSpecificationType;
@@ -51,7 +52,7 @@ class MIDDPLDigitizerTask
     LOG(INFO) << "initializing MID digitization";
 
     if (!gGeoManager) {
-      o2::base::GeometryManager::loadGeometry();
+      o2::base::GeometryManager::loadGeometry(o2::conf::DigiParams::Instance().digitizationgeometry);
     }
 
     mDigitizer = std::make_unique<Digitizer>(createDefaultChamberResponse(), createDefaultChamberEfficiencyResponse(), createTransformationFromManager(gGeoManager));

--- a/Steer/DigitizerWorkflow/src/PHOSDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/PHOSDigitizerSpec.cxx
@@ -26,6 +26,7 @@
 #include "DataFormatsPHOS/MCLabel.h"
 #include <SimulationDataFormat/MCTruthContainer.h>
 #include "DetectorsBase/GeometryManager.h"
+#include <SimConfig/DigiParams.h>
 
 using namespace o2::framework;
 using SubSpecificationType = o2::framework::DataAllocator::SubSpecificationType;
@@ -39,7 +40,7 @@ void DigitizerSpec::init(framework::InitContext& ic)
 {
   // make sure that the geometry is loaded (TODO will this be done centrally?)
   if (!gGeoManager) {
-    o2::base::GeometryManager::loadGeometry();
+    o2::base::GeometryManager::loadGeometry(o2::conf::DigiParams::Instance().digitizationgeometry);
   }
   // run 3 geometry == run 2 geometry for PHOS
   // create singleton geometry

--- a/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
+++ b/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
@@ -326,7 +326,6 @@ bool isMasterWorkflowDefinition(ConfigContext const& configcontext)
   auto argv = configcontext.argv();
   bool ismaster = true;
   for (int argi = 0; argi < argc; ++argi) {
-    LOG(INFO) << argi << " " << argv[argi];
     // when channel-config is present it means that this is started as
     // as FairMQDevice which means it is already a forked process
     if (strcmp(argv[argi], "--channel-config")) {
@@ -377,7 +376,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   // update the digitization configuration with the right geometry file
   // we take the geometry from the first simPrefix (could actually check if they are
   // all compatible)
-  auto geomfilename = o2::conf::NameConf::getGeomFileName(simPrefixes[0]);
+  auto geomfilename = o2::base::NameConf::getGeomFileName(simPrefixes[0]);
   ConfigurableParam::setValue("DigiParams.digitizationgeometry", geomfilename);
 
   // write the configuration used for the digitizer workflow

--- a/Steer/DigitizerWorkflow/src/TOFDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TOFDigitizerSpec.cxx
@@ -19,7 +19,6 @@
 #include "Steer/HitProcessingManager.h" // for DigitizationContext
 #include "TChain.h"
 #include "DetectorsBase/GeometryManager.h"
-
 #include "TOFSimulation/Digitizer.h"
 #include "DataFormatsParameters/GRPObject.h"
 #include <SimulationDataFormat/MCCompLabel.h>
@@ -27,6 +26,7 @@
 #include "DataFormatsTOF/CalibLHCphaseTOF.h"
 #include "DataFormatsTOF/CalibTimeSlewingParamTOF.h"
 #include "TOFCalibration/CalibTOFapi.h"
+#include "SimConfig/DigiParams.h"
 
 using namespace o2::framework;
 using SubSpecificationType = o2::framework::DataAllocator::SubSpecificationType;
@@ -197,7 +197,7 @@ DataProcessorSpec getTOFDigitizerSpec(int channel, bool useCCDB)
   auto initIt = [simChains, process, digitizer, labels](InitContext& ctx) {
     // make sure that the geometry is loaded (TODO will this be done centrally?)
     if (!gGeoManager) {
-      o2::base::GeometryManager::loadGeometry();
+      o2::base::GeometryManager::loadGeometry(o2::conf::DigiParams::Instance().digitizationgeometry);
     }
 
     // init digitizer

--- a/Steer/DigitizerWorkflow/src/TPCDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TPCDigitizerSpec.cxx
@@ -31,6 +31,7 @@
 #include "DetectorsBase/GeometryManager.h"
 #include "CommonDataFormat/RangeReference.h"
 #include "TPCSimulation/SAMPAProcessing.h"
+#include "SimConfig/DigiParams.h"
 
 using namespace o2::framework;
 using SubSpecificationType = o2::framework::DataAllocator::SubSpecificationType;
@@ -138,7 +139,7 @@ class TPCDPLDigitizerTask
     mDigitizer.setContinuousReadout(!triggeredMode);
 
     if (!gGeoManager) {
-      o2::base::GeometryManager::loadGeometry();
+      o2::base::GeometryManager::loadGeometry(o2::conf::DigiParams::Instance().digitizationgeometry);
     }
   }
 

--- a/Steer/src/O2MCApplication.cxx
+++ b/Steer/src/O2MCApplication.cxx
@@ -25,6 +25,7 @@
 #include <TGeoManager.h>
 #include <fstream>
 #include <FairVolume.h>
+#include <DetectorsCommonDataFormats/NameConf.h>
 
 namespace o2
 {
@@ -126,9 +127,9 @@ bool O2MCApplicationBase::MisalignGeometry()
   // we use this moment to stream our geometry (before other
   // VMC engine dependent modifications are done)
 
-  std::stringstream geomss;
-  geomss << "O2geometry.root";
-  gGeoManager->Export(geomss.str().c_str());
+  auto& confref = o2::conf::SimConfig::Instance();
+  auto geomfile = o2::base::NameConf::getGeomFileName(confref.getOutPrefix());
+  gGeoManager->Export(geomfile.c_str());
 
   // return original return value of misalignment procedure
   return b;

--- a/macro/CheckClusters_mft.C
+++ b/macro/CheckClusters_mft.C
@@ -53,7 +53,8 @@ void CheckClusters_mft(Int_t nEvents = 10, Int_t nMuons = 200)
   Char_t filename[100];
 
   // Geometry
-  o2::base::GeometryManager::loadGeometry("O2geometry.root", "FAIRGeom");
+  sprintf(filename, NameConf::getGeomFileName("o2sim").c_str());
+  o2::base::GeometryManager::loadGeometry(filename, "FAIRGeom");
   auto gman = o2::mft::GeometryTGeo::Instance();
   gman->fillMatrixCache(o2::utils::bit2Mask(o2::TransformType::T2L, o2::TransformType::T2G,
                                             o2::TransformType::L2G)); // request cached transforms

--- a/macro/analyzeOriginHits.C
+++ b/macro/analyzeOriginHits.C
@@ -150,7 +150,7 @@ Grid(T init, P&&... points)->Grid<sizeof...(P), T>;
 
 void analyzeOriginHits(const char* filename = "o2sim_Kine.root",
                        const std::string& volMapFile = "MCStepLoggerVolMap.dat",
-                       const std::string& geomFile = "O2geometry.root",
+                       const std::string& geomFile = "o2sim_geometry.root",
                        bool ignorePrimaries = false)
 {
   TFile rf(filename, "OPEN");

--- a/macro/initSimGeomAndField.C
+++ b/macro/initSimGeomAndField.C
@@ -9,9 +9,9 @@
 
 int initFieldFromGRP(const o2::parameters::GRPObject* grp);
 int initFieldFromGRP(const std::string grpFileName = "o2sim_grp.root", std::string grpName = "GRP");
-int initSimGeom(std::string geomFileName = "O2geometry.root", std::string geomName = "FAIRGeom");
+int initSimGeom(std::string geomFileName = "o2sim_geometry.root", std::string geomName = "FAIRGeom");
 
-int initSimGeomAndField(std::string geomFileName = "O2geometry.root", std::string grpFileName = "o2sim_grp.root",
+int initSimGeomAndField(std::string geomFileName = "o2sim_geometry.root", std::string grpFileName = "o2sim_grp.root",
                         std::string geomName = "FAIRGeom", std::string grpName = "GRP")
 {
   int res = 0;

--- a/macro/runSimRecMatchITSTPC.sh
+++ b/macro/runSimRecMatchITSTPC.sh
@@ -18,7 +18,7 @@ clsTPCNatFile='"o2clus_tpc_Native.root"'
 trcITSFile='"o2track_its.root"'
 trcTPCFile='"o2track_tpc.root"'
 matchFile='"o2match_itstpc.root"'
-geomFile='"O2geometry.root"'
+geomFile='"o2sim_geometry.root"'
 
 root -l -b -q $preload "$macroPath"/run_digi_all.C+\($rate,$digFile,$simFile,$parFile,$grpFile\) >& dig.log
 root -l -b -q $preload "$macroPath"/run_clus_its.C+\($clsITSFile,$digFile,$parFile\) >& clus_its.log

--- a/macro/run_match_TPCITS.C
+++ b/macro/run_match_TPCITS.C
@@ -23,7 +23,7 @@ void run_match_TPCITS(std::string path = "./", std::string outputfile = "o2match
                       std::string inputClustersITS = "o2clus_its.root",
                       std::string inputClustersTPC = "tpc-native-clusters.root",
                       std::string inputFITInfo = "o2reco_ft0.root", // optional FIT (T0) info
-                      std::string inputGeom = "O2geometry.root",
+                      std::string inputGeom = "o2sim_geometry.root",
                       std::string inputGRP = "o2sim_grp.root")
 {
 

--- a/macro/run_match_tof.C
+++ b/macro/run_match_tof.C
@@ -30,7 +30,7 @@ void run_match_tof(std::string path = "./", std::string outputfile = "o2match_to
                    std::string outputfileCalib = "o2calib_tof.root",
                    std::string inputTracksTPCITS = "o2match_itstpc.root",
                    std::string inputTracksTPC = "tpctracks.root",
-                   std::string inputClustersTOF = "tofclusters.root", std::string inputGeom = "O2geometry.root",
+                   std::string inputClustersTOF = "tofclusters.root", std::string inputGeom = "o2sim_geometry.root",
                    std::string inputGRP = "o2sim_grp.root")
 {
 

--- a/macro/run_primary_vertexer_ITS.C
+++ b/macro/run_primary_vertexer_ITS.C
@@ -34,7 +34,7 @@ int run_primary_vertexer_ITS(const GPUDataTypes::DeviceType dtype = GPUDataTypes
                              const std::string inputClustersITS = "o2clus_its.root",
                              const std::string inputGRP = "o2sim_grp.root",
                              const std::string simfilename = "o2sim_Kine.root",
-                             const std::string paramfilename = "O2geometry.root",
+                             const std::string paramfilename = "o2sim_geometry.root",
                              const std::string path = "./")
 {
   std::string gpuName;

--- a/macro/run_trac_ca_its.C
+++ b/macro/run_trac_ca_its.C
@@ -53,7 +53,7 @@ using MCLabCont = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
 
 void run_trac_ca_its(std::string path = "./",
                      std::string outputfile = "o2trac_its.root",
-                     std::string inputClustersITS = "o2clus_its.root", std::string inputGeom = "O2geometry.root",
+                     std::string inputClustersITS = "o2clus_its.root", std::string inputGeom = "o2sim_geometry.root",
                      std::string inputGRP = "o2sim_grp.root")
 {
 

--- a/macro/run_trac_its.C
+++ b/macro/run_trac_its.C
@@ -38,7 +38,7 @@ using MCLabCont = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
 using Vertex = o2::dataformats::Vertex<o2::dataformats::TimeStamp<int>>;
 
 void run_trac_its(std::string path = "./", std::string outputfile = "o2trac_its.root",
-                  std::string inputClustersITS = "o2clus_its.root", std::string inputGeom = "O2geometry.root",
+                  std::string inputClustersITS = "o2clus_its.root", std::string inputGeom = "o2sim_geometry.root",
                   std::string inputGRP = "o2sim_grp.root")
 {
 


### PR DESCRIPTION
Instead of always writing O2geometry.root we now follow the same scheme as for hits and kinematics: The geometry file will be `prefix_geometry.root`.

Also refactoring the TOFDigitizerSpec to use the DPL-Task formalism.