### PR TITLE
TPC track interpolation as DPL workflow, add TOF reader for matching information

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/CMakeLists.txt
+++ b/Detectors/GlobalTrackingWorkflow/CMakeLists.txt
@@ -22,4 +22,4 @@ o2_add_executable(match-workflow
                   PUBLIC_LINK_LIBRARIES O2::GlobalTrackingWorkflow )
 
 add_subdirectory(tofworkflow)
-
+add_subdirectory(tpcinterpolationworkflow)

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/CMakeLists.txt
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/CMakeLists.txt
@@ -10,8 +10,9 @@
 
 o2_add_library(TOFWorkflow
                SOURCES src/RecoWorkflowSpec.cxx
-		       src/TOFMatchedWriterSpec.cxx
-  		       src/TOFCalibWriterSpec.cxx
+                       src/TOFMatchedWriterSpec.cxx
+                       src/TOFCalibWriterSpec.cxx
+                       src/TOFMatchedReaderSpec.cxx
                PUBLIC_LINK_LIBRARIES O2::Framework O2::TOFBase O2::DataFormatsTOF O2::TOFReconstruction 
                                      O2::GlobalTracking O2::GlobalTrackingWorkflow O2::TOFWorkflowUtils
                                      O2::TOFCalibration O2::DataFormatsFT0 O2::FT0Reconstruction O2::FITWorkflow)

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/include/TOFWorkflow/TOFMatchedReaderSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/include/TOFWorkflow/TOFMatchedReaderSpec.h
@@ -1,0 +1,58 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   TOFMatchedReaderSpec.h
+
+#ifndef O2_TOF_MATCHINFOREADER
+#define O2_TOF_MATCHINFOREADER
+
+#include "TFile.h"
+#include "TTree.h"
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+#include "ReconstructionDataFormats/MatchInfoTOF.h"
+#include "SimulationDataFormat/MCCompLabel.h"
+
+namespace o2
+{
+namespace tof
+{
+
+class TOFMatchedReader : public o2::framework::Task
+{
+ public:
+  TOFMatchedReader(bool useMC) : mUseMC(useMC) {}
+  ~TOFMatchedReader() override = default;
+  void init(o2::framework::InitContext& ic) final;
+  void run(o2::framework::ProcessingContext& pc) final;
+
+ private:
+  void connectTree(const std::string& filename);
+
+  bool mUseMC = false;
+  std::string mInFileName{"o2match_tof.root"};
+  std::string mInTreeName{"matchTOF"};
+  std::unique_ptr<TFile> mFile = nullptr;
+  std::unique_ptr<TTree> mTree = nullptr;
+  std::vector<o2::dataformats::MatchInfoTOF> mMatches, *mMatchesPtr = &mMatches;
+  std::vector<o2::MCCompLabel> mLabelTOF, *mLabelTOFPtr = &mLabelTOF;
+  std::vector<o2::MCCompLabel> mLabelTPC, *mLabelTPCPtr = &mLabelTPC;
+  std::vector<o2::MCCompLabel> mLabelITS, *mLabelITSPtr = &mLabelITS;
+};
+
+/// create a processor spec
+/// read matched TOF clusters from a ROOT file
+framework::DataProcessorSpec getTOFMatchedReaderSpec(bool useMC);
+
+} // namespace tof
+} // namespace o2
+
+#endif /* O2_TOF_MATCHINFOREADER */

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/TOFMatchedReaderSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/TOFMatchedReaderSpec.cxx
@@ -1,0 +1,99 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   TOFMatchedReaderSpec.cxx
+
+#include <vector>
+
+#include "TTree.h"
+#include "TFile.h"
+
+#include "TOFWorkflow/TOFMatchedReaderSpec.h"
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Headers/DataHeader.h"
+#include "SimulationDataFormat/MCCompLabel.h"
+#include "SimulationDataFormat/MCTruthContainer.h"
+#include "ReconstructionDataFormats/MatchInfoTOF.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace tof
+{
+
+void TOFMatchedReader::init(InitContext& ic)
+{
+  // get the option from the init context
+  LOG(INFO) << "Init TOF matching info reader!";
+  mInFileName = ic.options().get<std::string>("tof-matched-infile");
+  mInTreeName = ic.options().get<std::string>("treename");
+  connectTree(mInFileName);
+}
+
+void TOFMatchedReader::connectTree(const std::string& filename)
+{
+  mTree.reset(nullptr); // in case it was already loaded
+  mFile.reset(TFile::Open(filename.c_str()));
+  assert(mFile && !mFile->IsZombie());
+  mTree.reset((TTree*)mFile->Get(mInTreeName.c_str()));
+  assert(mTree);
+  mTree->SetBranchAddress("TOFMatchInfo", &mMatchesPtr);
+  if (mUseMC) {
+    mTree->SetBranchAddress("MatchTOFMCTruth", &mLabelTOFPtr);
+    mTree->SetBranchAddress("MatchTPCMCTruth", &mLabelTPCPtr);
+    mTree->SetBranchAddress("MatchITSMCTruth", &mLabelITSPtr);
+  }
+  LOG(INFO) << "Loaded tree from " << filename << " with " << mTree->GetEntries() << " entries";
+}
+
+void TOFMatchedReader::run(ProcessingContext& pc)
+{
+  auto currEntry = mTree->GetReadEntry() + 1;
+  assert(currEntry < mTree->GetEntries()); // this should not happen
+  mTree->GetEntry(currEntry);
+  LOG(INFO) << "Pushing " << mMatches.size() << " TOF matchings at entry " << currEntry;
+
+  pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHINFOS", 0, Lifetime::Timeframe}, mMatches);
+  if (mUseMC) {
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHTOFINFOSMC", 0, Lifetime::Timeframe}, mLabelTOF);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHTPCINFOSMC", 0, Lifetime::Timeframe}, mLabelTPC);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "MATCHITSINFOSMC", 0, Lifetime::Timeframe}, mLabelITS);
+  }
+
+  if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
+    pc.services().get<ControlService>().endOfStream();
+    pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+  }
+}
+
+DataProcessorSpec getTOFMatchedReaderSpec(bool useMC)
+{
+  std::vector<OutputSpec> outputs;
+  outputs.emplace_back(o2::header::gDataOriginTOF, "MATCHINFOS", 0, Lifetime::Timeframe);
+  if (useMC) {
+    outputs.emplace_back(o2::header::gDataOriginTOF, "MATCHTOFINFOSMC", 0, Lifetime::Timeframe);
+    outputs.emplace_back(o2::header::gDataOriginTOF, "MATCHTPCINFOSMC", 0, Lifetime::Timeframe);
+    outputs.emplace_back(o2::header::gDataOriginTOF, "MATCHITSINFOSMC", 0, Lifetime::Timeframe);
+  }
+
+  return DataProcessorSpec{
+    "TOFMatchedReader",
+    Inputs{},
+    outputs,
+    AlgorithmSpec{adaptFromTask<TOFMatchedReader>(useMC)},
+    Options{
+      {"tof-matched-infile", VariantType::String, "o2match_tof.root", {"Name of the input file"}},
+      {"treename", VariantType::String, "matchTOF", {"Name of top-level TTree"}},
+    }};
+}
+} // namespace tof
+} // namespace o2

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/CMakeLists.txt
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright CERN and copyright holders of ALICE O2. This software is distributed
+# under the terms of the GNU General Public License v3 (GPL Version 3), copied
+# verbatim in the file "COPYING".
+#
+# See http://alice-o2.web.cern.ch/license for full licensing information.
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization or
+# submit itself to any jurisdiction.
+
+#TODO Does the O2::GlobalTracking library need to be linked?
+o2_add_library(TPCInterpolationWorkflow
+               SOURCES src/TPCInterpolationSpec.cxx
+                       src/TPCResidualWriterSpec.cxx
+                       src/TrackInterpolationReaderSpec.cxx
+                       src/TrackInterpolationWorkflow.cxx
+               PUBLIC_LINK_LIBRARIES O2::GlobalTracking
+                                     O2::ITSWorkflow
+                                     O2::SpacePoints
+                                     O2::GlobalTrackingWorkflow
+                                     O2::TOFWorkflow
+                                     O2::Framework
+                                     )
+
+o2_add_executable(scdcalib-interpolation-workflow
+                  COMPONENT_NAME tpc
+                  SOURCES src/tpc-interpolation-workflow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::TPCInterpolationWorkflow)

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCInterpolationSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCInterpolationSpec.h
@@ -1,0 +1,49 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TPC_INTERPOLATION_SPEC_H
+#define O2_TPC_INTERPOLATION_SPEC_H
+
+/// @file   TPCInterpolationSpec.h
+
+#include "DataFormatsTPC/Constants.h"
+#include "SpacePoints/TrackInterpolation.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace tpc
+{
+class TPCInterpolationDPL : public Task
+{
+ public:
+  TPCInterpolationDPL(bool useMC, const std::vector<int>& tpcClusLanes) : mUseMC(useMC), mTPCClusLanes(tpcClusLanes) {}
+  ~TPCInterpolationDPL() override = default;
+  void init(InitContext& ic) final;
+  void run(ProcessingContext& pc) final;
+
+ private:
+  o2::tpc::TrackInterpolation mInterpolation; // track interpolation engine
+  std::vector<int> mTPCClusLanes;
+  std::array<std::vector<char>, o2::tpc::Constants::MAXSECTOR> mBufferedTPCClusters;
+
+  bool mUseMC{false}; ///< MC flag
+};
+
+/// create a processor spec
+framework::DataProcessorSpec getTPCInterpolationSpec(bool useMC, const std::vector<int>& tpcClusLanes);
+
+} // namespace tpc
+} // namespace o2
+
+#endif

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCResidualWriterSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCResidualWriterSpec.h
@@ -1,0 +1,53 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TPC_RESIDUAL_WRITER_H
+#define O2_TPC_RESIDUAL_WRITER_H
+
+/// @file   TPCResidualWriterSpec.h
+
+#include "TFile.h"
+#include "TTree.h"
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+#include <string>
+
+namespace o2
+{
+namespace tpc
+{
+
+class ResidualWriterTPC : public o2::framework::Task
+{
+ public:
+  ResidualWriterTPC(bool useMC = false) : mUseMC(useMC) {}
+  ~ResidualWriterTPC() override = default;
+  void init(o2::framework::InitContext& ic) final;
+  void run(o2::framework::ProcessingContext& pc) final;
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+
+ private:
+  bool mUseMC = false;                               ///< MC flag
+  std::string mOutFileName = "o2residuals_tpc.root"; ///< name of output file
+  std::string mTreeName = "residualsTPC";            ///< name of tree containing output
+  std::string mOutTracksBranchName = "tracks";       ///< name of branch containing output used tracks
+  std::string mOutResidualsBranchName = "residuals"; ///< name of branch containing output used residuals
+  std::unique_ptr<TFile> mFile = nullptr;
+  std::unique_ptr<TTree> mTree = nullptr;
+};
+
+/// create a processor spec
+framework::DataProcessorSpec getTPCResidualWriterSpec(bool useMC);
+
+} // namespace tpc
+} // namespace o2
+
+#endif

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TrackInterpolationReaderSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TrackInterpolationReaderSpec.h
@@ -1,0 +1,26 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TPC_INTERPOLATION_READER_H
+#define O2_TPC_INTERPOLATION_READER_H
+
+/// @file   TrackInterpolationReaderSpec.h
+
+namespace o2
+{
+namespace tpc
+{
+
+// TODO add specification for reading TPC cluster residuals and reference tracks
+
+} // namespace tpc
+} // namespace o2
+
+#endif

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TrackInterpolationWorkflow.h
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TrackInterpolationWorkflow.h
@@ -1,0 +1,28 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TPC_INTERPOLATION_WORKFLOW_H
+#define O2_TPC_INTERPOLATION_WORKFLOW_H
+
+/// @file   TrackInterpolationWorkflow.h
+
+#include "Framework/WorkflowSpec.h"
+
+namespace o2
+{
+namespace tpc
+{
+
+framework::WorkflowSpec getTPCInterpolationWorkflow(bool useMC);
+
+} // namespace tpc
+} // namespace o2
+
+#endif

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
@@ -1,0 +1,258 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file  TPCInterpolationSpec.cxx
+
+#include <vector>
+
+#include "Framework/ControlService.h"
+#include "DataFormatsITS/TrackITS.h"
+#include "ReconstructionDataFormats/TrackTPCITS.h"
+#include "DataFormatsTPC/TrackTPC.h"
+#include "DataFormatsTPC/ClusterNative.h"
+#include "DataFormatsTPC/ClusterNativeHelper.h"
+#include "DataFormatsTPC/TPCSectorHeader.h"
+#include "DetectorsBase/GeometryManager.h"
+#include "DetectorsBase/Propagator.h"
+#include "TPCInterpolationWorkflow/TPCInterpolationSpec.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace tpc
+{
+
+void TPCInterpolationDPL::init(InitContext& ic)
+{
+  //-------- init geometry and field --------//
+  o2::base::GeometryManager::loadGeometry();
+  o2::base::Propagator::initFieldFromGRP("o2sim_grp.root");
+
+  mInterpolation.init();
+}
+
+void TPCInterpolationDPL::run(ProcessingContext& pc)
+{
+
+  const auto tracksITS = pc.inputs().get<gsl::span<o2::its::TrackITS>>("trackITS");
+  const auto tracksTPC = pc.inputs().get<gsl::span<o2::tpc::TrackTPC>>("trackTPC");
+  const auto tracksITSTPC = pc.inputs().get<gsl::span<o2::dataformats::TrackTPCITS>>("match");
+  const auto tracksTPCClRefs = pc.inputs().get<gsl::span<o2::tpc::TPCClRefElem>>("trackTPCClRefs");
+  const auto trackMatchesTOF = pc.inputs().get<gsl::span<o2::dataformats::MatchInfoTOF>>("matchTOF"); // FIXME missing reader
+  const auto clustersTOFInp = pc.inputs().get<std::vector<o2::tof::Cluster>>("clustersTOF");          // FIXME o2::tof::Cluster is not messageable type which is required to create span
+  // make copy of TOF clusters... Is it needed?
+  std::vector<o2::tof::Cluster> clustersTOFCopy = clustersTOFInp;
+  auto clustersTOF = gsl::make_span(clustersTOFInp);
+
+  // TPC Cluster loading part is copied from TPCITSMatchingSpec.cxx
+  //---------------------------->> TPC Clusters loading >>------------------------------------------
+  int operation = 0;
+  uint64_t activeSectors = 0;
+  std::bitset<o2::tpc::Constants::MAXSECTOR> validSectors = 0;
+  std::map<int, DataRef> datarefs;
+  for (auto const& lane : mTPCClusLanes) {
+    std::string inputLabel = "clusTPC" + std::to_string(lane);
+    LOG(INFO) << "Reading lane " << lane << " " << inputLabel;
+    auto ref = pc.inputs().get(inputLabel);
+    auto const* sectorHeader = DataRefUtils::getHeader<o2::tpc::TPCSectorHeader*>(ref);
+    if (sectorHeader == nullptr) {
+      // FIXME: think about error policy
+      LOG(ERROR) << "sector header missing on header stack";
+      return;
+    }
+    const int& sector = sectorHeader->sector;
+    // check the current operation, this is used to either signal eod or noop
+    // FIXME: the noop is not needed any more once the lane configuration with one
+    // channel per sector is used
+    if (sector < 0) {
+      if (operation < 0 && operation != sector) {
+        // we expect the same operation on all inputs
+        LOG(ERROR) << "inconsistent lane operation, got " << sector << ", expecting " << operation;
+      } else if (operation == 0) {
+        // store the operation
+        operation = sector;
+      }
+      continue;
+    }
+    if (validSectors.test(sector)) {
+      // have already data for this sector, this should not happen in the current
+      // sequential implementation, for parallel path merged at the tracker stage
+      // multiple buffers need to be handled
+      throw std::runtime_error("can only have one data set per sector");
+    }
+    activeSectors |= sectorHeader->activeSectors;
+    validSectors.set(sector);
+    datarefs[sector] = ref;
+  }
+
+  if (operation == -1) {
+    // EOD is transmitted in the sectorHeader with sector number equal to -1
+    LOG(WARNING) << "operation = " << operation;
+  }
+
+  auto printInputLog = [&validSectors, &activeSectors](auto& r, const char* comment, auto& s) {
+    LOG(INFO) << comment << " " << *(r.spec) << ", size " << DataRefUtils::getPayloadSize(r) //
+              << " for sector " << s                                                         //
+              << std::endl                                                                   //
+              << "  input status:   " << validSectors                                        //
+              << std::endl                                                                   //
+              << "  active sectors: " << std::bitset<o2::tpc::Constants::MAXSECTOR>(activeSectors);
+  };
+
+  if (activeSectors == 0 || (activeSectors & validSectors.to_ulong()) != activeSectors) {
+    // not all sectors available
+    // Since we expect complete input, this should not happen (why does the bufferization considered for TPC CA tracker? Ask Matthias)
+    throw std::runtime_error("Did not receive TPC clusters data for all sectors");
+    /*
+    for (auto const& refentry : datarefs) {
+      auto& sector = refentry.first;
+      auto& ref = refentry.second;
+      auto payploadSize = DataRefUtils::getPayloadSize(ref);
+      mBufferedTPCClusters[sector].resize(payploadSize);
+      std::copy(ref.payload, ref.payload + payploadSize, mBufferedTPCClusters[sector].begin());
+
+      printInputLog(ref, "buffering", sector);
+    }
+    // not needed to send something, DPL will simply drop this timeslice, whenever the
+    // data for all sectors is available, the output is sent in that time slice
+    return;
+    */
+  }
+  //------------------------------------------------------------------------------
+  std::array<std::vector<MCLabelContainer>, o2::tpc::Constants::MAXSECTOR> mcInputs; // DUMMY
+  std::array<gsl::span<const char>, o2::tpc::Constants::MAXSECTOR> clustersTPC;
+  auto sectorStatus = validSectors;
+
+  for (auto const& refentry : datarefs) {
+    auto& sector = refentry.first;
+    auto& ref = refentry.second;
+    clustersTPC[sector] = gsl::span(ref.payload, DataRefUtils::getPayloadSize(ref));
+    sectorStatus.reset(sector);
+    printInputLog(ref, "received", sector);
+  }
+  if (sectorStatus.any()) {
+    LOG(ERROR) << "Reading bufferized TPC clusters, this should not happen";
+    // some of the inputs have been buffered
+    for (size_t sector = 0; sector < sectorStatus.size(); ++sector) {
+      if (sectorStatus.test(sector)) {
+        clustersTPC[sector] = gsl::span(&mBufferedTPCClusters[sector].front(), mBufferedTPCClusters[sector].size());
+      }
+    }
+  }
+
+  // Just print TPC clusters status
+  {
+    // make human readable information from the bitfield
+    std::string bitInfo;
+    auto nActiveBits = validSectors.count();
+    if (((uint64_t)0x1 << nActiveBits) == validSectors.to_ulong() + 1) {
+      // sectors 0 to some upper bound are active
+      bitInfo = "0-" + std::to_string(nActiveBits - 1);
+    } else {
+      int rangeStart = -1;
+      int rangeEnd = -1;
+      for (size_t sector = 0; sector < validSectors.size(); sector++) {
+        if (validSectors.test(sector)) {
+          if (rangeStart < 0) {
+            if (rangeEnd >= 0) {
+              bitInfo += ",";
+            }
+            bitInfo += std::to_string(sector);
+            if (nActiveBits == 1) {
+              break;
+            }
+            rangeStart = sector;
+          }
+          rangeEnd = sector;
+        } else {
+          if (rangeStart >= 0 && rangeEnd > rangeStart) {
+            bitInfo += "-" + std::to_string(rangeEnd);
+          }
+          rangeStart = -1;
+        }
+      }
+      if (rangeStart >= 0 && rangeEnd > rangeStart) {
+        bitInfo += "-" + std::to_string(rangeEnd);
+      }
+    }
+    LOG(INFO) << "running matching for sector(s) " << bitInfo;
+  }
+
+  o2::tpc::ClusterNativeAccess clusterIndex;
+  std::unique_ptr<o2::tpc::ClusterNative[]> clusterBuffer;
+  o2::tpc::MCLabelContainer clusterMCBuffer;
+  memset(&clusterIndex, 0, sizeof(clusterIndex));
+  o2::tpc::ClusterNativeHelper::Reader::fillIndex(clusterIndex, clusterBuffer, clusterMCBuffer, clustersTPC, mcInputs, [&validSectors](auto& index) { return validSectors.test(index); });
+  //----------------------------<< TPC Clusters loading <<------------------------------------------
+
+  // pass input data to TrackInterpolation object
+  mInterpolation.setITSTracksInp(tracksITS);
+  mInterpolation.setTPCTracksInp(tracksTPC);
+  mInterpolation.setTPCTrackClusIdxInp(tracksTPCClRefs);
+  mInterpolation.setTPCClustersInp(&clusterIndex);
+  mInterpolation.setTOFMatchesInp(trackMatchesTOF);
+  mInterpolation.setITSTPCTrackMatchesInp(tracksITSTPC);
+  mInterpolation.setTOFClustersInp(clustersTOF);
+
+  if (mUseMC) {
+    // possibly MC labels will be used to check filtering procedure performance before interpolation
+    // not yet implemented
+  }
+
+  printf("TPC Interpolation Workflow initialized. Start processing...\n");
+
+  mInterpolation.process();
+
+  pc.outputs().snapshot(Output{"GLO", "TPCINT_TRK", 0, Lifetime::Timeframe}, mInterpolation.getReferenceTracks());
+  pc.outputs().snapshot(Output{"GLO", "TPCINT_RES", 0, Lifetime::Timeframe}, mInterpolation.getClusterResiduals());
+}
+
+DataProcessorSpec getTPCInterpolationSpec(bool useMC, const std::vector<int>& tpcClusLanes)
+{
+  std::vector<InputSpec> inputs;
+  std::vector<OutputSpec> outputs;
+
+  inputs.emplace_back("trackITS", "ITS", "TRACKS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("trackTPC", "TPC", "TRACKS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("trackTPCClRefs", "TPC", "CLUSREFS", 0, Lifetime::Timeframe);
+
+  for (auto lane : tpcClusLanes) {
+    std::string clusBind = "clusTPC" + std::to_string(lane);
+    inputs.emplace_back(clusBind.c_str(), "TPC", "CLUSTERNATIVE", lane, Lifetime::Timeframe);
+  }
+
+  inputs.emplace_back("match", "GLO", "TPCITS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("matchTOF", "TOF", "MATCHINFOS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("clustersTOF", "TOF", "CLUSTERS", 0, Lifetime::Timeframe);
+
+  if (useMC) {
+    LOG(FATAL) << "MC usage must be disabled for this workflow, since it is not yet implemented";
+    // are the MC inputs from ITS-TPC matching and TOF matching duplicates? if trackITSMCTR == matchTOFMCITS one of them should be removed
+    inputs.emplace_back("trackITSMCTR", "GLO", "TPCITS_ITSMC", 0, Lifetime::Timeframe);
+    inputs.emplace_back("trackTPCMCTR", "GLO", "TPCITS_TPCMC", 0, Lifetime::Timeframe);
+    inputs.emplace_back("matchTOFMC", o2::header::gDataOriginTOF, "MATCHTOFINFOSMC", 0, Lifetime::Timeframe);
+    inputs.emplace_back("matchTOFMCTPC", o2::header::gDataOriginTOF, "MATCHTPCINFOSMC", 0, Lifetime::Timeframe);
+    inputs.emplace_back("matchTOFMCITS", o2::header::gDataOriginTOF, "MATCHITSINFOSMC", 0, Lifetime::Timeframe);
+  }
+
+  outputs.emplace_back("GLO", "TPCINT_TRK", 0, Lifetime::Timeframe);
+  outputs.emplace_back("GLO", "TPCINT_RES", 0, Lifetime::Timeframe);
+
+  return DataProcessorSpec{
+    "tpc-track-interpolation",
+    inputs,
+    outputs,
+    AlgorithmSpec{adaptFromTask<TPCInterpolationDPL>(useMC, tpcClusLanes)},
+    Options{}};
+}
+
+} // namespace tpc
+} // namespace o2

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCResidualWriterSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCResidualWriterSpec.cxx
@@ -1,0 +1,97 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file  TPCResidualWriterSpec.cxx
+
+#include <vector>
+
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "SpacePoints/TrackInterpolation.h"
+#include "TPCInterpolationWorkflow/TPCResidualWriterSpec.h"
+#include "CommonUtils/StringUtils.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace tpc
+{
+
+template <typename T>
+TBranch* getOrMakeBranch(TTree* tree, const char* brname, T* ptr)
+{
+  if (auto br = tree->GetBranch(brname)) {
+    // return branch if it already exists
+    br->SetAddress(static_cast<void*>(ptr));
+    return br;
+  }
+  // otherwise make it
+  return tree->Branch(brname, ptr);
+}
+
+void ResidualWriterTPC::init(InitContext& ic)
+{
+  mOutFileName = ic.options().get<std::string>("residuals-outfile");
+  mFile = std::make_unique<TFile>(mOutFileName.c_str(), "RECREATE");
+  if (!mFile->IsOpen()) {
+    throw std::runtime_error(o2::utils::concat_string("Failed to open TPC SCD residuals output file ", mOutFileName));
+  }
+  mTree = std::make_unique<TTree>(mTreeName.c_str(), "Tree of TPC residuals and reference tracks");
+}
+
+void ResidualWriterTPC::run(ProcessingContext& pc)
+{
+
+  auto tracks = std::move(pc.inputs().get<const std::vector<TrackData>>("tracks"));
+  auto residuals = std::move(pc.inputs().get<const std::vector<TPCClusterResiduals>>("residuals"));
+
+  auto tracksPtr = &tracks;
+  auto residualsPtr = &residuals;
+
+  LOG(INFO) << "ResidualWriterTPC pulled " << tracks.size() << " reference tracks and " << residuals.size() << " TPC cluster residuals";
+
+  getOrMakeBranch(mTree.get(), mOutTracksBranchName.c_str(), &tracksPtr);
+  getOrMakeBranch(mTree.get(), mOutResidualsBranchName.c_str(), &residualsPtr);
+
+  if (mUseMC) {
+    // TODO
+  }
+
+  mTree->Fill();
+}
+
+void ResidualWriterTPC::endOfStream(EndOfStreamContext& ec)
+{
+  LOG(INFO) << "Finalizing TPC SCD interpolation residuals writing";
+  mTree->Write();
+  mTree.release()->Delete();
+  mFile->Close();
+}
+
+DataProcessorSpec getTPCResidualWriterSpec(bool useMC)
+{
+  std::vector<InputSpec> inputs;
+  inputs.emplace_back("tracks", "GLO", "TPCINT_TRK", 0, Lifetime::Timeframe);
+  inputs.emplace_back("residuals", "GLO", "TPCINT_RES", 0, Lifetime::Timeframe);
+  if (useMC) {
+    // TODO
+  }
+  return DataProcessorSpec{
+    "tpc-residuals-writer",
+    inputs,
+    Outputs{},
+    AlgorithmSpec{adaptFromTask<ResidualWriterTPC>(useMC)},
+    Options{
+      {"residuals-outfile", VariantType::String, "o2residuals_tpc.root", {"Name of the output file"}}}};
+}
+
+} // namespace tpc
+} // namespace o2

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TrackInterpolationReaderSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TrackInterpolationReaderSpec.cxx
@@ -1,0 +1,21 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file  TrackInterpolationReaderSpec.cxx
+
+#include "TPCInterpolationWorkflow/TrackInterpolationReaderSpec.h"
+
+namespace o2
+{
+namespace tpc
+{
+
+} // namespace tpc
+} // namespace o2

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TrackInterpolationWorkflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TrackInterpolationWorkflow.cxx
@@ -1,0 +1,61 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file  TrackInterpolationWorkflow.cxx
+
+#include <vector>
+
+#include "ITSWorkflow/TrackReaderSpec.h"
+#include "TPCWorkflow/TrackReaderSpec.h"
+#include "TPCWorkflow/PublisherSpec.h"
+#include "GlobalTrackingWorkflow/TrackTPCITSReaderSpec.h"
+#include "TOFWorkflow/ClusterReaderSpec.h"
+#include "TOFWorkflow/TOFMatchedReaderSpec.h"
+#include "Algorithm/RangeTokenizer.h"
+#include "TPCInterpolationWorkflow/TPCResidualWriterSpec.h"
+#include "TPCInterpolationWorkflow/TPCInterpolationSpec.h"
+#include "TPCInterpolationWorkflow/TrackInterpolationWorkflow.h"
+
+namespace o2
+{
+namespace tpc
+{
+
+framework::WorkflowSpec getTPCInterpolationWorkflow(bool useMC)
+{
+  framework::WorkflowSpec specs;
+
+  specs.emplace_back(o2::its::getITSTrackReaderSpec(useMC));
+  specs.emplace_back(o2::tpc::getTPCTrackReaderSpec(useMC));
+
+  std::vector<int> tpcClusSectors = o2::RangeTokenizer::tokenize<int>("0-35");
+  std::vector<int> tpcClusLanes = tpcClusSectors;
+  specs.emplace_back(o2::tpc::getPublisherSpec(o2::tpc::PublisherConf{
+                                                 "tpc-native-cluster-reader",
+                                                 "tpcrec",
+                                                 {"clusterbranch", "TPCClusterNative", "Branch with TPC native clusters"},
+                                                 {"clustermcbranch", "TPCClusterNativeMCTruth", "MC label branch"},
+                                                 OutputSpec{"TPC", "CLUSTERNATIVE"},
+                                                 OutputSpec{"TPC", "CLNATIVEMCLBL"},
+                                                 tpcClusSectors,
+                                                 tpcClusLanes},
+                                               useMC));
+
+  specs.emplace_back(o2::globaltracking::getTrackTPCITSReaderSpec(useMC));
+  specs.emplace_back(o2::tof::getClusterReaderSpec(useMC));
+  specs.emplace_back(o2::tof::getTOFMatchedReaderSpec(useMC));
+  specs.emplace_back(o2::tpc::getTPCInterpolationSpec(useMC, tpcClusLanes));
+  specs.emplace_back(o2::tpc::getTPCResidualWriterSpec(useMC));
+
+  return specs;
+}
+
+} // namespace tpc
+} // namespace o2

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/tpc-interpolation-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/tpc-interpolation-workflow.cxx
@@ -1,0 +1,42 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "TPCInterpolationWorkflow/TrackInterpolationWorkflow.h"
+#include "CommonUtils/ConfigurableParam.h"
+
+using namespace o2::framework;
+
+// ------------------------------------------------------------------
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  workflowOptions.push_back(ConfigParamSpec{
+    "disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation even if available"}});
+
+  std::string keyvaluehelp("Semicolon separated key=value strings ...");
+  workflowOptions.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {keyvaluehelp}});
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  // Update the (declared) parameters if changed from the command line
+  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
+  // write the configuration used for the workflow
+  o2::conf::ConfigurableParam::writeINI("o2tpcinterpolation-workflow_configuration.ini");
+
+  auto useMC = !configcontext.options().get<bool>("disable-mc");
+  return std::move(o2::tpc::getTPCInterpolationWorkflow(useMC));
+}

