### PR TITLE
Restore optionality of DebugGUI and GLFW for O2 build

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -15,6 +15,9 @@ if(GLFW_FOUND)
 else()
   set(GUI_SOURCES src/FrameworkDummyDebugger.cxx)
 endif()
+if (TARGET AliceO2::DebugGUI)
+  set(DEBUGGUI_TARGET AliceO2::DebugGUI)
+endif()
 
 o2_add_library(Framework
                SOURCES src/AODReaderHelpers.cxx
@@ -113,7 +116,7 @@ o2_add_library(Framework
                                      arrow::arrow_shared
                                      ms_gsl::ms_gsl
                                      ROOT::ROOTDataFrame
-                                     AliceO2::DebugGUI
+                                     ${DEBUGGUI_TARGET}
                                      O2::FrameworkLogger
                                      Boost::serialization
                                      arrow::gandiva_shared
@@ -245,12 +248,17 @@ endforeach()
 
 # #####################################################@
 
+if (TARGET AliceO2::DebugGUI)
+set (DEBUG_GUI_TESTS_WORKFLOW
+     CustomGUIGL
+     CustomGUISokol
+     SimpleTracksED
+     )
+endif()
+
 foreach(w
         BoostSerializedProcessing
         CallbackService
-        CustomGUIGL
-        CustomGUISokol
-        SimpleTracksED
         DanglingInputs
         DanglingOutputs
         DataAllocator
@@ -268,6 +276,7 @@ foreach(w
         SingleDataSource
         Task
         ExternalFairMQDeviceWorkflow
+        ${DEBUG_GUI_TESTS_WORKFLOW}
         )
   o2_add_test(${w} NAME test_Framework_test_${w}
               SOURCES test/test_${w}.cxx
@@ -283,6 +292,7 @@ endforeach()
 # part. [WARN] Incoming data is already obsolete, not relaying.
 set_property(TEST test_Framework_test_DanglingInputs PROPERTY DISABLED TRUE)
 
+if (TARGET AliceO2::DebugGUI)
 # TODO: investigate the problem with the two unit tests, maybe setup of the CI
 # environment assertion fired X11: The DISPLAY environment variable is missing
 # glfw-3.2.1/src/window.c:579: glfwGetFramebufferSize: Assertion `window !=
@@ -290,6 +300,7 @@ set_property(TEST test_Framework_test_DanglingInputs PROPERTY DISABLED TRUE)
 set_property(TEST test_Framework_test_SimpleTracksED PROPERTY DISABLED TRUE)
 set_property(TEST test_Framework_test_CustomGUIGL PROPERTY DISABLED TRUE)
 set_property(TEST test_Framework_test_CustomGUISokol PROPERTY DISABLED TRUE)
+endif()
 
 # there is a problem in the termination of the FairMQDevice by signals because
 # the pending input polling is aborted and this throws an error

--- a/Framework/Core/include/Framework/DebugGUI.h
+++ b/Framework/Core/include/Framework/DebugGUI.h
@@ -17,9 +17,21 @@ namespace o2
 namespace framework
 {
 
-void* initGUI(const char* name);
-bool pollGUI(void* context, std::function<void(void)> guiCallback);
-void disposeGUI();
+// The DebugGUI has been moved to a separate package, this is a dummy header file
+// included when the DebugGUI package is not found or disabled.
+void* initGUI(const char* name)
+{
+  return nullptr;
+}
+
+bool pollGUI(void* context, std::function<void(void)> guiCallback)
+{
+  // returns whether quit is requested, we return 'no'
+  return false;
+}
+void disposeGUI()
+{
+}
 
 } // namespace framework
 } // namespace o2

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -18,7 +18,9 @@
 #if __has_include(<DebugGUI/DebugGUI.h>)
 #include "DebugGUI/DebugGUI.h"
 #else
-#pragma message "Old DebugGUI.h included. Update alidist."
+// the DebugGUI is in a separate package and is optional for O2,
+// we include a header implementing GUI interface dummy methods
+#pragma message "Building DPL without Debug GUI"
 #include "Framework/DebugGUI.h"
 #endif
 #include "Framework/DeviceControl.h"

--- a/GPU/GPUTracking/CMakeLists.txt
+++ b/GPU/GPUTracking/CMakeLists.txt
@@ -228,10 +228,10 @@ string(REPLACE ".cxx" ".h" HDRS_TMP "${SRCS_NO_CINT}")
 set(HDRS_INSTALL ${HDRS_INSTALL} ${HDRS_TMP})
 unset(HDRS_TMP)
 
+# the internal copy of ImgGUI has been removed in commit 64a93f3f and there is
+# only the optional external package
 if (TARGET AliceO2::DebugGUI)
   set(DEBUGGUI_TARGET AliceO2::DebugGUI)
-else()
-  set(DEBUGGUI_TARGET O2::DebugGUI)
 endif()
 # Main CMake part for O2
 if(ALIGPU_BUILD_TYPE STREQUAL "O2")


### PR DESCRIPTION
This is a follow-up to the cleanup in commit 64a93f3f

Despite the message from the cmake configuration that the packages mentioned below
are recommended but not required, O2 does not build correctly if development package of
GLFW is not available on the system.
```
-- The following RECOMMENDED packages have not been found:

 * GLFW
 * DebugGUI

  CMake Error at cmake/O2AddLibrary.cmake:75 (add_library):
    Target "O2lib-Framework" links to target "AliceO2::DebugGUI" but the target
    was not found.  Perhaps a find_package() call is missing for an IMPORTED
    target, or an ALIAS target is missing?
```

The DebugGUI package depends on package GLFW, but the package is defined optional
by alidist. If GLFW development files are not found on the system, a dummy package
is added by alidist, but it is not a real installation. That makes DebugGUI recipe
work but the cmake target `AliceO2::DebugGUI` can not be found in O2.

While this truly needs to be checked in alidist, the original idea was to have the
DebugGUI as an optional package for O2.

The internal copy if the ImgGui was removed in commit 64a93f3f and this requires to
implement dummy methods directly in `DebugGUI.h`, also the target `O2::DebugGUI` needs to be
removed as dependency.