### PR TITLE
[MFT] Improve MFT fitter seed covariances

### DIFF
--- a/Detectors/ITSMFT/MFT/tracking/src/TrackFitter.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/TrackFitter.cxx
@@ -196,7 +196,7 @@ void TrackFitter::addCluster(const TrackParamMFT& startingParam, const o2::itsmf
   /// Throw an exception in case of failure
 
   if (cl.getZ() <= startingParam.getZ()) {
-    LOG(INFO) << "AddCluster ERROR: The new cluster must be upstream! ********************* ";
+    LOG(ERROR) << "AddCluster ERROR: The new cluster must be upstream! ********************* ";
     // FIXME! This should throw an error. Skiping due to bug on track finding.
     //throw std::runtime_error("The new cluster must be upstream");
   }

--- a/Detectors/ITSMFT/MFT/tracking/src/TrackFitter.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/TrackFitter.cxx
@@ -130,7 +130,8 @@ void TrackFitter::initTrack(const o2::itsmft::Cluster& cl, TrackParamMFT& param)
   double sigmax0sq = 0.0005;       // FIXME: from cluster
   double sigmay0sq = 0.0005;       // FIXME: from cluster
   double sigmaDeltaZsq = 5;        // Primary vertex distribution: beam interaction diamond
-  double sigmainvqptsq = .25 / pt; // Very large uncertainty on pt
+  double sigmaboost = 1e9;         // Boost q/pt seed covariances
+  double sigmainvqptsq = sigmaboost * 1e-8 / r0cu / r0cu * (sigmax0sq * x0 * x0 + sigmay0sq * y0 * y0); // .25 / pt; // Very large uncertainty on pt
 
   std::cout << "initTrack: pt = " << pt << std::endl;
   std::cout << " -iniTrack: cluster    X =  " << cl.getX() << " Y = " << cl.getY() << " Z = " << cl.getZ() << " phi2 = " << phi2 << std::endl;
@@ -152,19 +153,19 @@ void TrackFitter::initTrack(const o2::itsmft::Cluster& cl, TrackParamMFT& param)
   lastParamCov(0, 1) = 0;                           // <Y,X>
   lastParamCov(0, 2) = -sigmax0sq * y0 / r0sq;      // <PHI,X>
   lastParamCov(0, 3) = -dZ * sigmax0sq * x0 / r0cu; // <TANL,X>
-  lastParamCov(0, 4) = 1e-2;                        //- x0*sigmax0sq/r0cu; // <INVQPT,X>
+  lastParamCov(0, 4) = sigmaboost * -1e-4 * x0 * sigmax0sq / r0cu; // <INVQPT,X>
 
   lastParamCov(1, 1) = sigmay0sq;                   // <Y,Y>
   lastParamCov(1, 2) = sigmay0sq * x0 / r0sq;       // <PHI,Y>
   lastParamCov(1, 3) = -dZ * sigmay0sq * y0 / r0cu; // <TANL,Y>
-  lastParamCov(1, 4) = 1e-2;                        //- y0*sigmay0sq/r0cu; //1e-2; // <INVQPT,Y>
+  lastParamCov(1, 4) = sigmaboost * -1e-4 * y0 * sigmay0sq / r0cu; //1e-2; // <INVQPT,Y>
 
   lastParamCov(2, 2) = (sigmax0sq * y0 * y0 + sigmay0sq * x0 * x0) / r0sq / r0sq;    // <PHI,PHI>
   lastParamCov(2, 3) = dZ * x0 * y0 * (sigmax0sq - sigmay0sq) / r0sq / r0cu + 1e-10; //  <TANL,PHI>
-  lastParamCov(2, 4) = 0;                                                            //  <INVQPT,PHI>
+  lastParamCov(2, 4) = sigmaboost * 1e-4 * y0 * x0 / r0cu / r0sq * (sigmax0sq - sigmay0sq) + 1e-10; //  <INVQPT,PHI>
 
   lastParamCov(3, 3) = dZ * dZ * (sigmax0sq * x0 * x0 + sigmay0sq * y0 * y0) / r0cu / r0cu + sigmaDeltaZsq / r0sq; // <TANL,TANL>
-  lastParamCov(3, 4) = 0;                                                                                          // <INVQPT,TANL>
+  lastParamCov(3, 4) = sigmaboost * 1e-4 * dZ / r0cu / r0cu * (sigmax0sq * x0 * x0 + sigmay0sq * y0 * y0);         // <INVQPT,TANL>
 
   lastParamCov(4, 4) = sigmainvqptsq; // <INVQPT,INVQPT>
 
@@ -195,7 +196,9 @@ void TrackFitter::addCluster(const TrackParamMFT& startingParam, const o2::itsmf
   /// Throw an exception in case of failure
 
   if (cl.getZ() <= startingParam.getZ()) {
-    throw std::runtime_error("The new cluster must be upstream");
+    LOG(INFO) << "AddCluster ERROR: The new cluster must be upstream! ********************* ";
+    // FIXME! This should throw an error. Skiping due to bug on track finding.
+    //throw std::runtime_error("The new cluster must be upstream");
   }
   std::cout << "addCluster:     X = " << cl.getX() << " Y = " << cl.getY() << " Z = " << cl.getZ() << std::endl;
   // copy the current parameters into the new ones


### PR DESCRIPTION
This PR updates the seed covariances for the MFT track fitting.

It also disables a `throw runtime_error` due to a bug on MFT track finding, 
which sometimes return tracks with more than one cluster from the same 
MFT layer. 