### PR TITLE
[MFT] Propagation of MCLabels, use of SMatrix on TrackMFT

### DIFF
--- a/DataFormats/Detectors/ITSMFT/MFT/include/DataFormatsMFT/TrackMFT.h
+++ b/DataFormats/Detectors/ITSMFT/MFT/include/DataFormatsMFT/TrackMFT.h
@@ -17,8 +17,8 @@
 #define ALICEO2_MFT_TRACKMFT_H
 
 #include <vector>
-#include <TMatrixD.h>
 #include <TMath.h>
+#include "Math/SMatrix.h"
 
 #include "CommonDataFormat/RangeReference.h"
 #include "SimulationDataFormat/MCCompLabel.h"
@@ -37,12 +37,14 @@ class TrackMFT
 {
   using Cluster = o2::itsmft::Cluster;
   using ClusRefs = o2::dataformats::RangeRefComp<4>;
+  using SMatrix55 = ROOT::Math::SMatrix<double, 5, 5, ROOT::Math::MatRepSym<double, 5>>;
+  using SMatrix5 = ROOT::Math::SVector<Double_t, 5>;
 
  public:
 
   TrackMFT() = default;
   TrackMFT(const TrackMFT& t) = default;
-  TrackMFT(const Double_t Z, const TMatrixD parameters, const TMatrixD covariances, const Double_t chi2);
+  TrackMFT(const Double_t Z, const SMatrix5 parameters, const SMatrix55 covariances, const Double_t chi2);
 
   ~TrackMFT() = default;
 
@@ -50,26 +52,26 @@ class TrackMFT
   Double_t getZ() const { return mZ; }
   /// set Z coordinate (cm)
   void setZ(Double_t z) { mZ = z; }
-  Double_t getX() const { return mParameters(0, 0); }
-  void setX(Double_t x) { mParameters(0, 0) = x; }
+  Double_t getX() const { return mParameters(0); }
+  void setX(Double_t x) { mParameters(0) = x; }
   Double_t getSigmaX() const { return mCovariances(0, 0); }
 
-  Double_t getY() const { return mParameters(1, 0); }
-  void setY(Double_t y) { mParameters(1, 0) = y; }
+  Double_t getY() const { return mParameters(1); }
+  void setY(Double_t y) { mParameters(1) = y; }
   Double_t getSigmaY() const { return mCovariances(1, 1); }
 
-  void setPhi(Double_t phi) { mParameters(2, 0) = phi; }
-  Double_t getPhi() const { return mParameters(2, 0); }
+  void setPhi(Double_t phi) { mParameters(2) = phi; }
+  Double_t getPhi() const { return mParameters(2); }
   Double_t getSigmaPhi() const { return mCovariances(2, 2); }
 
-  void setTanl(Double_t tanl) { mParameters(3, 0) = tanl; }
-  Double_t getTanl() const { return mParameters(3, 0); }
+  void setTanl(Double_t tanl) { mParameters(3) = tanl; }
+  Double_t getTanl() const { return mParameters(3); }
   Double_t getSigmaTanl() const { return mCovariances(3, 3); }
 
-  void setInvQPt(Double_t invqpt) { mParameters(4, 0) = invqpt; }
-  Double_t getInvQPt() const { return mParameters(4, 0); } // return Inverse charged pt
-  Double_t getPt() const { return TMath::Abs(1.f / mParameters(4, 0)); }
-  Double_t getInvPt() const { return TMath::Abs(mParameters(4, 0)); }
+  void setInvQPt(Double_t invqpt) { mParameters(4) = invqpt; }
+  Double_t getInvQPt() const { return mParameters(4); } // return Inverse charged pt
+  Double_t getPt() const { return TMath::Abs(1.f / mParameters(4)); }
+  Double_t getInvPt() const { return TMath::Abs(mParameters(4)); }
   Double_t getSigmaInvQPt() const { return mCovariances(4, 4); }
 
   Double_t getPx() const { return TMath::Cos(getPhi()) * getPt(); } // return px
@@ -87,22 +89,21 @@ class TrackMFT
   Double_t getEta() const { return -TMath::Log(TMath::Tan((TMath::PiOver2() - TMath::ATan(getTanl())) / 2)); } // return total momentum
 
   /// return the charge (assumed forward motion)
-  Double_t getCharge() const { return TMath::Sign(1., mParameters(4, 0)); }
+  Double_t getCharge() const { return TMath::Sign(1., mParameters(4)); }
   /// set the charge (assumed forward motion)
   void setCharge(Double_t charge)
   {
-    if (charge * mParameters(4, 0) < 0.)
-      mParameters(4, 0) *= -1.;
+    if (charge * mParameters(4) < 0.)
+      mParameters(4) *= -1.;
   }
 
   /// return track parameters
-  const TMatrixD& getParameters() const { return mParameters; }
+  const SMatrix5& getParameters() const { return mParameters; }
   /// set track parameters
-  void setParameters(const TMatrixD& parameters) { mParameters = parameters; }
+  void setParameters(const SMatrix5& parameters) { mParameters = parameters; }
 
-  const TMatrixD& getCovariances() const;
-  void setCovariances(const TMatrixD& covariances);
-  void setCovariances(const Double_t matrix[5][5]);
+  const SMatrix55& getCovariances() const;
+  void setCovariances(const SMatrix55& covariances);
 
   /// return the chi2 of the track when the associated cluster was attached
   Double_t getTrackChi2() const { return mTrackChi2; }
@@ -163,7 +164,7 @@ class TrackMFT
   /// PHI     = azimutal angle
   /// TANL    = tangent of \lambda (dip angle)
   /// INVQPT    = Inverse transverse momentum (GeV/c ** -1) times charge (assumed forward motion)  </pre>
-  TMatrixD mParameters{5, 1}; ///< \brief Track parameters
+  SMatrix5 mParameters; ///< \brief Track parameters
 
   /// Covariance matrix of track parameters, ordered as follows:    <pre>
   ///  <X,X>         <Y,X>           <PHI,X>       <TANL,X>        <INVQPT,X>
@@ -171,7 +172,7 @@ class TrackMFT
   /// <X,PHI>       <Y,PHI>         <PHI,PHI>     <TANL,PHI>      <INVQPT,PHI>
   /// <X,TANL>      <Y,TANL>       <PHI,TANL>     <TANL,TANL>     <INVQPT,TANL>
   /// <X,INVQPT>   <Y,INVQPT>     <PHI,INVQPT>   <TANL,INVQPT>   <INVQPT,INVQPT>  </pre>
-  TMatrixD mCovariances{5, 5}; ///< \brief Covariance matrix of track parameters
+  SMatrix55 mCovariances;      ///< \brief Covariance matrix of track parameters
   Double_t mTrackChi2 = 0.;    ///< Chi2 of the track when the associated cluster was attached
   ClassDefNV(TrackMFT, 1);
 };

