### PR TITLE
Possibility to add to the link CRU page with preformatted payload:

### DIFF
--- a/Detectors/Raw/README.md
+++ b/Detectors/Raw/README.md
@@ -35,8 +35,8 @@ write their data to the same file:
 ```cpp
 using namespace o2::raw;
 RawFileWriter writer;
-writer.registerLink(fee_0, cru_0, link_0, endpoint_0, "outfile_0.raw");
-writer.registerLink(fee_1, cru_0, link_1, endpoint_0, "outfile_0.raw");
+auto& lnkA = writer.registerLink(fee_0, cru_0, link_0, endpoint_0, "outfile_0.raw");
+auto& lnkB = writer.registerLink(fee_1, cru_0, link_1, endpoint_0, "outfile_0.raw");
 ..
 // or
 o2::header::RawDataHeader rdh; // by default, v4 is used currently.
@@ -44,16 +44,18 @@ rdh.feeId = feeX;
 rdh.cruID = cruY;
 rdh.linkID = linkZ;
 rdh.endPointID = endpointQ;
-writer.registerLink( rdh, "outfile_f.raw");
+auto& lnkC = writer.registerLink( rdh, "outfile_f.raw");
 ```
+If needed, user may set manually the non-mutable (for given link) fields of the link RAWDataHeader via direct access to `lnkC.rdhCopy`. This fields will be cloned to all RDHs written for this link.
+
 *   add raw data payload to the `RawFileWriter`, providing the link information and the `o2::InteractionRecord` corresponding to payload.
 The data must be provided as a `gsl::span<char>`` and contain only detector GBT (16 bytes words) payload. The annotation by RDH,
 formatting to CRU pages and eventual splitting of the large payload to multiple pages will be done by the `RawFileWriter`.
 ```cpp
-writer.addData(cru_0, link_0, endpoint_0, {bc, orbit}, gsl::span( (char*)payload_0, payload_0_size ) );
+writer.addData(cru_0, link_0, endpoint_0, {bc, orbit}, gsl::span( (char*)payload_0, payload_0_size) );
 ...
 o2::InteractionRecord ir{bc, orbit};