--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/SpacePointsCalibParam.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/SpacePointsCalibParam.h
@@ -16,7 +16,7 @@
 #ifndef ALICEO2_TPC_PARAM_H_
 #define ALICEO2_TPC_PARAM_H_
 
-#define TPC_RUN2
+//#define TPC_RUN2
 
 #include "DataFormatsTPC/Constants.h"
 

--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackInterpolation.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackInterpolation.h
@@ -16,6 +16,7 @@
 #ifndef ALICEO2_TPC_TRACKINTERPOLATION_H_
 #define ALICEO2_TPC_TRACKINTERPOLATION_H_
 
+#include <gsl/span>
 #include "CommonDataFormat/EvIndex.h"
 #include "CommonDataFormat/RangeReference.h"
 #include "ReconstructionDataFormats/Track.h"
@@ -23,7 +24,6 @@
 #include "ReconstructionDataFormats/MatchInfoTOF.h"
 #include "DataFormatsITSMFT/Cluster.h"
 #include "DataFormatsITS/TrackITS.h"
-#include "DataFormatsTPC/ClusterNativeHelper.h"
 #include "DataFormatsTPC/TrackTPC.h"
 #include "DataFormatsTPC/Constants.h"
 #include "DataFormatsTOF/Cluster.h"
@@ -54,6 +54,7 @@ struct TPCClusterResiduals {
   void setZ(float val) { z = fabs(val) < param::MaxZ ? static_cast<short>(val * 0x7fff / param::MaxZ) : static_cast<short>(std::copysign(1., val) * 0x7fff); }
   void setPhi(float val) { phi = fabs(val) < param::MaxTgSlp ? static_cast<short>(val * 0x7fff / param::MaxTgSlp) : static_cast<short>(std::copysign(1., val) * 0x7fff); }
   void setTgl(float val) { tgl = fabs(val) < param::MaxTgSlp ? static_cast<short>(val * 0x7fff / param::MaxTgSlp) : static_cast<short>(std::copysign(1., val) * 0x7fff); }
+  ClassDefNV(TPCClusterResiduals, 1);
 };
 
 /// Structure filled for each track with track quality information and a vector with TPCClusterResiduals
