### PR TITLE
aod-writer with unique list of inputSpec

### DIFF
--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -327,8 +327,12 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
   std::vector<bool> isdangling;
   for (int ii = 0; ii < OutputsInputs.size(); ii++) {
     if ((outputtypes[ii] & 2) == 2) {
-      OutputsInputsAOD.emplace_back(OutputsInputs[ii]);
-      isdangling.emplace_back((outputtypes[ii] & 1) == 1);
+      
+      // temporarily also request to be dangling
+      if ((outputtypes[ii] & 1) == 1) {
+        OutputsInputsAOD.emplace_back(OutputsInputs[ii]);
+        isdangling.emplace_back((outputtypes[ii] & 1) == 1);
+      }
     }
   }
 
@@ -703,24 +707,27 @@ std::tuple<std::vector<InputSpec>, std::vector<unsigned char>> WorkflowHelpers::
     unsigned char outputtype = 0;
 
     // is AOD?
-    if (DataSpecUtils::partialMatch(outputSpec, header::DataOrigin("AOD")))
+    if (DataSpecUtils::partialMatch(outputSpec, header::DataOrigin("AOD"))) {
       outputtype += 2;
+    }
 
     // is dangling output?
     bool matched = false;
     for (size_t ii = 0, ie = inputs.size(); ii != ie; ++ii) {
       auto& input = inputs[ii];
       // Inputs of the same workflow cannot match outputs
-      if (output.workflowId == input.workflowId)
+      if (output.workflowId == input.workflowId) {
         continue;
+      }
       auto& inputSpec = workflow[input.workflowId].inputs[input.id];
       if (DataSpecUtils::match(inputSpec, outputSpec)) {
         matched = true;
         break;
       }
     }
-    if (!matched)
+    if (!matched) {
       outputtype += 1;
+    }
 
     // update results and outputtypes
     auto input = DataSpecUtils::matchingInput(outputSpec);
@@ -741,8 +748,9 @@ std::vector<InputSpec> WorkflowHelpers::computeDanglingOutputs(WorkflowSpec cons
 
   std::vector<InputSpec> results;
   for (int ii = 0; ii < OutputsInputs.size(); ii++) {
-    if ((outputtypes[ii] & 1) == 1)
+    if ((outputtypes[ii] & 1) == 1) {
       results.emplace_back(OutputsInputs[ii]);
+    }
   }
 
   return results;

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -327,7 +327,7 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
   std::vector<bool> isdangling;
   for (int ii = 0; ii < OutputsInputs.size(); ii++) {
     if ((outputtypes[ii] & 2) == 2) {
-      
+
       // temporarily also request to be dangling
       if ((outputtypes[ii] & 1) == 1) {
         OutputsInputsAOD.emplace_back(OutputsInputs[ii]);

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -327,12 +327,8 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
   std::vector<bool> isdangling;
   for (int ii = 0; ii < OutputsInputs.size(); ii++) {
     if ((outputtypes[ii] & 2) == 2) {
-
-      // temporarily also request to be dangling
-      if ((outputtypes[ii] & 1) == 1) {
-        OutputsInputsAOD.emplace_back(OutputsInputs[ii]);
-        isdangling.emplace_back((outputtypes[ii] & 1) == 1);
-      }
+      OutputsInputsAOD.emplace_back(OutputsInputs[ii]);
+      isdangling.emplace_back((outputtypes[ii] & 1) == 1);
     }
   }
 
@@ -733,10 +729,15 @@ std::tuple<std::vector<InputSpec>, std::vector<unsigned char>> WorkflowHelpers::
     auto input = DataSpecUtils::matchingInput(outputSpec);
     char buf[64];
     input.binding = (snprintf(buf, 63, "output_%zu_%zu", output.workflowId, output.id), buf);
-    results.emplace_back(input);
 
-    outputtypes.emplace_back(outputtype);
+    // make sure that entries are unique
+    if (std::find(results.begin(), results.end(), input) == results.end()) {
+      results.emplace_back(input);
+      outputtypes.emplace_back(outputtype);
+    }
   }
+
+  // make sure that results is unique
 
   return std::make_tuple(results, outputtypes);
 }


### PR DESCRIPTION
The vector of inputSpec given to aod-writer as input contains only unique elements. This should solve the problem encountered with certain workflows.