--- a/DataFormats/Detectors/ITSMFT/MFT/include/DataFormatsMFT/TrackMFT.h
+++ b/DataFormats/Detectors/ITSMFT/MFT/include/DataFormatsMFT/TrackMFT.h
@@ -21,6 +21,7 @@
 #include <TMath.h>
 
 #include "CommonDataFormat/RangeReference.h"
+#include "SimulationDataFormat/MCCompLabel.h"
 
 namespace o2
 {
@@ -51,20 +52,25 @@ class TrackMFT
   void setZ(Double_t z) { mZ = z; }
   Double_t getX() const { return mParameters(0, 0); }
   void setX(Double_t x) { mParameters(0, 0) = x; }
+  Double_t getSigmaX() const { return mCovariances(0, 0); }
 
   Double_t getY() const { return mParameters(1, 0); }
   void setY(Double_t y) { mParameters(1, 0) = y; }
+  Double_t getSigmaY() const { return mCovariances(1, 1); }
 
   void setPhi(Double_t phi) { mParameters(2, 0) = phi; }
   Double_t getPhi() const { return mParameters(2, 0); }
+  Double_t getSigmaPhi() const { return mCovariances(2, 2); }
 
   void setTanl(Double_t tanl) { mParameters(3, 0) = tanl; }
   Double_t getTanl() const { return mParameters(3, 0); }
+  Double_t getSigmaTanl() const { return mCovariances(3, 3); }
 
   void setInvQPt(Double_t invqpt) { mParameters(4, 0) = invqpt; }
   Double_t getInvQPt() const { return mParameters(4, 0); } // return Inverse charged pt
   Double_t getPt() const { return TMath::Abs(1.f / mParameters(4, 0)); }
   Double_t getInvPt() const { return TMath::Abs(mParameters(4, 0)); }
+  Double_t getSigmaInvQPt() const { return mCovariances(4, 4); }
 
   Double_t getPx() const { return TMath::Cos(getPhi()) * getPt(); } // return px
   Double_t getInvPx() const { return 1. / getPx(); }                // return invpx
@@ -77,6 +83,8 @@ class TrackMFT
 
   Double_t getP() const { return getPt() * TMath::Sqrt(1. + getTanl() * getTanl()); } // return total momentum
   Double_t getInverseMomentum() const { return 1.f / getP(); }
+
+  Double_t getEta() const { return -TMath::Log(TMath::Tan((TMath::PiOver2() - TMath::ATan(getTanl())) / 2)); } // return total momentum
 
   /// return the charge (assumed forward motion)
   Double_t getCharge() const { return TMath::Sign(1., mParameters(4, 0)); }
@@ -122,14 +130,29 @@ class TrackMFT
     mClusRef.set(firstEntry, n);
   }
 