@@ -70,6 +71,7 @@ struct TrackData {
   // TODO: Add an additional structure with event information and reference to the tracks for given event?
   int nTracksInEvent{};                      ///< total number of tracks in given event / timeframe ? Used for multiplicity estimate
   o2::dataformats::RangeReference<> clIdx{}; ///< index of first cluster residual and total number of cluster residuals of this track
+  ClassDefNV(TrackData, 1);
 };
 
 /// \class TrackInterpolation
@@ -105,6 +107,8 @@ class TrackInterpolation
     unsigned short clAvailable{0};
   };
 
+  // -------------------------------------- processing functions --------------------------------------------------
+
   /// Initialize everything
   void init();
 
@@ -122,7 +126,7 @@ class TrackInterpolation
   /// Interpolate ITS-TPC-TOF tracks in the TPC and store residuals to TPC clusters
   /// \param matchTOF
   /// \return flag if track could be processed successfully
-  bool interpolateTrackITSTOF(const std::pair<o2::dataformats::EvIndex<>, o2::dataformats::MatchInfoTOF>& matchTOF);
+  bool interpolateTrackITSTOF(const o2::dataformats::MatchInfoTOF& matchTOF);
 
   /// Check if given ITS-TPC track fullfills quality criteria
   /// \param matchITSTPC ITS-TPC track to be checked
