### PR TITLE
Temporary change of raw utils SubSpec definition

### DIFF
--- a/Detectors/ITSMFT/common/simulation/src/MC2RawEncoder.cxx
+++ b/Detectors/ITSMFT/common/simulation/src/MC2RawEncoder.cxx
@@ -33,7 +33,7 @@ void MC2RawEncoder<Mapping>::init()
     int nLinks = 0;
     for (int il = 0; il < MaxLinksPerRU; il++) {
       if (ruData.links[il]) {
-        auto subspec = o2::raw::HBFUtils::getSubSpec(ruData.links[il]->cruID, ruData.links[il]->id, ruData.links[il]->endPointID);
+        auto subspec = o2::raw::HBFUtils::getSubSpec(ruData.links[il]->cruID, ruData.links[il]->id, ruData.links[il]->endPointID, ruData.links[il]->feeID);
         if (!mWriter.isLinkRegistered(subspec)) {
           LOGF(INFO, "RU%3d FEEId 0x%04x Link %02d of CRU=0x%94x will be writing to default sink %s",
                int(ru), ruData.links[il]->feeID, ruData.links[il]->id, ruData.links[il]->cruID, mDefaultSinkName);
@@ -219,7 +219,8 @@ void MC2RawEncoder<Mapping>::fillGBTLinks(RUDecodeData& ru)
     LOGF(DEBUG, "Filled %s with %d GBT words", link->describe(), nPayLoadWordsNeeded + 3);
 
     // flush to writer
-    mWriter.addData(link->cruID, link->id, link->endPointID, mCurrIR, gsl::span((char*)link->data.data(), link->data.getSize()));
+    mWriter.addData(link->feeID, link->cruID, link->id, link->endPointID, mCurrIR,
+                    gsl::span((char*)link->data.data(), link->data.getSize()));
     link->data.clear();
     //
   } // loop over links of RU

--- a/Detectors/Raw/README.md
+++ b/Detectors/Raw/README.md
@@ -128,6 +128,11 @@ This `SubSpecification` is used to define the DPL InputSpecs (and match the Outp
 An `exception` will be thrown if 2 different link (i.e. with different RDH.feeId) of the same detector will be found to have the same SubSpec (i.e. the same cruID, linkID and PCIe EndPoint).
 Also, an `exception` is thrown if the block expected to be a RDH fails to be recognized as RDH.
 
+TEMPORARY UPDATE: given that some detectors (e.g. TOF, TPC) at the moment cannot guarantee a unique (within a given run) mapping FEEID <-> {cruID, linkID, EndPoint},
+the `SubSpecification` defined by the DataDistribution may mix data of different links (FEEDs) to single DPL input.
+To avoid this, the `SubSpecification` definition is temporarily changed to a 32 bit hash code (Fletcher32). When the new RDHv6 (with source ID) will be put in production, both
+DataDistribution and RawFileReader will be able to assign the `SubSpecification` in a consistent way, as a combination of FEEID and SourceID.
+
 Since the raw data (RDH) does not contain any explicit information equivalent to `o2::header::DataOrigin` and `o2::header::DataDescription` needed to create a valid DPL `OutputSpec`,
 for every raw data file provided to the `RawFileReader` the user can attach either explicitly needed origin and/or description, or to use default ones (which also can be modified by the user).
 By default, `RawFileReader` assumes `o2::header::gDataOriginFLP` and `o2::header::gDataDescriptionRawData` (leading to `FLP/RAWDATA` OutputSpec).

--- a/Detectors/Raw/include/DetectorsRaw/HBFUtils.h
+++ b/Detectors/Raw/include/DetectorsRaw/HBFUtils.h
@@ -152,13 +152,16 @@ struct HBFUtils : public o2::conf::ConfigurableParamHelper<HBFUtils> {
   static bool checkRDH(const o2::header::RAWDataHeaderV4& rdh, bool verbose = true);
   static bool checkRDH(const o2::header::RAWDataHeaderV5& rdh, bool verbose = true);
 
-  static LinkSubSpec_t getSubSpec(uint16_t cru, uint8_t link, uint8_t endpoint);
-  static LinkSubSpec_t getSubSpec(const o2::header::RAWDataHeaderV4& rdh) { return getSubSpec(rdh.cruID, rdh.linkID, rdh.endPointID); }
-  static LinkSubSpec_t getSubSpec(const o2::header::RAWDataHeaderV5& rdh) { return getSubSpec(rdh.cruID, rdh.linkID, rdh.endPointID); }
+  static LinkSubSpec_t getSubSpec(uint16_t cru, uint8_t link, uint8_t endpoint, uint16_t feeId);
+  static LinkSubSpec_t getSubSpec(const o2::header::RAWDataHeaderV4& rdh) { return getSubSpec(rdh.cruID, rdh.linkID, rdh.endPointID, rdh.feeId); }
+  static LinkSubSpec_t getSubSpec(const o2::header::RAWDataHeaderV5& rdh) { return getSubSpec(rdh.cruID, rdh.linkID, rdh.endPointID, rdh.feeId); }
 
   int nHBFPerTF = 1 + 0xff; // number of orbits per BC
   uint16_t bcFirst = 0;     ///< BC of 1st TF
   uint32_t orbitFirst = 0;  ///< orbit of 1st TF
+
+ private:
+  static uint32_t fletcher32(const uint16_t* data, int len);
 
   O2ParamDef(HBFUtils, "HBFUtils");
 };
@@ -217,11 +220,17 @@ inline o2::header::RAWDataHeaderV5 HBFUtils::createRDH<o2::header::RAWDataHeader
 }
 
 //_____________________________________________________________________
-inline LinkSubSpec_t HBFUtils::getSubSpec(uint16_t cru, uint8_t link, uint8_t endpoint)
+inline LinkSubSpec_t HBFUtils::getSubSpec(uint16_t cru, uint8_t link, uint8_t endpoint, uint16_t feeId)
 {
+  /*
+  // RS Temporarily suppress this way since such a subspec does not define the TOF/TPC links in a unique way
   // define subspecification as in DataDistribution
   int linkValue = (LinkSubSpec_t(link) + 1) << (endpoint == 1 ? 8 : 0);
   return (LinkSubSpec_t(cru) << 16) | linkValue;
+  */
+  // RS Temporarily suppress this way since such a link is ambiguous
+  uint16_t seq[3] = {cru, uint16_t((uint16_t(link) << 8) | endpoint), feeId};
+  return fletcher32(seq, 3);
 }
 
 } // namespace raw

--- a/Detectors/Raw/include/DetectorsRaw/RawFileWriter.h
+++ b/Detectors/Raw/include/DetectorsRaw/RawFileWriter.h
@@ -131,10 +131,10 @@ class RawFileWriter
   void registerLink(const RDH& rdh, const std::string& outFileName);
 
   LinkData& getLinkWithSubSpec(LinkSubSpec_t ss) { return mSSpec2Link[ss]; }
-  LinkData& getLinkWithSubSpec(const RDH& rdh) { return mSSpec2Link[HBFUtils::getSubSpec(rdh.cruID, rdh.linkID, rdh.endPointID)]; }
+  LinkData& getLinkWithSubSpec(const RDH& rdh) { return mSSpec2Link[HBFUtils::getSubSpec(rdh.cruID, rdh.linkID, rdh.endPointID, rdh.feeId)]; }
 
-  void addData(uint16_t cru, uint8_t lnk, uint8_t endpoint, const IR& ir, const gsl::span<char> data);
-  void addData(const RDH& rdh, const IR& ir, const gsl::span<char> data) { addData(rdh.cruID, rdh.linkID, rdh.endPointID, ir, data); }
+  void addData(uint16_t feeid, uint16_t cru, uint8_t lnk, uint8_t endpoint, const IR& ir, const gsl::span<char> data);
+  void addData(const RDH& rdh, const IR& ir, const gsl::span<char> data) { addData(rdh.feeId, rdh.cruID, rdh.linkID, rdh.endPointID, ir, data); }
 
   void setContinuousReadout() { mROMode = Continuous; }
   void setTriggeredReadout() { mROMode = Triggered; }

--- a/Detectors/Raw/src/HBFUtils.cxx
+++ b/Detectors/Raw/src/HBFUtils.cxx
@@ -240,3 +240,23 @@ bool HBFUtils::checkRDH(const o2::header::RAWDataHeaderV5& rdh, bool verbose)
   }
   return ok;
 }