+  const std::array<MCCompLabel, 10>& getMCCompLabels() const { return mMCCompLabels; } // constants::mft::LayersNumber = 10
+  void setMCCompLabels(const std::array<MCCompLabel, 10>& labels, int nPoints)
+  {
+    mMCCompLabels = labels;
+    mNPoints = nPoints;
+  }
+
   const ClusRefs& getClusterRefs() const { return mClusRef; }
   ClusRefs& getClusterRefs() { return mClusRef; }
 
   std::uint32_t getROFrame() const { return mROFrame; }
   void setROFrame(std::uint32_t f) { mROFrame = f; }
 
+  const Int_t getNPoints() const { return mNPoints; }
+
+  void print() const;
+  void printMCCompLabels() const;
+
  private:
   std::uint32_t mROFrame = 0;       ///< RO Frame
+  Int_t mNPoints{0};                // Number of clusters
+  std::array<MCCompLabel, 10> mMCCompLabels; // constants::mft::LayersNumber = 10
+
   ClusRefs mClusRef;                ///< references on clusters
 
   Double_t mZ = 0.; ///< Z coordinate (cm)

--- a/DataFormats/Detectors/ITSMFT/MFT/src/TrackMFT.cxx
+++ b/DataFormats/Detectors/ITSMFT/MFT/src/TrackMFT.cxx
@@ -56,5 +56,25 @@ void TrackMFT::setCovariances(const Double_t matrix[5][5])
   mCovariances = TMatrixD(5, 5, &(matrix[0][0]));
 }
 
+//__________________________________________________________________________
+void TrackMFT::print() const
+{
+  /// Printing TrackMFT information
+  LOG(INFO) << "TrackMFT: p =" << std::setw(5) << std::setprecision(3) << getP()
+            << " Tanl = " << std::setw(5) << std::setprecision(3) << getTanl()
+            << " phi = " << std::setw(5) << std::setprecision(3) << getPhi()
+            << " pz = " << std::setw(5) << std::setprecision(3) << getPz()
+            << " pt = " << std::setw(5) << std::setprecision(3) << getPt()
+            << " charge = " << std::setw(5) << std::setprecision(3) << getCharge()
+            << " chi2 = " << std::setw(5) << std::setprecision(3) << getTrackChi2() << std::endl;
+}
+
+//__________________________________________________________________________
+void TrackMFT::printMCCompLabels() const
+{
+  /// Printing TrackMFT MCLabel information
+  LOG(INFO) << "TrackMFT with " << mNPoints << " clusters. MCLabels: " << mMCCompLabels[0] << mMCCompLabels[1] << "..."; //<< mMCCompLabels[2] << mMCCompLabels[3] << mMCCompLabels[4] << mMCCompLabels[5] << mMCCompLabels[6] << mMCCompLabels[7] << mMCCompLabels[8] << mMCCompLabels[9];
+}
+
 } // namespace mft
 } // namespace o2

