### PR TITLE
[EMCAL-501] store energy in Digits in ADC counts

### DIFF
--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Cell.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Cell.h
@@ -48,6 +48,9 @@ class Cell
   void setEnergy(Double_t energy);
   Double_t getEnergy() const;
 
+  void setAmplitude(Double_t energy) { setEnergy(energy); }
+  Double_t getAmplitude() const { return getEnergy(); }
+
   void setType(ChannelType_t ctype);
   ChannelType_t getType() const;
 

--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Constants.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Constants.h
@@ -89,13 +89,14 @@ std::ostream& operator<<(std::ostream& stream, ChannelType_t chantype);
 namespace constants
 {
 
-constexpr int OVERFLOWCUT = 950;                ///< sample overflow
-constexpr int ORDER = 2;                        ///< Order of shaping stages of the signal conditioning unit
-constexpr double TAU = 2.35;                    ///< Approximate shaping time
-constexpr Double_t EMCAL_TIMESAMPLE = 100.;     ///< Width of a timebin in nanoseconds
-constexpr Double_t EMCAL_ADCENERGY = 0.0167;    ///< Energy of one ADC count in GeV/c^2
-constexpr Double_t EMCAL_HGLGTRANSITION = 800.; ///< Transition from High to Low Gain
-constexpr Int_t EMCAL_MAXTIMEBINS = 15;         ///< Maximum number of time bins for time response
+constexpr int OVERFLOWCUT = 950;             ///< sample overflow
+constexpr int ORDER = 2;                     ///< Order of shaping stages of the signal conditioning unit
+constexpr double TAU = 2.35;                 ///< Approximate shaping time
+constexpr Double_t EMCAL_TIMESAMPLE = 100.;  ///< Width of a timebin in nanoseconds
+constexpr Double_t EMCAL_ADCENERGY = 0.0162; ///< Energy of one ADC count in GeV/c^2
+constexpr Int_t EMCAL_HGLGFACTOR = 16;       ///< Conversion from High to Low Gain
+constexpr Int_t EMCAL_HGLGTRANSITION = 800;  ///< Transition from High to Low Gain
+constexpr Int_t EMCAL_MAXTIMEBINS = 15;      ///< Maximum number of time bins for time response
 } // namespace constants
 
 enum FitAlgorithm {

--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Digit.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Digit.h
@@ -34,7 +34,7 @@ class Digit : public DigitBase
  public:
   Digit() = default;
 
-  Digit(Short_t tower, Double_t energy, Double_t time);
+  Digit(Short_t tower, Double_t amplitudeGeV, Double_t time, ChannelType_t ctype = ChannelType_t::HIGH_GAIN);
   ~Digit() = default; // override
 
   bool operator<(const Digit& other) const { return getTimeStamp() < other.getTimeStamp(); }
@@ -46,8 +46,8 @@ class Digit : public DigitBase
     return (mTower == other.getTower() && std::abs(getTimeStamp() - other.getTimeStamp()) < constants::EMCAL_TIMESAMPLE);
   }
 