-writer.addData(rdh, ir, gsl::span( (char*)payload_f, payload_f_size ) );
+writer.addData(rdh, ir, gsl::span( (char*)payload_f, payload_f_size ));
 ```
 
 The `RawFileWriter` will take care of writing created CRU data to file in `super-pages` whose size can be set using
@@ -114,8 +116,20 @@ toAdd   : a vector (supplied empty) to be filled to a size multipe of 16 bytes
 
 The data `toAdd` will be inserted between the star/stop RDHs of the empty HBF.
 
+The behaviour descibed above can be modified by providing an extra argument in the `addData` method
+```cpp
+bool preformatted = true;
+writer.addData(cru_0, link_0, endpoint_0, {bc, orbit}, gsl::span( (char*)payload_0, payload_0_size ), preformatted );
+...
+o2::InteractionRecord ir{bc, orbit};
+writer.addData(rdh, ir, gsl::span( (char*)payload_f, payload_f_size ), preformatted );
+```
+
+In this case provided span is interpretted as a fully formatted CRU page payload (i.e. it lacks the RDH which will be added by the writer) of the maximum size `8192-sizeof(RDH) = 8128` bytes.
+The writer will create a new CRU page with provided payload equipping it with the proper RDH: copying already stored RDH of the current HBF, if the interaction record `ir` belongs to the same HBF or generating new RDH for new HBF otherwise (and filling all missing HBFs in-between). In case the payload size exceeds maximum, an exception will be thrown w/o any attempt to split the page.
+
 For further details see  ``ITSMFT/common/simulation/MC2RawEncoder`` class and the macro
-`Detectors/ITSMFT/ITS/macros/test/run_digi2rawVarPage_its.C` to steed the MC to raw data conversion.
+`Detectors/ITSMFT/ITS/macros/test/run_digi2rawVarPage_its.C` to steer the MC to raw data conversion.
 
 ## RawFileReader
 

--- a/Detectors/Raw/include/DetectorsRaw/HBFUtils.h
+++ b/Detectors/Raw/include/DetectorsRaw/HBFUtils.h
@@ -127,7 +127,7 @@ struct HBFUtils : public o2::conf::ConfigurableParamHelper<HBFUtils> {
 
   // some fields of the same meaning have different names in the RDH of different versions
   static uint32_t getHBOrbit(const void* rdhP);
-  static uint32_t getHBBC(const void* rdhP);
+  static uint16_t getHBBC(const void* rdhP);
   static IR getHBIR(const void* rdhP);
 
   static void printRDH(const void* rdhP);
@@ -138,8 +138,8 @@ struct HBFUtils : public o2::conf::ConfigurableParamHelper<HBFUtils> {
   static uint32_t getHBOrbit(const o2::header::RAWDataHeaderV4& rdh) { return rdh.heartbeatOrbit; }
   static uint32_t getHBOrbit(const o2::header::RAWDataHeaderV5& rdh) { return rdh.orbit; }
 
-  static uint32_t getHBBC(const o2::header::RAWDataHeaderV4& rdh) { return rdh.heartbeatBC; }
-  static uint32_t getHBBC(const o2::header::RAWDataHeaderV5& rdh) { return rdh.bunchCrossing; }
+  static uint16_t getHBBC(const o2::header::RAWDataHeaderV4& rdh) { return rdh.heartbeatBC; }
+  static uint16_t getHBBC(const o2::header::RAWDataHeaderV5& rdh) { return rdh.bunchCrossing; }
 
   static IR getHBIR(const o2::header::RAWDataHeaderV4& rdh) { return {uint16_t(rdh.heartbeatBC), uint32_t(rdh.heartbeatOrbit)}; }
   static IR getHBIR(const o2::header::RAWDataHeaderV5& rdh) { return {uint16_t(rdh.bunchCrossing), uint32_t(rdh.orbit)}; }

--- a/Detectors/Raw/src/HBFUtils.cxx
+++ b/Detectors/Raw/src/HBFUtils.cxx
@@ -156,7 +156,7 @@ uint32_t HBFUtils::getHBOrbit(const void* rdhP)
 }
 
 //_________________________________________________
-uint32_t HBFUtils::getHBBC(const void* rdhP)
+uint16_t HBFUtils::getHBBC(const void* rdhP)
 {
   int version = (reinterpret_cast<const char*>(rdhP))[0];
   if (version == 4) {

--- a/Detectors/Raw/test/testRawReaderWriter.cxx
+++ b/Detectors/Raw/test/testRawReaderWriter.cxx
@@ -33,12 +33,17 @@ using namespace o2::raw;
 using RDH = o2::header::RAWDataHeaderV4;
 using IR = o2::InteractionRecord;
 
-constexpr int NCRU = 3;        // number of CRUs
+constexpr int NCRU = 3 + 1;    // number of CRUs, the last one is a special CRU with preformatted data filled
 constexpr int NLinkPerCRU = 4; // number of links per CRU
+// sizes for preformatted pages filling (RDH size will be subtracted from the payload) in the last special CRU
+constexpr std::array<int, NLinkPerCRU> SpecSize = {512, 1024, 8192, 8192};
+constexpr int NPreformHBFPerTF = 32; // number of HBFs with preformatted input per HBF for special last CRU
 const std::string PLHeader = "HEADER          ";
 const std::string PLTrailer = "TRAILER         ";
 const std::string HBFEmpty = "EMPTY_HBF       ";
 const std::string CFGName = "test_RawReadWrite_.cfg";
+
+int nPreformatPages = 0;
 
 //
 // ========================= simple detector data writer ================================
@@ -58,9 +63,11 @@ struct SimpleRawWriter { // simple class to create detector payload for multiple
     for (int icru = 0; icru < NCRU; icru++) {
       std::string outFileName = "testdata_cru" + std::to_string(icru) + ".raw";
       for (int il = 0; il < NLinkPerCRU; il++) {
-        writer.registerLink((icru << 8) + il, icru, il, 0, outFileName);
+        auto& link = writer.registerLink((icru << 8) + il, icru, il, 0, outFileName);
+        link.rdhCopy.detectorField = 0xff << icru; // if needed, set extra link info, will be copied to all RDHs
       }
     }
+
     writer.setContinuousReadout();     // in case we want to issue StartOfContinuous trigger in the beginning
     writer.setCarryOverCallBack(this); // we want that writer to ask the detector code how to split large payloads
     writer.setEmptyPageCallBack(this); // we want the writer to ask the detector code what to put in empty HBFs
@@ -82,22 +89,36 @@ struct SimpleRawWriter { // simple class to create detector payload for multiple
 
     // create payload for every interaction and push it to writer
     for (const auto& ir : irs) {
-      for (int icru = 0; icru < NCRU; icru++) {
+      for (int icru = 0; icru < NCRU - 1; icru++) {
         // we will create non-0 payload for all but 1st link of every CRU, the writer should take care
         // of creating empty HBFs for the links w/o data
         for (int il = 0; il < NLinkPerCRU; il++) {
+          buffer.clear();
           int nGBT = gRandom->Poisson(HBFUtils::MAXCRUPage / HBFUtils::GBTWord * (il));
           if (nGBT) {
-            buffer.resize((nGBT + 2) * HBFUtils::GBTWord); // reserve 16B words accounting for the Header and Trailer
+            buffer.resize((nGBT + 2) * HBFUtils::GBTWord, icru * NLinkPerCRU + il); // reserve 16B words accounting for the Header and Trailer
             std::memcpy(buffer.data(), PLHeader.c_str(), HBFUtils::GBTWord);
             std::memcpy(buffer.data() + buffer.size() - HBFUtils::GBTWord, PLTrailer.c_str(), HBFUtils::GBTWord);
             // we don't care here about the content of the payload, except the presence of header and trailer
-          } else {
-            buffer.clear();
           }
           writer.addData((icru << 8) + il, icru, il, 0, ir, buffer);
         }
       }
+    }
+    // fill special CRU with preformatted pages
+    auto irHB = HBFUtils::Instance().getFirstIR(); // IR of the TF0/HBF0
+    int cruID = NCRU - 1;
+    while (irHB < irs.back()) {
+      for (int il = 0; il < NLinkPerCRU; il++) {
+        buffer.clear();
+        int pgSize = SpecSize[il] - sizeof(RDH);
+        buffer.resize(pgSize);
+        for (int ipg = 2 * (NLinkPerCRU - il); ipg--;) {                       // just to enforce writing multiple pages per selected HBFs
+          writer.addData((cruID << 8) + il, cruID, il, 0, irHB, buffer, true); // last argument is there to enforce a special "preformatted" mode
+          nPreformatPages++;
+        }
+      }
+      irHB.orbit += HBFUtils::Instance().getNOrbitsPerTF() / NPreformHBFPerTF; // we will write 32 such HBFs per TF
     }
 
     // for further use we write the configuration file for the output
@@ -185,7 +206,7 @@ struct SimpleRawReader { // simple class to read detector raw data for multiple 
     buffers.resize(nLinks); // 1 buffer per link
     firstHBF.resize(nLinks, true);
 
-    int nLinksRead = 0;
+    int nLinksRead = 0, nPreformatRead = 0;
     do {
       nLinksRead = 0;
       for (int il = 0; il < nLinks; il++) {
@@ -220,17 +241,26 @@ struct SimpleRawReader { // simple class to read detector raw data for multiple 
             if (rdhi.stop) {                                                   // closing page must be empty
               BOOST_CHECK(rdhi.memorySize == rdhi.headerSize);
             } else {
-              BOOST_CHECK(rdhi.memorySize > rdhi.headerSize);               // in this model all non-closing pages must contain something
-              if (rdhi.memorySize - rdhi.headerSize == HBFUtils::GBTWord) { // empty HBF will contain just a status word
-                testStr.assign(ptr + rdhi.headerSize, HBFUtils::GBTWord);
-                BOOST_CHECK(testStr == HBFEmpty);
-              } else {
-                // pages with real payload should have at least header + trailer + some payload
-                BOOST_CHECK(rdhi.memorySize - rdhi.headerSize > 2 * HBFUtils::GBTWord);
-                testStr.assign(ptr + rdhi.headerSize, HBFUtils::GBTWord);
-                BOOST_CHECK(testStr == PLHeader);
-                testStr.assign(ptr + rdhi.memorySize - HBFUtils::GBTWord, HBFUtils::GBTWord);
-                BOOST_CHECK(testStr == PLTrailer);
+              if (rdhi.cruID < NCRU - 1) {                                    // these are not special CRUs
+                BOOST_CHECK(rdhi.memorySize > rdhi.headerSize);               // in this model all non-closing pages must contain something
+                if (rdhi.memorySize - rdhi.headerSize == HBFUtils::GBTWord) { // empty HBF will contain just a status word
+                  testStr.assign(ptr + rdhi.headerSize, HBFUtils::GBTWord);
+                  BOOST_CHECK(testStr == HBFEmpty);
+                } else {
+                  // pages with real payload should have at least header + trailer + some payload
+                  BOOST_CHECK(rdhi.memorySize - rdhi.headerSize > 2 * HBFUtils::GBTWord);
+                  testStr.assign(ptr + rdhi.headerSize, HBFUtils::GBTWord);
+                  BOOST_CHECK(testStr == PLHeader);
+                  testStr.assign(ptr + rdhi.memorySize - HBFUtils::GBTWord, HBFUtils::GBTWord);
+                  BOOST_CHECK(testStr == PLTrailer);
+                }
+              } else { // for the special CRU with preformatted data make sure the page sizes were not modified
+                if (rdhi.memorySize > sizeof(RDH) + HBFUtils::GBTWord) {
+                  auto tfhb = HBFUtils::Instance().getTFandHBinTF({HBFUtils::getHBBC(rdhi), HBFUtils::getHBOrbit(rdhi)}); // TF and HBF relative to TF
+                  BOOST_CHECK(tfhb.second % (HBFUtils::Instance().getNOrbitsPerTF() / NPreformHBFPerTF) == 0);            // we were filling only every NPreformHBFPerTF-th HBF
+                  BOOST_CHECK(rdhi.memorySize == SpecSize[rdhi.linkID]);                                                  // check if the size is correct
+                  nPreformatRead++;
+                }
               }
             }
             ptr += rdhi.offsetToNext;
@@ -239,7 +269,10 @@ struct SimpleRawReader { // simple class to read detector raw data for multiple 
         }
       }
     } while (nLinksRead); // read until there is something to read
-  }                       // run
+
+    BOOST_CHECK(nPreformatRead == nPreformatPages); // make sure no preformatted page was lost
+
+  } // run
 };
 
 BOOST_AUTO_TEST_CASE(RawReaderWriter)


### PR DESCRIPTION
The autoformatting behaviour of RawFileWriter::addData can be changed
to preformatted page storage by adding an extra true argument in the end of addData method, e.g.
writer.addData(rdh, ir, gsl::span( (char*)payload_f, payload_f_size ), true );

In the case provided data blob is interpretted as a fully formatted CRU page payload (i.e. it lacks
the RDH which will be added by the writer) of the maximum size 8192-sizeof(RDH) = 8128 bytes.
The writer will create a new CRU page with provided payload, equipping it with the proper RDH:
copying already stored RDH of the current HBF, if the interaction record  belongs to the same HBF
or generating new RDH for new HBF otherwise (and filling all missing HBFs in-between).
In case the payload size exceeds maximum, an exception will be thrown w/o any attempt to split the page.