### PR TITLE
Tracking with compact clusters

### DIFF
--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/Cluster.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/Cluster.h
@@ -16,7 +16,7 @@
 #include "ReconstructionDataFormats/BaseCluster.h"
 
 // uncomment this to have cluster topology stored
-#define _ClusterTopology_
+//#define _ClusterTopology_
 
 #define CLUSTER_VERSION 4
 

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/ClusterPattern.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/ClusterPattern.h
@@ -24,6 +24,7 @@
 #include <Rtypes.h>
 #include <array>
 #include <iosfwd>
+#include <gsl/gsl>
 #include "DataFormatsITSMFT/Cluster.h"
 
 namespace o2
@@ -41,8 +42,19 @@ class ClusterPattern
   ClusterPattern();
   /// Standard constructor
   ClusterPattern(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes]);
-  /// Constructor from a vector with cluster patterns
-  ClusterPattern(std::vector<unsigned char>::iterator& patternIter);
+  /// Constructor from cluster patterns
+  template <class iterator>
+  ClusterPattern(iterator& pattIt)
+  {
+    mBitmap[0] = *pattIt++;
+    mBitmap[1] = *pattIt++;
+    int nbits = mBitmap[0] * mBitmap[1];
+    int nBytes = nbits / 8;
+    if (((nbits) % 8) != 0)
+      nBytes++;
+    memcpy(&mBitmap[2], &(*pattIt), nBytes);
+    pattIt += nBytes;
+  }
   /// Maximum number of bytes for the cluster puttern + 2 bytes respectively for the number of rows and columns of the bounding box
   static constexpr int kExtendedPatternBytes = Cluster::kMaxPatternBytes + 2;
   /// Returns the pattern

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/ClusterTopology.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/ClusterTopology.h
@@ -60,6 +60,12 @@ class ClusterTopology
   static unsigned long getCompleteHash(const ClusterTopology& topology);
   /// Sets the pattern
   void setPattern(int nRow, int nCol, const unsigned char patt[Cluster::kMaxPatternBytes]);