--- a/DataFormats/Detectors/ITSMFT/MFT/src/TrackMFT.cxx
+++ b/DataFormats/Detectors/ITSMFT/MFT/src/TrackMFT.cxx
@@ -16,7 +16,6 @@
 #include "DataFormatsMFT/TrackMFT.h"
 #include "CommonConstants/MathConstants.h"
 #include "DataFormatsITSMFT/Cluster.h"
-#include <TMatrixD.h>
 #include <TMath.h>
 
 using namespace o2::mft;
@@ -28,8 +27,11 @@ namespace o2
 namespace mft
 {
 
+using SMatrix55 = ROOT::Math::SMatrix<double, 5, 5, ROOT::Math::MatRepSym<double, 5>>;
+using SMatrix5 = ROOT::Math::SVector<Double_t, 5>;
+
 //__________________________________________________________________________
-TrackMFT::TrackMFT(const Double_t z, const TMatrixD parameters, const TMatrixD covariances, const Double_t chi2)
+TrackMFT::TrackMFT(const Double_t z, const SMatrix5 parameters, const SMatrix55 covariances, const Double_t chi2)
 {
   mZ = z;
   mParameters = parameters;
@@ -38,22 +40,16 @@ TrackMFT::TrackMFT(const Double_t z, const TMatrixD parameters, const TMatrixD c
 }
 
 //__________________________________________________________________________
-const TMatrixD& TrackMFT::getCovariances() const
+const SMatrix55& TrackMFT::getCovariances() const
 {
   /// Return the covariance matrix
   return mCovariances;
 }
 
 //__________________________________________________________________________
-void TrackMFT::setCovariances(const TMatrixD& covariances)
+void TrackMFT::setCovariances(const SMatrix55& covariances)
 {
   mCovariances = covariances;
-}
-
-//__________________________________________________________________________
-void TrackMFT::setCovariances(const Double_t matrix[5][5])
-{
-  mCovariances = TMatrixD(5, 5, &(matrix[0][0]));
 }
 
 //__________________________________________________________________________

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/FitterTrackMFT.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/FitterTrackMFT.h
@@ -21,6 +21,7 @@
 
 #include "DataFormatsITSMFT/Cluster.h"
 #include "MFTTracking/TrackParamMFT.h"
+#include "SimulationDataFormat/MCCompLabel.h"
 
 namespace o2
 {
@@ -44,6 +45,14 @@ class FitterTrackMFT
 
   /// Return the number of attached clusters
   const int getNClusters() const { return mParamAtClusters.size(); }
+
+  // Set and Get MCCompLabels
+  const std::array<MCCompLabel, 10>& getMCCompLabels() const { return mMCCompLabels; } // constants::mft::LayersNumber = 10
+  void setMCCompLabels(const std::array<MCCompLabel, 10>& labels, int nPoints)
+  {
+    mMCCompLabels = labels;
+    mNPoints = nPoints;
+  }
 
   /// Return a reference to the track parameters at first cluster
   const TrackParamMFT& first() const { return mParamAtClusters.front(); }
@@ -95,7 +104,9 @@ class FitterTrackMFT
   /// return the flag telling if this track should be deleted
   bool isRemovable() const { return mRemovable; }
 
-  void print() const;
+  void printMCCompLabels() const;
+
+  const Int_t getNPoints() const { return mNPoints; }
 
  private:
   TrackParamMFT mParamAtVertex{};                 ///< track parameters at vertex
@@ -104,6 +115,8 @@ class FitterTrackMFT
   int mCurrentLayer = -1;                         ///< current chamber on which the current parameters are given
   bool mConnected = false;                        ///< flag telling if this track shares cluster(s) with another
   bool mRemovable = false;                        ///< flag telling if this track should be deleted
+  Int_t mNPoints{0};                              // Number of clusters
+  std::array<MCCompLabel, 10> mMCCompLabels;      // constants::mft::LayersNumber = 10
 };
 
 } // namespace mft

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/TrackCA.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/TrackCA.h
@@ -56,9 +56,9 @@ class TrackCA final
   Int_t mRoadId{-1};
   Float_t mChiSquareZX{0.};
   Float_t mChiSquareZY{0.};
-  std::array<Float_t, constants::mft::LayersNumber> mX = {-15., -15., -15., -15., -15., -15., -15., -15., -15., -15.};
-  std::array<Float_t, constants::mft::LayersNumber> mY = {-15., -15., -15., -15., -15., -15., -15., -15., -15., -15.};
-  std::array<Float_t, constants::mft::LayersNumber> mZ = {-80., -80., -80., -80., -80., -80., -80., -80., -80., -80.};
+  std::array<Float_t, constants::mft::LayersNumber> mX = {-25., -25., -25., -25., -25., -25., -25., -25., -25., -25.};
+  std::array<Float_t, constants::mft::LayersNumber> mY = {-25., -25., -25., -25., -25., -25., -25., -25., -25., -25.};
+  std::array<Float_t, constants::mft::LayersNumber> mZ = {-120., -120., -120., -120., -120., -120., -120., -120., -120., -120.};
   std::array<Int_t, constants::mft::LayersNumber> mLayer;
   std::array<Int_t, constants::mft::LayersNumber> mClusterId;
   std::array<Int_t, constants::mft::LayersNumber> mCellLayer;
@@ -136,9 +136,9 @@ class TrackLTF final
 
  private:
   Int_t mNPoints = 0;
-  std::array<Float_t, constants::mft::LayersNumber> mX = {-15., -15., -15., -15., -15., -15., -15., -15., -15., -15.};
-  std::array<Float_t, constants::mft::LayersNumber> mY = {-15., -15., -15., -15., -15., -15., -15., -15., -15., -15.};
-  std::array<Float_t, constants::mft::LayersNumber> mZ = {-80., -80., -80., -80., -80., -80., -80., -80., -80., -80.};
+  std::array<Float_t, constants::mft::LayersNumber> mX = {-25., -25., -25., -25., -25., -25., -25., -25., -25., -25.};
+  std::array<Float_t, constants::mft::LayersNumber> mY = {-25., -25., -25., -25., -25., -25., -25., -25., -25., -25.};
+  std::array<Float_t, constants::mft::LayersNumber> mZ = {-120., -120., -120., -120., -120., -120., -120., -120., -120., -120.};
   std::array<Int_t, constants::mft::LayersNumber> mLayer;
   std::array<Int_t, constants::mft::LayersNumber> mClusterId;
   std::array<MCCompLabel, constants::mft::LayersNumber> mMCCompLabels;

--- a/Detectors/ITSMFT/MFT/tracking/src/FitterTrackMFT.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/FitterTrackMFT.cxx
@@ -61,7 +61,7 @@ TrackParamMFT& FitterTrackMFT::createParamAtCluster(const o2::itsmft::Cluster& c
   itParam->setX(cluster.getX());
   itParam->setY(cluster.getY());
   itParam->setClusterPtr(&cluster);
-
+  mNPoints++;
   return *itParam;
 }
 
@@ -143,14 +143,10 @@ TrackParamMFT& FitterTrackMFT::getCurrentParam()
 }
 
 //__________________________________________________________________________