+
+/// temporary: provide a hashcode (checksum) for RDH fields to be used as susbspec
+/// until unique soureID / FeeID is implemented
+/// Source: https://en.wikipedia.org/wiki/Fletcher%27s_checksum
+uint32_t HBFUtils::fletcher32(const uint16_t* data, int len)
+{
+  uint32_t c0, c1;
+  // We similarly solve for n > 0 and n * (n+1) / 2 * (2^16-1) < (2^32-1) here.
+  // On modern computers, using a 64-bit c0/c1 could allow a group size of 23726746.
+  for (c0 = c1 = 0; len > 0; len -= 360) {
+    int blocklen = len < 360 ? len : 360;
+    for (int i = 0; i < blocklen; ++i) {
+      c0 = c0 + *data++;
+      c1 = c1 + c0;
+    }
+    c0 = c0 % 65535;
+    c1 = c1 % 65535;
+  }
+  return (c1 << 16 | c0);
+}

--- a/Detectors/Raw/src/RawFileReader.cxx
+++ b/Detectors/Raw/src/RawFileReader.cxx
@@ -206,7 +206,7 @@ bool RawFileReader::LinkData::preprocessCRUPage(const RDH& rdh, bool newSPage)
     HBFUtils::dumpRDH(rdhl);
     LOGF(ERROR, "new RDH assigned SubSpec=0x%-8d:", subspec);
     HBFUtils::dumpRDH(rdh);