+  /// Sets the pattern
+  void setPattern(const ClusterPattern& patt)
+  {
+    mPattern = patt;
+    mHash = getCompleteHash(*this);
+  }
 
   ///Helper function useful for analyses with topologies stored on a separate branch
   static void makeRareTopologyMap(const std::vector<ClusterTopology>& vec, std::map<int, ClusterPattern>& map)

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/CompCluster.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/CompCluster.h
@@ -25,10 +25,11 @@ namespace itsmft
 
 class CompCluster
 {
- private:
+ public:
   static constexpr int NBitsRow = 9;     // number of bits for the row
   static constexpr int NBitsCol = 10;    // number of bits for the column
   static constexpr int NBitsPattID = 11; // number of bits for the pattern ID
+ private:
   static constexpr UInt_t RowMask = (0x1 << NBitsRow) - 1;
   static constexpr UInt_t ColMask = (0x1 << NBitsCol) - 1;
   static constexpr UInt_t PattIDMask = (0x1 << NBitsPattID) - 1;
@@ -40,6 +41,7 @@ class CompCluster
   void sanityCheck();
 
  public:
+  static constexpr unsigned short InvalidPatternID = (0x1 << NBitsPattID) - 1; // All 11 bits of pattern ID are 1
   CompCluster(UShort_t row = 0, UShort_t col = 0, UShort_t patt = 0)
   {
     set(row, col, patt);

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TopologyDictionary.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TopologyDictionary.h
@@ -114,7 +114,8 @@ class TopologyDictionary
   int GetSize() const { return (int)mVectorOfGroupIDs.size(); }
   ///Returns the local position of a compact cluster
   Point3D<float> getClusterCoordinates(const CompCluster& cl) const;
-  Point3D<float> getClusterCoordinates(const CompCluster& cl, const ClusterPattern& patt) const;
+  ///Returns the local position of a compact cluster
+  static Point3D<float> getClusterCoordinates(const CompCluster& cl, const ClusterPattern& patt);
 
   friend BuildTopologyDictionary;
   friend LookUp;

--- a/DataFormats/Detectors/ITSMFT/common/src/ClusterPattern.cxx
+++ b/DataFormats/Detectors/ITSMFT/common/src/ClusterPattern.cxx
@@ -29,18 +29,6 @@ ClusterPattern::ClusterPattern(int nRow, int nCol, const unsigned char patt[Clus
   setPattern(nRow, nCol, patt);
 }
 
-ClusterPattern::ClusterPattern(std::vector<unsigned char>::iterator& pattIt)
-{
-  mBitmap[0] = *pattIt++;
-  mBitmap[1] = *pattIt++;
-  int nbits = mBitmap[0] * mBitmap[1];
-  int nBytes = nbits / 8;
-  if (((nbits) % 8) != 0)
-    nBytes++;
-  memcpy(&mBitmap[2], &(*pattIt), nBytes);
-  pattIt += nBytes;
-}
-
 unsigned char ClusterPattern::getByte(int n) const
 {
   if (n < 0 || n > Cluster::kMaxPatternBytes + 1) {

--- a/DataFormats/Detectors/ITSMFT/common/src/TopologyDictionary.cxx
+++ b/DataFormats/Detectors/ITSMFT/common/src/TopologyDictionary.cxx
@@ -185,7 +185,7 @@ Point3D<float> TopologyDictionary::getClusterCoordinates(const CompCluster& cl) 
   return locCl;
 }
 
-Point3D<float> TopologyDictionary::getClusterCoordinates(const CompCluster& cl, const ClusterPattern& patt) const
+Point3D<float> TopologyDictionary::getClusterCoordinates(const CompCluster& cl, const ClusterPattern& patt)
 {
   float xCOG = 0, zCOG = 0;
   patt.getCOG(xCOG, zCOG);

--- a/Detectors/ITSMFT/ITS/macros/EVE/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/macros/EVE/CMakeLists.txt
@@ -8,6 +8,12 @@
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
 
+o2_add_test_root_macro(DisplayEventsComp.C
+                       PUBLIC_LINK_LIBRARIES O2::EventVisualisationView
+                                             O2::ITSMFTReconstruction
+                                             O2::ITSBase O2::DataFormatsITS
+                       LABELS its)
+
 o2_add_test_root_macro(DisplayEvents.C
                        PUBLIC_LINK_LIBRARIES O2::EventVisualisationView
                                              O2::ITSMFTReconstruction

--- a/Detectors/ITSMFT/ITS/macros/EVE/DisplayEvents.C
+++ b/Detectors/ITSMFT/ITS/macros/EVE/DisplayEvents.C
@@ -289,16 +289,16 @@ TEveElement* Data::getEveChipClusters(int chip)
   qclus->SetFrame(box);
   int ncl = 0;
   qclus->Reset(TEveQuadSet::kQT_LineXYFixedZ, kFALSE, 32);
+  auto gman = o2::its::GeometryTGeo::Instance();
   for (const auto& c : mClusters) {
     auto id = c.getSensorID();
     if (id != chip)
       continue;
     ncl++;
 
-    int row = c.getPatternRowMin();
-    int col = c.getPatternColMin();
-    int len = c.getPatternColSpan();
-    int wid = c.getPatternRowSpan();
+    auto xyz = c.getXYZLoc(*gman);
+    int row = 0, col = 0, len = 1, wid = 1;
+    SegmentationAlpide::localToDetector(xyz.X(), xyz.Z(), row, col);
     qclus->AddLine(col * dx, row * dy, len * dx, 0.);
     qclus->AddLine(col * dx, row * dy, 0., wid * dy);
     qclus->AddLine((col + len) * dx, row * dy, 0., wid * dy);
@@ -440,7 +440,7 @@ void init(int entry = 0, int chip = 13,
           bool rawdata = false,
           const std::vector<std::string> clusfiles = {"data-ep4-link0"},
           std::string tracfile = "o2trac_its.root",
-          std::string inputGeom = "O2geometry.root")
+          std::string inputGeom = "")
 {
   TEveManager::Create(kTRUE, "V");
   TEveBrowser* browser = gEve->GetBrowser();

--- a/Detectors/ITSMFT/ITS/macros/EVE/DisplayEventsComp.C
+++ b/Detectors/ITSMFT/ITS/macros/EVE/DisplayEventsComp.C
@@ -1,0 +1,593 @@
+/// \file DisplayEvents.C
+/// \brief Simple macro to display ITS digits, clusters and tracks
+
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include <iostream>
+#include <array>
+#include <algorithm>
+#include <fstream>
+
+#include <TFile.h>
+#include <TTree.h>
+#include <TEveManager.h>
+#include <TEveBrowser.h>
+#include <TGButton.h>
+#include <TGNumberEntry.h>
+#include <TGFrame.h>
+#include <TGTab.h>
+#include <TGLCameraOverlay.h>
+#include <TEveFrameBox.h>
+#include <TEveQuadSet.h>
+#include <TEveTrans.h>
+#include <TEvePointSet.h>
+#include <TEveTrackPropagator.h>
+#include <TEveTrack.h>
+#include <TEveEventManager.h>
+#include <TEveScene.h>
+
+#include "EventVisualisationView/MultiView.h"
+
+#include "ITSMFTReconstruction/ChipMappingITS.h"
+#include "ITSMFTReconstruction/DigitPixelReader.h"
+#include "ITSMFTReconstruction/RawPixelReader.h"
+#include "ITSMFTBase/SegmentationAlpide.h"
+#include "DataFormatsITSMFT/Digit.h"
+#include "ITSBase/GeometryTGeo.h"
+#include "DataFormatsITSMFT/CompCluster.h"
+#include "DataFormatsITSMFT/TopologyDictionary.h"
+#include "DataFormatsITSMFT/ROFRecord.h"
+#include "DataFormatsITS/TrackITS.h"
+#endif
+
+using namespace o2::itsmft;
+
+extern TEveManager* gEve;
+static TEveScene* chipScene;
+
+static TGNumberEntry* gEntry;
+static TGNumberEntry* gChipID;
+
+class Data
+{
+ public:
+  void loadData(int entry);
+  void displayData(int entry, int chip);
+  int getLastEvent() const { return mLastEvent; }
+  void setRawPixelReader(std::string input)
+  {
+    auto reader = new RawPixelReader<ChipMappingITS>();
+    reader->openInput(input);
+    mPixelReader = reader;
+    mPixelReader->getNextChipData(mChipData);
+    mIR = mChipData.getInteractionRecord();
+  }
+  void setDigitPixelReader(std::string input)
+  {
+    auto reader = new DigitPixelReader();
+    reader->openInput(input, o2::detectors::DetID("ITS"));
+    reader->init();
+    reader->readNextEntry();
+    mPixelReader = reader;
+    mPixelReader->getNextChipData(mChipData);
+    mIR = mChipData.getInteractionRecord();
+  }
+  void setDigiTree(TTree* t) { mDigiTree = t; }
+  void setClusTree(TTree* t);
+  void setTracTree(TTree* t);
+
+ private:
+  // Data loading members
+  int mLastEvent = 0;
+  PixelReader* mPixelReader = nullptr;
+  ChipPixelData mChipData;
+  o2::InteractionRecord mIR;
+  std::vector<Digit> mDigits;
+  std::vector<CompClusterExt>* mClusterBuffer = nullptr;
+  gsl::span<CompClusterExt> mClusters;
+  std::vector<o2::itsmft::ROFRecord>* mClustersROF = nullptr;
+  std::vector<o2::its::TrackITS>* mTrackBuffer = nullptr;
+  std::vector<int>* mClIdxBuffer = nullptr;
+  gsl::span<o2::its::TrackITS> mTracks;
+  std::vector<o2::itsmft::ROFRecord>* mTracksROF = nullptr;
+  void loadDigits();
+  void loadDigits(int entry);
+  void loadClusters(int entry);
+  void loadTracks(int entry);
+
+  TTree* mDigiTree = nullptr;
+  TTree* mClusTree = nullptr;
+  TTree* mTracTree = nullptr;
+
+  // TEve-related members
+  TEveElementList* mEvent = nullptr;
+  TEveElementList* mChip = nullptr;
+  TEveElement* getEveChipDigits(int chip);
+  TEveElement* getEveChipClusters(int chip);
+  TEveElement* getEveClusters();
+  TEveElement* getEveTracks();
+} evdata;
+
+o2::itsmft::TopologyDictionary dict;
+
+void Data::loadDigits()
+{
+  auto ir = mChipData.getInteractionRecord();
+  std::cout << "orbit/crossing: " << ' ' << ir.orbit << '/' << ir.bc << '\n';
+
+  mDigits.clear();
+
+  do {
+    auto chipID = mChipData.getChipID();
+    auto pixels = mChipData.getData();
+    for (auto& pixel : pixels) {
+      auto col = pixel.getCol();
+      auto row = pixel.getRowDirect();
+      mDigits.emplace_back(chipID, row, col, 0);
+    }
+    if (!mPixelReader->getNextChipData(mChipData))
+      return;
+    ir = mChipData.getInteractionRecord();
+  } while (mIR == ir);
+  mIR = ir;
+
+  std::cout << "Number of ITSDigits: " << mDigits.size() << '\n';
+}
+
+void Data::loadDigits(int entry)
+{
+  if (mPixelReader == nullptr)
+    return;
+
+  for (; mLastEvent < entry; mLastEvent++) {
+    auto ir = mChipData.getInteractionRecord();
+    do {
+      if (!mPixelReader->getNextChipData(mChipData))
+        return;
+      ir = mChipData.getInteractionRecord();
+    } while (mIR == ir);
+    mIR = ir;
+  }
+  mLastEvent++;
+  loadDigits();
+}
+
+void Data::setClusTree(TTree* tree)
+{
+  if (tree == nullptr) {
+    std::cerr << "No tree for clusters !\n";
+    return;
+  }
+  tree->SetBranchAddress("ITSClusterComp", &mClusterBuffer);
+  tree->SetBranchAddress("ITSClustersROF", &mClustersROF);
+  tree->GetEntry(0);
+  mClusTree = tree;
+}
+
+void Data::loadClusters(int entry)
+{
+  if (mClusTree == nullptr)
+    return;
+
+  int first = 0, last = mClusterBuffer->size();
+  if (!mClustersROF->empty()) {
+    auto rof = (*mClustersROF)[entry];
+    first = rof.getFirstEntry();
+    last = first + rof.getNEntries();
+  }
+  mClusters = gsl::make_span(&(*mClusterBuffer)[first], last - first);
+
+  std::cout << "Number of ITSClusters: " << mClusters.size() << '\n';
+}
+
+void Data::setTracTree(TTree* tree)
+{
+  if (tree == nullptr) {
+    std::cerr << "No tree for tracks !\n";
+    return;
+  }
+  tree->SetBranchAddress("ITSTrack", &mTrackBuffer);
+  tree->SetBranchAddress("ITSTrackClusIdx", &mClIdxBuffer);
+  tree->SetBranchAddress("ITSTracksROF", &mTracksROF);
+  tree->GetEntry(0);
+  mTracTree = tree;
+}
+
+void Data::loadTracks(int entry)
+{
+  static int lastLoaded = -1;
+
+  if (mTracTree == nullptr)
+    return;
+
+  int first = 0, last = mTrackBuffer->size();
+  if (!mTracksROF->empty()) {
+    auto rof = (*mTracksROF)[entry];
+    first = rof.getFirstEntry();
+    last = first + rof.getNEntries();
+  }
+  mTracks = gsl::make_span(&(*mTrackBuffer)[first], last - first);
+
+  std::cout << "Number of ITSTracks: " << mTracks.size() << '\n';
+}
+
+void Data::loadData(int entry)
+{
+  loadDigits(entry);
+  loadClusters(entry);
+  loadTracks(entry);
+}
+
+constexpr float sizey = SegmentationAlpide::ActiveMatrixSizeRows;
+constexpr float sizex = SegmentationAlpide::ActiveMatrixSizeCols;
+constexpr float dy = SegmentationAlpide::PitchRow;
+constexpr float dx = SegmentationAlpide::PitchCol;
+constexpr float gap = 1e-4; // For a better visualization of pixels
+
+TEveElement* Data::getEveChipDigits(int chip)
+{
+  TEveFrameBox* box = new TEveFrameBox();
+  box->SetAAQuadXY(0, 0, 0, sizex, sizey);
+  box->SetFrameColor(kGray);
+
+  // Digits
+  TEveQuadSet* qdigi = new TEveQuadSet("digits");
+  qdigi->SetOwnIds(kTRUE);
+  qdigi->SetFrame(box);
+  qdigi->Reset(TEveQuadSet::kQT_RectangleXY, kFALSE, 32);
+  auto gman = o2::its::GeometryTGeo::Instance();
+  std::vector<int> occup(gman->getNumberOfChips());
+  for (const auto& d : mDigits) {
+    auto id = d.getChipIndex();
+    occup[id]++;
+    if (id != chip)
+      continue;
+
+    int row = d.getRow();
+    int col = d.getColumn();
+    int charge = d.getCharge();
+    qdigi->AddQuad(col * dx + gap, row * dy + gap, 0., dx - 2 * gap, dy - 2 * gap);
+    qdigi->QuadValue(charge);
+  }
+  qdigi->RefitPlex();
+  TEveTrans& t = qdigi->RefMainTrans();
+  t.RotateLF(1, 3, 0.5 * TMath::Pi());
+  t.SetPos(0, 0, 0);
+
+  auto most = std::distance(occup.begin(), std::max_element(occup.begin(), occup.end()));
+  if (occup[most] > 0) {
+    std::cout << "Most occupied chip: " << most << " (" << occup[most] << " digits)\n";
+  }
+  if (occup[chip] > 0) {
+    std::cout << "Chip " << chip << " number of digits " << occup[chip] << '\n';
+    return qdigi;
+  }
+  delete qdigi;
+  return nullptr;
+}
+
+TEveElement* Data::getEveChipClusters(int chip)
+{
+  TEveFrameBox* box = new TEveFrameBox();
+  box->SetAAQuadXY(0, 0, 0, sizex, sizey);
+  box->SetFrameColor(kGray);
+
+  // Clusters
+  TEveQuadSet* qclus = new TEveQuadSet("clusters");
+  qclus->SetOwnIds(kTRUE);
+  qclus->SetFrame(box);
+  int ncl = 0;
+  qclus->Reset(TEveQuadSet::kQT_LineXYFixedZ, kFALSE, 32);
+  for (const auto& c : mClusters) {
+    auto id = c.getSensorID();
+    if (id != chip)
+      continue;
+    ncl++;
+
+    auto pattern = dict.GetPattern(c.getPatternID());
+    int row = c.getRow();
+    int col = c.getCol();
+    int len = pattern.getColumnSpan();
+    int wid = pattern.getRowSpan();
+    qclus->AddLine(col * dx, row * dy, len * dx, 0.);
+    qclus->AddLine(col * dx, row * dy, 0., wid * dy);
+    qclus->AddLine((col + len) * dx, row * dy, 0., wid * dy);
+    qclus->AddLine(col * dx, (row + wid) * dy, len * dx, 0.);
+  }
+  qclus->RefitPlex();
+  TEveTrans& ct = qclus->RefMainTrans();
+  ct.RotateLF(1, 3, 0.5 * TMath::Pi());
+  ct.SetPos(0, 0, 0);
+
+  if (ncl > 0) {
+    std::cout << "Chip " << chip << " number of clusters " << ncl << '\n';
+    return qclus;
+  }
+  delete qclus;
+  return nullptr;
+}
+
+TEveElement* Data::getEveClusters()
+{
+  if (mClusters.empty())
+    return nullptr;
+
+  auto gman = o2::its::GeometryTGeo::Instance();
+  TEvePointSet* clusters = new TEvePointSet("clusters");
+  clusters->SetMarkerColor(kBlue);
+  for (const auto& c : mClusters) {
+    auto locC = dict.getClusterCoordinates(c);
+    auto id = c.getSensorID();
+    const auto gloC = gman->getMatrixL2G(id) * locC;
+    clusters->SetNextPoint(gloC.X(), gloC.Y(), gloC.Z());
+  }
+  return clusters;
+}
+
+TEveElement* Data::getEveTracks()
+{
+  if (mTracks.empty())
+    return nullptr;
+
+  auto gman = o2::its::GeometryTGeo::Instance();
+  TEveTrackList* tracks = new TEveTrackList("tracks");
+  auto prop = tracks->GetPropagator();
+  prop->SetMagField(0.5);
+  prop->SetMaxR(50.);
+  for (const auto& rec : mTracks) {
+    std::array<float, 3> p;
+    rec.getPxPyPzGlo(p);
+    TEveRecTrackD t;
+    t.fP = {p[0], p[1], p[2]};
+    t.fSign = (rec.getSign() < 0) ? -1 : 1;
+    TEveTrack* track = new TEveTrack(&t, prop);
+    track->SetLineColor(kMagenta);
+    tracks->AddElement(track);
+
+    if (mClusters.empty())
+      continue;
+    TEvePointSet* tpoints = new TEvePointSet("tclusters");
+    tpoints->SetMarkerColor(kGreen);
+    int nc = rec.getNumberOfClusters();
+    int idxRef = rec.getFirstClusterEntry();
+
+    while (nc--) {
+      Int_t idx = (*mClIdxBuffer)[idxRef + nc];
+      const CompClusterExt& c = mClusters[idx];
+      auto locC = dict.getClusterCoordinates(c);
+      auto id = c.getSensorID();
+      const auto gloC = gman->getMatrixL2G(id) * locC;
+      tpoints->SetNextPoint(gloC.X(), gloC.Y(), gloC.Z());
+    }
+    track->AddElement(tpoints);
+  }
+  tracks->MakeTracks();
+
+  return tracks;
+}
+
+void Data::displayData(int entry, int chip)
+{
+  std::string ename("Event #");
+  ename += std::to_string(entry);
+
+  // Chip display
+  auto chipDigits = getEveChipDigits(chip);
+  auto chipClusters = getEveChipClusters(chip);
+  delete mChip;
+  mChip = nullptr;
+  if (chipDigits || chipClusters) {
+    std::string cname(ename + "  ALPIDE chip #");
+    cname += std::to_string(chip);
+    mChip = new TEveElementList(cname.c_str());
+    if (chipDigits) {
+      mChip->AddElement(chipDigits);
+    }
+    if (chipClusters) {
+      mChip->AddElement(chipClusters);
+    }
+    gEve->AddElement(mChip, chipScene);
+  }
+
+  // Event display
+  auto clusters = getEveClusters();
+  auto tracks = getEveTracks();
+  delete mEvent;
+  mEvent = nullptr;
+  if (clusters || tracks) {
+    mEvent = new TEveElementList(ename.c_str());
+    if (clusters)
+      mEvent->AddElement(clusters);
+    if (tracks)
+      mEvent->AddElement(tracks);
+    auto multi = o2::event_visualisation::MultiView::getInstance();
+    multi->registerEvent(mEvent);
+  }
+  gEve->Redraw3D(kFALSE);
+}
+
+void load(int entry, int chip)
+{
+  int lastEvent = evdata.getLastEvent();
+  if (lastEvent > entry) {
+    std::cerr << "\nERROR: Cannot stay or go back over events. Please increase the event number !\n\n";
+    gEntry->SetIntNumber(lastEvent - 1);
+    return;
+  }
+
+  gEntry->SetIntNumber(entry);
+  gChipID->SetIntNumber(chip);
+
+  std::cout << "\n*** Event #" << entry << " ***\n";
+  evdata.loadData(entry);
+  evdata.displayData(entry, chip);
+}
+
+void init(int entry = 0, int chip = 13,
+          std::string digifile = "itsdigits.root",
+          bool rawdata = false,
+          std::string clusfile = "o2clus_its.root",
+          std::string tracfile = "o2trac_its.root",
+          std::string inputGeom = "")
+{
+  dict.ReadBinaryFile("complete_dictionary.bin");
+
+  TEveManager::Create(kTRUE, "V");
+  TEveBrowser* browser = gEve->GetBrowser();
+
+  // Geometry
+  o2::base::GeometryManager::loadGeometry(inputGeom, "FAIRGeom");
+  auto gman = o2::its::GeometryTGeo::Instance();
+  gman->fillMatrixCache(o2::utils::bit2Mask(o2::TransformType::T2L, o2::TransformType::T2GRot,
+                                            o2::TransformType::L2G));
+
+  // Chip View
+  browser->GetTabRight()->SetText("Chip View");
+  auto chipView = gEve->GetDefaultViewer();
+  chipView->SetName("Chip Viewer");
+  chipView->DestroyElements();
+  chipScene = gEve->SpawnNewScene("Chip View", "Chip view desciption");
+  chipView->AddScene(chipScene);
+  TGLViewer* v = gEve->GetDefaultGLViewer();
+  v->SetCurrentCamera(TGLViewer::kCameraOrthoZOY);
+  TGLCameraOverlay* co = v->GetCameraOverlay();
+  co->SetShowOrthographic(kTRUE);
+  co->SetOrthographicMode(TGLCameraOverlay::kGridFront);
+
+  // Event View
+  auto multi = o2::event_visualisation::MultiView::getInstance();
+  multi->drawGeometryForDetector("ITS");
+
+  gEve->AddEvent(new TEveEventManager());
+
+  // Event navigation
+  browser->StartEmbedding(TRootBrowser::kBottom);
+  auto frame = new TGMainFrame(gClient->GetRoot(), 1000, 600, kVerticalFrame);
+
+  auto h = new TGHorizontalFrame(frame);
+  auto b = new TGTextButton(h, "PrevEvnt", "prev()");
+  h->AddFrame(b);
+  gEntry = new TGNumberEntry(h, 0, 5, -1, TGNumberFormat::kNESInteger, TGNumberFormat::kNEANonNegative, TGNumberFormat::kNELLimitMinMax, 0, 10000);
+  gEntry->Connect("ValueSet(Long_t)", 0, 0, "load()");
+  h->AddFrame(gEntry);
+  b = new TGTextButton(h, "NextEvnt", "next()");
+  h->AddFrame(b);
+  frame->AddFrame(h);
+
+  // Chip navigation
+  h = new TGHorizontalFrame(frame);
+  b = new TGTextButton(h, "PrevChip", "prevChip()");
+  h->AddFrame(b);
+  gChipID = new TGNumberEntry(h, 0, 5, -1, TGNumberFormat::kNESInteger, TGNumberFormat::kNEANonNegative, TGNumberFormat::kNELLimitMinMax, 0, gman->getNumberOfChips());
+  gChipID->Connect("ValueSet(Long_t)", 0, 0, "loadChip()");
+  h->AddFrame(gChipID);
+  b = new TGTextButton(h, "NextChip", "nextChip()");
+  h->AddFrame(b);
+  frame->AddFrame(h);
+
+  frame->MapSubwindows();
+  frame->MapWindow();
+  browser->StopEmbedding("Navigator");
+
+  TFile* file;
+
+  // Data sources
+  if (rawdata) {
+    std::ifstream* rawfile = new std::ifstream(digifile.data(), std::ifstream::binary);
+    if (rawfile->good()) {
+      delete rawfile;
+      std::cout << "Running with raw digits...\n";
+      evdata.setRawPixelReader(digifile.data());
+    } else
+      std::cerr << "\nERROR: Cannot open file: " << digifile << "\n\n";
+  } else {
+    file = TFile::Open(digifile.data());
+    if (file && gFile->IsOpen()) {
+      file->Close();
+      std::cout << "Running with MC digits...\n";
+      evdata.setDigitPixelReader(digifile.data());
+      //evdata.setDigiTree((TTree*)gFile->Get("o2sim"));
+    } else
+      std::cerr << "\nERROR: Cannot open file: " << digifile << "\n\n";
+  }
+
+  file = TFile::Open(clusfile.data());
+  if (file && gFile->IsOpen())
+    evdata.setClusTree((TTree*)gFile->Get("o2sim"));
+  else
+    std::cerr << "ERROR: Cannot open file: " << clusfile << "\n\n";
+
+  file = TFile::Open(tracfile.data());
+  if (file && gFile->IsOpen())
+    evdata.setTracTree((TTree*)gFile->Get("o2sim"));
+  else
+    std::cerr << "\nERROR: Cannot open file: " << tracfile << "\n\n";
+
+  std::cout << "\n **** Navigation over events and chips ****\n";
+  std::cout << " load(event, chip) \t jump to the specified event and chip\n";
+  std::cout << " next() \t\t load next event \n";
+  std::cout << " prev() \t\t load previous event \n";
+  std::cout << " loadChip(chip) \t jump to the specified chip within the current event \n";
+  std::cout << " nextChip() \t\t load the next chip within the current event \n";
+  std::cout << " prevChip() \t\t load the previous chip within the current event \n";
+
+  load(entry, chip);
+  gEve->Redraw3D(kTRUE);
+}
+
+void load()
+{
+  auto event = gEntry->GetNumberEntry()->GetIntNumber();
+  auto chip = gChipID->GetNumberEntry()->GetIntNumber();
+
+  load(event, chip);
+}
+
+void next()
+{
+  auto event = gEntry->GetNumberEntry()->GetIntNumber();
+  event++;
+  auto chip = gChipID->GetNumberEntry()->GetIntNumber();
+  load(event, chip);
+}
+
+void prev()
+{
+  auto event = gEntry->GetNumberEntry()->GetIntNumber();
+  event--;
+  auto chip = gChipID->GetNumberEntry()->GetIntNumber();
+  load(event, chip);
+}
+
+void loadChip()
+{
+  auto event = gEntry->GetNumberEntry()->GetIntNumber();
+  auto chip = gChipID->GetNumberEntry()->GetIntNumber();
+  evdata.displayData(event, chip);
+}
+
+void loadChip(int chip)
+{
+  gChipID->SetIntNumber(chip);
+  loadChip();
+}
+
+void nextChip()
+{
+  auto chip = gChipID->GetNumberEntry()->GetIntNumber();
+  chip++;
+  loadChip(chip);
+}
+
+void prevChip()
+{
+  auto chip = gChipID->GetNumberEntry()->GetIntNumber();
+  chip--;
+  loadChip(chip);
+}
+
+void DisplayEventsComp()
+{
+  // A dummy function with the same name as this macro
+  init(0, 7);
+  gEve->GetBrowser()->GetTabRight()->SetTab(1);
+}

--- a/Detectors/ITSMFT/ITS/macros/EVE/simple_geom_ITS.C
+++ b/Detectors/ITSMFT/ITS/macros/EVE/simple_geom_ITS.C
@@ -20,7 +20,7 @@
 
 void AddNodes(TGeoNode* node, TEveGeoNode* parent, Int_t depth, Int_t depthmax, TObjArray* list);
 
-void simple_geom_ITS(std::string inputGeom = "O2geometry.root")
+void simple_geom_ITS(std::string inputGeom = "o2sim_geometry.root")
 {
   const char* currentDetector = "ITS";
 

--- a/Detectors/ITSMFT/ITS/macros/test/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/macros/test/CMakeLists.txt
@@ -58,6 +58,7 @@ o2_add_test_root_macro(CheckCOG.C
 
 o2_add_test_root_macro(CheckTracks.C
                        PUBLIC_LINK_LIBRARIES O2::SimulationDataFormat
+                                             O2::ITSBase
                                              O2::DataFormatsITS
                                              O2::DataFormatsITSMFT
                        LABELS its)

--- a/Detectors/ITSMFT/ITS/macros/test/CheckCOG.C
+++ b/Detectors/ITSMFT/ITS/macros/test/CheckCOG.C
@@ -30,6 +30,7 @@ void CheckCOG(std::string clusfile = "o2clus_its.root", std::string inputGeom = 
   using namespace o2::its;
 
   using o2::itsmft::Cluster;
+  using o2::itsmft::CompCluster;
   using o2::itsmft::CompClusterExt;
   using o2::itsmft::TopologyDictionary;
 
@@ -56,7 +57,14 @@ void CheckCOG(std::string clusfile = "o2clus_its.root", std::string inputGeom = 
   int ievC = 0;
   int lastReadHitEv = -1;
 
-  TopologyDictionary dict(dictionary_file.c_str());
+  TopologyDictionary dict;
+  std::ifstream file(dictionary_file.c_str());
+  if (file.good()) {
+    LOG(INFO) << "Running with dictionary: " << dictionary_file.c_str();
+    dict.ReadBinaryFile(dictionary_file);
+  } else {
+    LOG(INFO) << "Running without dictionary !";
+  }
 
   TH1F* hTotalX = new TH1F("hTotalX", "All entries;x_{full} - x_{compact} (#mum);counts", 81, -40.5, 40.5);
   TH1F* hTotalZ = new TH1F("hTotalZ", "All entries;z_{full} - z_{compact} (#mum);counts", 81, -40.5, 40.5);
@@ -80,32 +88,37 @@ void CheckCOG(std::string clusfile = "o2clus_its.root", std::string inputGeom = 
     }
     printf("processing cluster event %d\n", ievC);
 
-    auto pattIdx = patternsPtr->begin();
+    auto pattIdx = patternsPtr->cbegin();
     for (int i = 0; i < nc; i++) {
       // cluster is in tracking coordinates always
       Cluster& c = (*clusArr)[i];
       const auto locC = c.getXYZLoc(*gman); // convert from tracking to local frame
 
+      float dx, dz;
+      Point3D<float> locComp;
       CompClusterExt& cComp = (*compclusArr)[i];
-      Point3D<float> locComp = dict.getClusterCoordinates(cComp);
+      auto pattID = cComp.getPatternID();
+      fOut << Form("groupID: %d\n", pattID);
+      if (pattID != CompCluster::InvalidPatternID) {
+        Point3D<float> locComp = dict.getClusterCoordinates(cComp);
 
-      float xComp = locComp.X();
-      float zComp = locComp.Z();
+        float xComp = locComp.X();
+        float zComp = locComp.Z();
 
-      float dx = (locC.X() - xComp) * 10000;
-      float dz = (locC.Z() - zComp) * 10000;
+        dx = (locC.X() - xComp) * 10000;
+        dz = (locC.Z() - zComp) * 10000;
 
-      hTotalX->Fill(dx);
-      hTotalZ->Fill(dz);
+        hTotalX->Fill(dx);
+        hTotalZ->Fill(dz);
 
-      fOut << Form("groupID: %d\n", cComp.getPatternID());
-      fOut << Form("is group: %o\n", dict.IsGroup(cComp.getPatternID()));
-      fOut << Form("x_full: %.4f x_comp: %.4f dx: %.4f x_shift: %.4f\n", locC.X(), xComp, dx / 10000, dict.GetXcog(cComp.getPatternID()));
-      fOut << Form("z_full: %.4f z_comp: %.4f dZ: %.4f z_shift: %.4f\n", locC.Z(), zComp, dz / 10000, dict.GetZcog(cComp.getPatternID()));
-      fOut << dict.GetPattern(cComp.getPatternID());
-      fOut << Form("***************************************\n");
+        fOut << Form("is group: %o\n", dict.IsGroup(pattID));
+        fOut << Form("x_full: %.4f x_comp: %.4f dx: %.4f x_shift: %.4f\n", locC.X(), xComp, dx / 10000, dict.GetXcog(pattID));
+        fOut << Form("z_full: %.4f z_comp: %.4f dZ: %.4f z_shift: %.4f\n", locC.Z(), zComp, dz / 10000, dict.GetZcog(pattID));
+        fOut << dict.GetPattern(pattID);
+        fOut << Form("***************************************\n");
+      }
 
-      if (dict.IsGroup(cComp.getPatternID())) {
+      if (pattID == CompCluster::InvalidPatternID || dict.IsGroup(pattID)) {
         if (patternsPtr) { // Restore the full pixel pattern information from the auxiliary branch
           o2::itsmft::ClusterPattern patt(pattIdx);
           auto locCl = dict.getClusterCoordinates(cComp, patt);

--- a/Detectors/ITSMFT/ITS/macros/test/CheckCOG.C
+++ b/Detectors/ITSMFT/ITS/macros/test/CheckCOG.C
@@ -23,7 +23,7 @@
 
 #endif
 
-void CheckCOG(std::string clusfile = "o2clus_its.root", std::string inputGeom = "O2geometry.root", std::string dictionary_file = "complete_dictionary.bin")
+void CheckCOG(std::string clusfile = "o2clus_its.root", std::string inputGeom = "", std::string dictionary_file = "complete_dictionary.bin")
 {
   gStyle->SetOptStat(0);
   using namespace o2::base;

--- a/Detectors/ITSMFT/ITS/macros/test/CheckClusterShape.C
+++ b/Detectors/ITSMFT/ITS/macros/test/CheckClusterShape.C
@@ -222,7 +222,7 @@ void AnalyzeClusters(Int_t nev, const map<UInt_t, Cluster>& clusters, TH1F* freq
 //////////////////////////////////////////
 //////////////////////////////////////////
 
-void CheckClusterShape(std::string digifile = "o2digi_its.root", std::string inputGeom = "O2geometry.root")
+void CheckClusterShape(std::string digifile = "o2digi_its.root", std::string inputGeom = "")
 {
   // Geometry
   o2::base::GeometryManager::loadGeometry(inputGeom, "FAIRGeom");

--- a/Detectors/ITSMFT/ITS/macros/test/CheckClusters.C
+++ b/Detectors/ITSMFT/ITS/macros/test/CheckClusters.C
@@ -21,7 +21,7 @@
 #include "SimulationDataFormat/MCTruthContainer.h"
 #endif
 
-void CheckClusters(std::string clusfile = "o2clus_its.root", std::string hitfile = "o2sim_HitsITS.root", std::string inputGeom = "O2geometry.root", std::string paramfile = "o2sim_par.root", std::string dictfile = "complete_dictionary.bin")
+void CheckClusters(std::string clusfile = "o2clus_its.root", std::string hitfile = "o2sim_HitsITS.root", std::string inputGeom = "o2sim_geometry.root", std::string paramfile = "o2sim_par.root", std::string dictfile = "complete_dictionary.bin")
 {
   const int QEDSourceID = 99; // Clusters from this MC source correspond to QED electrons
 
@@ -142,6 +142,7 @@ void CheckClusters(std::string clusfile = "o2clus_its.root", std::string hitfile
 
       const auto& cluster = (*clusArr)[clEntry];
 
+      int npix = 0;
       auto pattID = cluster.getPatternID();
       Point3D<float> locC;
       if (pattID == o2::itsmft::CompCluster::InvalidPatternID || dict.IsGroup(pattID)) {
@@ -149,6 +150,7 @@ void CheckClusters(std::string clusfile = "o2clus_its.root", std::string hitfile
         locC = dict.getClusterCoordinates(cluster, patt);
       } else {
         locC = dict.getClusterCoordinates(cluster);
+        npix = dict.GetNpixels(pattID);
       }
       auto chipID = cluster.getSensorID();
       // Transformation to the local --> global
@@ -171,7 +173,6 @@ void CheckClusters(std::string clusfile = "o2clus_its.root", std::string hitfile
       }
       const auto& hit = (*hitArray)[hitEntry->second];
       //
-      int npix = dict.GetNpixels(pattID);
       float dx = 0, dz = 0;
       int ievH = lab.getEventID();
       Point3D<float> locH, locHsta;

--- a/Detectors/ITSMFT/ITS/macros/test/CheckDigits.C
+++ b/Detectors/ITSMFT/ITS/macros/test/CheckDigits.C
@@ -23,7 +23,7 @@
 
 #endif
 
-void CheckDigits(std::string digifile = "itsdigits.root", std::string hitfile = "o2sim_HitsITS.root", std::string inputGeom = "O2geometry.root", std::string paramfile = "o2sim_par.root")
+void CheckDigits(std::string digifile = "itsdigits.root", std::string hitfile = "o2sim_HitsITS.root", std::string inputGeom = "", std::string paramfile = "o2sim_par.root")
 {
 
   using namespace o2::base;

--- a/Detectors/ITSMFT/ITS/macros/test/CheckLookUp.C
+++ b/Detectors/ITSMFT/ITS/macros/test/CheckLookUp.C
@@ -26,7 +26,8 @@ bool verbose = false;
 
 void CheckLookUp(std::string clusfile = "o2clus_its.root", std::string dictfile = "complete_dictionary.bin")
 {
-
+#ifdef _ClusterTopology_
+  // This macro needs itsmft::Clusters to be compiled with topology information
   using o2::itsmft::BuildTopologyDictionary;
   using o2::itsmft::Cluster;
   using o2::itsmft::ClusterTopology;
@@ -112,4 +113,5 @@ void CheckLookUp(std::string clusfile = "o2clus_its.root", std::string dictfile 
   hDistribution->Scale(1 / hDistribution->Integral());
   outroot.cd();
   hDistribution->Write();
+#endif
 }

--- a/Detectors/ITSMFT/ITS/macros/test/CheckTracks.C
+++ b/Detectors/ITSMFT/ITS/macros/test/CheckTracks.C
@@ -67,7 +67,7 @@ void CheckTracks(std::string tracfile = "o2trac_its.root", std::string clusfile 
                             "ipD:ipZ:label");
 
   // Geometry
-  o2::base::GeometryManager::loadGeometry("O2geometry.root", "FAIRGeom");
+  o2::base::GeometryManager::loadGeometry("o2sim_geometry.root", "FAIRGeom");
   auto gman = o2::its::GeometryTGeo::Instance();
 
   // MC tracks

--- a/Detectors/ITSMFT/ITS/macros/test/DisplayTrack.C
+++ b/Detectors/ITSMFT/ITS/macros/test/DisplayTrack.C
@@ -26,7 +26,7 @@
 #include "SimulationDataFormat/MCTruthContainer.h"
 #endif
 
-void DisplayTrack(Int_t event = 0, Int_t track = 0, std::string tracfile = "o2trac_its.root", std::string clusfile = "o2clus_its.root", std::string hitfile = "o2sim_HitsITS.root", std::string inputGeom = "O2geometry.root")
+void DisplayTrack(Int_t event = 0, Int_t track = 0, std::string tracfile = "o2trac_its.root", std::string clusfile = "o2clus_its.root", std::string hitfile = "o2sim_HitsITS.root", std::string inputGeom = "")
 {
   using namespace o2::base;
   using namespace o2::its;

--- a/Detectors/ITSMFT/ITS/macros/test/run_buildTopoDict_its.C
+++ b/Detectors/ITSMFT/ITS/macros/test/run_buildTopoDict_its.C
@@ -35,7 +35,7 @@
 
 void run_buildTopoDict_its(std::string clusfile = "o2clus_its.root",
                            std::string hitfile = "o2sim_HitsITS.root",
-                           std::string inputGeom = "O2geometry.root")
+                           std::string inputGeom = "")
 {
   const int QEDSourceID = 99; // Clusters from this MC source correspond to QED electrons
 

--- a/Detectors/ITSMFT/ITS/macros/test/run_test.sh
+++ b/Detectors/ITSMFT/ITS/macros/test/run_test.sh
@@ -10,7 +10,7 @@ mcGener=boxgen
 o2-sim -n $nEvents -e $mcEngine -g $mcGener -m PIPE ITS >& sim_its.log
 
 # Digitizing in triggered readout mode...
-o2-sim-digitizer-workflow --configKeyValues "ITSDigitizerParam.continuous=0" >& digi.log 
+o2-sim-digitizer-workflow -b --configKeyValues "ITSDigitizerParam.continuous=0" >& digi.log 
 
 root.exe -b -q CheckDigits.C+ >& CheckDigits.log
 
@@ -18,7 +18,7 @@ root -b -q $O2_ROOT/share/macro/run_clus_itsSA.C+\(\"itsdigits.root\",\"o2clus_i
 
 root.exe -b -q CheckClusters.C+ >& CheckClusters.log
 
-root.exe -b -q CheckTopologies.C+ >& CheckTopologies.log
+#root.exe -b -q CheckTopologies.C+ >& CheckTopologies.log
 
 root.exe -b -q $O2_ROOT/share/macro/run_trac_its.C+ >& trac_its.log
 

--- a/Detectors/ITSMFT/ITS/reconstruction/src/ClustererTask.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/ClustererTask.cxx
@@ -107,19 +107,10 @@ void ClustererTask::run(const std::string inpName, const std::string outName)
     }
 
     auto compClusPtr = &mCompClus;
-    if (mClusterer.getWantCompactClusters()) {
-      outTree.Branch("ITSClusterComp", &compClusPtr);
-    } else {
-      LOG(INFO) << Class()->GetName() << " output of compact clusters is not requested";
-    }
+    outTree.Branch("ITSClusterComp", &compClusPtr);
 
     auto rofRecVecPtr = &mROFRecVec;
     outTree.Branch("ITSClustersROF", &rofRecVecPtr);
-
-    if (mUseMCTruth && !(mClusterer.getWantFullClusters() || mClusterer.getWantCompactClusters())) {
-      mUseMCTruth = false;
-      LOG(WARNING) << "ITS clusters storage is not requested, suppressing MCTruth storage";
-    }
 
     auto clsLabelsPtr = &mClsLabels;
     if (mUseMCTruth && mReaderMC->getDigitsMCTruth()) {
@@ -185,12 +176,8 @@ void ClustererTask::writeTree(std::string basename, int i)
   }
 
   std::vector<CompClusterExt> compClusBuffer, *compClusPtr = &compClusBuffer;
-  if (mClusterer.getWantCompactClusters()) {
-    compClusBuffer.assign(&mCompClus[first], &mCompClus[last]);
-    outTree.Branch("ITSClusterComp", &compClusPtr);
-  } else {
-    LOG(INFO) << Class()->GetName() << " output of compact clusters is not requested";
-  }
+  compClusBuffer.assign(&mCompClus[first], &mCompClus[last]);
+  outTree.Branch("ITSClusterComp", &compClusPtr);
 
   if (mClusterer.getPatterns()) {
     outTree.Branch("ITSClusterPatt", &mPatterns);

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CookedTracker.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CookedTracker.cxx
@@ -28,7 +28,8 @@
 #include "CommonConstants/MathConstants.h"
 #include "DetectorsBase/Propagator.h"
 #include "Field/MagneticField.h"
-#include "DataFormatsITSMFT/Cluster.h"
+#include "DataFormatsITSMFT/CompCluster.h"
+#include "DataFormatsITSMFT/TopologyDictionary.h"
 #include "ITSReconstruction/CookedTracker.h"
 #include "MathUtils/Utils.h"
 #include "SimulationDataFormat/MCCompLabel.h"
@@ -100,7 +101,7 @@ Label CookedTracker::cookLabel(TrackITSExt& t, Float_t wrong) const
 
   for (int i = noc; i--;) {
     const Cluster* c = getCluster(t.getClusterIndex(i));
-    Int_t idx = c - mFirstCluster; // Index of this cluster in event
+    Int_t idx = c - &mClusterCache[0] + mFirstInFrame; // Index of this cluster in event
     auto labels = mClsLabels->getLabels(idx);
 
     for (auto lab : labels) { // check all labels of the cluster
@@ -263,7 +264,7 @@ void CookedTracker::makeSeeds(std::vector<TrackITSExt>& seeds, Int_t first, Int_
   for (Int_t n1 = first; n1 < last; n1++) {
     const Cluster* c1 = layer1.getCluster(n1);
     //
-    //auto lab = (mClsLabels->getLabels(c1-mFirstCluster))[0];
+    //auto lab = (mClsLabels->getLabels(c1 - &mClusterCache[0] + mFirstInFrame))[0];
     //
     auto xyz1 = c1->getXYZGloRot(*mGeom);
     auto z1 = xyz1.Z();
@@ -282,7 +283,7 @@ void CookedTracker::makeSeeds(std::vector<TrackITSExt>& seeds, Int_t first, Int_
     for (auto n2 : selected2) {
       const Cluster* c2 = layer2.getCluster(n2);
       //
-      //if ((mClsLabels->getLabels(c2-mFirstCluster))[0] != lab) continue;
+      //if ((mClsLabels->getLabels(c2 - &mClusterCache[0] + mFirstInFrame))[0] != lab) continue;
       //
       auto xyz2 = c2->getXYZGloRot(*mGeom);
       auto z2 = xyz2.Z();
@@ -300,7 +301,7 @@ void CookedTracker::makeSeeds(std::vector<TrackITSExt>& seeds, Int_t first, Int_
       for (auto n3 : selected3) {
         const Cluster* c3 = layer3.getCluster(n3);
         //
-        //if ((mClsLabels->getLabels(c3-mFirstCluster))[0] != lab) continue;
+        //if ((mClsLabels->getLabels(c3 - &mClusterCache[0] + mFirstInFrame))[0] != lab) continue;
         //
         auto xyz3 = c3->getXYZGloRot(*mGeom);
         auto z3 = xyz3.Z();
@@ -463,7 +464,10 @@ std::vector<TrackITSExt> CookedTracker::trackInThread(Int_t first, Int_t last)
   return seeds;
 }
 
-void CookedTracker::process(gsl::span<const Cluster> const& clusters, TrackInserter& inserter,
+void CookedTracker::process(gsl::span<const o2::itsmft::CompClusterExt> const& clusters,
+                            gsl::span<const unsigned char>::iterator& pattIt,
+                            const o2::itsmft::TopologyDictionary& dict,
+                            TrackInserter& inserter,
                             o2::itsmft::ROFRecord& rof)
 {
   //--------------------------------------------------------------------
@@ -477,9 +481,42 @@ void CookedTracker::process(gsl::span<const Cluster> const& clusters, TrackInser
 
   auto start = std::chrono::system_clock::now();
 
-  mFirstCluster = &clusters[0];
+  mFirstInFrame = rof.getFirstEntry();
 
-  auto nClFrame = loadClusters(clusters, rof);
+  mClusterCache.reserve(rof.getNEntries());
+  auto clusters_in_frame = rof.getROFData(clusters);
+  for (const auto& comp : clusters_in_frame) {
+
+    auto pattID = comp.getPatternID();
+    Point3D<float> locXYZ;
+    float sigmaY2 = 0.0015 * 0.0015, sigmaZ2 = sigmaY2, sigmaYZ = 0; //Dummy COG errors (about half pixel size)
+    if (pattID != itsmft::CompCluster::InvalidPatternID) {
+      sigmaY2 = dict.GetErrX(pattID);
+      sigmaY2 *= sigmaY2;
+      sigmaZ2 = dict.GetErrZ(pattID);
+      sigmaZ2 *= sigmaZ2;
+      if (!dict.IsGroup(pattID)) {
+        locXYZ = dict.getClusterCoordinates(comp);
+      } else {
+        o2::itsmft::ClusterPattern patt(pattIt);
+        locXYZ = dict.getClusterCoordinates(comp, patt);
+      }
+    } else {
+      o2::itsmft::ClusterPattern patt(pattIt);
+      locXYZ = dict.getClusterCoordinates(comp, patt);
+    }
+    auto sensorID = comp.getSensorID();
+    // Inverse transformation to the local --> tracking
+    auto trkXYZ = mGeom->getMatrixT2L(sensorID) ^ locXYZ;
+
+    Cluster c;
+    c.setSensorID(sensorID);
+    c.setPos(trkXYZ);
+    c.setErrors(sigmaY2, sigmaZ2, 0.f);
+    mClusterCache.push_back(c);
+  }
+
+  auto nClFrame = loadClusters();
 
   auto end = std::chrono::system_clock::now();
   std::chrono::duration<double> diff = end - start;
@@ -590,34 +627,34 @@ bool CookedTracker::makeBackPropParam(TrackITSExt& track) const
   return true;
 }
 
-int CookedTracker::loadClusters(gsl::span<const Cluster> clusters, const o2::itsmft::ROFRecord& rof)
+int CookedTracker::loadClusters()
 {
   //--------------------------------------------------------------------
   // This function reads the ITSU clusters from the tree,
   // sort them, distribute over the internal tracker arrays, etc
   //--------------------------------------------------------------------
-  mFirstInFrame = rof.getFirstEntry();
 
-  auto clusters_in_frame = rof.getROFData(clusters);
-  for (const auto& c : clusters_in_frame) {
+  if (mClusterCache.empty())
+    return 0;
+
+  for (const auto& c : mClusterCache) {
     Int_t layer = mGeom->getLayer(c.getSensorID());
     sLayers[layer].insertCluster(&c);
   }
 
-  if (clusters_in_frame.size()) {
-    std::vector<std::future<void>> fut;
-    for (Int_t l = 0; l < kNLayers; l += mNumOfThreads) {
-      for (Int_t t = 0; t < mNumOfThreads; t++) {
-        if (l + t >= kNLayers)
-          break;
-        auto f = std::async(std::launch::async, &CookedTracker::Layer::init, sLayers + (l + t));
-        fut.push_back(std::move(f));
-      }
-      for (Int_t t = 0; t < fut.size(); t++)
-        fut[t].wait();
+  std::vector<std::future<void>> fut;
+  for (Int_t l = 0; l < kNLayers; l += mNumOfThreads) {
+    for (Int_t t = 0; t < mNumOfThreads; t++) {
+      if (l + t >= kNLayers)
+        break;
+      auto f = std::async(std::launch::async, &CookedTracker::Layer::init, sLayers + (l + t));
+      fut.push_back(std::move(f));
     }
+    for (Int_t t = 0; t < fut.size(); t++)
+      fut[t].wait();
   }
-  return clusters_in_frame.size();
+
+  return mClusterCache.size();
 }
 
 void CookedTracker::unloadClusters()
@@ -625,6 +662,7 @@ void CookedTracker::unloadClusters()
   //--------------------------------------------------------------------
   // This function unloads ITSU clusters from the RAM
   //--------------------------------------------------------------------
+  mClusterCache.clear();
   for (Int_t i = 0; i < kNLayers; i++)
     sLayers[i].unloadClusters();
 }

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/IOUtils.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/IOUtils.h
@@ -41,6 +41,8 @@ class MCTruthContainer;
 namespace itsmft
 {
 class Cluster;
+class CompClusterExt;
+class TopologyDictionary;
 }
 
 namespace its
@@ -57,7 +59,13 @@ void loadConfigurations(const std::string&);
 std::vector<ROframe> loadEventData(const std::string&);
 void loadEventData(ROframe& events, gsl::span<const itsmft::Cluster> clusters,
                    const dataformats::MCTruthContainer<MCCompLabel>* clsLabels = nullptr);
+void loadEventData(ROframe& events, gsl::span<const itsmft::CompClusterExt> clusters,
+                   gsl::span<const unsigned char>::iterator& pattIt, const itsmft::TopologyDictionary& dict,
+                   const dataformats::MCTruthContainer<MCCompLabel>* clsLabels = nullptr);
 int loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& events, gsl::span<const itsmft::Cluster> clusters,
+                    const dataformats::MCTruthContainer<MCCompLabel>* mClsLabels = nullptr);
+int loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& events, gsl::span<const itsmft::CompClusterExt> clusters,
+                    gsl::span<const unsigned char>::iterator& pattIt, const itsmft::TopologyDictionary& dict,
                     const dataformats::MCTruthContainer<MCCompLabel>* mClsLabels = nullptr);
 void generateSimpleData(ROframe& event, const int phiDivs, const int zDivs);
 

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ClustererSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ClustererSpec.h
@@ -38,7 +38,7 @@ class ClustererDPL : public Task
  private:
   int mState = 0;
   bool mUseMC = true;
-  bool mFullClusters = true;
+  bool mFullClusters = false;
   bool mPatterns = true;
   std::unique_ptr<std::ifstream> mFile = nullptr;
   std::unique_ptr<o2::itsmft::Clusterer> mClusterer = nullptr;

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ClustererSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ClustererSpec.h
@@ -39,7 +39,6 @@ class ClustererDPL : public Task
   int mState = 0;
   bool mUseMC = true;
   bool mFullClusters = true;
-  bool mCompactClusters = true;
   bool mPatterns = true;
   std::unique_ptr<std::ifstream> mFile = nullptr;
   std::unique_ptr<o2::itsmft::Clusterer> mClusterer = nullptr;

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/CookedTrackerSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/CookedTrackerSpec.h
@@ -16,6 +16,7 @@
 #include "Framework/DataProcessorSpec.h"
 #include "ITSReconstruction/CookedTracker.h"
 #include "DataFormatsParameters/GRPObject.h"
+#include "DataFormatsITSMFT/TopologyDictionary.h"
 #include "Framework/Task.h"
 
 using namespace o2::framework;
@@ -36,6 +37,7 @@ class CookedTrackerDPL : public Task
  private:
   int mState = 0;
   bool mUseMC = true;
+  o2::itsmft::TopologyDictionary mDict;
   std::unique_ptr<o2::parameters::GRPObject> mGRP = nullptr;
   o2::its::CookedTracker mTracker;
 };

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/TrackerSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/TrackerSpec.h
@@ -14,6 +14,7 @@
 #define O2_ITS_TRACKERDPL
 
 #include "DataFormatsParameters/GRPObject.h"
+#include "DataFormatsITSMFT/TopologyDictionary.h"
 
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
@@ -43,6 +44,7 @@ class TrackerDPL : public framework::Task
  private:
   int mState = 0;
   bool mIsMC = false;
+  o2::itsmft::TopologyDictionary mDict;
   std::unique_ptr<o2::gpu::GPUReconstruction> mRecChain = nullptr;
   std::unique_ptr<parameters::GRPObject> mGRP = nullptr;
   std::unique_ptr<Tracker> mTracker = nullptr;

--- a/Detectors/ITSMFT/ITS/workflow/src/ClustererSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ClustererSpec.cxx
@@ -57,7 +57,7 @@ void ClustererDPL::init(InitContext& ic)
     return;
   }
 
-  mFullClusters = !ic.options().get<bool>("no-full-clusters");
+  mFullClusters = ic.options().get<bool>("full-clusters");
   mPatterns = !ic.options().get<bool>("no-patterns");
 
   // settings for the fired pixel overflow masking
@@ -166,7 +166,7 @@ DataProcessorSpec getClustererSpec(bool useMC)
     Options{
       {"its-dictionary-file", VariantType::String, "complete_dictionary.bin", {"Name of the cluster-topology dictionary file"}},
       {"grp-file", VariantType::String, "o2sim_grp.root", {"Name of the grp file"}},
-      {"no-full-clusters", o2::framework::VariantType::Bool, false, {"Ignore full clusters"}},
+      {"full-clusters", o2::framework::VariantType::Bool, false, {"Produce full clusters"}},
       {"no-patterns", o2::framework::VariantType::Bool, false, {"Do not save rare cluster patterns"}}}};
 }
 

--- a/macro/run_clus_itsSA.C
+++ b/macro/run_clus_itsSA.C
@@ -20,14 +20,14 @@
 // Use for RAW mode:
 // root -b -q run_clus_itsSA.C+\(\"o2clus_its.root\",\"dig.raw\"\) 2>&1 | tee clusSARAW.log
 //
-// Use of topology dictionary: flag withDicitonary -> true
-// A dictionary must be generated with the macro CheckTopologies.C
 
 void run_clus_itsSA(std::string inputfile = "rawits.bin", // output file name
                     std::string outputfile = "clr.root",  // input file name (root or raw)
                     bool raw = true,                      // flag if this is raw data
                     float strobe = -1.,                   // strobe length in ns of ALPIDE readout, if <0, get automatically
-                    bool withDictionary = false, std::string dictionaryfile = "complete_dictionary.bin", bool withPatterns = false)
+                    bool withFullClusters = true,
+                    std::string dictionaryfile = "complete_dictionary.bin",
+                    bool withPatterns = true)
 {
   // Initialize logger
   FairLogger* logger = FairLogger::GetLogger();
@@ -41,11 +41,17 @@ void run_clus_itsSA(std::string inputfile = "rawits.bin", // output file name
   Bool_t useMCTruth = kTRUE;  // kFALSE if no comparison with MC needed
   o2::its::ClustererTask* clus = new o2::its::ClustererTask(useMCTruth, raw);
   clus->setMaxROframe(2 << 21); // about 3 cluster files per a raw data chunk
-  if (withDictionary) {
+
+  std::ifstream file(dictionaryfile.c_str());
+  if (file.good()) {
+    LOG(INFO) << "Running with dictionary: " << dictionaryfile.c_str();
     clus->loadDictionary(dictionaryfile.c_str());
-    if (withPatterns) {
-      clus->setPatterns();
-    }
+  } else {
+    LOG(INFO) << "Running without dictionary !";
+  }
+
+  if (withPatterns) {
+    clus->setPatterns();
   }
 
   // Mask fired pixels separated by <= this number of BCs (for overflow pixels).
@@ -55,8 +61,7 @@ void run_clus_itsSA(std::string inputfile = "rawits.bin", // output file name
     strobe = dgParams.roFrameLength;
   }
   clus->getClusterer().setMaxBCSeparationToMask(strobe / o2::constants::lhc::LHCBunchSpacingNS + 10);
-  clus->getClusterer().setWantFullClusters(true);              // require clusters with coordinates and full pattern
-  clus->getClusterer().setWantCompactClusters(withDictionary); // require compact clusters with patternID
+  clus->getClusterer().setWantFullClusters(withFullClusters);
 
   clus->getClusterer().print();
   clus->run(inputfile, outputfile);

--- a/macro/run_trac_its.C
+++ b/macro/run_trac_its.C
@@ -42,7 +42,7 @@ using Vertex = o2::dataformats::Vertex<o2::dataformats::TimeStamp<int>>;
 void run_trac_its(std::string path = "./", std::string outputfile = "o2trac_its.root",
                   std::string inputClustersITS = "o2clus_its.root",
                   std::string dictfile = "complete_dictionary.bin",
-                  std::string inputGeom = "O2geometry.root",
+                  std::string inputGeom = "",
                   std::string inputGRP = "o2sim_grp.root")
 {
 
@@ -70,7 +70,7 @@ void run_trac_its(std::string path = "./", std::string outputfile = "o2trac_its.
   bool isContITS = grp->isDetContinuousReadOut(o2::detectors::DetID::ITS);
   LOG(INFO) << "ITS is in " << (isContITS ? "CONTINUOS" : "TRIGGERED") << " readout mode";
 
-  o2::base::GeometryManager::loadGeometry(path + inputGeom, "FAIRGeom");
+  o2::base::GeometryManager::loadGeometry(inputGeom, "FAIRGeom");
   auto gman = o2::its::GeometryTGeo::Instance();
   gman->fillMatrixCache(o2::utils::bit2Mask(o2::TransformType::T2GRot)); // request cached transforms
 
@@ -169,7 +169,8 @@ void run_trac_its(std::string path = "./", std::string outputfile = "o2trac_its.
   o2::its::Vertexer vertexer(&vertexerTraits);
   o2::its::ROframe event(0);
 
-  std::vector<unsigned char>::const_iterator pattIt = patterns->cbegin();
+  gsl::span<const unsigned char> patt(patterns->data(), patterns->size());
+  auto pattIt = patt.begin();
   auto clSpan = gsl::span(cclusters->data(), cclusters->size());
   for (auto& rof : *rofs) {
     auto it = pattIt;


### PR DESCRIPTION
This PR opens the possibility to
1) Build the topology dictionary from compact clusters and cluster patterns saved separately;
2) Reconstruct tracks using compact clusters;
3) Compare compact clusters with the MC truth.

The full clusters are not anymore produced by default, and so they are not propagated over DPL.