@@ -130,40 +134,11 @@ class TrackInterpolation
   /// \return Flag if quality criteria are met
   bool trackPassesQualityCuts(const o2::dataformats::TrackTPCITS& matchITSTPC, bool hasOuterPoint = true) const;
 
-  /// Load specified entry for all input trees
-  /// \param iEntry number of tree entry
-  void loadEntryForTrees(int iEntry);
-
-  /// Attach all input trees
-  void attachInputTrees();
-
-  /// Add branches to the output trees
-  void prepareOutputTrees();
 
   /// Reset cache and output vectors
   void reset();
 
   // -------------------------------------- settings --------------------------------------------------
-
-  /// Sets the tree/chain containing ITS-TPC matched tracks
-  void setInputTreeITSTPCTracks(TTree* tree) { mTreeITSTPCTracks = tree; }
-  /// Sets the tree/chain containing TPC tracks
-  void setInputTreeTPCTracks(TTree* tree) { mTreeTPCTracks = tree; }
-  ///< Sets the reader for TPC clusters
-  void setInputTPCClustersReader(ClusterNativeHelper::Reader* reader) { mTPCClusterReader = reader; }
-  /// Sets the tree/chain containing ITS tracks
-  void setInputTreeITSTracks(TTree* tree) { mTreeITSTracks = tree; }
-  /// Sets the tree/chain containing ITS clusters
-  void setInputTreeITSClusters(TTree* tree) { mTreeITSClusters = tree; }
-  /// Sets the tree/chain containing TOF matching information
-  void setInputTreeTOFMatches(TTree* tree) { mTreeTOFMatches = tree; }
-  ///< Sets the tree/chain containing TOF clusters
-  void setInputTreeTOFClusters(TTree* tree) { mTreeTOFClusters = tree; }
-
-  /// Sets the output tree for track information
-  void setOutputTreeTracks(TTree* tree) { mTreeOutTrackData = tree; }
-  /// Sets the output tree for TPC cluster residuals
-  void setOutputTreeResiduals(TTree* tree) { mTreeOutClusterRes = tree; }
 
   /// Sets the maximum phi angle at which track extrapolation is aborted
   void setMaxSnp(float snp) { mMaxSnp = snp; }