-  Digit& operator+=(const Digit& other);              // Adds energy of other digits to this digit.
-  friend Digit operator+(Digit lhs, const Digit& rhs) // Adds energy of two digits.
+  Digit& operator+=(const Digit& other);              // Adds amplitude of other digits to this digit.
+  friend Digit operator+(Digit lhs, const Digit& rhs) // Adds amplitudes of two digits.
   {
     lhs += rhs;
     return lhs;
@@ -56,30 +56,36 @@ class Digit : public DigitBase
   void setTower(Short_t tower) { mTower = tower; }
   Short_t getTower() const { return mTower; }
 
-  void setEnergy(Double_t energy) { mEnergy = energy; }
-  Double_t getEnergy() const { return mEnergy; }
+  void setAmplitude(Double_t amplitude); // GeV
+  Double_t getAmplitude() const { return getAmplitudeADC() * constants::EMCAL_ADCENERGY; }
+
+  void setEnergy(Double_t energy) { setAmplitude(energy); }
+  Double_t getEnergy() const { return getAmplitude(); }
+
+  void setAmplitudeADC(Short_t amplitude, ChannelType_t ctype = ChannelType_t::HIGH_GAIN);
+  Int_t getAmplitudeADC(ChannelType_t ctype = ChannelType_t::HIGH_GAIN) const;
 
   void setType(ChannelType_t ctype) { mChannelType = ctype; }
   ChannelType_t getType() const { return mChannelType; }
 
-  void setLowGain() { mChannelType = ChannelType_t::LOW_GAIN; }
-  Bool_t getLowGain() const { return mChannelType == ChannelType_t::LOW_GAIN; }
-
   void setHighGain() { mChannelType = ChannelType_t::HIGH_GAIN; }
   Bool_t getHighGain() const { return mChannelType == ChannelType_t::HIGH_GAIN; }
 
-  void setLEDMon() { mChannelType = ChannelType_t::LEDMON; }
-  Bool_t getLEDMon() const { return mChannelType == ChannelType_t::LEDMON; }
+  void setLowGain() { mChannelType = ChannelType_t::LOW_GAIN; }
+  Bool_t getLowGain() const { return mChannelType == ChannelType_t::LOW_GAIN; }
 
   void setTRU() { mChannelType = ChannelType_t::TRU; }
   Bool_t getTRU() const { return mChannelType == ChannelType_t::TRU; }
+
+  void setLEDMon() { mChannelType = ChannelType_t::LEDMON; }
+  Bool_t getLEDMon() const { return mChannelType == ChannelType_t::LEDMON; }
 
   void PrintStream(std::ostream& stream) const;
 
  private:
   friend class boost::serialization::access;
 
-  Double_t mEnergy = 0.;                                 ///< Energy (GeV/c^2)
+  Short_t mAmplitude = 0;                                ///< Amplitude (ADC counts)
   Short_t mTower = -1;                                   ///< Tower index (absolute cell ID)
   ChannelType_t mChannelType = ChannelType_t::HIGH_GAIN; ///< Channel type (high gain, low gain, TRU, LEDMON)
 

--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/MCLabel.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/MCLabel.h
@@ -26,14 +26,14 @@ namespace emcal
 class MCLabel : public o2::MCCompLabel
 {
  private:
-  Double_t mEnergyFraction;
+  Double_t mAmplitudeFraction;
 
  public:
   MCLabel() = default;
-  MCLabel(Int_t trackID, Int_t eventID, Int_t srcID, Bool_t fake, Double_t efraction) : o2::MCCompLabel(trackID, eventID, srcID, fake), mEnergyFraction(efraction) {}
-  MCLabel(Bool_t noise, Double_t efraction) : o2::MCCompLabel(noise), mEnergyFraction(efraction) {}
-  void setEnergyFraction(Double_t efraction) { mEnergyFraction = efraction; }
-  Double_t getEnergyFraction() const { return mEnergyFraction; }
+  MCLabel(Int_t trackID, Int_t eventID, Int_t srcID, Bool_t fake, Double_t afraction) : o2::MCCompLabel(trackID, eventID, srcID, fake), mAmplitudeFraction(afraction) {}
+  MCLabel(Bool_t noise, Double_t afraction) : o2::MCCompLabel(noise), mAmplitudeFraction(afraction) {}
+  void setAmplitudeFraction(Double_t afraction) { mAmplitudeFraction = afraction; }
+  Double_t getAmplitudeFraction() const { return mAmplitudeFraction; }
 
   ClassDefNV(MCLabel, 1);
 };

--- a/DataFormats/Detectors/EMCAL/src/Digit.cxx
+++ b/DataFormats/Detectors/EMCAL/src/Digit.cxx
@@ -13,22 +13,90 @@
 
 using namespace o2::emcal;
 
-Digit::Digit(Short_t tower, Double_t energy, Double_t time)
-  : DigitBase(time), mTower(tower), mEnergy(energy)
+Digit::Digit(Short_t tower, Double_t amplitudeGeV, Double_t time, ChannelType_t ctype)
+  : DigitBase(time), mTower(tower), mChannelType(ctype)
 {
+  setAmplitude(amplitudeGeV);
 }
 
 Digit& Digit::operator+=(const Digit& other)
 {
-  if (canAdd(other))
-    mEnergy += other.getEnergy();
-  // Does nothing if the digits are in different towers.
+  if (canAdd(other)) {
+    Int_t a = getAmplitudeADC() + other.getAmplitudeADC();
+    Short_t s = (Short_t)(a);
+
+    if (a < -0x8000)
+      setAmplitudeADC(-0x8000);
+    else if (a <= constants::EMCAL_HGLGTRANSITION)
+      setAmplitudeADC(s);
+    else if (a <= 0x7fff * constants::EMCAL_HGLGFACTOR)
+      setAmplitudeADC(s / constants::EMCAL_HGLGFACTOR, ChannelType_t::LOW_GAIN);
+    else
+      setAmplitudeADC(0x7fff, ChannelType_t::LOW_GAIN);
+  }
+  // Does nothing if the digits are in different towers or have incompatible times.
   return *this;
+}
+
+void Digit::setAmplitudeADC(Short_t amplitude, ChannelType_t ctype)
+{
+  if (ctype == ChannelType_t::LOW_GAIN) {
+    if (amplitude > constants::EMCAL_HGLGTRANSITION / constants::EMCAL_HGLGFACTOR) {
+      mAmplitude = amplitude;
+      mChannelType = ChannelType_t::LOW_GAIN;
+    } else if (amplitude < -0x8000 / constants::EMCAL_HGLGFACTOR) {
+      mAmplitude = -0x8000;
+      mChannelType = ChannelType_t::HIGH_GAIN;
+    } else {
+      mAmplitude = amplitude * constants::EMCAL_HGLGFACTOR;
+      mChannelType = ChannelType_t::HIGH_GAIN;
+    }
+  } else {
+    if (amplitude > constants::EMCAL_HGLGTRANSITION) {
+      mAmplitude = amplitude / constants::EMCAL_HGLGFACTOR;
+      mChannelType = ChannelType_t::LOW_GAIN;
+    } else {
+      mAmplitude = amplitude;
+      mChannelType = ctype;
+    }
+  }
+}
+
+Int_t Digit::getAmplitudeADC(ChannelType_t ctype) const
+{
+  if (ctype == ChannelType_t::LOW_GAIN) {
+    // return in units of Low-Gain ADC counts
+    if (mChannelType == ChannelType_t::LOW_GAIN)
+      return (Int_t)(mAmplitude);
+    else
+      return mAmplitude / constants::EMCAL_HGLGFACTOR;
+  }
+
+  // return in units of High-Gain ADC counts (default)
+  if (mChannelType == ChannelType_t::LOW_GAIN)
+    return mAmplitude * constants::EMCAL_HGLGFACTOR;
+
+  return (Int_t)(mAmplitude);
+}
+
+void Digit::setAmplitude(Double_t amplitude)
+{
+  if (amplitude < -0x8000 * constants::EMCAL_ADCENERGY) {
+    setAmplitudeADC(-0x8000, ChannelType_t::HIGH_GAIN);
+  } else if (amplitude <= constants::EMCAL_HGLGTRANSITION * constants::EMCAL_ADCENERGY) {
+    Short_t a = (Short_t)(std::floor(amplitude / constants::EMCAL_ADCENERGY));
+    setAmplitudeADC(a, ChannelType_t::HIGH_GAIN);
+  } else if (amplitude <= 0x7fff * constants::EMCAL_ADCENERGY * constants::EMCAL_HGLGFACTOR) {
+    Short_t a = (Short_t)(std::floor(amplitude / (constants::EMCAL_ADCENERGY * constants::EMCAL_HGLGFACTOR)));
+    setAmplitudeADC(a, ChannelType_t::LOW_GAIN);
+  } else {
+    setAmplitudeADC(0x7fff, ChannelType_t::LOW_GAIN);
+  }
 }
 
 void Digit::PrintStream(std::ostream& stream) const
 {
-  stream << "EMCAL Digit: Tower " << mTower << ", Time " << getTimeStamp() << ", Energy " << mEnergy << ", type " << mChannelType;
+  stream << "EMCAL Digit: Tower " << mTower << ", Time " << getTimeStamp() << ", Amplitude " << getAmplitude() << " GeV, Type " << mChannelType;
 }
 
 std::ostream& operator<<(std::ostream& stream, const Digit& digi)

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/Digitizer.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/Digitizer.h
@@ -116,9 +116,9 @@ class Digitizer : public TObject
   std::vector<int> mTimeBinOffset;                            // offset of first time bin
   std::vector<std::vector<double>> mAmplitudeInTimeBins;      // amplitude of signal for each time bin
 
-  float mLiveTime = 1500; // EMCal live time (ns)
-  float mBusyTime = 0;    // EMCal busy time (ns)
-  int mDelay = 0;         // number of (full) time bins corresponding to the signal time delay
+  float mLiveTime = 1500;  // EMCal live time (ns)
+  float mBusyTime = 35000; // EMCal busy time (ns)
+  int mDelay = 7;          // number of (full) time bins corresponding to the signal time delay
 
   ClassDefOverride(Digitizer, 1);
 };

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/LabeledDigit.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/LabeledDigit.h
@@ -36,7 +36,7 @@ class LabeledDigit
   LabeledDigit() = default;
 
   LabeledDigit(Digit digit, o2::emcal::MCLabel label);
