### PR TITLE
Bugfix: Including the correct header file for DebugGUI

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -100,7 +100,8 @@ o2_add_library(Framework
                        src/ExternalFairMQDeviceProxy.cxx
                        test/TestClasses.cxx
                PRIVATE_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_LIST_DIR}/src
-               PUBLIC_LINK_LIBRARIES AliceO2::Common
+               PUBLIC_LINK_LIBRARIES ${DEBUGGUI_TARGET}
+                                     AliceO2::Common
                                      AliceO2::Configuration
                                      AliceO2::InfoLogger
                                      AliceO2::Monitoring
@@ -116,7 +117,6 @@ o2_add_library(Framework
                                      arrow::arrow_shared
                                      ms_gsl::ms_gsl
                                      ROOT::ROOTDataFrame
-                                     ${DEBUGGUI_TARGET}
                                      O2::FrameworkLogger
                                      Boost::serialization
                                      arrow::gandiva_shared

--- a/Framework/Core/include/Framework/NoDebugGUI.h
+++ b/Framework/Core/include/Framework/NoDebugGUI.h
@@ -7,8 +7,8 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#ifndef FRAMEWORK_DEBUGGUI_H
-#define FRAMEWORK_DEBUGGUI_H
+#ifndef FRAMEWORK_NODEBUGGUI_H
+#define FRAMEWORK_NODEBUGGUI_H
 
 #include <functional>
 
@@ -19,21 +19,21 @@ namespace framework
 
 // The DebugGUI has been moved to a separate package, this is a dummy header file
 // included when the DebugGUI package is not found or disabled.
-void* initGUI(const char* name)
+static inline void* initGUI(const char* name)
 {
   return nullptr;
 }
 
-bool pollGUI(void* context, std::function<void(void)> guiCallback)
+static inline bool pollGUI(void* context, std::function<void(void)> guiCallback)
 {
   // returns whether quit is requested, we return 'no'
   return false;
 }
-void disposeGUI()
+static inline void disposeGUI()
 {
 }
 
 } // namespace framework
 } // namespace o2
 
-#endif // FRAMEWORK_DEBUGGUI_H
+#endif // FRAMEWORK_NODEBUGGUI_H

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -16,12 +16,12 @@
 #include "Framework/DataProcessingDevice.h"
 #include "Framework/DataProcessorSpec.h"
 #if __has_include(<DebugGUI/DebugGUI.h>)
-#include "DebugGUI/DebugGUI.h"
+#include <DebugGUI/DebugGUI.h>
 #else
 // the DebugGUI is in a separate package and is optional for O2,
 // we include a header implementing GUI interface dummy methods
 #pragma message "Building DPL without Debug GUI"
-#include "Framework/DebugGUI.h"
+#include "Framework/NoDebugGUI.h"
 #endif
 #include "Framework/DeviceControl.h"
 #include "Framework/DeviceExecution.h"

--- a/Framework/Core/test/test_CustomGUIGL.cxx
+++ b/Framework/Core/test/test_CustomGUIGL.cxx
@@ -13,10 +13,10 @@
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/ParallelContext.h"
 #include "Framework/runDataProcessing.h"
-#include "Framework/DebugGUI.h"
 
-#include "DebugGUI/Sokol3DUtils.h"
-#include "DebugGUI/imgui.h"
+#include <DebugGUI/DebugGUI.h>
+#include <DebugGUI/Sokol3DUtils.h>
+#include <DebugGUI/imgui.h>
 
 #include <chrono>
 #include <iostream>

--- a/Framework/Core/test/test_CustomGUISokol.cxx
+++ b/Framework/Core/test/test_CustomGUISokol.cxx
@@ -13,10 +13,10 @@
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/ParallelContext.h"
 #include "Framework/runDataProcessing.h"
-#include "Framework/DebugGUI.h"
 
-#include "DebugGUI/Sokol3DUtils.h"
-#include "DebugGUI/imgui.h"
+#include <DebugGUI/DebugGUI.h>
+#include <DebugGUI/Sokol3DUtils.h>
+#include <DebugGUI/imgui.h>
 
 #include <boost/algorithm/string.hpp>
 

--- a/Framework/Core/test/test_SimpleTracksED.cxx
+++ b/Framework/Core/test/test_SimpleTracksED.cxx
@@ -14,12 +14,12 @@
 #include "Framework/ParallelContext.h"
 #include "Framework/runDataProcessing.h"
 #include "Framework/InputRecord.h"
-#include "Framework/DebugGUI.h"
 #include "Framework/Logger.h"
 #include "Framework/AnalysisDataModel.h"
 
-#include "DebugGUI/Sokol3DUtils.h"
-#include "DebugGUI/imgui.h"
+#include <DebugGUI/DebugGUI.h>
+#include <DebugGUI/Sokol3DUtils.h>
+#include <DebugGUI/imgui.h>
 
 #include <chrono>
 #include <iostream>

--- a/GPU/GPUTracking/Standalone/display/GPUDisplayBackendGlfw.cxx
+++ b/GPU/GPUTracking/Standalone/display/GPUDisplayBackendGlfw.cxx
@@ -36,7 +36,7 @@ extern "C" int gl3wInit();
 #include "DebugGUI/imgui.h"
 #include "DebugGUI/imgui_impl_glfw_gl3.h"
 #endif
-#include "Framework/DebugGUI.h"
+#include <DebugGUI/DebugGUI.h>
 #endif
 
 using namespace GPUCA_NAMESPACE::gpu;


### PR DESCRIPTION
A follow up to #3245 

- The DebugGUI header needs to be loaded from the external DebugGUI
  package, the correct include path is `DebugGUI/DebugGUI.h`
- Make sure that DebugGUI dependencies are defined before internal ones
- Renaming dummy DebugGUI header into NoDebugGUI.h to make it really
  different from the header in the DebugGUI package
- Making dummy functions from NoDebugGUI.h 'static inline'

While the main DPL driver was including the correct header, some other
code was still including the wrong file. And having code including the dummy
DebugGUI.h header in the compilation was causing unwanted side effects.
While the DebugGUI was opening correctly for the workflow unit tests,
it did not open for all workflows linking to the GPU library which was
including the wrong dummy header. The linker preferred in those cases
the dummy implementations over the real implementations from the
DebugGUI package and did not complain because there is no collision at
object file level.