@@ -174,80 +149,56 @@ class TrackInterpolation
   /// Sets whether ITS tracks without match in TRD or TOF should be processed as well
   void setDoITSOnlyTracks(bool flag) { mDoITSOnlyTracks = flag; }
 
-  /// Setters and Getters for the input branch/file names
-  void setITSTPCTrackBranchName(const std::string& name) { mITSTPCTrackBranchName = name; }
-  void setTPCTrackBranchName(const std::string& name) { mTPCTrackBranchName = name; }
-  void setTPCTrackClIdxBranchName(const std::string& name) { mTPCTrackClIdxBranchName = name; }
-  void setTPCClusterFileName(const std::string& name) { mTPCClusterFileName = name; }
-  void setITSTrackBranchName(const std::string& name) { mITSTrackBranchName = name; }
-  void setITSClusterBranchName(const std::string& name) { mITSClusterBranchName = name; }
-  void setTOFMatchingBranchName(const std::string& name) { mTOFMatchingBranchName = name; }
-  void setTOFClusterBranchName(const std::string& name) { mTOFClusterBranchName = name; }
+  // --------------------------------- input ---------------------------------------------
 
-  const std::string& getITSTPCTrackBranchName() const { return mITSTPCTrackBranchName; }
-  const std::string& getTPCTrackBranchName() const { return mTPCTrackBranchName; }
-  const std::string& getTPCTrackClIdxBranchName() const { return mTPCTrackClIdxBranchName; }
-  const std::string& getTPCClusterFileName() const { return mTPCClusterFileName; }
-  const std::string& getITSTrackBranchName() const { return mITSTrackBranchName; }
-  const std::string& getITSClusterBranchName() const { return mITSClusterBranchName; }
-  const std::string& getTOFMatchingBranchName() const { return mTOFMatchingBranchName; }
-  const std::string& getTOFClusterBranchName() const { return mTOFClusterBranchName; }
+  /// Sets input ITS tracks received via DPL
+  void setITSTracksInp(const gsl::span<const o2::its::TrackITS> inp) { mITSTracksArray = inp; }
+  /// Sets input ITS-TPC matched tracks received via DPL
+  void setITSTPCTrackMatchesInp(const gsl::span<const o2::dataformats::TrackTPCITS> inp) { mITSTPCTracksArray = inp; }
+  /// Sets input TPC tracks received via DPL
+  void setTPCTracksInp(const gsl::span<const o2::tpc::TrackTPC> inp) { mTPCTracksArray = inp; }
+  /// Sets input TPC track cluster indices received via DPL
+  void setTPCTrackClusIdxInp(const gsl::span<const o2::tpc::TPCClRefElem> inp) { mTPCTracksClusIdx = inp; }
+  /// Sets input TPC clusters received via DPL
+  void setTPCClustersInp(const o2::tpc::ClusterNativeAccess* inp) { mTPCClusterIdxStruct = inp; }
+  /// Sets input TOF matching records received via DPL
+  void setTOFMatchesInp(const gsl::span<const o2::dataformats::MatchInfoTOF> inp) { mTOFMatchesArray = inp; }
+  /// Sets input TOF clusters received via DPL
+  void setTOFClustersInp(const gsl::span<const o2::tof::Cluster> inp) { mTOFClustersArray = inp; }
+
+  // --------------------------------- output ---------------------------------------------
+  std::vector<TPCClusterResiduals>& getClusterResiduals() { return mClRes; }
+  std::vector<TrackData>& getReferenceTracks() { return mTrackData; }
 
  private:
