### PR TITLE
Arranging data with respect to sector number instead of subspec

### DIFF
--- a/Detectors/TPC/workflow/include/TPCWorkflow/RecoWorkflow.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/RecoWorkflow.h
@@ -49,11 +49,11 @@ framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors,         
                                     int caClusterer = 0                           //
 );
 
-framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors,           //
-                                    bool propagateMC = true, unsigned nLanes = 1, //
-                                    std::string const& cfgInput = "digitizer",    //
-                                    std::string const& cfgOutput = "tracks",      //
-                                    int caClusterer = 0                           //
+static inline framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors,           //
+                                                  bool propagateMC = true, unsigned nLanes = 1, //
+                                                  std::string const& cfgInput = "digitizer",    //
+                                                  std::string const& cfgOutput = "tracks",      //
+                                                  int caClusterer = 0                           //
 )
 {
   // create a default lane configuration with ids [0, nLanes-1]
@@ -62,10 +62,10 @@ framework::WorkflowSpec getWorkflow(std::vector<int> const& tpcSectors,         
   return getWorkflow(tpcSectors, laneConfiguration, propagateMC, nLanes, cfgInput, cfgOutput, caClusterer);
 }
 
-framework::WorkflowSpec getWorkflow(bool propagateMC = true, unsigned nLanes = 1, //
-                                    std::string const& cfgInput = "digitizer",    //
-                                    std::string const& cfgOutput = "tracks",      //
-                                    int caClusterer = 0                           //
+static inline framework::WorkflowSpec getWorkflow(bool propagateMC = true, unsigned nLanes = 1, //
+                                                  std::string const& cfgInput = "digitizer",    //
+                                                  std::string const& cfgOutput = "tracks",      //
+                                                  int caClusterer = 0                           //
 )
 {
   // create a default lane configuration with ids [0, nLanes-1]

--- a/Detectors/TPC/workflow/src/ClustererSpec.cxx
+++ b/Detectors/TPC/workflow/src/ClustererSpec.cxx
@@ -26,6 +26,7 @@
 #include <FairMQLogger.h>
 #include <memory> // for make_shared
 #include <vector>
+#include <map>
 #include <numeric>   // std::accumulate
 #include <algorithm> // std::copy
 
@@ -143,15 +144,23 @@ DataProcessorSpec getClustererSpec(bool sendMC)
       };
       // loop over all inputs and their parts and associate data with corresponding mc truth data
       // by the subspecification
-      std::map<o2::header::DataHeader::SubSpecificationType, SectorInputDesc> inputs;
+      std::map<int, SectorInputDesc> inputs;
+      std::vector<InputSpec> filter = {
+        {"check", ConcreteDataTypeMatcher{gDataOriginTPC, "DIGITS"}, Lifetime::Timeframe},
+        {"check", ConcreteDataTypeMatcher{gDataOriginTPC, "DIGITSMCTR"}, Lifetime::Timeframe},
+      };
       for (auto const& inputRef : InputRecordWalker(pc.inputs())) {
-        auto const* dataHeader = DataRefUtils::getHeader<o2::header::DataHeader*>(inputRef);
-        assert(dataHeader);
+        auto const* sectorHeader = DataRefUtils::getHeader<o2::tpc::TPCSectorHeader*>(inputRef);
+        if (sectorHeader == nullptr) {
+          LOG(ERROR) << "sector header missing on header stack for input on " << inputRef.spec->binding;
+          continue;
+        }
+        const int sector = sectorHeader->sector;
         if (DataRefUtils::match(inputRef, {"check", ConcreteDataTypeMatcher{gDataOriginTPC, "DIGITS"}})) {
-          inputs[dataHeader->subSpecification].dataref = inputRef;
+          inputs[sector].dataref = inputRef;
         }
         if (DataRefUtils::match(inputRef, {"check", ConcreteDataTypeMatcher{gDataOriginTPC, "DIGITSMCTR"}})) {
-          inputs[dataHeader->subSpecification].mclabelref = inputRef;
+          inputs[sector].mclabelref = inputRef;
         }
       }
       for (auto const& input : inputs) {


### PR DESCRIPTION
Sort DataRef objects for the different sectors by sector number. This will
become necessary if multiple sectors are sent over the same route in a
single timeslice.

Also defining helper methods in the header file as 'static inline' to avoid
conflicts if the header file is inlcuded in both an executable and a library.