-  LabeledDigit(Short_t tower, Double_t energy, Double_t time, o2::emcal::MCLabel label);
+  LabeledDigit(Short_t tower, Double_t amplitudeGeV, Double_t time, o2::emcal::MCLabel label, ChannelType_t ctype = ChannelType_t::HIGH_GAIN);
   ~LabeledDigit() = default; // override
 
   void setDigit(Digit d) { mDigit = d; }
@@ -68,8 +68,29 @@ class LabeledDigit
   void setTower(Short_t tower) { mDigit.setTower(tower); }
   Short_t getTower() const { return mDigit.getTower(); }
 
-  void setEnergy(Double_t energy) { mDigit.setEnergy(energy); }
-  Double_t getEnergy() const { return mDigit.getEnergy(); }
+  void setAmplitude(Double_t amplitude) { mDigit.setAmplitude(amplitude); } // GeV
+  Double_t getAmplitude() const { return mDigit.getAmplitude(); }
+
+  void setEnergy(Double_t energy) { setAmplitude(energy); }
+  Double_t getEnergy() { return getAmplitude(); }
+
+  void setAmplitudeADC(Short_t amplitude, ChannelType_t ctype = ChannelType_t::HIGH_GAIN) { mDigit.setAmplitudeADC(amplitude, ctype); }
+  Int_t getAmplitudeADC(ChannelType_t ctype = ChannelType_t::HIGH_GAIN) const { return mDigit.getAmplitudeADC(ctype); }
+
+  void setType(ChannelType_t ctype) { mDigit.setType(ctype); }
+  ChannelType_t getType() const { return mDigit.getType(); }
+
+  void setHighGain() { mDigit.setHighGain(); }
+  Bool_t getHighGain() const { return mDigit.getHighGain(); }
+
+  void setLowGain() { mDigit.setLowGain(); }
+  Bool_t getLowGain() const { return mDigit.getLowGain(); }
+
+  void setTRU() { mDigit.setTRU(); }
+  Bool_t getTRU() const { return mDigit.getTRU(); }
+
+  void setLEDMon() { mDigit.setLEDMon(); }
+  Bool_t getLEDMon() const { return mDigit.getLEDMon(); }
 
   void PrintStream(std::ostream& stream) const;
 