-  // names of input files / branches
-  std::string mITSTPCTrackBranchName{"TPCITS"};                ///< name of branch containing ITS-TPC matched tracks
-  std::string mTPCTrackBranchName{"Tracks"};                   ///< name of branch containing TPC tracks (needed for TPC cluster access)
-  std::string mTPCTrackClIdxBranchName{"ClusRefs"};            ///< name of branch containing TPC tracks cluster refs (needed for TPC cluster access)
-  std::string mTPCClusterFileName{"tpc-native-clusters.root"}; ///< name of file containing TPC native clusters
-  std::string mITSTrackBranchName{"ITSTrack"};                 ///< name of branch containing input ITS tracks
-  std::string mITSClusterBranchName{"ITSCluster"};             ///< name of branch containing input ITS clusters
-  std::string mTOFMatchingBranchName{"TOFMatchInfo"};          ///< name of branch containing matching info for ITS-TPC-TOF tracks
-  std::string mTOFClusterBranchName{"TOFCluster"};             ///< name of branch containing TOF clusters
-
-  // parameters
+  // parameters + settings
   float mTPCTimeBinMUS{.2f}; ///< TPC time bin duration in us
   float mSigYZ2TOF{.75f};    ///< for now assume cluster error for TOF equal for all clusters in both Y and Z