-void FitterTrackMFT::print() const
+void FitterTrackMFT::printMCCompLabels() const
 {
-  //  mParamAtClusters.front().print();
-  //  cout << "\tcurrent chamber = " << mCurrentChamber + 1 << " ; clusters = {";
-  //  for (const auto& param : *this) {
-  //    cout << param.getClusterPtr()->getIdAsString() << ", ";
-  //  }
-  //  cout << "}" << endl;
+  /// Printing FitterTrackMFT MCLabel information
+  LOG(INFO) << "FitterTrackMFT with " << mNPoints << " clusters. MCLabels: " << mMCCompLabels[0] << mMCCompLabels[1] << "..."; //<< mMCCompLabels[2] << mMCCompLabels[3] << mMCCompLabels[4] << mMCCompLabels[5] << mMCCompLabels[6] << mMCCompLabels[7] << mMCCompLabels[8] << mMCCompLabels[9];
 }
 
 } // namespace mft

--- a/Detectors/ITSMFT/MFT/tracking/src/TrackFitter.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/TrackFitter.cxx
@@ -131,7 +131,7 @@ void TrackFitter::initTrack(const o2::itsmft::Cluster& cl, TrackParamMFT& param)
   double sigmax0sq = 0.0005;       // FIXME: from cluster
   double sigmay0sq = 0.0005;       // FIXME: from cluster
   double sigmaDeltaZsq = 5;        // Primary vertex distribution: beam interaction diamond