--- a/Detectors/EMCAL/simulation/src/Digitizer.cxx
+++ b/Detectors/EMCAL/simulation/src/Digitizer.cxx
@@ -121,8 +121,8 @@ void Digitizer::process(const std::vector<Hit>& hits)
         }
 
         MCLabel label(hit.GetTrackID(), mCurrEvID, mCurrSrcID, false, 1.0);
-        if (digit.getEnergy() == 0)
-          label.setEnergyFraction(0);
+        if (digit.getAmplitude() == 0)
+          label.setAmplitudeFraction(0);
         LabeledDigit d(digit, label);
         mDigits[id].push_back(d);
       }
@@ -194,9 +194,9 @@ void Digitizer::setEventTime(double t)
 //_______________________________________________________________________
 void Digitizer::addNoiseDigits(LabeledDigit& d1)
 {
-  double energy = d1.getEnergy();
+  double amplitude = d1.getAmplitude();
   double sigma = mSimParam->getPinNoise();
-  if (energy > constants::EMCAL_HGLGTRANSITION * constants::EMCAL_ADCENERGY) {
+  if (amplitude > constants::EMCAL_HGLGTRANSITION * constants::EMCAL_ADCENERGY) {
     sigma = mSimParam->getPinNoiseLG();
   }
 
@@ -235,9 +235,9 @@ void Digitizer::fillOutputContainer(std::vector<Digit>& digits, o2::dataformats:
         addNoiseDigits(ld1);
       }
 
-      if (mRemoveDigitsBelowThreshold && (ld1.getEnergy() < mSimParam->getDigitThreshold() * (constants::EMCAL_ADCENERGY)))
+      if (mRemoveDigitsBelowThreshold && (ld1.getAmplitude() < mSimParam->getDigitThreshold() * (constants::EMCAL_ADCENERGY)))
         continue;
-      if (ld1.getEnergy() < 0)
+      if (ld1.getAmplitude() < 0)
         continue;
       if (ld1.getTimeStamp() >= mSimParam->getLiveTime())
         continue;

--- a/Detectors/EMCAL/simulation/src/LabeledDigit.cxx
+++ b/Detectors/EMCAL/simulation/src/LabeledDigit.cxx
@@ -19,8 +19,8 @@ LabeledDigit::LabeledDigit(Digit digit, o2::emcal::MCLabel label)
   mLabels.push_back(label);
 }
 
-LabeledDigit::LabeledDigit(Short_t tower, Double_t energy, Double_t time, o2::emcal::MCLabel label)
-  : mDigit(tower, energy, time)
+LabeledDigit::LabeledDigit(Short_t tower, Double_t amplitudeGeV, Double_t time, o2::emcal::MCLabel label, ChannelType_t ctype)
+  : mDigit(tower, amplitudeGeV, time, ctype)
 {
   mLabels.push_back(label);
 }
@@ -28,27 +28,27 @@ LabeledDigit::LabeledDigit(Short_t tower, Double_t energy, Double_t time, o2::em
 LabeledDigit& LabeledDigit::operator+=(const LabeledDigit& other)
 {
   if (canAdd(other)) {
-    Double_t e1 = getEnergy();
-    Double_t e2 = other.getEnergy();
-    Double_t r = (e1 + e2 != 0) ? 1 / (e1 + e2) : 0;
+    Int_t a1 = getAmplitudeADC();
+    Int_t a2 = other.getAmplitudeADC();
+    Double_t r = ((a1 + a2) != 0) ? 1.0 / (a1 + a2) : 0.0;
     mDigit += other.getDigit();
 
     for (int j = 0; j < mLabels.size(); j++) {
-      mLabels.at(j).setEnergyFraction(mLabels.at(j).getEnergyFraction() * e1 * r);
+      mLabels.at(j).setAmplitudeFraction(mLabels.at(j).getAmplitudeFraction() * a1 * r);
     }
 
     for (auto label : other.getLabels()) {
-      label.setEnergyFraction(label.getEnergyFraction() * e2 * r);
+      label.setAmplitudeFraction(label.getAmplitudeFraction() * a2 * r);
       mLabels.push_back(label);
     }
   }
-  // Does nothing if the digits are in different towers.
+  // Does nothing if the digits are in different towers or have incompatible times.
   return *this;
 }
 
 void LabeledDigit::PrintStream(std::ostream& stream) const
 {
-  stream << "EMCAL LabeledDigit: Tower " << getTower() << ", Time " << getTimeStamp() << ", Energy " << getEnergy() << ", Labels ( ";
+  stream << "EMCAL LabeledDigit: Tower " << getTower() << ", Time " << getTimeStamp() << ", Amplitude " << getAmplitude() << " GeV, Type " << getType() << ", Labels ( ";
   for (auto label : mLabels) {
     stream << label.getRawValue() << " ";
   }


### PR DESCRIPTION
[WIP EMCAL-501] store energy in Digits in ADC counts

 - Change "Energy" -> "Amplitude" in Digit and related classes
 - Store amplitude in ADC counts (either Low or High Gain) in Digits
 - Add constants::EMCAL_HGLGFACTOR = 16
 - Change constants::EMCAL_HGLGTRANSITION to Int_t
 - Digitizer.h: set mBusyTime = 35000 and mDelay = 7 for consistency with default values in SimParam.h