### PR TITLE
DPL Analysis: rework invokeProcess to accept more than two arguments

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -48,6 +48,12 @@ constexpr bool is_type_with_metadata_v = false;
 template <typename T>
 constexpr bool is_type_with_metadata_v<T, std::void_t<decltype(sizeof(typename T::metadata))>> = true;
 
+template <typename, typename = void>
+constexpr bool is_type_with_binding_v = false;
+
+template <typename T>
+constexpr bool is_type_with_binding_v<T, std::void_t<decltype(sizeof(typename T::binding_t))>> = true;
+
 template <typename T, typename TLambda>
 void call_if_has_originals(TLambda&& lambda)
 {
@@ -1215,6 +1221,7 @@ struct Join : JoinBase<Ts...> {
   }
 
   using table_t = base;
+  using persistent_columns_t = typename table_t::persistent_columns_t;
   using iterator = typename table_t::template RowView<Join<Ts...>, Ts...>;
   using const_iterator = iterator;
   using filtered_iterator = typename table_t::template RowViewFiltered<Join<Ts...>, Ts...>;
@@ -1241,6 +1248,7 @@ struct Concat : ConcatBase<T1, T2> {
   using left_t = T1;
   using right_t = T2;
   using table_t = ConcatBase<T1, T2>;
+  using persistent_columns_t = typename table_t::persistent_columns_t;
 
   using iterator = typename table_t::template RowView<Concat<T1, T2>, T1, T2>;
   using filtered_iterator = typename table_t::template RowViewFiltered<Concat<T1, T2>, T1, T2>;
@@ -1258,6 +1266,7 @@ class Filtered : public T
  public:
   using originals = originals_pack_t<T>;
   using table_t = typename T::table_t;
+  using persistent_columns_t = typename T::persistent_columns_t;
 
   template <typename P, typename... Os>
   constexpr static auto make_it(framework::pack<Os...> const&)

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -22,6 +22,24 @@ namespace aod
 // the o2::aod namespace.
 DECLARE_SOA_STORE();
 
+template <typename... Tables>
+struct MetadataTrait<soa::Join<Tables...>> {
+  using type = soa::Join<Tables...>;
+  using metadata = typename MetadataTrait<typename framework::pack_element_t<0, typename type::originals>>::metadata;
+};
+
+template <typename... Tables>
+struct MetadataTrait<soa::Concat<Tables...>> {
+  using type = soa::Concat<Tables...>;
+  using metadata = typename MetadataTrait<typename framework::pack_element_t<0, typename type::originals>>::metadata;
+};
+
+template <typename... Tables>
+struct MetadataTrait<soa::Filtered<soa::Join<Tables...>>> {
+  using type = soa::Filtered<soa::Join<Tables...>>;
+  using metadata = typename MetadataTrait<typename framework::pack_element_t<0, typename type::originals>>::metadata;
+};
+
 namespace collision
 {
 // DECLARE_SOA_COLUMN(TimeframeId, timeframeId, uint64_t, "timeframeID");

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -22,24 +22,6 @@ namespace aod
 // the o2::aod namespace.
 DECLARE_SOA_STORE();
 
-template <typename... Tables>
-struct MetadataTrait<soa::Join<Tables...>> {
-  using type = soa::Join<Tables...>;
-  using metadata = typename MetadataTrait<typename framework::pack_element_t<0, typename type::originals>>::metadata;
-};
-
-template <typename... Tables>
-struct MetadataTrait<soa::Concat<Tables...>> {
-  using type = soa::Concat<Tables...>;
-  using metadata = typename MetadataTrait<typename framework::pack_element_t<0, typename type::originals>>::metadata;
-};
-
-template <typename... Tables>
-struct MetadataTrait<soa::Filtered<soa::Join<Tables...>>> {
-  using type = soa::Filtered<soa::Join<Tables...>>;
-  using metadata = typename MetadataTrait<typename framework::pack_element_t<0, typename type::originals>>::metadata;
-};
-
 namespace collision
 {
 // DECLARE_SOA_COLUMN(TimeframeId, timeframeId, uint64_t, "timeframeID");

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -349,7 +349,7 @@ struct AnalysisDataProcessorBuilder {
   static auto extractFilteredFromRecord(InputRecord& record, ExpressionInfo const& info, pack<Os...> const&)
   {
     if constexpr (soa::is_soa_iterator_t<T>::value) {
-      return soa::Filtered<typename T::table_t>(std::vector<std::shared_ptr<arrow::Table>>{extractTableFromRecord<Os>(record)...}, info.tree);
+      return typename T::parent_t(std::vector<std::shared_ptr<arrow::Table>>{extractTableFromRecord<Os>(record)...}, info.tree);
     } else {
       return T(std::vector<std::shared_ptr<arrow::Table>>{extractTableFromRecord<Os>(record)...}, info.tree);
     }
@@ -359,7 +359,8 @@ struct AnalysisDataProcessorBuilder {
   static auto extractSomethingFromRecord(InputRecord& record, std::vector<ExpressionInfo> const infos)
   {
     using decayed = std::decay_t<T>;
-    if constexpr (is_specialization<decayed, soa::Filtered>::value) {
+
+    if constexpr (soa::is_soa_filtered_t<decayed>::value) {
       for (auto& info : infos) {
         if (info.index == At)
           return extractFilteredFromRecord<decayed>(record, info, soa::make_originals_from_type<decayed>());
@@ -392,145 +393,235 @@ struct AnalysisDataProcessorBuilder {
     return std::tuple<>{};
   }
 
+  template <typename G, typename... A>
+  struct GroupSlicer {
+    using grouping_t = std::decay_t<G>;
+    GroupSlicer(G& gt, std::tuple<A...>& at)
+      : max{gt.size()},
+        mBegin{GroupSlicerIterator(gt, at)}
+    {
+    }
+
+    struct GroupSlicerSentinel {
+      int64_t position;
+    };
+
+    struct GroupSlicerIterator {
+      using associated_pack_t = framework::pack<A...>;
+
+      GroupSlicerIterator() = default;
+      GroupSlicerIterator(GroupSlicerIterator const&) = default;
+      GroupSlicerIterator(GroupSlicerIterator&&) = default;
+      GroupSlicerIterator& operator=(GroupSlicerIterator const&) = default;
+      GroupSlicerIterator& operator=(GroupSlicerIterator&&) = default;
+
+      GroupSlicerIterator(G& gt, std::tuple<A...>& at)
+        : mAt{&at},
+          groupingElement{gt.begin()},
+          position{0}
+      {
+        using groupingMetadata = typename aod::MetadataTrait<G>::metadata;
+        auto indexColumnName = std::string("f") + groupingMetadata::label() + "ID";
+        arrow::compute::FunctionContext ctx;
+        /// prepare slices and offsets for all associated tables that have index
+        /// to grouping table
+        ///
+        auto splitter = [&](auto&& x) {
+          if (hasIndexTo<std::decay_t<G>>(typename std::decay_t<decltype(x)>::persistent_columns_t{})) {
+            auto result = o2::framework::sliceByColumn(&ctx, indexColumnName,
+                                                       x.asArrowTable(),
+                                                       &groups[framework::has_type_at<std::decay_t<decltype(x)>>(associated_pack_t{})],
+                                                       &offsets[framework::has_type_at<std::decay_t<decltype(x)>>(associated_pack_t{})]);
+            if (result.ok() == false) {
+              throw std::runtime_error("Cannot split collection");
+            }
+          }
+        };
+
+        std::apply(
+          [&](auto&&... x) -> void {
+            (splitter(x), ...);
+          },
+          at);
+        /// extract selections from filtered associated tables
+        auto extractor = [&](auto&& x) {
+          if constexpr (soa::is_soa_filtered_t<std::decay_t<decltype(x)>>::value) {
+            selections[framework::has_type_at<std::decay_t<decltype(x)>>(associated_pack_t{})] = &x.getSelectedRows();
+            starts[framework::has_type_at<std::decay_t<decltype(x)>>(associated_pack_t{})] = selections[framework::has_type_at<std::decay_t<decltype(x)>>(associated_pack_t{})]->begin();
+            offsets[framework::has_type_at<std::decay_t<decltype(x)>>(associated_pack_t{})].push_back(std::get<std::decay_t<decltype(x)>>(at).tableSize());
+          }
+        };
+        std::apply(
+          [&](auto&&... x) -> void {
+            (extractor(x), ...);
+          },
+          at);
+      }
+
+      template <typename B, typename... C>
+      constexpr bool hasIndexTo(framework::pack<C...>&&)
+      {
+        return (isIndexTo<B, C>() || ...);
+      }
+
+      template <typename B, typename C>
+      constexpr bool isIndexTo()
+      {
+        if constexpr (soa::is_type_with_binding_v<C>) {
+          return std::is_same_v<typename C::binding_t, B>;
+        } else {
+          return false;
+        }
+        O2_BUILTIN_UNREACHABLE();
+      }
+
+      GroupSlicerIterator operator++()
+      {
+        ++position;
+        ++groupingElement;
+        return *this;
+      }
+
+      bool operator==(GroupSlicerSentinel const& other)
+      {
+        return O2_BUILTIN_UNLIKELY(position == other.position);
+      }
+
+      bool operator!=(GroupSlicerSentinel const& other)
+      {
+        return O2_BUILTIN_LIKELY(position != other.position);
+      }
+
+      auto& GroupingElement()
+      {
+        return groupingElement;
+      }
+
+      GroupSlicerIterator& operator*()
+      {
+        return *this;
+      }
+
+      auto AssociatedTables()
+      {
+        return std::make_tuple(prepareArgument<A>()...);
+      }
+
+      template <typename A1>
+      auto prepareArgument()
+      {
+        constexpr unsigned int index = framework::has_type_v<A1, associated_pack_t>;
+        if (hasIndexTo<G>(typename std::decay_t<A1>::persistent_columns_t{})) {
+          if constexpr (soa::is_soa_filtered_t<std::decay_t<A1>>::value) {
+            auto groupedElementsTable = arrow::util::get<std::shared_ptr<arrow::Table>>(((groups[index])[position]).value);
+
+            // for each grouping element we need to slice the selection vector
+            auto start_iterator = std::lower_bound(starts[index], selections[index]->end(), (offsets[index])[position]);
+            auto stop_iterator = std::lower_bound(start_iterator, selections[index]->end(), (offsets[index])[position + 1]);
+            starts[index] = stop_iterator;
+            soa::SelectionVector slicedSelection{start_iterator, stop_iterator};
+            std::transform(slicedSelection.begin(), slicedSelection.end(), slicedSelection.begin(),
+                           [&](int64_t idx) {
+                             return idx - static_cast<int64_t>((offsets[index])[position]);
+                           });
+
+            std::decay_t<A1> typedTable{{groupedElementsTable}, std::move(slicedSelection), (offsets[index])[position]};
+            return typedTable;
+          } else {
+            auto groupedElementsTable = arrow::util::get<std::shared_ptr<arrow::Table>>(((groups[index])[position]).value);
+            std::decay_t<A1> typedTable{{groupedElementsTable}, (offsets[index])[position]};
+            return typedTable;
+          }
+        } else {
+          return std::get<A1>(*mAt);
+        }
+        O2_BUILTIN_UNREACHABLE();
+      }
+
+      std::tuple<A...>* mAt;
+      typename grouping_t::iterator groupingElement;
+      uint64_t position = 0;
+
+      std::array<std::vector<arrow::compute::Datum>, sizeof...(A)> groups;
+      std::array<std::vector<uint64_t>, sizeof...(A)> offsets;
+      std::array<soa::SelectionVector const*, sizeof...(A)> selections;
+      std::array<soa::SelectionVector::const_iterator, sizeof...(A)> starts;
+    };
+
+    GroupSlicerIterator& begin()
+    {
+      return mBegin;
+    }
+
+    GroupSlicerSentinel end()
+    {
+      return GroupSlicerSentinel{max};
+    }
+    int64_t max;
+    GroupSlicerIterator mBegin;
+  };
+
   template <typename Task, typename R, typename C, typename Grouping, typename... Associated>
   static void invokeProcess(Task& task, InputRecord& inputs, R (C::*)(Grouping, Associated...), std::vector<ExpressionInfo> const& infos)
   {
+    using G = std::decay_t<Grouping>;
     auto groupingTable = AnalysisDataProcessorBuilder::bindGroupingTable(inputs, &C::process, infos);
-    auto associatedTables = AnalysisDataProcessorBuilder::bindAssociatedTables(inputs, &C::process, infos);
-
     if constexpr (sizeof...(Associated) == 0) {
-      // No extra tables: we need to either iterate over the contents of
-      // grouping or pass the whole grouping table, depending on whether Grouping
-      // is a o2::soa::Table or a o2::soa::RowView
-      if constexpr (soa::is_soa_table_t<std::decay_t<Grouping>>::value) {
-        task.process(groupingTable);
-      } else if constexpr (soa::is_soa_iterator_t<std::decay_t<Grouping>>::value) {
-        for (auto& groupedElement : groupingTable) {
-          task.process(groupedElement);
-        }
-      } else if constexpr (soa::is_soa_join_t<std::decay_t<Grouping>>::value) {
-        task.process(groupingTable);
-      } else if constexpr (soa::is_soa_filtered_t<std::decay_t<Grouping>>::value) {
-        task.process(groupingTable);
-      } else {
-        static_assert(always_static_assert_v<Grouping>,
-                      "The first argument of the process method of your task must be either"
-                      " a o2::soa::Table or a o2::soa::RowView");
-      }
-    } else if constexpr (sizeof...(Associated) == 1) {
-      // One extra table provided: if the first argument itself is a table,
-      // then we simply pass it over to the process method and let the user do the
-      // double looping (e.g. if they want to do some association between different
-      // physics quantities.
-      //
-      // If the first argument is a single element, we consider that the user
-      // wants to do a loop first on the table associated to the first element,
-      // then to the subgroup of the second table which is associated to the
-      // first one. E.g.:
-      //
-      // MyTask::process(Collision const& collision, Tracks const& tracks)
-      //
-      // Will iterate on all the tracks for the provided collision.
-      if constexpr (soa::is_soa_table_t<std::decay_t<Grouping>>::value) {
-        static_assert(((soa::is_soa_iterator_t<std::decay_t<Associated>>::value == false) && ...),
-                      "You cannot have a soa::RowView iterator as an argument after the "
-                      " first argument of type soa::Table which is found as in the "
-                      " prototype of the task process method.");
-        auto& associated = std::get<0>(associatedTables);
-        associated.bindExternalIndices(&groupingTable);
-        groupingTable.bindExternalIndices(&associated);
-        task.process(groupingTable, associated);
-      } else if constexpr (soa::is_soa_iterator_t<std::decay_t<Grouping>>::value) {
-        using AssociatedType = std::tuple_element_t<0, std::tuple<Associated...>>;
-        if constexpr (soa::is_soa_iterator_t<std::decay_t<AssociatedType>>::value) {
-          auto groupedTable = std::get<0>(associatedTables);
-          size_t currentGrouping = 0;
-          Grouping groupingElement = groupingTable.begin();
-          for (auto& groupedElement : groupedTable) {
-            // FIXME: this only works for collisions for now...
-            auto groupingIndex = groupedElement.collisionId(); // Fine for the moment.
-            // We find the associated collision, assuming they are sorted.
-            while (groupingIndex > currentGrouping) {
-              // This const_cast is done because I do not want people to be
-              // able to move the iterator in the user code.
-              ++const_cast<std::decay_t<Grouping>&>(groupingElement);
-              ++const_cast<std::decay_t<AssociatedType>&>(groupedElement);
-            }
-            task.process(groupingElement, groupedElement);
-          }
-        } else if constexpr (soa::is_soa_table_like_t<std::decay_t<AssociatedType>>::value) {
-          auto allGroupedTable = std::get<0>(associatedTables);
-          using groupingMetadata = typename aod::MetadataTrait<std::decay_t<Grouping>>::metadata;
-          arrow::compute::FunctionContext ctx;
-          std::vector<arrow::compute::Datum> groupsCollection;
-          auto indexColumnName = std::string("f") + groupingMetadata::label() + "ID";
-          std::vector<uint64_t> offsets;
-          auto result = o2::framework::sliceByColumn(&ctx, indexColumnName,
-                                                     allGroupedTable.asArrowTable(), &groupsCollection, &offsets);
-          if (result.ok() == false) {
-            LOGF(ERROR, "Error while splitting second collection");
-            return;
-          }
-          size_t currentGrouping = 0;
-          auto groupingElement = groupingTable.begin();
-
-          // FIXME: this assumes every groupingElement has a group associated,
-          // which migh not be the case.
-          size_t oi = 0;
-          if constexpr (soa::is_soa_table_t<std::decay_t<AssociatedType>>::value) {
-            for (auto& groupedDatum : groupsCollection) {
-              auto groupedElementsTable = arrow::util::get<std::shared_ptr<arrow::Table>>(groupedDatum.value);
-              std::decay_t<AssociatedType> typedTable{groupedElementsTable, offsets[oi]};
-              typedTable.bindExternalIndices(&groupingTable);
-              task.process(groupingElement, typedTable);
-              ++const_cast<std::decay_t<Grouping>&>(groupingElement);
-              ++oi;
-            }
-          } else if constexpr (soa::is_soa_filtered_t<std::decay_t<AssociatedType>>::value) {
-            auto& fullSelection = allGroupedTable.getSelectedRows();
-            offsets.push_back(allGroupedTable.tableSize());
-
-            auto current_start = fullSelection.begin();
-
-            for (auto& groupedDatum : groupsCollection) {
-              auto groupedElementsTable = arrow::util::get<std::shared_ptr<arrow::Table>>(groupedDatum.value);
-
-              // for each grouping element we need to slice the selection vector
-              auto start_iterator = std::lower_bound(current_start, fullSelection.end(), offsets[oi]);
-              auto stop_iterator = std::lower_bound(start_iterator, fullSelection.end(), offsets[oi + 1]);
-              current_start = stop_iterator;
-              soa::SelectionVector slicedSelection{start_iterator, stop_iterator};
-              std::transform(slicedSelection.begin(), slicedSelection.end(), slicedSelection.begin(), [&](int64_t index) { return index - static_cast<int64_t>(offsets[oi]); });
-
-              std::decay_t<AssociatedType> typedTable{{groupedElementsTable}, std::move(slicedSelection), offsets[oi]};
-              typedTable.bindExternalIndices(&groupingTable);
-              task.process(groupingElement, typedTable);
-              ++const_cast<std::decay_t<Grouping>&>(groupingElement);
-              ++oi;
-            }
-          } else if constexpr (soa::is_soa_join_t<std::decay_t<AssociatedType>>::value || soa::is_soa_concat_t<std::decay_t<AssociatedType>>::value) {
-            for (auto& groupedDatum : groupsCollection) {
-              auto groupedElementsTable = arrow::util::get<std::shared_ptr<arrow::Table>>(groupedDatum.value);
-              // Set the refererred table.
-              // FIXME: we should be able to do this upfront for all the tables.
-              std::decay_t<AssociatedType> typedTable{{groupedElementsTable}, offsets[oi]};
-              typedTable.bindExternalIndices(&groupingTable);
-              task.process(groupingElement, typedTable);
-              ++const_cast<std::decay_t<Grouping>&>(groupingElement);
-              ++oi;
-            }
-          }
-        } else {
-          static_assert(always_static_assert_v<AssociatedType>, "I do not know how to iterate on this");
+      // single argument to process
+      if constexpr (soa::is_soa_iterator_t<G>::value) {
+        for (auto& element : groupingTable) {
+          task.process(*element);
         }
       } else {
-        static_assert(always_static_assert_v<Grouping>,
-                      "Only grouping by Collision is supported for now");
+        static_assert(soa::is_soa_table_like_t<G>::value,
+                      "Single argument of process() should be a table-like or an iterator");
+        task.process(groupingTable);
       }
     } else {
-      static_assert(always_static_assert_v<Grouping, Associated...>,
-                    "Unable to find a way to iterate on the provided set of arguments. Probably unimplemented");
+      // multiple arguments to process
+      static_assert(((soa::is_soa_iterator_t<std::decay_t<Associated>>::value == false) && ...),
+                    "Associated arguments of process() should not be iterators");
+      auto associatedTables = AnalysisDataProcessorBuilder::bindAssociatedTables(inputs, &C::process, infos);
+      if constexpr (soa::is_soa_iterator_t<G>::value) {
+        // grouping case
+        auto slicer = GroupSlicer(groupingTable, associatedTables);
+        for (auto& slice : slicer) {
+          auto associatedSlices = slice.AssociatedTables();
+          (std::get<std::decay_t<Associated>>(associatedSlices).bindExternalIndices(&groupingTable), ...);
+          (groupingTable.bindExternalIndices(&std::get<std::decay_t<Associated>>(associatedSlices)), ...);
+          auto binder = [&](auto&& x) {
+            (std::get<std::decay_t<Associated>>(associatedSlices).bindExternalIndices(&x), ...);
+          };
+          std::apply(
+            [&](auto&&... x) {
+              (binder(x), ...);
+            },
+            associatedSlices);
+
+          invokeProcessWithArgs(task, slice.GroupingElement(), associatedSlices);
+        }
+      } else {
+        // non-grouping case
+        (std::get<std::decay_t<Associated>>(associatedTables).bindExternalIndices(&groupingTable), ...);
+        (groupingTable.bindExternalIndices(&std::get<std::decay_t<Associated>>(associatedTables)), ...);
+        auto binder = [&](auto&& x) {
+          (std::get<std::decay_t<Associated>>(associatedTables).bindExternalIndices(&x), ...);
+        };
+        std::apply(
+          [&](auto&&... x) {
+            (binder(x), ...);
+          },
+          associatedTables);
+
+        invokeProcessWithArgs(task, groupingTable, associatedTables);
+      }
     }
+  }
+
+  template <typename T, typename G, typename... A>
+  static void invokeProcessWithArgs(T& task, G g, std::tuple<A...>& at)
+  {
+    task.process(g, std::get<A>(at)...);
   }
 };
 

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -510,7 +510,7 @@ struct AnalysisDataProcessorBuilder {
       template <typename A1>
       auto prepareArgument()
       {
-        constexpr unsigned int index = framework::has_type_v<A1, associated_pack_t>;
+        constexpr auto index = framework::has_type_at<A1>(associated_pack_t{});
         if (hasIndexTo<G>(typename std::decay_t<A1>::persistent_columns_t{})) {
           if constexpr (soa::is_soa_filtered_t<std::decay_t<A1>>::value) {
             auto groupedElementsTable = arrow::util::get<std::shared_ptr<arrow::Table>>(((groups[index])[position]).value);

--- a/Framework/Core/test/test_AnalysisTask.cxx
+++ b/Framework/Core/test/test_AnalysisTask.cxx
@@ -58,7 +58,7 @@ struct ATask {
 // FIXME: for the moment we do not derive from AnalysisTask as
 // we need GCC 7.4+ to fix a bug.
 struct BTask {
-  void process(o2::aod::Collision const&, o2::aod::Track const&)
+  void process(o2::aod::Collision const&, o2::soa::Join<o2::aod::Tracks, o2::aod::TracksExtra, o2::aod::TracksCov> const&, o2::aod::UnassignedTracks const&, o2::soa::Join<o2::aod::Calos, o2::aod::CaloTriggers> const&)
   {
   }
 };
@@ -143,9 +143,14 @@ BOOST_AUTO_TEST_CASE(AdaptorCompilation)
   BOOST_CHECK_EQUAL(task1.outputs[0].binding.value, std::string("FooBars"));
 
   auto task2 = adaptAnalysisTask<BTask>("test2");
-  BOOST_CHECK_EQUAL(task2.inputs.size(), 2);
+  BOOST_CHECK_EQUAL(task2.inputs.size(), 7);
   BOOST_CHECK_EQUAL(task2.inputs[0].binding, "Collisions");
   BOOST_CHECK_EQUAL(task2.inputs[1].binding, "Tracks");
+  BOOST_CHECK_EQUAL(task2.inputs[2].binding, "TracksExtra");
+  BOOST_CHECK_EQUAL(task2.inputs[3].binding, "TracksCov");
+  BOOST_CHECK_EQUAL(task2.inputs[4].binding, "UnassignedTracks");
+  BOOST_CHECK_EQUAL(task2.inputs[5].binding, "Calos");
+  BOOST_CHECK_EQUAL(task2.inputs[6].binding, "CaloTriggers");
 
   auto task3 = adaptAnalysisTask<CTask>("test3");
   BOOST_CHECK_EQUAL(task3.inputs.size(), 2);


### PR DESCRIPTION
A substantial rework of invokeProcess() that allows user to request more than two arguments in process, see, for example, test_AnalysisTask.cxx:

```
struct BTask {
  void process(o2::aod::Collision const&, o2::soa::Join<o2::aod::Tracks, o2::aod::TracksExtra, o2::aod::TracksCov> const&, o2::aod::UnassignedTracks const&, o2::soa::Join<o2::aod::Calos, o2::aod::CaloTriggers> const&)
  {
  }
};
```

If the first argument of the process() is an iterator, all compatible tables in the rest of the arguments will be grouped according to the index of the table of the first argument. 