-  double sigmaboost = 1e9;         // Boost q/pt seed covariances
+  double sigmaboost = 1e7;         // Boost q/pt seed covariances
   double sigmainvqptsq = sigmaboost * 1e-8 / r0cu / r0cu * (sigmax0sq * x0 * x0 + sigmay0sq * y0 * y0); // .25 / pt; // Very large uncertainty on pt
 
   std::cout << "initTrack: pt = " << pt << std::endl;

--- a/Detectors/ITSMFT/MFT/tracking/src/TrackFitter.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/TrackFitter.cxx
@@ -19,6 +19,7 @@
 #include "MFTTracking/TrackExtrap.h"
 #include "DataFormatsMFT/TrackMFT.h"
 #include "DataFormatsITSMFT/Cluster.h"
+#include "SimulationDataFormat/MCCompLabel.h"
 #include "ITSMFTReconstruction/ChipMappingMFT.h"
 #include <stdexcept>
 #include <TMath.h>

--- a/Detectors/ITSMFT/MFT/tracking/src/TrackParamMFT.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/TrackParamMFT.cxx
@@ -355,13 +355,13 @@ Bool_t TrackParamMFT::isCompatibleTrackParamMFT(const TrackParamMFT& TrackParamM
 void TrackParamMFT::print() const
 {
   /// Printing TrackParamMFT informations
-  cout << "<TrackParamMFT> Bending P=" << setw(5) << setprecision(3) << 1. / mParameters(4, 0)
-       << ", NonBendSlope=" << setw(5) << setprecision(3) << mParameters(1, 0) * 180. / TMath::Pi()
-       << ", BendSlope=" << setw(5) << setprecision(3) << mParameters(3, 0) * 180. / TMath::Pi() << ", (x,y,z)_IP=("
-       << setw(5) << setprecision(3) << mParameters(0, 0) << "," << setw(5) << setprecision(3) << mParameters(2, 0)
-       << "," << setw(5) << setprecision(3) << mZ << ") cm, (px,py,pz)=(" << setw(5) << setprecision(3) << getPx() << ","
-       << setw(5) << setprecision(3) << getPy() << "," << setw(5) << setprecision(3) << getP() << ") GeV/c, "
-       << "local chi2=" << getLocalChi2() << endl;
+  LOG(INFO) << "TrackParamMFT: p =" << setw(5) << setprecision(3) << getP()
+            << " Tanl = " << setw(5) << setprecision(3) << getTanl()
+            << " phi = " << setw(5) << setprecision(3) << getPhi()
+            << " pz = " << setw(5) << setprecision(3) << getPz()
+            << " pt = " << setw(5) << setprecision(3) << getPt()
+            << " charge = " << setw(5) << setprecision(3) << getCharge()
+            << " chi2 = " << setw(5) << setprecision(3) << getTrackChi2() << endl;
 }
 
 } // namespace mft