-
-  // settings
   float mMaxSnp{.85f};          ///< max snp when propagating ITS tracks
   float mMaxStep{2.f};          ///< maximum step for propagation
-  int mMatCorr{1};              ///< if material correction should be done
+  int mMatCorr{0};              ///< if material correction should be done
   bool mDoITSOnlyTracks{false}; ///< if ITS only tracks should be processed or not
 
   // input
-  TTree* mTreeITSTPCTracks{nullptr};                                                                             ///< input tree for ITS-TPC matched tracks
-  TTree* mTreeTPCTracks{nullptr};                                                                                ///< input tree for TPC tracks
-  TTree* mTreeITSTracks{nullptr};                                                                                ///< input tree for ITS tracks
-  TTree* mTreeITSClusters{nullptr};                                                                              ///< input tree for ITS clusters
-  TTree* mTreeTOFMatches{nullptr};                                                                               ///< input tree for ITS-TPC-TOF matches
-  TTree* mTreeTOFClusters{nullptr};                                                                              ///< input tree for TOF clusters
-  std::vector<o2::dataformats::TrackTPCITS>* mITSTPCTrackVecInput{nullptr};                                      ///< input vector with ITS-TPC matched tracks
-  std::vector<TrackTPC>* mTPCTrackVecInput{nullptr};                                                             ///< input vector with TPC tracks
-  std::vector<TPCClRefElem>* mTPCTrackClIdxVecInput{nullptr};                                                    ///< input vector with TPC tracks cluster indicies
-  std::vector<o2::its::TrackITS>* mITSTrackVecInput{nullptr};                                                    ///< input vector with ITS tracks
-  std::vector<o2::itsmft::Cluster>* mITSClusterVecInput{nullptr};                                                ///< input vector with ITS clusters
-  ClusterNativeHelper::Reader* mTPCClusterReader = nullptr;                                                      ///< TPC cluster reader
-  std::unique_ptr<ClusterNativeAccess> mTPCClusterIdxStructOwn;                                                  ///< struct holding the TPC cluster indices (for tree-based I/O)
-  std::unique_ptr<ClusterNative[]> mTPCClusterBufferOwn;                                                         ///< buffer for clusters in mTPCClusterIdxStructOwn
-  MCLabelContainer mTPCClusterMCBufferOwn;                                                                       ///< buffer for mc labels
-  std::vector<std::pair<o2::dataformats::EvIndex<>, o2::dataformats::MatchInfoTOF>>* mTOFMatchVecInput{nullptr}; ///< input vector for ITS-TPC-TOF matching information
-  std::vector<o2::tof::Cluster>* mTOFClusterVecInput{nullptr};                                                   ///< input vector with TOF clusters
+  gsl::span<const o2::dataformats::TrackTPCITS> mITSTPCTracksArray; ///< input ITS-TPC matched tracks from span
+  gsl::span<const TrackTPC> mTPCTracksArray;                        ///< input TPC tracks from span
+  gsl::span<const TPCClRefElem> mTPCTracksClusIdx;                  ///< input TPC tracks cluster indicies from span
+  gsl::span<const o2::its::TrackITS> mITSTracksArray;               ///< input ITS tracks from span
+  gsl::span<const o2::dataformats::MatchInfoTOF> mTOFMatchesArray;  ///< input ITS-TPC-TOF matching information from span
+  gsl::span<const o2::tof::Cluster> mTOFClustersArray;              ///< input TOF clusters from span
 
   const ClusterNativeAccess* mTPCClusterIdxStruct = nullptr; ///< struct holding the TPC cluster indices
 
   // output