-    throw std::runtime_error("Confliting SubSpecs are provided");
+    throw std::runtime_error("Conflicting SubSpecs are provided");
     ok = false;
     nErrors++;
   }

--- a/Detectors/Raw/src/RawFileWriter.cxx
+++ b/Detectors/Raw/src/RawFileWriter.cxx
@@ -56,7 +56,7 @@ void RawFileWriter::registerLink(uint16_t fee, uint16_t cru, uint8_t link, uint8
 {
   // register the GBT link and its output file
 
-  auto sspec = HBFUtils::getSubSpec(cru, link, endpoint);
+  auto sspec = HBFUtils::getSubSpec(cru, link, endpoint, fee);
   auto& linkData = getLinkWithSubSpec(sspec);
   auto* file = mFName2File[outFileName];
   if (!file) {
@@ -99,16 +99,16 @@ void RawFileWriter::registerLink(const RDH& rdh, const std::string& outFileName)
 }
 
 //_____________________________________________________________________
-void RawFileWriter::addData(uint16_t cru, uint8_t lnk, uint8_t endpoint, const IR& ir, const gsl::span<char> data)
+void RawFileWriter::addData(uint16_t feeid, uint16_t cru, uint8_t lnk, uint8_t endpoint, const IR& ir, const gsl::span<char> data)
 {
   // add payload to relevant links
   if (data.size() % HBFUtils::GBTWord) {
     LOG(ERROR) << "provided payload size " << data.size() << " is not multiple of GBT word size";
     throw std::runtime_error("payload size is not mutiple of GBT word size");
   }
-  auto sspec = HBFUtils::getSubSpec(cru, lnk, endpoint);
+  auto sspec = HBFUtils::getSubSpec(cru, lnk, endpoint, feeid);
   if (!isLinkRegistered(sspec)) {
-    LOGF(ERROR, "The link for SubSpec=0x%ux(%u:%u:%u) was not registered", sspec, cru, lnk, endpoint);
+    LOGF(ERROR, "The link for SubSpec=0x%ux(%u:%u:%u:%u) was not registered", sspec, cru, lnk, endpoint, feeid);
     throw std::runtime_error("data for non-registered GBT link supplied");
   }
   auto& link = getLinkWithSubSpec(sspec);
@@ -340,7 +340,7 @@ std::string RawFileWriter::LinkData::describe() const
 {
   std::stringstream ss;
   ss << "Link SubSpec=0x" << std::hex << std::setw(8) << std::setfill('0')
-     << HBFUtils::getSubSpec(rdhCopy.cruID, rdhCopy.linkID, rdhCopy.endPointID) << std::dec
+     << HBFUtils::getSubSpec(rdhCopy.cruID, rdhCopy.linkID, rdhCopy.endPointID, rdhCopy.feeId) << std::dec
      << '(' << std::setw(3) << int(rdhCopy.cruID) << ':' << std::setw(2) << int(rdhCopy.linkID) << ':'
      << int(rdhCopy.endPointID) << ") feeID=0x" << std::hex << std::setw(4) << std::setfill('0') << rdhCopy.feeId;
   return ss.str();

--- a/Detectors/Raw/test/testRawReaderWriter.cxx
+++ b/Detectors/Raw/test/testRawReaderWriter.cxx
@@ -95,7 +95,7 @@ struct SimpleRawWriter { // simple class to create detector payload for multiple
           } else {
             buffer.clear();
           }
-          writer.addData(icru, il, 0, ir, buffer);
+          writer.addData((icru << 8) + il, icru, il, 0, ir, buffer);
         }
       }
     }


### PR DESCRIPTION
given that some detectors (e.g. TOF, TPC) at the moment cannot guarantee a unique
(within a given run) mapping FEEID <-> {cruID, linkID, EndPoint}, the
defined by the DataDistribution may mix data of different links (FEEDs) to single DPL input.

To avoid this, the  definition is temporarily changed to a 32 bit hash
code (Fletcher32). When the new RDHv6 (with source ID) will be put in production, both
DataDistribution and RawFileReader will be able to assign the  in a
consistent way, as a combination of FEEID and SourceID.