--- a/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/TrackFitterSpec.h
+++ b/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/TrackFitterSpec.h
@@ -26,6 +26,9 @@ namespace o2
 namespace mft
 {
 
+using SMatrix55 = ROOT::Math::SMatrix<double, 5, 5, ROOT::Math::MatRepSym<double, 5>>;
+using SMatrix5 = ROOT::Math::SVector<Double_t, 5>;
+
 class TrackFitterTask : public o2::framework::Task
 {
  public:
@@ -43,6 +46,9 @@ class TrackFitterTask : public o2::framework::Task
 
 template <typename T, typename O, typename C>
 void convertTrack(const T& inTrack, O& outTrack, C& clusters);
+
+SMatrix55 TtoSMatrixSym55(TMatrixD inMatrix);
+SMatrix5 TtoSMatrix5(TMatrixD inMatrix);
 
 o2::framework::DataProcessorSpec getTrackFitterSpec(bool useMC);
 

--- a/Detectors/ITSMFT/MFT/workflow/src/TrackFitterSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/TrackFitterSpec.cxx
@@ -112,8 +112,8 @@ void TrackFitterTask::run(ProcessingContext& pc)
   for (const auto& track : fittertracks) {
     o2::mft::TrackMFT& temptrack = finalMFTtracks.emplace_back();
     temptrack.setZ(track.first().getZ());
-    temptrack.setParameters(track.first().getParameters());
-    temptrack.setCovariances(track.first().getCovariances());
+    temptrack.setParameters(TtoSMatrix5(track.first().getParameters()));
+    temptrack.setCovariances(TtoSMatrixSym55(track.first().getCovariances()));
     temptrack.setTrackChi2(track.first().getTrackChi2());
     temptrack.setMCCompLabels(track.getMCCompLabels(), track.getNPoints());
     finalMFTtracks.back().printMCCompLabels();
@@ -176,6 +176,29 @@ void convertTrack(const T& inTrack, O& outTrack, C& clusters)
   //  std::cout << "     getZ() =  " << par->getZ() << std::endl;
 
   //fit(outTrack, false);
+}
+
+//_________________________________________________________________________________________________
+SMatrix55 TtoSMatrixSym55(TMatrixD inMatrix)
+{
+  // TMatrix to sym SMatrix
+  SMatrix55 outMatrix;
+  for (auto i = 5; i--;) {
+    outMatrix(i, i) = inMatrix(i, i);
+    for (auto j = i; j--;) {
+      outMatrix(i, j) = inMatrix(i, j);
+    }
+  }
+  return outMatrix;
+}
+
+//_________________________________________________________________________________________________
+SMatrix5 TtoSMatrix5(TMatrixD inMatrix)
+{
+  SMatrix5 outMatrix;
+  for (auto i = 0; i < 5; i++)
+    outMatrix(i) = inMatrix(i, 0);
+  return outMatrix;
 }
 
 } // namespace mft

--- a/Detectors/ITSMFT/MFT/workflow/src/TrackFitterSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/TrackFitterSpec.cxx
@@ -78,45 +78,39 @@ void TrackFitterTask::run(ProcessingContext& pc)
 
   int nTracksCA = 0;
   int nTracksLTF = 0;
-  std::vector<o2::mft::FitterTrackMFT> fittertracks;
+  std::vector<o2::mft::FitterTrackMFT> fittertracks(tracksLTF.size() + tracksCA.size());
   auto& finalMFTtracks = pc.outputs().make<std::vector<o2::mft::TrackMFT>>(Output{"MFT", "TRACKS", 0, Lifetime::Timeframe});
+  finalMFTtracks.resize(tracksLTF.size() + tracksCA.size());
   std::list<o2::itsmft::Cluster> clusters;
 
   // Fit LTF tracks
   for (const auto& track : tracksLTF) {
-    o2::mft::FitterTrackMFT& temptrack = fittertracks.emplace_back();
+    auto& temptrack = fittertracks.at(nTracksLTF);
     convertTrack(track, temptrack, clusters);
     mTrackFitter->fit(temptrack, false);
-    fittertracks.back().printMCCompLabels();
-    //LOG(INFO) << "tracksLTF: nTracksLTF  = " << nTracksLTF << " tracks.size() = " << fittertracks.size() << std::endl;
     nTracksLTF++;
   }
 
   // Fit CA tracks
   for (const auto& track : tracksCA) {
-    o2::mft::FitterTrackMFT& temptrack = fittertracks.emplace_back();
-    //o2::itsmft::Cluster& tempcluster = clusters.emplace_back();
+    auto& temptrack = fittertracks.at(nTracksLTF + nTracksCA);
     convertTrack(track, temptrack, clusters);
     mTrackFitter->fit(temptrack, false);
-    fittertracks.back().printMCCompLabels();
-    //LOG(INFO) << "tracksCA: nTracksCA  = " << nTracksCA << " tracks.size() = " << fittertracks.size() << std::endl;
     nTracksCA++;
   }
-
-  LOG(INFO) << "\n ********* Fitted MFTTracks MCLabels() ********* ";
-  for (auto& track : fittertracks)
-    track.printMCCompLabels();
-
-  LOG(INFO) << "\n ********* Final MFTTracks MCLabels() Output ********* ";
+  auto nTotalTracks = 0;
   // Convert fitter tracks to the final Standalone MFT Track
   for (const auto& track : fittertracks) {
-    o2::mft::TrackMFT& temptrack = finalMFTtracks.emplace_back();
+    //o2::mft::TrackMFT& temptrack = finalMFTtracks.emplace_back();
+    auto& temptrack = finalMFTtracks.at(nTotalTracks);
+
     temptrack.setZ(track.first().getZ());
     temptrack.setParameters(TtoSMatrix5(track.first().getParameters()));
     temptrack.setCovariances(TtoSMatrixSym55(track.first().getCovariances()));
     temptrack.setTrackChi2(track.first().getTrackChi2());
     temptrack.setMCCompLabels(track.getMCCompLabels(), track.getNPoints());
-    finalMFTtracks.back().printMCCompLabels();
+    //finalMFTtracks.back().printMCCompLabels();
+    nTotalTracks++;
   }
 
   LOG(INFO) << "MFTFitter loaded " << tracksLTF.size() << " LTF tracks";
@@ -160,22 +154,15 @@ void convertTrack(const T& inTrack, O& outTrack, C& clusters)
   auto nClusters = inTrack.getNPoints();
   static int ntrack = 0;
 
-  //std::cout << "** Converting MFT track with nClusters = " << nClusters << std::endl;
-  // Add clusters to Tracker's cluster vector & set fittedTrack cluster range
+  // Add clusters to Tracker's cluster vector & set fittedTrack cluster range.
+  // TODO: get rid of this cluster vector
   for (auto cls = 0; cls < nClusters; cls++) {
     o2::itsmft::Cluster& tempcluster = clusters.emplace_back(clusterIDs[cls], xpos[cls], ypos[cls], zpos[cls]);
-    //auto cluster = o2::itsmft::Cluster();
     tempcluster.setSigmaY2(0.0001); // FIXME:
     tempcluster.setSigmaZ2(0.0001); // FIXME: Use clusters errors once available
     outTrack.createParamAtCluster(tempcluster);
-    //std::cout << "Adding cluster " << cls << " to track " << ntrack << " with clusterID " << tempcluster.getSensorID() << " at z = " << tempcluster.getZ() << std::endl;
   }
   outTrack.setMCCompLabels(inTrack.getMCCompLabels(), nClusters);
-  //std::cout << "  ** outTrack has getNClusters = " << outTrack.getNClusters() << std::endl;
-  //for (auto par = outTrack.rbegin(); par != outTrack.rend(); par++)
-  //  std::cout << "     getZ() =  " << par->getZ() << std::endl;
-
-  //fit(outTrack, false);
 }
 
 //_________________________________________________________________________________________________


### PR DESCRIPTION
* Added propagation of MCLabels to fitted MFT Tracks and print function
* FitterWorkflow now uses gsl::span
* TrackMFT dropped TMatrix in favor of SMatrix
