### PR TITLE
DPL: adding DataAllocator method to check validity of a certain output

### DIFF
--- a/Framework/Core/include/Framework/DataAllocator.h
+++ b/Framework/Core/include/Framework/DataAllocator.h
@@ -430,6 +430,9 @@ class DataAllocator
     return snapshot(getOutputByBind(std::move(ref)), std::forward<Args>(args)...);
   }
 
+  /// check if a certain output is allowed
+  bool isAllowed(Output const& query);
+
  private:
   AllowedOutputRoutes mAllowedOutputRoutes;
   TimingInfo* mTimingInfo;

--- a/Framework/Core/src/DataAllocator.cxx
+++ b/Framework/Core/src/DataAllocator.cxx
@@ -251,5 +251,15 @@ Output DataAllocator::getOutputByBind(OutputRef&& ref)
   O2_BUILTIN_UNREACHABLE();
 }
 
+bool DataAllocator::isAllowed(Output const& query)
+{
+  for (auto const& route : mAllowedOutputRoutes) {
+    if (DataSpecUtils::match(route.matcher, query.origin, query.description, query.subSpec)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 } // namespace framework
 } // namespace o2

--- a/Framework/Core/test/test_DataAllocator.cxx
+++ b/Framework/Core/test/test_DataAllocator.cxx
@@ -19,6 +19,7 @@
 #include "Framework/RawDeviceService.h"
 #include "Framework/SerializationMethods.h"
 #include "Framework/OutputRoute.h"
+#include "Framework/ConcreteDataMatcher.h"
 #include "Headers/DataHeader.h"
 #include "TestClasses.h"
 #include "Framework/Logger.h"
@@ -142,6 +143,10 @@ DataProcessorSpec getSourceSpec()
     pc.outputs().adoptContainer(pmrOutputSpec, std::move(pmrvec));
     pc.services().get<ControlService>().endOfStream();
     pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+
+    ASSERT_ERROR(pc.outputs().isAllowed({"TST", "MESSAGEABLE", 0}) == true);
+    ASSERT_ERROR(pc.outputs().isAllowed({"TST", "MESSAGEABLE", 1}) == false);
+    ASSERT_ERROR(pc.outputs().isAllowed({"TST", "NOWAY", 0}) == false);
   };
 
   return DataProcessorSpec{"source", // name of the processor


### PR DESCRIPTION
`DataAllocator::isAllowed` can be used to check for conditional outputs.