### PR TITLE
Use LINK_WHAT_YOU_USE where needed (on Linux only)

### DIFF
--- a/run/CMakeLists.txt
+++ b/run/CMakeLists.txt
@@ -57,7 +57,11 @@ o2_add_executable(sim
 o2_add_executable(primary-server-device-runner
                   COMPONENT_NAME sim
                   SOURCES O2PrimaryServerDeviceRunner.cxx
-                  PUBLIC_LINK_LIBRARIES internal::allsim)
+                  PUBLIC_LINK_LIBRARIES internal::allsim
+                  TARGETVARNAME simexe)
+if(NOT APPLE)
+  set_property(TARGET ${simexe} PROPERTY LINK_WHAT_YOU_USE ON)
+endif()
 
 o2_add_executable(hit-merger-runner
                   COMPONENT_NAME sim


### PR DESCRIPTION
Otherwise on e.g. Ubuntu the o2-sim-primary-server-device-runner is
_not_ linked with all the subsystem libraries. One of the consequences
being that their dictionaries are not loaded and thus their ConfigParam
for instance are not usable.