### PR TITLE
Avoid creating empty span with non-default span c-tor

### DIFF
--- a/DataFormats/Detectors/FIT/FDD/include/DataFormatsFDD/Digit.h
+++ b/DataFormats/Detectors/FIT/FDD/include/DataFormatsFDD/Digit.h
@@ -70,7 +70,10 @@ struct Digit {
   uint32_t getOrbit() const { return mIntRecord.orbit; }
   uint16_t getBC() const { return mIntRecord.bc; }
   o2::InteractionRecord getIntRecord() const { return mIntRecord; };
-  gsl::span<const ChannelData> getBunchChannelData(const gsl::span<const ChannelData> tfdata) const { return gsl::span<const ChannelData>(&tfdata[ref.getFirstEntry()], ref.getEntries()); }
+  gsl::span<const ChannelData> getBunchChannelData(const gsl::span<const ChannelData> tfdata) const
+  {
+    return ref.getEntries() ? gsl::span<const ChannelData>(&tfdata[ref.getFirstEntry()], ref.getEntries()) : gsl::span<const ChannelData>();
+  }
 
   ClassDefNV(Digit, 3);
 };

--- a/DataFormats/Detectors/FIT/FT0/src/Digit.cxx
+++ b/DataFormats/Detectors/FIT/FT0/src/Digit.cxx
@@ -19,13 +19,15 @@ using namespace o2::ft0;
 gsl::span<const ChannelData> Digit::getBunchChannelData(const gsl::span<const ChannelData> tfdata) const
 {
   // extract the span of channel data for this bunch from the whole TF data
-  return gsl::span<const ChannelData>(&tfdata[ref.getFirstEntry()], ref.getEntries());
+  return ref.getEntries() ? gsl::span<const ChannelData>(&tfdata[ref.getFirstEntry()], ref.getEntries()) : gsl::span<const ChannelData>();
 }
+
 void Digit::printStream(std::ostream& stream) const
 {
   stream << "FT0 Digit:  BC " << mIntRecord.bc << " orbit " << mIntRecord.orbit << std::endl;
   stream << " A amp " << mTriggers.amplA << "  C amp " << mTriggers.amplC << " time A " << mTriggers.timeA << " time C " << mTriggers.timeC << std::endl;
 }
+
 std::ostream& operator<<(std::ostream& stream, const Digit& digi)
 {
   digi.printStream(stream);

--- a/DataFormats/Detectors/FIT/FT0/src/RecPoints.cxx
+++ b/DataFormats/Detectors/FIT/FT0/src/RecPoints.cxx
@@ -23,7 +23,7 @@ using namespace o2::ft0;
 gsl::span<const ChannelDataFloat> RecPoints::getBunchChannelData(const gsl::span<const ChannelDataFloat> tfdata) const
 {
   // extract the span of channel data for this bunch from the whole TF data
-  return gsl::span<const ChannelDataFloat>(tfdata).subspan(ref.getFirstEntry(), ref.getEntries());
+  return ref.getEntries() ? gsl::span<const ChannelDataFloat>(tfdata).subspan(ref.getFirstEntry(), ref.getEntries()) : gsl::span<const ChannelDataFloat>();
 }
 
 void ChannelDataFloat::print() const

--- a/DataFormats/Detectors/FIT/FV0/src/BCData.cxx
+++ b/DataFormats/Detectors/FIT/FV0/src/BCData.cxx
@@ -23,5 +23,5 @@ void BCData::print() const
 gsl::span<const ChannelData> BCData::getBunchChannelData(const gsl::span<const ChannelData> tfdata) const
 {
   // extract the span of channel data for this bunch from the whole TF data
-  return gsl::span<const ChannelData>(&tfdata[ref.getFirstEntry()], ref.getEntries());
+  return ref.getEntries() ? gsl::span<const ChannelData>(&tfdata[ref.getFirstEntry()], ref.getEntries()) : gsl::span<const ChannelData>();
 }

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/ROFRecord.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/ROFRecord.h
@@ -61,7 +61,7 @@ class ROFRecord
   template <typename T>
   gsl::span<const T> getROFData(const gsl::span<const T> tfdata) const
   {
-    return gsl::span<const T>(&tfdata[getFirstEntry()], getNEntries());
+    return getNEntries() ? gsl::span<const T>(&tfdata[getFirstEntry()], getNEntries()) : gsl::span<const T>();
   }
 
   template <typename T>
@@ -73,7 +73,7 @@ class ROFRecord
   template <typename T>
   gsl::span<const T> getROFData(const std::vector<T>& tfdata) const
   {
-    return gsl::span<const T>(&tfdata[getFirstEntry()], getNEntries());
+    return getNEntries() ? gsl::span<const T>(&tfdata[getFirstEntry()], getNEntries()) : gsl::span<const T>();
   }
 
   template <typename T>

--- a/DataFormats/Detectors/ZDC/src/BCData.cxx
+++ b/DataFormats/Detectors/ZDC/src/BCData.cxx
@@ -36,5 +36,5 @@ void BCData::print() const
 gsl::span<const ChannelData> BCData::getBunchChannelData(const gsl::span<const ChannelData> tfdata) const
 {
   // extract the span of channel data for this bunch from the whole TF data
-  return gsl::span<const ChannelData>(&tfdata[ref.getFirstEntry()], ref.getEntries());
+  return ref.getEntries() ? gsl::span<const ChannelData>(&tfdata[ref.getFirstEntry()], ref.getEntries()) : gsl::span<const ChannelData>();
 }

--- a/Detectors/ITSMFT/ITS/macros/test/run_digi2rawVarPage_its.C
+++ b/Detectors/ITSMFT/ITS/macros/test/run_digi2rawVarPage_its.C
@@ -89,7 +89,7 @@ void run_digi2rawVarPage_its(std::string outPrefix = "rawits",       // prefix o
         continue;
       }
       nEntProc++;
-      auto dgs = gsl::span<const o2::itsmft::Digit>(&digiVec[rofRec.getFirstEntry()], nDigROF);
+      auto dgs = nDigROF ? gsl::span<const o2::itsmft::Digit>(&digiVec[rofRec.getFirstEntry()], nDigROF) : gsl::span<const o2::itsmft::Digit>();
       m2r.digits2raw(dgs, rofRec.getBCData());
     }
   } // loop over multiple ROFvectors (in case of chaining)

--- a/Detectors/TOF/base/include/TOFBase/Digit.h
+++ b/Detectors/TOF/base/include/TOFBase/Digit.h
@@ -110,9 +110,7 @@ struct ReadoutWindowData {
   gsl::span<const Digit> getBunchChannelData(const gsl::span<const Digit> tfdata) const
   {
     // extract the span of channel data for this readout window from the whole TF data
-    if (!ref.getEntries())
-      return gsl::span<const Digit>(nullptr, ref.getEntries());
-    return gsl::span<const Digit>(&tfdata[ref.getFirstEntry()], ref.getEntries());
+    return ref.getEntries() ? gsl::span<const Digit>(&tfdata[ref.getFirstEntry()], ref.getEntries()) : gsl::span<const Digit>();
   }
 
   ReadoutWindowData() = default;


### PR DESCRIPTION
This fix will override https://github.com/AliceO2Group/AliceO2/pull/3262 as it covers more similar cases of dereferencing potentially random address while creating empty span.