-  TTree* mTreeOutTrackData{nullptr};                    ///< output tree with track quality information
   std::vector<TrackData> mTrackData{};                  ///< this vector is used to store the track quality information on a per track basis
-  std::vector<TrackData>* mTrackDataPtr{&mTrackData};   ///< pointer to vector with track data
-  TTree* mTreeOutClusterRes{nullptr};                   ///< output tree with TPC cluster residuals
   std::vector<TPCClusterResiduals> mClRes{};            ///< residuals for each available TPC cluster of all tracks
-  std::vector<TPCClusterResiduals>* mClResPtr{&mClRes}; ///< pointer to vector with residuals
 
   // cache
   std::array<CacheStruct, Constants::MAXGLOBALPADROW> mCache{{}}; ///< caching positions, covariances and angles for track extrapolations and interpolation
 
   // helpers
   std::unique_ptr<TPCFastTransform> mFastTransform{}; ///< TPC cluster transformation
+  bool mInitDone{false};                              ///< initialization done flag
 };
 
 } // namespace tpc

--- a/Detectors/TPC/calibration/SpacePoints/src/SpacePointCalibLinkDef.h
+++ b/Detectors/TPC/calibration/SpacePoints/src/SpacePointCalibLinkDef.h
@@ -17,7 +17,9 @@
 #pragma link C++ class o2::tpc::TrackInterpolation + ;
 #pragma link C++ class o2::tpc::TrackResiduals + ;
 #pragma link C++ class o2::tpc::TrackData + ;
+#pragma link C++ class std::vector < o2::tpc::TrackData> + ;
 #pragma link C++ class o2::tpc::TPCClusterResiduals + ;
+#pragma link C++ class std::vector < o2::tpc::TPCClusterResiduals> + ;
 #pragma link C++ class o2::tpc::TrackResiduals::LocalResid + ;
 #pragma link C++ class o2::tpc::TrackResiduals::VoxRes + ;
 


### PR DESCRIPTION
MatchInfoTof has the index of the matched track stored directly as a member now.